### PR TITLE
fix(aztec-up): add sensible defaults to installer y/n prompts

### DIFF
--- a/aztec-up/bin/0.0.1/aztec-install
+++ b/aztec-up/bin/0.0.1/aztec-install
@@ -86,10 +86,10 @@ function title {
   echo -e "  ${bold}${g}aztec-up${r}       - installs and manages aztec toolchain versions."
   echo -e "  ${bold}${g}aztec-wallet${r}   - a minimalistic wallet cli."
   echo
-  read -p "Do you wish to continue? (y/n) " -n 1 -r
+  read -p "Do you wish to continue? (Y/n) " -n 1 -r
   echo
   echo
-  if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+  if [[ ! $REPLY =~ ^[Yy]?$ ]]; then
     exit 1
   fi
 }
@@ -111,7 +111,7 @@ function check_for_old_install {
     echo_yellow "If you continue, the entire $AZTEC_HOME directory will be removed and replaced with the new installation."
     echo "You should manually remove old docker images you no longer need."
     echo
-    read -p "Do you wish to continue? (y/n) " -n 1 -r
+    read -p "Do you wish to continue? (y/N) " -n 1 -r
     echo
     echo
     if [[ ! $REPLY =~ ^[Yy]$ ]]; then

--- a/aztec-up/bin/0.0.1/aztec-up
+++ b/aztec-up/bin/0.0.1/aztec-up
@@ -376,7 +376,7 @@ function cmd_prune {
   done
   echo
 
-  read -p "Continue? (y/n) " -n 1 -r
+  read -p "Continue? (y/N) " -n 1 -r
   echo
   if [[ ! $REPLY =~ ^[Yy]$ ]]; then
     echo "Aborted."


### PR DESCRIPTION
## Problem

The Aztec installer prompts show `(y/n)` with no indicated default. Pressing Enter at any prompt aborts silently, which is confusing -- especially the fresh-install prompt where the user clearly intends to proceed.

## Fix

Give each prompt a sensible default and surface it in the prompt text using the standard `Y/n` (default-yes) and `y/N` (default-no) convention.

| Prompt | File | Default | Behavior on Enter |
|--------|------|---------|-------------------|
| Fresh install confirmation | **aztec-install** | **Yes** (`Y/n`) | Proceeds with install |
| Remove old install | **aztec-install** | **No** (`y/N`) | Aborts (destructive action) |
| Prune old versions | **aztec-up** | **No** (`y/N`) | Aborts (destructive action) |

Fixes F-445