### PR TITLE
feat(aztec-up): default install version to latest instead of nightly

### DIFF
--- a/aztec-up/bootstrap.sh
+++ b/aztec-up/bootstrap.sh
@@ -129,8 +129,8 @@ function release {
 # This is not done by CI.
 # It's a manual process, as updating the root installer and alias index requires careful consideration.
 function release_root_installer {
-    # Upload root aztec-install with VERSION defaulting to nightly (instead of local 0.0.1).
-    sed "s/^VERSION=.*/VERSION=\${VERSION:-nightly}/" bin/0.0.1/aztec-install | \
+    # Upload root aztec-install with VERSION defaulting to latest (instead of local 0.0.1).
+    sed "s/^VERSION=.*/VERSION=\${VERSION:-latest}/" bin/0.0.1/aztec-install | \
       do_or_dryrun aws s3 cp - "s3://install.aztec.network/aztec-install"
     do_or_dryrun aws s3 cp bin/0.0.1/aztec-up "s3://install.aztec.network/aztec-up"
 


### PR DESCRIPTION
## Summary

- When `release_root_installer` uploads `aztec-install` to S3, it rewrites the default `VERSION` from the local dev value (`0.0.1`) to a remote alias. Previously this defaulted to `nightly`, meaning `bash -i <(curl -s https://install.aztec.network)` would install a nightly build.
- Changed the default to `latest` so new users get the latest stable release.
- Takes effect next time `release_root_installer` is run manually.

Fixes F-480