### PR TITLE
fix(stdlib): accept null return_type for void Noir functions

### DIFF
--- a/yarn-project/stdlib/src/noir/index.ts
+++ b/yarn-project/stdlib/src/noir/index.ts
@@ -19,7 +19,7 @@ export const AZTEC_VIEW_ATTRIBUTE = 'abi_view';
 export interface NoirFunctionAbi {
   /** The parameters of the function. */
   parameters: ABIParameter[];
-  /** The return type of the function. */
+  /** The return type of the function, or null for void functions. */
   return_type: {
     /**
      * The type of the return value.
@@ -29,7 +29,7 @@ export interface NoirFunctionAbi {
      * The visibility of the return value.
      */
     visibility: ABIParameterVisibility;
-  };
+  } | null;
   /** Mapping of error selector => error type */
   error_types: Partial<Record<string, AbiErrorType>>;
 }


### PR DESCRIPTION
Fixing issue reproted by @just-mitch on [slack](https://aztecprotocol.slack.com/archives/C04PUD9AA4W/p1773715408859609).

## AI Summary

Fixes a TypeScript compilation error when running `aztec-builder codegen` on contracts where every function is void (most notably, a blank `#[aztec] contract Main {}`).

The `#[aztec]` macro injects lifecycle functions like `process_message` and `sync_state` into every contract. These are void, so the Noir compiler outputs `"return_type": null` for them. Our `NoirFunctionAbi` type only accepted a non-null object for `return_type`, which caused a type error on the `as NoirCompiledContract` cast in the generated TS.

For contracts with at least one non-void function, TypeScript infers the JSON array element type as a union (`null | { abi_type, visibility }`), which has enough overlap with the expected type for the `as` cast to succeed. But when *every* function is void, the inferred type is just `null` — zero overlap — so the cast fails.

The runtime code in `contract_artifact.ts` already handled the `null` case correctly. Only the type definition was out of sync with the compiler's actual output.

Repro: https://github.com/just-mitch/mytoken

## Test plan

- Verified `yarn build` passes with no new type errors
- Cloned the repro, confirmed the TS error, patched `node_modules/@aztec/stdlib` with the fix, confirmed clean compilation

🤖 Generated with [Claude Code](https://claude.com/claude-code)