### PR TITLE
fix: DeployMethod.getInstance recomputes on salt/deployer mismatch

### DIFF
--- a/yarn-project/aztec.js/src/contract/deploy_method.ts
+++ b/yarn-project/aztec.js/src/contract/deploy_method.ts
@@ -356,15 +356,25 @@ export class DeployMethod<TContract extends ContractBase = ContractBase> extends
    * @returns An instance object.
    */
   public async getInstance(options?: RequestDeployOptions): Promise<ContractInstanceWithAddress> {
-    if (!this.instance) {
-      this.instance = await getContractInstanceFromInstantiationParams(this.artifact, {
-        constructorArgs: this.args,
-        salt: options?.contractAddressSalt ?? Fr.random(),
-        publicKeys: this.publicKeys,
-        constructorArtifact: this.constructorArtifact,
-        deployer: options?.deployer ? options.deployer : AztecAddress.ZERO,
-      });
+    const requestedSalt = options?.contractAddressSalt;
+    const requestedDeployer = options?.deployer ?? AztecAddress.ZERO;
+
+    if (this.instance) {
+      // An explicit salt was requested but differs from the cached one — recompute.
+      const saltMismatch = requestedSalt !== undefined && !requestedSalt.equals(this.instance.salt);
+      const deployerMismatch = !requestedDeployer.equals(this.instance.deployer);
+      if (!saltMismatch && !deployerMismatch) {
+        return this.instance;
+      }
     }
+
+    this.instance = await getContractInstanceFromInstantiationParams(this.artifact, {
+      constructorArgs: this.args,
+      salt: requestedSalt ?? Fr.random(),
+      publicKeys: this.publicKeys,
+      constructorArtifact: this.constructorArtifact,
+      deployer: requestedDeployer,
+    });
     return this.instance;
   }
 

--- a/yarn-project/aztec.js/src/contract/deploy_method.ts
+++ b/yarn-project/aztec.js/src/contract/deploy_method.ts
@@ -357,24 +357,22 @@ export class DeployMethod<TContract extends ContractBase = ContractBase> extends
    */
   public async getInstance(options?: RequestDeployOptions): Promise<ContractInstanceWithAddress> {
     const requestedSalt = options?.contractAddressSalt;
-    const requestedDeployer = options?.deployer ?? AztecAddress.ZERO;
 
-    if (this.instance) {
-      // An explicit salt was requested but differs from the cached one — recompute.
-      const saltMismatch = requestedSalt !== undefined && !requestedSalt.equals(this.instance.salt);
-      const deployerMismatch = !requestedDeployer.equals(this.instance.deployer);
-      if (!saltMismatch && !deployerMismatch) {
-        return this.instance;
-      }
+    // If an explicit salt is provided and differs from the cached instance's salt, recompute.
+    // Without this check, a cached instance with a randomly-generated salt would be returned
+    // even when the caller supplies an explicit salt, silently deploying to the wrong address.
+    const saltMismatch =
+      requestedSalt !== undefined && this.instance !== undefined && !requestedSalt.equals(this.instance.salt);
+
+    if (!this.instance || saltMismatch) {
+      this.instance = await getContractInstanceFromInstantiationParams(this.artifact, {
+        constructorArgs: this.args,
+        salt: requestedSalt ?? Fr.random(),
+        publicKeys: this.publicKeys,
+        constructorArtifact: this.constructorArtifact,
+        deployer: options?.deployer ?? AztecAddress.ZERO,
+      });
     }
-
-    this.instance = await getContractInstanceFromInstantiationParams(this.artifact, {
-      constructorArgs: this.args,
-      salt: requestedSalt ?? Fr.random(),
-      publicKeys: this.publicKeys,
-      constructorArtifact: this.constructorArtifact,
-      deployer: requestedDeployer,
-    });
     return this.instance;
   }
 

--- a/yarn-project/aztec.js/src/contract/deploy_method.ts
+++ b/yarn-project/aztec.js/src/contract/deploy_method.ts
@@ -357,22 +357,24 @@ export class DeployMethod<TContract extends ContractBase = ContractBase> extends
    */
   public async getInstance(options?: RequestDeployOptions): Promise<ContractInstanceWithAddress> {
     const requestedSalt = options?.contractAddressSalt;
+    const requestedDeployer = options?.deployer ?? AztecAddress.ZERO;
 
-    // If an explicit salt is provided and differs from the cached instance's salt, recompute.
-    // Without this check, a cached instance with a randomly-generated salt would be returned
-    // even when the caller supplies an explicit salt, silently deploying to the wrong address.
-    const saltMismatch =
-      requestedSalt !== undefined && this.instance !== undefined && !requestedSalt.equals(this.instance.salt);
-
-    if (!this.instance || saltMismatch) {
-      this.instance = await getContractInstanceFromInstantiationParams(this.artifact, {
-        constructorArgs: this.args,
-        salt: requestedSalt ?? Fr.random(),
-        publicKeys: this.publicKeys,
-        constructorArtifact: this.constructorArtifact,
-        deployer: options?.deployer ?? AztecAddress.ZERO,
-      });
+    if (this.instance) {
+      // An explicit salt was requested but differs from the cached one — recompute.
+      const saltMismatch = requestedSalt !== undefined && !requestedSalt.equals(this.instance.salt);
+      const deployerMismatch = !requestedDeployer.equals(this.instance.deployer);
+      if (!saltMismatch && !deployerMismatch) {
+        return this.instance;
+      }
     }
+
+    this.instance = await getContractInstanceFromInstantiationParams(this.artifact, {
+      constructorArgs: this.args,
+      salt: requestedSalt ?? Fr.random(),
+      publicKeys: this.publicKeys,
+      constructorArtifact: this.constructorArtifact,
+      deployer: requestedDeployer,
+    });
     return this.instance;
   }
 


### PR DESCRIPTION
## Summary

- `DeployMethod.getInstance` cached the contract instance on the first call and returned it unconditionally on all subsequent calls
- If the first call used a random salt (e.g. via `simulate()` with no salt), a later `send({ contractAddressSalt: mySalt })` would silently deploy to the wrong address
- The fix recomputes the instance whenever an explicit salt or deployer is provided that doesn't match the cached one; if no explicit salt is given, the cached salt (or a freshly generated random one) is reused for consistency

Fixes [A-801](https://linear.app/aztec-labs/issue/A-801/audit-144-deploymethodgetinstance-caches-random-salt-ignores)

Made with [Cursor](https://cursor.com)