### PR TITLE
chore: some protective asserts for aes128

### DIFF
--- a/barretenberg/cpp/src/barretenberg/bbapi/bbapi.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/bbapi/bbapi.test.cpp
@@ -1,7 +1,9 @@
 #include "barretenberg/bbapi/bbapi.hpp"
 #include "barretenberg/api/file_io.hpp"
+#include "barretenberg/bbapi/bbapi_crypto.hpp"
 #include "barretenberg/bbapi/bbapi_shared.hpp"
 #include "barretenberg/chonk/private_execution_steps.hpp"
+#include "barretenberg/common/assert.hpp"
 #include "barretenberg/common/serialize.hpp"
 #include "barretenberg/common/utils.hpp"
 #include "barretenberg/serialize/test_helper.hpp"
@@ -183,4 +185,36 @@ TEST(BBApiInputValidation, MsgpackLoadRejectsTrailingData)
 
     EXPECT_THROW(PrivateExecutionStepRaw::load(tmp), std::invalid_argument);
     std::filesystem::remove(tmp);
+}
+
+// Regression tests for AesEncrypt/AesDecrypt input validation.
+// Without these guards, a socket client could force a ~4 GB allocation via the
+// uint32_t `length` field, or pass `length != plaintext.size()` and silently
+// encrypt zero-padded tail bytes.
+TEST(BBApiInputValidation, AesEncryptRejectsLengthMismatch)
+{
+    bbapi::BBApiRequest request{};
+    bbapi::AesEncrypt cmd{ .plaintext = std::vector<uint8_t>(16, 0), .iv = {}, .key = {}, .length = 32 };
+    EXPECT_THROW_OR_ABORT(std::move(cmd).execute(request), ".*length must equal plaintext.*");
+}
+
+TEST(BBApiInputValidation, AesEncryptRejectsNonBlockAlignedLength)
+{
+    bbapi::BBApiRequest request{};
+    bbapi::AesEncrypt cmd{ .plaintext = std::vector<uint8_t>(17, 0), .iv = {}, .key = {}, .length = 17 };
+    EXPECT_THROW_OR_ABORT(std::move(cmd).execute(request), ".*multiple of 16.*");
+}
+
+TEST(BBApiInputValidation, AesDecryptRejectsLengthMismatch)
+{
+    bbapi::BBApiRequest request{};
+    bbapi::AesDecrypt cmd{ .ciphertext = std::vector<uint8_t>(16, 0), .iv = {}, .key = {}, .length = 32 };
+    EXPECT_THROW_OR_ABORT(std::move(cmd).execute(request), ".*length must equal ciphertext.*");
+}
+
+TEST(BBApiInputValidation, AesDecryptRejectsNonBlockAlignedLength)
+{
+    bbapi::BBApiRequest request{};
+    bbapi::AesDecrypt cmd{ .ciphertext = std::vector<uint8_t>(17, 0), .iv = {}, .key = {}, .length = 17 };
+    EXPECT_THROW_OR_ABORT(std::move(cmd).execute(request), ".*multiple of 16.*");
 }

--- a/barretenberg/cpp/src/barretenberg/bbapi/bbapi_crypto.cpp
+++ b/barretenberg/cpp/src/barretenberg/bbapi/bbapi_crypto.cpp
@@ -9,6 +9,7 @@
  * @brief Implementation of cryptographic command execution for the Barretenberg RPC API
  */
 #include "barretenberg/bbapi/bbapi_crypto.hpp"
+#include "barretenberg/common/assert.hpp"
 #include "barretenberg/common/throw_or_abort.hpp"
 #include "barretenberg/crypto/aes128/aes128.hpp"
 #include "barretenberg/crypto/blake2s/blake2s.hpp"
@@ -66,6 +67,9 @@ Blake2sToField::Response Blake2sToField::execute(BB_UNUSED BBApiRequest& request
 
 AesEncrypt::Response AesEncrypt::execute(BB_UNUSED BBApiRequest& request) &&
 {
+    BB_ASSERT(length == plaintext.size(), "AesEncrypt: length must equal plaintext.size()");
+    BB_ASSERT(length % 16 == 0, "AesEncrypt: length must be a multiple of 16");
+
     // Copy plaintext as AES encrypts in-place
     std::vector<uint8_t> result = plaintext;
     result.resize(length);
@@ -77,6 +81,9 @@ AesEncrypt::Response AesEncrypt::execute(BB_UNUSED BBApiRequest& request) &&
 
 AesDecrypt::Response AesDecrypt::execute(BB_UNUSED BBApiRequest& request) &&
 {
+    BB_ASSERT(length == ciphertext.size(), "AesDecrypt: length must equal ciphertext.size()");
+    BB_ASSERT(length % 16 == 0, "AesDecrypt: length must be a multiple of 16");
+
     // Copy ciphertext as AES decrypts in-place
     std::vector<uint8_t> result = ciphertext;
     result.resize(length);

--- a/barretenberg/cpp/src/barretenberg/crypto/aes128/CMakeLists.txt
+++ b/barretenberg/cpp/src/barretenberg/crypto/aes128/CMakeLists.txt
@@ -1,1 +1,1 @@
-barretenberg_module(crypto_aes128)
+barretenberg_module(crypto_aes128 common)

--- a/barretenberg/cpp/src/barretenberg/crypto/aes128/aes128.cpp
+++ b/barretenberg/cpp/src/barretenberg/crypto/aes128/aes128.cpp
@@ -6,6 +6,7 @@
 
 #include "aes128.hpp"
 
+#include "barretenberg/common/assert.hpp"
 #include "barretenberg/crypto/hmac/hmac.hpp"
 #include "memory.h"
 #include <array>
@@ -195,6 +196,7 @@ void aes128_expand_key(const uint8_t* key, uint8_t* round_key)
         round_key[j + 2] = round_key[k + 2] ^ temp[2];
         round_key[j + 3] = round_key[k + 3] ^ temp[3];
     }
+    secure_erase_bytes(temp, sizeof(temp));
 }
 
 void aes128_inverse_cipher(uint8_t* input, const uint8_t* round_key)
@@ -231,6 +233,8 @@ void aes128_cipher(uint8_t* state, const uint8_t* round_key)
 
 void aes128_encrypt_buffer_cbc(uint8_t* buffer, uint8_t* iv, const uint8_t* key, const size_t length)
 {
+    BB_ASSERT(length % 16 == 0, "aes128_encrypt_buffer_cbc: length must be a multiple of 16");
+
     uint8_t round_key[176];
     aes128_expand_key(key, round_key);
 
@@ -252,6 +256,8 @@ void aes128_encrypt_buffer_cbc(uint8_t* buffer, uint8_t* iv, const uint8_t* key,
 
 void aes128_decrypt_buffer_cbc(uint8_t* buffer, uint8_t* iv, const uint8_t* key, const size_t length)
 {
+    BB_ASSERT(length % 16 == 0, "aes128_decrypt_buffer_cbc: length must be a multiple of 16");
+
     uint8_t round_key[176];
     aes128_expand_key(key, round_key);
     uint8_t block_state[16]{};

--- a/barretenberg/cpp/src/barretenberg/crypto/aes128/aes128.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/crypto/aes128/aes128.test.cpp
@@ -1,5 +1,6 @@
 #include "aes128.hpp"
 
+#include "barretenberg/common/assert.hpp"
 #include <gtest/gtest.h>
 
 using namespace bb;
@@ -60,4 +61,22 @@ TEST(aes128, decrypt_buffer_cbc)
     for (size_t i = 0; i < 64; ++i) {
         EXPECT_EQ(in[i], out[i]);
     }
+}
+
+// Regression: aes128_encrypt_buffer_cbc and aes128_decrypt_buffer_cbc require block-aligned length.
+// Prior to the guard, non-aligned lengths silently skipped the tail bytes.
+TEST(aes128, encrypt_buffer_cbc_rejects_non_block_aligned_length)
+{
+    uint8_t key[16]{};
+    uint8_t iv[16]{};
+    uint8_t buf[17]{};
+    EXPECT_THROW_OR_ABORT(crypto::aes128_encrypt_buffer_cbc(buf, iv, key, 17), ".*multiple of 16.*");
+}
+
+TEST(aes128, decrypt_buffer_cbc_rejects_non_block_aligned_length)
+{
+    uint8_t key[16]{};
+    uint8_t iv[16]{};
+    uint8_t buf[17]{};
+    EXPECT_THROW_OR_ABORT(crypto::aes128_decrypt_buffer_cbc(buf, iv, key, 17), ".*multiple of 16.*");
 }

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/aes128_constraint.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/aes128_constraint.cpp
@@ -22,6 +22,7 @@ template <typename Builder> void create_aes128_constraints(Builder& builder, con
     // Packs 16 bytes from the inputs (plaintext, iv, key) into a field element
     // Note that noir-stdlib already pads the inputs in accordance with PKCS7 padding scheme.
     BB_ASSERT(constraint.inputs.size() % 16 == 0, "Inputs must be a multiple of 16");
+    BB_ASSERT(constraint.outputs.size() == constraint.inputs.size(), "Outputs must have the same length as inputs");
     const auto convert_input = [&](std::span<const WitnessOrConstant<bb::fr>, std::dynamic_extent> inputs,
                                    Builder& builder) {
         field_ct converted = 0;

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/aes128_constraint.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/aes128_constraint.test.cpp
@@ -7,6 +7,7 @@
 #include "aes128_constraint.hpp"
 #include "acir_format.hpp"
 #include "barretenberg/circuit_checker/circuit_checker.hpp"
+#include "barretenberg/common/assert.hpp"
 #include "barretenberg/crypto/aes128/aes128.hpp"
 #include "barretenberg/dsl/acir_format/test_class.hpp"
 #include "barretenberg/dsl/acir_format/utils.hpp"
@@ -660,4 +661,66 @@ TEST_F(AES128RangeConstraintTest, OutputOutOfRangeFails)
     create_aes128_constraints(builder, constraint);
     EXPECT_TRUE(builder.failed()) << "Circuit should fail when output has byte > 255";
     EXPECT_FALSE(CircuitChecker::check(builder));
+}
+
+// =============================================================================
+// Shape Validation Regression Tests
+// =============================================================================
+// Guards in create_aes128_constraints enforce:
+//   - inputs.size() % 16 == 0
+//   - outputs.size() == inputs.size()
+// Malformed ACIR violating either invariant would otherwise produce circuits
+// with undefined behaviour (span OOB) or under-constrained output witnesses.
+// =============================================================================
+
+class AES128ShapeValidationTest : public ::testing::Test {
+  protected:
+    using Builder = UltraCircuitBuilder;
+    using FF = Builder::FF;
+
+    // Build a well-formed AES128Constraint with `num_input_bytes` input and
+    // `num_output_bytes` output witnesses. Values are zero; we only exercise
+    // the shape guards, which run before any AES math.
+    static std::pair<Builder, AES128Constraint> make_constraint(size_t num_input_bytes, size_t num_output_bytes)
+    {
+        Builder builder;
+        auto add_witness = [&builder](FF value) { return builder.add_variable(value); };
+
+        std::vector<WitnessOrConstant<FF>> input_witnesses;
+        for (size_t i = 0; i < num_input_bytes; ++i) {
+            input_witnesses.push_back(WitnessOrConstant<FF>::from_index(add_witness(FF(0))));
+        }
+
+        std::array<WitnessOrConstant<FF>, 16> key_witnesses{};
+        std::array<WitnessOrConstant<FF>, 16> iv_witnesses{};
+        for (size_t i = 0; i < 16; ++i) {
+            key_witnesses[i] = WitnessOrConstant<FF>::from_index(add_witness(FF(0)));
+            iv_witnesses[i] = WitnessOrConstant<FF>::from_index(add_witness(FF(0)));
+        }
+
+        std::vector<uint32_t> output_indices;
+        for (size_t i = 0; i < num_output_bytes; ++i) {
+            output_indices.push_back(add_witness(FF(0)));
+        }
+
+        AES128Constraint constraint{
+            .inputs = std::move(input_witnesses),
+            .iv = iv_witnesses,
+            .key = key_witnesses,
+            .outputs = std::move(output_indices),
+        };
+        return { std::move(builder), std::move(constraint) };
+    }
+};
+
+TEST_F(AES128ShapeValidationTest, InputsNotBlockAlignedRejected)
+{
+    auto [builder, constraint] = make_constraint(/*num_input_bytes=*/17, /*num_output_bytes=*/17);
+    EXPECT_THROW_OR_ABORT(create_aes128_constraints(builder, constraint), ".*multiple of 16.*");
+}
+
+TEST_F(AES128ShapeValidationTest, OutputsSizeMismatchRejected)
+{
+    auto [builder, constraint] = make_constraint(/*num_input_bytes=*/16, /*num_output_bytes=*/32);
+    EXPECT_THROW_OR_ABORT(create_aes128_constraints(builder, constraint), ".*same length as inputs.*");
 }


### PR DESCRIPTION
Addresses several concerns raised in the external audit of the aes128 hashing gadget by Spearbit.