### PR TITLE
chore: crypto primitives external audit response 0

### DIFF
--- a/barretenberg/cpp/src/barretenberg/commitment_schemes/commitment_key.hpp
+++ b/barretenberg/cpp/src/barretenberg/commitment_schemes/commitment_key.hpp
@@ -111,7 +111,6 @@ template <class Curve> class CommitmentKey {
             std::vector<std::span<Fr>> scalar_spans;
 
             for (auto& polynomial : polynomials.subspan(i, batch_end - i)) {
-                std::span<const Commitment> point_table = get_monomial_points().subspan(polynomial.start_index());
                 size_t consumed_srs = polynomial.start_index() + polynomial.size();
                 if (consumed_srs > get_monomial_size()) {
                     throw_or_abort(format("Attempting to commit to a polynomial that needs ",
@@ -119,6 +118,7 @@ template <class Curve> class CommitmentKey {
                                           " points with an SRS of size ",
                                           get_monomial_size()));
                 }
+                std::span<const Commitment> point_table = get_monomial_points().subspan(polynomial.start_index());
                 scalar_spans.emplace_back(polynomial.coeffs());
                 points_spans.emplace_back(point_table);
             }

--- a/barretenberg/cpp/src/barretenberg/commitment_schemes/ipa/ipa.hpp
+++ b/barretenberg/cpp/src/barretenberg/commitment_schemes/ipa/ipa.hpp
@@ -832,7 +832,7 @@ template <typename Curve_, size_t log_poly_length = CONST_ECCVM_LOG_N> class IPA
     {
         // Extract batch_mul arguments from the accumulator
         const auto& commitments = batch_opening_claim.commitments;
-        const auto& scalars = batch_opening_claim.scalars;
+        auto scalars = batch_opening_claim.scalars; // mutable copy: batch_mul temporarily modifies scalars
         const Fr& shplonk_eval_challenge = batch_opening_claim.evaluation_point;
         // Compute \f$ C = \sum \text{commitments}_i \cdot \text{scalars}_i \f$
         GroupElement shplonk_output_commitment = GroupElement::batch_mul(commitments, scalars);

--- a/barretenberg/cpp/src/barretenberg/ecc/fields/field_conversion.hpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/fields/field_conversion.hpp
@@ -133,7 +133,9 @@ class FrCodec {
             T val;
             val.x = deserialize_from_fields<BaseField>(fr_vec.subspan(0, BASE));
             val.y = deserialize_from_fields<BaseField>(fr_vec.subspan(BASE, BASE));
-            BB_ASSERT(val.on_curve());
+            if (!val.on_curve()) {
+                throw_or_abort("Deserialized point is not on the curve");
+            }
             return val;
         } else {
             // Array or Univariate
@@ -268,7 +270,9 @@ class U256Codec {
             if (val.x == BaseField::zero() && val.y == BaseField::zero()) {
                 val.self_set_infinity();
             }
-            BB_ASSERT(val.on_curve());
+            if (!val.on_curve()) {
+                throw_or_abort("Deserialized point is not on the curve");
+            }
             return val;
         } else {
             // Array or Univariate

--- a/barretenberg/cpp/src/barretenberg/ecc/groups/affine_element.hpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/groups/affine_element.hpp
@@ -199,7 +199,7 @@ template <typename Fq_, typename Fr_, typename Params_> class alignas(64) affine
      * @param masking_scalar Ignored for native (needed for safe offset generators in stdlib)
      */
     static affine_element batch_mul(std::span<const affine_element> points,
-                                    std::span<const Fr> scalars,
+                                    std::span<Fr> scalars,
                                     size_t max_num_bits = 0,
                                     bool with_edgecases = true,
                                     const Fr& masking_scalar = Fr(1)) noexcept;

--- a/barretenberg/cpp/src/barretenberg/ecc/groups/element.hpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/groups/element.hpp
@@ -107,7 +107,7 @@ template <class Fq, class Fr, class Params> class alignas(32) element {
      * @details Delegates to affine_element::batch_mul. Provided for interface compatibility with stdlib.
      */
     static affine_element<Fq, Fr, Params> batch_mul(std::span<const affine_element<Fq, Fr, Params>> points,
-                                                    std::span<const Fr> scalars,
+                                                    std::span<Fr> scalars,
                                                     size_t max_num_bits = 0,
                                                     bool with_edgecases = true,
                                                     const Fr& masking_scalar = Fr(1)) noexcept

--- a/barretenberg/cpp/src/barretenberg/ecc/groups/element_batch_mul.cpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/groups/element_batch_mul.cpp
@@ -25,7 +25,7 @@ template <> struct curve_for_element<fr, fq, grumpkin::G1Params> {
 template <class Fq, class Fr, class Params>
 affine_element<Fq, Fr, Params> affine_element<Fq, Fr, Params>::batch_mul(
     std::span<const affine_element<Fq, Fr, Params>> points,
-    std::span<const Fr> scalars,
+    std::span<Fr> scalars,
     [[maybe_unused]] size_t max_num_bits,
     bool with_edgecases,
     [[maybe_unused]] const Fr& masking_scalar) noexcept
@@ -42,14 +42,14 @@ affine_element<Fq, Fr, Params> affine_element<Fq, Fr, Params>::batch_mul(
 // Explicit instantiations for supported curves
 template affine_element<fq, fr, Bn254G1Params> affine_element<fq, fr, Bn254G1Params>::batch_mul(
     std::span<const affine_element<fq, fr, Bn254G1Params>> points,
-    std::span<const fr> scalars,
+    std::span<fr> scalars,
     size_t max_num_bits,
     bool with_edgecases,
     const fr& masking_scalar) noexcept;
 
 template affine_element<fr, fq, grumpkin::G1Params> affine_element<fr, fq, grumpkin::G1Params>::batch_mul(
     std::span<const affine_element<fr, fq, grumpkin::G1Params>> points,
-    std::span<const fq> scalars,
+    std::span<fq> scalars,
     size_t max_num_bits,
     bool with_edgecases,
     const fq& masking_scalar) noexcept;

--- a/barretenberg/cpp/src/barretenberg/ecc/scalar_multiplication/bitvector.hpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/scalar_multiplication/bitvector.hpp
@@ -17,6 +17,8 @@
  * @brief Custom class to handle packed vectors of bits
  * @details The cpp std::vector<bool> does not guarantee memory adjacency of values, and has no fast primitive for
  * clearing all bits in the vector. This is to avoid needing to clear all Pippenger buckets every round
+ * @note NOT THREAD-SAFE. Concurrent set() calls on indices sharing the same 64-bit word will race.
+ *       Current usage is safe because each BucketAccumulators instance is per-thread.
  */
 class BitVector {
   public:

--- a/barretenberg/cpp/src/barretenberg/ecc/scalar_multiplication/scalar_multiplication.hpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/scalar_multiplication/scalar_multiplication.hpp
@@ -39,6 +39,9 @@ template <typename Curve> class MSM {
 
     // Maximum bits per scalar slice (2^20 = 1M buckets, far beyond practical use)
     static constexpr size_t MAX_SLICE_BITS = 20;
+    static_assert(MAX_SLICE_BITS < 64,
+                  "get_scalar_slice uses 1ULL << lo_slice_bits where lo_slice_bits <= MAX_SLICE_BITS - 1; "
+                  "shifting uint64_t by >= 64 is UB.");
 
     // Number of points to look ahead for memory prefetching
     static constexpr size_t PREFETCH_LOOKAHEAD = 32;

--- a/barretenberg/cpp/src/barretenberg/hypernova/hypernova_prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/hypernova/hypernova_prover.cpp
@@ -14,7 +14,7 @@ namespace bb {
 
 template <size_t N>
 HypernovaFoldingProver::Commitment HypernovaFoldingProver::batch_mul(const RefArray<Commitment, N>& _points,
-                                                                     const std::vector<FF>& scalars)
+                                                                     std::vector<FF>& scalars)
 {
     std::vector<Commitment> points(N);
     for (size_t idx = 0; idx < N; ++idx) {

--- a/barretenberg/cpp/src/barretenberg/hypernova/hypernova_prover.hpp
+++ b/barretenberg/cpp/src/barretenberg/hypernova/hypernova_prover.hpp
@@ -113,7 +113,7 @@ class HypernovaFoldingProver {
     /**
      * @brief Utility to perform batch mul of commitments.
      */
-    template <size_t N> Commitment batch_mul(const RefArray<Commitment, N>& _points, const std::vector<FF>& scalars);
+    template <size_t N> Commitment batch_mul(const RefArray<Commitment, N>& _points, std::vector<FF>& scalars);
 };
 
 } // namespace bb

--- a/barretenberg/cpp/src/barretenberg/hypernova/hypernova_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/hypernova/hypernova_verifier.cpp
@@ -13,7 +13,7 @@ namespace bb {
 template <typename Flavor_>
 template <size_t N>
 HypernovaFoldingVerifier<Flavor_>::Commitment HypernovaFoldingVerifier<Flavor_>::batch_mul(
-    const RefArray<Commitment, N>& _points, const std::vector<FF>& scalars)
+    const RefArray<Commitment, N>& _points, std::vector<FF>& scalars)
 {
     std::vector<Commitment> points(N);
     for (size_t idx = 0; idx < N; ++idx) {

--- a/barretenberg/cpp/src/barretenberg/hypernova/hypernova_verifier.hpp
+++ b/barretenberg/cpp/src/barretenberg/hypernova/hypernova_verifier.hpp
@@ -89,6 +89,6 @@ template <typename Flavor_> class HypernovaFoldingVerifier {
     /**
      * @brief Utility to perform batch mul of commitments.
      */
-    template <size_t N> Commitment batch_mul(const RefArray<Commitment, N>& _points, const std::vector<FF>& scalars);
+    template <size_t N> Commitment batch_mul(const RefArray<Commitment, N>& _points, std::vector<FF>& scalars);
 };
 } // namespace bb

--- a/barretenberg/cpp/src/barretenberg/ipc/socket_server.cpp
+++ b/barretenberg/cpp/src/barretenberg/ipc/socket_server.cpp
@@ -6,6 +6,7 @@
 #include <span>
 #include <string>
 #include <sys/socket.h>
+#include <sys/stat.h>
 #include <sys/types.h>
 #include <sys/un.h>
 #include <unistd.h>
@@ -217,6 +218,9 @@ bool SocketServer::listen()
         return false;
     }
 
+    // Restrict socket to owner only, matching the 0600 mode used for SHM transport
+    ::chmod(socket_path_.c_str(), 0600);
+
     // Listen with backlog
     int backlog = initial_max_clients_ > 0 ? initial_max_clients_ : 10;
     if (::listen(listen_fd_, backlog) < 0) {
@@ -417,6 +421,9 @@ bool SocketServer::listen()
         listen_fd_ = -1;
         return false;
     }
+
+    // Restrict socket to owner only, matching the 0600 mode used for SHM transport
+    ::chmod(socket_path_.c_str(), 0600);
 
     // Listen with backlog
     int backlog = initial_max_clients_ > 0 ? initial_max_clients_ : 10;

--- a/barretenberg/cpp/src/barretenberg/srs/global_crs.cpp
+++ b/barretenberg/cpp/src/barretenberg/srs/global_crs.cpp
@@ -25,6 +25,9 @@ std::filesystem::path bb_crs_path()
 
 void init_bn254_mem_crs_factory(std::vector<g1::affine_element> const& points, g2::affine_element const& g2_point)
 {
+    if (bn254_crs_factory != nullptr) {
+        return;
+    }
     bn254_crs_factory = std::make_shared<factories::MemBn254CrsFactory>(points, g2_point);
 }
 


### PR DESCRIPTION
### Audit Context

Addresses findings from the "Aztec - Cryptographic Primitives" external audit. This is response 0, covering the findings that have straightforward fixes.

### Changes Made

**Finding 1: Off-Curve Proof Commitment Crashes WASM Verifier**
Replace `BB_ASSERT(val.on_curve())` with explicit `throw_or_abort` in both FrCodec and U256Codec deserialization paths (`field_conversion.hpp`). This routes the error through the standard error path that is catchable by bbapi's try-catch in native builds, rather than going through `assert_failure`.

**Finding 2: WASM Process DOS via Oversized Polynomial in Prover Commit Path**
No changes in this PR. Requires a WASM-compatible recovery boundary (setjmp/longjmp or extending try_catch_shim.hpp). Will be addressed in a follow-up.

**Finding 3: SRS Downloaded Using HTTP**
No changes in this PR. Already mitigated by SHA-256 chunk hash verification (PR #21113). Switching to HTTPS requires resolving the OpenSSL cross-compilation dependency. Deferred.

**Finding 4: bbapi Unix Socket Accepts Unauthenticated SRS Replacement**
- Add `chmod(socket_path, 0600)` after `bind()` on both macOS and Linux socket paths, matching the 0600 mode already used for the SHM transport.
- Add null-guard to `init_bn254_mem_crs_factory()` to prevent replacing an already-initialized SRS, matching the existing guards on `init_bn254_net_crs_factory` and `init_bn254_file_crs_factory`.

**Finding 5: Latent Shift-UB in get_scalar_slice**
Add `static_assert(MAX_SLICE_BITS < 64, ...)` to encode the invariant that the shift in `get_scalar_slice` remains well-defined.

**Finding 6: batch_commit() Subspan Constructed Before Bounds Check**
Move the SRS bounds check before the `subspan()` call in `batch_commit()`. `std::span::subspan()` has UB when offset > size(). This brings `batch_commit` in line with `commit()` which already validates first.

**Finding 7: Witness Polynomial Coefficients Vulnerable to Leakage**
No changes. Threat model does not support this being a real vector: PXE in an extension runs in a separate origin, and for embedded wallets there is no trust boundary. Not prioritized.

**Finding 8: BitVector::set() Non-Atomic RMW Has No Thread-Safety Guard**
Add NOT THREAD-SAFE documentation to `BitVector` class noting that concurrent `set()` calls on indices in the same 64-bit word will race. Current usage is safe due to per-thread `BucketAccumulators` ownership.

**Finding 9: batch_mul Mutates Scalars Through const Interface**
Change `batch_mul`'s public interface from `std::span<const Fr>` to `std::span<Fr>`, making the mutation contract explicit. The MSM internally converts scalars from/to Montgomery form, so callers must provide mutable scalars. Updated HyperNova prover/verifier wrappers (drop const) and IPA `reduce_batch_opening_claim` (mutable copy).

### Checklist

- [x] Confirmed and documented security issues found
- [x] Verified that tests cover all critical paths
- [x] Verified build passes (`ninja` clean build)
- [x] Ran ecc_tests (830 passed), srs_tests (29 passed), commitment_schemes_tests (88 passed), hypernova_tests (9 passed)