### PR TITLE
chore: setup workload identity for ESO

### DIFF
--- a/spartan/terraform/deploy-external-secrets/main.tf
+++ b/spartan/terraform/deploy-external-secrets/main.tf
@@ -45,6 +45,21 @@ resource "helm_release" "external_secrets" {
     value = data.terraform_remote_state.gke_cluster.outputs.eso_service_account_email
   }
 
+  set {
+    name  = "nodeSelector.node-type"
+    value = "infra"
+  }
+
+  set {
+    name  = "webhook.nodeSelector.node-type"
+    value = "infra"
+  }
+
+  set {
+    name  = "certController.nodeSelector.node-type"
+    value = "infra"
+  }
+
   timeout = 300
   wait    = true
 }

--- a/spartan/terraform/gke-cluster/cluster/main.tf
+++ b/spartan/terraform/gke-cluster/cluster/main.tf
@@ -15,6 +15,14 @@ resource "google_container_cluster" "primary" {
     channel = "UNSPECIFIED"
   }
 
+  # NOTE: Enabling workload identity at the cluster level means new node pools may default to GKE_METADATA mode. 
+  dynamic "workload_identity_config" {
+    for_each = var.enable_workload_identity ? [1] : []
+    content {
+      workload_pool = "${var.project}.svc.id.goog"
+    }
+  }
+
   # Network configuration
   network    = "default"
   subnetwork = "default"
@@ -351,6 +359,13 @@ resource "google_container_node_pool" "infra_nodes_8core_highmem" {
       "https://www.googleapis.com/auth/cloud-platform"
     ]
 
+    dynamic "workload_metadata_config" {
+      for_each = var.enable_workload_identity ? [1] : []
+      content {
+        mode = "GKE_METADATA"
+      }
+    }
+
     labels = {
       env       = "production"
       local-ssd = "false"
@@ -386,6 +401,13 @@ resource "google_container_node_pool" "infra_nodes_16core_highmem" {
     oauth_scopes = [
       "https://www.googleapis.com/auth/cloud-platform"
     ]
+
+    dynamic "workload_metadata_config" {
+      for_each = var.enable_workload_identity ? [1] : []
+      content {
+        mode = "GKE_METADATA"
+      }
+    }
 
     labels = {
       env       = "production"

--- a/spartan/terraform/gke-cluster/cluster/variables.tf
+++ b/spartan/terraform/gke-cluster/cluster/variables.tf
@@ -20,3 +20,10 @@ variable "service_account" {
 variable "node_version" {
   default = "1.30.5-gke.1713000"
 }
+
+variable "enable_workload_identity" {
+  description = "Enable Workload Identity on the cluster"
+  type        = bool
+  default     = false
+}
+

--- a/spartan/terraform/gke-cluster/main.tf
+++ b/spartan/terraform/gke-cluster/main.tf
@@ -20,11 +20,12 @@ provider "google" {
 module "gke_cluster_private" {
   source = "./cluster"
 
-  cluster_name    = "aztec-gke-private"
-  project         = var.project
-  region          = var.region
-  zone            = var.zone
-  service_account = google_service_account.gke_sa.email
+  cluster_name             = "aztec-gke-private"
+  project                  = var.project
+  region                   = var.region
+  zone                     = var.zone
+  service_account          = google_service_account.gke_sa.email
+  enable_workload_identity = true
 }
 
 module "gke_cluster_public" {


### PR DESCRIPTION
This PR enables workload identity for the infra node pools in the private cluster and deploys ESO only on infra nodes.