### PR TITLE
fix(sequencer): extract gas and blob configs from valid requests only (A-677)

### DIFF
--- a/yarn-project/sequencer-client/src/publisher/sequencer-publisher.test.ts
+++ b/yarn-project/sequencer-client/src/publisher/sequencer-publisher.test.ts
@@ -519,6 +519,54 @@ describe('SequencerPublisher', () => {
     expect((publisher as any).requests.length).toEqual(0);
   });
 
+  it('does not include gas config from expired requests', async () => {
+    const currentL2Slot = publisher.getCurrentL2Slot();
+
+    // Add an expired request with a gas config
+    publisher.addRequest({
+      action: 'vote-offenses',
+      request: {
+        to: mockRollupAddress,
+        data: encodeFunctionData({
+          abi: EmpireBaseAbi,
+          functionName: 'signal',
+          args: [EthAddress.random().toString()],
+        }),
+      },
+      lastValidL2Slot: SlotNumber(1), // expired
+      gasConfig: { gasLimit: 500_000n },
+      checkSuccess: () => true,
+    });
+
+    // Add a valid request with a gas config
+    publisher.addRequest({
+      action: 'propose',
+      request: {
+        to: mockRollupAddress,
+        data: encodeFunctionData({
+          abi: EmpireBaseAbi,
+          functionName: 'signal',
+          args: [EthAddress.random().toString()],
+        }),
+      },
+      lastValidL2Slot: SlotNumber(Number(currentL2Slot) + 10), // valid
+      gasConfig: { gasLimit: 100_000n },
+      checkSuccess: () => true,
+    });
+
+    forwardSpy.mockResolvedValue({
+      receipt: proposeTxReceipt,
+      errorMsg: undefined,
+    });
+
+    await publisher.sendRequests();
+
+    expect(forwardSpy).toHaveBeenCalledTimes(1);
+    // The gas config should only include the valid request's gas (100_000), not the expired one (500_000)
+    const txConfig = forwardSpy.mock.calls[0][2];
+    expect(txConfig?.gasLimit).toEqual(100_000n);
+  });
+
   it('does not signal for payload when quorum is reached', async () => {
     const { govPayload } = mockGovernancePayload();
 

--- a/yarn-project/sequencer-client/src/publisher/sequencer-publisher.ts
+++ b/yarn-project/sequencer-client/src/publisher/sequencer-publisher.ts
@@ -399,8 +399,8 @@ export class SequencerPublisher {
     // @note - we can only have one blob config per bundle
     // find requests with gas and blob configs
     // See https://github.com/AztecProtocol/aztec-packages/issues/11513
-    const gasConfigs = requestsToProcess.filter(request => request.gasConfig).map(request => request.gasConfig);
-    const blobConfigs = requestsToProcess.filter(request => request.blobConfig).map(request => request.blobConfig);
+    const gasConfigs = validRequests.filter(request => request.gasConfig).map(request => request.gasConfig);
+    const blobConfigs = validRequests.filter(request => request.blobConfig).map(request => request.blobConfig);
 
     if (blobConfigs.length > 1) {
       throw new Error('Multiple blob configs found');


### PR DESCRIPTION
## Motivation

The `sendRequests` method in the sequencer publisher correctly filters L1 publish requests by `lastValidL2Slot` to discard expired ones. However, gas and blob configs were extracted from the unfiltered request list, meaning expired requests' gas configurations leaked into the aggregated gas limit calculation. This could over-estimate gas and overpay for L1 transactions.

Fixes A-677

## Approach

Changed the gas and blob config extraction to use the filtered `validRequests` list instead of the unfiltered `requestsToProcess` list, so only non-expired requests contribute to the aggregated gas limit.

## Changes

- **sequencer-client**: Use `validRequests` instead of `requestsToProcess` when extracting `gasConfigs` and `blobConfigs` in `sendRequests`
- **sequencer-client (tests)**: Added test verifying that expired requests' gas configs are excluded from the aggregated gas limit