### PR TITLE
fix(pxe): verify private event commitment matches content

### DIFF
--- a/yarn-project/pxe/src/events/event_service.test.ts
+++ b/yarn-project/pxe/src/events/event_service.test.ts
@@ -1,10 +1,11 @@
 import { BlockNumber } from '@aztec/foundation/branded-types';
 import { Fr } from '@aztec/foundation/curves/bn254';
+import type { Logger } from '@aztec/foundation/log';
 import { openTmpStore } from '@aztec/kv-store/lmdb-v2';
 import { EventSelector } from '@aztec/stdlib/abi';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
 import { BlockHash } from '@aztec/stdlib/block';
-import { siloNullifier } from '@aztec/stdlib/hash';
+import { computePrivateEventCommitment, siloNullifier } from '@aztec/stdlib/hash';
 import type { AztecNode } from '@aztec/stdlib/interfaces/server';
 import { makeBlockHeader } from '@aztec/stdlib/testing';
 import { type IndexedTxEffect, TxEffect } from '@aztec/stdlib/tx';
@@ -28,6 +29,7 @@ describe('validateAndStoreEvent', () => {
 
   let privateEventStore: PrivateEventStore;
   let aztecNode: ReturnType<typeof mock<AztecNode>>;
+  let logger: ReturnType<typeof mock<Logger>>;
 
   let eventService: EventService;
 
@@ -47,7 +49,7 @@ describe('validateAndStoreEvent', () => {
     randomness = Fr.random();
     eventContent = [Fr.random(), Fr.random()];
 
-    eventCommitment = Fr.random();
+    eventCommitment = await computePrivateEventCommitment(randomness, eventSelector.toField(), eventContent);
     eventNullifier = await siloNullifier(contractAddress, eventCommitment);
 
     txEffect = TxEffect.from({
@@ -70,11 +72,13 @@ describe('validateAndStoreEvent', () => {
 
     aztecNode.getTxEffect.mockImplementation(() => Promise.resolve(indexedTxEffect));
 
-    eventService = new EventService(anchorBlockHeader, aztecNode, privateEventStore, 'test');
+    logger = mock<Logger>();
+    eventService = new EventService(anchorBlockHeader, aztecNode, privateEventStore, 'test', logger);
   });
 
   async function runStoreEvent(
     overrides: {
+      eventContent?: Fr[];
       eventCommitment?: Fr;
     } = {},
   ) {
@@ -82,7 +86,7 @@ describe('validateAndStoreEvent', () => {
       contractAddress,
       eventSelector,
       randomness,
-      eventContent,
+      overrides.eventContent || eventContent,
       overrides.eventCommitment || eventCommitment,
       txEffect.txHash,
       recipient,
@@ -109,10 +113,12 @@ describe('validateAndStoreEvent', () => {
   });
 
   it('should not store event if event commitment is not in the tx effects', async () => {
-    // The service logs a warning and returns early rather than throwing
-    await runStoreEvent({ eventCommitment: Fr.random() });
+    // Use a valid (content -> commitment) pair that just isn't present in the tx.
+    const otherContent = [Fr.random()];
+    const otherCommitment = await computePrivateEventCommitment(randomness, eventSelector.toField(), otherContent);
 
-    // Verify event was not stored
+    await runStoreEvent({ eventContent: otherContent, eventCommitment: otherCommitment });
+
     const result = await privateEventStore.getPrivateEvents(eventSelector, {
       contractAddress,
       fromBlock: blockNumber,
@@ -121,6 +127,22 @@ describe('validateAndStoreEvent', () => {
     });
 
     expect(result.length).toEqual(0);
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringMatching(/commitment is not present in its tx/));
+  });
+
+  it('should not store event if content does not match the event commitment', async () => {
+    // Commitment is legitimately present in the tx, but the provided content does not hash to it.
+    await runStoreEvent({ eventContent: [Fr.random(), Fr.random()] });
+
+    const result = await privateEventStore.getPrivateEvents(eventSelector, {
+      contractAddress,
+      fromBlock: blockNumber,
+      toBlock: blockNumber + 1,
+      scopes: [recipient],
+    });
+
+    expect(result.length).toEqual(0);
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringMatching(/content does not hash to the provided commitment/));
   });
 
   it('should store event for later retrieval', async () => {

--- a/yarn-project/pxe/src/events/event_service.ts
+++ b/yarn-project/pxe/src/events/event_service.ts
@@ -2,7 +2,7 @@ import type { Fr } from '@aztec/foundation/curves/bn254';
 import { createLogger } from '@aztec/foundation/log';
 import type { EventSelector } from '@aztec/stdlib/abi';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
-import { siloNullifier } from '@aztec/stdlib/hash';
+import { computePrivateEventCommitment, siloNullifier } from '@aztec/stdlib/hash';
 import type { AztecNode } from '@aztec/stdlib/interfaces/server';
 import type { BlockHeader, TxHash } from '@aztec/stdlib/tx';
 
@@ -26,6 +26,18 @@ export class EventService {
     txHash: TxHash,
     scope: AztecAddress,
   ): Promise<void> {
+    // Defense-in-depth: the built-in private-event path derives this commitment from content before enqueueing, but
+    // unconstrained PXE-side code (e.g. a custom message handler) can reach this oracle with arbitrary
+    // (content, commitment) pairs. Without this check it could bind arbitrary content to a legitimate tx nullifier,
+    // causing PXE to surface fabricated event data.
+    const recomputedCommitment = await computePrivateEventCommitment(randomness, selector.toField(), content);
+    if (!recomputedCommitment.equals(eventCommitment)) {
+      this.log.warn(
+        `Skipping event whose content does not hash to the provided commitment. contract=${contractAddress}, selector=${selector}, eventCommitment=${eventCommitment}, txHash=${txHash}, recomputedCommitment=${recomputedCommitment}`,
+      );
+      return;
+    }
+
     // While using 'latest' block number would be fine for private events since they cannot be accessed from Aztec.nr
     // (and thus we're less concerned about being ahead of the synced block), we use the synced block number to
     // maintain consistent behavior in the PXE. Additionally, events should never be ahead of the synced block here

--- a/yarn-project/stdlib/src/hash/hash.ts
+++ b/yarn-project/stdlib/src/hash/hash.ts
@@ -103,6 +103,18 @@ export function computeLogTag(rawTag: number | bigint | boolean | Fr | Buffer, d
   return poseidon2HashWithSeparator([new Fr(rawTag)], domSep);
 }
 
+/**
+ * Computes the commitment of a private event from its preimage.
+ * @param randomness - Random value emitted alongside the event to prevent preimage brute-forcing.
+ * @param eventSelector - Event selector as an Fr.
+ * @param content - Serialized event content.
+ *
+ * @dev Must match the implementation in aztec-nr/aztec/src/event/event_interface.nr > compute_private_serialized_event_commitment
+ */
+export function computePrivateEventCommitment(randomness: Fr, eventSelector: Fr, content: Fr[]): Promise<Fr> {
+  return poseidon2HashWithSeparator([randomness, eventSelector, ...content], DomainSeparator.EVENT_COMMITMENT);
+}
+
 export function computeSiloedPrivateLogFirstField(contract: AztecAddress, field: Fr): Promise<Fr> {
   return poseidon2HashWithSeparator([contract, field], DomainSeparator.PRIVATE_LOG_FIRST_FIELD);
 }


### PR DESCRIPTION
## Problem

`EventService.validateAndStoreEvent` received `content`, `randomness`, `selector`, and `eventCommitment` as independent inputs. It verified that `siloNullifier(contractAddress, eventCommitment)` was present in the tx's nullifiers, but never recomputed the commitment from `(randomness, selector, content)`. Unconstrained PXE-side contract code (e.g. a custom message handler, or a utility function that enqueues validation requests and then calls `validate_and_store_enqueued_notes_and_events` in the same call frame) could therefore bind arbitrary content to a legitimate tx nullifier, causing PXE to surface fabricated event data through `getPrivateEvents`.

The built-in private-event path already derives the commitment from content right before enqueueing (see `process_private_event_msg` in `aztec-nr/aztec/src/messages/discovery/private_events.nr`), so the happy path was safe. The gap was in contract-authored paths.

## Fix

- Add `computePrivateEventCommitment` to stdlib, mirroring `compute_private_serialized_event_commitment` on the Noir side.
- `validateAndStoreEvent` recomputes the commitment and warns + skips on mismatch.

Fixes AztecProtocol/aztec-claude#164