### PR TITLE
feat: default to kernelless simulations

### DIFF
--- a/yarn-project/pxe/src/contract_function_simulator/contract_function_simulator.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/contract_function_simulator.ts
@@ -17,6 +17,7 @@ import {
   MAX_NULLIFIERS_PER_TX,
   MAX_NULLIFIER_READ_REQUESTS_PER_TX,
   MAX_PRIVATE_LOGS_PER_TX,
+  MAX_TX_LIFETIME,
   PRIVATE_TX_L2_GAS_OVERHEAD,
   PUBLIC_TX_L2_GAS_OVERHEAD,
   TX_DA_GAS_OVERHEAD,
@@ -442,11 +443,22 @@ export async function generateSimulatedProvingResult(
 
   let publicTeardownCallRequest;
 
+  // Aggregate expiration timestamp across all calls by taking the minimum, mimicking the kernel circuits.
+  // Each private function defaults to anchor_block_timestamp + MAX_TX_LIFETIME (24h) unless explicitly set lower.
+  let expirationTimestamp =
+    privateExecutionResult.entrypoint.publicInputs.anchorBlockHeader.globalVariables.timestamp +
+    BigInt(MAX_TX_LIFETIME);
+
   const executions = [privateExecutionResult.entrypoint];
 
   while (executions.length !== 0) {
     const execution = executions.shift()!;
     executions.unshift(...execution!.nestedExecutionResults);
+
+    const callExpirationTimestamp = execution.publicInputs.expirationTimestamp;
+    if (callExpirationTimestamp !== 0n && callExpirationTimestamp < expirationTimestamp) {
+      expirationTimestamp = callExpirationTimestamp;
+    }
 
     const { contractAddress } = execution.publicInputs.callContext;
 
@@ -671,7 +683,7 @@ export async function generateSimulatedProvingResult(
       }),
     ),
     /*feePayer=*/ AztecAddress.zero(),
-    /*expirationTimestamp=*/ 0n,
+    /*expirationTimestamp=*/ expirationTimestamp,
     hasPublicCalls ? inputsForPublic : undefined,
     !hasPublicCalls ? inputsForRollup : undefined,
   );

--- a/yarn-project/pxe/src/contract_function_simulator/contract_function_simulator.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/contract_function_simulator.ts
@@ -455,6 +455,7 @@ export async function generateSimulatedProvingResult(
     const execution = executions.shift()!;
     executions.unshift(...execution!.nestedExecutionResults);
 
+    // Just like kernels we overwrite the default value if the call sets it.
     const callExpirationTimestamp = execution.publicInputs.expirationTimestamp;
     if (callExpirationTimestamp !== 0n && callExpirationTimestamp < expirationTimestamp) {
       expirationTimestamp = callExpirationTimestamp;

--- a/yarn-project/pxe/src/contract_function_simulator/contract_function_simulator.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/contract_function_simulator.ts
@@ -443,8 +443,7 @@ export async function generateSimulatedProvingResult(
 
   let publicTeardownCallRequest;
 
-  // Aggregate expiration timestamp across all calls by taking the minimum, mimicking the kernel circuits.
-  // Each private function defaults to anchor_block_timestamp + MAX_TX_LIFETIME (24h) unless explicitly set lower.
+  // We set expiration timestamp to anchor_block_timestamp + MAX_TX_LIFETIME (24h) just like kernels do
   let expirationTimestamp =
     privateExecutionResult.entrypoint.publicInputs.anchorBlockHeader.globalVariables.timestamp +
     BigInt(MAX_TX_LIFETIME);

--- a/yarn-project/pxe/src/pxe.ts
+++ b/yarn-project/pxe/src/pxe.ts
@@ -107,7 +107,9 @@ export type SimulateTxOpts = {
   skipTxValidation?: boolean;
   /** If false, fees are enforced. */
   skipFeeEnforcement?: boolean;
-  /** State overrides for the simulation, such as contract instances and artifacts. */
+  /** If true, kernel logic is emulated in TS for simulation */
+  skipKernels?: boolean;
+  /** State overrides for the simulation, such as contract instances and artifacts. Requires skipKernels: true */
   overrides?: SimulationOverrides;
   /** Addresses whose private state and keys are accessible during private execution */
   scopes: AccessScopes;
@@ -896,7 +898,14 @@ export class PXE {
    */
   public simulateTx(
     txRequest: TxExecutionRequest,
-    { simulatePublic, skipTxValidation = false, skipFeeEnforcement = false, overrides, scopes }: SimulateTxOpts,
+    {
+      simulatePublic,
+      skipTxValidation = false,
+      skipFeeEnforcement = false,
+      skipKernels = true,
+      overrides,
+      scopes,
+    }: SimulateTxOpts,
   ): Promise<TxSimulationResult> {
     // We disable concurrent simulations since those might execute oracles which read and write to the PXE stores (e.g.
     // to the capsules), and we need to prevent concurrent runs from interfering with one another (e.g. attempting to
@@ -920,13 +929,15 @@ export class PXE {
         await this.blockStateSynchronizer.sync();
         const syncTime = syncTimer.ms();
 
-        const contractFunctionSimulator = this.#getSimulatorForTx(overrides);
-        // Temporary: in case there are overrides, we have to skip the kernels or validations
-        // will fail. Consider handing control to the user/wallet on whether they want to run them
-        // or not.
         const overriddenContracts = overrides?.contracts ? new Set(Object.keys(overrides.contracts)) : undefined;
         const hasOverriddenContracts = overriddenContracts !== undefined && overriddenContracts.size > 0;
-        const skipKernels = hasOverriddenContracts;
+
+        if (hasOverriddenContracts && !skipKernels) {
+          throw new Error(
+            'Simulating with overridden contracts is not compatible with kernel execution. Please set skipKernels to true when simulating with overridden contracts.',
+          );
+        }
+        const contractFunctionSimulator = this.#getSimulatorForTx(overrides);
 
         // Set overridden contracts on the sync service so it knows to skip syncing them
         if (hasOverriddenContracts) {

--- a/yarn-project/wallets/src/embedded/embedded_wallet.ts
+++ b/yarn-project/wallets/src/embedded/embedded_wallet.ts
@@ -10,7 +10,12 @@ import { AztecAddress } from '@aztec/stdlib/aztec-address';
 import { getContractInstanceFromInstantiationParams } from '@aztec/stdlib/contract';
 import type { AztecNode } from '@aztec/stdlib/interfaces/client';
 import { deriveSigningKey } from '@aztec/stdlib/keys';
-import { ExecutionPayload, type TxSimulationResult, mergeExecutionPayloads } from '@aztec/stdlib/tx';
+import {
+  ExecutionPayload,
+  SimulationOverrides,
+  type TxSimulationResult,
+  mergeExecutionPayloads,
+} from '@aztec/stdlib/tx';
 import { BaseWallet, type FeeOptions } from '@aztec/wallet-sdk/base-wallet';
 
 import type { AccountContractsProvider } from './account-contract-providers/types.js';
@@ -84,10 +89,20 @@ export class EmbeddedWallet extends BaseWallet {
     from: AztecAddress,
     feeOptions: FeeOptions,
     scopes: AccessScopes,
-    _skipTxValidation?: boolean,
-    _skipFeeEnforcement?: boolean,
+    skipTxValidation?: boolean,
+    skipFeeEnforcement?: boolean,
   ): Promise<TxSimulationResult> {
-    const { account: fromAccount, instance, artifact } = await this.getFakeAccountDataFor(from);
+    let overrides: SimulationOverrides | undefined;
+    let fromAccount: Account;
+    if (!from.equals(AztecAddress.ZERO)) {
+      const { account, instance, artifact } = await this.getFakeAccountDataFor(from);
+      fromAccount = account;
+      overrides = {
+        contracts: { [from.toString()]: { instance, artifact } },
+      };
+    } else {
+      fromAccount = await this.getAccountFromAddress(from);
+    }
 
     const feeExecutionPayload = await feeOptions.walletFeePaymentMethod?.getExecutionPayload();
     const executionOptions: DefaultAccountEntrypointOptions = {
@@ -107,49 +122,33 @@ export class EmbeddedWallet extends BaseWallet {
     );
     return this.pxe.simulateTx(txRequest, {
       simulatePublic: true,
-      skipFeeEnforcement: true,
-      skipTxValidation: true,
-      overrides: {
-        contracts: { [from.toString()]: { instance, artifact } },
-      },
+      skipFeeEnforcement,
+      skipTxValidation,
+      overrides,
       scopes,
     });
   }
 
   private async getFakeAccountDataFor(address: AztecAddress) {
-    // While we have the convention of "Zero address means no auth", and also
-    // we don't have a way to trigger kernelless simulations without overrides,
-    // we need to explicitly handle the zero address case here by
-    // returning the actual multicall contract instead of trying to create a stub account for it.
-    if (!address.equals(AztecAddress.ZERO)) {
-      const originalAccount = await this.getAccountFromAddress(address);
-      if (originalAccount instanceof SignerlessAccount) {
-        throw new Error(`Cannot create fake account data for SignerlessAccount at address: ${address}`);
-      }
-      const originalAddress = (originalAccount as Account).getCompleteAddress();
-      const contractInstance = await this.pxe.getContractInstance(originalAddress.address);
-      if (!contractInstance) {
-        throw new Error(`No contract instance found for address: ${originalAddress.address}`);
-      }
-      const stubAccount = await this.accountContracts.createStubAccount(originalAddress);
-      const stubArtifact = await this.accountContracts.getStubAccountContractArtifact();
-      const instance = await getContractInstanceFromInstantiationParams(stubArtifact, {
-        salt: Fr.random(),
-      });
-      return {
-        account: stubAccount,
-        instance,
-        artifact: stubArtifact,
-      };
-    } else {
-      const { instance, artifact } = await this.accountContracts.getMulticallContract();
-      const account = new SignerlessAccount();
-      return {
-        instance,
-        account,
-        artifact,
-      };
+    const originalAccount = await this.getAccountFromAddress(address);
+    if (originalAccount instanceof SignerlessAccount) {
+      throw new Error(`Cannot create fake account data for SignerlessAccount at address: ${address}`);
     }
+    const originalAddress = (originalAccount as Account).getCompleteAddress();
+    const contractInstance = await this.pxe.getContractInstance(originalAddress.address);
+    if (!contractInstance) {
+      throw new Error(`No contract instance found for address: ${originalAddress.address}`);
+    }
+    const stubAccount = await this.accountContracts.createStubAccount(originalAddress);
+    const stubArtifact = await this.accountContracts.getStubAccountContractArtifact();
+    const instance = await getContractInstanceFromInstantiationParams(stubArtifact, {
+      salt: Fr.random(),
+    });
+    return {
+      account: stubAccount,
+      instance,
+      artifact: stubArtifact,
+    };
   }
 
   protected async createAccountInternal(


### PR DESCRIPTION
We're confident enough in them after ensuring expiration_timestamp is set
