### PR TITLE
feat: remove isRewardClaimable

### DIFF
--- a/docs/docs-operate/operators/sequencer-management/claiming-rewards.md
+++ b/docs/docs-operate/operators/sequencer-management/claiming-rewards.md
@@ -37,9 +37,8 @@ Rewards are not automatically sent to your coinbase address. You must explicitly
 
 Before claiming, verify these conditions:
 
-1. **Rewards must be claimable**: A governance vote must pass to enable the claiming of rewards (only possible after a minimum configured timestamp) and governance must have called `setRewardsClaimable(true)` on the rollup contract.
-2. **Rewards have accumulated**: Query your pending rewards before attempting to claim.
-3. **Sufficient gas**: Ensure you have ETH to pay transaction gas costs.
+1. **Rewards have accumulated**: Query your pending rewards before attempting to claim.
+2. **Sufficient gas**: Ensure you have ETH to pay transaction gas costs.
 
 ## Checking Reward Status
 
@@ -53,26 +52,6 @@ export ROLLUP_ADDRESS="[YOUR_ROLLUP_CONTRACT_ADDRESS]"
 ```
 
 Replace `[YOUR_ROLLUP_CONTRACT_ADDRESS]` with your actual Rollup contract address.
-
-### Check if Rewards Are Claimable
-
-Verify reward claiming is enabled before attempting to claim:
-
-```bash
-cast call $ROLLUP_ADDRESS "isRewardsClaimable()" --rpc-url $RPC_URL
-```
-
-**Expected output:**
-- `0x0000000000000000000000000000000000000000000000000000000000000001` - Rewards are claimable (true)
-- `0x0000000000000000000000000000000000000000000000000000000000000000` - Rewards are not yet claimable (false)
-
-If rewards are not claimable, check when they will become claimable:
-
-```bash
-cast call $ROLLUP_ADDRESS "getEarliestRewardsClaimableTimestamp()" --rpc-url $RPC_URL
-```
-
-This returns a Unix timestamp indicating the earliest time when governance can enable reward claiming.
 
 ### Query Your Pending Rewards
 
@@ -160,15 +139,6 @@ cast call $ROLLUP_ADDRESS "getSequencerRewards(address)" [COINBASE_ADDRESS] --rp
 ```
 
 ## Troubleshooting
-
-### "Rewards not claimable" Error
-
-**Symptom**: Transaction reverts with "Rewards not claimable" error.
-
-**Solution**:
-1. Check if rewards are claimable using `isRewardsClaimable()`
-2. If `false`, wait until governance enables claiming via `setRewardsClaimable(true)`
-3. Check the earliest claimable timestamp using `getEarliestRewardsClaimableTimestamp()`
 
 ### No Pending Rewards
 

--- a/l1-contracts/gas_benchmark.md
+++ b/l1-contracts/gas_benchmark.md
@@ -15,8 +15,8 @@
 | Function             | Avg Gas | Max Gas | Calldata Size | Calldata Gas |
 |----------------------|---------|---------|---------------|--------------|
 | propose              | 195,201 | 221,411 |           932 |       14,912 |
-| submitEpochRootProof | 698,954 | 744,754 |         2,820 |       45,120 |
-| setupEpoch           |  32,010 | 113,661 |             - |            - |
+| submitEpochRootProof | 698,976 | 744,776 |         2,820 |       45,120 |
+| setupEpoch           |  31,965 | 113,616 |             - |            - |
 
 **Avg Gas Cost per Second**: 3,331.7 gas/second
 *Epoch duration*: 0h 38m 24s
@@ -26,9 +26,9 @@
 | Function             | Avg Gas | Max Gas | Calldata Size | Calldata Gas |
 |----------------------|---------|---------|---------------|--------------|
 | propose              | 322,945 | 350,085 |         4,452 |       71,232 |
-| submitEpochRootProof | 897,128 | 942,932 |         5,316 |       85,056 |
-| aggregate3           | 371,446 | 384,876 |             - |            - |
-| setupEpoch           |  46,471 | 547,494 |             - |            - |
+| submitEpochRootProof | 897,150 | 942,954 |         5,316 |       85,056 |
+| aggregate3           | 371,401 | 384,831 |             - |            - |
+| setupEpoch           |  46,426 | 547,449 |             - |            - |
 
 **Avg Gas Cost per Second**: 5,284.3 gas/second
 *Epoch duration*: 0h 38m 24s

--- a/l1-contracts/gas_benchmark_results.json
+++ b/l1-contracts/gas_benchmark_results.json
@@ -11,17 +11,17 @@
     },
     "setupEpoch": {
       "calls": 150,
-      "min": 29281,
-      "mean": 32010,
-      "median": 29281,
-      "max": 113661
+      "min": 29236,
+      "mean": 31965,
+      "median": 29236,
+      "max": 113616
     },
     "submitEpochRootProof": {
       "calls": 4,
-      "min": 677906,
-      "mean": 698954,
-      "median": 686579,
-      "max": 744754,
+      "min": 677928,
+      "mean": 698976,
+      "median": 686601,
+      "max": 744776,
       "calldata_size": 2820,
       "calldata_gas": 45120
     }
@@ -38,26 +38,26 @@
     },
     "setupEpoch": {
       "calls": 150,
-      "min": 29281,
-      "mean": 46471,
-      "median": 29281,
-      "max": 547494
+      "min": 29236,
+      "mean": 46426,
+      "median": 29236,
+      "max": 547449
     },
     "submitEpochRootProof": {
       "calls": 4,
-      "min": 876090,
-      "mean": 897128,
-      "median": 884745,
-      "max": 942932,
+      "min": 876112,
+      "mean": 897150,
+      "median": 884767,
+      "max": 942954,
       "calldata_size": 5316,
       "calldata_gas": 85056
     },
     "aggregate3": {
       "calls": 55,
-      "min": 360343,
-      "mean": 371446,
-      "median": 371210,
-      "max": 384876
+      "min": 360298,
+      "mean": 371401,
+      "median": 371165,
+      "max": 384831
     }
   }
 }

--- a/l1-contracts/script/deploy/RollupConfiguration.sol
+++ b/l1-contracts/script/deploy/RollupConfiguration.sol
@@ -10,7 +10,6 @@ import {IRewardDistributor} from "@aztec/governance/interfaces/IRewardDistributo
 import {IBoosterCore} from "@aztec/core/reward-boost/RewardBooster.sol";
 import {EthValue, EthPerFeeAssetE12} from "@aztec/core/libraries/rollup/FeeLib.sol";
 import {GenesisState, RollupConfigInput} from "@aztec/core/interfaces/IRollup.sol";
-import {Timestamp} from "@aztec/core/libraries/TimeLib.sol";
 import {RewardBoostConfig} from "@aztec/core/reward-boost/RewardBooster.sol";
 import {StakingQueueConfig} from "@aztec/core/libraries/compressed-data/StakingQueueConfig.sol";
 import {RewardConfig, Bps} from "@aztec/core/libraries/rollup/RewardLib.sol";
@@ -19,7 +18,6 @@ interface IRollupConfiguration {
   function loadConfig() external;
   function useRealVerifier() external view returns (bool);
   function getFeeJuicePortalInitialBalance() external view returns (uint256);
-  function getEarliestRewardsClaimableTimestamp() external view returns (Timestamp);
   function getGenesisState() external view returns (GenesisState memory);
   function getRewardConfiguration(IRewardDistributor rewardDistributor) external view returns (RewardConfig memory);
   function getRewardBoostConfiguration() external pure returns (RewardBoostConfig memory);
@@ -46,16 +44,6 @@ contract RollupConfiguration is IRollupConfiguration, Test {
 
   function getFeeJuicePortalInitialBalance() external view returns (uint256) {
     return vm.envOr("FEE_JUICE_PORTAL_INITIAL_BALANCE", uint256(0));
-  }
-
-  function getEarliestRewardsClaimableTimestamp() public view returns (Timestamp) {
-    // We only set a delay on mainnet.
-    // Since we don't plan to redeploy on mainnet (knock on wood), this is mostly documentation in code form.
-    if (block.chainid == 1) {
-      return Timestamp.wrap(block.timestamp + 90 days);
-    } else {
-      return Timestamp.wrap(0);
-    }
   }
 
   function getGenesisState() external view returns (GenesisState memory) {
@@ -105,7 +93,6 @@ contract RollupConfiguration is IRollupConfiguration, Test {
     config.rewardConfig = this.getRewardConfiguration(_rewardDistributor);
     config.rewardBoostConfig = this.getRewardBoostConfiguration();
     config.stakingQueueConfig = this.getStakingQueueConfiguration();
-    config.earliestRewardsClaimableTimestamp = getEarliestRewardsClaimableTimestamp();
 
     // Compute version as first 4 bytes of hash(abi.encode(config, genesisState))
     config.version = _computeConfigVersion(config, this.getGenesisState());

--- a/l1-contracts/src/core/Rollup.sol
+++ b/l1-contracts/src/core/Rollup.sol
@@ -570,14 +570,6 @@ contract Rollup is IStaking, IValidatorSelection, IRollup, RollupCore {
     return RewardExtLib.getCheckpointReward();
   }
 
-  function isRewardsClaimable() external view override(IRollup) returns (bool) {
-    return RewardExtLib.isRewardsClaimable();
-  }
-
-  function getEarliestRewardsClaimableTimestamp() external view override(IRollup) returns (Timestamp) {
-    return RewardExtLib.getEarliestRewardsClaimableTimestamp();
-  }
-
   function getAvailableValidatorFlushes() external view override(IStaking) returns (uint256) {
     return ValidatorOperationsExtLib.getAvailableValidatorFlushes();
   }

--- a/l1-contracts/src/core/RollupCore.sol
+++ b/l1-contracts/src/core/RollupCore.sol
@@ -281,17 +281,6 @@ contract RollupCore is EIP712("Aztec Rollup", "1"), Ownable, IStakingCore, IVali
   }
 
   /**
-   * @notice Enables or disables reward claiming
-   * @dev Only callable by owner. This is a safety mechanism to control when rewards can be withdrawn.
-   *      Cannot set rewards as claimable before the earliest reward claimable timestamp.
-   * @param _isRewardsClaimable True to enable reward claims, false to disable
-   */
-  function setRewardsClaimable(bool _isRewardsClaimable) external override(IRollupCore) onlyOwner {
-    RewardExtLib.setIsRewardsClaimable(_isRewardsClaimable);
-    emit RewardsClaimableUpdated(_isRewardsClaimable);
-  }
-
-  /**
    * @notice Updates the slasher contract address
    * @dev Only callable by owner. The slasher handles punishment for validator misbehavior.
    * @param _slasher The address of the new slasher contract
@@ -341,7 +330,7 @@ contract RollupCore is EIP712("Aztec Rollup", "1"), Ownable, IStakingCore, IVali
 
   /**
    * @notice Claims accumulated rewards for a sequencer (checkpoint proposer)
-   * @dev Rewards must be enabled via isRewardsClaimable. Transfers all accumulated rewards to the recipient.
+   * @dev Transfers all accumulated rewards to the recipient.
    * @param _coinbase The address that has accumulated the rewards - rewards are sent to this address
    * @return The amount of rewards claimed
    */
@@ -351,8 +340,8 @@ contract RollupCore is EIP712("Aztec Rollup", "1"), Ownable, IStakingCore, IVali
 
   /**
    * @notice Claims prover rewards for specified epochs
-   * @dev Rewards must be enabled. Provers earn rewards for successfully proving epoch transitions.
-   *      Each epoch can only be claimed once per prover.
+   * @dev Provers earn rewards for successfully proving epoch transitions. Each epoch can only be claimed once per
+   *      prover.
    * @param _coinbase The address that has accumulated the rewards - rewards are sent to this address
    * @param _epochs Array of epochs to claim rewards for
    * @return The total amount of rewards claimed
@@ -598,7 +587,6 @@ contract RollupCore is EIP712("Aztec Rollup", "1"), Ownable, IStakingCore, IVali
       rewardConfig.booster = RewardExtLib.deployRewardBooster(_config.rewardBoostConfig);
     }
 
-    RewardExtLib.initialize(_config.earliestRewardsClaimableTimestamp);
     RewardExtLib.setConfig(rewardConfig);
   }
 

--- a/l1-contracts/src/core/interfaces/IRollup.sol
+++ b/l1-contracts/src/core/interfaces/IRollup.sol
@@ -79,7 +79,6 @@ struct RollupConfigInput {
   RewardBoostConfig rewardBoostConfig;
   StakingQueueConfig stakingQueueConfig;
   uint256 localEjectionThreshold;
-  Timestamp earliestRewardsClaimableTimestamp;
   uint256 inboxLag;
 }
 
@@ -115,9 +114,7 @@ interface IRollupCore {
   event RewardConfigUpdated(RewardConfig rewardConfig);
   event ManaTargetUpdated(uint256 indexed manaTarget);
   event PrunedPending(uint256 provenCheckpointNumber, uint256 pendingCheckpointNumber);
-  event RewardsClaimableUpdated(bool isRewardsClaimable);
 
-  function setRewardsClaimable(bool _isRewardsClaimable) external;
   function claimSequencerRewards(address _recipient) external returns (uint256);
   function claimProverRewards(address _recipient, Epoch[] memory _epochs) external returns (uint256);
 
@@ -237,6 +234,4 @@ interface IRollup is IRollupCore, IHaveVersion {
 
   function getRewardConfig() external view returns (RewardConfig memory);
   function getCheckpointReward() external view returns (uint256);
-  function getEarliestRewardsClaimableTimestamp() external view returns (Timestamp);
-  function isRewardsClaimable() external view returns (bool);
 }

--- a/l1-contracts/src/core/libraries/Errors.sol
+++ b/l1-contracts/src/core/libraries/Errors.sol
@@ -87,8 +87,6 @@ library Errors {
   error Rollup__ProverHaveAlreadySubmitted(address prover, Epoch epoch);
   error Rollup__InvalidManaTarget(uint256 minimum, uint256 provided);
   error Rollup__ManaLimitExceeded();
-  error Rollup__RewardsNotClaimable();
-  error Rollup__TooSoonToSetRewardsClaimable(uint256 earliestRewardsClaimableTimestamp, uint256 currentTimestamp);
   error Rollup__InvalidFirstEpochProof();
   error Rollup__InvalidCoinbase();
   error Rollup__UnavailableTempCheckpointLog(

--- a/l1-contracts/src/core/libraries/rollup/RewardExtLib.sol
+++ b/l1-contracts/src/core/libraries/rollup/RewardExtLib.sol
@@ -22,16 +22,8 @@ import {
 import {IRewardDistributor} from "@aztec/governance/interfaces/IRewardDistributor.sol";
 
 library RewardExtLib {
-  function initialize(Timestamp _earliestRewardsClaimableTimestamp) external {
-    RewardLib.initialize(_earliestRewardsClaimableTimestamp);
-  }
-
   function setConfig(RewardConfig memory _config) external {
     RewardLib.setConfig(_config);
-  }
-
-  function setIsRewardsClaimable(bool _isRewardsClaimable) external {
-    RewardLib.setIsRewardsClaimable(_isRewardsClaimable);
   }
 
   function claimSequencerRewards(address _sequencer) external returns (uint256) {
@@ -75,14 +67,6 @@ library RewardExtLib {
 
   function getCheckpointReward() external view returns (uint256) {
     return RewardLib.getCheckpointReward();
-  }
-
-  function isRewardsClaimable() external view returns (bool) {
-    return RewardLib.isRewardsClaimable();
-  }
-
-  function getEarliestRewardsClaimableTimestamp() external view returns (Timestamp) {
-    return RewardLib.getEarliestRewardsClaimableTimestamp();
   }
 
   function getRewardConfig() external view returns (RewardConfig memory) {

--- a/l1-contracts/src/core/libraries/rollup/RewardLib.sol
+++ b/l1-contracts/src/core/libraries/rollup/RewardLib.sol
@@ -9,7 +9,6 @@ import {STFLib} from "@aztec/core/libraries/rollup/STFLib.sol";
 import {Epoch, Timestamp, TimeLib} from "@aztec/core/libraries/TimeLib.sol";
 import {IBoosterCore} from "@aztec/core/reward-boost/RewardBooster.sol";
 import {IRewardDistributor} from "@aztec/governance/interfaces/IRewardDistributor.sol";
-import {CompressedTimeMath, CompressedTimestamp} from "@aztec/shared/libraries/CompressedTimeMath.sol";
 import {IERC20} from "@oz/token/ERC20/IERC20.sol";
 import {SafeERC20} from "@oz/token/ERC20/utils/SafeERC20.sol";
 import {Math} from "@oz/utils/math/Math.sol";
@@ -47,8 +46,6 @@ struct RewardStorage {
   mapping(Epoch => EpochRewards) epochRewards;
   mapping(address prover => BitMaps.BitMap claimed) proverClaimed;
   RewardConfig config;
-  CompressedTimestamp earliestRewardsClaimableTimestamp;
-  bool isRewardsClaimable;
 }
 
 struct Values {
@@ -67,8 +64,6 @@ struct Totals {
 library RewardLib {
   using SafeERC20 for IERC20;
   using BitMaps for BitMaps.BitMap;
-  using CompressedTimeMath for CompressedTimestamp;
-  using CompressedTimeMath for Timestamp;
   using TimeLib for Timestamp;
   using TimeLib for Epoch;
   using FeeHeaderLib for CompressedFeeHeader;
@@ -81,34 +76,14 @@ library RewardLib {
   // such as sacrificial hearts, during rituals performed within temples.
   address public constant BURN_ADDRESS = address(bytes20("CUAUHXICALLI"));
 
-  function initialize(Timestamp _earliestRewardsClaimableTimestamp) internal {
-    RewardStorage storage rewardStorage = getStorage();
-    rewardStorage.earliestRewardsClaimableTimestamp = _earliestRewardsClaimableTimestamp.compress();
-    rewardStorage.isRewardsClaimable = false;
-  }
-
   function setConfig(RewardConfig memory _config) internal {
     require(Bps.unwrap(_config.sequencerBps) <= 10_000, Errors.RewardLib__InvalidSequencerBps());
     RewardStorage storage rewardStorage = getStorage();
     rewardStorage.config = _config;
   }
 
-  function setIsRewardsClaimable(bool _isRewardsClaimable) internal {
-    RewardStorage storage rewardStorage = getStorage();
-    uint256 earliestRewardsClaimableTimestamp =
-      Timestamp.unwrap(rewardStorage.earliestRewardsClaimableTimestamp.decompress());
-    require(
-      block.timestamp >= earliestRewardsClaimableTimestamp,
-      Errors.Rollup__TooSoonToSetRewardsClaimable(earliestRewardsClaimableTimestamp, block.timestamp)
-    );
-
-    rewardStorage.isRewardsClaimable = _isRewardsClaimable;
-  }
-
   function claimSequencerRewards(address _sequencer) internal returns (uint256) {
     RewardStorage storage rewardStorage = getStorage();
-    require(rewardStorage.isRewardsClaimable, Errors.Rollup__RewardsNotClaimable());
-
     RollupStore storage rollupStore = STFLib.getStorage();
     uint256 amount = rewardStorage.sequencerRewards[_sequencer];
 
@@ -125,8 +100,6 @@ library RewardLib {
     RollupStore storage rollupStore = STFLib.getStorage();
 
     RewardStorage storage rewardStorage = getStorage();
-
-    require(rewardStorage.isRewardsClaimable, Errors.Rollup__RewardsNotClaimable());
 
     uint256 accumulatedRewards = 0;
     for (uint256 i = 0; i < _epochs.length; i++) {
@@ -294,14 +267,6 @@ library RewardLib {
     }
 
     return (se.shares[_prover] * er.rewards / se.summedShares);
-  }
-
-  function isRewardsClaimable() internal view returns (bool) {
-    return getStorage().isRewardsClaimable;
-  }
-
-  function getEarliestRewardsClaimableTimestamp() internal view returns (Timestamp) {
-    return getStorage().earliestRewardsClaimableTimestamp.decompress();
   }
 
   function getStorage() internal pure returns (RewardStorage storage storageStruct) {

--- a/l1-contracts/src/periphery/FlushRewarder.sol
+++ b/l1-contracts/src/periphery/FlushRewarder.sol
@@ -3,7 +3,6 @@
 pragma solidity >=0.8.27;
 
 import {IInstance} from "@aztec/core/interfaces/IInstance.sol";
-import {Errors} from "@aztec/core/libraries/Errors.sol";
 import {Ownable} from "@oz/access/Ownable.sol";
 import {IERC20} from "@oz/token/ERC20/IERC20.sol";
 import {SafeERC20} from "@oz/token/ERC20/utils/SafeERC20.sol";
@@ -47,8 +46,6 @@ contract FlushRewarder is Ownable, IFlushRewarder {
   }
 
   function claimRewards() external override(IFlushRewarder) {
-    require(ROLLUP.isRewardsClaimable(), Errors.Rollup__RewardsNotClaimable());
-
     uint256 rewardsToClaim = rewardsOf[msg.sender];
     if (rewardsToClaim > 0) {
       rewardsOf[msg.sender] = 0;

--- a/l1-contracts/test/MultiProof.t.sol
+++ b/l1-contracts/test/MultiProof.t.sol
@@ -4,11 +4,9 @@ pragma solidity >=0.8.27;
 
 import {DecoderBase} from "./base/DecoderBase.sol";
 
-import {Registry} from "@aztec/governance/Registry.sol";
 import {FeeJuicePortal} from "@aztec/core/messagebridge/FeeJuicePortal.sol";
 import {TestERC20} from "@aztec/mock/TestERC20.sol";
 import {TestConstants} from "./harnesses/TestConstants.sol";
-import {RewardDistributor} from "@aztec/governance/RewardDistributor.sol";
 import {ProposeArgs, ProposeLib} from "@aztec/core/libraries/rollup/ProposeLib.sol";
 
 import {Timestamp, Slot, Epoch, TimeLib} from "@aztec/core/libraries/TimeLib.sol";
@@ -18,7 +16,6 @@ import {Errors} from "@aztec/core/libraries/Errors.sol";
 
 import {RollupBase, IInstance} from "./base/RollupBase.sol";
 import {RollupBuilder} from "./builder/RollupBuilder.sol";
-import {Ownable} from "@oz/access/Ownable.sol";
 import {stdStorage, StdStorage} from "forge-std/StdStorage.sol";
 import {RewardBooster, ActivityScore} from "@aztec/core/reward-boost/RewardBooster.sol";
 import {BoostedHelper} from "./boosted_rewards/BoostRewardHelper.sol";
@@ -36,10 +33,8 @@ contract MultiProofTest is RollupBase {
   using TimeLib for Slot;
   using TimeLib for Epoch;
 
-  Registry internal registry;
   TestERC20 internal testERC20;
   FeeJuicePortal internal feeJuicePortal;
-  RewardDistributor internal rewardDistributor;
   RewardBooster internal rewardBooster;
 
   uint256 internal SLOT_DURATION;
@@ -144,18 +139,6 @@ contract MultiProofTest is RollupBase {
     assertTrue(rollup.getHasSubmitted(Epoch.wrap(0), 2, bob));
 
     assertEq(rollup.getProvenCheckpointNumber(), 2, "Checkpoint not proven");
-
-    {
-      // Ensure that we cannot claim rewards when not toggled yet
-      vm.expectRevert(abi.encodeWithSelector(Errors.Rollup__RewardsNotClaimable.selector));
-      rollup.claimSequencerRewards(sequencer);
-
-      vm.expectRevert(abi.encodeWithSelector(Errors.Rollup__RewardsNotClaimable.selector));
-      rollup.claimProverRewards(alice, new Epoch[](1));
-
-      vm.prank(Ownable(address(rollup)).owner());
-      rollup.setRewardsClaimable(true);
-    }
 
     {
       uint256 sequencerRewards = rollup.getSequencerRewards(sequencer);

--- a/l1-contracts/test/harnesses/TestConstants.sol
+++ b/l1-contracts/test/harnesses/TestConstants.sol
@@ -132,7 +132,6 @@ library TestConstants {
     config.slashAmounts = slashAmounts;
     config.slasherEnabled = false;
     config.localEjectionThreshold = 0;
-    config.earliestRewardsClaimableTimestamp = Timestamp.wrap(0);
     config.inboxLag = AZTEC_INBOX_LAG;
 
     // For the version we derive it based on the config (with a 0 version)

--- a/l1-contracts/test/staking/rewarded-flushing/rewardedFlushing.t.sol
+++ b/l1-contracts/test/staking/rewarded-flushing/rewardedFlushing.t.sol
@@ -7,21 +7,12 @@
 pragma solidity >=0.8.27;
 
 import {StakingBase} from "../base.t.sol";
-import {Errors} from "@aztec/core/libraries/Errors.sol";
-import {Epoch, Timestamp} from "@aztec/shared/libraries/TimeMath.sol";
-import {Status, AttesterView, IStakingCore} from "@aztec/core/interfaces/IStaking.sol";
-import {Math} from "@oz/utils/math/Math.sol";
-import {GSE, IGSECore} from "@aztec/governance/GSE.sol";
-import {StakingQueueLib, DepositArgs} from "@aztec/core/libraries/StakingQueue.sol";
-import {StakingQueueConfig, StakingQueueConfigLib} from "@aztec/core/libraries/compressed-data/StakingQueueConfig.sol";
+import {DepositArgs} from "@aztec/core/libraries/StakingQueue.sol";
+import {StakingQueueConfig} from "@aztec/core/libraries/compressed-data/StakingQueueConfig.sol";
 import {Rollup} from "@aztec/core/Rollup.sol";
-import {BN254Lib, G1Point, G2Point} from "@aztec/shared/libraries/BN254Lib.sol";
+import {BN254Lib} from "@aztec/shared/libraries/BN254Lib.sol";
 import {FlushRewarder, IFlushRewarder} from "@aztec/periphery/FlushRewarder.sol";
 import {IInstance} from "@aztec/core/interfaces/IInstance.sol";
-import {RollupBuilder} from "@test/builder/RollupBuilder.sol";
-import {MockVerifier} from "@aztec/mock/MockVerifier.sol";
-import {TestConstants} from "@test/harnesses/TestConstants.sol";
-import {RollupConfigInput} from "@aztec/core/interfaces/IRollup.sol";
 
 contract RewardedFlushingTest is StakingBase {
   uint256 public constant MAX_QUEUE_FLUSH_SIZE = 48;
@@ -62,28 +53,7 @@ contract RewardedFlushingTest is StakingBase {
     _;
   }
 
-  function test_givenRewardsNotClaimable() external givenFunding {
-    uint256 attestersBefore = staking.getActiveAttesterCount();
-    flushRewarder.flushEntryQueue();
-
-    assertEq(staking.getActiveAttesterCount(), attestersBefore + 8, "invalid active attester count");
-    assertEq(stakingAsset.balanceOf(address(flushRewarder)), 1_000_000e18, "invalid balance");
-    assertEq(flushRewarder.rewardsOf(address(this)), 8 * flushRewarder.rewardPerInsertion(), "invalid rewards");
-
-    vm.expectRevert(abi.encodeWithSelector(Errors.Rollup__RewardsNotClaimable.selector));
-    flushRewarder.claimRewards();
-
-    vm.expectRevert(abi.encodeWithSelector(IFlushRewarder.InsufficientRewardsAvailable.selector));
-    flushRewarder.recover(address(stakingAsset), address(this), 1_000_000e18);
-  }
-
-  modifier givenRewardsClaimable() {
-    vm.prank(address(staking.getGSE().getGovernance()));
-    Rollup(address(staking)).setRewardsClaimable(true);
-    _;
-  }
-
-  function test_givenFundingGivenRewardsClaimable() external givenFunding givenRewardsClaimable {
+  function test_givenFunding() external givenFunding {
     uint256 attestersBefore = staking.getActiveAttesterCount();
     flushRewarder.flushEntryQueue();
 
@@ -92,57 +62,13 @@ contract RewardedFlushingTest is StakingBase {
     uint256 rewards = flushRewarder.rewardsOf(address(this));
     assertEq(rewards, 8 * flushRewarder.rewardPerInsertion(), "invalid rewards");
 
+    vm.expectRevert(abi.encodeWithSelector(IFlushRewarder.InsufficientRewardsAvailable.selector));
+    flushRewarder.recover(address(stakingAsset), address(this), 1_000_000e18);
+
     flushRewarder.claimRewards();
     assertEq(stakingAsset.balanceOf(address(flushRewarder)), 1_000_000e18 - rewards, "invalid balance");
     assertEq(flushRewarder.rewardsOf(address(this)), 0, "invalid rewards");
     assertEq(stakingAsset.balanceOf(address(this)), rewards, "invalid balance");
-  }
-
-  function test_revertWhen_setRewardsClaimableCalledTooSoon() external {
-    // Set up a specific unlock timestamp (e.g., 30 days from now)
-    uint256 unlockTimestamp = block.timestamp + 30 days;
-
-    // Use the existing rollup setup from StakingBase but create a new one with unlock timestamp
-    Rollup existingRollup = Rollup(address(staking));
-
-    // Get the config and modify the earliestRewardsClaimableTimestamp
-    RollupConfigInput memory config = TestConstants.getRollupConfigInput();
-    config.earliestRewardsClaimableTimestamp = Timestamp.wrap(unlockTimestamp);
-
-    // Deploy a new rollup with the unlock timestamp
-    Rollup testRollup = new Rollup(
-      existingRollup.getFeeAsset(),
-      existingRollup.getFeeAsset(),
-      staking.getGSE(),
-      new MockVerifier(),
-      address(this),
-      TestConstants.getGenesisState(),
-      config
-    );
-
-    // Verify the unlock timestamp was set correctly
-    assertEq(
-      Timestamp.unwrap(testRollup.getEarliestRewardsClaimableTimestamp()),
-      unlockTimestamp,
-      "unlock timestamp not set correctly"
-    );
-
-    // Warp to before the unlock timestamp
-    vm.warp(unlockTimestamp - 1);
-
-    // Try to set rewards claimable and expect revert
-    vm.expectRevert(
-      abi.encodeWithSelector(Errors.Rollup__TooSoonToSetRewardsClaimable.selector, unlockTimestamp, unlockTimestamp - 1)
-    );
-    testRollup.setRewardsClaimable(true);
-
-    // Warp to exactly the unlock timestamp
-    vm.warp(unlockTimestamp);
-
-    // Now it should succeed
-    testRollup.setRewardsClaimable(true);
-
-    assertTrue(testRollup.isRewardsClaimable(), "rewards should be claimable");
   }
 
   function _help_deposit(address _attester, address _withdrawer, bool _moveWithLatestRollup) internal {


### PR DESCRIPTION
## Summary

Remove the reward-claimability lock from `l1-contracts`.

Reward claims no longer depend on a governance-controlled flag or an unlock timestamp. Claims now succeed or fail only based on the existing reward/accounting rules, such as whether rewards exist and whether prover claims are past the proof deadline.

## What Changed

- Removed `isRewardsClaimable` and `earliestRewardsClaimableTimestamp` from reward storage.
- Removed the related ABI/config surface:
  - getters
  - setter
  - event
  - errors
  - rollup forwarding methods
- Removed reward-claimability checks from:
  - `claimSequencerRewards`
  - `claimProverRewards`
  - `FlushRewarder.claimRewards`
- Removed deploy/test config plumbing for the unlock timestamp.
- Rewrote the affected tests to cover the simplified behavior directly.
- Updated the current operator docs for claiming rewards.