### PR TITLE
refactor: use Make targets for ci-barretenberg CI paths

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -235,7 +235,7 @@ bb-sol: bb-cpp-native bb-crs
 # Barretenberg Tests
 #==============================================================================
 
-bb-cpp-native-tests: bb-cpp-native
+bb-cpp-native-tests: bb-cpp-native bb-crs
 	$(call test,$@,barretenberg/cpp,native)
 
 bb-cpp-wasm-threads-tests: bb-cpp-wasm-threads

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -844,7 +844,7 @@ case "$cmd" in
     export USE_TEST_CACHE=1
     export AVM=0
     export AVM_TRANSPILER=0
-    barretenberg/cpp/bootstrap.sh ci
+    make bb-cpp-native-tests
     ;;
   "ci-barretenberg-full")
     export CI=1
@@ -854,7 +854,7 @@ case "$cmd" in
     export AVM_TRANSPILER=0
     pull_submodules
     noir/bootstrap.sh build_native  # Build nargo for acir_tests
-    barretenberg/bootstrap.sh ci
+    make bb-tests bb-full-tests
     ;;
 
   #######################


### PR DESCRIPTION
## Summary

- `ci-barretenberg` now uses `make bb-cpp-native-tests` instead of calling `barretenberg/cpp/bootstrap.sh ci` directly
- `ci-barretenberg-full` now uses `make bb-tests bb-full-tests` instead of `barretenberg/bootstrap.sh ci`
- Adds `bb-crs` as a dependency of `bb-cpp-native-tests`

This ensures dependencies like `bb-crs` are resolved automatically by Make, fixing test failures when `bn254_g1_compressed.dat` is missing from the CRS cache (e.g. `CrsFactory.Bn254CompressedChunkHash` tests). Previously, `ci-barretenberg` called `barretenberg/cpp/bootstrap.sh ci` directly, which never ran the CRS download step.

The underlying build and test functions are unchanged; only the orchestration layer switches from direct bootstrap.sh calls to Make targets.

## Test plan

- [ ] `ci-barretenberg` label triggers the same build+test flow via Make
- [ ] `ci-barretenberg-full` label triggers the same full build+test flow via Make
- [ ] CRS tests (CrsFactory.Bn254CompressedChunkHash*) pass even without pre-baked CRS in the AMI