### PR TITLE
chore: adjusting resources for e2e test + adding strict_scheduling

### DIFF
--- a/yarn-project/end-to-end/bootstrap.sh
+++ b/yarn-project/end-to-end/bootstrap.sh
@@ -23,6 +23,61 @@ function set_dump_avm {
   [ -n "${DUMP_AVM_INPUTS_TO_DIR:-}" ] && echo "DUMP_AVM_INPUTS_TO_DIR=${DUMP_AVM_INPUTS_TO_DIR}/$1"
 }
 
+# Returns resource overrides (CPUS=X:MEM=Yg) for tests that need more than the default 2 CPUs / 8g.
+# Based on the number of processes each test spins up (nodes, provers, validators).
+function get_test_resources {
+  local test=$1
+  case "$test" in
+    # P2P: extremely heavy (10+ processes)
+    src/e2e_p2p/preferred_gossip_network.test.ts | \
+    src/e2e_p2p/add_rollup.test.ts)
+      echo "CPUS=8:MEM=32g" ;;
+    # P2P: heavy - 6+ validators or with prover node
+    src/e2e_p2p/gossip_network.test.ts | \
+    src/e2e_p2p/fee_asset_price_oracle_gossip.test.ts | \
+    src/e2e_p2p/validators_sentinel.test.ts | \
+    src/e2e_p2p/inactivity_slash*.test.ts | \
+    src/e2e_p2p/slash_veto_demo.test.ts | \
+    src/e2e_p2p/multiple_validators_sentinel*.test.ts | \
+    src/e2e_p2p/reqresp/*.test.ts)
+      echo "CPUS=6:MEM=24g" ;;
+    # P2P: medium - 4 validators, no prover
+    src/e2e_p2p/*.test.ts)
+      echo "CPUS=4:MEM=16g" ;;
+    # Epochs: heavy multi-validator + prover
+    src/e2e_epochs/epochs_first_slot.test.ts | \
+    src/e2e_epochs/epochs_mbps*.test.ts | \
+    src/e2e_epochs/epochs_invalidate_block*.test.ts)
+      echo "CPUS=6:MEM=24g" ;;
+    # Epochs: medium multi-validator
+    src/e2e_epochs/epochs_simple_block_building.test.ts | \
+    src/e2e_epochs/epochs_high_tps_block_building.test.ts | \
+    src/e2e_epochs/epochs_ha_sync.test.ts | \
+    src/e2e_epochs/epochs_multi_proof.test.ts)
+      echo "CPUS=4:MEM=16g" ;;
+    # Epochs: single node without prover (use defaults)
+    src/e2e_epochs/epochs_missed_l1_slot.test.ts)
+      ;;
+    # Epochs: single node + prover (remaining epoch tests)
+    src/e2e_epochs/*.test.ts)
+      echo "CPUS=3:MEM=12g" ;;
+    # Fees: all use prover node
+    src/e2e_fees/*.test.ts)
+      echo "CPUS=3:MEM=12g" ;;
+    # Cross-chain with prover
+    src/e2e_cross_chain_messaging/l2_to_l1.test.ts | \
+    src/e2e_cross_chain_messaging/token_bridge_public.test.ts | \
+    src/e2e_cross_chain_messaging/token_bridge_private.test.ts)
+      echo "CPUS=3:MEM=12g" ;;
+    # Single node + prover or extra nodes
+    src/e2e_simple.test.ts | \
+    src/e2e_synching.test.ts)
+      echo "CPUS=3:MEM=12g" ;;
+    src/e2e_multi_validator/*.test.ts)
+      echo "CPUS=3:MEM=12g" ;;
+  esac
+}
+
 function test_cmds {
   local run_test_script="yarn-project/end-to-end/scripts/run_test.sh"
   local prefix="$hash:ISOLATE=1"
@@ -30,7 +85,7 @@ function test_cmds {
   if [ "$CI_FULL" -eq 1 ]; then
     echo "$prefix:TIMEOUT=20m:CPUS=16:MEM=96g:NAME=e2e_prover_full_real $run_test_script simple e2e_prover/full"
   else
-    echo "$prefix:NAME=e2e_prover_full_fake FAKE_PROOFS=1 $run_test_script simple e2e_prover/full"
+    echo "$prefix:CPUS=3:MEM=12g:NAME=e2e_prover_full_fake FAKE_PROOFS=1 $run_test_script simple e2e_prover/full"
   fi
   echo "$prefix:TIMEOUT=15m:NAME=e2e_block_building $(set_dump_avm e2e_block_building) $run_test_script simple e2e_block_building"
 
@@ -43,6 +98,8 @@ function test_cmds {
   for test in "${tests[@]}"; do
     local name=${test#*e2e_}
     name=e2e_${name%.test.ts}
+    local resources=$(get_test_resources "$test")
+    local test_prefix="$prefix${resources:+:$resources}"
 
     # Check if this is a .parallel.test.ts file
     if [[ "$test" == *.parallel.test.ts ]]; then
@@ -51,11 +108,11 @@ function test_cmds {
         # Create a safe name for the individual test (replace spaces with underscores)
         local safe_test_name=$(echo "$test_name" | sed 's/ /_/g')
         local full_name="${name}_${safe_test_name}"
-        echo "$prefix:NAME=$full_name $(set_dump_avm $full_name) $run_test_script simple $test \"$test_name\""
+        echo "$test_prefix:NAME=$full_name $(set_dump_avm $full_name) $run_test_script simple $test \"$test_name\""
       done < <(extract_test_names "$test")
     else
       # Regular test file - run the whole file
-      echo "$prefix:NAME=$name $(set_dump_avm $name) $run_test_script simple $test"
+      echo "$test_prefix:NAME=$name $(set_dump_avm $name) $run_test_script simple $test"
     fi
   done
 
@@ -99,7 +156,7 @@ function test_cmds {
 
 function test {
   echo_header "e2e tests"
-  test_cmds | filter_test_cmds | parallelize
+  test_cmds | filter_test_cmds | STRICT_SCHEDULING=1 parallelize
 }
 
 function bench_cmds {
@@ -175,7 +232,7 @@ function test_and_collect_avm_inputs {
   export DUMP_AVM_INPUTS_TO_DIR="$default_avm_inputs_dump_dir"
 
   # Run tests in parallel (like regular test command)
-  test_cmds | filter_test_cmds | parallelize
+  test_cmds | filter_test_cmds | STRICT_SCHEDULING=1 parallelize
 
   # Use AVM_INPUTS_HASH if set (computed before build in CI), otherwise fall back to $hash
   local avm_hash=${AVM_INPUTS_HASH:-$hash}


### PR DESCRIPTION
## Summary

- Increase CPU/memory allocation for E2E tests that spin up multiple nodes, prover nodes, or validators
- Enable strict (CPU-aware) scheduling for E2E test execution to prevent oversubscription

## Problem

All E2E tests currently run with the default `CPUS=2, MEM=8g`, regardless of how many processes they start. A standard test (1 Anvil + 1 Aztec Node + 1 PXE = 3 processes) fits comfortably in 2 CPUs. But P2P tests spin up 6-10+ full validator nodes, epoch tests run multiple validators plus prover nodes, and fee tests always start a prover node — all squeezed into the same 2 CPUs.

Meanwhile, GNU `parallel` runs up to 64 jobs concurrently (`num_cpus / 2`) without awareness of per-test CPU needs. It happily runs 64 tests each claiming 2 CPUs even when some actually need 6-8. This causes CPU starvation, missed sequencer timing windows, and flaky timeout failures.

## Changes

### 1. Per-test resource overrides (`get_test_resources`)

Added a function that maps test file paths to appropriate CPUS/MEM based on the number of processes each test actually runs. The values were chosen by analyzing the source code of each test to count processes at peak load:

| Category | Tests | CPUS | MEM | Processes at peak | Examples |
|----------|-------|------|-----|-------------------|---------|
| **Standard (1 node)** | ~70 | 2 (default) | 8g | AN + AZ + PXE = 3 | `e2e_token_contract/*`, `e2e_deploy_contract/*` |
| **Single node + prover** | ~15 | 3 | 12g | AN + AZ + PN + PXE = 4 | `e2e_fees/*`, `e2e_simple`, `e2e_epochs/epochs_multiple` |
| **Multi-validator (3-4 nodes)** | ~4 | 4 | 16g | AN + 3-4 AZ + PXE = 5-6 | `e2e_epochs/epochs_simple_block_building`, `epochs_multi_proof` |
| **P2P medium (4 validators, no prover)** | ~10 | 4 | 16g | AN + BS + 4 AZ = 6 | `e2e_p2p/duplicate_proposal_slash`, `rediscovery` |
| **Multi-validator + prover** | ~12 | 6 | 24g | AN + 4-6 AZ + PN = 7-9 | `e2e_p2p/gossip_network`, `epochs_mbps*`, `reqresp/*` |
| **Extremely heavy** | 2 | 8 | 32g | 10-13 processes | `e2e_p2p/preferred_gossip_network`, `add_rollup` |
| **Prover full fake** | 1 | 3 | 12g | AN + AZ + PN + PXE = 4 | `e2e_prover/full` (non-CI_FULL) |
| **Prover full real** | 1 | 16 | 96g | (unchanged) | `e2e_prover/full` (CI_FULL) |

Process abbreviations: AN = Anvil, AZ = Aztec Node (sequencer + archiver + world-state + P2P + validator), PN = Prover Node, PXE = Private eXecution Environment, BS = Bootstrap Node.

**Memory formula**: `MEM = CPUS * 4g` (same ratio as the existing default of CPUS=2/MEM=8g), which provides headroom for each process's heap, native code, and world-state trees.

### 2. Strict scheduling for standalone E2E test runs

Changed the `test` (and `test_and_collect_avm_inputs`) function in `yarn-project/end-to-end/bootstrap.sh` to use `STRICT_SCHEDULING=1`. This only affects **standalone execution** of E2E tests — i.e., when running `./bootstrap.sh test` directly (e.g., grind runs, local dev, or any workflow that invokes the `test` function). It does **not** affect normal CI runs, where the Makefile calls `test_cmds` and feeds commands to the test engine, which uses plain `parallelize` without strict scheduling.

The strict scheduler:

- Tracks available CPU cores with a semaphore
- Only starts a test when enough cores are free to satisfy its `CPUS` requirement
- Pins each test to specific cores via `CPU_LIST` / `taskset`

This prevents oversubscription in standalone runs: with 128 cores and tests requesting 2-8 CPUs each, the scheduler naturally limits concurrency to ~30-40 tests instead of the previous 64, with each test getting the cores it actually needs.

This is the same scheduler already used by benchmarks (`bench` function).
