### PR TITLE
fix(archiver): guard getL1ToL2Messages against incomplete message sync

### DIFF
--- a/yarn-project/archiver/src/archiver-sync.test.ts
+++ b/yarn-project/archiver/src/archiver-sync.test.ts
@@ -27,6 +27,7 @@ import { type MockProxy, mock } from 'jest-mock-extended';
 import type { GetBlockReturnType } from 'viem';
 
 import { Archiver, type ArchiverEmitter } from './archiver.js';
+import { L1ToL2MessagesNotReadyError } from './errors.js';
 import type { ArchiverInstrumentation } from './modules/instrumentation.js';
 import { ArchiverL1Synchronizer } from './modules/l1_synchronizer.js';
 import { KVArchiverDataStore } from './store/kv_archiver_store.js';
@@ -211,6 +212,7 @@ describe('Archiver Sync', () => {
       expect(await archiver.getL1ToL2Messages(CheckpointNumber(1))).toEqual(msgs1);
       expect(await archiver.getL1ToL2Messages(CheckpointNumber(2))).toEqual(msgs2);
       expect(await archiver.getL1ToL2Messages(CheckpointNumber(3))).toEqual(msgs3);
+      await expect(archiver.getL1ToL2Messages(CheckpointNumber(4))).rejects.toThrow(L1ToL2MessagesNotReadyError);
 
       // Verify logs for each block in the checkpoints
       for (const checkpoint of [cp1, cp2, cp3]) {
@@ -889,7 +891,7 @@ describe('Archiver Sync', () => {
       expect(await archiver.getL1ToL2Messages(CheckpointNumber(1))).toHaveLength(2);
       expect(await archiver.getL1ToL2Messages(CheckpointNumber(2))).toHaveLength(0);
       expect(await archiver.getL1ToL2Messages(CheckpointNumber(3))).toHaveLength(4);
-      expect(await archiver.getL1ToL2Messages(CheckpointNumber(4))).toHaveLength(0);
+      await expect(archiver.getL1ToL2Messages(CheckpointNumber(4))).rejects.toThrow(L1ToL2MessagesNotReadyError);
 
       // Simulate L1 reorg: remove last 2 messages from checkpoint 3, add new messages for checkpoints 4 and 5
       logger.warn('Reorging L1 to L2 messages');

--- a/yarn-project/archiver/src/errors.ts
+++ b/yarn-project/archiver/src/errors.ts
@@ -90,6 +90,20 @@ export class OutOfOrderLogInsertionError extends Error {
   }
 }
 
+/** Thrown when L1 to L2 messages are requested for a checkpoint whose message tree hasn't been sealed yet. */
+export class L1ToL2MessagesNotReadyError extends Error {
+  constructor(
+    public readonly checkpointNumber: number,
+    public readonly inboxTreeInProgress: bigint,
+  ) {
+    super(
+      `Cannot get L1 to L2 messages for checkpoint ${checkpointNumber}: ` +
+        `inbox tree in progress is ${inboxTreeInProgress}, messages not yet sealed`,
+    );
+    this.name = 'L1ToL2MessagesNotReadyError';
+  }
+}
+
 /** Thrown when a proposed block conflicts with an already checkpointed block (different content). */
 export class CannotOverwriteCheckpointedBlockError extends Error {
   constructor(

--- a/yarn-project/archiver/src/modules/l1_synchronizer.ts
+++ b/yarn-project/archiver/src/modules/l1_synchronizer.ts
@@ -391,6 +391,7 @@ export class ArchiverL1Synchronizer implements Traceable {
     const localMessagesInserted = await this.store.getTotalL1ToL2MessageCount();
     const localLastMessage = await this.store.getLastL1ToL2Message();
     const remoteMessagesState = await this.inbox.getState({ blockNumber: currentL1BlockNumber });
+    await this.store.setInboxTreeInProgress(remoteMessagesState.treeInProgress);
 
     this.log.trace(`Retrieved remote inbox state at L1 block ${currentL1BlockNumber}.`, {
       localMessagesInserted,

--- a/yarn-project/archiver/src/store/kv_archiver_store.test.ts
+++ b/yarn-project/archiver/src/store/kv_archiver_store.test.ts
@@ -49,6 +49,7 @@ import {
   CannotOverwriteCheckpointedBlockError,
   CheckpointNumberNotSequentialError,
   InitialCheckpointNumberNotSequentialError,
+  L1ToL2MessagesNotReadyError,
   OutOfOrderLogInsertionError,
 } from '../errors.js';
 import { MessageStoreError } from '../store/message_store.js';
@@ -2053,6 +2054,43 @@ describe('KVArchiverDataStore', () => {
 
       await store.removeL1ToL2Messages(msgs[13].index);
       await checkMessages(msgs.slice(0, 13));
+    });
+
+    describe('inbox tree in progress guard', () => {
+      it('throws when checkpointNumber >= treeInProgress', async () => {
+        const msgs = makeInboxMessages(3, { initialCheckpointNumber: CheckpointNumber(5) });
+        await store.addL1ToL2Messages(msgs);
+
+        // Set treeInProgress to 7, meaning checkpoints 5 and 6 are sealed, 7+ are not
+        await store.setInboxTreeInProgress(7n);
+
+        // Sealed checkpoint should succeed
+        await expect(store.getL1ToL2Messages(CheckpointNumber(5))).resolves.toEqual([msgs[0].leaf]);
+
+        // Unsealed checkpoint (== treeInProgress) should throw
+        await expect(store.getL1ToL2Messages(CheckpointNumber(7))).rejects.toThrow(L1ToL2MessagesNotReadyError);
+
+        // Future checkpoint should also throw
+        await expect(store.getL1ToL2Messages(CheckpointNumber(8))).rejects.toThrow(L1ToL2MessagesNotReadyError);
+      });
+
+      it('returns messages when checkpointNumber < treeInProgress', async () => {
+        const msgs = makeInboxMessages(3, { initialCheckpointNumber: CheckpointNumber(10) });
+        await store.addL1ToL2Messages(msgs);
+
+        await store.setInboxTreeInProgress(13n);
+
+        await expect(store.getL1ToL2Messages(CheckpointNumber(10))).resolves.toEqual([msgs[0].leaf]);
+        await expect(store.getL1ToL2Messages(CheckpointNumber(11))).resolves.toEqual([msgs[1].leaf]);
+      });
+
+      it('skips guard when treeInProgress is not set', async () => {
+        const msgs = makeInboxMessages(2, { initialCheckpointNumber: CheckpointNumber(1) });
+        await store.addL1ToL2Messages(msgs);
+
+        // No setInboxTreeInProgress call — guard should be permissive
+        await expect(store.getL1ToL2Messages(CheckpointNumber(1))).resolves.toEqual([msgs[0].leaf]);
+      });
     });
   });
 

--- a/yarn-project/archiver/src/store/kv_archiver_store.ts
+++ b/yarn-project/archiver/src/store/kv_archiver_store.ts
@@ -606,6 +606,11 @@ export class KVArchiverDataStore implements ContractDataSource {
     return this.#messageStore.rollbackL1ToL2MessagesToCheckpoint(targetCheckpointNumber);
   }
 
+  /** Persists the inbox tree-in-progress checkpoint number from L1 state. */
+  public setInboxTreeInProgress(value: bigint): Promise<void> {
+    return this.#messageStore.setInboxTreeInProgress(value);
+  }
+
   /** Returns an async iterator to all L1 to L2 messages on the range. */
   public iterateL1ToL2Messages(range: CustomRange<bigint> = {}): AsyncIterableIterator<InboxMessage> {
     return this.#messageStore.iterateL1ToL2Messages(range);

--- a/yarn-project/archiver/src/store/message_store.ts
+++ b/yarn-project/archiver/src/store/message_store.ts
@@ -14,6 +14,7 @@ import {
 } from '@aztec/kv-store';
 import { InboxLeaf } from '@aztec/stdlib/messaging';
 
+import { L1ToL2MessagesNotReadyError } from '../errors.js';
 import {
   type InboxMessage,
   deserializeInboxMessage,
@@ -40,6 +41,8 @@ export class MessageStore {
   #lastSynchedL1Block: AztecAsyncSingleton<Buffer>;
   /** Stores total messages stored */
   #totalMessageCount: AztecAsyncSingleton<bigint>;
+  /** Stores the checkpoint number whose message tree is currently being filled on L1. */
+  #inboxTreeInProgress: AztecAsyncSingleton<bigint>;
 
   #log = createLogger('archiver:message_store');
 
@@ -48,6 +51,7 @@ export class MessageStore {
     this.#l1ToL2MessageIndices = db.openMap('archiver_l1_to_l2_message_indices');
     this.#lastSynchedL1Block = db.openSingleton('archiver_last_l1_block_id');
     this.#totalMessageCount = db.openSingleton('archiver_l1_to_l2_message_count');
+    this.#inboxTreeInProgress = db.openSingleton('archiver_inbox_tree_in_progress');
   }
 
   public async getTotalL1ToL2MessageCount(): Promise<bigint> {
@@ -185,7 +189,22 @@ export class MessageStore {
     return msg ? deserializeInboxMessage(msg) : undefined;
   }
 
+  /** Returns the inbox tree-in-progress checkpoint number from L1, or undefined if not yet set. */
+  public getInboxTreeInProgress(): Promise<bigint | undefined> {
+    return this.#inboxTreeInProgress.getAsync();
+  }
+
+  /** Persists the inbox tree-in-progress checkpoint number from L1 state. */
+  public async setInboxTreeInProgress(value: bigint): Promise<void> {
+    await this.#inboxTreeInProgress.set(value);
+  }
+
   public async getL1ToL2Messages(checkpointNumber: CheckpointNumber): Promise<Fr[]> {
+    const treeInProgress = await this.#inboxTreeInProgress.getAsync();
+    if (treeInProgress !== undefined && BigInt(checkpointNumber) >= treeInProgress) {
+      throw new L1ToL2MessagesNotReadyError(checkpointNumber, treeInProgress);
+    }
+
     const messages: Fr[] = [];
 
     const [startIndex, endIndex] = InboxLeaf.indexRangeForCheckpoint(checkpointNumber);

--- a/yarn-project/archiver/src/test/fake_l1_state.ts
+++ b/yarn-project/archiver/src/test/fake_l1_state.ts
@@ -1,5 +1,6 @@
 import type { BlobClientInterface } from '@aztec/blob-client/client';
 import { type Blob, getBlobsPerL1Block, getPrefixedEthBlobCommitments } from '@aztec/blob-lib';
+import { INITIAL_CHECKPOINT_NUMBER } from '@aztec/constants';
 import type { CheckpointProposedLog, InboxContract, MessageSentLog, RollupContract } from '@aztec/ethereum/contracts';
 import { MULTI_CALL_3_ADDRESS } from '@aztec/ethereum/contracts';
 import type { ViemPublicClient } from '@aztec/ethereum/types';
@@ -450,13 +451,22 @@ export class FakeL1State {
   createMockInboxContract(_publicClient: MockProxy<ViemPublicClient>): MockProxy<InboxContract> {
     const mockInbox = mock<InboxContract>();
 
-    mockInbox.getState.mockImplementation(() =>
-      Promise.resolve({
+    mockInbox.getState.mockImplementation(() => {
+      // treeInProgress must be > any sealed checkpoint. On L1, a checkpoint can only be proposed
+      // after its messages are sealed, so treeInProgress > checkpointNumber for all published checkpoints.
+      const maxFromMessages =
+        this.messages.length > 0 ? Math.max(...this.messages.map(m => Number(m.checkpointNumber))) + 1 : 0;
+      const maxFromCheckpoints =
+        this.checkpoints.length > 0
+          ? Math.max(...this.checkpoints.filter(cp => !cp.pruned).map(cp => Number(cp.checkpointNumber))) + 1
+          : 0;
+      const treeInProgress = Math.max(maxFromMessages, maxFromCheckpoints, INITIAL_CHECKPOINT_NUMBER);
+      return Promise.resolve({
         messagesRollingHash: this.messagesRollingHash,
         totalMessagesInserted: BigInt(this.messages.length),
-        treeInProgress: 0n,
-      }),
-    );
+        treeInProgress: BigInt(treeInProgress),
+      });
+    });
 
     // Mock the wrapper methods for fetching message events
     mockInbox.getMessageSentEvents.mockImplementation((fromBlock: bigint, toBlock: bigint) =>

--- a/yarn-project/stdlib/src/messaging/l1_to_l2_message_source.ts
+++ b/yarn-project/stdlib/src/messaging/l1_to_l2_message_source.ts
@@ -10,7 +10,9 @@ export interface L1ToL2MessageSource {
   /**
    * Gets new L1 to L2 message (to be) included in a given checkpoint.
    * @param checkpointNumber - Checkpoint number to get messages for.
-   * @returns The L1 to L2 messages/leaves of the messages subtree (throws if not found).
+   * @returns The L1 to L2 messages/leaves of the messages subtree.
+   * @throws If the message tree for the given checkpoint has not yet been sealed on L1
+   * (i.e., checkpointNumber >= inbox treeInProgress).
    */
   getL1ToL2Messages(checkpointNumber: CheckpointNumber): Promise<Fr[]>;
 


### PR DESCRIPTION
## Motivation

`getL1ToL2Messages(checkpointNumber)` returns the L1-to-L2 messages for a given checkpoint by reading from the local message store. However, if the message tree for that checkpoint hasn't been fully sealed on L1 yet (or the archiver hasn't synced it), the method silently returns incomplete data — or an empty array for a checkpoint that will eventually have messages. This is indistinguishable from a legitimately empty checkpoint (one where no L1-to-L2 messages were sent).

Any caller that uses this result to compute `inHash` — the sequencer, validator, or slasher — would derive an incorrect hash, leading to mismatches and potential block validation failures.

## Approach

The L1 Inbox contract exposes a `treeInProgress` value: the checkpoint number whose message tree is currently being filled. Trees for checkpoints strictly below this value are sealed and complete. We persist this value in the archiver's message store during each L1 sync cycle and use it as a guard: `getL1ToL2Messages` now throws `L1ToL2MessagesNotReadyError` if the requested checkpoint number is >= `treeInProgress`. On first startup (before any sync), the guard is permissive (skipped) since the value hasn't been set yet.

This approach was chosen over a simpler "last message checkpoint" bound because it correctly handles empty checkpoints — a checkpoint with zero messages is still sealed once `treeInProgress` moves past it.

## Changes

- **archiver**: Added `L1ToL2MessagesNotReadyError`. The message store now persists `treeInProgress` as an LMDB singleton and guards `getL1ToL2Messages` against unsealed checkpoints. The L1 synchronizer writes the value on every sync cycle immediately after fetching inbox state.
- **archiver (tests)**: Updated the fake L1 state mock to compute `treeInProgress` dynamically from both messages and checkpoints. Added unit tests for the guard (sealed, unsealed, unset). Updated the L1 reorg test to expect the new error for unsealed checkpoints.
- **stdlib**: Documented the new throw condition on the `L1ToL2MessageSource` interface.

Fixes A-659