### PR TITLE
fix(aztec-up): add truncation protection to install scripts

### DIFF
--- a/aztec-up/bin/0.0.1/aztec-install
+++ b/aztec-up/bin/0.0.1/aztec-install
@@ -3,6 +3,9 @@
 # This script installs aztec-up and then delegates to it for version installation.
 # Usage: bash -i <(curl -s https://install.aztec.network)
 #    or: VERSION=0.85.0 bash -i <(curl -s https://install.aztec.network)
+
+# Guard against truncated curl downloads: bash must parse the entire {} block before executing any of it.
+{
 set -euo pipefail
 
 # Colors (truecolor with 256-color fallback)
@@ -242,3 +245,7 @@ function main {
 }
 
 main "$@"
+
+# Explicit exit prevents bash from reading past the closing brace.
+exit
+}

--- a/aztec-up/bin/0.0.1/install
+++ b/aztec-up/bin/0.0.1/install
@@ -2,6 +2,9 @@
 # Per-version installer script
 # This script is called by aztec-up to install a specific version of the Aztec toolchain.
 # It expects VERSION and INSTALL_URI to be set.
+
+# Guard against truncated curl downloads: bash must parse the entire {} block before executing any of it.
+{
 set -euo pipefail
 
 # Colors
@@ -232,3 +235,7 @@ function main {
 }
 
 main "$@"
+
+# Explicit exit prevents bash from reading past the closing brace.
+exit
+}


### PR DESCRIPTION
## Problem

The `install` and `aztec-install` scripts are both fetched and executed via `curl | bash` (e.g. `bash -i <(curl -s https://install.aztec.network)` for `aztec-install`, and `curl -fsSL "$install_url" | bash` in `aztec-up` line 163 for `install`).

When bash reads from a pipe, it processes input incrementally. If the download is truncated mid-stream (network drop, CDN timeout, partial response), bash can execute the portion it has already read, leaving the system in a broken or partially-configured state. For example, a truncated `install` script could create the version directory and download the versions manifest but never install the actual toolchain binaries, leaving users with a seemingly-installed but non-functional version.

`aztec-up` itself already has this protection (lines 4-6 and 496-498), but the two scripts it downloads and pipes to bash did not.

## Fix

Wrapped both scripts in `{ ... exit; }`, the same pattern already used by `aztec-up`:

```bash
#!/usr/bin/env bash
# Guard against truncated curl downloads: bash must parse the entire {} block before executing any of it.
{
set -euo pipefail

# ... script body ...

main "$@"

# Explicit exit prevents bash from reading past the closing brace.
exit
}
```

The `{}` grouping forces bash to read and parse the entire block before executing any of it. If the download is truncated, bash hits a parse error (unclosed `{`) and refuses to run anything. The explicit `exit` before `}` ensures the shell terminates cleanly and doesn't attempt to parse any trailing data.

**Files changed:**
- **aztec-install**: the root bootstrap script users invoke directly via curl
- **install**: the per-version installer that `aztec-up` downloads and pipes to bash

Fixes F-481