### PR TITLE
fix(p2p): include values in tx validation error messages

### DIFF
--- a/yarn-project/p2p/src/msg_validators/tx_validator/gas_validator.test.ts
+++ b/yarn-project/p2p/src/msg_validators/tx_validator/gas_validator.test.ts
@@ -70,11 +70,15 @@ describe('GasTxValidator', () => {
   };
 
   const expectInvalid = async (tx: Tx, reason: string) => {
-    await expect(validateTx(tx)).resolves.toEqual({ result: 'invalid', reason: [reason] });
+    const result = await validateTx(tx);
+    expect(result.result).toEqual('invalid');
+    expect((result as { reason: string[] }).reason[0]).toContain(reason);
   };
 
   const expectSkipped = async (tx: Tx, reason: string) => {
-    await expect(validateTx(tx)).resolves.toEqual({ result: 'skipped', reason: [reason] });
+    const result = await validateTx(tx);
+    expect(result.result).toEqual('skipped');
+    expect((result as { reason: string[] }).reason[0]).toContain(reason);
   };
 
   it('allows fee paying txs if fee payer has enough balance', async () => {
@@ -219,7 +223,7 @@ describe('GasTxValidator', () => {
         });
         await expect(validator.validateTx(tx)).resolves.toEqual({
           result: 'invalid',
-          reason: [TX_ERROR_GAS_LIMIT_TOO_HIGH],
+          reason: [expect.stringContaining(TX_ERROR_GAS_LIMIT_TOO_HIGH)],
         });
       });
 
@@ -233,7 +237,7 @@ describe('GasTxValidator', () => {
         });
         await expect(validator.validateTx(tx)).resolves.toEqual({
           result: 'invalid',
-          reason: [TX_ERROR_GAS_LIMIT_TOO_HIGH],
+          reason: [expect.stringContaining(TX_ERROR_GAS_LIMIT_TOO_HIGH)],
         });
       });
 
@@ -249,7 +253,7 @@ describe('GasTxValidator', () => {
         });
         await expect(validator.validateTx(tx)).resolves.toEqual({
           result: 'invalid',
-          reason: [TX_ERROR_GAS_LIMIT_TOO_HIGH],
+          reason: [expect.stringContaining(TX_ERROR_GAS_LIMIT_TOO_HIGH)],
         });
       });
 
@@ -273,7 +277,7 @@ describe('GasTxValidator', () => {
         });
         await expect(validator.validateTx(tx)).resolves.toEqual({
           result: 'invalid',
-          reason: [TX_ERROR_GAS_LIMIT_TOO_HIGH],
+          reason: [expect.stringContaining(TX_ERROR_GAS_LIMIT_TOO_HIGH)],
         });
       });
 
@@ -287,7 +291,7 @@ describe('GasTxValidator', () => {
         });
         await expect(validator.validateTx(tx)).resolves.toEqual({
           result: 'invalid',
-          reason: [TX_ERROR_GAS_LIMIT_TOO_HIGH],
+          reason: [expect.stringContaining(TX_ERROR_GAS_LIMIT_TOO_HIGH)],
         });
       });
 
@@ -311,7 +315,7 @@ describe('GasTxValidator', () => {
         });
         await expect(validator.validateTx(tx)).resolves.toEqual({
           result: 'invalid',
-          reason: [TX_ERROR_GAS_LIMIT_TOO_HIGH],
+          reason: [expect.stringContaining(TX_ERROR_GAS_LIMIT_TOO_HIGH)],
         });
       });
 
@@ -327,7 +331,7 @@ describe('GasTxValidator', () => {
         });
         await expect(validator.validateTx(tx)).resolves.toEqual({
           result: 'invalid',
-          reason: [TX_ERROR_GAS_LIMIT_TOO_HIGH],
+          reason: [expect.stringContaining(TX_ERROR_GAS_LIMIT_TOO_HIGH)],
         });
       });
 
@@ -343,7 +347,7 @@ describe('GasTxValidator', () => {
         });
         await expect(validator.validateTx(tx)).resolves.toEqual({
           result: 'invalid',
-          reason: [TX_ERROR_GAS_LIMIT_TOO_HIGH],
+          reason: [expect.stringContaining(TX_ERROR_GAS_LIMIT_TOO_HIGH)],
         });
       });
     });

--- a/yarn-project/p2p/src/msg_validators/tx_validator/gas_validator.ts
+++ b/yarn-project/p2p/src/msg_validators/tx_validator/gas_validator.ts
@@ -87,7 +87,12 @@ export class GasLimitsValidator<T extends HasGasLimitData> implements TxValidato
         gasLimits,
         minGasLimits,
       });
-      return { result: 'invalid', reason: [TX_ERROR_INSUFFICIENT_GAS_LIMIT] };
+      return {
+        result: 'invalid',
+        reason: [
+          `${TX_ERROR_INSUFFICIENT_GAS_LIMIT} (required=da:${minGasLimits.daGas},l2:${minGasLimits.l2Gas} got=da:${gasLimits.daGas},l2:${gasLimits.l2Gas})`,
+        ],
+      };
     }
 
     if (gasLimits.l2Gas > this.#effectiveMaxL2Gas) {
@@ -97,7 +102,10 @@ export class GasLimitsValidator<T extends HasGasLimitData> implements TxValidato
         rollupManaLimit: this.#rollupManaLimit,
         maxBlockL2Gas: this.#maxBlockL2Gas,
       });
-      return { result: 'invalid', reason: [TX_ERROR_GAS_LIMIT_TOO_HIGH] };
+      return {
+        result: 'invalid',
+        reason: [`${TX_ERROR_GAS_LIMIT_TOO_HIGH} (l2Gas=${gasLimits.l2Gas}, max=${this.#effectiveMaxL2Gas})`],
+      };
     }
 
     if (gasLimits.daGas > this.#effectiveMaxDAGas) {
@@ -106,7 +114,10 @@ export class GasLimitsValidator<T extends HasGasLimitData> implements TxValidato
         effectiveMaxDAGas: this.#effectiveMaxDAGas,
         maxBlockDAGas: this.#maxBlockDAGas,
       });
-      return { result: 'invalid', reason: [TX_ERROR_GAS_LIMIT_TOO_HIGH] };
+      return {
+        result: 'invalid',
+        reason: [`${TX_ERROR_GAS_LIMIT_TOO_HIGH} (daGas=${gasLimits.daGas}, max=${this.#effectiveMaxDAGas})`],
+      };
     }
 
     return { result: 'valid' };
@@ -157,19 +168,20 @@ export class GasTxValidator implements TxValidator<Tx> {
     if (gasLimitValidation.result === 'invalid') {
       return Promise.resolve(gasLimitValidation);
     }
-    if (this.#shouldSkip(tx)) {
-      return Promise.resolve({ result: 'skipped', reason: [TX_ERROR_INSUFFICIENT_FEE_PER_GAS] });
+    const skipReason = this.#getSkipReason(tx);
+    if (skipReason) {
+      return Promise.resolve({ result: 'skipped', reason: [skipReason] });
     }
     return await this.validateTxFee(tx);
   }
 
   /**
-   * Check whether the tx's max fees are valid for the current block, and skip if not.
+   * Check whether the tx's max fees are valid for the current block, and return a skip reason if not.
    * We skip instead of invalidating since the tx may become eligible later.
    * Note that circuits check max fees even if fee payer is unset, so we
    * keep this validation even if the tx does not pay fees.
    */
-  #shouldSkip(tx: Tx): boolean {
+  #getSkipReason(tx: Tx): string | undefined {
     const gasSettings = tx.data.constants.txContext.gasSettings;
 
     // Skip the tx if its max fees are not enough for the current block's gas fees.
@@ -182,8 +194,9 @@ export class GasTxValidator implements TxValidator<Tx> {
         txMaxFeesPerGas: maxFeesPerGas.toInspect(),
         currentGasFees: this.#gasFees.toInspect(),
       });
+      return `${TX_ERROR_INSUFFICIENT_FEE_PER_GAS} (maxFee=da:${maxFeesPerGas.feePerDaGas},l2:${maxFeesPerGas.feePerL2Gas} required=da:${this.#gasFees.feePerDaGas},l2:${this.#gasFees.feePerL2Gas})`;
     }
-    return notEnoughMaxFees;
+    return undefined;
   }
 
   /**
@@ -212,7 +225,10 @@ export class GasTxValidator implements TxValidator<Tx> {
         balance,
         feeLimit,
       });
-      return { result: 'invalid', reason: [TX_ERROR_INSUFFICIENT_FEE_PAYER_BALANCE] };
+      return {
+        result: 'invalid',
+        reason: [`${TX_ERROR_INSUFFICIENT_FEE_PAYER_BALANCE} (required=${feeLimit}, available=${balance})`],
+      };
     }
     return { result: 'valid' };
   }


### PR DESCRIPTION
## Motivation

When a transaction fails validation (e.g. insufficient balance, gas limits out of bounds), the error returned to the client is a static string like "Insufficient fee payer balance" with no context. Users have to guess what went wrong. The validators already have the relevant values (balance, fee limit, gas limits) and log them server-side, but don't include them in the error reason returned to the client.

## Approach

Append contextual values to each error reason string in `GasTxValidator` and `GasLimitsValidator`. The base error constant is preserved as a prefix so existing substring-based assertions (e2e tests using `toThrow`) continue to work. Refactored `#shouldSkip` to `#getSkipReason` so the fee-per-gas skip path can also include values.

## Changes

- **p2p (gas_validator.ts)**: All five validation error paths now include values in the reason string: fee payer balance (`required`/`available`), gas limits (`required`/`got` or `limit`/`max`), and fee per gas (`maxFee`/`required`)
- **p2p (gas_validator.test.ts)**: Updated test helpers and assertions to use substring matching (`toContain`/`stringContaining`) since error messages now have dynamic suffixes