### PR TITLE
feat: add #[error_enum] macro and Result type for typed decrypt errors

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/messages/discovery/process_message.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/discovery/process_message.nr
@@ -1,18 +1,22 @@
-use crate::messages::{
-    discovery::{
-        ComputeNoteHashAndNullifier, CustomMessageHandler, partial_notes::process_partial_note_private_msg,
-        private_events::process_private_event_msg, private_notes::process_private_note_msg,
+use crate::{
+    logging::{aztecnr_debug_log, aztecnr_warn_log_format},
+    messages::{
+        discovery::{
+            ComputeNoteHashAndNullifier, CustomMessageHandler, partial_notes::process_partial_note_private_msg,
+            private_events::process_private_event_msg, private_notes::process_private_note_msg,
+        },
+        encoding::{decode_message, MESSAGE_CIPHERTEXT_LEN, MESSAGE_PLAINTEXT_LEN},
+        encryption::{aes128::{AES128, DecryptError}, message_encryption::MessageEncryption},
+        msg_type::{
+            MIN_CUSTOM_MSG_TYPE_ID, PARTIAL_NOTE_PRIVATE_MSG_TYPE_ID, PRIVATE_EVENT_MSG_TYPE_ID,
+            PRIVATE_NOTE_MSG_TYPE_ID,
+        },
+        processing::MessageContext,
     },
-    encoding::{decode_message, MESSAGE_CIPHERTEXT_LEN, MESSAGE_PLAINTEXT_LEN},
-    encryption::{aes128::AES128, message_encryption::MessageEncryption},
-    msg_type::{
-        MIN_CUSTOM_MSG_TYPE_ID, PARTIAL_NOTE_PRIVATE_MSG_TYPE_ID, PRIVATE_EVENT_MSG_TYPE_ID, PRIVATE_NOTE_MSG_TYPE_ID,
-    },
-    processing::MessageContext,
+    protocol::address::AztecAddress,
+    utils::errors::warn_with_reason,
 };
-
-use crate::logging::{aztecnr_debug_log, aztecnr_warn_log_format};
-use crate::protocol::address::AztecAddress;
+use std::meta::ctstring::AsCtString;
 
 /// Processes a message that can contain notes, partial notes, or events.
 ///
@@ -33,19 +37,21 @@ pub unconstrained fn process_message_ciphertext<ComputeNoteHashAndNullifierEnv, 
     message_ciphertext: BoundedVec<Field, MESSAGE_CIPHERTEXT_LEN>,
     message_context: MessageContext,
 ) {
-    let message_plaintext_option = AES128::decrypt(message_ciphertext, message_context.recipient);
-
-    if message_plaintext_option.is_some() {
-        process_message_plaintext(
-            contract_address,
-            compute_note_hash_and_nullifier,
-            process_custom_message,
-            message_plaintext_option.unwrap(),
-            message_context,
-        );
-    } else {
-        aztecnr_warn_log_format!("Could not decrypt message ciphertext from tx {0}, ignoring")([message_context.tx_hash]);
-    }
+    let _ = AES128::decrypt(message_ciphertext, message_context.recipient)
+        .map(|plaintext| {
+            process_message_plaintext(
+                contract_address,
+                compute_note_hash_and_nullifier,
+                process_custom_message,
+                plaintext,
+                message_context,
+            );
+        })
+        .map_err(warn_with_reason!(
+            DecryptError::metadata(),
+            |reason| f"Could not decrypt message ciphertext from tx {{0}}, ignoring. Reason: {reason}".as_ctstring(),
+            quote { [message_context.tx_hash] },
+        ));
 }
 
 pub(crate) unconstrained fn process_message_plaintext<ComputeNoteHashAndNullifierEnv, CustomMessageHandlerEnv>(

--- a/noir-projects/aztec-nr/aztec/src/messages/encryption/aes128.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/encryption/aes128.nr
@@ -419,8 +419,7 @@ impl MessageEncryption for AES128 {
                         let unmasked_fields = masked_fields.mapi(|i, field| {
                             let unmasked = unmask_field(ciphertext_shared_secret, i, field);
                             // If we failed to unmask the field, we are dealing with the random padding. We'll ignore
-                            // it
-                            // later, so we can simply set it to 0
+                            // it later, so we can simply set it to 0.
                             unmasked.unwrap_or(0)
                         });
                         let ciphertext_without_eph_pk_x = bytes_from_fields(unmasked_fields);
@@ -436,12 +435,10 @@ impl MessageEncryption for AES128 {
                         let header_start = 0;
                         let header_ciphertext: [u8; HEADER_CIPHERTEXT_SIZE_IN_BYTES] =
                             array::subarray(ciphertext_without_eph_pk_x.storage(), header_start);
-                        // We need to convert the array to a BoundedVec because the oracle expects a BoundedVec as it's
-                        // designed to work with messages with unknown length at compile time. This would not be
-                        // necessary
-                        // here as the header ciphertext length is fixed. But we do it anyway to not have to have
-                        // duplicate
-                        // oracles.
+                        // We need to convert the array to a BoundedVec because the oracle expects a BoundedVec as
+                        // it's designed to work with messages with unknown length at compile time. This would not be
+                        // necessary here as the header ciphertext length is fixed. But we do it anyway to not have to
+                        // have duplicate oracles.
                         let header_ciphertext_bvec =
                             BoundedVec::<u8, HEADER_CIPHERTEXT_SIZE_IN_BYTES>::from_array(header_ciphertext);
 
@@ -469,8 +466,7 @@ impl MessageEncryption for AES128 {
                                 let plaintext_bytes = aes128_decrypt_oracle(ciphertext, body_iv, body_sym_key);
 
                                 // Convert bytes back to fields (32 bytes per field). Returns an error if the actual
-                                // bytes
-                                // are not valid.
+                                // bytes are not valid.
                                 Result::from_option(
                                     try_fields_from_bytes(plaintext_bytes),
                                     DecryptError::invalid_plaintext_bytes(),

--- a/noir-projects/aztec-nr/aztec/src/messages/encryption/aes128.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/encryption/aes128.nr
@@ -27,9 +27,23 @@ use crate::{
             bytes_to_fields::{bytes_from_fields, bytes_to_fields},
             fields_to_bytes::{fields_to_bytes, try_fields_from_bytes},
         },
+        errors::error_enum,
         point::point_from_x_coord_and_sign,
+        result::Result,
     },
 };
+
+/// Error type for AES128 message decryption failures.
+#[error_enum]
+pub struct DecryptError {
+    empty_ciphertext: (),
+    invalid_ephemeral_key: (),
+    invalid_header: (),
+    oversized_ciphertext: (),
+    invalid_plaintext_bytes: (),
+}
+
+use std::meta::ctstring::AsCtString;
 
 use std::aes128::aes128_encrypt;
 
@@ -38,7 +52,7 @@ use std::aes128::aes128_encrypt;
 /// NEVER re-use the same iv and sym_key. DO NOT call this function more than once with the same shared_secret.
 ///
 /// This function is only known to be safe if shared_secret is computed by combining a random ephemeral key with an
-/// address point. See big comment within the body of the function. See big comment within the body of the function.
+/// address point. See big comment within the body of the function.
 fn extract_many_close_to_uniformly_random_256_bits_from_ecdh_shared_secret_using_poseidon2_unsafe<let N: u32>(
     shared_secret: Point,
 ) -> [[u8; 32]; N] {
@@ -151,6 +165,7 @@ pub fn derive_aes_symmetric_key_and_iv_from_ecdh_shared_secret_using_poseidon2_u
 pub struct AES128 {}
 
 impl MessageEncryption for AES128 {
+    type DecryptError = DecryptError;
 
     /// AES128-CBC encryption for Aztec protocol messages.
     ///
@@ -381,71 +396,87 @@ impl MessageEncryption for AES128 {
     unconstrained fn decrypt(
         ciphertext: BoundedVec<Field, MESSAGE_CIPHERTEXT_LEN>,
         recipient: AztecAddress,
-    ) -> Option<BoundedVec<Field, MESSAGE_PLAINTEXT_LEN>> {
-        // Extract the ephemeral public key x-coordinate and masked fields, returning None for empty ciphertext.
+    ) -> Result<BoundedVec<Field, MESSAGE_PLAINTEXT_LEN>, DecryptError> {
+        // Extract the ephemeral public key x-coordinate and masked fields, returning an error for empty ciphertext.
         if ciphertext.len() > 0 {
             let masked_fields: BoundedVec<Field, MESSAGE_CIPHERTEXT_LEN - EPH_PK_X_SIZE_IN_FIELDS> =
                 array::subbvec(ciphertext, EPH_PK_X_SIZE_IN_FIELDS);
-            Option::some((ciphertext.get(0), masked_fields))
+            Result::Ok((ciphertext.get(0), masked_fields))
         } else {
-            Option::none()
+            Result::Err(DecryptError::empty_ciphertext())
         }
             .and_then(|(eph_pk_x, masked_fields)| {
                 // With the x-coordinate of the ephemeral public key we can reconstruct the point as we know that the
-                // y-coordinate must be positive. This may fail however, as not all x-coordinates are on the curve. In
-                // that case, we simply return `Option::none`.
-                point_from_x_coord_and_sign(eph_pk_x, true).and_then(|eph_pk| {
-                    // Derive shared secret
-                    let ciphertext_shared_secret = get_shared_secret(recipient, eph_pk);
+                // y-coordinate must be positive. This may fail however, as not all x-coordinates are on the curve.
+                Result::from_option(
+                    point_from_x_coord_and_sign(eph_pk_x, true),
+                    DecryptError::invalid_ephemeral_key(),
+                )
+                    .and_then(|eph_pk| {
+                        // Derive shared secret
+                        let ciphertext_shared_secret = get_shared_secret(recipient, eph_pk);
 
-                    let unmasked_fields = masked_fields.mapi(|i, field| {
-                        let unmasked = unmask_field(ciphertext_shared_secret, i, field);
-                        // If we failed to unmask the field, we are dealing with the random padding. We'll ignore it
-                        // later, so we can simply set it to 0
-                        unmasked.unwrap_or(0)
-                    });
-                    let ciphertext_without_eph_pk_x = bytes_from_fields(unmasked_fields);
+                        let unmasked_fields = masked_fields.mapi(|i, field| {
+                            let unmasked = unmask_field(ciphertext_shared_secret, i, field);
+                            // If we failed to unmask the field, we are dealing with the random padding. We'll ignore
+                            // it
+                            // later, so we can simply set it to 0
+                            unmasked.unwrap_or(0)
+                        });
+                        let ciphertext_without_eph_pk_x = bytes_from_fields(unmasked_fields);
 
-                    // Derive symmetric keys:
-                    let pairs = derive_aes_symmetric_key_and_iv_from_ecdh_shared_secret_using_poseidon2_unsafe::<2>(
-                        ciphertext_shared_secret,
-                    );
-                    let (body_sym_key, body_iv) = pairs[0];
-                    let (header_sym_key, header_iv) = pairs[1];
+                        // Derive symmetric keys:
+                        let pairs = derive_aes_symmetric_key_and_iv_from_ecdh_shared_secret_using_poseidon2_unsafe::<2>(
+                            ciphertext_shared_secret,
+                        );
+                        let (body_sym_key, body_iv) = pairs[0];
+                        let (header_sym_key, header_iv) = pairs[1];
 
-                    // Extract the header ciphertext
-                    let header_start = 0;
-                    let header_ciphertext: [u8; HEADER_CIPHERTEXT_SIZE_IN_BYTES] =
-                        array::subarray(ciphertext_without_eph_pk_x.storage(), header_start);
-                    // We need to convert the array to a BoundedVec because the oracle expects a BoundedVec as it's
-                    // designed to work with messages with unknown length at compile time. This would not be necessary
-                    // here as the header ciphertext length is fixed. But we do it anyway to not have to have duplicate
-                    // oracles.
-                    let header_ciphertext_bvec =
-                        BoundedVec::<u8, HEADER_CIPHERTEXT_SIZE_IN_BYTES>::from_array(header_ciphertext);
+                        // Extract the header ciphertext
+                        let header_start = 0;
+                        let header_ciphertext: [u8; HEADER_CIPHERTEXT_SIZE_IN_BYTES] =
+                            array::subarray(ciphertext_without_eph_pk_x.storage(), header_start);
+                        // We need to convert the array to a BoundedVec because the oracle expects a BoundedVec as it's
+                        // designed to work with messages with unknown length at compile time. This would not be
+                        // necessary
+                        // here as the header ciphertext length is fixed. But we do it anyway to not have to have
+                        // duplicate
+                        // oracles.
+                        let header_ciphertext_bvec =
+                            BoundedVec::<u8, HEADER_CIPHERTEXT_SIZE_IN_BYTES>::from_array(header_ciphertext);
 
-                    // Decrypt header
-                    let header_plaintext = aes128_decrypt_oracle(header_ciphertext_bvec, header_iv, header_sym_key);
+                        // Decrypt header
+                        let header_plaintext = aes128_decrypt_oracle(header_ciphertext_bvec, header_iv, header_sym_key);
 
-                    // Extract ciphertext length from header (2 bytes, big-endian)
-                    extract_ciphertext_length(header_plaintext)
-                        .filter(|ciphertext_length| ciphertext_length <= MESSAGE_PLAINTEXT_SIZE_IN_BYTES)
-                        .and_then(|ciphertext_length| {
-                            // Extract and decrypt main ciphertext
-                            let ciphertext_start = header_start + HEADER_CIPHERTEXT_SIZE_IN_BYTES;
-                            let ciphertext_with_padding: [u8; MESSAGE_PLAINTEXT_SIZE_IN_BYTES] =
-                                array::subarray(ciphertext_without_eph_pk_x.storage(), ciphertext_start);
-                            let ciphertext: BoundedVec<u8, MESSAGE_PLAINTEXT_SIZE_IN_BYTES> =
-                                BoundedVec::from_parts(ciphertext_with_padding, ciphertext_length);
+                        // Extract ciphertext length from header (2 bytes, big-endian)
+                        extract_ciphertext_length(header_plaintext)
+                            .and_then(|ciphertext_length| {
+                                if ciphertext_length <= MESSAGE_PLAINTEXT_SIZE_IN_BYTES {
+                                    Result::Ok(ciphertext_length)
+                                } else {
+                                    Result::Err(DecryptError::oversized_ciphertext())
+                                }
+                            })
+                            .and_then(|ciphertext_length| {
+                                // Extract and decrypt main ciphertext
+                                let ciphertext_start = header_start + HEADER_CIPHERTEXT_SIZE_IN_BYTES;
+                                let ciphertext_with_padding: [u8; MESSAGE_PLAINTEXT_SIZE_IN_BYTES] =
+                                    array::subarray(ciphertext_without_eph_pk_x.storage(), ciphertext_start);
+                                let ciphertext: BoundedVec<u8, MESSAGE_PLAINTEXT_SIZE_IN_BYTES> =
+                                    BoundedVec::from_parts(ciphertext_with_padding, ciphertext_length);
 
-                            // Decrypt main ciphertext and return it
-                            let plaintext_bytes = aes128_decrypt_oracle(ciphertext, body_iv, body_sym_key);
+                                // Decrypt main ciphertext and return it
+                                let plaintext_bytes = aes128_decrypt_oracle(ciphertext, body_iv, body_sym_key);
 
-                            // Convert bytes back to fields (32 bytes per field). Returns None if the actual bytes are
-                            // not valid.
-                            try_fields_from_bytes(plaintext_bytes)
-                        })
-                })
+                                // Convert bytes back to fields (32 bytes per field). Returns an error if the actual
+                                // bytes
+                                // are not valid.
+                                Result::from_option(
+                                    try_fields_from_bytes(plaintext_bytes),
+                                    DecryptError::invalid_plaintext_bytes(),
+                                )
+                            })
+                    })
             })
     }
 }
@@ -457,12 +488,12 @@ fn encode_header(ciphertext_length: u32) -> [u8; 2] {
 
 /// Extracts the body ciphertext length from a decrypted header as a 2-byte big-endian integer.
 ///
-/// Returns `Option::none()` if the header has fewer than 2 bytes.
-unconstrained fn extract_ciphertext_length<let N: u32>(header: BoundedVec<u8, N>) -> Option<u32> {
+/// Returns `DecryptError::invalid_header()` if the header has fewer than 2 bytes.
+unconstrained fn extract_ciphertext_length<let N: u32>(header: BoundedVec<u8, N>) -> Result<u32, DecryptError> {
     if header.len() >= 2 {
-        Option::some(((header.get(0) as u32) << 8) | (header.get(1) as u32))
+        Result::Ok(((header.get(0) as u32) << 8) | (header.get(1) as u32))
     } else {
-        Option::none()
+        Result::Err(DecryptError::invalid_header())
     }
 }
 
@@ -519,7 +550,7 @@ mod test {
         test::helpers::test_environment::TestEnvironment,
     };
     use crate::protocol::{address::AztecAddress, traits::FromField};
-    use super::{AES128, encode_header, random_address_point};
+    use super::{AES128, DecryptError, encode_header, random_address_point};
     use std::{embedded_curve_ops::EmbeddedCurveScalar, test::OracleMock};
 
     #[test]
@@ -652,7 +683,7 @@ mod test {
     }
 
     #[test]
-    unconstrained fn decrypt_invalid_ephemeral_public_key() {
+    unconstrained fn decrypt_fails_on_invalid_ephemeral_public_key() {
         let mut env = TestEnvironment::new();
 
         let recipient = env.create_light_account();
@@ -666,22 +697,26 @@ mod test {
             let mut bad_ciphertext = BoundedVec::from_array(ciphertext);
             bad_ciphertext.set(0, 3);
 
-            assert(AES128::decrypt(bad_ciphertext, recipient).is_none());
+            let result = AES128::decrypt(bad_ciphertext, recipient);
+            assert_eq(result.unwrap_err(), DecryptError::invalid_ephemeral_key());
         });
     }
 
     #[test]
-    unconstrained fn decrypt_returns_none_on_empty_ciphertext() {
+    unconstrained fn decrypt_fails_on_empty_ciphertext() {
         let mut env = TestEnvironment::new();
         let recipient = env.create_light_account();
 
-        env.private_context(|_| { assert(AES128::decrypt(BoundedVec::new(), recipient).is_none()); });
+        env.private_context(|_| {
+            let result = AES128::decrypt(BoundedVec::new(), recipient);
+            assert_eq(result.unwrap_err(), DecryptError::empty_ciphertext());
+        });
     }
 
     // Mocks the header AES decrypt oracle to return an empty result. The TS oracle never throws on invalid
     // input: it decrypts to garbage bytes or returns empty
     #[test]
-    unconstrained fn decrypt_returns_none_on_empty_header() {
+    unconstrained fn decrypt_fails_on_empty_header() {
         let mut env = TestEnvironment::new();
         let recipient = env.create_light_account();
 
@@ -692,14 +727,15 @@ mod test {
             let empty_header = BoundedVec::<u8, HEADER_CIPHERTEXT_SIZE_IN_BYTES>::new();
             let _ = OracleMock::mock("aztec_utl_aes128Decrypt").returns(empty_header).times(1);
 
-            assert(AES128::decrypt(ciphertext, recipient).is_none());
+            let result = AES128::decrypt(ciphertext, recipient);
+            assert_eq(result.unwrap_err(), DecryptError::invalid_header());
         });
     }
 
     // Mocks the header oracle to return a 2-byte header that decodes to a ciphertext_length one past the maximum
     // allowed value, verifying the edge case is handled correctly.
     #[test]
-    unconstrained fn decrypt_returns_none_on_oversized_ciphertext_length() {
+    unconstrained fn decrypt_fails_on_oversized_ciphertext_length() {
         let mut env = TestEnvironment::new();
         let recipient = env.create_light_account();
 
@@ -712,7 +748,8 @@ mod test {
             ));
             let _ = OracleMock::mock("aztec_utl_aes128Decrypt").returns(bad_header).times(1);
 
-            assert(AES128::decrypt(ciphertext, recipient).is_none());
+            let result = AES128::decrypt(ciphertext, recipient);
+            assert_eq(result.unwrap_err(), DecryptError::oversized_ciphertext());
         });
     }
 

--- a/noir-projects/aztec-nr/aztec/src/messages/encryption/message_encryption.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/encryption/message_encryption.nr
@@ -1,5 +1,6 @@
 use crate::messages::encoding::{MESSAGE_CIPHERTEXT_LEN, MESSAGE_PLAINTEXT_LEN};
 use crate::protocol::address::AztecAddress;
+use crate::utils::result::Result;
 
 /// Trait for encrypting and decrypting messages in the Aztec protocol.
 ///
@@ -17,6 +18,9 @@ use crate::protocol::address::AztecAddress;
 /// indistinguishable onchain. Implementations of this trait must handle padding the encrypted log to match this
 /// standardized length.
 pub trait MessageEncryption {
+    /// The error type returned by [`MessageEncryption::decrypt`] on failure.
+    type DecryptError;
+
     /// Encrypts a plaintext message to `recipient`.
     ///
     /// The returned message ciphertext can be passed to [`MessageEncryption::decrypt`] in order to obtain the
@@ -45,9 +49,9 @@ pub trait MessageEncryption {
     /// functions.
     ///
     /// Not all ciphertexts are valid - among other things, the ephemeral public key included in it may not correspond
-    /// to a point on the curve. In all such cases, [`Option::none`] is returned instead.
+    /// to a point on the curve. In all such cases, a [`Self::DecryptError`] describing the failure is returned.
     unconstrained fn decrypt(
         ciphertext: BoundedVec<Field, MESSAGE_CIPHERTEXT_LEN>,
         recipient: AztecAddress,
-    ) -> Option<BoundedVec<Field, MESSAGE_PLAINTEXT_LEN>>;
+    ) -> Result<BoundedVec<Field, MESSAGE_PLAINTEXT_LEN>, Self::DecryptError>;
 }

--- a/noir-projects/aztec-nr/aztec/src/messages/encryption/message_encryption.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/encryption/message_encryption.nr
@@ -49,7 +49,7 @@ pub trait MessageEncryption {
     /// functions.
     ///
     /// Not all ciphertexts are valid - among other things, the ephemeral public key included in it may not correspond
-    /// to a point on the curve. In all such cases, a [`Self::DecryptError`] describing the failure is returned.
+    /// to a point on the curve. In all such cases, a `DecryptError` describing the failure is returned.
     unconstrained fn decrypt(
         ciphertext: BoundedVec<Field, MESSAGE_CIPHERTEXT_LEN>,
         recipient: AztecAddress,

--- a/noir-projects/aztec-nr/aztec/src/utils/errors.nr
+++ b/noir-projects/aztec-nr/aztec/src/utils/errors.nr
@@ -1,0 +1,135 @@
+use std::meta::ctstring::AsCtString;
+
+/// Generates a coded error type from struct fields.
+///
+/// Each `field: ()` entry becomes a named constructor with an auto-assigned numeric code. Given:
+///
+/// ```noir
+/// #[error_enum]
+/// pub struct DecryptError {
+///     empty_ciphertext: (),
+///     invalid_header: (),
+/// }
+/// ```
+///
+/// The macro rewrites the struct and generates an impl block equivalent to:
+///
+/// ```noir
+/// pub struct DecryptError { _code: u8 }
+///
+/// impl DecryptError {
+///     // One constructor per field, codes assigned sequentially from 1
+///     pub fn empty_ciphertext() -> Self { Self { _code: 1 } }
+///     pub fn invalid_header() -> Self { Self { _code: 2 } }
+///
+///     // Accessor for the numeric code
+///     pub fn code(self) -> u8 { self._code }
+///
+///     // Comptime metadata: pairs each code with its field name as a reason string. The returned Quoted is the
+///     // type itself, needed by `warn_with_reason!` to annotate the closure parameter.
+///     pub comptime fn metadata() -> (Quoted, [(u8, CtString); 2]) {
+///         (quote { DecryptError }, [(1, "empty_ciphertext"), (2, "invalid_header")])
+///     }
+/// }
+///
+/// impl Eq for DecryptError { ... }
+/// ```
+pub comptime fn error_enum(s: TypeDefinition) -> Quoted {
+    let typ = s.as_type();
+    let fields = s.fields_as_written();
+    let n = fields.len();
+
+    let mut constructors_list = @[];
+    let mut error_reason_entries_list = @[];
+
+    for i in 0..n {
+        let (name, _typ, _vis) = fields[i];
+        let code = (i as u8) + 1;
+        let reason_str = f"{name}".as_ctstring().as_quoted_str();
+
+        constructors_list = constructors_list.push_back(quote { pub fn $name() -> Self { Self { _code: $code } } });
+        error_reason_entries_list = error_reason_entries_list.push_back(quote { ($code, $reason_str.as_ctstring()) });
+    }
+
+    let constructors = constructors_list.join(quote {});
+    let error_reason_entries = error_reason_entries_list.join(quote {,});
+
+    // Rewrite the struct body to `DecryptError { _code: u8 }`, discarding the original `field: ()` declarations.
+    // `set_fields` takes an array of (name, type, visibility) tuples. We leave visibility empty so `_code` is private,
+    // which forces callers to use the generated constructors (e.g. `DecryptError::empty_ciphertext()`) instead of
+    // constructing the struct directly.
+    let u8_type = quote { u8 }.as_type();
+    s.set_fields(@[(quote { _code }, u8_type, quote { })]);
+
+    quote {
+        impl $typ {
+            $constructors
+
+            pub fn code(self) -> u8 {
+                self._code
+            }
+
+            pub comptime fn metadata() -> (Quoted, [(u8, CtString); $n]) {
+                (quote { $typ }, [$error_reason_entries])
+            }
+        }
+
+        impl Eq for $typ {
+            fn eq(self, other: Self) -> bool {
+                self._code == other._code
+            }
+        }
+    }
+}
+
+/// Builds a warning-logger closure for error enums.
+///
+/// Returns a closure `|err| -> err` that matches the error code, logs a warning prefixed with `[aztec-nr]`, and
+/// returns the error. The `message_fn` closure receives each error's reason string and returns the full log message.
+/// The `context` is spliced as `{0}`, `{1}`, etc.
+///
+/// ## Example
+///
+/// ```noir
+/// let _ = AES128::decrypt(ciphertext, recipient)
+///     .map(|plaintext| process(plaintext))
+///     .map_err(warn_with_reason!(
+///         DecryptError::metadata(),
+///         |reason| f"Could not decrypt from tx {{0}}, ignoring. Reason: {reason}".as_ctstring(),
+///         quote { [message_context.tx_hash] },
+///     ));
+/// ```
+///
+/// For an error with code 1 (`empty_ciphertext`) and tx_hash `0xdead`, this logs:
+///
+/// ```text
+/// WARN: [aztec-nr] Could not decrypt from tx 0x...dead, ignoring. Reason: empty_ciphertext
+/// ```
+pub comptime fn warn_with_reason<let N: u32>(
+    metadata: (Quoted, [(u8, CtString); N]),
+    message_fn: fn(CtString) -> CtString,
+    context: Quoted,
+) -> Quoted {
+    let (error_enum, reasons) = metadata;
+
+    // For each error reason we generate an `if __err.code() == N { log(...) }` block. Joining them with `else`
+    // produces an `if ... else if ... else if ...` chain that matches the error code and logs the right message.
+    let mut branches_list = @[];
+    for i in 0..N {
+        let (code, reason) = reasons[i];
+        let msg = message_fn(reason).as_quoted_str();
+        branches_list = branches_list.push_back(
+            quote { if __err.code() == $code { crate::logging::aztecnr_warn_log_format!($msg)(__err_ctx); } },
+        );
+    }
+    let branches = branches_list.join(quote { else });
+
+    // Return a closure that takes a coded error, logs a warning, and returns the error.
+    quote {
+        |__err: $error_enum| -> $error_enum {
+            let __err_ctx = $context;
+            $branches
+            __err
+        }
+    }
+}

--- a/noir-projects/aztec-nr/aztec/src/utils/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/utils/mod.nr
@@ -4,6 +4,8 @@ pub mod array;
 pub mod comparison;
 pub mod conversion;
 pub mod point;
+pub mod errors;
+pub mod result;
 mod with_hash;
 pub use with_hash::WithHash;
 pub mod remove_constraints;

--- a/noir-projects/aztec-nr/aztec/src/utils/result.nr
+++ b/noir-projects/aztec-nr/aztec/src/utils/result.nr
@@ -1,0 +1,602 @@
+/// A type representing either success (`Ok`) or failure (`Err`), modeled after Rust's `std::result::Result`.
+///
+/// ## Examples
+///
+/// ```noir
+/// let ok: Result<u32, Field> = Result::Ok(42);
+/// assert(ok.is_ok());
+/// assert_eq(ok.unwrap(), 42);
+///
+/// let err: Result<u32, Field> = Result::Err(1);
+/// assert(err.is_err());
+/// assert_eq(err.unwrap_err(), 1);
+/// ```
+pub struct Result<T, E> {
+    _is_ok: bool,
+    _value: T,
+    _error: E,
+}
+
+impl<T, E> Result<T, E> {
+    /// Constructs an Ok value.
+    pub fn Ok(value: T) -> Self {
+        Self { _is_ok: true, _value: value, _error: std::mem::zeroed() }
+    }
+
+    /// Constructs an Err value.
+    pub fn Err(error: E) -> Self {
+        Self { _is_ok: false, _value: std::mem::zeroed(), _error: error }
+    }
+
+    /// True if this Result is Ok.
+    pub fn is_ok(self) -> bool {
+        self._is_ok
+    }
+
+    /// True if this Result is Err.
+    pub fn is_err(self) -> bool {
+        !self._is_ok
+    }
+
+    /// Returns `true` if the result is Ok and the value matches the predicate.
+    pub fn is_ok_and<Env>(self, f: fn[Env](T) -> bool) -> bool {
+        if self._is_ok {
+            f(self._value)
+        } else {
+            false
+        }
+    }
+
+    /// Returns `true` if the result is Err and the error matches the predicate.
+    pub fn is_err_and<Env>(self, f: fn[Env](E) -> bool) -> bool {
+        if self._is_ok {
+            false
+        } else {
+            f(self._error)
+        }
+    }
+
+    /// Converts to `Option<T>`, discarding any error.
+    pub fn ok(self) -> Option<T> {
+        if self._is_ok {
+            Option::some(self._value)
+        } else {
+            Option::none()
+        }
+    }
+
+    /// Converts to `Option<E>`, discarding any ok value.
+    pub fn err(self) -> Option<E> {
+        if self._is_ok {
+            Option::none()
+        } else {
+            Option::some(self._error)
+        }
+    }
+
+    /// Asserts `self.is_ok()` and returns the wrapped value.
+    pub fn unwrap(self) -> T {
+        assert(self._is_ok);
+        self._value
+    }
+
+    /// Asserts `self.is_err()` and returns the wrapped error.
+    pub fn unwrap_err(self) -> E {
+        assert(!self._is_ok);
+        self._error
+    }
+
+    /// Returns the inner value without asserting `self.is_ok()`. If `self` is `Err`, there is no guarantee what
+    /// value will be returned, only that it will be of type `T`.
+    pub fn unwrap_unchecked(self) -> T {
+        self._value
+    }
+
+    /// Returns the wrapped value if `self.is_ok()`. Otherwise, returns the given default value.
+    pub fn unwrap_or(self, default: T) -> T {
+        if self._is_ok {
+            self._value
+        } else {
+            default
+        }
+    }
+
+    /// Returns the wrapped value if `self.is_ok()`. Otherwise, calls the given function with the error to
+    /// produce a default value.
+    pub fn unwrap_or_else<Env>(self, default: fn[Env](E) -> T) -> T {
+        if self._is_ok {
+            self._value
+        } else {
+            default(self._error)
+        }
+    }
+
+    /// Asserts `self.is_ok()` with a provided custom message and returns the contained Ok value.
+    pub fn expect<let N: u32, MessageTypes>(self, message: fmtstr<N, MessageTypes>) -> T {
+        assert(self.is_ok(), message);
+        self._value
+    }
+
+    /// Asserts `self.is_err()` with a provided custom message and returns the contained Err value.
+    pub fn expect_err<let N: u32, MessageTypes>(self, message: fmtstr<N, MessageTypes>) -> E {
+        assert(self.is_err(), message);
+        self._error
+    }
+
+    /// If self is `Ok(x)`, this returns `Ok(f(x))`. Otherwise, this returns the `Err` value unchanged.
+    pub fn map<U, Env>(self, f: fn[Env](T) -> U) -> Result<U, E> {
+        if self._is_ok {
+            Result::Ok(f(self._value))
+        } else {
+            Result::Err(self._error)
+        }
+    }
+
+    /// Applies a function to the Ok value or returns a default.
+    pub fn map_or<U, Env>(self, default: U, f: fn[Env](T) -> U) -> U {
+        if self._is_ok {
+            f(self._value)
+        } else {
+            default
+        }
+    }
+
+    /// Applies a function to the Ok value, or computes a default from the Err value.
+    pub fn map_or_else<U, Env1, Env2>(self, default: fn[Env1](E) -> U, f: fn[Env2](T) -> U) -> U {
+        if self._is_ok {
+            f(self._value)
+        } else {
+            default(self._error)
+        }
+    }
+
+    /// If self is `Err(e)`, this returns `Err(f(e))`. Otherwise, this returns the `Ok` value unchanged.
+    pub fn map_err<F, Env>(self, f: fn[Env](E) -> F) -> Result<T, F> {
+        if self._is_ok {
+            Result::Ok(self._value)
+        } else {
+            Result::Err(f(self._error))
+        }
+    }
+
+    /// Calls `f` on the contained Ok value (if any), returning self unchanged.
+    pub fn inspect<Env>(self, f: fn[Env](T) -> ()) -> Self {
+        if self._is_ok {
+            f(self._value);
+        }
+        self
+    }
+
+    /// Calls `f` on the contained Err value (if any), returning self unchanged.
+    pub fn inspect_err<Env>(self, f: fn[Env](E) -> ()) -> Self {
+        if !self._is_ok {
+            f(self._error);
+        }
+        self
+    }
+
+    /// If self is `Ok(x)`, this returns `f(x)`. Otherwise, this returns the `Err` value unchanged.
+    ///
+    /// In some languages this function is called `flat_map` or `bind`.
+    pub fn and_then<U, Env>(self, f: fn[Env](T) -> Result<U, E>) -> Result<U, E> {
+        if self._is_ok {
+            f(self._value)
+        } else {
+            Result::Err(self._error)
+        }
+    }
+
+    /// Returns `other` if self is `Ok`, otherwise returns the `Err` value of self.
+    pub fn and<U>(self, other: Result<U, E>) -> Result<U, E> {
+        if self._is_ok {
+            other
+        } else {
+            Result::Err(self._error)
+        }
+    }
+
+    /// If self is `Err(e)`, this returns `f(e)`. Otherwise, this returns the `Ok` value unchanged.
+    pub fn or_else<F, Env>(self, f: fn[Env](E) -> Result<T, F>) -> Result<T, F> {
+        if self._is_ok {
+            Result::Ok(self._value)
+        } else {
+            f(self._error)
+        }
+    }
+
+    /// Returns self if it is `Ok`, otherwise returns `other`.
+    pub fn or<F>(self, other: Result<T, F>) -> Result<T, F> {
+        if self._is_ok {
+            Result::Ok(self._value)
+        } else {
+            other
+        }
+    }
+
+    /// Creates a `Result` from an `Option`, using the provided error if `None`.
+    pub fn from_option(option: Option<T>, error: E) -> Self {
+        if option.is_some() {
+            Result::Ok(option.unwrap_unchecked())
+        } else {
+            Result::Err(error)
+        }
+    }
+
+    /// Creates a `Result` from an `Option`, using a lazily-evaluated error if `None`.
+    pub fn from_option_or_else<Env>(option: Option<T>, error: fn[Env]() -> E) -> Self {
+        if option.is_some() {
+            Result::Ok(option.unwrap_unchecked())
+        } else {
+            Result::Err(error())
+        }
+    }
+}
+
+impl<T, E> Result<Result<T, E>, E> {
+    /// Converts `Result<Result<T, E>, E>` to `Result<T, E>`.
+    pub fn flatten(self) -> Result<T, E> {
+        if self._is_ok {
+            self._value
+        } else {
+            Result::Err(self._error)
+        }
+    }
+}
+
+impl<T, E> Result<Option<T>, E> {
+    /// Transposes a `Result<Option<T>, E>` into an `Option<Result<T, E>>`.
+    pub fn transpose(self) -> Option<Result<T, E>> {
+        if self._is_ok {
+            if self._value.is_some() {
+                Option::some(Result::Ok(self._value.unwrap_unchecked()))
+            } else {
+                Option::none()
+            }
+        } else {
+            Option::some(Result::Err(self._error))
+        }
+    }
+}
+
+impl<T, E> Eq for Result<T, E>
+where
+    T: Eq,
+    E: Eq,
+{
+    fn eq(self, other: Self) -> bool {
+        if self._is_ok == other._is_ok {
+            if self._is_ok {
+                self._value == other._value
+            } else {
+                self._error == other._error
+            }
+        } else {
+            false
+        }
+    }
+}
+
+mod tests {
+    use super::Result;
+
+    #[test]
+    fn ok_is_ok() {
+        let r: Result<u32, u8> = Result::Ok(42);
+        assert(r.is_ok());
+        assert(!r.is_err());
+        assert_eq(r.unwrap(), 42);
+    }
+
+    #[test]
+    fn err_is_err() {
+        let r: Result<u32, u8> = Result::Err(1);
+        assert(r.is_err());
+        assert(!r.is_ok());
+        assert_eq(r.unwrap_err(), 1);
+    }
+
+    #[test(should_fail)]
+    fn unwrap_on_err_panics() {
+        let r: Result<u32, u8> = Result::Err(1);
+        let _ = r.unwrap();
+    }
+
+    #[test(should_fail)]
+    fn unwrap_err_on_ok_panics() {
+        let r: Result<u32, u8> = Result::Ok(42);
+        let _ = r.unwrap_err();
+    }
+
+    #[test]
+    fn unwrap_or_returns_default_on_err() {
+        let r: Result<u32, u8> = Result::Err(1);
+        assert_eq(r.unwrap_or(99), 99);
+    }
+
+    #[test]
+    fn unwrap_or_returns_value_on_ok() {
+        let r: Result<u32, u8> = Result::Ok(42);
+        assert_eq(r.unwrap_or(99), 42);
+    }
+
+    #[test]
+    fn map_transforms_ok() {
+        let r: Result<u32, u8> = Result::Ok(2);
+        let mapped = r.map(|x| x * 3);
+        assert_eq(mapped.unwrap(), 6);
+    }
+
+    #[test]
+    fn map_preserves_err() {
+        let r: Result<u32, u8> = Result::Err(1);
+        let mapped = r.map(|x| x * 3);
+        assert(mapped.is_err());
+        assert_eq(mapped.unwrap_err(), 1);
+    }
+
+    #[test]
+    fn map_err_transforms_err() {
+        let r: Result<u32, u8> = Result::Err(1);
+        let mapped = r.map_err(|e| e + 10);
+        assert_eq(mapped.unwrap_err(), 11);
+    }
+
+    #[test]
+    fn map_err_preserves_ok() {
+        let r: Result<u32, u8> = Result::Ok(42);
+        let mapped = r.map_err(|e| e + 10);
+        assert_eq(mapped.unwrap(), 42);
+    }
+
+    #[test]
+    fn and_then_chains_ok() {
+        let r: Result<u32, u8> = Result::Ok(2);
+        let chained = r.and_then(|x| Result::Ok(x * 3));
+        assert_eq(chained.unwrap(), 6);
+    }
+
+    #[test]
+    fn and_then_short_circuits_on_err() {
+        let r: Result<u32, u8> = Result::Err(1);
+        let chained = r.and_then(|x| Result::Ok(x * 3));
+        assert(chained.is_err());
+        assert_eq(chained.unwrap_err(), 1);
+    }
+
+    #[test]
+    fn or_else_chains_err() {
+        let r: Result<u32, u8> = Result::Err(1);
+        let chained: Result<u32, u8> = r.or_else(|_e| Result::Ok(99));
+        assert_eq(chained.unwrap(), 99);
+    }
+
+    #[test]
+    fn or_else_preserves_ok() {
+        let r: Result<u32, u8> = Result::Ok(42);
+        let chained: Result<u32, u8> = r.or_else(|_e| Result::Ok(99));
+        assert_eq(chained.unwrap(), 42);
+    }
+
+    #[test]
+    fn ok_converts_ok() {
+        let r: Result<u32, u8> = Result::Ok(42);
+        assert_eq(r.ok().unwrap(), 42);
+    }
+
+    #[test]
+    fn ok_converts_err() {
+        let r: Result<u32, u8> = Result::Err(1);
+        assert(r.ok().is_none());
+    }
+
+    #[test]
+    fn err_converts_err() {
+        let r: Result<u32, u8> = Result::Err(7);
+        assert_eq(r.err().unwrap(), 7);
+    }
+
+    #[test]
+    fn err_converts_ok() {
+        let r: Result<u32, u8> = Result::Ok(42);
+        assert(r.err().is_none());
+    }
+
+    #[test]
+    fn from_option_some() {
+        let o: Option<u32> = Option::some(42);
+        let r: Result<u32, u8> = Result::from_option(o, 1);
+        assert_eq(r.unwrap(), 42);
+    }
+
+    #[test]
+    fn from_option_none() {
+        let o: Option<u32> = Option::none();
+        let r: Result<u32, u8> = Result::from_option(o, 1);
+        assert_eq(r.unwrap_err(), 1);
+    }
+
+    #[test]
+    fn eq_ok_values() {
+        let a: Result<u32, u8> = Result::Ok(42);
+        let b: Result<u32, u8> = Result::Ok(42);
+        assert_eq(a, b);
+    }
+
+    #[test]
+    fn eq_err_values() {
+        let a: Result<u32, u8> = Result::Err(1);
+        let b: Result<u32, u8> = Result::Err(1);
+        assert_eq(a, b);
+    }
+
+    #[test]
+    fn neq_ok_vs_err() {
+        let a: Result<u32, u8> = Result::Ok(42);
+        let b: Result<u32, u8> = Result::Err(1);
+        assert(a != b);
+    }
+
+    #[test]
+    fn is_ok_and_true() {
+        let r: Result<u32, u8> = Result::Ok(42);
+        assert(r.is_ok_and(|v| v == 42));
+    }
+
+    #[test]
+    fn is_ok_and_false_on_predicate() {
+        let r: Result<u32, u8> = Result::Ok(42);
+        assert(!r.is_ok_and(|v| v == 0));
+    }
+
+    #[test]
+    fn is_ok_and_false_on_err() {
+        let r: Result<u32, u8> = Result::Err(1);
+        assert(!r.is_ok_and(|_v| true));
+    }
+
+    #[test]
+    fn is_err_and_true() {
+        let r: Result<u32, u8> = Result::Err(1);
+        assert(r.is_err_and(|e| e == 1));
+    }
+
+    #[test]
+    fn is_err_and_false_on_predicate() {
+        let r: Result<u32, u8> = Result::Err(1);
+        assert(!r.is_err_and(|e| e == 0));
+    }
+
+    #[test]
+    fn is_err_and_false_on_ok() {
+        let r: Result<u32, u8> = Result::Ok(42);
+        assert(!r.is_err_and(|_e| true));
+    }
+
+    #[test]
+    fn expect_err_returns_error() {
+        let r: Result<u32, u8> = Result::Err(5);
+        assert_eq(r.expect_err(f"should be err"), 5);
+    }
+
+    #[test(should_fail)]
+    fn expect_err_panics_on_ok() {
+        let r: Result<u32, u8> = Result::Ok(42);
+        let _ = r.expect_err(f"was ok");
+    }
+
+    #[test]
+    fn map_or_returns_mapped_on_ok() {
+        let r: Result<u32, u8> = Result::Ok(2);
+        assert_eq(r.map_or(0, |x| x * 3), 6);
+    }
+
+    #[test]
+    fn map_or_returns_default_on_err() {
+        let r: Result<u32, u8> = Result::Err(1);
+        assert_eq(r.map_or(99, |x| x * 3), 99);
+    }
+
+    #[test]
+    fn map_or_else_returns_mapped_on_ok() {
+        let r: Result<u32, u8> = Result::Ok(2);
+        assert_eq(r.map_or_else(|_e| 0, |x| x * 3), 6);
+    }
+
+    #[test]
+    fn map_or_else_returns_default_on_err() {
+        let r: Result<u32, u8> = Result::Err(1);
+        assert_eq(r.map_or_else(|e| e as u32 + 10, |x| x * 3), 11);
+    }
+
+    #[test]
+    fn and_returns_other_on_ok() {
+        let a: Result<u32, u8> = Result::Ok(2);
+        let b: Result<u64, u8> = Result::Ok(100);
+        assert_eq(a.and(b).unwrap(), 100);
+    }
+
+    #[test]
+    fn and_returns_err_on_err() {
+        let a: Result<u32, u8> = Result::Err(1);
+        let b: Result<u64, u8> = Result::Ok(100);
+        assert_eq(a.and(b).unwrap_err(), 1);
+    }
+
+    #[test]
+    fn or_returns_self_on_ok() {
+        let a: Result<u32, u8> = Result::Ok(42);
+        let b: Result<u32, u16> = Result::Err(999);
+        assert_eq(a.or(b).unwrap(), 42);
+    }
+
+    #[test]
+    fn or_returns_other_on_err() {
+        let a: Result<u32, u8> = Result::Err(1);
+        let b: Result<u32, u16> = Result::Ok(99);
+        assert_eq(a.or(b).unwrap(), 99);
+    }
+
+    #[test]
+    fn inspect_calls_fn_on_ok() {
+        let r: Result<u32, u8> = Result::Ok(42);
+        assert_eq(r.inspect(|v| { assert_eq(v, 42); }).unwrap(), 42);
+    }
+
+    #[test]
+    fn inspect_preserves_err() {
+        let r: Result<u32, u8> = Result::Err(1);
+        assert_eq(r.inspect(|_v| panic(f"should not be called")).unwrap_err(), 1);
+    }
+
+    #[test]
+    fn inspect_err_calls_fn_on_err() {
+        let r: Result<u32, u8> = Result::Err(5);
+        assert_eq(r.inspect_err(|e| { assert_eq(e, 5); }).unwrap_err(), 5);
+    }
+
+    #[test]
+    fn inspect_err_preserves_ok() {
+        let r: Result<u32, u8> = Result::Ok(42);
+        assert_eq(r.inspect_err(|_e| panic(f"should not be called")).unwrap(), 42);
+    }
+
+    #[test]
+    fn flatten_ok_ok() {
+        let r: Result<Result<u32, u8>, u8> = Result::Ok(Result::Ok(42));
+        assert_eq(r.flatten().unwrap(), 42);
+    }
+
+    #[test]
+    fn flatten_ok_err() {
+        let r: Result<Result<u32, u8>, u8> = Result::Ok(Result::Err(1));
+        assert_eq(r.flatten().unwrap_err(), 1);
+    }
+
+    #[test]
+    fn flatten_err() {
+        let r: Result<Result<u32, u8>, u8> = Result::Err(2);
+        assert_eq(r.flatten().unwrap_err(), 2);
+    }
+
+    #[test]
+    fn transpose_ok_some() {
+        let r: Result<Option<u32>, u8> = Result::Ok(Option::some(42));
+        let t = r.transpose();
+        assert(t.is_some());
+        assert_eq(t.unwrap().unwrap(), 42);
+    }
+
+    #[test]
+    fn transpose_ok_none() {
+        let r: Result<Option<u32>, u8> = Result::Ok(Option::none());
+        assert(r.transpose().is_none());
+    }
+
+    #[test]
+    fn transpose_err() {
+        let r: Result<Option<u32>, u8> = Result::Err(1);
+        let t = r.transpose();
+        assert(t.is_some());
+        assert_eq(t.unwrap().unwrap_err(), 1);
+    }
+}


### PR DESCRIPTION
## Summary

- Add `#[error_enum]` comptime macro that generates coded error types from struct field declarations
- Add custom `Result<T, E>` type with a full Rust-like API (`and_then`, `map`, `map_err`, `inspect`, etc.)
- Replace `Option`-based error handling in `AES128::decrypt` with typed `Result<T, DecryptError>`
- Add `warn_with_reason!` comptime macro for structured error logging with reason strings

## Motivation

`AES128::decrypt` previously returned `Option<BoundedVec<Field, N>>`. When decryption failed, callers had no way to know *why* -- was the ciphertext empty? Was the ephemeral key invalid? Was the header malformed? All failures looked the same: `None`.

The natural fix is `Result<T, E>`, but Noir's compile-time string constraints make conventional error types awkward. You can't do `Result<T, str<N>>` because each message has a different length, and you can't use a single `Error` struct with a message field for the same reason. We also explored:

- **Padding**  (making all errors have the same length): It didn't look right when logged
- **Field-level attributes** (`#[text("reason")]` on struct fields): Noir doesn't support attributes on struct fields.
- **String literals in type position** (`field: ("reason text")`): Noir's parser rejects string literals as types.

## Proposed Solution

An `#[error_enum]` comptime macro turns a struct declaration into a self-contained coded error type:

```noir
#[error_enum]
pub struct DecryptError {
    empty_ciphertext: (),
    invalid_ephemeral_key: (),
    invalid_header: (),
    oversized_ciphertext: (),
    invalid_plaintext_bytes: (),
}
```

The macro rewrites the struct to hold a `_code: u8` and generates constructors, `code()`, `Eq`, and a `metadata()` comptime method. This all will allow us to return a `Result<T, DecryptError>` with enough information to be used by callers.

## Benefits

**Tests assert specific failure reasons** instead of checking `is_none()`:
```noir
// Before
assert(AES128::decrypt(bad_ciphertext, recipient).is_none());

// After
assert_eq(AES128::decrypt(bad_ciphertext, recipient).unwrap_err(), DecryptError::invalid_ephemeral_key());
```

**Structured warning logs with context**, built at compile time:
```
WARN: [aztec-nr] Could not decrypt message from tx 0x...dead, ignoring. Reason: empty_ciphertext
```

**`Result`'s fluent API** improves readability:
```noir
// Before
let message_plaintext_option = AES128::decrypt(message_ciphertext, message_context.recipient);

if message_plaintext_option.is_some() {
    process_message_plaintext(
        contract_address, compute_note_hash_and_nullifier, process_custom_message,
        message_plaintext_option.unwrap(), message_context,
    );
} else {
    aztecnr_warn_log_format!("Could not decrypt message ciphertext from tx {0}, ignoring")(
        [message_context.tx_hash],
    );
}

// After
let _ = AES128::decrypt(message_ciphertext, message_context.recipient)
    .map(|plaintext| {
        process_message_plaintext(
            contract_address, compute_note_hash_and_nullifier, process_custom_message,
            plaintext, message_context,
        );
    })
    .map_err(warn_with_reason!(
        DecryptError::metadata(),
        |reason| f"Could not decrypt from tx {{0}}, ignoring. Reason: {reason}".as_ctstring(),
        quote { [message_context.tx_hash] },
    ));
```