### PR TITLE
fix(p2p): penalize peers for errors during response reading

### DIFF
--- a/yarn-project/p2p/src/services/encoding.ts
+++ b/yarn-project/p2p/src/services/encoding.ts
@@ -9,6 +9,14 @@ import { webcrypto } from 'node:crypto';
 import { compressSync, uncompressSync } from 'snappy';
 import xxhashFactory from 'xxhash-wasm';
 
+/** Thrown when a Snappy-compressed response exceeds the allowed decompressed size. */
+export class OversizedSnappyResponseError extends Error {
+  constructor(decompressedSize: number, maxSizeKb: number) {
+    super(`Decompressed size ${decompressedSize} exceeds maximum allowed size of ${maxSizeKb}kb`);
+    this.name = 'OversizedSnappyResponseError';
+  }
+}
+
 // Load WASM
 const xxhash = await xxhashFactory();
 
@@ -86,7 +94,7 @@ export class SnappyTransform implements DataTransform {
     const { decompressedSize } = readSnappyPreamble(data);
     if (decompressedSize > maxSizeKb * 1024) {
       this.logger.warn(`Decompressed size ${decompressedSize} exceeds maximum allowed size of ${maxSizeKb}kb`);
-      throw new Error(`Decompressed size ${decompressedSize} exceeds maximum allowed size of ${maxSizeKb}kb`);
+      throw new OversizedSnappyResponseError(decompressedSize, maxSizeKb);
     }
 
     return Buffer.from(uncompressSync(data, { asBuffer: true }));

--- a/yarn-project/p2p/src/services/reqresp/reqresp.ts
+++ b/yarn-project/p2p/src/services/reqresp/reqresp.ts
@@ -16,7 +16,7 @@ import {
   IndividualReqRespTimeoutError,
   InvalidResponseError,
 } from '../../errors/reqresp.error.js';
-import { SnappyTransform } from '../encoding.js';
+import { OversizedSnappyResponseError, SnappyTransform } from '../encoding.js';
 import type { PeerScoring } from '../peer-manager/peer_scoring.js';
 import {
   DEFAULT_INDIVIDUAL_REQUEST_TIMEOUT_MS,
@@ -553,16 +553,10 @@ export class ReqResp implements ReqRespInterface {
         data: message,
       };
     } catch (e: any) {
+      // All errors (invalid status bytes, oversized snappy responses, corrupt data, etc.)
+      // are re-thrown so the caller can penalize the peer via handleResponseError.
       this.logger.debug(`Reading message failed: ${e.message}`);
-
-      let status = ReqRespStatus.UNKNOWN;
-      if (e instanceof ReqRespStatusError) {
-        status = e.status;
-      }
-
-      return {
-        status,
-      };
+      throw e;
     }
   }
 
@@ -778,6 +772,20 @@ export class ReqResp implements ReqRespInterface {
     if (e instanceof CollectiveReqRespTimeoutError || e instanceof InvalidResponseError) {
       this.logger.debug(`Non-punishable error in ${subProtocol}: ${e.message}`, logTags);
       return undefined;
+    }
+
+    // Invalid status byte: the peer sent a status byte that doesn't match any known status code.
+    // This is a protocol violation, penalize harshly.
+    if (e instanceof ReqRespStatusError) {
+      this.logger.warn(`Invalid status byte from peer ${peerId.toString()} in ${subProtocol}: ${e.message}`, logTags);
+      return PeerErrorSeverity.LowToleranceError;
+    }
+
+    // Oversized snappy response: the peer is sending data that exceeds the allowed size.
+    // This is a protocol violation that wastes bandwidth, so penalize harshly.
+    if (e instanceof OversizedSnappyResponseError) {
+      this.logger.warn(`Oversized response from peer ${peerId.toString()} in ${subProtocol}: ${e.message}`, logTags);
+      return PeerErrorSeverity.LowToleranceError;
     }
 
     return this.categorizeConnectionErrors(e, peerId, subProtocol);


### PR DESCRIPTION
## Motivation

Errors during `readMessage` (oversized snappy responses, corrupt data, etc.) were caught and silently converted to `{ status: UNKNOWN }` return values instead of re-throwing. Since `sendRequestToPeer` only calls `handleResponseError` in its own catch block, none of these errors resulted in peer penalties. The request was simply retried with another peer, allowing a malicious peer to waste bandwidth indefinitely.

## Approach

Re-throw non-protocol errors from `readMessage` so they propagate to `sendRequestToPeer`'s catch block where `handleResponseError` applies peer penalties. Additionally, introduce a dedicated `OversizedSnappyResponseError` class so oversized responses get a harsher `LowToleranceError` penalty (score -50, banned after 2 offenses) instead of falling through to the generic `HighToleranceError` catch-all.

## Changes

- **p2p (reqresp)**: Changed `readMessage` catch block to only return status for `ReqRespStatusError` and re-throw all other errors, so they reach `handleResponseError` for penalization
- **p2p (encoding)**: Added `OversizedSnappyResponseError` class for explicit categorization
- **p2p (reqresp)**: Added `OversizedSnappyResponseError` handling in `categorizeResponseError` with `LowToleranceError` severity