### PR TITLE
fix(logger): no arbitrary long logger module name

### DIFF
--- a/yarn-project/foundation/src/log/pino-logger.ts
+++ b/yarn-project/foundation/src/log/pino-logger.ts
@@ -21,6 +21,8 @@ export type LoggerBindings = {
   instanceId?: string;
 };
 
+const MAX_MODULE_NAME_LENGTH = 256;
+
 // Allow global hooks for providing default bindings.
 // Used by withLoggerBindings in pino-logger-server to propagate bindings via AsyncLocalStorage.
 type LogBindingsHandler = () => LoggerBindings | undefined;
@@ -48,7 +50,7 @@ function getBindingsFromHandlers(): LoggerBindings | undefined {
 }
 
 export function createLogger(module: string, bindings?: LoggerBindings): Logger {
-  module = module.replace(/^aztec:/, '');
+  module = module.slice(0, MAX_MODULE_NAME_LENGTH).replace(/^aztec:/, '');
 
   const resolvedBindings = { ...getBindingsFromHandlers(), ...bindings };
   const actor = resolvedBindings?.actor;

--- a/yarn-project/simulator/src/public/avm/avm_simulator.ts
+++ b/yarn-project/simulator/src/public/avm/avm_simulator.ts
@@ -63,7 +63,7 @@ export class AvmSimulator implements AvmSimulatorInterface {
   public static async build(context: AvmContext): Promise<AvmSimulator> {
     const simulator = new AvmSimulator(context);
     const fnName = await context.persistableState.getPublicFunctionDebugName(context.environment);
-    simulator.log = createLogger(`simulator:avm(f:${fnName})`);
+    simulator.log = createLogger(`simulator:avm(f:${fnName.slice(0, 128)})`);
 
     return simulator;
   }


### PR DESCRIPTION
Avoids potential issues with regex matching against module name, which happens when the logger is instantiated.

Note that we do not consider regex injection in the `LOG_LEVEL` definition to be an attack vector, since it's the operator who controls it.

Fixes A-769