### PR TITLE
fix(aztec-up): strip leading `v` prefix from version strings

### DIFF
--- a/aztec-up/bin/0.0.1/aztec-install
+++ b/aztec-up/bin/0.0.1/aztec-install
@@ -32,7 +32,7 @@ INSTALL_URI="${INSTALL_URI:-https://install.aztec-labs.com}"
 
 # Resolve alias (like "nightly") to actual version number.
 function resolve_version {
-  local version="$1"
+  local version="${1#v}"
   local semver_regex='^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.-]+)?(\+[a-zA-Z0-9.]+)?$'
   if [[ "$version" =~ $semver_regex ]]; then
     echo "$version"

--- a/aztec-up/bin/0.0.1/aztec-install
+++ b/aztec-up/bin/0.0.1/aztec-install
@@ -30,12 +30,20 @@ VERSION=${VERSION:-0.0.1}
 # Install URI (root, not version-specific)
 INSTALL_URI="${INSTALL_URI:-https://install.aztec-labs.com}"
 
+# Check if version string is valid semver
+function is_semver {
+  local version="$1"
+  local semver_regex='^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.-]+)?(\+[a-zA-Z0-9.]+)?$'
+  [[ "$version" =~ $semver_regex ]]
+}
+
 # Resolve alias (like "nightly") to actual version number.
 function resolve_version {
-  local version="${1#v}"
-  local semver_regex='^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.-]+)?(\+[a-zA-Z0-9.]+)?$'
-  if [[ "$version" =~ $semver_regex ]]; then
-    echo "$version"
+  local version="$1"
+  # Strip leading v from semver-like inputs (v0.85.0 -> 0.85.0), but not aliases (v4-nightly)
+  local stripped="${version#v}"
+  if is_semver "$stripped"; then
+    echo "$stripped"
   else
     local resolved
     if ! resolved=$(curl -fsSL "$INSTALL_URI/aliases/$version" 2>/dev/null); then

--- a/aztec-up/bin/0.0.1/aztec-up
+++ b/aztec-up/bin/0.0.1/aztec-up
@@ -102,7 +102,7 @@ function is_semver {
 
 # Resolve alias (like "nightly") to actual version number
 function resolve_version {
-  local version="$1"
+  local version="${1#v}"
   if is_semver "$version"; then
     echo "$version"
   else

--- a/aztec-up/bin/0.0.1/aztec-up
+++ b/aztec-up/bin/0.0.1/aztec-up
@@ -102,9 +102,11 @@ function is_semver {
 
 # Resolve alias (like "nightly") to actual version number
 function resolve_version {
-  local version="${1#v}"
-  if is_semver "$version"; then
-    echo "$version"
+  local version="$1"
+  # Strip leading v from semver-like inputs (v0.85.0 -> 0.85.0), but not aliases (v4-nightly)
+  local stripped="${version#v}"
+  if is_semver "$stripped"; then
+    echo "$stripped"
   else
     # Fetch alias file to get actual version
     local resolved


### PR DESCRIPTION
## Problem

When a user runs `aztec-up install v4.1.0-nightly.20260313` (note the `v` prefix), the version string fails the semver regex check because the pattern expects the string to start with a digit (`^[0-9]+\.…`). The code then falls through to alias resolution, which tries to fetch `https://install.aztec-labs.com/aliases/v4.1.0-nightly.20260313`. That endpoint doesn't exist, so the user gets a confusing error:

```
Error: Could not resolve alias 'v4.1.0-nightly.20260313'
```

This is a common UX pitfall -- many version managers and tools (git tags, GitHub releases, docker images) use a `v` prefix on versions, so users naturally copy-paste or type versions with the prefix.

## Fix

Strip a leading `v` from the version argument at the top of `resolve_version` using bash parameter expansion (`${1#v}`). This is a no-op when no `v` prefix is present, so existing usage is unaffected.

The fix is applied in both places where `resolve_version` is defined:
- **aztec-up/bin/0.0.1/aztec-up**: the version manager CLI
- **aztec-up/bin/0.0.1/aztec-install**: the bootstrap script (run via `curl | bash`)

Fixes F-440