### PR TITLE
feat: add error page mapping for incompatible oracles

### DIFF
--- a/docs/netlify.toml
+++ b/docs/netlify.toml
@@ -800,3 +800,8 @@
     # Aztec-nr: user-defined 'offchain_receive' is not allowed
     from = "/errors/7"
     to = "/aztec-nr-api/nightly/noir_aztec/messages/processing/offchain/fn.receive.html"
+
+[[redirects]]
+    # PXE: incompatible oracle version between contract and PXE
+    from = "/errors/8"
+    to = "/developers/docs/foundational-topics/pxe"

--- a/noir-projects/aztec-nr/aztec/src/oracle/version.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/version.nr
@@ -30,7 +30,7 @@ mod test {
         assert_compatible_oracle_version_oracle(ORACLE_VERSION);
     }
 
-    #[test(should_fail_with = "Incompatible oracle version. TXE is using version")]
+    #[test(should_fail_with = "Incompatible TXE version:")]
     unconstrained fn incompatible_oracle_version() {
         let arbitrary_incorrect_version = 318183437;
         assert_compatible_oracle_version_oracle(arbitrary_incorrect_version);

--- a/noir-projects/aztec-nr/aztec/src/oracle/version.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/version.nr
@@ -30,7 +30,7 @@ mod test {
         assert_compatible_oracle_version_oracle(ORACLE_VERSION);
     }
 
-    #[test(should_fail_with = "Incompatible TXE version:")]
+    #[test(should_fail_with = "Incompatible aztec cli version:")]
     unconstrained fn incompatible_oracle_version() {
         let arbitrary_incorrect_version = 318183437;
         assert_compatible_oracle_version_oracle(arbitrary_incorrect_version);

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/oracle_version_is_checked.test.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/oracle_version_is_checked.test.ts
@@ -203,6 +203,7 @@ describe('Oracle Version Check test suite', () => {
         capsuleStore,
         privateEventStore,
         messageContextService,
+        contractSyncService,
         jobId: 'test',
         scopes: 'ALL_SCOPES',
       });

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/oracle_version_is_checked.test.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/oracle_version_is_checked.test.ts
@@ -210,9 +210,11 @@ describe('Oracle Version Check test suite', () => {
 
     it('suggests upgrading PXE when contract oracle version is newer', () => {
       const newerVersion = ORACLE_VERSION + 1;
-      expect(() => oracle.assertCompatibleOracleVersion(newerVersion)).toThrow(/Incompatible PXE version:/);
       expect(() => oracle.assertCompatibleOracleVersion(newerVersion)).toThrow(
-        /Upgrade your PXE to a compatible version/,
+        /Incompatible private environment version:/,
+      );
+      expect(() => oracle.assertCompatibleOracleVersion(newerVersion)).toThrow(
+        /Upgrade your private environment to a compatible version/,
       );
       expect(() => oracle.assertCompatibleOracleVersion(newerVersion)).toThrow(
         /See https:\/\/docs\.aztec\.network\/errors\/8/,
@@ -221,7 +223,9 @@ describe('Oracle Version Check test suite', () => {
 
     it('suggests recompiling the contract when contract oracle version is older', () => {
       const olderVersion = ORACLE_VERSION - 1;
-      expect(() => oracle.assertCompatibleOracleVersion(olderVersion)).toThrow(/Incompatible PXE version:/);
+      expect(() => oracle.assertCompatibleOracleVersion(olderVersion)).toThrow(
+        /Incompatible private environment version:/,
+      );
       expect(() => oracle.assertCompatibleOracleVersion(olderVersion)).toThrow(
         /Recompile the contract with a compatible version of Aztec\.nr/,
       );

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/oracle_version_is_checked.test.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/oracle_version_is_checked.test.ts
@@ -14,6 +14,7 @@ import { mock } from 'jest-mock-extended';
 
 import type { ContractSyncService } from '../../contract_sync/contract_sync_service.js';
 import type { MessageContextService } from '../../messages/message_context_service.js';
+import { ORACLE_VERSION } from '../../oracle_version.js';
 import type { AddressStore } from '../../storage/address_store/address_store.js';
 import type { CapsuleStore } from '../../storage/capsule_store/capsule_store.js';
 import type { ContractStore } from '../../storage/contract_store/contract_store.js';
@@ -181,5 +182,56 @@ describe('Oracle Version Check test suite', () => {
 
       expect(assertCompatibleOracleVersionSpy).toHaveBeenCalledTimes(1);
     }, 30_000);
+  });
+
+  describe('oracle version mismatch error messages', () => {
+    let oracle: UtilityExecutionOracle;
+
+    beforeEach(async () => {
+      oracle = new UtilityExecutionOracle({
+        contractAddress,
+        authWitnesses: [],
+        capsules: [],
+        anchorBlockHeader,
+        contractStore,
+        noteStore,
+        keyStore,
+        addressStore,
+        aztecNode,
+        recipientTaggingStore,
+        senderAddressBookStore,
+        capsuleStore,
+        privateEventStore,
+        messageContextService,
+        jobId: 'test',
+        scopes: 'ALL_SCOPES',
+      });
+    });
+
+    it('suggests upgrading PXE when contract oracle version is newer', () => {
+      const newerVersion = ORACLE_VERSION + 1;
+      expect(() => oracle.assertCompatibleOracleVersion(newerVersion)).toThrow(/Incompatible PXE version:/);
+      expect(() => oracle.assertCompatibleOracleVersion(newerVersion)).toThrow(
+        /Upgrade your PXE to a compatible version/,
+      );
+      expect(() => oracle.assertCompatibleOracleVersion(newerVersion)).toThrow(
+        /See https:\/\/docs\.aztec\.network\/errors\/8/,
+      );
+    });
+
+    it('suggests recompiling the contract when contract oracle version is older', () => {
+      const olderVersion = ORACLE_VERSION - 1;
+      expect(() => oracle.assertCompatibleOracleVersion(olderVersion)).toThrow(/Incompatible PXE version:/);
+      expect(() => oracle.assertCompatibleOracleVersion(olderVersion)).toThrow(
+        /Recompile the contract with a compatible version of Aztec\.nr/,
+      );
+      expect(() => oracle.assertCompatibleOracleVersion(olderVersion)).toThrow(
+        /See https:\/\/docs\.aztec\.network\/errors\/8/,
+      );
+    });
+
+    it('does not throw when oracle version matches', () => {
+      expect(() => oracle.assertCompatibleOracleVersion(ORACLE_VERSION)).not.toThrow();
+    });
   });
 });

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/oracle_version_is_checked.test.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/oracle_version_is_checked.test.ts
@@ -211,26 +211,14 @@ describe('Oracle Version Check test suite', () => {
     it('suggests upgrading PXE when contract oracle version is newer', () => {
       const newerVersion = ORACLE_VERSION + 1;
       expect(() => oracle.assertCompatibleOracleVersion(newerVersion)).toThrow(
-        /Incompatible private environment version:/,
-      );
-      expect(() => oracle.assertCompatibleOracleVersion(newerVersion)).toThrow(
-        /Upgrade your private environment to a compatible version/,
-      );
-      expect(() => oracle.assertCompatibleOracleVersion(newerVersion)).toThrow(
-        /See https:\/\/docs\.aztec\.network\/errors\/8/,
+        /Incompatible private environment version:.*Upgrade your private environment to a compatible version.*See https:\/\/docs\.aztec\.network\/errors\/8/,
       );
     });
 
     it('suggests recompiling the contract when contract oracle version is older', () => {
       const olderVersion = ORACLE_VERSION - 1;
       expect(() => oracle.assertCompatibleOracleVersion(olderVersion)).toThrow(
-        /Incompatible private environment version:/,
-      );
-      expect(() => oracle.assertCompatibleOracleVersion(olderVersion)).toThrow(
-        /Recompile the contract with a compatible version of Aztec\.nr/,
-      );
-      expect(() => oracle.assertCompatibleOracleVersion(olderVersion)).toThrow(
-        /See https:\/\/docs\.aztec\.network\/errors\/8/,
+        /Incompatible private environment version:.*Recompile the contract with a compatible version of Aztec\.nr.*See https:\/\/docs\.aztec\.network\/errors\/8/,
       );
     });
 

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/oracle_version_is_checked.test.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/oracle_version_is_checked.test.ts
@@ -187,7 +187,7 @@ describe('Oracle Version Check test suite', () => {
   describe('oracle version mismatch error messages', () => {
     let oracle: UtilityExecutionOracle;
 
-    beforeEach(async () => {
+    beforeEach(() => {
       oracle = new UtilityExecutionOracle({
         contractAddress,
         authWitnesses: [],

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
@@ -128,15 +128,25 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
     const LEGACY_ORACLE_VERSION = 12;
     if (isProtocolContract(this.contractAddress)) {
       if (version !== LEGACY_ORACLE_VERSION && version !== ORACLE_VERSION) {
+        const hint =
+          version > ORACLE_VERSION
+            ? 'The contract was compiled with a newer version of Aztec.nr than this PXE supports. Upgrade your PXE to a compatible version.'
+            : 'The contract was compiled with an older version of Aztec.nr than this PXE supports. Recompile the contract with a compatible version of Aztec.nr.';
         throw new Error(
-          `Expected legacy oracle version ${LEGACY_ORACLE_VERSION} or current oracle version ${ORACLE_VERSION} for alpha payload contract at ${this.contractAddress}, got ${version}.`,
+          `Incompatible PXE version: ${hint} See https://docs.aztec.network/errors/8 (expected oracle version ${LEGACY_ORACLE_VERSION} or ${ORACLE_VERSION}, got ${version})`,
         );
       }
       return;
     }
 
     if (version !== ORACLE_VERSION) {
-      throw new Error(`Incompatible oracle version. Expected version ${ORACLE_VERSION}, got ${version}.`);
+      const hint =
+        version > ORACLE_VERSION
+          ? 'The contract was compiled with a newer version of Aztec.nr than this PXE supports. Upgrade your PXE to a compatible version.'
+          : 'The contract was compiled with an older version of Aztec.nr than this PXE supports. Recompile the contract with a compatible version of Aztec.nr.';
+      throw new Error(
+        `Incompatible PXE version: ${hint} See https://docs.aztec.network/errors/8 (expected oracle version ${ORACLE_VERSION}, got ${version})`,
+      );
     }
   }
 

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
@@ -130,10 +130,10 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
       if (version !== LEGACY_ORACLE_VERSION && version !== ORACLE_VERSION) {
         const hint =
           version > ORACLE_VERSION
-            ? 'The contract was compiled with a newer version of Aztec.nr than this PXE supports. Upgrade your PXE to a compatible version.'
-            : 'The contract was compiled with an older version of Aztec.nr than this PXE supports. Recompile the contract with a compatible version of Aztec.nr.';
+            ? 'The contract was compiled with a newer version of Aztec.nr than your private environment supports. Upgrade your private environment to a compatible version.'
+            : 'The contract was compiled with an older version of Aztec.nr than your private environment supports. Recompile the contract with a compatible version of Aztec.nr.';
         throw new Error(
-          `Incompatible PXE version: ${hint} See https://docs.aztec.network/errors/8 (expected oracle version ${LEGACY_ORACLE_VERSION} or ${ORACLE_VERSION}, got ${version})`,
+          `Incompatible private environment version: ${hint} See https://docs.aztec.network/errors/8 (expected oracle version ${LEGACY_ORACLE_VERSION} or ${ORACLE_VERSION}, got ${version})`,
         );
       }
       return;
@@ -142,10 +142,10 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
     if (version !== ORACLE_VERSION) {
       const hint =
         version > ORACLE_VERSION
-          ? 'The contract was compiled with a newer version of Aztec.nr than this PXE supports. Upgrade your PXE to a compatible version.'
-          : 'The contract was compiled with an older version of Aztec.nr than this PXE supports. Recompile the contract with a compatible version of Aztec.nr.';
+          ? 'The contract was compiled with a newer version of Aztec.nr than your private environment supports. Upgrade your private environment to a compatible version.'
+          : 'The contract was compiled with an older version of Aztec.nr than your private environment supports. Recompile the contract with a compatible version of Aztec.nr.';
       throw new Error(
-        `Incompatible PXE version: ${hint} See https://docs.aztec.network/errors/8 (expected oracle version ${ORACLE_VERSION}, got ${version})`,
+        `Incompatible private environment version: ${hint} See https://docs.aztec.network/errors/8 (expected oracle version ${ORACLE_VERSION}, got ${version})`,
       );
     }
   }

--- a/yarn-project/txe/src/oracle/txe_oracle_top_level_context.ts
+++ b/yarn-project/txe/src/oracle/txe_oracle_top_level_context.ts
@@ -122,10 +122,10 @@ export class TXEOracleTopLevelContext implements IMiscOracle, ITxeExecutionOracl
     if (version !== ORACLE_VERSION) {
       const hint =
         version > ORACLE_VERSION
-          ? 'The contract was compiled with a newer version of Aztec.nr than this TXE supports. Upgrade your TXE to a compatible version.'
-          : 'The contract was compiled with an older version of Aztec.nr than this TXE supports. Recompile the contract with a compatible version of Aztec.nr.';
+          ? 'The contract was compiled with a newer version of Aztec.nr than this aztec cli version supports. Upgrade your aztec cli version to a compatible version.'
+          : 'The contract was compiled with an older version of Aztec.nr than this aztec cli version supports. Recompile the contract with a compatible version of Aztec.nr.';
       throw new Error(
-        `Incompatible TXE version: ${hint} See https://docs.aztec.network/errors/8 (expected oracle version ${ORACLE_VERSION}, got ${version})`,
+        `Incompatible aztec cli version: ${hint} See https://docs.aztec.network/errors/8 (expected oracle version ${ORACLE_VERSION}, got ${version})`,
       );
     }
   }

--- a/yarn-project/txe/src/oracle/txe_oracle_top_level_context.ts
+++ b/yarn-project/txe/src/oracle/txe_oracle_top_level_context.ts
@@ -120,8 +120,12 @@ export class TXEOracleTopLevelContext implements IMiscOracle, ITxeExecutionOracl
 
   assertCompatibleOracleVersion(version: number): void {
     if (version !== ORACLE_VERSION) {
+      const hint =
+        version > ORACLE_VERSION
+          ? 'The contract was compiled with a newer version of Aztec.nr than this TXE supports. Upgrade your TXE to a compatible version.'
+          : 'The contract was compiled with an older version of Aztec.nr than this TXE supports. Recompile the contract with a compatible version of Aztec.nr.';
       throw new Error(
-        `Incompatible oracle version. TXE is using version '${ORACLE_VERSION}', but got a request for '${version}'.`,
+        `Incompatible TXE version: ${hint} See https://docs.aztec.network/errors/8 (expected oracle version ${ORACLE_VERSION}, got ${version})`,
       );
     }
   }


### PR DESCRIPTION
Changes the error messages thrown when oracle version issues are detected. It deemphasizes the "oracle" wording since that's about internals, and emphasizes that the contract has been compiled with an Aztec.nr version that their PXE doesn't know how to handle. It also adds an error page link where we can document more specifics in the future.

Closes F-486