### PR TITLE
fix(aztec.js): preserve extraHashedArgs in DeployMethod.with()

### DIFF
--- a/yarn-project/aztec.js/src/contract/deploy_method.ts
+++ b/yarn-project/aztec.js/src/contract/deploy_method.ts
@@ -468,11 +468,14 @@ export class DeployMethod<TContract extends ContractBase = ContractBase> extends
   public with({
     authWitnesses = [],
     capsules = [],
+    extraHashedArgs = [],
   }: {
     /** The authWitnesses to add to the deployment */
     authWitnesses?: AuthWitness[];
     /** The capsules to add to the deployment */
     capsules?: Capsule[];
+    /** The extra hashed args to add to the deployment */
+    extraHashedArgs?: HashedValues[];
   }): DeployMethod {
     return new DeployMethod(
       this.publicKeys,
@@ -483,6 +486,7 @@ export class DeployMethod<TContract extends ContractBase = ContractBase> extends
       this.constructorArtifact?.name,
       this.authWitnesses.concat(authWitnesses),
       this.capsules.concat(capsules),
+      this.extraHashedArgs.concat(extraHashedArgs),
     );
   }
 }


### PR DESCRIPTION
## Summary
- `DeployMethod.with()` was silently dropping `extraHashedArgs` — it neither accepted them as a parameter nor forwarded the existing ones to the new instance
- Added `extraHashedArgs` parameter and forward `this.extraHashedArgs.concat(extraHashedArgs)` to match how `ContractFunctionInteraction.with()` already handles it

Fixes [A-840](https://linear.app/aztec-labs/issue/A-840/audit-192-deploymethodwith-drops-extrahashedargs)

Made with [Cursor](https://cursor.com)