### PR TITLE
fix: docs examples does not build on simple bootstrap backport

### DIFF
--- a/docs/bootstrap.sh
+++ b/docs/bootstrap.sh
@@ -44,6 +44,9 @@ function test_cmds {
 
   local test_hash=$hash
   echo "$test_hash cd docs && yarn spellcheck"
+
+  # Delegate to examples for their test commands
+  (cd examples && ./bootstrap.sh test_cmds)
 }
 
 function test {

--- a/docs/examples/.rebuild_patterns
+++ b/docs/examples/.rebuild_patterns
@@ -1,0 +1,3 @@
+^docs/examples/
+^yarn-project/
+^noir-projects/

--- a/docs/examples/bootstrap.sh
+++ b/docs/examples/bootstrap.sh
@@ -11,6 +11,11 @@ export STRIP_AZTEC_NR_PREFIX=${STRIP_AZTEC_NR_PREFIX:-"$REPO_ROOT/noir-projects/
 export BB_HASH=${BB_HASH:-$("$REPO_ROOT/barretenberg/cpp/bootstrap.sh" hash)}
 export NOIR_HASH=${NOIR_HASH:-$("$REPO_ROOT/noir/bootstrap.sh" hash)}
 
+hash=$(hash_str \
+  $BB_HASH \
+  $NOIR_HASH \
+  $(cache_content_hash .rebuild_patterns))
+
 function compile-circuits {
   echo_header "Compiling vanilla Noir circuits"
   local CIRCUITS_DIR="$REPO_ROOT/docs/examples/circuits"
@@ -117,6 +122,15 @@ function execute-examples {
   echo_header "Executing TypeScript documentation examples"
   local COMPOSE_DIR="$REPO_ROOT/docs/examples/ts"
   run_compose_test "docs_examples" "docs-examples" "$COMPOSE_DIR"
+}
+
+function test_cmds {
+  echo "$hash:ONLY_TERM_PARENT=1 docs/examples/bootstrap.sh execute"
+}
+
+function test {
+  echo_header "docs examples test"
+  test_cmds | filter_test_cmds | parallelize
 }
 
 ##############################################################################
@@ -246,7 +260,6 @@ case "$cmd" in
     run_step "Compile (Noir contracts)" compile
     run_step "Compile (Solidity)" compile-solidity
     run_step "TypeScript validation" validate-ts
-    run_step "Execute examples" execute-examples
 
     if [[ ${#FAILED_STEPS[@]} -gt 0 ]]; then
       send_failure_slack_message
@@ -278,6 +291,9 @@ case "$cmd" in
         exit 1
       fi
     fi
+    ;;
+  "hash")
+    echo "$hash"
     ;;
   compile-circuits)
     compile-circuits


### PR DESCRIPTION
title