### PR TITLE
chore(docs): Add links to FeatureCards

### DIFF
--- a/docs/docs/index.mdx
+++ b/docs/docs/index.mdx
@@ -34,6 +34,7 @@ privacy, check out the [foundational topics](/developers/docs/foundational-topic
       <path d="M7 11V7a5 5 0 0110 0v4" />
     </svg>
   }
+  link="/developers/docs/aztec-nr/framework-description/functions/visibility"
 />
 
 <FeatureCard
@@ -45,6 +46,7 @@ privacy, check out the [foundational topics](/developers/docs/foundational-topic
       <path d="M12 6v6l4 2" />
     </svg>
   }
+  link="/developers/docs/foundational-topics/advanced/circuits/public_execution"
 />
 
 <FeatureCard
@@ -55,17 +57,19 @@ privacy, check out the [foundational topics](/developers/docs/foundational-topic
       <path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5" />
     </svg>
   }
+  link="/developers/docs/foundational-topics/pxe"
 />
 
 <FeatureCard
   title="Public State"
-  description="Maintain transparent state in a public merkle tree when required by your application."
+  description="Maintain transparent state in a public Merkle tree when required by your application."
   icon={
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
       <path d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
       <path d="M9 12l2 2 4-4" />
     </svg>
   }
+  link="/developers/docs/foundational-topics/state_management"
 />
 
 <FeatureCard
@@ -80,6 +84,7 @@ privacy, check out the [foundational topics](/developers/docs/foundational-topic
       <path d="M10 6h4M10 18h4M6 10v4M18 10v4" />
     </svg>
   }
+  link="/developers/docs/aztec-nr/framework-description/calling_contracts"
 />
 
 <FeatureCard
@@ -90,6 +95,7 @@ privacy, check out the [foundational topics](/developers/docs/foundational-topic
       <path d="M7 17l-4-4 4-4M17 7l4 4-4 4M14 3l-4 18" />
     </svg>
   }
+  link="/developers/docs/foundational-topics/ethereum-aztec-messaging"
 />
 
 </div>

--- a/docs/docs/index.mdx
+++ b/docs/docs/index.mdx
@@ -46,7 +46,7 @@ privacy, check out the [foundational topics](/developers/docs/foundational-topic
       <path d="M12 6v6l4 2" />
     </svg>
   }
-  link="/developers/docs/foundational-topics/advanced/circuits/public-execution"
+  link="/developers/docs/foundational-topics/advanced/circuits/public_execution"
 />
 
 <FeatureCard
@@ -84,7 +84,7 @@ privacy, check out the [foundational topics](/developers/docs/foundational-topic
       <path d="M10 6h4M10 18h4M6 10v4M18 10v4" />
     </svg>
   }
-  link="/developers/docs/aztec-nr/framework-description/calling-contracts"
+  link="/developers/docs/aztec-nr/framework-description/calling_contracts"
 />
 
 <FeatureCard
@@ -154,7 +154,7 @@ privacy, check out the [foundational topics](/developers/docs/foundational-topic
 <QuickLink
   title="Run a Sequencer"
   description="Set up and operate a sequencer node"
-  link="/operate/operators/setup/sequencer-setup"
+  link="/operate/operators/setup/sequencer_management"
   icon={
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
       <rect x="2" y="3" width="20" height="14" rx="2" />
@@ -166,7 +166,7 @@ privacy, check out the [foundational topics](/developers/docs/foundational-topic
 <QuickLink
   title="Run a Prover"
   description="Contribute computational power to the network"
-  link="/operate/operators/setup/running-a-prover"
+  link="/operate/operators/setup/running_a_prover"
   icon={
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
       <path d="M22 12h-4l-3 9L9 3l-3 9H2" />

--- a/docs/docs/index.mdx
+++ b/docs/docs/index.mdx
@@ -34,6 +34,7 @@ privacy, check out the [foundational topics](/developers/docs/foundational-topic
       <path d="M7 11V7a5 5 0 0110 0v4" />
     </svg>
   }
+  link="/developers/docs/aztec-nr/framework-description/functions/visibility"
 />
 
 <FeatureCard
@@ -45,6 +46,7 @@ privacy, check out the [foundational topics](/developers/docs/foundational-topic
       <path d="M12 6v6l4 2" />
     </svg>
   }
+  link="/developers/docs/foundational-topics/advanced/circuits/public-execution"
 />
 
 <FeatureCard
@@ -55,17 +57,19 @@ privacy, check out the [foundational topics](/developers/docs/foundational-topic
       <path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5" />
     </svg>
   }
+  link="/developers/docs/foundational-topics/pxe"
 />
 
 <FeatureCard
   title="Public State"
-  description="Maintain transparent state in a public merkle tree when required by your application."
+  description="Maintain transparent state in a public Merkle tree when required by your application."
   icon={
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
       <path d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
       <path d="M9 12l2 2 4-4" />
     </svg>
   }
+  link="/developers/docs/foundational-topics/state_management"
 />
 
 <FeatureCard
@@ -80,6 +84,7 @@ privacy, check out the [foundational topics](/developers/docs/foundational-topic
       <path d="M10 6h4M10 18h4M6 10v4M18 10v4" />
     </svg>
   }
+  link="/developers/docs/aztec-nr/framework-description/calling-contracts"
 />
 
 <FeatureCard
@@ -90,6 +95,7 @@ privacy, check out the [foundational topics](/developers/docs/foundational-topic
       <path d="M7 17l-4-4 4-4M17 7l4 4-4 4M14 3l-4 18" />
     </svg>
   }
+  link="/developers/docs/foundational-topics/ethereum-aztec-messaging"
 />
 
 </div>
@@ -148,7 +154,7 @@ privacy, check out the [foundational topics](/developers/docs/foundational-topic
 <QuickLink
   title="Run a Sequencer"
   description="Set up and operate a sequencer node"
-  link="/operate/operators/setup/sequencer_management"
+  link="/operate/operators/setup/sequencer-setup"
   icon={
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
       <rect x="2" y="3" width="20" height="14" rx="2" />
@@ -160,7 +166,7 @@ privacy, check out the [foundational topics](/developers/docs/foundational-topic
 <QuickLink
   title="Run a Prover"
   description="Contribute computational power to the network"
-  link="/operate/operators/setup/running_a_prover"
+  link="/operate/operators/setup/running-a-prover"
   icon={
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
       <path d="M22 12h-4l-3 9L9 3l-3 9H2" />


### PR DESCRIPTION
Summary                                                                                                                                          
 - Add links to all 6 FeatureCard components on the landing page, connecting them to relevant documentation pages (private/public functions, private/public state, composability, L1-L2 messaging)                                                                                            
- Fix 2 broken QuickLink paths: sequencer_management → sequencer-setup, running_a_prover → running-a-prover
- Capitalize "Merkle" in the Public State description 