### PR TITLE
chore: Fix nightly debug vk check

### DIFF
--- a/barretenberg/cpp/scripts/test_chonk_standalone_vks_havent_changed.sh
+++ b/barretenberg/cpp/scripts/test_chonk_standalone_vks_havent_changed.sh
@@ -1,8 +1,27 @@
 #!/usr/bin/env bash
 source $(git rev-parse --show-toplevel)/ci3/source
 
-# export bb as it is needed when using exported functions
-export bb="$root/barretenberg/cpp/$(./preset-build-dir)/bin/bb"
+# Resolve bb from an explicit preset when provided, and fall back to known build dirs.
+script_dir="$root/barretenberg/cpp/scripts"
+bb_preset="${BB_BUILD_PRESET:-${NATIVE_PRESET:-clang20}}"
+bb_build_dir="$root/barretenberg/cpp/$($script_dir/preset-build-dir "$bb_preset")"
+
+export bb_preset
+
+if [[ -x "$bb_build_dir/bin/bb" ]]; then
+  export bb="$bb_build_dir/bin/bb"
+elif [[ -x "$root/barretenberg/cpp/build-debug/bin/bb" ]]; then
+  export bb="$root/barretenberg/cpp/build-debug/bin/bb"
+elif [[ -x "$root/barretenberg/cpp/build/bin/bb" ]]; then
+  export bb="$root/barretenberg/cpp/build/bin/bb"
+else
+  echo_stderr "Error: Could not find bb binary. Tried:"
+  echo_stderr "  $bb_build_dir/bin/bb (preset: $bb_preset)"
+  echo_stderr "  $root/barretenberg/cpp/build-debug/bin/bb"
+  echo_stderr "  $root/barretenberg/cpp/build/bin/bb"
+  echo_stderr "Set BB_BUILD_PRESET or NATIVE_PRESET to the preset used for your build."
+  exit 1
+fi
 
 # script path to auto update short hash
 script_path="$root/barretenberg/cpp/scripts/test_chonk_standalone_vks_havent_changed.sh"
@@ -55,8 +74,13 @@ function check_circuit_vks {
   local flow_folder="$inputs_dir/$1"
   local output
   local exit_code=0
+  local -a bb_check_args=(check --scheme chonk --ivc_inputs_path "$flow_folder/ivc-inputs.msgpack")
 
-  output=$($bb check --scheme chonk --ivc_inputs_path "$flow_folder/ivc-inputs.msgpack") || exit_code=$?
+  if [[ "$bb_preset" == "debug" ]]; then
+    bb_check_args+=(--disable_asserts)
+  fi
+
+  output=$($bb "${bb_check_args[@]}") || exit_code=$?
 
   if [[ $exit_code -ne 0 ]]; then
     # Check if this is actually a VK change

--- a/barretenberg/cpp/scripts/test_chonk_standalone_vks_havent_changed.sh
+++ b/barretenberg/cpp/scripts/test_chonk_standalone_vks_havent_changed.sh
@@ -4,24 +4,10 @@ source $(git rev-parse --show-toplevel)/ci3/source
 # Resolve bb from an explicit preset when provided, and fall back to known build dirs.
 script_dir="$root/barretenberg/cpp/scripts"
 bb_preset="${BB_BUILD_PRESET:-${NATIVE_PRESET:-clang20}}"
-bb_build_dir="$root/barretenberg/cpp/$($script_dir/preset-build-dir "$bb_preset")"
+bb="$root/barretenberg/cpp/$($script_dir/preset-build-dir "$bb_preset")/bin/bb"
 
 export bb_preset
-
-if [[ -x "$bb_build_dir/bin/bb" ]]; then
-  export bb="$bb_build_dir/bin/bb"
-elif [[ -x "$root/barretenberg/cpp/build-debug/bin/bb" ]]; then
-  export bb="$root/barretenberg/cpp/build-debug/bin/bb"
-elif [[ -x "$root/barretenberg/cpp/build/bin/bb" ]]; then
-  export bb="$root/barretenberg/cpp/build/bin/bb"
-else
-  echo_stderr "Error: Could not find bb binary. Tried:"
-  echo_stderr "  $bb_build_dir/bin/bb (preset: $bb_preset)"
-  echo_stderr "  $root/barretenberg/cpp/build-debug/bin/bb"
-  echo_stderr "  $root/barretenberg/cpp/build/bin/bb"
-  echo_stderr "Set BB_BUILD_PRESET or NATIVE_PRESET to the preset used for your build."
-  exit 1
-fi
+export bb
 
 # script path to auto update short hash
 script_path="$root/barretenberg/cpp/scripts/test_chonk_standalone_vks_havent_changed.sh"

--- a/barretenberg/cpp/src/barretenberg/bb/cli.cpp
+++ b/barretenberg/cpp/src/barretenberg/bb/cli.cpp
@@ -26,6 +26,7 @@
 #include "barretenberg/bbapi/bbapi.hpp"
 #include "barretenberg/bbapi/bbapi_ultra_honk.hpp"
 #include "barretenberg/bbapi/c_bind.hpp"
+#include "barretenberg/common/assert.hpp"
 #include "barretenberg/common/bb_bench.hpp"
 #include "barretenberg/common/get_bytecode.hpp"
 #include "barretenberg/common/thread.hpp"
@@ -310,6 +311,15 @@ int parse_and_run_cli_command(int argc, char* argv[])
             ->group(advanced_group);
     };
 
+    bool disable_asserts = false;
+    const auto add_disable_asserts_flag = [&](CLI::App* subcommand) {
+        return subcommand
+            ->add_flag("--disable_asserts",
+                       disable_asserts,
+                       "Disable BB assertions (asserts become warnings). Not for production use.")
+            ->group(advanced_group);
+    };
+
     const auto add_include_gates_per_opcode_flag = [&](CLI::App* subcommand) {
         return subcommand->add_flag("--include_gates_per_opcode",
                                     flags.include_gates_per_opcode,
@@ -429,6 +439,7 @@ int parse_and_run_cli_command(int argc, char* argv[])
     add_witness_path_option(check);
     add_ivc_inputs_path_options(check);
     add_vk_policy_option(check);
+    add_disable_asserts_flag(check);
 
     /***************************************************************************************************************
      * Subcommand: gates
@@ -982,6 +993,10 @@ int parse_and_run_cli_command(int argc, char* argv[])
                 if (!std::filesystem::exists(ivc_inputs_path)) {
                     throw_or_abort("The check command for Chonk expect a valid file passed with --ivc_inputs_path "
                                    "<ivc-inputs.msgpack> (default ./ivc-inputs.msgpack)");
+                }
+                if (disable_asserts) {
+                    BB_DISABLE_ASSERTS();
+                    return api.check_precomputed_vks(flags, ivc_inputs_path) ? 0 : 1;
                 }
                 return api.check_precomputed_vks(flags, ivc_inputs_path) ? 0 : 1;
             }


### PR DESCRIPTION
The Chonk standalone vk check was failing because:
- The native preset was not used to resolve `bb` (so we were resolving `build/bin/bb` instead of `build-debug/bin/bb`)
- The VK check did not disable asserts (so when checking VKs we would detect mismatches due to the dummy data supplied to build VKs)

This PR fixes the above issues:
- Resolve `bb` using the script `preset-build-dir` with argument `NATIVE_PRESET`
- Add a flag to the `check` command in the bb api that disables asserts when checking vks