### PR TITLE
fix(pxe): serialize block stream event handling to prevent race conditions

### DIFF
--- a/yarn-project/pxe/src/block_synchronizer/block_synchronizer.ts
+++ b/yarn-project/pxe/src/block_synchronizer/block_synchronizer.ts
@@ -1,5 +1,6 @@
 import { BlockNumber } from '@aztec/foundation/branded-types';
 import { type Logger, type LoggerBindings, createLogger } from '@aztec/foundation/log';
+import { SerialQueue } from '@aztec/foundation/queue';
 import type { AztecAsyncKVStore } from '@aztec/kv-store';
 import type { L2TipsKVStore } from '@aztec/kv-store/stores';
 import { BlockHash, L2BlockStream, type L2BlockStreamEvent, type L2BlockStreamEventHandler } from '@aztec/stdlib/block';
@@ -20,6 +21,7 @@ import type { PrivateEventStore } from '../storage/private_event_store/private_e
 export class BlockSynchronizer implements L2BlockStreamEventHandler {
   private log: Logger;
   private isSyncing: Promise<void> | undefined;
+  private readonly eventQueue = new SerialQueue();
   protected readonly blockStream: L2BlockStream;
 
   constructor(
@@ -35,6 +37,7 @@ export class BlockSynchronizer implements L2BlockStreamEventHandler {
   ) {
     this.log = createLogger('pxe:block_synchronizer', bindings);
     this.blockStream = this.createBlockStream(config);
+    this.eventQueue.start();
   }
 
   protected createBlockStream(config: Partial<BlockSynchronizerConfig>): L2BlockStream {
@@ -52,8 +55,12 @@ export class BlockSynchronizer implements L2BlockStreamEventHandler {
     );
   }
 
-  /** Handle events emitted by the block stream. */
-  public async handleBlockStreamEvent(event: L2BlockStreamEvent): Promise<void> {
+  /** Handle events emitted by the block stream. Serialized to prevent concurrent mutations to anchor state. */
+  public handleBlockStreamEvent(event: L2BlockStreamEvent): Promise<void> {
+    return this.eventQueue.put(() => this.doHandleBlockStreamEvent(event));
+  }
+
+  private async doHandleBlockStreamEvent(event: L2BlockStreamEvent): Promise<void> {
     await this.l2TipsStore.handleBlockStreamEvent(event);
 
     switch (event.type) {
@@ -167,10 +174,11 @@ export class BlockSynchronizer implements L2BlockStreamEventHandler {
     }
   }
 
-  /** Stops the block synchronizer, waiting for any in-progress sync to complete. */
+  /** Stops the block synchronizer, waiting for any in-progress sync and queued events to complete. */
   public async stop() {
     await this.isSyncing;
     await this.blockStream.stop();
+    await this.eventQueue.end();
   }
 
   private async doSync() {


### PR DESCRIPTION
## Problem

`BlockSynchronizer.handleBlockStreamEvent` is a public method that assumes serial invocation. While the L2BlockStream currently dispatches events serially, nothing enforces this at the handler level. If two calls were to run concurrently, a `blocks-added` event could race with a `chain-pruned` event, causing the anchor block header to be read and then modified between the check and the rollback.

## Fix

Serialize `handleBlockStreamEvent` through a `SerialQueue` (the same primitive used elsewhere in the codebase for this pattern). The queue is started in the constructor and ended on `stop()`, ensuring all in-flight events complete before shutdown.

Fixes AztecProtocol/aztec-claude#162