### PR TITLE
fix(pxe): round tx expiration timestamp to reduce precision

### DIFF
--- a/yarn-project/pxe/src/private_kernel/private_kernel_execution_prover.test.ts
+++ b/yarn-project/pxe/src/private_kernel/private_kernel_execution_prover.test.ts
@@ -292,6 +292,25 @@ describe('Private Kernel Sequencer', () => {
     expect(proofCreator.simulateTail).toHaveBeenCalledTimes(1);
   });
 
+  it('rounds the expiration timestamp down before passing it to the tail circuit', async () => {
+    // Raw offset 7265s (1h + 1805s) should round down to the 1-hour bucket.
+    const rawOffset = 7265n;
+    const expectedRoundedOffset = 7200n;
+
+    const customOutput = simulateProofOutput();
+    customOutput.publicInputs.expirationTimestamp = blockTimestamp + rawOffset;
+    proofCreator.simulateInit.mockResolvedValue(customOutput);
+    proofCreator.simulateReset.mockResolvedValue(customOutput);
+
+    dependencies = { a: [] };
+    const executionResult = createExecutionResult('a');
+    await prove(executionResult);
+
+    expect(proofCreator.simulateTail).toHaveBeenCalledTimes(1);
+    const tailInputs = proofCreator.simulateTail.mock.calls[0][0];
+    expect(tailInputs.expirationTimestampUpperBound).toBe(blockTimestamp + expectedRoundedOffset);
+  });
+
   it('runs two consecutive inner resets when first reset output still overflows', async () => {
     // Set up: init output has MAX note hash read requests and key validation requests.
     proofCreator.simulateInit.mockResolvedValue(

--- a/yarn-project/pxe/src/private_kernel/private_kernel_execution_prover.ts
+++ b/yarn-project/pxe/src/private_kernel/private_kernel_execution_prover.ts
@@ -33,6 +33,7 @@ import {
 } from '@aztec/stdlib/tx';
 import { VerificationKeyAsFields, VerificationKeyData, VkData } from '@aztec/stdlib/vks';
 
+import { computeTxExpirationTimestamp } from './hints/compute_tx_expiration_timestamp.js';
 import { PrivateKernelResetPrivateInputsBuilder } from './hints/private_kernel_reset_private_inputs_builder.js';
 import type { PrivateKernelOracle } from './private_kernel_oracle.js';
 
@@ -267,15 +268,9 @@ export class PrivateKernelExecutionProver {
     // TODO: Enable padding once we better understand the final amounts to pad to.
     const paddedSideEffectAmounts = PaddedSideEffectAmounts.empty();
 
-    // Use the aggregated expirationTimestamp set throughout the tx execution.
-    // TODO: Call `computeTxExpirationTimestamp` to round the value down and reduce precision, improving privacy.
-    const expirationTimestampUpperBound = previousKernelData.publicInputs.expirationTimestamp;
-    const anchorBlockTimestamp = previousKernelData.publicInputs.constants.anchorBlockHeader.globalVariables.timestamp;
-    if (expirationTimestampUpperBound <= anchorBlockTimestamp) {
-      throw new Error(
-        `Include-by timestamp must be greater than the anchor block timestamp. Anchor block timestamp: ${anchorBlockTimestamp}. Include-by timestamp: ${expirationTimestampUpperBound}.`,
-      );
-    }
+    // Round the aggregated expirationTimestamp down to reduce precision and avoid leaking which private
+    // functions were called via their exact expiration offsets.
+    const expirationTimestampUpperBound = computeTxExpirationTimestamp(previousKernelData.publicInputs);
 
     const privateInputs = new PrivateKernelTailCircuitPrivateInputs(
       previousKernelData,


### PR DESCRIPTION
We are now using `computeTxExpirationTimestamp` to round the expiration timestamp and reduce privacy leaks

Reported by AI

Fixes https://github.com/AztecProtocol/aztec-claude/issues/402