### PR TITLE
chore(avm)!: Address Derivation pre-audit

### DIFF
--- a/barretenberg/cpp/pil/vm2/bytecode/address_derivation.pil
+++ b/barretenberg/cpp/pil/vm2/bytecode/address_derivation.pil
@@ -4,7 +4,91 @@ include "../poseidon2_hash.pil";
 include "../precomputed.pil";
 include "../scalar_mul.pil";
 
+/**
+ * This subtrace constrains the derivation of a contract address from its preimage. It is used
+ * during contract instance retrieval (contract_instance_retrieval.pil) in our execution flow.
+ * The address is defined by the following flow, where the hash fuction H() is Poseidon2, and G1
+ * is the Grumpkin curve's generator point:
+ *   1. salted_init_hash  = H(DOM_SEP__PARTIAL_ADDRESS, salt, init_hash, deployer_addr)
+ *   2. partial_address   = H(DOM_SEP__PARTIAL_ADDRESS, class_id, salted_init_hash)
+ *   3. public_keys_hash  = H(DOM_SEP__PUBLIC_KEYS_HASH,
+ *                             nullifier_key_x, nullifier_key_y, nullifier_key_is_infinity,
+ *                             incoming_viewing_key_x, incoming_viewing_key_y, incoming_viewing_key_is_infinity,
+ *                             outgoing_viewing_key_x, outgoing_viewing_key_y, outgoing_viewing_key_is_infinity,
+ *                             tagging_key_x, tagging_key_y, tagging_key_is_infinity)
+ *   4. preaddress        = H(DOM_SEP__CONTRACT_ADDRESS_V1, public_keys_hash, partial_address)
+ *   5. preaddress_public_key = preaddress * G1
+ *   6. address           = (preaddress_public_key + incoming_viewing_key).x
+ *
+ * Steps 1-4 are Poseidon hashes and steps 5-6 are point operations over the Grumpkin elliptic
+ * curve. See the 'Hash Computations', 'Elliptic Curve Operations', and 'INTERACTIONS' sections
+ * for details on how we enforce each step. This process follows Noir's AztecAddress::compute().
+ *
+ * Note: DOM_SEP__PARTIAL_ADDRESS is reused for both the salted initialization hash and the partial
+ * address computations (steps 1 and 2). TODO(MW): Find out more (possibly just reused to avoid defining more seps -
+ * reuse is safe here because the two hashes have different lengths => IVs => cannot collide)
+ *
+ * PRECONDITIONS: The correctness of the preimage members is not constrained here and must be
+ *               enforced by the calling circuits. Like class_id_derivation, this trace can be seen
+ *               as an independent 'destination' trace which is purely responsible for address
+ *               computation.
+ *               This means we assume all public keys are not the point at infinity, and so use
+ *               precomputed.zero to represent each key's is_infinity flag (see TODO(#7529)).
+ *
+ * USAGE: To enforce that an address is correctly derived from all preimage members
+ *        (adapted from #[ADDRESS_DERIVATION] in contract_instance_retrieval.pil):
+ *
+ *   sel {
+ *     derived_address, salt, deployer_addr,
+ *     class_id, init_hash,
+ *     nullifier_key_x, nullifier_key_y,
+ *     incoming_viewing_key_x, incoming_viewing_key_y,
+ *     outgoing_viewing_key_x, outgoing_viewing_key_y,
+ *     tagging_key_x, tagging_key_y
+ *   } in address_derivation.sel {
+ *     address_derivation.address, address_derivation.salt, address_derivation.deployer_addr,
+ *     address_derivation.class_id, address_derivation.init_hash,
+ *     address_derivation.nullifier_key_x, address_derivation.nullifier_key_y,
+ *     address_derivation.incoming_viewing_key_x, address_derivation.incoming_viewing_key_y,
+ *     address_derivation.outgoing_viewing_key_x, address_derivation.outgoing_viewing_key_y,
+ *     address_derivation.tagging_key_x, address_derivation.tagging_key_y
+ *   };
+ *
+ * TRACE SHAPE: 1 row per address derivation computation. Note that simulation deduplicates addresses
+ *             that have already been processed i.e. when the same contract address is retrieved
+ *             multiple times in the same tx, only one event is emitted.
+ *
+ * INTERACTIONS:
+ *  execution.pil --> bc_retrieval.pil --> contract_instance_retrieval.pil --> address_derivation.pil --> poseidon2_hash.pil
+ *                                                                                                    --> scalar_mul.pil
+ *                                                                                                    --> ecc.pil
+ *
+ * This subtrace is looked up by:
+ * - contract_instance_retrieval.pil: To verify that the contract address is correctly derived from
+ *                                    the retrieved contract instance and public keys (#[ADDRESS_DERIVATION]).
+ *
+ * This subtrace looks up:
+ * - poseidon2_hash.pil: To constrain four Poseidon2 hashes across a total of 9 lookups/rounds:
+ *                       - salted_init_hash: #[SALTED_INITIALIZATION_HASH_POSEIDON2_0..1]
+ *                       - partial_address:  #[PARTIAL_ADDRESS_POSEIDON2]
+ *                       - public_keys_hash: #[PUBLIC_KEYS_HASH_POSEIDON2_0..4]
+ *                       - preaddress:       #[PREADDRESS_POSEIDON2]
+ *                       Each round is a row in the poseidon trace. Each column above is constrained to be its
+ *                       corresponding poseidon2_hash.output value, which is propagated across each row
+ *                       so (under hash collision resistance) every lookup referencing the same output must
+ *                       reference the same computation.
+ *                       See 'Hash Computations' section for details on individual hashes.
+ * - scalar_mul.pil: To constrain that preaddress_public_key = preaddress * G1 on Grumpkin
+ *                   (#[PREADDRESS_SCALAR_MUL]).
+ * - ecc.pil: To constrain that address = (preaddress_public_key + incoming_viewing_key).x on Grumpkin
+ *            (#[ADDRESS_ECADD]).
+ */
+
 namespace address_derivation;
+
+    ///////////////////////////////
+    // Set Up Columns
+    ///////////////////////////////
 
     pol commit sel; // @boolean
     sel * (1 - sel) = 0;
@@ -12,11 +96,15 @@ namespace address_derivation;
     #[skippable_if]
     sel = 0;
 
-    // Address preimage components
+    // The expected derived address (x coordinate of address_point, constrained in #[ADDRESS_ECADD]).
+    pol commit address;
+
+    // Contract instance members (see ContractInstance in barretenberg/cpp/src/barretenberg/vm2/common/aztec_types.hpp).
     pol commit salt;
     pol commit deployer_addr;
-    pol commit class_id;
+    pol commit class_id; // = original_contract_class_id
     pol commit init_hash;
+    // Public keys, all Grumpkin curve points (see PublicKeys in barretenberg/cpp/src/barretenberg/vm2/common/aztec_types.hpp).
     pol commit nullifier_key_x;
     pol commit nullifier_key_y;
     pol commit incoming_viewing_key_x;
@@ -26,18 +114,21 @@ namespace address_derivation;
     pol commit tagging_key_x;
     pol commit tagging_key_y;
 
-    // Expected derived address
-    pol commit address;
 
-
-    // Computation of salted initialization hash
-
-    pol commit salted_init_hash;
-
-    // It's reused between the partial address and salted initialization hash. Weird.
-    // TODO: We need this temporarily while we dont allow for aliases in the lookup tuple
-    pol commit partial_address_domain_separator;
-    sel * (partial_address_domain_separator - constants.DOM_SEP__PARTIAL_ADDRESS) = 0;
+    ///////////////////////////////
+    // Hash Computations
+    ///////////////////////////////
+    //
+    // This trace constrains the result of four Poseidon2 hashes:
+    //   1. salted_init_hash  = H(DOM_SEP__PARTIAL_ADDRESS, salt, init_hash, deployer_addr)
+    //   2. partial_address   = H(DOM_SEP__PARTIAL_ADDRESS, class_id, salted_init_hash)
+    //   3. public_keys_hash  = H(DOM_SEP__PUBLIC_KEYS_HASH,
+    //                             nullifier_key_x, nullifier_key_y, 0,
+    //                             incoming_viewing_key_x, incoming_viewing_key_y, 0,
+    //                             outgoing_viewing_key_x, outgoing_viewing_key_y, 0,
+    //                             tagging_key_x, tagging_key_y, 0)
+    //   4. preaddress        = H(DOM_SEP__CONTRACT_ADDRESS_V1, public_keys_hash, partial_address)
+    //
 
     // Lookup constant support: Can be removed when we support constants in lookups.
     pol commit const_two;
@@ -48,81 +139,145 @@ namespace address_derivation;
     sel * (const_four - 4) = 0;
     pol commit const_thirteen;
     sel * (const_thirteen - 13) = 0;
+    pol commit partial_address_domain_separator;
+    sel * (partial_address_domain_separator - constants.DOM_SEP__PARTIAL_ADDRESS) = 0;
+    pol commit public_keys_hash_domain_separator;
+    sel * (public_keys_hash_domain_separator - constants.DOM_SEP__PUBLIC_KEYS_HASH) = 0;
+    pol commit preaddress_domain_separator;
+    sel * (preaddress_domain_separator - constants.DOM_SEP__CONTRACT_ADDRESS_V1) = 0;
 
+    // 1. Computation of salted initialization hash
+    pol commit salted_init_hash;
+
+    // Since Poseidon2 processes inputs in chunks of 3, we need 2 permutation rounds to cover our 4 inputs:
+    //  salted_init_hash = H(DOM_SEP__PARTIAL_ADDRESS, salt, init_hash, deployer_addr)
+    //   Round 1 (start, input_len=4): (DOM_SEP__PARTIAL_ADDRESS, salt, init_hash)
+    //   Round 2 (end):                (deployer_addr, 0, 0)
+
+    // Enforces the first round of salted_init_hash. Note that we must lookup poseidon2_hash.input_len == 4
+    // here since it is constrained in the poseidon trace on the start row.
     #[SALTED_INITIALIZATION_HASH_POSEIDON2_0]
     sel { partial_address_domain_separator, salt, init_hash, salted_init_hash, const_four }
     in poseidon2_hash.start { poseidon2_hash.input_0, poseidon2_hash.input_1, poseidon2_hash.input_2, poseidon2_hash.output, poseidon2_hash.input_len };
 
+    // Enforces the second and final round of salted_init_hash. Note that we must enforce the padded values are zero here.
     #[SALTED_INITIALIZATION_HASH_POSEIDON2_1]
     sel { deployer_addr, precomputed.zero, precomputed.zero, salted_init_hash }
     in poseidon2_hash.end { poseidon2_hash.input_0, poseidon2_hash.input_1, poseidon2_hash.input_2, poseidon2_hash.output };
 
-
-    // Computation of partial address
-
+    // 2. Computation of partial address
     pol commit partial_address;
 
+    // We have 3 inputs, hence a single Poseidon2 round:
+    //  partial_address = H(DOM_SEP__PARTIAL_ADDRESS, class_id, salted_init_hash)
+    //   Round 1 (start, input_len=3, end): (DOM_SEP__PARTIAL_ADDRESS, class_id, salted_init_hash)
+
+    // Enforces the single round of partial_address. Since input_len=3 fills exactly one permutation,
+    // this start lookup is also the final round and no separate end lookup is needed (the poseidon trace
+    // constrains this using num_perm_rounds_rem).
+    // TODO(MW): Could add sel == end to the lookup tuple to harden/for clarity?
     #[PARTIAL_ADDRESS_POSEIDON2]
     sel { partial_address_domain_separator, class_id, salted_init_hash, partial_address, const_three }
     in poseidon2_hash.start { poseidon2_hash.input_0, poseidon2_hash.input_1, poseidon2_hash.input_2, poseidon2_hash.output, poseidon2_hash.input_len };
 
-
-    // Hash the public keys
-
+    // 3. Computation of public keys hash
     pol commit public_keys_hash;
 
-    // TODO: We need this temporarily while we dont allow for aliases in the lookup tuple
-    pol commit public_keys_hash_domain_separator;
-    sel * (public_keys_hash_domain_separator - constants.DOM_SEP__PUBLIC_KEYS_HASH) = 0;
-
-    // Remove all the 0s for is_infinite when removed from public_keys.nr
+    // TODO(#7529): Remove all the 0s for is_infinity when removed from public_keys.nr
     // https://github.com/AztecProtocol/aztec-packages/issues/7529
+    // TODO(#14031): Compress keys in public_keys_hash
+    // https://github.com/AztecProtocol/aztec-packages/issues/14031
+
+    // We have 13 inputs, hence 5 permutation rounds:
+    //  public_keys_hash = H(DOM_SEP__PUBLIC_KEYS_HASH,
+    //                       nullifier_key_x, nullifier_key_y, 0,
+    //                       incoming_viewing_key_x, incoming_viewing_key_y, 0,
+    //                       outgoing_viewing_key_x, outgoing_viewing_key_y, 0,
+    //                       tagging_key_x, tagging_key_y, 0)
+    //   Round 1 (start, input_len=13): (DOM_SEP__PUBLIC_KEYS_HASH, nullifier_key_x, nullifier_key_y)
+    //   Round 2 (sel, rem=4):          (0, incoming_viewing_key_x, incoming_viewing_key_y)
+    //   Round 3 (sel, rem=3):          (0, outgoing_viewing_key_x, outgoing_viewing_key_y)
+    //   Round 4 (sel, rem=2):          (0, tagging_key_x, tagging_key_y)
+    //   Round 5 (end):                 (0, 0, 0)
+    //  Where each leading 0 is the is_infinity flag for the preceding curve point, and rem =
+    //  poseidon2_hash.num_perm_rounds_rem (the number of hashing rounds remaining), required in each
+    //  lookup to constrain correct ordering of rounds.
+
+    // Enforces the first poseidon round of public_keys_hash. Note that we must lookup poseidon2_hash.input_len == 13
+    // here since it is constrained in the poseidon trace on the start row.
     #[PUBLIC_KEYS_HASH_POSEIDON2_0]
     sel { public_keys_hash_domain_separator, nullifier_key_x, nullifier_key_y, public_keys_hash, const_thirteen }
     in poseidon2_hash.start { poseidon2_hash.input_0, poseidon2_hash.input_1, poseidon2_hash.input_2, poseidon2_hash.output, poseidon2_hash.input_len };
 
+    // Enforces round 2 (poseidon2_hash.input_0 = 0 = nullifier_key_is_infinity).
     #[PUBLIC_KEYS_HASH_POSEIDON2_1]
     sel { precomputed.zero, incoming_viewing_key_x, incoming_viewing_key_y, public_keys_hash, const_four }
     in poseidon2_hash.sel { poseidon2_hash.input_0, poseidon2_hash.input_1, poseidon2_hash.input_2, poseidon2_hash.output, poseidon2_hash.num_perm_rounds_rem };
 
+    // Enforces round 3 (poseidon2_hash.input_0 = 0 = incoming_viewing_key_is_infinity).
     #[PUBLIC_KEYS_HASH_POSEIDON2_2]
     sel { precomputed.zero, outgoing_viewing_key_x, outgoing_viewing_key_y, public_keys_hash, const_three }
     in poseidon2_hash.sel { poseidon2_hash.input_0, poseidon2_hash.input_1, poseidon2_hash.input_2, poseidon2_hash.output, poseidon2_hash.num_perm_rounds_rem };
 
+    // Enforces round 4 (poseidon2_hash.input_0 = 0 = outgoing_viewing_key_is_infinity).
     #[PUBLIC_KEYS_HASH_POSEIDON2_3]
     sel { precomputed.zero, tagging_key_x, tagging_key_y, public_keys_hash, const_two }
     in poseidon2_hash.sel { poseidon2_hash.input_0, poseidon2_hash.input_1, poseidon2_hash.input_2, poseidon2_hash.output, poseidon2_hash.num_perm_rounds_rem };
 
+    // Enforces round 5, the final round. This is a round entirely made of zeros:
+    //  poseidon2_hash.input_0 = 0 = tagging_key_is_infinity
+    //  poseidon2_hash.input_1 = 0 = padding
+    //  poseidon2_hash.input_2 = 0 = padding
     #[PUBLIC_KEYS_HASH_POSEIDON2_4]
     sel { precomputed.zero, precomputed.zero, precomputed.zero, public_keys_hash }
     in poseidon2_hash.end { poseidon2_hash.input_0, poseidon2_hash.input_1, poseidon2_hash.input_2, poseidon2_hash.output };
 
-
-    // Compute the preaddress
-
+    // 4. Computation of preaddress
     pol commit preaddress;
 
-    // TODO: We need this temporarily while we dont allow for aliases in the lookup tuple
-    pol commit preaddress_domain_separator;
-    sel * (preaddress_domain_separator - constants.DOM_SEP__CONTRACT_ADDRESS_V1) = 0;
+    // We have 3 inputs, hence a single Poseidon2 round:
+    //  preaddress = H(DOM_SEP__CONTRACT_ADDRESS_V1, public_keys_hash, partial_address)
+    //   Round 1 (start, input_len=3): (DOM_SEP__CONTRACT_ADDRESS_V1, public_keys_hash, partial_address)
 
+    // Enforces the single round of preaddress. Since input_len=3 fills exactly one permutation,
+    // this start lookup is also the final round and no separate end lookup is needed (the poseidon trace
+    // constrains this using num_perm_rounds_rem).
+    // TODO(MW): Could add sel == end to the lookup tuple to harden/for clarity?
     #[PREADDRESS_POSEIDON2]
     sel { preaddress_domain_separator, public_keys_hash, partial_address, preaddress, const_three }
     in poseidon2_hash.start { poseidon2_hash.input_0, poseidon2_hash.input_1, poseidon2_hash.input_2, poseidon2_hash.output, poseidon2_hash.input_len };
 
 
-    // Derive preaddress public key
+    ///////////////////////////////
+    // Elliptic Curve Operations
+    ///////////////////////////////
+    //
+    // This trace constrains two elliptic curve operations (steps 5 and 6 in above description);
+    //  preaddress_public_key = preaddress * G1
+    //  address               = (preaddress_public_key + incoming_viewing_key).x
+    //
+    // The first derives the preaddress public key via scalar multiplication of the preaddress
+    // (derived as a poseidon hash above) and Grumpkin's generator point G1. This is constrained
+    // through a lookup to scalar_mul.pil.
+    //
+    // The second derives the address point by adding the preaddress public key to the incoming viewing
+    // key, enforced through a lookup to ecc.pil.
+    //
 
-    pol commit preaddress_public_key_x;
-    pol commit preaddress_public_key_y;
-
-    // TODO: We need this temporarily while we dont allow for aliases in the lookup tuple
+    // Lookup constant support: Can be removed when we support constants in lookups.
     pol commit g1_x;
     sel * (g1_x - constants.GRUMPKIN_ONE_X) = 0;
-
     pol commit g1_y;
     sel * (g1_y - constants.GRUMPKIN_ONE_Y) = 0;
 
+    // Derive preaddress public key
+    pol commit preaddress_public_key_x;
+    pol commit preaddress_public_key_y;
+
+    // Enforces preaddress_public_key = preaddress * G1 on Grumpkin.
+    // Note that we can safely set is_infinity as false for both points since G1 is a generator of the curve
+    // (and not inf) so x * G1 would only be infinity if x == 0. Our scalar, the preaddress, is constrained
+    // to be a hash result above and hence near impossible to be zero.
     #[PREADDRESS_SCALAR_MUL]
     sel {
         preaddress,
@@ -134,11 +289,26 @@ namespace address_derivation;
         scalar_mul.res_x, scalar_mul.res_y, scalar_mul.res_inf
     };
 
+    // Enforces the ivk is on the curve:
+    //   - Note that this may not be strictly necessary since the hinted ivk is checked to be on the curve
+    //  during deployment in private through an implicit check in the bb dsl (TODO(MW): Update this when
+    //  checked explicitly).
+    //   - However, the check is a cheap relation which allows us to explicitly meet ecc.pil's precondition.
+    //   - It also enforces the ivk is not the point at infinity, since our (or any) representation
+    //  of it does not satisfy the curve equation.
+    //   - We do not check the preaddress. Since it's derived from G1 above, it must be on the curve.
 
-    // Finally, the address must be the x coordinate of preaddress_public_key + incoming_viewing_key
+    // Y^2 = X^3 − 17, re-formulate to Y^2 - (X^3 - 17) = 0
+    pol X3 = incoming_viewing_key_x * incoming_viewing_key_x * incoming_viewing_key_x;
+    pol Y2 = incoming_viewing_key_y * incoming_viewing_key_y;
+    #[IVK_ON_CURVE_CHECK]
+    sel * (Y2 - (X3 - 17)) = 0;
 
+    // Derive address_point
     pol commit address_y;
 
+    // Enforces address_point = preaddress_public_key + incoming_viewing_key on Grumpkin, and that
+    // address = address_point.x.
     #[ADDRESS_ECADD]
     sel {
         preaddress_public_key_x, preaddress_public_key_y, precomputed.zero,
@@ -150,4 +320,13 @@ namespace address_derivation;
         ecc.r_x, ecc.r_y, ecc.r_is_inf
     };
 
-
+    // TODO(MW): Possibly remove this section, TMI?
+    // Note: We can safely assume the address point is not infinity since that would imply either
+    // the ivk and preaddress public key are both infinity (which they cannot be, as explained above) or
+    // inverses of each other i.e. preaddress_public_key_x == incoming_viewing_key_x, and
+    // preaddress_public_key_y == -incoming_viewing_key_y.
+    // Though the ivk is hinted, we cannot choose it to be the inverse of the preaddress public key.
+    // The preaddress public key is derived from the preaddress, which itself is a hash result containing
+    // the ivk as part of the public_keys_hash preimage.
+    // In other words, we would need to impossibly choose this maliciious ivk 'after' it has been used
+    // to derive the preaddress public key we wish to exploit.

--- a/barretenberg/cpp/pil/vm2/bytecode/address_derivation.pil
+++ b/barretenberg/cpp/pil/vm2/bytecode/address_derivation.pil
@@ -7,7 +7,7 @@ include "../scalar_mul.pil";
 /**
  * This subtrace constrains the derivation of a contract address from its preimage. It is used
  * during contract instance retrieval (contract_instance_retrieval.pil) in our execution flow.
- * The address is defined by the following flow, where the hash fuction H() is Poseidon2, and G1
+ * The address is defined by the following flow, where the hash function H() is Poseidon2, and G1
  * is the Grumpkin curve's generator point:
  *   1. salted_init_hash  = H(DOM_SEP__PARTIAL_ADDRESS, salt, init_hash, deployer_addr)
  *   2. partial_address   = H(DOM_SEP__PARTIAL_ADDRESS, class_id, salted_init_hash)
@@ -198,10 +198,10 @@ namespace address_derivation;
     //   Round 2 (sel, rem=4):          (0, incoming_viewing_key_x, incoming_viewing_key_y)
     //   Round 3 (sel, rem=3):          (0, outgoing_viewing_key_x, outgoing_viewing_key_y)
     //   Round 4 (sel, rem=2):          (0, tagging_key_x, tagging_key_y)
-    //   Round 5 (end):                 (0, 0, 0)
+    //   Round 5 (end):                 (0, padding (= 0), padding (= 0))
     //  Where each leading 0 is the is_infinity flag for the preceding curve point, and rem =
     //  poseidon2_hash.num_perm_rounds_rem (the number of hashing rounds remaining), required in each
-    //  lookup to constrain correct ordering of rounds.
+    //  lookup to constrain correct ordering of rounds. See each round below for individual input details.
 
     // Enforces the first poseidon round of public_keys_hash. Note that we must lookup poseidon2_hash.input_len == 13
     // here since it is constrained in the poseidon trace on the start row.
@@ -325,5 +325,5 @@ namespace address_derivation;
     // Though the ivk is hinted, we cannot choose it to be the inverse of the preaddress public key.
     // The preaddress public key is derived from the preaddress, which itself is a hash result containing
     // the ivk as part of the public_keys_hash preimage.
-    // In other words, we would need to impossibly choose this maliciious ivk 'after' it has been used
+    // In other words, we would need to impossibly choose this malicious ivk 'after' it has been used
     // to derive the preaddress public key we wish to exploit.

--- a/barretenberg/cpp/pil/vm2/bytecode/address_derivation.pil
+++ b/barretenberg/cpp/pil/vm2/bytecode/address_derivation.pil
@@ -25,8 +25,9 @@ include "../scalar_mul.pil";
  * for details on how we enforce each step. This process follows Noir's AztecAddress::compute().
  *
  * Note: DOM_SEP__PARTIAL_ADDRESS is reused for both the salted initialization hash and the partial
- * address computations (steps 1 and 2). TODO(MW): Find out more (possibly just reused to avoid defining more seps -
- * reuse is safe here because the two hashes have different lengths => IVs => cannot collide)
+ * address computations (steps 1 and 2). This cannot lead to a collision since the preimages are of
+ * different lengths, hence will have different IV values. Unfortunately, why this is the case is not
+ * documented in the protocol.
  *
  * PRECONDITIONS: The correctness of the preimage members is not constrained here and must be
  *               enforced by the calling circuits. Like class_id_derivation, this trace can be seen
@@ -175,7 +176,6 @@ namespace address_derivation;
     // Enforces the single round of partial_address. Since input_len=3 fills exactly one permutation,
     // this start lookup is also the final round and no separate end lookup is needed (the poseidon trace
     // constrains this using num_perm_rounds_rem).
-    // TODO(MW): Could add sel == end to the lookup tuple to harden/for clarity?
     #[PARTIAL_ADDRESS_POSEIDON2]
     sel { partial_address_domain_separator, class_id, salted_init_hash, partial_address, const_three }
     in poseidon2_hash.start { poseidon2_hash.input_0, poseidon2_hash.input_1, poseidon2_hash.input_2, poseidon2_hash.output, poseidon2_hash.input_len };
@@ -242,7 +242,6 @@ namespace address_derivation;
     // Enforces the single round of preaddress. Since input_len=3 fills exactly one permutation,
     // this start lookup is also the final round and no separate end lookup is needed (the poseidon trace
     // constrains this using num_perm_rounds_rem).
-    // TODO(MW): Could add sel == end to the lookup tuple to harden/for clarity?
     #[PREADDRESS_POSEIDON2]
     sel { preaddress_domain_separator, public_keys_hash, partial_address, preaddress, const_three }
     in poseidon2_hash.start { poseidon2_hash.input_0, poseidon2_hash.input_1, poseidon2_hash.input_2, poseidon2_hash.output, poseidon2_hash.input_len };
@@ -319,7 +318,6 @@ namespace address_derivation;
         ecc.r_x, ecc.r_y, ecc.r_is_inf
     };
 
-    // TODO(MW): Possibly remove this section, TMI?
     // Note: We can safely assume the address point is not infinity since that would imply either
     // the ivk and preaddress public key are both infinity (which they cannot be, as explained above) or
     // inverses of each other i.e. preaddress_public_key_x == incoming_viewing_key_x, and

--- a/barretenberg/cpp/pil/vm2/bytecode/address_derivation.pil
+++ b/barretenberg/cpp/pil/vm2/bytecode/address_derivation.pil
@@ -291,8 +291,7 @@ namespace address_derivation;
 
     // Enforces the ivk is on the curve:
     //   - Note that this may not be strictly necessary since the hinted ivk is checked to be on the curve
-    //  during deployment in private through an implicit check in the bb dsl (TODO(MW): Update this when
-    //  checked explicitly).
+    //  during deployment in private.
     //   - However, the check is a cheap relation which allows us to explicitly meet ecc.pil's precondition.
     //   - It also enforces the ivk is not the point at infinity, since our (or any) representation
     //  of it does not satisfy the curve equation.

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/relations/address_derivation.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/relations/address_derivation.test.cpp
@@ -3,6 +3,7 @@
 
 #include "barretenberg/crypto/poseidon2/poseidon2.hpp"
 #include "barretenberg/crypto/poseidon2/poseidon2_params.hpp"
+#include "barretenberg/vm2/common/aztec_types.hpp"
 #include "barretenberg/vm2/constraining/flavor_settings.hpp"
 #include "barretenberg/vm2/constraining/testing/check_relation.hpp"
 #include "barretenberg/vm2/generated/columns.hpp"
@@ -142,19 +143,114 @@ TEST(AddressDerivationConstrainingTest, WithInteractions)
     ecc_builder.process_add(ecadd_event_emitter.dump_events(), trace);
     ecc_builder.process_scalar_mul(scalar_mul_event_emitter.dump_events(), trace);
 
-    check_interaction<AddressDerivationTraceBuilder,
-                      lookup_address_derivation_salted_initialization_hash_poseidon2_0_settings,
-                      lookup_address_derivation_salted_initialization_hash_poseidon2_1_settings,
-                      lookup_address_derivation_partial_address_poseidon2_settings,
-                      lookup_address_derivation_public_keys_hash_poseidon2_0_settings,
-                      lookup_address_derivation_public_keys_hash_poseidon2_1_settings,
-                      lookup_address_derivation_public_keys_hash_poseidon2_2_settings,
-                      lookup_address_derivation_public_keys_hash_poseidon2_3_settings,
-                      lookup_address_derivation_public_keys_hash_poseidon2_4_settings,
-                      lookup_address_derivation_preaddress_poseidon2_settings,
-                      lookup_address_derivation_preaddress_scalar_mul_settings,
-                      lookup_address_derivation_address_ecadd_settings>(trace);
+    check_all_interactions<AddressDerivationTraceBuilder>(trace);
     check_relation<address_derivation_relation>(trace);
+}
+
+TEST(AddressDerivationConstrainingTest, NegativeWithInteractions)
+{
+    EventEmitter<EccAddEvent> ecadd_event_emitter;
+    EventEmitter<ScalarMulEvent> scalar_mul_event_emitter;
+    NoopEventEmitter<EccAddMemoryEvent> ecc_add_memory_event_emitter;
+    EventEmitter<Poseidon2HashEvent> hash_event_emitter;
+    NoopEventEmitter<Poseidon2PermutationEvent> perm_event_emitter;
+    NoopEventEmitter<Poseidon2PermutationMemoryEvent> perm_mem_event_emitter;
+    EventEmitter<AddressDerivationEvent> address_derivation_event_emitter;
+
+    StrictMock<MockExecutionIdManager> mock_exec_id_manager;
+    EXPECT_CALL(mock_exec_id_manager, get_execution_id)
+        .WillRepeatedly(Return(0)); // Use a fixed execution ID for the test
+    StrictMock<MockGreaterThan> mock_gt;
+    Poseidon2 poseidon2_simulator(
+        mock_exec_id_manager, mock_gt, hash_event_emitter, perm_event_emitter, perm_mem_event_emitter);
+
+    PureToRadix to_radix_simulator;
+    Ecc ecc_simulator(mock_exec_id_manager,
+                      mock_gt,
+                      to_radix_simulator,
+                      ecadd_event_emitter,
+                      scalar_mul_event_emitter,
+                      ecc_add_memory_event_emitter);
+
+    AddressDerivation address_derivation(poseidon2_simulator, ecc_simulator, address_derivation_event_emitter);
+
+    TestTraceContainer trace({
+        { { C::precomputed_first_row, 1 } },
+    });
+
+    AddressDerivationTraceBuilder builder;
+    Poseidon2TraceBuilder poseidon2_builder;
+    EccTraceBuilder ecc_builder;
+
+    ContractInstance instance = testing::random_contract_instance();
+    AztecAddress address = compute_contract_address(instance);
+    address_derivation.assert_derivation(address, instance);
+
+    builder.process(address_derivation_event_emitter.dump_events(), trace);
+    poseidon2_builder.process_hash(hash_event_emitter.dump_events(), trace);
+    ecc_builder.process_add(ecadd_event_emitter.dump_events(), trace);
+    ecc_builder.process_scalar_mul(scalar_mul_event_emitter.dump_events(), trace);
+
+    check_all_interactions<AddressDerivationTraceBuilder>(trace);
+    check_relation<address_derivation_relation>(trace);
+
+    // Mutate the final address to the wrong value.
+    trace.set(C::address_derivation_address, 0, 1);
+    EXPECT_THROW_WITH_MESSAGE(
+        (check_interaction<AddressDerivationTraceBuilder, lookup_address_derivation_address_ecadd_settings>(trace)),
+        "Failed.*ADDRESS_ECADD. Could not find tuple in destination.");
+
+    // Reset.
+    trace.set(C::address_derivation_address, 0, address);
+    // Mutate the preaddress to the wrong value.
+    trace.set(C::address_derivation_preaddress, 0, 1);
+    // Both the derivation via hash and scalar mul of preaddress * G1 will fail.
+    EXPECT_THROW_WITH_MESSAGE(
+        (check_interaction<AddressDerivationTraceBuilder, lookup_address_derivation_preaddress_poseidon2_settings>(
+            trace)),
+        "Failed.*PREADDRESS_POSEIDON2. Could not find tuple in destination.");
+    EXPECT_THROW_WITH_MESSAGE(
+        (check_interaction<AddressDerivationTraceBuilder, lookup_address_derivation_preaddress_scalar_mul_settings>(
+            trace)),
+        "Failed.*PREADDRESS_SCALAR_MUL. Could not find tuple in destination.");
+}
+
+TEST(AddressDerivationConstrainingTest, NegativeIVKNotOnCurve)
+{
+    TestTraceContainer trace;
+    AddressDerivationTraceBuilder builder;
+
+    auto instance = testing::random_contract_instance();
+
+    // Mutate ivk to a point not on the curve.
+    instance.public_keys.incoming_viewing_key = AffinePoint(1, 2);
+
+    FF salted_initialization_hash =
+        poseidon2::hash({ DOM_SEP__PARTIAL_ADDRESS, instance.salt, instance.initialization_hash, instance.deployer });
+
+    FF partial_address =
+        poseidon2::hash({ DOM_SEP__PARTIAL_ADDRESS, instance.original_contract_class_id, salted_initialization_hash });
+
+    FF public_keys_hash = hash_public_keys(instance.public_keys);
+    FF preaddress = poseidon2::hash({ DOM_SEP__CONTRACT_ADDRESS_V1, public_keys_hash, partial_address });
+
+    EmbeddedCurvePoint g1 = EmbeddedCurvePoint::one();
+    EmbeddedCurvePoint preaddress_public_key = g1 * Fq(preaddress);
+    EmbeddedCurvePoint address_point = preaddress_public_key + instance.public_keys.incoming_viewing_key;
+
+    builder.process({ { .address = address_point.x(),
+                        .instance = instance,
+                        .salted_initialization_hash = salted_initialization_hash,
+                        .partial_address = partial_address,
+                        .public_keys_hash = public_keys_hash,
+                        .preaddress = preaddress,
+                        .preaddress_public_key = preaddress_public_key,
+                        .address_point = address_point } },
+                    trace);
+
+    EXPECT_THROW_WITH_MESSAGE(
+        check_relation<address_derivation_relation>(trace, address_derivation_relation::SR_IVK_ON_CURVE_CHECK),
+        "IVK_ON_CURVE_CHECK");
 }
 
 } // namespace

--- a/barretenberg/cpp/src/barretenberg/vm2/generated/relations/address_derivation.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/generated/relations/address_derivation.hpp
@@ -14,7 +14,7 @@ template <typename FF_> class address_derivationImpl {
   public:
     using FF = FF_;
 
-    static constexpr std::array<size_t, 10> SUBRELATION_PARTIAL_LENGTHS = { 3, 3, 3, 3, 3, 3, 3, 3, 3, 3 };
+    static constexpr std::array<size_t, 11> SUBRELATION_PARTIAL_LENGTHS = { 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 5 };
 
     template <typename AllEntities> inline static bool skip(const AllEntities& in)
     {
@@ -34,9 +34,15 @@ template <typename FF> class address_derivation : public Relation<address_deriva
   public:
     static constexpr const std::string_view NAME = "address_derivation";
 
+    // Subrelation indices constants, to be used in tests.
+    static constexpr size_t SR_IVK_ON_CURVE_CHECK = 10;
+
     static std::string get_subrelation_label(size_t index)
     {
-        switch (index) {}
+        switch (index) {
+        case SR_IVK_ON_CURVE_CHECK:
+            return "IVK_ON_CURVE_CHECK";
+        }
         return std::to_string(index);
     }
 };

--- a/barretenberg/cpp/src/barretenberg/vm2/generated/relations/address_derivation_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/generated/relations/address_derivation_impl.hpp
@@ -21,6 +21,11 @@ void address_derivationImpl<FF_>::accumulate(ContainerOverSubrelations& evals,
     const auto constants_DOM_SEP__PUBLIC_KEYS_HASH = FF(777457226);
     const auto constants_DOM_SEP__PARTIAL_ADDRESS = FF(2103633018);
     const auto constants_DOM_SEP__CONTRACT_ADDRESS_V1 = FF(1788365517);
+    const auto address_derivation_X3 = in.get(C::address_derivation_incoming_viewing_key_x) *
+                                       in.get(C::address_derivation_incoming_viewing_key_x) *
+                                       in.get(C::address_derivation_incoming_viewing_key_x);
+    const auto address_derivation_Y2 =
+        in.get(C::address_derivation_incoming_viewing_key_y) * in.get(C::address_derivation_incoming_viewing_key_y);
 
     {
         using View = typename std::tuple_element_t<0, ContainerOverSubrelations>::View;
@@ -31,32 +36,32 @@ void address_derivationImpl<FF_>::accumulate(ContainerOverSubrelations& evals,
     {
         using View = typename std::tuple_element_t<1, ContainerOverSubrelations>::View;
         auto tmp = static_cast<View>(in.get(C::address_derivation_sel)) *
-                   (static_cast<View>(in.get(C::address_derivation_partial_address_domain_separator)) -
-                    CView(constants_DOM_SEP__PARTIAL_ADDRESS));
+                   (static_cast<View>(in.get(C::address_derivation_const_two)) - FF(2));
         std::get<1>(evals) += (tmp * scaling_factor);
     }
     {
         using View = typename std::tuple_element_t<2, ContainerOverSubrelations>::View;
         auto tmp = static_cast<View>(in.get(C::address_derivation_sel)) *
-                   (static_cast<View>(in.get(C::address_derivation_const_two)) - FF(2));
+                   (static_cast<View>(in.get(C::address_derivation_const_three)) - FF(3));
         std::get<2>(evals) += (tmp * scaling_factor);
     }
     {
         using View = typename std::tuple_element_t<3, ContainerOverSubrelations>::View;
         auto tmp = static_cast<View>(in.get(C::address_derivation_sel)) *
-                   (static_cast<View>(in.get(C::address_derivation_const_three)) - FF(3));
+                   (static_cast<View>(in.get(C::address_derivation_const_four)) - FF(4));
         std::get<3>(evals) += (tmp * scaling_factor);
     }
     {
         using View = typename std::tuple_element_t<4, ContainerOverSubrelations>::View;
         auto tmp = static_cast<View>(in.get(C::address_derivation_sel)) *
-                   (static_cast<View>(in.get(C::address_derivation_const_four)) - FF(4));
+                   (static_cast<View>(in.get(C::address_derivation_const_thirteen)) - FF(13));
         std::get<4>(evals) += (tmp * scaling_factor);
     }
     {
         using View = typename std::tuple_element_t<5, ContainerOverSubrelations>::View;
         auto tmp = static_cast<View>(in.get(C::address_derivation_sel)) *
-                   (static_cast<View>(in.get(C::address_derivation_const_thirteen)) - FF(13));
+                   (static_cast<View>(in.get(C::address_derivation_partial_address_domain_separator)) -
+                    CView(constants_DOM_SEP__PARTIAL_ADDRESS));
         std::get<5>(evals) += (tmp * scaling_factor);
     }
     {
@@ -84,6 +89,12 @@ void address_derivationImpl<FF_>::accumulate(ContainerOverSubrelations& evals,
         auto tmp = static_cast<View>(in.get(C::address_derivation_sel)) *
                    (static_cast<View>(in.get(C::address_derivation_g1_y)) - CView(constants_GRUMPKIN_ONE_Y));
         std::get<9>(evals) += (tmp * scaling_factor);
+    }
+    { // IVK_ON_CURVE_CHECK
+        using View = typename std::tuple_element_t<10, ContainerOverSubrelations>::View;
+        auto tmp = static_cast<View>(in.get(C::address_derivation_sel)) *
+                   (CView(address_derivation_Y2) - (CView(address_derivation_X3) - FF(17)));
+        std::get<10>(evals) += (tmp * scaling_factor);
     }
 }
 

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/events/address_derivation_event.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/events/address_derivation_event.hpp
@@ -6,14 +6,14 @@
 namespace bb::avm2::simulation {
 
 struct AddressDerivationEvent {
-    AztecAddress address;
-    ContractInstance instance;
-    FF salted_initialization_hash;
-    FF partial_address;
-    FF public_keys_hash;
-    FF preaddress;
-    EmbeddedCurvePoint preaddress_public_key;
-    EmbeddedCurvePoint address_point;
+    AztecAddress address = 0;
+    ContractInstance instance{};
+    FF salted_initialization_hash = 0;
+    FF partial_address = 0;
+    FF public_keys_hash = 0;
+    FF preaddress = 0;
+    EmbeddedCurvePoint preaddress_public_key = EmbeddedCurvePoint::infinity();
+    EmbeddedCurvePoint address_point = EmbeddedCurvePoint::infinity();
 };
 
 } // namespace bb::avm2::simulation

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/address_derivation.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/address_derivation.cpp
@@ -7,43 +7,79 @@
 
 namespace bb::avm2::simulation {
 
+/**
+ * @brief Verifies a contract instance's address derivation and emits an AddressDerivationEvent.
+ * Corresponds to the subtrace address_derivation.pil.
+ *
+ * If the address has already been derived, an event has already been emitted and we skip
+ * repeating the computation and emission. Otherwise, we compute the address from the instance
+ * members using the poseidon2, scalar_mul, and ecc traces, which is given as:
+ *   1. salted_init_hash  = Poseidon2(DOM_SEP__PARTIAL_ADDRESS, salt, init_hash, deployer_addr)
+ *   2. partial_address   = Poseidon2(DOM_SEP__PARTIAL_ADDRESS, class_id, salted_init_hash)
+ *   3. public_keys_hash  = Poseidon2(DOM_SEP__PUBLIC_KEYS_HASH, [...public_keys.to_fields()])
+ *   4. preaddress        = Poseidon2(DOM_SEP__CONTRACT_ADDRESS_V1, public_keys_hash, partial_address)
+ *   5. preaddress_public_key = preaddress * G1  (Grumpkin scalar multiplication)
+ *   6. address           = (preaddress_public_key + incoming_viewing_key).x  (Grumpkin EC add)
+ *  and we add the output to the local cache.
+ *
+ * @throws Unexpected exception if
+ *        - the calculated address does not match @p address.
+ *
+ * @param address The expected derived address.
+ * @param instance The contract instance containing the address preimage.
+ */
 void AddressDerivation::assert_derivation(const AztecAddress& address, const ContractInstance& instance)
 {
-    // Check if we've already derived this address
+    // Check if we've already derived this address.
     if (cached_derivations.contains(address)) {
-        // Already processed this address - cache hit, don't emit event
+        // Already processed this address - cache hit, don't emit event.
         return;
     }
 
-    // First time seeing this address - do the actual derivation
+    // First time seeing this address - do the actual derivation.
+    // Emits Poseidon2HashEvents and Poseidon2PermutationEvents, see #[SALTED_INITIALIZATION_HASH_POSEIDON2_i] in
+    // address_derivation.pil.
     FF salted_initialization_hash =
         poseidon2.hash({ DOM_SEP__PARTIAL_ADDRESS, instance.salt, instance.initialization_hash, instance.deployer });
-
+    // Emits Poseidon2HashEvents and Poseidon2PermutationEvents, see #[PARTIAL_ADDRESS_POSEIDON2] in
+    // address_derivation.pil.
     FF partial_address =
         poseidon2.hash({ DOM_SEP__PARTIAL_ADDRESS, instance.original_contract_class_id, salted_initialization_hash });
 
     std::vector<FF> public_keys_hash_fields = instance.public_keys.to_fields();
     std::vector<FF> public_key_hash_vec{ DOM_SEP__PUBLIC_KEYS_HASH };
     for (size_t i = 0; i < public_keys_hash_fields.size(); i += 2) {
+        // Public key x coordinate.
         public_key_hash_vec.push_back(public_keys_hash_fields[i]);
+        // Public key y coordinate.
         public_key_hash_vec.push_back(public_keys_hash_fields[i + 1]);
-        // is_infinity will be removed from address preimage, asumming false.
+        // TODO(#7529): Public key is_infinity will be removed from address preimage, assuming false.
         public_key_hash_vec.push_back(FF::zero());
     }
+    // Emits Poseidon2HashEvents and Poseidon2PermutationEvents, see #[PUBLIC_KEYS_HASH_POSEIDON2_i] in
+    // address_derivation.pil.
     FF public_keys_hash = poseidon2.hash(public_key_hash_vec);
-
+    // Emits Poseidon2HashEvents and Poseidon2PermutationEvents, see #[PREADDRESS_POSEIDON2] in address_derivation.pil.
     FF preaddress = poseidon2.hash({ DOM_SEP__CONTRACT_ADDRESS_V1, public_keys_hash, partial_address });
 
     // Note: the below ecc calls assume points are on the curve. We know preaddress_public_key is (by definition),
     // but it may be possible that incoming_viewing_key is not.
+    // The circuit enforces that the point is on the curve to meet ecc's precondition. Here, ecc will throw an
+    // unexpected exception (TODO(MW): add an assert here to match with circuit?).
+
+    // Emits ScalarMulEvent and EccAddEvents, see #[PREADDRESS_SCALAR_MUL] in address_derivation.pil.
     EmbeddedCurvePoint preaddress_public_key = ecc.scalar_mul(EmbeddedCurvePoint::one(), preaddress);
+    // Emits EccAddEvent, see #[ADDRESS_ECADD] in address_derivation.pil.
     EmbeddedCurvePoint address_point = ecc.add(preaddress_public_key, instance.public_keys.incoming_viewing_key);
 
+    // This will throw an unexpected exception if it fails. If we have reached this point,
+    // the contract instance retrieval should have enforced this.
     BB_ASSERT_EQ(address, address_point.x(), "Address derivation mismatch");
 
     // Cache this derivation so we don't repeat it
     cached_derivations.insert(address);
 
+    // Emits AddressDerivationEvent.
     events.emit({
         .address = address,
         .instance = instance,

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/address_derivation.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/address_derivation.cpp
@@ -32,6 +32,11 @@ void AddressDerivation::assert_derivation(const AztecAddress& address, const Con
 {
     // Check if we've already derived this address.
     if (cached_derivations.contains(address)) {
+        // TODO(MW): This ignores the input instance, so if we have derived addr_a for instance A and call this
+        // again with addr_a but instance B, it will not fail and simply return. However calling this with addr_a and
+        // instance B /first/ will throw a runtime error. Neither case emits an event but only case throws -
+        // completeness issue?
+
         // Already processed this address - cache hit, don't emit event.
         return;
     }

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/address_derivation.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/address_derivation.cpp
@@ -4,7 +4,7 @@
 
 #include "barretenberg/vm2/common/aztec_constants.hpp"
 #include "barretenberg/vm2/common/field.hpp"
-// #include "barretenberg/vm2/simulation/lib/contract_crypto.hpp"
+#include "barretenberg/vm2/simulation/lib/contract_crypto.hpp"
 
 namespace bb::avm2::simulation {
 
@@ -33,9 +33,10 @@ void AddressDerivation::assert_derivation(const AztecAddress& address, const Con
 {
     // Check if we've already derived this address.
     if (cached_derivations.contains(address)) {
-        // TODO(MW): Is the below too heavy to exist here? Otherwise, we won't throw for a mismatch, unlike in the
-        // non-cache case, or need to store the whole instance in cached_derivations.
-        // BB_ASSERT_EQ(address, simulation::compute_contract_address(instance), "Address derivation mismatch");
+        // Note: it is likely safe to skip this recalculation, but if we do, then a mismatch will throw in the
+        // non-cache case and return in the cache case for the same input. No events are emitted either way, so
+        // circuit and tracegen behave the same. The below exists just to unify simulation behaviour (#21374).
+        BB_ASSERT_EQ(address, simulation::compute_contract_address(instance), "Address derivation mismatch");
         // Already processed this address - cache hit, don't emit event.
         return;
     }

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/address_derivation.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/address_derivation.cpp
@@ -68,8 +68,9 @@ void AddressDerivation::assert_derivation(const AztecAddress& address, const Con
 
     // Note: the below ecc calls assume points are on the curve. We know preaddress_public_key is (by definition),
     // but it may be possible that incoming_viewing_key is not.
-    // The circuit enforces that the point is on the curve to meet ecc's precondition. Here, ecc will throw an
-    // unexpected exception (TODO(MW): add an assert here to match with circuit?).
+    // The circuit enforces that the point is on the curve to meet ecc's precondition and we replicate this here.
+    BB_ASSERT(instance.public_keys.incoming_viewing_key.on_curve(),
+              "Incoming viewing key is not on the curve when asserting contract address derivation");
 
     // Emits ScalarMulEvent and EccAddEvents, see #[PREADDRESS_SCALAR_MUL] in address_derivation.pil.
     EmbeddedCurvePoint preaddress_public_key = ecc.scalar_mul(EmbeddedCurvePoint::one(), preaddress);

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/address_derivation.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/address_derivation.cpp
@@ -4,6 +4,7 @@
 
 #include "barretenberg/vm2/common/aztec_constants.hpp"
 #include "barretenberg/vm2/common/field.hpp"
+// #include "barretenberg/vm2/simulation/lib/contract_crypto.hpp"
 
 namespace bb::avm2::simulation {
 
@@ -32,11 +33,9 @@ void AddressDerivation::assert_derivation(const AztecAddress& address, const Con
 {
     // Check if we've already derived this address.
     if (cached_derivations.contains(address)) {
-        // TODO(MW): This ignores the input instance, so if we have derived addr_a for instance A and call this
-        // again with addr_a but instance B, it will not fail and simply return. However calling this with addr_a and
-        // instance B /first/ will throw a runtime error. Neither case emits an event but only case throws -
-        // completeness issue?
-
+        // TODO(MW): Is the below too heavy to exist here? Otherwise, we won't throw for a mismatch, unlike in the
+        // non-cache case, or need to store the whole instance in cached_derivations.
+        // BB_ASSERT_EQ(address, simulation::compute_contract_address(instance), "Address derivation mismatch");
         // Already processed this address - cache hit, don't emit event.
         return;
     }

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/address_derivation.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/address_derivation.test.cpp
@@ -54,7 +54,7 @@ TEST(AvmSimulationAddressDerivationTest, Positive)
     for (size_t i = 0; i < public_keys_hash_fields.size(); i += 2) {
         public_key_hash_vec.push_back(public_keys_hash_fields[i]);
         public_key_hash_vec.push_back(public_keys_hash_fields[i + 1]);
-        // is_infinity will be removed from address preimage, asumming false.
+        // TODO(#7529): is_infinity will be removed from address preimage, asumming false.
         public_key_hash_vec.push_back(FF::zero());
     }
     FF public_keys_hash = poseidon2::hash(public_key_hash_vec);

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/address_derivation.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/address_derivation.test.cpp
@@ -119,7 +119,7 @@ TEST(AvmSimulationAddressDerivationTest, Negative)
     // Should fail on incorrect derived address.
     EXPECT_THROW(address_derivation.assert_derivation(derived_address + 1, instance), std::runtime_error);
 
-    // Should fail on mutated instance.
+    // Should fail on mutated instance for unseen address.
     instance.public_keys.nullifier_key = AffinePoint::one();
 
     public_keys_hash = hash_public_keys(instance.public_keys);
@@ -132,24 +132,28 @@ TEST(AvmSimulationAddressDerivationTest, Negative)
     EXPECT_CALL(ecc, add(preaddress_public_key, EmbeddedCurvePoint(instance.public_keys.incoming_viewing_key)))
         .WillOnce(Return(address_point));
 
+    // The below fails and does not emit an event.
     EXPECT_THROW(address_derivation.assert_derivation(derived_address, instance), std::runtime_error);
     EXPECT_THAT(address_derivation_event_emitter.dump_events(), IsEmpty());
 
-    // TODO(MW): Rework below once behaviour unified.
-
-    // Perform a successful deriv for the instance above.
+    // Perform a successful derivation for the mutated instance above.
     EXPECT_CALL(ecc, scalar_mul(g1, preaddress)).WillOnce(Return(preaddress_public_key));
     EXPECT_CALL(ecc, add(preaddress_public_key, EmbeddedCurvePoint(instance.public_keys.incoming_viewing_key)))
         .WillOnce(Return(address_point));
+    // The below succeeds, emits an event, and stores the address in the cached_derivations cache.
     address_derivation.assert_derivation(address_point.x(), instance);
     EXPECT_THAT(address_derivation_event_emitter.dump_events(), SizeIs(1));
 
-    // Now, calling with a mismatch on address_point.x() does not fail, because it's cached:
-    ContractInstance new_instance = testing::random_contract_instance();
-    address_derivation.assert_derivation(address_point.x(), new_instance);
+    // Should fail on mutated instance for seen address.
+    ContractInstance new_instance = instance;
+    new_instance.deployer += 1;
+    // Note: EXPECT_CALLs not required since the address is cached.
+    EXPECT_THROW(address_derivation.assert_derivation(address_point.x(), new_instance), std::runtime_error);
+    EXPECT_THAT(address_derivation_event_emitter.dump_events(), IsEmpty());
 
-    // Which is the same behaviour as a successful cached derivation:
+    // The below succeeds and hits the cache, so does not emit an event.
     address_derivation.assert_derivation(address_point.x(), instance);
+    EXPECT_THAT(address_derivation_event_emitter.dump_events(), IsEmpty());
 }
 
 } // namespace

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/address_derivation.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/address_derivation.test.cpp
@@ -3,6 +3,7 @@
 #include <cstdint>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include <stdexcept>
 
 #include "barretenberg/crypto/poseidon2/poseidon2.hpp"
 #include "barretenberg/crypto/poseidon2/poseidon2_params.hpp"
@@ -49,15 +50,7 @@ TEST(AvmSimulationAddressDerivationTest, Positive)
                                                salted_init_hash };
     FF partial_address = poseidon2::hash(partial_address_inputs);
 
-    std::vector<FF> public_keys_hash_fields = instance.public_keys.to_fields();
-    std::vector<FF> public_key_hash_vec{ DOM_SEP__PUBLIC_KEYS_HASH };
-    for (size_t i = 0; i < public_keys_hash_fields.size(); i += 2) {
-        public_key_hash_vec.push_back(public_keys_hash_fields[i]);
-        public_key_hash_vec.push_back(public_keys_hash_fields[i + 1]);
-        // TODO(#7529): is_infinity will be removed from address preimage, asumming false.
-        public_key_hash_vec.push_back(FF::zero());
-    }
-    FF public_keys_hash = poseidon2::hash(public_key_hash_vec);
+    FF public_keys_hash = hash_public_keys(instance.public_keys);
 
     std::vector<FF> preaddress_inputs = { DOM_SEP__CONTRACT_ADDRESS_V1, public_keys_hash, partial_address };
     FF preaddress = poseidon2::hash(preaddress_inputs);
@@ -74,14 +67,89 @@ TEST(AvmSimulationAddressDerivationTest, Positive)
 
     auto events = address_derivation_event_emitter.dump_events();
     EXPECT_THAT(events, SizeIs(1));
-    EXPECT_THAT(events[0].instance, instance);
-    EXPECT_THAT(events[0].address, derived_address);
-    EXPECT_THAT(events[0].address_point.x(), derived_address);
+    EXPECT_EQ(events[0].instance, instance);
+    EXPECT_EQ(events[0].salted_initialization_hash, salted_init_hash);
+    EXPECT_EQ(events[0].partial_address, partial_address);
+    EXPECT_EQ(events[0].public_keys_hash, public_keys_hash);
+    EXPECT_EQ(events[0].preaddress, preaddress);
+    EXPECT_EQ(events[0].preaddress_public_key, preaddress_public_key);
+    EXPECT_EQ(events[0].address, derived_address);
+    EXPECT_EQ(events[0].address_point.x(), derived_address);
 
     // Second derivation for the same address should be a cache hit and should not emit an event
     address_derivation.assert_derivation(derived_address, instance);
     events = address_derivation_event_emitter.dump_events();
     EXPECT_THAT(events, IsEmpty());
+}
+
+TEST(AvmSimulationAddressDerivationTest, Negative)
+{
+    EventEmitter<AddressDerivationEvent> address_derivation_event_emitter;
+    PurePoseidon2 poseidon2 = PurePoseidon2();
+    StrictMock<MockEcc> ecc;
+
+    AddressDerivation address_derivation(poseidon2, ecc, address_derivation_event_emitter);
+
+    ContractInstance instance = testing::random_contract_instance();
+    AztecAddress derived_address = compute_contract_address(instance);
+
+    std::vector<FF> salted_init_hash_inputs = {
+        DOM_SEP__PARTIAL_ADDRESS, instance.salt, instance.initialization_hash, instance.deployer
+    };
+    FF salted_init_hash = poseidon2::hash(salted_init_hash_inputs);
+
+    std::vector<FF> partial_address_inputs = { DOM_SEP__PARTIAL_ADDRESS,
+                                               instance.original_contract_class_id,
+                                               salted_init_hash };
+    FF partial_address = poseidon2::hash(partial_address_inputs);
+
+    FF public_keys_hash = hash_public_keys(instance.public_keys);
+
+    std::vector<FF> preaddress_inputs = { DOM_SEP__CONTRACT_ADDRESS_V1, public_keys_hash, partial_address };
+    FF preaddress = poseidon2::hash(preaddress_inputs);
+
+    EmbeddedCurvePoint g1 = EmbeddedCurvePoint::one();
+    EmbeddedCurvePoint preaddress_public_key = g1 * Fq(preaddress);
+    EXPECT_CALL(ecc, scalar_mul(g1, preaddress)).WillOnce(Return(preaddress_public_key));
+
+    EmbeddedCurvePoint address_point = preaddress_public_key + instance.public_keys.incoming_viewing_key;
+    EXPECT_CALL(ecc, add(preaddress_public_key, EmbeddedCurvePoint(instance.public_keys.incoming_viewing_key)))
+        .WillOnce(Return(address_point));
+
+    // Should fail on incorrect derived address.
+    EXPECT_THROW(address_derivation.assert_derivation(derived_address + 1, instance), std::runtime_error);
+
+    // Should fail on mutated instance.
+    instance.public_keys.nullifier_key = AffinePoint::one();
+
+    public_keys_hash = hash_public_keys(instance.public_keys);
+    preaddress_inputs = { DOM_SEP__CONTRACT_ADDRESS_V1, public_keys_hash, partial_address };
+    preaddress = poseidon2::hash(preaddress_inputs);
+    preaddress_public_key = g1 * Fq(preaddress);
+    address_point = preaddress_public_key + instance.public_keys.incoming_viewing_key;
+
+    EXPECT_CALL(ecc, scalar_mul(g1, preaddress)).WillOnce(Return(preaddress_public_key));
+    EXPECT_CALL(ecc, add(preaddress_public_key, EmbeddedCurvePoint(instance.public_keys.incoming_viewing_key)))
+        .WillOnce(Return(address_point));
+
+    EXPECT_THROW(address_derivation.assert_derivation(derived_address, instance), std::runtime_error);
+    EXPECT_THAT(address_derivation_event_emitter.dump_events(), IsEmpty());
+
+    // TODO(MW): Possible completeness issue:
+
+    // Perform a successful deriv for the instance above.
+    EXPECT_CALL(ecc, scalar_mul(g1, preaddress)).WillOnce(Return(preaddress_public_key));
+    EXPECT_CALL(ecc, add(preaddress_public_key, EmbeddedCurvePoint(instance.public_keys.incoming_viewing_key)))
+        .WillOnce(Return(address_point));
+    address_derivation.assert_derivation(address_point.x(), instance);
+    EXPECT_THAT(address_derivation_event_emitter.dump_events(), SizeIs(1));
+
+    // Now, calling with a mismatch on address_point.x() does not fail, because it's cached:
+    ContractInstance new_instance = testing::random_contract_instance();
+    address_derivation.assert_derivation(address_point.x(), new_instance);
+
+    // Which is the same behaviour as a successful cached derivation:
+    address_derivation.assert_derivation(address_point.x(), instance);
 }
 
 } // namespace

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/address_derivation.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/address_derivation.test.cpp
@@ -135,7 +135,7 @@ TEST(AvmSimulationAddressDerivationTest, Negative)
     EXPECT_THROW(address_derivation.assert_derivation(derived_address, instance), std::runtime_error);
     EXPECT_THAT(address_derivation_event_emitter.dump_events(), IsEmpty());
 
-    // TODO(MW): Possible completeness issue:
+    // TODO(MW): Rework below once behaviour unified.
 
     // Perform a successful deriv for the instance above.
     EXPECT_CALL(ecc, scalar_mul(g1, preaddress)).WillOnce(Return(preaddress_public_key));

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/concrete_dbs.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/concrete_dbs.cpp
@@ -10,6 +10,7 @@ namespace bb::avm2::simulation {
 // Contracts DB starts.
 std::optional<ContractInstance> ContractDB::get_contract_instance(const AztecAddress& address) const
 {
+    // Get the contract instance from the raw DB.
     std::optional<ContractInstance> instance = raw_contract_db.get_contract_instance(address);
     // If we didn't get a contract instance, we don't prove anything.
     // It is the responsibility of the caller to prove what the protocol expects.
@@ -20,6 +21,7 @@ std::optional<ContractInstance> ContractDB::get_contract_instance(const AztecAdd
     // For protocol contracts the input address is the canonical address, we need to retrieve the derived address.
     AztecAddress derived_address;
     if (is_protocol_contract_address(address)) {
+        // Extract the stored derived address from the protocol contract.
         auto maybe_derived = get_derived_address(protocol_contracts, address);
         BB_ASSERT(maybe_derived.has_value(),
                   "Derived address should be found for protocol contract whose instance is found");
@@ -27,6 +29,10 @@ std::optional<ContractInstance> ContractDB::get_contract_instance(const AztecAdd
     } else {
         derived_address = address;
     }
+
+    // Perform address derivation to verify the derived_address is correctly calculated from the instance.
+    // Emits AddressDerivationEvent (and corresponding Poseidon2HashEvents, Poseidon2PermutationEvents, ScalarMulEvent,
+    // and EccAddEvents) if we have yet to derive it.
     address_derivation.assert_derivation(derived_address, instance.value());
     return instance;
 }

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/concrete_dbs.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/concrete_dbs.cpp
@@ -32,7 +32,7 @@ std::optional<ContractInstance> ContractDB::get_contract_instance(const AztecAdd
 
     // Perform address derivation to verify the derived_address is correctly calculated from the instance.
     // Emits AddressDerivationEvent (and corresponding Poseidon2HashEvents, Poseidon2PermutationEvents, ScalarMulEvent,
-    // and EccAddEvents) if we have yet to derive it.
+    // and EccAddEvents) if we have yet to derive it. Otherwise, ignores the instance and simply returns.
     address_derivation.assert_derivation(derived_address, instance.value());
     return instance;
 }

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/lib/contract_crypto.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/lib/contract_crypto.cpp
@@ -82,7 +82,7 @@ FF hash_public_keys(const PublicKeys& public_keys)
     for (size_t i = 0; i < public_keys_hash_fields.size(); i += 2) {
         public_key_hash_vec.push_back(public_keys_hash_fields[i]);
         public_key_hash_vec.push_back(public_keys_hash_fields[i + 1]);
-        // is_infinity will be removed from address preimage, asumming false.
+        // TODO(#7529): is_infinity will be removed from address preimage, asumming false.
         public_key_hash_vec.push_back(FF::zero());
     }
     return poseidon2::hash({ public_key_hash_vec });

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/lib/contract_crypto.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/lib/contract_crypto.cpp
@@ -82,12 +82,14 @@ FF hash_public_keys(const PublicKeys& public_keys)
     for (size_t i = 0; i < public_keys_hash_fields.size(); i += 2) {
         public_key_hash_vec.push_back(public_keys_hash_fields[i]);
         public_key_hash_vec.push_back(public_keys_hash_fields[i + 1]);
-        // TODO(#7529): is_infinity will be removed from address preimage, asumming false.
+        // TODO(#7529): is_infinity will be removed from address preimage, assuming false.
         public_key_hash_vec.push_back(FF::zero());
     }
     return poseidon2::hash({ public_key_hash_vec });
 }
 
+// Computes a contract instance's derived address. Follows method of AddressDerivation::assert_derivation() (noir's
+// AztecAddress::compute()).
 FF compute_contract_address(const ContractInstance& contract_instance)
 {
     FF salted_initialization_hash = poseidon2::hash({ DOM_SEP__PARTIAL_ADDRESS,

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/address_derivation_trace.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/address_derivation_trace.cpp
@@ -3,7 +3,6 @@
 #include <memory>
 
 #include "barretenberg/vm2/common/aztec_constants.hpp"
-#include "barretenberg/vm2/common/aztec_types.hpp"
 #include "barretenberg/vm2/common/field.hpp"
 #include "barretenberg/vm2/generated/relations/lookups_address_derivation.hpp"
 #include "barretenberg/vm2/simulation/events/address_derivation_event.hpp"
@@ -13,6 +12,22 @@
 
 namespace bb::avm2::tracegen {
 
+/**
+ * @brief Process address derivation events and populate the relevant columns in the trace.
+ *  Corresponds to the subtrace address_derivation.pil.
+ *
+ *  This trace is non memory-aware and does not handle any errors. It relies on the poseidon2,
+ *  scalar_mul, and ecc traces to constrain correctness of the address, which is derived as:
+ *   1. salted_init_hash  = Poseidon2(DOM_SEP__PARTIAL_ADDRESS, salt, init_hash, deployer_addr)
+ *   2. partial_address   = Poseidon2(DOM_SEP__PARTIAL_ADDRESS, class_id, salted_init_hash)
+ *   3. public_keys_hash  = Poseidon2(DOM_SEP__PUBLIC_KEYS_HASH, [...public_keys.to_fields()])
+ *   4. preaddress        = Poseidon2(DOM_SEP__CONTRACT_ADDRESS_V1, public_keys_hash, partial_address)
+ *   5. preaddress_public_key = preaddress * G1  (Grumpkin scalar multiplication)
+ *   6. address           = (preaddress_public_key + incoming_viewing_key).x  (Grumpkin EC add)
+ *
+ * @param events The container of address derivation events to process.
+ * @param trace The trace container.
+ */
 void AddressDerivationTraceBuilder::process(
     const simulation::EventEmitterInterface<simulation::AddressDerivationEvent>::Container& events,
     TraceContainer& trace)
@@ -26,10 +41,14 @@ void AddressDerivationTraceBuilder::process(
         trace.set(
             row,
             { { { C::address_derivation_sel, 1 },
+                // Address.
+                { C::address_derivation_address, event.address },
+                // Contract instance members.
                 { C::address_derivation_salt, event.instance.salt },
                 { C::address_derivation_deployer_addr, event.instance.deployer },
                 { C::address_derivation_class_id, event.instance.original_contract_class_id },
                 { C::address_derivation_init_hash, event.instance.initialization_hash },
+                // Public keys (Grumpkin curve points).
                 { C::address_derivation_nullifier_key_x, event.instance.public_keys.nullifier_key.x },
                 { C::address_derivation_nullifier_key_y, event.instance.public_keys.nullifier_key.y },
                 { C::address_derivation_incoming_viewing_key_x, event.instance.public_keys.incoming_viewing_key.x },
@@ -38,23 +57,25 @@ void AddressDerivationTraceBuilder::process(
                 { C::address_derivation_outgoing_viewing_key_y, event.instance.public_keys.outgoing_viewing_key.y },
                 { C::address_derivation_tagging_key_x, event.instance.public_keys.tagging_key.x },
                 { C::address_derivation_tagging_key_y, event.instance.public_keys.tagging_key.y },
-                { C::address_derivation_address, event.address },
+                // Intermediate hash results.
                 { C::address_derivation_salted_init_hash, event.salted_initialization_hash },
+                { C::address_derivation_partial_address, event.partial_address },
+                { C::address_derivation_public_keys_hash, event.public_keys_hash },
+                { C::address_derivation_preaddress, event.preaddress },
+                // Intermediate EC results.
+                { C::address_derivation_preaddress_public_key_x, event.preaddress_public_key.x() },
+                { C::address_derivation_preaddress_public_key_y, event.preaddress_public_key.y() },
+                { C::address_derivation_address_y, event.address_point.y() },
+                // Constant columns (this is temp because aliasing is not allowed in lookups).
                 { C::address_derivation_partial_address_domain_separator, DOM_SEP__PARTIAL_ADDRESS },
+                { C::address_derivation_public_keys_hash_domain_separator, DOM_SEP__PUBLIC_KEYS_HASH },
+                { C::address_derivation_preaddress_domain_separator, DOM_SEP__CONTRACT_ADDRESS_V1 },
+                { C::address_derivation_g1_x, g1.x() },
+                { C::address_derivation_g1_y, g1.y() },
                 { C::address_derivation_const_two, 2 },
                 { C::address_derivation_const_three, 3 },
                 { C::address_derivation_const_four, 4 },
-                { C::address_derivation_const_thirteen, 13 },
-                { C::address_derivation_partial_address, event.partial_address },
-                { C::address_derivation_public_keys_hash, event.public_keys_hash },
-                { C::address_derivation_public_keys_hash_domain_separator, DOM_SEP__PUBLIC_KEYS_HASH },
-                { C::address_derivation_preaddress, event.preaddress },
-                { C::address_derivation_preaddress_domain_separator, DOM_SEP__CONTRACT_ADDRESS_V1 },
-                { C::address_derivation_preaddress_public_key_x, event.preaddress_public_key.x() },
-                { C::address_derivation_preaddress_public_key_y, event.preaddress_public_key.y() },
-                { C::address_derivation_g1_x, g1.x() },
-                { C::address_derivation_g1_y, g1.y() },
-                { C::address_derivation_address_y, event.address_point.y() } } });
+                { C::address_derivation_const_thirteen, 13 } } });
         row++;
     }
 }

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/address_derivation_trace.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/address_derivation_trace.test.cpp
@@ -1,0 +1,81 @@
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <cstdint>
+
+#include "barretenberg/vm2/common/aztec_constants.hpp"
+#include "barretenberg/vm2/common/aztec_types.hpp"
+#include "barretenberg/vm2/common/field.hpp"
+#include "barretenberg/vm2/constraining/flavor_settings.hpp"
+#include "barretenberg/vm2/constraining/full_row.hpp"
+#include "barretenberg/vm2/simulation/events/address_derivation_event.hpp"
+#include "barretenberg/vm2/testing/fixtures.hpp"
+#include "barretenberg/vm2/testing/macros.hpp"
+#include "barretenberg/vm2/tracegen/address_derivation_trace.hpp"
+#include "barretenberg/vm2/tracegen/test_trace_container.hpp"
+
+namespace bb::avm2::tracegen {
+namespace {
+
+using ::testing::ElementsAre;
+
+using R = TestTraceContainer::Row;
+
+TEST(AddressDerivationTraceGenTest, TraceGeneration)
+{
+    TestTraceContainer trace;
+    AddressDerivationTraceBuilder builder;
+
+    ContractInstance instance = testing::random_contract_instance();
+
+    EmbeddedCurvePoint preaddress_public_key = EmbeddedCurvePoint::one() * Fq(56);
+    EmbeddedCurvePoint address_point = EmbeddedCurvePoint::one() * Fq(67);
+
+    simulation::AddressDerivationEvent addr_event{ .address = FF(0xdeadbeef),
+                                                   .instance = instance,
+                                                   .salted_initialization_hash = FF(12),
+                                                   .partial_address = FF(23),
+                                                   .public_keys_hash = FF(34),
+                                                   .preaddress = FF(45),
+                                                   .preaddress_public_key = preaddress_public_key,
+                                                   .address_point = address_point };
+    builder.process({ { addr_event } }, trace);
+
+    EXPECT_THAT(
+        trace.as_rows(),
+        ElementsAre(
+            // Only one row.
+            AllOf(ROW_FIELD_EQ(address_derivation_sel, 1),
+                  ROW_FIELD_EQ(address_derivation_address, FF(0xdeadbeef)),
+                  ROW_FIELD_EQ(address_derivation_salt, instance.salt),
+                  ROW_FIELD_EQ(address_derivation_deployer_addr, instance.deployer),
+                  ROW_FIELD_EQ(address_derivation_class_id, instance.original_contract_class_id),
+                  ROW_FIELD_EQ(address_derivation_init_hash, instance.initialization_hash),
+                  ROW_FIELD_EQ(address_derivation_nullifier_key_x, instance.public_keys.nullifier_key.x),
+                  ROW_FIELD_EQ(address_derivation_nullifier_key_y, instance.public_keys.nullifier_key.y),
+                  ROW_FIELD_EQ(address_derivation_incoming_viewing_key_x, instance.public_keys.incoming_viewing_key.x),
+                  ROW_FIELD_EQ(address_derivation_incoming_viewing_key_y, instance.public_keys.incoming_viewing_key.y),
+                  ROW_FIELD_EQ(address_derivation_outgoing_viewing_key_x, instance.public_keys.outgoing_viewing_key.x),
+                  ROW_FIELD_EQ(address_derivation_outgoing_viewing_key_y, instance.public_keys.outgoing_viewing_key.y),
+                  ROW_FIELD_EQ(address_derivation_tagging_key_x, instance.public_keys.tagging_key.x),
+                  ROW_FIELD_EQ(address_derivation_tagging_key_y, instance.public_keys.tagging_key.y),
+                  ROW_FIELD_EQ(address_derivation_salted_init_hash, FF(12)),
+                  ROW_FIELD_EQ(address_derivation_partial_address, FF(23)),
+                  ROW_FIELD_EQ(address_derivation_public_keys_hash, FF(34)),
+                  ROW_FIELD_EQ(address_derivation_preaddress, FF(45)),
+                  ROW_FIELD_EQ(address_derivation_preaddress_public_key_x, preaddress_public_key.x()),
+                  ROW_FIELD_EQ(address_derivation_preaddress_public_key_y, preaddress_public_key.y()),
+                  ROW_FIELD_EQ(address_derivation_address_y, address_point.y()),
+                  ROW_FIELD_EQ(address_derivation_partial_address_domain_separator, DOM_SEP__PARTIAL_ADDRESS),
+                  ROW_FIELD_EQ(address_derivation_public_keys_hash_domain_separator, DOM_SEP__PUBLIC_KEYS_HASH),
+                  ROW_FIELD_EQ(address_derivation_preaddress_domain_separator, DOM_SEP__CONTRACT_ADDRESS_V1),
+                  ROW_FIELD_EQ(address_derivation_g1_x, EmbeddedCurvePoint::one().x()),
+                  ROW_FIELD_EQ(address_derivation_g1_y, EmbeddedCurvePoint::one().y()),
+                  ROW_FIELD_EQ(address_derivation_const_two, 2),
+                  ROW_FIELD_EQ(address_derivation_const_three, 3),
+                  ROW_FIELD_EQ(address_derivation_const_four, 4),
+                  ROW_FIELD_EQ(address_derivation_const_thirteen, 13))));
+}
+
+} // namespace
+} // namespace bb::avm2::tracegen

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/class_id_derivation_trace.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/class_id_derivation_trace.test.cpp
@@ -13,7 +13,6 @@ namespace bb::avm2::tracegen {
 namespace {
 
 using testing::ElementsAre;
-using testing::Field;
 
 using R = TestTraceContainer::Row;
 

--- a/yarn-project/stdlib/src/contract/contract_address.ts
+++ b/yarn-project/stdlib/src/contract/contract_address.ts
@@ -13,9 +13,9 @@ import type { ContractInstance } from './interfaces/contract_instance.js';
 /**
  * Returns the deployment address for a given contract instance.
  * ```
- * salted_initialization_hash = pedersen([salt, initialization_hash, deployer], GENERATOR__SALTED_INITIALIZATION_HASH)
- * partial_address = pedersen([contract_class_id, salted_initialization_hash], GENERATOR__CONTRACT_PARTIAL_ADDRESS_V1)
- * address = ((poseidon2Hash([public_keys_hash, partial_address, GENERATOR__CONTRACT_ADDRESS_V1]) * G) + ivpk_m).x <- the x-coordinate of the address point
+ * salted_initialization_hash = poseidon2(DOM_SEP__PARTIAL_ADDRESS, [salt, initialization_hash, deployer])
+ * partial_address = poseidon2(DOM_SEP__PARTIAL_ADDRESS, [contract_class_id, salted_initialization_hash])
+ * address = ((poseidon2(DOM_SEP__CONTRACT_ADDRESS_V1, [public_keys_hash, partial_address]) * G) + ivpk_m).x <- the x-coordinate of the address point
  * ```
  * @param instance - A contract instance for which to calculate the deployment address.
  */

--- a/yarn-project/stdlib/src/contract/contract_class_id.ts
+++ b/yarn-project/stdlib/src/contract/contract_class_id.ts
@@ -13,10 +13,10 @@ import { computePrivateFunctionsRoot } from './private_function.js';
  *
  * ```
  * version = 1
- * private_function_leaves = private_functions.map(fn => pedersen([fn.function_selector as Field, fn.vk_hash], GENERATOR__PRIVATE_FUNCTION_LEAF))
+ * private_function_leaves = private_functions.map(fn => poseidon2(DOM_SEP__PRIVATE_FUNCTION_LEAF, [fn.function_selector as Field, fn.vk_hash]))
  * private_functions_root = merkleize(private_function_leaves)
  * bytecode_commitment = calculate_commitment(packed_bytecode)
- * contract_class_id = pedersen([version, artifact_hash, private_functions_root, bytecode_commitment], GENERATOR__CLASS_IDENTIFIER)
+ * contract_class_id = poseidon2(DOM_SEP__CONTRACT_CLASS_ID, [version, artifact_hash, private_functions_root, bytecode_commitment])
  * ```
  * @param contractClass - Contract class.
  * @returns The identifier.


### PR DESCRIPTION
Closes [AVM-55](https://linear.app/aztec-labs/issue/AVM-55/bytecode-address-deriv)

## Address Derivation

Very similar to #20853 (some docs etc are copied over), largely documentation and rearranging.

### On curve check
Only big change is asserting that the `ivpk` is on the curve to meet ecc.pil's precondition. The idea that the `ivpk` may not be on the curve was rediscovered in the ecc preaudit:

- Discussed [here](https://github.com/AztecProtocol/aztec-packages/pull/19134/changes#r2639911267) - the `ivpk` is only ~checked implicitly in bb~ Is now checked [explicitly](https://github.com/AztecProtocol/aztec-packages/pull/20517)!
- Our circuits have a hard precondition that points are assumed to be on the curve
- I don't believe that anything is exploitable by choosing some malicious `ivpk` not on the curve (other hash outputs/predicates protect us), but it feels wrong to be able to input garbage coordinates into ecc
- An on curve check is relatively cheap and hardens the (currently implicit in the AVM) assumption, making it easier to reason about for auditing

(Big thank you to @sirasistant and @IlyasRidhuan for continued discussions on the `ivpk`!)

### Non unified simulation behaviour

UPDATE: I believe this is low impact, possible solutions (or non solution!) in this [comment](https://github.com/AztecProtocol/aztec-packages/pull/21374/changes#r2930567672).

UPDATE UPDATE: fixed with an address recalculation and check, see this [comment](https://github.com/AztecProtocol/aztec-packages/pull/21374#discussion_r2945886831) for details.

See changes in https://github.com/AztecProtocol/aztec-packages/pull/21374/commits/33dc1f3b2ef5f642c76843b282285a880c9ddd4a and [comment](https://github.com/AztecProtocol/aztec-packages/pull/21374/changes#r2923943370).

Copied from preaudit scope doc:
 - Happy path: calling simulation `assert_derivation(addr_a, instance_a)` where addr_a is correct emits the derivation event and adds addr_a to the cache ✅ 
 - Error path: calling simulation `assert_derivation(addr_b, instance_a)` where addr_b does *not* match throws a runtime error (correctly - get_contract_instance should have fetched the correct instance given addr_b) and does not emit an event ✅ 
 - Other (?) path:  calling simulation `assert_derivation(addr_a, instance_b)` (where we have previously called `assert_derivation(addr_a, instance_a)` successfully) just returns and does not throw, even though a mismatch exists. No event is emitted (good!), but unlike the error path simulation continues on, and eventually proving get_contract_instance will fail for addr_a and instance_b - do we want to cover this with an error case in simulation for unification? ❔ 



### TODOs/Notes

- ~Tracegen tests for address derivation~
- ~More test cases in constraining and sim tests~
- ~Deal with simulation error cases~
- Otherwise see comments - just small ideas I had and unsure whether to implement.
