### PR TITLE
chore: UB updates

### DIFF
--- a/barretenberg/cpp/src/barretenberg/ecc/fields/field_declarations.hpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/fields/field_declarations.hpp
@@ -629,14 +629,14 @@ template <class Params_> struct alignas(32) field {
     BB_INLINE static field asm_sqr_with_coarse_reduction(const field& a) noexcept;
     BB_INLINE static field asm_add_with_coarse_reduction(const field& a, const field& b) noexcept;
     BB_INLINE static field asm_sub_with_coarse_reduction(const field& a, const field& b) noexcept;
-    BB_INLINE static void asm_self_mul_with_coarse_reduction(const field& a, const field& b) noexcept;
-    BB_INLINE static void asm_self_sqr_with_coarse_reduction(const field& a) noexcept;
-    BB_INLINE static void asm_self_add_with_coarse_reduction(const field& a, const field& b) noexcept;
-    BB_INLINE static void asm_self_sub_with_coarse_reduction(const field& a, const field& b) noexcept;
+    BB_INLINE static void asm_self_mul_with_coarse_reduction(field& a, const field& b) noexcept;
+    BB_INLINE static void asm_self_sqr_with_coarse_reduction(field& a) noexcept;
+    BB_INLINE static void asm_self_add_with_coarse_reduction(field& a, const field& b) noexcept;
+    BB_INLINE static void asm_self_sub_with_coarse_reduction(field& a, const field& b) noexcept;
 
     BB_INLINE static void asm_conditional_negate(field& r, uint64_t predicate) noexcept;
     BB_INLINE static field asm_reduce_once(const field& a) noexcept;
-    BB_INLINE static void asm_self_reduce_once(const field& a) noexcept;
+    BB_INLINE static void asm_self_reduce_once(field& a) noexcept;
     static constexpr uint64_t zero_reference = 0x00ULL;
 #endif
     constexpr field tonelli_shanks_sqrt() const noexcept;

--- a/barretenberg/cpp/src/barretenberg/ecc/fields/field_impl_x64.hpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/fields/field_impl_x64.hpp
@@ -46,7 +46,7 @@ template <class T> field<T> field<T>::asm_mul_with_coarse_reduction(const field&
     return r;
 }
 
-template <class T> void field<T>::asm_self_mul_with_coarse_reduction(const field& a, const field& b) noexcept
+template <class T> void field<T>::asm_self_mul_with_coarse_reduction(field& a, const field& b) noexcept
 {
     constexpr uint64_t r_inv = T::r_inv;
     constexpr uint64_t modulus_0 = modulus.data[0];
@@ -141,7 +141,7 @@ template <class T> field<T> field<T>::asm_sqr_with_coarse_reduction(const field&
     return r;
 }
 
-template <class T> void field<T>::asm_self_sqr_with_coarse_reduction(const field& a) noexcept
+template <class T> void field<T>::asm_self_sqr_with_coarse_reduction(field& a) noexcept
 {
     constexpr uint64_t r_inv = T::r_inv;
     constexpr uint64_t modulus_0 = modulus.data[0];
@@ -227,7 +227,7 @@ template <class T> field<T> field<T>::asm_add_with_coarse_reduction(const field&
     return r;
 }
 
-template <class T> void field<T>::asm_self_add_with_coarse_reduction(const field& a, const field& b) noexcept
+template <class T> void field<T>::asm_self_add_with_coarse_reduction(field& a, const field& b) noexcept
 {
     constexpr uint64_t twice_not_modulus_0 = twice_not_modulus.data[0];
     constexpr uint64_t twice_not_modulus_1 = twice_not_modulus.data[1];
@@ -277,7 +277,7 @@ template <class T> field<T> field<T>::asm_sub_with_coarse_reduction(const field&
     return r;
 }
 
-template <class T> void field<T>::asm_self_sub_with_coarse_reduction(const field& a, const field& b) noexcept
+template <class T> void field<T>::asm_self_sub_with_coarse_reduction(field& a, const field& b) noexcept
 {
     constexpr uint64_t twice_modulus_0 = twice_modulus.data[0];
     constexpr uint64_t twice_modulus_1 = twice_modulus.data[1];
@@ -353,7 +353,7 @@ template <class T> field<T> field<T>::asm_reduce_once(const field& a) noexcept
     return r;
 }
 
-template <class T> void field<T>::asm_self_reduce_once(const field& a) noexcept
+template <class T> void field<T>::asm_self_reduce_once(field& a) noexcept
 {
     constexpr uint64_t not_modulus_0 = not_modulus.data[0];
     constexpr uint64_t not_modulus_1 = not_modulus.data[1];

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/databus/databus.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/databus/databus.cpp
@@ -45,7 +45,9 @@ field_t<Builder> databus<Builder>::bus_vector::operator[](const field_pt& index)
     // Ensure the read is valid
     auto raw_index = static_cast<size_t>(uint256_t(index.get_value()).data[0]);
     if (raw_index >= length) {
+        // Set a failure when the index is out of bounds. Return early to avoid OOB vector access.
         context->failure("bus_vector: access out of bounds");
+        return field_pt::from_witness_index(context, context->zero_idx());
     }
 
     // The read index must be a witness; if constant, add it as a constant variable

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/ram_table.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/ram_table.cpp
@@ -180,9 +180,9 @@ template <typename Builder> field_t<Builder> ram_table<Builder>::read(const fiel
 
     const auto native_index = uint256_t(index.get_value());
     if (native_index >= length) {
-        // set a failure when the index is out of bounds. another error will be thrown when we try to call
-        // `read_RAM_array`.
+        // Set a failure when the index is out of bounds. Return early to avoid OOB vector access.
         context->failure("ram_table: RAM array access out of bounds");
+        return field_pt::from_witness_index(context, context->zero_idx());
     }
 
     if (!check_indices_initialized()) {

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/rom_table.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/rom_table.cpp
@@ -178,7 +178,9 @@ template <typename Builder> field_t<Builder> rom_table<Builder>::operator[](cons
 
     const auto native_index = uint256_t(index.get_value());
     if (native_index >= length) {
+        // Set a failure when the index is out of bounds. Return early to avoid OOB vector access.
         context->failure("rom_table: ROM array access out of bounds");
+        return field_pt::from_witness_index(context, context->zero_idx());
     }
 
     uint32_t output_idx = context->read_ROM_array(rom_id, index.get_witness_index());
@@ -188,7 +190,6 @@ template <typename Builder> field_t<Builder> rom_table<Builder>::operator[](cons
 
     // If the index is legitimate, restore the tag
     if (native_index < length) {
-
         element.set_origin_tag(_tags[cast_index]);
     }
     return element;

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/rom_table.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/rom_table.test.cpp
@@ -167,3 +167,28 @@ TEST(RomTable, OobConstantIndexDoesNotCrashRegression)
 
     EXPECT_TRUE(builder.failed());
 }
+
+/**
+ * @brief Regression: OOB witness-index read must soft-fail without OOB vector access.
+ */
+TEST(RomTable, OobWitnessIndexDoesNotCrashRegression)
+{
+    using Builder = UltraCircuitBuilder;
+    using field_ct = stdlib::field_t<Builder>;
+    using witness_ct = stdlib::witness_t<Builder>;
+    using rom_table_ct = stdlib::rom_table<Builder>;
+
+    Builder builder;
+
+    std::vector<field_ct> table_values;
+    table_values.emplace_back(witness_ct(&builder, bb::fr(1)));
+    table_values.emplace_back(witness_ct(&builder, bb::fr(2)));
+    table_values.emplace_back(witness_ct(&builder, bb::fr(3)));
+    rom_table_ct table(table_values);
+
+    // OOB witness index — should soft-fail, not crash
+    field_ct oob_index = witness_ct(&builder, bb::fr(100000000));
+    table[oob_index];
+
+    EXPECT_TRUE(builder.failed());
+}

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/twin_rom_table.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/twin_rom_table.cpp
@@ -150,7 +150,10 @@ std::array<field_t<Builder>, 2> twin_rom_table<Builder>::operator[](const field_
 
     initialize_table();
     if (uint256_t(index.get_value()) >= length) {
+        // Set a failure when the index is out of bounds. Return early to avoid OOB vector access.
         context->failure("twin_rom_table: ROM array access out of bounds");
+        return { field_pt::from_witness_index(context, context->zero_idx()),
+                 field_pt::from_witness_index(context, context->zero_idx()) };
     }
 
     auto output_indices = context->read_ROM_array_pair(rom_id, index.get_witness_index());

--- a/barretenberg/cpp/src/barretenberg/sumcheck/zk_sumcheck_data.hpp
+++ b/barretenberg/cpp/src/barretenberg/sumcheck/zk_sumcheck_data.hpp
@@ -151,7 +151,7 @@ template <typename Flavor> struct ZKSumcheckData {
         }
         total_sum *= scaling_factor;
 
-        return { total_sum + constant_term * (1 << libra_univariates.size()), scaling_factor };
+        return { total_sum + constant_term * (1UL << libra_univariates.size()), scaling_factor };
     }
 
     /**


### PR DESCRIPTION
Fixes the following from UB meta [issue](https://github.com/AztecProtocol/barretenberg-claude/issues/2414): 
- F11 (zk_sumcheck_data.hpp) — Signed 1 << n is UB when n≥31; changed to 1UL <<                                                                                                              
- F10 (rom_table.cpp, ram_table.cpp, twin_rom_table.cpp, databus.cpp) — OOB vector access after context->failure() soft fail; added early returns                                          
- F9 (field_declarations.hpp, field_impl_x64.hpp) — asm_self_* functions write through const& which is UB; changed to mutable ref    