### PR TITLE
fix(archiver): atomically update message syncpoint with deletions

### DIFF
--- a/yarn-project/archiver/src/archiver.ts
+++ b/yarn-project/archiver/src/archiver.ts
@@ -484,10 +484,12 @@ export class Archiver extends ArchiverDataSourceBase implements L2BlockSink, Tra
     );
     await this.updater.removeCheckpointsAfter(targetCheckpointNumber);
     this.log.info(`Rolling back L1 to L2 messages to checkpoint ${targetCheckpointNumber}`);
-    await this.store.rollbackL1ToL2MessagesToCheckpoint(targetCheckpointNumber);
+    await this.store.rollbackL1ToL2MessagesToCheckpoint(targetCheckpointNumber, {
+      l1BlockNumber: targetL1BlockNumber,
+      l1BlockHash: targetL1BlockHash,
+    });
     this.log.info(`Setting L1 syncpoints to ${targetL1BlockNumber}`);
     await this.store.setCheckpointSynchedL1BlockNumber(targetL1BlockNumber);
-    await this.store.setMessageSynchedL1Block({ l1BlockNumber: targetL1BlockNumber, l1BlockHash: targetL1BlockHash });
     if (targetL2BlockNumber < currentProvenBlock) {
       this.log.info(`Rolling back proven L2 checkpoint to ${targetCheckpointNumber}`);
       await this.updater.setProvenCheckpointNumber(targetCheckpointNumber);

--- a/yarn-project/archiver/src/modules/l1_synchronizer.ts
+++ b/yarn-project/archiver/src/modules/l1_synchronizer.ts
@@ -521,18 +521,17 @@ export class ArchiverL1Synchronizer implements Traceable {
       }
     }
 
-    // Delete everything after the common message we found.
-    const lastGoodIndex = commonMsg?.index;
-    this.log.warn(`Deleting all local L1 to L2 messages after index ${lastGoodIndex ?? 'undefined'}`);
-    await this.store.removeL1ToL2Messages(lastGoodIndex !== undefined ? lastGoodIndex + 1n : 0n);
-
-    // Update the syncpoint so the loop below reprocesses the changed messages. We go to the block before
+    // Compute the new syncpoint so the loop below reprocesses the changed messages. We go to the block before
     // the last common one, so we force reprocessing it, in case new messages were added on that same L1 block
     // after the last common message.
     const syncPointL1BlockNumber = commonMsg ? commonMsg.l1BlockNumber - 1n : this.l1Constants.l1StartBlock;
     const syncPointL1BlockHash = await this.getL1BlockHash(syncPointL1BlockNumber);
     messagesSyncPoint = { l1BlockNumber: syncPointL1BlockNumber, l1BlockHash: syncPointL1BlockHash };
-    await this.store.setMessageSynchedL1Block(messagesSyncPoint);
+
+    // Delete everything after the common message we found and update the syncpoint atomically.
+    const lastGoodIndex = commonMsg?.index;
+    this.log.warn(`Deleting all local L1 to L2 messages after index ${lastGoodIndex ?? 'undefined'}`);
+    await this.store.removeL1ToL2Messages(lastGoodIndex !== undefined ? lastGoodIndex + 1n : 0n, messagesSyncPoint);
     return messagesSyncPoint;
   }
 

--- a/yarn-project/archiver/src/store/kv_archiver_store.test.ts
+++ b/yarn-project/archiver/src/store/kv_archiver_store.test.ts
@@ -1811,7 +1811,7 @@ describe('KVArchiverDataStore', () => {
     it('returns the L1 block number that most recently added messages from inbox', async () => {
       const l1BlockHash = Buffer32.random();
       const l1BlockNumber = 10n;
-      await store.setMessageSynchedL1Block({ l1BlockNumber: 5n, l1BlockHash: Buffer32.random() });
+      await store.removeL1ToL2Messages(0n, { l1BlockNumber: 5n, l1BlockHash: Buffer32.random() });
       await store.addL1ToL2Messages([makeInboxMessage(Buffer16.ZERO, { l1BlockNumber, l1BlockHash })]);
       await expect(store.getSynchPoint()).resolves.toEqual({
         blocksSynchedTo: undefined,
@@ -1822,7 +1822,7 @@ describe('KVArchiverDataStore', () => {
     it('returns the latest syncpoint if latest message is behind', async () => {
       const l1BlockHash = Buffer32.random();
       const l1BlockNumber = 10n;
-      await store.setMessageSynchedL1Block({ l1BlockNumber, l1BlockHash });
+      await store.removeL1ToL2Messages(0n, { l1BlockNumber, l1BlockHash });
       const msg = makeInboxMessage(Buffer16.ZERO, { l1BlockNumber: 5n, l1BlockHash: Buffer32.random() });
       await store.addL1ToL2Messages([msg]);
       await expect(store.getSynchPoint()).resolves.toEqual({
@@ -2218,7 +2218,10 @@ describe('KVArchiverDataStore', () => {
       expect(await store.getL1ToL2Messages(CheckpointNumber(3))).toHaveLength(NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP);
       expect(await store.getL1ToL2Messages(CheckpointNumber(4))).toHaveLength(NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP);
 
-      await store.rollbackL1ToL2MessagesToCheckpoint(CheckpointNumber(2));
+      await store.rollbackL1ToL2MessagesToCheckpoint(CheckpointNumber(2), {
+        l1BlockNumber: 0n,
+        l1BlockHash: Buffer32.random(),
+      });
 
       expect(await store.getL1ToL2Messages(CheckpointNumber(1))).toHaveLength(NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP);
       expect(await store.getL1ToL2Messages(CheckpointNumber(2))).toHaveLength(NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP);
@@ -2232,7 +2235,7 @@ describe('KVArchiverDataStore', () => {
       const msgs = makeInboxMessagesWithFullBlocks(4, { initialCheckpointNumber: CheckpointNumber(1) });
       await store.addL1ToL2Messages(msgs);
 
-      await store.removeL1ToL2Messages(msgs[13].index);
+      await store.removeL1ToL2Messages(msgs[13].index, { l1BlockNumber: 0n, l1BlockHash: Buffer32.random() });
       await checkMessages(msgs.slice(0, 13));
     });
   });

--- a/yarn-project/archiver/src/store/kv_archiver_store.ts
+++ b/yarn-project/archiver/src/store/kv_archiver_store.ts
@@ -561,13 +561,6 @@ export class KVArchiverDataStore implements ContractDataSource {
   }
 
   /**
-   * Stores the l1 block that messages have been synched until
-   */
-  async setMessageSynchedL1Block(l1Block: L1BlockId) {
-    await this.#messageStore.setSynchedL1Block(l1Block);
-  }
-
-  /**
    * Returns the number of the most recent proven block
    * @returns The number of the most recent proven block
    */
@@ -594,9 +587,12 @@ export class KVArchiverDataStore implements ContractDataSource {
     return this.db.estimateSize();
   }
 
-  /** Deletes all L1 to L2 messages up until (excluding) the target checkpoint number. */
-  public rollbackL1ToL2MessagesToCheckpoint(targetCheckpointNumber: CheckpointNumber): Promise<void> {
-    return this.#messageStore.rollbackL1ToL2MessagesToCheckpoint(targetCheckpointNumber);
+  /** Deletes all L1 to L2 messages up until (excluding) the target checkpoint number and updates the message syncpoint atomically. */
+  public rollbackL1ToL2MessagesToCheckpoint(
+    targetCheckpointNumber: CheckpointNumber,
+    syncPoint: L1BlockId,
+  ): Promise<void> {
+    return this.#messageStore.rollbackL1ToL2MessagesToCheckpoint(targetCheckpointNumber, syncPoint);
   }
 
   /** Returns an async iterator to all L1 to L2 messages on the range. */
@@ -604,9 +600,9 @@ export class KVArchiverDataStore implements ContractDataSource {
     return this.#messageStore.iterateL1ToL2Messages(range);
   }
 
-  /** Removes all L1 to L2 messages starting from the given index (inclusive). */
-  public removeL1ToL2Messages(startIndex: bigint): Promise<void> {
-    return this.#messageStore.removeL1ToL2Messages(startIndex);
+  /** Removes all L1 to L2 messages starting from the given index (inclusive) and updates the message syncpoint atomically. */
+  public removeL1ToL2Messages(startIndex: bigint, syncPoint: L1BlockId): Promise<void> {
+    return this.#messageStore.removeL1ToL2Messages(startIndex, syncPoint);
   }
 
   /** Returns the last synced validation status of the pending chain. */

--- a/yarn-project/archiver/src/store/message_store.ts
+++ b/yarn-project/archiver/src/store/message_store.ts
@@ -217,7 +217,7 @@ export class MessageStore {
     }
   }
 
-  public removeL1ToL2Messages(startIndex: bigint): Promise<void> {
+  public removeL1ToL2Messages(startIndex: bigint, syncPoint: L1BlockId): Promise<void> {
     this.#log.debug(`Deleting L1 to L2 messages from index ${startIndex}`);
     let deleteCount = 0;
 
@@ -231,14 +231,18 @@ export class MessageStore {
         deleteCount++;
       }
       await this.increaseTotalMessageCount(-deleteCount);
+      await this.setSynchedL1Block(syncPoint);
       this.#log.warn(`Deleted ${deleteCount} L1 to L2 messages from index ${startIndex} from the store`);
     });
   }
 
-  public rollbackL1ToL2MessagesToCheckpoint(targetCheckpointNumber: CheckpointNumber): Promise<void> {
+  public rollbackL1ToL2MessagesToCheckpoint(
+    targetCheckpointNumber: CheckpointNumber,
+    syncPoint: L1BlockId,
+  ): Promise<void> {
     this.#log.debug(`Deleting L1 to L2 messages up to target checkpoint ${targetCheckpointNumber}`);
     const startIndex = InboxLeaf.smallestIndexForCheckpoint(CheckpointNumber(targetCheckpointNumber + 1));
-    return this.removeL1ToL2Messages(startIndex);
+    return this.removeL1ToL2Messages(startIndex, syncPoint);
   }
 
   private indexToKey(index: bigint): number {


### PR DESCRIPTION
## Motivation

The archiver previously deleted L1-to-L2 messages and updated the message syncpoint in two separate DB transactions. A crash between the two would leave the store inconsistent — messages deleted but the syncpoint still pointing to the old tip, or vice versa — which could corrupt reorg recovery.

## Approach

Removed the public `setMessageSynchedL1Block` method from the archiver store and made the syncpoint a mandatory argument to `removeL1ToL2Messages` and `rollbackL1ToL2MessagesToCheckpoint`. The message store now writes both the deletion and the syncpoint update inside a single `db.transactionAsync`, guaranteeing atomicity.

## Changes

- **archiver (message store)**: `removeL1ToL2Messages` and `rollbackL1ToL2MessagesToCheckpoint` now take an `L1BlockId` syncPoint and update it in the same transaction as the delete. Dropped the standalone `setMessageSynchedL1Block` from `KVArchiverDataStore`.
- **archiver (callers)**: `l1_synchronizer` and `archiver` compute the target syncpoint up front and pass it to the deletion methods in a single call.
- **archiver (tests)**: Replaced `setMessageSynchedL1Block` usages with `removeL1ToL2Messages(0n, syncPoint)` and threaded the new argument through the rollback/remove test cases.