### PR TITLE
chore: track proposed chain in metrics

### DIFF
--- a/yarn-project/archiver/src/archiver.ts
+++ b/yarn-project/archiver/src/archiver.ts
@@ -85,6 +85,8 @@ export class Archiver extends ArchiverDataSourceBase implements L2BlockSink, Tra
 
   public readonly tracer: Tracer;
 
+  private readonly instrumentation: ArchiverInstrumentation;
+
   /**
    * Creates a new instance of the Archiver.
    * @param publicClient - A client for interacting with the Ethereum node.
@@ -131,6 +133,7 @@ export class Archiver extends ArchiverDataSourceBase implements L2BlockSink, Tra
     super(dataStore, l1Constants);
 
     this.tracer = instrumentation.tracer;
+    this.instrumentation = instrumentation;
     this.initialSyncPromise = promiseWithResolvers();
     this.synchronizer = synchronizer;
     this.events = events;
@@ -243,6 +246,7 @@ export class Archiver extends ArchiverDataSourceBase implements L2BlockSink, Tra
 
       try {
         await this.updater.addProposedBlock(block);
+        this.instrumentation.processNewProposedBlock(block);
         this.log.debug(`Added block ${block.number} to store`);
         resolve();
       } catch (err: any) {

--- a/yarn-project/archiver/src/modules/instrumentation.ts
+++ b/yarn-project/archiver/src/modules/instrumentation.ts
@@ -113,6 +113,11 @@ export class ArchiverInstrumentation {
     return this.telemetry.isEnabled();
   }
 
+  public processNewProposedBlock(block: L2Block) {
+    this.blockHeight.record(block.number, { [Attributes.STATUS]: 'proposed' });
+    this.processNewBlock(block, 'proposed');
+  }
+
   public processNewBlocks(syncTimePerBlock: number, blocks: L2Block[]) {
     this.syncDurationPerBlock.record(Math.ceil(syncTimePerBlock));
     this.blockHeight.record(Math.max(...blocks.map(b => b.number)));
@@ -120,10 +125,19 @@ export class ArchiverInstrumentation {
     this.syncBlockCount.add(blocks.length);
 
     for (const block of blocks) {
-      this.txCount.add(block.body.txEffects.length);
-      this.txsPerBlock.record(block.body.txEffects.length);
-      this.manaPerBlock.record(block.header.totalManaUsed.toNumber() / 1e6);
+      this.processNewBlock(block);
     }
+  }
+
+  /** Records per-block metrics tagged with a status (e.g. 'proposed'). */
+  private processNewBlock(block: L2Block, status?: string) {
+    let attrs = undefined;
+    if (status) {
+      attrs = { [Attributes.STATUS]: status };
+    }
+    this.txCount.add(block.body.txEffects.length, attrs);
+    this.txsPerBlock.record(block.body.txEffects.length, attrs);
+    this.manaPerBlock.record(block.header.totalManaUsed.toNumber() / 1e6, attrs);
   }
 
   public processNewMessages(count: number, syncPerMessageMs: number) {


### PR DESCRIPTION
## Overview
Adds metric for proposed chain, right now block tips are only updated on l1 checkpoints, may as well measure the proposed chain too 