### PR TITLE
feat: assert AVM accumulated_data is zero-padded past length

### DIFF
--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/tx_base/components/public_tx_base_inputs_validator.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/tx_base/components/public_tx_base_inputs_validator.nr
@@ -3,11 +3,14 @@ use super::fees::compute_effective_gas_fees;
 use types::{
     abis::{
         avm_circuit_public_inputs::AvmCircuitPublicInputs, block_constant_data::BlockConstantData,
+        public_data_write::PublicDataWrite,
     },
     constants::{ARCHIVE_HEIGHT, PUBLIC_CHONK_VERIFIER_VK_INDEX},
+    messaging::l2_to_l1_message::L2ToL1Message,
     proof::proof_data::{AvmV2ProofData, RollupHonkProofData},
+    side_effect::Scoped,
     traits::Empty,
-    utils::arrays::array_length,
+    utils::arrays::{array_length, array_padded_with},
 };
 
 fn assert_eq_array_and_length<T, let N: u32, let M: u32>(
@@ -56,6 +59,7 @@ impl PublicTxBaseInputsValidator {
         // executed correctly and that the data from private is passed to the AVM properly.
         self.validate_private_tail();
         self.validate_public_chonk_verifier_against_avm();
+        self.validate_avm_accumulated_data_padding();
     }
 
     fn validate_public_chonk_verifier_proof_and_vk(self) {
@@ -239,5 +243,44 @@ impl PublicTxBaseInputsValidator {
         // or `block_root` to ensure they match the previous tx's `end_tree_snapshots`.
         // For the first tx in a checkpoint, `checkpoint_root` validates that they match the snapshots from the last
         // block of the previous checkpoint.
+    }
+
+    // Defensive: the AVM PIL doesn't constrain the accumulated_data cells past `length` (one-way lookups
+    // gated by sel_write_to_public_inputs), so the prover is free to place arbitrary values in that tail.
+    // Downstream consumers do not, and should not ever, read values past `length`, but we assert the tail
+    // is zero-padded anyway to make that invariant structural rather than rely on every current and future
+    // consumer honoring it.
+    fn validate_avm_accumulated_data_padding(self) {
+        let avm_acc = self.avm_proof_data.public_inputs.accumulated_data;
+        let avm_lens = self.avm_proof_data.public_inputs.accumulated_data_array_lengths;
+
+        assert(
+            array_padded_with(avm_acc.note_hashes, avm_lens.note_hashes, 0),
+            "AVM note_hashes not zero-padded past length",
+        );
+        assert(
+            array_padded_with(avm_acc.nullifiers, avm_lens.nullifiers, 0),
+            "AVM nullifiers not zero-padded past length",
+        );
+        assert(
+            array_padded_with(
+                avm_acc.l2_to_l1_msgs,
+                avm_lens.l2_to_l1_msgs,
+                Scoped::<L2ToL1Message>::empty(),
+            ),
+            "AVM l2_to_l1_msgs not zero-padded past length",
+        );
+        assert(
+            array_padded_with(
+                avm_acc.public_data_writes,
+                avm_lens.public_data_writes,
+                PublicDataWrite::empty(),
+            ),
+            "AVM public_data_writes not zero-padded past length",
+        );
+        assert(
+            array_padded_with(avm_acc.public_logs.payload, avm_acc.public_logs.length, 0),
+            "AVM public_logs payload not zero-padded past length",
+        );
     }
 }


### PR DESCRIPTION
## Summary

Adds `validate_avm_accumulated_data_padding` to `PublicTxBaseInputsValidator`: five `array_padded_with` asserts that the AVM's `accumulated_data` arrays contain zero/empty values past their committed `length`.

## Why

The AVM PIL's write lookups into `accumulated_data` are gated by `sel_write_to_public_inputs`, which leaves cells past `length` unconstrained. A malicious prover could place arbitrary values in the tail. Downstream consumers don't read past `length` today, but asserting it here makes the invariant structural rather than relying on every current and future consumer honoring it. This mirrors the existing pattern in `private_tail_validator::validate_contract_class_logs`.

## Arrays covered

- `note_hashes` (64 entries)
- `nullifiers` (64 entries)
- `l2_to_l1_msgs` (8 entries)
- `public_data_writes` (64 entries)
- `public_logs.payload` (4096 entries — dominant cost)

## Circuit size impact (`rollup_tx_base_public`)

| Metric | Before | After | Delta |
|---|---:|---:|---:|
| `acir_opcodes` | 254,632 | 280,690 | **+26,058 (+10.2%)** |
| `circuit_size` | 4,867,487 | 4,889,177 | **+21,690 (+0.45%)** |

The `public_logs.payload` check (4096 iters) dominates. The binding proving-cost metric (`circuit_size` after gate composition) only moves ~0.45%. Only `rollup_tx_base_public` is affected — the validator isn't called from any other circuit.

Measured with `bb-avm gates --scheme ultra_honk -t noir-rollup`.

## Test plan

- [ ] CI: protocol circuit compilation
- [ ] CI: existing e2e suites exercising public-tx-base rollup
- [ ] Confirm no unintended effect on `rollup_tx_base_public_simulated` or downstream rollup circuits

🤖 Generated with [Claude Code](https://claude.com/claude-code)