### PR TITLE
fix: add @aztec/accounts to backwards compatibility test infra

### DIFF
--- a/yarn-project/end-to-end/src/legacy-jest-resolver.cjs
+++ b/yarn-project/end-to-end/src/legacy-jest-resolver.cjs
@@ -1,5 +1,5 @@
 // Custom Jest resolver. When CONTRACT_ARTIFACTS_VERSION is set, redirects *only* JSON artifact files under
-// @aztec/noir-contracts.js/artifacts/ and @aztec/noir-test-contracts.js/artifacts/ to a local cache of the pinned
+// @aztec/noir-contracts.js/artifacts/, @aztec/noir-test-contracts.js/artifacts/, and @aztec/accounts/artifacts/ to a local cache of the pinned
 // legacy versions. TypeScript wrapper classes (e.g. Token.ts) continue to load from the current workspace and use the
 // current @aztec/aztec.js — only the artifact JSON (the deployed-contract ABI / bytecode / notes surface) is swapped.
 //
@@ -18,7 +18,7 @@ const fs = require('fs');
 const { execSync } = require('child_process');
 
 const version = process.env.CONTRACT_ARTIFACTS_VERSION;
-const REDIRECTED = ['@aztec/noir-contracts.js', '@aztec/noir-test-contracts.js'];
+const REDIRECTED = ['@aztec/noir-contracts.js', '@aztec/noir-test-contracts.js', '@aztec/accounts'];
 
 // Jest sets rootDir to <e2e>/src; this file lives there too.
 const e2eRoot = path.resolve(__dirname, '..');


### PR DESCRIPTION
## Summary
- Adds `@aztec/accounts` to the `REDIRECTED` array in the legacy Jest resolver so that account contract artifacts (e.g., `SchnorrAccount.json`) are also redirected when running backwards compatibility tests with `CONTRACT_ARTIFACTS_VERSION`.
- Without this, `e2e_fees/account_init.test.ts` fails because the `@aztec/accounts` artifacts were not being swapped to the legacy versions.

## Test plan
- Run `CONTRACT_ARTIFACTS_VERSION=<last-nightly> yarn workspace @aztec/end-to-end test:e2e src/e2e_fees/account_init.test.ts` and verify it passes
- Verify resolver logs show `@aztec/accounts` being installed and its artifacts redirected

🤖 Generated with [Claude Code](https://claude.com/claude-code)