### PR TITLE
fix: Update private-kernel-lib tests for bounded vec change

### DIFF
--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/tests/private_kernel_reset/reset_output_validator/mod.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/tests/private_kernel_reset/reset_output_validator/mod.nr
@@ -18,6 +18,21 @@ use super::{
     TRANSIENT_DATA_SQUASHING_HINTS_LEN,
 };
 
+/// Rebuilds a BoundedVec with clean zero-initialized storage past its length.
+/// BoundedVec.pop() no longer zeroes vacated slots; call this after pop() to
+/// ensure elements beyond the claimed length are zero.
+fn rebuild_bounded_vec<T, let N: u32>(vec: BoundedVec<T, N>) -> BoundedVec<T, N> {
+    let storage = vec.storage();
+    let len = vec.len();
+    let mut clean: BoundedVec<T, N> = BoundedVec::new();
+    for i in 0..N {
+        if i < len {
+            clean.push(storage[i]);
+        }
+    }
+    clean
+}
+
 impl TestBuilder {
     pub fn get_output_hints(self) -> SquashedOutputArrayHints {
         let previous_kernel = self.previous_kernel.to_private_kernel_circuit_public_inputs();

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/tests/private_kernel_reset/reset_output_validator/propagated_note_hashes_tests.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/tests/private_kernel_reset/reset_output_validator/propagated_note_hashes_tests.nr
@@ -1,5 +1,6 @@
 use crate::tests::private_kernel_reset::{NOTE_HASH_SILOING_AMOUNT, TestBuilder};
 use protocol_test_utils::swap_items;
+use super::rebuild_bounded_vec;
 
 #[test]
 fn previous_note_hashes_sorted() {
@@ -110,6 +111,9 @@ fn with_padded_note_hashes() {
         builder.previous_kernel.note_hashes.pop().innermost();
     builder.padded_side_effects.note_hashes[3] =
         builder.previous_kernel.note_hashes.pop().innermost();
+
+    // BoundedVec.pop() no longer zeroes vacated slots; rebuild with clean storage.
+    builder.previous_kernel.note_hashes = rebuild_bounded_vec(builder.previous_kernel.note_hashes);
 
     builder.output.append_siloed_note_hashes(3);
     builder.output.append_padded_note_hashes(2);

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/tests/private_kernel_reset/reset_output_validator/propagated_nullifiers_tests.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/tests/private_kernel_reset/reset_output_validator/propagated_nullifiers_tests.nr
@@ -1,5 +1,6 @@
 use crate::tests::private_kernel_reset::{NULLIFIER_SILOING_AMOUNT, TestBuilder};
 use protocol_test_utils::swap_items;
+use super::rebuild_bounded_vec;
 
 #[test]
 fn previous_nullifiers_sorted() {
@@ -125,6 +126,9 @@ fn with_padded_nullifiers() {
         builder.previous_kernel.nullifiers.pop().innermost().value;
     builder.padded_side_effects.nullifiers[3] =
         builder.previous_kernel.nullifiers.pop().innermost().value;
+
+    // BoundedVec.pop() no longer zeroes vacated slots; rebuild with clean storage.
+    builder.previous_kernel.nullifiers = rebuild_bounded_vec(builder.previous_kernel.nullifiers);
 
     builder.output.append_siloed_nullifiers(3);
     builder.output.append_padded_nullifiers(2);

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/tests/private_kernel_reset/reset_output_validator/propagated_private_logs_tests.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/tests/private_kernel_reset/reset_output_validator/propagated_private_logs_tests.nr
@@ -1,5 +1,6 @@
 use crate::tests::private_kernel_reset::{PRIVATE_LOG_SILOING_AMOUNT, TestBuilder};
 use protocol_test_utils::swap_items;
+use super::rebuild_bounded_vec;
 
 #[test]
 fn previous_private_logs_sorted() {
@@ -156,6 +157,9 @@ fn with_padded_private_logs() {
     builder.padded_side_effects.private_logs[1] =
         builder.previous_kernel.private_logs.pop().innermost().log;
 
+    // BoundedVec.pop() no longer zeroes vacated slots; rebuild with clean storage.
+    builder.previous_kernel.private_logs = rebuild_bounded_vec(builder.previous_kernel.private_logs);
+
     builder.output.append_siloed_private_logs(1);
     builder.output.append_padded_private_logs(2);
 
@@ -183,6 +187,9 @@ fn total_private_logs_more_than_capped_size() {
     // Pop the last private log and use it as padding.
     builder.padded_side_effects.private_logs[PRIVATE_LOG_SILOING_AMOUNT] =
         builder.previous_kernel.private_logs.pop().innermost().log;
+
+    // BoundedVec.pop() no longer zeroes vacated slots; rebuild with clean storage.
+    builder.previous_kernel.private_logs = rebuild_bounded_vec(builder.previous_kernel.private_logs);
 
     builder.output.append_siloed_private_logs(PRIVATE_LOG_SILOING_AMOUNT);
     builder.output.append_padded_private_logs(1);


### PR DESCRIPTION
https://github.com/noir-lang/noir/pull/11679 in the Noir compiler removes zeroing of BoundedVec elements past the length of the bounded vec. It is a potential footgun: due to the behavior of `BoundedVec::eq` previously checking these elements past the length, it meant that when returned from an unconstrained function, users also needed to constrain past-the-length elements, but this was not done in practice.

4 tests in private-kernel-lib are breaking with this change, I've edited them to manually create a Vec where each element past the length is zeroed instead.