### PR TITLE
feat: Multi app per kernel

### DIFF
--- a/barretenberg/cpp/src/barretenberg/chonk/batched_honk_translator/batched_honk_translator.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/chonk/batched_honk_translator/batched_honk_translator.test.cpp
@@ -140,12 +140,12 @@ class BatchedHonkTranslatorTests : public ::testing::Test {
             m.add_entry(round, "ECC_OP_WIRE_" + std::to_string(i), G);
         }
         // DataBus entities:
-        for (const auto& label : { "CALLDATA",
-                                   "CALLDATA_READ_COUNTS",
-                                   "SECONDARY_CALLDATA",
-                                   "SECONDARY_CALLDATA_READ_COUNTS",
-                                   "RETURN_DATA",
-                                   "RETURN_DATA_READ_COUNTS" }) {
+        for (const auto& label : { "KERNEL_CALLDATA",
+                                   "KERNEL_CALLDATA_READ_COUNTS",
+                                   "APP_CALLDATA",
+                                   "APP_CALLDATA_READ_COUNTS",
+                                   "RETURNDATA",
+                                   "RETURNDATA_READ_COUNTS" }) {
             m.add_entry(round, label, G);
         }
         m.add_challenge(round, "eta");
@@ -160,9 +160,9 @@ class BatchedHonkTranslatorTests : public ::testing::Test {
 
         // ── Round 2: MegaZK logderiv inverses + Z_PERM + translator Oink ─────────
         m.add_entry(round, "LOOKUP_INVERSES", G);
-        m.add_entry(round, "CALLDATA_INVERSES", G);
-        m.add_entry(round, "SECONDARY_CALLDATA_INVERSES", G);
-        m.add_entry(round, "RETURN_DATA_INVERSES", G);
+        m.add_entry(round, "KERNEL_CALLDATA_INVERSES", G);
+        m.add_entry(round, "APP_CALLDATA_INVERSES", G);
+        m.add_entry(round, "RETURNDATA_INVERSES", G);
         m.add_entry(round, "Z_PERM", G);
         // Translator Oink: vk_hash, masking commitment, 10 wire commitments
         m.add_entry(round, "vk_hash", Fr);

--- a/barretenberg/cpp/src/barretenberg/chonk/chonk.cpp
+++ b/barretenberg/cpp/src/barretenberg/chonk/chonk.cpp
@@ -173,8 +173,8 @@ Chonk::PublicInputsResult Chonk::process_public_inputs_and_consistency_checks(
 
         // App return data. Mega currently exposes a single app calldata witness commitment
         // (`secondary_calldata`), so MAX_APPS_PER_KERNEL remains 1.
+        static_assert(MAX_APPS_PER_KERNEL == 1, "Multiple app calldata witness columns are not wired yet");
         for (size_t idx = 0; idx < MAX_APPS_PER_KERNEL; ++idx) {
-            BB_ASSERT_EQ(MAX_APPS_PER_KERNEL, 1UL, "Multiple app calldata witness columns are not wired yet");
             bool app_return_data_match =
                 kernel_input.app_return_data[idx].get_value() == witness_commitments.secondary_calldata.get_value();
             BB_ASSERT_DEBUG(app_return_data_match,

--- a/barretenberg/cpp/src/barretenberg/chonk/chonk.cpp
+++ b/barretenberg/cpp/src/barretenberg/chonk/chonk.cpp
@@ -172,9 +172,9 @@ Chonk::PublicInputsResult Chonk::process_public_inputs_and_consistency_checks(
         kernel_input.kernel_return_data.incomplete_assert_equal(witness_commitments.calldata);
 
         // App return data. Mega currently exposes a single app calldata witness commitment
-        // (`secondary_calldata`), so NUM_APP_PER_KERNEL remains 1.
-        for (size_t idx = 0; idx < NUM_APP_PER_KERNEL; ++idx) {
-            BB_ASSERT_EQ(NUM_APP_PER_KERNEL, 1UL, "Multiple app calldata witness columns are not wired yet");
+        // (`secondary_calldata`), so MAX_APPS_PER_KERNEL remains 1.
+        for (size_t idx = 0; idx < MAX_APPS_PER_KERNEL; ++idx) {
+            BB_ASSERT_EQ(MAX_APPS_PER_KERNEL, 1UL, "Multiple app calldata witness columns are not wired yet");
             bool app_return_data_match =
                 kernel_input.app_return_data[idx].get_value() == witness_commitments.secondary_calldata.get_value();
             BB_ASSERT_DEBUG(app_return_data_match,
@@ -386,7 +386,7 @@ void Chonk::complete_kernel_circuit_logic(ClientCircuit& circuit)
 
         auto kernel_return_data_commitment = bus_depot.get_kernel_return_data_commitment(circuit);
         KernelIO::AppReturnDataCommitments app_return_data_commitments;
-        for (size_t idx = 0; idx < NUM_APP_PER_KERNEL; ++idx) {
+        for (size_t idx = 0; idx < MAX_APPS_PER_KERNEL; ++idx) {
             app_return_data_commitments[idx] = bus_depot.get_app_return_data_commitment(circuit, idx);
         }
 

--- a/barretenberg/cpp/src/barretenberg/chonk/chonk.cpp
+++ b/barretenberg/cpp/src/barretenberg/chonk/chonk.cpp
@@ -147,7 +147,8 @@ Chonk::PublicInputsResult Chonk::process_public_inputs_and_consistency_checks(
     const StdlibVerifierInputs& verifier_inputs,
     std::vector<StdlibFF>& public_inputs,
     WitnessCommitments& witness_commitments,
-    const std::optional<StdlibFF>& prev_accum_hash)
+    const std::optional<StdlibFF>& prev_accum_hash,
+    const std::optional<size_t>& app_return_data_idx)
 {
     if (verifier_inputs.is_kernel) {
         BB_ASSERT_EQ(verifier_inputs.type == QUEUE_TYPE::HN || verifier_inputs.type == QUEUE_TYPE::HN_TAIL ||
@@ -171,14 +172,19 @@ Chonk::PublicInputsResult Chonk::process_public_inputs_and_consistency_checks(
                                                                        << witness_commitments.calldata.get_value());
         kernel_input.kernel_return_data.incomplete_assert_equal(witness_commitments.calldata);
 
-        // App return data
-        bool app_return_data_match =
-            kernel_input.app_return_data.get_value() == witness_commitments.secondary_calldata.get_value();
-        BB_ASSERT_DEBUG(app_return_data_match,
-                        "app_return_data mismatch: proof contains "
-                            << kernel_input.app_return_data.get_value() << " but secondary_calldata commitment is "
-                            << witness_commitments.secondary_calldata.get_value());
-        kernel_input.app_return_data.incomplete_assert_equal(witness_commitments.secondary_calldata);
+        // App return data. Mega currently exposes a single app calldata witness commitment
+        // (`secondary_calldata`), so NUM_APP_PER_KERNEL remains 1.
+        for (size_t idx = 0; idx < NUM_APP_PER_KERNEL; ++idx) {
+            BB_ASSERT_EQ(NUM_APP_PER_KERNEL, 1UL, "Multiple app calldata witness columns are not wired yet");
+            bool app_return_data_match =
+                kernel_input.app_return_data[idx].get_value() == witness_commitments.secondary_calldata.get_value();
+            BB_ASSERT_DEBUG(app_return_data_match,
+                            "app_return_data mismatch: proof contains "
+                                << kernel_input.app_return_data[idx].get_value()
+                                << " but secondary_calldata commitment is "
+                                << witness_commitments.secondary_calldata.get_value());
+            kernel_input.app_return_data[idx].incomplete_assert_equal(witness_commitments.secondary_calldata);
+        }
 
         // ============= Perform accumulator hash consistency check =========================
 
@@ -203,7 +209,8 @@ Chonk::PublicInputsResult Chonk::process_public_inputs_and_consistency_checks(
     app_input.reconstruct_from_public(public_inputs);
 
     // Set the app return data commitment to be propagated via the public inputs
-    bus_depot.set_app_return_data_commitment(witness_commitments.return_data);
+    BB_ASSERT(app_return_data_idx.has_value(), "App return-data index expected for app verifier inputs");
+    bus_depot.set_app_return_data_commitment(witness_commitments.return_data, app_return_data_idx.value());
 
     return { std::move(app_input.pairing_inputs), std::nullopt };
 }
@@ -227,7 +234,8 @@ Chonk::recursive_verification_and_consistency_checks(
     const StdlibVerifierInputs& verifier_inputs,
     const std::optional<RecursiveVerifierAccumulator>& input_verifier_accumulator,
     const std::optional<StdlibFF>& running_hash,
-    const std::shared_ptr<RecursiveTranscript>& accumulation_recursive_transcript)
+    const std::shared_ptr<RecursiveTranscript>& accumulation_recursive_transcript,
+    const std::optional<size_t>& app_return_data_idx)
 {
     BB_BENCH_NAME("Chonk::recursive_verification_and_consistency_checks");
 
@@ -253,7 +261,7 @@ Chonk::recursive_verification_and_consistency_checks(
 
     // Step 2: Process public inputs and perform databus consistency checks
     auto [io_pairing_points, previous_ecc_op_hash] = process_public_inputs_and_consistency_checks(
-        verifier_inputs, public_inputs, witness_commitments, prev_accum_hash);
+        verifier_inputs, public_inputs, witness_commitments, prev_accum_hash, app_return_data_idx);
 
     std::optional<StdlibFF> updated_hash = running_hash;
     if (previous_ecc_op_hash.has_value()) {
@@ -324,15 +332,22 @@ void Chonk::complete_kernel_circuit_logic(ClientCircuit& circuit)
         current_stdlib_verifier_accumulator = RecursiveVerifierAccumulator::stdlib_from_native<RecursiveFlavor::Curve>(
             &circuit, recursive_verifier_native_accum);
     }
+    size_t app_return_data_idx = 0;
     while (!stdlib_verification_queue.empty()) {
         const StdlibVerifierInputs& verifier_input = stdlib_verification_queue.front();
+        std::optional<size_t> current_app_return_data_idx = std::nullopt;
+        if (!verifier_input.is_kernel) {
+            BB_ASSERT_LT(app_return_data_idx, NUM_APP_PER_KERNEL, "Too many app proofs in kernel verification queue");
+            current_app_return_data_idx = app_return_data_idx++;
+        }
 
         auto [output_stdlib_verifier_accumulator, pairing_points, updated_hash] =
             recursive_verification_and_consistency_checks(circuit,
                                                           verifier_input,
                                                           current_stdlib_verifier_accumulator,
                                                           running_hash,
-                                                          accumulation_recursive_transcript);
+                                                          accumulation_recursive_transcript,
+                                                          current_app_return_data_idx);
         points_accumulator.insert(points_accumulator.end(), pairing_points.begin(), pairing_points.end());
         running_hash = updated_hash;
 
@@ -376,9 +391,11 @@ void Chonk::complete_kernel_circuit_logic(ClientCircuit& circuit)
         // Extract native verifier accumulator from the stdlib accum to use it in the next round
         recursive_verifier_native_accum = current_stdlib_verifier_accumulator->get_value<VerifierAccumulator>();
 
-        // Get databus commitments
         auto kernel_return_data_commitment = bus_depot.get_kernel_return_data_commitment(circuit);
-        auto app_return_data_commitment = bus_depot.get_app_return_data_commitment(circuit);
+        KernelIO::AppReturnDataCommitments app_return_data_commitments;
+        for (size_t idx = 0; idx < NUM_APP_PER_KERNEL; ++idx) {
+            app_return_data_commitments[idx] = bus_depot.get_app_return_data_commitment(circuit, idx);
+        }
 
         // Compute hash of output accumulator
         RecursiveTranscript hash_transcript;
@@ -394,7 +411,7 @@ void Chonk::complete_kernel_circuit_logic(ClientCircuit& circuit)
         // Propagate public inputs
         KernelIO kernel_output{ pairing_points_aggregator,
                                 kernel_return_data_commitment,
-                                app_return_data_commitment,
+                                app_return_data_commitments,
                                 running_hash.value(),
                                 current_verifier_accum_hash };
         kernel_output.set_public();

--- a/barretenberg/cpp/src/barretenberg/chonk/chonk.cpp
+++ b/barretenberg/cpp/src/barretenberg/chonk/chonk.cpp
@@ -147,8 +147,7 @@ Chonk::PublicInputsResult Chonk::process_public_inputs_and_consistency_checks(
     const StdlibVerifierInputs& verifier_inputs,
     std::vector<StdlibFF>& public_inputs,
     WitnessCommitments& witness_commitments,
-    const std::optional<StdlibFF>& prev_accum_hash,
-    const std::optional<size_t>& app_return_data_idx)
+    const std::optional<StdlibFF>& prev_accum_hash)
 {
     if (verifier_inputs.is_kernel) {
         BB_ASSERT_EQ(verifier_inputs.type == QUEUE_TYPE::HN || verifier_inputs.type == QUEUE_TYPE::HN_TAIL ||
@@ -208,9 +207,8 @@ Chonk::PublicInputsResult Chonk::process_public_inputs_and_consistency_checks(
     AppIO app_input; // pairing points
     app_input.reconstruct_from_public(public_inputs);
 
-    // Set the app return data commitment to be propagated via the public inputs
-    BB_ASSERT(app_return_data_idx.has_value(), "App return-data index expected for app verifier inputs");
-    bus_depot.set_app_return_data_commitment(witness_commitments.return_data, app_return_data_idx.value());
+    // Set the app return data commitment to be propagated via the public inputs. The depot owns slot allocation.
+    bus_depot.set_app_return_data_commitment(witness_commitments.return_data);
 
     return { std::move(app_input.pairing_inputs), std::nullopt };
 }
@@ -234,8 +232,7 @@ Chonk::recursive_verification_and_consistency_checks(
     const StdlibVerifierInputs& verifier_inputs,
     const std::optional<RecursiveVerifierAccumulator>& input_verifier_accumulator,
     const std::optional<StdlibFF>& running_hash,
-    const std::shared_ptr<RecursiveTranscript>& accumulation_recursive_transcript,
-    const std::optional<size_t>& app_return_data_idx)
+    const std::shared_ptr<RecursiveTranscript>& accumulation_recursive_transcript)
 {
     BB_BENCH_NAME("Chonk::recursive_verification_and_consistency_checks");
 
@@ -261,7 +258,7 @@ Chonk::recursive_verification_and_consistency_checks(
 
     // Step 2: Process public inputs and perform databus consistency checks
     auto [io_pairing_points, previous_ecc_op_hash] = process_public_inputs_and_consistency_checks(
-        verifier_inputs, public_inputs, witness_commitments, prev_accum_hash, app_return_data_idx);
+        verifier_inputs, public_inputs, witness_commitments, prev_accum_hash);
 
     std::optional<StdlibFF> updated_hash = running_hash;
     if (previous_ecc_op_hash.has_value()) {
@@ -326,28 +323,24 @@ void Chonk::complete_kernel_circuit_logic(ClientCircuit& circuit)
 
     // Step 2: VERIFICATION LOOP - Recursively verify each proof in the queue
 
+    BB_ASSERT(bus_depot.app_return_data_slots_are_empty(),
+              "DataBusDepot has stale app return-data slots at kernel-completion boundary");
+
     std::vector<PairingPoints> points_accumulator;
     std::optional<RecursiveVerifierAccumulator> current_stdlib_verifier_accumulator;
     if (!is_init_kernel) {
         current_stdlib_verifier_accumulator = RecursiveVerifierAccumulator::stdlib_from_native<RecursiveFlavor::Curve>(
             &circuit, recursive_verifier_native_accum);
     }
-    size_t app_return_data_idx = 0;
     while (!stdlib_verification_queue.empty()) {
         const StdlibVerifierInputs& verifier_input = stdlib_verification_queue.front();
-        std::optional<size_t> current_app_return_data_idx = std::nullopt;
-        if (!verifier_input.is_kernel) {
-            BB_ASSERT_LT(app_return_data_idx, NUM_APP_PER_KERNEL, "Too many app proofs in kernel verification queue");
-            current_app_return_data_idx = app_return_data_idx++;
-        }
 
         auto [output_stdlib_verifier_accumulator, pairing_points, updated_hash] =
             recursive_verification_and_consistency_checks(circuit,
                                                           verifier_input,
                                                           current_stdlib_verifier_accumulator,
                                                           running_hash,
-                                                          accumulation_recursive_transcript,
-                                                          current_app_return_data_idx);
+                                                          accumulation_recursive_transcript);
         points_accumulator.insert(points_accumulator.end(), pairing_points.begin(), pairing_points.end());
         running_hash = updated_hash;
 

--- a/barretenberg/cpp/src/barretenberg/chonk/chonk.hpp
+++ b/barretenberg/cpp/src/barretenberg/chonk/chonk.hpp
@@ -202,7 +202,8 @@ class Chonk : public IVCBase {
             const StdlibVerifierInputs& verifier_inputs,
             const std::optional<RecursiveVerifierAccumulator>& input_verifier_accumulator,
             const std::optional<StdlibFF>& running_hash,
-            const std::shared_ptr<RecursiveTranscript>& accumulation_recursive_transcript);
+            const std::shared_ptr<RecursiveTranscript>& accumulation_recursive_transcript,
+            const std::optional<size_t>& app_return_data_idx = std::nullopt);
 
     // Complete the logic of a kernel circuit (e.g. HN/merge recursive verification, databus consistency checks)
     void complete_kernel_circuit_logic(ClientCircuit& circuit);
@@ -248,10 +249,12 @@ class Chonk : public IVCBase {
                                  const std::shared_ptr<RecursiveVerifierInstance>& verifier_instance,
                                  const std::shared_ptr<RecursiveTranscript>& accumulation_recursive_transcript) const;
 
-    PublicInputsResult process_public_inputs_and_consistency_checks(const StdlibVerifierInputs& verifier_inputs,
-                                                                    std::vector<StdlibFF>& public_inputs,
-                                                                    WitnessCommitments& witness_commitments,
-                                                                    const std::optional<StdlibFF>& prev_accum_hash);
+    PublicInputsResult process_public_inputs_and_consistency_checks(
+        const StdlibVerifierInputs& verifier_inputs,
+        std::vector<StdlibFF>& public_inputs,
+        WitnessCommitments& witness_commitments,
+        const std::optional<StdlibFF>& prev_accum_hash,
+        const std::optional<size_t>& app_return_data_idx = std::nullopt);
 
     void accumulate_hiding_kernel(ClientCircuit& circuit, const std::shared_ptr<MegaVerificationKey>& precomputed_vk);
 

--- a/barretenberg/cpp/src/barretenberg/chonk/chonk.hpp
+++ b/barretenberg/cpp/src/barretenberg/chonk/chonk.hpp
@@ -202,8 +202,7 @@ class Chonk : public IVCBase {
             const StdlibVerifierInputs& verifier_inputs,
             const std::optional<RecursiveVerifierAccumulator>& input_verifier_accumulator,
             const std::optional<StdlibFF>& running_hash,
-            const std::shared_ptr<RecursiveTranscript>& accumulation_recursive_transcript,
-            const std::optional<size_t>& app_return_data_idx = std::nullopt);
+            const std::shared_ptr<RecursiveTranscript>& accumulation_recursive_transcript);
 
     // Complete the logic of a kernel circuit (e.g. HN/merge recursive verification, databus consistency checks)
     void complete_kernel_circuit_logic(ClientCircuit& circuit);
@@ -249,12 +248,10 @@ class Chonk : public IVCBase {
                                  const std::shared_ptr<RecursiveVerifierInstance>& verifier_instance,
                                  const std::shared_ptr<RecursiveTranscript>& accumulation_recursive_transcript) const;
 
-    PublicInputsResult process_public_inputs_and_consistency_checks(
-        const StdlibVerifierInputs& verifier_inputs,
-        std::vector<StdlibFF>& public_inputs,
-        WitnessCommitments& witness_commitments,
-        const std::optional<StdlibFF>& prev_accum_hash,
-        const std::optional<size_t>& app_return_data_idx = std::nullopt);
+    PublicInputsResult process_public_inputs_and_consistency_checks(const StdlibVerifierInputs& verifier_inputs,
+                                                                    std::vector<StdlibFF>& public_inputs,
+                                                                    WitnessCommitments& witness_commitments,
+                                                                    const std::optional<StdlibFF>& prev_accum_hash);
 
     void accumulate_hiding_kernel(ClientCircuit& circuit, const std::shared_ptr<MegaVerificationKey>& precomputed_vk);
 

--- a/barretenberg/cpp/src/barretenberg/chonk/chonk.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/chonk/chonk.test.cpp
@@ -1,3 +1,4 @@
+#include <functional>
 #include <ranges>
 #include <sys/resource.h>
 
@@ -22,7 +23,22 @@
 
 using namespace bb;
 
-static constexpr size_t SMALL_LOG_2_NUM_GATES = 5;
+namespace {
+
+constexpr size_t SMALL_LOG_2_NUM_GATES = 5;
+
+/**
+ * @brief Enum for specifying which KernelIO field to tamper with in tests.
+ */
+enum class KernelIOField : uint8_t {
+    PAIRING_INPUTS,
+    ACCUMULATOR_HASH,
+    KERNEL_RETURN_DATA,
+    APP_RETURN_DATA,
+    ECC_OP_HASH
+};
+
+} // namespace
 
 class ChonkTests : public ::testing::Test {
   protected:
@@ -41,6 +57,11 @@ class ChonkTests : public ::testing::Test {
 
   public:
     /**
+     * @brief Hook fired after each accumulate() inside run_ivc.
+     */
+    using AccumulateHook = std::function<void(Chonk&, size_t)>;
+
+    /**
      * @brief Tamper with a proof
      * @details The first value in the proof after the public inputs is the commitment to the wire w.l (see
      * OinkProver). We modify the commitment by adding Commitment::one().
@@ -58,17 +79,30 @@ class ChonkTests : public ::testing::Test {
         }
     }
 
+    static std::pair<ChonkProof, std::shared_ptr<MegaZKFlavor::VKAndHash>> run_ivc(
+        size_t num_app_circuits,
+        TestSettings settings = {},
+        const AccumulateHook& post_hook = nullptr,
+        bool check_circuit_sizes = false)
+    {
+        CircuitProducer circuit_producer(num_app_circuits);
+        return run_ivc_impl(circuit_producer, settings, post_hook, check_circuit_sizes);
+    };
+
+    static std::pair<ChonkProof, std::shared_ptr<MegaZKFlavor::VKAndHash>> run_ivc(
+        std::vector<bool> leading_is_kernel_flags,
+        TestSettings settings = {},
+        const AccumulateHook& post_hook = nullptr,
+        bool check_circuit_sizes = false)
+    {
+        CircuitProducer circuit_producer(std::move(leading_is_kernel_flags), /*large_first_app=*/false);
+        return run_ivc_impl(circuit_producer, settings, post_hook, check_circuit_sizes);
+    };
+
     static std::pair<ChonkProof, std::shared_ptr<MegaZKFlavor::VKAndHash>> accumulate_and_prove_ivc(
         size_t num_app_circuits, TestSettings settings = {}, bool check_circuit_sizes = false)
     {
-        CircuitProducer circuit_producer(num_app_circuits);
-        const size_t num_circuits = circuit_producer.total_num_circuits;
-        Chonk ivc{ num_circuits };
-
-        for (size_t j = 0; j < num_circuits; ++j) {
-            circuit_producer.construct_and_accumulate_next_circuit(ivc, settings, check_circuit_sizes);
-        }
-        return { ivc.prove(), ivc.get_hiding_kernel_vk_and_hash() };
+        return run_ivc(num_app_circuits, settings, /*post_hook=*/nullptr, check_circuit_sizes);
     };
 
     static bool verify_chonk(const ChonkProof& proof, const std::shared_ptr<MegaZKFlavor::VKAndHash>& vk_and_hash)
@@ -76,11 +110,6 @@ class ChonkTests : public ::testing::Test {
         ChonkVerifier verifier(vk_and_hash);
         return verifier.verify(proof);
     }
-
-    /**
-     * @brief Enum for specifying which KernelIO field to tamper with in tests
-     */
-    enum class KernelIOField { PAIRING_INPUTS, ACCUMULATOR_HASH, KERNEL_RETURN_DATA, APP_RETURN_DATA, ECC_OP_HASH };
 
     /**
      * @brief Helper function to test tampering with AppIO pairing inputs
@@ -91,17 +120,8 @@ class ChonkTests : public ::testing::Test {
     {
         BB_DISABLE_ASSERTS();
 
-        const size_t NUM_APP_CIRCUITS = 2;
-        CircuitProducer circuit_producer(NUM_APP_CIRCUITS);
-        const size_t NUM_CIRCUITS = circuit_producer.total_num_circuits;
-        Chonk ivc{ NUM_CIRCUITS };
         TestSettings settings{ .log2_num_gates = SMALL_LOG_2_NUM_GATES };
-
-        for (size_t idx = 0; idx < NUM_CIRCUITS; ++idx) {
-            auto [circuit, vk] = circuit_producer.create_next_circuit_and_vk(ivc, settings);
-            ivc.accumulate(circuit, vk);
-
-            // After accumulating 3 circuits (app, kernel, app), we have 2 proofs in the queue
+        auto [proof, vk] = run_ivc(/*num_app_circuits=*/2, settings, [](Chonk& ivc, size_t idx) {
             if (idx == 2) {
                 EXPECT_EQ(ivc.verification_queue.size(), 2);
 
@@ -120,10 +140,8 @@ class ChonkTests : public ::testing::Test {
 
                 app_io.to_proof(app_entry.proof, num_public_inputs);
             }
-        }
-
-        auto proof = ivc.prove();
-        EXPECT_FALSE(verify_chonk(proof, ivc.get_hiding_kernel_vk_and_hash()));
+        });
+        EXPECT_FALSE(verify_chonk(proof, vk));
     }
 
     /**
@@ -135,17 +153,8 @@ class ChonkTests : public ::testing::Test {
     {
         BB_DISABLE_ASSERTS();
 
-        const size_t NUM_APP_CIRCUITS = 2;
-        CircuitProducer circuit_producer(NUM_APP_CIRCUITS);
-        const size_t NUM_CIRCUITS = circuit_producer.total_num_circuits;
-        Chonk ivc{ NUM_CIRCUITS };
         TestSettings settings{ .log2_num_gates = SMALL_LOG_2_NUM_GATES };
-
-        for (size_t idx = 0; idx < NUM_CIRCUITS; ++idx) {
-            auto [circuit, vk] = circuit_producer.create_next_circuit_and_vk(ivc, settings);
-            ivc.accumulate(circuit, vk);
-
-            // After accumulating 3 circuits (app, kernel, app), we have 2 proofs in the queue
+        auto [proof, vk] = run_ivc(/*num_app_circuits=*/2, settings, [field_to_tamper](Chonk& ivc, size_t idx) {
             if (idx == 2) {
                 EXPECT_EQ(ivc.verification_queue.size(), 2);
 
@@ -159,9 +168,12 @@ class ChonkTests : public ::testing::Test {
                 // Tamper with the specified field
                 switch (field_to_tamper) {
                 case KernelIOField::PAIRING_INPUTS: {
-                    // Replace with a different valid pairing: P0 = G1, P1 = -G1 satisfies e(G1,[1])·e(-G1,[x]) != 1
-                    // so instead use P0 + random offset to break binding without breaking the pairing trivially
-                    kernel_io.pairing_inputs.P0() = kernel_io.pairing_inputs.P0() + Commitment::one();
+                    // Set P0 to [x]₁ (the first SRS point after [1]) and P1 to [1]₁
+                    kernel_io.pairing_inputs.P0() =
+                        srs::get_crs_factory<curve::BN254>()->get_crs(2)->get_monomial_points()[1];
+                    kernel_io.pairing_inputs.P1() = -Commitment::one();
+
+                    EXPECT_TRUE(kernel_io.pairing_inputs.check());
                     break;
                 }
                 case KernelIOField::ACCUMULATOR_HASH:
@@ -180,10 +192,8 @@ class ChonkTests : public ::testing::Test {
 
                 kernel_io.to_proof(kernel_entry.proof, num_public_inputs);
             }
-        }
-
-        auto proof = ivc.prove();
-        EXPECT_FALSE(verify_chonk(proof, ivc.get_hiding_kernel_vk_and_hash()));
+        });
+        EXPECT_FALSE(verify_chonk(proof, vk));
     }
 
     /**
@@ -202,33 +212,27 @@ class ChonkTests : public ::testing::Test {
         using KernelIOSerde = bb::stdlib::recursion::honk::KernelIOSerde;
 
         const size_t NUM_APP_CIRCUITS = 2;
-        CircuitProducer circuit_producer(NUM_APP_CIRCUITS);
-        const size_t NUM_CIRCUITS = circuit_producer.total_num_circuits;
-        Chonk ivc{ NUM_CIRCUITS };
+        const size_t NUM_TOTAL_CIRCUITS = NUM_APP_CIRCUITS * 2 + /*num_trailing_kernels*/ 3;
         TestSettings settings{ .log2_num_gates = SMALL_LOG_2_NUM_GATES };
 
-        // Extract tail kernel IO before the last accumulation consumes the verification queue.
-        // The tail kernel (HN_FINAL) uses KernelIO format; the hiding kernel uses HidingKernelIO.
+        // Extract tail kernel IO before the hiding kernel consumes the verification queue.
         KernelIOSerde tail_io;
-        for (size_t idx = 0; idx < NUM_CIRCUITS; ++idx) {
-            if (idx == NUM_CIRCUITS - 1) {
-                for (auto& it : std::ranges::reverse_view(ivc.verification_queue)) {
-                    if (it.is_kernel) {
-                        size_t num_public_inputs = it.honk_vk->num_public_inputs;
-                        ASSERT_EQ(num_public_inputs, KernelIOSerde::PUBLIC_INPUTS_SIZE)
-                            << "Tail kernel should use KernelIO format";
-                        ASSERT_GT(it.proof.size(), num_public_inputs) << "Tail kernel proof too small";
-                        tail_io = KernelIOSerde::from_proof(it.proof, num_public_inputs);
-                        break;
+        auto [proof, vk_and_hash] =
+            run_ivc(/*num_app_circuits=*/NUM_APP_CIRCUITS, settings, [&tail_io](Chonk& ivc, size_t idx) {
+                // With 2 apps the layout is [app, kernel, app, kernel, reset, tail, hiding].
+                if (idx == NUM_TOTAL_CIRCUITS - 2) {
+                    for (auto& it : std::ranges::reverse_view(ivc.verification_queue)) {
+                        if (it.is_kernel) {
+                            size_t num_public_inputs = it.honk_vk->num_public_inputs;
+                            ASSERT_EQ(num_public_inputs, KernelIOSerde::PUBLIC_INPUTS_SIZE)
+                                << "Tail kernel should use KernelIO format";
+                            ASSERT_GT(it.proof.size(), num_public_inputs) << "Tail kernel proof too small";
+                            tail_io = KernelIOSerde::from_proof(it.proof, num_public_inputs);
+                            break;
+                        }
                     }
                 }
-            }
-            auto [circuit, vk] = circuit_producer.create_next_circuit_and_vk(ivc, settings);
-            ivc.accumulate(circuit, vk);
-        }
-
-        auto proof = ivc.prove();
-        auto vk_and_hash = ivc.get_hiding_kernel_vk_and_hash();
+            });
 
         size_t hiding_kernel_pub_inputs = vk_and_hash->vk->num_public_inputs;
         ASSERT_EQ(hiding_kernel_pub_inputs, HidingKernelIOSerde::PUBLIC_INPUTS_SIZE)
@@ -239,6 +243,25 @@ class ChonkTests : public ::testing::Test {
         EXPECT_EQ(tail_io.kernel_return_data, hiding_io.kernel_return_data)
             << "kernel_return_data mismatch: Tail has " << tail_io.kernel_return_data << " but HidingKernel has "
             << hiding_io.kernel_return_data;
+    }
+
+  private:
+    static std::pair<ChonkProof, std::shared_ptr<MegaZKFlavor::VKAndHash>> run_ivc_impl(
+        CircuitProducer& circuit_producer,
+        TestSettings settings,
+        const AccumulateHook& post_hook,
+        bool check_circuit_sizes)
+    {
+        const size_t num_circuits = circuit_producer.total_num_circuits;
+        Chonk ivc{ num_circuits };
+
+        for (size_t idx = 0; idx < num_circuits; ++idx) {
+            circuit_producer.construct_and_accumulate_next_circuit(ivc, settings, check_circuit_sizes);
+            if (post_hook) {
+                post_hook(ivc, idx);
+            }
+        }
+        return { ivc.prove(), ivc.get_hiding_kernel_vk_and_hash() };
     }
 };
 
@@ -455,15 +478,7 @@ TEST_F(ChonkTests, MsgpackProofFromFileOrBuffer)
     }
 };
 
-/**
- * @brief Test that tampering with kernel pairing inputs causes verification to fail
- * @details Pairing points (P0, P1) accumulate across the IVC chain through aggregation.
- * Even if we replace them with pairing points satisfying pairing check, the public input binding should must catch it.
- */
-TEST_F(ChonkTests, KernelPairingInputsTamperingFailure)
-{
-    ChonkTests::test_kernel_io_tampering(KernelIOField::PAIRING_INPUTS);
-}
+class KernelIOTamperingTests : public ChonkTests, public testing::WithParamInterface<KernelIOField> {};
 
 /**
  * @brief Test that tampering with app pairing inputs causes verification to fail
@@ -475,45 +490,33 @@ TEST_F(ChonkTests, AppPairingInputsTamperingFailure)
     ChonkTests::test_app_io_tampering();
 }
 
-/**
- * @brief Verify that tampering with the accumulator hash in public inputs causes IVC verification failure
- * @details Each kernel outputs `output_hn_accum_hash` as a public input. The next kernel computes the hash of its
- * input accumulator and compares it with the hash from the previous kernel's public inputs via assert_equal.
- * This test tampers with the hash to verify the binding.
- */
-TEST_F(ChonkTests, AccumulatorHashTamperingFailure)
+TEST_P(KernelIOTamperingTests, CausesVerificationFailure)
 {
-    ChonkTests::test_kernel_io_tampering(KernelIOField::ACCUMULATOR_HASH);
+    test_kernel_io_tampering(GetParam());
 }
 
-/**
- * @brief Test that tampering with kernel_return_data causes verification to fail
- * @details kernel_return_data is the commitment to the kernel's return data which must match
- * the calldata commitment of the next circuit. Tampering should cause databus consistency check to fail.
- */
-TEST_F(ChonkTests, KernelReturnDataTamperingFailure)
-{
-    ChonkTests::test_kernel_io_tampering(KernelIOField::KERNEL_RETURN_DATA);
-}
-
-/**
- * @brief Test that tampering with app_return_data causes verification to fail
- * @details app_return_data is the commitment to the app's return data which must match
- * the secondary_calldata commitment of the next circuit.
- */
-TEST_F(ChonkTests, AppReturnDataTamperingFailure)
-{
-    ChonkTests::test_kernel_io_tampering(KernelIOField::APP_RETURN_DATA);
-}
-
-/**
- * @brief Test that tampering with ecc_op_hash causes verification to fail
- * @details ecc_op_hash commits to the folded ECC operation subtable commitments for batch merge verification.
- */
-TEST_F(ChonkTests, EccOpHashTamperingFailure)
-{
-    ChonkTests::test_kernel_io_tampering(KernelIOField::ECC_OP_HASH);
-}
+INSTANTIATE_TEST_SUITE_P(All,
+                         KernelIOTamperingTests,
+                         testing::Values(KernelIOField::PAIRING_INPUTS,
+                                         KernelIOField::ACCUMULATOR_HASH,
+                                         KernelIOField::KERNEL_RETURN_DATA,
+                                         KernelIOField::APP_RETURN_DATA,
+                                         KernelIOField::ECC_OP_HASH),
+                         [](const testing::TestParamInfo<KernelIOField>& info) {
+                             switch (info.param) {
+                             case KernelIOField::PAIRING_INPUTS:
+                                 return "PairingInputs";
+                             case KernelIOField::ACCUMULATOR_HASH:
+                                 return "AccumulatorHash";
+                             case KernelIOField::KERNEL_RETURN_DATA:
+                                 return "KernelReturnData";
+                             case KernelIOField::APP_RETURN_DATA:
+                                 return "AppReturnData";
+                             case KernelIOField::ECC_OP_HASH:
+                                 return "EccOpHash";
+                             }
+                             return "Unknown";
+                         });
 
 /**
  * @brief Test that kernel_return_data is consistently propagated from Tail kernel to HidingKernel proof

--- a/barretenberg/cpp/src/barretenberg/chonk/chonk.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/chonk/chonk.test.cpp
@@ -171,7 +171,7 @@ class ChonkTests : public ::testing::Test {
                     kernel_io.kernel_return_data = kernel_io.kernel_return_data + Commitment::one();
                     break;
                 case KernelIOField::APP_RETURN_DATA:
-                    kernel_io.app_return_data = kernel_io.app_return_data + Commitment::one();
+                    kernel_io.app_return_data[0] = kernel_io.app_return_data[0] + Commitment::one();
                     break;
                 case KernelIOField::ECC_OP_HASH:
                     kernel_io.ecc_op_hash += FF(1);

--- a/barretenberg/cpp/src/barretenberg/chonk/mock_circuit_producer.hpp
+++ b/barretenberg/cpp/src/barretenberg/chonk/mock_circuit_producer.hpp
@@ -24,7 +24,7 @@ class MockDatabusProducer {
     using BusDataArray = std::vector<FF>;
 
     static constexpr size_t BUS_ARRAY_SIZE = 3; // arbitrary length of mock bus inputs
-    std::array<BusDataArray, NUM_APP_PER_KERNEL> app_return_data;
+    std::array<BusDataArray, MAX_APPS_PER_KERNEL> app_return_data;
     BusDataArray kernel_return_data;
 
     FF dummy_return_val = 1; // use simple return val for easier test debugging

--- a/barretenberg/cpp/src/barretenberg/chonk/mock_circuit_producer.hpp
+++ b/barretenberg/cpp/src/barretenberg/chonk/mock_circuit_producer.hpp
@@ -24,7 +24,7 @@ class MockDatabusProducer {
     using BusDataArray = std::vector<FF>;
 
     static constexpr size_t BUS_ARRAY_SIZE = 3; // arbitrary length of mock bus inputs
-    BusDataArray app_return_data;
+    std::array<BusDataArray, NUM_APP_PER_KERNEL> app_return_data;
     BusDataArray kernel_return_data;
 
     FF dummy_return_val = 1; // use simple return val for easier test debugging
@@ -45,9 +45,11 @@ class MockDatabusProducer {
      */
     void populate_app_databus(ClientCircuit& circuit)
     {
-        app_return_data = generate_random_bus_array();
-        for (auto& val : app_return_data) {
-            circuit.add_public_return_data(circuit.add_variable(val));
+        for (auto& app_data : app_return_data) {
+            app_data = generate_random_bus_array();
+            for (auto& val : app_data) {
+                circuit.add_public_return_data(circuit.add_variable(val));
+            }
         }
     };
 
@@ -59,13 +61,15 @@ class MockDatabusProducer {
     {
         // Populate calldata from previous kernel return data (if it exists)
         for (auto& val : kernel_return_data) {
-            circuit.add_public_calldata(circuit.add_variable(val));
+            circuit.add_public_calldata(BusId::KERNEL_CALLDATA, circuit.add_variable(val));
         }
         // Populate secondary_calldata from app return data (if it exists), then clear the app return data
-        for (auto& val : app_return_data) {
-            circuit.add_public_secondary_calldata(circuit.add_variable(val));
+        for (size_t idx = 0; idx < app_return_data.size(); ++idx) {
+            for (auto& val : app_return_data[idx]) {
+                circuit.add_public_calldata(static_cast<BusId>(idx + 1), circuit.add_variable(val));
+            }
+            app_return_data[idx].clear();
         }
-        app_return_data.clear();
 
         // Mock the return data for the present kernel circuit
         kernel_return_data = generate_random_bus_array();
@@ -78,7 +82,7 @@ class MockDatabusProducer {
      * @brief Add an arbitrary value to the app return data. This leads to a descrepency between the values used by the
      * app itself and the secondary_calldata values in the kernel that will be set based on these tampered values.
      */
-    void tamper_with_app_return_data() { app_return_data.emplace_back(17); }
+    void tamper_with_app_return_data() { app_return_data[0].emplace_back(17); }
 };
 
 /**

--- a/barretenberg/cpp/src/barretenberg/chonk/mock_circuit_producer.hpp
+++ b/barretenberg/cpp/src/barretenberg/chonk/mock_circuit_producer.hpp
@@ -41,7 +41,7 @@ class MockDatabusProducer {
 
   public:
     /**
-     * @brief Update the app return data and populate it in the app circuit
+     * @brief Update the next app return data and populate it in the app circuit. App slots are processed in order.
      */
     void populate_app_databus(ClientCircuit& circuit)
     {
@@ -80,12 +80,6 @@ class MockDatabusProducer {
             circuit.add_public_return_data(circuit.add_variable(val));
         }
     };
-
-    /**
-     * @brief Add an arbitrary value to the app return data. This leads to a descrepency between the values used by the
-     * app itself and the secondary_calldata values in the kernel that will be set based on these tampered values.
-     */
-    void tamper_with_app_return_data() { app_return_data[0].emplace_back(17); }
 };
 
 /**
@@ -283,11 +277,6 @@ class PrivateFunctionExecutionMockCircuitProducer {
         auto [circuit, vk] = create_next_circuit_and_vk(ivc, settings, check_circuit_sizes);
         ivc.accumulate(circuit, vk);
     }
-
-    /**
-     * @brief Tamper with databus data to facilitate failure testing
-     */
-    void tamper_with_databus() { mock_databus.tamper_with_app_return_data(); }
 };
 
 } // namespace

--- a/barretenberg/cpp/src/barretenberg/chonk/mock_circuit_producer.hpp
+++ b/barretenberg/cpp/src/barretenberg/chonk/mock_circuit_producer.hpp
@@ -46,9 +46,12 @@ class MockDatabusProducer {
     void populate_app_databus(ClientCircuit& circuit)
     {
         for (auto& app_data : app_return_data) {
-            app_data = generate_random_bus_array();
-            for (auto& val : app_data) {
-                circuit.add_public_return_data(circuit.add_variable(val));
+            if (app_data.empty()) {
+                app_data = generate_random_bus_array();
+                for (auto& val : app_data) {
+                    circuit.add_public_return_data(circuit.add_variable(val));
+                }
+                return;
             }
         }
     };

--- a/barretenberg/cpp/src/barretenberg/chonk/mock_circuit_producer.hpp
+++ b/barretenberg/cpp/src/barretenberg/chonk/mock_circuit_producer.hpp
@@ -137,6 +137,18 @@ class PrivateFunctionExecutionMockCircuitProducer {
         }
     }
 
+    PrivateFunctionExecutionMockCircuitProducer(std::vector<bool> leading_is_kernel_flags, bool large_first_app = false)
+        : is_kernel_flags(std::move(leading_is_kernel_flags))
+        , large_first_app(large_first_app)
+    {
+        BB_ASSERT(!is_kernel_flags.empty(), "Mock circuit layout must contain at least one leading circuit");
+        BB_ASSERT_EQ(is_kernel_flags[0], false, "Mock circuit layout must start with an app circuit");
+        for (size_t i = 0; i < NUM_TRAILING_KERNELS; ++i) {
+            is_kernel_flags.emplace_back(true);
+        }
+        total_num_circuits = is_kernel_flags.size();
+    }
+
     /**
      * @brief Precompute the verification key for the given circuit.
      */

--- a/barretenberg/cpp/src/barretenberg/chonk/test_bench_shared.hpp
+++ b/barretenberg/cpp/src/barretenberg/chonk/test_bench_shared.hpp
@@ -7,15 +7,9 @@
 
 namespace bb {
 
-/**
- * @brief Perform a specified number of circuit accumulation rounds
- *
- * @param NUM_CIRCUITS Number of circuits to accumulate (apps + kernels)
- */
 std::pair<ChonkProof, std::shared_ptr<MegaZKFlavor::VKAndHash>> accumulate_and_prove_with_precomputed_vks(
-    size_t num_app_circuits, auto& precomputed_vks, const bool large_first_app = true)
+    PrivateFunctionExecutionMockCircuitProducer& circuit_producer, auto& precomputed_vks)
 {
-    PrivateFunctionExecutionMockCircuitProducer circuit_producer(num_app_circuits, large_first_app);
     const size_t NUM_CIRCUITS = circuit_producer.total_num_circuits;
     Chonk ivc{ NUM_CIRCUITS };
 
@@ -33,11 +27,28 @@ std::pair<ChonkProof, std::shared_ptr<MegaZKFlavor::VKAndHash>> accumulate_and_p
     return { ivc.prove(), ivc.get_hiding_kernel_vk_and_hash() };
 }
 
-std::vector<std::shared_ptr<typename MegaFlavor::VerificationKey>> precompute_vks(const size_t num_app_circuits,
-                                                                                  const bool large_first_app = true)
+/**
+ * @brief Perform a specified number of circuit accumulation rounds
+ *
+ * @param num_app_circuits Number of app circuits to accumulate
+ */
+std::pair<ChonkProof, std::shared_ptr<MegaZKFlavor::VKAndHash>> accumulate_and_prove_with_precomputed_vks(
+    size_t num_app_circuits, auto& precomputed_vks, const bool large_first_app = true)
 {
-    using CircuitProducer = PrivateFunctionExecutionMockCircuitProducer;
-    CircuitProducer circuit_producer(num_app_circuits, large_first_app);
+    PrivateFunctionExecutionMockCircuitProducer circuit_producer(num_app_circuits, large_first_app);
+    return accumulate_and_prove_with_precomputed_vks(circuit_producer, precomputed_vks);
+}
+
+std::pair<ChonkProof, std::shared_ptr<MegaZKFlavor::VKAndHash>> accumulate_and_prove_with_precomputed_vks(
+    std::vector<bool> leading_is_kernel_flags, auto& precomputed_vks, const bool large_first_app = false)
+{
+    PrivateFunctionExecutionMockCircuitProducer circuit_producer(std::move(leading_is_kernel_flags), large_first_app);
+    return accumulate_and_prove_with_precomputed_vks(circuit_producer, precomputed_vks);
+}
+
+std::vector<std::shared_ptr<typename MegaFlavor::VerificationKey>> precompute_vks(
+    PrivateFunctionExecutionMockCircuitProducer& circuit_producer)
+{
     const size_t NUM_CIRCUITS = circuit_producer.total_num_circuits;
     Chonk ivc{ NUM_CIRCUITS };
 
@@ -46,12 +57,26 @@ std::vector<std::shared_ptr<typename MegaFlavor::VerificationKey>> precompute_vk
 
         auto circuit = circuit_producer.create_next_circuit(ivc);
         const bool is_hiding_kernel = (j == NUM_CIRCUITS - 1);
-        auto vk = CircuitProducer::get_verification_key(circuit, is_hiding_kernel);
+        auto vk = PrivateFunctionExecutionMockCircuitProducer::get_verification_key(circuit, is_hiding_kernel);
         vkeys.push_back(vk);
         ivc.accumulate(circuit, vk);
     }
 
     return vkeys;
+}
+
+std::vector<std::shared_ptr<typename MegaFlavor::VerificationKey>> precompute_vks(const size_t num_app_circuits,
+                                                                                  const bool large_first_app = true)
+{
+    PrivateFunctionExecutionMockCircuitProducer circuit_producer(num_app_circuits, large_first_app);
+    return precompute_vks(circuit_producer);
+}
+
+std::vector<std::shared_ptr<typename MegaFlavor::VerificationKey>> precompute_vks(
+    std::vector<bool> leading_is_kernel_flags, const bool large_first_app = false)
+{
+    PrivateFunctionExecutionMockCircuitProducer circuit_producer(std::move(leading_is_kernel_flags), large_first_app);
+    return precompute_vks(circuit_producer);
 }
 
 } // namespace bb

--- a/barretenberg/cpp/src/barretenberg/circuit_checker/mega_circuit_builder.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/circuit_checker/mega_circuit_builder.test.cpp
@@ -273,8 +273,8 @@ TEST(MegaCircuitBuilder, EmptyCircuitFinalization)
     EXPECT_EQ(builder.blocks.nnf.size(), 0);
     EXPECT_EQ(builder.blocks.poseidon2_external.size(), 0);
     EXPECT_EQ(builder.blocks.poseidon2_internal.size(), 0);
-    EXPECT_EQ(builder.get_calldata().size(), 0);
-    EXPECT_EQ(builder.get_secondary_calldata().size(), 0);
+    EXPECT_EQ(builder.get_calldata(BusId::KERNEL_CALLDATA).size(), 0);
+    EXPECT_EQ(builder.get_calldata(BusId::APP_CALLDATA).size(), 0);
     EXPECT_EQ(builder.get_return_data().size(), 0);
 
     EXPECT_TRUE(CircuitChecker::check(builder));
@@ -289,13 +289,13 @@ TEST(MegaCircuitBuilder, DatabusOutOfBoundsReadFails)
 
     // Add single entry to calldata
     auto val = builder.add_variable(fr(42));
-    builder.add_public_calldata(val);
+    builder.add_public_calldata(BusId::KERNEL_CALLDATA, val);
 
     // Try to read at index 1 (out of bounds - only index 0 exists)
     auto bad_idx = builder.add_variable(fr(1));
 
     // This should trigger an assertion in read_calldata
-    EXPECT_THROW(builder.read_calldata(bad_idx), std::runtime_error);
+    EXPECT_THROW(builder.read_calldata(BusId::KERNEL_CALLDATA, bad_idx), std::runtime_error);
 }
 
 } // namespace bb

--- a/barretenberg/cpp/src/barretenberg/constants.hpp
+++ b/barretenberg/cpp/src/barretenberg/constants.hpp
@@ -62,6 +62,9 @@ static constexpr uint32_t NUM_TRANSLATION_EVALUATIONS = 5;
 // The number of leading zero rows in the execution trace. Used to enable shifted polynomials.
 static constexpr size_t NUM_ZERO_ROWS = 1;
 
+// The maximum number of app circuits a single kernel can recursively verify in one accumulation group.
+static constexpr uint8_t NUM_APP_PER_KERNEL = 1;
+
 static constexpr size_t CHONK_MAX_NUM_CIRCUITS = 56 + /*trailing kernels*/ 3;
 
 static constexpr size_t BATCH_MERGE_PROOF_SIZE =

--- a/barretenberg/cpp/src/barretenberg/constants.hpp
+++ b/barretenberg/cpp/src/barretenberg/constants.hpp
@@ -62,7 +62,7 @@ static constexpr uint32_t NUM_TRANSLATION_EVALUATIONS = 5;
 // The number of leading zero rows in the execution trace. Used to enable shifted polynomials.
 static constexpr size_t NUM_ZERO_ROWS = 1;
 
-// The maximum number of app circuits a single kernel can recursively verify in one accumulation group.
+// The maximum number of app circuits a single kernel can recursively verify
 static constexpr uint8_t MAX_APPS_PER_KERNEL = 1;
 
 static constexpr size_t CHONK_MAX_NUM_CIRCUITS = 56 + /*trailing kernels*/ 3;

--- a/barretenberg/cpp/src/barretenberg/constants.hpp
+++ b/barretenberg/cpp/src/barretenberg/constants.hpp
@@ -63,7 +63,7 @@ static constexpr uint32_t NUM_TRANSLATION_EVALUATIONS = 5;
 static constexpr size_t NUM_ZERO_ROWS = 1;
 
 // The maximum number of app circuits a single kernel can recursively verify in one accumulation group.
-static constexpr uint8_t NUM_APP_PER_KERNEL = 1;
+static constexpr uint8_t MAX_APPS_PER_KERNEL = 1;
 
 static constexpr size_t CHONK_MAX_NUM_CIRCUITS = 56 + /*trailing kernels*/ 3;
 

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_to_constraint_buf.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_to_constraint_buf.cpp
@@ -791,7 +791,7 @@ BlockConstraint memory_init_to_block_constraint(Acir::Opcode::MemoryInit const& 
         .init = {},
         .trace = {},
         .type = BlockType::ROM,
-        .calldata_id = CallDataType::KernelCalldata,
+        .calldata_id = CallDataType::None,
     };
 
     for (const auto& init : mem_init.init) {

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_to_constraint_buf.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_to_constraint_buf.cpp
@@ -791,7 +791,7 @@ BlockConstraint memory_init_to_block_constraint(Acir::Opcode::MemoryInit const& 
         .init = {},
         .trace = {},
         .type = BlockType::ROM,
-        .calldata_id = CallDataType::None,
+        .calldata_id = CallDataType::KernelCalldata,
     };
 
     for (const auto& init : mem_init.init) {
@@ -802,10 +802,10 @@ BlockConstraint memory_init_to_block_constraint(Acir::Opcode::MemoryInit const& 
     // array.
     if (std::holds_alternative<Acir::BlockType::CallData>(mem_init.block_type.value)) {
         uint32_t calldata_id = std::get<Acir::BlockType::CallData>(mem_init.block_type.value).value;
-        BB_ASSERT(calldata_id == 0 || calldata_id == 1, "acir_format::handle_memory_init: Unsupported calldata id");
+        BB_ASSERT_LTE(calldata_id, NUM_APP_PER_KERNEL, "acir_format::handle_memory_init: Unsupported calldata id");
 
         block.type = BlockType::CallData;
-        block.calldata_id = calldata_id == 0 ? CallDataType::Primary : CallDataType::Secondary;
+        block.calldata_id = static_cast<CallDataType>(calldata_id);
     } else if (std::holds_alternative<Acir::BlockType::ReturnData>(mem_init.block_type.value)) {
         block.type = BlockType::ReturnData;
     }

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_to_constraint_buf.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_to_constraint_buf.cpp
@@ -802,7 +802,7 @@ BlockConstraint memory_init_to_block_constraint(Acir::Opcode::MemoryInit const& 
     // array.
     if (std::holds_alternative<Acir::BlockType::CallData>(mem_init.block_type.value)) {
         uint32_t calldata_id = std::get<Acir::BlockType::CallData>(mem_init.block_type.value).value;
-        BB_ASSERT_LTE(calldata_id, NUM_APP_PER_KERNEL, "acir_format::handle_memory_init: Unsupported calldata id");
+        BB_ASSERT_LTE(calldata_id, MAX_APPS_PER_KERNEL, "acir_format::handle_memory_init: Unsupported calldata id");
 
         block.type = BlockType::CallData;
         block.calldata_id = static_cast<CallDataType>(calldata_id);

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/block_constraint.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/block_constraint.cpp
@@ -165,17 +165,15 @@ void process_call_data_operations(Builder& builder,
         }
     };
 
-    // Process primary or secondary calldata based on calldata_id
-    switch (constraint.calldata_id) {
-    case CallDataType::Primary:
-        process_calldata(databus.calldata);
-        break;
-    case CallDataType::Secondary:
-        process_calldata(databus.secondary_calldata);
-        break;
-    default:
-        bb::assert_failure("Databus only supports two calldata arrays.");
-        break;
+    // Process kernel or app calldata based on the ACIR calldata id. Id 0 is kernel calldata; app calldata ids start at
+    // 1 and map directly onto app_calldata[id - 1].
+    const auto calldata_id = static_cast<uint32_t>(constraint.calldata_id);
+    if (calldata_id == static_cast<uint32_t>(CallDataType::KernelCalldata)) {
+        process_calldata(databus.kernel_calldata);
+    } else {
+        const size_t app_calldata_idx = calldata_id - static_cast<uint32_t>(CallDataType::AppCalldata);
+        BB_ASSERT_LT(app_calldata_idx, NUM_APP_PER_KERNEL, "Databus app calldata index out of bounds");
+        process_calldata(databus.app_calldata[app_calldata_idx]);
     }
 }
 

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/block_constraint.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/block_constraint.cpp
@@ -171,7 +171,7 @@ void process_call_data_operations(Builder& builder,
     if (calldata_id == static_cast<uint32_t>(CallDataType::KernelCalldata)) {
         process_calldata(databus.kernel_calldata);
     } else {
-        const size_t app_calldata_idx = calldata_id - static_cast<uint32_t>(CallDataType::AppCalldata);
+        const size_t app_calldata_idx = calldata_id - /*shift by kernel calldata*/ 1;
         BB_ASSERT_LT(app_calldata_idx, MAX_APPS_PER_KERNEL, "Databus app calldata index out of bounds");
         process_calldata(databus.app_calldata[app_calldata_idx]);
     }

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/block_constraint.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/block_constraint.cpp
@@ -172,7 +172,7 @@ void process_call_data_operations(Builder& builder,
         process_calldata(databus.kernel_calldata);
     } else {
         const size_t app_calldata_idx = calldata_id - static_cast<uint32_t>(CallDataType::AppCalldata);
-        BB_ASSERT_LT(app_calldata_idx, NUM_APP_PER_KERNEL, "Databus app calldata index out of bounds");
+        BB_ASSERT_LT(app_calldata_idx, MAX_APPS_PER_KERNEL, "Databus app calldata index out of bounds");
         process_calldata(databus.app_calldata[app_calldata_idx]);
     }
 }

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/block_constraint.hpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/block_constraint.hpp
@@ -47,7 +47,7 @@ enum BlockType : std::uint8_t {
  *          2. trace holds the sequence of memory operations (reads/writes) performed on the table
  *          3. type indicates the type of memory being constrained (RAM/ROM/CallData/ReturnData)
  *          4. calldata_id (used only for CallData) indicates whether we are operating on kernel calldata or an app
- *             calldata slot. The kernel calldata id is 0, app calldata ids are in [1, NUM_APP_PER_KERNEL].
+ *             calldata slot. The kernel calldata id is 0, app calldata ids are in [1, MAX_APPS_PER_KERNEL].
  */
 struct BlockConstraint {
     std::vector<uint32_t> init;

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/block_constraint.hpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/block_constraint.hpp
@@ -21,6 +21,7 @@ enum AccessType : std::uint8_t {
 enum CallDataType : std::uint32_t {
     KernelCalldata = 0,
     AppCalldata = 1,
+    None = bb::MAX_APPS_PER_KERNEL + 1, // Used for non-calldata blocks
 };
 
 /**

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/block_constraint.hpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/block_constraint.hpp
@@ -5,6 +5,7 @@
 // =====================
 
 #pragma once
+#include "barretenberg/constants.hpp"
 #include "barretenberg/dsl/acir_format/witness_constant.hpp"
 #include "barretenberg/stdlib/primitives/field/field.hpp"
 #include <cstdint>
@@ -17,10 +18,9 @@ enum AccessType : std::uint8_t {
     Write = 1,
 };
 
-enum CallDataType : std::uint8_t {
-    None = 0,
-    Primary = 1,
-    Secondary = 2,
+enum CallDataType : std::uint32_t {
+    KernelCalldata = 0,
+    AppCalldata = 1,
 };
 
 /**
@@ -46,8 +46,8 @@ enum BlockType : std::uint8_t {
  * @details 1. init holds the initial values of the RAM/ROM/CallData/ReturnData table
  *          2. trace holds the sequence of memory operations (reads/writes) performed on the table
  *          3. type indicates the type of memory being constrained (RAM/ROM/CallData/ReturnData)
- *          4. calldata_id (used only for CallData) indicates whether we are operating on primary (kernel) or secondary
- *             (app) calldata
+ *          4. calldata_id (used only for CallData) indicates whether we are operating on kernel calldata or an app
+ *             calldata slot. The kernel calldata id is 0, app calldata ids are in [1, NUM_APP_PER_KERNEL].
  */
 struct BlockConstraint {
     std::vector<uint32_t> init;

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/block_constraint.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/block_constraint.test.cpp
@@ -509,12 +509,12 @@ class CallDataTestingFunctions {
     }
 };
 
-using CallDataTestConfigs = testing::Types<CallDataTestParams<CallDataType::Primary, 0, 0, false>,
-                                           CallDataTestParams<CallDataType::Primary, 10, 5, false>,
-                                           CallDataTestParams<CallDataType::Primary, 10, 5, true>,
-                                           CallDataTestParams<CallDataType::Secondary, 0, 0, false>,
-                                           CallDataTestParams<CallDataType::Secondary, 10, 5, false>,
-                                           CallDataTestParams<CallDataType::Secondary, 10, 5, true>>;
+using CallDataTestConfigs = testing::Types<CallDataTestParams<CallDataType::KernelCalldata, 0, 0, false>,
+                                           CallDataTestParams<CallDataType::KernelCalldata, 10, 5, false>,
+                                           CallDataTestParams<CallDataType::KernelCalldata, 10, 5, true>,
+                                           CallDataTestParams<CallDataType::AppCalldata, 0, 0, false>,
+                                           CallDataTestParams<CallDataType::AppCalldata, 10, 5, false>,
+                                           CallDataTestParams<CallDataType::AppCalldata, 10, 5, true>>;
 
 template <typename Params>
 class CallDataTests : public ::testing::Test,

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/hypernova_recursion_constraint.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/hypernova_recursion_constraint.cpp
@@ -32,50 +32,59 @@ using namespace bb;
 std::shared_ptr<Chonk> create_mock_chonk_from_constraints(const std::vector<RecursionConstraint>& constraints)
 {
     auto ivc = std::make_shared<Chonk>(std::max(constraints.size(), static_cast<size_t>(4)));
-
     // Check constraint proof type. Throws if proof_type is not a valid HyperNova type
     auto constraint_has_type = [](const RecursionConstraint& c, Chonk::QUEUE_TYPE expected) {
         return proof_type_to_chonk_queue_type(c.proof_type) == expected;
     };
 
+    BB_ASSERT(!constraints.empty(), "At least one recursion constraint is required to determine Chonk state");
+    const bool is_init = constraint_has_type(constraints[0], Chonk::QUEUE_TYPE::OINK);
+    const bool is_reset = (constraints.size() == 1 && constraint_has_type(constraints[0], Chonk::QUEUE_TYPE::HN));
+    const bool is_tail = (constraints.size() == 1 && constraint_has_type(constraints[0], Chonk::QUEUE_TYPE::HN_TAIL));
+    const bool is_hiding =
+        (constraints.size() == 1 && constraint_has_type(constraints[0], Chonk::QUEUE_TYPE::HN_FINAL));
+    const size_t upper_bound = is_init ? MAX_APPS_PER_KERNEL : MAX_APPS_PER_KERNEL + 1;
+    BB_ASSERT_LTE(constraints.size(), upper_bound, "Too many recursion constraints encountered when mocking IVC state");
+
     // Match constraint patterns to kernel types and populate appropriate mock data:
 
     // INIT kernel: Verifies first app circuit (no prior accumulator exists)
-    if (constraints.size() == 1 && constraint_has_type(constraints[0], Chonk::QUEUE_TYPE::OINK)) {
+    if (is_init) {
         mock_chonk_accumulation(ivc, Chonk::QUEUE_TYPE::OINK, /*is_kernel=*/false);
+        for (size_t idx = 1; idx < constraints.size(); idx++) {
+            BB_ASSERT(constraint_has_type(constraints[idx], Chonk::QUEUE_TYPE::HN),
+                      "Subsequent constraints in init kernel must be HN type");
+            mock_chonk_accumulation(ivc, Chonk::QUEUE_TYPE::HN, /*is_kernel=*/false);
+        }
         return ivc;
     }
 
     // RESET kernel: Verifies only a previous kernel (resets the IVC accumulation)
-    if (constraints.size() == 1 && constraint_has_type(constraints[0], Chonk::QUEUE_TYPE::HN)) {
+    if (is_reset) {
         mock_chonk_accumulation(ivc, Chonk::QUEUE_TYPE::HN, /*is_kernel=*/true);
         return ivc;
     }
 
-    // TAIL kernel: Final kernel in the chain before generating tube proof
-    if (constraints.size() == 1 && constraint_has_type(constraints[0], Chonk::QUEUE_TYPE::HN_TAIL)) {
+    // TAIL kernel: Final kernel in the chain before hiding kernel
+    if (is_tail) {
         mock_chonk_accumulation(ivc, Chonk::QUEUE_TYPE::HN_TAIL, /*is_kernel=*/true);
         return ivc;
     }
 
-    // INNER kernel: Verifies previous kernel + new app circuit
-    if (constraints.size() == 2) {
-        BB_ASSERT(constraint_has_type(constraints[0], Chonk::QUEUE_TYPE::HN),
-                  "Inner kernel first constraint must be HN type");
-        BB_ASSERT(constraint_has_type(constraints[1], Chonk::QUEUE_TYPE::HN),
-                  "Inner kernel second constraint must be HN type");
-        mock_chonk_accumulation(ivc, Chonk::QUEUE_TYPE::HN, /*is_kernel=*/true);
-        mock_chonk_accumulation(ivc, Chonk::QUEUE_TYPE::HN, /*is_kernel=*/false);
-        return ivc;
-    }
-
     // HIDING kernel: Adds zero-knowledge hiding to the final proof
-    if (constraints.size() == 1 && constraint_has_type(constraints[0], Chonk::QUEUE_TYPE::HN_FINAL)) {
+    if (is_hiding) {
         mock_chonk_accumulation(ivc, Chonk::QUEUE_TYPE::HN_FINAL, /*is_kernel=*/true);
         return ivc;
     }
 
-    throw_or_abort("Invalid set of IVC recursion constraints!");
+    // INNER kernel: Verifies previous kernel + app circuits
+    bool is_kernel = true;
+    for (const auto& constraint : constraints) {
+        BB_ASSERT(constraint_has_type(constraint, Chonk::QUEUE_TYPE::HN),
+                  "All constraints in inner kernel must be HN type");
+        mock_chonk_accumulation(ivc, Chonk::QUEUE_TYPE::HN, /*is_kernel=*/is_kernel);
+        is_kernel = false; // First constraint verifies previous kernel, subsequent constraints verify apps
+    }
     return ivc;
 }
 

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/hypernova_recursion_constraint.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/hypernova_recursion_constraint.test.cpp
@@ -212,10 +212,9 @@ class HypernovaRecursionConstraintTest : public ::testing::Test {
         program.constraints.max_witness_index = static_cast<uint32_t>(program.witness.size() - 1);
         program.constraints.num_acir_opcodes = static_cast<uint32_t>(hn_recursion_constraints.size());
         program.constraints.hn_recursion_constraints = hn_recursion_constraints;
-        program.constraints.original_opcode_indices =
-            hn_recursion_constraints.size() == 1
-                ? AcirFormatOriginalOpcodeIndices{ .hn_recursion_constraints = { 0 } }
-                : AcirFormatOriginalOpcodeIndices{ .hn_recursion_constraints = { 0, 1 } };
+        for (size_t idx = 0; idx < hn_recursion_constraints.size(); ++idx) {
+            program.constraints.original_opcode_indices.hn_recursion_constraints.push_back(static_cast<uint32_t>(idx));
+        }
 
         return program;
     }

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/opcode_gate_count.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/opcode_gate_count.test.cpp
@@ -484,7 +484,7 @@ TYPED_TEST(OpcodeGateCountTests, BlockRomRead)
         .init = init,
         .trace = trace,
         .type = BlockType::ROM,
-        .calldata_id = CallDataType::KernelCalldata,
+        .calldata_id = CallDataType::None,
     };
 
     AcirFormat constraint_system = constraint_to_acir_format(block_constraint);
@@ -520,7 +520,7 @@ TYPED_TEST(OpcodeGateCountTests, BlockRamRead)
         .init = init,
         .trace = trace,
         .type = BlockType::RAM,
-        .calldata_id = CallDataType::KernelCalldata,
+        .calldata_id = CallDataType::None,
     };
 
     AcirFormat constraint_system = constraint_to_acir_format(block_constraint);
@@ -556,7 +556,7 @@ TYPED_TEST(OpcodeGateCountTests, BlockRamWrite)
         .init = init,
         .trace = trace,
         .type = BlockType::RAM,
-        .calldata_id = CallDataType::KernelCalldata,
+        .calldata_id = CallDataType::None,
     };
 
     AcirFormat constraint_system = constraint_to_acir_format(block_constraint);
@@ -654,7 +654,7 @@ TYPED_TEST(OpcodeGateCountTests, BlockReturnData)
         .init = init,
         .trace = {},
         .type = BlockType::ReturnData,
-        .calldata_id = CallDataType::KernelCalldata,
+        .calldata_id = CallDataType::None,
     };
 
     AcirFormat constraint_system = constraint_to_acir_format(block_constraint);

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/opcode_gate_count.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/opcode_gate_count.test.cpp
@@ -484,7 +484,7 @@ TYPED_TEST(OpcodeGateCountTests, BlockRomRead)
         .init = init,
         .trace = trace,
         .type = BlockType::ROM,
-        .calldata_id = CallDataType::None,
+        .calldata_id = CallDataType::KernelCalldata,
     };
 
     AcirFormat constraint_system = constraint_to_acir_format(block_constraint);
@@ -520,7 +520,7 @@ TYPED_TEST(OpcodeGateCountTests, BlockRamRead)
         .init = init,
         .trace = trace,
         .type = BlockType::RAM,
-        .calldata_id = CallDataType::None,
+        .calldata_id = CallDataType::KernelCalldata,
     };
 
     AcirFormat constraint_system = constraint_to_acir_format(block_constraint);
@@ -556,7 +556,7 @@ TYPED_TEST(OpcodeGateCountTests, BlockRamWrite)
         .init = init,
         .trace = trace,
         .type = BlockType::RAM,
-        .calldata_id = CallDataType::None,
+        .calldata_id = CallDataType::KernelCalldata,
     };
 
     AcirFormat constraint_system = constraint_to_acir_format(block_constraint);
@@ -592,13 +592,13 @@ TYPED_TEST(OpcodeGateCountTests, BlockCallData)
         .value = WitnessOrConstant<bb::fr>::from_index(3), // 10
     });
 
-    // Primary calldata
+    // Kernel calldata
     {
         BlockConstraint block_constraint{
             .init = init,
             .trace = trace,
             .type = BlockType::CallData,
-            .calldata_id = CallDataType::Primary,
+            .calldata_id = CallDataType::KernelCalldata,
         };
 
         AcirFormat constraint_system = constraint_to_acir_format(block_constraint);
@@ -614,13 +614,13 @@ TYPED_TEST(OpcodeGateCountTests, BlockCallData)
         EXPECT_EQ(program.constraints.gates_per_opcode, std::vector<size_t>({ BLOCK_CALLDATA<TypeParam> }));
     }
 
-    // Secondary calldata
+    // App calldata
     {
         BlockConstraint block_constraint{
             .init = init,
             .trace = trace,
             .type = BlockType::CallData,
-            .calldata_id = CallDataType::Secondary,
+            .calldata_id = CallDataType::AppCalldata,
         };
 
         AcirFormat constraint_system = constraint_to_acir_format(block_constraint);
@@ -654,7 +654,7 @@ TYPED_TEST(OpcodeGateCountTests, BlockReturnData)
         .init = init,
         .trace = {},
         .type = BlockType::ReturnData,
-        .calldata_id = CallDataType::None,
+        .calldata_id = CallDataType::KernelCalldata,
     };
 
     AcirFormat constraint_system = constraint_to_acir_format(block_constraint);

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/test_class.hpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/test_class.hpp
@@ -105,7 +105,7 @@ inline Acir::BlockType block_type_to_acir_block_type(BlockType type, CallDataTyp
         // ROM and RAM both map to Memory in ACIR
         return Acir::BlockType{ .value = Acir::BlockType::Memory{} };
     case BlockType::CallData: {
-        uint32_t id = (calldata_id == CallDataType::Primary) ? 0 : 1;
+        uint32_t id = static_cast<uint32_t>(calldata_id);
         return Acir::BlockType{ .value = Acir::BlockType::CallData{ .value = id } };
     }
     case BlockType::ReturnData:

--- a/barretenberg/cpp/src/barretenberg/flavor/mega_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/mega_flavor.hpp
@@ -389,15 +389,15 @@ class MegaFlavor {
             ecc_op_wire_2 = "ECC_OP_WIRE_2";
             ecc_op_wire_3 = "ECC_OP_WIRE_3";
             ecc_op_wire_4 = "ECC_OP_WIRE_4";
-            calldata = "CALLDATA";
-            calldata_read_counts = "CALLDATA_READ_COUNTS";
-            calldata_inverses = "CALLDATA_INVERSES";
-            secondary_calldata = "SECONDARY_CALLDATA";
-            secondary_calldata_read_counts = "SECONDARY_CALLDATA_READ_COUNTS";
-            secondary_calldata_inverses = "SECONDARY_CALLDATA_INVERSES";
-            return_data = "RETURN_DATA";
-            return_data_read_counts = "RETURN_DATA_READ_COUNTS";
-            return_data_inverses = "RETURN_DATA_INVERSES";
+            calldata = "KERNEL_CALLDATA";
+            calldata_read_counts = "KERNEL_CALLDATA_READ_COUNTS";
+            calldata_inverses = "KERNEL_CALLDATA_INVERSES";
+            secondary_calldata = "APP_CALLDATA";
+            secondary_calldata_read_counts = "APP_CALLDATA_READ_COUNTS";
+            secondary_calldata_inverses = "APP_CALLDATA_INVERSES";
+            return_data = "RETURNDATA";
+            return_data_read_counts = "RETURNDATA_READ_COUNTS";
+            return_data_inverses = "RETURNDATA_INVERSES";
 
             q_c = "Q_C";
             q_l = "Q_L";

--- a/barretenberg/cpp/src/barretenberg/honk/types/public_inputs_type.hpp
+++ b/barretenberg/cpp/src/barretenberg/honk/types/public_inputs_type.hpp
@@ -64,7 +64,7 @@ constexpr std::size_t kernel_public_inputs_size(std::size_t num_apps)
            /*output_hn_accum_hash*/ FR_PUBLIC_INPUTS_SIZE;
 }
 
-static constexpr std::size_t KERNEL_PUBLIC_INPUTS_SIZE = kernel_public_inputs_size(NUM_APP_PER_KERNEL);
+static constexpr std::size_t KERNEL_PUBLIC_INPUTS_SIZE = kernel_public_inputs_size(MAX_APPS_PER_KERNEL);
 
 // Number of bb::fr elements used to represent the default public inputs, i.e., the pairing points
 static constexpr std::size_t DEFAULT_PUBLIC_INPUTS_SIZE = PAIRING_POINTS_SIZE;

--- a/barretenberg/cpp/src/barretenberg/honk/types/public_inputs_type.hpp
+++ b/barretenberg/cpp/src/barretenberg/honk/types/public_inputs_type.hpp
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include "barretenberg/constants.hpp"
 #include <cstdint>
 
 namespace bb {
@@ -53,12 +54,17 @@ static constexpr std::size_t INVALID_PUBLIC_INPUTS_SIZE = 0;
 static constexpr std::size_t MEGA_EXECUTION_TRACE_NUM_WIRES = 4;
 
 // Number of bb::fr elements used to represent the public inputs of an INIT/INNER/RESET/TAIL kernel
-static constexpr std::size_t KERNEL_PUBLIC_INPUTS_SIZE =
-    /*pairing_inputs*/ PAIRING_POINTS_SIZE +
-    /*kernel_return_data*/ GOBLIN_GROUP_PUBLIC_INPUTS_SIZE +
-    /*app_return_data*/ GOBLIN_GROUP_PUBLIC_INPUTS_SIZE +
-    /*ecc_op_hash*/ FR_PUBLIC_INPUTS_SIZE +
-    /*output_hn_accum_hash*/ FR_PUBLIC_INPUTS_SIZE;
+// verifying num_apps application circuits in its accumulation group.
+constexpr std::size_t kernel_public_inputs_size(std::size_t num_apps)
+{
+    return /*pairing_inputs*/ PAIRING_POINTS_SIZE +
+           /*kernel_return_data*/ GOBLIN_GROUP_PUBLIC_INPUTS_SIZE +
+           /*app_return_data[num_apps]*/ (num_apps * GOBLIN_GROUP_PUBLIC_INPUTS_SIZE) +
+           /*ecc_op_hash*/ FR_PUBLIC_INPUTS_SIZE +
+           /*output_hn_accum_hash*/ FR_PUBLIC_INPUTS_SIZE;
+}
+
+static constexpr std::size_t KERNEL_PUBLIC_INPUTS_SIZE = kernel_public_inputs_size(NUM_APP_PER_KERNEL);
 
 // Number of bb::fr elements used to represent the default public inputs, i.e., the pairing points
 static constexpr std::size_t DEFAULT_PUBLIC_INPUTS_SIZE = PAIRING_POINTS_SIZE;

--- a/barretenberg/cpp/src/barretenberg/honk/types/public_inputs_type.hpp
+++ b/barretenberg/cpp/src/barretenberg/honk/types/public_inputs_type.hpp
@@ -64,8 +64,6 @@ constexpr std::size_t kernel_public_inputs_size(std::size_t num_apps)
            /*output_hn_accum_hash*/ FR_PUBLIC_INPUTS_SIZE;
 }
 
-static constexpr std::size_t KERNEL_PUBLIC_INPUTS_SIZE = kernel_public_inputs_size(MAX_APPS_PER_KERNEL);
-
 // Number of bb::fr elements used to represent the default public inputs, i.e., the pairing points
 static constexpr std::size_t DEFAULT_PUBLIC_INPUTS_SIZE = PAIRING_POINTS_SIZE;
 

--- a/barretenberg/cpp/src/barretenberg/hypernova/hypernova_verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/hypernova/hypernova_verifier.test.cpp
@@ -189,7 +189,7 @@ class HypernovaFoldingVerifierTests : public ::testing::Test {
         for (const auto& wire : { "ECC_OP_WIRE_1", "ECC_OP_WIRE_2", "ECC_OP_WIRE_3", "ECC_OP_WIRE_4" }) {
             manifest.add_entry(round, wire, frs_per_G);
         }
-        for (const auto& bus : { "CALLDATA", "SECONDARY_CALLDATA", "RETURN_DATA" }) {
+        for (const auto& bus : { "KERNEL_CALLDATA", "APP_CALLDATA", "RETURNDATA" }) {
             manifest.add_entry(round, bus, frs_per_G);
             manifest.add_entry(round, std::string(bus) + "_READ_COUNTS", frs_per_G);
         }
@@ -206,9 +206,9 @@ class HypernovaFoldingVerifierTests : public ::testing::Test {
         manifest.add_challenge(round, "alpha");
         manifest.add_challenge(round, "HypernovaFoldingProver:gate_challenge");
         manifest.add_entry(round, "LOOKUP_INVERSES", frs_per_G);
-        manifest.add_entry(round, "CALLDATA_INVERSES", frs_per_G);
-        manifest.add_entry(round, "SECONDARY_CALLDATA_INVERSES", frs_per_G);
-        manifest.add_entry(round, "RETURN_DATA_INVERSES", frs_per_G);
+        manifest.add_entry(round, "KERNEL_CALLDATA_INVERSES", frs_per_G);
+        manifest.add_entry(round, "APP_CALLDATA_INVERSES", frs_per_G);
+        manifest.add_entry(round, "RETURNDATA_INVERSES", frs_per_G);
         manifest.add_entry(round, "Z_PERM", frs_per_G);
         round++;
 

--- a/barretenberg/cpp/src/barretenberg/relations/databus_lookup_relation_consistency.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/relations/databus_lookup_relation_consistency.test.cpp
@@ -33,15 +33,15 @@ struct DatabusInputElements {
 
     // Column selectors (determine which bus column is being read)
     FF q_l; // calldata selector
-    FF q_r; // secondary_calldata selector
+    FF q_r; // app calldata selector
     FF q_o; // return_data selector
 
-    // Calldata (bus_idx = 0)
+    // Kernel calldata (bus_idx = 0)
     FF calldata;
     FF calldata_read_counts;
     FF calldata_inverses;
 
-    // Secondary calldata (bus_idx = 1)
+    // App calldata (bus_idx = 1)
     FF secondary_calldata;
     FF secondary_calldata_read_counts;
     FF secondary_calldata_inverses;

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/databus/databus.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/databus/databus.hpp
@@ -23,6 +23,8 @@ template <typename Builder> class databus {
         using field_pt = field_t<Builder>;
 
       public:
+        bus_vector() = default;
+
         bus_vector(const BusId bus_idx)
             : bus_idx(bus_idx) {};
 
@@ -59,9 +61,15 @@ template <typename Builder> class databus {
     };
 
   public:
-    // The columns of the DataBus
-    bus_vector calldata{ BusId::CALLDATA };
-    bus_vector secondary_calldata{ BusId::SECONDARY_CALLDATA };
+    // The columns of the DataBus.
+    bus_vector kernel_calldata{ BusId::KERNEL_CALLDATA };
+    std::array<bus_vector, NUM_APP_PER_KERNEL> app_calldata = []() {
+        std::array<bus_vector, NUM_APP_PER_KERNEL> result{};
+        for (uint8_t idx = 0; idx < NUM_APP_PER_KERNEL; ++idx) {
+            result[idx] = bus_vector{ static_cast<BusId>(idx + 1) };
+        }
+        return result;
+    }();
     bus_vector return_data{ BusId::RETURNDATA };
 };
 
@@ -91,11 +99,15 @@ template <class Builder> class DataBusDepot {
     using FrNative = typename Curve::ScalarFieldNative;
 
     // Storage for the return data commitments to be propagated via the public inputs
-    Commitment app_return_data_commitment;
+    std::array<Commitment, NUM_APP_PER_KERNEL> app_return_data_commitments;
     Commitment kernel_return_data_commitment;
 
     // Existence flags indicating whether each return data commitment has been set
-    bool app_return_data_commitment_exists = false;
+    std::array<bool, NUM_APP_PER_KERNEL> app_return_data_commitment_exists = []() {
+        std::array<bool, NUM_APP_PER_KERNEL> result{};
+        result.fill(false);
+        return result;
+    }();
     bool kernel_return_data_commitment_exists = false;
 
     void set_kernel_return_data_commitment(const Commitment& commitment)
@@ -104,10 +116,13 @@ template <class Builder> class DataBusDepot {
         kernel_return_data_commitment_exists = true;
     }
 
-    void set_app_return_data_commitment(const Commitment& commitment)
+    void set_app_return_data_commitment(const Commitment& commitment) { set_app_return_data_commitment(commitment, 0); }
+
+    void set_app_return_data_commitment(const Commitment& commitment, const size_t idx)
     {
-        app_return_data_commitment = commitment;
-        app_return_data_commitment_exists = true;
+        BB_ASSERT_LT(idx, NUM_APP_PER_KERNEL, "DataBusDepot app return-data index out of bounds");
+        app_return_data_commitments[idx] = commitment;
+        app_return_data_commitment_exists[idx] = true;
     }
 
     /**
@@ -139,13 +154,16 @@ template <class Builder> class DataBusDepot {
      * @brief Get the previously set app return data commitment if it exists, else a default one
      *
      */
-    Commitment get_app_return_data_commitment(Builder& builder)
+    Commitment get_app_return_data_commitment(Builder& builder) { return get_app_return_data_commitment(builder, 0); }
+
+    Commitment get_app_return_data_commitment(Builder& builder, const size_t idx)
     {
-        if (!app_return_data_commitment_exists) {
+        BB_ASSERT_LT(idx, NUM_APP_PER_KERNEL, "DataBusDepot app return-data index out of bounds");
+        if (!app_return_data_commitment_exists[idx]) {
             return construct_default_commitment(builder);
         }
-        app_return_data_commitment_exists = false; // Reset the existence flag after retrieval
-        return app_return_data_commitment;
+        app_return_data_commitment_exists[idx] = false; // Reset the existence flag after retrieval
+        return app_return_data_commitments[idx];
     }
 };
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/databus/databus.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/databus/databus.hpp
@@ -81,13 +81,12 @@ template <typename Builder> class databus {
  * \pi_i, and it has access to [C_i] directly from \pi_i. The consistency checks in circuit (i+1) are thus of the
  * form \pi_i.public_inputs.[R_{i-1}] = \pi_i.[C_i].
  *
- * For consistent behavior across kernels, every kernel propagates two return data commitments via its
- * public inputs. If one of either the app or kernel return data does not exist, it is populated with a default
- * value that will satisfy the consistency check on the next cycle. For example, the first kernel has no previous
- * kernel to verify and thus neither receives a previous kernel return data commitment nor a calldata input
- * corresponding to a previous kernel. The "empty" calldata will be populated with a default value, resulting in a
- * default commitment value. We set the same value for the missing return data herein so that the commitments agree
- * and the corresponding consistency check will be satisfied in the kernel in which it's performed.
+ * For consistent behavior across kernels, every kernel propagates `MAX_APPS_PER_KERNEL + 1` return-data commitments
+ * via its public inputs: one for the previous kernel and one per app slot. If any of these does not exist (e.g., the
+ * first kernel has no previous kernel; a kernel with fewer than MAX apps leaves the trailing app slots unset), it is
+ * populated with a default commitment value that will satisfy the consistency check on the next cycle. The "empty"
+ * calldata column on the next kernel side will commit to the same default value, so the commitments agree and the
+ * consistency check passes trivially.
  *
  * @tparam Builder
  */

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/databus/databus.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/databus/databus.hpp
@@ -116,11 +116,39 @@ template <class Builder> class DataBusDepot {
         kernel_return_data_commitment_exists = true;
     }
 
-    void set_app_return_data_commitment(const Commitment& commitment, const size_t idx)
+    /**
+     * @brief Whether all app return-data slots are currently empty.
+     * @details Used to assert the kernel-boundary invariant: at the start of each kernel completion, every slot must
+     * have been drained by the prior kernel's get-loop so that `set_app_return_data_commitment` begins filling from
+     * slot 0.
+     */
+    bool app_return_data_slots_are_empty() const
     {
-        BB_ASSERT_LT(idx, NUM_APP_PER_KERNEL, "DataBusDepot app return-data index out of bounds");
-        app_return_data_commitments[idx] = commitment;
-        app_return_data_commitment_exists[idx] = true;
+        for (size_t idx = 0; idx < NUM_APP_PER_KERNEL; ++idx) {
+            if (app_return_data_commitment_exists[idx]) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * @brief Record an app return-data commitment in the next available slot.
+     * @details Slot assignment is implicit: the depot fills slot 0 first, then slot 1, etc., as apps are processed in
+     * the kernel's verification queue. Slots are released by `get_app_return_data_commitment`; each kernel-completion
+     * pass drains every slot via the get-loop in `Chonk::complete_kernel_circuit_logic`, so the next kernel begins
+     * filling from slot 0 again.
+     */
+    void set_app_return_data_commitment(const Commitment& commitment)
+    {
+        for (size_t idx = 0; idx < NUM_APP_PER_KERNEL; ++idx) {
+            if (!app_return_data_commitment_exists[idx]) {
+                app_return_data_commitments[idx] = commitment;
+                app_return_data_commitment_exists[idx] = true;
+                return;
+            }
+        }
+        BB_ASSERT(false, "DataBusDepot has no free app return-data slot");
     }
 
     /**

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/databus/databus.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/databus/databus.hpp
@@ -63,9 +63,9 @@ template <typename Builder> class databus {
   public:
     // The columns of the DataBus.
     bus_vector kernel_calldata{ BusId::KERNEL_CALLDATA };
-    std::array<bus_vector, NUM_APP_PER_KERNEL> app_calldata = []() {
-        std::array<bus_vector, NUM_APP_PER_KERNEL> result{};
-        for (uint8_t idx = 0; idx < NUM_APP_PER_KERNEL; ++idx) {
+    std::array<bus_vector, MAX_APPS_PER_KERNEL> app_calldata = []() {
+        std::array<bus_vector, MAX_APPS_PER_KERNEL> result{};
+        for (uint8_t idx = 0; idx < MAX_APPS_PER_KERNEL; ++idx) {
             result[idx] = bus_vector{ static_cast<BusId>(idx + 1) };
         }
         return result;
@@ -99,12 +99,12 @@ template <class Builder> class DataBusDepot {
     using FrNative = typename Curve::ScalarFieldNative;
 
     // Storage for the return data commitments to be propagated via the public inputs
-    std::array<Commitment, NUM_APP_PER_KERNEL> app_return_data_commitments;
+    std::array<Commitment, MAX_APPS_PER_KERNEL> app_return_data_commitments;
     Commitment kernel_return_data_commitment;
 
     // Existence flags indicating whether each return data commitment has been set
-    std::array<bool, NUM_APP_PER_KERNEL> app_return_data_commitment_exists = []() {
-        std::array<bool, NUM_APP_PER_KERNEL> result{};
+    std::array<bool, MAX_APPS_PER_KERNEL> app_return_data_commitment_exists = []() {
+        std::array<bool, MAX_APPS_PER_KERNEL> result{};
         result.fill(false);
         return result;
     }();
@@ -124,7 +124,7 @@ template <class Builder> class DataBusDepot {
      */
     bool app_return_data_slots_are_empty() const
     {
-        for (size_t idx = 0; idx < NUM_APP_PER_KERNEL; ++idx) {
+        for (size_t idx = 0; idx < MAX_APPS_PER_KERNEL; ++idx) {
             if (app_return_data_commitment_exists[idx]) {
                 return false;
             }
@@ -141,7 +141,7 @@ template <class Builder> class DataBusDepot {
      */
     void set_app_return_data_commitment(const Commitment& commitment)
     {
-        for (size_t idx = 0; idx < NUM_APP_PER_KERNEL; ++idx) {
+        for (size_t idx = 0; idx < MAX_APPS_PER_KERNEL; ++idx) {
             if (!app_return_data_commitment_exists[idx]) {
                 app_return_data_commitments[idx] = commitment;
                 app_return_data_commitment_exists[idx] = true;
@@ -182,7 +182,7 @@ template <class Builder> class DataBusDepot {
      */
     Commitment get_app_return_data_commitment(Builder& builder, const size_t idx)
     {
-        BB_ASSERT_LT(idx, NUM_APP_PER_KERNEL, "DataBusDepot app return-data index out of bounds");
+        BB_ASSERT_LT(idx, MAX_APPS_PER_KERNEL, "DataBusDepot app return-data index out of bounds");
         if (!app_return_data_commitment_exists[idx]) {
             return construct_default_commitment(builder);
         }

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/databus/databus.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/databus/databus.hpp
@@ -116,8 +116,6 @@ template <class Builder> class DataBusDepot {
         kernel_return_data_commitment_exists = true;
     }
 
-    void set_app_return_data_commitment(const Commitment& commitment) { set_app_return_data_commitment(commitment, 0); }
-
     void set_app_return_data_commitment(const Commitment& commitment, const size_t idx)
     {
         BB_ASSERT_LT(idx, NUM_APP_PER_KERNEL, "DataBusDepot app return-data index out of bounds");
@@ -154,8 +152,6 @@ template <class Builder> class DataBusDepot {
      * @brief Get the previously set app return data commitment if it exists, else a default one
      *
      */
-    Commitment get_app_return_data_commitment(Builder& builder) { return get_app_return_data_commitment(builder, 0); }
-
     Commitment get_app_return_data_commitment(Builder& builder, const size_t idx)
     {
         BB_ASSERT_LT(idx, NUM_APP_PER_KERNEL, "DataBusDepot app return-data index out of bounds");

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/databus/databus.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/databus/databus.test.cpp
@@ -41,7 +41,7 @@ TEST(Databus, CallDataAndReturnData)
     for (auto& value : raw_calldata_values) {
         calldata_values.emplace_back(witness_ct(&builder, value));
     }
-    databus.calldata.set_values(calldata_values);
+    databus.kernel_calldata.set_values(calldata_values);
 
     // Populate the return data in the databus
     std::vector<field_ct> return_data_values;
@@ -53,14 +53,14 @@ TEST(Databus, CallDataAndReturnData)
     // Establish that the first two outputs are simply copied over from the inputs. Each 'copy' requires two read gates.
     field_ct idx_0(witness_ct(&builder, 0));
     field_ct idx_1(witness_ct(&builder, 1));
-    databus.calldata[idx_0].assert_equal(databus.return_data[idx_0]);
-    databus.calldata[idx_1].assert_equal(databus.return_data[idx_1]);
+    databus.kernel_calldata[idx_0].assert_equal(databus.return_data[idx_0]);
+    databus.kernel_calldata[idx_1].assert_equal(databus.return_data[idx_1]);
 
     // Get the last two entries in calldata and compute their sum
     field_ct idx_2(witness_ct(&builder, 2));
     field_ct idx_3(witness_ct(&builder, 3));
     // This line creates an arithmetic gate and two calldata read gates (via operator[]).
-    field_ct sum = databus.calldata[idx_2] + databus.calldata[idx_3];
+    field_ct sum = databus.kernel_calldata[idx_2] + databus.kernel_calldata[idx_3];
 
     // Read the last index of the return data. (Creates a return data read gate via operator[]).
     field_ct idx(witness_ct(&builder, 2));
@@ -124,14 +124,14 @@ TEST(Databus, UnnormalizedEntryAccess)
         // add the value to itself to make it unnormalized (the multiplicative constant will be 2)
         returndata_entries.emplace_back(entry_witness + entry_witness);
     }
-    databus.calldata.set_values(calldata_entries);
+    databus.kernel_calldata.set_values(calldata_entries);
     databus.return_data.set_values(returndata_entries);
     field_ct idx_0 = witness_ct(&builder, 0);
     field_ct idx_1 = witness_ct(&builder, 1);
     field_ct idx_2 = witness_ct(&builder, 2);
-    databus.return_data[idx_0].assert_equal(databus.calldata[idx_0] + databus.calldata[idx_0]);
-    databus.return_data[idx_1].assert_equal(databus.calldata[idx_1] + databus.calldata[idx_1]);
-    databus.return_data[idx_2].assert_equal(databus.calldata[idx_2] + databus.calldata[idx_2]);
+    databus.return_data[idx_0].assert_equal(databus.kernel_calldata[idx_0] + databus.kernel_calldata[idx_0]);
+    databus.return_data[idx_1].assert_equal(databus.kernel_calldata[idx_1] + databus.kernel_calldata[idx_1]);
+    databus.return_data[idx_2].assert_equal(databus.kernel_calldata[idx_2] + databus.kernel_calldata[idx_2]);
     EXPECT_TRUE(CircuitChecker::check(builder));
 }
 
@@ -150,7 +150,7 @@ TEST(Databus, ConstantAndUnnormalizedIndices)
     for (auto& value : raw_calldata_values) {
         calldata_values.emplace_back(witness_ct(&builder, value));
     }
-    databus.calldata.set_values(calldata_values);
+    databus.kernel_calldata.set_values(calldata_values);
 
     // Populate the return data in the databus
     std::vector<field_ct> returndata_values;
@@ -164,10 +164,10 @@ TEST(Databus, ConstantAndUnnormalizedIndices)
     field_ct idx_1(witness_ct(&builder, 1));
     // un-normalized index (with multiplicative constant 2)
     field_ct idx_2 = idx_1 + idx_1;
-    field_ct sum = databus.calldata[idx_0] + databus.calldata[idx_1] + databus.calldata[idx_2];
+    field_ct sum = databus.kernel_calldata[idx_0] + databus.kernel_calldata[idx_1] + databus.kernel_calldata[idx_2];
 
-    databus.return_data[idx_0].assert_equal(databus.calldata[idx_0]);
-    databus.return_data[idx_1].assert_equal(databus.calldata[idx_1]);
+    databus.return_data[idx_0].assert_equal(databus.kernel_calldata[idx_0]);
+    databus.return_data[idx_1].assert_equal(databus.kernel_calldata[idx_1]);
     databus.return_data[idx_2].assert_equal(sum);
 
     EXPECT_TRUE(CircuitChecker::check(builder));
@@ -218,7 +218,7 @@ TEST(Databus, BadCopyFailure)
 
     // Populate calldata with a single input
     fr input = 13;
-    databus.calldata.set_values({ witness_ct(&builder, input) });
+    databus.kernel_calldata.set_values({ witness_ct(&builder, input) });
 
     // Populate return data with an output different from the input
     fr output = input - 1;
@@ -227,7 +227,7 @@ TEST(Databus, BadCopyFailure)
     // Attempt to attest that the calldata has been copied into the return data
     size_t raw_idx = 0; // read at 0th index
     field_ct idx(witness_ct(&builder, raw_idx));
-    databus.calldata[idx].assert_equal(databus.return_data[idx]);
+    databus.kernel_calldata[idx].assert_equal(databus.return_data[idx]);
 
     // Since the output data is not a copy of the input, the checker should fail
     EXPECT_FALSE(CircuitChecker::check(builder));
@@ -251,7 +251,7 @@ TEST(Databus, DuplicateRead)
     for (auto& value : raw_calldata_values) {
         calldata_values.emplace_back(witness_ct(&builder, value));
     }
-    databus.calldata.set_values(calldata_values);
+    databus.kernel_calldata.set_values(calldata_values);
 
     // Populate the return data in the databus
     std::vector<field_ct> return_data_values;
@@ -264,10 +264,10 @@ TEST(Databus, DuplicateRead)
     field_ct idx_1(witness_ct(&builder, 1));
     field_ct idx_2(witness_ct(&builder, 2));
 
-    databus.calldata[idx_1];
-    databus.calldata[idx_1];
-    databus.calldata[idx_1];
-    databus.calldata[idx_2];
+    databus.kernel_calldata[idx_1];
+    databus.kernel_calldata[idx_1];
+    databus.kernel_calldata[idx_1];
+    databus.kernel_calldata[idx_2];
 
     databus.return_data[idx_2];
     databus.return_data[idx_2];

--- a/barretenberg/cpp/src/barretenberg/stdlib/special_public_inputs/special_public_inputs.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/special_public_inputs/special_public_inputs.hpp
@@ -55,10 +55,11 @@ std::array<typename bn254<Builder>::Group, Builder::NUM_WIRES> empty_ecc_op_tabl
 }
 
 /**
- * @brief Manages the data that is propagated on the public inputs of a kernel circuit
+ * @brief Manages the data that is propagated on the public inputs of a kernel circuit.
  *
+ * @tparam N Number of app return-data commitments carried by the kernel public inputs.
  */
-class KernelIO {
+template <size_t N> class KernelIO_ {
   public:
     using Builder = MegaCircuitBuilder;   // kernel builder is always Mega
     using Curve = stdlib::bn254<Builder>; // curve is always bn254
@@ -66,19 +67,20 @@ class KernelIO {
     using FF = Curve::ScalarField;
     using PairingInputs = stdlib::recursion::PairingPoints<Curve>;
     using TableCommitments = std::array<G1, Builder::NUM_WIRES>;
+    using AppReturnDataCommitments = std::array<G1, N>;
 
     using PublicPoint = stdlib::PublicInputComponent<G1>;
     using PublicPairingPoints = stdlib::PublicInputComponent<PairingInputs>;
     using PublicFF = stdlib::PublicInputComponent<FF>;
 
-    PairingInputs pairing_inputs; // Inputs {P0, P1} to an EC pairing check
-    G1 kernel_return_data;        // Commitment to the return data of a kernel circuit
-    G1 app_return_data;           // Commitment to the return data of an app circuit
-    FF ecc_op_hash;               // Running Poseidon2 hash over ECC op column commitments
-    FF output_hn_accum_hash;      // hash of the output HN verifier accumulator
+    PairingInputs pairing_inputs;             // Inputs {P0, P1} to an EC pairing check
+    G1 kernel_return_data;                    // Commitment to the return data of a kernel circuit
+    AppReturnDataCommitments app_return_data; // Commitment to each verified app circuit's return data
+    FF ecc_op_hash;                           // Running Poseidon2 hash over ECC op column commitments
+    FF output_hn_accum_hash;                  // hash of the output HN verifier accumulator
 
     // Total size of the kernel IO public inputs
-    static constexpr size_t PUBLIC_INPUTS_SIZE = KERNEL_PUBLIC_INPUTS_SIZE;
+    static constexpr size_t PUBLIC_INPUTS_SIZE = kernel_public_inputs_size(N);
     static constexpr bool HasIPA = false;
 
     /**
@@ -97,8 +99,10 @@ class KernelIO {
         index += PairingInputs::PUBLIC_INPUTS_SIZE;
         kernel_return_data = PublicPoint::reconstruct(public_inputs, PublicComponentKey{ index });
         index += G1::PUBLIC_INPUTS_SIZE;
-        app_return_data = PublicPoint::reconstruct(public_inputs, PublicComponentKey{ index });
-        index += G1::PUBLIC_INPUTS_SIZE;
+        for (auto& app_commitment : app_return_data) {
+            app_commitment = PublicPoint::reconstruct(public_inputs, PublicComponentKey{ index });
+            index += G1::PUBLIC_INPUTS_SIZE;
+        }
         ecc_op_hash = PublicFF::reconstruct(public_inputs, PublicComponentKey{ index });
         index += FF::PUBLIC_INPUTS_SIZE;
         output_hn_accum_hash = PublicFF::reconstruct(public_inputs, PublicComponentKey{ index });
@@ -115,7 +119,9 @@ class KernelIO {
 
         pairing_inputs.set_public(builder);
         kernel_return_data.set_public();
-        app_return_data.set_public();
+        for (auto& app_commitment : app_return_data) {
+            app_commitment.set_public();
+        }
         ecc_op_hash.set_public();
         output_hn_accum_hash.set_public();
 
@@ -129,16 +135,20 @@ class KernelIO {
      */
     static void add_default(Builder& builder)
     {
-        KernelIO inputs;
+        KernelIO_ inputs;
 
         inputs.pairing_inputs = PairingInputs::construct_default();
         inputs.kernel_return_data = DataBusDepot<Builder>::construct_default_commitment(builder);
-        inputs.app_return_data = DataBusDepot<Builder>::construct_default_commitment(builder);
+        for (auto& app_commitment : inputs.app_return_data) {
+            app_commitment = DataBusDepot<Builder>::construct_default_commitment(builder);
+        }
         inputs.ecc_op_hash = FF::from_witness(&builder, typename FF::native(0));
         inputs.output_hn_accum_hash = FF::from_witness(&builder, typename FF::native(0));
         inputs.set_public();
     }
 };
+
+using KernelIO = KernelIO_<NUM_APP_PER_KERNEL>;
 
 /**
  * @brief Manages the data that is propagated on the public inputs of an application/function circuit

--- a/barretenberg/cpp/src/barretenberg/stdlib/special_public_inputs/special_public_inputs.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/special_public_inputs/special_public_inputs.hpp
@@ -148,7 +148,7 @@ template <size_t N> class KernelIO_ {
     }
 };
 
-using KernelIO = KernelIO_<NUM_APP_PER_KERNEL>;
+using KernelIO = KernelIO_<MAX_APPS_PER_KERNEL>;
 
 /**
  * @brief Manages the data that is propagated on the public inputs of an application/function circuit

--- a/barretenberg/cpp/src/barretenberg/stdlib/special_public_inputs/special_public_inputs.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/special_public_inputs/special_public_inputs.test.cpp
@@ -24,7 +24,7 @@ TEST_F(SpecialPublicInputsTests, Basic)
     G1Native P0_val = G1Native::random_element();
     G1Native P1_val = G1Native::random_element();
     G1Native kernel_return_data_val = G1Native::random_element();
-    std::array<G1Native, NUM_APP_PER_KERNEL> app_return_data_val;
+    std::array<G1Native, MAX_APPS_PER_KERNEL> app_return_data_val;
     for (auto& value : app_return_data_val) {
         value = G1Native::random_element();
     }
@@ -43,7 +43,7 @@ TEST_F(SpecialPublicInputsTests, Basic)
         PairingInputs pairing_inputs{ G1::from_witness(&builder, P0_val), G1::from_witness(&builder, P1_val) };
         kernel_output.pairing_inputs = pairing_inputs;
         kernel_output.kernel_return_data = G1::from_witness(&builder, kernel_return_data_val);
-        for (size_t idx = 0; idx < NUM_APP_PER_KERNEL; ++idx) {
+        for (size_t idx = 0; idx < MAX_APPS_PER_KERNEL; ++idx) {
             kernel_output.app_return_data[idx] = G1::from_witness(&builder, app_return_data_val[idx]);
         }
         kernel_output.ecc_op_hash = FF::from_witness(&builder, ecc_op_hash_val);
@@ -75,7 +75,7 @@ TEST_F(SpecialPublicInputsTests, Basic)
         EXPECT_EQ(kernel_input.pairing_inputs.P0().get_value(), P0_val);
         EXPECT_EQ(kernel_input.pairing_inputs.P1().get_value(), P1_val);
         EXPECT_EQ(kernel_input.kernel_return_data.get_value(), kernel_return_data_val);
-        for (size_t idx = 0; idx < NUM_APP_PER_KERNEL; ++idx) {
+        for (size_t idx = 0; idx < MAX_APPS_PER_KERNEL; ++idx) {
             EXPECT_EQ(kernel_input.app_return_data[idx].get_value(), app_return_data_val[idx]);
         }
         EXPECT_EQ(kernel_input.ecc_op_hash.get_value(), ecc_op_hash_val);

--- a/barretenberg/cpp/src/barretenberg/stdlib/special_public_inputs/special_public_inputs.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/special_public_inputs/special_public_inputs.test.cpp
@@ -24,7 +24,10 @@ TEST_F(SpecialPublicInputsTests, Basic)
     G1Native P0_val = G1Native::random_element();
     G1Native P1_val = G1Native::random_element();
     G1Native kernel_return_data_val = G1Native::random_element();
-    G1Native app_return_data_val = G1Native::random_element();
+    std::array<G1Native, NUM_APP_PER_KERNEL> app_return_data_val;
+    for (auto& value : app_return_data_val) {
+        value = G1Native::random_element();
+    }
     FFNative ecc_op_hash_val = FFNative::random_element();
     FFNative output_hn_accum_hash_val = FFNative::random_element();
 
@@ -40,7 +43,9 @@ TEST_F(SpecialPublicInputsTests, Basic)
         PairingInputs pairing_inputs{ G1::from_witness(&builder, P0_val), G1::from_witness(&builder, P1_val) };
         kernel_output.pairing_inputs = pairing_inputs;
         kernel_output.kernel_return_data = G1::from_witness(&builder, kernel_return_data_val);
-        kernel_output.app_return_data = G1::from_witness(&builder, app_return_data_val);
+        for (size_t idx = 0; idx < NUM_APP_PER_KERNEL; ++idx) {
+            kernel_output.app_return_data[idx] = G1::from_witness(&builder, app_return_data_val[idx]);
+        }
         kernel_output.ecc_op_hash = FF::from_witness(&builder, ecc_op_hash_val);
         kernel_output.output_hn_accum_hash = FF::from_witness(&builder, output_hn_accum_hash_val);
 
@@ -70,7 +75,9 @@ TEST_F(SpecialPublicInputsTests, Basic)
         EXPECT_EQ(kernel_input.pairing_inputs.P0().get_value(), P0_val);
         EXPECT_EQ(kernel_input.pairing_inputs.P1().get_value(), P1_val);
         EXPECT_EQ(kernel_input.kernel_return_data.get_value(), kernel_return_data_val);
-        EXPECT_EQ(kernel_input.app_return_data.get_value(), app_return_data_val);
+        for (size_t idx = 0; idx < NUM_APP_PER_KERNEL; ++idx) {
+            EXPECT_EQ(kernel_input.app_return_data[idx].get_value(), app_return_data_val[idx]);
+        }
         EXPECT_EQ(kernel_input.ecc_op_hash.get_value(), ecc_op_hash_val);
         EXPECT_EQ(kernel_input.output_hn_accum_hash.get_value(), output_hn_accum_hash_val);
     }

--- a/barretenberg/cpp/src/barretenberg/stdlib/special_public_inputs/special_public_inputs_test_serde.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/special_public_inputs/special_public_inputs_test_serde.hpp
@@ -104,7 +104,7 @@ template <size_t N> class KernelIOSerde_ {
     }
 };
 
-using KernelIOSerde = KernelIOSerde_<NUM_APP_PER_KERNEL>;
+using KernelIOSerde = KernelIOSerde_<MAX_APPS_PER_KERNEL>;
 
 /**
  * @brief Native representation and serde for HidingKernelIO public inputs

--- a/barretenberg/cpp/src/barretenberg/stdlib/special_public_inputs/special_public_inputs_test_serde.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/special_public_inputs/special_public_inputs_test_serde.hpp
@@ -12,20 +12,21 @@ namespace bb::stdlib::recursion::honk {
 /**
  * @brief **For test purposes only**: Native representation and serde for KernelIO public inputs
  * @details Used for testing and verification with native bb::fr vectors.
- * Mirrors the structure of stdlib KernelIO but works with native types.
+ * Mirrors the structure of stdlib KernelIO_<N> but works with native types.
  */
-class KernelIOSerde {
+template <size_t N> class KernelIOSerde_ {
   public:
     using NativeFF = bb::fr;
     using NativeG1 = curve::BN254::AffineElement;
     using NativeFq = curve::BN254::BaseField;
     using NativePairingPoints = bb::PairingPoints<curve::BN254>;
+    using NativeAppReturnDataCommitments = std::array<NativeG1, N>;
 
-    static constexpr size_t PUBLIC_INPUTS_SIZE = KERNEL_PUBLIC_INPUTS_SIZE;
+    static constexpr size_t PUBLIC_INPUTS_SIZE = kernel_public_inputs_size(N);
 
     NativePairingPoints pairing_inputs;
     NativeG1 kernel_return_data;
-    NativeG1 app_return_data;
+    NativeAppReturnDataCommitments app_return_data;
     NativeFF ecc_op_hash;
     NativeFF output_hn_accum_hash;
 
@@ -36,9 +37,9 @@ class KernelIOSerde {
      * @details KernelIO is at the END of the public inputs section, so we start at
      *          offset (num_public_inputs - PUBLIC_INPUTS_SIZE)
      */
-    static KernelIOSerde from_proof(const std::vector<NativeFF>& proof, size_t num_public_inputs)
+    static KernelIOSerde_ from_proof(const std::vector<NativeFF>& proof, size_t num_public_inputs)
     {
-        KernelIOSerde result;
+        KernelIOSerde_ result;
         // KernelIO is at the end of public inputs, which are at the start of the proof
         size_t idx = num_public_inputs - PUBLIC_INPUTS_SIZE;
 
@@ -53,7 +54,9 @@ class KernelIOSerde {
         result.pairing_inputs.P0() = deserialize_point();
         result.pairing_inputs.P1() = deserialize_point();
         result.kernel_return_data = deserialize_point();
-        result.app_return_data = deserialize_point();
+        for (auto& app_commitment : result.app_return_data) {
+            app_commitment = deserialize_point();
+        }
         result.ecc_op_hash = proof[idx++];
         result.output_hn_accum_hash = proof[idx];
 
@@ -93,11 +96,15 @@ class KernelIOSerde {
         serialize_point(pairing_inputs.P0());
         serialize_point(pairing_inputs.P1());
         serialize_point(kernel_return_data);
-        serialize_point(app_return_data);
+        for (const auto& app_commitment : app_return_data) {
+            serialize_point(app_commitment);
+        }
         proof[idx++] = ecc_op_hash;
         proof[idx] = output_hn_accum_hash;
     }
 };
+
+using KernelIOSerde = KernelIOSerde_<NUM_APP_PER_KERNEL>;
 
 /**
  * @brief Native representation and serde for HidingKernelIO public inputs

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/databus.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/databus.hpp
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "barretenberg/common/assert.hpp"
+#include "barretenberg/constants.hpp"
 #include "barretenberg/ecc/curves/bn254/fr.hpp"
 #include "barretenberg/public_input_component/public_component_key.hpp"
 #include <cstdint>
@@ -73,9 +74,14 @@ struct BusVector {
  * in-circuit as we would with public inputs).
  *
  */
-constexpr size_t NUM_BUS_COLUMNS = 3;
+constexpr size_t NUM_BUS_COLUMNS = NUM_APP_PER_KERNEL + /*kernel calldata*/ 1 + /*return data*/ 1;
 
 using DataBus = std::array<BusVector, NUM_BUS_COLUMNS>;
-enum class BusId { CALLDATA, SECONDARY_CALLDATA, RETURNDATA };
+enum class BusId : uint8_t {
+    KERNEL_CALLDATA = 0,
+    APP_CALLDATA = 1,
+    RETURNDATA = NUM_APP_PER_KERNEL + 1,
+};
+static_assert(static_cast<size_t>(BusId::RETURNDATA) == NUM_BUS_COLUMNS - 1, "BusId must match DataBus layout");
 
 } // namespace bb

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/databus.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/databus.hpp
@@ -74,13 +74,13 @@ struct BusVector {
  * in-circuit as we would with public inputs).
  *
  */
-constexpr size_t NUM_BUS_COLUMNS = NUM_APP_PER_KERNEL + /*kernel calldata*/ 1 + /*return data*/ 1;
+constexpr size_t NUM_BUS_COLUMNS = MAX_APPS_PER_KERNEL + /*kernel calldata*/ 1 + /*return data*/ 1;
 
 using DataBus = std::array<BusVector, NUM_BUS_COLUMNS>;
 enum class BusId : uint8_t {
     KERNEL_CALLDATA = 0,
     APP_CALLDATA = 1,
-    RETURNDATA = NUM_APP_PER_KERNEL + 1,
+    RETURNDATA = MAX_APPS_PER_KERNEL + 1,
 };
 static_assert(static_cast<size_t>(BusId::RETURNDATA) == NUM_BUS_COLUMNS - 1, "BusId must match DataBus layout");
 

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/mega_circuit_builder.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/mega_circuit_builder.hpp
@@ -125,20 +125,10 @@ template <typename FF> class MegaCircuitBuilder_ : public UltraCircuitBuilder_<M
     size_t get_num_constant_gates() const override { return 0; }
 
     /**
-     * @brief Add a witness variable to the public calldata.
+     * @brief Add a witness variable to the specified calldata bus.
      *
      */
-    void add_public_calldata(const uint32_t& in) { return append_to_bus_vector(BusId::CALLDATA, in); }
-
-    /**
-     * @brief Add a witness variable to secondary_calldata.
-     * @details In practice this is used in aztec by the kernel circuit to recieve output from a function circuit
-     *
-     */
-    void add_public_secondary_calldata(const uint32_t& in)
-    {
-        return append_to_bus_vector(BusId::SECONDARY_CALLDATA, in);
-    }
+    void add_public_calldata(BusId bus_idx, const uint32_t& in) { return append_to_bus_vector(bus_idx, in); }
 
     /**
      * @brief Add a witness variable to the public return_data.
@@ -149,25 +139,12 @@ template <typename FF> class MegaCircuitBuilder_ : public UltraCircuitBuilder_<M
     uint32_t read_bus_vector(BusId bus_idx, const uint32_t& read_idx_witness_idx);
 
     /**
-     * @brief Read from calldata and create a corresponding databus read gate
+     * @brief Read from the specified calldata bus and create a corresponding databus read gate
      *
-     * @param read_idx_witness_idx Witness index for the calldata read index
-     * @return uint32_t Witness index for the result of the read
      */
-    uint32_t read_calldata(const uint32_t& read_idx_witness_idx)
+    uint32_t read_calldata(BusId bus_idx, const uint32_t& read_idx_witness_idx)
     {
-        return read_bus_vector(BusId::CALLDATA, read_idx_witness_idx);
-    };
-
-    /**
-     * @brief Read from secondary_calldata and create a corresponding databus read gate
-     *
-     * @param read_idx_witness_idx Witness index for the secondary_calldata read index
-     * @return uint32_t Witness index for the result of the read
-     */
-    uint32_t read_secondary_calldata(const uint32_t& read_idx_witness_idx)
-    {
-        return read_bus_vector(BusId::SECONDARY_CALLDATA, read_idx_witness_idx);
+        return read_bus_vector(bus_idx, read_idx_witness_idx);
     };
 
     /**
@@ -186,8 +163,7 @@ template <typename FF> class MegaCircuitBuilder_ : public UltraCircuitBuilder_<M
         databus[static_cast<size_t>(bus_idx)].append(witness_idx);
     }
 
-    const BusVector& get_calldata() const { return databus[static_cast<size_t>(BusId::CALLDATA)]; }
-    const BusVector& get_secondary_calldata() const { return databus[static_cast<size_t>(BusId::SECONDARY_CALLDATA)]; }
+    const BusVector& get_calldata(BusId idx) const { return databus[static_cast<size_t>(idx)]; }
     const BusVector& get_return_data() const { return databus[static_cast<size_t>(BusId::RETURNDATA)]; }
     // Indexed access to the databus columns; enables NUM_BUS_COLUMNS-driven iteration over bus vectors.
     const BusVector& get_bus_vector(size_t bus_idx) const { return databus[bus_idx]; }

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/databus.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/databus.test.cpp
@@ -1,3 +1,4 @@
+#include "barretenberg/stdlib_circuit_builders/databus.hpp"
 #include <cstddef>
 #include <cstdint>
 #include <gtest/gtest.h>
@@ -61,10 +62,7 @@ template <typename Flavor> class DataBusTests : public ::testing::Test {
      * @param read_bus_data Method for reading from a given bus column
      * @return Builder
      */
-    static Builder construct_circuit_with_databus_reads(
-        Builder& builder,
-        const std::function<void(Builder&, uint32_t)>& add_bus_data,
-        const std::function<uint32_t(Builder&, uint32_t)>& read_bus_data)
+    static Builder construct_circuit_with_databus_reads(Builder& builder, const BusId& bus_idx)
     {
 
         const uint32_t NUM_BUS_ENTRIES = 5; // number of entries in the bus column
@@ -74,52 +72,17 @@ template <typename Flavor> class DataBusTests : public ::testing::Test {
         for (size_t i = 0; i < NUM_BUS_ENTRIES; ++i) {
             FF val = FF::random_element();
             uint32_t val_witness_idx = builder.add_variable(val);
-            add_bus_data(builder, val_witness_idx);
+            builder.add_public_calldata(bus_idx, val_witness_idx);
         }
 
         // Read from the bus at some random indices
         for (size_t i = 0; i < NUM_READS; ++i) {
             uint32_t read_idx = engine.get_random_uint32() % NUM_BUS_ENTRIES;
             uint32_t read_idx_witness_idx = builder.add_variable(FF(read_idx));
-            read_bus_data(builder, read_idx_witness_idx);
+            builder.read_calldata(bus_idx, read_idx_witness_idx);
         }
 
         return builder;
-    }
-
-    static Builder construct_circuit_with_calldata_reads(Builder& builder)
-    {
-        // Define interfaces for the add and read methods for databus calldata
-        auto add_method = [](Builder& builder, uint32_t witness_idx) {
-            builder.add_public_calldata(BusId::KERNEL_CALLDATA, witness_idx);
-        };
-        auto read_method = [](Builder& builder, uint32_t witness_idx) {
-            return builder.read_calldata(BusId::KERNEL_CALLDATA, witness_idx);
-        };
-
-        return construct_circuit_with_databus_reads(builder, add_method, read_method);
-    }
-
-    static Builder construct_circuit_with_secondary_calldata_reads(Builder& builder)
-    {
-        // Define interfaces for the add and read methods for databus secondary_calldata
-        auto add_method = [](Builder& builder, uint32_t witness_idx) {
-            builder.add_public_calldata(BusId::APP_CALLDATA, witness_idx);
-        };
-        auto read_method = [](Builder& builder, uint32_t witness_idx) {
-            return builder.read_calldata(BusId::APP_CALLDATA, witness_idx);
-        };
-
-        return construct_circuit_with_databus_reads(builder, add_method, read_method);
-    }
-
-    static Builder construct_circuit_with_return_data_reads(Builder& builder)
-    {
-        // Define interfaces for the add and read methods for databus return data
-        auto add_method = [](Builder& builder, uint32_t witness_idx) { builder.add_public_return_data(witness_idx); };
-        auto read_method = [](Builder& builder, uint32_t witness_idx) { return builder.read_return_data(witness_idx); };
-
-        return construct_circuit_with_databus_reads(builder, add_method, read_method);
     }
 };
 
@@ -129,10 +92,10 @@ TYPED_TEST_SUITE(DataBusTests, FlavorTypes);
  * @brief Test proof construction/verification for a circuit with calldata lookup gates
  *
  */
-TYPED_TEST(DataBusTests, CallDataRead)
+TYPED_TEST(DataBusTests, KernelCallDataRead)
 {
     typename TypeParam::CircuitBuilder builder = this->construct_test_builder();
-    this->construct_circuit_with_calldata_reads(builder);
+    this->construct_circuit_with_databus_reads(builder, BusId::KERNEL_CALLDATA);
     EXPECT_TRUE(CircuitChecker::check(builder));
     EXPECT_TRUE(this->construct_and_verify_proof(builder));
 }
@@ -141,12 +104,14 @@ TYPED_TEST(DataBusTests, CallDataRead)
  * @brief Test proof construction/verification for a circuit with secondary_calldata lookup gates
  *
  */
-TYPED_TEST(DataBusTests, CallData2Read)
+TYPED_TEST(DataBusTests, AppCallDataRead)
 {
-    typename TypeParam::CircuitBuilder builder = this->construct_test_builder();
-    this->construct_circuit_with_secondary_calldata_reads(builder);
+    for (size_t idx = 0; idx < MAX_APPS_PER_KERNEL; ++idx) {
+        typename TypeParam::CircuitBuilder builder = this->construct_test_builder();
+        this->construct_circuit_with_databus_reads(builder, static_cast<BusId>(idx + 1));
 
-    EXPECT_TRUE(this->construct_and_verify_proof(builder));
+        EXPECT_TRUE(this->construct_and_verify_proof(builder)) << "Failed for app calldata bus with index " << idx;
+    }
 }
 
 /**
@@ -156,7 +121,7 @@ TYPED_TEST(DataBusTests, CallData2Read)
 TYPED_TEST(DataBusTests, ReturnDataRead)
 {
     typename TypeParam::CircuitBuilder builder = this->construct_test_builder();
-    this->construct_circuit_with_return_data_reads(builder);
+    this->construct_circuit_with_databus_reads(builder, BusId::RETURNDATA);
 
     EXPECT_TRUE(this->construct_and_verify_proof(builder));
 }
@@ -168,9 +133,11 @@ TYPED_TEST(DataBusTests, ReturnDataRead)
 TYPED_TEST(DataBusTests, ReadAll)
 {
     typename TypeParam::CircuitBuilder builder = this->construct_test_builder();
-    this->construct_circuit_with_calldata_reads(builder);
-    this->construct_circuit_with_secondary_calldata_reads(builder);
-    this->construct_circuit_with_return_data_reads(builder);
+    this->construct_circuit_with_databus_reads(builder, BusId::KERNEL_CALLDATA);
+    for (size_t idx = 0; idx < MAX_APPS_PER_KERNEL; ++idx) {
+        this->construct_circuit_with_databus_reads(builder, static_cast<BusId>(idx + 1));
+    }
+    this->construct_circuit_with_databus_reads(builder, BusId::RETURNDATA);
 
     EXPECT_TRUE(this->construct_and_verify_proof(builder));
 }

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/databus.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/databus.test.cpp
@@ -90,8 +90,12 @@ template <typename Flavor> class DataBusTests : public ::testing::Test {
     static Builder construct_circuit_with_calldata_reads(Builder& builder)
     {
         // Define interfaces for the add and read methods for databus calldata
-        auto add_method = [](Builder& builder, uint32_t witness_idx) { builder.add_public_calldata(witness_idx); };
-        auto read_method = [](Builder& builder, uint32_t witness_idx) { return builder.read_calldata(witness_idx); };
+        auto add_method = [](Builder& builder, uint32_t witness_idx) {
+            builder.add_public_calldata(BusId::KERNEL_CALLDATA, witness_idx);
+        };
+        auto read_method = [](Builder& builder, uint32_t witness_idx) {
+            return builder.read_calldata(BusId::KERNEL_CALLDATA, witness_idx);
+        };
 
         return construct_circuit_with_databus_reads(builder, add_method, read_method);
     }
@@ -100,10 +104,10 @@ template <typename Flavor> class DataBusTests : public ::testing::Test {
     {
         // Define interfaces for the add and read methods for databus secondary_calldata
         auto add_method = [](Builder& builder, uint32_t witness_idx) {
-            builder.add_public_secondary_calldata(witness_idx);
+            builder.add_public_calldata(BusId::APP_CALLDATA, witness_idx);
         };
         auto read_method = [](Builder& builder, uint32_t witness_idx) {
-            return builder.read_secondary_calldata(witness_idx);
+            return builder.read_calldata(BusId::APP_CALLDATA, witness_idx);
         };
 
         return construct_circuit_with_databus_reads(builder, add_method, read_method);
@@ -186,7 +190,7 @@ TYPED_TEST(DataBusTests, CallDataDuplicateRead)
 
     std::vector<FF> calldata_values = { 7, 10, 3, 12, 1 };
     for (auto& val : calldata_values) {
-        builder.add_public_calldata(builder.add_variable(val));
+        builder.add_public_calldata(BusId::KERNEL_CALLDATA, builder.add_variable(val));
     }
 
     // Define some read indices with a duplicate
@@ -198,7 +202,7 @@ TYPED_TEST(DataBusTests, CallDataDuplicateRead)
         // Create a variable corresponding to the index at which we want to read into calldata
         uint32_t read_idx_witness_idx = builder.add_variable(FF(read_idx));
 
-        auto value_witness_idx = builder.read_calldata(read_idx_witness_idx);
+        auto value_witness_idx = builder.read_calldata(BusId::KERNEL_CALLDATA, read_idx_witness_idx);
         result_witness_indices.emplace_back(value_witness_idx);
     }
 

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/honk_transcript.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/honk_transcript.test.cpp
@@ -106,12 +106,12 @@ template <typename Flavor> class HonkTranscriptTests : public ::testing::Test {
             manifest_expected.add_entry(round, "ECC_OP_WIRE_2", data_types_per_G);
             manifest_expected.add_entry(round, "ECC_OP_WIRE_3", data_types_per_G);
             manifest_expected.add_entry(round, "ECC_OP_WIRE_4", data_types_per_G);
-            manifest_expected.add_entry(round, "CALLDATA", data_types_per_G);
-            manifest_expected.add_entry(round, "CALLDATA_READ_COUNTS", data_types_per_G);
-            manifest_expected.add_entry(round, "SECONDARY_CALLDATA", data_types_per_G);
-            manifest_expected.add_entry(round, "SECONDARY_CALLDATA_READ_COUNTS", data_types_per_G);
-            manifest_expected.add_entry(round, "RETURN_DATA", data_types_per_G);
-            manifest_expected.add_entry(round, "RETURN_DATA_READ_COUNTS", data_types_per_G);
+            manifest_expected.add_entry(round, "KERNEL_CALLDATA", data_types_per_G);
+            manifest_expected.add_entry(round, "KERNEL_CALLDATA_READ_COUNTS", data_types_per_G);
+            manifest_expected.add_entry(round, "APP_CALLDATA", data_types_per_G);
+            manifest_expected.add_entry(round, "APP_CALLDATA_READ_COUNTS", data_types_per_G);
+            manifest_expected.add_entry(round, "RETURNDATA", data_types_per_G);
+            manifest_expected.add_entry(round, "RETURNDATA_READ_COUNTS", data_types_per_G);
         }
 
         manifest_expected.add_challenge(round, "eta");
@@ -126,9 +126,9 @@ template <typename Flavor> class HonkTranscriptTests : public ::testing::Test {
         manifest_expected.add_entry(round, "LOOKUP_INVERSES", data_types_per_G);
         // Mega-specific databus inverse commitments
         if constexpr (IsMegaFlavor<Flavor>) {
-            manifest_expected.add_entry(round, "CALLDATA_INVERSES", data_types_per_G);
-            manifest_expected.add_entry(round, "SECONDARY_CALLDATA_INVERSES", data_types_per_G);
-            manifest_expected.add_entry(round, "RETURN_DATA_INVERSES", data_types_per_G);
+            manifest_expected.add_entry(round, "KERNEL_CALLDATA_INVERSES", data_types_per_G);
+            manifest_expected.add_entry(round, "APP_CALLDATA_INVERSES", data_types_per_G);
+            manifest_expected.add_entry(round, "RETURNDATA_INVERSES", data_types_per_G);
         }
         manifest_expected.add_entry(round, "Z_PERM", data_types_per_G);
 

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/relation_correctness.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/relation_correctness.test.cpp
@@ -180,10 +180,10 @@ void create_some_databus_gates(auto& builder)
 {
     using FF = typename Flavor::FF;
     auto val = builder.add_variable(FF::random_element());
-    builder.add_public_calldata(val);
-    builder.read_calldata(builder.add_variable(FF(0)));
-    builder.add_public_secondary_calldata(val);
-    builder.read_secondary_calldata(builder.add_variable(FF(0)));
+    builder.add_public_calldata(BusId::KERNEL_CALLDATA, val);
+    builder.read_calldata(BusId::KERNEL_CALLDATA, builder.add_variable(FF(0)));
+    builder.add_public_calldata(BusId::APP_CALLDATA, val);
+    builder.read_calldata(BusId::APP_CALLDATA, builder.add_variable(FF(0)));
     builder.add_public_return_data(val);
     builder.read_return_data(builder.add_variable(FF(0)));
 }


### PR DESCRIPTION
Implementation of the required infrastructure to support multiple apps per kernel.

This PR generalises databus-related infrastructure to support multiple apps per kernel. It also generalised mocking IVC state, mock circuits producers, and public inputs structure so that we can easily transition to kernels processing multiple apps.