### PR TITLE
chore(avm): skip extend_to for zero selectors in AVM sumcheck lazy extension

### DIFF
--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/flavor.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/flavor.cpp
@@ -121,9 +121,17 @@ const bb::Univariate<AvmFlavor::FF, AvmFlavor::MAX_PARTIAL_RELATION_LENGTH>& Avm
         }
         auto& extended_ptr = mutable_entities[static_cast<size_t>(c)];
         if (extended_ptr.get() == nullptr) {
+            const auto& val0 = multivariate[current_edge];
+            const auto& val1 = multivariate[current_edge + 1];
+            // Fast path: if both edge values are zero, return a static zero univariate
+            // without allocating or computing extend_to. This avoids heap allocation and
+            // the extend_to computation for zero selectors on sparse AVM traces.
+            if (val0.is_zero() && val1.is_zero()) {
+                static const auto zero_univariate = bb::Univariate<FF, MAX_PARTIAL_RELATION_LENGTH>::zero();
+                return zero_univariate;
+            }
             extended_ptr = std::make_unique<bb::Univariate<FF, MAX_PARTIAL_RELATION_LENGTH>>(
-                bb::Univariate<FF, 2>({ multivariate[current_edge], multivariate[current_edge + 1] })
-                    .template extend_to<MAX_PARTIAL_RELATION_LENGTH>());
+                bb::Univariate<FF, 2>({ val0, val1 }).template extend_to<MAX_PARTIAL_RELATION_LENGTH>());
         }
         return *extended_ptr;
     }

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/flavor.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/flavor.cpp
@@ -128,7 +128,8 @@ const bb::Univariate<AvmFlavor::FF, AvmFlavor::MAX_PARTIAL_RELATION_LENGTH>& Avm
             // the extend_to computation for zero selectors on sparse AVM traces.
             if (val0.is_zero() && val1.is_zero()) {
                 static const auto zero_univariate = bb::Univariate<FF, MAX_PARTIAL_RELATION_LENGTH>::zero();
-                return zero_univariate;
+                return zero_univariate; // Weirdly, defining a single static zero_univariate above the "if" block
+                                        // leads to a performance regression and obliterates the performance gain.
             }
             extended_ptr = std::make_unique<bb::Univariate<FF, MAX_PARTIAL_RELATION_LENGTH>>(
                 bb::Univariate<FF, 2>({ val0, val1 }).template extend_to<MAX_PARTIAL_RELATION_LENGTH>());


### PR DESCRIPTION
In LazilyExtendedProverUnivariates::get(), check if both polynomial edge values are zero before allocating and computing extend_to. On sparse AVM traces, a lot of hit zero selectors are present and so this avoids the heap allocation and extend_to computation for the vast majority of get() calls during sumcheck.

Measured ~15% improvement on compute_univariate (median 2500ms vs 2947ms baseline over 3 runs each on avm_bulk test with 32 threads).

I performed several measurements later on mainframe and 32 threads on the full sumcheck. Though there were some string variations, we consistently observed a gain of at least 8% on sumcheck for bulk_test.

As the change is very minimal I think it is worth it.