### PR TITLE
fix(p2p): remove disconnected peers from scoring maps

### DIFF
--- a/yarn-project/p2p/src/services/peer-manager/peer_manager.ts
+++ b/yarn-project/p2p/src/services/peer-manager/peer_manager.ts
@@ -313,15 +313,20 @@ export class PeerManager implements PeerManagerInterface {
    */
   private handleDisconnectedPeerEvent(e: CustomEvent<PeerId>) {
     const peerId = e.detail;
+    const peerIdStr = peerId.toString();
     this.metrics.peerDisconnected(peerId);
-    this.logger.verbose(`Disconnected from peer ${peerId.toString()}`);
-    const validatorAddress = this.authenticatedPeerIdToValidatorAddress.get(peerId.toString());
+    this.logger.verbose(`Disconnected from peer ${peerIdStr}`);
+    const validatorAddress = this.authenticatedPeerIdToValidatorAddress.get(peerIdStr);
     if (validatorAddress !== undefined) {
       this.logger.info(
-        `Removing authentication for validator ${validatorAddress} at peer id ${peerId.toString()} due to disconnection`,
+        `Removing authentication for validator ${validatorAddress} at peer id ${peerIdStr} due to disconnection`,
       );
       this.authenticatedValidatorAddressToPeerId.delete(validatorAddress.toString());
-      this.authenticatedPeerIdToValidatorAddress.delete(peerId.toString());
+      this.authenticatedPeerIdToValidatorAddress.delete(peerIdStr);
+    }
+
+    if (this.peerScoring.getScoreState(peerIdStr) === PeerScoreState.Healthy) {
+      this.peerScoring.removePeer(peerIdStr);
     }
   }
 

--- a/yarn-project/p2p/src/services/peer-manager/peer_scoring.test.ts
+++ b/yarn-project/p2p/src/services/peer-manager/peer_scoring.test.ts
@@ -138,4 +138,31 @@ describe('PeerScoring', () => {
     // -60 * (0.9^10) ≈ -23.2, which is above the Disconnect threshold
     expect(peerScoring.getScoreState(testPeerId)).toBe(PeerScoreState.Healthy);
   });
+
+  test('removePeer should delete all score data for a peer', () => {
+    peerScoring.updateScore(testPeerId, -30);
+    expect(peerScoring.getScore(testPeerId)).toBe(-30);
+
+    peerScoring.removePeer(testPeerId);
+    expect(peerScoring.getScore(testPeerId)).toBe(0);
+    expect(peerScoring.getScoreState(testPeerId)).toBe(PeerScoreState.Healthy);
+  });
+
+  test('decayAllScores should remove entries that have decayed to near-zero', () => {
+    peerScoring.updateScore(testPeerId, -2);
+    peerScoring.updateScore('otherPeer', -100);
+
+    // Advance enough time for the small score to decay below threshold
+    // -2 * 0.9^50 ≈ -0.01, which is below 0.1
+    jest.advanceTimersByTime(50 * 60 * 1000);
+    peerScoring.decayAllScores();
+
+    // Small score should be cleaned up
+    expect(peerScoring.getScore(testPeerId)).toBe(0);
+    // Large score should still exist (decayed but still significant)
+    expect(peerScoring.getScore('otherPeer')).not.toBe(0);
+
+    const stats = peerScoring.getStats();
+    expect(stats.healthyCount).toBe(1);
+  });
 });

--- a/yarn-project/p2p/src/services/peer-manager/peer_scoring.ts
+++ b/yarn-project/p2p/src/services/peer-manager/peer_scoring.ts
@@ -54,6 +54,7 @@ export enum PeerScoreState {
 // TODO: move into config / constants
 const MIN_SCORE_BEFORE_BAN = -100;
 const MIN_SCORE_BEFORE_DISCONNECT = -50;
+const SCORE_CLEANUP_THRESHOLD = 0.1;
 
 export class PeerScoring {
   private logger = createLogger('p2p:peer-scoring');
@@ -118,10 +119,20 @@ export class PeerScoring {
       if (decayPeriods > 0) {
         let score = this.scores.get(peerId) || 0;
         score *= Math.pow(this.decayFactor, decayPeriods);
-        this.scores.set(peerId, score);
-        this.lastUpdateTime.set(peerId, currentTime);
+        if (Math.abs(score) < SCORE_CLEANUP_THRESHOLD) {
+          this.scores.delete(peerId);
+          this.lastUpdateTime.delete(peerId);
+        } else {
+          this.scores.set(peerId, score);
+          this.lastUpdateTime.set(peerId, currentTime);
+        }
       }
     }
+  }
+
+  removePeer(peerId: string): void {
+    this.scores.delete(peerId);
+    this.lastUpdateTime.delete(peerId);
   }
 
   getScore(peerId: string): number {


### PR DESCRIPTION
## Summary

- Fix memory leak in `PeerScoring` where the `scores` and `lastUpdateTime` maps grow unboundedly because entries for penalized peers are never removed after disconnect
- Add cleanup in `decayAllScores()` to prune entries once `|score|` decays below 0.1 (functionally zero)
- Add `removePeer()` method and call it from `handleDisconnectedPeerEvent` for peers in healthy score state, cleaning up immediately on disconnect
- Penalized (unhealthy) peers retain their score entries until decay completes, so they can't bypass penalties by reconnecting

Fixes [A-728](https://linear.app/aztec-labs/issue/A-728/audit-52-memory-leak-in-peer-scoring-disconnected-peers-never-removed)

### Tests

- Added unit test for `removePeer` verifying score data is fully deleted
- Added unit test for `decayAllScores` verifying near-zero entries are pruned while significant entries are retained
- All 14 peer scoring tests pass

Made with [Cursor](https://cursor.com)