### PR TITLE
chore: bench compressed chonk proof size 

### DIFF
--- a/barretenberg/cpp/scripts/ci_benchmark_ivc_flows.sh
+++ b/barretenberg/cpp/scripts/ci_benchmark_ivc_flows.sh
@@ -101,6 +101,14 @@ function chonk_flow {
   local proof_size_bytes=$(stat -c%s "$output/proof.tar.gz" 2>/dev/null || stat -f%z "$output/proof.tar.gz")
   local proof_size_kb=$(( proof_size_bytes / 1024 ))
 
+  # Get compressed proof size and number of public inputs via bb proof_stats
+  # proof_stats writes proof_stats.json (metadata) and proof_stats.bin (compressed proof + public inputs)
+  "./$native_build_dir/bin/bb" proof_stats --scheme chonk -p "$output/proof" -o "$output/proof_stats.json"
+  # Gzip the compressed proof + public inputs (same treatment as the raw proof above)
+  tar -czf "$output/proof_stats.tar.gz" -C "$output" proof_stats.bin
+  local compressed_proof_size_bytes=$(stat -c%s "$output/proof_stats.tar.gz" 2>/dev/null || stat -f%z "$output/proof_stats.tar.gz")
+  local compressed_proof_size_kb=$(( compressed_proof_size_bytes / 1024 ))
+
   cat > "$output/benchmarks.bench.json" <<EOF
 [
   {
@@ -117,6 +125,11 @@ function chonk_flow {
     "name": "$name_path/proof-size",
     "unit": "KB",
     "value": ${proof_size_kb}
+  },
+  {
+    "name": "$name_path/compressed-proof-size",
+    "unit": "KB",
+    "value": ${compressed_proof_size_kb}
   }
 ]
 EOF

--- a/barretenberg/cpp/src/barretenberg/api/api_chonk.cpp
+++ b/barretenberg/cpp/src/barretenberg/api/api_chonk.cpp
@@ -7,6 +7,7 @@
 #include "barretenberg/chonk/chonk_verifier.hpp"
 #include "barretenberg/chonk/mock_circuit_producer.hpp"
 #include "barretenberg/chonk/private_execution_steps.hpp"
+#include "barretenberg/chonk/proof_compression.hpp"
 #include "barretenberg/common/get_bytecode.hpp"
 #include "barretenberg/common/map.hpp"
 #include "barretenberg/common/throw_or_abort.hpp"
@@ -143,6 +144,31 @@ bool ChonkAPI::batch_verify([[maybe_unused]] const Flags& flags, const std::file
 
     auto response = bbapi::ChonkBatchVerify{ .proofs = std::move(proofs), .vks = std::move(vks) }.execute();
     return response.valid;
+}
+
+void ChonkAPI::proof_stats(const std::filesystem::path& proof_path, const std::filesystem::path& output_path)
+{
+    auto proof_fields = many_from_buffer<fr>(read_file(proof_path));
+    auto proof = ChonkProof::from_field_elements(proof_fields);
+
+    auto compressed = ProofCompressor::compress_chonk_proof(proof);
+
+    std::string json = "{\n"
+                       "  \"compressed_proof_size_bytes\": " +
+                       std::to_string(compressed.size()) +
+                       "\n"
+                       "}";
+
+    if (output_path == "-") {
+        std::cout << json << std::endl;
+    } else {
+        write_file(output_path, std::vector<uint8_t>(json.begin(), json.end()));
+        // Write the compressed proof alongside the JSON for further processing (e.g. gzip)
+        auto compressed_proof_path = output_path;
+        compressed_proof_path.replace_extension(".bin");
+        write_file(compressed_proof_path, compressed);
+        info("Proof stats written to ", output_path);
+    }
 }
 
 // WORKTODO(bbapi) remove this

--- a/barretenberg/cpp/src/barretenberg/api/api_chonk.hpp
+++ b/barretenberg/cpp/src/barretenberg/api/api_chonk.hpp
@@ -100,6 +100,17 @@ class ChonkAPI : public API {
      */
     bool check_precomputed_vks(const Flags& flags, const std::filesystem::path& input_path);
 
+    /**
+     * @brief Output proof statistics: compressed proof and its size.
+     *
+     * @details Reads a serialized Chonk proof, computes the compressed proof using ProofCompressor,
+     * writes the compressed proof binary and a JSON file with compressed_proof_size_bytes.
+     *
+     * @param proof_path Path to the serialized Chonk proof
+     * @param output_path Path to write the JSON stats file (or "-" for stdout)
+     */
+    void proof_stats(const std::filesystem::path& proof_path, const std::filesystem::path& output_path);
+
     bool check(const Flags& flags,
                const std::filesystem::path& bytecode_path,
                const std::filesystem::path& witness_path) override;

--- a/barretenberg/cpp/src/barretenberg/bb/cli.cpp
+++ b/barretenberg/cpp/src/barretenberg/bb/cli.cpp
@@ -534,6 +534,18 @@ int parse_and_run_cli_command(int argc, char* argv[])
     add_crs_path_option(batch_verify);
 
     /***************************************************************************************************************
+     * Subcommand: proof_stats
+     ***************************************************************************************************************/
+    CLI::App* proof_stats =
+        app.add_subcommand("proof_stats", "Output proof statistics (compressed size, number of public inputs).");
+
+    add_help_extended_flag(proof_stats);
+    add_scheme_option(proof_stats);
+    add_proof_path_option(proof_stats);
+    add_output_path_option(proof_stats, output_path);
+    add_verbose_flag(proof_stats);
+
+    /***************************************************************************************************************
      * Subcommand: write_solidity_verifier
      ***************************************************************************************************************/
     CLI::App* write_solidity_verifier =
@@ -977,6 +989,10 @@ int parse_and_run_cli_command(int argc, char* argv[])
                 const bool verified = api.batch_verify(flags, batch_verify_proofs_dir);
                 vinfo("batch verified: ", verified);
                 return verified ? 0 : 1;
+            }
+            if (proof_stats->parsed()) {
+                api.proof_stats(proof_path, output_path);
+                return 0;
             }
             return execute_non_prove_command(api);
         } else if (flags.scheme == "ultra_honk") {

--- a/barretenberg/cpp/src/barretenberg/eccvm/transcript_builder.hpp
+++ b/barretenberg/cpp/src/barretenberg/eccvm/transcript_builder.hpp
@@ -313,6 +313,8 @@ class ECCVMTranscriptBuilder {
                 add_lambda_denominator[i] = 0;
                 inverse_trace_x[i] = 0;
                 inverse_trace_y[i] = 0;
+                transcript_msm_x_inverse_trace[i] = 0;
+                msm_count_at_transition_inverse_trace[i] = 0;
             }
         }
 
@@ -534,7 +536,9 @@ class ECCVMTranscriptBuilder {
         const bool msm_output_infinity = msm_output.is_point_at_infinity();
         const bool row_msm_infinity = row.transcript_msm_infinity;
 
-        transcript_msm_x_inverse_trace = row_msm_infinity ? 0 : (msm_accumulator_trace.x - offset_generator().x);
+        transcript_msm_x_inverse_trace = (row_msm_infinity || msm_accumulator_trace.is_point_at_infinity())
+                                             ? 0
+                                             : (msm_accumulator_trace.x - offset_generator().x);
 
         FF lhsx;
         FF lhsy;


### PR DESCRIPTION
we use ProofCompression module to reduce Chonk proof size  without PI, the PI are padded (`PRIVATE_TO_ROLLUP_KERNEL_CIRCUIT_PUBLIC_INPUTS_LENGTH = 1281`), and most of these fields are zero, so gz compresses those efficiently, now we can track this size in the main flows' benches