### PR TITLE
fix: batch checkpoint unwinding in handleEpochPrune (A-690)

### DIFF
--- a/yarn-project/archiver/src/modules/l1_synchronizer.ts
+++ b/yarn-project/archiver/src/modules/l1_synchronizer.ts
@@ -3,6 +3,7 @@ import { EpochCache } from '@aztec/epoch-cache';
 import { InboxContract, RollupContract } from '@aztec/ethereum/contracts';
 import type { L1BlockId } from '@aztec/ethereum/l1-types';
 import type { ViemPublicClient, ViemPublicDebugClient } from '@aztec/ethereum/types';
+import { asyncPool } from '@aztec/foundation/async-pool';
 import { maxBigint } from '@aztec/foundation/bigint';
 import { BlockNumber, CheckpointNumber, EpochNumber } from '@aztec/foundation/branded-types';
 import { Buffer32 } from '@aztec/foundation/buffer';
@@ -336,25 +337,17 @@ export class ArchiverL1Synchronizer implements Traceable {
       // Fetch checkpoints and blocks in bounded batches to avoid unbounded concurrent
       // promises when the gap between local pending and proven checkpoint numbers is large.
       const BATCH_SIZE = 10;
-      const newBlocks = [];
-      for (let offset = 0; offset < checkpointsToUnwind; offset += BATCH_SIZE) {
-        const batchSize = Math.min(BATCH_SIZE, checkpointsToUnwind - offset);
-        const checkpoints = (
-          await Promise.all(
-            Array.from({ length: batchSize }, (_, i) =>
-              this.store.getCheckpointData(CheckpointNumber(offset + i + pruneFrom)),
-            ),
-          )
-        ).filter(isDefined);
-
-        const batchBlocks = (
-          await Promise.all(
-            checkpoints.map(cp => this.store.getBlocksForCheckpoint(CheckpointNumber(cp.checkpointNumber))),
-          )
-        ).filter(isDefined);
-
-        newBlocks.push(...batchBlocks.flat());
-      }
+      const indices = Array.from({ length: checkpointsToUnwind }, (_, i) => CheckpointNumber(i + pruneFrom));
+      const checkpoints = (await asyncPool(BATCH_SIZE, indices, idx => this.store.getCheckpointData(idx))).filter(
+        isDefined,
+      );
+      const newBlocks = (
+        await asyncPool(BATCH_SIZE, checkpoints, cp =>
+          this.store.getBlocksForCheckpoint(CheckpointNumber(cp.checkpointNumber)),
+        )
+      )
+        .filter(isDefined)
+        .flat();
 
       // Emit an event for listening services to react to the chain prune
       this.events.emit(L2BlockSourceEvents.L2PruneUnproven, {

--- a/yarn-project/archiver/src/modules/l1_synchronizer.ts
+++ b/yarn-project/archiver/src/modules/l1_synchronizer.ts
@@ -333,17 +333,28 @@ export class ArchiverL1Synchronizer implements Traceable {
 
       const checkpointsToUnwind = localPendingCheckpointNumber - provenCheckpointNumber;
 
-      const checkpointPromises = Array.from({ length: checkpointsToUnwind })
-        .fill(0)
-        .map((_, i) => this.store.getCheckpointData(CheckpointNumber(i + pruneFrom)));
-      const checkpoints = await Promise.all(checkpointPromises);
+      // Fetch checkpoints and blocks in bounded batches to avoid unbounded concurrent
+      // promises when the gap between local pending and proven checkpoint numbers is large.
+      const BATCH_SIZE = 10;
+      const newBlocks = [];
+      for (let offset = 0; offset < checkpointsToUnwind; offset += BATCH_SIZE) {
+        const batchSize = Math.min(BATCH_SIZE, checkpointsToUnwind - offset);
+        const checkpoints = (
+          await Promise.all(
+            Array.from({ length: batchSize }, (_, i) =>
+              this.store.getCheckpointData(CheckpointNumber(offset + i + pruneFrom)),
+            ),
+          )
+        ).filter(isDefined);
 
-      const blockPromises = await Promise.all(
-        checkpoints
-          .filter(isDefined)
-          .map(cp => this.store.getBlocksForCheckpoint(CheckpointNumber(cp.checkpointNumber))),
-      );
-      const newBlocks = blockPromises.filter(isDefined).flat();
+        const batchBlocks = (
+          await Promise.all(
+            checkpoints.map(cp => this.store.getBlocksForCheckpoint(CheckpointNumber(cp.checkpointNumber))),
+          )
+        ).filter(isDefined);
+
+        newBlocks.push(...batchBlocks.flat());
+      }
 
       // Emit an event for listening services to react to the chain prune
       this.events.emit(L2BlockSourceEvents.L2PruneUnproven, {


### PR DESCRIPTION
## Summary
- Replace the unbounded `Promise.all` in `handleEpochPrune` with a sequential for-loop
- Prevents memory pressure when the gap between local pending and proven checkpoint numbers is large

Fixes https://linear.app/aztec-labs/issue/A-690

🤖 Generated with [Claude Code](https://claude.com/claude-code)