### PR TITLE
feat(archiver): validate contract instance addresses before storing

### DIFF
--- a/yarn-project/archiver/src/modules/data_store_updater.ts
+++ b/yarn-project/archiver/src/modules/data_store_updater.ts
@@ -1,4 +1,5 @@
 import { BlockNumber, CheckpointNumber } from '@aztec/foundation/branded-types';
+import { filterAsync } from '@aztec/foundation/collection';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { createLogger } from '@aztec/foundation/log';
 import {
@@ -15,6 +16,7 @@ import { type PublishedCheckpoint, validateCheckpoint } from '@aztec/stdlib/chec
 import {
   type ExecutablePrivateFunctionWithMembershipProof,
   type UtilityFunctionWithMembershipProof,
+  computeContractAddressFromInstance,
   computePublicBytecodeCommitment,
   isValidPrivateFunctionMembershipProof,
   isValidUtilityFunctionMembershipProof,
@@ -356,10 +358,27 @@ export class ArchiverDataStoreUpdater {
     blockNum: BlockNumber,
     operation: Operation,
   ): Promise<boolean> {
-    const contractInstances = allLogs
+    const allInstances = allLogs
       .filter(log => ContractInstancePublishedEvent.isContractInstancePublishedEvent(log))
       .map(log => ContractInstancePublishedEvent.fromLog(log))
       .map(e => e.toContractInstance());
+
+    // Verify that each instance's address matches the one derived from its fields if we're adding
+    const contractInstances =
+      operation === Operation.Delete
+        ? allInstances
+        : await filterAsync(allInstances, async instance => {
+            const computedAddress = await computeContractAddressFromInstance(instance);
+            if (!computedAddress.equals(instance.address)) {
+              this.log.warn(
+                `Found contract instance with mismatched address at block ${blockNum}. Claimed ${instance.address} but computed ${computedAddress}.`,
+                { instanceAddress: instance.address.toString(), computedAddress: computedAddress.toString(), blockNum },
+              );
+              return false;
+            }
+            return true;
+          });
+
     if (contractInstances.length > 0) {
       contractInstances.forEach(c =>
         this.log.verbose(`${Operation[operation]} contract instance at ${c.address.toString()}`),

--- a/yarn-project/stdlib/src/contract/contract_address.test.ts
+++ b/yarn-project/stdlib/src/contract/contract_address.test.ts
@@ -1,4 +1,6 @@
 import { Fr } from '@aztec/foundation/curves/bn254';
+import { createLogger } from '@aztec/foundation/log';
+import { elapsed } from '@aztec/foundation/timer';
 
 import { type FunctionAbi, FunctionType } from '../abi/index.js';
 import { AztecAddress } from '../aztec-address/index.js';
@@ -64,17 +66,21 @@ describe('ContractAddress', () => {
     const initializationHash = new Fr(5n);
     const deployer = AztecAddress.fromField(new Fr(7));
     const publicKeys = (await deriveKeys(secretKey)).publicKeys;
-    const address = (
-      await computeContractAddressFromInstance({
-        publicKeys,
-        salt,
-        originalContractClassId: contractClassId,
-        currentContractClassId: contractClassId,
-        initializationHash,
-        deployer,
-        version: 1,
-      })
-    ).toString();
-    expect(address).toMatchInlineSnapshot(`"0x2cea4bfccb4a185354cbbd9eb5a39ace117abf1f9381c5b6167b1a6f94a0672c"`);
+    const instance = {
+      publicKeys,
+      salt,
+      originalContractClassId: contractClassId,
+      currentContractClassId: contractClassId,
+      initializationHash,
+      deployer,
+      version: 1 as const,
+    };
+
+    const [ms, address] = await elapsed(computeContractAddressFromInstance(instance));
+    const logger = createLogger('stdlib:contract_address:test');
+    logger.info(`Computed contract address from instance in ${ms}ms`);
+    expect(address.toString()).toMatchInlineSnapshot(
+      `"0x2cea4bfccb4a185354cbbd9eb5a39ace117abf1f9381c5b6167b1a6f94a0672c"`,
+    );
   });
 });


### PR DESCRIPTION
## Motivation

The archiver blindly stores contract instance data extracted from private logs without verifying that the claimed address matches the instance fields. While the p2p tx validator (#21771) catches this at the network layer, blocks received via req/resp or proposals skip that check. This adds a second line of defense at the storage layer.

## Approach

Before storing contract instances, the archiver now recomputes the address from the instance fields via `computeContractAddressFromInstance` and filters out any with mismatched addresses. The check is skipped during delete operations since we need to remove instances regardless.

## Changes

- **archiver**: Validate contract instance addresses in `updateDeployedContractInstances` before storing, filtering out mismatches with a warning log
- **stdlib (tests)**: Add elapsed timing to `computeContractAddressFromInstance` test (~1.3ms per call)