### PR TITLE
fix: update FaceID wallet redirects and strip anchors in redirect validation

### DIFF
--- a/docs/netlify.toml
+++ b/docs/netlify.toml
@@ -334,11 +334,11 @@
 # FaceID wallet redirect (page removed)
 [[redirects]]
     from = "/developers/tutorials/codealong/faceid_wallet"
-    to = "/developers/docs/tutorials"
+    to = "/developers/docs/tutorials/contract_tutorials/counter_contract"
 
 [[redirects]]
     from = "/developers/docs/tutorials/faceid_wallet"
-    to = "/developers/docs/tutorials"
+    to = "/developers/docs/tutorials/contract_tutorials/counter_contract"
 
 # Legacy network paths - SPECIFIC PATHS MUST COME BEFORE WILDCARDS
 # (Netlify processes redirects top-to-bottom, first match wins)
@@ -594,7 +594,7 @@
 
 [[redirects]]
     from = "/developers/docs/guides/local_env/advanced/faceid_wallet"
-    to = "/developers/docs/tutorials/faceid_wallet"
+    to = "/developers/docs/tutorials/contract_tutorials/counter_contract"
 
 [[redirects]]
     from = "/developers/docs/guides/local_env/*"

--- a/docs/scripts/validate_redirect_targets.sh
+++ b/docs/scripts/validate_redirect_targets.sh
@@ -291,8 +291,11 @@ while IFS= read -r to_path; do
     continue
   fi
 
+  # Strip fragment identifiers (#anchor) before validation
+  check_path="${to_path%%#*}"
+
   # Validate the path
-  if check_docs_path "$to_path"; then
+  if check_docs_path "$check_path"; then
     VALIDATED_COUNT=$((VALIDATED_COUNT + 1))
   else
     INVALID_PATHS="${INVALID_PATHS}  - ${to_path}\n"


### PR DESCRIPTION
## Summary
- Update three stale FaceID wallet redirect targets to point to `/developers/docs/tutorials/contract_tutorials/counter_contract` instead of the generic tutorials index
- Fix redirect validation script to strip `#anchor` fragments before path validation so targets with anchors don't falsely fail

## Test plan
- [ ] Run `docs/scripts/validate_redirect_targets.sh` and confirm no false positives from anchored paths
- [ ] Verify the three updated redirects resolve correctly on a deploy preview