### PR TITLE
fix(telemetry-client): use appropriate histogram buckets for L1 gas prices

### DIFF
--- a/yarn-project/node-lib/src/metrics/l1_tx_metrics.ts
+++ b/yarn-project/node-lib/src/metrics/l1_tx_metrics.ts
@@ -92,17 +92,19 @@ export class L1TxMetrics implements IL1TxMetrics {
     const attempts = isCancelTx ? state.cancelTxHashes.length : state.txHashes.length;
     this.txAttemptsUntilMined.record(attempts, attributes);
 
-    // Record gas prices at end state (in wei as integers)
-    const maxPriorityFeeWei = Number(state.gasPrice.maxPriorityFeePerGas);
-    const maxFeeWei = Number(state.gasPrice.maxFeePerGas);
-    const blobFeeWei = state.gasPrice.maxFeePerBlobGas ? Number(state.gasPrice.maxFeePerBlobGas) : undefined;
+    // Record gas prices at end state, converted from wei to gwei to match metric unit definitions
+    const weiToGwei = 1e9;
+    const maxPriorityFeeGwei = Number(state.gasPrice.maxPriorityFeePerGas) / weiToGwei;
+    const maxFeeGwei = Number(state.gasPrice.maxFeePerGas) / weiToGwei;
+    const blobFeeGwei = state.gasPrice.maxFeePerBlobGas
+      ? Number(state.gasPrice.maxFeePerBlobGas) / weiToGwei
+      : undefined;
 
-    this.maxPriorityFeeHistogram.record(maxPriorityFeeWei, attributes);
-    this.maxFeeHistogram.record(maxFeeWei, attributes);
+    this.maxPriorityFeeHistogram.record(maxPriorityFeeGwei, attributes);
+    this.maxFeeHistogram.record(maxFeeGwei, attributes);
 
-    // Record blob fee if present (in wei as integer)
-    if (blobFeeWei !== undefined) {
-      this.blobFeeHistogram.record(blobFeeWei, attributes);
+    if (blobFeeGwei !== undefined) {
+      this.blobFeeHistogram.record(blobFeeGwei, attributes);
     }
 
     this.logger.debug(`Recorded tx end state metrics`, {

--- a/yarn-project/node-lib/src/metrics/l1_tx_metrics.ts
+++ b/yarn-project/node-lib/src/metrics/l1_tx_metrics.ts
@@ -113,9 +113,9 @@ export class L1TxMetrics implements IL1TxMetrics {
       isCancelTx,
       isReverted,
       scope: this.scope,
-      maxPriorityFeeWei,
-      maxFeeWei,
-      blobFeeWei,
+      maxPriorityFeeGwei,
+      maxFeeGwei,
+      blobFeeGwei,
     });
   }
 

--- a/yarn-project/telemetry-client/src/otel.ts
+++ b/yarn-project/telemetry-client/src/otel.ts
@@ -334,6 +334,36 @@ export class OpenTelemetryClient implements TelemetryClient {
             true,
           ),
         }),
+        // L1 gas prices in gwei: priority fees ~0.01-10, base fees ~1-500, spikes to 1000+
+        new View({
+          instrumentType: InstrumentType.HISTOGRAM,
+          instrumentUnit: 'gwei',
+          aggregation: new ExplicitBucketHistogramAggregation(
+            [0.1, 0.5, 1, 2, 5, 10, 20, 50, 100, 200, 500, 1_000],
+            true,
+          ),
+        }),
+        // L1 gas consumption: tx gas 100k-30M, calldata/blob gas varies
+        new View({
+          instrumentType: InstrumentType.HISTOGRAM,
+          instrumentUnit: 'gas',
+          aggregation: new ExplicitBucketHistogramAggregation(
+            [
+              10_000, 50_000, 100_000, 250_000, 500_000, 1_000_000, 2_000_000, 5_000_000, 10_000_000, 15_000_000,
+              30_000_000,
+            ],
+            true,
+          ),
+        }),
+        // L1 tx total fee in ETH: typically 0.001 - 1 ETH
+        new View({
+          instrumentType: InstrumentType.HISTOGRAM,
+          instrumentUnit: 'eth',
+          aggregation: new ExplicitBucketHistogramAggregation(
+            [0.0001, 0.0005, 0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1, 5, 10],
+            true,
+          ),
+        }),
       ],
     });
   }


### PR DESCRIPTION
## Summary

- Fixes A-755: L1 gas price, gas consumption, and fee histograms were using OTel default buckets which don't match real-world distributions. Added View-based bucket configs for `gwei` (0.1–1000), `gas` (10k–30M), and `eth` (0.0001–10) unit histograms.
- Also fixed a unit mismatch in `l1_tx_metrics.ts` where gas prices were recorded in wei but the metric definitions declared gwei as the unit. Now converts wei to gwei before recording.

## Test plan

- Verify metrics are emitted with correct bucket boundaries in Grafana after deployment
- Existing telemetry and publisher tests should pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)