### PR TITLE
fix(archiver): (A-496) soft-delete contract data on prune, hard-delete on finalization

### DIFF
--- a/yarn-project/archiver/README.md
+++ b/yarn-project/archiver/README.md
@@ -123,6 +123,18 @@ Both message and checkpoint sync detect L1 reorgs by comparing local state again
 4. Archiver unwinds checkpoints 14 and 15
 5. Next sync iteration re-fetches the new checkpoints 14 and 15
 
+#### Contract Data Soft-Deletion
+
+When a prune/reorg occurs, the archiver removes blocks and their associated contract data (classes, instances, instance updates). However, an in-flight checkpoint build may hold a world-state fork created before the prune. That fork's nullifier tree still contains deployment nullifiers for contracts in the pruned blocks. If the AVM executes a tx on this fork and looks up a contract whose data was already hard-deleted from the archiver, it triggers a `BB_ASSERT` crash (`"Contract instance should be found if nullifier exists"`).
+
+To prevent this, contract data is **soft-deleted** on prune: entries are marked as pruned in separate tracking maps but remain in the main data maps. Getters continue to return the data normally. **Hard-deletion** occurs only when a checkpoint is finalized via `setFinalizedCheckpointNumber()`, at which point no in-flight fork can reference the pruned data.
+
+This is safe because the world-state nullifier tree is the source of truth for contract existence, not the archiver. A new fork created after the prune won't have the deployment nullifier, so the AVM will correctly reject txs referencing the pruned contract — regardless of whether the archiver still has the metadata.
+
+When a pruned contract is re-deployed (same txs re-included in new blocks), the `add*` methods remove it from the pending-deletion map and store fresh data. Subsequent finalization won't delete it since the tracking entry was already removed.
+
+The implementation lives in `ContractInstanceStore` and `ContractClassStore` (in `src/store/`), orchestrated by `ArchiverDataStoreUpdater` (in `src/modules/`).
+
 #### Epoch Prune
 
 If a prune would occur on the next checkpoint submission (checked via `canPruneAtTime`), the archiver preemptively unwinds to the proven checkpoint.

--- a/yarn-project/archiver/src/modules/data_store_updater.test.ts
+++ b/yarn-project/archiver/src/modules/data_store_updater.test.ts
@@ -80,7 +80,7 @@ describe('ArchiverDataStoreUpdater', () => {
       expect(retrievedInstance?.address.equals(instanceAddress)).toBe(true);
     });
 
-    it('removes contract class and instance data when blocks are pruned via setCheckpointData', async () => {
+    it('soft-deletes contract class and instance data when blocks are pruned via setCheckpointData', async () => {
       // First, add a local provisional block with contract data
       const localBlock = await L2Block.random(BlockNumber(1), {
         checkpointNumber: CheckpointNumber(1),
@@ -114,12 +114,17 @@ describe('ArchiverDataStoreUpdater', () => {
       // This should detect the conflict and prune the local block
       await updater.addCheckpoints([publishedCheckpoint]);
 
-      // Verify the contract data from the local block was removed
+      // Contract data should still be accessible after prune (soft-deleted)
+      expect(await store.getContractClass(contractClassId)).toBeDefined();
+      expect(await store.getContractInstance(instanceAddress, timestamp)).toBeDefined();
+
+      // Hard-delete occurs on finalization
+      await updater.setFinalizedCheckpointNumber(CheckpointNumber(1));
       expect(await store.getContractClass(contractClassId)).toBeUndefined();
       expect(await store.getContractInstance(instanceAddress, timestamp)).toBeUndefined();
     });
 
-    it('removes contract data when checkpoints are unwound', async () => {
+    it('soft-deletes contract data when checkpoints are unwound', async () => {
       // Create block with contract data and add it as a checkpoint
       const block = await L2Block.random(BlockNumber(1), {
         checkpointNumber: CheckpointNumber(1),
@@ -137,12 +142,45 @@ describe('ArchiverDataStoreUpdater', () => {
       expect(await store.getContractClass(contractClassId)).toBeDefined();
       expect(await store.getContractInstance(instanceAddress, timestamp)).toBeDefined();
 
-      // Remove the checkpoint
+      // Remove the checkpoint, data should still be accessible (soft-deleted)
+      await updater.removeCheckpointsAfter(CheckpointNumber(0));
+      expect(await store.getContractClass(contractClassId)).toBeDefined();
+      expect(await store.getContractInstance(instanceAddress, timestamp)).toBeDefined();
+    });
+
+    it('re-deploy after prune prevents finalization from hard-deleting contract class and instance', async () => {
+      // Add block with contract data
+      const block = await L2Block.random(BlockNumber(1), {
+        checkpointNumber: CheckpointNumber(1),
+        indexWithinCheckpoint: IndexWithinCheckpoint(0),
+      });
+      block.body.txEffects[0].contractClassLogs = [contractClassLog];
+      block.body.txEffects[0].privateLogs = [PrivateLog.fromBuffer(getSampleContractInstancePublishedEventPayload())];
+
+      const publishedCheckpoint = makePublishedCheckpoint(makeCheckpoint([block]), 10);
+      await updater.addCheckpoints([publishedCheckpoint]);
+
+      // Prune the checkpoint
       await updater.removeCheckpointsAfter(CheckpointNumber(0));
 
-      // Verify the contract data was removed
-      expect(await store.getContractClass(contractClassId)).toBeUndefined();
-      expect(await store.getContractInstance(instanceAddress, timestamp)).toBeUndefined();
+      // Re-add the same contract data in a new block
+      const newBlock = await L2Block.random(BlockNumber(1), {
+        checkpointNumber: CheckpointNumber(1),
+        indexWithinCheckpoint: IndexWithinCheckpoint(0),
+      });
+      newBlock.body.txEffects[0].contractClassLogs = [contractClassLog];
+      newBlock.body.txEffects[0].privateLogs = [
+        PrivateLog.fromBuffer(getSampleContractInstancePublishedEventPayload()),
+      ];
+
+      const newCheckpoint = makePublishedCheckpoint(makeCheckpoint([newBlock]), 20);
+      await updater.addCheckpoints([newCheckpoint]);
+
+      // Finalize, data should survive because re-deploy removed it from the pending-deletion map
+      await updater.setFinalizedCheckpointNumber(CheckpointNumber(1));
+      const timestamp = newBlock.header.globalVariables.timestamp + 1n;
+      expect(await store.getContractClass(contractClassId)).toBeDefined();
+      expect(await store.getContractInstance(instanceAddress, timestamp)).toBeDefined();
     });
   });
 

--- a/yarn-project/archiver/src/modules/data_store_updater.ts
+++ b/yarn-project/archiver/src/modules/data_store_updater.ts
@@ -288,6 +288,9 @@ export class ArchiverDataStoreUpdater {
   public async setFinalizedCheckpointNumber(checkpointNumber: CheckpointNumber): Promise<void> {
     await this.store.transactionAsync(async () => {
       await this.store.setFinalizedCheckpointNumber(checkpointNumber);
+      // Hard-delete pruned contract data for blocks at or before the finalized checkpoint
+      const finalizedBlockNumber = await this.store.getFinalizedL2BlockNumber();
+      await this.store.finalizeContractData(finalizedBlockNumber);
       await this.l2TipsCache?.refresh();
     });
   }
@@ -312,7 +315,12 @@ export class ArchiverDataStoreUpdater {
       await Promise.all([
         this.updatePublishedContractClasses(contractClassLogs, block.number, operation),
         this.updateDeployedContractInstances(privateLogs, block.number, operation),
-        this.updateUpdatedContractInstances(publicLogs, block.header.globalVariables.timestamp, operation),
+        this.updateUpdatedContractInstances(
+          publicLogs,
+          block.header.globalVariables.timestamp,
+          block.number,
+          operation,
+        ),
         operation === Operation.Store
           ? this.storeBroadcastedIndividualFunctions(contractClassLogs, block.number)
           : Promise.resolve(true),
@@ -379,6 +387,7 @@ export class ArchiverDataStoreUpdater {
   private async updateUpdatedContractInstances(
     allLogs: PublicLog[],
     timestamp: UInt64,
+    blockNum: BlockNumber,
     operation: Operation,
   ): Promise<boolean> {
     const contractUpdates = allLogs
@@ -393,7 +402,7 @@ export class ArchiverDataStoreUpdater {
       if (operation == Operation.Store) {
         return await this.store.addContractInstanceUpdates(contractUpdates, timestamp);
       } else if (operation == Operation.Delete) {
-        return await this.store.deleteContractInstanceUpdates(contractUpdates, timestamp);
+        return await this.store.deleteContractInstanceUpdates(contractUpdates, timestamp, blockNum);
       }
     }
     return true;

--- a/yarn-project/archiver/src/store/contract_class_store.ts
+++ b/yarn-project/archiver/src/store/contract_class_store.ts
@@ -17,10 +17,12 @@ import { Vector } from '@aztec/stdlib/types';
 export class ContractClassStore {
   #contractClasses: AztecAsyncMap<string, Buffer>;
   #bytecodeCommitments: AztecAsyncMap<string, Buffer>;
+  #prunedContractClasses: AztecAsyncMap<string, number>;
 
   constructor(private db: AztecAsyncKVStore) {
     this.#contractClasses = db.openMap('archiver_contract_classes');
     this.#bytecodeCommitments = db.openMap('archiver_bytecode_commitments');
+    this.#prunedContractClasses = db.openMap('archiver_pruned_contract_classes');
   }
 
   async addContractClass(
@@ -29,21 +31,30 @@ export class ContractClassStore {
     blockNumber: number,
   ): Promise<void> {
     await this.db.transactionAsync(async () => {
+      const classIdStr = contractClass.id.toString();
+      // If previously pruned, remove from pending-deletion map
+      const wasPruned = await this.#prunedContractClasses.getAsync(classIdStr);
+      if (wasPruned !== undefined) {
+        await this.#contractClasses.delete(classIdStr);
+        await this.#bytecodeCommitments.delete(classIdStr);
+        await this.#prunedContractClasses.delete(classIdStr);
+      }
       await this.#contractClasses.setIfNotExists(
-        contractClass.id.toString(),
+        classIdStr,
         serializeContractClassPublic({ ...contractClass, l2BlockNumber: blockNumber }),
       );
-      await this.#bytecodeCommitments.setIfNotExists(contractClass.id.toString(), bytecodeCommitment.toBuffer());
+      await this.#bytecodeCommitments.setIfNotExists(classIdStr, bytecodeCommitment.toBuffer());
     });
   }
 
+  /** Soft-deletes a contract class, tracks it for pending deletion but keeps data accessible for in-flight block builds. */
   async deleteContractClasses(contractClass: ContractClassPublic, blockNumber: number): Promise<void> {
-    const restoredContractClass = await this.#contractClasses.getAsync(contractClass.id.toString());
-    if (restoredContractClass && deserializeContractClassPublic(restoredContractClass).l2BlockNumber >= blockNumber) {
-      await this.db.transactionAsync(async () => {
-        await this.#contractClasses.delete(contractClass.id.toString());
-        await this.#bytecodeCommitments.delete(contractClass.id.toString());
-      });
+    const restoredContractClassBuf = await this.#contractClasses.getAsync(contractClass.id.toString());
+    if (restoredContractClassBuf) {
+      const restoredContractClass = deserializeContractClassPublic(restoredContractClassBuf);
+      if (restoredContractClass.l2BlockNumber >= blockNumber) {
+        await this.#prunedContractClasses.set(contractClass.id.toString(), restoredContractClass.l2BlockNumber);
+      }
     }
   }
 
@@ -59,6 +70,22 @@ export class ContractClassStore {
 
   async getContractClassIds(): Promise<Fr[]> {
     return (await toArray(this.#contractClasses.keysAsync())).map(key => Fr.fromHexString(key));
+  }
+
+  /**
+   * Hard-deletes pruned contract classes for blocks at or before the finalized block number.
+   * Called when a checkpoint is finalized, at which point no in-flight fork can reference the pruned data.
+   */
+  async finalizeContractClasses(finalizedBlockNumber: number): Promise<void> {
+    await this.db.transactionAsync(async () => {
+      for await (const [classId, l2BlockNumber] of this.#prunedContractClasses.entriesAsync()) {
+        if (l2BlockNumber <= finalizedBlockNumber) {
+          await this.#contractClasses.delete(classId);
+          await this.#bytecodeCommitments.delete(classId);
+          await this.#prunedContractClasses.delete(classId);
+        }
+      }
+    });
   }
 
   async addFunctions(

--- a/yarn-project/archiver/src/store/contract_instance_store.ts
+++ b/yarn-project/archiver/src/store/contract_instance_store.ts
@@ -11,6 +11,9 @@ import type { UInt64 } from '@aztec/stdlib/types';
 
 type ContractInstanceUpdateKey = [string, string] | [string, string, number];
 
+/** Duplicates key components in the value because LMDB can't deserialize tuple keys during iteration. */
+type PrunedUpdateEntry = { blockNumber: number; address: string; timestamp: string; logIndex: number };
+
 /**
  * LMDB-based contract instance storage for the archiver.
  */
@@ -18,11 +21,15 @@ export class ContractInstanceStore {
   #contractInstances: AztecAsyncMap<string, Buffer>;
   #contractInstancePublishedAt: AztecAsyncMap<string, number>;
   #contractInstanceUpdates: AztecAsyncMap<ContractInstanceUpdateKey, Buffer>;
+  #prunedContractInstances: AztecAsyncMap<string, number>;
+  #prunedContractInstanceUpdates: AztecAsyncMap<ContractInstanceUpdateKey, PrunedUpdateEntry>;
 
   constructor(private db: AztecAsyncKVStore) {
     this.#contractInstances = db.openMap('archiver_contract_instances');
     this.#contractInstancePublishedAt = db.openMap('archiver_contract_instances_publication_block_number');
     this.#contractInstanceUpdates = db.openMap('archiver_contract_instance_updates');
+    this.#prunedContractInstances = db.openMap('archiver_pruned_contract_instances');
+    this.#prunedContractInstanceUpdates = db.openMap('archiver_pruned_contract_instance_updates');
   }
 
   addContractInstance(contractInstance: ContractInstanceWithAddress, blockNumber: number): Promise<void> {
@@ -32,13 +39,18 @@ export class ContractInstanceStore {
         new SerializableContractInstance(contractInstance).toBuffer(),
       );
       await this.#contractInstancePublishedAt.set(contractInstance.address.toString(), blockNumber);
+      // If previously pruned, remove from pending-deletion map so finalization won't hard-delete it
+      await this.#prunedContractInstances.delete(contractInstance.address.toString());
     });
   }
 
-  deleteContractInstance(contractInstance: ContractInstanceWithAddress): Promise<void> {
+  deleteContractInstance(contractInstance: ContractInstanceWithAddress): Promise<boolean> {
     return this.db.transactionAsync(async () => {
-      await this.#contractInstances.delete(contractInstance.address.toString());
-      await this.#contractInstancePublishedAt.delete(contractInstance.address.toString());
+      const publishedAt = await this.#contractInstancePublishedAt.getAsync(contractInstance.address.toString());
+      if (publishedAt !== undefined) {
+        await this.#prunedContractInstances.set(contractInstance.address.toString(), publishedAt);
+      }
+      return true;
     });
   }
 
@@ -55,18 +67,31 @@ export class ContractInstanceStore {
     timestamp: UInt64,
     logIndex: number,
   ): Promise<void> {
-    return this.#contractInstanceUpdates.set(
-      this.getUpdateKey(contractInstanceUpdate.address, timestamp, logIndex),
-      new SerializableContractInstanceUpdate(contractInstanceUpdate).toBuffer(),
-    );
+    const key = this.getUpdateKey(contractInstanceUpdate.address, timestamp, logIndex);
+    return this.db.transactionAsync(async () => {
+      await this.#contractInstanceUpdates.set(
+        key,
+        new SerializableContractInstanceUpdate(contractInstanceUpdate).toBuffer(),
+      );
+      await this.#prunedContractInstanceUpdates.delete(key);
+    });
   }
 
-  deleteContractInstanceUpdate(
+  async deleteContractInstanceUpdate(
     contractInstanceUpdate: ContractInstanceUpdateWithAddress,
     timestamp: UInt64,
     logIndex: number,
-  ): Promise<void> {
-    return this.#contractInstanceUpdates.delete(this.getUpdateKey(contractInstanceUpdate.address, timestamp, logIndex));
+    blockNumber: number,
+  ): Promise<boolean> {
+    const key = this.getUpdateKey(contractInstanceUpdate.address, timestamp, logIndex);
+    const entry: PrunedUpdateEntry = {
+      blockNumber,
+      address: contractInstanceUpdate.address.toString(),
+      timestamp: timestamp.toString(),
+      logIndex,
+    };
+    await this.#prunedContractInstanceUpdates.set(key, entry);
+    return true;
   }
 
   async getCurrentContractInstanceClassId(address: AztecAddress, timestamp: UInt64, originalClassId: Fr): Promise<Fr> {
@@ -111,5 +136,30 @@ export class ContractInstanceStore {
 
   getContractInstanceDeploymentBlockNumber(address: AztecAddress): Promise<number | undefined> {
     return this.#contractInstancePublishedAt.getAsync(address.toString());
+  }
+
+  /**
+   * Hard-deletes pruned contract data for blocks at or before the finalized block number.
+   * Called when a checkpoint is finalized, at which point no in-flight fork can reference the pruned data.
+   */
+  async finalizeContractData(finalizedBlockNumber: number): Promise<void> {
+    await this.db.transactionAsync(async () => {
+      // Hard-delete pruned contract instances
+      for await (const [address, publishedAt] of this.#prunedContractInstances.entriesAsync()) {
+        if (publishedAt <= finalizedBlockNumber) {
+          await this.#contractInstances.delete(address);
+          await this.#contractInstancePublishedAt.delete(address);
+          await this.#prunedContractInstances.delete(address);
+        }
+      }
+
+      for await (const entry of this.#prunedContractInstanceUpdates.valuesAsync()) {
+        if (entry.blockNumber <= finalizedBlockNumber) {
+          const key: ContractInstanceUpdateKey = [entry.address, entry.timestamp, entry.logIndex];
+          await this.#contractInstanceUpdates.delete(key);
+          await this.#prunedContractInstanceUpdates.delete(key);
+        }
+      }
+    });
   }
 }

--- a/yarn-project/archiver/src/store/kv_archiver_store.test.ts
+++ b/yarn-project/archiver/src/store/kv_archiver_store.test.ts
@@ -2081,8 +2081,16 @@ describe('KVArchiverDataStore', () => {
       await expect(store.getContractInstance(await AztecAddress.random(), timestamp)).resolves.toBeUndefined();
     });
 
-    it('returns undefined if previously stored contract instances was deleted', async () => {
+    it('returns contract instance after soft-delete (still accessible for in-flight builds)', async () => {
       await store.deleteContractInstances([contractInstance], BlockNumber(blockNum));
+      await expect(store.getContractInstance(contractInstance.address, timestamp)).resolves.toMatchObject(
+        contractInstance,
+      );
+    });
+
+    it('returns undefined after finalization of soft-deleted contract instance', async () => {
+      await store.deleteContractInstances([contractInstance], BlockNumber(blockNum));
+      await store.finalizeContractData(BlockNumber(blockNum));
       await expect(store.getContractInstance(contractInstance.address, timestamp)).resolves.toBeUndefined();
     });
   });
@@ -2178,6 +2186,75 @@ describe('KVArchiverDataStore', () => {
       expect(fetchedInstance?.originalContractClassId).toEqual(classId);
       expect(fetchedInstance?.currentContractClassId).toEqual(nextClassId);
     });
+
+    it('returns update data after soft-delete (still accessible for in-flight builds)', async () => {
+      const blockNum = 5;
+      await store.deleteContractInstanceUpdates(
+        [
+          {
+            prevContractClassId: classId,
+            newContractClassId: nextClassId,
+            timestampOfChange,
+            address: contractInstance.address,
+          },
+        ],
+        timestampOfChange - 1n,
+        BlockNumber(blockNum),
+      );
+      const fetchedInstance = await store.getContractInstance(contractInstance.address, timestampOfChange + 1n);
+      expect(fetchedInstance?.currentContractClassId).toEqual(nextClassId);
+    });
+
+    it('returns original class id after finalization of soft-deleted update', async () => {
+      const blockNum = 5;
+      await store.deleteContractInstanceUpdates(
+        [
+          {
+            prevContractClassId: classId,
+            newContractClassId: nextClassId,
+            timestampOfChange,
+            address: contractInstance.address,
+          },
+        ],
+        timestampOfChange - 1n,
+        BlockNumber(blockNum),
+      );
+      await store.finalizeContractData(BlockNumber(blockNum));
+      const fetchedInstance = await store.getContractInstance(contractInstance.address, timestampOfChange + 1n);
+      expect(fetchedInstance?.currentContractClassId).toEqual(classId);
+    });
+
+    it('re-adding update after soft-delete prevents finalization from deleting it', async () => {
+      const blockNum = 5;
+      await store.deleteContractInstanceUpdates(
+        [
+          {
+            prevContractClassId: classId,
+            newContractClassId: nextClassId,
+            timestampOfChange,
+            address: contractInstance.address,
+          },
+        ],
+        timestampOfChange - 1n,
+        BlockNumber(blockNum),
+      );
+      // Re-add the same update
+      await store.addContractInstanceUpdates(
+        [
+          {
+            prevContractClassId: classId,
+            newContractClassId: nextClassId,
+            timestampOfChange,
+            address: contractInstance.address,
+          },
+        ],
+        timestampOfChange - 1n,
+      );
+      // Finalize should NOT delete the update because re-adding removed it from the pending-deletion map
+      await store.finalizeContractData(BlockNumber(blockNum));
+      const fetchedInstance = await store.getContractInstance(contractInstance.address, timestampOfChange + 1n);
+      expect(fetchedInstance?.currentContractClassId).toEqual(nextClassId);
+    });
   });
 
   describe('contractClasses', () => {
@@ -2197,8 +2274,14 @@ describe('KVArchiverDataStore', () => {
       await expect(store.getContractClass(contractClass.id)).resolves.toMatchObject(contractClass);
     });
 
-    it('returns undefined if the initial deployed contract class was deleted', async () => {
+    it('returns contract class after soft-delete (still accessible for in-flight builds)', async () => {
       await store.deleteContractClasses([contractClass], BlockNumber(blockNum));
+      await expect(store.getContractClass(contractClass.id)).resolves.toMatchObject(contractClass);
+    });
+
+    it('returns undefined after finalization of soft-deleted contract class', async () => {
+      await store.deleteContractClasses([contractClass], BlockNumber(blockNum));
+      await store.finalizeContractData(BlockNumber(blockNum));
       await expect(store.getContractClass(contractClass.id)).resolves.toBeUndefined();
     });
 

--- a/yarn-project/archiver/src/store/kv_archiver_store.ts
+++ b/yarn-project/archiver/src/store/kv_archiver_store.ts
@@ -233,14 +233,27 @@ export class KVArchiverDataStore implements ContractDataSource {
       )
     ).every(Boolean);
   }
-  async deleteContractInstanceUpdates(data: ContractInstanceUpdateWithAddress[], timestamp: UInt64): Promise<boolean> {
+  async deleteContractInstanceUpdates(
+    data: ContractInstanceUpdateWithAddress[],
+    timestamp: UInt64,
+    blockNumber: BlockNumber,
+  ): Promise<boolean> {
     return (
       await Promise.all(
         data.map((update, logIndex) =>
-          this.#contractInstanceStore.deleteContractInstanceUpdate(update, timestamp, logIndex),
+          this.#contractInstanceStore.deleteContractInstanceUpdate(update, timestamp, logIndex, blockNumber),
         ),
       )
     ).every(Boolean);
+  }
+
+  /**
+   * Hard-deletes all pruned contract data for blocks at or before the finalized block number.
+   * Called when a checkpoint is finalized, at which point no in-flight fork can reference the pruned data.
+   */
+  async finalizeContractData(finalizedBlockNumber: BlockNumber): Promise<void> {
+    await this.#contractInstanceStore.finalizeContractData(finalizedBlockNumber);
+    await this.#contractClassStore.finalizeContractClasses(finalizedBlockNumber);
   }
 
   /**


### PR DESCRIPTION
During a reorg, the archiver was hard-deleting contract instance/class data immediately, causing BB_ASSERT crashes when in-flight block builds referenced contracts whose nullifiers still existed in the world-state fork. Now marks pruned entries as soft-deleted so they remain accessible, and only hard-deletes when a checkpoint is finalized.


