### PR TITLE
fix(pxe): stop block synchronizer on PXE shutdown

### DIFF
--- a/yarn-project/pxe/src/block_synchronizer/block_synchronizer.test.ts
+++ b/yarn-project/pxe/src/block_synchronizer/block_synchronizer.test.ts
@@ -116,6 +116,43 @@ describe('BlockSynchronizer', () => {
     expect(rollback).toHaveBeenCalledWith(3, 4);
   });
 
+  describe('stop', () => {
+    it('resolves immediately when no sync is in progress', async () => {
+      await synchronizer.stop();
+      expect(blockStream.stop).toHaveBeenCalled();
+    });
+
+    it('waits for in-progress sync to complete', async () => {
+      let resolveSync!: () => void;
+      const syncBlocker = new Promise<void>(resolve => {
+        resolveSync = resolve;
+      });
+      blockStream.sync.mockReturnValue(syncBlocker);
+      aztecNode.getBlockHeader.mockResolvedValue((await L2Block.random(BlockNumber(0))).header);
+
+      // Start a sync (don't await)
+      const syncPromise = synchronizer.sync();
+
+      // stop() should not resolve until the sync finishes
+      let stopped = false;
+      const stopPromise = synchronizer.stop().then(() => {
+        stopped = true;
+      });
+
+      // Give the event loop a tick
+      await new Promise(resolve => setTimeout(resolve, 10));
+      expect(stopped).toBe(false);
+
+      // Release the sync
+      resolveSync();
+      await syncPromise;
+      await stopPromise;
+
+      expect(stopped).toBe(true);
+      expect(blockStream.stop).toHaveBeenCalled();
+    });
+  });
+
   describe('syncChainTip config', () => {
     it('updates anchor on blocks-added when syncChainTip is proposed (default)', async () => {
       synchronizer = createSynchronizer({ syncChainTip: 'proposed' });

--- a/yarn-project/pxe/src/block_synchronizer/block_synchronizer.ts
+++ b/yarn-project/pxe/src/block_synchronizer/block_synchronizer.ts
@@ -167,6 +167,12 @@ export class BlockSynchronizer implements L2BlockStreamEventHandler {
     }
   }
 
+  /** Stops the block synchronizer, waiting for any in-progress sync to complete. */
+  public async stop() {
+    await this.isSyncing;
+    await this.blockStream.stop();
+  }
+
   private async doSync() {
     let currentHeader;
 

--- a/yarn-project/pxe/src/pxe.ts
+++ b/yarn-project/pxe/src/pxe.ts
@@ -1180,6 +1180,7 @@ export class PXE {
    */
   public async stop(): Promise<void> {
     await this.jobQueue.end();
+    await this.blockStateSynchronizer.stop();
     await this.db.close();
   }
 }


### PR DESCRIPTION
## Summary

Fixes https://linear.app/aztec-labs/issue/F-339

The issue reported three resource leaks in `PXE.stop()`:

1. **`L2BlockStream` — active `RunningPromise` with timers**: The issue assumed the block stream runs in polling mode (`start()`), but in the PXE context `blockStream.start()` is never called — the stream is only used in manual sync mode via `blockStream.sync()`. So there are no active timers or `InterruptibleSleep` handles keeping the event loop alive. That said, calling `blockStream.stop()` is still good defensive practice in case the usage mode changes.

2. **LMDB store — open file descriptors**: `PXE.stop()` already calls `this.db.close()`, so this part was already fixed at some point after the issue was filed.

3. **HTTP keep-alive sockets from `createAztecNodeClient`**: Node's built-in `fetch` (undici) uses HTTP keep-alive by default — after a request completes, the underlying TCP socket stays open in case another request comes to the same host. These idle sockets register as active handles on the event loop, preventing `process.exit()` from happening naturally. Fixing this would require either using a custom undici `Agent`/`Pool` with a `close()` method, or setting `keepalive: false` (which hurts performance). In practice this doesn't matter: the sockets time out on their own after a few seconds, and for long-running services (the main use case) the process stays up anyway. Only relevant if you need the process to exit immediately after `stop()` without calling `process.exit(0)`.

**What this PR actually fixes**: `BlockSynchronizer` had no `stop()` method at all. If `PXE.stop()` were called while a sync was in progress, the ongoing sync could race against `db.close()`. While the job queue draining makes this unlikely in practice, adding an explicit `stop()` is the right defensive pattern and matches what `ServerWorldStateSynchronizer` already does.

### Changes
- Adds a `stop()` method to `BlockSynchronizer` that awaits any in-progress sync, then stops the block stream
- Calls `blockStateSynchronizer.stop()` in `PXE.stop()` between draining the job queue and closing the DB
- Shutdown order: job queue drains (no new syncs) → synchronizer stops (waits for in-flight sync) → DB closes