### PR TITLE
fix: (A-789) PXE proxiedContractStoreFactory returns undefined for unmatched overridden functions

### DIFF
--- a/yarn-project/pxe/src/contract_function_simulator/proxied_contract_data_source.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/proxied_contract_data_source.ts
@@ -47,9 +47,8 @@ export class ProxiedContractStoreFactory {
                     return fn;
                   }
                 }
-              } else {
-                return target.getFunctionArtifact(contractAddress, selector);
               }
+              return target.getFunctionArtifact(contractAddress, selector);
             };
           }
           case 'getFunctionArtifactWithDebugMetadata': {
@@ -64,9 +63,8 @@ export class ProxiedContractStoreFactory {
                     return fn;
                   }
                 }
-              } else {
-                return target.getFunctionArtifactWithDebugMetadata(contractAddress, selector);
               }
+              return target.getFunctionArtifactWithDebugMetadata(contractAddress, selector);
             };
           }
           default: {


### PR DESCRIPTION
When an address has overrides but the requested function selector is not found in the override artifact, both getFunctionArtifact and getFunctionArtifactWithDebugMetadata fall through the for-loop without returning anything, implicitly returning undefined. Fix now fallsback to the real store.

