### PR TITLE
fix: external audit fixes for BLAKE

### DIFF
--- a/barretenberg/cpp/src/barretenberg/crypto/blake3s/blake3s.hpp
+++ b/barretenberg/cpp/src/barretenberg/crypto/blake3s/blake3s.hpp
@@ -61,7 +61,7 @@ enum blake3s_constant {
     BLAKE3_MAX_DEPTH = 54
 };
 
-using key_array = std::array<uint32_t, BLAKE3_KEY_LEN>;
+using key_array = std::array<uint32_t, BLAKE3_KEY_LEN / sizeof(uint32_t)>;
 using block_array = std::array<uint8_t, BLAKE3_BLOCK_LEN>;
 using state_array = std::array<uint32_t, 16>;
 using out_array = std::array<uint8_t, BLAKE3_OUT_LEN>;

--- a/barretenberg/cpp/src/barretenberg/crypto/blake3s/blake3s.tcc
+++ b/barretenberg/cpp/src/barretenberg/crypto/blake3s/blake3s.tcc
@@ -180,7 +180,7 @@ struct output_t {
 constexpr output_t make_output(const key_array& input_cv, const uint8_t* block, uint8_t block_len, uint8_t flags)
 {
     output_t ret;
-    for (size_t i = 0; i < (BLAKE3_OUT_LEN >> 2); ++i) {
+    for (size_t i = 0; i < ret.input_cv.size(); ++i) {
         ret.input_cv[i] = input_cv[i];
     }
     for (size_t i = 0; i < BLAKE3_BLOCK_LEN; i++) {
@@ -193,7 +193,7 @@ constexpr output_t make_output(const key_array& input_cv, const uint8_t* block, 
 
 constexpr void blake3_hasher_init(blake3_hasher* self)
 {
-    for (size_t i = 0; i < (BLAKE3_KEY_LEN >> 2); ++i) {
+    for (size_t i = 0; i < IV.size(); ++i) {
         self->key[i] = IV[i];
         self->cv[i] = IV[i];
     }

--- a/barretenberg/cpp/src/barretenberg/crypto/blake3s/blake3s.tcc
+++ b/barretenberg/cpp/src/barretenberg/crypto/blake3s/blake3s.tcc
@@ -260,6 +260,11 @@ std::vector<uint8_t> blake3s(std::vector<uint8_t> const& input)
 
 constexpr std::array<uint8_t, BLAKE3_OUT_LEN> blake3s_constexpr(const uint8_t* input, const size_t input_size)
 {
+    if (std::is_constant_evaluated()) {
+        if (input_size > 1024U) {
+            __builtin_trap();
+        }
+    }
     blake3_hasher hasher;
     blake3_hasher_init(&hasher);
     blake3_hasher_update(&hasher, input, input_size);

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/blake3_constraint.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/blake3_constraint.cpp
@@ -16,6 +16,9 @@ template <typename Builder> void create_blake3_constraints(Builder& builder, con
     using byte_array_ct = bb::stdlib::byte_array<Builder>;
     using field_ct = bb::stdlib::field_t<Builder>;
 
+    BB_ASSERT_LTE(
+        constraint.inputs.size(), 1024U, "Barretenberg does not support blake3 inputs with more than 1024 bytes");
+
     // Build input byte array by appending constrained byte_arrays
     byte_array_ct arr = byte_array_ct::constant_padding(&builder, 0); // Start with empty array
 
@@ -30,7 +33,6 @@ template <typename Builder> void create_blake3_constraints(Builder& builder, con
         // Safe write: both arr and element_bytes are constrained
         arr.write(element_bytes);
     }
-    BB_ASSERT_LTE(arr.size(), 1024U, "Barretenberg does not support blake3 inputs with more than 1024 bytes");
     byte_array_ct output_bytes = bb::stdlib::Blake3s<Builder>::hash(arr);
 
     for (const auto& [output_byte, result_byte_idx] : zip_view(output_bytes.bytes(), constraint.result)) {

--- a/barretenberg/cpp/src/barretenberg/stdlib/hash/blake2s/blake2s.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/hash/blake2s/blake2s.cpp
@@ -39,15 +39,17 @@ namespace bb::stdlib {
 
 template <typename Builder> void Blake2s<Builder>::increment_counter(blake2s_state& S, const uint32_t inc)
 {
+    // Note that the initial blake2s_state values are circuit constants.
+    BB_ASSERT(S.t[0].is_constant());
+    BB_ASSERT(S.t[1].is_constant());
+
     field_ct inc_scalar(static_cast<uint256_t>(inc));
 
-    // Note that the initial blake2s_state values are circuit constants.
     S.t[0] = S.t[0] + inc_scalar;
-
-    // Note that although blake2s_state is a circuit constant, we use designated functions such as
-    // `ranged_less_than` to enforce constraints as appropriate.
-    bool_ct to_inc = S.t[0].template ranged_less_than<32>(inc_scalar);
-    S.t[1] = S.t[1] + field_ct(to_inc);
+    // Enforced constant state (t[0], t[1]) allows computing the carry out-of-circuit (with correct 32-bit wrap) without
+    // adding constraints.
+    const bool to_inc = uint32_t(uint256_t(S.t[0].get_value())) < inc;
+    S.t[1] = S.t[1] + (to_inc ? field_ct(1) : field_ct(0));
 }
 
 template <typename Builder> void Blake2s<Builder>::compress(blake2s_state& S, byte_array_ct const& in)


### PR DESCRIPTION
**finding 11: change `key_array` to use correct element count** --- fixed dfc08b51dc0a20e32cac6c05b2a83b2b3f8e0548
`key_array` over-allocated bytes and zero-initialized the additional bytes that are never used. This has been addressed by allocating only as many bytes as needed. 

**finding 13: input validation consistency between `blake3s` and `blake3s_constexpr`** --- fixed 97ec044d3e330d250d59d8120327f92803870ad5
`barretenberg` does not support Blake3 with input lengths greater than 1024 bytes. This is enforced in `blake3s` via `BB_ASSERT_LTE(input.size, 1024)` and such a check is missing in `blake3s_constexpr`. The check was probably omitted because `BB_ASSERT_LTE` is runtime and not compile-time. This has been addressed via introducing a compile-time check. 

**finding 15: performance optimisation in `blake3_constraint.cpp`** --- fixed f9b13ab7e27b9ee026cd7e26743fe92c51042723
`barretenberg` does not support Blake3 with input lengths greater than 1024 bytes. The input size validation check happens after memory is allocated to the input, even for an invalid input. This has been addressed to first check that the input size is less than or equal to 1024 bytes, and then followed by the memory allocation for the input. 

**finding 22: blake2s increment_counter logic** --- fixed 25eccda8019fc292ee419d806eaa5e2514b6f32e   
`increment_counter`  relied on `ranged_less_than<32>` over an untruncated field value to detect 32-bit carry and implicitly assumed the counter words were constants, making the logic fragile and potentially incorrect (for impractically large messages). This has been fixed by explicitly asserting that `t[0]` and `t[1]` are constants, and restoring the earlier version where the carry is computed using native 32-bit truncation, ensuring correct wrap-around semantics. Thanks for noting this. 