### PR TITLE
feat(avm): dynamic work distribution in AVM sumcheck prover round

### DIFF
--- a/barretenberg/cpp/src/barretenberg/sumcheck/sumcheck_round.hpp
+++ b/barretenberg/cpp/src/barretenberg/sumcheck/sumcheck_round.hpp
@@ -221,41 +221,42 @@ template <typename Flavor> class SumcheckProverRound {
         constexpr size_t rows_per_chunk = 16;
         static_assert((rows_per_chunk >= 2) && (rows_per_chunk % 2 == 0), "rows_per_chunk must be at least 2 and even");
 
-        const size_t num_accumulator_slots = bb::get_num_cpus();
+        // One accumulator slot per outer task; each outer task's iteration index IS its slot.
+        // No state is shared with other SumcheckProverRound invocations.
+        const size_t num_slots = bb::get_num_cpus();
+        std::vector<SumcheckTupleOfTuplesOfUnivariates> thread_univariate_accumulators(num_slots);
 
-        // Construct univariate accumulator containers; one per thread
-        // Note: std::vector will trigger {}-initialization of the contents. Therefore no need to zero the univariates.
-        std::vector<SumcheckTupleOfTuplesOfUnivariates> thread_univariate_accumulators(num_accumulator_slots);
-
-        size_t total_chunks =
+        const size_t total_chunks =
             (effective_round_size / rows_per_chunk) + (effective_round_size % rows_per_chunk > 0 ? 1 : 0);
 
-        // Each worker thread claims a unique accumulator slot on first use via the atomic counter.
-        // The thread_local initializer runs exactly once per OS thread; the slot then persists
-        // across all chunks assigned to that thread. The counter is static so that threads which
-        // participate late (not in the first parallel_for invocation) still get a unique slot.
-        static std::atomic<size_t> thread_counter{ 0 };
+        // Chunks are consumed dynamically via an atomic counter: faster threads naturally pick up
+        // more chunks while the slot they write to stays fixed for the life of their outer task.
+        std::atomic<size_t> next_chunk(0);
 
-        // Accumulate the contribution from each sub-relation across each edge of the hyper-cube
-        parallel_for(total_chunks, [&](size_t chunk_id) {
-            thread_local size_t thread_idx = thread_counter.fetch_add(1);
-
+        // Accumulate the contribution from each sub-relation across each edge of the hyper-cube.
+        parallel_for(num_slots, [&](size_t slot_id) {
             ExtendedEdges lazy_extended_edges(polynomials);
 
-            size_t start = chunk_id * rows_per_chunk;
-            size_t end = std::min(start + rows_per_chunk, effective_round_size);
+            while (true) {
+                const size_t chunk_id = next_chunk.fetch_add(1, std::memory_order_relaxed);
+                if (chunk_id >= total_chunks) {
+                    break;
+                }
+                size_t start = chunk_id * rows_per_chunk;
+                size_t end = std::min(start + rows_per_chunk, effective_round_size);
 
-            for (size_t edge_idx = start; edge_idx < end; edge_idx += 2) {
-                lazy_extended_edges.set_current_edge(edge_idx);
-                // Compute the \f$ \ell \f$-th edge's univariate contribution,
-                // scale it by the corresponding \f$ pow_{\beta} \f$ contribution and add it to the accumulators for
-                // \f$ \tilde{S}^i(X_i) \f$. If \f$ \ell \f$'s binary representation is given by \f$
-                // (\ell_{i+1},\ldots, \ell_{d-1})\f$, the \f$ pow_{\beta}\f$-contribution is
-                // \f$\beta_{i+1}^{\ell_{i+1}} \cdot \ldots \cdot \beta_{d-1}^{\ell_{d-1}}\f$.
-                accumulate_relation_univariates(thread_univariate_accumulators[thread_idx],
-                                                lazy_extended_edges,
-                                                relation_parameters,
-                                                gate_separators[edge_idx]);
+                for (size_t edge_idx = start; edge_idx < end; edge_idx += 2) {
+                    lazy_extended_edges.set_current_edge(edge_idx);
+                    // Compute the \f$ \ell \f$-th edge's univariate contribution,
+                    // scale it by the corresponding \f$ pow_{\beta} \f$ contribution and add it to the accumulators
+                    // for \f$ \tilde{S}^i(X_i) \f$. If \f$ \ell \f$'s binary representation is given by \f$
+                    // (\ell_{i+1},\ldots, \ell_{d-1})\f$, the \f$ pow_{\beta}\f$-contribution is
+                    // \f$\beta_{i+1}^{\ell_{i+1}} \cdot \ldots \cdot \beta_{d-1}^{\ell_{d-1}}\f$.
+                    accumulate_relation_univariates(thread_univariate_accumulators[slot_id],
+                                                    lazy_extended_edges,
+                                                    relation_parameters,
+                                                    gate_separators[edge_idx]);
+                }
             }
         });
 

--- a/barretenberg/cpp/src/barretenberg/sumcheck/sumcheck_round.hpp
+++ b/barretenberg/cpp/src/barretenberg/sumcheck/sumcheck_round.hpp
@@ -214,56 +214,48 @@ template <typename Flavor> class SumcheckProverRound {
         // Note: effective_round_size is expected to be even.
         BB_ASSERT(effective_round_size % 2 == 0, "effective_round_size must be even");
 
-        // Determine number of threads for multithreading.
-        // Note: Multithreading is "on" for every round but we reduce the number of threads from the max available based
-        // on a specified minimum number of iterations per thread. This eventually leads to the use of a single thread.
-        size_t min_iterations_per_thread = 1 << 6; // min number of iterations for which we'll spin up a unique thread
-        size_t num_threads = bb::calculate_num_threads(effective_round_size, min_iterations_per_thread);
+        // The AVM trace is very non-uniform: some rows are dense while others are nearly empty.
+        // To balance the load, we break the trace into fixed-size chunks (rows_per_chunk rows)
+        // and hand them out dynamically to workers via the atomic thread pool: each worker
+        // atomically grabs the next chunk when it finishes the previous one.
+        constexpr size_t rows_per_chunk = 16;
+        static_assert((rows_per_chunk >= 2) && (rows_per_chunk % 2 == 0), "rows_per_chunk must be at least 2 and even");
 
-        // In the AVM, the trace is more dense at the top and therefore it is worth to split the work per thread
-        // in a more distributed way over the edges. To achieve this, we split the trace into chunks and each chunk is
-        // evenly divided among the threads.
-
-        // Pattern over edges is now (note that horizontal direction here is edge direction, i.e., vertical direction in
-        // the trace):
-        //
-        //          chunk_0             |           chunk_1             |         chunk_2 ....
-        //  thread_0 | thread_1 ...     | thread_0 | thread_1 ...       | thread_0 | thread_1 ...
-        //
-        // Any thread now processes edges which are distributed at different locations in the trace contrary
-        // to the "standard" method where thread_0 processes all the low indices and the last thread processes
-        // all the high indices.
-
-        constexpr size_t rows_per_thread = 2; // Measured in rows, not edges.
-        static_assert((rows_per_thread >= 2) && (rows_per_thread % 2 == 0),
-                      "rows_per_thread must be at least 2 and even, because edges are processed in pairs");
-        size_t chunk_size = rows_per_thread * num_threads;
-        size_t num_chunks = (effective_round_size / chunk_size) +            // This rounds down.
-                            (effective_round_size % chunk_size > 0 ? 1 : 0); // If there's a remainder, add 1.
+        const size_t num_accumulator_slots = bb::get_num_cpus();
 
         // Construct univariate accumulator containers; one per thread
         // Note: std::vector will trigger {}-initialization of the contents. Therefore no need to zero the univariates.
-        std::vector<SumcheckTupleOfTuplesOfUnivariates> thread_univariate_accumulators(num_threads);
+        std::vector<SumcheckTupleOfTuplesOfUnivariates> thread_univariate_accumulators(num_accumulator_slots);
+
+        size_t total_chunks =
+            (effective_round_size / rows_per_chunk) + (effective_round_size % rows_per_chunk > 0 ? 1 : 0);
+
+        // Each worker thread claims a unique accumulator slot on first use via the atomic counter.
+        // The thread_local initializer runs exactly once per OS thread; the slot then persists
+        // across all chunks assigned to that thread. The counter is static so that threads which
+        // participate late (not in the first parallel_for invocation) still get a unique slot.
+        static std::atomic<size_t> thread_counter{ 0 };
 
         // Accumulate the contribution from each sub-relation across each edge of the hyper-cube
-        parallel_for(num_threads, [&](size_t thread_idx) {
+        parallel_for(total_chunks, [&](size_t chunk_id) {
+            thread_local size_t thread_idx = thread_counter.fetch_add(1);
+
             ExtendedEdges lazy_extended_edges(polynomials);
 
-            for (size_t chunk_idx = 0; chunk_idx < num_chunks; chunk_idx++) {
-                size_t start = (chunk_idx * chunk_size) + (thread_idx * rows_per_thread);
-                size_t end = std::min(start + rows_per_thread, effective_round_size);
-                for (size_t edge_idx = start; edge_idx < end; edge_idx += 2) {
-                    lazy_extended_edges.set_current_edge(edge_idx);
-                    // Compute the \f$ \ell \f$-th edge's univariate contribution,
-                    // scale it by the corresponding \f$ pow_{\beta} \f$ contribution and add it to the accumulators for
-                    // \f$ \tilde{S}^i(X_i) \f$. If \f$ \ell \f$'s binary representation is given by \f$
-                    // (\ell_{i+1},\ldots, \ell_{d-1})\f$, the \f$ pow_{\beta}\f$-contribution is
-                    // \f$\beta_{i+1}^{\ell_{i+1}} \cdot \ldots \cdot \beta_{d-1}^{\ell_{d-1}}\f$.
-                    accumulate_relation_univariates(thread_univariate_accumulators[thread_idx],
-                                                    lazy_extended_edges,
-                                                    relation_parameters,
-                                                    gate_separators[edge_idx]);
-                }
+            size_t start = chunk_id * rows_per_chunk;
+            size_t end = std::min(start + rows_per_chunk, effective_round_size);
+
+            for (size_t edge_idx = start; edge_idx < end; edge_idx += 2) {
+                lazy_extended_edges.set_current_edge(edge_idx);
+                // Compute the \f$ \ell \f$-th edge's univariate contribution,
+                // scale it by the corresponding \f$ pow_{\beta} \f$ contribution and add it to the accumulators for
+                // \f$ \tilde{S}^i(X_i) \f$. If \f$ \ell \f$'s binary representation is given by \f$
+                // (\ell_{i+1},\ldots, \ell_{d-1})\f$, the \f$ pow_{\beta}\f$-contribution is
+                // \f$\beta_{i+1}^{\ell_{i+1}} \cdot \ldots \cdot \beta_{d-1}^{\ell_{d-1}}\f$.
+                accumulate_relation_univariates(thread_univariate_accumulators[thread_idx],
+                                                lazy_extended_edges,
+                                                relation_parameters,
+                                                gate_separators[edge_idx]);
             }
         });
 


### PR DESCRIPTION
Switch compute_univariate_avm from static per-thread assignment to dynamic chunk distribution via the atomic thread pool. Each work item processes all relations for rows_per_chunk=16 consecutive rows, and threads atomically pick up the next chunk as they finish.

Here are results of benchmarks for 32, 15, 7 CPU cores over 20 runs.

Best-of-5 mean (sumcheck ms) across thread counts:

```
                                                    
  ┌─────────┬──────────┬─────────┬─────────────────────┐                                                                                                                                    
  │ Threads │ Baseline │ Dynamic │ Dynamic vs Baseline │
  ├─────────┼──────────┼─────────┼─────────────────────┤                                                                                                                                    
  │ 32      │ 2440.4   │ 2009.6  │ −17.6%              │                                                                                                                                    
  ├─────────┼──────────┼─────────┼─────────────────────┤                                                                                                                                    
  │ 15      │ 3432.2   │ 2993.6  │ −12.8%              │                                                                                                                                    
  ├─────────┼──────────┼─────────┼─────────────────────┤                                                                                                                                    
  │ 7       │ 6448.4   │ 5548.8  │ −14.0%              │                                                                                                                                    
  └─────────┴──────────┴─────────┴─────────────────────┘       

```

Median:

```  

  ┌─────────┬──────────────┬─────────────┬────────────┐                                                                                                                                     
  │ Threads │ Baseline med │ Dynamic med │ Δ (median) │
  ├─────────┼──────────────┼─────────────┼────────────┤                                                                                                                                     
  │ 32      │ 2558.0       │ 2209.0      │ −13.6%     │                 
  ├─────────┼──────────────┼─────────────┼────────────┤                                                                                                                                     
  │ 15      │ 3733.5       │ 3211.0      │ −14.0%     │                 
  ├─────────┼──────────────┼─────────────┼────────────┤                                                                                                                                     
  │ 7       │ 6887.5       │ 5995.0      │ −13.0%     │
  └─────────┴──────────────┴─────────────┴────────────┘      
```


The value rows_per_chunk = 16 was determined experimentally. A value 8 and 32 lead to slightly worse performance.
