### PR TITLE
fix: CRS tests work without compressed data on disk

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -235,7 +235,7 @@ bb-sol: bb-cpp-native bb-crs
 # Barretenberg Tests
 #==============================================================================
 
-bb-cpp-native-tests: bb-cpp-native bb-crs
+bb-cpp-native-tests: bb-cpp-native
 	$(call test,$@,barretenberg/cpp,native)
 
 bb-cpp-wasm-threads-tests: bb-cpp-wasm-threads

--- a/barretenberg/cpp/bootstrap.sh
+++ b/barretenberg/cpp/bootstrap.sh
@@ -380,8 +380,6 @@ case "$cmd" in
     build
     ;;
   "ci")
-    # Ensure CRS is downloaded before running tests
-    ../crs/bootstrap.sh
     build
     test
     ;;

--- a/barretenberg/cpp/src/barretenberg/srs/factories/crs_factory.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/srs/factories/crs_factory.test.cpp
@@ -10,6 +10,7 @@
 #include "barretenberg/srs/factories/mem_grumpkin_crs_factory.hpp"
 #include "barretenberg/srs/factories/native_crs_factory.hpp"
 #include "barretenberg/srs/global_crs.hpp"
+#include "http_download.hpp"
 #include <gtest/gtest.h>
 #include <span>
 #include <utility>
@@ -124,8 +125,10 @@ TEST(CrsFactory, DISABLED_Bn254Fallback)
 
 TEST(CrsFactory, Bn254CompressedChunkHashFirstChunk)
 {
-    // Verify that the first 4MB chunk of the compressed CRS matches the embedded hash
-    auto data = read_file(bb::srs::bb_crs_path() / "bn254_g1_compressed.dat", bb::srs::SRS_CHUNK_SIZE_BYTES);
+    // Download the first chunk of compressed CRS from CDN and verify its hash.
+    // We don't require compressed data on disk; only uncompressed is cached.
+    auto data = bb::srs::http_download(
+        "http://crs.aztec-cdn.foundation/g1_compressed.dat", 0, bb::srs::SRS_CHUNK_SIZE_BYTES - 1);
     auto chunk = std::span<const uint8_t>(data.data(), data.size());
     auto hash = bb::crypto::sha256(chunk);
     EXPECT_EQ(hash, bb::srs::BN254_G1_CHUNK_HASHES[0]);
@@ -133,8 +136,9 @@ TEST(CrsFactory, Bn254CompressedChunkHashFirstChunk)
 
 TEST(CrsFactory, Bn254CompressedChunkHashCorruptionDetected)
 {
-    // Verify that corrupted data fails chunk hash verification
-    auto data = read_file(bb::srs::bb_crs_path() / "bn254_g1_compressed.dat", bb::srs::SRS_CHUNK_SIZE_BYTES);
+    // Download compressed data and verify that corruption is detected.
+    auto data = bb::srs::http_download(
+        "http://crs.aztec-cdn.foundation/g1_compressed.dat", 0, bb::srs::SRS_CHUNK_SIZE_BYTES - 1);
 
     data[bb::srs::SRS_CHUNK_SIZE_BYTES / 2] ^= 0xFF;
     auto chunk = std::span<const uint8_t>(data.data(), data.size());

--- a/barretenberg/crs/bootstrap.sh
+++ b/barretenberg/crs/bootstrap.sh
@@ -8,7 +8,7 @@ shift || true
 # Download ignition up front to ensure no race conditions at runtime.
 # 2^25 points + 1 because the first is the generator, *32 bytes per compressed point, -1 because Range is inclusive.
 # We make the file read only to ensure no test can attempt to grow it any larger. 2^25 is already huge...
-# TODO: Make bb just download and append/overwrite required range, then it becomes idempotent.
+# Set CRS_UNCOMPRESSED=1 to also download uncompressed (64 bytes/point) for fast cold starts.
 
 # Primary CRS host (Cloudflare R2)
 CRS_PRIMARY_HOST="https://crs.aztec-cdn.foundation"
@@ -47,15 +47,31 @@ download_with_fallback() {
 function build {
   crs_path=$HOME/.bb-crs
   crs_size=$((2**25+1))
+  mkdir -p $crs_path
+
+  # Download compressed CRS (32 bytes/point) by default.
+  # bb will decompress and cache uncompressed on first use.
   crs_size_bytes=$((crs_size*32))
   g1=$crs_path/bn254_g1_compressed.dat
-  g2=$crs_path/bn254_g2.dat
   if [ ! -f "$g1" ] || [ $(stat -c%s "$g1") -lt $crs_size_bytes ]; then
     echo "Downloading compressed crs of size: ${crs_size} ($((crs_size_bytes/(1024*1024)))MB)"
-    mkdir -p $crs_path
     download_with_fallback "$g1" "g1_compressed.dat" "bytes=0-$((crs_size_bytes-1))"
     chmod a-w "$g1"
   fi
+
+  # Optionally also download uncompressed (64 bytes/point) to avoid decompression at runtime.
+  # Used for AMI baking where we want fast cold starts.
+  if [ "${CRS_UNCOMPRESSED:-0}" -eq 1 ]; then
+    g1_uncompressed=$crs_path/bn254_g1.dat
+    g1_uncompressed_bytes=$((crs_size*64))
+    if [ ! -f "$g1_uncompressed" ] || [ $(stat -c%s "$g1_uncompressed") -lt $g1_uncompressed_bytes ]; then
+      echo "Downloading uncompressed crs of size: ${crs_size} ($((g1_uncompressed_bytes/(1024*1024)))MB)"
+      download_with_fallback "$g1_uncompressed" "g1.dat" "bytes=0-$((g1_uncompressed_bytes-1))"
+      chmod a-w "$g1_uncompressed"
+    fi
+  fi
+
+  g2=$crs_path/bn254_g2.dat
   if [ ! -f "$g2" ]; then
     download_with_fallback "$g2" "g2.dat"
   fi

--- a/barretenberg/crs/bootstrap.sh
+++ b/barretenberg/crs/bootstrap.sh
@@ -6,9 +6,12 @@ shift || true
 
 # To run bb we need a crs.
 # Download ignition up front to ensure no race conditions at runtime.
-# 2^25 points + 1 because the first is the generator, *32 bytes per compressed point, -1 because Range is inclusive.
+# 2^25 points + 1 because the first is the generator, -1 because Range header is inclusive.
 # We make the file read only to ensure no test can attempt to grow it any larger. 2^25 is already huge...
-# Set CRS_UNCOMPRESSED=1 to also download uncompressed (64 bytes/point) for fast cold starts.
+#
+# CRS_FORMAT controls which BN254 G1 format to use:
+#   uncompressed  - Download uncompressed (64 bytes/point), delete compressed. Used for AMI baking.
+#   (default)     - Happy if either format already exists. If neither, download compressed.
 
 # Primary CRS host (Cloudflare R2)
 CRS_PRIMARY_HOST="https://crs.aztec-cdn.foundation"
@@ -49,27 +52,46 @@ function build {
   crs_size=$((2**25+1))
   mkdir -p $crs_path
 
-  # Download compressed CRS (32 bytes/point) by default.
-  # bb will decompress and cache uncompressed on first use.
-  crs_size_bytes=$((crs_size*32))
-  g1=$crs_path/bn254_g1_compressed.dat
-  if [ ! -f "$g1" ] || [ $(stat -c%s "$g1") -lt $crs_size_bytes ]; then
-    echo "Downloading compressed crs of size: ${crs_size} ($((crs_size_bytes/(1024*1024)))MB)"
-    download_with_fallback "$g1" "g1_compressed.dat" "bytes=0-$((crs_size_bytes-1))"
-    chmod a-w "$g1"
-  fi
+  local format="${CRS_FORMAT:-}"
+  local g1_compressed=$crs_path/bn254_g1_compressed.dat
+  local g1_uncompressed=$crs_path/bn254_g1.dat
+  local compressed_bytes=$((crs_size*32))
+  local uncompressed_bytes=$((crs_size*64))
 
-  # Optionally also download uncompressed (64 bytes/point) to avoid decompression at runtime.
-  # Used for AMI baking where we want fast cold starts.
-  if [ "${CRS_UNCOMPRESSED:-0}" -eq 1 ]; then
-    g1_uncompressed=$crs_path/bn254_g1.dat
-    g1_uncompressed_bytes=$((crs_size*64))
-    if [ ! -f "$g1_uncompressed" ] || [ $(stat -c%s "$g1_uncompressed") -lt $g1_uncompressed_bytes ]; then
-      echo "Downloading uncompressed crs of size: ${crs_size} ($((g1_uncompressed_bytes/(1024*1024)))MB)"
-      download_with_fallback "$g1_uncompressed" "g1.dat" "bytes=0-$((g1_uncompressed_bytes-1))"
-      chmod a-w "$g1_uncompressed"
-    fi
-  fi
+  case "$format" in
+    uncompressed)
+      # AMI bake: download uncompressed for fast cold starts, remove compressed.
+      if [ ! -f "$g1_uncompressed" ] || [ $(stat -c%s "$g1_uncompressed") -lt $uncompressed_bytes ]; then
+        echo "Downloading uncompressed crs of size: ${crs_size} ($((uncompressed_bytes/(1024*1024)))MB)"
+        download_with_fallback "$g1_uncompressed" "g1.dat" "bytes=0-$((uncompressed_bytes-1))"
+        chmod a-w "$g1_uncompressed"
+      fi
+      if [ -f "$g1_compressed" ]; then
+        chmod u+w "$g1_compressed" && rm "$g1_compressed" && echo "Removed compressed CRS."
+      fi
+      ;;
+    "")
+      # Default: happy if either format exists. If neither, download compressed (smaller).
+      local have_uncompressed=false
+      local have_compressed=false
+      if [ -f "$g1_uncompressed" ] && [ $(stat -c%s "$g1_uncompressed") -ge $uncompressed_bytes ]; then
+        have_uncompressed=true
+      fi
+      if [ -f "$g1_compressed" ] && [ $(stat -c%s "$g1_compressed") -ge $compressed_bytes ]; then
+        have_compressed=true
+      fi
+
+      if ! $have_uncompressed && ! $have_compressed; then
+        echo "Downloading compressed crs of size: ${crs_size} ($((compressed_bytes/(1024*1024)))MB)"
+        download_with_fallback "$g1_compressed" "g1_compressed.dat" "bytes=0-$((compressed_bytes-1))"
+        chmod a-w "$g1_compressed"
+      fi
+      ;;
+    *)
+      echo "Unknown CRS_FORMAT: $format (expected: uncompressed or empty)"
+      exit 1
+      ;;
+  esac
 
   g2=$crs_path/bn254_g2.dat
   if [ ! -f "$g2" ]; then

--- a/ci3/aws/ami_update.sh
+++ b/ci3/aws/ami_update.sh
@@ -50,8 +50,8 @@ ssh $ssh_args -F build_instance_ssh_config ubuntu@$ip '
 
 ssh -F build_instance_ssh_config -O exit ubuntu@$ip 2>/dev/null || true
 
-# Download crs onto machine (including uncompressed for fast cold starts).
-ssh $ssh_args -F build_instance_ssh_config ubuntu@$ip 'export CRS_UNCOMPRESSED=1; bash -s' < ../../barretenberg/crs/bootstrap.sh
+# Download uncompressed crs onto machine for fast cold starts (deletes compressed if present).
+ssh $ssh_args -F build_instance_ssh_config ubuntu@$ip 'export CRS_FORMAT=uncompressed; bash -s' < ../../barretenberg/crs/bootstrap.sh
 
 # Pull devbox onto host, and build into docker-in-docker volume.
 ssh $ssh_args -F build_instance_ssh_config ubuntu@$ip "

--- a/ci3/aws/ami_update.sh
+++ b/ci3/aws/ami_update.sh
@@ -50,8 +50,8 @@ ssh $ssh_args -F build_instance_ssh_config ubuntu@$ip '
 
 ssh -F build_instance_ssh_config -O exit ubuntu@$ip 2>/dev/null || true
 
-# Download crs onto machine.
-ssh $ssh_args -F build_instance_ssh_config ubuntu@$ip < ../../barretenberg/crs/bootstrap.sh
+# Download crs onto machine (including uncompressed for fast cold starts).
+ssh $ssh_args -F build_instance_ssh_config ubuntu@$ip 'export CRS_UNCOMPRESSED=1; bash -s' < ../../barretenberg/crs/bootstrap.sh
 
 # Pull devbox onto host, and build into docker-in-docker volume.
 ssh $ssh_args -F build_instance_ssh_config ubuntu@$ip "


### PR DESCRIPTION
## Summary
- CRS factory tests no longer require `bn254_g1_compressed.dat` on disk. `check_bn254_consistency` uses `get_bn254_g1_data()` which handles both formats. Chunk hash tests download directly from CDN inline.
- `crs/bootstrap.sh` gains a `CRS_FORMAT` mode: default is happy if either compressed or uncompressed exists; `CRS_FORMAT=uncompressed` downloads uncompressed and deletes compressed (for AMI baking).
- `ami_update.sh` uses `CRS_FORMAT=uncompressed` so AMI instances have uncompressed CRS for fast cold starts.

## Test plan
- [x] `srs_tests` builds and passes locally
- [ ] CI passes with `ci-barretenberg` label