### PR TITLE
fix: gate ci-external label on AztecProtocol/watchers membership

### DIFF
--- a/.github/workflows/ci3-external.yml
+++ b/.github/workflows/ci3-external.yml
@@ -39,6 +39,31 @@ jobs:
         if: github.event.pull_request.draft
         run: echo "CI is not run on drafts." && exit 1
 
+      # Gate 'ci-external' on the labeller being a member of AztecProtocol/watchers.
+      - name: Verify ci-external Labeller Authorization
+        if: contains(github.event.pull_request.labels.*.name, 'ci-external')
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
+        run: |
+          set -o pipefail
+          # Note: pipe to jq with -s add to flatten paginated arrays; gh's own --jq runs per-page.
+          labeller=$(gh api --paginate "/repos/$REPO/issues/$PR_NUMBER/events" \
+            | jq -r -s 'add | [.[] | select(.event == "labeled" and .label.name == "ci-external")] | last | .actor.login // empty')
+          if [ -z "$labeller" ] || [ "$labeller" = "null" ]; then
+            echo "Error: could not determine who applied the 'ci-external' label. Stripping it."
+            gh pr edit "$PR_NUMBER" --remove-label "ci-external" || true
+            exit 1
+          fi
+          state=$(gh api "/orgs/AztecProtocol/teams/watchers/memberships/$labeller" --jq '.state' 2>/dev/null || true)
+          if [ "$state" != "active" ]; then
+            echo "Error: labeller is not an active member of AztecProtocol/watchers. Stripping 'ci-external' label."
+            gh pr edit "$PR_NUMBER" --remove-label "ci-external"
+            exit 1
+          fi
+          echo "Labeller is authorized."
+
       - name: External Contributor Checks
         env:
           PR_BASE_REF: ${{ github.event.pull_request.base.ref }}


### PR DESCRIPTION
## Summary

Adds a labeller-authorization gate to `.github/workflows/ci3-external.yml`. External CI can now only be triggered by members of the `AztecProtocol/watchers` team.

- The step resolves the most recent labeller of `ci-external` from the issue events API (not `github.event.sender`), so cancel-then-push can't launder an unauthorized label.
- If the labeller isn't an active member of `watchers`, the label is stripped via `gh pr edit --remove-label` and the run exits non-zero.
- The check fires on every trigger where the label is present (not just the `labeled` event) to close the cancellation bypass.
- Uses `AZTEC_BOT_GITHUB_TOKEN` for the `read:org` scope needed to query team membership.
- `ci-external-once` is intentionally left ungated for now.
- Labeller username is kept out of the logs.

## Threat model closed

1. Unauthorized user (label-write access but not in `watchers`) applies `ci-external` → gate strips + fails.
2. Unauthorized user labels, cancels the workflow before the strip step runs, then pushes to trigger `synchronize` → gate re-runs on `synchronize`, re-resolves the original labeller from issue events, strips + fails.

## Rollout note

Open external PRs currently labelled by someone **not** in `AztecProtocol/watchers` will fail their next CI run and have the `ci-external` label stripped. A maintainer in the team can re-apply to resume CI.

## Test plan

- [ ] Label a fork PR as `ci-external` from an authorized account — CI runs
- [ ] Label a fork PR as `ci-external` from an unauthorized account — label is stripped, run fails
- [ ] Label from unauthorized account, cancel run, push new commit — next run still strips + fails (cancel bypass closed)
- [ ] `ci-external-once` still functions as before (ungated)