### PR TITLE
chore: fix wallet setup to use NO_FROM instead of ZERO address

### DIFF
--- a/yarn-project/end-to-end/src/spartan/setup_test_wallets.ts
+++ b/yarn-project/end-to-end/src/spartan/setup_test_wallets.ts
@@ -196,7 +196,7 @@ async function deployAccountWithDiagnostics(
 
       if (!sentTxHash) {
         const deployResult = await deployMethod.send({
-          from: AztecAddress.ZERO,
+          from: NO_FROM,
           fee: { paymentMethod, gasSettings },
           wait: NO_WAIT,
         });


### PR DESCRIPTION
This fixes the `mempool_limit` test that the scenario deployment tests.

Fixing a malformed merge.