### PR TITLE
fix(stdlib): decode `EthAddress`, `FunctionSelector` and wrapped field structs in `AbiDecoder`

### DIFF
--- a/noir-projects/noir-contracts/contracts/test/abi_types_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/abi_types_contract/src/main.nr
@@ -7,7 +7,14 @@ use aztec::macros::aztec;
 
 #[aztec]
 pub contract AbiTypes {
-    use aztec::{macros::functions::external, protocol::traits::{Deserialize, Serialize}};
+    use aztec::{
+        macros::functions::external,
+        protocol::{
+            abis::function_selector::FunctionSelector,
+            address::EthAddress,
+            traits::{Deserialize, Serialize},
+        },
+    };
 
     #[derive(Serialize, Deserialize, Eq)]
     pub struct CustomStruct {
@@ -15,6 +22,11 @@ pub contract AbiTypes {
         pub x: bool,
         pub y: u64,
         pub z: i64,
+    }
+
+    #[derive(Serialize, Deserialize, Eq)]
+    pub struct WrappedField {
+        pub inner: Field,
     }
 
     #[external("public")]
@@ -48,5 +60,20 @@ pub contract AbiTypes {
         e: CustomStruct,
     ) -> (bool, Field, u64, i64, CustomStruct) {
         (a, b, c, d, e)
+    }
+
+    #[external("utility")]
+    unconstrained fn return_eth_address(addr: EthAddress) -> EthAddress {
+        addr
+    }
+
+    #[external("utility")]
+    unconstrained fn return_function_selector(selector: FunctionSelector) -> FunctionSelector {
+        selector
+    }
+
+    #[external("utility")]
+    unconstrained fn return_wrapped_field(wrapped: WrappedField) -> WrappedField {
+        wrapped
     }
 }

--- a/yarn-project/end-to-end/src/e2e_abi_types.test.ts
+++ b/yarn-project/end-to-end/src/e2e_abi_types.test.ts
@@ -1,4 +1,6 @@
-import { AztecAddress } from '@aztec/aztec.js/addresses';
+import { FunctionSelector } from '@aztec/aztec.js/abi';
+import { AztecAddress, EthAddress } from '@aztec/aztec.js/addresses';
+import { Fr } from '@aztec/aztec.js/fields';
 import type { Wallet } from '@aztec/aztec.js/wallet';
 import { MAX_FIELD_VALUE } from '@aztec/constants';
 import { AbiTypesContract } from '@aztec/noir-test-contracts.js/AbiTypes';
@@ -82,6 +84,39 @@ describe('AbiTypes', () => {
       I64_MAX,
       { w: MAX_FIELD_VALUE, x: true, y: U64_MAX, z: I64_MAX },
     ]);
+  });
+
+  it('decodes EthAddress return value', async () => {
+    const ethAddr = EthAddress.fromString('0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045');
+
+    const { result } = await abiTypesContract.methods
+      .return_eth_address(ethAddr)
+      .simulate({ from: defaultAccountAddress });
+
+    expect(result).toBeInstanceOf(EthAddress);
+    expect(result).toEqual(ethAddr);
+  });
+
+  it('decodes FunctionSelector return value', async () => {
+    const selector = FunctionSelector.fromField(new Fr(0xdeadbeefn));
+
+    const { result } = await abiTypesContract.methods
+      .return_function_selector(selector)
+      .simulate({ from: defaultAccountAddress });
+
+    expect(result).toBeInstanceOf(FunctionSelector);
+    expect(result).toEqual(selector);
+  });
+
+  it('decodes wrapped field struct as Fr', async () => {
+    const value = new Fr(42n);
+
+    const { result } = await abiTypesContract.methods
+      .return_wrapped_field(42n)
+      .simulate({ from: defaultAccountAddress });
+
+    expect(result).toBeInstanceOf(Fr);
+    expect(result).toEqual(value);
   });
 
   it('passes utility parameters', async () => {

--- a/yarn-project/stdlib/src/abi/decoder.test.ts
+++ b/yarn-project/stdlib/src/abi/decoder.test.ts
@@ -1,4 +1,5 @@
 import { Fr } from '@aztec/foundation/curves/bn254';
+import { EthAddress } from '@aztec/foundation/eth-address';
 
 import { AztecAddress } from '../aztec-address/index.js';
 import type { ABIParameterVisibility, FunctionArtifact } from './abi.js';
@@ -324,5 +325,69 @@ describe('decoder', () => {
     );
 
     expect(decoded).toBeUndefined();
+  });
+
+  it('decodes EthAddress struct as EthAddress instance', () => {
+    const field = new Fr(0xdeadbeefn);
+    const decoded = decodeFromAbi(
+      [
+        {
+          kind: 'struct',
+          path: 'aztec::protocol_types::address::EthAddress',
+          fields: [{ name: 'inner', type: { kind: 'field' } }],
+        },
+      ],
+      [field],
+    );
+
+    expect(decoded).toBeInstanceOf(EthAddress);
+    expect(decoded).toEqual(EthAddress.fromField(field));
+  });
+
+  it('decodes wrapped field struct as Fr', () => {
+    const field = new Fr(42n);
+    const decoded = decodeFromAbi(
+      [
+        {
+          kind: 'struct',
+          path: 'some::custom::WrappedType',
+          fields: [{ name: 'inner', type: { kind: 'field' } }],
+        },
+      ],
+      [field],
+    );
+
+    expect(decoded).toBeInstanceOf(Fr);
+    expect(decoded).toEqual(field);
+  });
+
+  it('decodes EthAddress inside a larger struct', () => {
+    const addressField = new Fr(0x1234n);
+    const amountField = new Fr(100n);
+    const decoded = decodeFromAbi(
+      [
+        {
+          kind: 'struct',
+          path: 'MyContract::MyEvent',
+          fields: [
+            {
+              name: 'recipient',
+              type: {
+                kind: 'struct',
+                path: 'aztec::protocol_types::address::EthAddress',
+                fields: [{ name: 'inner', type: { kind: 'field' } }],
+              },
+            },
+            { name: 'amount', type: { kind: 'field' } },
+          ],
+        },
+      ],
+      [addressField, amountField],
+    );
+
+    expect(decoded).toEqual({
+      recipient: EthAddress.fromField(addressField),
+      amount: 100n,
+    });
   });
 });

--- a/yarn-project/stdlib/src/abi/decoder.test.ts
+++ b/yarn-project/stdlib/src/abi/decoder.test.ts
@@ -3,7 +3,8 @@ import { EthAddress } from '@aztec/foundation/eth-address';
 
 import { AztecAddress } from '../aztec-address/index.js';
 import type { ABIParameterVisibility, FunctionArtifact } from './abi.js';
-import { decodeFromAbi, decodeFunctionSignature, decodeFunctionSignatureWithParameterNames } from './decoder.js';
+import { decodeFromAbi } from './decoder.js';
+import { decodeFunctionSignature, decodeFunctionSignatureWithParameterNames } from './function_signature_decoder.js';
 
 describe('abi/decoder', () => {
   // Copied from noir-contracts/contracts/test_contract/target/Test.json

--- a/yarn-project/stdlib/src/abi/decoder.ts
+++ b/yarn-project/stdlib/src/abi/decoder.ts
@@ -1,8 +1,15 @@
 import { Fr } from '@aztec/foundation/curves/bn254';
+import { EthAddress } from '@aztec/foundation/eth-address';
 
 import { AztecAddress } from '../aztec-address/index.js';
 import type { ABIParameter, ABIVariable, AbiType } from './abi.js';
-import { isAztecAddressStruct, isOptionStruct, parseSignedInt } from './utils.js';
+import {
+  isAztecAddressStruct,
+  isEthAddressStruct,
+  isOptionStruct,
+  isWrappedFieldStruct,
+  parseSignedInt,
+} from './utils.js';
 
 /**
  * The type of our decoded ABI.
@@ -12,6 +19,8 @@ export type AbiDecoded =
   | boolean
   | string
   | AztecAddress
+  | EthAddress
+  | Fr
   | AbiDecoded[]
   | { [key: string]: AbiDecoded }
   | undefined;
@@ -57,6 +66,12 @@ class AbiDecoder {
         const struct: { [key: string]: AbiDecoded } = {};
         if (isAztecAddressStruct(abiType)) {
           return new AztecAddress(this.getNextField().toBuffer());
+        }
+        if (isEthAddressStruct(abiType)) {
+          return EthAddress.fromField(this.getNextField());
+        }
+        if (isWrappedFieldStruct(abiType)) {
+          return this.getNextField();
         }
         if (isOptionStruct(abiType)) {
           const isSome = this.decodeNext(abiType.fields[0].type);

--- a/yarn-project/stdlib/src/abi/decoder.ts
+++ b/yarn-project/stdlib/src/abi/decoder.ts
@@ -3,9 +3,11 @@ import { EthAddress } from '@aztec/foundation/eth-address';
 
 import { AztecAddress } from '../aztec-address/index.js';
 import type { ABIParameter, ABIVariable, AbiType } from './abi.js';
+import { FunctionSelector } from './function_selector.js';
 import {
   isAztecAddressStruct,
   isEthAddressStruct,
+  isFunctionSelectorStruct,
   isOptionStruct,
   isWrappedFieldStruct,
   parseSignedInt,
@@ -20,6 +22,7 @@ export type AbiDecoded =
   | string
   | AztecAddress
   | EthAddress
+  | FunctionSelector
   | Fr
   | AbiDecoded[]
   | { [key: string]: AbiDecoded }
@@ -69,6 +72,9 @@ class AbiDecoder {
         }
         if (isEthAddressStruct(abiType)) {
           return EthAddress.fromField(this.getNextField());
+        }
+        if (isFunctionSelectorStruct(abiType)) {
+          return FunctionSelector.fromField(this.getNextField());
         }
         if (isWrappedFieldStruct(abiType)) {
           return this.getNextField();

--- a/yarn-project/stdlib/src/abi/decoder.ts
+++ b/yarn-project/stdlib/src/abi/decoder.ts
@@ -2,7 +2,7 @@ import { Fr } from '@aztec/foundation/curves/bn254';
 import { EthAddress } from '@aztec/foundation/eth-address';
 
 import { AztecAddress } from '../aztec-address/index.js';
-import type { ABIParameter, ABIVariable, AbiType } from './abi.js';
+import type { AbiType } from './abi.js';
 import { FunctionSelector } from './function_selector.js';
 import {
   isAztecAddressStruct,
@@ -143,80 +143,4 @@ class AbiDecoder {
  */
 export function decodeFromAbi(typ: AbiType[], buffer: Fr[]) {
   return new AbiDecoder(typ, buffer.slice()).decode();
-}
-
-/**
- * Decodes the signature of a function from the name and parameters.
- */
-export class FunctionSignatureDecoder {
-  private separator: string;
-  constructor(
-    private name: string,
-    private parameters: ABIParameter[],
-    private includeNames = false,
-  ) {
-    this.separator = includeNames ? ', ' : ',';
-  }
-
-  /**
-   * Decodes a single function parameter type for the function signature.
-   * @param param - The parameter type to decode.
-   * @returns A string representing the parameter type.
-   */
-  private getParameterType(param: AbiType): string {
-    switch (param.kind) {
-      case 'field':
-        return 'Field';
-      case 'integer':
-        return param.sign === 'signed' ? `i${param.width}` : `u${param.width}`;
-      case 'boolean':
-        return 'bool';
-      case 'array':
-        return `[${this.getParameterType(param.type)};${param.length}]`;
-      case 'string':
-        return `str<${param.length}>`;
-      case 'struct':
-        return `(${param.fields.map(field => `${this.decodeParameter(field)}`).join(this.separator)})`;
-      default:
-        throw new Error(`Unsupported type: ${param.kind}`);
-    }
-  }
-
-  /**
-   * Decodes a single function parameter for the function signature.
-   * @param param - The parameter to decode.
-   * @returns A string representing the parameter type and optionally its name.
-   */
-  private decodeParameter(param: ABIVariable): string {
-    const type = this.getParameterType(param.type);
-    return this.includeNames ? `${param.name}: ${type}` : type;
-  }
-
-  /**
-   * Decodes all the parameters and build the function signature
-   * @returns The function signature.
-   */
-  public decode(): string {
-    return `${this.name}(${this.parameters.map(param => this.decodeParameter(param)).join(this.separator)})`;
-  }
-}
-
-/**
- * Decodes a function signature from the name and parameters.
- * @param name - The name of the function.
- * @param parameters - The parameters of the function.
- * @returns - The function signature.
- */
-export function decodeFunctionSignature(name: string, parameters: ABIParameter[]) {
-  return new FunctionSignatureDecoder(name, parameters).decode();
-}
-
-/**
- * Decodes a function signature from the name and parameters including parameter names.
- * @param name - The name of the function.
- * @param parameters - The parameters of the function.
- * @returns - The user-friendly function signature.
- */
-export function decodeFunctionSignatureWithParameterNames(name: string, parameters: ABIParameter[]) {
-  return new FunctionSignatureDecoder(name, parameters, true).decode();
 }

--- a/yarn-project/stdlib/src/abi/function_selector.ts
+++ b/yarn-project/stdlib/src/abi/function_selector.ts
@@ -6,7 +6,7 @@ import { type ZodFor, hexSchemaFor } from '@aztec/foundation/schemas';
 import { BufferReader, FieldReader, TypeRegistry } from '@aztec/foundation/serialize';
 
 import type { ABIParameter } from './abi.js';
-import { decodeFunctionSignature } from './decoder.js';
+import { decodeFunctionSignature } from './function_signature_decoder.js';
 import { Selector } from './selector.js';
 
 /* eslint-disable @typescript-eslint/no-unsafe-declaration-merging */

--- a/yarn-project/stdlib/src/abi/function_signature_decoder.ts
+++ b/yarn-project/stdlib/src/abi/function_signature_decoder.ts
@@ -1,0 +1,77 @@
+import type { ABIParameter, ABIVariable, AbiType } from './abi.js';
+
+/**
+ * Decodes the signature of a function from the name and parameters.
+ */
+export class FunctionSignatureDecoder {
+  private separator: string;
+  constructor(
+    private name: string,
+    private parameters: ABIParameter[],
+    private includeNames = false,
+  ) {
+    this.separator = includeNames ? ', ' : ',';
+  }
+
+  /**
+   * Decodes a single function parameter type for the function signature.
+   * @param param - The parameter type to decode.
+   * @returns A string representing the parameter type.
+   */
+  private getParameterType(param: AbiType): string {
+    switch (param.kind) {
+      case 'field':
+        return 'Field';
+      case 'integer':
+        return param.sign === 'signed' ? `i${param.width}` : `u${param.width}`;
+      case 'boolean':
+        return 'bool';
+      case 'array':
+        return `[${this.getParameterType(param.type)};${param.length}]`;
+      case 'string':
+        return `str<${param.length}>`;
+      case 'struct':
+        return `(${param.fields.map(field => `${this.decodeParameter(field)}`).join(this.separator)})`;
+      default:
+        throw new Error(`Unsupported type: ${param.kind}`);
+    }
+  }
+
+  /**
+   * Decodes a single function parameter for the function signature.
+   * @param param - The parameter to decode.
+   * @returns A string representing the parameter type and optionally its name.
+   */
+  private decodeParameter(param: ABIVariable): string {
+    const type = this.getParameterType(param.type);
+    return this.includeNames ? `${param.name}: ${type}` : type;
+  }
+
+  /**
+   * Decodes all the parameters and build the function signature
+   * @returns The function signature.
+   */
+  public decode(): string {
+    return `${this.name}(${this.parameters.map(param => this.decodeParameter(param)).join(this.separator)})`;
+  }
+}
+
+/**
+ * Decodes a function signature from the name and parameters.
+ * @param name - The name of the function.
+ * @param parameters - The parameters of the function.
+ * @returns - The function signature.
+ */
+export function decodeFunctionSignature(name: string, parameters: ABIParameter[]) {
+  return new FunctionSignatureDecoder(name, parameters).decode();
+}
+
+/**
+ * Decodes a function signature from the name and parameters including parameter names.
+ * @param name - The name of the function.
+ * @param parameters - The parameters of the function.
+ * @returns - The user-friendly function signature.
+ */
+export function decodeFunctionSignatureWithParameterNames(name: string, parameters: ABIParameter[]) {
+  return new FunctionSignatureDecoder(name, parameters, true).decode();
+}

--- a/yarn-project/stdlib/src/abi/index.ts
+++ b/yarn-project/stdlib/src/abi/index.ts
@@ -1,6 +1,7 @@
 export * from './abi.js';
 export * from './buffer.js';
 export * from './decoder.js';
+export * from './function_signature_decoder.js';
 export * from './encoder.js';
 export * from './authorization_selector.js';
 export * from './event_metadata_definition.js';


### PR DESCRIPTION
## Summary
- Fixes `AbiDecoder` to properly decode `EthAddress`, `FunctionSelector`, and wrapped field structs (single `inner: Field`) as their corresponding TS types (`EthAddress`, `FunctionSelector`, `Fr`) instead of generic `{ inner: bigint }` objects
- Extracts `FunctionSignatureDecoder` into its own file to break a circular dependency between `decoder.ts` and `function_selector.ts`
- Adds e2e tests for decoding `EthAddress`, `FunctionSelector`, and wrapped field return values
- Adds unit tests for `EthAddress` decoding, wrapped field decoding, and `EthAddress` nested inside a larger struct
- Adds `return_eth_address`, `return_function_selector`, and `return_wrapped_field` utility functions to the `AbiTypes` test contract

Fixes https://linear.app/aztec-labs/issue/F-482/bug-abidecoder-doesnt-decode-ethaddress-properly
Closes https://github.com/AztecProtocol/aztec-packages/issues/21878

🤖 Generated with [Claude Code](https://claude.com/claude-code)