### PR TITLE
fix: remove uintx UB ptr trick

### DIFF
--- a/barretenberg/cpp/src/barretenberg/numeric/uintx/uintx.hpp
+++ b/barretenberg/cpp/src/barretenberg/numeric/uintx/uintx.hpp
@@ -271,13 +271,7 @@ template <class base_uint> class uintx {
     base_uint lo;
     base_uint hi;
 
-    // `modulus` is passed as a pointer NTTP rather than a class-type value NTTP. The latter
-    // would cause Clang to materialize a template parameter object in `.rodata` at the section's
-    // natural alignment (16 bytes), which under-aligns an `alignas(32)` type and is UB under
-    // UBSan's alignment check. A pointer NTTP has no synthesized storage; it just names an
-    // existing static object, whose `alignas(32)` is honored normally. We therefore pass `&X` where `X` is a named
-    // `static constexpr base_uint` (see uses in `divmod`).
-    template <const base_uint* modulus_ptr> std::pair<uintx, uintx> barrett_reduction() const;
+    template <base_uint modulus> std::pair<uintx, uintx> barrett_reduction() const;
 
     // This only works (and is only used) for uint256_t
     std::pair<uintx, uintx> divmod(const uintx& b) const;

--- a/barretenberg/cpp/src/barretenberg/numeric/uintx/uintx.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/numeric/uintx/uintx.test.cpp
@@ -8,10 +8,9 @@ using namespace bb;
 
 // Explicit instantiation of barrett_reduction for the test-only 1024-bit modulus.
 namespace bb::numeric {
-static constexpr uint512_t TEST_MODULUS(
-    uint256_t{ "0x04689e957a1242c84a50189c6d96cadca602072d09eac1013b5458a2275d69b1" },
-    uint256_t{ "0x0925c4b8763cbf9c599a6f7c0348d21cb00b85511637560626edfa5c34c6b38d" });
-template std::pair<uint1024_t, uint1024_t> uintx<uint512_t>::barrett_reduction<&TEST_MODULUS>() const;
+constexpr uint512_t TEST_MODULUS(uint256_t{ "0x04689e957a1242c84a50189c6d96cadca602072d09eac1013b5458a2275d69b1" },
+                                 uint256_t{ "0x0925c4b8763cbf9c599a6f7c0348d21cb00b85511637560626edfa5c34c6b38d" });
+template std::pair<uint1024_t, uint1024_t> uintx<uint512_t>::barrett_reduction<TEST_MODULUS>() const;
 } // namespace bb::numeric
 
 namespace {
@@ -26,9 +25,9 @@ TEST(uintx, BarrettReduction512)
     static constexpr uint64_t modulus_1 = 0x97816a916871ca8dUL;
     static constexpr uint64_t modulus_2 = 0xb85045b68181585dUL;
     static constexpr uint64_t modulus_3 = 0x30644e72e131a029UL;
-    static constexpr uint256_t modulus(modulus_0, modulus_1, modulus_2, modulus_3);
+    constexpr uint256_t modulus(modulus_0, modulus_1, modulus_2, modulus_3);
 
-    const auto [quotient_result, remainder_result] = x.barrett_reduction<&modulus>();
+    const auto [quotient_result, remainder_result] = x.barrett_reduction<modulus>();
     const auto [quotient_expected, remainder_expected] = x.divmod_base(uint512_t(modulus));
     EXPECT_EQ(quotient_result, quotient_expected);
     EXPECT_EQ(remainder_result, remainder_expected);
@@ -38,11 +37,11 @@ TEST(uintx, BarrettReduction1024)
 {
     uint1024_t x = engine.get_random_uint1024();
 
-    static constexpr uint256_t modulus_lo{ "0x04689e957a1242c84a50189c6d96cadca602072d09eac1013b5458a2275d69b1" };
-    static constexpr uint256_t modulus_hi{ "0x0925c4b8763cbf9c599a6f7c0348d21cb00b85511637560626edfa5c34c6b38d" };
-    static constexpr uint512_t modulus{ modulus_lo, modulus_hi };
+    constexpr uint256_t modulus_lo{ "0x04689e957a1242c84a50189c6d96cadca602072d09eac1013b5458a2275d69b1" };
+    constexpr uint256_t modulus_hi{ "0x0925c4b8763cbf9c599a6f7c0348d21cb00b85511637560626edfa5c34c6b38d" };
+    constexpr uint512_t modulus{ modulus_lo, modulus_hi };
 
-    const auto [quotient_result, remainder_result] = x.barrett_reduction<&modulus>();
+    const auto [quotient_result, remainder_result] = x.barrett_reduction<modulus>();
     const auto [quotient_expected, remainder_expected] = x.divmod_base(uint1024_t(modulus));
     EXPECT_EQ(quotient_result, quotient_expected);
     EXPECT_EQ(remainder_result, remainder_expected);
@@ -337,14 +336,14 @@ TEST(uintx, Slice)
 TEST(uintx, BarrettReductionRegression)
 {
     // Test specific modulus and self values that may cause issues
-    static constexpr uint256_t modulus{ "0xffffffff00000001000000000000000000000000ffffffffffffffffffffffff" };
+    constexpr uint256_t modulus{ "0xffffffff00000001000000000000000000000000ffffffffffffffffffffffff" };
 
     // Test case 1: self = 0xffffffff0000000000000000000000000000000000000000003a000000000000
     // This is a 256-bit value, so we need to construct it as a single uint256_t
     constexpr uint256_t self_value{ "0xffffffff0000000000000000000000000000000000000000003a000000000000" };
     uint512_t self(self_value);
     self = self << 256;
-    const auto [quotient_result, remainder_result] = self.barrett_reduction<&modulus>();
+    const auto [quotient_result, remainder_result] = self.barrett_reduction<modulus>();
     const auto [quotient_expected, remainder_expected] = self.divmod_base(uint512_t(modulus));
     EXPECT_EQ(quotient_result, quotient_expected);
     EXPECT_EQ(remainder_result, remainder_expected);

--- a/barretenberg/cpp/src/barretenberg/numeric/uintx/uintx_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/numeric/uintx/uintx_impl.hpp
@@ -236,26 +236,21 @@ template <class base_uint> bool uintx<base_uint>::operator<=(const uintx& other)
 template <class base_uint> std::pair<uintx<base_uint>, uintx<base_uint>> uintx<base_uint>::divmod(const uintx& b) const
 
 {
-    // Barrett-reduction fast paths apply only when base_uint == uint256_t; for larger uintx
-    // instantiations a 256-bit `b` can never equal a 1024-bit-or-wider dividend's modulus.
-    if constexpr (std::is_same_v<base_uint, uint256_t>) {
-        // `static` is required so that `&X` below is a valid pointer NTTP for barrett_reduction.
-        static constexpr uint256_t BN254FQMODULUS256 =
-            uint256_t(0x3C208C16D87CFD47UL, 0x97816a916871ca8dUL, 0xb85045b68181585dUL, 0x30644e72e131a029UL);
-        static constexpr uint256_t SECP256K1FQMODULUS256 =
-            uint256_t(0xFFFFFFFEFFFFFC2FULL, 0xFFFFFFFFFFFFFFFFULL, 0xFFFFFFFFFFFFFFFFULL, 0xFFFFFFFFFFFFFFFFULL);
-        static constexpr uint256_t SECP256R1FQMODULUS256 =
-            uint256_t(0xFFFFFFFFFFFFFFFFULL, 0x00000000FFFFFFFFULL, 0x0000000000000000ULL, 0xFFFFFFFF00000001ULL);
+    constexpr uint256_t BN254FQMODULUS256 =
+        uint256_t(0x3C208C16D87CFD47UL, 0x97816a916871ca8dUL, 0xb85045b68181585dUL, 0x30644e72e131a029UL);
+    constexpr uint256_t SECP256K1FQMODULUS256 =
+        uint256_t(0xFFFFFFFEFFFFFC2FULL, 0xFFFFFFFFFFFFFFFFULL, 0xFFFFFFFFFFFFFFFFULL, 0xFFFFFFFFFFFFFFFFULL);
+    constexpr uint256_t SECP256R1FQMODULUS256 =
+        uint256_t(0xFFFFFFFFFFFFFFFFULL, 0x00000000FFFFFFFFULL, 0x0000000000000000ULL, 0xFFFFFFFF00000001ULL);
 
-        if (b == uintx(BN254FQMODULUS256)) {
-            return (*this).template barrett_reduction<&BN254FQMODULUS256>();
-        }
-        if (b == uintx(SECP256K1FQMODULUS256)) {
-            return (*this).template barrett_reduction<&SECP256K1FQMODULUS256>();
-        }
-        if (b == uintx(SECP256R1FQMODULUS256)) {
-            return (*this).template barrett_reduction<&SECP256R1FQMODULUS256>();
-        }
+    if (b == uintx(BN254FQMODULUS256)) {
+        return (*this).template barrett_reduction<BN254FQMODULUS256>();
+    }
+    if (b == uintx(SECP256K1FQMODULUS256)) {
+        return (*this).template barrett_reduction<SECP256K1FQMODULUS256>();
+    }
+    if (b == uintx(SECP256R1FQMODULUS256)) {
+        return (*this).template barrett_reduction<SECP256R1FQMODULUS256>();
     }
 
     return divmod_base(b);
@@ -273,11 +268,9 @@ template <class base_uint> std::pair<uintx<base_uint>, uintx<base_uint>> uintx<b
  * @return std::pair<uintx<base_uint>, uintx<base_uint>>
  */
 template <class base_uint>
-template <const base_uint* modulus_ptr>
+template <base_uint modulus>
 std::pair<uintx<base_uint>, uintx<base_uint>> uintx<base_uint>::barrett_reduction() const
 {
-    const base_uint& modulus = *modulus_ptr;
-
     // N.B. k could be modulus.get_msb() + 1 if we have strong bounds on the max value of (*self)
     //      (a smaller k would allow us to fit `redc_parameter` into `base_uint` and not `uintx`)
     constexpr size_t k = base_uint::length() - 1;


### PR DESCRIPTION
Remove a "trick" that I introduced to try to remove a benign instance of UB from uintx since it resulted in a massive slowdown in circuit construction.