### PR TITLE
chore: fixes in ecc/group internal audit

### DIFF
--- a/barretenberg/cpp/src/barretenberg/ecc/fields/field_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/fields/field_impl.hpp
@@ -421,8 +421,8 @@ void field<T>::batch_invert(C& coeffs) noexcept
 
     std::vector<field> temporaries;
     std::vector<bool> skipped;
-    temporaries.reserve(n);
-    skipped.reserve(n);
+    temporaries.resize(n);
+    skipped.resize(n);
 
     field accumulator = one();
     for (size_t i = 0; i < n; ++i) {

--- a/barretenberg/cpp/src/barretenberg/ecc/groups/affine_element.hpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/groups/affine_element.hpp
@@ -68,7 +68,6 @@ template <typename Fq_, typename Fr_, typename Params_> class alignas(64) affine
      * @brief Reconstruct a point in affine coordinates from compressed form.
      * @details #LARGE_MODULUS_AFFINE_POINT_COMPRESSION Point compression is implemented for curves of a prime
      * field F_p with p being 256 bits.
-     * TODO(Suyash): Check with kesha if this is correct.
      *
      * @param compressed compressed point
      * @return constexpr affine_element
@@ -163,6 +162,11 @@ template <typename Fq_, typename Fr_, typename Params_> class alignas(64) affine
         // same order in our various serialization flows
         read(buffer, write_x_first ? result.x : result.y);
         read(buffer, write_x_first ? result.y : result.x);
+
+        // Validate the deserialized point lies on the curve
+        if (!result.on_curve()) {
+            throw_or_abort("affine_element::serialize_from_buffer: point is not on the curve");
+        }
         return result;
     }
 

--- a/barretenberg/cpp/src/barretenberg/ecc/groups/affine_element.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/groups/affine_element.test.cpp
@@ -80,7 +80,7 @@ template <typename G1> class TestAffineElement : public testing::Test {
         affine_element::serialize_to_buffer(off_curve, ptr);
 
         if (!off_curve.on_curve()) {
-            EXPECT_THROW(affine_element::serialize_from_buffer(ptr), std::runtime_error);
+            EXPECT_THROW_OR_ABORT(affine_element::serialize_from_buffer(ptr), "not on the curve");
         }
     }
 

--- a/barretenberg/cpp/src/barretenberg/ecc/groups/affine_element.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/groups/affine_element.test.cpp
@@ -29,6 +29,7 @@ namespace {
 template <typename G1> class TestAffineElement : public testing::Test {
     using element = typename G1::element;
     using affine_element = typename G1::affine_element;
+    using Fr = typename G1::Fr;
 
   public:
     static void test_read_write_buffer()
@@ -254,6 +255,48 @@ template <typename G1> class TestAffineElement : public testing::Test {
         EXPECT_EQ(P, Q);
         EXPECT_NE(P, R);
     }
+
+    static void test_infinity_mul_by_scalar_is_infinity()
+    {
+        auto result = affine_element::infinity() * Fr::random_element();
+        EXPECT_TRUE(result.is_point_at_infinity());
+    }
+
+    static void test_batch_mul_matches_non_batch_mul()
+    {
+        constexpr size_t num_points = 512;
+        std::vector<affine_element> affine_points(num_points - 1, affine_element::infinity());
+        affine_points.push_back(affine_element::infinity());
+        Fr exponent = Fr::random_element();
+        std::vector<affine_element> expected;
+        std::transform(affine_points.begin(),
+                       affine_points.end(),
+                       std::back_inserter(expected),
+                       [exponent](const auto& el) { return el * exponent; });
+        std::vector<affine_element> result = element::batch_mul_with_endomorphism(affine_points, exponent);
+        EXPECT_THAT(result, ElementsAreArray(expected));
+    }
+
+    static void test_infinity_batch_mul_by_scalar_is_infinity()
+    {
+        constexpr size_t num_points = 1024;
+        std::vector<affine_element> affine_points(num_points, affine_element::infinity());
+        std::vector<affine_element> result = element::batch_mul_with_endomorphism(affine_points, Fr::random_element());
+        EXPECT_THAT(result, Each(Property(&affine_element::is_point_at_infinity, Eq(true))));
+    }
+
+    static void test_batch_mul_endomorphism_even_scalars()
+    {
+        const affine_element P = affine_element::one();
+        const std::vector<affine_element> points(4, P);
+        for (const Fr scalar : { Fr(0), Fr(2), Fr(4), Fr(6) }) {
+            const auto result = element::batch_mul_with_endomorphism(points, scalar);
+            const affine_element expected(element(P) * scalar);
+            for (size_t i = 0; i < points.size(); ++i) {
+                EXPECT_EQ(result[i], expected);
+            }
+        }
+    }
 };
 
 // using TestTypes = testing::Types<bb::g1>;
@@ -389,59 +432,39 @@ TEST(AffineElementFromPublicInputs, GrumpkinFromPublicInputs)
 // Scalar 0 gives k1 = k2 = 0 (both skews), and even scalars like 2 and 4 trigger the k1-skew path.
 // These are regression tests for the operator+ fix: reverting to add_chunked would abort when the
 // accumulated result happens to equal ±P during the skew correction.
-TEST(AffineElement, BatchMulEndomorphismEvenScalars)
+TYPED_TEST(TestAffineElement, BatchMulEndomorphismEvenScalars)
 {
-    using G1 = grumpkin::g1;
-    const G1::affine_element P = G1::affine_element::one();
-    const std::vector<G1::affine_element> points(4, P);
-
-    for (const grumpkin::fr scalar : { grumpkin::fr(0), grumpkin::fr(2), grumpkin::fr(4), grumpkin::fr(6) }) {
-        const auto result = G1::element::batch_mul_with_endomorphism(points, scalar);
-        const G1::affine_element expected(G1::element(P) * scalar);
-        for (size_t i = 0; i < points.size(); ++i) {
-            EXPECT_EQ(result[i], expected);
-        }
+    if constexpr (!TypeParam::USE_ENDOMORPHISM) {
+        GTEST_SKIP();
+    } else {
+        TestFixture::test_batch_mul_endomorphism_even_scalars();
     }
 }
 
-// TODO(https://github.com/AztecProtocol/barretenberg/issues/909): These tests are not typed for no reason
 // Multiplication of a point at infinity by a scalar should be a point at infinity
-TEST(AffineElement, InfinityMulByScalarIsInfinity)
+TYPED_TEST(TestAffineElement, InfinityMulByScalarIsInfinity)
 {
-    auto result = grumpkin::g1::affine_element::infinity() * grumpkin::fr::random_element();
-    EXPECT_TRUE(result.is_point_at_infinity());
+    TestFixture::test_infinity_mul_by_scalar_is_infinity();
 }
 
-// Batched multiplication of points should match
-TEST(AffineElement, BatchMulMatchesNonBatchMul)
+// Batched multiplication of points should match non-batched multiplication
+TYPED_TEST(TestAffineElement, BatchMulMatchesNonBatchMul)
 {
-    constexpr size_t num_points = 512;
-    std::vector<grumpkin::g1::affine_element> affine_points(num_points - 1, grumpkin::g1::affine_element::infinity());
-    // Include a point at infinity to test the mixed infinity + non-infinity case
-    affine_points.push_back(grumpkin::g1::affine_element::infinity());
-    grumpkin::fr exponent = grumpkin::fr::random_element();
-    std::vector<grumpkin::g1::affine_element> expected;
-    std::transform(affine_points.begin(),
-                   affine_points.end(),
-                   std::back_inserter(expected),
-                   [exponent](const auto& el) { return el * exponent; });
-
-    std::vector<grumpkin::g1::affine_element> result =
-        grumpkin::g1::element::batch_mul_with_endomorphism(affine_points, exponent);
-
-    EXPECT_THAT(result, ElementsAreArray(expected));
+    if constexpr (!TypeParam::USE_ENDOMORPHISM) {
+        GTEST_SKIP();
+    } else {
+        TestFixture::test_batch_mul_matches_non_batch_mul();
+    }
 }
 
 // Batched multiplication of a point at infinity by a scalar should result in points at infinity
-TEST(AffineElement, InfinityBatchMulByScalarIsInfinity)
+TYPED_TEST(TestAffineElement, InfinityBatchMulByScalarIsInfinity)
 {
-    constexpr size_t num_points = 1024;
-    std::vector<grumpkin::g1::affine_element> affine_points(num_points, grumpkin::g1::affine_element::infinity());
-
-    std::vector<grumpkin::g1::affine_element> result =
-        grumpkin::g1::element::batch_mul_with_endomorphism(affine_points, grumpkin::fr::random_element());
-
-    EXPECT_THAT(result, Each(Property(&grumpkin::g1::affine_element::is_point_at_infinity, Eq(true))));
+    if constexpr (!TypeParam::USE_ENDOMORPHISM) {
+        GTEST_SKIP();
+    } else {
+        TestFixture::test_infinity_batch_mul_by_scalar_is_infinity();
+    }
 }
 
 TYPED_TEST(TestAffineElement, BatchEndomoprhismByMinusOne)

--- a/barretenberg/cpp/src/barretenberg/ecc/groups/affine_element.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/groups/affine_element.test.cpp
@@ -36,19 +36,12 @@ template <typename G1> class TestAffineElement : public testing::Test {
         // a generic point
         {
             affine_element P = affine_element(element::random_element());
-            affine_element Q;
             affine_element R;
 
-            std::vector<uint8_t> v(65); // extra byte to allow a bad read
+            std::vector<uint8_t> v(64);
             uint8_t* ptr = v.data();
             affine_element::serialize_to_buffer(P, ptr);
 
-            // bad read
-            Q = affine_element::serialize_from_buffer(ptr + 1);
-            ASSERT_FALSE(Q.on_curve() && !Q.is_point_at_infinity());
-            ASSERT_FALSE(P == Q);
-
-            // good read
             R = affine_element::serialize_from_buffer(ptr);
             ASSERT_TRUE(R.on_curve());
             ASSERT_TRUE(P == R);
@@ -67,6 +60,26 @@ template <typename G1> class TestAffineElement : public testing::Test {
             R = affine_element::serialize_from_buffer(ptr);
             ASSERT_TRUE(R.is_point_at_infinity());
             ASSERT_TRUE(P == R);
+        }
+    }
+
+    // Verify that serialize_from_buffer rejects off-curve bytes by throwing.
+    static void test_deserialize_off_curve_throws()
+    {
+        using Fq = typename G1::Fq;
+        // Take a valid on-curve point and corrupt its y-coordinate.
+        // P.y + 1 satisfies (y+1)^2 != y^2 (i.e. off-curve) unless 2y + 1 = 0 (prob ~1/p).
+        affine_element P = affine_element(element::random_element());
+        affine_element off_curve;
+        off_curve.x = P.x;
+        off_curve.y = P.y + Fq::one();
+
+        std::vector<uint8_t> v(sizeof(affine_element));
+        uint8_t* ptr = v.data();
+        affine_element::serialize_to_buffer(off_curve, ptr);
+
+        if (!off_curve.on_curve()) {
+            EXPECT_THROW(affine_element::serialize_from_buffer(ptr), std::runtime_error);
         }
     }
 
@@ -192,6 +205,24 @@ template <typename G1> class TestAffineElement : public testing::Test {
         EXPECT_NE(P < Q, Q < P);
     }
 
+    // Verify that from_compressed with an x that has no y on the curve returns the (0,0) sentinel.
+    static void test_point_compression_invalid_x()
+    {
+        using Fq = typename G1::Fq;
+        size_t invalid_count = 0;
+        for (size_t i = 0; i < 20; ++i) {
+            affine_element result = affine_element::from_compressed(uint256_t(Fq::random_element()));
+            if (!result.on_curve()) {
+                ++invalid_count;
+                // from_compressed returns (0, 0) when x has no valid y
+                EXPECT_EQ(result.x, Fq::zero());
+                EXPECT_EQ(result.y, Fq::zero());
+            }
+        }
+        // With 20 trials ~10 should have no valid y, so we almost certainly exercise this path
+        EXPECT_GT(invalid_count, 0U);
+    }
+
     /**
      * @brief A regression test to make sure the -1 case is covered
      *
@@ -298,15 +329,22 @@ class TestElementPrivate {
 };
 } // namespace bb::group_elements
 
-// Our endomorphism-specialized multiplication should match our generic multiplication
+// Our endomorphism-specialized multiplication should match our generic multiplication.
+// Previously only tested on Grumpkin; now runs on every curve that has USE_ENDOMORPHISM.
 TYPED_TEST(TestAffineElement, MulWithEndomorphismMatchesMulWithoutEndomorphism)
 {
-    for (int i = 0; i < 100; i++) {
-        auto x1 = bb::group_elements::element(grumpkin::g1::affine_element::random_element());
-        auto f1 = grumpkin::fr::random_element();
-        auto r1 = bb::group_elements::TestElementPrivate::mul_without_endomorphism(x1, f1);
-        auto r2 = bb::group_elements::TestElementPrivate::mul_with_endomorphism(x1, f1);
-        EXPECT_EQ(r1, r2);
+    if constexpr (!TypeParam::USE_ENDOMORPHISM) {
+        GTEST_SKIP();
+    } else {
+        using element_t = typename TypeParam::element;
+        using Fr = typename TypeParam::Fr;
+        for (int i = 0; i < 100; i++) {
+            element_t x1(element_t::random_element());
+            Fr f1 = Fr::random_element();
+            element_t r1 = bb::group_elements::TestElementPrivate::mul_without_endomorphism(x1, f1);
+            element_t r2 = bb::group_elements::TestElementPrivate::mul_with_endomorphism(x1, f1);
+            EXPECT_EQ(r1, r2);
+        }
     }
 }
 
@@ -344,6 +382,26 @@ TEST(AffineElementFromPublicInputs, GrumpkinFromPublicInputs)
     auto reconstructed = FrCodec::deserialize_from_fields<AffineElement>(limbs);
 
     EXPECT_EQ(reconstructed, point);
+}
+
+// Verify that batch_mul_with_endomorphism gives correct results for even scalars (where k1 or k2 in the
+// GLV decomposition is even), exercising the skew-correction path that uses affine_element::operator+.
+// Scalar 0 gives k1 = k2 = 0 (both skews), and even scalars like 2 and 4 trigger the k1-skew path.
+// These are regression tests for the operator+ fix: reverting to add_chunked would abort when the
+// accumulated result happens to equal ±P during the skew correction.
+TEST(AffineElement, BatchMulEndomorphismEvenScalars)
+{
+    using G1 = grumpkin::g1;
+    const G1::affine_element P = G1::affine_element::one();
+    const std::vector<G1::affine_element> points(4, P);
+
+    for (const grumpkin::fr scalar : { grumpkin::fr(0), grumpkin::fr(2), grumpkin::fr(4), grumpkin::fr(6) }) {
+        const auto result = G1::element::batch_mul_with_endomorphism(points, scalar);
+        const G1::affine_element expected(G1::element(P) * scalar);
+        for (size_t i = 0; i < points.size(); ++i) {
+            EXPECT_EQ(result[i], expected);
+        }
+    }
 }
 
 // TODO(https://github.com/AztecProtocol/barretenberg/issues/909): These tests are not typed for no reason
@@ -392,6 +450,22 @@ TYPED_TEST(TestAffineElement, BatchEndomoprhismByMinusOne)
         TestFixture::test_batch_endomorphism_by_minus_one();
     } else {
         GTEST_SKIP();
+    }
+}
+
+// Verify that serialize_from_buffer rejects off-curve bytes by throwing (tests the invalid-curve attack fix).
+TYPED_TEST(TestAffineElement, DeserializeOffCurveThrows)
+{
+    TestFixture::test_deserialize_off_curve_throws();
+}
+
+// Verify that from_compressed returns the (0,0) sentinel for x values with no valid y.
+TYPED_TEST(TestAffineElement, PointCompressionInvalidX)
+{
+    if constexpr (TypeParam::Fq::modulus.data[3] >= MODULUS_TOP_LIMB_LARGE_THRESHOLD) {
+        GTEST_SKIP(); // from_compressed is not used on large-modulus curves
+    } else {
+        TestFixture::test_point_compression_invalid_x();
     }
 }
 

--- a/barretenberg/cpp/src/barretenberg/ecc/groups/affine_element.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/groups/affine_element.test.cpp
@@ -80,7 +80,9 @@ template <typename G1> class TestAffineElement : public testing::Test {
         affine_element::serialize_to_buffer(off_curve, ptr);
 
         if (!off_curve.on_curve()) {
+#ifndef __wasm__
             EXPECT_THROW_OR_ABORT(affine_element::serialize_from_buffer(ptr), "not on the curve");
+#endif
         }
     }
 

--- a/barretenberg/cpp/src/barretenberg/ecc/groups/affine_element.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/groups/affine_element.test.cpp
@@ -297,6 +297,17 @@ template <typename G1> class TestAffineElement : public testing::Test {
             }
         }
     }
+
+    static void test_frc_codec_round_trip()
+    {
+        using FrField = FrCodec::DataType;
+        affine_element point = affine_element::random_element();
+        std::vector<FrField> public_inputs = FrCodec::serialize_to_fields(point);
+        std::span<FrField, affine_element::PUBLIC_INPUTS_SIZE> limbs(public_inputs.data(),
+                                                                     affine_element::PUBLIC_INPUTS_SIZE);
+        auto reconstructed = FrCodec::deserialize_from_fields<affine_element>(limbs);
+        EXPECT_EQ(reconstructed, point);
+    }
 };
 
 // using TestTypes = testing::Types<bb::g1>;
@@ -391,40 +402,14 @@ TYPED_TEST(TestAffineElement, MulWithEndomorphismMatchesMulWithoutEndomorphism)
     }
 }
 
-TEST(AffineElementFromPublicInputs, Bn254FromPublicInputs)
+// FrCodec is defined only for BN254 and Grumpkin (the two curves whose points appear in transcripts).
+TYPED_TEST(TestAffineElement, FrCodecRoundTrip)
 {
-    using Curve = curve::BN254;
-    using Fr = Curve::ScalarField;
-    using AffineElement = Curve::AffineElement;
-
-    AffineElement point = AffineElement::random_element();
-
-    // Construct public inputs using FrCodec format (2 limbs of 136 bits per coordinate)
-    std::vector<Fr> public_inputs = FrCodec::serialize_to_fields(point);
-
-    std::span<Fr, AffineElement::PUBLIC_INPUTS_SIZE> limbs(public_inputs.data(), AffineElement::PUBLIC_INPUTS_SIZE);
-
-    auto reconstructed = FrCodec::deserialize_from_fields<AffineElement>(limbs);
-
-    EXPECT_EQ(reconstructed, point);
-}
-
-TEST(AffineElementFromPublicInputs, GrumpkinFromPublicInputs)
-{
-    using Curve = curve::Grumpkin;
-    using AffineElement = Curve::AffineElement;
-    using Fr = bb::fr;
-
-    AffineElement point = AffineElement::random_element();
-
-    // Construct public inputs using FrCodec format
-    std::vector<Fr> public_inputs = FrCodec::serialize_to_fields(point);
-
-    std::span<Fr, AffineElement::PUBLIC_INPUTS_SIZE> limbs(public_inputs.data(), AffineElement::PUBLIC_INPUTS_SIZE);
-
-    auto reconstructed = FrCodec::deserialize_from_fields<AffineElement>(limbs);
-
-    EXPECT_EQ(reconstructed, point);
+    if constexpr (std::is_same_v<TypeParam, bb::g1> || std::is_same_v<TypeParam, grumpkin::g1>) {
+        TestFixture::test_frc_codec_round_trip();
+    } else {
+        GTEST_SKIP();
+    }
 }
 
 // Verify that batch_mul_with_endomorphism gives correct results for even scalars (where k1 or k2 in the

--- a/barretenberg/cpp/src/barretenberg/ecc/groups/affine_element_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/groups/affine_element_impl.hpp
@@ -45,26 +45,23 @@ template <typename BaseField, typename CompileTimeEnabled>
 constexpr std::array<affine_element<Fq, Fr, T>, 2> affine_element<Fq, Fr, T>::from_compressed_unsafe(
     const uint256_t& compressed) noexcept
 {
-    auto get_y_coordinate = [](const uint256_t& x_coordinate) {
+    // Try x as a recovery candidate: check it is in [0, p), compute y² = x³ + ax + b,
+    // and return the point if y exists. Fq(x) reduces silently, so ensuring x is in [0, p) is necessary to prevent
+    // returning an incorrect pair (x mod q, y).
+    auto try_candidate = [](const uint256_t& x_coordinate) -> affine_element<Fq, Fr, T> {
+        if (x_coordinate >= Fq::modulus) {
+            return { Fq::zero(), Fq::zero() };
+        }
         Fq x = Fq(x_coordinate);
-        Fq y2 = (x.sqr() * x + T::b);
+        Fq y2 = ((x.sqr() * x) + T::b);
         if constexpr (T::has_a) {
             y2 += (x * T::a);
         }
-        return y2.sqrt();
+        auto [is_qr, y] = y2.sqrt();
+        return is_qr ? affine_element<Fq, Fr, T>(x, y) : affine_element<Fq, Fr, T>(Fq::zero(), Fq::zero());
     };
 
-    uint256_t x_1 = compressed;
-    uint256_t x_2 = compressed + Fr::modulus;
-    auto [is_quadratic_remainder_1, y_1] = get_y_coordinate(x_1);
-    auto [is_quadratic_remainder_2, y_2] = get_y_coordinate(x_2);
-
-    auto output_1 = is_quadratic_remainder_1 ? affine_element<Fq, Fr, T>(Fq(x_1), y_1)
-                                             : affine_element<Fq, Fr, T>(Fq::zero(), Fq::zero());
-    auto output_2 = is_quadratic_remainder_2 ? affine_element<Fq, Fr, T>(Fq(x_2), y_2)
-                                             : affine_element<Fq, Fr, T>(Fq::zero(), Fq::zero());
-
-    return { output_1, output_2 };
+    return { try_candidate(compressed), try_candidate(compressed + Fr::modulus) };
 }
 
 template <class Fq, class Fr, class T>
@@ -253,7 +250,11 @@ constexpr affine_element<Fq, Fr, T> affine_element<Fq, Fr, T>::hash_to_curve(con
     if (result.has_value()) {
         return result.value();
     }
-    return hash_to_curve(seed, attempt_count + 1);
+    // attempt_count is uint8_t: P(count > 255) ≈ 2^-255, so overflow cannot occur in practice.
+    // (See derive_generators in group.hpp for the justification.)
+    // NOTE: BB_ASSERT_LT cannot be used here because hash_to_curve is constexpr and BB_ASSERT_LT
+    // uses std::ostringstream, which is not a literal type.
+    return hash_to_curve(seed, static_cast<uint8_t>(attempt_count + 1));
 }
 
 template <typename Fq, typename Fr, typename T>

--- a/barretenberg/cpp/src/barretenberg/ecc/groups/affine_element_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/groups/affine_element_impl.hpp
@@ -250,11 +250,7 @@ constexpr affine_element<Fq, Fr, T> affine_element<Fq, Fr, T>::hash_to_curve(con
     if (result.has_value()) {
         return result.value();
     }
-    // attempt_count is uint8_t: P(count > 255) ≈ 2^-255, so overflow cannot occur in practice.
-    // (See derive_generators in group.hpp for the justification.)
-    // NOTE: BB_ASSERT_LT cannot be used here because hash_to_curve is constexpr and BB_ASSERT_LT
-    // uses std::ostringstream, which is not a literal type.
-    return hash_to_curve(seed, static_cast<uint8_t>(attempt_count + 1));
+    return hash_to_curve(seed, attempt_count + 1);
 }
 
 template <typename Fq, typename Fr, typename T>

--- a/barretenberg/cpp/src/barretenberg/ecc/groups/element.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/groups/element.test.cpp
@@ -230,6 +230,35 @@ template <typename G_> class TestElement : public testing::Test {
         }
     }
 
+    // batch_normalize must preserve infinity points and correctly normalize non-infinity ones.
+    static void test_batch_normalize_with_infinity()
+    {
+        constexpr size_t num_points = 6;
+        std::vector<element> points(num_points);
+        for (size_t i = 0; i < num_points; ++i) {
+            if (i % 3 == 0) {
+                points[i] = element::infinity();
+            } else {
+                element a = element::random_element();
+                element b = element::random_element();
+                points[i] = a + b;
+            }
+        }
+        std::vector<element> normalized = points;
+        element::batch_normalize(&normalized[0], num_points);
+
+        for (size_t i = 0; i < num_points; ++i) {
+            if (i % 3 == 0) {
+                EXPECT_TRUE(normalized[i].is_point_at_infinity());
+            } else {
+                Fq zz = points[i].z.sqr();
+                Fq zzz = points[i].z * zz;
+                EXPECT_EQ(normalized[i].x * zz, points[i].x);
+                EXPECT_EQ(normalized[i].y * zzz, points[i].y);
+            }
+        }
+    }
+
     static void test_group_exponentiation_zero_and_one()
     {
         affine_element result = G::one * Fr::zero();
@@ -356,6 +385,11 @@ TYPED_TEST(TestElement, AddMixedAddConsistencyCheck)
 TYPED_TEST(TestElement, BatchNormalize)
 {
     TestFixture::test_batch_normalize();
+}
+
+TYPED_TEST(TestElement, BatchNormalizeWithInfinity)
+{
+    TestFixture::test_batch_normalize_with_infinity();
 }
 
 TYPED_TEST(TestElement, GroupExponentiationZeroAndOne)

--- a/barretenberg/cpp/src/barretenberg/ecc/groups/element_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/groups/element_impl.hpp
@@ -97,7 +97,7 @@ template <class Fq, class Fr, class T> constexpr void element<Fq, Fr, T>::self_d
     // T1 = y*y
     Fq T1 = y.sqr();
 
-    // T2 = T2*T1 = y*y*y*y
+    // T2 = T1*T1 = y*y*y*y
     Fq T2 = T1.sqr();
 
     // T1 = T1 + x = x + y*y
@@ -940,21 +940,21 @@ std::vector<affine_element<Fq, Fr, T>> element<Fq, Fr, T>::batch_mul_with_endomo
             add_chunked(&temp_point_vector[0], &work_elements[0]);
         }
         // Apply skew for the first endo scalar
+        // Use affine_element::operator+ (via Jacobian) to handle edge cases related to the point at infinity.
         if (wnaf.skew) {
             for (size_t i = start; i < end; ++i) {
-                temp_point_vector[i] = -lookup_table[0][i];
+                work_elements[i] = work_elements[i] + (-lookup_table[0][i]);
             }
-            add_chunked(&temp_point_vector[0], &work_elements[0]);
         }
         // Apply skew for the second endo scalar
         if (wnaf.endo_skew) {
             for (size_t i = start; i < end; ++i) {
-                temp_point_vector[i] = lookup_table[0][i];
-                temp_point_vector[i].x *= beta;
+                affine_element endo_point = lookup_table[0][i];
+                endo_point.x *= beta;
+                work_elements[i] = work_elements[i] + endo_point;
             }
-            add_chunked(&temp_point_vector[0], &work_elements[0]);
         }
-        // handle points at infinity explicitly
+        // Handle points at infinity explicitly
         for (size_t i = start; i < end; ++i) {
             work_elements[i] = points[i].is_point_at_infinity() ? work_elements[i].set_infinity() : work_elements[i];
         }

--- a/barretenberg/cpp/src/barretenberg/ecc/groups/group.hpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/groups/group.hpp
@@ -70,8 +70,11 @@ template <typename Fq_, typename Fr_, typename Params> class group {
      *              (d), invert y-coordinate.
      *           j. return (x, y)
      *
-     * NOTE: In step 3b it is sufficient to use 1 byte to store `count`.
-     *       Step 3 has a 50% chance of returning, the probability of `count` exceeding 256 is 1 in 2^256
+     * NOTE: In step 3b it is sufficient to use 1 byte (uint8_t) to store `count` (called
+     *       `attempt_count` in hash_to_curve). For BN254/Grumpkin, approximately half of all Fq field
+     *       elements are quadratic residues, so each attempt succeeds with probability ~1/2. The
+     *       probability of needing more than N attempts is ~2^-N, making P(count > 255) ≈ 2^-255 —
+     *       negligible for any practical use. The type uint8_t is therefore intentional, not a bug.
      * NOTE: The domain separator is included to ensure that it is possible to derive independent sets of
      * index-addressable generators.
      * NOTE: we produce 64 bytes of BLAKE3 output when producing x-coordinate field


### PR DESCRIPTION
Minor fixes in groups:

- `serialize_from_buffer` accepted off-curve bytes without checking the curve equation. Now throws if the deserialized point doesn't satisfy y² = x³ + ax + b.
- `from_compressed_unsafe` passed x₂ = r + n to `Fq()` without a bounds check. Since r > p − n for most ECDSA signatures, Fq would silently reduce x₂ modulo p and return a spurious candidate. Now guards both candidates with `x < Fq::modulus` before evaluating the curve equation.
- `batch_mul_with_endomorphism` skew corrections used add_chunked, which has no edge-case handling and aborts when the accumulator equals ±P. Switched to `affine_element::operator+` (Jacobian) which handles all cases correctly.
- `batch_invert` used `reserve()` then indexed with operator[], which is UB (size remains 0). Changed to `resize()`.

