### PR TITLE
chore: Removed default snapshot url config

### DIFF
--- a/spartan/environments/network-defaults.yml
+++ b/spartan/environments/network-defaults.yml
@@ -332,7 +332,6 @@ networks:
     # Prover
     PROVER_REAL_PROOFS: true
     # Sync
-    SYNC_SNAPSHOTS_URLS: "https://aztec-labs-snapshots.com/mainnet/"
     BLOB_ALLOW_EMPTY_SOURCES: true
     # P2P
     P2P_MAX_PENDING_TX_COUNT: 1000


### PR DESCRIPTION
Our `network_defaults.yml` hardcoded a single snapshots provider for mainnet. But this should be removed in favour of using the network config json file.
