### PR TITLE
chore: bump yarn to enable package age gate

### DIFF
--- a/barretenberg/acir_tests/.yarnrc.yml
+++ b/barretenberg/acir_tests/.yarnrc.yml
@@ -1,1 +1,5 @@
 nodeLinker: node-modules
+
+npmMinimalAgeGate: 7d
+
+npmPreapprovedPackages: []

--- a/barretenberg/acir_tests/bbjs-test/.yarnrc.yml
+++ b/barretenberg/acir_tests/bbjs-test/.yarnrc.yml
@@ -1,1 +1,5 @@
 nodeLinker: node-modules
+
+npmMinimalAgeGate: 7d
+
+npmPreapprovedPackages: []

--- a/barretenberg/acir_tests/bbjs-test/package.json
+++ b/barretenberg/acir_tests/bbjs-test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bbjs-test",
-  "packageManager": "yarn@4.5.2",
+  "packageManager": "yarn@4.13.0",
   "main": "dest/index.js",
   "scripts": {
     "build": "yarn tsgo"

--- a/barretenberg/acir_tests/browser-test-app/.yarnrc.yml
+++ b/barretenberg/acir_tests/browser-test-app/.yarnrc.yml
@@ -1,1 +1,5 @@
 nodeLinker: node-modules
+
+npmMinimalAgeGate: 7d
+
+npmPreapprovedPackages: []

--- a/barretenberg/acir_tests/browser-test-app/package.json
+++ b/barretenberg/acir_tests/browser-test-app/package.json
@@ -22,5 +22,5 @@
     "webpack-cli": "^6.0.1",
     "webpack-dev-server": "^5.2.1"
   },
-  "packageManager": "yarn@4.5.2"
+  "packageManager": "yarn@4.13.0"
 }

--- a/barretenberg/acir_tests/headless-test/.yarnrc.yml
+++ b/barretenberg/acir_tests/headless-test/.yarnrc.yml
@@ -1,1 +1,5 @@
 nodeLinker: node-modules
+
+npmMinimalAgeGate: 7d
+
+npmPreapprovedPackages: []

--- a/barretenberg/acir_tests/headless-test/package.json
+++ b/barretenberg/acir_tests/headless-test/package.json
@@ -17,5 +17,5 @@
     "ts-node": "^10.9.2",
     "typescript": "^5.4.2"
   },
-  "packageManager": "yarn@4.5.2"
+  "packageManager": "yarn@4.13.0"
 }

--- a/barretenberg/acir_tests/package.json
+++ b/barretenberg/acir_tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aztec/acir-tests",
-  "packageManager": "yarn@4.5.2",
+  "packageManager": "yarn@4.13.0",
   "private": true,
   "workspaces": [
     "browser-test-app",

--- a/barretenberg/acir_tests/sol-test/.yarnrc.yml
+++ b/barretenberg/acir_tests/sol-test/.yarnrc.yml
@@ -1,1 +1,5 @@
 nodeLinker: node-modules
+
+npmMinimalAgeGate: 7d
+
+npmPreapprovedPackages: []

--- a/barretenberg/acir_tests/sol-test/package.json
+++ b/barretenberg/acir_tests/sol-test/package.json
@@ -11,5 +11,5 @@
     "ethers": "^6.8.1",
     "solc": "^0.8.27"
   },
-  "packageManager": "yarn@4.5.2"
+  "packageManager": "yarn@4.13.0"
 }

--- a/barretenberg/cpp/src/barretenberg/nodejs_module/.yarnrc.yml
+++ b/barretenberg/cpp/src/barretenberg/nodejs_module/.yarnrc.yml
@@ -1,1 +1,5 @@
 nodeLinker: node-modules
+
+npmMinimalAgeGate: 7d
+
+npmPreapprovedPackages: []

--- a/barretenberg/cpp/src/barretenberg/nodejs_module/package.json
+++ b/barretenberg/cpp/src/barretenberg/nodejs_module/package.json
@@ -2,7 +2,7 @@
   "name": "nodejs_module",
   "private": true,
   "version": "0.0.0",
-  "packageManager": "yarn@4.5.2",
+  "packageManager": "yarn@4.13.0",
   "dependencies": {
     "node-addon-api": "^8.0.0",
     "node-api-headers": "^1.1.0"

--- a/barretenberg/ts/.yarnrc.yml
+++ b/barretenberg/ts/.yarnrc.yml
@@ -8,5 +8,9 @@ logFilters:
 
 nodeLinker: node-modules
 
+npmMinimalAgeGate: 7d
+
+npmPreapprovedPackages: []
+
 changesetIgnorePatterns: ['.tsbuildinfo*', '.yarn']
 installStatePath: /dev/null

--- a/barretenberg/ts/package.json
+++ b/barretenberg/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aztec/bb.js",
-  "packageManager": "yarn@4.5.2",
+  "packageManager": "yarn@4.13.0",
   "version": "0.1.0",
   "homepage": "https://github.com/AztecProtocol/aztec-packages/tree/master/barretenberg/ts",
   "license": "MIT",

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -17,7 +17,7 @@ export expected_min_zig_version=0.15.1
 export expected_abs_rust_version=1.89.0
 export expected_abs_wasi_version=27.0
 export expected_abs_foundry_version=1.4.1
-export expected_abs_yarn_version=4.5.2
+export expected_abs_yarn_version=4.13.0
 
 function ensure {
   command -v $1 &>/dev/null

--- a/boxes/.yarnrc.yml
+++ b/boxes/.yarnrc.yml
@@ -1,1 +1,5 @@
 nodeLinker: node-modules
+
+npmMinimalAgeGate: 7d
+
+npmPreapprovedPackages: []

--- a/boxes/boxes/react/.yarnrc.yml
+++ b/boxes/boxes/react/.yarnrc.yml
@@ -1,1 +1,5 @@
 nodeLinker: node-modules
+
+npmMinimalAgeGate: 7d
+
+npmPreapprovedPackages: []

--- a/boxes/boxes/react/package.json
+++ b/boxes/boxes/react/package.json
@@ -83,5 +83,5 @@
     "!*.test.*"
   ],
   "types": "./dist/index.d.ts",
-  "packageManager": "yarn@4.5.2"
+  "packageManager": "yarn@4.13.0"
 }

--- a/boxes/package.json
+++ b/boxes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aztec/examples",
-  "packageManager": "yarn@4.5.2",
+  "packageManager": "yarn@4.13.0",
   "version": "0.5.0",
   "type": "module",
   "scripts": {

--- a/build-images/src/Dockerfile
+++ b/build-images/src/Dockerfile
@@ -133,7 +133,7 @@ COPY --from=foundry /opt/foundry /opt/foundry
 ENV PATH="/opt/foundry/bin:$PATH"
 
 # Install corepack and yarn.
-RUN npm install --global corepack && corepack enable && corepack install --global yarn@4.5.2
+RUN npm install --global corepack && corepack enable && corepack install --global yarn@4.13.0
 
 # Install solhint.
 RUN npm install --global solhint

--- a/docs/.yarnrc.yml
+++ b/docs/.yarnrc.yml
@@ -1,1 +1,5 @@
 nodeLinker: node-modules
+
+npmMinimalAgeGate: 7d
+
+npmPreapprovedPackages: []

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -10,7 +10,7 @@ You are working with the **Aztec Protocol Documentation** - a comprehensive docu
 
 ### Package Manager
 
-This project uses Yarn 4.5.2 as specified in the `packageManager` field of package.json. Make sure to use Yarn for all dependency management.
+This project uses Yarn 4.13.0 as specified in the `packageManager` field of package.json. Make sure to use Yarn for all dependency management.
 
 ### Essential Commands
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -99,5 +99,5 @@
     "axios": "^1.13.5",
     "fastify": "5.8.2"
   },
-  "packageManager": "yarn@4.5.2"
+  "packageManager": "yarn@4.13.0"
 }

--- a/l1-contracts/.yarnrc.yml
+++ b/l1-contracts/.yarnrc.yml
@@ -1,1 +1,5 @@
 nodeLinker: node-modules
+
+npmMinimalAgeGate: 7d
+
+npmPreapprovedPackages: []

--- a/l1-contracts/package.json
+++ b/l1-contracts/package.json
@@ -16,5 +16,5 @@
     "slither": "forge clean && forge build --build-info --skip '*/test/**' --force && slither . --checklist --ignore-compile --show-ignored-findings --config-file ./slither.config.json | tee slither_output.md",
     "slither-has-diff": "./slither_has_diff.sh"
   },
-  "packageManager": "yarn@4.5.2"
+  "packageManager": "yarn@4.13.0"
 }

--- a/noir-projects/noir-protocol-circuits/.yarnrc.yml
+++ b/noir-projects/noir-protocol-circuits/.yarnrc.yml
@@ -1,1 +1,5 @@
 nodeLinker: node-modules
+
+npmMinimalAgeGate: 7d
+
+npmPreapprovedPackages: []

--- a/noir-projects/noir-protocol-circuits/package.json
+++ b/noir-projects/noir-protocol-circuits/package.json
@@ -8,5 +8,5 @@
   "scripts": {
     "generate_variants": "node ./scripts/generate_variants.js"
   },
-  "packageManager": "yarn@4.5.2"
+  "packageManager": "yarn@4.13.0"
 }

--- a/playground/.yarnrc.yml
+++ b/playground/.yarnrc.yml
@@ -1,1 +1,5 @@
 nodeLinker: node-modules
+
+npmMinimalAgeGate: 7d
+
+npmPreapprovedPackages: []

--- a/playground/bootstrap.sh
+++ b/playground/bootstrap.sh
@@ -20,7 +20,7 @@ function test {
 
 function test_cmds {
   for browser in chromium firefox; do
-    echo "$hash playground/scripts/run_test.sh $browser"
+    echo "$hash:TIMEOUT=900s playground/scripts/run_test.sh $browser"
   done
 }
 

--- a/playground/docker-compose.yml
+++ b/playground/docker-compose.yml
@@ -52,6 +52,7 @@ services:
       L1_CHAIN_ID: 31337
       FORCE_COLOR: ${FORCE_COLOR:-1}
       BROWSER: ${BROWSER:-chromium}
+      COREPACK_ENABLE_DOWNLOAD_PROMPT: '0'
     depends_on:
       aztec:
         condition: service_healthy

--- a/playground/package.json
+++ b/playground/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aztec/playground",
-  "packageManager": "yarn@4.5.2",
+  "packageManager": "yarn@4.13.0",
   "private": true,
   "version": "0.0.0",
   "type": "module",

--- a/scripts/setup-container.sh
+++ b/scripts/setup-container.sh
@@ -218,7 +218,7 @@ log_info "Installing npm global packages (corepack, yarn, solhint)..."
 
 npm install --global corepack
 corepack enable
-corepack install --global yarn@4.5.2
+corepack install --global yarn@4.13.0
 npm install --global solhint
 
 # =============================================================================

--- a/spartan/metrics/irm-monitor/.yarnrc.yml
+++ b/spartan/metrics/irm-monitor/.yarnrc.yml
@@ -1,1 +1,5 @@
 nodeLinker: node-modules
+
+npmMinimalAgeGate: 7d
+
+npmPreapprovedPackages: []

--- a/spartan/metrics/irm-monitor/package.json
+++ b/spartan/metrics/irm-monitor/package.json
@@ -18,5 +18,5 @@
     "@typescript/native-preview": "7.0.0-dev.20251126.1",
     "typescript": "^5.4.5"
   },
-  "packageManager": "yarn@4.5.2+sha512.570504f67349ef26d2d86a768dc5ec976ead977aa086b0bb4237e97d5db7ae5c620f9f0e0edf3ea5047205063faff102bf2a2d778664a94eaaa1085ad483fe2e"
+  "packageManager": "yarn@4.13.0"
 }

--- a/yarn-project/.yarnrc.yml
+++ b/yarn-project/.yarnrc.yml
@@ -8,6 +8,10 @@ logFilters:
 
 nodeLinker: node-modules
 
+npmMinimalAgeGate: 7d
+
+npmPreapprovedPackages: []
+
 # Do not allow 'yarn install' on CI to format package.json files,
 # otherwise it will change their hash and bust the cache
 immutablePatterns: ['package.json', '*/package.json']

--- a/yarn-project/docs/package.json
+++ b/yarn-project/docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aztec/docs",
   "version": "0.0.0",
-  "packageManager": "yarn@4.5.2",
+  "packageManager": "yarn@4.13.0",
   "scripts": {
     "prepare": "",
     "build": "vite build",

--- a/yarn-project/package.json
+++ b/yarn-project/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aztec/aztec3-packages",
-  "packageManager": "yarn@4.5.2",
+  "packageManager": "yarn@4.13.0",
   "private": true,
   "scripts": {
     "ci": "../ci.sh",


### PR DESCRIPTION
Bump yarn in order to use the npm age gate feature (min yarn 4.10)