### PR TITLE
fix: unbounded memory in calldataRetriever

### DIFF
--- a/yarn-project/archiver/src/l1/calldata_retriever.ts
+++ b/yarn-project/archiver/src/l1/calldata_retriever.ts
@@ -1,6 +1,7 @@
 import { MULTI_CALL_3_ADDRESS, type ViemCommitteeAttestations, type ViemHeader } from '@aztec/ethereum/contracts';
 import type { ViemPublicClient, ViemPublicDebugClient } from '@aztec/ethereum/types';
 import { CheckpointNumber } from '@aztec/foundation/branded-types';
+import { LruSet } from '@aztec/foundation/collection';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import type { Logger } from '@aztec/foundation/log';
@@ -44,7 +45,7 @@ type CheckpointData = {
  */
 export class CalldataRetriever {
   /** Tx hashes we've already logged for trace+debug failure (log once per tx per process). */
-  private static readonly traceFailureWarnedTxHashes = new Set<string>();
+  private static readonly traceFailureWarnedTxHashes = new LruSet<string>(1000);
 
   /** Clears the trace-failure warned set. For testing only. */
   static resetTraceFailureWarnedForTesting(): void {

--- a/yarn-project/foundation/src/collection/index.ts
+++ b/yarn-project/foundation/src/collection/index.ts
@@ -1,2 +1,3 @@
 export * from './array.js';
+export * from './lru_set.js';
 export * from './object.js';

--- a/yarn-project/foundation/src/collection/lru_set.test.ts
+++ b/yarn-project/foundation/src/collection/lru_set.test.ts
@@ -1,0 +1,131 @@
+import { LruSet } from './lru_set.js';
+
+describe('LruSet', () => {
+  it('stores and retrieves items', () => {
+    const set = new LruSet<string>(3);
+    set.add('a');
+    set.add('b');
+    expect(set.has('a')).toBe(true);
+    expect(set.has('b')).toBe(true);
+    expect(set.has('c')).toBe(false);
+  });
+
+  it('reports correct size', () => {
+    const set = new LruSet<number>(5);
+    expect(set.size).toBe(0);
+    set.add(1);
+    expect(set.size).toBe(1);
+    set.add(2);
+    set.add(3);
+    expect(set.size).toBe(3);
+  });
+
+  it('does not grow beyond maxSize', () => {
+    const set = new LruSet<number>(3);
+    set.add(1);
+    set.add(2);
+    set.add(3);
+    set.add(4);
+    expect(set.size).toBe(3);
+    expect(set.has(1)).toBe(false); // evicted (least recent)
+    expect(set.has(2)).toBe(true);
+    expect(set.has(3)).toBe(true);
+    expect(set.has(4)).toBe(true);
+  });
+
+  it('evicts least recently used, not least recently added', () => {
+    const set = new LruSet<string>(3);
+    set.add('a');
+    set.add('b');
+    set.add('c');
+
+    // Access 'a' via has(), making it the most recently used
+    expect(set.has('a')).toBe(true);
+
+    // Now 'b' is the least recently used. Adding 'd' should evict 'b'.
+    set.add('d');
+    expect(set.has('b')).toBe(false); // evicted
+    expect(set.has('a')).toBe(true); // kept (was refreshed)
+    expect(set.has('c')).toBe(true);
+    expect(set.has('d')).toBe(true);
+  });
+
+  it('refreshes recency on add() of existing item', () => {
+    const set = new LruSet<string>(3);
+    set.add('a');
+    set.add('b');
+    set.add('c');
+
+    // Re-add 'a', refreshing its recency
+    set.add('a');
+
+    // 'b' is now least recent. Adding 'd' should evict 'b'.
+    set.add('d');
+    expect(set.has('b')).toBe(false); // evicted
+    expect(set.has('a')).toBe(true);
+    expect(set.size).toBe(3);
+  });
+
+  it('does not duplicate on add() of existing item', () => {
+    const set = new LruSet<number>(5);
+    set.add(1);
+    set.add(2);
+    set.add(1);
+    set.add(1);
+    expect(set.size).toBe(2);
+  });
+
+  it('clears all entries', () => {
+    const set = new LruSet<number>(5);
+    set.add(1);
+    set.add(2);
+    set.add(3);
+    set.clear();
+    expect(set.size).toBe(0);
+    expect(set.has(1)).toBe(false);
+    expect(set.has(2)).toBe(false);
+    expect(set.has(3)).toBe(false);
+  });
+
+  it('works correctly after clear and re-add', () => {
+    const set = new LruSet<string>(2);
+    set.add('a');
+    set.add('b');
+    set.clear();
+    set.add('c');
+    set.add('d');
+    expect(set.size).toBe(2);
+    expect(set.has('a')).toBe(false);
+    expect(set.has('c')).toBe(true);
+    expect(set.has('d')).toBe(true);
+  });
+
+  it('works with maxSize of 1', () => {
+    const set = new LruSet<number>(1);
+    set.add(1);
+    expect(set.has(1)).toBe(true);
+    set.add(2);
+    expect(set.has(1)).toBe(false);
+    expect(set.has(2)).toBe(true);
+    expect(set.size).toBe(1);
+  });
+
+  it('throws on invalid maxSize', () => {
+    expect(() => new LruSet<number>(0)).toThrow('LruSet maxSize must be at least 1');
+    expect(() => new LruSet<number>(-1)).toThrow('LruSet maxSize must be at least 1');
+  });
+
+  it('handles sequential evictions correctly', () => {
+    const set = new LruSet<number>(3);
+    // Fill to capacity
+    for (let i = 0; i < 3; i++) {
+      set.add(i);
+    }
+    // Evict each one in FIFO order (no access refreshes)
+    for (let i = 3; i < 10; i++) {
+      set.add(i);
+      expect(set.size).toBe(3);
+      expect(set.has(i - 3)).toBe(false); // oldest was evicted
+    }
+  });
+});

--- a/yarn-project/foundation/src/collection/lru_set.ts
+++ b/yarn-project/foundation/src/collection/lru_set.ts
@@ -1,0 +1,115 @@
+/** Node in a doubly-linked list used by {@link LruSet}. */
+type LruNode<T> = {
+  value: T;
+  prev: LruNode<T> | undefined;
+  next: LruNode<T> | undefined;
+};
+
+/**
+ * A bounded set with Least Recently Used (LRU) eviction.
+ * Both {@link has} and {@link add} count as an access and refresh the entry's
+ * recency, so items that are actively checked stay in the set longest.
+ *
+ * Uses a doubly-linked list for O(1) ordering and a Map for O(1) lookup.
+ * Head = least recent, tail = most recent.
+ */
+export class LruSet<T> {
+  /** Map from value to its linked-list node for O(1) lookup. */
+  private readonly map = new Map<T, LruNode<T>>();
+  private head: LruNode<T> | undefined;
+  private tail: LruNode<T> | undefined;
+
+  constructor(private readonly maxSize: number) {
+    if (maxSize < 1) {
+      throw new Error('LruSet maxSize must be at least 1');
+    }
+  }
+
+  /** Number of entries in the set. */
+  get size(): number {
+    return this.map.size;
+  }
+
+  /**
+   * Returns true if the item is in the set.
+   * Refreshes the item's recency so it becomes the most recently used.
+   */
+  has(item: T): boolean {
+    const node = this.map.get(item);
+    if (!node) {
+      return false;
+    }
+    this.moveToTail(node);
+    return true;
+  }
+
+  /**
+   * Adds an item to the set. If the item already exists, refreshes its recency.
+   * If the set is at capacity, evicts the least recently used item.
+   */
+  add(item: T): void {
+    const existing = this.map.get(item);
+    if (existing) {
+      this.moveToTail(existing);
+      return;
+    }
+
+    if (this.map.size >= this.maxSize) {
+      this.evictHead();
+    }
+
+    const node: LruNode<T> = { value: item, prev: this.tail, next: undefined };
+    if (this.tail) {
+      this.tail.next = node;
+    } else {
+      this.head = node;
+    }
+    this.tail = node;
+    this.map.set(item, node);
+  }
+
+  /** Removes all entries from the set. */
+  clear(): void {
+    this.map.clear();
+    this.head = undefined;
+    this.tail = undefined;
+  }
+
+  /** Unlinks a node from its current position and relinks it at the tail. */
+  private moveToTail(node: LruNode<T>): void {
+    if (node === this.tail) {
+      return;
+    }
+
+    // Unlink
+    if (node.prev) {
+      node.prev.next = node.next;
+    } else {
+      this.head = node.next;
+    }
+    if (node.next) {
+      node.next.prev = node.prev;
+    }
+
+    // Relink at tail
+    node.prev = this.tail;
+    node.next = undefined;
+    if (this.tail) {
+      this.tail.next = node;
+    }
+    this.tail = node;
+  }
+
+  /** Evicts the head (least recently used) node. */
+  private evictHead(): void {
+    const oldHead = this.head!;
+    this.map.delete(oldHead.value);
+
+    this.head = oldHead.next;
+    if (this.head) {
+      this.head.prev = undefined;
+    } else {
+      this.tail = undefined;
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Fix unbounded memory leak in `CalldataRetriever.traceFailureWarnedTxHashes` (audit finding A-685). The static `Set<string>` tracking L1 tx hashes that failed trace/debug RPC decoding grew without bound in long-running archiver nodes.
- Introduce a new `LruSet<T>` utility in `foundation/src/collection/` — a bounded set with LRU eviction using a doubly-linked list + Map for O(1) operations. Both `has()` and `add()` refresh recency, so actively-checked hashes stay cached while stale ones get evicted.
- Replace the unbounded `Set<string>` with `LruSet<string>(1000)` in the archiver. No new npm dependencies, no logic changes to the call site — the `LruSet` API is a drop-in replacement.

## Test plan

- 11 new unit tests for `LruSet` covering basic operations, eviction, LRU refresh semantics, edge cases (maxSize=1), and clear/re-add behavior
- All 55 existing `calldata_retriever.test.ts` tests pass unchanged, including the "warn once per tx hash" test
- Build, lint, and format verified

Fixes A-685

