### PR TITLE
fix: process all contract classes in storeBroadcastedIndividualFunctions (A-683)

### DIFF
--- a/yarn-project/archiver/src/modules/data_store_updater.ts
+++ b/yarn-project/archiver/src/modules/data_store_updater.ts
@@ -457,7 +457,7 @@ export class ArchiverDataStoreUpdater {
       if (validFnCount > 0) {
         this.log.verbose(`Storing ${validFnCount} functions for contract class ${contractClassId.toString()}`);
       }
-      return await this.store.addFunctions(contractClassId, validPrivateFns, validUtilityFns);
+      await this.store.addFunctions(contractClassId, validPrivateFns, validUtilityFns);
     }
     return true;
   }


### PR DESCRIPTION
Remove early return in for...of loop that caused only the first contract class's functions to be stored when multiple classes had broadcasts in the same block.

Fixes https://linear.app/aztec-labs/issue/A-683