### PR TITLE
fix: cancel SSM commands on signal to prevent orphaned in-progress commands

### DIFF
--- a/ci3/bootstrap_ec2
+++ b/ci3/bootstrap_ec2
@@ -48,7 +48,7 @@ cores=${CPUS:-$cores}
 # Trap function to terminate our running instance when the script exits.
 function cleanup {
   if [ -d "${state_dir:-}" ]; then
-    aws_terminate_instance "$state_dir"
+    aws_terminate_instance "$state_dir" >/dev/null 2>&1
   fi
 }
 # It's important that cleanup writes to /dev/null.

--- a/ci3/ssm_send_command
+++ b/ci3/ssm_send_command
@@ -71,6 +71,18 @@ fi
 
 echo "SSM command $command_id sent to $iid" >&2
 
+# Cancel the SSM command server-side on signal so it doesn't stay InProgress
+# after the instance is terminated. This is a runner→SSM-service API call,
+# independent of the SSM agent on the instance.
+# Exit so bootstrap_ec2's EXIT trap can run and terminate the EC2 instance.
+function cancel_ssm_command {
+  aws ssm cancel-command \
+    --region "$region" \
+    --command-id "$command_id" 2>/dev/null || true
+  exit 143  # 128 + 15 (SIGTERM)
+}
+trap cancel_ssm_command SIGINT SIGTERM
+
 # --- Step 2: Optionally skip polling (fire-and-forget) ---
 if [ "${SSM_NO_WAIT:-0}" -eq 1 ]; then
   exit 0


### PR DESCRIPTION
## Summary
- Add a `SIGINT`/`SIGTERM` trap in `ssm_send_command` that calls `aws ssm cancel-command` before exiting, preventing SSM commands from staying `InProgress` after the EC2 instance is terminated.
- Suppress output from `aws_terminate_instance` in `bootstrap_ec2`'s cleanup trap so it doesn't interfere with signal handling.

## Test plan
- [ ] Verify that interrupting a CI job (SIGTERM/SIGINT) cancels the SSM command server-side
- [ ] Verify normal (non-interrupted) SSM command execution is unaffected
- [ ] Verify `bootstrap_ec2` cleanup still terminates the instance correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)