### PR TITLE
fix: interactions clean up

### DIFF
--- a/docs/docs-developers/docs/resources/migration_notes.md
+++ b/docs/docs-developers/docs/resources/migration_notes.md
@@ -9,6 +9,27 @@ Aztec is in active development. Each version may introduce breaking changes that
 
 ## TBD
 
+### [aztec.js] `DeployMethod.send()` always returns `{ contract, receipt, instance }`
+
+The `returnReceipt` option in deploy wait options has been removed. `DeployMethod.send()` now always returns an object with `contract`, `receipt`, and `instance` at the top level, provided the user waits for the transaction to be included.
+
+The `DeployTxReceipt` and `DeployWaitOptions` types have been removed.
+
+**Migration:**
+
+```diff
+- const {
+-   receipt: { contract, instance },
+- } = await MyContract.deploy(wallet, ...args).send({
+-   from: address,
+-   wait: { returnReceipt: true },
+- });
+
++ const { contract, instance } = await MyContract.deploy(wallet, ...args).send({
++   from: address,
++ });
+```
+
 ### [aztec.js] `isContractInitialized` is now `initializationStatus` tri-state enum
 
 `ContractMetadata.isContractInitialized` has been renamed to `ContractMetadata.initializationStatus` and changed from `boolean | undefined` to a `ContractInitializationStatus` enum with values `INITIALIZED`, `UNINITIALIZED`, and `UNKNOWN`.
@@ -86,6 +107,7 @@ The `scope` field in `ExecuteUtilityOptions` has been renamed to `scopes` and ch
 ```
 
 **Impact**: Any code that calls `wallet.executeUtility` directly must update the options object. Wallets must update to adapt to the new interface
+
 ### [Aztec.nr] `attempt_note_discovery` now takes two separate functions instead of one
 
 The `attempt_note_discovery` function (and related discovery functions like `do_sync_state`, `process_message_ciphertext`) now takes separate `compute_note_hash` and `compute_note_nullifier` arguments instead of a single combined `compute_note_hash_and_nullifier`. The corresponding type aliases are now `ComputeNoteHash` and `ComputeNoteNullifier` (instead of `ComputeNoteHashAndNullifier`).

--- a/docs/examples/ts/recursive_verification/index.ts
+++ b/docs/examples/ts/recursive_verification/index.ts
@@ -22,7 +22,7 @@ if (!fs.existsSync("data.json")) {
 const data = JSON.parse(fs.readFileSync("data.json", "utf-8"));
 // docs:end:sample_data
 
-export const NODE_URL = "http://localhost:8080";
+export const NODE_URL = process.env.AZTEC_NODE_URL ?? "http://localhost:8080";
 
 // docs:start:setup_wallet
 // Setup sponsored fee payment - the FPC pays transaction fees for us

--- a/docs/examples/ts/recursive_verification/index.ts
+++ b/docs/examples/ts/recursive_verification/index.ts
@@ -22,7 +22,7 @@ if (!fs.existsSync("data.json")) {
 const data = JSON.parse(fs.readFileSync("data.json", "utf-8"));
 // docs:end:sample_data
 
-export const NODE_URL = process.env.AZTEC_NODE_URL ?? "http://localhost:8080";
+export const NODE_URL = "http://localhost:8080";
 
 // docs:start:setup_wallet
 // Setup sponsored fee payment - the FPC pays transaction fees for us
@@ -37,7 +37,7 @@ export const setupWallet = async (): Promise<EmbeddedWallet> => {
   try {
     // Create wallet with embedded PXE
     // The wallet manages accounts and connects to the node
-    let wallet = await EmbeddedWallet.create(NODE_URL);
+    let wallet = await EmbeddedWallet.create(NODE_URL, { ephemeral: true });
 
     // Register the sponsored FPC so the wallet knows about it
     await wallet.registerContract(sponsoredFPC, SponsoredFPCContract.artifact);

--- a/yarn-project/aztec.js/src/api/contract.ts
+++ b/yarn-project/aztec.js/src/api/contract.ts
@@ -10,16 +10,9 @@
  * or can be queried via `simulate()`.
  *
  * ```ts
- * // Deploy and get the contract instance directly (default behavior)
- * const contract = await Contract.deploy(wallet, MyContractArtifact, [...constructorArgs]).send({ from: accountAddress });
+ * // Deploy and get the contract, receipt, and instance
+ * const { contract, receipt, instance } = await Contract.deploy(wallet, MyContractArtifact, [...constructorArgs]).send({ from: accountAddress });
  * console.log(`Contract deployed at ${contract.address}`);
- *
- * // Or get the full receipt with contract and instance
- * const receipt = await Contract.deploy(wallet, MyContractArtifact, [...constructorArgs]).send({
- *   from: accountAddress,
- *   wait: { returnReceipt: true }
- * });
- * console.log(`Contract deployed at ${receipt.contract.address}`);
  * ```
  *
  * ```ts
@@ -74,8 +67,6 @@ export {
   type DeployOptions,
   type DeployResultMined,
   type DeployReturn,
-  type DeployTxReceipt,
-  type DeployWaitOptions,
   type DeployInteractionWaitOptions,
   DeployMethod,
   type RequestDeployOptions,

--- a/yarn-project/aztec.js/src/contract/batch_call.test.ts
+++ b/yarn-project/aztec.js/src/contract/batch_call.test.ts
@@ -1,8 +1,11 @@
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { FunctionCall, FunctionSelector, FunctionType } from '@aztec/stdlib/abi';
+import { AuthWitness } from '@aztec/stdlib/auth-witness';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
 import {
+  Capsule,
   ExecutionPayload,
+  HashedValues,
   OFFCHAIN_MESSAGE_IDENTIFIER,
   type OffchainEffect,
   TxSimulationResult,
@@ -404,6 +407,28 @@ describe('BatchCall', () => {
       expect(result.calls[0]).toEqual(feePayload.calls[0]);
       expect(result.calls[1]).toEqual(payload.calls[0]);
       expect(mockPaymentMethod.getExecutionPayload).toHaveBeenCalledTimes(1);
+    });
+
+    it('should propagate authWitnesses, capsules, and extraHashedArgs into the execution payload', async () => {
+      const contractAddress = await AztecAddress.random();
+      const payload = createPrivateExecutionPayload('func', [Fr.random()], contractAddress);
+
+      const authWitness = AuthWitness.random();
+      const capsule = new Capsule(await AztecAddress.random(), Fr.random(), [Fr.random()]);
+      const extraHashedArgs = [HashedValues.random()];
+
+      batchCall = new BatchCall(wallet, [payload], extraHashedArgs);
+      // Inject authWitnesses and capsules into the interaction (as BaseContractInteraction exposes these)
+      (batchCall as any).authWitnesses = [authWitness];
+      (batchCall as any).capsules = [capsule];
+
+      const result = await batchCall.request();
+
+      expect(result.calls).toHaveLength(1);
+      expect(result.calls[0]).toEqual(payload.calls[0]);
+      expect(result.authWitnesses).toContainEqual(authWitness);
+      expect(result.capsules).toContainEqual(capsule);
+      expect(result.extraHashedArgs).toContainEqual(extraHashedArgs[0]);
     });
   });
 });

--- a/yarn-project/aztec.js/src/contract/batch_call.ts
+++ b/yarn-project/aztec.js/src/contract/batch_call.ts
@@ -1,5 +1,11 @@
 import { type FunctionCall, FunctionType, decodeFromAbi } from '@aztec/stdlib/abi';
-import { ExecutionPayload, TxSimulationResult, UtilityExecutionResult, mergeExecutionPayloads } from '@aztec/stdlib/tx';
+import {
+  ExecutionPayload,
+  HashedValues,
+  TxSimulationResult,
+  UtilityExecutionResult,
+  mergeExecutionPayloads,
+} from '@aztec/stdlib/tx';
 
 import type { BatchedMethod, Wallet } from '../wallet/wallet.js';
 import { BaseContractInteraction } from './base_contract_interaction.js';
@@ -19,6 +25,7 @@ export class BatchCall extends BaseContractInteraction {
   constructor(
     wallet: Wallet,
     protected interactions: (BaseContractInteraction | ExecutionPayload)[],
+    private extraHashedArgs: HashedValues[] = [],
   ) {
     super(wallet);
   }
@@ -34,9 +41,19 @@ export class BatchCall extends BaseContractInteraction {
     const feeExecutionPayload = options.fee?.paymentMethod
       ? await options.fee.paymentMethod.getExecutionPayload()
       : undefined;
+    const { authWitnesses, capsules } = options;
+
+    // Propagates the included authwitnesses, capsules, and extraHashedArgs
+    // potentially baked into the interaction
+    const initialExecutionPayload = new ExecutionPayload(
+      [],
+      this.authWitnesses.concat(authWitnesses ?? []),
+      this.capsules.concat(capsules ?? []),
+      this.extraHashedArgs,
+    );
     const finalExecutionPayload = feeExecutionPayload
-      ? mergeExecutionPayloads([feeExecutionPayload, ...requests])
-      : mergeExecutionPayloads([...requests]);
+      ? mergeExecutionPayloads([initialExecutionPayload, feeExecutionPayload, ...requests])
+      : mergeExecutionPayloads([initialExecutionPayload, ...requests]);
     return finalExecutionPayload;
   }
 

--- a/yarn-project/aztec.js/src/contract/batch_call.ts
+++ b/yarn-project/aztec.js/src/contract/batch_call.ts
@@ -43,8 +43,7 @@ export class BatchCall extends BaseContractInteraction {
       : undefined;
     const { authWitnesses, capsules } = options;
 
-    // Propagates the included authwitnesses, capsules, and extraHashedArgs
-    // potentially baked into the interaction
+    // Propagates the included authwitnesses, capsules, and extraHashedArgs potentially baked into the interaction
     const initialExecutionPayload = new ExecutionPayload(
       [],
       this.authWitnesses.concat(authWitnesses ?? []),

--- a/yarn-project/aztec.js/src/contract/deploy_method.ts
+++ b/yarn-project/aztec.js/src/contract/deploy_method.ts
@@ -30,7 +30,6 @@ import {
   type SimulationInteractionFeeOptions,
   type SimulationResult,
   type TxSendResultImmediate,
-  type TxSendResultMined,
   extractOffchainOutput,
   toProfileOptions,
   toSendOptions,
@@ -39,21 +38,12 @@ import {
 import type { WaitOpts } from './wait_opts.js';
 
 /**
- * Wait options specific to deployment transactions.
- * Extends WaitOpts with a flag to return the full receipt instead of just the contract.
- */
-export type DeployWaitOptions = WaitOpts & {
-  /** If true, return the full DeployTxReceipt instead of just the contract. Defaults to false. */
-  returnReceipt?: boolean;
-};
-
-/**
  * Type for wait options in deployment interactions.
  * - NO_WAIT symbol: Don't wait, return TxHash immediately
- * - DeployWaitOptions: Wait with custom options
+ * - WaitOpts: Wait with custom options
  * - undefined: Wait with default options
  */
-export type DeployInteractionWaitOptions = NoWait | DeployWaitOptions | undefined;
+export type DeployInteractionWaitOptions = NoWait | WaitOpts | undefined;
 
 /**
  * Options for deploying a contract on the Aztec network.
@@ -96,7 +86,7 @@ export type DeployOptions<W extends DeployInteractionWaitOptions = undefined> = 
   /**
    * Options for waiting for the transaction to be mined.
    * - undefined (default): wait with default options and return the contract instance
-   * - DeployWaitOptions: wait with custom options and return contract or receipt based on returnReceipt flag
+   * - WaitOpts: wait with custom options
    * - NO_WAIT: return TxHash immediately without waiting
    */
   wait?: W;
@@ -120,40 +110,20 @@ export type SimulateDeployOptions = Omit<DeployOptionsWithoutWait, 'fee'> & {
   includeMetadata?: boolean;
 };
 
-/** Receipt for a deployment transaction with the deployed contract instance. */
-export type DeployTxReceipt<TContract extends ContractBase = ContractBase> = TxReceipt & {
-  /** Type-safe wrapper around the deployed contract instance, linked to the deployment wallet */
-  contract: TContract;
-  /** The deployed contract instance with address and metadata. */
-  instance: ContractInstanceWithAddress;
-};
-
-/** Wait options that request a full receipt instead of just the contract instance. */
-type WaitWithReturnReceipt = {
-  /** Request the full receipt instead of just the contract instance. */
-  returnReceipt: true;
-};
-
-/**
- * Represents the result type of deploying a contract.
- * - If wait is NO_WAIT, returns TxHash immediately.
- * - If wait has returnReceipt: true, returns DeployTxReceipt after waiting.
- * - Otherwise (undefined or DeployWaitOptions without returnReceipt), returns TContract after waiting.
- */
 /** Result of deploying a contract when waiting for mining (default case). */
 export type DeployResultMined<TContract extends ContractBase> = {
   /** The deployed contract instance. */
   contract: TContract;
+  /** The deployed contract instance with address and metadata. */
+  instance: ContractInstanceWithAddress;
   /** The deploy transaction receipt. */
-  receipt: DeployTxReceipt<TContract>;
+  receipt: TxReceipt;
 } & OffchainOutput;
 
 /** Conditional return type for deploy based on wait options. */
 export type DeployReturn<TContract extends ContractBase, W extends DeployInteractionWaitOptions> = W extends NoWait
   ? TxSendResultImmediate
-  : W extends WaitWithReturnReceipt
-    ? TxSendResultMined<DeployTxReceipt<TContract>>
-    : DeployResultMined<TContract>;
+  : DeployResultMined<TContract>;
 
 /**
  * Contract interaction for deployment.
@@ -234,20 +204,13 @@ export class DeployMethod<TContract extends ContractBase = ContractBase> extends
   }
 
   /**
-   * Converts DeployOptions to SendOptions, stripping out the returnReceipt flag if present.
-   * @param options - Deploy options with wait parameter
-   * @returns Send options with wait parameter
+   * Converts DeployOptions to SendOptions.
+   * @param options - Deploy options with wait parameter.
    */
   protected convertDeployOptionsToSendOptions<W extends DeployInteractionWaitOptions>(
     options: DeployOptions<W>,
-    // eslint-disable-next-line jsdoc/require-jsdoc
-  ): SendOptions<W extends { returnReceipt: true } ? WaitOpts : W> {
-    return {
-      ...toSendOptions({
-        ...options,
-        wait: options.wait as any,
-      }),
-    } as any;
+  ): SendOptions<W> {
+    return toSendOptions({ ...options, wait: options.wait as any }) as any;
   }
 
   /**
@@ -354,7 +317,7 @@ export class DeployMethod<TContract extends ContractBase = ContractBase> extends
    * By default, waits for the transaction to be mined and returns the deployed contract instance.
    *
    * @param options - An object containing various deployment options such as contractAddressSalt and from.
-   * @returns TxHash (if wait is NO_WAIT), TContract (if wait is undefined or doesn't have returnReceipt), or DeployTxReceipt (if wait.returnReceipt is true)
+   * @returns TxHash (if wait is NO_WAIT), or DeployResultMined with contract, receipt, and instance (otherwise)
    */
   // Overload for when wait is not specified at all - returns the contract
   public override send(options: DeployOptionsWithoutWait): Promise<DeployResultMined<TContract>>;
@@ -383,12 +346,7 @@ export class DeployMethod<TContract extends ContractBase = ContractBase> extends
     const instance = await this.getInstance(options);
     const contract = this.postDeployCtor(instance, this.wallet) as TContract;
 
-    // Return full receipt if requested, otherwise just the contract
-    if (options.wait && typeof options.wait === 'object' && options.wait.returnReceipt) {
-      return { receipt: { ...receipt, contract, instance }, ...offchainOutput };
-    }
-
-    return { contract, receipt, ...offchainOutput };
+    return { contract, receipt, instance, ...offchainOutput };
   }
 
   /**

--- a/yarn-project/aztec.js/src/wallet/deploy_account_method.ts
+++ b/yarn-project/aztec.js/src/wallet/deploy_account_method.ts
@@ -23,7 +23,6 @@ import {
   NO_FROM,
   type ProfileInteractionOptions,
 } from '../contract/interaction_options.js';
-import type { WaitOpts } from '../contract/wait_opts.js';
 import type { FeePaymentMethod } from '../fee/fee_payment_method.js';
 import { AccountEntrypointMetaPaymentMethod } from './account_entrypoint_meta_payment_method.js';
 import type { ProfileOptions, SendOptions, SimulateOptions, Wallet } from './index.js';
@@ -170,8 +169,7 @@ export class DeployAccountMethod<TContract extends ContractBase = Contract> exte
 
   protected override convertDeployOptionsToSendOptions<W extends DeployInteractionWaitOptions>(
     options: DeployOptions<W>,
-    // eslint-disable-next-line jsdoc/require-jsdoc
-  ): SendOptions<W extends { returnReceipt: true } ? WaitOpts : W> {
+  ): SendOptions<W> {
     return super.convertDeployOptionsToSendOptions(this.injectContractAddressIntoScopes(options));
   }
 

--- a/yarn-project/end-to-end/src/bench/client_flows/account_deployments.test.ts
+++ b/yarn-project/end-to-end/src/bench/client_flows/account_deployments.test.ts
@@ -92,7 +92,7 @@ describe('Deployment benchmark', () => {
 
           if (process.env.SANITY_CHECKS) {
             // Ensure we paid a fee
-            const { receipt } = await deploymentInteraction.send({ ...options, wait: { returnReceipt: true } });
+            const { receipt } = await deploymentInteraction.send({ ...options });
             expect(receipt.transactionFee!).toBeGreaterThan(0n);
           }
         });

--- a/yarn-project/end-to-end/src/bench/client_flows/client_flows_benchmark.ts
+++ b/yarn-project/end-to-end/src/bench/client_flows/client_flows_benchmark.ts
@@ -250,11 +250,14 @@ export class ClientFlowsBenchmark {
 
   async applyDeployBananaToken() {
     this.logger.info('Applying banana token deployment');
-    const {
-      receipt: { contract: bananaCoin, instance: bananaCoinInstance },
-    } = await BananaCoin.deploy(this.adminWallet, this.adminAddress, 'BC', 'BC', 18n).send({
+    const { contract: bananaCoin, instance: bananaCoinInstance } = await BananaCoin.deploy(
+      this.adminWallet,
+      this.adminAddress,
+      'BC',
+      'BC',
+      18n,
+    ).send({
       from: this.adminAddress,
-      wait: { returnReceipt: true },
     });
     this.logger.info(`BananaCoin deployed at ${bananaCoin.address}`);
     this.bananaCoin = bananaCoin;
@@ -263,11 +266,14 @@ export class ClientFlowsBenchmark {
 
   async applyDeployCandyBarToken() {
     this.logger.info('Applying candy bar token deployment');
-    const {
-      receipt: { contract: candyBarCoin, instance: candyBarCoinInstance },
-    } = await TokenContract.deploy(this.adminWallet, this.adminAddress, 'CBC', 'CBC', 18n).send({
+    const { contract: candyBarCoin, instance: candyBarCoinInstance } = await TokenContract.deploy(
+      this.adminWallet,
+      this.adminAddress,
+      'CBC',
+      'CBC',
+      18n,
+    ).send({
       from: this.adminAddress,
-      wait: { returnReceipt: true },
     });
     this.logger.info(`CandyBarCoin deployed at ${candyBarCoin.address}`);
     this.candyBarCoin = candyBarCoin;
@@ -280,11 +286,12 @@ export class ClientFlowsBenchmark {
     expect((await this.context.wallet.getContractMetadata(feeJuiceContract.address)).isContractPublished).toBe(true);
 
     const bananaCoin = this.bananaCoin;
-    const {
-      receipt: { contract: bananaFPC, instance: bananaFPCInstance },
-    } = await FPCContract.deploy(this.adminWallet, bananaCoin.address, this.adminAddress).send({
+    const { contract: bananaFPC, instance: bananaFPCInstance } = await FPCContract.deploy(
+      this.adminWallet,
+      bananaCoin.address,
+      this.adminAddress,
+    ).send({
       from: this.adminAddress,
-      wait: { returnReceipt: true },
     });
 
     this.logger.info(`BananaPay deployed at ${bananaFPC.address}`);
@@ -348,20 +355,21 @@ export class ClientFlowsBenchmark {
 
   public async applyDeployAmm() {
     this.logger.info('Applying AMM deployment');
-    const {
-      receipt: { contract: liquidityToken, instance: liquidityTokenInstance },
-    } = await TokenContract.deploy(this.adminWallet, this.adminAddress, 'LPT', 'LPT', 18n).send({
+    const { contract: liquidityToken, instance: liquidityTokenInstance } = await TokenContract.deploy(
+      this.adminWallet,
+      this.adminAddress,
+      'LPT',
+      'LPT',
+      18n,
+    ).send({
       from: this.adminAddress,
-      wait: { returnReceipt: true },
     });
-    const {
-      receipt: { contract: amm, instance: ammInstance },
-    } = await AMMContract.deploy(
+    const { contract: amm, instance: ammInstance } = await AMMContract.deploy(
       this.adminWallet,
       this.bananaCoin.address,
       this.candyBarCoin.address,
       liquidityToken.address,
-    ).send({ from: this.adminAddress, wait: { returnReceipt: true } });
+    ).send({ from: this.adminAddress });
     this.logger.info(`AMM deployed at ${amm.address}`);
     await liquidityToken.methods.set_minter(amm.address, true).send({ from: this.adminAddress });
     this.liquidityToken = liquidityToken;

--- a/yarn-project/end-to-end/src/bench/client_flows/deployments.test.ts
+++ b/yarn-project/end-to-end/src/bench/client_flows/deployments.test.ts
@@ -86,7 +86,7 @@ describe('Deployment benchmark', () => {
 
             if (process.env.SANITY_CHECKS) {
               // Ensure we paid a fee
-              const { receipt } = await deploymentInteraction.send({ ...options, wait: { returnReceipt: true } });
+              const { receipt } = await deploymentInteraction.send({ ...options });
               expect(receipt.transactionFee!).toBeGreaterThan(0n);
             }
           });

--- a/yarn-project/end-to-end/src/bench/client_flows/storage_proof.test.ts
+++ b/yarn-project/end-to-end/src/bench/client_flows/storage_proof.test.ts
@@ -34,9 +34,8 @@ describe('Storage proof benchmark', () => {
     await t.applyFPCSetup();
     await t.applyDeploySponsoredFPC();
 
-    const { receipt: deployed } = await StorageProofTestContract.deploy(t.adminWallet).send({
+    const deployed = await StorageProofTestContract.deploy(t.adminWallet).send({
       from: t.adminAddress,
-      wait: { returnReceipt: true },
     });
     storageProofContract = deployed.contract;
     storageProofInstance = deployed.instance;

--- a/yarn-project/end-to-end/src/composed/e2e_persistence.test.ts
+++ b/yarn-project/end-to-end/src/composed/e2e_persistence.test.ts
@@ -68,11 +68,8 @@ describe('Aztec persistence', () => {
     owner = initialFundedAccounts[0];
     ownerAddress = owner.address;
 
-    const {
-      receipt: { contract, instance },
-    } = await TokenBlacklistContract.deploy(wallet, ownerAddress).send({
+    const { contract, instance } = await TokenBlacklistContract.deploy(wallet, ownerAddress).send({
       from: ownerAddress,
-      wait: { returnReceipt: true },
     });
     contractInstance = instance;
     contractAddress = contract.address;

--- a/yarn-project/end-to-end/src/composed/ha/e2e_ha_full.test.ts
+++ b/yarn-project/end-to-end/src/composed/ha/e2e_ha_full.test.ts
@@ -326,7 +326,6 @@ describe('HA Full Setup', () => {
     const { receipt } = await deployer.deploy(ownerAddress, sender, 1).send({
       from: ownerAddress,
       contractAddressSalt: new Fr(BigInt(1)),
-      wait: { returnReceipt: true },
     });
 
     await waitForProven(aztecNode, receipt, {
@@ -445,7 +444,6 @@ describe('HA Full Setup', () => {
     const { receipt } = await deployer.deploy(ownerAddress, ownerAddress, 42).send({
       from: ownerAddress,
       contractAddressSalt: Fr.random(),
-      wait: { returnReceipt: true },
     });
     expect(receipt.blockNumber).toBeDefined();
     logger.info(`Transaction mined in block ${receipt.blockNumber}`);
@@ -604,7 +602,6 @@ describe('HA Full Setup', () => {
       const receipt = await deployer.deploy(ownerAddress, ownerAddress, 201).send({
         from: ownerAddress,
         contractAddressSalt: new Fr(201),
-        wait: { returnReceipt: true },
       });
       expect(receipt.receipt.blockNumber).toBeDefined();
       const [block] = await aztecNode.getCheckpointedBlocks(receipt.receipt.blockNumber!, 1);
@@ -647,7 +644,6 @@ describe('HA Full Setup', () => {
       const { receipt } = await deployer.deploy(ownerAddress, ownerAddress, i + 100).send({
         from: ownerAddress,
         contractAddressSalt: new Fr(BigInt(i + 100)),
-        wait: { returnReceipt: true },
       });
 
       expect(receipt.blockNumber).toBeDefined();

--- a/yarn-project/end-to-end/src/e2e_2_pxes.test.ts
+++ b/yarn-project/end-to-end/src/e2e_2_pxes.test.ts
@@ -108,11 +108,8 @@ describe('e2e_2_pxes', () => {
 
   const deployChildContractViaServerA = async () => {
     logger.info(`Deploying Child contract...`);
-    const {
-      receipt: { instance },
-    } = await ChildContract.deploy(walletA).send({
+    const { instance } = await ChildContract.deploy(walletA).send({
       from: accountAAddress,
-      wait: { returnReceipt: true },
     });
     logger.info('Child contract deployed');
 

--- a/yarn-project/end-to-end/src/e2e_avm_simulator.test.ts
+++ b/yarn-project/end-to-end/src/e2e_avm_simulator.test.ts
@@ -36,11 +36,8 @@ describe('e2e_avm_simulator', () => {
     let secondAvmContract: AvmTestContract;
 
     beforeEach(async () => {
-      ({
-        receipt: { contract: avmContract, instance: avmContractInstance },
-      } = await AvmTestContract.deploy(wallet).send({
+      ({ contract: avmContract, instance: avmContractInstance } = await AvmTestContract.deploy(wallet).send({
         from: defaultAccountAddress,
-        wait: { returnReceipt: true },
       }));
       ({ contract: secondAvmContract } = await AvmTestContract.deploy(wallet).send({ from: defaultAccountAddress }));
     });

--- a/yarn-project/end-to-end/src/e2e_contract_updates.test.ts
+++ b/yarn-project/end-to-end/src/e2e_contract_updates.test.ts
@@ -110,12 +110,9 @@ describe('e2e_contract_updates', () => {
     }
     sequencer = maybeSequencer;
 
-    ({
-      receipt: { contract, instance },
-    } = await UpdatableContract.deploy(wallet, constructorArgs[0]).send({
+    ({ contract, instance } = await UpdatableContract.deploy(wallet, constructorArgs[0]).send({
       from: defaultAccountAddress,
       contractAddressSalt: salt,
-      wait: { returnReceipt: true },
     }));
 
     const registerMethod = await publishContractClass(wallet, UpdatedContractArtifact);

--- a/yarn-project/end-to-end/src/e2e_deploy_contract/legacy.test.ts
+++ b/yarn-project/end-to-end/src/e2e_deploy_contract/legacy.test.ts
@@ -36,10 +36,8 @@ describe('e2e_deploy_contract legacy', () => {
       deployer: defaultAccountAddress,
     });
     const deployer = new ContractDeployer(TestContractArtifact, wallet);
-    const { receipt } = await deployer
-      .deploy()
-      .send({ from: defaultAccountAddress, contractAddressSalt: salt, wait: { returnReceipt: true } });
-    expect(receipt.contract.address).toEqual(deploymentData.address);
+    const { contract } = await deployer.deploy().send({ from: defaultAccountAddress, contractAddressSalt: salt });
+    expect(contract.address).toEqual(deploymentData.address);
     const { instance, isContractPublished } = await wallet.getContractMetadata(deploymentData.address);
     expect(instance).toBeDefined();
     expect(isContractPublished).toBe(true);
@@ -65,11 +63,11 @@ describe('e2e_deploy_contract legacy', () => {
 
     for (let index = 0; index < 2; index++) {
       logger.info(`Deploying contract ${index + 1}...`);
-      const { receipt } = await deployer
+      const { contract: deployed } = await deployer
         .deploy()
-        .send({ from: defaultAccountAddress, contractAddressSalt: Fr.random(), wait: { returnReceipt: true } });
+        .send({ from: defaultAccountAddress, contractAddressSalt: Fr.random() });
       logger.info(`Sending TX to contract ${index + 1}...`);
-      await receipt.contract.methods
+      await deployed.methods
         .get_master_incoming_viewing_public_key(defaultAccountAddress)
         .send({ from: defaultAccountAddress });
     }
@@ -104,8 +102,8 @@ describe('e2e_deploy_contract legacy', () => {
     };
 
     const [goodTxPromiseResult, badTxReceiptResult] = await Promise.allSettled([
-      goodDeploy.send({ ...firstOpts, wait: { returnReceipt: true } }),
-      badDeploy.send({ ...secondOpts, wait: { dontThrowOnRevert: true, returnReceipt: true } }),
+      goodDeploy.send({ ...firstOpts }),
+      badDeploy.send({ ...secondOpts, wait: { dontThrowOnRevert: true } }),
     ]);
 
     expect(goodTxPromiseResult.status).toBe('fulfilled');

--- a/yarn-project/end-to-end/src/e2e_fees/account_init.test.ts
+++ b/yarn-project/end-to-end/src/e2e_fees/account_init.test.ts
@@ -90,7 +90,7 @@ describe('e2e_fees account_init', () => {
       const [bobsInitialGas] = await t.getGasBalanceFn(bobsAddress);
       expect(bobsInitialGas).toEqual(mintAmount);
 
-      const { receipt: tx } = await bobsDeployMethod.send({ from: NO_FROM, wait: { returnReceipt: true } });
+      const { receipt: tx } = await bobsDeployMethod.send({ from: NO_FROM });
 
       expect(tx.transactionFee!).toBeGreaterThan(0n);
       await expect(t.getGasBalanceFn(bobsAddress)).resolves.toEqual([bobsInitialGas - tx.transactionFee!]);
@@ -102,7 +102,6 @@ describe('e2e_fees account_init', () => {
       const { receipt: tx } = await bobsDeployMethod.send({
         from: NO_FROM,
         fee: { paymentMethod },
-        wait: { returnReceipt: true },
       });
       expect(tx.transactionFee!).toBeGreaterThan(0n);
       await expect(t.getGasBalanceFn(bobsAddress)).resolves.toEqual([claim.claimAmount - tx.transactionFee!]);
@@ -122,7 +121,6 @@ describe('e2e_fees account_init', () => {
       const { receipt: tx } = await bobsDeployMethod.send({
         from: NO_FROM,
         fee: { paymentMethod },
-        wait: { returnReceipt: true },
       });
       const actualFee = tx.transactionFee!;
       expect(actualFee).toBeGreaterThan(0n);
@@ -152,7 +150,6 @@ describe('e2e_fees account_init', () => {
         from: NO_FROM,
         skipInstancePublication: false,
         fee: { paymentMethod },
-        wait: { returnReceipt: true },
       });
 
       const actualFee = tx.transactionFee!;
@@ -195,7 +192,6 @@ describe('e2e_fees account_init', () => {
         skipInstancePublication: true,
         skipInitialization: false,
         universalDeploy: true,
-        wait: { returnReceipt: true },
       });
 
       // alice paid in Fee Juice

--- a/yarn-project/end-to-end/src/e2e_fees/gas_estimation.test.ts
+++ b/yarn-project/end-to-end/src/e2e_fees/gas_estimation.test.ts
@@ -1,5 +1,4 @@
 import type { AztecAddress } from '@aztec/aztec.js/addresses';
-import type { DeployTxReceipt } from '@aztec/aztec.js/contracts';
 import { type FeePaymentMethod, PublicFeePaymentMethod } from '@aztec/aztec.js/fee';
 import type { AztecNode } from '@aztec/aztec.js/node';
 import type { Wallet } from '@aztec/aztec.js/wallet';
@@ -186,7 +185,6 @@ describe('e2e_fees gas_estimation', () => {
         from: aliceAddress,
         fee: { gasSettings: limits ? { ...gasSettings, ...limits } : gasSettings },
         skipClassPublication: true,
-        wait: { returnReceipt: true },
       };
     };
 
@@ -201,10 +199,10 @@ describe('e2e_fees gas_estimation', () => {
     const estimatedGas = sim3.estimatedGas!;
     logGasEstimate(estimatedGas);
 
-    const [{ receipt: withEstimate }, { receipt: withoutEstimate }] = (await Promise.all([
+    const [{ receipt: withEstimate }, { receipt: withoutEstimate }] = await Promise.all([
       deployMethod().send(deployOpts(estimatedGas)),
       deployMethod().send(deployOpts()),
-    ])) as unknown as { receipt: DeployTxReceipt }[];
+    ]);
 
     // Estimation should yield that teardown has no cost, so should send the tx with zero for teardown
     expect(withEstimate.transactionFee!).toEqual(withoutEstimate.transactionFee!);

--- a/yarn-project/end-to-end/src/e2e_multi_validator/e2e_multi_validator_node.test.ts
+++ b/yarn-project/end-to-end/src/e2e_multi_validator/e2e_multi_validator_node.test.ts
@@ -117,7 +117,6 @@ describe('e2e_multi_validator_node', () => {
     const { receipt: tx } = await deployer.deploy(ownerAddress, sender, 1).send({
       from: ownerAddress,
       contractAddressSalt: new Fr(BigInt(1)),
-      wait: { returnReceipt: true },
     });
     await waitForProven(aztecNode, tx, {
       provenTimeout: (config.aztecProofSubmissionEpochs + 1) * config.aztecEpochDuration * config.aztecSlotDuration,
@@ -178,7 +177,6 @@ describe('e2e_multi_validator_node', () => {
     const { receipt: tx } = await deployer.deploy(ownerAddress, sender, 1).send({
       from: ownerAddress,
       contractAddressSalt: new Fr(BigInt(1)),
-      wait: { returnReceipt: true },
     });
     await waitForProven(aztecNode, tx, {
       provenTimeout: (config.aztecProofSubmissionEpochs + 1) * config.aztecEpochDuration * config.aztecSlotDuration,

--- a/yarn-project/end-to-end/src/e2e_simple.test.ts
+++ b/yarn-project/end-to-end/src/e2e_simple.test.ts
@@ -75,7 +75,6 @@ describe('e2e_simple', () => {
       const { receipt: txReceipt } = await deployer.deploy(ownerAddress, sender, 1).send({
         from: ownerAddress,
         contractAddressSalt: new Fr(BigInt(1)),
-        wait: { returnReceipt: true },
       });
       await waitForProven(aztecNode, txReceipt, {
         provenTimeout: (config.aztecProofSubmissionEpochs + 1) * config.aztecEpochDuration * config.aztecSlotDuration,

--- a/yarn-project/end-to-end/src/fixtures/e2e_prover_test.ts
+++ b/yarn-project/end-to-end/src/fixtures/e2e_prover_test.ts
@@ -104,15 +104,13 @@ export class FullProverTest {
     await publicDeployAccounts(this.wallet, this.accounts.slice(0, 2));
 
     this.logger.info('Applying base setup: deploying token contract');
-    const {
-      receipt: { contract: asset, instance },
-    } = await TokenContract.deploy(
+    const { contract: asset, instance } = await TokenContract.deploy(
       this.wallet,
       this.accounts[0],
       FullProverTest.TOKEN_NAME,
       FullProverTest.TOKEN_SYMBOL,
       FullProverTest.TOKEN_DECIMALS,
-    ).send({ from: this.accounts[0], wait: { returnReceipt: true } });
+    ).send({ from: this.accounts[0] });
     this.logger.verbose(`Token deployed to ${asset.address}`);
 
     this.fakeProofsAsset = asset;

--- a/yarn-project/end-to-end/src/fixtures/token_utils.ts
+++ b/yarn-project/end-to-end/src/fixtures/token_utils.ts
@@ -6,11 +6,8 @@ import { TokenContract } from '@aztec/noir-contracts.js/Token';
 
 export async function deployToken(wallet: Wallet, admin: AztecAddress, initialAdminBalance: bigint, logger: Logger) {
   logger.info(`Deploying Token contract...`);
-  const {
-    receipt: { contract, instance },
-  } = await TokenContract.deploy(wallet, admin, 'TokenName', 'TokenSymbol', 18).send({
+  const { contract, instance } = await TokenContract.deploy(wallet, admin, 'TokenName', 'TokenSymbol', 18).send({
     from: admin,
-    wait: { returnReceipt: true },
   });
 
   if (initialAdminBalance > 0n) {

--- a/yarn-project/end-to-end/src/spartan/setup_test_wallets.ts
+++ b/yarn-project/end-to-end/src/spartan/setup_test_wallets.ts
@@ -346,14 +346,18 @@ async function deployTokenAndMint(
   logger: Logger,
 ) {
   logger.verbose(`Deploying TokenContract...`);
-  const {
-    receipt: { contract: tokenContract },
-  } = await TokenContract.deploy(wallet, admin, TOKEN_NAME, TOKEN_SYMBOL, TOKEN_DECIMALS).send({
+  const { contract: tokenContract } = await TokenContract.deploy(
+    wallet,
+    admin,
+    TOKEN_NAME,
+    TOKEN_SYMBOL,
+    TOKEN_DECIMALS,
+  ).send({
     from: admin,
     fee: {
       paymentMethod,
     },
-    wait: { timeout: 600, returnReceipt: true },
+    wait: { timeout: 600 },
   });
 
   const tokenAddress = tokenContract.address;


### PR DESCRIPTION
This PR attempts to improve our interaction classes.

Closes: https://github.com/AztecProtocol/aztec-packages/issues/21875

1. ) Addresses the aforementioned bug, where `BatchCall` wasn't forwarding the baked in interaction data (authwitnesses, capsules, extrahashedargs)
2. ) Removes the stale `returnReceipt` option from `DeployMethod`. This is a remnant from when we were just returning the deployed contract. Now that the return type is complex object, it just doesn't make sense to have extra complexity