### PR TITLE
fix: external audit fixes for Pedersen

### DIFF
--- a/barretenberg/cpp/src/barretenberg/crypto/pedersen_hash/pedersen.cpp
+++ b/barretenberg/cpp/src/barretenberg/crypto/pedersen_hash/pedersen.cpp
@@ -92,6 +92,10 @@ template <typename Curve>
 typename Curve::BaseField pedersen_hash_base<Curve>::hash_buffer(const std::vector<uint8_t>& input,
                                                                  const GeneratorContext context)
 {
+    if (input.empty()) {
+        throw_or_abort("pedersen hash_buffer: empty input");
+    }
+
     std::vector<Fq> converted = convert_buffer(input);
 
     if (converted.size() < 2) {

--- a/barretenberg/cpp/src/barretenberg/crypto/pedersen_hash/pedersen.cpp
+++ b/barretenberg/cpp/src/barretenberg/crypto/pedersen_hash/pedersen.cpp
@@ -77,6 +77,10 @@ std::vector<typename Curve::BaseField> pedersen_hash_base<Curve>::convert_buffer
 template <typename Curve>
 typename Curve::BaseField pedersen_hash_base<Curve>::hash(const std::vector<Fq>& inputs, const GeneratorContext context)
 {
+    if (inputs.empty()) {
+        throw_or_abort("pedersen hash: empty input");
+    }
+
     Element result = length_generator * Fr(inputs.size());
     return (result + pedersen_commitment_base<Curve>::commit_native(inputs, context)).normalize().x;
 }

--- a/barretenberg/cpp/src/barretenberg/crypto/pedersen_hash/pedersen.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/crypto/pedersen_hash/pedersen.test.cpp
@@ -75,4 +75,15 @@ TEST(Pedersen, HashRejectsEmptyInput)
         std::runtime_error);
 }
 
+// Verifies that hashing an empty input throws an exception
+TEST(Pedersen, HashBufferRejectsEmptyInput)
+{
+    EXPECT_THROW(
+        {
+            auto result = pedersen_hash::hash_buffer({});
+            static_cast<void>(result);
+        },
+        std::runtime_error);
+}
+
 } // namespace bb::crypto

--- a/barretenberg/cpp/src/barretenberg/crypto/pedersen_hash/pedersen.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/crypto/pedersen_hash/pedersen.test.cpp
@@ -64,5 +64,15 @@ TEST(Pedersen, Hash32Bytes)
 
     EXPECT_EQ(got, expected);
 }
+// Verifies that hashing an empty input throws an exception
+TEST(Pedersen, HashRejectsEmptyInput)
+{
+    EXPECT_THROW(
+        {
+            auto result = pedersen_hash::hash({});
+            static_cast<void>(result);
+        },
+        std::runtime_error);
+}
 
 } // namespace bb::crypto


### PR DESCRIPTION
**finding 19: guard in `hash` for empty inputs** --- fixed 29e5bbbe9671a2d7948d7d8ffd81aac46cd085ce
The guarantee documented in `pedersen.hpp` “hash output is never point at infinity” applies when the input size is greater than 0. When called on an empty input, `hash` was returning the x co-ordinate of point at infinity. This is addressed now by adding a `throw_or_abort` guard in `hash`to catch empty inputs. Tests are also included which verify that hashing an empty input throws an exception.

**finding 2: guard to prevent integer underflow in `convert_buffer` on empty input** --- fixed fc402569a691b979a557e6209b2ae2039b5a08fc
`convert_buffer` had an integer underflow when it was passed an empty input. This is addressed by including a `throw_or_abort` guard in `hash_buffer` before the call to `convert_buffer` is made so that an empty input cannot be sent to `convert_buffer`. Tests are also included which verify that hashing an empty input throws an exception.

**finding 18: capping `hash_index` `bbapi` Pedersen handlers** --- not fixed
`hash_index` is currently not capped. However, as pointed out, it is hardcoded to 0 in the current code and is not reachable. Hence, not fixing this. 
