### PR TITLE
fix: limit parallel blocks in prover to max AVM parallel simulations

### DIFF
--- a/yarn-project/native/src/native_module.ts
+++ b/yarn-project/native/src/native_module.ts
@@ -131,7 +131,7 @@ export function cancelSimulation(token: CancellationToken): void {
  * Maximum number of concurrent AVM simulations. Each simulation spawns a dedicated OS thread,
  * so this controls resource usage. Defaults to 4. Set to 0 for unlimited.
  */
-const AVM_MAX_CONCURRENT_SIMULATIONS = parseInt(process.env.AVM_MAX_CONCURRENT_SIMULATIONS ?? '4', 10);
+export const AVM_MAX_CONCURRENT_SIMULATIONS = parseInt(process.env.AVM_MAX_CONCURRENT_SIMULATIONS ?? '4', 10);
 const avmSimulationSemaphore =
   AVM_MAX_CONCURRENT_SIMULATIONS > 0 ? new Semaphore(AVM_MAX_CONCURRENT_SIMULATIONS) : null;
 

--- a/yarn-project/prover-node/package.json
+++ b/yarn-project/prover-node/package.json
@@ -66,6 +66,7 @@
     "@aztec/foundation": "workspace:^",
     "@aztec/kv-store": "workspace:^",
     "@aztec/l1-artifacts": "workspace:^",
+    "@aztec/native": "workspace:^",
     "@aztec/node-keystore": "workspace:^",
     "@aztec/node-lib": "workspace:^",
     "@aztec/noir-protocol-circuits-types": "workspace:^",

--- a/yarn-project/prover-node/src/config.ts
+++ b/yarn-project/prover-node/src/config.ts
@@ -60,7 +60,7 @@ export const specificProverNodeConfigMappings: ConfigMappingsType<SpecificProver
   proverNodeMaxParallelBlocksPerEpoch: {
     env: 'PROVER_NODE_MAX_PARALLEL_BLOCKS_PER_EPOCH',
     description: 'The Maximum number of blocks to process in parallel while proving an epoch',
-    ...numberConfigHelper(32),
+    ...numberConfigHelper(0),
   },
   proverNodeFailedEpochStore: {
     env: 'PROVER_NODE_FAILED_EPOCH_STORE',

--- a/yarn-project/prover-node/src/job/epoch-proving-job.ts
+++ b/yarn-project/prover-node/src/job/epoch-proving-job.ts
@@ -6,6 +6,7 @@ import { Fr } from '@aztec/foundation/curves/bn254';
 import { type Logger, type LoggerBindings, createLogger } from '@aztec/foundation/log';
 import { RunningPromise, promiseWithResolvers } from '@aztec/foundation/promise';
 import { Timer } from '@aztec/foundation/timer';
+import { AVM_MAX_CONCURRENT_SIMULATIONS } from '@aztec/native';
 import { getVKTreeRoot } from '@aztec/noir-protocol-circuits-types/vk-tree';
 import { protocolContractsHash } from '@aztec/protocol-contracts';
 import { buildFinalBlobChallenges } from '@aztec/prover-client/helpers';
@@ -164,7 +165,14 @@ export class EpochProvingJob implements Traceable {
       const previousBlockHeaders = this.gatherPreviousBlockHeaders();
 
       const allCheckpointsTimer = new Timer();
-      await asyncPool(this.config.parallelBlockLimit ?? 32, this.checkpoints, async checkpoint => {
+
+      const parallelism = this.config.parallelBlockLimit
+        ? this.config.parallelBlockLimit
+        : AVM_MAX_CONCURRENT_SIMULATIONS > 0
+          ? AVM_MAX_CONCURRENT_SIMULATIONS
+          : this.checkpoints.length;
+
+      await asyncPool(parallelism, this.checkpoints, async checkpoint => {
         this.checkState();
         const checkpointTimer = new Timer();
 

--- a/yarn-project/prover-node/src/prover-node.ts
+++ b/yarn-project/prover-node/src/prover-node.ts
@@ -84,7 +84,7 @@ export class ProverNode implements EpochMonitorHandler, ProverNodeApi, Traceable
     this.config = {
       proverNodePollingIntervalMs: 1_000,
       proverNodeMaxPendingJobs: 100,
-      proverNodeMaxParallelBlocksPerEpoch: 32,
+      proverNodeMaxParallelBlocksPerEpoch: 0,
       txGatheringIntervalMs: 1_000,
       txGatheringBatchSize: 10,
       txGatheringMaxParallelRequestsPerNode: 100,

--- a/yarn-project/prover-node/tsconfig.json
+++ b/yarn-project/prover-node/tsconfig.json
@@ -37,6 +37,9 @@
       "path": "../l1-artifacts"
     },
     {
+      "path": "../native"
+    },
+    {
       "path": "../node-keystore"
     },
     {


### PR DESCRIPTION
Drops the default MAX_PARALLEL_BLOCKS from 32 to 4 to make better use of available CPUs.