### PR TITLE
fix(avm)!: private revertible nullifier collisions are unrecoverable

### DIFF
--- a/barretenberg/cpp/pil/vm2/tx.pil
+++ b/barretenberg/cpp/pil/vm2/tx.pil
@@ -525,7 +525,7 @@ namespace tx;
         note_hash_tree_check.next_root
     };
 
-    // If reverted, the next state is unconstrained. This is okay since we are going to restore the state at the end of setup or fail proving.
+    // If reverted, the next state is unconstrained as `should_note_hash_append = 0`. This is okay since we are going to restore the state at the end of setup or fail proving.
     // Namely, #[RESTORE_STATE_ON_REVERT] restores the tree state to its value at the end of setup.
     should_note_hash_append * (prev_note_hash_tree_size + 1 - next_note_hash_tree_size) = 0;
     should_note_hash_append * (prev_num_note_hashes_emitted + 1 - next_num_note_hashes_emitted) = 0;
@@ -556,12 +556,12 @@ namespace tx;
     pol commit nullifier_tree_height;
     should_nullifier_append * (nullifier_tree_height - constants.NULLIFIER_TREE_HEIGHT) = 0;
 
-    // We revert if the nullifier already exists.
+    // Collisions are disallowed, if the nullifier already exists the transaction is unprovable
     #[NULLIFIER_APPEND]
     should_nullifier_append {
         leaf_value,
         prev_nullifier_tree_root,
-        reverted,
+        precomputed.zero, // Nullifiers emitted in tx trace cannot have existed
         next_nullifier_tree_root,
         prev_nullifier_tree_size,
         discard, // from tx_discard.pil virtual trace
@@ -580,10 +580,10 @@ namespace tx;
         indexed_tree_check.sel_silo
     };
 
-    // If reverted, the next state is unconstrained. This is okay since we are going to restore the state at the end of setup.
+    // If reverted, the next state is unconstrained since `should_nullifier_append = 0`. This is okay since we are going to restore the state at the end of setup.
     // Namely, #[RESTORE_STATE_ON_REVERT] restores the tree state to its value at the end of setup.
-    should_nullifier_append * (1 - reverted) * (prev_nullifier_tree_size + 1 - next_nullifier_tree_size) = 0;
-    should_nullifier_append * (1 - reverted) * (prev_num_nullifiers_emitted + 1 - next_num_nullifiers_emitted) = 0;
+    should_nullifier_append * (prev_nullifier_tree_size + 1 - next_nullifier_tree_size) = 0;
+    should_nullifier_append * (prev_num_nullifiers_emitted + 1 - next_num_nullifiers_emitted) = 0;
 
     // ===== L2 - L1 Messages =====
     pol commit should_try_l2_l1_msg_append; // @boolean (follows from definition)

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/relations/tx.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/relations/tx.test.cpp
@@ -849,4 +849,38 @@ TEST_F(TxExecutionConstrainingWithCalldataTest, SimpleHandleCalldata)
     check_relation<bb::avm2::calldata_hashing<FF>>(trace);
     check_all_interactions<tracegen::CalldataTraceBuilder>(trace);
 }
+
+// Verify that the nullifier state increment is unconditional when should_nullifier_append = 1.
+// A malicious prover cannot set reverted = 1 to skip the state increment.
+TEST(TxExecutionConstrainingTest, NegativeNullifierStateIncrementIsUnconditional)
+{
+    // Subrelation 42: should_nullifier_append * (prev_nullifier_tree_size + 1 - next_nullifier_tree_size) = 0
+    // Subrelation 43: should_nullifier_append * (prev_num_nullifiers_emitted + 1 - next_num_nullifiers_emitted) = 0
+    TestTraceContainer trace({
+        {
+            // Row 0
+            { C::precomputed_first_row, 1 },
+        },
+        {
+            // Row 1: Nullifier append with should_nullifier_append = 1 but state not incremented.
+            { C::tx_sel, 1 },
+            { C::tx_should_nullifier_append, 1 },
+            { C::tx_reverted, 1 }, // Prover tries to cheat by setting reverted = 1.
+            { C::tx_prev_nullifier_tree_size, 5 },
+            { C::tx_next_nullifier_tree_size, 5 }, // Should be 6.
+            { C::tx_prev_num_nullifiers_emitted, 3 },
+            { C::tx_next_num_nullifiers_emitted, 3 }, // Should be 4.
+        },
+    });
+
+    // Subrelation 42: tree size must increment.
+    EXPECT_THROW_WITH_MESSAGE(check_relation<tx>(trace, static_cast<size_t>(42)), "subrelation 42");
+    // Fix tree size, break emitted count.
+    trace.set(C::tx_next_nullifier_tree_size, 1, 6);
+    EXPECT_THROW_WITH_MESSAGE(check_relation<tx>(trace, static_cast<size_t>(43)), "subrelation 43");
+    // Fix emitted count — both should pass now.
+    trace.set(C::tx_next_num_nullifiers_emitted, 1, 4);
+    check_relation<tx>(trace, static_cast<size_t>(42), static_cast<size_t>(43));
+}
+
 } // namespace bb::avm2::constraining

--- a/barretenberg/cpp/src/barretenberg/vm2/generated/relations/lookups_tx.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/generated/relations/lookups_tx.hpp
@@ -181,7 +181,7 @@ struct lookup_tx_nullifier_append_settings_ {
     static constexpr std::array<ColumnAndShifts, LOOKUP_TUPLE_SIZE> SRC_COLUMNS = {
         ColumnAndShifts::tx_leaf_value,
         ColumnAndShifts::tx_prev_nullifier_tree_root,
-        ColumnAndShifts::tx_reverted,
+        ColumnAndShifts::precomputed_zero,
         ColumnAndShifts::tx_next_nullifier_tree_root,
         ColumnAndShifts::tx_prev_nullifier_tree_size,
         ColumnAndShifts::tx_discard,

--- a/barretenberg/cpp/src/barretenberg/vm2/generated/relations/tx.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/generated/relations/tx.hpp
@@ -16,7 +16,7 @@ template <typename FF_> class txImpl {
 
     static constexpr std::array<size_t, 64> SUBRELATION_PARTIAL_LENGTHS = {
         3, 3, 3, 3, 3, 3, 2, 3, 5, 3, 3, 3, 5, 4, 3, 3, 5, 3, 3, 3, 3, 3, 3, 3, 3, 4, 4, 4, 4, 2, 3, 5,
-        3, 3, 3, 3, 3, 5, 4, 3, 3, 3, 4, 4, 3, 5, 4, 3, 4, 3, 2, 4, 4, 4, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3
+        3, 3, 3, 3, 3, 5, 4, 3, 3, 3, 3, 3, 3, 5, 4, 3, 4, 3, 2, 4, 4, 4, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3
     };
 
     template <typename AllEntities> inline static bool skip(const AllEntities& in)

--- a/barretenberg/cpp/src/barretenberg/vm2/generated/relations/tx_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/generated/relations/tx_impl.hpp
@@ -342,7 +342,6 @@ void txImpl<FF_>::accumulate(ContainerOverSubrelations& evals,
     {
         using View = typename std::tuple_element_t<42, ContainerOverSubrelations>::View;
         auto tmp = static_cast<View>(in.get(C::tx_should_nullifier_append)) *
-                   (FF(1) - static_cast<View>(in.get(C::tx_reverted))) *
                    ((static_cast<View>(in.get(C::tx_prev_nullifier_tree_size)) + FF(1)) -
                     static_cast<View>(in.get(C::tx_next_nullifier_tree_size)));
         std::get<42>(evals) += (tmp * scaling_factor);
@@ -350,7 +349,6 @@ void txImpl<FF_>::accumulate(ContainerOverSubrelations& evals,
     {
         using View = typename std::tuple_element_t<43, ContainerOverSubrelations>::View;
         auto tmp = static_cast<View>(in.get(C::tx_should_nullifier_append)) *
-                   (FF(1) - static_cast<View>(in.get(C::tx_reverted))) *
                    ((static_cast<View>(in.get(C::tx_prev_num_nullifiers_emitted)) + FF(1)) -
                     static_cast<View>(in.get(C::tx_next_num_nullifiers_emitted)));
         std::get<43>(evals) += (tmp * scaling_factor);

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/tx_execution.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/tx_execution.cpp
@@ -58,9 +58,12 @@ std::string get_halting_information(const EnqueuedCallResult& result)
  * - Cleanup (11)
  *
  * If an error occurs during non-revertible insertions or a Setup phase enqueued call fails,
- * the transaction is considered unprovable and an unrecoverable TxExecutionException is thrown.
- * If an error occurs during revertible insertions or App Logic phase, all the state changes are reverted
- * to the post-setup state and we continue with the Teardown phase.
+ * the transaction is considered unprovable and an unrecoverable exception is thrown.
+ * If a side-effect limit is reached during revertible insertions or App Logic phase fails, all the state
+ * changes are reverted to the post-setup state and we continue with the Teardown phase.
+ * A nullifier collision during revertible insertions is ALSO unprovable (not revertible): the nullifier
+ * originated from private, so a collision indicates the tx should never have been proposed. The
+ * NullifierCollisionException propagates out of simulate() as-is.
  * If an error occurs during Teardown phase, all the state changes are reverted to the post-setup state and
  * we continue with the Collect Gas Fees phase.
  *
@@ -69,9 +72,11 @@ std::string get_halting_information(const EnqueuedCallResult& result)
  *
  * @param tx The transaction to simulate.
  * @return The result of the transaction simulation.
+ * @throws NullifierCollisionException if a private nullifier collision occurs in either the non-revertible
+ *         or revertible insertion phase.
  * @throws TxExecutionException if
- *         - there is a nullifier collision or the maximum number of
- *           nullifiers, note hashes, or L2 to L1 messages is reached as part of the non-revertible insertions.
+ *         - the maximum number of nullifiers, note hashes, or L2 to L1 messages is reached as part of the
+ *           non-revertible insertions.
  *         - a Setup phase enqueued call fails.
  *         - the fee payer does not have enough balance to pay the fee.
  * Note: Other low-level exceptions of other types are not caught and will be thrown.
@@ -161,8 +166,9 @@ TxExecutionResult TxExecution::simulate(const Tx& tx)
     call_stack_metadata_collector.set_phase(CoarseTransactionPhase::APP_LOGIC);
 
     try {
-        // Insert revertibles. This can throw if there is a nullifier collision.
-        // Such an exception should be handled and the tx be provable.
+        // Insert revertibles. This can throw TxExecutionException on a side-effect limit error
+        // (handled here, tx is provable) or NullifierCollisionException on a collision
+        // (not handled here - propagates as unrecoverable, since the tx is unprovable).
         // We catch separately here to record the revert reason in call stack metadata,
         // since no calls have populated the metadata yet at this point.
         try {
@@ -366,7 +372,8 @@ void TxExecution::emit_public_call_request(const PublicCallRequestWithCalldata& 
  *
  * @param revertible Whether the nullifier is revertible.
  * @param nullifier The nullifier to insert.
- * @throws TxExecutionException if the maximum number of nullifiers is reached or a nullifier collision occurs.
+ * @throws TxExecutionException if the maximum number of nullifiers is reached.
+ * @throws NullifierCollisionException if the nullifier collides with an existing one (unrecoverable).
  */
 void TxExecution::emit_nullifier(bool revertible, const FF& nullifier)
 {
@@ -383,7 +390,13 @@ void TxExecution::emit_nullifier(bool revertible, const FF& nullifier)
         try {
             merkle_db.siloed_nullifier_write(nullifier);
         } catch (const NullifierCollisionException& e) {
-            throw TxExecutionException(e.what());
+            // Do not handle the NullifierCollisionException as any collision at the tx execution
+            // level is unprovable (i.e. this is an unrecoverable error).
+            // Rethrow with more information - note that this exception isn't being caught in this file
+            throw NullifierCollisionException(format("[",
+                                                     revertible ? "R" : "NR",
+                                                     "_NULLIFIER_INSERTION] UNRECOVERABLE ERROR! Nullifier collision: ",
+                                                     e.what()));
         }
 
         events.emit(TxPhaseEvent{ .phase = phase,
@@ -489,11 +502,11 @@ void TxExecution::emit_l2_to_l1_message(bool revertible, const ScopedL2ToL1Messa
 /**
  * @brief Insert the non-revertible accumulated data into the Merkle DB and emit corresponding events.
  *        It might error if the limits for the number of allowable inserts are exceeded or a nullifier collision occurs,
- *        but this results in an unprovable tx.
+ *        either of which results in an unprovable tx.
  *
  * @param tx The transaction to insert the non-revertible accumulated data into.
- * @throws TxExecutionException if the maximum number of nullifiers, note hashes, L2 to L1 messages is reached, or a
- *         nullifier collision occurs.
+ * @throws TxExecutionException if the maximum number of nullifiers, note hashes, or L2 to L1 messages is reached.
+ * @throws NullifierCollisionException if a nullifier collision occurs (unrecoverable).
  */
 void TxExecution::insert_non_revertibles(const Tx& tx)
 {
@@ -541,11 +554,12 @@ void TxExecution::insert_non_revertibles(const Tx& tx)
 
 /**
  * @brief Insert the revertible accumulated data into the Merkle DB and emit corresponding events.
- *        It might error if the limits for the number of allowable inserts are exceeded or a nullifier collision occurs.
+ *        A side-effect limit error is recoverable (the caller reverts to post-setup); a nullifier
+ *        collision is unrecoverable (the tx is unprovable).
  *
  * @param tx The transaction to insert the revertible accumulated data into.
- * @throws TxExecutionException if the maximum number of nullifiers, note hashes, L2 to L1 messages is reached, or a
- *         nullifier collision occurs.
+ * @throws TxExecutionException if the maximum number of nullifiers, note hashes, or L2 to L1 messages is reached.
+ * @throws NullifierCollisionException if a nullifier collision occurs (unrecoverable).
  */
 void TxExecution::insert_revertibles(const Tx& tx)
 {

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/tx_execution.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/tx_execution.hpp
@@ -76,9 +76,11 @@ class TxExecution final {
     TxContext tx_context;
     bool skip_fee_enforcement;
 
-    // This function can throw if there is a nullifier collision.
+    // Throws TxExecutionException on a side-effect limit error, or NullifierCollisionException on a
+    // nullifier collision. Both are unrecoverable — they result in an unprovable tx.
     void insert_non_revertibles(const Tx& tx);
-    // This function can throw if there is a nullifier collision.
+    // Throws TxExecutionException on a side-effect limit error (recoverable — caller reverts to
+    // post-setup), or NullifierCollisionException on a nullifier collision (unrecoverable — unprovable tx).
     void insert_revertibles(const Tx& tx);
     void emit_public_call_request(const PublicCallRequestWithCalldata& call,
                                   TransactionPhase phase,

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/tx_execution.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/tx_execution.test.cpp
@@ -450,5 +450,72 @@ TEST_F(TxExecutionTest, L2ToL1MessageLimitReached)
     EXPECT_EQ(reverts, 1);
 }
 
+TEST_F(TxExecutionTest, RevertibleNullifierCollisionIsUnrecoverable)
+{
+    // A nullifier collision during revertible insertion must propagate as NullifierCollisionException
+    // (not TxExecutionException), bypassing all recovery logic and making the tx unprovable.
+    Tx tx = {
+        .hash = "0x1234567890abcdef",
+        .non_revertible_accumulated_data =
+            AccumulatedData{
+                .nullifiers = testing::random_fields(1),
+            },
+        .revertible_accumulated_data =
+            AccumulatedData{
+                .nullifiers = testing::random_fields(1),
+            },
+        .fee_payer = FF::random_element(),
+    };
+
+    AppendOnlyTreeSnapshot dummy_snapshot = {
+        .root = 0,
+        .next_available_leaf_index = 0,
+    };
+    TreeStates tree_state = {
+        .note_hash_tree = { .tree = dummy_snapshot, .counter = 0 },
+        .nullifier_tree = { .tree = dummy_snapshot, .counter = 0 },
+        .l1_to_l2_message_tree = { .tree = dummy_snapshot, .counter = 0 },
+        .public_data_tree = { .tree = dummy_snapshot, .counter = 0 },
+    };
+    ON_CALL(merkle_db, get_tree_state()).WillByDefault([&]() { return tree_state; });
+
+    // First call (non-revertible) succeeds, second call (revertible) collides.
+    EXPECT_CALL(merkle_db, siloed_nullifier_write(_))
+        .WillOnce([&](const auto& /*nullifier*/) { tree_state.nullifier_tree.counter++; })
+        .WillOnce([](const auto& /*nullifier*/) { throw NullifierCollisionException("Nullifier collision"); });
+
+    EXPECT_THROW(tx_execution.simulate(tx), NullifierCollisionException);
+}
+
+TEST_F(TxExecutionTest, NonRevertibleNullifierCollisionIsUnrecoverable)
+{
+    // A nullifier collision during non-revertible insertion must propagate as NullifierCollisionException.
+    Tx tx = {
+        .hash = "0x1234567890abcdef",
+        .non_revertible_accumulated_data =
+            AccumulatedData{
+                .nullifiers = testing::random_fields(1),
+            },
+        .fee_payer = FF::random_element(),
+    };
+
+    AppendOnlyTreeSnapshot dummy_snapshot = {
+        .root = 0,
+        .next_available_leaf_index = 0,
+    };
+    TreeStates tree_state = {
+        .note_hash_tree = { .tree = dummy_snapshot, .counter = 0 },
+        .nullifier_tree = { .tree = dummy_snapshot, .counter = 0 },
+        .l1_to_l2_message_tree = { .tree = dummy_snapshot, .counter = 0 },
+        .public_data_tree = { .tree = dummy_snapshot, .counter = 0 },
+    };
+    ON_CALL(merkle_db, get_tree_state()).WillByDefault([&]() { return tree_state; });
+    ON_CALL(merkle_db, siloed_nullifier_write(_)).WillByDefault([](const auto& /*nullifier*/) {
+        throw NullifierCollisionException("Nullifier collision");
+    });
+
+    EXPECT_THROW(tx_execution.simulate(tx), NullifierCollisionException);
+}
+
 } // namespace
 } // namespace bb::avm2::simulation

--- a/yarn-project/bb-prover/src/avm_proving_tests/avm_check_circuit2.test.ts
+++ b/yarn-project/bb-prover/src/avm_proving_tests/avm_check_circuit2.test.ts
@@ -1,3 +1,4 @@
+import { MAX_NULLIFIERS_PER_TX } from '@aztec/constants';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { AvmTestContractArtifact } from '@aztec/noir-test-contracts.js/AvmTest';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
@@ -77,6 +78,10 @@ describe('AVM check-circuit – unhappy paths 2', () => {
   });
 
   it('error during revertible insertions - skips to teardown', async () => {
+    // Exceed MAX_NULLIFIERS_PER_TX during revertible insertions so that the revertible phase
+    // errors out and the tx skips to teardown. Note: nullifier *collisions* during revertible
+    // insertions are unprovable (not revertible), so we use the side-effect limit path instead.
+    const revertibleNullifiers = Array.from({ length: MAX_NULLIFIERS_PER_TX }, (_, i) => new Fr(100_000 + i));
     await tester.simProveVerify(
       sender,
       /*setupCalls=*/ [],
@@ -96,9 +101,9 @@ describe('AVM check-circuit – unhappy paths 2', () => {
       },
       /*expectRevert=*/ true,
       /*feePayer=*/ sender,
-      // duplicate nullifiers during revertible insertions!
       /*privateInsertions=*/ {
-        revertible: { nullifiers: [new Fr(100_000), /*duplicate*/ new Fr(100_000)] },
+        // Total nullifiers = 1 non-revertible + MAX_NULLIFIERS_PER_TX revertible = over the limit.
+        revertible: { nullifiers: revertibleNullifiers },
         nonRevertible: { nullifiers: [/*firstNullifier=*/ new Fr(66000)] },
       },
     );

--- a/yarn-project/bb-prover/src/avm_proving_tests/avm_check_circuit3.test.ts
+++ b/yarn-project/bb-prover/src/avm_proving_tests/avm_check_circuit3.test.ts
@@ -1,4 +1,4 @@
-import { MAX_PROCESSABLE_DA_GAS_PER_CHECKPOINT, MAX_PROCESSABLE_L2_GAS } from '@aztec/constants';
+import { MAX_NULLIFIERS_PER_TX, MAX_PROCESSABLE_DA_GAS_PER_CHECKPOINT, MAX_PROCESSABLE_L2_GAS } from '@aztec/constants';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { AvmTestContractArtifact } from '@aztec/noir-test-contracts.js/AvmTest';
@@ -106,13 +106,18 @@ describe('AVM check-circuit – unhappy paths 3', () => {
   );
 
   it(
-    'top-level exceptional halt during revertible nullifiers (collision), remaining revertibles are skipped, and teardown is fine',
+    'top-level exceptional halt during revertible nullifiers (limit reached), remaining revertibles are skipped, and teardown is fine',
     async () => {
+      // Note: nullifier *collisions* during revertible insertions are unprovable (not revertible),
+      // so we use the side-effect limit path to exercise the skip-to-teardown behavior.
+      // 1 non-revertible + MAX_NULLIFIERS_PER_TX revertible exceeds the limit on the last revertible
+      // nullifier insertion; subsequent revertible note hashes and L2→L1 messages are skipped.
+      const revertibleNullifiers = Array.from({ length: MAX_NULLIFIERS_PER_TX }, (_, i) => new Fr(100_000 + i));
       await tester.simProveVerify(
         sender,
         /*setupCalls=*/ [],
         /*appCalls=*/ [
-          // skipped after nullifier collision
+          // skipped after the revertible insertion failure
           { address: avmTestContractInstance.address, fnName: 'add_args_return', args: [new Fr(1), new Fr(2)] },
         ],
         // and progression to teardown should be fine!
@@ -125,14 +130,7 @@ describe('AVM check-circuit – unhappy paths 3', () => {
         /*feePayer=*/ sender,
         /*privateInsertions=*/ {
           revertible: {
-            // nullifier collision ends revertible insertions and skips to teardown
-            nullifiers: [
-              new Fr(66666),
-              new Fr(42000),
-              /*duplicate*/ new Fr(66666),
-              /*rest are skipped*/ new Fr(11111),
-              new Fr(22222),
-            ],
+            nullifiers: revertibleNullifiers,
             // skipped ...
             noteHashes: [new Fr(11111), new Fr(22222), new Fr(33333), new Fr(44444), new Fr(55555)],
             // skipped ...

--- a/yarn-project/simulator/docs/avm/errors.md
+++ b/yarn-project/simulator/docs/avm/errors.md
@@ -21,7 +21,7 @@ An **error** occurs when the AVM encounters an invalid condition during executio
 | `RELATIVE_ADDRESS_OVERFLOW` | Base address + relative offset exceeds max memory | Validation | No |
 | `STATIC_CALL_VIOLATION` | State-modifying operation in static context | Execution | No |
 | `SIDE_EFFECT_LIMIT_REACHED` | Transaction limit exceeded for a side effect type | Execution | Yes |
-| `NULLIFIER_COLLISION` | Emitted nullifier already exists | Execution (opcode-specific) | Yes |
+| `NULLIFIER_COLLISION` | Emitted nullifier already exists | Execution (opcode-specific) | Yes (unprovable) |
 | `INTERNAL_CALL_STACK_UNDERFLOW` | INTERNALRETURN with empty internal call stack | Execution (opcode-specific) | No |
 | `DIVISION_BY_ZERO` | Division or modulo operation with divisor = 0 | Execution (opcode-specific) | No |
 | `POINT_NOT_ON_CURVE` | ECADD operand is not a valid Grumpkin curve point | Execution (opcode-specific) | No |
@@ -38,6 +38,10 @@ An **error** occurs when the AVM encounters an invalid condition during executio
 | **Exceptional halt** | Failure | All allocated gas consumed | Changes discarded | `OUT_OF_GAS`, `TAG_MISMATCH` |
 | **Explicit REVERT** | Failure | Unused gas refunded | Changes discarded | REVERT instruction |
 | **Explicit RETURN** | Success | Unused gas refunded | Changes merged | RETURN instruction |
+
+### Note on `NULLIFIER_COLLISION` during private insertions
+
+During opcode execution (`EMITNULLIFIER`), a nullifier collision is a regular exceptional halt that reverts the enqueued call. However, during tx-level insertion of private nullifiers (both non-revertible and revertible phases), a collision makes the transaction **unprovable** rather than revertible. See [Public Transaction Simulation](./public-tx-simulation.md) for details.
 
 
 ---

--- a/yarn-project/simulator/docs/avm/public-tx-simulation.md
+++ b/yarn-project/simulator/docs/avm/public-tx-simulation.md
@@ -149,7 +149,9 @@ Inserted **after** the post-setup checkpoint:
 - **Note hashes** from private's revertible portion
 - **L2→L1 messages** from private's revertible portion
 
-If any insertion fails (e.g., nullifier collision), state rolls back to the post-setup checkpoint, and execution proceeds immediately to the TEARDOWN phase.
+If the side-effect limit is reached (e.g., max nullifiers per tx exceeded), state rolls back to the post-setup checkpoint, and execution proceeds immediately to the TEARDOWN phase.
+
+A **nullifier collision** during revertible insertion results in the transaction being discarded entirely. Nullifier collisions from privately emitted nullifiers are disallowed regardless of the phase.
 
 ## Gas Allocation and Metering
 

--- a/yarn-project/simulator/src/public/public_processor/apps_tests/deployments.test.ts
+++ b/yarn-project/simulator/src/public/public_processor/apps_tests/deployments.test.ts
@@ -218,9 +218,10 @@ describe.each([
         },
       ],
     );
-    // FIXME(#12375): should be able to include the nullifier insertions, but at the moment
-    // tx simulator cannot recover from errors during revertible private insertions.
-    // Once fixed, this skipNullifierInsertion flag can be removed.
+    // We must skip the nullifier insertions here because this tx re-deploys the same contract
+    // class/instance as the first tx, which would produce a nullifier collision. By design, a
+    // nullifier collision during tx-level revertible insertions is unprovable (not revertible),
+    // so without this flag the tx would be thrown out rather than reverting in app logic.
     await addNewContractClassToTx(failingConstructorTx, contractClass, /*skipNullifierInsertion=*/ true);
     await addNewContractInstanceToTx(failingConstructorTx, contractInstance, /*skipNullifierInsertion=*/ true);
 

--- a/yarn-project/simulator/src/public/public_tx_simulator/public_tx_simulator.test.ts
+++ b/yarn-project/simulator/src/public/public_tx_simulator/public_tx_simulator.test.ts
@@ -1092,8 +1092,9 @@ describe('public_tx_simulator', () => {
     });
   });
 
-  it('nullifier collision in insertRevertiblesFromPrivate skips app logic but executes teardown', async () => {
-    // Mock a transaction with all three phases
+  it('nullifier collision in insertRevertiblesFromPrivate is unrecoverable', async () => {
+    // A nullifier collision during revertible insertions is unprovable (matches AVM circuit behavior).
+    // The NullifierCollisionError propagates out of simulate() rather than triggering a soft revert.
     const tx = await mockTxWithPublicCalls({
       numberOfSetupCalls: 1,
       numberOfAppLogicCalls: 1,
@@ -1104,16 +1105,7 @@ describe('public_tx_simulator', () => {
     tx.data.forPublic!.revertibleAccumulatedData.nullifiers[0] = duplicateNullifier;
     tx.data.forPublic!.revertibleAccumulatedData.nullifiers[1] = duplicateNullifier;
 
-    // Simulate the transaction
-    const txResult = await simulator.simulate(tx);
-
-    // Verify that the transaction has app logic reverted code
-    expect(txResult.revertCode).toEqual(RevertCode.APP_LOGIC_REVERTED);
-
-    // Verify that the SimulationError contains information about the nullifier collision
-    const revertReason = txResult.findRevertReason();
-    expect(revertReason).toBeDefined();
-    expect(revertReason?.getOriginalMessage()).toContain('Nullifier collision');
+    await expect(simulator.simulate(tx)).rejects.toThrow(/Nullifier collision/);
   });
 
   describe('prover id', () => {

--- a/yarn-project/simulator/src/public/public_tx_simulator/public_tx_simulator.ts
+++ b/yarn-project/simulator/src/public/public_tx_simulator/public_tx_simulator.ts
@@ -27,7 +27,6 @@ import { type PublicContractsDB, PublicTreesDB } from '../public_db_sources.js';
 import {
   L2ToL1MessageLimitReachedError,
   NoteHashLimitReachedError,
-  NullifierCollisionError,
   NullifierLimitReachedError,
 } from '../side_effect_errors.js';
 import type { PublicPersistableStateManager } from '../state_manager/state_manager.js';
@@ -147,7 +146,8 @@ export class PublicTxSimulator implements PublicTxSimulatorInterface {
     hintingContractsDB.createCheckpoint();
 
     try {
-      // This will throw if there is a nullifier collision or other insertion error (limit reached).
+      // This may throw: a side-effect limit error triggers a soft revert (caught below), while a
+      // nullifier collision is unrecoverable and propagates out of simulate() to throw out the tx.
       await this.insertRevertiblesFromPrivate(context);
 
       // Only proceed with app logic if there was no revert during revertible insertion.
@@ -409,9 +409,13 @@ export class PublicTxSimulator implements PublicTxSimulatorInterface {
    * Throws TxSimRevertibleInsertionsRevert if there is some checked error during revertible insertions.
    * This function checks for the following errors:
    * - NullifierLimitReachedError
-   * - NullifierCollisionError
    * - NoteHashLimitReachedError
    * - L2ToL1MessageLimitReachedError
+   *
+   * Note: NullifierCollisionError is intentionally NOT caught here. A nullifier collision
+   * during revertible insertions is unprovable (the nullifier originated from private, so
+   * a collision indicates the tx should never have been proposed). It propagates as-is to
+   * make the transaction unrecoverable, matching the AVM circuit behavior.
    */
   protected async insertRevertiblesFromPrivate(context: PublicTxContext) {
     const stateManager = context.state.getActiveStateManager();
@@ -421,7 +425,7 @@ export class PublicTxSimulator implements PublicTxSimulatorInterface {
         await stateManager.writeSiloedNullifier(siloedNullifier);
       }
     } catch (e: any) {
-      if (e instanceof NullifierLimitReachedError || e instanceof NullifierCollisionError) {
+      if (e instanceof NullifierLimitReachedError) {
         context.revert(
           TxExecutionPhase.APP_LOGIC,
           new SimulationError(
@@ -431,7 +435,7 @@ export class PublicTxSimulator implements PublicTxSimulatorInterface {
         );
         throw new TxSimRevertibleInsertionsRevert();
       } else {
-        // Unchecked/unknown error - re-throw as-is
+        // Unchecked/unknown error or NullifierCollisionError (unrecoverable) - re-throw as-is
         throw e;
       }
     }


### PR DESCRIPTION
The AVM now considers emitting a duplicate private nullifier an unrecoverable error, even if it occurred in the revertible phase.

The transaction is invalid and unprovable. Note that exceeding the emitted nullifier side effect limit during the **revertible** phase is still considered recoverable