### PR TITLE
fix: don't lose precision when sorting bigints

### DIFF
--- a/yarn-project/foundation/src/trees/indexed_merkle_tree_calculator.test.ts
+++ b/yarn-project/foundation/src/trees/indexed_merkle_tree_calculator.test.ts
@@ -198,7 +198,7 @@ describe('indexed merkle tree root calculator', () => {
     // Pick some value to find a witness for...
     const testIndex = 2;
     const testValue = values[testIndex];
-    const sortedValues = [...values].sort((a, b) => Number(a.toBigInt() - b.toBigInt()));
+    const sortedValues = [...values].sort((a, b) => a.cmp(b));
     // ...and find its next value.
     const nextValue = sortedValues[sortedValues.indexOf(testValue) + 1] || Fr.ZERO;
 
@@ -230,7 +230,7 @@ describe('indexed merkle tree root calculator', () => {
 
     // Pick some value to find a low leaf for...
     const testValue = Fr.random();
-    const sortedValues = [...values].sort((a, b) => Number(a.toBigInt() - b.toBigInt()));
+    const sortedValues = [...values].sort((a, b) => a.cmp(b));
     // ...and find its 'sandwich' values.
     const previousIndex = sortedValues.findIndex(
       (a, i) =>

--- a/yarn-project/foundation/src/trees/indexed_merkle_tree_calculator.ts
+++ b/yarn-project/foundation/src/trees/indexed_merkle_tree_calculator.ts
@@ -40,7 +40,11 @@ export class IndexedMerkleTreeCalculator<T extends IndexedTreeLeafPreimage, N ex
     }
     const sorted = values
       .map((v, i) => ({ value: v, index: i }))
-      .sort((a, b) => Number(toBigIntBE(b.value) - toBigIntBE(a.value)));
+      .sort((a, b): -1 | 0 | 1 => {
+        const aBigInt = toBigIntBE(a.value);
+        const bBigInt = toBigIntBE(b.value);
+        return aBigInt < bBigInt ? 1 : aBigInt > bBigInt ? -1 : 0;
+      });
     const indexedLeaves = sorted.map((item, i) => ({
       leaf: this.factory.fromBuffer(
         Buffer.concat([


### PR DESCRIPTION
Fix A-742