### PR TITLE
feat: cli-wallet

### DIFF
--- a/yarn-project/cli-wallet/src/cmds/create_account.ts
+++ b/yarn-project/cli-wallet/src/cmds/create_account.ts
@@ -1,12 +1,12 @@
 import { NO_FROM } from '@aztec/aztec.js/account';
 import { AztecAddress } from '@aztec/aztec.js/addresses';
 import { NO_WAIT } from '@aztec/aztec.js/contracts';
-import type { AztecNode } from '@aztec/aztec.js/node';
+import { type AztecNode, waitForTx } from '@aztec/aztec.js/node';
 import type { DeployAccountOptions } from '@aztec/aztec.js/wallet';
 import { prettyPrintJSON } from '@aztec/cli/cli-utils';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import type { LogFn, Logger } from '@aztec/foundation/log';
-import type { TxHash, TxReceipt } from '@aztec/stdlib/tx';
+import { type TxHash, type TxReceipt, TxStatus } from '@aztec/stdlib/tx';
 
 import { DEFAULT_TX_TIMEOUT_S } from '../utils/cli_wallet_and_node_wrapper.js';
 import type { AccountType } from '../utils/constants.js';
@@ -19,6 +19,7 @@ export async function createAccount(
   aztecNode: AztecNode,
   accountType: AccountType,
   secretKey: Fr | undefined,
+  salt: Fr | undefined,
   publicKey: string | undefined,
   alias: string | undefined,
   deployer: AztecAddress | undefined,
@@ -28,6 +29,7 @@ export async function createAccount(
   registerClass: boolean,
   wait: boolean,
   feeOpts: CLIFeeArgs,
+  waitForStatus: TxStatus,
   json: boolean,
   verbose: boolean,
   debugLogger: Logger,
@@ -39,10 +41,10 @@ export async function createAccount(
     undefined /* address, we don't have it yet */,
     secretKey,
     accountType,
-    Fr.ZERO,
+    salt,
     publicKey,
   );
-  const { salt } = account.getInstance();
+  const instanceSalt = account.getInstance().salt;
   const { address, publicKeys, partialAddress } = await account.getCompleteAddress();
 
   const out: Record<string, any> = {};
@@ -53,7 +55,7 @@ export async function createAccount(
       out.secretKey = secretKey;
     }
     out.partialAddress = partialAddress;
-    out.salt = salt;
+    out.salt = instanceSalt;
     out.initHash = account.getInstance().initializationHash;
   } else {
     log(`\nNew account:\n`);
@@ -63,7 +65,7 @@ export async function createAccount(
       log(`Secret key:     ${secretKey.toString()}`);
     }
     log(`Partial address: ${partialAddress.toString()}`);
-    log(`Salt:            ${salt.toString()}`);
+    log(`Salt:            ${instanceSalt.toString()}`);
     log(`Init hash:       ${account.getInstance().initializationHash.toString()}`);
   }
 
@@ -83,6 +85,7 @@ export async function createAccount(
       fee: { paymentMethod, gasSettings },
     };
 
+    const localStart = performance.now();
     const deployMethod = await account.getDeployMethod();
     const sim = await deployMethod.simulate({
       ...deployAccountOpts,
@@ -122,19 +125,24 @@ export async function createAccount(
             }
           : undefined,
       };
+
+      ({ txHash } = await deployMethod.send({ ...sendOpts, wait: NO_WAIT }));
+      const localTimeMs = performance.now() - localStart;
+
       if (wait) {
-        const { receipt } = await deployMethod.send({
-          ...sendOpts,
-          wait: { timeout: DEFAULT_TX_TIMEOUT_S, returnReceipt: true },
-        });
-        txReceipt = receipt;
-        txHash = receipt.txHash;
+        const nodeStart = performance.now();
+        txReceipt = await waitForTx(aztecNode, txHash, { timeout: DEFAULT_TX_TIMEOUT_S, waitForStatus });
+        const nodeTimeMs = performance.now() - nodeStart;
+
         out.txReceipt = {
           status: txReceipt.status,
           transactionFee: txReceipt.transactionFee,
         };
-      } else {
-        ({ txHash } = await deployMethod.send({ ...sendOpts, wait: NO_WAIT }));
+
+        if (!json) {
+          log(` Local processing time: ${(localTimeMs / 1000).toFixed(1)}s`);
+          log(` Node inclusion time: ${(nodeTimeMs / 1000).toFixed(1)}s`);
+        }
       }
       debugLogger.debug(`Account contract tx sent with hash ${txHash.toString()}`);
       out.txHash = txHash;
@@ -152,5 +160,5 @@ export async function createAccount(
     }
   }
 
-  return { alias, address, secretKey, salt };
+  return { alias, address, secretKey, salt: instanceSalt };
 }

--- a/yarn-project/cli-wallet/src/cmds/deploy.ts
+++ b/yarn-project/cli-wallet/src/cmds/deploy.ts
@@ -4,11 +4,12 @@ import type { DeployOptions } from '@aztec/aztec.js/contracts';
 import { NO_WAIT } from '@aztec/aztec.js/contracts';
 import { ContractDeployer } from '@aztec/aztec.js/deployment';
 import { Fr } from '@aztec/aztec.js/fields';
-import type { AztecNode } from '@aztec/aztec.js/node';
+import { type AztecNode, waitForTx } from '@aztec/aztec.js/node';
 import { encodeArgs, getContractArtifact, prettyPrintJSON } from '@aztec/cli/utils';
 import type { LogFn, Logger } from '@aztec/foundation/log';
 import { getAllFunctionAbis, getInitializer } from '@aztec/stdlib/abi';
 import { PublicKeys } from '@aztec/stdlib/keys';
+import type { TxStatus } from '@aztec/stdlib/tx';
 
 import { DEFAULT_TX_TIMEOUT_S } from '../utils/cli_wallet_and_node_wrapper.js';
 import { CLIFeeArgs } from '../utils/options/fees.js';
@@ -30,6 +31,7 @@ export async function deploy(
   skipInitialization: boolean | undefined,
   wait: boolean,
   feeOpts: CLIFeeArgs,
+  waitForStatus: TxStatus,
   verbose: boolean,
   timeout: number = DEFAULT_TX_TIMEOUT_S,
   debugLogger: Logger,
@@ -60,7 +62,7 @@ export async function deploy(
     debugLogger.debug(`Encoded arguments: ${args.join(', ')}`);
   }
 
-  const deploy = contractDeployer.deploy(...args);
+  const deployInteraction = contractDeployer.deploy(...args);
   const { paymentMethod, gasSettings } = await feeOpts.toUserFeeOptions(node, wallet, deployer);
   const deployOpts: DeployOptions = {
     fee: { gasSettings, paymentMethod },
@@ -72,7 +74,8 @@ export async function deploy(
     skipInstancePublication,
   };
 
-  const sim = await deploy.simulate({
+  const localStart = performance.now();
+  const sim = await deployInteraction.simulate({
     ...deployOpts,
     fee: { ...deployOpts.fee, estimateGas: true },
   });
@@ -98,14 +101,18 @@ export async function deploy(
       printProfileResult(stats, log);
     }
 
-    const { address, partialAddress } = deploy;
-    const instance = await deploy.getInstance();
+    const { address, partialAddress } = deployInteraction;
+    const instance = await deployInteraction.getInstance();
+
+    const { txHash } = await deployInteraction.send({ ...deployOpts, wait: NO_WAIT });
+    const localTimeMs = performance.now() - localStart;
+    debugLogger.debug(`Deploy tx sent with hash ${txHash.toString()}`);
+    out.hash = txHash;
 
     if (wait) {
-      const { receipt } = await deploy.send({ ...deployOpts, wait: { timeout, returnReceipt: true } });
-      const txHash = receipt.txHash;
-      debugLogger.debug(`Deploy tx sent with hash ${txHash.toString()}`);
-      out.hash = txHash;
+      const nodeStart = performance.now();
+      const receipt = await waitForTx(node, txHash, { timeout, waitForStatus });
+      const nodeTimeMs = performance.now() - nodeStart;
 
       if (!json) {
         log(`Contract deployed at ${address?.toString()}`);
@@ -115,6 +122,8 @@ export async function deploy(
         log(`Deployment salt: ${salt.toString()}`);
         log(`Deployer: ${instance.deployer.toString()}`);
         log(`Transaction fee: ${receipt.transactionFee?.toString()}`);
+        log(` Local processing time: ${(localTimeMs / 1000).toFixed(1)}s`);
+        log(` Node inclusion time: ${(nodeTimeMs / 1000).toFixed(1)}s`);
       } else {
         out.contract = {
           address: address?.toString(),
@@ -125,10 +134,6 @@ export async function deploy(
         };
       }
     } else {
-      const { txHash } = await deploy.send({ ...deployOpts, wait: NO_WAIT });
-      debugLogger.debug(`Deploy tx sent with hash ${txHash.toString()}`);
-      out.hash = txHash;
-
       if (!json) {
         log(`Contract deployed at ${address?.toString()}`);
         log(`Contract partial address ${(await partialAddress)?.toString()}`);
@@ -149,5 +154,5 @@ export async function deploy(
   if (json) {
     log(prettyPrintJSON(out));
   }
-  return deploy.address;
+  return deployInteraction.address;
 }

--- a/yarn-project/cli-wallet/src/cmds/deploy_account.ts
+++ b/yarn-project/cli-wallet/src/cmds/deploy_account.ts
@@ -1,11 +1,11 @@
 import { NO_FROM } from '@aztec/aztec.js/account';
 import { AztecAddress } from '@aztec/aztec.js/addresses';
 import { NO_WAIT } from '@aztec/aztec.js/contracts';
-import type { AztecNode } from '@aztec/aztec.js/node';
+import { type AztecNode, waitForTx } from '@aztec/aztec.js/node';
 import type { DeployAccountOptions } from '@aztec/aztec.js/wallet';
 import { prettyPrintJSON } from '@aztec/cli/cli-utils';
 import type { LogFn, Logger } from '@aztec/foundation/log';
-import type { TxHash, TxReceipt } from '@aztec/stdlib/tx';
+import type { TxHash, TxReceipt, TxStatus } from '@aztec/stdlib/tx';
 
 import { DEFAULT_TX_TIMEOUT_S } from '../utils/cli_wallet_and_node_wrapper.js';
 import type { CLIFeeArgs } from '../utils/options/fees.js';
@@ -22,6 +22,7 @@ export async function deployAccount(
   publicDeploy: boolean,
   skipInitialization: boolean,
   feeOpts: CLIFeeArgs,
+  waitForStatus: TxStatus,
   json: boolean,
   verbose: boolean,
   debugLogger: Logger,
@@ -63,6 +64,7 @@ export async function deployAccount(
     fee: { paymentMethod, gasSettings },
   };
 
+  const localStart = performance.now();
   const deployMethod = await account.getDeployMethod();
   const sim = await deployMethod.simulate({
     ...deployAccountOpts,
@@ -102,19 +104,24 @@ export async function deployAccount(
           }
         : undefined,
     };
+
+    ({ txHash } = await deployMethod.send({ ...sendOpts, wait: NO_WAIT }));
+    const localTimeMs = performance.now() - localStart;
+
     if (wait) {
-      const { receipt } = await deployMethod.send({
-        ...sendOpts,
-        wait: { timeout: DEFAULT_TX_TIMEOUT_S, returnReceipt: true },
-      });
-      txReceipt = receipt;
-      txHash = receipt.txHash;
+      const nodeStart = performance.now();
+      txReceipt = await waitForTx(aztecNode, txHash, { timeout: DEFAULT_TX_TIMEOUT_S, waitForStatus });
+      const nodeTimeMs = performance.now() - nodeStart;
+
       out.txReceipt = {
         status: txReceipt.status,
         transactionFee: txReceipt.transactionFee,
       };
-    } else {
-      ({ txHash } = await deployMethod.send({ ...sendOpts, wait: NO_WAIT }));
+
+      if (!json) {
+        log(` Local processing time: ${(localTimeMs / 1000).toFixed(1)}s`);
+        log(` Node inclusion time: ${(nodeTimeMs / 1000).toFixed(1)}s`);
+      }
     }
     debugLogger.debug(`Account contract tx sent with hash ${txHash.toString()}`);
     out.txHash = txHash;

--- a/yarn-project/cli-wallet/src/cmds/get_fee_juice_balance.ts
+++ b/yarn-project/cli-wallet/src/cmds/get_fee_juice_balance.ts
@@ -1,0 +1,37 @@
+import type { AztecAddress } from '@aztec/aztec.js/addresses';
+import type { AztecNode } from '@aztec/aztec.js/node';
+import { getFeeJuiceBalance } from '@aztec/aztec.js/utils';
+import { prettyPrintJSON } from '@aztec/cli/cli-utils';
+import type { LogFn } from '@aztec/foundation/log';
+
+const FEE_JUICE_DECIMALS = 18;
+const FEE_JUICE_UNIT = 10n ** BigInt(FEE_JUICE_DECIMALS);
+
+/** Formats a raw FeeJuice balance (18 decimals) for human-readable display. */
+function formatFeeJuice(raw: bigint, exact: boolean): string {
+  const whole = raw / FEE_JUICE_UNIT;
+  const fractional = raw % FEE_JUICE_UNIT;
+  const fracStr = fractional.toString().padStart(FEE_JUICE_DECIMALS, '0');
+  if (exact) {
+    return `${whole}.${fracStr} FJ`;
+  }
+  if (fractional === 0n) {
+    return `${whole} FJ`;
+  }
+  return `${whole}.${fracStr.replace(/0+$/, '')} FJ`;
+}
+
+export async function getFeeJuiceBalanceCmd(
+  node: AztecNode,
+  address: AztecAddress,
+  json: boolean,
+  exact: boolean,
+  log: LogFn,
+) {
+  const balance = await getFeeJuiceBalance(address, node);
+  if (json) {
+    log(prettyPrintJSON({ address: address.toString(), balance: balance.toString() }));
+  } else {
+    log(`Fee Juice balance for ${address.toString()}: ${formatFeeJuice(balance, exact)}`);
+  }
+}

--- a/yarn-project/cli-wallet/src/cmds/index.ts
+++ b/yarn-project/cli-wallet/src/cmds/index.ts
@@ -12,6 +12,7 @@ import {
 } from '@aztec/cli/utils';
 import { randomBytes } from '@aztec/foundation/crypto/random';
 import type { LogFn, Logger } from '@aztec/foundation/log';
+import { TxStatus } from '@aztec/stdlib/tx';
 
 import { type Command, Option } from 'commander';
 import inquirer from 'inquirer';
@@ -39,6 +40,17 @@ import {
   createVerboseOption,
   integerArgParser,
 } from '../utils/options/index.js';
+
+function parseWaitForStatus(status: string): TxStatus {
+  switch (status) {
+    case 'proposed':
+      return TxStatus.PROPOSED;
+    case 'checkpointed':
+      return TxStatus.CHECKPOINTED;
+    default:
+      throw new Error(`Invalid wait-for-status: ${status}. Use 'proposed' or 'checkpointed'.`);
+  }
+}
 
 // TODO: This function is only used in 1 place so we could just inline this
 export function injectCommands(
@@ -91,6 +103,11 @@ export function injectCommands(
     .addOption(createAliasOption('Alias for the account. Used for easy reference in subsequent commands.', !db))
     .addOption(createTypeOption(true))
     .option(
+      '-s, --salt <hex string>',
+      'Optional deployment salt as a hex string for generating the deployment address. Defaults to 0.',
+      parseFieldFromHexString,
+    )
+    .option(
       '--register-only',
       'Just register the account on the Wallet. Do not deploy or initialize the account contract.',
     )
@@ -98,6 +115,7 @@ export function injectCommands(
     // `options.wait` is default true. Passing `--no-wait` will set it to false.
     // https://github.com/tj/commander.js#other-option-types-negatable-boolean-and-booleanvalue
     .option('--no-wait', 'Skip waiting for the contract to be deployed. Print the hash of deployment transaction')
+    .option('--wait-for-status <status>', "Tx status to wait for: 'proposed' or 'checkpointed'", 'proposed')
     .addOption(createVerboseOption());
 
   addOptions(createAccountCommand, CLIFeeArgs.getOptions()).action(async (_options, command) => {
@@ -107,7 +125,9 @@ export function injectCommands(
       type,
       from: parsedFromAddress,
       secretKey,
+      salt,
       wait,
+      waitForStatus: waitForStatusStr,
       registerOnly,
       skipInitialization,
       publicDeploy,
@@ -137,6 +157,7 @@ export function injectCommands(
       node,
       type,
       secretKey,
+      salt,
       publicKey,
       alias,
       parsedFromAddress,
@@ -146,6 +167,7 @@ export function injectCommands(
       registerClass,
       wait,
       CLIFeeArgs.parse(options, log, db),
+      parseWaitForStatus(waitForStatusStr),
       json,
       verbose,
       debugLogger,
@@ -180,12 +202,22 @@ export function injectCommands(
       '--skip-initialization',
       'Skip initializing the account contract. Useful for publicly deploying an existing account.',
     )
+    .option('--wait-for-status <status>', "Tx status to wait for: 'proposed' or 'checkpointed'", 'proposed')
     .addOption(createVerboseOption());
 
   addOptions(deployAccountCommand, CLIFeeArgs.getOptions()).action(async (parsedAccount, _options, command) => {
     const { deployAccount } = await import('./deploy_account.js');
     const options = command.optsWithGlobals();
-    const { wait, from: parsedFromAddress, json, registerClass, skipInitialization, publicDeploy, verbose } = options;
+    const {
+      wait,
+      waitForStatus: waitForStatusStr,
+      from: parsedFromAddress,
+      json,
+      registerClass,
+      skipInitialization,
+      publicDeploy,
+      verbose,
+    } = options;
 
     const { wallet, node } = walletAndNodeWrapper;
 
@@ -199,6 +231,7 @@ export function injectCommands(
       publicDeploy,
       skipInitialization,
       CLIFeeArgs.parse(options, log, db),
+      parseWaitForStatus(waitForStatusStr),
       json,
       verbose,
       debugLogger,
@@ -219,7 +252,7 @@ export function injectCommands(
     )
     .option(
       '-s, --salt <hex string>',
-      'Optional deployment salt as a hex string for generating the deployment address.',
+      'Optional deployment salt as a hex string for generating the deployment address. Defaults to random.',
       parseFieldFromHexString,
     )
     .option('--universal', 'Do not mix the sender address into the deployment.')
@@ -238,6 +271,7 @@ export function injectCommands(
         'The amount of time in seconds to wait for the deployment to post to L2',
       ).conflicts('wait'),
     )
+    .option('--wait-for-status <status>', "Tx status to wait for: 'proposed' or 'checkpointed'", 'proposed')
     .addOption(createVerboseOption());
 
   addOptions(deployCommand, CLIFeeArgs.getOptions()).action(async (artifactPathPromise, _options, command) => {
@@ -249,6 +283,7 @@ export function injectCommands(
       args,
       salt,
       wait,
+      waitForStatus: waitForStatusStr,
       classRegistration,
       init,
       publicDeployment,
@@ -279,8 +314,9 @@ export function injectCommands(
       typeof init === 'string' ? false : init,
       wait,
       CLIFeeArgs.parse(options, log, db),
-      timeout,
+      parseWaitForStatus(waitForStatusStr),
       verbose,
+      timeout,
       debugLogger,
       log,
     );
@@ -308,6 +344,7 @@ export function injectCommands(
     )
     .addOption(createAccountOption('Alias or address of the account to send the transaction from', !db, db))
     .option('--no-wait', 'Print transaction hash without waiting for it to be mined')
+    .option('--wait-for-status <status>', "Tx status to wait for: 'proposed' or 'checkpointed'", 'proposed')
     .addOption(createVerboseOption());
 
   addOptions(sendCommand, CLIFeeArgs.getOptions()).action(async (functionName, _options, command) => {
@@ -319,6 +356,7 @@ export function injectCommands(
       contractAddress,
       from: parsedFromAddress,
       wait,
+      waitForStatus: waitForStatusStr,
       alias,
       authWitness: authWitnessArray,
       verbose,
@@ -342,6 +380,7 @@ export function injectCommands(
       alias,
       CLIFeeArgs.parse(options, log, db),
       authWitnesses,
+      parseWaitForStatus(waitForStatusStr),
       verbose,
       log,
     );
@@ -490,6 +529,20 @@ export function injectCommands(
       if (db) {
         await db.pushBridgedFeeJuice(recipient, secret, amount, messageLeafIndex, log);
       }
+    });
+
+  program
+    .command('get-fee-juice-balance')
+    .description('Checks the Fee Juice balance for a given address.')
+    .argument('<address>', 'Aztec address or alias to check balance for', address =>
+      aliasedAddressParser('accounts', address, db),
+    )
+    .option('--json', 'Emit output as json')
+    .option('--exact', 'Show exact balance with all 18 decimal places')
+    .action(async (address, options) => {
+      const { getFeeJuiceBalanceCmd } = await import('./get_fee_juice_balance.js');
+      const { json, exact } = options;
+      await getFeeJuiceBalanceCmd(walletAndNodeWrapper.node, address, json, exact, log);
     });
 
   program

--- a/yarn-project/cli-wallet/src/cmds/send.ts
+++ b/yarn-project/cli-wallet/src/cmds/send.ts
@@ -1,9 +1,10 @@
 import type { AztecAddress } from '@aztec/aztec.js/addresses';
 import { AuthWitness } from '@aztec/aztec.js/authorization';
 import { Contract, NO_WAIT, type SendInteractionOptions } from '@aztec/aztec.js/contracts';
-import type { AztecNode } from '@aztec/aztec.js/node';
+import { type AztecNode, waitForTx } from '@aztec/aztec.js/node';
 import { prepTx } from '@aztec/cli/utils';
 import type { LogFn } from '@aztec/foundation/log';
+import { TxStatus } from '@aztec/stdlib/tx';
 
 import { DEFAULT_TX_TIMEOUT_S } from '../utils/cli_wallet_and_node_wrapper.js';
 import { CLIFeeArgs } from '../utils/options/fees.js';
@@ -22,6 +23,7 @@ export async function send(
   cancellable: boolean,
   feeOpts: CLIFeeArgs,
   authWitnesses: AuthWitness[],
+  waitForStatus: TxStatus,
   verbose: boolean,
   log: LogFn,
 ) {
@@ -37,6 +39,7 @@ export async function send(
     authWitnesses,
   };
 
+  const localStart = performance.now();
   const sim = await call.simulate({
     ...sendOptions,
     fee: { ...sendOptions.fee, estimateGas: true },
@@ -53,21 +56,29 @@ export async function send(
     printProfileResult(stats!, log);
   }
 
+  const { txHash } = await call.send({
+    ...sendOptions,
+    fee: { ...sendOptions.fee, gasSettings: estimatedGas },
+    wait: NO_WAIT,
+  });
+  const localTimeMs = performance.now() - localStart;
+
+  log(`\nTransaction hash: ${txHash.toString()}`);
+
   if (wait) {
     try {
-      const { receipt } = await call.send({
-        ...sendOptions,
-        fee: { ...sendOptions.fee, gasSettings: estimatedGas },
-        wait: { timeout: DEFAULT_TX_TIMEOUT_S },
-      });
+      const nodeStart = performance.now();
+      const receipt = await waitForTx(node, txHash, { timeout: DEFAULT_TX_TIMEOUT_S, waitForStatus });
+      const nodeTimeMs = performance.now() - nodeStart;
 
-      const txHash = receipt.txHash;
-      log(`\nTransaction hash: ${txHash.toString()}`);
-      log('Transaction has been mined');
+      const statusLabel = waitForStatus === TxStatus.PROPOSED ? 'proposed' : 'checkpointed';
+      log(`Transaction has been ${statusLabel}`);
       log(` Tx fee: ${receipt.transactionFee}`);
       log(` Status: ${receipt.status}`);
       log(` Block number: ${receipt.blockNumber}`);
       log(` Block hash: ${receipt.blockHash?.toString()}`);
+      log(` Local processing time: ${(localTimeMs / 1000).toFixed(1)}s`);
+      log(` Node inclusion time: ${(nodeTimeMs / 1000).toFixed(1)}s`);
 
       return {
         txHash,
@@ -77,12 +88,6 @@ export async function send(
       throw err;
     }
   } else {
-    const { txHash } = await call.send({
-      ...sendOptions,
-      fee: { ...sendOptions.fee, gasSettings: estimatedGas },
-      wait: NO_WAIT,
-    });
-    log(`\nTransaction hash: ${txHash.toString()}`);
     log('Transaction pending. Check status with check-tx');
     return {
       txHash,


### PR DESCRIPTION
A few changes to the cli-wallet to make it easier to use for testing deployed networks:
- adds an optional salt parameter to `create-account`. This is so I can import a bot account which already has FJ
- adds a command to quickly check FJ balance
- all commands that send txs now take a `--wait-for-status <checkpointed|proposed>` optional flag (default: proposed) to control how long we wait for txs.