### PR TITLE
feat: private fuzzer container builds with cosign signing and OCI attribution

### DIFF
--- a/.github/workflows/fuzzing-docker-avm-build-private.yml
+++ b/.github/workflows/fuzzing-docker-avm-build-private.yml
@@ -1,4 +1,4 @@
-name: Build Fuzzing AVM Container
+name: Build Private Fuzzing AVM Container
 
 on:
   push:
@@ -12,9 +12,10 @@ on:
         default: ""
 jobs:
   build:
-    if: github.repository == 'AztecProtocol/aztec-packages'
+    if: github.repository == 'AztecProtocol/aztec-packages-private'
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       packages: write
       id-token: write
 
@@ -38,17 +39,22 @@ jobs:
         uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25
         with:
           context: container-builds/avm-fuzzing-container/src/
+          file: container-builds/avm-fuzzing-container/src/Dockerfile.private
           push: true
           tags: |
-            ghcr.io/aztecprotocol/avm-fuzzing-container:latest
-            ghcr.io/aztecprotocol/avm-fuzzing-container:${{ github.sha }}
+            ghcr.io/aztecprotocol/avm-fuzzing-container-private:latest
+            ghcr.io/aztecprotocol/avm-fuzzing-container-private:${{ github.sha }}
           build-args: |
             COMMIT=${{ github.event_name == 'workflow_dispatch' && github.event.inputs.commit || github.sha }}
+            BRANCH=${{ github.ref_name }}
+            REPO=${{ github.repository }}
+          secrets: |
+            github_token=${{ secrets.GITHUB_TOKEN }}
           labels: |
             com.aztec.source-repo=${{ github.repository }}
             com.aztec.source-branch=${{ github.ref_name }}
             com.aztec.commit=${{ github.sha }}
-            com.aztec.visibility=public
+            com.aztec.visibility=private
 
       - name: Install cosign
         uses: sigstore/cosign-installer@ba7bc0a3fef59531c69a25acd34668d6d3fe6f22 # v4.1.0
@@ -57,5 +63,5 @@ jobs:
 
       - name: Sign image
         run: |
-          cosign sign --yes \
-            ghcr.io/aztecprotocol/avm-fuzzing-container@${{ steps.build.outputs.digest }}
+          cosign sign --yes --tlog-upload=false \
+            ghcr.io/aztecprotocol/avm-fuzzing-container-private@${{ steps.build.outputs.digest }}

--- a/.github/workflows/fuzzing-docker-build-private.yml
+++ b/.github/workflows/fuzzing-docker-build-private.yml
@@ -1,4 +1,4 @@
-name: Build Fuzzing AVM Container
+name: Build Private Fuzzing Container
 
 on:
   push:
@@ -12,9 +12,10 @@ on:
         default: ""
 jobs:
   build:
-    if: github.repository == 'AztecProtocol/aztec-packages'
+    if: github.repository == 'AztecProtocol/aztec-packages-private'
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       packages: write
       id-token: write
 
@@ -37,18 +38,35 @@ jobs:
         id: build
         uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25
         with:
-          context: container-builds/avm-fuzzing-container/src/
+          context: container-builds/fuzzing-container/src/
+          file: container-builds/fuzzing-container/src/Dockerfile.private
           push: true
           tags: |
-            ghcr.io/aztecprotocol/avm-fuzzing-container:latest
-            ghcr.io/aztecprotocol/avm-fuzzing-container:${{ github.sha }}
+            ghcr.io/aztecprotocol/fuzzing-container-private:latest
+            ghcr.io/aztecprotocol/fuzzing-container-private:${{ github.sha }}
           build-args: |
             COMMIT=${{ github.event_name == 'workflow_dispatch' && github.event.inputs.commit || github.sha }}
+            BRANCH=${{ github.ref_name }}
+            REPO=${{ github.repository }}
+          secrets: |
+            github_token=${{ secrets.GITHUB_TOKEN }}
           labels: |
             com.aztec.source-repo=${{ github.repository }}
             com.aztec.source-branch=${{ github.ref_name }}
             com.aztec.commit=${{ github.sha }}
-            com.aztec.visibility=public
+            com.aztec.visibility=private
+
+      - name: Install oras
+        uses: oras-project/setup-oras@22ce207df3b08e061f537244349aac6ae1d214f6 # v1.2.4
+
+      - name: Extract and attach fuzzer manifest
+        run: |
+          docker create --name manifest-extract ghcr.io/aztecprotocol/fuzzing-container-private:${{ github.sha }}
+          docker cp manifest-extract:/home/fuzzer/aztec-packages/barretenberg/cpp/fuzzer_manifest.json ./fuzzer_manifest.json
+          docker rm manifest-extract
+          oras attach ghcr.io/aztecprotocol/fuzzing-container-private@${{ steps.build.outputs.digest }} \
+            --artifact-type application/vnd.aztec.fuzzer-manifest+json \
+            fuzzer_manifest.json
 
       - name: Install cosign
         uses: sigstore/cosign-installer@ba7bc0a3fef59531c69a25acd34668d6d3fe6f22 # v4.1.0
@@ -57,5 +75,5 @@ jobs:
 
       - name: Sign image
         run: |
-          cosign sign --yes \
-            ghcr.io/aztecprotocol/avm-fuzzing-container@${{ steps.build.outputs.digest }}
+          cosign sign --yes --tlog-upload=false \
+            ghcr.io/aztecprotocol/fuzzing-container-private@${{ steps.build.outputs.digest }}

--- a/.github/workflows/fuzzing-docker-build.yml
+++ b/.github/workflows/fuzzing-docker-build.yml
@@ -12,9 +12,11 @@ on:
         default: ""
 jobs:
   build:
+    if: github.repository == 'AztecProtocol/aztec-packages'
     runs-on: ubuntu-latest
     permissions:
       packages: write
+      id-token: write
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -42,6 +44,11 @@ jobs:
             ghcr.io/aztecprotocol/fuzzing-container:${{ github.sha }}
           build-args: |
             COMMIT=${{ github.event_name == 'workflow_dispatch' && github.event.inputs.commit || github.sha }}
+          labels: |
+            com.aztec.source-repo=${{ github.repository }}
+            com.aztec.source-branch=${{ github.ref_name }}
+            com.aztec.commit=${{ github.sha }}
+            com.aztec.visibility=public
 
       - name: Install oras
         uses: oras-project/setup-oras@22ce207df3b08e061f537244349aac6ae1d214f6 # v1.2.4
@@ -54,3 +61,13 @@ jobs:
           oras attach ghcr.io/aztecprotocol/fuzzing-container@${{ steps.build.outputs.digest }} \
             --artifact-type application/vnd.aztec.fuzzer-manifest+json \
             fuzzer_manifest.json
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@ba7bc0a3fef59531c69a25acd34668d6d3fe6f22 # v4.1.0
+        with:
+          cosign-release: 'v3.0.5'
+
+      - name: Sign image
+        run: |
+          cosign sign --yes \
+            ghcr.io/aztecprotocol/fuzzing-container@${{ steps.build.outputs.digest }}

--- a/barretenberg/cpp/CMakePresets.json
+++ b/barretenberg/cpp/CMakePresets.json
@@ -290,6 +290,7 @@
         "FUZZING_AVM": "ON",
         "CMAKE_BUILD_TYPE": "RelWithAssert",
         "MULTITHREADING": "ON",
+        "FUZZER_PRESET_NAME": "${presetName}",
         "CMAKE_AR": null,
         "CMAKE_RANLIB": null
       }

--- a/barretenberg/cpp/scripts/merge_fuzzer_manifests.py
+++ b/barretenberg/cpp/scripts/merge_fuzzer_manifests.py
@@ -39,7 +39,7 @@ def main():
     bb_names = set(preset_fuzzers.get("fuzzing", {}).keys())
     avm_names = set(preset_fuzzers.get("fuzzing-avm", {}).keys())
     noasm_names = set(preset_fuzzers.get("fuzzing-noasm", {}).keys())
-    cov_names = set(preset_fuzzers.get("fuzzing-cov", {}).keys())
+    cov_names = set(preset_fuzzers.get("fuzzing-coverage", {}).keys())
 
     merged = []
     for name, source_path in sorted(all_names.items()):

--- a/container-builds/avm-fuzzing-container/src/Dockerfile.private
+++ b/container-builds/avm-fuzzing-container/src/Dockerfile.private
@@ -1,0 +1,106 @@
+# AVM TX Fuzzer Container (Private)
+# Builds a container that can run the AVM transaction fuzzer from a private repo
+#
+# Build latest from 'next' branch:
+#   DOCKER_BUILDKIT=1 docker build --secret id=github_token,env=GITHUB_TOKEN \
+#     -f Dockerfile.private -t avm-tx-fuzzer container-builds/avm-fuzzing-container/src/
+#
+# Build specific commit:
+#   DOCKER_BUILDKIT=1 docker build --secret id=github_token,env=GITHUB_TOKEN \
+#     --build-arg COMMIT=<sha> -f Dockerfile.private -t avm-tx-fuzzer container-builds/avm-fuzzing-container/src/
+
+FROM aztecprotocol/build:3.0-amd64 AS builder
+
+ARG COMMIT=""
+ARG BRANCH="next"
+ARG REPO="AztecProtocol/aztec-packages-private"
+
+# Install ldid (not included in build image, only in basebox)
+RUN curl -sL https://github.com/ProcursusTeam/ldid/releases/download/v2.1.5-procursus7/ldid_linux_x86_64 -o /usr/local/bin/ldid \
+    && chmod +x /usr/local/bin/ldid
+
+# Install Node.js 24 (build image has Node 22, but bootstrap requires 24)
+RUN curl -fsSL https://deb.nodesource.com/setup_24.x | bash - && \
+    apt-get install -y nodejs
+
+WORKDIR /root
+
+# Clone private repo using BuildKit secret — token never persists in any layer
+RUN --mount=type=secret,id=github_token \
+    git clone https://x-access-token:$(cat /run/secrets/github_token)@github.com/${REPO}.git --depth 1 --branch ${BRANCH} aztec-packages && \
+    cd aztec-packages && \
+    if [ -n "$COMMIT" ]; then \
+        git fetch origin $COMMIT --depth 1; \
+        git checkout $COMMIT || exit 1; \
+    fi
+
+WORKDIR /root/aztec-packages
+
+# Run bootstrap up to yarn-project (release-image needs docker which isn't available)
+RUN BOOTSTRAP_TO=yarn-project ./bootstrap.sh
+
+# Build the tx fuzzer
+WORKDIR /root/aztec-packages/barretenberg/cpp
+RUN cmake --preset fuzzing-avm
+RUN cmake --build build-fuzzing-avm --target avm_fuzzer_tx_fuzzer
+
+# =============================================================================
+# Runtime image
+# =============================================================================
+FROM ubuntu:noble AS runtime
+
+RUN apt-get update && apt-get install -y \
+    libstdc++6 \
+    libgcc-s1 \
+    libc6 \
+    libdw1 \
+    libelf1 \
+    libdwarf1 \
+    ca-certificates \
+    curl && \
+    curl -fsSL https://deb.nodesource.com/setup_24.x | bash - && \
+    apt-get install -y nodejs && \
+    corepack enable && \
+    apt-get -y autoremove && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+RUN useradd -m fuzzer
+
+WORKDIR /home/fuzzer
+
+# Copy fuzzer binary
+COPY --from=builder /root/aztec-packages/barretenberg/cpp/build-fuzzing-avm/bin/avm_fuzzer_tx_fuzzer \
+    ./aztec-packages/barretenberg/cpp/build-fuzzing-avm/bin/
+
+# Copy run_fuzzer.sh
+COPY --from=builder /root/aztec-packages/barretenberg/cpp/src/barretenberg/avm_fuzzer/run_fuzzer.sh \
+    ./aztec-packages/barretenberg/cpp/src/barretenberg/avm_fuzzer/
+
+# Copy yarn-project (fully built)
+COPY --from=builder /root/aztec-packages/yarn-project \
+    ./aztec-packages/yarn-project/
+
+# Copy barretenberg/ts (for @aztec/bb.js)
+COPY --from=builder /root/aztec-packages/barretenberg/ts \
+    ./aztec-packages/barretenberg/ts/
+
+# Copy noir packages (for portal symlinks)
+COPY --from=builder /root/aztec-packages/noir/packages \
+    ./aztec-packages/noir/packages/
+
+# Create directories for corpus, crashes, etc.
+RUN mkdir -p aztec-packages/barretenberg/cpp/src/barretenberg/avm_fuzzer/corpus/tx \
+    aztec-packages/barretenberg/cpp/src/barretenberg/avm_fuzzer/sync_corpus/tx \
+    corpus output crash-reports artifacts
+
+# Make run_fuzzer.sh executable
+RUN chmod +x aztec-packages/barretenberg/cpp/src/barretenberg/avm_fuzzer/run_fuzzer.sh
+
+# Copy entrypoint script
+COPY entrypoint.sh .
+RUN chmod +x entrypoint.sh
+
+WORKDIR /home/fuzzer/aztec-packages/barretenberg/cpp/src/barretenberg/avm_fuzzer
+
+ENTRYPOINT ["/home/fuzzer/entrypoint.sh"]

--- a/container-builds/fuzzing-container/src/Dockerfile.private
+++ b/container-builds/fuzzing-container/src/Dockerfile.private
@@ -1,0 +1,122 @@
+# Build stage
+FROM ubuntu:noble AS builder
+
+RUN apt-get update && \
+    apt-get install -y \
+        build-essential \
+        python3 \
+        wget \
+        curl \
+        unzip \
+        git \
+        cmake \
+        clang \
+        ninja-build \
+        libdw-dev \
+        binutils-dev \
+        libelf-dev \
+        libdwarf-dev && \
+    apt-get -y autoremove && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+RUN useradd -m fuzzer -G sudo
+WORKDIR /home/fuzzer
+
+# Build argument to avoid layer caching
+# Alternatively pass nothing for latest commit, and delete the build for a rebuild.
+ARG COMMIT=""
+ARG BRANCH="next"
+ARG REPO="AztecProtocol/aztec-packages-private"
+
+# Clone repo using BuildKit secret — token never persists in any layer
+RUN --mount=type=secret,id=github_token \
+    git clone https://x-access-token:$(cat /run/secrets/github_token)@github.com/${REPO}.git --depth 1 --branch ${BRANCH} aztec-packages && \
+    cd aztec-packages && \
+    if [ -n "$COMMIT" ]; then \
+        git fetch origin $COMMIT; \
+        git checkout $COMMIT || exit 1; \
+    fi
+
+# Create a clean copy of the source tree for the runtime image
+RUN cp -r ./aztec-packages aztec-packages-src && rm -rf ./aztec-packages-src/.git
+
+# Download crs
+WORKDIR /home/fuzzer/aztec-packages/barretenberg
+RUN ./crs/bootstrap.sh
+
+WORKDIR /home/fuzzer/aztec-packages/barretenberg/cpp
+
+# We cleanup after each build to save disk space.
+
+# Build all fuzzers
+RUN cmake -DCMAKE_C_COMPILER=clang-18 -DCMAKE_CXX_COMPILER=clang++-18 --preset fuzzing
+RUN cmake --build build-fuzzing && mv build-fuzzing/bin bin-fuzzing && rm -rf build-fuzzing
+
+# Build all fuzzers
+RUN cmake -DCMAKE_C_COMPILER=clang-18 -DCMAKE_CXX_COMPILER=clang++-18 --preset fuzzing-noasm
+RUN cmake --build build-fuzzing-noasm && mv build-fuzzing-noasm/bin bin-fuzzing-noasm && rm -rf build-fuzzing-noasm
+
+# Build all post-crash loggers
+RUN cmake -DCMAKE_C_COMPILER=clang-18 -DCMAKE_CXX_COMPILER=clang++-18 --preset fuzzing-asan
+RUN cmake --build build-fuzzing-asan && mv build-fuzzing-asan/bin bin-fuzzing-asan && rm -rf build-fuzzing-asan
+
+# Build all coverage fuzzers (keep full build for LLVM links and external dependencies)
+RUN cmake -DCMAKE_C_COMPILER=clang-18 -DCMAKE_CXX_COMPILER=clang++-18 --preset fuzzing-coverage
+RUN cmake --build build-fuzzing-cov
+
+# Build avm fuzzers
+RUN cmake -DCMAKE_C_COMPILER=clang-18 -DCMAKE_CXX_COMPILER=clang++-18 --preset fuzzing-avm
+RUN cmake --build build-fuzzing-avm && mv build-fuzzing-avm/bin bin-fuzzing-avm && rm -rf build-fuzzing-avm
+
+# Merge per-preset manifests into unified manifest
+RUN python3 scripts/merge_fuzzer_manifests.py \
+    bin-fuzzing/fuzzer_manifest.json \
+    bin-fuzzing-noasm/fuzzer_manifest.json \
+    bin-fuzzing-avm/fuzzer_manifest.json \
+    build-fuzzing-cov/bin/fuzzer_manifest.json \
+    --output /tmp/fuzzer_manifest.json
+
+# Runtime stage
+FROM ubuntu:noble AS runtime
+
+# Install only runtime dependencies needed for fuzzing and coverage tools
+RUN apt-get update && \
+    apt-get install -y \
+        libstdc++6 \
+        libgcc-s1 \
+        libc6 \
+        libdw1 \
+        libelf1 \
+        libdwarf1 \
+        llvm-18 \
+        ca-certificates && \
+    apt-get -y autoremove && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+RUN useradd -m fuzzer -G sudo
+WORKDIR /home/fuzzer
+
+# Reuse source tree from builder for coverage reports
+COPY --from=builder /home/fuzzer/aztec-packages-src /home/fuzzer/aztec-packages
+
+WORKDIR /home/fuzzer/aztec-packages/barretenberg/cpp
+
+# Copy binaries from build stage
+COPY --from=builder /home/fuzzer/aztec-packages/barretenberg/cpp/bin-fuzzing ./build-fuzzing/bin
+COPY --from=builder /home/fuzzer/aztec-packages/barretenberg/cpp/bin-fuzzing-noasm ./build-fuzzing-noasm/bin
+COPY --from=builder /home/fuzzer/aztec-packages/barretenberg/cpp/bin-fuzzing-asan ./build-fuzzing-asan/bin
+COPY --from=builder /home/fuzzer/aztec-packages/barretenberg/cpp/bin-fuzzing-avm ./build-fuzzing-avm/bin
+
+# Copy full cov-build to keep LLVM links and external dependencies for coverage report
+COPY --from=builder /home/fuzzer/aztec-packages/barretenberg/cpp/build-fuzzing-cov/ ./build-fuzzing-cov/
+
+# Copy CRS
+COPY --from=builder /root/.bb-crs /root/.bb-crs
+
+# Copy fuzzer manifest
+COPY --from=builder /tmp/fuzzer_manifest.json ./fuzzer_manifest.json
+
+# Copy entrypoint script
+COPY entrypoint.sh .


### PR DESCRIPTION
## Summary
- Add `Dockerfile.private` for both `fuzzing-container` and `avm-fuzzing-container` that clone from the private repo using BuildKit secrets (`--mount=type=secret`). The token never persists in any image layer.
- Add CI workflows (`fuzzing-docker-build-private.yml`, `fuzzing-docker-avm-build-private.yml`) gated to `AztecProtocol/aztec-packages-private` via `if: github.repository` checks. Uses `GITHUB_TOKEN` directly since the workflow runs inside the private repo.
- Add repo guards to existing public workflows so they only run in `AztecProtocol/aztec-packages`.
- Add OCI labels (`com.aztec.source-repo`, `source-branch`, `commit`, `visibility`) to all container builds for orchestrator attribution via `skopeo inspect` / `docker inspect`.
- Add cosign keyless signing (GitHub OIDC) to all four workflows. Public containers log to Rekor transparency log; private containers use `--tlog-upload=false` to avoid leaking repo metadata. Action pinned to SHA, cosign binary pinned to v3.0.5.

### Container mapping

| Repo | Workflow | Image | Visibility |
|---|---|---|---|
| `aztec-packages` | `fuzzing-docker-build.yml` | `fuzzing-container` | public |
| `aztec-packages` | `fuzzing-docker-avm-build.yml` | `avm-fuzzing-container` | public |
| `aztec-packages-private` | `fuzzing-docker-build-private.yml` | `fuzzing-container-private` | private |
| `aztec-packages-private` | `fuzzing-docker-avm-build-private.yml` | `avm-fuzzing-container-private` | private |

### TODO
- [ ] Verify GHCR package visibility is private after first push (should be org default — confirm in GitHub UI)

### Note
The public/private workflow pairs could be combined into single workflows with conditional build steps to reduce duplication — left as a future improvement.

## Test plan
- [ ] Verify public workflows still trigger on `aztec-packages` pushes to `next`
- [ ] Verify public workflows show as skipped in `aztec-packages-private`
- [ ] Verify private workflows build and push with `GITHUB_TOKEN` in `aztec-packages-private`
- [ ] Verify `docker inspect` on pushed images shows correct OCI labels
- [ ] Verify `cosign verify` passes for signed images