### PR TITLE
fix(foundation): flush current batch on BatchQueue.stop()

### DIFF
--- a/yarn-project/foundation/src/queue/batch_queue.test.ts
+++ b/yarn-project/foundation/src/queue/batch_queue.test.ts
@@ -161,4 +161,18 @@ describe('BatchQueue', () => {
 
     expect(processSpy).toHaveBeenCalledTimes(batches);
   });
+
+  it('flushes the current unflushed batch on stop', async () => {
+    const partialSize = maxBatchSize - 1;
+    const promises: Promise<void>[] = [];
+    for (let i = 0; i < partialSize; i++) {
+      promises.push(queue.put(i, 0));
+    }
+
+    await queue.stop();
+    await Promise.all(promises);
+
+    expect(processSpy).toHaveBeenCalledTimes(1);
+    expect(processSpy).toHaveBeenCalledWith(range(partialSize), 0);
+  });
 });

--- a/yarn-project/foundation/src/queue/batch_queue.ts
+++ b/yarn-project/foundation/src/queue/batch_queue.ts
@@ -105,6 +105,7 @@ export class BatchQueue<T, K extends string | number> {
       return Promise.resolve();
     }
 
+    this.flushCurrentBatch();
     this.container.end();
     return runningPromise;
   }


### PR DESCRIPTION
## Summary

- `BatchQueue.stop()` was dropping the current unflushed batch — any items that hadn't reached `maxBatchSize` or whose timer hadn't fired yet were silently lost.
- In `KVBrokerDatabase`, this could lose proving job results on graceful shutdown, causing unnecessary re-computation on restart.
- Fix: call `flushCurrentBatch()` before `container.end()` in `stop()`.

## Test plan

- Added test `'flushes the current unflushed batch on stop'` that puts a partial batch (below `maxBatchSize`) and verifies it is processed when `stop()` is called.
- All existing `BatchQueue` tests continue to pass.