### PR TITLE
fix(pxe): throw error on origin/contract address mismatch in simulation

### DIFF
--- a/yarn-project/pxe/src/contract_function_simulator/contract_function_simulator.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/contract_function_simulator.ts
@@ -208,7 +208,7 @@ export class ContractFunctionSimulator {
     }
 
     if (request.origin !== contractAddress) {
-      this.log.warn(
+      throw new Error(
         `Request origin does not match contract address in simulation. Request origin: ${request.origin}, contract address: ${contractAddress}`,
       );
     }

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution.test.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution.test.ts
@@ -486,6 +486,40 @@ describe('Private Execution test suite', () => {
     });
   });
 
+  it('throws when request origin does not match contract address', async () => {
+    const contractAddress = await mockContractInstance(TestContractArtifact);
+    const differentAddress = await AztecAddress.random();
+    contracts[differentAddress.toString()] = TestContractArtifact;
+
+    const functionArtifact = getFunctionArtifactByName(TestContractArtifact, 'emit_array_as_encrypted_log');
+    const selector = await FunctionSelector.fromNameAndParameters(functionArtifact.name, functionArtifact.parameters);
+    const hashedArguments = await HashedValues.fromArgs(
+      encodeArguments(functionArtifact, [Fr.ZERO, times(5, () => Fr.random()), owner, false]),
+    );
+
+    const txRequest = TxExecutionRequest.from({
+      origin: differentAddress,
+      firstCallArgsHash: hashedArguments.hash,
+      functionSelector: selector,
+      txContext: TxContext.from(txContextFields),
+      argsOfCalls: [hashedArguments],
+      authWitnesses: [],
+      capsules: [],
+      salt: Fr.random(),
+    });
+
+    await expect(
+      acirSimulator.run(txRequest, {
+        contractAddress,
+        selector,
+        anchorBlockHeader,
+        senderForTags,
+        jobId: TEST_JOB_ID,
+        scopes: [owner],
+      }),
+    ).rejects.toThrow('Request origin does not match contract address');
+  });
+
   describe('stateful test contract', () => {
     let contractAddress: AztecAddress;
     const mockFirstNullifier = new Fr(1111);


### PR DESCRIPTION
## Summary

- Upgrades the origin/contract address mismatch check in `ContractFunctionSimulator.run()` from a warning to a thrown error, preventing simulation from proceeding with inconsistent addresses that could produce misleading results.
- Adds a test that verifies the error is thrown when `request.origin` differs from the `contractAddress` option.

Fixes AztecProtocol/aztec-claude#314