### PR TITLE
build: omit architecture specific path for loading tcmalloc

### DIFF
--- a/release-image/Dockerfile.base
+++ b/release-image/Dockerfile.base
@@ -35,7 +35,7 @@ COPY --from=build /opt/foundry/bin/forge /opt/foundry/bin/forge
 COPY --from=build /opt/foundry/bin/cast /opt/foundry/bin/cast
 ENV PATH="/opt/foundry/bin:$PATH" FOUNDRY_DISABLE_NIGHTLY_WARNING="1"
 # Use tcmalloc for reduced memory fragmentation and improved allocation performance.
-ENV LD_PRELOAD="/usr/lib/x86_64-linux-gnu/libtcmalloc_minimal.so.4"
+ENV LD_PRELOAD="libtcmalloc_minimal.so.4"
 # Copy in production dependencies.
 COPY --from=build /usr/src/yarn-project/node_modules /usr/src/yarn-project/node_modules
 # We install a symlink to yarn-project's node_modules at a location that all portalled packages can find as they


### PR DESCRIPTION
On an ARM image, you will get a warning that the tcmalloc library cannot be loaded, but that's because x86_64 specific path was used. Instead you can use the non-specific path and achieve the same result and be platform independent, avoiding the error and actually using the desired allocator: `ERROR: ld.so: object '/usr/lib/x86_64-linux-gnu/libtcmalloc_minimal.so.4' from LD_PRELOAD cannot be preloaded (cannot open shared object file): ignored.`

You can use the below to recreate the resulting outputs for both with and without this fix:
```shell
alias docker_run="docker run -it --rm --entrypoint node -e LD_DEBUG=libs,files"

# Works as expected given the hardcoded path
docker_run --platform linux/amd64 aztecprotocol/aztec:4.1.3 -e "console.log('ok')" 2>&1 | grep -i tcmalloc

# As is, there is no tcmalloc init in the output on ARM and the warnings appear
docker_run --platform linux/arm64 aztecprotocol/aztec:4.1.3 -e "console.log('ok')" 2>&1 | grep -i tcmalloc

# Arch independent LD_PRELOAD declaration, both have the same output
docker_run -e LD_PRELOAD=libtcmalloc_minimal.so.4 --platform linux/arm64 aztecprotocol/aztec:4.1.3 -e "console.log('ok')" 2>&1 | grep -i tcmalloc
docker_run -e LD_PRELOAD=libtcmalloc_minimal.so.4 --platform linux/amd64 aztecprotocol/aztec:4.1.3 -e "console.log('ok')" 2>&1 | grep -i tcmalloc
```

