### PR TITLE
refactor: type-safe config

### DIFF
--- a/yarn-project/archiver/src/config.ts
+++ b/yarn-project/archiver/src/config.ts
@@ -50,7 +50,7 @@ export const archiverConfigMappings: ConfigMappingsType<ArchiverConfig> = {
   },
   archiverStoreMapSizeKb: {
     env: 'ARCHIVER_STORE_MAP_SIZE_KB',
-    parseEnv: (val: string | undefined) => (val ? +val : undefined),
+    parseEnv: (val: string) => +val,
     description: 'The maximum possible size of the archiver DB in KB. Overwrites the general dataStoreMapSizeKb.',
   },
   skipValidateCheckpointAttestations: {

--- a/yarn-project/aztec/src/cli/aztec_start_options.ts
+++ b/yarn-project/aztec/src/cli/aztec_start_options.ts
@@ -36,7 +36,7 @@ export interface AztecStartOption {
   parseVal?: (val: string) => any;
 }
 
-export const getOptions = (namespace: string, configMappings: Record<string, ConfigMapping<any>>) => {
+export const getOptions = (namespace: string, configMappings: Record<string, ConfigMapping<unknown>>) => {
   const options: AztecStartOption[] = [];
   for (const [key, { env, defaultValue: def, parseEnv, description, printDefault, fallback }] of Object.entries(
     configMappings,
@@ -60,7 +60,7 @@ export const getOptions = (namespace: string, configMappings: Record<string, Con
 
 const configToFlag = (
   flag: string,
-  configMapping: ConfigMapping<any>,
+  configMapping: ConfigMapping<unknown>,
   overrideDefaultValue?: any,
 ): AztecStartOption => {
   if (!configMapping.isBoolean) {

--- a/yarn-project/aztec/src/cli/aztec_start_options.ts
+++ b/yarn-project/aztec/src/cli/aztec_start_options.ts
@@ -36,7 +36,7 @@ export interface AztecStartOption {
   parseVal?: (val: string) => any;
 }
 
-export const getOptions = (namespace: string, configMappings: Record<string, ConfigMapping>) => {
+export const getOptions = (namespace: string, configMappings: Record<string, ConfigMapping<any>>) => {
   const options: AztecStartOption[] = [];
   for (const [key, { env, defaultValue: def, parseEnv, description, printDefault, fallback }] of Object.entries(
     configMappings,
@@ -58,7 +58,11 @@ export const getOptions = (namespace: string, configMappings: Record<string, Con
   return options;
 };
 
-const configToFlag = (flag: string, configMapping: ConfigMapping, overrideDefaultValue?: any): AztecStartOption => {
+const configToFlag = (
+  flag: string,
+  configMapping: ConfigMapping<any>,
+  overrideDefaultValue?: any,
+): AztecStartOption => {
   if (!configMapping.isBoolean) {
     flag += ' <value>';
   }

--- a/yarn-project/aztec/src/cli/cmds/start_archiver.ts
+++ b/yarn-project/aztec/src/cli/cmds/start_archiver.ts
@@ -2,7 +2,6 @@ import { type ArchiverConfig, archiverConfigMappings, createArchiver, getArchive
 import { createLogger } from '@aztec/aztec.js/log';
 import { type BlobClientConfig, blobClientConfigMapping, createBlobClient } from '@aztec/blob-client/client';
 import { getL1Config } from '@aztec/cli/config';
-import type { ConfigMappingsType } from '@aztec/foundation/config';
 import type { NamespacedApiHandlers } from '@aztec/foundation/json-rpc/server';
 import { ArchiverApiSchema } from '@aztec/stdlib/interfaces/server';
 import { type DataStoreConfig, dataConfigMappings } from '@aztec/stdlib/kv-store';
@@ -22,10 +21,12 @@ export async function startArchiver(
   const cliOptions = extractRelevantOptions<ArchiverConfig & DataStoreConfig & BlobClientConfig>(
     options,
     {
-      ...archiverConfigMappings,
+      // dataConfigMappings must come first: its l1Contracts only maps rollupAddress,
+      // while archiverConfigMappings (spread later) maps all L1 contract addresses.
       ...dataConfigMappings,
+      ...archiverConfigMappings,
       ...blobClientConfigMapping,
-    } as ConfigMappingsType<ArchiverConfig & DataStoreConfig & BlobClientConfig>,
+    },
     'archiver',
   );
 

--- a/yarn-project/aztec/src/cli/cmds/start_archiver.ts
+++ b/yarn-project/aztec/src/cli/cmds/start_archiver.ts
@@ -2,6 +2,7 @@ import { type ArchiverConfig, archiverConfigMappings, createArchiver, getArchive
 import { createLogger } from '@aztec/aztec.js/log';
 import { type BlobClientConfig, blobClientConfigMapping, createBlobClient } from '@aztec/blob-client/client';
 import { getL1Config } from '@aztec/cli/config';
+import type { ConfigMappingsType } from '@aztec/foundation/config';
 import type { NamespacedApiHandlers } from '@aztec/foundation/json-rpc/server';
 import { ArchiverApiSchema } from '@aztec/stdlib/interfaces/server';
 import { type DataStoreConfig, dataConfigMappings } from '@aztec/stdlib/kv-store';
@@ -20,7 +21,11 @@ export async function startArchiver(
   const envConfig = getArchiverConfigFromEnv();
   const cliOptions = extractRelevantOptions<ArchiverConfig & DataStoreConfig & BlobClientConfig>(
     options,
-    { ...archiverConfigMappings, ...dataConfigMappings, ...blobClientConfigMapping },
+    {
+      ...archiverConfigMappings,
+      ...dataConfigMappings,
+      ...blobClientConfigMapping,
+    } as ConfigMappingsType<ArchiverConfig & DataStoreConfig & BlobClientConfig>,
     'archiver',
   );
 

--- a/yarn-project/blob-client/src/client/config.ts
+++ b/yarn-project/blob-client/src/client/config.ts
@@ -93,7 +93,7 @@ export const blobClientConfigMapping: ConfigMappingsType<BlobClientConfig> = {
   blobSinkMapSizeKb: {
     env: 'BLOB_SINK_MAP_SIZE_KB',
     description: 'The maximum possible size of the blob sink DB in KB. Overwrites the general dataStoreMapSizeKb.',
-    parseEnv: (val: string | undefined) => (val ? +val : undefined),
+    parseEnv: (val: string) => +val,
   },
   blobAllowEmptySources: {
     env: 'BLOB_ALLOW_EMPTY_SOURCES',
@@ -116,7 +116,7 @@ export const blobClientConfigMapping: ConfigMappingsType<BlobClientConfig> = {
   blobHealthcheckUploadIntervalMinutes: {
     env: 'BLOB_HEALTHCHECK_UPLOAD_INTERVAL_MINUTES',
     description: 'Interval in minutes for uploading healthcheck file to file store (default: 60 = 1 hour)',
-    parseEnv: (val: string | undefined) => (val ? +val : undefined),
+    parseEnv: (val: string) => +val,
   },
   l1HttpTimeoutMS: {
     env: 'ETHEREUM_HTTP_TIMEOUT_MS',

--- a/yarn-project/foundation/src/config/config.test.ts
+++ b/yarn-project/foundation/src/config/config.test.ts
@@ -154,14 +154,29 @@ describe('Config', () => {
       expect(parseEnv!('2.5e5')).toBe(250000n);
     });
 
-    it('returns default value for empty string', () => {
-      const { parseEnv } = bigintConfigHelper(42n);
-      expect(parseEnv!('')).toBe(42n);
-    });
-
     it('throws for non-integer scientific notation results', () => {
       const { parseEnv } = bigintConfigHelper();
       expect(() => parseEnv!('1e-3')).toThrow();
+    });
+
+    it('returns default value for empty string env var', () => {
+      const originalEnv = process.env;
+      process.env = { ...originalEnv, L1_MINIMUM_PRIORITY_FEE_PER_GAS_GWEI: '' };
+      try {
+        interface TestConfig {
+          value: bigint;
+        }
+        const config = getConfigFromMappings<TestConfig>({
+          value: {
+            env: 'L1_MINIMUM_PRIORITY_FEE_PER_GAS_GWEI',
+            description: 'test',
+            ...bigintConfigHelper(42n),
+          },
+        });
+        expect(config.value).toBe(42n);
+      } finally {
+        process.env = originalEnv;
+      }
     });
   });
 });

--- a/yarn-project/foundation/src/config/config.test.ts
+++ b/yarn-project/foundation/src/config/config.test.ts
@@ -170,7 +170,10 @@ describe('Config', () => {
           value: {
             env: 'L1_MINIMUM_PRIORITY_FEE_PER_GAS_GWEI',
             description: 'test',
-            ...bigintConfigHelper(42n),
+            parseEnv: () => {
+              throw new Error('parseEnv should not be called for empty string');
+            },
+            defaultValue: 42n,
           },
         });
         expect(config.value).toBe(42n);

--- a/yarn-project/foundation/src/config/index.ts
+++ b/yarn-project/foundation/src/config/index.ts
@@ -271,17 +271,17 @@ export function booleanConfigHelper(
   };
 }
 
-export function secretValueConfigHelper<T>(parse: (val: string | undefined) => T): Required<
-  Pick<ConfigMapping<SecretValue<T>>, 'parseEnv' | 'defaultValue' | 'isBoolean'> & {
-    parseVal: (val: string) => SecretValue<T>;
-  }
-> {
+export function secretValueConfigHelper<T>(parse: (val: string | undefined) => T): Pick<
+  ConfigMapping<SecretValue<T>>,
+  'parseEnv' | 'defaultValue'
+> & {
+  parseVal: (val: string) => SecretValue<T>;
+} {
   const wrap = (val: string) => new SecretValue(parse(val));
   return {
     parseEnv: wrap,
     parseVal: wrap,
     defaultValue: new SecretValue(parse(undefined)),
-    isBoolean: true,
   };
 }
 
@@ -291,26 +291,22 @@ export function secretStringConfigHelper(): {
   parseEnv: (val: string) => SecretValue<string>;
   parseVal: (val: string) => SecretValue<string>;
   defaultValue: undefined;
-  isBoolean: true;
 };
 export function secretStringConfigHelper(defaultValue: string): {
   parseEnv: (val: string) => SecretValue<string>;
   parseVal: (val: string) => SecretValue<string>;
   defaultValue: SecretValue<string>;
-  isBoolean: true;
 };
 export function secretStringConfigHelper(defaultValue?: string): {
   parseEnv: (val: string) => SecretValue<string>;
   parseVal: (val: string) => SecretValue<string>;
   defaultValue: SecretValue<string> | undefined;
-  isBoolean: true;
 } {
   const parse = (val: string) => new SecretValue(val);
   return {
     parseEnv: parse,
     parseVal: parse,
     defaultValue: defaultValue !== undefined ? new SecretValue(defaultValue) : undefined,
-    isBoolean: true,
   };
 }
 
@@ -318,26 +314,22 @@ export function secretFrConfigHelper(): {
   parseEnv: (val: string) => SecretValue<Fr>;
   parseVal: (val: string) => SecretValue<Fr>;
   defaultValue: undefined;
-  isBoolean: true;
 };
 export function secretFrConfigHelper(defaultValue: Fr): {
   parseEnv: (val: string) => SecretValue<Fr>;
   parseVal: (val: string) => SecretValue<Fr>;
   defaultValue: SecretValue<Fr>;
-  isBoolean: true;
 };
 export function secretFrConfigHelper(defaultValue?: Fr): {
   parseEnv: (val: string) => SecretValue<Fr>;
   parseVal: (val: string) => SecretValue<Fr>;
   defaultValue: SecretValue<Fr> | undefined;
-  isBoolean: true;
 } {
   const parse = (val: string) => new SecretValue(Fr.fromHexString(val));
   return {
     parseEnv: parse,
     parseVal: parse,
     defaultValue: defaultValue !== undefined ? new SecretValue(defaultValue) : undefined,
-    isBoolean: true,
   };
 }
 
@@ -345,26 +337,22 @@ export function secretFqConfigHelper(): {
   parseEnv: (val: string) => SecretValue<Fq>;
   parseVal: (val: string) => SecretValue<Fq>;
   defaultValue: undefined;
-  isBoolean: true;
 };
 export function secretFqConfigHelper(defaultValue: Fq): {
   parseEnv: (val: string) => SecretValue<Fq>;
   parseVal: (val: string) => SecretValue<Fq>;
   defaultValue: SecretValue<Fq>;
-  isBoolean: true;
 };
 export function secretFqConfigHelper(defaultValue?: Fq): {
   parseEnv: (val: string) => SecretValue<Fq>;
   parseVal: (val: string) => SecretValue<Fq>;
   defaultValue: SecretValue<Fq> | undefined;
-  isBoolean: true;
 } {
   const parse = (val: string) => new SecretValue(Fq.fromHexString(val));
   return {
     parseEnv: parse,
     parseVal: parse,
     defaultValue: defaultValue !== undefined ? new SecretValue(defaultValue) : undefined,
-    isBoolean: true,
   };
 }
 

--- a/yarn-project/foundation/src/config/index.ts
+++ b/yarn-project/foundation/src/config/index.ts
@@ -185,9 +185,6 @@ export function bigintConfigHelper(
 ): Pick<ConfigMapping<bigint | undefined>, 'parseEnv' | 'defaultValue'> {
   return {
     parseEnv: (val: string) => {
-      if (val === '') {
-        return defaultVal;
-      }
       // Handle scientific notation (e.g. "1e+23", "2E23") which BigInt() doesn't accept directly.
       // We parse it losslessly using bigint arithmetic instead of going through float64.
       if (/[eE]/.test(val)) {
@@ -239,12 +236,9 @@ export function enumConfigHelper<T extends string>(
 ): Pick<ConfigMapping<T | undefined>, 'parseEnv' | 'defaultValue'> {
   return {
     parseEnv: (val: string) => {
-      const sanitizedVal = (val ?? '').trim().toLowerCase();
-      if (values.includes(sanitizedVal as T)) {
-        return sanitizedVal as T;
-      }
-      if (!val && defaultValue) {
-        return defaultValue;
+      const sanitizedVal = val.trim().toLowerCase();
+      if (values.some(v => v.toLowerCase() === sanitizedVal)) {
+        return values.find(v => v.toLowerCase() === sanitizedVal)!;
       }
       throw new Error(`Invalid config value '${val}' (must be one of ${values.join(', ')})`);
     },

--- a/yarn-project/foundation/src/config/index.ts
+++ b/yarn-project/foundation/src/config/index.ts
@@ -10,14 +10,14 @@ export type { EnvVar, NetworkNames };
 export type { NetworkConfig, NetworkConfigMap } from './network_config.js';
 export { NetworkConfigMapSchema, NetworkConfigSchema } from './network_config.js';
 
-export interface ConfigMapping {
+export interface ConfigMapping<T> {
   env?: EnvVar;
-  parseEnv?: (val: string) => any;
-  defaultValue?: any;
+  parseEnv?: (val: string) => T;
+  defaultValue?: T;
   printDefault?: (val: any) => string;
   description: string;
   isBoolean?: boolean;
-  nested?: Record<string, ConfigMapping>;
+  nested?: Record<string, ConfigMapping<any>>;
   fallback?: EnvVar[];
   /**
    * List of deprecated env vars that are still supported but will log a warning.
@@ -30,7 +30,7 @@ export function isBooleanConfigValue<T>(obj: T, key: keyof T): boolean {
   return typeof obj[key] === 'boolean';
 }
 
-export type ConfigMappingsType<T> = Record<keyof T, ConfigMapping>;
+export type ConfigMappingsType<T> = Record<keyof T, ConfigMapping<any>>;
 
 /**
  * Shared utility function to get a value from environment variables with fallback support.
@@ -123,7 +123,7 @@ export function omitConfigMappings<T, K extends keyof T>(
  * @param defaultVal - The default numerical value to use if the environment variable is not set or is invalid
  * @returns Object with parseEnv and default values for a numerical config value
  */
-export function numberConfigHelper(defaultVal: number): Pick<ConfigMapping, 'parseEnv' | 'defaultValue'> {
+export function numberConfigHelper(defaultVal: number): Pick<ConfigMapping<number>, 'parseEnv' | 'defaultValue'> {
   return {
     parseEnv: (val: string) => safeParseNumber(val, defaultVal),
     defaultValue: defaultVal,
@@ -138,7 +138,7 @@ export function numberConfigHelper(defaultVal: number): Pick<ConfigMapping, 'par
 export function floatConfigHelper(
   defaultVal: number,
   validationFn?: (val: number) => void,
-): Pick<ConfigMapping, 'parseEnv' | 'defaultValue'> {
+): Pick<ConfigMapping<number>, 'parseEnv' | 'defaultValue'> {
   return {
     parseEnv: (val: string): number => {
       const parsed = safeParseFloat(val, defaultVal);
@@ -152,7 +152,7 @@ export function floatConfigHelper(
 /**
  * Parses an environment variable to a 0-1 percentage value
  */
-export function percentageConfigHelper(defaultVal: number): Pick<ConfigMapping, 'parseEnv' | 'defaultValue'> {
+export function percentageConfigHelper(defaultVal: number): Pick<ConfigMapping<number>, 'parseEnv' | 'defaultValue'> {
   return {
     parseEnv: (val: string): number => {
       const parsed = safeParseFloat(val, defaultVal);
@@ -171,7 +171,9 @@ export function percentageConfigHelper(defaultVal: number): Pick<ConfigMapping, 
  * @param defaultVal - The default numerical value to use if the environment variable is not set or is invalid
  * @returns Object with parseEnv and default values for a numerical config value
  */
-export function bigintConfigHelper(defaultVal?: bigint): Pick<ConfigMapping, 'parseEnv' | 'defaultValue'> {
+export function bigintConfigHelper(
+  defaultVal?: bigint,
+): Pick<ConfigMapping<bigint | undefined>, 'parseEnv' | 'defaultValue'> {
   return {
     parseEnv: (val: string) => {
       if (val === '') {
@@ -201,7 +203,7 @@ export function bigintConfigHelper(defaultVal?: bigint): Pick<ConfigMapping, 'pa
 /**
  * Generates parseEnv for an optional numerical config value.
  */
-export function optionalNumberConfigHelper(): Pick<ConfigMapping, 'parseEnv'> {
+export function optionalNumberConfigHelper(): Pick<ConfigMapping<number | undefined>, 'parseEnv'> {
   return {
     parseEnv: (val: string | undefined) => {
       if (val !== undefined && val.length > 0) {
@@ -217,7 +219,7 @@ export function optionalNumberConfigHelper(): Pick<ConfigMapping, 'parseEnv'> {
 export function enumConfigHelper<T extends string>(
   values: T[],
   defaultValue?: NoInfer<T>,
-): Pick<ConfigMapping, 'parseEnv' | 'defaultValue'> {
+): Pick<ConfigMapping<T | undefined>, 'parseEnv' | 'defaultValue'> {
   return {
     parseEnv: (val: string) => {
       const sanitizedVal = (val ?? '').trim().toLowerCase();
@@ -240,7 +242,9 @@ export function enumConfigHelper<T extends string>(
  */
 export function booleanConfigHelper(
   defaultVal = false,
-): Required<Pick<ConfigMapping, 'parseEnv' | 'defaultValue' | 'isBoolean'> & { parseVal: (val: string) => boolean }> {
+): Required<
+  Pick<ConfigMapping<boolean>, 'parseEnv' | 'defaultValue' | 'isBoolean'> & { parseVal: (val: string) => boolean }
+> {
   const parse = (val: string | boolean) => (typeof val === 'boolean' ? val : parseBooleanEnv(val));
   return {
     parseEnv: parse,
@@ -251,7 +255,7 @@ export function booleanConfigHelper(
 }
 
 export function secretValueConfigHelper<T>(parse: (val: string | undefined) => T): Required<
-  Pick<ConfigMapping, 'parseEnv' | 'defaultValue' | 'isBoolean'> & {
+  Pick<ConfigMapping<SecretValue<T>>, 'parseEnv' | 'defaultValue' | 'isBoolean'> & {
     parseVal: (val: string) => SecretValue<T>;
   }
 > {
@@ -267,17 +271,17 @@ export function secretValueConfigHelper<T>(parse: (val: string | undefined) => T
 export { parseBooleanEnv } from './parse-env.js';
 
 export function secretStringConfigHelper(): Required<
-  Pick<ConfigMapping, 'parseEnv' | 'defaultValue' | 'isBoolean'> & {
+  Pick<ConfigMapping<SecretValue<string | undefined>>, 'parseEnv' | 'defaultValue' | 'isBoolean'> & {
     parseVal: (val: string) => SecretValue<string | undefined>;
   }
 >;
 export function secretStringConfigHelper(defaultValue: string): Required<
-  Pick<ConfigMapping, 'parseEnv' | 'defaultValue' | 'isBoolean'> & {
+  Pick<ConfigMapping<SecretValue<string>>, 'parseEnv' | 'defaultValue' | 'isBoolean'> & {
     parseVal: (val: string) => SecretValue<string>;
   }
 >;
 export function secretStringConfigHelper(defaultValue?: string): Required<
-  Pick<ConfigMapping, 'parseEnv' | 'defaultValue' | 'isBoolean'> & {
+  Pick<ConfigMapping<SecretValue<string | typeof defaultValue>>, 'parseEnv' | 'defaultValue' | 'isBoolean'> & {
     parseVal: (val: string) => SecretValue<string | typeof defaultValue>;
   }
 > {
@@ -285,23 +289,23 @@ export function secretStringConfigHelper(defaultValue?: string): Required<
   return {
     parseEnv: parse,
     parseVal: parse,
-    defaultValue: defaultValue !== undefined ? new SecretValue(defaultValue) : undefined,
+    defaultValue: new SecretValue(defaultValue),
     isBoolean: true,
   };
 }
 
 export function secretFrConfigHelper(): Required<
-  Pick<ConfigMapping, 'parseEnv' | 'defaultValue' | 'isBoolean'> & {
+  Pick<ConfigMapping<SecretValue<Fr | undefined>>, 'parseEnv' | 'defaultValue' | 'isBoolean'> & {
     parseVal: (val: string) => SecretValue<Fr | undefined>;
   }
 >;
 export function secretFrConfigHelper(defaultValue: Fr): Required<
-  Pick<ConfigMapping, 'parseEnv' | 'defaultValue' | 'isBoolean'> & {
+  Pick<ConfigMapping<SecretValue<Fr>>, 'parseEnv' | 'defaultValue' | 'isBoolean'> & {
     parseVal: (val: string) => SecretValue<Fr>;
   }
 >;
 export function secretFrConfigHelper(defaultValue?: Fr): Required<
-  Pick<ConfigMapping, 'parseEnv' | 'defaultValue' | 'isBoolean'> & {
+  Pick<ConfigMapping<SecretValue<Fr | typeof defaultValue>>, 'parseEnv' | 'defaultValue' | 'isBoolean'> & {
     parseVal: (val: string) => SecretValue<Fr | typeof defaultValue>;
   }
 > {
@@ -309,23 +313,23 @@ export function secretFrConfigHelper(defaultValue?: Fr): Required<
   return {
     parseEnv: parse,
     parseVal: parse,
-    defaultValue: defaultValue !== undefined ? new SecretValue(defaultValue) : undefined,
+    defaultValue: new SecretValue(defaultValue),
     isBoolean: true,
   };
 }
 
 export function secretFqConfigHelper(defaultValue: Fq): Required<
-  Pick<ConfigMapping, 'parseEnv' | 'defaultValue' | 'isBoolean'> & {
+  Pick<ConfigMapping<SecretValue<Fq>>, 'parseEnv' | 'defaultValue' | 'isBoolean'> & {
     parseVal: (val: string) => SecretValue<Fq>;
   }
 >;
 export function secretFqConfigHelper(): Required<
-  Pick<ConfigMapping, 'parseEnv' | 'defaultValue' | 'isBoolean'> & {
+  Pick<ConfigMapping<SecretValue<Fq | undefined>>, 'parseEnv' | 'defaultValue' | 'isBoolean'> & {
     parseVal: (val: string) => SecretValue<Fq | undefined>;
   }
 >;
 export function secretFqConfigHelper(defaultValue?: Fq): Required<
-  Pick<ConfigMapping, 'parseEnv' | 'defaultValue' | 'isBoolean'> & {
+  Pick<ConfigMapping<SecretValue<Fq | typeof defaultValue>>, 'parseEnv' | 'defaultValue' | 'isBoolean'> & {
     parseVal: (val: string) => SecretValue<Fq | typeof defaultValue>;
   }
 > {
@@ -333,7 +337,7 @@ export function secretFqConfigHelper(defaultValue?: Fq): Required<
   return {
     parseEnv: parse,
     parseVal: parse,
-    defaultValue: typeof defaultValue !== 'undefined' ? new SecretValue(defaultValue) : undefined,
+    defaultValue: new SecretValue(defaultValue),
     isBoolean: true,
   };
 }

--- a/yarn-project/foundation/src/config/index.ts
+++ b/yarn-project/foundation/src/config/index.ts
@@ -30,7 +30,9 @@ export function isBooleanConfigValue<T>(obj: T, key: keyof T): boolean {
   return typeof obj[key] === 'boolean';
 }
 
-export type ConfigMappingsType<T> = Record<keyof T, ConfigMapping<any>>;
+export type ConfigMappingsType<T> = {
+  [K in keyof T]-?: ConfigMapping<T[K]>;
+};
 
 /**
  * Shared utility function to get a value from environment variables with fallback support.
@@ -171,6 +173,8 @@ export function percentageConfigHelper(defaultVal: number): Pick<ConfigMapping<n
  * @param defaultVal - The default numerical value to use if the environment variable is not set or is invalid
  * @returns Object with parseEnv and default values for a numerical config value
  */
+export function bigintConfigHelper(defaultVal: bigint): Pick<ConfigMapping<bigint>, 'parseEnv' | 'defaultValue'>;
+export function bigintConfigHelper(): Pick<ConfigMapping<bigint | undefined>, 'parseEnv' | 'defaultValue'>;
 export function bigintConfigHelper(
   defaultVal?: bigint,
 ): Pick<ConfigMapping<bigint | undefined>, 'parseEnv' | 'defaultValue'> {
@@ -216,6 +220,13 @@ export function optionalNumberConfigHelper(): Pick<ConfigMapping<number | undefi
 }
 
 /** Generates parseEnv for an enum-like config value. */
+export function enumConfigHelper<T extends string>(
+  values: T[],
+  defaultValue: NoInfer<T>,
+): Pick<ConfigMapping<T>, 'parseEnv' | 'defaultValue'>;
+export function enumConfigHelper<T extends string>(
+  values: T[],
+): Pick<ConfigMapping<T | undefined>, 'parseEnv' | 'defaultValue'>;
 export function enumConfigHelper<T extends string>(
   values: T[],
   defaultValue?: NoInfer<T>,
@@ -270,74 +281,83 @@ export function secretValueConfigHelper<T>(parse: (val: string | undefined) => T
 
 export { parseBooleanEnv } from './parse-env.js';
 
-export function secretStringConfigHelper(): Required<
-  Pick<ConfigMapping<SecretValue<string | undefined>>, 'parseEnv' | 'defaultValue' | 'isBoolean'> & {
-    parseVal: (val: string) => SecretValue<string | undefined>;
-  }
->;
-export function secretStringConfigHelper(defaultValue: string): Required<
-  Pick<ConfigMapping<SecretValue<string>>, 'parseEnv' | 'defaultValue' | 'isBoolean'> & {
-    parseVal: (val: string) => SecretValue<string>;
-  }
->;
-export function secretStringConfigHelper(defaultValue?: string): Required<
-  Pick<ConfigMapping<SecretValue<string | typeof defaultValue>>, 'parseEnv' | 'defaultValue' | 'isBoolean'> & {
-    parseVal: (val: string) => SecretValue<string | typeof defaultValue>;
-  }
-> {
+export function secretStringConfigHelper(): {
+  parseEnv: (val: string) => SecretValue<string>;
+  parseVal: (val: string) => SecretValue<string>;
+  defaultValue: undefined;
+  isBoolean: true;
+};
+export function secretStringConfigHelper(defaultValue: string): {
+  parseEnv: (val: string) => SecretValue<string>;
+  parseVal: (val: string) => SecretValue<string>;
+  defaultValue: SecretValue<string>;
+  isBoolean: true;
+};
+export function secretStringConfigHelper(defaultValue?: string): {
+  parseEnv: (val: string) => SecretValue<string>;
+  parseVal: (val: string) => SecretValue<string>;
+  defaultValue: SecretValue<string> | undefined;
+  isBoolean: true;
+} {
   const parse = (val: string) => new SecretValue(val);
   return {
     parseEnv: parse,
     parseVal: parse,
-    defaultValue: new SecretValue(defaultValue),
+    defaultValue: defaultValue !== undefined ? new SecretValue(defaultValue) : undefined,
     isBoolean: true,
   };
 }
 
-export function secretFrConfigHelper(): Required<
-  Pick<ConfigMapping<SecretValue<Fr | undefined>>, 'parseEnv' | 'defaultValue' | 'isBoolean'> & {
-    parseVal: (val: string) => SecretValue<Fr | undefined>;
-  }
->;
-export function secretFrConfigHelper(defaultValue: Fr): Required<
-  Pick<ConfigMapping<SecretValue<Fr>>, 'parseEnv' | 'defaultValue' | 'isBoolean'> & {
-    parseVal: (val: string) => SecretValue<Fr>;
-  }
->;
-export function secretFrConfigHelper(defaultValue?: Fr): Required<
-  Pick<ConfigMapping<SecretValue<Fr | typeof defaultValue>>, 'parseEnv' | 'defaultValue' | 'isBoolean'> & {
-    parseVal: (val: string) => SecretValue<Fr | typeof defaultValue>;
-  }
-> {
+export function secretFrConfigHelper(): {
+  parseEnv: (val: string) => SecretValue<Fr>;
+  parseVal: (val: string) => SecretValue<Fr>;
+  defaultValue: undefined;
+  isBoolean: true;
+};
+export function secretFrConfigHelper(defaultValue: Fr): {
+  parseEnv: (val: string) => SecretValue<Fr>;
+  parseVal: (val: string) => SecretValue<Fr>;
+  defaultValue: SecretValue<Fr>;
+  isBoolean: true;
+};
+export function secretFrConfigHelper(defaultValue?: Fr): {
+  parseEnv: (val: string) => SecretValue<Fr>;
+  parseVal: (val: string) => SecretValue<Fr>;
+  defaultValue: SecretValue<Fr> | undefined;
+  isBoolean: true;
+} {
   const parse = (val: string) => new SecretValue(Fr.fromHexString(val));
   return {
     parseEnv: parse,
     parseVal: parse,
-    defaultValue: new SecretValue(defaultValue),
+    defaultValue: defaultValue !== undefined ? new SecretValue(defaultValue) : undefined,
     isBoolean: true,
   };
 }
 
-export function secretFqConfigHelper(defaultValue: Fq): Required<
-  Pick<ConfigMapping<SecretValue<Fq>>, 'parseEnv' | 'defaultValue' | 'isBoolean'> & {
-    parseVal: (val: string) => SecretValue<Fq>;
-  }
->;
-export function secretFqConfigHelper(): Required<
-  Pick<ConfigMapping<SecretValue<Fq | undefined>>, 'parseEnv' | 'defaultValue' | 'isBoolean'> & {
-    parseVal: (val: string) => SecretValue<Fq | undefined>;
-  }
->;
-export function secretFqConfigHelper(defaultValue?: Fq): Required<
-  Pick<ConfigMapping<SecretValue<Fq | typeof defaultValue>>, 'parseEnv' | 'defaultValue' | 'isBoolean'> & {
-    parseVal: (val: string) => SecretValue<Fq | typeof defaultValue>;
-  }
-> {
+export function secretFqConfigHelper(): {
+  parseEnv: (val: string) => SecretValue<Fq>;
+  parseVal: (val: string) => SecretValue<Fq>;
+  defaultValue: undefined;
+  isBoolean: true;
+};
+export function secretFqConfigHelper(defaultValue: Fq): {
+  parseEnv: (val: string) => SecretValue<Fq>;
+  parseVal: (val: string) => SecretValue<Fq>;
+  defaultValue: SecretValue<Fq>;
+  isBoolean: true;
+};
+export function secretFqConfigHelper(defaultValue?: Fq): {
+  parseEnv: (val: string) => SecretValue<Fq>;
+  parseVal: (val: string) => SecretValue<Fq>;
+  defaultValue: SecretValue<Fq> | undefined;
+  isBoolean: true;
+} {
   const parse = (val: string) => new SecretValue(Fq.fromHexString(val));
   return {
     parseEnv: parse,
     parseVal: parse,
-    defaultValue: new SecretValue(defaultValue),
+    defaultValue: defaultValue !== undefined ? new SecretValue(defaultValue) : undefined,
     isBoolean: true,
   };
 }

--- a/yarn-project/foundation/src/config/index.ts
+++ b/yarn-project/foundation/src/config/index.ts
@@ -87,7 +87,11 @@ export function getConfigFromMappings<T>(configMappings: ConfigMappingsType<T>):
       (config as any)[key] = getConfigFromMappings(nested);
     } else {
       // Use the shared utility function
-      (config as any)[key] = getValueFromEnvWithFallback(env, parseEnv, defaultValue, fallback);
+      try {
+        (config as any)[key] = getValueFromEnvWithFallback(env, parseEnv, defaultValue, fallback);
+      } catch (e: any) {
+        throw new Error(`Failed to parse config '${key}' (env: ${env ?? 'none'}): ${e.message}`);
+      }
 
       // Check for deprecated env vars and warn if logger is set
       if (deprecatedFallback?.length) {
@@ -207,15 +211,16 @@ export function bigintConfigHelper(
 
 /**
  * Generates parseEnv for an optional numerical config value.
+ * Empty strings are already handled by getValueFromEnvWithFallback.
  */
-export function optionalNumberConfigHelper(): Pick<ConfigMapping<number | undefined>, 'parseEnv'> {
+export function optionalNumberConfigHelper(): Pick<ConfigMapping<number>, 'parseEnv'> {
   return {
-    parseEnv: (val: string | undefined) => {
-      if (val !== undefined && val.length > 0) {
-        const parsedValue = parseInt(val);
-        return Number.isSafeInteger(parsedValue) ? parsedValue : undefined;
+    parseEnv: (val: string) => {
+      const parsedValue = parseInt(val);
+      if (!Number.isSafeInteger(parsedValue)) {
+        throw new Error(`Invalid number: ${val}`);
       }
-      return undefined;
+      return parsedValue;
     },
   };
 }

--- a/yarn-project/foundation/src/config/index.ts
+++ b/yarn-project/foundation/src/config/index.ts
@@ -70,7 +70,7 @@ export function getValueFromEnvWithFallback<T>(
   }
 
   // Parse the value if needed. Empty strings are treated as "not set".
-  if (value) {
+  if (value !== undefined && value !== '') {
     return parseFunc ? parseFunc(value) : (value as unknown as T);
   }
 

--- a/yarn-project/foundation/src/config/index.ts
+++ b/yarn-project/foundation/src/config/index.ts
@@ -12,8 +12,8 @@ export { NetworkConfigMapSchema, NetworkConfigSchema } from './network_config.js
 
 export interface ConfigMapping<T> {
   env?: EnvVar;
-  /** Parse an env-var string into `T`. May return `undefined` to signal "not set." */
-  parseEnv?: (val: string) => T | undefined;
+  /** Parse an env-var string into `T`. Throws on invalid input. */
+  parseEnv?: (val: string) => T;
   defaultValue?: T;
   printDefault?: (val: any) => string;
   description: string;
@@ -69,8 +69,8 @@ export function getValueFromEnvWithFallback<T>(
     }
   }
 
-  // Parse the value if needed
-  if (value !== undefined) {
+  // Parse the value if needed. Empty strings are treated as "not set".
+  if (value) {
     return parseFunc ? parseFunc(value) : (value as unknown as T);
   }
 

--- a/yarn-project/foundation/src/config/index.ts
+++ b/yarn-project/foundation/src/config/index.ts
@@ -12,7 +12,8 @@ export { NetworkConfigMapSchema, NetworkConfigSchema } from './network_config.js
 
 export interface ConfigMapping<T> {
   env?: EnvVar;
-  parseEnv?: (val: string) => T;
+  /** Parse an env-var string into `T`. May return `undefined` to signal "not set." */
+  parseEnv?: (val: string) => T | undefined;
   defaultValue?: T;
   printDefault?: (val: any) => string;
   description: string;
@@ -31,7 +32,7 @@ export function isBooleanConfigValue<T>(obj: T, key: keyof T): boolean {
 }
 
 export type ConfigMappingsType<T> = {
-  [K in keyof T]-?: ConfigMapping<T[K]>;
+  [K in keyof T]-?: ConfigMapping<Required<T>[K]>;
 };
 
 /**

--- a/yarn-project/p2p/src/config.ts
+++ b/yarn-project/p2p/src/config.ts
@@ -218,23 +218,23 @@ export const p2pConfigMappings: ConfigMappingsType<P2PConfig> = {
     env: 'VALIDATOR_MAX_TX_PER_BLOCK',
     description:
       'Maximum transactions per block for validation. Overrides maxTxsPerBlock for gossip validation when set.',
-    parseEnv: (val: string) => (val ? parseInt(val, 10) : undefined),
+    parseEnv: (val: string) => parseInt(val, 10),
   },
   validateMaxTxsPerCheckpoint: {
     env: 'VALIDATOR_MAX_TX_PER_CHECKPOINT',
     description:
       'Maximum transactions per checkpoint for validation. Used as fallback for maxTxsPerBlock when that is not set.',
-    parseEnv: (val: string) => (val ? parseInt(val, 10) : undefined),
+    parseEnv: (val: string) => parseInt(val, 10),
   },
   validateMaxL2BlockGas: {
     env: 'VALIDATOR_MAX_L2_BLOCK_GAS',
     description: 'Maximum L2 gas per block for validation. When set, txs exceeding this limit are rejected.',
-    parseEnv: (val: string) => (val ? parseInt(val, 10) : undefined),
+    parseEnv: (val: string) => parseInt(val, 10),
   },
   validateMaxDABlockGas: {
     env: 'VALIDATOR_MAX_DA_BLOCK_GAS',
     description: 'Maximum DA gas per block for validation. When set, txs exceeding this limit are rejected.',
-    parseEnv: (val: string) => (val ? parseInt(val, 10) : undefined),
+    parseEnv: (val: string) => parseInt(val, 10),
   },
   p2pEnabled: {
     env: 'P2P_ENABLED',
@@ -436,7 +436,7 @@ export const p2pConfigMappings: ConfigMappingsType<P2PConfig> = {
   },
   p2pStoreMapSizeKb: {
     env: 'P2P_STORE_MAP_SIZE_KB',
-    parseEnv: (val: string | undefined) => (val ? +val : undefined),
+    parseEnv: (val: string) => +val,
     description: 'The maximum possible size of the P2P DB in KB. Overwrites the general dataStoreMapSizeKb.',
   },
   txPublicSetupAllowListExtend: {

--- a/yarn-project/p2p/src/services/reqresp/config.ts
+++ b/yarn-project/p2p/src/services/reqresp/config.ts
@@ -1,4 +1,4 @@
-import { type ConfigMapping, booleanConfigHelper, numberConfigHelper } from '@aztec/foundation/config';
+import { type ConfigMappingsType, booleanConfigHelper, numberConfigHelper } from '@aztec/foundation/config';
 
 export const DEFAULT_INDIVIDUAL_REQUEST_TIMEOUT_MS = 10_000;
 export const DEFAULT_OVERALL_REQUEST_TIMEOUT_MS = 10_000; // Not currently used
@@ -27,7 +27,7 @@ export interface P2PReqRespConfig {
   dialTimeoutMs: number;
 }
 
-export const p2pReqRespConfigMappings: Record<keyof P2PReqRespConfig, ConfigMapping> = {
+export const p2pReqRespConfigMappings: ConfigMappingsType<P2PReqRespConfig> = {
   overallRequestTimeoutMs: {
     env: 'P2P_REQRESP_OVERALL_REQUEST_TIMEOUT_MS',
     description: 'The overall timeout for a request response operation.',

--- a/yarn-project/prover-client/src/proving_broker/config.ts
+++ b/yarn-project/prover-client/src/proving_broker/config.ts
@@ -73,7 +73,7 @@ export const proverBrokerConfigMappings: ConfigMappingsType<ProverBrokerConfig> 
   },
   proverBrokerStoreMapSizeKb: {
     env: 'PROVER_BROKER_STORE_MAP_SIZE_KB',
-    parseEnv: (val: string | undefined) => (val ? +val : undefined),
+    parseEnv: (val: string) => +val,
     description: "The size of the prover broker's database. Will override the dataStoreMapSizeKb if set.",
   },
   proverBrokerDebugReplayEnabled: {

--- a/yarn-project/pxe/src/config/index.ts
+++ b/yarn-project/pxe/src/config/index.ts
@@ -1,6 +1,7 @@
 import {
   type ConfigMappingsType,
   booleanConfigHelper,
+  enumConfigHelper,
   getConfigFromMappings,
   numberConfigHelper,
   parseBooleanEnv,
@@ -58,14 +59,7 @@ export const pxeConfigMappings: ConfigMappingsType<PXEConfig> = {
   syncChainTip: {
     env: 'PXE_SYNC_CHAIN_TIP',
     description: 'Which chain tip to sync to (proposed, checkpointed, proven, finalized)',
-    defaultValue: 'proposed',
-    parseEnv: (val: string) => {
-      const allowedValues = ['proposed', 'checkpointed', 'proven', 'finalized'] as const;
-      if (allowedValues.includes(val as (typeof allowedValues)[number])) {
-        return val as (typeof allowedValues)[number];
-      }
-      throw new Error(`Invalid value for PXE_SYNC_CHAIN_TIP: ${val}. Allowed values are: ${allowedValues.join(', ')}`);
-    },
+    ...enumConfigHelper(['proposed', 'checkpointed', 'proven', 'finalized'], 'proposed'),
   },
 };
 

--- a/yarn-project/pxe/src/config/index.ts
+++ b/yarn-project/pxe/src/config/index.ts
@@ -60,9 +60,9 @@ export const pxeConfigMappings: ConfigMappingsType<PXEConfig> = {
     description: 'Which chain tip to sync to (proposed, checkpointed, proven, finalized)',
     defaultValue: 'proposed',
     parseEnv: (val: string) => {
-      const allowedValues = ['proposed', 'checkpointed', 'proven', 'finalized'];
-      if (allowedValues.includes(val)) {
-        return val;
+      const allowedValues = ['proposed', 'checkpointed', 'proven', 'finalized'] as const;
+      if (allowedValues.includes(val as (typeof allowedValues)[number])) {
+        return val as (typeof allowedValues)[number];
       }
       throw new Error(`Invalid value for PXE_SYNC_CHAIN_TIP: ${val}. Allowed values are: ${allowedValues.join(', ')}`);
     },

--- a/yarn-project/sequencer-client/src/config.ts
+++ b/yarn-project/sequencer-client/src/config.ts
@@ -237,13 +237,15 @@ export const sequencerConfigMappings: ConfigMappingsType<SequencerConfig> = {
 };
 
 export const sequencerClientConfigMappings: ConfigMappingsType<SequencerClientConfig> = {
+  // chainConfigMappings must come first: its l1Contracts only maps rollupAddress,
+  // while l1ReaderConfigMappings (spread later) maps all L1 contract addresses.
+  ...chainConfigMappings,
   ...validatorClientConfigMappings,
   ...sequencerConfigMappings,
   ...keyStoreConfigMappings,
   ...l1ReaderConfigMappings,
   ...sequencerTxSenderConfigMappings,
   ...sequencerPublisherConfigMappings,
-  ...chainConfigMappings,
   ...pipelineConfigMappings,
   ...pickConfigMappings(l1ContractsConfigMappings, ['ethereumSlotDuration', 'aztecSlotDuration', 'aztecEpochDuration']),
 };

--- a/yarn-project/sequencer-client/src/config.ts
+++ b/yarn-project/sequencer-client/src/config.ts
@@ -83,7 +83,7 @@ export const sequencerConfigMappings: ConfigMappingsType<SequencerConfig> = {
   maxTxsPerCheckpoint: {
     env: 'SEQ_MAX_TX_PER_CHECKPOINT',
     description: 'The maximum number of txs across all blocks in a checkpoint.',
-    parseEnv: (val: string) => (val ? parseInt(val, 10) : undefined),
+    parseEnv: (val: string) => parseInt(val, 10),
   },
   minTxsPerBlock: {
     env: 'SEQ_MIN_TX_PER_BLOCK',
@@ -102,12 +102,12 @@ export const sequencerConfigMappings: ConfigMappingsType<SequencerConfig> = {
   maxL2BlockGas: {
     env: 'SEQ_MAX_L2_BLOCK_GAS',
     description: 'The maximum L2 block gas.',
-    parseEnv: (val: string) => (val ? parseInt(val, 10) : undefined),
+    parseEnv: (val: string) => parseInt(val, 10),
   },
   maxDABlockGas: {
     env: 'SEQ_MAX_DA_BLOCK_GAS',
     description: 'The maximum DA block gas.',
-    parseEnv: (val: string) => (val ? parseInt(val, 10) : undefined),
+    parseEnv: (val: string) => parseInt(val, 10),
   },
   perBlockAllocationMultiplier: {
     env: 'SEQ_PER_BLOCK_ALLOCATION_MULTIPLIER',
@@ -124,7 +124,7 @@ export const sequencerConfigMappings: ConfigMappingsType<SequencerConfig> = {
   },
   coinbase: {
     env: 'COINBASE',
-    parseEnv: (val: string) => (val ? EthAddress.fromString(val) : undefined),
+    parseEnv: (val: string) => EthAddress.fromString(val),
     description: 'Recipient of block reward.',
   },
   feeRecipient: {
@@ -153,7 +153,7 @@ export const sequencerConfigMappings: ConfigMappingsType<SequencerConfig> = {
   l1PublishingTime: {
     env: 'SEQ_L1_PUBLISHING_TIME_ALLOWANCE_IN_SLOT',
     description: 'How much time (in seconds) we allow in the slot for publishing the L1 tx (defaults to 1 L1 slot).',
-    parseEnv: (val: string) => (val ? parseInt(val, 10) : undefined),
+    parseEnv: (val: string) => parseInt(val, 10),
   },
   attestationPropagationTime: {
     env: 'SEQ_ATTESTATION_PROPAGATION_TIME',

--- a/yarn-project/sequencer-client/src/publisher/config.ts
+++ b/yarn-project/sequencer-client/src/publisher/config.ts
@@ -168,7 +168,7 @@ export const sequencerPublisherConfigMappings: ConfigMappingsType<SequencerPubli
   sequencerPublisherForwarderAddress: {
     env: `SEQ_PUBLISHER_FORWARDER_ADDRESS`,
     description: 'Address of the forwarder contract to wrap all L1 transactions through (for testing purposes only)',
-    parseEnv: (val: string) => (val ? EthAddress.fromString(val) : undefined),
+    parseEnv: (val: string) => EthAddress.fromString(val),
   },
   l1TxFailedStore: {
     env: 'L1_TX_FAILED_STORE',
@@ -194,7 +194,7 @@ export const proverPublisherConfigMappings: ConfigMappingsType<ProverPublisherCo
   proverPublisherForwarderAddress: {
     env: `PROVER_PUBLISHER_FORWARDER_ADDRESS`,
     description: 'Address of the forwarder contract to wrap all L1 transactions through (for testing purposes only)',
-    parseEnv: (val: string) => (val ? EthAddress.fromString(val) : undefined),
+    parseEnv: (val: string) => EthAddress.fromString(val),
   },
   ...publisherFundingConfigMappings,
 };

--- a/yarn-project/sequencer-client/src/publisher/config.ts
+++ b/yarn-project/sequencer-client/src/publisher/config.ts
@@ -120,7 +120,8 @@ export const proverTxSenderConfigMappings: ConfigMappingsType<Omit<ProverTxSende
   proverPublisherPrivateKeys: {
     env: `PROVER_PUBLISHER_PRIVATE_KEYS`,
     description: 'The private keys to be used by the prover publisher.',
-    parseEnv: (val: string) => val.split(',').map(key => new SecretValue(`0x${key.replace('0x', '')}`)),
+    parseEnv: (val: string) =>
+      val.split(',').map(key => new SecretValue(`0x${key.replace('0x', '')}` as `0x${string}`)),
     defaultValue: [],
     fallback: [`PROVER_PUBLISHER_PRIVATE_KEY`],
   },
@@ -137,7 +138,8 @@ export const sequencerTxSenderConfigMappings: ConfigMappingsType<Omit<SequencerT
   sequencerPublisherPrivateKeys: {
     env: `SEQ_PUBLISHER_PRIVATE_KEYS`,
     description: 'The private keys to be used by the sequencer publisher.',
-    parseEnv: (val: string) => val.split(',').map(key => new SecretValue(`0x${key.replace('0x', '')}`)),
+    parseEnv: (val: string) =>
+      val.split(',').map(key => new SecretValue(`0x${key.replace('0x', '')}` as `0x${string}`)),
     defaultValue: [],
     fallback: [`SEQ_PUBLISHER_PRIVATE_KEY`],
   },

--- a/yarn-project/slasher/src/config.ts
+++ b/yarn-project/slasher/src/config.ts
@@ -40,7 +40,7 @@ export const slasherConfigMappings: ConfigMappingsType<SlasherConfig> = {
   slashOverridePayload: {
     env: 'SLASH_OVERRIDE_PAYLOAD',
     description: 'An Ethereum address for a slash payload to vote for unconditionally.',
-    parseEnv: (val: string) => (val ? EthAddress.fromString(val) : undefined),
+    parseEnv: (val: string) => EthAddress.fromString(val),
     defaultValue: DefaultSlasherConfig.slashOverridePayload,
   },
   slashMinPenaltyPercentage: {

--- a/yarn-project/stdlib/src/config/chain-config.ts
+++ b/yarn-project/stdlib/src/config/chain-config.ts
@@ -21,7 +21,13 @@ export const chainConfigMappings: ConfigMappingsType<ChainConfig> = {
   rollupVersion: {
     env: 'ROLLUP_VERSION',
     description: 'The version of the rollup.',
-    parseEnv: (val: string) => (Number.isSafeInteger(parseInt(val, 10)) ? parseInt(val, 10) : undefined),
+    parseEnv: (val: string) => {
+      const parsed = parseInt(val, 10);
+      if (!Number.isSafeInteger(parsed)) {
+        throw new Error(`Invalid rollup version: ${val}`);
+      }
+      return parsed;
+    },
   },
   l1Contracts: {
     description: 'The deployed L1 contract addresses',

--- a/yarn-project/stdlib/src/config/sequencer-config.ts
+++ b/yarn-project/stdlib/src/config/sequencer-config.ts
@@ -19,19 +19,19 @@ export const sharedSequencerConfigMappings: ConfigMappingsType<
     description:
       'Duration per block in milliseconds when building multiple blocks per slot. ' +
       'If undefined (default), builds a single block per slot using the full slot duration.',
-    parseEnv: (val: string) => (val ? parseInt(val, 10) : undefined),
+    parseEnv: (val: string) => parseInt(val, 10),
   },
   expectedBlockProposalsPerSlot: {
     env: 'SEQ_EXPECTED_BLOCK_PROPOSALS_PER_SLOT',
     description:
       'Expected number of block proposals per slot for P2P peer scoring. ' +
       '0 (default) disables block proposal scoring. Set to a positive value to enable.',
-    parseEnv: (val: string) => (val ? parseInt(val, 10) : 0),
+    parseEnv: (val: string) => parseInt(val, 10),
     defaultValue: 0,
   },
   maxTxsPerBlock: {
     env: 'SEQ_MAX_TX_PER_BLOCK',
     description: 'The maximum number of txs to include in a block.',
-    parseEnv: (val: string) => (val ? parseInt(val, 10) : undefined),
+    parseEnv: (val: string) => parseInt(val, 10),
   },
 };

--- a/yarn-project/stdlib/src/ha-signing/local_config.ts
+++ b/yarn-project/stdlib/src/ha-signing/local_config.ts
@@ -26,7 +26,7 @@ export const localSignerConfigMappings: ConfigMappingsType<LocalSignerConfig> = 
     env: 'SIGNING_PROTECTION_MAP_SIZE_KB',
     description:
       'Maximum size of the local signing-protection LMDB store in KB. Overwrites the general dataStoreMapSizeKb.',
-    parseEnv: (val: string | undefined) => (val ? +val : undefined),
+    parseEnv: (val: string) => +val,
   },
 };
 

--- a/yarn-project/stdlib/src/interfaces/prover-client.ts
+++ b/yarn-project/stdlib/src/interfaces/prover-client.ts
@@ -71,7 +71,7 @@ export const proverConfigMappings: ConfigMappingsType<ProverConfig> = {
   },
   proverId: {
     env: 'PROVER_ID',
-    parseEnv: (val?: string) => parseProverId(val),
+    parseEnv: (val: string) => parseProverId(val),
     description: 'Hex value that identifies the prover. Defaults to the address used for submitting proofs if not set.',
   },
   proverTestDelayType: {
@@ -117,10 +117,7 @@ export const proverConfigMappings: ConfigMappingsType<ProverConfig> = {
   },
 };
 
-function parseProverId(str?: string) {
-  if (!str) {
-    return undefined;
-  }
+function parseProverId(str: string) {
   return EthAddress.fromString(str);
 }
 

--- a/yarn-project/telemetry-client/src/config.ts
+++ b/yarn-project/telemetry-client/src/config.ts
@@ -18,17 +18,17 @@ export const telemetryClientConfigMappings: ConfigMappingsType<TelemetryClientCo
   metricsCollectorUrl: {
     env: 'OTEL_EXPORTER_OTLP_METRICS_ENDPOINT',
     description: 'The URL of the telemetry collector for metrics',
-    parseEnv: (val: string) => val && new URL(val),
+    parseEnv: (val: string) => (val ? new URL(val) : undefined),
   },
   tracesCollectorUrl: {
     env: 'OTEL_EXPORTER_OTLP_TRACES_ENDPOINT',
     description: 'The URL of the telemetry collector for traces',
-    parseEnv: (val: string) => val && new URL(val),
+    parseEnv: (val: string) => (val ? new URL(val) : undefined),
   },
   logsCollectorUrl: {
     env: 'OTEL_EXPORTER_OTLP_LOGS_ENDPOINT',
     description: 'The URL of the telemetry collector for logs',
-    parseEnv: (val: string) => val && new URL(val),
+    parseEnv: (val: string) => (val ? new URL(val) : undefined),
   },
   otelCollectIntervalMs: {
     env: 'OTEL_COLLECT_INTERVAL_MS',
@@ -70,7 +70,7 @@ export const telemetryClientConfigMappings: ConfigMappingsType<TelemetryClientCo
   publicMetricsCollectorUrl: {
     env: 'PUBLIC_OTEL_EXPORTER_OTLP_METRICS_ENDPOINT',
     description: 'A URL to publish a subset of metrics for public consumption',
-    parseEnv: (val: string) => val && new URL(val),
+    parseEnv: (val: string) => (val ? new URL(val) : undefined),
   },
   publicMetricsCollectFrom: {
     env: 'PUBLIC_OTEL_COLLECT_FROM',

--- a/yarn-project/telemetry-client/src/config.ts
+++ b/yarn-project/telemetry-client/src/config.ts
@@ -18,17 +18,17 @@ export const telemetryClientConfigMappings: ConfigMappingsType<TelemetryClientCo
   metricsCollectorUrl: {
     env: 'OTEL_EXPORTER_OTLP_METRICS_ENDPOINT',
     description: 'The URL of the telemetry collector for metrics',
-    parseEnv: (val: string) => (val ? new URL(val) : undefined),
+    parseEnv: (val: string) => new URL(val),
   },
   tracesCollectorUrl: {
     env: 'OTEL_EXPORTER_OTLP_TRACES_ENDPOINT',
     description: 'The URL of the telemetry collector for traces',
-    parseEnv: (val: string) => (val ? new URL(val) : undefined),
+    parseEnv: (val: string) => new URL(val),
   },
   logsCollectorUrl: {
     env: 'OTEL_EXPORTER_OTLP_LOGS_ENDPOINT',
     description: 'The URL of the telemetry collector for logs',
-    parseEnv: (val: string) => (val ? new URL(val) : undefined),
+    parseEnv: (val: string) => new URL(val),
   },
   otelCollectIntervalMs: {
     env: 'OTEL_COLLECT_INTERVAL_MS',
@@ -70,7 +70,7 @@ export const telemetryClientConfigMappings: ConfigMappingsType<TelemetryClientCo
   publicMetricsCollectorUrl: {
     env: 'PUBLIC_OTEL_EXPORTER_OTLP_METRICS_ENDPOINT',
     description: 'A URL to publish a subset of metrics for public consumption',
-    parseEnv: (val: string) => (val ? new URL(val) : undefined),
+    parseEnv: (val: string) => new URL(val),
   },
   publicMetricsCollectFrom: {
     env: 'PUBLIC_OTEL_COLLECT_FROM',

--- a/yarn-project/validator-client/src/config.ts
+++ b/yarn-project/validator-client/src/config.ts
@@ -75,22 +75,22 @@ export const validatorClientConfigMappings: ConfigMappingsType<ValidatorClientCo
   validateMaxL2BlockGas: {
     env: 'VALIDATOR_MAX_L2_BLOCK_GAS',
     description: 'Maximum L2 block gas for validation. Proposals exceeding this limit are rejected.',
-    parseEnv: (val: string) => (val ? parseInt(val, 10) : undefined),
+    parseEnv: (val: string) => parseInt(val, 10),
   },
   validateMaxDABlockGas: {
     env: 'VALIDATOR_MAX_DA_BLOCK_GAS',
     description: 'Maximum DA block gas for validation. Proposals exceeding this limit are rejected.',
-    parseEnv: (val: string) => (val ? parseInt(val, 10) : undefined),
+    parseEnv: (val: string) => parseInt(val, 10),
   },
   validateMaxTxsPerBlock: {
     env: 'VALIDATOR_MAX_TX_PER_BLOCK',
     description: 'Maximum transactions per block for validation. Proposals exceeding this limit are rejected.',
-    parseEnv: (val: string) => (val ? parseInt(val, 10) : undefined),
+    parseEnv: (val: string) => parseInt(val, 10),
   },
   validateMaxTxsPerCheckpoint: {
     env: 'VALIDATOR_MAX_TX_PER_CHECKPOINT',
     description: 'Maximum transactions per checkpoint for validation. Proposals exceeding this limit are rejected.',
-    parseEnv: (val: string) => (val ? parseInt(val, 10) : undefined),
+    parseEnv: (val: string) => parseInt(val, 10),
   },
   ...localSignerConfigMappings,
   ...validatorHASignerConfigMappings,

--- a/yarn-project/world-state/src/synchronizer/config.ts
+++ b/yarn-project/world-state/src/synchronizer/config.ts
@@ -42,41 +42,41 @@ export const worldStateConfigMappings: ConfigMappingsType<WorldStateConfig> = {
   },
   worldStateBlockRequestBatchSize: {
     env: 'WS_BLOCK_REQUEST_BATCH_SIZE',
-    parseEnv: (val: string | undefined) => (val ? +val : undefined),
+    parseEnv: (val: string) => +val,
     description: 'Size of the batch for each get-blocks request from the synchronizer to the archiver.',
   },
   worldStateDbMapSizeKb: {
     env: 'WS_DB_MAP_SIZE_KB',
-    parseEnv: (val: string | undefined) => (val ? +val : undefined),
+    parseEnv: (val: string) => +val,
     description: 'The maximum possible size of the world state DB in KB. Overwrites the general dataStoreMapSizeKb.',
   },
   archiveTreeMapSizeKb: {
     env: 'ARCHIVE_TREE_MAP_SIZE_KB',
-    parseEnv: (val: string | undefined) => (val ? +val : undefined),
+    parseEnv: (val: string) => +val,
     description:
       'The maximum possible size of the world state archive tree in KB. Overwrites the general worldStateDbMapSizeKb.',
   },
   nullifierTreeMapSizeKb: {
     env: 'NULLIFIER_TREE_MAP_SIZE_KB',
-    parseEnv: (val: string | undefined) => (val ? +val : undefined),
+    parseEnv: (val: string) => +val,
     description:
       'The maximum possible size of the world state nullifier tree in KB. Overwrites the general worldStateDbMapSizeKb.',
   },
   noteHashTreeMapSizeKb: {
     env: 'NOTE_HASH_TREE_MAP_SIZE_KB',
-    parseEnv: (val: string | undefined) => (val ? +val : undefined),
+    parseEnv: (val: string) => +val,
     description:
       'The maximum possible size of the world state note hash tree in KB. Overwrites the general worldStateDbMapSizeKb.',
   },
   messageTreeMapSizeKb: {
     env: 'MESSAGE_TREE_MAP_SIZE_KB',
-    parseEnv: (val: string | undefined) => (val ? +val : undefined),
+    parseEnv: (val: string) => +val,
     description:
       'The maximum possible size of the world state message tree in KB. Overwrites the general worldStateDbMapSizeKb.',
   },
   publicDataTreeMapSizeKb: {
     env: 'PUBLIC_DATA_TREE_MAP_SIZE_KB',
-    parseEnv: (val: string | undefined) => (val ? +val : undefined),
+    parseEnv: (val: string) => +val,
     description:
       'The maximum possible size of the world state public data tree in KB. Overwrites the general worldStateDbMapSizeKb.',
   },


### PR DESCRIPTION
Ref: A-175

  - Add type parameter to `ConfigMapping<T> `                                                                                               
  - Replace `ConfigMappingsType<T> = Record<keyof T, ConfigMapping<any>>` with a per-key mapped type: `{ [K in keyof T]-?: ConfigMapping<Required<T>[K]> }`
  - `parseEnv` must return T or throw — empty strings are treated as "not set" before `parseEnv` is called                                                                                  
  - Fix spread ordering bug in `sequencerClientConfigMappings` where narrow `l1Contracts` from `chainConfigMappings` was overwriting the full set from `l1ReaderConfigMappings`