### PR TITLE
chore: (A-832) fix defaultFetch double consuming response on JSON parse failure

### DIFF
--- a/yarn-project/foundation/src/json-rpc/client/fetch.ts
+++ b/yarn-project/foundation/src/json-rpc/client/fetch.ts
@@ -43,13 +43,14 @@ export async function defaultFetch(
   }
 
   let responseJson;
+  const responseText = await resp.text();
   try {
-    responseJson = await resp.json();
+    responseJson = JSON.parse(responseText);
   } catch {
     if (!resp.ok) {
       throw new Error(resp.statusText);
     }
-    throw new Error(`Failed to parse body as JSON: ${await resp.text()}`);
+    throw new Error(`Failed to parse body as JSON: ${responseText}`);
   }
 
   if (!resp.ok) {


### PR DESCRIPTION
When the json() call fails and the response was OK (2xx), the code called resp.tex() to include the body in the error. The error message never contains the actual body content since we have already consumed the response body. Now we read the body as text first, then parse as JSON.