### PR TITLE
fix(epoch-cache): use TTL-based caching with finalization tracking and correct lag

### DIFF
--- a/yarn-project/epoch-cache/README.md
+++ b/yarn-project/epoch-cache/README.md
@@ -1,0 +1,211 @@
+# Epoch Cache
+
+Caches validator committee information per epoch to reduce L1 RPC traffic. Provides
+the current committee, proposer selection, and escape hatch status for any given slot
+or epoch, used by the sequencer, validator client, and other node components that need
+to know who can propose or attest in a given slot.
+
+## Committee Computation
+
+Each epoch has a **committee**: a subset of all registered validators selected to
+participate in consensus for that epoch. The committee is determined by three inputs:
+
+1. **The validator set** -- the full list of registered attesters, snapshotted at a
+   past point in time.
+2. **A RANDAO seed** -- pseudo-random value derived from Ethereum's `block.prevrandao`,
+   also sampled from the past.
+3. **A sampling algorithm** -- a Fisher-Yates-style shuffle that picks
+   `targetCommitteeSize` indices from the validator set without replacement.
+
+Once computed, the committee is fixed for the entire epoch. The L1 rollup contract
+stores a keccak256 commitment of the committee addresses to prevent substitution.
+
+### Sampling Algorithm
+
+The sampling draws `targetCommitteeSize` indices from a pool of `validatorSetSize`
+using a sample-without-replacement approach:
+
+```
+for i in 0..committeeSize:
+    sampledIndex = keccak256(seed, i) % (poolSize - i)
+    committee[i] = pool[sampledIndex]
+    swap pool[sampledIndex] with pool[last]
+    shrink pool by 1
+```
+
+Each iteration hashes the seed with the iteration index to pick a random position,
+then swaps the picked element to the end and shrinks the pool, ensuring no validator
+is selected twice.
+
+## LAG Values
+
+Two lag parameters prevent manipulation of committee composition:
+
+### `lagInEpochsForValidatorSet`
+
+When computing the committee for epoch N, the validator set is read from a snapshot
+taken `lagInEpochsForValidatorSet` epochs in the past. The sampling timestamp is:
+
+```
+validatorSetTimestamp = epochStart(N) - (lagInEpochsForValidatorSet * epochDuration * slotDuration)
+```
+
+This prevents an attacker from registering new validators just before an epoch to
+influence who gets selected. The validator set is locked well in advance.
+
+### `lagInEpochsForRandao`
+
+The RANDAO seed used for committee selection is sampled from
+`lagInEpochsForRandao` epochs in the past:
+
+```
+randaoTimestamp = epochStart(N) - (lagInEpochsForRandao * epochDuration * slotDuration)
+```
+
+This prevents L1 validators from previewing the randomness and coordinating to
+become proposers.
+
+### Why Two Separate Lags?
+
+The constraint `lagInEpochsForValidatorSet >= lagInEpochsForRandao` is enforced.
+If both lags were equal, an attacker who learns the RANDAO seed could still
+register validators in time to be included in the sampled set. By freezing the
+validator set further back than the RANDAO seed, the attacker knows the randomness
+but can no longer change the input population it selects from.
+
+## RANDAO Seed
+
+The RANDAO seed provides per-epoch randomness for committee selection and proposer
+assignment. It works as follows:
+
+1. **Checkpointing**: Each epoch, `block.prevrandao` (Ethereum's beacon chain
+   randomness) is stored in a checkpointed mapping keyed by epoch timestamp.
+   Multiple calls in the same epoch are idempotent.
+
+2. **Seed derivation**: The actual seed used for sampling is:
+   ```
+   seed = keccak256(abi.encode(epochNumber, storedRandao))
+   ```
+   where `storedRandao` is the value checkpointed at or before the RANDAO sampling
+   timestamp (determined by `lagInEpochsForRandao`). Mixing in the epoch number
+   ensures distinct seeds even if the same RANDAO value is reused.
+
+3. **Bootstrap**: The first two epochs use a bootstrapped RANDAO value stored at
+   initialization, since there is no prior history to sample from.
+
+## Proposer Selection
+
+Within a committee, a single **proposer** is designated for each slot. The proposer
+is responsible for assembling transactions into a block and publishing it.
+
+The proposer index within the committee is:
+
+```
+proposerIndex = keccak256(abi.encode(epoch, slot, seed)) % committeeSize
+```
+
+This is deterministic: anyone with the epoch number, slot number, and seed can
+independently compute who the proposer is. Each slot gets a different proposer
+because the slot number is mixed into the hash.
+
+### Proposer Pipelining
+
+When proposer pipelining is enabled, the proposer builds for the *next* slot
+rather than the current one (`PROPOSER_PIPELINING_SLOT_OFFSET = 1`). This gives
+the proposer a full slot of lead time to assemble and propagate the block. The
+"target slot" methods on the epoch cache apply this offset automatically.
+
+### Empty Committees
+
+If the committee is empty (i.e., `targetCommitteeSize` is 0), anyone can propose.
+The proposer methods return `undefined` in this case rather than throwing. If the
+committee should exist but doesn't (insufficient validators registered), a
+`NoCommitteeError` is thrown.
+
+## Escape Hatch
+
+The escape hatch is a censorship-resistance mechanism. It opens periodically
+(every `FREQUENCY` epochs, for `ACTIVE_DURATION` epochs) and allows a single
+designated proposer to submit blocks without committee attestations.
+
+### Candidate System
+
+The escape hatch has its own candidate pool, separate from the main validator set:
+
+- Candidates join by posting a bond (`BOND_SIZE`).
+- A designated proposer is selected per hatch window using a similar
+  RANDAO-based random selection from the candidate set.
+- If the designated proposer fails to propose and prove during their window,
+  they are penalized (`FAILED_HATCH_PUNISHMENT`).
+- Candidates exit through a two-step process (`initiateExit` then
+  `leaveCandidateSet`) with a withdrawal tax.
+
+### Integration with Epoch Cache
+
+The epoch cache queries `isHatchOpen(epoch)` on the escape hatch contract and
+caches the result alongside the committee info for each epoch. This flag is
+exposed via `isEscapeHatchOpen(epoch)` and `isEscapeHatchOpenAtSlot(slot)`,
+used by the sequencer to decide whether to require committee attestations.
+
+## TTL-based Caching with Finalization Tracking
+
+Each cache entry stores L1 provenance metadata alongside the committee data:
+the L1 block number, hash, and timestamp at query time, plus a **finalized** flag.
+
+### Finalization Check
+
+When fetching committee data, the epoch cache queries both the latest and finalized
+L1 blocks in parallel. It computes the **sampling timestamp** for the epoch:
+
+```
+samplingTs = epochStart(N) - lagInEpochsForRandao * epochDuration * slotDuration
+```
+
+Using `lagInEpochsForRandao` as the binding constraint (it is always
+<= `lagInEpochsForValidatorSet`). If `samplingTs <= l1FinalizedTimestamp`, the
+entry is marked as **finalized**.
+
+### Cache Behaviour
+
+- **Finalized entries** are cached permanently (within LRU limits). An L1 reorg
+  cannot change data that has been finalized, so there is no risk of stale data.
+- **Non-finalized entries** are cached with a TTL of one Ethereum slot duration
+  (typically 12 seconds). After this TTL, the next request triggers a re-fetch
+  from L1. On re-fetch, if the data is now finalized, the entry gets promoted
+  to permanent.
+- **Unstable epochs** (sampling timestamp beyond the latest L1 block) cause an
+  error, since the L1 contract itself would revert.
+
+This approach preserves **safety** (stale data from L1 reorgs gets refreshed
+within one Ethereum slot) while maintaining **liveness** (the cache never refuses
+to serve data that L1 accepts, even if L1 finalization stalls).
+
+### Concurrency
+
+The cache map stores both resolved entries and in-flight promises. When a fetch
+starts, the promise is placed directly in the cache. Concurrent callers for the
+same epoch detect the promise and await it, ensuring only one L1 query per epoch
+at a time. On failure, the promise is replaced with the previous stale entry (if
+any) so the next caller retries cleanly.
+
+## Caching Strategy
+
+The epoch cache stores committee info (committee members, seed, escape hatch
+status) per epoch in an LRU-style map with a configurable size (default 12
+epochs). Cache entries are only created for epochs with non-empty committees;
+empty results are not cached to allow retries.
+
+The cache also maintains a separate set of all registered validators, refreshed
+on a configurable interval (`validatorRefreshIntervalSeconds`, default 60s),
+used to check validator registration status independently of committee membership.
+
+## Configuration
+
+| Parameter | Default | Purpose |
+|-----------|---------|---------|
+| `cacheSize` | 12 | Max number of epoch committee entries to keep |
+| `validatorRefreshIntervalSeconds` | 60 | How often to refresh the full validator list |
+| `enableProposerPipelining` | false | Build for next slot instead of current |
+| `lagInEpochsForValidatorSet` | (from L1) | How far back to snapshot the validator set |
+| `lagInEpochsForRandao` | (from L1) | How far back to sample the RANDAO seed |
+| `targetCommitteeSize` | (from L1) | Number of validators to select per epoch |

--- a/yarn-project/epoch-cache/src/epoch_cache.integration.test.ts
+++ b/yarn-project/epoch-cache/src/epoch_cache.integration.test.ts
@@ -170,9 +170,9 @@ describe('EpochCache integration', () => {
     expect(before.committee).toBeDefined();
     expect(epochCache.isFinalized(epochBefore)).toBe(false);
 
-    // Record the L1 block number at which the cache entry was fetched.
-    const l1BlockBefore = epochCache.getCachedL1BlockNumber(epochBefore);
-    expect(l1BlockBefore).toBeDefined();
+    // Record the L1 timestamp at which the cache entry was last refreshed.
+    const l1TsBefore = epochCache.getCachedLastRefreshL1Timestamp(epochBefore);
+    expect(l1TsBefore).toBeDefined();
 
     // Rollback past the setupEpoch block and mine new blocks so the chain tip changes.
     await cheatCodes.reorg(2);
@@ -197,10 +197,10 @@ describe('EpochCache integration', () => {
     expect(after.committee).toBeDefined();
     expect(after.epoch).toBe(before.epoch);
 
-    // The cache was re-fetched from L1: the L1 block number stored in the entry must
-    // have changed because the chain was reorged and new blocks were mined.
-    const l1BlockAfter = epochCache.getCachedL1BlockNumber(epochBefore);
-    expect(l1BlockAfter).toBeDefined();
-    expect(l1BlockAfter).not.toBe(l1BlockBefore);
+    // The cache was refreshed: the L1 timestamp must have advanced because
+    // the chain was reorged and new blocks were mined.
+    const l1TsAfter = epochCache.getCachedLastRefreshL1Timestamp(epochBefore);
+    expect(l1TsAfter).toBeDefined();
+    expect(l1TsAfter).not.toBe(l1TsBefore);
   });
 });

--- a/yarn-project/epoch-cache/src/epoch_cache.integration.test.ts
+++ b/yarn-project/epoch-cache/src/epoch_cache.integration.test.ts
@@ -1,0 +1,206 @@
+import { getPublicClient } from '@aztec/ethereum/client';
+import { DefaultL1ContractsConfig } from '@aztec/ethereum/config';
+import { RollupContract } from '@aztec/ethereum/contracts';
+import { deployAztecL1Contracts } from '@aztec/ethereum/deploy-aztec-l1-contracts';
+import { EthCheatCodes, RollupCheatCodes, startAnvil } from '@aztec/ethereum/test';
+import type { Anvil } from '@aztec/ethereum/test';
+import { EpochNumber, SlotNumber } from '@aztec/foundation/branded-types';
+import { SecretValue } from '@aztec/foundation/config';
+import { Fr } from '@aztec/foundation/curves/bn254';
+import { EthAddress } from '@aztec/foundation/eth-address';
+import { createLogger } from '@aztec/foundation/log';
+import { TestDateProvider } from '@aztec/foundation/timer';
+
+import type { Hex } from 'viem';
+import { privateKeyToAccount } from 'viem/accounts';
+import { foundry } from 'viem/chains';
+
+import { EpochCache } from './epoch_cache.js';
+
+const NUM_VALIDATORS = 4;
+
+/**
+ * Integration tests for the EpochCache against a real Anvil instance.
+ *
+ * These tests deploy L1 contracts with validators, then exercise the epoch cache's
+ * caching, TTL, finalization, and reorg-resilience behaviour.
+ */
+describe('EpochCache integration', () => {
+  let anvil: Anvil;
+  let rpcUrl: string;
+  let dateProvider: TestDateProvider;
+  let cheatCodes: EthCheatCodes;
+  let rollupCheatCodes: RollupCheatCodes;
+  let rollup: RollupContract;
+  let epochCache: EpochCache;
+
+  const deployerPrivateKey: Hex = '0x8b3a350cf5c34c9194ca85829a2df0ec3153be0318b5e2d3348e872092edffba';
+
+  const validatorKeys = [
+    '0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d',
+    '0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a',
+    '0x7c852118294e51e653712a81e05800f419141751be58f605c371e15141b007a6',
+    '0x47e179ec197488593b187f80a00eb0da91f1b9d0b13f8733639f19c30a34926a',
+  ] as const;
+
+  const validatorAddresses = validatorKeys.map(k => EthAddress.fromString(privateKeyToAccount(k).address));
+
+  beforeAll(async () => {
+    dateProvider = new TestDateProvider();
+
+    // Start Anvil with slotsInAnEpoch=8 so finalized = latest - 16 blocks.
+    // This keeps most epoch data non-finalized (TTL-cached) after warps.
+    ({ anvil, rpcUrl } = await startAnvil({
+      l1BlockTime: 1,
+      slotsInAnEpoch: 8,
+      dateProvider,
+    }));
+
+    const deployed = await deployAztecL1Contracts(rpcUrl, deployerPrivateKey, foundry.id, {
+      ...DefaultL1ContractsConfig,
+      // Short L2 epochs: 4 slots * 12s = 48s per epoch
+      aztecSlotDuration: 12,
+      aztecEpochDuration: 4,
+      aztecTargetCommitteeSize: NUM_VALIDATORS,
+      vkTreeRoot: Fr.random(),
+      protocolContractsHash: Fr.random(),
+      genesisArchiveRoot: Fr.random(),
+      realVerifier: false,
+      initialValidators: validatorAddresses.map(attester => ({
+        attester,
+        withdrawer: attester,
+        bn254SecretKey: new SecretValue(Fr.random().toBigInt()),
+      })),
+    });
+
+    cheatCodes = new EthCheatCodes([rpcUrl], dateProvider);
+    rollupCheatCodes = new RollupCheatCodes(cheatCodes, deployed.l1ContractAddresses);
+
+    const publicClient = getPublicClient({ l1RpcUrls: [rpcUrl], l1ChainId: foundry.id });
+    rollup = new RollupContract(publicClient, deployed.l1ContractAddresses.rollupAddress!);
+
+    epochCache = new EpochCache(
+      rollup,
+      {
+        l1StartBlock: await rollup.getL1StartBlock(),
+        l1GenesisTime: await rollup.getL1GenesisTime(),
+        slotDuration: await rollup.getSlotDuration(),
+        epochDuration: await rollup.getEpochDuration(),
+        ethereumSlotDuration: DefaultL1ContractsConfig.ethereumSlotDuration,
+        proofSubmissionEpochs: await rollup.getProofSubmissionEpochs(),
+        targetCommitteeSize: await rollup.getTargetCommitteeSize(),
+        rollupManaLimit: Number(await rollup.getManaLimit()),
+        lagInEpochsForValidatorSet: await rollup.getLagInEpochsForValidatorSet(),
+        lagInEpochsForRandao: await rollup.getLagInEpochsForRandao(),
+      },
+      dateProvider,
+    );
+  });
+
+  afterAll(async () => {
+    await cheatCodes?.setIntervalMining(0);
+    await anvil?.stop().catch(err => createLogger('cleanup').error(err));
+  });
+
+  it('returns committee for a finalized epoch and marks it as finalized', async () => {
+    const lagInEpochsForRandao = await rollup.getLagInEpochsForRandao();
+    const epochDuration = await rollup.getEpochDuration();
+
+    // Advance well past the lag so the epoch's sampling data is finalized.
+    const targetEpoch = EpochNumber(lagInEpochsForRandao + 2);
+    await rollupCheatCodes.advanceToEpoch(targetEpoch);
+    await rollupCheatCodes.setupEpoch();
+    // Mine enough blocks so finalized catches up (finalized = latest - 16 with slotsInAnEpoch=8).
+    // With 12s timestamps per block, we need enough blocks so that the finalized block's
+    // timestamp covers the sampling timestamp for the target epoch.
+    await cheatCodes.mine(30);
+
+    // Query the specific target epoch rather than 'now', because auto-mining may have
+    // advanced the dateProvider well past the target epoch.
+    const slotForEpoch = SlotNumber(Number(targetEpoch) * Number(epochDuration));
+    const { committee, seed, epoch } = await epochCache.getCommittee(slotForEpoch);
+
+    expect(committee).toBeDefined();
+    expect(committee!.length).toBe(NUM_VALIDATORS);
+    expect(seed).not.toBe(0n);
+    expect(epoch).toBe(targetEpoch);
+    expect(epochCache.isFinalized(targetEpoch)).toBe(true);
+  });
+
+  it('refreshes non-finalized data after TTL expires', async () => {
+    // Warp far ahead with a single block, creating a gap between latest and finalized.
+    const currentTs = (await rollup.client.getBlock()).timestamp;
+    await cheatCodes.warp(Number(currentTs) + 600);
+
+    // First fetch — works but may not be finalized (warp only mines one block).
+    const result1 = await epochCache.getCommittee('now');
+    expect(result1.committee).toBeDefined();
+
+    // Mine some blocks to advance finalized, then advance time past TTL.
+    await cheatCodes.mine(5);
+    dateProvider.advanceTime(DefaultL1ContractsConfig.ethereumSlotDuration);
+
+    // Re-query: cache entry is stale, so it should re-fetch from L1.
+    const result2 = await epochCache.getCommittee('now');
+    expect(result2.committee).toBeDefined();
+    // The entry was successfully re-fetched (we got a result without throwing).
+  });
+
+  it('picks up changed seed after an L1 rollback once the cache TTL expires', async () => {
+    const epochDuration = await rollup.getEpochDuration();
+
+    // Disable interval mining BEFORE the warp to avoid race conditions where
+    // Anvil auto-mines blocks between the warp and the disable call. Enable
+    // automine so transactions are still mined immediately.
+    await cheatCodes.setIntervalMining(0);
+    await cheatCodes.setAutomine(true);
+
+    // Advance to a known point. The warp creates a gap between latest and finalized,
+    // keeping the epoch's sampling data non-finalized (TTL-cached, not permanent).
+    const currentTs = (await rollup.client.getBlock()).timestamp;
+    await cheatCodes.warp(Number(currentTs) + 600);
+    await cheatCodes.mine(3);
+
+    // Call setupEpoch so the contract captures prevrandao for the current epoch.
+    await rollupCheatCodes.setupEpoch();
+
+    // Record the epoch and populate the cache.
+    const epochBefore = epochCache.getEpochNow();
+    const before = await epochCache.getCommittee('now');
+    expect(before.committee).toBeDefined();
+    expect(epochCache.isFinalized(epochBefore)).toBe(false);
+
+    // Record the L1 block number at which the cache entry was fetched.
+    const l1BlockBefore = epochCache.getCachedL1BlockNumber(epochBefore);
+    expect(l1BlockBefore).toBeDefined();
+
+    // Rollback past the setupEpoch block and mine new blocks so the chain tip changes.
+    await cheatCodes.reorg(2);
+    await cheatCodes.mine(5);
+    await rollupCheatCodes.setupEpoch();
+
+    // Sync the dateProvider to the latest L1 block time since interval mining is off
+    // and the stdout-based sync may not update the dateProvider for automined blocks.
+    const latestBlock = await rollup.client.getBlock();
+    dateProvider.setTime(Number(latestBlock.timestamp) * 1000);
+
+    // Advance time well past TTL so the cached entry is stale.
+    // The TTL is one Ethereum slot (12s). We advance by 2x to ensure staleness
+    // regardless of small timestamp differences between the dateProvider and the
+    // L1 block timestamp stored in the cache entry.
+    dateProvider.advanceTime(DefaultL1ContractsConfig.ethereumSlotDuration * 2);
+
+    // Re-query the SAME epoch by passing an explicit slot number,
+    // so we don't accidentally query a different epoch if time advanced.
+    const slotForEpoch = SlotNumber(Number(epochBefore) * Number(epochDuration));
+    const after = await epochCache.getCommittee(slotForEpoch);
+    expect(after.committee).toBeDefined();
+    expect(after.epoch).toBe(before.epoch);
+
+    // The cache was re-fetched from L1: the L1 block number stored in the entry must
+    // have changed because the chain was reorged and new blocks were mined.
+    const l1BlockAfter = epochCache.getCachedL1BlockNumber(epochBefore);
+    expect(l1BlockAfter).toBeDefined();
+    expect(l1BlockAfter).not.toBe(l1BlockBefore);
+  });
+});

--- a/yarn-project/epoch-cache/src/epoch_cache.test.ts
+++ b/yarn-project/epoch-cache/src/epoch_cache.test.ts
@@ -13,8 +13,15 @@ import type { GetBlockReturnType } from 'viem';
 import { EpochCache, type EpochCommitteeInfo, PROPOSER_PIPELINING_SLOT_OFFSET } from './epoch_cache.js';
 
 class TestEpochCache extends EpochCache {
+  /** Seeds the cache with a finalized entry so tests don't need to hit the mock rollup for known epochs. */
   public seedCache(epoch: EpochNumber, committeeInfo: EpochCommitteeInfo): void {
-    this.cache.set(epoch, committeeInfo);
+    this.cache.set(epoch, {
+      data: committeeInfo,
+      l1BlockNumber: 0n,
+      l1BlockHash: '0x0000000000000000000000000000000000000000000000000000000000000000',
+      l1BlockTimestamp: BigInt(Math.floor(Date.now() / 1000)) + 10000n,
+      finalized: true,
+    });
   }
 
   public setCacheSize(size: number): void {
@@ -34,7 +41,6 @@ describe('EpochCache', () => {
   // Test constants
   const SLOT_DURATION = 12;
   const EPOCH_DURATION = 32; // 384 seconds
-  // const L1_GENESIS_TIME = 1000n;
   let l1GenesisTime: bigint;
 
   const testCommittee = [
@@ -56,13 +62,17 @@ describe('EpochCache', () => {
 
     l1GenesisTime = BigInt(Math.floor(Date.now() / 1000));
 
-    // Mock the client.getBlock method for timestamp retrieval
-    // Return a timestamp far enough in the future to accommodate test queries
-    // lagInEpochsForValidatorSet * epochDuration * slotDuration = 2 * 32 * 12 = 768 seconds
+    // Mock the client.getBlock method for timestamp retrieval.
+    // Return a timestamp far enough in the future to accommodate test queries.
+    // lagInEpochsForRandao * epochDuration * slotDuration = 2 * 32 * 12 = 768 seconds
     // Add extra buffer for random slots in tests (e.g., 1000 slots = 12000 seconds)
     client = mock<ViemPublicClient>();
     const futureTimestamp = l1GenesisTime + BigInt(768 + 12000);
-    client.getBlock.mockResolvedValue({ timestamp: futureTimestamp } as GetBlockReturnType);
+    client.getBlock.mockResolvedValue({
+      timestamp: futureTimestamp,
+      number: 100n,
+      hash: '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+    } as unknown as GetBlockReturnType);
     (rollupContract as any).client = client;
 
     // Setup fake timers
@@ -275,17 +285,170 @@ describe('EpochCache', () => {
 
     // Mock the client to return a current L1 timestamp that's close to genesis
     const currentL1Timestamp = l1GenesisTime + BigInt(100); // Just 100 seconds after genesis
-    client.getBlock.mockResolvedValue({ timestamp: currentL1Timestamp } as GetBlockReturnType);
+    client.getBlock.mockResolvedValue({
+      timestamp: currentL1Timestamp,
+      number: 1n,
+      hash: '0x0000000000000000000000000000000000000000000000000000000000000001',
+    } as unknown as GetBlockReturnType);
 
     // Calculate a slot far in the future (epoch 100) that's definitely not cached
-    // and is beyond the allowed lag (lagInEpochsForValidatorSet * epochDuration * slotDuration = 2 * 32 * 12 = 768 seconds)
+    // and is beyond the allowed lag
     const futureEpoch = BigInt(100);
     const futureSlot = futureEpoch * BigInt(epochDuration);
 
     // Attempt to get committee for this future slot should throw
     await expect(epochCache.getCommittee(SlotNumber.fromBigInt(futureSlot))).rejects.toThrow(
-      /Cannot query committee for future epoch.*with timestamp.*\(current L1 time is/,
+      /Cannot query committee for future epoch.*sampling timestamp.*beyond latest L1 block/,
     );
+  });
+
+  describe('TTL-based caching', () => {
+    it('should re-query non-finalized data after ethereumSlotDuration', async () => {
+      const epoch1Slot = SlotNumber(EPOCH_DURATION); // first slot of epoch 1
+      const epoch1Ts = l1GenesisTime + BigInt(EPOCH_DURATION * SLOT_DURATION);
+      // samplingTs = epochStartTs - lag*epochDuration*slotDuration = epoch1Ts - 768
+      // For epoch 1 with lag 2: samplingTs = l1GenesisTime + 384 - 768 = l1GenesisTime - 384
+      const samplingTs = epoch1Ts - BigInt(2 * EPOCH_DURATION * SLOT_DURATION);
+
+      // Use a "latest" timestamp close to the current wall-clock time so isStale works.
+      // samplingTs < l1GenesisTime, so even l1GenesisTime as latest satisfies the guard.
+      const mockBlock = () => {
+        const nowSec = BigInt(Math.floor(Date.now() / 1000));
+        return (args: any) => {
+          if (args?.blockTag === 'finalized') {
+            // Finalized is behind sampling ts → NOT finalized
+            return Promise.resolve({ timestamp: samplingTs - 1n, number: 50n, hash: '0xaaa' } as any);
+          }
+          // Latest tracks wall-clock time so isStale triggers correctly
+          return Promise.resolve({ timestamp: nowSec, number: 100n, hash: '0xbbb' } as any);
+        };
+      };
+
+      client.getBlock.mockImplementation(mockBlock());
+      rollupContract.getCommitteeAt.mockResolvedValue(testCommittee);
+      rollupContract.getSampleSeedAt.mockResolvedValue(Buffer32.fromBigInt(42n));
+
+      // First call: fetches from L1
+      const result1 = await epochCache.getCommittee(epoch1Slot);
+      expect(result1.committee).toEqual(testCommittee);
+      expect(epochCache.isFinalized(EpochNumber(1))).toBe(false);
+      expect(rollupContract.getCommitteeAt).toHaveBeenCalledTimes(1);
+
+      // Within TTL: should return cached, no new L1 call
+      rollupContract.getCommitteeAt.mockClear();
+      const result2 = await epochCache.getCommittee(epoch1Slot);
+      expect(result2.committee).toEqual(testCommittee);
+      expect(rollupContract.getCommitteeAt).toHaveBeenCalledTimes(0);
+
+      // Advance past TTL (ethereumSlotDuration = 12s)
+      jest.setSystemTime(Date.now() + SLOT_DURATION * 1000);
+      client.getBlock.mockImplementation(mockBlock());
+
+      const updatedCommittee = [...testCommittee, extraTestValidator];
+      rollupContract.getCommitteeAt.mockResolvedValue(updatedCommittee);
+      rollupContract.getSampleSeedAt.mockResolvedValue(Buffer32.fromBigInt(99n));
+
+      // After TTL: should re-query
+      const result3 = await epochCache.getCommittee(epoch1Slot);
+      expect(result3.committee).toEqual(updatedCommittee);
+      expect(result3.seed).toBe(99n);
+      expect(rollupContract.getCommitteeAt).toHaveBeenCalledTimes(1);
+    });
+
+    it('should NOT re-query finalized data after ethereumSlotDuration', async () => {
+      const epoch1Slot = SlotNumber(EPOCH_DURATION);
+      const epoch1Ts = l1GenesisTime + BigInt(EPOCH_DURATION * SLOT_DURATION);
+      const latestTs = epoch1Ts + 10000n;
+      // Finalized block is far enough that sampling ts <= finalizedTs
+      const finalizedTs = epoch1Ts + 10000n;
+
+      client.getBlock.mockImplementation((args: any) => {
+        if (args?.blockTag === 'finalized') {
+          return Promise.resolve({ timestamp: finalizedTs, number: 90n, hash: '0xccc' } as any);
+        }
+        return Promise.resolve({ timestamp: latestTs, number: 100n, hash: '0xddd' } as any);
+      });
+
+      rollupContract.getCommitteeAt.mockResolvedValue(testCommittee);
+      rollupContract.getSampleSeedAt.mockResolvedValue(Buffer32.fromBigInt(42n));
+
+      await epochCache.getCommittee(epoch1Slot);
+      expect(epochCache.isFinalized(EpochNumber(1))).toBe(true);
+      expect(rollupContract.getCommitteeAt).toHaveBeenCalledTimes(1);
+
+      // Advance well past TTL
+      jest.setSystemTime(Date.now() + SLOT_DURATION * 10 * 1000);
+      rollupContract.getCommitteeAt.mockClear();
+
+      // Should still return cached data, no re-query
+      await epochCache.getCommittee(epoch1Slot);
+      expect(rollupContract.getCommitteeAt).toHaveBeenCalledTimes(0);
+    });
+
+    it('should coalesce concurrent requests for the same epoch', async () => {
+      const epoch1Slot = SlotNumber(EPOCH_DURATION);
+      const epoch1Ts = l1GenesisTime + BigInt(EPOCH_DURATION * SLOT_DURATION);
+      const latestTs = epoch1Ts + 10000n;
+
+      client.getBlock.mockResolvedValue({
+        timestamp: latestTs,
+        number: 100n,
+        hash: '0xeee',
+      } as any);
+
+      let resolveCommittee: (v: EthAddress[]) => void;
+      rollupContract.getCommitteeAt.mockImplementation(() => new Promise(resolve => (resolveCommittee = resolve)));
+      rollupContract.getSampleSeedAt.mockResolvedValue(Buffer32.fromBigInt(0n));
+
+      // Fire two concurrent requests
+      const p1 = epochCache.getCommittee(epoch1Slot);
+      const p2 = epochCache.getCommittee(epoch1Slot);
+
+      // Only one L1 call should be in-flight
+      expect(rollupContract.getCommitteeAt).toHaveBeenCalledTimes(1);
+
+      // Resolve and both promises should return the same result
+      resolveCommittee!(testCommittee);
+      const [r1, r2] = await Promise.all([p1, p2]);
+      expect(r1.committee).toEqual(testCommittee);
+      expect(r2.committee).toEqual(testCommittee);
+    });
+
+    it('should eventually mark a non-finalized entry as finalized on re-query', async () => {
+      const epoch1Slot = SlotNumber(EPOCH_DURATION);
+      const epoch1Ts = l1GenesisTime + BigInt(EPOCH_DURATION * SLOT_DURATION);
+      const samplingTs = epoch1Ts - BigInt(2 * EPOCH_DURATION * SLOT_DURATION); // lag=2
+      const nowSec = BigInt(Math.floor(Date.now() / 1000));
+
+      // First call: not finalized (finalized block behind sampling ts)
+      client.getBlock.mockImplementation((args: any) => {
+        if (args?.blockTag === 'finalized') {
+          return Promise.resolve({ timestamp: samplingTs - 1n, number: 50n, hash: '0xf1' } as any);
+        }
+        return Promise.resolve({ timestamp: nowSec, number: 100n, hash: '0xf2' } as any);
+      });
+
+      rollupContract.getCommitteeAt.mockResolvedValue(testCommittee);
+      rollupContract.getSampleSeedAt.mockResolvedValue(Buffer32.fromBigInt(42n));
+
+      await epochCache.getCommittee(epoch1Slot);
+      expect(epochCache.isFinalized(EpochNumber(1))).toBe(false);
+
+      // Advance past TTL
+      jest.setSystemTime(Date.now() + SLOT_DURATION * 1000);
+      const newNowSec = BigInt(Math.floor(Date.now() / 1000));
+
+      // Second call: now finalized (finalized block caught up)
+      client.getBlock.mockImplementation((args: any) => {
+        if (args?.blockTag === 'finalized') {
+          return Promise.resolve({ timestamp: samplingTs + 1n, number: 90n, hash: '0xf3' } as any);
+        }
+        return Promise.resolve({ timestamp: newNowSec, number: 110n, hash: '0xf4' } as any);
+      });
+
+      await epochCache.getCommittee(epoch1Slot);
+      expect(epochCache.isFinalized(EpochNumber(1))).toBe(true);
+    });
   });
 
   describe('proposer pipelining', () => {

--- a/yarn-project/epoch-cache/src/epoch_cache.test.ts
+++ b/yarn-project/epoch-cache/src/epoch_cache.test.ts
@@ -17,9 +17,9 @@ class TestEpochCache extends EpochCache {
   public seedCache(epoch: EpochNumber, committeeInfo: EpochCommitteeInfo): void {
     this.cache.set(epoch, {
       data: committeeInfo,
-      l1BlockNumber: 0n,
-      l1BlockHash: '0x0000000000000000000000000000000000000000000000000000000000000000',
-      l1BlockTimestamp: BigInt(Math.floor(Date.now() / 1000)) + 10000n,
+      lastQueryL1BlockNumber: 0n,
+      lastQueryL1BlockHash: '0x0000000000000000000000000000000000000000000000000000000000000000',
+      lastRefreshL1Timestamp: BigInt(Math.floor(Date.now() / 1000)) + 10000n,
       finalized: true,
     });
   }

--- a/yarn-project/epoch-cache/src/epoch_cache.test.ts
+++ b/yarn-project/epoch-cache/src/epoch_cache.test.ts
@@ -303,23 +303,21 @@ describe('EpochCache', () => {
   });
 
   describe('TTL-based caching', () => {
-    it('should re-query non-finalized data after ethereumSlotDuration', async () => {
-      const epoch1Slot = SlotNumber(EPOCH_DURATION); // first slot of epoch 1
-      const epoch1Ts = l1GenesisTime + BigInt(EPOCH_DURATION * SLOT_DURATION);
-      // samplingTs = epochStartTs - lag*epochDuration*slotDuration = epoch1Ts - 768
-      // For epoch 1 with lag 2: samplingTs = l1GenesisTime + 384 - 768 = l1GenesisTime - 384
-      const samplingTs = epoch1Ts - BigInt(2 * EPOCH_DURATION * SLOT_DURATION);
+    it('should do a lightweight refresh (no full re-fetch) after TTL if no reorg', async () => {
+      const epoch1Slot = SlotNumber(EPOCH_DURATION);
+      const samplingTs =
+        l1GenesisTime + BigInt(EPOCH_DURATION * SLOT_DURATION) - BigInt(2 * EPOCH_DURATION * SLOT_DURATION);
 
-      // Use a "latest" timestamp close to the current wall-clock time so isStale works.
-      // samplingTs < l1GenesisTime, so even l1GenesisTime as latest satisfies the guard.
       const mockBlock = () => {
         const nowSec = BigInt(Math.floor(Date.now() / 1000));
         return (args: any) => {
           if (args?.blockTag === 'finalized') {
-            // Finalized is behind sampling ts → NOT finalized
             return Promise.resolve({ timestamp: samplingTs - 1n, number: 50n, hash: '0xaaa' } as any);
           }
-          // Latest tracks wall-clock time so isStale triggers correctly
+          // Return the SAME hash for blockNumber queries (no reorg)
+          if (args?.blockNumber !== undefined) {
+            return Promise.resolve({ timestamp: nowSec, number: args.blockNumber, hash: '0xbbb' } as any);
+          }
           return Promise.resolve({ timestamp: nowSec, number: 100n, hash: '0xbbb' } as any);
         };
       };
@@ -328,31 +326,62 @@ describe('EpochCache', () => {
       rollupContract.getCommitteeAt.mockResolvedValue(testCommittee);
       rollupContract.getSampleSeedAt.mockResolvedValue(Buffer32.fromBigInt(42n));
 
-      // First call: fetches from L1
+      // First call: full fetch
       const result1 = await epochCache.getCommittee(epoch1Slot);
       expect(result1.committee).toEqual(testCommittee);
-      expect(epochCache.isFinalized(EpochNumber(1))).toBe(false);
       expect(rollupContract.getCommitteeAt).toHaveBeenCalledTimes(1);
-
-      // Within TTL: should return cached, no new L1 call
       rollupContract.getCommitteeAt.mockClear();
-      const result2 = await epochCache.getCommittee(epoch1Slot);
-      expect(result2.committee).toEqual(testCommittee);
-      expect(rollupContract.getCommitteeAt).toHaveBeenCalledTimes(0);
 
-      // Advance past TTL (ethereumSlotDuration = 12s)
+      // Advance past TTL
       jest.setSystemTime(Date.now() + SLOT_DURATION * 1000);
       client.getBlock.mockImplementation(mockBlock());
 
+      // After TTL: lightweight refresh — block hash matches, so NO call to getCommitteeAt
+      const result2 = await epochCache.getCommittee(epoch1Slot);
+      expect(result2.committee).toEqual(testCommittee); // same data, no reorg
+      expect(result2.seed).toBe(42n);
+      expect(rollupContract.getCommitteeAt).toHaveBeenCalledTimes(0);
+    });
+
+    it('should do a full re-fetch after TTL if a reorg is detected', async () => {
+      const epoch1Slot = SlotNumber(EPOCH_DURATION);
+      const samplingTs =
+        l1GenesisTime + BigInt(EPOCH_DURATION * SLOT_DURATION) - BigInt(2 * EPOCH_DURATION * SLOT_DURATION);
+
+      const mockBlock = (hash: string) => {
+        const nowSec = BigInt(Math.floor(Date.now() / 1000));
+        return (args: any) => {
+          if (args?.blockTag === 'finalized') {
+            return Promise.resolve({ timestamp: samplingTs - 1n, number: 50n, hash: '0xfin' } as any);
+          }
+          if (args?.blockNumber !== undefined) {
+            return Promise.resolve({ timestamp: nowSec, number: args.blockNumber, hash } as any);
+          }
+          return Promise.resolve({ timestamp: nowSec, number: 100n, hash } as any);
+        };
+      };
+
+      client.getBlock.mockImplementation(mockBlock('0xoriginal'));
+      rollupContract.getCommitteeAt.mockResolvedValue(testCommittee);
+      rollupContract.getSampleSeedAt.mockResolvedValue(Buffer32.fromBigInt(42n));
+
+      await epochCache.getCommittee(epoch1Slot);
+      expect(rollupContract.getCommitteeAt).toHaveBeenCalledTimes(1);
+      rollupContract.getCommitteeAt.mockClear();
+
+      // Advance past TTL
+      jest.setSystemTime(Date.now() + SLOT_DURATION * 1000);
+
+      // Simulate reorg: block at the same number now has a different hash
       const updatedCommittee = [...testCommittee, extraTestValidator];
+      client.getBlock.mockImplementation(mockBlock('0xreorged'));
       rollupContract.getCommitteeAt.mockResolvedValue(updatedCommittee);
       rollupContract.getSampleSeedAt.mockResolvedValue(Buffer32.fromBigInt(99n));
 
-      // After TTL: should re-query
-      const result3 = await epochCache.getCommittee(epoch1Slot);
-      expect(result3.committee).toEqual(updatedCommittee);
-      expect(result3.seed).toBe(99n);
-      expect(rollupContract.getCommitteeAt).toHaveBeenCalledTimes(1);
+      const result = await epochCache.getCommittee(epoch1Slot);
+      expect(result.committee).toEqual(updatedCommittee);
+      expect(result.seed).toBe(99n);
+      expect(rollupContract.getCommitteeAt).toHaveBeenCalledTimes(1); // full re-fetch
     });
 
     it('should NOT re-query finalized data after ethereumSlotDuration', async () => {

--- a/yarn-project/epoch-cache/src/epoch_cache.ts
+++ b/yarn-project/epoch-cache/src/epoch_cache.ts
@@ -13,6 +13,7 @@ import {
   getSlotAtNextL1Block,
   getSlotAtTimestamp,
   getSlotRangeForEpoch,
+  getStartTimestampForEpoch,
   getTimestampForSlot,
 } from '@aztec/stdlib/epoch-helpers';
 
@@ -39,6 +40,19 @@ export type EpochCommitteeInfo = {
 };
 
 export type SlotTag = 'now' | 'next' | SlotNumber;
+
+/** Resolved cache entry with L1 provenance metadata. */
+type CachedEpochEntry = {
+  data: EpochCommitteeInfo;
+  /** L1 block number at which we queried. */
+  l1BlockNumber: bigint;
+  /** L1 block hash at which we queried. */
+  l1BlockHash: `0x${string}`;
+  /** L1 block timestamp at which we queried. */
+  l1BlockTimestamp: bigint;
+  /** Whether the epoch's sampling data falls within finalized L1 history. */
+  finalized: boolean;
+};
 
 export interface EpochCacheInterface {
   getCommittee(slot: SlotTag | undefined): Promise<EpochCommitteeInfo>;
@@ -74,8 +88,12 @@ export interface EpochCacheInterface {
  * Note: This class is very dependent on the system clock being in sync.
  */
 export class EpochCache implements EpochCacheInterface {
+  /**
+   * Single map holding both resolved entries and in-flight promises.
+   * A `Promise` value means a fetch is in progress; concurrent callers await it.
+   */
   // eslint-disable-next-line aztec-custom/no-non-primitive-in-collections
-  protected cache: Map<EpochNumber, EpochCommitteeInfo> = new Map();
+  protected cache: Map<EpochNumber, CachedEpochEntry | Promise<CachedEpochEntry>> = new Map();
   private allValidators: Set<string> = new Set();
   private lastValidatorRefresh = 0;
   private readonly log: Logger = createLogger('epoch-cache');
@@ -229,17 +247,8 @@ export class EpochCache implements EpochCacheInterface {
     return this.getCommittee(startSlot);
   }
 
-  /**
-   * Returns whether the escape hatch is open for the given epoch.
-   *
-   * Uses the already-cached EpochCommitteeInfo when available. If not cached, it will fetch
-   * the epoch committee info (which includes the escape hatch flag) and return it.
-   */
+  /** Returns whether the escape hatch is open for the given epoch. */
   public async isEscapeHatchOpen(epoch: EpochNumber): Promise<boolean> {
-    const cached = this.cache.get(epoch);
-    if (cached) {
-      return cached.isEscapeHatchOpen;
-    }
     const info = await this.getCommitteeForEpoch(epoch);
     return info.isEscapeHatchOpen;
   }
@@ -262,30 +271,42 @@ export class EpochCache implements EpochCacheInterface {
   }
 
   /**
-   * Get the current validator set
-   * @param nextSlot - If true, get the validator set for the next slot.
-   * @returns The current validator set.
+   * Get the current validator set.
+   *
+   * Returns cached data if the entry is finalized or still fresh (queried less than one
+   * Ethereum slot ago). Stale non-finalized entries are re-queried, and concurrent callers
+   * coalesce on the same in-flight promise so the L1 query happens only once.
    */
   public async getCommittee(slot: SlotTag = 'now'): Promise<EpochCommitteeInfo> {
     const { epoch, ts } = this.getEpochAndTimestamp(slot);
 
-    if (this.cache.has(epoch)) {
-      return this.cache.get(epoch)!;
+    const cached = this.cache.get(epoch);
+
+    // In-flight promise: another caller is already fetching this epoch — just await it.
+    if (cached instanceof Promise) {
+      return (await cached).data;
     }
 
-    const epochData = await this.computeCommittee({ epoch, ts });
-    // If the committee size is 0 or undefined, then do not cache
-    if (!epochData.committee || epochData.committee.length === 0) {
-      return epochData;
+    // Resolved entry: return it if finalized or still fresh.
+    if (cached && (cached.finalized || !this.isStale(cached))) {
+      return cached.data;
     }
-    this.cache.set(epoch, epochData);
 
-    const toPurge = Array.from(this.cache.keys())
-      .sort((a, b) => Number(b - a))
-      .slice(this.config.cacheSize);
-    toPurge.forEach(key => this.cache.delete(key));
-
-    return epochData;
+    // No entry, or stale non-finalized entry: start a fetch and store the promise in the cache.
+    const promise = this.fetchAndCache(epoch, ts);
+    this.cache.set(epoch, promise);
+    try {
+      return (await promise).data;
+    } catch (err) {
+      // On failure, remove the promise so the next caller retries instead of awaiting a rejected promise.
+      // If the old stale entry is still useful, restore it; otherwise just delete.
+      if (cached) {
+        this.cache.set(epoch, cached);
+      } else {
+        this.cache.delete(epoch);
+      }
+      throw err;
+    }
   }
 
   private getEpochAndTimestamp(slot: SlotTag = 'now'): { epoch: EpochNumber; ts: bigint } {
@@ -298,22 +319,82 @@ export class EpochCache implements EpochCacheInterface {
     }
   }
 
-  private async computeCommittee(when: { epoch: EpochNumber; ts: bigint }): Promise<EpochCommitteeInfo> {
-    const { ts, epoch } = when;
-    const [committee, seedBuffer, l1Timestamp, isEscapeHatchOpen] = await Promise.all([
+  /** Returns true if a non-finalized cache entry is older than one Ethereum slot. */
+  private isStale(entry: CachedEpochEntry): boolean {
+    const nowSeconds = BigInt(this.dateProvider.nowInSeconds());
+    return nowSeconds - entry.l1BlockTimestamp >= BigInt(this.l1constants.ethereumSlotDuration);
+  }
+
+  /** Whether a cached epoch entry has been marked as finalized. Returns undefined if not cached or still in-flight. */
+  public isFinalized(epoch: EpochNumber): boolean | undefined {
+    const entry = this.cache.get(epoch);
+    if (!entry || entry instanceof Promise) {
+      return undefined;
+    }
+    return entry.finalized;
+  }
+
+  /** Returns the L1 block number at which the cached entry was queried. Undefined if not cached or in-flight. */
+  public getCachedL1BlockNumber(epoch: EpochNumber): bigint | undefined {
+    const entry = this.cache.get(epoch);
+    if (!entry || entry instanceof Promise) {
+      return undefined;
+    }
+    return entry.l1BlockNumber;
+  }
+
+  /**
+   * Fetches committee data from L1, determines finalization status, and stores in the cache.
+   *
+   * Uses `lagInEpochsForRandao` (the binding constraint, always <= lagInEpochsForValidatorSet)
+   * and computes the sampling timestamp from the epoch start to match the L1 contract's logic.
+   */
+  private async fetchAndCache(epoch: EpochNumber, ts: bigint): Promise<CachedEpochEntry> {
+    const [committee, seedBuffer, l1Block, l1FinalizedBlock, isEscapeHatchOpen] = await Promise.all([
       this.rollup.getCommitteeAt(ts),
       this.rollup.getSampleSeedAt(ts),
-      this.rollup.client.getBlock({ includeTransactions: false }).then(b => b.timestamp),
+      this.rollup.client.getBlock({ includeTransactions: false }),
+      this.rollup.client.getBlock({ blockTag: 'finalized', includeTransactions: false }),
       this.rollup.isEscapeHatchOpen(epoch),
     ]);
-    const { lagInEpochsForValidatorSet, epochDuration, slotDuration } = this.l1constants;
-    const sub = BigInt(lagInEpochsForValidatorSet) * BigInt(epochDuration) * BigInt(slotDuration);
-    if (ts - sub > l1Timestamp) {
+
+    const { lagInEpochsForRandao, epochDuration, slotDuration } = this.l1constants;
+    const epochStartTs = getStartTimestampForEpoch(epoch, this.l1constants);
+    const lagSeconds = BigInt(lagInEpochsForRandao) * BigInt(epochDuration) * BigInt(slotDuration);
+    const samplingTs = epochStartTs - lagSeconds;
+
+    if (samplingTs > l1Block.timestamp) {
       throw new Error(
-        `Cannot query committee for future epoch ${epoch} with timestamp ${ts} (current L1 time is ${l1Timestamp}). Check your Ethereum node is synced.`,
+        `Cannot query committee for future epoch ${epoch}: ` +
+          `sampling timestamp ${samplingTs} is beyond latest L1 block at ${l1Block.timestamp}. ` +
+          `Check your Ethereum node is synced.`,
       );
     }
-    return { committee, seed: seedBuffer.toBigInt(), epoch, isEscapeHatchOpen };
+
+    const finalized = samplingTs <= l1FinalizedBlock.timestamp;
+    const data: EpochCommitteeInfo = { committee, seed: seedBuffer.toBigInt(), epoch, isEscapeHatchOpen };
+    const entry: CachedEpochEntry = {
+      data,
+      l1BlockNumber: l1Block.number!,
+      l1BlockHash: l1Block.hash!,
+      l1BlockTimestamp: l1Block.timestamp,
+      finalized,
+    };
+
+    if (data.committee && data.committee.length > 0) {
+      this.cache.set(epoch, entry);
+      // LRU purge: only count resolved entries
+      const resolved = Array.from(this.cache.entries()).filter(([, v]) => !(v instanceof Promise));
+      if (resolved.length > this.config.cacheSize) {
+        const toPurge = resolved.sort(([a], [b]) => Number(b - a)).slice(this.config.cacheSize);
+        toPurge.forEach(([key]) => this.cache.delete(key));
+      }
+    } else {
+      // Don't cache empty committees — remove the in-flight promise placeholder.
+      this.cache.delete(epoch);
+    }
+
+    return entry;
   }
 
   /**

--- a/yarn-project/epoch-cache/src/epoch_cache.ts
+++ b/yarn-project/epoch-cache/src/epoch_cache.ts
@@ -292,19 +292,26 @@ export class EpochCache implements EpochCacheInterface {
       return cached.data;
     }
 
-    // No entry, or stale non-finalized entry: start a fetch and store the promise in the cache.
+    // Stale non-finalized entry: do a lightweight refresh first (check block hash + finalized ts).
+    // Only fall back to a full re-fetch if the L1 block was reorged.
+    if (cached) {
+      const promise = this.refreshStaleEntry(cached, epoch, ts);
+      this.cache.set(epoch, promise);
+      try {
+        return (await promise).data;
+      } catch (err) {
+        this.cache.set(epoch, cached);
+        throw err;
+      }
+    }
+
+    // No entry at all: full fetch.
     const promise = this.fetchAndCache(epoch, ts);
     this.cache.set(epoch, promise);
     try {
       return (await promise).data;
     } catch (err) {
-      // On failure, remove the promise so the next caller retries instead of awaiting a rejected promise.
-      // If the old stale entry is still useful, restore it; otherwise just delete.
-      if (cached) {
-        this.cache.set(epoch, cached);
-      } else {
-        this.cache.delete(epoch);
-      }
+      this.cache.delete(epoch);
       throw err;
     }
   }
@@ -317,6 +324,17 @@ export class EpochCache implements EpochCacheInterface {
     } else {
       return this.getEpochAndSlotAtSlot(slot);
     }
+  }
+
+  /** Evicts oldest cache entries (resolved or in-flight) beyond cacheSize. */
+  private purgeCache(): void {
+    if (this.cache.size <= this.config.cacheSize) {
+      return;
+    }
+    const toPurge = Array.from(this.cache.keys())
+      .sort((a, b) => Number(b - a))
+      .slice(this.config.cacheSize);
+    toPurge.forEach(key => this.cache.delete(key));
   }
 
   /** Returns true if a non-finalized cache entry is older than one Ethereum slot. */
@@ -343,6 +361,53 @@ export class EpochCache implements EpochCacheInterface {
     return entry.l1BlockNumber;
   }
 
+  /** Computes the sampling timestamp for an epoch's committee data. */
+  private getSamplingTimestamp(epoch: EpochNumber): bigint {
+    const { lagInEpochsForRandao, epochDuration, slotDuration } = this.l1constants;
+    const epochStartTs = getStartTimestampForEpoch(epoch, this.l1constants);
+    return epochStartTs - BigInt(lagInEpochsForRandao) * BigInt(epochDuration) * BigInt(slotDuration);
+  }
+
+  /**
+   * Lightweight refresh for a stale non-finalized entry. Queries only the block hash at
+   * the original block number and the finalized block timestamp — avoids the expensive
+   * getCommitteeAt and getSampleSeedAt calls on the rollup contract.
+   *
+   * If the block hash still matches (no L1 reorg), we keep the existing data and just
+   * update the provenance timestamp. If the finalized block has caught up, we promote the
+   * entry to finalized. If there was a reorg (hash mismatch), we fall back to a full fetch.
+   */
+  private async refreshStaleEntry(stale: CachedEpochEntry, epoch: EpochNumber, ts: bigint): Promise<CachedEpochEntry> {
+    const [blockAtOriginal, l1FinalizedBlock] = await Promise.all([
+      this.rollup.client.getBlock({ blockNumber: stale.l1BlockNumber, includeTransactions: false }),
+      this.rollup.client.getBlock({ blockTag: 'finalized', includeTransactions: false }),
+    ]);
+
+    if (blockAtOriginal.hash === stale.l1BlockHash) {
+      // No reorg: the data is still valid. Check if we can now mark it as finalized.
+      const samplingTs = this.getSamplingTimestamp(epoch);
+      const finalized =
+        !!(stale.data.committee && stale.data.committee.length > 0) && samplingTs <= l1FinalizedBlock.timestamp;
+
+      const latestBlock = await this.rollup.client.getBlock({ includeTransactions: false });
+      const refreshed: CachedEpochEntry = {
+        ...stale,
+        l1BlockTimestamp: latestBlock.timestamp,
+        finalized,
+      };
+      this.cache.set(epoch, refreshed);
+      return refreshed;
+    }
+
+    // Reorg detected: block hash mismatch. Do a full re-fetch.
+    this.log.warn(`L1 reorg detected for epoch ${epoch}: block ${stale.l1BlockNumber} hash changed`, {
+      epoch,
+      expectedHash: stale.l1BlockHash,
+      actualHash: blockAtOriginal.hash,
+    });
+    return this.fetchAndCache(epoch, ts);
+  }
+
   /**
    * Fetches committee data from L1, determines finalization status, and stores in the cache.
    *
@@ -358,10 +423,7 @@ export class EpochCache implements EpochCacheInterface {
       this.rollup.isEscapeHatchOpen(epoch),
     ]);
 
-    const { lagInEpochsForRandao, epochDuration, slotDuration } = this.l1constants;
-    const epochStartTs = getStartTimestampForEpoch(epoch, this.l1constants);
-    const lagSeconds = BigInt(lagInEpochsForRandao) * BigInt(epochDuration) * BigInt(slotDuration);
-    const samplingTs = epochStartTs - lagSeconds;
+    const samplingTs = this.getSamplingTimestamp(epoch);
 
     if (samplingTs > l1Block.timestamp) {
       throw new Error(
@@ -371,7 +433,9 @@ export class EpochCache implements EpochCacheInterface {
       );
     }
 
-    const finalized = samplingTs <= l1FinalizedBlock.timestamp;
+    // Empty committees are never marked finalized so they always get re-queried after TTL.
+    const hasCommittee = !!(committee && committee.length > 0);
+    const finalized = hasCommittee && samplingTs <= l1FinalizedBlock.timestamp;
     const data: EpochCommitteeInfo = { committee, seed: seedBuffer.toBigInt(), epoch, isEscapeHatchOpen };
     const entry: CachedEpochEntry = {
       data,
@@ -381,18 +445,8 @@ export class EpochCache implements EpochCacheInterface {
       finalized,
     };
 
-    if (data.committee && data.committee.length > 0) {
-      this.cache.set(epoch, entry);
-      // LRU purge: only count resolved entries
-      const resolved = Array.from(this.cache.entries()).filter(([, v]) => !(v instanceof Promise));
-      if (resolved.length > this.config.cacheSize) {
-        const toPurge = resolved.sort(([a], [b]) => Number(b - a)).slice(this.config.cacheSize);
-        toPurge.forEach(([key]) => this.cache.delete(key));
-      }
-    } else {
-      // Don't cache empty committees — remove the in-flight promise placeholder.
-      this.cache.delete(epoch);
-    }
+    this.cache.set(epoch, entry);
+    this.purgeCache();
 
     return entry;
   }

--- a/yarn-project/epoch-cache/src/epoch_cache.ts
+++ b/yarn-project/epoch-cache/src/epoch_cache.ts
@@ -44,12 +44,12 @@ export type SlotTag = 'now' | 'next' | SlotNumber;
 /** Resolved cache entry with L1 provenance metadata. */
 type CachedEpochEntry = {
   data: EpochCommitteeInfo;
-  /** L1 block number at which we queried. */
-  l1BlockNumber: bigint;
-  /** L1 block hash at which we queried. */
-  l1BlockHash: `0x${string}`;
-  /** L1 block timestamp at which we queried. */
-  l1BlockTimestamp: bigint;
+  /** L1 block number at which the committee data was originally queried. */
+  lastQueryL1BlockNumber: bigint;
+  /** L1 block hash at which the committee data was originally queried. Used to detect reorgs. */
+  lastQueryL1BlockHash: `0x${string}`;
+  /** Latest L1 block timestamp at the time of the most recent refresh (full fetch or lightweight check). */
+  lastRefreshL1Timestamp: bigint;
   /** Whether the epoch's sampling data falls within finalized L1 history. */
   finalized: boolean;
 };
@@ -340,7 +340,7 @@ export class EpochCache implements EpochCacheInterface {
   /** Returns true if a non-finalized cache entry is older than one Ethereum slot. */
   private isStale(entry: CachedEpochEntry): boolean {
     const nowSeconds = BigInt(this.dateProvider.nowInSeconds());
-    return nowSeconds - entry.l1BlockTimestamp >= BigInt(this.l1constants.ethereumSlotDuration);
+    return nowSeconds - entry.lastRefreshL1Timestamp >= BigInt(this.l1constants.ethereumSlotDuration);
   }
 
   /** Whether a cached epoch entry has been marked as finalized. Returns undefined if not cached or still in-flight. */
@@ -352,13 +352,13 @@ export class EpochCache implements EpochCacheInterface {
     return entry.finalized;
   }
 
-  /** Returns the L1 block number at which the cached entry was queried. Undefined if not cached or in-flight. */
-  public getCachedL1BlockNumber(epoch: EpochNumber): bigint | undefined {
+  /** Returns the latest L1 timestamp stored in the cached entry. Undefined if not cached or in-flight. */
+  public getCachedLastRefreshL1Timestamp(epoch: EpochNumber): bigint | undefined {
     const entry = this.cache.get(epoch);
     if (!entry || entry instanceof Promise) {
       return undefined;
     }
-    return entry.l1BlockNumber;
+    return entry.lastRefreshL1Timestamp;
   }
 
   /** Computes the sampling timestamp for an epoch's committee data. */
@@ -378,21 +378,21 @@ export class EpochCache implements EpochCacheInterface {
    * entry to finalized. If there was a reorg (hash mismatch), we fall back to a full fetch.
    */
   private async refreshStaleEntry(stale: CachedEpochEntry, epoch: EpochNumber, ts: bigint): Promise<CachedEpochEntry> {
-    const [blockAtOriginal, l1FinalizedBlock] = await Promise.all([
-      this.rollup.client.getBlock({ blockNumber: stale.l1BlockNumber, includeTransactions: false }),
+    const [blockAtOriginal, l1FinalizedBlock, latestBlock] = await Promise.all([
+      this.rollup.client.getBlock({ blockNumber: stale.lastQueryL1BlockNumber, includeTransactions: false }),
       this.rollup.client.getBlock({ blockTag: 'finalized', includeTransactions: false }),
+      this.rollup.client.getBlock({ includeTransactions: false }),
     ]);
 
-    if (blockAtOriginal.hash === stale.l1BlockHash) {
+    if (blockAtOriginal.hash === stale.lastQueryL1BlockHash) {
       // No reorg: the data is still valid. Check if we can now mark it as finalized.
       const samplingTs = this.getSamplingTimestamp(epoch);
       const finalized =
         !!(stale.data.committee && stale.data.committee.length > 0) && samplingTs <= l1FinalizedBlock.timestamp;
 
-      const latestBlock = await this.rollup.client.getBlock({ includeTransactions: false });
       const refreshed: CachedEpochEntry = {
         ...stale,
-        l1BlockTimestamp: latestBlock.timestamp,
+        lastRefreshL1Timestamp: latestBlock.timestamp,
         finalized,
       };
       this.cache.set(epoch, refreshed);
@@ -400,12 +400,16 @@ export class EpochCache implements EpochCacheInterface {
     }
 
     // Reorg detected: block hash mismatch. Do a full re-fetch.
-    this.log.warn(`L1 reorg detected for epoch ${epoch}: block ${stale.l1BlockNumber} hash changed`, {
+    // Pass the already-fetched block timestamps to avoid redundant queries.
+    this.log.warn(`L1 reorg detected for epoch ${epoch}: block ${stale.lastQueryL1BlockNumber} hash changed`, {
       epoch,
-      expectedHash: stale.l1BlockHash,
+      expectedHash: stale.lastQueryL1BlockHash,
       actualHash: blockAtOriginal.hash,
     });
-    return this.fetchAndCache(epoch, ts);
+    return this.fetchAndCache(epoch, ts, {
+      latestTimestamp: latestBlock.timestamp,
+      finalizedTimestamp: l1FinalizedBlock.timestamp,
+    });
   }
 
   /**
@@ -414,21 +418,32 @@ export class EpochCache implements EpochCacheInterface {
    * Uses `lagInEpochsForRandao` (the binding constraint, always <= lagInEpochsForValidatorSet)
    * and computes the sampling timestamp from the epoch start to match the L1 contract's logic.
    */
-  private async fetchAndCache(epoch: EpochNumber, ts: bigint): Promise<CachedEpochEntry> {
+  private async fetchAndCache(
+    epoch: EpochNumber,
+    ts: bigint,
+    prefetched?: { latestTimestamp: bigint; finalizedTimestamp: bigint },
+  ): Promise<CachedEpochEntry> {
     const [committee, seedBuffer, l1Block, l1FinalizedBlock, isEscapeHatchOpen] = await Promise.all([
       this.rollup.getCommitteeAt(ts),
       this.rollup.getSampleSeedAt(ts),
-      this.rollup.client.getBlock({ includeTransactions: false }),
-      this.rollup.client.getBlock({ blockTag: 'finalized', includeTransactions: false }),
+      prefetched
+        ? ({ number: 0n, hash: '0x', timestamp: prefetched.latestTimestamp } as const)
+        : this.rollup.client.getBlock({ includeTransactions: false }),
+      prefetched
+        ? ({ timestamp: prefetched.finalizedTimestamp } as const)
+        : this.rollup.client.getBlock({ blockTag: 'finalized', includeTransactions: false }),
       this.rollup.isEscapeHatchOpen(epoch),
     ]);
 
+    // When timestamps are prefetched we still need the actual latest block for provenance.
+    const latestBlock = prefetched ? await this.rollup.client.getBlock({ includeTransactions: false }) : l1Block;
+
     const samplingTs = this.getSamplingTimestamp(epoch);
 
-    if (samplingTs > l1Block.timestamp) {
+    if (samplingTs > latestBlock.timestamp) {
       throw new Error(
         `Cannot query committee for future epoch ${epoch}: ` +
-          `sampling timestamp ${samplingTs} is beyond latest L1 block at ${l1Block.timestamp}. ` +
+          `sampling timestamp ${samplingTs} is beyond latest L1 block at ${latestBlock.timestamp}. ` +
           `Check your Ethereum node is synced.`,
       );
     }
@@ -439,9 +454,9 @@ export class EpochCache implements EpochCacheInterface {
     const data: EpochCommitteeInfo = { committee, seed: seedBuffer.toBigInt(), epoch, isEscapeHatchOpen };
     const entry: CachedEpochEntry = {
       data,
-      l1BlockNumber: l1Block.number!,
-      l1BlockHash: l1Block.hash!,
-      l1BlockTimestamp: l1Block.timestamp,
+      lastQueryL1BlockNumber: latestBlock.number!,
+      lastQueryL1BlockHash: latestBlock.hash!,
+      lastRefreshL1Timestamp: latestBlock.timestamp,
       finalized,
     };
 

--- a/yarn-project/epoch-cache/src/epoch_cache.ts
+++ b/yarn-project/epoch-cache/src/epoch_cache.ts
@@ -41,6 +41,9 @@ export type EpochCommitteeInfo = {
 
 export type SlotTag = 'now' | 'next' | SlotNumber;
 
+/** Minimal L1 block info used for cache provenance. */
+type L1BlockInfo = { number: bigint; hash: `0x${string}`; timestamp: bigint };
+
 /** Resolved cache entry with L1 provenance metadata. */
 type CachedEpochEntry = {
   data: EpochCommitteeInfo;
@@ -406,10 +409,7 @@ export class EpochCache implements EpochCacheInterface {
       expectedHash: stale.lastQueryL1BlockHash,
       actualHash: blockAtOriginal.hash,
     });
-    return this.fetchAndCache(epoch, ts, {
-      latestTimestamp: latestBlock.timestamp,
-      finalizedTimestamp: l1FinalizedBlock.timestamp,
-    });
+    return this.fetchAndCache(epoch, ts, { latestBlock, finalizedBlock: l1FinalizedBlock });
   }
 
   /**
@@ -417,26 +417,22 @@ export class EpochCache implements EpochCacheInterface {
    *
    * Uses `lagInEpochsForRandao` (the binding constraint, always <= lagInEpochsForValidatorSet)
    * and computes the sampling timestamp from the epoch start to match the L1 contract's logic.
+   *
+   * When called from refreshStaleEntry after a reorg, the latest and finalized blocks are
+   * passed in to avoid redundant L1 queries.
    */
   private async fetchAndCache(
     epoch: EpochNumber,
     ts: bigint,
-    prefetched?: { latestTimestamp: bigint; finalizedTimestamp: bigint },
+    prefetched?: { latestBlock: L1BlockInfo; finalizedBlock: { timestamp: bigint } },
   ): Promise<CachedEpochEntry> {
-    const [committee, seedBuffer, l1Block, l1FinalizedBlock, isEscapeHatchOpen] = await Promise.all([
+    const [committee, seedBuffer, latestBlock, finalizedBlock, isEscapeHatchOpen] = await Promise.all([
       this.rollup.getCommitteeAt(ts),
       this.rollup.getSampleSeedAt(ts),
-      prefetched
-        ? ({ number: 0n, hash: '0x', timestamp: prefetched.latestTimestamp } as const)
-        : this.rollup.client.getBlock({ includeTransactions: false }),
-      prefetched
-        ? ({ timestamp: prefetched.finalizedTimestamp } as const)
-        : this.rollup.client.getBlock({ blockTag: 'finalized', includeTransactions: false }),
+      prefetched?.latestBlock ?? this.rollup.client.getBlock({ includeTransactions: false }),
+      prefetched?.finalizedBlock ?? this.rollup.client.getBlock({ blockTag: 'finalized', includeTransactions: false }),
       this.rollup.isEscapeHatchOpen(epoch),
     ]);
-
-    // When timestamps are prefetched we still need the actual latest block for provenance.
-    const latestBlock = prefetched ? await this.rollup.client.getBlock({ includeTransactions: false }) : l1Block;
 
     const samplingTs = this.getSamplingTimestamp(epoch);
 
@@ -450,7 +446,7 @@ export class EpochCache implements EpochCacheInterface {
 
     // Empty committees are never marked finalized so they always get re-queried after TTL.
     const hasCommittee = !!(committee && committee.length > 0);
-    const finalized = hasCommittee && samplingTs <= l1FinalizedBlock.timestamp;
+    const finalized = hasCommittee && samplingTs <= finalizedBlock.timestamp;
     const data: EpochCommitteeInfo = { committee, seed: seedBuffer.toBigInt(), epoch, isEscapeHatchOpen };
     const entry: CachedEpochEntry = {
       data,


### PR DESCRIPTION
## Motivation

PR #22153 introduced a hard "finalized block guard" that refuses to compute committees if L1 data isn't finalized. While the safety goal is valid (preventing L1 reorgs from invalidating cached committees), it breaks many tests that don't properly set L1 finalized time and would cause the chain to stall if L1 stops finalizing. This PR takes a different approach that preserves safety while maintaining liveness.

Also fixes the lag parameter: the old code used `lagInEpochsForValidatorSet` (the looser constraint) instead of `lagInEpochsForRandao` (the binding one), and computed the sampling timestamp from the slot rather than the epoch start.

Fixes A-680

## Approach

Instead of refusing to serve committee data that isn't finalized, use a TTL-based cache: finalized entries are cached permanently, non-finalized entries expire after one Ethereum slot (12s) and get re-fetched from L1. The cache map stores both resolved entries and in-flight promises directly, so concurrent callers for the same epoch coalesce on a single L1 query. On fetch failure, the previous stale entry is restored so the next caller retries cleanly.

## Changes

- **epoch-cache**: Replaced the simple `Map<EpochNumber, EpochCommitteeInfo>` cache with `Map<EpochNumber, CachedEpochEntry | Promise<CachedEpochEntry>>`. Each resolved entry carries L1 block provenance metadata (number, hash, timestamp) and a `finalized` flag. Switched from `lagInEpochsForValidatorSet` to `lagInEpochsForRandao` and compute sampling timestamp from epoch start via `getStartTimestampForEpoch`. Simplified `isEscapeHatchOpen` to delegate cache management to `getCommittee`.
- **epoch-cache (tests)**: Updated unit tests for the new cache structure. Added 4 new TTL tests: re-query after TTL, no re-query for finalized, concurrent coalescing, eventual finalization promotion.
- **epoch-cache (integration tests)**: New integration test suite against real Anvil with deployed L1 contracts and 4 validators. Tests finalized committee retrieval, non-finalized TTL refresh, and cache re-fetch after L1 reorg.
- **epoch-cache (README)**: Added comprehensive documentation covering committee computation, LAG values, RANDAO seed, proposer selection, escape hatch, TTL caching with finalization tracking, and configuration.