### PR TITLE
fix(foundation): flush current batch on BatchQueue.stop()

### DIFF
--- a/yarn-project/foundation/src/queue/batch_queue.test.ts
+++ b/yarn-project/foundation/src/queue/batch_queue.test.ts
@@ -161,4 +161,19 @@ describe('BatchQueue', () => {
 
     expect(processSpy).toHaveBeenCalledTimes(batches);
   });
+
+  it('flushes a partial batch on stop', async () => {
+    // Add fewer items than maxBatchSize so the batch stays unflushed
+    const itemCount = maxBatchSize - 1;
+    const promises: Promise<void>[] = [];
+    for (let i = 0; i < itemCount; i++) {
+      promises.push(queue.put(i, 0));
+    }
+
+    await queue.stop();
+    await Promise.all(promises);
+
+    expect(processSpy).toHaveBeenCalledTimes(1);
+    expect(processSpy).toHaveBeenCalledWith(range(itemCount), 0);
+  });
 });

--- a/yarn-project/foundation/src/queue/batch_queue.ts
+++ b/yarn-project/foundation/src/queue/batch_queue.ts
@@ -105,6 +105,7 @@ export class BatchQueue<T, K extends string | number> {
       return Promise.resolve();
     }
 
+    this.flushCurrentBatch();
     this.container.end();
     return runningPromise;
   }


### PR DESCRIPTION
## Summary

`BatchQueue.stop()` was not flushing the current in-progress batch before ending the underlying FIFO queue. Any items accumulated in `this.currentBatch` that hadn't yet hit `maxBatchSize` or the duration timeout were silently dropped, and their deferred promises never settled. This caused lost database writes in the prover-client's `KVBrokerDatabase` on shutdown.

## Changes

- Added `this.flushCurrentBatch()` call before `this.container.end()` in `BatchQueue.stop()` to ensure the current partial batch is pushed to the processing queue before shutdown.
- Added a test case covering the partial-batch-on-stop scenario.