### PR TITLE
feat!: make proposals EIP-712

### DIFF
--- a/l1-contracts/gas_benchmark.md
+++ b/l1-contracts/gas_benchmark.md
@@ -14,21 +14,22 @@
 
 | Function             | Avg Gas | Max Gas | Calldata Size | Calldata Gas |
 |----------------------|---------|---------|---------------|--------------|
-| propose              | 195,201 | 221,411 |           932 |       14,912 |
-| submitEpochRootProof | 698,976 | 744,776 |         2,820 |       45,120 |
-| setupEpoch           |  31,965 | 113,616 |             - |            - |
+| propose              | 195,988 | 222,201 |           932 |       14,912 |
+| submitEpochRootProof | 697,655 | 743,529 |         2,820 |       45,120 |
+| setupEpoch           |  31,998 | 113,793 |             - |            - |
 
-**Avg Gas Cost per Second**: 3,331.7 gas/second
+**Avg Gas Cost per Second**: 3,341.5 gas/second
 *Epoch duration*: 0h 38m 24s
 
 ## Validators
 
 | Function             | Avg Gas | Max Gas | Calldata Size | Calldata Gas |
 |----------------------|---------|---------|---------------|--------------|
-| propose              | 322,945 | 350,085 |         4,452 |       71,232 |
-| submitEpochRootProof | 897,150 | 942,954 |         5,316 |       85,056 |
-| aggregate3           | 371,401 | 384,831 |             - |            - |
-| setupEpoch           |  46,426 | 547,449 |             - |            - |
+| propose              | 324,449 | 351,604 |         4,452 |       71,232 |
+| submitEpochRootProof | 896,101 | 941,944 |         5,316 |       85,056 |
+| aggregate3           | 373,118 | 386,457 |             - |            - |
+| setupEpoch           |  46,459 | 547,626 |             - |            - |
 
-**Avg Gas Cost per Second**: 5,284.3 gas/second
+**Avg Gas Cost per Second**: 5,304.3 gas/second
 *Epoch duration*: 0h 38m 24s
+

--- a/l1-contracts/gas_benchmark_results.json
+++ b/l1-contracts/gas_benchmark_results.json
@@ -2,26 +2,26 @@
   "no_validators": {
     "propose": {
       "calls": 150,
-      "min": 181595,
-      "mean": 195201,
-      "median": 190979,
-      "max": 221411,
+      "min": 182373,
+      "mean": 195988,
+      "median": 191762,
+      "max": 222201,
       "calldata_size": 932,
       "calldata_gas": 14912
     },
     "setupEpoch": {
       "calls": 150,
-      "min": 29236,
-      "mean": 31965,
-      "median": 29236,
-      "max": 113616
+      "min": 29264,
+      "mean": 31998,
+      "median": 29264,
+      "max": 113793
     },
     "submitEpochRootProof": {
       "calls": 4,
-      "min": 677928,
-      "mean": 698976,
-      "median": 686601,
-      "max": 744776,
+      "min": 676491,
+      "mean": 697655,
+      "median": 685300,
+      "max": 743529,
       "calldata_size": 2820,
       "calldata_gas": 45120
     }
@@ -29,35 +29,35 @@
   "validators": {
     "propose": {
       "calls": 150,
-      "min": 300568,
-      "mean": 322945,
-      "median": 322454,
-      "max": 350085,
+      "min": 302105,
+      "mean": 324449,
+      "median": 323910,
+      "max": 351604,
       "calldata_size": 4452,
       "calldata_gas": 71232
     },
     "setupEpoch": {
       "calls": 150,
-      "min": 29236,
-      "mean": 46426,
-      "median": 29236,
-      "max": 547449
+      "min": 29264,
+      "mean": 46459,
+      "median": 29264,
+      "max": 547626
     },
     "submitEpochRootProof": {
       "calls": 4,
-      "min": 876112,
-      "mean": 897150,
-      "median": 884767,
-      "max": 942954,
+      "min": 874924,
+      "mean": 896101,
+      "median": 883769,
+      "max": 941944,
       "calldata_size": 5316,
       "calldata_gas": 85056
     },
     "aggregate3": {
       "calls": 55,
-      "min": 360298,
-      "mean": 371401,
-      "median": 371165,
-      "max": 384831
+      "min": 362015,
+      "mean": 373118,
+      "median": 372828,
+      "max": 386457
     }
   }
 }

--- a/l1-contracts/src/core/libraries/rollup/AttestationLib.sol
+++ b/l1-contracts/src/core/libraries/rollup/AttestationLib.sol
@@ -9,15 +9,6 @@ import {Signature, SignatureLib} from "@aztec/shared/libraries/SignatureLib.sol"
 uint256 constant SIGNATURE_LENGTH = 65; // v (1) + r (32) + s (32)
 uint256 constant ADDRESS_LENGTH = 20;
 
-/**
- * @notice The domain separator for the signatures
- */
-enum SignatureDomainSeparator {
-  checkpointProposal,
-  checkpointAttestation,
-  attestationsAndSigners
-}
-
 // A committee attestation can be made up of a signature and an address.
 // Committee members that have attested will produce a signature, and if they have not attested, the signature will be
 // empty and an address provided.
@@ -50,8 +41,7 @@ library AttestationLib {
     address _verifyingContract
   ) internal view returns (bytes32) {
     return CoordinationSignatureLib.attestationsAndSignersDigest(
-      keccak256(abi.encode(SignatureDomainSeparator.attestationsAndSigners, _attestations, _signers)),
-      _verifyingContract
+      keccak256(abi.encode(_attestations, _signers)), _verifyingContract
     );
   }
 

--- a/l1-contracts/src/core/libraries/rollup/AttestationLib.sol
+++ b/l1-contracts/src/core/libraries/rollup/AttestationLib.sol
@@ -3,6 +3,7 @@
 pragma solidity ^0.8.27;
 
 import {Errors} from "@aztec/core/libraries/Errors.sol";
+import {CoordinationSignatureLib} from "@aztec/core/libraries/rollup/CoordinationSignatureLib.sol";
 import {Signature, SignatureLib} from "@aztec/shared/libraries/SignatureLib.sol";
 
 uint256 constant SIGNATURE_LENGTH = 65; // v (1) + r (32) + s (32)
@@ -34,6 +35,25 @@ struct CommitteeAttestations {
 
 library AttestationLib {
   using SignatureLib for Signature;
+
+  function getAttestationsAndSignersDigest(CommitteeAttestations memory _attestations, address[] memory _signers)
+    internal
+    view
+    returns (bytes32)
+  {
+    return getAttestationsAndSignersDigest(_attestations, _signers, address(this));
+  }
+
+  function getAttestationsAndSignersDigest(
+    CommitteeAttestations memory _attestations,
+    address[] memory _signers,
+    address _verifyingContract
+  ) internal view returns (bytes32) {
+    return CoordinationSignatureLib.attestationsAndSignersDigest(
+      keccak256(abi.encode(SignatureDomainSeparator.attestationsAndSigners, _attestations, _signers)),
+      _verifyingContract
+    );
+  }
 
   /**
    * @notice Checks if the given CommitteeAttestations is empty
@@ -216,13 +236,5 @@ library AttestationLib {
     require(dataPtr == upperLimit, Errors.AttestationLib__InvalidDataSize(dataPtr - offset, upperLimit - offset));
 
     return addresses;
-  }
-
-  function getAttestationsAndSignersDigest(CommitteeAttestations memory _attestations, address[] memory _signers)
-    internal
-    pure
-    returns (bytes32)
-  {
-    return keccak256(abi.encode(SignatureDomainSeparator.attestationsAndSigners, _attestations, _signers));
   }
 }

--- a/l1-contracts/src/core/libraries/rollup/CoordinationSignatureLib.sol
+++ b/l1-contracts/src/core/libraries/rollup/CoordinationSignatureLib.sol
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024 Aztec Labs.
+pragma solidity ^0.8.27;
+
+library CoordinationSignatureLib {
+  bytes32 internal constant DOMAIN_TYPEHASH =
+    keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)");
+  bytes32 internal constant NAME_HASH = keccak256("Aztec Rollup");
+  bytes32 internal constant VERSION_HASH = keccak256("1");
+
+  bytes32 internal constant BLOCK_PROPOSAL_TYPEHASH = keccak256("BlockProposal(bytes32 payloadHash)");
+  bytes32 internal constant CHECKPOINT_PROPOSAL_TYPEHASH = keccak256("CheckpointProposal(bytes32 payloadHash)");
+  bytes32 internal constant CHECKPOINT_ATTESTATION_TYPEHASH = keccak256("CheckpointAttestation(bytes32 payloadHash)");
+  bytes32 internal constant ATTESTATIONS_AND_SIGNERS_TYPEHASH =
+    keccak256("AttestationsAndSigners(bytes32 payloadHash)");
+
+  function domainSeparator() internal view returns (bytes32) {
+    return domainSeparator(address(this));
+  }
+
+  function domainSeparator(address _verifyingContract) internal view returns (bytes32) {
+    return keccak256(abi.encode(DOMAIN_TYPEHASH, NAME_HASH, VERSION_HASH, block.chainid, _verifyingContract));
+  }
+
+  function toTypedDataHash(bytes32 _structHash) internal view returns (bytes32) {
+    return toTypedDataHash(_structHash, address(this));
+  }
+
+  function toTypedDataHash(bytes32 _structHash, address _verifyingContract) internal view returns (bytes32) {
+    return keccak256(abi.encodePacked(hex"1901", domainSeparator(_verifyingContract), _structHash));
+  }
+
+  function blockProposalDigest(bytes32 _payloadHash) internal view returns (bytes32) {
+    return blockProposalDigest(_payloadHash, address(this));
+  }
+
+  function blockProposalDigest(bytes32 _payloadHash, address _verifyingContract) internal view returns (bytes32) {
+    return toTypedDataHash(keccak256(abi.encode(BLOCK_PROPOSAL_TYPEHASH, _payloadHash)), _verifyingContract);
+  }
+
+  function checkpointProposalDigest(bytes32 _payloadHash) internal view returns (bytes32) {
+    return checkpointProposalDigest(_payloadHash, address(this));
+  }
+
+  function checkpointProposalDigest(bytes32 _payloadHash, address _verifyingContract) internal view returns (bytes32) {
+    return toTypedDataHash(keccak256(abi.encode(CHECKPOINT_PROPOSAL_TYPEHASH, _payloadHash)), _verifyingContract);
+  }
+
+  function checkpointAttestationDigest(bytes32 _payloadHash) internal view returns (bytes32) {
+    return checkpointAttestationDigest(_payloadHash, address(this));
+  }
+
+  function checkpointAttestationDigest(bytes32 _payloadHash, address _verifyingContract)
+    internal
+    view
+    returns (bytes32)
+  {
+    return toTypedDataHash(keccak256(abi.encode(CHECKPOINT_ATTESTATION_TYPEHASH, _payloadHash)), _verifyingContract);
+  }
+
+  function attestationsAndSignersDigest(bytes32 _payloadHash) internal view returns (bytes32) {
+    return attestationsAndSignersDigest(_payloadHash, address(this));
+  }
+
+  function attestationsAndSignersDigest(bytes32 _payloadHash, address _verifyingContract)
+    internal
+    view
+    returns (bytes32)
+  {
+    return toTypedDataHash(keccak256(abi.encode(ATTESTATIONS_AND_SIGNERS_TYPEHASH, _payloadHash)), _verifyingContract);
+  }
+}

--- a/l1-contracts/src/core/libraries/rollup/InvalidateLib.sol
+++ b/l1-contracts/src/core/libraries/rollup/InvalidateLib.sol
@@ -13,7 +13,6 @@ import {ValidatorSelectionLib} from "@aztec/core/libraries/rollup/ValidatorSelec
 import {Timestamp, Slot, Epoch, TimeLib} from "@aztec/core/libraries/TimeLib.sol";
 import {CompressedSlot, CompressedTimeMath} from "@aztec/shared/libraries/CompressedTimeMath.sol";
 import {ECDSA} from "@oz/utils/cryptography/ECDSA.sol";
-import {MessageHashUtils} from "@oz/utils/cryptography/MessageHashUtils.sol";
 
 /**
  * @title InvalidateLib
@@ -57,7 +56,6 @@ library InvalidateLib {
   using TimeLib for Epoch;
   using ChainTipsLib for CompressedChainTips;
   using AttestationLib for CommitteeAttestations;
-  using MessageHashUtils for bytes32;
   using CompressedTimeMath for CompressedSlot;
 
   /**
@@ -235,7 +233,7 @@ library InvalidateLib {
     );
 
     // Get the digest of the payload that was signed by the committee
-    bytes32 digest = checkpointLog.payloadDigest.toEthSignedMessageHash();
+    bytes32 digest = checkpointLog.payloadDigest;
 
     return (digest, committeeSize);
   }

--- a/l1-contracts/src/core/libraries/rollup/ProposeLib.sol
+++ b/l1-contracts/src/core/libraries/rollup/ProposeLib.sol
@@ -9,7 +9,7 @@ import {TempCheckpointLog} from "@aztec/core/libraries/compressed-data/Checkpoin
 import {FeeHeader} from "@aztec/core/libraries/compressed-data/fees/FeeStructs.sol";
 import {ChainTipsLib, CompressedChainTips} from "@aztec/core/libraries/compressed-data/Tips.sol";
 import {Errors} from "@aztec/core/libraries/Errors.sol";
-import {SignatureDomainSeparator, CommitteeAttestations} from "@aztec/core/libraries/rollup/AttestationLib.sol";
+import {CommitteeAttestations} from "@aztec/core/libraries/rollup/AttestationLib.sol";
 import {CoordinationSignatureLib} from "@aztec/core/libraries/rollup/CoordinationSignatureLib.sol";
 import {OracleInput, FeeLib, ManaMinFeeComponents} from "@aztec/core/libraries/rollup/FeeLib.sol";
 import {ValidatorSelectionLib} from "@aztec/core/libraries/rollup/ValidatorSelectionLib.sol";
@@ -381,8 +381,6 @@ library ProposeLib {
   }
 
   function digest(ProposePayload memory _args, address _verifyingContract) internal view returns (bytes32) {
-    return CoordinationSignatureLib.checkpointAttestationDigest(
-      keccak256(abi.encode(SignatureDomainSeparator.checkpointAttestation, _args)), _verifyingContract
-    );
+    return CoordinationSignatureLib.checkpointAttestationDigest(keccak256(abi.encode(_args)), _verifyingContract);
   }
 }

--- a/l1-contracts/src/core/libraries/rollup/ProposeLib.sol
+++ b/l1-contracts/src/core/libraries/rollup/ProposeLib.sol
@@ -10,6 +10,7 @@ import {FeeHeader} from "@aztec/core/libraries/compressed-data/fees/FeeStructs.s
 import {ChainTipsLib, CompressedChainTips} from "@aztec/core/libraries/compressed-data/Tips.sol";
 import {Errors} from "@aztec/core/libraries/Errors.sol";
 import {SignatureDomainSeparator, CommitteeAttestations} from "@aztec/core/libraries/rollup/AttestationLib.sol";
+import {CoordinationSignatureLib} from "@aztec/core/libraries/rollup/CoordinationSignatureLib.sol";
 import {OracleInput, FeeLib, ManaMinFeeComponents} from "@aztec/core/libraries/rollup/FeeLib.sol";
 import {ValidatorSelectionLib} from "@aztec/core/libraries/rollup/ValidatorSelectionLib.sol";
 import {Timestamp, Slot, Epoch, TimeLib} from "@aztec/core/libraries/TimeLib.sol";
@@ -375,7 +376,13 @@ library ProposeLib {
     return FeeLib.getManaMinFeeComponentsAt(checkpointOfInterest, _timestamp, _inFeeAsset);
   }
 
-  function digest(ProposePayload memory _args) internal pure returns (bytes32) {
-    return keccak256(abi.encode(SignatureDomainSeparator.checkpointAttestation, _args));
+  function digest(ProposePayload memory _args) internal view returns (bytes32) {
+    return digest(_args, address(this));
+  }
+
+  function digest(ProposePayload memory _args, address _verifyingContract) internal view returns (bytes32) {
+    return CoordinationSignatureLib.checkpointAttestationDigest(
+      keccak256(abi.encode(SignatureDomainSeparator.checkpointAttestation, _args)), _verifyingContract
+    );
   }
 }

--- a/l1-contracts/src/core/libraries/rollup/ValidatorSelectionLib.sol
+++ b/l1-contracts/src/core/libraries/rollup/ValidatorSelectionLib.sol
@@ -13,7 +13,6 @@ import {STFLib} from "@aztec/core/libraries/rollup/STFLib.sol";
 import {Timestamp, Slot, Epoch, TimeLib} from "@aztec/core/libraries/TimeLib.sol";
 import {SignatureLib, Signature} from "@aztec/shared/libraries/SignatureLib.sol";
 import {ECDSA} from "@oz/utils/cryptography/ECDSA.sol";
-import {MessageHashUtils} from "@oz/utils/cryptography/MessageHashUtils.sol";
 import {SafeCast} from "@oz/utils/math/SafeCast.sol";
 import {SlotDerivation} from "@oz/utils/SlotDerivation.sol";
 import {Checkpoints} from "@oz/utils/structs/Checkpoints.sol";
@@ -94,7 +93,6 @@ import {TransientSlot} from "@oz/utils/TransientSlot.sol";
  */
 library ValidatorSelectionLib {
   using EnumerableSet for EnumerableSet.AddressSet;
-  using MessageHashUtils for bytes32;
   using SignatureLib for Signature;
   using TimeLib for Timestamp;
   using TimeLib for Epoch;
@@ -273,14 +271,12 @@ library ValidatorSelectionLib {
     }
 
     // Check if the signature is correct
-    bytes32 digest = _digest.toEthSignedMessageHash();
     Signature memory signature = _attestations.getSignature(proposerIndex);
-    SignatureLib.verify(signature, proposer, digest);
+    SignatureLib.verify(signature, proposer, _digest);
 
     // Check that the proposer have signed the `_attestations|_signers` data such that invalid `_attestations|_signers`
     // data can be attributed to the `proposer` specifically.
-    bytes32 attestationsAndSignersDigest =
-      _attestations.getAttestationsAndSignersDigest(_signers).toEthSignedMessageHash();
+    bytes32 attestationsAndSignersDigest = _attestations.getAttestationsAndSignersDigest(_signers);
     SignatureLib.verify(_attestationsAndSignersSignature, proposer, attestationsAndSignersDigest);
 
     if (_updateCache) {
@@ -333,8 +329,6 @@ library ValidatorSelectionLib {
       reconstructedCommittee: new address[](targetCommitteeSize)
     });
 
-    bytes32 digest = _digest.toEthSignedMessageHash();
-
     bytes memory signaturesOrAddresses = _attestations.signaturesOrAddresses;
     uint256 dataPtr;
     assembly {
@@ -360,7 +354,7 @@ library ValidatorSelectionLib {
           }
 
           ++stack.signaturesRecovered;
-          stack.reconstructedCommittee[i] = ECDSA.recover(digest, v, r, s);
+          stack.reconstructedCommittee[i] = ECDSA.recover(_digest, v, r, s);
         } else {
           address addr;
           assembly {

--- a/l1-contracts/test/benchmark/happy.t.sol
+++ b/l1-contracts/test/benchmark/happy.t.sol
@@ -56,7 +56,6 @@ import {
   FeeHeaderModel,
   ManaMinFeeComponentsModel
 } from "test/fees/FeeModelTestPoints.t.sol";
-import {MessageHashUtils} from "@oz/utils/cryptography/MessageHashUtils.sol";
 import {Timestamp, Slot, Epoch, TimeLib} from "@aztec/core/libraries/TimeLib.sol";
 import {MultiAdder, CheatDepositArgs} from "@aztec/mock/MultiAdder.sol";
 import {RollupBuilder} from "../builder/RollupBuilder.sol";
@@ -98,7 +97,6 @@ contract FakeCanonical is IRewardDistributor {
 }
 
 contract BenchmarkRollupTest is FeeModelTestPoints, DecoderBase {
-  using MessageHashUtils for bytes32;
   using stdStorage for StdStorage;
   using TimeLib for Slot;
   using TimeLib for Timestamp;
@@ -286,7 +284,7 @@ contract BenchmarkRollupTest is FeeModelTestPoints, DecoderBase {
       ProposePayload memory proposePayload =
         ProposePayload({archive: proposeArgs.archive, oracleInput: proposeArgs.oracleInput, headerHash: headerHash});
 
-      bytes32 digest = ProposeLib.digest(proposePayload);
+      bytes32 digest = ProposeLib.digest(proposePayload, address(rollup));
 
       // loop through to make sure we create an attestation for the proposer
       for (uint256 i = 0; i < validators.length; i++) {
@@ -318,7 +316,9 @@ contract BenchmarkRollupTest is FeeModelTestPoints, DecoderBase {
     if (proposer != address(0)) {
       attestationsAndSignersSignature = createAttestation(
         proposer,
-        AttestationLib.getAttestationsAndSignersDigest(AttestationLibHelper.packAttestations(attestations), signers)
+        AttestationLib.getAttestationsAndSignersDigest(
+          AttestationLibHelper.packAttestations(attestations), signers, address(rollup)
+        )
       ).signature;
     }
 
@@ -334,8 +334,7 @@ contract BenchmarkRollupTest is FeeModelTestPoints, DecoderBase {
   function createAttestation(address _signer, bytes32 _digest) internal view returns (CommitteeAttestation memory) {
     uint256 privateKey = attesterPrivateKeys[_signer];
 
-    bytes32 digest = _digest.toEthSignedMessageHash();
-    (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, digest);
+    (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, _digest);
 
     Signature memory signature = Signature({v: v, r: r, s: s});
     // Address can be zero for signed attestations

--- a/l1-contracts/test/compression/PreHeating.t.sol
+++ b/l1-contracts/test/compression/PreHeating.t.sol
@@ -55,7 +55,6 @@ import {
   FeeHeaderModel,
   ManaMinFeeComponentsModel
 } from "test/fees/FeeModelTestPoints.t.sol";
-import {MessageHashUtils} from "@oz/utils/cryptography/MessageHashUtils.sol";
 import {Timestamp, Slot, Epoch, TimeLib} from "@aztec/core/libraries/TimeLib.sol";
 import {MultiAdder, CheatDepositArgs} from "@aztec/mock/MultiAdder.sol";
 import {RollupBuilder} from "../builder/RollupBuilder.sol";
@@ -99,7 +98,6 @@ contract FakeCanonical is IRewardDistributor {
  *          are testing some edges that will break if the `roundaboutSize` is wrong!
  */
 contract PreHeatingTest is FeeModelTestPoints, DecoderBase {
-  using MessageHashUtils for bytes32;
   using TimeLib for Slot;
   using FeeLib for uint256;
   using FeeLib for ManaMinFeeComponents;
@@ -343,7 +341,7 @@ contract PreHeatingTest is FeeModelTestPoints, DecoderBase {
       ProposePayload memory proposePayload =
         ProposePayload({archive: proposeArgs.archive, oracleInput: proposeArgs.oracleInput, headerHash: headerHash});
 
-      bytes32 digest = ProposeLib.digest(proposePayload);
+      bytes32 digest = ProposeLib.digest(proposePayload, address(rollup));
 
       // loop through to make sure we create an attestation for the proposer
       for (uint256 i = 0; i < validators.length; i++) {
@@ -375,7 +373,9 @@ contract PreHeatingTest is FeeModelTestPoints, DecoderBase {
     if (proposer != address(0)) {
       attestationsAndSignersSignature = createAttestation(
         proposer,
-        AttestationLib.getAttestationsAndSignersDigest(AttestationLibHelper.packAttestations(attestations), signers)
+        AttestationLib.getAttestationsAndSignersDigest(
+          AttestationLibHelper.packAttestations(attestations), signers, address(rollup)
+        )
       ).signature;
     }
 
@@ -391,8 +391,7 @@ contract PreHeatingTest is FeeModelTestPoints, DecoderBase {
   function createAttestation(address _signer, bytes32 _digest) internal view returns (CommitteeAttestation memory) {
     uint256 privateKey = attesterPrivateKeys[_signer];
 
-    bytes32 digest = _digest.toEthSignedMessageHash();
-    (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, digest);
+    (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, _digest);
 
     Signature memory signature = Signature({v: v, r: r, s: s});
     // Address can be zero for signed attestations

--- a/l1-contracts/test/escape-hatch/e2e/escapeHatchReplacement.t.sol
+++ b/l1-contracts/test/escape-hatch/e2e/escapeHatchReplacement.t.sol
@@ -95,7 +95,7 @@ contract EscapeHatchReplacementTest is EscapeHatchIntegrationBase {
     uint256 committeeSize = data.committee.length;
     data.attestations = new CommitteeAttestation[](committeeSize);
     address[] memory signers = new address[](committeeSize);
-    bytes32 digest = ProposeLib.digest(proposePayload);
+    bytes32 digest = ProposeLib.digest(proposePayload, address(rollup));
 
     for (uint256 i = 0; i < committeeSize; i++) {
       data.attestations[i] = _createAttestation(data.committee[i], digest);
@@ -118,8 +118,9 @@ contract EscapeHatchReplacementTest is EscapeHatchIntegrationBase {
 
     // Proposer signs over attestations and signers
     Signature memory attestationsAndSignersSignature =
-    _createAttestation(proposer, AttestationLib.getAttestationsAndSignersDigest(data.packedAttestations, signers))
-    .signature;
+    _createAttestation(
+      proposer, AttestationLib.getAttestationsAndSignersDigest(data.packedAttestations, signers, address(rollup))
+    ).signature;
 
     vm.prank(proposer);
     rollup.propose(

--- a/l1-contracts/test/escape-hatch/integration/EscapeHatchIntegrationBase.sol
+++ b/l1-contracts/test/escape-hatch/integration/EscapeHatchIntegrationBase.sol
@@ -20,7 +20,6 @@ import {
 import {CheckpointLog, SubmitEpochRootProofArgs, PublicInputArgs} from "@aztec/core/interfaces/IRollup.sol";
 import {IValidatorSelectionCore} from "@aztec/core/interfaces/IValidatorSelection.sol";
 import {Strings} from "@oz/utils/Strings.sol";
-import {MessageHashUtils} from "@oz/utils/cryptography/MessageHashUtils.sol";
 import {SafeCast} from "@oz/utils/math/SafeCast.sol";
 import {AttestationLibHelper} from "@test/helper_libraries/AttestationLibHelper.sol";
 
@@ -30,7 +29,6 @@ import {AttestationLibHelper} from "@test/helper_libraries/AttestationLibHelper.
  * @dev Provides common setup, configuration, and helper functions for integration tests
  */
 abstract contract EscapeHatchIntegrationBase is ValidatorSelectionTestBase {
-  using MessageHashUtils for bytes32;
   // ============ Escape Hatch Configuration ============
   uint96 internal constant DEFAULT_BOND_SIZE = 100e18;
   uint96 internal constant DEFAULT_WITHDRAWAL_TAX = 1e18;
@@ -215,7 +213,7 @@ abstract contract EscapeHatchIntegrationBase is ValidatorSelectionTestBase {
     uint256 committeeSize = committee.length;
     attestations = new CommitteeAttestation[](committeeSize);
     address[] memory signers = new address[](committeeSize);
-    bytes32 digest = ProposeLib.digest(proposePayload);
+    bytes32 digest = ProposeLib.digest(proposePayload, address(rollup));
 
     for (uint256 i = 0; i < committeeSize; i++) {
       attestations[i] = _createAttestation(committee[i], digest);
@@ -226,7 +224,9 @@ abstract contract EscapeHatchIntegrationBase is ValidatorSelectionTestBase {
     Signature memory attestationsAndSignersSignature =
     _createAttestation(
       proposer,
-      AttestationLib.getAttestationsAndSignersDigest(AttestationLibHelper.packAttestations(attestations), signers)
+      AttestationLib.getAttestationsAndSignersDigest(
+        AttestationLibHelper.packAttestations(attestations), signers, address(rollup)
+      )
     ).signature;
 
     // Propose the checkpoint
@@ -248,8 +248,7 @@ abstract contract EscapeHatchIntegrationBase is ValidatorSelectionTestBase {
   function _createAttestation(address _signer, bytes32 _digest) internal view returns (CommitteeAttestation memory) {
     uint256 privateKey = attesterPrivateKeys[_signer];
 
-    bytes32 digest = _digest.toEthSignedMessageHash();
-    (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, digest);
+    (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, _digest);
 
     Signature memory signature = Signature({v: v, r: r, s: s});
     return CommitteeAttestation({addr: _signer, signature: signature});

--- a/l1-contracts/test/escape-hatch/integration/invalidate.t.sol
+++ b/l1-contracts/test/escape-hatch/integration/invalidate.t.sol
@@ -153,7 +153,7 @@ contract invalidateTest is EscapeHatchIntegrationBase {
     uint256 committeeSize = data.committee.length;
     data.attestations = new CommitteeAttestation[](committeeSize);
     address[] memory signers = new address[](committeeSize);
-    bytes32 digest = ProposeLib.digest(proposePayload);
+    bytes32 digest = ProposeLib.digest(proposePayload, address(rollup));
 
     for (uint256 i = 0; i < committeeSize; i++) {
       data.attestations[i] = _createAttestation(data.committee[i], digest);
@@ -177,7 +177,9 @@ contract invalidateTest is EscapeHatchIntegrationBase {
     Signature memory attestationsAndSignersSignature =
     _createAttestation(
       proposer,
-      AttestationLib.getAttestationsAndSignersDigest(AttestationLibHelper.packAttestations(data.attestations), signers)
+      AttestationLib.getAttestationsAndSignersDigest(
+        AttestationLibHelper.packAttestations(data.attestations), signers, address(rollup)
+      )
     ).signature;
 
     // Propose the checkpoint

--- a/l1-contracts/test/validator-selection/ValidatorSelection.t.sol
+++ b/l1-contracts/test/validator-selection/ValidatorSelection.t.sol
@@ -16,7 +16,6 @@ import {Errors} from "@aztec/core/libraries/Errors.sol";
 import {Timestamp, Epoch} from "@aztec/core/libraries/TimeLib.sol";
 import {IPayload} from "@aztec/core/slashing/Slasher.sol";
 
-import {MessageHashUtils} from "@oz/utils/cryptography/MessageHashUtils.sol";
 import {SafeCast} from "@oz/utils/math/SafeCast.sol";
 
 import {ProposedHeaderLib} from "@aztec/core/libraries/rollup/ProposedHeaderLib.sol";
@@ -121,7 +120,6 @@ library TestFlagsLib {
  * The tests in this file is testing the sequencer selection
  */
 contract ValidatorSelectionTest is ValidatorSelectionTestBase {
-  using MessageHashUtils for bytes32;
   using TestFlagsLib for TestFlags;
 
   bytes4 NO_REVERT = bytes4(0);
@@ -565,7 +563,7 @@ contract ValidatorSelectionTest is ValidatorSelectionTestBase {
 
     ree.attestations = new CommitteeAttestation[](ree.attestationsCount);
     ree.signers = new address[](_signatureCount);
-    bytes32 digest = ProposeLib.digest(ree.proposePayload);
+    bytes32 digest = ProposeLib.digest(ree.proposePayload, address(rollup));
 
     {
       uint256 signersIndex = 0;
@@ -612,7 +610,7 @@ contract ValidatorSelectionTest is ValidatorSelectionTestBase {
         ree.attestationsAndSignersSignature = _createAttestation(
           ree.proposer,
           AttestationLib.getAttestationsAndSignersDigest(
-            AttestationLibHelper.packAttestations(ree.attestations), ree.signers
+            AttestationLibHelper.packAttestations(ree.attestations), ree.signers, address(rollup)
           )
         ).signature;
       }
@@ -665,7 +663,7 @@ contract ValidatorSelectionTest is ValidatorSelectionTestBase {
       ree.attestationsAndSignersSignature = _createAttestation(
         ree.proposer,
         AttestationLib.getAttestationsAndSignersDigest(
-          AttestationLibHelper.packAttestations(ree.attestations), ree.signers
+          AttestationLibHelper.packAttestations(ree.attestations), ree.signers, address(rollup)
         )
       ).signature;
     } else if (ree.proposer != address(0) && _flags.invalidAttestationAndSignersSignature) {
@@ -680,7 +678,7 @@ contract ValidatorSelectionTest is ValidatorSelectionTestBase {
       ree.attestationsAndSignersSignature = _createAttestation(
         invalidSigner,
         AttestationLib.getAttestationsAndSignersDigest(
-          AttestationLibHelper.packAttestations(ree.attestations), ree.signers
+          AttestationLibHelper.packAttestations(ree.attestations), ree.signers, address(rollup)
         )
       ).signature;
     }
@@ -767,8 +765,7 @@ contract ValidatorSelectionTest is ValidatorSelectionTestBase {
   function _createAttestation(address _signer, bytes32 _digest) internal view returns (CommitteeAttestation memory) {
     uint256 privateKey = attesterPrivateKeys[_signer];
 
-    bytes32 digest = _digest.toEthSignedMessageHash();
-    (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, digest);
+    (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, _digest);
 
     Signature memory signature = Signature({v: v, r: r, s: s});
     return CommitteeAttestation({addr: _signer, signature: signature});

--- a/l1-contracts/test/validator-selection/ValidatorSelectionBase.sol
+++ b/l1-contracts/test/validator-selection/ValidatorSelectionBase.sol
@@ -13,7 +13,6 @@ import {Registry} from "@aztec/governance/Registry.sol";
 import {Rollup} from "@aztec/core/Rollup.sol";
 import {MerkleTestUtil} from "../merkle/TestUtil.sol";
 import {TestERC20} from "@aztec/mock/TestERC20.sol";
-import {MessageHashUtils} from "@oz/utils/cryptography/MessageHashUtils.sol";
 import {TestConstants} from "../harnesses/TestConstants.sol";
 
 import {Epoch, Timestamp} from "@aztec/core/libraries/TimeLib.sol";
@@ -37,7 +36,6 @@ import {Math} from "@oz/utils/math/Math.sol";
  * The tests in this file is testing the sequencer selection
  */
 contract ValidatorSelectionTestBase is DecoderBase {
-  using MessageHashUtils for bytes32;
   using stdStorage for StdStorage;
 
   struct ProposeTestData {

--- a/l1-contracts/test/validator-selection/tmnt207.t.sol
+++ b/l1-contracts/test/validator-selection/tmnt207.t.sol
@@ -36,7 +36,6 @@ import {CheatDepositArgs} from "@aztec/mock/MultiAdder.sol";
 import {BN254Lib, G1Point, G2Point} from "@aztec/shared/libraries/BN254Lib.sol";
 import {StakingQueueConfig} from "@aztec/core/libraries/compressed-data/StakingQueueConfig.sol";
 import {ProposedHeaderLib} from "@aztec/core/libraries/rollup/ProposedHeaderLib.sol";
-import {MessageHashUtils} from "@oz/utils/cryptography/MessageHashUtils.sol";
 import {
   IRollup,
   IRollupCore,
@@ -56,7 +55,6 @@ struct Checkpoint {
 }
 
 contract Tmnt207Test is RollupBase {
-  using MessageHashUtils for bytes32;
   using ProposeLib for ProposeArgs;
   using TimeLib for Timestamp;
   using TimeLib for Slot;
@@ -277,7 +275,7 @@ contract Tmnt207Test is RollupBase {
       ProposePayload memory proposePayload =
         ProposePayload({archive: proposeArgs.archive, oracleInput: proposeArgs.oracleInput, headerHash: headerHash});
 
-      bytes32 digest = ProposeLib.digest(proposePayload);
+      bytes32 digest = ProposeLib.digest(proposePayload, address(rollup));
 
       // loop through to make sure we create an attestation for the proposer
       for (uint256 i = 0; i < validators.length; i++) {
@@ -309,7 +307,9 @@ contract Tmnt207Test is RollupBase {
     if (proposer != address(0)) {
       attestationsAndSignersSignature = createAttestation(
         proposer,
-        AttestationLib.getAttestationsAndSignersDigest(AttestationLibHelper.packAttestations(attestations), signers)
+        AttestationLib.getAttestationsAndSignersDigest(
+          AttestationLibHelper.packAttestations(attestations), signers, address(rollup)
+        )
       ).signature;
     }
 
@@ -325,8 +325,7 @@ contract Tmnt207Test is RollupBase {
   function createAttestation(address _signer, bytes32 _digest) internal view returns (CommitteeAttestation memory) {
     uint256 privateKey = attesterPrivateKeys[_signer];
 
-    bytes32 digest = _digest.toEthSignedMessageHash();
-    (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, digest);
+    (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, _digest);
 
     Signature memory signature = Signature({v: v, r: r, s: s});
     // Address can be zero for signed attestations

--- a/yarn-project/archiver/src/l1/calldata_retriever.test.ts
+++ b/yarn-project/archiver/src/l1/calldata_retriever.test.ts
@@ -11,7 +11,7 @@ import { withHexPrefix } from '@aztec/foundation/string';
 import { RollupAbi } from '@aztec/l1-artifacts';
 import { Signature } from '@aztec/stdlib/block';
 import { GasFees } from '@aztec/stdlib/gas';
-import { ConsensusPayload, SignatureDomainSeparator, getHashedSignaturePayloadTypedData } from '@aztec/stdlib/p2p';
+import { ConsensusPayload, getHashedSignaturePayloadTypedData } from '@aztec/stdlib/p2p';
 import { CheckpointHeader } from '@aztec/stdlib/rollup';
 
 import { jest } from '@jest/globals';
@@ -381,12 +381,11 @@ describe('CalldataRetriever', () => {
       // Compute the expected payloadDigest using the same EIP-712 typed data hash
       // that CalldataRetriever.computePayloadDigest uses under the hood.
       const checkpointHeader = CheckpointHeader.fromViem(header);
-      const consensusPayload = new ConsensusPayload(checkpointHeader, archiveRoot, feeAssetPriceModifier);
-      const expectedPayloadDigest = getHashedSignaturePayloadTypedData(
-        consensusPayload,
-        SignatureDomainSeparator.checkpointAttestation,
-        { chainId: 1, rollupAddress },
-      ).toString() as Hex;
+      const consensusPayload = new ConsensusPayload(checkpointHeader, archiveRoot, feeAssetPriceModifier, {
+        chainId: 1,
+        rollupAddress,
+      });
+      const expectedPayloadDigest = getHashedSignaturePayloadTypedData(consensusPayload).toString() as Hex;
 
       // Mock only attestationsHash computation; use real payloadDigest
       jest

--- a/yarn-project/archiver/src/l1/calldata_retriever.test.ts
+++ b/yarn-project/archiver/src/l1/calldata_retriever.test.ts
@@ -11,7 +11,7 @@ import { withHexPrefix } from '@aztec/foundation/string';
 import { RollupAbi } from '@aztec/l1-artifacts';
 import { Signature } from '@aztec/stdlib/block';
 import { GasFees } from '@aztec/stdlib/gas';
-import { ConsensusPayload, SignatureDomainSeparator } from '@aztec/stdlib/p2p';
+import { ConsensusPayload, SignatureDomainSeparator, getHashedSignaturePayloadTypedData } from '@aztec/stdlib/p2p';
 import { CheckpointHeader } from '@aztec/stdlib/rollup';
 
 import { jest } from '@jest/globals';
@@ -88,6 +88,8 @@ describe('CalldataRetriever', () => {
   beforeEach(() => {
     txHash = '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef';
     publicClient = mock<ViemPublicClient>();
+    // CalldataRetriever reads `publicClient.chain.id` to build the EIP-712 signing context.
+    (publicClient as unknown as { chain: { id: number } }).chain = { id: 1 };
     debugClient = mock<ViemPublicDebugClient>();
     logger = createLogger('test:calldata_retriever');
     instrumentation = mock<ArchiverInstrumentation>();
@@ -376,12 +378,15 @@ describe('CalldataRetriever', () => {
       const tx = makeMulticall3Transaction([{ target: rollupAddress.toString(), callData: proposeCalldata }]);
       publicClient.getTransaction.mockResolvedValue(tx);
 
-      // Compute the expected payloadDigest using ConsensusPayload (same logic as the validator)
-      // Note: feeAssetPriceModifier is 0n in makeProposeCalldata
+      // Compute the expected payloadDigest using the same EIP-712 typed data hash
+      // that CalldataRetriever.computePayloadDigest uses under the hood.
       const checkpointHeader = CheckpointHeader.fromViem(header);
       const consensusPayload = new ConsensusPayload(checkpointHeader, archiveRoot, feeAssetPriceModifier);
-      const payloadToSign = consensusPayload.getPayloadToSign(SignatureDomainSeparator.checkpointAttestation);
-      const expectedPayloadDigest = keccak256(payloadToSign);
+      const expectedPayloadDigest = getHashedSignaturePayloadTypedData(
+        consensusPayload,
+        SignatureDomainSeparator.checkpointAttestation,
+        { chainId: 1, rollupAddress },
+      ).toString() as Hex;
 
       // Mock only attestationsHash computation; use real payloadDigest
       jest

--- a/yarn-project/archiver/src/l1/calldata_retriever.ts
+++ b/yarn-project/archiver/src/l1/calldata_retriever.ts
@@ -7,7 +7,7 @@ import { EthAddress } from '@aztec/foundation/eth-address';
 import type { Logger } from '@aztec/foundation/log';
 import { RollupAbi } from '@aztec/l1-artifacts';
 import { CommitteeAttestation } from '@aztec/stdlib/block';
-import { ConsensusPayload, SignatureDomainSeparator, getHashedSignaturePayloadTypedData } from '@aztec/stdlib/p2p';
+import { ConsensusPayload, getHashedSignaturePayloadTypedData } from '@aztec/stdlib/p2p';
 import { CheckpointHeader } from '@aztec/stdlib/rollup';
 
 import {
@@ -473,12 +473,13 @@ export class CalldataRetriever {
 
   /** Computes the keccak256 payload digest from the checkpoint header, archive root, and fee asset price modifier. */
   private computePayloadDigest(header: CheckpointHeader, archiveRoot: Fr, feeAssetPriceModifier: bigint): Hex {
-    const consensusPayload = new ConsensusPayload(header, archiveRoot, feeAssetPriceModifier);
-    return getHashedSignaturePayloadTypedData(
-      consensusPayload,
-      SignatureDomainSeparator.checkpointAttestation,
+    const consensusPayload = new ConsensusPayload(
+      header,
+      archiveRoot,
+      feeAssetPriceModifier,
       this.getSignatureContext(),
-    ).toString();
+    );
+    return getHashedSignaturePayloadTypedData(consensusPayload).toString();
   }
 
   /**

--- a/yarn-project/archiver/src/l1/calldata_retriever.ts
+++ b/yarn-project/archiver/src/l1/calldata_retriever.ts
@@ -7,7 +7,7 @@ import { EthAddress } from '@aztec/foundation/eth-address';
 import type { Logger } from '@aztec/foundation/log';
 import { RollupAbi } from '@aztec/l1-artifacts';
 import { CommitteeAttestation } from '@aztec/stdlib/block';
-import { ConsensusPayload, SignatureDomainSeparator } from '@aztec/stdlib/p2p';
+import { ConsensusPayload, SignatureDomainSeparator, getHashedSignaturePayloadTypedData } from '@aztec/stdlib/p2p';
 import { CheckpointHeader } from '@aztec/stdlib/rollup';
 
 import {
@@ -60,6 +60,13 @@ export class CalldataRetriever {
     private readonly logger: Logger,
     private readonly rollupAddress: EthAddress,
   ) {}
+
+  private getSignatureContext() {
+    return {
+      chainId: this.publicClient.chain.id,
+      rollupAddress: this.rollupAddress,
+    };
+  }
 
   /**
    * Gets checkpoint header and metadata from the calldata of an L1 transaction.
@@ -467,8 +474,11 @@ export class CalldataRetriever {
   /** Computes the keccak256 payload digest from the checkpoint header, archive root, and fee asset price modifier. */
   private computePayloadDigest(header: CheckpointHeader, archiveRoot: Fr, feeAssetPriceModifier: bigint): Hex {
     const consensusPayload = new ConsensusPayload(header, archiveRoot, feeAssetPriceModifier);
-    const payloadToSign = consensusPayload.getPayloadToSign(SignatureDomainSeparator.checkpointAttestation);
-    return keccak256(payloadToSign);
+    return getHashedSignaturePayloadTypedData(
+      consensusPayload,
+      SignatureDomainSeparator.checkpointAttestation,
+      this.getSignatureContext(),
+    ).toString();
   }
 
   /**

--- a/yarn-project/archiver/src/modules/l1_synchronizer.ts
+++ b/yarn-project/archiver/src/modules/l1_synchronizer.ts
@@ -10,6 +10,7 @@ import { BlockNumber, CheckpointNumber, EpochNumber } from '@aztec/foundation/br
 import { Buffer16, Buffer32 } from '@aztec/foundation/buffer';
 import { partition, pick } from '@aztec/foundation/collection';
 import { Fr } from '@aztec/foundation/curves/bn254';
+import { EthAddress } from '@aztec/foundation/eth-address';
 import { type Logger, createLogger } from '@aztec/foundation/log';
 import { retryTimes } from '@aztec/foundation/retry';
 import { count } from '@aztec/foundation/string';
@@ -19,6 +20,7 @@ import { type ArchiverEmitter, L2BlockSourceEvents, type ValidateCheckpointResul
 import { Checkpoint, PublishedCheckpoint } from '@aztec/stdlib/checkpoint';
 import { type L1RollupConstants, getEpochAtSlot, getSlotAtNextL1Block } from '@aztec/stdlib/epoch-helpers';
 import { computeInHashFromL1ToL2Messages } from '@aztec/stdlib/messaging';
+import type { CoordinationSignatureContext } from '@aztec/stdlib/p2p';
 import { type Traceable, type Tracer, execInSpan, trackSpan } from '@aztec/telemetry-client';
 
 import { InitialCheckpointNumberNotSequentialError } from '../errors.js';
@@ -109,6 +111,13 @@ export class ArchiverL1Synchronizer implements Traceable {
   /** Returns the last L1 timestamp that was synced. */
   public getL1Timestamp(): bigint | undefined {
     return this.l1Timestamp;
+  }
+
+  private getSignatureContext(): CoordinationSignatureContext {
+    return {
+      chainId: this.publicClient.chain.id,
+      rollupAddress: EthAddress.fromString(this.rollup.address),
+    };
   }
 
   /** Checks that the ethereum node we are connected to has a latest timestamp no more than the allowed drift. Throw if not. */
@@ -812,7 +821,13 @@ export class ArchiverL1Synchronizer implements Traceable {
       for (const published of publishedCheckpoints) {
         const validationResult = this.config.skipValidateCheckpointAttestations
           ? { valid: true as const }
-          : await validateCheckpointAttestations(published, this.epochCache, this.l1Constants, this.log);
+          : await validateCheckpointAttestations(
+              published,
+              this.epochCache,
+              this.l1Constants,
+              this.getSignatureContext(),
+              this.log,
+            );
 
         // Only update the validation result if it has changed, so we can keep track of the first invalid checkpoint
         // in case there is a sequence of more than one invalid checkpoint, as we need to invalidate the first one.

--- a/yarn-project/archiver/src/modules/validation.test.ts
+++ b/yarn-project/archiver/src/modules/validation.test.ts
@@ -7,6 +7,7 @@ import { Signature } from '@aztec/foundation/eth-signature';
 import { type Logger, createLogger } from '@aztec/foundation/log';
 import { CommitteeAttestation, EthAddress } from '@aztec/stdlib/block';
 import { Checkpoint } from '@aztec/stdlib/checkpoint';
+import { TEST_COORDINATION_SIGNATURE_CONTEXT } from '@aztec/stdlib/testing';
 
 import { type MockProxy, mock } from 'jest-mock-extended';
 import assert from 'node:assert';
@@ -58,7 +59,13 @@ describe('validateCheckpointAttestations', () => {
 
     it('validates a checkpoint if no committee is found', async () => {
       const checkpoint = await makeCheckpoint([], []);
-      const result = await validateCheckpointAttestations(checkpoint, epochCache, constants, logger);
+      const result = await validateCheckpointAttestations(
+        checkpoint,
+        epochCache,
+        constants,
+        TEST_COORDINATION_SIGNATURE_CONTEXT,
+        logger,
+      );
 
       expect(result.valid).toBe(true);
       expect(epochCache.getCommitteeForEpoch).toHaveBeenCalledWith(EpochNumber(0));
@@ -66,7 +73,13 @@ describe('validateCheckpointAttestations', () => {
 
     it('validates a checkpoint with no attestations if no committee is found', async () => {
       const checkpoint = await makeCheckpoint(signers, committee);
-      const result = await validateCheckpointAttestations(checkpoint, epochCache, constants, logger);
+      const result = await validateCheckpointAttestations(
+        checkpoint,
+        epochCache,
+        constants,
+        TEST_COORDINATION_SIGNATURE_CONTEXT,
+        logger,
+      );
 
       expect(result.valid).toBe(true);
       expect(epochCache.getCommitteeForEpoch).toHaveBeenCalledWith(EpochNumber(0));
@@ -76,7 +89,13 @@ describe('validateCheckpointAttestations', () => {
       // This should already be covered by the case of empty committee
       epochCache.isEscapeHatchOpen.mockResolvedValue(true);
       const checkpoint = await makeCheckpoint(signers, committee);
-      const result = await validateCheckpointAttestations(checkpoint, epochCache, constants, logger);
+      const result = await validateCheckpointAttestations(
+        checkpoint,
+        epochCache,
+        constants,
+        TEST_COORDINATION_SIGNATURE_CONTEXT,
+        logger,
+      );
       expect(result.valid).toBe(true);
       expect(epochCache.isEscapeHatchOpen).not.toHaveBeenCalled();
     });
@@ -90,23 +109,44 @@ describe('validateCheckpointAttestations', () => {
     it('uses feeAssetPriceModifier when recovering attestors', async () => {
       const checkpoint = await makeCheckpoint(signers.slice(0, 4), committee, 1, 1n);
 
-      const attestationInfos = getAttestationInfoFromPublishedCheckpoint(checkpoint);
+      const attestationInfos = getAttestationInfoFromPublishedCheckpoint(
+        checkpoint,
+        TEST_COORDINATION_SIGNATURE_CONTEXT,
+      );
       expect(attestationInfos.filter(a => a.status === 'recovered-from-signature').length).toBe(4);
 
-      const result = await validateCheckpointAttestations(checkpoint, epochCache, constants, logger);
+      const result = await validateCheckpointAttestations(
+        checkpoint,
+        epochCache,
+        constants,
+        TEST_COORDINATION_SIGNATURE_CONTEXT,
+        logger,
+      );
       expect(result.valid).toBe(true);
     });
 
     it('requests committee for the correct epoch', async () => {
       const checkpoint = await makeCheckpoint(signers, committee, 28);
-      await validateCheckpointAttestations(checkpoint, epochCache, constants, logger);
+      await validateCheckpointAttestations(
+        checkpoint,
+        epochCache,
+        constants,
+        TEST_COORDINATION_SIGNATURE_CONTEXT,
+        logger,
+      );
       expect(epochCache.getCommitteeForEpoch).toHaveBeenCalledWith(EpochNumber(2));
     });
 
     it('fails if there is an attestation from a non-committee member', async () => {
       const badSigner = Secp256k1Signer.random();
       const checkpoint = await makeCheckpoint([...signers, badSigner], [...committee, badSigner.address]);
-      const result = await validateCheckpointAttestations(checkpoint, epochCache, constants, logger);
+      const result = await validateCheckpointAttestations(
+        checkpoint,
+        epochCache,
+        constants,
+        TEST_COORDINATION_SIGNATURE_CONTEXT,
+        logger,
+      );
       assert(!result.valid);
       assert(result.reason === 'invalid-attestation');
       expect(result.checkpoint.checkpointNumber).toEqual(checkpoint.checkpoint.number);
@@ -118,7 +158,13 @@ describe('validateCheckpointAttestations', () => {
     it('fails if there is an empty attestation', async () => {
       const checkpoint = await makeCheckpoint(signers.slice(0, 4), committee);
       checkpoint.attestations[1] = new CommitteeAttestation(EthAddress.ZERO, Signature.empty());
-      const result = await validateCheckpointAttestations(checkpoint, epochCache, constants, logger);
+      const result = await validateCheckpointAttestations(
+        checkpoint,
+        epochCache,
+        constants,
+        TEST_COORDINATION_SIGNATURE_CONTEXT,
+        logger,
+      );
       assert(!result.valid);
       assert(result.reason === 'invalid-attestation');
       expect(result.checkpoint.checkpointNumber).toEqual(checkpoint.checkpoint.number);
@@ -141,10 +187,16 @@ describe('validateCheckpointAttestations', () => {
       checkpoint.attestations[0] = new CommitteeAttestation(EthAddress.ZERO, invalidSig);
 
       // Verify that the invalid signature is detected
-      const attestations = getAttestationInfoFromPublishedCheckpoint(checkpoint);
+      const attestations = getAttestationInfoFromPublishedCheckpoint(checkpoint, TEST_COORDINATION_SIGNATURE_CONTEXT);
       expect(attestations[0].status).toBe('invalid-signature');
 
-      const result = await validateCheckpointAttestations(checkpoint, epochCache, constants, logger);
+      const result = await validateCheckpointAttestations(
+        checkpoint,
+        epochCache,
+        constants,
+        TEST_COORDINATION_SIGNATURE_CONTEXT,
+        logger,
+      );
       assert(!result.valid);
       assert(result.reason === 'invalid-attestation');
       expect(result.checkpoint.checkpointNumber).toEqual(checkpoint.checkpoint.number);
@@ -162,10 +214,16 @@ describe('validateCheckpointAttestations', () => {
       checkpoint.attestations[2] = new CommitteeAttestation(original.address, flipped);
 
       // Verify the flipped signature is detected as invalid
-      const attestations = getAttestationInfoFromPublishedCheckpoint(checkpoint);
+      const attestations = getAttestationInfoFromPublishedCheckpoint(checkpoint, TEST_COORDINATION_SIGNATURE_CONTEXT);
       expect(attestations[2].status).toBe('invalid-signature');
 
-      const result = await validateCheckpointAttestations(checkpoint, epochCache, constants, logger);
+      const result = await validateCheckpointAttestations(
+        checkpoint,
+        epochCache,
+        constants,
+        TEST_COORDINATION_SIGNATURE_CONTEXT,
+        logger,
+      );
       assert(!result.valid);
       assert(result.reason === 'invalid-attestation');
       expect(result.checkpoint.checkpointNumber).toEqual(checkpoint.checkpoint.number);
@@ -185,7 +243,13 @@ describe('validateCheckpointAttestations', () => {
 
       // Index 2 is a valid attestation from signers[2]
 
-      const result = await validateCheckpointAttestations(checkpoint, epochCache, constants, logger);
+      const result = await validateCheckpointAttestations(
+        checkpoint,
+        epochCache,
+        constants,
+        TEST_COORDINATION_SIGNATURE_CONTEXT,
+        logger,
+      );
       assert(!result.valid);
       assert(result.reason === 'invalid-attestation');
       expect(result.invalidIndex).toBe(1); // Should be 1 (the original index), not 0
@@ -193,7 +257,13 @@ describe('validateCheckpointAttestations', () => {
 
     it('returns false if insufficient attestations', async () => {
       const checkpoint = await makeCheckpoint(signers.slice(0, 2), committee);
-      const result = await validateCheckpointAttestations(checkpoint, epochCache, constants, logger);
+      const result = await validateCheckpointAttestations(
+        checkpoint,
+        epochCache,
+        constants,
+        TEST_COORDINATION_SIGNATURE_CONTEXT,
+        logger,
+      );
       assert(!result.valid);
       expect(result.reason).toBe('insufficient-attestations');
       expect(result.checkpoint.checkpointNumber).toEqual(checkpoint.checkpoint.number);
@@ -203,7 +273,13 @@ describe('validateCheckpointAttestations', () => {
 
     it('returns true if all attestations are valid and sufficient', async () => {
       const checkpoint = await makeCheckpoint(signers.slice(0, 4), committee);
-      const result = await validateCheckpointAttestations(checkpoint, epochCache, constants, logger);
+      const result = await validateCheckpointAttestations(
+        checkpoint,
+        epochCache,
+        constants,
+        TEST_COORDINATION_SIGNATURE_CONTEXT,
+        logger,
+      );
       expect(result.valid).toBe(true);
     });
 
@@ -217,7 +293,13 @@ describe('validateCheckpointAttestations', () => {
       checkpoint.attestations[1] = checkpoint.attestations[2];
       checkpoint.attestations[2] = temp;
 
-      const result = await validateCheckpointAttestations(checkpoint, epochCache, constants, logger);
+      const result = await validateCheckpointAttestations(
+        checkpoint,
+        epochCache,
+        constants,
+        TEST_COORDINATION_SIGNATURE_CONTEXT,
+        logger,
+      );
       assert(!result.valid);
       assert(result.reason === 'invalid-attestation');
       expect(result.checkpoint.checkpointNumber).toEqual(checkpoint.checkpoint.number);
@@ -230,7 +312,13 @@ describe('validateCheckpointAttestations', () => {
     it('validates a checkpoint if escape hatch is open', async () => {
       epochCache.isEscapeHatchOpen.mockResolvedValue(true);
       const checkpoint = await makeCheckpoint(signers, committee);
-      const result = await validateCheckpointAttestations(checkpoint, epochCache, constants, logger);
+      const result = await validateCheckpointAttestations(
+        checkpoint,
+        epochCache,
+        constants,
+        TEST_COORDINATION_SIGNATURE_CONTEXT,
+        logger,
+      );
       expect(result.valid).toBe(true);
       expect(epochCache.isEscapeHatchOpen).toHaveBeenCalledWith(EpochNumber(0));
     });

--- a/yarn-project/archiver/src/modules/validation.ts
+++ b/yarn-project/archiver/src/modules/validation.ts
@@ -10,7 +10,7 @@ import {
 } from '@aztec/stdlib/block';
 import type { PublishedCheckpoint } from '@aztec/stdlib/checkpoint';
 import { type L1RollupConstants, computeQuorum, getEpochAtSlot } from '@aztec/stdlib/epoch-helpers';
-import { ConsensusPayload } from '@aztec/stdlib/p2p';
+import { ConsensusPayload, type CoordinationSignatureContext } from '@aztec/stdlib/p2p';
 
 export type { ValidateCheckpointResult };
 
@@ -18,12 +18,12 @@ export type { ValidateCheckpointResult };
  * Extracts attestation information from a published checkpoint.
  * Returns info for each attestation, preserving array indices.
  */
-export function getAttestationInfoFromPublishedCheckpoint({
-  checkpoint,
-  attestations,
-}: PublishedCheckpoint): AttestationInfo[] {
+export function getAttestationInfoFromPublishedCheckpoint(
+  { checkpoint, attestations }: PublishedCheckpoint,
+  signatureContext: CoordinationSignatureContext,
+): AttestationInfo[] {
   const payload = ConsensusPayload.fromCheckpoint(checkpoint);
-  return getAttestationInfoFromPayload(payload, attestations);
+  return getAttestationInfoFromPayload(payload, attestations, signatureContext);
 }
 
 /**
@@ -34,9 +34,10 @@ export async function validateCheckpointAttestations(
   publishedCheckpoint: PublishedCheckpoint,
   epochCache: EpochCache,
   constants: Pick<L1RollupConstants, 'epochDuration'>,
+  signatureContext: CoordinationSignatureContext,
   logger?: Logger,
 ): Promise<ValidateCheckpointResult> {
-  const attestorInfos = getAttestationInfoFromPublishedCheckpoint(publishedCheckpoint);
+  const attestorInfos = getAttestationInfoFromPublishedCheckpoint(publishedCheckpoint, signatureContext);
   const attestors = compactArray(attestorInfos.map(info => ('address' in info ? info.address : undefined)));
   const { checkpoint, attestations } = publishedCheckpoint;
   const headerHash = checkpoint.header.hash();

--- a/yarn-project/archiver/src/modules/validation.ts
+++ b/yarn-project/archiver/src/modules/validation.ts
@@ -22,8 +22,8 @@ export function getAttestationInfoFromPublishedCheckpoint(
   { checkpoint, attestations }: PublishedCheckpoint,
   signatureContext: CoordinationSignatureContext,
 ): AttestationInfo[] {
-  const payload = ConsensusPayload.fromCheckpoint(checkpoint);
-  return getAttestationInfoFromPayload(payload, attestations, signatureContext);
+  const payload = ConsensusPayload.fromCheckpoint(checkpoint, signatureContext);
+  return getAttestationInfoFromPayload(payload, attestations);
 }
 
 /**

--- a/yarn-project/archiver/src/test/fake_l1_state.ts
+++ b/yarn-project/archiver/src/test/fake_l1_state.ts
@@ -15,12 +15,8 @@ import { CommitteeAttestation, CommitteeAttestationsAndSigners, L2Block } from '
 import { Checkpoint } from '@aztec/stdlib/checkpoint';
 import { getSlotAtTimestamp } from '@aztec/stdlib/epoch-helpers';
 import { InboxLeaf } from '@aztec/stdlib/messaging';
-import { ConsensusPayload, SignatureDomainSeparator } from '@aztec/stdlib/p2p';
-import {
-  makeAndSignCommitteeAttestationsAndSigners,
-  makeCheckpointAttestationFromCheckpoint,
-  mockCheckpointAndMessages,
-} from '@aztec/stdlib/testing';
+import { ConsensusPayload, SignatureDomainSeparator, getHashedSignaturePayloadTypedData } from '@aztec/stdlib/p2p';
+import { mockCheckpointAndMessages } from '@aztec/stdlib/testing';
 import { AppendOnlyTreeSnapshot } from '@aztec/stdlib/trees';
 
 import { type MockProxy, mock } from 'jest-mock-extended';
@@ -519,6 +515,9 @@ export class FakeL1State {
     const publicClient = mock<ViemPublicClient>();
 
     publicClient.getChainId.mockResolvedValue(1);
+    // Several consumers (CalldataRetriever, ArchiverL1Synchronizer) derive the EIP-712 signing
+    // context from `publicClient.chain.id`. Pin it so it matches `getSignatureContext()` below.
+    (publicClient as unknown as { chain: { id: number } }).chain = { id: 1 };
     publicClient.getBlockNumber.mockImplementation(() => Promise.resolve(this.l1BlockNumber));
 
     publicClient.getBlock.mockImplementation((async (args: { blockNumber?: bigint; blockTag?: string } = {}) => {
@@ -660,9 +659,15 @@ export class FakeL1State {
     checkpoint: Checkpoint,
     signers: Secp256k1Signer[],
   ): Promise<{ tx: Transaction; attestationsHash: Buffer32; payloadDigest: Buffer32 }> {
+    const consensusPayload = ConsensusPayload.fromCheckpoint(checkpoint);
+    const signatureContext = this.getSignatureContext();
+    const attestationDigest = getHashedSignaturePayloadTypedData(
+      consensusPayload,
+      SignatureDomainSeparator.checkpointAttestation,
+      signatureContext,
+    );
     const attestations = signers
-      .map(signer => makeCheckpointAttestationFromCheckpoint(checkpoint, signer))
-      .map(attestation => CommitteeAttestation.fromSignature(attestation.signature))
+      .map(signer => CommitteeAttestation.fromSignature(signer.sign(attestationDigest)))
       .map(committeeAttestation => committeeAttestation.toViem());
 
     const header = checkpoint.header.toViem();
@@ -672,9 +677,16 @@ export class FakeL1State {
       attestations.map(attestation => CommitteeAttestation.fromViem(attestation)),
     );
 
-    const attestationsAndSignersSignature = makeAndSignCommitteeAttestationsAndSigners(
-      attestationsAndSigners,
-      signers[0],
+    // Fall back to a random signer when no attesters are provided, so tests that
+    // don't care about the proposer identity (e.g. sync tests) still produce a
+    // valid-looking signature for the attestationsAndSigners struct.
+    const proposerSigner = signers[0] ?? Secp256k1Signer.random();
+    const attestationsAndSignersSignature = proposerSigner.sign(
+      getHashedSignaturePayloadTypedData(
+        attestationsAndSigners,
+        SignatureDomainSeparator.attestationsAndSigners,
+        signatureContext,
+      ),
     );
 
     const packedAttestations = attestationsAndSigners.getPackedAttestations();
@@ -715,9 +727,11 @@ export class FakeL1State {
     );
 
     // Compute payloadDigest (same logic as CalldataRetriever)
-    const consensusPayload = ConsensusPayload.fromCheckpoint(checkpoint);
-    const payloadToSign = consensusPayload.getPayloadToSign(SignatureDomainSeparator.checkpointAttestation);
-    const payloadDigest = Buffer32.fromString(keccak256(payloadToSign));
+    const payloadDigest = getHashedSignaturePayloadTypedData(
+      consensusPayload,
+      SignatureDomainSeparator.checkpointAttestation,
+      signatureContext,
+    );
 
     const tx = {
       input: multiCallInput,
@@ -727,6 +741,13 @@ export class FakeL1State {
     } as Transaction<bigint, number>;
 
     return { tx, attestationsHash, payloadDigest };
+  }
+
+  private getSignatureContext() {
+    return {
+      chainId: 1,
+      rollupAddress: this.config.rollupAddress,
+    };
   }
 
   /** Extracts the CommitteeAttestations struct definition from RollupAbi for hash computation. */

--- a/yarn-project/archiver/src/test/fake_l1_state.ts
+++ b/yarn-project/archiver/src/test/fake_l1_state.ts
@@ -15,7 +15,7 @@ import { CommitteeAttestation, CommitteeAttestationsAndSigners, L2Block } from '
 import { Checkpoint } from '@aztec/stdlib/checkpoint';
 import { getSlotAtTimestamp } from '@aztec/stdlib/epoch-helpers';
 import { InboxLeaf } from '@aztec/stdlib/messaging';
-import { ConsensusPayload, SignatureDomainSeparator, getHashedSignaturePayloadTypedData } from '@aztec/stdlib/p2p';
+import { ConsensusPayload, getHashedSignaturePayloadTypedData } from '@aztec/stdlib/p2p';
 import { mockCheckpointAndMessages } from '@aztec/stdlib/testing';
 import { AppendOnlyTreeSnapshot } from '@aztec/stdlib/trees';
 
@@ -659,13 +659,9 @@ export class FakeL1State {
     checkpoint: Checkpoint,
     signers: Secp256k1Signer[],
   ): Promise<{ tx: Transaction; attestationsHash: Buffer32; payloadDigest: Buffer32 }> {
-    const consensusPayload = ConsensusPayload.fromCheckpoint(checkpoint);
     const signatureContext = this.getSignatureContext();
-    const attestationDigest = getHashedSignaturePayloadTypedData(
-      consensusPayload,
-      SignatureDomainSeparator.checkpointAttestation,
-      signatureContext,
-    );
+    const consensusPayload = ConsensusPayload.fromCheckpoint(checkpoint, signatureContext);
+    const attestationDigest = getHashedSignaturePayloadTypedData(consensusPayload);
     const attestations = signers
       .map(signer => CommitteeAttestation.fromSignature(signer.sign(attestationDigest)))
       .map(committeeAttestation => committeeAttestation.toViem());
@@ -675,6 +671,7 @@ export class FakeL1State {
     const archive = toHex(checkpoint.archive.root.toBuffer());
     const attestationsAndSigners = new CommitteeAttestationsAndSigners(
       attestations.map(attestation => CommitteeAttestation.fromViem(attestation)),
+      signatureContext,
     );
 
     // Fall back to a random signer when no attesters are provided, so tests that
@@ -682,11 +679,7 @@ export class FakeL1State {
     // valid-looking signature for the attestationsAndSigners struct.
     const proposerSigner = signers[0] ?? Secp256k1Signer.random();
     const attestationsAndSignersSignature = proposerSigner.sign(
-      getHashedSignaturePayloadTypedData(
-        attestationsAndSigners,
-        SignatureDomainSeparator.attestationsAndSigners,
-        signatureContext,
-      ),
+      getHashedSignaturePayloadTypedData(attestationsAndSigners),
     );
 
     const packedAttestations = attestationsAndSigners.getPackedAttestations();
@@ -727,11 +720,7 @@ export class FakeL1State {
     );
 
     // Compute payloadDigest (same logic as CalldataRetriever)
-    const payloadDigest = getHashedSignaturePayloadTypedData(
-      consensusPayload,
-      SignatureDomainSeparator.checkpointAttestation,
-      signatureContext,
-    );
+    const payloadDigest = getHashedSignaturePayloadTypedData(consensusPayload);
 
     const tx = {
       input: multiCallInput,

--- a/yarn-project/archiver/src/test/mock_structs.ts
+++ b/yarn-project/archiver/src/test/mock_structs.ts
@@ -18,7 +18,7 @@ import { PrivateLog, PublicLog, SiloedTag, Tag } from '@aztec/stdlib/logs';
 import { InboxLeaf } from '@aztec/stdlib/messaging';
 import { orderAttestations } from '@aztec/stdlib/p2p';
 import { CheckpointHeader } from '@aztec/stdlib/rollup';
-import { makeCheckpointAttestationFromCheckpoint } from '@aztec/stdlib/testing';
+import { TEST_COORDINATION_SIGNATURE_CONTEXT, makeCheckpointAttestationFromCheckpoint } from '@aztec/stdlib/testing';
 import { AppendOnlyTreeSnapshot } from '@aztec/stdlib/trees';
 import { PartialStateReference, StateReference, TxEffect } from '@aztec/stdlib/tx';
 
@@ -230,7 +230,7 @@ export function makeSignedPublishedCheckpoint(
   l1BlockNumber = 1,
 ): PublishedCheckpoint {
   const attestations = signers.map(signer => makeCheckpointAttestationFromCheckpoint(checkpoint, signer));
-  const committeeAttestations = orderAttestations(attestations, committee);
+  const committeeAttestations = orderAttestations(attestations, committee, TEST_COORDINATION_SIGNATURE_CONTEXT);
   return new PublishedCheckpoint(checkpoint, makeL1PublishedData(l1BlockNumber), committeeAttestations);
 }
 

--- a/yarn-project/archiver/src/test/mock_structs.ts
+++ b/yarn-project/archiver/src/test/mock_structs.ts
@@ -18,7 +18,7 @@ import { PrivateLog, PublicLog, SiloedTag, Tag } from '@aztec/stdlib/logs';
 import { InboxLeaf } from '@aztec/stdlib/messaging';
 import { orderAttestations } from '@aztec/stdlib/p2p';
 import { CheckpointHeader } from '@aztec/stdlib/rollup';
-import { TEST_COORDINATION_SIGNATURE_CONTEXT, makeCheckpointAttestationFromCheckpoint } from '@aztec/stdlib/testing';
+import { makeCheckpointAttestationFromCheckpoint } from '@aztec/stdlib/testing';
 import { AppendOnlyTreeSnapshot } from '@aztec/stdlib/trees';
 import { PartialStateReference, StateReference, TxEffect } from '@aztec/stdlib/tx';
 
@@ -230,7 +230,7 @@ export function makeSignedPublishedCheckpoint(
   l1BlockNumber = 1,
 ): PublishedCheckpoint {
   const attestations = signers.map(signer => makeCheckpointAttestationFromCheckpoint(checkpoint, signer));
-  const committeeAttestations = orderAttestations(attestations, committee, TEST_COORDINATION_SIGNATURE_CONTEXT);
+  const committeeAttestations = orderAttestations(attestations, committee);
   return new PublishedCheckpoint(checkpoint, makeL1PublishedData(l1BlockNumber), committeeAttestations);
 }
 

--- a/yarn-project/aztec-node/src/sentinel/factory.ts
+++ b/yarn-project/aztec-node/src/sentinel/factory.ts
@@ -3,6 +3,7 @@ import { createLogger } from '@aztec/foundation/log';
 import { createStore } from '@aztec/kv-store/lmdb-v2';
 import type { P2PClient } from '@aztec/p2p';
 import type { L2BlockSource } from '@aztec/stdlib/block';
+import type { ChainConfig } from '@aztec/stdlib/config';
 import type { SlasherConfig } from '@aztec/stdlib/interfaces/server';
 import type { DataStoreConfig } from '@aztec/stdlib/kv-store';
 
@@ -14,7 +15,7 @@ export async function createSentinel(
   epochCache: EpochCache,
   archiver: L2BlockSource,
   p2p: P2PClient,
-  config: SentinelConfig & DataStoreConfig & SlasherConfig,
+  config: SentinelConfig & DataStoreConfig & SlasherConfig & Pick<ChainConfig, 'l1ChainId' | 'l1Contracts'>,
   logger = createLogger('node:sentinel'),
 ): Promise<Sentinel | undefined> {
   if (!config.sentinelEnabled) {

--- a/yarn-project/aztec-node/src/sentinel/sentinel.test.ts
+++ b/yarn-project/aztec-node/src/sentinel/sentinel.test.ts
@@ -6,7 +6,6 @@ import { EthAddress } from '@aztec/foundation/eth-address';
 import { AztecLMDBStoreV2, openTmpStore } from '@aztec/kv-store/lmdb-v2';
 import type { P2PClient } from '@aztec/p2p';
 import { OffenseType, WANT_TO_SLASH_EVENT, type WantToSlashArgs } from '@aztec/slasher';
-import type { SlasherConfig } from '@aztec/slasher/config';
 import {
   CommitteeAttestation,
   L2Block,
@@ -18,7 +17,11 @@ import {
 import { Checkpoint, L1PublishedData, PublishedCheckpoint } from '@aztec/stdlib/checkpoint';
 import { type L1RollupConstants, getEpochAtSlot, getSlotRangeForEpoch } from '@aztec/stdlib/epoch-helpers';
 import type { CheckpointAttestation } from '@aztec/stdlib/p2p';
-import { makeCheckpointAttestation, makeCheckpointAttestationFromCheckpoint } from '@aztec/stdlib/testing';
+import {
+  TEST_COORDINATION_SIGNATURE_CONTEXT,
+  makeCheckpointAttestation,
+  makeCheckpointAttestationFromCheckpoint,
+} from '@aztec/stdlib/testing';
 import type {
   ValidatorStats,
   ValidatorStatusHistory,
@@ -29,7 +32,7 @@ import type {
 import { jest } from '@jest/globals';
 import { type MockProxy, mock } from 'jest-mock-extended';
 
-import { Sentinel } from './sentinel.js';
+import { Sentinel, type SentinelRuntimeConfig } from './sentinel.js';
 import { SentinelStore } from './store.js';
 
 describe('sentinel', () => {
@@ -47,13 +50,12 @@ describe('sentinel', () => {
   let epoch: EpochNumber;
   let ts: bigint;
   let l1Constants: L1RollupConstants;
-  const config: Pick<
-    SlasherConfig,
-    'slashInactivityTargetPercentage' | 'slashInactivityPenalty' | 'slashInactivityConsecutiveEpochThreshold'
-  > = {
+  const config: SentinelRuntimeConfig = {
     slashInactivityPenalty: 100n,
     slashInactivityTargetPercentage: 0.8,
     slashInactivityConsecutiveEpochThreshold: 1,
+    l1ChainId: TEST_COORDINATION_SIGNATURE_CONTEXT.chainId,
+    l1Contracts: { rollupAddress: TEST_COORDINATION_SIGNATURE_CONTEXT.rollupAddress },
   };
 
   beforeEach(async () => {
@@ -168,7 +170,7 @@ describe('sentinel', () => {
       publishedCheckpoint = await emitCheckpointEvent(checkpoint, checkpointAttestations);
 
       const attestorsFromCheckpoint = compactArray(
-        getAttestationInfoFromPublishedCheckpoint(publishedCheckpoint).map(info =>
+        getAttestationInfoFromPublishedCheckpoint(publishedCheckpoint, TEST_COORDINATION_SIGNATURE_CONTEXT).map(info =>
           info.status === 'recovered-from-signature' || info.status === 'provided-as-address'
             ? info.address
             : undefined,
@@ -213,7 +215,10 @@ describe('sentinel', () => {
       // Verify that getAttestationInfoFromPublishedCheckpoint returns 4 entries total:
       // - 2 with status 'recovered-from-signature' (actual attestations with valid signatures)
       // - 2 with status 'provided-as-address' (placeholders for missing validators)
-      const attestationInfo = getAttestationInfoFromPublishedCheckpoint(publishedCheckpoint);
+      const attestationInfo = getAttestationInfoFromPublishedCheckpoint(
+        publishedCheckpoint,
+        TEST_COORDINATION_SIGNATURE_CONTEXT,
+      );
       expect(attestationInfo).toHaveLength(4);
       const recoveredSignatures = attestationInfo.filter(info => info.status === 'recovered-from-signature');
       const placeholders = attestationInfo.filter(info => info.status === 'provided-as-address');
@@ -946,10 +951,7 @@ class TestSentinel extends Sentinel {
     archiver: L2BlockSource,
     p2p: P2PClient,
     store: SentinelStore,
-    config: Pick<
-      SlasherConfig,
-      'slashInactivityTargetPercentage' | 'slashInactivityPenalty' | 'slashInactivityConsecutiveEpochThreshold'
-    >,
+    config: SentinelRuntimeConfig,
     protected override blockStream: L2BlockStream,
   ) {
     super(epochCache, archiver, p2p, store, config);

--- a/yarn-project/aztec-node/src/sentinel/sentinel.ts
+++ b/yarn-project/aztec-node/src/sentinel/sentinel.ts
@@ -375,9 +375,7 @@ export class Sentinel extends (EventEmitter as new () => WatcherEmitter) impleme
     const checkpoint = this.slotNumberToCheckpoint.get(slot);
     const p2pAttested = await this.p2p.getCheckpointAttestationsForSlot(slot, checkpoint?.archive);
     // Filter out attestations with invalid signatures
-    const p2pAttestors = p2pAttested
-      .map(a => a.getSender(this.getSignatureContext()))
-      .filter((s): s is EthAddress => s !== undefined);
+    const p2pAttestors = p2pAttested.map(a => a.getSender()).filter((s): s is EthAddress => s !== undefined);
     const attestors = new Set(
       [...p2pAttestors.map(a => a.toString()), ...(checkpoint?.attestors.map(a => a.toString()) ?? [])].filter(
         addr => proposer.toString() !== addr, // Exclude the proposer from the attestors

--- a/yarn-project/aztec-node/src/sentinel/sentinel.ts
+++ b/yarn-project/aztec-node/src/sentinel/sentinel.ts
@@ -21,7 +21,9 @@ import {
   type L2BlockStreamEventHandler,
   getAttestationInfoFromPublishedCheckpoint,
 } from '@aztec/stdlib/block';
+import type { ChainConfig } from '@aztec/stdlib/config';
 import { getEpochAtSlot, getSlotRangeForEpoch, getTimestampForSlot } from '@aztec/stdlib/epoch-helpers';
+import type { CoordinationSignatureContext } from '@aztec/stdlib/p2p';
 import type {
   SingleValidatorStats,
   ValidatorStats,
@@ -35,6 +37,12 @@ import type {
 import EventEmitter from 'node:events';
 
 import { SentinelStore } from './store.js';
+
+export type SentinelRuntimeConfig = Pick<
+  SlasherConfig,
+  'slashInactivityTargetPercentage' | 'slashInactivityPenalty' | 'slashInactivityConsecutiveEpochThreshold'
+> &
+  Pick<ChainConfig, 'l1ChainId' | 'l1Contracts'>;
 
 /** Maps a validator status to its category: proposer or attestation. */
 function statusToCategory(status: ValidatorStatusInSlot): ValidatorStatusType {
@@ -65,16 +73,20 @@ export class Sentinel extends (EventEmitter as new () => WatcherEmitter) impleme
     protected archiver: L2BlockSource,
     protected p2p: P2PClient,
     protected store: SentinelStore,
-    protected config: Pick<
-      SlasherConfig,
-      'slashInactivityTargetPercentage' | 'slashInactivityPenalty' | 'slashInactivityConsecutiveEpochThreshold'
-    >,
+    protected config: SentinelRuntimeConfig,
     protected logger = createLogger('node:sentinel'),
   ) {
     super();
     this.l2TipsStore = new L2TipsMemoryStore();
     const interval = (epochCache.getL1Constants().ethereumSlotDuration * 1000) / 4;
     this.runningPromise = new RunningPromise(this.work.bind(this), logger, interval);
+  }
+
+  private getSignatureContext(): CoordinationSignatureContext {
+    return {
+      chainId: this.config.l1ChainId,
+      rollupAddress: this.config.l1Contracts.rollupAddress,
+    };
   }
 
   public updateConfig(config: Partial<SlasherConfig>) {
@@ -117,7 +129,7 @@ export class Sentinel extends (EventEmitter as new () => WatcherEmitter) impleme
     this.slotNumberToCheckpoint.set(checkpoint.checkpoint.header.slotNumber, {
       checkpointNumber: checkpoint.checkpoint.number,
       archive: checkpoint.checkpoint.archive.root.toString(),
-      attestors: getAttestationInfoFromPublishedCheckpoint(checkpoint)
+      attestors: getAttestationInfoFromPublishedCheckpoint(checkpoint, this.getSignatureContext())
         .filter(a => a.status === 'recovered-from-signature')
         .map(a => a.address!),
     });
@@ -363,7 +375,9 @@ export class Sentinel extends (EventEmitter as new () => WatcherEmitter) impleme
     const checkpoint = this.slotNumberToCheckpoint.get(slot);
     const p2pAttested = await this.p2p.getCheckpointAttestationsForSlot(slot, checkpoint?.archive);
     // Filter out attestations with invalid signatures
-    const p2pAttestors = p2pAttested.map(a => a.getSender()).filter((s): s is EthAddress => s !== undefined);
+    const p2pAttestors = p2pAttested
+      .map(a => a.getSender(this.getSignatureContext()))
+      .filter((s): s is EthAddress => s !== undefined);
     const attestors = new Set(
       [...p2pAttestors.map(a => a.toString()), ...(checkpoint?.attestors.map(a => a.toString()) ?? [])].filter(
         addr => proposer.toString() !== addr, // Exclude the proposer from the attestors

--- a/yarn-project/end-to-end/src/composed/ha/e2e_ha_full.test.ts
+++ b/yarn-project/end-to-end/src/composed/ha/e2e_ha_full.test.ts
@@ -418,7 +418,7 @@ describe('HA Full Setup', () => {
     expect(p2pAttestationsWithSignatures.length).toBe(COMMITTEE_SIZE);
     const p2pValidatorAddresses = new Map<string, number>();
     for (const attestation of p2pAttestationsWithSignatures) {
-      const sender = attestation.getSender(getSignatureContext());
+      const sender = attestation.getSender();
       if (sender) {
         const addr = sender.toString();
         p2pValidatorAddresses.set(addr, (p2pValidatorAddresses.get(addr) || 0) + 1);
@@ -766,7 +766,7 @@ describe('HA Full Setup', () => {
       // Extract validator addresses from P2P attestations using getSender()
       const p2pValidatorAddresses = new Map<string, number>();
       for (const attestation of p2pAttestationsWithSignatures) {
-        const sender = attestation.getSender(getSignatureContext());
+        const sender = attestation.getSender();
         if (sender) {
           const addr = sender.toString();
           p2pValidatorAddresses.set(addr, (p2pValidatorAddresses.get(addr) || 0) + 1);

--- a/yarn-project/end-to-end/src/composed/ha/e2e_ha_full.test.ts
+++ b/yarn-project/end-to-end/src/composed/ha/e2e_ha_full.test.ts
@@ -89,6 +89,10 @@ describe('HA Full Setup', () => {
   let governanceProposer: GovernanceProposerContract;
   /** Per-node initial keystore JSON (all 4 attesters, node's own publisher) for restore after reload test */
   let initialKeystoreJsons: string[];
+  const getSignatureContext = () => ({
+    chainId: config.l1ChainId,
+    rollupAddress: deployL1ContractsValues.l1ContractAddresses.rollupAddress,
+  });
 
   beforeAll(async () => {
     // Check required environment variables
@@ -414,7 +418,7 @@ describe('HA Full Setup', () => {
     expect(p2pAttestationsWithSignatures.length).toBe(COMMITTEE_SIZE);
     const p2pValidatorAddresses = new Map<string, number>();
     for (const attestation of p2pAttestationsWithSignatures) {
-      const sender = attestation.getSender();
+      const sender = attestation.getSender(getSignatureContext());
       if (sender) {
         const addr = sender.toString();
         p2pValidatorAddresses.set(addr, (p2pValidatorAddresses.get(addr) || 0) + 1);
@@ -762,7 +766,7 @@ describe('HA Full Setup', () => {
       // Extract validator addresses from P2P attestations using getSender()
       const p2pValidatorAddresses = new Map<string, number>();
       for (const attestation of p2pAttestationsWithSignatures) {
-        const sender = attestation.getSender();
+        const sender = attestation.getSender(getSignatureContext());
         if (sender) {
           const addr = sender.toString();
           p2pValidatorAddresses.set(addr, (p2pValidatorAddresses.get(addr) || 0) + 1);
@@ -783,16 +787,19 @@ describe('HA Full Setup', () => {
       const [publishedCheckpoint] = await aztecNode.getCheckpoints(block.checkpointNumber, 1, {
         includeAttestations: true,
       });
-      const attestationInfos = getAttestationInfoFromPublishedCheckpoint({
-        attestations: publishedCheckpoint.attestations ?? [],
-        checkpoint: new Checkpoint(
-          publishedCheckpoint.archive,
-          publishedCheckpoint.header,
-          [],
-          publishedCheckpoint.number,
-          publishedCheckpoint.feeAssetPriceModifier,
-        ),
-      });
+      const attestationInfos = getAttestationInfoFromPublishedCheckpoint(
+        {
+          attestations: publishedCheckpoint.attestations ?? [],
+          checkpoint: new Checkpoint(
+            publishedCheckpoint.archive,
+            publishedCheckpoint.header,
+            [],
+            publishedCheckpoint.number,
+            publishedCheckpoint.feeAssetPriceModifier,
+          ),
+        },
+        getSignatureContext(),
+      );
 
       // Filter to only valid attestations with recovered addresses
       const validAttestations = attestationInfos.filter(

--- a/yarn-project/end-to-end/src/e2e_l1_publisher/e2e_l1_publisher.test.ts
+++ b/yarn-project/end-to-end/src/e2e_l1_publisher/e2e_l1_publisher.test.ts
@@ -504,7 +504,7 @@ describe('L1Publisher integration', () => {
 
         await publisher.enqueueProposeCheckpoint(
           checkpoint,
-          CommitteeAttestationsAndSigners.empty(),
+          CommitteeAttestationsAndSigners.empty(getSignatureContext()),
           Signature.empty(),
         );
         await publisher.sendRequests();
@@ -550,7 +550,7 @@ describe('L1Publisher integration', () => {
                 feeAssetPriceModifier: 0n,
               },
             },
-            CommitteeAttestationsAndSigners.empty().getPackedAttestations(),
+            CommitteeAttestationsAndSigners.packAttestations([]),
             [],
             Signature.empty().toViemSignature(),
             getPrefixedEthBlobCommitments(blockBlobs),
@@ -803,7 +803,11 @@ describe('L1Publisher integration', () => {
       const { checkpoint } = await buildSingleCheckpoint();
       const block = checkpoint.blocks[0];
 
-      await publisher.enqueueProposeCheckpoint(checkpoint, CommitteeAttestationsAndSigners.empty(), Signature.empty());
+      await publisher.enqueueProposeCheckpoint(
+        checkpoint,
+        CommitteeAttestationsAndSigners.empty(getSignatureContext()),
+        Signature.empty(),
+      );
       await publisher.enqueueGovernanceCastSignal(
         l1ContractAddresses.rollupAddress,
         block.slot,
@@ -827,7 +831,11 @@ describe('L1Publisher integration', () => {
       // Expect the simulation to fail
       const loggerErrorSpy = jest.spyOn((publisher as any).log, 'error');
       await expect(
-        publisher.enqueueProposeCheckpoint(checkpoint, CommitteeAttestationsAndSigners.empty(), Signature.empty()),
+        publisher.enqueueProposeCheckpoint(
+          checkpoint,
+          CommitteeAttestationsAndSigners.empty(getSignatureContext()),
+          Signature.empty(),
+        ),
       ).rejects.toThrow(/Rollup__InvalidInHash/);
       expect(loggerErrorSpy).toHaveBeenNthCalledWith(
         2,
@@ -875,9 +883,12 @@ describe('L1Publisher integration', () => {
     };
 
     const enqueueProposeL2Checkpoint = async (checkpoint: Checkpoint) => {
-      await publisher.enqueueProposeCheckpoint(checkpoint, CommitteeAttestationsAndSigners.empty(), Signature.empty(), {
-        txTimeoutAt: getProposeTxTimeoutAt(checkpoint),
-      });
+      await publisher.enqueueProposeCheckpoint(
+        checkpoint,
+        CommitteeAttestationsAndSigners.empty(getSignatureContext()),
+        Signature.empty(),
+        { txTimeoutAt: getProposeTxTimeoutAt(checkpoint) },
+      );
     };
 
     it(`cancels block proposal when the L2 slot ends`, async () => {

--- a/yarn-project/end-to-end/src/e2e_l1_publisher/e2e_l1_publisher.test.ts
+++ b/yarn-project/end-to-end/src/e2e_l1_publisher/e2e_l1_publisher.test.ts
@@ -58,7 +58,6 @@ import {
   CheckpointProposal,
   ConsensusPayload,
   CheckpointAttestation as P2PCheckpointAttestation,
-  SignatureDomainSeparator,
   getHashedSignaturePayloadTypedData,
   orderAttestations,
 } from '@aztec/stdlib/p2p';
@@ -143,36 +142,23 @@ describe('L1Publisher integration', () => {
     rollupAddress: l1ContractAddresses.rollupAddress,
   });
   const makeCheckpointAttestationForCurrentContext = (checkpoint: Checkpoint, signer: Secp256k1Signer) => {
-    const payload = ConsensusPayload.fromCheckpoint(checkpoint);
-    const attestationDigest = getHashedSignaturePayloadTypedData(
-      payload,
-      SignatureDomainSeparator.checkpointAttestation,
-      getSignatureContext(),
-    );
+    const signatureContext = getSignatureContext();
+    const payload = ConsensusPayload.fromCheckpoint(checkpoint, signatureContext);
+    const attestationDigest = getHashedSignaturePayloadTypedData(payload);
     const proposal = new CheckpointProposal(
       checkpoint.header,
       checkpoint.archive.root,
       checkpoint.feeAssetPriceModifier,
       Signature.empty(),
+      signatureContext,
     );
-    const proposalDigest = getHashedSignaturePayloadTypedData(
-      proposal,
-      SignatureDomainSeparator.checkpointProposal,
-      getSignatureContext(),
-    );
+    const proposalDigest = getHashedSignaturePayloadTypedData(proposal);
     return new P2PCheckpointAttestation(payload, signer.sign(attestationDigest), signer.sign(proposalDigest));
   };
   const signAttestationsAndSigners = (
     attestationsAndSigners: CommitteeAttestationsAndSigners,
     signer: Secp256k1Signer,
-  ) =>
-    signer.sign(
-      getHashedSignaturePayloadTypedData(
-        attestationsAndSigners,
-        SignatureDomainSeparator.attestationsAndSigners,
-        getSignatureContext(),
-      ),
-    );
+  ) => signer.sign(getHashedSignaturePayloadTypedData(attestationsAndSigners));
 
   const progressTimeBySlot = async (slotsToJump = 1) => {
     const currentTime = (await l1Client.getBlock()).timestamp;
@@ -629,7 +615,7 @@ describe('L1Publisher integration', () => {
     ) => {
       await publisher.enqueueProposeCheckpoint(
         checkpoint,
-        new CommitteeAttestationsAndSigners(attestations),
+        new CommitteeAttestationsAndSigners(attestations, getSignatureContext()),
         signature,
       );
       const result = await publisher.sendRequests();
@@ -642,7 +628,7 @@ describe('L1Publisher integration', () => {
       const block = checkpoint.blocks[0];
 
       const checkpointAttestations = validators.map(v => makeCheckpointAttestationForCurrentContext(checkpoint, v));
-      const attestations = orderAttestations(checkpointAttestations, committee!, getSignatureContext());
+      const attestations = orderAttestations(checkpointAttestations, committee!);
 
       const canPropose = await publisher.canProposeAt(new Fr(GENESIS_ARCHIVE_ROOT), proposer!);
       expect(canPropose?.slot).toEqual(block.header.getSlot());
@@ -650,7 +636,7 @@ describe('L1Publisher integration', () => {
 
       const proposerSigner = validators.find(v => v.address.equals(proposer!));
 
-      const attestationsAndSigners = new CommitteeAttestationsAndSigners(attestations);
+      const attestationsAndSigners = new CommitteeAttestationsAndSigners(attestations, getSignatureContext());
       const attestationsAndSignersSignature = signAttestationsAndSigners(attestationsAndSigners, proposerSigner!);
 
       await expectPublishCheckpoint(checkpoint, attestations, attestationsAndSignersSignature);
@@ -662,8 +648,8 @@ describe('L1Publisher integration', () => {
       const checkpointAttestations = validators.map(v => makeCheckpointAttestationForCurrentContext(checkpoint, v));
 
       // Reverse attestations to break proposer attestation
-      const attestations = orderAttestations(checkpointAttestations, committee!, getSignatureContext()).reverse();
-      const attestationsAndSigners = new CommitteeAttestationsAndSigners(attestations);
+      const attestations = orderAttestations(checkpointAttestations, committee!).reverse();
+      const attestationsAndSigners = new CommitteeAttestationsAndSigners(attestations, getSignatureContext());
 
       const canPropose = await publisher.canProposeAt(new Fr(GENESIS_ARCHIVE_ROOT), proposer!);
       expect(canPropose?.slot).toEqual(block.header.getSlot());
@@ -678,13 +664,13 @@ describe('L1Publisher integration', () => {
       const { checkpoint } = await buildSingleCheckpoint();
       const block = checkpoint.blocks[0];
       const checkpointAttestations = validators.map(v => makeCheckpointAttestationForCurrentContext(checkpoint, v));
-      const attestations = orderAttestations(checkpointAttestations, committee!, getSignatureContext());
+      const attestations = orderAttestations(checkpointAttestations, committee!);
 
       const canPropose = await publisher.canProposeAt(new Fr(GENESIS_ARCHIVE_ROOT), proposer!);
       expect(canPropose?.slot).toEqual(block.header.getSlot());
       await publisher.validateBlockHeader(checkpoint.header);
 
-      const attestationsAndSigners = new CommitteeAttestationsAndSigners(attestations);
+      const attestationsAndSigners = new CommitteeAttestationsAndSigners(attestations, getSignatureContext());
       const attestationsAndSignersSignature = signAttestationsAndSigners(
         attestationsAndSigners,
         validators.find(v => v.address.equals(proposer!))!,
@@ -703,13 +689,13 @@ describe('L1Publisher integration', () => {
       const { checkpoint } = await buildSingleCheckpoint();
       const block = checkpoint.blocks[0];
       const checkpointAttestations = validators.map(v => makeCheckpointAttestationForCurrentContext(checkpoint, v));
-      const attestations = orderAttestations(checkpointAttestations, committee!, getSignatureContext());
+      const attestations = orderAttestations(checkpointAttestations, committee!);
 
       const canPropose = await publisher.canProposeAt(new Fr(GENESIS_ARCHIVE_ROOT), proposer!);
       expect(canPropose?.slot).toEqual(block.header.getSlot());
       await publisher.validateBlockHeader(checkpoint.header);
 
-      const attestationsAndSigners = new CommitteeAttestationsAndSigners(attestations);
+      const attestationsAndSigners = new CommitteeAttestationsAndSigners(attestations, getSignatureContext());
       const attestationsAndSignersSignature = signAttestationsAndSigners(
         attestationsAndSigners,
         validators.find(v => v.address.equals(proposer!))!,
@@ -734,9 +720,9 @@ describe('L1Publisher integration', () => {
       const badCheckpointAttestations = validators
         .filter(v => v.address.equals(proposer!))
         .map(v => makeCheckpointAttestationForCurrentContext(badCheckpoint, v));
-      const badAttestations = orderAttestations(badCheckpointAttestations, committee!, getSignatureContext());
+      const badAttestations = orderAttestations(badCheckpointAttestations, committee!);
 
-      const badAttestationsAndSigners = new CommitteeAttestationsAndSigners(badAttestations);
+      const badAttestationsAndSigners = new CommitteeAttestationsAndSigners(badAttestations, getSignatureContext());
       const badAttestationsAndSignersSignature = signAttestationsAndSigners(
         badAttestationsAndSigners,
         validators.find(v => v.address.equals(proposer!))!,
@@ -756,7 +742,7 @@ describe('L1Publisher integration', () => {
       const block = checkpoint.blocks[0];
       expect(block.number).toEqual(badBlock.number);
       const checkpointAttestations = validators.map(v => makeCheckpointAttestationForCurrentContext(checkpoint, v));
-      const attestations = orderAttestations(checkpointAttestations, committee!, getSignatureContext());
+      const attestations = orderAttestations(checkpointAttestations, committee!);
 
       // Check we can invalidate the checkpoint
       logger.warn('Checking simulate invalidate checkpoint');
@@ -790,7 +776,7 @@ describe('L1Publisher integration', () => {
       await publisher.validateBlockHeader(checkpoint.header, invalidationSimulationOverridesPlan);
 
       // At this point I'm gonna need to propose the correct signature ye? So confused actually here.
-      const attestationsAndSigners = new CommitteeAttestationsAndSigners(attestations);
+      const attestationsAndSigners = new CommitteeAttestationsAndSigners(attestations, getSignatureContext());
       const attestationsAndSignersSignature = signAttestationsAndSigners(
         attestationsAndSigners,
         validators.find(v => v.address.equals(proposer!))!,

--- a/yarn-project/end-to-end/src/e2e_l1_publisher/e2e_l1_publisher.test.ts
+++ b/yarn-project/end-to-end/src/e2e_l1_publisher/e2e_l1_publisher.test.ts
@@ -54,14 +54,16 @@ import { Checkpoint, L1PublishedData, PublishedCheckpoint } from '@aztec/stdlib/
 import { type L1RollupConstants, getSlotStartBuildTimestamp } from '@aztec/stdlib/epoch-helpers';
 import { GasFees, GasSettings } from '@aztec/stdlib/gas';
 import { tryStop } from '@aztec/stdlib/interfaces/server';
-import { orderAttestations } from '@aztec/stdlib/p2p';
-import { CheckpointHeader } from '@aztec/stdlib/rollup';
 import {
-  fr,
-  makeAndSignCommitteeAttestationsAndSigners,
-  makeCheckpointAttestationFromCheckpoint,
-  mockProcessedTx,
-} from '@aztec/stdlib/testing';
+  CheckpointProposal,
+  ConsensusPayload,
+  CheckpointAttestation as P2PCheckpointAttestation,
+  SignatureDomainSeparator,
+  getHashedSignaturePayloadTypedData,
+  orderAttestations,
+} from '@aztec/stdlib/p2p';
+import { CheckpointHeader } from '@aztec/stdlib/rollup';
+import { fr, mockProcessedTx } from '@aztec/stdlib/testing';
 import type { BlockHeader, CheckpointGlobalVariables, ProcessedTx } from '@aztec/stdlib/tx';
 import {
   type MerkleTreeAdminDatabase,
@@ -136,6 +138,41 @@ describe('L1Publisher integration', () => {
 
   let rpcUrl: string;
   let anvil: Anvil;
+  const getSignatureContext = () => ({
+    chainId,
+    rollupAddress: l1ContractAddresses.rollupAddress,
+  });
+  const makeCheckpointAttestationForCurrentContext = (checkpoint: Checkpoint, signer: Secp256k1Signer) => {
+    const payload = ConsensusPayload.fromCheckpoint(checkpoint);
+    const attestationDigest = getHashedSignaturePayloadTypedData(
+      payload,
+      SignatureDomainSeparator.checkpointAttestation,
+      getSignatureContext(),
+    );
+    const proposal = new CheckpointProposal(
+      checkpoint.header,
+      checkpoint.archive.root,
+      checkpoint.feeAssetPriceModifier,
+      Signature.empty(),
+    );
+    const proposalDigest = getHashedSignaturePayloadTypedData(
+      proposal,
+      SignatureDomainSeparator.checkpointProposal,
+      getSignatureContext(),
+    );
+    return new P2PCheckpointAttestation(payload, signer.sign(attestationDigest), signer.sign(proposalDigest));
+  };
+  const signAttestationsAndSigners = (
+    attestationsAndSigners: CommitteeAttestationsAndSigners,
+    signer: Secp256k1Signer,
+  ) =>
+    signer.sign(
+      getHashedSignaturePayloadTypedData(
+        attestationsAndSigners,
+        SignatureDomainSeparator.attestationsAndSigners,
+        getSignatureContext(),
+      ),
+    );
 
   const progressTimeBySlot = async (slotsToJump = 1) => {
     const currentTime = (await l1Client.getBlock()).timestamp;
@@ -604,8 +641,8 @@ describe('L1Publisher integration', () => {
       const { checkpoint } = await buildSingleCheckpoint();
       const block = checkpoint.blocks[0];
 
-      const checkpointAttestations = validators.map(v => makeCheckpointAttestationFromCheckpoint(checkpoint, v));
-      const attestations = orderAttestations(checkpointAttestations, committee!);
+      const checkpointAttestations = validators.map(v => makeCheckpointAttestationForCurrentContext(checkpoint, v));
+      const attestations = orderAttestations(checkpointAttestations, committee!, getSignatureContext());
 
       const canPropose = await publisher.canProposeAt(new Fr(GENESIS_ARCHIVE_ROOT), proposer!);
       expect(canPropose?.slot).toEqual(block.header.getSlot());
@@ -614,10 +651,7 @@ describe('L1Publisher integration', () => {
       const proposerSigner = validators.find(v => v.address.equals(proposer!));
 
       const attestationsAndSigners = new CommitteeAttestationsAndSigners(attestations);
-      const attestationsAndSignersSignature = makeAndSignCommitteeAttestationsAndSigners(
-        attestationsAndSigners,
-        proposerSigner!,
-      );
+      const attestationsAndSignersSignature = signAttestationsAndSigners(attestationsAndSigners, proposerSigner!);
 
       await expectPublishCheckpoint(checkpoint, attestations, attestationsAndSignersSignature);
     });
@@ -625,10 +659,10 @@ describe('L1Publisher integration', () => {
     it('fails to publish a block without the proposer attestation', async () => {
       const { checkpoint } = await buildSingleCheckpoint();
       const block = checkpoint.blocks[0];
-      const checkpointAttestations = validators.map(v => makeCheckpointAttestationFromCheckpoint(checkpoint, v));
+      const checkpointAttestations = validators.map(v => makeCheckpointAttestationForCurrentContext(checkpoint, v));
 
       // Reverse attestations to break proposer attestation
-      const attestations = orderAttestations(checkpointAttestations, committee!).reverse();
+      const attestations = orderAttestations(checkpointAttestations, committee!, getSignatureContext()).reverse();
       const attestationsAndSigners = new CommitteeAttestationsAndSigners(attestations);
 
       const canPropose = await publisher.canProposeAt(new Fr(GENESIS_ARCHIVE_ROOT), proposer!);
@@ -643,15 +677,15 @@ describe('L1Publisher integration', () => {
     it('rejects flipped proposer signature', async () => {
       const { checkpoint } = await buildSingleCheckpoint();
       const block = checkpoint.blocks[0];
-      const checkpointAttestations = validators.map(v => makeCheckpointAttestationFromCheckpoint(checkpoint, v));
-      const attestations = orderAttestations(checkpointAttestations, committee!);
+      const checkpointAttestations = validators.map(v => makeCheckpointAttestationForCurrentContext(checkpoint, v));
+      const attestations = orderAttestations(checkpointAttestations, committee!, getSignatureContext());
 
       const canPropose = await publisher.canProposeAt(new Fr(GENESIS_ARCHIVE_ROOT), proposer!);
       expect(canPropose?.slot).toEqual(block.header.getSlot());
       await publisher.validateBlockHeader(checkpoint.header);
 
       const attestationsAndSigners = new CommitteeAttestationsAndSigners(attestations);
-      const attestationsAndSignersSignature = makeAndSignCommitteeAttestationsAndSigners(
+      const attestationsAndSignersSignature = signAttestationsAndSigners(
         attestationsAndSigners,
         validators.find(v => v.address.equals(proposer!))!,
       );
@@ -668,15 +702,15 @@ describe('L1Publisher integration', () => {
     it('rejects signature with invalid recovery value', async () => {
       const { checkpoint } = await buildSingleCheckpoint();
       const block = checkpoint.blocks[0];
-      const checkpointAttestations = validators.map(v => makeCheckpointAttestationFromCheckpoint(checkpoint, v));
-      const attestations = orderAttestations(checkpointAttestations, committee!);
+      const checkpointAttestations = validators.map(v => makeCheckpointAttestationForCurrentContext(checkpoint, v));
+      const attestations = orderAttestations(checkpointAttestations, committee!, getSignatureContext());
 
       const canPropose = await publisher.canProposeAt(new Fr(GENESIS_ARCHIVE_ROOT), proposer!);
       expect(canPropose?.slot).toEqual(block.header.getSlot());
       await publisher.validateBlockHeader(checkpoint.header);
 
       const attestationsAndSigners = new CommitteeAttestationsAndSigners(attestations);
-      const attestationsAndSignersSignature = makeAndSignCommitteeAttestationsAndSigners(
+      const attestationsAndSignersSignature = signAttestationsAndSigners(
         attestationsAndSigners,
         validators.find(v => v.address.equals(proposer!))!,
       );
@@ -699,11 +733,11 @@ describe('L1Publisher integration', () => {
       // Publish the first invalid block
       const badCheckpointAttestations = validators
         .filter(v => v.address.equals(proposer!))
-        .map(v => makeCheckpointAttestationFromCheckpoint(badCheckpoint, v));
-      const badAttestations = orderAttestations(badCheckpointAttestations, committee!);
+        .map(v => makeCheckpointAttestationForCurrentContext(badCheckpoint, v));
+      const badAttestations = orderAttestations(badCheckpointAttestations, committee!, getSignatureContext());
 
       const badAttestationsAndSigners = new CommitteeAttestationsAndSigners(badAttestations);
-      const badAttestationsAndSignersSignature = makeAndSignCommitteeAttestationsAndSigners(
+      const badAttestationsAndSignersSignature = signAttestationsAndSigners(
         badAttestationsAndSigners,
         validators.find(v => v.address.equals(proposer!))!,
       );
@@ -721,8 +755,8 @@ describe('L1Publisher integration', () => {
       const { checkpoint } = await buildSingleCheckpoint({ blockNumber: BlockNumber(1) });
       const block = checkpoint.blocks[0];
       expect(block.number).toEqual(badBlock.number);
-      const checkpointAttestations = validators.map(v => makeCheckpointAttestationFromCheckpoint(checkpoint, v));
-      const attestations = orderAttestations(checkpointAttestations, committee!);
+      const checkpointAttestations = validators.map(v => makeCheckpointAttestationForCurrentContext(checkpoint, v));
+      const attestations = orderAttestations(checkpointAttestations, committee!, getSignatureContext());
 
       // Check we can invalidate the checkpoint
       logger.warn('Checking simulate invalidate checkpoint');
@@ -757,7 +791,7 @@ describe('L1Publisher integration', () => {
 
       // At this point I'm gonna need to propose the correct signature ye? So confused actually here.
       const attestationsAndSigners = new CommitteeAttestationsAndSigners(attestations);
-      const attestationsAndSignersSignature = makeAndSignCommitteeAttestationsAndSigners(
+      const attestationsAndSignersSignature = signAttestationsAndSigners(
         attestationsAndSigners,
         validators.find(v => v.address.equals(proposer!))!,
       );

--- a/yarn-project/end-to-end/src/e2e_multi_validator/e2e_multi_validator_node.test.ts
+++ b/yarn-project/end-to-end/src/e2e_multi_validator/e2e_multi_validator_node.test.ts
@@ -129,10 +129,14 @@ describe('e2e_multi_validator_node', () => {
     const attestations = publishedCheckpoint.attestations
       .filter(a => !a.signature.isEmpty())
       .map(a => new CheckpointAttestation(payload, a.signature, Signature.empty()));
+    const signatureContext = {
+      chainId: config.l1ChainId,
+      rollupAddress: deployL1ContractsValues.l1ContractAddresses.rollupAddress,
+    };
 
     expect(attestations.length).toBeGreaterThanOrEqual((COMMITTEE_SIZE * 2) / 3 + 1);
 
-    const signers = attestations.map(att => att.getSender()!.toString());
+    const signers = attestations.map(att => att.getSender(signatureContext)!.toString());
 
     expect(signers.every(s => validatorAddresses.includes(s))).toBe(true);
   });
@@ -187,10 +191,14 @@ describe('e2e_multi_validator_node', () => {
     const attestations = publishedCheckpoint.attestations
       .filter(a => !a.signature.isEmpty())
       .map(a => new CheckpointAttestation(payload, a.signature, Signature.empty()));
+    const signatureContext = {
+      chainId: config.l1ChainId,
+      rollupAddress: deployL1ContractsValues.l1ContractAddresses.rollupAddress,
+    };
 
     expect(attestations.length).toBeGreaterThanOrEqual((COMMITTEE_SIZE * 2) / 3 + 1);
 
-    const signers = attestations.map(att => att.getSender()!.toString());
+    const signers = attestations.map(att => att.getSender(signatureContext)!.toString());
 
     expect(signers).toEqual(expect.arrayContaining(validatorAddresses.slice(0, COMMITTEE_SIZE)));
   });

--- a/yarn-project/end-to-end/src/e2e_multi_validator/e2e_multi_validator_node.test.ts
+++ b/yarn-project/end-to-end/src/e2e_multi_validator/e2e_multi_validator_node.test.ts
@@ -125,18 +125,18 @@ describe('e2e_multi_validator_node', () => {
     const dataStore = (aztecNode as AztecNodeService).getBlockSource() as Archiver;
     const checkpointedBlock = await dataStore.getCheckpointedBlock(tx.blockNumber!);
     const [publishedCheckpoint] = await dataStore.getCheckpoints(checkpointedBlock!.checkpointNumber, 1);
-    const payload = ConsensusPayload.fromCheckpoint(publishedCheckpoint.checkpoint);
-    const attestations = publishedCheckpoint.attestations
-      .filter(a => !a.signature.isEmpty())
-      .map(a => new CheckpointAttestation(payload, a.signature, Signature.empty()));
     const signatureContext = {
       chainId: config.l1ChainId,
       rollupAddress: deployL1ContractsValues.l1ContractAddresses.rollupAddress,
     };
+    const payload = ConsensusPayload.fromCheckpoint(publishedCheckpoint.checkpoint, signatureContext);
+    const attestations = publishedCheckpoint.attestations
+      .filter(a => !a.signature.isEmpty())
+      .map(a => new CheckpointAttestation(payload, a.signature, Signature.empty()));
 
     expect(attestations.length).toBeGreaterThanOrEqual((COMMITTEE_SIZE * 2) / 3 + 1);
 
-    const signers = attestations.map(att => att.getSender(signatureContext)!.toString());
+    const signers = attestations.map(att => att.getSender()!.toString());
 
     expect(signers.every(s => validatorAddresses.includes(s))).toBe(true);
   });
@@ -187,18 +187,18 @@ describe('e2e_multi_validator_node', () => {
     const dataStore = (aztecNode as AztecNodeService).getBlockSource() as Archiver;
     const checkpointedBlock = await dataStore.getCheckpointedBlock(tx.blockNumber!);
     const [publishedCheckpoint] = await dataStore.getCheckpoints(checkpointedBlock!.checkpointNumber, 1);
-    const payload = ConsensusPayload.fromCheckpoint(publishedCheckpoint.checkpoint);
-    const attestations = publishedCheckpoint.attestations
-      .filter(a => !a.signature.isEmpty())
-      .map(a => new CheckpointAttestation(payload, a.signature, Signature.empty()));
     const signatureContext = {
       chainId: config.l1ChainId,
       rollupAddress: deployL1ContractsValues.l1ContractAddresses.rollupAddress,
     };
+    const payload = ConsensusPayload.fromCheckpoint(publishedCheckpoint.checkpoint, signatureContext);
+    const attestations = publishedCheckpoint.attestations
+      .filter(a => !a.signature.isEmpty())
+      .map(a => new CheckpointAttestation(payload, a.signature, Signature.empty()));
 
     expect(attestations.length).toBeGreaterThanOrEqual((COMMITTEE_SIZE * 2) / 3 + 1);
 
-    const signers = attestations.map(att => att.getSender(signatureContext)!.toString());
+    const signers = attestations.map(att => att.getSender()!.toString());
 
     expect(signers).toEqual(expect.arrayContaining(validatorAddresses.slice(0, COMMITTEE_SIZE)));
   });

--- a/yarn-project/end-to-end/src/e2e_p2p/fee_asset_price_oracle_gossip.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/fee_asset_price_oracle_gossip.test.ts
@@ -185,15 +185,15 @@ describe('e2e_p2p_network', () => {
       120,
       1,
     );
-    const payload = ConsensusPayload.fromCheckpoint(publishedCheckpoint.checkpoint);
-    const attestations = publishedCheckpoint.attestations
-      .filter(a => !a.signature.isEmpty())
-      .map(a => new CheckpointAttestation(payload, a.signature, Signature.empty()));
     const signatureContext = {
       chainId: t.ctx.aztecNodeConfig.l1ChainId,
       rollupAddress: t.ctx.deployL1ContractsValues.l1ContractAddresses.rollupAddress,
     };
-    const signers = await Promise.all(attestations.map(att => att.getSender(signatureContext)!.toString()));
+    const payload = ConsensusPayload.fromCheckpoint(publishedCheckpoint.checkpoint, signatureContext);
+    const attestations = publishedCheckpoint.attestations
+      .filter(a => !a.signature.isEmpty())
+      .map(a => new CheckpointAttestation(payload, a.signature, Signature.empty()));
+    const signers = await Promise.all(attestations.map(att => att.getSender()!.toString()));
     t.logger.info(`Attestation signers`, { signers });
 
     // Check that the signers found are part of the proposer nodes to ensure the archiver fetched them right

--- a/yarn-project/end-to-end/src/e2e_p2p/fee_asset_price_oracle_gossip.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/fee_asset_price_oracle_gossip.test.ts
@@ -189,7 +189,11 @@ describe('e2e_p2p_network', () => {
     const attestations = publishedCheckpoint.attestations
       .filter(a => !a.signature.isEmpty())
       .map(a => new CheckpointAttestation(payload, a.signature, Signature.empty()));
-    const signers = await Promise.all(attestations.map(att => att.getSender()!.toString()));
+    const signatureContext = {
+      chainId: t.ctx.aztecNodeConfig.l1ChainId,
+      rollupAddress: t.ctx.deployL1ContractsValues.l1ContractAddresses.rollupAddress,
+    };
+    const signers = await Promise.all(attestations.map(att => att.getSender(signatureContext)!.toString()));
     t.logger.info(`Attestation signers`, { signers });
 
     // Check that the signers found are part of the proposer nodes to ensure the archiver fetched them right

--- a/yarn-project/end-to-end/src/e2e_p2p/gossip_network.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/gossip_network.test.ts
@@ -188,15 +188,15 @@ describe('e2e_p2p_network', () => {
     const dataStore = (nodes[0] as AztecNodeService).getBlockSource() as Archiver;
     const checkpointedBlock = await dataStore.getCheckpointedBlock(blockNumber);
     const [publishedCheckpoint] = await dataStore.getCheckpoints(checkpointedBlock!.checkpointNumber, 1);
-    const payload = ConsensusPayload.fromCheckpoint(publishedCheckpoint.checkpoint);
-    const attestations = publishedCheckpoint.attestations
-      .filter(a => !a.signature.isEmpty())
-      .map(a => new CheckpointAttestation(payload, a.signature, Signature.empty()));
     const signatureContext = {
       chainId: t.ctx.aztecNodeConfig.l1ChainId,
       rollupAddress: t.ctx.deployL1ContractsValues.l1ContractAddresses.rollupAddress,
     };
-    const signers = await Promise.all(attestations.map(att => att.getSender(signatureContext)!.toString()));
+    const payload = ConsensusPayload.fromCheckpoint(publishedCheckpoint.checkpoint, signatureContext);
+    const attestations = publishedCheckpoint.attestations
+      .filter(a => !a.signature.isEmpty())
+      .map(a => new CheckpointAttestation(payload, a.signature, Signature.empty()));
+    const signers = await Promise.all(attestations.map(att => att.getSender()!.toString()));
     t.logger.info(`Attestation signers`, { signers });
 
     // Check that the signers found are part of the proposer nodes to ensure the archiver fetched them right

--- a/yarn-project/end-to-end/src/e2e_p2p/gossip_network.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/gossip_network.test.ts
@@ -192,7 +192,11 @@ describe('e2e_p2p_network', () => {
     const attestations = publishedCheckpoint.attestations
       .filter(a => !a.signature.isEmpty())
       .map(a => new CheckpointAttestation(payload, a.signature, Signature.empty()));
-    const signers = await Promise.all(attestations.map(att => att.getSender()!.toString()));
+    const signatureContext = {
+      chainId: t.ctx.aztecNodeConfig.l1ChainId,
+      rollupAddress: t.ctx.deployL1ContractsValues.l1ContractAddresses.rollupAddress,
+    };
+    const signers = await Promise.all(attestations.map(att => att.getSender(signatureContext)!.toString()));
     t.logger.info(`Attestation signers`, { signers });
 
     // Check that the signers found are part of the proposer nodes to ensure the archiver fetched them right

--- a/yarn-project/end-to-end/src/e2e_p2p/gossip_network_no_cheat.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/gossip_network_no_cheat.test.ts
@@ -248,15 +248,15 @@ describe('e2e_p2p_network', () => {
     const dataStore = (nodes[0] as AztecNodeService).getBlockSource() as Archiver;
     const checkpointedBlock = await dataStore.getCheckpointedBlock(blockNumber);
     const [publishedCheckpoint] = await dataStore.getCheckpoints(checkpointedBlock!.checkpointNumber, 1);
-    const payload = ConsensusPayload.fromCheckpoint(publishedCheckpoint.checkpoint);
-    const attestations = publishedCheckpoint.attestations
-      .filter(a => !a.signature.isEmpty())
-      .map(a => new CheckpointAttestation(payload, a.signature, Signature.empty()));
     const signatureContext = {
       chainId: t.ctx.aztecNodeConfig.l1ChainId,
       rollupAddress: t.ctx.deployL1ContractsValues.l1ContractAddresses.rollupAddress,
     };
-    const signers = await Promise.all(attestations.map(att => att.getSender(signatureContext)!.toString()));
+    const payload = ConsensusPayload.fromCheckpoint(publishedCheckpoint.checkpoint, signatureContext);
+    const attestations = publishedCheckpoint.attestations
+      .filter(a => !a.signature.isEmpty())
+      .map(a => new CheckpointAttestation(payload, a.signature, Signature.empty()));
+    const signers = await Promise.all(attestations.map(att => att.getSender()!.toString()));
     t.logger.info(`Attestation signers`, { signers });
 
     // Check that the signers found are part of the proposer nodes to ensure the archiver fetched them right

--- a/yarn-project/end-to-end/src/e2e_p2p/gossip_network_no_cheat.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/gossip_network_no_cheat.test.ts
@@ -252,7 +252,11 @@ describe('e2e_p2p_network', () => {
     const attestations = publishedCheckpoint.attestations
       .filter(a => !a.signature.isEmpty())
       .map(a => new CheckpointAttestation(payload, a.signature, Signature.empty()));
-    const signers = await Promise.all(attestations.map(att => att.getSender()!.toString()));
+    const signatureContext = {
+      chainId: t.ctx.aztecNodeConfig.l1ChainId,
+      rollupAddress: t.ctx.deployL1ContractsValues.l1ContractAddresses.rollupAddress,
+    };
+    const signers = await Promise.all(attestations.map(att => att.getSender(signatureContext)!.toString()));
     t.logger.info(`Attestation signers`, { signers });
 
     // Check that the signers found are part of the proposer nodes to ensure the archiver fetched them right

--- a/yarn-project/end-to-end/src/e2e_p2p/preferred_gossip_network.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/preferred_gossip_network.test.ts
@@ -361,7 +361,11 @@ describe('e2e_p2p_preferred_network', () => {
     const attestations = publishedCheckpoint.attestations
       .filter(a => !a.signature.isEmpty())
       .map(a => new CheckpointAttestation(payload, a.signature, Signature.empty()));
-    const signers = await Promise.all(attestations.map(att => att.getSender()!.toString()));
+    const signatureContext = {
+      chainId: t.ctx.aztecNodeConfig.l1ChainId,
+      rollupAddress: t.ctx.deployL1ContractsValues.l1ContractAddresses.rollupAddress,
+    };
+    const signers = await Promise.all(attestations.map(att => att.getSender(signatureContext)!.toString()));
     t.logger.info(`Attestation signers`, { signers });
 
     expect(signers.length).toEqual(validators.length);

--- a/yarn-project/end-to-end/src/e2e_p2p/preferred_gossip_network.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/preferred_gossip_network.test.ts
@@ -357,15 +357,15 @@ describe('e2e_p2p_preferred_network', () => {
     const dataStore = (nodes[0] as AztecNodeService).getBlockSource() as Archiver;
     const checkpointedBlock = await dataStore.getCheckpointedBlock(blockNumber);
     const [publishedCheckpoint] = await dataStore.getCheckpoints(checkpointedBlock!.checkpointNumber, 1);
-    const payload = ConsensusPayload.fromCheckpoint(publishedCheckpoint.checkpoint);
-    const attestations = publishedCheckpoint.attestations
-      .filter(a => !a.signature.isEmpty())
-      .map(a => new CheckpointAttestation(payload, a.signature, Signature.empty()));
     const signatureContext = {
       chainId: t.ctx.aztecNodeConfig.l1ChainId,
       rollupAddress: t.ctx.deployL1ContractsValues.l1ContractAddresses.rollupAddress,
     };
-    const signers = await Promise.all(attestations.map(att => att.getSender(signatureContext)!.toString()));
+    const payload = ConsensusPayload.fromCheckpoint(publishedCheckpoint.checkpoint, signatureContext);
+    const attestations = publishedCheckpoint.attestations
+      .filter(a => !a.signature.isEmpty())
+      .map(a => new CheckpointAttestation(payload, a.signature, Signature.empty()));
+    const signers = await Promise.all(attestations.map(att => att.getSender()!.toString()));
     t.logger.info(`Attestation signers`, { signers });
 
     expect(signers.length).toEqual(validators.length);

--- a/yarn-project/end-to-end/src/e2e_p2p/reex.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/reex.test.ts
@@ -133,7 +133,7 @@ describe('e2e_p2p_reex', () => {
           chainId: t.ctx.aztecNodeConfig.l1ChainId,
           rollupAddress: t.ctx.deployL1ContractsValues.l1ContractAddresses.rollupAddress,
         };
-        const proposerAddress = proposal.getSender(signatureContext);
+        const proposerAddress = proposal.getSender();
         const txHashes = proposal.txHashes;
 
         // Mutate txhashes to remove the last one

--- a/yarn-project/end-to-end/src/e2e_p2p/reex.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/reex.test.ts
@@ -129,7 +129,11 @@ describe('e2e_p2p_reex', () => {
       jest.spyOn(p2pClient, 'broadcastProposal').mockImplementation(async (...args: unknown[]) => {
         // We remove one of the transactions, therefore the block root will be different!
         const proposal = args[0] as BlockProposal;
-        const proposerAddress = proposal.getSender();
+        const signatureContext = {
+          chainId: t.ctx.aztecNodeConfig.l1ChainId,
+          rollupAddress: t.ctx.deployL1ContractsValues.l1ContractAddresses.rollupAddress,
+        };
+        const proposerAddress = proposal.getSender(signatureContext);
         const txHashes = proposal.txHashes;
 
         // Mutate txhashes to remove the last one
@@ -146,7 +150,8 @@ describe('e2e_p2p_reex', () => {
           proposal.archiveRoot,
           proposal.txHashes,
           undefined,
-          (payload, context) => signer.signMessageWithAddress(proposerAddress!, payload, context),
+          signatureContext,
+          (typedData, context) => signer.signTypedDataWithAddress(proposerAddress!, typedData, context),
         );
 
         const p2pService = (p2pClient as any).p2pService as LibP2PService;

--- a/yarn-project/end-to-end/src/e2e_synching.test.ts
+++ b/yarn-project/end-to-end/src/e2e_synching.test.ts
@@ -477,7 +477,14 @@ describe('e2e_synching', () => {
         await cheatCodes.eth.mine();
       }
       // If it breaks here, first place you should look is the pruning.
-      await publisher.enqueueProposeCheckpoint(checkpoint, CommitteeAttestationsAndSigners.empty(), Signature.empty());
+      await publisher.enqueueProposeCheckpoint(
+        checkpoint,
+        CommitteeAttestationsAndSigners.empty({
+          chainId: 31337,
+          rollupAddress: deployL1ContractsValues.l1ContractAddresses.rollupAddress,
+        }),
+        Signature.empty(),
+      );
 
       await cheatCodes.rollup.markAsProven(CheckpointNumber(provenThrough));
     }

--- a/yarn-project/p2p/src/client/factory.ts
+++ b/yarn-project/p2p/src/client/factory.ts
@@ -81,6 +81,10 @@ export async function createP2PClient(
 
   const rollupAddress = inputConfig.l1Contracts.rollupAddress.toString().toLowerCase().replace(/^0x/, '');
   const txFileStoreBasePath = `aztec-${inputConfig.l1ChainId}-${inputConfig.rollupVersion}-0x${rollupAddress}`;
+  const signatureContext = {
+    chainId: inputConfig.l1ChainId,
+    rollupAddress: inputConfig.l1Contracts.rollupAddress,
+  };
 
   const allowedInSetup = [
     ...(await getDefaultAllowedSetupFunctions()),
@@ -133,7 +137,7 @@ export async function createP2PClient(
 
   const mempools: MemPools = {
     txPool,
-    attestationPool: deps.attestationPool ?? new AttestationPool(attestationStore, telemetry),
+    attestationPool: deps.attestationPool ?? new AttestationPool(attestationStore, signatureContext, telemetry),
   };
 
   const p2pService = await createP2PService(

--- a/yarn-project/p2p/src/client/factory.ts
+++ b/yarn-project/p2p/src/client/factory.ts
@@ -76,15 +76,11 @@ export async function createP2PClient(
   const store = deps.store ?? (await createStore(P2P_STORE_NAME, 2, config, bindings));
   const archive = await createStore(P2P_ARCHIVE_STORE_NAME, 1, config, bindings);
   const peerStore = await createStore(P2P_PEER_STORE_NAME, 1, config, bindings);
-  const attestationStore = await createStore(P2P_ATTESTATION_STORE_NAME, 1, config, bindings);
+  const attestationStore = await createStore(P2P_ATTESTATION_STORE_NAME, 2, config, bindings);
   const l1Constants = await archiver.getL1Constants();
 
   const rollupAddress = inputConfig.l1Contracts.rollupAddress.toString().toLowerCase().replace(/^0x/, '');
   const txFileStoreBasePath = `aztec-${inputConfig.l1ChainId}-${inputConfig.rollupVersion}-0x${rollupAddress}`;
-  const signatureContext = {
-    chainId: inputConfig.l1ChainId,
-    rollupAddress: inputConfig.l1Contracts.rollupAddress,
-  };
 
   const allowedInSetup = [
     ...(await getDefaultAllowedSetupFunctions()),
@@ -137,7 +133,7 @@ export async function createP2PClient(
 
   const mempools: MemPools = {
     txPool,
-    attestationPool: deps.attestationPool ?? new AttestationPool(attestationStore, signatureContext, telemetry),
+    attestationPool: deps.attestationPool ?? new AttestationPool(attestationStore, telemetry),
   };
 
   const p2pService = await createP2PService(

--- a/yarn-project/p2p/src/mem_pools/attestation_pool/attestation_pool.test.ts
+++ b/yarn-project/p2p/src/mem_pools/attestation_pool/attestation_pool.test.ts
@@ -3,7 +3,7 @@ import { Secp256k1Signer } from '@aztec/foundation/crypto/secp256k1-signer';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import type { AztecAsyncKVStore } from '@aztec/kv-store';
 import { openTmpStore } from '@aztec/kv-store/lmdb-v2';
-import { TEST_COORDINATION_SIGNATURE_CONTEXT, makeBlockHeader, makeBlockProposal } from '@aztec/stdlib/testing';
+import { makeBlockHeader, makeBlockProposal } from '@aztec/stdlib/testing';
 
 import { AttestationPool, MAX_ATTESTATIONS_PER_SLOT_AND_SIGNER } from './attestation_pool.js';
 import { describeAttestationPool } from './attestation_pool_test_suite.js';
@@ -15,7 +15,7 @@ describe('Attestation Pool', () => {
 
   beforeEach(async () => {
     store = await openTmpStore('test');
-    attestationPool = new AttestationPool(store, TEST_COORDINATION_SIGNATURE_CONTEXT);
+    attestationPool = new AttestationPool(store);
   });
 
   afterEach(() => store.close());

--- a/yarn-project/p2p/src/mem_pools/attestation_pool/attestation_pool.test.ts
+++ b/yarn-project/p2p/src/mem_pools/attestation_pool/attestation_pool.test.ts
@@ -3,7 +3,7 @@ import { Secp256k1Signer } from '@aztec/foundation/crypto/secp256k1-signer';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import type { AztecAsyncKVStore } from '@aztec/kv-store';
 import { openTmpStore } from '@aztec/kv-store/lmdb-v2';
-import { makeBlockHeader, makeBlockProposal } from '@aztec/stdlib/testing';
+import { TEST_COORDINATION_SIGNATURE_CONTEXT, makeBlockHeader, makeBlockProposal } from '@aztec/stdlib/testing';
 
 import { AttestationPool, MAX_ATTESTATIONS_PER_SLOT_AND_SIGNER } from './attestation_pool.js';
 import { describeAttestationPool } from './attestation_pool_test_suite.js';
@@ -15,7 +15,7 @@ describe('Attestation Pool', () => {
 
   beforeEach(async () => {
     store = await openTmpStore('test');
-    attestationPool = new AttestationPool(store);
+    attestationPool = new AttestationPool(store, TEST_COORDINATION_SIGNATURE_CONTEXT);
   });
 
   afterEach(() => store.close());

--- a/yarn-project/p2p/src/mem_pools/attestation_pool/attestation_pool.ts
+++ b/yarn-project/p2p/src/mem_pools/attestation_pool/attestation_pool.ts
@@ -8,6 +8,7 @@ import {
   CheckpointAttestation,
   CheckpointProposal,
   type CheckpointProposalCore,
+  type CoordinationSignatureContext,
 } from '@aztec/stdlib/p2p';
 import { type TelemetryClient, getTelemetryClient } from '@aztec/telemetry-client';
 
@@ -80,6 +81,7 @@ export class AttestationPool {
 
   constructor(
     private store: AztecAsyncKVStore,
+    private signatureContext: CoordinationSignatureContext,
     telemetry: TelemetryClient = getTelemetryClient(),
     private log = createLogger('aztec:attestation_pool'),
   ) {
@@ -350,7 +352,7 @@ export class AttestationPool {
       for (const attestation of attestations) {
         const slotNumber = attestation.payload.header.slotNumber;
         const proposalId = attestation.archive.toString();
-        const sender = attestation.getSender();
+        const sender = attestation.getSender(this.signatureContext);
 
         // Skip attestations with invalid signatures
         if (!sender) {
@@ -490,7 +492,7 @@ export class AttestationPool {
   public async tryAddCheckpointAttestation(attestation: CheckpointAttestation): Promise<TryAddResult> {
     const slotNumber = attestation.payload.header.slotNumber;
     const proposalId = attestation.archive.toString();
-    const sender = attestation.getSender();
+    const sender = attestation.getSender(this.signatureContext);
 
     if (!sender) {
       return { added: false, alreadyExists: false, count: 0 };
@@ -562,6 +564,7 @@ export class AttestationPool {
 /** Creates an AttestationPool backed by a temporary store for testing. */
 export async function createTestAttestationPool(telemetry?: TelemetryClient): Promise<AttestationPool> {
   const { openTmpStore } = await import('@aztec/kv-store/lmdb-v2');
+  const { EthAddress } = await import('@aztec/foundation/eth-address');
   const store = await openTmpStore('test-attestation-pool');
-  return new AttestationPool(store, telemetry);
+  return new AttestationPool(store, { chainId: 31337, rollupAddress: EthAddress.fromNumber(1) }, telemetry);
 }

--- a/yarn-project/p2p/src/mem_pools/attestation_pool/attestation_pool.ts
+++ b/yarn-project/p2p/src/mem_pools/attestation_pool/attestation_pool.ts
@@ -8,7 +8,6 @@ import {
   CheckpointAttestation,
   CheckpointProposal,
   type CheckpointProposalCore,
-  type CoordinationSignatureContext,
 } from '@aztec/stdlib/p2p';
 import { type TelemetryClient, getTelemetryClient } from '@aztec/telemetry-client';
 
@@ -81,7 +80,6 @@ export class AttestationPool {
 
   constructor(
     private store: AztecAsyncKVStore,
-    private signatureContext: CoordinationSignatureContext,
     telemetry: TelemetryClient = getTelemetryClient(),
     private log = createLogger('aztec:attestation_pool'),
   ) {
@@ -352,7 +350,7 @@ export class AttestationPool {
       for (const attestation of attestations) {
         const slotNumber = attestation.payload.header.slotNumber;
         const proposalId = attestation.archive.toString();
-        const sender = attestation.getSender(this.signatureContext);
+        const sender = attestation.getSender();
 
         // Skip attestations with invalid signatures
         if (!sender) {
@@ -492,7 +490,7 @@ export class AttestationPool {
   public async tryAddCheckpointAttestation(attestation: CheckpointAttestation): Promise<TryAddResult> {
     const slotNumber = attestation.payload.header.slotNumber;
     const proposalId = attestation.archive.toString();
-    const sender = attestation.getSender(this.signatureContext);
+    const sender = attestation.getSender();
 
     if (!sender) {
       return { added: false, alreadyExists: false, count: 0 };
@@ -564,7 +562,6 @@ export class AttestationPool {
 /** Creates an AttestationPool backed by a temporary store for testing. */
 export async function createTestAttestationPool(telemetry?: TelemetryClient): Promise<AttestationPool> {
   const { openTmpStore } = await import('@aztec/kv-store/lmdb-v2');
-  const { EthAddress } = await import('@aztec/foundation/eth-address');
   const store = await openTmpStore('test-attestation-pool');
-  return new AttestationPool(store, { chainId: 31337, rollupAddress: EthAddress.fromNumber(1) }, telemetry);
+  return new AttestationPool(store, telemetry);
 }

--- a/yarn-project/p2p/src/mem_pools/attestation_pool/attestation_pool_test_suite.ts
+++ b/yarn-project/p2p/src/mem_pools/attestation_pool/attestation_pool_test_suite.ts
@@ -4,7 +4,6 @@ import { Fr } from '@aztec/foundation/curves/bn254';
 import type { BlockProposal, CheckpointAttestation, CheckpointProposalCore } from '@aztec/stdlib/p2p';
 import { CheckpointHeader } from '@aztec/stdlib/rollup';
 import {
-  TEST_COORDINATION_SIGNATURE_CONTEXT,
   makeBlockHeader,
   makeBlockProposal,
   makeCheckpointHeader,
@@ -119,9 +118,7 @@ export function describeAttestationPool(getAttestationPool: () => AttestationPoo
       );
       expect(retreivedAttestations.length).toBe(1);
       expect(retreivedAttestations[0].toBuffer()).toEqual(attestations[0].toBuffer());
-      expect(retreivedAttestations[0].getSender(TEST_COORDINATION_SIGNATURE_CONTEXT)?.toString()).toEqual(
-        signer.address.toString(),
-      );
+      expect(retreivedAttestations[0].getSender()?.toString()).toEqual(signer.address.toString());
 
       // Try adding them on another operation and check they are still not duplicated
       await ap.addOwnCheckpointAttestations([attestations[0]]);
@@ -233,9 +230,7 @@ export function describeAttestationPool(getAttestationPool: () => AttestationPoo
       const retrievedProposal = await ap.getBlockProposal(proposalId);
       expect(retrievedProposal).toBeDefined();
       expect(retrievedProposal!.toBuffer()).toEqual(proposal1.toBuffer());
-      expect(retrievedProposal!.getSender(TEST_COORDINATION_SIGNATURE_CONTEXT)?.toString()).toBe(
-        signers[0].address.toString(),
-      );
+      expect(retrievedProposal!.getSender()?.toString()).toBe(signers[0].address.toString());
     });
   });
 
@@ -327,9 +322,7 @@ export function describeAttestationPool(getAttestationPool: () => AttestationPoo
       const retrievedProposal = await ap.getCheckpointProposal(proposalId);
       expect(retrievedProposal).toBeDefined();
       expect(retrievedProposal!.toBuffer()).toEqual(proposal1.toBuffer());
-      expect(retrievedProposal!.getSender(TEST_COORDINATION_SIGNATURE_CONTEXT)?.toString()).toBe(
-        signers[0].address.toString(),
-      );
+      expect(retrievedProposal!.getSender()?.toString()).toBe(signers[0].address.toString());
     });
 
     it('should return added=false when exceeding capacity', async () => {

--- a/yarn-project/p2p/src/mem_pools/attestation_pool/attestation_pool_test_suite.ts
+++ b/yarn-project/p2p/src/mem_pools/attestation_pool/attestation_pool_test_suite.ts
@@ -4,6 +4,7 @@ import { Fr } from '@aztec/foundation/curves/bn254';
 import type { BlockProposal, CheckpointAttestation, CheckpointProposalCore } from '@aztec/stdlib/p2p';
 import { CheckpointHeader } from '@aztec/stdlib/rollup';
 import {
+  TEST_COORDINATION_SIGNATURE_CONTEXT,
   makeBlockHeader,
   makeBlockProposal,
   makeCheckpointHeader,
@@ -118,7 +119,9 @@ export function describeAttestationPool(getAttestationPool: () => AttestationPoo
       );
       expect(retreivedAttestations.length).toBe(1);
       expect(retreivedAttestations[0].toBuffer()).toEqual(attestations[0].toBuffer());
-      expect(retreivedAttestations[0].getSender()?.toString()).toEqual(signer.address.toString());
+      expect(retreivedAttestations[0].getSender(TEST_COORDINATION_SIGNATURE_CONTEXT)?.toString()).toEqual(
+        signer.address.toString(),
+      );
 
       // Try adding them on another operation and check they are still not duplicated
       await ap.addOwnCheckpointAttestations([attestations[0]]);
@@ -230,7 +233,9 @@ export function describeAttestationPool(getAttestationPool: () => AttestationPoo
       const retrievedProposal = await ap.getBlockProposal(proposalId);
       expect(retrievedProposal).toBeDefined();
       expect(retrievedProposal!.toBuffer()).toEqual(proposal1.toBuffer());
-      expect(retrievedProposal!.getSender()?.toString()).toBe(signers[0].address.toString());
+      expect(retrievedProposal!.getSender(TEST_COORDINATION_SIGNATURE_CONTEXT)?.toString()).toBe(
+        signers[0].address.toString(),
+      );
     });
   });
 
@@ -322,7 +327,9 @@ export function describeAttestationPool(getAttestationPool: () => AttestationPoo
       const retrievedProposal = await ap.getCheckpointProposal(proposalId);
       expect(retrievedProposal).toBeDefined();
       expect(retrievedProposal!.toBuffer()).toEqual(proposal1.toBuffer());
-      expect(retrievedProposal!.getSender()?.toString()).toBe(signers[0].address.toString());
+      expect(retrievedProposal!.getSender(TEST_COORDINATION_SIGNATURE_CONTEXT)?.toString()).toBe(
+        signers[0].address.toString(),
+      );
     });
 
     it('should return added=false when exceeding capacity', async () => {

--- a/yarn-project/p2p/src/mem_pools/attestation_pool/mocks.ts
+++ b/yarn-project/p2p/src/mem_pools/attestation_pool/mocks.ts
@@ -3,11 +3,13 @@ import type { Secp256k1Signer } from '@aztec/foundation/crypto/secp256k1-signer'
 import { Fr } from '@aztec/foundation/curves/bn254';
 import {
   CheckpointAttestation,
+  CheckpointProposal,
   ConsensusPayload,
   SignatureDomainSeparator,
-  getHashedSignaturePayloadEthSignedMessage,
+  getHashedSignaturePayloadTypedData,
 } from '@aztec/stdlib/p2p';
 import { CheckpointHeader } from '@aztec/stdlib/rollup';
+import { TEST_COORDINATION_SIGNATURE_CONTEXT } from '@aztec/stdlib/testing';
 
 import { type LocalAccount, generatePrivateKey, privateKeyToAccount } from 'viem/accounts';
 
@@ -39,13 +41,19 @@ export const mockCheckpointAttestation = (
   header = header ?? CheckpointHeader.random({ slotNumber: SlotNumber(slot) });
   const payload = new ConsensusPayload(header, archive, feeAssetPriceModifier);
 
-  const attestationHash = getHashedSignaturePayloadEthSignedMessage(
+  const attestationHash = getHashedSignaturePayloadTypedData(
     payload,
     SignatureDomainSeparator.checkpointAttestation,
+    TEST_COORDINATION_SIGNATURE_CONTEXT,
   );
   const attestationSignature = signer.sign(attestationHash);
 
-  const proposalHash = getHashedSignaturePayloadEthSignedMessage(payload, SignatureDomainSeparator.checkpointProposal);
+  const proposal = new CheckpointProposal(header, archive, feeAssetPriceModifier, attestationSignature);
+  const proposalHash = getHashedSignaturePayloadTypedData(
+    proposal,
+    SignatureDomainSeparator.checkpointProposal,
+    TEST_COORDINATION_SIGNATURE_CONTEXT,
+  );
   const proposerSignature = signer.sign(proposalHash);
 
   return new CheckpointAttestation(payload, attestationSignature, proposerSignature);

--- a/yarn-project/p2p/src/mem_pools/attestation_pool/mocks.ts
+++ b/yarn-project/p2p/src/mem_pools/attestation_pool/mocks.ts
@@ -5,7 +5,6 @@ import {
   CheckpointAttestation,
   CheckpointProposal,
   ConsensusPayload,
-  SignatureDomainSeparator,
   getHashedSignaturePayloadTypedData,
 } from '@aztec/stdlib/p2p';
 import { CheckpointHeader } from '@aztec/stdlib/rollup';
@@ -39,21 +38,19 @@ export const mockCheckpointAttestation = (
   feeAssetPriceModifier: bigint = 0n,
 ): CheckpointAttestation => {
   header = header ?? CheckpointHeader.random({ slotNumber: SlotNumber(slot) });
-  const payload = new ConsensusPayload(header, archive, feeAssetPriceModifier);
+  const payload = new ConsensusPayload(header, archive, feeAssetPriceModifier, TEST_COORDINATION_SIGNATURE_CONTEXT);
 
-  const attestationHash = getHashedSignaturePayloadTypedData(
-    payload,
-    SignatureDomainSeparator.checkpointAttestation,
-    TEST_COORDINATION_SIGNATURE_CONTEXT,
-  );
+  const attestationHash = getHashedSignaturePayloadTypedData(payload);
   const attestationSignature = signer.sign(attestationHash);
 
-  const proposal = new CheckpointProposal(header, archive, feeAssetPriceModifier, attestationSignature);
-  const proposalHash = getHashedSignaturePayloadTypedData(
-    proposal,
-    SignatureDomainSeparator.checkpointProposal,
+  const proposal = new CheckpointProposal(
+    header,
+    archive,
+    feeAssetPriceModifier,
+    attestationSignature,
     TEST_COORDINATION_SIGNATURE_CONTEXT,
   );
+  const proposalHash = getHashedSignaturePayloadTypedData(proposal);
   const proposerSignature = signer.sign(proposalHash);
 
   return new CheckpointAttestation(payload, attestationSignature, proposerSignature);

--- a/yarn-project/p2p/src/msg_validators/attestation_validator/attestation_validator.test.ts
+++ b/yarn-project/p2p/src/msg_validators/attestation_validator/attestation_validator.test.ts
@@ -4,7 +4,7 @@ import { EpochNumber, SlotNumber } from '@aztec/foundation/branded-types';
 import { Secp256k1Signer } from '@aztec/foundation/crypto/secp256k1-signer';
 import { PeerErrorSeverity } from '@aztec/stdlib/p2p';
 import { CheckpointHeader } from '@aztec/stdlib/rollup';
-import { makeCheckpointAttestation } from '@aztec/stdlib/testing';
+import { TEST_COORDINATION_SIGNATURE_CONTEXT, makeCheckpointAttestation } from '@aztec/stdlib/testing';
 
 import { type MockProxy, mock } from 'jest-mock-extended';
 
@@ -22,7 +22,10 @@ describe('CheckpointAttestationValidator', () => {
       slotDuration: 72,
       ethereumSlotDuration: 12,
     } as any);
-    validator = new CheckpointAttestationValidator(epochCache, { l1PublishingTime: 12 });
+    validator = new CheckpointAttestationValidator(epochCache, {
+      l1PublishingTime: 12,
+      signatureContext: TEST_COORDINATION_SIGNATURE_CONTEXT,
+    });
     proposer = Secp256k1Signer.random();
     attester = Secp256k1Signer.random();
   });

--- a/yarn-project/p2p/src/msg_validators/attestation_validator/attestation_validator.test.ts
+++ b/yarn-project/p2p/src/msg_validators/attestation_validator/attestation_validator.test.ts
@@ -30,6 +30,20 @@ describe('CheckpointAttestationValidator', () => {
     attester = Secp256k1Signer.random();
   });
 
+  it('rejects foreign signature context with low tolerance error', async () => {
+    const mockAttestation = makeCheckpointAttestation({
+      attesterSigner: attester,
+      proposerSigner: proposer,
+      signatureContext: {
+        ...TEST_COORDINATION_SIGNATURE_CONTEXT,
+        chainId: TEST_COORDINATION_SIGNATURE_CONTEXT.chainId + 1,
+      },
+    });
+
+    const result = await validator.validate(mockAttestation);
+    expect(result).toEqual({ result: 'reject', severity: PeerErrorSeverity.LowToleranceError });
+  });
+
   it('returns high tolerance error if slot number is not current or next slot (outside clock tolerance)', async () => {
     const header = CheckpointHeader.random({ slotNumber: SlotNumber(97) });
     const mockAttestation = makeCheckpointAttestation({

--- a/yarn-project/p2p/src/msg_validators/attestation_validator/attestation_validator.ts
+++ b/yarn-project/p2p/src/msg_validators/attestation_validator/attestation_validator.ts
@@ -7,6 +7,7 @@ import {
   type P2PValidator,
   PeerErrorSeverity,
   type ValidationResult,
+  hasValidSignatureContext,
 } from '@aztec/stdlib/p2p';
 
 import { PipeliningWindow, isWithinClockTolerance } from '../clock_tolerance.js';
@@ -38,6 +39,17 @@ export class CheckpointAttestationValidator implements P2PValidator<CheckpointAt
     const slotNumber = message.payload.header.slotNumber;
 
     try {
+      // Cross-chain replay check: reject attestations that carry a foreign signing domain.
+      if (!hasValidSignatureContext(message.payload, this.signatureContext)) {
+        this.logger.warn(`Rejecting checkpoint attestation with foreign signature context for slot ${slotNumber}`, {
+          chainId: message.payload.signatureContext.chainId,
+          rollupAddress: message.payload.signatureContext.rollupAddress.toString(),
+          expectedChainId: this.signatureContext.chainId,
+          expectedRollupAddress: this.signatureContext.rollupAddress.toString(),
+        });
+        return { result: 'reject', severity: PeerErrorSeverity.HighToleranceError };
+      }
+
       // Use target slots since proposals target pipeline slots (slot + 1 when pipelining).
       const { targetSlot, nextSlot } = this.epochCache.getTargetAndNextSlot();
 
@@ -58,7 +70,7 @@ export class CheckpointAttestationValidator implements P2PValidator<CheckpointAt
       }
 
       // Verify the signature is valid
-      const attester = message.getSender(this.signatureContext);
+      const attester = message.getSender();
       if (attester === undefined) {
         this.logger.warn(`Invalid signature in checkpoint attestation for slot ${slotNumber}`);
         return { result: 'reject', severity: PeerErrorSeverity.LowToleranceError };
@@ -73,7 +85,7 @@ export class CheckpointAttestationValidator implements P2PValidator<CheckpointAt
       // Verify the proposer signature matches the expected proposer for the attestation's slot
       // We look up the proposer for the specific slot rather than using currentSlot/nextSlot
       // since timing differences could cause mismatches
-      const proposer = message.getProposer(this.signatureContext);
+      const proposer = message.getProposer();
       const expectedProposer = await this.epochCache.getProposerAttesterAddressInSlot(slotNumber);
       if (!expectedProposer) {
         this.logger.warn(`No proposer defined for slot ${slotNumber}`);

--- a/yarn-project/p2p/src/msg_validators/attestation_validator/attestation_validator.ts
+++ b/yarn-project/p2p/src/msg_validators/attestation_validator/attestation_validator.ts
@@ -3,6 +3,7 @@ import { NoCommitteeError } from '@aztec/ethereum/contracts';
 import { type Logger, createLogger } from '@aztec/foundation/log';
 import {
   type CheckpointAttestation,
+  type CoordinationSignatureContext,
   type P2PValidator,
   PeerErrorSeverity,
   type ValidationResult,
@@ -14,12 +15,14 @@ export class CheckpointAttestationValidator implements P2PValidator<CheckpointAt
   protected epochCache: EpochCacheInterface;
   protected logger: Logger;
   private readonly pipeliningWindow: PipeliningWindow;
+  protected readonly signatureContext: CoordinationSignatureContext;
 
   constructor(
     epochCache: EpochCacheInterface,
     opts: {
       l1PublishingTime?: number;
       p2pPropagationTime?: number;
+      signatureContext: CoordinationSignatureContext;
     },
   ) {
     this.epochCache = epochCache;
@@ -27,6 +30,7 @@ export class CheckpointAttestationValidator implements P2PValidator<CheckpointAt
       l1PublishingTime: opts.l1PublishingTime,
       p2pPropagationTime: opts.p2pPropagationTime,
     });
+    this.signatureContext = opts.signatureContext;
     this.logger = createLogger('p2p:checkpoint-attestation-validator');
   }
 
@@ -54,7 +58,7 @@ export class CheckpointAttestationValidator implements P2PValidator<CheckpointAt
       }
 
       // Verify the signature is valid
-      const attester = message.getSender();
+      const attester = message.getSender(this.signatureContext);
       if (attester === undefined) {
         this.logger.warn(`Invalid signature in checkpoint attestation for slot ${slotNumber}`);
         return { result: 'reject', severity: PeerErrorSeverity.LowToleranceError };
@@ -69,7 +73,7 @@ export class CheckpointAttestationValidator implements P2PValidator<CheckpointAt
       // Verify the proposer signature matches the expected proposer for the attestation's slot
       // We look up the proposer for the specific slot rather than using currentSlot/nextSlot
       // since timing differences could cause mismatches
-      const proposer = message.getProposer();
+      const proposer = message.getProposer(this.signatureContext);
       const expectedProposer = await this.epochCache.getProposerAttesterAddressInSlot(slotNumber);
       if (!expectedProposer) {
         this.logger.warn(`No proposer defined for slot ${slotNumber}`);

--- a/yarn-project/p2p/src/msg_validators/attestation_validator/attestation_validator.ts
+++ b/yarn-project/p2p/src/msg_validators/attestation_validator/attestation_validator.ts
@@ -47,7 +47,7 @@ export class CheckpointAttestationValidator implements P2PValidator<CheckpointAt
           expectedChainId: this.signatureContext.chainId,
           expectedRollupAddress: this.signatureContext.rollupAddress.toString(),
         });
-        return { result: 'reject', severity: PeerErrorSeverity.HighToleranceError };
+        return { result: 'reject', severity: PeerErrorSeverity.LowToleranceError };
       }
 
       // Use target slots since proposals target pipeline slots (slot + 1 when pipelining).

--- a/yarn-project/p2p/src/msg_validators/attestation_validator/fisherman_attestation_validator.test.ts
+++ b/yarn-project/p2p/src/msg_validators/attestation_validator/fisherman_attestation_validator.test.ts
@@ -5,6 +5,7 @@ import { Fr } from '@aztec/foundation/curves/bn254';
 import { PeerErrorSeverity } from '@aztec/stdlib/p2p';
 import { CheckpointHeader } from '@aztec/stdlib/rollup';
 import {
+  TEST_COORDINATION_SIGNATURE_CONTEXT,
   makeBlockHeader,
   makeCheckpointAttestation,
   makeCheckpointHeader,
@@ -33,6 +34,7 @@ describe('FishermanAttestationValidator', () => {
     attestationPool = mock<AttestationPool>();
     validator = new FishermanAttestationValidator(epochCache, attestationPool, getTelemetryClient(), {
       l1PublishingTime: 12,
+      signatureContext: TEST_COORDINATION_SIGNATURE_CONTEXT,
     });
     proposer = Secp256k1Signer.random();
     attester = Secp256k1Signer.random();

--- a/yarn-project/p2p/src/msg_validators/attestation_validator/fisherman_attestation_validator.ts
+++ b/yarn-project/p2p/src/msg_validators/attestation_validator/fisherman_attestation_validator.ts
@@ -1,5 +1,10 @@
 import type { EpochCacheInterface } from '@aztec/epoch-cache';
-import { type CheckpointAttestation, PeerErrorSeverity, type ValidationResult } from '@aztec/stdlib/p2p';
+import {
+  type CheckpointAttestation,
+  type CoordinationSignatureContext,
+  PeerErrorSeverity,
+  type ValidationResult,
+} from '@aztec/stdlib/p2p';
 import { Attributes, Metrics, type TelemetryClient, createUpDownCounterWithDefault } from '@aztec/telemetry-client';
 
 import type { AttestationPoolApi } from '../../mem_pools/attestation_pool/attestation_pool.js';
@@ -23,7 +28,8 @@ export class FishermanAttestationValidator extends CheckpointAttestationValidato
     opts: {
       l1PublishingTime?: number;
       p2pPropagationTime?: number;
-    } = {},
+      signatureContext: CoordinationSignatureContext;
+    },
   ) {
     super(epochCache, opts);
     this.logger = this.logger.createChild('[FISHERMAN]');
@@ -51,8 +57,8 @@ export class FishermanAttestationValidator extends CheckpointAttestationValidato
 
     // fisherman validation: verify attestation payload matches proposal payload
     const slotNumberBigInt = message.payload.header.slotNumber;
-    const attester = message.getSender();
-    const proposer = message.getProposer();
+    const attester = message.getSender(this.signatureContext);
+    const proposer = message.getProposer(this.signatureContext);
 
     if (!attester || !proposer) {
       return { result: 'accept' };

--- a/yarn-project/p2p/src/msg_validators/attestation_validator/fisherman_attestation_validator.ts
+++ b/yarn-project/p2p/src/msg_validators/attestation_validator/fisherman_attestation_validator.ts
@@ -57,8 +57,8 @@ export class FishermanAttestationValidator extends CheckpointAttestationValidato
 
     // fisherman validation: verify attestation payload matches proposal payload
     const slotNumberBigInt = message.payload.header.slotNumber;
-    const attester = message.getSender(this.signatureContext);
-    const proposer = message.getProposer(this.signatureContext);
+    const attester = message.getSender();
+    const proposer = message.getProposer();
 
     if (!attester || !proposer) {
       return { result: 'accept' };

--- a/yarn-project/p2p/src/msg_validators/proposal_validator/block_proposal_validator.ts
+++ b/yarn-project/p2p/src/msg_validators/proposal_validator/block_proposal_validator.ts
@@ -1,5 +1,5 @@
 import type { EpochCacheInterface } from '@aztec/epoch-cache';
-import type { BlockProposal, P2PValidator, ValidationResult } from '@aztec/stdlib/p2p';
+import type { BlockProposal, CoordinationSignatureContext, P2PValidator, ValidationResult } from '@aztec/stdlib/p2p';
 
 import { ProposalValidator } from '../proposal_validator/proposal_validator.js';
 
@@ -8,7 +8,12 @@ export class BlockProposalValidator implements P2PValidator<BlockProposal> {
 
   constructor(
     epochCache: EpochCacheInterface,
-    opts: { txsPermitted: boolean; maxTxsPerBlock?: number; p2pPropagationTime?: number },
+    opts: {
+      txsPermitted: boolean;
+      maxTxsPerBlock?: number;
+      p2pPropagationTime?: number;
+      signatureContext: CoordinationSignatureContext;
+    },
   ) {
     this.proposalValidator = new ProposalValidator(epochCache, opts, 'p2p:block_proposal_validator');
   }

--- a/yarn-project/p2p/src/msg_validators/proposal_validator/checkpoint_proposal_validator.ts
+++ b/yarn-project/p2p/src/msg_validators/proposal_validator/checkpoint_proposal_validator.ts
@@ -1,5 +1,10 @@
 import type { EpochCacheInterface } from '@aztec/epoch-cache';
-import type { CheckpointProposal, P2PValidator, ValidationResult } from '@aztec/stdlib/p2p';
+import type {
+  CheckpointProposal,
+  CoordinationSignatureContext,
+  P2PValidator,
+  ValidationResult,
+} from '@aztec/stdlib/p2p';
 
 import { ProposalValidator } from '../proposal_validator/proposal_validator.js';
 
@@ -8,7 +13,12 @@ export class CheckpointProposalValidator implements P2PValidator<CheckpointPropo
 
   constructor(
     epochCache: EpochCacheInterface,
-    opts: { txsPermitted: boolean; maxTxsPerBlock?: number; p2pPropagationTime?: number },
+    opts: {
+      txsPermitted: boolean;
+      maxTxsPerBlock?: number;
+      p2pPropagationTime?: number;
+      signatureContext: CoordinationSignatureContext;
+    },
   ) {
     this.proposalValidator = new ProposalValidator(epochCache, opts, 'p2p:checkpoint_proposal_validator');
   }

--- a/yarn-project/p2p/src/msg_validators/proposal_validator/proposal_validator.test.ts
+++ b/yarn-project/p2p/src/msg_validators/proposal_validator/proposal_validator.test.ts
@@ -22,6 +22,10 @@ describe('ProposalValidator', () => {
   const currentSlot = SlotNumber(100);
   const nextSlot = SlotNumber(101);
   const previousSlot = SlotNumber(99);
+  const foreignSignatureContext = {
+    ...TEST_COORDINATION_SIGNATURE_CONTEXT,
+    chainId: TEST_COORDINATION_SIGNATURE_CONTEXT.chainId + 1,
+  };
   let epochCache: MockProxy<EpochCacheInterface>;
   let validator: ProposalValidator;
 
@@ -74,15 +78,38 @@ describe('ProposalValidator', () => {
   describe.each([
     {
       name: 'block proposal',
-      factory: (slotNumber: SlotNumber, signer: Secp256k1Signer) =>
-        makeBlockProposal({ blockHeader: makeBlockHeader(0, { slotNumber }), signer }),
+      factory: (
+        slotNumber: SlotNumber,
+        signer: Secp256k1Signer,
+        signatureContext = TEST_COORDINATION_SIGNATURE_CONTEXT,
+      ) =>
+        makeBlockProposal({
+          blockHeader: makeBlockHeader(0, { slotNumber }),
+          signer,
+          signatureContext,
+        }),
     },
     {
       name: 'checkpoint proposal',
-      factory: (slotNumber: SlotNumber, signer: Secp256k1Signer) =>
-        makeCheckpointProposal({ checkpointHeader: makeCheckpointHeader(0, { slotNumber }), signer }),
+      factory: (
+        slotNumber: SlotNumber,
+        signer: Secp256k1Signer,
+        signatureContext = TEST_COORDINATION_SIGNATURE_CONTEXT,
+      ) =>
+        makeCheckpointProposal({
+          checkpointHeader: makeCheckpointHeader(0, { slotNumber }),
+          signer,
+          signatureContext,
+        }),
     },
   ])('validate with $name', ({ factory }) => {
+    it('rejects foreign signature context with low tolerance error', async () => {
+      const proposal = await factory(currentSlot, Secp256k1Signer.random(), foreignSignatureContext);
+
+      const result = await validator.validate(proposal);
+      expect(result).toEqual({ result: 'reject', severity: PeerErrorSeverity.LowToleranceError });
+    });
+
     it('rejects with high tolerance error if slot is outside clock tolerance', async () => {
       const proposal = await factory(previousSlot, Secp256k1Signer.random());
 

--- a/yarn-project/p2p/src/msg_validators/proposal_validator/proposal_validator.test.ts
+++ b/yarn-project/p2p/src/msg_validators/proposal_validator/proposal_validator.test.ts
@@ -5,6 +5,7 @@ import { Secp256k1Signer } from '@aztec/foundation/crypto/secp256k1-signer';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { PeerErrorSeverity } from '@aztec/stdlib/p2p';
 import {
+  TEST_COORDINATION_SIGNATURE_CONTEXT,
   makeBlockHeader,
   makeBlockProposal,
   makeCheckpointHeader,
@@ -47,7 +48,12 @@ describe('ProposalValidator', () => {
     } as any);
     validator = new ProposalValidator(
       epochCache,
-      { txsPermitted: true, maxTxsPerBlock: undefined, p2pPropagationTime: 2 },
+      {
+        txsPermitted: true,
+        maxTxsPerBlock: undefined,
+        p2pPropagationTime: 2,
+        signatureContext: TEST_COORDINATION_SIGNATURE_CONTEXT,
+      },
       'test',
     );
     epochCache.getEpochAndSlotNow.mockReturnValue({
@@ -233,7 +239,15 @@ describe('ProposalValidator', () => {
   describe('validateTxs', () => {
     describe('txsPermitted', () => {
       it('rejects proposal with txHashes when txs not permitted', async () => {
-        validator = new ProposalValidator(epochCache, { txsPermitted: false, maxTxsPerBlock: undefined }, 'test');
+        validator = new ProposalValidator(
+          epochCache,
+          {
+            txsPermitted: false,
+            maxTxsPerBlock: undefined,
+            signatureContext: TEST_COORDINATION_SIGNATURE_CONTEXT,
+          },
+          'test',
+        );
 
         const proposal = await makeBlockProposal({ txHashes: [TxHash.random(), TxHash.random()] });
         const result = await validator.validateTxs(proposal);
@@ -241,7 +255,15 @@ describe('ProposalValidator', () => {
       });
 
       it('accepts proposal with no txHashes when txs not permitted', async () => {
-        validator = new ProposalValidator(epochCache, { txsPermitted: false, maxTxsPerBlock: undefined }, 'test');
+        validator = new ProposalValidator(
+          epochCache,
+          {
+            txsPermitted: false,
+            maxTxsPerBlock: undefined,
+            signatureContext: TEST_COORDINATION_SIGNATURE_CONTEXT,
+          },
+          'test',
+        );
 
         const proposal = await makeBlockProposal({ txHashes: [] });
         const result = await validator.validateTxs(proposal);
@@ -281,7 +303,15 @@ describe('ProposalValidator', () => {
 
     describe('maxTxsPerBlock', () => {
       it('rejects when txHashes exceed maxTxsPerBlock', async () => {
-        validator = new ProposalValidator(epochCache, { txsPermitted: true, maxTxsPerBlock: 2 }, 'test');
+        validator = new ProposalValidator(
+          epochCache,
+          {
+            txsPermitted: true,
+            maxTxsPerBlock: 2,
+            signatureContext: TEST_COORDINATION_SIGNATURE_CONTEXT,
+          },
+          'test',
+        );
 
         const proposal = await makeBlockProposal({ txHashes: Array.from({ length: 3 }, () => TxHash.random()) });
         const result = await validator.validateTxs(proposal);
@@ -289,7 +319,15 @@ describe('ProposalValidator', () => {
       });
 
       it('accepts when txHashes count equals maxTxsPerBlock', async () => {
-        validator = new ProposalValidator(epochCache, { txsPermitted: true, maxTxsPerBlock: 2 }, 'test');
+        validator = new ProposalValidator(
+          epochCache,
+          {
+            txsPermitted: true,
+            maxTxsPerBlock: 2,
+            signatureContext: TEST_COORDINATION_SIGNATURE_CONTEXT,
+          },
+          'test',
+        );
 
         const proposal = await makeBlockProposal({ txHashes: Array.from({ length: 2 }, () => TxHash.random()) });
         const result = await validator.validateTxs(proposal);

--- a/yarn-project/p2p/src/msg_validators/proposal_validator/proposal_validator.ts
+++ b/yarn-project/p2p/src/msg_validators/proposal_validator/proposal_validator.ts
@@ -50,7 +50,7 @@ export class ProposalValidator {
           expectedChainId: this.signatureContext.chainId,
           expectedRollupAddress: this.signatureContext.rollupAddress.toString(),
         });
-        return { result: 'reject', severity: PeerErrorSeverity.HighToleranceError };
+        return { result: 'reject', severity: PeerErrorSeverity.LowToleranceError };
       }
 
       // Slot check: use target slots since proposals target pipeline slots (slot + 1 when pipelining).

--- a/yarn-project/p2p/src/msg_validators/proposal_validator/proposal_validator.ts
+++ b/yarn-project/p2p/src/msg_validators/proposal_validator/proposal_validator.ts
@@ -4,6 +4,7 @@ import { type Logger, createLogger } from '@aztec/foundation/log';
 import {
   type BlockProposal,
   type CheckpointProposalCore,
+  type CoordinationSignatureContext,
   PeerErrorSeverity,
   type ValidationResult,
 } from '@aztec/stdlib/p2p';
@@ -17,16 +18,23 @@ export class ProposalValidator {
   private txsPermitted: boolean;
   private maxTxsPerBlock?: number;
   private pipeliningWindow: PipeliningWindow;
+  private signatureContext: CoordinationSignatureContext;
 
   constructor(
     epochCache: EpochCacheInterface,
-    opts: { txsPermitted: boolean; maxTxsPerBlock?: number; p2pPropagationTime?: number },
+    opts: {
+      txsPermitted: boolean;
+      maxTxsPerBlock?: number;
+      p2pPropagationTime?: number;
+      signatureContext: CoordinationSignatureContext;
+    },
     loggerName: string,
   ) {
     this.epochCache = epochCache;
     this.txsPermitted = opts.txsPermitted;
     this.maxTxsPerBlock = opts.maxTxsPerBlock;
     this.pipeliningWindow = new PipeliningWindow(epochCache, { p2pPropagationTime: opts.p2pPropagationTime });
+    this.signatureContext = opts.signatureContext;
     this.logger = createLogger(loggerName);
   }
 
@@ -52,7 +60,7 @@ export class ProposalValidator {
       }
 
       // Signature validity
-      const proposer = proposal.getSender();
+      const proposer = proposal.getSender(this.signatureContext);
       if (!proposer) {
         this.logger.warn(`Penalizing peer for proposal with invalid signature`);
         return { result: 'reject', severity: PeerErrorSeverity.MidToleranceError };

--- a/yarn-project/p2p/src/msg_validators/proposal_validator/proposal_validator.ts
+++ b/yarn-project/p2p/src/msg_validators/proposal_validator/proposal_validator.ts
@@ -7,6 +7,7 @@ import {
   type CoordinationSignatureContext,
   PeerErrorSeverity,
   type ValidationResult,
+  hasValidSignatureContext,
 } from '@aztec/stdlib/p2p';
 
 import { PipeliningWindow, isWithinClockTolerance } from '../clock_tolerance.js';
@@ -41,6 +42,17 @@ export class ProposalValidator {
   /** Validates header-level fields: slot, signature, and proposer. */
   public async validate(proposal: BlockProposal | CheckpointProposalCore): Promise<ValidationResult> {
     try {
+      // Cross-chain replay check: reject proposals that carry a foreign signing domain.
+      if (!hasValidSignatureContext(proposal, this.signatureContext)) {
+        this.logger.warn(`Penalizing peer for proposal with foreign signature context`, {
+          chainId: proposal.signatureContext.chainId,
+          rollupAddress: proposal.signatureContext.rollupAddress.toString(),
+          expectedChainId: this.signatureContext.chainId,
+          expectedRollupAddress: this.signatureContext.rollupAddress.toString(),
+        });
+        return { result: 'reject', severity: PeerErrorSeverity.HighToleranceError };
+      }
+
       // Slot check: use target slots since proposals target pipeline slots (slot + 1 when pipelining).
       const { targetSlot, nextSlot } = this.epochCache.getTargetAndNextSlot();
 
@@ -60,7 +72,7 @@ export class ProposalValidator {
       }
 
       // Signature validity
-      const proposer = proposal.getSender(this.signatureContext);
+      const proposer = proposal.getSender();
       if (!proposer) {
         this.logger.warn(`Penalizing peer for proposal with invalid signature`);
         return { result: 'reject', severity: PeerErrorSeverity.MidToleranceError };

--- a/yarn-project/p2p/src/services/libp2p/libp2p_service.test.ts
+++ b/yarn-project/p2p/src/services/libp2p/libp2p_service.test.ts
@@ -514,7 +514,7 @@ describe('LibP2PService', () => {
 
     beforeEach(() => {
       signer = Secp256k1Signer.random();
-      attestationPool = new AttestationPool(openTmpStore(true), TEST_COORDINATION_SIGNATURE_CONTEXT);
+      attestationPool = new AttestationPool(openTmpStore(true));
       mockTxPool = mock<TxPoolV2>();
       mockTxPool.protectTxs.mockResolvedValue([]);
 
@@ -749,7 +749,7 @@ describe('LibP2PService', () => {
 
     beforeEach(() => {
       signer = Secp256k1Signer.random();
-      attestationPool = new AttestationPool(openTmpStore(true), TEST_COORDINATION_SIGNATURE_CONTEXT);
+      attestationPool = new AttestationPool(openTmpStore(true));
       mockTxPool = mock<TxPoolV2>();
       mockTxPool.protectTxs.mockResolvedValue([]);
 
@@ -1177,7 +1177,7 @@ function createTestLibP2PService(options: CreateTestLibP2PServiceOptions): TestL
     peerManager,
     node,
     archiver = mock<L2BlockSource & ContractDataSource>(),
-    attestationPool = new AttestationPool(openTmpStore(true), TEST_COORDINATION_SIGNATURE_CONTEXT),
+    attestationPool = new AttestationPool(openTmpStore(true)),
     txPool = mock<TxPoolV2>(),
     epochCache = mock<EpochCacheInterface>(),
   } = options;

--- a/yarn-project/p2p/src/services/libp2p/libp2p_service.test.ts
+++ b/yarn-project/p2p/src/services/libp2p/libp2p_service.test.ts
@@ -3,7 +3,6 @@ import { BlockNumber, IndexWithinCheckpoint, SlotNumber } from '@aztec/foundatio
 import { getDefaultConfig } from '@aztec/foundation/config';
 import { Secp256k1Signer } from '@aztec/foundation/crypto/secp256k1-signer';
 import { Fr } from '@aztec/foundation/curves/bn254';
-import { EthAddress } from '@aztec/foundation/eth-address';
 import { type Logger, createLogger } from '@aztec/foundation/log';
 import { openTmpStore } from '@aztec/kv-store/lmdb';
 import type { L2BlockSource } from '@aztec/stdlib/block';
@@ -12,6 +11,7 @@ import { GasFees } from '@aztec/stdlib/gas';
 import type { ClientProtocolCircuitVerifier } from '@aztec/stdlib/interfaces/server';
 import { BlockProposal, PeerErrorSeverity } from '@aztec/stdlib/p2p';
 import {
+  TEST_COORDINATION_SIGNATURE_CONTEXT,
   makeBlockHeader,
   makeBlockProposal,
   makeCheckpointHeader,
@@ -514,7 +514,7 @@ describe('LibP2PService', () => {
 
     beforeEach(() => {
       signer = Secp256k1Signer.random();
-      attestationPool = new AttestationPool(openTmpStore(true));
+      attestationPool = new AttestationPool(openTmpStore(true), TEST_COORDINATION_SIGNATURE_CONTEXT);
       mockTxPool = mock<TxPoolV2>();
       mockTxPool.protectTxs.mockResolvedValue([]);
 
@@ -749,7 +749,7 @@ describe('LibP2PService', () => {
 
     beforeEach(() => {
       signer = Secp256k1Signer.random();
-      attestationPool = new AttestationPool(openTmpStore(true));
+      attestationPool = new AttestationPool(openTmpStore(true), TEST_COORDINATION_SIGNATURE_CONTEXT);
       mockTxPool = mock<TxPoolV2>();
       mockTxPool.protectTxs.mockResolvedValue([]);
 
@@ -1058,10 +1058,10 @@ class TestLibP2PService extends LibP2PService {
       seenMessageCacheSize: 1000,
       debugP2PInstrumentMessages: false,
       disableTransactions: false,
-      l1ChainId: 1,
+      l1ChainId: TEST_COORDINATION_SIGNATURE_CONTEXT.chainId,
       rollupVersion: 1,
       l1Contracts: {
-        rollupAddress: EthAddress.random(),
+        rollupAddress: TEST_COORDINATION_SIGNATURE_CONTEXT.rollupAddress,
       },
     };
 
@@ -1177,7 +1177,7 @@ function createTestLibP2PService(options: CreateTestLibP2PServiceOptions): TestL
     peerManager,
     node,
     archiver = mock<L2BlockSource & ContractDataSource>(),
-    attestationPool = new AttestationPool(openTmpStore(true)),
+    attestationPool = new AttestationPool(openTmpStore(true), TEST_COORDINATION_SIGNATURE_CONTEXT),
     txPool = mock<TxPoolV2>(),
     epochCache = mock<EpochCacheInterface>(),
   } = options;

--- a/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
+++ b/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
@@ -15,7 +15,6 @@ import {
   CheckpointAttestation,
   CheckpointProposal,
   type CheckpointProposalCore,
-  type CoordinationSignatureContext,
   type Gossipable,
   P2PMessage,
   PeerErrorSeverity,
@@ -184,13 +183,6 @@ export class LibP2PService extends WithTracer implements P2PService {
   private telemetry: TelemetryClient;
 
   protected logger: Logger;
-
-  private getSignatureContext(): CoordinationSignatureContext {
-    return {
-      chainId: this.config.l1ChainId,
-      rollupAddress: this.config.l1Contracts.rollupAddress,
-    };
-  }
 
   constructor(
     private config: P2PConfig,
@@ -1158,7 +1150,7 @@ export class LibP2PService extends WithTracer implements P2PService {
         slot: slot.toString(),
         archive: attestation.archive.toString(),
         source: peerId.toString(),
-        attester: attestation.getSender(this.getSignatureContext())?.toString(),
+        attester: attestation.getSender()?.toString(),
         count,
       });
       return { result: TopicValidatorResult.Reject, severity: PeerErrorSeverity.HighToleranceError };
@@ -1167,7 +1159,7 @@ export class LibP2PService extends WithTracer implements P2PService {
     // Check if this is a duplicate attestation (signer attested to a different proposal at the same slot)
     // count is the number of attestations by this signer for this slot
     if (count === 2) {
-      const attester = attestation.getSender(this.getSignatureContext());
+      const attester = attestation.getSender();
       if (attester) {
         this.logger.warn(`Detected duplicate attestation (equivocation) at slot ${slot}`, {
           slot: slot.toString(),
@@ -1232,7 +1224,7 @@ export class LibP2PService extends WithTracer implements P2PService {
       this.logger.debug(`Ignoring duplicate block proposal received`, {
         ...block.toBlockInfo(),
         indexWithinCheckpoint: block.indexWithinCheckpoint,
-        proposer: block.getSender(this.getSignatureContext())?.toString(),
+        proposer: block.getSender()?.toString(),
         source: peerId.toString(),
       });
       return { result: TopicValidatorResult.Ignore, obj: block, metadata: { isEquivocated } };
@@ -1244,7 +1236,7 @@ export class LibP2PService extends WithTracer implements P2PService {
         ...block.toBlockInfo(),
         indexWithinCheckpoint: block.indexWithinCheckpoint,
         count,
-        proposer: block.getSender(this.getSignatureContext())?.toString(),
+        proposer: block.getSender()?.toString(),
         source: peerId.toString(),
       });
       return {
@@ -1257,7 +1249,7 @@ export class LibP2PService extends WithTracer implements P2PService {
     // If this was a duplicate proposal, do not process it, but do invoke the duplicate callback,
     // and do re-broadcast it so other nodes in the network know to slash the proposer
     if (isEquivocated) {
-      const proposer = block.getSender(this.getSignatureContext());
+      const proposer = block.getSender();
       this.logger.warn(`Detected duplicate block proposal (equivocation) at slot ${block.slotNumber}`, {
         ...block.toBlockInfo(),
         source: peerId.toString(),
@@ -1416,7 +1408,7 @@ export class LibP2PService extends WithTracer implements P2PService {
     // If this was a duplicate proposal, do not process it, but do invoke the duplicate callback,
     // and do re-broadcast it so other nodes in the network know to slash the proposer
     if (isEquivocated) {
-      const proposer = checkpoint.getSender(this.getSignatureContext());
+      const proposer = checkpoint.getSender();
       this.logger.warn(`Detected duplicate checkpoint proposal (equivocation) at slot ${checkpoint.slotNumber}`, {
         ...checkpoint.toCheckpointInfo(),
         source: peerId.toString(),

--- a/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
+++ b/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
@@ -15,6 +15,7 @@ import {
   CheckpointAttestation,
   CheckpointProposal,
   type CheckpointProposalCore,
+  type CoordinationSignatureContext,
   type Gossipable,
   P2PMessage,
   PeerErrorSeverity,
@@ -184,6 +185,13 @@ export class LibP2PService extends WithTracer implements P2PService {
 
   protected logger: Logger;
 
+  private getSignatureContext(): CoordinationSignatureContext {
+    return {
+      chainId: this.config.l1ChainId,
+      rollupAddress: this.config.l1Contracts.rollupAddress,
+    };
+  }
+
   constructor(
     private config: P2PConfig,
     protected node: PubSubLibp2p,
@@ -232,10 +240,18 @@ export class LibP2PService extends WithTracer implements P2PService {
       txsPermitted: !config.disableTransactions,
       maxTxsPerBlock: config.validateMaxTxsPerBlock ?? config.validateMaxTxsPerCheckpoint,
       p2pPropagationTime,
+      signatureContext: {
+        chainId: config.l1ChainId,
+        rollupAddress: config.l1Contracts.rollupAddress,
+      },
     };
     this.blockProposalValidator = new BlockProposalValidator(epochCache, proposalValidatorOpts);
     this.checkpointProposalValidator = new CheckpointProposalValidator(epochCache, proposalValidatorOpts);
-    const attestationValidatorOpts = { l1PublishingTime: config.l1PublishingTime, p2pPropagationTime };
+    const attestationValidatorOpts = {
+      l1PublishingTime: config.l1PublishingTime,
+      p2pPropagationTime,
+      signatureContext: proposalValidatorOpts.signatureContext,
+    };
     this.checkpointAttestationValidator = config.fishermanMode
       ? new FishermanAttestationValidator(epochCache, mempools.attestationPool, telemetry, attestationValidatorOpts)
       : new CheckpointAttestationValidator(epochCache, attestationValidatorOpts);
@@ -1142,7 +1158,7 @@ export class LibP2PService extends WithTracer implements P2PService {
         slot: slot.toString(),
         archive: attestation.archive.toString(),
         source: peerId.toString(),
-        attester: attestation.getSender()?.toString(),
+        attester: attestation.getSender(this.getSignatureContext())?.toString(),
         count,
       });
       return { result: TopicValidatorResult.Reject, severity: PeerErrorSeverity.HighToleranceError };
@@ -1151,7 +1167,7 @@ export class LibP2PService extends WithTracer implements P2PService {
     // Check if this is a duplicate attestation (signer attested to a different proposal at the same slot)
     // count is the number of attestations by this signer for this slot
     if (count === 2) {
-      const attester = attestation.getSender();
+      const attester = attestation.getSender(this.getSignatureContext());
       if (attester) {
         this.logger.warn(`Detected duplicate attestation (equivocation) at slot ${slot}`, {
           slot: slot.toString(),
@@ -1216,7 +1232,7 @@ export class LibP2PService extends WithTracer implements P2PService {
       this.logger.debug(`Ignoring duplicate block proposal received`, {
         ...block.toBlockInfo(),
         indexWithinCheckpoint: block.indexWithinCheckpoint,
-        proposer: block.getSender()?.toString(),
+        proposer: block.getSender(this.getSignatureContext())?.toString(),
         source: peerId.toString(),
       });
       return { result: TopicValidatorResult.Ignore, obj: block, metadata: { isEquivocated } };
@@ -1228,7 +1244,7 @@ export class LibP2PService extends WithTracer implements P2PService {
         ...block.toBlockInfo(),
         indexWithinCheckpoint: block.indexWithinCheckpoint,
         count,
-        proposer: block.getSender()?.toString(),
+        proposer: block.getSender(this.getSignatureContext())?.toString(),
         source: peerId.toString(),
       });
       return {
@@ -1241,7 +1257,7 @@ export class LibP2PService extends WithTracer implements P2PService {
     // If this was a duplicate proposal, do not process it, but do invoke the duplicate callback,
     // and do re-broadcast it so other nodes in the network know to slash the proposer
     if (isEquivocated) {
-      const proposer = block.getSender();
+      const proposer = block.getSender(this.getSignatureContext());
       this.logger.warn(`Detected duplicate block proposal (equivocation) at slot ${block.slotNumber}`, {
         ...block.toBlockInfo(),
         source: peerId.toString(),
@@ -1400,7 +1416,7 @@ export class LibP2PService extends WithTracer implements P2PService {
     // If this was a duplicate proposal, do not process it, but do invoke the duplicate callback,
     // and do re-broadcast it so other nodes in the network know to slash the proposer
     if (isEquivocated) {
-      const proposer = checkpoint.getSender();
+      const proposer = checkpoint.getSender(this.getSignatureContext());
       this.logger.warn(`Detected duplicate checkpoint proposal (equivocation) at slot ${checkpoint.slotNumber}`, {
         ...checkpoint.toCheckpointInfo(),
         source: peerId.toString(),

--- a/yarn-project/prover-node/src/prover-node-publisher.ts
+++ b/yarn-project/prover-node/src/prover-node-publisher.ts
@@ -364,9 +364,9 @@ export class ProverNodePublisher {
       end: argsArray[1],
       args: argsArray[2],
       fees: argsArray[3],
-      attestations: new CommitteeAttestationsAndSigners(
+      attestations: CommitteeAttestationsAndSigners.packAttestations(
         args.attestations.map(a => CommitteeAttestation.fromViem(a)),
-      ).getPackedAttestations(),
+      ),
       blobInputs: argsArray[4],
       proof: proofHex,
     };

--- a/yarn-project/sequencer-client/src/publisher/sequencer-publisher.test.ts
+++ b/yarn-project/sequencer-client/src/publisher/sequencer-publisher.test.ts
@@ -56,6 +56,10 @@ describe('compareActions sorting', () => {
 const mockRollupAddress = EthAddress.random().toString();
 const mockGovernanceProposerAddress = EthAddress.random().toString();
 const mockForwarderAddress = EthAddress.random().toString();
+const testSignatureContext = {
+  chainId: 1,
+  rollupAddress: EthAddress.fromString(mockRollupAddress),
+};
 
 describe('SequencerPublisher', () => {
   let rollup: MockProxy<RollupContract>;
@@ -207,7 +211,11 @@ describe('SequencerPublisher', () => {
   it('bundles propose and vote tx to l1', async () => {
     const checkpoint = new Checkpoint(l2Block.archive, header, [l2Block], l2Block.checkpointNumber);
     const expectedBlobs = await getBlobsPerL1Block(checkpoint.toBlobFields());
-    await publisher.enqueueProposeCheckpoint(checkpoint, CommitteeAttestationsAndSigners.empty(), Signature.empty());
+    await publisher.enqueueProposeCheckpoint(
+      checkpoint,
+      CommitteeAttestationsAndSigners.empty(testSignatureContext),
+      Signature.empty(),
+    );
 
     const { govPayload, voteSig } = mockGovernancePayload();
 
@@ -239,7 +247,7 @@ describe('SequencerPublisher', () => {
           feeAssetPriceModifier: 0n,
         },
       },
-      CommitteeAttestationsAndSigners.empty().getPackedAttestations(),
+      CommitteeAttestationsAndSigners.packAttestations([]),
       [],
       Signature.empty().toViemSignature(),
       blobInput,
@@ -290,7 +298,7 @@ describe('SequencerPublisher', () => {
 
     await publisher.enqueueProposeCheckpoint(
       new Checkpoint(l2Block.archive, header, [l2Block], l2Block.checkpointNumber),
-      CommitteeAttestationsAndSigners.empty(),
+      CommitteeAttestationsAndSigners.empty(testSignatureContext),
       Signature.empty(),
     );
     const result = await publisher.sendRequests();
@@ -351,7 +359,7 @@ describe('SequencerPublisher', () => {
 
       await rotatingPublisher.enqueueProposeCheckpoint(
         new Checkpoint(l2Block.archive, header, [l2Block], l2Block.checkpointNumber),
-        CommitteeAttestationsAndSigners.empty(),
+        CommitteeAttestationsAndSigners.empty(testSignatureContext),
         Signature.empty(),
       );
       const result = await rotatingPublisher.sendRequests();
@@ -389,7 +397,7 @@ describe('SequencerPublisher', () => {
 
       await rotatingPublisher.enqueueProposeCheckpoint(
         new Checkpoint(l2Block.archive, header, [l2Block], l2Block.checkpointNumber),
-        CommitteeAttestationsAndSigners.empty(),
+        CommitteeAttestationsAndSigners.empty(testSignatureContext),
         Signature.empty(),
       );
       // TimeoutError propagates to the outer catch in sendRequests which returns undefined
@@ -408,7 +416,7 @@ describe('SequencerPublisher', () => {
 
       await rotatingPublisher.enqueueProposeCheckpoint(
         new Checkpoint(l2Block.archive, header, [l2Block], l2Block.checkpointNumber),
-        CommitteeAttestationsAndSigners.empty(),
+        CommitteeAttestationsAndSigners.empty(testSignatureContext),
         Signature.empty(),
       );
       const result = await rotatingPublisher.sendRequests();
@@ -423,7 +431,7 @@ describe('SequencerPublisher', () => {
 
       await rotatingPublisher.enqueueProposeCheckpoint(
         new Checkpoint(l2Block.archive, header, [l2Block], l2Block.checkpointNumber),
-        CommitteeAttestationsAndSigners.empty(),
+        CommitteeAttestationsAndSigners.empty(testSignatureContext),
         Signature.empty(),
       );
       const result = await rotatingPublisher.sendRequests();
@@ -441,7 +449,7 @@ describe('SequencerPublisher', () => {
     await expect(
       publisher.enqueueProposeCheckpoint(
         new Checkpoint(l2Block.archive, header, [l2Block], l2Block.checkpointNumber),
-        CommitteeAttestationsAndSigners.empty(),
+        CommitteeAttestationsAndSigners.empty(testSignatureContext),
         Signature.empty(),
       ),
     ).rejects.toThrow();
@@ -461,7 +469,7 @@ describe('SequencerPublisher', () => {
 
     await publisher.enqueueProposeCheckpoint(
       new Checkpoint(l2Block.archive, header, [l2Block], l2Block.checkpointNumber),
-      CommitteeAttestationsAndSigners.empty(),
+      CommitteeAttestationsAndSigners.empty(testSignatureContext),
       Signature.empty(),
     );
     const result = await publisher.sendRequests();
@@ -485,7 +493,7 @@ describe('SequencerPublisher', () => {
     );
     await publisher.enqueueProposeCheckpoint(
       new Checkpoint(l2Block.archive, header, [l2Block], l2Block.checkpointNumber),
-      CommitteeAttestationsAndSigners.empty(),
+      CommitteeAttestationsAndSigners.empty(testSignatureContext),
       Signature.empty(),
     );
     publisher.interrupt();

--- a/yarn-project/sequencer-client/src/publisher/sequencer-publisher.ts
+++ b/yarn-project/sequencer-client/src/publisher/sequencer-publisher.ts
@@ -709,7 +709,7 @@ export class SequencerPublisher {
 
     const args = [
       header.toViem(),
-      CommitteeAttestationsAndSigners.empty().getPackedAttestations(),
+      CommitteeAttestationsAndSigners.packAttestations([]),
       [], // no signers
       Signature.empty().toViemSignature(),
       `0x${'0'.repeat(64)}`, // 32 empty bytes
@@ -850,9 +850,7 @@ export class SequencerPublisher {
     const logData = { ...checkpoint, reason };
     this.log.debug(`Building invalidate checkpoint ${checkpoint.checkpointNumber} request`, logData);
 
-    const attestationsAndSigners = new CommitteeAttestationsAndSigners(
-      validationResult.attestations,
-    ).getPackedAttestations();
+    const attestationsAndSigners = CommitteeAttestationsAndSigners.packAttestations(validationResult.attestations);
 
     if (reason === 'invalid-attestation') {
       return this.rollupContract.buildInvalidateBadAttestationRequest(

--- a/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.test.ts
@@ -251,22 +251,36 @@ describe('CheckpointProposalJob', () => {
           archiveRoot,
           txHashes,
           mockedSig,
+          signatureContext,
         );
       },
     );
     validatorClient.createCheckpointProposal.mockImplementation(
       async (checkpointHeader, archiveRoot, _checkpointNumber, feeAssetPriceModifier, lastBlockInfo) => {
         if (!lastBlockInfo) {
-          return new CheckpointProposal(checkpointHeader, archiveRoot, feeAssetPriceModifier, mockedSig);
+          return new CheckpointProposal(
+            checkpointHeader,
+            archiveRoot,
+            feeAssetPriceModifier,
+            mockedSig,
+            signatureContext,
+          );
         }
         const txHashes = await Promise.all((lastBlockInfo.txs ?? []).map((tx: Tx) => tx.getTxHash()));
-        return new CheckpointProposal(checkpointHeader, archiveRoot, feeAssetPriceModifier, mockedSig, {
-          blockHeader: lastBlockInfo.blockHeader,
-          indexWithinCheckpoint: lastBlockInfo.indexWithinCheckpoint,
-          txHashes,
-          signature: mockedSig,
-          // Note: signedTxs omitted since publishTxsWithProposals is false in tests
-        });
+        return new CheckpointProposal(
+          checkpointHeader,
+          archiveRoot,
+          feeAssetPriceModifier,
+          mockedSig,
+          signatureContext,
+          {
+            blockHeader: lastBlockInfo.blockHeader,
+            indexWithinCheckpoint: lastBlockInfo.indexWithinCheckpoint,
+            txHashes,
+            signature: mockedSig,
+            // Note: signedTxs omitted since publishTxsWithProposals is false in tests
+          },
+        );
       },
     );
     validatorClient.signAttestationsAndSigners.mockImplementation(() => Promise.resolve(getSignatures()[0].signature));

--- a/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.test.ts
@@ -41,7 +41,7 @@ import {
   type WorldStateSynchronizer,
 } from '@aztec/stdlib/interfaces/server';
 import type { L1ToL2MessageSource } from '@aztec/stdlib/messaging';
-import { BlockProposal, CheckpointProposal } from '@aztec/stdlib/p2p';
+import { BlockProposal, CheckpointProposal, type CoordinationSignatureContext } from '@aztec/stdlib/p2p';
 import { CheckpointHeader } from '@aztec/stdlib/rollup';
 import { AppendOnlyTreeSnapshot } from '@aztec/stdlib/trees';
 import { type FailedTx, GlobalVariables, type Tx } from '@aztec/stdlib/tx';
@@ -121,6 +121,10 @@ describe('CheckpointProposalJob', () => {
   const committee = [signer.address];
   const attestorAddress = EthAddress.random();
   const proposer = EthAddress.random();
+  const signatureContext: CoordinationSignatureContext = {
+    chainId: chainId.toNumber(),
+    rollupAddress: EthAddress.random(),
+  };
 
   const getSignatures = () => [mockedAttestation];
 
@@ -635,6 +639,7 @@ describe('CheckpointProposalJob', () => {
       checkpointsBuilder as unknown as FullNodeCheckpointsBuilder,
       blockSink,
       l1Constants,
+      signatureContext,
       config,
       timetable,
       slasherClient,

--- a/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.timing.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.timing.test.ts
@@ -20,6 +20,7 @@ import type {
   WorldStateSynchronizer,
 } from '@aztec/stdlib/interfaces/server';
 import type { L1ToL2MessageSource } from '@aztec/stdlib/messaging';
+import type { CoordinationSignatureContext } from '@aztec/stdlib/p2p';
 import { type CheckpointGlobalVariables, GlobalVariables, type Tx } from '@aztec/stdlib/tx';
 import { getTelemetryClient } from '@aztec/telemetry-client';
 import type {
@@ -223,6 +224,10 @@ describe('CheckpointProposalJob Timing Tests', () => {
   const version = Fr.ZERO;
   const coinbase = EthAddress.random();
   const gasFees = GasFees.empty();
+  const signatureContext: CoordinationSignatureContext = {
+    chainId: chainId.toNumber(),
+    rollupAddress: EthAddress.random(),
+  };
   const signer = Secp256k1Signer.random();
   const mockedSig = Signature.random();
   const committee = [signer.address];
@@ -309,6 +314,7 @@ describe('CheckpointProposalJob Timing Tests', () => {
       checkpointsBuilder as unknown as FullNodeCheckpointsBuilder,
       blockSink,
       l1Constants,
+      signatureContext,
       config,
       timetable,
       slasherClient,
@@ -1054,6 +1060,7 @@ describe('CheckpointProposalJob Timing Tests', () => {
         checkpointsBuilder as unknown as FullNodeCheckpointsBuilder,
         blockSink,
         l1Constants,
+        signatureContext,
         config,
         pipeliningTimetable,
         slasherClient,

--- a/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.ts
+++ b/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.ts
@@ -1054,7 +1054,7 @@ export class CheckpointProposalJob implements Traceable {
   ): Promise<CommitteeAttestationsAndSigners | undefined> {
     if (this.config.fishermanMode) {
       this.log.debug('Skipping attestation collection in fisherman mode');
-      return CommitteeAttestationsAndSigners.empty();
+      return CommitteeAttestationsAndSigners.empty(this.getSignatureContext());
     }
 
     const slotNumber = proposal.slotNumber;
@@ -1064,7 +1064,7 @@ export class CheckpointProposalJob implements Traceable {
       throw new Error('No committee when collecting attestations');
     } else if (committee.length === 0) {
       this.log.verbose(`Attesting committee is empty`);
-      return CommitteeAttestationsAndSigners.empty();
+      return CommitteeAttestationsAndSigners.empty(this.getSignatureContext());
     } else {
       this.log.debug(`Attesting committee length is ${committee.length}`, { committee });
     }

--- a/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.ts
+++ b/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.ts
@@ -48,6 +48,7 @@ import type {
   BlockProposalOptions,
   CheckpointProposal,
   CheckpointProposalOptions,
+  CoordinationSignatureContext,
 } from '@aztec/stdlib/p2p';
 import { orderAttestations, trimAttestations } from '@aztec/stdlib/p2p';
 import type { L2BlockBuiltStats } from '@aztec/stdlib/stats';
@@ -104,6 +105,10 @@ export class CheckpointProposalJob implements Traceable {
   /** Pipelined parent chain state used while building and later submitting this checkpoint. */
   private pipelinedParentSimulationOverridesPlan?: SimulationOverridesPlan;
 
+  private getSignatureContext(): CoordinationSignatureContext {
+    return this.signatureContext;
+  }
+
   constructor(
     private readonly slotNow: SlotNumber,
     private readonly targetSlot: SlotNumber,
@@ -124,6 +129,7 @@ export class CheckpointProposalJob implements Traceable {
     private readonly checkpointsBuilder: FullNodeCheckpointsBuilder,
     private readonly blockSink: L2BlockSink,
     private readonly l1Constants: SequencerRollupConstants,
+    private readonly signatureContext: CoordinationSignatureContext,
     protected config: ResolvedSequencerConfig,
     protected timetable: SequencerTimetable,
     private readonly slasherClient: SlasherClientInterface | undefined,
@@ -1068,7 +1074,9 @@ export class CheckpointProposalJob implements Traceable {
     if (this.config.skipCollectingAttestations) {
       this.log.warn('Skipping attestation collection as per config (attesting with own keys only)');
       const attestations = await this.validatorClient?.collectOwnAttestations(proposal, this.checkpointNumber);
-      return new CommitteeAttestationsAndSigners(orderAttestations(attestations ?? [], committee));
+      return new CommitteeAttestationsAndSigners(
+        orderAttestations(attestations ?? [], committee, this.getSignatureContext()),
+      );
     }
 
     const attestationTimeAllowed = this.config.enforceTimeTable
@@ -1097,13 +1105,14 @@ export class CheckpointProposalJob implements Traceable {
         numberOfRequiredAttestations,
         this.attestorAddress,
         localAddresses,
+        this.getSignatureContext(),
       );
       if (trimmed.length < attestations.length) {
         this.log.debug(`Trimmed attestations from ${attestations.length} to ${trimmed.length} for L1 submission`);
       }
 
       // Rollup contract requires that the signatures are provided in the order of the committee
-      const sorted = orderAttestations(trimmed, committee);
+      const sorted = orderAttestations(trimmed, committee, this.getSignatureContext());
 
       // Manipulate the attestations if we've been configured to do so
       if (

--- a/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.ts
+++ b/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.ts
@@ -1075,7 +1075,8 @@ export class CheckpointProposalJob implements Traceable {
       this.log.warn('Skipping attestation collection as per config (attesting with own keys only)');
       const attestations = await this.validatorClient?.collectOwnAttestations(proposal, this.checkpointNumber);
       return new CommitteeAttestationsAndSigners(
-        orderAttestations(attestations ?? [], committee, this.getSignatureContext()),
+        orderAttestations(attestations ?? [], committee),
+        this.getSignatureContext(),
       );
     }
 
@@ -1105,14 +1106,13 @@ export class CheckpointProposalJob implements Traceable {
         numberOfRequiredAttestations,
         this.attestorAddress,
         localAddresses,
-        this.getSignatureContext(),
       );
       if (trimmed.length < attestations.length) {
         this.log.debug(`Trimmed attestations from ${attestations.length} to ${trimmed.length} for L1 submission`);
       }
 
       // Rollup contract requires that the signatures are provided in the order of the committee
-      const sorted = orderAttestations(trimmed, committee, this.getSignatureContext());
+      const sorted = orderAttestations(trimmed, committee);
 
       // Manipulate the attestations if we've been configured to do so
       if (
@@ -1124,7 +1124,7 @@ export class CheckpointProposalJob implements Traceable {
         return this.manipulateAttestations(proposal.slotNumber, epoch, seed, committee, sorted);
       }
 
-      return new CommitteeAttestationsAndSigners(sorted);
+      return new CommitteeAttestationsAndSigners(sorted, this.getSignatureContext());
     } catch (err) {
       if (err && err instanceof AttestationTimeoutError) {
         collectedAttestationsCount = err.collectedCount;
@@ -1184,7 +1184,7 @@ export class CheckpointProposalJob implements Traceable {
           unfreeze(attestations[targetIndex]).signature = generateRecoverableSignature();
         }
       }
-      return new CommitteeAttestationsAndSigners(attestations);
+      return new CommitteeAttestationsAndSigners(attestations, this.getSignatureContext());
     }
 
     if (this.config.shuffleAttestationOrdering) {
@@ -1206,11 +1206,11 @@ export class CheckpointProposalJob implements Traceable {
         [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
       }
 
-      const signers = new CommitteeAttestationsAndSigners(attestations).getSigners();
-      return new MaliciousCommitteeAttestationsAndSigners(shuffled, signers);
+      const signers = new CommitteeAttestationsAndSigners(attestations, this.getSignatureContext()).getSigners();
+      return new MaliciousCommitteeAttestationsAndSigners(shuffled, signers, this.getSignatureContext());
     }
 
-    return new CommitteeAttestationsAndSigners(attestations);
+    return new CommitteeAttestationsAndSigners(attestations, this.getSignatureContext());
   }
 
   private async dropFailedTxsFromP2P(failedTxs: FailedTx[]) {

--- a/yarn-project/sequencer-client/src/sequencer/checkpoint_voter.ha.integration.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/checkpoint_voter.ha.integration.test.ts
@@ -235,6 +235,7 @@ describe('CheckpointVoter HA Integration', () => {
       disableValidator: false,
       disabledValidators: [],
       haSigningEnabled: true,
+      l1ChainId: 1,
       l1Contracts: { rollupAddress: EthAddress.fromString(rollupContract.address.toString()) },
       nodeId: config.nodeId || 'ha-node-1',
       pollingIntervalMs: 100,

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.test.ts
@@ -29,6 +29,7 @@ import {
   type ValidateCheckpointNegativeResult,
 } from '@aztec/stdlib/block';
 import { Checkpoint } from '@aztec/stdlib/checkpoint';
+import type { ChainConfig } from '@aztec/stdlib/config';
 import type { L1RollupConstants } from '@aztec/stdlib/epoch-helpers';
 import { GasFees } from '@aztec/stdlib/gas';
 import {
@@ -350,7 +351,12 @@ describe('sequencer', () => {
 
     dateProvider = new TestDateProvider();
 
-    const config: SequencerConfig = { enforceTimeTable: true, maxTxsPerBlock: 4 };
+    const config: SequencerConfig & Pick<ChainConfig, 'l1ChainId' | 'l1Contracts'> = {
+      enforceTimeTable: true,
+      maxTxsPerBlock: 4,
+      l1ChainId: chainId.toNumber(),
+      l1Contracts: { rollupAddress: EthAddress.random() },
+    };
     sequencer = new TestSequencer(
       publisherFactory,
       validatorClient,

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.test.ts
@@ -77,6 +77,7 @@ describe('sequencer', () => {
   let newBlockNumber: BlockNumber;
   let newSlotNumber: number;
   let hash: string;
+  let signatureContext: { chainId: number; rollupAddress: EthAddress };
 
   let block: L2Block;
   let globalVariables: GlobalVariables;
@@ -154,7 +155,7 @@ describe('sequencer', () => {
   };
 
   const expectPublisherProposeL2Block = () => {
-    const attestationsAndSigners = new CommitteeAttestationsAndSigners(getSignatures());
+    const attestationsAndSigners = new CommitteeAttestationsAndSigners(getSignatures(), signatureContext);
     expect(publisher.enqueueProposeCheckpoint).toHaveBeenCalledTimes(1);
     expect(publisher.enqueueProposeCheckpoint).toHaveBeenCalledWith(
       expect.any(Checkpoint),
@@ -351,11 +352,12 @@ describe('sequencer', () => {
 
     dateProvider = new TestDateProvider();
 
+    signatureContext = { chainId: chainId.toNumber(), rollupAddress: EthAddress.random() };
     const config: SequencerConfig & Pick<ChainConfig, 'l1ChainId' | 'l1Contracts'> = {
       enforceTimeTable: true,
       maxTxsPerBlock: 4,
-      l1ChainId: chainId.toNumber(),
-      l1Contracts: { rollupAddress: EthAddress.random() },
+      l1ChainId: signatureContext.chainId,
+      l1Contracts: { rollupAddress: signatureContext.rollupAddress },
     };
     sequencer = new TestSequencer(
       publisherFactory,
@@ -592,7 +594,7 @@ describe('sequencer', () => {
         await sequencer.work();
         await sequencer.awaitLastProposalSubmission();
 
-        const attestationsAndSigners = new CommitteeAttestationsAndSigners(getSignatures());
+        const attestationsAndSigners = new CommitteeAttestationsAndSigners(getSignatures(), signatureContext);
         expect(publishers[i].enqueueProposeCheckpoint).toHaveBeenCalledTimes(1);
         expect(publishers[i].enqueueProposeCheckpoint).toHaveBeenCalledWith(
           expect.any(Checkpoint),

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.ts
@@ -14,6 +14,7 @@ import type { P2P } from '@aztec/p2p';
 import type { SlasherClientInterface } from '@aztec/slasher';
 import type { BlockData, L2BlockSink, L2BlockSource, ValidateCheckpointResult } from '@aztec/stdlib/block';
 import type { Checkpoint, ProposedCheckpointData } from '@aztec/stdlib/checkpoint';
+import type { ChainConfig } from '@aztec/stdlib/config';
 import { getSlotStartBuildTimestamp } from '@aztec/stdlib/epoch-helpers';
 import {
   type ResolvedSequencerConfig,
@@ -22,6 +23,7 @@ import {
   type WorldStateSynchronizer,
 } from '@aztec/stdlib/interfaces/server';
 import type { L1ToL2MessageSource } from '@aztec/stdlib/messaging';
+import type { CoordinationSignatureContext } from '@aztec/stdlib/p2p';
 import { pickFromSchema } from '@aztec/stdlib/schemas';
 import { MerkleTreeId } from '@aztec/stdlib/trees';
 import { Attributes, type TelemetryClient, type Tracer, getTelemetryClient, trackSpan } from '@aztec/telemetry-client';
@@ -83,6 +85,7 @@ export class Sequencer extends (EventEmitter as new () => TypedEventEmitter<Sequ
 
   /** Config for the sequencer */
   protected config: ResolvedSequencerConfig = DefaultSequencerConfig;
+  private readonly signatureContext: CoordinationSignatureContext;
 
   constructor(
     protected publisherFactory: SequencerPublisherFactory,
@@ -98,7 +101,7 @@ export class Sequencer extends (EventEmitter as new () => TypedEventEmitter<Sequ
     protected dateProvider: DateProvider,
     protected epochCache: EpochCache,
     protected rollupContract: RollupContract,
-    config: SequencerConfig,
+    config: SequencerConfig & Pick<ChainConfig, 'l1ChainId' | 'l1Contracts'>,
     protected telemetry: TelemetryClient = getTelemetryClient(),
     protected log = createLogger('sequencer'),
   ) {
@@ -109,6 +112,10 @@ export class Sequencer extends (EventEmitter as new () => TypedEventEmitter<Sequ
       this.log = log.createChild('[FISHERMAN]');
     }
 
+    this.signatureContext = {
+      chainId: config.l1ChainId,
+      rollupAddress: config.l1Contracts.rollupAddress,
+    };
     this.metrics = new SequencerMetrics(telemetry, this.rollupContract, 'Sequencer');
     this.checkpointProposalJobMetrics = new CheckpointProposalJobMetrics(telemetry);
     this.updateConfig(config);
@@ -490,6 +497,7 @@ export class Sequencer extends (EventEmitter as new () => TypedEventEmitter<Sequ
       this.checkpointsBuilder,
       this.l2BlockSource,
       this.l1Constants,
+      this.signatureContext,
       this.config,
       this.timetable,
       this.slasherClient,

--- a/yarn-project/sequencer-client/src/test/utils.ts
+++ b/yarn-project/sequencer-client/src/test/utils.ts
@@ -145,8 +145,9 @@ export function createCheckpointAttestation(
   const checkpointHeader = createCheckpointHeaderFromBlock(block);
   const payload = new ConsensusPayload(checkpointHeader, block.archive.root, feeAssetPriceModifier);
   const attestation = new CheckpointAttestation(payload, signature, signature);
-  // Set sender directly for testing (bypasses signature recovery)
-  (attestation as any).sender = sender;
+  // Bypass signature recovery for testing since we use random signatures
+  (attestation as any).getSender = () => sender;
+  (attestation as any).getProposer = () => sender;
   return attestation;
 }
 

--- a/yarn-project/sequencer-client/src/test/utils.ts
+++ b/yarn-project/sequencer-client/src/test/utils.ts
@@ -10,7 +10,11 @@ import { PublicDataWrite } from '@aztec/stdlib/avm';
 import { CommitteeAttestation, L2Block } from '@aztec/stdlib/block';
 import { BlockProposal, CheckpointAttestation, CheckpointProposal, ConsensusPayload } from '@aztec/stdlib/p2p';
 import { CheckpointHeader } from '@aztec/stdlib/rollup';
-import { makeAppendOnlyTreeSnapshot, mockTxForRollup } from '@aztec/stdlib/testing';
+import {
+  TEST_COORDINATION_SIGNATURE_CONTEXT,
+  makeAppendOnlyTreeSnapshot,
+  mockTxForRollup,
+} from '@aztec/stdlib/testing';
 import { BlockHeader, GlobalVariables, type Tx, makeProcessedTxFromPrivateOnlyTx } from '@aztec/stdlib/tx';
 
 import type { MockProxy } from 'jest-mock-extended';
@@ -109,6 +113,7 @@ export function createBlockProposal(block: L2Block, signature: Signature): Block
     block.archive.root,
     txHashes,
     signature,
+    TEST_COORDINATION_SIGNATURE_CONTEXT,
   );
 }
 
@@ -123,12 +128,19 @@ export function createCheckpointProposal(
 ): CheckpointProposal {
   const txHashes = block.body.txEffects.map(tx => tx.txHash);
   const checkpointHeader = createCheckpointHeaderFromBlock(block);
-  return new CheckpointProposal(checkpointHeader, block.archive.root, feeAssetPriceModifier, checkpointSignature, {
-    blockHeader: block.header,
-    indexWithinCheckpoint: block.indexWithinCheckpoint,
-    txHashes,
-    signature: blockSignature ?? checkpointSignature, // Use checkpoint signature as block signature if not provided
-  });
+  return new CheckpointProposal(
+    checkpointHeader,
+    block.archive.root,
+    feeAssetPriceModifier,
+    checkpointSignature,
+    TEST_COORDINATION_SIGNATURE_CONTEXT,
+    {
+      blockHeader: block.header,
+      indexWithinCheckpoint: block.indexWithinCheckpoint,
+      txHashes,
+      signature: blockSignature ?? checkpointSignature, // Use checkpoint signature as block signature if not provided
+    },
+  );
 }
 
 /**
@@ -143,7 +155,12 @@ export function createCheckpointAttestation(
   feeAssetPriceModifier: bigint = 0n,
 ): CheckpointAttestation {
   const checkpointHeader = createCheckpointHeaderFromBlock(block);
-  const payload = new ConsensusPayload(checkpointHeader, block.archive.root, feeAssetPriceModifier);
+  const payload = new ConsensusPayload(
+    checkpointHeader,
+    block.archive.root,
+    feeAssetPriceModifier,
+    TEST_COORDINATION_SIGNATURE_CONTEXT,
+  );
   const attestation = new CheckpointAttestation(payload, signature, signature);
   // Bypass signature recovery for testing since we use random signatures
   (attestation as any).getSender = () => sender;

--- a/yarn-project/stdlib/src/block/attestation_info.ts
+++ b/yarn-project/stdlib/src/block/attestation_info.ts
@@ -3,11 +3,7 @@ import type { EthAddress } from '@aztec/foundation/eth-address';
 
 import { Checkpoint } from '../checkpoint/checkpoint.js';
 import { ConsensusPayload } from '../p2p/consensus_payload.js';
-import {
-  type CoordinationSignatureContext,
-  SignatureDomainSeparator,
-  getHashedSignaturePayloadTypedData,
-} from '../p2p/signature_utils.js';
+import { type CoordinationSignatureContext, getHashedSignaturePayloadTypedData } from '../p2p/signature_utils.js';
 import type { CommitteeAttestation } from './proposal/committee_attestation.js';
 
 /**
@@ -43,20 +39,15 @@ export function getAttestationInfoFromPublishedCheckpoint(
   },
   signatureContext: CoordinationSignatureContext,
 ): AttestationInfo[] {
-  const payload = ConsensusPayload.fromCheckpoint(block.checkpoint);
-  return getAttestationInfoFromPayload(payload, block.attestations, signatureContext);
+  const payload = ConsensusPayload.fromCheckpoint(block.checkpoint, signatureContext);
+  return getAttestationInfoFromPayload(payload, block.attestations);
 }
 
 export function getAttestationInfoFromPayload(
   payload: ConsensusPayload,
   attestations: CommitteeAttestation[],
-  signatureContext: CoordinationSignatureContext,
 ): AttestationInfo[] {
-  const hashedPayload = getHashedSignaturePayloadTypedData(
-    payload,
-    SignatureDomainSeparator.checkpointAttestation,
-    signatureContext,
-  );
+  const hashedPayload = getHashedSignaturePayloadTypedData(payload);
 
   return attestations.map(attestation => {
     // If signature is empty, check if we have an address directly

--- a/yarn-project/stdlib/src/block/attestation_info.ts
+++ b/yarn-project/stdlib/src/block/attestation_info.ts
@@ -3,7 +3,11 @@ import type { EthAddress } from '@aztec/foundation/eth-address';
 
 import { Checkpoint } from '../checkpoint/checkpoint.js';
 import { ConsensusPayload } from '../p2p/consensus_payload.js';
-import { SignatureDomainSeparator, getHashedSignaturePayloadEthSignedMessage } from '../p2p/signature_utils.js';
+import {
+  type CoordinationSignatureContext,
+  SignatureDomainSeparator,
+  getHashedSignaturePayloadTypedData,
+} from '../p2p/signature_utils.js';
 import type { CommitteeAttestation } from './proposal/committee_attestation.js';
 
 /**
@@ -32,21 +36,26 @@ export type AttestationInfo =
  * Extracts attestation information from a published checkpoint.
  * Returns info for each attestation, preserving array indices.
  */
-export function getAttestationInfoFromPublishedCheckpoint(block: {
-  attestations: CommitteeAttestation[];
-  checkpoint: Checkpoint;
-}): AttestationInfo[] {
+export function getAttestationInfoFromPublishedCheckpoint(
+  block: {
+    attestations: CommitteeAttestation[];
+    checkpoint: Checkpoint;
+  },
+  signatureContext: CoordinationSignatureContext,
+): AttestationInfo[] {
   const payload = ConsensusPayload.fromCheckpoint(block.checkpoint);
-  return getAttestationInfoFromPayload(payload, block.attestations);
+  return getAttestationInfoFromPayload(payload, block.attestations, signatureContext);
 }
 
 export function getAttestationInfoFromPayload(
   payload: ConsensusPayload,
   attestations: CommitteeAttestation[],
+  signatureContext: CoordinationSignatureContext,
 ): AttestationInfo[] {
-  const hashedPayload = getHashedSignaturePayloadEthSignedMessage(
+  const hashedPayload = getHashedSignaturePayloadTypedData(
     payload,
     SignatureDomainSeparator.checkpointAttestation,
+    signatureContext,
   );
 
   return attestations.map(attestation => {
@@ -62,7 +71,7 @@ export function getAttestationInfoFromPayload(
 
     // Try to recover address from signature
     try {
-      const recoveredAddress = recoverAddress(hashedPayload, attestation.signature);
+      const recoveredAddress = recoverAddress(hashedPayload, attestation.signature, { allowYParityAsV: true });
       return { address: recoveredAddress, status: 'recovered-from-signature' as const };
     } catch {
       // Signature present but recovery failed

--- a/yarn-project/stdlib/src/block/proposal/attestations_and_signers.ts
+++ b/yarn-project/stdlib/src/block/proposal/attestations_and_signers.ts
@@ -4,26 +4,38 @@ import { hexToBuffer } from '@aztec/foundation/string';
 import { encodeAbiParameters, parseAbiParameters } from 'viem';
 import { z } from 'zod';
 
-import type { Signable, SignatureDomainSeparator } from '../../p2p/signature_utils.js';
+import {
+  type CoordinationSignatureContext,
+  type CoordinationSignatureType,
+  EMPTY_COORDINATION_SIGNATURE_CONTEXT,
+  type Signable,
+  coordinationSignatureContextSchema,
+} from '../../p2p/signature_utils.js';
 import { CommitteeAttestation, EthAddress } from './committee_attestation.js';
 
 export class CommitteeAttestationsAndSigners implements Signable {
-  constructor(public attestations: CommitteeAttestation[]) {}
+  readonly primaryType: CoordinationSignatureType = 'AttestationsAndSigners';
+
+  constructor(
+    public attestations: CommitteeAttestation[],
+    public readonly signatureContext: CoordinationSignatureContext = EMPTY_COORDINATION_SIGNATURE_CONTEXT,
+  ) {}
 
   static get schema() {
     return z
       .object({
         attestations: CommitteeAttestation.schema.array(),
+        signatureContext: coordinationSignatureContextSchema.default(EMPTY_COORDINATION_SIGNATURE_CONTEXT),
       })
-      .transform(obj => new CommitteeAttestationsAndSigners(obj.attestations));
+      .transform(obj => new CommitteeAttestationsAndSigners(obj.attestations, obj.signatureContext));
   }
 
-  getPayloadToSign(domainSeparator: SignatureDomainSeparator): Buffer {
-    const abi = parseAbiParameters('uint8,(bytes,bytes),address[]');
+  getPayloadToSign(): Buffer {
+    // Matches the L1 abi.encode(attestations, signers) in AttestationLib.sol#getAttestationsAndSignersDigest.
+    const abi = parseAbiParameters('(bytes,bytes),address[]');
     const packed = this.getPackedAttestations();
 
     const encodedData = encodeAbiParameters(abi, [
-      domainSeparator,
       [packed.signatureIndices, packed.signaturesOrAddresses],
       this.getSigners().map(s => s.toString()),
     ]);
@@ -130,8 +142,9 @@ export class MaliciousCommitteeAttestationsAndSigners extends CommitteeAttestati
   constructor(
     attestations: CommitteeAttestation[],
     private signers: EthAddress[],
+    signatureContext: CoordinationSignatureContext = EMPTY_COORDINATION_SIGNATURE_CONTEXT,
   ) {
-    super(attestations);
+    super(attestations, signatureContext);
   }
 
   override getSigners(): EthAddress[] {

--- a/yarn-project/stdlib/src/block/proposal/attestations_and_signers.ts
+++ b/yarn-project/stdlib/src/block/proposal/attestations_and_signers.ts
@@ -7,7 +7,6 @@ import { z } from 'zod';
 import {
   type CoordinationSignatureContext,
   type CoordinationSignatureType,
-  EMPTY_COORDINATION_SIGNATURE_CONTEXT,
   type Signable,
   coordinationSignatureContextSchema,
 } from '../../p2p/signature_utils.js';
@@ -18,14 +17,14 @@ export class CommitteeAttestationsAndSigners implements Signable {
 
   constructor(
     public attestations: CommitteeAttestation[],
-    public readonly signatureContext: CoordinationSignatureContext = EMPTY_COORDINATION_SIGNATURE_CONTEXT,
+    public readonly signatureContext: CoordinationSignatureContext,
   ) {}
 
   static get schema() {
     return z
       .object({
         attestations: CommitteeAttestation.schema.array(),
-        signatureContext: coordinationSignatureContextSchema.default(EMPTY_COORDINATION_SIGNATURE_CONTEXT),
+        signatureContext: coordinationSignatureContextSchema,
       })
       .transform(obj => new CommitteeAttestationsAndSigners(obj.attestations, obj.signatureContext));
   }
@@ -43,8 +42,8 @@ export class CommitteeAttestationsAndSigners implements Signable {
     return hexToBuffer(encodedData);
   }
 
-  static empty(): CommitteeAttestationsAndSigners {
-    return new CommitteeAttestationsAndSigners([]);
+  static empty(signatureContext: CoordinationSignatureContext): CommitteeAttestationsAndSigners {
+    return new CommitteeAttestationsAndSigners([], signatureContext);
   }
 
   toString() {
@@ -65,9 +64,9 @@ export class CommitteeAttestationsAndSigners implements Signable {
    * @param attestations - Array of committee attestations with addresses and signatures
    * @returns Packed attestations with bitmap and tightly packed signature/address data
    */
-  getPackedAttestations(): ViemCommitteeAttestations {
-    const length = this.attestations.length;
-    const attestations = this.attestations.map(a => a.toViem());
+  static packAttestations(attestations: CommitteeAttestation[]): ViemCommitteeAttestations {
+    const length = attestations.length;
+    const viemAttestations = attestations.map(a => a.toViem());
 
     // Calculate bitmap size (1 bit per attestation, rounded up to nearest byte)
     const bitmapSize = Math.ceil(length / 8);
@@ -75,8 +74,8 @@ export class CommitteeAttestationsAndSigners implements Signable {
 
     // Calculate total data size needed
     let totalDataSize = 0;
-    for (let i = 0; i < length; i++) {
-      const signature = attestations[i].signature;
+    for (const attestation of viemAttestations) {
+      const signature = attestation.signature;
       // Check if signature is empty (v = 0)
       const isEmpty = signature.v === 0;
 
@@ -91,8 +90,7 @@ export class CommitteeAttestationsAndSigners implements Signable {
     let dataIndex = 0;
 
     // Pack the data
-    for (let i = 0; i < length; i++) {
-      const attestation = attestations[i];
+    for (const [i, attestation] of viemAttestations.entries()) {
       const signature = attestation.signature;
 
       // Check if signature is empty
@@ -102,7 +100,7 @@ export class CommitteeAttestationsAndSigners implements Signable {
         // Set bit in bitmap (bit 7-0 in each byte, left to right)
         const byteIndex = Math.floor(i / 8);
         const bitIndex = 7 - (i % 8);
-        signatureIndices[byteIndex] |= 1 << bitIndex;
+        signatureIndices[byteIndex] = (signatureIndices[byteIndex] ?? 0) | (1 << bitIndex);
 
         // Pack signature: v + r + s
         signaturesOrAddresses[dataIndex] = signature.v;
@@ -130,6 +128,10 @@ export class CommitteeAttestationsAndSigners implements Signable {
       signaturesOrAddresses: `0x${Buffer.from(signaturesOrAddresses).toString('hex')}`,
     };
   }
+
+  getPackedAttestations(): ViemCommitteeAttestations {
+    return CommitteeAttestationsAndSigners.packAttestations(this.attestations);
+  }
 }
 
 /**
@@ -142,7 +144,7 @@ export class MaliciousCommitteeAttestationsAndSigners extends CommitteeAttestati
   constructor(
     attestations: CommitteeAttestation[],
     private signers: EthAddress[],
-    signatureContext: CoordinationSignatureContext = EMPTY_COORDINATION_SIGNATURE_CONTEXT,
+    signatureContext: CoordinationSignatureContext,
   ) {
     super(attestations, signatureContext);
   }

--- a/yarn-project/stdlib/src/interfaces/aztec-node-admin.test.ts
+++ b/yarn-project/stdlib/src/interfaces/aztec-node-admin.test.ts
@@ -135,6 +135,7 @@ class MockAztecNodeAdmin implements AztecNodeAdmin {
       signingTimeoutMs: 3000,
       maxStuckDutiesAgeMs: 72000,
       dataStoreMapSizeKb: 128 * 1024 * 1024,
+      l1ChainId: 1,
       l1Contracts: {
         rollupAddress: EthAddress.random(),
       },

--- a/yarn-project/stdlib/src/interfaces/validator.ts
+++ b/yarn-project/stdlib/src/interfaces/validator.ts
@@ -19,6 +19,7 @@ import type { PeerId } from '@libp2p/interface';
 import { z } from 'zod';
 
 import type { CommitteeAttestationsAndSigners } from '../block/index.js';
+import type { ChainConfig } from '../config/chain-config.js';
 import {
   type LocalSignerConfig,
   LocalSignerConfigSchema,
@@ -32,6 +33,9 @@ import { AllowedElementSchema } from './allowed_element.js';
  */
 export type ValidatorClientConfig = ValidatorHASignerConfig &
   LocalSignerConfig & {
+    /** The L1 chain id used for EIP-712 proposal-path signing. */
+    l1ChainId: ChainConfig['l1ChainId'];
+
     /** The private keys of the validators participating in attestation duties */
     validatorPrivateKeys?: SecretValue<`0x${string}`[]>;
 
@@ -90,6 +94,7 @@ export type ValidatorClientFullConfig = ValidatorClientConfig &
 
 export const ValidatorClientConfigSchema = zodFor<Omit<ValidatorClientConfig, 'validatorPrivateKeys'>>()(
   ValidatorHASignerConfigSchema.merge(LocalSignerConfigSchema).extend({
+    l1ChainId: z.number().int().nonnegative(),
     validatorAddresses: z.array(schemas.EthAddress).optional(),
     disableValidator: z.boolean(),
     disabledValidators: z.array(schemas.EthAddress),

--- a/yarn-project/stdlib/src/p2p/attestation_utils.test.ts
+++ b/yarn-project/stdlib/src/p2p/attestation_utils.test.ts
@@ -5,19 +5,32 @@ import { Fr } from '@aztec/foundation/curves/bn254';
 import { jest } from '@jest/globals';
 
 import { CheckpointHeader } from '../rollup/index.js';
+import { TEST_COORDINATION_SIGNATURE_CONTEXT } from '../tests/mocks.js';
 import { trimAttestations } from './attestation_utils.js';
 import { CheckpointAttestation } from './checkpoint_attestation.js';
+import { CheckpointProposal } from './checkpoint_proposal.js';
 import { ConsensusPayload } from './consensus_payload.js';
-import { SignatureDomainSeparator, getHashedSignaturePayloadEthSignedMessage } from './signature_utils.js';
+import { SignatureDomainSeparator, getHashedSignaturePayloadTypedData } from './signature_utils.js';
 
 function makeAttestation(signer: Secp256k1Signer): CheckpointAttestation {
   const header = CheckpointHeader.random({ slotNumber: SlotNumber(0) });
   const payload = new ConsensusPayload(header, Fr.random(), 0n);
-  const attestationHash = getHashedSignaturePayloadEthSignedMessage(
+  const attestationHash = getHashedSignaturePayloadTypedData(
     payload,
     SignatureDomainSeparator.checkpointAttestation,
+    TEST_COORDINATION_SIGNATURE_CONTEXT,
   );
-  const proposalHash = getHashedSignaturePayloadEthSignedMessage(payload, SignatureDomainSeparator.checkpointProposal);
+  const proposal = new CheckpointProposal(
+    header,
+    payload.archive,
+    payload.feeAssetPriceModifier,
+    signer.sign(attestationHash),
+  );
+  const proposalHash = getHashedSignaturePayloadTypedData(
+    proposal,
+    SignatureDomainSeparator.checkpointProposal,
+    TEST_COORDINATION_SIGNATURE_CONTEXT,
+  );
   return new CheckpointAttestation(payload, signer.sign(attestationHash), signer.sign(proposalHash));
 }
 
@@ -36,6 +49,7 @@ describe('trimAttestations', () => {
       3,
       proposer.address,
       [],
+      TEST_COORDINATION_SIGNATURE_CONTEXT,
     );
 
     expect(result).toHaveLength(3);
@@ -50,6 +64,7 @@ describe('trimAttestations', () => {
       3,
       proposer.address,
       [],
+      TEST_COORDINATION_SIGNATURE_CONTEXT,
     );
 
     expect(result).toHaveLength(3);
@@ -65,10 +80,11 @@ describe('trimAttestations', () => {
       3,
       proposer.address,
       [],
+      TEST_COORDINATION_SIGNATURE_CONTEXT,
     );
 
     expect(result).toHaveLength(3);
-    const resultSenders = result.map(a => a.getSender()!.toString());
+    const resultSenders = result.map(a => a.getSender(TEST_COORDINATION_SIGNATURE_CONTEXT)!.toString());
     expect(resultSenders).toContain(proposer.address.toString());
   });
 
@@ -82,10 +98,16 @@ describe('trimAttestations', () => {
     const allAttestations = [proposer, local1, local2, external1, external2].map(i => i.attestation);
     const localAddresses = [local1.address, local2.address];
 
-    const result = trimAttestations(allAttestations, 3, proposer.address, localAddresses);
+    const result = trimAttestations(
+      allAttestations,
+      3,
+      proposer.address,
+      localAddresses,
+      TEST_COORDINATION_SIGNATURE_CONTEXT,
+    );
 
     expect(result).toHaveLength(3);
-    const resultSenders = new Set(result.map(a => a.getSender()!.toString()));
+    const resultSenders = new Set(result.map(a => a.getSender(TEST_COORDINATION_SIGNATURE_CONTEXT)!.toString()));
     expect(resultSenders.has(proposer.address.toString())).toBe(true);
     expect(resultSenders.has(local1.address.toString())).toBe(true);
     expect(resultSenders.has(local2.address.toString())).toBe(true);
@@ -102,10 +124,16 @@ describe('trimAttestations', () => {
 
     const allAttestations = [proposer, local1, external1, external2, external3].map(i => i.attestation);
 
-    const result = trimAttestations(allAttestations, 3, proposer.address, [local1.address]);
+    const result = trimAttestations(
+      allAttestations,
+      3,
+      proposer.address,
+      [local1.address],
+      TEST_COORDINATION_SIGNATURE_CONTEXT,
+    );
 
     expect(result).toHaveLength(3);
-    const resultSenders = new Set(result.map(a => a.getSender()!.toString()));
+    const resultSenders = new Set(result.map(a => a.getSender(TEST_COORDINATION_SIGNATURE_CONTEXT)!.toString()));
     expect(resultSenders.has(proposer.address.toString())).toBe(true);
     expect(resultSenders.has(local1.address.toString())).toBe(true);
     // One external fills the remaining slot
@@ -123,10 +151,16 @@ describe('trimAttestations', () => {
     // Proposer address is also listed in local addresses
     const localAddresses = [proposer.address, local1.address];
 
-    const result = trimAttestations(allAttestations, 3, proposer.address, localAddresses);
+    const result = trimAttestations(
+      allAttestations,
+      3,
+      proposer.address,
+      localAddresses,
+      TEST_COORDINATION_SIGNATURE_CONTEXT,
+    );
 
     expect(result).toHaveLength(3);
-    const resultSenders = result.map(a => a.getSender()!.toString());
+    const resultSenders = result.map(a => a.getSender(TEST_COORDINATION_SIGNATURE_CONTEXT)!.toString());
     // Proposer should appear exactly once
     expect(resultSenders.filter(s => s === proposer.address.toString())).toHaveLength(1);
     expect(resultSenders).toContain(local1.address.toString());
@@ -142,10 +176,10 @@ describe('trimAttestations', () => {
 
     const allAttestations = [proposer.attestation, valid.attestation, badAttestation, external1.attestation];
 
-    const result = trimAttestations(allAttestations, 3, proposer.address, []);
+    const result = trimAttestations(allAttestations, 3, proposer.address, [], TEST_COORDINATION_SIGNATURE_CONTEXT);
 
     expect(result).toHaveLength(3);
-    const resultSenders = result.map(a => a.getSender()?.toString()).filter(Boolean);
+    const resultSenders = result.map(a => a.getSender(TEST_COORDINATION_SIGNATURE_CONTEXT)?.toString()).filter(Boolean);
     expect(resultSenders).toHaveLength(3);
   });
 });

--- a/yarn-project/stdlib/src/p2p/attestation_utils.test.ts
+++ b/yarn-project/stdlib/src/p2p/attestation_utils.test.ts
@@ -10,27 +10,20 @@ import { trimAttestations } from './attestation_utils.js';
 import { CheckpointAttestation } from './checkpoint_attestation.js';
 import { CheckpointProposal } from './checkpoint_proposal.js';
 import { ConsensusPayload } from './consensus_payload.js';
-import { SignatureDomainSeparator, getHashedSignaturePayloadTypedData } from './signature_utils.js';
+import { getHashedSignaturePayloadTypedData } from './signature_utils.js';
 
 function makeAttestation(signer: Secp256k1Signer): CheckpointAttestation {
   const header = CheckpointHeader.random({ slotNumber: SlotNumber(0) });
-  const payload = new ConsensusPayload(header, Fr.random(), 0n);
-  const attestationHash = getHashedSignaturePayloadTypedData(
-    payload,
-    SignatureDomainSeparator.checkpointAttestation,
-    TEST_COORDINATION_SIGNATURE_CONTEXT,
-  );
+  const payload = new ConsensusPayload(header, Fr.random(), 0n, TEST_COORDINATION_SIGNATURE_CONTEXT);
+  const attestationHash = getHashedSignaturePayloadTypedData(payload);
   const proposal = new CheckpointProposal(
     header,
     payload.archive,
     payload.feeAssetPriceModifier,
     signer.sign(attestationHash),
-  );
-  const proposalHash = getHashedSignaturePayloadTypedData(
-    proposal,
-    SignatureDomainSeparator.checkpointProposal,
     TEST_COORDINATION_SIGNATURE_CONTEXT,
   );
+  const proposalHash = getHashedSignaturePayloadTypedData(proposal);
   return new CheckpointAttestation(payload, signer.sign(attestationHash), signer.sign(proposalHash));
 }
 
@@ -49,7 +42,6 @@ describe('trimAttestations', () => {
       3,
       proposer.address,
       [],
-      TEST_COORDINATION_SIGNATURE_CONTEXT,
     );
 
     expect(result).toHaveLength(3);
@@ -64,7 +56,6 @@ describe('trimAttestations', () => {
       3,
       proposer.address,
       [],
-      TEST_COORDINATION_SIGNATURE_CONTEXT,
     );
 
     expect(result).toHaveLength(3);
@@ -80,11 +71,10 @@ describe('trimAttestations', () => {
       3,
       proposer.address,
       [],
-      TEST_COORDINATION_SIGNATURE_CONTEXT,
     );
 
     expect(result).toHaveLength(3);
-    const resultSenders = result.map(a => a.getSender(TEST_COORDINATION_SIGNATURE_CONTEXT)!.toString());
+    const resultSenders = result.map(a => a.getSender()!.toString());
     expect(resultSenders).toContain(proposer.address.toString());
   });
 
@@ -98,16 +88,10 @@ describe('trimAttestations', () => {
     const allAttestations = [proposer, local1, local2, external1, external2].map(i => i.attestation);
     const localAddresses = [local1.address, local2.address];
 
-    const result = trimAttestations(
-      allAttestations,
-      3,
-      proposer.address,
-      localAddresses,
-      TEST_COORDINATION_SIGNATURE_CONTEXT,
-    );
+    const result = trimAttestations(allAttestations, 3, proposer.address, localAddresses);
 
     expect(result).toHaveLength(3);
-    const resultSenders = new Set(result.map(a => a.getSender(TEST_COORDINATION_SIGNATURE_CONTEXT)!.toString()));
+    const resultSenders = new Set(result.map(a => a.getSender()!.toString()));
     expect(resultSenders.has(proposer.address.toString())).toBe(true);
     expect(resultSenders.has(local1.address.toString())).toBe(true);
     expect(resultSenders.has(local2.address.toString())).toBe(true);
@@ -124,16 +108,10 @@ describe('trimAttestations', () => {
 
     const allAttestations = [proposer, local1, external1, external2, external3].map(i => i.attestation);
 
-    const result = trimAttestations(
-      allAttestations,
-      3,
-      proposer.address,
-      [local1.address],
-      TEST_COORDINATION_SIGNATURE_CONTEXT,
-    );
+    const result = trimAttestations(allAttestations, 3, proposer.address, [local1.address]);
 
     expect(result).toHaveLength(3);
-    const resultSenders = new Set(result.map(a => a.getSender(TEST_COORDINATION_SIGNATURE_CONTEXT)!.toString()));
+    const resultSenders = new Set(result.map(a => a.getSender()!.toString()));
     expect(resultSenders.has(proposer.address.toString())).toBe(true);
     expect(resultSenders.has(local1.address.toString())).toBe(true);
     // One external fills the remaining slot
@@ -151,16 +129,10 @@ describe('trimAttestations', () => {
     // Proposer address is also listed in local addresses
     const localAddresses = [proposer.address, local1.address];
 
-    const result = trimAttestations(
-      allAttestations,
-      3,
-      proposer.address,
-      localAddresses,
-      TEST_COORDINATION_SIGNATURE_CONTEXT,
-    );
+    const result = trimAttestations(allAttestations, 3, proposer.address, localAddresses);
 
     expect(result).toHaveLength(3);
-    const resultSenders = result.map(a => a.getSender(TEST_COORDINATION_SIGNATURE_CONTEXT)!.toString());
+    const resultSenders = result.map(a => a.getSender()!.toString());
     // Proposer should appear exactly once
     expect(resultSenders.filter(s => s === proposer.address.toString())).toHaveLength(1);
     expect(resultSenders).toContain(local1.address.toString());
@@ -176,10 +148,10 @@ describe('trimAttestations', () => {
 
     const allAttestations = [proposer.attestation, valid.attestation, badAttestation, external1.attestation];
 
-    const result = trimAttestations(allAttestations, 3, proposer.address, [], TEST_COORDINATION_SIGNATURE_CONTEXT);
+    const result = trimAttestations(allAttestations, 3, proposer.address, []);
 
     expect(result).toHaveLength(3);
-    const resultSenders = result.map(a => a.getSender(TEST_COORDINATION_SIGNATURE_CONTEXT)?.toString()).filter(Boolean);
+    const resultSenders = result.map(a => a.getSender()?.toString()).filter(Boolean);
     expect(resultSenders).toHaveLength(3);
   });
 });

--- a/yarn-project/stdlib/src/p2p/attestation_utils.ts
+++ b/yarn-project/stdlib/src/p2p/attestation_utils.ts
@@ -2,7 +2,6 @@ import type { EthAddress } from '@aztec/foundation/eth-address';
 
 import { CommitteeAttestation } from '../block/index.js';
 import type { CheckpointAttestation } from './checkpoint_attestation.js';
-import type { CoordinationSignatureContext } from './signature_utils.js';
 
 /**
  * Returns attestation signatures in the order of a series of provided ethereum addresses
@@ -12,13 +11,12 @@ import type { CoordinationSignatureContext } from './signature_utils.js';
 export function orderAttestations(
   attestations: CheckpointAttestation[],
   orderAddresses: EthAddress[],
-  signatureContext: CoordinationSignatureContext,
 ): CommitteeAttestation[] {
   // Create a map of sender addresses to attestations
   const attestationMap = new Map<string, CommitteeAttestation>();
 
   for (const attestation of attestations) {
-    const sender = attestation.getSender(signatureContext);
+    const sender = attestation.getSender();
     if (sender) {
       attestationMap.set(
         sender.toString(),
@@ -50,7 +48,6 @@ export function trimAttestations(
   required: number,
   proposerAddress: EthAddress,
   localAddresses: EthAddress[],
-  signatureContext: CoordinationSignatureContext,
 ): CheckpointAttestation[] {
   if (attestations.length <= required) {
     return attestations;
@@ -61,7 +58,7 @@ export function trimAttestations(
   const otherAttestations: CheckpointAttestation[] = [];
 
   for (const attestation of attestations) {
-    const sender = attestation.getSender(signatureContext);
+    const sender = attestation.getSender();
     if (!sender) {
       continue;
     }

--- a/yarn-project/stdlib/src/p2p/attestation_utils.ts
+++ b/yarn-project/stdlib/src/p2p/attestation_utils.ts
@@ -2,6 +2,7 @@ import type { EthAddress } from '@aztec/foundation/eth-address';
 
 import { CommitteeAttestation } from '../block/index.js';
 import type { CheckpointAttestation } from './checkpoint_attestation.js';
+import type { CoordinationSignatureContext } from './signature_utils.js';
 
 /**
  * Returns attestation signatures in the order of a series of provided ethereum addresses
@@ -11,12 +12,13 @@ import type { CheckpointAttestation } from './checkpoint_attestation.js';
 export function orderAttestations(
   attestations: CheckpointAttestation[],
   orderAddresses: EthAddress[],
+  signatureContext: CoordinationSignatureContext,
 ): CommitteeAttestation[] {
   // Create a map of sender addresses to attestations
   const attestationMap = new Map<string, CommitteeAttestation>();
 
   for (const attestation of attestations) {
-    const sender = attestation.getSender();
+    const sender = attestation.getSender(signatureContext);
     if (sender) {
       attestationMap.set(
         sender.toString(),
@@ -48,6 +50,7 @@ export function trimAttestations(
   required: number,
   proposerAddress: EthAddress,
   localAddresses: EthAddress[],
+  signatureContext: CoordinationSignatureContext,
 ): CheckpointAttestation[] {
   if (attestations.length <= required) {
     return attestations;
@@ -58,7 +61,7 @@ export function trimAttestations(
   const otherAttestations: CheckpointAttestation[] = [];
 
   for (const attestation of attestations) {
-    const sender = attestation.getSender();
+    const sender = attestation.getSender(signatureContext);
     if (!sender) {
       continue;
     }

--- a/yarn-project/stdlib/src/p2p/block_proposal.test.ts
+++ b/yarn-project/stdlib/src/p2p/block_proposal.test.ts
@@ -1,9 +1,11 @@
 // Serde test for the block proposal type
 import { Secp256k1Signer } from '@aztec/foundation/crypto/secp256k1-signer';
+import { Signature } from '@aztec/foundation/eth-signature';
 
 import { TEST_COORDINATION_SIGNATURE_CONTEXT, makeBlockProposal } from '../tests/mocks.js';
 import { Tx } from '../tx/tx.js';
 import { BlockProposal } from './block_proposal.js';
+import { SignedTxs } from './signed_txs.js';
 
 describe('Block Proposal serialization / deserialization', () => {
   const checkEquivalence = (serialized: BlockProposal, deserialized: BlockProposal) => {
@@ -56,7 +58,7 @@ describe('Block Proposal serialization / deserialization', () => {
     checkEquivalence(proposal, deserialized);
 
     // Recover signature
-    const sender = deserialized.getSender(TEST_COORDINATION_SIGNATURE_CONTEXT);
+    const sender = deserialized.getSender();
     expect(sender).toEqual(account.address);
   });
 
@@ -65,5 +67,29 @@ describe('Block Proposal serialization / deserialization', () => {
 
     expect(proposal.slotNumber).toBe(proposal.blockHeader.getSlot());
     expect(proposal.blockNumber).toBe(proposal.blockHeader.getBlockNumber());
+  });
+
+  it('getSender returns undefined when inner signedTxs carries a foreign signing domain', async () => {
+    const account = Secp256k1Signer.random();
+    const txs = await Promise.all([Tx.random(), Tx.random()]);
+    const proposal = await makeBlockProposal({ txs, signer: account });
+
+    const foreignContext = {
+      ...TEST_COORDINATION_SIGNATURE_CONTEXT,
+      chainId: TEST_COORDINATION_SIGNATURE_CONTEXT.chainId + 1,
+    };
+    const foreignSignedTxs = new SignedTxs(txs, Signature.random(), foreignContext);
+    const tampered = new BlockProposal(
+      proposal.blockHeader,
+      proposal.indexWithinCheckpoint,
+      proposal.inHash,
+      proposal.archiveRoot,
+      proposal.txHashes,
+      proposal.signature,
+      proposal.signatureContext,
+      foreignSignedTxs,
+    );
+
+    expect(tampered.getSender()).toBeUndefined();
   });
 });

--- a/yarn-project/stdlib/src/p2p/block_proposal.test.ts
+++ b/yarn-project/stdlib/src/p2p/block_proposal.test.ts
@@ -1,7 +1,7 @@
 // Serde test for the block proposal type
 import { Secp256k1Signer } from '@aztec/foundation/crypto/secp256k1-signer';
 
-import { makeBlockProposal } from '../tests/mocks.js';
+import { TEST_COORDINATION_SIGNATURE_CONTEXT, makeBlockProposal } from '../tests/mocks.js';
 import { Tx } from '../tx/tx.js';
 import { BlockProposal } from './block_proposal.js';
 
@@ -56,7 +56,7 @@ describe('Block Proposal serialization / deserialization', () => {
     checkEquivalence(proposal, deserialized);
 
     // Recover signature
-    const sender = deserialized.getSender();
+    const sender = deserialized.getSender(TEST_COORDINATION_SIGNATURE_CONTEXT);
     expect(sender).toEqual(account.address);
   });
 

--- a/yarn-project/stdlib/src/p2p/block_proposal.ts
+++ b/yarn-project/stdlib/src/p2p/block_proposal.ts
@@ -7,11 +7,12 @@ import {
 } from '@aztec/foundation/branded-types';
 import { type BaseBuffer32, Buffer32 } from '@aztec/foundation/buffer';
 import { keccak256 } from '@aztec/foundation/crypto/keccak';
-import { tryRecoverAddress } from '@aztec/foundation/crypto/secp256k1-signer';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import type { EthAddress } from '@aztec/foundation/eth-address';
 import { Signature } from '@aztec/foundation/eth-signature';
 import { BufferReader, serializeToBuffer } from '@aztec/foundation/serialize';
+
+import type { TypedDataDefinition } from 'viem';
 
 import type { L2Block } from '../block/l2_block.js';
 import type { L2BlockInfo } from '../block/l2_block_info.js';
@@ -22,9 +23,11 @@ import { TxHash } from '../tx/index.js';
 import type { Tx } from '../tx/tx.js';
 import { Gossipable } from './gossipable.js';
 import {
+  type CoordinationSignatureContext,
   SignatureDomainSeparator,
-  getHashedSignaturePayload,
-  getHashedSignaturePayloadEthSignedMessage,
+  getCoordinationSignatureContextKey,
+  getCoordinationSignatureTypedData,
+  recoverCoordinationSigner,
 } from './signature_utils.js';
 import { SignedTxs } from './signed_txs.js';
 import { TopicType } from './topic_type.js';
@@ -52,7 +55,12 @@ export type BlockProposalOptions = {
 export class BlockProposal extends Gossipable {
   static override p2pTopic = TopicType.block_proposal;
 
-  private sender: EthAddress | undefined;
+  private senderCache:
+    | {
+        key: string;
+        sender: EthAddress | undefined;
+      }
+    | undefined;
 
   constructor(
     /** The per-block header containing block state and global variables */
@@ -134,7 +142,9 @@ export class BlockProposal extends Gossipable {
     archiveRoot: Fr,
     txHashes: TxHash[],
     txs: Tx[] | undefined,
-    payloadSigner: (payload: Buffer32, context: SigningContext) => Promise<Signature>,
+    signatureContext: CoordinationSignatureContext,
+    proposalSigner: (typedData: TypedDataDefinition, context: SigningContext) => Promise<Signature>,
+    txsSigner?: (payload: Buffer32, context: SigningContext) => Promise<Signature>,
   ): Promise<BlockProposal> {
     // Create a temporary proposal to get the payload to sign
     const tempProposal = new BlockProposal(
@@ -155,15 +165,21 @@ export class BlockProposal extends Gossipable {
       dutyType: DutyType.BLOCK_PROPOSAL,
     };
 
-    const hashed = getHashedSignaturePayload(tempProposal, SignatureDomainSeparator.blockProposal);
-    const sig = await payloadSigner(hashed, blockContext);
+    const typedData = getCoordinationSignatureTypedData(
+      tempProposal,
+      SignatureDomainSeparator.blockProposal,
+      signatureContext,
+    );
+    const sig = await proposalSigner(typedData, blockContext);
 
     // If txs are provided, sign them as well
     let signedTxs: SignedTxs | undefined;
     if (txs) {
       const txsSigningContext: SigningContext = { dutyType: DutyType.TXS };
-      const txsSigner = (payload: Buffer32) => payloadSigner(payload, txsSigningContext);
-      signedTxs = await SignedTxs.createFromSigner(txs, txsSigner);
+      if (!txsSigner) {
+        throw new Error('signed_txs requires a message signer');
+      }
+      signedTxs = await SignedTxs.createFromSigner(txs, payload => txsSigner(payload, txsSigningContext));
     }
 
     return new BlockProposal(blockHeader, indexWithinCheckpoint, inHash, archiveRoot, txHashes, sig, signedTxs);
@@ -174,10 +190,15 @@ export class BlockProposal extends Gossipable {
    * If there's signedTxs, also verifies the signedTxs sender matches the block proposal sender.
    * @returns The sender address, or undefined if signature recovery fails or senders don't match
    */
-  getSender(): EthAddress | undefined {
-    if (!this.sender) {
-      const hashed = getHashedSignaturePayloadEthSignedMessage(this, SignatureDomainSeparator.blockProposal);
-      const blockSender = tryRecoverAddress(hashed, this.signature);
+  getSender(signatureContext: CoordinationSignatureContext): EthAddress | undefined {
+    const cacheKey = getCoordinationSignatureContextKey(signatureContext);
+    if (!this.senderCache || this.senderCache.key !== cacheKey) {
+      const blockSender = recoverCoordinationSigner(
+        this,
+        SignatureDomainSeparator.blockProposal,
+        this.signature,
+        signatureContext,
+      );
 
       // If there's signedTxs, verify the sender matches
       if (blockSender && this.signedTxs) {
@@ -188,10 +209,10 @@ export class BlockProposal extends Gossipable {
       }
 
       // Cache the sender for later use
-      this.sender = blockSender;
+      this.senderCache = { key: cacheKey, sender: blockSender };
     }
 
-    return this.sender;
+    return this.senderCache.sender;
   }
 
   getPayload() {

--- a/yarn-project/stdlib/src/p2p/block_proposal.ts
+++ b/yarn-project/stdlib/src/p2p/block_proposal.ts
@@ -5,7 +5,7 @@ import {
   IndexWithinCheckpoint,
   SlotNumber,
 } from '@aztec/foundation/branded-types';
-import { type BaseBuffer32, Buffer32 } from '@aztec/foundation/buffer';
+import type { BaseBuffer32 } from '@aztec/foundation/buffer';
 import { keccak256 } from '@aztec/foundation/crypto/keccak';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import type { EthAddress } from '@aztec/foundation/eth-address';
@@ -24,10 +24,14 @@ import type { Tx } from '../tx/tx.js';
 import { Gossipable } from './gossipable.js';
 import {
   type CoordinationSignatureContext,
-  SignatureDomainSeparator,
-  getCoordinationSignatureContextKey,
+  type CoordinationSignatureType,
+  EMPTY_COORDINATION_SIGNATURE_CONTEXT,
+  type Signable,
+  coordinationSignatureContextEquals,
   getCoordinationSignatureTypedData,
+  readCoordinationSignatureContext,
   recoverCoordinationSigner,
+  serializeCoordinationSignatureContext,
 } from './signature_utils.js';
 import { SignedTxs } from './signed_txs.js';
 import { TopicType } from './topic_type.js';
@@ -52,15 +56,12 @@ export type BlockProposalOptions = {
  * to be included in a block within a checkpoint. This is used for non-last blocks in a slot.
  * The last block is sent as part of a CheckpointProposal.
  */
-export class BlockProposal extends Gossipable {
+export class BlockProposal extends Gossipable implements Signable {
   static override p2pTopic = TopicType.block_proposal;
 
-  private senderCache:
-    | {
-        key: string;
-        sender: EthAddress | undefined;
-      }
-    | undefined;
+  readonly primaryType: CoordinationSignatureType = 'BlockProposal';
+
+  private cachedSender: EthAddress | undefined | null = null;
 
   constructor(
     /** The per-block header containing block state and global variables */
@@ -80,6 +81,9 @@ export class BlockProposal extends Gossipable {
 
     /** The proposer's signature over the block data */
     public readonly signature: Signature,
+
+    /** The signing domain (chainId + rollupAddress) the signature is bound to */
+    public readonly signatureContext: CoordinationSignatureContext,
 
     /** The signed transactions in the block (optional, for DA guarantees) */
     public readonly signedTxs?: SignedTxs,
@@ -122,9 +126,8 @@ export class BlockProposal extends Gossipable {
    * Get the payload to sign for this block proposal.
    * The signature is over: blockHeader + indexWithinCheckpoint + inHash + archiveRoot + txHashes
    */
-  getPayloadToSign(domainSeparator: SignatureDomainSeparator): Buffer {
+  getPayloadToSign(): Buffer {
     return serializeToBuffer([
-      domainSeparator,
       this.blockHeader,
       this.indexWithinCheckpoint,
       this.inHash,
@@ -144,7 +147,7 @@ export class BlockProposal extends Gossipable {
     txs: Tx[] | undefined,
     signatureContext: CoordinationSignatureContext,
     proposalSigner: (typedData: TypedDataDefinition, context: SigningContext) => Promise<Signature>,
-    txsSigner?: (payload: Buffer32, context: SigningContext) => Promise<Signature>,
+    txsSigner?: (typedData: TypedDataDefinition, context: SigningContext) => Promise<Signature>,
   ): Promise<BlockProposal> {
     // Create a temporary proposal to get the payload to sign
     const tempProposal = new BlockProposal(
@@ -154,6 +157,7 @@ export class BlockProposal extends Gossipable {
       archiveRoot,
       txHashes,
       Signature.empty(),
+      signatureContext,
     );
 
     // Create the block signing context
@@ -165,11 +169,7 @@ export class BlockProposal extends Gossipable {
       dutyType: DutyType.BLOCK_PROPOSAL,
     };
 
-    const typedData = getCoordinationSignatureTypedData(
-      tempProposal,
-      SignatureDomainSeparator.blockProposal,
-      signatureContext,
-    );
+    const typedData = getCoordinationSignatureTypedData(tempProposal);
     const sig = await proposalSigner(typedData, blockContext);
 
     // If txs are provided, sign them as well
@@ -177,46 +177,56 @@ export class BlockProposal extends Gossipable {
     if (txs) {
       const txsSigningContext: SigningContext = { dutyType: DutyType.TXS };
       if (!txsSigner) {
-        throw new Error('signed_txs requires a message signer');
+        throw new Error('signed_txs requires a typed-data signer');
       }
-      signedTxs = await SignedTxs.createFromSigner(txs, payload => txsSigner(payload, txsSigningContext));
+      signedTxs = await SignedTxs.createFromSigner(txs, signatureContext, typedData =>
+        txsSigner(typedData, txsSigningContext),
+      );
     }
 
-    return new BlockProposal(blockHeader, indexWithinCheckpoint, inHash, archiveRoot, txHashes, sig, signedTxs);
+    return new BlockProposal(
+      blockHeader,
+      indexWithinCheckpoint,
+      inHash,
+      archiveRoot,
+      txHashes,
+      sig,
+      signatureContext,
+      signedTxs,
+    );
   }
 
   /**
    * Lazily evaluate the sender of the proposal; result is cached.
-   * If there's signedTxs, also verifies the signedTxs sender matches the block proposal sender.
-   * @returns The sender address, or undefined if signature recovery fails or senders don't match
+   * If there's signedTxs, also verifies that its signing domain matches this proposal's and
+   * that the signedTxs sender matches the block proposal sender. This prevents a proposer
+   * from wrapping a foreign-chain SignedTxs bundle inside a local-chain proposal.
+   * @returns The sender address, or undefined if signature recovery fails or inner/outer mismatch
    */
-  getSender(signatureContext: CoordinationSignatureContext): EthAddress | undefined {
-    const cacheKey = getCoordinationSignatureContextKey(signatureContext);
-    if (!this.senderCache || this.senderCache.key !== cacheKey) {
-      const blockSender = recoverCoordinationSigner(
-        this,
-        SignatureDomainSeparator.blockProposal,
-        this.signature,
-        signatureContext,
-      );
+  getSender(): EthAddress | undefined {
+    if (this.cachedSender === null) {
+      const blockSender = recoverCoordinationSigner(this, this.signature);
 
-      // If there's signedTxs, verify the sender matches
       if (blockSender && this.signedTxs) {
+        if (!coordinationSignatureContextEquals(this.signedTxs.signatureContext, this.signatureContext)) {
+          this.cachedSender = undefined;
+          return undefined;
+        }
         const txsSender = this.signedTxs.getSender();
         if (!txsSender || !txsSender.equals(blockSender)) {
-          return undefined; // Sender mismatch - fail
+          this.cachedSender = undefined;
+          return undefined;
         }
       }
 
-      // Cache the sender for later use
-      this.senderCache = { key: cacheKey, sender: blockSender };
+      this.cachedSender = blockSender;
     }
 
-    return this.senderCache.sender;
+    return this.cachedSender;
   }
 
   getPayload() {
-    return this.getPayloadToSign(SignatureDomainSeparator.blockProposal);
+    return this.getPayloadToSign();
   }
 
   toBuffer(): Buffer {
@@ -226,6 +236,7 @@ export class BlockProposal extends Gossipable {
       this.inHash,
       this.archiveRoot,
       this.signature,
+      serializeCoordinationSignatureContext(this.signatureContext),
       this.txHashes.length,
       this.txHashes,
     ];
@@ -246,6 +257,7 @@ export class BlockProposal extends Gossipable {
     const inHash = reader.readObject(Fr);
     const archiveRoot = reader.readObject(Fr);
     const signature = reader.readObject(Signature);
+    const signatureContext = readCoordinationSignatureContext(reader);
     const txHashCount = reader.readNumber();
     if (txHashCount > MAX_TXS_PER_BLOCK) {
       throw new Error(`txHashes count ${txHashCount} exceeds maximum ${MAX_TXS_PER_BLOCK}`);
@@ -263,12 +275,21 @@ export class BlockProposal extends Gossipable {
           archiveRoot,
           txHashes,
           signature,
+          signatureContext,
           signedTxs,
         );
       }
     }
 
-    return new BlockProposal(blockHeader, indexWithinCheckpoint, inHash, archiveRoot, txHashes, signature);
+    return new BlockProposal(
+      blockHeader,
+      indexWithinCheckpoint,
+      inHash,
+      archiveRoot,
+      txHashes,
+      signature,
+      signatureContext,
+    );
   }
 
   getSize(): number {
@@ -278,6 +299,8 @@ export class BlockProposal extends Gossipable {
       this.inHash.size +
       this.archiveRoot.size +
       this.signature.getSize() +
+      4 /* chainId */ +
+      20 /* rollupAddress */ +
       4 /* txHashes.length */ +
       this.txHashes.length * TxHash.SIZE +
       4 /* hasSignedTxs flag */ +
@@ -286,7 +309,15 @@ export class BlockProposal extends Gossipable {
   }
 
   static empty(): BlockProposal {
-    return new BlockProposal(BlockHeader.empty(), IndexWithinCheckpoint(0), Fr.ZERO, Fr.ZERO, [], Signature.empty());
+    return new BlockProposal(
+      BlockHeader.empty(),
+      IndexWithinCheckpoint(0),
+      Fr.ZERO,
+      Fr.ZERO,
+      [],
+      Signature.empty(),
+      EMPTY_COORDINATION_SIGNATURE_CONTEXT,
+    );
   }
 
   static random(): BlockProposal {
@@ -297,6 +328,7 @@ export class BlockProposal extends Gossipable {
       Fr.random(),
       [TxHash.random(), TxHash.random()],
       Signature.random(),
+      EMPTY_COORDINATION_SIGNATURE_CONTEXT,
     );
   }
 
@@ -308,6 +340,8 @@ export class BlockProposal extends Gossipable {
       archiveRoot: this.archiveRoot.toString(),
       signature: this.signature.toString(),
       txHashes: this.txHashes.map(h => h.toString()),
+      chainId: this.signatureContext.chainId,
+      rollupAddress: this.signatureContext.rollupAddress.toString(),
     };
   }
 
@@ -333,6 +367,7 @@ export class BlockProposal extends Gossipable {
       this.archiveRoot,
       this.txHashes,
       this.signature,
+      this.signatureContext,
     );
   }
 }

--- a/yarn-project/stdlib/src/p2p/block_proposal.ts
+++ b/yarn-project/stdlib/src/p2p/block_proposal.ts
@@ -61,7 +61,7 @@ export class BlockProposal extends Gossipable implements Signable {
 
   readonly primaryType: CoordinationSignatureType = 'BlockProposal';
 
-  private cachedSender: EthAddress | undefined | null = null;
+  private cachedSender: EthAddress | undefined | null = undefined;
 
   constructor(
     /** The per-block header containing block state and global variables */
@@ -204,25 +204,25 @@ export class BlockProposal extends Gossipable implements Signable {
    * @returns The sender address, or undefined if signature recovery fails or inner/outer mismatch
    */
   getSender(): EthAddress | undefined {
-    if (this.cachedSender === null) {
+    if (this.cachedSender === undefined) {
       const blockSender = recoverCoordinationSigner(this, this.signature);
 
       if (blockSender && this.signedTxs) {
         if (!coordinationSignatureContextEquals(this.signedTxs.signatureContext, this.signatureContext)) {
-          this.cachedSender = undefined;
+          this.cachedSender = null;
           return undefined;
         }
         const txsSender = this.signedTxs.getSender();
         if (!txsSender || !txsSender.equals(blockSender)) {
-          this.cachedSender = undefined;
+          this.cachedSender = null;
           return undefined;
         }
       }
 
-      this.cachedSender = blockSender;
+      this.cachedSender = blockSender ?? null;
     }
 
-    return this.cachedSender;
+    return this.cachedSender ?? undefined;
   }
 
   getPayload() {

--- a/yarn-project/stdlib/src/p2p/checkpoint_attestation.ts
+++ b/yarn-project/stdlib/src/p2p/checkpoint_attestation.ts
@@ -12,12 +12,7 @@ import type { ZodFor } from '../schemas/index.js';
 import { CheckpointProposal } from './checkpoint_proposal.js';
 import { ConsensusPayload } from './consensus_payload.js';
 import { Gossipable } from './gossipable.js';
-import {
-  type CoordinationSignatureContext,
-  SignatureDomainSeparator,
-  getCoordinationSignatureContextKey,
-  recoverCoordinationSigner,
-} from './signature_utils.js';
+import { type CoordinationSignatureContext, recoverCoordinationSigner } from './signature_utils.js';
 import { TopicType } from './topic_type.js';
 
 export type { CheckpointAttestationHash } from '@aztec/foundation/branded-types';
@@ -31,18 +26,8 @@ export type { CheckpointAttestationHash } from '@aztec/foundation/branded-types'
 export class CheckpointAttestation extends Gossipable {
   static override p2pTopic = TopicType.checkpoint_attestation;
 
-  private senderCache:
-    | {
-        key: string;
-        sender: EthAddress | undefined;
-      }
-    | undefined;
-  private proposerCache:
-    | {
-        key: string;
-        proposer: EthAddress | undefined;
-      }
-    | undefined;
+  private cachedSender: EthAddress | undefined | null = null;
+  private cachedProposer: EthAddress | undefined | null = null;
 
   constructor(
     /** The payload of the message, and what the signature is over */
@@ -79,32 +64,27 @@ export class CheckpointAttestation extends Gossipable {
     return this.payload.header.slotNumber;
   }
 
+  get signatureContext(): CoordinationSignatureContext {
+    return this.payload.signatureContext;
+  }
+
   /**
    * Lazily evaluate and cache the signer of the attestation
    * @returns The signer of the attestation, or undefined if signature recovery fails
    */
-  getSender(signatureContext: CoordinationSignatureContext): EthAddress | undefined {
-    const cacheKey = getCoordinationSignatureContextKey(signatureContext);
-    if (!this.senderCache || this.senderCache.key !== cacheKey) {
-      const sender = recoverCoordinationSigner(
-        this.payload,
-        SignatureDomainSeparator.checkpointAttestation,
-        this.signature,
-        signatureContext,
-      );
-      this.senderCache = { key: cacheKey, sender };
+  getSender(): EthAddress | undefined {
+    if (this.cachedSender === null) {
+      this.cachedSender = recoverCoordinationSigner(this.payload, this.signature);
     }
-
-    return this.senderCache.sender;
+    return this.cachedSender;
   }
 
   /**
    * Lazily evaluate and cache the proposer of the checkpoint
    * @returns The proposer of the checkpoint
    */
-  getProposer(signatureContext: CoordinationSignatureContext): EthAddress | undefined {
-    const cacheKey = getCoordinationSignatureContextKey(signatureContext);
-    if (!this.proposerCache || this.proposerCache.key !== cacheKey) {
+  getProposer(): EthAddress | undefined {
+    if (this.cachedProposer === null) {
       // Create a temporary CheckpointProposal to recover the proposer address.
       // We need to use CheckpointProposal because it has a different getPayloadToSign()
       // implementation than ConsensusPayload (uses serializeToBuffer vs ABI encoding).
@@ -113,16 +93,15 @@ export class CheckpointAttestation extends Gossipable {
         this.payload.archive,
         this.payload.feeAssetPriceModifier,
         this.proposerSignature,
+        this.payload.signatureContext,
       );
-      const proposer = proposal.getSender(signatureContext);
-      this.proposerCache = { key: cacheKey, proposer };
+      this.cachedProposer = proposal.getSender();
     }
-
-    return this.proposerCache.proposer;
+    return this.cachedProposer;
   }
 
   getPayload(): Buffer {
-    return this.payload.getPayloadToSign(SignatureDomainSeparator.checkpointAttestation);
+    return this.payload.getPayloadToSign();
   }
 
   toBuffer(): Buffer {

--- a/yarn-project/stdlib/src/p2p/checkpoint_attestation.ts
+++ b/yarn-project/stdlib/src/p2p/checkpoint_attestation.ts
@@ -1,7 +1,6 @@
 import { CheckpointAttestationHash, SlotNumber } from '@aztec/foundation/branded-types';
 import type { BaseBuffer32 } from '@aztec/foundation/buffer';
 import { keccak256 } from '@aztec/foundation/crypto/keccak';
-import { tryRecoverAddress } from '@aztec/foundation/crypto/secp256k1-signer';
 import type { Fr } from '@aztec/foundation/curves/bn254';
 import type { EthAddress } from '@aztec/foundation/eth-address';
 import { Signature } from '@aztec/foundation/eth-signature';
@@ -13,7 +12,12 @@ import type { ZodFor } from '../schemas/index.js';
 import { CheckpointProposal } from './checkpoint_proposal.js';
 import { ConsensusPayload } from './consensus_payload.js';
 import { Gossipable } from './gossipable.js';
-import { SignatureDomainSeparator, getHashedSignaturePayloadEthSignedMessage } from './signature_utils.js';
+import {
+  type CoordinationSignatureContext,
+  SignatureDomainSeparator,
+  getCoordinationSignatureContextKey,
+  recoverCoordinationSigner,
+} from './signature_utils.js';
 import { TopicType } from './topic_type.js';
 
 export type { CheckpointAttestationHash } from '@aztec/foundation/branded-types';
@@ -27,8 +31,18 @@ export type { CheckpointAttestationHash } from '@aztec/foundation/branded-types'
 export class CheckpointAttestation extends Gossipable {
   static override p2pTopic = TopicType.checkpoint_attestation;
 
-  private sender: EthAddress | undefined;
-  private proposer: EthAddress | undefined;
+  private senderCache:
+    | {
+        key: string;
+        sender: EthAddress | undefined;
+      }
+    | undefined;
+  private proposerCache:
+    | {
+        key: string;
+        proposer: EthAddress | undefined;
+      }
+    | undefined;
 
   constructor(
     /** The payload of the message, and what the signature is over */
@@ -69,26 +83,28 @@ export class CheckpointAttestation extends Gossipable {
    * Lazily evaluate and cache the signer of the attestation
    * @returns The signer of the attestation, or undefined if signature recovery fails
    */
-  getSender(): EthAddress | undefined {
-    if (!this.sender) {
-      // Recover the sender from the attestation
-      const hashed = getHashedSignaturePayloadEthSignedMessage(
+  getSender(signatureContext: CoordinationSignatureContext): EthAddress | undefined {
+    const cacheKey = getCoordinationSignatureContextKey(signatureContext);
+    if (!this.senderCache || this.senderCache.key !== cacheKey) {
+      const sender = recoverCoordinationSigner(
         this.payload,
         SignatureDomainSeparator.checkpointAttestation,
+        this.signature,
+        signatureContext,
       );
-      // Cache the sender for later use
-      this.sender = tryRecoverAddress(hashed, this.signature);
+      this.senderCache = { key: cacheKey, sender };
     }
 
-    return this.sender;
+    return this.senderCache.sender;
   }
 
   /**
    * Lazily evaluate and cache the proposer of the checkpoint
    * @returns The proposer of the checkpoint
    */
-  getProposer(): EthAddress | undefined {
-    if (!this.proposer) {
+  getProposer(signatureContext: CoordinationSignatureContext): EthAddress | undefined {
+    const cacheKey = getCoordinationSignatureContextKey(signatureContext);
+    if (!this.proposerCache || this.proposerCache.key !== cacheKey) {
       // Create a temporary CheckpointProposal to recover the proposer address.
       // We need to use CheckpointProposal because it has a different getPayloadToSign()
       // implementation than ConsensusPayload (uses serializeToBuffer vs ABI encoding).
@@ -98,11 +114,11 @@ export class CheckpointAttestation extends Gossipable {
         this.payload.feeAssetPriceModifier,
         this.proposerSignature,
       );
-      // Cache the proposer for later use
-      this.proposer = proposal.getSender();
+      const proposer = proposal.getSender(signatureContext);
+      this.proposerCache = { key: cacheKey, proposer };
     }
 
-    return this.proposer;
+    return this.proposerCache.proposer;
   }
 
   getPayload(): Buffer {

--- a/yarn-project/stdlib/src/p2p/checkpoint_attestation.ts
+++ b/yarn-project/stdlib/src/p2p/checkpoint_attestation.ts
@@ -26,8 +26,8 @@ export type { CheckpointAttestationHash } from '@aztec/foundation/branded-types'
 export class CheckpointAttestation extends Gossipable {
   static override p2pTopic = TopicType.checkpoint_attestation;
 
-  private cachedSender: EthAddress | undefined | null = null;
-  private cachedProposer: EthAddress | undefined | null = null;
+  private cachedSender: EthAddress | undefined | null = undefined;
+  private cachedProposer: EthAddress | undefined | null = undefined;
 
   constructor(
     /** The payload of the message, and what the signature is over */
@@ -73,10 +73,10 @@ export class CheckpointAttestation extends Gossipable {
    * @returns The signer of the attestation, or undefined if signature recovery fails
    */
   getSender(): EthAddress | undefined {
-    if (this.cachedSender === null) {
-      this.cachedSender = recoverCoordinationSigner(this.payload, this.signature);
+    if (this.cachedSender === undefined) {
+      this.cachedSender = recoverCoordinationSigner(this.payload, this.signature) ?? null;
     }
-    return this.cachedSender;
+    return this.cachedSender ?? undefined;
   }
 
   /**
@@ -84,7 +84,7 @@ export class CheckpointAttestation extends Gossipable {
    * @returns The proposer of the checkpoint
    */
   getProposer(): EthAddress | undefined {
-    if (this.cachedProposer === null) {
+    if (this.cachedProposer === undefined) {
       // Create a temporary CheckpointProposal to recover the proposer address.
       // We need to use CheckpointProposal because it has a different getPayloadToSign()
       // implementation than ConsensusPayload (uses serializeToBuffer vs ABI encoding).
@@ -95,9 +95,9 @@ export class CheckpointAttestation extends Gossipable {
         this.proposerSignature,
         this.payload.signatureContext,
       );
-      this.cachedProposer = proposal.getSender();
+      this.cachedProposer = proposal.getSender() ?? null;
     }
-    return this.cachedProposer;
+    return this.cachedProposer ?? undefined;
   }
 
   getPayload(): Buffer {

--- a/yarn-project/stdlib/src/p2p/checkpoint_proposal.ts
+++ b/yarn-project/stdlib/src/p2p/checkpoint_proposal.ts
@@ -4,13 +4,14 @@ import {
   IndexWithinCheckpoint,
   SlotNumber,
 } from '@aztec/foundation/branded-types';
-import { type BaseBuffer32, Buffer32 } from '@aztec/foundation/buffer';
+import type { BaseBuffer32 } from '@aztec/foundation/buffer';
 import { keccak256 } from '@aztec/foundation/crypto/keccak';
-import { tryRecoverAddress } from '@aztec/foundation/crypto/secp256k1-signer';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import type { EthAddress } from '@aztec/foundation/eth-address';
 import { Signature } from '@aztec/foundation/eth-signature';
 import { BufferReader, serializeSignedBigInt, serializeToBuffer } from '@aztec/foundation/serialize';
+
+import type { TypedDataDefinition } from 'viem';
 
 import type { L2BlockInfo } from '../block/l2_block_info.js';
 import { MAX_TXS_PER_BLOCK } from '../deserialization/index.js';
@@ -22,9 +23,11 @@ import type { Tx } from '../tx/tx.js';
 import { BlockProposal } from './block_proposal.js';
 import { Gossipable } from './gossipable.js';
 import {
+  type CoordinationSignatureContext,
   SignatureDomainSeparator,
-  getHashedSignaturePayload,
-  getHashedSignaturePayloadEthSignedMessage,
+  getCoordinationSignatureContextKey,
+  getCoordinationSignatureTypedData,
+  recoverCoordinationSigner,
 } from './signature_utils.js';
 import { SignedTxs } from './signed_txs.js';
 import { TopicType } from './topic_type.js';
@@ -72,7 +75,12 @@ export type CheckpointLastBlock = Omit<CheckpointLastBlockData, 'txs'> & {
 export class CheckpointProposal extends Gossipable {
   static override p2pTopic = TopicType.checkpoint_proposal;
 
-  private sender: EthAddress | undefined;
+  private senderCache:
+    | {
+        key: string;
+        sender: EthAddress | undefined;
+      }
+    | undefined;
 
   constructor(
     /** The aggregated checkpoint header for consensus */
@@ -163,7 +171,8 @@ export class CheckpointProposal extends Gossipable {
     checkpointNumber: CheckpointNumber,
     feeAssetPriceModifier: bigint,
     lastBlockProposal: BlockProposal | undefined,
-    payloadSigner: (payload: Buffer32, context: SigningContext) => Promise<Signature>,
+    signatureContext: CoordinationSignatureContext,
+    payloadSigner: (typedData: TypedDataDefinition, context: SigningContext) => Promise<Signature>,
   ): Promise<CheckpointProposal> {
     // Sign the checkpoint payload with CHECKPOINT_PROPOSAL duty type
     const tempProposal = new CheckpointProposal(
@@ -172,15 +181,18 @@ export class CheckpointProposal extends Gossipable {
       feeAssetPriceModifier,
       Signature.empty(),
     );
-    const checkpointHash = getHashedSignaturePayload(tempProposal, SignatureDomainSeparator.checkpointProposal);
-
     const checkpointContext: SigningContext = {
       slot: checkpointHeader.slotNumber,
       checkpointNumber,
       dutyType: DutyType.CHECKPOINT_PROPOSAL,
     };
 
-    const checkpointSignature = await payloadSigner(checkpointHash, checkpointContext);
+    const typedData = getCoordinationSignatureTypedData(
+      tempProposal,
+      SignatureDomainSeparator.checkpointProposal,
+      signatureContext,
+    );
+    const checkpointSignature = await payloadSigner(typedData, checkpointContext);
 
     return new CheckpointProposal(
       checkpointHeader,
@@ -196,25 +208,30 @@ export class CheckpointProposal extends Gossipable {
    * If there's a lastBlock, also verifies the block proposal sender matches the checkpoint sender.
    * @returns The sender address, or undefined if signature recovery fails or senders don't match
    */
-  getSender(): EthAddress | undefined {
-    if (!this.sender) {
-      const hashed = getHashedSignaturePayloadEthSignedMessage(this, SignatureDomainSeparator.checkpointProposal);
-      const checkpointSender = tryRecoverAddress(hashed, this.signature);
+  getSender(signatureContext: CoordinationSignatureContext): EthAddress | undefined {
+    const cacheKey = getCoordinationSignatureContextKey(signatureContext);
+    if (!this.senderCache || this.senderCache.key !== cacheKey) {
+      const checkpointSender = recoverCoordinationSigner(
+        this,
+        SignatureDomainSeparator.checkpointProposal,
+        this.signature,
+        signatureContext,
+      );
 
       // If there's a lastBlock, verify the block proposal sender matches
       if (checkpointSender && this.lastBlock) {
         const blockProposal = this.getBlockProposal();
-        const blockSender = blockProposal?.getSender();
+        const blockSender = blockProposal?.getSender(signatureContext);
         if (!blockSender || !blockSender.equals(checkpointSender)) {
           return undefined; // Sender mismatch - fail
         }
       }
 
       // Cache the sender for later use
-      this.sender = checkpointSender;
+      this.senderCache = { key: cacheKey, sender: checkpointSender };
     }
 
-    return this.sender;
+    return this.senderCache.sender;
   }
 
   getPayload() {

--- a/yarn-project/stdlib/src/p2p/checkpoint_proposal.ts
+++ b/yarn-project/stdlib/src/p2p/checkpoint_proposal.ts
@@ -80,7 +80,7 @@ export class CheckpointProposal extends Gossipable implements Signable {
 
   readonly primaryType: CoordinationSignatureType = 'CheckpointProposal';
 
-  private cachedSender: EthAddress | undefined | null = null;
+  private cachedSender: EthAddress | undefined | null = undefined;
 
   constructor(
     /** The aggregated checkpoint header for consensus */
@@ -206,22 +206,22 @@ export class CheckpointProposal extends Gossipable implements Signable {
    * @returns The sender address, or undefined if signature recovery fails or senders don't match
    */
   getSender(): EthAddress | undefined {
-    if (this.cachedSender === null) {
+    if (this.cachedSender === undefined) {
       const checkpointSender = recoverCoordinationSigner(this, this.signature);
 
       if (checkpointSender && this.lastBlock) {
         const blockProposal = this.getBlockProposal();
         const blockSender = blockProposal?.getSender();
         if (!blockSender || !blockSender.equals(checkpointSender)) {
-          this.cachedSender = undefined;
+          this.cachedSender = null;
           return undefined;
         }
       }
 
-      this.cachedSender = checkpointSender;
+      this.cachedSender = checkpointSender ?? null;
     }
 
-    return this.cachedSender;
+    return this.cachedSender ?? undefined;
   }
 
   getPayload() {

--- a/yarn-project/stdlib/src/p2p/checkpoint_proposal.ts
+++ b/yarn-project/stdlib/src/p2p/checkpoint_proposal.ts
@@ -24,10 +24,13 @@ import { BlockProposal } from './block_proposal.js';
 import { Gossipable } from './gossipable.js';
 import {
   type CoordinationSignatureContext,
-  SignatureDomainSeparator,
-  getCoordinationSignatureContextKey,
+  type CoordinationSignatureType,
+  EMPTY_COORDINATION_SIGNATURE_CONTEXT,
+  type Signable,
   getCoordinationSignatureTypedData,
+  readCoordinationSignatureContext,
   recoverCoordinationSigner,
+  serializeCoordinationSignatureContext,
 } from './signature_utils.js';
 import { SignedTxs } from './signed_txs.js';
 import { TopicType } from './topic_type.js';
@@ -72,15 +75,12 @@ export type CheckpointLastBlock = Omit<CheckpointLastBlockData, 'txs'> & {
  * It includes the aggregated checkpoint header that validators will attest to, plus optionally
  * the last block's info for nodes to re-execute. This marks the completion of a slot's worth of blocks.
  */
-export class CheckpointProposal extends Gossipable {
+export class CheckpointProposal extends Gossipable implements Signable {
   static override p2pTopic = TopicType.checkpoint_proposal;
 
-  private senderCache:
-    | {
-        key: string;
-        sender: EthAddress | undefined;
-      }
-    | undefined;
+  readonly primaryType: CoordinationSignatureType = 'CheckpointProposal';
+
+  private cachedSender: EthAddress | undefined | null = null;
 
   constructor(
     /** The aggregated checkpoint header for consensus */
@@ -94,6 +94,9 @@ export class CheckpointProposal extends Gossipable {
 
     /** The proposer's signature over the checkpoint payload (checkpointHeader + archive + feeAssetPriceModifier) */
     public readonly signature: Signature,
+
+    /** The signing domain (chainId + rollupAddress) the signature is bound to */
+    public readonly signatureContext: CoordinationSignatureContext,
 
     /** Optional last block info, including its own signature for BlockProposal extraction */
     public readonly lastBlock?: CheckpointLastBlock,
@@ -125,6 +128,7 @@ export class CheckpointProposal extends Gossipable {
       this.archive,
       this.lastBlock.txHashes,
       this.lastBlock.signature,
+      this.signatureContext,
       this.lastBlock.signedTxs,
     );
   }
@@ -156,13 +160,8 @@ export class CheckpointProposal extends Gossipable {
    * Get the payload to sign for this checkpoint proposal.
    * The signature is over the checkpoint header + archive root + feeAssetPriceModifier (for consensus).
    */
-  getPayloadToSign(domainSeparator: SignatureDomainSeparator): Buffer {
-    return serializeToBuffer([
-      domainSeparator,
-      this.checkpointHeader,
-      this.archive,
-      serializeSignedBigInt(this.feeAssetPriceModifier),
-    ]);
+  getPayloadToSign(): Buffer {
+    return serializeToBuffer([this.checkpointHeader, this.archive, serializeSignedBigInt(this.feeAssetPriceModifier)]);
   }
 
   static async createProposalFromSigner(
@@ -180,6 +179,7 @@ export class CheckpointProposal extends Gossipable {
       archiveRoot,
       feeAssetPriceModifier,
       Signature.empty(),
+      signatureContext,
     );
     const checkpointContext: SigningContext = {
       slot: checkpointHeader.slotNumber,
@@ -187,11 +187,7 @@ export class CheckpointProposal extends Gossipable {
       dutyType: DutyType.CHECKPOINT_PROPOSAL,
     };
 
-    const typedData = getCoordinationSignatureTypedData(
-      tempProposal,
-      SignatureDomainSeparator.checkpointProposal,
-      signatureContext,
-    );
+    const typedData = getCoordinationSignatureTypedData(tempProposal);
     const checkpointSignature = await payloadSigner(typedData, checkpointContext);
 
     return new CheckpointProposal(
@@ -199,6 +195,7 @@ export class CheckpointProposal extends Gossipable {
       archiveRoot,
       feeAssetPriceModifier,
       checkpointSignature,
+      signatureContext,
       lastBlockProposal,
     );
   }
@@ -208,34 +205,27 @@ export class CheckpointProposal extends Gossipable {
    * If there's a lastBlock, also verifies the block proposal sender matches the checkpoint sender.
    * @returns The sender address, or undefined if signature recovery fails or senders don't match
    */
-  getSender(signatureContext: CoordinationSignatureContext): EthAddress | undefined {
-    const cacheKey = getCoordinationSignatureContextKey(signatureContext);
-    if (!this.senderCache || this.senderCache.key !== cacheKey) {
-      const checkpointSender = recoverCoordinationSigner(
-        this,
-        SignatureDomainSeparator.checkpointProposal,
-        this.signature,
-        signatureContext,
-      );
+  getSender(): EthAddress | undefined {
+    if (this.cachedSender === null) {
+      const checkpointSender = recoverCoordinationSigner(this, this.signature);
 
-      // If there's a lastBlock, verify the block proposal sender matches
       if (checkpointSender && this.lastBlock) {
         const blockProposal = this.getBlockProposal();
-        const blockSender = blockProposal?.getSender(signatureContext);
+        const blockSender = blockProposal?.getSender();
         if (!blockSender || !blockSender.equals(checkpointSender)) {
-          return undefined; // Sender mismatch - fail
+          this.cachedSender = undefined;
+          return undefined;
         }
       }
 
-      // Cache the sender for later use
-      this.senderCache = { key: cacheKey, sender: checkpointSender };
+      this.cachedSender = checkpointSender;
     }
 
-    return this.senderCache.sender;
+    return this.cachedSender;
   }
 
   getPayload() {
-    return this.getPayloadToSign(SignatureDomainSeparator.checkpointProposal);
+    return this.getPayloadToSign();
   }
 
   toBuffer(): Buffer {
@@ -244,6 +234,7 @@ export class CheckpointProposal extends Gossipable {
       this.archive,
       serializeSignedBigInt(this.feeAssetPriceModifier),
       this.signature,
+      serializeCoordinationSignatureContext(this.signatureContext),
     ];
 
     if (this.lastBlock) {
@@ -273,6 +264,7 @@ export class CheckpointProposal extends Gossipable {
     const archive = reader.readObject(Fr);
     const feeAssetPriceModifier = reader.readInt256();
     const signature = reader.readObject(Signature);
+    const signatureContext = readCoordinationSignatureContext(reader);
 
     const hasLastBlock = reader.readNumber();
 
@@ -294,7 +286,7 @@ export class CheckpointProposal extends Gossipable {
         }
       }
 
-      return new CheckpointProposal(checkpointHeader, archive, feeAssetPriceModifier, signature, {
+      return new CheckpointProposal(checkpointHeader, archive, feeAssetPriceModifier, signature, signatureContext, {
         blockHeader,
         indexWithinCheckpoint,
         txHashes,
@@ -303,7 +295,7 @@ export class CheckpointProposal extends Gossipable {
       });
     }
 
-    return new CheckpointProposal(checkpointHeader, archive, feeAssetPriceModifier, signature);
+    return new CheckpointProposal(checkpointHeader, archive, feeAssetPriceModifier, signature, signatureContext);
   }
 
   getSize(): number {
@@ -312,6 +304,8 @@ export class CheckpointProposal extends Gossipable {
       this.archive.size +
       this.signature.getSize() +
       8 /* feeAssetPriceModifier */ +
+      4 /* chainId */ +
+      20 /* rollupAddress */ +
       4; /* hasLastBlock flag */
 
     if (this.lastBlock) {
@@ -329,16 +323,29 @@ export class CheckpointProposal extends Gossipable {
   }
 
   static empty(): CheckpointProposal {
-    return new CheckpointProposal(CheckpointHeader.empty(), Fr.ZERO, 0n, Signature.empty());
+    return new CheckpointProposal(
+      CheckpointHeader.empty(),
+      Fr.ZERO,
+      0n,
+      Signature.empty(),
+      EMPTY_COORDINATION_SIGNATURE_CONTEXT,
+    );
   }
 
   static random(): CheckpointProposal {
-    return new CheckpointProposal(CheckpointHeader.random(), Fr.random(), 0n, Signature.random(), {
-      blockHeader: BlockHeader.random(),
-      indexWithinCheckpoint: IndexWithinCheckpoint(Math.floor(Math.random() * 5)),
-      txHashes: [TxHash.random(), TxHash.random()],
-      signature: Signature.random(),
-    });
+    return new CheckpointProposal(
+      CheckpointHeader.random(),
+      Fr.random(),
+      0n,
+      Signature.random(),
+      EMPTY_COORDINATION_SIGNATURE_CONTEXT,
+      {
+        blockHeader: BlockHeader.random(),
+        indexWithinCheckpoint: IndexWithinCheckpoint(Math.floor(Math.random() * 5)),
+        txHashes: [TxHash.random(), TxHash.random()],
+        signature: Signature.random(),
+      },
+    );
   }
 
   toInspect() {
@@ -347,6 +354,8 @@ export class CheckpointProposal extends Gossipable {
       archive: this.archive.toString(),
       signature: this.signature.toString(),
       feeAssetPriceModifier: this.feeAssetPriceModifier.toString(),
+      chainId: this.signatureContext.chainId,
+      rollupAddress: this.signatureContext.rollupAddress.toString(),
       lastBlock: this.lastBlock
         ? {
             blockHeader: this.lastBlock.blockHeader.toInspect(),
@@ -363,7 +372,13 @@ export class CheckpointProposal extends Gossipable {
    * Used when the lastBlock has been extracted and stored separately.
    */
   toCore(): CheckpointProposalCore {
-    return new CheckpointProposal(this.checkpointHeader, this.archive, this.feeAssetPriceModifier, this.signature);
+    return new CheckpointProposal(
+      this.checkpointHeader,
+      this.archive,
+      this.feeAssetPriceModifier,
+      this.signature,
+      this.signatureContext,
+    );
   }
 }
 

--- a/yarn-project/stdlib/src/p2p/consensus_payload.ts
+++ b/yarn-project/stdlib/src/p2p/consensus_payload.ts
@@ -10,10 +10,21 @@ import { z } from 'zod';
 import type { Checkpoint } from '../checkpoint/checkpoint.js';
 import { CheckpointHeader } from '../rollup/checkpoint_header.js';
 import type { CheckpointProposal, CheckpointProposalCore } from './checkpoint_proposal.js';
-import type { Signable, SignatureDomainSeparator } from './signature_utils.js';
+import {
+  type CoordinationSignatureContext,
+  type CoordinationSignatureType,
+  EMPTY_COORDINATION_SIGNATURE_CONTEXT,
+  type Signable,
+  coordinationSignatureContextEquals,
+  coordinationSignatureContextSchema,
+  readCoordinationSignatureContext,
+  serializeCoordinationSignatureContext,
+} from './signature_utils.js';
 
 /** Checkpoint consensus payload as signed by validators and verified on L1. */
 export class ConsensusPayload implements Signable {
+  readonly primaryType: CoordinationSignatureType = 'CheckpointAttestation';
+
   private size: number | undefined;
 
   constructor(
@@ -22,7 +33,9 @@ export class ConsensusPayload implements Signable {
     /** The archive root after the block is added */
     public readonly archive: Fr,
     /** The fee asset price modifier in basis points (from oracle) */
-    public readonly feeAssetPriceModifier: bigint = 0n,
+    public readonly feeAssetPriceModifier: bigint,
+    /** The signing domain (chainId + rollupAddress) the signature is bound to */
+    public readonly signatureContext: CoordinationSignatureContext,
   ) {}
 
   static get schema() {
@@ -31,36 +44,38 @@ export class ConsensusPayload implements Signable {
         header: CheckpointHeader.schema,
         archive: schemas.Fr,
         feeAssetPriceModifier: schemas.BigInt,
+        signatureContext: coordinationSignatureContextSchema,
       })
-      .transform(obj => new ConsensusPayload(obj.header, obj.archive, obj.feeAssetPriceModifier));
+      .transform(obj => new ConsensusPayload(obj.header, obj.archive, obj.feeAssetPriceModifier, obj.signatureContext));
   }
 
-  static getFields(fields: FieldsOf<ConsensusPayload>) {
-    return [fields.header, fields.archive, fields.feeAssetPriceModifier] as const;
+  static getFields(fields: Omit<FieldsOf<ConsensusPayload>, 'primaryType'>) {
+    return [fields.header, fields.archive, fields.feeAssetPriceModifier, fields.signatureContext] as const;
   }
 
-  getPayloadToSign(domainSeparator: SignatureDomainSeparator): Buffer {
+  getPayloadToSign(): Buffer {
+    // Matches the L1 ProposePayload struct in ProposeLib.sol.
     const abi = parseAbiParameters(
-      'uint8, ' + //domainSeperator
-        '(' +
+      '(' +
         'bytes32, ' + // archive
         '(int256), ' + // oracleInput
         'bytes32' + // headerHash
         ')',
     );
     const archiveRoot = this.archive.toString();
-
     const headerHash = this.header.hash().toString();
-    const encodedData = encodeAbiParameters(abi, [
-      domainSeparator,
-      [archiveRoot, [this.feeAssetPriceModifier], headerHash],
-    ] as const);
+    const encodedData = encodeAbiParameters(abi, [[archiveRoot, [this.feeAssetPriceModifier], headerHash]] as const);
 
     return hexToBuffer(encodedData);
   }
 
   toBuffer(): Buffer {
-    return serializeToBuffer([this.header, this.archive, serializeSignedBigInt(this.feeAssetPriceModifier)]);
+    return serializeToBuffer([
+      this.header,
+      this.archive,
+      serializeSignedBigInt(this.feeAssetPriceModifier),
+      serializeCoordinationSignatureContext(this.signatureContext),
+    ]);
   }
 
   public equals(other: ConsensusPayload | CheckpointProposal | CheckpointProposalCore): boolean {
@@ -69,34 +84,39 @@ export class ConsensusPayload implements Signable {
     return (
       this.header.equals(otherHeader) &&
       this.archive.equals(other.archive) &&
-      this.feeAssetPriceModifier === otherModifier
+      this.feeAssetPriceModifier === otherModifier &&
+      coordinationSignatureContextEquals(this.signatureContext, other.signatureContext)
     );
   }
 
   static fromBuffer(buf: Buffer | BufferReader): ConsensusPayload {
     const reader = BufferReader.asReader(buf);
-    const payload = new ConsensusPayload(
-      reader.readObject(CheckpointHeader),
-      reader.readObject(Fr),
-      reader.readInt256(),
+    const header = reader.readObject(CheckpointHeader);
+    const archive = reader.readObject(Fr);
+    const feeAssetPriceModifier = reader.readInt256();
+    const signatureContext = readCoordinationSignatureContext(reader);
+    return new ConsensusPayload(header, archive, feeAssetPriceModifier, signatureContext);
+  }
+
+  static fromFields(fields: Omit<FieldsOf<ConsensusPayload>, 'primaryType'>): ConsensusPayload {
+    return new ConsensusPayload(fields.header, fields.archive, fields.feeAssetPriceModifier, fields.signatureContext);
+  }
+
+  static fromCheckpoint(checkpoint: Checkpoint, signatureContext: CoordinationSignatureContext): ConsensusPayload {
+    return new ConsensusPayload(
+      checkpoint.header,
+      checkpoint.archive.root,
+      checkpoint.feeAssetPriceModifier,
+      signatureContext,
     );
-    return payload;
-  }
-
-  static fromFields(fields: FieldsOf<ConsensusPayload>): ConsensusPayload {
-    return new ConsensusPayload(fields.header, fields.archive, fields.feeAssetPriceModifier);
-  }
-
-  static fromCheckpoint(checkpoint: Checkpoint): ConsensusPayload {
-    return new ConsensusPayload(checkpoint.header, checkpoint.archive.root, checkpoint.feeAssetPriceModifier);
   }
 
   static empty(): ConsensusPayload {
-    return new ConsensusPayload(CheckpointHeader.empty(), Fr.ZERO, 0n);
+    return new ConsensusPayload(CheckpointHeader.empty(), Fr.ZERO, 0n, EMPTY_COORDINATION_SIGNATURE_CONTEXT);
   }
 
   static random(): ConsensusPayload {
-    return new ConsensusPayload(CheckpointHeader.random(), Fr.random(), 0n);
+    return new ConsensusPayload(CheckpointHeader.random(), Fr.random(), 0n, EMPTY_COORDINATION_SIGNATURE_CONTEXT);
   }
 
   /**
@@ -117,10 +137,12 @@ export class ConsensusPayload implements Signable {
       header: this.header.toInspect(),
       archive: this.archive.toString(),
       feeAssetPriceModifier: this.feeAssetPriceModifier.toString(),
+      chainId: this.signatureContext.chainId,
+      rollupAddress: this.signatureContext.rollupAddress.toString(),
     };
   }
 
   toString() {
-    return `header: ${this.header.toString()}, archive: ${this.archive.toString()}, feeAssetPriceModifier: ${this.feeAssetPriceModifier}}`;
+    return `header: ${this.header.toString()}, archive: ${this.archive.toString()}, feeAssetPriceModifier: ${this.feeAssetPriceModifier}, chainId: ${this.signatureContext.chainId}, rollupAddress: ${this.signatureContext.rollupAddress.toString()}`;
   }
 }

--- a/yarn-project/stdlib/src/p2p/signature_utils.test.ts
+++ b/yarn-project/stdlib/src/p2p/signature_utils.test.ts
@@ -15,9 +15,9 @@ import {
   makeCheckpointAttestation,
   makeCheckpointProposal,
 } from '../tests/mocks.js';
-import type { Signable } from './signature_utils.js';
+import { CheckpointAttestation } from './checkpoint_attestation.js';
+import type { CoordinationSignatureType, Signable } from './signature_utils.js';
 import {
-  SignatureDomainSeparator,
   getHashedSignaturePayload,
   getHashedSignaturePayloadTypedData,
   recoverCoordinationSigner,
@@ -29,12 +29,13 @@ const DOMAIN_TYPEHASH = `0x${keccak256String(
 const NAME_HASH = `0x${keccak256String('Aztec Rollup')}` as const;
 const VERSION_HASH = `0x${keccak256String('1')}` as const;
 
-const TYPEHASHES = {
-  [SignatureDomainSeparator.blockProposal]: `0x${keccak256String('BlockProposal(bytes32 payloadHash)')}`,
-  [SignatureDomainSeparator.checkpointProposal]: `0x${keccak256String('CheckpointProposal(bytes32 payloadHash)')}`,
-  [SignatureDomainSeparator.checkpointAttestation]: `0x${keccak256String('CheckpointAttestation(bytes32 payloadHash)')}`,
-  [SignatureDomainSeparator.attestationsAndSigners]: `0x${keccak256String('AttestationsAndSigners(bytes32 payloadHash)')}`,
-} as const;
+const TYPEHASHES: Record<CoordinationSignatureType, `0x${string}`> = {
+  BlockProposal: `0x${keccak256String('BlockProposal(bytes32 payloadHash)')}`,
+  CheckpointProposal: `0x${keccak256String('CheckpointProposal(bytes32 payloadHash)')}`,
+  CheckpointAttestation: `0x${keccak256String('CheckpointAttestation(bytes32 payloadHash)')}`,
+  AttestationsAndSigners: `0x${keccak256String('AttestationsAndSigners(bytes32 payloadHash)')}`,
+  SignedTxs: `0x${keccak256String('SignedTxs(bytes32 payloadHash)')}`,
+};
 
 const WRONG_CHAIN_CONTEXT = {
   ...TEST_COORDINATION_SIGNATURE_CONTEXT,
@@ -46,14 +47,8 @@ const WRONG_ROLLUP_CONTEXT = {
   rollupAddress: EthAddress.fromString('0x0000000000000000000000000000000000000002'),
 };
 
-type CoordinationSignatureDomain =
-  | SignatureDomainSeparator.blockProposal
-  | SignatureDomainSeparator.checkpointProposal
-  | SignatureDomainSeparator.checkpointAttestation
-  | SignatureDomainSeparator.attestationsAndSigners;
-
-function getSolidityCoordinationDigest(signable: Signable, domainSeparator: CoordinationSignatureDomain): Buffer32 {
-  const payloadHash = getHashedSignaturePayload(signable, domainSeparator);
+function getSolidityCoordinationDigest(signable: Signable): Buffer32 {
+  const payloadHash = getHashedSignaturePayload(signable);
   const domainSeparatorHash = Buffer32.fromBuffer(
     keccak256(
       hexToBuffer(
@@ -61,8 +56,8 @@ function getSolidityCoordinationDigest(signable: Signable, domainSeparator: Coor
           DOMAIN_TYPEHASH,
           NAME_HASH,
           VERSION_HASH,
-          BigInt(TEST_COORDINATION_SIGNATURE_CONTEXT.chainId),
-          TEST_COORDINATION_SIGNATURE_CONTEXT.rollupAddress.toString(),
+          BigInt(signable.signatureContext.chainId),
+          signable.signatureContext.rollupAddress.toString(),
         ]),
       ),
     ),
@@ -71,7 +66,7 @@ function getSolidityCoordinationDigest(signable: Signable, domainSeparator: Coor
     keccak256(
       hexToBuffer(
         encodeAbiParameters(parseAbiParameters('bytes32,bytes32'), [
-          TYPEHASHES[domainSeparator],
+          TYPEHASHES[signable.primaryType],
           payloadHash.toString() as `0x${string}`,
         ]),
       ),
@@ -89,40 +84,21 @@ describe('coordination signature typed data', () => {
     const blockProposal = await makeBlockProposal({ signer });
     const checkpointProposal = await makeCheckpointProposal({ signer });
     const checkpointAttestation = makeCheckpointAttestation({ signer });
-    const attestationsAndSigners = new CommitteeAttestationsAndSigners([
-      CommitteeAttestation.fromAddressAndSignature(signer.address, checkpointAttestation.signature),
-    ]);
-
-    expect(
-      getHashedSignaturePayloadTypedData(
-        blockProposal,
-        SignatureDomainSeparator.blockProposal,
-        TEST_COORDINATION_SIGNATURE_CONTEXT,
-      ),
-    ).toEqual(getSolidityCoordinationDigest(blockProposal, SignatureDomainSeparator.blockProposal));
-    expect(
-      getHashedSignaturePayloadTypedData(
-        checkpointProposal,
-        SignatureDomainSeparator.checkpointProposal,
-        TEST_COORDINATION_SIGNATURE_CONTEXT,
-      ),
-    ).toEqual(getSolidityCoordinationDigest(checkpointProposal, SignatureDomainSeparator.checkpointProposal));
-    expect(
-      getHashedSignaturePayloadTypedData(
-        checkpointAttestation.payload,
-        SignatureDomainSeparator.checkpointAttestation,
-        TEST_COORDINATION_SIGNATURE_CONTEXT,
-      ),
-    ).toEqual(
-      getSolidityCoordinationDigest(checkpointAttestation.payload, SignatureDomainSeparator.checkpointAttestation),
+    const attestationsAndSigners = new CommitteeAttestationsAndSigners(
+      [CommitteeAttestation.fromAddressAndSignature(signer.address, checkpointAttestation.signature)],
+      TEST_COORDINATION_SIGNATURE_CONTEXT,
     );
-    expect(
-      getHashedSignaturePayloadTypedData(
-        attestationsAndSigners,
-        SignatureDomainSeparator.attestationsAndSigners,
-        TEST_COORDINATION_SIGNATURE_CONTEXT,
-      ),
-    ).toEqual(getSolidityCoordinationDigest(attestationsAndSigners, SignatureDomainSeparator.attestationsAndSigners));
+
+    expect(getHashedSignaturePayloadTypedData(blockProposal)).toEqual(getSolidityCoordinationDigest(blockProposal));
+    expect(getHashedSignaturePayloadTypedData(checkpointProposal)).toEqual(
+      getSolidityCoordinationDigest(checkpointProposal),
+    );
+    expect(getHashedSignaturePayloadTypedData(checkpointAttestation.payload)).toEqual(
+      getSolidityCoordinationDigest(checkpointAttestation.payload),
+    );
+    expect(getHashedSignaturePayloadTypedData(attestationsAndSigners)).toEqual(
+      getSolidityCoordinationDigest(attestationsAndSigners),
+    );
   });
 
   it('recovers with the right context and changes sender for the wrong domain', async () => {
@@ -140,51 +116,72 @@ describe('coordination signature typed data', () => {
       attesterSigner,
       proposerSigner,
     });
-    const attestationsAndSigners = new CommitteeAttestationsAndSigners([
-      CommitteeAttestation.fromAddressAndSignature(attesterSigner.address, checkpointAttestation.signature),
-    ]);
+    const attestationsAndSigners = new CommitteeAttestationsAndSigners(
+      [CommitteeAttestation.fromAddressAndSignature(attesterSigner.address, checkpointAttestation.signature)],
+      TEST_COORDINATION_SIGNATURE_CONTEXT,
+    );
     const attestationsAndSignersSignature = makeAndSignCommitteeAttestationsAndSigners(
       attestationsAndSigners,
       attestationsAndSignersSigner,
     );
 
-    expect(blockProposal.getSender(TEST_COORDINATION_SIGNATURE_CONTEXT)).toEqual(blockSigner.address);
-    expect(blockProposal.getSender(WRONG_CHAIN_CONTEXT)).not.toEqual(blockSigner.address);
-    expect(blockProposal.getSender(WRONG_ROLLUP_CONTEXT)).not.toEqual(blockSigner.address);
+    // Helpers to create variants of the same signables but with the wrong context baked in.
+    // Reset any memoized sender/proposer so the copy re-derives them against the altered context.
+    const withContext = <T extends { signatureContext: unknown }>(
+      signable: T,
+      ctx: typeof TEST_COORDINATION_SIGNATURE_CONTEXT,
+    ): T => {
+      const copy = Object.create(Object.getPrototypeOf(signable));
+      Object.assign(copy, signable);
+      copy.signatureContext = ctx;
+      if ('cachedSender' in copy) {
+        copy.cachedSender = null;
+      }
+      if ('cachedProposer' in copy) {
+        copy.cachedProposer = null;
+      }
+      return copy;
+    };
 
-    expect(checkpointProposal.getSender(TEST_COORDINATION_SIGNATURE_CONTEXT)).toEqual(checkpointSigner.address);
-    expect(checkpointProposal.getSender(WRONG_CHAIN_CONTEXT)).not.toEqual(checkpointSigner.address);
-    expect(checkpointProposal.getSender(WRONG_ROLLUP_CONTEXT)).not.toEqual(checkpointSigner.address);
+    expect(blockProposal.getSender()).toEqual(blockSigner.address);
+    expect(withContext(blockProposal, WRONG_CHAIN_CONTEXT).getSender()).not.toEqual(blockSigner.address);
+    expect(withContext(blockProposal, WRONG_ROLLUP_CONTEXT).getSender()).not.toEqual(blockSigner.address);
 
-    expect(checkpointAttestation.getSender(TEST_COORDINATION_SIGNATURE_CONTEXT)).toEqual(attesterSigner.address);
-    expect(checkpointAttestation.getProposer(TEST_COORDINATION_SIGNATURE_CONTEXT)).toEqual(proposerSigner.address);
-    expect(checkpointAttestation.getSender(WRONG_CHAIN_CONTEXT)).not.toEqual(attesterSigner.address);
-    expect(checkpointAttestation.getSender(WRONG_ROLLUP_CONTEXT)).not.toEqual(attesterSigner.address);
-    expect(checkpointAttestation.getProposer(WRONG_CHAIN_CONTEXT)).not.toEqual(proposerSigner.address);
-    expect(checkpointAttestation.getProposer(WRONG_ROLLUP_CONTEXT)).not.toEqual(proposerSigner.address);
+    expect(checkpointProposal.getSender()).toEqual(checkpointSigner.address);
+    expect(withContext(checkpointProposal, WRONG_CHAIN_CONTEXT).getSender()).not.toEqual(checkpointSigner.address);
+    expect(withContext(checkpointProposal, WRONG_ROLLUP_CONTEXT).getSender()).not.toEqual(checkpointSigner.address);
 
+    expect(checkpointAttestation.getSender()).toEqual(attesterSigner.address);
+    expect(checkpointAttestation.getProposer()).toEqual(proposerSigner.address);
+    // To change the context on a CheckpointAttestation, we need to swap the embedded payload's context.
+    const wrongChainAttestation = new CheckpointAttestation(
+      withContext(checkpointAttestation.payload, WRONG_CHAIN_CONTEXT),
+      checkpointAttestation.signature,
+      checkpointAttestation.proposerSignature,
+    );
+    const wrongRollupAttestation = new CheckpointAttestation(
+      withContext(checkpointAttestation.payload, WRONG_ROLLUP_CONTEXT),
+      checkpointAttestation.signature,
+      checkpointAttestation.proposerSignature,
+    );
+    expect(wrongChainAttestation.getSender()).not.toEqual(attesterSigner.address);
+    expect(wrongRollupAttestation.getSender()).not.toEqual(attesterSigner.address);
+    expect(wrongChainAttestation.getProposer()).not.toEqual(proposerSigner.address);
+    expect(wrongRollupAttestation.getProposer()).not.toEqual(proposerSigner.address);
+
+    expect(recoverCoordinationSigner(attestationsAndSigners, attestationsAndSignersSignature)).toEqual(
+      attestationsAndSignersSigner.address,
+    );
     expect(
       recoverCoordinationSigner(
-        attestationsAndSigners,
-        SignatureDomainSeparator.attestationsAndSigners,
+        withContext(attestationsAndSigners, WRONG_CHAIN_CONTEXT),
         attestationsAndSignersSignature,
-        TEST_COORDINATION_SIGNATURE_CONTEXT,
-      ),
-    ).toEqual(attestationsAndSignersSigner.address);
-    expect(
-      recoverCoordinationSigner(
-        attestationsAndSigners,
-        SignatureDomainSeparator.attestationsAndSigners,
-        attestationsAndSignersSignature,
-        WRONG_CHAIN_CONTEXT,
       ),
     ).not.toEqual(attestationsAndSignersSigner.address);
     expect(
       recoverCoordinationSigner(
-        attestationsAndSigners,
-        SignatureDomainSeparator.attestationsAndSigners,
+        withContext(attestationsAndSigners, WRONG_ROLLUP_CONTEXT),
         attestationsAndSignersSignature,
-        WRONG_ROLLUP_CONTEXT,
       ),
     ).not.toEqual(attestationsAndSignersSigner.address);
   });

--- a/yarn-project/stdlib/src/p2p/signature_utils.test.ts
+++ b/yarn-project/stdlib/src/p2p/signature_utils.test.ts
@@ -135,10 +135,10 @@ describe('coordination signature typed data', () => {
       Object.assign(copy, signable);
       copy.signatureContext = ctx;
       if ('cachedSender' in copy) {
-        copy.cachedSender = null;
+        copy.cachedSender = undefined;
       }
       if ('cachedProposer' in copy) {
-        copy.cachedProposer = null;
+        copy.cachedProposer = undefined;
       }
       return copy;
     };

--- a/yarn-project/stdlib/src/p2p/signature_utils.test.ts
+++ b/yarn-project/stdlib/src/p2p/signature_utils.test.ts
@@ -1,0 +1,191 @@
+import { Buffer32 } from '@aztec/foundation/buffer';
+import { keccak256, keccak256String } from '@aztec/foundation/crypto/keccak';
+import { Secp256k1Signer } from '@aztec/foundation/crypto/secp256k1-signer';
+import { EthAddress } from '@aztec/foundation/eth-address';
+import { hexToBuffer } from '@aztec/foundation/string';
+
+import { encodeAbiParameters, parseAbiParameters } from 'viem';
+
+import { CommitteeAttestationsAndSigners } from '../block/proposal/attestations_and_signers.js';
+import { CommitteeAttestation } from '../block/proposal/committee_attestation.js';
+import {
+  TEST_COORDINATION_SIGNATURE_CONTEXT,
+  makeAndSignCommitteeAttestationsAndSigners,
+  makeBlockProposal,
+  makeCheckpointAttestation,
+  makeCheckpointProposal,
+} from '../tests/mocks.js';
+import type { Signable } from './signature_utils.js';
+import {
+  SignatureDomainSeparator,
+  getHashedSignaturePayload,
+  getHashedSignaturePayloadTypedData,
+  recoverCoordinationSigner,
+} from './signature_utils.js';
+
+const DOMAIN_TYPEHASH = `0x${keccak256String(
+  'EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)',
+)}` as const;
+const NAME_HASH = `0x${keccak256String('Aztec Rollup')}` as const;
+const VERSION_HASH = `0x${keccak256String('1')}` as const;
+
+const TYPEHASHES = {
+  [SignatureDomainSeparator.blockProposal]: `0x${keccak256String('BlockProposal(bytes32 payloadHash)')}`,
+  [SignatureDomainSeparator.checkpointProposal]: `0x${keccak256String('CheckpointProposal(bytes32 payloadHash)')}`,
+  [SignatureDomainSeparator.checkpointAttestation]: `0x${keccak256String('CheckpointAttestation(bytes32 payloadHash)')}`,
+  [SignatureDomainSeparator.attestationsAndSigners]: `0x${keccak256String('AttestationsAndSigners(bytes32 payloadHash)')}`,
+} as const;
+
+const WRONG_CHAIN_CONTEXT = {
+  ...TEST_COORDINATION_SIGNATURE_CONTEXT,
+  chainId: TEST_COORDINATION_SIGNATURE_CONTEXT.chainId + 1,
+};
+
+const WRONG_ROLLUP_CONTEXT = {
+  ...TEST_COORDINATION_SIGNATURE_CONTEXT,
+  rollupAddress: EthAddress.fromString('0x0000000000000000000000000000000000000002'),
+};
+
+type CoordinationSignatureDomain =
+  | SignatureDomainSeparator.blockProposal
+  | SignatureDomainSeparator.checkpointProposal
+  | SignatureDomainSeparator.checkpointAttestation
+  | SignatureDomainSeparator.attestationsAndSigners;
+
+function getSolidityCoordinationDigest(signable: Signable, domainSeparator: CoordinationSignatureDomain): Buffer32 {
+  const payloadHash = getHashedSignaturePayload(signable, domainSeparator);
+  const domainSeparatorHash = Buffer32.fromBuffer(
+    keccak256(
+      hexToBuffer(
+        encodeAbiParameters(parseAbiParameters('bytes32,bytes32,bytes32,uint256,address'), [
+          DOMAIN_TYPEHASH,
+          NAME_HASH,
+          VERSION_HASH,
+          BigInt(TEST_COORDINATION_SIGNATURE_CONTEXT.chainId),
+          TEST_COORDINATION_SIGNATURE_CONTEXT.rollupAddress.toString(),
+        ]),
+      ),
+    ),
+  );
+  const structHash = Buffer32.fromBuffer(
+    keccak256(
+      hexToBuffer(
+        encodeAbiParameters(parseAbiParameters('bytes32,bytes32'), [
+          TYPEHASHES[domainSeparator],
+          payloadHash.toString() as `0x${string}`,
+        ]),
+      ),
+    ),
+  );
+
+  return Buffer32.fromBuffer(
+    keccak256(Buffer.concat([Buffer.from('1901', 'hex'), domainSeparatorHash.toBuffer(), structHash.toBuffer()])),
+  );
+}
+
+describe('coordination signature typed data', () => {
+  it('matches the Solidity EIP-712 digest for all proposal-path message types', async () => {
+    const signer = Secp256k1Signer.random();
+    const blockProposal = await makeBlockProposal({ signer });
+    const checkpointProposal = await makeCheckpointProposal({ signer });
+    const checkpointAttestation = makeCheckpointAttestation({ signer });
+    const attestationsAndSigners = new CommitteeAttestationsAndSigners([
+      CommitteeAttestation.fromAddressAndSignature(signer.address, checkpointAttestation.signature),
+    ]);
+
+    expect(
+      getHashedSignaturePayloadTypedData(
+        blockProposal,
+        SignatureDomainSeparator.blockProposal,
+        TEST_COORDINATION_SIGNATURE_CONTEXT,
+      ),
+    ).toEqual(getSolidityCoordinationDigest(blockProposal, SignatureDomainSeparator.blockProposal));
+    expect(
+      getHashedSignaturePayloadTypedData(
+        checkpointProposal,
+        SignatureDomainSeparator.checkpointProposal,
+        TEST_COORDINATION_SIGNATURE_CONTEXT,
+      ),
+    ).toEqual(getSolidityCoordinationDigest(checkpointProposal, SignatureDomainSeparator.checkpointProposal));
+    expect(
+      getHashedSignaturePayloadTypedData(
+        checkpointAttestation.payload,
+        SignatureDomainSeparator.checkpointAttestation,
+        TEST_COORDINATION_SIGNATURE_CONTEXT,
+      ),
+    ).toEqual(
+      getSolidityCoordinationDigest(checkpointAttestation.payload, SignatureDomainSeparator.checkpointAttestation),
+    );
+    expect(
+      getHashedSignaturePayloadTypedData(
+        attestationsAndSigners,
+        SignatureDomainSeparator.attestationsAndSigners,
+        TEST_COORDINATION_SIGNATURE_CONTEXT,
+      ),
+    ).toEqual(getSolidityCoordinationDigest(attestationsAndSigners, SignatureDomainSeparator.attestationsAndSigners));
+  });
+
+  it('recovers with the right context and changes sender for the wrong domain', async () => {
+    const blockSigner = Secp256k1Signer.random();
+    const checkpointSigner = Secp256k1Signer.random();
+    const attesterSigner = Secp256k1Signer.random();
+    const proposerSigner = Secp256k1Signer.random();
+    const attestationsAndSignersSigner = Secp256k1Signer.random();
+
+    const blockProposal = await makeBlockProposal({ signer: blockSigner });
+    const checkpointProposal = await makeCheckpointProposal({
+      signer: checkpointSigner,
+    });
+    const checkpointAttestation = makeCheckpointAttestation({
+      attesterSigner,
+      proposerSigner,
+    });
+    const attestationsAndSigners = new CommitteeAttestationsAndSigners([
+      CommitteeAttestation.fromAddressAndSignature(attesterSigner.address, checkpointAttestation.signature),
+    ]);
+    const attestationsAndSignersSignature = makeAndSignCommitteeAttestationsAndSigners(
+      attestationsAndSigners,
+      attestationsAndSignersSigner,
+    );
+
+    expect(blockProposal.getSender(TEST_COORDINATION_SIGNATURE_CONTEXT)).toEqual(blockSigner.address);
+    expect(blockProposal.getSender(WRONG_CHAIN_CONTEXT)).not.toEqual(blockSigner.address);
+    expect(blockProposal.getSender(WRONG_ROLLUP_CONTEXT)).not.toEqual(blockSigner.address);
+
+    expect(checkpointProposal.getSender(TEST_COORDINATION_SIGNATURE_CONTEXT)).toEqual(checkpointSigner.address);
+    expect(checkpointProposal.getSender(WRONG_CHAIN_CONTEXT)).not.toEqual(checkpointSigner.address);
+    expect(checkpointProposal.getSender(WRONG_ROLLUP_CONTEXT)).not.toEqual(checkpointSigner.address);
+
+    expect(checkpointAttestation.getSender(TEST_COORDINATION_SIGNATURE_CONTEXT)).toEqual(attesterSigner.address);
+    expect(checkpointAttestation.getProposer(TEST_COORDINATION_SIGNATURE_CONTEXT)).toEqual(proposerSigner.address);
+    expect(checkpointAttestation.getSender(WRONG_CHAIN_CONTEXT)).not.toEqual(attesterSigner.address);
+    expect(checkpointAttestation.getSender(WRONG_ROLLUP_CONTEXT)).not.toEqual(attesterSigner.address);
+    expect(checkpointAttestation.getProposer(WRONG_CHAIN_CONTEXT)).not.toEqual(proposerSigner.address);
+    expect(checkpointAttestation.getProposer(WRONG_ROLLUP_CONTEXT)).not.toEqual(proposerSigner.address);
+
+    expect(
+      recoverCoordinationSigner(
+        attestationsAndSigners,
+        SignatureDomainSeparator.attestationsAndSigners,
+        attestationsAndSignersSignature,
+        TEST_COORDINATION_SIGNATURE_CONTEXT,
+      ),
+    ).toEqual(attestationsAndSignersSigner.address);
+    expect(
+      recoverCoordinationSigner(
+        attestationsAndSigners,
+        SignatureDomainSeparator.attestationsAndSigners,
+        attestationsAndSignersSignature,
+        WRONG_CHAIN_CONTEXT,
+      ),
+    ).not.toEqual(attestationsAndSignersSigner.address);
+    expect(
+      recoverCoordinationSigner(
+        attestationsAndSigners,
+        SignatureDomainSeparator.attestationsAndSigners,
+        attestationsAndSignersSignature,
+        WRONG_ROLLUP_CONTEXT,
+      ),
+    ).not.toEqual(attestationsAndSignersSigner.address);
+  });
+});

--- a/yarn-project/stdlib/src/p2p/signature_utils.ts
+++ b/yarn-project/stdlib/src/p2p/signature_utils.ts
@@ -1,33 +1,68 @@
 import { Buffer32 } from '@aztec/foundation/buffer';
 import { keccak256 } from '@aztec/foundation/crypto/keccak';
-import { makeEthSignDigest, tryRecoverAddress } from '@aztec/foundation/crypto/secp256k1-signer';
-import type { EthAddress } from '@aztec/foundation/eth-address';
+import { tryRecoverAddress } from '@aztec/foundation/crypto/secp256k1-signer';
+import { EthAddress } from '@aztec/foundation/eth-address';
 import type { Signature } from '@aztec/foundation/eth-signature';
+import { type BufferReader, serializeToBuffer } from '@aztec/foundation/serialize';
 
 import { type TypedDataDefinition, hashTypedData } from 'viem';
+import { z } from 'zod';
 
-export enum SignatureDomainSeparator {
-  blockProposal = 0,
-  checkpointAttestation = 1,
-  attestationsAndSigners = 2,
-  checkpointProposal = 3,
-  signedTxs = 4,
-}
+import type { ZodFor } from '../schemas/index.js';
 
-export interface Signable {
-  getPayloadToSign(domainSeparator: SignatureDomainSeparator): Buffer;
-}
+export type CoordinationSignatureType =
+  | 'BlockProposal'
+  | 'CheckpointProposal'
+  | 'CheckpointAttestation'
+  | 'AttestationsAndSigners'
+  | 'SignedTxs';
 
 export type CoordinationSignatureContext = {
   chainId: number;
   rollupAddress: EthAddress;
 };
 
-type CoordinationSignatureType =
-  | 'BlockProposal'
-  | 'CheckpointProposal'
-  | 'CheckpointAttestation'
-  | 'AttestationsAndSigners';
+export const EMPTY_COORDINATION_SIGNATURE_CONTEXT: CoordinationSignatureContext = {
+  chainId: 0,
+  rollupAddress: EthAddress.ZERO,
+};
+
+export const coordinationSignatureContextSchema: ZodFor<CoordinationSignatureContext> = z.object({
+  chainId: z.number(),
+  rollupAddress: EthAddress.schema,
+});
+
+export interface Signable {
+  readonly primaryType: CoordinationSignatureType;
+  readonly signatureContext: CoordinationSignatureContext;
+  getPayloadToSign(): Buffer;
+}
+
+export function coordinationSignatureContextEquals(
+  a: CoordinationSignatureContext,
+  b: CoordinationSignatureContext,
+): boolean {
+  return a.chainId === b.chainId && a.rollupAddress.equals(b.rollupAddress);
+}
+
+export function serializeCoordinationSignatureContext(ctx: CoordinationSignatureContext): Buffer {
+  return serializeToBuffer([ctx.chainId, ctx.rollupAddress]);
+}
+
+export function readCoordinationSignatureContext(reader: BufferReader): CoordinationSignatureContext {
+  const chainId = reader.readNumber();
+  const rollupAddress = reader.readObject(EthAddress);
+  return { chainId, rollupAddress };
+}
+
+/**
+ * Returns true if the signable carries a context matching the node's expected context.
+ * Use this at the P2P ingress boundary to reject foreign-chain messages cheaply before
+ * performing any signature recovery.
+ */
+export function hasValidSignatureContext(signable: Signable, expected: CoordinationSignatureContext): boolean {
+  return coordinationSignatureContextEquals(signable.signatureContext, expected);
+}
 
 const COORDINATION_SIGNATURE_NAME = 'Aztec Rollup';
 const COORDINATION_SIGNATURE_VERSION = '1';
@@ -45,26 +80,8 @@ const COORDINATION_SIGNATURE_TYPES = {
   CheckpointProposal: [{ name: 'payloadHash', type: 'bytes32' }],
   CheckpointAttestation: [{ name: 'payloadHash', type: 'bytes32' }],
   AttestationsAndSigners: [{ name: 'payloadHash', type: 'bytes32' }],
+  SignedTxs: [{ name: 'payloadHash', type: 'bytes32' }],
 } as const;
-
-function getCoordinationSignatureType(domainSeparator: SignatureDomainSeparator): CoordinationSignatureType {
-  switch (domainSeparator) {
-    case SignatureDomainSeparator.blockProposal:
-      return 'BlockProposal';
-    case SignatureDomainSeparator.checkpointProposal:
-      return 'CheckpointProposal';
-    case SignatureDomainSeparator.checkpointAttestation:
-      return 'CheckpointAttestation';
-    case SignatureDomainSeparator.attestationsAndSigners:
-      return 'AttestationsAndSigners';
-    case SignatureDomainSeparator.signedTxs:
-      throw new Error('SignedTxs does not use the coordination EIP-712 signature domain');
-  }
-}
-
-export function getCoordinationSignatureContextKey(context: CoordinationSignatureContext): string {
-  return `${context.chainId}:${context.rollupAddress.toString()}`;
-}
 
 export function getCoordinationSignatureTypedDataForPayloadHash(
   payloadHash: Buffer32,
@@ -86,55 +103,20 @@ export function getCoordinationSignatureTypedDataForPayloadHash(
   };
 }
 
-export function getCoordinationSignatureTypedData(
-  signable: Signable,
-  domainSeparator: SignatureDomainSeparator,
-  context: CoordinationSignatureContext,
-): TypedDataDefinition {
-  const payloadHash = getHashedSignaturePayload(signable, domainSeparator);
-  return getCoordinationSignatureTypedDataForPayloadHash(
-    payloadHash,
-    getCoordinationSignatureType(domainSeparator),
-    context,
-  );
+export function getCoordinationSignatureTypedData(signable: Signable): TypedDataDefinition {
+  const payloadHash = getHashedSignaturePayload(signable);
+  return getCoordinationSignatureTypedDataForPayloadHash(payloadHash, signable.primaryType, signable.signatureContext);
 }
 
-export function getHashedSignaturePayloadTypedData(
-  signable: Signable,
-  domainSeparator: SignatureDomainSeparator,
-  context: CoordinationSignatureContext,
-): Buffer32 {
-  return Buffer32.fromString(hashTypedData(getCoordinationSignatureTypedData(signable, domainSeparator, context)));
+export function getHashedSignaturePayloadTypedData(signable: Signable): Buffer32 {
+  return Buffer32.fromString(hashTypedData(getCoordinationSignatureTypedData(signable)));
 }
 
-export function recoverCoordinationSigner(
-  signable: Signable,
-  domainSeparator: SignatureDomainSeparator,
-  signature: Signature,
-  context: CoordinationSignatureContext,
-): EthAddress | undefined {
-  const digest = getHashedSignaturePayloadTypedData(signable, domainSeparator, context);
+export function recoverCoordinationSigner(signable: Signable, signature: Signature): EthAddress | undefined {
+  const digest = getHashedSignaturePayloadTypedData(signable);
   return tryRecoverAddress(digest, signature, { allowYParityAsV: true });
 }
 
-/**
- * Get the hashed payload for the signature of the `Signable`
- * @param s - The `Signable` to sign
- * @returns The hashed payload for the signature of the `Signable`
- */
-export function getHashedSignaturePayload(s: Signable, domainSeparator: SignatureDomainSeparator): Buffer32 {
-  return Buffer32.fromBuffer(keccak256(s.getPayloadToSign(domainSeparator)));
-}
-
-/**
- * Get the hashed payload for the signature of the `Signable` as an Ethereum signed message EIP-712
- * @param s - the `Signable` to sign
- * @returns The hashed payload for the signature of the `Signable` as an Ethereum signed message
- */
-export function getHashedSignaturePayloadEthSignedMessage(
-  s: Signable,
-  domainSeparator: SignatureDomainSeparator,
-): Buffer32 {
-  const payload = getHashedSignaturePayload(s, domainSeparator);
-  return makeEthSignDigest(payload);
+export function getHashedSignaturePayload(s: Signable): Buffer32 {
+  return Buffer32.fromBuffer(keccak256(s.getPayloadToSign()));
 }

--- a/yarn-project/stdlib/src/p2p/signature_utils.ts
+++ b/yarn-project/stdlib/src/p2p/signature_utils.ts
@@ -1,6 +1,10 @@
 import { Buffer32 } from '@aztec/foundation/buffer';
 import { keccak256 } from '@aztec/foundation/crypto/keccak';
-import { makeEthSignDigest } from '@aztec/foundation/crypto/secp256k1-signer';
+import { makeEthSignDigest, tryRecoverAddress } from '@aztec/foundation/crypto/secp256k1-signer';
+import type { EthAddress } from '@aztec/foundation/eth-address';
+import type { Signature } from '@aztec/foundation/eth-signature';
+
+import { type TypedDataDefinition, hashTypedData } from 'viem';
 
 export enum SignatureDomainSeparator {
   blockProposal = 0,
@@ -12,6 +16,105 @@ export enum SignatureDomainSeparator {
 
 export interface Signable {
   getPayloadToSign(domainSeparator: SignatureDomainSeparator): Buffer;
+}
+
+export type CoordinationSignatureContext = {
+  chainId: number;
+  rollupAddress: EthAddress;
+};
+
+type CoordinationSignatureType =
+  | 'BlockProposal'
+  | 'CheckpointProposal'
+  | 'CheckpointAttestation'
+  | 'AttestationsAndSigners';
+
+const COORDINATION_SIGNATURE_NAME = 'Aztec Rollup';
+const COORDINATION_SIGNATURE_VERSION = '1';
+
+const EIP712_DOMAIN_FIELDS = [
+  { name: 'name', type: 'string' },
+  { name: 'version', type: 'string' },
+  { name: 'chainId', type: 'uint256' },
+  { name: 'verifyingContract', type: 'address' },
+] as const;
+
+const COORDINATION_SIGNATURE_TYPES = {
+  EIP712Domain: EIP712_DOMAIN_FIELDS,
+  BlockProposal: [{ name: 'payloadHash', type: 'bytes32' }],
+  CheckpointProposal: [{ name: 'payloadHash', type: 'bytes32' }],
+  CheckpointAttestation: [{ name: 'payloadHash', type: 'bytes32' }],
+  AttestationsAndSigners: [{ name: 'payloadHash', type: 'bytes32' }],
+} as const;
+
+function getCoordinationSignatureType(domainSeparator: SignatureDomainSeparator): CoordinationSignatureType {
+  switch (domainSeparator) {
+    case SignatureDomainSeparator.blockProposal:
+      return 'BlockProposal';
+    case SignatureDomainSeparator.checkpointProposal:
+      return 'CheckpointProposal';
+    case SignatureDomainSeparator.checkpointAttestation:
+      return 'CheckpointAttestation';
+    case SignatureDomainSeparator.attestationsAndSigners:
+      return 'AttestationsAndSigners';
+    case SignatureDomainSeparator.signedTxs:
+      throw new Error('SignedTxs does not use the coordination EIP-712 signature domain');
+  }
+}
+
+export function getCoordinationSignatureContextKey(context: CoordinationSignatureContext): string {
+  return `${context.chainId}:${context.rollupAddress.toString()}`;
+}
+
+export function getCoordinationSignatureTypedDataForPayloadHash(
+  payloadHash: Buffer32,
+  type: CoordinationSignatureType,
+  context: CoordinationSignatureContext,
+): TypedDataDefinition {
+  return {
+    domain: {
+      name: COORDINATION_SIGNATURE_NAME,
+      version: COORDINATION_SIGNATURE_VERSION,
+      chainId: context.chainId,
+      verifyingContract: context.rollupAddress.toString() as `0x${string}`,
+    },
+    types: COORDINATION_SIGNATURE_TYPES,
+    primaryType: type,
+    message: {
+      payloadHash: payloadHash.toString() as `0x${string}`,
+    },
+  };
+}
+
+export function getCoordinationSignatureTypedData(
+  signable: Signable,
+  domainSeparator: SignatureDomainSeparator,
+  context: CoordinationSignatureContext,
+): TypedDataDefinition {
+  const payloadHash = getHashedSignaturePayload(signable, domainSeparator);
+  return getCoordinationSignatureTypedDataForPayloadHash(
+    payloadHash,
+    getCoordinationSignatureType(domainSeparator),
+    context,
+  );
+}
+
+export function getHashedSignaturePayloadTypedData(
+  signable: Signable,
+  domainSeparator: SignatureDomainSeparator,
+  context: CoordinationSignatureContext,
+): Buffer32 {
+  return Buffer32.fromString(hashTypedData(getCoordinationSignatureTypedData(signable, domainSeparator, context)));
+}
+
+export function recoverCoordinationSigner(
+  signable: Signable,
+  domainSeparator: SignatureDomainSeparator,
+  signature: Signature,
+  context: CoordinationSignatureContext,
+): EthAddress | undefined {
+  const digest = getHashedSignaturePayloadTypedData(signable, domainSeparator, context);
+  return tryRecoverAddress(digest, signature, { allowYParityAsV: true });
 }
 
 /**

--- a/yarn-project/stdlib/src/p2p/signed_txs.ts
+++ b/yarn-project/stdlib/src/p2p/signed_txs.ts
@@ -25,7 +25,7 @@ import {
 export class SignedTxs implements Signable {
   readonly primaryType: CoordinationSignatureType = 'SignedTxs';
 
-  private cachedSender: EthAddress | undefined | null = null;
+  private cachedSender: EthAddress | undefined | null = undefined;
 
   constructor(
     /** The transactions */
@@ -45,10 +45,10 @@ export class SignedTxs implements Signable {
    * @returns The sender address, or undefined if signature recovery fails
    */
   getSender(): EthAddress | undefined {
-    if (this.cachedSender === null) {
-      this.cachedSender = recoverCoordinationSigner(this, this.signature);
+    if (this.cachedSender === undefined) {
+      this.cachedSender = recoverCoordinationSigner(this, this.signature) ?? null;
     }
-    return this.cachedSender;
+    return this.cachedSender ?? undefined;
   }
 
   /**

--- a/yarn-project/stdlib/src/p2p/signed_txs.ts
+++ b/yarn-project/stdlib/src/p2p/signed_txs.ts
@@ -1,15 +1,20 @@
-import { Buffer32 } from '@aztec/foundation/buffer';
-import { tryRecoverAddress } from '@aztec/foundation/crypto/secp256k1-signer';
 import type { EthAddress } from '@aztec/foundation/eth-address';
 import { Signature } from '@aztec/foundation/eth-signature';
 import { BufferReader, serializeToBuffer } from '@aztec/foundation/serialize';
 
+import type { TypedDataDefinition } from 'viem';
+
 import { MAX_TXS_PER_BLOCK } from '../deserialization/index.js';
 import { Tx } from '../tx/tx.js';
 import {
-  SignatureDomainSeparator,
-  getHashedSignaturePayload,
-  getHashedSignaturePayloadEthSignedMessage,
+  type CoordinationSignatureContext,
+  type CoordinationSignatureType,
+  EMPTY_COORDINATION_SIGNATURE_CONTEXT,
+  type Signable,
+  getCoordinationSignatureTypedData,
+  readCoordinationSignatureContext,
+  recoverCoordinationSigner,
+  serializeCoordinationSignatureContext,
 } from './signature_utils.js';
 
 /**
@@ -17,50 +22,56 @@ import {
  * The signature is over the transaction objects themselves, providing
  * data availability guarantees beyond just the transaction hashes.
  */
-export class SignedTxs {
-  private sender: EthAddress | undefined;
+export class SignedTxs implements Signable {
+  readonly primaryType: CoordinationSignatureType = 'SignedTxs';
+
+  private cachedSender: EthAddress | undefined | null = null;
 
   constructor(
     /** The transactions */
     public readonly txs: Tx[],
     /** The proposer's signature over the transactions */
     public readonly signature: Signature,
+    /** The signing domain (chainId + rollupAddress) the signature is bound to */
+    public readonly signatureContext: CoordinationSignatureContext,
   ) {}
 
-  /**
-   * Get the payload to sign for this signed txs.
-   */
-  getPayloadToSign(domainSeparator: SignatureDomainSeparator): Buffer {
-    return serializeToBuffer([domainSeparator, this.txs.length, this.txs]);
+  getPayloadToSign(): Buffer {
+    return serializeToBuffer([this.txs.length, this.txs]);
   }
 
   /**
-   * Lazily evaluate the sender of the signed txs; result is cached
+   * Lazily evaluate the sender of the signed txs; result is cached.
    * @returns The sender address, or undefined if signature recovery fails
    */
   getSender(): EthAddress | undefined {
-    if (!this.sender) {
-      const hashed = getHashedSignaturePayloadEthSignedMessage(this, SignatureDomainSeparator.signedTxs);
-      this.sender = tryRecoverAddress(hashed, this.signature);
+    if (this.cachedSender === null) {
+      this.cachedSender = recoverCoordinationSigner(this, this.signature);
     }
-    return this.sender;
+    return this.cachedSender;
   }
 
   /**
-   * Create SignedTxs from a signer function
+   * Create SignedTxs from a typed-data signer function
    */
   static async createFromSigner(
     txs: Tx[],
-    payloadSigner: (payload: Buffer32) => Promise<Signature>,
+    signatureContext: CoordinationSignatureContext,
+    typedDataSigner: (typedData: TypedDataDefinition) => Promise<Signature>,
   ): Promise<SignedTxs> {
-    const tempSignedTxs = new SignedTxs(txs, Signature.empty());
-    const hashed = getHashedSignaturePayload(tempSignedTxs, SignatureDomainSeparator.signedTxs);
-    const signature = await payloadSigner(hashed);
-    return new SignedTxs(txs, signature);
+    const tempSignedTxs = new SignedTxs(txs, Signature.empty(), signatureContext);
+    const typedData = getCoordinationSignatureTypedData(tempSignedTxs);
+    const signature = await typedDataSigner(typedData);
+    return new SignedTxs(txs, signature, signatureContext);
   }
 
   toBuffer(): Buffer {
-    return serializeToBuffer([this.txs.length, this.txs, this.signature]);
+    return serializeToBuffer([
+      this.txs.length,
+      this.txs,
+      this.signature,
+      serializeCoordinationSignatureContext(this.signatureContext),
+    ]);
   }
 
   static fromBuffer(buf: Buffer | BufferReader): SignedTxs {
@@ -71,18 +82,25 @@ export class SignedTxs {
     }
     const txs = reader.readArray(txCount, Tx);
     const signature = reader.readObject(Signature);
-    return new SignedTxs(txs, signature);
+    const signatureContext = readCoordinationSignatureContext(reader);
+    return new SignedTxs(txs, signature, signatureContext);
   }
 
   getSize(): number {
-    return 4 /* txs.length */ + this.txs.reduce((acc, tx) => acc + tx.getSize(), 0) + this.signature.getSize();
+    return (
+      4 /* txs.length */ +
+      this.txs.reduce((acc, tx) => acc + tx.getSize(), 0) +
+      this.signature.getSize() +
+      4 /* chainId */ +
+      20 /* rollupAddress */
+    );
   }
 
   static empty(): SignedTxs {
-    return new SignedTxs([], Signature.empty());
+    return new SignedTxs([], Signature.empty(), EMPTY_COORDINATION_SIGNATURE_CONTEXT);
   }
 
   static random(): SignedTxs {
-    return new SignedTxs([Tx.random(), Tx.random()], Signature.random());
+    return new SignedTxs([Tx.random(), Tx.random()], Signature.random(), EMPTY_COORDINATION_SIGNATURE_CONTEXT);
   }
 }

--- a/yarn-project/stdlib/src/tests/mocks.ts
+++ b/yarn-project/stdlib/src/tests/mocks.ts
@@ -54,12 +54,7 @@ import { BlockProposal } from '../p2p/block_proposal.js';
 import { CheckpointAttestation } from '../p2p/checkpoint_attestation.js';
 import { CheckpointProposal } from '../p2p/checkpoint_proposal.js';
 import { ConsensusPayload } from '../p2p/consensus_payload.js';
-import {
-  type CoordinationSignatureContext,
-  SignatureDomainSeparator,
-  getHashedSignaturePayloadEthSignedMessage,
-  getHashedSignaturePayloadTypedData,
-} from '../p2p/signature_utils.js';
+import { type CoordinationSignatureContext, getHashedSignaturePayloadTypedData } from '../p2p/signature_utils.js';
 import { ChonkProof } from '../proofs/chonk_proof.js';
 import { ProvingRequestType } from '../proofs/proving_request_type.js';
 import { CheckpointHeader } from '../rollup/checkpoint_header.js';
@@ -536,6 +531,7 @@ export interface MakeConsensusPayloadOptions {
   txHashes?: TxHash[];
   txs?: Tx[];
   feeAssetPriceModifier?: bigint;
+  signatureContext?: CoordinationSignatureContext;
 }
 
 export interface MakeBlockProposalOptions {
@@ -546,6 +542,7 @@ export interface MakeBlockProposalOptions {
   archiveRoot?: Fr;
   txHashes?: TxHash[];
   txs?: Tx[];
+  signatureContext?: CoordinationSignatureContext;
 }
 
 export interface MakeCheckpointProposalOptions {
@@ -553,6 +550,7 @@ export interface MakeCheckpointProposalOptions {
   checkpointHeader?: CheckpointHeader;
   archiveRoot?: Fr;
   feeAssetPriceModifier?: bigint;
+  signatureContext?: CoordinationSignatureContext;
   /** Options for the lastBlock - if undefined, no lastBlock is included */
   lastBlock?: {
     blockHeader?: BlockHeader;
@@ -563,10 +561,7 @@ export interface MakeCheckpointProposalOptions {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-const makeAndSignConsensusPayload = (
-  domainSeparator: SignatureDomainSeparator,
-  options?: MakeConsensusPayloadOptions,
-) => {
+const makeAndSignConsensusPayload = (options?: MakeConsensusPayloadOptions) => {
   const header = options?.header ?? makeCheckpointHeader(1);
   const { signer = Secp256k1Signer.random(), archive = Fr.random(), feeAssetPriceModifier = 0n } = options ?? {};
 
@@ -574,12 +569,10 @@ const makeAndSignConsensusPayload = (
     header,
     archive,
     feeAssetPriceModifier,
+    signatureContext: TEST_COORDINATION_SIGNATURE_CONTEXT,
   });
 
-  const hash =
-    domainSeparator === SignatureDomainSeparator.signedTxs
-      ? getHashedSignaturePayloadEthSignedMessage(payload, domainSeparator)
-      : getHashedSignaturePayloadTypedData(payload, domainSeparator, TEST_COORDINATION_SIGNATURE_CONTEXT);
+  const hash = getHashedSignaturePayloadTypedData(payload);
   const signature = signer.sign(hash);
 
   return { blockNumber: header.slotNumber, payload, signature };
@@ -589,11 +582,7 @@ export const makeAndSignCommitteeAttestationsAndSigners = (
   attestationsAndSigners: CommitteeAttestationsAndSigners,
   signer: Secp256k1Signer = Secp256k1Signer.random(),
 ) => {
-  const hash = getHashedSignaturePayloadTypedData(
-    attestationsAndSigners,
-    SignatureDomainSeparator.attestationsAndSigners,
-    TEST_COORDINATION_SIGNATURE_CONTEXT,
-  );
+  const hash = getHashedSignaturePayloadTypedData(attestationsAndSigners);
   return signer.sign(hash);
 };
 
@@ -605,6 +594,7 @@ export const makeBlockProposal = (options?: MakeBlockProposalOptions): Promise<B
   const txHashes = options?.txHashes ?? [0, 1, 2, 3, 4, 5].map(() => TxHash.random());
   const txs = options?.txs;
   const signer = options?.signer ?? Secp256k1Signer.random();
+  const signatureContext = options?.signatureContext ?? TEST_COORDINATION_SIGNATURE_CONTEXT;
 
   return BlockProposal.createProposalFromSigner(
     blockHeader,
@@ -614,9 +604,9 @@ export const makeBlockProposal = (options?: MakeBlockProposalOptions): Promise<B
     archiveRoot,
     txHashes,
     txs,
-    TEST_COORDINATION_SIGNATURE_CONTEXT,
+    signatureContext,
     (typedData, _context) => Promise.resolve(signTypedData(signer, typedData)),
-    (payload, _context) => Promise.resolve(signer.signMessage(payload)),
+    (typedData, _context) => Promise.resolve(signTypedData(signer, typedData)),
   );
 };
 
@@ -625,6 +615,7 @@ export const makeCheckpointProposal = async (options?: MakeCheckpointProposalOpt
   const archiveRoot = options?.archiveRoot ?? Fr.random();
   const feeAssetPriceModifier = options?.feeAssetPriceModifier ?? 0n;
   const signer = options?.signer ?? Secp256k1Signer.random();
+  const signatureContext = options?.signatureContext ?? TEST_COORDINATION_SIGNATURE_CONTEXT;
 
   // Build a signed block proposal if lastBlock options are provided
   const lastBlockProposal = options?.lastBlock
@@ -636,6 +627,7 @@ export const makeCheckpointProposal = async (options?: MakeCheckpointProposalOpt
         txHashes: options.lastBlock.txHashes,
         txs: options.lastBlock.txs,
         signer,
+        signatureContext,
       })
     : undefined;
 
@@ -645,7 +637,7 @@ export const makeCheckpointProposal = async (options?: MakeCheckpointProposalOpt
     CheckpointNumber(1),
     feeAssetPriceModifier,
     lastBlockProposal,
-    TEST_COORDINATION_SIGNATURE_CONTEXT,
+    signatureContext,
     typedData => Promise.resolve(signTypedData(signer, typedData)),
   );
 };
@@ -660,6 +652,7 @@ export type MakeCheckpointAttestationOptions = {
   attesterSigner?: Secp256k1Signer;
   proposerSigner?: Secp256k1Signer;
   signer?: Secp256k1Signer;
+  signatureContext?: CoordinationSignatureContext;
 };
 
 /**
@@ -669,28 +662,27 @@ export const makeCheckpointAttestation = (options: MakeCheckpointAttestationOpti
   const header = options.header ?? makeCheckpointHeader(1);
   const archive = options.archive ?? Fr.random();
   const feeAssetPriceModifier = options.feeAssetPriceModifier ?? 0n;
+  const signatureContext = options.signatureContext ?? TEST_COORDINATION_SIGNATURE_CONTEXT;
   const { signer, attesterSigner = signer, proposerSigner = signer } = options;
 
-  const payload = new ConsensusPayload(header, archive, feeAssetPriceModifier);
+  const payload = new ConsensusPayload(header, archive, feeAssetPriceModifier, signatureContext);
 
   // Sign as attester
-  const attestationHash = getHashedSignaturePayloadTypedData(
-    payload,
-    SignatureDomainSeparator.checkpointAttestation,
-    TEST_COORDINATION_SIGNATURE_CONTEXT,
-  );
+  const attestationHash = getHashedSignaturePayloadTypedData(payload);
   const attestationSigner = attesterSigner ?? Secp256k1Signer.random();
   const attestationSignature = attestationSigner.sign(attestationHash);
 
   // Sign as proposer - use CheckpointProposal's payload format (serializeToBuffer)
   // This is different from ConsensusPayload's format (ABI encoding)
   const proposalSignerToUse = proposerSigner ?? Secp256k1Signer.random();
-  const tempProposal = new CheckpointProposal(header, archive, feeAssetPriceModifier, Signature.empty());
-  const proposalHash = getHashedSignaturePayloadTypedData(
-    tempProposal,
-    SignatureDomainSeparator.checkpointProposal,
-    TEST_COORDINATION_SIGNATURE_CONTEXT,
+  const tempProposal = new CheckpointProposal(
+    header,
+    archive,
+    feeAssetPriceModifier,
+    Signature.empty(),
+    signatureContext,
   );
+  const proposalHash = getHashedSignaturePayloadTypedData(tempProposal);
   const proposerSignature = proposalSignerToUse.sign(proposalHash);
 
   return new CheckpointAttestation(payload, attestationSignature, proposerSignature);
@@ -703,14 +695,15 @@ export const makeCheckpointAttestationFromProposal = (
   proposal: CheckpointProposal,
   attesterSigner?: Secp256k1Signer,
 ): CheckpointAttestation => {
-  const payload = new ConsensusPayload(proposal.checkpointHeader, proposal.archive, proposal.feeAssetPriceModifier);
+  const payload = new ConsensusPayload(
+    proposal.checkpointHeader,
+    proposal.archive,
+    proposal.feeAssetPriceModifier,
+    proposal.signatureContext,
+  );
 
   // Sign as attester
-  const attestationHash = getHashedSignaturePayloadTypedData(
-    payload,
-    SignatureDomainSeparator.checkpointAttestation,
-    TEST_COORDINATION_SIGNATURE_CONTEXT,
-  );
+  const attestationHash = getHashedSignaturePayloadTypedData(payload);
   const attestationSigner = attesterSigner ?? Secp256k1Signer.random();
   const attestationSignature = attestationSigner.sign(attestationHash);
 

--- a/yarn-project/stdlib/src/tests/mocks.ts
+++ b/yarn-project/stdlib/src/tests/mocks.ts
@@ -14,7 +14,10 @@ import { padArrayEnd, times } from '@aztec/foundation/collection';
 import { randomBytes } from '@aztec/foundation/crypto/random';
 import { Secp256k1Signer } from '@aztec/foundation/crypto/secp256k1-signer';
 import { Fr } from '@aztec/foundation/curves/bn254';
+import { EthAddress } from '@aztec/foundation/eth-address';
 import { Signature } from '@aztec/foundation/eth-signature';
+
+import { type TypedDataDefinition, hashTypedData } from 'viem';
 
 import type { ContractArtifact } from '../abi/abi.js';
 import { PublicTxEffect } from '../avm/avm.js';
@@ -51,7 +54,12 @@ import { BlockProposal } from '../p2p/block_proposal.js';
 import { CheckpointAttestation } from '../p2p/checkpoint_attestation.js';
 import { CheckpointProposal } from '../p2p/checkpoint_proposal.js';
 import { ConsensusPayload } from '../p2p/consensus_payload.js';
-import { SignatureDomainSeparator, getHashedSignaturePayloadEthSignedMessage } from '../p2p/signature_utils.js';
+import {
+  type CoordinationSignatureContext,
+  SignatureDomainSeparator,
+  getHashedSignaturePayloadEthSignedMessage,
+  getHashedSignaturePayloadTypedData,
+} from '../p2p/signature_utils.js';
 import { ChonkProof } from '../proofs/chonk_proof.js';
 import { ProvingRequestType } from '../proofs/proving_request_type.js';
 import { CheckpointHeader } from '../rollup/checkpoint_header.js';
@@ -85,6 +93,15 @@ import {
   makePublicCallRequest,
   makePublicDataWrite,
 } from './factories.js';
+
+export const TEST_COORDINATION_SIGNATURE_CONTEXT: CoordinationSignatureContext = {
+  chainId: 31337,
+  rollupAddress: EthAddress.fromNumber(1),
+};
+
+function signTypedData(signer: Secp256k1Signer, typedData: TypedDataDefinition): Signature {
+  return signer.sign(Buffer32.fromString(hashTypedData(typedData)));
+}
 
 export const randomTxHash = (): TxHash => TxHash.random();
 
@@ -559,7 +576,10 @@ const makeAndSignConsensusPayload = (
     feeAssetPriceModifier,
   });
 
-  const hash = getHashedSignaturePayloadEthSignedMessage(payload, domainSeparator);
+  const hash =
+    domainSeparator === SignatureDomainSeparator.signedTxs
+      ? getHashedSignaturePayloadEthSignedMessage(payload, domainSeparator)
+      : getHashedSignaturePayloadTypedData(payload, domainSeparator, TEST_COORDINATION_SIGNATURE_CONTEXT);
   const signature = signer.sign(hash);
 
   return { blockNumber: header.slotNumber, payload, signature };
@@ -569,9 +589,10 @@ export const makeAndSignCommitteeAttestationsAndSigners = (
   attestationsAndSigners: CommitteeAttestationsAndSigners,
   signer: Secp256k1Signer = Secp256k1Signer.random(),
 ) => {
-  const hash = getHashedSignaturePayloadEthSignedMessage(
+  const hash = getHashedSignaturePayloadTypedData(
     attestationsAndSigners,
     SignatureDomainSeparator.attestationsAndSigners,
+    TEST_COORDINATION_SIGNATURE_CONTEXT,
   );
   return signer.sign(hash);
 };
@@ -593,7 +614,9 @@ export const makeBlockProposal = (options?: MakeBlockProposalOptions): Promise<B
     archiveRoot,
     txHashes,
     txs,
-    (_payload, _context) => Promise.resolve(signer.signMessage(_payload)),
+    TEST_COORDINATION_SIGNATURE_CONTEXT,
+    (typedData, _context) => Promise.resolve(signTypedData(signer, typedData)),
+    (payload, _context) => Promise.resolve(signer.signMessage(payload)),
   );
 };
 
@@ -622,7 +645,8 @@ export const makeCheckpointProposal = async (options?: MakeCheckpointProposalOpt
     CheckpointNumber(1),
     feeAssetPriceModifier,
     lastBlockProposal,
-    payload => Promise.resolve(signer.signMessage(payload)),
+    TEST_COORDINATION_SIGNATURE_CONTEXT,
+    typedData => Promise.resolve(signTypedData(signer, typedData)),
   );
 };
 
@@ -650,9 +674,10 @@ export const makeCheckpointAttestation = (options: MakeCheckpointAttestationOpti
   const payload = new ConsensusPayload(header, archive, feeAssetPriceModifier);
 
   // Sign as attester
-  const attestationHash = getHashedSignaturePayloadEthSignedMessage(
+  const attestationHash = getHashedSignaturePayloadTypedData(
     payload,
     SignatureDomainSeparator.checkpointAttestation,
+    TEST_COORDINATION_SIGNATURE_CONTEXT,
   );
   const attestationSigner = attesterSigner ?? Secp256k1Signer.random();
   const attestationSignature = attestationSigner.sign(attestationHash);
@@ -661,9 +686,10 @@ export const makeCheckpointAttestation = (options: MakeCheckpointAttestationOpti
   // This is different from ConsensusPayload's format (ABI encoding)
   const proposalSignerToUse = proposerSigner ?? Secp256k1Signer.random();
   const tempProposal = new CheckpointProposal(header, archive, feeAssetPriceModifier, Signature.empty());
-  const proposalHash = getHashedSignaturePayloadEthSignedMessage(
+  const proposalHash = getHashedSignaturePayloadTypedData(
     tempProposal,
     SignatureDomainSeparator.checkpointProposal,
+    TEST_COORDINATION_SIGNATURE_CONTEXT,
   );
   const proposerSignature = proposalSignerToUse.sign(proposalHash);
 
@@ -680,9 +706,10 @@ export const makeCheckpointAttestationFromProposal = (
   const payload = new ConsensusPayload(proposal.checkpointHeader, proposal.archive, proposal.feeAssetPriceModifier);
 
   // Sign as attester
-  const attestationHash = getHashedSignaturePayloadEthSignedMessage(
+  const attestationHash = getHashedSignaturePayloadTypedData(
     payload,
     SignatureDomainSeparator.checkpointAttestation,
+    TEST_COORDINATION_SIGNATURE_CONTEXT,
   );
   const attestationSigner = attesterSigner ?? Secp256k1Signer.random();
   const attestationSignature = attestationSigner.sign(attestationHash);

--- a/yarn-project/validator-client/src/config.ts
+++ b/yarn-project/validator-client/src/config.ts
@@ -30,6 +30,12 @@ export const validatorClientConfigMappings: ConfigMappingsType<ValidatorClientCo
         .map(address => EthAddress.fromString(address.trim())),
     defaultValue: [],
   },
+  l1ChainId: {
+    env: 'L1_CHAIN_ID',
+    description: 'The chain ID of the ethereum host.',
+    parseEnv: (val: string) => +val,
+    defaultValue: 31337,
+  },
   disableValidator: {
     env: 'VALIDATOR_DISABLED',
     description: 'Do not run the validator',

--- a/yarn-project/validator-client/src/duties/validation_service.test.ts
+++ b/yarn-project/validator-client/src/duties/validation_service.test.ts
@@ -3,7 +3,12 @@ import { CheckpointNumber, IndexWithinCheckpoint } from '@aztec/foundation/brand
 import { Buffer32 } from '@aztec/foundation/buffer';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { EthAddress } from '@aztec/foundation/eth-address';
-import { makeBlockHeader, makeCheckpointHeader, makeCheckpointProposal } from '@aztec/stdlib/testing';
+import {
+  TEST_COORDINATION_SIGNATURE_CONTEXT,
+  makeBlockHeader,
+  makeCheckpointHeader,
+  makeCheckpointProposal,
+} from '@aztec/stdlib/testing';
 import { Tx } from '@aztec/stdlib/tx';
 import { DutyType } from '@aztec/validator-ha-signer/types';
 
@@ -22,7 +27,7 @@ describe('ValidationService', () => {
     keys = [generatePrivateKey(), generatePrivateKey()];
     addresses = keys.map(key => EthAddress.fromString(getAddressFromPrivateKey(key)));
     store = new LocalKeyStore(keys.map(key => Buffer32.fromString(key)));
-    service = new ValidationService(store);
+    service = new ValidationService(store, TEST_COORDINATION_SIGNATURE_CONTEXT);
   });
 
   it('creates a block proposal with txs appended', async () => {
@@ -42,7 +47,7 @@ describe('ValidationService', () => {
       addresses[0],
       { publishFullTxs: true },
     );
-    expect(proposal.getSender()).toEqual(store.getAddress(0));
+    expect(proposal.getSender(TEST_COORDINATION_SIGNATURE_CONTEXT)).toEqual(store.getAddress(0));
     expect(proposal.txs).toBeDefined();
     expect(proposal.txs).toBe(txs);
   });
@@ -64,7 +69,7 @@ describe('ValidationService', () => {
       addresses[0],
       { publishFullTxs: false },
     );
-    expect(proposal.getSender()).toEqual(addresses[0]);
+    expect(proposal.getSender(TEST_COORDINATION_SIGNATURE_CONTEXT)).toEqual(addresses[0]);
     expect(proposal.txs).toBeUndefined();
   });
 
@@ -73,8 +78,8 @@ describe('ValidationService', () => {
     const proposal = await makeCheckpointProposal({ lastBlock: { txs } });
     const attestations = await service.attestToCheckpointProposal(proposal, addresses, CheckpointNumber(1));
     expect(attestations.length).toBe(2);
-    expect(attestations[0].getSender()).toEqual(addresses[0]);
-    expect(attestations[1].getSender()).toEqual(addresses[1]);
+    expect(attestations[0].getSender(TEST_COORDINATION_SIGNATURE_CONTEXT)).toEqual(addresses[0]);
+    expect(attestations[1].getSender(TEST_COORDINATION_SIGNATURE_CONTEXT)).toEqual(addresses[1]);
   });
 
   it('creates checkpoint proposal with an already-signed block proposal', async () => {
@@ -101,17 +106,17 @@ describe('ValidationService', () => {
     const capturedContexts: Array<{ dutyType: DutyType; blockIndexWithinCheckpoint?: number }> = [];
     const spyStore = {
       ...store,
-      signMessageWithAddress: (address: EthAddress, message: Buffer32, context: any) => {
+      signTypedDataWithAddress: (address: EthAddress, typedData: any, context: any) => {
         capturedContexts.push({
           dutyType: context.dutyType,
           blockIndexWithinCheckpoint: context.blockIndexWithinCheckpoint,
         });
-        return store.signMessageWithAddress(address, message, context);
+        return store.signTypedDataWithAddress(address, typedData, context);
       },
       getAddress: (index: number) => store.getAddress(index),
       getAddresses: () => store.getAddresses(),
     };
-    const spyService = new ValidationService(spyStore as any);
+    const spyService = new ValidationService(spyStore as any, TEST_COORDINATION_SIGNATURE_CONTEXT);
 
     // Create checkpoint proposal with the already-signed block proposal
     const proposal = await spyService.createCheckpointProposal(
@@ -125,7 +130,7 @@ describe('ValidationService', () => {
     );
 
     // Verify proposal was created successfully
-    expect(proposal.getSender()).toEqual(addresses[0]);
+    expect(proposal.getSender(TEST_COORDINATION_SIGNATURE_CONTEXT)).toEqual(addresses[0]);
     expect(proposal.lastBlock).toBeDefined();
     expect(proposal.lastBlock!.signature).toEqual(blockProposal.signature);
 

--- a/yarn-project/validator-client/src/duties/validation_service.test.ts
+++ b/yarn-project/validator-client/src/duties/validation_service.test.ts
@@ -47,7 +47,7 @@ describe('ValidationService', () => {
       addresses[0],
       { publishFullTxs: true },
     );
-    expect(proposal.getSender(TEST_COORDINATION_SIGNATURE_CONTEXT)).toEqual(store.getAddress(0));
+    expect(proposal.getSender()).toEqual(store.getAddress(0));
     expect(proposal.txs).toBeDefined();
     expect(proposal.txs).toBe(txs);
   });
@@ -69,7 +69,7 @@ describe('ValidationService', () => {
       addresses[0],
       { publishFullTxs: false },
     );
-    expect(proposal.getSender(TEST_COORDINATION_SIGNATURE_CONTEXT)).toEqual(addresses[0]);
+    expect(proposal.getSender()).toEqual(addresses[0]);
     expect(proposal.txs).toBeUndefined();
   });
 
@@ -78,8 +78,8 @@ describe('ValidationService', () => {
     const proposal = await makeCheckpointProposal({ lastBlock: { txs } });
     const attestations = await service.attestToCheckpointProposal(proposal, addresses, CheckpointNumber(1));
     expect(attestations.length).toBe(2);
-    expect(attestations[0].getSender(TEST_COORDINATION_SIGNATURE_CONTEXT)).toEqual(addresses[0]);
-    expect(attestations[1].getSender(TEST_COORDINATION_SIGNATURE_CONTEXT)).toEqual(addresses[1]);
+    expect(attestations[0].getSender()).toEqual(addresses[0]);
+    expect(attestations[1].getSender()).toEqual(addresses[1]);
   });
 
   it('creates checkpoint proposal with an already-signed block proposal', async () => {
@@ -130,7 +130,7 @@ describe('ValidationService', () => {
     );
 
     // Verify proposal was created successfully
-    expect(proposal.getSender(TEST_COORDINATION_SIGNATURE_CONTEXT)).toEqual(addresses[0]);
+    expect(proposal.getSender()).toEqual(addresses[0]);
     expect(proposal.lastBlock).toBeDefined();
     expect(proposal.lastBlock!.signature).toEqual(blockProposal.signature);
 

--- a/yarn-project/validator-client/src/duties/validation_service.ts
+++ b/yarn-project/validator-client/src/duties/validation_service.ts
@@ -3,7 +3,7 @@ import { Fr } from '@aztec/foundation/curves/bn254';
 import type { EthAddress } from '@aztec/foundation/eth-address';
 import type { Signature } from '@aztec/foundation/eth-signature';
 import { createLogger } from '@aztec/foundation/log';
-import type { CommitteeAttestationsAndSigners } from '@aztec/stdlib/block';
+import { CommitteeAttestationsAndSigners } from '@aztec/stdlib/block';
 import {
   BlockProposal,
   type BlockProposalOptions,
@@ -13,7 +13,6 @@ import {
   type CheckpointProposalOptions,
   ConsensusPayload,
   type CoordinationSignatureContext,
-  SignatureDomainSeparator,
   getCoordinationSignatureTypedData,
 } from '@aztec/stdlib/p2p';
 import type { CheckpointHeader } from '@aztec/stdlib/rollup';
@@ -67,8 +66,10 @@ export class ValidationService {
       typedData: Parameters<ValidatorKeyStore['signTypedDataWithAddress']>[1],
       context: SigningContext,
     ) => this.keyStore.signTypedDataWithAddress(address, typedData, context);
-    const txsSigner = (payload: Parameters<ValidatorKeyStore['signMessageWithAddress']>[1], context: SigningContext) =>
-      this.keyStore.signMessageWithAddress(address, payload, context);
+    const txsSigner = (
+      typedData: Parameters<ValidatorKeyStore['signTypedDataWithAddress']>[1],
+      context: SigningContext,
+    ) => this.keyStore.signTypedDataWithAddress(address, typedData, context);
 
     return BlockProposal.createProposalFromSigner(
       blockHeader,
@@ -148,12 +149,13 @@ export class ValidationService {
     checkpointNumber: CheckpointNumber,
   ): Promise<CheckpointAttestation[]> {
     // Create the attestation payload from the checkpoint proposal
-    const payload = new ConsensusPayload(proposal.checkpointHeader, proposal.archive, proposal.feeAssetPriceModifier);
-    const typedData = getCoordinationSignatureTypedData(
-      payload,
-      SignatureDomainSeparator.checkpointAttestation,
+    const payload = new ConsensusPayload(
+      proposal.checkpointHeader,
+      proposal.archive,
+      proposal.feeAssetPriceModifier,
       this.signatureContext,
     );
+    const typedData = getCoordinationSignatureTypedData(payload);
 
     const context: SigningContext = {
       slot: proposal.slotNumber,
@@ -211,11 +213,7 @@ export class ValidationService {
       dutyType: DutyType.ATTESTATIONS_AND_SIGNERS,
     };
 
-    const typedData = getCoordinationSignatureTypedData(
-      attestationsAndSigners,
-      SignatureDomainSeparator.attestationsAndSigners,
-      this.signatureContext,
-    );
+    const typedData = getCoordinationSignatureTypedData(attestationsAndSigners);
     return this.keyStore.signTypedDataWithAddress(proposer, typedData, context);
   }
 }

--- a/yarn-project/validator-client/src/duties/validation_service.ts
+++ b/yarn-project/validator-client/src/duties/validation_service.ts
@@ -1,6 +1,4 @@
 import { type CheckpointNumber, IndexWithinCheckpoint, type SlotNumber } from '@aztec/foundation/branded-types';
-import { Buffer32 } from '@aztec/foundation/buffer';
-import { keccak256 } from '@aztec/foundation/crypto/keccak';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import type { EthAddress } from '@aztec/foundation/eth-address';
 import type { Signature } from '@aztec/foundation/eth-signature';
@@ -14,7 +12,9 @@ import {
   type CheckpointProposalCore,
   type CheckpointProposalOptions,
   ConsensusPayload,
+  type CoordinationSignatureContext,
   SignatureDomainSeparator,
+  getCoordinationSignatureTypedData,
 } from '@aztec/stdlib/p2p';
 import type { CheckpointHeader } from '@aztec/stdlib/rollup';
 import type { BlockHeader, Tx } from '@aztec/stdlib/tx';
@@ -26,6 +26,7 @@ import type { ValidatorKeyStore } from '../key_store/interface.js';
 export class ValidationService {
   constructor(
     private keyStore: ValidatorKeyStore,
+    private signatureContext: CoordinationSignatureContext,
     private log = createLogger('validator:validation-service'),
   ) {}
 
@@ -62,7 +63,11 @@ export class ValidationService {
 
     // Create a signer that uses the appropriate address
     const address = proposerAttesterAddress ?? this.keyStore.getAddress(0);
-    const payloadSigner = (payload: Buffer32, context: SigningContext) =>
+    const payloadSigner = (
+      typedData: Parameters<ValidatorKeyStore['signTypedDataWithAddress']>[1],
+      context: SigningContext,
+    ) => this.keyStore.signTypedDataWithAddress(address, typedData, context);
+    const txsSigner = (payload: Parameters<ValidatorKeyStore['signMessageWithAddress']>[1], context: SigningContext) =>
       this.keyStore.signMessageWithAddress(address, payload, context);
 
     return BlockProposal.createProposalFromSigner(
@@ -73,7 +78,9 @@ export class ValidationService {
       archive,
       txs.map(tx => tx.getTxHash()),
       options.publishFullTxs ? txs : undefined,
+      this.signatureContext,
       payloadSigner,
+      txsSigner,
     );
   }
 
@@ -106,9 +113,12 @@ export class ValidationService {
     }
 
     // Create a signer that takes payload and context, and uses the appropriate address
-    const payloadSigner = (payload: Buffer32, context: SigningContext) => {
+    const payloadSigner = (
+      typedData: Parameters<ValidatorKeyStore['signTypedDataWithAddress']>[1],
+      context: SigningContext,
+    ) => {
       const address = proposerAttesterAddress ?? this.keyStore.getAddress(0);
-      return this.keyStore.signMessageWithAddress(address, payload, context);
+      return this.keyStore.signTypedDataWithAddress(address, typedData, context);
     };
 
     return CheckpointProposal.createProposalFromSigner(
@@ -117,6 +127,7 @@ export class ValidationService {
       checkpointNumber,
       feeAssetPriceModifier,
       lastBlockProposal,
+      this.signatureContext,
       payloadSigner,
     );
   }
@@ -138,8 +149,10 @@ export class ValidationService {
   ): Promise<CheckpointAttestation[]> {
     // Create the attestation payload from the checkpoint proposal
     const payload = new ConsensusPayload(proposal.checkpointHeader, proposal.archive, proposal.feeAssetPriceModifier);
-    const buf = Buffer32.fromBuffer(
-      keccak256(payload.getPayloadToSign(SignatureDomainSeparator.checkpointAttestation)),
+    const typedData = getCoordinationSignatureTypedData(
+      payload,
+      SignatureDomainSeparator.checkpointAttestation,
+      this.signatureContext,
     );
 
     const context: SigningContext = {
@@ -151,8 +164,7 @@ export class ValidationService {
     // Sign each attestor in parallel, catching HA errors per-attestor
     const results = await Promise.allSettled(
       attestors.map(async attestor => {
-        const sig = await this.keyStore.signMessageWithAddress(attestor, buf, context);
-        // return new BlockAttestation(proposal.payload, sig, proposal.signature);
+        const sig = await this.keyStore.signTypedDataWithAddress(attestor, typedData, context);
         return new CheckpointAttestation(payload, sig, proposal.signature);
       }),
     );
@@ -199,9 +211,11 @@ export class ValidationService {
       dutyType: DutyType.ATTESTATIONS_AND_SIGNERS,
     };
 
-    const buf = Buffer32.fromBuffer(
-      keccak256(attestationsAndSigners.getPayloadToSign(SignatureDomainSeparator.attestationsAndSigners)),
+    const typedData = getCoordinationSignatureTypedData(
+      attestationsAndSigners,
+      SignatureDomainSeparator.attestationsAndSigners,
+      this.signatureContext,
     );
-    return this.keyStore.signMessageWithAddress(proposer, buf, context);
+    return this.keyStore.signTypedDataWithAddress(proposer, typedData, context);
   }
 }

--- a/yarn-project/validator-client/src/factory.ts
+++ b/yarn-project/validator-client/src/factory.ts
@@ -28,10 +28,17 @@ export function createProposalHandler(
     telemetry: TelemetryClient;
   },
 ) {
-  const metrics = new ValidatorMetrics(deps.telemetry);
+  const metrics = new ValidatorMetrics(deps.telemetry, {
+    chainId: config.l1ChainId,
+    rollupAddress: config.l1Contracts.rollupAddress,
+  });
   const blockProposalValidator = new BlockProposalValidator(deps.epochCache, {
     txsPermitted: !config.disableTransactions,
     maxTxsPerBlock: config.validateMaxTxsPerBlock ?? config.validateMaxTxsPerCheckpoint,
+    signatureContext: {
+      chainId: config.l1ChainId,
+      rollupAddress: config.l1Contracts.rollupAddress,
+    },
   });
   return new ProposalHandler(
     deps.checkpointsBuilder,

--- a/yarn-project/validator-client/src/factory.ts
+++ b/yarn-project/validator-client/src/factory.ts
@@ -28,10 +28,7 @@ export function createProposalHandler(
     telemetry: TelemetryClient;
   },
 ) {
-  const metrics = new ValidatorMetrics(deps.telemetry, {
-    chainId: config.l1ChainId,
-    rollupAddress: config.l1Contracts.rollupAddress,
-  });
+  const metrics = new ValidatorMetrics(deps.telemetry);
   const blockProposalValidator = new BlockProposalValidator(deps.epochCache, {
     txsPermitted: !config.disableTransactions,
     maxTxsPerBlock: config.validateMaxTxsPerBlock ?? config.validateMaxTxsPerCheckpoint,

--- a/yarn-project/validator-client/src/metrics.ts
+++ b/yarn-project/validator-client/src/metrics.ts
@@ -1,6 +1,6 @@
 import type { EpochNumber } from '@aztec/foundation/branded-types';
 import type { EthAddress } from '@aztec/foundation/eth-address';
-import type { BlockProposal, CoordinationSignatureContext } from '@aztec/stdlib/p2p';
+import type { BlockProposal } from '@aztec/stdlib/p2p';
 import {
   Attributes,
   type Gauge,
@@ -27,10 +27,7 @@ export class ValidatorMetrics {
   private checkpointProposalToPipelinedStateDuration: Histogram;
   private checkpointProposalReceiveOffsetFromNextSlotBoundary: Histogram;
 
-  constructor(
-    telemetryClient: TelemetryClient,
-    private signatureContext: CoordinationSignatureContext,
-  ) {
+  constructor(telemetryClient: TelemetryClient) {
     const meter = telemetryClient.getMeter('Validator');
 
     this.failedReexecutionCounter = createUpDownCounterWithDefault(meter, Metrics.VALIDATOR_FAILED_REEXECUTION_COUNT, {
@@ -107,7 +104,7 @@ export class ValidatorMetrics {
   }
 
   public recordFailedReexecution(proposal: BlockProposal) {
-    const proposer = proposal.getSender(this.signatureContext);
+    const proposer = proposal.getSender();
     this.failedReexecutionCounter.add(1, {
       [Attributes.STATUS]: 'failed',
       [Attributes.BLOCK_PROPOSER]: proposer?.toString() ?? 'unknown',

--- a/yarn-project/validator-client/src/metrics.ts
+++ b/yarn-project/validator-client/src/metrics.ts
@@ -1,6 +1,6 @@
 import type { EpochNumber } from '@aztec/foundation/branded-types';
 import type { EthAddress } from '@aztec/foundation/eth-address';
-import type { BlockProposal } from '@aztec/stdlib/p2p';
+import type { BlockProposal, CoordinationSignatureContext } from '@aztec/stdlib/p2p';
 import {
   Attributes,
   type Gauge,
@@ -27,7 +27,10 @@ export class ValidatorMetrics {
   private checkpointProposalToPipelinedStateDuration: Histogram;
   private checkpointProposalReceiveOffsetFromNextSlotBoundary: Histogram;
 
-  constructor(telemetryClient: TelemetryClient) {
+  constructor(
+    telemetryClient: TelemetryClient,
+    private signatureContext: CoordinationSignatureContext,
+  ) {
     const meter = telemetryClient.getMeter('Validator');
 
     this.failedReexecutionCounter = createUpDownCounterWithDefault(meter, Metrics.VALIDATOR_FAILED_REEXECUTION_COUNT, {
@@ -104,7 +107,7 @@ export class ValidatorMetrics {
   }
 
   public recordFailedReexecution(proposal: BlockProposal) {
-    const proposer = proposal.getSender();
+    const proposer = proposal.getSender(this.signatureContext);
     this.failedReexecutionCounter.add(1, {
       [Attributes.STATUS]: 'failed',
       [Attributes.BLOCK_PROPOSER]: proposer?.toString() ?? 'unknown',

--- a/yarn-project/validator-client/src/proposal_handler.test.ts
+++ b/yarn-project/validator-client/src/proposal_handler.test.ts
@@ -14,7 +14,12 @@ import type { ITxProvider, ValidatorClientFullConfig, WorldStateSynchronizer } f
 import type { L1ToL2MessageSource } from '@aztec/stdlib/messaging';
 import { accumulateCheckpointOutHashes } from '@aztec/stdlib/messaging';
 import { CheckpointHeader } from '@aztec/stdlib/rollup';
-import { makeBlockHeader, makeCheckpointHeader, makeCheckpointProposal } from '@aztec/stdlib/testing';
+import {
+  TEST_COORDINATION_SIGNATURE_CONTEXT,
+  makeBlockHeader,
+  makeCheckpointHeader,
+  makeCheckpointProposal,
+} from '@aztec/stdlib/testing';
 import { AppendOnlyTreeSnapshot } from '@aztec/stdlib/trees';
 import { GlobalVariables } from '@aztec/stdlib/tx';
 
@@ -77,7 +82,10 @@ describe('ProposalHandler checkpoint validation', () => {
     dateProvider = new TestDateProvider();
     metrics = mock<ValidatorMetrics>();
 
-    config = {} as ValidatorClientFullConfig;
+    config = {
+      l1ChainId: TEST_COORDINATION_SIGNATURE_CONTEXT.chainId,
+      l1Contracts: { rollupAddress: TEST_COORDINATION_SIGNATURE_CONTEXT.rollupAddress },
+    } as ValidatorClientFullConfig;
 
     handler = new ProposalHandler(
       checkpointsBuilder,

--- a/yarn-project/validator-client/src/proposal_handler.ts
+++ b/yarn-project/validator-client/src/proposal_handler.ts
@@ -24,7 +24,12 @@ import {
   accumulateCheckpointOutHashes,
   computeInHashFromL1ToL2Messages,
 } from '@aztec/stdlib/messaging';
-import type { BlockProposal, CheckpointAttestation, CheckpointProposalCore } from '@aztec/stdlib/p2p';
+import type {
+  BlockProposal,
+  CheckpointAttestation,
+  CheckpointProposalCore,
+  CoordinationSignatureContext,
+} from '@aztec/stdlib/p2p';
 import { MerkleTreeId } from '@aztec/stdlib/trees';
 import type { CheckpointGlobalVariables, FailedTx, Tx } from '@aztec/stdlib/tx';
 import {
@@ -122,6 +127,13 @@ export class ProposalHandler {
     this.tracer = telemetry.getTracer('ProposalHandler');
   }
 
+  private getSignatureContext(): CoordinationSignatureContext {
+    return {
+      chainId: this.config.l1ChainId,
+      rollupAddress: this.config.l1Contracts.rollupAddress,
+    };
+  }
+
   /**
    * Registers handlers for block and checkpoint proposals on the p2p client.
    * Block proposals are registered for non-validator nodes (validators register their own enhanced handler).
@@ -181,11 +193,11 @@ export class ProposalHandler {
         const proposalInfo: LogData = {
           slot: proposal.slotNumber,
           archive: proposal.archive.toString(),
-          proposer: proposal.getSender()?.toString(),
+          proposer: proposal.getSender(this.getSignatureContext())?.toString(),
         };
 
         // For own proposals, skip validation — the proposer already built and validated the checkpoint
-        const proposer = proposal.getSender();
+        const proposer = proposal.getSender(this.getSignatureContext());
         const ownAddresses = this.getOwnValidatorAddresses?.();
         const isOwnProposal = proposer && ownAddresses?.some(addr => addr === proposer.toString());
 
@@ -221,7 +233,7 @@ export class ProposalHandler {
     shouldReexecute: boolean,
   ): Promise<BlockProposalValidationResult> {
     const slotNumber = proposal.slotNumber;
-    const proposer = proposal.getSender();
+    const proposer = proposal.getSender(this.getSignatureContext());
     const config = this.checkpointsBuilder.getConfig();
 
     // Reject proposals with invalid signatures
@@ -745,7 +757,7 @@ export class ProposalHandler {
       return this.lastCheckpointValidationResult.result;
     }
 
-    const proposer = proposal.getSender();
+    const proposer = proposal.getSender(this.getSignatureContext());
     if (!proposer) {
       this.log.warn(`Received checkpoint proposal with invalid signature for slot ${proposal.slotNumber}`);
       const result: CheckpointProposalValidationResult = { isValid: false, reason: 'invalid_signature' };

--- a/yarn-project/validator-client/src/proposal_handler.ts
+++ b/yarn-project/validator-client/src/proposal_handler.ts
@@ -24,12 +24,7 @@ import {
   accumulateCheckpointOutHashes,
   computeInHashFromL1ToL2Messages,
 } from '@aztec/stdlib/messaging';
-import type {
-  BlockProposal,
-  CheckpointAttestation,
-  CheckpointProposalCore,
-  CoordinationSignatureContext,
-} from '@aztec/stdlib/p2p';
+import type { BlockProposal, CheckpointAttestation, CheckpointProposalCore } from '@aztec/stdlib/p2p';
 import { MerkleTreeId } from '@aztec/stdlib/trees';
 import type { CheckpointGlobalVariables, FailedTx, Tx } from '@aztec/stdlib/tx';
 import {
@@ -127,13 +122,6 @@ export class ProposalHandler {
     this.tracer = telemetry.getTracer('ProposalHandler');
   }
 
-  private getSignatureContext(): CoordinationSignatureContext {
-    return {
-      chainId: this.config.l1ChainId,
-      rollupAddress: this.config.l1Contracts.rollupAddress,
-    };
-  }
-
   /**
    * Registers handlers for block and checkpoint proposals on the p2p client.
    * Block proposals are registered for non-validator nodes (validators register their own enhanced handler).
@@ -193,11 +181,11 @@ export class ProposalHandler {
         const proposalInfo: LogData = {
           slot: proposal.slotNumber,
           archive: proposal.archive.toString(),
-          proposer: proposal.getSender(this.getSignatureContext())?.toString(),
+          proposer: proposal.getSender()?.toString(),
         };
 
         // For own proposals, skip validation — the proposer already built and validated the checkpoint
-        const proposer = proposal.getSender(this.getSignatureContext());
+        const proposer = proposal.getSender();
         const ownAddresses = this.getOwnValidatorAddresses?.();
         const isOwnProposal = proposer && ownAddresses?.some(addr => addr === proposer.toString());
 
@@ -233,7 +221,7 @@ export class ProposalHandler {
     shouldReexecute: boolean,
   ): Promise<BlockProposalValidationResult> {
     const slotNumber = proposal.slotNumber;
-    const proposer = proposal.getSender(this.getSignatureContext());
+    const proposer = proposal.getSender();
     const config = this.checkpointsBuilder.getConfig();
 
     // Reject proposals with invalid signatures
@@ -757,7 +745,7 @@ export class ProposalHandler {
       return this.lastCheckpointValidationResult.result;
     }
 
-    const proposer = proposal.getSender(this.getSignatureContext());
+    const proposer = proposal.getSender();
     if (!proposer) {
       this.log.warn(`Received checkpoint proposal with invalid signature for slot ${proposal.slotNumber}`);
       const result: CheckpointProposalValidationResult = { isValid: false, reason: 'invalid_signature' };

--- a/yarn-project/validator-client/src/validator.ha.integration.test.ts
+++ b/yarn-project/validator-client/src/validator.ha.integration.test.ts
@@ -20,7 +20,13 @@ import type { L2BlockSink, L2BlockSource } from '@aztec/stdlib/block';
 import type { SlasherConfig, ValidatorClientFullConfig, WorldStateSynchronizer } from '@aztec/stdlib/interfaces/server';
 import { computeInHashFromL1ToL2Messages } from '@aztec/stdlib/messaging';
 import type { L1ToL2MessageSource } from '@aztec/stdlib/messaging';
-import { makeBlockHeader, makeCheckpointHeader, makeCheckpointProposal, mockTx } from '@aztec/stdlib/testing';
+import {
+  TEST_COORDINATION_SIGNATURE_CONTEXT,
+  makeBlockHeader,
+  makeCheckpointHeader,
+  makeCheckpointProposal,
+  mockTx,
+} from '@aztec/stdlib/testing';
 import { TxHash } from '@aztec/stdlib/tx';
 import { type TelemetryClient, getTelemetryClient } from '@aztec/telemetry-client';
 import { INSERT_SCHEMA_VERSION, SCHEMA_SETUP, SCHEMA_VERSION } from '@aztec/validator-ha-signer/db';
@@ -123,7 +129,7 @@ describe('ValidatorClient HA Integration', () => {
     };
     keyStoreManager = new KeystoreManager(keyStore);
 
-    rollupAddress = EthAddress.random();
+    rollupAddress = TEST_COORDINATION_SIGNATURE_CONTEXT.rollupAddress;
 
     // Create 5 HA validator instances for use across all tests
     const baseConfig: ValidatorClientConfig &
@@ -137,6 +143,7 @@ describe('ValidatorClient HA Integration', () => {
       disabledValidators: [],
       slashBroadcastedInvalidBlockPenalty: 1n,
       l1Contracts: { rollupAddress },
+      l1ChainId: TEST_COORDINATION_SIGNATURE_CONTEXT.chainId,
       slashDuplicateProposalPenalty: 1n,
       slashDuplicateAttestationPenalty: 1n,
       haSigningEnabled: true,
@@ -196,10 +203,11 @@ describe('ValidatorClient HA Integration', () => {
     const haKeyStore = new HAKeyStore(baseKeyStore, haSigner);
 
     // Create block proposal handler
-    const metrics = new ValidatorMetrics(getTelemetryClient());
+    const metrics = new ValidatorMetrics(getTelemetryClient(), TEST_COORDINATION_SIGNATURE_CONTEXT);
     const blockProposalValidator = new BlockProposalValidator(epochCache, {
       txsPermitted: true,
       maxTxsPerBlock: undefined,
+      signatureContext: TEST_COORDINATION_SIGNATURE_CONTEXT,
     });
     const proposalHandler = new ProposalHandler(
       checkpointsBuilder,
@@ -312,7 +320,7 @@ describe('ValidatorClient HA Integration', () => {
       const successfulResult = results.find(r => r.status === 'fulfilled') as PromiseFulfilledResult<any> | undefined;
       expect(successfulResult).toBeDefined();
       expect(successfulResult?.value).toBeDefined();
-      expect(successfulResult?.value?.getSender()).toEqual(proposerAddress);
+      expect(successfulResult?.value?.getSender(TEST_COORDINATION_SIGNATURE_CONTEXT)).toEqual(proposerAddress);
     });
 
     it('should allow different validators to create proposals for different slots', async () => {
@@ -342,7 +350,7 @@ describe('ValidatorClient HA Integration', () => {
       expect(proposals).toHaveLength(5);
       proposals.forEach(proposal => {
         expect(proposal).toBeDefined();
-        expect(proposal.getSender()).toEqual(proposerAddress);
+        expect(proposal.getSender(TEST_COORDINATION_SIGNATURE_CONTEXT)).toEqual(proposerAddress);
       });
     });
 

--- a/yarn-project/validator-client/src/validator.ha.integration.test.ts
+++ b/yarn-project/validator-client/src/validator.ha.integration.test.ts
@@ -203,7 +203,7 @@ describe('ValidatorClient HA Integration', () => {
     const haKeyStore = new HAKeyStore(baseKeyStore, haSigner);
 
     // Create block proposal handler
-    const metrics = new ValidatorMetrics(getTelemetryClient(), TEST_COORDINATION_SIGNATURE_CONTEXT);
+    const metrics = new ValidatorMetrics(getTelemetryClient());
     const blockProposalValidator = new BlockProposalValidator(epochCache, {
       txsPermitted: true,
       maxTxsPerBlock: undefined,
@@ -320,7 +320,7 @@ describe('ValidatorClient HA Integration', () => {
       const successfulResult = results.find(r => r.status === 'fulfilled') as PromiseFulfilledResult<any> | undefined;
       expect(successfulResult).toBeDefined();
       expect(successfulResult?.value).toBeDefined();
-      expect(successfulResult?.value?.getSender(TEST_COORDINATION_SIGNATURE_CONTEXT)).toEqual(proposerAddress);
+      expect(successfulResult?.value?.getSender()).toEqual(proposerAddress);
     });
 
     it('should allow different validators to create proposals for different slots', async () => {
@@ -350,7 +350,7 @@ describe('ValidatorClient HA Integration', () => {
       expect(proposals).toHaveLength(5);
       proposals.forEach(proposal => {
         expect(proposal).toBeDefined();
-        expect(proposal.getSender(TEST_COORDINATION_SIGNATURE_CONTEXT)).toEqual(proposerAddress);
+        expect(proposal.getSender()).toEqual(proposerAddress);
       });
     });
 

--- a/yarn-project/validator-client/src/validator.integration.test.ts
+++ b/yarn-project/validator-client/src/validator.integration.test.ts
@@ -402,9 +402,7 @@ describe('ValidatorClient Integration', () => {
       const attestations = await attestor.validator.attestToCheckpointProposal(proposal, mockPeerId);
       expect(attestations).toBeDefined();
       expect(attestations).toHaveLength(1);
-      expect(attestations![0].getSender({ chainId: chainId.toNumber(), rollupAddress })).toEqual(
-        validatorSigner.address,
-      );
+      expect(attestations![0].getSender()).toEqual(validatorSigner.address);
 
       // Verify blocks are in archiver and hashes match
       await attestor.archiver.syncImmediate();
@@ -439,9 +437,7 @@ describe('ValidatorClient Integration', () => {
       const attestations = await attestor.validator.attestToCheckpointProposal(proposal, mockPeerId);
       expect(attestations).toBeDefined();
       expect(attestations).toHaveLength(1);
-      expect(attestations![0].getSender({ chainId: chainId.toNumber(), rollupAddress })).toEqual(
-        validatorSigner.address,
-      );
+      expect(attestations![0].getSender()).toEqual(validatorSigner.address);
 
       // Verify blocks are in archiver and hashes match
       await attestor.archiver.syncImmediate();

--- a/yarn-project/validator-client/src/validator.integration.test.ts
+++ b/yarn-project/validator-client/src/validator.integration.test.ts
@@ -36,6 +36,7 @@ import { getGenesisValues } from '@aztec/world-state/testing';
 
 import { describe, expect, it, jest } from '@jest/globals';
 import { type MockProxy, mock } from 'jest-mock-extended';
+import { hashTypedData } from 'viem';
 import { generatePrivateKey } from 'viem/accounts';
 
 import { CheckpointBuilder, FullNodeCheckpointsBuilder } from './checkpoint_builder.js';
@@ -162,6 +163,7 @@ describe('ValidatorClient Integration', () => {
     const validator = await ValidatorClient.new(
       {
         l1Contracts: { rollupAddress },
+        l1ChainId: chainId.toNumber(),
         validatorPrivateKeys: new SecretValue([privateKey]),
         attestationPollingIntervalMs: 100,
         disableValidator: false,
@@ -400,7 +402,9 @@ describe('ValidatorClient Integration', () => {
       const attestations = await attestor.validator.attestToCheckpointProposal(proposal, mockPeerId);
       expect(attestations).toBeDefined();
       expect(attestations).toHaveLength(1);
-      expect(attestations![0].getSender()).toEqual(validatorSigner.address);
+      expect(attestations![0].getSender({ chainId: chainId.toNumber(), rollupAddress })).toEqual(
+        validatorSigner.address,
+      );
 
       // Verify blocks are in archiver and hashes match
       await attestor.archiver.syncImmediate();
@@ -435,7 +439,9 @@ describe('ValidatorClient Integration', () => {
       const attestations = await attestor.validator.attestToCheckpointProposal(proposal, mockPeerId);
       expect(attestations).toBeDefined();
       expect(attestations).toHaveLength(1);
-      expect(attestations![0].getSender()).toEqual(validatorSigner.address);
+      expect(attestations![0].getSender({ chainId: chainId.toNumber(), rollupAddress })).toEqual(
+        validatorSigner.address,
+      );
 
       // Verify blocks are in archiver and hashes match
       await attestor.archiver.syncImmediate();
@@ -545,7 +551,8 @@ describe('ValidatorClient Integration', () => {
         CheckpointNumber(1),
         0n,
         undefined,
-        payload => Promise.resolve(proposerSigner.sign(payload)),
+        { chainId: chainId.toNumber(), rollupAddress },
+        typedData => Promise.resolve(proposerSigner.sign(Buffer32.fromString(hashTypedData(typedData)))),
       );
 
       await attestorValidateBlocks(blocks);

--- a/yarn-project/validator-client/src/validator.test.ts
+++ b/yarn-project/validator-client/src/validator.test.ts
@@ -231,7 +231,7 @@ describe('ValidatorClient', () => {
       expect(blockProposal).toBeDefined();
 
       const validatorAddress = EthAddress.fromString(validatorAccounts[0].address);
-      expect(blockProposal?.getSender(TEST_COORDINATION_SIGNATURE_CONTEXT)).toEqual(validatorAddress);
+      expect(blockProposal?.getSender()).toEqual(validatorAddress);
       expect(blockProposal!.txs).toBeUndefined();
     });
   });
@@ -389,9 +389,7 @@ describe('ValidatorClient', () => {
         ts: 0n,
         nowSeconds: 0n,
       });
-      epochCache.getProposerAttesterAddressInSlot.mockResolvedValue(
-        proposal.getSender(TEST_COORDINATION_SIGNATURE_CONTEXT),
-      );
+      epochCache.getProposerAttesterAddressInSlot.mockResolvedValue(proposal.getSender());
       epochCache.filterInCommittee.mockResolvedValue([EthAddress.fromString(validatorAccounts[0].address)]);
       epochCache.isEscapeHatchOpenAtSlot.mockResolvedValue(false);
 
@@ -461,9 +459,7 @@ describe('ValidatorClient', () => {
 
       // Under pipelining, the target slot is the future slot the proposer is building for,
       // and the expected proposer for that slot is whoever signed the future proposal.
-      epochCache.getProposerAttesterAddressInSlot.mockResolvedValue(
-        futureProposal.getSender(TEST_COORDINATION_SIGNATURE_CONTEXT),
-      );
+      epochCache.getProposerAttesterAddressInSlot.mockResolvedValue(futureProposal.getSender());
       epochCache.getTargetAndNextSlot.mockReturnValue({
         targetSlot: futureSlot,
         nextSlot: SlotNumber(futureSlot + 1),
@@ -676,7 +672,7 @@ describe('ValidatorClient', () => {
       expect(isValid).toBe(false);
 
       // We should emit WANT_TO_SLASH_EVENT
-      const proposer = proposal.getSender(TEST_COORDINATION_SIGNATURE_CONTEXT);
+      const proposer = proposal.getSender();
       expect(proposer).toBeDefined();
       expect(emitSpy).toHaveBeenCalledWith(WANT_TO_SLASH_EVENT, [
         {
@@ -789,9 +785,7 @@ describe('ValidatorClient', () => {
     });
 
     it('should return false if the proposal is not for the current or next slot', async () => {
-      epochCache.getProposerAttesterAddressInSlot.mockResolvedValue(
-        proposal.getSender(TEST_COORDINATION_SIGNATURE_CONTEXT),
-      );
+      epochCache.getProposerAttesterAddressInSlot.mockResolvedValue(proposal.getSender());
       epochCache.getTargetAndNextSlot.mockReturnValue({
         targetSlot: SlotNumber(proposal.slotNumber + 20),
         nextSlot: SlotNumber(proposal.slotNumber + 21),
@@ -870,9 +864,7 @@ describe('ValidatorClient', () => {
         });
 
         // Update epochCache mock for the new proposal
-        epochCache.getProposerAttesterAddressInSlot.mockResolvedValue(
-          nonFirstBlockProposal.getSender(TEST_COORDINATION_SIGNATURE_CONTEXT),
-        );
+        epochCache.getProposerAttesterAddressInSlot.mockResolvedValue(nonFirstBlockProposal.getSender());
         epochCache.getTargetAndNextSlot.mockReturnValue({
           targetSlot: nonFirstBlockProposal.slotNumber,
           nextSlot: SlotNumber(nonFirstBlockProposal.slotNumber + 1),

--- a/yarn-project/validator-client/src/validator.test.ts
+++ b/yarn-project/validator-client/src/validator.test.ts
@@ -35,6 +35,7 @@ import type { SlasherConfig, WorldStateSynchronizer } from '@aztec/stdlib/interf
 import { type L1ToL2MessageSource, computeInHashFromL1ToL2Messages } from '@aztec/stdlib/messaging';
 import type { BlockProposal } from '@aztec/stdlib/p2p';
 import {
+  TEST_COORDINATION_SIGNATURE_CONTEXT,
   makeBlockHeader,
   makeBlockProposal,
   makeCheckpointAttestation,
@@ -182,7 +183,8 @@ describe('ValidatorClient', () => {
       slashDuplicateAttestationPenalty: 1n,
       disableTransactions: false,
       haSigningEnabled: false,
-      l1Contracts: { rollupAddress: EthAddress.random() },
+      l1ChainId: TEST_COORDINATION_SIGNATURE_CONTEXT.chainId,
+      l1Contracts: { rollupAddress: TEST_COORDINATION_SIGNATURE_CONTEXT.rollupAddress },
       nodeId: 'test-node-id',
       pollingIntervalMs: 1000,
       signingTimeoutMs: 1000,
@@ -229,7 +231,7 @@ describe('ValidatorClient', () => {
       expect(blockProposal).toBeDefined();
 
       const validatorAddress = EthAddress.fromString(validatorAccounts[0].address);
-      expect(blockProposal?.getSender()).toEqual(validatorAddress);
+      expect(blockProposal?.getSender(TEST_COORDINATION_SIGNATURE_CONTEXT)).toEqual(validatorAddress);
       expect(blockProposal!.txs).toBeUndefined();
     });
   });
@@ -387,7 +389,9 @@ describe('ValidatorClient', () => {
         ts: 0n,
         nowSeconds: 0n,
       });
-      epochCache.getProposerAttesterAddressInSlot.mockResolvedValue(proposal.getSender());
+      epochCache.getProposerAttesterAddressInSlot.mockResolvedValue(
+        proposal.getSender(TEST_COORDINATION_SIGNATURE_CONTEXT),
+      );
       epochCache.filterInCommittee.mockResolvedValue([EthAddress.fromString(validatorAccounts[0].address)]);
       epochCache.isEscapeHatchOpenAtSlot.mockResolvedValue(false);
 
@@ -457,7 +461,9 @@ describe('ValidatorClient', () => {
 
       // Under pipelining, the target slot is the future slot the proposer is building for,
       // and the expected proposer for that slot is whoever signed the future proposal.
-      epochCache.getProposerAttesterAddressInSlot.mockResolvedValue(futureProposal.getSender());
+      epochCache.getProposerAttesterAddressInSlot.mockResolvedValue(
+        futureProposal.getSender(TEST_COORDINATION_SIGNATURE_CONTEXT),
+      );
       epochCache.getTargetAndNextSlot.mockReturnValue({
         targetSlot: futureSlot,
         nextSlot: SlotNumber(futureSlot + 1),
@@ -670,7 +676,7 @@ describe('ValidatorClient', () => {
       expect(isValid).toBe(false);
 
       // We should emit WANT_TO_SLASH_EVENT
-      const proposer = proposal.getSender();
+      const proposer = proposal.getSender(TEST_COORDINATION_SIGNATURE_CONTEXT);
       expect(proposer).toBeDefined();
       expect(emitSpy).toHaveBeenCalledWith(WANT_TO_SLASH_EVENT, [
         {
@@ -783,7 +789,9 @@ describe('ValidatorClient', () => {
     });
 
     it('should return false if the proposal is not for the current or next slot', async () => {
-      epochCache.getProposerAttesterAddressInSlot.mockResolvedValue(proposal.getSender());
+      epochCache.getProposerAttesterAddressInSlot.mockResolvedValue(
+        proposal.getSender(TEST_COORDINATION_SIGNATURE_CONTEXT),
+      );
       epochCache.getTargetAndNextSlot.mockReturnValue({
         targetSlot: SlotNumber(proposal.slotNumber + 20),
         nextSlot: SlotNumber(proposal.slotNumber + 21),
@@ -862,7 +870,9 @@ describe('ValidatorClient', () => {
         });
 
         // Update epochCache mock for the new proposal
-        epochCache.getProposerAttesterAddressInSlot.mockResolvedValue(nonFirstBlockProposal.getSender());
+        epochCache.getProposerAttesterAddressInSlot.mockResolvedValue(
+          nonFirstBlockProposal.getSender(TEST_COORDINATION_SIGNATURE_CONTEXT),
+        );
         epochCache.getTargetAndNextSlot.mockReturnValue({
           targetSlot: nonFirstBlockProposal.slotNumber,
           nextSlot: SlotNumber(nonFirstBlockProposal.slotNumber + 1),

--- a/yarn-project/validator-client/src/validator.ts
+++ b/yarn-project/validator-client/src/validator.ts
@@ -114,7 +114,7 @@ export class ValidatorClient extends (EventEmitter as new () => WatcherEmitter) 
     this.log = config.fishermanMode ? log.createChild('[FISHERMAN]') : log;
 
     this.tracer = telemetry.getTracer('Validator');
-    this.metrics = new ValidatorMetrics(telemetry, this.getSignatureContext());
+    this.metrics = new ValidatorMetrics(telemetry);
 
     this.validationService = new ValidationService(
       keyStore,
@@ -197,10 +197,7 @@ export class ValidatorClient extends (EventEmitter as new () => WatcherEmitter) 
     telemetry: TelemetryClient = getTelemetryClient(),
     slashingProtectionDb?: SlashingProtectionDatabase,
   ) {
-    const metrics = new ValidatorMetrics(telemetry, {
-      chainId: config.l1ChainId,
-      rollupAddress: config.l1Contracts.rollupAddress,
-    });
+    const metrics = new ValidatorMetrics(telemetry);
     const blockProposalValidator = new BlockProposalValidator(epochCache, {
       txsPermitted: !config.disableTransactions,
       maxTxsPerBlock: config.validateMaxTxsPerBlock,
@@ -395,7 +392,7 @@ export class ValidatorClient extends (EventEmitter as new () => WatcherEmitter) 
     // but we intentionally reject them and disable slashing invalid block and attestation flow.
     const escapeHatchOpen = await this.epochCache.isEscapeHatchOpenAtSlot(slotNumber);
 
-    const proposer = proposal.getSender(this.getSignatureContext());
+    const proposer = proposal.getSender();
 
     // Reject proposals with invalid signatures
     if (!proposer) {
@@ -498,7 +495,7 @@ export class ValidatorClient extends (EventEmitter as new () => WatcherEmitter) 
     _proposalSender: PeerId,
   ): Promise<CheckpointAttestation[] | undefined> {
     const proposalSlotNumber = proposal.slotNumber;
-    const proposer = proposal.getSender(this.getSignatureContext());
+    const proposer = proposal.getSender();
 
     // If escape hatch is open for this slot's epoch, do not attest.
     if (await this.epochCache.isEscapeHatchOpenAtSlot(proposalSlotNumber)) {
@@ -672,7 +669,7 @@ export class ValidatorClient extends (EventEmitter as new () => WatcherEmitter) 
   }
 
   private slashInvalidBlock(proposal: BlockProposal) {
-    const proposer = proposal.getSender(this.getSignatureContext());
+    const proposer = proposal.getSender();
 
     // Skip if signature is invalid (shouldn't happen since we validate earlier)
     if (!proposer) {
@@ -895,7 +892,7 @@ export class ValidatorClient extends (EventEmitter as new () => WatcherEmitter) 
           if (!attestation.archive.equals(proposal.archive)) {
             this.log.warn(
               `Received attestation for slot ${slot} with mismatched archive from ${attestation
-                .getSender(this.getSignatureContext())
+                .getSender()
                 ?.toString()}`,
               { attestationArchive: attestation.archive.toString(), proposalArchive: proposal.archive.toString() },
             );
@@ -906,9 +903,9 @@ export class ValidatorClient extends (EventEmitter as new () => WatcherEmitter) 
       );
 
       // Log new attestations we collected
-      const oldSenders = attestations.map(attestation => attestation.getSender(this.getSignatureContext()));
+      const oldSenders = attestations.map(attestation => attestation.getSender());
       for (const collected of collectedAttestations) {
-        const collectedSender = collected.getSender(this.getSignatureContext());
+        const collectedSender = collected.getSender();
         // Skip attestations with invalid signatures
         if (!collectedSender) {
           this.log.warn(`Skipping attestation with invalid signature for slot ${slot}`);

--- a/yarn-project/validator-client/src/validator.ts
+++ b/yarn-project/validator-client/src/validator.ts
@@ -30,6 +30,7 @@ import {
   CheckpointProposal,
   type CheckpointProposalCore,
   type CheckpointProposalOptions,
+  type CoordinationSignatureContext,
 } from '@aztec/stdlib/p2p';
 import type { CheckpointHeader } from '@aztec/stdlib/rollup';
 import type { BlockHeader, Tx } from '@aztec/stdlib/tx';
@@ -113,9 +114,13 @@ export class ValidatorClient extends (EventEmitter as new () => WatcherEmitter) 
     this.log = config.fishermanMode ? log.createChild('[FISHERMAN]') : log;
 
     this.tracer = telemetry.getTracer('Validator');
-    this.metrics = new ValidatorMetrics(telemetry);
+    this.metrics = new ValidatorMetrics(telemetry, this.getSignatureContext());
 
-    this.validationService = new ValidationService(keyStore, this.log.createChild('validation-service'));
+    this.validationService = new ValidationService(
+      keyStore,
+      this.getSignatureContext(),
+      this.log.createChild('validation-service'),
+    );
 
     // Refresh epoch cache every second to trigger alert if participation in committee changes
     this.epochCacheUpdateLoop = new RunningPromise(this.handleEpochCommitteeUpdate.bind(this), this.log, 1000);
@@ -192,10 +197,17 @@ export class ValidatorClient extends (EventEmitter as new () => WatcherEmitter) 
     telemetry: TelemetryClient = getTelemetryClient(),
     slashingProtectionDb?: SlashingProtectionDatabase,
   ) {
-    const metrics = new ValidatorMetrics(telemetry);
+    const metrics = new ValidatorMetrics(telemetry, {
+      chainId: config.l1ChainId,
+      rollupAddress: config.l1Contracts.rollupAddress,
+    });
     const blockProposalValidator = new BlockProposalValidator(epochCache, {
       txsPermitted: !config.disableTransactions,
       maxTxsPerBlock: config.validateMaxTxsPerBlock,
+      signatureContext: {
+        chainId: config.l1ChainId,
+        rollupAddress: config.l1Contracts.rollupAddress,
+      },
     });
     const proposalHandler = new ProposalHandler(
       checkpointsBuilder,
@@ -275,6 +287,13 @@ export class ValidatorClient extends (EventEmitter as new () => WatcherEmitter) 
     return this.keyStore.signTypedDataWithAddress(addr, msg, context);
   }
 
+  private getSignatureContext(): CoordinationSignatureContext {
+    return {
+      chainId: this.config.l1ChainId,
+      rollupAddress: this.config.l1Contracts.rollupAddress,
+    };
+  }
+
   public getCoinbaseForAttestor(attestor: EthAddress): EthAddress {
     return this.keyStore.getCoinbaseAddress(attestor);
   }
@@ -294,7 +313,11 @@ export class ValidatorClient extends (EventEmitter as new () => WatcherEmitter) 
   public reloadKeystore(newManager: KeystoreManager): void {
     const newAdapter = NodeKeystoreAdapter.fromKeyStoreManager(newManager);
     this.keyStore = new HAKeyStore(newAdapter, this.slashingProtectionSigner);
-    this.validationService = new ValidationService(this.keyStore, this.log.createChild('validation-service'));
+    this.validationService = new ValidationService(
+      this.keyStore,
+      this.getSignatureContext(),
+      this.log.createChild('validation-service'),
+    );
   }
 
   public async start() {
@@ -372,7 +395,7 @@ export class ValidatorClient extends (EventEmitter as new () => WatcherEmitter) 
     // but we intentionally reject them and disable slashing invalid block and attestation flow.
     const escapeHatchOpen = await this.epochCache.isEscapeHatchOpenAtSlot(slotNumber);
 
-    const proposer = proposal.getSender();
+    const proposer = proposal.getSender(this.getSignatureContext());
 
     // Reject proposals with invalid signatures
     if (!proposer) {
@@ -475,7 +498,7 @@ export class ValidatorClient extends (EventEmitter as new () => WatcherEmitter) 
     _proposalSender: PeerId,
   ): Promise<CheckpointAttestation[] | undefined> {
     const proposalSlotNumber = proposal.slotNumber;
-    const proposer = proposal.getSender();
+    const proposer = proposal.getSender(this.getSignatureContext());
 
     // If escape hatch is open for this slot's epoch, do not attest.
     if (await this.epochCache.isEscapeHatchOpenAtSlot(proposalSlotNumber)) {
@@ -649,7 +672,7 @@ export class ValidatorClient extends (EventEmitter as new () => WatcherEmitter) 
   }
 
   private slashInvalidBlock(proposal: BlockProposal) {
-    const proposer = proposal.getSender();
+    const proposer = proposal.getSender(this.getSignatureContext());
 
     // Skip if signature is invalid (shouldn't happen since we validate earlier)
     if (!proposer) {
@@ -871,7 +894,9 @@ export class ValidatorClient extends (EventEmitter as new () => WatcherEmitter) 
         attestation => {
           if (!attestation.archive.equals(proposal.archive)) {
             this.log.warn(
-              `Received attestation for slot ${slot} with mismatched archive from ${attestation.getSender()?.toString()}`,
+              `Received attestation for slot ${slot} with mismatched archive from ${attestation
+                .getSender(this.getSignatureContext())
+                ?.toString()}`,
               { attestationArchive: attestation.archive.toString(), proposalArchive: proposal.archive.toString() },
             );
             return false;
@@ -881,9 +906,9 @@ export class ValidatorClient extends (EventEmitter as new () => WatcherEmitter) 
       );
 
       // Log new attestations we collected
-      const oldSenders = attestations.map(attestation => attestation.getSender());
+      const oldSenders = attestations.map(attestation => attestation.getSender(this.getSignatureContext()));
       for (const collected of collectedAttestations) {
-        const collectedSender = collected.getSender();
+        const collectedSender = collected.getSender(this.getSignatureContext());
         // Skip attestations with invalid signatures
         if (!collectedSender) {
           this.log.warn(`Skipping attestation with invalid signature for slot ${slot}`);


### PR DESCRIPTION
This changes proposal-path validator signatures from `eth_sign` / `personal_sign` style payload signing to EIP-712 typed-data signing. Proposal and attestation signatures are now bound to both the L1 `chainId` and the rollup contract address, which closes cross-chain and cross-rollup replay for block proposals, checkpoint proposals, checkpoint attestations, and the proposer signature over packed attestations/signers.

On the Solidity side, the rollup path now computes EIP-712 digests through `CoordinationSignatureLib.sol`, reusing the existing `Aztec Rollup` domain name and version `1`, and threads the verifying contract explicitly where needed. On the TypeScript side, proposal-path signing and recovery now require a `{ chainId, rollupAddress }` signature context, validator duties sign typed data instead of raw messages, and the shared helper surface was renamed to `CoordinationSignature*` to match Solidity.

Tests were updated to check digest parity between TS and Solidity, sender recovery under the correct domain, failure under the wrong `chainId` or rollup address, and the affected contract flows that verify or invalidate checkpoint-related signatures.

Historically, it was possible to reason about replay from archives and chain history, but it was not always stupid-simple. With the EIP-712 domain binding, the replay boundary is explicit in the signature itself, so checking whether a signature targets the wrong chain or wrong rollup becomes straightforward and only depends on current L1 state.
