### PR TITLE
fix: remove redundant p2pClient.start() call

### DIFF
--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -466,7 +466,6 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, Traceable {
     void archiver
       .waitForInitialSync()
       .then(async () => {
-        await p2pClient.start();
         await validatorsSentinel?.start();
         await epochPruneWatcher?.start();
         await attestationsBlockWatcher?.start();


### PR DESCRIPTION
Removes the duplicate `p2pClient.start()`. The P2P client is already fully started (and synced) by the unconditional `await p2pClient.start()` earlier in `createAztecNode`.

The second call just hits the guard clause (`if state !== IDLE return syncPromise`) and is a no-op. This is just for cleanup

Fixes [A-736](https://linear.app/aztec-labs/issue/A-736/audit-60-p2p-client-start-called-twice-in-serverts-duplicate-listeners)