### PR TITLE
fix(sequencer): await syncing proposed block to archiver

### DIFF
--- a/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.test.ts
@@ -899,6 +899,22 @@ describe('CheckpointProposalJob', () => {
       expect(validatorClient.collectAttestations).toHaveBeenCalled();
     });
 
+    it('aborts checkpoint when syncing proposed block to archiver fails', async () => {
+      const { txs, block } = await setupTxsAndBlock(p2p, globalVariables, 1, chainId);
+      checkpointBuilder.seedBlocks([block], [txs]);
+
+      // Mock blockSink.addBlock to reject, simulating a consistency error
+      blockSink.addBlock.mockRejectedValue(new Error('Consistency error: block does not match world state'));
+
+      const checkpoint = await job.execute();
+
+      // The checkpoint should be aborted since the archiver sync failure now propagates
+      expect(checkpoint).toBeUndefined();
+      expect(blockSink.addBlock).toHaveBeenCalledWith(block);
+      // Should not attempt to collect attestations since the error aborts the loop
+      expect(validatorClient.collectAttestations).not.toHaveBeenCalled();
+    });
+
     it('handles empty committee gracefully', async () => {
       // Mock empty committee
       epochCache.getCommittee.mockResolvedValue({

--- a/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.ts
+++ b/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.ts
@@ -464,12 +464,9 @@ export class CheckpointProposalJob implements Traceable {
       blocksInCheckpoint.push(block);
 
       // Sync the proposed block to the archiver to make it available
-      // Note that the checkpoint builder uses its own fork so it should not need to wait for this syncing
-      // Eventually we should refactor the checkpoint builder to not need a separate long-lived fork
-      // Fire and forget - don't block the critical path, but log errors
-      this.syncProposedBlockToArchiver(block).catch(err => {
-        this.log.error(`Failed to sync proposed block ${block.number} to archiver`, { blockNumber: block.number, err });
-      });
+      // We wait for the sync to succeed, as this helps catch consistency errors, even if it means we lose some time for block-building
+      // If this throws, we abort the entire checkpoint
+      await this.syncProposedBlockToArchiver(block);
 
       usedTxs.forEach(tx => txHashesAlreadyIncluded.add(tx.txHash.toString()));
 


### PR DESCRIPTION
While this means we waste a bit more time during block building, it also means we catch early any consistency errors, including an l1 reorg that removed the previous checkpoint while we were building ours.

Fixes A-665