### PR TITLE
chore: crypto primitives external audit response 1

### DIFF
--- a/barretenberg/cpp/scripts/wasmtime.sh
+++ b/barretenberg/cpp/scripts/wasmtime.sh
@@ -5,6 +5,7 @@ set -eu
 export WASMTIME_BACKTRACE_DETAILS=1
 exec wasmtime run \
   -Wthreads=y \
+  -Wunknown-imports-trap=y \
   -Sthreads=y \
   ${HARDWARE_CONCURRENCY:+--env HARDWARE_CONCURRENCY} \
   --env HOME \

--- a/barretenberg/cpp/src/barretenberg/env/throw_or_abort_impl.cpp
+++ b/barretenberg/cpp/src/barretenberg/env/throw_or_abort_impl.cpp
@@ -1,3 +1,14 @@
+// In WASM builds, throw_or_abort_impl is provided by the JavaScript environment
+// (declared as WASM_IMPORT in throw_or_abort_impl.hpp). The JS implementation
+// throws a catchable JS Error with the error message.
+//
+// For non-JS WASM runtimes (wasmtime), the import must also be provided.
+// See barretenberg/cpp/scripts/wasmtime.sh for the wasmtime configuration.
+//
+// We guard out the C++ definition so the JS import is used instead of being
+// shadowed by the local definition (which would call std::abort).
+#ifndef __wasm__
+
 #include "barretenberg/common/log.hpp"
 #include "barretenberg/common/wasm_export.hpp"
 #include <stdexcept>
@@ -27,3 +38,5 @@ WASM_EXPORT void throw_or_abort_impl [[noreturn]] (const char* err)
     abort_with_message(err);
 #endif
 }
+
+#endif // !__wasm__


### PR DESCRIPTION
### Audit Context

Addresses finding #2 from the "Aztec - Cryptographic Primitives" external audit: WASM Process DOS via Oversized Polynomial in Prover Commit Path.

In WASM builds, `BB_NO_EXCEPTIONS` is defined. The C++ definition of `throw_or_abort_impl` calls `std::abort()`, killing the WASM process on any error. Meanwhile, the header (`throw_or_abort_impl.hpp`) declares the same function as a `WASM_IMPORT` from JavaScript, where it throws a catchable JS `Error`. But the local C++ definition shadows the import, so the JS throw is never used.

### Changes Made

**throw_or_abort_impl.cpp**: Guard out the C++ definition with `#ifndef __wasm__` so the JS-provided import is used in WASM builds. The header already declares it as `WASM_IMPORT("throw_or_abort_impl")` with the comment "For a WASM build, this is provided by the JavaScript environment."

**wasmtime.sh**: Add `-Wunknown-imports-trap=y` so wasmtime (non-JS WASM runtime used in CI tests) stubs the import with a trap instead of failing with "unknown import". This is correct behavior: errors in wasmtime should still abort.

No TypeScript changes needed. The JS side already provides the import that throws a catchable `Error` with the actual error message.

**Before**: Any `throw_or_abort` in WASM calls `abort_with_message()` -> `std::abort()` -> WASM process dies, PXE crashes with no error message.
**After**: `throw_or_abort` in WASM calls the JS import which throws `new Error(msg)`. The JS caller catches this as a normal exception. The WASM instance stays alive.

### Testing

Verified with `barretenberg/ts/src/bbapi/exception_handling.test.ts` (full WASM build + TS test):
```
PASS  bbapi/exception_handling.test.js
  BBApi Exception Handling from bb.js
    ✓ should catch CRS initialization exceptions from WASM (25 ms)
    ✓ should return error message from caught exception (12 ms)
```

### Checklist

- [x] Verified native build passes (ninja)
- [x] Verified WASM build passes (ninja barretenberg.wasm)
- [x] Ran bbapi_tests natively (2 passed)
- [x] Ran TS exception_handling.test.ts against WASM build (2 passed)