### PR TITLE
chore: (A-815) fix l1 tx utils fallback id logic

### DIFF
--- a/yarn-project/ethereum/src/l1_tx_utils/l1_tx_utils.ts
+++ b/yarn-project/ethereum/src/l1_tx_utils/l1_tx_utils.ts
@@ -281,7 +281,7 @@ export class L1TxUtils extends ReadOnlyL1TxUtils {
       // Create the new state for monitoring
       const l1TxState: L1TxState = {
         ...baseState,
-        id: (await this.store?.consumeNextStateId(account)) ?? Math.max(...this.txs.map(tx => tx.id), 0),
+        id: (await this.store?.consumeNextStateId(account)) ?? Math.max(...this.txs.map(tx => tx.id), -1) + 1,
         txHashes: [txHash],
         cancelTxHashes: [],
         status: TxUtilsState.IDLE,


### PR DESCRIPTION
This is purely a correctness fix, no behavioral changes as the id is only used for store operations and when there is no store, this fallback is never hit.

**Fallback logic previous:** 
If `txs.map` is empty then `this.txs.map(tx => tx.id)` resolves to nothing and `Math.max(0)` resolves to 0.
Next iteration, `this.txs.map(tx => tx.id)` resolves to 0 and `Math.max(0, 0)` resolves to 0 again. Collision!

**Fallback logic fixed:**
If `txs.map` is empty then `this.txs.map(tx => tx.id)` resolves to empty and `Math.max(-1) + 1` resolves to 0.
Next iteration, `this.txs.map(tx => tx.id)` resolves to 0 and `Math.max(0, -1) + 1` resolves to 1, a unique id. 