### PR TITLE
refactor: remove aztec dependency from aztec_sublib

### DIFF
--- a/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/Nargo.toml
+++ b/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/Nargo.toml
@@ -3,5 +3,4 @@ name = "aztec_sublib"
 type = "lib"
 
 [dependencies]
-aztec = { path = "../../../../aztec-nr/aztec" }
 protocol_types = { path = "../../../../noir-protocol-circuits/crates/types" }

--- a/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/oracle/mod.nr
+++ b/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/oracle/mod.nr
@@ -16,5 +16,4 @@ pub mod logs;
 // here from protocol_types.
 pub use protocol_types::logging;
 
-// version oracle is defined in aztec-nr and re-exported here as re-defining versions is not practical.
-pub use aztec::oracle::version;
+pub mod version;

--- a/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/oracle/version.nr
+++ b/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/oracle/version.nr
@@ -1,0 +1,38 @@
+/// The ORACLE_VERSION constant is used to check that the oracle interface is in sync between PXE and Aztec.nr. We need
+/// to version the oracle interface to ensure that developers get a reasonable error message if they use incompatible
+/// versions of Aztec.nr and PXE. The TypeScript counterpart is in `oracle_version.ts`.
+///
+/// @dev Whenever a contract function or Noir test is run, the `aztec_utl_assertCompatibleOracleVersion` oracle is
+/// called and if the oracle version is incompatible an error is thrown.
+pub global ORACLE_VERSION: Field = 21;
+
+/// Asserts that the version of the oracle is compatible with the version expected by the contract.
+pub fn assert_compatible_oracle_version() {
+    // Safety: This oracle call returns nothing: we only call it to check Aztec.nr and Oracle interface versions are
+    // compatible. It is therefore always safe to call.
+    unsafe {
+        assert_compatible_oracle_version_wrapper();
+    }
+}
+
+unconstrained fn assert_compatible_oracle_version_wrapper() {
+    assert_compatible_oracle_version_oracle(ORACLE_VERSION);
+}
+
+#[oracle(aztec_utl_assertCompatibleOracleVersion)]
+unconstrained fn assert_compatible_oracle_version_oracle(version: Field) {}
+
+mod test {
+    use super::{assert_compatible_oracle_version_oracle, ORACLE_VERSION};
+
+    #[test]
+    unconstrained fn compatible_oracle_version() {
+        assert_compatible_oracle_version_oracle(ORACLE_VERSION);
+    }
+
+    #[test(should_fail_with = "Incompatible aztec cli version:")]
+    unconstrained fn incompatible_oracle_version() {
+        let arbitrary_incorrect_version = 318183437;
+        assert_compatible_oracle_version_oracle(arbitrary_incorrect_version);
+    }
+}


### PR DESCRIPTION
Reverting [bad decision of mine](https://github.com/AztecProtocol/aztec-packages/pull/21533#discussion_r2948490973) from a while ago.

## Summary
- Copies the version oracle into `aztec_sublib` so it no longer depends on the `aztec` (aztecnr) crate
- Removes the `aztec` dependency from `aztec_sublib/Nargo.toml`
- Makes `aztec_sublib` fully independent, allowing it to be audited and versioned separately from aztecnr

Resolves https://linear.app/aztec-labs/issue/F-466/extract-oracles-mod-specifically-for-aztec-sublib

## Test plan
- [x] `nargo check --package fee_juice_contract` compiles successfully
- [x] No remaining `aztec::` imports in aztec_sublib

🤖 Generated with [Claude Code](https://claude.com/claude-code)