### PR TITLE
fix: separate timestamp from ci_log_id and fix deploy-test

### DIFF
--- a/ci3/dashboard/deploy-test.sh
+++ b/ci3/dashboard/deploy-test.sh
@@ -26,7 +26,7 @@ echo "Using instance: $INSTANCE_ID"
 echo "Packaging dashboard files..."
 STAGING=$(mktemp -d /tmp/rk-test-stage-XXXXXX)
 TARBALL="$STAGING.tar.gz"
-rsync -a --exclude='deploy.sh' --exclude='deploy-test.sh' "$SCRIPT_DIR"/ "$STAGING"/
+rsync -a --exclude='deploy.sh' --exclude='deploy-test.sh' "$SCRIPT_DIR"/ "$STAGING/dashboard/"
 rsync -a "$SCRIPT_DIR/../ci-metrics/" "$STAGING/ci-metrics/"
 tar -czf "$TARBALL" -C "$STAGING" .
 rm -rf "$STAGING"

--- a/ci3/dashboard/rk_core.py
+++ b/ci3/dashboard/rk_core.py
@@ -68,7 +68,8 @@ def render(group: list) -> str:
             link_color = GREEN
         else:
             link_color = RESET
-        job_links.append(f"{link_color}{hyperlink(BASE_URL + '/' + str(job['timestamp']), job['job_id'])}{RESET}")
+        log_id = job.get('ci_log_id', job['timestamp'])
+        job_links.append(f"{link_color}{hyperlink(BASE_URL + '/' + str(log_id), job['job_id'])}{RESET}")
     links_str = ",".join(job_links)
     date_time = datetime.fromtimestamp(ts // 1000).strftime("%m-%d %H:%M:%S")
 

--- a/ci3/dashboard/set-filter.lua
+++ b/ci3/dashboard/set-filter.lua
@@ -25,8 +25,8 @@ for _, member in ipairs(allMembers) do
   local ok, parsed = pcall(cjson.decode, member)
   if ok then
     if parsed["status"] == "RUNNING" then
-      local ts = parsed["timestamp"]
-      local hb_key = "hb-" .. tostring(ts)
+      local log_id = parsed["ci_log_id"] or parsed["timestamp"]
+      local hb_key = "hb-" .. tostring(log_id)
       if redis.call("EXISTS", hb_key) == 0 then
         parsed["status"] = "INACTIVE"
       end

--- a/ci3/log_ci_run
+++ b/ci3/log_ci_run
@@ -48,8 +48,11 @@ if [ "$status" = "RUNNING" ]; then
   msg=$(pr_link "$msg")
   dashboard="${range_key#ci-run-}"
 
+  # timestamp is the real ms epoch; ci_log_id includes a random suffix for uniqueness.
+  real_ts=${key:0:13}
   json=$(jq -c -j -n \
-      --argjson timestamp "$key" \
+      --argjson timestamp "$real_ts" \
+      --argjson ci_log_id "$key" \
       --arg run_id "${RUN_ID:-}" \
       --arg job_id "${JOB_ID:-}" \
       --arg status "$status" \
@@ -63,7 +66,7 @@ if [ "$status" = "RUNNING" ]; then
       --arg pr_number "$pr_number" \
       --arg dashboard "$dashboard" \
       --arg github_actor "${GITHUB_ACTOR:-}" \
-      '{timestamp: $timestamp, run_id: $run_id, job_id: $job_id, status: $status, msg: $msg, name: $name, author: $author, github_actor: $github_actor, arch: $arch, spot: $spot, instance_type: $instance_type, instance_vcpus: $instance_vcpus, pr_number: $pr_number, dashboard: $dashboard}')
+      '{timestamp: $timestamp, ci_log_id: $ci_log_id, run_id: $run_id, job_id: $job_id, status: $status, msg: $msg, name: $name, author: $author, github_actor: $github_actor, arch: $arch, spot: $spot, instance_type: $instance_type, instance_vcpus: $instance_vcpus, pr_number: $pr_number, dashboard: $dashboard}')
   # echo "$json" >&2
   redis_cli ZADD $range_key $key "$json" &>/dev/null
   redis_cli SETEX hb-$key 60 1 &>/dev/null

--- a/ci3/lua/set-filter.lua
+++ b/ci3/lua/set-filter.lua
@@ -32,8 +32,8 @@ for _, member in ipairs(allMembers) do
   local ok, parsed = pcall(cjson.decode, member)
   if ok then
     if parsed["status"] == "RUNNING" then
-      local ts = parsed["timestamp"]
-      local hb_key = "hb-" .. tostring(ts)
+      local log_id = parsed["ci_log_id"] or parsed["timestamp"]
+      local hb_key = "hb-" .. tostring(log_id)
       if redis.call("EXISTS", hb_key) == 0 then
         parsed["status"] = "INACTIVE"
       end


### PR DESCRIPTION
## Summary
- Separates `timestamp` (real 13-digit ms epoch) from `ci_log_id` (full ID with random suffix) in `log_ci_run` JSON payload
- Fixes `ValueError: year 58159 is out of range` dashboard crash caused by 16-digit CI_LOG_ID being treated as ms timestamp
- Updates Lua scripts and dashboard to use `ci_log_id` for heartbeat lookups and log links, with fallback for pre-existing entries
- Fixes `deploy-test.sh` staging layout to match Dockerfile expectations (`dashboard/` subdirectory)