### PR TITLE
chore: Use explicit constant type for `ScheduledDelayChange`

### DIFF
--- a/noir-projects/noir-protocol-circuits/crates/types/src/delayed_public_mutable/delayed_public_mutable_values/test.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/delayed_public_mutable/delayed_public_mutable_values/test.nr
@@ -74,7 +74,7 @@ unconstrained fn packed_delayed_public_mutable_values_match_typescript() {
     let pre_value = MockStruct { a: 1, b: 2 };
     let post_value = MockStruct { a: 3, b: 4 };
 
-    let sdc = ScheduledDelayChange::<0>::new(Option::some(1), Option::some(50), 2);
+    let sdc = ScheduledDelayChange::<0u64>::new(Option::some(1), Option::some(50), 2);
     let svc = ScheduledValueChange::new(pre_value, post_value, 50);
     let dpmv = DelayedPublicMutableValues::new(svc, sdc);
 


### PR DESCRIPTION
Use an explicit constant type for `ScheduledDelayChange` to unblock a breaking compiler change (https://github.com/noir-lang/noir/pull/11838) which removes type inference for type-level constants in noir.