### PR TITLE
chore: Set the vector semantic length in `handle_returndata_copy`

### DIFF
--- a/avm-transpiler/src/transpile.rs
+++ b/avm-transpiler/src/transpile.rs
@@ -711,7 +711,7 @@ fn handle_emit_public_log(
     }
 
     // The fields are a slice, and this is represented as a (length: Field, slice: HeapVector).
-    // The length field is redundant and we skipt it.
+    // The length field is redundant and we skip it.
     let (message_offset, message_size_offset) = match &inputs[1] {
         ValueOrArray::HeapVector(vec) => (vec.pointer, vec.size),
         _ => panic!("Unexpected inputs for ForeignCall::EMITPUBLICLOG: {:?}", inputs),
@@ -1508,7 +1508,14 @@ fn handle_returndata_copy(
         _ => panic!("ReturndataCopy size should be a memory address"),
     };
 
-    // We skip the first destination, which is the size of the slice.
+    // The first destination is the semantic lenght of the slice.
+    // We set it to avoid leaving the memory uninitialized.
+    let semantic_length_offset = match destinations[0] {
+        ValueOrArray::MemoryAddress(address) => address,
+        _ => panic!("ReturndataCopy semantic length should be a memory address"),
+    };
+    // The second destination is the vector data structure itself:
+    // the pointer to the contents and its size.
     let (dest_offset, write_size_here_offset) = match destinations[1] {
         ValueOrArray::HeapVector(HeapVector { pointer, size }) => (pointer, size),
         _ => panic!("ReturndataCopy destination should be a vector (slice)"),
@@ -1542,6 +1549,17 @@ fn handle_returndata_copy(
             ),
             copy_size_offset.to_u32(),
             write_size_here_offset.to_u32(),
+        ),
+        // Then we set the semantic length, which in this case also matches the input size.
+        generate_mov_instruction(
+            Some(
+                AddressingModeBuilder::default()
+                    .direct_operand(&copy_size_offset)
+                    .direct_operand(&semantic_length_offset)
+                    .build(),
+            ),
+            copy_size_offset.to_u32(),
+            semantic_length_offset.to_u32(),
         ),
     ]);
 }


### PR DESCRIPTION
Changes `handle_returndata_copy` in the AVM transpiler to set the address in `destinations[0]` to the semantic length of the returned vector; if I'm not mistaken that should be the same as the vector size in this instance. 

This is related to https://github.com/noir-lang/noir/pull/11878 : we are changing the Brillig codegen to stop ignoring the returned semantic length, which we think is the correct way to handle an audit issue related to zero-sized types. 

The linked PR implements the following behaviour for the returned semantic length:
* if it's zero, then we set it to the value we calculate based on the returned data
* if it's not zero, then we verify that it matches the value we calculate based on the returned data
* if we cannot calculate the length based on the returned data because the type is empty, then we use the semantic length as-is

We are considering an alternative where we don't treat 0 as a special default value (the 1st case), and always verify if we can (2nd case). 

The linked PR also emits an opcode _before_ the call to make sure that the memory is initialised to 0, but that's specifically to prevent any problems from the AVM skipping the destination completely. Should it be untouched during the call, it could have the same value as the memory slot had on the stack from a previous variable that had that slot allocated to it. This was not a problem before, because we generated opcodes to set the memory to what we calculated, ignoring whatever the AVM or JSON-RPC returned.

Once this PR is in, that defensive measure shouldn't be needed any more, and we could remove the defaulting logic as well.

I haven't found any other use of vectors in return position in oracles, but do let me know if there are 🙏 