### PR TITLE
fix: capture txs not available error reason in proposal handler

### DIFF
--- a/yarn-project/validator-client/src/block_proposal_handler.ts
+++ b/yarn-project/validator-client/src/block_proposal_handler.ts
@@ -487,7 +487,9 @@ export class BlockProposalHandler {
   }
 
   private getReexecuteFailureReason(err: any): BlockProposalValidationFailureReason {
-    if (err instanceof ReExInitialStateMismatchError) {
+    if (err instanceof TransactionsNotAvailableError) {
+      return 'txs_not_available';
+    } else if (err instanceof ReExInitialStateMismatchError) {
       return 'initial_state_mismatch';
     } else if (err instanceof ReExStateMismatchError) {
       return 'state_mismatch';


### PR DESCRIPTION
We were reporting txs not available as an unknown error.
