### PR TITLE
fix(pxe): throw clear error for invalid comparator in pick_notes

### DIFF
--- a/yarn-project/pxe/src/contract_function_simulator/pick_notes.test.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/pick_notes.test.ts
@@ -361,4 +361,19 @@ describe('getNotes', () => {
       [7n, 6n, 3n],
     ]);
   });
+
+  it('throws a clear error for an invalid comparator value', () => {
+    const notes = [createNote([1n])];
+    const options = {
+      selects: [
+        {
+          selector: { index: 0, offset: 0, length: 32 },
+          value: new Fr(1n),
+          comparator: 99 as Comparator,
+        },
+      ],
+    };
+
+    expect(() => pickNotes(notes, options)).toThrow('Invalid comparator value: 99');
+  });
 });

--- a/yarn-project/pxe/src/contract_function_simulator/pick_notes.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/pick_notes.ts
@@ -110,7 +110,11 @@ const selectNotes = <T extends ContainsNote>(noteDatas: T[], selects: Select[]):
         [Comparator.GTE]: () => !noteValueFr.lt(value),
       };
 
-      return comparatorSelector[comparator]();
+      const fn = comparatorSelector[comparator];
+      if (!fn) {
+        throw new Error(`Invalid comparator value: ${comparator}`);
+      }
+      return fn();
     }),
   );
 


### PR DESCRIPTION
## Summary

- `pick_notes` looks up a comparator handler via `comparatorSelector[comparator]`; an out-of-range value would invoke `undefined()` and surface a cryptic `TypeError`.
- Check the lookup and throw `Invalid comparator value: <n>` instead, so a malformed comparator from a contract call produces an actionable error.
- Adds a unit test covering the invalid-comparator path.

Fixes AztecProtocol/aztec-claude#161