### PR TITLE
Fix crash-looping fuzzers: nullptr, FF constructor, deserialization

### DIFF
--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/harness/calldata.fuzzer.cpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/harness/calldata.fuzzer.cpp
@@ -310,7 +310,7 @@ extern "C" size_t LLVMFuzzerCustomMutator(uint8_t* data, size_t size, size_t max
         std::uniform_int_distribution<size_t> index_dist(0, input.init_calldata_values.size() - 1);
         size_t value_idx = index_dist(rng);
         std::uniform_int_distribution<uint64_t> dist(0, std::numeric_limits<uint64_t>::max());
-        FF value = FF(dist(rng), dist(rng), dist(rng), dist(rng));
+        FF value = FF(uint256_t(dist(rng), dist(rng), dist(rng), dist(rng)));
         input.init_calldata_values[value_idx] = value;
         break;
     }

--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/harness/ecc.fuzzer.cpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/harness/ecc.fuzzer.cpp
@@ -62,7 +62,7 @@ Fq random_fq_scalar(std::mt19937_64& rng)
         limbs[i] = dist(rng);
     }
 
-    return Fq(limbs[0], limbs[1], limbs[2], limbs[3]);
+    return Fq(uint256_t(limbs[0], limbs[1], limbs[2], limbs[3]));
 }
 
 // Right now just mutate the address within the u32 range
@@ -141,7 +141,13 @@ extern "C" size_t LLVMFuzzerCustomMutator(uint8_t* data, size_t size, size_t max
     std::mt19937_64 rng(seed);
 
     // Deserialize current input
-    EccFuzzerInput input = EccFuzzerInput::from_buffer(data);
+    EccFuzzerInput input;
+    try {
+        input = EccFuzzerInput::from_buffer(data);
+    } catch (...) {
+        input.to_buffer(data);
+        return sizeof(EccFuzzerInput);
+    }
 
     // We want to define sensible mutation of points as random bits are unlikely to yield valid points.
     // Lib Fuzzer will stack 5-6 mutations on top of each other by default
@@ -225,7 +231,12 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
     }
 
     // Parse input
-    const EccFuzzerInput input = EccFuzzerInput::from_buffer(data);
+    EccFuzzerInput input;
+    try {
+        input = EccFuzzerInput::from_buffer(data);
+    } catch (...) {
+        return 0;
+    }
     bool error = false;
 
     EmbeddedCurvePoint point_p = EmbeddedCurvePoint(input.p);

--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/harness/emit_public_log.fuzzer.cpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/harness/emit_public_log.fuzzer.cpp
@@ -191,7 +191,7 @@ extern "C" size_t LLVMFuzzerCustomMutator(uint8_t* data, size_t size, size_t max
     case 0: {
         // Set contract address
         std::uniform_int_distribution<uint64_t> addr_dist(0, std::numeric_limits<uint64_t>::max());
-        input.contract_address = FF(addr_dist(rng), addr_dist(rng), addr_dist(rng), addr_dist(rng));
+        input.contract_address = FF(uint256_t(addr_dist(rng), addr_dist(rng), addr_dist(rng), addr_dist(rng)));
         break;
     }
     case 1: {
@@ -221,7 +221,7 @@ extern "C" size_t LLVMFuzzerCustomMutator(uint8_t* data, size_t size, size_t max
         std::uniform_int_distribution<size_t> index_dist(0, input.init_log_values.size() - 1);
         size_t value_idx = index_dist(rng);
         std::uniform_int_distribution<uint64_t> dist(0, std::numeric_limits<uint64_t>::max());
-        FF value = FF(dist(rng), dist(rng), dist(rng), dist(rng));
+        FF value = FF(uint256_t(dist(rng), dist(rng), dist(rng), dist(rng)));
         input.init_log_values[value_idx] = value;
         break;
     }

--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/harness/memory.fuzzer.cpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/harness/memory.fuzzer.cpp
@@ -219,7 +219,7 @@ extern "C" size_t LLVMFuzzerCustomMutator(uint8_t* data, size_t size, size_t, un
         for (size_t i = 0; i < 4; ++i) {
             limbs[i] = dist(rng);
         }
-        auto random_value = FF(limbs[0], limbs[1], limbs[2], limbs[3]);
+        auto random_value = FF(uint256_t(limbs[0], limbs[1], limbs[2], limbs[3]));
         input.init_memory_values[value_idx] = MemoryValue::from_tag_truncating(memory_tags[tag_idx], random_value);
         break;
     }

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/byte_array/byte_array.fuzzer.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/byte_array/byte_array.fuzzer.hpp
@@ -343,7 +343,12 @@ template <typename Builder> class ByteArrayFuzzBase {
       public:
         std::vector<uint8_t> reference_value;
 
-        byte_array_t byte_array{ nullptr, std::vector<uint8_t>{} };
+        static Builder& dummy_builder()
+        {
+            static Builder b;
+            return b;
+        }
+        byte_array_t byte_array{ &dummy_builder(), std::vector<uint8_t>{} };
 
         static std::vector<uint8_t> get_value(const byte_array_t& byte_array) { return byte_array.get_value(); }
         static const std::vector<uint8_t>& bool_to_vector(const bool& b)


### PR DESCRIPTION
## Summary
- Fix 5 crash-looping fuzzer harnesses that were failing on startup due to constructor misuse or unhandled deserialization errors
- These are source-level fixes in barretenberg that both the `fuzzing-container` and `avm-fuzzing-container` depend on

## Fixes

| File | Issue | Fix |
|------|-------|-----|
| `byte_array.fuzzer.hpp` | `nullptr` builder causes null deref | Static `dummy_builder()` |
| `calldata.fuzzer.cpp` | `FF(u64,u64,u64,u64)` — no such constructor | `FF(uint256_t(...))` |
| `memory.fuzzer.cpp` | Same FF constructor issue | `FF(uint256_t(...))` |
| `emit_public_log.fuzzer.cpp` | Same FF constructor issue (2 places) | `FF(uint256_t(...))` |
| `ecc.fuzzer.cpp` | `Fq(u64,u64,u64,u64)` + off-curve point deser crash | `Fq(uint256_t(...))` + try-catch around `from_buffer()` |

## Test plan
- [ ] `cmake --preset fuzzing-avm && cmake --build build-fuzzing-avm --target harness_ecc_fuzzer` compiles
- [ ] `cmake --preset fuzzing && cmake --build build-fuzzing` compiles (byte_array fix)
- [ ] Run each fixed fuzzer for 30s to verify no immediate crash loop