### PR TITLE
feat(pipeline): minimize deadzone w cross slot attesting

### DIFF
--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_mbps.pipeline.parallel.test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_mbps.pipeline.parallel.test.ts
@@ -30,10 +30,10 @@ import { EpochsTestContext } from './epochs_test.js';
 jest.setTimeout(1000 * 60 * 20);
 
 const NODE_COUNT = 4;
-const EXPECTED_BLOCKS_PER_CHECKPOINT = 3;
+const EXPECTED_BLOCKS_PER_CHECKPOINT = 8;
 
 // Send enough transactions to trigger multiple blocks within a checkpoint assuming 2 txs per block.
-const TX_COUNT = 10;
+const TX_COUNT = 24;
 
 /**
  * E2E tests for proposer pipelining with Multiple Blocks Per Slot (MBPS).
@@ -72,16 +72,15 @@ describe('e2e_epochs/epochs_mbps_pipeline', () => {
       initialValidators: validators,
       enableProposerPipelining: true, // <- yehaw
       mockGossipSubNetwork: true,
+      mockGossipSubNetworkLatency: 500, // adverse network conditions
       disableAnvilTestWatcher: true,
       startProverNode: true,
-      perBlockAllocationMultiplier: 1,
+      perBlockAllocationMultiplier: 8,
       aztecEpochDuration: 4,
       enforceTimeTable: true,
-      ethereumSlotDuration: 4,
-      aztecSlotDuration: 36,
+      ethereumSlotDuration: 12,
+      aztecSlotDuration: 72,
       blockDurationMs: 8000,
-      l1PublishingTime: 2,
-      attestationPropagationTime: 0.5,
       aztecTargetCommitteeSize: 3,
       inboxLag: 2,
       ...setupOpts,

--- a/yarn-project/end-to-end/src/e2e_l1_publisher/e2e_l1_publisher.test.ts
+++ b/yarn-project/end-to-end/src/e2e_l1_publisher/e2e_l1_publisher.test.ts
@@ -22,7 +22,7 @@ import { EpochCache } from '@aztec/epoch-cache';
 import { createEthereumChain } from '@aztec/ethereum/chain';
 import { createExtendedL1Client } from '@aztec/ethereum/client';
 import { getL1ContractsConfigEnvVars } from '@aztec/ethereum/config';
-import { GovernanceProposerContract, RollupContract } from '@aztec/ethereum/contracts';
+import { GovernanceProposerContract, RollupContract, SimulationOverridesBuilder } from '@aztec/ethereum/contracts';
 import { type DeployAztecL1ContractsArgs, deployAztecL1Contracts } from '@aztec/ethereum/deploy-aztec-l1-contracts';
 import type { L1ContractAddresses } from '@aztec/ethereum/l1-contract-addresses';
 import { TxUtilsState, createL1TxUtils } from '@aztec/ethereum/l1-tx-utils';
@@ -743,20 +743,21 @@ describe('L1Publisher integration', () => {
       expect(invalidateRequest).toBeDefined();
       const forcePendingCheckpointNumber = invalidateRequest?.forcePendingCheckpointNumber;
       expect(forcePendingCheckpointNumber).toEqual(0);
+      const invalidationSimulationOverridesPlan = new SimulationOverridesBuilder()
+        .forPendingCheckpoint(forcePendingCheckpointNumber ?? CheckpointNumber.ZERO)
+        .build();
 
       // We cannot propose directly, we need to assume the previous checkpoint is invalidated
       const genesis = new Fr(GENESIS_ARCHIVE_ROOT);
       logger.warn(`Checking can propose at next eth block on top of genesis ${genesis}`);
       expect(await publisher.canProposeAt(genesis, proposer!)).toBeUndefined();
-      const canPropose = await publisher.canProposeAt(genesis, proposer!, { forcePendingCheckpointNumber });
+      const canPropose = await publisher.canProposeAt(genesis, proposer!, invalidationSimulationOverridesPlan);
       expect(canPropose?.slot).toEqual(block.header.getSlot());
 
       // Same for validation
       logger.warn('Checking validate block header');
       await expect(publisher.validateBlockHeader(checkpoint.header)).rejects.toThrow(/Rollup__InvalidArchive/);
-      await publisher.validateBlockHeader(checkpoint.header, {
-        forcePendingCheckpointNumber: forcePendingCheckpointNumber ?? CheckpointNumber.ZERO,
-      });
+      await publisher.validateBlockHeader(checkpoint.header, invalidationSimulationOverridesPlan);
 
       // At this point I'm gonna need to propose the correct signature ye? So confused actually here.
       const attestationsAndSigners = new CommitteeAttestationsAndSigners(attestations);
@@ -769,7 +770,7 @@ describe('L1Publisher integration', () => {
       logger.warn('Enqueuing requests to invalidate and propose the checkpoint');
       publisher.enqueueInvalidateCheckpoint(invalidateRequest);
       await publisher.enqueueProposeCheckpoint(checkpoint, attestationsAndSigners, attestationsAndSignersSignature, {
-        forcePendingCheckpointNumber: forcePendingCheckpointNumber ?? CheckpointNumber.ZERO,
+        simulationOverridesPlan: invalidationSimulationOverridesPlan,
       });
       const result = await publisher.sendRequests();
       expect(result!.successfulActions).toEqual(['invalidate-by-insufficient-attestations', 'propose']);

--- a/yarn-project/end-to-end/src/e2e_p2p/duplicate_attestation_slash.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/duplicate_attestation_slash.test.ts
@@ -85,6 +85,7 @@ describe('e2e_p2p_duplicate_attestation_slash', () => {
         slashAmountLarge: slashingUnit * 3n,
         enforceTimeTable: true,
         blockDurationMs: BLOCK_DURATION * 1000,
+        l1PublishingTime: 1,
         slashDuplicateProposalPenalty: slashingUnit,
         slashDuplicateAttestationPenalty: slashingUnit,
         slashingOffsetInRounds: 1,

--- a/yarn-project/end-to-end/src/fixtures/setup.ts
+++ b/yarn-project/end-to-end/src/fixtures/setup.ts
@@ -179,6 +179,8 @@ export type SetupOptions = {
   proverNodeConfig?: Partial<ProverNodeConfig>;
   /** Whether to use a mock gossip sub network for p2p clients. */
   mockGossipSubNetwork?: boolean;
+  /** Whether to add simulated latency to the mock gossipsub network (in ms) */
+  mockGossipSubNetworkLatency?: number;
   /** Whether to disable the anvil test watcher (can still be manually started) */
   disableAnvilTestWatcher?: boolean;
   /** Whether to enable anvil automine during deployment of L1 contracts (consider defaulting this to true). */
@@ -470,7 +472,7 @@ export async function setup(
     let p2pClientDeps: P2PClientDeps | undefined = undefined;
 
     if (opts.mockGossipSubNetwork) {
-      mockGossipSubNetwork = new MockGossipSubNetwork();
+      mockGossipSubNetwork = new MockGossipSubNetwork(opts.mockGossipSubNetworkLatency);
       p2pClientDeps = { p2pServiceFactory: getMockPubSubP2PServiceFactory(mockGossipSubNetwork) };
     }
 

--- a/yarn-project/ethereum/src/contracts/chain_state_override.ts
+++ b/yarn-project/ethereum/src/contracts/chain_state_override.ts
@@ -1,0 +1,147 @@
+import { toHex as toPaddedHex } from '@aztec/foundation/bigint-buffer';
+import type { CheckpointNumber } from '@aztec/foundation/branded-types';
+import type { Fr } from '@aztec/foundation/curves/bn254';
+
+import type { StateOverride } from 'viem';
+
+import { type FeeHeader, RollupContract } from './rollup.js';
+
+export type PendingCheckpointOverrideState = {
+  archive?: Fr;
+  feeHeader?: FeeHeader;
+};
+
+/** Describes the simulated L1 rollup state that downstream calls should observe. */
+export type SimulationOverridesPlan = {
+  pendingCheckpointNumber?: CheckpointNumber;
+  pendingCheckpointState?: PendingCheckpointOverrideState;
+  disableBlobCheck?: boolean;
+};
+
+/** Builds a single-checkpoint simulation plan before it is translated into a viem state override. */
+export class SimulationOverridesBuilder {
+  private pendingCheckpointNumber?: CheckpointNumber;
+  private pendingCheckpointState?: PendingCheckpointOverrideState;
+  private disableBlobCheck = false;
+
+  /** Starts from an existing plan so callers can extend or specialize it. */
+  public static from(plan: SimulationOverridesPlan | undefined): SimulationOverridesBuilder {
+    return new SimulationOverridesBuilder().merge(plan);
+  }
+
+  /** Merges another plan into this builder. Later values win. */
+  public merge(plan: SimulationOverridesPlan | undefined): this {
+    if (!plan) {
+      return this;
+    }
+
+    this.pendingCheckpointNumber = plan.pendingCheckpointNumber;
+    this.pendingCheckpointState = plan.pendingCheckpointState
+      ? { ...(this.pendingCheckpointState ?? {}), ...plan.pendingCheckpointState }
+      : this.pendingCheckpointState;
+    this.disableBlobCheck = this.disableBlobCheck || (plan.disableBlobCheck ?? false);
+
+    return this;
+  }
+
+  /** Sets the checkpoint number that archive and fee header overrides should attach to. */
+  public forPendingCheckpoint(pendingCheckpointNumber: CheckpointNumber | undefined): this {
+    this.pendingCheckpointNumber = pendingCheckpointNumber;
+    return this;
+  }
+
+  /** Overrides the archive root for the configured pending checkpoint. */
+  public withPendingArchive(archive: Fr): this {
+    this.assertPendingCheckpointNumber();
+    this.pendingCheckpointState = { ...(this.pendingCheckpointState ?? {}), archive };
+    return this;
+  }
+
+  /** Overrides the fee header for the configured pending checkpoint. */
+  public withPendingFeeHeader(feeHeader: FeeHeader): this {
+    this.assertPendingCheckpointNumber();
+    this.pendingCheckpointState = { ...(this.pendingCheckpointState ?? {}), feeHeader };
+    return this;
+  }
+
+  /** Disables blob checking for simulations that cannot provide DA inputs. */
+  public withoutBlobCheck(): this {
+    this.disableBlobCheck = true;
+    return this;
+  }
+
+  /** Builds the final plan, or `undefined` when no overrides were configured. */
+  public build(): SimulationOverridesPlan | undefined {
+    if (!this.pendingCheckpointState && this.pendingCheckpointNumber === undefined && !this.disableBlobCheck) {
+      return undefined;
+    }
+
+    return {
+      pendingCheckpointNumber: this.pendingCheckpointNumber,
+      pendingCheckpointState: this.pendingCheckpointState,
+      disableBlobCheck: this.disableBlobCheck || undefined,
+    };
+  }
+
+  private assertPendingCheckpointNumber(): void {
+    if (this.pendingCheckpointNumber === undefined) {
+      throw new Error('pendingCheckpointNumber must be set before attaching archive or fee header overrides');
+    }
+  }
+}
+
+/** Translates a simulation plan into the viem state override shape expected by rollup calls. */
+export async function buildSimulationOverridesStateOverride(
+  rollup: RollupContract,
+  plan: SimulationOverridesPlan | undefined,
+): Promise<StateOverride> {
+  if (!plan) {
+    return [];
+  }
+
+  const rollupStateDiff: NonNullable<StateOverride[number]['stateDiff']> = [];
+
+  if (plan.pendingCheckpointNumber !== undefined) {
+    rollupStateDiff.push(
+      ...extractRollupStateDiff(await rollup.makePendingCheckpointNumberOverride(plan.pendingCheckpointNumber)),
+    );
+  }
+
+  if (plan.pendingCheckpointState && plan.pendingCheckpointNumber === undefined) {
+    throw new Error('pendingCheckpointState requires pendingCheckpointNumber to be set');
+  }
+
+  if (plan.pendingCheckpointState?.archive) {
+    rollupStateDiff.push(
+      ...extractRollupStateDiff(
+        rollup.makeArchiveOverride(plan.pendingCheckpointNumber!, plan.pendingCheckpointState.archive),
+      ),
+    );
+  }
+
+  if (plan.pendingCheckpointState?.feeHeader) {
+    rollupStateDiff.push(
+      ...extractRollupStateDiff(
+        await rollup.makeFeeHeaderOverride(plan.pendingCheckpointNumber!, plan.pendingCheckpointState.feeHeader),
+      ),
+    );
+  }
+
+  if (plan.disableBlobCheck) {
+    rollupStateDiff.push({
+      slot: toPaddedHex(RollupContract.checkBlobStorageSlot, true),
+      value: toPaddedHex(0n, true),
+    });
+  }
+
+  if (rollupStateDiff.length === 0) {
+    return [];
+  }
+
+  return [{ address: rollup.address, stateDiff: rollupStateDiff }];
+}
+
+function extractRollupStateDiff(override: StateOverride | StateOverride[number] | undefined) {
+  const entries = Array.isArray(override) ? override : override ? [override] : [];
+  return entries.flatMap(entry => entry.stateDiff ?? []);
+}

--- a/yarn-project/ethereum/src/contracts/index.ts
+++ b/yarn-project/ethereum/src/contracts/index.ts
@@ -1,3 +1,4 @@
+export * from './chain_state_override.js';
 export * from './empire_base.js';
 export * from './errors.js';
 export * from './fee_asset_handler.js';

--- a/yarn-project/ethereum/src/contracts/rollup.test.ts
+++ b/yarn-project/ethereum/src/contracts/rollup.test.ts
@@ -328,6 +328,27 @@ describe('Rollup', () => {
     });
   });
 
+  describe('makeArchiveOverride', () => {
+    it('creates state override that correctly sets archive for a checkpoint number', async () => {
+      const checkpointNumber = CheckpointNumber(5);
+      const expectedArchive = Fr.random();
+
+      // Create the override
+      const stateOverride = rollup.makeArchiveOverride(checkpointNumber, expectedArchive);
+
+      // Test the override using simulateContract to read archiveAt(checkpointNumber)
+      const { result: overriddenArchive } = await publicClient.simulateContract({
+        address: rollupAddress,
+        abi: RollupAbi as Abi,
+        functionName: 'archiveAt',
+        args: [BigInt(checkpointNumber)],
+        stateOverride,
+      });
+
+      expect(Fr.fromString(overriddenArchive as string).equals(expectedArchive)).toBe(true);
+    });
+  });
+
   describe('getSlashingProposer', () => {
     it('returns a slashing proposer', async () => {
       const slashingProposer = await rollup.getSlashingProposer();

--- a/yarn-project/ethereum/src/contracts/rollup.ts
+++ b/yarn-project/ethereum/src/contracts/rollup.ts
@@ -765,18 +765,10 @@ export class RollupContract {
     archive: Buffer,
     account: `0x${string}` | Account,
     timestamp: bigint,
-    opts: {
-      forcePendingCheckpointNumber?: CheckpointNumber;
-      forceArchive?: { checkpointNumber: CheckpointNumber; archive: Fr };
-    } = {},
+    stateOverride: StateOverride = [],
   ): Promise<{ slot: SlotNumber; checkpointNumber: CheckpointNumber; timeOfNextL1Slot: bigint }> {
     const timeOfNextL1Slot = timestamp;
     const who = typeof account === 'string' ? account : account.address;
-
-    const stateOverride = RollupContract.mergeStateOverrides(
-      await this.makePendingCheckpointNumberOverride(opts.forcePendingCheckpointNumber),
-      opts.forceArchive ? this.makeArchiveOverride(opts.forceArchive.checkpointNumber, opts.forceArchive.archive) : [],
-    );
 
     try {
       const {

--- a/yarn-project/p2p/src/config.ts
+++ b/yarn-project/p2p/src/config.ts
@@ -39,7 +39,14 @@ export interface P2PConfig
     ChainConfig,
     TxCollectionConfig,
     TxFileStoreConfig,
-    Pick<SequencerConfig, 'blockDurationMs' | 'expectedBlockProposalsPerSlot' | 'maxTxsPerBlock'> {
+    Pick<
+      SequencerConfig,
+      | 'blockDurationMs'
+      | 'expectedBlockProposalsPerSlot'
+      | 'l1PublishingTime'
+      | 'maxTxsPerBlock'
+      | 'attestationPropagationTime'
+    > {
   /** Maximum transactions per block for validation. Overrides maxTxsPerBlock for gossip validation when set. */
   validateMaxTxsPerBlock?: number;
 
@@ -494,6 +501,11 @@ export const p2pConfigMappings: ConfigMappingsType<P2PConfig> = {
     env: 'DEBUG_P2P_INSTRUMENT_MESSAGES',
     description: 'Alters the format of p2p messages to include things like broadcast timestamp FOR TESTING ONLY',
     ...booleanConfigHelper(false),
+  },
+  l1PublishingTime: {
+    env: 'SEQ_L1_PUBLISHING_TIME_ALLOWANCE_IN_SLOT',
+    description: 'How much time (in seconds) we allow in the slot for publishing the L1 tx (defaults to 1 L1 slot).',
+    parseEnv: (val: string) => (val ? parseInt(val, 10) : undefined),
   },
   fishermanMode: {
     env: 'FISHERMAN_MODE',

--- a/yarn-project/p2p/src/msg_validators/attestation_validator/attestation_validator.test.ts
+++ b/yarn-project/p2p/src/msg_validators/attestation_validator/attestation_validator.test.ts
@@ -18,7 +18,11 @@ describe('CheckpointAttestationValidator', () => {
 
   beforeEach(() => {
     epochCache = mock<EpochCacheInterface>();
-    validator = new CheckpointAttestationValidator(epochCache);
+    epochCache.getL1Constants.mockReturnValue({
+      slotDuration: 72,
+      ethereumSlotDuration: 12,
+    } as any);
+    validator = new CheckpointAttestationValidator(epochCache, { l1PublishingTime: 12 });
     proposer = Secp256k1Signer.random();
     attester = Secp256k1Signer.random();
   });
@@ -72,6 +76,74 @@ describe('CheckpointAttestationValidator', () => {
 
     const result = await validator.validate(mockAttestation);
     expect(result).toEqual({ result: 'ignore' });
+  });
+
+  it('accepts attestation for current slot until the target-slot publish cutoff', async () => {
+    // Attestation is for slot 98 (current wallclock slot), but targetSlot is 99 (pipelining).
+    const header = CheckpointHeader.random({ slotNumber: SlotNumber(98) });
+    const mockAttestation = makeCheckpointAttestation({
+      header,
+      attesterSigner: attester,
+      proposerSigner: proposer,
+    });
+
+    epochCache.getTargetAndNextSlot.mockReturnValue({
+      targetSlot: SlotNumber(99),
+      nextSlot: SlotNumber(100),
+    });
+    epochCache.getSlotNow.mockReturnValue(SlotNumber(98));
+    epochCache.isProposerPipeliningEnabled.mockReturnValue(true);
+    epochCache.getL1Constants.mockReturnValue({
+      slotDuration: 72,
+      ethereumSlotDuration: 12,
+    } as any);
+
+    // Within attestation window: 59000ms elapsed < (slotDuration - l1PublishingTime) * 1000 = 60000ms
+    epochCache.getEpochAndSlotNow.mockReturnValue({
+      epoch: EpochNumber(1),
+      slot: SlotNumber(98),
+      ts: 1000n,
+      nowMs: 1059000n, // 59000ms elapsed
+    });
+    epochCache.isInCommittee.mockResolvedValue(true);
+    epochCache.getProposerAttesterAddressInSlot.mockResolvedValue(proposer.address);
+
+    const result = await validator.validate(mockAttestation);
+    expect(result).toEqual({ result: 'accept' });
+  });
+
+  it('rejects attestation for current slot after the target-slot publish cutoff', async () => {
+    // Attestation is for slot 98 (one behind target slot 99), after the publish cutoff.
+    const header = CheckpointHeader.random({ slotNumber: SlotNumber(98) });
+    const mockAttestation = makeCheckpointAttestation({
+      header,
+      attesterSigner: attester,
+      proposerSigner: proposer,
+    });
+
+    epochCache.getTargetAndNextSlot.mockReturnValue({
+      targetSlot: SlotNumber(99),
+      nextSlot: SlotNumber(100),
+    });
+    epochCache.getTargetSlot.mockReturnValue(SlotNumber(99));
+    epochCache.getSlotNow.mockReturnValue(SlotNumber(98));
+    epochCache.isProposerPipeliningEnabled.mockReturnValue(true);
+    epochCache.getL1Constants.mockReturnValue({
+      slotDuration: 72,
+      ethereumSlotDuration: 12,
+    } as any);
+
+    // Outside attestation window AND outside clock tolerance: 61000ms elapsed > 60000ms cutoff
+    epochCache.getEpochAndSlotNow.mockReturnValue({
+      epoch: EpochNumber(1),
+      slot: SlotNumber(99),
+      ts: 1000n,
+      nowMs: 1061000n, // 61000ms elapsed
+    });
+    epochCache.isInCommittee.mockResolvedValue(true);
+
+    const result = await validator.validate(mockAttestation);
+    expect(result).toEqual({ result: 'reject', severity: PeerErrorSeverity.HighToleranceError });
   });
 
   it('returns high tolerance error if attester is not in committee', async () => {

--- a/yarn-project/p2p/src/msg_validators/attestation_validator/attestation_validator.ts
+++ b/yarn-project/p2p/src/msg_validators/attestation_validator/attestation_validator.ts
@@ -8,14 +8,21 @@ import {
   type ValidationResult,
 } from '@aztec/stdlib/p2p';
 
-import { isWithinClockTolerance } from '../clock_tolerance.js';
+import { PipeliningWindow, isWithinClockTolerance } from '../clock_tolerance.js';
 
 export class CheckpointAttestationValidator implements P2PValidator<CheckpointAttestation> {
   protected epochCache: EpochCacheInterface;
   protected logger: Logger;
+  private readonly pipeliningWindow: PipeliningWindow;
 
-  constructor(epochCache: EpochCacheInterface) {
+  constructor(
+    epochCache: EpochCacheInterface,
+    opts: {
+      l1PublishingTime?: number;
+    },
+  ) {
     this.epochCache = epochCache;
+    this.pipeliningWindow = new PipeliningWindow(epochCache, { l1PublishingTime: opts.l1PublishingTime });
     this.logger = createLogger('p2p:checkpoint-attestation-validator');
   }
 
@@ -23,19 +30,23 @@ export class CheckpointAttestationValidator implements P2PValidator<CheckpointAt
     const slotNumber = message.payload.header.slotNumber;
 
     try {
-      // Use target slots since proposals target pipeline slots (slot + 1 when pipelining)
+      // Use target slots since proposals target pipeline slots (slot + 1 when pipelining).
       const { targetSlot, nextSlot } = this.epochCache.getTargetAndNextSlot();
 
       if (slotNumber !== targetSlot && slotNumber !== nextSlot) {
-        // Check if message is for previous slot and within clock tolerance
-        if (!isWithinClockTolerance(slotNumber, targetSlot, this.epochCache)) {
+        // When pipelining, accept attestations for the current slot (built in the previous slot)
+        // until the target slot reaches its L1 publish cutoff.
+        if (this.pipeliningWindow.acceptsAttestation(slotNumber)) {
+          // Fall through to remaining validation (signature, committee, etc.)
+        } else if (!isWithinClockTolerance(slotNumber, targetSlot, this.epochCache)) {
           this.logger.warn(
             `Checkpoint attestation slot ${slotNumber} is not current (${targetSlot}) or next (${nextSlot}) slot`,
           );
           return { result: 'reject', severity: PeerErrorSeverity.HighToleranceError };
+        } else {
+          this.logger.debug(`Ignoring checkpoint attestation for previous slot ${slotNumber} within clock tolerance`);
+          return { result: 'ignore' };
         }
-        this.logger.debug(`Ignoring checkpoint attestation for previous slot ${slotNumber} within clock tolerance`);
-        return { result: 'ignore' };
       }
 
       // Verify the signature is valid

--- a/yarn-project/p2p/src/msg_validators/attestation_validator/fisherman_attestation_validator.test.ts
+++ b/yarn-project/p2p/src/msg_validators/attestation_validator/fisherman_attestation_validator.test.ts
@@ -26,8 +26,14 @@ describe('FishermanAttestationValidator', () => {
 
   beforeEach(() => {
     epochCache = mock<EpochCacheInterface>();
+    epochCache.getL1Constants.mockReturnValue({
+      slotDuration: 72,
+      ethereumSlotDuration: 12,
+    } as any);
     attestationPool = mock<AttestationPool>();
-    validator = new FishermanAttestationValidator(epochCache, attestationPool, getTelemetryClient());
+    validator = new FishermanAttestationValidator(epochCache, attestationPool, getTelemetryClient(), {
+      l1PublishingTime: 12,
+    });
     proposer = Secp256k1Signer.random();
     attester = Secp256k1Signer.random();
   });

--- a/yarn-project/p2p/src/msg_validators/attestation_validator/fisherman_attestation_validator.ts
+++ b/yarn-project/p2p/src/msg_validators/attestation_validator/fisherman_attestation_validator.ts
@@ -20,8 +20,11 @@ export class FishermanAttestationValidator extends CheckpointAttestationValidato
     epochCache: EpochCacheInterface,
     private attestationPool: AttestationPoolApi,
     telemetryClient: TelemetryClient,
+    opts: {
+      l1PublishingTime?: number;
+    } = {},
   ) {
-    super(epochCache);
+    super(epochCache, opts);
     this.logger = this.logger.createChild('[FISHERMAN]');
 
     const meter = telemetryClient.getMeter('FishermanAttestationValidator');

--- a/yarn-project/p2p/src/msg_validators/clock_tolerance.test.ts
+++ b/yarn-project/p2p/src/msg_validators/clock_tolerance.test.ts
@@ -3,7 +3,7 @@ import { SlotNumber } from '@aztec/foundation/branded-types';
 
 import { mock } from 'jest-mock-extended';
 
-import { MAXIMUM_GOSSIP_CLOCK_DISPARITY_MS, isWithinClockTolerance } from './clock_tolerance.js';
+import { MAXIMUM_GOSSIP_CLOCK_DISPARITY_MS, PipeliningWindow, isWithinClockTolerance } from './clock_tolerance.js';
 
 describe('clock_tolerance', () => {
   describe('MAXIMUM_GOSSIP_CLOCK_DISPARITY_MS', () => {
@@ -202,6 +202,181 @@ describe('clock_tolerance', () => {
 
       // Even though timing is within tolerance, the sanity check fails
       expect(isWithinClockTolerance(messageSlot, currentSlot, epochCache)).toBe(false);
+    });
+  });
+
+  describe('PipeliningWindow.acceptsProposal', () => {
+    let epochCache: ReturnType<typeof mock<EpochCacheInterface>>;
+    let pipeliningWindow: PipeliningWindow;
+
+    beforeEach(() => {
+      epochCache = mock<EpochCacheInterface>();
+      epochCache.getSlotNow.mockReturnValue(SlotNumber(100));
+      epochCache.isProposerPipeliningEnabled.mockReturnValue(true);
+      epochCache.getL1Constants.mockReturnValue({
+        slotDuration: 72,
+        ethereumSlotDuration: 12,
+      } as any);
+      pipeliningWindow = new PipeliningWindow(epochCache);
+    });
+
+    it('returns true when pipelining enabled, message is for current slot, and within grace period', () => {
+      // Grace period = DEFAULT_P2P_PROPAGATION_TIME * 1000 = 2000ms
+      epochCache.getEpochAndSlotNow.mockReturnValue({
+        epoch: 1 as any,
+        slot: SlotNumber(100),
+        ts: 1000n,
+        nowMs: 1001000n, // 1000ms elapsed, within 2000ms grace period
+      });
+
+      expect(pipeliningWindow.acceptsProposal(SlotNumber(100))).toBe(true);
+    });
+
+    it('returns true at exactly 0ms elapsed', () => {
+      epochCache.getEpochAndSlotNow.mockReturnValue({
+        epoch: 1 as any,
+        slot: SlotNumber(100),
+        ts: 1000n,
+        nowMs: 1000000n, // 0ms elapsed
+      });
+
+      expect(pipeliningWindow.acceptsProposal(SlotNumber(100))).toBe(true);
+    });
+
+    it('returns false when elapsed time exceeds grace period', () => {
+      // 3000ms elapsed > 2000ms grace period
+      epochCache.getEpochAndSlotNow.mockReturnValue({
+        epoch: 1 as any,
+        slot: SlotNumber(100),
+        ts: 1000n,
+        nowMs: 1003000n, // 3000ms elapsed
+      });
+
+      expect(pipeliningWindow.acceptsProposal(SlotNumber(100))).toBe(false);
+    });
+
+    it('returns true at the propagation boundary when within clock disparity allowance', () => {
+      // 2000ms elapsed = DEFAULT_P2P_PROPAGATION_TIME * 1000, still within the extra 500ms allowance
+      epochCache.getEpochAndSlotNow.mockReturnValue({
+        epoch: 1 as any,
+        slot: SlotNumber(100),
+        ts: 1000n,
+        nowMs: 1002000n, // 2000ms elapsed
+      });
+
+      expect(pipeliningWindow.acceptsProposal(SlotNumber(100))).toBe(true);
+    });
+
+    it('returns false at exactly the propagation boundary plus clock disparity allowance', () => {
+      // 2500ms elapsed = 2000ms propagation window + 500ms disparity allowance (not strictly less than)
+      epochCache.getEpochAndSlotNow.mockReturnValue({
+        epoch: 1 as any,
+        slot: SlotNumber(100),
+        ts: 1000n,
+        nowMs: 1002500n, // 2500ms elapsed
+      });
+
+      expect(pipeliningWindow.acceptsProposal(SlotNumber(100))).toBe(false);
+    });
+
+    it('returns false when pipelining is disabled', () => {
+      epochCache.isProposerPipeliningEnabled.mockReturnValue(false);
+
+      epochCache.getEpochAndSlotNow.mockReturnValue({
+        epoch: 1 as any,
+        slot: SlotNumber(100),
+        ts: 1000n,
+        nowMs: 1001000n, // 1000ms elapsed, within grace period
+      });
+
+      expect(pipeliningWindow.acceptsProposal(SlotNumber(100))).toBe(false);
+    });
+
+    it('returns false when message is not for current slot', () => {
+      epochCache.getEpochAndSlotNow.mockReturnValue({
+        epoch: 1 as any,
+        slot: SlotNumber(100),
+        ts: 1000n,
+        nowMs: 1001000n,
+      });
+
+      // Message for slot 99, current slot is 100
+      expect(pipeliningWindow.acceptsProposal(SlotNumber(99))).toBe(false);
+    });
+
+    it('returns false when message is for a future slot', () => {
+      epochCache.getEpochAndSlotNow.mockReturnValue({
+        epoch: 1 as any,
+        slot: SlotNumber(100),
+        ts: 1000n,
+        nowMs: 1001000n,
+      });
+
+      // Message for slot 101, current slot is 100
+      expect(pipeliningWindow.acceptsProposal(SlotNumber(101))).toBe(false);
+    });
+
+    it('uses the provided propagation time instead of the default', () => {
+      epochCache.getEpochAndSlotNow.mockReturnValue({
+        epoch: 1 as any,
+        slot: SlotNumber(100),
+        ts: 1000n,
+        nowMs: 1003000n, // 3000ms elapsed
+      });
+
+      const longerWindow = new PipeliningWindow(epochCache, { p2pPropagationTime: 4 });
+
+      expect(longerWindow.acceptsProposal(SlotNumber(100))).toBe(true);
+      expect(pipeliningWindow.acceptsProposal(SlotNumber(100))).toBe(false);
+    });
+  });
+
+  describe('PipeliningWindow.acceptsAttestation', () => {
+    let epochCache: ReturnType<typeof mock<EpochCacheInterface>>;
+    let pipeliningWindow: PipeliningWindow;
+
+    beforeEach(() => {
+      epochCache = mock<EpochCacheInterface>();
+      epochCache.getSlotNow.mockReturnValue(SlotNumber(100));
+      epochCache.isProposerPipeliningEnabled.mockReturnValue(true);
+      epochCache.getL1Constants.mockReturnValue({
+        slotDuration: 72,
+        ethereumSlotDuration: 12,
+      } as any);
+      pipeliningWindow = new PipeliningWindow(epochCache, { l1PublishingTime: 12 });
+    });
+
+    it('returns true while still before the target-slot publish cutoff', () => {
+      epochCache.getEpochAndSlotNow.mockReturnValue({
+        epoch: 1 as any,
+        slot: SlotNumber(100),
+        ts: 1000n,
+        nowMs: 1059000n, // 59000ms elapsed
+      });
+
+      expect(pipeliningWindow.acceptsAttestation(SlotNumber(100))).toBe(true);
+    });
+
+    it('returns true at the target-slot publish cutoff when within clock disparity allowance', () => {
+      epochCache.getEpochAndSlotNow.mockReturnValue({
+        epoch: 1 as any,
+        slot: SlotNumber(100),
+        ts: 1000n,
+        nowMs: 1060000n, // 60000ms elapsed
+      });
+
+      expect(pipeliningWindow.acceptsAttestation(SlotNumber(100))).toBe(true);
+    });
+
+    it('returns false at the target-slot publish cutoff plus clock disparity allowance', () => {
+      epochCache.getEpochAndSlotNow.mockReturnValue({
+        epoch: 1 as any,
+        slot: SlotNumber(100),
+        ts: 1000n,
+        nowMs: 1060500n, // 60500ms elapsed
+      });
+
+      expect(pipeliningWindow.acceptsAttestation(SlotNumber(100))).toBe(false);
     });
   });
 });

--- a/yarn-project/p2p/src/msg_validators/clock_tolerance.ts
+++ b/yarn-project/p2p/src/msg_validators/clock_tolerance.ts
@@ -1,5 +1,6 @@
 import type { EpochCacheInterface } from '@aztec/epoch-cache';
 import { SlotNumber } from '@aztec/foundation/branded-types';
+import { DEFAULT_P2P_PROPAGATION_TIME, createPipelinedCheckpointTimingModel } from '@aztec/stdlib/timetable';
 
 /**
  * Maximum clock disparity tolerance for P2P message validation (in milliseconds).
@@ -49,4 +50,71 @@ export function isWithinClockTolerance(
   const elapsedMs = Number(nowMs - slotStartMs);
 
   return elapsedMs < MAXIMUM_GOSSIP_CLOCK_DISPARITY_MS;
+}
+
+/**
+ * Checks if a message should be accepted under the pipelining grace period.
+ *
+ * When pipelining is enabled, `targetSlot = slotNow + 1`. A proposal built in slot N-1
+ * for slot N arrives when validators are in slot N, so their `targetSlot = N+1`.
+ * This function accepts proposals for the current wallclock slot if we're within the
+ * first `windowSeconds` seconds of the slot (the pipelining grace period). - see stdlib/timetable/index.ts
+ *
+ * @param messageSlot - The slot number from the received message
+ * @param epochCache - EpochCache to get timing and pipelining state
+ * @param windowSeconds - The window grace period allowed for attestations into the next slot
+ * @returns true if pipelining is enabled, the message is for the current slot, and we're within the grace period
+ */
+function isWithinPipeliningWindow(
+  messageSlot: SlotNumber,
+  epochCache: EpochCacheInterface,
+  windowSeconds: number,
+): boolean {
+  if (!epochCache.isProposerPipeliningEnabled()) {
+    return false;
+  }
+
+  const currentSlot = epochCache.getSlotNow();
+  if (messageSlot !== currentSlot) {
+    return false;
+  }
+
+  const { ts: slotStartTs, nowMs } = epochCache.getEpochAndSlotNow();
+  const slotStartMs = slotStartTs * 1000n;
+  const elapsedMs = Number(nowMs - slotStartMs);
+  const windowMs = windowSeconds * 1000 + MAXIMUM_GOSSIP_CLOCK_DISPARITY_MS;
+
+  return elapsedMs < windowMs;
+}
+
+export class PipeliningWindow {
+  private readonly proposalWindowIntoTargetSlot: number;
+  private readonly attestationWindowIntoTargetSlot: number;
+
+  constructor(
+    private readonly epochCache: EpochCacheInterface,
+    opts: {
+      p2pPropagationTime?: number;
+      l1PublishingTime?: number;
+    } = {},
+  ) {
+    const l1Constants = epochCache.getL1Constants();
+    const checkpointTiming = createPipelinedCheckpointTimingModel({
+      aztecSlotDuration: l1Constants.slotDuration,
+      ethereumSlotDuration: l1Constants.ethereumSlotDuration,
+      l1PublishingTime: opts.l1PublishingTime ?? l1Constants.ethereumSlotDuration,
+      p2pPropagationTime: opts.p2pPropagationTime ?? DEFAULT_P2P_PROPAGATION_TIME,
+    });
+
+    this.proposalWindowIntoTargetSlot = checkpointTiming.proposalWindowIntoTargetSlot;
+    this.attestationWindowIntoTargetSlot = checkpointTiming.attestationWindowIntoTargetSlot;
+  }
+
+  public acceptsProposal(messageSlot: SlotNumber): boolean {
+    return isWithinPipeliningWindow(messageSlot, this.epochCache, this.proposalWindowIntoTargetSlot);
+  }
+
+  public acceptsAttestation(messageSlot: SlotNumber): boolean {
+    return isWithinPipeliningWindow(messageSlot, this.epochCache, this.attestationWindowIntoTargetSlot);
+  }
 }

--- a/yarn-project/p2p/src/msg_validators/proposal_validator/block_proposal_validator.ts
+++ b/yarn-project/p2p/src/msg_validators/proposal_validator/block_proposal_validator.ts
@@ -6,7 +6,10 @@ import { ProposalValidator } from '../proposal_validator/proposal_validator.js';
 export class BlockProposalValidator implements P2PValidator<BlockProposal> {
   private proposalValidator: ProposalValidator;
 
-  constructor(epochCache: EpochCacheInterface, opts: { txsPermitted: boolean; maxTxsPerBlock?: number }) {
+  constructor(
+    epochCache: EpochCacheInterface,
+    opts: { txsPermitted: boolean; maxTxsPerBlock?: number; p2pPropagationTime?: number },
+  ) {
     this.proposalValidator = new ProposalValidator(epochCache, opts, 'p2p:block_proposal_validator');
   }
 

--- a/yarn-project/p2p/src/msg_validators/proposal_validator/checkpoint_proposal_validator.ts
+++ b/yarn-project/p2p/src/msg_validators/proposal_validator/checkpoint_proposal_validator.ts
@@ -6,7 +6,10 @@ import { ProposalValidator } from '../proposal_validator/proposal_validator.js';
 export class CheckpointProposalValidator implements P2PValidator<CheckpointProposal> {
   private proposalValidator: ProposalValidator;
 
-  constructor(epochCache: EpochCacheInterface, opts: { txsPermitted: boolean; maxTxsPerBlock?: number }) {
+  constructor(
+    epochCache: EpochCacheInterface,
+    opts: { txsPermitted: boolean; maxTxsPerBlock?: number; p2pPropagationTime?: number },
+  ) {
     this.proposalValidator = new ProposalValidator(epochCache, opts, 'p2p:checkpoint_proposal_validator');
   }
 

--- a/yarn-project/p2p/src/msg_validators/proposal_validator/proposal_validator.test.ts
+++ b/yarn-project/p2p/src/msg_validators/proposal_validator/proposal_validator.test.ts
@@ -41,7 +41,15 @@ describe('ProposalValidator', () => {
 
   beforeEach(() => {
     epochCache = mock<EpochCacheInterface>();
-    validator = new ProposalValidator(epochCache, { txsPermitted: true, maxTxsPerBlock: undefined }, 'test');
+    epochCache.getL1Constants.mockReturnValue({
+      slotDuration: 72,
+      ethereumSlotDuration: 12,
+    } as any);
+    validator = new ProposalValidator(
+      epochCache,
+      { txsPermitted: true, maxTxsPerBlock: undefined, p2pPropagationTime: 2 },
+      'test',
+    );
     epochCache.getEpochAndSlotNow.mockReturnValue({
       epoch: EpochNumber(1),
       slot: currentSlot,
@@ -53,6 +61,8 @@ describe('ProposalValidator', () => {
       nextSlot,
     });
     epochCache.getTargetSlot.mockReturnValue(currentSlot);
+    epochCache.getSlotNow.mockReturnValue(currentSlot);
+    epochCache.isProposerPipeliningEnabled.mockReturnValue(false);
   });
 
   describe.each([
@@ -168,6 +178,57 @@ describe('ProposalValidator', () => {
       mockGetProposer(EthAddress.random(), signer.address);
       const result = await validator.validate(proposal);
       expect(result).toEqual({ result: 'accept' });
+    });
+
+    it('accepts proposal for current slot within pipelining grace period', async () => {
+      // Simulate pipelining: targetSlot = 101, but proposal is for slot 100 (current wallclock slot)
+      epochCache.getTargetAndNextSlot.mockReturnValue({
+        targetSlot: SlotNumber(101),
+        nextSlot: SlotNumber(102),
+      });
+      epochCache.getSlotNow.mockReturnValue(currentSlot); // slot 100
+      epochCache.isProposerPipeliningEnabled.mockReturnValue(true);
+
+      // Within grace period: 1000ms elapsed < configured propagation window 2000ms
+      epochCache.getEpochAndSlotNow.mockReturnValue({
+        epoch: EpochNumber(1),
+        slot: currentSlot,
+        ts: 1000n,
+        nowMs: 1001000n, // 1000ms elapsed
+      });
+
+      const signer = Secp256k1Signer.random();
+      const proposal = await factory(currentSlot, signer);
+
+      epochCache.getProposerAttesterAddressInSlot.mockResolvedValue(signer.address);
+      const result = await validator.validate(proposal);
+      expect(result).toEqual({ result: 'accept' });
+    });
+
+    it('rejects proposal for current slot outside pipelining grace period', async () => {
+      // Simulate pipelining: targetSlot = 101, but proposal is for slot 100 (current wallclock slot)
+      epochCache.getTargetAndNextSlot.mockReturnValue({
+        targetSlot: SlotNumber(101),
+        nextSlot: SlotNumber(102),
+      });
+      epochCache.getTargetSlot.mockReturnValue(SlotNumber(101));
+      epochCache.getSlotNow.mockReturnValue(currentSlot); // slot 100
+      epochCache.isProposerPipeliningEnabled.mockReturnValue(true);
+
+      // Outside grace period: 7000ms elapsed > configured propagation window 2000ms
+      epochCache.getEpochAndSlotNow.mockReturnValue({
+        epoch: EpochNumber(1),
+        slot: currentSlot,
+        ts: 1000n,
+        nowMs: 1007000n, // 7000ms elapsed
+      });
+
+      const signer = Secp256k1Signer.random();
+      const proposal = await factory(currentSlot, signer);
+
+      epochCache.getProposerAttesterAddressInSlot.mockResolvedValue(signer.address);
+      const result = await validator.validate(proposal);
+      expect(result).toEqual({ result: 'reject', severity: PeerErrorSeverity.HighToleranceError });
     });
   });
 

--- a/yarn-project/p2p/src/msg_validators/proposal_validator/proposal_validator.ts
+++ b/yarn-project/p2p/src/msg_validators/proposal_validator/proposal_validator.ts
@@ -8,7 +8,7 @@ import {
   type ValidationResult,
 } from '@aztec/stdlib/p2p';
 
-import { isWithinClockTolerance } from '../clock_tolerance.js';
+import { PipeliningWindow, isWithinClockTolerance } from '../clock_tolerance.js';
 
 /** Validates header-level and tx-level fields of block and checkpoint proposals. */
 export class ProposalValidator {
@@ -16,33 +16,39 @@ export class ProposalValidator {
   private logger: Logger;
   private txsPermitted: boolean;
   private maxTxsPerBlock?: number;
+  private pipeliningWindow: PipeliningWindow;
 
   constructor(
     epochCache: EpochCacheInterface,
-    opts: { txsPermitted: boolean; maxTxsPerBlock?: number },
+    opts: { txsPermitted: boolean; maxTxsPerBlock?: number; p2pPropagationTime?: number },
     loggerName: string,
   ) {
     this.epochCache = epochCache;
     this.txsPermitted = opts.txsPermitted;
     this.maxTxsPerBlock = opts.maxTxsPerBlock;
+    this.pipeliningWindow = new PipeliningWindow(epochCache, { p2pPropagationTime: opts.p2pPropagationTime });
     this.logger = createLogger(loggerName);
   }
 
   /** Validates header-level fields: slot, signature, and proposer. */
   public async validate(proposal: BlockProposal | CheckpointProposalCore): Promise<ValidationResult> {
     try {
-      // Slot check: use target slots since proposals target pipeline slots (slot + 1 when pipelining)
+      // Slot check: use target slots since proposals target pipeline slots (slot + 1 when pipelining).
       const { targetSlot, nextSlot } = this.epochCache.getTargetAndNextSlot();
 
       const slotNumber = proposal.slotNumber;
       if (slotNumber !== targetSlot && slotNumber !== nextSlot) {
-        // Check if message is for previous slot and within clock tolerance
-        if (!isWithinClockTolerance(slotNumber, targetSlot, this.epochCache)) {
+        // When pipelining, accept proposals for the current slot (built in the previous slot)
+        // if they're still within the shared proposal acceptance window.
+        if (this.pipeliningWindow.acceptsProposal(slotNumber)) {
+          // Fall through to remaining validation (signature, proposer, etc.)
+        } else if (!isWithinClockTolerance(slotNumber, targetSlot, this.epochCache)) {
           this.logger.warn(`Penalizing peer for invalid slot number ${slotNumber}`, { targetSlot, nextSlot });
           return { result: 'reject', severity: PeerErrorSeverity.HighToleranceError };
+        } else {
+          this.logger.verbose(`Ignoring proposal for previous slot ${slotNumber} within clock tolerance`);
+          return { result: 'ignore' };
         }
-        this.logger.verbose(`Ignoring proposal for previous slot ${slotNumber} within clock tolerance`);
-        return { result: 'ignore' };
       }
 
       // Signature validity

--- a/yarn-project/p2p/src/services/gossipsub/topic_score_params.test.ts
+++ b/yarn-project/p2p/src/services/gossipsub/topic_score_params.test.ts
@@ -20,8 +20,10 @@ describe('Topic Score Params', () => {
   // Standard network parameters for testing (matching production values)
   const standardParams = {
     slotDurationMs: 72000, // 72 seconds
+    ethereumSlotDuration: 12,
     heartbeatIntervalMs: 700, // 700ms gossipsub heartbeat
     targetCommitteeSize: 48,
+    l1PublishingTime: 12,
   };
 
   describe('calculateBlocksPerSlot', () => {
@@ -42,10 +44,19 @@ describe('Topic Score Params', () => {
       expect(result).toBeGreaterThanOrEqual(1);
     });
 
-    it('returns at least 1 block per slot', () => {
-      // Even with very long block duration, should return at least 1
-      const result = calculateBlocksPerSlot(72000, 60000);
-      expect(result).toBeGreaterThanOrEqual(1);
+    it('uses the same compressed timing allowances as the sequencer for test configs', () => {
+      expect(() =>
+        calculateBlocksPerSlot(24000, 4000, {
+          ethereumSlotDuration: 8,
+          l1PublishingTime: 1,
+        }),
+      ).not.toThrow();
+    });
+
+    it('throws for an impossible timing configuration', () => {
+      expect(() => calculateBlocksPerSlot(72000, 60000)).toThrow(
+        'Invalid timing configuration: only -6s available for block building, which is less than one blockDuration (60s).',
+      );
     });
   });
 

--- a/yarn-project/p2p/src/services/gossipsub/topic_score_params.ts
+++ b/yarn-project/p2p/src/services/gossipsub/topic_score_params.ts
@@ -1,5 +1,5 @@
 import { TopicType, createTopicString } from '@aztec/stdlib/p2p';
-import { calculateMaxBlocksPerSlot } from '@aztec/stdlib/timetable';
+import { createCheckpointTimingModel } from '@aztec/stdlib/timetable';
 
 import { createTopicScoreParams } from '@chainsafe/libp2p-gossipsub/score';
 
@@ -9,12 +9,18 @@ import { createTopicScoreParams } from '@chainsafe/libp2p-gossipsub/score';
 export type TopicScoringNetworkParams = {
   /** L2 slot duration in milliseconds */
   slotDurationMs: number;
+  /** L1 slot duration in seconds */
+  ethereumSlotDuration: number;
   /** Gossipsub heartbeat interval in milliseconds */
   heartbeatIntervalMs: number;
   /** Target committee size (number of validators expected to attest per slot) */
   targetCommitteeSize: number;
   /** Duration per block in milliseconds when building multiple blocks per slot. If undefined, single block mode. */
   blockDurationMs?: number;
+  /** Time budget in seconds reserved for L1 publishing. Defaults to ethereumSlotDuration. */
+  l1PublishingTime?: number;
+  /** One-way proposal/attestation propagation budget in seconds. */
+  p2pPropagationTime?: number;
   /** Expected number of block proposals per slot for scoring override. 0 disables scoring, undefined falls back to blocksPerSlot - 1. */
   expectedBlockProposalsPerSlot?: number;
 };
@@ -25,10 +31,32 @@ export type TopicScoringNetworkParams = {
  *
  * @param slotDurationMs - L2 slot duration in milliseconds
  * @param blockDurationMs - Duration per block in milliseconds (undefined = single block mode)
+ * @param opts - Shared checkpoint timing inputs used by the sequencer and validators
  * @returns Number of blocks per slot
  */
-export function calculateBlocksPerSlot(slotDurationMs: number, blockDurationMs: number | undefined): number {
-  return calculateMaxBlocksPerSlot(slotDurationMs / 1000, blockDurationMs ? blockDurationMs / 1000 : undefined);
+export function calculateBlocksPerSlot(
+  slotDurationMs: number,
+  blockDurationMs: number | undefined,
+  opts?: {
+    ethereumSlotDuration: number;
+    l1PublishingTime?: number;
+    p2pPropagationTime?: number;
+  },
+): number {
+  if (!opts) {
+    return createCheckpointTimingModel({
+      aztecSlotDuration: slotDurationMs / 1000,
+      blockDuration: blockDurationMs ? blockDurationMs / 1000 : undefined,
+    }).calculateMaxBlocksPerSlot();
+  }
+
+  return createCheckpointTimingModel({
+    aztecSlotDuration: slotDurationMs / 1000,
+    ethereumSlotDuration: opts.ethereumSlotDuration,
+    blockDuration: blockDurationMs ? blockDurationMs / 1000 : undefined,
+    l1PublishingTime: opts.l1PublishingTime ?? opts.ethereumSlotDuration,
+    p2pPropagationTime: opts.p2pPropagationTime,
+  }).calculateMaxBlocksPerSlot();
 }
 
 /**
@@ -279,7 +307,11 @@ export class TopicScoreParamsFactory {
     const { slotDurationMs, heartbeatIntervalMs, blockDurationMs } = params;
 
     // Compute values that are the same for all topics
-    this.blocksPerSlot = calculateBlocksPerSlot(slotDurationMs, blockDurationMs);
+    this.blocksPerSlot = calculateBlocksPerSlot(slotDurationMs, blockDurationMs, {
+      ethereumSlotDuration: params.ethereumSlotDuration,
+      l1PublishingTime: params.l1PublishingTime,
+      p2pPropagationTime: params.p2pPropagationTime,
+    });
     this.heartbeatsPerSlot = slotDurationMs / heartbeatIntervalMs;
     this.invalidDecay = computeDecay(heartbeatIntervalMs, slotDurationMs, INVALID_DECAY_WINDOW_SLOTS);
 

--- a/yarn-project/p2p/src/services/libp2p/libp2p_service.test.ts
+++ b/yarn-project/p2p/src/services/libp2p/libp2p_service.test.ts
@@ -1180,6 +1180,10 @@ function createTestLibP2PService(options: CreateTestLibP2PServiceOptions): TestL
     epochCache = mock<EpochCacheInterface>(),
   } = options;
 
+  epochCache.getL1Constants.mockReturnValue({
+    slotDuration: 36,
+  } as any);
+
   const mempools = mock<MemPools>();
   mempools.attestationPool = attestationPool;
   mempools.txPool = txPool;

--- a/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
+++ b/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
@@ -228,15 +228,19 @@ export class LibP2PService extends WithTracer implements P2PService {
       this.protocolVersion,
     );
 
+    const p2pPropagationTime = config.attestationPropagationTime;
     const proposalValidatorOpts = {
       txsPermitted: !config.disableTransactions,
       maxTxsPerBlock: config.validateMaxTxsPerBlock ?? config.validateMaxTxsPerCheckpoint,
+      p2pPropagationTime,
     };
     this.blockProposalValidator = new BlockProposalValidator(epochCache, proposalValidatorOpts);
     this.checkpointProposalValidator = new CheckpointProposalValidator(epochCache, proposalValidatorOpts);
     this.checkpointAttestationValidator = config.fishermanMode
-      ? new FishermanAttestationValidator(epochCache, mempools.attestationPool, telemetry)
-      : new CheckpointAttestationValidator(epochCache);
+      ? new FishermanAttestationValidator(epochCache, mempools.attestationPool, telemetry, {
+          l1PublishingTime: config.l1PublishingTime,
+        })
+      : new CheckpointAttestationValidator(epochCache, { l1PublishingTime: config.l1PublishingTime });
 
     this.gossipSubEventHandler = this.handleGossipSubEvent.bind(this);
 
@@ -346,9 +350,12 @@ export class LibP2PService extends WithTracer implements P2PService {
     const l1Constants = epochCache.getL1Constants();
     const topicScoreParams = createAllTopicScoreParams(protocolVersion, {
       slotDurationMs: l1Constants.slotDuration * 1000,
+      ethereumSlotDuration: l1Constants.ethereumSlotDuration,
       heartbeatIntervalMs: config.gossipsubInterval,
       targetCommitteeSize: l1Constants.targetCommitteeSize,
       blockDurationMs: config.blockDurationMs,
+      l1PublishingTime: config.l1PublishingTime,
+      p2pPropagationTime: config.attestationPropagationTime,
       expectedBlockProposalsPerSlot: config.expectedBlockProposalsPerSlot,
     });
 

--- a/yarn-project/p2p/src/test-helpers/mock-pubsub.ts
+++ b/yarn-project/p2p/src/test-helpers/mock-pubsub.ts
@@ -1,5 +1,6 @@
 import type { EpochCacheInterface } from '@aztec/epoch-cache';
 import { type Logger, createLogger } from '@aztec/foundation/log';
+import { sleep } from '@aztec/foundation/sleep';
 import type { AztecAsyncKVStore } from '@aztec/kv-store';
 import type { L2BlockSource } from '@aztec/stdlib/block';
 import type { ContractDataSource } from '@aztec/stdlib/contract';
@@ -139,6 +140,11 @@ class MockReqResp implements ReqRespInterface {
     const responses: InstanceType<SubProtocolMap[SubProtocol]['response']>[] = [];
     const peers = this.network.getReqRespPeers().filter(p => !p.peerId.equals(this.peerId));
     const targetPeers = pinnedPeer ? peers.filter(p => p.peerId.equals(pinnedPeer)) : peers;
+    const delayMs = this.network.getPropagationDelayMs();
+
+    if (delayMs > 0) {
+      await sleep(delayMs);
+    }
 
     for (const request of requests) {
       const requestBuffer = request.toBuffer();
@@ -175,7 +181,12 @@ class MockReqResp implements ReqRespInterface {
       return { status: ReqRespStatus.SUCCESS, data: Buffer.from([]) };
     }
     try {
+      const delayMs = this.network.getPropagationDelayMs();
+      if (delayMs > 0) {
+        await sleep(delayMs);
+      }
       const data = await handler(this.peerId, payload);
+
       return { status: ReqRespStatus.SUCCESS, data };
     } catch {
       return { status: ReqRespStatus.FAILURE };
@@ -243,10 +254,10 @@ class MockGossipSubService extends TypedEventEmitter<GossipsubEvents> implements
     score: (_peerId: PeerIdStr) => 0,
   };
 
-  publish(topic: TopicStr, data: Uint8Array, _opts?: PublishOpts): Promise<PublishResult> {
+  async publish(topic: TopicStr, data: Uint8Array, _opts?: PublishOpts): Promise<PublishResult> {
     this.logger.debug(`Publishing message on topic ${topic}`, { topic, sender: this.peerId.toString() });
-    this.network.publishToPeers(topic, data, this.peerId);
-    return Promise.resolve({ recipients: this.network.getPeers().filter(peer => !this.peerId.equals(peer)) });
+    await this.network.publishToPeers(topic, data, this.peerId);
+    return { recipients: this.network.getPeers().filter(peer => !this.peerId.equals(peer)) };
   }
 
   receive(msg: GossipsubMessage) {
@@ -282,7 +293,8 @@ class MockGossipSubService extends TypedEventEmitter<GossipsubEvents> implements
 
 /**
  * Mock gossip sub network used for testing.
- * All instances of MockGossipSubService connected to the same network will instantly receive the same messages.
+ * All instances of MockGossipSubService connected to the same network receive the same messages,
+ * optionally delayed by a configurable propagation time.
  */
 export class MockGossipSubNetwork {
   private peers: MockGossipSubService[] = [];
@@ -290,6 +302,15 @@ export class MockGossipSubNetwork {
   private nextMsgId = 0;
 
   private logger = createLogger('p2p:test:mock-gossipsub-network');
+
+  constructor(
+    /** Artificial propagation delay in milliseconds applied to each message delivery. */
+    private propagationDelayMs: number = 0,
+  ) {}
+
+  public getPropagationDelayMs(): number {
+    return this.propagationDelayMs;
+  }
 
   public getPeers(): PeerId[] {
     return this.peers.map(peer => peer.peerId);
@@ -307,7 +328,7 @@ export class MockGossipSubNetwork {
     return this.reqRespPeers;
   }
 
-  public publishToPeers(topic: TopicStr, data: Uint8Array, sender: PeerId): void {
+  public async publishToPeers(topic: TopicStr, data: Uint8Array, sender: PeerId): Promise<void> {
     const msgId = (this.nextMsgId++).toString();
     this.logger.debug(`Network is distributing message on topic ${topic}`, {
       topic,
@@ -315,6 +336,10 @@ export class MockGossipSubNetwork {
       sender: sender.toString(),
       msgId,
     });
+
+    if (this.propagationDelayMs > 0) {
+      await sleep(this.propagationDelayMs);
+    }
 
     const gossipSubMsg: GossipsubMessage = { msgId, msg: { type: 'unsigned', topic, data }, propagationSource: sender };
     for (const peer of this.peers) {

--- a/yarn-project/sequencer-client/src/config.ts
+++ b/yarn-project/sequencer-client/src/config.ts
@@ -155,11 +155,6 @@ export const sequencerConfigMappings: ConfigMappingsType<SequencerConfig> = {
     description: 'How much time (in seconds) we allow in the slot for publishing the L1 tx (defaults to 1 L1 slot).',
     parseEnv: (val: string) => (val ? parseInt(val, 10) : undefined),
   },
-  attestationPropagationTime: {
-    env: 'SEQ_ATTESTATION_PROPAGATION_TIME',
-    description: 'How many seconds it takes for proposals and attestations to travel across the p2p layer (one-way)',
-    ...numberConfigHelper(DefaultSequencerConfig.attestationPropagationTime),
-  },
   fakeProcessingDelayPerTxMs: {
     description: 'Used for testing to introduce a fake delay after processing each tx',
   },

--- a/yarn-project/sequencer-client/src/global_variable_builder/global_builder.ts
+++ b/yarn-project/sequencer-client/src/global_variable_builder/global_builder.ts
@@ -1,4 +1,8 @@
-import { RollupContract } from '@aztec/ethereum/contracts';
+import {
+  RollupContract,
+  type SimulationOverridesPlan,
+  buildSimulationOverridesStateOverride,
+} from '@aztec/ethereum/contracts';
 import type { L1ContractAddresses } from '@aztec/ethereum/l1-contract-addresses';
 import type { ViemPublicClient } from '@aztec/ethereum/types';
 import { BlockNumber, SlotNumber } from '@aztec/foundation/branded-types';
@@ -10,7 +14,6 @@ import type { AztecAddress } from '@aztec/stdlib/aztec-address';
 import { type L1RollupConstants, getNextL1SlotTimestamp, getTimestampForSlot } from '@aztec/stdlib/epoch-helpers';
 import { GasFees } from '@aztec/stdlib/gas';
 import type {
-  BuildCheckpointGlobalVariablesOpts,
   CheckpointGlobalVariables,
   GlobalVariableBuilder as GlobalVariableBuilderInterface,
 } from '@aztec/stdlib/tx';
@@ -120,7 +123,7 @@ export class GlobalVariableBuilder implements GlobalVariableBuilderInterface {
     coinbase: EthAddress,
     feeRecipient: AztecAddress,
     slotNumber: SlotNumber,
-    opts?: BuildCheckpointGlobalVariablesOpts,
+    simulationOverridesPlan?: SimulationOverridesPlan,
   ): Promise<CheckpointGlobalVariables> {
     const { chainId, version } = this;
 
@@ -129,18 +132,7 @@ export class GlobalVariableBuilder implements GlobalVariableBuilderInterface {
       l1GenesisTime: this.l1GenesisTime,
     });
 
-    // When pipelining, force the proposed checkpoint number and fee header to the parent so that
-    // the fee computation matches what L1 will see when the previous pipelined checkpoint has landed.
-    const pendingNumberOverride = await this.rollupContract.makePendingCheckpointNumberOverride(
-      opts?.forcePendingCheckpointNumber,
-    );
-    const feeHeaderOverride = opts?.forceProposedFeeHeader
-      ? await this.rollupContract.makeFeeHeaderOverride(
-          opts.forceProposedFeeHeader.checkpointNumber,
-          opts.forceProposedFeeHeader.feeHeader,
-        )
-      : [];
-    const stateOverride = RollupContract.mergeStateOverrides(pendingNumberOverride, feeHeaderOverride);
+    const stateOverride = await buildSimulationOverridesStateOverride(this.rollupContract, simulationOverridesPlan);
     const gasFees = new GasFees(0, await this.rollupContract.getManaMinFeeAt(timestamp, true, stateOverride));
 
     return { chainId, version, slotNumber, timestamp, coinbase, feeRecipient, gasFees };

--- a/yarn-project/sequencer-client/src/publisher/sequencer-publisher.ts
+++ b/yarn-project/sequencer-client/src/publisher/sequencer-publisher.ts
@@ -4,15 +4,17 @@ import type { EpochCache } from '@aztec/epoch-cache';
 import type { L1ContractsConfig } from '@aztec/ethereum/config';
 import {
   FeeAssetPriceOracle,
-  type FeeHeader,
   type GovernanceProposerContract,
   type IEmpireBase,
   MULTI_CALL_3_ADDRESS,
   Multicall3,
   RollupContract,
+  SimulationOverridesBuilder,
+  type SimulationOverridesPlan,
   type SlashingProposerContract,
   type ViemCommitteeAttestations,
   type ViemHeader,
+  buildSimulationOverridesStateOverride,
 } from '@aztec/ethereum/contracts';
 import { type L1FeeAnalysisResult, L1FeeAnalyzer } from '@aztec/ethereum/l1-fee-analysis';
 import {
@@ -26,7 +28,6 @@ import {
 } from '@aztec/ethereum/l1-tx-utils';
 import { FormattedViemError, formatViemError, mergeAbis, tryExtractEvent } from '@aztec/ethereum/utils';
 import { sumBigint } from '@aztec/foundation/bigint';
-import { toHex as toPaddedHex } from '@aztec/foundation/bigint-buffer';
 import { CheckpointNumber, SlotNumber } from '@aztec/foundation/branded-types';
 import { trimmedBytesLength } from '@aztec/foundation/buffer';
 import { pick } from '@aztec/foundation/collection';
@@ -50,7 +51,6 @@ import { type TelemetryClient, type Tracer, getTelemetryClient, trackSpan } from
 
 import {
   type Hex,
-  type StateOverride,
   type TransactionReceipt,
   type TypedDataDefinition,
   encodeFunctionData,
@@ -117,6 +117,11 @@ export type InvalidateCheckpointRequest = {
   forcePendingCheckpointNumber: CheckpointNumber;
   /** Archive at the rollback target checkpoint (checkpoint N-1). */
   lastArchive: Fr;
+};
+
+type EnqueueProposeCheckpointOpts = {
+  txTimeoutAt?: Date;
+  simulationOverridesPlan?: SimulationOverridesPlan;
 };
 
 interface RequestWithExpiry {
@@ -662,27 +667,21 @@ export class SequencerPublisher {
    * @param tipArchive - The archive to check
    * @returns The slot and block number if it is possible to propose, undefined otherwise
    */
-  public canProposeAt(
-    tipArchive: Fr,
-    msgSender: EthAddress,
-    opts: {
-      forcePendingCheckpointNumber?: CheckpointNumber;
-      forceArchive?: { checkpointNumber: CheckpointNumber; archive: Fr };
-      pipelined?: boolean;
-    } = {},
-  ) {
+  public async canProposeAt(tipArchive: Fr, msgSender: EthAddress, simulationOverridesPlan?: SimulationOverridesPlan) {
     // TODO: #14291 - should loop through multiple keys to check if any of them can propose
     const ignoredErrors = ['SlotAlreadyInChain', 'InvalidProposer', 'InvalidArchive'];
 
-    const pipelined = opts.pipelined ?? this.epochCache.isProposerPipeliningEnabled();
+    const pipelined = this.epochCache.isProposerPipeliningEnabled();
     const slotOffset = pipelined ? this.aztecSlotDuration : 0n;
     const nextL1SlotTs = this.getNextL1SlotTimestamp() + slotOffset;
 
     return this.rollupContract
-      .canProposeAt(tipArchive.toBuffer(), msgSender.toString(), nextL1SlotTs, {
-        forcePendingCheckpointNumber: opts.forcePendingCheckpointNumber,
-        forceArchive: opts.forceArchive,
-      })
+      .canProposeAt(
+        tipArchive.toBuffer(),
+        msgSender.toString(),
+        nextL1SlotTs,
+        await buildSimulationOverridesStateOverride(this.rollupContract, simulationOverridesPlan),
+      )
       .catch(err => {
         if (err instanceof FormattedViemError && ignoredErrors.find(e => err.message.includes(e))) {
           this.log.warn(`Failed canProposeAtTime check with ${ignoredErrors.find(e => err.message.includes(e))}`, {
@@ -704,7 +703,7 @@ export class SequencerPublisher {
   @trackSpan('SequencerPublisher.validateBlockHeader')
   public async validateBlockHeader(
     header: CheckpointHeader,
-    opts?: { forcePendingCheckpointNumber: CheckpointNumber | undefined },
+    simulationOverridesPlan?: SimulationOverridesPlan,
   ): Promise<void> {
     const flags = { ignoreDA: true, ignoreSignatures: true };
 
@@ -719,9 +718,7 @@ export class SequencerPublisher {
     ] as const;
 
     const ts = this.getSimulationTimestamp(header.slotNumber);
-    const stateOverrides = await this.rollupContract.makePendingCheckpointNumberOverride(
-      opts?.forcePendingCheckpointNumber,
-    );
+    const stateOverrides = await buildSimulationOverridesStateOverride(this.rollupContract, simulationOverridesPlan);
     let balance = 0n;
     if (this.config.fishermanMode) {
       // In fisherman mode, we can't know where the proposer is publishing from
@@ -882,10 +879,7 @@ export class SequencerPublisher {
     checkpoint: Checkpoint,
     attestationsAndSigners: CommitteeAttestationsAndSigners,
     attestationsAndSignersSignature: Signature,
-    options: {
-      forcePendingCheckpointNumber?: CheckpointNumber;
-      forceProposedFeeHeader?: { checkpointNumber: CheckpointNumber; feeHeader: FeeHeader };
-    },
+    simulationOverridesPlan?: SimulationOverridesPlan,
   ): Promise<void> {
     const blobFields = checkpoint.toBlobFields();
     const blobs = await getBlobsPerL1Block(blobFields);
@@ -905,7 +899,7 @@ export class SequencerPublisher {
       blobInput,
     ] as const;
 
-    await this.simulateProposeTx(args, options);
+    await this.simulateProposeTx(args, simulationOverridesPlan);
   }
 
   private async enqueueCastSignalHelper(
@@ -1154,11 +1148,7 @@ export class SequencerPublisher {
     checkpoint: Checkpoint,
     attestationsAndSigners: CommitteeAttestationsAndSigners,
     attestationsAndSignersSignature: Signature,
-    opts: {
-      txTimeoutAt?: Date;
-      forcePendingCheckpointNumber?: CheckpointNumber;
-      forceProposedFeeHeader?: { checkpointNumber: CheckpointNumber; feeHeader: FeeHeader };
-    } = {},
+    opts: EnqueueProposeCheckpointOpts = {},
   ): Promise<void> {
     const checkpointHeader = checkpoint.header;
 
@@ -1174,6 +1164,10 @@ export class SequencerPublisher {
       feeAssetPriceModifier: checkpoint.feeAssetPriceModifier,
     };
 
+    const simulationOverridesPlan = SimulationOverridesBuilder.from(opts.simulationOverridesPlan)
+      .withoutBlobCheck()
+      .build();
+
     try {
       // @note  This will make sure that we are passing the checks for our header ASSUMING that the data is also made available
       //        This means that we can avoid the simulation issues in later checks.
@@ -1184,13 +1178,13 @@ export class SequencerPublisher {
         checkpoint,
         attestationsAndSigners,
         attestationsAndSignersSignature,
-        opts,
+        simulationOverridesPlan,
       );
     } catch (err: any) {
       this.log.error(`Checkpoint validation failed. ${err instanceof Error ? err.message : 'No error message'}`, err, {
         ...checkpoint.getStats(),
         slotNumber: checkpoint.header.slotNumber,
-        forcePendingCheckpointNumber: opts.forcePendingCheckpointNumber,
+        simulationOverridesPlan,
       });
       throw err;
     }
@@ -1205,16 +1199,22 @@ export class SequencerPublisher {
           checkpoint,
           attestationsAndSigners,
           attestationsAndSignersSignature,
-          {
-            // Forcing pending checkpoint number is included its required if an invalidation request is included
-            forcePendingCheckpointNumber: opts.forcePendingCheckpointNumber,
-          },
+          simulationOverridesPlan,
         );
       };
     }
 
-    this.log.verbose(`Enqueuing checkpoint propose transaction`, { ...checkpoint.toCheckpointInfo(), ...opts });
-    await this.addProposeTx(checkpoint, proposeTxArgs, opts, preCheck);
+    this.log.verbose(`Enqueuing checkpoint propose transaction`, {
+      ...checkpoint.toCheckpointInfo(),
+      txTimeoutAt: opts.txTimeoutAt,
+      simulationOverridesPlan,
+    });
+    await this.addProposeTx(
+      checkpoint,
+      proposeTxArgs,
+      { txTimeoutAt: opts.txTimeoutAt, simulationOverridesPlan },
+      preCheck,
+    );
   }
 
   public enqueueInvalidateCheckpoint(
@@ -1344,10 +1344,7 @@ export class SequencerPublisher {
     this.l1TxUtils.restart();
   }
 
-  private async prepareProposeTx(
-    encodedData: L1ProcessArgs,
-    options: { forcePendingCheckpointNumber?: CheckpointNumber },
-  ) {
+  private async prepareProposeTx(encodedData: L1ProcessArgs, simulationOverridesPlan?: SimulationOverridesPlan) {
     const kzg = Blob.getViemKzgInstance();
     const blobInput = getPrefixedEthBlobCommitments(encodedData.blobs);
     this.log.debug('Validating blob input', { blobInput });
@@ -1418,7 +1415,7 @@ export class SequencerPublisher {
       blobInput,
     ] as const;
 
-    const { rollupData, simulationResult } = await this.simulateProposeTx(args, options);
+    const { rollupData, simulationResult } = await this.simulateProposeTx(args, simulationOverridesPlan);
 
     return { args, blobEvaluationGas, rollupData, simulationResult };
   }
@@ -1442,10 +1439,7 @@ export class SequencerPublisher {
       ViemSignature,
       `0x${string}`,
     ],
-    options: {
-      forcePendingCheckpointNumber?: CheckpointNumber;
-      forceProposedFeeHeader?: { checkpointNumber: CheckpointNumber; feeHeader: FeeHeader };
-    },
+    simulationOverridesPlan?: SimulationOverridesPlan,
   ) {
     const rollupData = encodeFunctionData({
       abi: RollupAbi,
@@ -1453,34 +1447,7 @@ export class SequencerPublisher {
       args,
     });
 
-    // override the proposed checkpoint number if requested
-    const forcePendingCheckpointNumberStateDiff = (
-      options.forcePendingCheckpointNumber !== undefined
-        ? await this.rollupContract.makePendingCheckpointNumberOverride(options.forcePendingCheckpointNumber)
-        : []
-    ).flatMap(override => override.stateDiff ?? []);
-
-    // override the fee header for a specific checkpoint number if requested (used when pipelining)
-    const forceProposedFeeHeaderStateDiff = (
-      options.forceProposedFeeHeader !== undefined
-        ? await this.rollupContract.makeFeeHeaderOverride(
-            options.forceProposedFeeHeader.checkpointNumber,
-            options.forceProposedFeeHeader.feeHeader,
-          )
-        : []
-    ).flatMap(override => override.stateDiff ?? []);
-
-    const stateOverrides: StateOverride = [
-      {
-        address: this.rollupContract.address,
-        // @note we override checkBlob to false since blobs are not part simulate()
-        stateDiff: [
-          { slot: toPaddedHex(RollupContract.checkBlobStorageSlot, true), value: toPaddedHex(0n, true) },
-          ...forcePendingCheckpointNumberStateDiff,
-          ...forceProposedFeeHeaderStateDiff,
-        ],
-      },
-    ];
+    const stateOverrides = await buildSimulationOverridesStateOverride(this.rollupContract, simulationOverridesPlan);
     // In fisherman mode, simulate as the proposer but with sufficient balance
     if (this.proposerAddressForSimulation) {
       stateOverrides.push({
@@ -1545,17 +1512,16 @@ export class SequencerPublisher {
   private async addProposeTx(
     checkpoint: Checkpoint,
     encodedData: L1ProcessArgs,
-    opts: {
-      txTimeoutAt?: Date;
-      forcePendingCheckpointNumber?: CheckpointNumber;
-      forceProposedFeeHeader?: { checkpointNumber: CheckpointNumber; feeHeader: FeeHeader };
-    } = {},
+    opts: EnqueueProposeCheckpointOpts = {},
     preCheck?: () => Promise<void>,
   ): Promise<void> {
     const slot = checkpoint.header.slotNumber;
     const timer = new Timer();
     const kzg = Blob.getViemKzgInstance();
-    const { rollupData, simulationResult, blobEvaluationGas } = await this.prepareProposeTx(encodedData, opts);
+    const { rollupData, simulationResult, blobEvaluationGas } = await this.prepareProposeTx(
+      encodedData,
+      opts.simulationOverridesPlan,
+    );
     const startBlock = await this.l1TxUtils.getBlockNumber();
     const gasLimit = this.l1TxUtils.bumpGasLimit(
       BigInt(Math.ceil((Number(simulationResult.gasUsed) * 64) / 63)) +
@@ -1578,7 +1544,7 @@ export class SequencerPublisher {
         data: rollupData,
       },
       lastValidL2Slot: checkpoint.header.slotNumber,
-      gasConfig: { ...opts, gasLimit },
+      gasConfig: { txTimeoutAt: opts.txTimeoutAt, gasLimit },
       preCheck,
       blobConfig: {
         blobs: encodedData.blobs.map(b => b.data),

--- a/yarn-project/sequencer-client/src/sequencer/README.md
+++ b/yarn-project/sequencer-client/src/sequencer/README.md
@@ -88,7 +88,8 @@ checkpointFinalizationTime = propagationTime
 timeReservedAtEnd (normal mode) = blockDuration               (last sub-slot for reexecution)
                                 + checkpointFinalizationTime
 
-timeReservedAtEnd (pipelining) = blockDuration                (last sub-slot for reexecution only)
+timeReservedAtEnd (pipelining) = assembleTime
+                               + propagationTime             (proposal must reach validators before the slot flips)
 
 timeAvailableForBlocks = slotDuration - initializationOffset - timeReservedAtEnd
 
@@ -109,9 +110,9 @@ This means:
 
 **The same slot with proposer pipelining enabled:**
 ```
-timeReservedAtEnd = 8s
-timeAvailableForBlocks = 72s - 2s - 8s = 62s
-numberOfBlocks = floor(62s / 8s) = 7 blocks
+timeReservedAtEnd = 1s + 2s = 3s
+timeAvailableForBlocks = 72s - 2s - 3s = 67s
+numberOfBlocks = floor(67s / 8s) = 8 blocks
 ```
 
 The extra two block opportunities come from not charging the current slot for checkpoint finalization and L1 publishing.
@@ -128,8 +129,8 @@ It helps to think in terms of two different slots:
 So the work is split like this:
 
 - **During slot N-1**: Initialization, block building, and last-block re-execution
-- **Near the end of slot N-1**: The checkpoint proposal is broadcast and validators attest to checkpoint N.
-- **During slot N**: The proposer collects signatures, and the checkpoint is submitted to L1
+- **Near the end of slot N-1**: The checkpoint proposal is broadcast so validators can start the last re-execution as slot `N` begins.
+- **During slot N**: Validators finish re-executing, send attestations, the proposer collects them, and the checkpoint is submitted to L1 before slot `N` reaches its publish cutoff
 
 In other words, pipelining does not mean "do everything for slot N earlier". It specifically moves **block production and block re-execution** earlier, while **checkpoint proposal, attestation gathering, and L1 submission** remain aligned with slot `N`.
 
@@ -142,7 +143,7 @@ Slot 11 (wall clock):
 - Collect checkpoint 12 attestations
 
 Slot 12 (target/submission slot):
-- Collect remaining checkpoint 12 attestations
+- Collect attestations for checkpoint 12 until slot 12 reaches its L1 publish cutoff
 - Submit checkpoint 12 to L1
 ```
 
@@ -534,7 +535,7 @@ The sequencer transitions through these states during a slot:
 | **WAITING_UNTIL_NEXT_BLOCK** | Until next sub-slot start | Sleep between blocks to maintain intervals |
 | **ASSEMBLING_CHECKPOINT** | assembleTime (1s) | Assemble final checkpoint |
 | **COLLECTING_ATTESTATIONS** | Until L1 publish deadline | Wait for validator signatures |
-| **PUBLISHING_CHECKPOINT** | Until slot end | Submit to L1 |
+| **PUBLISHING_CHECKPOINT** | Until L1 publish deadline | Submit to L1 |
 
 ## Complete Example: 72-Second Slot with 8-Second Sub-Slots
 

--- a/yarn-project/sequencer-client/src/sequencer/chain_state_overrides.ts
+++ b/yarn-project/sequencer-client/src/sequencer/chain_state_overrides.ts
@@ -1,0 +1,87 @@
+import { RollupContract, SimulationOverridesBuilder, type SimulationOverridesPlan } from '@aztec/ethereum/contracts';
+import { CheckpointNumber } from '@aztec/foundation/branded-types';
+import type { Fr } from '@aztec/foundation/curves/bn254';
+import type { Logger } from '@aztec/foundation/log';
+import type { ProposedCheckpointData } from '@aztec/stdlib/checkpoint';
+
+type PipelinedParentSimulationOverridesPlanInput = {
+  checkpointNumber: CheckpointNumber;
+  proposedCheckpointData?: ProposedCheckpointData;
+  rollup: RollupContract;
+  log: Logger;
+};
+
+type SubmissionSimulationOverridesPlanInput = {
+  pipelinedParentPlan?: SimulationOverridesPlan;
+  invalidateToPendingCheckpointNumber?: CheckpointNumber;
+  lastArchiveRoot: Fr;
+  pipeliningEnabled: boolean;
+};
+
+/** Builds the simulated parent checkpoint view used while constructing a pipelined proposal. */
+export async function buildPipelinedParentSimulationOverridesPlan(
+  input: PipelinedParentSimulationOverridesPlanInput,
+): Promise<SimulationOverridesPlan | undefined> {
+  const parentCheckpointNumber = CheckpointNumber(input.checkpointNumber - 1);
+  const builder = new SimulationOverridesBuilder().forPendingCheckpoint(parentCheckpointNumber);
+
+  const pendingFeeHeader = await computePipelinedParentFeeHeader(input);
+  if (pendingFeeHeader) {
+    builder.withPendingFeeHeader(pendingFeeHeader);
+  }
+
+  return builder.build();
+}
+
+/** Builds the simulated chain view used when validating and enqueueing checkpoint submission. */
+export function buildSubmissionSimulationOverridesPlan(
+  input: SubmissionSimulationOverridesPlanInput,
+): SimulationOverridesPlan | undefined {
+  const pendingCheckpointNumber =
+    input.invalidateToPendingCheckpointNumber ?? input.pipelinedParentPlan?.pendingCheckpointNumber;
+
+  const builder = SimulationOverridesBuilder.from(input.pipelinedParentPlan).forPendingCheckpoint(
+    pendingCheckpointNumber,
+  );
+
+  if (input.pipeliningEnabled && pendingCheckpointNumber !== undefined) {
+    builder.withPendingArchive(input.lastArchiveRoot);
+  }
+
+  return builder.build();
+}
+
+/** Derives the pending parent fee header used during pipelined proposal simulation. */
+export async function computePipelinedParentFeeHeader(input: PipelinedParentSimulationOverridesPlanInput) {
+  if (!input.proposedCheckpointData || input.checkpointNumber < 2) {
+    return undefined;
+  }
+
+  const grandparentCheckpointNumber = CheckpointNumber(input.checkpointNumber - 2);
+
+  try {
+    const [grandparentCheckpoint, manaTarget] = await Promise.all([
+      input.rollup.getCheckpoint(grandparentCheckpointNumber),
+      input.rollup.getManaTarget(),
+    ]);
+
+    if (!grandparentCheckpoint?.feeHeader) {
+      input.log.error(
+        `Grandparent checkpoint or feeHeader missing for checkpoint ${grandparentCheckpointNumber.toString()}`,
+      );
+      return undefined;
+    }
+
+    return RollupContract.computeChildFeeHeader(
+      grandparentCheckpoint.feeHeader,
+      input.proposedCheckpointData.totalManaUsed,
+      input.proposedCheckpointData.feeAssetPriceModifier,
+      manaTarget,
+    );
+  } catch (err) {
+    input.log.error(
+      `Failed to derive pipelined parent fee header for checkpoint ${grandparentCheckpointNumber.toString()}: ${err}`,
+    );
+    return undefined;
+  }
+}

--- a/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.test.ts
@@ -13,6 +13,7 @@ import { Fr } from '@aztec/foundation/curves/bn254';
 import { TimeoutError } from '@aztec/foundation/error';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { Signature } from '@aztec/foundation/eth-signature';
+import { createLogger } from '@aztec/foundation/log';
 import { TestDateProvider } from '@aztec/foundation/timer';
 import type { TypedEventEmitter } from '@aztec/foundation/types';
 import { type P2P, P2PClientState } from '@aztec/p2p';
@@ -62,6 +63,7 @@ import {
   mockTxIterator,
   setupTxsAndBlock,
 } from '../test/utils.js';
+import { computePipelinedParentFeeHeader } from './chain_state_overrides.js';
 import { CheckpointProposalJob } from './checkpoint_proposal_job.js';
 import type { SequencerEvents } from './events.js';
 import type { SequencerMetrics } from './metrics.js';
@@ -309,7 +311,7 @@ describe('CheckpointProposalJob', () => {
 
       validatorClient.collectAttestations.mockResolvedValue(getAttestations(block));
 
-      const checkpoint = await job.execute();
+      const checkpoint = await job.executeAndAwait();
 
       expect(checkpoint).toBeDefined();
       expect(checkpointBuilder.buildBlockCalls).toHaveLength(1);
@@ -330,7 +332,7 @@ describe('CheckpointProposalJob', () => {
 
       job.updateConfig({ minTxsPerBlock: 2 });
 
-      const checkpoint = await job.execute();
+      const checkpoint = await job.executeAndAwait();
 
       expect(checkpoint).toBeUndefined();
       expect(checkpointBuilder.buildBlockCalls).toHaveLength(0);
@@ -347,7 +349,7 @@ describe('CheckpointProposalJob', () => {
 
       job.updateConfig({ buildCheckpointIfEmpty: true, minTxsPerBlock: 1 });
 
-      const checkpoint = await job.execute();
+      const checkpoint = await job.executeAndAwait();
 
       expect(checkpoint).toBeDefined();
       expect(checkpointBuilder.buildBlockCalls).toHaveLength(1);
@@ -368,7 +370,7 @@ describe('CheckpointProposalJob', () => {
 
       validatorClient.collectAttestations.mockResolvedValue(getAttestations(block));
 
-      await job.execute();
+      await job.executeAndAwait();
 
       expect(validatorClient.collectAttestations).toHaveBeenCalledTimes(1);
       expect(validatorClient.collectAttestations).toHaveBeenCalledWith(
@@ -403,7 +405,7 @@ describe('CheckpointProposalJob', () => {
       checkpointBuilder.seedBlocks([block], [txs]);
       validatorClient.collectAttestations.mockResolvedValue(getAttestations(block));
 
-      await job.execute();
+      await job.executeAndAwait();
 
       // Verify startCheckpoint was called with the out hashes from previous checkpoints
       expect(checkpointsBuilder.startCheckpointCalls).toHaveLength(1);
@@ -444,7 +446,7 @@ describe('CheckpointProposalJob', () => {
       checkpointBuilder.seedBlocks([block], [txs]);
       validatorClient.collectAttestations.mockResolvedValue(getAttestations(block));
 
-      await job.execute();
+      await job.executeAndAwait();
 
       // Verify only the checkpoint before the current one is included
       expect(checkpointsBuilder.startCheckpointCalls).toHaveLength(1);
@@ -601,46 +603,9 @@ describe('CheckpointProposalJob', () => {
     );
   }
 
-  describe('computeForceProposedFeeHeader', () => {
+  describe('computePipelinedParentFeeHeader', () => {
     // Use checkpoint 3 so the grandparent (checkpoint 1) is valid
     const pipelinedCheckpointNumber = CheckpointNumber(3);
-
-    function createJobWithProposedCheckpoint(pendingData: ProposedCheckpointData): TestCheckpointProposalJob {
-      const setStateFn = jest.fn();
-      const eventEmitter = new EventEmitter() as TypedEventEmitter<SequencerEvents>;
-
-      return new TestCheckpointProposalJob(
-        SlotNumber(newSlotNumber),
-        SlotNumber(newSlotNumber),
-        epoch,
-        pipelinedCheckpointNumber,
-        lastBlockNumber,
-        proposer,
-        publisher,
-        attestorAddress,
-        undefined,
-        validatorClient,
-        globalVariableBuilder,
-        p2p,
-        worldState,
-        l1ToL2MessageSource,
-        l2BlockSource,
-        checkpointsBuilder as unknown as FullNodeCheckpointsBuilder,
-        blockSink,
-        l1Constants,
-        config,
-        timetable,
-        slasherClient,
-        epochCache,
-        dateProvider,
-        metrics,
-        eventEmitter,
-        setStateFn,
-        getTelemetryClient().getTracer('test'),
-        { actor: 'test' },
-        pendingData,
-      );
-    }
 
     const pendingData: ProposedCheckpointData = {
       checkpointNumber: CheckpointNumber(1),
@@ -662,7 +627,12 @@ describe('CheckpointProposalJob', () => {
     };
 
     it('returns undefined when proposedCheckpointData is not set', async () => {
-      const result = await job.computeForceProposedFeeHeader(CheckpointNumber(1));
+      const result = await computePipelinedParentFeeHeader({
+        checkpointNumber: pipelinedCheckpointNumber,
+        proposedCheckpointData: undefined,
+        rollup: publisher.rollupContract,
+        log: createLogger('test'),
+      });
       expect(result).toBeUndefined();
     });
 
@@ -673,16 +643,18 @@ describe('CheckpointProposalJob', () => {
     }
 
     it('computes fee header from grandparent checkpoint', async () => {
-      const jobWithPending = createJobWithProposedCheckpoint(pendingData);
       const manaTarget = 10_000n;
 
       mockRollup({ grandparentCheckpoint: { feeHeader: grandparentFeeHeader }, manaTarget });
 
-      const parentCheckpointNumber = CheckpointNumber(1);
-      const result = await jobWithPending.computeForceProposedFeeHeader(parentCheckpointNumber);
+      const result = await computePipelinedParentFeeHeader({
+        checkpointNumber: pipelinedCheckpointNumber,
+        proposedCheckpointData: pendingData,
+        rollup: publisher.rollupContract,
+        log: createLogger('test'),
+      });
 
       expect(result).toBeDefined();
-      expect(result!.checkpointNumber).toBe(parentCheckpointNumber);
 
       const expected = RollupContract.computeChildFeeHeader(
         grandparentFeeHeader,
@@ -690,43 +662,56 @@ describe('CheckpointProposalJob', () => {
         pendingData.feeAssetPriceModifier,
         manaTarget,
       );
-      expect(result!.feeHeader).toEqual(expected);
+      expect(result).toEqual(expected);
     });
 
     it('returns undefined when grandparent checkpoint is not found', async () => {
-      const jobWithPending = createJobWithProposedCheckpoint(pendingData);
       mockRollup({ grandparentCheckpoint: undefined });
 
-      const result = await jobWithPending.computeForceProposedFeeHeader(CheckpointNumber(1));
+      const result = await computePipelinedParentFeeHeader({
+        checkpointNumber: pipelinedCheckpointNumber,
+        proposedCheckpointData: pendingData,
+        rollup: publisher.rollupContract,
+        log: createLogger('test'),
+      });
       expect(result).toBeUndefined();
     });
 
     it('returns undefined when grandparent checkpoint has no feeHeader', async () => {
-      const jobWithPending = createJobWithProposedCheckpoint(pendingData);
       mockRollup({ grandparentCheckpoint: { feeHeader: undefined } });
 
-      const result = await jobWithPending.computeForceProposedFeeHeader(CheckpointNumber(1));
+      const result = await computePipelinedParentFeeHeader({
+        checkpointNumber: pipelinedCheckpointNumber,
+        proposedCheckpointData: pendingData,
+        rollup: publisher.rollupContract,
+        log: createLogger('test'),
+      });
       expect(result).toBeUndefined();
     });
 
     it('returns undefined when rollup calls throw', async () => {
-      const jobWithPending = createJobWithProposedCheckpoint(pendingData);
       jest.spyOn(publisher.rollupContract, 'getCheckpoint').mockRejectedValue(new Error('rpc error'));
 
-      const result = await jobWithPending.computeForceProposedFeeHeader(CheckpointNumber(1));
+      const result = await computePipelinedParentFeeHeader({
+        checkpointNumber: pipelinedCheckpointNumber,
+        proposedCheckpointData: pendingData,
+        rollup: publisher.rollupContract,
+        log: createLogger('test'),
+      });
       expect(result).toBeUndefined();
     });
   });
 
   describe('multiple block mode', () => {
     beforeEach(() => {
-      // Multiple block mode: set blockDurationMs to 8 seconds
+      // Keep the real L1 publish budget and use the largest valid non-pipelined
+      // block duration for a 24s slot under the stricter timing guards.
       job.setTimetable(
         new SequencerTimetable({
           ethereumSlotDuration,
           aztecSlotDuration: slotDuration,
           l1PublishingTime: ethereumSlotDuration,
-          blockDurationMs: 8000,
+          blockDurationMs: 3000,
           enforce: true,
         }),
       );
@@ -747,7 +732,7 @@ describe('CheckpointProposalJob', () => {
       // Install spy on waitUntilTimeInSlot to verify it's called with expected deadlines
       const waitSpy = jest.spyOn(job, 'waitUntilTimeInSlot');
 
-      const checkpoint = await job.execute();
+      const checkpoint = await job.executeAndAwait();
 
       expect(checkpoint).toBeDefined();
       expect(checkpointBuilder.buildBlockCalls).toHaveLength(2);
@@ -777,7 +762,7 @@ describe('CheckpointProposalJob', () => {
       const waitSpy = jest.spyOn(job, 'waitUntilTimeInSlot');
 
       job.updateConfig({ minTxsPerBlock: 0 });
-      const checkpoint = await job.execute();
+      const checkpoint = await job.executeAndAwait();
 
       expect(checkpoint).toBeDefined();
       expect(checkpointBuilder.buildBlockCalls).toHaveLength(1);
@@ -806,7 +791,7 @@ describe('CheckpointProposalJob', () => {
       const waitSpy = jest.spyOn(job, 'waitUntilTimeInSlot');
 
       job.updateConfig({ minTxsPerBlock: 5, buildCheckpointIfEmpty: true });
-      const checkpoint = await job.execute();
+      const checkpoint = await job.executeAndAwait();
 
       expect(checkpoint).toBeDefined();
       expect(checkpointBuilder.buildBlockCalls).toHaveLength(1);
@@ -834,7 +819,7 @@ describe('CheckpointProposalJob', () => {
       const waitSpy = jest.spyOn(job, 'waitUntilTimeInSlot');
 
       job.updateConfig({ minTxsPerBlock: 5, buildCheckpointIfEmpty: false });
-      const checkpoint = await job.execute();
+      const checkpoint = await job.executeAndAwait();
 
       expect(checkpoint).toBeUndefined();
       expect(checkpointBuilder.buildBlockCalls).toHaveLength(0);
@@ -867,7 +852,7 @@ describe('CheckpointProposalJob', () => {
       // Install spy on waitUntilTimeInSlot
       const waitSpy = jest.spyOn(job, 'waitUntilTimeInSlot');
 
-      const checkpoint = await job.execute();
+      const checkpoint = await job.executeAndAwait();
 
       expect(checkpoint).toBeDefined();
       // Only one block built due to time constraints
@@ -880,7 +865,7 @@ describe('CheckpointProposalJob', () => {
     });
 
     it('calls waitUntilTimeInSlot with expected deadline based on block duration', async () => {
-      const blockDurationSeconds = 8; // 8000ms / 1000
+      const blockDurationSeconds = 3; // 3000ms / 1000
 
       // Mock timetable to allow 3 blocks
       jest
@@ -896,13 +881,13 @@ describe('CheckpointProposalJob', () => {
 
       const waitSpy = jest.spyOn(job, 'waitUntilTimeInSlot');
 
-      await job.execute();
+      await job.executeAndAwait();
 
       // With 3 blocks where the 3rd is the last, waitUntilTimeInSlot should be called twice
       // (after block 1 and block 2, but not after block 3 since it's the last)
       expect(waitSpy).toHaveBeenCalledTimes(2);
-      expect(waitSpy.mock.calls[0][0]).toEqual(10);
-      expect(waitSpy.mock.calls[1][0]).toEqual(18);
+      expect(waitSpy.mock.calls[0][0]).toEqual(5);
+      expect(waitSpy.mock.calls[1][0]).toEqual(8);
     });
 
     it('does not call waitUntilTimeInSlot when building the last block', async () => {
@@ -925,7 +910,7 @@ describe('CheckpointProposalJob', () => {
 
       const waitSpy = jest.spyOn(job, 'waitUntilTimeInSlot');
 
-      const checkpoint = await job.execute();
+      const checkpoint = await job.executeAndAwait();
 
       expect(checkpoint).toBeDefined();
       expect(checkpointBuilder.buildBlockCalls).toHaveLength(1);
@@ -993,7 +978,7 @@ describe('CheckpointProposalJob', () => {
       p2p.getPendingTxCount.mockResolvedValue(txs.length);
       p2p.iterateEligiblePendingTxs.mockImplementation(() => mockTxIterator(Promise.resolve(txs)));
 
-      const checkpoint = await job.execute();
+      const checkpoint = await job.executeAndAwait();
 
       // Should return undefined when no time available
       expect(checkpoint).toBeUndefined();
@@ -1011,7 +996,7 @@ describe('CheckpointProposalJob', () => {
 
       validatorClient.collectAttestations.mockResolvedValue(getAttestations(block));
 
-      const checkpoint = await job.execute();
+      const checkpoint = await job.executeAndAwait();
 
       expect(checkpoint).toBeDefined();
       expect(checkpointBuilder.buildBlockCalls).toHaveLength(1);
@@ -1034,7 +1019,7 @@ describe('CheckpointProposalJob', () => {
 
       validatorClient.collectAttestations.mockResolvedValue(getAttestations(block));
 
-      const checkpoint = await job.execute();
+      const checkpoint = await job.executeAndAwait();
 
       // Should still complete if first block succeeds
       expect(checkpoint).toBeDefined();
@@ -1052,7 +1037,7 @@ describe('CheckpointProposalJob', () => {
       checkpointBuilder.errorOnBuild = new Error('Block build failed');
 
       // The job catches the error internally and returns undefined
-      const checkpoint = await job.execute();
+      const checkpoint = await job.executeAndAwait();
       expect(checkpoint).toBeUndefined();
     });
 
@@ -1063,9 +1048,10 @@ describe('CheckpointProposalJob', () => {
       // Mock collectAttestations to fail with timeout
       validatorClient.collectAttestations.mockRejectedValue(new AttestationTimeoutError(0, 3, SlotNumber.ZERO));
 
-      const checkpoint = await job.execute();
+      // Checkpoint is returned after broadcast — attestation failure happens in the background
+      const checkpoint = await job.executeAndAwait();
 
-      expect(checkpoint).toBeUndefined();
+      expect(checkpoint).toBeDefined();
       expect(validatorClient.collectAttestations).toHaveBeenCalled();
     });
 
@@ -1112,7 +1098,7 @@ describe('CheckpointProposalJob', () => {
       const { txs, block } = await setupTxsAndBlock(p2p, globalVariables, 1, chainId);
       checkpointBuilder.seedBlocks([block], [txs]);
 
-      const checkpoint = await job.execute();
+      const checkpoint = await job.executeAndAwait();
 
       // Should complete even with empty committee
       expect(checkpoint).toBeDefined();
@@ -1127,7 +1113,7 @@ describe('CheckpointProposalJob', () => {
       const attestations = getAttestations(block);
       validatorClient.collectAttestations.mockResolvedValue(attestations);
 
-      const checkpoint = await job.execute();
+      const checkpoint = await job.executeAndAwait();
 
       expect(checkpoint).toBeDefined();
       expect(validatorClient.collectAttestations).toHaveBeenCalled();
@@ -1139,9 +1125,9 @@ describe('CheckpointProposalJob', () => {
 
       validatorClient.collectAttestations.mockRejectedValue(new TimeoutError('Attestation collection timed out'));
 
-      await job.execute();
+      await job.executeAndAwait();
 
-      // Should handle timeout gracefully
+      // Should handle timeout gracefully (in background pipeline)
       expect(validatorClient.collectAttestations).toHaveBeenCalled();
     });
   });
@@ -1158,7 +1144,7 @@ describe('CheckpointProposalJob', () => {
           ethereumSlotDuration,
           aztecSlotDuration: slotDuration,
           l1PublishingTime: ethereumSlotDuration,
-          blockDurationMs: 8000,
+          blockDurationMs: 3000,
           enforce: true,
         }),
       );
@@ -1176,7 +1162,7 @@ describe('CheckpointProposalJob', () => {
         throw new DutyAlreadySignedError(SlotNumber(1), DutyType.BLOCK_PROPOSAL, 0, 'node-2');
       });
 
-      const result = await job.execute();
+      const result = await job.executeAndAwait();
 
       // Should return undefined and stop building
       expect(result).toBeUndefined();
@@ -1199,7 +1185,7 @@ describe('CheckpointProposalJob', () => {
           ethereumSlotDuration,
           aztecSlotDuration: slotDuration,
           l1PublishingTime: ethereumSlotDuration,
-          blockDurationMs: 8000,
+          blockDurationMs: 3000,
           enforce: true,
         }),
       );
@@ -1217,7 +1203,7 @@ describe('CheckpointProposalJob', () => {
         throw new SlashingProtectionError(SlotNumber(1), DutyType.BLOCK_PROPOSAL, 0, 'hash1', 'hash2', 'node-1');
       });
 
-      const result = await job.execute();
+      const result = await job.executeAndAwait();
 
       // Should return undefined and stop building
       expect(result).toBeUndefined();
@@ -1238,6 +1224,13 @@ class TestCheckpointProposalJob extends CheckpointProposalJob {
     return Promise.resolve();
   }
 
+  /** Wraps execute + awaitPendingSubmission so tests see the full pipeline complete. */
+  public async executeAndAwait(): Promise<Checkpoint | undefined> {
+    const result = await this.execute();
+    await this.awaitPendingSubmission();
+    return result;
+  }
+
   /** Update config for testing - allows tests to modify config after job creation */
   public updateConfig(partialConfig: Partial<ResolvedSequencerConfig>): void {
     this.config = { ...this.config, ...partialConfig };
@@ -1251,11 +1244,6 @@ class TestCheckpointProposalJob extends CheckpointProposalJob {
   /** Get timetable for testing - allows tests to spy on methods */
   public getTimetable(): SequencerTimetable {
     return this.timetable;
-  }
-
-  /** Expose computeForceProposedFeeHeader for testing */
-  public override computeForceProposedFeeHeader(parentCheckpointNumber: CheckpointNumber) {
-    return super.computeForceProposedFeeHeader(parentCheckpointNumber);
   }
 
   /** Expose internal buildSingleBlock method */

--- a/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.timing.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.timing.test.ts
@@ -889,6 +889,7 @@ describe('CheckpointProposalJob Timing Tests', () => {
       job.setTimetable(timetable);
 
       await job.execute();
+      await job.awaitPendingSubmission();
 
       // Verify collectAttestations was called
       expect(validatorClient.collectAttestations).toHaveBeenCalled();
@@ -927,6 +928,7 @@ describe('CheckpointProposalJob Timing Tests', () => {
       job.setTimetable(timetable);
 
       await job.execute();
+      await job.awaitPendingSubmission();
 
       // Attestation collection should start after the last block is built and checkpoint is assembled
       // Last block deadline at 17s (sub-slot 2), plus assembly time
@@ -956,9 +958,140 @@ describe('CheckpointProposalJob Timing Tests', () => {
       job.setTimetable(timetable);
 
       await job.execute();
+      await job.awaitPendingSubmission();
 
       // Deadline should still be absolute (slotStart + 60s), not relative to start time
       // Uses PUBLISHING_CHECKPOINT state: slotDuration - l1PublishingTime = 72 - 12 = 60
+      const slotStart = getSlotStartTime(slotNumber);
+      const expectedDeadlineSeconds = slotStart + AZTEC_SLOT_DURATION - L1_PUBLISHING_TIME;
+      const actualDeadlineSeconds = collectAttestationsDeadline!.getTime() / 1000;
+
+      expect(actualDeadlineSeconds).toBeCloseTo(expectedDeadlineSeconds, 0);
+    });
+  });
+
+  describe('Pipelining Attestation Timing', () => {
+    const targetSlot = SlotNumber(2); // Target slot is one ahead of build slot
+
+    /** Create a pipelining-aware job where targetSlot = slotNumber + 1 */
+    function createPipeliningJob(): TimingTestCheckpointProposalJob {
+      const pipeliningTimetable = new SequencerTimetable(
+        {
+          ethereumSlotDuration: ETHEREUM_SLOT_DURATION,
+          aztecSlotDuration: AZTEC_SLOT_DURATION,
+          l1PublishingTime: L1_PUBLISHING_TIME,
+          p2pPropagationTime: P2P_PROPAGATION_TIME,
+          blockDurationMs: BLOCK_DURATION * 1000,
+          enforce: true,
+          pipelining: true,
+        },
+        undefined,
+        createLogger('test:timetable:pipelining'),
+      );
+
+      const setStateFn = jest.fn();
+      const eventEmitter = new EventEmitter() as TypedEventEmitter<SequencerEvents>;
+
+      const job = new TimingTestCheckpointProposalJob(
+        dateProvider,
+        getSecondsIntoSlot,
+        slotNumber,
+        targetSlot,
+        epoch,
+        checkpointNumber,
+        BlockNumber.ZERO,
+        proposer,
+        publisher,
+        attestorAddress,
+        undefined, // invalidateCheckpoint
+        validatorClient,
+        globalVariableBuilder,
+        p2p,
+        worldState,
+        l1ToL2MessageSource,
+        l2BlockSource,
+        checkpointsBuilder as unknown as FullNodeCheckpointsBuilder,
+        blockSink,
+        l1Constants,
+        config,
+        pipeliningTimetable,
+        slasherClient,
+        epochCache,
+        dateProvider,
+        metrics,
+        eventEmitter,
+        setStateFn,
+        getTelemetryClient().getTracer('timing-test-pipelining'),
+        { actor: 'timing-test-pipelining' },
+      );
+
+      return job;
+    }
+
+    beforeEach(() => {
+      epochCache.isProposerPipeliningEnabled.mockReturnValue(true);
+    });
+
+    it('sets attestation deadline to the target-slot publish cutoff when pipelining', async () => {
+      const { blocks, txs } = await createTestBlocksAndTxs(2);
+      mockP2pWithTxs(txs);
+      checkpointBuilder.seedBlocks(
+        blocks,
+        blocks.map((_, i) => [txs[i]]),
+      );
+      checkpointBuilder.setExecutionDurations([5, 5]);
+
+      let collectAttestationsDeadline: Date | undefined;
+      validatorClient.collectAttestations.mockImplementation((_proposal, _required, deadline) => {
+        collectAttestationsDeadline = deadline;
+        return Promise.resolve(getAttestations(blocks[1]));
+      });
+
+      setTimeInSlot(1);
+
+      const job = createPipeliningJob();
+      await job.execute();
+      await job.awaitPendingSubmission();
+
+      expect(validatorClient.collectAttestations).toHaveBeenCalled();
+      expect(collectAttestationsDeadline).toBeDefined();
+
+      // Attestation deadline = buildSlotStart + (2 * aztecSlotDuration - l1PublishingTime)
+      // so collection can continue until the target slot's publish cutoff.
+      const buildSlotStart = getSlotStartTime(slotNumber);
+      const expectedDeadlineSeconds = buildSlotStart + 2 * AZTEC_SLOT_DURATION - L1_PUBLISHING_TIME;
+      const actualDeadlineSeconds = collectAttestationsDeadline!.getTime() / 1000;
+
+      expect(actualDeadlineSeconds).toBeCloseTo(expectedDeadlineSeconds, 0);
+    });
+
+    it('non-pipelining attestation deadline is unchanged', async () => {
+      epochCache.isProposerPipeliningEnabled.mockReturnValue(false);
+
+      const { blocks, txs } = await createTestBlocksAndTxs(2);
+      mockP2pWithTxs(txs);
+      checkpointBuilder.seedBlocks(
+        blocks,
+        blocks.map((_, i) => [txs[i]]),
+      );
+      checkpointBuilder.setExecutionDurations([5, 5]);
+
+      let collectAttestationsDeadline: Date | undefined;
+      validatorClient.collectAttestations.mockImplementation((_proposal, _required, deadline) => {
+        collectAttestationsDeadline = deadline;
+        return Promise.resolve(getAttestations(blocks[1]));
+      });
+
+      setTimeInSlot(1);
+
+      const job = createJob();
+      job.setTimetable(timetable);
+      await job.execute();
+      await job.awaitPendingSubmission();
+
+      expect(collectAttestationsDeadline).toBeDefined();
+
+      // Non-pipelining: deadline = buildSlotStart + slotDuration - l1PublishingTime
       const slotStart = getSlotStartTime(slotNumber);
       const expectedDeadlineSeconds = slotStart + AZTEC_SLOT_DURATION - L1_PUBLISHING_TIME;
       const actualDeadlineSeconds = collectAttestationsDeadline!.getTime() / 1000;

--- a/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.ts
+++ b/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.ts
@@ -1,5 +1,5 @@
 import type { EpochCache } from '@aztec/epoch-cache';
-import { type FeeHeader, RollupContract } from '@aztec/ethereum/contracts';
+import type { SimulationOverridesPlan } from '@aztec/ethereum/contracts';
 import {
   BlockNumber,
   CheckpointNumber,
@@ -57,6 +57,10 @@ import { DutyAlreadySignedError, SlashingProtectionError } from '@aztec/validato
 
 import type { GlobalVariableBuilder } from '../global_variable_builder/global_builder.js';
 import type { InvalidateCheckpointRequest, SequencerPublisher } from '../publisher/sequencer-publisher.js';
+import {
+  buildPipelinedParentSimulationOverridesPlan,
+  buildSubmissionSimulationOverridesPlan,
+} from './chain_state_overrides.js';
 import { CheckpointVoter } from './checkpoint_voter.js';
 import { SequencerInterruptedError } from './errors.js';
 import type { SequencerEvents } from './events.js';
@@ -68,7 +72,14 @@ import { SequencerState } from './utils.js';
 /** How much time to sleep while waiting for min transactions to accumulate for a block */
 const TXS_POLLING_MS = 500;
 
-/** Result from proposeCheckpoint when a checkpoint was successfully built and attested. */
+/** Result from proposeCheckpoint when a checkpoint was successfully built and broadcast. */
+type CheckpointProposalBroadcast = {
+  checkpoint: Checkpoint;
+  proposal: CheckpointProposal;
+  blockProposedAt: number;
+};
+
+/** Result after attestation collection and signing, ready for L1 submission. */
 type CheckpointProposalResult = {
   checkpoint: Checkpoint;
   attestations: CommitteeAttestationsAndSigners;
@@ -87,8 +98,8 @@ export class CheckpointProposalJob implements Traceable {
   /** Tracks the fire-and-forget L1 submission promise so it can be awaited during shutdown. */
   private pendingL1Submission: Promise<void> | undefined;
 
-  /** Fee header override computed during proposeCheckpoint, reused in enqueueCheckpointForSubmission. */
-  private computedForceProposedFeeHeader?: { checkpointNumber: CheckpointNumber; feeHeader: FeeHeader };
+  /** Pipelined parent chain state used while building and later submitting this checkpoint. */
+  private pipelinedParentSimulationOverridesPlan?: SimulationOverridesPlan;
 
   constructor(
     private readonly slotNow: SlotNumber,
@@ -136,8 +147,9 @@ export class CheckpointProposalJob implements Traceable {
 
   /**
    * Executes the checkpoint proposal job.
-   * Builds blocks, collects attestations, enqueues requests, and schedules L1 submission as a
-   * background task so the work loop can return to IDLE immediately.
+   * Builds blocks, assembles checkpoint, and broadcasts the proposal (blocking).
+   * Attestation collection, signing, and L1 submission are backgrounded so the
+   * work loop can return to IDLE immediately for consecutive slot proposals.
    * Returns the built checkpoint if successful, undefined otherwise.
    */
   @trackSpan('CheckpointProposalJob.execute')
@@ -157,71 +169,99 @@ export class CheckpointProposalJob implements Traceable {
       this.log,
     ).enqueueVotes();
 
-    // Build and propose the checkpoint. Builds blocks, broadcasts, collects attestations, and signs.
-    // Does NOT enqueue to L1 yet — that happens after the pipeline sleep.
-    const proposalResult = await this.proposeCheckpoint();
-    const checkpoint = proposalResult?.checkpoint;
+    // Build blocks, assemble checkpoint, and broadcast proposal (BLOCKING).
+    // Returns after broadcast — attestation collection is deferred.
+    const broadcast = await this.proposeCheckpoint();
 
-    // Wait until the voting promises have resolved, so all requests are enqueued (not sent)
-    await Promise.all(votesPromises);
-
-    if (checkpoint) {
-      this.metrics.recordCheckpointProposalSuccess();
+    if (!broadcast) {
+      await Promise.all(votesPromises);
+      // Still submit votes even without a checkpoint
+      if (!this.config.fishermanMode) {
+        this.pendingL1Submission = this.publisher.sendRequestsAt(this.dateProvider.nowAsDate()).then(() => {});
+      }
+      return undefined;
     }
+
+    const { checkpoint } = broadcast;
+    this.metrics.recordCheckpointProposalSuccess();
 
     // Do not post anything to L1 if we are fishermen, but do perform L1 fee analysis
     if (this.config.fishermanMode) {
       await this.handleCheckpointEndAsFisherman(checkpoint);
-      return;
+      return checkpoint;
     }
 
-    // Enqueue the checkpoint for L1 submission
-    if (proposalResult) {
-      try {
-        await this.enqueueCheckpointForSubmission(proposalResult);
-      } catch (err) {
-        this.log.error(`Failed to enqueue checkpoint for L1 submission at slot ${this.targetSlot}`, err);
-        // Continue to sendRequestsAt so votes are still sent
-      }
-    }
-
-    // Compute the earliest time to submit: pipeline slot start when pipelining, now otherwise.
-    const submitAfter = this.epochCache.isProposerPipeliningEnabled()
-      ? new Date(Number(getTimestampForSlot(this.targetSlot, this.l1Constants)) * 1000)
-      : new Date(this.dateProvider.now());
-
-    // Schedule L1 submission in the background so the work loop returns immediately.
-    // The publisher will sleep until submitAfter, then send the bundled requests.
-    // The promise is stored so it can be awaited during shutdown.
-    this.pendingL1Submission = this.publisher
-      .sendRequestsAt(submitAfter)
-      .then(async l1Response => {
-        const proposedAction = l1Response?.successfulActions.find(a => a === 'propose');
-        if (proposedAction) {
-          this.eventEmitter.emit('checkpoint-published', { checkpoint: this.checkpointNumber, slot: this.targetSlot });
-          const coinbase = checkpoint?.header.coinbase;
-          await this.metrics.incFilledSlot(this.publisher.getSenderAddress().toString(), coinbase);
-        } else if (checkpoint) {
-          this.eventEmitter.emit('checkpoint-publish-failed', { ...l1Response, slot: this.targetSlot });
-
-          if (this.epochCache.isProposerPipeliningEnabled()) {
-            this.metrics.recordPipelineDiscard();
-          }
-        }
-      })
-      .catch(err => {
-        this.log.error(`Background L1 submission failed for slot ${this.targetSlot}`, err);
-        if (checkpoint) {
-          this.eventEmitter.emit('checkpoint-publish-failed', { slot: this.targetSlot });
-
-          if (this.epochCache.isProposerPipeliningEnabled()) {
-            this.metrics.recordPipelineDiscard();
-          }
-        }
-      });
+    // Background the attestation → signing → L1 pipeline so the work loop is unblocked
+    this.pendingL1Submission = this.waitForAttestationsAndEnqueueSubmissionAsync(broadcast, votesPromises);
 
     // Return the built checkpoint immediately — the work loop is now unblocked
     return checkpoint;
+  }
+
+  /**
+   * Background pipeline: collects attestations, signs them, enqueues the checkpoint, and submits to L1.
+   * Runs as a fire-and-forget task stored in `pendingL1Submission` so the work loop is unblocked.
+   */
+  private async waitForAttestationsAndEnqueueSubmissionAsync(
+    broadcast: CheckpointProposalBroadcast,
+    votesPromises: Promise<unknown>[],
+  ): Promise<void> {
+    const { checkpoint, proposal, blockProposedAt } = broadcast;
+    try {
+      await Promise.all(votesPromises);
+
+      this.setStateFn(SequencerState.COLLECTING_ATTESTATIONS, this.targetSlot);
+      const attestations = await this.waitForAttestations(proposal);
+
+      this.metrics.recordCheckpointAttestationDelay(this.dateProvider.now() - blockProposedAt);
+
+      // Proposer must sign over the attestations before pushing them to L1
+      const signer = this.proposer ?? this.publisher.getSenderAddress();
+      let attestationsSignature: Signature;
+      try {
+        attestationsSignature = await this.validatorClient.signAttestationsAndSigners(
+          attestations,
+          signer,
+          this.targetSlot,
+          this.checkpointNumber,
+        );
+      } catch (err) {
+        if (this.handleHASigningError(err, 'Attestations signature')) {
+          return;
+        }
+        throw err;
+      }
+
+      // Enqueue the checkpoint for L1 submission
+      await this.enqueueCheckpointForSubmission({ checkpoint, attestations, attestationsSignature });
+
+      // Compute the earliest time to submit: pipeline slot start when pipelining, now otherwise.
+      const submitAfter = this.epochCache.isProposerPipeliningEnabled()
+        ? new Date(Number(getTimestampForSlot(this.targetSlot, this.l1Constants)) * 1000)
+        : new Date(this.dateProvider.now());
+
+      const l1Response = await this.publisher.sendRequestsAt(submitAfter);
+      const proposedAction = l1Response?.successfulActions.find(a => a === 'propose');
+      if (proposedAction) {
+        this.eventEmitter.emit('checkpoint-published', { checkpoint: this.checkpointNumber, slot: this.targetSlot });
+        const coinbase = checkpoint.header.coinbase;
+        await this.metrics.incFilledSlot(this.publisher.getSenderAddress().toString(), coinbase);
+      } else {
+        this.eventEmitter.emit('checkpoint-publish-failed', { ...l1Response, slot: this.targetSlot });
+        if (this.epochCache.isProposerPipeliningEnabled()) {
+          this.metrics.recordPipelineDiscard();
+        }
+      }
+    } catch (err) {
+      if (err instanceof SequencerInterruptedError) {
+        return;
+      }
+      this.log.error(`Background attestation/L1 pipeline failed for slot ${this.targetSlot}`, err);
+      this.eventEmitter.emit('checkpoint-publish-failed', { slot: this.targetSlot });
+      if (this.epochCache.isProposerPipeliningEnabled()) {
+        this.metrics.recordPipelineDiscard();
+      }
+    }
   }
 
   /** Enqueues the checkpoint for L1 submission. Called after pipeline sleep in execute(). */
@@ -247,10 +287,17 @@ export class CheckpointProposalJob implements Traceable {
       }
     }
 
+    const isPipelining = this.epochCache.isProposerPipeliningEnabled();
+    const submissionSimulationOverridesPlan = buildSubmissionSimulationOverridesPlan({
+      pipelinedParentPlan: this.pipelinedParentSimulationOverridesPlan,
+      invalidateToPendingCheckpointNumber: this.invalidateCheckpoint?.forcePendingCheckpointNumber,
+      lastArchiveRoot: checkpoint.header.lastArchiveRoot,
+      pipeliningEnabled: isPipelining,
+    });
+
     await this.publisher.enqueueProposeCheckpoint(checkpoint, attestations, attestationsSignature, {
       txTimeoutAt,
-      forcePendingCheckpointNumber: this.invalidateCheckpoint?.forcePendingCheckpointNumber,
-      forceProposedFeeHeader: this.computedForceProposedFeeHeader,
+      ...(submissionSimulationOverridesPlan ? { simulationOverridesPlan: submissionSimulationOverridesPlan } : {}),
     });
   }
 
@@ -261,7 +308,7 @@ export class CheckpointProposalJob implements Traceable {
       [Attributes.SLOT_NUMBER]: this.targetSlot,
     };
   })
-  private async proposeCheckpoint(): Promise<CheckpointProposalResult | undefined> {
+  private async proposeCheckpoint(): Promise<CheckpointProposalBroadcast | undefined> {
     try {
       // Get operator configured coinbase and fee recipient for this attestor
       const coinbase = this.validatorClient.getCoinbaseForAttestor(this.attestorAddress);
@@ -287,21 +334,20 @@ export class CheckpointProposalJob implements Traceable {
       // When pipelining, force the proposed checkpoint number and fee header to our parent so the
       // fee computation sees the same chain tip that L1 will see once the previous pipelined checkpoint lands.
       const isPipelining = this.epochCache.isProposerPipeliningEnabled();
-      const parentCheckpointNumber = isPipelining ? CheckpointNumber(this.checkpointNumber - 1) : undefined;
-
-      // Compute the parent's fee header override when pipelining
-      if (isPipelining && this.proposedCheckpointData) {
-        this.computedForceProposedFeeHeader = await this.computeForceProposedFeeHeader(parentCheckpointNumber!);
-      }
+      this.pipelinedParentSimulationOverridesPlan = isPipelining
+        ? await buildPipelinedParentSimulationOverridesPlan({
+            checkpointNumber: this.checkpointNumber,
+            proposedCheckpointData: this.proposedCheckpointData,
+            rollup: this.publisher.rollupContract,
+            log: this.log,
+          })
+        : undefined;
 
       const checkpointGlobalVariables = await this.globalsBuilder.buildCheckpointGlobalVariables(
         coinbase,
         feeRecipient,
         this.targetSlot,
-        {
-          forcePendingCheckpointNumber: parentCheckpointNumber,
-          forceProposedFeeHeader: this.computedForceProposedFeeHeader,
-        },
+        this.pipelinedParentSimulationOverridesPlan,
       );
 
       // Collect L1 to L2 messages for the checkpoint and compute their hash
@@ -410,7 +456,7 @@ export class CheckpointProposalJob implements Traceable {
         Number(checkpoint.header.totalManaUsed.toBigInt()),
       );
 
-      // Do not collect attestations nor publish to L1 in fisherman mode
+      // In fisherman mode, return the checkpoint without broadcasting or collecting attestations
       if (this.config.fishermanMode) {
         this.log.info(
           `Built checkpoint for slot ${this.targetSlot} with ${blocksInCheckpoint.length} blocks. ` +
@@ -422,11 +468,8 @@ export class CheckpointProposalJob implements Traceable {
           },
         );
         this.metrics.recordCheckpointSuccess();
-        return {
-          checkpoint,
-          attestations: CommitteeAttestationsAndSigners.empty(),
-          attestationsSignature: Signature.empty(),
-        };
+        // Return a broadcast result with a dummy proposal — fisherman mode skips attestation collection
+        return { checkpoint, proposal: undefined!, blockProposedAt: this.dateProvider.now() };
       }
 
       // Create the checkpoint proposal and broadcast it
@@ -442,33 +485,8 @@ export class CheckpointProposalJob implements Traceable {
       const blockProposedAt = this.dateProvider.now();
       await this.p2pClient.broadcastCheckpointProposal(proposal);
 
-      this.setStateFn(SequencerState.COLLECTING_ATTESTATIONS, this.targetSlot);
-      const attestations = await this.waitForAttestations(proposal);
-      const blockAttestedAt = this.dateProvider.now();
-
-      this.metrics.recordCheckpointAttestationDelay(blockAttestedAt - blockProposedAt);
-
-      // Proposer must sign over the attestations before pushing them to L1
-      const signer = this.proposer ?? this.publisher.getSenderAddress();
-      let attestationsSignature: Signature;
-      try {
-        attestationsSignature = await this.validatorClient.signAttestationsAndSigners(
-          attestations,
-          signer,
-          this.targetSlot,
-          this.checkpointNumber,
-        );
-      } catch (err) {
-        // We shouldn't really get here since we yield to another HA node
-        // as soon as we see these errors when creating block or checkpoint proposals.
-        if (this.handleHASigningError(err, 'Attestations signature')) {
-          return undefined;
-        }
-        throw err;
-      }
-
-      // Return the result for the caller to enqueue after the pipeline sleep
-      return { checkpoint, attestations, attestationsSignature };
+      // Return immediately after broadcast — attestation collection happens in the background
+      return { checkpoint, proposal, blockProposedAt };
     } catch (err) {
       if (err && (err instanceof DutyAlreadySignedError || err instanceof SlashingProtectionError)) {
         // swallow this error. It's already been logged by a function deeper in the stack
@@ -864,7 +882,7 @@ export class CheckpointProposalJob implements Traceable {
     }
 
     const attestationTimeAllowed = this.config.enforceTimeTable
-      ? this.timetable.getMaxAllowedTime(SequencerState.PUBLISHING_CHECKPOINT)!
+      ? this.timetable.getCheckpointAttestationDeadline()
       : this.l1Constants.slotDuration;
     const attestationDeadline = new Date((this.getSlotStartBuildTimestamp() + attestationTimeAllowed) * 1000);
 
@@ -1068,56 +1086,6 @@ export class CheckpointProposalJob implements Traceable {
       return true;
     }
     return false;
-  }
-
-  /**
-   * In times of congestion we need to simulate using the correct fee header override for the previous block
-   * We calculate the correct fee header values.
-   *
-   * If we are in block 1, or the checkpoint we are querying does not exist, we return undefined. However
-   * If we are pipelining - where this function is called, the grandparentCheckpointNumber should always exist
-   * @param parentCheckpointNumber
-   * @returns
-   */
-  protected async computeForceProposedFeeHeader(parentCheckpointNumber: CheckpointNumber): Promise<
-    | {
-        checkpointNumber: CheckpointNumber;
-        feeHeader: FeeHeader;
-      }
-    | undefined
-  > {
-    if (!this.proposedCheckpointData) {
-      return undefined;
-    }
-
-    const rollup = this.publisher.rollupContract;
-    const grandparentCheckpointNumber = CheckpointNumber(this.checkpointNumber - 2);
-    try {
-      const [grandparentCheckpoint, manaTarget] = await Promise.all([
-        rollup.getCheckpoint(grandparentCheckpointNumber),
-        rollup.getManaTarget(),
-      ]);
-
-      if (!grandparentCheckpoint || !grandparentCheckpoint.feeHeader) {
-        this.log.error(
-          `Grandparent checkpoint or its feeHeader is undefined for checkpointNumber=${grandparentCheckpointNumber.toString()}`,
-        );
-        return undefined;
-      } else {
-        const parentFeeHeader = RollupContract.computeChildFeeHeader(
-          grandparentCheckpoint.feeHeader,
-          this.proposedCheckpointData.totalManaUsed,
-          this.proposedCheckpointData.feeAssetPriceModifier,
-          manaTarget,
-        );
-        return { checkpointNumber: parentCheckpointNumber, feeHeader: parentFeeHeader };
-      }
-    } catch (err) {
-      this.log.error(
-        `Failed to fetch grandparent checkpoint or mana target for checkpointNumber=${grandparentCheckpointNumber.toString()}: ${err}`,
-      );
-      return undefined;
-    }
   }
 
   /** Waits until a specific time within the current slot */

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.test.ts
@@ -158,9 +158,9 @@ describe('sequencer', () => {
       expect.any(Checkpoint),
       attestationsAndSigners,
       getSignatures()[0].signature,
-      {
+      expect.objectContaining({
         txTimeoutAt: expect.any(Date),
-      },
+      }),
     );
   };
 
@@ -373,6 +373,7 @@ describe('sequencer', () => {
     it('builds a block out of a single tx', async () => {
       await setupSingleTxBlock();
       await sequencer.work();
+      await sequencer.awaitLastProposalSubmission();
 
       expectPublisherProposeL2Block();
     });
@@ -417,6 +418,7 @@ describe('sequencer', () => {
       });
 
       await sequencer.work();
+      await sequencer.awaitLastProposalSubmission();
       // Now we should build and publish the checkpoint
       expect(checkpointBuilder.buildBlockCalls.length).toBeGreaterThan(0);
       expectPublisherProposeL2Block();
@@ -439,6 +441,7 @@ describe('sequencer', () => {
       block = await makeBlock(txs);
 
       await sequencer.work();
+      await sequencer.awaitLastProposalSubmission();
 
       expect(checkpointBuilder.buildBlockCalls.length).toBeGreaterThan(0);
       expectPublisherProposeL2Block();
@@ -455,6 +458,7 @@ describe('sequencer', () => {
       // Archiver reports synced to slot 0, which satisfies syncedL2Slot + 1 >= slot (slot=1)
       l2BlockSource.getSyncedL2SlotNumber.mockResolvedValue(SlotNumber(0));
       await sequencer.work();
+      await sequencer.awaitLastProposalSubmission();
       expect(publisher.enqueueProposeCheckpoint).toHaveBeenCalled();
     });
 
@@ -475,10 +479,9 @@ describe('sequencer', () => {
 
       publisher.enqueueProposeCheckpoint.mockRejectedValueOnce(new Error('Failed to enqueue propose checkpoint'));
 
+      // The error is caught in the background attestation/L1 pipeline and does not surface as an unhandled rejection
       await sequencer.work();
-
-      // We still call sendRequestsAt in case there are votes enqueued
-      expect(publisher.sendRequestsAt).toHaveBeenCalled();
+      await sequencer.awaitLastProposalSubmission();
     });
 
     it('should proceed with block proposal when there is no proposer yet', async () => {
@@ -497,6 +500,7 @@ describe('sequencer', () => {
       block = await makeBlock(txs);
 
       await sequencer.work();
+      await sequencer.awaitLastProposalSubmission();
 
       // Verify that the sequencer attempted to create and broadcast a block proposal
       expect(publisher.enqueueProposeCheckpoint).toHaveBeenCalled();
@@ -579,6 +583,7 @@ describe('sequencer', () => {
         block = await makeBlock([tx]);
         TestUtils.mockPendingTxs(p2p, [tx]);
         await sequencer.work();
+        await sequencer.awaitLastProposalSubmission();
 
         const attestationsAndSigners = new CommitteeAttestationsAndSigners(getSignatures());
         expect(publishers[i].enqueueProposeCheckpoint).toHaveBeenCalledTimes(1);
@@ -586,7 +591,9 @@ describe('sequencer', () => {
           expect.any(Checkpoint),
           attestationsAndSigners,
           getSignatures()[0].signature,
-          { txTimeoutAt: expect.any(Date) },
+          expect.objectContaining({
+            txTimeoutAt: expect.any(Date),
+          }),
         );
       }
     });
@@ -928,6 +935,7 @@ describe('sequencer', () => {
       await setupSingleTxBlock();
 
       await sequencer.work();
+      await sequencer.awaitLastProposalSubmission();
 
       // Verify checkpoint was built and proposed
       expect(checkpointBuilder.buildBlockCalls.length).toBeGreaterThan(0);
@@ -941,6 +949,7 @@ describe('sequencer', () => {
       await setupSingleTxBlock();
 
       await sequencer.work();
+      await sequencer.awaitLastProposalSubmission();
 
       // Verify checkpoint was built and proposed
       expect(checkpointBuilder.buildBlockCalls).toHaveLength(1);
@@ -957,6 +966,7 @@ describe('sequencer', () => {
       TestUtils.mockPendingTxs(p2p, txs);
 
       await sequencer.work();
+      await sequencer.awaitLastProposalSubmission();
 
       expect(checkpointBuilder.buildBlockCalls.length).toBeGreaterThan(1);
       expect(validatorClient.createCheckpointProposal).toHaveBeenCalled();
@@ -1055,14 +1065,9 @@ describe('sequencer', () => {
 
       await sequencer.work();
 
-      // L1 check should be called with archive override for the parent checkpoint
-      expect(publisher.canProposeAt).toHaveBeenCalledWith(
-        expect.anything(), // archive
-        expect.anything(), // proposer
-        expect.objectContaining({
-          forceArchive: expect.objectContaining({ checkpointNumber: CheckpointNumber(1) }),
-        }),
-      );
+      const simulationOverridesPlan = publisher.canProposeAt.mock.calls.at(-1)?.[2];
+      expect(simulationOverridesPlan?.pendingCheckpointNumber).toEqual(CheckpointNumber(1));
+      expect(simulationOverridesPlan?.pendingCheckpointState?.archive).toEqual(expect.anything());
     });
 
     it('skips proposal when checkpoint exceeds pipeline depth', async () => {
@@ -1130,8 +1135,7 @@ describe('sequencer', () => {
 
       await sequencer.work();
 
-      // L1 check should be called without archive override (empty overrides object)
-      expect(publisher.canProposeAt).toHaveBeenCalledWith(expect.anything(), expect.anything(), {});
+      expect(publisher.canProposeAt.mock.calls.at(-1)?.[2]).toBeUndefined();
     });
 
     it('calls L1 check without overrides when not pipelining', async () => {
@@ -1153,8 +1157,7 @@ describe('sequencer', () => {
 
       await sequencer.work();
 
-      // L1 check should be called without any overrides (empty object)
-      expect(publisher.canProposeAt).toHaveBeenCalledWith(expect.anything(), expect.anything(), {});
+      expect(publisher.canProposeAt.mock.calls.at(-1)?.[2]).toBeUndefined();
     });
   });
 
@@ -1210,6 +1213,10 @@ class TestSequencer extends Sequencer {
       return;
     }
     return super.work();
+  }
+
+  public async awaitLastProposalSubmission() {
+    await this.lastCheckpointProposalJob?.awaitPendingSubmission();
   }
 
   public checkCanProposeForTest(slot: SlotNumber) {

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.ts
@@ -1,7 +1,7 @@
 import { getKzg } from '@aztec/blob-lib';
 import { INITIAL_L2_BLOCK_NUM } from '@aztec/constants';
 import type { EpochCache } from '@aztec/epoch-cache';
-import { NoCommitteeError, type RollupContract } from '@aztec/ethereum/contracts';
+import { NoCommitteeError, type RollupContract, SimulationOverridesBuilder } from '@aztec/ethereum/contracts';
 import { BlockNumber, CheckpointNumber, EpochNumber, SlotNumber } from '@aztec/foundation/branded-types';
 import { merge, omit, pick } from '@aztec/foundation/collection';
 import { Fr } from '@aztec/foundation/curves/bn254';
@@ -73,7 +73,7 @@ export class Sequencer extends (EventEmitter as new () => TypedEventEmitter<Sequ
   private lastEpochForStrategyComparison: EpochNumber | undefined;
 
   /** The last checkpoint proposal job, tracked so we can await its pending L1 submission during shutdown. */
-  private lastCheckpointProposalJob: CheckpointProposalJob | undefined;
+  protected lastCheckpointProposalJob: CheckpointProposalJob | undefined;
 
   /** The maximum number of seconds that the sequencer can be into a slot to transition to a particular state. */
   protected timetable!: SequencerTimetable;
@@ -115,12 +115,13 @@ export class Sequencer extends (EventEmitter as new () => TypedEventEmitter<Sequ
     const filteredConfig = pickFromSchema(config, SequencerConfigSchema);
     this.log.info(`Updated sequencer config`, omit(filteredConfig, 'txPublicSetupAllowListExtend'));
     this.config = merge(this.config, filteredConfig);
+    const p2pPropagationTime = this.config.attestationPropagationTime;
     this.timetable = new SequencerTimetable(
       {
         ethereumSlotDuration: this.l1Constants.ethereumSlotDuration,
         aztecSlotDuration: this.aztecSlotDuration,
         l1PublishingTime: this.l1PublishingTime,
-        p2pPropagationTime: this.config.attestationPropagationTime,
+        p2pPropagationTime,
         blockDurationMs: this.config.blockDurationMs,
         enforce: this.config.enforceTimeTable,
         pipelining: this.epochCache.isProposerPipeliningEnabled(),
@@ -361,17 +362,13 @@ export class Sequencer extends (EventEmitter as new () => TypedEventEmitter<Sequ
     // The L1 contract reads archives[proposedCheckpointNumber] and compares it with the provided archive.
     // When invalidating or pipelining, the local archive may differ from L1's, so we adjust accordingly.
     let archiveForCheck = syncedTo.archive;
-    const l1Overrides: {
-      forcePendingCheckpointNumber?: CheckpointNumber;
-      forceArchive?: { checkpointNumber: CheckpointNumber; archive: Fr };
-    } = {};
+    const l1SimulationOverridesBuilder = new SimulationOverridesBuilder();
 
     if (this.epochCache.isProposerPipeliningEnabled() && syncedTo.hasProposedCheckpoint) {
       // Parent checkpoint hasn't landed on L1 yet. Override both the proposed checkpoint number
       // and the archive at that checkpoint so L1 simulation sees the correct chain tip.
       const parentCheckpointNumber = CheckpointNumber(checkpointNumber - 1);
-      l1Overrides.forcePendingCheckpointNumber = parentCheckpointNumber;
-      l1Overrides.forceArchive = { checkpointNumber: parentCheckpointNumber, archive: syncedTo.archive };
+      l1SimulationOverridesBuilder.forPendingCheckpoint(parentCheckpointNumber).withPendingArchive(syncedTo.archive);
       this.metrics.recordPipelineDepth(1);
 
       this.log.verbose(
@@ -383,13 +380,18 @@ export class Sequencer extends (EventEmitter as new () => TypedEventEmitter<Sequ
       // After invalidation, L1 will roll back to checkpoint N-1. The archive at N-1 already
       // exists on L1, so we just pass the matching archive (the lastArchive of the invalid checkpoint).
       archiveForCheck = invalidateCheckpoint.lastArchive;
-      l1Overrides.forcePendingCheckpointNumber = invalidateCheckpoint.forcePendingCheckpointNumber;
+      l1SimulationOverridesBuilder.forPendingCheckpoint(invalidateCheckpoint.forcePendingCheckpointNumber);
       this.metrics.recordPipelineDepth(0);
     } else {
       this.metrics.recordPipelineDepth(0);
     }
 
-    const canProposeCheck = await publisher.canProposeAt(archiveForCheck, proposer ?? EthAddress.ZERO, l1Overrides);
+    const simulationOverridesPlan = l1SimulationOverridesBuilder.build();
+    const canProposeCheck = await publisher.canProposeAt(
+      archiveForCheck,
+      proposer ?? EthAddress.ZERO,
+      simulationOverridesPlan,
+    );
 
     if (canProposeCheck === undefined) {
       this.log.warn(

--- a/yarn-project/sequencer-client/src/sequencer/timetable.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/timetable.test.ts
@@ -457,7 +457,7 @@ describe('sequencer-timetable', () => {
       expect(withPipelining.maxNumberOfBlocks).toBeGreaterThan(withoutPipelining.maxNumberOfBlocks);
     });
 
-    it('uses entire slot minus init and re-execution for block building', () => {
+    it('reserves time for assembly and one-way broadcast at end of slot', () => {
       const tt = new SequencerTimetable({
         ethereumSlotDuration: ETHEREUM_SLOT_DURATION,
         aztecSlotDuration: AZTEC_SLOT_DURATION,
@@ -468,8 +468,9 @@ describe('sequencer-timetable', () => {
       });
 
       const blockDuration = BLOCK_DURATION_MS / 1000;
-      // Reserves one blockDuration for validator re-execution, but no finalization time
-      const availableTime = AZTEC_SLOT_DURATION - tt.initializationOffset - blockDuration;
+      // Reserves assembleTime + p2pPropagation (one-way broadcast) at end
+      const timeReservedAtEnd = tt.checkpointAssembleTime + tt.p2pPropagationTime;
+      const availableTime = AZTEC_SLOT_DURATION - tt.initializationOffset - timeReservedAtEnd;
       expect(tt.maxNumberOfBlocks).toBe(Math.floor(availableTime / blockDuration));
     });
 
@@ -501,8 +502,67 @@ describe('sequencer-timetable', () => {
       });
 
       // With pipelining and test config (ethereumSlotDuration < 8):
-      // init=0.5, reExec=8, available = 36 - 0.5 - 8 = 27.5, floor(27.5/8) = 3
-      expect(tt.maxNumberOfBlocks).toBe(3);
+      // init=0.5, reservedAtEnd = 0.5 + 0 = 0.5, available = 36 - 0.5 - 0.5 = 35, floor(35/8) = 4
+      expect(tt.maxNumberOfBlocks).toBe(4);
+    });
+
+    it('sets pipeliningAttestationGracePeriod to blockDuration + p2pPropagationTime', () => {
+      const tt = new SequencerTimetable({
+        ethereumSlotDuration: ETHEREUM_SLOT_DURATION,
+        aztecSlotDuration: AZTEC_SLOT_DURATION,
+        l1PublishingTime: L1_PUBLISHING_TIME,
+        blockDurationMs: BLOCK_DURATION_MS,
+        enforce: ENFORCE_TIMETABLE,
+        pipelining: true,
+      });
+
+      expect(tt.pipeliningAttestationGracePeriod).toBe(tt.blockDuration! + tt.p2pPropagationTime);
+    });
+
+    it('uses separate pipelined deadlines for attestation start vs publish cutoff', () => {
+      const tt = new SequencerTimetable({
+        ethereumSlotDuration: ETHEREUM_SLOT_DURATION,
+        aztecSlotDuration: AZTEC_SLOT_DURATION,
+        l1PublishingTime: L1_PUBLISHING_TIME,
+        blockDurationMs: BLOCK_DURATION_MS,
+        enforce: ENFORCE_TIMETABLE,
+        pipelining: true,
+      });
+
+      expect(tt.getMaxAllowedTime(SequencerState.ASSEMBLING_CHECKPOINT)).toBe(
+        AZTEC_SLOT_DURATION + tt.pipeliningAttestationGracePeriod,
+      );
+      expect(tt.getMaxAllowedTime(SequencerState.COLLECTING_ATTESTATIONS)).toBe(
+        AZTEC_SLOT_DURATION + tt.pipeliningAttestationGracePeriod,
+      );
+      expect(tt.getCheckpointAttestationDeadline()).toBe(2 * AZTEC_SLOT_DURATION - L1_PUBLISHING_TIME);
+      expect(tt.getMaxAllowedTime(SequencerState.PUBLISHING_CHECKPOINT)).toBe(
+        2 * AZTEC_SLOT_DURATION - L1_PUBLISHING_TIME,
+      );
+    });
+
+    it('ensures enough time from last block deadline to grace period end for assembly + round-trip + re-execution', () => {
+      const P2P_PROPAGATION_TIME = 2;
+      const BLOCK_DURATION = BLOCK_DURATION_MS / 1000;
+
+      const tt = new SequencerTimetable({
+        ethereumSlotDuration: ETHEREUM_SLOT_DURATION,
+        aztecSlotDuration: AZTEC_SLOT_DURATION,
+        l1PublishingTime: L1_PUBLISHING_TIME,
+        p2pPropagationTime: P2P_PROPAGATION_TIME,
+        blockDurationMs: BLOCK_DURATION_MS,
+        enforce: ENFORCE_TIMETABLE,
+        pipelining: true,
+      });
+
+      // Time from last block deadline to end of grace period into next slot
+      const lastBlockDeadline = tt.initializationOffset + tt.maxNumberOfBlocks * BLOCK_DURATION;
+      const remainingInBuildSlot = AZTEC_SLOT_DURATION - lastBlockDeadline;
+      const totalTimeAvailable = remainingInBuildSlot + tt.pipeliningAttestationGracePeriod;
+
+      // Must be enough for: assembly + round-trip p2p + re-execution
+      const requiredTime = tt.checkpointAssembleTime + 2 * P2P_PROPAGATION_TIME + BLOCK_DURATION;
+      expect(totalTimeAvailable).toBeGreaterThanOrEqual(requiredTime);
     });
 
     it('produces more blocks with production config where finalization time is large', () => {

--- a/yarn-project/sequencer-client/src/sequencer/timetable.ts
+++ b/yarn-project/sequencer-client/src/sequencer/timetable.ts
@@ -2,8 +2,10 @@ import type { Logger } from '@aztec/foundation/log';
 import {
   CHECKPOINT_ASSEMBLE_TIME,
   CHECKPOINT_INITIALIZATION_TIME,
+  type CheckpointTiming,
   DEFAULT_P2P_PROPAGATION_TIME,
   MIN_EXECUTION_TIME,
+  createCheckpointTimingModel,
 } from '@aztec/stdlib/timetable';
 
 import { SequencerTooSlowError } from './errors.js';
@@ -11,6 +13,8 @@ import type { SequencerMetrics } from './metrics.js';
 import { SequencerState } from './utils.js';
 
 export class SequencerTimetable {
+  private readonly checkpointTiming: CheckpointTiming;
+
   /**
    * How late into the slot can we be to start working. Computed as the total time needed for assembling and publishing a block,
    * assuming an execution time equal to `minExecutionTime`, subtracted from the slot duration. This means that, if the proposer
@@ -73,6 +77,12 @@ export class SequencerTimetable {
   /** Whether pipelining is enabled (checkpoint finalization deferred to next slot). */
   public readonly pipelining: boolean;
 
+  /**
+   * How far into the target slot attestation collection can extend when pipelining.
+   * Covers validator re-execution (one block duration) plus one-way attestation return.
+   */
+  public readonly pipeliningAttestationGracePeriod: number;
+
   constructor(
     opts: {
       ethereumSlotDuration: number;
@@ -89,58 +99,31 @@ export class SequencerTimetable {
     this.ethereumSlotDuration = opts.ethereumSlotDuration;
     this.aztecSlotDuration = opts.aztecSlotDuration;
     this.l1PublishingTime = opts.l1PublishingTime;
-    this.p2pPropagationTime = opts.p2pPropagationTime ?? DEFAULT_P2P_PROPAGATION_TIME;
     this.blockDuration = opts.blockDurationMs ? opts.blockDurationMs / 1000 : undefined;
     this.enforce = opts.enforce;
     this.pipelining = opts.pipelining ?? false;
 
-    // Assume zero-cost propagation time and faster runs in test environments where L1 slot duration is shortened
-    if (this.ethereumSlotDuration < 8) {
-      this.p2pPropagationTime = 0;
-      this.checkpointAssembleTime = 0.5;
-      this.checkpointInitializationTime = 0.5;
-      this.minExecutionTime = 1;
-    }
+    this.checkpointTiming = createCheckpointTimingModel({
+      aztecSlotDuration: this.aztecSlotDuration,
+      ethereumSlotDuration: this.ethereumSlotDuration,
+      blockDuration: this.blockDuration,
+      l1PublishingTime: this.l1PublishingTime,
+      p2pPropagationTime: opts.p2pPropagationTime ?? DEFAULT_P2P_PROPAGATION_TIME,
+      pipelining: this.pipelining,
+    });
 
-    // Min execution time cannot be less than the block duration if set
-    if (this.blockDuration !== undefined && this.minExecutionTime > this.blockDuration) {
-      this.minExecutionTime = this.blockDuration;
-    }
+    this.p2pPropagationTime = this.checkpointTiming.p2pPropagationTime;
+    this.checkpointAssembleTime = this.checkpointTiming.checkpointAssembleTime;
+    this.checkpointInitializationTime = this.checkpointTiming.checkpointInitializationTime;
+    this.minExecutionTime = this.checkpointTiming.minExecutionTime;
 
     // Calculate initialization offset - estimate of time needed for sync + proposer check
     // This is the baseline for all sub-slot deadlines
-    this.initializationOffset = this.checkpointInitializationTime;
-
-    // Calculate total checkpoint finalization time (assembly + attestations + L1 publishing)
-    this.checkpointFinalizationTime =
-      this.checkpointAssembleTime +
-      this.p2pPropagationTime * 2 + // Round-trip propagation
-      this.l1PublishingTime; // L1 publishing
-
-    // Calculate maximum number of blocks that fit in this slot
-    if (!this.blockDuration) {
-      this.maxNumberOfBlocks = 1; // Single block per slot
-    } else {
-      // When pipelining, finalization is deferred to the next slot, but we still need
-      // a sub-slot for validator re-execution so they can produce attestations.
-      let timeReservedAtEnd = this.blockDuration; // Validatior re-execution only
-      if (!this.pipelining) {
-        timeReservedAtEnd += this.checkpointFinalizationTime;
-      }
-
-      const timeAvailableForBlocks = this.aztecSlotDuration - this.initializationOffset - timeReservedAtEnd;
-      this.maxNumberOfBlocks = Math.floor(timeAvailableForBlocks / this.blockDuration);
-    }
-
-    // Minimum work to do within a slot for building a block with the minimum time for execution and publishing its checkpoint.
-    // When pipelining, finalization is deferred, but we still need time for execution and validator re-execution.
-    let minWorkToDo = this.initializationOffset + this.minExecutionTime * 2;
-    if (!this.pipelining) {
-      minWorkToDo += this.checkpointFinalizationTime;
-    }
-
-    const initializeDeadline = this.aztecSlotDuration - minWorkToDo;
-    this.initializeDeadline = initializeDeadline;
+    this.initializationOffset = this.checkpointTiming.checkpointInitializationTime;
+    this.checkpointFinalizationTime = this.checkpointTiming.checkpointFinalizationTime;
+    this.pipeliningAttestationGracePeriod = this.checkpointTiming.pipeliningAttestationGracePeriod;
+    this.maxNumberOfBlocks = this.checkpointTiming.calculateMaxBlocksPerSlot();
+    this.initializeDeadline = this.checkpointTiming.initializeDeadline;
 
     this.log?.info(
       `Sequencer timetable initialized with ${this.maxNumberOfBlocks} blocks per slot (${this.enforce ? 'enforced' : 'not enforced'})`,
@@ -155,17 +138,34 @@ export class SequencerTimetable {
         initializeDeadline: this.initializeDeadline,
         enforce: this.enforce,
         pipelining: this.pipelining,
-        minWorkToDo,
+        pipeliningAttestationGracePeriod: this.pipeliningAttestationGracePeriod,
+        minWorkToDo: this.checkpointTiming.minimumBuildSlotWork,
         blockDuration: this.blockDuration,
         maxNumberOfBlocks: this.maxNumberOfBlocks,
       },
     );
 
-    if (initializeDeadline <= 0) {
+    if (this.initializeDeadline <= 0) {
       throw new Error(
-        `Block proposal initialize deadline cannot be negative (got ${initializeDeadline} from total time needed ${minWorkToDo} and a slot duration of ${this.aztecSlotDuration}).`,
+        `Block proposal initialize deadline cannot be negative (got ${this.initializeDeadline} from total time needed ${this.checkpointTiming.minimumBuildSlotWork} and a slot duration of ${this.aztecSlotDuration}).`,
       );
     }
+  }
+
+  public getCheckpointAssemblyDeadline(): number {
+    return this.checkpointTiming.checkpointAssemblyDeadline;
+  }
+
+  public getCheckpointAttestationDeadline(): number {
+    return this.checkpointTiming.checkpointAttestationDeadline;
+  }
+
+  public getCheckpointAttestationStartDeadline(): number {
+    return this.checkpointTiming.checkpointAttestationStartDeadline;
+  }
+
+  public getCheckpointPublishingDeadline(): number {
+    return this.checkpointTiming.checkpointPublishingDeadline;
   }
 
   public getMaxAllowedTime(
@@ -190,10 +190,11 @@ export class SequencerTimetable {
       case SequencerState.WAITING_UNTIL_NEXT_BLOCK:
         return this.initializeDeadline + this.checkpointInitializationTime;
       case SequencerState.ASSEMBLING_CHECKPOINT:
+        return this.getCheckpointAssemblyDeadline();
       case SequencerState.COLLECTING_ATTESTATIONS:
-        return this.aztecSlotDuration - this.l1PublishingTime - 2 * this.p2pPropagationTime;
+        return this.getCheckpointAttestationStartDeadline();
       case SequencerState.PUBLISHING_CHECKPOINT:
-        return this.aztecSlotDuration - this.l1PublishingTime;
+        return this.getCheckpointPublishingDeadline();
       default: {
         const _exhaustiveCheck: never = state;
         throw new Error(`Unexpected state: ${state}`);

--- a/yarn-project/stdlib/src/config/sequencer-config.ts
+++ b/yarn-project/stdlib/src/config/sequencer-config.ts
@@ -1,6 +1,7 @@
 import type { ConfigMappingsType } from '@aztec/foundation/config';
 
 import type { SequencerConfig } from '../interfaces/configs.js';
+import { DEFAULT_P2P_PROPAGATION_TIME } from '../timetable/index.js';
 
 /** Default maximum number of transactions per block. */
 export const DEFAULT_MAX_TXS_PER_BLOCK = 32;
@@ -12,7 +13,10 @@ export const DEFAULT_MAX_TXS_PER_BLOCK = 32;
  * to avoid duplication.
  */
 export const sharedSequencerConfigMappings: ConfigMappingsType<
-  Pick<SequencerConfig, 'blockDurationMs' | 'expectedBlockProposalsPerSlot' | 'maxTxsPerBlock'>
+  Pick<
+    SequencerConfig,
+    'blockDurationMs' | 'expectedBlockProposalsPerSlot' | 'maxTxsPerBlock' | 'attestationPropagationTime'
+  >
 > = {
   blockDurationMs: {
     env: 'SEQ_BLOCK_DURATION_MS',
@@ -33,5 +37,11 @@ export const sharedSequencerConfigMappings: ConfigMappingsType<
     env: 'SEQ_MAX_TX_PER_BLOCK',
     description: 'The maximum number of txs to include in a block.',
     parseEnv: (val: string) => (val ? parseInt(val, 10) : undefined),
+  },
+  attestationPropagationTime: {
+    env: 'SEQ_ATTESTATION_PROPAGATION_TIME',
+    description: 'How many seconds it takes for proposals and attestations to travel across the p2p layer (one-way).',
+    parseEnv: (val: string) => (val ? parseFloat(val) : undefined),
+    defaultValue: DEFAULT_P2P_PROPAGATION_TIME,
   },
 };

--- a/yarn-project/stdlib/src/timetable/index.test.ts
+++ b/yarn-project/stdlib/src/timetable/index.test.ts
@@ -1,0 +1,79 @@
+import { createCheckpointTimingModel, createPipelinedCheckpointTimingModel } from './index.js';
+
+describe('timetable validation', () => {
+  it('accepts a non-pipelined multi-block config that fits exactly one block', () => {
+    const timing = createCheckpointTimingModel({
+      aztecSlotDuration: 34,
+      blockDuration: 8,
+      checkpointInitializationTime: 1,
+      checkpointAssembleTime: 1,
+      p2pPropagationTime: 2,
+      l1PublishingTime: 12,
+      pipelining: false,
+    });
+
+    expect(timing.calculateMaxBlocksPerSlot()).toBe(1);
+  });
+
+  it('rejects a non-pipelined multi-block config that cannot fit one block', () => {
+    expect(() =>
+      createCheckpointTimingModel({
+        aztecSlotDuration: 33,
+        blockDuration: 8,
+        checkpointInitializationTime: 1,
+        checkpointAssembleTime: 1,
+        p2pPropagationTime: 2,
+        l1PublishingTime: 12,
+        pipelining: false,
+      }),
+    ).toThrow(/less than one blockDuration/i);
+  });
+
+  it('accepts a pipelined multi-block config that fits exactly one block', () => {
+    const timing = createPipelinedCheckpointTimingModel({
+      aztecSlotDuration: 12,
+      blockDuration: 8,
+      checkpointInitializationTime: 1,
+      checkpointAssembleTime: 1,
+      p2pPropagationTime: 2,
+      l1PublishingTime: 12,
+    });
+
+    expect(timing.calculateMaxBlocksPerSlot()).toBe(1);
+  });
+
+  it('rejects a pipelined multi-block config that cannot fit one block', () => {
+    expect(() =>
+      createPipelinedCheckpointTimingModel({
+        aztecSlotDuration: 11,
+        blockDuration: 8,
+        checkpointInitializationTime: 1,
+        checkpointAssembleTime: 1,
+        p2pPropagationTime: 2,
+        l1PublishingTime: 12,
+      }),
+    ).toThrow(/less than one blockDuration/i);
+  });
+
+  it('allows single-block mode without blockDuration', () => {
+    const timing = createCheckpointTimingModel({
+      aztecSlotDuration: 10,
+      checkpointInitializationTime: 1,
+      pipelining: false,
+    });
+
+    expect(timing.calculateMaxBlocksPerSlot()).toBe(1);
+  });
+
+  it('uses compressed timing allowances for short ethereum test slots', () => {
+    const timing = createCheckpointTimingModel({
+      aztecSlotDuration: 24,
+      ethereumSlotDuration: 4,
+      blockDuration: 8,
+      l1PublishingTime: 2,
+      p2pPropagationTime: 0.5,
+    });
+
+    expect(timing.calculateMaxBlocksPerSlot()).toBe(1);
+  });
+});

--- a/yarn-project/stdlib/src/timetable/index.ts
+++ b/yarn-project/stdlib/src/timetable/index.ts
@@ -25,6 +25,219 @@ export const DEFAULT_L1_PUBLISHING_TIME = 12;
 /** Minimum execution time for building a block in seconds */
 export const MIN_EXECUTION_TIME = 2;
 
+export type CheckpointTimingConfig = {
+  aztecSlotDuration: number;
+  ethereumSlotDuration?: number;
+  blockDuration?: number;
+  checkpointAssembleTime?: number;
+  checkpointInitializationTime?: number;
+  l1PublishingTime?: number;
+  minExecutionTime?: number;
+  p2pPropagationTime?: number;
+  pipelining?: boolean;
+};
+
+export interface CheckpointTiming {
+  readonly aztecSlotDuration: number;
+  readonly blockDuration: number | undefined;
+  readonly checkpointAssembleTime: number;
+  readonly checkpointInitializationTime: number;
+  readonly l1PublishingTime: number;
+  readonly minExecutionTime: number;
+  readonly p2pPropagationTime: number;
+  readonly checkpointFinalizationTime: number;
+  readonly pipeliningAttestationGracePeriod: number;
+  readonly timeReservedAtEnd: number;
+  readonly minimumBuildSlotWork: number;
+  readonly initializeDeadline: number;
+  readonly checkpointAssemblyDeadline: number;
+  readonly checkpointAttestationStartDeadline: number;
+  readonly checkpointAttestationDeadline: number;
+  readonly checkpointPublishingDeadline: number;
+
+  calculateMaxBlocksPerSlot(): number;
+}
+
+export interface PipelinedCheckpointTiming extends CheckpointTiming {
+  readonly proposalWindowIntoTargetSlot: number;
+  readonly attestationWindowIntoTargetSlot: number;
+}
+
+/**
+ * Shared base for checkpoint timing implementations.
+ *
+ * This class owns the common inputs and formulas used by both pipelined and
+ * non-pipelined scheduling. Variant-specific deadline math is delegated to the
+ * concrete subclasses below.
+ */
+abstract class BaseCheckpointTiming implements CheckpointTiming {
+  public readonly aztecSlotDuration: number;
+  public readonly blockDuration: number | undefined;
+  public readonly checkpointAssembleTime: number;
+  public readonly checkpointInitializationTime: number;
+  public readonly l1PublishingTime: number;
+  public readonly minExecutionTime: number;
+  public readonly p2pPropagationTime: number;
+
+  constructor(opts: CheckpointTimingConfig) {
+    this.aztecSlotDuration = opts.aztecSlotDuration;
+    this.blockDuration = opts.blockDuration;
+
+    this.checkpointAssembleTime = opts.checkpointAssembleTime ?? CHECKPOINT_ASSEMBLE_TIME;
+    this.checkpointInitializationTime = opts.checkpointInitializationTime ?? CHECKPOINT_INITIALIZATION_TIME;
+    this.l1PublishingTime = opts.l1PublishingTime ?? DEFAULT_L1_PUBLISHING_TIME;
+    this.minExecutionTime = opts.minExecutionTime ?? MIN_EXECUTION_TIME;
+    this.p2pPropagationTime = opts.p2pPropagationTime ?? DEFAULT_P2P_PROPAGATION_TIME;
+  }
+
+  public get checkpointFinalizationTime(): number {
+    // Allow enough time to
+    // - build the checkpoint
+    // - Round-trip over p2p
+    // - Publish to L1
+    return this.checkpointAssembleTime + this.p2pPropagationTime * 2 + this.l1PublishingTime;
+  }
+
+  public get pipeliningAttestationGracePeriod(): number {
+    // Allow enough time to
+    // - build the block
+    // - pass it back over p2p
+    return (this.blockDuration ?? 0) + this.p2pPropagationTime;
+  }
+
+  public abstract get timeReservedAtEnd(): number;
+  public abstract get minimumBuildSlotWork(): number;
+
+  public get initializeDeadline(): number {
+    return this.aztecSlotDuration - this.minimumBuildSlotWork;
+  }
+
+  public abstract get checkpointAssemblyDeadline(): number;
+
+  public get checkpointAttestationStartDeadline(): number {
+    return this.checkpointAssemblyDeadline;
+  }
+
+  public abstract get checkpointAttestationDeadline(): number;
+  public abstract get checkpointPublishingDeadline(): number;
+
+  public calculateMaxBlocksPerSlot(): number {
+    if (!this.blockDuration) {
+      return 1;
+    }
+
+    const timeAvailableForBlocks = this.aztecSlotDuration - this.checkpointInitializationTime - this.timeReservedAtEnd;
+    return Math.floor(timeAvailableForBlocks / this.blockDuration);
+  }
+}
+
+/**
+ * Checkpoint timing model for the non-pipelined sequencer flow.
+ *
+ * In this mode, checkpoint assembly, attestation collection, and L1 publishing
+ * must all complete within the current Aztec slot.
+ */
+class StandardCheckpointTimingModel extends BaseCheckpointTiming {
+  public get timeReservedAtEnd(): number {
+    return (this.blockDuration ?? 0) + this.checkpointFinalizationTime;
+  }
+
+  public get minimumBuildSlotWork(): number {
+    return this.checkpointInitializationTime + this.minExecutionTime * 2 + this.checkpointFinalizationTime;
+  }
+
+  public get checkpointAssemblyDeadline(): number {
+    return this.aztecSlotDuration - this.l1PublishingTime - 2 * this.p2pPropagationTime;
+  }
+
+  public get checkpointAttestationDeadline(): number {
+    return this.aztecSlotDuration - this.l1PublishingTime;
+  }
+
+  public get checkpointPublishingDeadline(): number {
+    return this.aztecSlotDuration - this.l1PublishingTime;
+  }
+}
+
+/**
+ * Checkpoint timing model for proposer pipelining.
+ *
+ * In this mode, the build work still starts in the current slot, but checkpoint
+ * assembly and attestation collection can extend into the target slot. The extra
+ * target-slot window getters are intended for consumers such as P2P validators
+ * that need to validate pipelined messages against wallclock time.
+ */
+class PipelinedCheckpointTimingModel extends BaseCheckpointTiming implements PipelinedCheckpointTiming {
+  public get proposalWindowIntoTargetSlot(): number {
+    // Allow the p2p propagation time to receive a checkpoint proposal from leader
+    return this.p2pPropagationTime;
+  }
+
+  public get attestationWindowIntoTargetSlot(): number {
+    return this.aztecSlotDuration - this.l1PublishingTime;
+  }
+
+  public get timeReservedAtEnd(): number {
+    return this.checkpointAssembleTime + this.p2pPropagationTime;
+  }
+
+  public get minimumBuildSlotWork(): number {
+    return this.checkpointInitializationTime + this.minExecutionTime * 2;
+  }
+
+  public get checkpointAssemblyDeadline(): number {
+    // Allow enough time to
+    // - build all blocks
+    // - receive attestations
+    return this.aztecSlotDuration + this.pipeliningAttestationGracePeriod;
+  }
+
+  public get checkpointAttestationDeadline(): number {
+    // Allowed to be into the next wallclock slot minus the allocated l1 publishing time
+    return this.aztecSlotDuration * 2 - this.l1PublishingTime;
+  }
+
+  public get checkpointPublishingDeadline(): number {
+    // Allowed to be into the next wallclock slot minus the allocated l1 Publishing time
+    return this.aztecSlotDuration * 2 - this.l1PublishingTime;
+  }
+}
+
+/**
+ * Creates a checkpoint timing model for the requested scheduling mode.
+ *
+ * Most callers should use this factory and depend only on the shared
+ * `CheckpointTiming` interface. The returned implementation is selected from
+ * `opts.pipelining`.
+ */
+export function createCheckpointTimingModel(opts: CheckpointTimingConfig): CheckpointTiming {
+  validateCheckpointTimingConfig(opts);
+  const normalizedOpts = normalizeCheckpointTimingConfig(opts);
+
+  const timing = normalizedOpts.pipelining
+    ? new PipelinedCheckpointTimingModel(normalizedOpts)
+    : new StandardCheckpointTimingModel(normalizedOpts);
+  validateCheckpointTimingModel(timing);
+  return timing;
+}
+
+/**
+ * Creates a pipelined checkpoint timing model with target-slot window accessors.
+ *
+ * Use this when the caller specifically needs the pipelined-only timing surface,
+ * such as proposal or attestation acceptance windows into the target slot.
+ */
+export function createPipelinedCheckpointTimingModel(
+  opts: Omit<CheckpointTimingConfig, 'pipelining'>,
+): PipelinedCheckpointTiming {
+  validateCheckpointTimingConfig(opts);
+  const normalizedOpts = normalizeCheckpointTimingConfig(opts);
+
+  const timing = new PipelinedCheckpointTimingModel(normalizedOpts);
+  validateCheckpointTimingModel(timing);
+  return timing;
+}
+
 /**
  * Calculates the maximum number of blocks that can be built in a slot.
  * Used by both the sequencer timetable and p2p gossipsub scoring.
@@ -45,27 +258,89 @@ export function calculateMaxBlocksPerSlot(
     pipelining?: boolean;
   } = {},
 ): number {
-  if (!blockDurationSec) {
-    return 1; // Single block per slot
+  return createCheckpointTimingModel({
+    aztecSlotDuration: aztecSlotDurationSec,
+    blockDuration: blockDurationSec,
+    checkpointAssembleTime: opts.checkpointAssembleTime,
+    checkpointInitializationTime: opts.checkpointInitializationTime,
+    l1PublishingTime: opts.l1PublishingTime,
+    p2pPropagationTime: opts.p2pPropagationTime,
+    pipelining: opts.pipelining,
+  }).calculateMaxBlocksPerSlot();
+}
+
+function assertNonNegative(name: string, value: number): void {
+  if (value < 0) {
+    throw new Error(`${name} must be non-negative (got ${value})`);
+  }
+}
+
+function validateCheckpointTimingConfig(opts: CheckpointTimingConfig): void {
+  if (opts.aztecSlotDuration <= 0) {
+    throw new Error(`aztecSlotDuration must be positive (got ${opts.aztecSlotDuration})`);
   }
 
-  const initOffset = opts.checkpointInitializationTime ?? CHECKPOINT_INITIALIZATION_TIME;
-  const assembleTime = opts.checkpointAssembleTime ?? CHECKPOINT_ASSEMBLE_TIME;
-  const p2pTime = opts.p2pPropagationTime ?? DEFAULT_P2P_PROPAGATION_TIME;
-  const l1Time = opts.l1PublishingTime ?? DEFAULT_L1_PUBLISHING_TIME;
-
-  // Calculate checkpoint finalization time (assembly + round-trip propagation + L1 publishing)
-  const checkpointFinalizationTime = assembleTime + p2pTime * 2 + l1Time;
-
-  // When pipelining, finalization is deferred to the next slot, but we still reserve
-  // a sub-slot for validator re-execution so they can produce attestations.
-  let timeReservedAtEnd = blockDurationSec;
-  if (!opts.pipelining) {
-    timeReservedAtEnd += checkpointFinalizationTime;
+  if (opts.ethereumSlotDuration !== undefined && opts.ethereumSlotDuration <= 0) {
+    throw new Error(`ethereumSlotDuration must be positive when provided (got ${opts.ethereumSlotDuration})`);
   }
 
-  // Time available for building blocks
-  const timeAvailableForBlocks = aztecSlotDurationSec - initOffset - timeReservedAtEnd;
+  if (opts.blockDuration !== undefined && opts.blockDuration <= 0) {
+    throw new Error(`blockDuration must be positive when provided (got ${opts.blockDuration})`);
+  }
 
-  return Math.max(1, Math.floor(timeAvailableForBlocks / blockDurationSec));
+  if (opts.minExecutionTime !== undefined && opts.minExecutionTime <= 0) {
+    throw new Error(`minExecutionTime must be positive when provided (got ${opts.minExecutionTime})`);
+  }
+
+  if (opts.checkpointAssembleTime !== undefined) {
+    assertNonNegative('checkpointAssembleTime', opts.checkpointAssembleTime);
+  }
+  if (opts.checkpointInitializationTime !== undefined) {
+    assertNonNegative('checkpointInitializationTime', opts.checkpointInitializationTime);
+  }
+  if (opts.l1PublishingTime !== undefined) {
+    assertNonNegative('l1PublishingTime', opts.l1PublishingTime);
+  }
+  if (opts.p2pPropagationTime !== undefined) {
+    assertNonNegative('p2pPropagationTime', opts.p2pPropagationTime);
+  }
+}
+
+function normalizeCheckpointTimingConfig(opts: CheckpointTimingConfig): CheckpointTimingConfig {
+  let checkpointAssembleTime = opts.checkpointAssembleTime ?? CHECKPOINT_ASSEMBLE_TIME;
+  let checkpointInitializationTime = opts.checkpointInitializationTime ?? CHECKPOINT_INITIALIZATION_TIME;
+  let minExecutionTime = opts.minExecutionTime ?? MIN_EXECUTION_TIME;
+  let p2pPropagationTime = opts.p2pPropagationTime ?? DEFAULT_P2P_PROPAGATION_TIME;
+
+  if (opts.ethereumSlotDuration !== undefined && opts.ethereumSlotDuration < 8) {
+    p2pPropagationTime = 0;
+    checkpointAssembleTime = 0.5;
+    checkpointInitializationTime = 0.5;
+    minExecutionTime = 1;
+  }
+
+  if (opts.blockDuration !== undefined && minExecutionTime > opts.blockDuration) {
+    minExecutionTime = opts.blockDuration;
+  }
+
+  return {
+    ...opts,
+    checkpointAssembleTime,
+    checkpointInitializationTime,
+    minExecutionTime,
+    p2pPropagationTime,
+  };
+}
+
+function validateCheckpointTimingModel(model: CheckpointTiming): void {
+  if (model.blockDuration === undefined) {
+    return;
+  }
+
+  const timeAvailableForBlocks = model.aztecSlotDuration - model.checkpointInitializationTime - model.timeReservedAtEnd;
+  if (timeAvailableForBlocks < model.blockDuration) {
+    throw new Error(
+      `Invalid timing configuration: only ${timeAvailableForBlocks}s available for block building, which is less than one blockDuration (${model.blockDuration}s).`,
+    );
+  }
 }

--- a/yarn-project/stdlib/src/tx/global_variable_builder.ts
+++ b/yarn-project/stdlib/src/tx/global_variable_builder.ts
@@ -1,5 +1,4 @@
-import type { FeeHeader } from '@aztec/ethereum/contracts';
-import type { CheckpointNumber } from '@aztec/foundation/branded-types';
+import type { SimulationOverridesPlan } from '@aztec/ethereum/contracts';
 import type { EthAddress } from '@aztec/foundation/eth-address';
 import type { SlotNumber } from '@aztec/foundation/schemas';
 
@@ -7,18 +6,6 @@ import type { AztecAddress } from '../aztec-address/index.js';
 import type { GasFees } from '../gas/gas_fees.js';
 import type { UInt32 } from '../types/index.js';
 import type { CheckpointGlobalVariables, GlobalVariables } from './global_variables.js';
-
-/** Fee header fields needed for pipelining overrides. */
-export type ForceProposedFeeHeader = {
-  checkpointNumber: CheckpointNumber;
-  feeHeader: FeeHeader;
-};
-
-/** Options for building checkpoint global variables during pipelining. */
-export type BuildCheckpointGlobalVariablesOpts = {
-  forcePendingCheckpointNumber?: CheckpointNumber;
-  forceProposedFeeHeader?: ForceProposedFeeHeader;
-};
 
 /**
  * Interface for building global variables for Aztec blocks.
@@ -46,6 +33,6 @@ export interface GlobalVariableBuilder {
     coinbase: EthAddress,
     feeRecipient: AztecAddress,
     slotNumber: SlotNumber,
-    opts?: BuildCheckpointGlobalVariablesOpts,
+    simulationOverridesPlan?: SimulationOverridesPlan,
   ): Promise<CheckpointGlobalVariables>;
 }

--- a/yarn-project/txe/src/state_machine/global_variable_builder.ts
+++ b/yarn-project/txe/src/state_machine/global_variable_builder.ts
@@ -1,14 +1,10 @@
+import type { SimulationOverridesPlan } from '@aztec/ethereum/contracts';
 import { BlockNumber, type SlotNumber } from '@aztec/foundation/branded-types';
 import type { EthAddress } from '@aztec/foundation/eth-address';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
 import { GasFees } from '@aztec/stdlib/gas';
 import { makeGlobalVariables } from '@aztec/stdlib/testing';
-import {
-  type BuildCheckpointGlobalVariablesOpts,
-  type CheckpointGlobalVariables,
-  type GlobalVariableBuilder,
-  GlobalVariables,
-} from '@aztec/stdlib/tx';
+import { type CheckpointGlobalVariables, type GlobalVariableBuilder, GlobalVariables } from '@aztec/stdlib/tx';
 
 export class TXEGlobalVariablesBuilder implements GlobalVariableBuilder {
   public getCurrentMinFees(): Promise<GasFees> {
@@ -28,7 +24,7 @@ export class TXEGlobalVariablesBuilder implements GlobalVariableBuilder {
     _coinbase: EthAddress,
     _feeRecipient: AztecAddress,
     _slotNumber: SlotNumber,
-    _opts?: BuildCheckpointGlobalVariablesOpts,
+    _simulationOverridesPlan?: SimulationOverridesPlan,
   ): Promise<CheckpointGlobalVariables> {
     const vars = makeGlobalVariables();
     return Promise.resolve({

--- a/yarn-project/txe/src/state_machine/mock_epoch_cache.ts
+++ b/yarn-project/txe/src/state_machine/mock_epoch_cache.ts
@@ -33,10 +33,6 @@ export class MockEpochCache implements EpochCacheInterface {
     return EpochNumber.ZERO;
   }
 
-  pipeliningOffset(): number {
-    return 0;
-  }
-
   getEpochAndSlotNow(): EpochAndSlot & { nowMs: bigint } {
     return {
       epoch: EpochNumber.ZERO,
@@ -61,6 +57,10 @@ export class MockEpochCache implements EpochCacheInterface {
 
   isProposerPipeliningEnabled(): boolean {
     return false;
+  }
+
+  pipeliningOffset(): number {
+    return 0;
   }
 
   getProposerIndexEncoding(_epoch: EpochNumber, _slot: SlotNumber, _seed: bigint): `0x${string}` {

--- a/yarn-project/validator-client/src/validator.ha.integration.test.ts
+++ b/yarn-project/validator-client/src/validator.ha.integration.test.ts
@@ -86,6 +86,7 @@ describe('ValidatorClient HA Integration', () => {
     p2pClient.getCheckpointAttestationsForSlot.mockImplementation(() => Promise.resolve([]));
     p2pClient.addOwnCheckpointAttestations.mockResolvedValue();
     p2pClient.broadcastCheckpointAttestations.mockResolvedValue();
+    const slotDuration = 24;
     checkpointsBuilder = mock<FullNodeCheckpointsBuilder>();
     checkpointsBuilder.getConfig.mockReturnValue({
       l1GenesisTime: 1n,
@@ -96,6 +97,9 @@ describe('ValidatorClient HA Integration', () => {
     });
     worldState = mock<WorldStateSynchronizer>();
     epochCache = mock<EpochCache>();
+    epochCache.getL1Constants.mockReturnValue({
+      slotDuration,
+    } as any);
     // Default mock: return all addresses passed (all are in committee)
     epochCache.filterInCommittee.mockImplementation((_slot, addresses) => Promise.resolve(addresses));
     blockSource = mock<L2BlockSource & L2BlockSink>();


### PR DESCRIPTION
## Overview

Allow validators to attest to old proposals slightly into the next slot, this allows validators from the slot before to send their checkpoint proposals 
later in their own slot.

## Key points
- Allows timetable to extend past the current slot 
- Decouples attestation gathering from the hot path for sequencers - it can move async
- Refactor of the timetable model into stdlib so it can be consumed elsewhere
