### PR TITLE
feat: filtering public logs by tag

### DIFF
--- a/yarn-project/archiver/src/store/kv_archiver_store.test.ts
+++ b/yarn-project/archiver/src/store/kv_archiver_store.test.ts
@@ -2782,6 +2782,24 @@ describe('KVArchiverDataStore', () => {
       }
     });
 
+    it('"tag" filter param is respected', async () => {
+      // Get a random tag from the logs
+      const targetBlockIndex = randomInt(numBlocksForPublicLogs);
+      const targetBlock = publishedCheckpoints[targetBlockIndex].checkpoint.blocks[0];
+      const targetTxIndex = randomInt(getTxsPerBlock(targetBlock));
+      const targetLogIndex = randomInt(getPublicLogsPerTx(targetBlock, targetTxIndex));
+      const targetTag = targetBlock.body.txEffects[targetTxIndex].publicLogs[targetLogIndex].fields[0];
+
+      const response = await store.getPublicLogs({ tag: targetTag });
+
+      expect(response.maxLogsHit).toBeFalsy();
+      expect(response.logs.length).toBeGreaterThan(0);
+
+      for (const extendedLog of response.logs) {
+        expect(extendedLog.log.fields[0].equals(targetTag)).toBeTruthy();
+      }
+    });
+
     it('"afterLog" filter param is respected', async () => {
       // Get a random log as reference
       const targetBlockIndex = randomInt(numBlocksForPublicLogs);

--- a/yarn-project/archiver/src/store/log_store.ts
+++ b/yarn-project/archiver/src/store/log_store.ts
@@ -592,7 +592,10 @@ export class LogStore {
     let logIndex = typeof filter.afterLog?.logIndex === 'number' ? filter.afterLog.logIndex + 1 : 0;
     for (; logIndex < txLogs.length; logIndex++) {
       const log = txLogs[logIndex];
-      if (!filter.contractAddress || log.contractAddress.equals(filter.contractAddress)) {
+      if (
+        (!filter.contractAddress || log.contractAddress.equals(filter.contractAddress)) &&
+        (!filter.tag || log.fields[0]?.equals(filter.tag))
+      ) {
         results.push(
           new ExtendedPublicLog(new LogId(BlockNumber(blockNumber), blockHash, txHash, txIndex, logIndex), log),
         );

--- a/yarn-project/stdlib/src/logs/log_filter.ts
+++ b/yarn-project/stdlib/src/logs/log_filter.ts
@@ -1,3 +1,5 @@
+import type { Fr } from '@aztec/foundation/curves/bn254';
+
 import { z } from 'zod';
 
 import type { AztecAddress } from '../aztec-address/index.js';
@@ -20,6 +22,8 @@ export type LogFilter = {
   afterLog?: LogId;
   /** The contract address to filter logs by. */
   contractAddress?: AztecAddress;
+  /** The tag (first field of the log) to filter logs by. */
+  tag?: Fr;
 };
 
 export const LogFilterSchema: ZodFor<LogFilter> = z.object({
@@ -28,4 +32,5 @@ export const LogFilterSchema: ZodFor<LogFilter> = z.object({
   toBlock: schemas.Integer.optional(),
   afterLog: LogId.schema.optional(),
   contractAddress: schemas.AztecAddress.optional(),
+  tag: schemas.Fr.optional(),
 });


### PR DESCRIPTION
I am not sure if the code in this PR is good because it doesn't leverage the tag index as was requested by [this issue](https://linear.app/aztec-labs/issue/F-224/index-public-events-by-tag).

When I answered that F-224 seems to be implemented I was not aware that that index is not easily usable. The issue is that we seem to have multiple log types and the getPublicLogs function looks too complicated (see [here](https://github.com/AztecProtocol/aztec-packages/blob/9ff56567188562f162b16b7a8de04ea9c6cfccf4/yarn-project/archiver/src/store/log_store.ts#L371-L379)).

This is the plan AI came up with:

<img width="961" height="939" alt="image" src="https://github.com/user-attachments/assets/0e230d15-62a0-4681-8841-77351cdeaadd" />

This is what I propose:
1. Since this changes node interface and we want to have all the changes done to the node interface by alpha release we merge this inefficient but from the POV of node interface final code,
2. we ping alpha team about this inefficiency and let them do whatever with it (I don't think fairies should be doing this).