### PR TITLE
feat: auto-generate fuzzer manifest from CMake build metadata

### DIFF
--- a/.github/workflows/fuzzing-docker-build.yml
+++ b/.github/workflows/fuzzing-docker-build.yml
@@ -32,6 +32,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
+        id: build
         uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25
         with:
           context: container-builds/fuzzing-container/src/
@@ -41,3 +42,15 @@ jobs:
             ghcr.io/aztecprotocol/fuzzing-container:${{ github.sha }}
           build-args: |
             COMMIT=${{ github.event_name == 'workflow_dispatch' && github.event.inputs.commit || github.sha }}
+
+      - name: Install oras
+        uses: oras-project/setup-oras@22ce207df3b08e061f537244349aac6ae1d214f6 # v1.2.4
+
+      - name: Extract and attach fuzzer manifest
+        run: |
+          docker create --name manifest-extract ghcr.io/aztecprotocol/fuzzing-container:${{ github.sha }}
+          docker cp manifest-extract:/home/fuzzer/aztec-packages/barretenberg/cpp/fuzzer_manifest.json ./fuzzer_manifest.json
+          docker rm manifest-extract
+          oras attach ghcr.io/aztecprotocol/fuzzing-container@${{ steps.build.outputs.digest }} \
+            --artifact-type application/vnd.aztec.fuzzer-manifest+json \
+            fuzzer_manifest.json

--- a/barretenberg/cpp/CMakeLists.txt
+++ b/barretenberg/cpp/CMakeLists.txt
@@ -178,6 +178,27 @@ endif()
 include(cmake/backward-cpp.cmake)
 
 add_subdirectory(src)
+
+# Generate fuzzer manifest after all modules have been processed
+if(FUZZING)
+    get_property(_manifest_entries GLOBAL PROPERTY BB_FUZZER_MANIFEST_ENTRIES)
+    file(WRITE "${CMAKE_BINARY_DIR}/fuzzer_entries.txt" "")
+    foreach(_entry ${_manifest_entries})
+        file(APPEND "${CMAKE_BINARY_DIR}/fuzzer_entries.txt" "${_entry}\n")
+    endforeach()
+
+    set(_preset_name "${FUZZER_PRESET_NAME}")
+
+    add_custom_target(fuzzer_manifest ALL
+        COMMAND ${CMAKE_COMMAND} -E env python3
+            ${CMAKE_SOURCE_DIR}/scripts/generate_fuzzer_manifest.py
+            ${CMAKE_BINARY_DIR}/fuzzer_entries.txt
+            ${CMAKE_BINARY_DIR}/bin/fuzzer_manifest.json
+            ${_preset_name}
+        COMMENT "Generating fuzzer manifest"
+    )
+endif()
+
 if (ENABLE_ASAN AND NOT(FUZZING))
     find_program(LLVM_SYMBOLIZER_PATH NAMES llvm-symbolizer-20)
     if (NOT(LLVM_SYMBOLIZER_PATH))

--- a/barretenberg/cpp/CMakePresets.json
+++ b/barretenberg/cpp/CMakePresets.json
@@ -228,7 +228,8 @@
         "AVM": "OFF",
         "AVM_TRANSPILER_LIB": "",
         "CMAKE_BUILD_TYPE": "RelWithAssert",
-        "MULTITHREADING": "OFF"
+        "MULTITHREADING": "OFF",
+        "FUZZER_PRESET_NAME": "${presetName}"
       }
     },
     {

--- a/barretenberg/cpp/cmake/module.cmake
+++ b/barretenberg/cpp/cmake/module.cmake
@@ -237,6 +237,14 @@ function(barretenberg_module_with_sources MODULE_NAME)
                 ${MODULE_DEPENDENCIES}
             )
 
+            # Record fuzzer metadata for manifest generation
+            get_filename_component(_fuzzer_dir "${FUZZER_SOURCE_FILE}" DIRECTORY)
+            file(RELATIVE_PATH _source_path
+                "${CMAKE_SOURCE_DIR}/src/barretenberg"
+                "${_fuzzer_dir}")
+            set_property(GLOBAL APPEND PROPERTY BB_FUZZER_MANIFEST_ENTRIES
+                "${MODULE_NAME}_${FUZZER_NAME_STEM}_fuzzer|${_source_path}")
+
             if(ENABLE_STACKTRACES)
                 target_link_libraries(
                     ${MODULE_NAME}_${FUZZER_NAME_STEM}_fuzzer

--- a/barretenberg/cpp/scripts/generate_fuzzer_manifest.py
+++ b/barretenberg/cpp/scripts/generate_fuzzer_manifest.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+"""Generate a per-preset fuzzer manifest from CMake-collected entries."""
+
+import json
+import os
+import sys
+
+
+def main():
+    entries_file = sys.argv[1]
+    output_file = sys.argv[2]
+    preset = sys.argv[3] if len(sys.argv) > 3 else "unknown"
+
+    fuzzers = []
+    if os.path.exists(entries_file):
+        with open(entries_file) as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                name, source_path = line.split("|", 1)
+                fuzzers.append({"name": name, "source_path": source_path})
+
+    os.makedirs(os.path.dirname(output_file), exist_ok=True)
+    with open(output_file, "w") as f:
+        json.dump({"version": 1, "preset": preset, "fuzzers": fuzzers}, f, indent=2)
+
+    print(f"Wrote {len(fuzzers)} fuzzers to {output_file} (preset: {preset})")
+
+
+if __name__ == "__main__":
+    main()

--- a/barretenberg/cpp/scripts/merge_fuzzer_manifests.py
+++ b/barretenberg/cpp/scripts/merge_fuzzer_manifests.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Merge per-preset fuzzer manifests into a unified manifest.
+
+Derives category, noasm, and has_coverage fields from which presets
+contain each fuzzer.
+"""
+
+import argparse
+import json
+import os
+import sys
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Merge per-preset fuzzer manifests")
+    parser.add_argument("manifests", nargs="+", help="Per-preset manifest JSON files")
+    parser.add_argument("--output", required=True, help="Output merged manifest path")
+    args = parser.parse_args()
+
+    # Collect fuzzers per preset
+    preset_fuzzers: dict[str, dict[str, str]] = {}  # preset -> {name: source_path}
+    for path in args.manifests:
+        if not os.path.exists(path):
+            print(f"Warning: {path} not found, skipping", file=sys.stderr)
+            continue
+        with open(path) as f:
+            manifest = json.load(f)
+        preset = manifest.get("preset", "unknown")
+        for fuzzer in manifest.get("fuzzers", []):
+            preset_fuzzers.setdefault(preset, {})[fuzzer["name"]] = fuzzer["source_path"]
+
+    # Build unified list
+    all_names: dict[str, str] = {}  # name -> source_path (first seen wins)
+    for fuzzers in preset_fuzzers.values():
+        for name, source_path in fuzzers.items():
+            if name not in all_names:
+                all_names[name] = source_path
+
+    bb_names = set(preset_fuzzers.get("fuzzing", {}).keys())
+    avm_names = set(preset_fuzzers.get("fuzzing-avm", {}).keys())
+    noasm_names = set(preset_fuzzers.get("fuzzing-noasm", {}).keys())
+    cov_names = set(preset_fuzzers.get("fuzzing-cov", {}).keys())
+
+    merged = []
+    for name, source_path in sorted(all_names.items()):
+        merged.append({
+            "name": name,
+            "source_path": source_path,
+            "category": "avm" if name in avm_names and name not in bb_names else "bb",
+            "noasm": name in noasm_names,
+            "has_coverage": name in cov_names,
+        })
+
+    os.makedirs(os.path.dirname(args.output) or ".", exist_ok=True)
+    with open(args.output, "w") as f:
+        json.dump({"version": 1, "fuzzers": merged}, f, indent=2)
+
+    print(f"Merged {len(merged)} fuzzers into {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/container-builds/fuzzing-container/src/Dockerfile
+++ b/container-builds/fuzzing-container/src/Dockerfile
@@ -65,6 +65,14 @@ RUN cmake --build build-fuzzing-cov
 RUN cmake -DCMAKE_C_COMPILER=clang-18 -DCMAKE_CXX_COMPILER=clang++-18 --preset fuzzing-avm
 RUN cmake --build build-fuzzing-avm && mv build-fuzzing-avm/bin bin-fuzzing-avm && rm -rf build-fuzzing-avm
 
+# Merge per-preset manifests into unified manifest
+RUN python3 scripts/merge_fuzzer_manifests.py \
+    bin-fuzzing/fuzzer_manifest.json \
+    bin-fuzzing-noasm/fuzzer_manifest.json \
+    bin-fuzzing-avm/fuzzer_manifest.json \
+    build-fuzzing-cov/bin/fuzzer_manifest.json \
+    --output /tmp/fuzzer_manifest.json
+
 # Runtime stage
 FROM ubuntu:noble AS runtime
 
@@ -102,6 +110,9 @@ COPY --from=builder /home/fuzzer/aztec-packages/barretenberg/cpp/build-fuzzing-c
 
 # Copy CRS
 COPY --from=builder /root/.bb-crs /root/.bb-crs
+
+# Copy fuzzer manifest
+COPY --from=builder /tmp/fuzzer_manifest.json ./fuzzer_manifest.json
 
 # Copy entrypoint script
 COPY entrypoint.sh .

--- a/container-builds/fuzzing-container/src/entrypoint.sh
+++ b/container-builds/fuzzing-container/src/entrypoint.sh
@@ -13,6 +13,7 @@ jobs_='4'
 workers='0'
 asm='on'
 show_only=0
+show_manifest=0
 avm='off'
 rss_limit='2048'
 
@@ -66,6 +67,7 @@ show_help() {
 	echo "  -r, --rss-limit <MB>        Set RSS limit in megabytes (default: 2048 MB)"
 	echo "  -h, --help                  Display this help and exit"
 	echo "  --show-fuzzers              Display the available fuzzers"
+	echo "  --show-manifest             Output the fuzzer manifest JSON"
 	echo ""
 	echo "This script handles fuzzing testing with specified parameters, managing crash reports,"
 	echo "and coverage testing based on the mode specified."
@@ -89,6 +91,10 @@ while [[ $# -gt 0 ]]; do
 		;;
 	--show-fuzzers)
 		show_only=1
+		shift
+		;;
+	--show-manifest)
+		show_manifest=1
 		shift
 		;;
 	-t | --timeout)
@@ -138,6 +144,11 @@ while [[ $# -gt 0 ]]; do
 done
 
 set_main_fuzzer
+
+if [[ "$show_manifest" -eq 1 ]]; then
+	cat ./fuzzer_manifest.json
+	exit 0
+fi
 
 if [[ "$show_only" -eq 1 ]]; then
 	show_fuzzers


### PR DESCRIPTION
## Summary
- Collects fuzzer binary names and source paths during CMake configuration via a global property in `module.cmake`
- Generates per-preset JSON manifests with a Python script invoked as a CMake custom target
- Merges per-preset manifests into a unified manifest during Docker build, tagging each fuzzer with category (bb/avm), noasm availability, and coverage support
- Adds `--show-manifest` flag to the entrypoint for runtime discovery of available fuzzers

## Test plan
- [x] Built `fuzzing` preset locally on macOS — verified `fuzzer_manifest.json` contains all 17 bb fuzzers
- [x] Built `fuzzing-noasm` preset — verified manifest generated with correct preset label
- [x] Built `fuzzing-avm` preset — verified 31 fuzzers (17 bb + 14 avm-specific)
- [x] Tested `merge_fuzzer_manifests.py` with real per-preset manifests — verified correct category/noasm/cov tagging
- [x] Tested `entrypoint.sh --show-manifest` flag — outputs manifest JSON and exits