### PR TITLE
fix(bb-prover): synchronize executeBB timeout and close handlers to prevent resource leak

### DIFF
--- a/yarn-project/bb-prover/src/bb/execute.ts
+++ b/yarn-project/bb-prover/src/bb/execute.ts
@@ -92,10 +92,26 @@ export function executeBB(
       env,
     });
 
+    let resolved = false;
+    const rlStdout = readline.createInterface({ input: bb.stdout });
+    const rlStderr = readline.createInterface({ input: bb.stderr });
+    rlStdout.on('line', logger);
+    rlStderr.on('line', logger);
+
+    const cleanup = () => {
+      rlStdout.close();
+      rlStderr.close();
+    };
+
     let timeoutId: NodeJS.Timeout | undefined;
     if (timeout !== undefined) {
       timeoutId = setTimeout(() => {
+        if (resolved) {
+          return;
+        }
+        resolved = true;
         logger(`BB execution timed out after ${timeout}ms, killing process`);
+        cleanup();
         if (bb.pid) {
           bb.kill('SIGKILL');
         }
@@ -103,13 +119,15 @@ export function executeBB(
       }, timeout);
     }
 
-    readline.createInterface({ input: bb.stdout }).on('line', logger);
-    readline.createInterface({ input: bb.stderr }).on('line', logger);
-
     bb.on('close', (exitCode: number, signal?: string) => {
       if (timeoutId) {
         clearTimeout(timeoutId);
       }
+      if (resolved) {
+        return;
+      }
+      resolved = true;
+      cleanup();
       if (resultParser(exitCode)) {
         resolve({ status: BB_RESULT.SUCCESS, exitCode, signal });
       } else {


### PR DESCRIPTION
## Summary

The `executeBB` function's timeout handler and process `close` event handler could both resolve the same promise, and two `readline` interfaces were created without storing references, preventing explicit cleanup on timeout.

## Changes

- Added a `resolved` guard flag to prevent double promise resolution between the timeout and close handlers.
- Stored `readline` interfaces in variables so they can be explicitly closed.
- Added a `cleanup` helper that deterministically closes both readline interfaces, called from both the timeout and close code paths.
- No functional change for current callers since none pass a `timeout` argument.