### PR TITLE
chore: rename pxe-side oracle implementations

### DIFF
--- a/yarn-project/pxe/src/contract_function_simulator/contract_function_simulator.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/contract_function_simulator.ts
@@ -284,7 +284,7 @@ export class ContractFunctionSimulator {
       );
       const publicFunctionsCalldata = await Promise.all(
         publicCallRequests.map(async r => {
-          const calldata = await privateExecutionOracle.loadFromExecutionCache(r.calldataHash);
+          const calldata = await privateExecutionOracle.getHashPreimage(r.calldataHash);
           return new HashedValues(calldata, r.calldataHash);
         }),
       );

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/interfaces.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/interfaces.ts
@@ -86,7 +86,7 @@ export interface IUtilityExecutionOracle {
     nullifier: Fr,
   ): Promise<NullifierMembershipWitness | undefined>;
   getBlockHeader(blockNumber: BlockNumber): Promise<BlockHeader | undefined>;
-  tryGetPublicKeysAndPartialAddress(
+  getPublicKeysAndPartialAddress(
     account: AztecAddress,
   ): Promise<{ publicKeys: PublicKeys; partialAddress: PartialAddress } | undefined>;
   getAuthWitness(messageHash: Fr): Promise<Fr[] | undefined>;
@@ -107,19 +107,19 @@ export interface IUtilityExecutionOracle {
     offset: number,
     status: NoteStatus,
   ): Promise<NoteData[]>;
-  checkNullifierExists(innerNullifier: Fr): Promise<boolean>;
+  doesNullifierExist(innerNullifier: Fr): Promise<boolean>;
   getL1ToL2MembershipWitness(
     contractAddress: AztecAddress,
     messageHash: Fr,
     secret: Fr,
   ): Promise<MessageLoadOracleInputs<typeof L1_TO_L2_MSG_TREE_HEIGHT>>;
-  storageRead(
+  getFromPublicStorage(
     anchorBlockHash: BlockHash,
     contractAddress: AztecAddress,
     startStorageSlot: Fr,
     numberOfElements: number,
   ): Promise<Fr[]>;
-  fetchTaggedLogs(pendingTaggedLogArrayBaseSlot: Fr, scope: AztecAddress): Promise<void>;
+  getPendingTaggedLogs(pendingTaggedLogArrayBaseSlot: Fr, scope: AztecAddress): Promise<void>;
   validateAndStoreEnqueuedNotesAndEvents(
     contractAddress: AztecAddress,
     noteValidationRequestsArrayBaseSlot: Fr,
@@ -128,20 +128,20 @@ export interface IUtilityExecutionOracle {
     maxEventSerializedLen: number,
     scope: AztecAddress,
   ): Promise<void>;
-  bulkRetrieveLogs(
+  getLogsByTag(
     contractAddress: AztecAddress,
     logRetrievalRequestsArrayBaseSlot: Fr,
     logRetrievalResponsesArrayBaseSlot: Fr,
     scope: AztecAddress,
   ): Promise<void>;
-  utilityResolveMessageContexts(
+  getMessageContextsByTxHash(
     contractAddress: AztecAddress,
     messageContextRequestsArrayBaseSlot: Fr,
     messageContextResponsesArrayBaseSlot: Fr,
     scope: AztecAddress,
   ): Promise<void>;
-  storeCapsule(contractAddress: AztecAddress, key: Fr, capsule: Fr[], scope: AztecAddress): void;
-  loadCapsule(contractAddress: AztecAddress, key: Fr, scope: AztecAddress): Promise<Fr[] | null>;
+  setCapsule(contractAddress: AztecAddress, key: Fr, capsule: Fr[], scope: AztecAddress): void;
+  getCapsule(contractAddress: AztecAddress, key: Fr, scope: AztecAddress): Promise<Fr[] | null>;
   deleteCapsule(contractAddress: AztecAddress, key: Fr, scope: AztecAddress): void;
   copyCapsule(
     contractAddress: AztecAddress,
@@ -150,9 +150,9 @@ export interface IUtilityExecutionOracle {
     numEntries: number,
     scope: AztecAddress,
   ): Promise<void>;
-  aes128Decrypt(ciphertext: Buffer, iv: Buffer, symKey: Buffer): Promise<Buffer>;
+  decryptAes128(ciphertext: Buffer, iv: Buffer, symKey: Buffer): Promise<Buffer>;
   getSharedSecret(address: AztecAddress, ephPk: Point, contractAddress: AztecAddress): Promise<Fr>;
-  invalidateContractSyncCache(contractAddress: AztecAddress, scopes: AztecAddress[]): void;
+  setContractSyncCacheInvalid(contractAddress: AztecAddress, scopes: AztecAddress[]): void;
   emitOffchainEffect(data: Fr[]): Promise<void>;
 }
 
@@ -163,8 +163,8 @@ export interface IUtilityExecutionOracle {
 export interface IPrivateExecutionOracle {
   isPrivate: true;
 
-  storeInExecutionCache(values: Fr[], hash: Fr): void;
-  loadFromExecutionCache(hash: Fr): Promise<Fr[]>;
+  setHashPreimage(values: Fr[], hash: Fr): void;
+  getHashPreimage(hash: Fr): Promise<Fr[]>;
   notifyCreatedNote(
     owner: AztecAddress,
     storageSlot: Fr,
@@ -185,9 +185,9 @@ export interface IPrivateExecutionOracle {
     sideEffectCounter: number,
     isStaticCall: boolean,
   ): Promise<{ endSideEffectCounter: Fr; returnsHash: Fr }>;
-  validatePublicCalldata(calldataHash: Fr): Promise<void>;
+  assertValidPublicCalldata(calldataHash: Fr): Promise<void>;
   notifyRevertiblePhaseStart(minRevertibleSideEffectCounter: number): Promise<void>;
-  inRevertiblePhase(sideEffectCounter: number): Promise<boolean>;
+  isExecutionInRevertiblePhase(sideEffectCounter: number): Promise<boolean>;
   getSenderForTags(): Promise<AztecAddress | undefined>;
   setSenderForTags(senderForTags: AztecAddress): Promise<void>;
   getNextAppTagAsSender(sender: AztecAddress, recipient: AztecAddress): Promise<Tag>;

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/oracle.ts
@@ -27,6 +27,25 @@ export class UnavailableOracleError extends Error {
 
 /**
  * A data source that has all the apis required by Aztec.nr.
+ *
+ * ## Oracle naming conventions
+ *
+ * We try to keep oracle naming consistent, please see below the conventions we adhere to.
+ *
+ * Each oracle method name has the form `aztec_{scope}_{verb}{Object}`, where:
+ *
+ * - **Scope prefix** indicates the execution context required:
+ *   - `aztec_prv_` — available only during private function execution.
+ *   - `aztec_utl_` — available during both utility and private execution.
+ *
+ * - **Verb** signals the operation's semantics (verb-first, then object):
+ *   - `get`              — read / lookup / get data from oracle into contract.
+ *   - `does`/`is`/`has`  — predicate (returns boolean).
+ *   - `emit`/`notify`    — propagate data from contract to oracle.
+ *   - `set`              — contract driven oracle state mutation (capsules, execution cache, tagging, etc).
+ *   - `call`             — trigger nested execution (control flow).
+ *   - `assert`           — validate a condition, throw on failure.
+ *   - Standalone verbs (`delete`, `copy`, `decrypt`, `log`, etc) are used when no generic verb fits.
  */
 export class Oracle {
   constructor(private handler: IMiscOracle | IUtilityExecutionOracle | IPrivateExecutionOracle) {}
@@ -109,13 +128,13 @@ export class Oracle {
 
   // eslint-disable-next-line camelcase
   aztec_prv_setHashPreimage(values: ACVMField[], [hash]: ACVMField[]): Promise<ACVMField[]> {
-    this.handlerAsPrivate().storeInExecutionCache(values.map(Fr.fromString), Fr.fromString(hash));
+    this.handlerAsPrivate().setHashPreimage(values.map(Fr.fromString), Fr.fromString(hash));
     return Promise.resolve([]);
   }
 
   // eslint-disable-next-line camelcase
   async aztec_prv_getHashPreimage([returnsHash]: ACVMField[]): Promise<ACVMField[][]> {
-    const values = await this.handlerAsPrivate().loadFromExecutionCache(Fr.fromString(returnsHash));
+    const values = await this.handlerAsPrivate().getHashPreimage(Fr.fromString(returnsHash));
     return [values.map(toACVMField)];
   }
 
@@ -254,7 +273,7 @@ export class Oracle {
   // eslint-disable-next-line camelcase
   async aztec_utl_getPublicKeysAndPartialAddress([address]: ACVMField[]): Promise<(ACVMField | ACVMField[])[]> {
     const parsedAddress = AztecAddress.fromField(Fr.fromString(address));
-    const result = await this.handlerAsUtility().tryGetPublicKeysAndPartialAddress(parsedAddress);
+    const result = await this.handlerAsUtility().getPublicKeysAndPartialAddress(parsedAddress);
 
     // We are going to return a Noir Option struct to represent the possibility of null values. Options are a struct
     // with two fields: `some` (a boolean) and `value` (a field array in this case).
@@ -381,7 +400,7 @@ export class Oracle {
 
   // eslint-disable-next-line camelcase
   async aztec_utl_doesNullifierExist([innerNullifier]: ACVMField[]): Promise<ACVMField[]> {
-    const exists = await this.handlerAsUtility().checkNullifierExists(Fr.fromString(innerNullifier));
+    const exists = await this.handlerAsUtility().doesNullifierExist(Fr.fromString(innerNullifier));
     return [toACVMField(exists)];
   }
 
@@ -406,7 +425,7 @@ export class Oracle {
     [startStorageSlot]: ACVMField[],
     [numberOfElements]: ACVMField[],
   ): Promise<ACVMField[][]> {
-    const values = await this.handlerAsUtility().storageRead(
+    const values = await this.handlerAsUtility().getFromPublicStorage(
       BlockHash.fromString(blockHash),
       new AztecAddress(Fr.fromString(contractAddress)),
       Fr.fromString(startStorageSlot),
@@ -465,7 +484,7 @@ export class Oracle {
 
   // eslint-disable-next-line camelcase
   async aztec_prv_assertValidPublicCalldata([calldataHash]: ACVMField[]): Promise<ACVMField[]> {
-    await this.handlerAsPrivate().validatePublicCalldata(Fr.fromString(calldataHash));
+    await this.handlerAsPrivate().assertValidPublicCalldata(Fr.fromString(calldataHash));
     return [];
   }
 
@@ -477,7 +496,9 @@ export class Oracle {
 
   // eslint-disable-next-line camelcase
   async aztec_prv_isExecutionInRevertiblePhase([sideEffectCounter]: ACVMField[]): Promise<ACVMField[]> {
-    const isRevertible = await this.handlerAsPrivate().inRevertiblePhase(Fr.fromString(sideEffectCounter).toNumber());
+    const isRevertible = await this.handlerAsPrivate().isExecutionInRevertiblePhase(
+      Fr.fromString(sideEffectCounter).toNumber(),
+    );
     return Promise.resolve([toACVMField(isRevertible)]);
   }
 
@@ -495,7 +516,7 @@ export class Oracle {
     [pendingTaggedLogArrayBaseSlot]: ACVMField[],
     [scope]: ACVMField[],
   ): Promise<ACVMField[]> {
-    await this.handlerAsUtility().fetchTaggedLogs(
+    await this.handlerAsUtility().getPendingTaggedLogs(
       Fr.fromString(pendingTaggedLogArrayBaseSlot),
       AztecAddress.fromString(scope),
     );
@@ -530,7 +551,7 @@ export class Oracle {
     [logRetrievalResponsesArrayBaseSlot]: ACVMField[],
     [scope]: ACVMField[],
   ): Promise<ACVMField[]> {
-    await this.handlerAsUtility().bulkRetrieveLogs(
+    await this.handlerAsUtility().getLogsByTag(
       AztecAddress.fromString(contractAddress),
       Fr.fromString(logRetrievalRequestsArrayBaseSlot),
       Fr.fromString(logRetrievalResponsesArrayBaseSlot),
@@ -546,7 +567,7 @@ export class Oracle {
     [messageContextResponsesArrayBaseSlot]: ACVMField[],
     [scope]: ACVMField[],
   ): Promise<ACVMField[]> {
-    await this.handlerAsUtility().utilityResolveMessageContexts(
+    await this.handlerAsUtility().getMessageContextsByTxHash(
       AztecAddress.fromString(contractAddress),
       Fr.fromString(messageContextRequestsArrayBaseSlot),
       Fr.fromString(messageContextResponsesArrayBaseSlot),
@@ -562,7 +583,7 @@ export class Oracle {
     capsule: ACVMField[],
     [scope]: ACVMField[],
   ): Promise<ACVMField[]> {
-    this.handlerAsUtility().storeCapsule(
+    this.handlerAsUtility().setCapsule(
       AztecAddress.fromField(Fr.fromString(contractAddress)),
       Fr.fromString(slot),
       capsule.map(Fr.fromString),
@@ -578,7 +599,7 @@ export class Oracle {
     [tSize]: ACVMField[],
     [scope]: ACVMField[],
   ): Promise<(ACVMField | ACVMField[])[]> {
-    const values = await this.handlerAsUtility().loadCapsule(
+    const values = await this.handlerAsUtility().getCapsule(
       AztecAddress.fromField(Fr.fromString(contractAddress)),
       Fr.fromString(slot),
       AztecAddress.fromField(Fr.fromString(scope)),
@@ -640,7 +661,7 @@ export class Oracle {
 
     // Noir Option<BoundedVec> is encoded as [is_some: Field, storage: Field[], length: Field].
     try {
-      const plaintext = await this.handlerAsUtility().aes128Decrypt(ciphertext, ivBuffer, symKeyBuffer);
+      const plaintext = await this.handlerAsUtility().decryptAes128(ciphertext, ivBuffer, symKeyBuffer);
       const [storage, length] = bufferToBoundedVec(plaintext, ciphertextBVecStorage.length);
       return [toACVMField(1), storage, length];
     } catch {
@@ -672,7 +693,7 @@ export class Oracle {
     [scopeCount]: ACVMField[],
   ): Promise<ACVMField[]> {
     const scopeAddresses = scopes.slice(0, +scopeCount).map(s => AztecAddress.fromField(Fr.fromString(s)));
-    this.handlerAsUtility().invalidateContractSyncCache(
+    this.handlerAsUtility().setContractSyncCacheInvalid(
       AztecAddress.fromField(Fr.fromString(contractAddress)),
       scopeAddresses,
     );

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/oracle_version_is_checked.test.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/oracle_version_is_checked.test.ts
@@ -66,7 +66,7 @@ describe('Oracle Version Check test suite', () => {
 
     aztecNode.getPublicStorageAt.mockResolvedValue(Fr.ZERO);
     anchorBlockHeader = BlockHeader.random();
-    capsuleStore.loadCapsule.mockImplementation((_, __) => Promise.resolve(null));
+    capsuleStore.getCapsule.mockImplementation((_, __) => Promise.resolve(null));
     capsuleStore.readCapsuleArray.mockResolvedValue([]);
     senderTaggingStore.getLastFinalizedIndex.mockResolvedValue(undefined);
     senderTaggingStore.getLastUsedIndex.mockResolvedValue(undefined);

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution.test.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution.test.ts
@@ -286,7 +286,7 @@ describe('Private Execution test suite', () => {
     senderAddressBookStore = mock<SenderAddressBookStore>();
     contractSyncService = mock<ContractSyncService>();
     messageContextService = mock<MessageContextService>();
-    messageContextService.resolveMessageContexts.mockResolvedValue([]);
+    messageContextService.getMessageContextsByTxHash.mockResolvedValue([]);
     // Configure mock to actually perform sync_state calls (needed for nested call tests)
     contractSyncService.ensureContractSynced.mockImplementation(
       async (contractAddress, functionToInvokeAfterSync, utilityExecutor, anchorBlockHeader, jobId, scopes) => {
@@ -436,7 +436,7 @@ describe('Private Execution test suite', () => {
       });
     });
 
-    capsuleStore.loadCapsule.mockImplementation((_, __) => Promise.resolve(null));
+    capsuleStore.getCapsule.mockImplementation((_, __) => Promise.resolve(null));
 
     aztecNode.getPublicStorageAt.mockImplementation(
       (_block: BlockParameter, _address: AztecAddress, _storageSlot: Fr) => {

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution.ts
@@ -76,7 +76,7 @@ export async function executePrivateFunction(
 
   const contractClassLogs = privateExecutionOracle.getContractClassLogs();
 
-  const rawReturnValues = await privateExecutionOracle.loadFromExecutionCache(publicInputs.returnsHash);
+  const rawReturnValues = await privateExecutionOracle.getHashPreimage(publicInputs.returnsHash);
 
   const newNotes = privateExecutionOracle.getNewNotes();
   const noteHashNullifierCounterMap = privateExecutionOracle.getNoteHashNullifierCounterMap();

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution_oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution_oracle.ts
@@ -265,7 +265,7 @@ export class PrivateExecutionOracle extends UtilityExecutionOracle implements IP
    * @param values - Values to store.
    * @returns The hash of the values.
    */
-  public storeInExecutionCache(values: Fr[], hash: Fr) {
+  public setHashPreimage(values: Fr[], hash: Fr) {
     return this.executionCache.store(values, hash);
   }
 
@@ -274,7 +274,7 @@ export class PrivateExecutionOracle extends UtilityExecutionOracle implements IP
    * @param hash - Hash of the values.
    * @returns The values.
    */
-  public loadFromExecutionCache(hash: Fr): Promise<Fr[]> {
+  public getHashPreimage(hash: Fr): Promise<Fr[]> {
     const preimage = this.executionCache.getPreimage(hash);
     if (!preimage) {
       throw new Error(`Preimage for hash ${hash.toString()} not found in cache`);
@@ -282,7 +282,7 @@ export class PrivateExecutionOracle extends UtilityExecutionOracle implements IP
     return Promise.resolve(preimage);
   }
 
-  override async checkNullifierExists(innerNullifier: Fr): Promise<boolean> {
+  override async doesNullifierExist(innerNullifier: Fr): Promise<boolean> {
     // This oracle must be overridden because while utility execution can only meaningfully check if a nullifier exists
     // in the synched block, during private execution there's also the possibility of it being pending, i.e. created
     // in the current transaction.
@@ -295,7 +295,7 @@ export class PrivateExecutionOracle extends UtilityExecutionOracle implements IP
 
     return (
       this.noteCache.getNullifiers(this.contractAddress).has(nullifier) ||
-      (await super.checkNullifierExists(innerNullifier))
+      (await super.doesNullifierExist(innerNullifier))
     );
   }
 
@@ -598,7 +598,7 @@ export class PrivateExecutionOracle extends UtilityExecutionOracle implements IP
   }
 
   /** Validates the calldata preimage exists in the cache and checks cumulative calldata size is within limits. */
-  public validatePublicCalldata(calldataHash: Fr) {
+  public assertValidPublicCalldata(calldataHash: Fr) {
     const calldata = this.executionCache.getPreimage(calldataHash);
     if (!calldata) {
       throw new Error('Calldata for public call not found in cache');
@@ -615,7 +615,7 @@ export class PrivateExecutionOracle extends UtilityExecutionOracle implements IP
     return this.noteCache.setMinRevertibleSideEffectCounter(minRevertibleSideEffectCounter);
   }
 
-  public inRevertiblePhase(sideEffectCounter: number): Promise<boolean> {
+  public isExecutionInRevertiblePhase(sideEffectCounter: number): Promise<boolean> {
     return Promise.resolve(this.noteCache.isSideEffectCounterRevertible(sideEffectCounter));
   }
 

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution.test.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution.test.ts
@@ -201,7 +201,7 @@ describe('Utility Execution test suite', () => {
       ),
     );
 
-    capsuleStore.loadCapsule.mockImplementation((_, __) => Promise.resolve(null));
+    capsuleStore.getCapsule.mockImplementation((_, __) => Promise.resolve(null));
 
     const execRequest = FunctionCall.from({
       name: artifact.name,
@@ -274,15 +274,15 @@ describe('Utility Execution test suite', () => {
         const dstSlot = Fr.random();
         const capsule = [Fr.random()];
 
-        capsuleStore.loadCapsule.mockResolvedValueOnce(capsule);
+        capsuleStore.getCapsule.mockResolvedValueOnce(capsule);
 
-        utilityExecutionOracle.storeCapsule(contractAddress, slot, capsule, scope);
-        await utilityExecutionOracle.loadCapsule(contractAddress, slot, scope);
+        utilityExecutionOracle.setCapsule(contractAddress, slot, capsule, scope);
+        await utilityExecutionOracle.getCapsule(contractAddress, slot, scope);
         utilityExecutionOracle.deleteCapsule(contractAddress, slot, scope);
         await utilityExecutionOracle.copyCapsule(contractAddress, srcSlot, dstSlot, 1, scope);
 
-        expect(capsuleStore.storeCapsule).toHaveBeenCalledWith(contractAddress, slot, capsule, 'test-job-id', scope);
-        expect(capsuleStore.loadCapsule).toHaveBeenCalledWith(contractAddress, slot, 'test-job-id', scope);
+        expect(capsuleStore.setCapsule).toHaveBeenCalledWith(contractAddress, slot, capsule, 'test-job-id', scope);
+        expect(capsuleStore.getCapsule).toHaveBeenCalledWith(contractAddress, slot, 'test-job-id', scope);
         expect(capsuleStore.deleteCapsule).toHaveBeenCalledWith(contractAddress, slot, 'test-job-id', scope);
         expect(capsuleStore.copyCapsule).toHaveBeenCalledWith(
           contractAddress,
@@ -324,15 +324,15 @@ describe('Utility Execution test suite', () => {
           scopes: 'ALL_SCOPES',
         });
 
-        capsuleStore.loadCapsule.mockResolvedValueOnce(persisted);
+        capsuleStore.getCapsule.mockResolvedValueOnce(persisted);
 
-        expect(await utilityExecutionOracle.loadCapsule(contractAddress, slot, AztecAddress.ZERO)).toEqual(
+        expect(await utilityExecutionOracle.getCapsule(contractAddress, slot, AztecAddress.ZERO)).toEqual(
           transientGlobal,
         );
-        expect(await utilityExecutionOracle.loadCapsule(contractAddress, slot, AztecAddress.ZERO)).toEqual(
+        expect(await utilityExecutionOracle.getCapsule(contractAddress, slot, AztecAddress.ZERO)).toEqual(
           transientGlobal,
         );
-        expect(await utilityExecutionOracle.loadCapsule(contractAddress, slot, scope)).toEqual(transientScoped);
+        expect(await utilityExecutionOracle.getCapsule(contractAddress, slot, scope)).toEqual(transientScoped);
       });
     });
 
@@ -340,7 +340,7 @@ describe('Utility Execution test suite', () => {
       it('throws when contract address does not match', async () => {
         const otherAddress = await AztecAddress.random();
         const scope = await AztecAddress.random();
-        expect(() => utilityExecutionOracle.invalidateContractSyncCache(otherAddress, [scope])).toThrow(
+        expect(() => utilityExecutionOracle.setContractSyncCacheInvalid(otherAddress, [scope])).toThrow(
           `Contract ${contractAddress} cannot invalidate sync cache of ${otherAddress}`,
         );
         expect(contractSyncService.invalidateContractForScopes).not.toHaveBeenCalled();
@@ -349,7 +349,7 @@ describe('Utility Execution test suite', () => {
       it('invalidates cache for the given scopes', async () => {
         const scopeA = await AztecAddress.random();
         const scopeB = await AztecAddress.random();
-        utilityExecutionOracle.invalidateContractSyncCache(contractAddress, [scopeA, scopeB]);
+        utilityExecutionOracle.setContractSyncCacheInvalid(contractAddress, [scopeA, scopeB]);
         expect(contractSyncService.invalidateContractForScopes).toHaveBeenCalledWith(contractAddress, [scopeA, scopeB]);
       });
     });
@@ -362,14 +362,14 @@ describe('Utility Execution test suite', () => {
       it('throws when contractAddress does not match', async () => {
         const wrongAddress = await AztecAddress.random();
         await expect(
-          utilityExecutionOracle.utilityResolveMessageContexts(wrongAddress, requestSlot, responseSlot, scope),
+          utilityExecutionOracle.getMessageContextsByTxHash(wrongAddress, requestSlot, responseSlot, scope),
         ).rejects.toThrow(`Got a message context request from ${wrongAddress}, expected ${contractAddress}`);
       });
 
       it('sets null in response capsule for zero tx hashes', async () => {
         capsuleStore.readCapsuleArray.mockResolvedValueOnce([[Fr.ZERO]]);
 
-        await utilityExecutionOracle.utilityResolveMessageContexts(contractAddress, requestSlot, responseSlot, scope);
+        await utilityExecutionOracle.getMessageContextsByTxHash(contractAddress, requestSlot, responseSlot, scope);
 
         const response = capsuleStore.setCapsuleArray.mock.calls.find(
           call => call[0].equals(contractAddress) && call[1].equals(responseSlot),
@@ -393,7 +393,7 @@ describe('Utility Execution test suite', () => {
           data: { txHash, noteHashes: [noteHash], nullifiers: [firstNullifier] },
         } as any);
 
-        await utilityExecutionOracle.utilityResolveMessageContexts(contractAddress, requestSlot, responseSlot, scope);
+        await utilityExecutionOracle.getMessageContextsByTxHash(contractAddress, requestSlot, responseSlot, scope);
 
         const response = capsuleStore.setCapsuleArray.mock.calls.find(
           call => call[0].equals(contractAddress) && call[1].equals(responseSlot),
@@ -415,7 +415,7 @@ describe('Utility Execution test suite', () => {
           data: { txHash, noteHashes: [], nullifiers: [Fr.random()] },
         } as any);
 
-        await utilityExecutionOracle.utilityResolveMessageContexts(contractAddress, requestSlot, responseSlot, scope);
+        await utilityExecutionOracle.getMessageContextsByTxHash(contractAddress, requestSlot, responseSlot, scope);
 
         const response = capsuleStore.setCapsuleArray.mock.calls.find(
           call => call[0].equals(contractAddress) && call[1].equals(responseSlot),
@@ -428,20 +428,20 @@ describe('Utility Execution test suite', () => {
       it('throws on empty capsule entry', async () => {
         capsuleStore.readCapsuleArray.mockResolvedValueOnce([[]]);
         await expect(
-          utilityExecutionOracle.utilityResolveMessageContexts(contractAddress, requestSlot, responseSlot, scope),
+          utilityExecutionOracle.getMessageContextsByTxHash(contractAddress, requestSlot, responseSlot, scope),
         ).rejects.toThrow('Malformed message context request at index 0: expected 1 field (tx hash), got 0');
       });
 
       it('throws on capsule entry with extra fields', async () => {
         capsuleStore.readCapsuleArray.mockResolvedValueOnce([[Fr.random(), Fr.random()]]);
         await expect(
-          utilityExecutionOracle.utilityResolveMessageContexts(contractAddress, requestSlot, responseSlot, scope),
+          utilityExecutionOracle.getMessageContextsByTxHash(contractAddress, requestSlot, responseSlot, scope),
         ).rejects.toThrow('Malformed message context request at index 0: expected 1 field (tx hash), got 2');
       });
 
       it('clears the request capsule after processing', async () => {
         capsuleStore.readCapsuleArray.mockResolvedValueOnce([]);
-        await utilityExecutionOracle.utilityResolveMessageContexts(contractAddress, requestSlot, responseSlot, scope);
+        await utilityExecutionOracle.getMessageContextsByTxHash(contractAddress, requestSlot, responseSlot, scope);
         expect(capsuleStore.setCapsuleArray).toHaveBeenCalledWith(
           contractAddress,
           requestSlot,
@@ -454,7 +454,7 @@ describe('Utility Execution test suite', () => {
       it('clears the request capsule even on error', async () => {
         capsuleStore.readCapsuleArray.mockResolvedValueOnce([[]]);
         await expect(
-          utilityExecutionOracle.utilityResolveMessageContexts(contractAddress, requestSlot, responseSlot, scope),
+          utilityExecutionOracle.getMessageContextsByTxHash(contractAddress, requestSlot, responseSlot, scope),
         ).rejects.toThrow();
         expect(capsuleStore.setCapsuleArray).toHaveBeenCalledWith(
           contractAddress,

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
@@ -285,7 +285,7 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
    * @param account - The account address.
    * @returns The public keys and partial address, or `undefined` if the account is not registered.
    */
-  public async tryGetPublicKeysAndPartialAddress(
+  public async getPublicKeysAndPartialAddress(
     account: AztecAddress,
   ): Promise<{ publicKeys: PublicKeys; partialAddress: PartialAddress } | undefined> {
     const completeAddress = await this.addressStore.getCompleteAddress(account);
@@ -391,7 +391,7 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
    * @param innerNullifier - The inner nullifier.
    * @returns A boolean indicating whether the nullifier exists in the tree or not.
    */
-  public async checkNullifierExists(innerNullifier: Fr) {
+  public async doesNullifierExist(innerNullifier: Fr) {
     const [nullifier, anchorBlockHash] = await Promise.all([
       siloNullifier(this.contractAddress, innerNullifier!),
       this.anchorBlockHeader.hash(),
@@ -429,7 +429,7 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
    * @param startStorageSlot - The starting storage slot.
    * @param numberOfElements - Number of elements to read from the starting storage slot.
    */
-  public storageRead(
+  public getFromPublicStorage(
     blockHash: BlockHash,
     contractAddress: AztecAddress,
     startStorageSlot: Fr,
@@ -497,7 +497,7 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
     logContractMessage(logger, LogLevels[level], strippedMessage, fields);
   }
 
-  public async fetchTaggedLogs(pendingTaggedLogArrayBaseSlot: Fr, scope: AztecAddress) {
+  public async getPendingTaggedLogs(pendingTaggedLogArrayBaseSlot: Fr, scope: AztecAddress) {
     const logService = new LogService(
       this.aztecNode,
       this.anchorBlockHeader,
@@ -594,7 +594,7 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
     );
   }
 
-  public async bulkRetrieveLogs(
+  public async getLogsByTag(
     contractAddress: AztecAddress,
     logRetrievalRequestsArrayBaseSlot: Fr,
     logRetrievalResponsesArrayBaseSlot: Fr,
@@ -623,7 +623,7 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
       this.logger.getBindings(),
     );
 
-    const maybeLogRetrievalResponses = await logService.bulkRetrieveLogs(logRetrievalRequests);
+    const maybeLogRetrievalResponses = await logService.fetchLogsByTag(logRetrievalRequests);
 
     // Requests are cleared once we're done.
     await this.capsuleStore.setCapsuleArray(contractAddress, logRetrievalRequestsArrayBaseSlot, [], this.jobId, scope);
@@ -638,7 +638,7 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
     );
   }
 
-  public async utilityResolveMessageContexts(
+  public async getMessageContextsByTxHash(
     contractAddress: AztecAddress,
     messageContextRequestsArrayBaseSlot: Fr,
     messageContextResponsesArrayBaseSlot: Fr,
@@ -669,7 +669,7 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
         return fields[0];
       });
 
-      const maybeMessageContexts = await this.messageContextService.resolveMessageContexts(
+      const maybeMessageContexts = await this.messageContextService.getMessageContextsByTxHash(
         txHashes,
         this.anchorBlockHeader.getBlockNumber(),
       );
@@ -693,15 +693,15 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
     }
   }
 
-  public storeCapsule(contractAddress: AztecAddress, slot: Fr, capsule: Fr[], scope: AztecAddress): void {
+  public setCapsule(contractAddress: AztecAddress, slot: Fr, capsule: Fr[], scope: AztecAddress): void {
     if (!contractAddress.equals(this.contractAddress)) {
       // TODO(#10727): instead of this check that this.contractAddress is allowed to access the external DB
       throw new Error(`Contract ${contractAddress} is not allowed to access ${this.contractAddress}'s PXE DB`);
     }
-    this.capsuleStore.storeCapsule(contractAddress, slot, capsule, this.jobId, scope);
+    this.capsuleStore.setCapsule(contractAddress, slot, capsule, this.jobId, scope);
   }
 
-  public async loadCapsule(contractAddress: AztecAddress, slot: Fr, scope: AztecAddress): Promise<Fr[] | null> {
+  public async getCapsule(contractAddress: AztecAddress, slot: Fr, scope: AztecAddress): Promise<Fr[] | null> {
     if (!contractAddress.equals(this.contractAddress)) {
       // TODO(#10727): instead of this check that this.contractAddress is allowed to access the external DB
       throw new Error(`Contract ${contractAddress} is not allowed to access ${this.contractAddress}'s PXE DB`);
@@ -714,7 +714,7 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
     )?.data;
 
     // TODO(#12425): On the following line, the pertinent capsule gets overshadowed by the transient one. Tackle this.
-    return maybeTransientCapsule ?? (await this.capsuleStore.loadCapsule(contractAddress, slot, this.jobId, scope));
+    return maybeTransientCapsule ?? (await this.capsuleStore.getCapsule(contractAddress, slot, this.jobId, scope));
   }
 
   public deleteCapsule(contractAddress: AztecAddress, slot: Fr, scope: AztecAddress): void {
@@ -743,7 +743,7 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
    * Clears cached sync state for a contract for a set of scopes, forcing re-sync on the next query so that newly
    * stored notes or events are discovered.
    */
-  public invalidateContractSyncCache(contractAddress: AztecAddress, scopes: AztecAddress[]): void {
+  public setContractSyncCacheInvalid(contractAddress: AztecAddress, scopes: AztecAddress[]): void {
     if (!contractAddress.equals(this.contractAddress)) {
       throw new Error(`Contract ${this.contractAddress} cannot invalidate sync cache of ${contractAddress}`);
     }
@@ -751,7 +751,7 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
   }
 
   // TODO(#11849): consider replacing this oracle with a pure Noir implementation of aes decryption.
-  public aes128Decrypt(ciphertext: Buffer, iv: Buffer, symKey: Buffer): Promise<Buffer> {
+  public decryptAes128(ciphertext: Buffer, iv: Buffer, symKey: Buffer): Promise<Buffer> {
     const aes128 = new Aes128();
     return aes128.decryptBufferCBC(ciphertext, iv, symKey);
   }

--- a/yarn-project/pxe/src/logs/log_service.test.ts
+++ b/yarn-project/pxe/src/logs/log_service.test.ts
@@ -65,7 +65,7 @@ describe('LogService', () => {
       aztecNode.getPrivateLogsByTags.mockResolvedValue([[]]);
       aztecNode.getPublicLogsByTagsFromContract.mockResolvedValue([[]]);
       const request = new LogRetrievalRequest(contractAddress, tag);
-      const responses = await logService.bulkRetrieveLogs([request]);
+      const responses = await logService.fetchLogsByTag([request]);
       expect(responses.length).toEqual(1);
       expect(responses[0]).toBeNull();
     });
@@ -78,7 +78,7 @@ describe('LogService', () => {
 
       const request = new LogRetrievalRequest(contractAddress, new Tag(scopedLog.logData[0]));
 
-      const responses = await logService.bulkRetrieveLogs([request]);
+      const responses = await logService.fetchLogsByTag([request]);
 
       expect(responses.length).toEqual(1);
       expect(responses[0]).not.toBeNull();
@@ -92,7 +92,7 @@ describe('LogService', () => {
 
       const request = new LogRetrievalRequest(contractAddress, new Tag(scopedLog.logData[0]));
 
-      const responses = await logService.bulkRetrieveLogs([request]);
+      const responses = await logService.fetchLogsByTag([request]);
 
       expect(responses.length).toEqual(1);
       expect(responses[0]).not.toBeNull();

--- a/yarn-project/pxe/src/logs/log_service.ts
+++ b/yarn-project/pxe/src/logs/log_service.ts
@@ -41,7 +41,7 @@ export class LogService {
     this.log = createLogger('pxe:log_service', bindings);
   }
 
-  public async bulkRetrieveLogs(logRetrievalRequests: LogRetrievalRequest[]): Promise<(LogRetrievalResponse | null)[]> {
+  public async fetchLogsByTag(logRetrievalRequests: LogRetrievalRequest[]): Promise<(LogRetrievalResponse | null)[]> {
     return await Promise.all(
       logRetrievalRequests.map(async request => {
         const [publicLog, privateLog] = await Promise.all([

--- a/yarn-project/pxe/src/messages/message_context_service.test.ts
+++ b/yarn-project/pxe/src/messages/message_context_service.test.ts
@@ -20,7 +20,7 @@ describe('MessageContextService', () => {
   });
 
   it('returns null for zero tx hash', async () => {
-    const results = await service.resolveMessageContexts([Fr.ZERO], anchorBlockNumber);
+    const results = await service.getMessageContextsByTxHash([Fr.ZERO], anchorBlockNumber);
 
     expect(results).toEqual([null]);
     expect(aztecNode.getTxEffect).not.toHaveBeenCalled();
@@ -30,7 +30,7 @@ describe('MessageContextService', () => {
     const txHash = TxHash.random();
     aztecNode.getTxEffect.mockResolvedValueOnce(undefined);
 
-    const results = await service.resolveMessageContexts([txHash.hash], anchorBlockNumber);
+    const results = await service.getMessageContextsByTxHash([txHash.hash], anchorBlockNumber);
 
     expect(results).toEqual([null]);
   });
@@ -44,7 +44,7 @@ describe('MessageContextService', () => {
       data: { txHash, noteHashes: [Fr.random()], nullifiers: [Fr.random()] },
     } as any);
 
-    const results = await service.resolveMessageContexts([txHash.hash], anchorBlockNumber);
+    const results = await service.getMessageContextsByTxHash([txHash.hash], anchorBlockNumber);
 
     expect(results).toEqual([null]);
   });
@@ -58,7 +58,7 @@ describe('MessageContextService', () => {
       data: { txHash, noteHashes: [Fr.random()], nullifiers: [] },
     } as any);
 
-    await expect(service.resolveMessageContexts([txHash.hash], anchorBlockNumber)).rejects.toThrow(
+    await expect(service.getMessageContextsByTxHash([txHash.hash], anchorBlockNumber)).rejects.toThrow(
       `Tx effect for ${txHash} has no nullifiers`,
     );
   });
@@ -75,7 +75,7 @@ describe('MessageContextService', () => {
       data: { txHash, noteHashes, nullifiers: [firstNullifier, Fr.random()] },
     } as any);
 
-    const results = await service.resolveMessageContexts([txHash.hash], anchorBlockNumber);
+    const results = await service.getMessageContextsByTxHash([txHash.hash], anchorBlockNumber);
 
     expect(results).toEqual([new MessageContext(txHash, noteHashes, firstNullifier)]);
   });
@@ -108,7 +108,7 @@ describe('MessageContextService', () => {
       return undefined; // notFoundTxHash
     });
 
-    const results = await service.resolveMessageContexts(
+    const results = await service.getMessageContextsByTxHash(
       [
         Fr.ZERO, // zero → null
         validTxHash.hash, // valid → MessageContext

--- a/yarn-project/pxe/src/messages/message_context_service.ts
+++ b/yarn-project/pxe/src/messages/message_context_service.ts
@@ -14,7 +14,7 @@ export class MessageContextService {
    * process messages that originated from that transaction. Returns `null` for tx hashes that are zero, not yet
    * available, or in blocks beyond the anchor block.
    */
-  resolveMessageContexts(txHashes: Fr[], anchorBlockNumber: number): Promise<(MessageContext | null)[]> {
+  getMessageContextsByTxHash(txHashes: Fr[], anchorBlockNumber: number): Promise<(MessageContext | null)[]> {
     // TODO: optimize, we might be hitting the node to get the same txHash repeatedly
     return Promise.all(
       txHashes.map(async txHashField => {

--- a/yarn-project/pxe/src/storage/capsule_store/capsule_store.test.ts
+++ b/yarn-project/pxe/src/storage/capsule_store/capsule_store.test.ts
@@ -24,8 +24,8 @@ describe('capsule data provider', () => {
       const slot = new Fr(1);
       const values = [new Fr(42)];
 
-      capsuleStore.storeCapsule(contract, slot, values, 'test', scope);
-      const result = await capsuleStore.loadCapsule(contract, slot, 'test', scope);
+      capsuleStore.setCapsule(contract, slot, values, 'test', scope);
+      const result = await capsuleStore.getCapsule(contract, slot, 'test', scope);
       expect(result).toEqual(values);
     });
 
@@ -33,8 +33,8 @@ describe('capsule data provider', () => {
       const slot = new Fr(1);
       const values = [new Fr(42), new Fr(43), new Fr(44)];
 
-      capsuleStore.storeCapsule(contract, slot, values, 'test', scope);
-      const result = await capsuleStore.loadCapsule(contract, slot, 'test', scope);
+      capsuleStore.setCapsule(contract, slot, values, 'test', scope);
+      const result = await capsuleStore.getCapsule(contract, slot, 'test', scope);
       expect(result).toEqual(values);
     });
 
@@ -43,10 +43,10 @@ describe('capsule data provider', () => {
       const initialValues = [new Fr(42)];
       const newValues = [new Fr(100)];
 
-      capsuleStore.storeCapsule(contract, slot, initialValues, 'test', scope);
-      capsuleStore.storeCapsule(contract, slot, newValues, 'test', scope);
+      capsuleStore.setCapsule(contract, slot, initialValues, 'test', scope);
+      capsuleStore.setCapsule(contract, slot, newValues, 'test', scope);
 
-      const result = await capsuleStore.loadCapsule(contract, slot, 'test', scope);
+      const result = await capsuleStore.getCapsule(contract, slot, 'test', scope);
       expect(result).toEqual(newValues);
     });
 
@@ -56,11 +56,11 @@ describe('capsule data provider', () => {
       const values1 = [new Fr(42)];
       const values2 = [new Fr(100)];
 
-      capsuleStore.storeCapsule(contract, slot, values1, 'test', scope);
-      capsuleStore.storeCapsule(anotherContract, slot, values2, 'test', scope);
+      capsuleStore.setCapsule(contract, slot, values1, 'test', scope);
+      capsuleStore.setCapsule(anotherContract, slot, values2, 'test', scope);
 
-      const result1 = await capsuleStore.loadCapsule(contract, slot, 'test', scope);
-      const result2 = await capsuleStore.loadCapsule(anotherContract, slot, 'test', scope);
+      const result1 = await capsuleStore.getCapsule(contract, slot, 'test', scope);
+      const result2 = await capsuleStore.getCapsule(anotherContract, slot, 'test', scope);
 
       expect(result1).toEqual(values1);
       expect(result2).toEqual(values2);
@@ -73,27 +73,27 @@ describe('capsule data provider', () => {
       const valuesA = [new Fr(42)];
       const valuesB = [new Fr(100)];
 
-      capsuleStore.storeCapsule(contract, slot, valuesA, 'test', scopeA);
-      capsuleStore.storeCapsule(contract, slot, valuesB, 'test', scopeB);
+      capsuleStore.setCapsule(contract, slot, valuesA, 'test', scopeA);
+      capsuleStore.setCapsule(contract, slot, valuesB, 'test', scopeB);
 
-      expect(await capsuleStore.loadCapsule(contract, slot, 'test', scopeA)).toEqual(valuesA);
-      expect(await capsuleStore.loadCapsule(contract, slot, 'test', scopeB)).toEqual(valuesB);
-      expect(await capsuleStore.loadCapsule(contract, slot, 'test', scope)).toBeNull();
+      expect(await capsuleStore.getCapsule(contract, slot, 'test', scopeA)).toEqual(valuesA);
+      expect(await capsuleStore.getCapsule(contract, slot, 'test', scopeB)).toEqual(valuesB);
+      expect(await capsuleStore.getCapsule(contract, slot, 'test', scope)).toBeNull();
     });
 
     it('different scopes are isolated', async () => {
       const slot = new Fr(1);
       const values = [new Fr(42)];
 
-      capsuleStore.storeCapsule(contract, slot, values, 'test', scope);
+      capsuleStore.setCapsule(contract, slot, values, 'test', scope);
 
-      expect(await capsuleStore.loadCapsule(contract, slot, 'test', scope)).toEqual(values);
-      expect(await capsuleStore.loadCapsule(contract, slot, 'test', AztecAddress.ZERO)).toBeNull();
+      expect(await capsuleStore.getCapsule(contract, slot, 'test', scope)).toEqual(values);
+      expect(await capsuleStore.getCapsule(contract, slot, 'test', AztecAddress.ZERO)).toBeNull();
     });
 
     it('returns null for non-existent slots', async () => {
       const slot = Fr.random();
-      const result = await capsuleStore.loadCapsule(contract, slot, 'test', scope);
+      const result = await capsuleStore.getCapsule(contract, slot, 'test', scope);
       expect(result).toBeNull();
     });
   });
@@ -103,17 +103,17 @@ describe('capsule data provider', () => {
       const slot = new Fr(1);
       const values = [new Fr(42)];
 
-      capsuleStore.storeCapsule(contract, slot, values, 'test', scope);
+      capsuleStore.setCapsule(contract, slot, values, 'test', scope);
       capsuleStore.deleteCapsule(contract, slot, 'test', scope);
 
-      expect(await capsuleStore.loadCapsule(contract, slot, 'test', scope)).toBeNull();
+      expect(await capsuleStore.getCapsule(contract, slot, 'test', scope)).toBeNull();
     });
 
     it('deletes an empty slot', async () => {
       const slot = new Fr(1);
       capsuleStore.deleteCapsule(contract, slot, 'test', scope);
 
-      expect(await capsuleStore.loadCapsule(contract, slot, 'test', scope)).toBeNull();
+      expect(await capsuleStore.getCapsule(contract, slot, 'test', scope)).toBeNull();
     });
 
     it('deletes a scoped capsule without affecting other scopes', async () => {
@@ -124,15 +124,15 @@ describe('capsule data provider', () => {
       const valuesB = [Fr.random(), Fr.random(), Fr.random()];
       const globalValues = [Fr.random(), Fr.random(), Fr.random()];
 
-      capsuleStore.storeCapsule(contract, slot, valuesA, 'test', scopeA);
-      capsuleStore.storeCapsule(contract, slot, valuesB, 'test', scopeB);
-      capsuleStore.storeCapsule(contract, slot, globalValues, 'test', scope);
+      capsuleStore.setCapsule(contract, slot, valuesA, 'test', scopeA);
+      capsuleStore.setCapsule(contract, slot, valuesB, 'test', scopeB);
+      capsuleStore.setCapsule(contract, slot, globalValues, 'test', scope);
 
       capsuleStore.deleteCapsule(contract, slot, 'test', scopeA);
 
-      expect(await capsuleStore.loadCapsule(contract, slot, 'test', scopeA)).toBeNull();
-      expect(await capsuleStore.loadCapsule(contract, slot, 'test', scopeB)).toEqual(valuesB);
-      expect(await capsuleStore.loadCapsule(contract, slot, 'test', scope)).toEqual(globalValues);
+      expect(await capsuleStore.getCapsule(contract, slot, 'test', scopeA)).toBeNull();
+      expect(await capsuleStore.getCapsule(contract, slot, 'test', scopeB)).toEqual(valuesB);
+      expect(await capsuleStore.getCapsule(contract, slot, 'test', scope)).toEqual(globalValues);
     });
   });
 
@@ -141,79 +141,79 @@ describe('capsule data provider', () => {
       const slot = new Fr(1);
       const values = [new Fr(42)];
 
-      capsuleStore.storeCapsule(contract, slot, values, 'test', scope);
+      capsuleStore.setCapsule(contract, slot, values, 'test', scope);
 
       const dstSlot = new Fr(5);
       await capsuleStore.copyCapsule(contract, slot, dstSlot, 1, 'test', scope);
 
-      expect(await capsuleStore.loadCapsule(contract, dstSlot, 'test', scope)).toEqual(values);
+      expect(await capsuleStore.getCapsule(contract, dstSlot, 'test', scope)).toEqual(values);
     });
 
     it('copies multiple non-overlapping values', async () => {
       const src = new Fr(1);
       const valuesArray = [[new Fr(42)], [new Fr(1337)], [new Fr(13)]];
 
-      capsuleStore.storeCapsule(contract, src, valuesArray[0], 'test', scope);
-      capsuleStore.storeCapsule(contract, src.add(new Fr(1)), valuesArray[1], 'test', scope);
-      capsuleStore.storeCapsule(contract, src.add(new Fr(2)), valuesArray[2], 'test', scope);
+      capsuleStore.setCapsule(contract, src, valuesArray[0], 'test', scope);
+      capsuleStore.setCapsule(contract, src.add(new Fr(1)), valuesArray[1], 'test', scope);
+      capsuleStore.setCapsule(contract, src.add(new Fr(2)), valuesArray[2], 'test', scope);
 
       const dst = new Fr(5);
       await capsuleStore.copyCapsule(contract, src, dst, 3, 'test', scope);
 
-      expect(await capsuleStore.loadCapsule(contract, dst, 'test', scope)).toEqual(valuesArray[0]);
-      expect(await capsuleStore.loadCapsule(contract, dst.add(new Fr(1)), 'test', scope)).toEqual(valuesArray[1]);
-      expect(await capsuleStore.loadCapsule(contract, dst.add(new Fr(2)), 'test', scope)).toEqual(valuesArray[2]);
+      expect(await capsuleStore.getCapsule(contract, dst, 'test', scope)).toEqual(valuesArray[0]);
+      expect(await capsuleStore.getCapsule(contract, dst.add(new Fr(1)), 'test', scope)).toEqual(valuesArray[1]);
+      expect(await capsuleStore.getCapsule(contract, dst.add(new Fr(2)), 'test', scope)).toEqual(valuesArray[2]);
     });
 
     it('copies overlapping values with src ahead', async () => {
       const src = new Fr(1);
       const valuesArray = [[new Fr(42)], [new Fr(1337)], [new Fr(13)]];
 
-      capsuleStore.storeCapsule(contract, src, valuesArray[0], 'test', scope);
-      capsuleStore.storeCapsule(contract, src.add(new Fr(1)), valuesArray[1], 'test', scope);
-      capsuleStore.storeCapsule(contract, src.add(new Fr(2)), valuesArray[2], 'test', scope);
+      capsuleStore.setCapsule(contract, src, valuesArray[0], 'test', scope);
+      capsuleStore.setCapsule(contract, src.add(new Fr(1)), valuesArray[1], 'test', scope);
+      capsuleStore.setCapsule(contract, src.add(new Fr(2)), valuesArray[2], 'test', scope);
 
       const dst = new Fr(2);
       await capsuleStore.copyCapsule(contract, src, dst, 3, 'test', scope);
 
-      expect(await capsuleStore.loadCapsule(contract, dst, 'test', scope)).toEqual(valuesArray[0]);
-      expect(await capsuleStore.loadCapsule(contract, dst.add(new Fr(1)), 'test', scope)).toEqual(valuesArray[1]);
-      expect(await capsuleStore.loadCapsule(contract, dst.add(new Fr(2)), 'test', scope)).toEqual(valuesArray[2]);
+      expect(await capsuleStore.getCapsule(contract, dst, 'test', scope)).toEqual(valuesArray[0]);
+      expect(await capsuleStore.getCapsule(contract, dst.add(new Fr(1)), 'test', scope)).toEqual(valuesArray[1]);
+      expect(await capsuleStore.getCapsule(contract, dst.add(new Fr(2)), 'test', scope)).toEqual(valuesArray[2]);
 
       // Slots 2 and 3 (src[1] and src[2]) should have been overwritten since they are also dst[0] and dst[1]
-      expect(await capsuleStore.loadCapsule(contract, src, 'test', scope)).toEqual(valuesArray[0]); // src[0] (unchanged)
-      expect(await capsuleStore.loadCapsule(contract, src.add(new Fr(1)), 'test', scope)).toEqual(valuesArray[0]); // dst[0]
-      expect(await capsuleStore.loadCapsule(contract, src.add(new Fr(2)), 'test', scope)).toEqual(valuesArray[1]); // dst[1]
+      expect(await capsuleStore.getCapsule(contract, src, 'test', scope)).toEqual(valuesArray[0]); // src[0] (unchanged)
+      expect(await capsuleStore.getCapsule(contract, src.add(new Fr(1)), 'test', scope)).toEqual(valuesArray[0]); // dst[0]
+      expect(await capsuleStore.getCapsule(contract, src.add(new Fr(2)), 'test', scope)).toEqual(valuesArray[1]); // dst[1]
     });
 
     it('copies overlapping values with dst ahead', async () => {
       const src = new Fr(5);
       const valuesArray = [[new Fr(42)], [new Fr(1337)], [new Fr(13)]];
 
-      capsuleStore.storeCapsule(contract, src, valuesArray[0], 'test', scope);
-      capsuleStore.storeCapsule(contract, src.add(new Fr(1)), valuesArray[1], 'test', scope);
-      capsuleStore.storeCapsule(contract, src.add(new Fr(2)), valuesArray[2], 'test', scope);
+      capsuleStore.setCapsule(contract, src, valuesArray[0], 'test', scope);
+      capsuleStore.setCapsule(contract, src.add(new Fr(1)), valuesArray[1], 'test', scope);
+      capsuleStore.setCapsule(contract, src.add(new Fr(2)), valuesArray[2], 'test', scope);
 
       const dst = new Fr(4);
       await capsuleStore.copyCapsule(contract, src, dst, 3, 'test', scope);
 
-      expect(await capsuleStore.loadCapsule(contract, dst, 'test', scope)).toEqual(valuesArray[0]);
-      expect(await capsuleStore.loadCapsule(contract, dst.add(new Fr(1)), 'test', scope)).toEqual(valuesArray[1]);
-      expect(await capsuleStore.loadCapsule(contract, dst.add(new Fr(2)), 'test', scope)).toEqual(valuesArray[2]);
+      expect(await capsuleStore.getCapsule(contract, dst, 'test', scope)).toEqual(valuesArray[0]);
+      expect(await capsuleStore.getCapsule(contract, dst.add(new Fr(1)), 'test', scope)).toEqual(valuesArray[1]);
+      expect(await capsuleStore.getCapsule(contract, dst.add(new Fr(2)), 'test', scope)).toEqual(valuesArray[2]);
 
       // Slots 5 and 6 (src[0] and src[1]) should have been overwritten since they are also dst[1] and dst[2]
-      expect(await capsuleStore.loadCapsule(contract, src, 'test', scope)).toEqual(valuesArray[1]); // dst[1]
-      expect(await capsuleStore.loadCapsule(contract, src.add(new Fr(1)), 'test', scope)).toEqual(valuesArray[2]); // dst[2]
-      expect(await capsuleStore.loadCapsule(contract, src.add(new Fr(2)), 'test', scope)).toEqual(valuesArray[2]); // src[2] (unchanged)
+      expect(await capsuleStore.getCapsule(contract, src, 'test', scope)).toEqual(valuesArray[1]); // dst[1]
+      expect(await capsuleStore.getCapsule(contract, src.add(new Fr(1)), 'test', scope)).toEqual(valuesArray[2]); // dst[2]
+      expect(await capsuleStore.getCapsule(contract, src.add(new Fr(2)), 'test', scope)).toEqual(valuesArray[2]); // src[2] (unchanged)
     });
 
     it('copying fails if any value is empty', async () => {
       const src = new Fr(1);
       const valuesArray = [[new Fr(42)], [new Fr(1337)], [new Fr(13)]];
 
-      capsuleStore.storeCapsule(contract, src, valuesArray[0], 'test', scope);
+      capsuleStore.setCapsule(contract, src, valuesArray[0], 'test', scope);
       // We skip src[1]
-      capsuleStore.storeCapsule(contract, src.add(new Fr(2)), valuesArray[2], 'test', scope);
+      capsuleStore.setCapsule(contract, src.add(new Fr(2)), valuesArray[2], 'test', scope);
 
       const dst = new Fr(5);
       await expect(capsuleStore.copyCapsule(contract, src, dst, 3, 'test', scope)).rejects.toThrow(
@@ -227,11 +227,11 @@ describe('capsule data provider', () => {
       const dst = new Fr(5);
       const values = [new Fr(42)];
 
-      capsuleStore.storeCapsule(contract, src, values, 'test', scope);
+      capsuleStore.setCapsule(contract, src, values, 'test', scope);
       await capsuleStore.copyCapsule(contract, src, dst, 1, 'test', scope);
 
-      expect(await capsuleStore.loadCapsule(contract, dst, 'test', scope)).toEqual(values);
-      expect(await capsuleStore.loadCapsule(contract, dst, 'test', AztecAddress.ZERO)).toBeNull();
+      expect(await capsuleStore.getCapsule(contract, dst, 'test', scope)).toEqual(values);
+      expect(await capsuleStore.getCapsule(contract, dst, 'test', AztecAddress.ZERO)).toBeNull();
     });
   });
 
@@ -243,11 +243,9 @@ describe('capsule data provider', () => {
 
         await capsuleStore.appendToCapsuleArray(contract, baseSlot, array, 'test', scope);
 
-        expect(await capsuleStore.loadCapsule(contract, baseSlot, 'test', scope)).toEqual([new Fr(array.length)]);
+        expect(await capsuleStore.getCapsule(contract, baseSlot, 'test', scope)).toEqual([new Fr(array.length)]);
         for (const i of range(array.length)) {
-          expect(await capsuleStore.loadCapsule(contract, baseSlot.add(new Fr(1 + i)), 'test', scope)).toEqual(
-            array[i],
-          );
+          expect(await capsuleStore.getCapsule(contract, baseSlot.add(new Fr(1 + i)), 'test', scope)).toEqual(array[i]);
         }
       });
 
@@ -262,9 +260,9 @@ describe('capsule data provider', () => {
 
         const expectedLength = originalArray.length + newElements.length;
 
-        expect(await capsuleStore.loadCapsule(contract, baseSlot, 'test', scope)).toEqual([new Fr(expectedLength)]);
+        expect(await capsuleStore.getCapsule(contract, baseSlot, 'test', scope)).toEqual([new Fr(expectedLength)]);
         for (const i of range(expectedLength)) {
-          expect(await capsuleStore.loadCapsule(contract, baseSlot.add(new Fr(1 + i)), 'test', scope)).toEqual(
+          expect(await capsuleStore.getCapsule(contract, baseSlot.add(new Fr(1 + i)), 'test', scope)).toEqual(
             [...originalArray, ...newElements][i],
           );
         }
@@ -292,7 +290,7 @@ describe('capsule data provider', () => {
         const baseSlot = new Fr(3);
 
         // Store in the base slot a non-zero value, indicating a non-zero array length
-        capsuleStore.storeCapsule(contract, baseSlot, [new Fr(1)], 'test', scope);
+        capsuleStore.setCapsule(contract, baseSlot, [new Fr(1)], 'test', scope);
 
         // Reading should now fail as some of the capsules in the array are empty
         await expect(capsuleStore.readCapsuleArray(contract, baseSlot, 'test', scope)).rejects.toThrow(
@@ -340,7 +338,7 @@ describe('capsule data provider', () => {
         // Not only do we read the expected array, but also all capsules past the new array length have been cleared
         for (const i of range(originalArray.length - newArray.length)) {
           expect(
-            await capsuleStore.loadCapsule(contract, baseSlot.add(new Fr(1 + newArray.length + i)), 'test', scope),
+            await capsuleStore.getCapsule(contract, baseSlot.add(new Fr(1 + newArray.length + i)), 'test', scope),
           ).toBeNull();
         }
       });
@@ -358,7 +356,7 @@ describe('capsule data provider', () => {
 
         // All capsules from the original array have been cleared
         for (const i of range(originalArray.length)) {
-          expect(await capsuleStore.loadCapsule(contract, baseSlot.add(new Fr(1 + i)), 'test', scope)).toBeNull();
+          expect(await capsuleStore.getCapsule(contract, baseSlot.add(new Fr(1 + i)), 'test', scope)).toBeNull();
         }
       });
     });
@@ -531,20 +529,20 @@ describe('capsule data provider', () => {
       const committedValues1 = [Fr.random()];
       const committedValues2 = [Fr.random()];
 
-      capsuleStore.storeCapsule(contract, slot, committedValues1, 'job-1', scope);
+      capsuleStore.setCapsule(contract, slot, committedValues1, 'job-1', scope);
 
       // After this commit, 'job-1' should logically be reset
       // Any read of contract-slot after this should see committedValues1
       await capsuleStore.commit('job-1');
 
       // Any read of contract-slot should see job2committedValues
-      capsuleStore.storeCapsule(contract, slot, committedValues2, 'job-2', scope);
+      capsuleStore.setCapsule(contract, slot, committedValues2, 'job-2', scope);
       await capsuleStore.commit('job-2');
 
       // If we failed to properly dispose 'job-1's staged writes on commit,
       // Instead of reading committedValues2 (as we should), we would end
       // up reading committedValues1 (which would be wrong)
-      expect(await capsuleStore.loadCapsule(contract, slot, 'job-1', scope)).toEqual(committedValues2);
+      expect(await capsuleStore.getCapsule(contract, slot, 'job-1', scope)).toEqual(committedValues2);
     });
 
     it('writes to job view are isolated from another job view', async () => {
@@ -556,17 +554,17 @@ describe('capsule data provider', () => {
       const stagedJob2: string = 'staged-job-2';
 
       // First set a committed capsule (using a different job that we commit)
-      capsuleStore.storeCapsule(contract, slot, committedValues, commitJobId, scope);
+      capsuleStore.setCapsule(contract, slot, committedValues, commitJobId, scope);
       await capsuleStore.commit(commitJobId);
 
       // Then set a staged capsule (not committed)
-      capsuleStore.storeCapsule(contract, slot, stagedValues, stagedJob1, scope);
+      capsuleStore.setCapsule(contract, slot, stagedValues, stagedJob1, scope);
 
       // With jobId=1, should get staged capsule
-      expect(await capsuleStore.loadCapsule(contract, slot, stagedJob1, scope)).toEqual(stagedValues);
+      expect(await capsuleStore.getCapsule(contract, slot, stagedJob1, scope)).toEqual(stagedValues);
 
       // With jobId=2, should get committed capsule
-      expect(await capsuleStore.loadCapsule(contract, slot, stagedJob2, scope)).toEqual(committedValues);
+      expect(await capsuleStore.getCapsule(contract, slot, stagedJob2, scope)).toEqual(committedValues);
     });
 
     it('staged deletions hide committed data', async () => {
@@ -577,17 +575,17 @@ describe('capsule data provider', () => {
       const stagedJob2: string = 'staged-job-2';
 
       // First set a committed capsule
-      capsuleStore.storeCapsule(contract, slot, committedValues, commitJobId, scope);
+      capsuleStore.setCapsule(contract, slot, committedValues, commitJobId, scope);
       await capsuleStore.commit(commitJobId);
 
       // Delete in staging (not committed)
       capsuleStore.deleteCapsule(contract, slot, stagedJob1, scope);
 
       // Without jobId=2, should still see committed capsule
-      expect(await capsuleStore.loadCapsule(contract, slot, stagedJob2, scope)).toEqual(committedValues);
+      expect(await capsuleStore.getCapsule(contract, slot, stagedJob2, scope)).toEqual(committedValues);
 
       // With jobId=1, should see null (deleted in staging)
-      expect(await capsuleStore.loadCapsule(contract, slot, stagedJob1, scope)).toBeNull();
+      expect(await capsuleStore.getCapsule(contract, slot, stagedJob1, scope)).toBeNull();
     });
 
     it('commit applies staged deletions', async () => {
@@ -596,14 +594,14 @@ describe('capsule data provider', () => {
       const commitJobId: string = 'commit-job';
       const deleteJobId: string = 'delete-job';
 
-      capsuleStore.storeCapsule(contract, slot, committedValues, commitJobId, scope);
+      capsuleStore.setCapsule(contract, slot, committedValues, commitJobId, scope);
       await capsuleStore.commit(commitJobId);
       capsuleStore.deleteCapsule(contract, slot, deleteJobId, scope);
 
       await capsuleStore.commit(deleteJobId);
 
       // Now any job should see this null (deleted)
-      expect(await capsuleStore.loadCapsule(contract, slot, 'any-job-sees-this', scope)).toBeNull();
+      expect(await capsuleStore.getCapsule(contract, slot, 'any-job-sees-this', scope)).toBeNull();
     });
 
     it('discardStaged removes staged data without affecting main', async () => {
@@ -613,17 +611,17 @@ describe('capsule data provider', () => {
       const commitJobId: string = 'commit-job';
       const stagingJobId: string = 'staging-job';
 
-      capsuleStore.storeCapsule(contract, slot, committedValues, commitJobId, scope);
+      capsuleStore.setCapsule(contract, slot, committedValues, commitJobId, scope);
       await capsuleStore.commit(commitJobId);
-      capsuleStore.storeCapsule(contract, slot, stagedValues, stagingJobId, scope);
+      capsuleStore.setCapsule(contract, slot, stagedValues, stagingJobId, scope);
 
       await capsuleStore.discardStaged(stagingJobId);
 
       // Should still get committed capsule
-      expect(await capsuleStore.loadCapsule(contract, slot, 'any-job', scope)).toEqual(committedValues);
+      expect(await capsuleStore.getCapsule(contract, slot, 'any-job', scope)).toEqual(committedValues);
 
       // With stagingJobId should fall back to committed since staging was discarded
-      expect(await capsuleStore.loadCapsule(contract, slot, stagingJobId, scope)).toEqual(committedValues);
+      expect(await capsuleStore.getCapsule(contract, slot, stagingJobId, scope)).toEqual(committedValues);
     });
   });
 });

--- a/yarn-project/pxe/src/storage/capsule_store/capsule_store.ts
+++ b/yarn-project/pxe/src/storage/capsule_store/capsule_store.ts
@@ -135,7 +135,7 @@ export class CapsuleStore implements StagedStore {
    * to public contract storage in that it's indexed by the contract address and storage slot but instead of the global
    * network state it's backed by local PXE db.
    */
-  storeCapsule(contractAddress: AztecAddress, slot: Fr, capsule: Fr[], jobId: string, scope: AztecAddress) {
+  setCapsule(contractAddress: AztecAddress, slot: Fr, capsule: Fr[], jobId: string, scope: AztecAddress) {
     const dbSlotKey = dbSlotToKey(contractAddress, slot, scope);
 
     // A store overrides any pre-existing data on the slot
@@ -148,7 +148,7 @@ export class CapsuleStore implements StagedStore {
    * @param slot - The slot in the database to read.
    * @returns The stored data or `null` if no data is stored under the slot.
    */
-  async loadCapsule(contractAddress: AztecAddress, slot: Fr, jobId: string, scope: AztecAddress): Promise<Fr[] | null> {
+  async getCapsule(contractAddress: AztecAddress, slot: Fr, jobId: string, scope: AztecAddress): Promise<Fr[] | null> {
     const dataBuffer = await this.#getFromStage(jobId, dbSlotToKey(contractAddress, slot, scope));
     if (!dataBuffer) {
       this.logger.trace(`Data not found for contract ${contractAddress.toString()} and slot ${slot.toString()}`);
@@ -240,18 +240,18 @@ export class CapsuleStore implements StagedStore {
     // and not using a transaction here would heavily impact performance.
     return this.#store.transactionAsync(async () => {
       // Load current length, defaulting to 0 if not found
-      const lengthData = await this.loadCapsule(contractAddress, baseSlot, jobId, scope);
+      const lengthData = await this.getCapsule(contractAddress, baseSlot, jobId, scope);
       const currentLength = lengthData ? lengthData[0].toNumber() : 0;
 
       // Store each capsule at consecutive slots after baseSlot + 1 + currentLength
       for (let i = 0; i < content.length; i++) {
         const nextSlot = arraySlot(baseSlot, currentLength + i);
-        this.storeCapsule(contractAddress, nextSlot, content[i], jobId, scope);
+        this.setCapsule(contractAddress, nextSlot, content[i], jobId, scope);
       }
 
       // Update length to include all new capsules
       const newLength = currentLength + content.length;
-      this.storeCapsule(contractAddress, baseSlot, [new Fr(newLength)], jobId, scope);
+      this.setCapsule(contractAddress, baseSlot, [new Fr(newLength)], jobId, scope);
     });
   }
 
@@ -263,14 +263,14 @@ export class CapsuleStore implements StagedStore {
     // of jobs: different calls running concurrently on the same contract may cause trouble.
     return this.#store.transactionAsync(async () => {
       // Load length, defaulting to 0 if not found
-      const maybeLength = await this.loadCapsule(contractAddress, baseSlot, jobId, scope);
+      const maybeLength = await this.getCapsule(contractAddress, baseSlot, jobId, scope);
       const length = maybeLength ? maybeLength[0].toBigInt() : 0n;
 
       const values: Fr[][] = [];
 
       // Read each capsule at consecutive slots after baseSlot
       for (let i = 0; i < length; i++) {
-        const currentValue = await this.loadCapsule(contractAddress, arraySlot(baseSlot, i), jobId, scope);
+        const currentValue = await this.getCapsule(contractAddress, arraySlot(baseSlot, i), jobId, scope);
         if (currentValue == undefined) {
           throw new Error(
             `Expected non-empty value at capsule array in base slot ${baseSlot} at index ${i} for contract ${contractAddress}`,
@@ -295,15 +295,15 @@ export class CapsuleStore implements StagedStore {
     // of jobs: different calls running concurrently on the same contract may cause trouble.
     return this.#store.transactionAsync(async () => {
       // Load current length, defaulting to 0 if not found
-      const maybeLength = await this.loadCapsule(contractAddress, baseSlot, jobId, scope);
+      const maybeLength = await this.getCapsule(contractAddress, baseSlot, jobId, scope);
       const originalLength = maybeLength ? maybeLength[0].toNumber() : 0;
 
       // Set the new length
-      this.storeCapsule(contractAddress, baseSlot, [new Fr(content.length)], jobId, scope);
+      this.setCapsule(contractAddress, baseSlot, [new Fr(content.length)], jobId, scope);
 
       // Store the new content, possibly overwriting existing values
       for (let i = 0; i < content.length; i++) {
-        this.storeCapsule(contractAddress, arraySlot(baseSlot, i), content[i], jobId, scope);
+        this.setCapsule(contractAddress, arraySlot(baseSlot, i), content[i], jobId, scope);
       }
 
       // Clear any stragglers

--- a/yarn-project/txe/src/oracle/txe_oracle_top_level_context.ts
+++ b/yarn-project/txe/src/oracle/txe_oracle_top_level_context.ts
@@ -416,7 +416,7 @@ export class TXEOracleTopLevelContext implements IMiscOracle, ITxeExecutionOracl
       );
       const publicFunctionsCalldata = await Promise.all(
         publicCallRequests.map(async r => {
-          const calldata = await privateExecutionOracle.loadFromExecutionCache(r.calldataHash);
+          const calldata = await privateExecutionOracle.getHashPreimage(r.calldataHash);
           return new HashedValues(calldata, r.calldataHash);
         }),
       );

--- a/yarn-project/txe/src/rpc_translator.ts
+++ b/yarn-project/txe/src/rpc_translator.ts
@@ -343,7 +343,7 @@ export class RPCTranslator {
     const values = fromArray(foreignValues);
     const hash = fromSingle(foreignHash);
 
-    this.handlerAsPrivate().storeInExecutionCache(values, hash);
+    this.handlerAsPrivate().setHashPreimage(values, hash);
 
     return toForeignCallResult([]);
   }
@@ -352,7 +352,7 @@ export class RPCTranslator {
   async aztec_prv_getHashPreimage(foreignHash: ForeignCallSingle) {
     const hash = fromSingle(foreignHash);
 
-    const returns = await this.handlerAsPrivate().loadFromExecutionCache(hash);
+    const returns = await this.handlerAsPrivate().getHashPreimage(hash);
 
     return toForeignCallResult([toArray(returns)]);
   }
@@ -389,7 +389,7 @@ export class RPCTranslator {
     const startStorageSlot = fromSingle(foreignStartStorageSlot);
     const numberOfElements = fromSingle(foreignNumberOfElements).toNumber();
 
-    const values = await this.handlerAsUtility().storageRead(
+    const values = await this.handlerAsUtility().getFromPublicStorage(
       blockHash,
       contractAddress,
       startStorageSlot,
@@ -559,7 +559,7 @@ export class RPCTranslator {
   async aztec_utl_doesNullifierExist(foreignInnerNullifier: ForeignCallSingle) {
     const innerNullifier = fromSingle(foreignInnerNullifier);
 
-    const exists = await this.handlerAsUtility().checkNullifierExists(innerNullifier);
+    const exists = await this.handlerAsUtility().doesNullifierExist(innerNullifier);
 
     return toForeignCallResult([toSingle(new Fr(exists))]);
   }
@@ -585,7 +585,7 @@ export class RPCTranslator {
   async aztec_utl_getPublicKeysAndPartialAddress(foreignAddress: ForeignCallSingle) {
     const address = addressFromSingle(foreignAddress);
 
-    const result = await this.handlerAsUtility().tryGetPublicKeysAndPartialAddress(address);
+    const result = await this.handlerAsUtility().getPublicKeysAndPartialAddress(address);
 
     // We are going to return a Noir Option struct to represent the possibility of null values. Options are a struct
     // with two fields: `some` (a boolean) and `value` (a field array in this case).
@@ -664,7 +664,7 @@ export class RPCTranslator {
   // eslint-disable-next-line camelcase
   public async aztec_prv_isExecutionInRevertiblePhase(foreignSideEffectCounter: ForeignCallSingle) {
     const sideEffectCounter = fromSingle(foreignSideEffectCounter).toNumber();
-    const isRevertible = await this.handlerAsPrivate().inRevertiblePhase(sideEffectCounter);
+    const isRevertible = await this.handlerAsPrivate().isExecutionInRevertiblePhase(sideEffectCounter);
     return toForeignCallResult([toSingle(new Fr(isRevertible))]);
   }
 
@@ -745,7 +745,7 @@ export class RPCTranslator {
     const pendingTaggedLogArrayBaseSlot = fromSingle(foreignPendingTaggedLogArrayBaseSlot);
     const scope = AztecAddress.fromField(fromSingle(foreignScope));
 
-    await this.handlerAsUtility().fetchTaggedLogs(pendingTaggedLogArrayBaseSlot, scope);
+    await this.handlerAsUtility().getPendingTaggedLogs(pendingTaggedLogArrayBaseSlot, scope);
 
     return toForeignCallResult([]);
   }
@@ -790,7 +790,7 @@ export class RPCTranslator {
     const logRetrievalResponsesArrayBaseSlot = fromSingle(foreignLogRetrievalResponsesArrayBaseSlot);
     const scope = AztecAddress.fromField(fromSingle(foreignScope));
 
-    await this.handlerAsUtility().bulkRetrieveLogs(
+    await this.handlerAsUtility().getLogsByTag(
       contractAddress,
       logRetrievalRequestsArrayBaseSlot,
       logRetrievalResponsesArrayBaseSlot,
@@ -812,7 +812,7 @@ export class RPCTranslator {
     const messageContextResponsesArrayBaseSlot = fromSingle(foreignMessageContextResponsesArrayBaseSlot);
     const scope = AztecAddress.fromField(fromSingle(foreignScope));
 
-    await this.handlerAsUtility().utilityResolveMessageContexts(
+    await this.handlerAsUtility().getMessageContextsByTxHash(
       contractAddress,
       messageContextRequestsArrayBaseSlot,
       messageContextResponsesArrayBaseSlot,
@@ -834,7 +834,7 @@ export class RPCTranslator {
     const capsule = fromArray(foreignCapsule);
     const scope = AztecAddress.fromField(fromSingle(foreignScope));
 
-    this.handlerAsUtility().storeCapsule(contractAddress, slot, capsule, scope);
+    this.handlerAsUtility().setCapsule(contractAddress, slot, capsule, scope);
 
     return toForeignCallResult([]);
   }
@@ -851,7 +851,7 @@ export class RPCTranslator {
     const tSize = fromSingle(foreignTSize).toNumber();
     const scope = AztecAddress.fromField(fromSingle(foreignScope));
 
-    const values = await this.handlerAsUtility().loadCapsule(contractAddress, slot, scope);
+    const values = await this.handlerAsUtility().getCapsule(contractAddress, slot, scope);
 
     // We are going to return a Noir Option struct to represent the possibility of null values. Options are a struct
     // with two fields: `some` (a boolean) and `value` (a field array in this case).
@@ -915,7 +915,7 @@ export class RPCTranslator {
 
     // Noir Option<BoundedVec> is encoded as [is_some: Field, storage: Field[], length: Field].
     try {
-      const plaintextBuffer = await this.handlerAsUtility().aes128Decrypt(ciphertext, iv, symKey);
+      const plaintextBuffer = await this.handlerAsUtility().decryptAes128(ciphertext, iv, symKey);
       const [storage, length] = arrayToBoundedVec(
         bufferToU8Array(plaintextBuffer),
         foreignCiphertextBVecStorage.length,
@@ -960,7 +960,7 @@ export class RPCTranslator {
       .slice(0, count)
       .map(f => new AztecAddress(f));
 
-    this.handlerAsUtility().invalidateContractSyncCache(contractAddress, scopes);
+    this.handlerAsUtility().setContractSyncCacheInvalid(contractAddress, scopes);
 
     return Promise.resolve(toForeignCallResult([]));
   }


### PR DESCRIPTION
This is a continuation of #22018. While #22018 changed actual oracle names, this is just about making the internal names of PXE oracle implemenations align with the new ones. This change should have nil impact in oracle versions and public API's.