### PR TITLE
chore: disable flaky docs/examples execute test

### DIFF
--- a/docs/examples/bootstrap.sh
+++ b/docs/examples/bootstrap.sh
@@ -128,7 +128,10 @@ function execute-examples {
 }
 
 function test_cmds {
-  echo "$hash:ONLY_TERM_PARENT=1 docs/examples/bootstrap.sh execute"
+  # Disabled: timing out on merge queue (~600s), blocked on proving block 64.
+  # See http://ci.aztec-labs.com/aabf2c7e271636a0
+  # echo "$hash:ONLY_TERM_PARENT=1 docs/examples/bootstrap.sh execute"
+  echo ""
 }
 
 function test {


### PR DESCRIPTION
## Summary
- Comments out the `docs/examples/bootstrap.sh execute` test, which has been timing out repeatedly on merge queue
- The test has timed out 3+ times on merge queue today, always stuck at "proven: 63, needed: 64"
- Even passing runs take 594-598s against a 600s timeout
- CI log: http://ci.aztec-labs.com/aabf2c7e271636a0

## Test plan
- No functional change; only disables a flaky CI test