### PR TITLE
feat(p2p): use l2 priority fee only for tx priority

### DIFF
--- a/yarn-project/p2p/src/mem_pools/tx_pool/priority.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool/priority.ts
@@ -12,12 +12,9 @@ export function getPendingTxPriority(tx: Tx): string {
 }
 
 /**
- * Returns the priority of a tx based on the priority fees, capped by the max fees per gas.
+ * Returns the priority of a tx based on the L2 priority fee only, capped by the max fees per gas.
  */
 export function getTxPriorityFee(tx: Tx): bigint {
   const { maxPriorityFeesPerGas: priorityFees, maxFeesPerGas } = tx.getGasSettings();
-  const totalFees =
-    minBigint(maxFeesPerGas.feePerDaGas, priorityFees.feePerDaGas) +
-    minBigint(maxFeesPerGas.feePerL2Gas, priorityFees.feePerL2Gas);
-  return totalFees;
+  return minBigint(maxFeesPerGas.feePerL2Gas, priorityFees.feePerL2Gas);
 }


### PR DESCRIPTION
Simplifies the issue of summing two different rates over two different magnitudes.

Fixes A-655