### PR TITLE
fix: make PXE#getSyncedBlockHeader a concurrency=1 job to prevent IDB tx liveness issues

### DIFF
--- a/yarn-project/pxe/src/pxe.ts
+++ b/yarn-project/pxe/src/pxe.ts
@@ -502,7 +502,9 @@ export class PXE {
    * @returns The synced block header
    */
   public getSyncedBlockHeader(): Promise<BlockHeader> {
-    return this.anchorBlockStore.getBlockHeader();
+    return this.#putInJobQueue(() => {
+      return this.anchorBlockStore.getBlockHeader();
+    });
   }
 
   /**


### PR DESCRIPTION
Follow up from troubleshooting a user app. This app was interacting with PXE in a way that it is not designed to work, but ultimately "protecting" this method by queueing it makes it a bit more robust even when misused.

Closes F-485