### PR TITLE
fix: update webapp-tutorial for new API patterns

### DIFF
--- a/docs/docs-developers/docs/tutorials/js_tutorials/webapp/03-network-and-wallet.md
+++ b/docs/docs-developers/docs/tutorials/js_tutorials/webapp/03-network-and-wallet.md
@@ -43,7 +43,7 @@ Both modes produce the same `Wallet` interface, so the rest of your app doesn't 
 
 ## Embedded wallet (local development)
 
-For local development, the app uses an `EmbeddedWallet` class that extends `BaseWallet` from the Aztec wallet SDK. `BaseWallet` provides account abstraction, transaction signing, and fee handling — the subclass supplies initialization logic, account management, and a fee payment strategy.
+For local development, the app uses a custom `EmbeddedWallet` class that extends the official `EmbeddedWallet` from `@aztec/wallets/embedded`. The official wallet already provides account creation and persistence, transaction sending with gas estimation, automatic authwitness generation, and stub-account simulation. The tutorial subclass adds one thing: **SponsoredFPC fee payment** so users don't need to hold fee tokens.
 
 Open `src/embedded-wallet.ts`:
 
@@ -55,11 +55,11 @@ Open `src/embedded-wallet.ts`:
 
 #include_code initialize /docs/examples/webapp-tutorial/src/embedded-wallet.ts typescript
 
-This is similar to `createLocalPXE` from `config.ts`, but additionally registers the SponsoredFPC contract with PXE so that fee payment works out of the box.
+The `initialize` factory calls the inherited `create()` method, which sets up an in-browser PXE and account storage. It then registers the SponsoredFPC contract with PXE so that fee payment works out of the box.
 
 ### Connecting a test account
 
-The local network ships with pre-deployed test accounts. These are Schnorr-signature accounts that are already registered and funded, so you can use them immediately without deploying a new account contract. You select one by index (0, 1, 2, etc.).
+The local network ships with pre-deployed test accounts. These are Schnorr-signature accounts that are already registered and funded, so you can use them immediately without deploying a new account contract. The inherited `createSchnorrAccount` handles account creation, contract registration with PXE, and persistence in the wallet database. You select one by index (0, 1, 2, etc.).
 
 #include_code connect-test-account /docs/examples/webapp-tutorial/src/embedded-wallet.ts typescript
 
@@ -75,7 +75,7 @@ SponsoredFPC only works on the local network and devnet. Production Aztec networ
 
 ### Full class
 
-The complete `EmbeddedWallet` puts these pieces together:
+The complete `EmbeddedWallet` — most of the heavy lifting (simulation, proving, gas estimation) is inherited from the official wallet:
 
 #include_code embedded-wallet-class /docs/examples/webapp-tutorial/src/embedded-wallet.ts typescript
 

--- a/docs/docs-developers/docs/tutorials/js_tutorials/webapp/04-contract-interaction.md
+++ b/docs/docs-developers/docs/tutorials/js_tutorials/webapp/04-contract-interaction.md
@@ -20,7 +20,7 @@ The `deployContract` function calls `PodRacingContract.deploy()` to construct a 
 
 ### Attaching to an existing contract
 
-When joining someone else's game, you didn't deploy the contract, so your PXE doesn't know about it. `attachToContract` first registers the contract with your PXE by fetching the on-chain instance from the node and providing the compiled artifact — this is required for private function execution, since PXE needs the contract bytecode locally to generate proofs. It then calls `PodRacingContract.at()` to create a typed contract handle bound to the existing contract address and wallet.
+When joining someone else's game, you didn't deploy the contract, so your PXE doesn't know about it. `attachToContract` first registers the contract with your PXE by fetching the onchain instance from the node and providing the compiled artifact — this is required for private function execution, since PXE needs the contract bytecode locally to generate proofs. It then calls `PodRacingContract.at()` to create a typed contract handle bound to the existing contract address and wallet.
 
 ### Game actions
 

--- a/docs/examples/webapp-tutorial/package.json
+++ b/docs/examples/webapp-tutorial/package.json
@@ -42,7 +42,7 @@
     "@vitejs/plugin-react-swc": "^3.7.2",
     "esbuild": "^0.24.0",
     "jsdom": "^25.0.0",
-    "puppeteer": "^23.0.0",
+    "puppeteer": "^24.40.0",
     "typescript": "^5.6.0",
     "vite": "^6.0.0",
     "vite-plugin-node-polyfills": "^0.22.0",

--- a/docs/examples/webapp-tutorial/package.json
+++ b/docs/examples/webapp-tutorial/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "clean": "rm -rf ../../target src/artifacts/*.json src/artifacts/*.ts dist",
-    "compile": "cd ../.. && ${AZTEC:-aztec} compile examples/webapp-tutorial/contracts --force && mkdir -p examples/webapp-tutorial/src/artifacts && cp target/*.json examples/webapp-tutorial/src/artifacts",
+    "compile": "cd ../.. && ${AZTEC:-aztec} compile --package pod_racing_contract --force && mkdir -p examples/webapp-tutorial/src/artifacts && cp target/pod_racing_contract-PodRacing.json examples/webapp-tutorial/src/artifacts",
     "codegen": "cd ../.. && ${AZTEC:-aztec} codegen ./target -o ./target && cp target/*.ts examples/webapp-tutorial/src/artifacts",
     "prep": "yarn compile && yarn codegen",
     "dev": "vite",

--- a/docs/examples/webapp-tutorial/scripts/deploy-and-interact.ts
+++ b/docs/examples/webapp-tutorial/scripts/deploy-and-interact.ts
@@ -14,7 +14,7 @@ console.log("Accounts ready:", alice.address.toString(), bob.address.toString())
 // docs:end:script-setup
 
 // docs:start:script-deploy
-const contract = await PodRacingContract.deploy(wallet, alice.address).send({
+const { contract } = await PodRacingContract.deploy(wallet, alice.address).send({
   from: alice.address,
 });
 console.log("Contract deployed at:", contract.address.toString());

--- a/docs/examples/webapp-tutorial/src/components/GameBoard.tsx
+++ b/docs/examples/webapp-tutorial/src/components/GameBoard.tsx
@@ -50,7 +50,7 @@ export function GameBoard({
     try {
       addLog('Building private transaction proof...', 'pending');
       const receipt = await playRound(contract, account, gameId, currentRound, allocations);
-      addLog(`Round ${currentRound} submitted successfully`, 'success', receipt.txHash?.toString());
+      addLog(`Round ${currentRound} submitted successfully`, 'success', receipt.receipt.txHash?.toString());
       setStatus('Round submitted!');
       setAllocations([2, 2, 2, 2, 1]);
       onRoundPlayed();
@@ -72,7 +72,7 @@ export function GameBoard({
     try {
       addLog('Reading private notes and computing totals...', 'pending');
       const receipt = await finishGame(contract, account, gameId);
-      addLog('Scores revealed successfully', 'success', receipt.txHash?.toString());
+      addLog('Scores revealed successfully', 'success', receipt.receipt.txHash?.toString());
       setStatus('Scores revealed! Waiting for opponent to reveal, then finalize.');
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : String(err);
@@ -89,7 +89,7 @@ export function GameBoard({
     addLog('Finalizing game and determining winner...', 'pending');
     try {
       const receipt = await finalizeGame(contract, account, gameId);
-      addLog('Game finalized! Winner determined.', 'success', receipt.txHash?.toString());
+      addLog('Game finalized! Winner determined.', 'success', receipt.receipt.txHash?.toString());
       setStatus('Game finalized! Winner determined.');
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : String(err);

--- a/docs/examples/webapp-tutorial/src/components/GameLobby.tsx
+++ b/docs/examples/webapp-tutorial/src/components/GameLobby.tsx
@@ -47,7 +47,7 @@ export function GameLobby({ wallet, account, onGameJoined }: GameLobbyProps) {
       setStatus('Creating game...');
       addLog('Creating game...', 'pending');
       const receipt = await createGame(contract, account, gId);
-      addLog(`Game ${gId} created successfully`, 'success', receipt.txHash?.toString());
+      addLog(`Game ${gId} created successfully`, 'success', receipt.receipt.txHash?.toString());
 
       setStatus(`Game created! Share contract address: ${contract.address}`);
       onGameJoined(contract, gId);
@@ -89,7 +89,7 @@ export function GameLobby({ wallet, account, onGameJoined }: GameLobbyProps) {
       addLog(`Attached to contract ${contractAddr.toString()}`, 'info');
       addLog(`Joining game ${gId}...`, 'pending');
       const receipt = await joinGame(contract, account, gId);
-      addLog(`Joined game ${gId} successfully`, 'success', receipt.txHash?.toString());
+      addLog(`Joined game ${gId} successfully`, 'success', receipt.receipt.txHash?.toString());
 
       setStatus('Joined game!');
       onGameJoined(contract, gId);

--- a/docs/examples/webapp-tutorial/src/components/WalletConnect.tsx
+++ b/docs/examples/webapp-tutorial/src/components/WalletConnect.tsx
@@ -70,6 +70,8 @@ export function WalletConnect({ network, onWalletConnected }: WalletConnectProps
     let isMounted = true;
     done.then(() => {
       if (isMounted) setDiscoveryDone(true);
+    }).catch((err) => {
+      if (isMounted) setStatus(`Discovery error: ${err.message}`);
     });
 
     return () => {

--- a/docs/examples/webapp-tutorial/src/contract.ts
+++ b/docs/examples/webapp-tutorial/src/contract.ts
@@ -13,7 +13,7 @@ import { EmbeddedWallet } from './embedded-wallet';
  */
 export async function deployContract(wallet: Wallet, deployer: AztecAddress): Promise<PodRacingContract> {
   const paymentMethod = await createSponsoredFeePayment();
-  const contract = await PodRacingContract.deploy(wallet, deployer)
+  const { contract } = await PodRacingContract.deploy(wallet, deployer)
     .send({ from: deployer, fee: { paymentMethod } });
 
   console.log('Pod Racing contract deployed at:', contract.address.toString());
@@ -51,7 +51,7 @@ export async function createGame(
     .create_game(gameId)
     .send({ from, fee: { paymentMethod } });
 
-  console.log('Game created, tx hash:', receipt.txHash.toString());
+  console.log('Game created, tx hash:', receipt.receipt.txHash.toString());
   return receipt;
 }
 
@@ -68,7 +68,7 @@ export async function joinGame(
     .join_game(gameId)
     .send({ from, fee: { paymentMethod } });
 
-  console.log('Joined game, tx hash:', receipt.txHash.toString());
+  console.log('Joined game, tx hash:', receipt.receipt.txHash.toString());
   return receipt;
 }
 
@@ -87,7 +87,7 @@ export async function playRound(
     .play_round(gameId, round, tracks[0], tracks[1], tracks[2], tracks[3], tracks[4])
     .send({ from, fee: { paymentMethod } });
 
-  console.log('Round played, tx hash:', receipt.txHash.toString());
+  console.log('Round played, tx hash:', receipt.receipt.txHash.toString());
   return receipt;
 }
 
@@ -104,7 +104,7 @@ export async function finishGame(
     .finish_game(gameId)
     .send({ from, fee: { paymentMethod } });
 
-  console.log('Game finished (scores revealed), tx hash:', receipt.txHash.toString());
+  console.log('Game finished (scores revealed), tx hash:', receipt.receipt.txHash.toString());
   return receipt;
 }
 
@@ -121,7 +121,7 @@ export async function finalizeGame(
     .finalize_game(gameId)
     .send({ from, fee: { paymentMethod } });
 
-  console.log('Game finalized, tx hash:', receipt.txHash.toString());
+  console.log('Game finalized, tx hash:', receipt.receipt.txHash.toString());
   return receipt;
 }
 // docs:end:game-actions

--- a/docs/examples/webapp-tutorial/src/embedded-wallet.ts
+++ b/docs/examples/webapp-tutorial/src/embedded-wallet.ts
@@ -1,69 +1,34 @@
 // docs:start:embedded-wallet
 // docs:start:embedded-wallet-imports
-import { Account, SignerlessAccount } from '@aztec/aztec.js/account';
+import { type NoFrom, NO_FROM } from '@aztec/aztec.js/account';
 import { AztecAddress } from '@aztec/aztec.js/addresses';
-import {
-  getContractInstanceFromInstantiationParams,
-  InteractionWaitOptions,
-} from '@aztec/aztec.js/contracts';
+import { getContractInstanceFromInstantiationParams } from '@aztec/aztec.js/contracts';
 import { SponsoredFeePaymentMethod } from '@aztec/aztec.js/fee';
 import { Fr } from '@aztec/aztec.js/fields';
-import { createLogger } from '@aztec/aztec.js/log';
-import { createAztecNodeClient } from '@aztec/aztec.js/node';
-import {
-  AccountManager,
-  DeployAccountOptions,
-  SimulateOptions,
-} from '@aztec/aztec.js/wallet';
-import { type FeeOptions, BaseWallet } from '@aztec/wallet-sdk/base-wallet';
 import { SPONSORED_FPC_SALT } from '@aztec/constants';
+import { AccountFeePaymentMethodOptions } from '@aztec/entrypoints/account';
 import type { FieldsOf } from '@aztec/foundation/types';
-import { SchnorrAccountContract } from '@aztec/accounts/schnorr/lazy';
-import { getPXEConfig } from '@aztec/pxe/config';
-import { createPXE } from '@aztec/pxe/client/lazy';
 import { getInitialTestAccountsData } from '@aztec/accounts/testing/lazy';
-import {
-  getStubAccountContractArtifact,
-  createStubAccount,
-} from '@aztec/accounts/stub/lazy';
 import type { ContractArtifact } from '@aztec/stdlib/abi';
-import { ExecutionPayload, mergeExecutionPayloads } from '@aztec/stdlib/tx';
-import { TxSimulationResult } from '@aztec/stdlib/tx';
 import { GasSettings } from '@aztec/stdlib/gas';
-import {
-  AccountFeePaymentMethodOptions,
-  DefaultAccountEntrypointOptions,
-} from '@aztec/entrypoints/account';
+import { type FeeOptions } from '@aztec/wallet-sdk/base-wallet';
+import { EmbeddedWallet as BaseEmbeddedWallet } from '@aztec/wallets/embedded';
 // docs:end:embedded-wallet-imports
-
-const logger = createLogger('embedded-wallet');
 
 // docs:start:embedded-wallet-class
 /**
- * A minimal in-browser wallet for local development.
- * Extends BaseWallet from the wallet-sdk to provide account management
- * and sponsored fee payment via the SponsoredFPC contract.
+ * A tutorial wallet for local development and devnet.
+ * Extends the official EmbeddedWallet to add SponsoredFPC fee payment
+ * so users don't need to hold fee tokens.
  *
- * WARNING: This stores keys in plain text in localStorage.
- * Do not use in production without understanding the security implications.
+ * Inherits from the SDK's EmbeddedWallet which provides:
+ * - Account creation and persistence via WalletDB
+ * - Pre-simulation with gas estimation in sendTx
+ * - Automatic authwitness generation
+ * - Stub-account simulation (no expensive kernel proving)
  */
-export class EmbeddedWallet extends BaseWallet {
-  protected minFeePadding = 1.0; // 100% padding for volatile devnet fees
+export class EmbeddedWallet extends BaseEmbeddedWallet {
   connectedAccount: AztecAddress | null = null;
-  protected accounts: Map<string, Account> = new Map();
-
-  protected async getAccountFromAddress(
-    address: AztecAddress
-  ): Promise<Account> {
-    if (address.equals(AztecAddress.ZERO)) {
-      return new SignerlessAccount();
-    }
-    const account = this.accounts.get(address?.toString() ?? '');
-    if (!account) {
-      throw new Error(`Account not found for address: ${address}`);
-    }
-    return account;
-  }
 
   // docs:start:fee-options
   /**
@@ -71,9 +36,9 @@ export class EmbeddedWallet extends BaseWallet {
    * don't need to hold fee tokens.
    */
   override async completeFeeOptions(
-    from: AztecAddress,
+    from: AztecAddress | NoFrom,
     feePayer?: AztecAddress,
-    gasSettings?: Partial<FieldsOf<GasSettings>>
+    gasSettings?: Partial<FieldsOf<GasSettings>>,
   ): Promise<FeeOptions> {
     const maxFeesPerGas =
       gasSettings?.maxFeesPerGas ??
@@ -83,39 +48,26 @@ export class EmbeddedWallet extends BaseWallet {
     let accountFeePaymentMethodOptions;
 
     if (!feePayer) {
-      const sponsoredFPCContract =
-        await EmbeddedWallet.#getSponsoredFPCContract();
+      const fpc = await EmbeddedWallet.#getSponsoredFPCContract();
       walletFeePaymentMethod = new SponsoredFeePaymentMethod(
-        sponsoredFPCContract.instance.address
+        fpc.instance.address,
       );
-      accountFeePaymentMethodOptions = AccountFeePaymentMethodOptions.EXTERNAL;
-    } else {
+      if (from !== NO_FROM) {
+        accountFeePaymentMethodOptions = AccountFeePaymentMethodOptions.EXTERNAL;
+      }
+    } else if (from !== NO_FROM) {
       accountFeePaymentMethodOptions = from.equals(feePayer)
         ? AccountFeePaymentMethodOptions.FEE_JUICE_WITH_CLAIM
         : AccountFeePaymentMethodOptions.EXTERNAL;
     }
 
-    const fullGasSettings = GasSettings.default({
-      ...gasSettings,
-      maxFeesPerGas,
-    });
-
     return {
-      gasSettings: fullGasSettings,
+      gasSettings: GasSettings.default({ ...gasSettings, maxFeesPerGas }),
       walletFeePaymentMethod,
       accountFeePaymentMethodOptions,
     };
   }
   // docs:end:fee-options
-
-  getAccounts() {
-    return Promise.resolve(
-      Array.from(this.accounts.values()).map((acc) => ({
-        alias: '',
-        item: acc.getAddress(),
-      }))
-    );
-  }
 
   // docs:start:initialize
   /**
@@ -123,18 +75,18 @@ export class EmbeddedWallet extends BaseWallet {
    * Sets up an in-browser PXE and registers the SponsoredFPC contract.
    */
   static async initialize(nodeUrl: string) {
-    const aztecNode = createAztecNodeClient(nodeUrl);
-    const config = getPXEConfig();
-    config.l1Contracts = await aztecNode.getL1ContractAddresses();
-    const isLocal = nodeUrl.includes('localhost') || nodeUrl.includes('127.0.0.1');
-    config.proverEnabled = !isLocal;
-    const pxe = await createPXE(aztecNode, config, {});
+    const isLocal =
+      nodeUrl.includes('localhost') || nodeUrl.includes('127.0.0.1');
+    const wallet = await EmbeddedWallet.create(nodeUrl, {
+      ephemeral: true,
+      pxeConfig: { proverEnabled: !isLocal },
+    });
 
     // Register SponsoredFPC so we can pay fees
-    await pxe.registerContract(await EmbeddedWallet.#getSponsoredFPCContract());
-    logger.info('PXE connected to node at', nodeUrl);
+    const fpc = await EmbeddedWallet.#getSponsoredFPCContract();
+    await wallet.registerContract(fpc.instance, fpc.artifact);
 
-    return new EmbeddedWallet(pxe, aztecNode);
+    return wallet;
   }
   // docs:end:initialize
 
@@ -144,7 +96,7 @@ export class EmbeddedWallet extends BaseWallet {
     );
     const instance = await getContractInstanceFromInstantiationParams(
       SponsoredFPCContractArtifact,
-      { salt: new Fr(SPONSORED_FPC_SALT) }
+      { salt: new Fr(SPONSORED_FPC_SALT) },
     );
     return { instance, artifact: SponsoredFPCContractArtifact };
   }
@@ -153,132 +105,42 @@ export class EmbeddedWallet extends BaseWallet {
     return this.connectedAccount;
   }
 
-  private async registerAccount(accountManager: AccountManager) {
-    const instance = await accountManager.getInstance();
-    const artifact = await accountManager
-      .getAccountContract()
-      .getContractArtifact();
-    await this.registerContract(
-      instance,
-      artifact,
-      accountManager.getSecretKey()
-    );
-  }
-
   // docs:start:connect-test-account
   /**
    * Connects one of the pre-deployed test accounts available on the local network.
-   * These accounts are already deployed and funded — perfect for development.
+   * Uses the inherited createSchnorrAccount which handles account creation,
+   * contract registration, and WalletDB persistence.
    */
   async connectTestAccount(index: number) {
     const testAccounts = await getInitialTestAccountsData();
     const accountData = testAccounts[index];
 
-    const accountManager = await AccountManager.create(
-      this,
+    const accountManager = await this.createSchnorrAccount(
       accountData.secret,
-      new SchnorrAccountContract(accountData.signingKey),
-      accountData.salt
+      accountData.salt,
+      accountData.signingKey,
     );
 
-    await this.registerAccount(accountManager);
-    this.accounts.set(
-      accountManager.address.toString(),
-      await accountManager.getAccount()
-    );
     this.connectedAccount = accountManager.address;
     return this.connectedAccount;
   }
   // docs:end:connect-test-account
 
   /**
-   * Fetches a contract instance from the Aztec node (on-chain) and registers it
+   * Fetches a contract instance from the Aztec node (onchain) and registers it
    * with this wallet's PXE. Required before calling private functions on contracts
    * deployed by another wallet/PXE.
    */
-  async registerContractFromNode(address: AztecAddress, artifact: ContractArtifact) {
+  async registerContractFromNode(
+    address: AztecAddress,
+    artifact: ContractArtifact,
+  ) {
     const instance = await this.aztecNode.getContract(address);
     if (!instance) {
-      throw new Error(`Contract not found on-chain at ${address}`);
+      throw new Error(`Contract not found onchain at ${address}`);
     }
     await this.registerContract(instance, artifact);
   }
   // docs:end:embedded-wallet-class
-
-  private async getFakeAccountDataFor(address: AztecAddress) {
-    const originalAccount = await this.getAccountFromAddress(address);
-    if (originalAccount instanceof SignerlessAccount) {
-      throw new Error(
-        `Cannot create fake account data for SignerlessAccount at address: ${address}`
-      );
-    }
-    const originalAddress = (originalAccount as Account).getCompleteAddress();
-    const contractInstance = await this.pxe.getContractInstance(
-      originalAddress.address
-    );
-    if (!contractInstance) {
-      throw new Error(
-        `No contract instance found for address: ${originalAddress.address}`
-      );
-    }
-    const stubAccount = createStubAccount(originalAddress);
-    const StubAccountContractArtifact = await getStubAccountContractArtifact();
-    const instance = await getContractInstanceFromInstantiationParams(
-      StubAccountContractArtifact,
-      { salt: Fr.random() }
-    );
-    return { account: stubAccount, instance, artifact: StubAccountContractArtifact };
-  }
-
-  async simulateTx(
-    executionPayload: ExecutionPayload,
-    opts: SimulateOptions
-  ): Promise<TxSimulationResult> {
-    const feeOptions = opts.fee?.estimateGas
-      ? await this.completeFeeOptionsForEstimation(
-          opts.from,
-          executionPayload.feePayer,
-          opts.fee?.gasSettings
-        )
-      : await this.completeFeeOptions(
-          opts.from,
-          executionPayload.feePayer,
-          opts.fee?.gasSettings
-        );
-    const feeExecutionPayload =
-      await feeOptions.walletFeePaymentMethod?.getExecutionPayload();
-    const executionOptions: DefaultAccountEntrypointOptions = {
-      txNonce: Fr.random(),
-      cancellable: this.cancellableTransactions,
-      feePaymentMethodOptions: feeOptions.accountFeePaymentMethodOptions,
-    };
-    const finalExecutionPayload = feeExecutionPayload
-      ? mergeExecutionPayloads([feeExecutionPayload, executionPayload])
-      : executionPayload;
-    const {
-      account: fromAccount,
-      instance,
-      artifact,
-    } = await this.getFakeAccountDataFor(opts.from);
-    const chainInfo = await this.getChainInfo();
-    const txRequest = await fromAccount.createTxExecutionRequest(
-      finalExecutionPayload,
-      feeOptions.gasSettings,
-      chainInfo,
-      executionOptions
-    );
-    const contractOverrides = {
-      [opts.from.toString()]: { instance, artifact },
-    };
-    return this.pxe.simulateTx(txRequest, {
-      simulatePublic: true,
-      skipTxValidation: true,
-      skipFeeEnforcement: true,
-      overrides: {
-        contracts: contractOverrides,
-      },
-      scopes: [opts.from],
-    });
-  }
 }
 // docs:end:embedded-wallet


### PR DESCRIPTION
## Summary
- Update `PodRacingContract.deploy()` to destructure `{ contract }` from the return value
- Access `receipt.receipt.txHash` instead of `receipt.txHash` across all components and contract helpers
- Fix compile script to use `--package pod_racing_contract` instead of path-based compilation
- Add error handling for wallet discovery promise in `WalletConnect.tsx`

## Test plan
- [ ] Run `yarn prep` in webapp-tutorial to verify compile command works
- [ ] Verify the app builds without TypeScript errors
- [ ] Test game flow (create, join, play round, finish, finalize) end-to-end