### PR TITLE
chore: fix asm_self_* field arithmetic signatures

### DIFF
--- a/barretenberg/cpp/src/barretenberg/ecc/fields/field_declarations.hpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/fields/field_declarations.hpp
@@ -629,14 +629,14 @@ template <class Params_> struct alignas(32) field {
     BB_INLINE static field asm_sqr_with_coarse_reduction(const field& a) noexcept;
     BB_INLINE static field asm_add_with_coarse_reduction(const field& a, const field& b) noexcept;
     BB_INLINE static field asm_sub_with_coarse_reduction(const field& a, const field& b) noexcept;
-    BB_INLINE static void asm_self_mul_with_coarse_reduction(const field& a, const field& b) noexcept;
-    BB_INLINE static void asm_self_sqr_with_coarse_reduction(const field& a) noexcept;
-    BB_INLINE static void asm_self_add_with_coarse_reduction(const field& a, const field& b) noexcept;
-    BB_INLINE static void asm_self_sub_with_coarse_reduction(const field& a, const field& b) noexcept;
+    BB_INLINE static void asm_self_mul_with_coarse_reduction(field& a, const field& b) noexcept;
+    BB_INLINE static void asm_self_sqr_with_coarse_reduction(field& a) noexcept;
+    BB_INLINE static void asm_self_add_with_coarse_reduction(field& a, const field& b) noexcept;
+    BB_INLINE static void asm_self_sub_with_coarse_reduction(field& a, const field& b) noexcept;
 
     BB_INLINE static void asm_conditional_negate(field& r, uint64_t predicate) noexcept;
     BB_INLINE static field asm_reduce_once(const field& a) noexcept;
-    BB_INLINE static void asm_self_reduce_once(const field& a) noexcept;
+    BB_INLINE static void asm_self_reduce_once(field& a) noexcept;
     static constexpr uint64_t zero_reference = 0x00ULL;
 #endif
     constexpr field tonelli_shanks_sqrt() const noexcept;

--- a/barretenberg/cpp/src/barretenberg/ecc/fields/field_impl_x64.hpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/fields/field_impl_x64.hpp
@@ -46,7 +46,7 @@ template <class T> field<T> field<T>::asm_mul_with_coarse_reduction(const field&
     return r;
 }
 
-template <class T> void field<T>::asm_self_mul_with_coarse_reduction(const field& a, const field& b) noexcept
+template <class T> void field<T>::asm_self_mul_with_coarse_reduction(field& a, const field& b) noexcept
 {
     constexpr uint64_t r_inv = T::r_inv;
     constexpr uint64_t modulus_0 = modulus.data[0];
@@ -141,7 +141,7 @@ template <class T> field<T> field<T>::asm_sqr_with_coarse_reduction(const field&
     return r;
 }
 
-template <class T> void field<T>::asm_self_sqr_with_coarse_reduction(const field& a) noexcept
+template <class T> void field<T>::asm_self_sqr_with_coarse_reduction(field& a) noexcept
 {
     constexpr uint64_t r_inv = T::r_inv;
     constexpr uint64_t modulus_0 = modulus.data[0];
@@ -227,7 +227,7 @@ template <class T> field<T> field<T>::asm_add_with_coarse_reduction(const field&
     return r;
 }
 
-template <class T> void field<T>::asm_self_add_with_coarse_reduction(const field& a, const field& b) noexcept
+template <class T> void field<T>::asm_self_add_with_coarse_reduction(field& a, const field& b) noexcept
 {
     constexpr uint64_t twice_not_modulus_0 = twice_not_modulus.data[0];
     constexpr uint64_t twice_not_modulus_1 = twice_not_modulus.data[1];
@@ -277,7 +277,7 @@ template <class T> field<T> field<T>::asm_sub_with_coarse_reduction(const field&
     return r;
 }
 
-template <class T> void field<T>::asm_self_sub_with_coarse_reduction(const field& a, const field& b) noexcept
+template <class T> void field<T>::asm_self_sub_with_coarse_reduction(field& a, const field& b) noexcept
 {
     constexpr uint64_t twice_modulus_0 = twice_modulus.data[0];
     constexpr uint64_t twice_modulus_1 = twice_modulus.data[1];
@@ -353,7 +353,7 @@ template <class T> field<T> field<T>::asm_reduce_once(const field& a) noexcept
     return r;
 }
 
-template <class T> void field<T>::asm_self_reduce_once(const field& a) noexcept
+template <class T> void field<T>::asm_self_reduce_once(field& a) noexcept
 {
     constexpr uint64_t not_modulus_0 = not_modulus.data[0];
     constexpr uint64_t not_modulus_1 = not_modulus.data[1];


### PR DESCRIPTION
## Summary

- Remove incorrect `const` from the first parameter of the 5 `asm_self_*` field functions (mul, sqr, add, sub, reduce_once). These functions modify the parameter in-place via inline assembly but declared it `const field&`.

## Test plan

- [x] `ecc_tests` — 836/836 passed