### PR TITLE
chore: meaningful error for unexpected input size in encoder

### DIFF
--- a/yarn-project/stdlib/src/abi/encoder.test.ts
+++ b/yarn-project/stdlib/src/abi/encoder.test.ts
@@ -61,6 +61,39 @@ describe('abi/encoder', () => {
     expect(encodeArguments(abi, [arr])).toEqual(arr);
   });
 
+  it('throws when array argument length does not match fixed-length ABI type', () => {
+    const abi: FunctionAbi = {
+      name: 'constructor',
+      isInitializer: true,
+      functionType: FunctionType.PRIVATE,
+      isOnlySelf: false,
+      isStatic: false,
+      parameters: [
+        {
+          name: 'proof',
+          type: {
+            kind: 'array',
+            length: 500,
+            type: { kind: 'field' },
+          },
+          visibility: 'private',
+        },
+      ],
+      returnTypes: [],
+      errorTypes: {},
+    };
+
+    const oversized = Array.from({ length: 519 }, () => Fr.random());
+    expect(() => encodeArguments(abi, [oversized])).toThrow(
+      "Error encoding param 'proof': expected an array of length 500 and got 519 instead",
+    );
+
+    const undersized = Array.from({ length: 499 }, () => Fr.random());
+    expect(() => encodeArguments(abi, [undersized])).toThrow(
+      "Error encoding param 'proof': expected an array of length 500 and got 499 instead",
+    );
+  });
+
   it('serializes string', () => {
     const abi: FunctionAbi = {
       name: 'constructor',

--- a/yarn-project/stdlib/src/abi/encoder.ts
+++ b/yarn-project/stdlib/src/abi/encoder.ts
@@ -106,6 +106,12 @@ class ArgumentEncoder {
         this.flattened.push(new Fr(arg ? 1n : 0n));
         break;
       case 'array':
+        if (arg.length !== abiType.length) {
+          throw new Error(
+            `Error encoding param '${name ?? 'unnamed'}': ` +
+              `expected an array of length ${abiType.length} and got ${arg.length} instead`,
+          );
+        }
         for (let i = 0; i < abiType.length; i += 1) {
           this.encodeArgument(abiType.type, arg[i], `${name}[${i}]`);
         }


### PR DESCRIPTION
Previously the ArgumentEncoder silently truncated oversized fixed-length array arguments by iterating only up to the ABI-declared length. External reported that a 519-field noir-rollup proof passed to a [Field; 500] was silently truncated. PR adds a length check in the case 'array'. Adds a unit test to avoid regression.