### PR TITLE
fix: remove redundant native copy from copy_cross.sh

### DIFF
--- a/barretenberg/ts/scripts/copy_cross.sh
+++ b/barretenberg/ts/scripts/copy_cross.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copies native bb binary and napi module to dest.
+# Copies cross-compiled bb binary and napi module to dest.
 set -e
 NO_CD=1 source $(git rev-parse --show-toplevel)/ci3/source
 
@@ -12,12 +12,8 @@ if [ -n "${1:-}" ]; then
   cp ../cpp/build-zig-$arch/lib/nodejs_module.node ./build/$arch
 elif semver check "${REF_NAME:-}" && [[ "$(arch)" == "amd64" ]]; then
   # We're building a release.
-  # We take host build for amd64-linux.
-  mkdir -p ./build/amd64-linux
-  cp ../cpp/build/bin/bb ./build/amd64-linux
-  cp ../cpp/build/lib/nodejs_module.node ./build/amd64-linux
-
-  # We also copy in all cross-compiled architectures for release builds.
+  # Copy all cross-compiled architectures for release builds.
+  # The native amd64-linux binary is already copied by copy_native.sh (bb-ts target).
   for arch in arm64-linux amd64-macos arm64-macos; do
     mkdir -p ./build/$arch
     cp ../cpp/build-zig-$arch/bin/bb ./build/$arch


### PR DESCRIPTION
## Summary
- Removes the redundant native amd64-linux binary copy from `copy_cross.sh` that was already handled by `copy_native.sh` (via the `bb-ts` Makefile target)
- This eliminates the `Text file busy` (ETXTBSY) error in nightly release builds when the docs tests Docker container is executing the `bb` binary while `copy_cross.sh` tries to overwrite it
- Root cause: `copy_cross.sh` did `cp ../cpp/build/bin/bb ./build/amd64-linux/bb` over a binary being executed by a bind-mounted Docker container running `bb msgpack run`

## Test plan
- [ ] CI release build passes without `Text file busy` error
- [ ] Cross-compiled binaries (arm64-linux, amd64-macos, arm64-macos) are still correctly copied