### PR TITLE
refactor!: make proposer sign same ConsensusPayload as attestors

### DIFF
--- a/yarn-project/p2p/src/mem_pools/attestation_pool/mocks.ts
+++ b/yarn-project/p2p/src/mem_pools/attestation_pool/mocks.ts
@@ -45,7 +45,10 @@ export const mockCheckpointAttestation = (
   );
   const attestationSignature = signer.sign(attestationHash);
 
-  const proposalHash = getHashedSignaturePayloadEthSignedMessage(payload, SignatureDomainSeparator.checkpointProposal);
+  const proposalHash = getHashedSignaturePayloadEthSignedMessage(
+    payload,
+    SignatureDomainSeparator.checkpointAttestation,
+  );
   const proposerSignature = signer.sign(proposalHash);
 
   return new CheckpointAttestation(payload, attestationSignature, proposerSignature);

--- a/yarn-project/stdlib/src/p2p/attestation_utils.test.ts
+++ b/yarn-project/stdlib/src/p2p/attestation_utils.test.ts
@@ -17,7 +17,10 @@ function makeAttestation(signer: Secp256k1Signer): CheckpointAttestation {
     payload,
     SignatureDomainSeparator.checkpointAttestation,
   );
-  const proposalHash = getHashedSignaturePayloadEthSignedMessage(payload, SignatureDomainSeparator.checkpointProposal);
+  const proposalHash = getHashedSignaturePayloadEthSignedMessage(
+    payload,
+    SignatureDomainSeparator.checkpointAttestation,
+  );
   return new CheckpointAttestation(payload, signer.sign(attestationHash), signer.sign(proposalHash));
 }
 

--- a/yarn-project/stdlib/src/p2p/checkpoint_attestation.ts
+++ b/yarn-project/stdlib/src/p2p/checkpoint_attestation.ts
@@ -10,7 +10,6 @@ import { BufferReader, serializeToBuffer } from '@aztec/foundation/serialize';
 import { z } from 'zod';
 
 import type { ZodFor } from '../schemas/index.js';
-import { CheckpointProposal } from './checkpoint_proposal.js';
 import { ConsensusPayload } from './consensus_payload.js';
 import { Gossipable } from './gossipable.js';
 import { SignatureDomainSeparator, getHashedSignaturePayloadEthSignedMessage } from './signature_utils.js';
@@ -88,22 +87,17 @@ export class CheckpointAttestation extends Gossipable {
   }
 
   /**
-   * Lazily evaluate and cache the proposer of the checkpoint
+   * Lazily evaluate and cache the proposer of the checkpoint.
+   * The proposer signs the same ConsensusPayload as attestors, so we can recover directly.
    * @returns The proposer of the checkpoint
    */
   getProposer(): EthAddress | undefined {
     if (!this.proposer) {
-      // Create a temporary CheckpointProposal to recover the proposer address.
-      // We need to use CheckpointProposal because it has a different getPayloadToSign()
-      // implementation than ConsensusPayload (uses serializeToBuffer vs ABI encoding).
-      const proposal = new CheckpointProposal(
-        this.payload.header,
-        this.payload.archive,
-        this.payload.feeAssetPriceModifier,
-        this.proposerSignature,
+      const hashed = getHashedSignaturePayloadEthSignedMessage(
+        this.payload,
+        SignatureDomainSeparator.checkpointAttestation,
       );
-      // Cache the proposer for later use
-      this.proposer = proposal.getSender();
+      this.proposer = tryRecoverAddress(hashed, this.proposerSignature);
     }
 
     return this.proposer;

--- a/yarn-project/stdlib/src/p2p/checkpoint_proposal.ts
+++ b/yarn-project/stdlib/src/p2p/checkpoint_proposal.ts
@@ -15,12 +15,9 @@ import { BlockHeader } from '../tx/block_header.js';
 import { TxHash } from '../tx/index.js';
 import type { Tx } from '../tx/tx.js';
 import { BlockProposal } from './block_proposal.js';
+import { ConsensusPayload } from './consensus_payload.js';
 import { Gossipable } from './gossipable.js';
-import {
-  SignatureDomainSeparator,
-  getHashedSignaturePayload,
-  getHashedSignaturePayloadEthSignedMessage,
-} from './signature_utils.js';
+import { SignatureDomainSeparator, getHashedSignaturePayloadEthSignedMessage } from './signature_utils.js';
 import { SignedTxs } from './signed_txs.js';
 import { TopicType } from './topic_type.js';
 
@@ -146,15 +143,16 @@ export class CheckpointProposal extends Gossipable {
 
   /**
    * Get the payload to sign for this checkpoint proposal.
-   * The signature is over the checkpoint header + archive root + feeAssetPriceModifier (for consensus).
+   * Uses the same ABI-encoded ConsensusPayload format that validators sign for attestations,
+   * so the proposer's signature is directly verifiable on L1 as an attestation.
    */
   getPayloadToSign(domainSeparator: SignatureDomainSeparator): Buffer {
-    return serializeToBuffer([
-      domainSeparator,
-      this.checkpointHeader,
-      this.archive,
-      serializeSignedBigInt(this.feeAssetPriceModifier),
-    ]);
+    return this.toConsensusPayload().getPayloadToSign(domainSeparator);
+  }
+
+  /** Returns the ConsensusPayload for this proposal. */
+  toConsensusPayload(): ConsensusPayload {
+    return new ConsensusPayload(this.checkpointHeader, this.archive, this.feeAssetPriceModifier);
   }
 
   static async createProposalFromSigner(
@@ -165,14 +163,12 @@ export class CheckpointProposal extends Gossipable {
     lastBlockProposal: BlockProposal | undefined,
     payloadSigner: (payload: Buffer32, context: SigningContext) => Promise<Signature>,
   ): Promise<CheckpointProposal> {
-    // Sign the checkpoint payload with CHECKPOINT_PROPOSAL duty type
-    const tempProposal = new CheckpointProposal(
-      checkpointHeader,
-      archiveRoot,
-      feeAssetPriceModifier,
-      Signature.empty(),
+    // Sign the consensus payload with the checkpointAttestation domain separator,
+    // so the proposer's signature is L1-verifiable and usable as an attestation.
+    const payload = new ConsensusPayload(checkpointHeader, archiveRoot, feeAssetPriceModifier);
+    const checkpointHash = Buffer32.fromBuffer(
+      keccak256(payload.getPayloadToSign(SignatureDomainSeparator.checkpointAttestation)),
     );
-    const checkpointHash = getHashedSignaturePayload(tempProposal, SignatureDomainSeparator.checkpointProposal);
 
     const checkpointContext: SigningContext = {
       slot: checkpointHeader.slotNumber,
@@ -198,7 +194,7 @@ export class CheckpointProposal extends Gossipable {
    */
   getSender(): EthAddress | undefined {
     if (!this.sender) {
-      const hashed = getHashedSignaturePayloadEthSignedMessage(this, SignatureDomainSeparator.checkpointProposal);
+      const hashed = getHashedSignaturePayloadEthSignedMessage(this, SignatureDomainSeparator.checkpointAttestation);
       const checkpointSender = tryRecoverAddress(hashed, this.signature);
 
       // If there's a lastBlock, verify the block proposal sender matches
@@ -218,7 +214,7 @@ export class CheckpointProposal extends Gossipable {
   }
 
   getPayload() {
-    return this.getPayloadToSign(SignatureDomainSeparator.checkpointProposal);
+    return this.getPayloadToSign(SignatureDomainSeparator.checkpointAttestation);
   }
 
   toBuffer(): Buffer {

--- a/yarn-project/stdlib/src/p2p/signature_utils.ts
+++ b/yarn-project/stdlib/src/p2p/signature_utils.ts
@@ -6,8 +6,7 @@ export enum SignatureDomainSeparator {
   blockProposal = 0,
   checkpointAttestation = 1,
   attestationsAndSigners = 2,
-  checkpointProposal = 3,
-  signedTxs = 4,
+  signedTxs = 3,
 }
 
 export interface Signable {

--- a/yarn-project/stdlib/src/tests/mocks.ts
+++ b/yarn-project/stdlib/src/tests/mocks.ts
@@ -14,7 +14,6 @@ import { padArrayEnd, times } from '@aztec/foundation/collection';
 import { randomBytes } from '@aztec/foundation/crypto/random';
 import { Secp256k1Signer } from '@aztec/foundation/crypto/secp256k1-signer';
 import { Fr } from '@aztec/foundation/curves/bn254';
-import { Signature } from '@aztec/foundation/eth-signature';
 
 import type { ContractArtifact } from '../abi/abi.js';
 import { PublicTxEffect } from '../avm/avm.js';
@@ -545,26 +544,6 @@ export interface MakeCheckpointProposalOptions {
   };
 }
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const makeAndSignConsensusPayload = (
-  domainSeparator: SignatureDomainSeparator,
-  options?: MakeConsensusPayloadOptions,
-) => {
-  const header = options?.header ?? makeCheckpointHeader(1);
-  const { signer = Secp256k1Signer.random(), archive = Fr.random(), feeAssetPriceModifier = 0n } = options ?? {};
-
-  const payload = ConsensusPayload.fromFields({
-    header,
-    archive,
-    feeAssetPriceModifier,
-  });
-
-  const hash = getHashedSignaturePayloadEthSignedMessage(payload, domainSeparator);
-  const signature = signer.sign(hash);
-
-  return { blockNumber: header.slotNumber, payload, signature };
-};
-
 export const makeAndSignCommitteeAttestationsAndSigners = (
   attestationsAndSigners: CommitteeAttestationsAndSigners,
   signer: Secp256k1Signer = Secp256k1Signer.random(),
@@ -657,13 +636,11 @@ export const makeCheckpointAttestation = (options: MakeCheckpointAttestationOpti
   const attestationSigner = attesterSigner ?? Secp256k1Signer.random();
   const attestationSignature = attestationSigner.sign(attestationHash);
 
-  // Sign as proposer - use CheckpointProposal's payload format (serializeToBuffer)
-  // This is different from ConsensusPayload's format (ABI encoding)
+  // Sign as proposer - uses the same ConsensusPayload format as attestors
   const proposalSignerToUse = proposerSigner ?? Secp256k1Signer.random();
-  const tempProposal = new CheckpointProposal(header, archive, feeAssetPriceModifier, Signature.empty());
   const proposalHash = getHashedSignaturePayloadEthSignedMessage(
-    tempProposal,
-    SignatureDomainSeparator.checkpointProposal,
+    payload,
+    SignatureDomainSeparator.checkpointAttestation,
   );
   const proposerSignature = proposalSignerToUse.sign(proposalHash);
 


### PR DESCRIPTION
## Motivation

The proposer's checkpoint signature used a different encoding format (raw buffer serialization) and domain separator (`checkpointProposal`) than what validators sign for attestations (ABI-encoded `ConsensusPayload` with `checkpointAttestation` separator). This meant the proposer's signature was only verifiable P2P, not on L1. Making it L1-verifiable allows anyone to submit the proposer's signature as an attestation on their behalf.

## Approach

Changed `CheckpointProposal` to delegate its `getPayloadToSign` to `ConsensusPayload`, using the same ABI-encoded format and `checkpointAttestation` domain separator. Simplified `CheckpointAttestation.getProposer()` since it no longer needs to construct a temporary `CheckpointProposal` to recover the address. Removed the now-unused `checkpointProposal` domain separator from the enum.

## Changes

- **stdlib (p2p)**: `CheckpointProposal.getPayloadToSign` now delegates to `ConsensusPayload`. `getSender`, `createProposalFromSigner`, and `getPayload` all use `checkpointAttestation` domain separator. Added `toConsensusPayload()` helper. Removed `checkpointProposal` from `SignatureDomainSeparator` enum.
- **stdlib (p2p)**: Simplified `CheckpointAttestation.getProposer()` to recover directly from `ConsensusPayload` instead of constructing a temporary `CheckpointProposal`.
- **stdlib, p2p (tests/mocks)**: Updated all mock attestation factories to sign proposer payload with `checkpointAttestation` on `ConsensusPayload`. Removed unused `makeAndSignConsensusPayload` and `Signature` import.