### PR TITLE
fix: drop denoise/ from statuses

### DIFF
--- a/ci3/denoise
+++ b/ci3/denoise
@@ -148,7 +148,7 @@ if [ "$status" -ne 0 ]; then
     fi
     echo -e ". ${red}failed${reset} ($time) ${log_info:-}"
     if [ "${CI:-0}" == "1" ]; then
-      post_github_status failure "denoise/${display_cmd:0:240}" "$url" "failed ($time)" 2>/dev/null || true
+      post_github_status failure "${display_cmd:0:240}" "$url" "failed ($time)" 2>/dev/null || true
     fi
   fi
 else


### PR DESCRIPTION
This was an unnecessary low level detail.