### PR TITLE
fix(pxe): warn when block header unavailable for proven/finalized events

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/macros/utils.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/utils.nr
@@ -30,13 +30,9 @@ pub(crate) comptime fn is_fn_initializer(f: FunctionDefinition) -> bool {
 }
 
 pub(crate) comptime fn fn_has_noinitcheck(f: FunctionDefinition) -> bool {
-    if f.has_named_attribute("noinitcheck") {
-        true
-    } else {
-        // #[only_self] functions automatically skip the initialization check as the check is assumed to be done by the
-        // calling external function or explicitly skipped. See only_self function docs for more details.
-        is_fn_only_self(f)
-    }
+    // #[only_self] functions automatically skip the initialization check as the check is assumed to be done by the
+    // calling external function or explicitly skipped. See only_self function docs for more details.
+    f.has_named_attribute("noinitcheck") | is_fn_only_self(f)
 }
 
 pub(crate) comptime fn fn_has_allow_phase_change(f: FunctionDefinition) -> bool {

--- a/yarn-project/pxe/src/block_synchronizer/block_synchronizer.ts
+++ b/yarn-project/pxe/src/block_synchronizer/block_synchronizer.ts
@@ -156,6 +156,8 @@ export class BlockSynchronizer implements L2BlockStreamEventHandler {
     }
 
     this.log.debug(`Syncing PXE with the node`);
+    // Capture the promise locally so we always await the exact promise we created, even if this.isSyncing is modified
+    // between assignment and await (e.g. due to future refactors introducing a yield point).
     const isSyncing = this.doSync();
     this.isSyncing = isSyncing;
     try {

--- a/yarn-project/pxe/src/block_synchronizer/block_synchronizer.ts
+++ b/yarn-project/pxe/src/block_synchronizer/block_synchronizer.ts
@@ -77,6 +77,8 @@ export class BlockSynchronizer implements L2BlockStreamEventHandler {
           const blockHeader = await this.node.getBlockHeader(BlockNumber(event.block.number));
           if (blockHeader) {
             await this.updateAnchorBlockHeader(blockHeader);
+          } else {
+            this.log.warn(`Block header not found for proven block ${event.block.number}, skipping anchor update`);
           }
         }
         break;
@@ -86,6 +88,8 @@ export class BlockSynchronizer implements L2BlockStreamEventHandler {
           const blockHeader = await this.node.getBlockHeader(BlockNumber(event.block.number));
           if (blockHeader) {
             await this.updateAnchorBlockHeader(blockHeader);
+          } else {
+            this.log.warn(`Block header not found for finalized block ${event.block.number}, skipping anchor update`);
           }
         }
         break;


### PR DESCRIPTION
Improved logging based on audit finding 114 in #21500 + random improvements that I noticed could be done

## Summary
- Adds warning logs in PXE block synchronizer when `getBlockHeader` returns null for `chain-proven` and `chain-finalized` events, instead of silently skipping the anchor update.
- Aligns with the `chain-pruned` handler which already throws on missing headers.

Closes #21500 .
