### PR TITLE
fix(p2p): evict expired failed-auth-handshake entries on heartbeat

### DIFF
--- a/yarn-project/p2p/src/services/peer-manager/peer_manager.test.ts
+++ b/yarn-project/p2p/src/services/peer-manager/peer_manager.test.ts
@@ -1887,6 +1887,39 @@ describe('PeerManager', () => {
       expect(failedHandshakes.get(peerIdStr).count).toBe(2);
     });
 
+    it('should clean up expired failed-auth entries during heartbeat', async () => {
+      const peerId = await createSecp256k1PeerId();
+      const peerIdStr = peerId.toString();
+      const ipAddress = '10.0.0.1';
+
+      const mockConnection = {
+        remotePeer: peerId,
+        remoteAddr: {
+          nodeAddress: () => ({ address: ipAddress }),
+        },
+      };
+      mockLibP2PNode.getConnections.mockReturnValue([mockConnection]);
+
+      // Exceed the threshold so the peer is blocked
+      for (let i = 0; i < 4; i++) {
+        (peerManager as any).markAuthHandshakeFailed(peerId);
+      }
+
+      expect(peerManager.isNodeAllowedToConnect(peerIdStr)).toBe(false);
+      expect(peerManager.isNodeAllowedToConnect(ipAddress)).toBe(false);
+
+      // Advance time past expiry (1 hour + 1 minute)
+      jest.advanceTimersByTime(61 * 60 * 1000);
+
+      // Trigger heartbeat — should proactively clean up stale entries without needing
+      // isNodeAllowedToConnect to be called first for each peer
+      await peerManager.heartbeat();
+
+      const failedHandshakes = (peerManager as any).failedAuthHandshakes;
+      expect(failedHandshakes.has(peerIdStr)).toBe(false);
+      expect(failedHandshakes.has(ipAddress)).toBe(false);
+    });
+
     it('should handle auth failure during actual handshake process', async () => {
       jest.useRealTimers(); // needed here to allow sleep couple of lines below
       const peerId = await createSecp256k1PeerId();

--- a/yarn-project/p2p/src/services/peer-manager/peer_manager.ts
+++ b/yarn-project/p2p/src/services/peer-manager/peer_manager.ts
@@ -226,18 +226,28 @@ export class PeerManager implements PeerManagerInterface {
   }
 
   /**
-   * Cleans up expired timeouts.
+   * Cleans up expired timeouts and stale failed-auth-handshake entries.
    *
    * When peers fail to dial after a number of retries, they are temporarily timed out.
    * This function removes any peers that have been in the timed out state for too long.
    * To give them a chance to reconnect.
+   *
+   * Also evicts entries from the failed-auth-handshake map whose expiry window has passed.
+   * Without this, peers that probe once and never reconnect would leave their entries in the
+   * map forever, causing an unbounded memory leak.
    */
   private cleanupExpiredTimeouts() {
-    // Clean up expired timeouts
     const now = this.dateProvider.now();
+
     for (const [peerId, timedOutPeer] of this.timedOutPeers.entries()) {
       if (now >= timedOutPeer.timeoutUntilMs) {
         this.timedOutPeers.delete(peerId);
+      }
+    }
+
+    for (const [id, entry] of this.failedAuthHandshakes.entries()) {
+      if (now - entry.lastFailureTimestamp > FAILED_AUTH_HANDSHAKE_EXPIRY_MS) {
+        this.failedAuthHandshakes.delete(id);
       }
     }
   }


### PR DESCRIPTION
The `failedAuthHandshakes` map accumulates entries for every peer/IP that fails the auth handshake. The only existing cleanup was lazy (triggered when that specific peer calls `isNodeAllowedToConnect` again) or on success. Peers that probe once and disappear leave entries that grow the map forever.

Fix: extend `cleanupExpiredTimeouts()` — already called on every heartbeat — to also evict entries from `failedAuthHandshakes` whose expiry window (`FAILED_AUTH_HANDSHAKE_EXPIRY_MS` = 1 hour) has passed.

Fixes [A-759](https://linear.app/aztec-labs/issue/A-759/audit-90-memory-leak-in-auth-handshake-failed-handshake-state-never)

Made with [Cursor](https://cursor.com)