### PR TITLE
chore(monitor): print out l2 fees components

### DIFF
--- a/yarn-project/ethereum/src/contracts/rollup.ts
+++ b/yarn-project/ethereum/src/contracts/rollup.ts
@@ -134,6 +134,14 @@ export type L1FeeData = {
   blobFee: bigint;
 };
 
+/** Components of the minimum fee per mana, as returned by the L1 rollup contract. */
+export type ManaMinFeeComponents = {
+  sequencerCost: bigint;
+  proverCost: bigint;
+  congestionCost: bigint;
+  congestionMultiplier: bigint;
+};
+
 /**
  * Reward configuration for the rollup
  */
@@ -861,6 +869,16 @@ export class RollupContract {
 
   getManaMinFeeAt(timestamp: bigint, inFeeAsset: boolean): Promise<bigint> {
     return this.rollup.read.getManaMinFeeAt([timestamp, inFeeAsset]);
+  }
+
+  async getManaMinFeeComponentsAt(timestamp: bigint, inFeeAsset: boolean): Promise<ManaMinFeeComponents> {
+    const result = await this.rollup.read.getManaMinFeeComponentsAt([timestamp, inFeeAsset]);
+    return {
+      sequencerCost: result.sequencerCost,
+      proverCost: result.proverCost,
+      congestionCost: result.congestionCost,
+      congestionMultiplier: result.congestionMultiplier,
+    };
   }
 
   async getSlotAt(timestamp: bigint): Promise<SlotNumber> {

--- a/yarn-project/ethereum/src/test/chain_monitor.ts
+++ b/yarn-project/ethereum/src/test/chain_monitor.ts
@@ -1,4 +1,4 @@
-import type { RollupContract } from '@aztec/ethereum/contracts';
+import type { ManaMinFeeComponents, RollupContract } from '@aztec/ethereum/contracts';
 import { InboxContract } from '@aztec/ethereum/contracts';
 import { CheckpointNumber, EpochNumber, SlotNumber } from '@aztec/foundation/branded-types';
 import { EthAddress } from '@aztec/foundation/eth-address';
@@ -10,6 +10,20 @@ import { EventEmitter } from 'events';
 
 import type { ViemClient } from '../types.js';
 
+/** L2 fee data reported by the chain monitor. */
+export type L2FeeData = ManaMinFeeComponents & {
+  /** Total minimum fee per mana in Fee Juice (sum of sequencerCost + proverCost + congestionCost). */
+  minFeePerMana: bigint;
+  /** L1 base fee observed by the oracle. */
+  l1BaseFee: bigint;
+  /** L1 blob fee observed by the oracle. */
+  l1BlobFee: bigint;
+  /** ETH per fee asset exchange rate (1e12 precision). */
+  ethPerFeeAsset: bigint;
+  /** Mana target per checkpoint. */
+  manaTarget: bigint;
+};
+
 export type ChainMonitorEventMap = {
   'l1-block': [{ l1BlockNumber: number; timestamp: bigint }];
   checkpoint: [
@@ -19,6 +33,7 @@ export type ChainMonitorEventMap = {
   'l2-messages': [{ totalL2Messages: number; l1BlockNumber: number }];
   'l2-epoch': [{ l2EpochNumber: EpochNumber; timestamp: bigint; committee: EthAddress[] | undefined }];
   'l2-slot': [{ l2SlotNumber: SlotNumber; timestamp: bigint }];
+  'l2-fees': [L2FeeData];
 };
 
 /** Utility class that polls the chain on quick intervals and logs new L1 blocks, L2 blocks, and L2 proofs. */
@@ -45,6 +60,8 @@ export class ChainMonitor extends EventEmitter<ChainMonitorEventMap> {
   public l2EpochNumber!: EpochNumber;
   /** Current L2 slot number */
   public l2SlotNumber!: SlotNumber;
+  /** Current L2 fee data (components of the minimum fee per mana). */
+  public l2FeeData!: L2FeeData;
 
   constructor(
     private readonly rollup: RollupContract,
@@ -77,7 +94,7 @@ export class ChainMonitor extends EventEmitter<ChainMonitorEventMap> {
     }
   }
 
-  private async getInbox() {
+  protected async getInbox() {
     if (!this.inbox) {
       const { inboxAddress } = await this.rollup.getRollupAddresses();
       this.inbox = new InboxContract(this.l1Client, inboxAddress);
@@ -158,12 +175,19 @@ export class ChainMonitor extends EventEmitter<ChainMonitorEventMap> {
       this.l2EpochNumber = l2Epoch;
       committee = await this.rollup.getCurrentEpochCommittee();
       this.emit('l2-epoch', { l2EpochNumber: l2Epoch, timestamp, committee });
-      msg += ` starting new epoch ${this.l2EpochNumber} `;
+      msg += ` starting new epoch ${this.l2EpochNumber}`;
     }
 
     if (l2SlotNumber !== this.l2SlotNumber) {
       this.l2SlotNumber = l2SlotNumber;
       this.emit('l2-slot', { l2SlotNumber, timestamp });
+    }
+
+    const feeData = await this.fetchFeeData(timestamp);
+    if (this.hasFeeDataChanged(feeData)) {
+      msg += ` with L2 min fee ${feeData.minFeePerMana}`;
+      this.l2FeeData = feeData;
+      this.emit('l2-fees', feeData);
     }
 
     this.logger.info(msg, {
@@ -176,6 +200,7 @@ export class ChainMonitor extends EventEmitter<ChainMonitorEventMap> {
       provenCheckpointNumber: this.provenCheckpointNumber,
       totalL2Messages: this.totalL2Messages,
       committee,
+      ...this.l2FeeData,
     });
 
     return this;
@@ -241,5 +266,37 @@ export class ChainMonitor extends EventEmitter<ChainMonitorEventMap> {
       };
       this.on('checkpoint', listener);
     });
+  }
+
+  private async fetchFeeData(timestamp: bigint): Promise<L2FeeData> {
+    const [components, minFeePerMana, l1Fees, ethPerFeeAsset, manaTarget] = await Promise.all([
+      this.rollup.getManaMinFeeComponentsAt(timestamp, true),
+      this.rollup.getManaMinFeeAt(timestamp, true),
+      this.rollup.getL1FeesAt(timestamp),
+      this.rollup.getEthPerFeeAsset(),
+      this.rollup.getManaTarget(),
+    ]);
+    return {
+      ...components,
+      minFeePerMana,
+      l1BaseFee: l1Fees.baseFee,
+      l1BlobFee: l1Fees.blobFee,
+      ethPerFeeAsset,
+      manaTarget,
+    };
+  }
+
+  private hasFeeDataChanged(newData: L2FeeData): boolean {
+    if (!this.l2FeeData) {
+      return true;
+    }
+    return (
+      this.l2FeeData.sequencerCost !== newData.sequencerCost ||
+      this.l2FeeData.proverCost !== newData.proverCost ||
+      this.l2FeeData.congestionCost !== newData.congestionCost ||
+      this.l2FeeData.l1BaseFee !== newData.l1BaseFee ||
+      this.l2FeeData.l1BlobFee !== newData.l1BlobFee ||
+      this.l2FeeData.ethPerFeeAsset !== newData.ethPerFeeAsset
+    );
   }
 }

--- a/yarn-project/stdlib/src/gas/README.md
+++ b/yarn-project/stdlib/src/gas/README.md
@@ -1,0 +1,123 @@
+# Aztec Gas and Fee Model
+
+The minimum fee per mana and its components are computed on L1 in
+`l1-contracts/src/core/libraries/rollup/FeeLib.sol`. This document describes the
+formulas, the oracle lag/lifetime mechanism, and the TypeScript types in this directory.
+
+## Mana
+
+Aztec uses **mana** as its unit of work (analogous to Ethereum gas). Transactions consume
+mana in two dimensions: **DA** (data availability) and **L2** (execution). The total fee
+is `gasUsed * feePerMana` summed across both dimensions.
+
+## Fee Components
+
+The minimum fee per mana has four components:
+
+### Sequencer Cost
+
+L1 cost to propose a checkpoint (calldata gas + blob data), amortized over `manaTarget`:
+
+```
+sequencerCost = ((L1_GAS_PER_CHECKPOINT_PROPOSED * baseFee)
+              + (BLOBS_PER_CHECKPOINT * BLOB_GAS_PER_BLOB * blobFee))
+              / manaTarget
+```
+
+### Prover Cost
+
+L1 cost to verify an epoch proof, amortized over epoch duration and `manaTarget`, plus a
+governance-set proving cost that compensates for off-chain proof generation:
+
+```
+proverCost = (L1_GAS_PER_EPOCH_VERIFIED * baseFee / epochDuration) / manaTarget
+           + provingCostPerMana
+```
+
+### Congestion Cost
+
+An exponential surcharge when the network is congested (inspired by EIP-1559; the
+implementation uses the `fakeExponential` Taylor series approximation from EIP-4844):
+
+```
+baseCost          = sequencerCost + proverCost
+congestionCost    = baseCost * congestionMultiplier / MINIMUM_CONGESTION_MULTIPLIER - baseCost
+```
+
+When there is no congestion the multiplier equals `MINIMUM_CONGESTION_MULTIPLIER` (1e9)
+and congestion cost is zero.
+
+### Congestion Multiplier
+
+```
+excessMana          = max(0, prevExcessMana + prevManaUsed - manaTarget)
+congestionMultiplier = fakeExponential(MINIMUM_CONGESTION_MULTIPLIER, excessMana, denominator)
+```
+
+Each additional `manaTarget` of excess mana increases the multiplier by ~12.5%.
+
+### Total
+
+```
+minFeePerMana = sequencerCost + proverCost + congestionCost
+```
+
+## L1 Gas Oracle: Lag and Lifetime
+
+The oracle feeds Ethereum's `baseFee` and `blobFee` into the fee model using a two-phase
+(`pre` / `post`) system that smooths out L1 fee volatility.
+
+- **LAG = 2 slots** — when new L1 fees are observed, they activate `LAG` slots later
+  (`slotOfChange = currentSlot + LAG`). This gives mempool transactions time to land
+  before fees change.
+- **LIFETIME = 5 slots** — after an oracle update, the next update is rejected until
+  `slotOfChange + (LIFETIME - LAG)` = 3 more slots have passed. This rate-limits how
+  frequently L1 fee data can change.
+
+Fee resolution at a given timestamp:
+
+```
+if slot < slotOfChange  →  use pre  (old fees)
+else                    →  use post (new fees)
+```
+
+**Net effect**: L1 fee changes reach L2 with a 2-slot delay and can update at most once
+every 5 slots.
+
+## Fee Asset Price
+
+Fees are computed in ETH internally but converted to the fee asset (Fee Juice) via
+`ethPerFeeAsset` (1e12 precision). The price updates at most ±1% (±100 bps) per
+checkpoint:
+
+```
+newPrice = currentPrice * (10000 + modifierBps) / 10000
+```
+
+## Maximum Fee Change Rate
+
+| Component              | Bound                                                   |
+| ---------------------- | ------------------------------------------------------- |
+| L1 base fee / blob fee | At most once every 5 slots (oracle LIFETIME)            |
+| Fee asset price        | ±1% per checkpoint                                      |
+| Congestion multiplier  | Depends on excess mana accumulation/drain per checkpoint |
+| Sequencer/prover costs | Scale linearly with L1 fees                             |
+
+## Key Constants
+
+| Constant                       | Value          |
+| ------------------------------ | -------------- |
+| `L1_GAS_PER_CHECKPOINT_PROPOSED` | 300,000      |
+| `L1_GAS_PER_EPOCH_VERIFIED`     | 3,600,000    |
+| `BLOBS_PER_CHECKPOINT`          | 3            |
+| `BLOB_GAS_PER_BLOB`             | 2^17         |
+| `MINIMUM_CONGESTION_MULTIPLIER` | 1e9          |
+| `LAG`                           | 2 slots      |
+| `LIFETIME`                      | 5 slots      |
+
+## TypeScript Types
+
+- **`Gas`** — mana quantity in two dimensions (`daGas`, `l2Gas`).
+- **`GasFees`** — per-unit price in each dimension (`feePerDaGas`, `feePerL2Gas`).
+- **`GasSettings`** — sender-chosen fee parameters: gas limits, teardown limits, max fees, priority fees.
+- **`GasUsed`** — actual consumption after execution. Note: `billedGas` uses the teardown gas *limit*, not actual usage.


### PR DESCRIPTION
Helps debugging fee issues in tests. Also includes a README on how fees are computed in L2.

```
[16:51:01.188] INFO: e2e:e2e_epochs:epochs_mbps L1 block 25 mined at 16:58:17 {"currentTimestamp":1773431897,"l1Timestamp":"1773431897","l1BlockNumber":25,"l2SlotNumber":13,"l2Epoch":3,"checkpointNumber":2,"provenCheckpointNumber":0,"totalL2Messages":0,"sequencerCost":"214068600000","proverCost":"642215700000","congestionCost":"0","congestionMultiplier":"1000000000","minFeePerMana":"856284300000","l1BaseFee":"713561860","l1BlobFee":"1","ethPerFeeAsset":"10000000","manaTarget":"100000000"}
[16:51:05.194] INFO: e2e:e2e_epochs:epochs_mbps L1 block 26 mined at 16:58:21 {"currentTimestamp":1773431901,"l1Timestamp":"1773431901","l1BlockNumber":26,"l2SlotNumber":13,"l2Epoch":3,"checkpointNumber":2,"provenCheckpointNumber":0,"totalL2Messages":0,"sequencerCost":"214068600000","proverCost":"642215700000","congestionCost":"0","congestionMultiplier":"1000000000","minFeePerMana":"856284300000","l1BaseFee":"713561860","l1BlobFee":"1","ethPerFeeAsset":"10000000","manaTarget":"100000000"}
[16:51:09.208] INFO: e2e:e2e_epochs:epochs_mbps L1 block 27 mined at 16:58:25 with minFee=248383500000 {"currentTimestamp":1773431905,"l1Timestamp":"1773431905","l1BlockNumber":27,"l2SlotNumber":14,"l2Epoch":3,"checkpointNumber":2,"provenCheckpointNumber":0,"totalL2Messages":0,"sequencerCost":"62093400000","proverCost":"186290100000","congestionCost":"0","congestionMultiplier":"1000000000","minFeePerMana":"248383500000","l1BaseFee":"206977871","l1BlobFee":"1","ethPerFeeAsset":"10000000","manaTarget":"100000000"}
```