### PR TITLE
fix: address review feedback from PRs #21284 and #21237

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/macros/internals_functions_generation/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/internals_functions_generation/mod.nr
@@ -75,7 +75,7 @@ pub(crate) comptime fn process_functions(m: Module) -> Quoted {
     );
     make_functions_uncallable(
         utility_functions,
-        "Calling utility functions directly from within the contract is not supported. You attempted to call ",
+        "Direct invocation of utility functions is not supported. You attempted to call ",
     );
 
     // INTERNAL FUNCTIONS

--- a/noir-projects/noir-contracts-comp-failures/contracts/panic_on_direct_utility_external_fn_call/expected_error
+++ b/noir-projects/noir-contracts-comp-failures/contracts/panic_on_direct_utility_external_fn_call/expected_error
@@ -1,1 +1,1 @@
-Calling utility functions directly from within the contract is not supported. You attempted to call arbitrary_external_function. See https://docs.aztec.network/errors/6
+Direct invocation of utility functions is not supported. You attempted to call arbitrary_external_function. See https://docs.aztec.network/errors/6

--- a/yarn-project/aztec/src/cli/cmds/utils/needs_recompile.ts
+++ b/yarn-project/aztec/src/cli/cmds/utils/needs_recompile.ts
@@ -77,6 +77,7 @@ async function collectCrateDirs(startCrateDir: string): Promise<string[]> {
 
     const members = (parsed.workspace as Record<string, any>)?.members as string[] | undefined;
 
+    // A Nargo.toml is either a workspace root (has workspace.members) or a single crate (has dependencies).
     if (Array.isArray(members)) {
       // The crate is a workspace root and has members defined so we visit the members
       for (const member of members) {


### PR DESCRIPTION
## Summary
- Add a one-line comment in `needs_recompile.ts` explaining that a `Nargo.toml` is either a workspace root (has `workspace.members`) or a single crate (has `dependencies`) (#21284)
- Make utility function direct invocation error message consistent with private/public function messages: "Direct invocation of utility functions is not supported..." (#21237)

## Test plan
- CI should pass — the `expected_error` file was updated to match the new error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)