### PR TITLE
chore: pre-audit of AVM GetContractInstance gadget and opcode

### DIFF
--- a/barretenberg/cpp/pil/vm2/bytecode/bc_retrieval.pil
+++ b/barretenberg/cpp/pil/vm2/bytecode/bc_retrieval.pil
@@ -140,16 +140,18 @@ pol commit instance_exists; // @boolean (by lookup into contract_instance_retrie
 #[CONTRACT_INSTANCE_RETRIEVAL]
 sel {
     address,
-    current_class_id,
-    instance_exists,
+    nullifier_tree_root,
     public_data_tree_root,
-    nullifier_tree_root
+    instance_exists,
+    current_class_id
 } in contract_instance_retrieval.sel {
     contract_instance_retrieval.address,
-    contract_instance_retrieval.current_class_id,
-    contract_instance_retrieval.exists,
+    contract_instance_retrieval.nullifier_tree_root,
     contract_instance_retrieval.public_data_tree_root,
-    contract_instance_retrieval.nullifier_tree_root
+    contract_instance_retrieval.exists,
+    // Note: don't need deployer_addr for bc retrieval
+    contract_instance_retrieval.current_class_id
+    // Note: don't need init_hash for bc retrieval
 };
 
 ////////////////////////////////////////////////

--- a/barretenberg/cpp/pil/vm2/opcodes/get_contract_instance.pil
+++ b/barretenberg/cpp/pil/vm2/opcodes/get_contract_instance.pil
@@ -86,13 +86,11 @@ include "../precomputed.pil";
 
 namespace get_contract_instance;
 
-    // Selector for when this gadget is active
-    pol commit sel; // @boolean
-    sel * (1 - sel) = 0;
-
-    // No relations will be checked if this identity is satisfied.
     #[skippable_if]
     sel = 0;
+
+    pol commit sel; // @boolean
+    sel * (1 - sel) = 0;
 
     // Interface columns
     pol commit clk;
@@ -207,7 +205,7 @@ namespace get_contract_instance;
     pol commit member_write_offset;
     #[MEMBER_WRITE_OFFSET]
     member_write_offset = is_valid_writes_in_bounds * (dst_offset + 1);
-    // TODO: remove these once we can use constants in permutations
+    // Lookup constant support: Can be removed when we support constants in permutations.
     pol commit exists_tag;
     exists_tag = is_valid_writes_in_bounds * constants.MEM_TAG_U1;
     pol commit member_tag;

--- a/barretenberg/cpp/pil/vm2/opcodes/get_contract_instance.pil
+++ b/barretenberg/cpp/pil/vm2/opcodes/get_contract_instance.pil
@@ -4,80 +4,84 @@ include "../memory.pil";
 include "../precomputed.pil";
 
 /**
- * Dedicated opcode gadget for the GetContractInstance opcode.
- * It interacts with core ContractInstanceRetrieval gadget.
- * It performs write out-of-bounds checking, member enum validation,
- * contract instance retrieval, instance member selection, and two memory writes.
+ * Dedicated opcode gadget for the GetContractInstance opcode. Dispatched by execution.pil
+ * to retrieve a contract instance member and write the result to memory.
  *
- * In more detail:
- * - Performs bounds checking for dst_offset+1 using AVM_HIGHEST_MEM_ADDRESS
- * - Validates member_enum <= MAX (3)
- * - Retrieves contract instance using the shared ContractInstanceRetrieval gadget
- *   - Only does this if there are no errors (write out-of-bounds or invalid enum)
- * - Selects appropriate member based on enum (deployer/class_id/init_hash)
- * - Performs two memory writes and tag assignments (again, only if there are no errors):
- *   - exists flag (U1) at dst_offset
- *   - member value (FF) at dst_offset+1
+ * GADGET LOGIC:
+ *     - Bounds-check dst_offset+1 via #[WRITE_OUT_OF_BOUNDS_CHECK]. If dst_offset is the
+ *       maximum valid address, dst_offset+1 would be out of bounds.
+ *     - Look up member_enum in the precomputed table (#[PRECOMPUTED_INFO]) to determine
+ *       validity and which member is selected (deployer, class_id, or init_hash).
+ *       The precomputed table covers the full 8-bit range:
+ *       +-------+----------------------+-------------+-------------+--------------+
+ *       | idx   | is_valid_member_enum | is_deployer | is_class_id | is_init_hash |
+ *       +-------+----------------------+-------------+-------------+--------------+
+ *       |   0   |         1            |      1      |      0      |      0       |
+ *       |   1   |         1            |      0      |      1      |      0       |
+ *       |   2   |         1            |      0      |      0      |      1       |
+ *       |  3+   |         0            |      0      |      0      |      0       |
+ *       +-------+----------------------+-------------+-------------+--------------+
+ *     - Aggregate errors via #[ERROR_AGGREGATION]. sel_error is set when either
+ *       is_valid_writes_in_bounds or is_valid_member_enum is false.
+ *     - [no error only] Retrieve contract instance via the ContractInstanceRetrieval gadget
+ *       (#[CONTRACT_INSTANCE_RETRIEVAL]).
+ *     - [no error only] Select the member indicated by the enum (#[SELECTED_MEMBER]).
+ *     - [no error only] Write two values to memory:
+ *         - exists flag (U1) at dst_offset (#[MEM_WRITE_CONTRACT_INSTANCE_EXISTS]).
+ *         - member value (FF) at dst_offset+1 (#[MEM_WRITE_CONTRACT_INSTANCE_MEMBER]).
  *
- * Note: this gadget relies on execution to perform address resolution for address_offset and dst_offset,
- * and to perform the memory-read and tag-checking of address.
+ * PRECONDITIONS:
+ *     - Execution resolves rop[0] (address_offset) and rop[1] (dst_offset) via addressing,
+ *       ensuring dst_offset is within valid memory bounds.
+ *     - Execution reads register[0] = M[address_offset] (the contract address) from memory
+ *       and tag-checks it as FF. This gadget receives the resolved value directly.
+ *     - rop[2] (member_enum) is a U8 immediate operand, guaranteed to be 8-bit by execution.
  *
- * Opcode operands (relevant in EXECUTION when interacting with this gadget):
- * - rop[0]: address_offset (input offset operand)
- * - rop[1]: dst_offset (output offset operand)
- * - rop[2]: member_enum (immediate operand)
- * Memory I/O:
- * - register[0]: M[address_offset} aka address (input - read from memory BY EXECUTION, not here)
- *     - address is tagged-checked by execution/registers to be FF based on instruction spec.
- * - register[1]: M[dst_offset] aka exists (output - written to memory by this gadget)
- *     - tagged by this gadget to be U1.
- * - M[rop[1]+1]: M[dst_offset+1] aka memberValue (output - written to memory by this gadget)
- *     - tagged by this gadget to be FF.
+ * USAGE:
+ *     Execution dispatches into this gadget via a permutation on sel
+ *     (#[DISPATCH_TO_GET_CONTRACT_INSTANCE] in execution.pil):
  *
- * Possible errors:
- * - dst_offset+1 is an out-of-bounds memory offset.
- * - enum value is invalid (out of range).
+ *     sel_exec_dispatch_get_contract_instance {
+ *         // inputs
+ *         clk,
+ *         register[0], // contract_address
+ *         rop[1], // dst_offset
+ *         rop[2], // member_enum
+ *         context_id, // space_id
+ *         nullifier_tree_root,
+ *         public_data_tree_root,
+ *         // outputs/errors
+ *         sel_opcode_error
+ *     } is get_contract_instance.sel {
+ *         // inputs
+ *         get_contract_instance.clk,
+ *         get_contract_instance.contract_address,
+ *         get_contract_instance.dst_offset,
+ *         get_contract_instance.member_enum,
+ *         get_contract_instance.space_id,
+ *         get_contract_instance.nullifier_tree_root,
+ *         get_contract_instance.public_data_tree_root,
+ *         // outputs/errors
+ *         get_contract_instance.sel_error
+ *     };
  *
- * A precomputed table is used to retrieve the following selectors based on member_enum:
- * - is_valid_member_enum
- * - is_deployer
- * - is_class_id
- * - is_init_hash
- * +-------+----------------------+---------------+-------------+---------------+
- * |  Row  | is_valid_member_enum | is_deployer   | is_class_id | is_init_hash  |
- * | (idx) |                      |               |             |               |
- * +-------+----------------------+---------------+-------------+---------------+
- * |   0   |         1            |      1        |      0      |      0        |
- * |   1   |         1            |      0        |      1      |      0        |
- * |   2   |         1            |      0        |      0      |      1        |
- * |   3+  |         0            |      0        |      0      |      0        |
- * +-------+----------------------+---------------+-------------+---------------+
+ * TRACE SHAPE:
+ *     1 row per event. Row 0 is reserved (sel=0) for the skippable gadget optimization.
+ *     Both error and normal events produce exactly 1 row.
  *
- * Usage from execution:
+ * ERROR HANDLING:
+ *     Two error conditions, which are NOT mutually exclusive:
+ *     - Write out-of-bounds: dst_offset == AVM_HIGHEST_MEM_ADDRESS (dst_offset+1 overflows).
+ *     - Invalid member enum: member_enum >= 3 (precomputed table returns is_valid_member_enum=0).
+ *     On error, the row has sel_error=1. The contract instance retrieval lookup and memory
+ *     write permutations are disabled (their selectors is_valid_member_enum / is_valid_writes_in_bounds
+ *     are 0), so no destination interactions fire for error rows.
  *
- * sel_exec_dispatch_get_contract_instance {
- *     // inputs
- *     clk,
- *     register[0],
- *     rop[1],
- *     rop[2],
- *     context_id,
- *     context_stack.nullifier_tree_root,
- *     context_stack.public_data_tree_root,
- *     // outputs/errors
- *     sel_opcode_error
- * } is get_contract_instance.sel {
- *     // inputs
- *     get_contract_instance.clk,
- *     get_contract_instance.contract_address,
- *     get_contract_instance.dst_offset,
- *     get_contract_instance.member_enum,
- *     get_contract_instance.space_id,
- *     get_contract_instance.nullifier_tree_root,
- *     get_contract_instance.public_data_tree_root,
- *     // outputs/errors
- *     get_contract_instance.sel_error
- * };
+ * INTERACTIONS:
+ *     - precomputed.pil: Member enum validation and selector lookup (#[PRECOMPUTED_INFO])
+ *     - contract_instance_retrieval.pil: Instance retrieval (#[CONTRACT_INSTANCE_RETRIEVAL])
+ *     - memory.pil: Write exists flag to M[dst_offset] (#[MEM_WRITE_CONTRACT_INSTANCE_EXISTS])
+ *     - memory.pil: Write member value to M[dst_offset+1] (#[MEM_WRITE_CONTRACT_INSTANCE_MEMBER])
  */
 
 namespace get_contract_instance;

--- a/barretenberg/cpp/pil/vm2/opcodes/get_contract_instance.pil
+++ b/barretenberg/cpp/pil/vm2/opcodes/get_contract_instance.pil
@@ -1,4 +1,7 @@
 include "../bytecode/contract_instance_retrieval.pil";
+include "../constants_gen.pil";
+include "../memory.pil";
+include "../precomputed.pil";
 
 /**
  * Dedicated opcode gadget for the GetContractInstance opcode.

--- a/barretenberg/cpp/pil/vm2/opcodes/get_contract_instance.pil
+++ b/barretenberg/cpp/pil/vm2/opcodes/get_contract_instance.pil
@@ -114,12 +114,18 @@ namespace get_contract_instance;
     is_valid_writes_in_bounds * (1 - is_valid_writes_in_bounds) = 0;
     pol WRITES_OUT_OF_BOUNDS = 1 - is_valid_writes_in_bounds;
     pol DST_OFFSET_DIFF_MAX = constants.AVM_HIGHEST_MEM_ADDRESS - dst_offset;
-    pol commit dst_offset_diff_max_inv;
+    pol commit dst_offset_diff_max_inv; // @zero-check
+    // See https://github.com/AztecProtocol/aztec-packages/blob/next/barretenberg/cpp/pil/vm2/docs/recipes.md#with-error-support.
     #[WRITE_OUT_OF_BOUNDS_CHECK]
     sel * (DST_OFFSET_DIFF_MAX * (WRITES_OUT_OF_BOUNDS * (1 - dst_offset_diff_max_inv) + dst_offset_diff_max_inv) - 1 + WRITES_OUT_OF_BOUNDS) = 0;
 
     // Member selection helper columns
     // (from precomputed.pil's GETCONTRACTINSTANCE opcode precomputed columns)
+    // These are constrained only via the #[PRECOMPUTED_INFO] lookup when is_valid_writes_in_bounds == 1.
+    // When the lookup is disabled (writes out of bounds), is_valid_member_enum is forced to 0 by
+    // #[IS_VALID_MEMBER_ENUM_ONLY_SET_BY_PRECOMPUTED_LOOKUP]. is_deployer/is_class_id/is_init_hash
+    // are free in that case, but safe: they are only consumed in #[SELECTED_MEMBER] and the memory
+    // write permutations, all of which are gated on is_valid_member_enum (which is 0).
     pol commit is_valid_member_enum; // @boolean (by lookup when is_valid_writes_in_bounds == 1)
     pol commit is_deployer; // @boolean (by lookup when is_valid_writes_in_bounds == 1)
     pol commit is_class_id; // @boolean (by lookup when is_valid_writes_in_bounds == 1)
@@ -159,7 +165,10 @@ namespace get_contract_instance;
     #[ERROR_AGGREGATION]
     sel_error = sel * (1 - is_valid_writes_in_bounds * is_valid_member_enum);
 
-    // Retrieved instance members and existence (from lookup to the core instance retrieval gadget)
+    // Retrieved instance members and existence (from lookup to the core instance retrieval gadget).
+    // These are constrained only via #[CONTRACT_INSTANCE_RETRIEVAL] when is_valid_member_enum == 1.
+    // When the lookup is disabled (error), these columns are free, but safe: they are only consumed
+    // in #[SELECTED_MEMBER] and the memory write permutations, all gated on is_valid_member_enum.
     pol commit instance_exists;
     pol commit retrieved_deployer_addr;
     pol commit retrieved_class_id;

--- a/barretenberg/cpp/pil/vm2/opcodes/get_contract_instance.pil
+++ b/barretenberg/cpp/pil/vm2/opcodes/get_contract_instance.pil
@@ -228,8 +228,7 @@ namespace get_contract_instance;
         memory.tag,
         memory.rw
     };
-    // TODO(dbanks12): consider reusing a single memory permutation for both writes,
-    // or do the first write in execution (after returning `exists` to execution).
+
     #[MEM_WRITE_CONTRACT_INSTANCE_MEMBER]
     is_valid_member_enum {
         clk,

--- a/barretenberg/cpp/src/barretenberg/vm2/generated/relations/lookups_bc_retrieval.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/generated/relations/lookups_bc_retrieval.hpp
@@ -23,17 +23,17 @@ struct lookup_bc_retrieval_contract_instance_retrieval_settings_ {
     static constexpr Column INVERSES = Column::lookup_bc_retrieval_contract_instance_retrieval_inv;
     static constexpr std::array<ColumnAndShifts, LOOKUP_TUPLE_SIZE> SRC_COLUMNS = {
         ColumnAndShifts::bc_retrieval_address,
-        ColumnAndShifts::bc_retrieval_current_class_id,
-        ColumnAndShifts::bc_retrieval_instance_exists,
+        ColumnAndShifts::bc_retrieval_nullifier_tree_root,
         ColumnAndShifts::bc_retrieval_public_data_tree_root,
-        ColumnAndShifts::bc_retrieval_nullifier_tree_root
+        ColumnAndShifts::bc_retrieval_instance_exists,
+        ColumnAndShifts::bc_retrieval_current_class_id
     };
     static constexpr std::array<ColumnAndShifts, LOOKUP_TUPLE_SIZE> DST_COLUMNS = {
         ColumnAndShifts::contract_instance_retrieval_address,
-        ColumnAndShifts::contract_instance_retrieval_current_class_id,
-        ColumnAndShifts::contract_instance_retrieval_exists,
+        ColumnAndShifts::contract_instance_retrieval_nullifier_tree_root,
         ColumnAndShifts::contract_instance_retrieval_public_data_tree_root,
-        ColumnAndShifts::contract_instance_retrieval_nullifier_tree_root
+        ColumnAndShifts::contract_instance_retrieval_exists,
+        ColumnAndShifts::contract_instance_retrieval_current_class_id
     };
 };
 

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/events/get_contract_instance_event.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/events/get_contract_instance_event.hpp
@@ -18,20 +18,20 @@ struct GetContractInstanceException : public std::runtime_error {
 
 struct GetContractInstanceEvent {
     // Interface columns
-    uint32_t execution_clk;
-    AztecAddress contract_address;
-    MemoryAddress dst_offset;
-    uint8_t member_enum;
-    uint16_t space_id;
-    FF nullifier_tree_root;
-    FF public_data_tree_root;
+    uint32_t execution_clk = 0;
+    AztecAddress contract_address = 0;
+    MemoryAddress dst_offset = 0;
+    uint8_t member_enum = 0;
+    uint16_t space_id = 0;
+    FF nullifier_tree_root = 0;
+    FF public_data_tree_root = 0;
 
     // Instance retrieval results including all three members which are all needed for tracegen
     // despite only needing the selected member in simulation.
-    bool instance_exists;
-    FF retrieved_deployer_addr;
-    FF retrieved_class_id;
-    FF retrieved_init_hash;
+    bool instance_exists = false;
+    FF retrieved_deployer_addr = 0;
+    FF retrieved_class_id = 0;
+    FF retrieved_init_hash = 0;
 };
 
 } // namespace bb::avm2::simulation

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/get_contract_instance.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/get_contract_instance.cpp
@@ -6,9 +6,19 @@
 
 #include "barretenberg/vm2/common/aztec_constants.hpp"
 #include "barretenberg/vm2/common/stringify.hpp"
+#include "barretenberg/vm2/common/uint1.hpp"
+#include "barretenberg/vm2/simulation/interfaces/memory.hpp"
 
 namespace bb::avm2::simulation {
 
+/**
+ * @brief Construct a GetContractInstance gadget with its dependencies.
+ *
+ * @param execution_id_manager Provides monotonic execution clock values for event ordering.
+ * @param merkle_db High-level Merkle database for reading tree state (roots).
+ * @param event_emitter Emitter for GetContractInstanceEvent used by tracegen.
+ * @param instance_manager Manager that retrieves (and caches) contract instances from the world state.
+ */
 GetContractInstance::GetContractInstance(ExecutionIdManagerInterface& execution_id_manager,
                                          HighLevelMerkleDBInterface& merkle_db,
                                          EventEmitterInterface<GetContractInstanceEvent>& event_emitter,
@@ -19,6 +29,20 @@ GetContractInstance::GetContractInstance(ExecutionIdManagerInterface& execution_
     , instance_manager(instance_manager)
 {}
 
+/**
+ * @brief Retrieve a contract instance member and write the result to memory.
+ *
+ * Validates that dst_offset+1 is in bounds and that member_enum is valid, then retrieves the
+ * contract instance via the ContractInstanceManager. Writes the existence flag (U1) to dst_offset
+ * and the selected member value (FF) to dst_offset+1.
+ *
+ * @param memory The memory interface for the current context.
+ * @param contract_address The address of the contract to look up.
+ * @param dst_offset The memory offset at which to write the exists flag.
+ * @param member_enum The enum selecting which instance member to retrieve (deployer/class_id/init_hash).
+ * @throws GetContractInstanceException If dst_offset+1 is out of bounds (checked first).
+ * @throws GetContractInstanceException If member_enum is invalid (checked after bounds check).
+ */
 void GetContractInstance::get_contract_instance(MemoryInterface& memory,
                                                 const AztecAddress& contract_address,
                                                 MemoryAddress dst_offset,
@@ -74,6 +98,14 @@ void GetContractInstance::get_contract_instance(MemoryInterface& memory,
     event_emitter.emit(std::move(event));
 }
 
+/**
+ * @brief Write the contract instance existence flag and member value to memory.
+ *
+ * @param memory The memory interface for the current context.
+ * @param dst_offset The memory offset at which to write the exists flag (U1).
+ * @param exists Whether the contract instance was found.
+ * @param member_value The selected member value to write at dst_offset+1 (FF).
+ */
 void GetContractInstance::write_results(MemoryInterface& memory,
                                         MemoryAddress dst_offset,
                                         bool exists,
@@ -85,6 +117,14 @@ void GetContractInstance::write_results(MemoryInterface& memory,
     memory.set(dst_offset + 1, MemoryValue::from<FF>(member_value));
 }
 
+/**
+ * @brief Select a contract instance member by enum value.
+ *
+ * @param instance The contract instance to select from.
+ * @param member_enum The enum value identifying which member to return.
+ * @return The field value of the selected member.
+ * @throws std::runtime_error If member_enum is not a valid ContractInstanceMember (should be unreachable).
+ */
 FF GetContractInstance::select_instance_member(const ContractInstance& instance, uint8_t member_enum)
 {
     switch (static_cast<ContractInstanceMember>(member_enum)) {

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/get_contract_instance.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/get_contract_instance.cpp
@@ -49,53 +49,58 @@ void GetContractInstance::get_contract_instance(MemoryInterface& memory,
                                                 uint8_t member_enum)
 {
     const auto& tree_state = merkle_db.get_tree_state();
-    GetContractInstanceEvent event{
-        .execution_clk = execution_id_manager.get_execution_id(),
-        .contract_address = contract_address,
-        .dst_offset = dst_offset,
-        .member_enum = member_enum,
-        .space_id = memory.get_space_id(),
-        .nullifier_tree_root = tree_state.nullifier_tree.tree.root,
-        .public_data_tree_root = tree_state.public_data_tree.tree.root,
-    };
+    const auto execution_clk = execution_id_manager.get_execution_id();
+    const auto space_id = memory.get_space_id();
+    const auto& nullifier_tree_root = tree_state.nullifier_tree.tree.root;
+    const auto& public_data_tree_root = tree_state.public_data_tree.tree.root;
 
     // Memory bounds checking for dst_offset+1
     // Note that execution does address resolution for dst_offset, so we already
     // know that dst_offset is in bounds.
     // So, the only scenario when dstOffset+1 can be out of bounds is if dstOffset == MAX address.
     if (dst_offset == AVM_HIGHEST_MEM_ADDRESS) {
-        event_emitter.emit(std::move(event));
+        event_emitter.emit({ .execution_clk = execution_clk,
+                             .contract_address = contract_address,
+                             .dst_offset = dst_offset,
+                             .member_enum = member_enum,
+                             .space_id = space_id,
+                             .nullifier_tree_root = nullifier_tree_root,
+                             .public_data_tree_root = public_data_tree_root });
         throw GetContractInstanceException("Write dst out of range: " + field_to_string(dst_offset));
     }
 
     // Member enum validation
     if (member_enum > static_cast<uint8_t>(ContractInstanceMember::MAX)) {
-        event_emitter.emit(std::move(event));
+        event_emitter.emit({ .execution_clk = execution_clk,
+                             .contract_address = contract_address,
+                             .dst_offset = dst_offset,
+                             .member_enum = member_enum,
+                             .space_id = space_id,
+                             .nullifier_tree_root = nullifier_tree_root,
+                             .public_data_tree_root = public_data_tree_root });
         throw GetContractInstanceException("Invalid member enum: " + std::to_string(member_enum));
     }
 
     // Retrieve contract instance using shared ContractInstanceManager
-    auto maybe_instance = instance_manager.get_contract_instance(event.contract_address);
-    bool instance_exists = maybe_instance.has_value();
-    event.instance_exists = instance_exists;
+    auto maybe_instance = instance_manager.get_contract_instance(contract_address);
+    const bool instance_exists = maybe_instance.has_value();
 
-    // Extract all member values for event (even if we only use one for the memory write)
-    // This is needed for the PIL gadget trace generation which includes all retrieved members
-    FF selected_member_value = 0; // default if instance does not exist
-    if (instance_exists) {
-        const auto& instance = maybe_instance.value();
-        event.retrieved_deployer_addr = instance.deployer;
-        event.retrieved_class_id = instance.current_contract_class_id;
-        event.retrieved_init_hash = instance.initialization_hash;
-
-        // Select the requested member based on the enum
-        selected_member_value = select_instance_member(instance, member_enum);
-    }
-
-    // Perform two memory writes
+    // Select the requested member and write results to memory
+    const FF selected_member_value =
+        instance_exists ? select_instance_member(maybe_instance.value(), member_enum) : FF(0);
     write_results(memory, dst_offset, instance_exists, selected_member_value);
 
-    event_emitter.emit(std::move(event));
+    event_emitter.emit({ .execution_clk = execution_clk,
+                         .contract_address = contract_address,
+                         .dst_offset = dst_offset,
+                         .member_enum = member_enum,
+                         .space_id = space_id,
+                         .nullifier_tree_root = nullifier_tree_root,
+                         .public_data_tree_root = public_data_tree_root,
+                         .instance_exists = instance_exists,
+                         .retrieved_deployer_addr = instance_exists ? maybe_instance->deployer : FF(0),
+                         .retrieved_class_id = instance_exists ? maybe_instance->current_contract_class_id : FF(0),
+                         .retrieved_init_hash = instance_exists ? maybe_instance->initialization_hash : FF(0) });
 }
 
 /**

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/get_contract_instance.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/get_contract_instance.cpp
@@ -1,15 +1,11 @@
 #include "barretenberg/vm2/simulation/gadgets/get_contract_instance.hpp"
 
-#include <cassert>
-#include <cstdint>
 #include <stdexcept>
+#include <string>
+#include <utility>
 
 #include "barretenberg/vm2/common/aztec_constants.hpp"
-#include "barretenberg/vm2/common/aztec_types.hpp"
-#include "barretenberg/vm2/common/field.hpp"
-#include "barretenberg/vm2/common/memory_types.hpp"
 #include "barretenberg/vm2/common/stringify.hpp"
-#include "barretenberg/vm2/simulation/events/get_contract_instance_event.hpp"
 
 namespace bb::avm2::simulation {
 

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/get_contract_instance.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/get_contract_instance.hpp
@@ -7,8 +7,8 @@
 #include "barretenberg/vm2/common/memory_types.hpp"
 #include "barretenberg/vm2/simulation/events/event_emitter.hpp"
 #include "barretenberg/vm2/simulation/events/get_contract_instance_event.hpp"
-#include "barretenberg/vm2/simulation/gadgets/contract_instance_manager.hpp"
-#include "barretenberg/vm2/simulation/gadgets/memory.hpp"
+#include "barretenberg/vm2/simulation/interfaces/contract_instance_manager.hpp"
+#include "barretenberg/vm2/simulation/interfaces/db.hpp"
 #include "barretenberg/vm2/simulation/interfaces/get_contract_instance.hpp"
 #include "barretenberg/vm2/simulation/lib/execution_id_manager.hpp"
 

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/lib/get_contract_instance_spec.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/lib/get_contract_instance_spec.cpp
@@ -3,7 +3,15 @@
 
 namespace bb::avm2::tracegen {
 
-// See ASCII table in `get_contract_instance.pil` for reference.
+/**
+ * @brief Look up the precomputed table entry for a given member enum value.
+ *
+ * Returns boolean selectors indicating whether the enum is valid and which member it selects.
+ * See the ASCII table in get_contract_instance.pil for the full mapping.
+ *
+ * @param member_enum The member enum value (0=deployer, 1=class_id, 2=init_hash, 3+=invalid).
+ * @return A Table struct with is_valid_member_enum and the per-member selector flags.
+ */
 GetContractInstanceSpec::Table GetContractInstanceSpec::get_table(uint8_t member_enum)
 {
     // default for invalid enum

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/lib/get_contract_instance_spec.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/lib/get_contract_instance_spec.hpp
@@ -2,8 +2,6 @@
 
 #include <cstdint>
 
-#include "barretenberg/vm2/common/aztec_types.hpp"
-
 namespace bb::avm2::tracegen {
 
 class GetContractInstanceSpec {

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/opcodes/get_contract_instance_trace.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/opcodes/get_contract_instance_trace.cpp
@@ -1,19 +1,13 @@
 #include "barretenberg/vm2/tracegen/opcodes/get_contract_instance_trace.hpp"
 
-#include <cstddef>
 #include <cstdint>
 
 #include "barretenberg/vm2/common/aztec_constants.hpp"
-#include "barretenberg/vm2/common/aztec_types.hpp"
-#include "barretenberg/vm2/common/constants.hpp"
-#include "barretenberg/vm2/common/memory_types.hpp"
+#include "barretenberg/vm2/common/field.hpp"
 #include "barretenberg/vm2/common/tagged_value.hpp"
 #include "barretenberg/vm2/generated/columns.hpp"
 #include "barretenberg/vm2/generated/relations/lookups_get_contract_instance.hpp"
-#include "barretenberg/vm2/simulation/events/event_emitter.hpp"
-#include "barretenberg/vm2/simulation/events/get_contract_instance_event.hpp"
 #include "barretenberg/vm2/tracegen/lib/get_contract_instance_spec.hpp"
-#include "barretenberg/vm2/tracegen/lib/interaction_def.hpp"
 
 namespace bb::avm2::tracegen {
 

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/opcodes/get_contract_instance_trace.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/opcodes/get_contract_instance_trace.cpp
@@ -13,6 +13,19 @@ namespace bb::avm2::tracegen {
 
 using C = Column;
 
+/**
+ * @brief Process the GetContractInstance events and populate the relevant columns in the trace.
+ *
+ * Events are emitted in the following flavors:
+ * - Out-of-bounds error: dst_offset == AVM_HIGHEST_MEM_ADDRESS. Instance retrieval fields are
+ *   unpopulated (defaults). Event is emitted before the exception is thrown.
+ * - Invalid enum error: member_enum > MAX. Instance retrieval fields are unpopulated (defaults).
+ *   Event is emitted before the exception is thrown.
+ * - Normal execution: all fields populated including instance_exists and retrieved member values.
+ *
+ * @param events Container of GetContractInstanceEvent to process.
+ * @param trace The trace container to populate.
+ */
 void GetContractInstanceTraceBuilder::process(
     const simulation::EventEmitterInterface<simulation::GetContractInstanceEvent>::Container& events,
     TraceContainer& trace)

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/opcodes/get_contract_instance_trace.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/opcodes/get_contract_instance_trace.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "barretenberg/vm2/generated/columns.hpp"
 #include "barretenberg/vm2/simulation/events/event_emitter.hpp"
 #include "barretenberg/vm2/simulation/events/get_contract_instance_event.hpp"
 #include "barretenberg/vm2/tracegen/lib/interaction_def.hpp"


### PR DESCRIPTION
Mostly just cleanup and standard pre-audit steps.

Also went and reordered `bc_retrieval`'s tuple in its lookup to `contract_instance_retrieval` to align with that gadget's usage comment (a forgotten step from `contract_instance_retrieval` pre-audit).