### PR TITLE
fix: use llvm-objdump-20 for Mach-O re-signing in version injection

### DIFF
--- a/barretenberg/cpp/bootstrap.sh
+++ b/barretenberg/cpp/bootstrap.sh
@@ -39,7 +39,7 @@ function inject_version {
   # Re-sign after modifying the binary.
   if [[ "$(os)" == "macos" ]]; then
     codesign -s - -f "$binary" 2>/dev/null || true
-  elif llvm-objdump --macho --private-header "$binary" &>/dev/null; then
+  elif llvm-objdump-20 --macho --private-header "$binary" 2>/dev/null | grep -q "Mach header"; then
     ldid -S "$binary"
   fi
 }


### PR DESCRIPTION
## Summary

- macOS release binaries were broken (SIGKILL/exit 137) because `inject_version` in `bootstrap.sh` used `llvm-objdump` (unversioned) to detect Mach-O binaries for re-signing, but the CI environment only has `llvm-objdump-20`
- The detection silently failed (`&>/dev/null`), skipping `ldid -S` re-signing after version injection, leaving binaries with an invalidated linker-signed code signature
- Fix: `llvm-objdump` → `llvm-objdump-20`