### PR TITLE
chore: misnamed copy function in public db

### DIFF
--- a/yarn-project/simulator/src/public/contracts_db_checkpoint.ts
+++ b/yarn-project/simulator/src/public/contracts_db_checkpoint.ts
@@ -31,7 +31,7 @@ export class ContractsDbCheckpoint {
     return this.bytecodeCommitments.get(classId.toString());
   }
 
-  public deepCopy(): ContractsDbCheckpoint {
+  public fork(): ContractsDbCheckpoint {
     const copy = new ContractsDbCheckpoint();
     this.instances.forEach((value, key) => copy.instances.set(key, value));
     this.classes.forEach((value, key) => copy.classes.set(key, value));

--- a/yarn-project/simulator/src/public/public_db_sources.ts
+++ b/yarn-project/simulator/src/public/public_db_sources.ts
@@ -81,7 +81,7 @@ export class PublicContractsDB implements PublicContractsDBInterface {
    */
   public createCheckpoint(): void {
     const currentState = this.getCurrentState();
-    const newState = currentState.deepCopy();
+    const newState = currentState.fork();
     this.contractStateStack.push(newState);
   }
 


### PR DESCRIPTION
It's not a deep copy! A shallow copy or more accurately a fork.