### PR TITLE
fix: HA deadlock for last block edge case

### DIFF
--- a/yarn-project/stdlib/src/p2p/checkpoint_proposal.ts
+++ b/yarn-project/stdlib/src/p2p/checkpoint_proposal.ts
@@ -178,29 +178,32 @@ export class CheckpointProposal extends Gossipable {
       blockNumber: lastBlockInfo?.blockHeader?.globalVariables.blockNumber ?? BlockNumber(0),
       dutyType: DutyType.CHECKPOINT_PROPOSAL,
     };
-    const checkpointSignature = await payloadSigner(checkpointHash, checkpointContext);
 
-    if (!lastBlockInfo) {
-      return new CheckpointProposal(checkpointHeader, archiveRoot, feeAssetPriceModifier, checkpointSignature);
+    if (lastBlockInfo) {
+      // Sign block proposal before signing checkpoint proposal to ensure HA protection
+      const lastBlockProposal = await BlockProposal.createProposalFromSigner(
+        lastBlockInfo.blockHeader,
+        lastBlockInfo.indexWithinCheckpoint,
+        checkpointHeader.inHash,
+        archiveRoot,
+        lastBlockInfo.txHashes,
+        lastBlockInfo.txs,
+        payloadSigner,
+      );
+
+      const checkpointSignature = await payloadSigner(checkpointHash, checkpointContext);
+
+      return new CheckpointProposal(checkpointHeader, archiveRoot, feeAssetPriceModifier, checkpointSignature, {
+        blockHeader: lastBlockInfo.blockHeader,
+        indexWithinCheckpoint: lastBlockInfo.indexWithinCheckpoint,
+        txHashes: lastBlockInfo.txHashes,
+        signature: lastBlockProposal.signature,
+        signedTxs: lastBlockProposal.signedTxs,
+      });
     }
 
-    const lastBlockProposal = await BlockProposal.createProposalFromSigner(
-      lastBlockInfo.blockHeader,
-      lastBlockInfo.indexWithinCheckpoint,
-      checkpointHeader.inHash,
-      archiveRoot,
-      lastBlockInfo.txHashes,
-      lastBlockInfo.txs,
-      payloadSigner,
-    );
-
-    return new CheckpointProposal(checkpointHeader, archiveRoot, feeAssetPriceModifier, checkpointSignature, {
-      blockHeader: lastBlockInfo.blockHeader,
-      indexWithinCheckpoint: lastBlockInfo.indexWithinCheckpoint,
-      txHashes: lastBlockInfo.txHashes,
-      signature: lastBlockProposal.signature,
-      signedTxs: lastBlockProposal.signedTxs,
-    });
+    const checkpointSignature = await payloadSigner(checkpointHash, checkpointContext);
+    return new CheckpointProposal(checkpointHeader, archiveRoot, feeAssetPriceModifier, checkpointSignature);
   }
 
   /**


### PR DESCRIPTION
change ordering for `lastBlock` case when creating a checkpoint proposal, so that we first sign the last block and then the checkpoint