### PR TITLE
fix(pxe): deduplicate registerContract by checking for existing instance

### DIFF
--- a/yarn-project/pxe/src/pxe.test.ts
+++ b/yarn-project/pxe/src/pxe.test.ts
@@ -157,6 +157,23 @@ describe('PXE', () => {
     await expect(pxe.registerContract({ instance, artifact })).rejects.toThrow(/Artifact does not match/i);
   });
 
+  it('does not throw when registering the same contract twice and deduplicates', async () => {
+    const contract = await randomDeployedContract();
+    await pxe.registerContract(contract);
+
+    // Clear the mock so we can verify the second registration short-circuits
+    node.registerContractFunctionSignatures.mockClear();
+
+    await pxe.registerContract(contract);
+
+    // If dedup is working, the second call should return early without re-registering function signatures
+    expect(node.registerContractFunctionSignatures).not.toHaveBeenCalled();
+
+    const contractAddresses = await pxe.getContracts();
+    const matches = contractAddresses.filter(addr => addr.equals(contract.instance.address));
+    expect(matches).toHaveLength(1);
+  });
+
   // These tests are meant to quickly exercise PXE as a
   // frontier API so we don't need to rely on slower E2E
   // tests (which in turn are more meaningful for acceptance).

--- a/yarn-project/pxe/src/pxe.ts
+++ b/yarn-project/pxe/src/pxe.ts
@@ -625,6 +625,12 @@ export class PXE {
     const { instance } = contract;
     let { artifact } = contract;
 
+    const existing = await this.contractStore.getContractInstance(instance.address);
+    if (existing) {
+      this.log.debug(`Contract already registered at ${instance.address.toString()}, skipping.`);
+      return;
+    }
+
     if (artifact) {
       // If the user provides an artifact, validate it against the expected class id and register it
       const contractClass = await getContractClassFromArtifact(artifact);


### PR DESCRIPTION
part of https://github.com/AztecProtocol/aztec-packages/issues/21514

honestly not fussed about this one
- worst case when running on the pxe it would run this again, although only user error would really get us here. Just hygiene really - only opening up as the automated review suggested it

## Summary

- `registerContract` now checks if a contract is already registered at the given address before performing any work, matching the existing pattern in `registerAccount` and `registerSender`
- Skips redundant artifact validation, address computation, and store writes on duplicate registration
- Added test verifying the second registration short-circuits without re-registering function signatures

## Test plan

- Unit test confirms `node.registerContractFunctionSignatures` is not called on duplicate registration
- Test verifies contract appears exactly once in `getContracts()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)