### PR TITLE
feat(foundation): support pino deferred format string interpolation

### DIFF
--- a/yarn-project/foundation/src/log/log_fn.ts
+++ b/yarn-project/foundation/src/log/log_fn.ts
@@ -1,5 +1,10 @@
 /** Structured log data to include with the message. */
 export type LogData = Record<string, string | number | bigint | boolean | { toString(): string } | undefined | null>;
 
-/** A callable logger instance. */
-export type LogFn = (msg: string, data?: unknown) => void;
+/**
+ * A callable logger instance. Supports Pino format string interpolation (%s, %d, %o, %j).
+ * Format args are interpolated into the message string and bypass redaction — never pass
+ * sensitive values (private keys, mnemonics) as format args; use structured data instead.
+ *
+ */
+export type LogFn = (msg: string, ...args: unknown[]) => void;

--- a/yarn-project/foundation/src/log/pino-logger.test.ts
+++ b/yarn-project/foundation/src/log/pino-logger.test.ts
@@ -312,6 +312,219 @@ describe('pino-logger', () => {
     });
   });
 
+  describe('format string interpolation', () => {
+    it('interpolates %s format specifiers', () => {
+      const testLogger = createLogger('fmt-test');
+      capturingStream.clear();
+
+      testLogger.info('Hello %s, welcome to %s', 'Alice', 'Aztec');
+
+      const entries = capturingStream.getJsonLines();
+      expect(entries).toHaveLength(1);
+      expect(entries[0]).toMatchObject({
+        module: 'fmt-test',
+        msg: 'Hello Alice, welcome to Aztec',
+      });
+    });
+
+    it('interpolates %d format specifiers for numbers', () => {
+      const testLogger = createLogger('fmt-num-test');
+      capturingStream.clear();
+
+      testLogger.info('Block %d processed with %d txs', 42, 10);
+
+      const entries = capturingStream.getJsonLines();
+      expect(entries).toHaveLength(1);
+      expect(entries[0]).toMatchObject({
+        msg: 'Block 42 processed with 10 txs',
+      });
+    });
+
+    it('supports mixed format specifiers', () => {
+      const testLogger = createLogger('fmt-mixed-test');
+      capturingStream.clear();
+
+      testLogger.info('User %s processed %d items', 'Bob', 5);
+
+      const entries = capturingStream.getJsonLines();
+      expect(entries).toHaveLength(1);
+      expect(entries[0]).toMatchObject({
+        msg: 'User Bob processed 5 items',
+      });
+    });
+
+    it('passes trailing object as structured data alongside format args', () => {
+      const testLogger = createLogger('fmt-data-test');
+      capturingStream.clear();
+
+      testLogger.info('Checkpoint %d ready', 7, { slot: 100, proposer: 'alice' });
+
+      const entries = capturingStream.getJsonLines();
+      expect(entries).toHaveLength(1);
+      expect(entries[0]).toMatchObject({
+        msg: 'Checkpoint 7 ready',
+        slot: 100,
+        proposer: 'alice',
+      });
+    });
+
+    it('handles BigInt with %s specifier', () => {
+      const testLogger = createLogger('fmt-bigint-test');
+      capturingStream.clear();
+
+      const bigValue = 123456789012345678901234n;
+      testLogger.info('Amount is %s', bigValue);
+
+      const entries = capturingStream.getJsonLines();
+      expect(entries).toHaveLength(1);
+      expect(entries[0]).toMatchObject({
+        msg: 'Amount is 123456789012345678901234',
+      });
+    });
+
+    it('does not trigger format path for escaped %% sequences', () => {
+      const testLogger = createLogger('fmt-escape-test');
+      capturingStream.clear();
+
+      testLogger.info('100%% complete', { status: 'done' });
+
+      const entries = capturingStream.getJsonLines();
+      expect(entries).toHaveLength(1);
+      expect(entries[0]).toMatchObject({
+        msg: '100%% complete',
+        status: 'done',
+      });
+    });
+
+    it('preserves existing (msg, data) behavior when no format specifiers', () => {
+      const testLogger = createLogger('fmt-compat-test');
+      capturingStream.clear();
+
+      testLogger.info('Simple message', { key: 'value', count: 42 });
+
+      const entries = capturingStream.getJsonLines();
+      expect(entries).toHaveLength(1);
+      expect(entries[0]).toMatchObject({
+        msg: 'Simple message',
+        key: 'value',
+        count: 42,
+      });
+    });
+
+    it('preserves existing (msg) behavior with no args', () => {
+      const testLogger = createLogger('fmt-noarg-test');
+      capturingStream.clear();
+
+      testLogger.info('Just a message');
+
+      const entries = capturingStream.getJsonLines();
+      expect(entries).toHaveLength(1);
+      expect(entries[0]).toMatchObject({
+        msg: 'Just a message',
+      });
+    });
+
+    it('does not evaluate format args when level is disabled', () => {
+      capturingStream.clear();
+
+      // Set parent level to error BEFORE creating child logger so it inherits correctly.
+      const savedLevel = logger.level;
+      logger.level = 'error';
+
+      try {
+        const testLogger = createLogger('fmt-level-test');
+
+        // Verify debug is actually disabled for this logger
+        expect(testLogger.isLevelEnabled('debug')).toBe(false);
+
+        let toStringCalled = false;
+        const obj = {
+          toString() {
+            toStringCalled = true;
+            return 'expensive';
+          },
+        };
+
+        // debug is below error, so this should be a no-op
+        testLogger.debug('Value is %s', obj);
+
+        // toString should NOT have been called since debug is disabled
+        expect(toStringCalled).toBe(false);
+        expect(capturingStream.lines).toHaveLength(0);
+      } finally {
+        logger.level = savedLevel;
+      }
+    });
+
+    it('works with warn level', () => {
+      const testLogger = createLogger('fmt-warn-test');
+      capturingStream.clear();
+
+      testLogger.warn('Warning %s at step %d', 'overflow', 3);
+
+      const entries = capturingStream.getJsonLines();
+      expect(entries).toHaveLength(1);
+      expect(entries[0]).toMatchObject({ msg: 'Warning overflow at step 3', level: 40 });
+    });
+
+    it('handles format string with no trailing data object', () => {
+      const testLogger = createLogger('fmt-nodata-test');
+      capturingStream.clear();
+
+      testLogger.info('Block %d at slot %d', 42, 100);
+
+      const entries = capturingStream.getJsonLines();
+      expect(entries).toHaveLength(1);
+      const entry = entries[0] as Record<string, unknown>;
+      expect(entry.msg).toBe('Block 42 at slot 100');
+      // Should not have extraneous data keys beyond standard pino fields
+      expect(entry).not.toHaveProperty('0');
+      expect(entry).not.toHaveProperty('1');
+    });
+
+    it('consumes object as format arg when it matches a specifier position', () => {
+      const testLogger = createLogger('fmt-obj-as-arg-test');
+      capturingStream.clear();
+
+      // When %s is present and an object is the first arg, it is consumed as a format arg,
+      // NOT as structured data. This matches Pino's native behavior.
+      testLogger.info('User %s logged in', { name: 'Alice' });
+
+      const entries = capturingStream.getJsonLines();
+      expect(entries).toHaveLength(1);
+      const entry = entries[0] as Record<string, unknown>;
+      // The object is stringified via %s as [object Object] — it is NOT treated as structured data.
+      expect(entry.msg).toBe('User [object Object] logged in');
+      expect(entry).not.toHaveProperty('name');
+    });
+
+    it('does not crash when error is called with undefined message', () => {
+      const testLogger = createLogger('fmt-undef-test');
+      capturingStream.clear();
+
+      // Callers may pass undefined as the message (e.g. from a failed assertion).
+      // This should not throw — it should log gracefully.
+      expect(() => testLogger.error(undefined as unknown as string)).not.toThrow();
+
+      const entries = capturingStream.getJsonLines();
+      expect(entries).toHaveLength(1);
+    });
+
+    it('error and fatal do not support format string interpolation', () => {
+      const testLogger = createLogger('fmt-error-test');
+      capturingStream.clear();
+
+      // error treats second arg as err (passed through inspect), not as a format arg.
+      testLogger.error('Step %d failed', 42);
+
+      const entries = capturingStream.getJsonLines();
+      expect(entries).toHaveLength(1);
+      const entry = entries[0] as Record<string, unknown>;
+      // %d is NOT interpolated — the 42 is treated as an error and appended via inspect.
+      expect(entry.msg).toBe('Step %d failed: 42');
+    });
+  });
+
   describe('actor colors', () => {
     beforeEach(() => {
       resetActorColors();

--- a/yarn-project/foundation/src/log/pino-logger.ts
+++ b/yarn-project/foundation/src/log/pino-logger.ts
@@ -47,6 +47,33 @@ function getBindingsFromHandlers(): LoggerBindings | undefined {
   return undefined;
 }
 
+/** Returns true if msg contains a Pino-style format specifier (%s, %d, %i, %f, %o, %O, %j). */
+function hasFormatSpecifier(msg: string): boolean {
+  if (typeof msg !== 'string') {
+    return false;
+  }
+  for (let i = 0; i < msg.length - 1; i++) {
+    if (msg.charCodeAt(i) === 37 /* % */) {
+      const next = msg.charCodeAt(i + 1);
+      if (next === 37) {
+        i++; // skip %% escape
+      } else if (
+        next === 115 ||
+        next === 100 ||
+        next === 105 ||
+        next === 102 ||
+        next === 106 ||
+        next === 111 ||
+        next === 79
+      ) {
+        // s=115 d=100 i=105 f=102 j=106 o=111 O=79
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
 export function createLogger(module: string, bindings?: LoggerBindings): Logger {
   module = module.replace(/^aztec:/, '');
 
@@ -61,8 +88,29 @@ export function createLogger(module: string, bindings?: LoggerBindings): Logger 
 
   // We check manually for isLevelEnabled to avoid calling processLogData unnecessarily.
   // Note that isLevelEnabled is missing from the browser version of pino.
-  const logFn = (level: LogLevel, msg: string, data?: unknown) =>
-    isLevelEnabled(pinoLogger, level) && pinoLogger[level](processLogData((data as LogData) ?? {}), msg);
+  // SECURITY: Format interpolation args bypass processLogData and Pino's redact config.
+  // Never pass sensitive values (keys, mnemonics) as format args — use structured data instead.
+  const logFn = (level: LogLevel, msg: string, ...args: unknown[]) => {
+    if (!isLevelEnabled(pinoLogger, level)) {
+      return;
+    }
+
+    if (args.length === 0) {
+      pinoLogger[level]({}, msg);
+    } else if (!hasFormatSpecifier(msg)) {
+      // No format specifiers: first arg is structured data.
+      pinoLogger[level](processLogData((args[0] as LogData) ?? {}), msg);
+    } else {
+      // Format string path: let Pino handle interpolation natively.
+      // If last arg is a plain object (and not the only arg), treat it as structured data.
+      const last = args[args.length - 1];
+      if (args.length > 1 && last !== null && last !== undefined && typeof last === 'object' && !Array.isArray(last)) {
+        pinoLogger[level](processLogData(last as LogData), msg, ...args.slice(0, -1));
+      } else {
+        pinoLogger[level]({}, msg, ...args);
+      }
+    }
+  };
 
   return {
     silent: () => {},
@@ -72,15 +120,15 @@ export function createLogger(module: string, bindings?: LoggerBindings): Logger 
     /** Log as error. Use for errors in general. */
     error: (msg: string, err?: unknown, data?: unknown) => logFn('error', formatErr(msg, err), data),
     /** Log as warn. Use for when we stray from the happy path. */
-    warn: (msg: string, data?: unknown) => logFn('warn', msg, data),
+    warn: (msg: string, ...args: unknown[]) => logFn('warn', msg, ...args),
     /** Log as info. Use for providing an operator with info on what the system is doing. */
-    info: (msg: string, data?: unknown) => logFn('info', msg, data),
+    info: (msg: string, ...args: unknown[]) => logFn('info', msg, ...args),
     /** Log as verbose. Use for when we need additional insight on what a subsystem is doing. */
-    verbose: (msg: string, data?: unknown) => logFn('verbose', msg, data),
+    verbose: (msg: string, ...args: unknown[]) => logFn('verbose', msg, ...args),
     /** Log as debug. Use for when we need debugging info to troubleshoot an issue on a specific component. */
-    debug: (msg: string, data?: unknown) => logFn('debug', msg, data),
+    debug: (msg: string, ...args: unknown[]) => logFn('debug', msg, ...args),
     /** Log as trace. Use for when we want to denial-of-service any recipient of the logs. */
-    trace: (msg: string, data?: unknown) => logFn('trace', msg, data),
+    trace: (msg: string, ...args: unknown[]) => logFn('trace', msg, ...args),
     /** Level of the logger */
     level: pinoLogger.level as LogLevel,
     /** Whether the given level is enabled for this logger. */
@@ -354,12 +402,15 @@ export function registerLoggingStream(stream: Writable): void {
 }
 
 /** Log function that accepts an exception object */
-type ErrorLogFn = (msg: string, err?: unknown, data?: LogData) => void;
+type ErrorLogFn = (msg: string, err?: unknown, data?: unknown) => void;
 
 /**
  * Logger that supports multiple severity levels.
  */
-export type Logger = { [K in LogLevel]: LogFn } & { /** Error log function */ error: ErrorLogFn } & {
+export type Logger = { [K in Exclude<LogLevel, 'error' | 'fatal'>]: LogFn } & {
+  /** Error log function */ error: ErrorLogFn;
+  /** Fatal log function */ fatal: ErrorLogFn;
+} & {
   level: LogLevel;
   isLevelEnabled: (level: LogLevel) => boolean;
   module: string;


### PR DESCRIPTION
## Overview

Pino logging was using ${} syntax which we pay for every time, even if the log level is not set. There is a real performance impact
to toString() everything that shows up here.
