### PR TITLE
fix(aztec-up): always reinstall noirup and foundryup bootstrappers

### DIFF
--- a/aztec-up/bin/0.0.1/install
+++ b/aztec-up/bin/0.0.1/install
@@ -144,10 +144,8 @@ function install_noir {
     temp_nargo_home=$(mktemp -d) || { echo "Error: Failed to create temp directory" >&2; exit 1; }
     mkdir -p "$temp_nargo_home/bin"
 
-    # Install noirup if not already present
-    if [ ! -f "$HOME/.nargo/bin/noirup" ]; then
-      curl -Ls https://raw.githubusercontent.com/noir-lang/noirup/refs/heads/main/install | bash
-    fi
+    # Always install/update noirup
+    curl -Ls https://raw.githubusercontent.com/noir-lang/noirup/refs/heads/main/install | bash
 
     # Install noir to temp location and move to version directory
     NARGO_HOME="$temp_nargo_home" "$HOME/.nargo/bin/noirup" -v "$noir_version"
@@ -172,10 +170,8 @@ function install_foundry {
   temp_foundry_dir=$(mktemp -d) || { echo "Error: Failed to create temp directory" >&2; exit 1; }
   mkdir -p "$temp_foundry_dir/bin"
 
-  # Install foundryup if not present or wrong version.
-  if ! "$HOME/.foundry/bin/foundryup" --help 2>&1 | grep -q -- '-i, --install'; then
-    curl --max-time 30 -L https://foundry.paradigm.xyz | bash
-  fi
+  # Always install/update foundryup
+  curl --max-time 30 -L https://foundry.paradigm.xyz | bash
 
   # Install foundry to temp location and move to version directory
   FOUNDRY_DIR="$temp_foundry_dir" timeout 30 "$HOME/.foundry/bin/foundryup" -i "$foundry_version"


### PR DESCRIPTION
## Problem

`aztec-up install` skipped re-downloading `noirup` and `foundryup` if they were already present on the user's machine. This meant returning users kept stale bootstrappers while new users got the latest ones.

When `noirup` gained support for downloading `noir-profiler`, users with an old `noirup` hit a hard failure at `mv noir-profiler` (the binary was never fetched). Existing users broke; new users didn't.

## Fix

Remove the conditional guards around both bootstrapper installs. Every `aztec-up install` now unconditionally re-curls `noirup` and `foundryup` install scripts, ensuring every user ends up with the same bootstrappers versions regardless of prior state. The ~2-5s overhead is negligible compared to the rest of the install.

Fixes F-471