### PR TITLE
chore: fixing build on mac

### DIFF
--- a/barretenberg/cpp/cmake/arch.cmake
+++ b/barretenberg/cpp/cmake/arch.cmake
@@ -5,18 +5,13 @@ if(WASM)
     add_compile_options(-fno-exceptions -fno-slp-vectorize)
 endif()
 
-# Auto-detect TARGET_ARCH if not explicitly set (native builds only).
-# Use 'skylake' on x86_64 (matches our cross-compile presets) and 'generic' on ARM
-# to avoid emitting CPU-specific instructions (e.g. SVE on Graviton) that break on
-# other ARM machines like Apple Silicon.
+# Auto-detect TARGET_ARCH on x86_64 if not explicitly set (native builds only).
+# On ARM, we skip -march entirely — the zig wrappers use an explicit aarch64 target
+# to produce generic ARM64 code without CPU-specific extensions (e.g. SVE).
 # Skip auto-detection when cross-compiling — the toolchain (e.g. Zig -mcpu) handles
 # architecture targeting, and injecting -march here conflicts with it.
-if(NOT WASM AND NOT TARGET_ARCH AND NOT CMAKE_CROSSCOMPILING)
-    if(ARM)
-        set(TARGET_ARCH "generic")
-    else()
-        set(TARGET_ARCH "skylake")
-    endif()
+if(NOT WASM AND NOT TARGET_ARCH AND NOT ARM AND NOT CMAKE_CROSSCOMPILING)
+    set(TARGET_ARCH "skylake")
 endif()
 
 if(NOT WASM AND TARGET_ARCH)

--- a/barretenberg/cpp/scripts/zig-c++.sh
+++ b/barretenberg/cpp/scripts/zig-c++.sh
@@ -1,10 +1,15 @@
 #!/bin/bash
 # Wrapper for zig c++ that pins glibc 2.35 on Linux (Ubuntu 22.04+ compat)
 # and uses native target on macOS.
-# Note: arch.cmake handles -march selection (skylake on x86, generic on ARM)
-# which overrides zig's native CPU detection, preventing CPU-specific instructions.
+# On ARM64 Linux, use an explicit aarch64 target instead of 'native' to produce
+# generic ARM64 code. This prevents CPU-specific instructions (e.g. SVE on Graviton)
+# from being emitted, ensuring binaries work across all ARM64 machines including
+# Apple Silicon in devcontainers.
 if [[ "$(uname -s)" == "Linux" ]]; then
-  exec zig c++ -target native-linux-gnu.2.35 "$@"
+  case "$(uname -m)" in
+    aarch64|arm64) exec zig c++ -target aarch64-linux-gnu.2.35 "$@" ;;
+    *)             exec zig c++ -target native-linux-gnu.2.35 "$@" ;;
+  esac
 else
   exec zig c++ "$@"
 fi

--- a/barretenberg/cpp/scripts/zig-cc.sh
+++ b/barretenberg/cpp/scripts/zig-cc.sh
@@ -1,10 +1,15 @@
 #!/bin/bash
 # Wrapper for zig cc that pins glibc 2.35 on Linux (Ubuntu 22.04+ compat)
 # and uses native target on macOS.
-# Note: arch.cmake handles -march selection (skylake on x86, generic on ARM)
-# which overrides zig's native CPU detection, preventing CPU-specific instructions.
+# On ARM64 Linux, use an explicit aarch64 target instead of 'native' to produce
+# generic ARM64 code. This prevents CPU-specific instructions (e.g. SVE on Graviton)
+# from being emitted, ensuring binaries work across all ARM64 machines including
+# Apple Silicon in devcontainers.
 if [[ "$(uname -s)" == "Linux" ]]; then
-  exec zig cc -target native-linux-gnu.2.35 "$@"
+  case "$(uname -m)" in
+    aarch64|arm64) exec zig cc -target aarch64-linux-gnu.2.35 "$@" ;;
+    *)             exec zig cc -target native-linux-gnu.2.35 "$@" ;;
+  esac
 else
   exec zig cc "$@"
 fi


### PR DESCRIPTION
# fix: ARM64 devcontainer builds — skip `-march` on ARM and use explicit zig aarch64 target

## Summary

Fixes SIGILL (Illegal Instruction) crashes and build failures on ARM64 Mac (M3/Apple Silicon) devcontainers caused by incorrect `-march` handling introduced in #21611.

## Problem

PR #21611 originally fixed ARM64 devcontainer builds by using explicit `aarch64-linux-gnu.2.35` zig targets. During the merge, that approach was replaced with cmake-based auto-detection that sets `TARGET_ARCH=generic` on ARM and passes `-march=generic` to the compiler. This caused two distinct failures:

### 1. SIGILL crashes (`Illegal instruction`)

The zig compiler wrappers still used `-target native-linux-gnu.2.35`, which auto-detects the host CPU. On CI (AWS Graviton with SVE extensions), this produces binaries containing SVE instructions. These cached binaries are then downloaded on Apple Silicon devcontainers (ARM64 without SVE), causing SIGILL when executed — e.g. `honk_solidity_key_gen` crashing during `barretenberg/sol` bootstrap.

The `-march=generic` flag was supposed to override this, but `-march=generic` is **not a valid value on aarch64**. It's an x86 concept. LLVM/zig silently ignored it, so the native CPU detection still produced SVE instructions.

### 2. Build failures (`unknown CPU: 'armv8'`)

Even attempting `-march=armv8-a` (a valid GCC/Clang aarch64 value) fails because zig uses its own CPU naming scheme (e.g. `generic`, `cortex_a72`, `apple_m3`), not GCC-style architecture strings. Zig interprets `-march=armv8-a` as CPU name `armv8`, which doesn't exist → `error: unknown CPU: 'armv8'`.

**Bottom line:** The `-march` cmake approach fundamentally doesn't work with zig on ARM. Zig has its own architecture targeting via `-target`, which is the correct mechanism.

## What this PR changes

### 1. `arch.cmake` — Skip `-march` auto-detection on ARM

Removed the ARM branch from the auto-detection. On x86_64, we still auto-detect `TARGET_ARCH=skylake`. On ARM, we don't set `TARGET_ARCH` at all, so no `-march` flag is passed — the zig wrappers handle architecture targeting instead.

### 2. `zig-cc.sh` / `zig-c++.sh` — Explicit aarch64 target on ARM Linux

Restored the original fix from #21611 that was dropped during merge. On ARM64 Linux, the wrappers now use `-target aarch64-linux-gnu.2.35` instead of `-target native-linux-gnu.2.35`. This produces generic ARM64 code without CPU-specific extensions (SVE, etc.), ensuring cached binaries work on all ARM64 machines — Graviton, Apple Silicon, Ampere, etc.

x86_64 behavior is unchanged (still uses `-target native`).

## Context: what happened after #21611

After #21611 merged with the cmake auto-detection approach, it triggered a cascade of follow-up PRs trying to fix the fallout:

| PR | Status | Issue |
|----|--------|-------|
| #21621 | Merged | Introduced the auto-detect approach (replaced zig wrapper fix with cmake `-march`) |
| #21356 | Merged | Added `NOT CMAKE_CROSSCOMPILING` guard for cross-compile failures |
| #21637 | Open | Attempting to fix cross-compiles + restore `native_build_dir` |
| #21660 | Open | Attempting to fix cross-compile targets |
| #21632 | Open | Attempting to fix cross-compile targets |
| #21662 | Open | Adding `CMAKE_SYSTEM_PROCESSOR` to ARM64 cross-compile presets |
| #21653 | Open | Attempting to skip auto-detection when cross-compiling |
| #21655 | Open | Attempting to skip auto-detection for cross-compilation targets |

This PR supersedes the still-open PRs above by addressing the root cause: `-march` via cmake doesn't work with zig on ARM. The zig `-target` mechanism is the correct approach.
