### PR TITLE
fix: ensure empty docs packages `yarn.lock` files

### DIFF
--- a/docs/examples/bootstrap.sh
+++ b/docs/examples/bootstrap.sh
@@ -11,6 +11,11 @@ export STRIP_AZTEC_NR_PREFIX=${STRIP_AZTEC_NR_PREFIX:-"$REPO_ROOT/noir-projects/
 export BB_HASH=${BB_HASH:-$("$REPO_ROOT/barretenberg/cpp/bootstrap.sh" hash)}
 export NOIR_HASH=${NOIR_HASH:-$("$REPO_ROOT/noir/bootstrap.sh" hash)}
 
+# Safety net: ensure all TS example yarn.lock files are empty on exit.
+# Both validate-ts and execute-examples (via Docker volume mount) can populate
+# these files, and their per-project cleanup may not run if processes are killed.
+trap 'for lf in "$REPO_ROOT"/docs/examples/ts/*/yarn.lock; do [ -f "$lf" ] && > "$lf"; done' EXIT
+
 function compile-circuits {
   echo_header "Compiling vanilla Noir circuits"
   local CIRCUITS_DIR="$REPO_ROOT/docs/examples/circuits"

--- a/docs/examples/ts/bootstrap.sh
+++ b/docs/examples/ts/bootstrap.sh
@@ -11,6 +11,10 @@ export BUILDER_CLI="$REPO_ROOT/yarn-project/builder/dest/bin/cli.js"
 # Set parallel flags for concurrent validation
 export PARALLEL_FLAGS="-j${PARALLELISM:-4} --halt now,fail=1"
 
+# Ensure all yarn.lock files are empty on exit. The per-project cleanup trap
+# handles the normal case, but parallel's --halt can kill jobs before their trap runs.
+trap 'for lf in */yarn.lock; do [ -f "$lf" ] && > "$lf"; done' EXIT
+
 # Validate config.yaml structure before processing
 validate_config() {
     local config_file=$1


### PR DESCRIPTION
on failure, it would sometimes not clean correctly