### PR TITLE
fix: addresses logic audit findings 

### DIFF
--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/logic_constraint.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/logic_constraint.cpp
@@ -24,10 +24,11 @@ void create_logic_gate(Builder& builder,
 
     field_ct computed_result = bb::stdlib::logic<Builder>::create_logic_constraint(left, right, num_bits, is_xor_gate);
 
-    // In write-VK mode the result witness holds a dummy zero. When both inputs are constant the computed result is a
-    // compile-time constant, so assert_equal would spuriously fail. Patch the witness value so the downstream
-    // assertion sees the correct value.
-    if (builder.is_write_vk_mode() && computed_result.is_constant()) {
+    // In write-VK mode the result witness holds a dummy zero. In certain cases, the computed result is non-zero so the
+    // assert_equal would spuriously fail. Patch the witness value so the downstream assertion sees the correct value.
+    // Eg. for an XOR gate, if the inputs are constants such that the result is a non-zero constant, the assert_equal
+    // will fail in write-VK mode since the result witness is initialized to zero.
+    if (builder.is_write_vk_mode()) {
         builder.set_variable(result, computed_result.get_value());
     }
 

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/logic_constraint.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/logic_constraint.cpp
@@ -23,6 +23,14 @@ void create_logic_gate(Builder& builder,
     field_ct right = to_field_ct(b, builder);
 
     field_ct computed_result = bb::stdlib::logic<Builder>::create_logic_constraint(left, right, num_bits, is_xor_gate);
+
+    // In write-VK mode the result witness holds a dummy zero. When both inputs are constant the computed result is a
+    // compile-time constant, so assert_equal would spuriously fail. Patch the witness value so the downstream
+    // assertion sees the correct value.
+    if (builder.is_write_vk_mode() && computed_result.is_constant()) {
+        builder.set_variable(result, computed_result.get_value());
+    }
+
     field_ct acir_result = field_ct::from_witness_index(&builder, result);
     computed_result.assert_equal(acir_result);
 }

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/logic_constraint.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/logic_constraint.test.cpp
@@ -73,8 +73,8 @@ class LogicConstraintTestingFunctions {
             return WitnessOrConstant<FF>::from_index(input_index);
         };
 
-        bb::fr lhs = FF(static_cast<uint256_t>(1) << num_bits - 1); // All bits from 0 to num_bits-1 are set
-        bb::fr rhs = FF(static_cast<uint256_t>(1) << num_bits - 1); // All bits from 0 to num_bits-1 are set
+        bb::fr lhs = FF((static_cast<uint256_t>(1) << num_bits) - 1); // All bits from 0 to num_bits-1 are set
+        bb::fr rhs = FF((static_cast<uint256_t>(1) << num_bits) - 1); // All bits from 0 to num_bits-1 are set
         bb::fr result = is_xor_gate ? (static_cast<uint256_t>(lhs) ^ static_cast<uint256_t>(rhs))
                                     : (static_cast<uint256_t>(lhs) & static_cast<uint256_t>(rhs));
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/logic/logic.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/logic/logic.cpp
@@ -70,7 +70,7 @@ field_t<Builder> logic<Builder>::create_logic_constraint(
         return create_logic_constraint(a, b_witness, num_bits, is_xor_gate, get_chunk);
     }
 
-    Builder* ctx = a.get_context();
+    Builder* ctx = validate_context<Builder>(a.get_context(), b.get_context());
 
     // We slice the input values into 32-bit chunks, and then use a multi-table lookup to compute the AND or XOR
     // of each chunk. Since we perform the lookup from 32-bit multi-tables, the lookup operation implicitly enforces a

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/logic/logic.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/logic/logic.cpp
@@ -58,6 +58,7 @@ field_t<Builder> logic<Builder>::create_logic_constraint(
         Builder* ctx = b.get_context();
         uint256_t a_native(a.get_value());
         field_pt a_witness = field_pt::from_witness_index(ctx, ctx->put_constant_variable(a_native));
+        a_witness.set_origin_tag(a.get_origin_tag());
         return create_logic_constraint(a_witness, b, num_bits, is_xor_gate, get_chunk);
     }
 
@@ -65,6 +66,7 @@ field_t<Builder> logic<Builder>::create_logic_constraint(
         Builder* ctx = a.get_context();
         uint256_t b_native(b.get_value());
         field_pt b_witness = field_pt::from_witness_index(ctx, ctx->put_constant_variable(b_native));
+        b_witness.set_origin_tag(b.get_origin_tag());
         return create_logic_constraint(a, b_witness, num_bits, is_xor_gate, get_chunk);
     }
 
@@ -111,6 +113,7 @@ field_t<Builder> logic<Builder>::create_logic_constraint(
     a.assert_equal(a_accumulator, "stdlib logic: failed to reconstruct left operand");
     b.assert_equal(b_accumulator, "stdlib logic: failed to reconstruct right operand");
 
+    res.set_origin_tag(OriginTag(a.get_origin_tag(), b.get_origin_tag()));
     return res;
 }
 template class logic<bb::UltraCircuitBuilder>;

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/logic/logic.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/logic/logic.test.cpp
@@ -143,3 +143,64 @@ TYPED_TEST(LogicTest, DifferentWitnessSameResult)
     bool result = CircuitChecker::check(builder);
     EXPECT_EQ(result, false);
 }
+
+// Regression test: OriginTag must propagate through all logic constraint paths.
+TYPED_TEST(LogicTest, OriginTagPropagation)
+{
+    STDLIB_TYPE_ALIASES
+    STANDARD_TESTING_TAGS
+
+    auto builder = Builder();
+    uint256_t a_val = 0xAB;
+    uint256_t b_val = 0xCD;
+
+    // Both witnesses
+    {
+        field_ct x = witness_ct(&builder, a_val);
+        field_ct y = witness_ct(&builder, b_val);
+        x.set_origin_tag(submitted_value_origin_tag);
+        y.set_origin_tag(challenge_origin_tag);
+
+        field_ct and_result = stdlib::logic<Builder>::create_logic_constraint(x, y, 8, false);
+        field_ct xor_result = stdlib::logic<Builder>::create_logic_constraint(x, y, 8, true);
+
+        EXPECT_EQ(and_result.get_origin_tag(), first_two_merged_tag);
+        EXPECT_EQ(xor_result.get_origin_tag(), first_two_merged_tag);
+    }
+
+    // Left constant, right witness
+    {
+        field_ct x_const(&builder, a_val);
+        field_ct y = witness_ct(&builder, b_val);
+        x_const.set_origin_tag(submitted_value_origin_tag);
+        y.set_origin_tag(challenge_origin_tag);
+
+        field_ct result = stdlib::logic<Builder>::create_logic_constraint(x_const, y, 8, false);
+        EXPECT_EQ(result.get_origin_tag(), first_two_merged_tag);
+    }
+
+    // Right constant, left witness
+    {
+        field_ct x = witness_ct(&builder, a_val);
+        field_ct y_const(&builder, b_val);
+        x.set_origin_tag(submitted_value_origin_tag);
+        y_const.set_origin_tag(challenge_origin_tag);
+
+        field_ct result = stdlib::logic<Builder>::create_logic_constraint(x, y_const, 8, false);
+        EXPECT_EQ(result.get_origin_tag(), first_two_merged_tag);
+    }
+
+    // Both constants
+    {
+        field_ct x_const(&builder, a_val);
+        field_ct y_const(&builder, b_val);
+        x_const.set_origin_tag(submitted_value_origin_tag);
+        y_const.set_origin_tag(challenge_origin_tag);
+
+        field_ct result = stdlib::logic<Builder>::create_logic_constraint(x_const, y_const, 8, false);
+        EXPECT_EQ(result.get_origin_tag(), first_two_merged_tag);
+    }
+
+    bool result = CircuitChecker::check(builder);
+    EXPECT_EQ(result, true);
+}


### PR DESCRIPTION

#### L1: ACIR `num_bits` Validation

Status: won't fix

It is true that `create_logic_constraint` uses `BB_ASSERT` (which aborts) rather than throwing an exception when `num_bits` is invalid. `BB_ASSERT` is the standard pattern throughout barretenberg for structural invariant checks. Additionally, the `num_bits` value originates from Noir's `IntegerBitSize` enum, which restricts values to {1, 8, 16, 32, 64, 128} at the compiler level, so invalid values cannot reach this code through normal operation.

#### L2: OriginTag Provenance

Status: fixed 0f3ca1c6a8

`create_logic_constraint` was not propagating `OriginTag` when converting constant inputs to witnesses, or when returning the final result. Tags are now copied onto the witness before recursing (for both the left-constant and right-constant paths), and the final accumulated result is tagged with the merged tag of both operands. Note we do not propagate tags to the chunks because these are intermediate circuit variables that are not used outside of logic.

#### L3: Builder Context Validation

Status: fixed 249bfdc760

When both inputs are witnesses, the code extracted the builder context from only one operand without verifying both refer to the same builder. Added `validate_context<Builder>(a.get_context(), b.get_context())` to assert consistency, matching the pattern used in other stdlib primitives.

#### L4: Write-VK Mode Guard for Constant Inputs

Status: fixed 5b3d4b857a

In write-VK mode, when both inputs are constants, `create_logic_constraint` returns a constant `field_t`. The ACIR bridge then attempts `assert_equal` against a result witness that holds a dummy zero, causing a spurious failure. The fix uses `builder.set_variable()` to patch the result witness with the correct computed value before the equality check.

#### I1: Witness Bounds Checks Are Debug-Only

Status: acknowledged, will be fixed later

The witness index bounds checks in `get_variable()` use `BB_ASSERT_DEBUG`, which is compiled out in release builds. This is known and it affects every circuit component that calls `get_variable()`, not just the logic gadget. We are discussing this the noir team if it can be exploited in any meaningful way. Regardless, we will enable these asserts in release mode soon after ensuring no significant hit in performance because of the asserts.

#### I2: Oversized Plookup Table

Status: won't fix

The code always uses `UINT32_XOR`/`UINT32_AND` plookup tables even when the last chunk is smaller than 32 bits. Smaller tables (UINT8, UINT16) exist and would use fewer sub-lookups. However, this is a minor optimization that would change the circuit structure, which we want to avoid at this point. The existing explicit range constraint on the last chunk ensures correctness regardless of table size.

#### I3: Operator Precedence Bug in Test

Status: fixed — 2a597fb73b

The test computed `1 << num_bits - 1` intending "all bits set" (`(1 << num_bits) - 1`), but C++ precedence evaluates it as `1 << (num_bits - 1)` (a single bit). For `num_bits = 8`, this gives `128` instead of `255`. Corrected the test.

#### I4: Redundant Range Constraints

Status: won't fix

Yes there could be cases of redundant range constraints (on the noir side as well as barretenberg) but we prefer to have redundancy over missing a range constraint. This was a good find but we decided to not use the optimisation.