### PR TITLE
feat: split bb.js into arch-specific npm packages

### DIFF
--- a/aztec-up/bootstrap.sh
+++ b/aztec-up/bootstrap.sh
@@ -78,6 +78,15 @@ EOF
     version=0.0.1
     # TODO(AD): we have kludged a retry here. a local NPM install ought to be robust enough not to.
     echo "Deploying packages to local npm registry (version: $version)..."
+
+    # Publish bb.js arch-specific packages first (must exist before the wrapper's optionalDependencies resolve).
+    $root/barretenberg/ts/scripts/prepare_arch_packages.sh
+    for pkg in $root/barretenberg/ts/packages/bb.js-*/; do
+      [ -d "$pkg" ] || continue
+      (cd "$pkg" && retry "deploy_npm latest $version" >/dev/null)
+    done
+
+    # Then publish everything else (including the bb.js wrapper).
     {
       echo $root/barretenberg/ts
       $root/noir/bootstrap.sh get_projects

--- a/barretenberg/ts/.gitignore
+++ b/barretenberg/ts/.gitignore
@@ -12,3 +12,4 @@ package
 
 # Generated files
 src/cbind/generated/
+packages/

--- a/barretenberg/ts/bootstrap.sh
+++ b/barretenberg/ts/bootstrap.sh
@@ -64,6 +64,13 @@ function test {
 
 function release {
   cross_copy
+  ./scripts/prepare_arch_packages.sh
+  # Publish arch-specific packages first (the wrapper's optionalDependencies must already exist).
+  for pkg in packages/bb.js-*/; do
+    [ -d "$pkg" ] || continue
+    (cd "$pkg" && retry "deploy_npm $(dist_tag) ${REF_NAME#v}")
+  done
+  # Then publish the wrapper package.
   retry "deploy_npm $(dist_tag) ${REF_NAME#v}"
 }
 

--- a/barretenberg/ts/package.json
+++ b/barretenberg/ts/package.json
@@ -19,7 +19,6 @@
   "files": [
     "src/",
     "dest/",
-    "build/",
     "README.md"
   ],
   "scripts": {
@@ -64,6 +63,12 @@
     ],
     "testRegex": "./src/.*\\.test\\.ts$",
     "rootDir": "./src"
+  },
+  "optionalDependencies": {
+    "@aztec/bb.js-linux-x64": "0.1.0",
+    "@aztec/bb.js-linux-arm64": "0.1.0",
+    "@aztec/bb.js-darwin-x64": "0.1.0",
+    "@aztec/bb.js-darwin-arm64": "0.1.0"
   },
   "dependencies": {
     "comlink": "^4.4.1",

--- a/barretenberg/ts/package.json
+++ b/barretenberg/ts/package.json
@@ -64,12 +64,6 @@
     "testRegex": "./src/.*\\.test\\.ts$",
     "rootDir": "./src"
   },
-  "optionalDependencies": {
-    "@aztec/bb.js-linux-x64": "0.1.0",
-    "@aztec/bb.js-linux-arm64": "0.1.0",
-    "@aztec/bb.js-darwin-x64": "0.1.0",
-    "@aztec/bb.js-darwin-arm64": "0.1.0"
-  },
   "dependencies": {
     "comlink": "^4.4.1",
     "commander": "^12.1.0",

--- a/barretenberg/ts/scripts/prepare_arch_packages.sh
+++ b/barretenberg/ts/scripts/prepare_arch_packages.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Generates architecture-specific npm packages from cross-compiled binaries.
+# Each package contains only the native bb binary and nodejs_module.node for one platform.
+# These are published as optionalDependencies of @aztec/bb.js so users only download
+# the binaries for their platform.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+# Mapping: build_dir → npm_package_suffix os cpu
+declare -A PLATFORMS=(
+  ["amd64-linux"]="linux-x64 linux x64"
+  ["arm64-linux"]="linux-arm64 linux arm64"
+  ["amd64-macos"]="darwin-x64 darwin x64"
+  ["arm64-macos"]="darwin-arm64 darwin arm64"
+)
+
+# Read version from the wrapper package.json
+version=$(jq -r '.version' package.json)
+
+for build_dir in "${!PLATFORMS[@]}"; do
+  read -r suffix os cpu <<< "${PLATFORMS[$build_dir]}"
+  pkg_name="@aztec/bb.js-${suffix}"
+  out_dir="packages/bb.js-${suffix}"
+
+  # Skip if no binaries exist for this platform
+  if [ ! -d "build/${build_dir}" ]; then
+    echo "Skipping ${pkg_name}: no build/${build_dir} directory"
+    continue
+  fi
+
+  echo "Preparing ${pkg_name} from build/${build_dir}..."
+  rm -rf "${out_dir}"
+  mkdir -p "${out_dir}"
+
+  # Copy native binaries
+  cp "build/${build_dir}/bb" "${out_dir}/bb" 2>/dev/null || true
+  cp "build/${build_dir}/nodejs_module.node" "${out_dir}/nodejs_module.node" 2>/dev/null || true
+
+  # Generate package.json
+  cat > "${out_dir}/package.json" <<EOF
+{
+  "name": "${pkg_name}",
+  "version": "${version}",
+  "description": "Native binaries for @aztec/bb.js (${suffix})",
+  "license": "MIT",
+  "os": ["${os}"],
+  "cpu": ["${cpu}"],
+  "files": ["bb", "nodejs_module.node"],
+  "preferUnplugged": true
+}
+EOF
+
+  echo "  → ${out_dir}/ ready"
+done
+
+echo "Architecture packages prepared."

--- a/barretenberg/ts/src/bb_backends/node/platform.ts
+++ b/barretenberg/ts/src/bb_backends/node/platform.ts
@@ -1,6 +1,7 @@
 import * as path from 'path';
 import * as fs from 'fs';
 import { fileURLToPath } from 'url';
+import { createRequire } from 'module';
 
 function getCurrentDir() {
   if (typeof __dirname !== 'undefined') {
@@ -14,7 +15,6 @@ function getCurrentDir() {
 
 /**
  * Find package root by climbing directory tree until package.json is found.
- * @param startDir Starting directory to search from
  * @returns Absolute path to package root, or null if not found
  */
 export function findPackageRoot(): string | null {
@@ -24,10 +24,12 @@ export function findPackageRoot(): string | null {
   while (currentDir !== root) {
     const packageJsonPath = path.join(currentDir, 'package.json');
     if (fs.existsSync(packageJsonPath)) {
-      // Check if this is the actual package root by verifying it has a 'build' directory
-      // This ensures we skip intermediate package.json files (e.g., in dest/node-cjs/)
+      // Check if this is the actual package root by verifying it has a 'build' or 'dest' directory.
+      // 'build' exists in local dev; 'dest' exists in published packages (which no longer ship 'build').
+      // This ensures we skip intermediate package.json files (e.g., in dest/node-cjs/).
       const buildDir = path.join(currentDir, 'build');
-      if (fs.existsSync(buildDir)) {
+      const destDir = path.join(currentDir, 'dest');
+      if (fs.existsSync(buildDir) || fs.existsSync(destDir)) {
         return currentDir;
       }
     }
@@ -43,7 +45,7 @@ export function findPackageRoot(): string | null {
 export type Platform = 'x86_64-linux' | 'x86_64-darwin' | 'aarch64-linux' | 'aarch64-darwin';
 
 /**
- * Map from Platform to build directory name.
+ * Map from Platform to build directory name (for local dev fallback).
  */
 const PLATFORM_TO_BUILD_DIR: Record<Platform, string> = {
   'x86_64-linux': 'amd64-linux',
@@ -51,6 +53,31 @@ const PLATFORM_TO_BUILD_DIR: Record<Platform, string> = {
   'aarch64-linux': 'arm64-linux',
   'aarch64-darwin': 'arm64-macos',
 };
+
+/**
+ * Map from Platform to the architecture-specific npm package name.
+ */
+const PLATFORM_TO_PACKAGE: Record<Platform, string> = {
+  'x86_64-linux': '@aztec/bb.js-linux-x64',
+  'x86_64-darwin': '@aztec/bb.js-darwin-x64',
+  'aarch64-linux': '@aztec/bb.js-linux-arm64',
+  'aarch64-darwin': '@aztec/bb.js-darwin-arm64',
+};
+
+/**
+ * Try to find the directory of the architecture-specific npm package.
+ * Uses require.resolve to locate the package regardless of hoisting or PnP.
+ */
+function findArchPackageDir(platform: Platform): string | null {
+  const packageName = PLATFORM_TO_PACKAGE[platform];
+  try {
+    const require = createRequire(getCurrentDir() + '/');
+    const pkgJsonPath = require.resolve(`${packageName}/package.json`);
+    return path.dirname(pkgJsonPath);
+  } catch {
+    return null;
+  }
+}
 
 /**
  * Detect the current platform and architecture.
@@ -77,80 +104,54 @@ export function detectPlatform(): Platform | null {
 }
 
 /**
- * Find the bb binary for the native backend.
- * @param customPath Optional custom path to bb binary (overrides automatic detection)
- * @returns Absolute path to bb binary, or null if not found
+ * Find a native binary by name, searching arch-specific packages first, then local build/.
  *
  * Search order:
  * 1. If customPath is provided and exists, return it
- * 2. Otherwise search in <package-root>/build/<platform>/bb
+ * 2. Architecture-specific npm package (e.g., @aztec/bb.js-linux-x64)
+ * 3. Local build directory fallback (for local development)
  */
-export function findBbBinary(customPath?: string): string | null {
-  // Check custom path first if provided
+function findNativeBinary(binaryName: string, customPath?: string): string | null {
   if (customPath) {
-    if (fs.existsSync(customPath)) {
-      return path.resolve(customPath);
-    }
-    // Custom path provided but doesn't exist - return null
-    return null;
+    return fs.existsSync(customPath) ? path.resolve(customPath) : null;
   }
 
-  // Automatic detection
   const platform = detectPlatform();
   if (!platform) {
     return null;
   }
 
-  const buildDir = PLATFORM_TO_BUILD_DIR[platform];
-
-  // Get package root by climbing directory tree to find package.json
-  const packageRoot = findPackageRoot();
-
-  if (!packageRoot) {
-    return null;
+  // Try arch-specific npm package first
+  const archDir = findArchPackageDir(platform);
+  if (archDir) {
+    const binPath = path.join(archDir, binaryName);
+    if (fs.existsSync(binPath)) {
+      return binPath;
+    }
   }
 
-  // Check in build/<platform>/bb
-  const bbPath = path.join(packageRoot, 'build', buildDir, 'bb');
-
-  if (fs.existsSync(bbPath)) {
-    return bbPath;
+  // Fall back to local build/ directory (local development)
+  const packageRoot = findPackageRoot();
+  if (packageRoot) {
+    const buildDir = PLATFORM_TO_BUILD_DIR[platform];
+    const binPath = path.join(packageRoot, 'build', buildDir, binaryName);
+    if (fs.existsSync(binPath)) {
+      return binPath;
+    }
   }
 
   return null;
 }
 
+/**
+ * Find the bb binary for the native backend.
+ * @param customPath Optional custom path to bb binary (overrides automatic detection)
+ * @returns Absolute path to bb binary, or null if not found
+ */
+export function findBbBinary(customPath?: string): string | null {
+  return findNativeBinary('bb', customPath);
+}
+
 export function findNapiBinary(customPath?: string): string | null {
-  // Check custom path first if provided
-  if (customPath) {
-    if (fs.existsSync(customPath)) {
-      return path.resolve(customPath);
-    }
-    // Custom path provided but doesn't exist - return null
-    return null;
-  }
-
-  // Automatic detection
-  const platform = detectPlatform();
-  if (!platform) {
-    return null;
-  }
-
-  const buildDir = PLATFORM_TO_BUILD_DIR[platform];
-
-  // Get package root by climbing directory tree to find package.json
-  const packageRoot = findPackageRoot();
-
-  if (!packageRoot) {
-    return null;
-  }
-
-  // Check in build/<platform>/nodejs_module.node
-  const bbPath = path.join(packageRoot, 'build', buildDir, 'nodejs_module.node');
-
-  if (fs.existsSync(bbPath)) {
-    return bbPath;
-  }
-
-  return null;
+  return findNativeBinary('nodejs_module.node', customPath);
 }

--- a/barretenberg/ts/src/bin/index.ts
+++ b/barretenberg/ts/src/bin/index.ts
@@ -5,7 +5,11 @@ import { spawnSync } from 'node:child_process';
 const bin = findBbBinary();
 
 if (!bin) {
-  console.error('Could not find bb binary. Please ensure it is built and accessible.');
+  console.error(
+    'Could not find bb binary for your platform.\n' +
+      'Ensure the platform-specific package is installed (e.g., @aztec/bb.js-linux-x64),\n' +
+      'or build from source with: yarn build:native',
+  );
   process.exit(1);
 }
 

--- a/ci3/release_prep_package_json
+++ b/ci3/release_prep_package_json
@@ -9,7 +9,7 @@ jq --arg v $version '.version = $v' package.json >$tmp && mv $tmp package.json
 
 # We update every category of dependency.
 # While we don't strictly need to update devDependencies, 'workspace:^' is not a valid URL in npm.
-for deps in dependencies devDependencies peerDependencies; do
+for deps in dependencies devDependencies peerDependencies optionalDependencies; do
   # Update each dependency @aztec package version in package.json.
   for pkg in $(jq --raw-output "(.$deps // {}) | keys[] | select(contains(\"@aztec/\"))" package.json); do
     jq --arg v $version ".$deps[\"$pkg\"] = \$v" package.json >$tmp

--- a/ci3/release_prep_package_json
+++ b/ci3/release_prep_package_json
@@ -7,6 +7,20 @@ tmp=$(mktemp)
 
 jq --arg v $version '.version = $v' package.json >$tmp && mv $tmp package.json
 
+# For @aztec/bb.js, inject optionalDependencies for arch-specific binary packages.
+# These aren't in the source package.json (they'd break yarn install in dev/CI since the
+# packages only exist on npm after a release). They're injected here at publish time so that
+# end users' package managers download only their platform's native binaries.
+package_name=$(jq -r '.name' package.json)
+if [ "$package_name" = "@aztec/bb.js" ]; then
+  jq --arg v "$version" '.optionalDependencies = {
+    "@aztec/bb.js-linux-x64": $v,
+    "@aztec/bb.js-linux-arm64": $v,
+    "@aztec/bb.js-darwin-x64": $v,
+    "@aztec/bb.js-darwin-arm64": $v
+  }' package.json >$tmp && mv $tmp package.json
+fi
+
 # We update every category of dependency.
 # While we don't strictly need to update devDependencies, 'workspace:^' is not a valid URL in npm.
 for deps in dependencies devDependencies peerDependencies optionalDependencies; do


### PR DESCRIPTION
## Summary

- Ships `@aztec/bb.js` native binaries as separate per-platform packages (`@aztec/bb.js-linux-x64`, `@aztec/bb.js-linux-arm64`, `@aztec/bb.js-darwin-x64`, `@aztec/bb.js-darwin-arm64`) using the `optionalDependencies` pattern (same as esbuild, swc, etc.)
- The wrapper `@aztec/bb.js` drops from ~170MB to ~17MB (JS + WASM only); npm/yarn/pnpm only download the matching platform's binaries
- Platform detection in `platform.ts` resolves binaries from the arch package first, falls back to local `build/` for dev
- Release pipeline and aztec-up Verdaccio setup updated to publish arch packages before the wrapper

## Test plan

- [ ] Verify `npm pack` in `barretenberg/ts/` excludes `build/` directory
- [ ] Verify `prepare_arch_packages.sh` generates correct package dirs with binaries
- [ ] Verify `findBbBinary()` resolves from both arch package and `build/` fallback
- [ ] Verify aztec-up Verdaccio tests install the correct arch package
- [ ] Verify WASM fallback still works when no arch package is installed