### PR TITLE
fix: external audit fixes for Keccak

### DIFF
--- a/barretenberg/cpp/src/barretenberg/crypto/keccak/keccak.cpp
+++ b/barretenberg/cpp/src/barretenberg/crypto/keccak/keccak.cpp
@@ -110,30 +110,3 @@ struct keccak256 ethash_keccak256(const uint8_t* data, size_t size) NOEXCEPT
     keccak(hash.word64s, 256, data, size);
     return hash;
 }
-
-struct keccak256 hash_field_elements(const uint64_t* limbs, size_t num_elements)
-{
-    std::vector<uint8_t> input_buffer(num_elements * KECCAK256_OUTPUT_BYTES);
-
-    for (size_t i = 0; i < num_elements; ++i) {
-        for (size_t j = 0; j < KECCAK256_OUTPUT_WORDS; ++j) {
-            uint64_t word = (limbs[i * KECCAK256_OUTPUT_WORDS + j]);
-            size_t idx = i * 32 + j * 8;
-            input_buffer[idx] = (uint8_t)((word >> 56) & 0xff);
-            input_buffer[idx + 1] = (uint8_t)((word >> 48) & 0xff);
-            input_buffer[idx + 2] = (uint8_t)((word >> 40) & 0xff);
-            input_buffer[idx + 3] = (uint8_t)((word >> 32) & 0xff);
-            input_buffer[idx + 4] = (uint8_t)((word >> 24) & 0xff);
-            input_buffer[idx + 5] = (uint8_t)((word >> 16) & 0xff);
-            input_buffer[idx + 6] = (uint8_t)((word >> 8) & 0xff);
-            input_buffer[idx + 7] = (uint8_t)(word & 0xff);
-        }
-    }
-
-    return ethash_keccak256(input_buffer.data(), num_elements * KECCAK256_OUTPUT_BYTES);
-}
-
-struct keccak256 hash_field_element(const uint64_t* limb)
-{
-    return hash_field_elements(limb, 1);
-}

--- a/barretenberg/cpp/src/barretenberg/crypto/keccak/keccak.hpp
+++ b/barretenberg/cpp/src/barretenberg/crypto/keccak/keccak.hpp
@@ -40,10 +40,6 @@ void ethash_keccakf1600(uint64_t state[KECCAKF1600_LANES]) NOEXCEPT;
 
 struct keccak256 ethash_keccak256(const uint8_t* data, size_t size) NOEXCEPT;
 
-struct keccak256 hash_field_elements(const uint64_t* limbs, size_t num_elements);
-
-struct keccak256 hash_field_element(const uint64_t* limb);
-
 namespace bb::crypto {
 /**
  * @brief A wrapper class used to construct `KeccakTranscript`.

--- a/barretenberg/cpp/src/barretenberg/stdlib/hash/keccak/keccak.fuzzer.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/hash/keccak/keccak.fuzzer.cpp
@@ -81,6 +81,6 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* Data, size_t Size)
     assert(circuit_output_u == expected_state);
 
     // Verify circuit correctness
-    assert(!CircuitChecker::check(builder));
+    assert(CircuitChecker::check(builder));
     return 0;
 }


### PR DESCRIPTION
**finding 7: inverted assertion in keccak fuzzer** --- fixed 4da6a6545264003dcf60c15402fe3fb0b295b589
The keccak fuzzer had an inverted assertion in the circuit checker. This has been fixed. 

**finding 10: delete dead code pertaining to `hash_field_element`** --- fixed 940f6e437a2784fc96680c9c96b315bc2e6c649d
`hash_field_element` and `hash_field_elements` constitute dead code, which was missed to be removed in the internal audit. These have been deleted now. 
