### PR TITLE
fix: verify accumulated pairing points in native ChonkVerifier (v4 backport)

### DIFF
--- a/barretenberg/cpp/src/barretenberg/chonk/chonk_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/chonk/chonk_verifier.cpp
@@ -27,6 +27,12 @@ template <> ChonkVerifier<false>::Output ChonkVerifier<false>::verify(const Proo
     HidingKernelIO kernel_io;
     kernel_io.reconstruct_from_public(verifier.get_public_inputs());
 
+    // Check accumulated pairing points from the IVC chain (inner recursive verifications)
+    if (!kernel_io.pairing_inputs.check()) {
+        info("ChonkVerifier: verification failed at PI pairing points check");
+        return false;
+    }
+
     // Step 2: Perform databus consistency check
     const Commitment calldata_commitment = verifier.get_calldata_commitment();
     const Commitment return_data_commitment = kernel_io.kernel_return_data;


### PR DESCRIPTION
## Summary

- Backport of 50ba735e73 to v4
- Native `ChonkVerifier::verify` was missing `kernel_io.pairing_inputs.check()` — the accumulated pairing points from inner recursive verifications
- The recursive verifier already included this check; the native verifier did not
- Adds the missing check for parity between native and recursive verification paths