### PR TITLE
fix(p2p): replace non-null assertions on blockStream with explicit checks

### DIFF
--- a/yarn-project/p2p/src/client/p2p_client.ts
+++ b/yarn-project/p2p/src/client/p2p_client.ts
@@ -257,7 +257,11 @@ export class P2PClient extends WithTracer implements P2P {
       });
     }
 
-    this.blockStream!.start();
+    // Should never happen: all branches above call initBlockStream()
+    if (!this.blockStream) {
+      throw new Error('Block stream not initialized');
+    }
+    this.blockStream.start();
     await this.txCollection.start();
     this.txFileStore?.start();
 
@@ -319,7 +323,11 @@ export class P2PClient extends WithTracer implements P2P {
   /** Triggers a sync to the archiver. Used for testing. */
   public async sync() {
     this.initBlockStream();
-    await this.blockStream!.sync();
+    // Should never happen: initBlockStream() creates blockStream if absent
+    if (!this.blockStream) {
+      throw new Error('Block stream not initialized');
+    }
+    await this.blockStream.sync();
   }
 
   @trackSpan('p2pClient.broadcastProposal', async proposal => ({


### PR DESCRIPTION
Replace `!` non-null assertions on `blockStream` with explicit null checks that throw.

Fixes [A-739](https://linear.app/aztec-labs/issue/A-739/audit-63-non-null-assertion-on-potentially-undefined-blockstream)