### PR TITLE
fix: handle error event on SSH agent socket to prevent Node crash

### DIFF
--- a/yarn-project/accounts/src/utils/ssh_agent.ts
+++ b/yarn-project/accounts/src/utils/ssh_agent.ts
@@ -41,6 +41,7 @@ type StoredKey = {
 export function getIdentities(): Promise<StoredKey[]> {
   return new Promise((resolve, reject) => {
     const stream = connectToAgent();
+    stream.on('error', reject);
     stream.on('connect', () => {
       const request = Buffer.concat([
         Buffer.from([0, 0, 0, 5 + 4]), // length
@@ -96,6 +97,7 @@ export function getIdentities(): Promise<StoredKey[]> {
 export function signWithAgent(keyType: Buffer, curveName: Buffer, publicKey: Buffer, data: Buffer) {
   return new Promise<Buffer>((resolve, reject) => {
     const stream = connectToAgent();
+    stream.on('error', reject);
     stream.on('connect', () => {
       // Construct the key blob
       const keyBlob = Buffer.concat([


### PR DESCRIPTION
Both `getIdentities()` and `signWithAgent()` in `ssh_agent.ts` create a `net.Socket` but never register an `error` event handler. When the connection to the SSH agent fails (e.g. `SSH_AUTH_SOCK` points to a stale socket), the socket emits an `error` event with no listener, causing Node.js to throw an unhandled exception and crash the process.

The fix adds `stream.on('error', reject)` to both promise constructors, so connection errors are correctly propagated as rejected promises instead of crashing the process.

Fixes [A-802](https://linear.app/aztec-labs/issue/A-802)

Made with [Cursor](https://cursor.com)