### PR TITLE
chore: elliptic intra-op fusion only

### DIFF
--- a/barretenberg/cpp/src/barretenberg/circuit_checker/ultra_circuit_builder_elliptic.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/circuit_checker/ultra_circuit_builder_elliptic.test.cpp
@@ -175,7 +175,7 @@ TEST_F(UltraCircuitBuilderElliptic, MultipleOperationsUnchained)
 }
 
 // Verifies that a chain of three operations (add-double-add) can be made to reuse intermediate results via
-// fuse_ecc_*_gate.
+// create_fused_ecc_*_gate.
 TEST_F(UltraCircuitBuilderElliptic, ChainedOperationsWithDouble)
 {
     UltraCircuitBuilder builder;
@@ -206,8 +206,8 @@ TEST_F(UltraCircuitBuilderElliptic, ChainedOperationsWithDouble)
 
     // First op: non-fused. Subsequent ops: explicitly fused via prev_gate_idx.
     size_t prev = builder.create_ecc_add_gate({ x1, y1, x2, y2, x_temp1, y_temp1, /*is_addition=*/true });
-    prev = builder.fuse_ecc_dbl_gate(prev, { x_temp1, y_temp1, x_temp2, y_temp2 });
-    builder.fuse_ecc_add_gate(prev, { x_temp2, y_temp2, x3, y3, x_result, y_result, /*is_addition=*/true });
+    prev = builder.create_fused_ecc_dbl_gate(prev, { x_temp1, y_temp1, x_temp2, y_temp2 });
+    builder.create_fused_ecc_add_gate(prev, { x_temp2, y_temp2, x3, y3, x_result, y_result, /*is_addition=*/true });
 
     EXPECT_EQ(builder.blocks.elliptic.size(), 4UL); // 3 chained operations: 2 + 1 + 1 gates (fusion saves 2)
     EXPECT_TRUE(CircuitChecker::check(builder));
@@ -245,8 +245,8 @@ TEST_F(UltraCircuitBuilderElliptic, ChainedOperationsDoubleFailure)
 
     // Use explicit fusion to chain the operations
     size_t prev = builder.create_ecc_add_gate({ x1, y1, x2, y2, x_temp1, y_temp1, /*is_addition=*/true });
-    prev = builder.fuse_ecc_dbl_gate(prev, { x_temp1, y_temp1, x_temp2, y_temp2 });
-    builder.fuse_ecc_add_gate(prev, { x_temp2, y_temp2, x3, y3, x_result, y_result, /*is_addition=*/true });
+    prev = builder.create_fused_ecc_dbl_gate(prev, { x_temp1, y_temp1, x_temp2, y_temp2 });
+    builder.create_fused_ecc_add_gate(prev, { x_temp2, y_temp2, x3, y3, x_result, y_result, /*is_addition=*/true });
 
     EXPECT_EQ(builder.blocks.elliptic.size(), 4UL); // 3 chained operations: 2 + 1 + 1 gates (fusion saves 2)
     // Should fail because the middle operation (doubling) has an invalid result
@@ -280,8 +280,8 @@ TEST_F(UltraCircuitBuilderElliptic, DoubleOffCurveOriginUnconstrainedOutput)
     EXPECT_TRUE(CircuitChecker::check(builder));
 }
 
-// Verifies that fuse_ecc_add_gate falls back to a non-fused gate pair when prev_gate_idx is not at the block tail.
-// The fusion decision is based on structural adjacency (is the previous gate still the last in the block?). This
+// Verifies that create_fused_ecc_add_gate falls back to a non-fused gate pair when prev_gate_idx is not at the block
+// tail. The fusion decision is based on structural adjacency (is the previous gate still the last in the block?). This
 // ensures that the gate structure of an ACIR opcode involving cycle_group is independent of its witness values.
 TEST_F(UltraCircuitBuilderElliptic, FuseEccAddGateFallsBackWhenNotAtBlockTail)
 {
@@ -300,14 +300,15 @@ TEST_F(UltraCircuitBuilderElliptic, FuseEccAddGateFallsBackWhenNotAtBlockTail)
     EXPECT_EQ(builder.blocks.elliptic.size(), 4UL); // 2 non-fused ops = 4 gates
 
     // Attempt to fuse into first_output_idx, which is no longer at the block tail.
-    // The adjacency check fails, so fuse_ecc_add_gate deterministically falls back to create_ecc_add_gate.
+    // The adjacency check fails, so create_fused_ecc_add_gate deterministically falls back to create_ecc_add_gate.
     affine_element p3 = crypto::pedersen_commitment::commit_native({ bb::fr(3) }, 0);
     affine_element result(element(first_add.result) + element(p3));
     uint32_t x3 = builder.add_variable(p3.x);
     uint32_t y3 = builder.add_variable(p3.y);
     uint32_t x_result = builder.add_variable(result.x);
     uint32_t y_result = builder.add_variable(result.y);
-    builder.fuse_ecc_add_gate(first_output_idx, { x_temp1, y_temp1, x3, y3, x_result, y_result, /*is_addition=*/true });
+    builder.create_fused_ecc_add_gate(first_output_idx,
+                                      { x_temp1, y_temp1, x3, y3, x_result, y_result, /*is_addition=*/true });
 
     EXPECT_EQ(builder.blocks.elliptic.size(), 6UL); // fell back to non-fused: 4 + 2 = 6 (not 4 + 1 = 5)
     EXPECT_TRUE(CircuitChecker::check(builder));

--- a/barretenberg/cpp/src/barretenberg/circuit_checker/ultra_circuit_builder_elliptic.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/circuit_checker/ultra_circuit_builder_elliptic.test.cpp
@@ -1,5 +1,6 @@
 #include "barretenberg/circuit_checker/circuit_checker.hpp"
 #include "barretenberg/crypto/pedersen_commitment/pedersen.hpp"
+#include "barretenberg/stdlib/primitives/group/cycle_group.hpp"
 #include "barretenberg/stdlib_circuit_builders/ultra_circuit_builder.hpp"
 
 #include <gtest/gtest.h>
@@ -173,35 +174,8 @@ TEST_F(UltraCircuitBuilderElliptic, MultipleOperationsUnchained)
     EXPECT_TRUE(CircuitChecker::check(builder));
 }
 
-// Verifies that chaining two operations by reusing intermediate results reduces the gate count.
-TEST_F(UltraCircuitBuilderElliptic, ChainedOperations)
-{
-    UltraCircuitBuilder builder;
-
-    // First addition: p1 + p2 = temp
-    auto first_add = create_add_points(1, 2, true);
-
-    // Second addition: temp + p3 = result
-    affine_element p3 = crypto::pedersen_commitment::commit_native({ bb::fr(3) }, 0);
-    affine_element result(element(first_add.result) + element(p3));
-
-    // Add variables for first operation
-    auto [x1, y1, x2, y2, x_temp, y_temp] = add_add_gate_variables(builder, first_add);
-
-    // Add variables for second operation
-    uint32_t x3 = builder.add_variable(p3.x);
-    uint32_t y3 = builder.add_variable(p3.y);
-    uint32_t x_result = builder.add_variable(result.x);
-    uint32_t y_result = builder.add_variable(result.y);
-
-    builder.create_ecc_add_gate({ x1, y1, x2, y2, x_temp, y_temp, /*is_addition=*/true });
-    builder.create_ecc_add_gate({ x_temp, y_temp, x3, y3, x_result, y_result, /*is_addition=*/true });
-
-    EXPECT_EQ(builder.blocks.elliptic.size(), 3UL); // 2 chained operations = 2 + (2 - 1) gates
-    EXPECT_TRUE(CircuitChecker::check(builder));
-}
-
-// Verifies that a chain of three operations (add-double-add) correctly reuses intermediate results.
+// Verifies that a chain of three operations (add-double-add) can be made to reuse intermediate results via
+// fuse_ecc_*_gate.
 TEST_F(UltraCircuitBuilderElliptic, ChainedOperationsWithDouble)
 {
     UltraCircuitBuilder builder;
@@ -230,11 +204,12 @@ TEST_F(UltraCircuitBuilderElliptic, ChainedOperationsWithDouble)
     uint32_t x_result = builder.add_variable(result.x);
     uint32_t y_result = builder.add_variable(result.y);
 
-    builder.create_ecc_add_gate({ x1, y1, x2, y2, x_temp1, y_temp1, /*is_addition=*/true });
-    builder.create_ecc_dbl_gate({ x_temp1, y_temp1, x_temp2, y_temp2 });
-    builder.create_ecc_add_gate({ x_temp2, y_temp2, x3, y3, x_result, y_result, /*is_addition=*/true });
+    // First op: non-fused. Subsequent ops: explicitly fused via prev_gate_idx.
+    size_t prev = builder.create_ecc_add_gate({ x1, y1, x2, y2, x_temp1, y_temp1, /*is_addition=*/true });
+    prev = builder.fuse_ecc_dbl_gate(prev, { x_temp1, y_temp1, x_temp2, y_temp2 });
+    builder.fuse_ecc_add_gate(prev, { x_temp2, y_temp2, x3, y3, x_result, y_result, /*is_addition=*/true });
 
-    EXPECT_EQ(builder.blocks.elliptic.size(), 4UL); // 3 chained operations, 2 + (2 - 1) + (2 - 1) gates
+    EXPECT_EQ(builder.blocks.elliptic.size(), 4UL); // 3 chained operations: 2 + 1 + 1 gates (fusion saves 2)
     EXPECT_TRUE(CircuitChecker::check(builder));
 }
 
@@ -268,11 +243,12 @@ TEST_F(UltraCircuitBuilderElliptic, ChainedOperationsDoubleFailure)
     uint32_t x_result = builder.add_variable(result.x);
     uint32_t y_result = builder.add_variable(result.y);
 
-    builder.create_ecc_add_gate({ x1, y1, x2, y2, x_temp1, y_temp1, /*is_addition=*/true });
-    builder.create_ecc_dbl_gate({ x_temp1, y_temp1, x_temp2, y_temp2 });
-    builder.create_ecc_add_gate({ x_temp2, y_temp2, x3, y3, x_result, y_result, /*is_addition=*/true });
+    // Use explicit fusion to chain the operations
+    size_t prev = builder.create_ecc_add_gate({ x1, y1, x2, y2, x_temp1, y_temp1, /*is_addition=*/true });
+    prev = builder.fuse_ecc_dbl_gate(prev, { x_temp1, y_temp1, x_temp2, y_temp2 });
+    builder.fuse_ecc_add_gate(prev, { x_temp2, y_temp2, x3, y3, x_result, y_result, /*is_addition=*/true });
 
-    EXPECT_EQ(builder.blocks.elliptic.size(), 4UL); // 3 chained operations, 2 + (2 - 1) + (2 - 1) gates
+    EXPECT_EQ(builder.blocks.elliptic.size(), 4UL); // 3 chained operations: 2 + 1 + 1 gates (fusion saves 2)
     // Should fail because the middle operation (doubling) has an invalid result
     EXPECT_FALSE(CircuitChecker::check(builder));
 }
@@ -302,4 +278,93 @@ TEST_F(UltraCircuitBuilderElliptic, DoubleOffCurveOriginUnconstrainedOutput)
     // The circuit checker passes because the relation is trivially satisfied for (0,0) input.
     // This is NOT a bug — production code never lets (0,0) reach a doubling gate.
     EXPECT_TRUE(CircuitChecker::check(builder));
+}
+
+// Verifies that fuse_ecc_add_gate falls back to a non-fused gate pair when prev_gate_idx is not at the block tail.
+// The fusion decision is based on structural adjacency (is the previous gate still the last in the block?). This
+// ensures that the gate structure of an ACIR opcode involving cycle_group is independent of its witness values.
+TEST_F(UltraCircuitBuilderElliptic, FuseEccAddGateFallsBackWhenNotAtBlockTail)
+{
+    UltraCircuitBuilder builder;
+
+    // First operation: p1 + p2 = temp1
+    auto first_add = create_add_points(1, 2, true);
+    auto [x1, y1, x2, y2, x_temp1, y_temp1] = add_add_gate_variables(builder, first_add);
+    size_t first_output_idx = builder.create_ecc_add_gate({ x1, y1, x2, y2, x_temp1, y_temp1, /*is_addition=*/true });
+
+    // Independent operation: an unrelated addition appends gates, moving the block tail past first_output_idx
+    auto unrelated = create_add_points(4, 5, true);
+    auto [ux1, uy1, ux2, uy2, ux3, uy3] = add_add_gate_variables(builder, unrelated);
+    builder.create_ecc_add_gate({ ux1, uy1, ux2, uy2, ux3, uy3, /*is_addition=*/true });
+
+    EXPECT_EQ(builder.blocks.elliptic.size(), 4UL); // 2 non-fused ops = 4 gates
+
+    // Attempt to fuse into first_output_idx, which is no longer at the block tail.
+    // The adjacency check fails, so fuse_ecc_add_gate deterministically falls back to create_ecc_add_gate.
+    affine_element p3 = crypto::pedersen_commitment::commit_native({ bb::fr(3) }, 0);
+    affine_element result(element(first_add.result) + element(p3));
+    uint32_t x3 = builder.add_variable(p3.x);
+    uint32_t y3 = builder.add_variable(p3.y);
+    uint32_t x_result = builder.add_variable(result.x);
+    uint32_t y_result = builder.add_variable(result.y);
+    builder.fuse_ecc_add_gate(first_output_idx, { x_temp1, y_temp1, x3, y3, x_result, y_result, /*is_addition=*/true });
+
+    EXPECT_EQ(builder.blocks.elliptic.size(), 6UL); // fell back to non-fused: 4 + 2 = 6 (not 4 + 1 = 5)
+    EXPECT_TRUE(CircuitChecker::check(builder));
+}
+
+// The gate structure of an ACIR opcode must be independent of witness values. ECC gate fusion is an optimization
+// that reduces gate count within a single opcode's implementation (e.g., the Straus MSM loop), but must not cause
+// the gate count to vary between independent opcodes based on whether their wire indices happen to match.
+//
+// Fusion is controlled by _ecc_gate_idx on cycle_group: it is set when an ECC gate is created and consumed by the
+// next ECC operation on the same object. At ACIR opcode boundaries, cycle_groups are reconstructed from witness
+// indices, which resets _ecc_gate_idx to nullopt, deterministically preventing cross-opcode fusion.
+//
+// Scenario A: two adds chained within a single logical operation — fusion occurs (3 gates).
+// Scenario B: same two adds, but the intermediate result is reconstructed from witness indices as ACIR does at
+//             opcode boundaries — fusion does not occur (4 gates).
+TEST_F(UltraCircuitBuilderElliptic, FusionBreaksAcrossAcirOpcodeBoundary)
+{
+    using cycle_group = stdlib::cycle_group<UltraCircuitBuilder>;
+    using field_t = stdlib::field_t<UltraCircuitBuilder>;
+
+    affine_element p1 = crypto::pedersen_commitment::commit_native({ bb::fr(1) }, 0);
+    affine_element p2 = crypto::pedersen_commitment::commit_native({ bb::fr(2) }, 0);
+    affine_element p3 = crypto::pedersen_commitment::commit_native({ bb::fr(3) }, 0);
+
+    // --- Scenario A: chained within a single opcode (fusion expected) ---
+    {
+        UltraCircuitBuilder builder;
+        auto P1 = cycle_group::from_witness(&builder, p1);
+        auto P2 = cycle_group::from_witness(&builder, p2);
+        auto P3 = cycle_group::from_witness(&builder, p3);
+
+        auto mid = P1.unconditional_add(P2);     // non-fused: 2 gates
+        auto result = mid.unconditional_add(P3); // fused into mid's output: 1 gate
+        (void)result;
+
+        EXPECT_EQ(builder.blocks.elliptic.size(), 3UL);
+        EXPECT_TRUE(CircuitChecker::check(builder));
+    }
+
+    // --- Scenario B: reconstructed at opcode boundary (no fusion) ---
+    {
+        UltraCircuitBuilder builder;
+        auto P1 = cycle_group::from_witness(&builder, p1);
+        auto P2 = cycle_group::from_witness(&builder, p2);
+        auto P3 = cycle_group::from_witness(&builder, p3);
+
+        auto mid = P1.unconditional_add(P2); // non-fused: 2 gates
+
+        // Reconstruct from witness indices, as ACIR does when one opcode's output becomes another's input.
+        // The fresh cycle_group has no _ecc_gate_idx, so the next operation cannot fuse.
+        auto mid_fresh = cycle_group(field_t::from_witness_index(&builder, mid.x().get_witness_index()),
+                                     field_t::from_witness_index(&builder, mid.y().get_witness_index()));
+        auto result = mid_fresh.unconditional_add(P3); // non-fused: 2 gates
+        (void)result;
+
+        EXPECT_EQ(builder.blocks.elliptic.size(), 4UL);
+        EXPECT_TRUE(CircuitChecker::check(builder));
+    }
 }

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/group/cycle_group.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/group/cycle_group.cpp
@@ -337,12 +337,18 @@ cycle_group<Builder> cycle_group<Builder>::dbl(const std::optional<AffineElement
         result = cycle_group(
             witness_t(context, x3), witness_t(context, y3), is_point_at_infinity(), /*assert_on_curve=*/false);
 
-        context->create_ecc_dbl_gate(bb::ecc_dbl_gate_<bb::fr>{
+        bb::ecc_dbl_gate_<bb::fr> gate_data{
             .x1 = _x.get_witness_index(),
             .y1 = modified_y.get_witness_index(),
             .x3 = result._x.get_witness_index(),
             .y3 = result._y.get_witness_index(),
-        });
+        };
+        // Fuse into the previous ECC gate if this point was produced by one; otherwise create a standalone gate pair.
+        if (_ecc_gate_idx.has_value()) {
+            result._ecc_gate_idx = context->fuse_ecc_dbl_gate(_ecc_gate_idx.value(), gate_data);
+        } else {
+            result._ecc_gate_idx = context->create_ecc_dbl_gate(gate_data);
+        }
 
         // Merge the x and y origin tags since the output depends on both
         result._x.set_origin_tag(OriginTag(_x.get_origin_tag(), _y.get_origin_tag()));
@@ -419,7 +425,7 @@ cycle_group<Builder> cycle_group<Builder>::_unconditional_add_or_subtract(const 
         result = cycle_group(
             witness_t(context, x3), witness_t(context, y3), /*is_infinity=*/false, /*assert_on_curve=*/false);
 
-        context->create_ecc_add_gate(bb::ecc_add_gate_{
+        bb::ecc_add_gate_ gate_data{
             .x1 = _x.get_witness_index(),
             .y1 = _y.get_witness_index(),
             .x2 = other._x.get_witness_index(),
@@ -427,7 +433,13 @@ cycle_group<Builder> cycle_group<Builder>::_unconditional_add_or_subtract(const 
             .x3 = result._x.get_witness_index(),
             .y3 = result._y.get_witness_index(),
             .is_addition = is_addition,
-        });
+        };
+        // Fuse into the previous ECC gate if this point was produced by one; otherwise create a standalone gate pair.
+        if (_ecc_gate_idx.has_value()) {
+            result._ecc_gate_idx = context->fuse_ecc_add_gate(_ecc_gate_idx.value(), gate_data);
+        } else {
+            result._ecc_gate_idx = context->create_ecc_add_gate(gate_data);
+        }
     }
 
     // Merge the origin tags from both inputs

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/group/cycle_group.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/group/cycle_group.cpp
@@ -345,7 +345,7 @@ cycle_group<Builder> cycle_group<Builder>::dbl(const std::optional<AffineElement
         };
         // Fuse into the previous ECC gate if this point was produced by one; otherwise create a standalone gate pair.
         if (_ecc_gate_idx.has_value()) {
-            result._ecc_gate_idx = context->fuse_ecc_dbl_gate(_ecc_gate_idx.value(), gate_data);
+            result._ecc_gate_idx = context->create_fused_ecc_dbl_gate(_ecc_gate_idx.value(), gate_data);
         } else {
             result._ecc_gate_idx = context->create_ecc_dbl_gate(gate_data);
         }
@@ -436,7 +436,7 @@ cycle_group<Builder> cycle_group<Builder>::_unconditional_add_or_subtract(const 
         };
         // Fuse into the previous ECC gate if this point was produced by one; otherwise create a standalone gate pair.
         if (_ecc_gate_idx.has_value()) {
-            result._ecc_gate_idx = context->fuse_ecc_add_gate(_ecc_gate_idx.value(), gate_data);
+            result._ecc_gate_idx = context->create_fused_ecc_add_gate(_ecc_gate_idx.value(), gate_data);
         } else {
             result._ecc_gate_idx = context->create_ecc_add_gate(gate_data);
         }

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/group/cycle_group.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/group/cycle_group.hpp
@@ -217,6 +217,13 @@ template <typename Builder> class cycle_group {
     bool_t _is_infinity;
     Builder* context;
 
+    // Index in the elliptic block of the most recent elliptic gate creation involving this point.
+    // When explicitly set, the next elliptic gate involving this element will attempt to fuse into the previous one,
+    // saving one gate per chained operation. If not set (e.g. default initialized), no fusion will occur regardless of
+    // whether the witness values would technically allow it. This means that structurally fusion will occur WITHIN a
+    // single cycle group operation (e.g. on the adds/dbls in a batch mul) but not BETWEEN two independent operations.
+    std::optional<size_t> _ecc_gate_idx;
+
     static batch_mul_internal_output _variable_base_batch_mul_internal(std::span<cycle_scalar> scalars,
                                                                        std::span<cycle_group> base_points,
                                                                        std::span<AffineElement const> offset_generators,

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.cpp
@@ -352,23 +352,21 @@ void UltraCircuitBuilder_<ExecutionTrace>::create_arithmetic_gate(const arithmet
 }
 
 /**
- * @brief Create an elliptic curve addition gate
- * @details Adds either one or two gates. In general, this method creates two gates with the following structure:
+ * @brief Create an elliptic curve addition gate (non-fused)
+ * @details Creates two gates with the following structure:
  *
  *      | q_ecc | w1  | w2  | w3  | w4  |
  *      |-------|-----|-----|-----|-----|
  *      |    1  |  -  | x1  | y1  |  -  | --> constrained
  *      |    0  | x2  | x3  | y3  | y2  | --> "unconstrained" (utilized by previous gate via shifts)
  *
- * However, if the "output" of the previous gate is equal to the "input" of the current gate, i.e. (x3, y3)_{i-1} ==
- * (x1, y1)_i, we can fuse them together by simply setting the selector values of the previous gate {i-1} to q_ecc = 1
- * and q_sign = ±1 based on is_addition. We take advantage of this frequently when performing chained additions or
- * doubling operations.
+ * For chained operations (e.g. Straus MSM), use fuse_ecc_add_gate to avoid the extra setup gate.
  *
  * @param in Elliptic curve point addition gate parameters
+ * @return Index (within the elliptic block) of the output gate, usable as prev_gate_idx for fuse_ecc_add/dbl_gate
  */
 template <typename ExecutionTrace>
-void UltraCircuitBuilder_<ExecutionTrace>::create_ecc_add_gate(const ecc_add_gate_& in)
+size_t UltraCircuitBuilder_<ExecutionTrace>::create_ecc_add_gate(const ecc_add_gate_& in)
 {
     this->assert_valid_variables({ in.x1, in.x2, in.x3, in.y1, in.y2, in.y3 });
 
@@ -378,79 +376,126 @@ void UltraCircuitBuilder_<ExecutionTrace>::create_ecc_add_gate(const ecc_add_gat
     // The elliptic curve relation assumes q_sign² = 1 (see elliptic_relation.hpp)
     const FF q_sign = in.is_addition ? FF(1) : FF(-1);
 
-    // Determine whether we can fuse this addition operation into the previous gate in the block
-    bool can_fuse_into_previous_gate =
-        block.size() > 0 &&                       /* a previous gate exists in the block */
-        block.w_r()[block.size() - 1] == in.x1 && /* output x coord of previous gate is input of this one */
-        block.w_o()[block.size() - 1] == in.y1;   /* output y coord of previous gate is input of this one */
+    block.populate_wires(this->zero_idx(), in.x1, in.y1, this->zero_idx());
+    block.q_3().emplace_back(0);
+    block.q_4().emplace_back(0);
+    block.q_1().emplace_back(q_sign);
 
-    if (can_fuse_into_previous_gate) {
-        block.q_1().set(block.size() - 1, q_sign);   // set q_sign of previous gate
-        block.q_elliptic().set(block.size() - 1, 1); // set q_ecc of previous gate to 1
-    } else {
-        block.populate_wires(this->zero_idx(), in.x1, in.y1, this->zero_idx());
-        block.q_3().emplace_back(0);
-        block.q_4().emplace_back(0);
-        block.q_1().emplace_back(q_sign);
+    block.q_2().emplace_back(0);
+    block.q_m().emplace_back(0);
+    block.q_c().emplace_back(0);
+    block.set_gate_selector(1);
+    check_selector_length_consistency();
+    this->increment_num_gates();
 
-        block.q_2().emplace_back(0);
-        block.q_m().emplace_back(0);
-        block.q_c().emplace_back(0);
-        block.set_gate_selector(1);
-        check_selector_length_consistency();
-        this->increment_num_gates();
-    }
-    // Create the unconstrained gate with the output of the doubling to be read into by the previous gate via shifts
+    // Create the unconstrained gate with the output to be read into by the previous gate via shifts
     create_unconstrained_gate(block, in.x2, in.x3, in.y3, in.y2);
+    return block.size() - 1;
 }
 
 /**
- * @brief Create an elliptic curve doubling gate
- * @details Adds either one or two gates. In general, this method creates two gates with the following structure:
+ * @brief Attempt to fuse an elliptic curve point addition into a previously created ECC gate
+ * @details If the previous gate (at prev_gate_idx) is still the last in the block and its output wires match this
+ * gate's inputs, fuses by setting selectors on that gate and appending only the output row. Otherwise falls back to
+ * create_ecc_add_gate (a full non-fused gate pair).
+ *
+ * @param prev_gate_idx Block-relative index of the previous ECC output gate to try to fuse into
+ * @param in Elliptic curve point addition gate parameters
+ * @return Index (within the elliptic block) of the output gate
+ */
+template <typename ExecutionTrace>
+size_t UltraCircuitBuilder_<ExecutionTrace>::fuse_ecc_add_gate(size_t prev_gate_idx, const ecc_add_gate_& in)
+{
+    this->assert_valid_variables({ in.x1, in.x2, in.x3, in.y1, in.y2, in.y3 });
+
+    auto& block = blocks.elliptic;
+
+    // Fusion requires (1) adjacency: the previous gate must be the last in the block so that the new unconstrained
+    // output gate is on the next row (the relation reads it via shifts), and (2) wire compatibility: the previous
+    // gate's output coordinates must match this gate's input coordinates. If either condition fails, fall back to a
+    // non-fused gate pair. These checks are structural (adjacency) and identity-based (wire indices), not
+    // value-based, ensuring the gate structure is determined by control flow, not by witness values.
+    bool can_fuse = prev_gate_idx == block.size() - 1 &&   // adjacency
+                    block.w_r()[prev_gate_idx] == in.x1 && // output x matches input x
+                    block.w_o()[prev_gate_idx] == in.y1;   // output y matches input y
+    if (!can_fuse) {
+        return create_ecc_add_gate(in);
+    }
+
+    const FF q_sign = in.is_addition ? FF(1) : FF(-1);
+    block.q_1().set(prev_gate_idx, q_sign);
+    block.q_elliptic().set(prev_gate_idx, 1);
+
+    create_unconstrained_gate(block, in.x2, in.x3, in.y3, in.y2);
+    return block.size() - 1;
+}
+
+/**
+ * @brief Create an elliptic curve doubling gate (non-fused)
+ * @details Creates two gates with the following structure:
  *
  *      | q_ecc | w1  | w2  | w3  | w4  |
  *      |-------|-----|-----|-----|-----|
  *      |    1  |  -  | x1  | y1  |  -  | --> constrained
  *      |    0  |  -  | x3  | y3  |  -  | --> "unconstrained" (utilized by previous gate via shifts)
  *
- * However, if the "output" of the previous gate is equal to the "input" of the current gate, i.e. (x3, y3)_{i-1} ==
- * (x1, y1)_i, we can fuse them together by simply setting the selector values of the previous gate {i-1} to q_ecc = 1
- * and q_m = 1 (which in the relation translates to q_is_double = 1). We take advantage of this frequently when
- * performing chained additions or doubling operations.
+ * For chained operations (e.g. Straus MSM), use fuse_ecc_dbl_gate to avoid the extra setup gate.
  *
  * @param in Elliptic curve point doubling gate parameters
+ * @return Index (within the elliptic block) of the output gate, usable as prev_gate_idx for fuse_ecc_add/dbl_gate
  */
 template <typename ExecutionTrace>
-void UltraCircuitBuilder_<ExecutionTrace>::create_ecc_dbl_gate(const ecc_dbl_gate_<FF>& in)
+size_t UltraCircuitBuilder_<ExecutionTrace>::create_ecc_dbl_gate(const ecc_dbl_gate_<FF>& in)
 {
     this->assert_valid_variables({ in.x1, in.x3, in.y1, in.y3 });
 
     auto& block = blocks.elliptic;
 
-    // Determine whether we can fuse this doubling operation into the previous gate in the block
-    bool can_fuse_into_previous_gate =
-        block.size() > 0 &&                       /* a previous gate exists in the block */
-        block.w_r()[block.size() - 1] == in.x1 && /* output x coord of previous gate is input of this one */
-        block.w_o()[block.size() - 1] == in.y1;   /* output y coord of previous gate is input of this one */
+    block.populate_wires(this->zero_idx(), in.x1, in.y1, this->zero_idx());
+    block.q_m().emplace_back(1);
+    block.q_1().emplace_back(0);
+    block.q_2().emplace_back(0);
+    block.q_3().emplace_back(0);
+    block.q_c().emplace_back(0);
+    block.q_4().emplace_back(0);
+    block.set_gate_selector(1);
+    check_selector_length_consistency();
+    this->increment_num_gates();
 
-    // If possible, update the previous gate to be the first gate in the pair, otherwise create a new gate
-    if (can_fuse_into_previous_gate) {
-        block.q_elliptic().set(block.size() - 1, 1); // set q_ecc of previous gate to 1
-        block.q_m().set(block.size() - 1, 1);        // set q_m (q_is_double) of previous gate to 1
-    } else {
-        block.populate_wires(this->zero_idx(), in.x1, in.y1, this->zero_idx());
-        block.q_m().emplace_back(1);
-        block.q_1().emplace_back(0);
-        block.q_2().emplace_back(0);
-        block.q_3().emplace_back(0);
-        block.q_c().emplace_back(0);
-        block.q_4().emplace_back(0);
-        block.set_gate_selector(1);
-        check_selector_length_consistency();
-        this->increment_num_gates();
-    }
     // Create the unconstrained gate with the output of the doubling to be read into by the previous gate via shifts
     create_unconstrained_gate(block, this->zero_idx(), in.x3, in.y3, this->zero_idx());
+    return block.size() - 1;
+}
+
+/**
+ * @brief Attempt to fuse an elliptic curve point doubling into a previously created ECC gate
+ * @details If the previous gate (at prev_gate_idx) is still the last in the block and its output wires match this
+ * gate's inputs, fuses by setting selectors on that gate and appending only the output row. Otherwise falls back to
+ * create_ecc_dbl_gate (a full non-fused gate pair). See fuse_ecc_add_gate for detailed rationale.
+ *
+ * @param prev_gate_idx Block-relative index of the previous ECC output gate to try to fuse into
+ * @param in Elliptic curve point doubling gate parameters
+ * @return Index (within the elliptic block) of the output gate
+ */
+template <typename ExecutionTrace>
+size_t UltraCircuitBuilder_<ExecutionTrace>::fuse_ecc_dbl_gate(size_t prev_gate_idx, const ecc_dbl_gate_<FF>& in)
+{
+    this->assert_valid_variables({ in.x1, in.x3, in.y1, in.y3 });
+
+    auto& block = blocks.elliptic;
+
+    // Fusion requires adjacency and wire compatibility (see fuse_ecc_add_gate for detailed rationale).
+    bool can_fuse =
+        prev_gate_idx == block.size() - 1 && block.w_r()[prev_gate_idx] == in.x1 && block.w_o()[prev_gate_idx] == in.y1;
+    if (!can_fuse) {
+        return create_ecc_dbl_gate(in);
+    }
+
+    block.q_elliptic().set(prev_gate_idx, 1);
+    block.q_m().set(prev_gate_idx, 1);
+
+    create_unconstrained_gate(block, this->zero_idx(), in.x3, in.y3, this->zero_idx());
+    return block.size() - 1;
 }
 
 /**

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.cpp
@@ -360,10 +360,11 @@ void UltraCircuitBuilder_<ExecutionTrace>::create_arithmetic_gate(const arithmet
  *      |    1  |  -  | x1  | y1  |  -  | --> constrained
  *      |    0  | x2  | x3  | y3  | y2  | --> "unconstrained" (utilized by previous gate via shifts)
  *
- * For chained operations (e.g. Straus MSM), use fuse_ecc_add_gate to avoid the extra setup gate.
+ * For chained operations (e.g. Straus MSM), use create_fused_ecc_add_gate to avoid the extra setup gate.
  *
  * @param in Elliptic curve point addition gate parameters
- * @return Index (within the elliptic block) of the output gate, usable as prev_gate_idx for fuse_ecc_add/dbl_gate
+ * @return Index (within the elliptic block) of the output gate, usable as prev_gate_idx for
+ * create_fused_ecc_add/dbl_gate
  */
 template <typename ExecutionTrace>
 size_t UltraCircuitBuilder_<ExecutionTrace>::create_ecc_add_gate(const ecc_add_gate_& in)
@@ -404,7 +405,7 @@ size_t UltraCircuitBuilder_<ExecutionTrace>::create_ecc_add_gate(const ecc_add_g
  * @return Index (within the elliptic block) of the output gate
  */
 template <typename ExecutionTrace>
-size_t UltraCircuitBuilder_<ExecutionTrace>::fuse_ecc_add_gate(size_t prev_gate_idx, const ecc_add_gate_& in)
+size_t UltraCircuitBuilder_<ExecutionTrace>::create_fused_ecc_add_gate(size_t prev_gate_idx, const ecc_add_gate_& in)
 {
     this->assert_valid_variables({ in.x1, in.x2, in.x3, in.y1, in.y2, in.y3 });
 
@@ -439,10 +440,11 @@ size_t UltraCircuitBuilder_<ExecutionTrace>::fuse_ecc_add_gate(size_t prev_gate_
  *      |    1  |  -  | x1  | y1  |  -  | --> constrained
  *      |    0  |  -  | x3  | y3  |  -  | --> "unconstrained" (utilized by previous gate via shifts)
  *
- * For chained operations (e.g. Straus MSM), use fuse_ecc_dbl_gate to avoid the extra setup gate.
+ * For chained operations (e.g. Straus MSM), use create_fused_ecc_dbl_gate to avoid the extra setup gate.
  *
  * @param in Elliptic curve point doubling gate parameters
- * @return Index (within the elliptic block) of the output gate, usable as prev_gate_idx for fuse_ecc_add/dbl_gate
+ * @return Index (within the elliptic block) of the output gate, usable as prev_gate_idx for
+ * create_fused_ecc_add/dbl_gate
  */
 template <typename ExecutionTrace>
 size_t UltraCircuitBuilder_<ExecutionTrace>::create_ecc_dbl_gate(const ecc_dbl_gate_<FF>& in)
@@ -471,20 +473,21 @@ size_t UltraCircuitBuilder_<ExecutionTrace>::create_ecc_dbl_gate(const ecc_dbl_g
  * @brief Attempt to fuse an elliptic curve point doubling into a previously created ECC gate
  * @details If the previous gate (at prev_gate_idx) is still the last in the block and its output wires match this
  * gate's inputs, fuses by setting selectors on that gate and appending only the output row. Otherwise falls back to
- * create_ecc_dbl_gate (a full non-fused gate pair). See fuse_ecc_add_gate for detailed rationale.
+ * create_ecc_dbl_gate (a full non-fused gate pair). See create_fused_ecc_add_gate for detailed rationale.
  *
  * @param prev_gate_idx Block-relative index of the previous ECC output gate to try to fuse into
  * @param in Elliptic curve point doubling gate parameters
  * @return Index (within the elliptic block) of the output gate
  */
 template <typename ExecutionTrace>
-size_t UltraCircuitBuilder_<ExecutionTrace>::fuse_ecc_dbl_gate(size_t prev_gate_idx, const ecc_dbl_gate_<FF>& in)
+size_t UltraCircuitBuilder_<ExecutionTrace>::create_fused_ecc_dbl_gate(size_t prev_gate_idx,
+                                                                       const ecc_dbl_gate_<FF>& in)
 {
     this->assert_valid_variables({ in.x1, in.x3, in.y1, in.y3 });
 
     auto& block = blocks.elliptic;
 
-    // Fusion requires adjacency and wire compatibility (see fuse_ecc_add_gate for detailed rationale).
+    // Fusion requires adjacency and wire compatibility (see create_fused_ecc_add_gate for detailed rationale).
     bool can_fuse =
         prev_gate_idx == block.size() - 1 && block.w_r()[prev_gate_idx] == in.x1 && block.w_o()[prev_gate_idx] == in.y1;
     if (!can_fuse) {

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.hpp
@@ -300,8 +300,10 @@ class UltraCircuitBuilder_ : public CircuitBuilderBase<typename ExecutionTrace_:
 
     void create_bool_gate(const uint32_t a);
     void create_arithmetic_gate(const arithmetic_triple_<FF>& in);
-    void create_ecc_add_gate(const ecc_add_gate_& in);
-    void create_ecc_dbl_gate(const ecc_dbl_gate_<FF>& in);
+    size_t create_ecc_add_gate(const ecc_add_gate_& in);
+    size_t fuse_ecc_add_gate(size_t prev_gate_idx, const ecc_add_gate_& in);
+    size_t create_ecc_dbl_gate(const ecc_dbl_gate_<FF>& in);
+    size_t fuse_ecc_dbl_gate(size_t prev_gate_idx, const ecc_dbl_gate_<FF>& in);
 
     void fix_witness(const uint32_t witness_index, const FF& witness_value);
 

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.hpp
@@ -301,9 +301,9 @@ class UltraCircuitBuilder_ : public CircuitBuilderBase<typename ExecutionTrace_:
     void create_bool_gate(const uint32_t a);
     void create_arithmetic_gate(const arithmetic_triple_<FF>& in);
     size_t create_ecc_add_gate(const ecc_add_gate_& in);
-    size_t fuse_ecc_add_gate(size_t prev_gate_idx, const ecc_add_gate_& in);
+    size_t create_fused_ecc_add_gate(size_t prev_gate_idx, const ecc_add_gate_& in);
     size_t create_ecc_dbl_gate(const ecc_dbl_gate_<FF>& in);
-    size_t fuse_ecc_dbl_gate(size_t prev_gate_idx, const ecc_dbl_gate_<FF>& in);
+    size_t create_fused_ecc_dbl_gate(size_t prev_gate_idx, const ecc_dbl_gate_<FF>& in);
 
     void fix_witness(const uint32_t witness_index, const FF& witness_value);
 


### PR DESCRIPTION
TLDR: Currently, two elliptic gates can be "fused" if outputs of one match inputs to the next. This is done via an explicit check on witness values. This PR removes the "surprise" element and makes it the callers responsibility to request a gate fusion.

Details: A grumpkin add/dbl can be performed in no more that two Elliptic gates. However, if two operations are such that the output of one is the input to the next, they can be "fused" such that, e.g., two adds can be performed in only three gates. 

Prior to this PR, the fusing was triggered automatically in the builder by checking the witness values for this structure at the time of gate creation. This leads to the following inconvenient fact: Two consecutive ACIR op-codes performing Grumpkin EC operations have circuit structure dependent on the _values_ of their underlying witnesses. This is not a correctness issue but does make it impossible to predict circuit structure from op-code type alone which makes things like pre-allocating offsets for parallelization difficult. (This is the only instance of this kind of "witness-dependent" behavior in the circuit builder, aside from e.g. "cached" range constraints which are easier to handle).

This PR maintains the intended optimization of fusing while removing its implicit nature by by making it the responsibility of the caller to determine whether gates can be fused or not. We add methods like `create_fused_ecc_add_gate` vs `create_ecc_dbl_gate` which allow callers like `batch_mul` to ensure all internal operations are fused, while operations _between_ two distinct operations (like two ACIR EC-add ops) are not.

Note that the VKs for our sample transactions have _not_ changed, since for the vast majority of circuits this results in identical behavior.