### PR TITLE
refactor(sequencer): sign last block before archiver sync

### DIFF
--- a/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.test.ts
@@ -818,7 +818,7 @@ describe('CheckpointProposalJob', () => {
       const failedTxs: FailedTx[] = txs.slice(1).map(tx => ({ tx, error: new Error('Invalid tx') }));
       checkpointBuilder.buildBlock.mockRejectedValue(new InsufficientValidTxsError(1, 2, failedTxs));
 
-      const checkpoint = await job.buildSingleBlock(checkpointBuilder, {
+      const result = await job.buildSingleBlock(checkpointBuilder, {
         blockNumber: newBlockNumber,
         indexWithinCheckpoint: IndexWithinCheckpoint(1),
         buildDeadline: undefined,
@@ -826,7 +826,7 @@ describe('CheckpointProposalJob', () => {
         txHashesAlreadyIncluded: new Set<string>(),
       });
 
-      expect(checkpoint).toBeUndefined();
+      expect(result).toEqual({ failure: 'insufficient-valid-txs' });
       expect(p2p.handleFailedExecution).toHaveBeenCalledWith(failedTxs.map(ftx => ftx.tx.txHash));
     });
 
@@ -839,7 +839,7 @@ describe('CheckpointProposalJob', () => {
       const failedTxs: FailedTx[] = txs.slice(1).map(tx => ({ tx, error: new Error('Invalid tx') }));
       checkpointBuilder.buildBlock.mockRejectedValue(new InsufficientValidTxsError(0, 3, failedTxs));
 
-      const checkpoint = await job.buildSingleBlock(checkpointBuilder, {
+      const result = await job.buildSingleBlock(checkpointBuilder, {
         blockNumber: newBlockNumber,
         indexWithinCheckpoint: IndexWithinCheckpoint(1),
         buildDeadline: undefined,
@@ -847,7 +847,7 @@ describe('CheckpointProposalJob', () => {
         txHashesAlreadyIncluded: new Set<string>(),
       });
 
-      expect(checkpoint).toBeUndefined();
+      expect(result).toEqual({ failure: 'insufficient-valid-txs' });
       expect(p2p.handleFailedExecution).toHaveBeenCalledWith(failedTxs.map(ftx => ftx.tx.txHash));
     });
   });
@@ -1121,7 +1121,9 @@ class TestCheckpointProposalJob extends CheckpointProposalJob {
       buildDeadline: Date | undefined;
       txHashesAlreadyIncluded: Set<string>;
     },
-  ): Promise<{ block: L2Block; usedTxs: Tx[] } | { error: Error } | undefined> {
+  ): Promise<
+    { block: L2Block; usedTxs: Tx[] } | { failure: 'insufficient-txs' | 'insufficient-valid-txs' } | { error: Error }
+  > {
     return super.buildSingleBlock(checkpointBuilder, opts);
   }
 }

--- a/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.ts
+++ b/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.ts
@@ -272,7 +272,7 @@ export class CheckpointProposalJob implements Traceable {
       };
 
       let blocksInCheckpoint: L2Block[] = [];
-      let blockPendingBroadcast: { block: L2Block; txs: Tx[] } | undefined = undefined;
+      let blockPendingBroadcast: BlockProposal | undefined = undefined;
       const checkpointBuildTimer = new Timer();
 
       try {
@@ -355,19 +355,12 @@ export class CheckpointProposalJob implements Traceable {
         return checkpoint;
       }
 
-      // Include the block pending broadcast in the checkpoint proposal if any
-      const lastBlock = blockPendingBroadcast && {
-        blockHeader: blockPendingBroadcast.block.header,
-        indexWithinCheckpoint: blockPendingBroadcast.block.indexWithinCheckpoint,
-        txs: blockPendingBroadcast.txs,
-      };
-
       // Create the checkpoint proposal and broadcast it
       const proposal = await this.validatorClient.createCheckpointProposal(
         checkpoint.header,
         checkpoint.archive.root,
         feeAssetPriceModifier,
-        lastBlock,
+        blockPendingBroadcast,
         this.proposer,
         checkpointProposalOptions,
       );
@@ -448,14 +441,14 @@ export class CheckpointProposalJob implements Traceable {
     blockProposalOptions: BlockProposalOptions,
   ): Promise<{
     blocksInCheckpoint: L2Block[];
-    blockPendingBroadcast: { block: L2Block; txs: Tx[] } | undefined;
+    blockPendingBroadcast: BlockProposal | undefined;
   }> {
     const blocksInCheckpoint: L2Block[] = [];
     const txHashesAlreadyIncluded = new Set<string>();
     const initialBlockNumber = BlockNumber(this.syncedToBlockNumber + 1);
 
     // Last block in the checkpoint will usually be flagged as pending broadcast, so we send it along with the checkpoint proposal
-    let blockPendingBroadcast: { block: L2Block; txs: Tx[] } | undefined = undefined;
+    let blockPendingBroadcast: BlockProposal | undefined = undefined;
 
     while (true) {
       const blocksBuilt = blocksInCheckpoint.length;
@@ -488,19 +481,20 @@ export class CheckpointProposalJob implements Traceable {
         txHashesAlreadyIncluded,
       });
 
-      // TODO(palla/mbps): Review these conditions. We may want to keep trying in some scenarios.
-      if (!buildResult && timingInfo.isLastBlock) {
-        // If no block was produced due to not enough txs and this was the last subslot, exit
-        break;
-      } else if (!buildResult && timingInfo.deadline !== undefined) {
-        // But if there is still time for more blocks, wait until the next subslot and try again
+      // If we failed to build the block due to insufficient txs, we try again if there is still time left in the slot
+      if ('failure' in buildResult) {
+        // If this was the last subslot, or we're running with a single block per slot, we're done
+        if (timingInfo.isLastBlock || timingInfo.deadline === undefined) {
+          break;
+        }
+        // Otherwise, if there is still time for more blocks, we wait until the next subslot and try again
         await this.waitUntilNextSubslot(timingInfo.deadline);
         continue;
-      } else if (!buildResult) {
-        // Exit if there is no possibility of building more blocks
-        break;
-      } else if ('error' in buildResult) {
-        // If there was an error building the block, just exit the loop and give up the rest of the slot
+      }
+
+      // If there was an error building the block, we just exit the loop and give up the rest of the slot.
+      // We don't want to risk building more blocks if something went wrong.
+      if ('error' in buildResult) {
         if (!(buildResult.error instanceof SequencerInterruptedError)) {
           this.log.warn(`Halting block building for slot ${this.targetSlot}`, {
             slot: this.targetSlot,
@@ -515,29 +509,25 @@ export class CheckpointProposalJob implements Traceable {
       blocksInCheckpoint.push(block);
       usedTxs.forEach(tx => txHashesAlreadyIncluded.add(tx.txHash.toString()));
 
-      // If this is the last block, sync it to the archiver and exit the loop
-      // so we can build the checkpoint and start collecting attestations.
+      // Sign the block proposal. This will throw if HA signing fails.
+      const proposal = await this.createBlockProposal(block, inHash, usedTxs, blockProposalOptions);
+
+      // Sync the proposed block to the archiver to make it available, only after we've managed to sign the proposal,
+      // so we avoid polluting our archive with a block that would fail.
+      // We wait for the sync to succeed, as this helps catch consistency errors, even if it means we lose some time for block-building.
+      // If this throws, we abort the entire checkpoint.
+      await this.syncProposedBlockToArchiver(block);
+
+      // If this is the last block, do not broadcast it, since it will be included in the checkpoint proposal.
       if (timingInfo.isLastBlock) {
-        await this.syncProposedBlockToArchiver(block);
         this.log.verbose(`Completed final block ${blockNumber} for slot ${this.targetSlot}`, {
           slot: this.targetSlot,
           blockNumber,
           blocksBuilt,
         });
-        blockPendingBroadcast = { block, txs: usedTxs };
+        blockPendingBroadcast = proposal;
         break;
       }
-
-      // Broadcast the block proposal (unless we're in fisherman mode) unless the block is the last one,
-      // in which case we'll broadcast it along with the checkpoint at the end of the loop.
-      // Note that we only send the block to the archiver if we manage to create the proposal, so if there's
-      // a HA error we don't pollute our archiver with a block that won't make it to the chain.
-      const proposal = await this.createBlockProposal(block, inHash, usedTxs, blockProposalOptions);
-
-      // Sync the proposed block to the archiver to make it available, only after we've managed to sign the proposal.
-      // We wait for the sync to succeed, as this helps catch consistency errors, even if it means we lose some time for block-building.
-      // If this throws, we abort the entire checkpoint.
-      await this.syncProposedBlockToArchiver(block);
 
       // Once we have a signed proposal and the archiver agreed with our proposed block, then we broadcast it.
       proposal && (await this.p2pClient.broadcastProposal(proposal));
@@ -598,7 +588,9 @@ export class CheckpointProposalJob implements Traceable {
       buildDeadline: Date | undefined;
       txHashesAlreadyIncluded: Set<string>;
     },
-  ): Promise<{ block: L2Block; usedTxs: Tx[] } | { error: Error } | undefined> {
+  ): Promise<
+    { block: L2Block; usedTxs: Tx[] } | { failure: 'insufficient-txs' | 'insufficient-valid-txs' } | { error: Error }
+  > {
     const { blockTimestamp, forceCreate, blockNumber, indexWithinCheckpoint, buildDeadline, txHashesAlreadyIncluded } =
       opts;
 
@@ -617,7 +609,7 @@ export class CheckpointProposalJob implements Traceable {
         );
         this.eventEmitter.emit('block-tx-count-check-failed', { minTxs, availableTxs, slot: this.targetSlot });
         this.metrics.recordBlockProposalFailed('insufficient_txs');
-        return undefined;
+        return { failure: 'insufficient-txs' };
       }
 
       // Create iterator to pending txs. We filter out txs already included in previous blocks in the checkpoint
@@ -680,7 +672,7 @@ export class CheckpointProposalJob implements Traceable {
           slot: this.targetSlot,
         });
         this.metrics.recordBlockProposalFailed('insufficient_valid_txs');
-        return undefined;
+        return { failure: 'insufficient-valid-txs' };
       }
 
       // Block creation succeeded, emit stats and metrics

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.test.ts
@@ -469,8 +469,8 @@ describe('sequencer', () => {
       // Verify that the sequencer attempted to create and broadcast a block proposal
       expect(publisher.enqueueProposeCheckpoint).toHaveBeenCalled();
 
-      // Verify that the sequencer did not broadcast for attestations since there's no committee
-      expect(validatorClient.createBlockProposal).not.toHaveBeenCalled();
+      // Verify that the sequencer did not broadcast the block proposal since there's no committee
+      // (block proposal is still created since it's included in the checkpoint)
       expect(validatorClient.broadcastBlockProposal).not.toHaveBeenCalled();
     });
   });

--- a/yarn-project/stdlib/src/interfaces/validator.ts
+++ b/yarn-project/stdlib/src/interfaces/validator.ts
@@ -9,7 +9,6 @@ import type {
   BlockProposal,
   BlockProposalOptions,
   CheckpointAttestation,
-  CheckpointLastBlockData,
   CheckpointProposal,
   CheckpointProposalOptions,
 } from '@aztec/stdlib/p2p';
@@ -118,8 +117,6 @@ export const ValidatorClientFullConfigSchema = zodFor<Omit<ValidatorClientFullCo
   }),
 );
 
-export type CreateCheckpointProposalLastBlockData = Omit<CheckpointLastBlockData, 'txHashes'> & { txs: Tx[] };
-
 export interface Validator {
   start(): Promise<void>;
   updateConfig(config: Partial<ValidatorClientFullConfig>): void;
@@ -140,7 +137,7 @@ export interface Validator {
     checkpointHeader: CheckpointHeader,
     archive: Fr,
     feeAssetPriceModifier: bigint,
-    lastBlockInfo: CreateCheckpointProposalLastBlockData | undefined,
+    lastBlockProposal: BlockProposal | undefined,
     proposerAddress: EthAddress | undefined,
     options: CheckpointProposalOptions,
   ): Promise<CheckpointProposal>;

--- a/yarn-project/stdlib/src/p2p/checkpoint_proposal.ts
+++ b/yarn-project/stdlib/src/p2p/checkpoint_proposal.ts
@@ -161,7 +161,7 @@ export class CheckpointProposal extends Gossipable {
     checkpointHeader: CheckpointHeader,
     archiveRoot: Fr,
     feeAssetPriceModifier: bigint,
-    lastBlockInfo: CheckpointLastBlockData | undefined,
+    lastBlockProposal: BlockProposal | undefined,
     payloadSigner: (payload: Buffer32, context: SigningContext) => Promise<Signature>,
   ): Promise<CheckpointProposal> {
     // Sign the checkpoint payload with CHECKPOINT_PROPOSAL duty type
@@ -175,35 +175,19 @@ export class CheckpointProposal extends Gossipable {
 
     const checkpointContext: SigningContext = {
       slot: checkpointHeader.slotNumber,
-      blockNumber: lastBlockInfo?.blockHeader?.globalVariables.blockNumber ?? BlockNumber(0),
+      blockNumber: lastBlockProposal?.blockNumber ?? BlockNumber(0),
       dutyType: DutyType.CHECKPOINT_PROPOSAL,
     };
 
-    if (lastBlockInfo) {
-      // Sign block proposal before signing checkpoint proposal to ensure HA protection
-      const lastBlockProposal = await BlockProposal.createProposalFromSigner(
-        lastBlockInfo.blockHeader,
-        lastBlockInfo.indexWithinCheckpoint,
-        checkpointHeader.inHash,
-        archiveRoot,
-        lastBlockInfo.txHashes,
-        lastBlockInfo.txs,
-        payloadSigner,
-      );
-
-      const checkpointSignature = await payloadSigner(checkpointHash, checkpointContext);
-
-      return new CheckpointProposal(checkpointHeader, archiveRoot, feeAssetPriceModifier, checkpointSignature, {
-        blockHeader: lastBlockInfo.blockHeader,
-        indexWithinCheckpoint: lastBlockInfo.indexWithinCheckpoint,
-        txHashes: lastBlockInfo.txHashes,
-        signature: lastBlockProposal.signature,
-        signedTxs: lastBlockProposal.signedTxs,
-      });
-    }
-
     const checkpointSignature = await payloadSigner(checkpointHash, checkpointContext);
-    return new CheckpointProposal(checkpointHeader, archiveRoot, feeAssetPriceModifier, checkpointSignature);
+
+    return new CheckpointProposal(
+      checkpointHeader,
+      archiveRoot,
+      feeAssetPriceModifier,
+      checkpointSignature,
+      lastBlockProposal,
+    );
   }
 
   /**

--- a/yarn-project/stdlib/src/tests/mocks.ts
+++ b/yarn-project/stdlib/src/tests/mocks.ts
@@ -596,28 +596,30 @@ export const makeBlockProposal = (options?: MakeBlockProposalOptions): Promise<B
   );
 };
 
-export const makeCheckpointProposal = (options?: MakeCheckpointProposalOptions): Promise<CheckpointProposal> => {
-  const blockHeader = options?.lastBlock?.blockHeader ?? makeBlockHeader(1);
+export const makeCheckpointProposal = async (options?: MakeCheckpointProposalOptions): Promise<CheckpointProposal> => {
   const checkpointHeader = options?.checkpointHeader ?? makeCheckpointHeader(1);
   const archiveRoot = options?.archiveRoot ?? Fr.random();
   const feeAssetPriceModifier = options?.feeAssetPriceModifier ?? 0n;
   const signer = options?.signer ?? Secp256k1Signer.random();
 
-  // Build lastBlock info if provided
-  const lastBlockInfo = options?.lastBlock
-    ? {
-        blockHeader,
-        indexWithinCheckpoint: options.lastBlock.indexWithinCheckpoint ?? IndexWithinCheckpoint(4), // Last block in a 5-block checkpoint
-        txHashes: options.lastBlock.txHashes ?? [0, 1, 2, 3, 4, 5].map(() => TxHash.random()),
+  // Build a signed block proposal if lastBlock options are provided
+  const lastBlockProposal = options?.lastBlock
+    ? await makeBlockProposal({
+        blockHeader: options.lastBlock.blockHeader,
+        indexWithinCheckpoint: options.lastBlock.indexWithinCheckpoint ?? IndexWithinCheckpoint(4),
+        inHash: checkpointHeader.inHash,
+        archiveRoot,
+        txHashes: options.lastBlock.txHashes,
         txs: options.lastBlock.txs,
-      }
+        signer,
+      })
     : undefined;
 
   return CheckpointProposal.createProposalFromSigner(
     checkpointHeader,
     archiveRoot,
     feeAssetPriceModifier,
-    lastBlockInfo,
+    lastBlockProposal,
     payload => Promise.resolve(signer.signMessage(payload)),
   );
 };

--- a/yarn-project/validator-client/src/duties/validation_service.test.ts
+++ b/yarn-project/validator-client/src/duties/validation_service.test.ts
@@ -75,15 +75,24 @@ describe('ValidationService', () => {
     expect(attestations[1].getSender()).toEqual(addresses[1]);
   });
 
-  it('creates checkpoint proposal with different duty types for checkpoint and block', async () => {
-    // This test verifies the fix for HA double-signing issue where both checkpoint
-    // and block were incorrectly using the same CHECKPOINT_PROPOSAL duty type.
-    // Now they should use CHECKPOINT_PROPOSAL and BLOCK_PROPOSAL respectively.
-
+  it('creates checkpoint proposal with an already-signed block proposal', async () => {
     const txs = await Promise.all([Tx.random(), Tx.random()]);
     const blockHeader = makeBlockHeader(1);
     const indexWithinCheckpoint = IndexWithinCheckpoint(0);
     const archive = Fr.random();
+    const checkpointHeader = makeCheckpointHeader(1);
+
+    // Create the block proposal first (as the sequencer would), using the checkpoint's inHash
+    // so that getSender() can verify the block proposal sender matches
+    const blockProposal = await service.createBlockProposal(
+      blockHeader,
+      indexWithinCheckpoint,
+      checkpointHeader.inHash,
+      archive,
+      txs,
+      addresses[0],
+      { publishFullTxs: true },
+    );
 
     // Create a spy keystore to capture signing contexts
     const capturedContexts: Array<{ dutyType: DutyType; blockIndexWithinCheckpoint?: number }> = [];
@@ -101,49 +110,23 @@ describe('ValidationService', () => {
     };
     const spyService = new ValidationService(spyStore as any);
 
-    // Create checkpoint header
-    const checkpointHeader = makeCheckpointHeader(1);
-
-    // Create checkpoint proposal with lastBlock
+    // Create checkpoint proposal with the already-signed block proposal
     const proposal = await spyService.createCheckpointProposal(
       checkpointHeader,
       archive,
-      0n, // feeAssetPriceModifier
-      {
-        blockHeader,
-        indexWithinCheckpoint,
-        txs,
-      },
+      0n,
+      blockProposal,
       addresses[0],
-      { publishFullTxs: true },
+      {},
     );
 
     // Verify proposal was created successfully
     expect(proposal.getSender()).toEqual(addresses[0]);
     expect(proposal.lastBlock).toBeDefined();
+    expect(proposal.lastBlock!.signature).toEqual(blockProposal.signature);
 
-    // Verify we captured signing operations:
-    // 1. CHECKPOINT_PROPOSAL for the checkpoint itself
-    // 2. BLOCK_PROPOSAL for the block itself
-    // 3. TXS for the SignedTxs
-    expect(capturedContexts.length).toBe(3);
-
-    // Find the checkpoint and block signatures
-    const checkpointSigs = capturedContexts.filter(c => c.dutyType === DutyType.CHECKPOINT_PROPOSAL);
-    const blockSigs = capturedContexts.filter(c => c.dutyType === DutyType.BLOCK_PROPOSAL);
-    const txsSigs = capturedContexts.filter(c => c.dutyType === DutyType.TXS);
-
-    // Should have exactly 1 checkpoint signature (no blockIndexWithinCheckpoint)
-    expect(checkpointSigs.length).toBe(1);
-    expect(checkpointSigs[0].blockIndexWithinCheckpoint).toBeUndefined();
-
-    // Should have exactly 2 block signatures (both with blockIndexWithinCheckpoint)
-    // One for the block proposal, one for the SignedTxs
-    expect(blockSigs.length).toBe(1);
-    expect(blockSigs[0].blockIndexWithinCheckpoint).toBe(indexWithinCheckpoint);
-
-    // Should have exactly 1 txs signature
-    expect(txsSigs.length).toBe(1);
-    expect(txsSigs[0].blockIndexWithinCheckpoint).toBeUndefined();
+    // Only the checkpoint signing should happen — the block was already signed
+    expect(capturedContexts.length).toBe(1);
+    expect(capturedContexts[0].dutyType).toBe(DutyType.CHECKPOINT_PROPOSAL);
   });
 });

--- a/yarn-project/validator-client/src/duties/validation_service.ts
+++ b/yarn-project/validator-client/src/duties/validation_service.ts
@@ -11,7 +11,6 @@ import type { EthAddress } from '@aztec/foundation/eth-address';
 import type { Signature } from '@aztec/foundation/eth-signature';
 import { createLogger } from '@aztec/foundation/log';
 import type { CommitteeAttestationsAndSigners } from '@aztec/stdlib/block';
-import type { CreateCheckpointProposalLastBlockData } from '@aztec/stdlib/interfaces/server';
 import {
   BlockProposal,
   type BlockProposalOptions,
@@ -86,7 +85,7 @@ export class ValidationService {
    *
    * @param checkpointHeader - The checkpoint header containing aggregated data
    * @param archive - The archive of the checkpoint
-   * @param lastBlockInfo - Info about the last block (header, index, txs) or undefined
+   * @param lastBlockProposal - Signed block proposal for the last block in the checkpoint, or undefined
    * @param proposerAttesterAddress - The address of the proposer
    * @param options - Checkpoint proposal options
    *
@@ -96,13 +95,15 @@ export class ValidationService {
     checkpointHeader: CheckpointHeader,
     archive: Fr,
     feeAssetPriceModifier: bigint,
-    lastBlockInfo: CreateCheckpointProposalLastBlockData | undefined,
+    lastBlockProposal: BlockProposal | undefined,
     proposerAttesterAddress: EthAddress | undefined,
     options: CheckpointProposalOptions,
   ): Promise<CheckpointProposal> {
-    // For testing: change the archive to trigger state_mismatch validation failure
+    // For testing: change the archive to trigger state_mismatch validation failure.
+    // If there's a last block proposal, use its (already invalid) archive to keep signatures consistent
+    // so P2P validation passes and the slasher can detect the offense.
     if (options.broadcastInvalidCheckpointProposal) {
-      archive = Fr.random();
+      archive = lastBlockProposal?.archiveRoot ?? Fr.random();
       this.log.warn(`Creating INVALID checkpoint proposal for slot ${checkpointHeader.slotNumber}`);
     }
 
@@ -112,19 +113,11 @@ export class ValidationService {
       return this.keyStore.signMessageWithAddress(address, payload, context);
     };
 
-    // Last block to include in the proposal
-    const lastBlock = lastBlockInfo && {
-      blockHeader: lastBlockInfo.blockHeader,
-      indexWithinCheckpoint: lastBlockInfo.indexWithinCheckpoint,
-      txHashes: lastBlockInfo.txs.map(tx => tx.getTxHash()),
-      txs: options.publishFullTxs ? lastBlockInfo.txs : undefined,
-    };
-
     return CheckpointProposal.createProposalFromSigner(
       checkpointHeader,
       archive,
       feeAssetPriceModifier,
-      lastBlock,
+      lastBlockProposal,
       payloadSigner,
     );
   }

--- a/yarn-project/validator-client/src/validator.ts
+++ b/yarn-project/validator-client/src/validator.ts
@@ -22,7 +22,6 @@ import type { AztecAddress } from '@aztec/stdlib/aztec-address';
 import type { CommitteeAttestationsAndSigners, L2BlockSink, L2BlockSource } from '@aztec/stdlib/block';
 import { getEpochAtSlot } from '@aztec/stdlib/epoch-helpers';
 import type {
-  CreateCheckpointProposalLastBlockData,
   ITxProvider,
   Validator,
   ValidatorClientFullConfig,
@@ -730,7 +729,7 @@ export class ValidatorClient extends (EventEmitter as new () => WatcherEmitter) 
     checkpointHeader: CheckpointHeader,
     archive: Fr,
     feeAssetPriceModifier: bigint,
-    lastBlockInfo: CreateCheckpointProposalLastBlockData | undefined,
+    lastBlockProposal: BlockProposal | undefined,
     proposerAddress: EthAddress | undefined,
     options: CheckpointProposalOptions = {},
   ): Promise<CheckpointProposal> {
@@ -752,7 +751,7 @@ export class ValidatorClient extends (EventEmitter as new () => WatcherEmitter) 
       checkpointHeader,
       archive,
       feeAssetPriceModifier,
-      lastBlockInfo,
+      lastBlockProposal,
       proposerAddress,
       options,
     );


### PR DESCRIPTION
## Motivation

The last block in a checkpoint was being synced to the archiver _before_ passing through the HA signing gate. If HA signing failed afterwards, the archiver would be polluted with a block that never made it on-chain. 

## Approach

Reorder the block-building loop so that block proposal signing and archiver sync happen in the same order for all blocks (sign first, sync second), not just for non-last blocks. Pass the already-signed `BlockProposal` through to `CheckpointProposal.createProposalFromSigner` instead of raw block data. 

Unrelated to the above, we replaced `undefined` returns from `buildSingleBlock` with typed `{ failure: 'insufficient-txs' | 'insufficient-valid-txs' }` objects, so the failure reason is made explicit.

## Changes

- **sequencer-client**: Reorder block-building loop so signing happens before archiver sync for all blocks (including last). Simplify `blockPendingBroadcast` to just `BlockProposal | undefined`. Return typed failure objects from `buildSingleBlock` instead of `undefined`. Update caller to check `'failure' in buildResult`.
- **stdlib**: `CheckpointProposal.createProposalFromSigner` accepts `BlockProposal | undefined` instead of `CheckpointLastBlockData`. Remove `CreateCheckpointProposalLastBlockData` type. Update `makeCheckpointProposal` test helper to create a real `BlockProposal` via `makeBlockProposal`.
- **validator-client**: Update `Validator` interface, `ValidatorClient`, and `ValidationService` to pass `BlockProposal` instead of raw block data for checkpoint proposal creation.
- **tests**: Update assertions from `toBeUndefined()` to `toEqual({ failure: ... })`, update signing-context test to reflect that only checkpoint signing happens in `createCheckpointProposal`.