### PR TITLE
chore: syncing oracle versions

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/oracle/version.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/version.nr
@@ -4,7 +4,7 @@
 ///
 /// @dev Whenever a contract function or Noir test is run, the `aztec_utl_assertCompatibleOracleVersion` oracle is
 /// called and if the oracle version is incompatible an error is thrown.
-pub global ORACLE_VERSION: Field = 21;
+pub global ORACLE_VERSION: Field = 22;
 
 /// Asserts that the version of the oracle is compatible with the version expected by the contract.
 pub fn assert_compatible_oracle_version() {

--- a/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/oracle/version.nr
+++ b/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/oracle/version.nr
@@ -4,7 +4,7 @@
 ///
 /// @dev Whenever a contract function or Noir test is run, the `aztec_utl_assertCompatibleOracleVersion` oracle is
 /// called and if the oracle version is incompatible an error is thrown.
-pub global ORACLE_VERSION: Field = 21;
+pub global ORACLE_VERSION: Field = 22;
 
 /// Asserts that the version of the oracle is compatible with the version expected by the contract.
 pub fn assert_compatible_oracle_version() {

--- a/yarn-project/pxe/src/oracle_version.ts
+++ b/yarn-project/pxe/src/oracle_version.ts
@@ -4,7 +4,7 @@
 ///
 /// @dev Whenever a contract function or Noir test is run, the `aztec_utl_assertCompatibleOracleVersion` oracle is called
 /// and if the oracle version is incompatible an error is thrown.
-export const ORACLE_VERSION = 21;
+export const ORACLE_VERSION = 22;
 
 /// This hash is computed as by hashing the Oracle interface and it is used to detect when the Oracle interface changes,
 /// which in turn implies that you need to update the ORACLE_VERSION constant in this file and in


### PR DESCRIPTION
Currently the `ORACLE_VERSION` on `v4-next` is 22 but on `merge-train/fairies` it's 21.

I think this has accidentally happened when backporting as it should never happen that code on v4-next is ahead of v5 (the version was bumped in [this commit](https://github.com/AztecProtocol/aztec-packages/commit/a0cbbb64d82798623b56fb0162735160863c6037) on v4-next).

For this reason I am bumping the version here to 22 as I could imagine it could cause issues.