### PR TITLE
refactor(aztec-nr): remove storage from init_test_contract

### DIFF
--- a/noir-projects/noir-contracts/contracts/test/init_test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/init_test_contract/src/main.nr
@@ -4,17 +4,8 @@ use aztec::macros::aztec;
 
 #[aztec]
 pub contract InitTest {
-    use aztec::macros::{
-        functions::{external, initializer, noinitcheck, only_self, view},
-        storage::storage,
-    };
+    use aztec::macros::functions::{external, initializer, noinitcheck, only_self, view};
     use aztec::protocol::address::AztecAddress;
-    use aztec::state_vars::{Map, PublicMutable};
-
-    #[storage]
-    struct Storage<Context> {
-        public_values: Map<AztecAddress, PublicMutable<Field, Context>, Context>,
-    }
 
     #[external("private")]
     #[initializer]
@@ -64,19 +55,17 @@ pub contract InitTest {
     fn priv_no_init_check(owner: AztecAddress, value: Field) {}
 
     #[external("public")]
-    fn pub_init_check(owner: AztecAddress, value: Field) {
-        self.storage.public_values.at(owner).write(value);
-    }
+    fn pub_init_check(owner: AztecAddress, value: Field) {}
 
     #[external("public")]
     #[noinitcheck]
     #[view]
     fn pub_no_init_check(owner: AztecAddress) -> pub Field {
-        self.storage.public_values.at(owner).read()
+        1
     }
 
     #[external("utility")]
     unconstrained fn utility_init_check(owner: AztecAddress) -> Field {
-        self.storage.public_values.at(owner).read()
+        2
     }
 }

--- a/yarn-project/end-to-end/src/e2e_deploy_contract/private_initialization.test.ts
+++ b/yarn-project/end-to-end/src/e2e_deploy_contract/private_initialization.test.ts
@@ -153,10 +153,8 @@ describe('e2e_deploy_contract private initialization', () => {
     const { contract, initArgs } = await deployUninitialized();
     const owner = defaultAccountAddress;
     await contract.methods.constructor(...initArgs).send({ from: defaultAccountAddress });
-    // Write a value via public function so the utility function has something to read.
-    await contract.methods.pub_init_check(owner, 84).send({ from: defaultAccountAddress });
     const result = await contract.methods.utility_init_check(owner).simulate({ from: defaultAccountAddress });
-    expect(result.result).toEqual(84n);
+    expect(result.result).toEqual(2n);
   });
 
   // A public call enqueued before the private constructor should fail the init check, even though the
@@ -180,7 +178,7 @@ describe('e2e_deploy_contract private initialization', () => {
     ]);
     await batch.send({ from: defaultAccountAddress });
     expect((await contract.methods.pub_no_init_check(owner).simulate({ from: defaultAccountAddress })).result).toEqual(
-      84n,
+      1n,
     );
   });
 


### PR DESCRIPTION
## Summary

- **init_test_contract/src/main.nr**: removed `Storage` struct and `PublicMutable`/`Map` usage since the contract only tests initialization checks (revert vs no-revert), not storage behavior
- Functions now return unique field values (`pub_no_init_check` returns `1`, `utility_init_check` returns `2`) instead of reading from storage
- **private_initialization.test.ts**: updated expectations to match the new return values

Followup from https://github.com/AztecProtocol/aztec-packages/pull/21751#discussion_r2986093003