### PR TITLE
fix(p2p): check peer rate limit before global to prevent quota starvation

### DIFF
--- a/yarn-project/p2p/src/services/reqresp/rate-limiter/rate_limiter.test.ts
+++ b/yarn-project/p2p/src/services/reqresp/rate-limiter/rate_limiter.test.ts
@@ -156,6 +156,27 @@ describe('rate limiter', () => {
     multiProtocolRateLimiter.stop();
   });
 
+  it('Should not consume global quota when a peer is denied', () => {
+    // peer1 has a limit of 5/s; peer2 is a different peer
+    const spammingPeer = makePeer('spammer');
+    const legitimatePeer = makePeer('legit');
+
+    // Exhaust spammingPeer's per-peer quota (5 requests)
+    for (let i = 0; i < 5; i++) {
+      expect(rateLimiter.allow(ReqRespSubProtocol.TX, spammingPeer)).toBe(RateLimitStatus.Allowed);
+    }
+
+    // All further spammer requests are denied at the peer level
+    // With the bug, each of these would also consume a global token
+    for (let i = 0; i < 9; i++) {
+      expect(rateLimiter.allow(ReqRespSubProtocol.TX, spammingPeer)).toBe(RateLimitStatus.DeniedPeer);
+    }
+
+    // The legitimate peer should still be allowed: the global quota (10/s) must not
+    // have been consumed by the spammer's peer-denied requests
+    expect(rateLimiter.allow(ReqRespSubProtocol.TX, legitimatePeer)).toBe(RateLimitStatus.Allowed);
+  });
+
   it('Should allow requests if no rate limiter is configured', () => {
     const rateLimiter = new RequestResponseRateLimiter(peerScoring, {} as ReqRespSubProtocolRateLimits);
     expect(rateLimiter.allow(ReqRespSubProtocol.TX, makePeer('peer1'))).toBe(RateLimitStatus.Allowed);

--- a/yarn-project/p2p/src/services/reqresp/rate-limiter/rate_limiter.ts
+++ b/yarn-project/p2p/src/services/reqresp/rate-limiter/rate_limiter.ts
@@ -97,9 +97,10 @@ export function prettyPrintRateLimitStatus(status: RateLimitStatus) {
  * 2. Individual rate limits for each peer.
  *
  * How it works:
- * - When a request comes in, it first checks against the global rate limit.
- * - If the global limit allows, it then checks against the specific peer's rate limit.
- * - The request is only allowed if both the global and peer-specific limits allow it.
+ * - When a request comes in, it first checks against the peer's individual rate limit.
+ * - If the peer limit allows, it then checks against the global rate limit.
+ * - The request is only allowed if both the peer-specific and global limits allow it.
+ * - Checking peer limit first ensures a rate-limited peer cannot exhaust the global quota.
  * - It automatically creates and manages rate limiters for new peers as they make requests.
  * - It periodically cleans up rate limiters for inactive peers to conserve memory.
  *
@@ -119,10 +120,6 @@ export class SubProtocolRateLimiter {
   }
 
   allow(peerId: PeerId): RateLimitStatus {
-    if (!this.globalLimiter.allow()) {
-      return RateLimitStatus.DeniedGlobal;
-    }
-
     const peerIdStr = peerId.toString();
     let peerLimiter: PeerRateLimiter | undefined = this.peerLimiters.get(peerIdStr);
     if (!peerLimiter) {
@@ -135,10 +132,17 @@ export class SubProtocolRateLimiter {
     } else {
       peerLimiter.lastAccess = Date.now();
     }
-    const peerLimitAllowed = peerLimiter.limiter.allow();
-    if (!peerLimitAllowed) {
+
+    // Check peer limit first: a rate-limited peer must not consume global quota,
+    // otherwise one spamming peer can starve all others by exhausting the global bucket.
+    if (!peerLimiter.limiter.allow()) {
       return RateLimitStatus.DeniedPeer;
     }
+
+    if (!this.globalLimiter.allow()) {
+      return RateLimitStatus.DeniedGlobal;
+    }
+
     return RateLimitStatus.Allowed;
   }
 


### PR DESCRIPTION
## Summary

In `SubProtocolRateLimiter.allow()`, the global rate limiter was checked first. `GCRARateLimiter.allow()` advances its virtual scheduling time (VST) as a side effect whenever it returns `true`, so a request that passed the global check but failed the per-peer check would silently consume a global quota token. A single spamming peer could therefore exhaust the global rate limit, starving all other peers on that sub-protocol.

Fix: check the per-peer limit first. A peer that exceeds its individual quota is rejected immediately, without touching the shared global bucket.

Fixes [A-758](https://linear.app/aztec-labs/issue/A-758)

Made with [Cursor](https://cursor.com)