### PR TITLE
fix(aztec): respect TEST_ACCOUNTS env var in local network mode

### DIFF
--- a/yarn-project/aztec/src/cli/aztec_start_action.ts
+++ b/yarn-project/aztec/src/cli/aztec_start_action.ts
@@ -27,8 +27,7 @@ export async function aztecStart(options: any, userLog: LogFn, debugLogger: Logg
   let config: ChainConfig | undefined = undefined;
 
   if (options.localNetwork) {
-    const localNetwork = extractNamespacedOptions(options, 'local-network');
-    localNetwork.testAccounts = true;
+    const localNetwork = extractNamespacedOptions(options, 'localNetwork');
     userLog(`${splash}\n${github}\n\n`);
     userLog(`Setting up Aztec local network ${packageVersion ?? 'unknown'}, please stand by...`);
 

--- a/yarn-project/aztec/src/cli/aztec_start_options.test.ts
+++ b/yarn-project/aztec/src/cli/aztec_start_options.test.ts
@@ -94,6 +94,21 @@ describe('aztec_start_options commander integration', () => {
     expect(typeof opts.port).toBe('number');
   });
 
+  it('respects TEST_ACCOUNTS env var for local network', () => {
+    process.env.TEST_ACCOUNTS = 'false';
+    const cmd = buildCommandWith(['LOCAL_NETWORK']);
+    cmd.parse(['node', 'cli']);
+    const opts = cmd.opts();
+    expect(opts['localNetwork.testAccounts']).toBe(false);
+  });
+
+  it('defaults testAccounts to true for local network', () => {
+    const cmd = buildCommandWith(['LOCAL_NETWORK']);
+    cmd.parse(['node', 'cli']);
+    const opts = cmd.opts();
+    expect(opts['localNetwork.testAccounts']).toBe(true);
+  });
+
   it('parses optional boolean flag values', () => {
     const cmd = buildCommandWith(['P2P SUBSYSTEM']);
 

--- a/yarn-project/aztec/src/cli/aztec_start_options.ts
+++ b/yarn-project/aztec/src/cli/aztec_start_options.ts
@@ -129,6 +129,12 @@ export const aztecStartOptions: { [key: string]: AztecStartOption[] } = {
       defaultValue: DefaultMnemonic,
       env: 'MNEMONIC',
     },
+    {
+      flag: '--local-network.testAccounts',
+      description: 'Deploy test accounts on local network start',
+      env: 'TEST_ACCOUNTS',
+      ...booleanConfigHelper(true),
+    },
   ],
   API: [
     {


### PR DESCRIPTION
## Summary

- Fixes `TEST_ACCOUNTS=false` being ignored when running `aztec start --local-network` (hardcoded to `true`)
- Adds `--local-network.testAccounts` CLI option bound to `TEST_ACCOUNTS` env var (defaults to `true` for backwards compatibility)
- Fixes `extractNamespacedOptions` namespace mismatch — Commander camelCases `--local-network.*` to `localNetwork.*`, but the extraction used the `local-network.` prefix (also fixes `--local-network.l1Mnemonic` which was silently broken)

Closes https://github.com/AztecProtocol/aztec-packages/issues/21563

## Test plan

- Added 2 unit tests verifying `TEST_ACCOUNTS=false` env var is respected and the default is `true`
- All 12 tests in `aztec_start_options.test.ts` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)