### PR TITLE
fix(aztec-nr): warn on unknown note type id in compute_note_hash_and_nullifier

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/macros/aztec.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/aztec.nr
@@ -340,6 +340,10 @@ comptime fn generate_contract_library_method_compute_note_hash_and_nullifier() -
             ) -> Option<aztec::messages::discovery::NoteHashAndNullifier> {
                 $if_note_type_id_match_statements
                 else {
+                    aztec::protocol::logging::warn_log_format(
+                        "[aztec-nr] Unknown note type id {0}. Skipping note.",
+                        [note_type_id],
+                    );
                     Option::none()
                 }
             }

--- a/noir-projects/noir-contracts/contracts/test/note_hash_and_nullifier/note_hash_and_nullifier_contract/src/test.nr
+++ b/noir-projects/noir-contracts/contracts/test/note_hash_and_nullifier/note_hash_and_nullifier_contract/src/test.nr
@@ -63,3 +63,20 @@ unconstrained fn returns_none_for_empty_packed_note() {
 
     assert(result.is_none());
 }
+
+#[test]
+unconstrained fn returns_none_for_unknown_note_type_id() {
+    let packed_note = BoundedVec::from_array([42]);
+
+    let result = NoteHashAndNullifier::test_compute_note_hash_and_nullifier(
+        packed_note,
+        AztecAddress::zero(),
+        0,
+        0xdeadbeef,
+        AztecAddress::zero(),
+        0,
+        0,
+    );
+
+    assert(result.is_none());
+}


### PR DESCRIPTION
## Summary

- Log a warning when `_compute_note_hash_and_nullifier` encounters an unknown note type id, instead of silently returning `None`
- Add test for the unknown note type id case

Fixes F-436