### PR TITLE
fix(aztec-up): validate semver in uninstall to prevent path traversal

### DIFF
--- a/aztec-up/bin/0.0.1/aztec-up
+++ b/aztec-up/bin/0.0.1/aztec-up
@@ -314,6 +314,11 @@ function cmd_uninstall {
     exit 1
   fi
 
+  if ! is_semver "$version"; then
+    echo "Error: Invalid version '$version'. Expected a semver string (e.g. 0.85.0)."
+    exit 1
+  fi
+
   local current_version
   current_version=$(get_current_version)
 


### PR DESCRIPTION
## Problem

`aztec-up uninstall` passes user input directly into an `rm -rf` path without validating the format:

```bash
rm -rf "$AZTEC_HOME/versions/$version"
```

The existing `is_version_installed` guard checks `[ -d "$AZTEC_HOME/versions/$version" ]`, but this passes for path-traversal inputs like `../` because `$AZTEC_HOME/versions/../` resolves to `$AZTEC_HOME/` which is a valid directory.

This means `aztec-up uninstall ../` executes `rm -rf "$AZTEC_HOME/"`, deleting the entire Aztec home directory including all installed versions, the `current` symlink, and shared binaries like `aztec-up` itself.

## Fix

Added a semver validation check using the existing `is_semver` function before the `rm -rf` is reached. Since installed version directories are always named with concrete semver strings (aliases like `nightly` are resolved to semver at install time), this rejects any input that isn't a valid version -- including path traversal attempts, typos, and other malformed strings.

The check is placed after `is_version_installed` so that the more user-friendly "not installed" message is shown first for valid-looking versions that simply aren't present.

Fixes F-484