### PR TITLE
fix: add TLS alignment pad to fix x86_64-macos segfault

### DIFF
--- a/barretenberg/cpp/src/barretenberg/common/parallel_for_mutex_pool.cpp
+++ b/barretenberg/cpp/src/barretenberg/common/parallel_for_mutex_pool.cpp
@@ -19,7 +19,7 @@
 // also present (from Rust static libraries). Adding an alignas(16) initialized
 // thread_local forces __thread_data alignment to 16, ensuring __thread_bss starts
 // at a 16-byte-aligned TLS template offset.
-// See: https://codeberg.org/AztecProtocol/zig-macho-tls-bug
+// See: https://codeberg.org/ziglang/zig/issues/31461
 // NOLINTBEGIN
 alignas(16) thread_local char tls_alignment_pad[16] __attribute__((used)) = { 1 };
 // NOLINTEND

--- a/barretenberg/cpp/src/barretenberg/common/parallel_for_mutex_pool.cpp
+++ b/barretenberg/cpp/src/barretenberg/common/parallel_for_mutex_pool.cpp
@@ -14,12 +14,13 @@
 
 #include "barretenberg/common/compiler_hints.hpp"
 
-// Work around an LLVM Mach-O linker bug (affects both Zig's linker and ld64.lld)
-// where __thread_bss TLS template offsets are misaligned when __thread_data is
-// also present (from Rust static libraries). Adding an alignas(16) initialized
+// Fix for https://github.com/AztecProtocol/barretenberg/issues/1275
+// Zig's Mach-O linker (https://codeberg.org/ziglang/zig/issues/31461) misaligns
+// __thread_bss TLS template offsets when __thread_data is also present (from Rust
+// static libraries), causing x86_64-macos segfaults on any thread_local requiring
+// 16-byte alignment (e.g. std::mutex). Adding an alignas(16) initialized
 // thread_local forces __thread_data alignment to 16, ensuring __thread_bss starts
-// at a 16-byte-aligned TLS template offset.
-// See: https://codeberg.org/ziglang/zig/issues/31461
+// at a correctly aligned TLS template offset.
 // NOLINTBEGIN
 alignas(16) thread_local char tls_alignment_pad[16] __attribute__((used)) = { 1 };
 // NOLINTEND

--- a/barretenberg/cpp/src/barretenberg/common/parallel_for_mutex_pool.cpp
+++ b/barretenberg/cpp/src/barretenberg/common/parallel_for_mutex_pool.cpp
@@ -14,7 +14,7 @@
 
 #include "barretenberg/common/compiler_hints.hpp"
 
-// Fix for https://github.com/AztecProtocol/barretenberg/issues/1275
+// Fix for https://github.com/AztecProtocol/aztec-packages/issues/19769
 // Zig's Mach-O linker (https://codeberg.org/ziglang/zig/issues/31461) misaligns
 // __thread_bss TLS template offsets when __thread_data is also present (from Rust
 // static libraries), causing x86_64-macos segfaults on any thread_local requiring

--- a/barretenberg/cpp/src/barretenberg/common/parallel_for_mutex_pool.cpp
+++ b/barretenberg/cpp/src/barretenberg/common/parallel_for_mutex_pool.cpp
@@ -19,7 +19,7 @@
 // also present (from Rust static libraries). Adding an alignas(16) initialized
 // thread_local forces __thread_data alignment to 16, ensuring __thread_bss starts
 // at a 16-byte-aligned TLS template offset.
-// See: https://github.com/AztecProtocol/aztec-packages/pull/21253
+// See: https://codeberg.org/AztecProtocol/zig-macho-tls-bug
 // NOLINTBEGIN
 alignas(16) thread_local char tls_alignment_pad[16] __attribute__((used)) = { 1 };
 // NOLINTEND

--- a/barretenberg/cpp/src/barretenberg/common/parallel_for_mutex_pool.cpp
+++ b/barretenberg/cpp/src/barretenberg/common/parallel_for_mutex_pool.cpp
@@ -14,6 +14,16 @@
 
 #include "barretenberg/common/compiler_hints.hpp"
 
+// Work around an LLVM Mach-O linker bug (affects both Zig's linker and ld64.lld)
+// where __thread_bss TLS template offsets are misaligned when __thread_data is
+// also present (from Rust static libraries). Adding an alignas(16) initialized
+// thread_local forces __thread_data alignment to 16, ensuring __thread_bss starts
+// at a 16-byte-aligned TLS template offset.
+// See: https://github.com/AztecProtocol/aztec-packages/pull/21253
+// NOLINTBEGIN
+alignas(16) thread_local char tls_alignment_pad[16] __attribute__((used)) = { 1 };
+// NOLINTEND
+
 namespace {
 
 class ThreadPool {


### PR DESCRIPTION
## Summary

- Fixes x86_64-macos segfault (`EXC_I386_GPFLT`) when `bb` is cross-compiled with Zig and linked with a Rust static library (AVM transpiler)
- Root cause: LLVM's Mach-O linker misaligns `__thread_bss` TLS template offsets when `__thread_data` (from Rust) is also present, causing 16-byte-aligned `thread_local` objects (like `std::mutex`) to be placed at 8-byte-aligned addresses
- Fix: a single `alignas(16) thread_local` variable forces `__thread_data` section alignment to 16, making the linker pad it correctly

Fixes https://github.com/AztecProtocol/aztec-packages/issues/21225
Fixes https://github.com/AztecProtocol/aztec-packages/issues/19769

## Details

Both Zig's built-in Mach-O linker and `ld64.lld-20` share the same LLVM code for laying out TLS sections. When `__thread_data` (align 8, from Rust objects) precedes `__thread_bss` (align 16, from C++ `thread_local`), the linker aligns the `__thread_bss` virtual address to 16 but the TLS template offset remains misaligned because `__thread_data` starts at an 8-aligned VA.

At runtime, `dyld` allocates a 16-aligned TLS block and copies the template at the recorded offsets. Variables that should be at `block + 0x40` (16-aligned) end up at `block + 0x38` (8-aligned), causing `MOVAPS` instructions to fault.

The fix adds an `alignas(16)` initialized `thread_local` that forces the `__thread_data` section alignment to 16, which makes the linker pad the section end to a 16-byte boundary.

Upstream bug: https://codeberg.org/ziglang/zig/issues/31461

## Test plan

- [x] Cross-compiled `bb` binary with Zig for x86_64-macos
- [x] Verified TLS section alignment: `__thread_data` align 2^4 (16), offset to `__thread_bss` is 0x40 (mod 16 = 0)
- [x] Tested on macOS VM: `bb prove --scheme ultra_honk` runs without segfault
- [x] Previous binary (without pad) segfaults immediately with `EXC_I386_GPFLT`

Supersedes #21253