### PR TITLE
fix: minor fixes pt. 4

### DIFF
--- a/barretenberg/cpp/scripts/test_chonk_standalone_vks_havent_changed.sh
+++ b/barretenberg/cpp/scripts/test_chonk_standalone_vks_havent_changed.sh
@@ -21,7 +21,7 @@ script_path="$root/barretenberg/cpp/scripts/test_chonk_standalone_vks_havent_cha
 # - Generate a hash for versioning: sha256sum bb-chonk-inputs.tar.gz
 # - Upload the compressed results: aws s3 cp bb-chonk-inputs.tar.gz s3://aztec-ci-artifacts/protocol/bb-chonk-inputs-[hash(0:8)].tar.gz
 # Note: In case of the "Test suite failed to run ... Unexpected token 'with' " error, need to run: docker pull aztecprotocol/build:3.0
-pinned_short_hash="7f8e5859"
+pinned_short_hash="33a01e19"
 pinned_chonk_inputs_url="https://aztec-ci-artifacts.s3.us-east-2.amazonaws.com/protocol/bb-chonk-inputs-${pinned_short_hash}.tar.gz"
 
 function update_pinned_hash_in_script {

--- a/barretenberg/cpp/src/barretenberg/chonk/chonk.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/chonk/chonk.test.cpp
@@ -159,10 +159,9 @@ class ChonkTests : public ::testing::Test {
                 // Tamper with the specified field
                 switch (field_to_tamper) {
                 case KernelIOField::PAIRING_INPUTS: {
-                    // Replace with valid pairing points at infinity (different from actual accumulated values)
-                    kernel_io.pairing_inputs.P0() = Commitment::infinity();
-                    kernel_io.pairing_inputs.P1() = Commitment::infinity();
-                    EXPECT_TRUE(kernel_io.pairing_inputs.check());
+                    // Replace with a different valid pairing: P0 = G1, P1 = -G1 satisfies e(G1,[1])·e(-G1,[x]) != 1
+                    // so instead use P0 + random offset to break binding without breaking the pairing trivially
+                    kernel_io.pairing_inputs.P0() = kernel_io.pairing_inputs.P0() + Commitment::one();
                     break;
                 }
                 case KernelIOField::ACCUMULATOR_HASH:
@@ -406,7 +405,7 @@ HEAVY_TEST(ChonkKernelCapacity, MaxCapacityPassing)
 {
     bb::srs::init_file_crs_factory(bb::srs::bb_crs_path());
 
-    const size_t NUM_APP_CIRCUITS = 17;
+    const size_t NUM_APP_CIRCUITS = 18;
     auto [proof, vk] = ChonkTests::accumulate_and_prove_ivc(NUM_APP_CIRCUITS);
 
     bool verified = ChonkTests::verify_chonk(proof, vk);

--- a/barretenberg/cpp/src/barretenberg/circuit_checker/mega_circuit_builder.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/circuit_checker/mega_circuit_builder.test.cpp
@@ -258,8 +258,8 @@ TEST(MegaCircuitBuilder, EmptyCircuitFinalization)
 
     builder.finalize_circuit(true);
 
-    // After finalization, should have non-zero content for required polynomials
-    EXPECT_GT(builder.blocks.ecc_op.size(), 0) << "Finalization should add ECC ops for non-zero polynomials";
+    // After finalization, ecc_op block remains empty (no dummy ops needed)
+    EXPECT_EQ(builder.blocks.ecc_op.size(), 0);
     EXPECT_GT(builder.get_calldata().size(), 0) << "Finalization should add databus entries";
     EXPECT_GT(builder.get_secondary_calldata().size(), 0);
     EXPECT_GT(builder.get_return_data().size(), 0);

--- a/barretenberg/cpp/src/barretenberg/commitment_schemes/ipa/ipa.hpp
+++ b/barretenberg/cpp/src/barretenberg/commitment_schemes/ipa/ipa.hpp
@@ -474,8 +474,9 @@ template <typename Curve_, size_t log_poly_length = CONST_ECCVM_LOG_N> class IPA
             G_zero =
                 scalar_multiplication::pippenger_unsafe<Curve>(data.s_vec, { &srs_elements[0], /*size*/ poly_length });
         }
-        BB_ASSERT_EQ(
-            G_zero, data.G_zero_from_prover, "G_0 should be equal to G_0 sent in transcript. IPA verification fails.");
+        if (G_zero != data.G_zero_from_prover) {
+            return false;
+        }
 
         // Step 10.
         // Compute C_right = a_0 * G_s + a_0 * b_0 * U
@@ -809,8 +810,8 @@ template <typename Curve_, size_t log_poly_length = CONST_ECCVM_LOG_N> class IPA
         srs_elements.resize(poly_length);
         Commitment computed_G_zero = Commitment::batch_mul(srs_elements, s_vec);
         // check the computed G_zero and the claimed G_zero are the same.
-        claimed_G_zero.assert_equal(computed_G_zero);
-        BB_ASSERT_EQ(computed_G_zero.get_value(), claimed_G_zero.get_value(), "G_zero doesn't match received G_zero.");
+        // The circuit constraint enforces correctness; mismatched witnesses will produce an unsatisfiable circuit.
+        claimed_G_zero.assert_equal(computed_G_zero, "G_zero doesn't match received G_zero.");
 
         bool running_truth_value = verifier_accumulator.running_truth_value;
         return running_truth_value;

--- a/barretenberg/cpp/src/barretenberg/commitment_schemes/shplonk/shplemini.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/commitment_schemes/shplonk/shplemini.test.cpp
@@ -816,9 +816,8 @@ void run_libra_tampering_test(ShpleminiTest<TypeParam>* test,
 
     // PCS verification should always fail when tampering occurred
     if constexpr (std::is_same_v<TypeParam, GrumpkinSettings>) {
-        EXPECT_THROW(ShpleminiTest<TypeParam>::IPA::reduce_verify_batch_opening_claim(
-                         batch_opening_claim, test->vk(), verifier_transcript),
-                     std::runtime_error);
+        EXPECT_FALSE(ShpleminiTest<TypeParam>::IPA::reduce_verify_batch_opening_claim(
+            batch_opening_claim, test->vk(), verifier_transcript));
     } else {
         const auto pairing_points =
             KZG<Curve>::reduce_verify_batch_opening_claim(std::move(batch_opening_claim), verifier_transcript);

--- a/barretenberg/cpp/src/barretenberg/flavor/multilinear_batching_flavor.cpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/multilinear_batching_flavor.cpp
@@ -30,11 +30,11 @@ MultilinearBatchingFlavor::ProvingKey::ProvingKey(ProverClaim&& accumulator_clai
     polynomials.batched_shifted_accumulator = preshifted_accumulator.shifted();
     polynomials.batched_shifted_instance = preshifted_instance.shifted();
 
-    // Construct `eq` polynomials from challenges
-    polynomials.eq_accumulator =
-        ProverEqPolynomial<FF>::construct(accumulator_claim.challenge, bb::numeric::get_msb(circuit_size));
-    polynomials.eq_instance =
-        ProverEqPolynomial<FF>::construct(instance_claim.challenge, bb::numeric::get_msb(circuit_size));
+    // Construct eq polynomials with 2^m coefficients (m = log2(circuit_size)), not 2^VIRTUAL_LOG_N.
+    // Virtual sumcheck rounds handle the remaining challenges without needing the full table.
+    const size_t log_circuit_size = bb::numeric::get_msb(circuit_size);
+    polynomials.eq_accumulator = ProverEqPolynomial<FF>::construct(accumulator_claim.challenge, log_circuit_size);
+    polynomials.eq_instance = ProverEqPolynomial<FF>::construct(instance_claim.challenge, log_circuit_size);
     polynomials.increase_polynomials_virtual_size(virtual_circuit_size);
 
     // Move incoming challenges  and copy commitments with corresponding evaluations

--- a/barretenberg/cpp/src/barretenberg/goblin/merge.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/goblin/merge.test.cpp
@@ -478,9 +478,6 @@ template <typename Curve> class MergeTests : public testing::Test {
             auto native_proof = prover_transcript->export_proof();
 
             // === Verify with unmodified verifier (which has BB_ASSERT_GT for shift_size > 0) ===
-            // Disable the assert so we can test the math
-            BB_DISABLE_ASSERTS();
-
             // Build input commitments: t = empty (zero commits), T_prev = right table
             InputCommitments input_commitments;
             for (size_t idx = 0; idx < NUM_WIRES; idx++) {

--- a/barretenberg/cpp/src/barretenberg/goblin/merge.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/goblin/merge.test.cpp
@@ -1,4 +1,5 @@
 #include "barretenberg/circuit_checker/circuit_checker.hpp"
+#include "barretenberg/commitment_schemes/kzg/kzg.hpp"
 #include "barretenberg/common/test.hpp"
 #include "barretenberg/ecc/fields/field_conversion.hpp"
 #include "barretenberg/goblin/merge_prover.hpp"
@@ -347,6 +348,155 @@ template <typename Curve> class MergeTests : public testing::Test {
 
         prove_and_verify_merge(op_queue, settings, TamperProofMode::LEval, false);
     }
+
+    /**
+     * @brief Test that an honestly constructed merge proof with shift_size = 0 (empty left table) verifies
+     * @details Manually constructs a merge proof where the left table is empty, M = R, and all PCS
+     * openings are computed honestly. This bypasses the op queue (which structurally prevents empty
+     * subtables) to test the protocol math directly.
+     */
+    static void test_honest_empty_left_table()
+    {
+        if constexpr (IsRecursive) {
+            GTEST_SKIP() << "Native-only test";
+            return;
+        }
+        if constexpr (!IsRecursive) {
+
+            using InnerFlavor = MegaFlavor;
+            using InnerBuilder = typename InnerFlavor::CircuitBuilder;
+            using Polynomial = bb::Polynomial<bb::fr>;
+            using CommitmentKey = bb::CommitmentKey<curve::BN254>;
+
+            // Build an op queue with some ops to serve as the right (previous) table
+            auto op_queue = std::make_shared<ECCOpQueue>();
+            InnerBuilder circuit{ op_queue };
+            GoblinMockCircuits::construct_simple_circuit(circuit);
+            op_queue->merge();
+
+            // Right table = the merged previous table; Left table = empty
+            std::array<Polynomial, NUM_WIRES> right_table = op_queue->construct_ultra_ops_table_columns();
+            std::array<Polynomial, NUM_WIRES> left_table;
+            std::array<Polynomial, NUM_WIRES> merged_table;
+            for (size_t idx = 0; idx < NUM_WIRES; idx++) {
+                left_table[idx] = Polynomial(0);                  // empty
+                merged_table[idx] = Polynomial(right_table[idx]); // M = R
+            }
+
+            CommitmentKey ck(right_table[0].size());
+            auto prover_transcript = std::make_shared<NativeTranscript>();
+
+            // === Replicate MergeProver::construct_proof with shift_size = 0 ===
+            prover_transcript->send_to_verifier("shift_size", static_cast<uint32_t>(0));
+
+            for (size_t idx = 0; idx < NUM_WIRES; idx++) {
+                prover_transcript->send_to_verifier("MERGED_TABLE_" + std::to_string(idx),
+                                                    ck.commit(merged_table[idx]));
+            }
+
+            std::array<std::string, 4> degree_labels = { "LEFT_TABLE_DEGREE_CHECK_0",
+                                                         "LEFT_TABLE_DEGREE_CHECK_1",
+                                                         "LEFT_TABLE_DEGREE_CHECK_2",
+                                                         "LEFT_TABLE_DEGREE_CHECK_3" };
+            // Consume challenges to advance transcript state (values unused since L is empty)
+            prover_transcript->template get_challenges<bb::fr>(degree_labels);
+            Polynomial reversed_batched_left_tables(0); // empty
+            prover_transcript->send_to_verifier("REVERSED_BATCHED_LEFT_TABLES",
+                                                ck.commit(reversed_batched_left_tables));
+
+            std::array<std::string, 13> shplonk_labels = {
+                "SHPLONK_MERGE_BATCHING_CHALLENGE_0",  "SHPLONK_MERGE_BATCHING_CHALLENGE_1",
+                "SHPLONK_MERGE_BATCHING_CHALLENGE_2",  "SHPLONK_MERGE_BATCHING_CHALLENGE_3",
+                "SHPLONK_MERGE_BATCHING_CHALLENGE_4",  "SHPLONK_MERGE_BATCHING_CHALLENGE_5",
+                "SHPLONK_MERGE_BATCHING_CHALLENGE_6",  "SHPLONK_MERGE_BATCHING_CHALLENGE_7",
+                "SHPLONK_MERGE_BATCHING_CHALLENGE_8",  "SHPLONK_MERGE_BATCHING_CHALLENGE_9",
+                "SHPLONK_MERGE_BATCHING_CHALLENGE_10", "SHPLONK_MERGE_BATCHING_CHALLENGE_11",
+                "SHPLONK_MERGE_BATCHING_CHALLENGE_12"
+            };
+            auto shplonk_batching_challenges = prover_transcript->template get_challenges<bb::fr>(shplonk_labels);
+
+            bb::fr kappa = prover_transcript->template get_challenge<bb::fr>("kappa");
+            bb::fr kappa_inv = kappa.invert();
+
+            // Evaluations at kappa
+            std::vector<bb::fr> evals;
+            for (size_t idx = 0; idx < NUM_WIRES; idx++) {
+                evals.emplace_back(left_table[idx].evaluate(kappa)); // L_j(κ) = 0
+                prover_transcript->send_to_verifier("LEFT_TABLE_EVAL_" + std::to_string(idx), evals.back());
+            }
+            for (size_t idx = 0; idx < NUM_WIRES; idx++) {
+                evals.emplace_back(right_table[idx].evaluate(kappa));
+                prover_transcript->send_to_verifier("RIGHT_TABLE_EVAL_" + std::to_string(idx), evals.back());
+            }
+            for (size_t idx = 0; idx < NUM_WIRES; idx++) {
+                evals.emplace_back(merged_table[idx].evaluate(kappa));
+                prover_transcript->send_to_verifier("MERGED_TABLE_EVAL_" + std::to_string(idx), evals.back());
+            }
+            evals.emplace_back(reversed_batched_left_tables.evaluate(kappa_inv)); // G(κ⁻¹) = 0
+            prover_transcript->send_to_verifier("REVERSED_BATCHED_LEFT_TABLES_EVAL", evals.back());
+
+            // Shplonk batched quotient: Q such that Q·(X-κ)·(X-κ⁻¹) = ...
+            // With L=0 and G=0, only R and M (=R) terms contribute at kappa.
+            size_t poly_size = merged_table[0].size();
+            Polynomial shplonk_batched_quotient(poly_size);
+
+            for (size_t idx = 0; idx < NUM_WIRES; idx++) {
+                // L terms: zero (left_table is empty)
+                // R terms
+                bb::fr beta_r = shplonk_batching_challenges[NUM_WIRES + idx];
+                shplonk_batched_quotient.add_scaled(right_table[idx], beta_r);
+                shplonk_batched_quotient.at(0) -= beta_r * evals[NUM_WIRES + idx];
+                // M terms
+                bb::fr beta_m = shplonk_batching_challenges[2 * NUM_WIRES + idx];
+                shplonk_batched_quotient.add_scaled(merged_table[idx], beta_m);
+                shplonk_batched_quotient.at(0) -= beta_m * evals[2 * NUM_WIRES + idx];
+            }
+            shplonk_batched_quotient.factor_roots(kappa);
+            // G term at kappa_inv: G=0 so nothing to add
+
+            prover_transcript->send_to_verifier("SHPLONK_BATCHED_QUOTIENT", ck.commit(shplonk_batched_quotient));
+
+            // Shplonk opening claim
+            bb::fr z = prover_transcript->template get_challenge<bb::fr>("shplonk_opening_challenge");
+            Polynomial Q_prime(std::move(shplonk_batched_quotient));
+            Q_prime *= -(z - kappa);
+
+            for (size_t idx = 0; idx < NUM_WIRES; idx++) {
+                bb::fr beta_r = shplonk_batching_challenges[NUM_WIRES + idx];
+                Q_prime.add_scaled(right_table[idx], beta_r);
+                Q_prime.at(0) -= beta_r * evals[NUM_WIRES + idx];
+                bb::fr beta_m = shplonk_batching_challenges[2 * NUM_WIRES + idx];
+                Q_prime.add_scaled(merged_table[idx], beta_m);
+                Q_prime.at(0) -= beta_m * evals[2 * NUM_WIRES + idx];
+            }
+            // G term: G=0, so (G-g)·factor = 0, nothing to add
+
+            ProverOpeningClaim<curve::BN254> opening_claim = { .polynomial = std::move(Q_prime),
+                                                               .opening_pair = { z, bb::fr(0) } };
+            KZG<curve::BN254>::compute_opening_proof(ck, opening_claim, prover_transcript);
+
+            auto native_proof = prover_transcript->export_proof();
+
+            // === Verify with unmodified verifier (which has BB_ASSERT_GT for shift_size > 0) ===
+            // Disable the assert so we can test the math
+            BB_DISABLE_ASSERTS();
+
+            // Build input commitments: t = empty (zero commits), T_prev = right table
+            InputCommitments input_commitments;
+            for (size_t idx = 0; idx < NUM_WIRES; idx++) {
+                input_commitments.t_commitments[idx] = ck.commit(left_table[idx]);
+                input_commitments.T_prev_commitments[idx] = ck.commit(right_table[idx]);
+            }
+
+            auto verifier_transcript = std::make_shared<NativeTranscript>();
+            MergeVerifierType verifier{ MergeSettings::PREPEND, verifier_transcript };
+            auto result = verifier.reduce_to_pairing_check(native_proof, input_commitments);
+
+            bool pairing_verified = result.pairing_points.check();
+            bool verified = pairing_verified && result.reduction_succeeded;
+            EXPECT_TRUE(verified);
+        } // if constexpr (!IsRecursive)
+    }
 };
 
 // Define test types: native and recursive contexts
@@ -404,6 +554,11 @@ TYPED_TEST(MergeTests, EvalFailurePrepend)
 TYPED_TEST(MergeTests, EvalFailureAppend)
 {
     TestFixture::test_eval_failure(MergeSettings::APPEND);
+}
+
+TYPED_TEST(MergeTests, HonestEmptyLeftTable)
+{
+    TestFixture::test_honest_empty_left_table();
 }
 
 /**

--- a/barretenberg/cpp/src/barretenberg/goblin/merge_prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/goblin/merge_prover.cpp
@@ -75,7 +75,9 @@ MergeProver::Polynomial MergeProver::compute_shplonk_batched_quotient(
                 shplonk_batched_quotient.add_scaled(merged_table[idx], challenge);
             }
             // Q -= eval·βᵢ
-            shplonk_batched_quotient.at(0) -= challenge * eval;
+            if (!shplonk_batched_quotient.is_empty()) {
+                shplonk_batched_quotient.at(0) -= challenge * eval;
+            }
         }
     }
     // Q /= (X - κ)
@@ -83,7 +85,9 @@ MergeProver::Polynomial MergeProver::compute_shplonk_batched_quotient(
 
     // Q += (G - g)/(X - κ⁻¹)·β
     Polynomial reversed_batched_left_tables_copy(reversed_batched_left_tables);
-    reversed_batched_left_tables_copy.at(0) -= evals.back();
+    if (!reversed_batched_left_tables_copy.is_empty()) {
+        reversed_batched_left_tables_copy.at(0) -= evals.back();
+    }
     reversed_batched_left_tables_copy.factor_roots(kappa_inv);
     shplonk_batched_quotient.add_scaled(reversed_batched_left_tables_copy, shplonk_batching_challenges.back());
 
@@ -123,12 +127,16 @@ MergeProver::OpeningClaim MergeProver::compute_shplonk_opening_claim(
                 shplonk_partially_evaluated_batched_quotient.add_scaled(merged_table[idx], challenge);
             }
             // Q' -= eval·βᵢ
-            shplonk_partially_evaluated_batched_quotient.at(0) -= challenge * eval;
+            if (!shplonk_partially_evaluated_batched_quotient.is_empty()) {
+                shplonk_partially_evaluated_batched_quotient.at(0) -= challenge * eval;
+            }
         }
     }
 
     // Q' += (G - g)·(z - κ)/(z - κ⁻¹)·β
-    reversed_batched_left_tables.at(0) -= evals.back();
+    if (!reversed_batched_left_tables.is_empty()) {
+        reversed_batched_left_tables.at(0) -= evals.back();
+    }
     shplonk_partially_evaluated_batched_quotient.add_scaled(reversed_batched_left_tables,
                                                             shplonk_batching_challenges.back() *
                                                                 (shplonk_opening_challenge - kappa) *

--- a/barretenberg/cpp/src/barretenberg/goblin/merge_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/goblin/merge_verifier.cpp
@@ -122,13 +122,6 @@ typename MergeVerifier_<Curve>::ReductionResult MergeVerifier_<Curve>::reduce_to
     // For native: shift_size is uint32_t
     // For stdlib: shift_size is FF (we'll get the value later)
     const FF shift_size = transcript->template receive_from_prover<FF>("shift_size");
-    ;
-    if constexpr (IsRecursive) {
-        BB_ASSERT_GT(uint32_t(shift_size.get_value()), 0U, "Shift size should always be bigger than 0");
-    } else {
-
-        BB_ASSERT_GT(shift_size, 0U, "Shift size should always be bigger than 0");
-    }
 
     // Store T_commitments of the verifier
     TableCommitments merged_table_commitments;

--- a/barretenberg/cpp/src/barretenberg/goblin/mock_circuits.hpp
+++ b/barretenberg/cpp/src/barretenberg/goblin/mock_circuits.hpp
@@ -90,13 +90,6 @@ class GoblinMockCircuits {
             generate_sha256_test_circuit<MegaBuilder>(builder, 8);
             stdlib::generate_ecdsa_verification_test_circuit(builder, 2);
         }
-
-        // TODO(https://github.com/AztecProtocol/barretenberg/issues/911): We require goblin ops to be added to the
-        // function circuit because we cannot support zero commtiments. While the builder handles this at
-        // ProverInstance creation stage via the add_gates_to_ensure_all_polys_are_non_zero function for other
-        // MegaHonk circuits (where we don't explicitly need to add goblin ops), in IVC merge proving happens prior to
-        // folding where the absense of goblin ecc ops will result in zero commitments.
-        MockCircuits::construct_goblin_ecc_op_circuit(builder);
     }
 
     /**

--- a/barretenberg/cpp/src/barretenberg/op_queue/ecc_ops_table.hpp
+++ b/barretenberg/cpp/src/barretenberg/op_queue/ecc_ops_table.hpp
@@ -259,7 +259,13 @@ class UltraEccOpsTable {
         }
         return base_size;
     }
-    size_t current_ultra_subtable_size() const { return table.get()[current_subtable_idx].size() * NUM_ROWS_PER_OP; }
+    size_t current_ultra_subtable_size() const
+    {
+        if (table.num_subtables() == 0) {
+            return 0;
+        }
+        return table.get()[current_subtable_idx].size() * NUM_ROWS_PER_OP;
+    }
     size_t previous_ultra_table_size() const { return (num_ultra_rows() - current_ultra_subtable_size()); }
     void create_new_subtable(size_t size_hint = 0) { table.create_new_subtable(size_hint); }
     void push(const UltraOp& op) { table.push(op); }
@@ -386,6 +392,9 @@ class UltraEccOpsTable {
     ColumnPolynomials construct_column_polynomials_with_fixed_append(const size_t poly_size) const
     {
         ColumnPolynomials column_polynomials;
+        if (poly_size == 0) {
+            return column_polynomials;
+        }
         for (auto& poly : column_polynomials) {
             poly = Polynomial<Fr>(poly_size); // Initialized to zeros
         }
@@ -424,6 +433,9 @@ class UltraEccOpsTable {
                                                                   const size_t subtable_end_idx) const
     {
         ColumnPolynomials column_polynomials;
+        if (poly_size == 0) {
+            return column_polynomials;
+        }
         for (auto& poly : column_polynomials) {
             poly = Polynomial<Fr>(poly_size);
         }

--- a/barretenberg/cpp/src/barretenberg/op_queue/ecc_ops_table.hpp
+++ b/barretenberg/cpp/src/barretenberg/op_queue/ecc_ops_table.hpp
@@ -230,7 +230,7 @@ class UltraEccOpsTable {
     using UltraOpsTable = EccOpsTable<UltraOp>;
     using ColumnPolynomials = std::array<Polynomial<Fr>, TABLE_WIDTH>;
 
-    size_t current_subtable_idx = 0; // index of the current subtable being constructed
+    std::optional<size_t> current_subtable_idx; // index of the most recently merged subtable (nullopt if empty merge)
     UltraOpsTable table;
 
     // For fixed-location append functionality
@@ -261,16 +261,17 @@ class UltraEccOpsTable {
     }
     size_t current_ultra_subtable_size() const
     {
-        if (table.num_subtables() == 0) {
+        if (!current_subtable_idx.has_value()) {
             return 0;
         }
-        return table.get()[current_subtable_idx].size() * NUM_ROWS_PER_OP;
+        return table.get()[current_subtable_idx.value()].size() * NUM_ROWS_PER_OP;
     }
     size_t previous_ultra_table_size() const { return (num_ultra_rows() - current_ultra_subtable_size()); }
     void create_new_subtable(size_t size_hint = 0) { table.create_new_subtable(size_hint); }
     void push(const UltraOp& op) { table.push(op); }
     void merge(MergeSettings settings = MergeSettings::PREPEND, std::optional<size_t> offset = std::nullopt)
     {
+        const size_t num_subtables_before = table.num_subtables();
         if (settings == MergeSettings::APPEND) {
             // All appends are treated as fixed-location for ultra ops
             BB_ASSERT(!has_fixed_append, "Can only perform fixed-location append once");
@@ -281,7 +282,9 @@ class UltraEccOpsTable {
             current_subtable_idx = table.num_subtables() - 1;
         } else { // MergeSettings::PREPEND
             table.merge(settings);
-            current_subtable_idx = 0;
+            // Only update current_subtable_idx if a subtable was actually added (non-empty merge)
+            current_subtable_idx =
+                (table.num_subtables() > num_subtables_before) ? std::optional<size_t>(0) : std::nullopt;
         }
     }
 
@@ -348,8 +351,13 @@ class UltraEccOpsTable {
     ColumnPolynomials construct_previous_table_columns() const
     {
         const size_t poly_size = previous_ultra_table_size();
-        const size_t subtable_start_idx = current_subtable_idx == 0 ? 1 : 0;
-        const size_t subtable_end_idx = current_subtable_idx == 0 ? table.num_subtables() : table.num_subtables() - 1;
+        if (!current_subtable_idx.has_value()) {
+            // Empty merge: the entire table is "previous"
+            return construct_column_polynomials_from_subtables(poly_size, 0, table.num_subtables());
+        }
+        const size_t idx = current_subtable_idx.value();
+        const size_t subtable_start_idx = idx == 0 ? 1 : 0;
+        const size_t subtable_end_idx = idx == 0 ? table.num_subtables() : table.num_subtables() - 1;
 
         return construct_column_polynomials_from_subtables(poly_size, subtable_start_idx, subtable_end_idx);
     }
@@ -358,9 +366,13 @@ class UltraEccOpsTable {
     // depening on whether it has been prepended or appended
     ColumnPolynomials construct_current_ultra_ops_subtable_columns() const
     {
+        if (!current_subtable_idx.has_value()) {
+            // Empty merge: return empty column polynomials
+            return ColumnPolynomials{};
+        }
         const size_t poly_size = current_ultra_subtable_size();
-        const size_t subtable_start_idx = current_subtable_idx;
-        const size_t subtable_end_idx = current_subtable_idx + 1;
+        const size_t subtable_start_idx = current_subtable_idx.value();
+        const size_t subtable_end_idx = current_subtable_idx.value() + 1;
 
         return construct_column_polynomials_from_subtables(poly_size, subtable_start_idx, subtable_end_idx);
     }

--- a/barretenberg/cpp/src/barretenberg/polynomials/polynomial_arithmetic.cpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/polynomial_arithmetic.cpp
@@ -194,37 +194,6 @@ template <typename Fr> Fr evaluate(const Fr* coeffs, const Fr& z, const size_t n
     return r;
 }
 
-template <typename Fr> Fr evaluate(const std::vector<Fr*> coeffs, const Fr& z, const size_t large_n)
-{
-    const size_t num_polys = coeffs.size();
-    const size_t poly_size = large_n / num_polys;
-    BB_ASSERT(is_power_of_two(poly_size));
-    const size_t log2_poly_size = (size_t)numeric::get_msb(poly_size);
-    const size_t num_threads = get_num_cpus();
-    std::vector<Fr> evaluations(num_threads, Fr::zero());
-    parallel_for([&](const ThreadChunk& chunk) {
-        // parallel_for with ThreadChunk uses get_num_cpus() threads
-        BB_ASSERT_EQ(chunk.total_threads, evaluations.size());
-        auto range = chunk.range(large_n);
-        if (range.empty()) {
-            return;
-        }
-        size_t start = *range.begin();
-        Fr z_acc = z.pow(static_cast<uint64_t>(start));
-        for (size_t i : range) {
-            Fr work_var = z_acc * coeffs[i >> log2_poly_size][i & (poly_size - 1)];
-            evaluations[chunk.thread_index] += work_var;
-            z_acc *= z;
-        }
-    });
-
-    Fr r = Fr::zero();
-    for (const auto& eval : evaluations) {
-        r += eval;
-    }
-    return r;
-}
-
 // This function computes sum of all scalars in a given array.
 template <typename Fr> Fr compute_sum(const Fr* src, const size_t n)
 {

--- a/barretenberg/cpp/src/barretenberg/polynomials/polynomial_arithmetic.cpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/polynomial_arithmetic.cpp
@@ -358,7 +358,6 @@ void compute_efficient_interpolation(const Fr* src, Fr* dest, const Fr* evaluati
 }
 
 template fr evaluate<fr>(const fr*, const fr&, const size_t);
-template fr evaluate<fr>(const std::vector<fr*>, const fr&, const size_t);
 template void fft_inner_parallel<fr>(fr*, fr*, const EvaluationDomain<fr>&, const fr&, const std::vector<fr*>&);
 template void ifft<fr>(fr*, fr*, const EvaluationDomain<fr>&);
 template fr compute_sum<fr>(const fr*, const size_t);
@@ -366,7 +365,6 @@ template void compute_linear_polynomial_product<fr>(const fr*, fr*, const size_t
 template void compute_efficient_interpolation<fr>(const fr*, fr*, const fr*, const size_t);
 
 template grumpkin::fr evaluate<grumpkin::fr>(const grumpkin::fr*, const grumpkin::fr&, const size_t);
-template grumpkin::fr evaluate<grumpkin::fr>(const std::vector<grumpkin::fr*>, const grumpkin::fr&, const size_t);
 template grumpkin::fr compute_sum<grumpkin::fr>(const grumpkin::fr*, const size_t);
 template void compute_linear_polynomial_product<grumpkin::fr>(const grumpkin::fr*, grumpkin::fr*, const size_t);
 template void compute_efficient_interpolation<grumpkin::fr>(const grumpkin::fr*,

--- a/barretenberg/cpp/src/barretenberg/polynomials/polynomial_arithmetic.hpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/polynomial_arithmetic.hpp
@@ -56,6 +56,9 @@ void compute_efficient_interpolation(const Fr* src, Fr* dest, const Fr* evaluati
 template <typename Fr> void factor_roots(std::span<Fr> polynomial, const Fr& root)
 {
     const size_t size = polynomial.size();
+    if (size == 0) {
+        return;
+    }
     if (root.is_zero()) {
         // if one of the roots is 0 after having divided by all other roots,
         // then p(X) = a₁⋅X + ⋯ + aₙ₋₁⋅Xⁿ⁻¹

--- a/barretenberg/cpp/src/barretenberg/polynomials/polynomial_arithmetic.hpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/polynomial_arithmetic.hpp
@@ -30,8 +30,6 @@ template <typename Fr> Fr evaluate(std::span<const Fr> coeffs, const Fr& z)
 {
     return evaluate(coeffs, z, coeffs.size());
 };
-template <typename Fr> Fr evaluate(const std::vector<Fr*> coeffs, const Fr& z, const size_t large_n);
-
 template <typename Fr>
     requires SupportsFFT<Fr>
 void fft_inner_parallel(

--- a/barretenberg/cpp/src/barretenberg/polynomials/polynomial_arithmetic.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/polynomial_arithmetic.test.cpp
@@ -67,30 +67,6 @@ TEST(polynomials, ifft_consistency)
     }
 }
 
-TEST(polynomials, split_polynomial_evaluate)
-{
-    constexpr size_t n = 256;
-    std::array<fr, n> fft_transform;
-    std::array<fr, n> poly;
-
-    for (size_t i = 0; i < n; ++i) {
-        poly[i] = fr::random_element();
-        fr::__copy(poly[i], fft_transform[i]);
-    }
-
-    constexpr size_t num_poly = 4;
-    constexpr size_t n_poly = n / num_poly;
-    fr fft_transform_[num_poly][n_poly];
-    for (size_t i = 0; i < n; ++i) {
-        fft_transform_[i / n_poly][i % n_poly] = poly[i];
-    }
-
-    fr z = fr::random_element();
-    EXPECT_EQ(polynomial_arithmetic::evaluate(
-                  { fft_transform_[0], fft_transform_[1], fft_transform_[2], fft_transform_[3] }, z, n),
-              polynomial_arithmetic::evaluate(poly.data(), z, n));
-}
-
 TEST(polynomials, linear_poly_product)
 {
     constexpr size_t n = 64;

--- a/barretenberg/cpp/src/barretenberg/stdlib/hash/poseidon2/poseidon2.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/hash/poseidon2/poseidon2.test.cpp
@@ -249,9 +249,9 @@ template <typename Builder> class StdlibPoseidon2 : public testing::Test {
         }
 
         // The domain separation IV depends on the input size, therefore, the hashes must not coincide.
+        EXPECT_NE(hashes[0], hashes[1]);
         EXPECT_NE(hashes[1], hashes[2]);
-        EXPECT_NE(hashes[2], hashes[3]);
-        EXPECT_NE(hashes[1], hashes[3]);
+        EXPECT_NE(hashes[0], hashes[2]);
     }
 
     // Test vectors and the expected values are taken from https://github.com/zemse/poseidon2-evm

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/mega_circuit_builder.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/mega_circuit_builder.cpp
@@ -56,13 +56,6 @@ template <typename FF> void MegaCircuitBuilder_<FF>::add_mega_gates_to_ensure_al
     raw_read_idx = static_cast<uint32_t>(get_return_data().size()) - 1;   // read data that was just added
     read_idx = this->add_variable(FF(raw_read_idx));
     update_finalize_witnesses({ read_idx, read_return_data(read_idx) });
-
-    if (op_queue->get_current_subtable_size() == 0) {
-        // Add a mul dummy op in the subtable to avoid column polynomial being zero (it has to be a mul rather than an
-        // add to ensure all 4 column polynomials contain some data)
-        this->queue_ecc_mul_accum(bb::g1::affine_element::one(), 2, /*in_finalize=*/true);
-        this->queue_ecc_eq(/*in_finalize=*/true);
-    }
 }
 
 /**

--- a/barretenberg/cpp/src/barretenberg/sumcheck/sumcheck.hpp
+++ b/barretenberg/cpp/src/barretenberg/sumcheck/sumcheck.hpp
@@ -629,9 +629,10 @@ template <typename Flavor> class SumcheckProver {
         vinfo("completed ", multivariate_d, " rounds of sumcheck");
 
         // Zero univariates are used to pad the proof to the fixed size virtual_log_n.
+        // Route through the handler so committed sumcheck flavors send the correct transcript format.
         auto zero_univariate = bb::Univariate<FF, Flavor::BATCHED_RELATION_PARTIAL_LENGTH>::zero();
         for (size_t idx = multivariate_d; idx < virtual_log_n; idx++) {
-            transcript->send_to_verifier("Sumcheck:univariate_" + std::to_string(idx), zero_univariate);
+            handler.process_round_univariate(idx, zero_univariate);
 
             FF round_challenge = transcript->template get_challenge<FF>("Sumcheck:u_" + std::to_string(idx));
             multivariate_challenge.emplace_back(round_challenge);

--- a/barretenberg/cpp/src/barretenberg/sumcheck/sumcheck.hpp
+++ b/barretenberg/cpp/src/barretenberg/sumcheck/sumcheck.hpp
@@ -598,7 +598,8 @@ template <typename Flavor> class SumcheckProver {
                 transcript->template get_challenge<FF>("Sumcheck:u_" + std::to_string(round_idx));
             multivariate_challenge.emplace_back(round_challenge);
 
-            // Fold masking values BEFORE partially_evaluate (need to read PE at active positions)
+            // Fold masking values BEFORE partially_evaluate: after PE, disabled-edge positions for
+            // masked witness polys are stale; correct values are in masking_tail.folded.
             if constexpr (UseRowDisablingPolynomial<Flavor>) {
                 masking_tail.fold_masking_values(
                     round_challenge, round_idx, round.round_size, &partially_evaluated_polynomials);

--- a/barretenberg/cpp/src/barretenberg/sumcheck/zk_sumcheck_data.hpp
+++ b/barretenberg/cpp/src/barretenberg/sumcheck/zk_sumcheck_data.hpp
@@ -151,7 +151,7 @@ template <typename Flavor> struct ZKSumcheckData {
         }
         total_sum *= scaling_factor;
 
-        return { total_sum + constant_term * (1 << libra_univariates.size()), scaling_factor };
+        return { total_sum + constant_term * (static_cast<uint64_t>(1) << libra_univariates.size()), scaling_factor };
     }
 
     /**


### PR DESCRIPTION
another batch of claude issues



- [2208](https://github.com/AztecProtocol/barretenberg-claude/issues/2208) Merge with shift size 0
- [2447](https://github.com/AztecProtocol/barretenberg-claude/issues/2447) ub in Poseidon2 tests
- [2448](https://github.com/AztecProtocol/barretenberg-claude/issues/2448) overly restrictive BB_ASSERTs in IPA
- [2390](https://github.com/AztecProtocol/barretenberg-claude/issues/2390) expanded comment for eq polys handling
- [2252](https://github.com/AztecProtocol/barretenberg-claude/issues/2252) removed unused multi-polynomial evaluate 

removed dummy ops from all mega circuits -- allows to bump up the max chonk capacity to 18 circuits (it's really close to 19, ~100 msm rows above 2^15)
