### PR TITLE
chore(avm): Add keccak test vectors in integration tests

### DIFF
--- a/noir-projects/noir-contracts/contracts/test/avm_gadgets_test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/avm_gadgets_test_contract/src/main.nr
@@ -9,6 +9,12 @@ contract AvmGadgetsTest {
         keccak256::keccak256(data, data.len())
     }
 
+    // 300 bytes exceeds the keccak256 rate (136 bytes), triggering multi-block permutation.
+    #[external("public")]
+    fn keccak_hash_300(data: [u8; 300]) -> [u8; 32] {
+        keccak256::keccak256(data, data.len())
+    }
+
     #[external("public")]
     fn keccak_hash_1400(data: [u8; 1400]) -> [u8; 32] {
         keccak256::keccak256(data, data.len())

--- a/yarn-project/bb-prover/src/avm_proving_tests/avm_proven_gadgets.test.ts
+++ b/yarn-project/bb-prover/src/avm_proving_tests/avm_proven_gadgets.test.ts
@@ -140,8 +140,7 @@ describe('AVM proven gadgets test: test vectors', () => {
       ],
     );
     expect(result.revertCode.isOK()).toBe(true);
-    const returnValues = result.getAppLogicReturnValues()[0].values!;
-    const outputBytes = returnValues.map(fr => Number(fr.toBigInt()));
+    const outputBytes = result.getAppLogicReturnValues()?.[0]?.values?.map(fr => Number(fr.toBigInt()));
     const expected = [...Buffer.from('f0ae86a6257e615bce8b0fe73794934deda00c13d58f80b466a9354e306c9eb0', 'hex')];
     expect(outputBytes).toEqual(expected);
   }, 180_000);
@@ -163,8 +162,7 @@ describe('AVM proven gadgets test: test vectors', () => {
       ],
     );
     expect(result.revertCode.isOK()).toBe(true);
-    const returnValues = result.getAppLogicReturnValues()[0].values!;
-    const outputBytes = returnValues.map(fr => Number(fr.toBigInt()));
+    const outputBytes = result.getAppLogicReturnValues()?.[0]?.values?.map(fr => Number(fr.toBigInt()));
     const expected = [...Buffer.from('a679e749a6af300c36e7ff2255d220864eab27b382f9cfdc5aa4d13563ba36ff', 'hex')];
     expect(outputBytes).toEqual(expected);
   }, 180_000);
@@ -185,8 +183,7 @@ describe('AVM proven gadgets test: test vectors', () => {
       ],
     );
     expect(result.revertCode.isOK()).toBe(true);
-    const returnValues = result.getAppLogicReturnValues()[0].values!;
-    const outputBytes = returnValues.map(fr => Number(fr.toBigInt()));
+    const outputBytes = result.getAppLogicReturnValues()?.[0]?.values?.map(fr => Number(fr.toBigInt()));
     const expected = [...Buffer.from('1f825aa2f0020ef7cf91dfa30da4668d791c5d4824fc8e41354b89ec05795ab3', 'hex')];
     expect(outputBytes).toEqual(expected);
   }, 180_000);
@@ -208,8 +205,7 @@ describe('AVM proven gadgets test: test vectors', () => {
       ],
     );
     expect(result.revertCode.isOK()).toBe(true);
-    const returnValues = result.getAppLogicReturnValues()[0].values!;
-    const outputBytes = returnValues.map(fr => Number(fr.toBigInt()));
+    const outputBytes = result.getAppLogicReturnValues()?.[0]?.values?.map(fr => Number(fr.toBigInt()));
     const expected = [...Buffer.from('3f8591112c6bbe5c963965954e293108b7208ed2af893e500d859368c654eabe', 'hex')];
     expect(outputBytes).toEqual(expected);
   }, 180_000);

--- a/yarn-project/bb-prover/src/avm_proving_tests/avm_proven_gadgets.test.ts
+++ b/yarn-project/bb-prover/src/avm_proving_tests/avm_proven_gadgets.test.ts
@@ -102,3 +102,115 @@ describe.skip('AVM proven gadgets test', () => {
     expect(result.revertCode.isOK()).toBe(true);
   }, 300_000);
 });
+
+describe('AVM proven gadgets test: test vectors', () => {
+  let tester: AvmProvingTester;
+  let worldStateService: NativeWorldStateService;
+
+  const sender = AztecAddress.fromNumber(42);
+  let avmGadgetsTestContract: ContractInstanceWithAddress;
+
+  beforeEach(async () => {
+    worldStateService = await NativeWorldStateService.tmp();
+    tester = await AvmProvingTester.new(worldStateService, /*checkCircuitOnly=*/ false, /*globals=*/ defaultGlobals());
+    avmGadgetsTestContract = await tester.registerAndDeployContract(
+      /*constructorArgs=*/ [],
+      sender,
+      /*contractArtifact=*/ AvmGadgetsTestContractArtifact,
+    );
+  });
+
+  afterEach(async () => {
+    await worldStateService.close();
+  });
+
+  it('keccak_hash_test_vector', async () => {
+    // keccak256([0x00, 0x01, ..., 0x09]) = f0ae86a6257e615bce8b0fe73794934deda00c13d58f80b466a9354e306c9eb0
+    const input = [0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09];
+    const result = await tester.executeTxWithLabel(
+      /*txLabel=*/ 'AvmGadgetsTest/keccak_hash',
+      /*sender=*/ sender,
+      /*setupCalls=*/ [],
+      /*appCalls=*/ [
+        {
+          address: avmGadgetsTestContract.address,
+          fnName: 'keccak_hash',
+          args: [input],
+        },
+      ],
+    );
+    expect(result.revertCode.isOK()).toBe(true);
+    const returnValues = result.getAppLogicReturnValues()[0].values!;
+    const outputBytes = returnValues.map(fr => Number(fr.toBigInt()));
+    const expected = [...Buffer.from('f0ae86a6257e615bce8b0fe73794934deda00c13d58f80b466a9354e306c9eb0', 'hex')];
+    expect(outputBytes).toEqual(expected);
+  }, 180_000);
+
+  it('keccak_hash_test_vector_300bytes', async () => {
+    // 300 bytes exceeds the keccak256 rate (136 bytes), triggering multi-block permutation.
+    // keccak256([0x00, 0x01, ..., 0x2b, 0x00, 0x01, ..., 0x2b, ...]) for 300 bytes
+    const input = Array.from({ length: 300 }, (_, i) => i % 256);
+    const result = await tester.executeTxWithLabel(
+      /*txLabel=*/ 'AvmGadgetsTest/keccak_hash_300',
+      /*sender=*/ sender,
+      /*setupCalls=*/ [],
+      /*appCalls=*/ [
+        {
+          address: avmGadgetsTestContract.address,
+          fnName: 'keccak_hash_300',
+          args: [input],
+        },
+      ],
+    );
+    expect(result.revertCode.isOK()).toBe(true);
+    const returnValues = result.getAppLogicReturnValues()[0].values!;
+    const outputBytes = returnValues.map(fr => Number(fr.toBigInt()));
+    const expected = [...Buffer.from('a679e749a6af300c36e7ff2255d220864eab27b382f9cfdc5aa4d13563ba36ff', 'hex')];
+    expect(outputBytes).toEqual(expected);
+  }, 180_000);
+
+  it('sha256_hash_test_vector', async () => {
+    // sha256([0x00, 0x01, ..., 0x09]) = 1f825aa2f0020ef7cf91dfa30da4668d791c5d4824fc8e41354b89ec05795ab3
+    const input = [0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09];
+    const result = await tester.executeTxWithLabel(
+      /*txLabel=*/ 'AvmGadgetsTest/sha256_hash_10',
+      /*sender=*/ sender,
+      /*setupCalls=*/ [],
+      /*appCalls=*/ [
+        {
+          address: avmGadgetsTestContract.address,
+          fnName: 'sha256_hash_10',
+          args: [input],
+        },
+      ],
+    );
+    expect(result.revertCode.isOK()).toBe(true);
+    const returnValues = result.getAppLogicReturnValues()[0].values!;
+    const outputBytes = returnValues.map(fr => Number(fr.toBigInt()));
+    const expected = [...Buffer.from('1f825aa2f0020ef7cf91dfa30da4668d791c5d4824fc8e41354b89ec05795ab3', 'hex')];
+    expect(outputBytes).toEqual(expected);
+  }, 180_000);
+
+  it('sha256_hash_test_vector_255bytes', async () => {
+    // 255 bytes exceeds the sha256 block size (64 bytes), triggering multi-block compression.
+    // sha256([0x00, 0x01, ..., 0xfe]) = 3f8591112c6bbe5c963965954e293108b7208ed2af893e500d859368c654eabe
+    const input = Array.from({ length: 255 }, (_, i) => i);
+    const result = await tester.executeTxWithLabel(
+      /*txLabel=*/ 'AvmGadgetsTest/sha256_hash_255',
+      /*sender=*/ sender,
+      /*setupCalls=*/ [],
+      /*appCalls=*/ [
+        {
+          address: avmGadgetsTestContract.address,
+          fnName: 'sha256_hash_255',
+          args: [input],
+        },
+      ],
+    );
+    expect(result.revertCode.isOK()).toBe(true);
+    const returnValues = result.getAppLogicReturnValues()[0].values!;
+    const outputBytes = returnValues.map(fr => Number(fr.toBigInt()));
+    const expected = [...Buffer.from('3f8591112c6bbe5c963965954e293108b7208ed2af893e500d859368c654eabe', 'hex')];
+    expect(outputBytes).toEqual(expected);
+  }, 180_000);
+});

--- a/yarn-project/simulator/src/public/public_tx_simulator/apps_tests/avm_gadgets.test.ts
+++ b/yarn-project/simulator/src/public/public_tx_simulator/apps_tests/avm_gadgets.test.ts
@@ -74,8 +74,7 @@ describe('Public TX simulator apps tests: gadgets', () => {
         ],
       );
       expect(result.revertCode.isOK()).toBe(true);
-      const returnValues = result.getAppLogicReturnValues()[0].values!;
-      const outputBytes = returnValues.map(fr => Number(fr.toBigInt()));
+      const outputBytes = result.getAppLogicReturnValues()?.[0]?.values?.map(fr => Number(fr.toBigInt()));
       const expected = [...Buffer.from('1f825aa2f0020ef7cf91dfa30da4668d791c5d4824fc8e41354b89ec05795ab3', 'hex')];
       expect(outputBytes).toEqual(expected);
     });
@@ -97,8 +96,7 @@ describe('Public TX simulator apps tests: gadgets', () => {
         ],
       );
       expect(result.revertCode.isOK()).toBe(true);
-      const returnValues = result.getAppLogicReturnValues()[0].values!;
-      const outputBytes = returnValues.map(fr => Number(fr.toBigInt()));
+      const outputBytes = result.getAppLogicReturnValues()?.[0]?.values?.map(fr => Number(fr.toBigInt()));
       const expected = [...Buffer.from('3f8591112c6bbe5c963965954e293108b7208ed2af893e500d859368c654eabe', 'hex')];
       expect(outputBytes).toEqual(expected);
     });
@@ -135,8 +133,7 @@ describe('Public TX simulator apps tests: gadgets', () => {
         ],
       );
       expect(result.revertCode.isOK()).toBe(true);
-      const returnValues = result.getAppLogicReturnValues()[0].values!;
-      const outputBytes = returnValues.map(fr => Number(fr.toBigInt()));
+      const outputBytes = result.getAppLogicReturnValues()?.[0]?.values?.map(fr => Number(fr.toBigInt()));
       const expected = [...Buffer.from('f0ae86a6257e615bce8b0fe73794934deda00c13d58f80b466a9354e306c9eb0', 'hex')];
       expect(outputBytes).toEqual(expected);
     });
@@ -158,8 +155,7 @@ describe('Public TX simulator apps tests: gadgets', () => {
         ],
       );
       expect(result.revertCode.isOK()).toBe(true);
-      const returnValues = result.getAppLogicReturnValues()[0].values!;
-      const outputBytes = returnValues.map(fr => Number(fr.toBigInt()));
+      const outputBytes = result.getAppLogicReturnValues()?.[0]?.values?.map(fr => Number(fr.toBigInt()));
       const expected = [...Buffer.from('a679e749a6af300c36e7ff2255d220864eab27b382f9cfdc5aa4d13563ba36ff', 'hex')];
       expect(outputBytes).toEqual(expected);
     });

--- a/yarn-project/simulator/src/public/public_tx_simulator/apps_tests/avm_gadgets.test.ts
+++ b/yarn-project/simulator/src/public/public_tx_simulator/apps_tests/avm_gadgets.test.ts
@@ -58,6 +58,51 @@ describe('Public TX simulator apps tests: gadgets', () => {
       });
     });
 
+    it('sha256_hash_test_vector', async () => {
+      // sha256([0x00, 0x01, ..., 0x09]) = 1f825aa2f0020ef7cf91dfa30da4668d791c5d4824fc8e41354b89ec05795ab3
+      const input = [0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09];
+      const result = await tester.executeTxWithLabel(
+        /*txLabel=*/ 'AvmGadgetsTest/sha256_hash_10',
+        /*sender=*/ deployer,
+        /*setupCalls=*/ [],
+        /*appCalls=*/ [
+          {
+            address: avmGadgetsTestContract.address,
+            fnName: 'sha256_hash_10',
+            args: [input],
+          },
+        ],
+      );
+      expect(result.revertCode.isOK()).toBe(true);
+      const returnValues = result.getAppLogicReturnValues()[0].values!;
+      const outputBytes = returnValues.map(fr => Number(fr.toBigInt()));
+      const expected = [...Buffer.from('1f825aa2f0020ef7cf91dfa30da4668d791c5d4824fc8e41354b89ec05795ab3', 'hex')];
+      expect(outputBytes).toEqual(expected);
+    });
+
+    it('sha256_hash_test_vector_255bytes', async () => {
+      // 255 bytes exceeds the sha256 block size (64 bytes), triggering multi-block compression.
+      // sha256([0x00, 0x01, ..., 0xfe]) = 3f8591112c6bbe5c963965954e293108b7208ed2af893e500d859368c654eabe
+      const input = Array.from({ length: 255 }, (_, i) => i);
+      const result = await tester.executeTxWithLabel(
+        /*txLabel=*/ 'AvmGadgetsTest/sha256_hash_255',
+        /*sender=*/ deployer,
+        /*setupCalls=*/ [],
+        /*appCalls=*/ [
+          {
+            address: avmGadgetsTestContract.address,
+            fnName: 'sha256_hash_255',
+            args: [input],
+          },
+        ],
+      );
+      expect(result.revertCode.isOK()).toBe(true);
+      const returnValues = result.getAppLogicReturnValues()[0].values!;
+      const outputBytes = returnValues.map(fr => Number(fr.toBigInt()));
+      const expected = [...Buffer.from('3f8591112c6bbe5c963965954e293108b7208ed2af893e500d859368c654eabe', 'hex')];
+      expect(outputBytes).toEqual(expected);
+    });
+
     it('keccak_hash', async () => {
       const result = await tester.executeTxWithLabel(
         /*txLabel=*/ 'AvmGadgetsTest/keccak_hash',
@@ -72,6 +117,51 @@ describe('Public TX simulator apps tests: gadgets', () => {
         ],
       );
       expect(result.revertCode.isOK()).toBe(true);
+    });
+
+    it('keccak_hash_test_vector', async () => {
+      // keccak256([0x00, 0x01, ..., 0x09]) = f0ae86a6257e615bce8b0fe73794934deda00c13d58f80b466a9354e306c9eb0
+      const input = [0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09];
+      const result = await tester.executeTxWithLabel(
+        /*txLabel=*/ 'AvmGadgetsTest/keccak_hash',
+        /*sender=*/ deployer,
+        /*setupCalls=*/ [],
+        /*appCalls=*/ [
+          {
+            address: avmGadgetsTestContract.address,
+            fnName: 'keccak_hash',
+            args: [input],
+          },
+        ],
+      );
+      expect(result.revertCode.isOK()).toBe(true);
+      const returnValues = result.getAppLogicReturnValues()[0].values!;
+      const outputBytes = returnValues.map(fr => Number(fr.toBigInt()));
+      const expected = [...Buffer.from('f0ae86a6257e615bce8b0fe73794934deda00c13d58f80b466a9354e306c9eb0', 'hex')];
+      expect(outputBytes).toEqual(expected);
+    });
+
+    it('keccak_hash_test_vector_300bytes', async () => {
+      // 300 bytes exceeds the keccak256 rate (136 bytes), triggering multi-block permutation.
+      // keccak256([0x00, 0x01, ..., 0x2b, 0x00, 0x01, ..., 0x2b, ...]) for 300 bytes
+      const input = Array.from({ length: 300 }, (_, i) => i % 256);
+      const result = await tester.executeTxWithLabel(
+        /*txLabel=*/ 'AvmGadgetsTest/keccak_hash_300',
+        /*sender=*/ deployer,
+        /*setupCalls=*/ [],
+        /*appCalls=*/ [
+          {
+            address: avmGadgetsTestContract.address,
+            fnName: 'keccak_hash_300',
+            args: [input],
+          },
+        ],
+      );
+      expect(result.revertCode.isOK()).toBe(true);
+      const returnValues = result.getAppLogicReturnValues()[0].values!;
+      const outputBytes = returnValues.map(fr => Number(fr.toBigInt()));
+      const expected = [...Buffer.from('a679e749a6af300c36e7ff2255d220864eab27b382f9cfdc5aa4d13563ba36ff', 'hex')];
+      expect(outputBytes).toEqual(expected);
     });
 
     it('keccak_hash_1400', async () => {


### PR DESCRIPTION
Linear issue [AVM-39](https://linear.app/aztec-labs/issue/AVM-39/keccak-test-vectors)