### PR TITLE
fix: align OIDC role duration and SSM poll timeout with shutdown timer

### DIFF
--- a/.github/workflows/ci3.yml
+++ b/.github/workflows/ci3.yml
@@ -68,6 +68,7 @@ jobs:
           role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
           aws-region: us-east-2
           role-session-name: ci3-${{ github.run_id }}
+          role-duration-seconds: 7200 # 2h – covers max AWS_SHUTDOWN_TIME (90 min ARM) + 30 min buffer
 
       - name: Determine CI Mode
         env:
@@ -191,6 +192,7 @@ jobs:
           role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
           aws-region: us-east-2
           role-session-name: ci3-network-scenario-${{ github.run_id }}
+          role-duration-seconds: 23400 # 6.5h – covers AWS_SHUTDOWN_TIME (360 min) + 30 min buffer
 
       - name: Run Network Scenarios
         timeout-minutes: 350
@@ -396,6 +398,7 @@ jobs:
           role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
           aws-region: us-east-2
           role-session-name: ci3-network-kind-${{ github.run_id }}
+          role-duration-seconds: 12600 # 3.5h – covers AWS_SHUTDOWN_TIME (180 min) + 30 min buffer
 
       - name: Run KIND Test
         env:

--- a/ci3/bootstrap_ec2
+++ b/ci3/bootstrap_ec2
@@ -404,7 +404,7 @@ else
   # Send host script via SSM and poll until completion.
   # Run as ubuntu to match SSH behavior (SSM defaults to root).
   set +e
-  SSM_RUN_AS=ubuntu SSM_POLL_TIMEOUT=${SSM_POLL_TIMEOUT:-7200} \
+  SSM_RUN_AS=ubuntu SSM_POLL_TIMEOUT=${SSM_POLL_TIMEOUT:-$((AWS_SHUTDOWN_TIME * 60 + 600))} \
     ssm_send_command "$iid" "$host_script"
   exit_code=$?
   set -e

--- a/ci3/ssm_send_command
+++ b/ci3/ssm_send_command
@@ -8,6 +8,8 @@
 # Env:
 #   SSM_RUN_AS       - User to run the command as (default: no runuser wrapper).
 #   SSM_POLL_TIMEOUT - Max seconds to poll for completion (default: 7200 = 2h).
+#   SSM_EXEC_TIMEOUT - Max seconds AWS allows the command to run (default: SSM_POLL_TIMEOUT).
+#                      Maps to the AWS-RunShellScript executionTimeout parameter.
 #   SSM_NO_WAIT      - If set to 1, fire-and-forget: send the command and exit 0 immediately.
 #   AWS_DEFAULT_REGION - Region (default: us-east-2).
 #
@@ -45,8 +47,14 @@ else
   run_prefix=""
 fi
 
-ssm_params=$(jq -n --arg e "$encoded" --arg p "$run_prefix" \
-  '{commands: ["f=$(mktemp /tmp/ssm_cmd.XXXXXX); echo " + ($e | @json) + " | base64 -d > $f; chmod 644 $f; " + $p + "bash $f; ret=$?; rm -f $f; exit $ret"]}')
+# AWS-RunShellScript executionTimeout defaults to 3600s (1h). For long-running
+# jobs (e.g. 6h network scenarios), this silently kills the command on the AWS
+# side. Align it with the poll timeout so the server-side limit matches.
+SSM_POLL_TIMEOUT=${SSM_POLL_TIMEOUT:-7200}
+exec_timeout=${SSM_EXEC_TIMEOUT:-$SSM_POLL_TIMEOUT}
+
+ssm_params=$(jq -n --arg e "$encoded" --arg p "$run_prefix" --arg t "$exec_timeout" \
+  '{commands: ["f=$(mktemp /tmp/ssm_cmd.XXXXXX); echo " + ($e | @json) + " | base64 -d > $f; chmod 644 $f; " + $p + "bash $f; ret=$?; rm -f $f; exit $ret"], executionTimeout: [$t]}')
 
 command_id=$(aws ssm send-command \
   --region "$region" \
@@ -73,7 +81,6 @@ fi
 # StandardOutputContent / StandardErrorContent are cumulative snapshots of the
 # first 24KB of output. Each poll returns the *full* buffer so far, so we track
 # how many characters we've already printed and only emit the new portion.
-SSM_POLL_TIMEOUT=${SSM_POLL_TIMEOUT:-7200}
 poll_start=$SECONDS
 
 while true; do


### PR DESCRIPTION
## Summary
- **SSM poll timeout** was hardcoded to 7200s (2h) while jobs like `ci-network-scenario` set `AWS_SHUTDOWN_TIME` to 360 min (6h). When polling exceeded the OIDC credential lifetime, the subsequent `terminate-instances` call failed with `RequestExpired`.
- Derive `SSM_POLL_TIMEOUT` from `AWS_SHUTDOWN_TIME` + 10 min buffer so it always outlasts the shutdown timer.
- Set `role-duration-seconds` on each OIDC step to match the job's shutdown timer + 30 min buffer.

| Job | Shutdown time | SSM poll timeout | OIDC role duration |
|-----|--------------|------------------|--------------------|
| `ci` | 60–90 min | shutdown + 10 min | 7200s (2h) |
| `ci-network-scenario` | 360 min | shutdown + 10 min | 23400s (6.5h) |
| `ci-network-kind` | 180 min | shutdown + 10 min | 12600s (3.5h) |

## Test plan
- [ ] Verify the IAM role `MaxSessionDuration` is >= 23400s (6.5h) — if not, update it in AWS
- [ ] Run a `ci-network-scenario` job and confirm no `RequestExpired` errors on cleanup