### PR TITLE
chore: Protective asserts in proof decompression

### DIFF
--- a/barretenberg/cpp/src/barretenberg/chonk/chonk.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/chonk/chonk.test.cpp
@@ -591,3 +591,84 @@ TEST_F(ChonkTests, ProofCompressionRoundtrip)
     // Verify the decompressed proof
     EXPECT_TRUE(verify_chonk(decompressed, vk_and_hash));
 }
+
+/**
+ * @brief Build a valid compressed proof, then corrupt a specific 32-byte element.
+ */
+static std::vector<uint8_t> compress_and_corrupt(const ChonkProof& proof, size_t element_idx, const uint256_t& value)
+{
+    auto compressed = ProofCompressor::compress_chonk_proof(proof);
+    size_t byte_offset = element_idx * 32;
+    EXPECT_LT(byte_offset + 32, compressed.size());
+    // Overwrite the element with the given value (big-endian)
+    std::vector<uint8_t> buf;
+    write(buf, value);
+    std::copy(buf.begin(), buf.end(), compressed.begin() + static_cast<ptrdiff_t>(byte_offset));
+    return compressed;
+}
+
+// Rejects a BN scalar value >= Fr::modulus
+TEST_F(ChonkTests, DecompressionRejectsNonCanonicalBN254Scalar)
+{
+    TestSettings settings{ .log2_num_gates = SMALL_LOG_2_NUM_GATES };
+    auto [proof, vk_and_hash] = accumulate_and_prove_ivc(/*num_app_circuits=*/1, settings);
+    size_t mega_num_pub_inputs =
+        proof.hiding_oink_proof.size() - ProofLength::Oink<MegaZKFlavor>::LENGTH_WITHOUT_PUB_INPUTS;
+    ASSERT_GT(mega_num_pub_inputs, 0); // Need at least one public input (BN254 scalar)
+
+    // Element 0 is the first public input (a BN254 scalar). Set it to Fr::modulus (non-canonical).
+    using Fr = curve::BN254::ScalarField;
+
+    auto corrupted = compress_and_corrupt(proof, 0, Fr::modulus);
+    EXPECT_THROW_OR_ABORT(ProofCompressor::decompress_chonk_proof(corrupted, mega_num_pub_inputs), "");
+}
+
+// Rejects a BN commitment x-coordinate >= Fq::modulus
+TEST_F(ChonkTests, DecompressionRejectsNonCanonicalBN254CommitmentX)
+{
+    using Fq = curve::BN254::BaseField;
+
+    TestSettings settings{ .log2_num_gates = SMALL_LOG_2_NUM_GATES };
+    auto [proof, vk_and_hash] = accumulate_and_prove_ivc(/*num_app_circuits=*/1, settings);
+    size_t mega_num_pub_inputs =
+        proof.hiding_oink_proof.size() - ProofLength::Oink<MegaZKFlavor>::LENGTH_WITHOUT_PUB_INPUTS;
+
+    // First BN254 commitment is at element index mega_num_pub_inputs.
+    // Set x-coordinate to Fq::modulus + 1 (non-canonical, with no sign bit).
+    auto corrupted = compress_and_corrupt(proof, mega_num_pub_inputs, Fq::modulus + 1);
+    EXPECT_THROW_OR_ABORT(ProofCompressor::decompress_chonk_proof(corrupted, mega_num_pub_inputs), "");
+}
+
+// Rejects a canonical x-coordinate that is not on the BN254 curve
+TEST_F(ChonkTests, DecompressionRejectsInvalidBN254CurvePoint)
+{
+    using Fq = curve::BN254::BaseField;
+
+    TestSettings settings{ .log2_num_gates = SMALL_LOG_2_NUM_GATES };
+    auto [proof, vk_and_hash] = accumulate_and_prove_ivc(/*num_app_circuits=*/1, settings);
+    size_t mega_num_pub_inputs =
+        proof.hiding_oink_proof.size() - ProofLength::Oink<MegaZKFlavor>::LENGTH_WITHOUT_PUB_INPUTS;
+
+    // x=4 is not on BN254
+    Fq x_not_on_curve(4);
+    Fq rhs = x_not_on_curve * x_not_on_curve * x_not_on_curve + Fq(3);
+    auto [is_sq, _] = rhs.sqrt();
+    ASSERT_FALSE(is_sq);
+
+    auto corrupted = compress_and_corrupt(proof, mega_num_pub_inputs, uint256_t(x_not_on_curve));
+    EXPECT_THROW_OR_ABORT(ProofCompressor::decompress_chonk_proof(corrupted, mega_num_pub_inputs), "");
+}
+
+// Rejects a compressed proof that is too short (read_u256 bounds check)
+TEST_F(ChonkTests, DecompressionRejectsTruncatedProof)
+{
+    TestSettings settings{ .log2_num_gates = SMALL_LOG_2_NUM_GATES };
+    auto [proof, vk_and_hash] = accumulate_and_prove_ivc(/*num_app_circuits=*/1, settings);
+    size_t mega_num_pub_inputs =
+        proof.hiding_oink_proof.size() - ProofLength::Oink<MegaZKFlavor>::LENGTH_WITHOUT_PUB_INPUTS;
+
+    auto compressed = ProofCompressor::compress_chonk_proof(proof);
+    // Truncate by removing the last 32-byte element
+    compressed.resize(compressed.size() - 32);
+    EXPECT_THROW_OR_ABORT(ProofCompressor::decompress_chonk_proof(compressed, mega_num_pub_inputs), "");
+}

--- a/barretenberg/cpp/src/barretenberg/chonk/proof_compression.hpp
+++ b/barretenberg/cpp/src/barretenberg/chonk/proof_compression.hpp
@@ -59,6 +59,7 @@ class ProofCompressor {
 
     static uint256_t read_u256(const std::vector<uint8_t>& data, size_t& pos)
     {
+        BB_ASSERT(pos + 32 <= data.size());
         uint256_t val{ 0, 0, 0, 0 };
         for (int i = 31; i >= 0; --i) {
             val.data[i / 8] |= static_cast<uint64_t>(data[pos++]) << (8 * (i % 8));
@@ -502,7 +503,11 @@ class ProofCompressor {
         size_t pos = 0;
 
         // BN254 callbacks
-        auto bn254_scalar = [&]() { flat.emplace_back(read_u256(compressed, pos)); };
+        auto bn254_scalar = [&]() {
+            uint256_t raw = read_u256(compressed, pos);
+            BB_ASSERT(raw < Fr::modulus);
+            flat.emplace_back(raw);
+        };
 
         auto bn254_comm = [&]() {
             uint256_t raw = read_u256(compressed, pos);
@@ -516,6 +521,7 @@ class ProofCompressor {
                 return;
             }
 
+            BB_ASSERT(x_val < Fq::modulus);
             Fq x(x_val);
             Fq y_squared = x * x * x + Bn254G1Params::b;
             auto [is_square, y] = y_squared.sqrt();
@@ -545,6 +551,7 @@ class ProofCompressor {
                 return;
             }
 
+            BB_ASSERT(x_val < Fr::modulus);
             Fr x(x_val);
             // Grumpkin curve: y² = x³ + b, where b = -17 (in BN254::ScalarField)
             Fr y_squared = x * x * x + grumpkin::G1Params::b;
@@ -561,6 +568,7 @@ class ProofCompressor {
 
         auto grumpkin_scalar = [&]() {
             uint256_t raw = read_u256(compressed, pos);
+            BB_ASSERT(raw < Fq::modulus);
             Fq fq_val(raw);
             auto [lo, hi] = split_fq(fq_val);
             flat.emplace_back(lo);

--- a/barretenberg/cpp/src/barretenberg/chonk/proof_compression.hpp
+++ b/barretenberg/cpp/src/barretenberg/chonk/proof_compression.hpp
@@ -36,6 +36,11 @@ class ProofCompressor {
 
     static constexpr uint256_t SIGN_BIT_MASK = uint256_t(1) << 255;
 
+    // Non-canonical Fq value used as the point-at-infinity marker for BN254 commitments.
+    // Using Fq::modulus avoids ambiguity with x=0, which is a valid BN254 curve point (y²=3 is a QR mod p).
+    // Grumpkin does not need this since x=0 is not on the Grumpkin curve (y²=-17 is not a QR mod r).
+    static constexpr uint256_t BN254_INFINITY_MARKER = Fq::modulus;
+
     // Fq values are stored as (lo, hi) Fr pairs split at 2*NUM_LIMB_BITS = 136 bits.
     static constexpr uint64_t NUM_LIMB_BITS = 68;
     static constexpr uint64_t FQ_SPLIT_BITS = NUM_LIMB_BITS * 2; // 136
@@ -448,7 +453,7 @@ class ProofCompressor {
             bool is_infinity = flat[offset].is_zero() && flat[offset + 1].is_zero() && flat[offset + 2].is_zero() &&
                                flat[offset + 3].is_zero();
             if (is_infinity) {
-                write_u256(out, uint256_t(0));
+                write_u256(out, BN254_INFINITY_MARKER);
                 offset += 4;
                 return;
             }
@@ -511,16 +516,17 @@ class ProofCompressor {
 
         auto bn254_comm = [&]() {
             uint256_t raw = read_u256(compressed, pos);
-            bool sign = (raw & SIGN_BIT_MASK) != 0;
-            uint256_t x_val = raw & ~SIGN_BIT_MASK;
 
-            if (x_val == uint256_t(0) && !sign) {
+            // Point-at-infinity is encoded as Fq::modulus (a non-canonical value)
+            if (raw == BN254_INFINITY_MARKER) {
                 for (int j = 0; j < 4; j++) {
                     flat.emplace_back(Fr::zero());
                 }
                 return;
             }
 
+            bool sign = (raw & SIGN_BIT_MASK) != 0;
+            uint256_t x_val = raw & ~SIGN_BIT_MASK;
             BB_ASSERT(x_val < Fq::modulus);
             Fq x(x_val);
             Fq y_squared = x * x * x + Bn254G1Params::b;

--- a/barretenberg/cpp/src/barretenberg/chonk/proof_compression.hpp
+++ b/barretenberg/cpp/src/barretenberg/chonk/proof_compression.hpp
@@ -36,11 +36,6 @@ class ProofCompressor {
 
     static constexpr uint256_t SIGN_BIT_MASK = uint256_t(1) << 255;
 
-    // Non-canonical Fq value used as the point-at-infinity marker for BN254 commitments.
-    // Using Fq::modulus avoids ambiguity with x=0, which is a valid BN254 curve point (y²=3 is a QR mod p).
-    // Grumpkin does not need this since x=0 is not on the Grumpkin curve (y²=-17 is not a QR mod r).
-    static constexpr uint256_t BN254_INFINITY_MARKER = Fq::modulus;
-
     // Fq values are stored as (lo, hi) Fr pairs split at 2*NUM_LIMB_BITS = 136 bits.
     static constexpr uint64_t NUM_LIMB_BITS = 68;
     static constexpr uint64_t FQ_SPLIT_BITS = NUM_LIMB_BITS * 2; // 136
@@ -453,7 +448,7 @@ class ProofCompressor {
             bool is_infinity = flat[offset].is_zero() && flat[offset + 1].is_zero() && flat[offset + 2].is_zero() &&
                                flat[offset + 3].is_zero();
             if (is_infinity) {
-                write_u256(out, BN254_INFINITY_MARKER);
+                write_u256(out, uint256_t(0));
                 offset += 4;
                 return;
             }
@@ -516,17 +511,18 @@ class ProofCompressor {
 
         auto bn254_comm = [&]() {
             uint256_t raw = read_u256(compressed, pos);
+            bool sign = (raw & SIGN_BIT_MASK) != 0;
+            uint256_t x_val = raw & ~SIGN_BIT_MASK;
 
-            // Point-at-infinity is encoded as Fq::modulus (a non-canonical value)
-            if (raw == BN254_INFINITY_MARKER) {
+            // Point-at-infinity is encoded as all zeros (x=0, sign=false).
+            // Unambiguous because x=0 is not on BN254
+            if (x_val == uint256_t(0) && !sign) {
                 for (int j = 0; j < 4; j++) {
                     flat.emplace_back(Fr::zero());
                 }
                 return;
             }
 
-            bool sign = (raw & SIGN_BIT_MASK) != 0;
-            uint256_t x_val = raw & ~SIGN_BIT_MASK;
             BB_ASSERT(x_val < Fq::modulus);
             Fq x(x_val);
             Fq y_squared = x * x * x + Bn254G1Params::b;
@@ -551,6 +547,8 @@ class ProofCompressor {
             bool sign = (raw & SIGN_BIT_MASK) != 0;
             uint256_t x_val = raw & ~SIGN_BIT_MASK;
 
+            // Point-at-infinity is encoded as all zeros (x=0, sign=false).
+            // Unambiguous because x=0 is not on Grumpkin
             if (x_val == uint256_t(0) && !sign) {
                 flat.emplace_back(Fr::zero());
                 flat.emplace_back(Fr::zero());
@@ -559,7 +557,6 @@ class ProofCompressor {
 
             BB_ASSERT(x_val < Fr::modulus);
             Fr x(x_val);
-            // Grumpkin curve: y² = x³ + b, where b = -17 (in BN254::ScalarField)
             Fr y_squared = x * x * x + grumpkin::G1Params::b;
             auto [is_square, y] = y_squared.sqrt();
             BB_ASSERT(is_square);


### PR DESCRIPTION
Resolves the following defense in depth issues related to Chonk Proof decompression:
- [2205](https://github.com/AztecProtocol/barretenberg-claude/issues/2205): ensure deserialized u256s are less than field modulus. (No real risk in not fixing this; there's no attack)
- EDIT: [2207](https://github.com/AztecProtocol/barretenberg-claude/issues/2207): is a non-issue because (0, sqrt(3)) is NOT on BN. keeping the original x==0 representaiton for infinity is fine for both BN and Grump