### PR TITLE
feat(rpc): add package version to RPC response headers

### DIFF
--- a/yarn-project/aztec/src/cli/aztec_start_action.ts
+++ b/yarn-project/aztec/src/cli/aztec_start_action.ts
@@ -23,14 +23,14 @@ export async function aztecStart(options: any, userLog: LogFn, debugLogger: Logg
   const signalHandlers: Array<() => Promise<void>> = [];
   const services: NamespacedApiHandlers = {};
   const adminServices: NamespacedApiHandlers = {};
+  const packageVersion = getPackageVersion();
   let config: ChainConfig | undefined = undefined;
 
   if (options.localNetwork) {
-    const cliVersion = getPackageVersion() ?? 'unknown';
     const localNetwork = extractNamespacedOptions(options, 'local-network');
     localNetwork.testAccounts = true;
     userLog(`${splash}\n${github}\n\n`);
-    userLog(`Setting up Aztec local network ${cliVersion}, please stand by...`);
+    userLog(`Setting up Aztec local network ${packageVersion ?? 'unknown'}, please stand by...`);
 
     const { node, stop } = await createLocalNetwork(
       {
@@ -90,13 +90,14 @@ export async function aztecStart(options: any, userLog: LogFn, debugLogger: Logg
 
   installSignalHandlers(debugLogger.info, signalHandlers);
   const versions = getVersions(config);
+  const versioningOpts = { packageVersion };
 
   // Start the main JSON-RPC server
   if (Object.entries(services).length > 0) {
     const rpcServer = createNamespacedSafeJsonRpcServer(services, {
       http200OnError: false,
       log: debugLogger,
-      middlewares: [getOtelJsonRpcPropagationMiddleware(), getVersioningMiddleware(versions)],
+      middlewares: [getOtelJsonRpcPropagationMiddleware(), getVersioningMiddleware(versions, versioningOpts)],
       maxBatchSize: options.rpcMaxBatchSize,
       maxBodySizeBytes: options.rpcMaxBodySize,
     });
@@ -106,7 +107,7 @@ export async function aztecStart(options: any, userLog: LogFn, debugLogger: Logg
 
   // If there are any admin services, start a separate JSON-RPC server for them
   if (Object.entries(adminServices).length > 0) {
-    const adminMiddlewares = [getOtelJsonRpcPropagationMiddleware(), getVersioningMiddleware(versions)];
+    const adminMiddlewares = [getOtelJsonRpcPropagationMiddleware(), getVersioningMiddleware(versions, versioningOpts)];
 
     // Resolve the admin API key (auto-generated and persisted, or opt-out)
     const apiKeyResolution = await resolveAdminApiKey(

--- a/yarn-project/stdlib/src/versioning/versioning.ts
+++ b/yarn-project/stdlib/src/versioning/versioning.ts
@@ -115,7 +115,7 @@ export function validatePartialComponentVersionsMatch(
 }
 
 /** Returns a Koa middleware that injects the versioning info as headers. */
-export function getVersioningMiddleware(versions: Partial<ComponentsVersions>) {
+export function getVersioningMiddleware(versions: Partial<ComponentsVersions>, opts?: { packageVersion?: string }) {
   return async (ctx: Koa.Context, next: () => Promise<void>) => {
     try {
       await next();
@@ -127,6 +127,9 @@ export function getVersioningMiddleware(versions: Partial<ComponentsVersions>) {
         if (value !== undefined) {
           ctx.set(`x-aztec-${key}`, value.toString());
         }
+      }
+      if (opts?.packageVersion) {
+        ctx.set('x-aztec-packageVersion', opts.packageVersion);
       }
     }
   };


### PR DESCRIPTION
## Motivation

The JSON-RPC server already returns `x-aztec-*` headers for protocol component versions (chain id, rollup address, etc.), but does not include the node's package version. This makes it harder to identify which software version a node is running when debugging or monitoring.

## Approach

Extended `getVersioningMiddleware` to accept an optional `packageVersion` parameter and emit it as an `x-aztec-packageVersion` response header alongside existing versioning headers.

## Example

```
$ curl -s -D- http://localhost:8090 -H 'content-type: application/json' -d '[{"jsonrpc":"2.0","id":1,"method":"node_getNodeVersion","params":[]}]'
HTTP/1.1 200 OK
Vary: Accept-Encoding, Origin
Access-Control-Allow-Origin: *
Content-Type: application/json; charset=utf-8
x-aztec-l2CircuitsVkTreeRoot: 0x06624799e2080c43aba671cdece34d5f4cdff2122bc6be41d80bd903ca0975cc
x-aztec-l2ProtocolContractsHash: 0x23c2022f0b69b29e354b4f7612d5db3ba0bc4259d71ac9186ed272945a644b9c
x-aztec-packageVersion: 5.0.0
Content-Length: 43
Date: Fri, 13 Mar 2026 16:04:31 GMT
Connection: keep-alive
Keep-Alive: timeout=5

[{"jsonrpc":"2.0","id":1,"result":"5.0.0"}]
```

## Changes

- **stdlib**: Updated `getVersioningMiddleware` to accept an optional `opts` bag with `packageVersion`, setting `x-aztec-packageVersion` header when provided
- **aztec**: Wired `getPackageVersion()` into both the main and admin RPC server middleware calls