### PR TITLE
fix: handle error types serialization errors

### DIFF
--- a/yarn-project/foundation/src/log/pino-logger.test.ts
+++ b/yarn-project/foundation/src/log/pino-logger.test.ts
@@ -1,5 +1,6 @@
 import { build as buildPrettyStream } from 'pino-pretty';
 import { Writable } from 'stream';
+import { inspect } from 'util';
 
 import {
   createLogger,
@@ -309,6 +310,63 @@ describe('pino-logger', () => {
     expect(bindings).toEqual({
       actor: 'main',
       instanceId: 'id-123',
+    });
+  });
+
+  describe('formatErr via error logging', () => {
+    it('formats error using inspect by default', () => {
+      const testLogger = createLogger('format-err-default');
+      capturingStream.clear();
+
+      const err = new Error('something broke');
+      testLogger.error('operation failed', err);
+
+      const entries = capturingStream.getJsonLines();
+      expect(entries).toHaveLength(1);
+      const msg = (entries[0] as { msg: string }).msg;
+      // inspect formats errors with full stack trace
+      expect(msg).toMatch(/^operation failed: Error: something broke\n\s+at/);
+    });
+
+    it('falls back to Error name and message when inspect throws', () => {
+      const testLogger = createLogger('format-err-test');
+      capturingStream.clear();
+
+      // An Error with a custom inspect that throws triggers the first catch
+      const err = new Error('original message');
+      (err as unknown as Record<symbol, () => void>)[inspect.custom] = () => {
+        throw new Error('custom inspect broke');
+      };
+
+      testLogger.error('something failed', err);
+
+      const entries = capturingStream.getJsonLines();
+      expect(entries).toHaveLength(1);
+      expect((entries[0] as { msg: string }).msg).toBe('something failed: Error: original message');
+    });
+
+    it('returns unserializable error when both inspect and String throw', () => {
+      const testLogger = createLogger('unserializable-test');
+      capturingStream.clear();
+
+      // An object where inspect(), toString(), and String() all throw
+      const unserializable = {
+        [inspect.custom]() {
+          throw new Error('custom inspect broke');
+        },
+        toString() {
+          throw new Error('toString broke');
+        },
+        [Symbol.toPrimitive]() {
+          throw new Error('toPrimitive broke');
+        },
+      };
+
+      testLogger.error('total failure', unserializable);
+
+      const entries = capturingStream.getJsonLines();
+      expect(entries).toHaveLength(1);
+      expect((entries[0] as { msg: string }).msg).toBe('total failure: [unserializable error]');
     });
   });
 

--- a/yarn-project/foundation/src/log/pino-logger.ts
+++ b/yarn-project/foundation/src/log/pino-logger.ts
@@ -377,5 +377,20 @@ export type Logger = { [K in LogLevel]: LogFn } & { /** Error log function */ er
  * @returns A string with both the log message and the error message.
  */
 function formatErr(msg: string, err?: unknown): string {
-  return err ? `${msg}: ${inspect(err)}` : msg;
+  if (!err) {
+    return msg;
+  }
+
+  try {
+    return `${msg}: ${inspect(err)}`;
+  } catch {
+    // inspect can crash on error objects with broken property descriptors
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-base-to-string
+      return `${msg}: ${err instanceof Error ? `${err.name}: ${err.message}` : String(err)}`;
+    } catch {
+      // if even String(err) fails, return the original message with a note about the error
+      return `${msg}: [unserializable error]`;
+    }
+  }
 }


### PR DESCRIPTION
Do not throw in the logger when we try to log something that fails during serialization.

I ran into this while playing with a test script:
```
TypeError: Cannot read properties of undefined (reading 'value')                                         
    at formatProperty (node:internal/util/inspect:2280:12)                                               
    at formatRaw (node:internal/util/inspect:1176:9)                                                     
    at formatValue (node:internal/util/inspect:932:10)                                                   
    at inspect (node:internal/util/inspect:409:10)                                                       
    at formatErr                                                                                         
(file:///home/santiago/Projects/aztec-3/yarn-project/foundation/dest/log/pino-logger.js:326:29)          
    at Object.error                                                                                      
(file:///home/santiago/Projects/aztec-3/yarn-project/foundation/dest/log/pino-logger.js:56:97)           
    at L2BlockStream.work (file:///home/santiago/Projects/aztec-3/yarn-project/stdlib/dest/block/l2_bloc 
k_stream/l2_block_stream.js:222:22)                                                                      
    at process.processTicksAndRejections (node:internal/process/task_queues:103:5)                       
    at async L2BlockStream.sync (file:///home/santiago/Projects/aztec-3/yarn-project/stdlib/dest/block/l 
2_block_stream/l2_block_stream.js:46:9)                                                                  
    at async BlockSynchronizer.doSync (file:///home/santiago/Projects/aztec-3/yarn-project/pxe/dest/bloc 
k_synchronizer/block_synchronizer.js:157:9)                                                              
[18:27:08.952] INFO: teardown-failure:pxe:service Simulating transaction execution request to 0xf04908a9 
 at 0x0000000000000000000000000000000000000000000000000000000000000004                                   
{"origin":"0x0000000000000000000000000000000000000000000000000000000000000004","functionSelector":"0xf04 
908a9","simulatePublic":true,"chainId":"0x0000000000000000000000000000000000000000000000000000000000aa36 
a7","version":"0x000000000000000000000000000000000000000000000000000000009a3a0b73","authWitnesses":["0x2 
983e158c25f7487e066bfa57d58f43340b2b45a114e6d6934dbc95213778ee6"]}                                       
[18:27:09.301] ERROR: teardown-failure:pxe:service TypeError: TypeError: Cannot read properties of       
undefined (reading 'value')                                                                              
    at formatProperty (node:internal/util/inspect:2280:12)                                               
    at formatRaw (node:internal/util/inspect:1176:9)                                                     
    at formatValue (node:internal/util/inspect:932:10)                                                   
    at inspect (node:internal/util/inspect:409:10)                                                       
    at formatErr                                                                                         
(file:///home/santiago/Projects/aztec-3/yarn-project/foundation/dest/log/pino-logger.js:326:29)          
    at Object.error                                                                                      
(file:///home/santiago/Projects/aztec-3/yarn-project/foundation/dest/log/pino-logger.js:56:97)           
    at L2BlockStream.work (file:///home/santiago/Projects/aztec-3/yarn-project/stdlib/dest/block/l2_bloc 
k_stream/l2_block_stream.js:222:22)                                                                      
    at process.processTicksAndRejections (node:internal/process/task_queues:103:5)                       
    at async L2BlockStream.sync (file:///home/santiago/Projects/aztec-3/yarn-project/stdlib/dest/block/l 
2_block_stream/l2_block_stream.js:46:9)                                                                  
    at async BlockSynchronizer.doSync (file:///home/santiago/Projects/aztec-3/yarn-project/pxe/dest/bloc 
k_synchronizer/block_synchronizer.js:157:9)                                                              
```