### PR TITLE
feat: check noir release has nargo binaries before releasing

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -504,34 +504,6 @@ function release_bb_github {
     --notes "Release $REF_NAME — see https://github.com/AztecProtocol/aztec-packages/commits/$COMMIT_HASH"
 }
 
-function check_noir_release_assets {
-  git -C noir/noir-repo fetch --tags 2>/dev/null || true
-  local noir_tag
-  noir_tag=$(git -C noir/noir-repo describe --tags --exact-match HEAD 2>/dev/null) || {
-    echo "Warning: noir-repo HEAD is not a tagged commit. Skipping noir release asset check."
-    return 0
-  }
-
-  echo "Checking noir release $noir_tag for nargo binary assets..."
-  local asset_count
-  asset_count=$(gh release view "$noir_tag" \
-    --repo noir-lang/noir \
-    --json assets \
-    --jq '[.assets[] | select(.name | test("^nargo-"))] | length') || {
-    echo_stderr "Error: Failed to query noir-lang/noir release '$noir_tag'. Does the release exist?"
-    exit 1
-  }
-
-  if [ "$asset_count" -eq 0 ]; then
-    echo_stderr "Error: Noir release '$noir_tag' exists but has no nargo binary assets."
-    echo_stderr "Users will get 404 errors when trying to install nargo via noirup."
-    echo_stderr "Ensure the noir release pipeline has finished uploading binaries before releasing aztec-packages."
-    exit 1
-  fi
-
-  echo "Found $asset_count nargo binary asset(s) in noir release $noir_tag."
-}
-
 function release {
   # Releases are triggered when REF_NAME is a valid semver (but can have a leading v).
   # We ensure there is a github release for our REF_NAME, if not on latest (in which case release-please creates it).
@@ -831,7 +803,6 @@ case "$cmd" in
     if ! semver check $REF_NAME; then
       exit 1
     fi
-    check_noir_release_assets
     if [[ "$(semver prerelease $REF_NAME)" == private* ]]; then
       echo_header "Private fork release: $REF_NAME"
       echo "Creating GitHub release from public repo context (COMMIT_HASH=$COMMIT_HASH)..."

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -504,6 +504,34 @@ function release_bb_github {
     --notes "Release $REF_NAME — see https://github.com/AztecProtocol/aztec-packages/commits/$COMMIT_HASH"
 }
 
+function check_noir_release_assets {
+  git -C noir/noir-repo fetch --tags 2>/dev/null || true
+  local noir_tag
+  noir_tag=$(git -C noir/noir-repo describe --tags --exact-match HEAD 2>/dev/null) || {
+    echo "Warning: noir-repo HEAD is not a tagged commit. Skipping noir release asset check."
+    return 0
+  }
+
+  echo "Checking noir release $noir_tag for nargo binary assets..."
+  local asset_count
+  asset_count=$(gh release view "$noir_tag" \
+    --repo noir-lang/noir \
+    --json assets \
+    --jq '[.assets[] | select(.name | test("^nargo-"))] | length') || {
+    echo_stderr "Error: Failed to query noir-lang/noir release '$noir_tag'. Does the release exist?"
+    exit 1
+  }
+
+  if [ "$asset_count" -eq 0 ]; then
+    echo_stderr "Error: Noir release '$noir_tag' exists but has no nargo binary assets."
+    echo_stderr "Users will get 404 errors when trying to install nargo via noirup."
+    echo_stderr "Ensure the noir release pipeline has finished uploading binaries before releasing aztec-packages."
+    exit 1
+  fi
+
+  echo "Found $asset_count nargo binary asset(s) in noir release $noir_tag."
+}
+
 function release {
   # Releases are triggered when REF_NAME is a valid semver (but can have a leading v).
   # We ensure there is a github release for our REF_NAME, if not on latest (in which case release-please creates it).
@@ -803,6 +831,7 @@ case "$cmd" in
     if ! semver check $REF_NAME; then
       exit 1
     fi
+    check_noir_release_assets
     if [[ "$(semver prerelease $REF_NAME)" == private* ]]; then
       echo_header "Private fork release: $REF_NAME"
       echo "Creating GitHub release from public repo context (COMMIT_HASH=$COMMIT_HASH)..."

--- a/noir/bootstrap.sh
+++ b/noir/bootstrap.sh
@@ -108,6 +108,26 @@ function build {
       echo_stderr "We're building a release but the noir-repo HEAD is not an official release."
       exit 1
     fi
+
+    # Check that the noir release has nargo binaries available for download.
+    # Without this check, users get 404/gzip errors when noirup tries to download nargo.
+    local noir_tag=$(git -C noir-repo describe --tags --exact-match HEAD)
+    echo "Checking noir release $noir_tag for nargo binary assets..."
+    local asset_count
+    asset_count=$(gh release view "$noir_tag" \
+      --repo noir-lang/noir \
+      --json assets \
+      --jq '[.assets[] | select(.name | test("^nargo-"))] | length') || {
+      echo_stderr "Error: Failed to query noir-lang/noir release '$noir_tag'. Does the release exist?"
+      exit 1
+    }
+    if [ "$asset_count" -eq 0 ]; then
+      echo_stderr "Error: Noir release '$noir_tag' exists but has no nargo binary assets."
+      echo_stderr "Users will get 404 errors when trying to install nargo via noirup."
+      echo_stderr "Ensure the noir release pipeline has finished uploading binaries before releasing aztec-packages."
+      exit 1
+    fi
+    echo "Found $asset_count nargo binary asset(s) in noir release $noir_tag."
   fi
 
   denoise "retry install_deps"

--- a/noir/bootstrap.sh
+++ b/noir/bootstrap.sh
@@ -103,14 +103,16 @@ function build {
   echo_header "noir build"
 
   if semver check $REF_NAME; then
+    # REF_NAME matches semver meaning we are doing a release
+
     git -C noir-repo fetch --tags
     if ! git -C noir-repo describe --tags --exact-match HEAD &>/dev/null; then
       echo_stderr "We're building a release but the noir-repo HEAD is not an official release."
       exit 1
     fi
 
-    # Check that the noir release has nargo binaries available for download.
-    # Without this check, users get 404/gzip errors when noirup tries to download nargo.
+    # Check that the noir release has nargo binaries available for download. Without this check, we could push an aztec
+    # release that errors out with a 404/gzip error on install (the install scripts invoke noirup which would fail).
     local noir_tag=$(git -C noir-repo describe --tags --exact-match HEAD)
     echo "Checking noir release $noir_tag for nargo binary assets..."
     local asset_count


### PR DESCRIPTION
## Summary
- Adds a `check_noir_release_assets` function to root `bootstrap.sh` that queries the GitHub API to verify the noir release has nargo binary assets
- Called from the `ci-release` case, right after semver validation and before the build starts -- so it fails fast and only runs during releases
- Prevents releases like `v4.2.0-aztecnr-rc.2` where the noir tag existed but had no binaries, causing 404 errors when users ran `noirup`

## Test plan
- [x] Verified `gh release view` query returns correct asset count against a known noir release (`v1.0.0-beta.3` → 5 assets)
- [ ] CI passes

Fixes https://linear.app/aztec-labs/issue/F-506/check-noir-binaries-exist-on-release