### PR TITLE
feat: disable noir test cache on merge-train/fairies

### DIFF
--- a/noir-projects/aztec-nr/bootstrap.sh
+++ b/noir-projects/aztec-nr/bootstrap.sh
@@ -4,7 +4,13 @@ source $(git rev-parse --show-toplevel)/ci3/source_bootstrap
 export RAYON_NUM_THREADS=${RAYON_NUM_THREADS:-16}
 export HARDWARE_CONCURRENCY=${HARDWARE_CONCURRENCY:-16}
 export NARGO=${NARGO:-../../noir/noir-repo/target/release/nargo}
-hash=$(hash_str $(../../noir/bootstrap.sh hash) $(cache_content_hash "^noir-projects/aztec-nr"))
+
+# Fairies want to run these tests on every PR
+if [ "${TARGET_BRANCH:-}" = "merge-train/fairies" ]; then
+  hash=disabled-cache
+else
+  hash=$(hash_str $(../../noir/bootstrap.sh hash) $(cache_content_hash "^noir-projects/aztec-nr"))
+fi
 
 function build {
   # Being a library, aztec-nr does not technically need to be built. But we can still run nargo check to find any type

--- a/noir-projects/noir-contracts-comp-failures/bootstrap.sh
+++ b/noir-projects/noir-contracts-comp-failures/bootstrap.sh
@@ -51,7 +51,12 @@ test() {
 }
 
 function test_cmds {
-    hash=$(hash_str $(../../noir/bootstrap.sh hash) $(cache_content_hash ^noir-projects/noir-contracts-comp-failures))
+    # Fairies want to run these tests on every PR
+    if [ "${TARGET_BRANCH:-}" = "merge-train/fairies" ]; then
+      hash=disabled-cache
+    else
+      hash=$(hash_str $(../../noir/bootstrap.sh hash) $(cache_content_hash ^noir-projects/noir-contracts-comp-failures))
+    fi
     echo "$hash ./noir-projects/noir-contracts-comp-failures/bootstrap.sh test"
 }
 

--- a/noir-projects/noir-contracts/bootstrap.sh
+++ b/noir-projects/noir-contracts/bootstrap.sh
@@ -233,7 +233,6 @@ function build {
 }
 
 function test_cmds {
-  local -A cache
   local folder_name
   if [ -n "${DOCS_WORKING_DIR:-}" ]; then
     folder_name="examples"
@@ -244,12 +243,22 @@ function test_cmds {
   # Test bb aztec_process command
   echo "$BB_HASH noir-projects/scripts/test_aztec_process.sh"
 
-  i=0
-  $NARGO test --list-tests --silence-warnings | sort | while read -r package test; do
-    port=$((14730 + (i++ % ${NUM_TXES:-1})))
-    [ -z "${cache[$package]:-}" ] && cache[$package]=$(get_contract_hash $package $folder_name)
-    echo "${cache[$package]} noir-projects/scripts/run_test.sh noir-contracts $package $test $port"
-  done
+  # Fairies want to run these tests on every PR
+  if [ "${TARGET_BRANCH:-}" = "merge-train/fairies" ]; then
+    i=0
+    $NARGO test --list-tests --silence-warnings | sort | while read -r package test; do
+      port=$((14730 + (i++ % ${NUM_TXES:-1})))
+      echo "disabled-cache noir-projects/scripts/run_test.sh noir-contracts $package $test $port"
+    done
+  else
+    local -A cache
+    i=0
+    $NARGO test --list-tests --silence-warnings | sort | while read -r package test; do
+      port=$((14730 + (i++ % ${NUM_TXES:-1})))
+      [ -z "${cache[$package]:-}" ] && cache[$package]=$(get_contract_hash $package $folder_name)
+      echo "${cache[$package]} noir-projects/scripts/run_test.sh noir-contracts $package $test $port"
+    done
+  fi
 }
 
 function test {


### PR DESCRIPTION
It has happened a couple of times that we broke our merge train branch because we merged in a PR that had failing Noir tests and we broke them because we modified PXE/TXE. In this PR we set it up such that these tests are always run on our branch.

## Summary
- When `TARGET_BRANCH` is `merge-train/fairies`, use `disabled-cache` as the test hash for `aztec-nr`, `noir-contracts`, and `noir-contracts-comp-failures`
- This ensures these tests always run on fairies PRs since `yarn-project` changes (e.g. TXE foreign call handlers) can affect test outcomes but are not included in the content hash
- No impact on other branches — hash computation is unchanged elsewhere

## Test plan
- [ ] Verify CI runs noir tests on this PR despite no noir-projects source changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)