### PR TITLE
chore: delete old field comparison fns in favor of lt

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/history/nullifier.nr
+++ b/noir-projects/aztec-nr/aztec/src/history/nullifier.nr
@@ -4,12 +4,7 @@ use crate::oracle::get_nullifier_membership_witness::{
     get_low_nullifier_membership_witness, get_nullifier_membership_witness,
 };
 
-use crate::protocol::{
-    abis::block_header::BlockHeader,
-    merkle_tree::root::root_from_sibling_path,
-    traits::Hash,
-    utils::field::{full_field_greater_than, full_field_less_than},
-};
+use crate::protocol::{abis::block_header::BlockHeader, merkle_tree::root::root_from_sibling_path, traits::Hash};
 
 mod test;
 
@@ -105,7 +100,7 @@ pub fn assert_nullifier_did_not_exist_by(block_header: BlockHeader, siloed_nulli
 
     // 4) Prove that the low leaf is indeed smaller than the nullifier
     assert(
-        full_field_less_than(low_nullifier_leaf.nullifier, siloed_nullifier),
+        low_nullifier_leaf.nullifier.lt(siloed_nullifier),
         "Proving nullifier non-inclusion failed: low_nullifier.value < nullifier.value check failed",
     );
 
@@ -113,8 +108,7 @@ pub fn assert_nullifier_did_not_exist_by(block_header: BlockHeader, siloed_nulli
     // the nullifier tree, since if it were it'd need to be between the low leaf and the next leaf. Note the special
     // case in which the low leaf is the largest of all entries, in which case there's no 'next' entry.
     assert(
-        full_field_greater_than(low_nullifier_leaf.next_nullifier, siloed_nullifier)
-            | (low_nullifier_leaf.next_index == 0),
+        siloed_nullifier.lt(low_nullifier_leaf.next_nullifier) | (low_nullifier_leaf.next_index == 0),
         "Proving nullifier non-inclusion failed: low_nullifier.next_value > nullifier.value check failed",
     );
 }

--- a/noir-projects/noir-contracts/contracts/test/pending_note_hashes_contract/src/filter.nr
+++ b/noir-projects/noir-contracts/contracts/test/pending_note_hashes_contract/src/filter.nr
@@ -1,8 +1,5 @@
 // docs:start:custom_filter_imports
-use aztec::{
-    note::HintedNote,
-    protocol::{constants::MAX_NOTE_HASH_READ_REQUESTS_PER_CALL, utils::field::full_field_less_than},
-};
+use aztec::{note::HintedNote, protocol::constants::MAX_NOTE_HASH_READ_REQUESTS_PER_CALL};
 // docs:end:custom_filter_imports
 use field_note::FieldNote;
 
@@ -15,7 +12,7 @@ pub fn filter_notes_min_sum(
 
     let mut sum = 0;
     for i in 0..notes.len() {
-        if notes[i].is_some() & full_field_less_than(sum, min_sum) {
+        if notes[i].is_some() & sum.lt(min_sum) {
             let hinted_note = notes[i].unwrap_unchecked();
             selected[i] = Option::some(hinted_note);
             sum += hinted_note.note.value;

--- a/noir-projects/noir-protocol-circuits/crates/types/src/utils/field.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/utils/field.nr
@@ -34,15 +34,6 @@ pub fn field_from_bytes_32_trunc(bytes32: [u8; 32]) -> Field {
     low + high * v
 }
 
-// TODO to radix returns u8, so we cannot use bigger radixes. It'd be ideal to use a radix of the maximum range-constrained integer noir supports
-pub fn full_field_less_than(lhs: Field, rhs: Field) -> bool {
-    lhs.lt(rhs)
-}
-
-pub fn full_field_greater_than(lhs: Field, rhs: Field) -> bool {
-    rhs.lt(lhs)
-}
-
 pub fn min(f1: Field, f2: Field) -> Field {
     if f1.lt(f2) {
         f1
@@ -297,17 +288,6 @@ unconstrained fn min_test() {
     assert_eq(min(10, 5), 5);
     assert_eq(min(7, 7), 7);
     assert_eq(min(0, 1), 0);
-}
-
-#[test]
-unconstrained fn full_field_comparison_test() {
-    assert(full_field_less_than(5, 10));
-    assert(!full_field_less_than(10, 5));
-    assert(!full_field_less_than(5, 5));
-
-    assert(full_field_greater_than(10, 5));
-    assert(!full_field_greater_than(5, 10));
-    assert(!full_field_greater_than(5, 5));
 }
 
 #[test]


### PR DESCRIPTION
From #21213. These are now archaic.