### PR TITLE
chore: fix inconsistent usage of contract class hash fn

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/context/private_context.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/private_context.nr
@@ -39,7 +39,7 @@ use crate::protocol::{
         MAX_PRIVATE_CALL_STACK_LENGTH_PER_CALL, MAX_PRIVATE_LOGS_PER_CALL, MAX_TX_LIFETIME,
         NULL_MSG_SENDER_CONTRACT_ADDRESS, PRIVATE_LOG_CIPHERTEXT_LEN,
     },
-    hash::poseidon2_hash,
+    hash::compute_contract_class_log_hash,
     messaging::l2_to_l1_message::L2ToL1Message,
     side_effect::{Counted, scoped::Scoped},
     traits::{Empty, Hash, ToField},
@@ -942,6 +942,13 @@ impl PrivateContext {
         self.private_logs.push(private_log.count(counter));
     }
 
+    /// Emits large data blobs.
+    ///
+    /// This reuses the Contract Class Log channel to emit blobs of up to [`CONTRACT_CLASS_LOG_SIZE_IN_FIELDS`].
+    ///
+    /// ## Privacy
+    ///
+    /// The address of the contract emitting these blobs is revelead.
     pub fn emit_contract_class_log<let N: u32>(&mut self, log: [Field; N]) {
         let contract_address = self.this_address();
         let counter = self.next_counter();
@@ -953,10 +960,10 @@ impl PrivateContext {
         // Safety: The below length is constrained in the base rollup, which will make sure that all the fields beyond
         // length are zero. However, it won't be able to check that we didn't add extra padding (trailing zeroes) or
         // that we cut trailing zeroes from the end.
-        let length = unsafe { trimmed_array_length_hint(log_to_emit) };
+        let length = unsafe { trimmed_array_length_hint(log) };
         // We hash the entire padded log to ensure a user cannot pass a shorter length and so emit incorrect shorter
         // bytecode.
-        let log_hash = poseidon2_hash(log_to_emit);
+        let log_hash = compute_contract_class_log_hash(log_to_emit);
         // Safety: the below only exists to broadcast the raw log, so we can provide it to the base rollup later to be
         // constrained.
         unsafe {


### PR DESCRIPTION
From #21213. The hash fn is the same, so the behavior doesn't change. But it will keep things aligned in the future.

It's too early to write docs for this, but I at least added the note on all privacy being lost.