### PR TITLE
fix: cap decompress() buffer at 256 MB to prevent zip bomb OOM

### DIFF
--- a/barretenberg/cpp/src/barretenberg/chonk/private_execution_steps.cpp
+++ b/barretenberg/cpp/src/barretenberg/chonk/private_execution_steps.cpp
@@ -42,6 +42,7 @@ std::vector<uint8_t> compress(const std::vector<uint8_t>& input)
  */
 std::vector<uint8_t> decompress(const void* bytes, size_t size)
 {
+    static constexpr size_t MAX_DECOMPRESSED_SIZE = 256ULL * 1024 * 1024; // 256 MB
     std::vector<uint8_t> content;
     // initial size guess
     content.resize(1024ULL * 128ULL);
@@ -53,8 +54,11 @@ std::vector<uint8_t> decompress(const void* bytes, size_t size)
         libdeflate_result decompress_result =
             libdeflate_gzip_decompress(decompressor.get(), bytes, size, content.data(), content.size(), &actual_size);
         if (decompress_result == LIBDEFLATE_INSUFFICIENT_SPACE) {
-            // need a bigger buffer
-            content.resize(content.size() * 2);
+            size_t new_size = content.size() * 2;
+            if (new_size > MAX_DECOMPRESSED_SIZE) {
+                THROW std::runtime_error("decompressed size exceeds 256 MB limit");
+            }
+            content.resize(new_size);
             continue;
         }
         if (decompress_result == LIBDEFLATE_BAD_DATA) {


### PR DESCRIPTION
## Summary
- Adds a 256 MB cap to the decompression buffer doubling loop in `decompress()`, preventing a gzip zip bomb from causing OOM via unbounded allocation
- Real IVC inputs decompress to low single-digit MBs, so 256 MB is generous headroom

Closes AztecProtocol/barretenberg-claude#2441