### PR TITLE
fix: polynomials module audit response

### DIFF
--- a/barretenberg/cpp/src/barretenberg/polynomials/backing_memory.hpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/backing_memory.hpp
@@ -159,7 +159,7 @@ template <typename Fr> struct BackingMemory {
 
         std::string filename = temp_dir / ("poly-mmap-" + std::to_string(getpid()) + "-" + std::to_string(id));
 
-        int fd = open(filename.c_str(), O_CREAT | O_RDWR | O_TRUNC, 0644);
+        int fd = open(filename.c_str(), O_CREAT | O_RDWR | O_TRUNC | O_EXCL, 0600);
         if (fd < 0) {
             current_storage_usage.fetch_sub(required_bytes);
             return false;
@@ -172,7 +172,7 @@ template <typename Fr> struct BackingMemory {
             return false;
         }
 
-        void* addr = mmap(nullptr, file_size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+        void* addr = mmap(nullptr, file_size, PROT_READ | PROT_WRITE, MAP_PRIVATE, fd, 0);
         if (addr == MAP_FAILED) {
             close(fd);
             std::filesystem::remove(filename);

--- a/barretenberg/cpp/src/barretenberg/polynomials/polynomial_arithmetic.cpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/polynomial_arithmetic.cpp
@@ -212,6 +212,9 @@ template <typename Fr> Fr compute_sum(const Fr* src, const size_t n)
 // This function computes the polynomial (x - a)(x - b)(x - c)... given n distinct roots (a, b, c, ...).
 template <typename Fr> void compute_linear_polynomial_product(const Fr* roots, Fr* dest, const size_t n)
 {
+    if (n == 0) {
+        return;
+    }
 
     auto scratch_space_ptr = get_scratch_space<Fr>(n);
     auto scratch_space = scratch_space_ptr.get();

--- a/barretenberg/cpp/src/barretenberg/polynomials/univariate_coefficient_basis.hpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/univariate_coefficient_basis.hpp
@@ -43,11 +43,14 @@ template <class Fr, size_t domain_end, bool has_a0_plus_a1> class UnivariateCoef
     using value_type = Fr; // used to get the type of the elements consistently with std::array
 
     /**
-     * @brief coefficients is a length-3 array with the following representation:
+     * @brief Storage for polynomial coefficients (always 3 elements for uniform layout).
      * @details This class represents a polynomial P(X) = a0 + a1.X + a2.X^2
-     *          We define `coefficients[0] = a0` and `coefficients[1] = a1`
-     *          If LENGTH == 2 AND `has_a0_plus_a1 = true` then `coefficients[2] = a0 + a1`
-     *          If LENGTH == 3 then `coefficients[2] = a2`
+     *          `coefficients[0] = a0`, `coefficients[1] = a1`.
+     *          The meaning of `coefficients[2]` depends on the template parameters:
+     *            - LENGTH == 2 AND has_a0_plus_a1 == true:  coefficients[2] = a0 + a1
+     *              (precomputed for Karatsuba multiplication; NOT a polynomial coefficient)
+     *            - LENGTH == 2 AND has_a0_plus_a1 == false: coefficients[2] is unused
+     *            - LENGTH == 3:                             coefficients[2] = a2
      */
     std::array<Fr, 3> coefficients;
 


### PR DESCRIPTION
## Summary

Addresses findings from the polynomials/ module security audit (https://github.com/AztecProtocol/barretenberg-claude/issues/2383).

- **F1** (Low): Harden file-backed polynomial memory: restrict temp file permissions to `0600`, add `O_EXCL` to prevent race conditions, use `MAP_PRIVATE` instead of `MAP_SHARED`
- **F4** (Info): Guard `compute_linear_polynomial_product` against `n=0` to prevent underflow
- **F5** (Info): Clarify `UnivariateCoefficientBasis` docstring to distinguish Karatsuba precomputation from polynomial coefficients

**Already fixed upstream:**
- **F2** (Low): `factor_roots` empty polynomial guard (in #22282)
- **F3** (Info): `get_scratch_space` thread safety via mutex (in #22306)