### PR TITLE
chore(blob-client): update beacon API references from deprecated getBlobSidecars to getBlobs

### DIFF
--- a/yarn-project/blob-client/src/client/http.ts
+++ b/yarn-project/blob-client/src/client/http.ts
@@ -773,8 +773,8 @@ async function parseBlobJsonsFromResponse(response: any, logger: Logger): Promis
   }
 }
 
-// Blobs will be in this form when requested from the blob client, or from the beacon chain via `getBlobSidecars`:
-// https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Beacon/getBlobSidecars
+// Blobs will be in this form when requested from the blob client, or from the beacon chain via `getBlobs`:
+// https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Beacon/getBlobs
 // Here we attempt to parse the response data to Buffer, and check the lengths (via Blob's constructor), to avoid
 // throwing an error down the line when calling Blob.fromJson().
 async function parseBlobJson(rawHex: string): Promise<BlobJson> {

--- a/yarn-project/blob-lib/src/blob.ts
+++ b/yarn-project/blob-lib/src/blob.ts
@@ -82,8 +82,8 @@ export class Blob {
    * Create a Blob from a JSON object.
    *
    * Blobs will be in this form when requested from the blob client, or from
-   * the beacon chain via `getBlobSidecars`
-   * https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Beacon/getBlobSidecars
+   * the beacon chain via `getBlobs`
+   * https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Beacon/getBlobs
    *
    * @param json - The JSON object to create the Blob from.
    * @returns A Blob created from the JSON object.

--- a/yarn-project/blob-lib/src/interface.ts
+++ b/yarn-project/blob-lib/src/interface.ts
@@ -1,5 +1,5 @@
 /**
- * The relevant parts of a response from https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Beacon/getBlobSidecars
+ * The relevant parts of a response from https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Beacon/getBlobs
  */
 export interface BlobJson {
   blob: string;


### PR DESCRIPTION
## Summary

The code uses `/eth/v1/beacon/blobs/{slot}` but comments in `blob-lib` and `blob-client` referenced the deprecated `getBlobSidecars` spec URL. Updated all references to point to the current `getBlobs` endpoint documentation.

## Changes

- Updated spec URL in `BlobJson` interface comment (`blob-lib/src/interface.ts`)
- Updated spec URL in `Blob.fromJson` JSDoc (`blob-lib/src/blob.ts`)
- Updated spec URL in `parseBlobJson` comment (`blob-client/src/client/http.ts`)