### PR TITLE
fix: check all aztec-nr dependency tags, not just aztec

### DIFF
--- a/yarn-project/aztec/src/cli/cmds/utils/warn_if_aztec_version_mismatch.test.ts
+++ b/yarn-project/aztec/src/cli/cmds/utils/warn_if_aztec_version_mismatch.test.ts
@@ -67,6 +67,75 @@ describe('warnIfAztecVersionMismatch', () => {
     expect(logMessages[0]).toContain('v1.0.0');
   });
 
+  it('warns when a non-aztec aztec-nr dependency tag does not match the CLI version', async () => {
+    await makePackage(tempDir, 'project', 'contract', {
+      // eslint-disable-next-line camelcase
+      uint_note: '{ git = "https://github.com/AztecProtocol/aztec-nr", tag = "v0.99.0", directory = "uint-note" }',
+    });
+
+    await warnIfAztecVersionMismatch(log, '1.0.0');
+
+    expect(logMessages).toHaveLength(1);
+    expect(logMessages[0]).toContain('WARNING');
+    expect(logMessages[0]).toContain('uint_note');
+    expect(logMessages[0]).toContain('v0.99.0');
+    expect(logMessages[0]).toContain('v1.0.0');
+  });
+
+  it('warns about a sibling aztec-nr dependency even when the aztec dependency matches', async () => {
+    await makePackage(tempDir, 'project', 'contract', {
+      aztec: '{ git = "https://github.com/AztecProtocol/aztec-nr", tag = "v1.0.0", directory = "aztec" }',
+      // eslint-disable-next-line camelcase
+      uint_note: '{ git = "https://github.com/AztecProtocol/aztec-nr", tag = "v0.99.0", directory = "uint-note" }',
+    });
+
+    await warnIfAztecVersionMismatch(log, '1.0.0');
+
+    expect(logMessages).toHaveLength(1);
+    expect(logMessages[0]).toContain('WARNING');
+    expect(logMessages[0]).toContain('uint_note');
+    expect(logMessages[0]).not.toMatch(/—\s*aztec\s*\(/);
+  });
+
+  it('does not warn when multiple aztec-nr dependencies all match the CLI version', async () => {
+    await makePackage(tempDir, 'project', 'contract', {
+      aztec: '{ git = "https://github.com/AztecProtocol/aztec-nr", tag = "v1.0.0", directory = "aztec" }',
+      // eslint-disable-next-line camelcase
+      uint_note: '{ git = "https://github.com/AztecProtocol/aztec-nr", tag = "v1.0.0", directory = "uint-note" }',
+      // eslint-disable-next-line camelcase
+      compressed_string:
+        '{ git = "https://github.com/AztecProtocol/aztec-nr", tag = "v1.0.0", directory = "compressed-string" }',
+    });
+
+    await warnIfAztecVersionMismatch(log, '1.0.0');
+
+    expect(logMessages.filter(m => m.includes('WARNING'))).toHaveLength(0);
+  });
+
+  it('does not warn for unrelated third-party git dependencies', async () => {
+    await makePackage(tempDir, 'project', 'contract', {
+      aztec: '{ git = "https://github.com/AztecProtocol/aztec-nr", tag = "v1.0.0", directory = "aztec" }',
+      // eslint-disable-next-line camelcase
+      noir_string_search: '{ git = "https://github.com/noir-lang/noir_string_search", tag = "v0.1.0" }',
+    });
+
+    await warnIfAztecVersionMismatch(log, '1.0.0');
+
+    expect(logMessages.filter(m => m.includes('WARNING'))).toHaveLength(0);
+  });
+
+  it('normalizes trailing slashes and .git suffixes in the aztec-nr git URL', async () => {
+    await makePackage(tempDir, 'project', 'contract', {
+      aztec: '{ git = "https://github.com/AztecProtocol/aztec-nr.git", tag = "v1.0.0", directory = "aztec" }',
+      // eslint-disable-next-line camelcase
+      uint_note: '{ git = "https://github.com/AztecProtocol/aztec-nr/", tag = "v1.0.0", directory = "uint-note" }',
+    });
+
+    await warnIfAztecVersionMismatch(log, '1.0.0');
+
+    expect(logMessages.filter(m => m.includes('WARNING'))).toHaveLength(0);
+  });
+
   it('warns when the CLI version is not available', async () => {
     await makePackage(tempDir, 'project', 'contract');
 

--- a/yarn-project/aztec/src/cli/cmds/utils/warn_if_aztec_version_mismatch.ts
+++ b/yarn-project/aztec/src/cli/cmds/utils/warn_if_aztec_version_mismatch.ts
@@ -7,7 +7,25 @@ import { join } from 'path';
 
 import { collectCrateDirs } from './collect_crate_dirs.js';
 
-/** Warns if the `aztec` dependency tag in any crate's Nargo.toml doesn't match the CLI version. */
+/** Returns true if the given git URL points to the AztecProtocol/aztec-nr repository. */
+function isAztecNrGitUrl(gitUrl: string): boolean {
+  let url: URL;
+  try {
+    url = new URL(gitUrl);
+  } catch {
+    return false;
+  }
+  if (url.hostname !== 'github.com') {
+    return false;
+  }
+  const repoPath = url.pathname
+    .replace(/^\//, '')
+    .replace(/\.git$/, '')
+    .replace(/\/$/, '');
+  return repoPath === 'AztecProtocol/aztec-nr';
+}
+
+/** Warns if any aztec-nr git dependency in a crate's Nargo.toml has a tag that doesn't match the CLI version. */
 export async function warnIfAztecVersionMismatch(log: LogFn, cliVersion?: string): Promise<void> {
   const version = cliVersion ?? getPackageVersion();
   if (!version) {
@@ -16,7 +34,7 @@ export async function warnIfAztecVersionMismatch(log: LogFn, cliVersion?: string
   }
 
   const expectedTag = `v${version}`;
-  const mismatches: { file: string; tag: string }[] = [];
+  const mismatches: { file: string; depName: string; tag: string }[] = [];
 
   const crateDirs = await collectCrateDirs('.', { skipGitDeps: true });
 
@@ -30,23 +48,28 @@ export async function warnIfAztecVersionMismatch(log: LogFn, cliVersion?: string
     }
 
     const parsed = TOML.parse(content) as Record<string, any>;
-    const aztecDep = (parsed.dependencies as Record<string, any>)?.aztec;
-    if (!aztecDep || typeof aztecDep !== 'object' || typeof aztecDep.tag !== 'string') {
-      // If a dep called "aztec" doesn't exist or it does not get parsed to an object or it doesn't have a tag defined
-      // we skip the check.
-      continue;
-    }
+    const deps = (parsed.dependencies as Record<string, any>) ?? {};
 
-    if (aztecDep.tag !== expectedTag) {
-      mismatches.push({ file: tomlPath, tag: aztecDep.tag });
+    for (const [depName, dep] of Object.entries(deps)) {
+      // Skip non-object deps (e.g. malformed entries) and anything that isn't a tagged git dep.
+      if (!dep || typeof dep !== 'object' || typeof dep.git !== 'string' || typeof dep.tag !== 'string') {
+        continue;
+      }
+      // Only flag deps that are sourced from the aztec-nr repo.
+      if (!isAztecNrGitUrl(dep.git)) {
+        continue;
+      }
+      if (dep.tag !== expectedTag) {
+        mismatches.push({ file: tomlPath, depName, tag: dep.tag });
+      }
     }
   }
 
   if (mismatches.length > 0) {
-    const details = mismatches.map(m => `  ${m.file} (${m.tag})`).join('\n');
+    const details = mismatches.map(m => `  ${m.file} — ${m.depName} (${m.tag})`).join('\n');
     log(
       `WARNING: Aztec dependency version mismatch detected.\n` +
-        `The following crates have an aztec dependency that does not match the CLI version (${expectedTag}):\n` +
+        `The following aztec-nr dependencies do not match the CLI version (${expectedTag}):\n` +
         `${details}\n\n` +
         `See https://docs.aztec.network/errors/9 for how to update your dependencies.`,
     );


### PR DESCRIPTION
Until now we have only checked that `aztec` dep matches the version of `aztec cli`. This was incomplete as there are also other crates in the aztec-nr repo (e.g. `uint_note`) that should have this same check applied to them. In this PR I tackle that.

## AI Summary

- Broadens `warnIfAztecVersionMismatch` to inspect **every** dependency in a contract's `Nargo.toml` whose git URL points at `github.com/AztecProtocol/aztec-nr`, rather than only the single dep literally named `aztec`.
- Dependencies like `uint_note`, `compressed_string`, `balance_set`, etc. are now flagged when their `tag` drifts from the CLI version (common after `aztec-up` forgets one).
- Warning now names the offending dep so users know exactly which one to bump.
- URL normalization handles `.git` suffixes and trailing slashes.

Closes [F-504](https://linear.app/aztec-labs/issue/F-504/check-all-aztec-nr-dependencies-have-matching-tags-not-just-aztec).

🤖 Generated with [Claude Code](https://claude.com/claude-code)