### PR TITLE
fix: avoid calling the node for L2 tips on every sync

### DIFF
--- a/yarn-project/pxe/src/contract_function_simulator/contract_function_simulator.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/contract_function_simulator.ts
@@ -42,7 +42,7 @@ import type { FunctionCall } from '@aztec/stdlib/abi';
 import { FunctionSelector, FunctionType } from '@aztec/stdlib/abi';
 import type { AuthWitness } from '@aztec/stdlib/auth-witness';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
-import type { BlockParameter } from '@aztec/stdlib/block';
+import type { BlockParameter, L2TipsProvider } from '@aztec/stdlib/block';
 import { Gas } from '@aztec/stdlib/gas';
 import {
   computeNoteHashNonce,
@@ -134,6 +134,7 @@ export type ContractFunctionSimulatorArgs = {
   keyStore: KeyStore;
   addressStore: AddressStore;
   aztecNode: AztecNode;
+  l2TipsStore: L2TipsProvider;
   senderTaggingStore: SenderTaggingStore;
   recipientTaggingStore: RecipientTaggingStore;
   senderAddressBookStore: SenderAddressBookStore;
@@ -154,6 +155,7 @@ export class ContractFunctionSimulator {
   private readonly keyStore: KeyStore;
   private readonly addressStore: AddressStore;
   private readonly aztecNode: AztecNode;
+  private readonly l2TipsStore: L2TipsProvider;
   private readonly senderTaggingStore: SenderTaggingStore;
   private readonly recipientTaggingStore: RecipientTaggingStore;
   private readonly senderAddressBookStore: SenderAddressBookStore;
@@ -169,6 +171,7 @@ export class ContractFunctionSimulator {
     this.keyStore = args.keyStore;
     this.addressStore = args.addressStore;
     this.aztecNode = args.aztecNode;
+    this.l2TipsStore = args.l2TipsStore;
     this.senderTaggingStore = args.senderTaggingStore;
     this.recipientTaggingStore = args.recipientTaggingStore;
     this.senderAddressBookStore = args.senderAddressBookStore;
@@ -255,6 +258,7 @@ export class ContractFunctionSimulator {
       scopes,
       senderForTags,
       simulator: this.simulator,
+      l2TipsStore: this.l2TipsStore,
     });
 
     const setupTime = simulatorSetupTimer.ms();
@@ -344,6 +348,7 @@ export class ContractFunctionSimulator {
       privateEventStore: this.privateEventStore,
       messageContextService: this.messageContextService,
       contractSyncService: this.contractSyncService,
+      l2TipsStore: this.l2TipsStore,
       jobId,
       scopes,
     });

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/oracle_version_is_checked.test.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/oracle_version_is_checked.test.ts
@@ -4,6 +4,7 @@ import { OracleVersionCheckContractArtifact } from '@aztec/noir-test-contracts.j
 import { WASMSimulator } from '@aztec/simulator/client';
 import { FunctionCall, FunctionSelector, FunctionType, encodeArguments } from '@aztec/stdlib/abi';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
+import type { L2TipsProvider } from '@aztec/stdlib/block';
 import type { ContractInstanceWithAddress } from '@aztec/stdlib/contract';
 import { GasFees, GasSettings } from '@aztec/stdlib/gas';
 import type { AztecNode } from '@aztec/stdlib/interfaces/server';
@@ -43,6 +44,7 @@ describe('Oracle Version Check test suite', () => {
   let privateEventStore: ReturnType<typeof mock<PrivateEventStore>>;
   let contractSyncService: ReturnType<typeof mock<ContractSyncService>>;
   let messageContextService: ReturnType<typeof mock<MessageContextService>>;
+  let l2TipsStore: ReturnType<typeof mock<L2TipsProvider>>;
   let acirSimulator: ContractFunctionSimulator;
   let contractAddress: AztecAddress;
   let anchorBlockHeader: BlockHeader;
@@ -63,6 +65,7 @@ describe('Oracle Version Check test suite', () => {
     privateEventStore = mock<PrivateEventStore>();
     contractSyncService = mock<ContractSyncService>();
     messageContextService = mock<MessageContextService>();
+    l2TipsStore = mock<L2TipsProvider>();
     assertCompatibleOracleVersionSpy = jest.spyOn(UtilityExecutionOracle.prototype, 'assertCompatibleOracleVersion');
     assertCompatibleOracleVersionSpy.mockClear();
 
@@ -99,6 +102,7 @@ describe('Oracle Version Check test suite', () => {
       keyStore,
       addressStore,
       aztecNode,
+      l2TipsStore: mock(),
       senderTaggingStore,
       recipientTaggingStore,
       senderAddressBookStore,
@@ -208,6 +212,7 @@ describe('Oracle Version Check test suite', () => {
         contractSyncService,
         jobId: 'test',
         scopes: [],
+        l2TipsStore,
       });
     });
 

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution.test.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution.test.ts
@@ -26,7 +26,7 @@ import {
   getFunctionArtifactByName,
 } from '@aztec/stdlib/abi';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
-import { BlockHash, type BlockParameter } from '@aztec/stdlib/block';
+import { BlockHash, type BlockParameter, type L2TipsProvider } from '@aztec/stdlib/block';
 import {
   CompleteAddress,
   getContractClassFromArtifact,
@@ -111,6 +111,7 @@ describe('Private Execution test suite', () => {
   let privateEventStore: MockProxy<PrivateEventStore>;
   let contractSyncService: MockProxy<ContractSyncService>;
   let messageContextService: MockProxy<MessageContextService>;
+  let l2TipsStore: MockProxy<L2TipsProvider>;
   let acirSimulator: ContractFunctionSimulator;
   let anchorBlockHeader = BlockHeader.empty();
   let logger: Logger;
@@ -282,6 +283,7 @@ describe('Private Execution test suite', () => {
     aztecNode = mock<AztecNode>();
     keyStore = mock<KeyStore>();
     capsuleStore = mock<CapsuleStore>();
+    l2TipsStore = mock<L2TipsProvider>();
     privateEventStore = mock<PrivateEventStore>();
     senderAddressBookStore = mock<SenderAddressBookStore>();
     contractSyncService = mock<ContractSyncService>();
@@ -322,13 +324,7 @@ describe('Private Execution test suite', () => {
     aztecNode.getPrivateLogsByTags.mockImplementation((tags: SiloedTag[]) => Promise.resolve(tags.map(() => [])));
 
     // Mock getL2Tips and getBlockHeader for loadPrivateLogsForSenderRecipientPair
-    aztecNode.getL2Tips.mockResolvedValue(makeL2Tips(anchorBlockHeader.globalVariables.blockNumber));
-    aztecNode.getBlockHeader.mockImplementation((blockNumber: BlockNumber | 'latest') => {
-      if (blockNumber === 'latest') {
-        return Promise.resolve(anchorBlockHeader);
-      }
-      return Promise.resolve(anchorBlockHeader);
-    });
+    l2TipsStore.getL2Tips.mockResolvedValue(makeL2Tips(anchorBlockHeader.globalVariables.blockNumber));
 
     // TODO: refactor. Maybe it's worth stubbing a key store
     // and cleaning up the mess that is setting up keys.
@@ -462,6 +458,7 @@ describe('Private Execution test suite', () => {
       keyStore,
       addressStore,
       aztecNode,
+      l2TipsStore,
       senderTaggingStore,
       recipientTaggingStore,
       senderAddressBookStore,

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution_oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution_oracle.ts
@@ -575,6 +575,7 @@ export class PrivateExecutionOracle extends UtilityExecutionOracle implements IP
       scopes: this.scopes,
       senderForTags: this.senderForTags,
       simulator: this.simulator!,
+      l2TipsStore: this.l2TipsStore,
     });
 
     const setupTime = simulatorSetupTimer.ms();

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution.test.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution.test.ts
@@ -7,7 +7,7 @@ import { StatefulTestContractArtifact } from '@aztec/noir-test-contracts.js/Stat
 import { WASMSimulator } from '@aztec/simulator/client';
 import { FunctionCall, FunctionSelector, FunctionType, encodeArguments } from '@aztec/stdlib/abi';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
-import { BlockHash } from '@aztec/stdlib/block';
+import { BlockHash, type L2TipsProvider } from '@aztec/stdlib/block';
 import {
   CompleteAddress,
   type ContractInstanceWithAddress,
@@ -51,6 +51,7 @@ describe('Utility Execution test suite', () => {
   let capsuleStore: ReturnType<typeof mock<CapsuleStore>>;
   let privateEventStore: ReturnType<typeof mock<PrivateEventStore>>;
   let contractSyncService: ReturnType<typeof mock<ContractSyncService>>;
+  let l2TipsStore: ReturnType<typeof mock<L2TipsProvider>>;
   let messageContextService: MessageContextService;
   let acirSimulator: ContractFunctionSimulator;
   let owner: AztecAddress;
@@ -74,6 +75,7 @@ describe('Utility Execution test suite', () => {
     capsuleStore = mock<CapsuleStore>();
     privateEventStore = mock<PrivateEventStore>();
     contractSyncService = mock<ContractSyncService>();
+    l2TipsStore = mock<L2TipsProvider>();
     messageContextService = new MessageContextService(aztecNode);
     const capsuleArrays = new Map<string, Fr[][]>();
     anchorBlockHeader = BlockHeader.random();
@@ -83,14 +85,7 @@ describe('Utility Execution test suite', () => {
     senderTaggingStore.storePendingIndexes.mockResolvedValue();
     senderAddressBookStore.getSenders.mockResolvedValue([]);
 
-    // Mock getL2Tips and getBlockHeader for loadPrivateLogsForSenderRecipientPair
-    aztecNode.getL2Tips.mockResolvedValue(makeL2Tips(anchorBlockHeader.globalVariables.blockNumber));
-    aztecNode.getBlockHeader.mockImplementation((blockNumber: BlockNumber | 'latest') => {
-      if (blockNumber === 'latest') {
-        return Promise.resolve(anchorBlockHeader);
-      }
-      return Promise.resolve(anchorBlockHeader);
-    });
+    l2TipsStore.getL2Tips.mockResolvedValue(makeL2Tips(anchorBlockHeader.globalVariables.blockNumber));
     aztecNode.getPrivateLogsByTags.mockImplementation((tags: any[]) => Promise.resolve(tags.map(() => [])));
 
     capsuleStore.setCapsuleArray.mockImplementation((address, slot, content) => {
@@ -106,6 +101,7 @@ describe('Utility Execution test suite', () => {
       keyStore,
       addressStore,
       aztecNode,
+      l2TipsStore,
       senderTaggingStore,
       recipientTaggingStore,
       senderAddressBookStore,
@@ -260,6 +256,7 @@ describe('Utility Execution test suite', () => {
         contractSyncService,
         jobId: 'test-job-id',
         scopes: [scope],
+        l2TipsStore,
       });
     });
 
@@ -326,6 +323,7 @@ describe('Utility Execution test suite', () => {
           contractSyncService,
           jobId: 'test-job-id',
           scopes: [scope],
+          l2TipsStore,
         });
 
         capsuleStore.getCapsule.mockResolvedValueOnce(persisted);
@@ -506,6 +504,7 @@ describe('Utility Execution test suite', () => {
             contractSyncService,
             jobId: 'test-job-id',
             scopes: [],
+            l2TipsStore,
           });
 
         const oracleA = makeOracle(contractAddressA);

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
@@ -9,7 +9,7 @@ import type { KeyStore } from '@aztec/key-store';
 import { isProtocolContract } from '@aztec/protocol-contracts';
 import type { AuthWitness } from '@aztec/stdlib/auth-witness';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
-import { BlockHash } from '@aztec/stdlib/block';
+import { BlockHash, type L2TipsProvider } from '@aztec/stdlib/block';
 import type { CompleteAddress, ContractInstance, PartialAddress } from '@aztec/stdlib/contract';
 import { siloNullifier } from '@aztec/stdlib/hash';
 import type { AztecNode } from '@aztec/stdlib/interfaces/server';
@@ -63,6 +63,7 @@ export type UtilityExecutionOracleArgs = {
   privateEventStore: PrivateEventStore;
   messageContextService: MessageContextService;
   contractSyncService: ContractSyncService;
+  l2TipsStore: L2TipsProvider;
   jobId: string;
   log?: ReturnType<typeof createLogger>;
   scopes: AztecAddress[];
@@ -98,6 +99,7 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
   protected readonly privateEventStore: PrivateEventStore;
   protected readonly messageContextService: MessageContextService;
   protected readonly contractSyncService: ContractSyncService;
+  protected readonly l2TipsStore: L2TipsProvider;
   protected readonly jobId: string;
   protected logger: ReturnType<typeof createLogger>;
   protected readonly scopes: AztecAddress[];
@@ -118,6 +120,7 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
     this.privateEventStore = args.privateEventStore;
     this.messageContextService = args.messageContextService;
     this.contractSyncService = args.contractSyncService;
+    this.l2TipsStore = args.l2TipsStore;
     this.jobId = args.jobId;
     this.logger = args.log ?? createLogger('simulator:client_view_context');
     this.scopes = args.scopes;
@@ -531,6 +534,7 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
     return new LogService(
       this.aztecNode,
       this.anchorBlockHeader,
+      this.l2TipsStore,
       this.keyStore,
       this.recipientTaggingStore,
       this.senderAddressBookStore,

--- a/yarn-project/pxe/src/logs/log_service.test.ts
+++ b/yarn-project/pxe/src/logs/log_service.test.ts
@@ -5,6 +5,7 @@ import { Fr } from '@aztec/foundation/curves/bn254';
 import { KeyStore } from '@aztec/key-store';
 import { openTmpStore } from '@aztec/kv-store/lmdb-v2';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
+import type { L2TipsProvider } from '@aztec/stdlib/block';
 import type { AztecNode } from '@aztec/stdlib/interfaces/server';
 import { Tag } from '@aztec/stdlib/logs';
 import { makeBlockHeader, randomTxScopedPrivateL2Log } from '@aztec/stdlib/testing';
@@ -49,6 +50,7 @@ describe('LogService', () => {
       logService = new LogService(
         aztecNode,
         anchorBlockHeader,
+        mock<L2TipsProvider>(),
         keyStore,
         recipientTaggingStore,
         senderAddressBookStore,

--- a/yarn-project/pxe/src/logs/log_service.ts
+++ b/yarn-project/pxe/src/logs/log_service.ts
@@ -120,9 +120,6 @@ export class LogService {
     const anchorBlockNumber = this.anchorBlockHeader.getBlockNumber();
     const anchorBlockHash = await this.anchorBlockHeader.hash();
 
-    // Fetch chain state once — all sender-recipient pairs need the same values and fetching
-    // per-pair would cause N redundant RPC calls in parallel. We read tips from the local store
-    // (no RPC) and use the anchor block's timestamp for log aging, which is always recent enough.
     const l2Tips = await this.l2TipsStore.getL2Tips();
     const currentTimestamp = this.anchorBlockHeader.globalVariables.timestamp;
     // Get all secrets for this recipient (one per sender)

--- a/yarn-project/pxe/src/logs/log_service.ts
+++ b/yarn-project/pxe/src/logs/log_service.ts
@@ -118,6 +118,15 @@ export class LogService {
     const anchorBlockNumber = this.anchorBlockHeader.getBlockNumber();
     const anchorBlockHash = await this.anchorBlockHeader.hash();
 
+    // Fetch chain state once — all sender-recipient pairs need the same values and fetching
+    // per-pair would cause N redundant node_getL2Tips + node_getBlockHeader calls in parallel.
+    const [l2Tips, latestBlockHeader] = await Promise.all([
+      this.aztecNode.getL2Tips(),
+      this.aztecNode.getBlockHeader('latest'),
+    ]);
+    if (!latestBlockHeader) {
+      throw new Error('Node failed to return latest block header when syncing logs');
+    }
     // Get all secrets for this recipient (one per sender)
     const secrets = await this.#getSecretsForSenders(contractAddress, recipient);
 
@@ -130,6 +139,8 @@ export class LogService {
           this.recipientTaggingStore,
           anchorBlockNumber,
           anchorBlockHash,
+          latestBlockHeader.globalVariables.timestamp,
+          l2Tips.finalized.block.number,
           this.jobId,
         ),
       ),

--- a/yarn-project/pxe/src/logs/log_service.ts
+++ b/yarn-project/pxe/src/logs/log_service.ts
@@ -1,6 +1,7 @@
 import { type Logger, type LoggerBindings, createLogger } from '@aztec/foundation/log';
 import type { KeyStore } from '@aztec/key-store';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
+import type { L2TipsProvider } from '@aztec/stdlib/block';
 import type { AztecNode } from '@aztec/stdlib/interfaces/server';
 import { ExtendedDirectionalAppTaggingSecret, PendingTaggedLog, SiloedTag, Tag } from '@aztec/stdlib/logs';
 import type { BlockHeader } from '@aztec/stdlib/tx';
@@ -22,6 +23,7 @@ export class LogService {
   constructor(
     private readonly aztecNode: AztecNode,
     private readonly anchorBlockHeader: BlockHeader,
+    private readonly l2TipsStore: L2TipsProvider,
     private readonly keyStore: KeyStore,
     private readonly recipientTaggingStore: RecipientTaggingStore,
     private readonly senderAddressBookStore: SenderAddressBookStore,
@@ -119,14 +121,10 @@ export class LogService {
     const anchorBlockHash = await this.anchorBlockHeader.hash();
 
     // Fetch chain state once — all sender-recipient pairs need the same values and fetching
-    // per-pair would cause N redundant node_getL2Tips + node_getBlockHeader calls in parallel.
-    const [l2Tips, latestBlockHeader] = await Promise.all([
-      this.aztecNode.getL2Tips(),
-      this.aztecNode.getBlockHeader('latest'),
-    ]);
-    if (!latestBlockHeader) {
-      throw new Error('Node failed to return latest block header when syncing logs');
-    }
+    // per-pair would cause N redundant RPC calls in parallel. We read tips from the local store
+    // (no RPC) and use the anchor block's timestamp for log aging, which is always recent enough.
+    const l2Tips = await this.l2TipsStore.getL2Tips();
+    const currentTimestamp = this.anchorBlockHeader.globalVariables.timestamp;
     // Get all secrets for this recipient (one per sender)
     const secrets = await this.#getSecretsForSenders(contractAddress, recipient);
 
@@ -139,7 +137,7 @@ export class LogService {
           this.recipientTaggingStore,
           anchorBlockNumber,
           anchorBlockHash,
-          latestBlockHeader.globalVariables.timestamp,
+          currentTimestamp,
           l2Tips.finalized.block.number,
           this.jobId,
         ),

--- a/yarn-project/pxe/src/pxe.ts
+++ b/yarn-project/pxe/src/pxe.ts
@@ -18,6 +18,7 @@ import {
 } from '@aztec/stdlib/abi';
 import type { AuthWitness } from '@aztec/stdlib/auth-witness';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
+import type { L2TipsProvider } from '@aztec/stdlib/block';
 import {
   CompleteAddress,
   type ContractInstanceWithAddress,
@@ -161,6 +162,7 @@ export class PXE {
     private privateEventStore: PrivateEventStore,
     private contractSyncService: ContractSyncService,
     private messageContextService: MessageContextService,
+    private l2TipsStore: L2TipsProvider,
     private simulator: CircuitSimulator,
     private proverEnabled: boolean,
     private proofCreator: PrivateKernelProver,
@@ -260,6 +262,7 @@ export class PXE {
       privateEventStore,
       contractSyncService,
       messageContextService,
+      tipsStore,
       simulator,
       proverEnabled,
       proofCreator,
@@ -294,6 +297,7 @@ export class PXE {
       keyStore: this.keyStore,
       addressStore: this.addressStore,
       aztecNode: BenchmarkedNodeFactory.create(this.node),
+      l2TipsStore: this.l2TipsStore,
       senderTaggingStore: this.senderTaggingStore,
       recipientTaggingStore: this.recipientTaggingStore,
       senderAddressBookStore: this.senderAddressBookStore,

--- a/yarn-project/pxe/src/tagging/recipient_sync/load_private_logs_for_sender_recipient_pair.test.ts
+++ b/yarn-project/pxe/src/tagging/recipient_sync/load_private_logs_for_sender_recipient_pair.test.ts
@@ -5,12 +5,7 @@ import { openTmpStore } from '@aztec/kv-store/lmdb-v2';
 import { BlockHash } from '@aztec/stdlib/block';
 import type { AztecNode } from '@aztec/stdlib/interfaces/server';
 import { type ExtendedDirectionalAppTaggingSecret, SiloedTag } from '@aztec/stdlib/logs';
-import {
-  makeBlockHeader,
-  makeL2Tips,
-  randomExtendedDirectionalAppTaggingSecret,
-  randomTxScopedPrivateL2Log,
-} from '@aztec/stdlib/testing';
+import { randomExtendedDirectionalAppTaggingSecret, randomTxScopedPrivateL2Log } from '@aztec/stdlib/testing';
 
 import { type MockProxy, mock } from 'jest-mock-extended';
 
@@ -46,15 +41,11 @@ describe('loadPrivateLogsForSenderRecipientPair', () => {
 
   beforeEach(async () => {
     aztecNode.getPrivateLogsByTags.mockReset();
-    aztecNode.getL2Tips.mockReset();
-    aztecNode.getBlockHeader.mockReset();
     taggingStore = new RecipientTaggingStore(await openTmpStore('test'));
   });
 
   it('returns empty array when no logs found', async () => {
-    aztecNode.getL2Tips.mockResolvedValue(makeL2Tips(10));
-
-    aztecNode.getBlockHeader.mockResolvedValue(makeBlockHeader(0, { timestamp: currentTimestamp }));
+    const finalizedBlockNumber = BlockNumber(10);
 
     // no logs found for any tag
     aztecNode.getPrivateLogsByTags.mockImplementation((tags: SiloedTag[]) => {
@@ -67,6 +58,8 @@ describe('loadPrivateLogsForSenderRecipientPair', () => {
       taggingStore,
       FAR_FUTURE_BLOCK_NUMBER,
       MOCK_ANCHOR_BLOCK_HASH,
+      currentTimestamp,
+      finalizedBlockNumber,
       'test',
     );
 
@@ -76,21 +69,17 @@ describe('loadPrivateLogsForSenderRecipientPair', () => {
   });
 
   it('loads log and updates highest finalized index but not highest aged index', async () => {
-    const finalizedBlockNumber = 10;
+    const finalizedBlockNumber = BlockNumber(10);
 
     const logBlockTimestamp = currentTimestamp - 5000n; // not aged
     const logIndex = 5;
     const logTag = await computeSiloedTagForIndex(logIndex);
 
-    aztecNode.getL2Tips.mockResolvedValue(makeL2Tips(finalizedBlockNumber));
-
-    aztecNode.getBlockHeader.mockResolvedValue(makeBlockHeader(0, { timestamp: currentTimestamp }));
-
     // The log is finalized
     aztecNode.getPrivateLogsByTags.mockImplementation((tags: SiloedTag[]) => {
       return Promise.resolve(
         tags.map((t: SiloedTag) =>
-          t.equals(logTag) ? [makeLog(finalizedBlockNumber, logBlockTimestamp, logTag.value)] : [],
+          t.equals(logTag) ? [makeLog(Number(finalizedBlockNumber), logBlockTimestamp, logTag.value)] : [],
         ),
       );
     });
@@ -101,6 +90,8 @@ describe('loadPrivateLogsForSenderRecipientPair', () => {
       taggingStore,
       FAR_FUTURE_BLOCK_NUMBER,
       MOCK_ANCHOR_BLOCK_HASH,
+      currentTimestamp,
+      finalizedBlockNumber,
       'test',
     );
 
@@ -110,21 +101,17 @@ describe('loadPrivateLogsForSenderRecipientPair', () => {
   });
 
   it('loads log and updates both highest aged and highest finalized indexes', async () => {
-    const finalizedBlockNumber = 10;
+    const finalizedBlockNumber = BlockNumber(10);
 
     const logBlockTimestamp = currentTimestamp - BigInt(MAX_TX_LIFETIME) - 1000n; // aged
     const logIndex = 7;
     const logTag = await computeSiloedTagForIndex(logIndex);
 
-    aztecNode.getL2Tips.mockResolvedValue(makeL2Tips(finalizedBlockNumber));
-
-    aztecNode.getBlockHeader.mockResolvedValue(makeBlockHeader(0, { timestamp: currentTimestamp }));
-
     // The log is finalized
     aztecNode.getPrivateLogsByTags.mockImplementation((tags: SiloedTag[]) => {
       return Promise.resolve(
         tags.map((t: SiloedTag) =>
-          t.equals(logTag) ? [makeLog(finalizedBlockNumber, logBlockTimestamp, logTag.value)] : [],
+          t.equals(logTag) ? [makeLog(Number(finalizedBlockNumber), logBlockTimestamp, logTag.value)] : [],
         ),
       );
     });
@@ -135,6 +122,8 @@ describe('loadPrivateLogsForSenderRecipientPair', () => {
       taggingStore,
       FAR_FUTURE_BLOCK_NUMBER,
       MOCK_ANCHOR_BLOCK_HASH,
+      currentTimestamp,
+      finalizedBlockNumber,
       'test',
     );
 
@@ -144,7 +133,7 @@ describe('loadPrivateLogsForSenderRecipientPair', () => {
   });
 
   it('logs at boundaries are properly loaded, window and highest indexes advance as expected', async () => {
-    const finalizedBlockNumber = 10;
+    const finalizedBlockNumber = BlockNumber(10);
 
     const log1BlockTimestamp = currentTimestamp - BigInt(MAX_TX_LIFETIME) - 1000n; // Aged
     const log2BlockTimestamp = currentTimestamp - 5000n; // Not aged
@@ -159,10 +148,6 @@ describe('loadPrivateLogsForSenderRecipientPair', () => {
     await taggingStore.updateHighestAgedIndex(secret, highestAgedIndex, 'test');
     await taggingStore.updateHighestFinalizedIndex(secret, highestFinalizedIndex, 'test');
 
-    aztecNode.getL2Tips.mockResolvedValue(makeL2Tips(finalizedBlockNumber));
-
-    aztecNode.getBlockHeader.mockResolvedValue(makeBlockHeader(0, { timestamp: currentTimestamp }));
-
     // We record the number of queried tags to be able to verify that the window was moved forward correctly.
     let numQueriedTags = 0;
 
@@ -171,9 +156,9 @@ describe('loadPrivateLogsForSenderRecipientPair', () => {
       return Promise.resolve(
         tags.map((t: SiloedTag) => {
           if (t.equals(log1Tag)) {
-            return [makeLog(finalizedBlockNumber, log1BlockTimestamp, log1Tag.value)];
+            return [makeLog(Number(finalizedBlockNumber), log1BlockTimestamp, log1Tag.value)];
           } else if (t.equals(log2Tag)) {
-            return [makeLog(finalizedBlockNumber, log2BlockTimestamp, log2Tag.value)];
+            return [makeLog(Number(finalizedBlockNumber), log2BlockTimestamp, log2Tag.value)];
           }
           return [];
         }),
@@ -186,6 +171,8 @@ describe('loadPrivateLogsForSenderRecipientPair', () => {
       taggingStore,
       FAR_FUTURE_BLOCK_NUMBER,
       MOCK_ANCHOR_BLOCK_HASH,
+      currentTimestamp,
+      finalizedBlockNumber,
       'test',
     );
 

--- a/yarn-project/pxe/src/tagging/recipient_sync/load_private_logs_for_sender_recipient_pair.ts
+++ b/yarn-project/pxe/src/tagging/recipient_sync/load_private_logs_for_sender_recipient_pair.ts
@@ -21,6 +21,8 @@ export async function loadPrivateLogsForSenderRecipientPair(
   taggingStore: RecipientTaggingStore,
   anchorBlockNumber: BlockNumber,
   anchorBlockHash: BlockHash,
+  currentTimestamp: bigint,
+  finalizedBlockNumber: BlockNumber,
   jobId: string,
 ): Promise<TxScopedL2Log[]> {
   // # Explanation of how the algorithm works
@@ -60,20 +62,6 @@ export async function loadPrivateLogsForSenderRecipientPair(
   // When a sender chooses a tagging index, they will select an index that is at most `WINDOW_LEN` greater than
   // the highest finalized index. If that index was already used, they will throw an error. For this reason we
   // don't have to look further than `highestFinalizedIndex + WINDOW_LEN`.
-
-  let finalizedBlockNumber: number, currentTimestamp: bigint;
-  {
-    const [l2Tips, latestBlockHeader] = await Promise.all([aztecNode.getL2Tips(), aztecNode.getBlockHeader('latest')]);
-
-    if (!latestBlockHeader) {
-      throw new Error('Node failed to return latest block header when syncing logs');
-    }
-
-    [finalizedBlockNumber, currentTimestamp] = [
-      l2Tips.finalized.block.number,
-      latestBlockHeader.globalVariables.timestamp,
-    ];
-  }
 
   let start: number, end: number;
   {

--- a/yarn-project/stdlib/src/block/l2_block_stream/interfaces.ts
+++ b/yarn-project/stdlib/src/block/l2_block_stream/interfaces.ts
@@ -2,10 +2,14 @@ import type { PublishedCheckpoint } from '../../checkpoint/published_checkpoint.
 import type { L2Block } from '../l2_block.js';
 import type { CheckpointId, L2BlockId, L2Tips } from '../l2_block_source.js';
 
-/** Interface to the local view of the chain. Implemented by world-state and l2-tips-store. */
-export interface L2BlockStreamLocalDataProvider {
-  getL2BlockHash(number: number): Promise<string | undefined>;
+/** Provides the current chain tips. Implemented by world-state, l2-tips-store, and AztecNode. */
+export interface L2TipsProvider {
   getL2Tips(): Promise<L2Tips>;
+}
+
+/** Interface to the local view of the chain. Implemented by world-state and l2-tips-store. */
+export interface L2BlockStreamLocalDataProvider extends L2TipsProvider {
+  getL2BlockHash(number: number): Promise<string | undefined>;
 }
 
 /** Interface to a handler of events emitted. */

--- a/yarn-project/txe/src/oracle/txe_oracle_top_level_context.ts
+++ b/yarn-project/txe/src/oracle/txe_oracle_top_level_context.ts
@@ -406,6 +406,7 @@ export class TXEOracleTopLevelContext implements IMiscOracle, ITxeExecutionOracl
       senderForTags: from,
       simulator,
       messageContextService: this.stateMachine.messageContextService,
+      l2TipsStore: this.stateMachine.node,
     });
 
     // Note: This is a slight modification of simulator.run without any of the checks. Maybe we should modify simulator.run with a boolean value to skip checks.
@@ -764,6 +765,7 @@ export class TXEOracleTopLevelContext implements IMiscOracle, ITxeExecutionOracl
         privateEventStore: this.privateEventStore,
         messageContextService: this.stateMachine.messageContextService,
         contractSyncService: this.contractSyncService,
+        l2TipsStore: this.stateMachine.node,
         jobId,
         scopes,
       });

--- a/yarn-project/txe/src/txe_session.ts
+++ b/yarn-project/txe/src/txe_session.ts
@@ -375,6 +375,7 @@ export class TXESession implements TXESessionStateHandler {
       capsuleService: new CapsuleService(this.capsuleStore, await this.keyStore.getAccounts()),
       privateEventStore: this.privateEventStore,
       contractSyncService: this.stateMachine.contractSyncService,
+      l2TipsStore: this.stateMachine.node,
       jobId: this.currentJobId,
       scopes: await this.keyStore.getAccounts(),
       messageContextService: this.stateMachine.messageContextService,
@@ -448,6 +449,7 @@ export class TXESession implements TXESessionStateHandler {
       privateEventStore: this.privateEventStore,
       messageContextService: this.stateMachine.messageContextService,
       contractSyncService: this.contractSyncService,
+      l2TipsStore: this.stateMachine.node,
       jobId: this.currentJobId,
       scopes: await this.keyStore.getAccounts(),
     });
@@ -541,6 +543,7 @@ export class TXESession implements TXESessionStateHandler {
           privateEventStore: this.privateEventStore,
           messageContextService: this.stateMachine.messageContextService,
           contractSyncService: this.contractSyncService,
+          l2TipsStore: this.stateMachine.node,
           jobId: this.currentJobId,
           scopes,
         });


### PR DESCRIPTION
`fetchTaggedLogs` repeatedly called the node for current timestamp and finalization block number. `PXE` triggers a sync just before simulation, so this is extremely wasteful and causes extra round trips on every sync


