### PR TITLE
fix(archiver): swallow error when rollup contract not yet finalized on L1

### DIFF
--- a/yarn-project/archiver/src/modules/l1_synchronizer.ts
+++ b/yarn-project/archiver/src/modules/l1_synchronizer.ts
@@ -251,8 +251,11 @@ export class ArchiverL1Synchronizer implements Traceable {
           finalizedL1BlockNumber,
         });
       }
-    } catch (err) {
-      this.log.warn(`Failed to update finalized checkpoint: ${err}`);
+    } catch (err: any) {
+      // The rollup contract may not exist at the finalized L1 block right after deployment.
+      if (!err?.message?.includes('returned no data')) {
+        this.log.warn(`Failed to update finalized checkpoint: ${err}`);
+      }
     }
   }
 


### PR DESCRIPTION
## Motivation

Right after deployment, the archiver's L1 sync queries `getProvenCheckpointNumber` at the finalized L1 block tag. But if the rollup contract didn't exist yet at that L1 block, the call returns no data and logs a noisy warning on every sync iteration.

## Approach

Swallow the "returned no data" error in `updateFinalizedCheckpoint` since it's an expected transient condition. Other errors still log a warning.

## Changes

- **archiver**: Silence the `ContractFunctionExecutionError` with "returned no data" in `updateFinalizedCheckpoint`, which occurs when the rollup contract is too new to exist at the finalized L1 block