### PR TITLE
docs: add macOS prerequisites and improve Node.js version guidance

### DIFF
--- a/docs/developer_versioned_docs/version-v4.2.0-aztecnr-rc.2/getting_started_on_local_network.md
+++ b/docs/developer_versioned_docs/version-v4.2.0-aztecnr-rc.2/getting_started_on_local_network.md
@@ -27,6 +27,11 @@ import { General, Fees } from '@site/src/components/Snippets/general_snippets';
 
 - <General.node_ver />
 
+### macOS-specific requirements
+
+- **Homebrew**: [Homebrew](https://brew.sh/) is required for installing dependencies on macOS.
+- **Bash**: macOS ships with an outdated version of Bash (v3.2) that is known to cause issues with the Aztec installer. Install a modern version with `brew install bash`. Even if you use zsh as your default shell, the installer explicitly invokes `bash`. If the installer still picks up the old version, add the Homebrew `bash` to your `$PATH` or [set it as your default shell](https://support.apple.com/en-gb/guide/terminal/trml113/mac).
+
 ## Install and run the local network
 
 ### Install the Aztec toolchain

--- a/docs/docs-developers/getting_started_on_local_network.md
+++ b/docs/docs-developers/getting_started_on_local_network.md
@@ -27,6 +27,11 @@ import { General, Fees } from '@site/src/components/Snippets/general_snippets';
 
 - <General.node_ver />
 
+### macOS-specific requirements
+
+- **Homebrew**: [Homebrew](https://brew.sh/) is required for installing dependencies on macOS.
+- **Bash**: macOS ships with an outdated version of Bash (v3.2) that is known to cause issues with the Aztec installer. Install a modern version with `brew install bash`. Even if you use zsh as your default shell, the installer explicitly invokes `bash`. If the installer still picks up the old version, add the Homebrew `bash` to your `$PATH` or [set it as your default shell](https://support.apple.com/en-gb/guide/terminal/trml113/mac).
+
 ## Install and run the local network
 
 ### Install the Aztec toolchain

--- a/docs/docs-operate/operators/prerequisites.md
+++ b/docs/docs-operate/operators/prerequisites.md
@@ -59,6 +59,16 @@ Install the Aztec toolchain using the official installer:
 VERSION=#release_version bash -i <(curl -sL https://install.aztec.network/#release_version)
 ```
 
+:::note macOS users
+macOS ships with an outdated version of Bash (v3.2) that is known to cause issues with the installer. Install a modern version with [Homebrew](https://brew.sh/):
+
+```bash
+brew install bash
+```
+
+Even if you use zsh as your default shell, the installer explicitly invokes `bash`. If the installer still picks up the old version, add the Homebrew `bash` to your `$PATH` or [set it as your default shell](https://support.apple.com/en-gb/guide/terminal/trml113/mac).
+:::
+
 ### L1 Ethereum Node Access
 
 All Aztec nodes require access to Ethereum L1 node endpoints:

--- a/docs/network_versioned_docs/version-v4.1.3/operators/prerequisites.md
+++ b/docs/network_versioned_docs/version-v4.1.3/operators/prerequisites.md
@@ -59,6 +59,16 @@ Install the Aztec toolchain using the official installer:
 VERSION=4.1.3 bash -i <(curl -sL https://install.aztec.network/4.1.3)
 ```
 
+:::note macOS users
+macOS ships with an outdated version of Bash (v3.2) that is known to cause issues with the installer. Install a modern version with [Homebrew](https://brew.sh/):
+
+```bash
+brew install bash
+```
+
+Even if you use zsh as your default shell, the installer explicitly invokes `bash`. If the installer still picks up the old version, add the Homebrew `bash` to your `$PATH` or [set it as your default shell](https://support.apple.com/en-gb/guide/terminal/trml113/mac).
+:::
+
 ### L1 Ethereum Node Access
 
 All Aztec nodes require access to Ethereum L1 node endpoints:

--- a/docs/src/components/Snippets/general_snippets.js
+++ b/docs/src/components/Snippets/general_snippets.js
@@ -19,9 +19,11 @@ export const General = {
 
   node_ver: () => (
     <p>
-      Aztec libraries require Node.js version 24. You can use{" "}
-      <a href="https://github.com/nvm-sh/nvm">nvm</a> to help manage node
-      versions.
+      Aztec libraries require Node.js version 24. If you have an older version
+      installed, the installer will try to upgrade via{" "}
+      <a href="https://github.com/nvm-sh/nvm">nvm</a> if available. If nvm is
+      not installed, you will need to upgrade Node.js manually (e.g.{" "}
+      <code>nvm install 24</code> after installing nvm).
     </p>
   ),
 


### PR DESCRIPTION
## Summary

- Adds macOS-specific prerequisites (Homebrew and modern Bash) to the developer getting-started guide and operator prerequisites page, including versioned copies.
- Updates the shared Node.js version snippet to clarify that the installer will attempt to upgrade Node via nvm if available, and explains what to do if nvm is not installed.

## Test plan

- [ ] Verify the docs site builds without errors (`yarn build` in `docs/`)
- [ ] Check the macOS prerequisites section renders correctly on the getting started page
- [ ] Check the macOS admonition renders correctly on the operator prerequisites page
- [ ] Confirm the updated Node.js snippet reads clearly