### PR TITLE
fix(pxe): propagate calldata count from nested private oracles

### DIFF
--- a/noir-projects/noir-contracts/Nargo.toml
+++ b/noir-projects/noir-contracts/Nargo.toml
@@ -41,6 +41,7 @@ members = [
     "contracts/test/avm_initializer_test_contract",
     "contracts/test/avm_test_contract",
     "contracts/test/benchmarking_contract",
+    "contracts/test/calldata_limit_test_contract",
     "contracts/test/child_contract",
     "contracts/test/counter/counter_contract",
     "contracts/test/custom_message_contract",

--- a/noir-projects/noir-contracts/contracts/test/calldata_limit_test_contract/Nargo.toml
+++ b/noir-projects/noir-contracts/contracts/test/calldata_limit_test_contract/Nargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "calldata_limit_test_contract"
+authors = [""]
+compiler_version = ">=0.25.0"
+type = "contract"
+
+[dependencies]
+aztec = { path = "../../../../aztec-nr/aztec" }

--- a/noir-projects/noir-contracts/contracts/test/calldata_limit_test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/calldata_limit_test_contract/src/main.nr
@@ -1,0 +1,32 @@
+use aztec::macros::aztec;
+
+// Test contract covering behavior around the MAX_FR_CALLDATA_TO_ALL_ENQUEUED_CALLS limit.
+#[aztec]
+pub contract CalldataLimitTest {
+    use aztec::macros::functions::{external, only_self};
+    use aztec::protocol::constants::MAX_FR_CALLDATA_TO_ALL_ENQUEUED_CALLS;
+
+    // Each call contributes MAX/3 args + 1 function-selector field. Three such calls total MAX + 3, over the limit.
+    #[external("public")]
+    #[only_self]
+    fn public_call_with_third_of_max_args(
+        _args: [Field; MAX_FR_CALLDATA_TO_ALL_ENQUEUED_CALLS / 3],
+    ) {}
+
+    // Enqueues three public calls split across a parent/nested-private-call boundary: one from the parent, one from
+    // the nested call, and one more from the parent after the nested call returns. Expected to fail during private
+    // simulation: each individual frame's calldata total stays under the limit, but the tree-wide total is over.
+    #[external("private")]
+    fn exceed_calldata_limit_via_nested_call() {
+        let args = [0; MAX_FR_CALLDATA_TO_ALL_ENQUEUED_CALLS / 3];
+        self.enqueue_self.public_call_with_third_of_max_args(args);
+        self.call_self.enqueue_one_public_call();
+        self.enqueue_self.public_call_with_third_of_max_args(args);
+    }
+
+    #[external("private")]
+    fn enqueue_one_public_call() {
+        let args = [0; MAX_FR_CALLDATA_TO_ALL_ENQUEUED_CALLS / 3];
+        self.enqueue_self.public_call_with_third_of_max_args(args);
+    }
+}

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution.test.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution.test.ts
@@ -11,6 +11,7 @@ import { EthAddress } from '@aztec/foundation/eth-address';
 import { type Logger, createLogger } from '@aztec/foundation/log';
 import type { FieldsOf } from '@aztec/foundation/types';
 import { KeyStore } from '@aztec/key-store';
+import { CalldataLimitTestContractArtifact } from '@aztec/noir-test-contracts.js/CalldataLimitTest';
 import { ChildContractArtifact } from '@aztec/noir-test-contracts.js/Child';
 import { ParentContractArtifact } from '@aztec/noir-test-contracts.js/Parent';
 import { PendingNoteHashesContractArtifact } from '@aztec/noir-test-contracts.js/PendingNoteHashes';
@@ -1049,6 +1050,21 @@ describe('Private Execution test suite', () => {
           artifact: parentContractArtifact,
           functionName: 'enqueue_call_to_child_with_many_args_and_recurse',
           args,
+        }),
+      ).rejects.toThrow(/Too many total args to all enqueued public calls/);
+    });
+
+    it('should error if parent and nested private call enqueue public calls with too many TOTAL args', async () => {
+      const contractArtifact = structuredClone(CalldataLimitTestContractArtifact);
+      const contractAddress = await mockContractInstance(contractArtifact);
+
+      await expect(
+        runSimulator({
+          msgSender: contractAddress,
+          contractAddress: contractAddress,
+          anchorBlockHeader,
+          artifact: contractArtifact,
+          functionName: 'exceed_calldata_limit_via_nested_call',
         }),
       ).rejects.toThrow(/Too many total args to all enqueued public calls/);
     });

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution_oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution_oracle.ts
@@ -593,6 +593,9 @@ export class PrivateExecutionOracle extends UtilityExecutionOracle implements IP
       functionSelector,
     );
 
+    // Propagate the nested call's calldata count so the parent sees its increments on subsequent enqueues.
+    this.totalPublicCalldataCount = privateExecutionOracle.getTotalPublicCalldataCount();
+
     if (isStaticCall) {
       this.#checkValidStaticCall(childExecutionResult);
     }
@@ -624,6 +627,10 @@ export class PrivateExecutionOracle extends UtilityExecutionOracle implements IP
       throw new Error(`Too many total args to all enqueued public calls! (> ${MAX_FR_CALLDATA_TO_ALL_ENQUEUED_CALLS})`);
     }
     return Promise.resolve();
+  }
+
+  public getTotalPublicCalldataCount(): number {
+    return this.totalPublicCalldataCount;
   }
 
   public notifyRevertiblePhaseStart(minRevertibleSideEffectCounter: number): Promise<void> {


### PR DESCRIPTION
## Problem

`totalPublicCalldataCount` on `PrivateExecutionOracle` was passed by value (as a primitive `number`) when constructing nested oracles. When a nested call enqueued public calls, its increments applied to its local copy but never propagated back to the parent on return. A tx could distribute enqueues across nested frames such that each frame's individual view stayed under `MAX_FR_CALLDATA_TO_ALL_ENQUEUED_CALLS` while the tree-wide total went over — silently passing the in-PXE pre-check.

The node-level `DataTxValidator` still rejects such txs via an authoritative recount off `tx.publicFunctionCalldata`, so there is no consensus bypass. The impact is UX: a tx the PXE happily built and proved fails at submission.

## Fix

After `executePrivateFunction` returns for a nested call, read the child oracle's final counter back into the parent via a new `getTotalPublicCalldataCount()` accessor. Mirrors how `endSideEffectCounter` already flows back out of the child.

Fixes https://github.com/AztecProtocol/aztec-claude/issues/148