### PR TITLE
chore: add lib method for root verification plus tests of root merge

### DIFF
--- a/barretenberg/acir_tests/bootstrap.sh
+++ b/barretenberg/acir_tests/bootstrap.sh
@@ -86,7 +86,7 @@ function regenerate_recursive_inputs {
   mv ./target/assert_statement.json ./target/program.json
   mv ./target/assert_statement.gz ./target/witness.gz
   cd ../..
-  parallel 'run_proof_generation {}' ::: "double_verify_honk_proof" "verify_honk_proof" "verify_honk_zk_proof" "double_verify_honk_zk_proof" "verify_rollup_honk_proof"
+  parallel 'run_proof_generation {}' ::: "double_verify_honk_proof" "verify_honk_proof" "verify_honk_zk_proof" "double_verify_honk_zk_proof" "verify_rollup_honk_proof" "double_verify_root_rollup_honk_proof"
 }
 
 export -f regenerate_recursive_inputs run_proof_generation generate_toml
@@ -140,7 +140,7 @@ function test_cmds {
 
   # non_recursive_tests include all of the non recursive test programs
   local non_recursive_tests=$(find ./acir_tests -maxdepth 1 -mindepth 1 -type d | \
-    grep -vE 'verify_honk_proof|verify_honk_zk_proof|verify_rollup_honk_proof')
+    grep -vE 'verify_honk_proof|verify_honk_zk_proof|verify_rollup_honk_proof|double_verify_root_rollup_honk_proof')
   local scripts=$(realpath --relative-to=$root scripts)
 
   local sol_prefix="$tests_hash:ISOLATE=1"
@@ -193,6 +193,9 @@ function test_cmds {
   #echo "$tests_hash $scripts/bb_prove.sh assert_statement --oracle_hash starknet"
   # Test rollup verification (rollup uses --ipa_accumulation)
   echo "$tests_hash $scripts/bb_prove.sh verify_rollup_honk_proof --ipa_accumulation"
+  # Test root-rollup verification: outer circuit verifies two RollupHonk proofs and closes the IPA
+  # accumulator in-circuit, so it is proved as a standard (non-rollup) UltraHonk (no --ipa_accumulation).
+  echo "$tests_hash $scripts/bb_prove.sh double_verify_root_rollup_honk_proof"
   # Run the assert_statement test with ZK disabled.
   echo "$tests_hash $scripts/bb_prove.sh assert_statement --disable_zk"
 

--- a/barretenberg/acir_tests/internal_test_programs/double_verify_root_rollup_honk_proof/Nargo.toml
+++ b/barretenberg/acir_tests/internal_test_programs/double_verify_root_rollup_honk_proof/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "double_verify_root_rollup_honk_proof"
+type = "bin"
+authors = [""]
+
+[dependencies]
+bb_proof_verification = { path = "../../../noir/bb_proof_verification" }

--- a/barretenberg/acir_tests/internal_test_programs/double_verify_root_rollup_honk_proof/src/main.nr
+++ b/barretenberg/acir_tests/internal_test_programs/double_verify_root_rollup_honk_proof/src/main.nr
@@ -1,0 +1,22 @@
+// This circuit aggregates two RollupHonk proofs from `assert_statement` at the root of a rollup
+// aggregation tree: each inner verification defers its IPA claim, the two claims are accumulated
+// into one, and the accumulated claim is then fully verified in-circuit. The outer circuit is
+// therefore proved as a standard (non-rollup) UltraHonk - its proof carries no deferred IPA
+// material and is verifiable by `verify_honk_proof_non_zk` / `verify_honk_proof`.
+use bb_proof_verification::{RollupHonkProof, RollupHonkVerificationKey, verify_root_rolluphonk_proof};
+
+fn main(
+    verification_key: RollupHonkVerificationKey,
+    // This is the proof without public inputs attached.
+    // This means: the size of this does not change with the number of public inputs.
+    proof: RollupHonkProof,
+    public_inputs: pub [Field; 1],
+    // This is currently not public. It is fine given that the vk is a part of the circuit definition.
+    // I believe we want to eventually make it public too though.
+    key_hash: Field,
+    // The second proof, currently set to be identical.
+    proof_b: RollupHonkProof,
+) {
+    verify_root_rolluphonk_proof(verification_key, proof, public_inputs, key_hash);
+    verify_root_rolluphonk_proof(verification_key, proof_b, public_inputs, key_hash);
+}

--- a/barretenberg/noir/bb_proof_verification/src/lib.nr
+++ b/barretenberg/noir/bb_proof_verification/src/lib.nr
@@ -8,6 +8,7 @@ pub type UltraHonkVerificationKey = [Field; ULTRA_VK_LENGTH_IN_FIELDS];
 
 // Constants for Rollup-UltraHonk recursive verifier inputs (N.B. this is equivalent to UH plus IPA claim and proof)
 pub global PROOF_TYPE_ROLLUP_HONK: u32 = 4; // identifier for rollup-UltraHonk verfier
+pub global PROOF_TYPE_ROOT_ROLLUP_HONK: u32 = 5; // identifier for root-rollup-UltraHonk verfier (closes the IPA accumulator)
 pub global IPA_CLAIM_SIZE: u32 = 6;
 pub global IPA_PROOF_LENGTH: u32 = 64;
 pub global RECURSIVE_ROLLUP_HONK_PROOF_LENGTH: u32 =
@@ -59,11 +60,36 @@ pub fn verify_rolluphonk_proof<let N: u32>(
     );
 }
 
+// Verifies a non-zero-knowledge Rollup UltraHonk proof and closes the IPA accumulator in-circuit.
+//
+// Use this at the root of a rollup aggregation tree. The inner proof has the same RollupHonk shape
+// as `verify_rolluphonk_proof`, but instead of propagating an accumulated IPA claim out as a public
+// input, this variant performs a full native IPA verification inside the circuit. The outer circuit
+// should therefore be proved as a standard (non-rollup) UltraHonk circuit, producing a proof
+// suitable for verification by `verify_honk_proof` / `verify_honk_proof_non_zk`.
+//
+// When two RollupHonk inputs are verified this way in one circuit, their two IPA claims are first
+// accumulated into one, then the accumulated claim is fully verified.
+pub fn verify_root_rolluphonk_proof<let N: u32>(
+    verification_key: RollupHonkVerificationKey,
+    proof: RollupHonkProof,
+    public_inputs: [Field; N],
+    key_hash: Field, // Hash of the verification key
+) {
+    std::verify_proof_with_type(
+        verification_key,
+        proof,
+        public_inputs,
+        key_hash,
+        PROOF_TYPE_ROOT_ROLLUP_HONK,
+    );
+}
+
 // Verifies a zero-knowledge UltraHonk proof.
 //
 // This verifier is for UltraHonk proofs constructed with zero-knowledge, which hide the witness
 // values from the verifier.
-// Note: We intentionally choose the generic name "verify_honk_proof" for this function, as we 
+// Note: We intentionally choose the generic name "verify_honk_proof" for this function, as we
 // want ZK to be the default unless the user explicitly opts out.
 pub fn verify_honk_proof<let N: u32>(
     verification_key: UltraHonkVerificationKey,


### PR DESCRIPTION
Add method `verify_root_rolluphonk_proof` to bb hosted noir verification lib to facilitate writing of Aztec-style root rollup circuit. Adds test that uses this method to mimmic the structure of that circuit.