### PR TITLE
chore: replace dead BOOTSTRAP_TO env var with bootstrap.sh build arg

### DIFF
--- a/.claude/skills/backport/SKILL.md
+++ b/.claude/skills/backport/SKILL.md
@@ -147,7 +147,7 @@ git diff --name-only | grep -v '^yarn-project/' || true
 
 If changes exist outside yarn-project, run bootstrap from the repo root:
 ```bash
-BOOTSTRAP_TO=yarn-project ./bootstrap.sh
+./bootstrap.sh build yarn-project
 ```
 
 Fix any build errors that arise from the backport adaptation.

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -827,7 +827,7 @@ case "$cmd" in
   "ci-docs")
     export CI=1
     export USE_TEST_CACHE=1
-    BOOTSTRAP_TO=yarn-project ./bootstrap.sh
+    ./bootstrap.sh build yarn-project
     docs/bootstrap.sh ci
     ;;
   "ci-barretenberg-debug")

--- a/container-builds/avm-fuzzing-container/src/Dockerfile
+++ b/container-builds/avm-fuzzing-container/src/Dockerfile
@@ -32,7 +32,7 @@ RUN git clone https://github.com/AztecProtocol/aztec-packages.git --depth 1 --br
 WORKDIR /root/aztec-packages
 
 # Run bootstrap up to yarn-project (release-image needs docker which isn't available)
-RUN BOOTSTRAP_TO=yarn-project ./bootstrap.sh
+RUN ./bootstrap.sh build yarn-project
 
 # Build the tx fuzzer
 WORKDIR /root/aztec-packages/barretenberg/cpp

--- a/yarn-project/.claude/skills/fix-pr/SKILL.md
+++ b/yarn-project/.claude/skills/fix-pr/SKILL.md
@@ -69,7 +69,7 @@ git diff origin/<base-branch>...HEAD --name-only | grep -v '^yarn-project/'
 
 If yes, run bootstrap:
 ```bash
-(cd $(git rev-parse --show-toplevel) && BOOTSTRAP_TO=yarn-project ./bootstrap.sh)
+(cd $(git rev-parse --show-toplevel) && ./bootstrap.sh build yarn-project)
 ```
 
 ### Phase 4: Fix Based on Failure Type

--- a/yarn-project/.claude/skills/rebase-pr/SKILL.md
+++ b/yarn-project/.claude/skills/rebase-pr/SKILL.md
@@ -69,7 +69,7 @@ git diff origin/<base-branch>...HEAD --name-only | grep -v '^yarn-project/'
 
 If yes, run bootstrap from repo root:
 ```bash
-(cd $(git rev-parse --show-toplevel) && BOOTSTRAP_TO=yarn-project ./bootstrap.sh)
+(cd $(git rev-parse --show-toplevel) && ./bootstrap.sh build yarn-project)
 ```
 
 ### Step 5: Verify Build

--- a/yarn-project/CLAUDE.md
+++ b/yarn-project/CLAUDE.md
@@ -54,7 +54,7 @@ Git commands work from any subdirectory of a repo—there is no need to `cd` to 
 - Rebasing on a branch that has changes outside `yarn-project`
 
 ```bash
-(cd $(git rev-parse --show-toplevel) && BOOTSTRAP_TO=yarn-project ./bootstrap.sh)
+(cd $(git rev-parse --show-toplevel) && ./bootstrap.sh build yarn-project)
 ```
 
 Bootstrap takes several minutes to run. Be patient.


### PR DESCRIPTION
## Motivation

`BOOTSTRAP_TO=yarn-project ./bootstrap.sh` was used in several places to build up to yarn-project, but the env var is no longer read by any code — it became dead after the Makefile introduction. Running it just runs a full `./bootstrap.sh` ignoring the variable entirely.

## Approach

Replace all occurrences with `./bootstrap.sh build yarn-project`, which calls `prep` (submodule update + toolchain checks) then `make yarn-project`.

## Changes

- **bootstrap.sh**: Replace in `ci-docs` case
- **container-builds/avm-fuzzing-container/src/Dockerfile**: Replace in build step
- **yarn-project/CLAUDE.md**: Update developer instructions
- **.claude/skills/{backport,fix-pr,rebase-pr}**: Update skill instructions