### PR TITLE
fix(archiver): do not query MessageSent events by blockhash

### DIFF
--- a/yarn-project/archiver/src/l1/data_retrieval.ts
+++ b/yarn-project/archiver/src/l1/data_retrieval.ts
@@ -346,7 +346,7 @@ export async function retrieveL1ToL2Message(
   inbox: InboxContract,
   message: InboxMessage,
 ): Promise<InboxMessage | undefined> {
-  const log = await inbox.getMessageSentEventByHash(message.leaf.toString(), message.l1BlockHash.toString());
+  const log = await inbox.getMessageSentEventByHash(message.leaf.toString(), message.l1BlockNumber);
   return log && mapLogInboxMessage(log);
 }
 

--- a/yarn-project/archiver/src/modules/l1_synchronizer.ts
+++ b/yarn-project/archiver/src/modules/l1_synchronizer.ts
@@ -405,7 +405,7 @@ export class ArchiverL1Synchronizer implements Traceable {
           `Failed to store L1 to L2 messages retrieved from L1: ${error.message}. Rolling back syncpoint to retry.`,
           { inboxMessage: error.inboxMessage },
         );
-        await this.rollbackL1ToL2Messages(remoteMessagesState.treeInProgress);
+        await this.rollbackL1ToL2Messages(remoteMessagesState);
         return false;
       }
       throw error;
@@ -420,7 +420,7 @@ export class ArchiverL1Synchronizer implements Traceable {
         `Local L1 to L2 messages state does not match remote after sync attempt. Rolling back syncpoint to retry.`,
         { localLastMessageAfterSync, remoteMessagesState },
       );
-      await this.rollbackL1ToL2Messages(remoteMessagesState.treeInProgress);
+      await this.rollbackL1ToL2Messages(remoteMessagesState);
       return false;
     }
 
@@ -475,18 +475,39 @@ export class ArchiverL1Synchronizer implements Traceable {
    * Rolls back local L1 to L2 messages to the last common message with L1, and updates the syncpoint to the L1 block of that message.
    * If no common message is found, rolls back all messages and sets the syncpoint to the start block.
    */
-  private async rollbackL1ToL2Messages(remoteTreeInProgress: bigint): Promise<L1BlockId> {
-    // Slowly go back through our messages until we find the last common message.
-    // We could query the logs in batch as an optimization, but the depth of the reorg should not be deep, and this
-    // is a very rare case, so it's fine to query one log at a time.
+  private async rollbackL1ToL2Messages(remoteMessagesState: InboxContractState): Promise<L1BlockId> {
+    const { treeInProgress: remoteTreeInProgress, messagesRollingHash: remoteRollingHash } = remoteMessagesState;
+
+    // Slowly go back through our messages until we find the last common message. We could query the logs in
+    // batch as an optimization, but the depth of the reorg should not be deep, and this is a very rare case,
+    // so it's fine to query one log at a time.
     let commonMsg: undefined | InboxMessage;
     let messagesToDelete = 0;
     this.log.verbose(`Searching most recent common L1 to L2 message`);
     for await (const localMsg of this.store.iterateL1ToL2Messages({ reverse: true })) {
+      const logCtx = { remoteMsg: undefined as InboxMessage | undefined, localMsg, remoteMessagesState };
+
+      // First check if the local message rolling hash matches the current rolling hash of the inbox contract,
+      // which means we just need to rollback some local messages and we should be back in sync. This means there
+      // was an L1 reorg that removed some of the messages we had, but no new messages were added compared.
+      if (localMsg.rollingHash.equals(remoteRollingHash)) {
+        this.log.info(
+          `Found common L1 to L2 message at index ${localMsg.index} on L1 block ${localMsg.l1BlockNumber} matching current remote state`,
+          logCtx,
+        );
+        commonMsg = localMsg;
+        break;
+      }
+
+      // If there's no match with the current remote state, check if the message exists on the inbox contract at all
+      // by looking at the inbox events. If the L1 reorg *added* new messages in addition to deleting existing ones,
+      // then the current remote state's rolling hash will not match anything we have locally, so we need to check existence
+      // of individual messages via logs. Note we use logs and not historical queries so we don't have to depend on
+      // an archival rpc node, since the message could be from a long time ago if we're catching up with syncing.
       const remoteMsg = await retrieveL1ToL2Message(this.inbox, localMsg);
-      const logCtx = { remoteMsg, localMsg: localMsg };
+      logCtx.remoteMsg = remoteMsg;
       if (remoteMsg && remoteMsg.rollingHash.equals(localMsg.rollingHash)) {
-        this.log.verbose(
+        this.log.info(
           `Found most recent common L1 to L2 message at index ${localMsg.index} on L1 block ${localMsg.l1BlockNumber}`,
           logCtx,
         );

--- a/yarn-project/archiver/src/test/fake_l1_state.ts
+++ b/yarn-project/archiver/src/test/fake_l1_state.ts
@@ -502,8 +502,8 @@ export class FakeL1State {
       Promise.resolve(this.getMessageSentLogs(fromBlock, toBlock)),
     );
 
-    mockInbox.getMessageSentEventByHash.mockImplementation((msgHash: string, l1BlockHash: string) =>
-      Promise.resolve(this.getMessageSentLogByHash(msgHash, l1BlockHash) as MessageSentLog),
+    mockInbox.getMessageSentEventByHash.mockImplementation((msgHash: string, aroundL1BlockNumber: bigint) =>
+      Promise.resolve(this.getMessageSentLogByHash(msgHash, aroundL1BlockNumber) as MessageSentLog),
     );
 
     return mockInbox;
@@ -623,9 +623,12 @@ export class FakeL1State {
       }));
   }
 
-  private getMessageSentLogByHash(msgHash: string, l1BlockHash: string): MessageSentLog | undefined {
+  private getMessageSentLogByHash(msgHash: string, aroundL1BlockNumber: bigint): MessageSentLog | undefined {
     const msg = this.messages.find(
-      msg => msg.leaf.toString() === msgHash && Buffer32.fromBigInt(msg.l1BlockNumber).toString() === l1BlockHash,
+      msg =>
+        msg.leaf.toString() === msgHash &&
+        msg.l1BlockNumber >= aroundL1BlockNumber - 5n &&
+        msg.l1BlockNumber <= aroundL1BlockNumber + 5n,
     );
     if (!msg) {
       return undefined;

--- a/yarn-project/ethereum/src/contracts/inbox.ts
+++ b/yarn-project/ethereum/src/contracts/inbox.ts
@@ -1,3 +1,4 @@
+import { maxBigint } from '@aztec/foundation/bigint';
 import { CheckpointNumber } from '@aztec/foundation/branded-types';
 import { Buffer16, Buffer32 } from '@aztec/foundation/buffer';
 import { Fr } from '@aztec/foundation/curves/bn254';
@@ -82,9 +83,16 @@ export class InboxContract {
       .map(log => this.mapMessageSentLog(log));
   }
 
-  /** Fetches MessageSent events for a specific message hash at a specific block. */
-  async getMessageSentEventByHash(msgHash: Hex, l1BlockHash: Hex): Promise<MessageSentLog> {
-    const [log] = await this.inbox.getEvents.MessageSent({ hash: msgHash }, { blockHash: l1BlockHash });
+  /** Fetches MessageSent events for a specific message hash around a specific block. */
+  async getMessageSentEventByHash(msgHash: Hex, aroundL1BlockNumber: bigint): Promise<MessageSentLog> {
+    // We don't use blockHash here because we don't want the query to throw if the L1 block number no longer exists on chain
+    // due to an L1 reorg. The use case for this method is usually checking if a message still exists on the Inbox after
+    // a reorg, so it's possible the message was moved one block up or down, and that the original L1 block where we
+    // saw it no longer exists, rendering the block-by-hash approach invalid.
+    const [log] = await this.inbox.getEvents.MessageSent(
+      { hash: msgHash },
+      { fromBlock: maxBigint(aroundL1BlockNumber - 5n, 1n), toBlock: aroundL1BlockNumber + 5n },
+    );
     return log && this.mapMessageSentLog(log);
   }
 


### PR DESCRIPTION
When rolling back local L1 to L2 messages, we query each message against L1 by fetching its log. Since #22154 (v5) this was done via blockHash. However, querying logs by blockhash throws an RPC error if the block no longer exists, which is likely if the local message was removed due to an L1 reorg. We never hit this during testing because of https://github.com/foundry-rs/foundry/pull/14371.

To fix this, we know query by an L1 block number range. This also allows to still find the locall message on L1 even if it was moved by a few blocks due to a small reorg.

Additionally, this PR adds a fast-path in `rollbackL1ToL2Messages` that matches the local rolling hash against the current remote state, so we don't query by event when we don't need to.
