### PR TITLE
fix(docs): use label-based API version mapping in aztec-nr api page

### DIFF
--- a/docs/docs-developers/docs/aztec-nr/api.mdx
+++ b/docs/docs-developers/docs/aztec-nr/api.mdx
@@ -10,11 +10,13 @@ import { useActiveVersion } from "@docusaurus/plugin-content-docs/client";
 
 export const useApiVersion = () => {
   const version = useActiveVersion("developer");
-  const versionName = version?.name || "current";
-  // Map Docusaurus version to API docs folder
-  if (versionName === "current") return "next";
-  if (versionName.includes("rc") || versionName.includes("testnet")) return "testnet";
-  return versionName;
+  if (!version || version.name === "current") return "next";
+  // Map Docusaurus version to API docs folder using version label
+  // Labels are set explicitly in docusaurus.config.js (e.g., "Mainnet (...)")
+  const label = version.label || "";
+  if (label.startsWith("Alpha")) return "mainnet";
+  if (label.startsWith("Testnet")) return "testnet";
+  return version.name;
 };
 
 export const ModuleLink = ({ path, children }) => {


### PR DESCRIPTION
## Summary

Mirrors the fix from #22617 (against `next`) on the `backport-to-v4-next-staging` branch, but applied to the unversioned source since this branch does not yet have a `v4.2.0` versioned snapshot.

## Background

The Aztec.nr API reference page in v4.2.0 on `next` shipped with the pre-mainnet `useApiVersion` logic — links pointed to `/aztec-nr-api/v4.2.0/...` instead of `/aztec-nr-api/mainnet/...` and 404'd on the live site. The root cause on `next` was a stale versioned snapshot, already patched in #22617.

On this branch, `docs-developers/docs/aztec-nr/api.mdx` still has the same stale name-based `useApiVersion`:

```js
const versionName = version?.name || "current";
if (versionName === "current") return "next";
if (versionName.includes("rc") || versionName.includes("testnet")) return "testnet";
return versionName;  // ← v4.2.0 would fall through here
```

If a mainnet version gets cut from this branch, the new snapshot would inherit the same bug. Pre-empting that here.

## Fix

Replace `useApiVersion` with the label-based mapping that already lives on `next`:

```js
if (!version || version.name === "current") return "next";
const label = version.label || "";
if (label.startsWith("Alpha")) return "mainnet";
if (label.startsWith("Testnet")) return "testnet";
return version.name;
```

The `Alpha (...)` label comes from `docusaurus.config.js` for mainnet-mapped versions, so `useApiVersion()` resolves to `"mainnet"` for any future v4.2.0+ snapshot cut from this branch.

## Test plan

- [ ] Run `yarn start` locally on this branch and verify the Aztec.nr API Reference page renders without broken links on the current (dev) version.
- [ ] When the next mainnet cut lands, confirm the resulting snapshot inherits the label-based logic.