### PR TITLE
fix(aztec-up): pass VERSION to per-version installer and fix release sed

### DIFF
--- a/aztec-up/bin/0.0.1/aztec-up
+++ b/aztec-up/bin/0.0.1/aztec-up
@@ -236,7 +236,7 @@ function cmd_install {
   fi
 
   # Download and run the version-specific installer
-  curl -fsSL "$install_url" | bash
+  curl -fsSL "$install_url" | VERSION="$resolved_version" bash
 
   # Update the current symlink
   ln -sfn "$AZTEC_HOME/versions/$resolved_version" "$AZTEC_HOME/current"

--- a/aztec-up/bootstrap.sh
+++ b/aztec-up/bootstrap.sh
@@ -141,7 +141,7 @@ function release {
 # It's a manual process, as updating the root installer and alias index requires careful consideration.
 function release_root_installer {
     # Upload root installer assets: aztec-install (with VERSION defaulting to latest), aztec-up, and banner files.
-    sed "s/^VERSION=.*/VERSION=\${VERSION:-latest}/" bin/0.0.1/aztec-install | \
+    sed "s/^VERSION=\${VERSION:-.*}/VERSION=\${VERSION:-latest}/" bin/0.0.1/aztec-install | \
       do_or_dryrun aws s3 cp - "s3://install.aztec.network/aztec-install"
     do_or_dryrun aws s3 cp bin/0.0.1/aztec-up "s3://install.aztec.network/aztec-up"
     do_or_dryrun aws s3 cp bin/0.0.1/aztec-banner "s3://install.aztec.network/aztec-banner"


### PR DESCRIPTION
## Problem

`bash -i <(curl -sL https://install.aztec.network)` fails for all new users with two different errors depending on whether `VERSION` is set:

- **Without `VERSION`**: the per-version installer fails with `VERSION: VERSION must be set` because `aztec-up`'s `cmd_install` pipes the installer into a bare `bash` without passing `VERSION` as an env var. This was intentionally removed in e44fe3832a to rely on hardcoded versions at release time, but the live per-version installers on S3 (e.g. `4.1.2/install`) were released before that change and still expect `VERSION` from the environment.

- **With `VERSION=latest`**: the per-version installer gets the literal string `latest` (never resolved to a semver like `4.1.2`), then tries to fetch `https://install.aztec-labs.com/latest/versions` which 404s. This happens because `release_root_installer` in `bootstrap.sh` runs `sed "s/^VERSION=.*/VERSION=${VERSION:-latest}/"` which replaces **every** line starting with `VERSION=`, including the `VERSION=$(resolve_version "$VERSION")` call on line 64 of `aztec-install`. The live root installer at `install.aztec.network` therefore never resolves aliases.

## Fix

- **`aztec-up/bin/0.0.1/aztec-up`**: Restore `VERSION="$resolved_version"` as an env var prefix on the `curl | bash` line in `cmd_install`, so the per-version installer always receives the resolved semver regardless of what's in the parent environment.

- **`aztec-up/bootstrap.sh`**: Narrow the sed pattern in `release_root_installer` from `^VERSION=.*` to `^VERSION=\${VERSION:-.*}` so it only replaces the default-value assignment on line 32 and leaves the `resolve_version` call on line 64 intact.

After merging, `release_root_installer` must be re-run manually to push the corrected root installer to S3.

Fixes F-502