### PR TITLE
fix(pxe): guard private event store rollback against in-flight jobs

### DIFF
--- a/yarn-project/pxe/src/storage/private_event_store/private_event_store.test.ts
+++ b/yarn-project/pxe/src/storage/private_event_store/private_event_store.test.ts
@@ -669,7 +669,7 @@ describe('PrivateEventStore', () => {
           txIndexInBlock: 0,
           eventIndexInTx: 0,
         },
-        'test',
+        'before-rollback',
       );
       await privateEventStore.commit('before-rollback');
 
@@ -746,6 +746,33 @@ describe('PrivateEventStore', () => {
 
       expect(events.length).toBe(1);
       expect(events[0].packedEvent).toEqual(msgContent1);
+    });
+
+    it('throws when rollback is called while jobs are running', async () => {
+      await privateEventStore.storePrivateEventLog(
+        eventSelector,
+        randomness,
+        msgContent1,
+        Fr.random(),
+        {
+          contractAddress,
+          scope,
+          txHash: TxHash.random(),
+          l2BlockNumber: BlockNumber(100),
+          l2BlockHash,
+          txIndexInBlock: 0,
+          eventIndexInTx: 0,
+        },
+        'uncommitted-job',
+      );
+
+      await expect(privateEventStore.rollback(0, 10)).rejects.toThrow(
+        'PXE private event store rollback is not allowed while jobs are running',
+      );
+
+      await privateEventStore.discardStaged('uncommitted-job');
+
+      await expect(privateEventStore.rollback(0, 10)).resolves.not.toThrow();
     });
   });
 

--- a/yarn-project/pxe/src/storage/private_event_store/private_event_store.ts
+++ b/yarn-project/pxe/src/storage/private_event_store/private_event_store.ts
@@ -234,6 +234,10 @@ export class PrivateEventStore implements StagedStore {
    * IMPORTANT: This method must be called within a transaction to ensure atomicity.
    */
   public async rollback(blockNumber: number, synchedBlockNumber: number): Promise<void> {
+    if (this.#eventsForJob.size > 0) {
+      throw new Error('PXE private event store rollback is not allowed while jobs are running');
+    }
+
     // First pass: collect all event IDs for all blocks, starting reads during iteration to keep tx alive.
     const eventsByBlock: Map<number, { eventId: string; eventReadPromise: Promise<Buffer | undefined> }[]> = new Map();
 


### PR DESCRIPTION
## Problem

`PrivateEventStore.rollback()` did not check for in-flight jobs before rolling back persisted data. If a `chain-pruned` event triggered a rollback while a job had staged events in memory (`#eventsForJob`), the rollback would clear persisted data but leave staged data intact. When the job later committed, it would re-introduce invalidated data from pruned blocks.

`NoteStore` already had this guard, but `PrivateEventStore` was missing it.

## Fix

- Added the same `#eventsForJob.size > 0` check to `PrivateEventStore.rollback()` that `NoteStore` already uses, throwing if jobs are in progress.
- Fixed a pre-existing bug in the rollback test that used mismatched job IDs (stored under `'test'`, committed under `'before-rollback'`).
- Added a test for the new guard, mirroring the equivalent test in `NoteStore`.

Fixes https://github.com/AztecProtocol/aztec-claude/issues/305