### PR TITLE
fix: use NonBlockingCall in ThreadedAsyncOperation to prevent SIGBUS on macOS

### DIFF
--- a/barretenberg/cpp/src/barretenberg/nodejs_module/util/async_op.hpp
+++ b/barretenberg/cpp/src/barretenberg/nodejs_module/util/async_op.hpp
@@ -124,10 +124,13 @@ class ThreadedAsyncOperation {
                         auto error = Napi::Error::New(env, op->_error);
                         op->_deferred->Reject(error.Value());
                     }
-                    // Release the TSFN and self-destruct
                     op->_completion_tsfn.Release();
-                    delete op;
                 });
+            // BlockingCall has returned — the callback is done and the TSFN is released,
+            // but `this` is still alive. Safe to delete now (moving it into the callback
+            // caused a use-after-free / SIGBUS on macOS because BlockingCall was still
+            // unwinding through the destroyed _completion_tsfn member).
+            delete this;
         }).detach();
     }
 


### PR DESCRIPTION
Fixes SIGBUS crash on macOS in `ThreadedAsyncOperation` (#21138).

`delete op` was inside the `BlockingCall` callback, destroying the object while `BlockingCall` was still unwinding on the worker thread. macOS unmaps freed pages aggressively → SIGBUS. Linux keeps them mapped → silent use-after-free.

Fix: move `delete this` to after `BlockingCall` returns on the worker thread.

[Full post mortem with diagrams](https://gist.github.com/ludamad/443afe321853389a08693c4ff73676f7)