### PR TITLE
fix: pass additionalScopes to executeUtility

### DIFF
--- a/yarn-project/aztec.js/src/contract/contract_function_interaction.ts
+++ b/yarn-project/aztec.js/src/contract/contract_function_interaction.ts
@@ -131,7 +131,7 @@ export class ContractFunctionInteraction extends BaseContractInteraction {
     if (this.functionDao.functionType == FunctionType.UTILITY) {
       const call = await this.getFunctionCall();
       const utilityResult = await this.wallet.executeUtility(call, {
-        scopes: options.from === NO_FROM ? [] : [options.from],
+        scopes: options.from === NO_FROM ? [] : [options.from, ...(options.additionalScopes ?? [])],
         authWitnesses: options.authWitnesses,
       });
 

--- a/yarn-project/aztec.js/src/contract/contract_function_interaction.ts
+++ b/yarn-project/aztec.js/src/contract/contract_function_interaction.ts
@@ -130,8 +130,9 @@ export class ContractFunctionInteraction extends BaseContractInteraction {
     // docs:end:simulate
     if (this.functionDao.functionType == FunctionType.UTILITY) {
       const call = await this.getFunctionCall();
+      const scopes = [...(options.additionalScopes ?? [])];
       const utilityResult = await this.wallet.executeUtility(call, {
-        scopes: options.from === NO_FROM ? [] : [options.from, ...(options.additionalScopes ?? [])],
+        scopes: options.from === NO_FROM ? scopes : [options.from, ...scopes],
         authWitnesses: options.authWitnesses,
       });
 


### PR DESCRIPTION
Necessary to enable patterns like the `Immutables` macro. Wallets still need to verify scopes forwarded from the app, so this is harmless and useful