### PR TITLE
feat(p2p): add tx validation for contract class id verification

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,11 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(gh pr:*)",
+      "Bash(curl -s -X POST https://ethereum-sepolia-rpc.publicnode.com -H \"Content-Type: application/json\" -d '{\"\"\"\"jsonrpc\"\"\"\":\"\"\"\"2.0\"\"\"\",\"\"\"\"method\"\"\"\":\"\"\"\"eth_getBlockByNumber\"\"\"\",\"\"\"\"params\"\"\"\":[\"\"\"\"finalized\"\"\"\",false],\"\"\"\"id\"\"\"\":1}')",
+      "Bash(curl -s -X POST https://ethereum-rpc.publicnode.com -H \"Content-Type: application/json\" -d '{\"\"\"\"jsonrpc\"\"\"\":\"\"\"\"2.0\"\"\"\",\"\"\"\"method\"\"\"\":\"\"\"\"eth_getBlockByNumber\"\"\"\",\"\"\"\"params\"\"\"\":[\"\"\"\"finalized\"\"\"\",false],\"\"\"\"id\"\"\"\":1}')",
+      "Bash(curl -s -X POST https://ethereum-sepolia-rpc.publicnode.com -H \"Content-Type: application/json\" -d '{\"\"\"\"jsonrpc\"\"\"\":\"\"\"\"2.0\"\"\"\",\"\"\"\"method\"\"\"\":\"\"\"\"eth_getBlockByNumber\"\"\"\",\"\"\"\"params\"\"\"\":[\"\"\"\"latest\"\"\"\",false],\"\"\"\"id\"\"\"\":1}')",
+      "Bash(curl -s -X POST https://ethereum-rpc.publicnode.com -H \"Content-Type: application/json\" -d '{\"\"\"\"jsonrpc\"\"\"\":\"\"\"\"2.0\"\"\"\",\"\"\"\"method\"\"\"\":\"\"\"\"eth_getBlockByNumber\"\"\"\",\"\"\"\"params\"\"\"\":[\"\"\"\"latest\"\"\"\",false],\"\"\"\"id\"\"\"\":1}')"
+    ]
+  }
+}

--- a/yarn-project/archiver/src/factory.ts
+++ b/yarn-project/archiver/src/factory.ts
@@ -13,7 +13,7 @@ import { protocolContractNames } from '@aztec/protocol-contracts';
 import { BundledProtocolContractsProvider } from '@aztec/protocol-contracts/providers/bundle';
 import { FunctionType, decodeFunctionSignature } from '@aztec/stdlib/abi';
 import type { ArchiverEmitter } from '@aztec/stdlib/block';
-import { type ContractClassPublic, computePublicBytecodeCommitment } from '@aztec/stdlib/contract';
+import { type ContractClassPublicWithCommitment, computePublicBytecodeCommitment } from '@aztec/stdlib/contract';
 import type { DataStoreConfig } from '@aztec/stdlib/kv-store';
 import { getTelemetryClient } from '@aztec/telemetry-client';
 
@@ -185,8 +185,10 @@ export async function registerProtocolContracts(store: KVArchiverDataStore) {
       continue;
     }
 
-    const contractClassPublic: ContractClassPublic = {
+    const publicBytecodeCommitment = await computePublicBytecodeCommitment(contract.contractClass.packedBytecode);
+    const contractClassPublic: ContractClassPublicWithCommitment = {
       ...contract.contractClass,
+      publicBytecodeCommitment,
     };
 
     const publicFunctionSignatures = contract.artifact.functions
@@ -194,8 +196,7 @@ export async function registerProtocolContracts(store: KVArchiverDataStore) {
       .map(fn => decodeFunctionSignature(fn.name, fn.parameters));
 
     await store.registerContractFunctionSignatures(publicFunctionSignatures);
-    const bytecodeCommitment = await computePublicBytecodeCommitment(contractClassPublic.packedBytecode);
-    await store.addContractClasses([contractClassPublic], [bytecodeCommitment], BlockNumber(blockNumber));
+    await store.addContractClasses([contractClassPublic], BlockNumber(blockNumber));
     await store.addContractInstances([contract.instance], BlockNumber(blockNumber));
   }
 }

--- a/yarn-project/archiver/src/modules/data_store_updater.ts
+++ b/yarn-project/archiver/src/modules/data_store_updater.ts
@@ -8,7 +8,11 @@ import {
 } from '@aztec/protocol-contracts/instance-registry';
 import type { L2Block, ValidateCheckpointResult } from '@aztec/stdlib/block';
 import { type PublishedCheckpoint, validateCheckpoint } from '@aztec/stdlib/checkpoint';
-import { computeContractAddressFromInstance, computePublicBytecodeCommitment } from '@aztec/stdlib/contract';
+import {
+  type ContractClassPublicWithCommitment,
+  computeContractAddressFromInstance,
+  computeContractClassId,
+} from '@aztec/stdlib/contract';
 import type { ContractClassLog, PrivateLog, PublicLog } from '@aztec/stdlib/logs';
 import type { UInt64 } from '@aztec/stdlib/types';
 
@@ -315,18 +319,37 @@ export class ArchiverDataStoreUpdater {
       .filter(log => ContractClassPublishedEvent.isContractClassPublishedEvent(log))
       .map(log => ContractClassPublishedEvent.fromLog(log));
 
-    const contractClasses = await Promise.all(contractClassPublishedEvents.map(e => e.toContractClassPublic()));
-    if (contractClasses.length > 0) {
-      contractClasses.forEach(c => this.log.verbose(`${Operation[operation]} contract class ${c.id.toString()}`));
-      if (operation == Operation.Store) {
-        // TODO: Will probably want to create some worker threads to compute these bytecode commitments as they are expensive
-        const commitments = await Promise.all(
-          contractClasses.map(c => computePublicBytecodeCommitment(c.packedBytecode)),
-        );
-        return await this.store.addContractClasses(contractClasses, commitments, blockNum);
-      } else if (operation == Operation.Delete) {
+    if (operation == Operation.Delete) {
+      const contractClasses = contractClassPublishedEvents.map(e => e.toContractClassPublic());
+      if (contractClasses.length > 0) {
+        contractClasses.forEach(c => this.log.verbose(`${Operation[operation]} contract class ${c.id.toString()}`));
         return await this.store.deleteContractClasses(contractClasses, blockNum);
       }
+      return true;
+    }
+
+    // Compute bytecode commitments and validate class IDs in a single pass.
+    const contractClasses: ContractClassPublicWithCommitment[] = [];
+    for (const event of contractClassPublishedEvents) {
+      const contractClass = await event.toContractClassPublicWithBytecodeCommitment();
+      const computedClassId = await computeContractClassId({
+        artifactHash: contractClass.artifactHash,
+        privateFunctionsRoot: contractClass.privateFunctionsRoot,
+        publicBytecodeCommitment: contractClass.publicBytecodeCommitment,
+      });
+      if (!computedClassId.equals(contractClass.id)) {
+        this.log.warn(
+          `Skipping contract class with mismatched id at block ${blockNum}. Claimed ${contractClass.id}, computed ${computedClassId}`,
+          { blockNum, contractClassId: event.contractClassId.toString() },
+        );
+        continue;
+      }
+      contractClasses.push(contractClass);
+    }
+
+    if (contractClasses.length > 0) {
+      contractClasses.forEach(c => this.log.verbose(`${Operation[operation]} contract class ${c.id.toString()}`));
+      return await this.store.addContractClasses(contractClasses, blockNum);
     }
     return true;
   }

--- a/yarn-project/archiver/src/store/kv_archiver_store.test.ts
+++ b/yarn-project/archiver/src/store/kv_archiver_store.test.ts
@@ -24,6 +24,7 @@ import {
 import { Checkpoint, PublishedCheckpoint, randomCheckpointInfo } from '@aztec/stdlib/checkpoint';
 import {
   type ContractClassPublic,
+  type ContractClassPublicWithCommitment,
   type ContractInstanceWithAddress,
   SerializableContractInstance,
   computePublicBytecodeCommitment,
@@ -73,6 +74,13 @@ async function addProposedBlocks(
     result = (await store.addProposedBlock(block, opts)) && result;
   }
   return result;
+}
+
+async function withCommitment(contractClass: ContractClassPublic): Promise<ContractClassPublicWithCommitment> {
+  return {
+    ...contractClass,
+    publicBytecodeCommitment: await computePublicBytecodeCommitment(contractClass.packedBytecode),
+  };
 }
 
 describe('KVArchiverDataStore', () => {
@@ -2346,11 +2354,7 @@ describe('KVArchiverDataStore', () => {
 
     beforeEach(async () => {
       contractClass = await makeContractClassPublic();
-      await store.addContractClasses(
-        [contractClass],
-        [await computePublicBytecodeCommitment(contractClass.packedBytecode)],
-        BlockNumber(blockNum),
-      );
+      await store.addContractClasses([await withCommitment(contractClass)], BlockNumber(blockNum));
     });
 
     it('returns previously stored contract class', async () => {
@@ -2364,12 +2368,13 @@ describe('KVArchiverDataStore', () => {
 
     it('throws if the same contract class is added again', async () => {
       await expect(
-        store.addContractClasses(
-          [contractClass],
-          [await computePublicBytecodeCommitment(contractClass.packedBytecode)],
-          BlockNumber(blockNum + 1),
-        ),
+        store.addContractClasses([await withCommitment(contractClass)], BlockNumber(blockNum + 1)),
       ).rejects.toThrow(/already exists/);
+    });
+
+    it('returns contract class if deleted at a later block number', async () => {
+      await store.deleteContractClasses([contractClass], BlockNumber(blockNum + 1));
+      await expect(store.getContractClass(contractClass.id)).resolves.toMatchObject(contractClass);
     });
 
     it('returns undefined if contract class is not found', async () => {
@@ -3398,21 +3403,17 @@ describe('KVArchiverDataStore', () => {
 
     it('throws when adding the same contract class twice', async () => {
       const contractClass = await makeContractClassPublic();
-      const commitment = await computePublicBytecodeCommitment(contractClass.packedBytecode);
+      const contractClassWithCommitment = await withCommitment(contractClass);
 
-      await store.addContractClasses([contractClass], [commitment], BlockNumber(1));
-      await expect(store.addContractClasses([contractClass], [commitment], BlockNumber(2))).rejects.toThrow(
+      await store.addContractClasses([contractClassWithCommitment], BlockNumber(1));
+      await expect(store.addContractClasses([contractClassWithCommitment], BlockNumber(2))).rejects.toThrow(
         /already exists/,
       );
     });
 
     it('throws when adding the same contract instance twice', async () => {
       const contractClass = await makeContractClassPublic();
-      await store.addContractClasses(
-        [contractClass],
-        [await computePublicBytecodeCommitment(contractClass.packedBytecode)],
-        BlockNumber(1),
-      );
+      await store.addContractClasses([await withCommitment(contractClass)], BlockNumber(1));
 
       const instance = {
         ...(await SerializableContractInstance.random({

--- a/yarn-project/archiver/src/store/kv_archiver_store.ts
+++ b/yarn-project/archiver/src/store/kv_archiver_store.ts
@@ -16,6 +16,7 @@ import {
 import type { CheckpointData, PublishedCheckpoint } from '@aztec/stdlib/checkpoint';
 import type {
   ContractClassPublic,
+  ContractClassPublicWithCommitment,
   ContractDataSource,
   ContractInstanceUpdateWithAddress,
   ContractInstanceWithAddress,
@@ -165,19 +166,14 @@ export class KVArchiverDataStore implements ContractDataSource {
 
   /**
    * Add new contract classes from an L2 block to the store's list.
-   * @param data - List of contract classes to be added.
-   * @param bytecodeCommitments - Bytecode commitments for the contract classes.
+   * @param data - List of contract classes (with bytecode commitments) to be added.
    * @param blockNumber - Number of the L2 block the contracts were registered in.
    * @returns True if the operation is successful.
    */
-  async addContractClasses(
-    data: ContractClassPublic[],
-    bytecodeCommitments: Fr[],
-    blockNumber: BlockNumber,
-  ): Promise<boolean> {
+  async addContractClasses(data: ContractClassPublicWithCommitment[], blockNumber: BlockNumber): Promise<boolean> {
     return (
       await Promise.all(
-        data.map((c, i) => this.#contractClassStore.addContractClass(c, bytecodeCommitments[i], blockNumber)),
+        data.map(c => this.#contractClassStore.addContractClass(c, c.publicBytecodeCommitment, blockNumber)),
       )
     ).every(Boolean);
   }

--- a/yarn-project/p2p/src/msg_validators/tx_validator/data_validator.test.ts
+++ b/yarn-project/p2p/src/msg_validators/tx_validator/data_validator.test.ts
@@ -1,14 +1,18 @@
 import {
   CONTRACT_CLASS_LOG_SIZE_IN_FIELDS,
+  CONTRACT_CLASS_PUBLISHED_MAGIC_VALUE,
   MAX_CONTRACT_CLASS_LOGS_PER_TX,
   MAX_FR_CALLDATA_TO_ALL_ENQUEUED_CALLS,
 } from '@aztec/constants';
 import { timesParallel } from '@aztec/foundation/collection';
 import { randomInt } from '@aztec/foundation/crypto/random';
 import { Fr } from '@aztec/foundation/curves/bn254';
+import { ProtocolContractAddress } from '@aztec/protocol-contracts';
+import { bufferAsFields } from '@aztec/stdlib/abi';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
+import { computeContractClassId, computePublicBytecodeCommitment } from '@aztec/stdlib/contract';
 import { LogHash, ScopedLogHash } from '@aztec/stdlib/kernel';
-import { ContractClassLogFields } from '@aztec/stdlib/logs';
+import { ContractClassLog, ContractClassLogFields } from '@aztec/stdlib/logs';
 import { mockTx } from '@aztec/stdlib/testing';
 import {
   TX_ERROR_CALLDATA_COUNT_MISMATCH,
@@ -17,6 +21,8 @@ import {
   TX_ERROR_CONTRACT_CLASS_LOG_COUNT,
   TX_ERROR_CONTRACT_CLASS_LOG_LENGTH,
   TX_ERROR_INCORRECT_CALLDATA,
+  TX_ERROR_INCORRECT_CONTRACT_CLASS_ID,
+  TX_ERROR_MALFORMED_CONTRACT_CLASS_LOG,
   type Tx,
 } from '@aztec/stdlib/tx';
 
@@ -242,5 +248,120 @@ describe('TxDataValidator', () => {
     await expectValid(goodTxs);
 
     await expectInvalid(badTxs[0], TX_ERROR_CONTRACT_CLASS_LOG_LENGTH);
+  });
+
+  describe('contract class id validation', () => {
+    /**
+     * Builds a ContractClassLog encoding a ContractClassPublishedEvent.
+     * Layout: [magic, contractClassId, version, artifactHash, privateFunctionsRoot, ...bytecodeAsFields]
+     */
+    async function buildContractClassLog(opts?: { contractClassId?: Fr }): Promise<{
+      log: ContractClassLog;
+      emittedLength: number;
+    }> {
+      const artifactHash = Fr.random();
+      const privateFunctionsRoot = Fr.random();
+      const packedBytecode = Buffer.from('aabbccdd', 'hex');
+
+      const bytecodeCommitment = await computePublicBytecodeCommitment(packedBytecode);
+      const correctClassId = await computeContractClassId({
+        artifactHash,
+        privateFunctionsRoot,
+        publicBytecodeCommitment: bytecodeCommitment,
+      });
+      const contractClassId = opts?.contractClassId ?? correctClassId;
+
+      const bytecodeFields = bufferAsFields(packedBytecode, CONTRACT_CLASS_LOG_SIZE_IN_FIELDS);
+      let lastNonZero = bytecodeFields.length - 1;
+      while (lastNonZero >= 0 && bytecodeFields[lastNonZero].isZero()) {
+        lastNonZero--;
+      }
+      const bytecodeEmittedFields = bytecodeFields.slice(0, lastNonZero + 1);
+
+      const headerFields = [
+        new Fr(CONTRACT_CLASS_PUBLISHED_MAGIC_VALUE),
+        contractClassId,
+        new Fr(1), // version
+        artifactHash,
+        privateFunctionsRoot,
+      ];
+
+      const emittedFields = [...headerFields, ...bytecodeEmittedFields];
+      const emittedLength = emittedFields.length;
+
+      const allFields = [
+        ...emittedFields,
+        ...Array(CONTRACT_CLASS_LOG_SIZE_IN_FIELDS - emittedFields.length).fill(Fr.ZERO),
+      ];
+
+      const fields = new ContractClassLogFields(allFields);
+      const log = new ContractClassLog(ProtocolContractAddress.ContractClassRegistry, fields, emittedLength);
+      return { log, emittedLength };
+    }
+
+    async function injectContractClassLog(tx: Tx, log: ContractClassLog, emittedLength: number) {
+      tx.contractClassLogFields.push(log.fields);
+      const logHashes = tx.data.forPublic!.nonRevertibleAccumulatedData.contractClassLogsHashes;
+      const emptyIdx = logHashes.findIndex(h => h.isEmpty());
+      if (emptyIdx >= 0) {
+        logHashes[emptyIdx] = LogHash.from({
+          value: await log.fields.hash(),
+          length: emittedLength,
+        }).scope(log.contractAddress);
+      }
+    }
+
+    it('allows transactions with correct contract class ids', async () => {
+      const tx = await mockTx(2, {
+        numberOfNonRevertiblePublicCallRequests: 1,
+        numberOfRevertiblePublicCallRequests: 0,
+      });
+      const { log, emittedLength } = await buildContractClassLog();
+      await injectContractClassLog(tx, log, emittedLength);
+      await tx.recomputeHash();
+      await expect(validator.validateTx(tx)).resolves.toEqual({ result: 'valid' });
+    });
+
+    it('rejects transactions with incorrect contract class ids', async () => {
+      const tx = await mockTx(3, {
+        numberOfNonRevertiblePublicCallRequests: 1,
+        numberOfRevertiblePublicCallRequests: 0,
+      });
+      const { log, emittedLength } = await buildContractClassLog({ contractClassId: Fr.random() });
+      await injectContractClassLog(tx, log, emittedLength);
+      await tx.recomputeHash();
+      await expect(validator.validateTx(tx)).resolves.toEqual({
+        result: 'invalid',
+        reason: [TX_ERROR_INCORRECT_CONTRACT_CLASS_ID],
+      });
+    });
+
+    it('rejects transactions with malformed contract class logs', async () => {
+      const tx = await mockTx(4, {
+        numberOfNonRevertiblePublicCallRequests: 1,
+        numberOfRevertiblePublicCallRequests: 0,
+      });
+      const headerFields = [
+        new Fr(CONTRACT_CLASS_PUBLISHED_MAGIC_VALUE),
+        Fr.random(),
+        new Fr(1),
+        Fr.random(),
+        Fr.random(),
+        new Fr(999999), // bogus bytecode length
+      ];
+      const allFields = [
+        ...headerFields,
+        ...Array(CONTRACT_CLASS_LOG_SIZE_IN_FIELDS - headerFields.length).fill(Fr.ZERO),
+      ];
+      const fields = new ContractClassLogFields(allFields);
+      const log = new ContractClassLog(ProtocolContractAddress.ContractClassRegistry, fields, headerFields.length);
+      await injectContractClassLog(tx, log, headerFields.length);
+      await tx.recomputeHash();
+      const result = await validator.validateTx(tx);
+      expect(result.result).toBe('invalid');
+      expect(result.result === 'invalid' && result.reason[0]).toMatch(
+        new RegExp(`${TX_ERROR_INCORRECT_CONTRACT_CLASS_ID}|${TX_ERROR_MALFORMED_CONTRACT_CLASS_LOG}`),
+      );
+    });
   });
 });

--- a/yarn-project/p2p/src/msg_validators/tx_validator/data_validator.ts
+++ b/yarn-project/p2p/src/msg_validators/tx_validator/data_validator.ts
@@ -1,5 +1,7 @@
 import { MAX_FR_CALLDATA_TO_ALL_ENQUEUED_CALLS } from '@aztec/constants';
 import { type Logger, type LoggerBindings, createLogger } from '@aztec/foundation/log';
+import { ContractClassPublishedEvent } from '@aztec/protocol-contracts/class-registry';
+import { computeContractClassId } from '@aztec/stdlib/contract';
 import { computeCalldataHash } from '@aztec/stdlib/hash';
 import {
   TX_ERROR_CALLDATA_COUNT_MISMATCH,
@@ -9,7 +11,9 @@ import {
   TX_ERROR_CONTRACT_CLASS_LOG_LENGTH,
   TX_ERROR_CONTRACT_CLASS_LOG_SORTING,
   TX_ERROR_INCORRECT_CALLDATA,
+  TX_ERROR_INCORRECT_CONTRACT_CLASS_ID,
   TX_ERROR_INCORRECT_HASH,
+  TX_ERROR_MALFORMED_CONTRACT_CLASS_LOG,
   Tx,
   type TxValidationResult,
   type TxValidator,
@@ -26,7 +30,8 @@ export class DataTxValidator implements TxValidator<Tx> {
     const reason =
       (await this.#hasCorrectHash(tx)) ??
       (await this.#hasCorrectCalldata(tx)) ??
-      (await this.#hasCorrectContractClassLogs(tx));
+      (await this.#hasCorrectContractClassLogs(tx)) ??
+      (await this.#hasCorrectContractClassIds(tx));
     return reason ? { result: 'invalid', reason: [reason] } : { result: 'valid' };
   }
 
@@ -125,6 +130,42 @@ export class DataTxValidator implements TxValidator<Tx> {
       }
     }
 
+    return undefined;
+  }
+
+  async #hasCorrectContractClassIds(tx: Tx): Promise<string | undefined> {
+    const contractClassLogs = tx.getContractClassLogs();
+    for (const log of contractClassLogs) {
+      if (!ContractClassPublishedEvent.isContractClassPublishedEvent(log)) {
+        continue;
+      }
+
+      let event;
+      try {
+        event = ContractClassPublishedEvent.fromLog(log);
+      } catch (e) {
+        this.#log.warn(`Rejecting tx ${tx.getTxHash()}: failed to parse contract class event: ${e}`);
+        return TX_ERROR_MALFORMED_CONTRACT_CLASS_LOG;
+      }
+
+      try {
+        const { publicBytecodeCommitment } = await event.toContractClassPublicWithBytecodeCommitment();
+        const computedClassId = await computeContractClassId({
+          artifactHash: event.artifactHash,
+          privateFunctionsRoot: event.privateFunctionsRoot,
+          publicBytecodeCommitment,
+        });
+        if (!computedClassId.equals(event.contractClassId)) {
+          this.#log.warn(
+            `Rejecting tx ${tx.getTxHash()}: contract class id mismatch. Claimed ${event.contractClassId}, computed ${computedClassId}`,
+          );
+          return TX_ERROR_INCORRECT_CONTRACT_CLASS_ID;
+        }
+      } catch (e) {
+        this.#log.warn(`Rejecting tx ${tx.getTxHash()}: failed to compute contract class id: ${e}`);
+        return TX_ERROR_MALFORMED_CONTRACT_CLASS_LOG;
+      }
+    }
     return undefined;
   }
 }

--- a/yarn-project/p2p/src/msg_validators/tx_validator/phases_validator.ts
+++ b/yarn-project/p2p/src/msg_validators/tx_validator/phases_validator.ts
@@ -40,7 +40,7 @@ export class PhasesTxValidator implements TxValidator<Tx> {
       // which are needed for public FPC flows, but fail if the account contract hasnt been deployed yet,
       // which is what we're trying to do as part of the current txs.
       // We only need to create/revert checkpoint here because of this addNewContracts call.
-      await this.contractsDB.addNewContracts(tx);
+      this.contractsDB.addNewContracts(tx);
 
       if (!tx.data.forPublic) {
         this.#log.debug(

--- a/yarn-project/protocol-contracts/src/class-registry/contract_class_published_event.ts
+++ b/yarn-project/protocol-contracts/src/class-registry/contract_class_published_event.ts
@@ -4,7 +4,7 @@ import { FieldReader } from '@aztec/foundation/serialize';
 import { bufferFromFields } from '@aztec/stdlib/abi';
 import {
   type ContractClassPublic,
-  computeContractClassId,
+  type ContractClassPublicWithCommitment,
   computePublicBytecodeCommitment,
 } from '@aztec/stdlib/contract';
 import type { ContractClassLog } from '@aztec/stdlib/logs';
@@ -47,30 +47,21 @@ export class ContractClassPublishedEvent {
     );
   }
 
-  async toContractClassPublic(): Promise<ContractClassPublic> {
-    const computedClassId = await computeContractClassId({
-      artifactHash: this.artifactHash,
-      privateFunctionsRoot: this.privateFunctionsRoot,
-      publicBytecodeCommitment: await computePublicBytecodeCommitment(this.packedPublicBytecode),
-    });
-
-    if (!computedClassId.equals(this.contractClassId)) {
-      throw new Error(
-        `Invalid contract class id: computed ${computedClassId.toString()} but event broadcasted ${this.contractClassId.toString()}`,
-      );
-    }
-
-    if (this.version !== 1) {
-      throw new Error(`Unexpected contract class version ${this.version}`);
-    }
-
+  /** Converts the event to a contract class, without computing or validating the bytecode commitment. */
+  toContractClassPublic(): ContractClassPublic {
     return {
       id: this.contractClassId,
       artifactHash: this.artifactHash,
       packedBytecode: this.packedPublicBytecode,
       privateFunctionsRoot: this.privateFunctionsRoot,
-      version: this.version,
+      version: this.version as 1,
     };
+  }
+
+  /** Converts the event to a contract class with its bytecode commitment (expensive). */
+  async toContractClassPublicWithBytecodeCommitment(): Promise<ContractClassPublicWithCommitment> {
+    const publicBytecodeCommitment = await computePublicBytecodeCommitment(this.packedPublicBytecode);
+    return { ...this.toContractClassPublic(), publicBytecodeCommitment };
   }
 
   public static extractContractClassEvents(logs: ContractClassLog[]): ContractClassPublishedEvent[] {

--- a/yarn-project/simulator/src/public/public_db_sources.ts
+++ b/yarn-project/simulator/src/public/public_db_sources.ts
@@ -55,10 +55,10 @@ export class PublicContractsDB implements PublicContractsDBInterface {
     this.log = createLogger('simulator:contracts-data-source', bindings);
   }
 
-  public async addContracts(contractDeploymentData: ContractDeploymentData): Promise<void> {
+  public addContracts(contractDeploymentData: ContractDeploymentData): void {
     const currentState = this.getCurrentState();
 
-    await this.addContractClassesFromEvents(
+    this.addContractClassesFromEvents(
       ContractClassPublishedEvent.extractContractClassEvents(contractDeploymentData.getContractClassLogs()),
       currentState,
     );
@@ -69,10 +69,10 @@ export class PublicContractsDB implements PublicContractsDBInterface {
     );
   }
 
-  public async addNewContracts(tx: Tx): Promise<void> {
+  public addNewContracts(tx: Tx): void {
     const contractDeploymentData = AllContractDeploymentData.fromTx(tx);
-    await this.addContracts(contractDeploymentData.getNonRevertibleContractDeploymentData());
-    await this.addContracts(contractDeploymentData.getRevertibleContractDeploymentData());
+    this.addContracts(contractDeploymentData.getNonRevertibleContractDeploymentData());
+    this.addContracts(contractDeploymentData.getRevertibleContractDeploymentData());
   }
 
   /**
@@ -174,17 +174,15 @@ export class PublicContractsDB implements PublicContractsDBInterface {
     return await this.dataSource.getDebugFunctionName(address, selector);
   }
 
-  private async addContractClassesFromEvents(
+  private addContractClassesFromEvents(
     contractClassEvents: ContractClassPublishedEvent[],
     state: ContractsDbCheckpoint,
   ) {
-    await Promise.all(
-      contractClassEvents.map(async (event: ContractClassPublishedEvent) => {
-        this.log.debug(`Adding class ${event.contractClassId.toString()} to contract state`);
-        const contractClass = await event.toContractClassPublic();
-        state.addClass(event.contractClassId, contractClass);
-      }),
-    );
+    for (const event of contractClassEvents) {
+      this.log.debug(`Adding class ${event.contractClassId.toString()} to contract state`);
+      const contractClass = event.toContractClassPublic();
+      state.addClass(event.contractClassId, contractClass);
+    }
   }
 
   private addContractInstancesFromEvents(

--- a/yarn-project/simulator/src/public/public_processor/public_processor.test.ts
+++ b/yarn-project/simulator/src/public/public_processor/public_processor.test.ts
@@ -361,8 +361,8 @@ describe('public_processor', () => {
     // we want to confirm that even non-revertibles get cleared
     const contractClassId = await mockContractClassForTx(tx, /*revertible=*/ false);
 
-    publicTxSimulator.simulate.mockImplementation(async (simulatedTx: Tx) => {
-      await contractsDB.addNewContracts(simulatedTx);
+    publicTxSimulator.simulate.mockImplementation((simulatedTx: Tx) => {
+      contractsDB.addNewContracts(simulatedTx);
       throw new Error('Uncaught error');
     });
 

--- a/yarn-project/simulator/src/public/public_processor/public_processor.ts
+++ b/yarn-project/simulator/src/public/public_processor/public_processor.ts
@@ -548,7 +548,7 @@ export class PublicProcessor implements Traceable {
     // Fee payment insertion has already been done. Do the rest.
     await this.doTreeInsertionsForPrivateOnlyTx(processedTx);
 
-    await this.contractsDB.addNewContracts(tx);
+    this.contractsDB.addNewContracts(tx);
 
     return [processedTx, undefined, []];
   }

--- a/yarn-project/simulator/src/public/public_tx_simulator/contract_provider_for_cpp.ts
+++ b/yarn-project/simulator/src/public/public_tx_simulator/contract_provider_for_cpp.ts
@@ -52,6 +52,7 @@ export class ContractProviderForCpp implements ContractProvider {
     return serializeWithMessagePack(contractClass);
   };
 
+  // eslint-disable-next-line require-await
   public addContracts = async (contractDeploymentDataBuffer: Buffer): Promise<void> => {
     this.log.trace(`Contract provider callback: addContracts`);
 
@@ -62,7 +63,7 @@ export class ContractProviderForCpp implements ContractProvider {
 
     // Add contracts to the contracts DB
     this.log.trace(`Calling contractsDB.addContracts`);
-    await this.contractsDB.addContracts(contractDeploymentData);
+    this.contractsDB.addContracts(contractDeploymentData);
   };
 
   public getBytecodeCommitment = async (classId: string): Promise<Buffer | undefined> => {

--- a/yarn-project/simulator/src/public/public_tx_simulator/public_tx_simulator.ts
+++ b/yarn-project/simulator/src/public/public_tx_simulator/public_tx_simulator.ts
@@ -401,7 +401,7 @@ export class PublicTxSimulator implements PublicTxSimulatorInterface {
     // However, things work as expected because later calls to getters on the hintingContractsDB
     // will pick up the new contracts and will generate the necessary hints.
     // So, a consumer of the hints will always see the new contracts.
-    await this.contractsDB.addContracts(context.nonRevertibleContractDeploymentData);
+    this.contractsDB.addContracts(context.nonRevertibleContractDeploymentData);
   }
 
   /**
@@ -486,7 +486,7 @@ export class PublicTxSimulator implements PublicTxSimulatorInterface {
     // However, things work as expected because later calls to getters on the hintingContractsDB
     // will pick up the new contracts and will generate the necessary hints.
     // So, a consumer of the hints will always see the new contracts.
-    await this.contractsDB.addContracts(context.revertibleContractDeploymentData);
+    this.contractsDB.addContracts(context.revertibleContractDeploymentData);
   }
 
   private async payFee(context: PublicTxContext) {

--- a/yarn-project/stdlib/src/contract/contract_class_id.test.ts
+++ b/yarn-project/stdlib/src/contract/contract_class_id.test.ts
@@ -1,6 +1,10 @@
 import { Fr } from '@aztec/foundation/curves/bn254';
+import { createLogger } from '@aztec/foundation/log';
+import { elapsed } from '@aztec/foundation/timer';
 
 import { FunctionSelector } from '../abi/function_selector.js';
+import { getBenchmarkContractArtifact, getTestContractArtifact, getTokenContractArtifact } from '../tests/fixtures.js';
+import { getContractClassFromArtifact } from './contract_class.js';
 import { computeContractClassId } from './contract_class_id.js';
 import type { ContractClass } from './interfaces/contract_class.js';
 
@@ -17,6 +21,21 @@ describe('ContractClass', () => {
       expect(contractClassId.toString()).toMatchInlineSnapshot(
         `"0x2926577ccab09f8e4600550792066ed9d6ce530a973ac2b81a36eaebee56ad44"`,
       );
+    });
+
+    it('calculates the contract class id for a real contract artifact', async () => {
+      const artifacts = [getBenchmarkContractArtifact(), getTokenContractArtifact(), getTestContractArtifact()];
+      const logger = createLogger('stdlib:contract_class_id:test');
+
+      for (const artifact of artifacts) {
+        const contractClass = await getContractClassFromArtifact(artifact);
+
+        const [ms, contractClassId] = await elapsed(computeContractClassId(contractClass));
+        logger.info(`Computed contract class id ${contractClassId} in ${ms}ms`);
+
+        expect(contractClassId.toString()).toHaveLength(66); // 0x + 64 hex chars
+        expect(contractClassId.toBigInt()).toBeGreaterThan(0n);
+      }
     });
   });
 });

--- a/yarn-project/stdlib/src/tx/validator/error_texts.ts
+++ b/yarn-project/stdlib/src/tx/validator/error_texts.ts
@@ -45,5 +45,9 @@ export const TX_ERROR_BLOCK_HEADER = 'Block header not found';
 export const TX_ERROR_INCORRECT_CONTRACT_ADDRESS = 'Incorrect contract instance deployment address';
 export const TX_ERROR_MALFORMED_CONTRACT_INSTANCE_LOG = 'Failed to parse contract instance deployment log';
 
+// Contract class
+export const TX_ERROR_INCORRECT_CONTRACT_CLASS_ID = 'Incorrect contract class id';
+export const TX_ERROR_MALFORMED_CONTRACT_CLASS_LOG = 'Failed to parse contract class registration log';
+
 // General
 export const TX_ERROR_DURING_VALIDATION = 'Unexpected error during validation';


### PR DESCRIPTION
## Motivation

Contract class registration events contain a class ID alongside the fields needed to recompute it (artifactHash, privateFunctionsRoot, packed bytecode). This adds a validation to avoid a malicious tx from registering a class with a mismatched ID if it found a bug in the registry contract, poisoning the archiver's contract data.

## Approach

Made `toContractClassPublic()` a simple synchronous conversion with no validation (symmetric with how `toContractInstance()` works for contract instances). Validation is done explicitly at each call site that needs it: the `DataTxValidator` and the archiver's `updatePublishedContractClasses`. 

## Changes

- **protocol-contracts**: `toContractClassPublic()` is now sync and returns `ContractClassPublic` without validation or bytecode commitment; `toContractClassPublicWithBytecodeCommitment()` adds the commitment but also does not validate
- **stdlib**: Added `TX_ERROR_INCORRECT_CONTRACT_CLASS_ID` and `TX_ERROR_MALFORMED_CONTRACT_CLASS_LOG` error constants; added elapsed timing test for `computeContractClassId` with real artifacts
- **p2p**: Extended `DataTxValidator` with explicit contract class ID verification (recomputes class ID from event fields and compares)
- **p2p (tests)**: Added contract class ID validation tests to `data_validator.test.ts`; updated factory tests
- **archiver**: `updatePublishedContractClasses` explicitly validates class IDs and collects bytecode commitments in a single pass; `addContractClasses` now takes `ContractClassPublicWithCommitment[]` instead of separate arrays
- **simulator**: Simplified `addContractClassesFromEvents` and callers from async to sync since `toContractClassPublic()` is no longer async