### PR TITLE
chore: (A-777) add warn logs for regressive path in block synchronizer

### DIFF
--- a/yarn-project/pxe/src/block_synchronizer/block_synchronizer.ts
+++ b/yarn-project/pxe/src/block_synchronizer/block_synchronizer.ts
@@ -77,6 +77,10 @@ export class BlockSynchronizer implements L2BlockStreamEventHandler {
           const blockHeader = await this.node.getBlockHeader(BlockNumber(event.block.number));
           if (blockHeader) {
             await this.updateAnchorBlockHeader(blockHeader);
+          } else {
+            this.log.warn(
+              `Block header not found for proven block ${event.block.number}, skipping anchor block header update`,
+            );
           }
         }
         break;
@@ -86,6 +90,10 @@ export class BlockSynchronizer implements L2BlockStreamEventHandler {
           const blockHeader = await this.node.getBlockHeader(BlockNumber(event.block.number));
           if (blockHeader) {
             await this.updateAnchorBlockHeader(blockHeader);
+          } else {
+            this.log.warn(
+              `Block header not found for finalized block ${event.block.number}, skipping anchor block header update`,
+            );
           }
         }
         break;


### PR DESCRIPTION
On a chain-proven or chain-finalized block event, if the block header does not exist for a proven/finalized block event, then we should log a warning that we will not be updating the anchor block header. But more importantly, this is a regressive path, the block header should always exist if the block event was fired, if it doesn't there might be a bug and this warn log will catch it without hard erroring.