### PR TITLE
[NO_MERGE] fix: fallback to current artifacts in legacy jest resolver

### DIFF
--- a/yarn-project/end-to-end/src/legacy-jest-resolver.cjs
+++ b/yarn-project/end-to-end/src/legacy-jest-resolver.cjs
@@ -87,6 +87,15 @@ function printBannerOnce() {
   process.stderr.write(lines.join('\n') + '\n');
 }
 
+// Artifact renames across versions. When the current code imports a name that didn't exist in an older release, map it
+// to the legacy equivalent so the old artifact is still used (keeping the test strict). Each entry documents which
+// version introduced the rename.
+const ARTIFACT_RENAMES = {
+  // SimulatedAccount was split into SimulatedEcdsaAccount + SimulatedSchnorrAccount after 4.2.0-aztecnr-rc.2.
+  'SimulatedEcdsaAccount.json': 'SimulatedAccount.json',
+  'SimulatedSchnorrAccount.json': 'SimulatedAccount.json',
+};
+
 // Match a resolved absolute path against the workspace artifacts dirs and return the legacy cache equivalent, or null
 // if it's not an artifact path we should redirect.
 function legacyArtifactPath(resolved) {
@@ -102,7 +111,24 @@ function legacyArtifactPath(resolved) {
       continue;
     }
     const basename = resolved.slice(idx + marker.length);
-    return path.join(cacheRoot, 'node_modules', pkg, 'artifacts', basename);
+    const artifactsDir = path.join(cacheRoot, 'node_modules', pkg, 'artifacts');
+    const candidate = path.join(artifactsDir, basename);
+    if (fs.existsSync(candidate)) {
+      return candidate;
+    }
+    // Try a known rename fallback before giving up.
+    const mapped = ARTIFACT_RENAMES[basename];
+    if (mapped) {
+      const fallback = path.join(artifactsDir, mapped);
+      if (fs.existsSync(fallback)) {
+        if (!seen.has(resolved)) {
+          seen.add(resolved);
+          process.stderr.write(`[legacy-contracts][jest] mapped ${basename} -> ${mapped} (rename in @${version})\n`);
+        }
+        return fallback;
+      }
+    }
+    return candidate; // return original path; caller will throw if it doesn't exist
   }
   return null;
 }


### PR DESCRIPTION
I would leave this unmerged now because it makes the backwards compatibility tests less strict (e.g. if some oracle was used only by the old account contracts whose artifacts failed to resolved then this would be a breaking change and we would not detect this).

## Summary

- When running backwards compatibility tests with `CONTRACT_ARTIFACTS_VERSION` pointing to an older release (e.g. `4.2.0-aztecnr-rc.2`), the legacy Jest resolver would throw if an artifact didn't exist in the legacy cache
- This happened because `SimulatedEcdsaAccount.json` and `SimulatedSchnorrAccount.json` were split from `SimulatedAccount.json` after that release, and every test loads these stub artifacts via `TestWallet`
- Instead of throwing, the resolver we now use re-mappings for the contracts that were renamed.