### PR TITLE
fix: update nullifier non-inclusion test expectations after early oracle throw

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/history/note/test.nr
+++ b/noir-projects/aztec-nr/aztec/src/history/note/test.nr
@@ -42,7 +42,7 @@ unconstrained fn succeeds_on_blocks_after_creation_and_before_nullification() {
     });
 }
 
-#[test(should_fail_with = "Proving nullifier non-inclusion failed")]
+#[test(should_fail_with = "Cannot prove nullifier non-inclusion")]
 unconstrained fn fails_on_blocks_after_note_nullification() {
     let (env, hinted_note) = test::create_note_and_nullify_it();
 

--- a/noir-projects/aztec-nr/aztec/src/history/nullifier/test.nr
+++ b/noir-projects/aztec-nr/aztec/src/history/nullifier/test.nr
@@ -79,7 +79,7 @@ unconstrained fn note_not_nullified_succeeds_in_blocks_before_note_nullification
     );
 }
 
-#[test(should_fail_with = "Proving nullifier non-inclusion failed")]
+#[test(should_fail_with = "Cannot prove nullifier non-inclusion")]
 unconstrained fn note_not_nullified_fails_in_blocks_after_note_nullification_fails() {
     let (env, hinted_note) = test::create_note_and_nullify_it();
 
@@ -100,7 +100,7 @@ unconstrained fn nullifier_non_inclusion_succeeds_in_blocks_before_nullifier_cre
     });
 }
 
-#[test(should_fail_with = "Proving nullifier non-inclusion failed")]
+#[test(should_fail_with = "Cannot prove nullifier non-inclusion")]
 unconstrained fn nullifier_non_inclusion_fails_in_blocks_after_nullifier_creation() {
     let env = TestEnvironment::new();
 

--- a/noir-projects/noir-contracts/contracts/test/test_contract/src/test/deployment_proofs.nr
+++ b/noir-projects/noir-contracts/contracts/test/test_contract/src/test/deployment_proofs.nr
@@ -103,7 +103,7 @@ unconstrained fn assert_contract_was_initialized_by_before_initialization_fails(
     );
 }
 
-#[test(should_fail_with = "Proving nullifier non-inclusion failed")]
+#[test(should_fail_with = "Cannot prove nullifier non-inclusion")]
 unconstrained fn assert_contract_bytecode_was_not_published_by_of_deployed_fails() {
     let (env, contract_address, _owner) = setup();
 
@@ -119,7 +119,7 @@ unconstrained fn assert_contract_bytecode_was_not_published_by_of_deployed_fails
     );
 }
 
-#[test(should_fail_with = "Proving nullifier non-inclusion failed")]
+#[test(should_fail_with = "Cannot prove nullifier non-inclusion")]
 unconstrained fn assert_contract_was_not_initialized_by_of_initialized_fails() {
     let (env, contract_address, _owner) = setup();
 

--- a/noir-projects/noir-protocol-circuits/crates/types/src/delayed_public_mutable/delayed_public_mutable_values/test.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/delayed_public_mutable/delayed_public_mutable_values/test.nr
@@ -74,7 +74,7 @@ unconstrained fn packed_delayed_public_mutable_values_match_typescript() {
     let pre_value = MockStruct { a: 1, b: 2 };
     let post_value = MockStruct { a: 3, b: 4 };
 
-    let sdc = ScheduledDelayChange::<0u64>::new(Option::some(1), Option::some(50), 2);
+    let sdc = ScheduledDelayChange::<0_u64>::new(Option::some(1), Option::some(50), 2);
     let svc = ScheduledValueChange::new(pre_value, post_value, 50);
     let dpmv = DelayedPublicMutableValues::new(svc, sdc);
 


### PR DESCRIPTION
## Summary

- Update 5 `should_fail_with` test expectations from `"Proving nullifier non-inclusion failed"` to `"Cannot prove nullifier non-inclusion"`
- Include unrelated nargo fmt fix (`0u64` -> `0_u64`)

## Context

PR #21472 changed `getLowNullifierMembershipWitness` in the aztec-node to throw a descriptive error early when a nullifier already exists in the tree, instead of returning the wrong witness and letting the circuit fail downstream. The new error message is `"Cannot prove nullifier non-inclusion: nullifier ... already exists in the tree"`.

The Noir tests still expected the old downstream circuit error `"Proving nullifier non-inclusion failed"`, causing them to fail with "Test failed with the wrong message".

## Files changed

- `noir-projects/aztec-nr/aztec/src/history/nullifier/test.nr` (2 tests)
- `noir-projects/aztec-nr/aztec/src/history/note/test.nr` (1 test)
- `noir-projects/noir-contracts/contracts/test/test_contract/src/test/deployment_proofs.nr` (2 tests)
- `noir-projects/noir-protocol-circuits/crates/types/.../test.nr` (nargo fmt)