### PR TITLE
fix(aztec-node): throw on existing nullifier in getLowNullifierMembershipWitness

### DIFF
--- a/yarn-project/aztec-node/src/aztec-node/server.test.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.test.ts
@@ -398,6 +398,33 @@ describe('aztec node', () => {
       });
     });
 
+    describe('getLowNullifierMembershipWitness', () => {
+      beforeEach(() => {
+        lastBlockNumber = BlockNumber(1);
+      });
+
+      it('throws when nullifier already exists in the tree', async () => {
+        const nullifier = Fr.random();
+        merkleTreeOps.getPreviousValueIndex.mockImplementation((treeId: MerkleTreeId, value: bigint) => {
+          if (treeId === MerkleTreeId.NULLIFIER_TREE && value === nullifier.toBigInt()) {
+            return Promise.resolve({ index: 42n, alreadyPresent: true });
+          }
+          return Promise.resolve(undefined);
+        });
+
+        await expect(node.getLowNullifierMembershipWitness('latest', nullifier)).rejects.toThrow(
+          /Cannot prove nullifier non-inclusion/,
+        );
+      });
+
+      it('returns undefined when nullifier not found', async () => {
+        merkleTreeOps.getPreviousValueIndex.mockResolvedValue(undefined);
+
+        const result = await node.getLowNullifierMembershipWitness('latest', Fr.random());
+        expect(result).toBeUndefined();
+      });
+    });
+
     describe('findLeavesIndexes', () => {
       const blockHash1 = Fr.random();
       const blockHash2 = Fr.random();

--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -1133,16 +1133,6 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, Traceable {
     return new NullifierMembershipWitness(index, leafPreimage as NullifierLeafPreimage, path);
   }
 
-  /**
-   * Returns a low nullifier membership witness for a given nullifier at a given block.
-   * @param referenceBlock - The block parameter (block number, block hash, or 'latest') at which to get the data.
-   * @param nullifier - Nullifier we try to find the low nullifier witness for.
-   * @returns The low nullifier membership witness (if found).
-   * @throws If the nullifier already exists in the tree, since non-inclusion cannot be proven.
-   * @remarks Low nullifier witness can be used to perform a nullifier non-inclusion proof by leveraging the "linked
-   * list structure" of leaves and proving that a lower nullifier is pointing to a bigger next value than the nullifier
-   * we are trying to prove non-inclusion for.
-   */
   public async getLowNullifierMembershipWitness(
     referenceBlock: BlockParameter,
     nullifier: Fr,

--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -1135,18 +1135,13 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, Traceable {
 
   /**
    * Returns a low nullifier membership witness for a given nullifier at a given block.
-   * @param referenceBlock - The block parameter (block number, block hash, or 'latest') at which to get the data
-   * (which contains the root of the nullifier tree in which we are searching for the nullifier).
+   * @param referenceBlock - The block parameter (block number, block hash, or 'latest') at which to get the data.
    * @param nullifier - Nullifier we try to find the low nullifier witness for.
    * @returns The low nullifier membership witness (if found).
+   * @throws If the nullifier already exists in the tree, since non-inclusion cannot be proven.
    * @remarks Low nullifier witness can be used to perform a nullifier non-inclusion proof by leveraging the "linked
    * list structure" of leaves and proving that a lower nullifier is pointing to a bigger next value than the nullifier
    * we are trying to prove non-inclusion for.
-   *
-   * Note: This function returns the membership witness of the nullifier itself and not the low nullifier when
-   * the nullifier already exists in the tree. This is because the `getPreviousValueIndex` function returns the
-   * index of the nullifier itself when it already exists in the tree.
-   * TODO: This is a confusing behavior and we should eventually address that.
    */
   public async getLowNullifierMembershipWitness(
     referenceBlock: BlockParameter,
@@ -1159,7 +1154,9 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, Traceable {
     }
     const { index, alreadyPresent } = findResult;
     if (alreadyPresent) {
-      this.log.warn(`Nullifier ${nullifier.toBigInt()} already exists in the tree`);
+      throw new Error(
+        `Cannot prove nullifier non-inclusion: nullifier ${nullifier.toBigInt()} already exists in the tree`,
+      );
     }
     const preimageData = (await committedDb.getLeafPreimage(MerkleTreeId.NULLIFIER_TREE, index))!;
 

--- a/yarn-project/stdlib/src/interfaces/aztec-node.ts
+++ b/yarn-project/stdlib/src/interfaces/aztec-node.ts
@@ -122,6 +122,7 @@ export interface AztecNode
    * @param referenceBlock - The block parameter (block number, block hash, or 'latest') at which to get the data.
    * @param nullifier - Nullifier we try to find the low nullifier witness for.
    * @returns The low nullifier membership witness (if found).
+   * @throws If the nullifier already exists in the tree, since non-inclusion cannot be proven.
    * @remarks Low nullifier witness can be used to perform a nullifier non-inclusion proof by leveraging the "linked
    * list structure" of leaves and proving that a lower nullifier is pointing to a bigger next value than the nullifier
    * we are trying to prove non-inclusion for.


### PR DESCRIPTION
As I was going through TODOs I found this ancient TODO of mine (from November 2023):

```
   * Note: This function returns the membership witness of the nullifier itself and not the low nullifier when
   * the nullifier already exists in the tree. This is because the `getPreviousValueIndex` function returns the
   * index of the nullifier itself when it already exists in the tree.
   * TODO: This is a confusing behavior and we should eventually address that.
```

In this PR i handle it by instead throwing an error in this scenario.

This doesn't modify the interface so it was not urgent to do but felt like it makes sense to do now anyway so I went with it.

(Pinged this PR to alpha team)

## Summary

- `getLowNullifierMembershipWitness` now throws a descriptive error when the queried nullifier already exists in the tree, instead of silently returning the nullifier's own witness (which is wrong for a non-inclusion proof)
- Removes the long-standing TODO about confusing behavior (open since Nov 2023)
- Adds `@throws` JSDoc to both the interface and implementation
- Adds unit tests for the throw and undefined-return paths

## Context

Previously, `getPreviousValueIndex` returns the nullifier's own index when `alreadyPresent: true`. The method just logged a warning and returned that witness anyway. The Noir circuit would catch this implicitly (the `low < target` assertion fails), but the error surfaced as a cryptic circuit assertion rather than a clear "nullifier already exists" message.

## Test plan

- Unit tests added in `server.test.ts` covering both the throw-on-exists and return-undefined paths
- All 34 existing tests in `server.test.ts` continue to pass
- Build, format, and lint pass


🤖 Generated with [Claude Code](https://claude.com/claude-code)