### PR TITLE
fix(stdlib): correct NoteDao size

### DIFF
--- a/yarn-project/stdlib/src/note/note_dao.test.ts
+++ b/yarn-project/stdlib/src/note/note_dao.test.ts
@@ -7,6 +7,12 @@ describe('NoteDao', () => {
     expect(NoteDao.fromBuffer(buf)).toEqual(note);
   });
 
+  it('reports the serialized size', async () => {
+    const note = await NoteDao.random();
+
+    expect(note.getSize()).toBe(note.toBuffer().length);
+  });
+
   describe('equals', () => {
     it('returns true for identical NoteDao instances', async () => {
       const note1 = await NoteDao.random();

--- a/yarn-project/stdlib/src/note/note_dao.ts
+++ b/yarn-project/stdlib/src/note/note_dao.ts
@@ -1,6 +1,5 @@
 import { BlockNumber } from '@aztec/foundation/branded-types';
 import { Fr } from '@aztec/foundation/curves/bn254';
-import { Point } from '@aztec/foundation/curves/grumpkin';
 import { BufferReader, serializeToBuffer } from '@aztec/foundation/serialize';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
 import { Note } from '@aztec/stdlib/note';
@@ -148,9 +147,7 @@ export class NoteDao {
    * @returns - Its size in bytes.
    */
   public getSize() {
-    const noteSize = 4 + this.note.items.length * Fr.SIZE_IN_BYTES;
-    // 2 numbers for txIndexInBlock and noteIndexInTx (4 bytes each)
-    return noteSize + AztecAddress.SIZE_IN_BYTES * 2 + Fr.SIZE_IN_BYTES * 4 + TxHash.SIZE + Point.SIZE_IN_BYTES + 8;
+    return this.toBuffer().length;
   }
 
   static async random({


### PR DESCRIPTION
## Summary
- make `NoteDao.getSize()` return the actual serialized buffer length
- add a regression test that checks `getSize()` matches `toBuffer().length`

Fixes [A-838](https://linear.app/aztec-labs/issue/A-838/audit-190-notedao-getsize-calculation-incorrect)