### PR TITLE
fix(pxe): queue registerSender wipe to avoid racing with in-flight jobs

### DIFF
--- a/yarn-project/pxe/src/pxe.ts
+++ b/yarn-project/pxe/src/pxe.ts
@@ -582,9 +582,7 @@ export class PXE {
       this.log.info(`Added sender:\n ${sender.toString()}`);
       // Wipe the entire sync cache: the new sender's tagged logs could contain notes/events for any contract, so
       // all contracts must re-sync to discover them. Queued to avoid wiping while a job is in flight.
-      await this.#putInJobQueue(async () => {
-        this.contractSyncService.wipe();
-      });
+      await this.#putInJobQueue(() => Promise.resolve(this.contractSyncService.wipe()));
     } else {
       this.log.info(`Sender:\n "${sender.toString()}"\n already registered.`);
     }

--- a/yarn-project/pxe/src/pxe.ts
+++ b/yarn-project/pxe/src/pxe.ts
@@ -581,8 +581,10 @@ export class PXE {
     if (wasAdded) {
       this.log.info(`Added sender:\n ${sender.toString()}`);
       // Wipe the entire sync cache: the new sender's tagged logs could contain notes/events for any contract, so
-      // all contracts must re-sync to discover them.
-      this.contractSyncService.wipe();
+      // all contracts must re-sync to discover them. Queued to avoid wiping while a job is in flight.
+      await this.#putInJobQueue(async () => {
+        this.contractSyncService.wipe();
+      });
     } else {
       this.log.info(`Sender:\n "${sender.toString()}"\n already registered.`);
     }


### PR DESCRIPTION
## Summary

- `registerSender` calls `contractSyncService.wipe()` to force a re-sync after adding a new sender. This ran outside the job queue, so it could clear cached sync state while a simulation or proving job was in flight, causing that job to operate on stale or incomplete contract state.
- Fix: queue the `wipe()` call through `#putInJobQueue` so it waits for any in-flight job to finish before clearing the cache. The `addSender` store write stays outside the queue since it doesn't interfere with in-flight jobs.

Closes https://github.com/AztecProtocol/aztec-claude/issues/146

## Trade-off

`registerSender` now awaits the queued wipe, meaning it blocks until any in-flight job finishes. If this latency is a concern, we could fire-and-forget the wipe (`void this.#putInJobQueue(...)`) at the cost of the caller not knowing when the wipe completes.