### PR TITLE
fix(e2e): set anvilSlotsInAnEpoch in slashing tests

### DIFF
--- a/yarn-project/end-to-end/src/e2e_p2p/broadcasted_invalid_block_proposal_slash.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/broadcasted_invalid_block_proposal_slash.test.ts
@@ -56,6 +56,7 @@ describe('e2e_p2p_broadcasted_invalid_block_proposal_slash', () => {
       basePort: BOOT_NODE_UDP_PORT,
       metricsPort: shouldCollectMetrics(),
       initialConfig: {
+        anvilSlotsInAnEpoch: 4,
         listenAddress: '127.0.0.1',
         aztecEpochDuration,
         ethereumSlotDuration: ETHEREUM_SLOT_DURATION,

--- a/yarn-project/end-to-end/src/e2e_p2p/data_withholding_slash.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/data_withholding_slash.test.ts
@@ -58,6 +58,7 @@ describe('e2e_p2p_data_withholding_slash', () => {
       basePort: BOOT_NODE_UDP_PORT,
       metricsPort: shouldCollectMetrics(),
       initialConfig: {
+        anvilSlotsInAnEpoch: 4,
         listenAddress: '127.0.0.1',
         aztecEpochDuration,
         ethereumSlotDuration: 4,

--- a/yarn-project/end-to-end/src/e2e_p2p/duplicate_attestation_slash.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/duplicate_attestation_slash.test.ts
@@ -68,6 +68,7 @@ describe('e2e_p2p_duplicate_attestation_slash', () => {
       basePort: BOOT_NODE_UDP_PORT,
       metricsPort: shouldCollectMetrics(),
       initialConfig: {
+        anvilSlotsInAnEpoch: 4,
         listenAddress: '127.0.0.1',
         aztecEpochDuration,
         ethereumSlotDuration: ETHEREUM_SLOT_DURATION,

--- a/yarn-project/end-to-end/src/e2e_p2p/duplicate_proposal_slash.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/duplicate_proposal_slash.test.ts
@@ -60,6 +60,7 @@ describe('e2e_p2p_duplicate_proposal_slash', () => {
       basePort: BOOT_NODE_UDP_PORT,
       metricsPort: shouldCollectMetrics(),
       initialConfig: {
+        anvilSlotsInAnEpoch: 4,
         listenAddress: '127.0.0.1',
         aztecEpochDuration,
         ethereumSlotDuration: ETHEREUM_SLOT_DURATION,

--- a/yarn-project/end-to-end/src/e2e_p2p/inactivity_slash_test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/inactivity_slash_test.ts
@@ -58,6 +58,7 @@ export class P2PInactivityTest {
       basePort: BOOT_NODE_UDP_PORT,
       startProverNode: true,
       initialConfig: {
+        anvilSlotsInAnEpoch: 4,
         proverNodeConfig: { proverNodeEpochProvingDelayMs: AZTEC_SLOT_DURATION * 1000 },
         aztecTargetCommitteeSize: COMMITTEE_SIZE,
         aztecSlotDuration: AZTEC_SLOT_DURATION,

--- a/yarn-project/end-to-end/src/e2e_p2p/multiple_validators_sentinel.parallel.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/multiple_validators_sentinel.parallel.test.ts
@@ -44,6 +44,7 @@ describe('e2e_p2p_multiple_validators_sentinel', () => {
       basePort: BOOT_NODE_UDP_PORT,
       startProverNode: true,
       initialConfig: {
+        anvilSlotsInAnEpoch: 4,
         aztecTargetCommitteeSize: NUM_VALIDATORS,
         aztecSlotDuration: AZTEC_SLOT_DURATION,
         ethereumSlotDuration: ETHEREUM_SLOT_DURATION,

--- a/yarn-project/end-to-end/src/e2e_p2p/slash_veto_demo.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/slash_veto_demo.test.ts
@@ -78,6 +78,7 @@ describe('veto slash', () => {
       basePort: BOOT_NODE_UDP_PORT,
       startProverNode: true,
       initialConfig: {
+        anvilSlotsInAnEpoch: 4,
         aztecSlotDuration: AZTEC_SLOT_DURATION,
         ethereumSlotDuration: ETHEREUM_SLOT_DURATION,
         aztecProofSubmissionEpochs: 1024, // effectively do not reorg

--- a/yarn-project/end-to-end/src/e2e_p2p/valid_epoch_pruned_slash.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/valid_epoch_pruned_slash.test.ts
@@ -52,6 +52,7 @@ describe('e2e_p2p_valid_epoch_pruned_slash', () => {
       basePort: BOOT_NODE_UDP_PORT,
       metricsPort: shouldCollectMetrics(),
       initialConfig: {
+        anvilSlotsInAnEpoch: 4,
         enforceTimeTable: true,
         cancelTxOnTimeout: false,
         sequencerPublisherAllowInvalidStates: true,

--- a/yarn-project/end-to-end/src/e2e_p2p/validators_sentinel.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/validators_sentinel.test.ts
@@ -39,6 +39,7 @@ describe('e2e_p2p_validators_sentinel', () => {
       basePort: BOOT_NODE_UDP_PORT,
       startProverNode: true,
       initialConfig: {
+        anvilSlotsInAnEpoch: 4,
         aztecTargetCommitteeSize: NUM_VALIDATORS,
         aztecSlotDuration: AZTEC_SLOT_DURATION,
         ethereumSlotDuration: ETHEREUM_SLOT_DURATION,

--- a/yarn-project/end-to-end/src/e2e_sequencer/slasher_config.test.ts
+++ b/yarn-project/end-to-end/src/e2e_sequencer/slasher_config.test.ts
@@ -11,6 +11,7 @@ describe('e2e_slasher_config', () => {
 
   beforeAll(async () => {
     ({ aztecNodeAdmin, aztecNode, teardown } = await setup(0, {
+      anvilSlotsInAnEpoch: 4,
       slashInactivityTargetPercentage: 1,
       slashInactivityPenalty: 42n,
     }));


### PR DESCRIPTION
With the default `slotsInAnEpoch=1`, anvil finalizes blocks almost immediately (`finalized = latest - 2`). This causes the P2P client to prune its attestation pool before the sentinel gets a chance to read it, leading to false `attestation-missed` flakes in sentinel and slashing tests. Bumps to 4 so finalization doesn't race ahead of sentinel processing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)