### PR TITLE
fix: add pull-requests write permission to ci-external workflow

### DIFF
--- a/.github/workflows/ci3-external.yml
+++ b/.github/workflows/ci3-external.yml
@@ -22,6 +22,9 @@ jobs:
     runs-on: ubuntu-latest
     # exclusive with ci3.yml, only run on forks.
     if: github.event.pull_request.head.repo.fork
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683


### PR DESCRIPTION
## Summary
- The `ci-external` workflow fails with `Resource not accessible by integration (removeLabelsFromLabelable)` because `github.token` defaults to read-only when no `permissions` block is set.
- Adds `contents: read` + `pull-requests: write` to the `ci-external` job so `gh pr edit --remove-label "ci-external-once"` can succeed.

## Context
- Safe because the workflow uses `pull_request_target` (code always from base branch, not fork) and is gated by a maintainer adding the `ci-external` / `ci-external-once` label.
- Matches the pattern used by other label-modifying workflows in the repo (e.g., `merge-train-create-pr`, `auto-close-stale-drafts`).
- Fixes the CI failure seen on external PRs like #21885.