### PR TITLE
Split AVM fuzzers into dedicated container

### DIFF
--- a/.github/workflows/fuzzing-docker-avm-build-private.yml
+++ b/.github/workflows/fuzzing-docker-avm-build-private.yml
@@ -56,6 +56,18 @@ jobs:
             org.opencontainers.image.revision.branch=${{ github.ref_name }}
             com.aztec.visibility=private
 
+      - name: Install oras
+        uses: oras-project/setup-oras@22ce207df3b08e061f537244349aac6ae1d214f6 # v1.2.4
+
+      - name: Extract and attach fuzzer manifest
+        run: |
+          docker create --name manifest-extract ghcr.io/aztecprotocol/avm-fuzzing-container-private:${{ github.sha }}
+          docker cp manifest-extract:/home/fuzzer/fuzzer_manifest.json ./fuzzer_manifest.json
+          docker rm manifest-extract
+          oras attach ghcr.io/aztecprotocol/avm-fuzzing-container-private@${{ steps.build.outputs.digest }} \
+            --artifact-type application/vnd.contfuzzer.manifest+json \
+            fuzzer_manifest.json
+
       - name: Install cosign
         uses: sigstore/cosign-installer@ba7bc0a3fef59531c69a25acd34668d6d3fe6f22 # v4.1.0
         with:

--- a/.github/workflows/fuzzing-docker-avm-build.yml
+++ b/.github/workflows/fuzzing-docker-avm-build.yml
@@ -50,6 +50,18 @@ jobs:
             org.opencontainers.image.revision.branch=${{ github.ref_name }}
             com.aztec.visibility=public
 
+      - name: Install oras
+        uses: oras-project/setup-oras@22ce207df3b08e061f537244349aac6ae1d214f6 # v1.2.4
+
+      - name: Extract and attach fuzzer manifest
+        run: |
+          docker create --name manifest-extract ghcr.io/aztecprotocol/avm-fuzzing-container:${{ github.sha }}
+          docker cp manifest-extract:/home/fuzzer/fuzzer_manifest.json ./fuzzer_manifest.json
+          docker rm manifest-extract
+          oras attach ghcr.io/aztecprotocol/avm-fuzzing-container@${{ steps.build.outputs.digest }} \
+            --artifact-type application/vnd.contfuzzer.manifest+json \
+            fuzzer_manifest.json
+
       - name: Install cosign
         uses: sigstore/cosign-installer@ba7bc0a3fef59531c69a25acd34668d6d3fe6f22 # v4.1.0
         with:

--- a/barretenberg/cpp/CMakePresets.json
+++ b/barretenberg/cpp/CMakePresets.json
@@ -255,7 +255,8 @@
         "ENABLE_ASAN": "ON",
         "DISABLE_ASM": "ON",
         "CMAKE_BUILD_TYPE": "RelWithAssert",
-        "MULTITHREADING": "OFF"
+        "MULTITHREADING": "OFF",
+        "FUZZER_PRESET_NAME": "${presetName}"
       }
     },
     {

--- a/barretenberg/cpp/cmake/module.cmake
+++ b/barretenberg/cpp/cmake/module.cmake
@@ -245,6 +245,12 @@ function(barretenberg_module_with_sources MODULE_NAME)
             set_property(GLOBAL APPEND PROPERTY BB_FUZZER_MANIFEST_ENTRIES
                 "${MODULE_NAME}_${FUZZER_NAME_STEM}_fuzzer|${_source_path}")
 
+            # Track AVM-specific fuzzer targets for the avm_fuzzers umbrella target
+            if(_source_path MATCHES "^avm_fuzzer")
+                set_property(GLOBAL APPEND PROPERTY BB_AVM_FUZZER_TARGETS
+                    ${MODULE_NAME}_${FUZZER_NAME_STEM}_fuzzer)
+            endif()
+
             if(ENABLE_STACKTRACES)
                 target_link_libraries(
                     ${MODULE_NAME}_${FUZZER_NAME_STEM}_fuzzer

--- a/barretenberg/cpp/scripts/flatten_and_manifest.py
+++ b/barretenberg/cpp/scripts/flatten_and_manifest.py
@@ -109,8 +109,10 @@ def main():
         if i == 0:
             base_names = set(copied)
 
-        # See docstring above — only the AVM preset needs dedup.
-        dedup = preset == "fuzzing-avm" and bool(base_names)
+        # See docstring above — only the AVM preset needs dedup, and only when
+        # a prior (non-AVM) base manifest established the base_names set.
+        # When fuzzing-avm is the first/only manifest, skip dedup entirely.
+        dedup = preset == "fuzzing-avm" and i > 0 and bool(base_names)
 
         # Use preset-specific resources if provided, otherwise global defaults
         res = preset_res.get(preset, {"cpus": args.cpus, "memory_gb": args.memory_gb})

--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/CMakeLists.txt
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/CMakeLists.txt
@@ -42,4 +42,14 @@ if(FUZZING_AVM)
         add_executable(avm_tx_corpus_analyzer avm_tx_corpus_analyzer.cpp)
         target_link_libraries(avm_tx_corpus_analyzer avm_fuzzer)
     endif()
+
+endif()
+
+# Umbrella target: `cmake --build <dir> --target avm_fuzzers` builds only
+# AVM-specific fuzzers without the collateral base fuzzers (stdlib_*, etc.)
+# that the fuzzing-avm preset also compiles. Targets are registered by
+# module.cmake into BB_AVM_FUZZER_TARGETS when their source is under avm_fuzzer/.
+if(FUZZING AND FUZZING_AVM)
+    get_property(_avm_targets GLOBAL PROPERTY BB_AVM_FUZZER_TARGETS)
+    add_custom_target(avm_fuzzers DEPENDS ${_avm_targets} fuzzer_manifest)
 endif()

--- a/container-builds/avm-fuzzing-container/run.sh
+++ b/container-builds/avm-fuzzing-container/run.sh
@@ -20,7 +20,7 @@ show_help() {
 	echo ""
 	echo "Options:"
 	echo "  -t, --target <name>     Target name (from /targets/), e.g. harness_alu_fuzzer_avm"
-	echo "  -m, --mode <mode>       fuzz | coverage | minimize | reproduce | regress (default: $mode)"
+	echo "  --mode <mode>           fuzz | coverage | minimize | reproduce | regress (default: $mode)"
 	echo "  --timeout <secs>        Fuzzing timeout in seconds (default: $timeout)"
 	echo "  -c, --cpus <n>          CPU allocation (default: $cpus)"
 	echo "  --mem <size>            Memory limit (default: $mem)"
@@ -39,7 +39,7 @@ list_targets=0
 while [[ $# -gt 0 ]]; do
 	case "$1" in
 	-t | --target)  target="$2";    shift 2 ;;
-	-m | --mode)    mode="$2";      shift 2 ;;
+	--mode)         mode="$2";      shift 2 ;;
 	--timeout)      timeout="$2";   shift 2 ;;
 	-c | --cpus)    cpus="$2"; jobs_="$cpus"; shift 2 ;;
 	--mem)          mem="$2";       shift 2 ;;

--- a/container-builds/avm-fuzzing-container/run.sh
+++ b/container-builds/avm-fuzzing-container/run.sh
@@ -1,117 +1,100 @@
 #!/usr/bin/env bash
+# Local runner for the AVM fuzzing container.
+# Builds the image and runs a target using the ContFuzzer v2 env-var interface.
 
 set -euo pipefail
 IFS=$'\n\t'
 
-timeout='2592000' # 1 month
+target=''
+mode='fuzz'
+timeout='2592000'
 cpus='1'
-mem="8G"
+mem='8G'
 jobs_="$cpus"
 workers='1'
+rss_limit='2048'
 max_len='8192'
 
 show_help() {
-    echo "Usage: $0 [options]"
-    echo ""
-    echo "Options:"
-    echo "  -t, --timeout <timeout>     Set the maximum total time for fuzzing in seconds (default: $timeout - 1 month)"
-    echo "  -c, --cpus <cpus>           Set the amount of CPUs for container to use (default: $cpus)"
-    echo "  --mem <memory>              Set the amount of memory for container to use (default: $mem)"
-    echo "  -j, --jobs <N>              Set the amount of processes to run (default: $jobs_)"
-    echo "  -w, --workers <N>           Set the amount of subprocesses per job (default: $workers)"
-    echo "  -m, --max-len <N>           Set the maximum input length in bytes (default: $max_len)"
-    echo "  -h, --help                  Display this help and exit"
-    echo "  --                          Pass additional arguments to the fuzzer"
-    echo ""
-    echo "This script builds and runs the AVM TX fuzzer container."
+	echo "Usage: $0 [options]"
+	echo ""
+	echo "Options:"
+	echo "  -t, --target <name>     Target name (from /targets/), e.g. harness_alu_fuzzer_avm"
+	echo "  -m, --mode <mode>       fuzz | coverage | minimize | reproduce | regress (default: $mode)"
+	echo "  --timeout <secs>        Fuzzing timeout in seconds (default: $timeout)"
+	echo "  -c, --cpus <n>          CPU allocation (default: $cpus)"
+	echo "  --mem <size>            Memory limit (default: $mem)"
+	echo "  -j, --jobs <n>          Parallelism (default: $jobs_)"
+	echo "  -w, --workers <n>       Subprocesses per job (default: $workers)"
+	echo "  -r, --rss-limit <MB>    RSS limit in MB (default: $rss_limit)"
+	echo "  --max-len <N>           Max input length in bytes (default: $max_len)"
+	echo "  --list-targets          List available targets and exit"
+	echo "  -h, --help              Show this help"
+	echo ""
+	echo "AVM fuzzers default to --cpus 1 --mem 8G due to LMDB single-writer constraint."
 }
 
-EXTRA_ARGS=()
+list_targets=0
 
 while [[ $# -gt 0 ]]; do
-    case "$1" in
-    -t | --timeout)
-        timeout="$2"
-        shift 2
-        ;;
-    -w | --workers)
-        workers="$2"
-        shift 2
-        ;;
-    -j | --jobs)
-        jobs_="$2"
-        shift 2
-        ;;
-    -c | --cpus)
-        cpus="$2"
-        shift 2
-        ;;
-    --mem)
-        mem="$2"
-        shift 2
-        ;;
-    -m | --max-len)
-        max_len="$2"
-        shift 2
-        ;;
-    -h | --help)
-        show_help
-        exit 0
-        ;;
-    --)
-        shift
-        EXTRA_ARGS=("$@")
-        break
-        ;;
-    -*)
-        echo "Error: Unsupported flag $1" >&2
-        exit 1
-        ;;
-    *)
-        break
-        ;;
-    esac
+	case "$1" in
+	-t | --target)  target="$2";    shift 2 ;;
+	-m | --mode)    mode="$2";      shift 2 ;;
+	--timeout)      timeout="$2";   shift 2 ;;
+	-c | --cpus)    cpus="$2"; jobs_="$cpus"; shift 2 ;;
+	--mem)          mem="$2";       shift 2 ;;
+	-j | --jobs)    jobs_="$2";     shift 2 ;;
+	-w | --workers) workers="$2";   shift 2 ;;
+	-r | --rss-limit) rss_limit="$2"; shift 2 ;;
+	--max-len) max_len="$2"; shift 2 ;;
+	--list-targets) list_targets=1; shift ;;
+	-h | --help)    show_help; exit 0 ;;
+	*)              echo "Unknown flag: $1" >&2; exit 1 ;;
+	esac
 done
 
-image_name=avm-tx-fuzzer
+image_name=avm-fuzzing
 
 # Get the directory where this script is located
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 echo "Building container image: $image_name"
-docker build -t "$image_name":latest "$SCRIPT_DIR/src"
+docker build "$SCRIPT_DIR/src" -t "$image_name":latest
 
-mkdir -p crash-reports output corpus artifacts
+if [[ "$list_targets" -eq 1 ]]; then
+	docker run --rm --entrypoint ls "$image_name" /targets/
+	exit 0
+fi
+
+if [ -z "$target" ]; then
+	echo "err: No target specified. Use --target <name> or --list-targets" >&2
+	show_help
+	exit 1
+fi
+
+mkdir -p corpus crashes output
 
 docker_args=(
-    --rm
-    --user root
-    -v "$(pwd)/crash-reports:/home/fuzzer/crash-reports:rw"
-    -v "$(pwd)/output:/home/fuzzer/output:rw"
-    -v "$(pwd)/corpus:/home/fuzzer/corpus:rw"
-    -v "$(pwd)/artifacts:/home/fuzzer/artifacts:rw"
-    --cpus="$cpus"
-    -m "$mem"
+	--rm
+	--user root
+	--cpus="$cpus"
+	-m "$mem"
+	-e "FUZZ_TARGET=$target"
+	-e "FUZZ_MODE=$mode"
+	-e "FUZZ_TIMEOUT=$timeout"
+	-e "FUZZ_JOBS=$jobs_"
+	-e "FUZZ_WORKERS=$workers"
+	-e "FUZZ_RSS_LIMIT=$rss_limit"
+	-e "FUZZ_MAX_LEN=$max_len"
+	-v "$(pwd)/corpus:/corpus:rw"
+	-v "$(pwd)/crashes:/crashes:rw"
+	-v "$(pwd)/output:/output:rw"
 )
 
 # Add -it only if we're in an interactive terminal
 if [ -t 0 ] && [ -t 1 ]; then
-    docker_args=(-it "${docker_args[@]}")
+	docker_args=(-it "${docker_args[@]}")
 fi
 
-docker_args+=("$image_name")
-
-entrypoint_args=(
-    --timeout "$timeout"
-    --workers "$workers"
-    --jobs "$jobs_"
-    --max-len "$max_len"
-)
-
-# Add extra arguments after --
-if [ ${#EXTRA_ARGS[@]} -gt 0 ]; then
-    entrypoint_args+=(-- "${EXTRA_ARGS[@]}")
-fi
-
-echo "Starting AVM TX fuzzer container..."
-docker run "${docker_args[@]}" "${entrypoint_args[@]}"
+echo "Starting AVM fuzzer: $target (mode=$mode)"
+docker run "${docker_args[@]}" "$image_name"

--- a/container-builds/avm-fuzzing-container/src/Dockerfile
+++ b/container-builds/avm-fuzzing-container/src/Dockerfile
@@ -47,24 +47,10 @@ WORKDIR /root/aztec-packages/barretenberg/cpp
 # Create a clean copy of the source tree BEFORE builds (for coverage reports)
 RUN cp -r /root/aztec-packages /root/aztec-packages-src && rm -rf /root/aztec-packages-src/.git
 
-# Build AVM-specific fuzzers only (the preset also rebuilds all base fuzzers
-# as a side effect — listing targets explicitly avoids that and cuts ~15 GB).
+# Build AVM-specific fuzzers only via the umbrella target (the preset also
+# rebuilds all base fuzzers as a side effect — avm_fuzzers avoids that).
 RUN cmake --preset fuzzing-avm
-RUN cmake --build build-fuzzing-avm --target \
-    avm_fuzzer_avm_differential_fuzzer \
-    avm_fuzzer_prover_fuzzer \
-    avm_fuzzer_tx_fuzzer \
-    harness_alu_fuzzer \
-    harness_bitwise_fuzzer \
-    harness_calldata_fuzzer \
-    harness_ecc_fuzzer \
-    harness_emit_public_log_fuzzer \
-    harness_external_call_fuzzer \
-    harness_gt_fuzzer \
-    harness_internal_call_fuzzer \
-    harness_memory_fuzzer \
-    harness_merkle_check_fuzzer \
-    harness_range_check_fuzzer
+RUN cmake --build build-fuzzing-avm --target avm_fuzzers
 
 # Build coverage variants (instrumented for llvm-cov)
 RUN cmake -B build-fuzzing-avm-cov -G Ninja \
@@ -74,21 +60,7 @@ RUN cmake -B build-fuzzing-avm-cov -G Ninja \
     -DFUZZER_PRESET_NAME=fuzzing-cov \
     -DCMAKE_CXX_FLAGS="-fprofile-instr-generate -fcoverage-mapping" \
     -DCMAKE_C_FLAGS="-fprofile-instr-generate -fcoverage-mapping"
-RUN cmake --build build-fuzzing-avm-cov --target \
-    avm_fuzzer_avm_differential_fuzzer \
-    avm_fuzzer_prover_fuzzer \
-    avm_fuzzer_tx_fuzzer \
-    harness_alu_fuzzer \
-    harness_bitwise_fuzzer \
-    harness_calldata_fuzzer \
-    harness_ecc_fuzzer \
-    harness_emit_public_log_fuzzer \
-    harness_external_call_fuzzer \
-    harness_gt_fuzzer \
-    harness_internal_call_fuzzer \
-    harness_memory_fuzzer \
-    harness_merkle_check_fuzzer \
-    harness_range_check_fuzzer
+RUN cmake --build build-fuzzing-avm-cov --target avm_fuzzers
 
 # Flatten binaries into /targets/ and auto-generate v2 manifest.
 # AVM fuzzers use a singleton LMDB world state that cannot handle concurrent

--- a/container-builds/avm-fuzzing-container/src/Dockerfile
+++ b/container-builds/avm-fuzzing-container/src/Dockerfile
@@ -44,6 +44,9 @@ RUN CRS_FORMAT=uncompressed ./crs/bootstrap.sh
 
 WORKDIR /root/aztec-packages/barretenberg/cpp
 
+# Create a clean copy of the source tree BEFORE builds (for coverage reports)
+RUN cp -r /root/aztec-packages /root/aztec-packages-src && rm -rf /root/aztec-packages-src/.git
+
 # Build all AVM fuzzers
 RUN cmake --preset fuzzing-avm
 RUN cmake --build build-fuzzing-avm
@@ -51,13 +54,11 @@ RUN cmake --build build-fuzzing-avm
 # Build coverage variants (instrumented for llvm-cov)
 RUN cmake -B build-fuzzing-avm-cov -G Ninja \
     -DCMAKE_C_COMPILER=clang-20 -DCMAKE_CXX_COMPILER=clang++-20 \
-    -DFUZZING=ON -DFUZZING_AVM=ON \
+    -DCMAKE_BUILD_TYPE=RelWithAssert \
+    -DFUZZING=ON -DFUZZING_AVM=ON -DDISABLE_ASM=OFF -DMULTITHREADING=ON \
     -DCMAKE_CXX_FLAGS="-fprofile-instr-generate -fcoverage-mapping" \
     -DCMAKE_C_FLAGS="-fprofile-instr-generate -fcoverage-mapping"
 RUN cmake --build build-fuzzing-avm-cov
-
-# Create a clean copy of the source tree for coverage reports
-RUN cp -r /root/aztec-packages /root/aztec-packages-src && rm -rf /root/aztec-packages-src/.git
 
 # Flatten binaries into /targets/ and auto-generate v2 manifest.
 # AVM fuzzers use a singleton LMDB world state that cannot handle concurrent
@@ -104,16 +105,18 @@ COPY --from=builder /root/aztec-packages/barretenberg/ts \
 COPY --from=builder /root/aztec-packages/noir/packages \
     ./aztec-packages/noir/packages/
 
-# Copy source tree for coverage reports
-COPY --from=builder /root/aztec-packages-src ./aztec-packages-src
+# Copy source tree for coverage reports at the same path used during build,
+# so llvm-cov can find source files without path remapping.
+COPY --from=builder /root/aztec-packages-src /root/aztec-packages
 
 # Copy coverage build directory (needed for llvm-cov links)
 COPY --from=builder /root/aztec-packages/barretenberg/cpp/build-fuzzing-avm-cov/ \
-    ./aztec-packages/barretenberg/cpp/build-fuzzing-avm-cov/
+    /root/aztec-packages/barretenberg/cpp/build-fuzzing-avm-cov/
 
-# Copy CRS
-COPY --from=builder /root/.bb-crs /home/fuzzer/aztec-packages/.bb-crs
-ENV CRS_PATH=/home/fuzzer/aztec-packages/.bb-crs
+# Copy CRS to a world-readable location so non-root containers can access it
+COPY --from=builder /root/.bb-crs /opt/bb-crs
+RUN chmod -R 755 /opt/bb-crs
+ENV CRS_PATH=/opt/bb-crs
 
 # AVM simulator binary path for differential fuzzers
 ENV AVM_SIMULATOR_BIN=/home/fuzzer/aztec-packages/yarn-project/simulator/dest/public/fuzzing/avm_simulator_bin.js
@@ -132,7 +135,8 @@ COPY entrypoint.sh ./entrypoint.sh
 # All copied files must be world-readable/executable.
 RUN chmod a+rx /home/fuzzer && \
     chmod -R a+rX /home/fuzzer/aztec-packages/ && \
-    chmod -R a+rX /home/fuzzer/aztec-packages-src/ && \
+    chmod a+rx /root && \
+    chmod -R a+rX /root/aztec-packages/ && \
     chmod a+rx /home/fuzzer/entrypoint.sh && \
     chmod -R a+rx /targets/
 

--- a/container-builds/avm-fuzzing-container/src/Dockerfile
+++ b/container-builds/avm-fuzzing-container/src/Dockerfile
@@ -50,7 +50,7 @@ RUN cmake --build build-fuzzing-avm
 
 # Build coverage variants (instrumented for llvm-cov)
 RUN cmake -B build-fuzzing-avm-cov -G Ninja \
-    -DCMAKE_C_COMPILER=clang-18 -DCMAKE_CXX_COMPILER=clang++-18 \
+    -DCMAKE_C_COMPILER=clang-20 -DCMAKE_CXX_COMPILER=clang++-20 \
     -DFUZZING=ON -DFUZZING_AVM=ON \
     -DCMAKE_CXX_FLAGS="-fprofile-instr-generate -fcoverage-mapping" \
     -DCMAKE_C_FLAGS="-fprofile-instr-generate -fcoverage-mapping"

--- a/container-builds/avm-fuzzing-container/src/Dockerfile
+++ b/container-builds/avm-fuzzing-container/src/Dockerfile
@@ -47,18 +47,48 @@ WORKDIR /root/aztec-packages/barretenberg/cpp
 # Create a clean copy of the source tree BEFORE builds (for coverage reports)
 RUN cp -r /root/aztec-packages /root/aztec-packages-src && rm -rf /root/aztec-packages-src/.git
 
-# Build all AVM fuzzers
+# Build AVM-specific fuzzers only (the preset also rebuilds all base fuzzers
+# as a side effect — listing targets explicitly avoids that and cuts ~15 GB).
 RUN cmake --preset fuzzing-avm
-RUN cmake --build build-fuzzing-avm
+RUN cmake --build build-fuzzing-avm --target \
+    avm_fuzzer_avm_differential_fuzzer \
+    avm_fuzzer_prover_fuzzer \
+    avm_fuzzer_tx_fuzzer \
+    harness_alu_fuzzer \
+    harness_bitwise_fuzzer \
+    harness_calldata_fuzzer \
+    harness_ecc_fuzzer \
+    harness_emit_public_log_fuzzer \
+    harness_external_call_fuzzer \
+    harness_gt_fuzzer \
+    harness_internal_call_fuzzer \
+    harness_memory_fuzzer \
+    harness_merkle_check_fuzzer \
+    harness_range_check_fuzzer
 
 # Build coverage variants (instrumented for llvm-cov)
 RUN cmake -B build-fuzzing-avm-cov -G Ninja \
     -DCMAKE_C_COMPILER=clang-20 -DCMAKE_CXX_COMPILER=clang++-20 \
     -DCMAKE_BUILD_TYPE=RelWithAssert \
     -DFUZZING=ON -DFUZZING_AVM=ON -DDISABLE_ASM=OFF -DMULTITHREADING=ON \
+    -DFUZZER_PRESET_NAME=fuzzing-cov \
     -DCMAKE_CXX_FLAGS="-fprofile-instr-generate -fcoverage-mapping" \
     -DCMAKE_C_FLAGS="-fprofile-instr-generate -fcoverage-mapping"
-RUN cmake --build build-fuzzing-avm-cov
+RUN cmake --build build-fuzzing-avm-cov --target \
+    avm_fuzzer_avm_differential_fuzzer \
+    avm_fuzzer_prover_fuzzer \
+    avm_fuzzer_tx_fuzzer \
+    harness_alu_fuzzer \
+    harness_bitwise_fuzzer \
+    harness_calldata_fuzzer \
+    harness_ecc_fuzzer \
+    harness_emit_public_log_fuzzer \
+    harness_external_call_fuzzer \
+    harness_gt_fuzzer \
+    harness_internal_call_fuzzer \
+    harness_memory_fuzzer \
+    harness_merkle_check_fuzzer \
+    harness_range_check_fuzzer
 
 # Flatten binaries into /targets/ and auto-generate v2 manifest.
 # AVM fuzzers use a singleton LMDB world state that cannot handle concurrent

--- a/container-builds/avm-fuzzing-container/src/Dockerfile
+++ b/container-builds/avm-fuzzing-container/src/Dockerfile
@@ -1,14 +1,18 @@
-# AVM TX Fuzzer Container
-# Builds a container that can run the AVM transaction fuzzer
+# AVM Fuzzing Container
+# Builds all 14 AVM fuzzer targets with Node.js runtime for differential testing.
 #
 # Build latest from 'next' branch:
-#   docker build -t avm-tx-fuzzer container-builds/avm-fuzzing-container/src/
+#   docker build -t avm-fuzzing container-builds/avm-fuzzing-container/src/
 #
 # Build specific commit:
-#   docker build -t avm-tx-fuzzer --build-arg COMMIT=<sha> container-builds/avm-fuzzing-container/src/
+#   docker build -t avm-fuzzing --build-arg COMMIT=<sha> container-builds/avm-fuzzing-container/src/
 
+# =============================================================================
+# Builder stage
+# =============================================================================
 FROM aztecprotocol/build:3.0-amd64 AS builder
 
+ARG BRANCH=next
 ARG COMMIT=""
 
 # Install ldid (not included in build image, only in basebox)
@@ -22,7 +26,7 @@ RUN curl -fsSL https://deb.nodesource.com/setup_24.x | bash - && \
 WORKDIR /root
 
 # Clone the repository
-RUN git clone https://github.com/AztecProtocol/aztec-packages.git --depth 1 --branch next && \
+RUN git clone https://github.com/AztecProtocol/aztec-packages.git --depth 1 --branch ${BRANCH} && \
     cd aztec-packages && \
     if [ -n "$COMMIT" ]; then \
         git fetch origin $COMMIT --depth 1; \
@@ -34,13 +38,37 @@ WORKDIR /root/aztec-packages
 # Run bootstrap up to yarn-project (release-image needs docker which isn't available)
 RUN ./bootstrap.sh build yarn-project
 
-# Build the tx fuzzer
+# Download CRS
+WORKDIR /root/aztec-packages/barretenberg
+RUN CRS_FORMAT=uncompressed ./crs/bootstrap.sh
+
 WORKDIR /root/aztec-packages/barretenberg/cpp
+
+# Build all AVM fuzzers
 RUN cmake --preset fuzzing-avm
-RUN cmake --build build-fuzzing-avm --target avm_fuzzer_tx_fuzzer
+RUN cmake --build build-fuzzing-avm
+
+# Build coverage variants (instrumented for llvm-cov)
+RUN cmake -B build-fuzzing-avm-cov -G Ninja \
+    -DCMAKE_C_COMPILER=clang-18 -DCMAKE_CXX_COMPILER=clang++-18 \
+    -DFUZZING=ON -DFUZZING_AVM=ON \
+    -DCMAKE_CXX_FLAGS="-fprofile-instr-generate -fcoverage-mapping" \
+    -DCMAKE_C_FLAGS="-fprofile-instr-generate -fcoverage-mapping"
+RUN cmake --build build-fuzzing-avm-cov
+
+# Create a clean copy of the source tree for coverage reports
+RUN cp -r /root/aztec-packages /root/aztec-packages-src && rm -rf /root/aztec-packages-src/.git
+
+# Flatten binaries into /targets/ and auto-generate v2 manifest.
+# AVM fuzzers use a singleton LMDB world state that cannot handle concurrent
+# writers, so they run single-threaded (cpus=1, memory_gb=8).
+RUN python3 scripts/flatten_and_manifest.py /targets /tmp/fuzzer_manifest.json \
+    build-fuzzing-avm/bin/fuzzer_manifest.json \
+    --copy-only build-fuzzing-avm-cov/bin/fuzzer_manifest.json \
+    --cpus 1 --memory-gb 8
 
 # =============================================================================
-# Runtime image
+# Runtime stage
 # =============================================================================
 FROM ubuntu:noble AS runtime
 
@@ -52,7 +80,8 @@ RUN apt-get update && apt-get install -y \
     libelf1 \
     libdwarf1 \
     ca-certificates \
-    curl && \
+    curl \
+    llvm-20 && \
     curl -fsSL https://deb.nodesource.com/setup_24.x | bash - && \
     apt-get install -y nodejs && \
     corepack enable && \
@@ -61,16 +90,7 @@ RUN apt-get update && apt-get install -y \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 RUN useradd -m fuzzer
-
 WORKDIR /home/fuzzer
-
-# Copy fuzzer binary
-COPY --from=builder /root/aztec-packages/barretenberg/cpp/build-fuzzing-avm/bin/avm_fuzzer_tx_fuzzer \
-    ./aztec-packages/barretenberg/cpp/build-fuzzing-avm/bin/
-
-# Copy run_fuzzer.sh
-COPY --from=builder /root/aztec-packages/barretenberg/cpp/src/barretenberg/avm_fuzzer/run_fuzzer.sh \
-    ./aztec-packages/barretenberg/cpp/src/barretenberg/avm_fuzzer/
 
 # Copy yarn-project (fully built)
 COPY --from=builder /root/aztec-packages/yarn-project \
@@ -84,18 +104,40 @@ COPY --from=builder /root/aztec-packages/barretenberg/ts \
 COPY --from=builder /root/aztec-packages/noir/packages \
     ./aztec-packages/noir/packages/
 
-# Create directories for corpus, crashes, etc.
-RUN mkdir -p aztec-packages/barretenberg/cpp/src/barretenberg/avm_fuzzer/corpus/tx \
-    aztec-packages/barretenberg/cpp/src/barretenberg/avm_fuzzer/sync_corpus/tx \
-    corpus output crash-reports artifacts
+# Copy source tree for coverage reports
+COPY --from=builder /root/aztec-packages-src ./aztec-packages-src
 
-# Make run_fuzzer.sh executable
-RUN chmod +x aztec-packages/barretenberg/cpp/src/barretenberg/avm_fuzzer/run_fuzzer.sh
+# Copy coverage build directory (needed for llvm-cov links)
+COPY --from=builder /root/aztec-packages/barretenberg/cpp/build-fuzzing-avm-cov/ \
+    ./aztec-packages/barretenberg/cpp/build-fuzzing-avm-cov/
+
+# Copy CRS
+COPY --from=builder /root/.bb-crs /home/fuzzer/aztec-packages/.bb-crs
+ENV CRS_PATH=/home/fuzzer/aztec-packages/.bb-crs
+
+# AVM simulator binary path for differential fuzzers
+ENV AVM_SIMULATOR_BIN=/home/fuzzer/aztec-packages/yarn-project/simulator/dest/public/fuzzing/avm_simulator_bin.js
+ENV AVM_FUZZER_LOGGING=1
+
+# Copy flattened target binaries
+COPY --from=builder /targets/ /targets/
+
+# Copy auto-generated fuzzer manifest
+COPY --from=builder /tmp/fuzzer_manifest.json ./fuzzer_manifest.json
 
 # Copy entrypoint script
-COPY entrypoint.sh .
-RUN chmod +x entrypoint.sh
+COPY entrypoint.sh ./entrypoint.sh
 
-WORKDIR /home/fuzzer/aztec-packages/barretenberg/cpp/src/barretenberg/avm_fuzzer
+# The container runs as a non-root UID (65534/nobody) on the fuzzing platform.
+# All copied files must be world-readable/executable.
+RUN chmod a+rx /home/fuzzer && \
+    chmod -R a+rX /home/fuzzer/aztec-packages/ && \
+    chmod -R a+rX /home/fuzzer/aztec-packages-src/ && \
+    chmod a+rx /home/fuzzer/entrypoint.sh && \
+    chmod -R a+rx /targets/
 
-ENTRYPOINT ["/home/fuzzer/entrypoint.sh"]
+# Create directories for corpus, crashes, output, and temp
+RUN mkdir -p /corpus /crashes /output /reproduce-input /tmp && \
+    chmod 777 /corpus /crashes /output /reproduce-input /tmp
+
+ENTRYPOINT ["./entrypoint.sh"]

--- a/container-builds/avm-fuzzing-container/src/Dockerfile.private
+++ b/container-builds/avm-fuzzing-container/src/Dockerfile.private
@@ -1,18 +1,21 @@
-# AVM TX Fuzzer Container (Private)
-# Builds a container that can run the AVM transaction fuzzer from a private repo
+# AVM Fuzzing Container (Private)
+# Builds all 14 AVM fuzzer targets with Node.js runtime for differential testing.
 #
 # Build latest from 'next' branch:
 #   DOCKER_BUILDKIT=1 docker build --secret id=github_token,env=GITHUB_TOKEN \
-#     -f Dockerfile.private -t avm-tx-fuzzer container-builds/avm-fuzzing-container/src/
+#     -f Dockerfile.private -t avm-fuzzing container-builds/avm-fuzzing-container/src/
 #
 # Build specific commit:
 #   DOCKER_BUILDKIT=1 docker build --secret id=github_token,env=GITHUB_TOKEN \
-#     --build-arg COMMIT=<sha> -f Dockerfile.private -t avm-tx-fuzzer container-builds/avm-fuzzing-container/src/
+#     --build-arg COMMIT=<sha> -f Dockerfile.private -t avm-fuzzing container-builds/avm-fuzzing-container/src/
 
+# =============================================================================
+# Builder stage
+# =============================================================================
 FROM aztecprotocol/build:3.0-amd64 AS builder
 
-ARG COMMIT=""
 ARG BRANCH="next"
+ARG COMMIT=""
 ARG REPO="AztecProtocol/aztec-packages-private"
 
 # Install ldid (not included in build image, only in basebox)
@@ -37,15 +40,39 @@ RUN --mount=type=secret,id=github_token \
 WORKDIR /root/aztec-packages
 
 # Run bootstrap up to yarn-project (release-image needs docker which isn't available)
-RUN BOOTSTRAP_TO=yarn-project ./bootstrap.sh
+RUN ./bootstrap.sh build yarn-project
 
-# Build the tx fuzzer
+# Download CRS
+WORKDIR /root/aztec-packages/barretenberg
+RUN CRS_FORMAT=uncompressed ./crs/bootstrap.sh
+
 WORKDIR /root/aztec-packages/barretenberg/cpp
+
+# Build all AVM fuzzers
 RUN cmake --preset fuzzing-avm
-RUN cmake --build build-fuzzing-avm --target avm_fuzzer_tx_fuzzer
+RUN cmake --build build-fuzzing-avm
+
+# Build coverage variants (instrumented for llvm-cov)
+RUN cmake -B build-fuzzing-avm-cov -G Ninja \
+    -DCMAKE_C_COMPILER=clang-18 -DCMAKE_CXX_COMPILER=clang++-18 \
+    -DFUZZING=ON -DFUZZING_AVM=ON \
+    -DCMAKE_CXX_FLAGS="-fprofile-instr-generate -fcoverage-mapping" \
+    -DCMAKE_C_FLAGS="-fprofile-instr-generate -fcoverage-mapping"
+RUN cmake --build build-fuzzing-avm-cov
+
+# Create a clean copy of the source tree for coverage reports
+RUN cp -r /root/aztec-packages /root/aztec-packages-src && rm -rf /root/aztec-packages-src/.git
+
+# Flatten binaries into /targets/ and auto-generate v2 manifest.
+# AVM fuzzers use a singleton LMDB world state that cannot handle concurrent
+# writers, so they run single-threaded (cpus=1, memory_gb=8).
+RUN python3 scripts/flatten_and_manifest.py /targets /tmp/fuzzer_manifest.json \
+    build-fuzzing-avm/bin/fuzzer_manifest.json \
+    --copy-only build-fuzzing-avm-cov/bin/fuzzer_manifest.json \
+    --cpus 1 --memory-gb 8
 
 # =============================================================================
-# Runtime image
+# Runtime stage
 # =============================================================================
 FROM ubuntu:noble AS runtime
 
@@ -57,7 +84,8 @@ RUN apt-get update && apt-get install -y \
     libelf1 \
     libdwarf1 \
     ca-certificates \
-    curl && \
+    curl \
+    llvm-20 && \
     curl -fsSL https://deb.nodesource.com/setup_24.x | bash - && \
     apt-get install -y nodejs && \
     corepack enable && \
@@ -66,16 +94,7 @@ RUN apt-get update && apt-get install -y \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 RUN useradd -m fuzzer
-
 WORKDIR /home/fuzzer
-
-# Copy fuzzer binary
-COPY --from=builder /root/aztec-packages/barretenberg/cpp/build-fuzzing-avm/bin/avm_fuzzer_tx_fuzzer \
-    ./aztec-packages/barretenberg/cpp/build-fuzzing-avm/bin/
-
-# Copy run_fuzzer.sh
-COPY --from=builder /root/aztec-packages/barretenberg/cpp/src/barretenberg/avm_fuzzer/run_fuzzer.sh \
-    ./aztec-packages/barretenberg/cpp/src/barretenberg/avm_fuzzer/
 
 # Copy yarn-project (fully built)
 COPY --from=builder /root/aztec-packages/yarn-project \
@@ -89,18 +108,41 @@ COPY --from=builder /root/aztec-packages/barretenberg/ts \
 COPY --from=builder /root/aztec-packages/noir/packages \
     ./aztec-packages/noir/packages/
 
-# Create directories for corpus, crashes, etc.
-RUN mkdir -p aztec-packages/barretenberg/cpp/src/barretenberg/avm_fuzzer/corpus/tx \
-    aztec-packages/barretenberg/cpp/src/barretenberg/avm_fuzzer/sync_corpus/tx \
-    corpus output crash-reports artifacts
+# Copy source tree for coverage reports
+COPY --from=builder /root/aztec-packages-src ./aztec-packages-src
 
-# Make run_fuzzer.sh executable
-RUN chmod +x aztec-packages/barretenberg/cpp/src/barretenberg/avm_fuzzer/run_fuzzer.sh
+# Copy coverage build directory (needed for llvm-cov links)
+COPY --from=builder /root/aztec-packages/barretenberg/cpp/build-fuzzing-avm-cov/ \
+    ./aztec-packages/barretenberg/cpp/build-fuzzing-avm-cov/
+
+# Copy CRS to a world-readable location so non-root containers can access it
+COPY --from=builder /root/.bb-crs /opt/bb-crs
+RUN chmod -R 755 /opt/bb-crs
+ENV CRS_PATH=/opt/bb-crs
+
+# AVM simulator binary path for differential fuzzers
+ENV AVM_SIMULATOR_BIN=/home/fuzzer/aztec-packages/yarn-project/simulator/dest/public/fuzzing/avm_simulator_bin.js
+ENV AVM_FUZZER_LOGGING=1
+
+# Copy flattened target binaries
+COPY --from=builder /targets/ /targets/
+
+# Copy auto-generated fuzzer manifest
+COPY --from=builder /tmp/fuzzer_manifest.json ./fuzzer_manifest.json
 
 # Copy entrypoint script
-COPY entrypoint.sh .
-RUN chmod +x entrypoint.sh
+COPY entrypoint.sh ./entrypoint.sh
 
-WORKDIR /home/fuzzer/aztec-packages/barretenberg/cpp/src/barretenberg/avm_fuzzer
+# The container runs as a non-root UID (65534/nobody) on the fuzzing platform.
+# All copied files must be world-readable/executable.
+RUN chmod a+rx /home/fuzzer && \
+    chmod -R a+rX /home/fuzzer/aztec-packages/ && \
+    chmod -R a+rX /home/fuzzer/aztec-packages-src/ && \
+    chmod a+rx /home/fuzzer/entrypoint.sh && \
+    chmod -R a+rx /targets/
 
-ENTRYPOINT ["/home/fuzzer/entrypoint.sh"]
+# Create directories for corpus, crashes, output, and temp
+RUN mkdir -p /corpus /crashes /output /reproduce-input /tmp && \
+    chmod 777 /corpus /crashes /output /reproduce-input /tmp
+
+ENTRYPOINT ["./entrypoint.sh"]

--- a/container-builds/avm-fuzzing-container/src/Dockerfile.private
+++ b/container-builds/avm-fuzzing-container/src/Dockerfile.private
@@ -54,7 +54,7 @@ RUN cmake --build build-fuzzing-avm
 
 # Build coverage variants (instrumented for llvm-cov)
 RUN cmake -B build-fuzzing-avm-cov -G Ninja \
-    -DCMAKE_C_COMPILER=clang-18 -DCMAKE_CXX_COMPILER=clang++-18 \
+    -DCMAKE_C_COMPILER=clang-20 -DCMAKE_CXX_COMPILER=clang++-20 \
     -DFUZZING=ON -DFUZZING_AVM=ON \
     -DCMAKE_CXX_FLAGS="-fprofile-instr-generate -fcoverage-mapping" \
     -DCMAKE_C_FLAGS="-fprofile-instr-generate -fcoverage-mapping"

--- a/container-builds/avm-fuzzing-container/src/Dockerfile.private
+++ b/container-builds/avm-fuzzing-container/src/Dockerfile.private
@@ -51,24 +51,10 @@ WORKDIR /root/aztec-packages/barretenberg/cpp
 # Create a clean copy of the source tree BEFORE builds (for coverage reports)
 RUN cp -r /root/aztec-packages /root/aztec-packages-src && rm -rf /root/aztec-packages-src/.git
 
-# Build AVM-specific fuzzers only (the preset also rebuilds all base fuzzers
-# as a side effect — listing targets explicitly avoids that and cuts ~15 GB).
+# Build AVM-specific fuzzers only via the umbrella target (the preset also
+# rebuilds all base fuzzers as a side effect — avm_fuzzers avoids that).
 RUN cmake --preset fuzzing-avm
-RUN cmake --build build-fuzzing-avm --target \
-    avm_fuzzer_avm_differential_fuzzer \
-    avm_fuzzer_prover_fuzzer \
-    avm_fuzzer_tx_fuzzer \
-    harness_alu_fuzzer \
-    harness_bitwise_fuzzer \
-    harness_calldata_fuzzer \
-    harness_ecc_fuzzer \
-    harness_emit_public_log_fuzzer \
-    harness_external_call_fuzzer \
-    harness_gt_fuzzer \
-    harness_internal_call_fuzzer \
-    harness_memory_fuzzer \
-    harness_merkle_check_fuzzer \
-    harness_range_check_fuzzer
+RUN cmake --build build-fuzzing-avm --target avm_fuzzers
 
 # Build coverage variants (instrumented for llvm-cov)
 RUN cmake -B build-fuzzing-avm-cov -G Ninja \
@@ -78,21 +64,7 @@ RUN cmake -B build-fuzzing-avm-cov -G Ninja \
     -DFUZZER_PRESET_NAME=fuzzing-cov \
     -DCMAKE_CXX_FLAGS="-fprofile-instr-generate -fcoverage-mapping" \
     -DCMAKE_C_FLAGS="-fprofile-instr-generate -fcoverage-mapping"
-RUN cmake --build build-fuzzing-avm-cov --target \
-    avm_fuzzer_avm_differential_fuzzer \
-    avm_fuzzer_prover_fuzzer \
-    avm_fuzzer_tx_fuzzer \
-    harness_alu_fuzzer \
-    harness_bitwise_fuzzer \
-    harness_calldata_fuzzer \
-    harness_ecc_fuzzer \
-    harness_emit_public_log_fuzzer \
-    harness_external_call_fuzzer \
-    harness_gt_fuzzer \
-    harness_internal_call_fuzzer \
-    harness_memory_fuzzer \
-    harness_merkle_check_fuzzer \
-    harness_range_check_fuzzer
+RUN cmake --build build-fuzzing-avm-cov --target avm_fuzzers
 
 # Flatten binaries into /targets/ and auto-generate v2 manifest.
 # AVM fuzzers use a singleton LMDB world state that cannot handle concurrent

--- a/container-builds/avm-fuzzing-container/src/Dockerfile.private
+++ b/container-builds/avm-fuzzing-container/src/Dockerfile.private
@@ -51,18 +51,48 @@ WORKDIR /root/aztec-packages/barretenberg/cpp
 # Create a clean copy of the source tree BEFORE builds (for coverage reports)
 RUN cp -r /root/aztec-packages /root/aztec-packages-src && rm -rf /root/aztec-packages-src/.git
 
-# Build all AVM fuzzers
+# Build AVM-specific fuzzers only (the preset also rebuilds all base fuzzers
+# as a side effect — listing targets explicitly avoids that and cuts ~15 GB).
 RUN cmake --preset fuzzing-avm
-RUN cmake --build build-fuzzing-avm
+RUN cmake --build build-fuzzing-avm --target \
+    avm_fuzzer_avm_differential_fuzzer \
+    avm_fuzzer_prover_fuzzer \
+    avm_fuzzer_tx_fuzzer \
+    harness_alu_fuzzer \
+    harness_bitwise_fuzzer \
+    harness_calldata_fuzzer \
+    harness_ecc_fuzzer \
+    harness_emit_public_log_fuzzer \
+    harness_external_call_fuzzer \
+    harness_gt_fuzzer \
+    harness_internal_call_fuzzer \
+    harness_memory_fuzzer \
+    harness_merkle_check_fuzzer \
+    harness_range_check_fuzzer
 
 # Build coverage variants (instrumented for llvm-cov)
 RUN cmake -B build-fuzzing-avm-cov -G Ninja \
     -DCMAKE_C_COMPILER=clang-20 -DCMAKE_CXX_COMPILER=clang++-20 \
     -DCMAKE_BUILD_TYPE=RelWithAssert \
     -DFUZZING=ON -DFUZZING_AVM=ON -DDISABLE_ASM=OFF -DMULTITHREADING=ON \
+    -DFUZZER_PRESET_NAME=fuzzing-cov \
     -DCMAKE_CXX_FLAGS="-fprofile-instr-generate -fcoverage-mapping" \
     -DCMAKE_C_FLAGS="-fprofile-instr-generate -fcoverage-mapping"
-RUN cmake --build build-fuzzing-avm-cov
+RUN cmake --build build-fuzzing-avm-cov --target \
+    avm_fuzzer_avm_differential_fuzzer \
+    avm_fuzzer_prover_fuzzer \
+    avm_fuzzer_tx_fuzzer \
+    harness_alu_fuzzer \
+    harness_bitwise_fuzzer \
+    harness_calldata_fuzzer \
+    harness_ecc_fuzzer \
+    harness_emit_public_log_fuzzer \
+    harness_external_call_fuzzer \
+    harness_gt_fuzzer \
+    harness_internal_call_fuzzer \
+    harness_memory_fuzzer \
+    harness_merkle_check_fuzzer \
+    harness_range_check_fuzzer
 
 # Flatten binaries into /targets/ and auto-generate v2 manifest.
 # AVM fuzzers use a singleton LMDB world state that cannot handle concurrent

--- a/container-builds/avm-fuzzing-container/src/Dockerfile.private
+++ b/container-builds/avm-fuzzing-container/src/Dockerfile.private
@@ -48,6 +48,9 @@ RUN CRS_FORMAT=uncompressed ./crs/bootstrap.sh
 
 WORKDIR /root/aztec-packages/barretenberg/cpp
 
+# Create a clean copy of the source tree BEFORE builds (for coverage reports)
+RUN cp -r /root/aztec-packages /root/aztec-packages-src && rm -rf /root/aztec-packages-src/.git
+
 # Build all AVM fuzzers
 RUN cmake --preset fuzzing-avm
 RUN cmake --build build-fuzzing-avm
@@ -55,13 +58,11 @@ RUN cmake --build build-fuzzing-avm
 # Build coverage variants (instrumented for llvm-cov)
 RUN cmake -B build-fuzzing-avm-cov -G Ninja \
     -DCMAKE_C_COMPILER=clang-20 -DCMAKE_CXX_COMPILER=clang++-20 \
-    -DFUZZING=ON -DFUZZING_AVM=ON \
+    -DCMAKE_BUILD_TYPE=RelWithAssert \
+    -DFUZZING=ON -DFUZZING_AVM=ON -DDISABLE_ASM=OFF -DMULTITHREADING=ON \
     -DCMAKE_CXX_FLAGS="-fprofile-instr-generate -fcoverage-mapping" \
     -DCMAKE_C_FLAGS="-fprofile-instr-generate -fcoverage-mapping"
 RUN cmake --build build-fuzzing-avm-cov
-
-# Create a clean copy of the source tree for coverage reports
-RUN cp -r /root/aztec-packages /root/aztec-packages-src && rm -rf /root/aztec-packages-src/.git
 
 # Flatten binaries into /targets/ and auto-generate v2 manifest.
 # AVM fuzzers use a singleton LMDB world state that cannot handle concurrent
@@ -108,12 +109,13 @@ COPY --from=builder /root/aztec-packages/barretenberg/ts \
 COPY --from=builder /root/aztec-packages/noir/packages \
     ./aztec-packages/noir/packages/
 
-# Copy source tree for coverage reports
-COPY --from=builder /root/aztec-packages-src ./aztec-packages-src
+# Copy source tree for coverage reports at the same path used during build,
+# so llvm-cov can find source files without path remapping.
+COPY --from=builder /root/aztec-packages-src /root/aztec-packages
 
 # Copy coverage build directory (needed for llvm-cov links)
 COPY --from=builder /root/aztec-packages/barretenberg/cpp/build-fuzzing-avm-cov/ \
-    ./aztec-packages/barretenberg/cpp/build-fuzzing-avm-cov/
+    /root/aztec-packages/barretenberg/cpp/build-fuzzing-avm-cov/
 
 # Copy CRS to a world-readable location so non-root containers can access it
 COPY --from=builder /root/.bb-crs /opt/bb-crs
@@ -137,7 +139,8 @@ COPY entrypoint.sh ./entrypoint.sh
 # All copied files must be world-readable/executable.
 RUN chmod a+rx /home/fuzzer && \
     chmod -R a+rX /home/fuzzer/aztec-packages/ && \
-    chmod -R a+rX /home/fuzzer/aztec-packages-src/ && \
+    chmod a+rx /root && \
+    chmod -R a+rX /root/aztec-packages/ && \
     chmod a+rx /home/fuzzer/entrypoint.sh && \
     chmod -R a+rx /targets/
 

--- a/container-builds/avm-fuzzing-container/src/entrypoint.sh
+++ b/container-builds/avm-fuzzing-container/src/entrypoint.sh
@@ -495,11 +495,7 @@ do_regress() {
 	done
 
 	log "Regression complete: $total file(s) tested, $failures failure(s)"
-	# Non-fatal regression: move failures to crashes but don't exit 1
-	# AVM fuzzers may have transient failures due to Node.js simulator state
-	if [ "$failures" -gt 0 ]; then
-		log "WARNING: $failures failure(s) moved to $FUZZ_CRASH_DIR"
-	fi
+	[ "$failures" -gt 0 ] && exit 1
 	exit 0
 }
 

--- a/container-builds/avm-fuzzing-container/src/entrypoint.sh
+++ b/container-builds/avm-fuzzing-container/src/entrypoint.sh
@@ -1,138 +1,516 @@
 #!/usr/bin/env bash
+# ContFuzzer v2 entrypoint for AVM fuzzing container.
 
 set -uo pipefail
 IFS=$'\n\t'
-
 umask 000
 
-timeout='2592000' # 1 month
-jobs_='1'
-workers='1'
-max_len='8192'
+# ---------------------------------------------------------------------------
+# Platform contract — these variables are set by the ContFuzzer platform.
+# Do not change defaults without updating api/jobs/config_builder.py.
+# ---------------------------------------------------------------------------
+: "${FUZZ_MODE:=fuzz}"             # fuzz | coverage | minimize | reproduce | regress
+: "${FUZZ_TARGET:=}"               # target binary name (maps to /targets/<name>)
+: "${FUZZ_CORPUS_DIR:=/corpus}"    # mounted corpus directory
+: "${FUZZ_CRASH_DIR:=/crashes}"    # mounted crash directory
+: "${FUZZ_OUTPUT_DIR:=/output}"    # mounted output directory (logs, reports, artifacts)
+: "${FUZZ_TIMEOUT:=0}"            # wall-clock seconds (0 = unlimited)
+: "${FUZZ_JOBS:=1}"               # parallelism hint (AVM default: 1 due to LMDB)
+: "${FUZZ_REPRODUCE_DIR:=}"       # input dir for batch reproduce mode
+: "${FUZZ_CRASH_FILE:=}"          # specific crash file for single-file reproduce
+: "${FUZZ_MEMORY:=}"              # total memory budget (e.g. "16g", "512m")
 
-show_help() {
-    echo "Usage: $0 [options]"
-    echo ""
-    echo "Options:"
-    echo "  -t, --timeout <timeout>     Set the maximum total time for fuzzing in seconds (default: $timeout - 1 month)"
-    echo "  -j, --jobs <N>              Set the amount of processes to run (default: $jobs_)"
-    echo "  -w, --workers <N>           Set the amount of subprocesses per job (default: $workers)"
-    echo "  -m, --max-len <N>           Set the maximum input length in bytes (default: $max_len)"
-    echo "  -h, --help                  Display this help and exit"
-    echo "  --                          Pass additional arguments to the fuzzer"
-    echo ""
-    echo "This container runs the AVM TX fuzzer for differential testing."
+# ---------------------------------------------------------------------------
+# Container-internal — tuning knobs for libFuzzer, not set by the platform.
+# ---------------------------------------------------------------------------
+: "${FUZZ_WORKERS:=$FUZZ_JOBS}"           # libFuzzer -workers (defaults to JOBS)
+: "${FUZZ_VERBOSITY:=0}"                  # libFuzzer verbosity (0 = quiet)
+: "${FUZZ_MAX_LEN:=8192}"                 # max input length in bytes
+: "${FUZZ_INPUT_TIMEOUT:=1200}"           # per-test-case timeout in seconds
+: "${FUZZ_MERGE_JOBS:=1}"                 # merge phase parallelism (keep low, flaky)
+: "${FUZZ_MERGE_WORKERS:=1}"              # merge phase workers
+
+# Derive per-worker RSS limit from FUZZ_MEMORY if provided.
+# FUZZ_MEMORY is the total container budget (e.g. "16g"); we divide by
+# FUZZ_JOBS so each libFuzzer worker gets a fair share and libFuzzer can
+# kill a runaway worker before Docker OOM-kills the whole container.
+# Falls back to 2048 MB if FUZZ_MEMORY is unset (standalone/local runs).
+_parse_memory_mb() {
+	local mem="${1:-}"
+	case "$mem" in
+		*[gG]) echo $(( ${mem%[gG]} * 1024 )) ;;
+		*[mM]) echo "${mem%[mM]}" ;;
+		*)     echo "" ;;
+	esac
 }
 
-log() {
-    echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*"
+if [ -n "$FUZZ_MEMORY" ]; then
+	_total_mb=$(_parse_memory_mb "$FUZZ_MEMORY")
+	if [ -n "$_total_mb" ] && [ "$_total_mb" -gt 0 ] 2>/dev/null; then
+		FUZZ_RSS_LIMIT=$(( _total_mb / FUZZ_JOBS ))
+		# Floor: don't go below 512 MB per worker — targets need headroom
+		[ "$FUZZ_RSS_LIMIT" -lt 512 ] && FUZZ_RSS_LIMIT=512
+	else
+		FUZZ_RSS_LIMIT=2048
+	fi
+else
+	: "${FUZZ_RSS_LIMIT:=2048}"
+fi
+: "${FUZZ_MERGE_RSS_LIMIT:=$FUZZ_RSS_LIMIT}"  # merge RSS limit (raise if merge OOMs)
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*"; }
+
+# Run libFuzzer merge; logs to logfile. Sets global _merge_status.
+_run_merge() {
+	local logfile=$1
+	shift
+	: >"$logfile"
+	set +e
+	"$@" >>"$logfile" 2>&1
+	_merge_status=$?
+	set -e
 }
 
-EXTRA_ARGS=()
+# Replace contents of dest_dir with files from src_dir. Fails if mv loses data.
+_swap_corpus_dir() {
+	local dest_dir=$1
+	local src_dir=$2
+	local label=$3
 
-while [[ $# -gt 0 ]]; do
-    case "$1" in
-    -t | --timeout)
-        timeout="$2"
-        shift 2
-        ;;
-    -w | --workers)
-        workers="$2"
-        shift 2
-        ;;
-    -j | --jobs)
-        jobs_="$2"
-        shift 2
-        ;;
-    -m | --max-len)
-        max_len="$2"
-        shift 2
-        ;;
-    -h | --help)
-        show_help
-        exit 0
-        ;;
-    --)
-        shift
-        EXTRA_ARGS=("$@")
-        break
-        ;;
-    -*)
-        log "Error: Unsupported flag $1"
-        exit 1
-        ;;
-    *)
-        break
-        ;;
-    esac
-done
+	if [ ! -d "$src_dir" ]; then
+		log "ERROR: $label: source dir missing: $src_dir"
+		return 1
+	fi
+	local n
+	n=$(find "$src_dir" -type f 2>/dev/null | wc -l | tr -d ' ')
+	if [ "${n:-0}" -eq 0 ]; then
+		log "ERROR: $label: source has no files: $src_dir"
+		return 1
+	fi
 
-workdir="/home/fuzzer"
-CORPUS="$workdir/corpus/tx"
-OUTPUT="$workdir/output"
-CRASHES="$workdir/crash-reports"
-ARTIFACTS="$workdir/artifacts"
+	rm -rf "${dest_dir:?}/"*
+	if ! mv "$src_dir"/* "$dest_dir/" 2>/dev/null; then
+		log "ERROR: $label: mv to $dest_dir failed (permissions? read-only volume?)"
+		return 1
+	fi
+	return 0
+}
 
-mkdir -p "$CORPUS" "$OUTPUT" "$CRASHES" "$ARTIFACTS"
+_restore_corpus_backup() {
+	local dest_dir=$1
+	local backup=$2
+	log "Restoring corpus from backup..."
+	rm -rf "${dest_dir:?}/"*
+	if ! mv "$backup"/* "$dest_dir/" 2>/dev/null; then
+		log "ERROR: restore from backup failed — corpus at $dest_dir may be empty"
+		return 1
+	fi
+	return 0
+}
 
-# Link the corpus directory to where run_fuzzer.sh expects it
-FUZZER_CORPUS="$workdir/aztec-packages/barretenberg/cpp/src/barretenberg/avm_fuzzer/corpus/tx"
-if [ ! -L "$FUZZER_CORPUS" ] && [ -d "$FUZZER_CORPUS" ]; then
-    rm -rf "$FUZZER_CORPUS"
-fi
-mkdir -p "$(dirname "$FUZZER_CORPUS")"
-ln -sf "$CORPUS" "$FUZZER_CORPUS" 2>/dev/null || true
+# ---------------------------------------------------------------------------
+# Resolve binaries
+# ---------------------------------------------------------------------------
 
-# Build fuzzer arguments
-FUZZER_ARGS=(
-    -timeout=1200
-    -workers="$workers"
-    -jobs="$jobs_"
-    -entropic=1
-    -shrink=1
-    -max_len="$max_len"
-    -max_total_time="$timeout"
-    -artifact_prefix="$CRASHES/"
-)
-
-# Add extra arguments
-if [ ${#EXTRA_ARGS[@]} -gt 0 ]; then
-    FUZZER_ARGS+=("${EXTRA_ARGS[@]}")
+if [ -z "$FUZZ_TARGET" ]; then
+	log "ERROR: FUZZ_TARGET not set"
+	exit 2
 fi
 
-log "=========================================="
-log "AVM TX Fuzzer"
-log "=========================================="
-log "Corpus directory: $CORPUS"
-log "Output directory: $OUTPUT"
-log "Crashes directory: $CRASHES"
-log "Parameters:"
-log "  timeout=$timeout"
-log "  jobs=$jobs_"
-log "  workers=$workers"
-log "  max_len=$max_len"
-if [ ${#EXTRA_ARGS[@]} -gt 0 ]; then
-    log "Extra arguments: ${EXTRA_ARGS[*]}"
-fi
-log "=========================================="
-log ""
-
-cd "$workdir/aztec-packages/barretenberg/cpp/src/barretenberg/avm_fuzzer"
-
-# Run the fuzzer
-log "Starting AVM TX fuzzer..."
-./run_fuzzer.sh fuzz tx -- "${FUZZER_ARGS[@]}" 2>&1 | tee "$OUTPUT/session.log"
-
-exit_code=${PIPESTATUS[0]}
-
-log "Fuzzer exited with code: $exit_code"
-
-# Package artifacts if any crashes found
-if compgen -G "$CRASHES/*" >/dev/null; then
-    log "Crashes found, packaging artifacts..."
-    tar -czf "$ARTIFACTS/tx-fuzzer-results.tar.gz" \
-        -C "$CRASHES" . \
-        -C "$CORPUS" . 2>/dev/null || true
+BINARY="/targets/$FUZZ_TARGET"
+if [ ! -x "$BINARY" ]; then
+	log "ERROR: Binary not found: $BINARY"
+	log "Available targets:"
+	ls /targets/ 2>/dev/null
+	exit 2
 fi
 
-exit "$exit_code"
+# Derive base name (strip variant suffix) for companion binaries.
+# AVM targets use _avm suffix; coverage companions use _cov.
+BASE_NAME=$(echo "$FUZZ_TARGET" | sed -E 's/_(avm|cov)$//')
+COV_BINARY="/targets/${BASE_NAME}_cov"
+[ ! -x "$COV_BINARY" ] && COV_BINARY="$BINARY"
+
+# ASAN companion: AVM container doesn't build a separate ASAN variant,
+# so fall back to the primary binary for crash reproduction.
+ASAN_BINARY="$BINARY"
+
+mkdir -p "$FUZZ_CORPUS_DIR" "$FUZZ_CRASH_DIR" "$FUZZ_OUTPUT_DIR" "$FUZZ_OUTPUT_DIR/coverage"
+
+# All writes go to FUZZ_OUTPUT_DIR — libFuzzer -jobs=N creates fuzz-*.log in CWD,
+# and the rootfs is read-only in production (ContFuzzer platform).
+cd "$FUZZ_OUTPUT_DIR"
+
+# ---------------------------------------------------------------------------
+# Regression — run existing crash inputs before fuzzing
+# ---------------------------------------------------------------------------
+regress() {
+	local src="$1"
+	if ! compgen -G "$src/*" &>/dev/null; then return 0; fi
+	log "Regression testing $src..."
+	local failures=0
+	for x in "$src"/*; do
+		set +e
+		"$BINARY" "$x" &>/dev/null
+		local s=$?
+		set -e
+		if [ "$s" -ne 0 ]; then
+			"$ASAN_BINARY" "$x" &>"$FUZZ_OUTPUT_DIR/$(basename "$x")_result.txt" || true
+			cp "$x" "$FUZZ_CRASH_DIR/" 2>/dev/null || true
+			log "Regression failure: $x (exit $s)"
+			failures=$((failures + 1))
+		fi
+	done
+	if [ "$failures" -gt 0 ]; then
+		log "WARNING: $failures regression failure(s) found, moving to crashes and continuing"
+	else
+		log "Regression passed: $src"
+	fi
+}
+
+# ---------------------------------------------------------------------------
+# Mode: fuzz
+# ---------------------------------------------------------------------------
+do_fuzz() {
+	# regress "$FUZZ_CORPUS_DIR"   	#expensive, don't run per fuzz for now
+
+	TMPOUT="$FUZZ_OUTPUT_DIR/tmp"
+	mkdir -p "$TMPOUT"
+	trap 'rm -rf "$TMPOUT" 2>/dev/null' EXIT
+
+	ARGS=("-artifact_prefix=$TMPOUT/")
+	ARGS+=("-jobs=$FUZZ_JOBS" "-workers=$FUZZ_WORKERS")
+	ARGS+=("-verbosity=$FUZZ_VERBOSITY")
+	ARGS+=("-rss_limit_mb=$FUZZ_RSS_LIMIT")
+	ARGS+=("-entropic=1" "-shrink=1" "-use_value_profile=1" "-print_final_stats=1")
+	ARGS+=("-max_len=$FUZZ_MAX_LEN")
+	ARGS+=("-timeout=$FUZZ_INPUT_TIMEOUT")
+	# Suppress Node.js stdout/stderr noise from AVM simulator
+	ARGS+=("-close_fd_mask=3")
+	[ "$FUZZ_TIMEOUT" -gt 0 ] 2>/dev/null && ARGS+=("-max_total_time=$FUZZ_TIMEOUT")
+	ARGS+=("$FUZZ_CORPUS_DIR")
+
+	log "Fuzzing: $BINARY ${ARGS[*]}"
+	set +e
+	"$BINARY" "${ARGS[@]}" &>"$TMPOUT/session.log"
+	local status=$?
+	set -e
+	log "Fuzzer exited ($status)"
+
+	# Process crashes
+	local exit_code=0
+	local crash_files=("$TMPOUT"/crash-*)
+	if [ -e "${crash_files[0]:-}" ]; then
+		log "Found ${#crash_files[@]} crash(es), minimizing..."
+		for crash in "${crash_files[@]}"; do
+			local cname=$(basename "$crash")
+			log "  Minimizing $cname ($(wc -c <"$crash")B)"
+
+			local mindir=$(mktemp -d)
+			mv "$crash" "$mindir/"
+			"$BINARY" -minimize_crash=1 -runs=10000 -rss_limit_mb="$FUZZ_RSS_LIMIT" \
+				-close_fd_mask=3 \
+				-artifact_prefix="$mindir/" "$mindir/$cname" &>>"$TMPOUT/minimize.log" || true
+
+			local smallest=$(ls -S "$mindir/" | tail -n 1)
+			log "  Minimized: $smallest ($(wc -c <"$mindir/$smallest")B)"
+
+			cp "$mindir/$smallest" "$FUZZ_OUTPUT_DIR/"
+			"$ASAN_BINARY" "$mindir/$smallest" &>"$FUZZ_OUTPUT_DIR/${smallest}_result.txt" || true
+			mv "$mindir/"* "$FUZZ_CRASH_DIR/" 2>/dev/null || true
+			rm -rf "$mindir"
+		done
+		exit_code=1
+	elif [ "$status" -ne 0 ]; then
+		# Check for timeout/OOM artifacts — these are non-fatal for AVM fuzzers
+		local timeout_files=("$TMPOUT"/timeout-*)
+		local oom_files=("$TMPOUT"/oom-*)
+		if [ -e "${timeout_files[0]:-}" ] || [ -e "${oom_files[0]:-}" ]; then
+			log "Timeout/OOM artifacts found (non-fatal for AVM)"
+			for art in "$TMPOUT"/timeout-* "$TMPOUT"/oom-*; do
+				[ -e "$art" ] || continue
+				cp "$art" "$FUZZ_CRASH_DIR/" 2>/dev/null || true
+				log "  Saved artifact: $(basename "$art")"
+			done
+		else
+			log "Non-fuzzing failure (exit $status)"
+			exit_code=1
+		fi
+	fi
+
+	# Corpus minimization (backup original in case merge fails)
+	local before=$(find "$FUZZ_CORPUS_DIR" -type f 2>/dev/null | wc -l | tr -d ' ')
+	log "Minimizing corpus ($before entries)..."
+	local mincorp="$TMPOUT/corpus"
+	local backup="$TMPOUT/corpus-backup"
+	mkdir -p "$mincorp"
+	cp -a "$FUZZ_CORPUS_DIR"/. "$backup/"
+
+	log "Merge: jobs=$FUZZ_MERGE_JOBS workers=$FUZZ_MERGE_WORKERS rss_mb=$FUZZ_MERGE_RSS_LIMIT (see merge.log)"
+	_run_merge "$TMPOUT/merge.log" \
+		"$BINARY" -merge=1 \
+		-jobs="$FUZZ_MERGE_JOBS" -workers="$FUZZ_MERGE_WORKERS" \
+		-rss_limit_mb="$FUZZ_MERGE_RSS_LIMIT" \
+		-close_fd_mask=3 \
+		"$mincorp" "$FUZZ_CORPUS_DIR"
+
+	local merged_n
+	merged_n=$(find "$mincorp" -type f 2>/dev/null | wc -l | tr -d ' ')
+
+	if [ "$_merge_status" -eq 0 ] && [ "${merged_n:-0}" -gt 0 ]; then
+		if _swap_corpus_dir "$FUZZ_CORPUS_DIR" "$mincorp" "post-merge"; then
+			:
+		else
+			log "Corpus merge produced files but install to $FUZZ_CORPUS_DIR failed, restoring backup"
+			_restore_corpus_backup "$FUZZ_CORPUS_DIR" "$backup" || true
+		fi
+	else
+		log "Corpus merge failed (exit $_merge_status) or empty output ($merged_n files) — see merge.log"
+		_restore_corpus_backup "$FUZZ_CORPUS_DIR" "$backup" || true
+	fi
+
+	local after=$(find "$FUZZ_CORPUS_DIR" -type f 2>/dev/null | wc -l | tr -d ' ')
+	log "Corpus minimized: $before -> $after"
+
+	cp "$TMPOUT/"*.log "$FUZZ_OUTPUT_DIR/" 2>/dev/null || true
+
+	# Translate libfuzzer exit codes to platform convention
+	case $exit_code in
+		0)  exit 0 ;;
+		77) exit 137 ;;
+		*)  exit $exit_code ;;
+	esac
+}
+
+# ---------------------------------------------------------------------------
+# Mode: coverage
+# ---------------------------------------------------------------------------
+do_coverage() {
+	if ! compgen -G "$FUZZ_CORPUS_DIR/*" &>/dev/null; then
+		log "Corpus is empty, nothing to collect coverage from."
+		exit 0
+	fi
+
+	local covdir="$FUZZ_OUTPUT_DIR/coverage"
+	local rawdir="$covdir/raw"
+	mkdir -p "$rawdir"
+
+	rm -f "$rawdir"/*.profraw "$covdir/fuzz.profdata" 2>/dev/null || true
+	rm -rf "$covdir/cov-html" 2>/dev/null || true
+
+	local tmpdir="$FUZZ_OUTPUT_DIR/tmp"
+	mkdir -p "$tmpdir"
+	trap 'rm -rf "$tmpdir"' EXIT
+	local ts=$(date +%Y%m%dT%H%M%S)
+	local cov_mergelog="$tmpdir/coverage-merge.log"
+
+	log "Collecting coverage with $COV_BINARY..."
+	set +e
+	LLVM_PROFILE_FILE="$rawdir/${ts}-%p.profraw" \
+		"$COV_BINARY" -merge=1 \
+		-jobs="$FUZZ_MERGE_JOBS" -workers="$FUZZ_MERGE_WORKERS" \
+		-rss_limit_mb="$FUZZ_MERGE_RSS_LIMIT" \
+		-close_fd_mask=3 \
+		"$tmpdir" "$FUZZ_CORPUS_DIR/" >>"$cov_mergelog" 2>&1
+	local cov_merge_st=$?
+	set -e
+	cp "$cov_mergelog" "$FUZZ_OUTPUT_DIR/coverage-merge.log" 2>/dev/null || true
+	if [ "$cov_merge_st" -ne 0 ]; then
+		log "Coverage merge step exited $cov_merge_st — see $FUZZ_OUTPUT_DIR/coverage-merge.log"
+		exit 1
+	fi
+
+	log "Merging profile data..."
+	llvm-profdata-20 merge -sparse "$rawdir/"*.profraw -o "$covdir/fuzz.profdata"
+
+	log "Generating HTML report..."
+	llvm-cov-20 show "$COV_BINARY" \
+		-instr-profile="$covdir/fuzz.profdata" \
+		-format=html \
+		-output-dir="$covdir/cov-html" \
+		-show-line-counts-or-regions \
+		--show-branches=percent \
+		--show-directory-coverage
+
+	log "Exporting coverage JSON summary..."
+	llvm-cov-20 export "$COV_BINARY" \
+		-instr-profile="$covdir/fuzz.profdata" \
+		-summary-only > "$covdir/coverage.json"
+
+	log "Exporting LCOV..."
+	llvm-cov-20 export "$COV_BINARY" \
+		-instr-profile="$covdir/fuzz.profdata" \
+		-format=lcov > "$covdir/coverage.lcov"
+
+	# Generate content hashes (SHA256 of each source file referenced in LCOV).
+	# Enables high-confidence cross-fuzzer file deduplication on the platform.
+	log "Generating content hashes..."
+	local _hash_tmp
+	_hash_tmp=$(mktemp)
+	grep '^SF:' "$covdir/coverage.lcov" | cut -d: -f2- | sort -u | while IFS= read -r fpath; do
+		if [ -f "$fpath" ]; then
+			hash=$(sha256sum "$fpath" | cut -d' ' -f1)
+			printf '"%s":"%s"\n' "$fpath" "$hash" >> "$_hash_tmp"
+		fi
+	done
+	printf '{%s}' "$(paste -sd, "$_hash_tmp")" > "$covdir/coverage_hashes.json"
+	rm -f "$_hash_tmp"
+
+	log "Coverage outputs: cov-html/, coverage.json, coverage.lcov, coverage_hashes.json"
+	exit 0
+}
+
+# ---------------------------------------------------------------------------
+# Mode: minimize
+# ---------------------------------------------------------------------------
+do_minimize() {
+	if ! compgen -G "$FUZZ_CORPUS_DIR/*" &>/dev/null; then
+		log "Corpus is empty."
+		exit 0
+	fi
+
+	local before=$(find "$FUZZ_CORPUS_DIR" -type f | wc -l | tr -d ' ')
+	log "Minimizing corpus ($before entries)..."
+
+	local tmp_bundle="$FUZZ_OUTPUT_DIR/tmp"
+	local mergedir="$tmp_bundle/merge-out"
+	local mergelog="$tmp_bundle/minimize-merge.log"
+	local backup="$tmp_bundle/backup"
+	mkdir -p "$mergedir" "$backup"
+	cp -a "$FUZZ_CORPUS_DIR"/. "$backup/"
+
+	_run_merge "$mergelog" \
+		"$BINARY" -merge=1 \
+		-jobs="$FUZZ_MERGE_JOBS" -workers="$FUZZ_MERGE_WORKERS" \
+		-rss_limit_mb="$FUZZ_MERGE_RSS_LIMIT" \
+		-close_fd_mask=3 \
+		"$mergedir" "$FUZZ_CORPUS_DIR"
+
+	cp "$mergelog" "$FUZZ_OUTPUT_DIR/minimize-merge.log" 2>/dev/null || true
+
+	local merged_n
+	merged_n=$(find "$mergedir" -type f 2>/dev/null | wc -l | tr -d ' ')
+
+	if [ "$_merge_status" -eq 0 ] && [ "${merged_n:-0}" -gt 0 ]; then
+		if ! _swap_corpus_dir "$FUZZ_CORPUS_DIR" "$mergedir" "minimize"; then
+			log "Install failed, restoring backup — see $FUZZ_OUTPUT_DIR/minimize-merge.log"
+			_restore_corpus_backup "$FUZZ_CORPUS_DIR" "$backup" || true
+		fi
+	else
+		log "Corpus merge failed (exit $_merge_status) or empty ($merged_n files)"
+		_restore_corpus_backup "$FUZZ_CORPUS_DIR" "$backup" || true
+	fi
+
+	rm -rf "$tmp_bundle" 2>/dev/null || true
+
+	local after=$(find "$FUZZ_CORPUS_DIR" -type f 2>/dev/null | wc -l | tr -d ' ')
+	log "Corpus minimized: $before -> $after"
+	exit 0
+}
+
+# ---------------------------------------------------------------------------
+# Mode: reproduce
+# ---------------------------------------------------------------------------
+do_reproduce() {
+	local last_exit=0
+
+	if [ -n "${FUZZ_CRASH_FILE:-}" ]; then
+		# Single-file reproduce (platform sets FUZZ_CRASH_FILE)
+		if [ ! -f "$FUZZ_CRASH_FILE" ]; then
+			log "ERROR: Crash file not found: $FUZZ_CRASH_FILE"
+			exit 2
+		fi
+		local cname=$(basename "$FUZZ_CRASH_FILE")
+		log "Reproducing $FUZZ_CRASH_FILE..."
+		set +e
+		"$BINARY" "$FUZZ_CRASH_FILE"
+		last_exit=$?
+		set -e
+		if [ "$last_exit" -ne 0 ]; then
+			cp "$FUZZ_CRASH_FILE" "$FUZZ_CRASH_DIR/$cname"
+			"$ASAN_BINARY" "$FUZZ_CRASH_FILE" &>"$FUZZ_OUTPUT_DIR/${cname}_result.txt" || true
+			log "REPRODUCED (exit $last_exit): $FUZZ_CRASH_FILE"
+		else
+			log "Did not reproduce: $FUZZ_CRASH_FILE"
+		fi
+	else
+		# Batch: iterate inputs from FUZZ_REPRODUCE_DIR (or fall back to FUZZ_CRASH_DIR)
+		local src_dir="${FUZZ_REPRODUCE_DIR:-$FUZZ_CRASH_DIR}"
+		if ! compgen -G "$src_dir/*" &>/dev/null; then
+			log "ERROR: No crash files in $src_dir"
+			exit 2
+		fi
+		for input_file in "$src_dir"/*; do
+			[ -f "$input_file" ] || continue
+			local cname=$(basename "$input_file")
+			log "Reproducing $input_file..."
+			set +e
+			"$BINARY" "$input_file"
+			local s=$?
+			set -e
+			if [ "$s" -ne 0 ]; then
+				cp "$input_file" "$FUZZ_CRASH_DIR/$cname"
+				"$ASAN_BINARY" "$input_file" &>"$FUZZ_OUTPUT_DIR/${cname}_result.txt" || true
+				log "REPRODUCED (exit $s): $input_file"
+				last_exit=$s
+			else
+				log "Did not reproduce: $input_file"
+			fi
+		done
+	fi
+
+	# Translate libfuzzer exit codes to platform convention
+	case $last_exit in
+		0)  exit 0 ;;
+		77) exit 137 ;;
+		*)  exit $last_exit ;;
+	esac
+}
+
+# ---------------------------------------------------------------------------
+# Mode: regress
+# ---------------------------------------------------------------------------
+do_regress() {
+	if ! compgen -G "$FUZZ_CORPUS_DIR/*" &>/dev/null; then
+		log "Corpus is empty, nothing to regress."
+		exit 0
+	fi
+
+	local failures=0
+	local total=0
+
+	log "Regressing $FUZZ_CORPUS_DIR..."
+	for x in "$FUZZ_CORPUS_DIR"/*; do
+		total=$((total + 1))
+		set +e
+		"$BINARY" "$x" &>/dev/null
+		local s=$?
+		set -e
+		if [ "$s" -ne 0 ]; then
+			"$ASAN_BINARY" "$x" &>"$FUZZ_OUTPUT_DIR/$(basename "$x")_result.txt" || true
+			cp "$x" "$FUZZ_CRASH_DIR/" 2>/dev/null || true
+			log "FAIL: $x (exit $s)"
+			failures=$((failures + 1))
+		fi
+	done
+
+	log "Regression complete: $total file(s) tested, $failures failure(s)"
+	# Non-fatal regression: move failures to crashes but don't exit 1
+	# AVM fuzzers may have transient failures due to Node.js simulator state
+	if [ "$failures" -gt 0 ]; then
+		log "WARNING: $failures failure(s) moved to $FUZZ_CRASH_DIR"
+	fi
+	exit 0
+}
+
+# ---------------------------------------------------------------------------
+# Dispatch
+# ---------------------------------------------------------------------------
+case "$FUZZ_MODE" in
+	fuzz)      do_fuzz ;;
+	coverage)  do_coverage ;;
+	minimize)  do_minimize ;;
+	reproduce) do_reproduce ;;
+	regress)   do_regress ;;
+	*)         log "ERROR: Unknown FUZZ_MODE=$FUZZ_MODE"; exit 2 ;;
+esac

--- a/container-builds/avm-fuzzing-container/src/entrypoint.sh
+++ b/container-builds/avm-fuzzing-container/src/entrypoint.sh
@@ -156,8 +156,8 @@ regress() {
 		set -e
 		if [ "$s" -ne 0 ]; then
 			"$ASAN_BINARY" "$x" &>"$FUZZ_OUTPUT_DIR/$(basename "$x")_result.txt" || true
-			cp "$x" "$FUZZ_CRASH_DIR/" 2>/dev/null || true
-			log "Regression failure: $x (exit $s)"
+			mv "$x" "$FUZZ_CRASH_DIR/" 2>/dev/null || true
+			log "Regression failure: $x (exit $s) — moved to crashes"
 			failures=$((failures + 1))
 		fi
 	done

--- a/container-builds/fuzzing-container/src/Dockerfile
+++ b/container-builds/fuzzing-container/src/Dockerfile
@@ -61,22 +61,14 @@ RUN cmake --build build-fuzzing-asan && mv build-fuzzing-asan/bin bin-fuzzing-as
 RUN cmake -DCMAKE_C_COMPILER=clang-18 -DCMAKE_CXX_COMPILER=clang++-18 --preset fuzzing-coverage
 RUN cmake --build build-fuzzing-cov
 
-# Build avm fuzzers
-RUN cmake -DCMAKE_C_COMPILER=clang-18 -DCMAKE_CXX_COMPILER=clang++-18 --preset fuzzing-avm
-RUN cmake --build build-fuzzing-avm && mv build-fuzzing-avm/bin bin-fuzzing-avm && rm -rf build-fuzzing-avm
-
 # Flatten variant binaries into /targets/<name>[_suffix] and generate v2 manifest.
 # Positional manifests = scheduled as independent fuzz jobs by the platform.
 # --copy-only = companion binaries (asan for crash repro, cov for coverage collection).
-# AVM fuzzers use a singleton LMDB world state (/tmp/avm_fuzzer_ws/) that
-# cannot handle concurrent writers, so they must run single-threaded (cpus=1).
 RUN python3 scripts/flatten_and_manifest.py /targets /tmp/fuzzer_manifest.json \
     bin-fuzzing/fuzzer_manifest.json \
     bin-fuzzing-noasm/fuzzer_manifest.json \
-    bin-fuzzing-avm/fuzzer_manifest.json \
     --copy-only bin-fuzzing-asan/fuzzer_manifest.json \
-    --copy-only build-fuzzing-cov/bin/fuzzer_manifest.json \
-    --preset-resources fuzzing-avm:1:8
+    --copy-only build-fuzzing-cov/bin/fuzzer_manifest.json
 
 # Runtime stage
 FROM ubuntu:noble AS runtime

--- a/container-builds/fuzzing-container/src/Dockerfile.private
+++ b/container-builds/fuzzing-container/src/Dockerfile.private
@@ -65,22 +65,14 @@ RUN cmake --build build-fuzzing-asan && mv build-fuzzing-asan/bin bin-fuzzing-as
 RUN cmake -DCMAKE_C_COMPILER=clang-18 -DCMAKE_CXX_COMPILER=clang++-18 --preset fuzzing-coverage
 RUN cmake --build build-fuzzing-cov
 
-# Build avm fuzzers
-RUN cmake -DCMAKE_C_COMPILER=clang-18 -DCMAKE_CXX_COMPILER=clang++-18 --preset fuzzing-avm
-RUN cmake --build build-fuzzing-avm && mv build-fuzzing-avm/bin bin-fuzzing-avm && rm -rf build-fuzzing-avm
-
 # Flatten variant binaries into /targets/<name>[_suffix] and generate v2 manifest.
 # Positional manifests = scheduled as independent fuzz jobs by the platform.
 # --copy-only = companion binaries (asan for crash repro, cov for coverage collection).
-# AVM fuzzers use a singleton LMDB world state (/tmp/avm_fuzzer_ws/) that
-# cannot handle concurrent writers, so they must run single-threaded (cpus=1).
 RUN python3 scripts/flatten_and_manifest.py /targets /tmp/fuzzer_manifest.json \
     bin-fuzzing/fuzzer_manifest.json \
     bin-fuzzing-noasm/fuzzer_manifest.json \
-    bin-fuzzing-avm/fuzzer_manifest.json \
     --copy-only bin-fuzzing-asan/fuzzer_manifest.json \
-    --copy-only build-fuzzing-cov/bin/fuzzer_manifest.json \
-    --preset-resources fuzzing-avm:1:8
+    --copy-only build-fuzzing-cov/bin/fuzzer_manifest.json
 
 # Runtime stage
 FROM ubuntu:noble AS runtime


### PR DESCRIPTION
## Summary
- Remove `fuzzing-avm` preset build from the non-AVM `fuzzing-container` — it built AVM binaries but couldn't run them (no Node.js)
- Rewrite `avm-fuzzing-container` to build all 14 AVM fuzzer targets with Node.js runtime, coverage variants, and a ContFuzzer v2 entrypoint
- Auto-generate manifest via `flatten_and_manifest.py` (same pattern as `fuzzing-container`)

## What changed

### fuzzing-container (removal)
- Dropped `fuzzing-avm` cmake configure + build steps
- Removed `bin-fuzzing-avm` and `--preset-resources fuzzing-avm:1:8` from `flatten_and_manifest.py` call

### avm-fuzzing-container (rewrite)
- **Dockerfile**: `aztecprotocol/build:3.0-amd64` base, Node.js 24, full bootstrap + yarn-project, builds all AVM fuzzers + coverage variants, `flatten_and_manifest.py` for manifest generation, `llvm-20` in runtime
- **entrypoint.sh**: ContFuzzer v2 interface (`FUZZ_MODE`, `FUZZ_TARGET`, etc.), `FUZZ_MEMORY` → per-worker RSS derivation, `-close_fd_mask=3` for Node.js noise, non-fatal regression, timeout/OOM artifact processing, corpus backup/restore, content hash generation for LCOV
- **run.sh**: v2 local runner with `--target`/`--mode`/`--list-targets`/`--workers`/`--max-len`

## Test plan
- [ ] Review Dockerfiles for correctness (can't docker build on macOS ARM)
- [ ] Verify fuzzing-container no longer references AVM in Dockerfile
- [ ] Verify avm-fuzzing-container uses `flatten_and_manifest.py` for manifest generation
- [ ] Build avm-fuzzing-container on amd64 and verify all 14 targets appear in `/targets/`