### PR TITLE
refactor(pxe): rename sideEffectCounter to initialSideEffectCounter

### DIFF
--- a/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution_oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution_oracle.ts
@@ -81,7 +81,7 @@ export class PrivateExecutionOracle extends UtilityExecutionOracle implements IP
   private readonly taggingIndexCache: ExecutionTaggingIndexCache;
   private readonly senderTaggingStore: SenderTaggingStore;
   private totalPublicCalldataCount: number;
-  protected sideEffectCounter: number;
+  private readonly initialSideEffectCounter: number;
   private senderForTags?: AztecAddress;
   private readonly simulator?: CircuitSimulator;
 
@@ -100,13 +100,18 @@ export class PrivateExecutionOracle extends UtilityExecutionOracle implements IP
     this.taggingIndexCache = args.taggingIndexCache;
     this.senderTaggingStore = args.senderTaggingStore;
     this.totalPublicCalldataCount = args.totalPublicCalldataCount ?? 0;
-    this.sideEffectCounter = args.sideEffectCounter ?? 0;
+    this.initialSideEffectCounter = args.sideEffectCounter ?? 0;
     this.senderForTags = args.senderForTags;
     this.simulator = args.simulator;
   }
 
   public getPrivateContextInputs(): PrivateContextInputs {
-    return new PrivateContextInputs(this.callContext, this.anchorBlockHeader, this.txContext, this.sideEffectCounter);
+    return new PrivateContextInputs(
+      this.callContext,
+      this.anchorBlockHeader,
+      this.txContext,
+      this.initialSideEffectCounter,
+    );
   }
 
   // We still need this function until we can get user-defined ordering of structs for fn arguments


### PR DESCRIPTION
## Summary

- An AI audit flagged that the parent oracle's `sideEffectCounter` becomes stale after nested private function calls, since the child's counter consumption is never reflected back. In practice this is harmless because the field is only read once at initialization to build `PrivateContextInputs`, and the Noir VM owns the actual counter throughout execution.
- Renamed to `initialSideEffectCounter` and made it `private readonly`, making it clear that it's just the initial counter and preventing future misuse.


Fixes https://github.com/AztecProtocol/aztec-claude/issues/330