### PR TITLE
fix: pin typescript and harden lockfile check in docs examples CI

### DIFF
--- a/docs/examples/ts/bootstrap.sh
+++ b/docs/examples/ts/bootstrap.sh
@@ -231,7 +231,7 @@ validate_project() {
             echo_stderr "  ✓ $pkg_name: $dts_count .d.ts files"
         done
 
-        yarn add -D typescript >/dev/null 2>&1
+        yarn add -D "typescript@^5.3.3" >/dev/null 2>&1
 
         # Create tsconfig.json from template
         if [ ! -f "$REPO_ROOT/docs/examples/ts/tsconfig.template.json" ]; then
@@ -264,16 +264,20 @@ get_all_projects() {
     done
 }
 
-# In CI, validate all yarn.lock files are empty (they must exist but contain no content).
+# In CI, validate all yarn.lock files are committed empty (they must exist but contain no content).
+# We check git state (not filesystem) because a previous interrupted validation run may have
+# populated lockfiles on disk via yarn add before cleanup could run.
 # Locally, the pre-commit hook handles this; here we catch it in case hooks were bypassed.
 if [ "${CI:-0}" != "0" ]; then
     for lockfile in */yarn.lock; do
         [ -f "$lockfile" ] || continue
-        if [ -s "$lockfile" ]; then
-            echo_stderr "ERROR: $lockfile is not empty. These files must be committed empty."
+        if [ -n "$(git show HEAD:"docs/examples/ts/$lockfile" 2>/dev/null)" ]; then
+            echo_stderr "ERROR: $lockfile is not empty in git. These files must be committed empty."
             echo_stderr "       Run: > $lockfile && git add $lockfile"
             exit 1
         fi
+        # Ensure clean filesystem state (may be dirty from a previous interrupted run)
+        > "$lockfile"
     done
 fi
 


### PR DESCRIPTION
## Summary

- Pin `typescript@^5.3.3` in docs examples validation to match `yarn-project`. The unpinned `yarn add -D typescript` started pulling TypeScript 6.0, which changed JSON import type inference and made existing `@ts-expect-error` directives unused (TS2578 errors), breaking `example_swap` type-checking.
- Use git state (`git show HEAD:...`) instead of filesystem state (`-s`) for yarn.lock emptiness check. When `example_swap` fails, GNU parallel's `--halt now,fail=1` kills other jobs mid-`yarn add` before cleanup traps run, leaving lockfiles dirty on disk. On retry, the check found dirty filesystem state and reported the misleading `token_bridge/yarn.lock is not empty` error.

## Context

Multiple unrelated PRs (#21865, #21907, #21812) are failing with:
```
ERROR: token_bridge/yarn.lock is not empty. These files must be committed empty.
```

Root cause chain:
1. `yarn add -D typescript` (unpinned) pulls TS 6.0, released today
2. TS 6.0 improved JSON import type inference, making `@ts-expect-error` directives unused → TS2578 errors in `example_swap`
3. `example_swap` fails → `--halt now,fail=1` kills `token_bridge` mid-`yarn add` → cleanup trap never runs
4. Retry finds dirty `token_bridge/yarn.lock` on filesystem → misleading error

## Test plan

- [ ] CI passes on this PR (docs examples validation succeeds)
- [ ] Verify `example_swap` and `token_bridge` type-check cleanly with pinned TS 5.x


🤖 Generated with [Claude Code](https://claude.com/claude-code)