### PR TITLE
fix: add contract addresses to prover stack

### DIFF
--- a/spartan/aztec-prover-stack/values.yaml
+++ b/spartan/aztec-prover-stack/values.yaml
@@ -3,6 +3,10 @@ global:
   aztecNetwork: ""
   customAztecNetwork:
     enabled: false
+    l1ChainId:
+    registryContractAddress:
+    slashFactoryContractAddress:
+    feeAssetHandlerContractAddress:
 
   l1ExecutionUrls: []
   l1ConsensusUrls: []


### PR DESCRIPTION
After redeploying a network, the validator would connect to the correct registry contract, but not the prover node or broker. Do we think this would fix it?