### PR TITLE
chore: fix unnecessary and inconsistent side-effect counter increments

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/context/private_context.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/private_context.nr
@@ -1161,7 +1161,7 @@ impl PrivateContext {
         // all side effects emitted in the child call have counters within the range [start_side_effect_counter,
         // end_side_effect_counter]. Therefore, we only need to ensure that the next side effect from the current call
         // starts after the end side effect from the child call.
-        let _ = self.next_counter();
+        self.side_effect_counter = end_side_effect_counter + 1;
 
         ReturnsHash::new(returns_hash)
     }

--- a/noir-projects/aztec-nr/aztec/src/context/private_context.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/private_context.nr
@@ -559,9 +559,12 @@ impl PrivateContext {
     pub fn end_setup(&mut self) {
         // Incrementing the side effect counter when ending setup ensures non ambiguity for the counter where we change
         // phases.
-        self.side_effect_counter += 1;
-        aztecnr_trace_log_format!("Ending setup at counter {0}")([self.side_effect_counter as Field]);
         self.min_revertible_side_effect_counter = self.next_counter();
+        aztecnr_trace_log_format!(
+            "Ending setup, minimum revertible side effect counter is {0}",
+        )(
+            [self.min_revertible_side_effect_counter as Field],
+        );
         notify_revertible_phase_start(self.min_revertible_side_effect_counter);
     }
 
@@ -1162,8 +1165,9 @@ impl PrivateContext {
         // ); if item.public_inputs.min_revertible_side_effect_counter
         //     > self.min_revertible_side_effect_counter { self.min_revertible_side_effect_counter =
         // item.public_inputs.min_revertible_side_effect_counter; }
-        self.side_effect_counter = end_side_effect_counter + 1; // TODO: call `next_counter`
-        // instead, for consistency
+
+        // Increment side-effect counter
+        let _ = self.next_counter();
         ReturnsHash::new(returns_hash)
     }
 

--- a/noir-projects/aztec-nr/aztec/src/context/private_context.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/private_context.nr
@@ -557,10 +557,15 @@ impl PrivateContext {
     /// counter.
     ///
     pub fn end_setup(&mut self) {
-        // Incrementing the side effect counter when ending setup ensures non ambiguity for the counter where we change
-        // phases.
+        // We bump the counter twice: once so that `min_revertible_side_effect_counter` sits strictly above any
+        // non-revertible side effect counter (including queries made via `in_revertible_phase` before this call), and
+        // once more so that the next revertible side effect counter is strictly greater than
+        // `min_revertible_side_effect_counter`. This ensures `min_revertible_side_effect_counter` occupies a gap that
+        // no side effect takes, which the kernel relies on when validating the phase split.
         self.side_effect_counter += 1;
         self.min_revertible_side_effect_counter = self.side_effect_counter;
+        self.side_effect_counter += 1;
+
         aztecnr_trace_log_format!(
             "Ending setup, minimum revertible side effect counter is {0}",
         )(

--- a/noir-projects/aztec-nr/aztec/src/context/private_context.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/private_context.nr
@@ -559,7 +559,8 @@ impl PrivateContext {
     pub fn end_setup(&mut self) {
         // Incrementing the side effect counter when ending setup ensures non ambiguity for the counter where we change
         // phases.
-        self.min_revertible_side_effect_counter = self.next_counter();
+        self.side_effect_counter += 1;
+        self.min_revertible_side_effect_counter = self.side_effect_counter;
         aztecnr_trace_log_format!(
             "Ending setup, minimum revertible side effect counter is {0}",
         )(

--- a/noir-projects/aztec-nr/aztec/src/context/private_context.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/private_context.nr
@@ -1157,17 +1157,12 @@ impl PrivateContext {
             },
         );
 
-        // TODO (fees) figure out why this crashes the prover and enable it we need this in order to pay fees inside
-        // child call contexts assert(
-        //     (item.public_inputs.min_revertible_side_effect_counter == 0 as u32)
-        //     | (item.public_inputs.min_revertible_side_effect_counter
-        //         > self.min_revertible_side_effect_counter)
-        // ); if item.public_inputs.min_revertible_side_effect_counter
-        //     > self.min_revertible_side_effect_counter { self.min_revertible_side_effect_counter =
-        // item.public_inputs.min_revertible_side_effect_counter; }
-
-        // Increment side-effect counter
+        // The kernel circuits ensure that end_side_effect_counter is greater than start_side_effect_counter, and that
+        // all side effects emitted in the child call have counters within the range [start_side_effect_counter,
+        // end_side_effect_counter]. Therefore, we only need to ensure that the next side effect from the current call
+        // starts after the end side effect from the child call.
         let _ = self.next_counter();
+
         ReturnsHash::new(returns_hash)
     }
 


### PR DESCRIPTION
The extra increment had no real consequences, but it made the core mode confusing. I adjusted the log to more clearly show what's been done.

I also removed a TODO that was both stale and incorrect.