### PR TITLE
fix(spartan): add preStartScript to blob-sink to fetch bootstrap nodes

### DIFF
--- a/spartan/terraform/deploy-aztec-infra/values/blob-sink.yaml
+++ b/spartan/terraform/deploy-aztec-infra/values/blob-sink.yaml
@@ -3,6 +3,17 @@ node:
   env:
     OTEL_SERVICE_NAME: "blob-sink"
 
+  preStartScript: |
+    if [ -n "${BOOT_NODE_HOST:-}" ]; then
+      until curl --silent --head --fail "${BOOT_NODE_HOST}/status" > /dev/null; do
+        echo "Waiting for boot node..."
+        sleep 1
+      done
+      echo "Boot node is ready!"
+
+      export BOOTSTRAP_NODES=$(curl -X POST -H "content-type: application/json" --data '{"method": "bootstrap_getEncodedEnr"}' $BOOT_NODE_HOST | jq -r .result)
+    fi
+
   startCmd:
     - --node
     - --archiver


### PR DESCRIPTION
## Summary
- The blob-sink deployment was missing the `preStartScript` that fetches the bootstrap ENR from the boot node, resulting in 0 P2P peers in all deployments (e.g. stg-pub).
- Adds the same `preStartScript` used by `full-node.yaml` and `validator.yaml` so the blob-sink can join the P2P network.

## Test plan
- Deploy to staging-public and verify the blob-sink picks up bootstrap nodes and connects to peers
- Check logs for `peer_manager` showing non-zero peer count

🤖 Generated with [Claude Code](https://claude.com/claude-code)