### PR TITLE
fix: add rc/testnet version detection to API reference pages

### DIFF
--- a/docs/developer_versioned_docs/version-v4.1.0-rc.2/docs/aztec-js/typescript_api_reference.mdx
+++ b/docs/developer_versioned_docs/version-v4.1.0-rc.2/docs/aztec-js/typescript_api_reference.mdx
@@ -14,6 +14,7 @@ export const useApiVersion = () => {
   if (versionName === "current") return "next";
   if (versionName.includes("nightly")) return "nightly";
   if (versionName.includes("devnet")) return "devnet";
+  if (versionName.includes("rc") || versionName.includes("testnet")) return "testnet";
   return versionName;
 };
 

--- a/docs/developer_versioned_docs/version-v4.1.0-rc.2/docs/aztec-nr/api.mdx
+++ b/docs/developer_versioned_docs/version-v4.1.0-rc.2/docs/aztec-nr/api.mdx
@@ -16,6 +16,7 @@ export const useApiVersion = () => {
   if (versionName === "current") return "next";
   if (versionName.includes("nightly")) return "nightly";
   if (versionName.includes("devnet")) return "devnet";
+  if (versionName.includes("rc") || versionName.includes("testnet")) return "testnet";
   return versionName;
 };
 

--- a/docs/docs-developers/docs/aztec-js/typescript_api_reference.mdx
+++ b/docs/docs-developers/docs/aztec-js/typescript_api_reference.mdx
@@ -14,6 +14,7 @@ export const useApiVersion = () => {
   if (versionName === "current") return "next";
   if (versionName.includes("nightly")) return "nightly";
   if (versionName.includes("devnet")) return "devnet";
+  if (versionName.includes("rc") || versionName.includes("testnet")) return "testnet";
   return versionName;
 };
 

--- a/docs/docs-developers/docs/aztec-nr/api.mdx
+++ b/docs/docs-developers/docs/aztec-nr/api.mdx
@@ -16,6 +16,7 @@ export const useApiVersion = () => {
   if (versionName === "current") return "next";
   if (versionName.includes("nightly")) return "nightly";
   if (versionName.includes("devnet")) return "devnet";
+  if (versionName.includes("rc") || versionName.includes("testnet")) return "testnet";
   return versionName;
 };
 


### PR DESCRIPTION
## Summary
- Adds handling for `rc` and `testnet` version names in the `useApiVersion` hook across API reference pages
- Without this, rc/testnet versioned docs fell through to the default case instead of resolving to `"testnet"`

## Test plan
- [ ] Verify API reference pages load correctly for rc-versioned docs
- [ ] Verify API reference pages load correctly for testnet-versioned docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)