### PR TITLE
feat: stamping aztec version into contract artifacts

### DIFF
--- a/ci3/source_refname
+++ b/ci3/source_refname
@@ -53,8 +53,3 @@ fi
 if [ -z "${CURRENT_VERSION:-}" ]; then
   export CURRENT_VERSION=$(jq -r '."."' $root/.release-please-manifest.json)
 fi
-
-# Aztec version to inject into contract artifacts. Only set when REF_NAME is a valid semver (release tag).
-if [ -z "${AZTEC_VERSION:-}" ] && semver check "$REF_NAME" 2>/dev/null; then
-  export AZTEC_VERSION="${REF_NAME#v}"
-fi

--- a/ci3/source_refname
+++ b/ci3/source_refname
@@ -53,3 +53,8 @@ fi
 if [ -z "${CURRENT_VERSION:-}" ]; then
   export CURRENT_VERSION=$(jq -r '."."' $root/.release-please-manifest.json)
 fi
+
+# Aztec version to inject into contract artifacts. Only set when REF_NAME is a valid semver (release tag).
+if [ -z "${AZTEC_VERSION:-}" ] && semver check "$REF_NAME" 2>/dev/null; then
+  export AZTEC_VERSION="${REF_NAME#v}"
+fi

--- a/noir-projects/noir-contracts/bootstrap.sh
+++ b/noir-projects/noir-contracts/bootstrap.sh
@@ -93,10 +93,10 @@ function get_contract_path {
 }
 export -f get_contract_path
 
-# Stamps the aztec version into a contract artifact JSON in place. Mirrors injectAztecVersion in
+# Stamps the aztec version into a contract artifact JSON in place. Mirrors stampAztecVersion in
 # yarn-project/aztec/src/cli/cmds/compile.ts so monorepo-built artifacts match those produced by `aztec compile`.
 # On release builds (REF_NAME is valid semver) the tag without the leading "v" is used; otherwise "dev".
-function inject_aztec_version {
+function stamp_aztec_version {
   local json_path=$1
   local version="dev"
   semver check "$REF_NAME" 2>/dev/null && version="${REF_NAME#v}"
@@ -104,7 +104,7 @@ function inject_aztec_version {
   jq --arg v "$version" '.aztec_version = $v' "$json_path" > "$tmp"
   mv "$tmp" "$json_path"
 }
-export -f inject_aztec_version
+export -f stamp_aztec_version
 
 # This compiles a noir contract, transpiles public functions, strips internal prefixes,
 # and generates verification keys for private functions via 'bb aztec_process'.
@@ -128,7 +128,7 @@ function compile {
   fi
   # Stamp the current version after the cache block so the field always matches the build's version, whether
   # the artifact came from a fresh compile or a cache hit.
-  inject_aztec_version "$json_path"
+  stamp_aztec_version "$json_path"
 }
 export -f compile
 

--- a/noir-projects/noir-contracts/bootstrap.sh
+++ b/noir-projects/noir-contracts/bootstrap.sh
@@ -31,8 +31,7 @@ export BB=${BB:-../../barretenberg/cpp/build/bin/bb}
 export NARGO=${NARGO:-../../noir/noir-repo/target/release/nargo}
 export BB_HASH=${BB_HASH:-$(../../barretenberg/cpp/bootstrap.sh hash)}
 export NOIR_HASH=${NOIR_HASH:-$(../../noir/bootstrap.sh hash)}
-# Use the git tag version (e.g. 5.0.0-nightly.20260414) when available, otherwise "dev" for local builds.
-export AZTEC_VERSION=${REF_NAME:+${REF_NAME#v}}
+# Aztec version to inject into contract artifacts. Set by the release pipeline (e.g. AZTEC_VERSION=5.0.0-nightly.20260414).
 export AZTEC_VERSION=${AZTEC_VERSION:-dev}
 
 # Set common flags for parallel.

--- a/noir-projects/noir-contracts/bootstrap.sh
+++ b/noir-projects/noir-contracts/bootstrap.sh
@@ -98,6 +98,7 @@ export -f get_contract_path
 # On release builds (REF_NAME is valid semver) the tag without the leading "v" is used; otherwise "dev".
 function stamp_aztec_version {
   local json_path=$1
+  # "dev" here corresponds to DEV_VERSION in yarn-project/stdlib/src/update-checker/package_version.ts.
   local version="dev"
   semver check "$REF_NAME" 2>/dev/null && version="${REF_NAME#v}"
   local tmp=$(mktemp)

--- a/noir-projects/noir-contracts/bootstrap.sh
+++ b/noir-projects/noir-contracts/bootstrap.sh
@@ -98,7 +98,7 @@ export -f get_contract_path
 # On release builds (REF_NAME is valid semver) the tag without the leading "v" is used; otherwise "dev".
 function stamp_aztec_version {
   local json_path=$1
-  # "dev" here corresponds to DEV_VERSION in yarn-project/stdlib/src/update-checker/package_version.ts.
+  # "dev" here corresponds to DEV_VERSION in yarn-project/stdlib/src/update-checker/dev_version.ts.
   local version="dev"
   semver check "$REF_NAME" 2>/dev/null && version="${REF_NAME#v}"
   local tmp=$(mktemp)

--- a/noir-projects/noir-contracts/bootstrap.sh
+++ b/noir-projects/noir-contracts/bootstrap.sh
@@ -31,16 +31,6 @@ export BB=${BB:-../../barretenberg/cpp/build/bin/bb}
 export NARGO=${NARGO:-../../noir/noir-repo/target/release/nargo}
 export BB_HASH=${BB_HASH:-$(../../barretenberg/cpp/bootstrap.sh hash)}
 export NOIR_HASH=${NOIR_HASH:-$(../../noir/bootstrap.sh hash)}
-# Aztec version to inject into contract artifacts.
-# On release builds (REF_NAME is valid semver), use the tag without the leading "v".
-# Otherwise default to "dev".
-if [ -z "${AZTEC_VERSION:-}" ]; then
-  if semver check "$REF_NAME" 2>/dev/null; then
-    export AZTEC_VERSION="${REF_NAME#v}"
-  else
-    export AZTEC_VERSION="dev"
-  fi
-fi
 
 # Set common flags for parallel.
 export PARALLEL_FLAGS="-j${PARALLELISM:-16} --halt now,fail=1 --memsuspend $(memsuspend_limit)"
@@ -103,6 +93,19 @@ function get_contract_path {
 }
 export -f get_contract_path
 
+# Stamps the aztec version into a contract artifact JSON in place. Mirrors injectAztecVersion in
+# yarn-project/aztec/src/cli/cmds/compile.ts so monorepo-built artifacts match those produced by `aztec compile`.
+# On release builds (REF_NAME is valid semver) the tag without the leading "v" is used; otherwise "dev".
+function inject_aztec_version {
+  local json_path=$1
+  local version="dev"
+  semver check "$REF_NAME" 2>/dev/null && version="${REF_NAME#v}"
+  local tmp=$(mktemp)
+  jq --arg v "$version" '.aztec_version = $v' "$json_path" > "$tmp"
+  mv "$tmp" "$json_path"
+}
+export -f inject_aztec_version
+
 # This compiles a noir contract, transpiles public functions, strips internal prefixes,
 # and generates verification keys for private functions via 'bb aztec_process'.
 # $1 is the input package name, $2 is the folder name (e.g. "contracts" or "examples")
@@ -123,6 +126,9 @@ function compile {
     $BB aztec_process -i $json_path
     cache_upload contract-$contract_hash.tar.gz $json_path
   fi
+  # Stamp the current version after the cache block so the field always matches the build's version, whether
+  # the artifact came from a fresh compile or a cache hit.
+  inject_aztec_version "$json_path"
 }
 export -f compile
 

--- a/noir-projects/noir-contracts/bootstrap.sh
+++ b/noir-projects/noir-contracts/bootstrap.sh
@@ -31,8 +31,16 @@ export BB=${BB:-../../barretenberg/cpp/build/bin/bb}
 export NARGO=${NARGO:-../../noir/noir-repo/target/release/nargo}
 export BB_HASH=${BB_HASH:-$(../../barretenberg/cpp/bootstrap.sh hash)}
 export NOIR_HASH=${NOIR_HASH:-$(../../noir/bootstrap.sh hash)}
-# Aztec version to inject into contract artifacts. Set by the release pipeline (e.g. AZTEC_VERSION=5.0.0-nightly.20260414).
-export AZTEC_VERSION=${AZTEC_VERSION:-dev}
+# Aztec version to inject into contract artifacts.
+# On release builds (REF_NAME is valid semver), use the tag without the leading "v".
+# Otherwise default to "dev".
+if [ -z "${AZTEC_VERSION:-}" ]; then
+  if semver check "$REF_NAME" 2>/dev/null; then
+    export AZTEC_VERSION="${REF_NAME#v}"
+  else
+    export AZTEC_VERSION="dev"
+  fi
+fi
 
 # Set common flags for parallel.
 export PARALLEL_FLAGS="-j${PARALLELISM:-16} --halt now,fail=1 --memsuspend $(memsuspend_limit)"

--- a/noir-projects/noir-contracts/bootstrap.sh
+++ b/noir-projects/noir-contracts/bootstrap.sh
@@ -31,6 +31,9 @@ export BB=${BB:-../../barretenberg/cpp/build/bin/bb}
 export NARGO=${NARGO:-../../noir/noir-repo/target/release/nargo}
 export BB_HASH=${BB_HASH:-$(../../barretenberg/cpp/bootstrap.sh hash)}
 export NOIR_HASH=${NOIR_HASH:-$(../../noir/bootstrap.sh hash)}
+# Use the git tag version (e.g. 5.0.0-nightly.20260414) when available, otherwise "dev" for local builds.
+export AZTEC_VERSION=${REF_NAME:+${REF_NAME#v}}
+export AZTEC_VERSION=${AZTEC_VERSION:-dev}
 
 # Set common flags for parallel.
 export PARALLEL_FLAGS="-j${PARALLELISM:-16} --halt now,fail=1 --memsuspend $(memsuspend_limit)"

--- a/yarn-project/aztec.js/src/contract/contract.test.ts
+++ b/yarn-project/aztec.js/src/contract/contract.test.ts
@@ -9,6 +9,7 @@ import {
 } from '@aztec/stdlib/contract';
 import type { TxExecutionRequest, TxReceipt, UtilityExecutionResult } from '@aztec/stdlib/tx';
 import { OFFCHAIN_MESSAGE_IDENTIFIER } from '@aztec/stdlib/tx';
+import { DEV_VERSION } from '@aztec/stdlib/update-checker';
 
 import { type MockProxy, mock } from 'jest-mock-extended';
 
@@ -38,6 +39,7 @@ describe('Contract Class', () => {
 
   const defaultArtifact: ContractArtifact = {
     name: 'FooContract',
+    aztecVersion: DEV_VERSION,
     functions: [
       {
         name: 'bar',

--- a/yarn-project/aztec.js/src/contract/deploy_method.test.ts
+++ b/yarn-project/aztec.js/src/contract/deploy_method.test.ts
@@ -6,6 +6,7 @@ import type { ContractInstanceWithAddress } from '@aztec/stdlib/contract';
 import { Gas } from '@aztec/stdlib/gas';
 import { PublicKeys } from '@aztec/stdlib/keys';
 import { OFFCHAIN_MESSAGE_IDENTIFIER, type OffchainEffect } from '@aztec/stdlib/tx';
+import { DEV_VERSION } from '@aztec/stdlib/update-checker';
 
 import { type MockProxy, mock } from 'jest-mock-extended';
 
@@ -19,6 +20,7 @@ describe('DeployMethod', () => {
 
   const artifact: ContractArtifact = {
     name: 'TestContract',
+    aztecVersion: DEV_VERSION,
     functions: [
       {
         name: 'constructor',

--- a/yarn-project/aztec.js/src/scripts/generate_protocol_contract_types.ts
+++ b/yarn-project/aztec.js/src/scripts/generate_protocol_contract_types.ts
@@ -63,6 +63,7 @@ function generateProtocolContractArtifact(input: ContractArtifact): string {
 
   return `{
   name: '${input.name}',
+  aztecVersion: '${input.aztecVersion}',
   functions: [
     ${functionsArray}
   ],

--- a/yarn-project/aztec.js/src/wallet/wallet.test.ts
+++ b/yarn-project/aztec.js/src/wallet/wallet.test.ts
@@ -18,6 +18,7 @@ import {
   TxSimulationResult,
   UtilityExecutionResult,
 } from '@aztec/stdlib/tx';
+import { DEV_VERSION } from '@aztec/stdlib/update-checker';
 
 import {
   type InteractionWaitOptions,
@@ -126,6 +127,7 @@ describe('WalletSchema', () => {
   it('registerContract', async () => {
     const mockArtifact: ContractArtifact = {
       name: 'TestContract',
+      aztecVersion: DEV_VERSION,
       functions: [],
       nonDispatchPublicFunctions: [],
       outputs: { structs: {}, globals: {} },
@@ -318,6 +320,7 @@ describe('WalletSchema', () => {
 
     const mockArtifact: ContractArtifact = {
       name: 'TestContract',
+      aztecVersion: DEV_VERSION,
       functions: [],
       nonDispatchPublicFunctions: [],
       outputs: { structs: {}, globals: {} },

--- a/yarn-project/aztec/src/cli/cmds/compile.ts
+++ b/yarn-project/aztec/src/cli/cmds/compile.ts
@@ -4,7 +4,7 @@ import { getAztecVersion } from '@aztec/stdlib/update-checker';
 
 import { execFileSync } from 'child_process';
 import type { Command } from 'commander';
-import { readFile } from 'fs/promises';
+import { readFile, writeFile } from 'fs/promises';
 import { join } from 'path';
 
 import { readArtifactFiles } from './utils/artifacts.js';

--- a/yarn-project/aztec/src/cli/cmds/compile.ts
+++ b/yarn-project/aztec/src/cli/cmds/compile.ts
@@ -1,5 +1,6 @@
 import { findBbBinary } from '@aztec/bb.js';
 import type { LogFn } from '@aztec/foundation/log';
+import { getAztecVersion } from '@aztec/stdlib/update-checker';
 
 import { execFileSync } from 'child_process';
 import type { Command } from 'commander';
@@ -23,6 +24,17 @@ async function collectContractArtifacts(): Promise<string[]> {
     throw err;
   }
   return files.filter(f => Array.isArray(f.content.functions)).map(f => f.filePath);
+}
+
+/** Injects the Aztec stack version into contract artifacts. */
+async function injectAztecVersion(artifactPaths: string[]): Promise<void> {
+  const version = getAztecVersion();
+  for (const path of artifactPaths) {
+    const artifact = JSON.parse(await readFile(path, 'utf-8'));
+    // eslint-disable-next-line camelcase
+    artifact.aztec_version = version;
+    await writeFile(path, JSON.stringify(artifact, null, 2) + '\n');
+  }
 }
 
 /** Returns the set of package names that are contract crates in the current workspace. */
@@ -148,6 +160,8 @@ async function compileAztecContract(nargoArgs: string[], log: LogFn): Promise<vo
     log('Postprocessing contracts...');
     const bbArgs = artifacts.flatMap(a => ['-i', a]);
     await run(bb, ['aztec_process', ...bbArgs]);
+
+    await injectAztecVersion(artifacts);
   }
 
   log('Compilation complete!');

--- a/yarn-project/aztec/src/cli/cmds/compile.ts
+++ b/yarn-project/aztec/src/cli/cmds/compile.ts
@@ -1,13 +1,11 @@
 import { findBbBinary } from '@aztec/bb.js';
 import type { LogFn } from '@aztec/foundation/log';
-import { DEV_VERSION } from '@aztec/stdlib/update-checker';
+import { getPackageVersion } from '@aztec/stdlib/update-checker';
 
 import { execFileSync } from 'child_process';
 import type { Command } from 'commander';
-import { readFileSync } from 'fs';
 import { readFile, writeFile } from 'fs/promises';
-import { dirname, join, resolve } from 'path';
-import { fileURLToPath } from 'url';
+import { join } from 'path';
 
 import { readArtifactFiles } from './utils/artifacts.js';
 import { needsRecompile } from './utils/needs_recompile.js';
@@ -28,20 +26,9 @@ async function collectContractArtifacts(): Promise<string[]> {
   return files.filter(f => Array.isArray(f.content.functions)).map(f => f.filePath);
 }
 
-/**
- * Returns the package version for embedding in contract artifacts or `dev` if the version in package.json is
- * the placeholder value (that would indicate that this is used from a locally checked out monorepo instead of npm).
- */
-function getPackageVersionOrDev(): string {
-  const dir = dirname(fileURLToPath(import.meta.url));
-  const packageJsonPath = resolve(dir, '../../../package.json');
-  const version = JSON.parse(readFileSync(packageJsonPath).toString()).version;
-  return version === '0.1.0' ? DEV_VERSION : version;
-}
-
 /** Injects the Aztec stack version into contract artifacts. */
 async function injectAztecVersion(artifactPaths: string[]): Promise<void> {
-  const version = getPackageVersionOrDev();
+  const version = getPackageVersion();
   for (const path of artifactPaths) {
     const artifact = JSON.parse(await readFile(path, 'utf-8'));
     // eslint-disable-next-line camelcase

--- a/yarn-project/aztec/src/cli/cmds/compile.ts
+++ b/yarn-project/aztec/src/cli/cmds/compile.ts
@@ -1,11 +1,13 @@
 import { findBbBinary } from '@aztec/bb.js';
 import type { LogFn } from '@aztec/foundation/log';
-import { getAztecVersion } from '@aztec/stdlib/update-checker';
+import { DEV_VERSION } from '@aztec/stdlib/update-checker';
 
 import { execFileSync } from 'child_process';
 import type { Command } from 'commander';
+import { readFileSync } from 'fs';
 import { readFile, writeFile } from 'fs/promises';
-import { join } from 'path';
+import { dirname, join, resolve } from 'path';
+import { fileURLToPath } from 'url';
 
 import { readArtifactFiles } from './utils/artifacts.js';
 import { needsRecompile } from './utils/needs_recompile.js';
@@ -26,9 +28,20 @@ async function collectContractArtifacts(): Promise<string[]> {
   return files.filter(f => Array.isArray(f.content.functions)).map(f => f.filePath);
 }
 
+/**
+ * Returns the package version for embedding in contract artifacts or `dev` if the version in package.json is
+ * the placeholder value (that would indicate that this is used from a locally checked out monorepo instead of npm).
+ */
+function getPackageVersionOrDev(): string {
+  const dir = dirname(fileURLToPath(import.meta.url));
+  const packageJsonPath = resolve(dir, '../../../package.json');
+  const version = JSON.parse(readFileSync(packageJsonPath).toString()).version;
+  return version === '0.1.0' ? DEV_VERSION : version;
+}
+
 /** Injects the Aztec stack version into contract artifacts. */
 async function injectAztecVersion(artifactPaths: string[]): Promise<void> {
-  const version = getAztecVersion();
+  const version = getPackageVersionOrDev();
   for (const path of artifactPaths) {
     const artifact = JSON.parse(await readFile(path, 'utf-8'));
     // eslint-disable-next-line camelcase

--- a/yarn-project/aztec/src/cli/cmds/compile.ts
+++ b/yarn-project/aztec/src/cli/cmds/compile.ts
@@ -26,8 +26,8 @@ async function collectContractArtifacts(): Promise<string[]> {
   return files.filter(f => Array.isArray(f.content.functions)).map(f => f.filePath);
 }
 
-/** Injects the Aztec stack version into contract artifacts. */
-async function injectAztecVersion(artifactPaths: string[]): Promise<void> {
+/** Stamps the Aztec stack version into the contract artifacts. */
+async function stampAztecVersion(artifactPaths: string[]): Promise<void> {
   const version = getPackageVersion();
   for (const path of artifactPaths) {
     const artifact = JSON.parse(await readFile(path, 'utf-8'));
@@ -161,7 +161,7 @@ async function compileAztecContract(nargoArgs: string[], log: LogFn): Promise<vo
     const bbArgs = artifacts.flatMap(a => ['-i', a]);
     await run(bb, ['aztec_process', ...bbArgs]);
 
-    await injectAztecVersion(artifacts);
+    await stampAztecVersion(artifacts);
   }
 
   log('Compilation complete!');

--- a/yarn-project/end-to-end/src/fixtures/setup.ts
+++ b/yarn-project/end-to-end/src/fixtures/setup.ts
@@ -271,6 +271,25 @@ export type EndToEndContext = {
 };
 
 /**
+ * When CONTRACT_ARTIFACTS_VERSION is set (backwards compatibility testing), asserts that the loaded artifact's
+ * aztecVersion matches the expected version. This ensures that the legacy artifact resolver actually swapped in the
+ * correct version.
+ */
+function assertContractArtifactsVersion() {
+  const expected = process.env.CONTRACT_ARTIFACTS_VERSION;
+  if (!expected) {
+    return;
+  }
+  const { aztecVersion } = SponsoredFPCContract.artifact;
+  if (aztecVersion !== expected) {
+    throw new Error(
+      `Artifact version mismatch: expected ${expected} but got ${aztecVersion}. ` +
+        `The legacy artifact resolver may not have swapped in the correct version.`,
+    );
+  }
+}
+
+/**
  * Sets up the environment for the end-to-end tests.
  * @param numberOfAccounts - The number of new accounts to be created once the PXE is initiated.
  * @param opts - Options to pass to the node initialization and to the setup script.
@@ -282,6 +301,7 @@ export async function setup(
   pxeOpts: Partial<PXEConfig> = {},
   chain: Chain = foundry,
 ): Promise<EndToEndContext> {
+  assertContractArtifactsVersion();
   let anvil: Anvil | undefined;
   try {
     opts.aztecTargetCommitteeSize ??= 0;

--- a/yarn-project/end-to-end/src/fixtures/setup.ts
+++ b/yarn-project/end-to-end/src/fixtures/setup.ts
@@ -50,6 +50,7 @@ import { protocolContractsHash } from '@aztec/protocol-contracts';
 import type { ProverNodeConfig } from '@aztec/prover-node';
 import { type PXEConfig, getPXEConfig } from '@aztec/pxe/server';
 import type { SequencerClient } from '@aztec/sequencer-client';
+import { ARTIFACT_VERSION_BEFORE_INJECTION } from '@aztec/stdlib/abi';
 import { type ContractInstanceWithAddress, getContractInstanceFromInstantiationParams } from '@aztec/stdlib/contract';
 import type { AztecNodeAdmin, AztecNodeDebug } from '@aztec/stdlib/interfaces/client';
 import { tryStop } from '@aztec/stdlib/interfaces/server';
@@ -281,6 +282,13 @@ function assertContractArtifactsVersion() {
     return;
   }
   const { aztecVersion } = SponsoredFPCContract.artifact;
+  // TODO(F-557): Remove this bypass once pre-version artifacts are no longer tested.
+  if (aztecVersion === ARTIFACT_VERSION_BEFORE_INJECTION) {
+    createLogger('e2e:setup').info(
+      `Skipping artifact version check: artifact predates version injection (CONTRACT_ARTIFACTS_VERSION=${expected})`,
+    );
+    return;
+  }
   if (aztecVersion !== expected) {
     throw new Error(
       `Artifact version mismatch: expected ${expected} but got ${aztecVersion}. ` +

--- a/yarn-project/end-to-end/src/fixtures/setup.ts
+++ b/yarn-project/end-to-end/src/fixtures/setup.ts
@@ -273,8 +273,8 @@ export type EndToEndContext = {
 
 /**
  * When CONTRACT_ARTIFACTS_VERSION is set (backwards compatibility testing), asserts that the loaded artifact's
- * aztecVersion matches the expected version. This ensures that the legacy artifact resolver actually swapped in the
- * correct version.
+ * aztecVersion matches the expected version. This is a sanity check verifying that the legacy artifact resolver
+ * actually swapped in the correct version.
  */
 function assertContractArtifactsVersion() {
   const expected = process.env.CONTRACT_ARTIFACTS_VERSION;

--- a/yarn-project/stdlib/src/abi/abi.ts
+++ b/yarn-project/stdlib/src/abi/abi.ts
@@ -6,7 +6,7 @@ import { schemas, zodFor } from '@aztec/foundation/schemas';
 import { inflate } from 'pako';
 import { z } from 'zod';
 
-import { DEV_VERSION } from '../update-checker/package_version.js';
+import { DEV_VERSION } from '../update-checker/dev_version.js';
 import { FunctionSelector } from './function_selector.js';
 
 /** A basic value. */

--- a/yarn-project/stdlib/src/abi/abi.ts
+++ b/yarn-project/stdlib/src/abi/abi.ts
@@ -6,6 +6,7 @@ import { schemas, zodFor } from '@aztec/foundation/schemas';
 import { inflate } from 'pako';
 import { z } from 'zod';
 
+import { DEV_VERSION } from '../update-checker/package_version.js';
 import { FunctionSelector } from './function_selector.js';
 
 /** A basic value. */
@@ -343,6 +344,9 @@ export interface ContractArtifact {
   /** The name of the contract. */
   name: string;
 
+  /** The version of the Aztec stack that compiled this artifact. */
+  aztecVersion: string;
+
   /** The functions of the contract. Includes private and utility functions, plus the public dispatch function. */
   functions: FunctionArtifact[];
 
@@ -365,6 +369,7 @@ export interface ContractArtifact {
 export const ContractArtifactSchema = zodFor<ContractArtifact>()(
   z.object({
     name: z.string(),
+    aztecVersion: z.string(),
     functions: z.array(FunctionArtifactSchema),
     nonDispatchPublicFunctions: z.array(FunctionAbiSchema),
     outputs: z.object({
@@ -551,6 +556,7 @@ export function emptyFunctionArtifact(): FunctionArtifact {
 export function emptyContractArtifact(): ContractArtifact {
   return {
     name: '',
+    aztecVersion: DEV_VERSION,
     functions: [emptyFunctionArtifact()],
     nonDispatchPublicFunctions: [emptyFunctionAbi()],
     outputs: {

--- a/yarn-project/stdlib/src/abi/abi.ts
+++ b/yarn-project/stdlib/src/abi/abi.ts
@@ -339,6 +339,9 @@ export type FieldLayout = {
   slot: Fr;
 };
 
+/** Placeholder version injected into artifacts compiled before aztecVersion was added. TODO(F-557): Remove. */
+export const ARTIFACT_VERSION_BEFORE_INJECTION = 'FROM_RELEASE_BEFORE_VERSION_INJECTION';
+
 /** Defines artifact of a contract. */
 export interface ContractArtifact {
   /** The name of the contract. */
@@ -369,7 +372,7 @@ export interface ContractArtifact {
 export const ContractArtifactSchema = zodFor<ContractArtifact>()(
   z.object({
     name: z.string(),
-    aztecVersion: z.string(),
+    aztecVersion: z.string().default(ARTIFACT_VERSION_BEFORE_INJECTION), // TODO(F-557): Remove default.
     functions: z.array(FunctionArtifactSchema),
     nonDispatchPublicFunctions: z.array(FunctionAbiSchema),
     outputs: z.object({

--- a/yarn-project/stdlib/src/abi/contract_artifact.ts
+++ b/yarn-project/stdlib/src/abi/contract_artifact.ts
@@ -12,6 +12,7 @@ import {
 import {
   type ABIParameter,
   type ABIParameterVisibility,
+  ARTIFACT_VERSION_BEFORE_INJECTION,
   type AbiType,
   type BasicValue,
   type ContractArtifact,
@@ -51,6 +52,10 @@ export function contractArtifactFromBuffer(buffer: Buffer): ContractArtifact {
  */
 export function loadContractArtifact(input: NoirCompiledContract): ContractArtifact {
   if (isContractArtifact(input)) {
+    // TODO(F-557): Remove this fallback once pre-version artifacts are no longer tested.
+    if (!(input as unknown as Record<string, unknown>).aztecVersion) {
+      return { ...input, aztecVersion: ARTIFACT_VERSION_BEFORE_INJECTION };
+    }
     return input;
   }
   return generateContractArtifact(input);

--- a/yarn-project/stdlib/src/abi/contract_artifact.ts
+++ b/yarn-project/stdlib/src/abi/contract_artifact.ts
@@ -276,10 +276,9 @@ function getStorageLayout(input: NoirCompiledContract) {
 }
 
 /**
- * Given a Nargo output generates an Aztec-compatible contract artifact.
+ * Given a post-processed Nargo output defined as `contract` generates an Aztec-compatible contract artifact.
+ *
  * Does not include public bytecode, apart from the public_dispatch function.
- * @param compiled - Noir build output.
- * @returns Aztec contract build artifact.
  */
 function generateContractArtifact(contract: NoirCompiledContract): ContractArtifact {
   try {
@@ -288,6 +287,7 @@ function generateContractArtifact(contract: NoirCompiledContract): ContractArtif
     }
     return ContractArtifactSchema.parse({
       name: contract.name,
+      aztecVersion: contract.aztec_version,
       functions: contract.functions.filter(f => retainBytecode(f)).map(f => generateFunctionArtifact(f, contract)),
       nonDispatchPublicFunctions: contract.functions
         .filter(f => !retainBytecode(f))
@@ -302,15 +302,15 @@ function generateContractArtifact(contract: NoirCompiledContract): ContractArtif
 }
 
 /**
- * Given a Nargo output generates an Aztec-compatible contract artifact.
+ * Given a post-processed Nargo output defined as `contract` generates an Aztec-compatible contract artifact.
+ *
  * Retains all public bytecode.
- * @param compiled - Noir build output.
- * @returns Aztec contract build artifact.
  */
 function generateContractArtifactForPublic(contract: NoirCompiledContract): ContractArtifact {
   try {
     return ContractArtifactSchema.parse({
       name: contract.name,
+      aztecVersion: contract.aztec_version,
       functions: contract.functions.map(f => generateFunctionArtifact(f, contract)),
       nonDispatchPublicFunctions: contract.functions
         .filter(f => !retainBytecode(f))

--- a/yarn-project/stdlib/src/contract/artifact_hash.test.ts
+++ b/yarn-project/stdlib/src/contract/artifact_hash.test.ts
@@ -1,5 +1,6 @@
 import type { ContractArtifact } from '../abi/index.js';
 import { getTestContractArtifact } from '../tests/fixtures.js';
+import { DEV_VERSION } from '../update-checker/package_version.js';
 import { computeArtifactHash } from './artifact_hash.js';
 
 describe('ArtifactHash', () => {
@@ -9,6 +10,7 @@ describe('ArtifactHash', () => {
       functions: [],
       nonDispatchPublicFunctions: [],
       name: 'Test',
+      aztecVersion: DEV_VERSION,
       outputs: {
         globals: {},
         structs: {},

--- a/yarn-project/stdlib/src/contract/artifact_hash.test.ts
+++ b/yarn-project/stdlib/src/contract/artifact_hash.test.ts
@@ -1,6 +1,6 @@
 import type { ContractArtifact } from '../abi/index.js';
 import { getTestContractArtifact } from '../tests/fixtures.js';
-import { DEV_VERSION } from '../update-checker/package_version.js';
+import { DEV_VERSION } from '../update-checker/dev_version.js';
 import { computeArtifactHash } from './artifact_hash.js';
 
 describe('ArtifactHash', () => {

--- a/yarn-project/stdlib/src/noir/index.ts
+++ b/yarn-project/stdlib/src/noir/index.ts
@@ -64,6 +64,8 @@ interface NoirFunctionEntry {
 export interface NoirCompiledContract {
   /** The name of the contract. */
   name: string;
+  /** The version of the Aztec stack that compiled this contract. */
+  aztec_version: string;
   /** Is the contract's public bytecode transpiled? */
   transpiled?: boolean;
   /** The functions of the contract. */

--- a/yarn-project/stdlib/src/tests/mocks.ts
+++ b/yarn-project/stdlib/src/tests/mocks.ts
@@ -75,7 +75,7 @@ import { NestedProcessReturnValues, PublicSimulationOutput } from '../tx/public_
 import { TxSimulationResult } from '../tx/simulated_tx.js';
 import { TxEffect } from '../tx/tx_effect.js';
 import { TxHash } from '../tx/tx_hash.js';
-import { DEV_VERSION } from '../update-checker/package_version.js';
+import { DEV_VERSION } from '../update-checker/dev_version.js';
 import {
   makeAvmCircuitInputs,
   makeAztecAddress,

--- a/yarn-project/stdlib/src/tests/mocks.ts
+++ b/yarn-project/stdlib/src/tests/mocks.ts
@@ -75,6 +75,7 @@ import { NestedProcessReturnValues, PublicSimulationOutput } from '../tx/public_
 import { TxSimulationResult } from '../tx/simulated_tx.js';
 import { TxEffect } from '../tx/tx_effect.js';
 import { TxHash } from '../tx/tx_hash.js';
+import { DEV_VERSION } from '../update-checker/package_version.js';
 import {
   makeAvmCircuitInputs,
   makeAztecAddress,
@@ -491,6 +492,7 @@ export async function mockCheckpointAndMessages(
 
 export const randomContractArtifact = (): ContractArtifact => ({
   name: randomBytes(4).toString('hex'),
+  aztecVersion: DEV_VERSION,
   functions: [],
   nonDispatchPublicFunctions: [],
   outputs: {

--- a/yarn-project/stdlib/src/update-checker/dev_version.ts
+++ b/yarn-project/stdlib/src/update-checker/dev_version.ts
@@ -1,0 +1,2 @@
+/** Placeholder version returned when running from a local monorepo checkout rather than an npm-installed package. */
+export const DEV_VERSION = 'dev';

--- a/yarn-project/stdlib/src/update-checker/index.ts
+++ b/yarn-project/stdlib/src/update-checker/index.ts
@@ -1,2 +1,3 @@
+export * from './dev_version.js';
 export * from './package_version.js';
 export * from './version_checker.js';

--- a/yarn-project/stdlib/src/update-checker/package_version.ts
+++ b/yarn-project/stdlib/src/update-checker/package_version.ts
@@ -16,9 +16,3 @@ export function getPackageVersion(): string {
   const version = JSON.parse(readFileSync(packageJsonPath).toString()).version;
   return version === '0.1.0' ? DEV_VERSION : version;
 }
-
-/**
- * Placeholder aztec version stamped into artifacts compiled from a local repo checkout, where the real release version
- * isn't yet known. Published CLIs stamp the installed package.json version instead.
- */
-export const DEV_VERSION = 'dev';

--- a/yarn-project/stdlib/src/update-checker/package_version.ts
+++ b/yarn-project/stdlib/src/update-checker/package_version.ts
@@ -3,8 +3,7 @@ import { fileURLToPath } from '@aztec/foundation/url';
 import { readFileSync } from 'fs';
 import { dirname, resolve } from 'path';
 
-/** Placeholder version returned when running from a local monorepo checkout rather than an npm-installed package. */
-export const DEV_VERSION = 'dev';
+import { DEV_VERSION } from './dev_version.js';
 
 /**
  * Returns the package version from the stdlib `package.json`, or `DEV_VERSION` when the version is the `0.1.0`

--- a/yarn-project/stdlib/src/update-checker/package_version.ts
+++ b/yarn-project/stdlib/src/update-checker/package_version.ts
@@ -24,7 +24,7 @@ export function getPackageVersion(): string {
 export const DEV_VERSION = 'dev';
 
 /**
- * Returns the precise Aztec stack version for embedding in contract artifacts.
+ * Returns the Aztec stack version for embedding in contract artifacts.
  *
  * 1. package.json version — when a developer installs the CLI (e.g. via aztec-up or npm) and runs `aztec compile`. The
  *    installed package.json carries the exact version.
@@ -32,18 +32,9 @@ export const DEV_VERSION = 'dev';
  */
 export function getAztecVersion(): string {
   const dir = dirname(fileURLToPath(import.meta.url));
-
-  try {
-    const packageJsonPath = resolve(dir, '../../package.json');
-    const version = JSON.parse(readFileSync(packageJsonPath).toString()).version;
-    // 0.1.0 is the placeholder version in all monorepo package.json files during development. Published packages will
-    // have the real version (e.g. 5.0.0-nightly.20260414).
-    if (version && version !== '0.1.0') {
-      return version;
-    }
-  } catch {
-    // No package.json found.
-  }
-
-  return DEV_VERSION;
+  const packageJsonPath = resolve(dir, '../../package.json');
+  const version = JSON.parse(readFileSync(packageJsonPath).toString()).version;
+  // 0.1.0 is the placeholder version in all monorepo package.json files during development. Published packages will
+  // have the real version (e.g. 5.0.0-nightly.20260414).
+  return version === '0.1.0' ? DEV_VERSION : version;
 }

--- a/yarn-project/stdlib/src/update-checker/package_version.ts
+++ b/yarn-project/stdlib/src/update-checker/package_version.ts
@@ -26,21 +26,13 @@ export const DEV_VERSION = 'dev';
 /**
  * Returns the precise Aztec stack version for embedding in contract artifacts.
  *
- * 1. AZTEC_VERSION env var (e.g. "5.0.0-nightly.20260414") — set by ci3/source_refname during CI release builds when
- *    the git tag is a valid semver.
- * 2. package.json version — when a developer installs the CLI (e.g. via aztec-up or npm) and runs `aztec compile`. The
+ * 1. package.json version — when a developer installs the CLI (e.g. via aztec-up or npm) and runs `aztec compile`. The
  *    installed package.json carries the exact version.
- * 3. DEV_VERSION — local repo checkout during development (neither CI release nor npm install).
+ * 2. DEV_VERSION — local repo checkout during development (no npm install).
  */
 export function getAztecVersion(): string {
-  const aztecVersion = process.env.AZTEC_VERSION;
-  if (aztecVersion) {
-    return aztecVersion;
-  }
-
   const dir = dirname(fileURLToPath(import.meta.url));
 
-  // Fall back to the stdlib package.json version (works in npm-installed packages).
   try {
     const packageJsonPath = resolve(dir, '../../package.json');
     const version = JSON.parse(readFileSync(packageJsonPath).toString()).version;

--- a/yarn-project/stdlib/src/update-checker/package_version.ts
+++ b/yarn-project/stdlib/src/update-checker/package_version.ts
@@ -26,17 +26,16 @@ export const DEV_VERSION = 'dev';
 /**
  * Returns the precise Aztec stack version for embedding in contract artifacts.
  *
- * 1. REF_NAME env var (e.g. "v5.0.0-nightly.20260414") — set during CI release builds when bootstrap.sh compiles
- *    contracts before publishing npm packages.
+ * 1. AZTEC_VERSION env var (e.g. "5.0.0-nightly.20260414") — set by ci3/source_refname during CI release builds when
+ *    the git tag is a valid semver.
  * 2. package.json version — when a developer installs the CLI (e.g. via aztec-up or npm) and runs `aztec compile`. The
  *    installed package.json carries the exact version.
  * 3. DEV_VERSION — local repo checkout during development (neither CI release nor npm install).
  */
 export function getAztecVersion(): string {
-  // Use the git tag version (e.g. 5.0.0-nightly.20260414) when available in CI release builds.
-  const refName = process.env.REF_NAME;
-  if (refName?.startsWith('v')) {
-    return refName.slice(1);
+  const aztecVersion = process.env.AZTEC_VERSION;
+  if (aztecVersion) {
+    return aztecVersion;
   }
 
   const dir = dirname(fileURLToPath(import.meta.url));
@@ -45,6 +44,8 @@ export function getAztecVersion(): string {
   try {
     const packageJsonPath = resolve(dir, '../../package.json');
     const version = JSON.parse(readFileSync(packageJsonPath).toString()).version;
+    // 0.1.0 is the placeholder version in all monorepo package.json files during development. Published packages will
+    // have the real version (e.g. 5.0.0-nightly.20260414).
     if (version && version !== '0.1.0') {
       return version;
     }

--- a/yarn-project/stdlib/src/update-checker/package_version.ts
+++ b/yarn-project/stdlib/src/update-checker/package_version.ts
@@ -18,23 +18,7 @@ export function getPackageVersion(): string {
 }
 
 /**
- * Fallback version used when compiling contracts from a local repo checkout rather than from a published release. Both
- * CI release builds (via REF_NAME) and npm-installed packages (via package.json) will have a real version.
+ * Placeholder aztec version stamped into artifacts compiled from a local repo checkout, where the real release version
+ * isn't yet known. Published CLIs stamp the installed package.json version instead.
  */
 export const DEV_VERSION = 'dev';
-
-/**
- * Returns the Aztec stack version for embedding in contract artifacts.
- *
- * 1. package.json version — when a developer installs the CLI (e.g. via aztec-up or npm) and runs `aztec compile`. The
- *    installed package.json carries the exact version.
- * 2. DEV_VERSION — local repo checkout during development (no npm install).
- */
-export function getAztecVersion(): string {
-  const dir = dirname(fileURLToPath(import.meta.url));
-  const packageJsonPath = resolve(dir, '../../package.json');
-  const version = JSON.parse(readFileSync(packageJsonPath).toString()).version;
-  // 0.1.0 is the placeholder version in all monorepo package.json files during development. Published packages will
-  // have the real version (e.g. 5.0.0-nightly.20260414).
-  return version === '0.1.0' ? DEV_VERSION : version;
-}

--- a/yarn-project/stdlib/src/update-checker/package_version.ts
+++ b/yarn-project/stdlib/src/update-checker/package_version.ts
@@ -16,3 +16,41 @@ export function getPackageVersion(): string {
   const version = JSON.parse(readFileSync(packageJsonPath).toString()).version;
   return version === '0.1.0' ? DEV_VERSION : version;
 }
+
+/**
+ * Fallback version used when compiling contracts from a local repo checkout rather than from a published release. Both
+ * CI release builds (via REF_NAME) and npm-installed packages (via package.json) will have a real version.
+ */
+export const DEV_VERSION = 'dev';
+
+/**
+ * Returns the precise Aztec stack version for embedding in contract artifacts.
+ *
+ * 1. REF_NAME env var (e.g. "v5.0.0-nightly.20260414") — set during CI release builds when bootstrap.sh compiles
+ *    contracts before publishing npm packages.
+ * 2. package.json version — when a developer installs the CLI (e.g. via aztec-up or npm) and runs `aztec compile`. The
+ *    installed package.json carries the exact version.
+ * 3. DEV_VERSION — local repo checkout during development (neither CI release nor npm install).
+ */
+export function getAztecVersion(): string {
+  // Use the git tag version (e.g. 5.0.0-nightly.20260414) when available in CI release builds.
+  const refName = process.env.REF_NAME;
+  if (refName?.startsWith('v')) {
+    return refName.slice(1);
+  }
+
+  const dir = dirname(fileURLToPath(import.meta.url));
+
+  // Fall back to the stdlib package.json version (works in npm-installed packages).
+  try {
+    const packageJsonPath = resolve(dir, '../../package.json');
+    const version = JSON.parse(readFileSync(packageJsonPath).toString()).version;
+    if (version && version !== '0.1.0') {
+      return version;
+    }
+  } catch {
+    // No package.json found.
+  }
+
+  return DEV_VERSION;
+}


### PR DESCRIPTION
Injects aztec stack version into Noir contract artifacts as it's a very useful info for debugging and other purposes (like verifying our backwards compatibility infra works).

Closes [F-549](https://linear.app/aztec-labs/issue/F-549/include-aztecnr-and-stack-versions-in-contract-artifact)