### PR TITLE
fix(stdlib): clamp Gas.sub() to zero to prevent underflow

### DIFF
--- a/yarn-project/stdlib/src/gas/gas.test.ts
+++ b/yarn-project/stdlib/src/gas/gas.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from '@jest/globals';
+
+import { Gas } from './gas.js';
+
+describe('Gas', () => {
+  describe('sub', () => {
+    it('clamps to zero when both dimensions underflow', () => {
+      const result = new Gas(5, 10).sub(new Gas(10, 20));
+      expect(result).toEqual(new Gas(0, 0));
+    });
+
+    it('clamps to zero only on the dimension that underflows', () => {
+      const result = new Gas(5, 20).sub(new Gas(10, 10));
+      expect(result).toEqual(new Gas(0, 10));
+    });
+
+    it('returns correct result when no underflow occurs', () => {
+      const result = new Gas(20, 30).sub(new Gas(10, 10));
+      expect(result).toEqual(new Gas(10, 20));
+    });
+
+    it('returns zero when subtracting exact values', () => {
+      const result = new Gas(10, 10).sub(new Gas(10, 10));
+      expect(result).toEqual(new Gas(0, 0));
+    });
+  });
+});

--- a/yarn-project/stdlib/src/gas/gas.ts
+++ b/yarn-project/stdlib/src/gas/gas.ts
@@ -91,8 +91,9 @@ export class Gas {
     return new Gas(this.daGas + other.daGas, this.l2Gas + other.l2Gas);
   }
 
+  /** Subtracts gas, clamping each dimension to a minimum of zero. */
   sub(other: Gas) {
-    return new Gas(this.daGas - other.daGas, this.l2Gas - other.l2Gas);
+    return new Gas(Math.max(0, this.daGas - other.daGas), Math.max(0, this.l2Gas - other.l2Gas));
   }
 
   mul(scalar: number) {


### PR DESCRIPTION
## Summary

- `Gas.sub()` performed unchecked subtraction that could produce negative values, causing downstream crashes (`Fr` constructor throws on negative, `Buffer.writeUInt32BE` throws `RangeError`)
- Clamp each dimension to zero using `Math.max(0, ...)`
- Added unit tests for underflow, partial underflow, exact subtraction, and normal cases

## Test plan

- New unit tests in `stdlib/src/gas/gas.test.ts` covering:
  - Both dimensions underflow → clamped to `Gas(0, 0)`
  - Single dimension underflow → only that dimension clamped
  - No underflow → correct subtraction
  - Exact subtraction → `Gas(0, 0)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)