### PR TITLE
feat: enforce accumulator_not_empty = 0 at ECCVM lagrange_first row

### DIFF
--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/gate_count_constants.hpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/gate_count_constants.hpp
@@ -113,7 +113,7 @@ constexpr std::tuple<size_t, size_t> HONK_RECURSION_CONSTANTS(
 // ========================================
 
 // Gate count for Chonk recursive verification (Ultra with RollupIO)
-inline constexpr size_t CHONK_RECURSION_GATES = 1491593;
+inline constexpr size_t CHONK_RECURSION_GATES = 1491767;
 
 // ========================================
 // Hypernova Recursion Constants
@@ -147,7 +147,7 @@ inline constexpr size_t HIDING_KERNEL_ULTRA_OPS = 127;
 // ========================================
 
 // Gate count for ECCVM recursive verifier (Ultra-arithmetized)
-inline constexpr size_t ECCVM_RECURSIVE_VERIFIER_GATE_COUNT = 224336;
+inline constexpr size_t ECCVM_RECURSIVE_VERIFIER_GATE_COUNT = 224510;
 
 // ========================================
 // Goblin AVM Recursive Verifier Constants

--- a/barretenberg/cpp/src/barretenberg/relations/ecc_vm/ecc_transcript_relation.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/ecc_vm/ecc_transcript_relation.hpp
@@ -99,11 +99,13 @@ template <typename FF_> class ECCVMTranscriptRelationImpl {
         INFINITY_ACC_X = 29,
         // Infinity flag consistency: acc_y = 0 when accumulator empty
         INFINITY_ACC_Y = 30,
+        // Boundary: accumulator_not_empty must be 0 at lagrange_first row
+        ACCUMULATOR_NOT_EMPTY_INIT = 31,
         NUM_SUBRELATIONS,
     };
 
-    static constexpr std::array<size_t, 31> SUBRELATION_PARTIAL_LENGTHS{
-        8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8,
+    static constexpr std::array<size_t, 32> SUBRELATION_PARTIAL_LENGTHS{
+        8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8,
     };
     static_assert(NUM_SUBRELATIONS == SUBRELATION_PARTIAL_LENGTHS.size());
 

--- a/barretenberg/cpp/src/barretenberg/relations/ecc_vm/ecc_transcript_relation_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/ecc_vm/ecc_transcript_relation_impl.hpp
@@ -566,5 +566,14 @@ void ECCVMTranscriptRelationImpl<FF>::accumulate(ContainerOverSubrelations& accu
         is_accumulator_empty * transcript_accumulator_x * scaling_factor; // degree 2
     std::get<INFINITY_ACC_Y>(accumulator) +=
         is_accumulator_empty * transcript_accumulator_y * scaling_factor; // degree 2
+
+    /**
+     * @brief Enforce accumulator_not_empty = 0 at the lagrange_first row.
+     * Without this, a malicious prover can set accumulator_not_empty = 1 at the lagrange_first row,
+     * which disables INFINITY_ACC_X/Y above, allowing arbitrary accumulator coordinates to be injected
+     * without any relation catching it.
+     */
+    std::get<ACCUMULATOR_NOT_EMPTY_INIT>(accumulator) +=
+        lagrange_first * View(in.transcript_accumulator_not_empty) * scaling_factor; // degree 2
 }
 } // namespace bb


### PR DESCRIPTION
## Summary

Add `lagrange_first * transcript_accumulator_not_empty = 0` subrelation to `ECCVMTranscriptRelation`.

This is a prerequisite for #22334 (masking at top of ECCVM circuit). The audit in #22442 identified that when `lagrange_first` moves to row k (away from the PCS-enforced zero row), `transcript_accumulator_not_empty` is the only shiftable column where a malicious prover can potentially set a non-zero value at the `lagrange_first` row without any existing relation catching it. Setting it to 1 disables `INFINITY_ACC_X/Y`, allowing arbitrary accumulator coordinates to be injected.

## Changes

- New subrelation `ACCUMULATOR_NOT_EMPTY_INIT` in `ecc_transcript_relation.hpp` (degree 2)
- Gate count updates (+174 gates from the new subrelation):
  - `ECCVM_RECURSIVE_VERIFIER_GATE_COUNT`: 224336 → 224510
  - `CHONK_RECURSION_GATES`: 1491593 → 1491767

## Test plan

- [x] `eccvm_tests` — all 44 tests pass
- [x] `stdlib_eccvm_verifier_tests` — `SingleRecursiveVerification` passes with updated gate count
- [x] `dsl_tests` — `GateCountChonkRecursion` passes with updated gate count