### PR TITLE
chore: Use 7 bit rom tables in biggroup

### DIFF
--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/gate_count_constants.hpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/gate_count_constants.hpp
@@ -55,7 +55,7 @@ template <typename Builder> inline constexpr size_t ASSERT_EQUALITY = ZERO_GATE 
 // Honk Recursion Constants
 // ========================================
 
-inline constexpr size_t ROOT_ROLLUP_GATE_COUNT = 12904895;
+inline constexpr size_t ROOT_ROLLUP_GATE_COUNT = 12857523;
 
 template <typename RecursiveFlavor>
 constexpr std::tuple<size_t, size_t> HONK_RECURSION_CONSTANTS(
@@ -67,18 +67,18 @@ constexpr std::tuple<size_t, size_t> HONK_RECURSION_CONSTANTS(
     if constexpr (std::is_same_v<RecursiveFlavor, bb::UltraRecursiveFlavor_<UltraCircuitBuilder>>) {
         switch (mode) {
         case PredicateTestCase::ConstantTrue:
-            return std::make_tuple(681767, 0);
+            return std::make_tuple(658126, 0);
         case PredicateTestCase::WitnessTrue:
         case PredicateTestCase::WitnessFalse:
-            return std::make_tuple(682824, 0);
+            return std::make_tuple(659183, 0);
         }
     } else if constexpr (std::is_same_v<RecursiveFlavor, bb::UltraZKRecursiveFlavor_<UltraCircuitBuilder>>) {
         switch (mode) {
         case PredicateTestCase::ConstantTrue:
-            return std::make_tuple(703922, 0);
+            return std::make_tuple(673904, 0);
         case PredicateTestCase::WitnessTrue:
         case PredicateTestCase::WitnessFalse:
-            return std::make_tuple(705075, 0);
+            return std::make_tuple(675057, 0);
         }
     } else if constexpr (std::is_same_v<RecursiveFlavor, bb::UltraRecursiveFlavor_<MegaCircuitBuilder>>) {
         switch (mode) {
@@ -100,7 +100,7 @@ constexpr std::tuple<size_t, size_t> HONK_RECURSION_CONSTANTS(
         if (mode != PredicateTestCase::ConstantTrue) {
             bb::assert_failure("Unhandled mode in MegaZKRecursiveFlavor.");
         }
-        return std::make_tuple(781915, 0);
+        return std::make_tuple(738408, 0);
     } else {
         bb::assert_failure("Unhandled recursive flavor.");
     }
@@ -113,7 +113,7 @@ constexpr std::tuple<size_t, size_t> HONK_RECURSION_CONSTANTS(
 // ========================================
 
 // Gate count for Chonk recursive verification (Ultra with RollupIO)
-inline constexpr size_t CHONK_RECURSION_GATES = 1491767;
+inline constexpr size_t CHONK_RECURSION_GATES = 1436981;
 
 // ========================================
 // Hypernova Recursion Constants

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup.hpp
@@ -695,15 +695,17 @@ template <class Builder_, class Fq, class Fr, class NativeGroup> class element {
      *
      **/
     struct batch_lookup_table_plookup {
+
         batch_lookup_table_plookup(const std::vector<element>& points)
             : num_points(points.size())
-            , num_sevens(num_points / 7)
+            , num_sevens(0)
             , num_sixes(0)
             , num_fives(0)
         {
-            // size-7 is the primary table; fall back to size-6, size-5, then small tables.
-            // For the N=63-81 MSMs in recursive verifiers, k=7 gives the fewest gates.
-            size_t remaining_points = num_points - (num_sevens * 7);
+            // Greedily allocate tables from k = 7 downward
+            size_t remaining_points = num_points;
+            num_sevens = remaining_points / 7;
+            remaining_points -= num_sevens * 7;
             num_sixes = remaining_points / 6;
             remaining_points -= num_sixes * 6;
             num_fives = remaining_points / 5;

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup.hpp
@@ -697,58 +697,52 @@ template <class Builder_, class Fq, class Fr, class NativeGroup> class element {
     struct batch_lookup_table_plookup {
         batch_lookup_table_plookup(const std::vector<element>& points)
             : num_points(points.size())
-            , num_fives(num_points / 5)
+            , num_sevens(num_points / 7)
+            , num_sixes(0)
+            , num_fives(0)
         {
-            // size-6 table is expensive and only benefits us if creating them reduces the number of total tables
-            if (num_points == 1) {
-                num_fives = 0;
-                num_sixes = 0;
-            } else if (num_fives * 5 == (num_points - 1)) {
-                // last 6 points to be added as one 6-table
-                num_fives -= 1;
-                num_sixes = 1;
-            } else if (num_fives * 5 == (num_points - 2) && num_fives >= 2) {
-                // last 12 points to be added as two 6-tables
-                num_fives -= 2;
-                num_sixes = 2;
-            } else if (num_fives * 5 == (num_points - 3) && num_fives >= 3) {
-                // last 18 points to be added as three 6-tables
-                num_fives -= 3;
-                num_sixes = 3;
-            }
+            // size-7 is the primary table; fall back to size-6, size-5, then small tables.
+            // For the N=63-81 MSMs in recursive verifiers, k=7 gives the fewest gates.
+            size_t remaining_points = num_points - (num_sevens * 7);
+            num_sixes = remaining_points / 6;
+            remaining_points -= num_sixes * 6;
+            num_fives = remaining_points / 5;
+            remaining_points -= num_fives * 5;
 
-            // Calculate remaining points after allocating fives and sixes tables
-            size_t remaining_points = num_points - (num_fives * 5 + num_sixes * 6);
-
-            // Allocate one quad table if required (and update remaining points)
             has_quad = (remaining_points >= 4) && (num_points >= 4);
             if (has_quad) {
                 remaining_points -= 4;
             }
-
-            // Allocate one triple table if required (and update remaining points)
             has_triple = (remaining_points >= 3) && (num_points >= 3);
             if (has_triple) {
                 remaining_points -= 3;
             }
-
-            // Allocate one twin table if required (and update remaining points)
             has_twin = (remaining_points >= 2) && (num_points >= 2);
             if (has_twin) {
                 remaining_points -= 2;
             }
-
-            // If there is anything remaining, allocate a singleton
             has_singleton = (remaining_points != 0) && (num_points >= 1);
 
             // Sanity check
             BB_ASSERT_EQ(num_points,
-                         num_sixes * 6 + num_fives * 5 + static_cast<size_t>(has_quad) * 4 +
+                         num_sevens * 7 + num_sixes * 6 + num_fives * 5 + static_cast<size_t>(has_quad) * 4 +
                              static_cast<size_t>(has_triple) * 3 + static_cast<size_t>(has_twin) * 2 +
                              static_cast<size_t>(has_singleton) * 1,
                          "point allocation mismatch");
 
             size_t offset = 0;
+            for (size_t i = 0; i < num_sevens; ++i) {
+                seven_tables.push_back(lookup_table_plookup<7>({
+                    points[offset + (7 * i)],
+                    points[offset + (7 * i) + 1],
+                    points[offset + (7 * i) + 2],
+                    points[offset + (7 * i) + 3],
+                    points[offset + (7 * i) + 4],
+                    points[offset + (7 * i) + 5],
+                    points[offset + (7 * i) + 6],
+                }));
+            }
+            offset += 7 * num_sevens;
             for (size_t i = 0; i < num_sixes; ++i) {
                 six_tables.push_back(lookup_table_plookup<6>({
                     points[offset + (6 * i)],
@@ -790,6 +784,9 @@ template <class Builder_, class Fq, class Fr, class NativeGroup> class element {
         chain_add_accumulator get_chain_initial_entry() const
         {
             std::vector<element> add_accumulator;
+            for (size_t i = 0; i < num_sevens; ++i) {
+                add_accumulator.push_back(seven_tables[i][0]);
+            }
             for (size_t i = 0; i < num_sixes; ++i) {
                 add_accumulator.push_back(six_tables[i][0]);
             }
@@ -821,15 +818,25 @@ template <class Builder_, class Fq, class Fr, class NativeGroup> class element {
         element::chain_add_accumulator get_chain_add_accumulator(std::vector<bool_ct>& naf_entries) const
         {
             std::vector<element> round_accumulator;
-            for (size_t j = 0; j < num_sixes; ++j) {
-                round_accumulator.push_back(six_tables[j].get({ naf_entries[6 * j],
-                                                                naf_entries[(6 * j) + 1],
-                                                                naf_entries[(6 * j) + 2],
-                                                                naf_entries[(6 * j) + 3],
-                                                                naf_entries[(6 * j) + 4],
-                                                                naf_entries[(6 * j) + 5] }));
+            for (size_t j = 0; j < num_sevens; ++j) {
+                round_accumulator.push_back(seven_tables[j].get({ naf_entries[7 * j],
+                                                                  naf_entries[(7 * j) + 1],
+                                                                  naf_entries[(7 * j) + 2],
+                                                                  naf_entries[(7 * j) + 3],
+                                                                  naf_entries[(7 * j) + 4],
+                                                                  naf_entries[(7 * j) + 5],
+                                                                  naf_entries[(7 * j) + 6] }));
             }
-            size_t offset = num_sixes * 6;
+            size_t offset = num_sevens * 7;
+            for (size_t j = 0; j < num_sixes; ++j) {
+                round_accumulator.push_back(six_tables[j].get({ naf_entries[offset + (6 * j)],
+                                                                naf_entries[offset + (6 * j) + 1],
+                                                                naf_entries[offset + (6 * j) + 2],
+                                                                naf_entries[offset + (6 * j) + 3],
+                                                                naf_entries[offset + (6 * j) + 4],
+                                                                naf_entries[offset + (6 * j) + 5] }));
+            }
+            offset += num_sixes * 6;
             for (size_t j = 0; j < num_fives; ++j) {
                 round_accumulator.push_back(five_tables[j].get({ naf_entries[offset + (j * 5)],
                                                                  naf_entries[offset + (j * 5) + 1],
@@ -877,16 +884,25 @@ template <class Builder_, class Fq, class Fr, class NativeGroup> class element {
         element get(std::vector<bool_ct>& naf_entries) const
         {
             std::vector<element> round_accumulator;
-            for (size_t j = 0; j < num_sixes; ++j) {
-                round_accumulator.push_back(six_tables[j].get({ naf_entries[(6 * j)],
-                                                                naf_entries[(6 * j) + 1],
-                                                                naf_entries[(6 * j) + 2],
-                                                                naf_entries[(6 * j) + 3],
-                                                                naf_entries[(6 * j) + 4],
-                                                                naf_entries[(6 * j) + 5] }));
+            for (size_t j = 0; j < num_sevens; ++j) {
+                round_accumulator.push_back(seven_tables[j].get({ naf_entries[(7 * j)],
+                                                                  naf_entries[(7 * j) + 1],
+                                                                  naf_entries[(7 * j) + 2],
+                                                                  naf_entries[(7 * j) + 3],
+                                                                  naf_entries[(7 * j) + 4],
+                                                                  naf_entries[(7 * j) + 5],
+                                                                  naf_entries[(7 * j) + 6] }));
             }
-            size_t offset = num_sixes * 6;
-
+            size_t offset = num_sevens * 7;
+            for (size_t j = 0; j < num_sixes; ++j) {
+                round_accumulator.push_back(six_tables[j].get({ naf_entries[offset + (6 * j)],
+                                                                naf_entries[offset + (6 * j) + 1],
+                                                                naf_entries[offset + (6 * j) + 2],
+                                                                naf_entries[offset + (6 * j) + 3],
+                                                                naf_entries[offset + (6 * j) + 4],
+                                                                naf_entries[offset + (6 * j) + 5] }));
+            }
+            offset += num_sixes * 6;
             for (size_t j = 0; j < num_fives; ++j) {
                 round_accumulator.push_back(five_tables[j].get({ naf_entries[offset + (5 * j)],
                                                                  naf_entries[offset + (5 * j) + 1],
@@ -894,7 +910,6 @@ template <class Builder_, class Fq, class Fr, class NativeGroup> class element {
                                                                  naf_entries[offset + (5 * j) + 3],
                                                                  naf_entries[offset + (5 * j) + 4] }));
             }
-
             offset += num_fives * 5;
 
             if (has_quad) {
@@ -931,6 +946,7 @@ template <class Builder_, class Fq, class Fr, class NativeGroup> class element {
             return element::chain_add_end(accumulator);
         }
 
+        std::vector<lookup_table_plookup<7>> seven_tables;
         std::vector<lookup_table_plookup<6>> six_tables;
         std::vector<lookup_table_plookup<5>> five_tables;
         std::vector<quad_lookup_table> quad_tables;
@@ -939,8 +955,9 @@ template <class Builder_, class Fq, class Fr, class NativeGroup> class element {
         std::vector<element> singletons;
         size_t num_points;
 
+        size_t num_sevens = 0;
         size_t num_sixes = 0;
-        size_t num_fives;
+        size_t num_fives = 0;
         bool has_quad;
         bool has_triple;
         bool has_twin;

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_tables.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_tables.hpp
@@ -177,7 +177,7 @@ template <typename C, class Fq, class Fr, class G>
 template <size_t length>
 element<C, Fq, Fr, G>::lookup_table_plookup<length>::lookup_table_plookup(const std::array<element, length>& inputs)
 {
-    static_assert(length <= 6, "lookup_table_plookup only supports up to 6 input elements");
+    static_assert(length <= 7, "lookup_table_plookup only supports up to 7 input elements");
 
     if constexpr (length == 2) {
         auto [A0, A1] = inputs[1].checked_unconditional_add_sub(inputs[0]);
@@ -308,7 +308,138 @@ element<C, Fq, Fr, G>::lookup_table_plookup<length>::lookup_table_plookup(const 
         element_table[29] = W5;
         element_table[30] = W6;
         element_table[31] = W7;
+    } else if constexpr (length == 7) {
+        // 82 adds (41 add_sub ops). Split inputs as (3-point)+(4-point), build subtables, cross-combine.
+        //
+        // Index encoding: index = bits[6]*64 + bits[5]*32 + bits[4]*16 + bits[3]*8 + bits[2]*4 + bits[1]*2 + bits[0]
+        // Convention: bit[i]=0 → +inputs[i],  bit[i]=1 → -inputs[i]
+        // First 64 entries (bit[6]=0): inputs[6] positive.  Upper 64 filled by negation loop.
+        //
+        // 3-point subtable for inputs[0,1,2] → C0..C3 (bits[2..0] ∈ {000,001,010,011})
+        // C4=-C3, C5=-C2, C6=-C1, C7=-C0  (used implicitly via the cross-product pairing below)
+        auto [R0, R1] = inputs[1].checked_unconditional_add_sub(inputs[0]); // R0=A+B, R1=A-B
+        auto [C0, C3] = inputs[2].checked_unconditional_add_sub(R0);        // C0=+A+B+C, C3=-A-B+C
+        auto [C1, C2] = inputs[2].checked_unconditional_add_sub(R1);        // C1=-A+B+C, C2=+A-B+C
+
+        // 4-point subtable for inputs[3..6] → D0..D7 (bits[6..3] with bit[6]=0)
+        auto [T0, T1] = inputs[4].checked_unconditional_add_sub(inputs[3]); // T0=D+E, T1=D-E
+        auto [T2, T3] = inputs[6].checked_unconditional_add_sub(inputs[5]); // T2=F+G, T3=F-G
+        auto [D0, D3] = T2.checked_unconditional_add_sub(T0);               // D0=+D+E+F+G, D3=-D-E+F+G
+        auto [D1, D2] = T2.checked_unconditional_add_sub(T1);               // D1=-D+E+F+G, D2=+D-E+F+G
+        auto [D4, D7] = T3.checked_unconditional_add_sub(T0);               // D4=+D+E-F+G, D7=-D-E-F+G
+        auto [D5, D6] = T3.checked_unconditional_add_sub(T1);               // D5=-D+E-F+G, D6=+D-E-F+G
+
+        // Cross-combine: each D_d ± C{0,1,2,3} covers indices [8*d..8*d+7]
+        // D_d + C0 → index 8*d+0,  D_d - C0 → index 8*d+7  (since -C0 = C7)
+        // D_d + C1 → index 8*d+1,  D_d - C1 → index 8*d+6  (since -C1 = C6)
+        // D_d + C2 → index 8*d+2,  D_d - C2 → index 8*d+5  (since -C2 = C5)
+        // D_d + C3 → index 8*d+3,  D_d - C3 → index 8*d+4  (since -C3 = C4)
+        auto [E00, E07] = D0.checked_unconditional_add_sub(C0);
+        auto [E01, E06] = D0.checked_unconditional_add_sub(C1);
+        auto [E02, E05] = D0.checked_unconditional_add_sub(C2);
+        auto [E03, E04] = D0.checked_unconditional_add_sub(C3);
+
+        auto [E10, E17] = D1.checked_unconditional_add_sub(C0);
+        auto [E11, E16] = D1.checked_unconditional_add_sub(C1);
+        auto [E12, E15] = D1.checked_unconditional_add_sub(C2);
+        auto [E13, E14] = D1.checked_unconditional_add_sub(C3);
+
+        auto [E20, E27] = D2.checked_unconditional_add_sub(C0);
+        auto [E21, E26] = D2.checked_unconditional_add_sub(C1);
+        auto [E22, E25] = D2.checked_unconditional_add_sub(C2);
+        auto [E23, E24] = D2.checked_unconditional_add_sub(C3);
+
+        auto [E30, E37] = D3.checked_unconditional_add_sub(C0);
+        auto [E31, E36] = D3.checked_unconditional_add_sub(C1);
+        auto [E32, E35] = D3.checked_unconditional_add_sub(C2);
+        auto [E33, E34] = D3.checked_unconditional_add_sub(C3);
+
+        auto [E40, E47] = D4.checked_unconditional_add_sub(C0);
+        auto [E41, E46] = D4.checked_unconditional_add_sub(C1);
+        auto [E42, E45] = D4.checked_unconditional_add_sub(C2);
+        auto [E43, E44] = D4.checked_unconditional_add_sub(C3);
+
+        auto [E50, E57] = D5.checked_unconditional_add_sub(C0);
+        auto [E51, E56] = D5.checked_unconditional_add_sub(C1);
+        auto [E52, E55] = D5.checked_unconditional_add_sub(C2);
+        auto [E53, E54] = D5.checked_unconditional_add_sub(C3);
+
+        auto [E60, E67] = D6.checked_unconditional_add_sub(C0);
+        auto [E61, E66] = D6.checked_unconditional_add_sub(C1);
+        auto [E62, E65] = D6.checked_unconditional_add_sub(C2);
+        auto [E63, E64] = D6.checked_unconditional_add_sub(C3);
+
+        auto [E70, E77] = D7.checked_unconditional_add_sub(C0);
+        auto [E71, E76] = D7.checked_unconditional_add_sub(C1);
+        auto [E72, E75] = D7.checked_unconditional_add_sub(C2);
+        auto [E73, E74] = D7.checked_unconditional_add_sub(C3);
+
+        element_table[0] = E00;
+        element_table[1] = E01;
+        element_table[2] = E02;
+        element_table[3] = E03;
+        element_table[4] = E04;
+        element_table[5] = E05;
+        element_table[6] = E06;
+        element_table[7] = E07;
+        element_table[8] = E10;
+        element_table[9] = E11;
+        element_table[10] = E12;
+        element_table[11] = E13;
+        element_table[12] = E14;
+        element_table[13] = E15;
+        element_table[14] = E16;
+        element_table[15] = E17;
+        element_table[16] = E20;
+        element_table[17] = E21;
+        element_table[18] = E22;
+        element_table[19] = E23;
+        element_table[20] = E24;
+        element_table[21] = E25;
+        element_table[22] = E26;
+        element_table[23] = E27;
+        element_table[24] = E30;
+        element_table[25] = E31;
+        element_table[26] = E32;
+        element_table[27] = E33;
+        element_table[28] = E34;
+        element_table[29] = E35;
+        element_table[30] = E36;
+        element_table[31] = E37;
+        element_table[32] = E40;
+        element_table[33] = E41;
+        element_table[34] = E42;
+        element_table[35] = E43;
+        element_table[36] = E44;
+        element_table[37] = E45;
+        element_table[38] = E46;
+        element_table[39] = E47;
+        element_table[40] = E50;
+        element_table[41] = E51;
+        element_table[42] = E52;
+        element_table[43] = E53;
+        element_table[44] = E54;
+        element_table[45] = E55;
+        element_table[46] = E56;
+        element_table[47] = E57;
+        element_table[48] = E60;
+        element_table[49] = E61;
+        element_table[50] = E62;
+        element_table[51] = E63;
+        element_table[52] = E64;
+        element_table[53] = E65;
+        element_table[54] = E66;
+        element_table[55] = E67;
+        element_table[56] = E70;
+        element_table[57] = E71;
+        element_table[58] = E72;
+        element_table[59] = E73;
+        element_table[60] = E74;
+        element_table[61] = E75;
+        element_table[62] = E76;
+        element_table[63] = E77;
     }
+
     for (size_t i = 0; i < table_size / 2; ++i) {
         element_table[i + (table_size / 2)] = (-element_table[(table_size / 2) - 1 - i]);
     }


### PR DESCRIPTION
Using groups of 7 points (instead of 6) gives a slight improvement in recursive verifier circuit sizes:

| Flavor | N | Before | After | % improv. | Dyadic (before) | Dyadic (after) | Boundary? |
|---|---|---|---|---|---|---|---|
| UltraRecursive | 63 | 531,999 | 501,978 | **5.6%** | 2²⁰ | **2¹⁹** | **Yes** |
| UltraZKRecursive | 67 | 568,343 | 539,706 | 5.0% | 2²⁰ | 2²⁰ | No |
| MegaZKRecursive | 76 | 645,124 | 598,440 | 7.2% | 2²⁰ | 2²⁰ | No |
| MegaRecursive | 81 | 685,558 | 643,576 | 6.1% | 2²⁰ | 2²⁰ | No |


This is not intended to be merged as of now, we'll revisit this.

