### PR TITLE
fix: add missing default cases in treeId switch statements

### DIFF
--- a/barretenberg/cpp/src/barretenberg/nodejs_module/world_state/world_state.cpp
+++ b/barretenberg/cpp/src/barretenberg/nodejs_module/world_state/world_state.cpp
@@ -514,6 +514,8 @@ bool WorldStateWrapper::find_leaf_indices(msgpack::object& obj, msgpack::sbuffer
             request.value.revision, request.value.treeId, r3.value.leaves, response.indices, r3.value.startIndex);
         break;
     }
+    default:
+        throw std::runtime_error("Unsupported tree type");
     }
 
     MsgHeader header(request.header.messageId);
@@ -555,6 +557,8 @@ bool WorldStateWrapper::find_sibling_paths(msgpack::object& obj, msgpack::sbuffe
             request.value.revision, request.value.treeId, r3.value.leaves, response.paths);
         break;
     }
+    default:
+        throw std::runtime_error("Unsupported tree type");
     }
 
     MsgHeader header(request.header.messageId);
@@ -607,6 +611,8 @@ bool WorldStateWrapper::append_leaves(msgpack::object& obj, msgpack::sbuffer& bu
         _ws->append_leaves<crypto::merkle_tree::NullifierLeafValue>(r3.value.treeId, r3.value.leaves, r3.value.forkId);
         break;
     }
+    default:
+        throw std::runtime_error("Unsupported tree type");
     }
 
     MsgHeader header(request.header.messageId);


### PR DESCRIPTION
## Summary
- Adds missing `default:` cases to 3 switch statements on `treeId` in `nodejs_module/world_state/world_state.cpp`
- Affected functions: `find_leaf_indices`, `find_sibling_paths`, `append_leaves`
- Without these, unknown `treeId` values silently fell through instead of throwing errors

Fixes A-858