### PR TITLE
fix: bot gas estimations

### DIFF
--- a/barretenberg/ts/src/cbind/schema_visitor.ts
+++ b/barretenberg/ts/src/cbind/schema_visitor.ts
@@ -197,6 +197,7 @@ export class SchemaVisitor {
       'unsigned int': 'u32',
       'unsigned short': 'u16',
       'unsigned long': 'u64',
+      'unsigned long long': 'u64',
       'unsigned char': 'u8',
       'double': 'f64',
       'string': 'string',

--- a/yarn-project/bot/src/amm_bot.ts
+++ b/yarn-project/bot/src/amm_bot.ts
@@ -87,7 +87,7 @@ export class AmmBot extends BaseBot {
         authWitnesses: [swapAuthwit],
       });
 
-    const opts = await this.getSendMethodOpts(swapExactTokensInteraction);
+    const opts = this.getSendMethodOpts();
 
     this.log.verbose(`Sending transaction`, logCtx);
     this.log.info(`Tx. Balances: ${jsonStringify(balances)}`, { ...logCtx, balances });

--- a/yarn-project/bot/src/base_bot.ts
+++ b/yarn-project/bot/src/base_bot.ts
@@ -1,5 +1,5 @@
 import { AztecAddress } from '@aztec/aztec.js/addresses';
-import { BatchCall, ContractFunctionInteraction, type SendInteractionOptions } from '@aztec/aztec.js/contracts';
+import { type SendInteractionOptions } from '@aztec/aztec.js/contracts';
 import { createLogger } from '@aztec/aztec.js/log';
 import { waitForTx } from '@aztec/aztec.js/node';
 import { TxHash, TxReceipt, TxStatus } from '@aztec/aztec.js/tx';
@@ -56,27 +56,19 @@ export abstract class BaseBot {
     return Promise.resolve();
   }
 
-  protected async getSendMethodOpts(
-    interaction: ContractFunctionInteraction | BatchCall,
-  ): Promise<SendInteractionOptions> {
+  protected getSendMethodOpts(): SendInteractionOptions {
     const { l2GasLimit, daGasLimit, minFeePadding } = this.config;
 
     this.wallet.setMinFeePadding(minFeePadding);
 
-    let gasSettings;
-    if (l2GasLimit !== undefined && l2GasLimit > 0 && daGasLimit !== undefined && daGasLimit > 0) {
-      gasSettings = { gasLimits: Gas.from({ l2Gas: l2GasLimit, daGas: daGasLimit }) };
-      this.log.verbose(`Using gas limits ${l2GasLimit} L2 gas ${daGasLimit} DA gas`);
-    } else {
-      this.log.verbose(`Estimating gas for transaction`);
-      ({ estimatedGas: gasSettings } = await interaction.simulate({
-        fee: { estimateGas: true },
-        from: this.defaultAccountAddress,
-      }));
-    }
+    const gasSettings =
+      l2GasLimit !== undefined && l2GasLimit > 0 && daGasLimit !== undefined && daGasLimit > 0
+        ? { gasLimits: Gas.from({ l2Gas: l2GasLimit, daGas: daGasLimit }) }
+        : undefined;
+
     return {
       from: this.defaultAccountAddress,
-      fee: { gasSettings },
+      ...(gasSettings ? { fee: { gasSettings } } : {}),
     };
   }
 }

--- a/yarn-project/bot/src/base_bot.ts
+++ b/yarn-project/bot/src/base_bot.ts
@@ -1,5 +1,5 @@
 import { AztecAddress } from '@aztec/aztec.js/addresses';
-import { type SendInteractionOptions } from '@aztec/aztec.js/contracts';
+import type { SendInteractionOptions } from '@aztec/aztec.js/contracts';
 import { createLogger } from '@aztec/aztec.js/log';
 import { waitForTx } from '@aztec/aztec.js/node';
 import { TxHash, TxReceipt, TxStatus } from '@aztec/aztec.js/tx';

--- a/yarn-project/bot/src/bot.ts
+++ b/yarn-project/bot/src/bot.ts
@@ -70,10 +70,7 @@ export class Bot extends BaseBot {
         );
 
     const batch = new BatchCall(wallet, calls);
-    const opts = await this.getSendMethodOpts(batch);
-
-    this.log.verbose(`Simulating transaction with ${calls.length}`, logCtx);
-    await batch.simulate({ from: this.defaultAccountAddress });
+    const opts = this.getSendMethodOpts();
 
     this.log.verbose(`Sending transaction`, logCtx);
     const { txHash } = await batch.send({ ...opts, wait: NO_WAIT });

--- a/yarn-project/bot/src/config.ts
+++ b/yarn-project/bot/src/config.ts
@@ -69,9 +69,9 @@ export type BotConfig = {
   maxPendingTxs: number;
   /** Whether to flush after sending each 'setup' transaction */
   flushSetupTransactions: boolean;
-  /** L2 gas limit for the tx (empty to use default gas limits). */
+  /** L2 gas limit for the tx (empty to let the bot's wallet estimate). */
   l2GasLimit: number | undefined;
-  /** DA gas limit for the tx (empty to use default gas limits). */
+  /** DA gas limit for the tx (empty to let the bot's wallet estimate). */
   daGasLimit: number | undefined;
   /** Token contract to use */
   contract: SupportedTokenContracts;
@@ -243,12 +243,12 @@ export const botConfigMappings: ConfigMappingsType<BotConfig> = {
   },
   l2GasLimit: {
     env: 'BOT_L2_GAS_LIMIT',
-    description: 'L2 gas limit for the tx (empty to use default gas limits).',
+    description: "L2 gas limit for the tx (empty to let the bot's wallet estimate).",
     ...optionalNumberConfigHelper(),
   },
   daGasLimit: {
     env: 'BOT_DA_GAS_LIMIT',
-    description: 'DA gas limit for the tx (empty to use default gas limits).',
+    description: "DA gas limit for the tx (empty to let the bot's wallet estimate).",
     ...optionalNumberConfigHelper(),
   },
   contract: {

--- a/yarn-project/bot/src/config.ts
+++ b/yarn-project/bot/src/config.ts
@@ -69,9 +69,9 @@ export type BotConfig = {
   maxPendingTxs: number;
   /** Whether to flush after sending each 'setup' transaction */
   flushSetupTransactions: boolean;
-  /** L2 gas limit for the tx (empty to have the bot trigger an estimate gas). */
+  /** L2 gas limit for the tx (empty to use default gas limits). */
   l2GasLimit: number | undefined;
-  /** DA gas limit for the tx (empty to have the bot trigger an estimate gas). */
+  /** DA gas limit for the tx (empty to use default gas limits). */
   daGasLimit: number | undefined;
   /** Token contract to use */
   contract: SupportedTokenContracts;
@@ -243,12 +243,12 @@ export const botConfigMappings: ConfigMappingsType<BotConfig> = {
   },
   l2GasLimit: {
     env: 'BOT_L2_GAS_LIMIT',
-    description: 'L2 gas limit for the tx (empty to have the bot trigger an estimate gas).',
+    description: 'L2 gas limit for the tx (empty to use default gas limits).',
     ...optionalNumberConfigHelper(),
   },
   daGasLimit: {
     env: 'BOT_DA_GAS_LIMIT',
-    description: 'DA gas limit for the tx (empty to have the bot trigger an estimate gas).',
+    description: 'DA gas limit for the tx (empty to use default gas limits).',
     ...optionalNumberConfigHelper(),
   },
   contract: {

--- a/yarn-project/bot/src/cross_chain_bot.ts
+++ b/yarn-project/bot/src/cross_chain_bot.ts
@@ -137,7 +137,7 @@ export class CrossChainBot extends BaseBot {
     }
 
     const batch = new BatchCall(this.wallet, calls);
-    const opts = await this.getSendMethodOpts(batch);
+    const opts = this.getSendMethodOpts();
 
     this.log.verbose(`Sending cross-chain batch with ${calls.length} calls`, logCtx);
     const { txHash } = await batch.send({ ...opts, wait: NO_WAIT });

--- a/yarn-project/bot/src/factory.ts
+++ b/yarn-project/bot/src/factory.ts
@@ -29,7 +29,6 @@ import { PrivateTokenContract } from '@aztec/noir-contracts.js/PrivateToken';
 import { TokenContract } from '@aztec/noir-contracts.js/Token';
 import { TestContract } from '@aztec/noir-test-contracts.js/Test';
 import type { ContractInstanceWithAddress } from '@aztec/stdlib/contract';
-import { GasFees, GasSettings } from '@aztec/stdlib/gas';
 import type { AztecNode, AztecNodeAdmin } from '@aztec/stdlib/interfaces/client';
 import { deriveSigningKey } from '@aztec/stdlib/keys';
 import { EmbeddedWallet } from '@aztec/wallets/embedded';
@@ -224,21 +223,14 @@ export class BotFactory {
 
       const paymentMethod = new FeeJuicePaymentMethodWithClaim(accountManager.address, claim);
       const deployMethod = await accountManager.getDeployMethod();
-      const maxFeesPerGas = (await this.aztecNode.getCurrentMinFees()).mul(1 + this.config.minFeePadding);
-
-      const { estimatedGas } = await deployMethod.simulate({
-        from: NO_FROM,
-        fee: { estimateGas: true, paymentMethod },
-      });
-      const gasSettings = GasSettings.from({ ...estimatedGas!, maxFeesPerGas, maxPriorityFeesPerGas: GasFees.empty() });
 
       await this.withNoMinTxsPerBlock(async () => {
         const { txHash } = await deployMethod.send({
           from: NO_FROM,
-          fee: { gasSettings, paymentMethod },
+          fee: { paymentMethod },
           wait: NO_WAIT,
         });
-        this.log.info(`Sent tx for account deployment with hash ${txHash.toString()}`, { gasSettings });
+        this.log.info(`Sent tx for account deployment with hash ${txHash.toString()}`);
         return waitForTx(this.aztecNode, txHash, { timeout: this.config.txMinedWaitSeconds });
       });
       this.log.info(`Account deployed at ${address}`);
@@ -304,9 +296,8 @@ export class BotFactory {
       await deploy.register();
     } else {
       this.log.info(`Deploying token contract at ${address.toString()}`);
-      const { estimatedGas } = await deploy.simulate({ ...deployOpts, fee: { estimateGas: true } });
-      const { txHash } = await deploy.send({ ...deployOpts, fee: { gasSettings: estimatedGas }, wait: NO_WAIT });
-      this.log.info(`Sent tx for token setup with hash ${txHash.toString()}`, { estimatedGas });
+      const { txHash } = await deploy.send({ ...deployOpts, wait: NO_WAIT });
+      this.log.info(`Sent tx for token setup with hash ${txHash.toString()}`);
       await this.withNoMinTxsPerBlock(async () => {
         await waitForTx(this.aztecNode, txHash, { timeout: this.config.txMinedWaitSeconds });
         return token;
@@ -347,18 +338,11 @@ export class BotFactory {
 
     this.log.info(`AMM deployed at ${amm.address}`);
     const setMinterInteraction = lpToken.methods.set_minter(amm.address, true);
-    const { estimatedGas: setMinterGas } = await setMinterInteraction.simulate({
-      from: deployer,
-      fee: { estimateGas: true },
-    });
     const { receipt: minterReceipt } = await setMinterInteraction.send({
       from: deployer,
-      fee: { gasSettings: setMinterGas },
       wait: { timeout: this.config.txMinedWaitSeconds },
     });
-    this.log.info(`Set LP token minter to AMM txHash=${minterReceipt.txHash.toString()}`, {
-      estimatedGas: setMinterGas,
-    });
+    this.log.info(`Set LP token minter to AMM txHash=${minterReceipt.txHash.toString()}`);
     this.log.info(`Liquidity token initialized`);
 
     return amm;
@@ -430,17 +414,12 @@ export class BotFactory {
       token0.methods.mint_to_private(liquidityProvider, MINT_BALANCE),
       token1.methods.mint_to_private(liquidityProvider, MINT_BALANCE),
     ]);
-    const { estimatedGas: mintGas } = await mintBatch.simulate({
-      from: liquidityProvider,
-      fee: { estimateGas: true },
-    });
     const { receipt: mintReceipt } = await mintBatch.send({
       from: liquidityProvider,
-      fee: { gasSettings: mintGas },
       wait: { timeout: this.config.txMinedWaitSeconds },
     });
 
-    this.log.info(`Sent mint tx: ${mintReceipt.txHash.toString()}`, { estimatedGas: mintGas });
+    this.log.info(`Sent mint tx: ${mintReceipt.txHash.toString()}`);
 
     const addLiquidityInteraction = amm.methods.add_liquidity(
       amount0Max,
@@ -449,21 +428,13 @@ export class BotFactory {
       amount1Min,
       authwitNonce,
     );
-    const { estimatedGas: addLiquidityGas } = await addLiquidityInteraction.simulate({
-      from: liquidityProvider,
-      fee: { estimateGas: true },
-      authWitnesses: [token0Authwit, token1Authwit],
-    });
     const { receipt: addLiquidityReceipt } = await addLiquidityInteraction.send({
       from: liquidityProvider,
-      fee: { gasSettings: addLiquidityGas },
       authWitnesses: [token0Authwit, token1Authwit],
       wait: { timeout: this.config.txMinedWaitSeconds },
     });
 
-    this.log.info(`Sent tx to add liquidity to the AMM: ${addLiquidityReceipt.txHash.toString()}`, {
-      estimatedGas: addLiquidityGas,
-    });
+    this.log.info(`Sent tx to add liquidity to the AMM: ${addLiquidityReceipt.txHash.toString()}`);
     this.log.info(`Liquidity added`);
 
     const [newT0Bal, newT1Bal, newLPBal] = await getPrivateBalances();
@@ -484,10 +455,9 @@ export class BotFactory {
       this.log.info(`Contract ${name} at ${address.toString()} already deployed`);
       await deploy.register();
     } else {
-      const { estimatedGas } = await deploy.simulate({ ...deployOpts, fee: { estimateGas: true } });
-      this.log.info(`Deploying contract ${name} at ${address.toString()}`, { estimatedGas });
+      this.log.info(`Deploying contract ${name} at ${address.toString()}`);
       await this.withNoMinTxsPerBlock(async () => {
-        const { txHash } = await deploy.send({ ...deployOpts, fee: { gasSettings: estimatedGas }, wait: NO_WAIT });
+        const { txHash } = await deploy.send({ ...deployOpts, wait: NO_WAIT });
         this.log.info(`Sent contract ${name} setup tx with hash ${txHash.toString()}`);
         return waitForTx(this.aztecNode, txHash, { timeout: this.config.txMinedWaitSeconds });
       });
@@ -532,15 +502,13 @@ export class BotFactory {
     // PrivateToken's mint accesses contract-level private storage vars (admin, total_supply).
     const additionalScopes = isStandardToken ? undefined : [token.address];
     const mintBatch = new BatchCall(token.wallet, calls);
-    const { estimatedGas } = await mintBatch.simulate({ from: minter, fee: { estimateGas: true }, additionalScopes });
     await this.withNoMinTxsPerBlock(async () => {
       const { txHash } = await mintBatch.send({
         from: minter,
         additionalScopes,
-        fee: { gasSettings: estimatedGas },
         wait: NO_WAIT,
       });
-      this.log.info(`Sent token mint tx with hash ${txHash.toString()}`, { estimatedGas });
+      this.log.info(`Sent token mint tx with hash ${txHash.toString()}`);
       return waitForTx(this.aztecNode, txHash, { timeout: this.config.txMinedWaitSeconds });
     });
   }


### PR DESCRIPTION
Now that `EmbeddedWallet` estimates gas on send, these simulations are redundant