### PR TITLE
fix(telemetry-client): log warning when BatchSpanProcessor drops spans

### DIFF
--- a/yarn-project/telemetry-client/src/monitored_batch_span_processor.ts
+++ b/yarn-project/telemetry-client/src/monitored_batch_span_processor.ts
@@ -1,0 +1,72 @@
+import type { Logger } from '@aztec/foundation/log';
+
+import type { Context } from '@opentelemetry/api';
+import type { SpanExporter } from '@opentelemetry/sdk-trace-base';
+import { BatchSpanProcessor, type BufferConfig, type ReadableSpan, type Span } from '@opentelemetry/sdk-trace-node';
+
+/** Minimum interval between drop warnings to avoid log spam. */
+const DROP_WARNING_INTERVAL_MS = 30_000;
+
+/**
+ * Wraps BatchSpanProcessor to emit warnings when spans are dropped due to a full queue.
+ * The standard BatchSpanProcessor silently discards spans when its internal queue reaches
+ * maxQueueSize, making telemetry data loss invisible to operators.
+ */
+export class MonitoredBatchSpanProcessor extends BatchSpanProcessor {
+  private readonly maxQueueSize: number;
+  private readonly log: Logger;
+
+  private approxQueueSize = 0;
+  private droppedSinceLastWarning = 0;
+  private totalDropped = 0;
+  private lastWarningTime = 0;
+
+  constructor(exporter: SpanExporter, log: Logger, config?: BufferConfig) {
+    const maxQueueSize = config?.maxQueueSize ?? 2048;
+    super(exporter, { ...config, maxQueueSize });
+    this.maxQueueSize = maxQueueSize;
+    this.log = log;
+  }
+
+  override onStart(span: Span, parentContext: Context): void {
+    super.onStart(span, parentContext);
+  }
+
+  override onEnd(span: ReadableSpan): void {
+    if (this.approxQueueSize >= this.maxQueueSize) {
+      this.droppedSinceLastWarning++;
+      this.totalDropped++;
+      this.maybeLogDropWarning();
+    } else {
+      this.approxQueueSize++;
+    }
+    super.onEnd(span);
+  }
+
+  override async forceFlush(): Promise<void> {
+    await super.forceFlush();
+    this.approxQueueSize = 0;
+  }
+
+  override async shutdown(): Promise<void> {
+    if (this.totalDropped > 0) {
+      this.log.warn(`BatchSpanProcessor shutting down with ${this.totalDropped} total spans dropped`, {
+        totalDropped: this.totalDropped,
+      });
+    }
+    await super.shutdown();
+  }
+
+  private maybeLogDropWarning(): void {
+    const now = Date.now();
+    if (now - this.lastWarningTime >= DROP_WARNING_INTERVAL_MS) {
+      this.log.warn(
+        `BatchSpanProcessor dropping spans: queue full (maxQueueSize=${this.maxQueueSize}). ` +
+          `${this.droppedSinceLastWarning} dropped since last warning, ${this.totalDropped} total.`,
+        { droppedSinceLastWarning: this.droppedSinceLastWarning, totalDropped: this.totalDropped },
+      );
+      this.droppedSinceLastWarning = 0;
+      this.lastWarningTime = now;
+    }
+  }
+}

--- a/yarn-project/telemetry-client/src/otel.ts
+++ b/yarn-project/telemetry-client/src/otel.ts
@@ -28,11 +28,12 @@ import {
   type PeriodicExportingMetricReaderOptions,
   View,
 } from '@opentelemetry/sdk-metrics';
-import { BatchSpanProcessor, NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
+import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
 import { ATTR_SERVICE_NAME, ATTR_SERVICE_VERSION } from '@opentelemetry/semantic-conventions';
 
 import type { TelemetryClientConfig } from './config.js';
 import { toMetricOptions } from './metric-utils.js';
+import { MonitoredBatchSpanProcessor } from './monitored_batch_span_processor.js';
 import type { MetricDefinition } from './metrics.js';
 import { NodejsMetricsMonitor } from './nodejs_metrics_monitor.js';
 import { OtelFilterMetricExporter, PublicOtelFilterMetricExporter } from './otel_filter_metric_exporter.js';
@@ -343,7 +344,7 @@ export class OpenTelemetryClient implements TelemetryClient {
       const tracerProvider = new NodeTracerProvider({
         resource,
         spanProcessors: config.tracesCollectorUrl
-          ? [new BatchSpanProcessor(new OTLPTraceExporter({ url: config.tracesCollectorUrl.href }))]
+          ? [new MonitoredBatchSpanProcessor(new OTLPTraceExporter({ url: config.tracesCollectorUrl.href }), log)]
           : [],
       });
 

--- a/yarn-project/telemetry-client/src/otel.ts
+++ b/yarn-project/telemetry-client/src/otel.ts
@@ -33,8 +33,8 @@ import { ATTR_SERVICE_NAME, ATTR_SERVICE_VERSION } from '@opentelemetry/semantic
 
 import type { TelemetryClientConfig } from './config.js';
 import { toMetricOptions } from './metric-utils.js';
-import { MonitoredBatchSpanProcessor } from './monitored_batch_span_processor.js';
 import type { MetricDefinition } from './metrics.js';
+import { MonitoredBatchSpanProcessor } from './monitored_batch_span_processor.js';
 import { NodejsMetricsMonitor } from './nodejs_metrics_monitor.js';
 import { OtelFilterMetricExporter, PublicOtelFilterMetricExporter } from './otel_filter_metric_exporter.js';
 import { registerOtelLoggerProvider } from './otel_logger_provider.js';


### PR DESCRIPTION
## Summary

- Fixes A-747: The OTel `BatchSpanProcessor` silently drops spans when its internal queue is full. Introduced `MonitoredBatchSpanProcessor` that extends it, tracks approximate queue depth, and emits rate-limited warnings (every 30s) when drops are detected. Also logs total drops on shutdown.

## Test plan

- Verify telemetry client starts correctly with the new processor
- Under high span volume, confirm warning logs appear instead of silent drops
- Existing telemetry tests should pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)