### PR TITLE
chore: Fix log statement in ECDSA test

### DIFF
--- a/barretenberg/cpp/src/barretenberg/stdlib/encryption/ecdsa/ecdsa.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/encryption/ecdsa/ecdsa.test.cpp
@@ -63,7 +63,7 @@ template <class Curve> class EcdsaTests : public ::testing::Test {
 
         if (random_signature) {
             // Logging in case of random signature
-            info("The private key used generate this signature is: ", private_key);
+            info("The private key used generate this signature is: ", account.private_key);
         }
 
         return { account, signature };


### PR DESCRIPTION
When testing ECDSA signatures with a random private key, we were logging the fixed private key. This PR fixes the logging so that we log the randomly generated private key.