### PR TITLE
feat: add extra getters

### DIFF
--- a/l1-contracts/src/core/Rollup.sol
+++ b/l1-contracts/src/core/Rollup.sol
@@ -550,6 +550,18 @@ contract Rollup is IStaking, IValidatorSelection, IRollup, RollupCore {
     return STFLib.getStorage().config.feeAssetPortal;
   }
 
+  function getVkTreeRoot() external view override(IRollup) returns (bytes32) {
+    return STFLib.getStorage().config.vkTreeRoot;
+  }
+
+  function getProtocolContractsHash() external view override(IRollup) returns (bytes32) {
+    return STFLib.getStorage().config.protocolContractsHash;
+  }
+
+  function getEpochProofVerifier() external view override(IRollup) returns (IVerifier) {
+    return STFLib.getStorage().config.epochProofVerifier;
+  }
+
   function getRewardDistributor() external view override(IRollup) returns (IRewardDistributor) {
     return RewardExtLib.getRewardDistributor();
   }

--- a/l1-contracts/src/core/interfaces/IRollup.sol
+++ b/l1-contracts/src/core/interfaces/IRollup.sol
@@ -232,6 +232,10 @@ interface IRollup is IRollupCore, IHaveVersion {
   function getInbox() external view returns (IInbox);
   function getOutbox() external view returns (IOutbox);
 
+  function getVkTreeRoot() external view returns (bytes32);
+  function getProtocolContractsHash() external view returns (bytes32);
+  function getEpochProofVerifier() external view returns (IVerifier);
+
   function getRewardConfig() external view returns (RewardConfig memory);
   function getCheckpointReward() external view returns (uint256);
 }

--- a/l1-contracts/test/RollupGetters.t.sol
+++ b/l1-contracts/test/RollupGetters.t.sol
@@ -7,6 +7,7 @@ pragma solidity >=0.8.27;
 
 import {IRollupCore, CheckpointLog} from "@aztec/core/interfaces/IRollup.sol";
 import {IStakingCore} from "@aztec/core/interfaces/IStaking.sol";
+import {IVerifier} from "@aztec/core/interfaces/IVerifier.sol";
 import {TestConstants} from "./harnesses/TestConstants.sol";
 import {Timestamp, Slot, Epoch} from "@aztec/shared/libraries/TimeMath.sol";
 import {RewardConfig, Bps} from "@aztec/core/libraries/rollup/RewardLib.sol";
@@ -287,6 +288,21 @@ contract RollupShouldBeGetters is ValidatorSelectionTestBase {
     vm.record();
 
     rollup.canProposeAtTime(t, log.archive, proposer);
+
+    (, bytes32[] memory writes) = vm.accesses(address(rollup));
+    assertEq(writes.length, 0, "No writes should be done");
+  }
+
+  function test_getGenesisConfig() external setup(1, 1) {
+    vm.record();
+
+    bytes32 vkTreeRoot = rollup.getVkTreeRoot();
+    bytes32 protocolContractsHash = rollup.getProtocolContractsHash();
+    IVerifier epochProofVerifier = rollup.getEpochProofVerifier();
+
+    assertEq(vkTreeRoot, TestConstants.GENESIS_VK_TREE_ROOT, "invalid vkTreeRoot");
+    assertEq(protocolContractsHash, TestConstants.GENESIS_PROTOCOL_CONTRACTS_HASH, "invalid protocolContractsHash");
+    assertTrue(address(epochProofVerifier) != address(0), "epochProofVerifier not set");
 
     (, bytes32[] memory writes) = vm.accesses(address(rollup));
     assertEq(writes.length, 0, "No writes should be done");


### PR DESCRIPTION
Adds external getters for the last three `RollupConfig` fields that were previously unreachable from outside the contract:                                                                              
- `getVkTreeRoot()`                                                                                                                                                          
- `getProtocolContractsHash()`
- `getEpochProofVerifier()`
                                                                                                                                                                                                             
These were omitted originally because the rollup was tight on bytecode. Recent size reductions (TMNT-509, TMNT-513, TMNT-514) freed enough room to add them directly in `Rollup.sol` without needing ExtLib delegation.