### PR TITLE
fix(e2e): pause L1 mining during slot query + warp in epochs_ha_sync

### DIFF
--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_ha_sync.test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_ha_sync.test.ts
@@ -152,13 +152,14 @@ describe('e2e_epochs/epochs_ha_sync', () => {
 
     // Warp to 1 L1 slot before the start of the following L2 slot, so sequencers start cleanly.
     // We don't warp to the next L2 slot because we may already be less than 1 L1 slot before it.
-    const currentSlot = await rollup.getSlotNumber();
-    const nextSlot = SlotNumber(currentSlot + 2);
-    const nextSlotTimestamp = getTimestampForSlot(nextSlot, test.constants);
-    await context.cheatCodes.eth.warp(Number(nextSlotTimestamp) - test.L1_BLOCK_TIME_IN_S, {
-      resetBlockInterval: true,
+    // Pause L1 mining so the chain doesn't advance past the warp target between the slot query and the warp call.
+    await context.cheatCodes.eth.execWithPausedAnvil(async () => {
+      const currentSlot = await rollup.getSlotNumber();
+      const nextSlot = SlotNumber(currentSlot + 2);
+      const nextSlotTimestamp = getTimestampForSlot(nextSlot, test.constants);
+      await context.cheatCodes.eth.warp(Number(nextSlotTimestamp) - test.L1_BLOCK_TIME_IN_S);
+      logger.warn(`Warped to 1 L1 slot before L2 slot ${nextSlot}.`);
     });
-    logger.warn(`Warped to 1 L1 slot before L2 slot ${nextSlot}.`);
 
     // Start the sequencers on all nodes.
     await Promise.all(nodes.map(n => n.getSequencer()!.start()));

--- a/yarn-project/validator-client/src/proposal_handler.test.ts
+++ b/yarn-project/validator-client/src/proposal_handler.test.ts
@@ -199,7 +199,9 @@ describe('ProposalHandler checkpoint validation', () => {
       } as any;
       blockSource.getBlockDataByArchive.mockResolvedValue(blockData);
 
-      jest.spyOn(handler, 'handleCheckpointProposal').mockResolvedValue({ isValid: true });
+      jest
+        .spyOn(handler, 'handleCheckpointProposal')
+        .mockResolvedValue({ isValid: true, checkpointNumber: CheckpointNumber(3) });
 
       handler.register(p2p, true, archiver);
       await checkpointHandler!(proposal, {} as any);


### PR DESCRIPTION
Fixes a ~1.7% flake in `epochs_ha_sync` caused by a race between Anvil's interval mining and the test's slot computation + warp sequence. During the ~8s spent proving/sending transactions, L1 blocks kept being mined, and by the time `warp()` was called, the chain had already advanced past the target timestamp. Wraps the slot query + warp in `execWithPausedAnvil` so L1 can't advance between the two calls.

Fixes [A-892](https://linear.app/aztec-labs/issue/A-892/fix-the-ha-sync-test)
