### PR TITLE
fix(docs): remove stale @ts-expect-error directives in docs examples

### DIFF
--- a/docs/examples/ts/example_swap/index.ts
+++ b/docs/examples/ts/example_swap/index.ts
@@ -151,7 +151,6 @@ await l2Dai.methods
   .send({ from: account.address });
 
 // Initialize L1 portals with registry, underlying token, and L2 bridge addresses
-// @ts-expect-error - viem type inference doesn't work with JSON-imported ABIs
 const initWethPortal = await l1Client.writeContract({
   address: wethPortalAddress.toString() as `0x${string}`,
   abi: ExampleTokenPortal.abi,
@@ -164,7 +163,6 @@ const initWethPortal = await l1Client.writeContract({
 });
 await l1Client.waitForTransactionReceipt({ hash: initWethPortal });
 
-// @ts-expect-error - viem type inference doesn't work with JSON-imported ABIs
 const initDaiPortal = await l1Client.writeContract({
   address: daiPortalAddress.toString() as `0x${string}`,
   abi: ExampleTokenPortal.abi,
@@ -178,7 +176,6 @@ const initDaiPortal = await l1Client.writeContract({
 await l1Client.waitForTransactionReceipt({ hash: initDaiPortal });
 
 // Initialize uniswap portal
-// @ts-expect-error - viem type inference doesn't work with JSON-imported ABIs
 const initUniswapPortal = await l1Client.writeContract({
   address: uniswapPortalAddress.toString() as `0x${string}`,
   abi: ExampleUniswapPortal.abi,
@@ -196,7 +193,6 @@ console.log("Funding accounts...\n");
 const SWAP_AMOUNT = 100n * 10n ** 18n; // 100 tokens
 
 // Mint WETH on L1 for the user
-// @ts-expect-error - viem type inference doesn't work with JSON-imported ABIs
 const mintWethHash = await l1Client.writeContract({
   address: wethAddress.toString() as `0x${string}`,
   abi: ExampleERC20.abi,
@@ -206,7 +202,6 @@ const mintWethHash = await l1Client.writeContract({
 await l1Client.waitForTransactionReceipt({ hash: mintWethHash });
 
 // Pre-fund the uniswap portal with DAI (for the mock 1:1 swap)
-// @ts-expect-error - viem type inference doesn't work with JSON-imported ABIs
 const mintDaiHash = await l1Client.writeContract({
   address: daiAddress.toString() as `0x${string}`,
   abi: ExampleERC20.abi,
@@ -226,7 +221,6 @@ const depositSecret = Fr.random();
 const depositSecretHash = await computeSecretHash(depositSecret);
 
 // Approve WETH portal to take tokens
-// @ts-expect-error - viem type inference doesn't work with JSON-imported ABIs
 const approveHash = await l1Client.writeContract({
   address: wethAddress.toString() as `0x${string}`,
   abi: ExampleERC20.abi,
@@ -236,7 +230,6 @@ const approveHash = await l1Client.writeContract({
 await l1Client.waitForTransactionReceipt({ hash: approveHash });
 
 // Deposit to Aztec publicly
-// @ts-expect-error - viem type inference doesn't work with JSON-imported ABIs
 const depositHash = await l1Client.writeContract({
   address: wethPortalAddress.toString() as `0x${string}`,
   abi: ExampleTokenPortal.abi,
@@ -403,7 +396,6 @@ console.log("Consuming L2->L1 messages on L1...\n");
 // 1. Token bridge exit (withdraw WETH to uniswap portal)
 // 2. Uniswap swap intent
 
-// @ts-expect-error - viem type inference doesn't work with JSON-imported ABIs
 const portalRollupVersion = (await l1Client.readContract({
   address: wethPortalAddress.toString() as `0x${string}`,
   abi: ExampleTokenPortal.abi,
@@ -510,7 +502,6 @@ const swapSiblingPath = swapWitness!.siblingPath
 
 // docs:start:consume_l1_messages_execute
 // Execute the swap on L1 (consumes both messages)
-// @ts-expect-error - viem type inference doesn't work with JSON-imported ABIs
 const l1SwapHash = await l1Client.writeContract({
   address: uniswapPortalAddress.toString() as `0x${string}`,
   abi: ExampleUniswapPortal.abi,

--- a/docs/examples/ts/token_bridge/index.ts
+++ b/docs/examples/ts/token_bridge/index.ts
@@ -80,7 +80,6 @@ console.log(`L2 Bridge: ${l2Bridge.address.toString()}\n`);
 console.log("Initializing portal...");
 
 // Initialize the portal contract
-// @ts-expect-error - viem type inference doesn't work with JSON-imported ABIs
 const initHash = await l1Client.writeContract({
   address: portalAddress.toString() as `0x${string}`,
   abi: NFTPortal.abi,
@@ -109,7 +108,6 @@ console.log("Bridge configured\n");
 // docs:start:mint_nft_l1
 console.log("Minting NFT on L1...");
 
-// @ts-expect-error - viem type inference doesn't work with JSON-imported ABIs
 const mintHash = await l1Client.writeContract({
   address: nftAddress.toString() as `0x${string}`,
   abi: SimpleNFT.abi,
@@ -131,7 +129,6 @@ const secret = Fr.random();
 const secretHash = await computeSecretHash(secret);
 
 // Approve portal to transfer the NFT
-// @ts-expect-error - viem type inference doesn't work with JSON-imported ABIs
 const approveHash = await l1Client.writeContract({
   address: nftAddress.toString() as `0x${string}`,
   abi: SimpleNFT.abi,
@@ -141,7 +138,6 @@ const approveHash = await l1Client.writeContract({
 await l1Client.waitForTransactionReceipt({ hash: approveHash });
 
 // Deposit to Aztec
-// @ts-expect-error - viem type inference doesn't work with JSON-imported ABIs
 const depositHash = await l1Client.writeContract({
   address: portalAddress.toString() as `0x${string}`,
   abi: NFTPortal.abi,
@@ -268,7 +264,6 @@ const recipientBuffer = Buffer.from(
 const content = sha256ToField([tokenIdBuffer, recipientBuffer]);
 
 // Get rollup version from the portal contract (it stores it during initialize)
-// @ts-expect-error - viem type inference doesn't work with JSON-imported ABIs
 const version = (await l1Client.readContract({
   address: portalAddress.toString() as `0x${string}`,
   abi: NFTPortal.abi,
@@ -314,7 +309,6 @@ const siblingPathHex = witness!.siblingPath
 
 // docs:start:withdraw_on_l1
 console.log("Withdrawing NFT on L1...");
-// @ts-expect-error - viem type inference doesn't work with JSON-imported ABIs
 const withdrawHash = await l1Client.writeContract({
   address: portalAddress.toString() as `0x${string}`,
   abi: NFTPortal.abi,


### PR DESCRIPTION
Docs build was broken and it resulted in flakes in 2 of my other PRs:
- https://github.com/AztecProtocol/aztec-packages/pull/21926
- https://github.com/AztecProtocol/aztec-packages/pull/21093

I am not exactly sure why this happened but the changes here seem harmless so I think we can just merge this to not cause pain to other people today.

## AI Summary
- Removed 9 unused `@ts-expect-error` directives from `docs/examples/ts/example_swap/index.ts`
- Removed 6 unused `@ts-expect-error` directives from `docs/examples/ts/token_bridge/index.ts`

These directives were suppressing viem type inference errors for JSON-imported ABIs, but `@aztec/viem@2.38.2` now handles this correctly. The stale directives cause `TS2578: Unused '@ts-expect-error' directive` errors during the docs examples validation pipeline (`docs/bootstrap.sh`).

## Test plan
- [x] Verified `example_swap` passes `tsc --noEmit` locally
- [x] Verified `token_bridge` passes `tsc --noEmit` locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)