### PR TITLE
fix(sequencer): re-check parent checkpoint validity before pipelined L1 submission

### DIFF
--- a/yarn-project/archiver/src/index.ts
+++ b/yarn-project/archiver/src/index.ts
@@ -11,3 +11,4 @@ export { ContractInstanceStore } from './store/contract_instance_store.js';
 export { L2TipsCache } from './store/l2_tips_cache.js';
 
 export { retrieveCheckpointsFromRollup, retrieveL2ProofVerifiedEvents } from './l1/data_retrieval.js';
+export { CalldataRetriever } from './l1/calldata_retriever.js';

--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_invalidate_block.parallel.test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_invalidate_block.parallel.test.ts
@@ -1,3 +1,4 @@
+import { CalldataRetriever } from '@aztec/archiver';
 import type { AztecNodeService } from '@aztec/aztec-node';
 import type { AztecAddress } from '@aztec/aztec.js/addresses';
 import { NO_WAIT } from '@aztec/aztec.js/contracts';
@@ -6,22 +7,23 @@ import type { Logger } from '@aztec/aztec.js/log';
 import { waitForTx } from '@aztec/aztec.js/node';
 import { RollupContract } from '@aztec/ethereum/contracts';
 import type { Operator } from '@aztec/ethereum/deploy-aztec-l1-contracts';
-import type { ExtendedViemWalletClient } from '@aztec/ethereum/types';
+import type { ExtendedViemWalletClient, ViemPublicClient, ViemPublicDebugClient } from '@aztec/ethereum/types';
 import { asyncMap } from '@aztec/foundation/async-map';
 import { CheckpointNumber, SlotNumber } from '@aztec/foundation/branded-types';
 import { times, timesAsync } from '@aztec/foundation/collection';
 import { SecretValue } from '@aztec/foundation/config';
 import { EthAddress } from '@aztec/foundation/eth-address';
+import { createLogger } from '@aztec/foundation/log';
 import { promiseWithResolvers } from '@aztec/foundation/promise';
 import { retryUntil } from '@aztec/foundation/retry';
 import { bufferToHex } from '@aztec/foundation/string';
 import { timeoutPromise } from '@aztec/foundation/timer';
-import { RollupAbi } from '@aztec/l1-artifacts';
 import type { TestContract } from '@aztec/noir-test-contracts.js/Test';
 import { OffenseType } from '@aztec/slasher';
-import { getTimestampForSlot } from '@aztec/stdlib/epoch-helpers';
+import { computeQuorum, getTimestampForSlot } from '@aztec/stdlib/epoch-helpers';
 
 import { jest } from '@jest/globals';
+import type { Log } from 'viem';
 import { privateKeyToAccount } from 'viem/accounts';
 
 import { getAnvilPort } from '../fixtures/fixtures.js';
@@ -30,8 +32,9 @@ import { EpochsTestContext } from './epochs_test.js';
 
 jest.setTimeout(1000 * 60 * 10);
 
-const NODE_COUNT = 5;
-const VALIDATOR_COUNT = 5;
+// Set up 6 nodes with 1 validator each, so that we can have up to 2 malicious ones and still achieve quorum
+const NODE_COUNT = 6;
+const VALIDATOR_COUNT = 6;
 
 const BASE_ANVIL_PORT = getAnvilPort();
 
@@ -70,6 +73,7 @@ describe('e2e_epochs/epochs_invalidate_block', () => {
       aztecProofSubmissionEpochs: 1024,
       startProverNode: false,
       aztecTargetCommitteeSize: VALIDATOR_COUNT,
+      secondsBeforeInvalidatingBlockAsCommitteeMember: Number.MAX_SAFE_INTEGER,
       archiverPollingIntervalMS: 200,
       anvilAccounts: 20,
       anvilPort: BASE_ANVIL_PORT + ++anvilPortOffset,
@@ -110,6 +114,54 @@ describe('e2e_epochs/epochs_invalidate_block', () => {
     await test.teardown();
   });
 
+  function awaitCheckpointInvalidationEvent(
+    waitSlots = 8,
+  ): Promise<{ checkpointNumber: CheckpointNumber; event: Log }> {
+    const promise = promiseWithResolvers<{ checkpointNumber: CheckpointNumber; event: Log }>();
+    const unwatch = rollupContract.listenToCheckpointInvalidated(({ checkpointNumber, event }) => {
+      unwatch();
+      logger.warn(`Checkpoint ${checkpointNumber} has been invalidated`);
+      promise.resolve({ checkpointNumber, event });
+    });
+    return Promise.race([
+      promise.promise,
+      timeoutPromise(test.L2_SLOT_DURATION_IN_S * waitSlots * 1000, 'Waiting for CheckpointInvalidated event'),
+    ]);
+  }
+
+  /**
+   * Asserts that the given checkpoint, as posted on L1, has fewer valid attestations than quorum.
+   * Useful to catch config-timing races where malicious config does not take effect before the proposer
+   * starts its work, leading to the test assuming a checkpoint is bad when it actually landed valid.
+   */
+  async function assertCheckpointInsufficientAttestations(checkpointNumber: CheckpointNumber): Promise<void> {
+    const proposedEvents = await rollupContract.getCheckpointProposedEvents(1n, await l1Client.getBlockNumber());
+    const event = proposedEvents.find(e => e.args.checkpointNumber === checkpointNumber);
+    expect(event).toBeDefined();
+
+    const calldataRetriever = new CalldataRetriever(
+      l1Client as unknown as ViemPublicClient,
+      l1Client as unknown as ViemPublicDebugClient,
+      VALIDATOR_COUNT,
+      undefined,
+      createLogger('e2e:epochs_invalidate_block:calldata'),
+      EthAddress.fromString(rollupContract.address),
+    );
+    const { attestations } = await calldataRetriever.getCheckpointFromRollupTx(
+      event!.l1TransactionHash,
+      event!.args.versionedBlobHashes,
+      checkpointNumber,
+      {
+        attestationsHash: event!.args.attestationsHash.toString(),
+        payloadDigest: event!.args.payloadDigest.toString(),
+      },
+    );
+    const validCount = attestations.filter(a => !a.signature.isEmpty()).length;
+    const quorum = computeQuorum(VALIDATOR_COUNT);
+    logger.warn(`Checkpoint ${checkpointNumber} has ${validCount}/${VALIDATOR_COUNT} attestations (quorum=${quorum})`);
+    expect(validCount).toBeLessThan(quorum);
+  }
+
   /**
    * Configures all sequencers with an attack config, enables the attack for a single checkpoint,
    * disables it after the first checkpoint is mined (also stopping block production), and waits
@@ -137,28 +189,10 @@ describe('e2e_epochs/epochs_invalidate_block', () => {
     await Promise.all(sequencers.map(s => s.start()));
 
     // Wait for the CheckpointInvalidated event
-    const checkpointInvalidatedFilter = await l1Client.createContractEventFilter({
-      address: rollupContract.address,
-      abi: RollupAbi,
-      eventName: 'CheckpointInvalidated',
-      fromBlock: 1n,
-      toBlock: 'latest',
-    });
-
-    const checkpointInvalidatedEvents = await retryUntil(
-      async () => {
-        const events = await l1Client.getFilterLogs({ filter: checkpointInvalidatedFilter });
-        return events.length > 0 ? events : undefined;
-      },
-      'CheckpointInvalidated event',
-      test.L2_SLOT_DURATION_IN_S * 5,
-      0.1,
-    );
+    const { checkpointNumber: invalidatedCheckpointNumber } = await awaitCheckpointInvalidationEvent();
 
     // Verify the checkpoint was invalidated and the chain rolled back
-    const [event] = checkpointInvalidatedEvents;
-    logger.warn(`CheckpointInvalidated event emitted`, { event });
-    expect(event.args.checkpointNumber).toBeGreaterThan(initialCheckpointNumber);
+    expect(invalidatedCheckpointNumber).toBeGreaterThan(initialCheckpointNumber);
     expect(await test.rollup.getCheckpointNumber()).toEqual(initialCheckpointNumber);
 
     logger.warn(`Test succeeded '${expect.getState().currentTestName}'`);
@@ -224,6 +258,9 @@ describe('e2e_epochs/epochs_invalidate_block', () => {
     logger.warn(`Test succeeded '${expect.getState().currentTestName}'`);
   }
 
+  // To be able to post its own checkpoint under pipelining, there should be no "proposed" checkpoint in flight,
+  // otherwise we consider it's the proposed checkpoint that will invalidate the previous one. If it's the
+  // proposed checkpoint the one that ends up being invalid, we need to discard our work, and cannot post our own.
   it('proposer invalidates previous checkpoint with multiple blocks while posting its own', async () => {
     const sequencers = nodes.map(node => node.getSequencer()!);
     const [initialCheckpointNumber, initialBlockNumber] = await nodes[0]
@@ -234,18 +271,25 @@ describe('e2e_epochs/epochs_invalidate_block', () => {
     // Also set minBlocksForCheckpoint to ensure multi-block checkpoints
     logger.warn('Configuring all sequencers to skip attestation collection');
     sequencers.forEach(sequencer => {
-      sequencer.updateConfig({ skipCollectingAttestations: true, minBlocksForCheckpoint: 2 });
+      sequencer.updateConfig({
+        skipCollectingAttestations: true,
+        maxTxsPerBlock: 1,
+        minBlocksForCheckpoint: 2,
+        buildCheckpointIfEmpty: false,
+      });
     });
 
     // Send a few transactions so the sequencer builds multiple blocks in the checkpoint
     // We'll later check that the first tx at least was picked up and mined
-    logger.warn('Sending multiple transactions to trigger block building');
-    const [{ txHash: sentTx }] = await timesAsync(8, i =>
+    logger.warn('Sending transactions to trigger initial block building');
+    const [{ txHash: sentTx }] = await timesAsync(2, i =>
       testContract.methods.emit_nullifier(BigInt(i + 1)).send({ from, wait: NO_WAIT }),
     );
 
     // Disable skipCollectingAttestations after the first checkpoint and capture its number
+    const badCheckpointMinedPromise = promiseWithResolvers<CheckpointNumber>();
     test.monitor.on('checkpoint', ({ checkpointNumber }) => {
+      badCheckpointMinedPromise.resolve(checkpointNumber);
       logger.warn(`Disabling skipCollectingAttestations after checkpoint ${checkpointNumber} has been mined`);
       sequencers.forEach(sequencer => {
         sequencer.updateConfig({ skipCollectingAttestations: false });
@@ -256,34 +300,32 @@ describe('e2e_epochs/epochs_invalidate_block', () => {
     await Promise.all(sequencers.map(s => s.start()));
     logger.warn(`Started all sequencers with skipCollectingAttestations=true`);
 
-    // Create a filter for CheckpointInvalidated events
-    const checkpointInvalidatedFilter = await l1Client.createContractEventFilter({
-      address: rollupContract.address,
-      abi: RollupAbi,
-      eventName: 'CheckpointInvalidated',
-      fromBlock: 1n,
-      toBlock: 'latest',
-    });
+    // Wait for the bad checkpoint to be mined, which means the attack is live
+    const badCheckpointNumber = await badCheckpointMinedPromise.promise;
+    await assertCheckpointInsufficientAttestations(badCheckpointNumber);
+
+    // Wait for a slot so we dont have a proposed in-flight checkpoint
+    await test.monitor.waitUntilNextL2Slot();
+
+    // And build the next block
+    logger.warn('Sending second round of txs');
+    await timesAsync(2, i =>
+      testContract.methods.emit_nullifier(BigInt(i + 50)).send({ from: context.accounts[0], wait: NO_WAIT }),
+    );
 
     // The next proposer should invalidate the previous checkpoint and publish a new one
     logger.warn('Waiting for next proposer to invalidate the previous checkpoint');
+    const { checkpointNumber: invalidatedCheckpointNumber, event } = await awaitCheckpointInvalidationEvent();
+    expect(invalidatedCheckpointNumber).toBeGreaterThan(initialCheckpointNumber);
 
-    // Wait for the CheckpointInvalidated event
-    const checkpointInvalidatedEvents = await retryUntil(
-      async () => {
-        const events = await l1Client.getFilterLogs({ filter: checkpointInvalidatedFilter });
-        return events.length > 0 ? events : undefined;
-      },
-      'CheckpointInvalidated event',
-      test.L2_SLOT_DURATION_IN_S * 5,
-      0.1,
+    // The invalidation must have been bundled with a new checkpoint proposal in the same L1 tx.
+    const proposedInSameBlock = await rollupContract.getCheckpointProposedEvents(
+      event.blockNumber!,
+      event.blockNumber!,
     );
-
-    // Verify the CheckpointInvalidated event was emitted and that the block was removed
-    const [event] = checkpointInvalidatedEvents;
-    logger.warn(`CheckpointInvalidated event emitted`, { event });
-    expect(event.args.checkpointNumber).toBeGreaterThan(initialCheckpointNumber);
-    expect(test.rollup.address).toEqual(event.address);
+    const proposedInSameTx = proposedInSameBlock.find(e => e.l1TransactionHash === event.transactionHash);
+    expect(proposedInSameTx).toBeDefined();
+    logger.warn(`Invalidation bundled with new checkpoint ${proposedInSameTx!.args.checkpointNumber} in same L1 tx`);
 
     // Wait for all nodes to sync the new block proposed
     logger.warn('Waiting for all nodes to sync');
@@ -316,6 +358,159 @@ describe('e2e_epochs/epochs_invalidate_block', () => {
 
     logger.warn(`Waiting for checkpoint ${currentCheckpoint + 2} to be mined to ensure chain can progress`);
     await test.waitUntilCheckpointNumber(CheckpointNumber(currentCheckpoint + 2), test.L2_SLOT_DURATION_IN_S * 8);
+
+    logger.warn(`Test succeeded '${expect.getState().currentTestName}'`);
+  });
+
+  // Here we disable invalidation checks from two of the proposers. Our goal is to get two invalid checkpoints
+  // in a row, so the third proposer invalidates the earliest one, and the chain progresses. Note that the
+  // second invalid checkpoint will also have invalid attestations, we are *not* testing the scenario where the
+  // committee is malicious (or incompetent) and attests for the descendent of an invalid checkpoint.
+  it('proposer invalidates multiple checkpoints', async () => {
+    // Start all sequencers with default (good) config, wait for the first checkpoint to land,
+    // then apply the bad config to the proposers of the next two slots. This avoids the race
+    // where a bad proposer is also the proposer of slot+1 and gets the bad config too early.
+    const sequencers = nodes.map(node => node.getSequencer()!);
+    sequencers.forEach(s => s.updateConfig({ minTxsPerBlock: 0 }));
+    await Promise.all(sequencers.map(s => s.start()));
+    logger.warn(`Started all sequencers, waiting for first checkpoint before applying malicious config`);
+
+    // Wait for at least one checkpoint to be mined so that any in-progress slot has completed
+    const initialCheckpointNumber = (await nodes[0].getL2Tips()).checkpointed.checkpoint.number;
+    await test.waitUntilCheckpointNumber(CheckpointNumber(initialCheckpointNumber + 1), test.L2_SLOT_DURATION_IN_S * 4);
+    const { l2SlotNumber: currentSlot } = await test.monitor.run();
+    logger.warn(`First checkpoint mined, current slot is ${currentSlot}`);
+
+    // Pick the next two slots after the current one, with a 1-slot gap to account for pipelining
+    const badSlot1 = SlotNumber.add(currentSlot, 2);
+    const badSlot2 = SlotNumber.add(currentSlot, 3);
+    const badSlots = [badSlot1, badSlot2];
+    const badProposers = await Promise.all(badSlots.map(s => test.epochCache.getProposerAttesterAddressInSlot(s)));
+
+    const badNodes = [];
+    for (let badProposerIndex = 0; badProposerIndex < badProposers.length; badProposerIndex++) {
+      const badProposer = badProposers[badProposerIndex];
+      logger.warn(`Disabling invalidation checks and attestation gathering for proposer ${badProposer}`);
+      const nodeIndex = nodes.findIndex(n => n.getSequencer()!.validatorAddresses!.some(a => a.equals(badProposer!)));
+      if (nodeIndex === -1) {
+        throw new Error(`Could not find node for proposer ${badProposer}`);
+      }
+      const node = nodes[nodeIndex];
+      badNodes.push(node);
+      await node.setConfig({
+        skipInvalidateBlockAsProposer: true,
+        skipCollectingAttestations: true,
+        skipValidateCheckpointAttestations: true,
+        minTxsPerBlock: 0,
+      });
+
+      const badSlot = badSlots[badProposerIndex];
+      logger.warn(`Applied malicious config to node ${nodeIndex} with proposer ${badProposer} for slot ${badSlot}`);
+    }
+
+    // We should see two invalid blocks being proposed by the bad proposers in those two slots
+    const firstCheckpointPromise = promiseWithResolvers<CheckpointNumber>();
+    const secondCheckpointPromise = promiseWithResolvers<CheckpointNumber>();
+    const expectedFirstSlot = badSlot1;
+    const expectedSecondSlot = badSlot2;
+    test.monitor.on('checkpoint', ({ checkpointNumber, l2SlotNumber }) => {
+      logger.warn(`Checkpoint ${checkpointNumber} at slot ${l2SlotNumber} has been mined`);
+      if (l2SlotNumber === expectedFirstSlot) {
+        firstCheckpointPromise.resolve(checkpointNumber);
+      }
+      if (l2SlotNumber === expectedSecondSlot) {
+        secondCheckpointPromise.resolve(checkpointNumber);
+      }
+    });
+
+    // Wait for both checkpoints to be mined
+    logger.warn(`Waiting for two checkpoints to be mined on slots ${expectedFirstSlot} and ${expectedSecondSlot}`);
+    const [firstCheckpoint, secondCheckpoint] = await Promise.race([
+      await Promise.all([firstCheckpointPromise.promise, secondCheckpointPromise.promise]),
+      timeoutPromise(test.L2_SLOT_DURATION_IN_S * 8 * 1000).then(() => [CheckpointNumber(0), CheckpointNumber(0)]),
+    ]);
+
+    // Sanity check: verify that both bad checkpoints landed on L1 with insufficient attestations.
+    // This catches config-timing races where `skipCollectingAttestations` doesn't take effect in time.
+    await assertCheckpointInsufficientAttestations(firstCheckpoint);
+    await assertCheckpointInsufficientAttestations(secondCheckpoint);
+
+    // As soon as it's the turn of a good proposer, we should see the first checkpoint being invalidated
+    // Note that this may take a few slots to happen
+    logger.warn(`Waiting for invalidation`);
+    const { checkpointNumber: invalidatedCheckpointNumber } = await awaitCheckpointInvalidationEvent(16);
+
+    // The invalidated checkpoint should be the first one,
+    // but it may also be a checkpoint *before* the first one that gets mined in an early slot
+    expect(invalidatedCheckpointNumber).toBeLessThanOrEqual(firstCheckpoint);
+
+    // Now restore bad nodes back to normal
+    logger.warn(`Restoring bad nodes config back to normal`);
+    await Promise.all(
+      badNodes.map(async node => {
+        await node.setConfig({
+          skipInvalidateBlockAsProposer: false,
+          skipCollectingAttestations: false,
+          skipValidateCheckpointAttestations: false,
+        });
+      }),
+    );
+
+    // And wait for more checkpoints to be mined
+    const nextCheckpointNumber = CheckpointNumber(firstCheckpoint + 3);
+    logger.warn(`Waiting until more checkpoints have been mined to ensure the chain can progress`);
+    await Promise.all(nodes.map(node => node.setConfig({ minTxsPerBlock: 0 })));
+    await test.waitUntilCheckpointNumber(nextCheckpointNumber, test.L2_SLOT_DURATION_IN_S * 16);
+
+    logger.warn(`Test succeeded '${expect.getState().currentTestName}'`);
+  });
+
+  // All tests but this one disable invalidation by committee. This test disables invalidation by proposer and
+  // instead waits for a committee member to invalidate the block after several proposers not doing so.
+  it('committee member invalidates a block if proposer does not come through', async () => {
+    const sequencers = nodes.map(node => node.getSequencer()!);
+    const initialCheckpointNumber = await nodes[0].getL2Tips().then(t => t.checkpointed.checkpoint.number);
+
+    // Configure all sequencers to skip collecting attestations before starting
+    logger.warn('Configuring all sequencers to skip attestation collection and invalidation as proposer');
+    const invalidationDelay = test.L1_BLOCK_TIME_IN_S * 4;
+    sequencers.forEach(sequencer => {
+      sequencer.updateConfig({
+        skipCollectingAttestations: true,
+        minTxsPerBlock: 0,
+        skipInvalidateBlockAsProposer: true,
+        secondsBeforeInvalidatingBlockAsCommitteeMember: invalidationDelay,
+      });
+    });
+
+    // Disable skipCollectingAttestations after the first block is mined
+    let invalidCheckpointSlotNumber: SlotNumber | undefined;
+    test.monitor.once('checkpoint', ({ checkpointNumber, l2SlotNumber }) => {
+      logger.warn(
+        `Disabling skipCollectingAttestations after L2 block ${checkpointNumber} has been mined at L2 slot ${l2SlotNumber}`,
+        { checkpointNumber, l2SlotNumber },
+      );
+      invalidCheckpointSlotNumber = l2SlotNumber;
+      sequencers.forEach(sequencer => {
+        sequencer.updateConfig({ skipCollectingAttestations: false });
+      });
+    });
+
+    // Start all sequencers
+    await Promise.all(sequencers.map(s => s.start()));
+    logger.warn(`Started all sequencers with skipCollectingAttestations=true`);
+
+    // Some committee member should invalidate the previous checkpoint
+    logger.warn('Waiting for committee member to invalidate the previous checkpoint');
+    const { checkpointNumber: invalidatedCheckpointNumber, event } = await awaitCheckpointInvalidationEvent();
+    expect(invalidatedCheckpointNumber).toBeGreaterThan(initialCheckpointNumber);
+
+    // And check that the invalidation happened at least after the specified timeout.
+    // We use the checkpoint header timestamp (L2 timestamp) since that's what the sequencer uses
+    // to calculate how long to wait before invalidating, not the L1 block timestamp when it landed.
+    const invalidSlotTimestamp = getTimestampForSlot(invalidCheckpointSlotNumber!, test.constants);
+    const { timestamp: invalidationTimestamp } = await l1Client.getBlock({ blockNumber: event.blockNumber! });
+    expect(invalidationTimestamp).toBeGreaterThanOrEqual(invalidSlotTimestamp + BigInt(invalidationDelay));
 
     logger.warn(`Test succeeded '${expect.getState().currentTestName}'`);
   });
@@ -366,220 +561,5 @@ describe('e2e_epochs/epochs_invalidate_block', () => {
       attackConfig: { shuffleAttestationOrdering: true },
       disableConfig: { shuffleAttestationOrdering: false },
     });
-  });
-
-  // Here we disable invalidation checks from two of the proposers. Our goal is to get two invalid checkpoints
-  // in a row, so the third proposer invalidates the earliest one, and the chain progresses. Note that the
-  // second invalid checkpoint will also have invalid attestations, we are *not* testing the scenario where the
-  // committee is malicious (or incompetent) and attests for the descendent of an invalid checkpoint.
-  it('proposer invalidates multiple checkpoints', async () => {
-    // Start all sequencers with default (good) config, wait for the first checkpoint to land,
-    // then apply the bad config to the proposers of the next two slots. This avoids the race
-    // where a bad proposer is also the proposer of slot+1 and gets the bad config too early.
-    const sequencers = nodes.map(node => node.getSequencer()!);
-    sequencers.forEach(s => s.updateConfig({ minTxsPerBlock: 0 }));
-    await Promise.all(sequencers.map(s => s.start()));
-    logger.warn(`Started all sequencers, waiting for first checkpoint before applying malicious config`);
-
-    // Wait for at least one checkpoint to be mined so that any in-progress slot has completed
-    const initialCheckpointNumber = (await nodes[0].getL2Tips()).checkpointed.checkpoint.number;
-    await test.waitUntilCheckpointNumber(CheckpointNumber(initialCheckpointNumber + 1), test.L2_SLOT_DURATION_IN_S * 4);
-    const { l2SlotNumber: currentSlot } = await test.monitor.run();
-    logger.warn(`First checkpoint mined, current slot is ${currentSlot}`);
-
-    // Pick the next two slots after the current one
-    const badSlot1 = currentSlot + 1;
-    const badSlot2 = currentSlot + 2;
-    const badProposers = await Promise.all([
-      test.epochCache.getProposerAttesterAddressInSlot(SlotNumber(badSlot1)),
-      test.epochCache.getProposerAttesterAddressInSlot(SlotNumber(badSlot2)),
-    ]);
-
-    const badNodes = [];
-    for (const badProposer of badProposers) {
-      logger.warn(`Disabling invalidation checks and attestation gathering for proposer ${badProposer}`);
-      const node = nodes.find(n => n.getSequencer()!.validatorAddresses!.some(a => a.equals(badProposer!)));
-      if (!node) {
-        throw new Error(`Could not find node for proposer ${badProposer}`);
-      }
-      badNodes.push(node);
-      await node.setConfig({
-        skipInvalidateBlockAsProposer: true,
-        skipCollectingAttestations: true,
-        skipValidateCheckpointAttestations: true,
-        minTxsPerBlock: 0,
-      });
-    }
-    logger.warn(`Applied malicious config to proposers of slots ${badSlot1} and ${badSlot2}`);
-
-    // We should see two invalid blocks being proposed by the bad proposers in those two slots
-    const firstCheckpointPromise = promiseWithResolvers<CheckpointNumber>();
-    const secondCheckpointPromise = promiseWithResolvers<CheckpointNumber>();
-    const expectedFirstSlot = badSlot1;
-    const expectedSecondSlot = badSlot2;
-    test.monitor.on('checkpoint', ({ checkpointNumber, l2SlotNumber }) => {
-      logger.warn(`Checkpoint ${checkpointNumber} at slot ${l2SlotNumber} has been mined`);
-      if (l2SlotNumber === expectedFirstSlot) {
-        firstCheckpointPromise.resolve(checkpointNumber);
-      }
-      if (l2SlotNumber === expectedSecondSlot) {
-        secondCheckpointPromise.resolve(checkpointNumber);
-      }
-    });
-
-    // Wait for both checkpoints to be mined
-    logger.warn(`Waiting for two checkpoints to be mined on slots ${expectedFirstSlot} and ${expectedSecondSlot}`);
-    const [firstCheckpoint, secondCheckpoint] = await Promise.race([
-      await Promise.all([firstCheckpointPromise.promise, secondCheckpointPromise.promise]),
-      timeoutPromise(test.L2_SLOT_DURATION_IN_S * 8 * 1000).then(() => [CheckpointNumber(0), CheckpointNumber(0)]),
-    ]);
-
-    // Subscribe to checkpoint invalidation events
-    const checkpointInvalidatedFilter = await l1Client.createContractEventFilter({
-      address: rollupContract.address,
-      abi: RollupAbi,
-      eventName: 'CheckpointInvalidated',
-      fromBlock: 1n,
-      toBlock: 'latest',
-    });
-
-    // Wait for a slot with a good proposer
-    logger.warn(
-      `Checkpoints ${firstCheckpoint} and ${secondCheckpoint} have been mined. Waiting for slot with good proposer.`,
-    );
-    const goodProposer = await retryUntil(async () => {
-      const { currentSlot } = test.epochCache.getCurrentAndNextSlot();
-      const currentProposer = await test.epochCache.getProposerAttesterAddressInSlot(currentSlot);
-      if (badProposers.every(p => !p!.equals(currentProposer!))) {
-        return currentProposer;
-      }
-    });
-
-    // As soon as it's the turn of a good proposer, we should see the first checkpoint being invalidated
-    logger.warn(`Turn for ${goodProposer}. Waiting for invalidation.`);
-    const invalidationEvent = await retryUntil(
-      async () => {
-        const events = await l1Client.getFilterLogs({ filter: checkpointInvalidatedFilter });
-        if (events.length > 0) {
-          const event = events[0];
-          return {
-            checkpointNumber: CheckpointNumber.fromBigInt(event.args.checkpointNumber!),
-            l1BlockNumber: event.blockNumber,
-          };
-        }
-        return undefined;
-      },
-      'CheckpointInvalidated event',
-      test.L2_SLOT_DURATION_IN_S * 4,
-      0.1,
-    );
-
-    // The invalidated checkpoint should be the first one,
-    // but it may also be a checkpoint *before* the first one that gets mined in an early slot
-    expect(invalidationEvent.checkpointNumber).toBeLessThanOrEqual(firstCheckpoint);
-
-    // Verify the invalidation happened during the good proposer's target slot (pipelining: targetSlot = slotNow + 1).
-    // This confirms it was the proposer's waitForParentCheckpointOnL1 that detected and invalidated,
-    // not the committee member fallback (which has a 144s delay).
-    const { timestamp: invalidationL1Timestamp } = await l1Client.getBlock({
-      blockNumber: invalidationEvent.l1BlockNumber,
-    });
-    const { currentSlot: goodProposerSlot } = test.epochCache.getCurrentAndNextSlot();
-    const goodProposerTargetSlotTimestamp = getTimestampForSlot(SlotNumber(goodProposerSlot + 1), test.constants);
-    // The invalidation should have happened within one L2 slot of the good proposer's target slot start
-    expect(Number(invalidationL1Timestamp)).toBeLessThan(
-      Number(goodProposerTargetSlotTimestamp) + test.L2_SLOT_DURATION_IN_S,
-    );
-
-    // Restore bad nodes back to normal. They should eventually detect that their archive root does not
-    // match the value on chain and roll back their invalid nodes.
-    await Promise.all(
-      badNodes.map(async node => {
-        await node.setConfig({
-          skipInvalidateBlockAsProposer: false,
-          skipCollectingAttestations: false,
-          skipValidateCheckpointAttestations: false,
-        });
-      }),
-    );
-
-    // And wait for more checkpoints to be mined
-    const nextCheckpointNumber = CheckpointNumber(firstCheckpoint + 3);
-    logger.warn(`Waiting until more checkpoints have been mined to ensure the chain can progress`);
-    await Promise.all(nodes.map(node => node.setConfig({ minTxsPerBlock: 0 })));
-    await test.waitUntilCheckpointNumber(nextCheckpointNumber, test.L2_SLOT_DURATION_IN_S * 16);
-
-    logger.warn(`Test succeeded '${expect.getState().currentTestName}'`);
-  });
-
-  it('committee member invalidates a block if proposer does not come through', async () => {
-    const sequencers = nodes.map(node => node.getSequencer()!);
-    const initialCheckpointNumber = await nodes[0].getL2Tips().then(t => t.checkpointed.checkpoint.number);
-
-    // Configure all sequencers to skip collecting attestations before starting
-    logger.warn('Configuring all sequencers to skip attestation collection and invalidation as proposer');
-    const invalidationDelay = test.L1_BLOCK_TIME_IN_S * 4;
-    sequencers.forEach(sequencer => {
-      sequencer.updateConfig({
-        skipCollectingAttestations: true,
-        minTxsPerBlock: 0,
-        skipInvalidateBlockAsProposer: true,
-        secondsBeforeInvalidatingBlockAsCommitteeMember: invalidationDelay,
-      });
-    });
-
-    // Disable skipCollectingAttestations after the first block is mined
-    let invalidCheckpointSlotNumber: SlotNumber | undefined;
-    test.monitor.once('checkpoint', ({ checkpointNumber, l2SlotNumber }) => {
-      logger.warn(
-        `Disabling skipCollectingAttestations after L2 block ${checkpointNumber} has been mined at L2 slot ${l2SlotNumber}`,
-        { checkpointNumber, l2SlotNumber },
-      );
-      invalidCheckpointSlotNumber = l2SlotNumber;
-      sequencers.forEach(sequencer => {
-        sequencer.updateConfig({ skipCollectingAttestations: false });
-      });
-    });
-
-    // Start all sequencers
-    await Promise.all(sequencers.map(s => s.start()));
-    logger.warn(`Started all sequencers with skipCollectingAttestations=true`);
-
-    // Create a filter for CheckpointInvalidated events
-    const checkpointInvalidatedFilter = await l1Client.createContractEventFilter({
-      address: rollupContract.address,
-      abi: RollupAbi,
-      eventName: 'CheckpointInvalidated',
-      fromBlock: 1n,
-      toBlock: 'latest',
-    });
-
-    // Some committee member should invalidate the previous checkpoint
-    logger.warn('Waiting for committee member to invalidate the previous checkpoint');
-
-    // Wait for the CheckpointInvalidated event
-    const checkpointInvalidatedEvents = await retryUntil(
-      async () => {
-        const events = await l1Client.getFilterLogs({ filter: checkpointInvalidatedFilter });
-        return events.length > 0 ? events : undefined;
-      },
-      'CheckpointInvalidated event',
-      test.L2_SLOT_DURATION_IN_S * 5,
-      0.1,
-    );
-
-    // Verify the CheckpointInvalidated event was emitted
-    const [event] = checkpointInvalidatedEvents;
-    logger.warn(`CheckpointInvalidated event emitted`, { event });
-    expect(event.args.checkpointNumber).toBeGreaterThan(initialCheckpointNumber);
-
-    // And check that the invalidation happened at least after the specified timeout.
-    // We use the checkpoint header timestamp (L2 timestamp) since that's what the sequencer uses
-    // to calculate how long to wait before invalidating, not the L1 block timestamp when it landed.
-    const invalidSlotTimestamp = getTimestampForSlot(invalidCheckpointSlotNumber!, test.constants);
-    const { timestamp: invalidationTimestamp } = await l1Client.getBlock({ blockNumber: event.blockNumber });
-    expect(invalidationTimestamp).toBeGreaterThanOrEqual(invalidSlotTimestamp + BigInt(invalidationDelay));
-
-    logger.warn(`Test succeeded '${expect.getState().currentTestName}'`);
   });
 });

--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_invalidate_block.parallel.test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_invalidate_block.parallel.test.ts
@@ -434,8 +434,7 @@ describe('e2e_epochs/epochs_invalidate_block', () => {
       timeoutPromise(test.L2_SLOT_DURATION_IN_S * 8 * 1000).then(() => [CheckpointNumber(0), CheckpointNumber(0)]),
     ]);
 
-    // Subscribe to checkpoint invalidation events, capturing the L1 tx hash so we can verify the sender
-    const invalidatePromise = promiseWithResolvers<{ checkpointNumber: CheckpointNumber; txHash: `0x${string}` }>();
+    // Subscribe to checkpoint invalidation events
     const checkpointInvalidatedFilter = await l1Client.createContractEventFilter({
       address: rollupContract.address,
       abi: RollupAbi,

--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_invalidate_block.parallel.test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_invalidate_block.parallel.test.ts
@@ -79,6 +79,8 @@ describe('e2e_epochs/epochs_invalidate_block', () => {
       minTxsPerBlock: 1,
       maxTxsPerBlock: 1,
       skipInitialSequencer: true,
+      enableProposerPipelining: true,
+      inboxLag: 2,
     });
 
     ({ context, logger, l1Client } = test);
@@ -432,12 +434,14 @@ describe('e2e_epochs/epochs_invalidate_block', () => {
       timeoutPromise(test.L2_SLOT_DURATION_IN_S * 8 * 1000).then(() => [CheckpointNumber(0), CheckpointNumber(0)]),
     ]);
 
-    // Subscribe to checkpoint invalidation events
-    const invalidatePromise = promiseWithResolvers<CheckpointNumber>();
-    const unsubscribe = rollupContract.listenToCheckpointInvalidated(event => {
-      logger.warn(`Checkpoint ${event.checkpointNumber} has been invalidated`, event);
-      invalidatePromise.resolve(event.checkpointNumber);
-      unsubscribe();
+    // Subscribe to checkpoint invalidation events, capturing the L1 tx hash so we can verify the sender
+    const invalidatePromise = promiseWithResolvers<{ checkpointNumber: CheckpointNumber; txHash: `0x${string}` }>();
+    const checkpointInvalidatedFilter = await l1Client.createContractEventFilter({
+      address: rollupContract.address,
+      abi: RollupAbi,
+      eventName: 'CheckpointInvalidated',
+      fromBlock: 1n,
+      toBlock: 'latest',
     });
 
     // Wait for a slot with a good proposer
@@ -454,14 +458,39 @@ describe('e2e_epochs/epochs_invalidate_block', () => {
 
     // As soon as it's the turn of a good proposer, we should see the first checkpoint being invalidated
     logger.warn(`Turn for ${goodProposer}. Waiting for invalidation.`);
-    const invalidatedCheckpoint = await Promise.race([
-      invalidatePromise.promise,
-      timeoutPromise(test.L2_SLOT_DURATION_IN_S * 4 * 1000).then(() => CheckpointNumber(0)),
-    ]);
+    const invalidationEvent = await retryUntil(
+      async () => {
+        const events = await l1Client.getFilterLogs({ filter: checkpointInvalidatedFilter });
+        if (events.length > 0) {
+          const event = events[0];
+          return {
+            checkpointNumber: CheckpointNumber.fromBigInt(event.args.checkpointNumber!),
+            l1BlockNumber: event.blockNumber,
+          };
+        }
+        return undefined;
+      },
+      'CheckpointInvalidated event',
+      test.L2_SLOT_DURATION_IN_S * 4,
+      0.1,
+    );
 
     // The invalidated checkpoint should be the first one,
     // but it may also be a checkpoint *before* the first one that gets mined in an early slot
-    expect(invalidatedCheckpoint).toBeLessThanOrEqual(firstCheckpoint);
+    expect(invalidationEvent.checkpointNumber).toBeLessThanOrEqual(firstCheckpoint);
+
+    // Verify the invalidation happened during the good proposer's target slot (pipelining: targetSlot = slotNow + 1).
+    // This confirms it was the proposer's waitForParentCheckpointOnL1 that detected and invalidated,
+    // not the committee member fallback (which has a 144s delay).
+    const { timestamp: invalidationL1Timestamp } = await l1Client.getBlock({
+      blockNumber: invalidationEvent.l1BlockNumber,
+    });
+    const { currentSlot: goodProposerSlot } = test.epochCache.getCurrentAndNextSlot();
+    const goodProposerTargetSlotTimestamp = getTimestampForSlot(SlotNumber(goodProposerSlot + 1), test.constants);
+    // The invalidation should have happened within one L2 slot of the good proposer's target slot start
+    expect(Number(invalidationL1Timestamp)).toBeLessThan(
+      Number(goodProposerTargetSlotTimestamp) + test.L2_SLOT_DURATION_IN_S,
+    );
 
     // Restore bad nodes back to normal. They should eventually detect that their archive root does not
     // match the value on chain and roll back their invalid nodes.

--- a/yarn-project/ethereum/src/contracts/rollup.ts
+++ b/yarn-project/ethereum/src/contracts/rollup.ts
@@ -15,6 +15,7 @@ import {
   type Account,
   type GetContractReturnType,
   type Hex,
+  type Log,
   type StateOverride,
   type WatchContractEventReturnType,
   encodeAbiParameters,
@@ -1224,7 +1225,7 @@ export class RollupContract {
   }
 
   public listenToCheckpointInvalidated(
-    callback: (args: { checkpointNumber: CheckpointNumber }) => unknown,
+    callback: (args: { checkpointNumber: CheckpointNumber; event: Log }) => unknown,
   ): WatchContractEventReturnType {
     return this.rollup.watchEvent.CheckpointInvalidated(
       {},
@@ -1233,7 +1234,7 @@ export class RollupContract {
           for (const log of logs) {
             const args = log.args;
             if (args.checkpointNumber !== undefined) {
-              callback({ checkpointNumber: CheckpointNumber.fromBigInt(args.checkpointNumber) });
+              callback({ checkpointNumber: CheckpointNumber.fromBigInt(args.checkpointNumber), event: log });
             }
           }
         },

--- a/yarn-project/ethereum/src/test/chain_monitor.ts
+++ b/yarn-project/ethereum/src/test/chain_monitor.ts
@@ -221,6 +221,11 @@ export class ChainMonitor extends EventEmitter<ChainMonitorEventMap> {
     });
   }
 
+  public async waitUntilNextL2Slot(): Promise<void> {
+    const targetSlot = SlotNumber.add((await this.run()).l2SlotNumber, 1);
+    return this.waitUntilL2Slot(targetSlot);
+  }
+
   public waitUntilL1Block(block: number | bigint): Promise<void> {
     const targetBlock = typeof block === 'bigint' ? block.valueOf() : block;
     if (this.l1BlockNumber >= targetBlock) {

--- a/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.test.ts
@@ -813,6 +813,7 @@ describe('CheckpointProposalJob', () => {
       checkpointedHash?: string;
     }) {
       l2BlockSource.getSyncedL2SlotNumber.mockResolvedValue(opts.syncedSlot ?? SlotNumber(newSlotNumber));
+      l2BlockSource.getPendingChainValidationStatus.mockResolvedValue({ valid: true });
       l2BlockSource.getL2Tips.mockResolvedValue({
         proposed: { number: BlockNumber(1), hash: 'proposed-hash' },
         checkpointed: {
@@ -840,7 +841,6 @@ describe('CheckpointProposalJob', () => {
     it('proposes checkpoint when parent landed with matching hash and valid attestations', async () => {
       const pipelinedJob = await createPipelinedJobWithBlock(proposedParent);
       mockL2BlockSource({ checkpointedNumber: CheckpointNumber(1), checkpointedHash: parentCheckpointHash });
-      l2BlockSource.getPendingChainValidationStatus.mockResolvedValue({ valid: true });
 
       await pipelinedJob.executeAndAwait();
 
@@ -961,6 +961,59 @@ describe('CheckpointProposalJob', () => {
       expect(publisher.simulateInvalidateCheckpoint).not.toHaveBeenCalled();
       expect(publisher.enqueueInvalidateCheckpoint).not.toHaveBeenCalled();
       expect(mismatchEvents).toEqual([expect.objectContaining({ reason: 'parent-invalid-attestations' })]);
+    });
+
+    it('enqueues invalidation when attestation collection fails and pending chain has invalid attestations', async () => {
+      const pipelinedJob = await createPipelinedJobWithBlock(proposedParent);
+      mockL2BlockSource({ checkpointedNumber: CheckpointNumber(1), checkpointedHash: parentCheckpointHash });
+
+      // Attestation collection fails — waitForAttestations will return undefined
+      validatorClient.collectAttestations.mockRejectedValue(new AttestationTimeoutError(0, 1, SlotNumber.ZERO));
+
+      const invalidValidation: ValidateCheckpointResult = {
+        valid: false,
+        reason: 'invalid-attestation',
+        checkpoint: {
+          archive: Fr.random(),
+          lastArchive: Fr.random(),
+          slotNumber: SlotNumber(1),
+          checkpointNumber: CheckpointNumber(1),
+          timestamp: 0n,
+        },
+        committee: [EthAddress.random()],
+        epoch: EpochNumber.ZERO,
+        seed: 0n,
+        attestors: [EthAddress.random()],
+        invalidIndex: 0,
+        attestations: [CommitteeAttestation.random()],
+      };
+      l2BlockSource.getPendingChainValidationStatus.mockResolvedValue(invalidValidation);
+
+      const fakeRequest = { fake: true } as any;
+      publisher.simulateInvalidateCheckpoint.mockResolvedValue(fakeRequest);
+
+      await pipelinedJob.executeAndAwait();
+
+      // No propose action since we didn't collect attestations
+      expect(publisher.enqueueProposeCheckpoint).not.toHaveBeenCalled();
+      // But we still enqueue invalidation so the chain is cleaned up for the next proposer
+      expect(publisher.simulateInvalidateCheckpoint).toHaveBeenCalledWith(invalidValidation);
+      expect(publisher.enqueueInvalidateCheckpoint).toHaveBeenCalledWith(fakeRequest, expect.any(Object));
+      expect(publisher.sendRequestsAt).toHaveBeenCalled();
+    });
+
+    it('does not enqueue invalidation when attestation collection fails but pending chain is valid', async () => {
+      const pipelinedJob = await createPipelinedJobWithBlock(proposedParent);
+      mockL2BlockSource({ checkpointedNumber: CheckpointNumber(1), checkpointedHash: parentCheckpointHash });
+
+      validatorClient.collectAttestations.mockRejectedValue(new AttestationTimeoutError(0, 1, SlotNumber.ZERO));
+
+      await pipelinedJob.executeAndAwait();
+
+      expect(publisher.enqueueProposeCheckpoint).not.toHaveBeenCalled();
+      expect(publisher.simulateInvalidateCheckpoint).not.toHaveBeenCalled();
+      expect(publisher.enqueueInvalidateCheckpoint).not.toHaveBeenCalled();
+      expect(publisher.sendRequestsAt).toHaveBeenCalled();
     });
 
     it('skips proposal with unexpected-parent-appeared when a new checkpoint appears without proposed parent', async () => {

--- a/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.test.ts
@@ -19,7 +19,13 @@ import type { TypedEventEmitter } from '@aztec/foundation/types';
 import { type P2P, P2PClientState } from '@aztec/p2p';
 import type { SlasherClientInterface } from '@aztec/slasher';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
-import { CommitteeAttestation, L2Block, type L2BlockSink, type L2BlockSource } from '@aztec/stdlib/block';
+import {
+  CommitteeAttestation,
+  L2Block,
+  type L2BlockSink,
+  type L2BlockSource,
+  type ValidateCheckpointResult,
+} from '@aztec/stdlib/block';
 import {
   Checkpoint,
   type CheckpointData,
@@ -743,6 +749,233 @@ describe('CheckpointProposalJob', () => {
     });
   });
 
+  describe('pipelining parent checkpoint validation', () => {
+    const parentCheckpointHeader = CheckpointHeader.empty();
+    const parentCheckpointHash = parentCheckpointHeader.hash().toString();
+
+    const proposedParent: ProposedCheckpointData = {
+      checkpointNumber: CheckpointNumber(1),
+      header: parentCheckpointHeader,
+      archive: new AppendOnlyTreeSnapshot(Fr.ZERO, 1),
+      checkpointOutHash: Fr.ZERO,
+      startBlock: BlockNumber(1),
+      blockCount: 1,
+      totalManaUsed: 5000n,
+      feeAssetPriceModifier: 100n,
+    };
+
+    let mismatchEvents: { slot: SlotNumber; checkpointNumber: CheckpointNumber; reason: string }[];
+
+    /** Creates a pipelined job for checkpoint 2, builds one block, and returns the job ready for executeAndAwait. */
+    async function createPipelinedJobWithBlock(
+      proposedCheckpointData?: ProposedCheckpointData,
+    ): Promise<TestCheckpointProposalJob> {
+      checkpointNumber = CheckpointNumber(2);
+      epochCache.isProposerPipeliningEnabled.mockReturnValue(true);
+
+      const pipelinedJob = createCheckpointProposalJob({
+        targetSlot: SlotNumber(newSlotNumber + 1),
+        proposedCheckpointData,
+      });
+
+      // Listen for mismatch events on this job's emitter
+      mismatchEvents = [];
+      pipelinedJob.eventEmitter.on(
+        'checkpoint-parent-mismatch',
+        (evt: { slot: SlotNumber; checkpointNumber: CheckpointNumber; reason: string }) => {
+          mismatchEvents.push(evt);
+        },
+      );
+
+      // Seed a block so the checkpoint builds successfully
+      const { txs, block } = await setupTxsAndBlock(p2p, globalVariables, 1, chainId);
+      // Re-create the checkpoint builder for checkpoint 2
+      const checkpointConstants = {
+        slotNumber: globalVariables.slotNumber,
+        timestamp: globalVariables.timestamp,
+        coinbase: globalVariables.coinbase,
+        feeRecipient: globalVariables.feeRecipient,
+        gasFees: globalVariables.gasFees,
+        chainId: globalVariables.chainId,
+        version: globalVariables.version,
+      };
+      checkpointBuilder = checkpointsBuilder.createCheckpointBuilder(checkpointConstants, checkpointNumber);
+      checkpointBuilder.seedBlocks([block], [txs]);
+      validatorClient.collectAttestations.mockResolvedValue(getAttestations(block));
+
+      return pipelinedJob;
+    }
+
+    /** Helper to set up l2BlockSource mocks for tips and synced slot. */
+    function mockL2BlockSource(opts: {
+      syncedSlot?: SlotNumber;
+      checkpointedNumber?: CheckpointNumber;
+      checkpointedHash?: string;
+    }) {
+      l2BlockSource.getSyncedL2SlotNumber.mockResolvedValue(opts.syncedSlot ?? SlotNumber(newSlotNumber));
+      l2BlockSource.getL2Tips.mockResolvedValue({
+        proposed: { number: BlockNumber(1), hash: 'proposed-hash' },
+        checkpointed: {
+          block: { number: BlockNumber(1), hash: 'block-hash' },
+          checkpoint: {
+            number: opts.checkpointedNumber ?? CheckpointNumber(1),
+            hash: opts.checkpointedHash ?? parentCheckpointHash,
+          },
+        },
+        proposedCheckpoint: {
+          block: { number: BlockNumber(1), hash: 'block-hash' },
+          checkpoint: { number: CheckpointNumber(1), hash: parentCheckpointHash },
+        },
+        proven: {
+          block: { number: BlockNumber.ZERO, hash: 'proven-hash' },
+          checkpoint: { number: CheckpointNumber.ZERO, hash: 'proven-ckpt-hash' },
+        },
+        finalized: {
+          block: { number: BlockNumber.ZERO, hash: 'finalized-hash' },
+          checkpoint: { number: CheckpointNumber.ZERO, hash: 'finalized-ckpt-hash' },
+        },
+      });
+    }
+
+    it('proposes checkpoint when parent landed with matching hash and valid attestations', async () => {
+      const pipelinedJob = await createPipelinedJobWithBlock(proposedParent);
+      mockL2BlockSource({ checkpointedNumber: CheckpointNumber(1), checkpointedHash: parentCheckpointHash });
+      l2BlockSource.getPendingChainValidationStatus.mockResolvedValue({ valid: true });
+
+      await pipelinedJob.executeAndAwait();
+
+      expect(publisher.enqueueProposeCheckpoint).toHaveBeenCalledTimes(1);
+      expect(publisher.sendRequestsAt).toHaveBeenCalled();
+      expect(mismatchEvents).toHaveLength(0);
+    });
+
+    it('proposes checkpoint when no proposed parent and none appeared on L1', async () => {
+      const pipelinedJob = await createPipelinedJobWithBlock(undefined);
+      mockL2BlockSource({ checkpointedNumber: CheckpointNumber(0) });
+
+      await pipelinedJob.executeAndAwait();
+
+      expect(publisher.enqueueProposeCheckpoint).toHaveBeenCalledTimes(1);
+      expect(publisher.sendRequestsAt).toHaveBeenCalled();
+      expect(mismatchEvents).toHaveLength(0);
+    });
+
+    it('skips proposal with archiver-sync-timeout when archiver does not sync in time', async () => {
+      const pipelinedJob = await createPipelinedJobWithBlock(proposedParent);
+      l2BlockSource.getSyncedL2SlotNumber.mockResolvedValue(SlotNumber(0));
+
+      await pipelinedJob.executeAndAwait();
+
+      expect(publisher.enqueueProposeCheckpoint).not.toHaveBeenCalled();
+      expect(publisher.sendRequestsAt).toHaveBeenCalled();
+      expect(mismatchEvents).toEqual([expect.objectContaining({ reason: 'archiver-sync-timeout' })]);
+      expect(metrics.recordPipelineParentCheckpointMismatch).toHaveBeenCalledWith('archiver-sync-timeout');
+    }, 120_000);
+
+    it('skips proposal with parent-not-on-l1 when parent checkpoint did not land', async () => {
+      const pipelinedJob = await createPipelinedJobWithBlock(proposedParent);
+      mockL2BlockSource({ checkpointedNumber: CheckpointNumber(0) });
+
+      await pipelinedJob.executeAndAwait();
+
+      expect(publisher.enqueueProposeCheckpoint).not.toHaveBeenCalled();
+      expect(publisher.sendRequestsAt).toHaveBeenCalled();
+      expect(mismatchEvents).toEqual([expect.objectContaining({ reason: 'parent-not-on-l1' })]);
+      expect(metrics.recordPipelineParentCheckpointMismatch).toHaveBeenCalledWith('parent-not-on-l1');
+    });
+
+    it('skips proposal with parent-hash-mismatch when parent landed with different hash', async () => {
+      const pipelinedJob = await createPipelinedJobWithBlock(proposedParent);
+      mockL2BlockSource({ checkpointedNumber: CheckpointNumber(1), checkpointedHash: 'different-hash' });
+
+      await pipelinedJob.executeAndAwait();
+
+      expect(publisher.enqueueProposeCheckpoint).not.toHaveBeenCalled();
+      expect(publisher.sendRequestsAt).toHaveBeenCalled();
+      expect(mismatchEvents).toEqual([expect.objectContaining({ reason: 'parent-hash-mismatch' })]);
+      expect(metrics.recordPipelineParentCheckpointMismatch).toHaveBeenCalledWith('parent-hash-mismatch');
+    });
+
+    it('skips proposal and enqueues invalidation with parent-invalid-attestations', async () => {
+      const pipelinedJob = await createPipelinedJobWithBlock(proposedParent);
+      mockL2BlockSource({ checkpointedNumber: CheckpointNumber(1), checkpointedHash: parentCheckpointHash });
+
+      const invalidValidation: ValidateCheckpointResult = {
+        valid: false,
+        reason: 'invalid-attestation',
+        checkpoint: {
+          archive: Fr.random(),
+          lastArchive: Fr.random(),
+          slotNumber: SlotNumber(1),
+          checkpointNumber: CheckpointNumber(1),
+          timestamp: 0n,
+        },
+        committee: [EthAddress.random()],
+        epoch: EpochNumber.ZERO,
+        seed: 0n,
+        attestors: [EthAddress.random()],
+        invalidIndex: 0,
+        attestations: [CommitteeAttestation.random()],
+      };
+      l2BlockSource.getPendingChainValidationStatus.mockResolvedValue(invalidValidation);
+
+      const fakeRequest = { fake: true } as any;
+      publisher.simulateInvalidateCheckpoint.mockResolvedValue(fakeRequest);
+
+      await pipelinedJob.executeAndAwait();
+
+      expect(publisher.enqueueProposeCheckpoint).not.toHaveBeenCalled();
+      expect(publisher.simulateInvalidateCheckpoint).toHaveBeenCalledWith(invalidValidation);
+      expect(publisher.enqueueInvalidateCheckpoint).toHaveBeenCalledWith(fakeRequest, expect.any(Object));
+      expect(publisher.sendRequestsAt).toHaveBeenCalled();
+      expect(mismatchEvents).toEqual([expect.objectContaining({ reason: 'parent-invalid-attestations' })]);
+      expect(metrics.recordPipelineParentCheckpointMismatch).toHaveBeenCalledWith('parent-invalid-attestations');
+    });
+
+    it('skips invalidation when skipInvalidateBlockAsProposer is set', async () => {
+      const pipelinedJob = await createPipelinedJobWithBlock(proposedParent);
+      pipelinedJob.updateConfig({ skipInvalidateBlockAsProposer: true });
+      mockL2BlockSource({ checkpointedNumber: CheckpointNumber(1), checkpointedHash: parentCheckpointHash });
+
+      l2BlockSource.getPendingChainValidationStatus.mockResolvedValue({
+        valid: false,
+        reason: 'invalid-attestation',
+        checkpoint: {
+          archive: Fr.random(),
+          lastArchive: Fr.random(),
+          slotNumber: SlotNumber(1),
+          checkpointNumber: CheckpointNumber(1),
+          timestamp: 0n,
+        },
+        committee: [EthAddress.random()],
+        epoch: EpochNumber.ZERO,
+        seed: 0n,
+        attestors: [EthAddress.random()],
+        invalidIndex: 0,
+        attestations: [CommitteeAttestation.random()],
+      });
+
+      await pipelinedJob.executeAndAwait();
+
+      expect(publisher.enqueueProposeCheckpoint).not.toHaveBeenCalled();
+      expect(publisher.simulateInvalidateCheckpoint).not.toHaveBeenCalled();
+      expect(publisher.enqueueInvalidateCheckpoint).not.toHaveBeenCalled();
+      expect(mismatchEvents).toEqual([expect.objectContaining({ reason: 'parent-invalid-attestations' })]);
+    });
+
+    it('skips proposal with unexpected-parent-appeared when a new checkpoint appears without proposed parent', async () => {
+      const pipelinedJob = await createPipelinedJobWithBlock(undefined);
+      mockL2BlockSource({ checkpointedNumber: CheckpointNumber(2) });
+
+      await pipelinedJob.executeAndAwait();
+
+      expect(publisher.enqueueProposeCheckpoint).not.toHaveBeenCalled();
+      expect(publisher.sendRequestsAt).toHaveBeenCalled();
+      expect(mismatchEvents).toEqual([expect.objectContaining({ reason: 'unexpected-parent-appeared' })]);
+      expect(metrics.recordPipelineParentCheckpointMismatch).toHaveBeenCalledWith('unexpected-parent-appeared');
+    });
+  });
+
   describe('multiple block mode', () => {
     beforeEach(() => {
       // Keep the real L1 publish budget and use the largest valid non-pipelined
@@ -1259,6 +1492,8 @@ describe('CheckpointProposalJob', () => {
 });
 
 class TestCheckpointProposalJob extends CheckpointProposalJob {
+  declare public eventEmitter: EventEmitter;
+
   /** Override to be a no-op for testing - allows tests to run without timing delays */
   public override waitUntilTimeInSlot(targetSecondsIntoSlot: number): Promise<void> {
     this.log.warn(`Skipping waitUntilTimeInSlot(${targetSecondsIntoSlot}) in test`);

--- a/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.test.ts
@@ -58,7 +58,7 @@ import type { TransactionReceipt } from 'viem';
 
 import { DefaultSequencerConfig } from '../config.js';
 import type { GlobalVariableBuilder } from '../global_variable_builder/global_builder.js';
-import type { SequencerPublisher } from '../publisher/sequencer-publisher.js';
+import type { InvalidateCheckpointRequest, SequencerPublisher } from '../publisher/sequencer-publisher.js';
 import {
   MockCheckpointBuilder,
   MockCheckpointsBuilder,
@@ -781,7 +781,7 @@ describe('CheckpointProposalJob', () => {
       // Listen for mismatch events on this job's emitter
       mismatchEvents = [];
       pipelinedJob.eventEmitter.on(
-        'checkpoint-parent-mismatch',
+        'pipelined-checkpoint-discarded',
         (evt: { slot: SlotNumber; checkpointNumber: CheckpointNumber; reason: string }) => {
           mismatchEvents.push(evt);
         },
@@ -919,7 +919,7 @@ describe('CheckpointProposalJob', () => {
       };
       l2BlockSource.getPendingChainValidationStatus.mockResolvedValue(invalidValidation);
 
-      const fakeRequest = { fake: true } as any;
+      const fakeRequest = { fake: true } as unknown as InvalidateCheckpointRequest;
       publisher.simulateInvalidateCheckpoint.mockResolvedValue(fakeRequest);
 
       await pipelinedJob.executeAndAwait();
@@ -989,7 +989,7 @@ describe('CheckpointProposalJob', () => {
       };
       l2BlockSource.getPendingChainValidationStatus.mockResolvedValue(invalidValidation);
 
-      const fakeRequest = { fake: true } as any;
+      const fakeRequest = { fake: true } as unknown as InvalidateCheckpointRequest;
       publisher.simulateInvalidateCheckpoint.mockResolvedValue(fakeRequest);
 
       await pipelinedJob.executeAndAwait();

--- a/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.timing.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.timing.test.ts
@@ -1073,7 +1073,7 @@ describe('CheckpointProposalJob Timing Tests', () => {
     beforeEach(() => {
       epochCache.isProposerPipeliningEnabled.mockReturnValue(true);
 
-      // Mock l2BlockSource methods needed by waitForParentCheckpointOnL1
+      // Mock l2BlockSource methods needed by waitForValidParentCheckpointOnL1
       l2BlockSource.getSyncedL2SlotNumber.mockResolvedValue(slotNumber);
       l2BlockSource.getL2Tips.mockResolvedValue({
         proposed: { number: BlockNumber.ZERO, hash: '' },

--- a/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.timing.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.timing.test.ts
@@ -1072,6 +1072,28 @@ describe('CheckpointProposalJob Timing Tests', () => {
 
     beforeEach(() => {
       epochCache.isProposerPipeliningEnabled.mockReturnValue(true);
+
+      // Mock l2BlockSource methods needed by waitForParentCheckpointOnL1
+      l2BlockSource.getSyncedL2SlotNumber.mockResolvedValue(slotNumber);
+      l2BlockSource.getL2Tips.mockResolvedValue({
+        proposed: { number: BlockNumber.ZERO, hash: '' },
+        checkpointed: {
+          block: { number: BlockNumber.ZERO, hash: '' },
+          checkpoint: { number: CheckpointNumber(0), hash: '' },
+        },
+        proposedCheckpoint: {
+          block: { number: BlockNumber.ZERO, hash: '' },
+          checkpoint: { number: CheckpointNumber(0), hash: '' },
+        },
+        proven: {
+          block: { number: BlockNumber.ZERO, hash: '' },
+          checkpoint: { number: CheckpointNumber(0), hash: '' },
+        },
+        finalized: {
+          block: { number: BlockNumber.ZERO, hash: '' },
+          checkpoint: { number: CheckpointNumber(0), hash: '' },
+        },
+      });
     });
 
     it('sets attestation deadline to the target-slot publish cutoff when pipelining', async () => {

--- a/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.ts
+++ b/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.ts
@@ -222,7 +222,7 @@ export class CheckpointProposalJob implements Traceable {
 
       // If pipelining, wait for the previous checkpoint to land on L1 before submitting,
       // so we can check it matches the proposed checkpoint we used as parent, and has valid attestations.
-      if (signedAttestations && (!isPipelining || (await this.waitForParentCheckpointOnL1()))) {
+      if (signedAttestations && (!isPipelining || (await this.waitForValidParentCheckpointOnL1()))) {
         await this.enqueueCheckpointForSubmission({ checkpoint, ...signedAttestations });
       }
 
@@ -314,7 +314,7 @@ export class CheckpointProposalJob implements Traceable {
   private async waitForSyncedL2SlotNumber(waitForSlot: SlotNumber): Promise<boolean> {
     const targetSlotStart = Number(getTimestampForSlot(this.targetSlot, this.l1Constants));
     const targetSlotEndMs = (targetSlotStart + this.l1Constants.slotDuration) * 1000;
-    const syncDelayTolerance = this.l1Constants.slotDuration * 1000;
+    const syncDelayTolerance = this.l1Constants.ethereumSlotDuration * 2 * 1000;
     const timeoutSeconds = Math.max(0.1, (targetSlotEndMs + syncDelayTolerance - this.dateProvider.now()) / 1000);
 
     try {
@@ -344,7 +344,7 @@ export class CheckpointProposalJob implements Traceable {
    * - If we built without a proposed parent: no new checkpoint must have appeared for that slot.
    * If the parent has invalid attestations, enqueues an invalidation. Returns whether to proceed with the proposal.
    */
-  protected async waitForParentCheckpointOnL1(): Promise<boolean> {
+  protected async waitForValidParentCheckpointOnL1(): Promise<boolean> {
     const parentCheckpointNumber = CheckpointNumber(this.checkpointNumber - 1);
 
     // Wait until archiver has synced L1 past the parent's slot (slotNow)

--- a/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.ts
+++ b/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.ts
@@ -210,43 +210,38 @@ export class CheckpointProposalJob implements Traceable {
     broadcast: CheckpointProposalBroadcast,
     votesPromises: Promise<unknown>[],
   ): Promise<void> {
-    const { checkpoint, proposal, blockProposedAt } = broadcast;
+    const { checkpoint } = broadcast;
     const isPipelining = this.epochCache.isProposerPipeliningEnabled();
 
     try {
+      // Wait for all votes actions, enqueued at the beginning, to resolve
       await Promise.all(votesPromises);
 
-      this.setStateFn(SequencerState.COLLECTING_ATTESTATIONS, this.targetSlot);
-      const attestations = await this.waitForAttestations(proposal);
-
-      this.checkpointMetrics.recordCheckpointAttestationDelay(this.dateProvider.now() - blockProposedAt);
-
-      // Proposer must sign over the attestations before pushing them to L1
-      const signer = this.proposer ?? this.publisher.getSenderAddress();
-      let attestationsSignature: Signature;
-      try {
-        attestationsSignature = await this.validatorClient.signAttestationsAndSigners(
-          attestations,
-          signer,
-          this.targetSlot,
-          this.checkpointNumber,
-        );
-      } catch (err) {
-        if (this.handleHASigningError(err, 'Attestations signature')) {
-          return;
-        }
-        throw err;
-      }
+      // Try to collect attestations from the committee
+      const signedAttestations = await this.getSignedCommitteeAttestations(broadcast);
 
       // If pipelining, wait for the previous checkpoint to land on L1 before submitting,
       // so we can check it matches the proposed checkpoint we used as parent, and has valid attestations.
-      if (!isPipelining || (await this.waitForParentCheckpointOnL1())) {
-        await this.enqueueCheckpointForSubmission({ checkpoint, attestations, attestationsSignature });
+      if (signedAttestations && (!isPipelining || (await this.waitForParentCheckpointOnL1()))) {
+        await this.enqueueCheckpointForSubmission({ checkpoint, ...signedAttestations });
+      }
+
+      // If we failed to collect attestations, at least check if we need to issue an invalidation
+      // Note that if we are not pipelining, we enqueued the invalidation at the beginning
+      if (!signedAttestations && isPipelining && (await this.waitForSyncedL2SlotNumber(this.slotNow))) {
+        const validationStatus = await this.l2BlockSource.getPendingChainValidationStatus();
+        if (!validationStatus.valid) {
+          this.log.warn(
+            `Checkpoint ${validationStatus.checkpoint.checkpointNumber} has invalid attestations, enqueuing invalidation in spite of attestation collection failure`,
+            { checkpoint: validationStatus.checkpoint, reason: validationStatus.reason },
+          );
+          await this.enqueueInvalidation(validationStatus);
+        }
       }
 
       // Send whatever was enqueued: votes + (propose | invalidation | nothing).
       // Compute the earliest time to submit: pipeline slot start when pipelining, now otherwise.
-      const submitAfter = this.epochCache.isProposerPipeliningEnabled()
+      const submitAfter = isPipelining
         ? new Date(Number(getTimestampForSlot(this.targetSlot, this.l1Constants)) * 1000)
         : new Date(this.dateProvider.now());
 
@@ -268,7 +263,7 @@ export class CheckpointProposalJob implements Traceable {
       }
       this.log.error(`Background attestation/L1 pipeline failed for slot ${this.targetSlot}`, err);
       this.eventEmitter.emit('checkpoint-publish-failed', { slot: this.targetSlot });
-      if (this.epochCache.isProposerPipeliningEnabled()) {
+      if (isPipelining) {
         this.metrics.recordPipelineDiscard();
       }
     }
@@ -312,6 +307,35 @@ export class CheckpointProposalJob implements Traceable {
   }
 
   /**
+   * Wait until the archiver syncs past the given L2 slot number.
+   * The deadline is the end of `this.targetSlot`, beyond which any pipelined work would miss its
+   * L1 submission window and is no longer useful.
+   */
+  private async waitForSyncedL2SlotNumber(waitForSlot: SlotNumber): Promise<boolean> {
+    const targetSlotStart = Number(getTimestampForSlot(this.targetSlot, this.l1Constants));
+    const targetSlotEndMs = (targetSlotStart + this.l1Constants.slotDuration) * 1000;
+    const timeoutSeconds = Math.max(0, (targetSlotEndMs - this.dateProvider.now()) / 1000);
+    try {
+      return await retryUntil(
+        async () => {
+          const syncedSlot = await this.l2BlockSource.getSyncedL2SlotNumber();
+          return syncedSlot !== undefined && syncedSlot >= waitForSlot;
+        },
+        `archiver sync past slot ${waitForSlot}`,
+        timeoutSeconds,
+        0.2,
+      );
+    } catch {
+      this.log.warn(
+        `Archiver did not sync L1 past slot ${waitForSlot} before slot ${this.targetSlot} expired, discarding pipelined work`,
+        { checkpointNumber: this.checkpointNumber },
+      );
+      this.emitPipelineParentCheckpointMismatch('archiver-sync-timeout');
+      return false;
+    }
+  }
+
+  /**
    * Waits for the parent checkpoint to land on L1 before submitting a pipelined checkpoint.
    * Polls until the archiver has synced L1 past the parent's slot, then verifies:
    * - If we built on a proposed parent: it must have landed on L1 with matching hash and valid attestations.
@@ -322,30 +346,31 @@ export class CheckpointProposalJob implements Traceable {
     const parentCheckpointNumber = CheckpointNumber(this.checkpointNumber - 1);
 
     // Wait until archiver has synced L1 past the parent's slot (slotNow)
-    try {
-      await retryUntil(
-        async () => {
-          const syncedSlot = await this.l2BlockSource.getSyncedL2SlotNumber();
-          return syncedSlot !== undefined && syncedSlot >= this.slotNow;
-        },
-        `archiver sync past slot ${this.slotNow}`,
-        this.l1Constants.slotDuration * 2,
-        0.2,
-      );
-    } catch {
-      this.log.warn(`Archiver did not sync L1 past slot ${this.slotNow} before slot expired, discarding checkpoint`, {
-        checkpointNumber: this.checkpointNumber,
-        parentCheckpointNumber,
-      });
-      this.emitPipelineParentCheckpointMismatch('archiver-sync-timeout');
+    if (!(await this.waitForSyncedL2SlotNumber(this.slotNow))) {
       return false;
     }
 
     const tips = await this.l2BlockSource.getL2Tips();
     const checkpointedNumber = tips.checkpointed.checkpoint.number;
 
+    // We built on top of a proposed checkpoint. Verify it landed on L1 as expected.
     if (this.proposedCheckpointData) {
-      // We built on top of a proposed checkpoint. Verify it landed correctly.
+      // After syncing from L1 we see the chain tip has invalid attestations. This means the parent checkpoint was posted
+      // with invalid attestations, or it built on top of something with invalid attestations and didnt invalidate them.
+      // Either way, we thought our parent would be valid, so we have to throw away our work. But at least we'll try and
+      // invalidate on L1 so we clean up the chain for the next proposer. And we'll slash them, but that's handled elsewhere.
+      const validationStatus = await this.l2BlockSource.getPendingChainValidationStatus();
+      if (!validationStatus.valid) {
+        this.log.warn(
+          `Parent checkpoint ${parentCheckpointNumber} has invalid attestations, discarding pipelined work`,
+          { checkpointNumber: this.checkpointNumber, reason: validationStatus.reason },
+        );
+        this.emitPipelineParentCheckpointMismatch('parent-invalid-attestations');
+        await this.enqueueInvalidation(validationStatus);
+        return false;
+      }
+
+      // The pending chain is valid. But did the parent checkpoint land on L1 at all?
       if (checkpointedNumber < parentCheckpointNumber) {
         this.log.warn(`Parent checkpoint ${parentCheckpointNumber} did not land on L1, discarding pipelined work`, {
           checkpointNumber: this.checkpointNumber,
@@ -355,7 +380,7 @@ export class CheckpointProposalJob implements Traceable {
         return false;
       }
 
-      // And verify it's the one we expected.
+      // It landed. But is it the one we were expecting?
       const expectedHash = this.proposedCheckpointData.header.hash().toString();
       if (tips.checkpointed.checkpoint.hash !== expectedHash) {
         this.log.warn(`Parent checkpoint ${parentCheckpointNumber} hash mismatch on L1, discarding pipelined work`, {
@@ -367,28 +392,15 @@ export class CheckpointProposalJob implements Traceable {
         return false;
       }
 
-      // Parent landed and matches. Check attestation validity.
-      const validationStatus = await this.l2BlockSource.getPendingChainValidationStatus();
-      if (!validationStatus.valid) {
-        this.log.warn(
-          `Parent checkpoint ${parentCheckpointNumber} has invalid attestations, discarding pipelined work`,
-          {
-            checkpointNumber: this.checkpointNumber,
-            reason: validationStatus.reason,
-          },
-        );
-        this.emitPipelineParentCheckpointMismatch('parent-invalid-attestations');
-        await this.enqueueInvalidationForParent(validationStatus);
-        return false;
-      }
-
       return true;
     } else {
-      // We didn't see a proposed checkpoint at build time (built on checkpointed parent from two slots ago).
-      // If a new checkpoint for the previous slot appeared on L1 in the meantime, our build assumed the wrong parent.
+      // We didn't see a proposed checkpoint at build time, so we built on checkpointed parent from two slots ago.
+      // But if a new checkpoint for the previous slot appeared on L1 in the meantime, our checkpoint assumed the wrong parent,
+      // so we have to discard our work. This can happen if we're somehow cut off from p2p and fail to see the checkpoint
+      // proposal for the previous slot.
       if (checkpointedNumber > parentCheckpointNumber) {
         this.log.warn(
-          `New checkpoint ${checkpointedNumber} appeared on L1 after we built on parent ${parentCheckpointNumber}, discarding`,
+          `Unexpected checkpoint ${checkpointedNumber} landed on L1 after we built on top of parent ${parentCheckpointNumber}, discarding pipelined work`,
           { checkpointNumber: this.checkpointNumber, checkpointedNumber },
         );
         this.emitPipelineParentCheckpointMismatch('unexpected-parent-appeared');
@@ -410,7 +422,7 @@ export class CheckpointProposalJob implements Traceable {
   }
 
   /** Simulates and enqueues an invalidation request for the invalid parent checkpoint. */
-  private async enqueueInvalidationForParent(validationStatus: ValidateCheckpointResult): Promise<void> {
+  private async enqueueInvalidation(validationStatus: ValidateCheckpointResult): Promise<void> {
     if (this.config.skipInvalidateBlockAsProposer) {
       this.log.warn(`Skipping checkpoint invalidation as proposer due to test configuration`);
       return;
@@ -994,12 +1006,44 @@ export class CheckpointProposalJob implements Traceable {
     return { canStartBuilding: true, availableTxs, minTxs };
   }
 
+  private async getSignedCommitteeAttestations(
+    broadcast: CheckpointProposalBroadcast,
+  ): Promise<{ attestations: CommitteeAttestationsAndSigners; attestationsSignature: Signature } | undefined> {
+    const { proposal, blockProposedAt } = broadcast;
+    this.setStateFn(SequencerState.COLLECTING_ATTESTATIONS, this.targetSlot);
+    const attestations = await this.waitForAttestations(proposal);
+    if (!attestations) {
+      return undefined;
+    }
+    this.checkpointMetrics.recordCheckpointAttestationDelay(this.dateProvider.now() - blockProposedAt);
+
+    // Proposer must sign over the attestations before pushing them to L1
+    const signer = this.proposer ?? this.publisher.getSenderAddress();
+    try {
+      const attestationsSignature = await this.validatorClient.signAttestationsAndSigners(
+        attestations,
+        signer,
+        this.targetSlot,
+        this.checkpointNumber,
+      );
+      return { attestations, attestationsSignature };
+    } catch (err) {
+      if (this.handleHASigningError(err, 'Attestations signature')) {
+        return;
+      }
+      this.log.error(`Error signing attestations for checkpoint proposal at slot ${proposal.slotNumber}`, err);
+      return undefined;
+    }
+  }
+
   /**
    * Waits for enough attestations to be collected via p2p.
    * This is run after all blocks for the checkpoint have been built.
    */
   @trackSpan('CheckpointProposalJob.waitForAttestations')
-  private async waitForAttestations(proposal: CheckpointProposal): Promise<CommitteeAttestationsAndSigners> {
+  private async waitForAttestations(
+    proposal: CheckpointProposal,
+  ): Promise<CommitteeAttestationsAndSigners | undefined> {
     if (this.config.fishermanMode) {
       this.log.debug('Skipping attestation collection in fisherman mode');
       return CommitteeAttestationsAndSigners.empty();
@@ -1073,8 +1117,14 @@ export class CheckpointProposalJob implements Traceable {
     } catch (err) {
       if (err && err instanceof AttestationTimeoutError) {
         collectedAttestationsCount = err.collectedCount;
+        this.log.error(
+          `Timeout while waiting for attestations for checkpoint proposal at slot ${proposal.slotNumber} (collected ${collectedAttestationsCount}/${numberOfRequiredAttestations})`,
+          err,
+        );
+      } else {
+        this.log.error(`Error collecting attestations for checkpoint proposal at slot ${proposal.slotNumber}`, err);
       }
-      throw err;
+      return undefined;
     } finally {
       this.metrics.recordCollectedAttestations(collectedAttestationsCount, collectAttestationsTimer.ms());
     }

--- a/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.ts
+++ b/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.ts
@@ -18,6 +18,7 @@ import { EthAddress } from '@aztec/foundation/eth-address';
 import { Signature } from '@aztec/foundation/eth-signature';
 import { filter } from '@aztec/foundation/iterator';
 import { type Logger, type LoggerBindings, createLogger } from '@aztec/foundation/log';
+import { retryUntil } from '@aztec/foundation/retry';
 import { sleep, sleepUntil } from '@aztec/foundation/sleep';
 import { type DateProvider, Timer } from '@aztec/foundation/timer';
 import { type TypedEventEmitter, isErrorClass, unfreeze } from '@aztec/foundation/types';
@@ -30,6 +31,7 @@ import {
   type L2BlockSink,
   type L2BlockSource,
   MaliciousCommitteeAttestationsAndSigners,
+  type ValidateCheckpointResult,
 } from '@aztec/stdlib/block';
 import { type Checkpoint, type ProposedCheckpointData, validateCheckpoint } from '@aztec/stdlib/checkpoint';
 import { computeQuorum, getSlotStartBuildTimestamp, getTimestampForSlot } from '@aztec/stdlib/epoch-helpers';
@@ -129,7 +131,7 @@ export class CheckpointProposalJob implements Traceable {
     private readonly dateProvider: DateProvider,
     private readonly metrics: SequencerMetrics,
     private readonly checkpointMetrics: CheckpointProposalJobMetricsRecorder,
-    private readonly eventEmitter: TypedEventEmitter<SequencerEvents>,
+    protected readonly eventEmitter: TypedEventEmitter<SequencerEvents>,
     private readonly setStateFn: (state: SequencerState, slot?: SlotNumber) => void,
     public readonly tracer: Tracer,
     bindings?: LoggerBindings,
@@ -209,6 +211,8 @@ export class CheckpointProposalJob implements Traceable {
     votesPromises: Promise<unknown>[],
   ): Promise<void> {
     const { checkpoint, proposal, blockProposedAt } = broadcast;
+    const isPipelining = this.epochCache.isProposerPipeliningEnabled();
+
     try {
       await Promise.all(votesPromises);
 
@@ -234,9 +238,13 @@ export class CheckpointProposalJob implements Traceable {
         throw err;
       }
 
-      // Enqueue the checkpoint for L1 submission
-      await this.enqueueCheckpointForSubmission({ checkpoint, attestations, attestationsSignature });
+      // If pipelining, wait for the previous checkpoint to land on L1 before submitting,
+      // so we can check it matches the proposed checkpoint we used as parent, and has valid attestations.
+      if (!isPipelining || (await this.waitForParentCheckpointOnL1())) {
+        await this.enqueueCheckpointForSubmission({ checkpoint, attestations, attestationsSignature });
+      }
 
+      // Send whatever was enqueued: votes + (propose | invalidation | nothing).
       // Compute the earliest time to submit: pipeline slot start when pipelining, now otherwise.
       const submitAfter = this.epochCache.isProposerPipeliningEnabled()
         ? new Date(Number(getTimestampForSlot(this.targetSlot, this.l1Constants)) * 1000)
@@ -250,7 +258,7 @@ export class CheckpointProposalJob implements Traceable {
         await this.metrics.incFilledSlot(this.publisher.getSenderAddress().toString(), coinbase);
       } else {
         this.eventEmitter.emit('checkpoint-publish-failed', { ...l1Response, slot: this.targetSlot });
-        if (this.epochCache.isProposerPipeliningEnabled()) {
+        if (isPipelining) {
           this.metrics.recordPipelineDiscard();
         }
       }
@@ -301,6 +309,122 @@ export class CheckpointProposalJob implements Traceable {
       txTimeoutAt,
       ...(submissionSimulationOverridesPlan ? { simulationOverridesPlan: submissionSimulationOverridesPlan } : {}),
     });
+  }
+
+  /**
+   * Waits for the parent checkpoint to land on L1 before submitting a pipelined checkpoint.
+   * Polls until the archiver has synced L1 past the parent's slot, then verifies:
+   * - If we built on a proposed parent: it must have landed on L1 with matching hash and valid attestations.
+   * - If we built without a proposed parent: no new checkpoint must have appeared for that slot.
+   * If the parent has invalid attestations, enqueues an invalidation. Returns whether to proceed with the proposal.
+   */
+  protected async waitForParentCheckpointOnL1(): Promise<boolean> {
+    const parentCheckpointNumber = CheckpointNumber(this.checkpointNumber - 1);
+
+    // Wait until archiver has synced L1 past the parent's slot (slotNow)
+    try {
+      await retryUntil(
+        async () => {
+          const syncedSlot = await this.l2BlockSource.getSyncedL2SlotNumber();
+          return syncedSlot !== undefined && syncedSlot >= this.slotNow;
+        },
+        `archiver sync past slot ${this.slotNow}`,
+        this.l1Constants.slotDuration * 2,
+        0.2,
+      );
+    } catch {
+      this.log.warn(`Archiver did not sync L1 past slot ${this.slotNow} before slot expired, discarding checkpoint`, {
+        checkpointNumber: this.checkpointNumber,
+        parentCheckpointNumber,
+      });
+      this.emitPipelineParentCheckpointMismatch('archiver-sync-timeout');
+      return false;
+    }
+
+    const tips = await this.l2BlockSource.getL2Tips();
+    const checkpointedNumber = tips.checkpointed.checkpoint.number;
+
+    if (this.proposedCheckpointData) {
+      // We built on top of a proposed checkpoint. Verify it landed correctly.
+      if (checkpointedNumber < parentCheckpointNumber) {
+        this.log.warn(`Parent checkpoint ${parentCheckpointNumber} did not land on L1, discarding pipelined work`, {
+          checkpointNumber: this.checkpointNumber,
+          checkpointedNumber,
+        });
+        this.emitPipelineParentCheckpointMismatch('parent-not-on-l1');
+        return false;
+      }
+
+      // And verify it's the one we expected.
+      const expectedHash = this.proposedCheckpointData.header.hash().toString();
+      if (tips.checkpointed.checkpoint.hash !== expectedHash) {
+        this.log.warn(`Parent checkpoint ${parentCheckpointNumber} hash mismatch on L1, discarding pipelined work`, {
+          checkpointNumber: this.checkpointNumber,
+          expectedHash,
+          actualHash: tips.checkpointed.checkpoint.hash,
+        });
+        this.emitPipelineParentCheckpointMismatch('parent-hash-mismatch');
+        return false;
+      }
+
+      // Parent landed and matches. Check attestation validity.
+      const validationStatus = await this.l2BlockSource.getPendingChainValidationStatus();
+      if (!validationStatus.valid) {
+        this.log.warn(
+          `Parent checkpoint ${parentCheckpointNumber} has invalid attestations, discarding pipelined work`,
+          {
+            checkpointNumber: this.checkpointNumber,
+            reason: validationStatus.reason,
+          },
+        );
+        this.emitPipelineParentCheckpointMismatch('parent-invalid-attestations');
+        await this.enqueueInvalidationForParent(validationStatus);
+        return false;
+      }
+
+      return true;
+    } else {
+      // We didn't see a proposed checkpoint at build time (built on checkpointed parent from two slots ago).
+      // If a new checkpoint for the previous slot appeared on L1 in the meantime, our build assumed the wrong parent.
+      if (checkpointedNumber > parentCheckpointNumber) {
+        this.log.warn(
+          `New checkpoint ${checkpointedNumber} appeared on L1 after we built on parent ${parentCheckpointNumber}, discarding`,
+          { checkpointNumber: this.checkpointNumber, checkpointedNumber },
+        );
+        this.emitPipelineParentCheckpointMismatch('unexpected-parent-appeared');
+        return false;
+      }
+
+      return true;
+    }
+  }
+
+  /** Emits the checkpoint-parent-mismatch event and records the metric. */
+  private emitPipelineParentCheckpointMismatch(reason: string): void {
+    this.metrics.recordPipelineParentCheckpointMismatch(reason);
+    this.eventEmitter.emit('checkpoint-parent-mismatch', {
+      slot: this.targetSlot,
+      checkpointNumber: this.checkpointNumber,
+      reason,
+    });
+  }
+
+  /** Simulates and enqueues an invalidation request for the invalid parent checkpoint. */
+  private async enqueueInvalidationForParent(validationStatus: ValidateCheckpointResult): Promise<void> {
+    if (this.config.skipInvalidateBlockAsProposer) {
+      this.log.warn(`Skipping checkpoint invalidation as proposer due to test configuration`);
+      return;
+    }
+    const invalidateRequest = await this.publisher.simulateInvalidateCheckpoint(validationStatus);
+    if (invalidateRequest) {
+      const submissionSlotStart = Number(getTimestampForSlot(this.targetSlot, this.l1Constants));
+      const txTimeoutAt = new Date((submissionSlotStart + this.l1Constants.slotDuration) * 1000);
+      this.publisher.enqueueInvalidateCheckpoint(invalidateRequest, { txTimeoutAt });
+    } else {
+      this.log.info(`Invalidation simulation returned undefined, checkpoint may have been removed already`, {
+        checkpointNumber: this.checkpointNumber,
+      });
+    }
   }
 
   @trackSpan('CheckpointProposalJob.proposeCheckpoint', function () {

--- a/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.ts
+++ b/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.ts
@@ -314,8 +314,9 @@ export class CheckpointProposalJob implements Traceable {
   private async waitForSyncedL2SlotNumber(waitForSlot: SlotNumber): Promise<boolean> {
     const targetSlotStart = Number(getTimestampForSlot(this.targetSlot, this.l1Constants));
     const targetSlotEndMs = (targetSlotStart + this.l1Constants.slotDuration) * 1000;
-    // Use a small positive floor to avoid retryUntil treating timeout=0 as "never timeout".
-    const timeoutSeconds = Math.max(0.1, (targetSlotEndMs - this.dateProvider.now()) / 1000);
+    const syncDelayTolerance = this.l1Constants.slotDuration * 1000;
+    const timeoutSeconds = Math.max(0.1, (targetSlotEndMs + syncDelayTolerance - this.dateProvider.now()) / 1000);
+
     try {
       return await retryUntil(
         async () => {

--- a/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.ts
+++ b/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.ts
@@ -314,7 +314,8 @@ export class CheckpointProposalJob implements Traceable {
   private async waitForSyncedL2SlotNumber(waitForSlot: SlotNumber): Promise<boolean> {
     const targetSlotStart = Number(getTimestampForSlot(this.targetSlot, this.l1Constants));
     const targetSlotEndMs = (targetSlotStart + this.l1Constants.slotDuration) * 1000;
-    const timeoutSeconds = Math.max(0, (targetSlotEndMs - this.dateProvider.now()) / 1000);
+    // Use a small positive floor to avoid retryUntil treating timeout=0 as "never timeout".
+    const timeoutSeconds = Math.max(0.1, (targetSlotEndMs - this.dateProvider.now()) / 1000);
     try {
       return await retryUntil(
         async () => {
@@ -330,7 +331,7 @@ export class CheckpointProposalJob implements Traceable {
         `Archiver did not sync L1 past slot ${waitForSlot} before slot ${this.targetSlot} expired, discarding pipelined work`,
         { checkpointNumber: this.checkpointNumber },
       );
-      this.emitPipelineParentCheckpointMismatch('archiver-sync-timeout');
+      this.emitPipelinedCheckpointDiscarded('archiver-sync-timeout');
       return false;
     }
   }
@@ -365,7 +366,7 @@ export class CheckpointProposalJob implements Traceable {
           `Parent checkpoint ${parentCheckpointNumber} has invalid attestations, discarding pipelined work`,
           { checkpointNumber: this.checkpointNumber, reason: validationStatus.reason },
         );
-        this.emitPipelineParentCheckpointMismatch('parent-invalid-attestations');
+        this.emitPipelinedCheckpointDiscarded('parent-invalid-attestations');
         await this.enqueueInvalidation(validationStatus);
         return false;
       }
@@ -376,7 +377,7 @@ export class CheckpointProposalJob implements Traceable {
           checkpointNumber: this.checkpointNumber,
           checkpointedNumber,
         });
-        this.emitPipelineParentCheckpointMismatch('parent-not-on-l1');
+        this.emitPipelinedCheckpointDiscarded('parent-not-on-l1');
         return false;
       }
 
@@ -388,7 +389,7 @@ export class CheckpointProposalJob implements Traceable {
           expectedHash,
           actualHash: tips.checkpointed.checkpoint.hash,
         });
-        this.emitPipelineParentCheckpointMismatch('parent-hash-mismatch');
+        this.emitPipelinedCheckpointDiscarded('parent-hash-mismatch');
         return false;
       }
 
@@ -403,7 +404,7 @@ export class CheckpointProposalJob implements Traceable {
           `Unexpected checkpoint ${checkpointedNumber} landed on L1 after we built on top of parent ${parentCheckpointNumber}, discarding pipelined work`,
           { checkpointNumber: this.checkpointNumber, checkpointedNumber },
         );
-        this.emitPipelineParentCheckpointMismatch('unexpected-parent-appeared');
+        this.emitPipelinedCheckpointDiscarded('unexpected-parent-appeared');
         return false;
       }
 
@@ -411,10 +412,10 @@ export class CheckpointProposalJob implements Traceable {
     }
   }
 
-  /** Emits the checkpoint-parent-mismatch event and records the metric. */
-  private emitPipelineParentCheckpointMismatch(reason: string): void {
+  /** Emits the pipelined-checkpoint-discarded event and records the metric. */
+  private emitPipelinedCheckpointDiscarded(reason: string): void {
     this.metrics.recordPipelineParentCheckpointMismatch(reason);
-    this.eventEmitter.emit('checkpoint-parent-mismatch', {
+    this.eventEmitter.emit('pipelined-checkpoint-discarded', {
       slot: this.targetSlot,
       checkpointNumber: this.checkpointNumber,
       reason,

--- a/yarn-project/sequencer-client/src/sequencer/events.ts
+++ b/yarn-project/sequencer-client/src/sequencer/events.ts
@@ -24,7 +24,7 @@ export type SequencerEvents = {
   }) => void;
   ['checkpoint-published']: (args: { checkpoint: CheckpointNumber; slot: SlotNumber }) => void;
   ['checkpoint-error']: (args: { error: Error }) => void;
-  ['checkpoint-parent-mismatch']: (args: {
+  ['pipelined-checkpoint-discarded']: (args: {
     slot: SlotNumber;
     checkpointNumber: CheckpointNumber;
     reason: string;

--- a/yarn-project/sequencer-client/src/sequencer/events.ts
+++ b/yarn-project/sequencer-client/src/sequencer/events.ts
@@ -24,4 +24,9 @@ export type SequencerEvents = {
   }) => void;
   ['checkpoint-published']: (args: { checkpoint: CheckpointNumber; slot: SlotNumber }) => void;
   ['checkpoint-error']: (args: { error: Error }) => void;
+  ['checkpoint-parent-mismatch']: (args: {
+    slot: SlotNumber;
+    checkpointNumber: CheckpointNumber;
+    reason: string;
+  }) => void;
 };

--- a/yarn-project/sequencer-client/src/sequencer/metrics.ts
+++ b/yarn-project/sequencer-client/src/sequencer/metrics.ts
@@ -46,6 +46,7 @@ export class SequencerMetrics {
   private slashingAttempts: UpDownCounter;
   private pipelineDepth: Gauge;
   private pipelineDiscards: UpDownCounter;
+  private pipelineParentCheckpointMismatches: UpDownCounter;
 
   // Fisherman fee analysis metrics
   private fishermanWouldBeIncluded: UpDownCounter;
@@ -141,6 +142,19 @@ export class SequencerMetrics {
 
     this.pipelineDepth = this.meter.createGauge(Metrics.SEQUENCER_PIPELINE_DEPTH);
     this.pipelineDiscards = createUpDownCounterWithDefault(this.meter, Metrics.SEQUENCER_PIPELINE_DISCARDS_COUNT);
+    this.pipelineParentCheckpointMismatches = createUpDownCounterWithDefault(
+      this.meter,
+      Metrics.SEQUENCER_PIPELINE_PARENT_CHECKPOINT_MISMATCH_COUNT,
+      {
+        [Attributes.ERROR_TYPE]: [
+          'archiver-sync-timeout',
+          'parent-not-on-l1',
+          'parent-hash-mismatch',
+          'parent-invalid-attestations',
+          'unexpected-parent-appeared',
+        ],
+      },
+    );
     this.pipelineDepth.record(0);
 
     // Fisherman fee analysis metrics
@@ -244,6 +258,12 @@ export class SequencerMetrics {
 
   recordPipelineDiscard(count = 1) {
     this.pipelineDiscards.add(count);
+  }
+
+  recordPipelineParentCheckpointMismatch(reason: string) {
+    this.pipelineParentCheckpointMismatches.add(1, {
+      [Attributes.ERROR_TYPE]: reason,
+    });
   }
 
   incOpenSlot(slot: SlotNumber, proposer: string) {

--- a/yarn-project/telemetry-client/src/metrics.ts
+++ b/yarn-project/telemetry-client/src/metrics.ts
@@ -545,6 +545,11 @@ export const SEQUENCER_PIPELINE_DISCARDS_COUNT: MetricDefinition = {
   description: 'The number of times a pipeline was discarded',
   valueType: ValueType.INT,
 };
+export const SEQUENCER_PIPELINE_PARENT_CHECKPOINT_MISMATCH_COUNT: MetricDefinition = {
+  name: 'aztec.sequencer.pipeline.parent_checkpoint_mismatch_count',
+  description: 'The number of times a pipelined checkpoint was discarded because the parent did not match expectations',
+  valueType: ValueType.INT,
+};
 
 // Fisherman fee analysis metrics
 export const FISHERMAN_FEE_ANALYSIS_WOULD_BE_INCLUDED: MetricDefinition = {


### PR DESCRIPTION
## Motivation

With pipelining enabled, the sequencer optimistically builds a checkpoint on top of a proposed parent. If that parent checkpoint lands on L1 with invalid attestations, the pipelined checkpoint was never invalidating it — the invalidation was cleared at build time under the assumption the parent would handle it.

## Approach

At submission time (after the pipelining sleep), the sequencer now waits for the parent checkpoint to land on L1, then verifies it matches expectations: correct hash, valid attestations, and no unexpected checkpoints appeared. If the parent is invalid, the pipelined work is discarded and an invalidation is enqueued instead. The `skipInvalidateBlockAsProposer` config is respected so the committee member fallback path still works.

## Changes

- **sequencer-client (checkpoint_proposal_job)**: Restructured `waitForAttestationsAndEnqueueSubmissionAsync` to defer `enqueueCheckpointForSubmission` until after parent validation when pipelining. Added `waitForParentCheckpointOnL1` which polls the archiver and checks 5 failure conditions: archiver sync timeout, parent not on L1, parent hash mismatch, parent invalid attestations, unexpected parent appeared. Added `enqueueInvalidationForParent` helper that respects `skipInvalidateBlockAsProposer`.
- **sequencer-client (events)**: New `checkpoint-parent-mismatch` event with slot, checkpoint number, and reason.
- **sequencer-client (metrics)**: New `recordPipelineParentCheckpointMismatch` counter with reason attribute.
- **telemetry-client**: New `SEQUENCER_PIPELINE_PARENT_CHECKPOINT_MISMATCH_COUNT` metric definition.
- **sequencer-client (tests)**: 8 new unit tests covering all failure reasons and success paths via `executeAndAwait`, asserting publisher actions and emitted events.
- **end-to-end**: Enabled pipelining (`enableProposerPipelining: true, inboxLag: 2`) in `epochs_invalidate_block` tests. Updated `proposer invalidates multiple checkpoints` test to verify the invalidation happens promptly (proposer path, not committee fallback).

Fixes A-909
Fixes A-921