### PR TITLE
fix(pxe): cap event filter toBlock to last synced block

### DIFF
--- a/yarn-project/pxe/src/events/private_event_filter_validator.test.ts
+++ b/yarn-project/pxe/src/events/private_event_filter_validator.test.ts
@@ -93,6 +93,38 @@ describe('PrivateEventFilterValidator', () => {
     ).toThrow(/toBlock must be strictly greater than fromBlock/);
   });
 
+  it('caps toBlock to last synced block + 1 when it exceeds the synced range', () => {
+    const dataProviderFilter = validator.validate({
+      contractAddress,
+      scopes: [scope],
+      fromBlock: INITIAL_L2_BLOCK_NUM,
+      toBlock: BlockNumber(lastKnownBlockNumber + 100),
+    });
+    expect(dataProviderFilter).toEqual({
+      contractAddress,
+      scopes: [scope],
+      fromBlock: INITIAL_L2_BLOCK_NUM,
+      toBlock: BlockNumber(lastKnownBlockNumber + 1),
+    });
+  });
+
+  it('leaves filter unchanged when fromBlock is past the synced range', () => {
+    const fromBlock = BlockNumber(lastKnownBlockNumber + 5);
+    const toBlock = BlockNumber(lastKnownBlockNumber + 10);
+    const dataProviderFilter = validator.validate({
+      contractAddress,
+      scopes: [scope],
+      fromBlock,
+      toBlock,
+    });
+    expect(dataProviderFilter).toEqual({
+      contractAddress,
+      scopes: [scope],
+      fromBlock,
+      toBlock,
+    });
+  });
+
   it('preserves txHash', () => {
     let dataProviderFilter = validator.validate({
       contractAddress,

--- a/yarn-project/pxe/src/events/private_event_filter_validator.ts
+++ b/yarn-project/pxe/src/events/private_event_filter_validator.ts
@@ -1,11 +1,14 @@
 import type { PrivateEventFilter } from '@aztec/aztec.js/wallet';
 import { INITIAL_L2_BLOCK_NUM } from '@aztec/constants';
 import { BlockNumber } from '@aztec/foundation/branded-types';
+import { createLogger } from '@aztec/foundation/log';
 
 import type { PrivateEventStoreFilter } from '../storage/private_event_store/private_event_store.js';
 
 export class PrivateEventFilterValidator {
-  constructor(private lastBlock: BlockNumber) {}
+  private readonly log = createLogger('pxe:private_event_filter_validator');
+
+  constructor(private readonly lastBlock: BlockNumber) {}
 
   validate(filter: PrivateEventFilter): PrivateEventStoreFilter {
     let { fromBlock, toBlock } = filter;
@@ -33,6 +36,23 @@ export class PrivateEventFilterValidator {
 
     if (fromBlock >= toBlock) {
       throw new Error('toBlock must be strictly greater than fromBlock');
+    }
+
+    // Cap the requested range to the synced block range. Without this, callers that pass a large
+    // toBlock (e.g. Number.MAX_SAFE_INTEGER as a "give me everything" idiom) would silently receive
+    // only the events that happen to be synced and believe they have complete coverage.
+    // We warn + cap rather than throw so callers don't need to query the last synced block before
+    // every request (which would also be unreliable, as the block can advance between the two calls).
+    const syncedUpperBound = BlockNumber(this.lastBlock + 1);
+    if (fromBlock >= syncedUpperBound) {
+      this.log.warn(
+        `Requested fromBlock ${fromBlock} is past last synced block ${this.lastBlock}; no events will be returned until PXE syncs further.`,
+      );
+    } else if (toBlock > syncedUpperBound) {
+      this.log.warn(
+        `Requested toBlock ${toBlock} exceeds last synced block ${this.lastBlock}; capping to ${syncedUpperBound}. Retry once PXE is further synced for complete coverage.`,
+      );
+      toBlock = syncedUpperBound;
     }
 
     return {


### PR DESCRIPTION
## Problem

`PrivateEventFilterValidator` defaults `toBlock` to `lastBlock + 1` when omitted, but when explicitly provided it was not capped against the synced range. A caller passing `toBlock = Number.MAX_SAFE_INTEGER` (a common "give me everything" idiom) would silently receive only the events in the synced portion of the chain and believe they had complete coverage up to the requested block.

This was surfaced by an AI-assisted audit pass.

## Fix

Warn and cap `toBlock` to `lastBlock + 1` when it exceeds the synced range. If `fromBlock` is already past the synced tip, leave the filter unchanged and emit a warning — the store returns an empty result, matching reality.

Chose warn+cap over throw so callers don't need to query the last synced block before every request (which would also be unreliable since the block can advance between the two calls).

Fixes https://github.com/AztecProtocol/aztec-claude/issues/322