### PR TITLE
feat(aztec-up): decouple infra assets from toolchain VERSION

### DIFF
--- a/aztec-up/bin/0.0.1/aztec-install
+++ b/aztec-up/bin/0.0.1/aztec-install
@@ -28,10 +28,14 @@ fi
 AZTEC_HOME="${AZTEC_HOME:-$HOME/.aztec}"
 shared_bin_path="$AZTEC_HOME/bin"
 
+# Toolchain version to install (alias or semver). Replaced at release time.
 VERSION=${VERSION:-0.0.1}
+# Infrastructure version: controls where to fetch installer assets (banner, aztec-up).
+# When empty, assets are fetched directly from INSTALL_URI.
+INFRA_VERSION=${INFRA_VERSION:-}
 
-# Install URI (root, not version-specific)
 INSTALL_URI="${INSTALL_URI:-https://install.aztec-labs.com}"
+INFRA_BASE_URI="$INSTALL_URI${INFRA_VERSION:+/$INFRA_VERSION}"
 
 # Check if version string is valid semver
 function is_semver {
@@ -74,9 +78,9 @@ function typewriter {
 function title {
   clear
   if [ "${COLORTERM:-}" = "truecolor" ] || [ "${COLORTERM:-}" = "24bit" ]; then
-    curl -fsSL "$INSTALL_URI/$VERSION/aztec-banner-truecolor" 2>/dev/null || true
+    curl -fsSL "$INFRA_BASE_URI/aztec-banner-truecolor" 2>/dev/null || true
   else
-    curl -fsSL "$INSTALL_URI/$VERSION/aztec-banner" 2>/dev/null || true
+    curl -fsSL "$INFRA_BASE_URI/aztec-banner" 2>/dev/null || true
   fi
   typewriter "initializing stealth protocols..." "${p}"
   sleep 1
@@ -171,11 +175,7 @@ function install_jq {
 }
 
 function install_aztec_up {
-  # If there's a version of aztec-up at the VERSION location, use that, else fallback to root installer.
-  if ! curl -fsSL "$INSTALL_URI/$VERSION/aztec-up" -o "$shared_bin_path/aztec-up"; then
-    # Download aztec-up from root.
-    curl -fsSL "$INSTALL_URI/aztec-up" -o "$shared_bin_path/aztec-up"
-  fi
+  curl -fsSL "$INFRA_BASE_URI/aztec-up" -o "$shared_bin_path/aztec-up"
   chmod +x "$shared_bin_path/aztec-up"
 }
 

--- a/aztec-up/bootstrap.sh
+++ b/aztec-up/bootstrap.sh
@@ -129,10 +129,12 @@ function release {
 # This is not done by CI.
 # It's a manual process, as updating the root installer and alias index requires careful consideration.
 function release_root_installer {
-    # Upload root aztec-install with VERSION defaulting to latest (instead of local 0.0.1).
+    # Upload root installer assets: aztec-install (with VERSION defaulting to latest), aztec-up, and banner files.
     sed "s/^VERSION=.*/VERSION=\${VERSION:-latest}/" bin/0.0.1/aztec-install | \
       do_or_dryrun aws s3 cp - "s3://install.aztec.network/aztec-install"
     do_or_dryrun aws s3 cp bin/0.0.1/aztec-up "s3://install.aztec.network/aztec-up"
+    do_or_dryrun aws s3 cp bin/0.0.1/aztec-banner "s3://install.aztec.network/aztec-banner"
+    do_or_dryrun aws s3 cp bin/0.0.1/aztec-banner-truecolor "s3://install.aztec.network/aztec-banner-truecolor"
 
     # Update alias list.
     do_or_dryrun aws s3 cp bin/aliases/index "s3://install.aztec.network/aliases/index"
@@ -205,6 +207,7 @@ function install_on_mac_vm {
     # Point npm at local Verdaccio and scripts at local HTTP server.
     export npm_config_registry=http://$host_ip:$verdaccio_port
     export INSTALL_URI=http://$host_ip:$http_port
+    export INFRA_VERSION=0.0.1
     export NO_NEW_SHELL=1
 
     touch \$HOME/.zshrc

--- a/aztec-up/scripts/run_isolated_test.sh
+++ b/aztec-up/scripts/run_isolated_test.sh
@@ -93,7 +93,7 @@ EOF
   else
     export NON_INTERACTIVE=1
   fi
-  VERSION=0.0.1 bash ${bash_args:-} <(curl -s $INSTALL_URI/0.0.1/aztec-install)
+  VERSION=0.0.1 INFRA_VERSION=0.0.1 bash ${bash_args:-} <(curl -s $INSTALL_URI/0.0.1/aztec-install)
 
   echo "Version information:"
 


### PR DESCRIPTION
## Summary

- Introduces `INFRA_VERSION` env var to control where `aztec-install` fetches infrastructure assets (banner, aztec-up) independently from the toolchain `VERSION`. Previously `VERSION` controlled both, coupling toolchain selection with installer asset paths.
- When `INFRA_VERSION` is empty (default), assets are fetched from the root of `INSTALL_URI`. Tests set `INFRA_VERSION=0.0.1` to match the local file layout.
- Updates `release_root_installer` to upload banner files to the S3 root alongside `aztec-up`.

Fixes F-501