### PR TITLE
fix(p2p): replace process.exit() with graceful shutdown in worker cleanup

### DIFF
--- a/yarn-project/p2p/src/client/test/tx_proposal_collector/proposal_tx_collector_worker.ts
+++ b/yarn-project/p2p/src/client/test/tx_proposal_collector/proposal_tx_collector_worker.ts
@@ -259,9 +259,20 @@ async function stopClient() {
   attestationPool = undefined;
 }
 
+function gracefulExit(code: number = 0) {
+  try {
+    if (process.connected) {
+      process.disconnect();
+    }
+  } catch {
+    // IPC channel already closed
+  }
+  setTimeout(() => process.exit(code), 5000).unref();
+}
+
 process.on('disconnect', () => {
   ipcDisconnected = true;
-  void stopClient().finally(() => process.exit(0));
+  void stopClient();
 });
 
 process.on('error', err => {
@@ -325,7 +336,7 @@ process.on('message', (msg: WorkerCommand) => {
         case 'STOP': {
           await stopClient();
           await sendMessage({ type: 'STOPPED', requestId });
-          process.exit(0);
+          gracefulExit(0);
           break;
         }
         default: {
@@ -336,7 +347,8 @@ process.on('message', (msg: WorkerCommand) => {
     } catch (err: any) {
       await sendMessage({ type: 'ERROR', requestId, error: err?.message ?? String(err) });
       if (msg.type === 'START') {
-        process.exit(1);
+        await stopClient();
+        gracefulExit(1);
       }
     }
   })();

--- a/yarn-project/p2p/src/testbench/p2p_client_testbench_worker.ts
+++ b/yarn-project/p2p/src/testbench/p2p_client_testbench_worker.ts
@@ -321,6 +321,37 @@ let workerConfig: P2PConfig | null = null;
 let workerLogger: Logger | null = null;
 let kvStore: Awaited<ReturnType<typeof openTmpStore>> | null = null;
 
+async function stopWorker() {
+  try {
+    if (workerClient) {
+      await workerClient.stop();
+      workerClient = null;
+    }
+  } catch (e) {
+    workerLogger?.error('Error stopping worker client', e);
+  }
+  try {
+    if (kvStore?.close) {
+      await kvStore.close();
+      kvStore = null;
+    }
+  } catch (e) {
+    workerLogger?.error('Error closing kv store', e);
+  }
+}
+
+function gracefulExit(code: number = 0) {
+  try {
+    if (process.connected) {
+      process.disconnect();
+    }
+  } catch {
+    // IPC channel already closed
+  }
+  // Safety fallback if lingering handles prevent the event loop from draining
+  setTimeout(() => process.exit(code), 5000).unref();
+}
+
 // eslint-disable-next-line @typescript-eslint/no-misused-promises
 process.on('message', async msg => {
   const {
@@ -410,13 +441,8 @@ process.on('message', async msg => {
     const cmd = msg as any;
     switch (cmd.type) {
       case 'STOP':
-        if (workerClient) {
-          await workerClient.stop();
-        }
-        if (kvStore?.close) {
-          await kvStore.close();
-        }
-        process.exit(0);
+        await stopWorker();
+        gracefulExit(0);
         break;
 
       case 'SEND_TX':
@@ -493,7 +519,12 @@ process.on('message', async msg => {
       }
     }
   } catch (err: any) {
-    process.send!({ type: 'ERROR', error: err.message });
-    process.exit(1);
+    try {
+      process.send!({ type: 'ERROR', error: err.message });
+    } catch {
+      // IPC channel may be closed
+    }
+    await stopWorker();
+    gracefulExit(1);
   }
 });

--- a/yarn-project/p2p/src/testbench/worker_client_manager.ts
+++ b/yarn-project/p2p/src/testbench/worker_client_manager.ts
@@ -72,7 +72,6 @@ class WorkerClientManager {
   destroy() {
     this.cleanup().catch((error: Error) => {
       this.logger.error('Failed to cleanup worker client manager', error);
-      process.exit(1);
     });
   }
 


### PR DESCRIPTION
## Summary

Fixes [A-731](https://linear.app/aztec-labs/issue/A-731)

- **`worker_client_manager.ts`**: Removed `process.exit(1)` from parent-process `destroy()` method — a cleanup failure no longer kills the entire parent process.
- **`p2p_client_testbench_worker.ts`**: Added `stopWorker()` helper for resource cleanup and `gracefulExit()` that uses `process.disconnect()` to flush pending IPC messages, with a 5s safety timeout. Error handler now cleans up before exiting.
- **`proposal_tx_collector_worker.ts`**: Same `gracefulExit()` pattern. START failure now runs `stopClient()` before exiting. Disconnect handler no longer calls `process.exit(0)` — just cleans up and lets the event loop drain.

Made with [Cursor](https://cursor.com)