### PR TITLE
fix: reqresp flake & add logging

### DIFF
--- a/yarn-project/end-to-end/src/e2e_p2p/reqresp/utils.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/reqresp/utils.ts
@@ -149,6 +149,10 @@ export async function runReqrespTxTest(params: {
   const submittedTxs = await Promise.all(
     txBatches.map(async (batch, batchIndex) => {
       const proposerNode = nodes[proposerIndexes[batchIndex]];
+      const txHashes = batch.map(tx => tx.getTxHash().toString());
+      t.logger.info(
+        `Sending batch ${batchIndex} to proposer ${getNodePort(proposerIndexes[batchIndex])}: ${txHashes.join(', ')}`,
+      );
       await Promise.all(
         batch.map(async tx => {
           try {
@@ -162,6 +166,12 @@ export async function runReqrespTxTest(params: {
       return batch.map(tx => ({ node: proposerNode, txHash: tx.getTxHash() }));
     }),
   );
+
+  // Log pool state per node after sending
+  for (let i = 0; i < NUM_VALIDATORS; i++) {
+    const count = await nodes[i].getPendingTxCount();
+    t.logger.info(`Node ${getNodePort(i)} pool has ${count} pending txs`);
+  }
 
   t.logger.info('Waiting for all transactions to be mined');
   await Promise.all(

--- a/yarn-project/end-to-end/src/e2e_p2p/reqresp/utils.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/reqresp/utils.ts
@@ -149,6 +149,9 @@ export async function runReqrespTxTest(params: {
   const submittedTxs = await Promise.all(
     txBatches.map(async (batch, batchIndex) => {
       const proposerNode = nodes[proposerIndexes[batchIndex]];
+      for (const tx of batch) {
+        t.logger.info(`Tx ${tx.getTxHash().toString()} base64: ${tx.toBuffer().toString('base64')}`);
+      }
       const txHashes = batch.map(tx => tx.getTxHash().toString());
       t.logger.info(
         `Sending batch ${batchIndex} to proposer ${getNodePort(proposerIndexes[batchIndex])}: ${txHashes.join(', ')}`,
@@ -188,8 +191,16 @@ export async function runReqrespTxTest(params: {
 
   // Assert that multiple blocks were built for at least one slot
   t.logger.info('Verifying multiple blocks for at least one checkpoint');
-  const checkpoints = await nodes[0].getCheckpoints(CheckpointNumber(1), 50);
-  expect(checkpoints.length).toBeGreaterThan(0);
+  // Wait for L1 checkpoint sync, which may lag behind P2P block propagation.
+  const checkpoints = await retryUntil(
+    async () => {
+      const cps = await nodes[0].getCheckpoints(CheckpointNumber(1), 50);
+      return cps.length > 0 && cps.some(cp => cp.checkpoint.blocks.length >= 2) ? cps : undefined;
+    },
+    'waiting for multi-block checkpoint to sync from L1',
+    30,
+    1,
+  );
 
   let mbpsFound = false;
   let expectedBlockNumber = checkpoints[0].checkpoint.blocks[0].number;

--- a/yarn-project/p2p/src/mem_pools/tx_pool_v2/tx_pool_v2_impl.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool_v2/tx_pool_v2_impl.ts
@@ -354,6 +354,7 @@ export class TxPoolV2Impl {
 
     // Check if already in pool
     if (this.#indices.has(txHashStr)) {
+      this.#log.verbose(`canAddPendingTx: tx ${txHashStr} already in pool`);
       return 'ignored';
     }
 
@@ -362,7 +363,13 @@ export class TxPoolV2Impl {
     const poolAccess = this.#createPreAddPoolAccess();
     const preAddResult = await this.#evictionManager.runPreAddRules(meta, poolAccess);
 
-    return preAddResult.shouldIgnore ? 'ignored' : 'accepted';
+    if (preAddResult.shouldIgnore) {
+      this.#log.verbose(`canAddPendingTx: tx ${txHashStr} ignored by pre-add rule`, {
+        reason: preAddResult.reason?.message,
+      });
+      return 'ignored';
+    }
+    return 'accepted';
   }
 
   async addProtectedTxs(txs: Tx[], block: BlockHeader, opts: { source?: string }): Promise<void> {

--- a/yarn-project/p2p/src/mem_pools/tx_pool_v2/tx_pool_v2_impl.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool_v2/tx_pool_v2_impl.ts
@@ -365,7 +365,7 @@ export class TxPoolV2Impl {
 
     if (preAddResult.shouldIgnore) {
       this.#log.verbose(`canAddPendingTx: tx ${txHashStr} ignored by pre-add rule`, {
-        reason: preAddResult.reason?.message,
+        reason: preAddResult.reason?.message ?? 'no reason provided',
       });
       return 'ignored';
     }

--- a/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
+++ b/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
@@ -948,8 +948,9 @@ export class LibP2PService extends WithTracer implements P2PService {
       const secondStageValidators = this.createSecondStageMessageValidators();
       const secondStageOutcome = await this.runValidations(tx, secondStageValidators);
       if (!secondStageOutcome.allPassed) {
-        const { severity } = secondStageOutcome.failure;
+        const { severity, name } = secondStageOutcome.failure;
         this.logger.verbose(`Rejecting gossiped tx ${tx.getTxHash().toString()}: stage 2 validation failed`, {
+          validator: name,
           severity,
           source: source.toString(),
         });

--- a/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
+++ b/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
@@ -754,6 +754,9 @@ export class LibP2PService extends WithTracer implements P2PService {
     if (!validator || !validator.addMessage(msgId)) {
       this.instrumentation.incMessagePrevalidationStatus(false, topicType);
       this.node.services.pubsub.reportMessageValidationResult(msgId, source.toString(), TopicValidatorResult.Ignore);
+      if (topicType === TopicType.tx) {
+        this.logger.verbose(`Ignoring already-seen tx gossip message`, { msgId, source: source.toString() });
+      }
       return { result: false, topicType };
     }
 
@@ -923,6 +926,11 @@ export class LibP2PService extends WithTracer implements P2PService {
           severity = await this.handleDoubleSpendFailure(tx, txBlockNumber);
         }
 
+        this.logger.verbose(`Rejecting gossiped tx ${tx.getTxHash().toString()}: stage 1 validation failed`, {
+          validator: name,
+          severity,
+          source: source.toString(),
+        });
         this.peerManager.penalizePeer(source, severity);
         return { result: TopicValidatorResult.Reject };
       }
@@ -930,6 +938,9 @@ export class LibP2PService extends WithTracer implements P2PService {
       // Pool pre-check: see if the pool would accept this tx before doing expensive proof verification
       const canAdd = await this.mempools.txPool.canAddPendingTx(tx);
       if (canAdd === 'ignored') {
+        this.logger.verbose(`Ignoring gossiped tx ${tx.getTxHash().toString()}: pool pre-check returned ignored`, {
+          source: source.toString(),
+        });
         return { result: TopicValidatorResult.Ignore, obj: tx };
       }
 
@@ -938,6 +949,10 @@ export class LibP2PService extends WithTracer implements P2PService {
       const secondStageOutcome = await this.runValidations(tx, secondStageValidators);
       if (!secondStageOutcome.allPassed) {
         const { severity } = secondStageOutcome.failure;
+        this.logger.verbose(`Rejecting gossiped tx ${tx.getTxHash().toString()}: stage 2 validation failed`, {
+          severity,
+          source: source.toString(),
+        });
         this.peerManager.penalizePeer(source, severity);
         return { result: TopicValidatorResult.Reject };
       }
@@ -949,7 +964,7 @@ export class LibP2PService extends WithTracer implements P2PService {
       const wasAccepted = addResult.accepted.some(h => h.equals(txHash));
       const wasIgnored = addResult.ignored.some(h => h.equals(txHash));
 
-      this.logger.trace(`Validate propagated tx`, {
+      this.logger.verbose(`Validate propagated tx ${txHash.toString()}`, {
         wasAccepted,
         wasIgnored,
         [Attributes.P2P_ID]: source.toString(),


### PR DESCRIPTION
Ref: A-634

## The test is set up this way:
- Block proposers are connected via gossip between each other.
- All other nodes drop all gossip messages.
- Each proposer gets a part of the entire tx set. In a normal scenario they exchange these txs via gossip, so every proposer has every tx.

## What happened:
- P2 sends Tx2 to P1 — this send succeeds.
- P1 sends Tx1 to P2 — this send fails.
- Tx2 gets mined by P1.
- P2 proposes an empty block because the only tx it had was mined by P1.
- This is where the test ends and we start waiting for all txs to get mined (including Tx1).

## Changes
I didn't find any evidence for why the gossip failure happened. This PR adds more logs to the gossip pipeline to try to find why this failure occurred. The flake could not be reproduced after hundreds of test runs.

Also found an unrelated flake: after transactions are mined, we query checkpoints, but the checkpoint might not yet be published to L1 and synced by the archiver, causing the assertion to fail.