### PR TITLE
chore!: Make `is_less_than` range-check stricter

### DIFF
--- a/barretenberg/cpp/scripts/test_chonk_standalone_vks_havent_changed.sh
+++ b/barretenberg/cpp/scripts/test_chonk_standalone_vks_havent_changed.sh
@@ -16,7 +16,7 @@ script_path="$root/barretenberg/cpp/scripts/test_chonk_standalone_vks_havent_cha
 # - Generate a hash for versioning: sha256sum bb-chonk-inputs.tar.gz
 # - Upload the compressed results: aws s3 cp bb-chonk-inputs.tar.gz s3://aztec-ci-artifacts/protocol/bb-chonk-inputs-[hash(0:8)].tar.gz
 # Note: In case of the "Test suite failed to run ... Unexpected token 'with' " error, need to run: docker pull aztecprotocol/build:3.0
-pinned_short_hash="4fbbe231"
+pinned_short_hash="a7fe72e1"
 pinned_chonk_inputs_url="https://aztec-ci-artifacts.s3.us-east-2.amazonaws.com/protocol/bb-chonk-inputs-${pinned_short_hash}.tar.gz"
 
 function update_pinned_hash_in_script {

--- a/barretenberg/cpp/scripts/test_chonk_standalone_vks_havent_changed.sh
+++ b/barretenberg/cpp/scripts/test_chonk_standalone_vks_havent_changed.sh
@@ -16,7 +16,7 @@ script_path="$root/barretenberg/cpp/scripts/test_chonk_standalone_vks_havent_cha
 # - Generate a hash for versioning: sha256sum bb-chonk-inputs.tar.gz
 # - Upload the compressed results: aws s3 cp bb-chonk-inputs.tar.gz s3://aztec-ci-artifacts/protocol/bb-chonk-inputs-[hash(0:8)].tar.gz
 # Note: In case of the "Test suite failed to run ... Unexpected token 'with' " error, need to run: docker pull aztecprotocol/build:3.0
-pinned_short_hash="831712f6"
+pinned_short_hash="4fbbe231"
 pinned_chonk_inputs_url="https://aztec-ci-artifacts.s3.us-east-2.amazonaws.com/protocol/bb-chonk-inputs-${pinned_short_hash}.tar.gz"
 
 function update_pinned_hash_in_script {

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/gate_count_constants.hpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/gate_count_constants.hpp
@@ -34,9 +34,9 @@ template <typename Builder> inline constexpr size_t AES128_ENCRYPTION = 1559 + Z
 // overlap with the values added for ECCVM. secp256k1 uses table of size 16 whose indices contain all the 4 values
 // set for ECCVM (hence the same value for Ultra and Mega builders). secp256r1 uses ROM tables of size 4, which
 // contain only 2 of the values set for ECCVM (hence the difference of two gates between Ultra and Mega builders).
-template <typename Builder> inline constexpr size_t ECDSA_SECP256K1 = 42839 + ZERO_GATE;
+template <typename Builder> inline constexpr size_t ECDSA_SECP256K1 = 42837 + ZERO_GATE;
 template <typename Builder>
-inline constexpr size_t ECDSA_SECP256R1 = 72614 + ZERO_GATE + (IsMegaBuilder<Builder> ? 2 : 0);
+inline constexpr size_t ECDSA_SECP256R1 = 72612 + ZERO_GATE + (IsMegaBuilder<Builder> ? 2 : 0);
 
 template <typename Builder> inline constexpr size_t BLAKE2S = 2952 + ZERO_GATE + MEGA_OFFSET<Builder>;
 template <typename Builder> inline constexpr size_t BLAKE3 = 2158 + ZERO_GATE + MEGA_OFFSET<Builder>;

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.test.cpp
@@ -2617,6 +2617,11 @@ TYPED_TEST(stdlib_bigfield, less_than_works)
 
     // c_ct > modulus fails comparison but doesn't make the circuit fail
     std::vector<uint8_t> c_bytes(32, 0xff);
+    if constexpr (std::is_same_v<TypeParam, typename bb::stdlib::bn254<UltraCircuitBuilder>::BaseField>) {
+        // For bn254, NUM_LAST_LIMB_BITS = 50, so we need to set the first byte to something bigger than 0x30 (the first
+        // byte of the modulus) that still fits in 50 bits
+        c_bytes[0] = 0x31;
+    }
     byte_array_ct c_byte_array = byte_array_ct(&builder, c_bytes);
     fq_ct reconstructed_from_bytes(c_byte_array);
     auto is_not_ok_larger_than_modulus = reconstructed_from_bytes.is_less_than(fq_ct::modulus);

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
@@ -1886,7 +1886,8 @@ bool_t<Builder> bigfield<Builder, T>::is_less_than(const uint256_t& upper_limit,
     const uint256_t upper_limit_value_0 = upper_limit.slice(0, NUM_LIMB_BITS);
     const uint256_t upper_limit_value_1 = upper_limit.slice(NUM_LIMB_BITS, NUM_LIMB_BITS * 2);
     const uint256_t upper_limit_value_2 = upper_limit.slice(NUM_LIMB_BITS * 2, NUM_LIMB_BITS * 3);
-    const uint256_t upper_limit_value_3 = upper_limit.slice(NUM_LIMB_BITS * 3, NUM_LAST_LIMB_BITS);
+    const uint256_t upper_limit_value_3 =
+        upper_limit.slice(NUM_LIMB_BITS * 3, (NUM_LIMB_BITS * 3) + NUM_LAST_LIMB_BITS);
 
     bool_t<Builder> third_limb_is_smaller = binary_basis_limbs[3].element.template ranged_less_than<NUM_LAST_LIMB_BITS>(
         field_t<Builder>(upper_limit_value_3));

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
@@ -1880,16 +1880,16 @@ bool_t<Builder> bigfield<Builder, T>::is_less_than(const uint256_t& upper_limit,
     ctx->range_constrain_two_limbs(binary_basis_limbs[2].element.get_witness_index(),
                                    binary_basis_limbs[3].element.get_witness_index(),
                                    static_cast<size_t>(NUM_LIMB_BITS),
-                                   static_cast<size_t>(NUM_LIMB_BITS),
+                                   static_cast<size_t>(NUM_LAST_LIMB_BITS),
                                    is_default_msg ? "bigfield::is_less_than: limb 2 or 3 too large" : msg);
 
     const uint256_t upper_limit_value_0 = upper_limit.slice(0, NUM_LIMB_BITS);
     const uint256_t upper_limit_value_1 = upper_limit.slice(NUM_LIMB_BITS, NUM_LIMB_BITS * 2);
     const uint256_t upper_limit_value_2 = upper_limit.slice(NUM_LIMB_BITS * 2, NUM_LIMB_BITS * 3);
-    const uint256_t upper_limit_value_3 = upper_limit.slice(NUM_LIMB_BITS * 3, NUM_LIMB_BITS * 4);
+    const uint256_t upper_limit_value_3 = upper_limit.slice(NUM_LIMB_BITS * 3, NUM_LAST_LIMB_BITS);
 
-    bool_t<Builder> third_limb_is_smaller =
-        binary_basis_limbs[3].element.template ranged_less_than<NUM_LIMB_BITS>(field_t<Builder>(upper_limit_value_3));
+    bool_t<Builder> third_limb_is_smaller = binary_basis_limbs[3].element.template ranged_less_than<NUM_LAST_LIMB_BITS>(
+        field_t<Builder>(upper_limit_value_3));
     bool_t<Builder> third_limb_is_equal = binary_basis_limbs[3].element == field_t<Builder>(upper_limit_value_3);
 
     bool_t<Builder> second_limb_is_smaller =


### PR DESCRIPTION
In the bigfield function `is_less_than` we range constrain the last limb to fit in `NUM_LAST_LIMB_BITS`, this is a stricter range constraint than the one used previously.