### PR TITLE
docs: add Alpha Network page and update privacy/limitations docs

### DIFF
--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -52,14 +52,14 @@ For development:
 
 The preprocessing system uses these environment variables:
 
-| Variable       | Description                                                         | Default                                  |
-| -------------- | ------------------------------------------------------------------- | ---------------------------------------- |
-| `RELEASE_TYPE` | Release type: `nightly`, `devnet`, `testnet`, `mainnet`             | `nightly`                                |
-| `NIGHTLY_TAG`  | Version for nightly builds (falls back to `COMMIT_TAG`)             | from `developer_version_config.json`     |
-| `DEVNET_TAG`   | Version for devnet builds                                           | from `developer_version_config.json`     |
-| `TESTNET_TAG`  | Version for testnet builds                                          | from `developer_version_config.json`     |
-| `MAINNET_TAG`  | Version for mainnet builds                                          | from `developer_version_config.json`     |
-| `COMMIT_TAG`   | Legacy variable, used as fallback for `NIGHTLY_TAG`                 | `next`                                   |
+| Variable       | Description                                             | Default                              |
+| -------------- | ------------------------------------------------------- | ------------------------------------ |
+| `RELEASE_TYPE` | Release type: `nightly`, `devnet`, `testnet`, `mainnet` | `nightly`                            |
+| `NIGHTLY_TAG`  | Version for nightly builds (falls back to `COMMIT_TAG`) | from `developer_version_config.json` |
+| `DEVNET_TAG`   | Version for devnet builds                               | from `developer_version_config.json` |
+| `TESTNET_TAG`  | Version for testnet builds                              | from `developer_version_config.json` |
+| `MAINNET_TAG`  | Version for mainnet builds                              | from `developer_version_config.json` |
+| `COMMIT_TAG`   | Legacy variable, used as fallback for `NIGHTLY_TAG`     | `next`                               |
 
 ### Preprocessing Macros
 
@@ -165,6 +165,7 @@ The `examples/` directory contains runnable code examples that are included in d
 - **`AZTEC_NODE_URL`**: All example `index.ts` files and `run.sh` use this env var (defaults to `http://localhost:8080`). In Docker Compose, it points to `http://local-network:8080`.
 
 When adding new TypeScript examples:
+
 1. Create a directory under `examples/ts/` with `index.ts`, `config.yaml`, and empty `yarn.lock`
 2. Use `process.env.AZTEC_NODE_URL ?? "http://localhost:8080"` for the node URL
 3. Add the example to the list in `examples/ts/aztecjs_runner/run.sh` if it should be executed at runtime
@@ -248,6 +249,31 @@ Use these terms consistently throughout:
 - **Emphasis**: Use _italics_ sparingly for emphasis
 - **File paths**: Always use forward slashes (e.g., `/usr/local/bin`)
 - **Placeholders**: Use `[PLACEHOLDER_NAME]` format in examples
+- **Em-dashes (`—`)**: Do not use em-dashes. They often signal AI-generated prose and add friction when editing across tools. Rewrite with a comma, colon, parentheses, or a new sentence. Examples:
+  - ❌ `Alpha is live — bugs are expected.`
+  - ✅ `Alpha is live, and bugs are expected.`
+  - ❌ `Limits apply — number of notes, nullifiers, logs.`
+  - ✅ `Limits apply: number of notes, nullifiers, logs.`
+  - ❌ `[Networks Overview](/networks) — Technical details`
+  - ✅ `[Networks Overview](/networks): Technical details`
+
+### Heading Capitalization
+
+**Use sentence case for all headings (H1 through H6).** Only capitalize the first word and proper nouns. Do not capitalize common nouns, verbs, prepositions, articles, or conjunctions.
+
+**Examples:**
+
+- ✅ `## What Alpha is`
+- ✅ `## Known limitations and expected issues`
+- ✅ `### Proving system bugs`
+- ✅ `## State migration and rollup upgrades`
+- ✅ `## Path to beta`
+- ✅ `## How to deploy a contract`
+- ❌ `## What Alpha Is`
+- ❌ `## Known Limitations and Expected Issues`
+- ❌ `## How To Deploy A Contract`
+
+**Applying this to existing files:** When editing an existing page that uses Title Case, convert the headings you touch (and ideally the whole page) to sentence case. The goal is to converge on one style across the site, rather than preserving historical inconsistency.
 
 ### Standard Sections
 
@@ -290,7 +316,8 @@ The description should:
 - ✅ Missing context or assumptions about user knowledge
 - ✅ Outdated screenshots or version references
 - ✅ Broken markdown formatting
-- ✅ Inconsistent capitalization in headings
+- ✅ Headings using Title Case instead of sentence case (see "Heading Capitalization")
+- ✅ Em-dashes (`—`) in prose (see "Formatting Conventions")
 - ✅ Missing alt text for images
 - ✅ Security implications of commands or configurations
 
@@ -301,7 +328,7 @@ The description should:
 - ❌ Legal disclaimers or license text
 - ❌ Direct quotes from external sources
 - ❌ API endpoint URLs or configuration values
-- ❌ Existing migration notes in `resources/migration_notes.md` — never modify already-published migration entries. Instead, add new migration notes to the `## TBD` section at the top of the file.
+- ❌ Existing migration notes in `resources/migration_notes.md`. Never modify already-published migration entries. Instead, add new migration notes to the `## TBD` section at the top of the file.
 
 ## Review Output Format
 
@@ -357,5 +384,5 @@ Approved external documentation sources:
 - Suggest improvements even if they go beyond pure editing
 - When making changes to documentation processes or tooling, remember to check and update READMEs, project documentation (like this file), and code comments
 
-Last updated: 2026-03-27
-Version: 1.6
+Last updated: 2026-04-21
+Version: 1.7

--- a/docs/docs-developers/docs/resources/considerations/limitations.md
+++ b/docs/docs-developers/docs/resources/considerations/limitations.md
@@ -72,13 +72,9 @@ Ethereum has a notion of a "full node" which keeps up with the blockchain and st
 
 This pattern is likely to develop in Aztec as well, except there is a problem: privacy. If a privacy-seeking user makes a query to a third-party full node, that user might leak data about who they are, about their historical network activity, or about their future intentions. One solution to this problem is "always run a full node", but pragmatically, not everyone will. To protect less-advanced users' privacy, research is underway to explore how a privacy-seeking user may request and receive data from a third-party node without revealing what that data is, nor who is making the request.
 
-### No private data authentication
+### Limited private data authentication
 
-Private data should not be returned to an app unless the user authorizes such access to the app. An authorization layer is not yet in place.
-
-#### What are the consequences?
-
-Any app can request and receive any private user data relating to any other private app. An authorization layer will be added in due course.
+The PXE supports a `scopes` parameter that restricts which accounts' notes a function call can access. However, this is caller-specified — the app chooses its own scopes. There is no mandatory, protocol-enforced authorization layer where the PXE denies an app access to another app's private data. A wallet can restrict scope on behalf of the user, but this is not yet standardized or enforced by default.
 
 ### No client-side bytecode validation
 

--- a/docs/docs-developers/docs/resources/considerations/limitations.md
+++ b/docs/docs-developers/docs/resources/considerations/limitations.md
@@ -74,7 +74,7 @@ This pattern is likely to develop in Aztec as well, except there is a problem: p
 
 ### Limited private data authentication
 
-The PXE supports a `scopes` parameter that restricts which accounts' notes a function call can access. However, this is caller-specified — the app chooses its own scopes. There is no mandatory, protocol-enforced authorization layer where the PXE denies an app access to another app's private data. A wallet can restrict scope on behalf of the user, but this is not yet standardized or enforced by default.
+The PXE supports a `scopes` parameter that restricts which accounts' notes a function call can access. However, this is caller-specified: the app chooses its own scopes. There is no mandatory, protocol-enforced authorization layer where the PXE denies an app access to another app's private data. A wallet can restrict scope on behalf of the user, but this is not yet standardized or enforced by default.
 
 ### No client-side bytecode validation
 

--- a/docs/docs-developers/docs/resources/considerations/limitations.md
+++ b/docs/docs-developers/docs/resources/considerations/limitations.md
@@ -30,11 +30,11 @@ Help shape and define:
 ## Limitations developers need to know about
 
 - It is a testing environment, insecure and unaudited. It is only for testing purposes.
-- `msg_sender` is currently leaked when making private -> public calls.
-  - The `msg_sender` is always set. If you call a public function from the private world, the `msg_sender` is set to the private caller's address.
-  - There are patterns that can mitigate this.
+- `msg_sender` is leaked by default when making private -> public calls.
+  - `self.enqueue(...)` sets `msg_sender` to the private caller's address, which is publicly visible.
+  - Use `self.enqueue_incognito(...)` to hide the sender. The called public function must use `maybe_msg_sender()` instead of `msg_sender()` to handle the null sender.
 - The initial `msg_sender` is `-1`, which can be problematic for some contracts.
-- The number of side-effects attached to a transaction (when sending the transaction to the mempool) is leaky. At this stage of development, this is _intentional_, so that we can gauge appropriate choices for privacy sets. We have clear plans to implement privacy sets so that side effects are much less leaky, and these will be in place for mainnet.
+- Some side-effect counts are still visible in a transaction. Note hashes, nullifiers, and private logs are padded to hide their true counts, but the number of public function calls and L2->L1 messages remains visible. Privacy sets to further reduce leakage are still under development.
 - A transaction can only emit a limited number of side-effects (notes, nullifiers, logs, L2->L1 messages). See [circuit limitations](#circuit-limitations).
   - We have not settled on the final constants, since we are still in a testing phase. You could find that certain compositions of nested private function calls (for example, call stacks that are dynamic in size, based on runtime data) could accumulate so many side-effects as to exceed transaction limits. Such transactions would then be unprovable. Please open an issue if you encounter this, as it will help us decide on adequate sizes for our constants.
 - Not all Noir cryptographic primitives work in public (AVM) functions. Signature verification (ECDSA secp256k1/r1), AES-128, Blake2s, and Blake3 are not supported. See [AVM Cryptographic Compatibility](../../foundational-topics/advanced/circuits/avm_compatibility.md) for details and workarounds.
@@ -103,10 +103,6 @@ We are planning a full assessment of the protocol's hashes, including rigorous d
 #### What are the consequences?
 
 Collisions and other hash-related attacks might be possible in the local network. This would be problematic in production, but it is unlikely to cause problems at this early stage of testing.
-
-### `msg_sender` is leaked when making a private -> public call
-
-There are ongoing discussions [here](https://forum.aztec.network/t/what-is-msg-sender-when-calling-private-public-plus-a-big-foray-into-stealth-addresses/7527) (and some more recent discussions that need to be documented) around how to address this.
 
 ### New privacy standards are required
 

--- a/docs/docs-developers/docs/resources/considerations/limitations.md
+++ b/docs/docs-developers/docs/resources/considerations/limitations.md
@@ -29,7 +29,7 @@ Help shape and define:
 
 ## Limitations developers need to know about
 
-- It is a testing environment, insecure and unaudited. It is only for testing purposes.
+- The Aztec stack is unaudited and under active development. See the [Alpha Network](/participate/alpha) page for details on what this means.
 - `msg_sender` is leaked by default when making private -> public calls.
   - `self.enqueue(...)` sets `msg_sender` to the private caller's address, which is publicly visible.
   - Use `self.enqueue_incognito(...)` to hide the sender. The called public function must use `maybe_msg_sender()` instead of `msg_sender()` to handle the null sender.
@@ -42,7 +42,7 @@ Help shape and define:
 
 ## WARNING
 
-Do not use real, meaningful secrets in Aztec testnets. Some privacy features are still in development, including ensuring a secure "zk" property. Since the Aztec stack is still being developed, there are no guarantees that real secrets will remain secret.
+Do not use real, meaningful secrets on Aztec networks. Some privacy features are still in development, including ensuring a secure "zk" property. Since the Aztec stack is still being developed, there are no guarantees that real secrets will remain secret.
 
 ## Limitations
 
@@ -60,15 +60,11 @@ Some of our more complex circuits are still in development, so they are still un
 
 Sound proofs are really only needed as a protection against malicious behavior, which we are not testing for at this stage.
 
-### Keys and addresses are subject to change
+### Keys and addresses may change in future rollup versions
 
-The way in which keypairs and addresses are derived is still being iterated on as we receive feedback.
+The key derivation scheme is documented and stable within the current rollup version, but it may change in future rollup upgrades. Applications should not hardcode assumptions about the specific derivation algorithm.
 
-#### What are the consequences?
-
-This will impact the kinds of apps that you can build with the local network as it is today.
-
-Please open new discussions on [Discourse](https://discourse.aztec.network) or open issues on [GitHub](https://github.com/AztecProtocol/aztec-packages) if you have requirements that are not yet being met by the local network's current key derivation scheme.
+Please open new discussions on [Discourse](https://discourse.aztec.network) or open issues on [GitHub](https://github.com/AztecProtocol/aztec-packages) if you have requirements that are not being met by the current key derivation scheme.
 
 ### No privacy-preserving queries to nodes
 
@@ -82,19 +78,15 @@ Private data should not be returned to an app unless the user authorizes such ac
 
 #### What are the consequences?
 
-Any app can request and receive any private user data relating to any other private app. This sounds problematic, but the local network is a sandbox, and no meaningful value or credentials should be stored there - only test values and test credentials.
+Any app can request and receive any private user data relating to any other private app. An authorization layer will be added in due course.
 
-An authorization layer will be added in due course.
+### No client-side bytecode validation
 
-### No bytecode validation
-
-For safety reasons, bytecode should not be executed unless the PXE (Private eXecution Environment) or wallet has validated that the user's intentions (the function signature and contract address) match the bytecode.
+Public bytecode is validated at the protocol level when contract classes are registered (the Contract Class Registry verifies encoding and commitments). However, the PXE and wallets do not yet validate that the bytecode a user is about to execute matches their stated intentions (function signature and contract address).
 
 #### What are the consequences?
 
-Without bytecode validation, if incorrect bytecode is executed and that bytecode is malicious, it could read private data from some other contract and emit that private data to the world. This would be problematic in production, but the local network is a sandbox, and no meaningful value or credentials should be stored there - only test values and test credentials.
-
-There are plans to add bytecode validation soon.
+If incorrect or malicious bytecode is executed, it could read private data from another contract and emit it publicly. Client-side bytecode validation is planned to close this gap.
 
 ### Insecure hashes
 
@@ -102,7 +94,7 @@ We are planning a full assessment of the protocol's hashes, including rigorous d
 
 #### What are the consequences?
 
-Collisions and other hash-related attacks might be possible in the local network. This would be problematic in production, but it is unlikely to cause problems at this early stage of testing.
+Collisions and other hash-related attacks might be possible. This is unlikely to cause problems at this early stage, but is a known area of ongoing work.
 
 ### New privacy standards are required
 

--- a/docs/docs-developers/docs/resources/considerations/privacy_considerations.md
+++ b/docs/docs-developers/docs/resources/considerations/privacy_considerations.md
@@ -45,7 +45,7 @@ There are many caveats to the above. Since Aztec also enables interaction with t
 Any time a private function makes a call to a public function, information is leaked. Now, that might be perfectly fine in some use cases (it's up to the smart contract developer). Indeed, most interesting apps will require some public state. But let's have a look at some leaky patterns:
 
 - Calling a public function from a private function. The public function execution will be publicly visible.
-- Calling a public function from a private function and revealing the `msg_sender` of that call (the `msg_sender` will be publicly visible).
+- Calling a public function from a private function and revealing the `msg_sender` of that call (the `msg_sender` will be publicly visible). You can hide the sender by using `self.enqueue_incognito(...)` instead of `self.enqueue(...)`, which sets `msg_sender` to a null address. The called function must use `maybe_msg_sender()` to handle this.
 - Passing arguments to a public function from a private function. All of those arguments will be publicly visible.
 - Calling an internal public function from a private function. The fact that the call originated from a private function of that same contract will be trivially known.
 - Emitting unencrypted events from a private function. The unencrypted event name and arguments will be publicly visible.
@@ -81,17 +81,13 @@ A 'Function Fingerprint' is any data which is exposed by a function to the outsi
   - The contents of L2 -> L1 messages.
 - All public logs (topics and arguments).
 - The roots of all trees which have been read from.
-- The _number_ of ['side effects'](https://en.wikipedia.org/wiki/Side_effect_(computer_science)):
-  - \# new note hashes
-  - \# new nullifiers
-  - \# bytes of encrypted logs
+- The _number_ of some ['side effects'](https://en.wikipedia.org/wiki/Side_effect_(computer_science)). Note hashes, nullifiers, and private logs are padded to hide their true counts, but the following remain visible:
   - \# public function calls
   - \# L2->L1 messages
-  - \# nonzero roots
 
 > Note: many of these were mentioned in the ["Crossing the private to public boundary"](#crossing-the-private-to-public-boundary) section.
 
-> Note: the transaction effects submitted to L1 are [encoded (GitHub link)](https://github.com/AztecProtocol/aztec-packages/blob/master/l1-contracts/src/core/libraries/Decoder.sol) but not garbled with other transactions. The distinct Tx Fingerprint of each transaction is publicly visible when submitted to the L2 tx pool.
+> Note: the distinct Tx Fingerprint of each transaction is publicly visible when submitted to the L2 tx pool.
 
 #### Standardizing Fingerprints
 

--- a/docs/docs-developers/docs/resources/considerations/privacy_considerations.md
+++ b/docs/docs-developers/docs/resources/considerations/privacy_considerations.md
@@ -87,7 +87,7 @@ A 'Function Fingerprint' is any data which is exposed by a function to the outsi
 
 > Note: many of these were mentioned in the ["Crossing the private to public boundary"](#crossing-the-private-to-public-boundary) section.
 
-> Note: the distinct Tx Fingerprint of each transaction is publicly visible when submitted to the L2 tx pool.
+> Note: a transaction's Tx Fingerprint is the combined set of publicly observable data listed above (for example: the number of public function calls, the number of L2->L1 messages, the contents of public logs, and which tree roots were read). Anyone watching the L2 transaction pool can see this fingerprint for every transaction that is submitted, and transactions with distinctive fingerprints can be linked to specific contracts or to patterns of user behavior.
 
 #### Standardizing Fingerprints
 

--- a/docs/docs-participate/alpha.md
+++ b/docs/docs-participate/alpha.md
@@ -4,11 +4,11 @@ description: "Understand the Aztec Alpha network: its purpose, known limitations
 displayed_sidebar: participateSidebar
 ---
 
-Alpha is the Aztec mainnet in its initial operational phase. It is live on Ethereum mainnet with real staking, governance, and user transactions. It is also early, unaudited software where bugs — including critical ones — are expected.
+Alpha is the Aztec mainnet in its initial operational phase. It is live on Ethereum mainnet with real staking, governance, and user transactions. It is also early, unaudited software where bugs, including critical ones, are expected.
 
 This page is the central reference for understanding what Alpha is, what risks come with using it, and how the network will evolve.
 
-## What Alpha Is
+## What Alpha is
 
 Alpha is the first production deployment of the Aztec rollup. Governance, staking, and block production are fully operational with real economic stakes. Sequencers must stake real tokens to participate, and governance proposals have real consequences.
 
@@ -21,9 +21,17 @@ However, "production" does not mean "finished." Alpha exists to:
 
 Think of Alpha as a live stress test with real stakes. The protocol is functional, but it is not yet hardened.
 
-## Known Limitations and Expected Issues
+## What to build on Alpha
 
-### Proving System Bugs
+Alpha is an experimentation phase for developers as much as it is for the protocol. This is the moment to try things that were not possible before: private smart contracts, hybrid public/private applications, novel privacy-preserving primitives, and patterns that no other chain can support.
+
+Much like the early days of Ethereum, the applications built now will shape what Aztec becomes. Expect rough edges, breaking changes, and the need to redeploy after upgrades. In exchange, you get a first-mover opportunity to explore a new design space alongside the protocol itself. Build on [Testnet](/networks#testnet) first to iterate quickly, then deploy to Alpha when you are ready to validate against real network conditions.
+
+## Known limitations and expected issues
+
+See the [Limitations](/developers/docs/resources/considerations/limitations) page for the full list of current developer-facing limitations. The sections below summarize the highest-impact issues for Alpha users.
+
+### Proving system bugs
 
 The Aztec proving system is novel and complex. Bugs in proof generation, verification, and circuit constraints are expected during Alpha. Some circuits are still under-constrained, meaning that soundness is not fully guaranteed. In practice, this means:
 
@@ -33,11 +41,11 @@ The Aztec proving system is novel and complex. Bugs in proof generation, verific
 
 These are known risks of an early-stage ZK rollup, not unexpected failures.
 
-### Unaudited Software
+### Unaudited software
 
-No part of the Aztec stack has been fully audited. The protocol, smart contracts, client software, and cryptographic primitives are all under active development. Code is being iterated on daily and audits are ongoing.
+No part of the Aztec stack has been fully audited. The protocol, smart contracts, client software, and cryptographic primitives are all under active development. Code is being iterated on daily and audits are ongoing. Published audit reports are available in the [Aztec audit reports repository](https://github.com/AztecProtocol/audit-reports).
 
-### Privacy Is Not Guaranteed
+### Privacy is not guaranteed
 
 Some privacy features are still in development. Known leakage includes:
 
@@ -45,13 +53,11 @@ Some privacy features are still in development. Known leakage includes:
 - No privacy-preserving queries to third-party nodes exist yet
 - New privacy standards for smart contract design have not been established
 
-### Circuit and Transaction Limits
+### Circuit and transaction limits
 
-ZK-SNARK circuits impose hard upper bounds on what a single transaction can do — the number of state reads/writes, notes, nullifiers, logs, and messages. Deeply nested function calls can exceed per-transaction limits. See [Limitations](/developers/docs/resources/considerations/limitations#circuit-limitations) for current constants.
+ZK-SNARK circuits impose hard upper bounds on what a single transaction can do, including the number of state reads and writes, notes, nullifiers, logs, and messages. Deeply nested function calls can exceed per-transaction limits. See [Limitations](/developers/docs/resources/considerations/limitations#circuit-limitations) for current constants.
 
-## State Migration and Rollup Upgrades
-
-### Future upgrades will be disruptive
+## State migration and rollup upgrades
 
 As the protocol matures, it will undergo rollup upgrades through the [governance process](/participate/governance/upgrades). When a new rollup version is deployed:
 
@@ -59,40 +65,40 @@ As the protocol matures, it will undergo rollup upgrades through the [governance
 - The new rollup becomes canonical (receives block rewards)
 - The old rollup remains accessible for bridging assets in and out
 
-### State migration is difficult
+### State migration
 
 Migrating application state from one rollup version to another is a hard problem for any ZK rollup, and Aztec is no exception. You should expect that:
 
 - **State does not carry over automatically.** Application data, deployed contracts, and notes on the current rollup will not be directly accessible on a new rollup version without explicit migration steps.
 - **Migration tooling is still being developed.** There are no mature, battle-tested tools for migrating L2 state across rollup upgrades yet.
 - **Applications will need to redeploy.** Developers should plan that contracts will need to be redeployed and state reconstructed (or omitted) after a rollup upgrade.
-- **User assets can always be recovered.** The Registry model ensures that users can bridge assets out of any historical rollup version, so funds are not permanently locked.
+- **User funds are not permanently locked, but they are not immune to protocol bugs.** The Registry model ensures that users can always bridge assets out of any historical rollup version. However, a proving system bug or other protocol flaw could still allow funds to be stolen before guardrails are in place, so "not locked" is not the same as "risk-free."
 
 If you are building on Alpha, design your application with rollup upgrades in mind. Avoid assumptions about state permanence at this stage.
 
 For details on how rollup upgrades work, see [Network Upgrades](/participate/governance/upgrades).
 
-## Security Disclosures
+## Security disclosures
 
 We expect bugs, including critical ones, to be discovered during Alpha. Aztec is preparing a bug bounty program and actively conducts internal and external reviews.
 
-### Reporting Vulnerabilities
+### Reporting vulnerabilities
 
 If you discover a security vulnerability:
 
 1. **Do not** open a public GitHub issue or pull request
 2. Use [GitHub Private Vulnerability Reporting](https://github.com/AztecProtocol/aztec-packages/security/advisories/new) to submit details
-3. You can also email security@aztec.foundation (but submit full details through GitHub, not email)
+3. You can also email [security@aztec.foundation](mailto:security@aztec.foundation) (but submit full details through GitHub, not email)
 
 Mark reports as **CRITICAL** if you believe a vulnerability is actively being exploited or could result in loss of funds, key compromise, or broad user impact.
 
 For the full security policy, see [SECURITY.md](https://github.com/AztecProtocol/aztec-packages/blob/master/SECURITY.md).
 
-### Non-Security Bugs
+### Non-security bugs
 
 For bugs that are not security-sensitive (performance issues, feature requests, unexpected behavior), open a [GitHub Issue](https://github.com/AztecProtocol/aztec-packages/issues). Keeping non-security bugs public helps the community track progress and collaborate on fixes.
 
-## Path to Beta
+## Path to beta
 
 The transition from Alpha to Beta is defined by performance milestones, not a specific calendar date. The network will be considered Beta when it consistently meets the following targets:
 
@@ -104,20 +110,20 @@ The transition from Alpha to Beta is defined by performance milestones, not a sp
 
 These thresholds reflect the minimum bar for a network that application developers and users can rely on for production workloads. Until they are met, expect the instability and limitations described on this page.
 
-## What This Means for You
+## What this means for you
 
-| If you are a...            | Expect...                                                                                                                                             |
-| -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Validator / Sequencer**  | Occasional downtime, software updates, and proving failures. Stay current with node releases.                                                         |
-| **Developer**              | Breaking changes, API instability, and the need to redeploy after upgrades. Build on [Testnet](/networks#testnet) first, and design for impermanence. |
-| **Governance Participant** | An active role in shaping the protocol. Upgrades are real and consequential — participate in proposals and voting.                                    |
-| **User**                   | A functional but rough experience. Do not store meaningful secrets or rely on state permanence.                                                       |
+| If you are a...            | Expect...                                                                                                                                               |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Validator / Sequencer**  | Occasional downtime, software updates, and proving failures. Stay current with node releases.                                                           |
+| **Developer**              | Breaking changes, API instability, and the need to redeploy after upgrades. Build on [Testnet](/networks#testnet) first, and design for impermanence.   |
+| **Governance Participant** | An active role in shaping the protocol. Upgrades are real and consequential, so participate in proposals and voting.                                    |
+| **User**                   | A functional but rough experience. Do not store meaningful secrets or rely on state permanence.                                                         |
 
-## Next Steps
+## Next steps
 
-- [Networks Overview](/networks) — Technical details, RPC endpoints, and contract addresses
-- [Limitations](/developers/docs/resources/considerations/limitations) — Full list of current developer-facing limitations
-- [Privacy Considerations](/developers/docs/resources/considerations/privacy_considerations) — What leaks and what doesn't
-- [Network Upgrades](/participate/governance/upgrades) — How rollup upgrades work through governance
-- [Security Policy](https://github.com/AztecProtocol/aztec-packages/blob/master/SECURITY.md) — How to report vulnerabilities
-- [Operator Guides](/operate/operators) — Running network infrastructure
+- [Networks Overview](/networks): Technical details, RPC endpoints, and contract addresses
+- [Limitations](/developers/docs/resources/considerations/limitations): Full list of current developer-facing limitations
+- [Privacy Considerations](/developers/docs/resources/considerations/privacy_considerations): What leaks and what doesn't
+- [Network Upgrades](/participate/governance/upgrades): How rollup upgrades work through governance
+- [Security Policy](https://github.com/AztecProtocol/aztec-packages/blob/master/SECURITY.md): How to report vulnerabilities
+- [Operator Guides](/operate/operators): Running network infrastructure

--- a/docs/docs-participate/alpha.md
+++ b/docs/docs-participate/alpha.md
@@ -1,0 +1,123 @@
+---
+title: Alpha Network
+description: "Understand the Aztec Alpha network: its purpose, known limitations, expected issues, and what to expect as the protocol matures."
+displayed_sidebar: participateSidebar
+---
+
+Alpha is the Aztec mainnet in its initial operational phase. It is live on Ethereum mainnet with real staking, governance, and user transactions. It is also early, unaudited software where bugs — including critical ones — are expected.
+
+This page is the central reference for understanding what Alpha is, what risks come with using it, and how the network will evolve.
+
+## What Alpha Is
+
+Alpha is the first production deployment of the Aztec rollup. Governance, staking, and block production are fully operational with real economic stakes. Sequencers must stake real tokens to participate, and governance proposals have real consequences.
+
+However, "production" does not mean "finished." Alpha exists to:
+
+- Battle-test the protocol under real conditions
+- Establish decentralized governance and validator sets
+- Identify bugs that only surface at scale or under adversarial conditions
+- Build toward a mature, stable mainnet
+
+Think of Alpha as a live stress test with real stakes. The protocol is functional, but it is not yet hardened.
+
+## Known Limitations and Expected Issues
+
+### Proving System Bugs
+
+The Aztec proving system is novel and complex. Bugs in proof generation, verification, and circuit constraints are expected during Alpha. Some circuits are still under-constrained, meaning that soundness is not fully guaranteed. In practice, this means:
+
+- Provers may occasionally produce invalid proofs
+- Proof verification on L1 may encounter edge cases
+- Block production may halt temporarily while issues are diagnosed and patched
+
+These are known risks of an early-stage ZK rollup, not unexpected failures.
+
+### Unaudited Software
+
+No part of the Aztec stack has been fully audited. The protocol, smart contracts, client software, and cryptographic primitives are all under active development. Code is being iterated on daily and audits are ongoing.
+
+### Privacy Is Not Guaranteed
+
+Some privacy features are still in development. Known leakage includes:
+
+- The number of side effects in a transaction is visible (private transactions can be fingerprinted based on their side effect count)
+- No privacy-preserving queries to third-party nodes exist yet
+- New privacy standards for smart contract design have not been established
+
+### Circuit and Transaction Limits
+
+ZK-SNARK circuits impose hard upper bounds on what a single transaction can do — the number of state reads/writes, notes, nullifiers, logs, and messages. Deeply nested function calls can exceed per-transaction limits. See [Limitations](/developers/resources/considerations/limitations#circuit-limitations) for current constants.
+
+## State Migration and Rollup Upgrades
+
+### Future upgrades will be disruptive
+
+As the protocol matures, it will undergo rollup upgrades through the [governance process](/participate/governance/upgrades). When a new rollup version is deployed:
+
+- A new rollup contract is added to the onchain Registry
+- The new rollup becomes canonical (receives block rewards)
+- The old rollup remains accessible for bridging assets in and out
+
+### State migration is difficult
+
+Migrating application state from one rollup version to another is a hard problem for any ZK rollup, and Aztec is no exception. You should expect that:
+
+- **State does not carry over automatically.** Application data, deployed contracts, and notes on the current rollup will not be directly accessible on a new rollup version without explicit migration steps.
+- **Migration tooling is still being developed.** There are no mature, battle-tested tools for migrating L2 state across rollup upgrades yet.
+- **Applications will need to redeploy.** Developers should plan that contracts will need to be redeployed and state reconstructed (or omitted) after a rollup upgrade.
+- **User assets can always be recovered.** The Registry model ensures that users can bridge assets out of any historical rollup version, so funds are not permanently locked.
+
+If you are building on Alpha, design your application with rollup upgrades in mind. Avoid assumptions about state permanence at this stage.
+
+For details on how rollup upgrades work, see [Network Upgrades](/participate/governance/upgrades).
+
+## Security Disclosures
+
+We expect bugs, including critical ones, to be discovered during Alpha. Aztec is preparing a bug bounty program and actively conducts internal and external reviews.
+
+### Reporting Vulnerabilities
+
+If you discover a security vulnerability:
+
+1. **Do not** open a public GitHub issue or pull request
+2. Use [GitHub Private Vulnerability Reporting](https://github.com/AztecProtocol/aztec-packages/security/advisories/new) to submit details
+3. You can also email security@aztec.foundation (but submit full details through GitHub, not email)
+
+Mark reports as **CRITICAL** if you believe a vulnerability is actively being exploited or could result in loss of funds, key compromise, or broad user impact.
+
+For the full security policy, see [SECURITY.md](https://github.com/AztecProtocol/aztec-packages/blob/master/SECURITY.md).
+
+### Non-Security Bugs
+
+For bugs that are not security-sensitive (performance issues, feature requests, unexpected behavior), open a [GitHub Issue](https://github.com/AztecProtocol/aztec-packages/issues). Keeping non-security bugs public helps the community track progress and collaborate on fixes.
+
+## Path to Beta
+
+The transition from Alpha to Beta is defined by performance milestones, not a specific calendar date. The network will be considered Beta when it consistently meets the following targets:
+
+| Metric                     | Target     |
+| -------------------------- | ---------- |
+| **User-perceived latency** | 12s median |
+| **Sustained throughput**   | 10 TPS     |
+| **Uptime**                 | 99.9%      |
+
+These thresholds reflect the minimum bar for a network that application developers and users can rely on for production workloads. Until they are met, expect the instability and limitations described on this page.
+
+## What This Means for You
+
+| If you are a...            | Expect...                                                                                                                                             |
+| -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Validator / Sequencer**  | Occasional downtime, software updates, and proving failures. Stay current with node releases.                                                         |
+| **Developer**              | Breaking changes, API instability, and the need to redeploy after upgrades. Build on [Testnet](/networks#testnet) first, and design for impermanence. |
+| **Governance Participant** | An active role in shaping the protocol. Upgrades are real and consequential — participate in proposals and voting.                                    |
+| **User**                   | A functional but rough experience. Do not store meaningful secrets or rely on state permanence.                                                       |
+
+## Next Steps
+
+- [Networks Overview](/networks) — Technical details, RPC endpoints, and contract addresses
+- [Limitations](/developers/resources/considerations/limitations) — Full list of current developer-facing limitations
+- [Privacy Considerations](/developers/resources/considerations/privacy_considerations) — What leaks and what doesn't
+- [Network Upgrades](/participate/governance/upgrades) — How rollup upgrades work through governance
+- [Security Policy](https://github.com/AztecProtocol/aztec-packages/blob/master/SECURITY.md) — How to report vulnerabilities
+- [Operator Guides](/operate/operators) — Running network infrastructure

--- a/docs/docs-participate/alpha.md
+++ b/docs/docs-participate/alpha.md
@@ -47,7 +47,7 @@ Some privacy features are still in development. Known leakage includes:
 
 ### Circuit and Transaction Limits
 
-ZK-SNARK circuits impose hard upper bounds on what a single transaction can do — the number of state reads/writes, notes, nullifiers, logs, and messages. Deeply nested function calls can exceed per-transaction limits. See [Limitations](/developers/resources/considerations/limitations#circuit-limitations) for current constants.
+ZK-SNARK circuits impose hard upper bounds on what a single transaction can do — the number of state reads/writes, notes, nullifiers, logs, and messages. Deeply nested function calls can exceed per-transaction limits. See [Limitations](/developers/docs/resources/considerations/limitations#circuit-limitations) for current constants.
 
 ## State Migration and Rollup Upgrades
 
@@ -116,8 +116,8 @@ These thresholds reflect the minimum bar for a network that application develope
 ## Next Steps
 
 - [Networks Overview](/networks) — Technical details, RPC endpoints, and contract addresses
-- [Limitations](/developers/resources/considerations/limitations) — Full list of current developer-facing limitations
-- [Privacy Considerations](/developers/resources/considerations/privacy_considerations) — What leaks and what doesn't
+- [Limitations](/developers/docs/resources/considerations/limitations) — Full list of current developer-facing limitations
+- [Privacy Considerations](/developers/docs/resources/considerations/privacy_considerations) — What leaks and what doesn't
 - [Network Upgrades](/participate/governance/upgrades) — How rollup upgrades work through governance
 - [Security Policy](https://github.com/AztecProtocol/aztec-packages/blob/master/SECURITY.md) — How to report vulnerabilities
 - [Operator Guides](/operate/operators) — Running network infrastructure

--- a/docs/docs-participate/index.md
+++ b/docs/docs-participate/index.md
@@ -9,7 +9,7 @@ displayed_sidebar: participateSidebar
 Welcome to the Participate section. Here you'll find educational content about how the Aztec network operates, the $AZTEC token, and how governance works.
 
 :::caution Alpha Network
-Aztec is currently in its **Alpha** phase — a live mainnet where bugs, including critical ones, are expected. Before using the network, read the [Alpha Network](/participate/alpha) page to understand current limitations, security expectations, and what to expect from rollup upgrades.
+Aztec is currently in its **Alpha** phase, a live mainnet where bugs, including critical ones, are expected. Before using the network, read the [Alpha Network](/participate/alpha) page to understand current limitations, security expectations, and what to expect from rollup upgrades.
 :::
 
 ## Basics of Aztec

--- a/docs/docs-participate/index.md
+++ b/docs/docs-participate/index.md
@@ -8,6 +8,10 @@ displayed_sidebar: participateSidebar
 
 Welcome to the Participate section. Here you'll find educational content about how the Aztec network operates, the $AZTEC token, and how governance works.
 
+:::caution Alpha Network
+Aztec is currently in its **Alpha** phase — a live mainnet where bugs, including critical ones, are expected. Before using the network, read the [Alpha Network](/participate/alpha) page to understand current limitations, security expectations, and what to expect from rollup upgrades.
+:::
+
 ## Basics of Aztec
 
 New to Aztec? Start here to understand the fundamentals:

--- a/docs/docs/networks.md
+++ b/docs/docs/networks.md
@@ -94,7 +94,7 @@ The developer SDK/aztec-nr version (used for writing and compiling contracts) ma
 
 ### Alpha (Mainnet)
 
-Alpha is the Aztec **mainnet** in its initial operational phase, with governance, networking, and transaction processing fully active.
+Alpha is the Aztec **mainnet** in its initial operational phase, with governance, networking, and transaction processing fully active. Alpha is live but early — bugs, including critical ones, are expected. For a full explanation of what this means, see the **[Alpha Network](/participate/alpha)** page.
 
 #### Overview
 

--- a/docs/sidebars-participate.js
+++ b/docs/sidebars-participate.js
@@ -6,6 +6,7 @@
 const sidebars = {
   participateSidebar: [
     { type: "doc", id: "index", label: "Overview" },
+    { type: "doc", id: "alpha", label: "Alpha Network" },
     {
       type: "html",
       value: '<span class="sidebar-title">Basics of Aztec</span>',


### PR DESCRIPTION
## Summary

- Add a dedicated **Alpha Network** page at `/participate/alpha` explaining what Alpha is, known limitations (proving system bugs, unaudited software, privacy gaps), state migration challenges for rollup upgrades, security disclosure process, path-to-Beta performance milestones, and per-role expectations
- Update `privacy_considerations.md` to document `enqueue_incognito` for hiding `msg_sender`, update side-effect padding status (note hashes/nullifiers/private logs are now padded), and remove stale `Decoder.sol` link
- Update `limitations.md` with the same `msg_sender` and side-effect corrections, remove duplicate `msg_sender` section
- Add sidebar entry, link from `networks.md`, and add caution banner to Participate index

## Test plan

- [ ] Verify `yarn start` in docs/ serves the new page at `/participate/alpha`
- [ ] Check all internal links resolve (networks, limitations, privacy considerations, governance/upgrades, SECURITY.md)
- [ ] Verify sidebar shows "Alpha Network" after Overview in the Participate section
- [ ] Review content accuracy with team — especially state migration expectations and Beta milestone targets

🤖 Generated with [Claude Code](https://claude.com/claude-code)