### PR TITLE
chore: Read tx filestores from network config

### DIFF
--- a/yarn-project/cli/src/config/network_config.ts
+++ b/yarn-project/cli/src/config/network_config.ts
@@ -139,6 +139,9 @@ export async function enrichEnvironmentWithNetworkConfig(networkName: NetworkNam
   if (networkConfig.blobFileStoreUrls?.length) {
     enrichVar('BLOB_FILE_STORE_URLS', networkConfig.blobFileStoreUrls.join(','));
   }
+  if (networkConfig.txCollectionFileStoreUrls?.length) {
+    enrichVar('TX_COLLECTION_FILE_STORE_URLS', networkConfig.txCollectionFileStoreUrls.join(','));
+  }
   if (networkConfig.blockDurationMs !== undefined) {
     enrichVar('SEQ_BLOCK_DURATION_MS', String(networkConfig.blockDurationMs));
   }

--- a/yarn-project/foundation/src/config/network_config.ts
+++ b/yarn-project/foundation/src/config/network_config.ts
@@ -5,6 +5,7 @@ export const NetworkConfigSchema = z
     bootnodes: z.array(z.string()),
     snapshots: z.array(z.string()),
     blobFileStoreUrls: z.array(z.string()).optional(),
+    txCollectionFileStoreUrls: z.array(z.string()).optional(),
     registryAddress: z.string(),
     feeAssetHandlerAddress: z.string().optional(),
     l1ChainId: z.number(),


### PR DESCRIPTION
This PR adds transaction filestore config to the network config schema.
