### PR TITLE
fix: increase gossipsub mcache length to prevent valid messages being dropped

### DIFF
--- a/yarn-project/p2p/src/config.ts
+++ b/yarn-project/p2p/src/config.ts
@@ -371,7 +371,7 @@ export const p2pConfigMappings: ConfigMappingsType<P2PConfig> = {
   gossipsubMcacheLength: {
     env: 'P2P_GOSSIPSUB_MCACHE_LENGTH',
     description: 'The number of gossipsub interval message cache windows to keep.',
-    ...numberConfigHelper(6),
+    ...numberConfigHelper(12),
   },
   gossipsubMcacheGossip: {
     env: 'P2P_GOSSIPSUB_MCACHE_GOSSIP',

--- a/yarn-project/p2p/src/services/libp2p/instrumentation.ts
+++ b/yarn-project/p2p/src/services/libp2p/instrumentation.ts
@@ -18,6 +18,7 @@ export class P2PInstrumentation {
   private messagePrevalidationCount: UpDownCounter;
   private messageLatency: Histogram;
   private txReceivedCount: UpDownCounter;
+  private slowValidationCount: UpDownCounter;
 
   private aggLatencyHisto = new Map<TopicType, RecordableHistogram>();
   private aggValidationHisto = new Map<TopicType, RecordableHistogram>();
@@ -47,6 +48,15 @@ export class P2PInstrumentation {
     this.messageLatency = meter.createHistogram(Metrics.P2P_GOSSIP_MESSAGE_LATENCY);
 
     this.txReceivedCount = createUpDownCounterWithDefault(meter, Metrics.P2P_GOSSIP_TX_RECEIVED_COUNT);
+
+    this.slowValidationCount = createUpDownCounterWithDefault(meter, Metrics.P2P_GOSSIP_SLOW_VALIDATION_COUNT, {
+      [Attributes.TOPIC_NAME]: [
+        TopicType.tx,
+        TopicType.block_proposal,
+        TopicType.checkpoint_proposal,
+        TopicType.checkpoint_attestation,
+      ],
+    });
 
     this.aggLatencyMetrics = {
       avg: meter.createObservableGauge(Metrics.P2P_GOSSIP_AGG_MESSAGE_LATENCY_AVG),
@@ -85,6 +95,10 @@ export class P2PInstrumentation {
 
   public incrementTxReceived(count: number) {
     this.txReceivedCount.add(count);
+  }
+
+  public incSlowValidation(topicName: TopicType) {
+    this.slowValidationCount.add(1, { [Attributes.TOPIC_NAME]: topicName });
   }
 
   public incMessagePrevalidationStatus(passed: boolean, topicName: TopicType | undefined) {

--- a/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
+++ b/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
@@ -920,7 +920,8 @@ export class LibP2PService extends WithTracer implements P2PService {
     const validationTimeMs = timer.ms();
     const mcacheWindowMs = this.config.gossipsubMcacheLength * this.config.gossipsubInterval;
     if (validationTimeMs > mcacheWindowMs * 0.75) {
-      this.logger.debug(
+      this.instrumentation.incSlowValidation(topicType);
+      this.logger.warn(
         `Gossip validation for ${topicType} took ${validationTimeMs}ms, approaching mcache eviction window of ${mcacheWindowMs}ms. ` +
           `Message forwarding may be skipped if validation exceeds the window.`,
         { msgId, source: source.toString(), topicType, validationTimeMs, mcacheWindowMs },

--- a/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
+++ b/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
@@ -920,7 +920,7 @@ export class LibP2PService extends WithTracer implements P2PService {
     const validationTimeMs = timer.ms();
     const mcacheWindowMs = this.config.gossipsubMcacheLength * this.config.gossipsubInterval;
     if (validationTimeMs > mcacheWindowMs * 0.75) {
-      this.logger.warn(
+      this.logger.debug(
         `Gossip validation for ${topicType} took ${validationTimeMs}ms, approaching mcache eviction window of ${mcacheWindowMs}ms. ` +
           `Message forwarding may be skipped if validation exceeds the window.`,
         { msgId, source: source.toString(), topicType, validationTimeMs, mcacheWindowMs },

--- a/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
+++ b/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
@@ -917,6 +917,16 @@ export class LibP2PService extends WithTracer implements P2PService {
       this.logger.error(`Error validating gossipsub message`, err, { msgId, source: source.toString(), topicType });
     }
 
+    const validationTimeMs = timer.ms();
+    const mcacheWindowMs = this.config.gossipsubMcacheLength * this.config.gossipsubInterval;
+    if (validationTimeMs > mcacheWindowMs * 0.75) {
+      this.logger.warn(
+        `Gossip validation for ${topicType} took ${validationTimeMs}ms, approaching mcache eviction window of ${mcacheWindowMs}ms. ` +
+          `Message forwarding may be skipped if validation exceeds the window.`,
+        { msgId, source: source.toString(), topicType, validationTimeMs, mcacheWindowMs },
+      );
+    }
+
     if (resultAndObj.result === TopicValidatorResult.Accept) {
       this.logger.debug(`Message ${topicType} accepted by validator`, { msgId, source: source.toString(), topicType });
       this.instrumentation.recordMessageValidation(topicType, timer);

--- a/yarn-project/telemetry-client/src/metrics.ts
+++ b/yarn-project/telemetry-client/src/metrics.ts
@@ -940,6 +940,12 @@ export const P2P_GOSSIP_AGG_MESSAGE_VALIDATION_DURATION_AVG: MetricDefinition = 
   valueType: ValueType.INT,
 };
 
+export const P2P_GOSSIP_SLOW_VALIDATION_COUNT: MetricDefinition = {
+  name: 'aztec.p2p.gossip.slow_validation_count',
+  description: 'Number of gossip validations that exceeded 75% of the mcache eviction window',
+  valueType: ValueType.INT,
+};
+
 export const PUBLIC_PROCESSOR_TX_DURATION: MetricDefinition = {
   name: 'aztec.public_processor.tx_duration',
   description: 'Duration to process a public transaction',


### PR DESCRIPTION
## Summary

- Doubles the gossipsub `mcacheLength` default from 6 to 12, extending the async validation window from ~4.2s to ~8.4s (~12% of a 72s slot)
- Adds a warning log when gossip validation time approaches 75% of the mcache eviction window for early detection

The gossipsub message cache eviction window (`mcacheLength × heartbeatInterval`) was too short at ~4.2s. When `asyncValidation` is enabled, `reportMessageValidationResult(Accept)` only forwards a message if it's still in the mcache. Checkpoint attestation validation involves epoch cache lookups (potentially cold L1 RPC calls) and signature recovery, which can exceed this window under load, causing valid messages to be silently dropped.

Fixes [A-763](https://linear.app/aztec-labs/issue/A-763/audit-94-gossip-validation-timeout-too-short-for-block)