### PR TITLE
chore: run tests in constrained mode

### DIFF
--- a/noir-projects/noir-protocol-circuits/crates/blob/src/blob.nr
+++ b/noir-projects/noir-protocol-circuits/crates/blob/src/blob.nr
@@ -363,7 +363,7 @@ mod tests {
     }
 
     #[test]
-    unconstrained fn test_one_note() {
+    fn test_one_note() {
         let mut blob_fields: [Field; FIELDS_PER_BLOB] = [0; FIELDS_PER_BLOB];
         blob_fields[0] = 1;
 
@@ -384,14 +384,18 @@ mod tests {
         //* p(z).(z - 1) = ---------
         //*                    d
         //
-        let rhs = super::compute_factor(challenge_z);
-        let z_minus_1 = challenge_z.__sub(BLS12_381_Fr::one());
-        let lhs = y.__mul(z_minus_1);
+        let rhs = compute_factor(challenge_z);
+        // Safety: using unconstrained BigNum ops for verification
+        let lhs = unsafe {
+            let z_minus_1 = challenge_z.__sub(BLS12_381_Fr::one());
+            y.__mul(z_minus_1)
+        };
+
         assert_eq(lhs, rhs);
     }
 
     #[test]
-    unconstrained fn test_400() {
+    fn test_400() {
         let blob_fields = [3; 400];
         let blob_fields_hash = poseidon2_hash(blob_fields);
 
@@ -414,7 +418,7 @@ mod tests {
     }
 
     #[test]
-    unconstrained fn test_full_blob() {
+    fn test_full_blob() {
         let mut blob_fields = [0; FIELDS_PER_BLOB];
         for i in 0..FIELDS_PER_BLOB {
             blob_fields[i] = i as Field + 2;
@@ -455,19 +459,10 @@ mod tests {
         // evaluate the blob at z = 2 to yield y:
         let y = barycentric_evaluate_blob_at_z(ys, fracs, factor);
 
-        let mut expected_y: [u128; 3] = [0; 3];
-        if (FIELDS_PER_BLOB == 4096) {
-            // Computed with the eth consensus specs py lib
-            expected_y =
-                [0x0c62e352a428e8e9842eadc1c106bd, 0x902c5b4968d755b6f49c0231e15af8, 0x00049a];
-            // Also computed with cKzg, in the typescript tests:
-            // 0x049a902c5b4968d755b6f49c0231e15af80c62e352a428e8e9842eadc1c106bd
-        }
-        if (FIELDS_PER_BLOB == 8) {
-            // Computed with the eth consensus specs py lib (after hacking it to cope with blobs of size 8 instead of 4096):
-            expected_y =
-                [0xb04cdea4304000053abffffffb203a, 0x0000000002e30785c8afa4496f8e38, 0x000000];
-        }
+        // Computed with the eth consensus specs py lib
+        let expected_y =
+            [0x0c62e352a428e8e9842eadc1c106bd, 0x902c5b4968d755b6f49c0231e15af8, 0x00049a];
+
         assert(y.get_limbs() == expected_y);
     }
 
@@ -740,6 +735,7 @@ mod tests {
         let correct_factor = unsafe { super::__compute_factor_helper(z_pow_d_val) };
 
         // Add 1 to corrupt the factor
+        // Safety: using unconstrained BigNum ops to corrupt the value
         let invalid_factor = unsafe { correct_factor.__add(BLS12_381_Fr::one()) };
 
         // This should fail because the constraint won't be satisfied
@@ -763,14 +759,13 @@ mod tests {
     fn test_validate_fracs_rejects_invalid_frac() {
         // Test that validate_fracs rejects incorrect frac hints
         let z = BLS12_381_Fr::from_limbs([42, 0, 0]);
-        let mut ys = [BLS12_381_Fr::zero(); FIELDS_PER_BLOB];
-        ys[0] = BLS12_381_Fr::from_limbs([100, 0, 0]);
 
         // Compute correct fracs, then corrupt one
         // Safety: computing correct values first
         let mut fracs = unsafe { __compute_fracs(z) };
 
         // Corrupt fracs[0] by adding 1
+        // Safety: using unconstrained BigNum ops to corrupt the value
         fracs[0] = unsafe { fracs[0].__add(BLS12_381_Fr::one()) };
 
         // This should fail because fracs[0] * (z - w^0) != ys[0]
@@ -781,9 +776,6 @@ mod tests {
     fn test_validate_fracs_rejects_swapped_fracs() {
         // Test that validate_fracs rejects fracs that are swapped between positions
         let z = BLS12_381_Fr::from_limbs([42, 0, 0]);
-        let mut ys = [BLS12_381_Fr::zero(); FIELDS_PER_BLOB];
-        ys[0] = BLS12_381_Fr::from_limbs([100, 0, 0]);
-        ys[1] = BLS12_381_Fr::from_limbs([200, 0, 0]);
 
         // Compute correct fracs
         // Safety: computing correct values first
@@ -803,7 +795,6 @@ mod tests {
         // Test that when y[i] = 0, fracs[i] must also satisfy the constraint
         // (which means fracs[i] * (z - w^i) = 0)
         let z = BLS12_381_Fr::from_limbs([42, 0, 0]);
-        let ys = [BLS12_381_Fr::zero(); FIELDS_PER_BLOB]; // All zeros
 
         // Compute correct fracs (should all be zero)
         // Safety: computing correct values first

--- a/noir-projects/noir-protocol-circuits/crates/blob/src/blob_batching.nr
+++ b/noir-projects/noir-protocol-circuits/crates/blob/src/blob_batching.nr
@@ -147,7 +147,7 @@ mod tests {
     };
 
     #[test]
-    unconstrained fn test_1_blob_batched() {
+    fn test_1_blob_batched() {
         // We evaluate 1 blob of 400 items using the batch methods.
         // This ensures a block with a single blob will work:
         let num_fields = 400;
@@ -224,7 +224,7 @@ mod tests {
     }
 
     #[test]
-    unconstrained fn test_3_blobs_batched() {
+    fn test_3_blobs_batched() {
         let num_blobs = 3;
         // Create 2 full blobs and 1 blob with 123 fields.
         let num_fields = FIELDS_PER_BLOB * 2 + 123;
@@ -341,10 +341,11 @@ mod tests {
         let final_acc = output.finalize();
 
         assert_eq(final_acc.z, final_challenges.z);
-        assert_eq(
-            output.gamma_pow_acc,
-            final_challenges.gamma.__pow(BLS12_381_Fr::from(num_blobs as Field)),
-        );
+
+        // Safety: using unconstrained BigNum ops for verification
+        let gamma_pow_acc =
+            unsafe { final_challenges.gamma.__pow(BLS12_381_Fr::from(num_blobs as Field)) };
+        assert_eq(output.gamma_pow_acc, gamma_pow_acc);
 
         let expected_y = BLS12_381_Fr::from_limbs(y_limbs_3_blobs_from_ts);
 
@@ -360,7 +361,7 @@ mod tests {
     }
 
     #[test]
-    unconstrained fn test_empty_blob() {
+    fn test_empty_blob() {
         let blob = [0; FIELDS_PER_BLOB];
         let final_challenges = FinalBlobBatchingChallenges::empty();
 
@@ -379,7 +380,7 @@ mod tests {
     }
 
     #[test(should_fail_with = "Non canonical x coordinate at infinity")]
-    unconstrained fn test_non_canonical_point_at_infinity_fails() {
+    fn test_non_canonical_point_at_infinity_fails() {
         let blob = [0; FIELDS_PER_BLOB];
         let point = BLSPoint { x: BLS12_381_Fq::one(), y: BLS12_381_Fq::zero(), is_infinity: true };
         let final_challenges = FinalBlobBatchingChallenges::empty();
@@ -398,7 +399,7 @@ mod tests {
     }
 
     #[test(should_fail)]
-    unconstrained fn test_point_not_on_curve_fails() {
+    fn test_point_not_on_curve_fails() {
         let blob = [0; FIELDS_PER_BLOB];
         let point = BLSPoint {
             x: BLS12_381_Fq::from_limbs([0, 0, 0, 42]),

--- a/noir-projects/noir-protocol-circuits/crates/blob/src/mock_blob_oracle.nr
+++ b/noir-projects/noir-protocol-circuits/crates/blob/src/mock_blob_oracle.nr
@@ -18,7 +18,7 @@ pub unconstrained fn evaluate_blobs_and_batch<let NumBlobs: u32>(
     kzg_commitments: [BLSPoint; NumBlobs],
     final_blob_challenges: FinalBlobBatchingChallenges,
     start_accumulator: BlobAccumulator,
-    challenge_z: BLS12_381_Fr,
+    _challenge_z: BLS12_381_Fr,
 ) -> BlobAccumulator {
     let fields = evaluate_blobs_oracle(
         NumBlobs,

--- a/noir-projects/noir-protocol-circuits/crates/blob/src/utils/compress_to_blob_commitment.nr
+++ b/noir-projects/noir-protocol-circuits/crates/blob/src/utils/compress_to_blob_commitment.nr
@@ -61,7 +61,7 @@ mod tests {
     use types::constants::BLS12_POINT_COMPRESSED_BYTES;
 
     #[test]
-    unconstrained fn point_compression() {
+    fn point_compression() {
         let point = BLSPoint::offset_generator();
         let (flags, x) = get_flags(point);
         // is_compressed = true
@@ -76,17 +76,21 @@ mod tests {
         bytes[0] &= 31;
         let reconstructed_x = BLS12_381_Fq::from_be_bytes(bytes);
         assert_eq(reconstructed_x, x);
-        let (a, b) = (BLS12_381_PARAMS.a, BLS12_381_PARAMS.b);
-        // y^2 = x^3 + ax + b
-        let reconstructed_y_squared =
-            reconstructed_x.__pow(BLS12_381_Fq::from(3)).add(a.mul(reconstructed_x)).add(b);
-        let reconstructed_y = -(reconstructed_y_squared.__sqrt().unwrap());
+
+        // Safety: using unconstrained BigNum ops for verification
+        let reconstructed_y = unsafe {
+            // y^2 = x^3 + ax + b
+            let (a, b) = (BLS12_381_PARAMS.a, BLS12_381_PARAMS.b);
+            let reconstructed_y_squared =
+                reconstructed_x.__pow(BLS12_381_Fq::from(3)).add(a.mul(reconstructed_x)).add(b);
+            -(reconstructed_y_squared.__sqrt().unwrap())
+        };
 
         assert_eq(reconstructed_y, point.y);
     }
 
     #[test]
-    unconstrained fn infinity_point_compression() {
+    fn infinity_point_compression() {
         let point = BLSPoint::point_at_infinity();
         let (flags, x) = get_flags(point);
         // is_compressed = true
@@ -105,7 +109,7 @@ mod tests {
     }
 
     #[test]
-    unconstrained fn test_point_compression_greater() {
+    fn test_point_compression_greater() {
         // Note that this p is the negation of p from the test test_point_compression_not_greater...
         let p = BLSPoint {
             x: BLS12_381_Fq::from_limbs([
@@ -135,7 +139,7 @@ mod tests {
     }
 
     #[test]
-    unconstrained fn test_point_compression_not_greater() {
+    fn test_point_compression_not_greater() {
         // Note that this p is the negation of p from the test test_point_compression_greater...
         let p = BLSPoint {
             x: BLS12_381_Fq::from_limbs([

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/accumulated_data/assert_sorted_transformed_array/get_order_hints.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/accumulated_data/assert_sorted_transformed_array/get_order_hints.nr
@@ -51,20 +51,25 @@ mod tests {
     use super::{get_order_hints, OrderHints};
     use types::tests::{types::TestValue, utils::pad_end};
 
+    fn assert_eq_get_order_hints<let N: u32>(array: [TestValue; N], expected_hints: OrderHints<N>) {
+        // Safety: Testing an unconstrained function.
+        let hints = unsafe { get_order_hints(array) };
+        assert_eq(hints, expected_hints);
+    }
+
     #[test]
-    unconstrained fn full_non_empty_items() {
+    fn full_non_empty_items() {
         let array = [
             TestValue { value: 100, counter: 9 },
             TestValue { value: 200, counter: 3 },
             TestValue { value: 300, counter: 6 },
         ];
         let expected = OrderHints { sorted_counters: [3, 6, 9], sorted_indexes: [2, 0, 1] };
-        let hints = get_order_hints(array);
-        assert_eq(hints, expected);
+        assert_eq_get_order_hints(array, expected);
     }
 
     #[test]
-    unconstrained fn with_padded_empty_items() {
+    fn with_padded_empty_items() {
         let array = pad_end([
             TestValue { value: 100, counter: 9 },
             TestValue { value: 200, counter: 3 },
@@ -74,7 +79,6 @@ mod tests {
             sorted_counters: [3, 6, 9, 0, 0],
             sorted_indexes: [2, 0, 1, 3, 4], // `sorted_index` of the padded empty item equals `i`
         };
-        let hints = get_order_hints(array);
-        assert_eq(hints, expected);
+        assert_eq_get_order_hints(array, expected);
     }
 }

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/accumulated_data/assert_split_sorted_transformed_arrays/get_split_order_hints.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/accumulated_data/assert_split_sorted_transformed_arrays/get_split_order_hints.nr
@@ -98,14 +98,15 @@ mod tests {
             TestBuilder { original_array: pad_end(values), split_counter }
         }
 
-        pub unconstrained fn expect_hints_equal(self, expected: SplitOrderHints<N>) {
-            let hints = get_split_order_hints(self.original_array, self.split_counter);
+        pub fn expect_hints_equal(self, expected: SplitOrderHints<N>) {
+            // Safety: Testing an unconstrained function.
+            let hints = unsafe { get_split_order_hints(self.original_array, self.split_counter) };
             assert_eq(hints, expected);
         }
     }
 
     #[test]
-    unconstrained fn full_non_empty_items_zero_split_counter() {
+    fn full_non_empty_items_zero_split_counter() {
         let builder = TestBuilder::new_full();
         builder.expect_hints_equal(
             SplitOrderHints {
@@ -117,7 +118,7 @@ mod tests {
     }
 
     #[test]
-    unconstrained fn full_non_empty_items_non_zero_split_counter() {
+    fn full_non_empty_items_non_zero_split_counter() {
         let mut builder = TestBuilder::new_full();
 
         builder.split_counter = 25;
@@ -132,7 +133,7 @@ mod tests {
     }
 
     #[test]
-    unconstrained fn empty_padded_zero_split_counter() {
+    fn empty_padded_zero_split_counter() {
         let builder = TestBuilder::new_padded();
         builder.expect_hints_equal(
             SplitOrderHints {
@@ -144,7 +145,7 @@ mod tests {
     }
 
     #[test]
-    unconstrained fn empty_padded_non_zero_split_counter() {
+    fn empty_padded_non_zero_split_counter() {
         let mut builder = TestBuilder::new_padded();
 
         builder.split_counter = 25;
@@ -159,7 +160,7 @@ mod tests {
     }
 
     #[test]
-    unconstrained fn empty_padded_non_zero_split_counter_equals_value() {
+    fn empty_padded_non_zero_split_counter_equals_value() {
         let mut builder = TestBuilder::new_padded();
 
         // The split counter equals one of the values.

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/accumulated_data/sort_by_counter.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/accumulated_data/sort_by_counter.nr
@@ -24,15 +24,22 @@ mod tests {
     use super::{compare_for_ascending_sort_with_empty_padding, sort_by_counter};
     use types::{tests::types::TestValue, traits::Empty};
 
-    unconstrained fn compare_test_items(value_1: u32, value_2: u32) -> bool {
+    fn compare_test_items(counter_1: u32, counter_2: u32) -> bool {
+        // The default value is 0, so if a counter is 0, it should be considered empty.
         compare_for_ascending_sort_with_empty_padding(
-            TestValue { value: value_1 as Field, counter: value_1 },
-            TestValue { value: value_2 as Field, counter: value_2 },
+            TestValue { value: 0, counter: counter_1 },
+            TestValue { value: 0, counter: counter_2 },
         )
     }
 
+    fn assert_eq_sort_by_counter<let N: u32>(original: [TestValue; N], expected: [TestValue; N]) {
+        // Safety: Testing an unconstrained function.
+        let sorted = unsafe { sort_by_counter(original) };
+        assert_eq(sorted, expected);
+    }
+
     #[test]
-    unconstrained fn compare_for_ascending_sort_with_empty_padding_as_expected() {
+    fn compare_for_ascending_sort_with_empty_padding_as_expected() {
         assert_eq(compare_test_items(1, 2), true);
         assert_eq(compare_test_items(1, 1), false);
         assert_eq(compare_test_items(2, 1), false);
@@ -42,7 +49,7 @@ mod tests {
     }
 
     #[test]
-    unconstrained fn all_non_empty_values() {
+    fn all_non_empty_values() {
         let original = [
             TestValue { value: 14, counter: 4 },
             TestValue { value: 92, counter: 2 },
@@ -57,12 +64,11 @@ mod tests {
             TestValue { value: 14, counter: 4 },
             TestValue { value: 75, counter: 5 },
         ];
-        let sorted = sort_by_counter(original);
-        assert_eq(sorted, expected);
+        assert_eq_sort_by_counter(original, expected);
     }
 
     #[test]
-    unconstrained fn some_empty_values() {
+    fn some_empty_values() {
         let original = [
             TestValue { value: 14, counter: 4 },
             TestValue { value: 92, counter: 2 },
@@ -83,12 +89,11 @@ mod tests {
             TestValue::empty(),
             TestValue::empty(),
         ];
-        let sorted = sort_by_counter(original);
-        assert_eq(sorted, expected);
+        assert_eq_sort_by_counter(original, expected);
     }
 
     #[test]
-    unconstrained fn non_empty_values_with_zero_counters() {
+    fn non_empty_values_with_zero_counters() {
         let original = [
             TestValue { value: 55, counter: 1 },
             TestValue { value: 11, counter: 0 },
@@ -107,7 +112,6 @@ mod tests {
             TestValue::empty(),
             TestValue::empty(),
         ];
-        let sorted = sort_by_counter(original);
-        assert_eq(sorted, expected);
+        assert_eq_sort_by_counter(original, expected);
     }
 }

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/private_kernel_reset.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/private_kernel_reset.nr
@@ -170,8 +170,8 @@ impl<let NoteHashPendingReadHintsLen: u32, let NoteHashSettledReadHintsLen: u32,
 
         if !::std::runtime::is_unconstrained() {
             self.previous_kernel.verify(false);
-            self.previous_kernel.validate_vk_in_vk_tree(ALLOWED_PREVIOUS_CIRCUITS);
         }
+        self.previous_kernel.validate_vk_in_vk_tree(ALLOWED_PREVIOUS_CIRCUITS);
 
         // Generate output.
         // Safety: The output is validated below by ResetOutputValidator.

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/private_kernel_tail.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/private_kernel_tail.nr
@@ -59,9 +59,8 @@ pub fn execute(
     // Validate inputs.
     if !::std::runtime::is_unconstrained() {
         inputs.previous_kernel.verify(true);
-        inputs.previous_kernel.validate_vk_in_vk_tree(ALLOWED_PREVIOUS_CIRCUITS);
     }
-
+    inputs.previous_kernel.validate_vk_in_vk_tree(ALLOWED_PREVIOUS_CIRCUITS);
     validate_previous_kernel_for_tail(inputs.previous_kernel.public_inputs, false);
 
     // Generate output.

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/private_kernel_tail_to_public.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/private_kernel_tail_to_public.nr
@@ -67,8 +67,8 @@ pub fn execute(
     // Validate inputs.
     if !::std::runtime::is_unconstrained() {
         inputs.previous_kernel.verify(true /* is_last_kernel */);
-        inputs.previous_kernel.validate_vk_in_vk_tree(ALLOWED_PREVIOUS_CIRCUITS);
     }
+    inputs.previous_kernel.validate_vk_in_vk_tree(ALLOWED_PREVIOUS_CIRCUITS);
     validate_previous_kernel_for_tail(
         inputs.previous_kernel.public_inputs,
         true, /* is_for_public */

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/reset/transient_data/squash_transient_data.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/reset/transient_data/squash_transient_data.nr
@@ -127,7 +127,7 @@ mod tests {
     };
 
     #[test]
-    unconstrained fn squash_transient_data_squash_some() {
+    fn squash_transient_data_squash_some() {
         let mut builder = TransientDataFixtureBuilder::new();
 
         builder.add_note_hashes([
@@ -156,12 +156,15 @@ mod tests {
         builder.add_squashing_hint(0, 1); // Squash note_hashes[0] with nullifier[1]
         builder.add_squashing_hint(3, 3); // Squash note_hashes[3] with nullifier[3]
 
-        let (kept_note_hashes, kept_nullifiers, kept_logs) = squash_transient_data(
-            builder.note_hashes,
-            builder.nullifiers,
-            builder.logs,
-            builder.transient_data_squashing_hints,
-        );
+        // Safety: Testing an unconstrained function.
+        let (kept_note_hashes, kept_nullifiers, kept_logs) = unsafe {
+            squash_transient_data(
+                builder.note_hashes,
+                builder.nullifiers,
+                builder.logs,
+                builder.transient_data_squashing_hints,
+            )
+        };
 
         // Note hashes 0, 3, nullifiers 1, 3, and logs 0, 1, 4 are squashed.
         let note_hashes = builder.note_hashes.array;

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/checkpoint_merge/checkpoint_merge_rollup.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/checkpoint_merge/checkpoint_merge_rollup.nr
@@ -41,15 +41,17 @@ pub struct CheckpointMergeRollupPrivateInputs {
 pub fn execute(inputs: CheckpointMergeRollupPrivateInputs) -> CheckpointRollupPublicInputs {
     // Verify the previous rollup proofs and vks.
     if !::std::runtime::is_unconstrained() {
-        let vk_tree_root = inputs.previous_rollups[0].public_inputs.constants.vk_tree_root;
-
         for i in 0..2 {
             inputs.previous_rollups[i].verify_proof();
-            inputs.previous_rollups[i].vk_data.validate_allowed_in_vk_tree(
-                vk_tree_root,
-                ALLOWED_VK_INDICES,
-            );
         }
+    }
+
+    let vk_tree_root = inputs.previous_rollups[0].public_inputs.constants.vk_tree_root;
+    for i in 0..2 {
+        inputs.previous_rollups[i].vk_data.validate_allowed_in_vk_tree(
+            vk_tree_root,
+            ALLOWED_VK_INDICES,
+        );
     }
 
     let left = inputs.previous_rollups[0].public_inputs;

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/tx_base/tests/private_tx_base/child_proof_vk_tests.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/tx_base/tests/private_tx_base/child_proof_vk_tests.nr
@@ -2,14 +2,14 @@ use super::TestBuilder;
 use types::tests::fixtures::vk_tree::VK_MERKLE_TREE;
 
 #[test]
-unconstrained fn default_setup_success() {
+fn default_setup_success() {
     let builder = TestBuilder::new();
     let pi = builder.execute();
     builder.assert_expected_public_inputs(pi);
 }
 
 #[test(should_fail_with = "Incorrect hiding kernel vk index")]
-unconstrained fn incorrect_hiding_kernel_vk_index() {
+fn incorrect_hiding_kernel_vk_index() {
     let mut builder = TestBuilder::new();
 
     builder.hiding_kernel_vk_index += 1;
@@ -18,7 +18,7 @@ unconstrained fn incorrect_hiding_kernel_vk_index() {
 }
 
 #[test(should_fail_with = "Membership check failed: vk hash not found in vk tree")]
-unconstrained fn hiding_kernel_vk_hash_not_in_vk_tree() {
+fn hiding_kernel_vk_hash_not_in_vk_tree() {
     let mut builder = TestBuilder::new();
 
     // Change the hiding kernel vk hash so that the old vk hash in the proof data is no longer in the vk tree.

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/tx_base/tests/private_tx_base/end_blob_sponge_tests.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/tx_base/tests/private_tx_base/end_blob_sponge_tests.nr
@@ -11,7 +11,7 @@ use types::{
 };
 
 #[test]
-unconstrained fn full_tx_effects() {
+fn full_tx_effects() {
     let mut builder = TestBuilder::new();
 
     let mut fixture_builder = FixtureBuilder::new();
@@ -119,7 +119,7 @@ unconstrained fn full_tx_effects() {
 }
 
 #[test]
-unconstrained fn all_side_effects_non_full() {
+fn all_side_effects_non_full() {
     let mut builder = TestBuilder::new();
 
     let mut fixture_builder = FixtureBuilder::new();
@@ -230,7 +230,7 @@ unconstrained fn all_side_effects_non_full() {
 }
 
 #[test]
-unconstrained fn partially_empty_tx_effects() {
+fn partially_empty_tx_effects() {
     let mut builder = TestBuilder::new();
 
     let mut fixture_builder = FixtureBuilder::new();

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/tx_base/tests/private_tx_base/end_tree_snapshot_tests.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/tx_base/tests/private_tx_base/end_tree_snapshot_tests.nr
@@ -19,6 +19,16 @@ impl TestBuilder {
         self,
         new_note_hashes: [Field; MAX_NOTE_HASHES_PER_TX],
     ) -> AppendOnlyTreeSnapshot {
+        // Safety: test-only tree building doesn't need constraining. Running in unconstrained mode to speed up testing.
+        unsafe {
+            self._build_full_note_hash_tree(new_note_hashes)
+        }
+    }
+
+    unconstrained fn _build_full_note_hash_tree(
+        self,
+        new_note_hashes: [Field; MAX_NOTE_HASHES_PER_TX],
+    ) -> AppendOnlyTreeSnapshot {
         let note_hashes = self.pre_existing_note_hashes.concat(new_note_hashes);
 
         let existing_leaf_start_index =
@@ -36,6 +46,17 @@ impl TestBuilder {
     }
 
     pub fn build_full_nullifier_tree(
+        self,
+        updated_existing_nullifiers: [NullifierLeafPreimage; MAX_NULLIFIERS_PER_TX],
+        new_nullifiers: [NullifierLeafPreimage; MAX_NULLIFIERS_PER_TX],
+    ) -> AppendOnlyTreeSnapshot {
+        // Safety: test-only tree building doesn't need constraining. Running in unconstrained mode to speed up testing.
+        unsafe {
+            self._build_full_nullifier_tree(updated_existing_nullifiers, new_nullifiers)
+        }
+    }
+
+    unconstrained fn _build_full_nullifier_tree(
         self,
         updated_existing_nullifiers: [NullifierLeafPreimage; MAX_NULLIFIERS_PER_TX],
         new_nullifiers: [NullifierLeafPreimage; MAX_NULLIFIERS_PER_TX],
@@ -58,7 +79,7 @@ impl TestBuilder {
 }
 
 #[test]
-unconstrained fn tree_roots_not_change_if_no_side_effects_and_transaction_fee() {
+fn tree_roots_not_change_if_no_side_effects_and_transaction_fee() {
     let mut builder = TestBuilder::new();
 
     // Set gas fees to empty so that the transaction fee will be 0.
@@ -99,7 +120,7 @@ unconstrained fn tree_roots_not_change_if_no_side_effects_and_transaction_fee() 
 // --- Note hash tree ---
 
 #[test]
-unconstrained fn full_note_hashes() {
+fn full_note_hashes() {
     let mut builder = TestBuilder::new();
 
     // Fill new note hashes with values.
@@ -121,7 +142,7 @@ unconstrained fn full_note_hashes() {
 }
 
 #[test]
-unconstrained fn identical_note_hashes() {
+fn identical_note_hashes() {
     let mut builder = TestBuilder::new();
 
     let existing_note_hashes = builder.pre_existing_note_hashes;
@@ -137,7 +158,7 @@ unconstrained fn identical_note_hashes() {
 }
 
 #[test]
-unconstrained fn insert_at_large_index_to_fill_note_hash_tree() {
+fn insert_at_large_index_to_fill_note_hash_tree() {
     let mut builder = TestBuilder::new();
 
     let max_num_note_hashes = (1 << NOTE_HASH_TREE_HEIGHT as u64) as Field;
@@ -151,7 +172,7 @@ unconstrained fn insert_at_large_index_to_fill_note_hash_tree() {
 }
 
 #[test(should_fail_with = "Field failed to decompose into specified 36 limbs")]
-unconstrained fn insert_at_large_index_to_overfill_note_hash_tree() {
+fn insert_at_large_index_to_overfill_note_hash_tree() {
     let mut builder = TestBuilder::new();
 
     let max_num_note_hashes = (1 << NOTE_HASH_TREE_HEIGHT as u64) as Field;
@@ -164,7 +185,7 @@ unconstrained fn insert_at_large_index_to_overfill_note_hash_tree() {
 // --- Nullifier tree ---
 
 #[test]
-unconstrained fn full_nullifiers_all_larger_than_existing() {
+fn full_nullifiers_all_larger_than_existing() {
     let mut builder = TestBuilder::new();
 
     let largest_existing_nullifier_index = 1;
@@ -207,7 +228,7 @@ unconstrained fn full_nullifiers_all_larger_than_existing() {
 }
 
 #[test]
-unconstrained fn non_full_unordered_nullifiers() {
+fn non_full_unordered_nullifiers() {
     let mut builder = TestBuilder::new();
 
     // Pre-existing nullifiers are: 22, 44, 11, 33
@@ -272,7 +293,7 @@ unconstrained fn non_full_unordered_nullifiers() {
 }
 
 #[test(should_fail_with = "Empty low leaf")]
-unconstrained fn new_nullifier_same_as_existing_use_empty_leaf_as_low_leaf() {
+fn new_nullifier_same_as_existing_use_empty_leaf_as_low_leaf() {
     let mut builder = TestBuilder::new();
 
     // Set the first new nullifier to be the same as one of the pre-existing nullifiers.
@@ -291,7 +312,7 @@ unconstrained fn new_nullifier_same_as_existing_use_empty_leaf_as_low_leaf() {
 }
 
 #[test(should_fail_with = "Invalid low leaf: Value is not less than the next leaf")]
-unconstrained fn new_nullifier_same_as_existing_use_low_leaf_with_smaller_value() {
+fn new_nullifier_same_as_existing_use_low_leaf_with_smaller_value() {
     let mut builder = TestBuilder::new();
 
     // Set the first new nullifier to be the same as one of the pre-existing nullifiers.
@@ -314,7 +335,7 @@ unconstrained fn new_nullifier_same_as_existing_use_low_leaf_with_smaller_value(
 }
 
 #[test(should_fail_with = "Invalid low leaf: Value is not greater than the low leaf")]
-unconstrained fn new_nullifier_same_as_existing_use_low_leaf_with_valid_next_leaf() {
+fn new_nullifier_same_as_existing_use_low_leaf_with_valid_next_leaf() {
     let mut builder = TestBuilder::new();
 
     // Set the first new nullifier to be the same as one of the pre-existing nullifiers.
@@ -337,7 +358,7 @@ unconstrained fn new_nullifier_same_as_existing_use_low_leaf_with_valid_next_lea
 }
 
 #[test(should_fail_with = "Membership check failed: low leaf does not exist in tree")]
-unconstrained fn new_nullifier_same_as_existing_fake_low_leaf() {
+fn new_nullifier_same_as_existing_fake_low_leaf() {
     let mut builder = TestBuilder::new();
 
     // Set the first new nullifier to be the same as one of the pre-existing nullifiers.
@@ -357,7 +378,7 @@ unconstrained fn new_nullifier_same_as_existing_fake_low_leaf() {
 }
 
 #[test(should_fail_with = "Membership check failed: low leaf does not exist in tree")]
-unconstrained fn identical_new_nullifiers() {
+fn identical_new_nullifiers() {
     let mut builder = TestBuilder::new();
 
     // Add 2 nullifiers that are the same.
@@ -376,7 +397,7 @@ unconstrained fn identical_new_nullifiers() {
 }
 
 #[test]
-unconstrained fn insert_at_large_index_to_fill_nullifier_tree() {
+fn insert_at_large_index_to_fill_nullifier_tree() {
     let mut builder = TestBuilder::new();
 
     let max_num_nullifiers = (1 << NULLIFIER_TREE_HEIGHT as u64) as Field;
@@ -390,7 +411,7 @@ unconstrained fn insert_at_large_index_to_fill_nullifier_tree() {
 }
 
 #[test(should_fail_with = "Field failed to decompose into specified 36 limbs")]
-unconstrained fn insert_at_large_index_to_overfill_nullifier_tree() {
+fn insert_at_large_index_to_overfill_nullifier_tree() {
     let mut builder = TestBuilder::new();
 
     let max_num_nullifiers = (1 << NULLIFIER_TREE_HEIGHT as u64) as Field;
@@ -403,7 +424,7 @@ unconstrained fn insert_at_large_index_to_overfill_nullifier_tree() {
 // --- Public data tree ---
 
 #[test]
-unconstrained fn fee_payer_balance_leaf_updated() {
+fn fee_payer_balance_leaf_updated() {
     let mut builder = TestBuilder::new();
 
     let tx_fee = builder.get_transaction_fee();
@@ -437,7 +458,7 @@ unconstrained fn fee_payer_balance_leaf_updated() {
 }
 
 #[test]
-unconstrained fn fee_payer_balance_leaf_update_at_large_index() {
+fn fee_payer_balance_leaf_update_at_large_index() {
     let mut builder = TestBuilder::new();
 
     let tx_fee = builder.get_transaction_fee();
@@ -477,7 +498,7 @@ unconstrained fn fee_payer_balance_leaf_update_at_large_index() {
 }
 
 #[test(should_fail_with = "attempt to bit-shift with overflow")]
-unconstrained fn fee_payer_balance_leaf_index_too_large() {
+fn fee_payer_balance_leaf_index_too_large() {
     let mut builder = TestBuilder::new();
 
     // Tweak the index of the leaf to be beyond the tree size.

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/tx_base/tests/private_tx_base/fee_tests.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/tx_base/tests/private_tx_base/fee_tests.nr
@@ -1,7 +1,7 @@
 use super::TestBuilder;
 
 #[test(should_fail_with = "Wrong leaf slot for fee payer balance")]
-unconstrained fn hint_to_incorrect_public_data_leaf() {
+fn hint_to_incorrect_public_data_leaf() {
     let mut builder = TestBuilder::new();
 
     // Point to another public data preimage.
@@ -12,7 +12,7 @@ unconstrained fn hint_to_incorrect_public_data_leaf() {
 }
 
 #[test(should_fail_with = "Not enough balance for fee payer to pay for transaction")]
-unconstrained fn insufficient_balance_to_pay_fee() {
+fn insufficient_balance_to_pay_fee() {
     let mut builder = TestBuilder::new();
 
     let tx_fee = builder.get_transaction_fee();
@@ -25,7 +25,7 @@ unconstrained fn insufficient_balance_to_pay_fee() {
 }
 
 #[test]
-unconstrained fn balance_equal_transaction_fee() {
+fn balance_equal_transaction_fee() {
     let mut builder = TestBuilder::new();
 
     let tx_fee = builder.get_transaction_fee();
@@ -41,7 +41,7 @@ unconstrained fn balance_equal_transaction_fee() {
 }
 
 #[test(should_fail_with = "Membership check failed: public data leaf preimage does not exist in tree")]
-unconstrained fn incorrect_fee_payer_balance_leaf_preimage() {
+fn incorrect_fee_payer_balance_leaf_preimage() {
     let mut builder = TestBuilder::new();
 
     // Tweak the value of the preimage without updating it to the tree.
@@ -51,7 +51,7 @@ unconstrained fn incorrect_fee_payer_balance_leaf_preimage() {
 }
 
 #[test(should_fail_with = "Membership check failed: public data leaf preimage does not exist in tree")]
-unconstrained fn incorrect_fee_payer_pre_existing_leaf_index() {
+fn incorrect_fee_payer_pre_existing_leaf_index() {
     let mut builder = TestBuilder::new();
 
     // Tweak the value of the leaf index.

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/tx_base/tests/private_tx_base/mod.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/tx_base/tests/private_tx_base/mod.nr
@@ -68,6 +68,14 @@ pub struct TestBuilder {
 
 impl TestBuilder {
     pub fn new() -> Self {
+        // Safety: building trees/hints is test-only setup that doesn't need constraining. Running in unconstrained mode
+        // to speed up testing.
+        unsafe {
+            Self::_new()
+        }
+    }
+
+    unconstrained fn _new() -> Self {
         let rollup_fixture_builder = RollupFixtureBuilder::new();
         let block_number = rollup_fixture_builder.start_block_number;
 
@@ -189,6 +197,11 @@ impl TestBuilder {
     }
 
     pub fn build_note_hash_tree(&mut self, start_index: Field) {
+        // Safety: test-only tree building doesn't need constraining.
+        *self = unsafe { self._build_note_hash_tree(start_index) };
+    }
+
+    unconstrained fn _build_note_hash_tree(mut self, start_index: Field) -> Self {
         self.note_hash_tree = SingleSubtreeMerkleTree::new_at_index(
             pad_end(self.pre_existing_note_hashes),
             start_index,
@@ -205,9 +218,16 @@ impl TestBuilder {
             self.note_hash_tree.get_sibling_path(next_available_leaf_index),
             NOTE_HASH_SUBTREE_HEIGHT,
         );
+
+        self
     }
 
     pub fn build_nullifier_tree(&mut self, start_index: Field) {
+        // Safety: test-only tree building doesn't need constraining.
+        *self = unsafe { self._build_nullifier_tree(start_index) };
+    }
+
+    unconstrained fn _build_nullifier_tree(mut self, start_index: Field) -> Self {
         let leaf_values = self.pre_existing_nullifiers.map(|nullifier| nullifier.as_leaf());
         self.nullifier_tree =
             SingleSubtreeMerkleTree::new_at_index(pad_end(leaf_values), start_index);
@@ -218,13 +238,19 @@ impl TestBuilder {
         };
 
         // If the tree is rebuilt, might need to call `build_hints_for_new_nullifiers` again to update the hints.
+
+        self
     }
 
     pub fn build_hints_for_new_nullifiers(&mut self) {
+        // Safety: test-only hint building doesn't need constraining.
+        *self = unsafe { self._build_hints_for_new_nullifiers() };
+    }
+
+    unconstrained fn _build_hints_for_new_nullifiers(mut self) -> Self {
         let new_nullifiers = self.private_tail.end.nullifiers;
 
-        // Safety: This is for testing only.
-        let sorted_tuples = unsafe { get_sorted_tuples(new_nullifiers, |a, b| b.lt(a)) };
+        let sorted_tuples = get_sorted_tuples(new_nullifiers, |a, b| b.lt(a));
         let sorted_nullifiers = sorted_tuples.map(|tuple| tuple.elem);
         let sorted_nullifier_indexes = sorted_tuples.map(|tuple| tuple.original_index);
         self.tree_snapshot_diff_hints.sorted_nullifiers = sorted_nullifiers;
@@ -236,16 +262,13 @@ impl TestBuilder {
             self.start_tree_snapshots.nullifier_tree.next_available_leaf_index;
         for i in 0..sorted_nullifiers.len() {
             let new_nullifier = sorted_nullifiers[i];
-            // Safety: This is for testing only.
-            let low_leaf_index = unsafe {
-                find_first_index(
-                    low_leaves,
-                    |leaf| {
-                        leaf.nullifier.lt(new_nullifier)
-                            & (new_nullifier.lt(leaf.next_nullifier) | (leaf.next_nullifier == 0))
-                    },
-                )
-            };
+            let low_leaf_index = find_first_index(
+                low_leaves,
+                |leaf| {
+                    leaf.nullifier.lt(new_nullifier)
+                        & (new_nullifier.lt(leaf.next_nullifier) | (leaf.next_nullifier == 0))
+                },
+            );
             if low_leaf_index != low_leaves.len() {
                 self.tree_snapshot_diff_hints.nullifier_predecessor_preimages[i] =
                     low_leaves[low_leaf_index];
@@ -271,9 +294,16 @@ impl TestBuilder {
             cloned_nullifier_tree.get_sibling_path(new_batch_start_index),
             NULLIFIER_SUBTREE_HEIGHT,
         );
+
+        self
     }
 
     pub fn build_public_data_tree(&mut self, start_index: Field) {
+        // Safety: test-only tree building doesn't need constraining.
+        *self = unsafe { self._build_public_data_tree(start_index) };
+    }
+
+    unconstrained fn _build_public_data_tree(mut self, start_index: Field) -> Self {
         self.public_data_tree = SingleSubtreeMerkleTree::new_at_index(
             self.pre_existing_public_data_preimages.map(|leaf| leaf.as_leaf()),
             start_index,
@@ -286,9 +316,16 @@ impl TestBuilder {
 
         // If the tree is rebuilt and the start index has changed, call `build_hints_for_fee_payer_balance` again to
         // update the hints.
+
+        self
     }
 
     pub fn build_hints_for_fee_payer_balance(&mut self) {
+        // Safety: test-only hint building doesn't need constraining.
+        *self = unsafe { self._build_hints_for_fee_payer_balance() };
+    }
+
+    unconstrained fn _build_hints_for_fee_payer_balance(mut self) -> Self {
         let start_index = self.public_data_tree.get_next_available_index()
             - TEST_PUBLIC_DATA_SUBTREE_WIDTH as Field;
         let leaf_index = start_index + self.fee_payer_preimage_index as Field;
@@ -296,6 +333,8 @@ impl TestBuilder {
             leaf_index,
             sibling_path: self.public_data_tree.get_sibling_path(leaf_index),
         };
+
+        self
     }
 
     pub fn execute(self) -> TxRollupPublicInputs {

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/tx_base/tests/private_tx_base/out_hash_tests.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/tx_base/tests/private_tx_base/out_hash_tests.nr
@@ -4,7 +4,7 @@ use types::{
 };
 
 #[test]
-unconstrained fn empty_l2_to_l1_msgs() {
+fn empty_l2_to_l1_msgs() {
     let builder = TestBuilder::new();
 
     let pi = builder.execute();
@@ -14,7 +14,7 @@ unconstrained fn empty_l2_to_l1_msgs() {
 }
 
 #[test]
-unconstrained fn max_l2_to_l1_msgs() {
+fn max_l2_to_l1_msgs() {
     let mut builder = TestBuilder::new();
 
     let mut fixture_builder = FixtureBuilder::new();
@@ -30,7 +30,7 @@ unconstrained fn max_l2_to_l1_msgs() {
 }
 
 #[test]
-unconstrained fn unbalanced_l2_to_l1_msg_tree() {
+fn unbalanced_l2_to_l1_msg_tree() {
     let mut builder = TestBuilder::new();
 
     let num_l2_to_l1_msgs = 3; // Will create a subtree of 2 and another subtree of 1.

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/tx_base/tests/private_tx_base/validate_private_tail_tests.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/tx_base/tests/private_tx_base/validate_private_tail_tests.nr
@@ -2,7 +2,7 @@ use super::TestBuilder;
 use types::{constants::MAX_PROCESSABLE_L2_GAS, tests::fixture_builder::FixtureBuilder};
 
 #[test(should_fail_with = "Membership check failed: anchor block header hash not found in archive tree")]
-unconstrained fn anchor_block_header_not_in_archive() {
+fn anchor_block_header_not_in_archive() {
     let mut builder = TestBuilder::new();
 
     builder.private_tail.constants.anchor_block_header.state.partial.note_hash_tree.root = 999;
@@ -11,7 +11,7 @@ unconstrained fn anchor_block_header_not_in_archive() {
 }
 
 #[test(should_fail_with = "Mismatched chain_id between kernel and rollup")]
-unconstrained fn mismatch_chain_id() {
+fn mismatch_chain_id() {
     let mut builder = TestBuilder::new();
 
     builder.private_tail.constants.tx_context.chain_id += 1;
@@ -20,7 +20,7 @@ unconstrained fn mismatch_chain_id() {
 }
 
 #[test(should_fail_with = "Mismatched version between kernel and rollup")]
-unconstrained fn mismatch_version() {
+fn mismatch_version() {
     let mut builder = TestBuilder::new();
 
     builder.private_tail.constants.tx_context.version += 1;
@@ -29,7 +29,7 @@ unconstrained fn mismatch_version() {
 }
 
 #[test(should_fail_with = "Mismatched protocol_contracts_hash between kernel and rollup")]
-unconstrained fn mismatch_protocol_contracts_hash() {
+fn mismatch_protocol_contracts_hash() {
     let mut builder = TestBuilder::new();
 
     builder.private_tail.constants.protocol_contracts_hash += 1;
@@ -38,7 +38,7 @@ unconstrained fn mismatch_protocol_contracts_hash() {
 }
 
 #[test(should_fail_with = "da gas is higher than the maximum specified by the tx")]
-unconstrained fn not_enough_fee_per_da_gas() {
+fn not_enough_fee_per_da_gas() {
     let mut builder = TestBuilder::new();
 
     builder.private_tail.constants.tx_context.gas_settings.max_fees_per_gas.fee_per_da_gas = 3;
@@ -48,7 +48,7 @@ unconstrained fn not_enough_fee_per_da_gas() {
 }
 
 #[test(should_fail_with = "l2 gas is higher than the maximum specified by the tx")]
-unconstrained fn not_enough_fee_per_l2_gas() {
+fn not_enough_fee_per_l2_gas() {
     let mut builder = TestBuilder::new();
 
     builder.private_tail.constants.tx_context.gas_settings.max_fees_per_gas.fee_per_l2_gas = 3;
@@ -58,7 +58,7 @@ unconstrained fn not_enough_fee_per_l2_gas() {
 }
 
 #[test(should_fail_with = "l2 gas limit exceeds max processable l2 gas")]
-unconstrained fn gas_settings_l2_gas_limit_exceeds_max_processable_l2_gas() {
+fn gas_settings_l2_gas_limit_exceeds_max_processable_l2_gas() {
     let mut builder = TestBuilder::new();
 
     builder.private_tail.constants.tx_context.gas_settings.gas_limits.l2_gas =
@@ -68,7 +68,7 @@ unconstrained fn gas_settings_l2_gas_limit_exceeds_max_processable_l2_gas() {
 }
 
 #[test(should_fail_with = "Mismatched contract class log hash")]
-unconstrained fn mismatch_contract_class_log_fields() {
+fn mismatch_contract_class_log_fields() {
     let mut builder = TestBuilder::new();
 
     // Add a contract class log.
@@ -83,7 +83,7 @@ unconstrained fn mismatch_contract_class_log_fields() {
 }
 
 #[test(should_fail_with = "Mismatched contract class log hash")]
-unconstrained fn extra_non_zero_contract_class_log_fields() {
+fn extra_non_zero_contract_class_log_fields() {
     let mut builder = TestBuilder::new();
 
     // Add a contract class log.
@@ -98,7 +98,7 @@ unconstrained fn extra_non_zero_contract_class_log_fields() {
 }
 
 #[test(should_fail_with = "Incorrect contract class log length")]
-unconstrained fn incorrect_contract_class_log_length() {
+fn incorrect_contract_class_log_length() {
     let mut builder = TestBuilder::new();
 
     // Add a contract class log.
@@ -113,7 +113,7 @@ unconstrained fn incorrect_contract_class_log_length() {
 }
 
 #[test(should_fail_with = "tx expiration_timestamp is smaller than block timestamp")]
-unconstrained fn expiration_timestamp_lower_than_block_timestamp() {
+fn expiration_timestamp_lower_than_block_timestamp() {
     let mut builder = TestBuilder::new();
 
     builder.private_tail.expiration_timestamp = builder.constants.global_variables.timestamp - 1;
@@ -122,7 +122,7 @@ unconstrained fn expiration_timestamp_lower_than_block_timestamp() {
 }
 
 #[test]
-unconstrained fn expiration_timestamp_equal_to_block_timestamp() {
+fn expiration_timestamp_equal_to_block_timestamp() {
     let mut builder = TestBuilder::new();
 
     builder.private_tail.expiration_timestamp = builder.constants.global_variables.timestamp;
@@ -132,7 +132,7 @@ unconstrained fn expiration_timestamp_equal_to_block_timestamp() {
 }
 
 #[test]
-unconstrained fn expiration_timestamp_higher_than_block_timestamp() {
+fn expiration_timestamp_higher_than_block_timestamp() {
     let mut builder = TestBuilder::new();
 
     builder.private_tail.expiration_timestamp = builder.constants.global_variables.timestamp + 1;

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/tx_base/tests/public_tx_base/child_proof_vk_tests.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/tx_base/tests/public_tx_base/child_proof_vk_tests.nr
@@ -2,14 +2,14 @@ use super::TestBuilder;
 use types::tests::fixtures::vk_tree::VK_MERKLE_TREE;
 
 #[test]
-unconstrained fn default_setup_success() {
+fn default_setup_success() {
     let builder = TestBuilder::new();
     let pi = builder.execute();
     builder.assert_expected_public_inputs(pi);
 }
 
 #[test(should_fail_with = "Incorrect public chonk verifier vk index")]
-unconstrained fn incorrect_public_chonk_verifier_vk_index() {
+fn incorrect_public_chonk_verifier_vk_index() {
     let mut builder = TestBuilder::new();
 
     builder.public_chonk_verifier_vk_index += 1;
@@ -18,7 +18,7 @@ unconstrained fn incorrect_public_chonk_verifier_vk_index() {
 }
 
 #[test(should_fail_with = "Membership check failed: vk hash not found in vk tree")]
-unconstrained fn public_chonk_verifier_vk_hash_not_in_vk_tree() {
+fn public_chonk_verifier_vk_hash_not_in_vk_tree() {
     let mut builder = TestBuilder::new();
 
     // Change the public chonk verifier vk hash so that the old vk hash in the proof data is no longer in the vk tree.

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/tx_base/tests/public_tx_base/end_blob_sponge_tests.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/tx_base/tests/public_tx_base/end_blob_sponge_tests.nr
@@ -13,7 +13,7 @@ use types::{
 };
 
 #[test]
-unconstrained fn full_tx_effects() {
+fn full_tx_effects() {
     let mut builder = TestBuilder::new();
 
     let mut fixture_builder = FixtureBuilder::new();
@@ -146,7 +146,7 @@ unconstrained fn full_tx_effects() {
 }
 
 #[test]
-unconstrained fn all_side_effects_non_full() {
+fn all_side_effects_non_full() {
     let mut builder = TestBuilder::new();
 
     let mut fixture_builder = FixtureBuilder::new();
@@ -276,7 +276,7 @@ unconstrained fn all_side_effects_non_full() {
 }
 
 #[test]
-unconstrained fn partially_empty_tx_effects() {
+fn partially_empty_tx_effects() {
     let mut builder = TestBuilder::new();
 
     let mut fixture_builder = FixtureBuilder::new();
@@ -337,7 +337,7 @@ unconstrained fn partially_empty_tx_effects() {
 }
 
 #[test]
-unconstrained fn discard_reverted_side_effects() {
+fn discard_reverted_side_effects() {
     let mut builder = TestBuilder::new();
 
     // Mark the tx as reverted.

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/tx_base/tests/public_tx_base/mod.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/tx_base/tests/public_tx_base/mod.nr
@@ -38,6 +38,14 @@ struct TestBuilder {
 
 impl TestBuilder {
     pub fn new() -> Self {
+        // Safety: building fixtures is test-only setup that doesn't need constraining. Running in unconstrained mode
+        // to speed up testing.
+        unsafe {
+            Self::_new()
+        }
+    }
+
+    unconstrained fn _new() -> Self {
         let prover_id = 42;
         // --- Build things at tx level ---
         let mut builder = FixtureBuilder::new();

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/tx_base/tests/public_tx_base/out_hash_tests.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/tx_base/tests/public_tx_base/out_hash_tests.nr
@@ -5,7 +5,7 @@ use types::{
 };
 
 #[test]
-unconstrained fn empty_l2_to_l1_msgs() {
+fn empty_l2_to_l1_msgs() {
     let builder = TestBuilder::new();
 
     let pi = builder.execute();
@@ -15,7 +15,7 @@ unconstrained fn empty_l2_to_l1_msgs() {
 }
 
 #[test]
-unconstrained fn max_l2_to_l1_msgs() {
+fn max_l2_to_l1_msgs() {
     let mut builder = TestBuilder::new();
 
     let mut fixture_builder = FixtureBuilder::new();
@@ -32,7 +32,7 @@ unconstrained fn max_l2_to_l1_msgs() {
 }
 
 #[test]
-unconstrained fn unbalanced_l2_to_l1_msg_tree() {
+fn unbalanced_l2_to_l1_msg_tree() {
     let mut builder = TestBuilder::new();
 
     let num_l2_to_l1_msgs = 5; // Will create a subtree of 4 and another subtree of 1.

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/tx_base/tests/public_tx_base/validate_private_tail_to_public_tests.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/tx_base/tests/public_tx_base/validate_private_tail_to_public_tests.nr
@@ -2,7 +2,7 @@ use super::TestBuilder;
 use types::{constants::MAX_PROCESSABLE_L2_GAS, tests::fixture_builder::FixtureBuilder};
 
 #[test(should_fail_with = "Membership check failed: anchor block header hash not found in archive tree")]
-unconstrained fn anchor_block_header_not_in_archive() {
+fn anchor_block_header_not_in_archive() {
     let mut builder = TestBuilder::new();
 
     builder.private_tail.constants.anchor_block_header.state.partial.note_hash_tree.root = 999;
@@ -11,7 +11,7 @@ unconstrained fn anchor_block_header_not_in_archive() {
 }
 
 #[test(should_fail_with = "Mismatched chain_id between kernel and rollup")]
-unconstrained fn mismatch_chain_id() {
+fn mismatch_chain_id() {
     let mut builder = TestBuilder::new();
 
     builder.private_tail.constants.tx_context.chain_id += 1;
@@ -20,7 +20,7 @@ unconstrained fn mismatch_chain_id() {
 }
 
 #[test(should_fail_with = "Mismatched version between kernel and rollup")]
-unconstrained fn mismatch_version() {
+fn mismatch_version() {
     let mut builder = TestBuilder::new();
 
     builder.private_tail.constants.tx_context.version += 1;
@@ -29,7 +29,7 @@ unconstrained fn mismatch_version() {
 }
 
 #[test(should_fail_with = "da gas is higher than the maximum specified by the tx")]
-unconstrained fn not_enough_fee_per_da_gas() {
+fn not_enough_fee_per_da_gas() {
     let mut builder = TestBuilder::new();
 
     builder.private_tail.constants.tx_context.gas_settings.max_fees_per_gas.fee_per_da_gas = 3;
@@ -39,7 +39,7 @@ unconstrained fn not_enough_fee_per_da_gas() {
 }
 
 #[test(should_fail_with = "l2 gas is higher than the maximum specified by the tx")]
-unconstrained fn not_enough_fee_per_l2_gas() {
+fn not_enough_fee_per_l2_gas() {
     let mut builder = TestBuilder::new();
 
     builder.private_tail.constants.tx_context.gas_settings.max_fees_per_gas.fee_per_l2_gas = 3;
@@ -49,7 +49,7 @@ unconstrained fn not_enough_fee_per_l2_gas() {
 }
 
 #[test(should_fail_with = "l2 gas limit exceeds max processable l2 gas")]
-unconstrained fn gas_settings_l2_gas_limit_exceeds_max_processable_l2_gas() {
+fn gas_settings_l2_gas_limit_exceeds_max_processable_l2_gas() {
     let mut builder = TestBuilder::new();
 
     builder.private_tail.constants.tx_context.gas_settings.gas_limits.l2_gas =
@@ -59,7 +59,7 @@ unconstrained fn gas_settings_l2_gas_limit_exceeds_max_processable_l2_gas() {
 }
 
 #[test(should_fail_with = "Mismatched contract class log hash")]
-unconstrained fn mismatch_contract_class_log_fields() {
+fn mismatch_contract_class_log_fields() {
     let mut builder = TestBuilder::new();
 
     // Add a contract class log.
@@ -74,7 +74,7 @@ unconstrained fn mismatch_contract_class_log_fields() {
 }
 
 #[test(should_fail_with = "Mismatched contract class log hash")]
-unconstrained fn extra_non_zero_contract_class_log_fields() {
+fn extra_non_zero_contract_class_log_fields() {
     let mut builder = TestBuilder::new();
 
     // Add a contract class log.
@@ -89,7 +89,7 @@ unconstrained fn extra_non_zero_contract_class_log_fields() {
 }
 
 #[test(should_fail_with = "Incorrect contract class log length")]
-unconstrained fn incorrect_contract_class_log_length() {
+fn incorrect_contract_class_log_length() {
     let mut builder = TestBuilder::new();
 
     // Add a contract class log.
@@ -105,7 +105,7 @@ unconstrained fn incorrect_contract_class_log_length() {
 }
 
 #[test(should_fail_with = "Incorrect contract class log length")]
-unconstrained fn non_empty_contract_class_log_fields_for_reverted_log() {
+fn non_empty_contract_class_log_fields_for_reverted_log() {
     let mut builder = TestBuilder::new();
 
     // Mark the tx as reverted.
@@ -124,7 +124,7 @@ unconstrained fn non_empty_contract_class_log_fields_for_reverted_log() {
 }
 
 #[test(should_fail_with = "tx expiration_timestamp is smaller than block timestamp")]
-unconstrained fn expiration_timestamp_lower_than_block_timestamp() {
+fn expiration_timestamp_lower_than_block_timestamp() {
     let mut builder = TestBuilder::new();
 
     builder.private_tail.expiration_timestamp = builder.avm.global_variables.timestamp - 1;
@@ -133,7 +133,7 @@ unconstrained fn expiration_timestamp_lower_than_block_timestamp() {
 }
 
 #[test]
-unconstrained fn expiration_timestamp_equal_to_block_timestamp() {
+fn expiration_timestamp_equal_to_block_timestamp() {
     let mut builder = TestBuilder::new();
 
     builder.private_tail.expiration_timestamp = builder.avm.global_variables.timestamp;
@@ -143,7 +143,7 @@ unconstrained fn expiration_timestamp_equal_to_block_timestamp() {
 }
 
 #[test]
-unconstrained fn expiration_timestamp_higher_than_block_timestamp() {
+fn expiration_timestamp_higher_than_block_timestamp() {
     let mut builder = TestBuilder::new();
 
     builder.private_tail.expiration_timestamp = builder.avm.global_variables.timestamp + 1;

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/tx_base/tests/public_tx_base/validate_public_chonk_verifier_against_avm_tests.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/tx_base/tests/public_tx_base/validate_public_chonk_verifier_against_avm_tests.nr
@@ -2,7 +2,7 @@ use super::TestBuilder;
 use types::{abis::protocol_contracts::ProtocolContracts, traits::Empty};
 
 #[test(should_fail_with = "Mismatched prover_id between private and avm")]
-unconstrained fn mismatch_prover_id() {
+fn mismatch_prover_id() {
     let mut builder = TestBuilder::new();
 
     builder.avm.prover_id += 1;
@@ -11,7 +11,7 @@ unconstrained fn mismatch_prover_id() {
 }
 
 #[test(should_fail_with = "Mismatched protocol_contracts between private and avm")]
-unconstrained fn mismatch_protocol_contracts() {
+fn mismatch_protocol_contracts() {
     let mut builder = TestBuilder::new();
 
     builder.avm.protocol_contracts = ProtocolContracts::empty();
@@ -20,7 +20,7 @@ unconstrained fn mismatch_protocol_contracts() {
 }
 
 #[test(should_fail_with = "Mismatched start_gas_used between private and avm")]
-unconstrained fn mismatch_start_l2_gas_used() {
+fn mismatch_start_l2_gas_used() {
     let mut builder = TestBuilder::new();
 
     builder.avm.start_gas_used.l2_gas += 1;
@@ -29,7 +29,7 @@ unconstrained fn mismatch_start_l2_gas_used() {
 }
 
 #[test(should_fail_with = "Mismatched start_gas_used between private and avm")]
-unconstrained fn mismatch_start_da_gas_used() {
+fn mismatch_start_da_gas_used() {
     let mut builder = TestBuilder::new();
 
     builder.avm.start_gas_used.da_gas += 1;
@@ -38,7 +38,7 @@ unconstrained fn mismatch_start_da_gas_used() {
 }
 
 #[test(should_fail_with = "Mismatched gas_settings between private and avm")]
-unconstrained fn mismatch_gas_limits() {
+fn mismatch_gas_limits() {
     let mut builder = TestBuilder::new();
 
     builder.avm.gas_settings.gas_limits.da_gas += 1;
@@ -47,7 +47,7 @@ unconstrained fn mismatch_gas_limits() {
 }
 
 #[test(should_fail_with = "Mismatched gas_settings between private and avm")]
-unconstrained fn mismatch_teardown_gas_limits() {
+fn mismatch_teardown_gas_limits() {
     let mut builder = TestBuilder::new();
 
     builder.avm.gas_settings.teardown_gas_limits.l2_gas += 1;
@@ -56,7 +56,7 @@ unconstrained fn mismatch_teardown_gas_limits() {
 }
 
 #[test(should_fail_with = "Mismatched gas_settings between private and avm")]
-unconstrained fn mismatch_max_fees_per_gas() {
+fn mismatch_max_fees_per_gas() {
     let mut builder = TestBuilder::new();
 
     builder.avm.gas_settings.max_fees_per_gas.fee_per_da_gas += 1;
@@ -65,7 +65,7 @@ unconstrained fn mismatch_max_fees_per_gas() {
 }
 
 #[test(should_fail_with = "Mismatched gas_settings between private and avm")]
-unconstrained fn mismatch_max_priority_fees_per_gas() {
+fn mismatch_max_priority_fees_per_gas() {
     let mut builder = TestBuilder::new();
 
     builder.avm.gas_settings.max_priority_fees_per_gas.fee_per_l2_gas += 1;
@@ -74,7 +74,7 @@ unconstrained fn mismatch_max_priority_fees_per_gas() {
 }
 
 #[test(should_fail_with = "Incorrect effective gas fees used in the avm")]
-unconstrained fn mismatch_effective_l2_gas_fees() {
+fn mismatch_effective_l2_gas_fees() {
     let mut builder = TestBuilder::new();
 
     builder.avm.effective_gas_fees.fee_per_l2_gas += 1;
@@ -83,7 +83,7 @@ unconstrained fn mismatch_effective_l2_gas_fees() {
 }
 
 #[test(should_fail_with = "Incorrect effective gas fees used in the avm")]
-unconstrained fn mismatch_effective_da_gas_fees() {
+fn mismatch_effective_da_gas_fees() {
     let mut builder = TestBuilder::new();
 
     builder.avm.effective_gas_fees.fee_per_da_gas += 1;
@@ -92,7 +92,7 @@ unconstrained fn mismatch_effective_da_gas_fees() {
 }
 
 #[test(should_fail_with = "Mismatched fee_payer between private and avm")]
-unconstrained fn mismatch_fee_payer() {
+fn mismatch_fee_payer() {
     let mut builder = TestBuilder::new();
 
     builder.avm.fee_payer.inner += 1;
@@ -101,7 +101,7 @@ unconstrained fn mismatch_fee_payer() {
 }
 
 #[test(should_fail_with = "Mismatched non-revertible public_call_requests between private and avm")]
-unconstrained fn mismatch_non_revertible_public_call_requests() {
+fn mismatch_non_revertible_public_call_requests() {
     let mut builder = TestBuilder::new();
 
     builder.avm.public_setup_call_requests[1].contract_address.inner += 1;
@@ -110,7 +110,7 @@ unconstrained fn mismatch_non_revertible_public_call_requests() {
 }
 
 #[test(should_fail_with = "Mismatched non-revertible public_call_requests array length between private and avm")]
-unconstrained fn mismatch_non_revertible_public_call_requests_length() {
+fn mismatch_non_revertible_public_call_requests_length() {
     let mut builder = TestBuilder::new();
 
     builder.avm.public_call_request_array_lengths.setup_calls += 1;
@@ -119,7 +119,7 @@ unconstrained fn mismatch_non_revertible_public_call_requests_length() {
 }
 
 #[test(should_fail_with = "Mismatched revertible public_call_requests between private and avm")]
-unconstrained fn mismatch_revertible_public_call_requests() {
+fn mismatch_revertible_public_call_requests() {
     let mut builder = TestBuilder::new();
 
     builder.avm.public_app_logic_call_requests[0].contract_address.inner += 1;
@@ -128,7 +128,7 @@ unconstrained fn mismatch_revertible_public_call_requests() {
 }
 
 #[test(should_fail_with = "Mismatched revertible public_call_requests array length between private and avm")]
-unconstrained fn mismatch_revertible_public_call_requests_length() {
+fn mismatch_revertible_public_call_requests_length() {
     let mut builder = TestBuilder::new();
 
     builder.avm.public_call_request_array_lengths.app_logic_calls += 1;
@@ -137,7 +137,7 @@ unconstrained fn mismatch_revertible_public_call_requests_length() {
 }
 
 #[test(should_fail_with = "Mismatched public_teardown_call_request between private and avm")]
-unconstrained fn mismatch_public_teardown_call_request() {
+fn mismatch_public_teardown_call_request() {
     let mut builder = TestBuilder::new();
 
     builder.avm.public_teardown_call_request.contract_address.inner += 1;
@@ -146,7 +146,7 @@ unconstrained fn mismatch_public_teardown_call_request() {
 }
 
 #[test(should_fail_with = "Mismatched public_teardown_call_request length between private and avm")]
-unconstrained fn mismatch_public_teardown_call_request_length() {
+fn mismatch_public_teardown_call_request_length() {
     let mut builder = TestBuilder::new();
 
     builder.avm.public_call_request_array_lengths.teardown_call = true;
@@ -155,7 +155,7 @@ unconstrained fn mismatch_public_teardown_call_request_length() {
 }
 
 #[test(should_fail_with = "Mismatched non-revertible note_hashes between private and avm")]
-unconstrained fn mismatch_non_revertible_note_hashes() {
+fn mismatch_non_revertible_note_hashes() {
     let mut builder = TestBuilder::new();
 
     builder.avm.previous_non_revertible_accumulated_data.note_hashes[0] += 1;
@@ -164,7 +164,7 @@ unconstrained fn mismatch_non_revertible_note_hashes() {
 }
 
 #[test(should_fail_with = "Mismatched non-revertible note_hashes array length between private and avm")]
-unconstrained fn mismatch_non_revertible_note_hashes_length() {
+fn mismatch_non_revertible_note_hashes_length() {
     let mut builder = TestBuilder::new();
 
     builder.avm.previous_non_revertible_accumulated_data_array_lengths.note_hashes += 1;
@@ -173,7 +173,7 @@ unconstrained fn mismatch_non_revertible_note_hashes_length() {
 }
 
 #[test(should_fail_with = "Mismatched non-revertible nullifiers between private and avm")]
-unconstrained fn mismatch_non_revertible_nullifiers() {
+fn mismatch_non_revertible_nullifiers() {
     let mut builder = TestBuilder::new();
 
     builder.avm.previous_non_revertible_accumulated_data.nullifiers[0] += 1;
@@ -182,7 +182,7 @@ unconstrained fn mismatch_non_revertible_nullifiers() {
 }
 
 #[test(should_fail_with = "Mismatched non-revertible nullifiers array length between private and avm")]
-unconstrained fn mismatch_non_revertible_nullifiers_length() {
+fn mismatch_non_revertible_nullifiers_length() {
     let mut builder = TestBuilder::new();
 
     builder.avm.previous_non_revertible_accumulated_data_array_lengths.nullifiers += 1;
@@ -191,7 +191,7 @@ unconstrained fn mismatch_non_revertible_nullifiers_length() {
 }
 
 #[test(should_fail_with = "Mismatched non-revertible l2_to_l1_msgs between private and avm")]
-unconstrained fn mismatch_non_revertible_l2_to_l1_msgs() {
+fn mismatch_non_revertible_l2_to_l1_msgs() {
     let mut builder = TestBuilder::new();
 
     builder.avm.previous_non_revertible_accumulated_data.l2_to_l1_msgs[0].inner.content += 1;
@@ -200,7 +200,7 @@ unconstrained fn mismatch_non_revertible_l2_to_l1_msgs() {
 }
 
 #[test(should_fail_with = "Mismatched non-revertible l2_to_l1_msgs array length between private and avm")]
-unconstrained fn mismatch_non_revertible_l2_to_l1_msgs_length() {
+fn mismatch_non_revertible_l2_to_l1_msgs_length() {
     let mut builder = TestBuilder::new();
 
     builder.avm.previous_non_revertible_accumulated_data_array_lengths.l2_to_l1_msgs += 1;
@@ -209,7 +209,7 @@ unconstrained fn mismatch_non_revertible_l2_to_l1_msgs_length() {
 }
 
 #[test(should_fail_with = "Mismatched revertible note_hashes between private and avm")]
-unconstrained fn mismatch_revertible_note_hashes() {
+fn mismatch_revertible_note_hashes() {
     let mut builder = TestBuilder::new();
 
     builder.avm.previous_revertible_accumulated_data.note_hashes[0] += 1;
@@ -218,7 +218,7 @@ unconstrained fn mismatch_revertible_note_hashes() {
 }
 
 #[test(should_fail_with = "Mismatched revertible note_hashes array length between private and avm")]
-unconstrained fn mismatch_revertible_note_hashes_length() {
+fn mismatch_revertible_note_hashes_length() {
     let mut builder = TestBuilder::new();
 
     builder.avm.previous_revertible_accumulated_data_array_lengths.note_hashes += 1;
@@ -227,7 +227,7 @@ unconstrained fn mismatch_revertible_note_hashes_length() {
 }
 
 #[test(should_fail_with = "Mismatched revertible nullifiers between private and avm")]
-unconstrained fn mismatch_revertible_nullifiers() {
+fn mismatch_revertible_nullifiers() {
     let mut builder = TestBuilder::new();
 
     builder.avm.previous_revertible_accumulated_data.nullifiers[0] += 1;
@@ -236,7 +236,7 @@ unconstrained fn mismatch_revertible_nullifiers() {
 }
 
 #[test(should_fail_with = "Mismatched revertible nullifiers array length between private and avm")]
-unconstrained fn mismatch_revertible_nullifiers_length() {
+fn mismatch_revertible_nullifiers_length() {
     let mut builder = TestBuilder::new();
 
     builder.avm.previous_revertible_accumulated_data_array_lengths.nullifiers += 1;
@@ -245,7 +245,7 @@ unconstrained fn mismatch_revertible_nullifiers_length() {
 }
 
 #[test(should_fail_with = "Mismatched revertible l2_to_l1_msgs between private and avm")]
-unconstrained fn mismatch_revertible_l2_to_l1_msgs() {
+fn mismatch_revertible_l2_to_l1_msgs() {
     let mut builder = TestBuilder::new();
 
     builder.avm.previous_revertible_accumulated_data.l2_to_l1_msgs[0].inner.content += 1;
@@ -254,7 +254,7 @@ unconstrained fn mismatch_revertible_l2_to_l1_msgs() {
 }
 
 #[test(should_fail_with = "Mismatched revertible l2_to_l1_msgs array length between private and avm")]
-unconstrained fn mismatch_revertible_l2_to_l1_msgs_length() {
+fn mismatch_revertible_l2_to_l1_msgs_length() {
     let mut builder = TestBuilder::new();
 
     builder.avm.previous_revertible_accumulated_data_array_lengths.l2_to_l1_msgs += 1;

--- a/noir-projects/noir-protocol-circuits/crates/serde/src/tests.nr
+++ b/noir-projects/noir-protocol-circuits/crates/serde/src/tests.nr
@@ -150,7 +150,7 @@ fn option_array_serialization() {
 }
 
 #[test]
-unconstrained fn bounded_vec_serialization() {
+fn bounded_vec_serialization() {
     // Test empty BoundedVec
     let empty_vec: BoundedVec<Field, 3> = BoundedVec::from_array([]);
     let serialized = empty_vec.serialize();

--- a/noir-projects/noir-protocol-circuits/crates/serde/src/type_impls.nr
+++ b/noir-projects/noir-protocol-circuits/crates/serde/src/type_impls.nr
@@ -798,7 +798,7 @@ mod impls {
 }
 
 #[test]
-unconstrained fn bounded_vec_serialization() {
+fn bounded_vec_serialization() {
     // Test empty BoundedVec
     let empty_vec: BoundedVec<Field, 3> = BoundedVec::from_array([]);
     let serialized = empty_vec.serialize();

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/avm_circuit_public_inputs.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/avm_circuit_public_inputs.nr
@@ -535,14 +535,6 @@ fn serialization_of_empty_avm_circuit_public_inputs() {
 }
 
 #[test]
-fn flat_columns_of_empty_avm_circuit_public_inputs() {
-    let item = AvmCircuitPublicInputs::empty();
-    let flat = item.serialize_to_columns();
-    // some assertion just to make sure it isn't optimized away
-    assert(flat.len() == AVM_PUBLIC_INPUTS_COLUMNS_COMBINED_LENGTH);
-}
-
-#[test]
 fn flat_columns_of_avm_circuit_public_inputs() {
     // Create a test instance with specific values
     let mut item = AvmCircuitPublicInputs::empty();
@@ -591,6 +583,8 @@ fn flat_columns_of_avm_circuit_public_inputs() {
 
     // Serialize to columns
     let flat = item.serialize_to_columns();
+
+    assert_eq(flat.len(), AVM_PUBLIC_INPUTS_COLUMNS_COMBINED_LENGTH);
 
     // Verify length
     // Define column offsets

--- a/noir-projects/noir-protocol-circuits/crates/types/src/address/aztec_address.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/address/aztec_address.nr
@@ -300,7 +300,7 @@ fn to_address_point_valid() {
 }
 
 #[test]
-unconstrained fn to_address_point_invalid() {
+fn to_address_point_invalid() {
     // x = 3 where x^3 - 17 = 27 - 17 = 10, which is a non-residue in this field
     let address = AztecAddress { inner: 3 };
 

--- a/noir-projects/noir-protocol-circuits/crates/types/src/blob_data/sponge_blob.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/blob_data/sponge_blob.nr
@@ -196,7 +196,7 @@ fn test_sponge_blob_serialization() {
 }
 
 #[test]
-unconstrained fn absorb_in_chunks() {
+fn absorb_in_chunks() {
     // This tests that absorbing two arrays separately then squeezing matches absorbing everything as a single array.
     let mut chunk_sponge = SpongeBlob::init();
     let array0 = [1, 2, 3];
@@ -218,7 +218,7 @@ unconstrained fn absorb_in_chunks() {
 }
 
 #[test(should_fail_with = "Given in_len to absorb is larger than the input array len")]
-unconstrained fn absorb_incorrect_in_len() {
+fn absorb_incorrect_in_len() {
     let mut sponge_blob = SpongeBlob::init();
     let input_3 = [1, 2, 3];
     // The below should fail, as we try to absorb 10 inputs but only provide 3
@@ -245,7 +245,7 @@ fn should_not_absorb_more_than_len() {
 }
 
 #[test]
-unconstrained fn full_sponge_hash_match_typescript() {
+fn full_sponge_hash_match_typescript() {
     let mut fields = [0; BLOBS_PER_CHECKPOINT * FIELDS_PER_BLOB];
     for i in 0..fields.len() {
         fields[i] = (i as Field) + 123;

--- a/noir-projects/noir-protocol-circuits/crates/types/src/constants.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/constants.nr
@@ -1311,7 +1311,7 @@ mod test {
     };
 
     #[test]
-    unconstrained fn test_grumpkin_point() {
+    fn test_grumpkin_point() {
         assert_eq(
             super::GRUMPKIN_ONE_X,
             std::embedded_curve_ops::EmbeddedCurvePoint::generator().x,
@@ -1323,7 +1323,7 @@ mod test {
     }
 
     #[test]
-    unconstrained fn test_avm_written_public_data_slots_tree_height() {
+    fn test_avm_written_public_data_slots_tree_height() {
         assert_eq(
             1 << AVM_WRITTEN_PUBLIC_DATA_SLOTS_TREE_HEIGHT,
             MAX_PUBLIC_DATA_UPDATE_REQUESTS_PER_TX + 1,
@@ -1331,7 +1331,7 @@ mod test {
     }
 
     #[test]
-    unconstrained fn test_avm_retrieved_bytecodes_tree_height() {
+    fn test_avm_retrieved_bytecodes_tree_height() {
         assert(
             1 << AVM_RETRIEVED_BYTECODES_TREE_HEIGHT
                 >= MAX_PUBLIC_CALLS_TO_UNIQUE_CONTRACT_CLASS_IDS + 1,
@@ -1343,7 +1343,7 @@ mod test {
     }
 
     #[test]
-    unconstrained fn test_side_effect_masking_address() {
+    fn test_side_effect_masking_address() {
         assert(
             (MAX_PROTOCOL_CONTRACTS as Field).lt(SIDE_EFFECT_MASKING_ADDRESS.to_field()),
             "Side effect masking address cannot overlap with protocol contract addresses",
@@ -1351,7 +1351,7 @@ mod test {
     }
 
     #[test]
-    unconstrained fn parity_covers_all_l1_to_l2_msgs() {
+    fn parity_covers_all_l1_to_l2_msgs() {
         assert_eq(
             NUM_BASE_PARITY_PER_ROOT_PARITY * NUM_MSGS_PER_BASE_PARITY,
             NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP,

--- a/noir-projects/noir-protocol-circuits/crates/types/src/data/hash.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/data/hash.nr
@@ -12,7 +12,7 @@ pub fn compute_public_data_leaf_slot(contract_address: AztecAddress, storage_slo
 }
 
 #[test]
-unconstrained fn public_data_leaf_slot_matches_typescript() {
+fn public_data_leaf_slot_matches_typescript() {
     let contract_address = AztecAddress::from_field(987);
     let storage_slot = 123;
     let hash = compute_public_data_leaf_slot(contract_address, storage_slot);

--- a/noir-projects/noir-protocol-circuits/crates/types/src/delayed_public_mutable/delayed_public_mutable_values/test.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/delayed_public_mutable/delayed_public_mutable_values/test.nr
@@ -7,14 +7,12 @@ use crate::delayed_public_mutable::{
 global TEST_INITIAL_DELAY: u64 = 13;
 
 #[derive(Eq, Packable)]
-pub struct MockStruct {
+struct MockStruct {
     pub a: Field,
     pub b: Field,
 }
 
-unconstrained fn assert_equal_after_conversion<T>(
-    original: DelayedPublicMutableValues<T, TEST_INITIAL_DELAY>,
-)
+fn assert_equal_after_conversion<T>(original: DelayedPublicMutableValues<T, TEST_INITIAL_DELAY>)
 where
     T: Packable + Eq,
 {
@@ -24,7 +22,7 @@ where
 }
 
 #[test]
-unconstrained fn test_packable() {
+fn test_packable() {
     let pre_delay = 1;
     let post_delay = 2;
     let timestamp_of_change = 50;
@@ -45,7 +43,7 @@ unconstrained fn test_packable() {
 }
 
 #[test]
-unconstrained fn test_packable_large_values() {
+fn test_packable_large_values() {
     // We test max u32 even when the actual timestamp is u64 because the timestamp is packed in 32 bits. This makes
     // the code fail in year 2106. This is a tech debt that is not worth tackling.
     let max_u32 = ((1 as u64 << 32) - 1) as u64;
@@ -70,7 +68,7 @@ unconstrained fn test_packable_large_values() {
 }
 
 #[test]
-unconstrained fn packed_delayed_public_mutable_values_match_typescript() {
+fn packed_delayed_public_mutable_values_match_typescript() {
     let pre_value = MockStruct { a: 1, b: 2 };
     let post_value = MockStruct { a: 3, b: 4 };
 

--- a/noir-projects/noir-protocol-circuits/crates/types/src/delayed_public_mutable/scheduled_delay_change/test.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/delayed_public_mutable/scheduled_delay_change/test.nr
@@ -2,7 +2,7 @@ use crate::delayed_public_mutable::scheduled_delay_change::ScheduledDelayChange;
 
 global TEST_INITIAL_DELAY: u64 = 13;
 
-unconstrained fn get_non_initial_delay_change(
+fn get_non_initial_delay_change(
     pre: u64,
     post: u64,
     timestamp_of_change: u64,
@@ -10,12 +10,12 @@ unconstrained fn get_non_initial_delay_change(
     ScheduledDelayChange::new(Option::some(pre), Option::some(post), timestamp_of_change)
 }
 
-unconstrained fn get_initial_delay_change() -> ScheduledDelayChange<TEST_INITIAL_DELAY> {
+fn get_initial_delay_change() -> ScheduledDelayChange<TEST_INITIAL_DELAY> {
     std::mem::zeroed()
 }
 
 #[test]
-unconstrained fn test_get_current() {
+fn test_get_current() {
     let pre = 1;
     let post = 2;
     let timestamp_of_change = 50;
@@ -29,7 +29,7 @@ unconstrained fn test_get_current() {
 }
 
 #[test]
-unconstrained fn test_get_current_initial() {
+fn test_get_current_initial() {
     let delay_change = get_initial_delay_change();
 
     assert_eq(delay_change.get_current(0), TEST_INITIAL_DELAY);
@@ -37,7 +37,7 @@ unconstrained fn test_get_current_initial() {
 }
 
 #[test]
-unconstrained fn test_get_scheduled() {
+fn test_get_scheduled() {
     let pre = 1;
     let post = 2;
     let timestamp_of_change = 50;
@@ -48,14 +48,14 @@ unconstrained fn test_get_scheduled() {
 }
 
 #[test]
-unconstrained fn test_get_scheduled_initial() {
+fn test_get_scheduled_initial() {
     let delay_change = get_initial_delay_change();
 
     assert_eq(delay_change.get_scheduled(), (TEST_INITIAL_DELAY, 0));
 }
 
 #[test]
-unconstrained fn test_schedule_change_to_shorter_delay_before_change() {
+fn test_schedule_change_to_shorter_delay_before_change() {
     let pre = 15;
     let post = 25;
     let timestamp_of_change = 500;
@@ -74,7 +74,7 @@ unconstrained fn test_schedule_change_to_shorter_delay_before_change() {
 }
 
 #[test]
-unconstrained fn test_schedule_change_to_shorter_delay_after_change() {
+fn test_schedule_change_to_shorter_delay_after_change() {
     let pre = 15;
     let post = 25;
     let timestamp_of_change = 500;
@@ -92,7 +92,7 @@ unconstrained fn test_schedule_change_to_shorter_delay_after_change() {
 }
 
 #[test]
-unconstrained fn test_schedule_change_to_shorter_delay_from_initial() {
+fn test_schedule_change_to_shorter_delay_from_initial() {
     let new = TEST_INITIAL_DELAY - 1;
     let current_timestamp = 50;
 
@@ -107,7 +107,7 @@ unconstrained fn test_schedule_change_to_shorter_delay_from_initial() {
 }
 
 #[test]
-unconstrained fn test_schedule_change_to_longer_delay_before_change() {
+fn test_schedule_change_to_longer_delay_before_change() {
     let pre = 15;
     let post = 25;
     let timestamp_of_change = 500;
@@ -127,7 +127,7 @@ unconstrained fn test_schedule_change_to_longer_delay_before_change() {
 }
 
 #[test]
-unconstrained fn test_schedule_change_to_longer_delay_after_change() {
+fn test_schedule_change_to_longer_delay_after_change() {
     let pre = 15;
     let post = 25;
     let timestamp_of_change = 500;
@@ -146,7 +146,7 @@ unconstrained fn test_schedule_change_to_longer_delay_after_change() {
 }
 
 #[test]
-unconstrained fn test_schedule_change_to_longer_delay_from_initial() {
+fn test_schedule_change_to_longer_delay_from_initial() {
     let new: u64 = TEST_INITIAL_DELAY + 1;
     let current_timestamp = 50;
 
@@ -161,7 +161,7 @@ unconstrained fn test_schedule_change_to_longer_delay_from_initial() {
     assert_eq(delay_change.get_current(current_timestamp), new);
 }
 
-unconstrained fn assert_effective_minimum_delay_invariants<let INITIAL_DELAY: u64>(
+fn assert_effective_minimum_delay_invariants<let INITIAL_DELAY: u64>(
     delay_change: &mut ScheduledDelayChange<INITIAL_DELAY>,
     anchor_block_timestamp: u64,
     effective_minimum_delay: u64,
@@ -199,7 +199,7 @@ unconstrained fn assert_effective_minimum_delay_invariants<let INITIAL_DELAY: u6
 }
 
 #[test]
-unconstrained fn test_get_effective_delay_at_before_change_in_far_future() {
+fn test_get_effective_delay_at_before_change_in_far_future() {
     let pre = 15;
     let post = 25;
     let timestamp_of_change = 500;
@@ -222,7 +222,7 @@ unconstrained fn test_get_effective_delay_at_before_change_in_far_future() {
 }
 
 #[test]
-unconstrained fn test_get_effective_delay_at_before_change_to_long_delay() {
+fn test_get_effective_delay_at_before_change_to_long_delay() {
     let pre = 15;
     let post = 25;
     let timestamp_of_change = 500;
@@ -246,7 +246,7 @@ unconstrained fn test_get_effective_delay_at_before_change_to_long_delay() {
 }
 
 #[test]
-unconstrained fn test_get_effective_delay_at_before_near_change_to_short_delay() {
+fn test_get_effective_delay_at_before_near_change_to_short_delay() {
     let pre = 15;
     let post = 3;
     let timestamp_of_change = 500;
@@ -272,7 +272,7 @@ unconstrained fn test_get_effective_delay_at_before_near_change_to_short_delay()
 }
 
 #[test]
-unconstrained fn test_get_effective_delay_at_after_change() {
+fn test_get_effective_delay_at_after_change() {
     let pre = 15;
     let post = 25;
     let timestamp_of_change = 500;
@@ -294,7 +294,7 @@ unconstrained fn test_get_effective_delay_at_after_change() {
 }
 
 #[test]
-unconstrained fn test_get_effective_delay_at_initial() {
+fn test_get_effective_delay_at_initial() {
     let mut delay_change = get_initial_delay_change();
 
     let anchor_block_timestamp = 200;

--- a/noir-projects/noir-protocol-circuits/crates/types/src/delayed_public_mutable/scheduled_value_change/test.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/delayed_public_mutable/scheduled_value_change/test.nr
@@ -3,7 +3,7 @@ use crate::delayed_public_mutable::scheduled_value_change::ScheduledValueChange;
 global TEST_DELAY: u64 = 200;
 
 #[test]
-unconstrained fn test_get_current_at() {
+fn test_get_current_at() {
     let pre = 1;
     let post = 2;
     let timestamp_of_change = 50;
@@ -18,7 +18,7 @@ unconstrained fn test_get_current_at() {
 }
 
 #[test]
-unconstrained fn test_get_scheduled() {
+fn test_get_scheduled() {
     let pre = 1;
     let post = 2;
     let timestamp_of_change = 50;
@@ -29,7 +29,7 @@ unconstrained fn test_get_scheduled() {
     assert_eq(value_change.get_scheduled(), (post, timestamp_of_change));
 }
 
-unconstrained fn assert_time_horizon_invariants(
+fn assert_time_horizon_invariants(
     value_change: &mut ScheduledValueChange<Field>,
     anchor_block_timestamp: u64,
     time_horizon: u64,
@@ -55,7 +55,7 @@ unconstrained fn assert_time_horizon_invariants(
 }
 
 #[test]
-unconstrained fn test_get_time_horizon_change_in_past() {
+fn test_get_time_horizon_change_in_past() {
     let anchor_block_timestamp = 100;
     let timestamp_of_change = 50;
 
@@ -69,7 +69,7 @@ unconstrained fn test_get_time_horizon_change_in_past() {
 }
 
 #[test]
-unconstrained fn test_get_time_horizon_change_in_immediate_past() {
+fn test_get_time_horizon_change_in_immediate_past() {
     let anchor_block_timestamp = 100;
     let timestamp_of_change = 100;
 
@@ -83,7 +83,7 @@ unconstrained fn test_get_time_horizon_change_in_immediate_past() {
 }
 
 #[test]
-unconstrained fn test_get_time_horizon_change_in_near_future() {
+fn test_get_time_horizon_change_in_near_future() {
     let anchor_block_timestamp = 100;
     let timestamp_of_change = 120;
 
@@ -100,7 +100,7 @@ unconstrained fn test_get_time_horizon_change_in_near_future() {
 }
 
 #[test]
-unconstrained fn test_get_time_horizon_change_in_far_future() {
+fn test_get_time_horizon_change_in_far_future() {
     let anchor_block_timestamp = 100;
     let timestamp_of_change = 500;
 
@@ -114,7 +114,7 @@ unconstrained fn test_get_time_horizon_change_in_far_future() {
 }
 
 #[test]
-unconstrained fn test_get_time_horizon_n0_delay() {
+fn test_get_time_horizon_n0_delay() {
     let anchor_block_timestamp = 100;
     let timestamp_of_change = 50;
 
@@ -128,7 +128,7 @@ unconstrained fn test_get_time_horizon_n0_delay() {
 }
 
 #[test]
-unconstrained fn test_schedule_change_before_change() {
+fn test_schedule_change_before_change() {
     let pre = 1;
     let post = 2;
     let timestamp_of_change = 500;
@@ -147,7 +147,7 @@ unconstrained fn test_schedule_change_before_change() {
 }
 
 #[test]
-unconstrained fn test_schedule_change_after_change() {
+fn test_schedule_change_after_change() {
     let pre = 1;
     let post = 2;
     let timestamp_of_change = 500;
@@ -165,7 +165,7 @@ unconstrained fn test_schedule_change_after_change() {
 }
 
 #[test]
-unconstrained fn test_schedule_change_no_delay() {
+fn test_schedule_change_no_delay() {
     let pre = 1;
     let post = 2;
     let timestamp_of_change = 500;

--- a/noir-projects/noir-protocol-circuits/crates/types/src/hash.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/hash.nr
@@ -405,12 +405,13 @@ fn l2_to_l1_message_hash_matches_typescript() {
 }
 
 #[test]
-unconstrained fn poseidon2_hash_with_separator_bounded_vec_matches_non_bounded_vec_version() {
+fn poseidon2_hash_with_separator_bounded_vec_matches_non_bounded_vec_version() {
     let inputs = BoundedVec::<Field, 4>::from_array([1, 2, 3]);
     let separator = 42;
 
     // Hash using bounded vec version
-    let bounded_result = poseidon2_hash_with_separator_bounded_vec(inputs, separator);
+    // Safety: Testing an unconstrained function.
+    let bounded_result = unsafe { poseidon2_hash_with_separator_bounded_vec(inputs, separator) };
 
     // Hash using regular version
     let regular_result = poseidon2_hash_with_separator([1, 2, 3], separator);

--- a/noir-projects/noir-protocol-circuits/crates/types/src/point.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/point.nr
@@ -48,35 +48,35 @@ mod tests {
     use std::embedded_curve_ops::EmbeddedCurvePoint as Point;
 
     #[test]
-    unconstrained fn test_validate_on_curve_generator() {
+    fn test_validate_on_curve_generator() {
         // The generator point should be on the curve
         let generator = Point::generator();
         validate_on_curve(generator);
     }
 
     #[test]
-    unconstrained fn test_validate_on_curve_infinity() {
+    fn test_validate_on_curve_infinity() {
         // Canonical infinite point (x=0, y=0) should pass
         let infinity = Point { x: 0, y: 0, is_infinite: true };
         validate_on_curve(infinity);
     }
 
     #[test(should_fail_with = "Point not on curve")]
-    unconstrained fn test_validate_on_curve_invalid_point() {
+    fn test_validate_on_curve_invalid_point() {
         // A point not on the curve should fail
         let invalid = Point { x: 1, y: 1, is_infinite: false };
         validate_on_curve(invalid);
     }
 
     #[test(should_fail_with = "Point at infinity should have canonical representation (0 0)")]
-    unconstrained fn test_validate_on_curve_infinity_non_canonical_x() {
+    fn test_validate_on_curve_infinity_non_canonical_x() {
         // Infinite point with non-zero x should fail
         let invalid_infinity = Point { x: 1, y: 0, is_infinite: true };
         validate_on_curve(invalid_infinity);
     }
 
     #[test(should_fail_with = "Point at infinity should have canonical representation (0 0)")]
-    unconstrained fn test_validate_on_curve_infinity_non_canonical_y() {
+    fn test_validate_on_curve_infinity_non_canonical_y() {
         // Infinite point with non-zero y should fail
         let invalid_infinity = Point { x: 0, y: 1, is_infinite: true };
         validate_on_curve(invalid_infinity);

--- a/noir-projects/noir-protocol-circuits/crates/types/src/poseidon2.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/poseidon2.nr
@@ -20,7 +20,7 @@ pub struct Poseidon2Sponge {
 impl Poseidon2Sponge {
     #[no_predicates]
     pub fn hash<let N: u32>(input: [Field; N], message_size: u32) -> Field {
-        Poseidon2Sponge::hash_internal(input, message_size, message_size != N)
+        Poseidon2Sponge::hash_internal(input, message_size)
     }
 
     pub(crate) fn new(iv: Field) -> Poseidon2Sponge {
@@ -66,11 +66,7 @@ impl Poseidon2Sponge {
         self.state[0]
     }
 
-    fn hash_internal<let N: u32>(
-        input: [Field; N],
-        in_len: u32,
-        is_variable_length: bool,
-    ) -> Field {
+    fn hash_internal<let N: u32>(input: [Field; N], in_len: u32) -> Field {
         let iv: Field = (in_len as Field) * TWO_POW_64;
         let mut sponge = Poseidon2Sponge::new(iv);
         for i in 0..input.len() {

--- a/noir-projects/noir-protocol-circuits/crates/types/src/public_keys.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/public_keys.nr
@@ -135,7 +135,7 @@ mod test {
     use std::embedded_curve_ops::EmbeddedCurvePoint as Point;
 
     #[test]
-    unconstrained fn compute_public_keys_hash() {
+    fn compute_public_keys_hash() {
         let keys = PublicKeys {
             npk_m: NpkM { inner: Point { x: 1, y: 2, is_infinite: false } },
             ivpk_m: IvpkM { inner: Point { x: 3, y: 4, is_infinite: false } },
@@ -153,7 +153,7 @@ mod test {
     }
 
     #[test]
-    unconstrained fn compute_default_hash() {
+    fn compute_default_hash() {
         let keys = PublicKeys::default();
 
         let actual = keys.hash();
@@ -166,7 +166,7 @@ mod test {
     }
 
     #[test]
-    unconstrained fn serde() {
+    fn serde() {
         let keys = PublicKeys {
             npk_m: NpkM { inner: Point { x: 1, y: 2, is_infinite: false } },
             ivpk_m: IvpkM { inner: Point { x: 3, y: 4, is_infinite: false } },

--- a/noir-projects/noir-protocol-circuits/crates/types/src/utils/arrays.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/utils/arrays.nr
@@ -219,25 +219,34 @@ fn test_validate_array_length_hint_out_of_bounds() {
 
 // ==================== trimmed_array_length_hint tests ====================
 
-#[test]
-unconstrained fn test_trimmed_array_length_hint_with_trailing_empties() {
-    assert_eq(trimmed_array_length_hint([10, 20, 30, 0, 0]), 3);
+fn assert_eq_trimmed_array_length_hint<T, let N: u32>(array: [T; N], expected: u32)
+where
+    T: Empty,
+{
+    // Safety: Testing an unconstrained function.
+    let result = unsafe { trimmed_array_length_hint(array) };
+    assert_eq(result, expected);
 }
 
 #[test]
-unconstrained fn test_trimmed_array_length_hint_fully_empty() {
-    assert_eq(trimmed_array_length_hint([0, 0, 0, 0, 0]), 0);
+fn test_trimmed_array_length_hint_with_trailing_empties() {
+    assert_eq_trimmed_array_length_hint([10, 20, 30, 0, 0], 3);
 }
 
 #[test]
-unconstrained fn test_trimmed_array_length_hint_no_empties() {
-    assert_eq(trimmed_array_length_hint([10, 20, 30, 40, 50]), 5);
+fn test_trimmed_array_length_hint_fully_empty() {
+    assert_eq_trimmed_array_length_hint([0, 0, 0, 0, 0], 0);
 }
 
 #[test]
-unconstrained fn test_trimmed_array_length_hint_with_gaps() {
+fn test_trimmed_array_length_hint_no_empties() {
+    assert_eq_trimmed_array_length_hint([10, 20, 30, 40, 50], 5);
+}
+
+#[test]
+fn test_trimmed_array_length_hint_with_gaps() {
     // Unlike array_length, this trims from the right only, so gaps don't matter
-    assert_eq(trimmed_array_length_hint([10, 0, 30, 0, 0]), 3);
+    assert_eq_trimmed_array_length_hint([10, 0, 30, 0, 0], 3);
 }
 
 // ==================== array_length_until tests ====================

--- a/noir-projects/noir-protocol-circuits/crates/types/src/utils/arrays/find_index.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/utils/arrays/find_index.nr
@@ -31,54 +31,78 @@ pub unconstrained fn find_last_index<T, let N: u32, Env>(
     index
 }
 
-#[test]
-unconstrained fn find_first_index_unique_element() {
-    let array = [11, 22, 33];
+mod tests {
+    use super::{find_first_index, find_last_index};
 
-    assert_eq(find_first_index(array, |x| x == 11), 0);
-    assert_eq(find_first_index(array, |x| x == 22), 1);
-    assert_eq(find_first_index(array, |x| x == 33), 2);
-}
+    fn assert_eq_find_first_index<T, let N: u32, Env>(
+        array: [T; N],
+        find: fn[Env](T) -> bool,
+        expected: u32,
+    ) {
+        // Safety: Testing an unconstrained function.
+        let result = unsafe { find_first_index(array, find) };
+        assert_eq(result, expected);
+    }
 
-#[test]
-unconstrained fn find_first_index_duplicate_elements() {
-    let array = [11, 22, 33, 11, 22, 33];
+    fn assert_eq_find_last_index<T, let N: u32, Env>(
+        array: [T; N],
+        find: fn[Env](T) -> bool,
+        expected: u32,
+    ) {
+        // Safety: Testing an unconstrained function.
+        let result = unsafe { find_last_index(array, find) };
+        assert_eq(result, expected);
+    }
 
-    assert_eq(find_first_index(array, |x| x == 11), 0);
-    assert_eq(find_first_index(array, |x| x == 22), 1);
-    assert_eq(find_first_index(array, |x| x == 33), 2);
-}
+    #[test]
+    fn find_first_index_unique_element() {
+        let array = [11, 22, 33];
 
-#[test]
-unconstrained fn find_first_index_not_found() {
-    let array = [11, 22, 33];
+        assert_eq_find_first_index(array, |x| x == 11, 0);
+        assert_eq_find_first_index(array, |x| x == 22, 1);
+        assert_eq_find_first_index(array, |x| x == 33, 2);
+    }
 
-    assert_eq(find_first_index(array, |x| x == 0), 3);
-    assert_eq(find_first_index(array, |x| x == 44), 3);
-}
+    #[test]
+    fn find_first_index_duplicate_elements() {
+        let array = [11, 22, 33, 11, 22, 33];
 
-#[test]
-unconstrained fn find_last_index_unique_element() {
-    let array = [11, 22, 33];
+        assert_eq_find_first_index(array, |x| x == 11, 0);
+        assert_eq_find_first_index(array, |x| x == 22, 1);
+        assert_eq_find_first_index(array, |x| x == 33, 2);
+    }
 
-    assert_eq(find_last_index(array, |x| x == 11), 0);
-    assert_eq(find_last_index(array, |x| x == 22), 1);
-    assert_eq(find_last_index(array, |x| x == 33), 2);
-}
+    #[test]
+    fn find_first_index_not_found() {
+        let array = [11, 22, 33];
 
-#[test]
-unconstrained fn find_last_index_duplicate_elements() {
-    let array = [11, 22, 33, 11, 22, 33];
+        assert_eq_find_first_index(array, |x| x == 0, 3);
+        assert_eq_find_first_index(array, |x| x == 44, 3);
+    }
 
-    assert_eq(find_last_index(array, |x| x == 11), 3);
-    assert_eq(find_last_index(array, |x| x == 22), 4);
-    assert_eq(find_last_index(array, |x| x == 33), 5);
-}
+    #[test]
+    fn find_last_index_unique_element() {
+        let array = [11, 22, 33];
 
-#[test]
-unconstrained fn find_last_index_not_found() {
-    let array = [11, 22, 33];
+        assert_eq_find_last_index(array, |x| x == 11, 0);
+        assert_eq_find_last_index(array, |x| x == 22, 1);
+        assert_eq_find_last_index(array, |x| x == 33, 2);
+    }
 
-    assert_eq(find_last_index(array, |x| x == 0), 3);
-    assert_eq(find_last_index(array, |x| x == 44), 3);
+    #[test]
+    fn find_last_index_duplicate_elements() {
+        let array = [11, 22, 33, 11, 22, 33];
+
+        assert_eq_find_last_index(array, |x| x == 11, 3);
+        assert_eq_find_last_index(array, |x| x == 22, 4);
+        assert_eq_find_last_index(array, |x| x == 33, 5);
+    }
+
+    #[test]
+    fn find_last_index_not_found() {
+        let array = [11, 22, 33];
+
+        assert_eq_find_last_index(array, |x| x == 0, 3);
+        assert_eq_find_last_index(array, |x| x == 44, 3);
+    }
 }

--- a/noir-projects/noir-protocol-circuits/crates/types/src/utils/arrays/get_sorted_tuples.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/utils/arrays/get_sorted_tuples.nr
@@ -33,8 +33,26 @@ where
 mod tests {
     use super::{get_sorted_tuples, SortedTuple};
 
+    fn assert_eq_sorted_tuples<T, let N: u32, Env>(
+        array: [T; N],
+        ordering: fn[Env](T, T) -> bool,
+        expected: [SortedTuple<T>; N],
+    )
+    where
+        T: Eq,
+    {
+        // Safety: Testing an unconstrained function.
+        let tuples = unsafe { get_sorted_tuples(array, ordering) };
+        assert_eq(tuples, expected);
+
+        // Verify original indices point to correct elements
+        for i in 0..N {
+            assert_eq(array[tuples[i].original_index], tuples[i].elem);
+        }
+    }
+
     #[test]
-    unconstrained fn sort_u64_in_ascending_order() {
+    fn sort_u64_in_ascending_order() {
         let array: [u64; 4] = [3, 2, 9, 5];
         let expected = [
             SortedTuple { elem: 2, original_index: 1 },
@@ -42,12 +60,11 @@ mod tests {
             SortedTuple { elem: 5, original_index: 3 },
             SortedTuple { elem: 9, original_index: 2 },
         ];
-        let tuples = get_sorted_tuples(array, |a, b| a < b);
-        assert_eq(tuples, expected);
+        assert_eq_sorted_tuples(array, |a, b| a < b, expected);
     }
 
     #[test]
-    unconstrained fn sort_u64_in_descending_order() {
+    fn sort_u64_in_descending_order() {
         let array: [u64; 4] = [3, 2, 9, 5];
         let expected = [
             SortedTuple { elem: 9, original_index: 2 },
@@ -55,20 +72,18 @@ mod tests {
             SortedTuple { elem: 3, original_index: 0 },
             SortedTuple { elem: 2, original_index: 1 },
         ];
-        let tuples = get_sorted_tuples(array, |a, b| a > b);
-        assert_eq(tuples, expected);
+        assert_eq_sorted_tuples(array, |a, b| a > b, expected);
     }
 
     #[test]
-    unconstrained fn sort_single_element() {
+    fn sort_single_element() {
         let array: [u64; 1] = [42];
         let expected = [SortedTuple { elem: 42, original_index: 0 }];
-        let tuples = get_sorted_tuples(array, |a, b| a < b);
-        assert_eq(tuples, expected);
+        assert_eq_sorted_tuples(array, |a, b| a < b, expected);
     }
 
     #[test]
-    unconstrained fn sort_already_sorted_array() {
+    fn sort_already_sorted_array() {
         let array: [u64; 4] = [1, 2, 3, 4];
         let expected = [
             SortedTuple { elem: 1, original_index: 0 },
@@ -76,12 +91,11 @@ mod tests {
             SortedTuple { elem: 3, original_index: 2 },
             SortedTuple { elem: 4, original_index: 3 },
         ];
-        let tuples = get_sorted_tuples(array, |a, b| a < b);
-        assert_eq(tuples, expected);
+        assert_eq_sorted_tuples(array, |a, b| a < b, expected);
     }
 
     #[test]
-    unconstrained fn sort_reverse_sorted_array() {
+    fn sort_reverse_sorted_array() {
         let array: [u64; 4] = [4, 3, 2, 1];
         let expected = [
             SortedTuple { elem: 1, original_index: 3 },
@@ -89,45 +103,31 @@ mod tests {
             SortedTuple { elem: 3, original_index: 1 },
             SortedTuple { elem: 4, original_index: 0 },
         ];
-        let tuples = get_sorted_tuples(array, |a, b| a < b);
-        assert_eq(tuples, expected);
+        assert_eq_sorted_tuples(array, |a, b| a < b, expected);
     }
 
     #[test]
-    unconstrained fn sort_with_duplicate_elements() {
+    fn sort_with_duplicate_elements() {
         let array: [u64; 5] = [3, 1, 3, 2, 1];
-        let tuples = get_sorted_tuples(array, |a, b| a < b);
-
-        // Verify elements are sorted
-        assert_eq(tuples[0].elem, 1);
-        assert_eq(tuples[1].elem, 1);
-        assert_eq(tuples[2].elem, 2);
-        assert_eq(tuples[3].elem, 3);
-        assert_eq(tuples[4].elem, 3);
-
-        // Verify original indices point to correct elements
-        for i in 0..5 {
-            assert_eq(array[tuples[i].original_index], tuples[i].elem);
-        }
+        let expected = [
+            SortedTuple { elem: 1, original_index: 4 },
+            SortedTuple { elem: 1, original_index: 1 },
+            SortedTuple { elem: 2, original_index: 3 },
+            SortedTuple { elem: 3, original_index: 0 },
+            SortedTuple { elem: 3, original_index: 2 },
+        ];
+        assert_eq_sorted_tuples(array, |a, b| a < b, expected);
     }
 
     #[test]
-    unconstrained fn sort_all_identical_elements() {
+    fn sort_all_identical_elements() {
         let array: [u64; 4] = [5, 5, 5, 5];
-        let tuples = get_sorted_tuples(array, |a, b| a < b);
-
-        // All elements should be 5
-        for i in 0..4 {
-            assert_eq(tuples[i].elem, 5);
-        }
-
-        // All original indices should be unique and valid
-        let mut seen = [false; 4];
-        for i in 0..4 {
-            let idx = tuples[i].original_index;
-            assert(idx < 4);
-            assert(!seen[idx]);
-            seen[idx] = true;
-        }
+        let expected = [
+            SortedTuple { elem: 5, original_index: 3 },
+            SortedTuple { elem: 5, original_index: 0 },
+            SortedTuple { elem: 5, original_index: 1 },
+            SortedTuple { elem: 5, original_index: 2 },
+        ];
+        assert_eq_sorted_tuples(array, |a, b| a < b, expected);
     }
 }

--- a/noir-projects/noir-protocol-circuits/crates/types/src/utils/field.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/utils/field.nr
@@ -193,7 +193,7 @@ fn validate_not_sqrt_hint(x: Field, hint: Field) {
 }
 
 #[test]
-unconstrained fn bytes_field_test() {
+fn bytes_field_test() {
     // Tests correctness of field_from_bytes_32_trunc against existing methods
     // Bytes representing 0x543e0a6642ffeb8039296861765a53407bba62bd1c97ca43374de950bbe0a7
     let inputs = [
@@ -216,7 +216,7 @@ unconstrained fn bytes_field_test() {
 }
 
 #[test]
-unconstrained fn max_field_test() {
+fn max_field_test() {
     // Tests the hardcoded value in constants.nr vs underlying modulus
     // NB: We can't use 0-1 in constants.nr as it will be transpiled incorrectly to ts and sol constants files
     let max_value = crate::constants::MAX_FIELD_VALUE;
@@ -231,7 +231,7 @@ unconstrained fn max_field_test() {
 }
 
 #[test]
-unconstrained fn sqrt_valid_test() {
+fn sqrt_valid_test() {
     let x = 16; // examples: 16, 9, 25, 81
     let result = sqrt(x);
     assert(result.is_some());
@@ -239,28 +239,28 @@ unconstrained fn sqrt_valid_test() {
 }
 
 #[test]
-unconstrained fn sqrt_invalid_test() {
+fn sqrt_invalid_test() {
     let x = KNOWN_NON_RESIDUE; // has no square root in the field
     let result = sqrt(x);
     assert(result.is_none());
 }
 
 #[test]
-unconstrained fn sqrt_zero_test() {
+fn sqrt_zero_test() {
     let result = sqrt(0);
     assert(result.is_some());
     assert_eq(result.unwrap(), 0);
 }
 
 #[test]
-unconstrained fn sqrt_one_test() {
+fn sqrt_one_test() {
     let result = sqrt(1);
     assert(result.is_some());
     assert_eq(result.unwrap() * result.unwrap(), 1);
 }
 
 #[test]
-unconstrained fn field_from_bytes_empty_test() {
+fn field_from_bytes_empty_test() {
     let empty: [u8; 0] = [];
     let result = field_from_bytes(empty, true);
     assert_eq(result, 0);
@@ -270,7 +270,7 @@ unconstrained fn field_from_bytes_empty_test() {
 }
 
 #[test]
-unconstrained fn field_from_bytes_little_endian_test() {
+fn field_from_bytes_little_endian_test() {
     // Test little-endian conversion: [0x01, 0x02] should be 0x0201 = 513
     let bytes = [0x01, 0x02];
     let result_le = field_from_bytes(bytes, false);
@@ -282,7 +282,7 @@ unconstrained fn field_from_bytes_little_endian_test() {
 }
 
 #[test]
-unconstrained fn pow_test() {
+fn pow_test() {
     assert_eq(pow(2, 0), 1);
     assert_eq(pow(2, 1), 2);
     assert_eq(pow(2, 10), 1024);
@@ -292,7 +292,7 @@ unconstrained fn pow_test() {
 }
 
 #[test]
-unconstrained fn min_test() {
+fn min_test() {
     assert_eq(min(5, 10), 5);
     assert_eq(min(10, 5), 5);
     assert_eq(min(7, 7), 7);
@@ -300,7 +300,7 @@ unconstrained fn min_test() {
 }
 
 #[test]
-unconstrained fn full_field_comparison_test() {
+fn full_field_comparison_test() {
     assert(full_field_less_than(5, 10));
     assert(!full_field_less_than(10, 5));
     assert(!full_field_less_than(5, 5));
@@ -311,7 +311,7 @@ unconstrained fn full_field_comparison_test() {
 }
 
 #[test]
-unconstrained fn sqrt_has_two_roots_test() {
+fn sqrt_has_two_roots_test() {
     // Every square has two roots: r and -r (i.e., p - r)
     // sqrt(16) can return 4 or -4
     let x = 16;
@@ -333,14 +333,14 @@ unconstrained fn sqrt_has_two_roots_test() {
 }
 
 #[test]
-unconstrained fn sqrt_negative_one_test() {
+fn sqrt_negative_one_test() {
     let x = 0 - 1;
     let result = sqrt(x);
     assert(result.unwrap() == 0x30644e72e131a029048b6e193fd841045cea24f6fd736bec231204708f703636);
 }
 
 #[test]
-unconstrained fn validate_sqrt_hint_valid_test() {
+fn validate_sqrt_hint_valid_test() {
     // 4 is a valid sqrt of 16
     validate_sqrt_hint(16, 4);
     // -4 is also a valid sqrt of 16
@@ -354,27 +354,28 @@ unconstrained fn validate_sqrt_hint_valid_test() {
 }
 
 #[test(should_fail_with = "is not the sqrt of x")]
-unconstrained fn validate_sqrt_hint_invalid_test() {
+fn validate_sqrt_hint_invalid_test() {
     // 5 is not a valid sqrt of 16
     validate_sqrt_hint(16, 5);
 }
 
 #[test]
-unconstrained fn validate_not_sqrt_hint_valid_test() {
+fn validate_not_sqrt_hint_valid_test() {
     // 5 (KNOWN_NON_RESIDUE) is not a square.
     let x = KNOWN_NON_RESIDUE;
-    let hint = tonelli_shanks_sqrt(x * KNOWN_NON_RESIDUE);
+    // Safety: Testing an unconstrained function.
+    let hint = unsafe { tonelli_shanks_sqrt(x * KNOWN_NON_RESIDUE) };
     validate_not_sqrt_hint(x, hint);
 }
 
 #[test(should_fail_with = "0 has a square root")]
-unconstrained fn validate_not_sqrt_hint_zero_test() {
+fn validate_not_sqrt_hint_zero_test() {
     // 0 has a square root, so we cannot claim it is not square
     validate_not_sqrt_hint(0, 0);
 }
 
 #[test(should_fail_with = "does not demonstrate that")]
-unconstrained fn validate_not_sqrt_hint_wrong_hint_test() {
+fn validate_not_sqrt_hint_wrong_hint_test() {
     // Provide a wrong hint for a non-square
     let x = KNOWN_NON_RESIDUE;
     validate_not_sqrt_hint(x, 123);


### PR DESCRIPTION
Changing most tests to run in constrained mode. Exception:
  - tests for checkpoint root rollup: as it requires processing 6 blobs and will take minutes to run, only a couple of tests are constrained to ensure the blob-related data is correctly validated, which is the only part in the circuit that acts differently depends on whether being constrained or not.
  - tests in blob.nr: the 3 tests that call `evaluate_blob` are now being constrained. The others that are still unconstrained are already covered by constrained tests.