### PR TITLE
fix(p2p): penalize peer on tx rejected by pool

### DIFF
--- a/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
+++ b/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
@@ -976,6 +976,11 @@ export class LibP2PService extends WithTracer implements P2PService {
       } else if (wasIgnored) {
         return { result: TopicValidatorResult.Ignore, obj: tx };
       } else {
+        this.logger.warn(`Gossiped tx ${txHash.toString()} unexpectedly rejected by pool`, {
+          source: source.toString(),
+          txHash: txHash.toString(),
+        });
+        this.peerManager.penalizePeer(source, PeerErrorSeverity.HighToleranceError);
         return { result: TopicValidatorResult.Reject };
       }
     };


### PR DESCRIPTION
The pool should never reject a tx that passed validation. However, in case it does, we now add a warning and penalize the peer that sent us the invalid tx.
