### PR TITLE
feat: switch memory profiling from peak RSS to live heap usage

### DIFF
--- a/barretenberg/cpp/scripts/extract_memory_benchmarks.py
+++ b/barretenberg/cpp/scripts/extract_memory_benchmarks.py
@@ -44,8 +44,8 @@ try:
         entries.append({
             "name": f"{name_path}/{label}",
             "unit": "MB",
-            "value": cp["rss_mb"],
-            "extra": f"stacked:{name_path}/rss_over_stages"
+            "value": cp["heap_mb"],
+            "extra": f"stacked:{name_path}/heap_over_stages"
         })
 
     # Append to existing benchmarks file

--- a/barretenberg/cpp/scripts/extract_memory_benchmarks.py
+++ b/barretenberg/cpp/scripts/extract_memory_benchmarks.py
@@ -44,8 +44,8 @@ try:
         entries.append({
             "name": f"{name_path}/{label}",
             "unit": "MB",
-            "value": cp["heap_mb"],
-            "extra": f"stacked:{name_path}/heap_over_stages"
+            "value": cp["rss_mb"],
+            "extra": f"stacked:{name_path}/rss_over_stages"
         })
 
     # Append to existing benchmarks file

--- a/barretenberg/cpp/src/barretenberg/chonk/chonk.cpp
+++ b/barretenberg/cpp/src/barretenberg/chonk/chonk.cpp
@@ -540,7 +540,7 @@ void Chonk::accumulate_and_fold(ClientCircuit& circuit,
     }
 
     if (detail::use_memory_profile) {
-        detail::GLOBAL_MEMORY_PROFILE.add_rss_checkpoint("after_accumulate");
+        detail::GLOBAL_MEMORY_PROFILE.add_checkpoint("after_accumulate");
         detail::GLOBAL_MEMORY_PROFILE.next_circuit();
     }
 

--- a/barretenberg/cpp/src/barretenberg/chonk/chonk.cpp
+++ b/barretenberg/cpp/src/barretenberg/chonk/chonk.cpp
@@ -540,7 +540,7 @@ void Chonk::accumulate_and_fold(ClientCircuit& circuit,
     }
 
     if (detail::use_memory_profile) {
-        detail::GLOBAL_MEMORY_PROFILE.add_checkpoint("after_accumulate");
+        detail::GLOBAL_MEMORY_PROFILE.add_rss_checkpoint("after_accumulate");
         detail::GLOBAL_MEMORY_PROFILE.next_circuit();
     }
 

--- a/barretenberg/cpp/src/barretenberg/common/memory_profile.cpp
+++ b/barretenberg/cpp/src/barretenberg/common/memory_profile.cpp
@@ -6,6 +6,27 @@
 
 #include "barretenberg/serialize/msgpack_impl.hpp"
 
+#if defined(__linux__)
+#include <malloc.h>
+#endif
+
+namespace {
+
+size_t heap_allocated_mb()
+{
+#if defined(__linux__)
+    struct mallinfo2 info = mallinfo2();
+    return info.uordblks / (1024ULL * 1024ULL);
+#elif defined(__wasm__)
+    return 0;
+#else
+    // mallinfo2 is Linux-specific; fall back to peak RSS on other platforms
+    return peak_rss_bytes() / (1024ULL * 1024ULL);
+#endif
+}
+
+} // namespace
+
 namespace bb::detail {
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
@@ -13,15 +34,10 @@ bool use_memory_profile = false;
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 MemoryProfile GLOBAL_MEMORY_PROFILE;
 
-void MemoryProfile::add_rss_checkpoint(const std::string& stage)
+void MemoryProfile::add_checkpoint(const std::string& stage)
 {
     std::lock_guard<std::mutex> lock(mutex);
-#ifdef __wasm__
-    size_t rss_mb = 0;
-#else
-    size_t rss_mb = static_cast<size_t>(peak_rss_bytes() / (1024ULL * 1024ULL));
-#endif
-    rss_checkpoints.push_back(RssCheckpoint{ stage, current_circuit_index, current_circuit_name, rss_mb });
+    checkpoints.push_back(MemoryCheckpoint{ stage, current_circuit_index, current_circuit_name, heap_allocated_mb() });
 }
 
 void MemoryProfile::set_circuit_name(const std::string& name)
@@ -39,7 +55,7 @@ void MemoryProfile::next_circuit()
 void MemoryProfile::clear()
 {
     std::lock_guard<std::mutex> lock(mutex);
-    rss_checkpoints.clear();
+    checkpoints.clear();
     current_circuit_name.clear();
     current_circuit_index = 0;
 }
@@ -48,7 +64,7 @@ void MemoryProfile::serialize_json(std::ostream& os) const
 {
     // Use msgpack round-trip to produce JSON (same pattern as bb_bench.cpp)
     msgpack::sbuffer buffer;
-    msgpack::pack(buffer, rss_checkpoints);
+    msgpack::pack(buffer, checkpoints);
     msgpack::object_handle oh = msgpack::unpack(buffer.data(), buffer.size());
     os << oh.get() << std::endl;
 }

--- a/barretenberg/cpp/src/barretenberg/common/memory_profile.cpp
+++ b/barretenberg/cpp/src/barretenberg/common/memory_profile.cpp
@@ -6,27 +6,6 @@
 
 #include "barretenberg/serialize/msgpack_impl.hpp"
 
-#if defined(__linux__)
-#include <malloc.h>
-#endif
-
-namespace {
-
-size_t heap_allocated_mb()
-{
-#if defined(__linux__)
-    struct mallinfo2 info = mallinfo2();
-    return info.uordblks / (1024ULL * 1024ULL);
-#elif defined(__wasm__)
-    return 0;
-#else
-    // mallinfo2 is Linux-specific; fall back to peak RSS on other platforms
-    return peak_rss_bytes() / (1024ULL * 1024ULL);
-#endif
-}
-
-} // namespace
-
 namespace bb::detail {
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
@@ -34,10 +13,15 @@ bool use_memory_profile = false;
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 MemoryProfile GLOBAL_MEMORY_PROFILE;
 
-void MemoryProfile::add_checkpoint(const std::string& stage)
+void MemoryProfile::add_rss_checkpoint(const std::string& stage)
 {
     std::lock_guard<std::mutex> lock(mutex);
-    checkpoints.push_back(MemoryCheckpoint{ stage, current_circuit_index, current_circuit_name, heap_allocated_mb() });
+#ifdef __wasm__
+    size_t rss_mb = 0;
+#else
+    size_t rss_mb = static_cast<size_t>(peak_rss_bytes() / (1024ULL * 1024ULL));
+#endif
+    rss_checkpoints.push_back(RssCheckpoint{ stage, current_circuit_index, current_circuit_name, rss_mb });
 }
 
 void MemoryProfile::set_circuit_name(const std::string& name)
@@ -55,7 +39,7 @@ void MemoryProfile::next_circuit()
 void MemoryProfile::clear()
 {
     std::lock_guard<std::mutex> lock(mutex);
-    checkpoints.clear();
+    rss_checkpoints.clear();
     current_circuit_name.clear();
     current_circuit_index = 0;
 }
@@ -64,7 +48,7 @@ void MemoryProfile::serialize_json(std::ostream& os) const
 {
     // Use msgpack round-trip to produce JSON (same pattern as bb_bench.cpp)
     msgpack::sbuffer buffer;
-    msgpack::pack(buffer, checkpoints);
+    msgpack::pack(buffer, rss_checkpoints);
     msgpack::object_handle oh = msgpack::unpack(buffer.data(), buffer.size());
     os << oh.get() << std::endl;
 }

--- a/barretenberg/cpp/src/barretenberg/common/memory_profile.hpp
+++ b/barretenberg/cpp/src/barretenberg/common/memory_profile.hpp
@@ -13,22 +13,22 @@ namespace bb::detail {
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 extern bool use_memory_profile;
 
-struct RssCheckpoint {
+struct MemoryCheckpoint {
     std::string stage;
     size_t circuit_index;
     std::string circuit_name;
-    size_t rss_mb;
+    size_t heap_mb; // live heap allocations via mallinfo2 (Linux) or peak RSS (other platforms)
 
-    SERIALIZATION_FIELDS(stage, circuit_index, circuit_name, rss_mb);
+    SERIALIZATION_FIELDS(stage, circuit_index, circuit_name, heap_mb);
 };
 
 struct MemoryProfile {
     std::mutex mutex;
-    std::vector<RssCheckpoint> rss_checkpoints;
+    std::vector<MemoryCheckpoint> checkpoints;
     std::string current_circuit_name;
     size_t current_circuit_index = 0;
 
-    void add_rss_checkpoint(const std::string& stage);
+    void add_checkpoint(const std::string& stage);
     void set_circuit_name(const std::string& name);
     void next_circuit();
     void serialize_json(std::ostream& os) const;

--- a/barretenberg/cpp/src/barretenberg/common/memory_profile.hpp
+++ b/barretenberg/cpp/src/barretenberg/common/memory_profile.hpp
@@ -13,22 +13,22 @@ namespace bb::detail {
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 extern bool use_memory_profile;
 
-struct MemoryCheckpoint {
+struct RssCheckpoint {
     std::string stage;
     size_t circuit_index;
     std::string circuit_name;
-    size_t heap_mb; // live heap allocations via mallinfo2 (Linux) or peak RSS (other platforms)
+    size_t rss_mb;
 
-    SERIALIZATION_FIELDS(stage, circuit_index, circuit_name, heap_mb);
+    SERIALIZATION_FIELDS(stage, circuit_index, circuit_name, rss_mb);
 };
 
 struct MemoryProfile {
     std::mutex mutex;
-    std::vector<MemoryCheckpoint> checkpoints;
+    std::vector<RssCheckpoint> rss_checkpoints;
     std::string current_circuit_name;
     size_t current_circuit_index = 0;
 
-    void add_checkpoint(const std::string& stage);
+    void add_rss_checkpoint(const std::string& stage);
     void set_circuit_name(const std::string& name);
     void next_circuit();
     void serialize_json(std::ostream& os) const;

--- a/barretenberg/cpp/src/barretenberg/common/serialize.hpp
+++ b/barretenberg/cpp/src/barretenberg/common/serialize.hpp
@@ -163,7 +163,7 @@ void read(std::vector<uint8_t> const& buf, std::integral auto& value)
 void write(std::vector<uint8_t>& buf, const std::integral auto& value)
 {
     buf.resize(buf.size() + sizeof(value));
-    uint8_t* ptr = &*buf.end() - sizeof(value);
+    uint8_t* ptr = buf.data() + buf.size() - sizeof(value);
     write(ptr, value);
 }
 
@@ -248,7 +248,7 @@ inline void write(std::ostream& os, std::vector<uint8_t> const& value)
 template <size_t N> inline void write(std::vector<uint8_t>& buf, std::array<uint8_t, N> const& value)
 {
     buf.resize(buf.size() + N);
-    auto* ptr = &*buf.end() - N;
+    auto* ptr = buf.data() + buf.size() - N;
     write(ptr, value);
 }
 

--- a/barretenberg/cpp/src/barretenberg/hypernova/hypernova_prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/hypernova/hypernova_prover.cpp
@@ -120,7 +120,7 @@ HypernovaFoldingProver::Accumulator HypernovaFoldingProver::instance_to_accumula
     MegaOinkProver oink_prover{ instance, precomputed_vk, transcript };
     oink_prover.prove();
     if (detail::use_memory_profile) {
-        detail::GLOBAL_MEMORY_PROFILE.add_rss_checkpoint("after_oink");
+        detail::GLOBAL_MEMORY_PROFILE.add_checkpoint("after_oink");
     }
 
     instance->gate_challenges = transcript->template get_dyadic_powers_of_challenge<FF>(
@@ -136,7 +136,7 @@ HypernovaFoldingProver::Accumulator HypernovaFoldingProver::instance_to_accumula
                                 Flavor::VIRTUAL_LOG_N);
     auto sumcheck_output = sumcheck.prove();
     if (detail::use_memory_profile) {
-        detail::GLOBAL_MEMORY_PROFILE.add_rss_checkpoint("after_sumcheck");
+        detail::GLOBAL_MEMORY_PROFILE.add_checkpoint("after_sumcheck");
     }
 
     Accumulator accumulator = sumcheck_output_to_accumulator(sumcheck_output, instance, precomputed_vk);

--- a/barretenberg/cpp/src/barretenberg/hypernova/hypernova_prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/hypernova/hypernova_prover.cpp
@@ -120,7 +120,7 @@ HypernovaFoldingProver::Accumulator HypernovaFoldingProver::instance_to_accumula
     MegaOinkProver oink_prover{ instance, precomputed_vk, transcript };
     oink_prover.prove();
     if (detail::use_memory_profile) {
-        detail::GLOBAL_MEMORY_PROFILE.add_checkpoint("after_oink");
+        detail::GLOBAL_MEMORY_PROFILE.add_rss_checkpoint("after_oink");
     }
 
     instance->gate_challenges = transcript->template get_dyadic_powers_of_challenge<FF>(
@@ -136,7 +136,7 @@ HypernovaFoldingProver::Accumulator HypernovaFoldingProver::instance_to_accumula
                                 Flavor::VIRTUAL_LOG_N);
     auto sumcheck_output = sumcheck.prove();
     if (detail::use_memory_profile) {
-        detail::GLOBAL_MEMORY_PROFILE.add_checkpoint("after_sumcheck");
+        detail::GLOBAL_MEMORY_PROFILE.add_rss_checkpoint("after_sumcheck");
     }
 
     Accumulator accumulator = sumcheck_output_to_accumulator(sumcheck_output, instance, precomputed_vk);

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/prover_instance.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/prover_instance.cpp
@@ -73,7 +73,7 @@ template <typename Flavor> ProverInstance_<Flavor>::ProverInstance_(Circuit& cir
     }
 
     if (detail::use_memory_profile) {
-        detail::GLOBAL_MEMORY_PROFILE.add_rss_checkpoint("after_alloc");
+        detail::GLOBAL_MEMORY_PROFILE.add_checkpoint("after_alloc");
     }
 
     // Construct and add to proving key the wire, selector and copy constraint polynomials
@@ -106,7 +106,7 @@ template <typename Flavor> ProverInstance_<Flavor>::ProverInstance_(Circuit& cir
         analyze_prover_polynomials(polynomials);
     }
     if (detail::use_memory_profile) {
-        detail::GLOBAL_MEMORY_PROFILE.add_rss_checkpoint("after_trace");
+        detail::GLOBAL_MEMORY_PROFILE.add_checkpoint("after_trace");
     }
 }
 

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/prover_instance.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/prover_instance.cpp
@@ -73,7 +73,7 @@ template <typename Flavor> ProverInstance_<Flavor>::ProverInstance_(Circuit& cir
     }
 
     if (detail::use_memory_profile) {
-        detail::GLOBAL_MEMORY_PROFILE.add_checkpoint("after_alloc");
+        detail::GLOBAL_MEMORY_PROFILE.add_rss_checkpoint("after_alloc");
     }
 
     // Construct and add to proving key the wire, selector and copy constraint polynomials
@@ -106,7 +106,7 @@ template <typename Flavor> ProverInstance_<Flavor>::ProverInstance_(Circuit& cir
         analyze_prover_polynomials(polynomials);
     }
     if (detail::use_memory_profile) {
-        detail::GLOBAL_MEMORY_PROFILE.add_checkpoint("after_trace");
+        detail::GLOBAL_MEMORY_PROFILE.add_rss_checkpoint("after_trace");
     }
 }
 

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/ultra_prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/ultra_prover.cpp
@@ -80,7 +80,7 @@ template <typename Flavor> typename UltraProver_<Flavor>::Proof UltraProver_<Fla
     oink_prover.prove();
     vinfo("created oink proof");
     if (detail::use_memory_profile) {
-        detail::GLOBAL_MEMORY_PROFILE.add_rss_checkpoint("after_oink");
+        detail::GLOBAL_MEMORY_PROFILE.add_checkpoint("after_oink");
     }
 
     generate_gate_challenges();
@@ -89,13 +89,13 @@ template <typename Flavor> typename UltraProver_<Flavor>::Proof UltraProver_<Fla
     execute_sumcheck_iop();
     vinfo("finished relation check rounds");
     if (detail::use_memory_profile) {
-        detail::GLOBAL_MEMORY_PROFILE.add_rss_checkpoint("after_sumcheck");
+        detail::GLOBAL_MEMORY_PROFILE.add_checkpoint("after_sumcheck");
     }
     // Execute Shplemini PCS
     execute_pcs();
     vinfo("finished PCS rounds");
     if (detail::use_memory_profile) {
-        detail::GLOBAL_MEMORY_PROFILE.add_rss_checkpoint("after_pcs");
+        detail::GLOBAL_MEMORY_PROFILE.add_checkpoint("after_pcs");
     }
 
     return export_proof();

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/ultra_prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/ultra_prover.cpp
@@ -80,7 +80,7 @@ template <typename Flavor> typename UltraProver_<Flavor>::Proof UltraProver_<Fla
     oink_prover.prove();
     vinfo("created oink proof");
     if (detail::use_memory_profile) {
-        detail::GLOBAL_MEMORY_PROFILE.add_checkpoint("after_oink");
+        detail::GLOBAL_MEMORY_PROFILE.add_rss_checkpoint("after_oink");
     }
 
     generate_gate_challenges();
@@ -89,13 +89,13 @@ template <typename Flavor> typename UltraProver_<Flavor>::Proof UltraProver_<Fla
     execute_sumcheck_iop();
     vinfo("finished relation check rounds");
     if (detail::use_memory_profile) {
-        detail::GLOBAL_MEMORY_PROFILE.add_checkpoint("after_sumcheck");
+        detail::GLOBAL_MEMORY_PROFILE.add_rss_checkpoint("after_sumcheck");
     }
     // Execute Shplemini PCS
     execute_pcs();
     vinfo("finished PCS rounds");
     if (detail::use_memory_profile) {
-        detail::GLOBAL_MEMORY_PROFILE.add_checkpoint("after_pcs");
+        detail::GLOBAL_MEMORY_PROFILE.add_rss_checkpoint("after_pcs");
     }
 
     return export_proof();


### PR DESCRIPTION
## Summary

Replaces #22229 (which was accidentally merged into the wrong branch and reverted).

Switches `--memory_profile_out` from peak RSS (getrusage, monotonically increasing) to live heap usage (mallinfo2, goes up and down). This matches what Tracy's memory view showed and reveals when memory is actually freed.

- Uses `mallinfo2().uordblks` on Linux, returns 0 on WASM, falls back to peak RSS on other platforms
- Renamed `RssCheckpoint` to `MemoryCheckpoint`, `rss_mb` to `heap_mb`
- Renamed `add_rss_checkpoint` to `add_checkpoint`

Refs: AztecProtocol/barretenberg#1641

## Example output

```
 0 MultiCallEntrypoint:entrypoint  after_alloc     76 MiB
 0 MultiCallEntrypoint:entrypoint  after_oink      60 MiB  <-- freed during commitments
 6 EcdsaRAccount:entrypoint        after_trace    202 MiB  <-- peak
 6 EcdsaRAccount:entrypoint        after_oink     157 MiB  <-- 45 MiB freed
 8 SponsoredFPC:sponsor            after_alloc     42 MiB  <-- small circuit
```

## Test plan

- [x] Builds cleanly (native + asan-fast locally)
- [x] Tested with deploy_ecdsar1+sponsored_fpc: heap values go up and down as expected
- [ ] CI build passes