### PR TITLE
chore: drop dead legacy oracle mappings

### DIFF
--- a/yarn-project/pxe/src/contract_function_simulator/oracle/legacy_oracle_mappings.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/legacy_oracle_mappings.ts
@@ -84,20 +84,11 @@ export function buildLegacyOracleCallbacks(oracle: Oracle): ACIRCallback {
       secret: ACVMField[],
     ): Promise<(ACVMField | ACVMField[])[]> =>
       oracle.aztec_utl_getL1ToL2MembershipWitness(contractAddress, messageHash, secret),
-    utilityEmitOffchainEffect: (data: ACVMField[]): Promise<ACVMField[]> => oracle.aztec_utl_emitOffchainEffect(data),
     // Renames (same signature, different oracle name)
     privateNotifySetMinRevertibleSideEffectCounter: (counter: ACVMField[]): Promise<ACVMField[]> =>
       oracle.aztec_prv_notifyRevertiblePhaseStart(counter),
-    privateIsSideEffectCounterRevertible: (sideEffectCounter: ACVMField[]): Promise<ACVMField[]> =>
-      oracle.aztec_prv_isExecutionInRevertiblePhase(sideEffectCounter),
     // Signature changes: old 4-param oracles → new 1-param validatePublicCalldata
     privateNotifyEnqueuedPublicFunctionCall: (
-      _contractAddress: ACVMField[],
-      calldataHash: ACVMField[],
-      _sideEffectCounter: ACVMField[],
-      _isStaticCall: ACVMField[],
-    ): Promise<ACVMField[]> => oracle.aztec_prv_assertValidPublicCalldata(calldataHash),
-    privateNotifySetPublicTeardownFunctionCall: (
       _contractAddress: ACVMField[],
       calldataHash: ACVMField[],
       _sideEffectCounter: ACVMField[],


### PR DESCRIPTION
Dropping unused legacy oracle mappings.

I think the first 2 below got in because `SponsoredFPC` used to be pinned and then it was unpinned. Not sure about `utilityEmitOffchainEffect` but it's not in any pinned contract bytecode (the bytecode contains full source code).

The backport PR is [here](https://github.com/AztecProtocol/aztec-packages/pull/22035) - created the backport manually as I wanted to see if tests actually pass on `v4-next`. So if you approve this one please approve the backport as well.

## Summary
- Remove 3 legacy oracle mappings that are not called by any pinned v4 protocol contract:
  - `privateIsSideEffectCounterRevertible`
  - `privateNotifySetPublicTeardownFunctionCall`
  - `utilityEmitOffchainEffect`
- Verified by decoding the Brillig bytecode from the pinned protocol contract artifacts on v4-next — none of these oracle names appear in any of the 6 pinned contracts.

## Test plan
- CI passes (no functional change — these mappings were dead code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)