### PR TITLE
fix(aztec-up): narrow PATH cleanup regex to avoid removing user PATH entries

### DIFF
--- a/aztec-up/bin/0.0.1/aztec-install
+++ b/aztec-up/bin/0.0.1/aztec-install
@@ -194,7 +194,7 @@ function update_path_env_var {
   if grep -q '\.aztec' "$shell_profile" 2>/dev/null; then
     # Remove old aztec PATH entries.
     local tmp_file=$(mktemp)
-    grep -Ev 'export PATH=.*/\.aztec/' "$shell_profile" > "$tmp_file" || true
+    grep -Ev 'export PATH="\$(HOME/\.aztec/|PATH:.*\.aztec/)' "$shell_profile" > "$tmp_file" || true
     mv "$tmp_file" "$shell_profile"
   fi
 


### PR DESCRIPTION
## Problem

The `update_path_env_var` function in `aztec-install` uses a broad regex to clean up old aztec PATH entries from the user's shell profile:

```bash
grep -Ev 'export PATH=.*/\.aztec/' "$shell_profile"
```

This matches **any** `export PATH=` line containing `/.aztec/` anywhere, which means it silently removes user-written PATH lines that happen to include `.aztec` directories. For example, a user with:

```bash
export PATH="/usr/local/bin:$HOME/.aztec/bin:$HOME/go/bin:$PATH"
```

would have this line deleted every time they run the installer, losing their `/usr/local/bin` and `$HOME/go/bin` entries.

### PATH formats found in git history

The installer has written two formats over time:

1. **Old format** (pre-version-manager, `5a80cd7adf`): `export PATH="$PATH:$HOME/.aztec/bin"` — appends aztec to PATH
2. **Current format** (since `f69c7bfe67`): `export PATH="$HOME/.aztec/current/bin:$HOME/.aztec/current/node_modules/.bin:$HOME/.aztec/bin:$PATH"` — prepends aztec to PATH

Both need to be cleaned up on re-install. Neither should cause collateral damage to user lines.

## Fix

Replace the broad regex with a targeted alternation that only matches the two known installer-written formats:

```bash
grep -Ev 'export PATH="\$(HOME/\.aztec/|PATH:.*\.aztec/)' "$shell_profile"
```

This matches:
- `export PATH="$HOME/.aztec/...` — current format (PATH value starts with `$HOME/.aztec/`)
- `export PATH="$PATH:.../.aztec/...` — old format (PATH value starts with `$PATH:` and contains `/.aztec/`)

And does **not** match user lines like:
- `export PATH="/usr/local/bin:$HOME/.aztec/bin:$HOME/go/bin:$PATH"` (doesn't start with `$HOME/.aztec` or `$PATH:`)
- `export PATH="$HOME/.local/bin:$HOME/.aztec/bin:$PATH"` (starts with `$HOME/.local`, not `$HOME/.aztec`)
- `export PATH="$HOME/.aztec-tools/bin:$PATH"` (trailing `/` after `.aztec` prevents matching `.aztec-tools`)

Fixes F-470