### PR TITLE
refactor(pxe): type and audit legacy oracle mappings

### DIFF
--- a/yarn-project/pxe/src/contract_function_simulator/oracle/legacy_oracle_mappings.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/legacy_oracle_mappings.ts
@@ -11,39 +11,108 @@ import type { Oracle } from './oracle.js';
 export function buildLegacyOracleCallbacks(oracle: Oracle): ACIRCallback {
   return {
     // Simple prefix renames (privateXxx/utilityXxx → aztec_prv_/aztec_utl_)
-    utilityLog: (...args: ACVMField[][]) => oracle.aztec_utl_log(args[0], args[1], args[2], args[3]),
-    utilityAssertCompatibleOracleVersion: (...args: ACVMField[][]) =>
-      oracle.aztec_utl_assertCompatibleOracleVersion(args[0]),
-    utilityLoadCapsule: (...args: ACVMField[][]) => oracle.aztec_utl_loadCapsule(args[0], args[1], args[2]),
-    privateStoreInExecutionCache: (...args: ACVMField[][]) => oracle.aztec_prv_storeInExecutionCache(args[0], args[1]),
-    privateLoadFromExecutionCache: (...args: ACVMField[][]) => oracle.aztec_prv_loadFromExecutionCache(args[0]),
-    privateCallPrivateFunction: (...args: ACVMField[][]) =>
-      oracle.aztec_prv_callPrivateFunction(args[0], args[1], args[2], args[3], args[4]),
-    privateIsNullifierPending: (...args: ACVMField[][]) => oracle.aztec_prv_isNullifierPending(args[0], args[1]),
-    privateNotifyCreatedNullifier: (...args: ACVMField[][]) => oracle.aztec_prv_notifyCreatedNullifier(args[0]),
-    privateNotifyCreatedContractClassLog: (...args: ACVMField[][]) =>
-      oracle.aztec_prv_notifyCreatedContractClassLog(args[0], args[1], args[2], args[3]),
-    privateGetNextAppTagAsSender: (...args: ACVMField[][]) => oracle.aztec_prv_getNextAppTagAsSender(args[0], args[1]),
-    privateGetSenderForTags: () => oracle.aztec_prv_getSenderForTags(),
-    privateSetSenderForTags: (...args: ACVMField[][]) => oracle.aztec_prv_setSenderForTags(args[0]),
-    utilityGetUtilityContext: () => oracle.aztec_utl_getUtilityContext(),
-    utilityStorageRead: (...args: ACVMField[][]) => oracle.aztec_utl_storageRead(args[0], args[1], args[2], args[3]),
-    utilityStoreCapsule: (...args: ACVMField[][]) => oracle.aztec_utl_storeCapsule(args[0], args[1], args[2]),
-    utilityCopyCapsule: (...args: ACVMField[][]) => oracle.aztec_utl_copyCapsule(args[0], args[1], args[2], args[3]),
-    utilityDeleteCapsule: (...args: ACVMField[][]) => oracle.aztec_utl_deleteCapsule(args[0], args[1]),
-    utilityAes128Decrypt: (...args: ACVMField[][]) =>
-      oracle.aztec_utl_aes128Decrypt(args[0], args[1], args[2], args[3]),
-    utilityGetSharedSecret: (...args: ACVMField[][]) =>
-      oracle.aztec_utl_getSharedSecret(args[0], args[1], args[2], args[3]),
-    utilityFetchTaggedLogs: (...args: ACVMField[][]) => oracle.aztec_utl_fetchTaggedLogs(args[0]),
-    utilityBulkRetrieveLogs: (...args: ACVMField[][]) => oracle.aztec_utl_bulkRetrieveLogs(args[0], args[1], args[2]),
+    utilityLog: (
+      level: ACVMField[],
+      message: ACVMField[],
+      _ignoredFieldsSize: ACVMField[],
+      fields: ACVMField[],
+    ): Promise<ACVMField[]> => oracle.aztec_utl_log(level, message, _ignoredFieldsSize, fields),
+    utilityAssertCompatibleOracleVersion: (version: ACVMField[]): Promise<ACVMField[]> =>
+      oracle.aztec_utl_assertCompatibleOracleVersion(version),
+    utilityLoadCapsule: (
+      contractAddress: ACVMField[],
+      slot: ACVMField[],
+      tSize: ACVMField[],
+    ): Promise<(ACVMField | ACVMField[])[]> => oracle.aztec_utl_loadCapsule(contractAddress, slot, tSize),
+    privateStoreInExecutionCache: (values: ACVMField[], hash: ACVMField[]): Promise<ACVMField[]> =>
+      oracle.aztec_prv_storeInExecutionCache(values, hash),
+    privateLoadFromExecutionCache: (returnsHash: ACVMField[]): Promise<ACVMField[][]> =>
+      oracle.aztec_prv_loadFromExecutionCache(returnsHash),
+    privateCallPrivateFunction: (
+      contractAddress: ACVMField[],
+      functionSelector: ACVMField[],
+      argsHash: ACVMField[],
+      sideEffectCounter: ACVMField[],
+      isStaticCall: ACVMField[],
+    ): Promise<ACVMField[][]> =>
+      oracle.aztec_prv_callPrivateFunction(
+        contractAddress,
+        functionSelector,
+        argsHash,
+        sideEffectCounter,
+        isStaticCall,
+      ),
+    privateIsNullifierPending: (innerNullifier: ACVMField[], contractAddress: ACVMField[]): Promise<ACVMField[]> =>
+      oracle.aztec_prv_isNullifierPending(innerNullifier, contractAddress),
+    privateNotifyCreatedNullifier: (innerNullifier: ACVMField[]): Promise<ACVMField[]> =>
+      oracle.aztec_prv_notifyCreatedNullifier(innerNullifier),
+    privateNotifyCreatedContractClassLog: (
+      contractAddress: ACVMField[],
+      message: ACVMField[],
+      length: ACVMField[],
+      counter: ACVMField[],
+    ): Promise<ACVMField[]> =>
+      oracle.aztec_prv_notifyCreatedContractClassLog(contractAddress, message, length, counter),
+    utilityGetUtilityContext: (): Promise<(ACVMField | ACVMField[])[]> => oracle.aztec_utl_getUtilityContext(),
+    utilityStorageRead: (
+      blockHash: ACVMField[],
+      contractAddress: ACVMField[],
+      startStorageSlot: ACVMField[],
+      numberOfElements: ACVMField[],
+    ): Promise<ACVMField[][]> =>
+      oracle.aztec_utl_storageRead(blockHash, contractAddress, startStorageSlot, numberOfElements),
+    utilityStoreCapsule: (
+      contractAddress: ACVMField[],
+      slot: ACVMField[],
+      capsule: ACVMField[],
+    ): Promise<ACVMField[]> => oracle.aztec_utl_storeCapsule(contractAddress, slot, capsule),
+    utilityCopyCapsule: (
+      contractAddress: ACVMField[],
+      srcSlot: ACVMField[],
+      dstSlot: ACVMField[],
+      numEntries: ACVMField[],
+    ): Promise<ACVMField[]> => oracle.aztec_utl_copyCapsule(contractAddress, srcSlot, dstSlot, numEntries),
+    utilityDeleteCapsule: (contractAddress: ACVMField[], slot: ACVMField[]): Promise<ACVMField[]> =>
+      oracle.aztec_utl_deleteCapsule(contractAddress, slot),
+    utilityAes128Decrypt: (
+      ciphertextBVecStorage: ACVMField[],
+      ciphertextLength: ACVMField[],
+      iv: ACVMField[],
+      symKey: ACVMField[],
+    ): Promise<(ACVMField | ACVMField[])[]> =>
+      oracle.aztec_utl_aes128Decrypt(ciphertextBVecStorage, ciphertextLength, iv, symKey),
+    utilityGetSharedSecret: (
+      address: ACVMField[],
+      ephPKField0: ACVMField[],
+      ephPKField1: ACVMField[],
+      ephPKField2: ACVMField[],
+    ): Promise<ACVMField[]> => oracle.aztec_utl_getSharedSecret(address, ephPKField0, ephPKField1, ephPKField2),
+    utilityFetchTaggedLogs: (pendingTaggedLogArrayBaseSlot: ACVMField[]): Promise<ACVMField[]> =>
+      oracle.aztec_utl_fetchTaggedLogs(pendingTaggedLogArrayBaseSlot),
+    utilityBulkRetrieveLogs: (
+      contractAddress: ACVMField[],
+      logRetrievalRequestsArrayBaseSlot: ACVMField[],
+      logRetrievalResponsesArrayBaseSlot: ACVMField[],
+    ): Promise<ACVMField[]> =>
+      oracle.aztec_utl_bulkRetrieveLogs(
+        contractAddress,
+        logRetrievalRequestsArrayBaseSlot,
+        logRetrievalResponsesArrayBaseSlot,
+      ),
+    utilityGetL1ToL2MembershipWitness: (
+      contractAddress: ACVMField[],
+      messageHash: ACVMField[],
+      secret: ACVMField[],
+    ): Promise<(ACVMField | ACVMField[])[]> =>
+      oracle.aztec_utl_getL1ToL2MembershipWitness(contractAddress, messageHash, secret),
+    utilityEmitOffchainEffect: (data: ACVMField[]): Promise<ACVMField[]> => oracle.aztec_utl_emitOffchainEffect(data),
     // Adapter: old 3-param signature → new 5-param with injected constants.
     // Values derived from: MAX_MESSAGE_CONTENT_LEN(11) - RESERVED_FIELDS (3 for notes, 1 for events).
     utilityValidateAndStoreEnqueuedNotesAndEvents: (
       contractAddress: ACVMField[],
       noteValidationRequestsArrayBaseSlot: ACVMField[],
       eventValidationRequestsArrayBaseSlot: ACVMField[],
-    ) =>
+    ): Promise<ACVMField[]> =>
       oracle.aztec_utl_validateAndStoreEnqueuedNotesAndEvents(
         contractAddress,
         noteValidationRequestsArrayBaseSlot,
@@ -51,27 +120,23 @@ export function buildLegacyOracleCallbacks(oracle: Oracle): ACIRCallback {
         [new Fr(8).toString()],
         [new Fr(10).toString()],
       ),
-    utilityGetL1ToL2MembershipWitness: (...args: ACVMField[][]) =>
-      oracle.aztec_utl_getL1ToL2MembershipWitness(args[0], args[1], args[2]),
-    utilityCheckNullifierExists: (...args: ACVMField[][]) => oracle.aztec_utl_checkNullifierExists(args[0]),
-    utilityGetRandomField: () => oracle.aztec_utl_getRandomField(),
-    utilityEmitOffchainEffect: (...args: ACVMField[][]) => oracle.aztec_utl_emitOffchainEffect(args[0]),
     // Renames (same signature, different oracle name)
-    privateNotifySetMinRevertibleSideEffectCounter: (...args: ACVMField[][]) =>
-      oracle.aztec_prv_notifyRevertiblePhaseStart(args[0]),
-    privateIsSideEffectCounterRevertible: (...args: ACVMField[][]) => oracle.aztec_prv_inRevertiblePhase(args[0]),
+    privateNotifySetMinRevertibleSideEffectCounter: (counter: ACVMField[]): Promise<ACVMField[]> =>
+      oracle.aztec_prv_notifyRevertiblePhaseStart(counter),
+    privateIsSideEffectCounterRevertible: (sideEffectCounter: ACVMField[]): Promise<ACVMField[]> =>
+      oracle.aztec_prv_inRevertiblePhase(sideEffectCounter),
     // Signature changes: old 4-param oracles → new 1-param validatePublicCalldata
     privateNotifyEnqueuedPublicFunctionCall: (
-      [_contractAddress]: ACVMField[],
-      [calldataHash]: ACVMField[],
-      [_sideEffectCounter]: ACVMField[],
-      [_isStaticCall]: ACVMField[],
-    ) => oracle.aztec_prv_validatePublicCalldata([calldataHash]),
+      _contractAddress: ACVMField[],
+      calldataHash: ACVMField[],
+      _sideEffectCounter: ACVMField[],
+      _isStaticCall: ACVMField[],
+    ): Promise<ACVMField[]> => oracle.aztec_prv_validatePublicCalldata(calldataHash),
     privateNotifySetPublicTeardownFunctionCall: (
-      [_contractAddress]: ACVMField[],
-      [calldataHash]: ACVMField[],
-      [_sideEffectCounter]: ACVMField[],
-      [_isStaticCall]: ACVMField[],
-    ) => oracle.aztec_prv_validatePublicCalldata([calldataHash]),
+      _contractAddress: ACVMField[],
+      calldataHash: ACVMField[],
+      _sideEffectCounter: ACVMField[],
+      _isStaticCall: ACVMField[],
+    ): Promise<ACVMField[]> => oracle.aztec_prv_validatePublicCalldata(calldataHash),
   };
 }


### PR DESCRIPTION
## Summary

- Added explicit parameter and return type annotations to all entries in `buildLegacyOracleCallbacks`, so that changes to Oracle method signatures produce compile-time errors instead of silently breaking at runtime.
- Removed 5 unused legacy entries that were not used by any pinned protocol contract
  - `privateGetNextAppTagAsSender`
  - `privateGetSenderForTags`
  - `privateSetSenderForTags`
  - `utilityCheckNullifierExists`
  - `utilityGetRandomField`

Closes F-451