### PR TITLE
chore: re-enable docs/examples execute test, disable only aave_bridge

### DIFF
--- a/docs/examples/bootstrap.sh
+++ b/docs/examples/bootstrap.sh
@@ -128,10 +128,7 @@ function execute-examples {
 }
 
 function test_cmds {
-  # Disabled: timing out on merge queue (~600s), blocked on proving block 64.
-  # See http://ci.aztec-labs.com/aabf2c7e271636a0
-  # echo "$hash:ONLY_TERM_PARENT=1 docs/examples/bootstrap.sh execute"
-  echo ""
+  echo "$hash:ONLY_TERM_PARENT=1 docs/examples/bootstrap.sh execute"
 }
 
 function test {

--- a/docs/examples/ts/aztecjs_runner/run.sh
+++ b/docs/examples/ts/aztecjs_runner/run.sh
@@ -176,7 +176,9 @@ cleanup_project() {
 # Note: bob_token_contract and other custom contract examples require verification keys
 # which aren't generated during docs compilation, so they're not included by default
 if [ $# -eq 0 ]; then
-    EXAMPLES=("aztecjs_connection" "aztecjs_getting_started" "aztecjs_advanced" "aztecjs_authwit" "aztecjs_testing" "example_swap" "aave_bridge" "recursive_verification")
+    # aave_bridge disabled: timing out on merge queue (~600s), blocked on proving block 64.
+    # See http://ci.aztec-labs.com/aabf2c7e271636a0
+    EXAMPLES=("aztecjs_connection" "aztecjs_getting_started" "aztecjs_advanced" "aztecjs_authwit" "aztecjs_testing" "example_swap" "recursive_verification")
 else
     EXAMPLES=()
     for arg in "$@"; do


### PR DESCRIPTION
## Summary
- Re-enables the docs/examples execute test that was fully disabled in #22013
- Removes only `aave_bridge` from the default examples list — it was timing out (~600s) blocked on proving block 64
- All other examples continue to run in CI

See http://ci.aztec-labs.com/aabf2c7e271636a0 for the original failure.