### PR TITLE
fix: explicitly handle initial block case for getBlockHashMembershipWitness

### DIFF
--- a/yarn-project/aztec-node/src/aztec-node/server.test.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.test.ts
@@ -653,7 +653,7 @@ describe('aztec node', () => {
         merkleTreeOps.getInitialHeader.mockReturnValue(initialHeader);
       });
 
-      it('does not crash when reference block is the initial block hash', async () => {
+      it('returns undefined when reference block is the initial block hash', async () => {
         // The initial block (block 0) has an empty archive — no block hashes exist in it.
         // getBlockHashMembershipWitness computes referenceBlockNumber - 1, which would be 0 - 1 = -1.
         // This should return undefined (empty archive has no witnesses) rather than crashing.

--- a/yarn-project/aztec-node/src/aztec-node/server.test.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.test.ts
@@ -641,6 +641,30 @@ describe('aztec node', () => {
         expect(result).toBe(snapshotMerkleTreeOps);
       });
     });
+
+    describe('getBlockHashMembershipWitness', () => {
+      let initialHeader: BlockHeader;
+
+      beforeEach(() => {
+        lastBlockNumber = BlockNumber(5);
+        initialHeader = BlockHeader.empty({
+          globalVariables: GlobalVariables.empty({ blockNumber: BlockNumber.ZERO }),
+        });
+        merkleTreeOps.getInitialHeader.mockReturnValue(initialHeader);
+      });
+
+      it('does not crash when reference block is the initial block hash', async () => {
+        // The initial block (block 0) has an empty archive — no block hashes exist in it.
+        // getBlockHashMembershipWitness computes referenceBlockNumber - 1, which would be 0 - 1 = -1.
+        // This should return undefined (empty archive has no witnesses) rather than crashing.
+        const initialHash = await initialHeader.hash();
+        const initialBlockHash = new BlockHash(initialHash);
+        const someBlockHash = BlockHash.random();
+
+        const result = await node.getBlockHashMembershipWitness(initialBlockHash, someBlockHash);
+        expect(result).toBeUndefined();
+      });
+    });
   });
 
   describe('simulatePublicCalls', () => {

--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -1054,6 +1054,7 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, Traceable {
     // So we need the world state at block N-1, not block N, to produce a sibling path matching that root.
     const referenceBlockNumber = await this.resolveBlockNumber(referenceBlock);
     if (referenceBlockNumber === BlockNumber.ZERO) {
+      // Block 0 (the initial block) has an empty archive, so no membership witness can exist.
       return undefined;
     }
     const committedDb = await this.getWorldState(BlockNumber(referenceBlockNumber - 1));

--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -1053,6 +1053,9 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, Traceable {
     // which is the archive tree root BEFORE the anchor block was added (i.e. the state after block N-1).
     // So we need the world state at block N-1, not block N, to produce a sibling path matching that root.
     const referenceBlockNumber = await this.resolveBlockNumber(referenceBlock);
+    if (referenceBlockNumber === 0) {
+      return undefined;
+    }
     const committedDb = await this.getWorldState(BlockNumber(referenceBlockNumber - 1));
     const [pathAndIndex] = await committedDb.findSiblingPaths<MerkleTreeId.ARCHIVE>(MerkleTreeId.ARCHIVE, [blockHash]);
     return pathAndIndex === undefined

--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -1053,7 +1053,7 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, Traceable {
     // which is the archive tree root BEFORE the anchor block was added (i.e. the state after block N-1).
     // So we need the world state at block N-1, not block N, to produce a sibling path matching that root.
     const referenceBlockNumber = await this.resolveBlockNumber(referenceBlock);
-    if (referenceBlockNumber === 0) {
+    if (referenceBlockNumber === BlockNumber.ZERO) {
       return undefined;
     }
     const committedDb = await this.getWorldState(BlockNumber(referenceBlockNumber - 1));


### PR DESCRIPTION
Just a minor nit, but I noticed getBlockHashMembershipWitness was not handling the initial block case explicitly and it made me nervous.

@spalladino please let me know if it's ok to backport this too

Closes F-473