### PR TITLE
fix(aztec-up): show installed version after install

### DIFF
--- a/aztec-up/bin/0.0.1/aztec-up
+++ b/aztec-up/bin/0.0.1/aztec-up
@@ -164,6 +164,12 @@ function cmd_install {
 
   # Update the current symlink
   ln -sfn "$AZTEC_HOME/versions/$resolved_version" "$AZTEC_HOME/current"
+
+  if [ "$version" != "$resolved_version" ]; then
+    echo_green "Installed and activated $version ($resolved_version)"
+  else
+    echo_green "Installed and activated version $resolved_version"
+  fi
 }
 
 # Switch to a version


### PR DESCRIPTION
## Problem

When running `aztec-up install nightly` (or any alias), the command completes without telling the user which concrete version was installed:

```
$ aztec-up install nightly
Installing version manifest... done.
Installing node... done.
Installing nargo... done.
Installing foundry... done.
Installing aztec packages... done.
```

There's no indication of what version "nightly" resolved to, so the user has no way of knowing what they're running without manually checking.

## Fix
When the user installed via an alias (e.g. `nightly`), the message includes both the alias and the resolved version so the user can see the mapping:

```
Installed and activated nightly (5.0.0-nightly.20260315)
```

When installed by exact semver, it just confirms the version:

```
Installed and activated version 5.0.0
```

This follows the same pattern as `rustup install nightly`, which shows the alias alongside the resolved toolchain version.

Fixes F-441