### PR TITLE
fix: skip oracle version check for pinned protocol contracts

### DIFF
--- a/yarn-project/protocol-contracts/src/protocol_contract.ts
+++ b/yarn-project/protocol-contracts/src/protocol_contract.ts
@@ -16,12 +16,16 @@ export interface ProtocolContract {
   address: AztecAddress;
 }
 
-/** Returns true if the address is one of the actual protocol contracts (ContractInstanceRegistry,
+export function isProtocolContract(address: AztecAddress) {
+  return Object.values(ProtocolContractAddress).some(a => a.equals(address));
+}
+
+/** Returns true if the address is one of the ACTUAL protocol contracts (ContractInstanceRegistry,
  * ContractClassRegistry or FeeJuice).
  *
  * TODO(F-416): Drop this function when protocol contracts are redeployed.
  */
-export function isProtocolContract(address: AztecAddress) {
+export function isActualProtocolContract(address: AztecAddress) {
   return (
     address.equals(ProtocolContractAddress.ContractInstanceRegistry) ||
     address.equals(ProtocolContractAddress.ContractClassRegistry) ||

--- a/yarn-project/protocol-contracts/src/protocol_contract.ts
+++ b/yarn-project/protocol-contracts/src/protocol_contract.ts
@@ -16,8 +16,17 @@ export interface ProtocolContract {
   address: AztecAddress;
 }
 
+/** Returns true if the address is one of the actual protocol contracts (ContractInstanceRegistry,
+ * ContractClassRegistry or FeeJuice).
+ *
+ * TODO(F-416): Drop this function when protocol contracts are redeployed.
+ */
 export function isProtocolContract(address: AztecAddress) {
-  return Object.values(ProtocolContractAddress).some(a => a.equals(address));
+  return (
+    address.equals(ProtocolContractAddress.ContractInstanceRegistry) ||
+    address.equals(ProtocolContractAddress.ContractClassRegistry) ||
+    address.equals(ProtocolContractAddress.FeeJuice)
+  );
 }
 
 export { type ProtocolContractsProvider } from './provider/protocol_contracts_provider.js';

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/oracle.ts
@@ -85,13 +85,28 @@ export class Oracle {
     });
 
     // Build callback object and return it
-    return oracleNames.reduce((acc, name) => {
+    const callback = oracleNames.reduce((acc, name) => {
       const method = this[name as keyof Omit<Oracle, (typeof excludedProps)[number]>];
       acc[name] = method.bind(this);
       return acc;
     }, {} as ACIRCallback);
+
+    // Legacy oracle names used by alpha payload protocol contracts (ContractInstanceRegistry,
+    // ContractClassRegistry, FeeJuice). Their bytecode is committed and cannot be changed.
+    // TODO(F-416): Remove these aliases on v5 when protocol contracts are redeployed.
+    const legacyOracles: ACIRCallback = {
+      utilityLog: this.aztec_utl_log.bind(this),
+      utilityAssertCompatibleOracleVersion: this.aztec_utl_assertCompatibleOracleVersion.bind(this),
+      utilityLoadCapsule: this.aztec_utl_loadCapsule.bind(this),
+      privateStoreInExecutionCache: this.aztec_prv_storeInExecutionCache.bind(this),
+      privateLoadFromExecutionCache: this.aztec_prv_loadFromExecutionCache.bind(this),
+    };
+
+    return { ...callback, ...legacyOracles };
   }
 
+  // TODO(F-416): This oracle must never change its signature - it is called by the pinned alpha payload protocol
+  // contracts (ContractInstanceRegistry, ContractClassRegistry, FeeJuice) which cannot be redeployed.
   // eslint-disable-next-line camelcase
   aztec_utl_assertCompatibleOracleVersion([version]: ACVMField[]) {
     this.handlerAsMisc().assertCompatibleOracleVersion(Fr.fromString(version).toNumber());
@@ -104,12 +119,16 @@ export class Oracle {
     return Promise.resolve([toACVMField(val)]);
   }
 
+  // TODO(F-416): This oracle must never change its signature - it is called by the pinned alpha payload protocol
+  // contracts (ContractInstanceRegistry, ContractClassRegistry, FeeJuice) which cannot be redeployed.
   // eslint-disable-next-line camelcase
   aztec_prv_storeInExecutionCache(values: ACVMField[], [hash]: ACVMField[]): Promise<ACVMField[]> {
     this.handlerAsPrivate().storeInExecutionCache(values.map(Fr.fromString), Fr.fromString(hash));
     return Promise.resolve([]);
   }
 
+  // TODO(F-416): This oracle must never change its signature - it is called by the pinned alpha payload protocol
+  // contracts (ContractInstanceRegistry, ContractClassRegistry, FeeJuice) which cannot be redeployed.
   // eslint-disable-next-line camelcase
   async aztec_prv_loadFromExecutionCache([returnsHash]: ACVMField[]): Promise<ACVMField[][]> {
     const values = await this.handlerAsPrivate().loadFromExecutionCache(Fr.fromString(returnsHash));
@@ -426,6 +445,8 @@ export class Oracle {
     return Promise.resolve([]);
   }
 
+  // TODO(F-416): This oracle must never change its signature - it is called by the pinned alpha payload protocol
+  // contracts (ContractInstanceRegistry, ContractClassRegistry, FeeJuice) which cannot be redeployed.
   // eslint-disable-next-line camelcase
   async aztec_utl_log(
     level: ACVMField[],
@@ -540,6 +561,8 @@ export class Oracle {
     return [];
   }
 
+  // TODO(F-416): This oracle must never change its signature - it is called by the pinned alpha payload protocol
+  // contracts (ContractInstanceRegistry, ContractClassRegistry, FeeJuice) which cannot be redeployed.
   // eslint-disable-next-line camelcase
   async aztec_utl_loadCapsule(
     [contractAddress]: ACVMField[],

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
@@ -6,7 +6,7 @@ import { Point } from '@aztec/foundation/curves/grumpkin';
 import { LogLevels, type Logger, createLogger } from '@aztec/foundation/log';
 import type { MembershipWitness } from '@aztec/foundation/trees';
 import type { KeyStore } from '@aztec/key-store';
-import { isProtocolContract } from '@aztec/protocol-contracts';
+import { isActualProtocolContract } from '@aztec/protocol-contracts';
 import type { AuthWitness } from '@aztec/stdlib/auth-witness';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
 import { BlockHash } from '@aztec/stdlib/block';
@@ -113,7 +113,7 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
     // Alpha payload protocol contracts (ContractInstanceRegistry, ContractClassRegistry, FeeJuice) shipped with
     // committed bytecode that cannot be changed. Skip the version check for these contracts.
     // TODO(F-416): Remove this hack on v5 when protocol contracts are redeployed.
-    if (isProtocolContract(this.contractAddress)) {
+    if (isActualProtocolContract(this.contractAddress)) {
       return;
     }
     if (version !== ORACLE_VERSION) {

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
@@ -6,6 +6,7 @@ import { Point } from '@aztec/foundation/curves/grumpkin';
 import { LogLevels, type Logger, createLogger } from '@aztec/foundation/log';
 import type { MembershipWitness } from '@aztec/foundation/trees';
 import type { KeyStore } from '@aztec/key-store';
+import { isProtocolContract } from '@aztec/protocol-contracts';
 import type { AuthWitness } from '@aztec/stdlib/auth-witness';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
 import { BlockHash } from '@aztec/stdlib/block';
@@ -109,6 +110,12 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
   }
 
   public assertCompatibleOracleVersion(version: number): void {
+    // Alpha payload protocol contracts (ContractInstanceRegistry, ContractClassRegistry, FeeJuice) shipped with
+    // committed bytecode that cannot be changed. Skip the version check for these contracts.
+    // TODO(F-416): Remove this hack on v5 when protocol contracts are redeployed.
+    if (isProtocolContract(this.contractAddress)) {
+      return;
+    }
     if (version !== ORACLE_VERSION) {
       throw new Error(`Incompatible oracle version. Expected version ${ORACLE_VERSION}, got ${version}.`);
     }


### PR DESCRIPTION
We messed up backports of PRs modifying oracles because we forgot that we already have pinned protocol contracts artifacts on the `v4` branch that effectively result in us having dependency on the old oracles. We agreed with Nico that to get around this we have to:
1. Map the old oracles that are used by the protocol contracts to the new handlers,
2. skip the oracle versions check for protocol the contracts,
3. keep in mind that we no longer can modify the oracles used by the protocol contracts.

Note that this will need to be backported with https://github.com/AztecProtocol/aztec-packages/pull/21101 at the same time #21101 is not backportable on its own.



## AI Summary

- Skip the oracle version check for pinned protocol contracts (ContractInstanceRegistry, ContractClassRegistry, FeeJuice) whose bytecode is committed and cannot be changed
- Register legacy oracle name aliases (`utilityLog`, `utilityAssertCompatibleOracleVersion`, `utilityLoadCapsule`, `privateStoreInExecutionCache`, `privateLoadFromExecutionCache`) so the old oracle names used by these contracts still resolve
- Narrow `isProtocolContract` to only the 3 actual protocol dependencies (was previously checking all 6 canonical addresses)
- Add `TODO(F-416)` preservation comments to all affected oracle methods