### PR TITLE
fix: add non-progress guard to retrieveL1ToL2Messages loop (A-693)

### DIFF
--- a/yarn-project/archiver/src/l1/data_retrieval.ts
+++ b/yarn-project/archiver/src/l1/data_retrieval.ts
@@ -375,7 +375,13 @@ export async function retrieveL1ToL2Messages(
     }
 
     retrievedL1ToL2Messages.push(...mapLogsInboxMessage(messageSentLogs));
-    searchStartBlock = messageSentLogs.at(-1)!.l1BlockNumber + 1n;
+    const nextStartBlock = messageSentLogs.at(-1)!.l1BlockNumber + 1n;
+    if (nextStartBlock <= searchStartBlock) {
+      throw new Error(
+        `retrieveL1ToL2Messages: search did not progress (stuck at L1 block ${searchStartBlock}, range ${searchStartBlock}-${searchEndBlock})`,
+      );
+    }
+    searchStartBlock = nextStartBlock;
   }
 
   return retrievedL1ToL2Messages;


### PR DESCRIPTION
## Summary
- Add a guard in `retrieveL1ToL2Messages` to break out of the pagination loop if `searchStartBlock` doesn't advance
- Prevents infinite loop if `getMessageSentEvents` returns events that don't progress the search window

Fixes https://linear.app/aztec-labs/issue/A-693

🤖 Generated with [Claude Code](https://claude.com/claude-code)