### PR TITLE
fix(p2p): use per-batch ops array in AztecDatastore.batch()

### DIFF
--- a/yarn-project/p2p/src/services/data_store.test.ts
+++ b/yarn-project/p2p/src/services/data_store.test.ts
@@ -50,6 +50,28 @@ describe('AztecDatastore with AztecLmdbStore', () => {
     await expect(datastore.get(key)).rejects.toHaveProperty('code', 'ERR_NOT_FOUND');
   });
 
+  it('concurrent batches do not interfere with each other', async () => {
+    const batch1 = datastore.batch();
+    const batch2 = datastore.batch();
+
+    const key1 = new Key('batch1key');
+    const key2 = new Key('batch2key');
+    const value1 = new Uint8Array([1, 2, 3]);
+    const value2 = new Uint8Array([4, 5, 6]);
+
+    batch1.put(key1, value1);
+    batch2.put(key2, value2);
+
+    // Committing batch1 should only apply batch1's operations
+    await batch1.commit();
+    expect(await datastore.has(key1)).toBe(true);
+    expect(await datastore.has(key2)).toBe(false);
+
+    // Committing batch2 should still apply batch2's operations
+    await batch2.commit();
+    expect(await datastore.has(key2)).toBe(true);
+  });
+
   it('batch operations commit correctly', async () => {
     const batch = datastore.batch();
     const key1 = new Key('key1');

--- a/yarn-project/p2p/src/services/data_store.ts
+++ b/yarn-project/p2p/src/services/data_store.ts
@@ -28,8 +28,6 @@ export class AztecDatastore implements Datastore {
   #memoryDatastore: Map<string, MemoryItem>;
   #dbDatastore: AztecAsyncMap<string, Uint8Array>;
 
-  #batchOps: BatchOp[] = [];
-
   private maxMemoryItems: number;
 
   constructor(db: AztecAsyncKVStore, { maxMemoryItems } = { maxMemoryItems: 50 }) {
@@ -92,23 +90,17 @@ export class AztecDatastore implements Datastore {
   }
 
   batch(): Batch {
+    const ops: BatchOp[] = [];
     return {
       put: (key, value) => {
-        this.#batchOps.push({
-          type: 'put',
-          key,
-          value,
-        });
+        ops.push({ type: 'put', key, value });
       },
       delete: key => {
-        this.#batchOps.push({
-          type: 'del',
-          key,
-        });
+        ops.push({ type: 'del', key });
       },
       commit: async () => {
         await this.#db.transactionAsync(async () => {
-          for (const op of this.#batchOps) {
+          for (const op of ops) {
             if (op.type === 'put' && op.value) {
               await this.put(op.key, op.value);
             } else if (op.type === 'del') {
@@ -116,7 +108,7 @@ export class AztecDatastore implements Datastore {
             }
           }
         });
-        this.#batchOps = []; // Clear operations after commit
+        ops.length = 0;
       },
     };
   }


### PR DESCRIPTION
## Summary

- `AztecDatastore.batch()` stored batch operations in a shared class-level `#batchOps` array, meaning concurrent batches would corrupt each other's operations. Replaced with a local `ops` array per batch call, matching the reference `BaseDatastore` implementation from `datastore-core`.
- Added a test that verifies concurrent batches don't interfere with each other.

Fixes [A-761](https://linear.app/aztec-labs/issue/A-761/audit-92-aztecdatastorebatch-shares-batchops-across-concurrent-batches)