### PR TITLE
chore: cache getSenders and getAccounts to avoid redundant DB reads

### DIFF
--- a/yarn-project/key-store/src/key_store.ts
+++ b/yarn-project/key-store/src/key_store.ts
@@ -29,6 +29,7 @@ export class KeyStore {
   public static readonly SCHEMA_VERSION = 1;
   #db: AztecAsyncKVStore;
   #keys: AztecAsyncMap<string, Buffer>;
+  #cachedAccounts: AztecAddress[] | undefined;
 
   constructor(database: AztecAsyncKVStore) {
     this.#db = database;
@@ -89,6 +90,8 @@ export class KeyStore {
       await this.#keys.set(`${account.toString()}-tpk_m_hash`, masterTaggingPublicKeyHash.toBuffer());
     });
 
+    this.#cachedAccounts = undefined;
+
     // At last, we return the newly derived account address
     return completeAddress;
   }
@@ -98,10 +101,14 @@ export class KeyStore {
    * @returns A Promise that resolves to an array of account addresses.
    */
   public async getAccounts(): Promise<AztecAddress[]> {
+    if (this.#cachedAccounts) {
+      return this.#cachedAccounts;
+    }
     const allMapKeys = await toArray(this.#keys.keysAsync());
     // We return account addresses based on the map keys that end with '-ivsk_m'
     const accounts = allMapKeys.filter(key => key.endsWith('-ivsk_m')).map(key => key.split('-')[0]);
-    return accounts.map(account => AztecAddress.fromString(account));
+    this.#cachedAccounts = accounts.map(account => AztecAddress.fromString(account));
+    return this.#cachedAccounts;
   }
 
   /** Checks whether an account is registered in the key store. */

--- a/yarn-project/pxe/src/storage/tagging_store/sender_address_book_store.ts
+++ b/yarn-project/pxe/src/storage/tagging_store/sender_address_book_store.ts
@@ -9,6 +9,7 @@ import { AztecAddress } from '@aztec/stdlib/aztec-address';
 export class SenderAddressBookStore {
   #store: AztecAsyncKVStore;
   #addressBook: AztecAsyncMap<string, true>;
+  #cachedSenders: AztecAddress[] | undefined;
 
   constructor(store: AztecAsyncKVStore) {
     this.#store = store;
@@ -23,14 +24,19 @@ export class SenderAddressBookStore {
       }
 
       await this.#addressBook.set(address.toString(), true);
+      this.#cachedSenders = undefined;
 
       return true;
     });
   }
 
   getSenders(): Promise<AztecAddress[]> {
+    if (this.#cachedSenders) {
+      return Promise.resolve(this.#cachedSenders);
+    }
     return this.#store.transactionAsync(async () => {
-      return (await toArray(this.#addressBook.keysAsync())).map(AztecAddress.fromString);
+      this.#cachedSenders = (await toArray(this.#addressBook.keysAsync())).map(AztecAddress.fromString);
+      return this.#cachedSenders;
     });
   }
 
@@ -41,6 +47,7 @@ export class SenderAddressBookStore {
       }
 
       await this.#addressBook.delete(address.toString());
+      this.#cachedSenders = undefined;
 
       return true;
     });


### PR DESCRIPTION
This is a follow up to #21923. 