### PR TITLE
fix(sequencer): use last L1 slot of L2 slot as eth_simulateV1 timestamp

### DIFF
--- a/yarn-project/end-to-end/src/e2e_l1_publisher/e2e_l1_publisher.test.ts
+++ b/yarn-project/end-to-end/src/e2e_l1_publisher/e2e_l1_publisher.test.ts
@@ -786,7 +786,6 @@ describe('L1Publisher integration', () => {
       await publisher.enqueueGovernanceCastSignal(
         l1ContractAddresses.rollupAddress,
         block.slot,
-        block.timestamp,
         EthAddress.random(),
         (_payload: any) => Promise.resolve(Signature.random().toString()),
       );

--- a/yarn-project/sequencer-client/src/publisher/sequencer-publisher.test.ts
+++ b/yarn-project/sequencer-client/src/publisher/sequencer-publisher.test.ts
@@ -222,7 +222,6 @@ describe('SequencerPublisher', () => {
       await publisher.enqueueGovernanceCastSignal(
         govPayload,
         SlotNumber(2),
-        1n,
         EthAddress.fromString(testHarnessAttesterAccount.address),
         msg => testHarnessAttesterAccount.signTypedData(msg),
       ),
@@ -589,7 +588,6 @@ describe('SequencerPublisher', () => {
       await publisher.enqueueGovernanceCastSignal(
         govPayload,
         SlotNumber(2),
-        1n,
         EthAddress.fromString(testHarnessAttesterAccount.address),
         msg => testHarnessAttesterAccount.signTypedData(msg),
       ),
@@ -604,7 +602,6 @@ describe('SequencerPublisher', () => {
       await publisher.enqueueGovernanceCastSignal(
         govPayload,
         SlotNumber(2),
-        1n,
         EthAddress.fromString(testHarnessAttesterAccount.address),
         msg => testHarnessAttesterAccount.signTypedData(msg),
       ),
@@ -619,7 +616,6 @@ describe('SequencerPublisher', () => {
       await publisher.enqueueGovernanceCastSignal(
         govPayload,
         SlotNumber(2),
-        1n,
         EthAddress.fromString(testHarnessAttesterAccount.address),
         msg => testHarnessAttesterAccount.signTypedData(msg),
       ),
@@ -634,7 +630,6 @@ describe('SequencerPublisher', () => {
       await publisher.enqueueGovernanceCastSignal(
         govPayload,
         SlotNumber(2),
-        1n,
         EthAddress.fromString(testHarnessAttesterAccount.address),
         msg => testHarnessAttesterAccount.signTypedData(msg),
       ),
@@ -648,7 +643,6 @@ describe('SequencerPublisher', () => {
     await publisher.enqueueGovernanceCastSignal(
       govPayload,
       SlotNumber(2),
-      1n,
       EthAddress.fromString(testHarnessAttesterAccount.address),
       msg => testHarnessAttesterAccount.signTypedData(msg),
     );
@@ -656,7 +650,6 @@ describe('SequencerPublisher', () => {
     await publisher.enqueueGovernanceCastSignal(
       govPayload,
       SlotNumber(3),
-      2n,
       EthAddress.fromString(testHarnessAttesterAccount.address),
       msg => testHarnessAttesterAccount.signTypedData(msg),
     );
@@ -675,7 +668,6 @@ describe('SequencerPublisher', () => {
       await publisher.enqueueGovernanceCastSignal(
         govPayload,
         SlotNumber(2),
-        1n,
         EthAddress.fromString(testHarnessAttesterAccount.address),
         msg => testHarnessAttesterAccount.signTypedData(msg),
       ),
@@ -690,7 +682,6 @@ describe('SequencerPublisher', () => {
       await publisher.enqueueGovernanceCastSignal(
         govPayload,
         SlotNumber(2),
-        1n,
         EthAddress.fromString(testHarnessAttesterAccount.address),
         msg => testHarnessAttesterAccount.signTypedData(msg),
       ),
@@ -706,7 +697,6 @@ describe('SequencerPublisher', () => {
       await publisher.enqueueGovernanceCastSignal(
         govPayload,
         SlotNumber(2),
-        1n,
         EthAddress.fromString(testHarnessAttesterAccount.address),
         msg => testHarnessAttesterAccount.signTypedData(msg),
       ),
@@ -717,7 +707,6 @@ describe('SequencerPublisher', () => {
       await publisher.enqueueGovernanceCastSignal(
         govPayload,
         SlotNumber(3),
-        2n,
         EthAddress.fromString(testHarnessAttesterAccount.address),
         msg => testHarnessAttesterAccount.signTypedData(msg),
       ),

--- a/yarn-project/sequencer-client/src/publisher/sequencer-publisher.ts
+++ b/yarn-project/sequencer-client/src/publisher/sequencer-publisher.ts
@@ -42,7 +42,7 @@ import { EmpireBaseAbi, ErrorsAbi, RollupAbi } from '@aztec/l1-artifacts';
 import { type ProposerSlashAction, encodeSlashConsensusVotes } from '@aztec/slasher';
 import { CommitteeAttestationsAndSigners, type ValidateCheckpointResult } from '@aztec/stdlib/block';
 import type { Checkpoint } from '@aztec/stdlib/checkpoint';
-import { getNextL1SlotTimestamp } from '@aztec/stdlib/epoch-helpers';
+import { getLastL1SlotTimestampForL2Slot, getNextL1SlotTimestamp } from '@aztec/stdlib/epoch-helpers';
 import { SlashFactoryContract } from '@aztec/stdlib/l1-contracts';
 import type { CheckpointHeader } from '@aztec/stdlib/rollup';
 import type { L1PublishCheckpointStats } from '@aztec/stdlib/stats';
@@ -656,7 +656,7 @@ export class SequencerPublisher {
       flags,
     ] as const;
 
-    const ts = this.getNextL1SlotTimestamp();
+    const ts = this.getSimulationTimestamp(header.slotNumber);
     const stateOverrides = await this.rollupContract.makePendingCheckpointNumberOverride(
       opts?.forcePendingCheckpointNumber,
     );
@@ -679,7 +679,7 @@ export class SequencerPublisher {
         data: encodeFunctionData({ abi: RollupAbi, functionName: 'validateHeaderWithAttestations', args }),
         from: MULTI_CALL_3_ADDRESS,
       },
-      { time: ts + 1n },
+      { time: ts },
       stateOverrides,
     );
     this.log.debug(`Simulated validateHeader`);
@@ -820,15 +820,7 @@ export class SequencerPublisher {
     attestationsAndSigners: CommitteeAttestationsAndSigners,
     attestationsAndSignersSignature: Signature,
     options: { forcePendingCheckpointNumber?: CheckpointNumber },
-  ): Promise<bigint> {
-    // When pipelining, the checkpoint targets the next slot so its timestamp is in the future.
-    // Without pipelining, the checkpoint targets the current slot so its timestamp is in the past
-    // by the time we simulate (~24s of build time), causing eth_simulateV1 to reject it.
-    // In that case, use the latest L1 block timestamp + one ethereum slot, which is just ahead
-    // of L1 and still within the same L2 slot.
-    const ts = this.epochCache.isProposerPipeliningEnabled()
-      ? checkpoint.header.timestamp
-      : (await this.l1TxUtils.getBlock()).timestamp + this.ethereumSlotDuration;
+  ): Promise<void> {
     const blobFields = checkpoint.toBlobFields();
     const blobs = await getBlobsPerL1Block(blobFields);
     const blobInput = getPrefixedEthBlobCommitments(blobs);
@@ -847,13 +839,11 @@ export class SequencerPublisher {
       blobInput,
     ] as const;
 
-    await this.simulateProposeTx(args, ts, options);
-    return ts;
+    await this.simulateProposeTx(args, options);
   }
 
   private async enqueueCastSignalHelper(
     slotNumber: SlotNumber,
-    timestamp: bigint,
     signalType: GovernanceSignalAction,
     payload: EthAddress,
     base: IEmpireBase,
@@ -932,13 +922,17 @@ export class SequencerPublisher {
     });
 
     const l1BlockNumber = await this.l1TxUtils.getBlockNumber();
+    const timestamp = this.getSimulationTimestamp(slotNumber);
 
     try {
       await this.l1TxUtils.simulate(request, { time: timestamp }, [], mergeAbis([request.abi ?? [], ErrorsAbi]));
       this.log.debug(`Simulation for ${action} at slot ${slotNumber} succeeded`, { request });
     } catch (err) {
       const viemError = formatViemError(err);
-      this.log.error(`Failed simulation for ${action} at slot ${slotNumber} (enqueuing the action anyway)`, viemError);
+      this.log.error(`Failed simulation for ${action} at slot ${slotNumber} (enqueuing the action anyway)`, viemError, {
+        simulationTimestamp: timestamp,
+        l1BlockNumber,
+      });
       this.backupFailedTx({
         id: keccak256(request.data!),
         failureType: 'simulation',
@@ -1001,19 +995,16 @@ export class SequencerPublisher {
   /**
    * Enqueues a governance castSignal transaction to cast a signal for a given slot number.
    * @param slotNumber - The slot number to cast a signal for.
-   * @param timestamp - The timestamp of the slot to cast a signal for.
    * @returns True if the signal was successfully enqueued, false otherwise.
    */
   public enqueueGovernanceCastSignal(
     governancePayload: EthAddress,
     slotNumber: SlotNumber,
-    timestamp: bigint,
     signerAddress: EthAddress,
     signer: (msg: TypedDataDefinition) => Promise<`0x${string}`>,
   ): Promise<boolean> {
     return this.enqueueCastSignalHelper(
       slotNumber,
-      timestamp,
       'governance-signal',
       governancePayload,
       this.govProposerContract,
@@ -1026,7 +1017,6 @@ export class SequencerPublisher {
   public async enqueueSlashingActions(
     actions: ProposerSlashAction[],
     slotNumber: SlotNumber,
-    timestamp: bigint,
     signerAddress: EthAddress,
     signer: (msg: TypedDataDefinition) => Promise<`0x${string}`>,
   ): Promise<boolean> {
@@ -1047,7 +1037,6 @@ export class SequencerPublisher {
           });
           await this.enqueueCastSignalHelper(
             slotNumber,
-            timestamp,
             'empire-slashing-signal',
             action.payload,
             this.slashingProposerContract,
@@ -1066,7 +1055,6 @@ export class SequencerPublisher {
             (receipt: TransactionReceipt) =>
               !!this.slashFactoryContract.tryExtractSlashPayloadCreatedEvent(receipt.logs),
             slotNumber,
-            timestamp,
           );
           break;
         }
@@ -1084,7 +1072,6 @@ export class SequencerPublisher {
             request,
             (receipt: TransactionReceipt) => !!empireSlashingProposer.tryExtractPayloadSubmittedEvent(receipt.logs),
             slotNumber,
-            timestamp,
           );
           break;
         }
@@ -1108,7 +1095,6 @@ export class SequencerPublisher {
             request,
             (receipt: TransactionReceipt) => !!tallySlashingProposer.tryExtractVoteCastEvent(receipt.logs),
             slotNumber,
-            timestamp,
           );
           break;
         }
@@ -1130,7 +1116,6 @@ export class SequencerPublisher {
             request,
             (receipt: TransactionReceipt) => !!tallySlashingProposer.tryExtractRoundExecutedEvent(receipt.logs),
             slotNumber,
-            timestamp,
           );
           break;
         }
@@ -1166,15 +1151,13 @@ export class SequencerPublisher {
       feeAssetPriceModifier: checkpoint.feeAssetPriceModifier,
     };
 
-    let ts: bigint;
-
     try {
       // @note  This will make sure that we are passing the checks for our header ASSUMING that the data is also made available
       //        This means that we can avoid the simulation issues in later checks.
       //        By simulation issue, I mean the fact that the block.timestamp is equal to the last block, not the next, which
       //        make time consistency checks break.
       // TODO(palla): Check whether we're validating twice, once here and once within addProposeTx, since we call simulateProposeTx in both places.
-      ts = await this.validateCheckpointForSubmission(
+      await this.validateCheckpointForSubmission(
         checkpoint,
         attestationsAndSigners,
         attestationsAndSignersSignature,
@@ -1190,7 +1173,7 @@ export class SequencerPublisher {
     }
 
     this.log.verbose(`Enqueuing checkpoint propose transaction`, { ...checkpoint.toCheckpointInfo(), ...opts });
-    await this.addProposeTx(checkpoint, proposeTxArgs, opts, ts);
+    await this.addProposeTx(checkpoint, proposeTxArgs, opts);
   }
 
   public enqueueInvalidateCheckpoint(
@@ -1233,8 +1216,8 @@ export class SequencerPublisher {
     request: L1TxRequest,
     checkSuccess: (receipt: TransactionReceipt) => boolean | undefined,
     slotNumber: SlotNumber,
-    timestamp: bigint,
   ) {
+    const timestamp = this.getSimulationTimestamp(slotNumber);
     const logData = { slotNumber, timestamp, gasLimit: undefined as bigint | undefined };
     if (this.lastActions[action] && this.lastActions[action] === slotNumber) {
       this.log.debug(`Skipping duplicate action ${action} for slot ${slotNumber}`);
@@ -1250,8 +1233,9 @@ export class SequencerPublisher {
 
     let gasUsed: bigint;
     const simulateAbi = mergeAbis([request.abi ?? [], ErrorsAbi]);
+
     try {
-      ({ gasUsed } = await this.l1TxUtils.simulate(request, { time: timestamp }, [], simulateAbi)); // TODO(palla/slash): Check the timestamp logic
+      ({ gasUsed } = await this.l1TxUtils.simulate(request, { time: timestamp }, [], simulateAbi));
       this.log.verbose(`Simulation for ${action} succeeded`, { ...logData, request, gasUsed });
     } catch (err) {
       const viemError = formatViemError(err, simulateAbi);
@@ -1320,7 +1304,6 @@ export class SequencerPublisher {
 
   private async prepareProposeTx(
     encodedData: L1ProcessArgs,
-    timestamp: bigint,
     options: { forcePendingCheckpointNumber?: CheckpointNumber },
   ) {
     const kzg = Blob.getViemKzgInstance();
@@ -1393,7 +1376,7 @@ export class SequencerPublisher {
       blobInput,
     ] as const;
 
-    const { rollupData, simulationResult } = await this.simulateProposeTx(args, timestamp, options);
+    const { rollupData, simulationResult } = await this.simulateProposeTx(args, options);
 
     return { args, blobEvaluationGas, rollupData, simulationResult };
   }
@@ -1401,7 +1384,6 @@ export class SequencerPublisher {
   /**
    * Simulates the propose tx with eth_simulateV1
    * @param args - The propose tx args
-   * @param timestamp - The timestamp to simulate proposal at
    * @returns The simulation result
    */
   private async simulateProposeTx(
@@ -1418,7 +1400,6 @@ export class SequencerPublisher {
       ViemSignature,
       `0x${string}`,
     ],
-    timestamp: bigint,
     options: { forcePendingCheckpointNumber?: CheckpointNumber },
   ) {
     const rollupData = encodeFunctionData({
@@ -1453,6 +1434,7 @@ export class SequencerPublisher {
     }
 
     const l1BlockNumber = await this.l1TxUtils.getBlockNumber();
+    const simTs = this.getSimulationTimestamp(SlotNumber.fromBigInt(args[0].header.slotNumber));
 
     const simulationResult = await this.l1TxUtils
       .simulate(
@@ -1463,8 +1445,7 @@ export class SequencerPublisher {
           ...(this.proposerAddressForSimulation && { from: this.proposerAddressForSimulation.toString() }),
         },
         {
-          // @note we add 1n to the timestamp because geth implementation doesn't like simulation timestamp to be equal to the current block timestamp
-          time: timestamp + 1n,
+          time: simTs,
           // @note reth should have a 30m gas limit per block but throws errors that this tx is beyond limit so we increase here
           gasLimit: MAX_L1_TX_LIMIT * 2n,
         },
@@ -1486,7 +1467,7 @@ export class SequencerPublisher {
             logs: [],
           };
         }
-        this.log.error(`Failed to simulate propose tx`, viemError);
+        this.log.error(`Failed to simulate propose tx`, viemError, { simulationTimestamp: simTs });
         this.backupFailedTx({
           id: keccak256(rollupData),
           failureType: 'simulation',
@@ -1509,16 +1490,11 @@ export class SequencerPublisher {
     checkpoint: Checkpoint,
     encodedData: L1ProcessArgs,
     opts: { txTimeoutAt?: Date; forcePendingCheckpointNumber?: CheckpointNumber } = {},
-    timestamp: bigint,
   ): Promise<void> {
     const slot = checkpoint.header.slotNumber;
     const timer = new Timer();
     const kzg = Blob.getViemKzgInstance();
-    const { rollupData, simulationResult, blobEvaluationGas } = await this.prepareProposeTx(
-      encodedData,
-      timestamp,
-      opts,
-    );
+    const { rollupData, simulationResult, blobEvaluationGas } = await this.prepareProposeTx(encodedData, opts);
     const startBlock = await this.l1TxUtils.getBlockNumber();
     const gasLimit = this.l1TxUtils.bumpGasLimit(
       BigInt(Math.ceil((Number(simulationResult.gasUsed) * 64) / 63)) +
@@ -1595,7 +1571,14 @@ export class SequencerPublisher {
     });
   }
 
-  /** Returns the timestamp to use when simulating L1 proposal calls */
+  /** Returns the timestamp of the last L1 slot within a given L2 slot. Used as the simulation timestamp
+   * for eth_simulateV1 calls, since it's guaranteed to be greater than any L1 block produced during the slot. */
+  private getSimulationTimestamp(slot: SlotNumber): bigint {
+    const l1Constants = this.epochCache.getL1Constants();
+    return getLastL1SlotTimestampForL2Slot(slot, l1Constants);
+  }
+
+  /** Returns the timestamp of the next L1 slot boundary after now. */
   private getNextL1SlotTimestamp(): bigint {
     const l1Constants = this.epochCache.getL1Constants();
     return getNextL1SlotTimestamp(this.dateProvider.nowInSeconds(), l1Constants);

--- a/yarn-project/sequencer-client/src/sequencer/checkpoint_voter.ha.integration.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/checkpoint_voter.ha.integration.test.ts
@@ -294,6 +294,7 @@ describe('CheckpointVoter HA Integration', () => {
       nowMs: BigInt(Date.now()),
     });
     epochCache.getSlotNow.mockReturnValue(slot);
+    epochCache.getL1Constants.mockReturnValue(TEST_L1_CONSTANTS as any);
 
     const slashFactoryContract = mock<SlashFactoryContract>();
 

--- a/yarn-project/sequencer-client/src/sequencer/checkpoint_voter.ts
+++ b/yarn-project/sequencer-client/src/sequencer/checkpoint_voter.ts
@@ -2,7 +2,6 @@ import type { SlotNumber } from '@aztec/foundation/branded-types';
 import type { EthAddress } from '@aztec/foundation/eth-address';
 import type { Logger } from '@aztec/foundation/log';
 import type { SlasherClientInterface } from '@aztec/slasher';
-import { getTimestampForSlot } from '@aztec/stdlib/epoch-helpers';
 import type { ResolvedSequencerConfig } from '@aztec/stdlib/interfaces/server';
 import type { ValidatorClient } from '@aztec/validator-client';
 import { DutyAlreadySignedError } from '@aztec/validator-ha-signer/errors';
@@ -18,7 +17,6 @@ import type { SequencerRollupConstants } from './types.js';
  * Handles governance and slashing voting for a given slot.
  */
 export class CheckpointVoter {
-  private slotTimestamp: bigint;
   private governanceSigner: (msg: TypedDataDefinition) => Promise<`0x${string}`>;
   private slashingSigner: (msg: TypedDataDefinition) => Promise<`0x${string}`>;
 
@@ -33,8 +31,6 @@ export class CheckpointVoter {
     private readonly metrics: SequencerMetrics,
     private readonly log: Logger,
   ) {
-    this.slotTimestamp = getTimestampForSlot(this.slot, this.l1Constants);
-
     // Create separate signers with appropriate duty contexts for governance and slashing votes
     // These use HA protection to ensure only one node signs per slot/duty
     const governanceContext: SigningContext = { slot: this.slot, dutyType: DutyType.GOVERNANCE_VOTE };
@@ -77,7 +73,6 @@ export class CheckpointVoter {
       return await this.publisher.enqueueGovernanceCastSignal(
         governanceProposerPayload,
         this.slot,
-        this.slotTimestamp,
         this.attestorAddress,
         this.governanceSigner,
       );
@@ -108,13 +103,7 @@ export class CheckpointVoter {
 
       this.metrics.recordSlashingAttempt(actions.length);
 
-      return await this.publisher.enqueueSlashingActions(
-        actions,
-        this.slot,
-        this.slotTimestamp,
-        this.attestorAddress,
-        this.slashingSigner,
-      );
+      return await this.publisher.enqueueSlashingActions(actions, this.slot, this.attestorAddress, this.slashingSigner);
     } catch (err) {
       if (err instanceof DutyAlreadySignedError) {
         this.log.info(`Slashing vote already signed by another node`, {

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.test.ts
@@ -668,7 +668,6 @@ describe('sequencer', () => {
       expect(publisher.enqueueGovernanceCastSignal).toHaveBeenCalledWith(
         governancePayload,
         SlotNumber(1),
-        expect.any(BigInt),
         expect.any(EthAddress),
         expect.any(Function),
       );

--- a/yarn-project/stdlib/src/epoch-helpers/index.test.ts
+++ b/yarn-project/stdlib/src/epoch-helpers/index.test.ts
@@ -1,6 +1,11 @@
-import { EpochNumber } from '@aztec/foundation/branded-types';
+import { EpochNumber, SlotNumber } from '@aztec/foundation/branded-types';
 
-import { type L1RollupConstants, getProofSubmissionDeadlineTimestamp, getTimestampRangeForEpoch } from './index.js';
+import {
+  type L1RollupConstants,
+  getLastL1SlotTimestampForL2Slot,
+  getProofSubmissionDeadlineTimestamp,
+  getTimestampRangeForEpoch,
+} from './index.js';
 
 describe('EpochHelpers', () => {
   let constants: Omit<L1RollupConstants, 'l1StartBlock'>;
@@ -33,5 +38,15 @@ describe('EpochHelpers', () => {
   it('returns proof submission deadline', () => {
     const deadline = getProofSubmissionDeadlineTimestamp(EpochNumber.fromBigInt(3n), constants);
     expect(deadline).toEqual(l1GenesisTime + BigInt(24 * 4 * 3) + BigInt(24 * 8));
+  });
+
+  it('returns last L1 slot timestamp for L2 slot', () => {
+    // L2 slot 0 starts at l1GenesisTime, lasts 24s with 12s L1 slots, so last L1 slot is at +12
+    const ts = getLastL1SlotTimestampForL2Slot(SlotNumber(0), constants);
+    expect(ts).toEqual(l1GenesisTime + BigInt(24 - 12));
+
+    // L2 slot 5 starts at l1GenesisTime + 5*24 = +120, last L1 slot at +120+12 = +132
+    const ts2 = getLastL1SlotTimestampForL2Slot(SlotNumber(5), constants);
+    expect(ts2).toEqual(l1GenesisTime + BigInt(5 * 24 + 24 - 12));
   });
 });

--- a/yarn-project/stdlib/src/epoch-helpers/index.ts
+++ b/yarn-project/stdlib/src/epoch-helpers/index.ts
@@ -68,6 +68,14 @@ export function getNextL1SlotTimestamp(
   return constants.l1GenesisTime + (currentL1Slot + 1n) * BigInt(constants.ethereumSlotDuration);
 }
 
+/** Returns the timestamp of the last L1 slot within a given L2 slot. */
+export function getLastL1SlotTimestampForL2Slot(
+  slot: SlotNumber,
+  constants: Pick<L1RollupConstants, 'l1GenesisTime' | 'slotDuration' | 'ethereumSlotDuration'>,
+): bigint {
+  return getTimestampForSlot(slot, constants) + BigInt(constants.slotDuration - constants.ethereumSlotDuration);
+}
+
 /** Returns the L2 slot number at the next L1 block based on the current timestamp. */
 export function getSlotAtNextL1Block(
   currentL1Timestamp: bigint,


### PR DESCRIPTION
## Motivation

All `eth_simulateV1` calls in the sequencer publisher use a `blockOverrides.time` to set the simulated block's timestamp. The EVM requires this timestamp to be **strictly greater** than the parent block's timestamp, and since the simulation defaults to building on top of the latest L1 block (`latest`), the override must always be ahead of the current L1 chain tip. This required hacks like always adding one second to the simulation timestamp.

This caused the bug `block timestamps must be in order: 1774258537 <= 1774258560` that broke next-net after https://github.com/AztecProtocol/aztec-packages/pull/21853. With pipelining disabled, we were using the slot timestamp as simulation timestamp, which was already way older than the current L1 timestamp. It was fixed by https://github.com/AztecProtocol/aztec-packages/pull/21888 by rolling back to flooring the simulation timestamp with the current L1 timestamp. However, we'd want to avoid querying the L1 current timestamp unnecessarily, especially since it can lead to issues on missed L1 blocks (see https://github.com/AztecProtocol/aztec-packages/pull/21769 for context).

## Approach

Use the timestamp of the **last L1 slot within the L2 slot** as the simulation timestamp. This is computed as `slotStart + slotDuration - ethereumSlotDuration` and is deterministic, always in the future relative to any L1 block produced during the slot, and works identically for both pipelining and non-pipelining modes. This eliminates the need for wall-clock-based timestamps, L1 block fetches, `+1n` hacks, and pipelining branches.

A new helper `getLastL1SlotTimestampForL2Slot` is added to `stdlib/epoch-helpers`. Each simulate call site now computes the timestamp internally from the slot number available in its context, removing the need to thread `timestamp` parameters through the call chain.

## Changes

- **stdlib/epoch-helpers**: Added `getLastL1SlotTimestampForL2Slot(slot, constants)` helper with unit tests
- **sequencer-client/publisher**: Unified all 5 `eth_simulateV1` call sites to use `getSimulationTimestamp(slot)`. Removed `+1n` hacks, pipelining branches, and L1 block fetch fallback. Removed now-unused `timestamp` parameters from `enqueueCastSignalHelper`, `enqueueGovernanceCastSignal`, `enqueueSlashingActions`, `simulateAndEnqueueRequest`, `validateCheckpointForSubmission` (return type changed to `void`), `addProposeTx`, `prepareProposeTx`, and `simulateProposeTx`. Added `simulationTimestamp` to failure log context.
- **sequencer-client/checkpoint_voter**: Removed unused `slotTimestamp` field and `getTimestampForSlot` import
- **sequencer-client (tests)**, **end-to-end (tests)**: Updated call sites to match new signatures