### PR TITLE
chore: deflake e2e ha sync test

### DIFF
--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_ha_sync.test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_ha_sync.test.ts
@@ -150,9 +150,10 @@ describe('e2e_epochs/epochs_ha_sync', () => {
     const txHashes = await Promise.all(txs.map(tx => tx.send({ wait: NO_WAIT })));
     logger.warn(`Sent ${txHashes.length} transactions.`);
 
-    // Warp to 1 L1 slot before the start of the next L2 slot, so sequencers start cleanly.
+    // Warp to 1 L1 slot before the start of the following L2 slot, so sequencers start cleanly.
+    // We don't warp to the next L2 slot because we may already be less than 1 L1 slot before it.
     const currentSlot = await rollup.getSlotNumber();
-    const nextSlot = SlotNumber(currentSlot + 1);
+    const nextSlot = SlotNumber(currentSlot + 2);
     const nextSlotTimestamp = getTimestampForSlot(nextSlot, test.constants);
     await context.cheatCodes.eth.warp(Number(nextSlotTimestamp) - test.L1_BLOCK_TIME_IN_S, {
       resetBlockInterval: true,


### PR DESCRIPTION
Test was failing with:

```
15:21:49     Error warping: InvalidParamsRpcError: Invalid parameters were provided to the RPC method.
15:21:49     Double check you have provided the correct parameters.
15:21:49 
15:21:49     URL: http://127.0.0.1:8545/
15:21:49     Request body: {"method":"evm_setNextBlockTimestamp","params":[1775575740]}
15:21:49 
15:21:49     Details: Timestamp error: 1775575740 is lower than previous block's timestamp
15:21:49     Version: viem@2.38.2
15:21:49 
15:21:49       250 |             }
15:21:49       251 |         } catch (err) {
15:21:49     > 252 |             throw new Error(`Error warping: ${err}`);
15:21:49           |                   ^
15:21:49       253 |         } finally{
15:21:49       254 |             // Restore interval mining so the next block is mined in `blockInterval` seconds from this one
15:21:49       255 |             if (opts.resetBlockInterval && blockInterval !== null && blockInterval > 0) {
15:21:49 
15:21:49       at EthCheatCodes.warp (../../ethereum/dest/test/eth_cheat_codes.js:252:19)
15:21:49       at Object.<anonymous> (e2e_epochs/epochs_ha_sync.test.ts:157:5)
```