### PR TITLE
fix: install verdaccio to local prefix to avoid EACCES

### DIFF
--- a/aztec-up/bootstrap.sh
+++ b/aztec-up/bootstrap.sh
@@ -46,7 +46,9 @@ EOF
   echo 'testuser:$2y$05$R1tRwE1mM3iT1dJ8hG16fOCTq7tFhFJ0IWrZ1bMCGJ6W9unQF3H3K' > /tmp/htpasswd
 
   if ! command -v verdaccio &>/dev/null; then
-    npm i -g verdaccio
+    # Install to a local prefix to avoid requiring root for global npm install.
+    npm i -g --prefix /tmp/verdaccio-pkg verdaccio
+    export PATH="/tmp/verdaccio-pkg/bin:$PATH"
   fi
 
   local base_hash=$(cache_content_hash ^aztec-up/Dockerfile.base)

--- a/boxes/boxes/vanilla/contracts/src/test/first.nr
+++ b/boxes/boxes/vanilla/contracts/src/test/first.nr
@@ -6,7 +6,7 @@ use crate::PrivateVoting::ElectionId;
 
 #[test]
 unconstrained fn test_initializer() {
-    let (mut env, voting_contract_address, admin) = utils::setup();
+    let (env, voting_contract_address, admin) = utils::setup();
 
     env.public_context_at(voting_contract_address, |context| {
         let current_admin = context.storage_read(PrivateVoting::storage_layout().admin.slot);
@@ -16,7 +16,7 @@ unconstrained fn test_initializer() {
 
 #[test]
 unconstrained fn test_check_vote_status() {
-    let (mut env, voting_contract_address, _) = utils::setup();
+    let (env, voting_contract_address, _) = utils::setup();
 
     env.public_context_at(voting_contract_address, |context| {
         let vote_ended = context.storage_read(PrivateVoting::storage_layout().vote_ended.slot);


### PR DESCRIPTION
This didn't make the whole bootstrap fail but it resulted in mess in the logs.

Pointed at `next` such that other teams don't waste time on fixing this.

## Summary
- `npm i -g verdaccio` in `aztec-up/bootstrap.sh` fails with `EACCES` when the user doesn't have root permissions to write to `/usr/lib/node_modules/`.
- Fix: install to a local `--prefix` (`/tmp/verdaccio-pkg`) and add its `bin/` to `PATH`.