### PR TITLE
chore: misc hash gadget updates 

### DIFF
--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_null_deref.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_null_deref.test.cpp
@@ -1,0 +1,185 @@
+/**
+ * @file acir_null_deref.test.cpp
+ * @brief Exploit and fix tests for null shared_ptr dereference in ACIR deserialization.
+ *
+ * Demonstrates that crafted ACIR bytecode containing msgpack NIL values for
+ * shared_ptr<array<T,N>> fields would produce a null pointer dereference in
+ * acir_to_constraint_buf.cpp, and that the fix (rejecting NIL in conv_fld_from_kvmap
+ * and conv_fld_from_array) prevents the crash.
+ *
+ * Attack vector: An attacker crafts raw ACIR bytecode (bypassing the Noir compiler)
+ * containing a BlackBoxFuncCall opcode where a fixed-size array field is encoded as
+ * msgpack NIL (0xc0). Without the fix, the AztecProtocol/msgpack-c fork silently
+ * converts NIL to a null shared_ptr, which is then dereferenced unconditionally.
+ * With the fix, deserialization rejects NIL for required fields and throws.
+ */
+
+#include <gtest/gtest.h>
+#include <memory>
+#include <regex>
+#include <vector>
+
+#include "acir_to_constraint_buf.hpp"
+#include "barretenberg/common/assert.hpp"
+#include "barretenberg/serialize/msgpack_impl.hpp"
+#include "serde/acir.hpp"
+
+using namespace acir_format;
+
+class AcirNullDerefTest : public ::testing::Test {};
+
+/**
+ * Helper: build a ProgramWithoutBrillig wire format by manually packing with msgpack.
+ * We can't use ProgramWithoutBrillig::msgpack_pack because std::monostate lacks a pack adaptor.
+ * Instead, we pack the structure by hand: ARRAY[ARRAY[circuit], NIL].
+ */
+static std::vector<uint8_t> serialize_program_with_circuit(const Acir::Circuit& circuit)
+{
+    msgpack::sbuffer sbuf;
+    msgpack::packer<msgpack::sbuffer> packer(sbuf);
+
+    // ProgramWithoutBrillig = ARRAY[functions, unconstrained_functions]
+    packer.pack_array(2);
+
+    // functions = ARRAY[circuit]
+    packer.pack_array(1);
+    packer.pack(circuit);
+
+    // unconstrained_functions = NIL (std::monostate — ignored by ProgramWithoutBrillig::msgpack_unpack)
+    packer.pack_nil();
+
+    // Prepend format marker 0x03 (FORMAT_MSGPACK_COMPACT)
+    std::vector<uint8_t> buf;
+    buf.reserve(1 + sbuf.size());
+    buf.push_back(0x03);
+    buf.insert(buf.end(), sbuf.data(), sbuf.data() + sbuf.size());
+    return buf;
+}
+
+// ============================================================================
+// Exploit tests: These construct null shared_ptr directly in the struct,
+// bypassing deserialization. They prove the dereference sites are unguarded.
+// ============================================================================
+
+TEST_F(AcirNullDerefTest, AES128Encrypt_NullIV_DirectCircuit_Crashes)
+{
+    Acir::BlackBoxFuncCall::AES128Encrypt aes_op{
+        .inputs = {},
+        .iv = nullptr,
+        .key = nullptr,
+        .outputs = {},
+    };
+
+    Acir::BlackBoxFuncCall bbfc;
+    bbfc.value = aes_op;
+
+    Acir::Circuit circuit{
+        .opcodes = { Acir::Opcode{ Acir::Opcode::BlackBoxFuncCall{ .value = bbfc } } },
+        .public_parameters = {},
+        .return_values = {},
+    };
+
+    // Dereferences nullptr at acir_to_constraint_buf.cpp:636: *arg.iv
+    EXPECT_DEATH(circuit_serde_to_acir_format(circuit), "");
+}
+
+TEST_F(AcirNullDerefTest, Keccakf1600_NullInputs_DirectCircuit_Crashes)
+{
+    Acir::BlackBoxFuncCall::Keccakf1600 keccak_op{
+        .inputs = nullptr,
+        .outputs = nullptr,
+    };
+
+    Acir::BlackBoxFuncCall bbfc;
+    bbfc.value = keccak_op;
+
+    Acir::Circuit circuit{
+        .opcodes = { Acir::Opcode{ Acir::Opcode::BlackBoxFuncCall{ .value = bbfc } } },
+        .public_parameters = {},
+        .return_values = {},
+    };
+
+    // Dereferences nullptr at acir_to_constraint_buf.cpp:716: *arg.inputs
+    EXPECT_DEATH(circuit_serde_to_acir_format(circuit), "");
+}
+
+TEST_F(AcirNullDerefTest, Sha256Compression_NullInputs_DirectCircuit_Crashes)
+{
+    Acir::BlackBoxFuncCall::Sha256Compression sha_op{
+        .inputs = nullptr,
+        .hash_values = nullptr,
+        .outputs = nullptr,
+    };
+
+    Acir::BlackBoxFuncCall bbfc;
+    bbfc.value = sha_op;
+
+    Acir::Circuit circuit{
+        .opcodes = { Acir::Opcode{ Acir::Opcode::BlackBoxFuncCall{ .value = bbfc } } },
+        .public_parameters = {},
+        .return_values = {},
+    };
+
+    // Dereferences nullptr at acir_to_constraint_buf.cpp:644: *arg.inputs
+    EXPECT_DEATH(circuit_serde_to_acir_format(circuit), "");
+}
+
+// ============================================================================
+// Fix tests: These go through the deserialization path (raw bytes or msgpack
+// roundtrip). The fix in conv_fld_from_array rejects NIL before it can become
+// a null shared_ptr, throwing instead of crashing.
+// ============================================================================
+
+TEST_F(AcirNullDerefTest, AES128Encrypt_NullIV_FromBytes_ThrowsAfterFix)
+{
+    Acir::BlackBoxFuncCall::AES128Encrypt aes_op{
+        .inputs = {},
+        .iv = nullptr, // Serialized as NIL (0xc0)
+        .key = nullptr,
+        .outputs = {},
+    };
+
+    Acir::BlackBoxFuncCall bbfc;
+    bbfc.value = aes_op;
+
+    Acir::Circuit circuit{
+        .opcodes = { Acir::Opcode{ Acir::Opcode::BlackBoxFuncCall{ .value = bbfc } } },
+        .public_parameters = {},
+        .return_values = {},
+    };
+
+    auto buf = serialize_program_with_circuit(circuit);
+
+    // Verify the buffer contains NIL byte (0xc0) from the null shared_ptr
+    size_t nil_count = 0;
+    for (uint8_t b : buf) {
+        if (b == 0xc0) {
+            nil_count++;
+        }
+    }
+    ASSERT_GE(nil_count, 2U) << "Buffer must contain at least 2 NIL (0xc0) bytes for null iv and key";
+
+    // After fix: deserialization rejects NIL for required fields → throws instead of SIGSEGV
+    EXPECT_THROW_WITH_MESSAGE(circuit_buf_to_acir_format(std::move(buf)), "nil value for required field");
+}
+
+TEST_F(AcirNullDerefTest, NullSharedPtr_RejectedByMsgpackRoundtrip)
+{
+    // After the fix, a null shared_ptr encoded as NIL is rejected during deserialization.
+    // conv_fld_from_array detects NIL at the array slot and throws before converting.
+    Acir::BlackBoxFuncCall::AES128Encrypt original{
+        .inputs = {},
+        .iv = nullptr,
+        .key = nullptr,
+        .outputs = {},
+    };
+
+    // Serialize (null shared_ptr → NIL byte 0xc0)
+    msgpack::sbuffer sbuf;
+    msgpack::pack(sbuf, original);
+
+    // Deserialize — should throw because iv slot is NIL
+    auto oh = msgpack::unpack(sbuf.data(), sbuf.size());
+    Acir::BlackBoxFuncCall::AES128Encrypt deserialized;
+    EXPECT_THROW_WITH_MESSAGE(oh.get().convert(deserialized), "nil value for required field");
+}

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/serde/acir.hpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/serde/acir.hpp
@@ -32,6 +32,9 @@ struct Helpers {
     {
         auto it = kvmap.find(field_name);
         if (it != kvmap.end()) {
+            if (!is_optional && it->second->type == msgpack::type::NIL) {
+                throw_or_abort("nil value for required field: " + struct_name + "::" + field_name);
+            }
             try {
                 it->second->convert(field);
             } catch (const msgpack::type_error&) {
@@ -54,6 +57,9 @@ struct Helpers {
             throw_or_abort("index out of bounds: " + struct_name + "::" + field_name + " at " + std::to_string(index));
         }
         auto element = array.ptr[index];
+        if (element.type == msgpack::type::NIL) {
+            throw_or_abort("nil value for required field: " + struct_name + "::" + field_name);
+        }
         try {
             element.convert(field);
         } catch (const msgpack::type_error&) {

--- a/barretenberg/cpp/src/barretenberg/ecc/groups/wnaf.hpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/groups/wnaf.hpp
@@ -87,18 +87,18 @@ template <size_t bits, size_t bit_position> inline uint64_t get_wnaf_bits_const(
  */
 inline uint64_t get_wnaf_bits(const uint64_t* scalar, const uint64_t bits, const uint64_t bit_position) noexcept
 {
-
     const auto lo_limb_idx = static_cast<size_t>(bit_position >> 6);
     const auto hi_limb_idx = static_cast<size_t>((bit_position + bits - 1) >> 6);
     const uint64_t lo_shift = bit_position & 63UL;
     const uint64_t bit_mask = (1UL << static_cast<uint64_t>(bits)) - 1UL;
+    const bool spans_limbs = (lo_limb_idx != hi_limb_idx);
 
-    const uint64_t lo = (scalar[lo_limb_idx] >> lo_shift);
-    const uint64_t hi_shift = bit_position ? 64UL - (bit_position & 63UL) : 0;
-    const uint64_t hi = ((scalar[hi_limb_idx] << (hi_shift)));
-    const uint64_t hi_mask = bit_mask & (0ULL - (lo_limb_idx != hi_limb_idx));
+    const uint64_t lo = scalar[lo_limb_idx] >> lo_shift;
+    // spans_limbs is true only when bit_position is not aligned to a limb boundary, so lo_shift > 0
+    // and 64 - lo_shift ∈ [1, 63]. (If lo_shift were 0, 64 - lo_shift = 64 would be UB on uint64_t.)
+    const uint64_t hi = spans_limbs ? (scalar[hi_limb_idx] << (64UL - lo_shift)) : 0UL;
 
-    return (lo & bit_mask) | (hi & hi_mask);
+    return (lo | hi) & bit_mask;
 }
 
 /**

--- a/barretenberg/cpp/src/barretenberg/numeric/uintx/uintx.hpp
+++ b/barretenberg/cpp/src/barretenberg/numeric/uintx/uintx.hpp
@@ -271,7 +271,13 @@ template <class base_uint> class uintx {
     base_uint lo;
     base_uint hi;
 
-    template <base_uint modulus> std::pair<uintx, uintx> barrett_reduction() const;
+    // `modulus` is passed as a pointer NTTP rather than a class-type value NTTP. The latter
+    // would cause Clang to materialize a template parameter object in `.rodata` at the section's
+    // natural alignment (16 bytes), which under-aligns an `alignas(32)` type and is UB under
+    // UBSan's alignment check. A pointer NTTP has no synthesized storage; it just names an
+    // existing static object, whose `alignas(32)` is honored normally. We therefore pass `&X` where `X` is a named
+    // `static constexpr base_uint` (see uses in `divmod`).
+    template <const base_uint* modulus_ptr> std::pair<uintx, uintx> barrett_reduction() const;
 
     // This only works (and is only used) for uint256_t
     std::pair<uintx, uintx> divmod(const uintx& b) const;
@@ -306,6 +312,10 @@ extern template class uintx<uint256_t>;
 using uint512_t = uintx<uint256_t>;
 extern template class uintx<uint512_t>;
 using uint1024_t = uintx<uint512_t>;
+
+// Pin the [class.mem]/19 alignment-propagation rule: uintx<uint256_t> must inherit alignas(32).
+static_assert(alignof(uint512_t) >= 32);
+static_assert(alignof(uint1024_t) >= 32);
 
 } // namespace bb::numeric
 

--- a/barretenberg/cpp/src/barretenberg/numeric/uintx/uintx.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/numeric/uintx/uintx.test.cpp
@@ -8,9 +8,10 @@ using namespace bb;
 
 // Explicit instantiation of barrett_reduction for the test-only 1024-bit modulus.
 namespace bb::numeric {
-constexpr uint512_t TEST_MODULUS(uint256_t{ "0x04689e957a1242c84a50189c6d96cadca602072d09eac1013b5458a2275d69b1" },
-                                 uint256_t{ "0x0925c4b8763cbf9c599a6f7c0348d21cb00b85511637560626edfa5c34c6b38d" });
-template std::pair<uint1024_t, uint1024_t> uintx<uint512_t>::barrett_reduction<TEST_MODULUS>() const;
+static constexpr uint512_t TEST_MODULUS(
+    uint256_t{ "0x04689e957a1242c84a50189c6d96cadca602072d09eac1013b5458a2275d69b1" },
+    uint256_t{ "0x0925c4b8763cbf9c599a6f7c0348d21cb00b85511637560626edfa5c34c6b38d" });
+template std::pair<uint1024_t, uint1024_t> uintx<uint512_t>::barrett_reduction<&TEST_MODULUS>() const;
 } // namespace bb::numeric
 
 namespace {
@@ -25,9 +26,9 @@ TEST(uintx, BarrettReduction512)
     static constexpr uint64_t modulus_1 = 0x97816a916871ca8dUL;
     static constexpr uint64_t modulus_2 = 0xb85045b68181585dUL;
     static constexpr uint64_t modulus_3 = 0x30644e72e131a029UL;
-    constexpr uint256_t modulus(modulus_0, modulus_1, modulus_2, modulus_3);
+    static constexpr uint256_t modulus(modulus_0, modulus_1, modulus_2, modulus_3);
 
-    const auto [quotient_result, remainder_result] = x.barrett_reduction<modulus>();
+    const auto [quotient_result, remainder_result] = x.barrett_reduction<&modulus>();
     const auto [quotient_expected, remainder_expected] = x.divmod_base(uint512_t(modulus));
     EXPECT_EQ(quotient_result, quotient_expected);
     EXPECT_EQ(remainder_result, remainder_expected);
@@ -37,11 +38,11 @@ TEST(uintx, BarrettReduction1024)
 {
     uint1024_t x = engine.get_random_uint1024();
 
-    constexpr uint256_t modulus_lo{ "0x04689e957a1242c84a50189c6d96cadca602072d09eac1013b5458a2275d69b1" };
-    constexpr uint256_t modulus_hi{ "0x0925c4b8763cbf9c599a6f7c0348d21cb00b85511637560626edfa5c34c6b38d" };
-    constexpr uint512_t modulus{ modulus_lo, modulus_hi };
+    static constexpr uint256_t modulus_lo{ "0x04689e957a1242c84a50189c6d96cadca602072d09eac1013b5458a2275d69b1" };
+    static constexpr uint256_t modulus_hi{ "0x0925c4b8763cbf9c599a6f7c0348d21cb00b85511637560626edfa5c34c6b38d" };
+    static constexpr uint512_t modulus{ modulus_lo, modulus_hi };
 
-    const auto [quotient_result, remainder_result] = x.barrett_reduction<modulus>();
+    const auto [quotient_result, remainder_result] = x.barrett_reduction<&modulus>();
     const auto [quotient_expected, remainder_expected] = x.divmod_base(uint1024_t(modulus));
     EXPECT_EQ(quotient_result, quotient_expected);
     EXPECT_EQ(remainder_result, remainder_expected);
@@ -336,14 +337,14 @@ TEST(uintx, Slice)
 TEST(uintx, BarrettReductionRegression)
 {
     // Test specific modulus and self values that may cause issues
-    constexpr uint256_t modulus{ "0xffffffff00000001000000000000000000000000ffffffffffffffffffffffff" };
+    static constexpr uint256_t modulus{ "0xffffffff00000001000000000000000000000000ffffffffffffffffffffffff" };
 
     // Test case 1: self = 0xffffffff0000000000000000000000000000000000000000003a000000000000
     // This is a 256-bit value, so we need to construct it as a single uint256_t
     constexpr uint256_t self_value{ "0xffffffff0000000000000000000000000000000000000000003a000000000000" };
     uint512_t self(self_value);
     self = self << 256;
-    const auto [quotient_result, remainder_result] = self.barrett_reduction<modulus>();
+    const auto [quotient_result, remainder_result] = self.barrett_reduction<&modulus>();
     const auto [quotient_expected, remainder_expected] = self.divmod_base(uint512_t(modulus));
     EXPECT_EQ(quotient_result, quotient_expected);
     EXPECT_EQ(remainder_result, remainder_expected);

--- a/barretenberg/cpp/src/barretenberg/numeric/uintx/uintx_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/numeric/uintx/uintx_impl.hpp
@@ -236,21 +236,26 @@ template <class base_uint> bool uintx<base_uint>::operator<=(const uintx& other)
 template <class base_uint> std::pair<uintx<base_uint>, uintx<base_uint>> uintx<base_uint>::divmod(const uintx& b) const
 
 {
-    constexpr uint256_t BN254FQMODULUS256 =
-        uint256_t(0x3C208C16D87CFD47UL, 0x97816a916871ca8dUL, 0xb85045b68181585dUL, 0x30644e72e131a029UL);
-    constexpr uint256_t SECP256K1FQMODULUS256 =
-        uint256_t(0xFFFFFFFEFFFFFC2FULL, 0xFFFFFFFFFFFFFFFFULL, 0xFFFFFFFFFFFFFFFFULL, 0xFFFFFFFFFFFFFFFFULL);
-    constexpr uint256_t SECP256R1FQMODULUS256 =
-        uint256_t(0xFFFFFFFFFFFFFFFFULL, 0x00000000FFFFFFFFULL, 0x0000000000000000ULL, 0xFFFFFFFF00000001ULL);
+    // Barrett-reduction fast paths apply only when base_uint == uint256_t; for larger uintx
+    // instantiations a 256-bit `b` can never equal a 1024-bit-or-wider dividend's modulus.
+    if constexpr (std::is_same_v<base_uint, uint256_t>) {
+        // `static` is required so that `&X` below is a valid pointer NTTP for barrett_reduction.
+        static constexpr uint256_t BN254FQMODULUS256 =
+            uint256_t(0x3C208C16D87CFD47UL, 0x97816a916871ca8dUL, 0xb85045b68181585dUL, 0x30644e72e131a029UL);
+        static constexpr uint256_t SECP256K1FQMODULUS256 =
+            uint256_t(0xFFFFFFFEFFFFFC2FULL, 0xFFFFFFFFFFFFFFFFULL, 0xFFFFFFFFFFFFFFFFULL, 0xFFFFFFFFFFFFFFFFULL);
+        static constexpr uint256_t SECP256R1FQMODULUS256 =
+            uint256_t(0xFFFFFFFFFFFFFFFFULL, 0x00000000FFFFFFFFULL, 0x0000000000000000ULL, 0xFFFFFFFF00000001ULL);
 
-    if (b == uintx(BN254FQMODULUS256)) {
-        return (*this).template barrett_reduction<BN254FQMODULUS256>();
-    }
-    if (b == uintx(SECP256K1FQMODULUS256)) {
-        return (*this).template barrett_reduction<SECP256K1FQMODULUS256>();
-    }
-    if (b == uintx(SECP256R1FQMODULUS256)) {
-        return (*this).template barrett_reduction<SECP256R1FQMODULUS256>();
+        if (b == uintx(BN254FQMODULUS256)) {
+            return (*this).template barrett_reduction<&BN254FQMODULUS256>();
+        }
+        if (b == uintx(SECP256K1FQMODULUS256)) {
+            return (*this).template barrett_reduction<&SECP256K1FQMODULUS256>();
+        }
+        if (b == uintx(SECP256R1FQMODULUS256)) {
+            return (*this).template barrett_reduction<&SECP256R1FQMODULUS256>();
+        }
     }
 
     return divmod_base(b);
@@ -268,9 +273,11 @@ template <class base_uint> std::pair<uintx<base_uint>, uintx<base_uint>> uintx<b
  * @return std::pair<uintx<base_uint>, uintx<base_uint>>
  */
 template <class base_uint>
-template <base_uint modulus>
+template <const base_uint* modulus_ptr>
 std::pair<uintx<base_uint>, uintx<base_uint>> uintx<base_uint>::barrett_reduction() const
 {
+    const base_uint& modulus = *modulus_ptr;
+
     // N.B. k could be modulus.get_msb() + 1 if we have strong bounds on the max value of (*self)
     //      (a smaller k would allow us to fit `redc_parameter` into `base_uint` and not `uintx`)
     constexpr size_t k = base_uint::length() - 1;

--- a/barretenberg/cpp/src/barretenberg/stdlib/encryption/aes128/aes128.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/encryption/aes128/aes128.test.cpp
@@ -3,26 +3,34 @@
 #include "barretenberg/crypto/aes128/aes128.hpp"
 #include "barretenberg/numeric/bitop/sparse_form.hpp"
 #include "barretenberg/stdlib/primitives/plookup/plookup.hpp"
+#include "barretenberg/stdlib_circuit_builders/mega_circuit_builder.hpp"
 #include "barretenberg/stdlib_circuit_builders/ultra_circuit_builder.hpp"
 
 #include <gtest/gtest.h>
 
 using namespace bb;
 
+// ============================================================================
+// Gadget tests — exercised against both UltraCircuitBuilder and MegaCircuitBuilder
+// ============================================================================
+
+template <class Builder> class StdlibAes128 : public ::testing::Test {};
+
+using BuilderTypes = ::testing::Types<bb::UltraCircuitBuilder, bb::MegaCircuitBuilder>;
+TYPED_TEST_SUITE(StdlibAes128, BuilderTypes);
+
 // Helper function to create field element as either constant or witness
-stdlib::field_t<UltraCircuitBuilder> create_field_element(UltraCircuitBuilder& builder,
-                                                          const uint256_t& value,
-                                                          bool as_witness)
+template <class Builder>
+stdlib::field_t<Builder> create_field_element(Builder& builder, const uint256_t& value, bool as_witness)
 {
     if (as_witness) {
-        return stdlib::field_t<UltraCircuitBuilder>(stdlib::witness_t(&builder, fr(value)));
-    } else {
-        return stdlib::field_t<UltraCircuitBuilder>(value);
+        return stdlib::field_t<Builder>(stdlib::witness_t<Builder>(&builder, fr(value)));
     }
+    return stdlib::field_t<Builder>(value);
 }
 
 // Helper function to convert byte array to uint256_t
-uint256_t convert_bytes_to_uint256(const uint8_t* data)
+static uint256_t convert_bytes_to_uint256(const uint8_t* data)
 {
     uint256_t converted(0);
     for (uint64_t i = 0; i < 16; ++i) {
@@ -33,9 +41,9 @@ uint256_t convert_bytes_to_uint256(const uint8_t* data)
 }
 
 // Test function for a specific combination of witness/constant inputs
-void test_aes128_combination(bool key_as_witness, bool iv_as_witness, bool input_as_witness)
+template <class Builder> void test_aes128_combination(bool key_as_witness, bool iv_as_witness, bool input_as_witness)
 {
-    typedef stdlib::field_t<UltraCircuitBuilder> field_pt;
+    using field_pt = stdlib::field_t<Builder>;
 
     uint8_t key[16]{ 0x2b, 0x7e, 0x15, 0x16, 0x28, 0xae, 0xd2, 0xa6, 0xab, 0xf7, 0x15, 0x88, 0x09, 0xcf, 0x4f, 0x3c };
     uint8_t out[64]{ 0x76, 0x49, 0xab, 0xac, 0x81, 0x19, 0xb2, 0x46, 0xce, 0xe9, 0x8e, 0x9b, 0x12, 0xe9, 0x19, 0x7d,
@@ -48,7 +56,7 @@ void test_aes128_combination(bool key_as_witness, bool iv_as_witness, bool input
                     0x30, 0xc8, 0x1c, 0x46, 0xa3, 0x5c, 0xe4, 0x11, 0xe5, 0xfb, 0xc1, 0x19, 0x1a, 0x0a, 0x52, 0xef,
                     0xf6, 0x9f, 0x24, 0x45, 0xdf, 0x4f, 0x9b, 0x17, 0xad, 0x2b, 0x41, 0x7b, 0xe6, 0x6c, 0x37, 0x10 };
 
-    auto builder = UltraCircuitBuilder();
+    auto builder = Builder();
 
     // Create input blocks with specified witness/constant configuration
     std::vector<field_pt> in_field;
@@ -88,9 +96,10 @@ void test_aes128_combination(bool key_as_witness, bool iv_as_witness, bool input
 }
 
 // Test function for mixed input blocks (some constant, some witness)
+template <class Builder>
 void test_aes128_mixed_input(bool key_as_witness, bool iv_as_witness, const std::vector<bool>& input_block_config)
 {
-    typedef stdlib::field_t<UltraCircuitBuilder> field_pt;
+    using field_pt = stdlib::field_t<Builder>;
 
     uint8_t key[16]{ 0x2b, 0x7e, 0x15, 0x16, 0x28, 0xae, 0xd2, 0xa6, 0xab, 0xf7, 0x15, 0x88, 0x09, 0xcf, 0x4f, 0x3c };
     uint8_t out[64]{ 0x76, 0x49, 0xab, 0xac, 0x81, 0x19, 0xb2, 0x46, 0xce, 0xe9, 0x8e, 0x9b, 0x12, 0xe9, 0x19, 0x7d,
@@ -103,7 +112,7 @@ void test_aes128_mixed_input(bool key_as_witness, bool iv_as_witness, const std:
                     0x30, 0xc8, 0x1c, 0x46, 0xa3, 0x5c, 0xe4, 0x11, 0xe5, 0xfb, 0xc1, 0x19, 0x1a, 0x0a, 0x52, 0xef,
                     0xf6, 0x9f, 0x24, 0x45, 0xdf, 0x4f, 0x9b, 0x17, 0xad, 0x2b, 0x41, 0x7b, 0xe6, 0x6c, 0x37, 0x10 };
 
-    auto builder = UltraCircuitBuilder();
+    auto builder = Builder();
 
     // Create input blocks with mixed witness/constant configuration
     std::vector<field_pt> in_field;
@@ -144,51 +153,52 @@ void test_aes128_mixed_input(bool key_as_witness, bool iv_as_witness, const std:
     }
 }
 
-TEST(stdlib_aes128, encrypt_64_bytes_all_witness)
+TYPED_TEST(StdlibAes128, encrypt_64_bytes_all_witness)
 {
-    test_aes128_combination(true, true, true);
+    test_aes128_combination<TypeParam>(true, true, true);
 }
 
-TEST(stdlib_aes128, encrypt_64_bytes_all_constant)
+TYPED_TEST(StdlibAes128, encrypt_64_bytes_all_constant)
 {
-    test_aes128_combination(false, false, false);
+    test_aes128_combination<TypeParam>(false, false, false);
 }
 
-TEST(stdlib_aes128, encrypt_64_bytes_key_witness_iv_constant_input_constant)
+TYPED_TEST(StdlibAes128, encrypt_64_bytes_key_witness_iv_constant_input_constant)
 {
-    test_aes128_combination(true, false, false);
+    test_aes128_combination<TypeParam>(true, false, false);
 }
 
-TEST(stdlib_aes128, encrypt_64_bytes_key_constant_iv_witness_input_constant)
+TYPED_TEST(StdlibAes128, encrypt_64_bytes_key_constant_iv_witness_input_constant)
 {
-    test_aes128_combination(false, true, false);
+    test_aes128_combination<TypeParam>(false, true, false);
 }
 
-TEST(stdlib_aes128, encrypt_64_bytes_key_constant_iv_constant_input_witness)
+TYPED_TEST(StdlibAes128, encrypt_64_bytes_key_constant_iv_constant_input_witness)
 {
-    test_aes128_combination(false, false, true);
+    test_aes128_combination<TypeParam>(false, false, true);
 }
 
-TEST(stdlib_aes128, encrypt_64_bytes_key_witness_iv_witness_input_constant)
+TYPED_TEST(StdlibAes128, encrypt_64_bytes_key_witness_iv_witness_input_constant)
 {
-    test_aes128_combination(true, true, false);
+    test_aes128_combination<TypeParam>(true, true, false);
 }
 
-TEST(stdlib_aes128, encrypt_64_bytes_key_witness_iv_constant_input_witness)
+TYPED_TEST(StdlibAes128, encrypt_64_bytes_key_witness_iv_constant_input_witness)
 {
-    test_aes128_combination(true, false, true);
+    test_aes128_combination<TypeParam>(true, false, true);
 }
 
-TEST(stdlib_aes128, encrypt_64_bytes_key_constant_iv_witness_input_witness)
+TYPED_TEST(StdlibAes128, encrypt_64_bytes_key_constant_iv_witness_input_witness)
 {
-    test_aes128_combination(false, true, true);
+    test_aes128_combination<TypeParam>(false, true, true);
 }
 
 // Original test for backward compatibility
-TEST(stdlib_aes128, encrypt_64_bytes_original)
+TYPED_TEST(StdlibAes128, encrypt_64_bytes_original)
 {
-    typedef stdlib::field_t<UltraCircuitBuilder> field_pt;
-    typedef stdlib::witness_t<bb::UltraCircuitBuilder> witness_pt;
+    using Builder = TypeParam;
+    using field_pt = stdlib::field_t<Builder>;
+    using witness_pt = stdlib::witness_t<Builder>;
 
     uint8_t key[16]{ 0x2b, 0x7e, 0x15, 0x16, 0x28, 0xae, 0xd2, 0xa6, 0xab, 0xf7, 0x15, 0x88, 0x09, 0xcf, 0x4f, 0x3c };
     uint8_t out[64]{ 0x76, 0x49, 0xab, 0xac, 0x81, 0x19, 0xb2, 0x46, 0xce, 0xe9, 0x8e, 0x9b, 0x12, 0xe9, 0x19, 0x7d,
@@ -210,7 +220,7 @@ TEST(stdlib_aes128, encrypt_64_bytes_original)
         return converted;
     };
 
-    auto builder = UltraCircuitBuilder();
+    auto builder = Builder();
 
     std::vector<field_pt> in_field{
         witness_pt(&builder, fr(convert_bytes(in))),
@@ -239,44 +249,44 @@ TEST(stdlib_aes128, encrypt_64_bytes_original)
 }
 
 // Mixed input tests - different combinations of constant/witness blocks
-TEST(stdlib_aes128, encrypt_64_bytes_mixed_input_first_witness_rest_constant)
+TYPED_TEST(StdlibAes128, encrypt_64_bytes_mixed_input_first_witness_rest_constant)
 {
-    test_aes128_mixed_input(false, false, { true, false, false, false });
+    test_aes128_mixed_input<TypeParam>(false, false, { true, false, false, false });
 }
 
-TEST(stdlib_aes128, encrypt_64_bytes_mixed_input_alternating_witness_constant)
+TYPED_TEST(StdlibAes128, encrypt_64_bytes_mixed_input_alternating_witness_constant)
 {
-    test_aes128_mixed_input(false, false, { true, false, true, false });
+    test_aes128_mixed_input<TypeParam>(false, false, { true, false, true, false });
 }
 
-TEST(stdlib_aes128, encrypt_64_bytes_mixed_input_first_constant_rest_witness)
+TYPED_TEST(StdlibAes128, encrypt_64_bytes_mixed_input_first_constant_rest_witness)
 {
-    test_aes128_mixed_input(false, false, { false, true, true, true });
+    test_aes128_mixed_input<TypeParam>(false, false, { false, true, true, true });
 }
 
-TEST(stdlib_aes128, encrypt_64_bytes_mixed_input_key_witness_mixed_blocks)
+TYPED_TEST(StdlibAes128, encrypt_64_bytes_mixed_input_key_witness_mixed_blocks)
 {
-    test_aes128_mixed_input(true, false, { true, false, true, false });
+    test_aes128_mixed_input<TypeParam>(true, false, { true, false, true, false });
 }
 
-TEST(stdlib_aes128, encrypt_64_bytes_mixed_input_iv_witness_mixed_blocks)
+TYPED_TEST(StdlibAes128, encrypt_64_bytes_mixed_input_iv_witness_mixed_blocks)
 {
-    test_aes128_mixed_input(false, true, { false, true, false, true });
+    test_aes128_mixed_input<TypeParam>(false, true, { false, true, false, true });
 }
 
-TEST(stdlib_aes128, encrypt_64_bytes_mixed_input_key_iv_witness_mixed_blocks)
+TYPED_TEST(StdlibAes128, encrypt_64_bytes_mixed_input_key_iv_witness_mixed_blocks)
 {
-    test_aes128_mixed_input(true, true, { true, false, true, false });
+    test_aes128_mixed_input<TypeParam>(true, true, { true, false, true, false });
 }
 
-TEST(stdlib_aes128, encrypt_64_bytes_mixed_input_all_witness_blocks)
+TYPED_TEST(StdlibAes128, encrypt_64_bytes_mixed_input_all_witness_blocks)
 {
-    test_aes128_mixed_input(false, false, { true, true, true, true });
+    test_aes128_mixed_input<TypeParam>(false, false, { true, true, true, true });
 }
 
-TEST(stdlib_aes128, encrypt_64_bytes_mixed_input_all_constant_blocks)
+TYPED_TEST(StdlibAes128, encrypt_64_bytes_mixed_input_all_constant_blocks)
 {
-    test_aes128_mixed_input(false, false, { false, false, false, false });
+    test_aes128_mixed_input<TypeParam>(false, false, { false, false, false, false });
 }
 
 // ============================================================================
@@ -288,6 +298,9 @@ TEST(stdlib_aes128, encrypt_64_bytes_mixed_input_all_constant_blocks)
 //   - Normalization maps: even digits → 0, odd digits → 1 (exactly XOR semantics)
 //
 // This allows XOR to be computed as: sparse(a) + sparse(b), then normalize
+//
+// These tests exercise the plookup lookup tables and `numeric::map_*` helpers
+// rather than the aes128 gadget template itself, so they are Ultra-only.
 // ============================================================================
 
 constexpr uint64_t AES_SPARSE_BASE = 9;

--- a/barretenberg/cpp/src/barretenberg/stdlib/hash/blake2s/blake2s.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/hash/blake2s/blake2s.test.cpp
@@ -2,6 +2,8 @@
 #include "barretenberg/circuit_checker/circuit_checker.hpp"
 #include "barretenberg/flavor/ultra_flavor.hpp"
 #include "barretenberg/numeric/uint256/uint256.hpp"
+#include "barretenberg/stdlib_circuit_builders/mega_circuit_builder.hpp"
+#include "barretenberg/stdlib_circuit_builders/ultra_circuit_builder.hpp"
 #include "barretenberg/ultra_honk/prover_instance.hpp"
 #include "blake2s.hpp"
 #include <gtest/gtest.h>
@@ -9,13 +11,12 @@
 using namespace bb;
 using namespace bb::stdlib;
 
-using Builder = UltraCircuitBuilder;
+template <class Builder> class StdlibBlake2s : public ::testing::Test {};
 
-using field_ct = field_t<Builder>;
-using witness_ct = witness_t<Builder>;
-using byte_array_ct = byte_array<Builder>;
-using public_witness_t = public_witness_t<Builder>;
+using BuilderTypes = ::testing::Types<bb::UltraCircuitBuilder, bb::MegaCircuitBuilder>;
+TYPED_TEST_SUITE(StdlibBlake2s, BuilderTypes);
 
+namespace {
 std::vector<std::string> test_vectors = { "",
                                           "a",
                                           "ab",
@@ -30,9 +31,13 @@ std::vector<std::string> test_vectors = { "",
                                           "abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz01",
                                           "abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz012",
                                           "abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789" };
+} // namespace
 
-TEST(stdlib_blake2s, test_single_block)
+TYPED_TEST(StdlibBlake2s, test_single_block)
 {
+    using Builder = TypeParam;
+    using byte_array_ct = byte_array<Builder>;
+
     Builder builder;
     std::string input = "abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz01";
     std::vector<uint8_t> input_v(input.begin(), input.end());
@@ -50,8 +55,11 @@ TEST(stdlib_blake2s, test_single_block)
     EXPECT_EQ(proof_result, true);
 }
 
-TEST(stdlib_blake2s, test_double_block)
+TYPED_TEST(StdlibBlake2s, test_double_block)
 {
+    using Builder = TypeParam;
+    using byte_array_ct = byte_array<Builder>;
+
     Builder builder;
     std::string input = "abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789";
     std::vector<uint8_t> input_v(input.begin(), input.end());
@@ -69,8 +77,11 @@ TEST(stdlib_blake2s, test_double_block)
     EXPECT_EQ(proof_result, true);
 }
 
-TEST(stdlib_blake2s, test_witness_and_constant)
+TYPED_TEST(StdlibBlake2s, test_witness_and_constant)
 {
+    using Builder = TypeParam;
+    using byte_array_ct = byte_array<Builder>;
+
     Builder builder;
 
     // create a byte array that is a circuit witness
@@ -108,8 +119,11 @@ TEST(stdlib_blake2s, test_witness_and_constant)
     EXPECT_EQ(proof_result, true);
 }
 
-TEST(stdlib_blake2s, test_constant_only)
+TYPED_TEST(StdlibBlake2s, test_constant_only)
 {
+    using Builder = TypeParam;
+    using byte_array_ct = byte_array<Builder>;
+
     Builder builder;
     size_t len = 65;
 
@@ -136,8 +150,10 @@ TEST(stdlib_blake2s, test_constant_only)
     EXPECT_EQ(proof_result, true);
 }
 
-TEST(stdlib_blake2s, test_multiple_sized_blocks)
+TYPED_TEST(StdlibBlake2s, test_multiple_sized_blocks)
 {
+    using Builder = TypeParam;
+    using byte_array_ct = byte_array<Builder>;
 
     int i = 0;
 
@@ -165,8 +181,11 @@ TEST(stdlib_blake2s, test_multiple_sized_blocks)
 // second half of every call to `g` to ensure that the overflow doesn't go beyond 3 bits. The edge case that caused
 // addition overflow issues in Blake is tested here. See https://hackmd.io/@aztec-network/SyTHLkAWZx for a detailed
 // description of the addition overflow issue.
-TEST(stdlib_blake2s, test_edge_case_addition_overflow)
+TYPED_TEST(StdlibBlake2s, test_edge_case_addition_overflow)
 {
+    using Builder = TypeParam;
+    using byte_array_ct = byte_array<Builder>;
+
     std::array<uint8_t, 62> v = { 0x0E, 0xF6, 0xF6, 0xF6, 0xF6, 0xF6, 0xF6, 0xF6, 0xF6, 0xF6, 0xF6, 0xF6, 0xF6,
                                   0xF6, 0xF6, 0xF6, 0xF6, 0xF6, 0xF6, 0xF6, 0xF6, 0xF6, 0xF6, 0xF6, 0xF6, 0xF6,
                                   0xF6, 0xF6, 0xF6, 0xF6, 0xF6, 0xF6, 0xF6, 0xF6, 0xF6, 0xF6, 0xF6, 0xF6, 0xFF,

--- a/barretenberg/cpp/src/barretenberg/stdlib/hash/blake3s/blake3s.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/hash/blake3s/blake3s.test.cpp
@@ -2,14 +2,19 @@
 #include "barretenberg/circuit_checker/circuit_checker.hpp"
 #include "barretenberg/common/assert.hpp"
 #include "barretenberg/common/streams.hpp"
+#include "barretenberg/stdlib_circuit_builders/mega_circuit_builder.hpp"
+#include "barretenberg/stdlib_circuit_builders/ultra_circuit_builder.hpp"
 #include "blake3s.hpp"
 #include <gtest/gtest.h>
 
 using namespace bb;
 
-using byte_array_ct = stdlib::byte_array<bb::UltraCircuitBuilder>;
-using UltraBuilder = UltraCircuitBuilder;
+template <class Builder> class StdlibBlake3s : public ::testing::Test {};
 
+using BuilderTypes = ::testing::Types<bb::UltraCircuitBuilder, bb::MegaCircuitBuilder>;
+TYPED_TEST_SUITE(StdlibBlake3s, BuilderTypes);
+
+namespace {
 std::vector<std::string> test_vectors = { std::string{},
                                           "a",
                                           "ab",
@@ -24,15 +29,19 @@ std::vector<std::string> test_vectors = { std::string{},
                                           "abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz01",
                                           "abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz012",
                                           "abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789" };
+} // namespace
 
-TEST(stdlib_blake3s, test_single_block)
+TYPED_TEST(StdlibBlake3s, test_single_block)
 {
-    auto builder = UltraBuilder();
+    using Builder = TypeParam;
+    using byte_array_ct = stdlib::byte_array<Builder>;
+
+    Builder builder;
     std::string input = "abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz01";
     std::vector<uint8_t> input_v(input.begin(), input.end());
 
     byte_array_ct input_arr(&builder, input_v);
-    byte_array_ct output = stdlib::Blake3s<UltraBuilder>::hash(input_arr);
+    byte_array_ct output = stdlib::Blake3s<Builder>::hash(input_arr);
 
     std::vector<uint8_t> expected = blake3::blake3s(input_v);
 
@@ -44,14 +53,17 @@ TEST(stdlib_blake3s, test_single_block)
     EXPECT_EQ(proof_result, true);
 }
 
-TEST(stdlib_blake3s, test_double_block)
+TYPED_TEST(StdlibBlake3s, test_double_block)
 {
-    auto builder = UltraBuilder();
+    using Builder = TypeParam;
+    using byte_array_ct = stdlib::byte_array<Builder>;
+
+    Builder builder;
     std::string input = "abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789";
     std::vector<uint8_t> input_v(input.begin(), input.end());
 
     byte_array_ct input_arr(&builder, input_v);
-    byte_array_ct output = stdlib::Blake3s<UltraBuilder>::hash(input_arr);
+    byte_array_ct output = stdlib::Blake3s<Builder>::hash(input_arr);
 
     std::vector<uint8_t> expected = blake3::blake3s(input_v);
 
@@ -63,20 +75,26 @@ TEST(stdlib_blake3s, test_double_block)
     EXPECT_EQ(proof_result, true);
 }
 
-TEST(stdlib_blake3s, test_too_large_input)
+TYPED_TEST(StdlibBlake3s, test_too_large_input)
 {
-    auto builder = UltraBuilder();
+    using Builder = TypeParam;
+    using byte_array_ct = stdlib::byte_array<Builder>;
+
+    Builder builder;
 
     std::vector<uint8_t> input_v(1025, 0);
 
     byte_array_ct input_arr(&builder, input_v);
-    EXPECT_THROW_WITH_MESSAGE(stdlib::Blake3s<UltraBuilder>::hash(input_arr),
+    EXPECT_THROW_WITH_MESSAGE(stdlib::Blake3s<Builder>::hash(input_arr),
                               "Barretenberg does not support blake3s with input lengths greater than 1024 bytes.");
 }
 
-TEST(stdlib_blake3s, test_witness_and_constant)
+TYPED_TEST(StdlibBlake3s, test_witness_and_constant)
 {
-    UltraBuilder builder;
+    using Builder = TypeParam;
+    using byte_array_ct = stdlib::byte_array<Builder>;
+
+    Builder builder;
 
     // create a byte array that is a circuit witness
     std::string witness_str = "abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz";
@@ -100,7 +118,7 @@ TEST(stdlib_blake3s, test_witness_and_constant)
     EXPECT_EQ(input_arr.get_value(), input_v);
 
     // hash the combined byte array
-    byte_array_ct output = stdlib::Blake3s<UltraBuilder>::hash(input_arr);
+    byte_array_ct output = stdlib::Blake3s<Builder>::hash(input_arr);
 
     // compute expected hash
     auto expected = blake3::blake3s(input_v);
@@ -113,9 +131,12 @@ TEST(stdlib_blake3s, test_witness_and_constant)
     EXPECT_EQ(proof_result, true);
 }
 
-TEST(stdlib_blake3s, test_constant_only)
+TYPED_TEST(StdlibBlake3s, test_constant_only)
 {
-    UltraBuilder builder;
+    using Builder = TypeParam;
+    using byte_array_ct = stdlib::byte_array<Builder>;
+
+    Builder builder;
     size_t len = 65;
 
     // create a byte array that is a circuit constant
@@ -128,7 +149,7 @@ TEST(stdlib_blake3s, test_constant_only)
     EXPECT_EQ(input_arr.get_value(), input_v);
 
     // hash the byte array
-    byte_array_ct output = stdlib::Blake3s<UltraBuilder>::hash(input_arr);
+    byte_array_ct output = stdlib::Blake3s<Builder>::hash(input_arr);
 
     // compute expected hash
     auto expected = blake3::blake3s(input_v);
@@ -141,17 +162,20 @@ TEST(stdlib_blake3s, test_constant_only)
     EXPECT_EQ(proof_result, true);
 }
 
-TEST(stdlib_blake3s, test_multiple_sized_blocks)
+TYPED_TEST(StdlibBlake3s, test_multiple_sized_blocks)
 {
+    using Builder = TypeParam;
+    using byte_array_ct = stdlib::byte_array<Builder>;
+
     int i = 0;
 
     for (auto v : test_vectors) {
-        UltraBuilder builder;
+        Builder builder;
 
         std::vector<uint8_t> input_v(v.begin(), v.end());
 
         byte_array_ct input_arr(&builder, input_v);
-        byte_array_ct output = stdlib::Blake3s<UltraBuilder>::hash(input_arr);
+        byte_array_ct output = stdlib::Blake3s<Builder>::hash(input_arr);
 
         auto expected = blake3::blake3s(input_v);
 
@@ -169,18 +193,21 @@ TEST(stdlib_blake3s, test_multiple_sized_blocks)
 // second half of every call to `g` to ensure that the overflow doesn't go beyond 3 bits. The edge case that caused
 // addition overflow issues in Blake is tested here. See https://hackmd.io/@aztec-network/SyTHLkAWZx for a detailed
 // description of the addition overflow issue.
-TEST(stdlib_blake3s, test_edge_case_addition_overflow)
+TYPED_TEST(StdlibBlake3s, test_edge_case_addition_overflow)
 {
+    using Builder = TypeParam;
+    using byte_array_ct = stdlib::byte_array<Builder>;
+
     std::array<uint8_t, 34> v = { 0xC3, 0x2B, 0xC3, 0x91, 0x23, 0xFF, 0xFF, 0xFF, 0xFF, 0xC3, 0xFF, 0xFF,
                                   0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
                                   0xFF, 0xFF, 0xFF, 0xFF, 0xC3, 0x03, 0x83, 0x83, 0x83, 0x40 };
 
-    UltraBuilder builder;
+    Builder builder;
 
     std::vector<uint8_t> input_v(v.begin(), v.end());
 
     byte_array_ct input_arr(&builder, input_v);
-    byte_array_ct output = stdlib::Blake3s<UltraBuilder>::hash(input_arr);
+    byte_array_ct output = stdlib::Blake3s<Builder>::hash(input_arr);
 
     auto expected = blake3::blake3s(input_v);
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/hash/keccak/keccak.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/hash/keccak/keccak.test.cpp
@@ -2,23 +2,28 @@
 #include "../../primitives/plookup/plookup.hpp"
 #include "barretenberg/circuit_checker/circuit_checker.hpp"
 #include "barretenberg/numeric/random/engine.hpp"
+#include "barretenberg/stdlib_circuit_builders/mega_circuit_builder.hpp"
+#include "barretenberg/stdlib_circuit_builders/ultra_circuit_builder.hpp"
 #include "keccak.hpp"
 #include <gtest/gtest.h>
 
 using namespace bb;
 
-using Builder = UltraCircuitBuilder;
-using byte_array = stdlib::byte_array<Builder>;
-using public_witness_t = stdlib::public_witness_t<Builder>;
-using field_ct = stdlib::field_t<Builder>;
-using witness_ct = stdlib::witness_t<Builder>;
+template <class Builder> class StdlibKeccak : public ::testing::Test {};
+
+using BuilderTypes = ::testing::Types<bb::UltraCircuitBuilder, bb::MegaCircuitBuilder>;
+TYPED_TEST_SUITE(StdlibKeccak, BuilderTypes);
 
 namespace {
 auto& engine = numeric::get_debug_randomness();
 }
 
-TEST(stdlib_keccak, keccak_format_input_table)
+TYPED_TEST(StdlibKeccak, keccak_format_input_table)
 {
+    using Builder = TypeParam;
+    using field_ct = stdlib::field_t<Builder>;
+    using witness_ct = stdlib::witness_t<Builder>;
+
     Builder builder = Builder();
 
     for (size_t i = 0; i < 25; ++i) {
@@ -41,8 +46,12 @@ TEST(stdlib_keccak, keccak_format_input_table)
     EXPECT_EQ(proof_result, true);
 }
 
-TEST(stdlib_keccak, keccak_format_output_table)
+TYPED_TEST(StdlibKeccak, keccak_format_output_table)
 {
+    using Builder = TypeParam;
+    using field_ct = stdlib::field_t<Builder>;
+    using witness_ct = stdlib::witness_t<Builder>;
+
     Builder builder = Builder();
 
     for (size_t i = 0; i < 25; ++i) {
@@ -58,8 +67,12 @@ TEST(stdlib_keccak, keccak_format_output_table)
     EXPECT_EQ(proof_result, true);
 }
 
-TEST(stdlib_keccak, keccak_theta_output_table)
+TYPED_TEST(StdlibKeccak, keccak_theta_output_table)
 {
+    using Builder = TypeParam;
+    using field_ct = stdlib::field_t<Builder>;
+    using witness_ct = stdlib::witness_t<Builder>;
+
     Builder builder = Builder();
 
     for (size_t i = 0; i < 25; ++i) {
@@ -84,8 +97,12 @@ TEST(stdlib_keccak, keccak_theta_output_table)
     EXPECT_EQ(proof_result, true);
 }
 
-TEST(stdlib_keccak, keccak_rho_output_table)
+TYPED_TEST(StdlibKeccak, keccak_rho_output_table)
 {
+    using Builder = TypeParam;
+    using field_ct = stdlib::field_t<Builder>;
+    using witness_ct = stdlib::witness_t<Builder>;
+
     Builder builder = Builder();
 
     constexpr_for<0, 25, 1>([&]<size_t i> {
@@ -109,7 +126,7 @@ TEST(stdlib_keccak, keccak_rho_output_table)
         const uint256_t expected_msb = (binary_native >> 63);
         field_ct limb(witness_ct(&builder, extended_native));
         field_ct result_msb;
-        field_ct result_limb = stdlib::keccak<Builder>::normalize_and_rotate<i>(limb, result_msb);
+        field_ct result_limb = stdlib::keccak<Builder>::template normalize_and_rotate<i>(limb, result_msb);
         EXPECT_EQ(static_cast<uint256_t>(result_limb.get_value()), expected_limb);
         EXPECT_EQ(static_cast<uint256_t>(result_msb.get_value()), expected_msb);
     });
@@ -119,8 +136,12 @@ TEST(stdlib_keccak, keccak_rho_output_table)
     EXPECT_EQ(proof_result, true);
 }
 
-TEST(stdlib_keccak, keccak_chi_output_table)
+TYPED_TEST(StdlibKeccak, keccak_chi_output_table)
 {
+    using Builder = TypeParam;
+    using field_ct = stdlib::field_t<Builder>;
+    using witness_ct = stdlib::witness_t<Builder>;
+
     static constexpr uint64_t chi_normalization_table[5]{
         0, // 1 + 2a - b + c => a xor (~b & c)
         0, 1, 1, 0,
@@ -156,8 +177,12 @@ TEST(stdlib_keccak, keccak_chi_output_table)
 }
 
 // Matches the fuzzer logic
-TEST(stdlib_keccak, permutation_opcode)
+TYPED_TEST(StdlibKeccak, permutation_opcode)
 {
+    using Builder = TypeParam;
+    using field_ct = stdlib::field_t<Builder>;
+    using witness_ct = stdlib::witness_t<Builder>;
+
     Builder builder = Builder();
 
     // Create a random state (25 lanes of 64 bits)

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/circuit_builder_base.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/circuit_builder_base.hpp
@@ -16,6 +16,7 @@
 #include <utility>
 
 #include <algorithm>
+#include <span>
 #include <unordered_map>
 
 namespace bb {
@@ -76,7 +77,8 @@ template <typename FF_> class CircuitBuilderBase {
      * variables
      * @param variable_indices The indices to validate
      */
-    void assert_valid_variables(const std::vector<uint32_t>& variable_indices);
+    void assert_valid_variables(std::initializer_list<uint32_t> variable_indices);
+    void assert_valid_variables(std::span<const uint32_t> variable_indices);
 
     /**
      * @brief The permutation on variable tags, as a constituent of the generalized permutation argument.

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/circuit_builder_base_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/circuit_builder_base_impl.hpp
@@ -145,13 +145,18 @@ void CircuitBuilderBase<FF>::assert_equal(const uint32_t a_variable_idx,
 }
 
 template <typename FF_>
-void CircuitBuilderBase<FF_>::assert_valid_variables([[maybe_unused]] const std::vector<uint32_t>& variable_indices)
+void CircuitBuilderBase<FF_>::assert_valid_variables(std::initializer_list<uint32_t> variable_indices)
 {
-#ifndef NDEBUG
     for (const auto& variable_index : variable_indices) {
         BB_ASSERT_LT(variable_index, variables.size());
     }
-#endif
+}
+
+template <typename FF_> void CircuitBuilderBase<FF_>::assert_valid_variables(std::span<const uint32_t> variable_indices)
+{
+    for (const auto& variable_index : variable_indices) {
+        BB_ASSERT_LT(variable_index, variables.size());
+    }
 }
 
 template <typename FF_> bool CircuitBuilderBase<FF_>::failed() const


### PR DESCRIPTION
| # | Finding | Resolution |                                                                                                                                      
  |---|---------|------------|                                          
  | 3, 12 | Msgpack NIL produces null `shared_ptr`, dereferenced in ACIR parsers | **Patched.** NIL rejection in deserializer helpers, plus tests |
  | 6 | `result_infinite` unconstrained in EC gadgets; prover could forge it | **Already fixed** in PR #21865 |                                                     
  | 9 | `assert_valid_variables` debug-only, heap-allocated a vector per call | **Patched.** Updated to use `initializer_list`/`span` to make cheap enough, always-on, (check in `get_variable` too expensive) |                        
  | 16 | Sparse witness map amplifies ~10 bytes into ~137 GB allocation | **Accepted risk.** No cap works without potentially rejecting valid inputs |                         
  | 20 | UB shift-by-64 in `get_wnaf_bits`; hash tests Ultra-only | **Patched.** Fixed UB, added Mega coverage to 4 test suites |                                    
  | 21 | Clang under-aligns NTTP objects, UB in `barrett_reduction` | **Patched.** Root cause different than claimed in issue (see `static_assert` guards), Pointer NTTP refactor resolves UB per UBsan | 
