### PR TITLE
chore: Properly compute finalized block (#21156)

### DIFF
--- a/barretenberg/rust/bootstrap.sh
+++ b/barretenberg/rust/bootstrap.sh
@@ -60,6 +60,12 @@ function release {
     (cd ../ts && yarn generate)
   fi
 
+  # Check if this version is already published on crates.io (idempotent re-runs).
+  if curl -sf -H "User-Agent: aztec-packages-ci (tech@aztec-labs.com)" "https://crates.io/api/v1/crates/barretenberg-rs/$version" | jq -e '.version.num' &>/dev/null; then
+    echo "barretenberg-rs@$version already published on crates.io. Skipping."
+    return 0
+  fi
+
   # Publish to crates.io (--allow-dirty because version was just set and generated files are gitignored)
   local extra_flags=""
   if ! gh release view "v$version" --repo AztecProtocol/aztec-packages &>/dev/null; then

--- a/yarn-project/archiver/src/archiver-misc.test.ts
+++ b/yarn-project/archiver/src/archiver-misc.test.ts
@@ -55,9 +55,7 @@ describe('Archiver misc', () => {
 
     const tracer = getTelemetryClient().getTracer('');
     const instrumentation = mock<ArchiverInstrumentation>({ isEnabled: () => true, tracer });
-    const archiverStore = new KVArchiverDataStore(await openTmpStore('archiver_misc_test'), 1000, {
-      epochDuration: EPOCH_DURATION,
-    });
+    const archiverStore = new KVArchiverDataStore(await openTmpStore('archiver_misc_test'), 1000);
     const events = new EventEmitter() as ArchiverEmitter;
     const l2TipsCache = new L2TipsCache(archiverStore.blockStore);
 

--- a/yarn-project/archiver/src/archiver-store.test.ts
+++ b/yarn-project/archiver/src/archiver-store.test.ts
@@ -61,7 +61,7 @@ describe('Archiver Store', () => {
     const tracer = getTelemetryClient().getTracer('');
     instrumentation = mock<ArchiverInstrumentation>({ isEnabled: () => true, tracer });
 
-    archiverStore = new KVArchiverDataStore(await openTmpStore('archiver_test'), 1000, { epochDuration: 4 });
+    archiverStore = new KVArchiverDataStore(await openTmpStore('archiver_test'), 1000);
 
     l1Constants = {
       l1GenesisTime: BigInt(now),
@@ -543,6 +543,48 @@ describe('Archiver Store', () => {
 
       expect(await archiver.getSynchedCheckpointNumber()).toEqual(CheckpointNumber(2));
       expect(await archiver.getProvenCheckpointNumber()).toEqual(CheckpointNumber(1));
+    });
+
+    it('rolls back finalized checkpoint number when target is before finalized block', async () => {
+      const genesisArchive = new AppendOnlyTreeSnapshot(new Fr(GENESIS_ARCHIVE_ROOT), 1);
+      // Checkpoint 1: blocks 1-2, Checkpoint 2: blocks 3-4, Checkpoint 3: blocks 5-6
+      const testCheckpoints = await makeChainedCheckpoints(3, {
+        previousArchive: genesisArchive,
+        blocksPerCheckpoint: 2,
+      });
+      await archiverStore.addCheckpoints(testCheckpoints);
+
+      // Mark checkpoints 1 and 2 as proven and finalized
+      await archiverStore.setProvenCheckpointNumber(CheckpointNumber(2));
+      await archiverStore.setFinalizedCheckpointNumber(CheckpointNumber(2));
+      expect(await archiver.getFinalizedL2BlockNumber()).toEqual(BlockNumber(4));
+
+      // Roll back to block 2 (end of checkpoint 1), which is before finalized block 4
+      await archiver.rollbackTo(BlockNumber(2));
+
+      expect(await archiver.getSynchedCheckpointNumber()).toEqual(CheckpointNumber(1));
+      expect(await archiver.getFinalizedL2BlockNumber()).toEqual(BlockNumber(2));
+    });
+
+    it('preserves finalized checkpoint number when target is after finalized block', async () => {
+      const genesisArchive = new AppendOnlyTreeSnapshot(new Fr(GENESIS_ARCHIVE_ROOT), 1);
+      // Checkpoint 1: blocks 1-2, Checkpoint 2: blocks 3-4, Checkpoint 3: blocks 5-6
+      const testCheckpoints = await makeChainedCheckpoints(3, {
+        previousArchive: genesisArchive,
+        blocksPerCheckpoint: 2,
+      });
+      await archiverStore.addCheckpoints(testCheckpoints);
+
+      // Mark checkpoint 1 as finalized, checkpoint 2 as proven
+      await archiverStore.setProvenCheckpointNumber(CheckpointNumber(2));
+      await archiverStore.setFinalizedCheckpointNumber(CheckpointNumber(1));
+      expect(await archiver.getFinalizedL2BlockNumber()).toEqual(BlockNumber(2));
+
+      // Roll back to block 4 (end of checkpoint 2), which is after finalized block 2
+      await archiver.rollbackTo(BlockNumber(4));
+
+      expect(await archiver.getSynchedCheckpointNumber()).toEqual(CheckpointNumber(2));
+      expect(await archiver.getFinalizedL2BlockNumber()).toEqual(BlockNumber(2));
     });
   });
 });

--- a/yarn-project/archiver/src/archiver-sync.test.ts
+++ b/yarn-project/archiver/src/archiver-sync.test.ts
@@ -95,7 +95,7 @@ describe('Archiver Sync', () => {
     instrumentation = mock<ArchiverInstrumentation>({ isEnabled: () => true, tracer });
 
     // Create archiver store
-    archiverStore = new KVArchiverDataStore(await openTmpStore('archiver_sync_test'), 1000, { epochDuration: 32 });
+    archiverStore = new KVArchiverDataStore(await openTmpStore('archiver_sync_test'), 1000);
 
     const contractAddresses = {
       registryAddress,
@@ -1223,6 +1223,71 @@ describe('Archiver Sync', () => {
 
       expect(await archiver.getCheckpointNumber()).toEqual(CheckpointNumber(2));
     }, 15_000);
+  });
+
+  describe('finalized checkpoint', () => {
+    it('reports no finalized blocks before any checkpoint is proven', async () => {
+      fake.setL1BlockNumber(100n);
+      fake.setFinalizedL1BlockNumber(100n);
+      await archiver.syncImmediate();
+
+      const tips = await archiver.getL2Tips();
+      expect(tips.finalized.checkpoint.number).toEqual(CheckpointNumber(0));
+      expect(tips.finalized.block.number).toEqual(BlockNumber(0));
+    });
+
+    it('updates finalized checkpoint when the L1 finalized block is at or past the proven checkpoint L1 block', async () => {
+      const { checkpoint: cp1 } = await fake.addCheckpoint(CheckpointNumber(1), {
+        l1BlockNumber: 70n,
+        messagesL1BlockNumber: 50n,
+        numL1ToL2Messages: 3,
+      });
+
+      // Sync all checkpoints
+      fake.setL1BlockNumber(100n);
+      await archiver.syncImmediate();
+
+      // Mark checkpoint 1 as proven and advance L1 so proven is registered
+      fake.markCheckpointAsProven(CheckpointNumber(1));
+      fake.setL1BlockNumber(101n);
+      await archiver.syncImmediate();
+      expect(await archiver.getProvenCheckpointNumber()).toEqual(CheckpointNumber(1));
+
+      // Finalized L1 block is at or past where checkpoint 1 was published (70)
+      fake.setFinalizedL1BlockNumber(70n);
+      fake.setL1BlockNumber(102n);
+      await archiver.syncImmediate();
+
+      const tips = await archiver.getL2Tips();
+      const lastBlockInCp1 = cp1.blocks.at(-1)!.number;
+      expect(tips.finalized.checkpoint.number).toEqual(CheckpointNumber(1));
+      expect(tips.finalized.block.number).toEqual(lastBlockInCp1);
+    });
+
+    it('does not advance finalized checkpoint when finalized L1 block is before the proven checkpoint', async () => {
+      await fake.addCheckpoint(CheckpointNumber(1), {
+        l1BlockNumber: 70n,
+        messagesL1BlockNumber: 50n,
+        numL1ToL2Messages: 3,
+      });
+
+      fake.setL1BlockNumber(100n);
+      await archiver.syncImmediate();
+
+      fake.markCheckpointAsProven(CheckpointNumber(1));
+      fake.setL1BlockNumber(101n);
+      await archiver.syncImmediate();
+      expect(await archiver.getProvenCheckpointNumber()).toEqual(CheckpointNumber(1));
+
+      // Finalized L1 block is before where checkpoint 1 was published (70)
+      fake.setFinalizedL1BlockNumber(50n);
+      fake.setL1BlockNumber(102n);
+      await archiver.syncImmediate();
+
+      const tips = await archiver.getL2Tips();
+      expect(tips.finalized.checkpoint.number).toEqual(CheckpointNumber(0));
+      expect(tips.finalized.block.number).toEqual(BlockNumber(0));
+    });
   });
 
   describe('checkpointing local proposed blocks', () => {

--- a/yarn-project/archiver/src/archiver.ts
+++ b/yarn-project/archiver/src/archiver.ts
@@ -473,11 +473,10 @@ export class Archiver extends ArchiverDataSourceBase implements L2BlockSink, Tra
       this.log.info(`Rolling back proven L2 checkpoint to ${targetCheckpointNumber}`);
       await this.updater.setProvenCheckpointNumber(targetCheckpointNumber);
     }
-    // TODO(palla/reorg): Set the finalized block when we add support for it.
-    // const currentFinalizedBlock = currentBlocks.finalized.block.number;
-    // if (targetL2BlockNumber < currentFinalizedBlock) {
-    //   this.log.info(`Rolling back finalized L2 checkpoint to ${targetCheckpointNumber}`);
-    //   await this.updater.setFinalizedCheckpointNumber(targetCheckpointNumber);
-    // }
+    const currentFinalizedBlock = currentBlocks.finalized.block.number;
+    if (targetL2BlockNumber < currentFinalizedBlock) {
+      this.log.info(`Rolling back finalized L2 checkpoint to ${targetCheckpointNumber}`);
+      await this.updater.setFinalizedCheckpointNumber(targetCheckpointNumber);
+    }
   }
 }

--- a/yarn-project/archiver/src/factory.ts
+++ b/yarn-project/archiver/src/factory.ts
@@ -14,7 +14,6 @@ import { BundledProtocolContractsProvider } from '@aztec/protocol-contracts/prov
 import { FunctionType, decodeFunctionSignature } from '@aztec/stdlib/abi';
 import type { ArchiverEmitter } from '@aztec/stdlib/block';
 import { type ContractClassPublic, computePublicBytecodeCommitment } from '@aztec/stdlib/contract';
-import type { L1RollupConstants } from '@aztec/stdlib/epoch-helpers';
 import { getTelemetryClient } from '@aztec/telemetry-client';
 
 import { EventEmitter } from 'events';
@@ -32,14 +31,13 @@ export const ARCHIVER_STORE_NAME = 'archiver';
 /** Creates an archiver store. */
 export async function createArchiverStore(
   userConfig: Pick<ArchiverConfig, 'archiverStoreMapSizeKb' | 'maxLogs'> & DataStoreConfig,
-  l1Constants: Pick<L1RollupConstants, 'epochDuration'>,
 ) {
   const config = {
     ...userConfig,
     dataStoreMapSizeKb: userConfig.archiverStoreMapSizeKb ?? userConfig.dataStoreMapSizeKb,
   };
   const store = await createStore(ARCHIVER_STORE_NAME, ARCHIVER_DB_VERSION, config);
-  return new KVArchiverDataStore(store, config.maxLogs, l1Constants);
+  return new KVArchiverDataStore(store, config.maxLogs);
 }
 
 /**
@@ -54,7 +52,7 @@ export async function createArchiver(
   deps: ArchiverDeps,
   opts: { blockUntilSync: boolean } = { blockUntilSync: true },
 ): Promise<Archiver> {
-  const archiverStore = await createArchiverStore(config, { epochDuration: config.aztecEpochDuration });
+  const archiverStore = await createArchiverStore(config);
   await registerProtocolContracts(archiverStore);
 
   // Create Ethereum clients

--- a/yarn-project/archiver/src/modules/data_store_updater.test.ts
+++ b/yarn-project/archiver/src/modules/data_store_updater.test.ts
@@ -42,7 +42,7 @@ describe('ArchiverDataStoreUpdater', () => {
   let instanceAddress: AztecAddress;
 
   beforeEach(async () => {
-    store = new KVArchiverDataStore(await openTmpStore('data_store_updater_test'), 1000, { epochDuration: 32 });
+    store = new KVArchiverDataStore(await openTmpStore('data_store_updater_test'), 1000);
     updater = new ArchiverDataStoreUpdater(store);
 
     // Create contract class log from sample fixture data

--- a/yarn-project/archiver/src/modules/data_store_updater.ts
+++ b/yarn-project/archiver/src/modules/data_store_updater.ts
@@ -283,6 +283,17 @@ export class ArchiverDataStoreUpdater {
     });
   }
 
+  /**
+   * Updates the finalized checkpoint number and refreshes the L2 tips cache.
+   * @param checkpointNumber - The checkpoint number to set as finalized.
+   */
+  public async setFinalizedCheckpointNumber(checkpointNumber: CheckpointNumber): Promise<void> {
+    await this.store.transactionAsync(async () => {
+      await this.store.setFinalizedCheckpointNumber(checkpointNumber);
+      await this.l2TipsCache?.refresh();
+    });
+  }
+
   /** Extracts and stores contract data from a single block. */
   private addContractDataToDb(block: L2Block): Promise<boolean> {
     return this.updateContractDataOnDb(block, Operation.Store);

--- a/yarn-project/archiver/src/modules/l1_synchronizer.ts
+++ b/yarn-project/archiver/src/modules/l1_synchronizer.ts
@@ -216,6 +216,9 @@ export class ArchiverL1Synchronizer implements Traceable {
       this.instrumentation.updateL1BlockHeight(currentL1BlockNumber);
     }
 
+    // Update the finalized L2 checkpoint based on L1 finality.
+    await this.updateFinalizedCheckpoint();
+
     // After syncing has completed, update the current l1 block number and timestamp,
     // otherwise we risk announcing to the world that we've synced to a given point,
     // but the corresponding blocks have not been processed (see #12631).
@@ -229,6 +232,27 @@ export class ArchiverL1Synchronizer implements Traceable {
       l1TimestampAtStart: currentL1Timestamp,
       l1BlockNumberAtEnd,
     });
+  }
+
+  /** Query L1 for its finalized block and update the finalized checkpoint accordingly. */
+  private async updateFinalizedCheckpoint(): Promise<void> {
+    try {
+      const finalizedL1Block = await this.publicClient.getBlock({ blockTag: 'finalized', includeTransactions: false });
+      const finalizedL1BlockNumber = finalizedL1Block.number;
+      const finalizedCheckpointNumber = await this.rollup.getProvenCheckpointNumber({
+        blockNumber: finalizedL1BlockNumber,
+      });
+      const localFinalizedCheckpointNumber = await this.store.getFinalizedCheckpointNumber();
+      if (localFinalizedCheckpointNumber !== finalizedCheckpointNumber) {
+        await this.updater.setFinalizedCheckpointNumber(finalizedCheckpointNumber);
+        this.log.info(`Updated finalized chain to checkpoint ${finalizedCheckpointNumber}`, {
+          finalizedCheckpointNumber,
+          finalizedL1BlockNumber,
+        });
+      }
+    } catch (err) {
+      this.log.warn(`Failed to update finalized checkpoint: ${err}`);
+    }
   }
 
   /** Prune all proposed local blocks that should have been checkpointed by now. */

--- a/yarn-project/archiver/src/modules/l1_synchronizer.ts
+++ b/yarn-project/archiver/src/modules/l1_synchronizer.ts
@@ -245,10 +245,16 @@ export class ArchiverL1Synchronizer implements Traceable {
       const localFinalizedCheckpointNumber = await this.store.getFinalizedCheckpointNumber();
       if (localFinalizedCheckpointNumber !== finalizedCheckpointNumber) {
         await this.updater.setFinalizedCheckpointNumber(finalizedCheckpointNumber);
-        this.log.info(`Updated finalized chain to checkpoint ${finalizedCheckpointNumber}`, {
-          finalizedCheckpointNumber,
-          finalizedL1BlockNumber,
-        });
+        const finalizedL2BlockNumber = await this.store.getFinalizedL2BlockNumber();
+        this.log.info(
+          `Updated finalized chain to checkpoint ${finalizedCheckpointNumber} (L2 block ${finalizedL2BlockNumber})`,
+          {
+            finalizedCheckpointNumber,
+            previousFinalizedCheckpointNumber: localFinalizedCheckpointNumber,
+            finalizedL2BlockNumber,
+            finalizedL1BlockNumber,
+          },
+        );
       }
     } catch (err) {
       this.log.warn(`Failed to update finalized checkpoint: ${err}`);

--- a/yarn-project/archiver/src/store/block_store.ts
+++ b/yarn-project/archiver/src/store/block_store.ts
@@ -97,6 +97,9 @@ export class BlockStore {
   /** Stores last proven checkpoint */
   #lastProvenCheckpoint: AztecAsyncSingleton<number>;
 
+  /** Stores last finalized checkpoint (proven at or before the finalized L1 block) */
+  #lastFinalizedCheckpoint: AztecAsyncSingleton<number>;
+
   /** Stores the pending chain validation status */
   #pendingChainValidationStatus: AztecAsyncSingleton<Buffer>;
 
@@ -111,10 +114,7 @@ export class BlockStore {
 
   #log = createLogger('archiver:block_store');
 
-  constructor(
-    private db: AztecAsyncKVStore,
-    private l1Constants: Pick<L1RollupConstants, 'epochDuration'>,
-  ) {
+  constructor(private db: AztecAsyncKVStore) {
     this.#blocks = db.openMap('archiver_blocks');
     this.#blockTxs = db.openMap('archiver_block_txs');
     this.#txEffects = db.openMap('archiver_tx_effects');
@@ -123,21 +123,27 @@ export class BlockStore {
     this.#blockArchiveIndex = db.openMap('archiver_block_archive_index');
     this.#lastSynchedL1Block = db.openSingleton('archiver_last_synched_l1_block');
     this.#lastProvenCheckpoint = db.openSingleton('archiver_last_proven_l2_checkpoint');
+    this.#lastFinalizedCheckpoint = db.openSingleton('archiver_last_finalized_l2_checkpoint');
     this.#pendingChainValidationStatus = db.openSingleton('archiver_pending_chain_validation_status');
     this.#checkpoints = db.openMap('archiver_checkpoints');
     this.#slotToCheckpoint = db.openMap('archiver_slot_to_checkpoint');
   }
 
   /**
-   * Computes the finalized block number based on the proven block number.
-   * We approximate finalization as 2 epochs worth of checkpoints behind the proven block.
-   * Each checkpoint is assumed to contain 4 blocks, so the lookback is epochDuration * 2 * 4 blocks.
-   * TODO(#13569): Compute proper finalized block number based on L1 finalized block.
+   * Returns the finalized L2 block number. An L2 block is finalized when it was proven
+   * in an L1 block that has itself been finalized on Ethereum.
    * @returns The finalized block number.
    */
   async getFinalizedL2BlockNumber(): Promise<BlockNumber> {
-    const provenBlockNumber = await this.getProvenBlockNumber();
-    return BlockNumber(Math.max(provenBlockNumber - this.l1Constants.epochDuration * 2 * 4, 0));
+    const finalizedCheckpointNumber = await this.getFinalizedCheckpointNumber();
+    if (finalizedCheckpointNumber === INITIAL_CHECKPOINT_NUMBER - 1) {
+      return BlockNumber(INITIAL_L2_BLOCK_NUM - 1);
+    }
+    const checkpointStorage = await this.#checkpoints.getAsync(finalizedCheckpointNumber);
+    if (!checkpointStorage) {
+      throw new CheckpointNotFoundError(finalizedCheckpointNumber);
+    }
+    return BlockNumber(checkpointStorage.startBlock + checkpointStorage.blockCount - 1);
   }
 
   /**
@@ -982,6 +988,20 @@ export class BlockStore {
   async setProvenCheckpointNumber(checkpointNumber: CheckpointNumber) {
     const result = await this.#lastProvenCheckpoint.set(checkpointNumber);
     return result;
+  }
+
+  async getFinalizedCheckpointNumber(): Promise<CheckpointNumber> {
+    const [latestCheckpointNumber, finalizedCheckpointNumber] = await Promise.all([
+      this.getLatestCheckpointNumber(),
+      this.#lastFinalizedCheckpoint.getAsync(),
+    ]);
+    return (finalizedCheckpointNumber ?? 0) > latestCheckpointNumber
+      ? latestCheckpointNumber
+      : CheckpointNumber(finalizedCheckpointNumber ?? 0);
+  }
+
+  setFinalizedCheckpointNumber(checkpointNumber: CheckpointNumber) {
+    return this.#lastFinalizedCheckpoint.set(checkpointNumber);
   }
 
   #computeBlockRange(start: BlockNumber, limit: number): Required<Pick<Range<number>, 'start' | 'limit'>> {

--- a/yarn-project/archiver/src/store/kv_archiver_store.test.ts
+++ b/yarn-project/archiver/src/store/kv_archiver_store.test.ts
@@ -89,7 +89,7 @@ describe('KVArchiverDataStore', () => {
   };
 
   beforeEach(async () => {
-    store = new KVArchiverDataStore(await openTmpStore('archiver_test'), 1000, { epochDuration: 32 });
+    store = new KVArchiverDataStore(await openTmpStore('archiver_test'), 1000);
     // Create checkpoints sequentially to ensure archive roots are chained properly.
     // Each block's header.lastArchive must equal the previous block's archive.
     publishedCheckpoints = [];

--- a/yarn-project/archiver/src/store/kv_archiver_store.ts
+++ b/yarn-project/archiver/src/store/kv_archiver_store.ts
@@ -22,7 +22,6 @@ import type {
   ExecutablePrivateFunctionWithMembershipProof,
   UtilityFunctionWithMembershipProof,
 } from '@aztec/stdlib/contract';
-import type { L1RollupConstants } from '@aztec/stdlib/epoch-helpers';
 import type { GetContractClassLogsResponse, GetPublicLogsResponse } from '@aztec/stdlib/interfaces/client';
 import type { LogFilter, SiloedTag, Tag, TxScopedL2Log } from '@aztec/stdlib/logs';
 import type { BlockHeader, TxHash, TxReceipt } from '@aztec/stdlib/tx';
@@ -71,9 +70,8 @@ export class KVArchiverDataStore implements ContractDataSource {
   constructor(
     private db: AztecAsyncKVStore,
     logsMaxPageSize: number = 1000,
-    l1Constants: Pick<L1RollupConstants, 'epochDuration'>,
   ) {
-    this.#blockStore = new BlockStore(db, l1Constants);
+    this.#blockStore = new BlockStore(db);
     this.#logStore = new LogStore(db, this.#blockStore, logsMaxPageSize);
     this.#messageStore = new MessageStore(db);
     this.#contractClassStore = new ContractClassStore(db);
@@ -543,6 +541,22 @@ export class KVArchiverDataStore implements ContractDataSource {
    */
   async setProvenCheckpointNumber(checkpointNumber: CheckpointNumber) {
     await this.#blockStore.setProvenCheckpointNumber(checkpointNumber);
+  }
+
+  /**
+   * Gets the number of the latest finalized checkpoint processed.
+   * @returns The number of the latest finalized checkpoint processed.
+   */
+  getFinalizedCheckpointNumber(): Promise<CheckpointNumber> {
+    return this.#blockStore.getFinalizedCheckpointNumber();
+  }
+
+  /**
+   * Stores the number of the latest finalized checkpoint processed.
+   * @param checkpointNumber - The number of the latest finalized checkpoint processed.
+   */
+  async setFinalizedCheckpointNumber(checkpointNumber: CheckpointNumber) {
+    await this.#blockStore.setFinalizedCheckpointNumber(checkpointNumber);
   }
 
   async setBlockSynchedL1BlockNumber(l1BlockNumber: bigint) {

--- a/yarn-project/archiver/src/store/kv_archiver_store.ts
+++ b/yarn-project/archiver/src/store/kv_archiver_store.ts
@@ -22,6 +22,7 @@ import type {
   ExecutablePrivateFunctionWithMembershipProof,
   UtilityFunctionWithMembershipProof,
 } from '@aztec/stdlib/contract';
+import type { L1RollupConstants } from '@aztec/stdlib/epoch-helpers';
 import type { GetContractClassLogsResponse, GetPublicLogsResponse } from '@aztec/stdlib/interfaces/client';
 import type { LogFilter, SiloedTag, Tag, TxScopedL2Log } from '@aztec/stdlib/logs';
 import type { BlockHeader, TxHash, TxReceipt } from '@aztec/stdlib/tx';

--- a/yarn-project/archiver/src/test/fake_l1_state.ts
+++ b/yarn-project/archiver/src/test/fake_l1_state.ts
@@ -150,8 +150,12 @@ export class FakeL1State {
   // Computed from checkpoints based on L1 block visibility
   private pendingCheckpointNumber: CheckpointNumber = CheckpointNumber(0);
 
+  // The L1 block number reported as "finalized" (defaults to the start block)
+  private finalizedL1BlockNumber: bigint;
+
   constructor(private readonly config: FakeL1StateConfig) {
     this.l1BlockNumber = config.l1StartBlock;
+    this.finalizedL1BlockNumber = config.l1StartBlock;
     this.lastArchive = new AppendOnlyTreeSnapshot(config.genesisArchiveRoot, 1);
   }
 
@@ -283,9 +287,28 @@ export class FakeL1State {
     this.updatePendingCheckpointNumber();
   }
 
+  /** Sets the L1 block number that will be reported as "finalized". */
+  setFinalizedL1BlockNumber(blockNumber: bigint): void {
+    this.finalizedL1BlockNumber = blockNumber;
+  }
+
   /** Marks a checkpoint as proven. Updates provenCheckpointNumber. */
   markCheckpointAsProven(checkpointNumber: CheckpointNumber): void {
     this.provenCheckpointNumber = checkpointNumber;
+  }
+
+  /**
+   * Simulates what `rollup.getProvenCheckpointNumber({ blockNumber: atL1Block })` would return.
+   */
+  getProvenCheckpointNumberAtL1Block(atL1Block: bigint): CheckpointNumber {
+    if (this.provenCheckpointNumber === 0) {
+      return CheckpointNumber(0);
+    }
+    const checkpoint = this.checkpoints.find(cp => cp.checkpointNumber === this.provenCheckpointNumber);
+    if (checkpoint && checkpoint.l1BlockNumber <= atL1Block) {
+      return this.provenCheckpointNumber;
+    }
+    return CheckpointNumber(0);
   }
 
   /** Sets the target committee size for attestation validation. */
@@ -406,6 +429,11 @@ export class FakeL1State {
       });
     });
 
+    mockRollup.getProvenCheckpointNumber.mockImplementation((options?: { blockNumber?: bigint }) => {
+      const atBlock = options?.blockNumber ?? this.l1BlockNumber;
+      return Promise.resolve(this.getProvenCheckpointNumberAtL1Block(atBlock));
+    });
+
     mockRollup.canPruneAtTime.mockImplementation(() => Promise.resolve(this.canPruneResult));
 
     // Mock the wrapper method for fetching checkpoint events
@@ -449,10 +477,13 @@ export class FakeL1State {
     publicClient.getChainId.mockResolvedValue(1);
     publicClient.getBlockNumber.mockImplementation(() => Promise.resolve(this.l1BlockNumber));
 
-    // Use async function pattern that existing test uses for getBlock
-
-    publicClient.getBlock.mockImplementation((async (args: { blockNumber?: bigint } = {}) => {
-      const blockNum = args.blockNumber ?? (await publicClient.getBlockNumber());
+    publicClient.getBlock.mockImplementation((async (args: { blockNumber?: bigint; blockTag?: string } = {}) => {
+      let blockNum: bigint;
+      if (args.blockTag === 'finalized') {
+        blockNum = this.finalizedL1BlockNumber;
+      } else {
+        blockNum = args.blockNumber ?? (await publicClient.getBlockNumber());
+      }
       return {
         number: blockNum,
         timestamp: BigInt(blockNum) * BigInt(this.config.ethereumSlotDuration) + this.config.l1GenesisTime,

--- a/yarn-project/end-to-end/src/composed/integration_proof_verification.test.ts
+++ b/yarn-project/end-to-end/src/composed/integration_proof_verification.test.ts
@@ -2,13 +2,13 @@ import { BBCircuitVerifier } from '@aztec/bb-prover';
 import { PAIRING_POINTS_SIZE } from '@aztec/constants';
 import { createExtendedL1Client } from '@aztec/ethereum/client';
 import { deployL1Contract } from '@aztec/ethereum/deploy-l1-contract';
+import type { Anvil } from '@aztec/ethereum/test';
 import type { ExtendedViemWalletClient } from '@aztec/ethereum/types';
 import type { Logger } from '@aztec/foundation/log';
 import { HonkVerifierAbi, HonkVerifierBytecode, IVerifierAbi } from '@aztec/l1-artifacts';
 import { Proof } from '@aztec/stdlib/proofs';
 import { RootRollupPublicInputs } from '@aztec/stdlib/rollup';
 
-import type { Anvil } from '@viem/anvil';
 import { readFile } from 'fs/promises';
 import { join } from 'path';
 import { fileURLToPath } from 'url';

--- a/yarn-project/end-to-end/src/e2e_cheat_codes.test.ts
+++ b/yarn-project/end-to-end/src/e2e_cheat_codes.test.ts
@@ -1,10 +1,10 @@
 import { EthAddress } from '@aztec/aztec.js/addresses';
 import { EthCheatCodes } from '@aztec/aztec/testing';
 import { createExtendedL1Client } from '@aztec/ethereum/client';
+import type { Anvil } from '@aztec/ethereum/test';
 import type { ExtendedViemWalletClient } from '@aztec/ethereum/types';
 import { DateProvider } from '@aztec/foundation/timer';
 
-import type { Anvil } from '@viem/anvil';
 import { parseEther } from 'viem';
 import { mnemonicToAccount } from 'viem/accounts';
 import { foundry } from 'viem/chains';

--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_l1_reorgs.parallel.test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_l1_reorgs.parallel.test.ts
@@ -73,6 +73,8 @@ describe('e2e_epochs/epochs_l1_reorgs', () => {
       maxTxsPerBlock: 1,
       enforceTimeTable: true,
       aztecProofSubmissionEpochs: 1,
+      // Use 32 slots/epoch (matching real Ethereum mainnet)
+      anvilSlotsInAnEpoch: 32,
     });
     ({ proverDelayer, sequencerDelayer, context, logger, monitor, L1_BLOCK_TIME_IN_S, L2_SLOT_DURATION_IN_S } = test);
     node = context.aztecNode;
@@ -101,11 +103,31 @@ describe('e2e_epochs/epochs_l1_reorgs', () => {
     const getProvenCheckpointNumber = (node: AztecNode) => node.getL2Tips().then(tips => tips.proven.checkpoint.number);
 
     it('prunes L2 blocks if a proof is removed due to an L1 reorg', async () => {
+      /** Logs a full state snapshot: L1 latest/finalized and archiver L2 tips. */
+      const logState = async (label: string) => {
+        const [l1Latest, l1Finalized, archiverTips] = await Promise.all([
+          test.l1Client.getBlockNumber(),
+          test.l1Client.getBlock({ blockTag: 'finalized', includeTransactions: false }).then(b => b.number),
+          archiver.getL2Tips(),
+        ]);
+        logger.warn(`[state:${label}]`, {
+          l1Latest,
+          l1Finalized,
+          l2Proposed: archiverTips.proposed.number,
+          l2Checkpointed: archiverTips.checkpointed.block.number,
+          l2Proven: archiverTips.proven.block.number,
+          provenCheckpoint: archiverTips.proven.checkpoint.number,
+          l2Finalized: archiverTips.finalized.block.number,
+          finalizedCheckpoint: archiverTips.finalized.checkpoint.number,
+        });
+      };
+
       // Send txs to trigger multi-block checkpoints
       await sendTransactions(TX_COUNT);
 
       // Capture initial chain state
       const initialProvenCheckpoint = (await monitor.run(true)).provenCheckpointNumber;
+      await logState('initial');
 
       // Wait until we have proven something and the nodes have caught up
       const epochDurationSeconds = test.constants.epochDuration * test.constants.slotDuration;
@@ -130,12 +152,23 @@ describe('e2e_epochs/epochs_l1_reorgs', () => {
         epochDurationSeconds * 4 * 1000,
       );
 
+      logger.warn(
+        `Proof for checkpoint ${provenBlockEvent.provenCheckpointNumber} mined at L1 block ${provenBlockEvent.l1BlockNumber}`,
+      );
+      await logState('proof-landed');
+
       // Stop the prover node (by stopping its hosting aztec node) so it doesn't re-submit the proof after we've removed it
-      logger.warn(`Proof for block ${provenBlockEvent.provenCheckpointNumber} mined, stopping prover node`);
+      logger.warn(`Stopping prover node`);
       await test.proverNodes[0].stop();
+      await logState('prover-stopped');
 
       // And remove the proof from L1
-      await context.cheatCodes.eth.reorgTo(provenBlockEvent.l1BlockNumber - 1);
+      const reorgTarget = provenBlockEvent.l1BlockNumber - 1;
+      logger.warn(
+        `Reorging L1 from current tip to block ${reorgTarget} (removing proof block ${provenBlockEvent.l1BlockNumber})`,
+      );
+      await context.cheatCodes.eth.reorgTo(reorgTarget);
+      await logState('after-reorg');
       expect((await monitor.run(true)).provenCheckpointNumber).toEqual(initialProvenCheckpoint);
 
       // Wait until the end of the proof submission window for the epoch of the proven checkpoint
@@ -143,6 +176,7 @@ describe('e2e_epochs/epochs_l1_reorgs', () => {
         CheckpointNumber(provenBlockEvent.provenCheckpointNumber),
       );
       await test.waitUntilLastSlotOfProofSubmissionWindow(provenCheckpointEpoch);
+      await logState('after-submission-window');
 
       // Ensure that a new node sees the reorg
       logger.warn(`Syncing new node to test reorg`);
@@ -164,6 +198,7 @@ describe('e2e_epochs/epochs_l1_reorgs', () => {
         L2_SLOT_DURATION_IN_S * 4,
         0.1,
       );
+      await logState('old-node-synced');
       expect(await getCheckpointNumber(node)).toBeWithin(monitor.checkpointNumber - 1, monitor.checkpointNumber + 1);
 
       // Verify multi-block checkpoints were built

--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_multiple.test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_multiple.test.ts
@@ -4,7 +4,7 @@ import { BlockNumber } from '@aztec/foundation/branded-types';
 
 import { jest } from '@jest/globals';
 
-import { EpochsTestContext } from './epochs_test.js';
+import { EpochsTestContext, WORLD_STATE_CHECKPOINT_HISTORY } from './epochs_test.js';
 
 jest.setTimeout(1000 * 60 * 15);
 
@@ -44,6 +44,22 @@ describe('e2e_epochs/epochs_multiple', () => {
       // Verify the state syncs. Assumes one block per checkpoint.
       const epochEndBlockNumber = BlockNumber.fromCheckpointNumber(epochEndCheckpointNumber);
       await test.waitForNodeToSync(epochEndBlockNumber, 'proven');
+      await test.verifyHistoricBlock(epochEndBlockNumber, true);
+
+      // Check that finalized blocks are purged from world state.
+      // Anvil is started with --slots-in-an-epoch 1, so 'finalized' = latest - 2. By the time
+      // we reach this point the proof has been on L1 for many blocks, so the finalized L1 block
+      // is past the proof submission block, making finalized checkpoint == proven checkpoint.
+      // This test is setup as 1 block per checkpoint.
+      const provenBlockNumber = epochEndBlockNumber;
+      const finalizedBlockNumber = provenBlockNumber;
+      const expectedOldestHistoricBlock = Math.max(finalizedBlockNumber - WORLD_STATE_CHECKPOINT_HISTORY + 1, 1);
+      const expectedBlockRemoved = expectedOldestHistoricBlock - 1;
+      await test.waitForNodeToSync(BlockNumber(expectedOldestHistoricBlock), 'historic');
+      await test.verifyHistoricBlock(BlockNumber(expectedOldestHistoricBlock), true);
+      if (expectedBlockRemoved > 0) {
+        await test.verifyHistoricBlock(BlockNumber(expectedBlockRemoved), false);
+      }
     }
     logger.info('Test Succeeded');
   });

--- a/yarn-project/end-to-end/src/e2e_fee_asset_price_oracle.test.ts
+++ b/yarn-project/end-to-end/src/e2e_fee_asset_price_oracle.test.ts
@@ -2,11 +2,11 @@ import type { Logger } from '@aztec/aztec.js/log';
 import { EthCheatCodes } from '@aztec/aztec/testing';
 import { createExtendedL1Client } from '@aztec/ethereum/client';
 import { RollupContract, STATE_VIEW_ADDRESS } from '@aztec/ethereum/contracts';
+import type { Anvil } from '@aztec/ethereum/test';
 import { retryUntil } from '@aztec/foundation/retry';
 import { DateProvider } from '@aztec/foundation/timer';
 
 import { jest } from '@jest/globals';
-import type { Anvil } from '@viem/anvil';
 import { mnemonicToAccount } from 'viem/accounts';
 import { foundry } from 'viem/chains';
 

--- a/yarn-project/end-to-end/src/e2e_l1_publisher/e2e_l1_publisher.test.ts
+++ b/yarn-project/end-to-end/src/e2e_l1_publisher/e2e_l1_publisher.test.ts
@@ -27,6 +27,7 @@ import { type DeployAztecL1ContractsArgs, deployAztecL1Contracts } from '@aztec/
 import type { L1ContractAddresses } from '@aztec/ethereum/l1-contract-addresses';
 import { TxUtilsState, createL1TxUtils } from '@aztec/ethereum/l1-tx-utils';
 import { EthCheatCodesWithState, RollupCheatCodes, startAnvil } from '@aztec/ethereum/test';
+import type { Anvil } from '@aztec/ethereum/test';
 import type { ExtendedViemWalletClient } from '@aztec/ethereum/types';
 import { range } from '@aztec/foundation/array';
 import { BlockNumber, CheckpointNumber, EpochNumber, SlotNumber } from '@aztec/foundation/branded-types';
@@ -75,7 +76,6 @@ import {
 } from '@aztec/world-state';
 
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
-import type { Anvil } from '@viem/anvil';
 import { type MockProxy, mock } from 'jest-mock-extended';
 import { type Address, encodeFunctionData, getAbiItem, getAddress, multicall3Abi } from 'viem';
 import { type PrivateKeyAccount, privateKeyToAccount } from 'viem/accounts';

--- a/yarn-project/end-to-end/src/e2e_pruned_blocks.test.ts
+++ b/yarn-project/end-to-end/src/e2e_pruned_blocks.test.ts
@@ -3,7 +3,6 @@ import type { Logger } from '@aztec/aztec.js/log';
 import type { AztecNode } from '@aztec/aztec.js/node';
 import { MerkleTreeId } from '@aztec/aztec.js/trees';
 import type { Wallet } from '@aztec/aztec.js/wallet';
-import { CheatCodes } from '@aztec/aztec/testing';
 import { retryUntil } from '@aztec/foundation/retry';
 import { TokenContract } from '@aztec/noir-contracts.js/Token';
 import type { AztecNodeAdmin } from '@aztec/stdlib/interfaces/client';
@@ -18,7 +17,6 @@ describe('e2e_pruned_blocks', () => {
 
   let aztecNode: AztecNode;
   let aztecNodeAdmin: AztecNodeAdmin | undefined;
-  let cheatCodes: CheatCodes;
 
   let wallet: Wallet;
 
@@ -32,7 +30,6 @@ describe('e2e_pruned_blocks', () => {
 
   // Don't make this value too high since we need to mine this number of empty blocks, which is relatively slow.
   const WORLD_STATE_CHECKPOINT_HISTORY = 2;
-  const EPOCH_LENGTH = 2;
   const WORLD_STATE_CHECK_INTERVAL_MS = 300;
   const ARCHIVER_POLLING_INTERVAL_MS = 300;
 
@@ -40,13 +37,11 @@ describe('e2e_pruned_blocks', () => {
     ({
       aztecNode,
       aztecNodeAdmin,
-      cheatCodes,
       logger,
       teardown,
       wallet,
       accounts: [admin, sender, recipient],
     } = await setup(3, {
-      aztecEpochDuration: EPOCH_LENGTH,
       worldStateCheckpointHistory: WORLD_STATE_CHECKPOINT_HISTORY,
       worldStateBlockCheckIntervalMS: WORLD_STATE_CHECK_INTERVAL_MS,
       archiverPollingIntervalMS: ARCHIVER_POLLING_INTERVAL_MS,
@@ -92,13 +87,13 @@ describe('e2e_pruned_blocks', () => {
         .data,
     ).toBeGreaterThan(0);
 
-    // We now mine dummy blocks, mark them as proven and wait for the node to process them, which should result in older
-    // blocks (notably the one with the minted note) being pruned. Given world state prunes based on the finalized tip,
-    // and we are defining the finalized tip as two epochs behind the proven one, we need to mine two extra epochs.
-    // This test assumes 1 block per checkpoint
+    // Mine enough blocks so the first mint block gets pruned. The test infrastructure auto-proves every
+    // checkpoint as it lands, and with slotsInAnEpoch=1 Anvil reports finalized = latest - 2, so
+    // finalization lags proving by just 2 L1 blocks. We mine WORLD_STATE_CHECKPOINT_HISTORY + 3 blocks:
+    // WORLD_STATE_CHECKPOINT_HISTORY to push the first mint block far enough back in history, and 3 to
+    // account for the 2-block finality lag plus one buffer.
     await aztecNodeAdmin!.setConfig({ minTxsPerBlock: 0 });
-    await waitBlocks(WORLD_STATE_CHECKPOINT_HISTORY + EPOCH_LENGTH * 2 + 1);
-    await cheatCodes.rollup.markAsProven();
+    await waitBlocks(WORLD_STATE_CHECKPOINT_HISTORY + 3);
 
     // The same historical query we performed before should now fail since this block is not available anymore. We poll
     // the node for a bit until it processes the blocks we marked as proven, causing the historical query to fail.

--- a/yarn-project/end-to-end/src/fixtures/setup.ts
+++ b/yarn-project/end-to-end/src/fixtures/setup.ts
@@ -185,6 +185,11 @@ export type SetupOptions = {
   anvilAccounts?: number;
   /** Port to start anvil (defaults to 8545) */
   anvilPort?: number;
+  /**
+   * Number of slots per epoch for Anvil's finality simulation.
+   * Anvil reports `finalized = latest - slotsInAnEpoch * 2`.
+   */
+  anvilSlotsInAnEpoch?: number;
   /** Key to use for publishing L1 contracts */
   l1PublisherKey?: SecretValue<`0x${string}`>;
   /** ZkPassport configuration (domain, scope, mock verifier) */
@@ -305,6 +310,7 @@ export async function setup(
         l1BlockTime: opts.ethereumSlotDuration,
         accounts: opts.anvilAccounts,
         port: opts.anvilPort ?? (process.env.ANVIL_PORT ? parseInt(process.env.ANVIL_PORT) : undefined),
+        slotsInAnEpoch: opts.anvilSlotsInAnEpoch,
       });
       anvil = res.anvil;
       config.l1RpcUrls = [res.rpcUrl];

--- a/yarn-project/end-to-end/src/fixtures/setup.ts
+++ b/yarn-project/end-to-end/src/fixtures/setup.ts
@@ -29,7 +29,7 @@ import {
   deployAztecL1Contracts,
 } from '@aztec/ethereum/deploy-aztec-l1-contracts';
 import type { Delayer } from '@aztec/ethereum/l1-tx-utils';
-import { EthCheatCodes, EthCheatCodesWithState, startAnvil } from '@aztec/ethereum/test';
+import { type Anvil, EthCheatCodes, EthCheatCodesWithState, startAnvil } from '@aztec/ethereum/test';
 import { BlockNumber, EpochNumber } from '@aztec/foundation/branded-types';
 import { SecretValue } from '@aztec/foundation/config';
 import { randomBytes } from '@aztec/foundation/crypto/random';
@@ -60,7 +60,6 @@ import { BenchmarkTelemetryClient } from '@aztec/telemetry-client/bench';
 import { deployFundedSchnorrAccounts } from '@aztec/wallets/testing';
 import { getGenesisValues } from '@aztec/world-state/testing';
 
-import type { Anvil } from '@viem/anvil';
 import fs from 'fs/promises';
 import { tmpdir } from 'os';
 import path from 'path';

--- a/yarn-project/ethereum/src/contracts/fee_asset_handler.test.ts
+++ b/yarn-project/ethereum/src/contracts/fee_asset_handler.test.ts
@@ -3,7 +3,6 @@ import { EthAddress } from '@aztec/foundation/eth-address';
 import { type Logger, createLogger } from '@aztec/foundation/log';
 import { TestERC20Abi as FeeAssetAbi } from '@aztec/l1-artifacts/TestERC20Abi';
 
-import type { Anvil } from '@viem/anvil';
 import omit from 'lodash.omit';
 import { type GetContractReturnType, getContract } from 'viem';
 import { type PrivateKeyAccount, privateKeyToAccount } from 'viem/accounts';
@@ -13,7 +12,7 @@ import { createExtendedL1Client } from '../client.js';
 import { DefaultL1ContractsConfig } from '../config.js';
 import { deployAztecL1Contracts } from '../deploy_aztec_l1_contracts.js';
 import { L1TxUtils, createL1TxUtils } from '../l1_tx_utils/index.js';
-import { startAnvil } from '../test/start_anvil.js';
+import { type Anvil, startAnvil } from '../test/start_anvil.js';
 import type { ExtendedViemWalletClient } from '../types.js';
 import { FeeAssetHandlerContract } from './fee_asset_handler.js';
 

--- a/yarn-project/ethereum/src/contracts/governance.test.ts
+++ b/yarn-project/ethereum/src/contracts/governance.test.ts
@@ -2,13 +2,12 @@ import { createExtendedL1Client, getPublicClient } from '@aztec/ethereum/client'
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { createLogger } from '@aztec/foundation/log';
 
-import type { Anvil } from '@viem/anvil';
 import { type PrivateKeyAccount, privateKeyToAccount } from 'viem/accounts';
 import { foundry } from 'viem/chains';
 
 import { DefaultL1ContractsConfig } from '../config.js';
 import { deployAztecL1Contracts } from '../deploy_aztec_l1_contracts.js';
-import { startAnvil } from '../test/start_anvil.js';
+import { type Anvil, startAnvil } from '../test/start_anvil.js';
 import type { ExtendedViemWalletClient, ViemClient } from '../types.js';
 import { GovernanceContract, ReadOnlyGovernanceContract } from './governance.js';
 

--- a/yarn-project/ethereum/src/contracts/gse.test.ts
+++ b/yarn-project/ethereum/src/contracts/gse.test.ts
@@ -2,12 +2,11 @@ import { getPublicClient } from '@aztec/ethereum/client';
 import { GSEContract } from '@aztec/ethereum/contracts';
 import { Fr } from '@aztec/foundation/curves/bn254';
 
-import type { Anvil } from '@viem/anvil';
 import { foundry } from 'viem/chains';
 
 import { DefaultL1ContractsConfig } from '../config.js';
 import { deployAztecL1Contracts } from '../deploy_aztec_l1_contracts.js';
-import { startAnvil } from '../test/start_anvil.js';
+import { type Anvil, startAnvil } from '../test/start_anvil.js';
 import type { ViemClient } from '../types.js';
 
 describe('Governance', () => {

--- a/yarn-project/ethereum/src/contracts/multicall.test.ts
+++ b/yarn-project/ethereum/src/contracts/multicall.test.ts
@@ -5,7 +5,6 @@ import { GovernanceProposerAbi } from '@aztec/l1-artifacts/GovernanceProposerAbi
 import { TestERC20Abi } from '@aztec/l1-artifacts/TestERC20Abi';
 import { TestERC20Bytecode } from '@aztec/l1-artifacts/TestERC20Bytecode';
 
-import type { Anvil } from '@viem/anvil';
 import { type GetContractReturnType, type PrivateKeyAccount, encodeFunctionData, getContract } from 'viem';
 import { privateKeyToAccount } from 'viem/accounts';
 import { foundry } from 'viem/chains';
@@ -15,7 +14,7 @@ import { DefaultL1ContractsConfig } from '../config.js';
 import { type DeployAztecL1ContractsReturnType, deployAztecL1Contracts } from '../deploy_aztec_l1_contracts.js';
 import { deployL1Contract } from '../deploy_l1_contract.js';
 import { L1TxUtils, createL1TxUtils } from '../l1_tx_utils/index.js';
-import { startAnvil } from '../test/start_anvil.js';
+import { type Anvil, startAnvil } from '../test/start_anvil.js';
 import type { ExtendedViemWalletClient } from '../types.js';
 import { FormattedViemError } from '../utils.js';
 import { MULTI_CALL_3_ADDRESS, Multicall3, deployMulticall3 } from './multicall.js';

--- a/yarn-project/ethereum/src/contracts/registry.test.ts
+++ b/yarn-project/ethereum/src/contracts/registry.test.ts
@@ -4,7 +4,6 @@ import { type Logger, createLogger } from '@aztec/foundation/log';
 import { DateProvider } from '@aztec/foundation/timer';
 import { RegistryAbi } from '@aztec/l1-artifacts/RegistryAbi';
 
-import type { Anvil } from '@viem/anvil';
 import omit from 'lodash.omit';
 import { type Hex, createPublicClient, getContract, http } from 'viem';
 import { type PrivateKeyAccount, privateKeyToAccount } from 'viem/accounts';
@@ -17,7 +16,7 @@ import { L1Deployer } from '../deploy_l1_contract.js';
 import type { L1ContractAddresses } from '../l1_contract_addresses.js';
 import { defaultL1TxUtilsConfig } from '../l1_tx_utils/index.js';
 import { EthCheatCodes } from '../test/eth_cheat_codes.js';
-import { startAnvil } from '../test/start_anvil.js';
+import { type Anvil, startAnvil } from '../test/start_anvil.js';
 import type { ExtendedViemWalletClient } from '../types.js';
 import { RegistryContract } from './registry.js';
 import { RollupContract } from './rollup.js';

--- a/yarn-project/ethereum/src/contracts/rollup.test.ts
+++ b/yarn-project/ethereum/src/contracts/rollup.test.ts
@@ -6,14 +6,13 @@ import { createLogger } from '@aztec/foundation/log';
 import { DateProvider } from '@aztec/foundation/timer';
 import { RollupAbi } from '@aztec/l1-artifacts/RollupAbi';
 
-import type { Anvil } from '@viem/anvil';
 import type { Abi } from 'viem';
 import { foundry } from 'viem/chains';
 
 import { DefaultL1ContractsConfig } from '../config.js';
 import { deployAztecL1Contracts } from '../deploy_aztec_l1_contracts.js';
 import { EthCheatCodes } from '../test/eth_cheat_codes.js';
-import { startAnvil } from '../test/start_anvil.js';
+import { type Anvil, startAnvil } from '../test/start_anvil.js';
 import type { ViemClient } from '../types.js';
 import { RollupContract } from './rollup.js';
 

--- a/yarn-project/ethereum/src/contracts/rollup.ts
+++ b/yarn-project/ethereum/src/contracts/rollup.ts
@@ -527,8 +527,9 @@ export class RollupContract {
     return CheckpointNumber.fromBigInt(await this.rollup.read.getPendingCheckpointNumber());
   }
 
-  async getProvenCheckpointNumber(): Promise<CheckpointNumber> {
-    return CheckpointNumber.fromBigInt(await this.rollup.read.getProvenCheckpointNumber());
+  async getProvenCheckpointNumber(options?: { blockNumber?: bigint }): Promise<CheckpointNumber> {
+    await checkBlockTag(options?.blockNumber, this.client);
+    return CheckpointNumber.fromBigInt(await this.rollup.read.getProvenCheckpointNumber(options));
   }
 
   async getSlotNumber(): Promise<SlotNumber> {

--- a/yarn-project/ethereum/src/contracts/tally_slashing_proposer.test.ts
+++ b/yarn-project/ethereum/src/contracts/tally_slashing_proposer.test.ts
@@ -1,4 +1,4 @@
-import { EthCheatCodes, RollupCheatCodes, startAnvil } from '@aztec/ethereum/test';
+import { type Anvil, EthCheatCodes, RollupCheatCodes, startAnvil } from '@aztec/ethereum/test';
 import type { ExtendedViemWalletClient } from '@aztec/ethereum/types';
 import { EpochNumber, SlotNumber } from '@aztec/foundation/branded-types';
 import { SecretValue } from '@aztec/foundation/config';
@@ -9,7 +9,6 @@ import { bufferToHex } from '@aztec/foundation/string';
 import { DateProvider } from '@aztec/foundation/timer';
 import { TallySlashingProposerAbi } from '@aztec/l1-artifacts/TallySlashingProposerAbi';
 
-import type { Anvil } from '@viem/anvil';
 import { type Hex, type TypedDataDefinition, encodeFunctionData, hashTypedData } from 'viem';
 import { type PrivateKeyAccount, privateKeyToAccount } from 'viem/accounts';
 import { foundry } from 'viem/chains';

--- a/yarn-project/ethereum/src/l1_tx_utils/forwarder_l1_tx_utils.test.ts
+++ b/yarn-project/ethereum/src/l1_tx_utils/forwarder_l1_tx_utils.test.ts
@@ -4,7 +4,6 @@ import { createLogger } from '@aztec/foundation/log';
 import { TestDateProvider } from '@aztec/foundation/timer';
 import { TestERC20Abi, TestERC20Bytecode } from '@aztec/l1-artifacts';
 
-import type { Anvil } from '@viem/anvil';
 import { type Hex, encodeFunctionData, parseEventLogs } from 'viem';
 import { mnemonicToAccount, privateKeyToAccount } from 'viem/accounts';
 import { foundry } from 'viem/chains';
@@ -12,7 +11,7 @@ import { foundry } from 'viem/chains';
 import { createExtendedL1Client } from '../client.js';
 import { FORWARDER_ABI, FORWARDER_BYTECODE } from '../forwarder_proxy.js';
 import { EthCheatCodes } from '../test/eth_cheat_codes.js';
-import { startAnvil } from '../test/start_anvil.js';
+import { type Anvil, startAnvil } from '../test/start_anvil.js';
 import type { ExtendedViemWalletClient } from '../types.js';
 import { ForwarderL1TxUtils } from './forwarder_l1_tx_utils.js';
 import { createViemSigner } from './signer.js';

--- a/yarn-project/ethereum/src/l1_tx_utils/l1_fee_analyzer.test.ts
+++ b/yarn-project/ethereum/src/l1_tx_utils/l1_fee_analyzer.test.ts
@@ -3,14 +3,13 @@ import { SlotNumber } from '@aztec/foundation/branded-types';
 import { createLogger } from '@aztec/foundation/log';
 import { DateProvider, TestDateProvider } from '@aztec/foundation/timer';
 
-import type { Anvil } from '@viem/anvil';
 import { type Hex, parseGwei } from 'viem';
 import { mnemonicToAccount, privateKeyToAccount } from 'viem/accounts';
 import { foundry } from 'viem/chains';
 
 import { createExtendedL1Client } from '../client.js';
 import { EthCheatCodes } from '../test/eth_cheat_codes.js';
-import { startAnvil } from '../test/start_anvil.js';
+import { type Anvil, startAnvil } from '../test/start_anvil.js';
 import type { ExtendedViemWalletClient } from '../types.js';
 import { WEI_CONST } from './constants.js';
 import type { PriorityFeeStrategy } from './fee-strategies/types.js';

--- a/yarn-project/ethereum/src/l1_tx_utils/l1_tx_utils.test.ts
+++ b/yarn-project/ethereum/src/l1_tx_utils/l1_tx_utils.test.ts
@@ -9,7 +9,6 @@ import { sleep } from '@aztec/foundation/sleep';
 import { DateProvider, TestDateProvider } from '@aztec/foundation/timer';
 
 import { jest } from '@jest/globals';
-import type { Anvil } from '@viem/anvil';
 import { type MockProxy, mock } from 'jest-mock-extended';
 import assert from 'node:assert';
 import {
@@ -28,7 +27,7 @@ import { foundry } from 'viem/chains';
 
 import { createExtendedL1Client, getPublicClient } from '../client.js';
 import { EthCheatCodes } from '../test/eth_cheat_codes.js';
-import { startAnvil } from '../test/start_anvil.js';
+import { type Anvil, startAnvil } from '../test/start_anvil.js';
 import type { ExtendedViemWalletClient, ViemClient } from '../types.js';
 import { formatViemError } from '../utils.js';
 import {

--- a/yarn-project/ethereum/src/test/eth_cheat_codes.test.ts
+++ b/yarn-project/ethereum/src/test/eth_cheat_codes.test.ts
@@ -5,7 +5,6 @@ import { sleep } from '@aztec/foundation/sleep';
 import { DateProvider } from '@aztec/foundation/timer';
 import { TestERC20Abi, TestERC20Bytecode } from '@aztec/l1-artifacts';
 
-import type { Anvil } from '@viem/anvil';
 import { type Hex, encodeFunctionData, getContract } from 'viem';
 import { mnemonicToAccount, privateKeyToAccount } from 'viem/accounts';
 import { foundry } from 'viem/chains';
@@ -14,7 +13,7 @@ import { createExtendedL1Client } from '../client.js';
 import { deployL1Contract } from '../deploy_l1_contract.js';
 import type { ExtendedViemWalletClient } from '../types.js';
 import { EthCheatCodes } from './eth_cheat_codes.js';
-import { startAnvil } from './start_anvil.js';
+import { type Anvil, startAnvil } from './start_anvil.js';
 
 const MNEMONIC = 'test test test test test test test test test test test junk';
 const ANVIL_RPC_URL = process.env.ANVIL_RPC_URL;

--- a/yarn-project/ethereum/src/test/fallback_transport.test.ts
+++ b/yarn-project/ethereum/src/test/fallback_transport.test.ts
@@ -1,5 +1,4 @@
 import { jest } from '@jest/globals';
-import type { Anvil } from '@viem/anvil';
 import {
   type Account,
   type Chain,
@@ -23,7 +22,7 @@ import {
 import { privateKeyToAccount } from 'viem/accounts';
 import { foundry } from 'viem/chains';
 
-import { startAnvil } from './start_anvil.js';
+import { type Anvil, startAnvil } from './start_anvil.js';
 
 // using new type for custom transports
 export type ExtendedWalletClient = Client<

--- a/yarn-project/ethereum/src/test/rollup_cheat_codes.test.ts
+++ b/yarn-project/ethereum/src/test/rollup_cheat_codes.test.ts
@@ -4,7 +4,6 @@ import { createLogger } from '@aztec/foundation/log';
 import { DateProvider } from '@aztec/foundation/timer';
 import { InboxAbi } from '@aztec/l1-artifacts/InboxAbi';
 
-import type { Anvil } from '@viem/anvil';
 import { foundry } from 'viem/chains';
 
 import { DefaultL1ContractsConfig } from '../config.js';
@@ -12,7 +11,7 @@ import { deployAztecL1Contracts } from '../deploy_aztec_l1_contracts.js';
 import type { ViemClient } from '../types.js';
 import { EthCheatCodes } from './eth_cheat_codes.js';
 import { RollupCheatCodes } from './rollup_cheat_codes.js';
-import { startAnvil } from './start_anvil.js';
+import { type Anvil, startAnvil } from './start_anvil.js';
 
 describe('RollupCheatCodes', () => {
   let anvil: Anvil;

--- a/yarn-project/ethereum/src/test/start_anvil.test.ts
+++ b/yarn-project/ethereum/src/test/start_anvil.test.ts
@@ -1,10 +1,9 @@
 import { type Logger, createLogger } from '@aztec/foundation/log';
 import { sleep } from '@aztec/foundation/sleep';
 
-import type { Anvil } from '@viem/anvil';
 import { createPublicClient, http, parseAbiItem } from 'viem';
 
-import { startAnvil } from './start_anvil.js';
+import { type Anvil, startAnvil } from './start_anvil.js';
 
 describe('start_anvil', () => {
   let logger: Logger;

--- a/yarn-project/ethereum/src/test/start_anvil.ts
+++ b/yarn-project/ethereum/src/test/start_anvil.ts
@@ -2,8 +2,16 @@ import { createLogger } from '@aztec/foundation/log';
 import { makeBackoff, retry } from '@aztec/foundation/retry';
 import { fileURLToPath } from '@aztec/foundation/url';
 
-import { type Anvil, createAnvil } from '@viem/anvil';
+import { type ChildProcess, spawn } from 'child_process';
 import { dirname, resolve } from 'path';
+
+/** Minimal interface matching the @viem/anvil Anvil shape used by callers. */
+export interface Anvil {
+  readonly port: number;
+  readonly host: string;
+  readonly status: 'listening' | 'idle';
+  stop(): Promise<void>;
+}
 
 /**
  * Ensures there's a running Anvil instance and returns the RPC URL.
@@ -16,56 +24,173 @@ export async function startAnvil(
     captureMethodCalls?: boolean;
     accounts?: number;
     chainId?: number;
-    /** The hardfork to use - note: @viem/anvil types are out of date but 'cancun' and 'latest' work */
+    /** The hardfork to use (e.g. 'cancun', 'latest'). */
     hardfork?: string;
+    /**
+     * Number of slots per epoch used by anvil to compute the 'finalized' and 'safe' block tags.
+     * Anvil reports `finalized = latest - slotsInAnEpoch * 2`.
+     * Defaults to 1 so the finalized block advances immediately, making tests that check
+     * L1-finality-based logic work without needing hundreds of mined blocks.
+     */
+    slotsInAnEpoch?: number;
   } = {},
 ): Promise<{ anvil: Anvil; methodCalls?: string[]; rpcUrl: string; stop: () => Promise<void> }> {
   const anvilBinary = resolve(dirname(fileURLToPath(import.meta.url)), '../../', 'scripts/anvil_kill_wrapper.sh');
   const logger = opts.log ? createLogger('ethereum:anvil') : undefined;
   const methodCalls = opts.captureMethodCalls ? ([] as string[]) : undefined;
 
-  let port: number | undefined;
+  let detectedPort: number | undefined;
 
-  // Start anvil.
-  // We go via a wrapper script to ensure if the parent dies, anvil dies.
   const anvil = await retry(
     async () => {
-      const anvil = createAnvil({
-        anvilBinary,
-        host: '127.0.0.1',
-        port: opts.port ?? (process.env.ANVIL_PORT ? parseInt(process.env.ANVIL_PORT) : 8545),
-        blockTime: opts.l1BlockTime,
-        stopTimeout: 1000,
-        accounts: opts.accounts ?? 20,
-        gasLimit: 45_000_000n,
-        chainId: opts.chainId ?? 31337,
+      const port = opts.port ?? (process.env.ANVIL_PORT ? parseInt(process.env.ANVIL_PORT) : 8545);
+      const args: string[] = [
+        '--host',
+        '127.0.0.1',
+        '--port',
+        String(port),
+        '--accounts',
+        String(opts.accounts ?? 20),
+        '--gas-limit',
+        String(45_000_000),
+        '--chain-id',
+        String(opts.chainId ?? 31337),
+      ];
+      if (opts.l1BlockTime !== undefined) {
+        args.push('--block-time', String(opts.l1BlockTime));
+      }
+      if (opts.hardfork !== undefined) {
+        args.push('--hardfork', opts.hardfork);
+      }
+      args.push('--slots-in-an-epoch', String(opts.slotsInAnEpoch ?? 1));
+
+      const child = spawn(anvilBinary, args, {
+        stdio: ['ignore', 'pipe', 'pipe'],
+        env: { ...process.env, RAYON_NUM_THREADS: '1' },
       });
 
-      // Listen to the anvil output to get the port.
-      const removeHandler = anvil.on('message', (message: string) => {
-        logger?.debug(message.trim());
+      // Wait for "Listening on" or an early exit.
+      await new Promise<void>((resolve, reject) => {
+        let stderr = '';
 
-        methodCalls?.push(...(message.match(/eth_[^\s]+/g) || []));
-        if (port === undefined && message.includes('Listening on')) {
-          port = parseInt(message.match(/Listening on ([^:]+):(\d+)/)![2]);
-        }
+        const onStdout = (data: Buffer) => {
+          const text = data.toString();
+          logger?.debug(text.trim());
+          methodCalls?.push(...(text.match(/eth_[^\s]+/g) || []));
+
+          if (detectedPort === undefined && text.includes('Listening on')) {
+            const match = text.match(/Listening on ([^:]+):(\d+)/);
+            if (match) {
+              detectedPort = parseInt(match[2]);
+            }
+          }
+          if (detectedPort !== undefined) {
+            child.stdout?.removeListener('data', onStdout);
+            child.stderr?.removeListener('data', onStderr);
+            child.removeListener('close', onClose);
+            resolve();
+          }
+        };
+
+        const onStderr = (data: Buffer) => {
+          stderr += data.toString();
+          logger?.debug(data.toString().trim());
+        };
+
+        const onClose = (code: number | null) => {
+          child.stdout?.removeListener('data', onStdout);
+          child.stderr?.removeListener('data', onStderr);
+          reject(new Error(`Anvil exited with code ${code} before listening. stderr: ${stderr}`));
+        };
+
+        child.stdout?.on('data', onStdout);
+        child.stderr?.on('data', onStderr);
+        child.once('close', onClose);
       });
-      await anvil.start();
-      if (!logger && !opts.captureMethodCalls) {
-        removeHandler();
+
+      // Continue piping for logging / method-call capture after startup.
+      if (logger || opts.captureMethodCalls) {
+        child.stdout?.on('data', (data: Buffer) => {
+          const text = data.toString();
+          logger?.debug(text.trim());
+          methodCalls?.push(...(text.match(/eth_[^\s]+/g) || []));
+        });
+        child.stderr?.on('data', (data: Buffer) => {
+          logger?.debug(data.toString().trim());
+        });
+      } else {
+        // Consume streams so the child process doesn't block on full pipe buffers.
+        child.stdout?.resume();
+        child.stderr?.resume();
       }
 
-      return anvil;
+      return child;
     },
     'Start anvil',
     makeBackoff([5, 5, 5]),
   );
 
-  if (!port) {
+  if (!detectedPort) {
     throw new Error('Failed to start anvil');
   }
 
-  // Monkeypatch the anvil instance to include the actually assigned port
-  // Object.defineProperty(anvil, 'port', { value: port, writable: false });
-  return { anvil, methodCalls, stop: () => anvil.stop(), rpcUrl: `http://127.0.0.1:${port}` };
+  const port = detectedPort;
+  let status: 'listening' | 'idle' = 'listening';
+
+  anvil.once('close', () => {
+    status = 'idle';
+  });
+
+  const stop = async () => {
+    if (status === 'idle') {
+      return;
+    }
+    await killChild(anvil);
+  };
+
+  const anvilObj: Anvil = {
+    port,
+    host: '127.0.0.1',
+    get status() {
+      return status;
+    },
+    stop,
+  };
+
+  return { anvil: anvilObj, methodCalls, stop, rpcUrl: `http://127.0.0.1:${port}` };
+}
+
+/** Send SIGTERM, wait up to 5 s, then SIGKILL. All timers are always cleared. */
+function killChild(child: ChildProcess): Promise<void> {
+  return new Promise<void>(resolve => {
+    if (child.exitCode !== null || child.killed) {
+      child.stdout?.destroy();
+      child.stderr?.destroy();
+      resolve();
+      return;
+    }
+
+    let killTimer: NodeJS.Timeout | undefined;
+
+    const onClose = () => {
+      if (killTimer !== undefined) {
+        clearTimeout(killTimer);
+      }
+      // Destroy stdio streams so their PipeWrap handles don't keep the event loop alive.
+      child.stdout?.destroy();
+      child.stderr?.destroy();
+      resolve();
+    };
+
+    child.once('close', onClose);
+    child.kill('SIGTERM');
+
+    killTimer = setTimeout(() => {
+      killTimer = undefined;
+      child.kill('SIGKILL');
+    }, 5000);
+
+    // Ensure the timer does not prevent Node from exiting.
+    killTimer.unref();
+  });
 }

--- a/yarn-project/ethereum/src/test/tx_delayer.test.ts
+++ b/yarn-project/ethereum/src/test/tx_delayer.test.ts
@@ -5,7 +5,6 @@ import { sleep } from '@aztec/foundation/sleep';
 import { DateProvider, TestDateProvider } from '@aztec/foundation/timer';
 import { TestERC20Abi, TestERC20Bytecode } from '@aztec/l1-artifacts';
 
-import type { Anvil } from '@viem/anvil';
 import { type PrivateKeyAccount, createWalletClient, fallback, getContract, http, publicActions } from 'viem';
 import { privateKeyToAccount } from 'viem/accounts';
 import { foundry } from 'viem/chains';
@@ -13,7 +12,7 @@ import { foundry } from 'viem/chains';
 import { Delayer, createDelayer, waitUntilBlock, wrapClientWithDelayer } from '../l1_tx_utils/tx_delayer.js';
 import type { ExtendedViemWalletClient } from '../types.js';
 import { EthCheatCodes } from './eth_cheat_codes.js';
-import { startAnvil } from './start_anvil.js';
+import { type Anvil, startAnvil } from './start_anvil.js';
 
 describe('tx_delayer', () => {
   let anvil: Anvil;

--- a/yarn-project/node-lib/src/actions/snapshot-sync.ts
+++ b/yarn-project/node-lib/src/actions/snapshot-sync.ts
@@ -60,7 +60,7 @@ export async function trySnapshotSync(config: SnapshotSyncConfig, log: Logger) {
 
   // Create an archiver store to check the current state (do this only once)
   log.verbose(`Creating temporary archiver data store`);
-  const archiverStore = await createArchiverStore(config, { epochDuration: config.aztecEpochDuration });
+  const archiverStore = await createArchiverStore(config);
   let archiverL1BlockNumber: bigint | undefined;
   let archiverL2BlockNumber: number | undefined;
   try {

--- a/yarn-project/prover-node/src/actions/rerun-epoch-proving-job.ts
+++ b/yarn-project/prover-node/src/actions/rerun-epoch-proving-job.ts
@@ -30,7 +30,7 @@ export async function rerunEpochProvingJob(
   const telemetry = getTelemetryClient();
   const metrics = new ProverNodeJobMetrics(telemetry.getMeter('prover-job'), telemetry.getTracer('prover-job'));
   const worldState = await createWorldState(config);
-  const archiver = await createArchiverStore(config, { epochDuration: config.aztecEpochDuration });
+  const archiver = await createArchiverStore(config);
   const publicProcessorFactory = new PublicProcessorFactory(archiver, undefined, undefined, log.getBindings());
 
   const publisher = { submitEpochProof: () => Promise.resolve(true) };

--- a/yarn-project/stdlib/src/block/l2_block_source.ts
+++ b/yarn-project/stdlib/src/block/l2_block_source.ts
@@ -68,9 +68,8 @@ export interface L2BlockSource {
   getCheckpointedL2BlockNumber(): Promise<BlockNumber>;
 
   /**
-   * Computes the finalized block number based on the proven block number.
-   * A block is considered finalized when it's 2 epochs behind the proven block.
-   * TODO(#13569): Compute proper finalized block number based on L1 finalized block.
+   * Returns the finalized L2 block number. A block is finalized when it was proven
+   * in an L1 block that has itself been finalized on Ethereum.
    * @returns The finalized block number.
    */
   getFinalizedL2BlockNumber(): Promise<BlockNumber>;

--- a/yarn-project/stdlib/src/l1-contracts/slash_factory.test.ts
+++ b/yarn-project/stdlib/src/l1-contracts/slash_factory.test.ts
@@ -1,7 +1,7 @@
 import { createExtendedL1Client, getPublicClient } from '@aztec/ethereum/client';
 import { DefaultL1ContractsConfig } from '@aztec/ethereum/config';
 import { deployAztecL1Contracts } from '@aztec/ethereum/deploy-aztec-l1-contracts';
-import { EthCheatCodes, startAnvil } from '@aztec/ethereum/test';
+import { type Anvil, EthCheatCodes, startAnvil } from '@aztec/ethereum/test';
 import type { ExtendedViemWalletClient, ViemClient } from '@aztec/ethereum/types';
 import { tryExtractEvent } from '@aztec/ethereum/utils';
 import { Fr } from '@aztec/foundation/curves/bn254';
@@ -10,7 +10,6 @@ import { createLogger } from '@aztec/foundation/log';
 import { DateProvider } from '@aztec/foundation/timer';
 import { SlashFactoryAbi } from '@aztec/l1-artifacts/SlashFactoryAbi';
 
-import type { Anvil } from '@viem/anvil';
 import { type TransactionReceipt, decodeFunctionData } from 'viem';
 import { type PrivateKeyAccount, privateKeyToAccount } from 'viem/accounts';
 import { foundry } from 'viem/chains';

--- a/yarn-project/stdlib/src/tx/tx_receipt.ts
+++ b/yarn-project/stdlib/src/tx/tx_receipt.ts
@@ -15,7 +15,7 @@ export enum TxStatus {
   PROPOSED = 'proposed',
   CHECKPOINTED = 'checkpointed',
   PROVEN = 'proven',
-  FINALIZED = 'finalized', // TODO(#13569): Implement finalized status properly
+  FINALIZED = 'finalized',
 }
 
 /** Tx status sorted by finalization progress. */

--- a/yarn-project/txe/src/state_machine/archiver.ts
+++ b/yarn-project/txe/src/state_machine/archiver.ts
@@ -17,7 +17,7 @@ export class TXEArchiver extends ArchiverDataSourceBase {
   private readonly updater = new ArchiverDataStoreUpdater(this.store);
 
   constructor(db: AztecAsyncKVStore) {
-    const store = new KVArchiverDataStore(db, 9999, { epochDuration: 32 });
+    const store = new KVArchiverDataStore(db, 9999);
     super(store);
   }
 

--- a/yarn-project/validator-client/src/validator.integration.test.ts
+++ b/yarn-project/validator-client/src/validator.integration.test.ts
@@ -97,14 +97,11 @@ describe('ValidatorClient Integration', () => {
   /** Creates a new validator and dependencies */
   const createValidatorContext = async (privateKey: Hex<32>): Promise<ValidatorContext> => {
     // Create archiver store and NoopL1Archiver
-    const archiverStore = await createArchiverStore(
-      {
-        archiverStoreMapSizeKb: 1024 * 1024,
-        dataDirectory: undefined,
-        dataStoreMapSizeKb: 1024 * 1024,
-      },
-      { epochDuration: l1Constants.epochDuration },
-    );
+    const archiverStore = await createArchiverStore({
+      archiverStoreMapSizeKb: 1024 * 1024,
+      dataDirectory: undefined,
+      dataStoreMapSizeKb: 1024 * 1024,
+    });
     await registerProtocolContracts(archiverStore);
     const archiver = await createNoopL1Archiver(archiverStore, { ...l1Constants, genesisArchiveRoot });
     await archiver.start();

--- a/yarn-project/world-state/src/synchronizer/server_world_state_synchronizer.ts
+++ b/yarn-project/world-state/src/synchronizer/server_world_state_synchronizer.ts
@@ -359,7 +359,7 @@ export class ServerWorldStateSynchronizer
   }
 
   private async handleChainFinalized(blockNumber: BlockNumber) {
-    this.log.verbose(`Finalized chain is now at block ${blockNumber}`);
+    this.log.info(`Updating world state finalized chain to block ${blockNumber}`);
     // If the finalized block number is older than the oldest available block in world state,
     // skip entirely. The finalized block number can jump backwards (e.g. when the finalization
     // heuristic changes) and try to read block data that has already been pruned. When this
@@ -373,6 +373,11 @@ export class ServerWorldStateSynchronizer
       return;
     }
     const summary = await this.merkleTreeDb.setFinalized(blockNumber);
+    this.log.info(`World state finalized chain updated`, {
+      finalizedBlockNumber: summary.finalizedBlockNumber,
+      unfinalizedBlockNumber: summary.unfinalizedBlockNumber,
+      oldestHistoricalBlock: summary.oldestHistoricalBlock,
+    });
     if (this.historyToKeep === undefined) {
       return;
     }


### PR DESCRIPTION
Fixes
[A-551](https://linear.app/aztec-labs/issue/A-551/properly-compute-finalized-block)

Replaces the heuristic finalized block computation (`provenBlock - 2 * epochDuration`) with L1 finality.

On each archiver sync iteration, we now:
1. Fetch the finalized L1 block via `getBlock({ blockTag: 'finalized' })`
2. Query the rollup contract for the proven checkpoint number at that L1 block
3. Persist that as the finalized checkpoint, from which the finalized L2 block number is derived

Failures in this step are caught and logged as warnings so they don't disrupt the rest of the sync loop (e.g. if the RPC node can't serve state at the finalized block).

- `RollupContract.getProvenCheckpointNumber` now accepts an optional `{ blockNumber }` to query historical contract state
- `BlockStore` stores a `lastFinalizedCheckpoint` singleton and derives `getFinalizedL2BlockNumber` from it instead of the old arithmetic heuristic
- `ArchiverL1Synchronizer` gains `updateFinalizedCheckpoint()`, called every sync iteration
- `KVArchiverDataStore` constructor no longer takes `l1Constants` (the `epochDuration` it was used for is no longer needed)
- `FakeL1State` updated to support `blockTag: 'finalized'` and `getProvenCheckpointNumber` with a block number, enabling new sync tests
