### PR TITLE
fix(docs): restore Aztec.nr API reference links on v4.2.0

### DIFF
--- a/docs/developer_versioned_docs/version-v4.2.0/docs/aztec-nr/api.mdx
+++ b/docs/developer_versioned_docs/version-v4.2.0/docs/aztec-nr/api.mdx
@@ -10,11 +10,13 @@ import { useActiveVersion } from "@docusaurus/plugin-content-docs/client";
 
 export const useApiVersion = () => {
   const version = useActiveVersion("developer");
-  const versionName = version?.name || "current";
-  // Map Docusaurus version to API docs folder
-  if (versionName === "current") return "next";
-  if (versionName.includes("rc") || versionName.includes("testnet")) return "testnet";
-  return versionName;
+  if (!version || version.name === "current") return "next";
+  // Map Docusaurus version to API docs folder using version label
+  // Labels are set explicitly in docusaurus.config.js (e.g., "Mainnet (...)")
+  const label = version.label || "";
+  if (label.startsWith("Alpha")) return "mainnet";
+  if (label.startsWith("Testnet")) return "testnet";
+  return version.name;
 };
 
 export const ModuleLink = ({ path, children }) => {


### PR DESCRIPTION
## Summary

The Aztec.nr API reference page on docs.aztec.network (v4.2.0, currently the default/mainnet version) has broken links — e.g. [the main page](https://docs.aztec.network/developers/docs/aztec-nr/api) points at `/aztec-nr-api/v4.2.0/noir_aztec/index.html`, which 404s. The generated static docs actually live at `/aztec-nr-api/mainnet/...`.

## Root cause

When the v4.2.0 developer docs were cut (`0506bfd865e`, *"chore(docs): cut versioned developer docs for v4.2.0 (mainnet)"*), the snapshot of `docs/aztec-nr/api.mdx` landed with the **old** name-based `useApiVersion` logic:

```js
const versionName = version?.name || "current";
if (versionName === "current") return "next";
if (versionName.includes("rc") || versionName.includes("testnet")) return "testnet";
return versionName;  // ← v4.2.0 falls through here
```

For an `v4.2.0` version name there is no mainnet handling, so the hook returns `"v4.2.0"` and every `<ModuleLink>` produces a 404 href.

The `docs-developers` source was updated to the label-based logic back in `b3f4a7ec30a` (2026-03-27, *"docs: add mainnet developer docs version (v4.2.0-aztecnr-rc.2)"*), and the earlier `v4.2.0-aztecnr-rc.2` versioned snapshot had the correct logic — but the v4.2.0 cut somehow shipped with stale pre-mainnet code. Likely a stale `processed-docs/` during the cut.

## Fix

Replace the `useApiVersion` implementation in `developer_versioned_docs/version-v4.2.0/docs/aztec-nr/api.mdx` with the same label-based mapping used in `docs-developers/docs/aztec-nr/api.mdx`:

```js
if (!version || version.name === "current") return "next";
const label = version.label || "";
if (label.startsWith("Alpha")) return "mainnet";
if (label.startsWith("Testnet")) return "testnet";
return version.name;
```

For the active v4.2.0 version (label `"Alpha (v4.2.0)"`), `useApiVersion()` now returns `"mainnet"`, producing working URLs like `/aztec-nr-api/mainnet/noir_aztec/index.html`.

## Why `validate_api_ref_links.sh` didn't catch this

Two reasons worth a follow-up:

1. The script only matches static `](pathname:///aztec-nr-api/...)` and `href="/aztec-nr-api/..."`. The broken link is a JSX template literal (`href={\`/aztec-nr-api/${apiVersion}/...\`}`), which the regex doesn't see.
2. The script intentionally exits `0` on broken links (*"Exit 0 with warnings to avoid breaking builds initially"*), so it wouldn't fail `yarn build` regardless.

Not fixing those here — out of scope for this regression fix — but flagging.

## Test plan

- [ ] Run `yarn start` locally, switch to Alpha (v4.2.0), open Aztec.nr API Reference, confirm links resolve (no 404).
- [ ] After deploy, verify links on https://docs.aztec.network/developers/docs/aztec-nr/api point to `/aztec-nr-api/mainnet/...`.