### PR TITLE
fix: reuse anchor block in kernel oracle

### DIFF
--- a/yarn-project/pxe/src/private_kernel/private_kernel_oracle.ts
+++ b/yarn-project/pxe/src/private_kernel/private_kernel_oracle.ts
@@ -14,6 +14,7 @@ import { computePublicDataTreeLeafSlot } from '@aztec/stdlib/hash';
 import type { AztecNode } from '@aztec/stdlib/interfaces/client';
 import { UpdatedClassIdHints } from '@aztec/stdlib/kernel';
 import type { NullifierMembershipWitness } from '@aztec/stdlib/trees';
+import type { BlockHeader } from '@aztec/stdlib/tx';
 import type { VerificationKeyAsFields } from '@aztec/stdlib/vks';
 
 import type { ContractStore } from '../storage/contract_store/contract_store.js';
@@ -26,7 +27,7 @@ export class PrivateKernelOracle {
     private contractStore: ContractStore,
     private keyStore: KeyStore,
     private node: AztecNode,
-    private blockHash: BlockHash,
+    private blockHeader: BlockHeader,
   ) {}
 
   /** Retrieves the preimage of a contract address from the registered contract instances db. */
@@ -80,22 +81,20 @@ export class PrivateKernelOracle {
   }
 
   /** Returns a membership witness with the sibling path and leaf index in our note hash tree. */
-  getNoteHashMembershipWitness(noteHash: Fr): Promise<MembershipWitness<typeof NOTE_HASH_TREE_HEIGHT> | undefined> {
-    return this.node.getNoteHashMembershipWitness(this.blockHash, noteHash);
+  async getNoteHashMembershipWitness(
+    noteHash: Fr,
+  ): Promise<MembershipWitness<typeof NOTE_HASH_TREE_HEIGHT> | undefined> {
+    return this.node.getNoteHashMembershipWitness(await this.blockHeader.hash(), noteHash);
   }
 
   /** Returns a membership witness with the sibling path and leaf index in our nullifier indexed merkle tree. */
-  getNullifierMembershipWitness(nullifier: Fr): Promise<NullifierMembershipWitness | undefined> {
-    return this.node.getNullifierMembershipWitness(this.blockHash, nullifier);
+  async getNullifierMembershipWitness(nullifier: Fr): Promise<NullifierMembershipWitness | undefined> {
+    return this.node.getNullifierMembershipWitness(await this.blockHeader.hash(), nullifier);
   }
 
   /** Returns the root of our note hash merkle tree. */
-  async getNoteHashTreeRoot(): Promise<Fr> {
-    const header = await this.node.getBlockHeader(this.blockHash);
-    if (!header) {
-      throw new Error(`No block header found for block hash ${this.blockHash}`);
-    }
-    return header.state.partial.noteHashTree.root;
+  getNoteHashTreeRoot(): Fr {
+    return this.blockHeader.state.partial.noteHashTree.root;
   }
 
   /**
@@ -126,14 +125,16 @@ export class PrivateKernelOracle {
       ProtocolContractAddress.ContractInstanceRegistry,
       delayedPublicMutableHashSlot,
     );
-    const updatedClassIdWitness = await this.node.getPublicDataWitness(this.blockHash, hashLeafSlot);
+    const blockHash = await this.blockHeader.hash();
+
+    const updatedClassIdWitness = await this.node.getPublicDataWitness(blockHash, hashLeafSlot);
 
     if (!updatedClassIdWitness) {
       throw new Error(`No public data tree witness found for ${hashLeafSlot}`);
     }
 
     const readStorage = (storageSlot: Fr) =>
-      this.node.getPublicStorageAt(this.blockHash, ProtocolContractAddress.ContractInstanceRegistry, storageSlot);
+      this.node.getPublicStorageAt(blockHash, ProtocolContractAddress.ContractInstanceRegistry, storageSlot);
     const delayedPublicMutableValues = await DelayedPublicMutableValues.readFromTree(
       delayedPublicMutableSlot,
       readStorage,

--- a/yarn-project/pxe/src/private_kernel/private_kernel_oracle.ts
+++ b/yarn-project/pxe/src/private_kernel/private_kernel_oracle.ts
@@ -7,7 +7,6 @@ import { getVKIndex, getVKSiblingPath } from '@aztec/noir-protocol-circuits-type
 import { ProtocolContractAddress } from '@aztec/protocol-contracts';
 import type { FunctionSelector } from '@aztec/stdlib/abi';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
-import { BlockHash } from '@aztec/stdlib/block';
 import { type ContractInstanceWithAddress, computeSaltedInitializationHash } from '@aztec/stdlib/contract';
 import { DelayedPublicMutableValues, DelayedPublicMutableValuesWithHash } from '@aztec/stdlib/delayed-public-mutable';
 import { computePublicDataTreeLeafSlot } from '@aztec/stdlib/hash';

--- a/yarn-project/pxe/src/pxe.ts
+++ b/yarn-project/pxe/src/pxe.ts
@@ -486,8 +486,7 @@ export class PXE {
     config: PrivateKernelExecutionProverConfig,
   ): Promise<PrivateKernelExecutionProofOutput<PrivateKernelTailCircuitPublicInputs>> {
     const anchorBlockHeader = await this.anchorBlockStore.getBlockHeader();
-    const anchorBlockHash = await anchorBlockHeader.hash();
-    const kernelOracle = new PrivateKernelOracle(this.contractStore, this.keyStore, this.node, anchorBlockHash);
+    const kernelOracle = new PrivateKernelOracle(this.contractStore, this.keyStore, this.node, anchorBlockHeader);
     const kernelTraceProver = new PrivateKernelExecutionProver(
       kernelOracle,
       proofCreator,


### PR DESCRIPTION
More attempts at reducing our RPC load. This will result in broadly the same amount of roundtrips, but we'll reduce the bandwidth consumed (which is important in the browser)