### PR TITLE
chore(avm): verbose print halting mode and message

### DIFF
--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/execution.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/execution.cpp
@@ -793,6 +793,7 @@ void Execution::ret(ContextInterface& context, MemoryAddress ret_size_offset, Me
                            .gas_used = context.get_gas_used(),
                            .success = true,
                            .halting_pc = context.get_pc(),
+                           .halting_mode = HaltingMode::RETURN,
                            .halting_message = std::nullopt });
 
     context.halt();
@@ -826,6 +827,7 @@ void Execution::revert(ContextInterface& context, MemoryAddress rev_size_offset,
                            .gas_used = context.get_gas_used(),
                            .success = false,
                            .halting_pc = context.get_pc(),
+                           .halting_mode = HaltingMode::REVERT,
                            .halting_message = "Assertion failed: " });
 
     context.halt();
@@ -1849,9 +1851,11 @@ EnqueuedCallResult Execution::execute(std::unique_ptr<ContextInterface> enqueued
     }
 
     const ExecutionResult& result = get_execution_result();
-    return {
+    return EnqueuedCallResult{
         .success = result.success,
         .gas_used = result.gas_used,
+        .halting_mode = result.halting_mode,
+        .halting_message = result.halting_message,
     };
 }
 
@@ -1969,6 +1973,7 @@ void Execution::handle_exceptional_halt(ContextInterface& context, const std::st
         .gas_used = context.get_gas_used(),
         .success = false,
         .halting_pc = context.get_pc(),
+        .halting_mode = HaltingMode::EXCEPTIONAL_HALT,
         .halting_message = halting_message,
     });
 }

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/execution.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/execution.hpp
@@ -213,7 +213,8 @@ class Execution : public ExecutionInterface {
         MemoryAddress rd_size;
         Gas gas_used;
         bool success;
-        PC halting_pc = 0;                          // PC at which the context halted.
+        PC halting_pc = 0; // PC at which the context halted.
+        HaltingMode halting_mode = HaltingMode::UNDEFINED;
         std::optional<std::string> halting_message; // If reverted.
     };
 

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/tx_execution.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/tx_execution.cpp
@@ -18,6 +18,23 @@ class TxExecutionException : public std::runtime_error {
     {}
 };
 
+std::string get_halting_information(const EnqueuedCallResult& result)
+{
+    std::string halting_message =
+        result.halting_message.has_value() ? " with message: " + result.halting_message.value() : "";
+
+    switch (result.halting_mode) {
+    case HaltingMode::RETURN:
+        return "RETURN" + halting_message;
+    case HaltingMode::REVERT:
+        return "REVERT" + halting_message;
+    case HaltingMode::EXCEPTIONAL_HALT:
+        return "EXCEPTIONAL_HALT";
+    default:
+        return "UNKNOWN" + halting_message;
+    }
+}
+
 } // namespace
 
 /**
@@ -115,6 +132,11 @@ TxExecutionResult TxExecution::simulate(const Tx& tx)
             // This call should not throw unless it's an unexpected unrecoverable failure.
             EnqueuedCallResult result = call_execution.execute(std::move(context));
             tx_context.gas_used = result.gas_used;
+            vinfo("[SETUP] Enqueued call to ",
+                  call.request.contract_address,
+                  " halted via ",
+                  get_halting_information(result));
+
             emit_public_call_request(call,
                                      TransactionPhase::SETUP,
                                      /*transaction_fee=*/FF(0),
@@ -175,6 +197,10 @@ TxExecutionResult TxExecution::simulate(const Tx& tx)
                 // This call should not throw unless it's an unexpected unrecoverable failure.
                 EnqueuedCallResult result = call_execution.execute(std::move(context));
                 tx_context.gas_used = result.gas_used;
+                vinfo("[APP_LOGIC] Enqueued call to ",
+                      call.request.contract_address,
+                      " halted via ",
+                      get_halting_information(result));
 
                 emit_public_call_request(call,
                                          TransactionPhase::APP_LOGIC,
@@ -239,6 +265,11 @@ TxExecutionResult TxExecution::simulate(const Tx& tx)
             // This call should not throw unless it's an unexpected unrecoverable failure.
             EnqueuedCallResult result = call_execution.execute(std::move(context));
             gas_used_by_teardown = result.gas_used;
+            vinfo("[TEARDOWN] Enqueued call to ",
+                  teardown_enqueued_call.request.contract_address,
+                  " halted via ",
+                  get_halting_information(result));
+
             emit_public_call_request(teardown_enqueued_call,
                                      TransactionPhase::TEARDOWN,
                                      fee,

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/interfaces/execution.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/interfaces/execution.hpp
@@ -15,9 +15,19 @@ namespace bb::avm2::simulation {
 // Forward declarations
 class ContextInterface;
 
+enum HaltingMode : uint8_t {
+    UNDEFINED,
+    RETURN,
+    REVERT,
+    EXCEPTIONAL_HALT,
+};
+
 struct EnqueuedCallResult {
     bool success;
     Gas gas_used;
+    // For debugging.
+    HaltingMode halting_mode;
+    std::optional<std::string> halting_message;
 };
 
 class ExecutionInterface {

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/standalone/hybrid_execution.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/standalone/hybrid_execution.cpp
@@ -103,10 +103,12 @@ EnqueuedCallResult HybridExecution::execute(std::unique_ptr<ContextInterface> en
         }
     }
 
-    ExecutionResult result = get_execution_result();
-    return {
+    const ExecutionResult& result = get_execution_result();
+    return EnqueuedCallResult{
         .success = result.success,
         .gas_used = result.gas_used,
+        .halting_mode = result.halting_mode,
+        .halting_message = result.halting_message,
     };
 }
 


### PR DESCRIPTION
Now we get verbose output like this

```
[SETUP] Executing enqueued call to 0x0000000000000000000000000000000000000000000000000000000000000001::<selector: 0x00000000000000000000000000000000000000000000000000000000b839de91> (mem: 1369.10 MiB)
[SETUP] Enqueued call to 0x0000000000000000000000000000000000000000000000000000000000000001 halted via RETURN (mem: 1369.10 MiB)
[SETUP] Executing enqueued call to 0x032c58e96ae548117429f076b27ae0280211d7f6833ff22d3835ca90cfac8cdd::<selector: 0x000000000000000000000000000000000000000000000000000000008c9e5472> (mem: 1369.10 MiB)
[SETUP] Enqueued call to 0x032c58e96ae548117429f076b27ae0280211d7f6833ff22d3835ca90cfac8cdd halted via REVERT with message: Assertion failed:  (mem: 1369.10 MiB)
PureTxBytecodeManager held 1183 instructions in cache, totaling ~179 kB. (mem: 1369.10 MiB)
```

Happens only once per enqueued call and only in verbose mode so it shouldn't be a problem with performance.

Note: this is only in C++ and does not propagate to TS.