### PR TITLE
fix: disable max capacity test in debug + tiny gate separator improvements

### DIFF
--- a/barretenberg/cpp/src/barretenberg/chonk/batched_honk_translator/batched_honk_translator.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/chonk/batched_honk_translator/batched_honk_translator.test.cpp
@@ -187,9 +187,7 @@ class BatchedHonkTranslatorTests : public ::testing::Test {
         // ── Round 3: translator Z_PERM, then joint alpha + gate challenges ────────
         m.add_entry(round, "Z_PERM", G);
         m.add_challenge(round, "Sumcheck:alpha");
-        for (size_t i = 0; i < JOINT_LOG_N; ++i) {
-            m.add_challenge(round, "Sumcheck:gate_challenge_" + std::to_string(i));
-        }
+        m.add_challenge(round, "Sumcheck:gate_challenge");
         round++;
 
         // ── Round 4: Libra masking commitment + Sum ───────────────────────────────

--- a/barretenberg/cpp/src/barretenberg/chonk/batched_honk_translator/batched_honk_translator_prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/chonk/batched_honk_translator/batched_honk_translator_prover.cpp
@@ -69,10 +69,8 @@ void BatchedHonkTranslatorProver::execute_joint_sumcheck_rounds()
     const FF alpha = transcript->template get_challenge<FF>("Sumcheck:alpha");
 
     // Draw joint gate challenges (17 total).
-    std::vector<FF> gate_challenges(JOINT_LOG_N);
-    for (size_t i = 0; i < JOINT_LOG_N; i++) {
-        gate_challenges[i] = transcript->template get_challenge<FF>("Sumcheck:gate_challenge_" + std::to_string(i));
-    }
+    std::vector<FF> gate_challenges =
+        transcript->template get_dyadic_powers_of_challenge<FF>("Sumcheck:gate_challenge", JOINT_LOG_N);
 
     // Compute α^{K_H}: offset for translator subrelation separators.
     FF alpha_power_KH = FF(1);
@@ -95,12 +93,9 @@ void BatchedHonkTranslatorProver::execute_joint_sumcheck_rounds()
     MegaZKCommitmentKey small_ck(1 << (log_subgroup_size + 1));
     zk_sumcheck_data = ZKData(JOINT_LOG_N, transcript, small_ck);
 
-    // Gate separator polynomials:
-    //   MegaZK circuit uses gate_challenges[0..mega_zk_log_n-1] for beta_products (real rounds only).
-    //   During virtual rounds, only betas[] and partial_evaluation_result are accessed.
-    //   Translator uses all JOINT_LOG_N challenges.
-    GateSeparatorPolynomial<FF> mega_zk_gate_sep(gate_challenges, mega_zk_log_n);
-    GateSeparatorPolynomial<FF> translator_gate_sep(gate_challenges, JOINT_LOG_N);
+    // Single gate separator for both circuits: beta_products has size 2^JOINT_LOG_N which covers
+    // both the MegaZK real rounds (2^mega_zk_log_n) and translator rounds (2^JOINT_LOG_N).
+    GateSeparatorPolynomial<FF> gate_sep(gate_challenges, JOINT_LOG_N);
 
     // Round helper objects.
     MegaZKProverRound mega_zk_round(static_cast<size_t>(1) << mega_zk_log_n);
@@ -146,8 +141,7 @@ void BatchedHonkTranslatorProver::execute_joint_sumcheck_rounds()
                                          TranslatorFlavor::get_minicircuit_evaluations(translator_partial));
         }
         zk_sumcheck_data.update_zk_sumcheck_data(u, round_idx);
-        mega_zk_gate_sep.partially_evaluate(u);
-        translator_gate_sep.partially_evaluate(u);
+        gate_sep.partially_evaluate(u);
         translator_round.round_size >>= 1;
     };
 
@@ -159,13 +153,13 @@ void BatchedHonkTranslatorProver::execute_joint_sumcheck_rounds()
     auto do_round = [&](auto& hpolys, auto& tpolys, size_t round_idx) -> FF {
         U_joint = SumcheckRoundUnivariate::zero();
 
-        auto U_H = mega_zk_round.compute_univariate(hpolys, mega_zk_params, mega_zk_gate_sep, mega_zk_alphas);
+        auto U_H = mega_zk_round.compute_univariate(hpolys, mega_zk_params, gate_sep, mega_zk_alphas);
         U_H += mega_zk_round.compute_disabled_contribution(
-            hpolys, mega_zk_params, mega_zk_gate_sep, mega_zk_alphas, rdp, masking_tail);
+            hpolys, mega_zk_params, gate_sep, mega_zk_alphas, rdp, masking_tail);
         U_joint += U_H;
 
-        auto U_T = translator_round.compute_univariate(
-            tpolys, translator_relation_parameters, translator_gate_sep, translator_alphas);
+        auto U_T =
+            translator_round.compute_univariate(tpolys, translator_relation_parameters, gate_sep, translator_alphas);
         for (auto& eval : U_T.evaluations) {
             eval *= alpha_power_KH;
         }
@@ -235,13 +229,13 @@ void BatchedHonkTranslatorProver::execute_joint_sumcheck_rounds()
     for (size_t round_idx = mega_zk_log_n; round_idx < JOINT_LOG_N; round_idx++) {
         U_joint = SumcheckRoundUnivariate::zero();
 
-        auto U_H = mega_zk_round.compute_virtual_contribution(
-            mega_zk_partial, mega_zk_params, mega_zk_gate_sep, mega_zk_alphas);
+        auto U_H =
+            mega_zk_round.compute_virtual_contribution(mega_zk_partial, mega_zk_params, gate_sep, mega_zk_alphas);
         U_H *= rdp_scalar;
         U_joint += U_H;
 
         auto U_T = translator_round.compute_univariate(
-            translator_partial, translator_relation_parameters, translator_gate_sep, translator_alphas);
+            translator_partial, translator_relation_parameters, gate_sep, translator_alphas);
         for (auto& eval : U_T.evaluations) {
             eval *= alpha_power_KH;
         }

--- a/barretenberg/cpp/src/barretenberg/chonk/batched_honk_translator/batched_honk_translator_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/chonk/batched_honk_translator/batched_honk_translator_verifier.cpp
@@ -113,10 +113,8 @@ template <typename Curve> bool BatchedHonkTranslatorVerifier_<Curve>::verify_joi
     auto translator_alphas = initialize_relation_separator<FF, TransFlavor::NUM_SUBRELATIONS - 1>(alpha);
 
     // Draw gate challenges.
-    std::vector<FF> gate_challenges(JOINT_LOG_N);
-    for (size_t i = 0; i < JOINT_LOG_N; i++) {
-        gate_challenges[i] = transcript->template get_challenge<FF>("Sumcheck:gate_challenge_" + std::to_string(i));
-    }
+    std::vector<FF> gate_challenges =
+        transcript->template get_dyadic_powers_of_challenge<FF>("Sumcheck:gate_challenge", JOINT_LOG_N);
 
     // Receive Libra masking commitments.
     libra_commitments = {};

--- a/barretenberg/cpp/src/barretenberg/chonk/chonk.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/chonk/chonk.test.cpp
@@ -401,6 +401,7 @@ TEST_F(ChonkTests, VKIndependenceFromCircuitSize)
  * @brief Test to establish the "max" number of apps that can be accumulated due to limitations on the ECCVM size
  *
  */
+#ifdef NDEBUG
 HEAVY_TEST(ChonkKernelCapacity, MaxCapacityPassing)
 {
     bb::srs::init_file_crs_factory(bb::srs::bb_crs_path());
@@ -411,6 +412,7 @@ HEAVY_TEST(ChonkKernelCapacity, MaxCapacityPassing)
     bool verified = ChonkTests::verify_chonk(proof, vk);
     EXPECT_TRUE(verified);
 };
+#endif
 
 /**
  * @brief Test methods for serializing and deserializing a proof to/from a file/buffer in msgpack format

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/gate_count_constants.hpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/gate_count_constants.hpp
@@ -113,7 +113,7 @@ constexpr std::tuple<size_t, size_t> HONK_RECURSION_CONSTANTS(
 // ========================================
 
 // Gate count for Chonk recursive verification (Ultra with RollupIO)
-inline constexpr size_t CHONK_RECURSION_GATES = 1494161;
+inline constexpr size_t CHONK_RECURSION_GATES = 1491513;
 
 // ========================================
 // Hypernova Recursion Constants
@@ -147,7 +147,7 @@ inline constexpr size_t HIDING_KERNEL_ULTRA_OPS = 127;
 // ========================================
 
 // Gate count for ECCVM recursive verifier (Ultra-arithmetized)
-inline constexpr size_t ECCVM_RECURSIVE_VERIFIER_GATE_COUNT = 225236;
+inline constexpr size_t ECCVM_RECURSIVE_VERIFIER_GATE_COUNT = 224206;
 
 // ========================================
 // Goblin AVM Recursive Verifier Constants

--- a/barretenberg/cpp/src/barretenberg/eccvm/eccvm_prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/eccvm/eccvm_prover.cpp
@@ -144,10 +144,8 @@ void ECCVMProver::execute_relation_check_rounds()
     //  i = 0, ..., NUM_SUBRELATIONS- 1.
     FF alpha = transcript->template get_challenge<FF>("Sumcheck:alpha");
 
-    std::vector<FF> gate_challenges(CONST_ECCVM_LOG_N);
-    for (size_t idx = 0; idx < gate_challenges.size(); idx++) {
-        gate_challenges[idx] = transcript->template get_challenge<FF>("Sumcheck:gate_challenge_" + std::to_string(idx));
-    }
+    std::vector<FF> gate_challenges =
+        transcript->template get_dyadic_powers_of_challenge<FF>("Sumcheck:gate_challenge", CONST_ECCVM_LOG_N);
 
     Sumcheck sumcheck(key->circuit_size,
                       key->polynomials,

--- a/barretenberg/cpp/src/barretenberg/eccvm/eccvm_transcript.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/eccvm/eccvm_transcript.test.cpp
@@ -136,10 +136,7 @@ class ECCVMTranscriptTests : public ::testing::Test {
         manifest_expected.add_entry(round, "Z_PERM", frs_per_G);
         manifest_expected.add_challenge(round, "Sumcheck:alpha");
 
-        for (size_t i = 0; i < CONST_ECCVM_LOG_N; i++) {
-            std::string label = "Sumcheck:gate_challenge_" + std::to_string(i);
-            manifest_expected.add_challenge(round, label);
-        }
+        manifest_expected.add_challenge(round, "Sumcheck:gate_challenge");
         round++;
 
         manifest_expected.add_entry(round, "Libra:concatenation_commitment", frs_per_G);

--- a/barretenberg/cpp/src/barretenberg/eccvm/eccvm_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/eccvm/eccvm_verifier.cpp
@@ -74,10 +74,8 @@ typename ECCVMVerifier_<Flavor>::ReductionResult ECCVMVerifier_<Flavor>::reduce_
     // Execute Sumcheck Verifier
     SumcheckVerifier<Flavor> sumcheck(transcript, alpha, CONST_ECCVM_LOG_N);
 
-    std::vector<FF> gate_challenges(CONST_ECCVM_LOG_N);
-    for (size_t idx = 0; idx < gate_challenges.size(); idx++) {
-        gate_challenges[idx] = transcript->template get_challenge<FF>("Sumcheck:gate_challenge_" + std::to_string(idx));
-    }
+    std::vector<FF> gate_challenges =
+        transcript->template get_dyadic_powers_of_challenge<FF>("Sumcheck:gate_challenge", CONST_ECCVM_LOG_N);
 
     // Receive commitments to Libra masking polynomials
     std::array<Commitment, NUM_LIBRA_COMMITMENTS> libra_commitments = {};

--- a/barretenberg/cpp/src/barretenberg/stdlib/hash/poseidon2/poseidon2.circuit.failure.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/hash/poseidon2/poseidon2.circuit.failure.test.cpp
@@ -76,11 +76,8 @@ class Poseidon2FailureTests : public ::testing::Test {
         // Generate challenges via transcript for Fiat-Shamir
         SubrelationSeparator subrelation_separator = prover_transcript->template get_challenge<FF>("Sumcheck:alpha");
 
-        std::vector<FF> gate_challenges(virtual_log_n);
-        for (size_t idx = 0; idx < virtual_log_n; idx++) {
-            gate_challenges[idx] =
-                prover_transcript->template get_challenge<FF>("Sumcheck:gate_challenge_" + std::to_string(idx));
-        }
+        std::vector<FF> gate_challenges =
+            prover_transcript->template get_dyadic_powers_of_challenge<FF>("Sumcheck:gate_challenge", virtual_log_n);
 
         // Set gate challenges on prover instance
         prover_instance->gate_challenges = gate_challenges;
@@ -98,11 +95,8 @@ class Poseidon2FailureTests : public ::testing::Test {
 
         SubrelationSeparator verifier_subrelation_separator =
             verifier_transcript->template get_challenge<FF>("Sumcheck:alpha");
-        std::vector<FF> verifier_gate_challenges(virtual_log_n);
-        for (size_t idx = 0; idx < virtual_log_n; idx++) {
-            verifier_gate_challenges[idx] =
-                verifier_transcript->template get_challenge<FF>("Sumcheck:gate_challenge_" + std::to_string(idx));
-        }
+        std::vector<FF> verifier_gate_challenges =
+            verifier_transcript->template get_dyadic_powers_of_challenge<FF>("Sumcheck:gate_challenge", virtual_log_n);
 
         // Run sumcheck verifier
         SumcheckVerifier verifier(verifier_transcript, verifier_subrelation_separator, virtual_log_n);

--- a/barretenberg/cpp/src/barretenberg/translator_vm/translator.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/translator.test.cpp
@@ -98,9 +98,7 @@ class TranslatorTests : public ::testing::Test {
         // Round 1: Z_PERM -> Sumcheck:alpha + all gate challenges (same round, no data between them)
         manifest.add_entry(1, "Z_PERM", frs_per_G);
         manifest.add_challenge(1, "Sumcheck:alpha");
-        for (size_t i = 0; i < NUM_SUMCHECK_ROUNDS; ++i) {
-            manifest.add_challenge(1, "Sumcheck:gate_challenge_" + std::to_string(i));
-        }
+        manifest.add_challenge(1, "Sumcheck:gate_challenge");
 
         // Round 2: Libra concatenation commitment + Sum -> Libra:Challenge
         manifest.add_entry(2, "Libra:concatenation_commitment", frs_per_G);

--- a/barretenberg/cpp/src/barretenberg/translator_vm/translator_prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/translator_prover.cpp
@@ -139,10 +139,8 @@ void TranslatorProver::execute_relation_check_rounds()
     //  i = 0, ..., NUM_SUBRELATIONS- 1.
     const FF alpha = transcript->template get_challenge<FF>("Sumcheck:alpha");
 
-    std::vector<FF> gate_challenges(Flavor::CONST_TRANSLATOR_LOG_N);
-    for (size_t idx = 0; idx < gate_challenges.size(); idx++) {
-        gate_challenges[idx] = transcript->template get_challenge<FF>("Sumcheck:gate_challenge_" + std::to_string(idx));
-    }
+    std::vector<FF> gate_challenges = transcript->template get_dyadic_powers_of_challenge<FF>(
+        "Sumcheck:gate_challenge", Flavor::CONST_TRANSLATOR_LOG_N);
 
     const size_t circuit_size = key->proving_key->circuit_size;
 

--- a/barretenberg/cpp/src/barretenberg/translator_vm/translator_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/translator_verifier.cpp
@@ -206,10 +206,8 @@ typename TranslatorVerifier_<Flavor>::ReductionResult TranslatorVerifier_<Flavor
     // Execute Sumcheck Verifier
     Sumcheck sumcheck(transcript, alpha, TranslatorFlavor::CONST_TRANSLATOR_LOG_N);
 
-    std::vector<FF> gate_challenges(TranslatorFlavor::CONST_TRANSLATOR_LOG_N);
-    for (size_t idx = 0; idx < gate_challenges.size(); idx++) {
-        gate_challenges[idx] = transcript->template get_challenge<FF>("Sumcheck:gate_challenge_" + std::to_string(idx));
-    }
+    std::vector<FF> gate_challenges = transcript->template get_dyadic_powers_of_challenge<FF>(
+        "Sumcheck:gate_challenge", TranslatorFlavor::CONST_TRANSLATOR_LOG_N);
 
     // Receive commitments to Libra masking polynomials
     std::array<Commitment, NUM_LIBRA_COMMITMENTS> libra_commitments = {};


### PR DESCRIPTION
- Max chonk capacity test is very heavy, and running it in nightly debug is not really needed
- Noticed that we're still using log_n independent challenges for eccvm, translator, and batched honk-translator, switched to using dyadic power of a single challenge, as it's done elsewhere
- Noticed that previously introduced a redundnt gate separator in the batched flow - MegaZK sumcheck path can re-use translator's gate separator