### PR TITLE
chore: clean up noisy CI log output

### DIFF
--- a/ci3/bootstrap_ec2
+++ b/ci3/bootstrap_ec2
@@ -169,7 +169,7 @@ container_script=$(
   git config --global user.name "AztecBot"
   cd aztec-packages
   git config --global advice.detachedHead false
-  git init . &>/dev/null
+  git init .
   if [ -n "\${GITHUB_TOKEN:-}" ]; then
     git remote add origin "https://x-access-token:\$GITHUB_TOKEN@github.com/\$GITHUB_REPOSITORY.git"
   else

--- a/ci3/log_ci_run
+++ b/ci3/log_ci_run
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
 NO_CD=1 source $(git rev-parse --show-toplevel)/ci3/source
 
-set -x
-
 key=${1:?usage: log_ci_run <key> [status]}
 status=${2:-RUNNING}
 

--- a/ci3/ssm_send_command
+++ b/ci3/ssm_send_command
@@ -75,8 +75,6 @@ fi
 # how many characters we've already printed and only emit the new portion.
 SSM_POLL_TIMEOUT=${SSM_POLL_TIMEOUT:-7200}
 poll_start=$SECONDS
-prev_stdout_len=0
-prev_stderr_len=0
 
 while true; do
   if (( SECONDS - poll_start >= SSM_POLL_TIMEOUT )); then
@@ -90,17 +88,9 @@ while true; do
     --instance-id "$iid" \
     --output json 2>/dev/null || echo '{}')
 
+  # SSM output is a truncated 24KB snapshot; real logs go to cache_log/S3.
+  # We only need the status to know when the command finishes.
   status=$(printf '%s' "$inv" | jq -r '.Status // "Unknown"')
-  stdout=$(printf '%s' "$inv" | jq -r '.StandardOutputContent // ""')
-  stderr=$(printf '%s' "$inv" | jq -r '.StandardErrorContent // ""')
-
-  # Print only the new portion of stdout/stderr since the last poll.
-  new_stdout=${stdout:$prev_stdout_len}
-  new_stderr=${stderr:$prev_stderr_len}
-  [ -n "$new_stdout" ] && printf "%s" "$new_stdout"
-  [ -n "$new_stderr" ] && printf "%s" "$new_stderr" >&2
-  prev_stdout_len=${#stdout}
-  prev_stderr_len=${#stderr}
 
   case "$status" in
     Success|Cancelled|TimedOut|Failed)


### PR DESCRIPTION
## Summary
- Stop printing truncated SSM stdout/stderr snapshots in `ssm_send_command` — real logs go to `cache_log`/S3, the SSM poll output was just noise (and capped at 24KB anyway)
- Remove `set -x` from `log_ci_run` that was added for debugging

## Test plan
- [ ] Verify CI runs still complete and logs are available on the dashboard
- [ ] Confirm GitHub Actions logs are cleaner (no git fetch/checkout/docker login noise)