### PR TITLE
fix(pxe): correct stale authwitness comment and inverted tagging error

### DIFF
--- a/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
@@ -330,10 +330,9 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
   }
 
   /**
-   * Returns an auth witness for the given message hash. Checks on the list of transient witnesses
-   * for this transaction first, and falls back to the local database if not found.
+   * Returns an auth witness for the given message hash from the list of transient witnesses for this transaction.
    * @param messageHash - Hash of the message to authenticate.
-   * @returns Authentication witness for the requested message hash.
+   * @returns Authentication witness for the requested message hash, or undefined if not found.
    */
   public getAuthWitness(messageHash: Fr): Promise<Fr[] | undefined> {
     return Promise.resolve(this.authWitnesses.find(w => w.requestHash.equals(messageHash))?.witness);

--- a/yarn-project/pxe/src/tagging/recipient_sync/load_private_logs_for_sender_recipient_pair.ts
+++ b/yarn-project/pxe/src/tagging/recipient_sync/load_private_logs_for_sender_recipient_pair.ts
@@ -125,7 +125,9 @@ export async function loadPrivateLogsForSenderRecipientPair(
 
     if (highestAgedIndex !== undefined && highestAgedIndex > highestFinalizedIndex) {
       // This is just a sanity check as this should never happen.
-      throw new Error('Highest aged index lower than highest finalized index invariant violated');
+      throw new Error(
+        `Highest aged index (${highestAgedIndex}) must not exceed highest finalized index (${highestFinalizedIndex})`,
+      );
     }
 
     await taggingStore.updateHighestFinalizedIndex(secret, highestFinalizedIndex, jobId);


### PR DESCRIPTION
## Summary

Two findings from an AI audit of the PXE package:

- Drop the stale "falls back to the local database" claim from `getAuthWitness` JSDoc; the implementation only checks transient witnesses.
- Fix the inverted error message in `load_private_logs_for_sender_recipient_pair`: the check is `aged > finalized`, but the message said "lower than". The new message includes both values.

Fixes [aztec-claude#329](https://github.com/AztecProtocol/aztec-claude/issues/329)
Fixes [aztec-claude#316](https://github.com/AztecProtocol/aztec-claude/issues/316)