### PR TITLE
fix: no division by zero in sentinel

### DIFF
--- a/yarn-project/aztec-node/src/sentinel/sentinel.ts
+++ b/yarn-project/aztec-node/src/sentinel/sentinel.ts
@@ -228,7 +228,7 @@ export class Sentinel extends (EventEmitter as new () => WatcherEmitter) impleme
     }
 
     const inactiveValidators = getEntries(performance)
-      .filter(([_, { missed, total }]) => missed / total >= this.config.slashInactivityTargetPercentage)
+      .filter(([_, { missed, total }]) => total > 0 && missed / total >= this.config.slashInactivityTargetPercentage)
       .map(([address]) => address);
 
     this.logger.debug(`Found ${inactiveValidators.length} inactive validators in epoch ${epoch}`, {


### PR DESCRIPTION
Fixes A-772

Note that the original issue reads "when commitee size is zero". That was not the case, not on the sentinel at least.