### PR TITLE
fix(pxe): warn and return first log instead of throwing on ambiguous log retrieval

### DIFF
--- a/yarn-project/pxe/src/logs/log_service.test.ts
+++ b/yarn-project/pxe/src/logs/log_service.test.ts
@@ -84,6 +84,48 @@ describe('LogService', () => {
       expect(responses[0]).not.toBeNull();
     });
 
+    it('returns first log when multiple public logs are found for a single tag', async () => {
+      const scopedLog1 = randomTxScopedPrivateL2Log();
+      const scopedLog2 = randomTxScopedPrivateL2Log();
+
+      aztecNode.getPublicLogsByTagsFromContract.mockResolvedValue([[scopedLog1, scopedLog2]]);
+      aztecNode.getPrivateLogsByTags.mockResolvedValue([[]]);
+
+      const request = new LogRetrievalRequest(contractAddress, tag);
+      const responses = await logService.fetchLogsByTag([request]);
+
+      expect(responses.length).toEqual(1);
+      expect(responses[0]).not.toBeNull();
+    });
+
+    it('returns first log when multiple private logs are found for a single tag', async () => {
+      const scopedLog1 = randomTxScopedPrivateL2Log();
+      const scopedLog2 = randomTxScopedPrivateL2Log();
+
+      aztecNode.getPublicLogsByTagsFromContract.mockResolvedValue([[]]);
+      aztecNode.getPrivateLogsByTags.mockResolvedValue([[scopedLog1, scopedLog2]]);
+
+      const request = new LogRetrievalRequest(contractAddress, tag);
+      const responses = await logService.fetchLogsByTag([request]);
+
+      expect(responses.length).toEqual(1);
+      expect(responses[0]).not.toBeNull();
+    });
+
+    it('returns first log when both a public and private log are found for a single tag', async () => {
+      const publicLog = randomTxScopedPrivateL2Log();
+      const privateLog = randomTxScopedPrivateL2Log();
+
+      aztecNode.getPublicLogsByTagsFromContract.mockResolvedValue([[publicLog]]);
+      aztecNode.getPrivateLogsByTags.mockResolvedValue([[privateLog]]);
+
+      const request = new LogRetrievalRequest(contractAddress, tag);
+      const responses = await logService.fetchLogsByTag([request]);
+
+      expect(responses.length).toEqual(1);
+      expect(responses[0]).not.toBeNull();
+    });
+
     it('returns a private log if one is found', async () => {
       const scopedLog = randomTxScopedPrivateL2Log();
 

--- a/yarn-project/pxe/src/logs/log_service.ts
+++ b/yarn-project/pxe/src/logs/log_service.ts
@@ -50,8 +50,8 @@ export class LogService {
         ]);
 
         if (publicLog !== null && privateLog !== null) {
-          throw new Error(
-            `Found both a public and private log when searching for tag ${request.tag} from contract ${request.contractAddress}`,
+          this.log.warn(
+            `Found both a public and private log for tag ${request.tag} from contract ${request.contractAddress}. This may indicate a contract bug. Returning the public log.`,
           );
         }
 
@@ -73,9 +73,8 @@ export class LogService {
     if (logsForTag.length === 0) {
       return null;
     } else if (logsForTag.length > 1) {
-      // TODO(#11627): handle this case
-      throw new Error(
-        `Got ${logsForTag.length} logs for tag ${tag} and contract ${contractAddress.toString()}. getPublicLogByTag currently only supports a single log per tag`,
+      this.log.warn(
+        `Expected at most 1 public log for tag ${tag} and contract ${contractAddress.toString()}, got ${logsForTag.length}. This may indicate a contract bug. Returning the first log.`,
       );
     }
 
@@ -97,9 +96,8 @@ export class LogService {
     if (logsForTag.length === 0) {
       return null;
     } else if (logsForTag.length > 1) {
-      // TODO(#11627): handle this case
-      throw new Error(
-        `Got ${logsForTag.length} logs for tag ${siloedTag}. getPrivateLogByTag currently only supports a single log per tag`,
+      this.log.warn(
+        `Expected at most 1 private log for tag ${siloedTag}, got ${logsForTag.length}. This may indicate a contract bug. Returning the first log.`,
       );
     }
 


### PR DESCRIPTION
## Summary

- Replace `throw new Error` with `this.log.warn` + return the first log when `LogService` encounters ambiguous results (multiple public logs, multiple private logs, or both a public and private log for the same tag)
- Add tests covering all three ambiguous log retrieval scenarios

## Test plan

- Unit tests added and passing for all three ambiguous cases