### PR TITLE
fix: add random suffix to CI_LOG_ID to prevent collisions

### DIFF
--- a/ci3/bootstrap_ec2
+++ b/ci3/bootstrap_ec2
@@ -20,7 +20,7 @@ export CI=1
 export CI_USE_BUILD_INSTANCE_KEY=${CI_USE_BUILD_INSTANCE_KEY:-1}
 
 # Pre-generate a log ID and print the dashboard link.
-export CI_LOG_ID=$(date +%s%3N)
+export CI_LOG_ID=$(date +%s%3N)$((100 + RANDOM % 900))
 log_url="http://ci.aztec-labs.com/$CI_LOG_ID"
 echo -e "CI Log: ${yellow}$log_url${reset}"
 if [ -n "${CI_DASHBOARD:-}" ]; then


### PR DESCRIPTION
## Summary
- `CI_LOG_ID` is a millisecond timestamp used as the Redis sorted set score in `log_ci_run`
- Fix: append a 3-digit random suffix (100-999) using bash built-in `$RANDOM`, making collisions much less likely