### PR TITLE
fix(pxe): bounds-check PropertySelector in pick_notes

### DIFF
--- a/yarn-project/pxe/src/contract_function_simulator/pick_notes.test.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/pick_notes.test.ts
@@ -376,4 +376,43 @@ describe('getNotes', () => {
 
     expect(() => pickNotes(notes, options)).toThrow('Invalid comparator value: 99');
   });
+
+  it('throws when selector.index is out of bounds', () => {
+    const notes = [createNote([1n, 2n])];
+    const options = {
+      selects: [
+        {
+          selector: { index: 5, offset: 0, length: 32 },
+          value: new Fr(1n),
+          comparator: Comparator.EQ,
+        },
+      ],
+    };
+
+    expect(() => pickNotes(notes, options)).toThrow(/index 5 out of bounds/);
+  });
+
+  it('throws when selector.index is out of bounds in a sort', () => {
+    const notes = [createNote([1n]), createNote([2n])];
+    const options = {
+      sorts: [{ selector: { index: 3, offset: 0, length: 32 }, order: SortOrder.ASC }],
+    };
+
+    expect(() => pickNotes(notes, options)).toThrow(/index 3 out of bounds/);
+  });
+
+  it('throws when selector.offset + selector.length exceeds Fr buffer size', () => {
+    const notes = [createNote([1n])];
+    const options = {
+      selects: [
+        {
+          selector: { index: 0, offset: 30, length: 5 },
+          value: new Fr(0n),
+          comparator: Comparator.EQ,
+        },
+      ],
+    };
+
+    expect(() => pickNotes(notes, options)).toThrow(/exceeds Fr buffer size/);
+  });
 });

--- a/yarn-project/pxe/src/contract_function_simulator/pick_notes.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/pick_notes.ts
@@ -85,6 +85,14 @@ interface ContainsNote {
 }
 
 const selectPropertyFromPackedNoteContent = (noteData: Fr[], selector: PropertySelector): Fr => {
+  if (selector.index >= noteData.length) {
+    throw new Error(`Property selector index ${selector.index} out of bounds for note with ${noteData.length} fields`);
+  }
+  if (selector.offset + selector.length > Fr.SIZE_IN_BYTES) {
+    throw new Error(
+      `Property selector range (offset=${selector.offset}, length=${selector.length}) exceeds Fr buffer size of ${Fr.SIZE_IN_BYTES} bytes`,
+    );
+  }
   const noteValueBuffer = noteData[selector.index].toBuffer();
   // Noir's PropertySelector counts offset from the LSB (last byte of the big-endian buffer),
   // so offset=0,length=Fr.SIZE_IN_BYTES reads the entire field, and offset=0,length=1 reads the last byte.


### PR DESCRIPTION
## Summary

- Validate `PropertySelector` bounds in `selectPropertyFromPackedNoteContent`: throw on out-of-range `selector.index` and on `selector.offset + selector.length > Fr.SIZE_IN_BYTES`.
- Without the offset+length check, `Buffer.subarray` silently clamps out-of-range ranges, so the padded buffer passed to `Fr.fromBuffer` can encode a truncated value and produce incorrect note selection or sort order with no error.

Fixes https://github.com/AztecProtocol/aztec-claude/issues/160