### PR TITLE
fix(avm)!: assert keys are non-zero on contract registration

### DIFF
--- a/noir-projects/noir-contracts/contracts/protocol/contract_instance_registry_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/protocol/contract_instance_registry_contract/src/main.nr
@@ -133,8 +133,9 @@ pub contract ContractInstanceRegistry {
         let partial_address =
             PartialAddress::compute(contract_class_id, salt, initialization_hash, deployer);
 
-        // Validate public key points lie on the Grumpkin curve to prevent AVM DoS attacks.
+        // Validate public key points lie on the Grumpkin curve and are non-0 to prevent AVM DoS attacks.
         public_keys.validate_on_curve();
+        public_keys.validate_non_infinity();
 
         let address = AztecAddress::compute(public_keys, partial_address);
 

--- a/noir-projects/noir-protocol-circuits/crates/types/src/public_keys.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/public_keys.nr
@@ -114,6 +114,13 @@ impl PublicKeys {
         validate_on_curve(self.ovpk_m.inner);
         validate_on_curve(self.tpk_m.inner);
     }
+
+    pub fn validate_non_infinity(self) {
+        assert_eq(self.npk_m.inner.is_infinite, false, "NpkM is the point at infinity");
+        assert_eq(self.ivpk_m.inner.is_infinite, false, "IvpkM is the point at infinity");
+        assert_eq(self.ovpk_m.inner.is_infinite, false, "OvpkM is the point at infinity");
+        assert_eq(self.tpk_m.inner.is_infinite, false, "TpkM is the point at infinity");
+    }
 }
 
 pub struct AddressPoint {
@@ -133,6 +140,7 @@ mod test {
         public_keys::{IvpkM, NpkM, OvpkM, PublicKeys, TpkM},
         traits::{Deserialize, Serialize},
     };
+    use std::ops::Neg;
 
     #[test]
     unconstrained fn compute_public_keys_hash() {
@@ -150,6 +158,54 @@ mod test {
             0x056998309f6c119e4d753e404f94fef859dddfa530a9379634ceb0854b29bf7a;
 
         assert(actual.to_field() == expected_public_keys_hash);
+    }
+
+    #[test]
+    unconstrained fn test_validate_on_curve() {
+        let keys = PublicKeys {
+            npk_m: NpkM { inner: Point::generator() },
+            ivpk_m: IvpkM { inner: Point::generator().double() },
+            ovpk_m: OvpkM { inner: Point::generator().neg() },
+            tpk_m: TpkM { inner: Point::generator() + Point::generator().double() },
+        };
+
+        keys.validate_on_curve();
+    }
+
+    #[test(should_fail_with = "Point not on curve")]
+    unconstrained fn test_validate_not_on_curve() {
+        let keys = PublicKeys {
+            npk_m: NpkM { inner: Point { x: 1, y: 2, is_infinite: false } },
+            ivpk_m: IvpkM { inner: Point { x: 3, y: 4, is_infinite: false } },
+            ovpk_m: OvpkM { inner: Point { x: 5, y: 6, is_infinite: false } },
+            tpk_m: TpkM { inner: Point { x: 7, y: 8, is_infinite: false } },
+        };
+
+        keys.validate_on_curve();
+    }
+
+    #[test]
+    unconstrained fn test_validate_non_infinity() {
+        let keys = PublicKeys {
+            npk_m: NpkM { inner: Point::generator() },
+            ivpk_m: IvpkM { inner: Point::generator().double() },
+            ovpk_m: OvpkM { inner: Point::generator().neg() },
+            tpk_m: TpkM { inner: Point::generator() + Point::generator().double() },
+        };
+
+        keys.validate_non_infinity();
+    }
+
+    #[test(should_fail_with = "TpkM is the point at infinity")]
+    unconstrained fn test_validate_infinity() {
+        let keys = PublicKeys {
+            npk_m: NpkM { inner: Point::generator() },
+            ivpk_m: IvpkM { inner: Point::generator().double() },
+            ovpk_m: OvpkM { inner: Point::generator().neg() },
+            tpk_m: TpkM { inner: Point::point_at_infinity() },
+        };
+
+        keys.validate_non_infinity();
     }
 
     #[test]


### PR DESCRIPTION
### Changes

During address derivation, the AVM assumes that all input public keys are non-infinite points, and hardcodes an `is_infinity` flag as zero. In reviewing how address derivation changes now that noir no longer uses a flag, we [found that](https://github.com/AztecProtocol/aztec-packages/pull/22393/changes/BASE..6ce45576564c12e39a4a0ea138f33e11def435f3#r3063596289) we actually couldn't rely on that assumption (I thought we could due to  #7529 and comments around the repo). This PR explicity checks all keys are non-infinity.

Edit: Some keys are checked in the [private context](https://github.com/AztecProtocol/aztec-packages/blob/e88ecdf581dbb7ade7bdc883d7da2ba86137f8e0/noir-projects/aztec-nr/aztec/src/context/private_context.nr#L778), but since this isn't in a protocol contract/the rollup circuits, we still require this change for the avm!

### Notes

The DoS (for before or after removing the `inf` flag from noir) seems to be protected against at the archiver level (https://github.com/AztecProtocol/aztec-packages/pull/21787) but this is an explicit, constrained solution.

Before removing the `inf` flag, the AVM hardcoded it as zero in the hash preimage(s) to the address. Now it does not exist in noir, we simply omit the flag (see [diff](https://github.com/AztecProtocol/aztec-packages/pull/22393/changes/BASE..6ce45576564c12e39a4a0ea138f33e11def435f3#diff-f8cc678527e3ed7de63f64b12494329eb9ad389c1dbfce9bea7b480199220836)) to match the new address derivation. 

However, we still rely on this assumption for the `ivpk` in `#[IVK_ON_CURVE_CHECK]` (which would fail in the AVM for an inf point with `(0,0)` coordinates, but not in noir), and assume it is non-inf in the call to `ecc` for `address_point = preaddress_public_key + incoming_viewing_key`.
