### PR TITLE
feat(pxe): disallow registering invalid addresses as senders

### DIFF
--- a/yarn-project/pxe/src/logs/log_service.ts
+++ b/yarn-project/pxe/src/logs/log_service.ts
@@ -174,7 +174,6 @@ export class LogService {
 
         if (!secret) {
           // Note that all senders originate from either the SenderAddressBookStore or the KeyStore.
-          // TODO(F-512): make sure we actually prevent registering invalid senders.
           throw new Error(
             `Failed to compute a tagging secret for sender ${sender} - this implies this is an invalid address, which should not happen as they have been previously registered in PXE.`,
           );

--- a/yarn-project/pxe/src/pxe.test.ts
+++ b/yarn-project/pxe/src/pxe.test.ts
@@ -97,6 +97,12 @@ describe('PXE', () => {
     expect(accounts).toContainEqual(completeAddress);
   });
 
+  it('refuses to register an invalid address as a sender', async () => {
+    // x = 3 is not a valid x-coordinate on the Grumpkin curve (y^2 = x^3 - 17 = 10 has no square root in Fr)
+    const invalidAddress = new AztecAddress(new Fr(3));
+    await expect(pxe.registerSender(invalidAddress)).rejects.toThrow(/not valid/);
+  });
+
   it('does not throw when registering the same account twice (just ignores the second attempt)', async () => {
     const randomSecretKey = Fr.random();
     const randomPartialAddress = Fr.random();

--- a/yarn-project/pxe/src/pxe.ts
+++ b/yarn-project/pxe/src/pxe.ts
@@ -560,6 +560,12 @@ export class PXE {
    * TODO: It's strange that we return the address here and I (benesjan) think we should drop the return value.
    */
   public async registerSender(sender: AztecAddress): Promise<AztecAddress> {
+    if (!(await sender.isValid())) {
+      throw new Error(
+        `Address ${sender} is not valid: it does not correspond to a point on the Grumpkin curve. Cannot register it as a sender.`,
+      );
+    }
+
     const accounts = await this.keyStore.getAccounts();
     if (accounts.includes(sender)) {
       this.log.info(`Sender:\n "${sender.toString()}"\n already registered.`);


### PR DESCRIPTION
## Summary

Resolves https://linear.app/aztec-labs/issue/F-512/disallow-registering-invalid-addresses-as-senders-in-pxe

- Validates sender addresses in `PXE.registerSender()` via `address.isValid()` before storing them in the sender address book
- Removes the `TODO(F-512)` comment in `LogService.#getSecretsForSenders`
- Adds a unit test with a known invalid Grumpkin x-coordinate

## Why validate at the API boundary instead of globally?

We considered enforcing validity at the `AztecAddress` constructor level, but this is impractical:
- `isValid()` is async (calls into Barretenberg WASM for `bn254FrSqrt`), so making construction enforce validity would require making all ~650+ construction sites async
- There are legitimate uses of invalid addresses internally (representing external blockchain data, graceful handling in crypto code)
- The performance cost (~1-2ms per check at the WASM boundary) would be significant in deserialization-heavy paths like block processing

Validating at the PXE API boundary targets the real risk (invalid addresses from untrusted user input) without the migration and performance costs.

## Test plan

- Unit test verifies `registerSender` rejects an address with x=3 (not on the Grumpkin curve since y^2 = 10 has no square root in Fr)

🤖 Generated with [Claude Code](https://claude.com/claude-code)