### PR TITLE
fix(docs): audit and fix aztec-js how-to guides for v4.2.0

### DIFF
--- a/docs/developer_versioned_docs/version-v4.2.0-aztecnr-rc.2/docs/aztec-js/how_to_create_account.md
+++ b/docs/developer_versioned_docs/version-v4.2.0-aztecnr-rc.2/docs/aztec-js/how_to_create_account.md
@@ -83,25 +83,26 @@ See the [guide on fees](./how_to_pay_fees.md#sponsored-fee-payment-contracts) fo
 
 ### Using Fee Juice
 
-If your account already has Fee Juice (for example, [bridged from L1](./how_to_pay_fees.md#bridge-fee-juice-from-l1)):
+If your account has Fee Juice from a [bridge from L1](./how_to_pay_fees.md#bridge-fee-juice-from-l1), you can claim it and deploy in one step using `FeeJuicePaymentMethodWithClaim`:
 
-```typescript title="deploy_account_fee_juice" showLineNumbers 
-// Deploy the account using the bridged Fee Juice
-const deployMethodFeeJuice = await feeJuiceAccount.getDeployMethod();
-await deployMethodFeeJuice.send({
+```typescript title="bridge_fee_juice_claim" showLineNumbers
+import { FeeJuicePaymentMethodWithClaim } from "@aztec/aztec.js/fee";
+
+// claim is from the bridgeTokensPublic step above
+// Create a payment method that claims the bridged Fee Juice and uses it to pay
+const bridgePaymentMethod = new FeeJuicePaymentMethodWithClaim(feeJuiceAccount.address, claim);
+
+// Use it to pay for any transaction — here we deploy the account in one step
+const deployMethodBridged = await feeJuiceAccount.getDeployMethod();
+await deployMethodBridged.send({
   from: NO_FROM,
-  fee: {
-    paymentMethod: new FeeJuicePaymentMethodWithClaim(
-      feeJuiceAccount.address,
-      claim,
-    ),
-  },
+  fee: { paymentMethod: bridgePaymentMethod },
 });
 ```
-> <sup><sub><a href="https://github.com/AztecProtocol/aztec-packages/blob/v4.2.0-aztecnr-rc.2/docs/examples/ts/aztecjs_connection/index.ts#L143-L155" target="_blank" rel="noopener noreferrer">Source code: docs/examples/ts/aztecjs_connection/index.ts#L143-L155</a></sub></sup>
 
+If the account already has Fee Juice on L2 (for example, from a faucet or a previously claimed bridge), no special payment method is needed — just call `send({ from: NO_FROM })` and Fee Juice is used automatically.
 
-The `from: NO_FROM` signals that this transaction should be executed without account contract mediation. The wallet will directly execute it via a default entrypoint with no authorization
+The `from: NO_FROM` signals that this transaction should be executed without account contract mediation. The wallet will directly execute it via a default entrypoint with no authorization.
 
 ## Verify deployment
 

--- a/docs/developer_versioned_docs/version-v4.2.0-aztecnr-rc.2/docs/aztec-js/how_to_pay_fees.md
+++ b/docs/developer_versioned_docs/version-v4.2.0-aztecnr-rc.2/docs/aztec-js/how_to_pay_fees.md
@@ -41,10 +41,10 @@ When using `EmbeddedWallet`, gas is estimated automatically on every `send()` ca
 Before sending a transaction, you can estimate the mana it will consume by simulating with `estimateGas: true`:
 
 ```typescript
-const { estimatedGas } = await contract.methods
-  .myFunction(arg1, arg2)
+const { estimatedGas } = await token.methods
+  .transfer_in_public(aliceAddress, bobAddress, 1n, 0n)
   .simulate({
-    from: sender.address,
+    from: aliceAddress,
     fee: { estimateGas: true, estimatedGasPadding: 0.1 },
   });
 ```
@@ -61,9 +61,7 @@ The `estimatedGas` object contains:
 To calculate the expected fee from estimated gas, use the `computeFee` method with current network fees:
 
 ```typescript
-// import { createAztecNodeClient } from '@aztec/aztec.js/node';
-// const aztecNode = createAztecNodeClient('http://localhost:8080');
-const currentFees = await aztecNode.getCurrentMinFees();
+const currentFees = await node.getCurrentMinFees();
 const estimatedFee = estimatedGas.gasLimits.computeFee(currentFees).toBigInt();
 console.log("Estimated fee:", estimatedFee);
 ```
@@ -77,23 +75,18 @@ The `estimatedGasPadding` parameter adds a safety margin to the estimate. A valu
 After a transaction is mined, you can retrieve the fee paid from the receipt:
 
 ```typescript
-const receipt = await contract.methods
-  .myFunction(arg1, arg2)
-  .send({ from: sender.address })
-  .wait();
-
-console.log("Transaction fee:", receipt.transactionFee);
+const { receipt: feeReceipt } = await token.methods
+  .mint_to_public(aliceAddress, 1n)
+  .send({ from: aliceAddress });
+console.log("Transaction fee:", feeReceipt.transactionFee);
 ```
 
 The `transactionFee` field is a `bigint` representing the total fee paid in the fee token (Fee Juice). You can also check execution status:
 
 ```typescript
-if (receipt.hasExecutionSucceeded()) {
-  console.log("Transaction succeeded in block:", receipt.blockNumber);
-  console.log("Fee paid:", receipt.transactionFee);
-} else {
-  console.log("Transaction failed:", receipt.error);
-}
+console.log("Succeeded:", feeReceipt.hasExecutionSucceeded());
+console.log("Block:", feeReceipt.blockNumber);
+console.log("Fee paid:", feeReceipt.transactionFee);
 ```
 
 ## Pay with Fee Juice
@@ -104,12 +97,13 @@ If your account has Fee Juice (for example, from a faucet), is [deployed](./how_
 
 ```typescript
 // contract is a deployed contract instance; aliceAddress is from the connection guide
-const receipt = await contract.methods.myFunction(param1, param2).send({
-  from: aliceAddress,
-  // no fee payment method needed
-});
-
-console.log("Transaction fee:", receipt.transactionFee);
+const { receipt: feeJuiceReceipt } = await token.methods
+  .mint_to_public(aliceAddress, 1n)
+  .send({
+    from: aliceAddress,
+    // no fee payment method needed — Fee Juice is used automatically
+  });
+console.log("Transaction fee:", feeJuiceReceipt.transactionFee);
 ```
 
 ## Use Fee Payment Contracts
@@ -219,32 +213,31 @@ Fee Juice is non-transferable on L2, but you can bridge it from L1, claim it on 
 
 `aztec.js` provides helpers to simplify the process:
 
-```typescript
-// essentially returns an extended wallet from Viem
-import { createExtendedL1Client } from "@aztec/ethereum";
-const walletClient = createExtendedL1Client(
-  ["https://your-ethereum-host"], // ex. http://localhost:8545 on the local network (yes it runs Anvil under the hood)
-  privateKey, // the private key for some account, needs funds for gas!
-);
-
-// a helper to interact with the L1 fee juice portal
+```typescript title="bridge_fee_juice_setup" showLineNumbers
+import { createExtendedL1Client } from "@aztec/ethereum/client";
 import { L1FeeJuicePortalManager } from "@aztec/aztec.js/ethereum";
-const portalManager = await L1FeeJuicePortalManager.new(
-  node, // your Aztec node, ex. https://aztec-testnet-fullnode.zkv.xyz, or http://localhost:8080 for local network
-  walletClient,
-  logger, // a logger, ex. import { createLogger } from "@aztec/aztec.js"
-);
+import { createLogger } from "@aztec/aztec.js/log";
+
+// Create an L1 client (accepts a mnemonic or 0x-prefixed private key)
+const l1RpcUrl = process.env.ETHEREUM_HOST ?? "http://localhost:8545";
+const l1Mnemonic =
+  "test test test test test test test test test test test junk";
+const l1Client = createExtendedL1Client([l1RpcUrl], l1Mnemonic);
+
+// Create a portal manager to interact with the L1 fee juice portal
+const logger = createLogger("docs:fee-juice-bridge");
+const portalManager = await L1FeeJuicePortalManager.new(node, l1Client, logger);
 ```
 
 Under the hood, `L1FeeJuicePortalManager` gets the L1 addresses from the node `node_getNodeInfo` endpoint. It then exposes an easy method `bridgeTokensPublic` which mints fee juice on L1 and sends it to an L2 address via the L1 portal:
 
-```typescript
+```typescript title="bridge_fee_juice_execute" showLineNumbers
 // portalManager is from the L1FeeJuicePortalManager setup above
-// aliceAddress is an Aztec address from the connection guide
+// feeJuiceAccount.address is an Aztec address from createSchnorrAccount
 const claim = await portalManager.bridgeTokensPublic(
-  aliceAddress, // the L2 address
+  feeJuiceAccount.address, // the L2 address
   1000000000000000000000n, // the amount to send to the L1 portal
-  true, // whether to mint or not (set to false if your walletClient account already has fee juice!)
+  true, // whether to mint or not (set to false if your L1 account already has fee juice!)
 );
 
 console.log("Claim secret:", claim.claimSecret);
@@ -253,16 +246,19 @@ console.log("Claim amount:", claim.claimAmount);
 
 After this transaction is minted on L1 and a few blocks pass, you can claim the message on L2 and use it directly to pay for fees:
 
-```typescript
+```typescript title="bridge_fee_juice_claim" showLineNumbers
 import { FeeJuicePaymentMethodWithClaim } from "@aztec/aztec.js/fee";
 
-// aliceAddress and claim are from the bridgeTokensPublic step above
-// contract is a deployed contract instance; gasSettings is from the gas settings section
-// Use the claim from bridgeTokensPublic to pay for a transaction
-const paymentMethod = new FeeJuicePaymentMethodWithClaim(aliceAddress, claim);
-const receipt = await contract.methods
-  .myFunction()
-  .send({ from: aliceAddress, fee: { gasSettings, paymentMethod } });
+// claim is from the bridgeTokensPublic step above
+// Create a payment method that claims the bridged Fee Juice and uses it to pay
+const bridgePaymentMethod = new FeeJuicePaymentMethodWithClaim(feeJuiceAccount.address, claim);
+
+// Use it to pay for any transaction — here we deploy the account in one step
+const deployMethodBridged = await feeJuiceAccount.getDeployMethod();
+await deployMethodBridged.send({
+  from: NO_FROM,
+  fee: { paymentMethod: bridgePaymentMethod },
+});
 ```
 
 ## Configure gas settings
@@ -282,27 +278,25 @@ The fee limit is calculated as `gasLimits × maxFeesPerGas` for each dimension.
 
 Set custom gas limits by importing from `stdlib`:
 
-```typescript
-import { GasSettings } from "@aztec/stdlib/gas";
-
-// contract is a deployed contract instance
-// alice is from the connection guide
-// paymentMethod is from one of the payment method sections above
+```typescript title="custom_gas_settings" showLineNumbers
+// Query current network fees to set realistic limits
+const networkFees = await node.getCurrentMinFees();
 const gasSettings = GasSettings.from({
-  gasLimits: { daGas: 100000, l2Gas: 100000 },
-  teardownGasLimits: { daGas: 10000, l2Gas: 10000 },
-  maxFeesPerGas: { daGas: 10, l2Gas: 10 },
-  maxPriorityFeesPerGas: { daGas: 1, l2Gas: 1 },
-});
-
-const receipt = await contract.methods.myFunction().send({
-  from: aliceAddress,
-  fee: {
-    paymentMethod,
-    gasSettings,
-  },
+  gasLimits: { daGas: 100_000, l2Gas: 2_000_000 },
+  teardownGasLimits: { daGas: 100_000, l2Gas: 2_000_000 },
+  maxFeesPerGas: { feePerDaGas: networkFees.feePerDaGas * 2n, feePerL2Gas: networkFees.feePerL2Gas * 2n },
+  maxPriorityFeesPerGas: { feePerDaGas: 0n, feePerL2Gas: 0n },
 });
 ```
+
+```typescript
+const { receipt: gsReceipt } = await token.methods.mint_to_public(aliceAddress, 1n).send({
+  from: aliceAddress,
+  fee: { gasSettings },
+});
+```
+
+Note that `gasLimits` and `teardownGasLimits` use `daGas`/`l2Gas` field names, while `maxFeesPerGas` and `maxPriorityFeesPerGas` use `feePerDaGas`/`feePerL2Gas`.
 
 ### Use automatic gas estimation
 
@@ -310,16 +304,18 @@ const receipt = await contract.methods.myFunction().send({
 When using `EmbeddedWallet`, gas estimation happens automatically on every `send()` — you don't need to pass `estimateGas`. This option is useful for custom wallet implementations or when you want to estimate gas during a `simulate()` call.
 :::
 
-```typescript
-// contract, aliceAddress, and paymentMethod are from the examples above
-const receipt = await contract.methods.myFunction().send({
-  from: aliceAddress,
-  fee: {
-    paymentMethod,
-    estimateGas: true,
-    estimatedGasPadding: 0.2, // 20% padding
-  },
-});
+```typescript title="auto_gas_estimation" showLineNumbers
+// Estimate gas for a transaction before sending
+const { estimatedGas: autoEstimate } = await token.methods
+  .mint_to_public(aliceAddress, 1n)
+  .simulate({
+    from: aliceAddress,
+    fee: {
+      estimateGas: true,
+      estimatedGasPadding: 0.2, // 20% padding
+    },
+  });
+console.log("Auto-estimated L2 gas:", autoEstimate.gasLimits.l2Gas);
 ```
 
 :::tip

--- a/docs/developer_versioned_docs/version-v4.2.0-aztecnr-rc.2/docs/aztec-js/how_to_read_data.md
+++ b/docs/developer_versioned_docs/version-v4.2.0-aztecnr-rc.2/docs/aztec-js/how_to_read_data.md
@@ -28,19 +28,7 @@ console.log(`Alice's token balance: ${balance}`);
 > <sup><sub><a href="https://github.com/AztecProtocol/aztec-packages/blob/v4.2.0-aztecnr-rc.2/docs/examples/ts/aztecjs_connection/index.ts#L135-L141" target="_blank" rel="noopener noreferrer">Source code: docs/examples/ts/aztecjs_connection/index.ts#L135-L141</a></sub></sup>
 
 
-The `from` option specifies which address context to use for the simulation. This is required for all simulations, though it only affects private function execution (public functions ignore this value).
-
-### Basic simulation
-
-```typescript title="simulate_function" showLineNumbers 
-const { result: balance } = await token.methods
-  .balance_of_public(aliceAddress)
-  .simulate({ from: aliceAddress });
-
-console.log(`Alice's token balance: ${balance}`);
-```
-> <sup><sub><a href="https://github.com/AztecProtocol/aztec-packages/blob/v4.2.0-aztecnr-rc.2/docs/examples/ts/aztecjs_connection/index.ts#L135-L141" target="_blank" rel="noopener noreferrer">Source code: docs/examples/ts/aztecjs_connection/index.ts#L135-L141</a></sub></sup>
-
+The `from` option specifies which account context to use for the simulation. This is required for all simulations. For private functions, it determines which account's private state is accessed. For public functions, it sets the `msg_sender` context.
 
 ### Handling return values
 
@@ -48,7 +36,7 @@ For functions returning multiple values, destructure the result:
 
 ```typescript
 // contract and callerAddress are from the example above
-const [value1, value2] = await contract.methods
+const { result: [value1, value2] } = await contract.methods
   .get_multiple_values()
   .simulate({ from: callerAddress });
 ```
@@ -57,37 +45,26 @@ const [value1, value2] = await contract.methods
 
 Set `includeMetadata: true` to get additional information about the simulation:
 
-```typescript
-// contract and callerAddress are from the examples above
-const result = await contract.methods
-  .balance_of_public(address)
-  .simulate({ from: callerAddress, includeMetadata: true });
-
-// Result includes:
-// - result: the function return value
-// - stats: execution statistics (timing, circuit sizes)
-// - offchainEffects: any offchain effects emitted
-// - estimatedGas: gas limit estimates (gasLimits and teardownGasLimits)
-console.log("Balance:", result.result);
-console.log("L2 gas limit:", result.estimatedGas.gasLimits.l2Gas);
-console.log("DA gas limit:", result.estimatedGas.gasLimits.daGas);
+```typescript title="simulate_with_metadata" showLineNumbers
+const metaResult = await token.methods
+  .balance_of_public(aliceAddress)
+  .simulate({ from: aliceAddress, includeMetadata: true });
+console.log("Balance:", metaResult.result);
+console.log("L2 gas limit:", metaResult.estimatedGas.gasLimits.l2Gas);
+console.log("DA gas limit:", metaResult.estimatedGas.gasLimits.daGas);
 ```
+
+The result includes `result` (the function return value), `stats` (execution statistics), `offchainEffects`, and `estimatedGas` (with `gasLimits` and `teardownGasLimits`).
 
 ### Private function considerations
 
 When simulating private functions, the caller must have access to any private state being read. The PXE only has visibility into notes belonging to registered accounts.
 
 ```typescript
-// contract and callerAddress are from the examples above
-// This works if callerAddress owns the notes
-const balance = await contract.methods
-  .balance_of_private(callerAddress)
-  .simulate({ from: callerAddress });
-
-// This fails if callerAddress doesn't have access to otherAddress's notes
-const otherBalance = await contract.methods
-  .balance_of_private(otherAddress)
-  .simulate({ from: callerAddress }); // Error: cannot access private state
+// This works if aliceAddress owns the notes
+const { result: privateBalance } = await token.methods
+  .balance_of_private(aliceAddress)
+  .simulate({ from: aliceAddress });
 ```
 
 :::warning
@@ -111,19 +88,22 @@ Contracts emit data in two forms you can read:
 
 Use `aztecNode.getPublicLogs()` to retrieve raw log data:
 
+```typescript title="read_public_logs" showLineNumbers
+const publicLogs = await node.getPublicLogs({ fromBlock: 1, toBlock: await node.getBlockNumber() + 1 });
+if (publicLogs.logs.length > 0) {
+  const rawFields = publicLogs.logs[0].log.getEmittedFields(); // Fr[]
+  console.log("Raw log fields:", rawFields.length);
+}
+```
+
+You can also filter by transaction hash or block range:
+
 ```typescript
-// aztecNode is from createAztecNodeClient() in the connection guide
-// receipt is from a transaction's send() call
 // Get logs for a specific transaction
-const logs = await aztecNode.getPublicLogs({ txHash: receipt.txHash });
-const rawFields = logs.logs[0].log.getEmittedFields(); // Fr[]
+const txLogs = await node.getPublicLogs({ txHash: gsReceipt.txHash });
 
 // Get logs for a block range
-const logFilter = {
-  fromBlock: startBlock,
-  toBlock: endBlock,
-};
-const publicLogs = (await aztecNode.getPublicLogs(logFilter)).logs;
+const rangeLogs = await node.getPublicLogs({ fromBlock: 1, toBlock: await node.getBlockNumber() + 1 });
 ```
 
 ## Reading events
@@ -177,7 +157,7 @@ Private events are stored in the PXE with privacy scoping. Use `wallet.getPrivat
 
 ```typescript
 import type { PrivateEventFilter } from "@aztec/aztec.js/wallet";
-import { BlockNumber } from "@aztec/foundation/branded-types";
+import { BlockNumber } from "@aztec/aztec.js/fields";
 ```
 
 The `BlockNumber` type is a branded type that wraps raw numbers for type safety. Use it when setting `fromBlock` and `toBlock` in filters.

--- a/docs/developer_versioned_docs/version-v4.2.0-aztecnr-rc.2/docs/aztec-js/how_to_send_transaction.md
+++ b/docs/developer_versioned_docs/version-v4.2.0-aztecnr-rc.2/docs/aztec-js/how_to_send_transaction.md
@@ -24,22 +24,22 @@ import { General } from '@site/src/components/Snippets/general_snippets';
 After connecting to a contract:
 
 ```typescript
-import { Contract } from "@aztec/aztec.js";
+import { Contract } from "@aztec/aztec.js/contracts";
+import { TokenContract } from "@aztec/noir-contracts.js/Token";
 
-// wallet is from the connection guide; contractAddress and artifact are from your deployed contract
-const contract = await Contract.at(contractAddress, artifact, wallet);
+// wallet is from the connection guide; token is the contract deployed in the deploy guide
+const contract = await Contract.at(token.address, TokenContract.artifact, wallet);
 ```
 
 Call a function and wait for it to be mined:
 
 ```typescript
-// contract is from the step above; alice is from the connection guide
-const receipt = await contract.methods
-  .transfer(bobAddress, amount)
+// contract is from the step above; aliceAddress is from the connection guide
+const { receipt: sendReceipt } = await contract.methods
+  .transfer_in_public(aliceAddress, bobAddress, 100n, 0n)
   .send({ from: aliceAddress });
-
-console.log(`Transaction mined in block ${receipt.blockNumber}`);
-console.log(`Transaction fee: ${receipt.transactionFee}`);
+console.log(`Transaction mined in block ${sendReceipt.blockNumber}`);
+console.log(`Transaction fee: ${sendReceipt.transactionFee}`);
 ```
 
 The `from` field specifies which account sends the transaction. If that account has Fee Juice, it pays for the transaction automatically. For other fee payment options, see [paying fees](./how_to_pay_fees.md).
@@ -123,7 +123,7 @@ console.log(`Transaction fee: ${txReceipt.transactionFee}`);
 
 The receipt includes:
 
-- `status` - Transaction status (`success`, `reverted`, `dropped`, or `pending`)
+- `status` - Transaction status (`pending`, `proposed`, `checkpointed`, `proven`, `finalized`, or `dropped`)
 - `blockNumber` - Block where the transaction was included
 - `transactionFee` - Fee paid for the transaction
 - `error` - Error message if the transaction reverted

--- a/docs/developer_versioned_docs/version-v4.2.0-aztecnr-rc.2/docs/aztec-js/how_to_test.md
+++ b/docs/developer_versioned_docs/version-v4.2.0-aztecnr-rc.2/docs/aztec-js/how_to_test.md
@@ -55,7 +55,7 @@ Deploy contracts using the generated contract class:
 import { TokenContract } from "@aztec/noir-contracts.js/Token";
 
 // wallet is from the setup section; alice is from registerInitialLocalNetworkAccountsInWallet
-const contract = await TokenContract.deploy(
+const { contract: testToken } = await TokenContract.deploy(
   wallet,
   alice, // admin
   "TestToken",
@@ -217,19 +217,27 @@ runTests().catch(console.error);
 
 Test that invalid operations revert as expected:
 
-```typescript
-// token, alice, and bob are from the test setup in beforeAll
-it("reverts when transferring more than balance", async () => {
-  const balance = await token.methods
-    .balance_of_public(alice)
-    .simulate({ from: alice });
+```typescript title="test_revert_case" showLineNumbers
+// token, aliceAddress, and bobAddress are from the test setup
+async function testRevertExample() {
+  const { result: balance } = await token.methods
+    .balance_of_public(aliceAddress)
+    .simulate({ from: aliceAddress });
 
-  await expect(
-    token.methods
-      .transfer_in_public(bob, balance + 1n)
-      .simulate({ from: alice }),
-  ).rejects.toThrow();
-});
+  let reverted = false;
+  try {
+    await token.methods
+      .transfer_in_public(aliceAddress, bobAddress, balance + 1n, 0n)
+      .simulate({ from: aliceAddress });
+  } catch (error) {
+    reverted = true;
+  }
+
+  if (!reverted) {
+    throw new Error("Expected simulation to revert for over-transfer");
+  }
+  console.log("✓ Revert on over-transfer test passed");
+}
 ```
 
 Use `.simulate()` to test reverts without spending gas. The simulation will throw if the transaction would fail onchain.

--- a/docs/docs-developers/docs/aztec-js/how_to_create_account.md
+++ b/docs/docs-developers/docs/aztec-js/how_to_create_account.md
@@ -46,11 +46,13 @@ See the [guide on fees](./how_to_pay_fees.md#sponsored-fee-payment-contracts) fo
 
 ### Using Fee Juice
 
-If your account already has Fee Juice (for example, [bridged from L1](./how_to_pay_fees.md#bridge-fee-juice-from-l1)):
+If your account has Fee Juice from a [bridge from L1](./how_to_pay_fees.md#bridge-fee-juice-from-l1), you can claim it and deploy in one step using `FeeJuicePaymentMethodWithClaim`:
 
-#include_code deploy_account_fee_juice /docs/examples/ts/aztecjs_connection/index.ts typescript
+#include_code bridge_fee_juice_claim /docs/examples/ts/aztecjs_connection/index.ts typescript
 
-The `from: NO_FROM` signals that this transaction should be executed without account contract mediation. The wallet will directly execute it via a default entrypoint with no authorization
+If the account already has Fee Juice on L2 (for example, from a faucet or a previously claimed bridge), no special payment method is needed — just call `send({ from: NO_FROM })` and Fee Juice is used automatically.
+
+The `from: NO_FROM` signals that this transaction should be executed without account contract mediation. The wallet will directly execute it via a default entrypoint with no authorization.
 
 ## Verify deployment
 

--- a/docs/docs-developers/docs/aztec-js/how_to_pay_fees.md
+++ b/docs/docs-developers/docs/aztec-js/how_to_pay_fees.md
@@ -42,14 +42,7 @@ When using `EmbeddedWallet`, gas is estimated automatically on every `send()` ca
 
 Before sending a transaction, you can estimate the mana it will consume by simulating with `estimateGas: true`:
 
-```typescript
-const { estimatedGas } = await contract.methods
-  .myFunction(arg1, arg2)
-  .simulate({
-    from: sender.address,
-    fee: { estimateGas: true, estimatedGasPadding: 0.1 },
-  });
-```
+#include_code estimate_mana /docs/examples/ts/aztecjs_advanced/index.ts typescript
 
 The `estimatedGas` object contains:
 
@@ -62,13 +55,7 @@ The `estimatedGas` object contains:
 
 To calculate the expected fee from estimated gas, use the `computeFee` method with current network fees:
 
-```typescript
-// import { createAztecNodeClient } from '@aztec/aztec.js/node';
-// const aztecNode = createAztecNodeClient('http://localhost:8080');
-const currentFees = await aztecNode.getCurrentMinFees();
-const estimatedFee = estimatedGas.gasLimits.computeFee(currentFees).toBigInt();
-console.log("Estimated fee:", estimatedFee);
-```
+#include_code compute_fee_from_estimate /docs/examples/ts/aztecjs_advanced/index.ts typescript
 
 :::tip
 The `estimatedGasPadding` parameter adds a safety margin to the estimate. A value of `0.1` adds 10% padding. Use higher padding for transactions with variable gas costs.
@@ -78,25 +65,11 @@ The `estimatedGasPadding` parameter adds a safety margin to the estimate. A valu
 
 After a transaction is mined, you can retrieve the fee paid from the receipt:
 
-```typescript
-const receipt = await contract.methods
-  .myFunction(arg1, arg2)
-  .send({ from: sender.address })
-  .wait();
-
-console.log("Transaction fee:", receipt.transactionFee);
-```
+#include_code get_fee_from_receipt /docs/examples/ts/aztecjs_advanced/index.ts typescript
 
 The `transactionFee` field is a `bigint` representing the total fee paid in the fee token (Fee Juice). You can also check execution status:
 
-```typescript
-if (receipt.hasExecutionSucceeded()) {
-  console.log("Transaction succeeded in block:", receipt.blockNumber);
-  console.log("Fee paid:", receipt.transactionFee);
-} else {
-  console.log("Transaction failed:", receipt.error);
-}
-```
+#include_code check_receipt_status /docs/examples/ts/aztecjs_advanced/index.ts typescript
 
 ## Pay with Fee Juice
 
@@ -104,15 +77,7 @@ Fee Juice is the native fee token on Aztec.
 
 If your account has Fee Juice (for example, from a faucet), is [deployed](./how_to_create_account.md), and is registered in your wallet, it will be used automatically to pay for the fee of the transaction:
 
-```typescript
-// contract is a deployed contract instance; aliceAddress is from the connection guide
-const receipt = await contract.methods.myFunction(param1, param2).send({
-  from: aliceAddress,
-  // no fee payment method needed
-});
-
-console.log("Transaction fee:", receipt.transactionFee);
-```
+#include_code pay_with_fee_juice /docs/examples/ts/aztecjs_advanced/index.ts typescript
 
 ## Use Fee Payment Contracts
 
@@ -151,51 +116,15 @@ Fee Juice is non-transferable on L2, but you can bridge it from L1, claim it on 
 
 `aztec.js` provides helpers to simplify the process:
 
-```typescript
-// essentially returns an extended wallet from Viem
-import { createExtendedL1Client } from "@aztec/ethereum";
-const walletClient = createExtendedL1Client(
-  ["https://your-ethereum-host"], // ex. http://localhost:8545 on the local network (yes it runs Anvil under the hood)
-  privateKey, // the private key for some account, needs funds for gas!
-);
-
-// a helper to interact with the L1 fee juice portal
-import { L1FeeJuicePortalManager } from "@aztec/aztec.js/ethereum";
-const portalManager = await L1FeeJuicePortalManager.new(
-  node, // your Aztec node, ex. https://aztec-testnet-fullnode.zkv.xyz, or http://localhost:8080 for local network
-  walletClient,
-  logger, // a logger, ex. import { createLogger } from "@aztec/aztec.js"
-);
-```
+#include_code bridge_fee_juice_setup /docs/examples/ts/aztecjs_connection/index.ts typescript
 
 Under the hood, `L1FeeJuicePortalManager` gets the L1 addresses from the node `node_getNodeInfo` endpoint. It then exposes an easy method `bridgeTokensPublic` which mints fee juice on L1 and sends it to an L2 address via the L1 portal:
 
-```typescript
-// portalManager is from the L1FeeJuicePortalManager setup above
-// aliceAddress is an Aztec address from the connection guide
-const claim = await portalManager.bridgeTokensPublic(
-  aliceAddress, // the L2 address
-  1000000000000000000000n, // the amount to send to the L1 portal
-  true, // whether to mint or not (set to false if your walletClient account already has fee juice!)
-);
-
-console.log("Claim secret:", claim.claimSecret);
-console.log("Claim amount:", claim.claimAmount);
-```
+#include_code bridge_fee_juice_execute /docs/examples/ts/aztecjs_connection/index.ts typescript
 
 After this transaction is minted on L1 and a few blocks pass, you can claim the message on L2 and use it directly to pay for fees:
 
-```typescript
-import { FeeJuicePaymentMethodWithClaim } from "@aztec/aztec.js/fee";
-
-// aliceAddress and claim are from the bridgeTokensPublic step above
-// contract is a deployed contract instance; gasSettings is from the gas settings section
-// Use the claim from bridgeTokensPublic to pay for a transaction
-const paymentMethod = new FeeJuicePaymentMethodWithClaim(aliceAddress, claim);
-const receipt = await contract.methods
-  .myFunction()
-  .send({ from: aliceAddress, fee: { gasSettings, paymentMethod } });
-```
+#include_code bridge_fee_juice_claim /docs/examples/ts/aztecjs_connection/index.ts typescript
 
 ## Configure gas settings
 
@@ -214,27 +143,13 @@ The fee limit is calculated as `gasLimits × maxFeesPerGas` for each dimension.
 
 Set custom gas limits by importing from `stdlib`:
 
-```typescript
-import { GasSettings } from "@aztec/stdlib/gas";
+#include_code custom_gas_settings /docs/examples/ts/aztecjs_advanced/index.ts typescript
 
-// contract is a deployed contract instance
-// alice is from the connection guide
-// paymentMethod is from one of the payment method sections above
-const gasSettings = GasSettings.from({
-  gasLimits: { daGas: 100000, l2Gas: 100000 },
-  teardownGasLimits: { daGas: 10000, l2Gas: 10000 },
-  maxFeesPerGas: { daGas: 10, l2Gas: 10 },
-  maxPriorityFeesPerGas: { daGas: 1, l2Gas: 1 },
-});
+Then pass the settings when sending:
 
-const receipt = await contract.methods.myFunction().send({
-  from: aliceAddress,
-  fee: {
-    paymentMethod,
-    gasSettings,
-  },
-});
-```
+#include_code send_with_gas_settings /docs/examples/ts/aztecjs_advanced/index.ts typescript
+
+Note that `gasLimits` and `teardownGasLimits` use `daGas`/`l2Gas` field names, while `maxFeesPerGas` and `maxPriorityFeesPerGas` use `feePerDaGas`/`feePerL2Gas`.
 
 ### Use automatic gas estimation
 
@@ -242,17 +157,7 @@ const receipt = await contract.methods.myFunction().send({
 When using `EmbeddedWallet`, gas estimation happens automatically on every `send()` — you don't need to pass `estimateGas`. This option is useful for custom wallet implementations or when you want to estimate gas during a `simulate()` call.
 :::
 
-```typescript
-// contract, aliceAddress, and paymentMethod are from the examples above
-const receipt = await contract.methods.myFunction().send({
-  from: aliceAddress,
-  fee: {
-    paymentMethod,
-    estimateGas: true,
-    estimatedGasPadding: 0.2, // 20% padding
-  },
-});
-```
+#include_code auto_gas_estimation /docs/examples/ts/aztecjs_advanced/index.ts typescript
 
 :::tip
 Gas estimation runs a simulation first to determine actual gas usage, then adds padding for safety. This works with all payment methods, including FPCs.

--- a/docs/docs-developers/docs/aztec-js/how_to_read_data.md
+++ b/docs/docs-developers/docs/aztec-js/how_to_read_data.md
@@ -20,11 +20,7 @@ The `simulate` method executes a contract function locally and returns its resul
 
 #include_code simulate_function /docs/examples/ts/aztecjs_connection/index.ts typescript
 
-The `from` option specifies which address context to use for the simulation. This is required for all simulations, though it only affects private function execution (public functions ignore this value).
-
-### Basic simulation
-
-#include_code simulate_function docs/examples/ts/aztecjs_connection/index.ts typescript
+The `from` option specifies which account context to use for the simulation. This is required for all simulations. For private functions, it determines which account's private state is accessed. For public functions, it sets the `msg_sender` context.
 
 ### Handling return values
 
@@ -32,7 +28,7 @@ For functions returning multiple values, destructure the result:
 
 ```typescript
 // contract and callerAddress are from the example above
-const [value1, value2] = await contract.methods
+const { result: [value1, value2] } = await contract.methods
   .get_multiple_values()
   .simulate({ from: callerAddress });
 ```
@@ -41,38 +37,17 @@ const [value1, value2] = await contract.methods
 
 Set `includeMetadata: true` to get additional information about the simulation:
 
-```typescript
-// contract and callerAddress are from the examples above
-const result = await contract.methods
-  .balance_of_public(address)
-  .simulate({ from: callerAddress, includeMetadata: true });
+#include_code simulate_with_metadata /docs/examples/ts/aztecjs_advanced/index.ts typescript
 
-// Result includes:
-// - result: the function return value
-// - stats: execution statistics (timing, circuit sizes)
-// - offchainEffects: any offchain effects emitted
-// - estimatedGas: gas limit estimates (gasLimits and teardownGasLimits)
-console.log("Balance:", result.result);
-console.log("L2 gas limit:", result.estimatedGas.gasLimits.l2Gas);
-console.log("DA gas limit:", result.estimatedGas.gasLimits.daGas);
-```
+The result includes `result` (the function return value), `stats` (execution statistics), `offchainEffects`, and `estimatedGas` (with `gasLimits` and `teardownGasLimits`).
 
 ### Private function considerations
 
 When simulating private functions, the caller must have access to any private state being read. The PXE only has visibility into notes belonging to registered accounts.
 
-```typescript
-// contract and callerAddress are from the examples above
-// This works if callerAddress owns the notes
-const balance = await contract.methods
-  .balance_of_private(callerAddress)
-  .simulate({ from: callerAddress });
+#include_code simulate_private_access /docs/examples/ts/aztecjs_advanced/index.ts typescript
 
-// This fails if callerAddress doesn't have access to otherAddress's notes
-const otherBalance = await contract.methods
-  .balance_of_private(otherAddress)
-  .simulate({ from: callerAddress }); // Error: cannot access private state
-```
+If the caller doesn't have access to another address's notes, the simulation will fail with an error.
 
 :::warning
 Simulation runs locally without generating proofs. No correctness guarantees are provided on the result. See [Call Types](../foundational-topics/call_types.md#simulate) for more details.
@@ -95,20 +70,11 @@ Contracts emit data in two forms you can read:
 
 Use `aztecNode.getPublicLogs()` to retrieve raw log data:
 
-```typescript
-// aztecNode is from createAztecNodeClient() in the connection guide
-// receipt is from a transaction's send() call
-// Get logs for a specific transaction
-const logs = await aztecNode.getPublicLogs({ txHash: receipt.txHash });
-const rawFields = logs.logs[0].log.getEmittedFields(); // Fr[]
+#include_code read_public_logs /docs/examples/ts/aztecjs_advanced/index.ts typescript
 
-// Get logs for a block range
-const logFilter = {
-  fromBlock: startBlock,
-  toBlock: endBlock,
-};
-const publicLogs = (await aztecNode.getPublicLogs(logFilter)).logs;
-```
+You can also filter by transaction hash or block range:
+
+#include_code read_logs_by_filter /docs/examples/ts/aztecjs_advanced/index.ts typescript
 
 ## Reading events
 
@@ -118,9 +84,7 @@ Events provide typed access to contract emissions. The event metadata from your 
 
 Use the `getPublicEvents` helper to retrieve typed public events:
 
-```typescript
-import { getPublicEvents } from "@aztec/aztec.js/events";
-```
+#include_code import_get_public_events /docs/examples/ts/aztecjs_advanced/index.ts typescript
 
 #include_code get_public_events yarn-project/end-to-end/src/e2e_event_logs.test.ts typescript
 
@@ -140,10 +104,7 @@ Each returned event includes both the decoded `event` data and `metadata` (block
 
 Private events are stored in the PXE with privacy scoping. Use `wallet.getPrivateEvents()` to retrieve them:
 
-```typescript
-import type { PrivateEventFilter } from "@aztec/aztec.js/wallet";
-import { BlockNumber } from "@aztec/foundation/branded-types";
-```
+#include_code import_private_event_types /docs/examples/ts/aztecjs_advanced/index.ts typescript
 
 The `BlockNumber` type is a branded type that wraps raw numbers for type safety. Use it when setting `fromBlock` and `toBlock` in filters.
 

--- a/docs/docs-developers/docs/aztec-js/how_to_send_transaction.md
+++ b/docs/docs-developers/docs/aztec-js/how_to_send_transaction.md
@@ -23,24 +23,11 @@ import { General } from '@site/src/components/Snippets/general_snippets';
 
 After connecting to a contract:
 
-```typescript
-import { Contract } from "@aztec/aztec.js";
-
-// wallet is from the connection guide; contractAddress and artifact are from your deployed contract
-const contract = await Contract.at(contractAddress, artifact, wallet);
-```
+#include_code connect_to_contract /docs/examples/ts/aztecjs_advanced/index.ts typescript
 
 Call a function and wait for it to be mined:
 
-```typescript
-// contract is from the step above; alice is from the connection guide
-const receipt = await contract.methods
-  .transfer(bobAddress, amount)
-  .send({ from: aliceAddress });
-
-console.log(`Transaction mined in block ${receipt.blockNumber}`);
-console.log(`Transaction fee: ${receipt.transactionFee}`);
-```
+#include_code basic_send_transaction /docs/examples/ts/aztecjs_advanced/index.ts typescript
 
 The `from` field specifies which account sends the transaction. If that account has Fee Juice, it pays for the transaction automatically. For other fee payment options, see [paying fees](./how_to_pay_fees.md).
 
@@ -53,9 +40,7 @@ When using `EmbeddedWallet`, calling `send()` triggers a **simulation** step bef
 
 This means a simple `.send()` is all most apps need. You can adjust the gas padding if desired:
 
-```typescript
-wallet.setEstimatedGasPadding(0.2); // 20% padding instead of the default 10%
-```
+#include_code set_gas_padding /docs/examples/ts/aztecjs_advanced/index.ts typescript
 
 :::note
 Public authwits still need to be set explicitly before the transaction, as they require a separate onchain transaction. See [Using Authentication Witnesses](./how_to_use_authwit.md) for details.
@@ -85,7 +70,7 @@ After sending a transaction without waiting, you can query its receipt using the
 
 The receipt includes:
 
-- `status` - Transaction status (`success`, `reverted`, `dropped`, or `pending`)
+- `status` - Transaction status (`pending`, `proposed`, `checkpointed`, `proven`, `finalized`, or `dropped`)
 - `blockNumber` - Block where the transaction was included
 - `transactionFee` - Fee paid for the transaction
 - `error` - Error message if the transaction reverted

--- a/docs/docs-developers/docs/aztec-js/how_to_test.md
+++ b/docs/docs-developers/docs/aztec-js/how_to_test.md
@@ -25,29 +25,13 @@ The `EmbeddedWallet` manages accounts, tracks deployed contracts, and handles tr
 
 The local network comes with pre-funded accounts. Load them into your wallet:
 
-```typescript
-import { registerInitialLocalNetworkAccountsInWallet } from "@aztec/wallets/testing";
-
-// wallet is the EmbeddedWallet from the setup section above
-const [alice, bob] = await registerInitialLocalNetworkAccountsInWallet(wallet);
-```
+#include_code load_test_accounts /docs/examples/ts/aztecjs_testing/index.ts typescript
 
 ## Deploying contracts in tests
 
 Deploy contracts using the generated contract class:
 
-```typescript
-import { TokenContract } from "@aztec/noir-contracts.js/Token";
-
-// wallet is from the setup section; alice is from registerInitialLocalNetworkAccountsInWallet
-const contract = await TokenContract.deploy(
-  wallet,
-  alice, // admin
-  "TestToken",
-  "TST",
-  18,
-).send({ from: alice });
-```
+#include_code deploy_test_contract /docs/examples/ts/aztecjs_testing/index.ts typescript
 
 ## Verifying contract state
 
@@ -79,20 +63,7 @@ Here's a complete test example showing the typical structure with setup, test ca
 
 Test that invalid operations revert as expected:
 
-```typescript
-// token, alice, and bob are from the test setup in beforeAll
-it("reverts when transferring more than balance", async () => {
-  const balance = await token.methods
-    .balance_of_public(alice)
-    .simulate({ from: alice });
-
-  await expect(
-    token.methods
-      .transfer_in_public(bob, balance + 1n)
-      .simulate({ from: alice }),
-  ).rejects.toThrow();
-});
-```
+#include_code test_revert_case /docs/examples/ts/aztecjs_testing/index.ts typescript
 
 Use `.simulate()` to test reverts without spending gas. The simulation will throw if the transaction would fail onchain.
 

--- a/docs/examples/ts/aztecjs_advanced/index.ts
+++ b/docs/examples/ts/aztecjs_advanced/index.ts
@@ -8,12 +8,12 @@ import { getInitialTestAccountsData } from "@aztec/accounts/testing";
 import { TokenContract, type Transfer } from "@aztec/noir-contracts.js/Token";
 import { SponsoredFPCContract } from "@aztec/noir-contracts.js/SponsoredFPC";
 import { Fr } from "@aztec/aztec.js/fields";
-import { NO_WAIT, BatchCall } from "@aztec/aztec.js/contracts";
+import { NO_WAIT, BatchCall, Contract } from "@aztec/aztec.js/contracts";
 import { SponsoredFeePaymentMethod } from "@aztec/aztec.js/fee/testing";
 import { getContractInstanceFromInstantiationParams } from "@aztec/stdlib/contract";
 import { PublicKeys } from "@aztec/stdlib/keys";
 import { getPublicEvents } from "@aztec/aztec.js/events";
-import { BlockNumber } from "@aztec/aztec.js/fields";
+import { GasSettings } from "@aztec/stdlib/gas";
 
 // Setup: connect to network
 const node = createAztecNodeClient(process.env.AZTEC_NODE_URL ?? "http://localhost:8080");
@@ -304,5 +304,136 @@ async function pollForTransferEvents() {
 // Example: poll once (in production, use setInterval)
 await pollForTransferEvents();
 // docs:end:poll_for_events
+
+// docs:start:connect_to_contract
+// wallet is from the connection guide; token is the contract deployed in the deploy guide
+const contract = await Contract.at(token.address, TokenContract.artifact, wallet);
+// docs:end:connect_to_contract
+
+// docs:start:basic_send_transaction
+// contract is from the step above; aliceAddress is from the connection guide
+const { receipt: sendReceipt } = await contract.methods
+  .transfer_in_public(aliceAddress, bobAddress, 100n, 0n)
+  .send({ from: aliceAddress });
+console.log(`Transaction mined in block ${sendReceipt.blockNumber}`);
+console.log(`Transaction fee: ${sendReceipt.transactionFee}`);
+// docs:end:basic_send_transaction
+
+// docs:start:set_gas_padding
+wallet.setEstimatedGasPadding(0.2); // 20% padding instead of the default 10%
+// docs:end:set_gas_padding
+
+// docs:start:simulate_with_metadata
+const metaResult = await token.methods
+  .balance_of_public(aliceAddress)
+  .simulate({ from: aliceAddress, includeMetadata: true });
+console.log("Balance:", metaResult.result);
+console.log("L2 gas limit:", metaResult.estimatedGas.gasLimits.l2Gas);
+console.log("DA gas limit:", metaResult.estimatedGas.gasLimits.daGas);
+// docs:end:simulate_with_metadata
+
+// docs:start:read_public_logs
+const publicLogs = await node.getPublicLogs({ fromBlock: 1, toBlock: await node.getBlockNumber() + 1 });
+if (publicLogs.logs.length > 0) {
+  const rawFields = publicLogs.logs[0].log.getEmittedFields(); // Fr[]
+  console.log("Raw log fields:", rawFields.length);
+}
+// docs:end:read_public_logs
+
+// docs:start:estimate_mana
+const { estimatedGas } = await token.methods
+  .transfer_in_public(aliceAddress, bobAddress, 1n, 0n)
+  .simulate({
+    from: aliceAddress,
+    fee: { estimateGas: true, estimatedGasPadding: 0.1 },
+  });
+// docs:end:estimate_mana
+
+// docs:start:compute_fee_from_estimate
+const currentFees = await node.getCurrentMinFees();
+const estimatedFee = estimatedGas.gasLimits.computeFee(currentFees).toBigInt();
+console.log("Estimated fee:", estimatedFee);
+// docs:end:compute_fee_from_estimate
+
+// docs:start:get_fee_from_receipt
+const { receipt: feeReceipt } = await token.methods
+  .mint_to_public(aliceAddress, 1n)
+  .send({ from: aliceAddress });
+console.log("Transaction fee:", feeReceipt.transactionFee);
+// docs:end:get_fee_from_receipt
+
+// docs:start:check_receipt_status
+console.log("Succeeded:", feeReceipt.hasExecutionSucceeded());
+console.log("Block:", feeReceipt.blockNumber);
+console.log("Fee paid:", feeReceipt.transactionFee);
+// docs:end:check_receipt_status
+
+// docs:start:pay_with_fee_juice
+// contract is a deployed contract instance; aliceAddress is from the connection guide
+const { receipt: feeJuiceReceipt } = await token.methods
+  .mint_to_public(aliceAddress, 1n)
+  .send({
+    from: aliceAddress,
+    // no fee payment method needed — Fee Juice is used automatically
+  });
+console.log("Transaction fee:", feeJuiceReceipt.transactionFee);
+// docs:end:pay_with_fee_juice
+
+// docs:start:custom_gas_settings
+// Query current network fees to set realistic limits
+const networkFees = await node.getCurrentMinFees();
+const gasSettings = GasSettings.from({
+  gasLimits: { daGas: 100_000, l2Gas: 2_000_000 },
+  teardownGasLimits: { daGas: 100_000, l2Gas: 2_000_000 },
+  maxFeesPerGas: { feePerDaGas: networkFees.feePerDaGas * 2n, feePerL2Gas: networkFees.feePerL2Gas * 2n },
+  maxPriorityFeesPerGas: { feePerDaGas: 0n, feePerL2Gas: 0n },
+});
+// docs:end:custom_gas_settings
+
+// docs:start:send_with_gas_settings
+const { receipt: gsReceipt } = await token.methods.mint_to_public(aliceAddress, 1n).send({
+  from: aliceAddress,
+  fee: { gasSettings },
+});
+// docs:end:send_with_gas_settings
+
+// docs:start:read_logs_by_filter
+// Get logs for a specific transaction
+const txLogs = await node.getPublicLogs({ txHash: gsReceipt.txHash });
+
+// Get logs for a block range
+const rangeLogs = await node.getPublicLogs({ fromBlock: 1, toBlock: await node.getBlockNumber() + 1 });
+// docs:end:read_logs_by_filter
+
+// docs:start:auto_gas_estimation
+// Estimate gas for a transaction before sending
+const { estimatedGas: autoEstimate } = await token.methods
+  .mint_to_public(aliceAddress, 1n)
+  .simulate({
+    from: aliceAddress,
+    fee: {
+      estimateGas: true,
+      estimatedGasPadding: 0.2, // 20% padding
+    },
+  });
+console.log("Auto-estimated L2 gas:", autoEstimate.gasLimits.l2Gas);
+// docs:end:auto_gas_estimation
+
+// docs:start:import_get_public_events
+import { getPublicEvents as _importCheck } from "@aztec/aztec.js/events";
+// docs:end:import_get_public_events
+
+// docs:start:import_private_event_types
+import type { PrivateEventFilter } from "@aztec/aztec.js/wallet";
+import { BlockNumber } from "@aztec/aztec.js/fields";
+// docs:end:import_private_event_types
+
+// docs:start:simulate_private_access
+// This works if aliceAddress owns the notes
+const { result: privateBalance } = await token.methods
+  .balance_of_private(aliceAddress)
+  .simulate({ from: aliceAddress });
+// docs:end:simulate_private_access
+
 
 console.log("All advanced examples completed successfully");

--- a/docs/examples/ts/aztecjs_connection/index.ts
+++ b/docs/examples/ts/aztecjs_connection/index.ts
@@ -81,12 +81,6 @@ await deployMethod.send({
 });
 // docs:end:deploy_account_sponsored_fpc
 
-// docs:start:bridge_account_fee_juice
-import { createExtendedL1Client } from "@aztec/ethereum/client";
-import { L1FeeJuicePortalManager } from "@aztec/aztec.js/ethereum";
-import { FeeJuicePaymentMethodWithClaim } from "@aztec/aztec.js/fee";
-import { createLogger } from "@aztec/aztec.js/log";
-
 // Create a separate account to deploy with Fee Juice bridged from L1
 const feeJuiceSecret = Fr.random();
 const feeJuiceSalt = Fr.random();
@@ -95,19 +89,34 @@ const feeJuiceAccount = await wallet.createSchnorrAccount(
   feeJuiceSalt,
 );
 
-// Bridge Fee Juice from L1 to the new account
+// docs:start:bridge_fee_juice_setup
+import { createExtendedL1Client } from "@aztec/ethereum/client";
+import { L1FeeJuicePortalManager } from "@aztec/aztec.js/ethereum";
+import { createLogger } from "@aztec/aztec.js/log";
+
+// Create an L1 client (accepts a mnemonic or 0x-prefixed private key)
 const l1RpcUrl = process.env.ETHEREUM_HOST ?? "http://localhost:8545";
 const l1Mnemonic =
   "test test test test test test test test test test test junk";
 const l1Client = createExtendedL1Client([l1RpcUrl], l1Mnemonic);
+
+// Create a portal manager to interact with the L1 fee juice portal
 const logger = createLogger("docs:fee-juice-bridge");
 const portalManager = await L1FeeJuicePortalManager.new(node, l1Client, logger);
+// docs:end:bridge_fee_juice_setup
+
+// docs:start:bridge_fee_juice_execute
+// portalManager is from the L1FeeJuicePortalManager setup above
+// feeJuiceAccount.address is an Aztec address from createSchnorrAccount
 const claim = await portalManager.bridgeTokensPublic(
-  feeJuiceAccount.address,
-  1000000000000000000000n, // 1000 Fee Juice
-  true, // mint on L1 (local network only)
+  feeJuiceAccount.address, // the L2 address
+  1000000000000000000000n, // the amount to send to the L1 portal
+  true, // whether to mint or not (set to false if your L1 account already has fee juice!)
 );
-// docs:end:bridge_account_fee_juice
+
+console.log("Claim secret:", claim.claimSecret);
+console.log("Claim amount:", claim.claimAmount);
+// docs:end:bridge_fee_juice_execute
 
 // docs:start:deploy_contract
 import { TokenContract } from "@aztec/noir-contracts.js/Token";
@@ -140,19 +149,20 @@ const { result: balance } = await token.methods
 console.log(`Alice's token balance: ${balance}`);
 // docs:end:simulate_function
 
-// docs:start:deploy_account_fee_juice
-// Deploy the account using the bridged Fee Juice
-const deployMethodFeeJuice = await feeJuiceAccount.getDeployMethod();
-await deployMethodFeeJuice.send({
+// docs:start:bridge_fee_juice_claim
+import { FeeJuicePaymentMethodWithClaim } from "@aztec/aztec.js/fee";
+
+// claim is from the bridgeTokensPublic step above
+// Create a payment method that claims the bridged Fee Juice and uses it to pay
+const bridgePaymentMethod = new FeeJuicePaymentMethodWithClaim(feeJuiceAccount.address, claim);
+
+// Use it to pay for any transaction — here we deploy the account in one step
+const deployMethodBridged = await feeJuiceAccount.getDeployMethod();
+await deployMethodBridged.send({
   from: NO_FROM,
-  fee: {
-    paymentMethod: new FeeJuicePaymentMethodWithClaim(
-      feeJuiceAccount.address,
-      claim,
-    ),
-  },
+  fee: { paymentMethod: bridgePaymentMethod },
 });
-// docs:end:deploy_account_fee_juice
+// docs:end:bridge_fee_juice_claim
 
 // docs:start:verify_account_deployment
 const metadata = await wallet.getContractMetadata(feeJuiceAccount.address);

--- a/docs/examples/ts/aztecjs_testing/index.ts
+++ b/docs/examples/ts/aztecjs_testing/index.ts
@@ -101,5 +101,48 @@ async function runTests() {
   console.log("\n✓ All tests passed");
 }
 
-runTests().catch(console.error);
+await runTests();
 // docs:end:complete_test_example
+
+// docs:start:load_test_accounts
+import { registerInitialLocalNetworkAccountsInWallet } from "@aztec/wallets/testing";
+
+// wallet is the EmbeddedWallet from the setup section above
+const [alice, bob] = await registerInitialLocalNetworkAccountsInWallet(wallet);
+// docs:end:load_test_accounts
+
+// docs:start:deploy_test_contract
+// wallet is from the setup section; alice is from registerInitialLocalNetworkAccountsInWallet
+const { contract: testToken } = await TokenContract.deploy(
+  wallet,
+  alice, // admin
+  "TestToken",
+  "TST",
+  18,
+).send({ from: alice });
+// docs:end:deploy_test_contract
+
+// docs:start:test_revert_case
+async function testRevertExample() {
+  // testToken and alice are from the deploy/load sections above
+  const { result: balance } = await testToken.methods
+    .balance_of_public(alice)
+    .simulate({ from: alice });
+
+  let reverted = false;
+  try {
+    await testToken.methods
+      .transfer_in_public(alice, bob, balance + 1n, 0n)
+      .simulate({ from: alice });
+  } catch (error) {
+    reverted = true;
+  }
+
+  if (!reverted) {
+    throw new Error("Expected simulation to revert for over-transfer");
+  }
+  console.log("✓ Revert on over-transfer test passed");
+}
+
+await testRevertExample();
+// docs:end:test_revert_case


### PR DESCRIPTION
## Summary
- Fix code examples across aztec-js how-to guides to use correct API patterns (destructured `{ result }` and `{ receipt }`, proper import paths like `@aztec/aztec.js/contracts`, real contract methods like `transfer_in_public`)
- Replace hardcoded inline code blocks in source docs (`docs-developers/`) with `#include_code` macros pointing to the TypeScript example files, so examples stay in sync with compilable code
- Fix inaccurate field names in `GasSettings` (`maxFeesPerGas` uses `feePerDaGas`/`feePerL2Gas`, not `daGas`/`l2Gas`), correct transaction status enum values, and improve explanatory text

## Test plan
- [ ] `yarn build` in `docs/` passes (spellcheck, preprocessing, Docusaurus build)
- [ ] Verify `#include_code` macros resolve correctly in the built output
- [ ] TypeScript examples in `docs/examples/ts/` type-check via `examples/bootstrap.sh`