### PR TITLE
fix(docs): fix token contract tutorial setup issues

### DIFF
--- a/docs/developer_versioned_docs/version-v4.2.0-aztecnr-rc.2/docs/tutorials/contract_tutorials/token_contract.md
+++ b/docs/developer_versioned_docs/version-v4.2.0-aztecnr-rc.2/docs/tutorials/contract_tutorials/token_contract.md
@@ -39,18 +39,17 @@ We'll create BOB tokens with:
 Let's create a simple yarn + aztec.nr project:
 
 ```bash
-mkdir bob_token
+aztec new bob_token
 cd bob_token
 yarn init
 # This is to ensure yarn uses node_modules instead of pnp for dependency installation
 yarn config set nodeLinker node-modules
-yarn add @aztec/aztec.js@4.2.0-aztecnr-rc.2 @aztec/accounts@4.2.0-aztecnr-rc.2 @aztec/kv-store@4.2.0-aztecnr-rc.2
-aztec init
+yarn add @aztec/aztec.js@4.2.0-aztecnr-rc.2 @aztec/accounts@4.2.0-aztecnr-rc.2 @aztec/kv-store@4.2.0-aztecnr-rc.2 @aztec/wallets@4.2.0-aztecnr-rc.2
 ```
 
 ## Contract structure
 
-The `aztec init` command created a contract project with `Nargo.toml` and `src/main.nr`. Let's replace the boilerplate in `src/main.nr` with a simple starting point:
+The `aztec new` command created a contract project with `Nargo.toml` and `src/main.nr`. Let's replace the boilerplate in `src/main.nr` with a simple starting point:
 
 ```rust
 use aztec::macros::aztec;
@@ -63,7 +62,7 @@ pub contract BobToken {
 
 The `#[aztec]` macro transforms our contract code to work with Aztec's privacy protocol.
 
-Let's make sure the Aztec.nr library is listed in our dependencies in `bob_token_contract/Nargo.toml`:
+Replace the contents of `Nargo.toml` with the following:
 
 ```toml
 [package]
@@ -315,7 +314,7 @@ npx tsx index.ts
 
 :::tip
 
-What's this `tsx` dark magic? Well, it just compiles and runs typescript using reasonable defaults. Pretty cool for small snippets like this!
+What's this `tsx` dark magic? `tsx` is a tool that compiles and runs TypeScript using reasonable defaults. `npx` will auto-install it if you don't have it. If you'd prefer to install it explicitly, run `yarn add -D tsx` first.
 
 :::
 
@@ -357,7 +356,7 @@ In this case, all that the network sees (including Giggle) is just "something ha
 
 ### Updating Storage for Privacy
 
-For something like balances, you can use a simple library called `easy_private_state` which abstracts away a custom private Note. A Note is at the core of how private state works in Aztec and you can read about it [here](../../foundational-topics/state_management.md). For now, let's just import the library in `bob_token_contract/Nargo.toml`:
+For something like balances, you can use a simple library called `easy_private_state` which abstracts away a custom private Note. A Note is at the core of how private state works in Aztec and you can read about it [here](../../foundational-topics/state_management.md). For now, let's add it by replacing the `[dependencies]` section in `Nargo.toml`:
 
 ```toml
 [dependencies]

--- a/docs/docs-developers/docs/tutorials/contract_tutorials/token_contract.md
+++ b/docs/docs-developers/docs/tutorials/contract_tutorials/token_contract.md
@@ -39,18 +39,17 @@ We'll create BOB tokens with:
 Let's create a simple yarn + aztec.nr project:
 
 ```bash
-mkdir bob_token
+aztec new bob_token
 cd bob_token
 yarn init
 # This is to ensure yarn uses node_modules instead of pnp for dependency installation
 yarn config set nodeLinker node-modules
-yarn add @aztec/aztec.js@#include_aztec_version @aztec/accounts@#include_aztec_version @aztec/kv-store@#include_aztec_version
-aztec init
+yarn add @aztec/aztec.js@#include_aztec_version @aztec/accounts@#include_aztec_version @aztec/kv-store@#include_aztec_version @aztec/wallets@#include_aztec_version
 ```
 
 ## Contract structure
 
-The `aztec init` command created a contract project with `Nargo.toml` and `src/main.nr`. Let's replace the boilerplate in `src/main.nr` with a simple starting point:
+The `aztec new` command created a contract project with `Nargo.toml` and `src/main.nr`. Let's replace the boilerplate in `src/main.nr` with a simple starting point:
 
 ```rust
 #include_code start /docs/examples/contracts/bob_token_contract/src/main.nr raw
@@ -60,7 +59,7 @@ The `aztec init` command created a contract project with `Nargo.toml` and `src/m
 
 The `#[aztec]` macro transforms our contract code to work with Aztec's privacy protocol.
 
-Let's make sure the Aztec.nr library is listed in our dependencies in `bob_token_contract/Nargo.toml`:
+Replace the contents of `Nargo.toml` with the following:
 
 ```toml
 [package]
@@ -212,7 +211,7 @@ npx tsx index.ts
 
 :::tip
 
-What's this `tsx` dark magic? Well, it just compiles and runs typescript using reasonable defaults. Pretty cool for small snippets like this!
+What's this `tsx` dark magic? `tsx` is a tool that compiles and runs TypeScript using reasonable defaults. `npx` will auto-install it if you don't have it. If you'd prefer to install it explicitly, run `yarn add -D tsx` first.
 
 :::
 
@@ -254,7 +253,7 @@ In this case, all that the network sees (including Giggle) is just "something ha
 
 ### Updating Storage for Privacy
 
-For something like balances, you can use a simple library called `easy_private_state` which abstracts away a custom private Note. A Note is at the core of how private state works in Aztec and you can read about it [here](../../foundational-topics/state_management.md). For now, let's just import the library in `bob_token_contract/Nargo.toml`:
+For something like balances, you can use a simple library called `easy_private_state` which abstracts away a custom private Note. A Note is at the core of how private state works in Aztec and you can read about it [here](../../foundational-topics/state_management.md). For now, let's add it by replacing the `[dependencies]` section in `Nargo.toml`:
 
 ```toml
 [dependencies]


### PR DESCRIPTION
## Summary

Fixes several issues in the Private Token Contract tutorial discovered during a walkthrough:

- **Add missing `@aztec/wallets` package** to the `yarn add` command — the tutorial's `index.ts` imports from `@aztec/wallets/embedded` but the install command didn't include it, causing a `Cannot find module` error (blocker)
- **Use `aztec new` instead of `aztec init`** — aligns with all other tutorials and scaffolds the correct `type = "contract"` project structure
- **Fix `Nargo.toml` path references** — `aztec new` creates a flat structure, so references should be `Nargo.toml` not `bob_token_contract/Nargo.toml` (since the user has already cd'd into the project)
- **Clarify `balance_set` dependency instruction** — explicitly say to replace the `[dependencies]` section rather than implying it's already present
- **Improve `tsx` tip** — explain that `npx` auto-installs it and how to install explicitly

Changes applied to both the source docs and the v4.2.0-aztecnr-rc.2 versioned docs.

## Verified

Followed the updated tutorial end-to-end: `aztec new`, compile, codegen, deploy, and ran the full interaction script (public mint, public transfer, public-to-private, private transfer, private-to-public, private mint). All operations succeeded with correct balances.

## Test plan

- [x] `aztec new bob_token` creates correct project structure
- [x] `yarn add` with all four packages installs without errors
- [x] `aztec compile` succeeds
- [x] `aztec codegen` generates `BobToken.ts`
- [x] `npx tsx index.ts` deploys and runs all operations successfully