### PR TITLE
chore: expose reduce_ms and ipa_ms in VerifyResult for phase benchmarking

### DIFF
--- a/barretenberg/cpp/src/barretenberg/benchmark/chonk_bench/chonk.bench.cpp
+++ b/barretenberg/cpp/src/barretenberg/benchmark/chonk_bench/chonk.bench.cpp
@@ -6,6 +6,7 @@
 #include <benchmark/benchmark.h>
 #include <chrono>
 
+#include "barretenberg/chonk/chonk_batch_verifier.hpp"
 #include "barretenberg/chonk/chonk_verifier.hpp"
 #include "barretenberg/chonk/proof_compression.hpp"
 #include "barretenberg/chonk/test_bench_shared.hpp"
@@ -112,6 +113,61 @@ BENCHMARK_DEFINE_F(ChonkBench, VerifyIndividual)(benchmark::State& state)
     }
 }
 
+/**
+ * @brief Benchmark batch verification with phase breakdown (reduce vs IPA MSM).
+ * range(0) = batch_size, range(1) = num_cores.
+ * Reports: wall time, plus custom counters for reduce_ms and ipa_ms from C++ VerifyResult fields.
+ */
+BENCHMARK_DEFINE_F(ChonkBench, BatchVerify)(benchmark::State& state)
+{
+    const auto batch_size = static_cast<uint32_t>(state.range(0));
+    const auto num_cores = static_cast<uint32_t>(state.range(1));
+    auto precomputed_vks = precompute_vks(1);
+    auto [proof, vk_and_hash] = accumulate_and_prove_with_precomputed_vks(1, precomputed_vks);
+
+    double total_reduce_ms = 0;
+    double total_ipa_ms = 0;
+    size_t result_count = 0;
+
+    for (auto _ : state) {
+        std::vector<VerifyResult> results;
+        std::mutex results_mutex;
+        std::condition_variable results_cv;
+
+        ChonkBatchVerifier verifier;
+        verifier.start({ vk_and_hash }, num_cores, batch_size, [&](VerifyResult r) {
+            std::lock_guard lock(results_mutex);
+            results.push_back(std::move(r));
+            results_cv.notify_one();
+        });
+
+        for (uint32_t i = 0; i < batch_size; ++i) {
+            verifier.enqueue(VerifyRequest{
+                .request_id = i, .vk_index = 0, .proof = proof // copy each time
+            });
+        }
+
+        {
+            std::unique_lock lock(results_mutex);
+            results_cv.wait(lock, [&] { return results.size() >= batch_size; });
+        }
+        verifier.stop();
+
+        // Accumulate phase timings
+        for (const auto& r : results) {
+            total_reduce_ms += r.reduce_ms;
+            total_ipa_ms += r.ipa_ms;
+            result_count++;
+        }
+    }
+
+    // Report phase breakdown as custom counters
+    if (result_count > 0) {
+        state.counters["avg_reduce_ms"] = total_reduce_ms / static_cast<double>(result_count);
+        state.counters["ipa_ms"] = total_ipa_ms / static_cast<double>(result_count);
+    }
+}
+
 #define ARGS Arg(ChonkBench::NUM_ITERATIONS_MEDIUM_COMPLEXITY)->Arg(2)
 
 BENCHMARK_REGISTER_F(ChonkBench, Full)->Unit(benchmark::kMillisecond)->ARGS;
@@ -119,6 +175,15 @@ BENCHMARK_REGISTER_F(ChonkBench, VerificationOnly)->Unit(benchmark::kMillisecond
 BENCHMARK_REGISTER_F(ChonkBench, ProofCompress)->Unit(benchmark::kMillisecond);
 BENCHMARK_REGISTER_F(ChonkBench, ProofDecompress)->Unit(benchmark::kMillisecond);
 BENCHMARK_REGISTER_F(ChonkBench, VerifyIndividual)->Unit(benchmark::kMillisecond)->Arg(1)->Arg(2)->Arg(4)->Arg(8);
+// BatchVerify: sweep batch_size x cores
+// clang-format off
+BENCHMARK_REGISTER_F(ChonkBench, BatchVerify)->Unit(benchmark::kMillisecond)
+    ->Args({1, 1})->Args({1, 2})->Args({1, 4})->Args({1, 6})->Args({1, 8})
+    ->Args({4, 1})->Args({4, 2})->Args({4, 4})->Args({4, 6})->Args({4, 8})
+    ->Args({8, 1})->Args({8, 2})->Args({8, 4})->Args({8, 6})->Args({8, 8})
+    ->Args({16, 1})->Args({16, 2})->Args({16, 4})->Args({16, 6})->Args({16, 8})
+    ->Iterations(1);
+// clang-format on
 
 } // namespace
 

--- a/barretenberg/cpp/src/barretenberg/chonk/batch_verifier_types.hpp
+++ b/barretenberg/cpp/src/barretenberg/chonk/batch_verifier_types.hpp
@@ -32,6 +32,8 @@ struct VerifyResult {
     std::string error_message;
     double time_in_queue_ms = 0;
     double time_in_verify_ms = 0;
+    double reduce_ms = 0;             // Phase 1: reduce_to_ipa_claim time for this proof
+    double ipa_ms = 0;                // Phase 2: batch_check (IPA MSM) wall time for this batch
     uint32_t batch_failure_count = 0; // Number of bisection levels to identify failure
 
     bool verified() const { return status == static_cast<uint8_t>(VerifyStatus::OK); }
@@ -43,7 +45,8 @@ struct VerifyResult {
                  .error_message = std::move(msg) };
     }
 
-    SERIALIZATION_FIELDS(request_id, status, error_message, time_in_queue_ms, time_in_verify_ms, batch_failure_count);
+    SERIALIZATION_FIELDS(
+        request_id, status, error_message, time_in_queue_ms, time_in_verify_ms, reduce_ms, ipa_ms, batch_failure_count);
     bool operator==(const VerifyResult&) const = default;
 };
 

--- a/barretenberg/cpp/src/barretenberg/chonk/chonk_batch_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/chonk/chonk_batch_verifier.cpp
@@ -290,6 +290,8 @@ void ChonkBatchVerifier::emit_ok(const std::vector<ReduceResult>& results,
             .status = static_cast<uint8_t>(VerifyStatus::OK),
             .time_in_queue_ms = ms_between(rr.enqueue_time, reduce_start),
             .time_in_verify_ms = rr.reduce_ms + ipa_ms,
+            .reduce_ms = rr.reduce_ms,
+            .ipa_ms = ipa_ms,
             .batch_failure_count = depth,
         });
     }

--- a/yarn-project/bb-prover/src/verifier/batch_chonk_verifier.ts
+++ b/yarn-project/bb-prover/src/verifier/batch_chonk_verifier.ts
@@ -25,6 +25,8 @@ interface FifoVerifyResult {
   status: number;
   error_message: string;
   time_in_verify_ms: number;
+  reduce_ms: number;
+  ipa_ms: number;
 }
 
 /** Maps client protocol artifacts used for chonk verification to VK indices. */
@@ -236,7 +238,13 @@ export class BatchChonkVerifier implements ClientProtocolCircuitVerifier {
     const durationMs = result.time_in_verify_ms;
     const totalDurationMs = pending.totalTimer.ms();
 
-    const ivcResult: IVCProofVerificationResult = { valid, durationMs, totalDurationMs };
+    const ivcResult: IVCProofVerificationResult = {
+      valid,
+      durationMs,
+      totalDurationMs,
+      reduceMs: result.reduce_ms,
+      ipaMs: result.ipa_ms,
+    };
 
     if (!valid) {
       this.logger.warn(`Proof verification failed for request_id=${result.request_id}: ${result.error_message}`);
@@ -244,6 +252,8 @@ export class BatchChonkVerifier implements ClientProtocolCircuitVerifier {
       this.logger.debug(`Proof verified`, {
         requestId: result.request_id,
         durationMs: Math.ceil(durationMs),
+        reduceMs: Math.ceil(result.reduce_ms),
+        ipaMs: Math.ceil(result.ipa_ms),
         totalDurationMs: Math.ceil(totalDurationMs),
       });
     }

--- a/yarn-project/ivc-integration/src/batch_verifier.bench.test.ts
+++ b/yarn-project/ivc-integration/src/batch_verifier.bench.test.ts
@@ -115,17 +115,23 @@ describe('Batch Chonk Verifier Benchmarks (Real Proofs)', () => {
         expect(results.every(r => r.valid)).toBe(true);
 
         const avgVerifyMs = results.reduce((sum, r) => sum + r.durationMs, 0) / results.length;
+        const avgReduceMs = results.reduce((sum, r) => sum + (r.reduceMs ?? 0), 0) / results.length;
+        const ipaMs = results[0]?.ipaMs ?? 0;
         const throughput = (numProofs / wallMs) * 1000;
 
         benchResults.push(
           { name: `BatchVerify/16_real_proofs/${numCores}_cores/wall_time`, value: wallMs, unit: 'ms' },
           { name: `BatchVerify/16_real_proofs/${numCores}_cores/avg_verify`, value: avgVerifyMs, unit: 'ms' },
+          { name: `BatchVerify/16_real_proofs/${numCores}_cores/avg_reduce`, value: avgReduceMs, unit: 'ms' },
+          { name: `BatchVerify/16_real_proofs/${numCores}_cores/ipa_ms`, value: ipaMs, unit: 'ms' },
           { name: `BatchVerify/16_real_proofs/${numCores}_cores/throughput`, value: throughput, unit: 'proofs/sec' },
         );
 
         logger.info(`16 proofs, ${numCores} cores`, {
           wallMs: Math.ceil(wallMs),
           avgVerifyMs: Math.ceil(avgVerifyMs),
+          avgReduceMs: Math.ceil(avgReduceMs),
+          ipaMs: Math.ceil(ipaMs),
           throughput: throughput.toFixed(2),
         });
       } finally {

--- a/yarn-project/stdlib/src/interfaces/server_circuit_prover.ts
+++ b/yarn-project/stdlib/src/interfaces/server_circuit_prover.ts
@@ -195,10 +195,14 @@ export interface ServerCircuitProver {
 export type IVCProofVerificationResult = {
   // The result of verification
   valid: boolean;
-  // The duration of the verification in milliseconds
+  // The duration of the verification in milliseconds (reduce + IPA)
   durationMs: number;
   // The total duration, including proof serialisation and file-system cleanup
   totalDurationMs: number;
+  // Phase 1: reduce_to_ipa_claim time for this proof (ms)
+  reduceMs?: number;
+  // Phase 2: batch_check (IPA MSM) wall time for this batch (ms)
+  ipaMs?: number;
 };
 
 /**


### PR DESCRIPTION
Adds `reduce_ms` and `ipa_ms` fields to the C++ `VerifyResult` struct, wired through the FIFO to TypeScript's `IVCProofVerificationResult`.

This enables the batch verifier bench to report exact per-phase timings from C++ rather than inferring them from wall time deltas. The IPA MSM uses `set_parallel_for_concurrency(num_cores_)` so its cost scales with cores — accurate measurement requires the benchmark machine.

### Changes
- `batch_verifier_types.hpp`: Add `reduce_ms`, `ipa_ms` to `VerifyResult` + serialization
- `chonk_batch_verifier.cpp`: Populate new fields in `emit_ok()`
- `batch_chonk_verifier.ts`: Read new fields from FIFO, pass to `IVCProofVerificationResult`
- `server_circuit_prover.ts`: Add optional `reduceMs?`, `ipaMs?` to `IVCProofVerificationResult`
- `batch_verifier.bench.test.ts`: Output `avg_reduce` and `ipa_ms` per config

### Bench output (new fields)
```
BatchVerify/16_real_proofs/6_cores/avg_reduce: Xms
BatchVerify/16_real_proofs/6_cores/ipa_ms: Yms
```