### PR TITLE
chore: (A-751) robust response error handling in json-rpc client

### DIFF
--- a/yarn-project/foundation/src/json-rpc/client/fetch.ts
+++ b/yarn-project/foundation/src/json-rpc/client/fetch.ts
@@ -54,7 +54,7 @@ export async function defaultFetch(
   }
 
   if (!resp.ok) {
-    const errorMessage = `Error ${resp.status} from server ${host}: ${responseJson.error.message}`;
+    const errorMessage = `Error ${resp.status} from server ${host}: ${responseJson?.error?.message ?? JSON.stringify(responseJson)}`;
     if (noRetry || (resp.status >= 400 && resp.status < 500)) {
       throw new NoRetryError(errorMessage);
     } else {


### PR DESCRIPTION
Better error handling for json-rpc client responses in the case that non-standard errors are returned if using reverse proxies. 