### PR TITLE
fix(docs): correct execution delay to 30 days and governance withdrawal to ~38 days

### DIFF
--- a/docs/docs-operate/operators/sequencer-management/governance-participation.md
+++ b/docs/docs-operate/operators/sequencer-management/governance-participation.md
@@ -98,7 +98,7 @@ The governance process follows these stages:
 #else
 3. **Voting Delay** (3 days): A mandatory waiting period before voting opens (allows time for community review).
 4. **Voting Period** (7 days): Users who hold stake in the network vote on the proposal using their staked tokens. A proposal passes if it receives at least 20% quorum, 2/3 of votes are "yea", and a minimum of 500 validators' worth of voting power is cast.
-5. **Execution Delay** (7 days): After passing the vote, another mandatory delay before execution (allows time for node upgrades).
+5. **Execution Delay** (30 days): After passing the vote, another mandatory delay before execution (allows time for node upgrades).
 6. **Execution**: Anyone can execute the proposal, which applies the changes. There is a 7-day grace period after the execution delay during which the proposal can still be executed.
 #endif
 

--- a/docs/docs-participate/token/staking.md
+++ b/docs/docs-participate/token/staking.md
@@ -74,7 +74,7 @@ If your tokens are deposited in the Governance Staking Escrow (GSE) for voting, 
 To unstake your tokens, use the [Aztec Staking Dashboard](https://stake.aztec.network/). The dashboard guides you through the unstaking process:
 
 1. **Initiate withdrawal**: Select your validator and begin the exit process
-2. **Wait for the exit delay**: Your tokens remain locked during this period
+2. **Wait for the exit delay**: Your tokens remain locked during this period (if your tokens are also in the Governance Staking Escrow, the longer governance withdrawal delay applies)
 3. **Finalize withdrawal**: After the delay, complete the withdrawal to receive your tokens
 
 If you've delegated stake, contact your operator or use the delegation interface to request unstaking.

--- a/docs/docs-participate/token/voting.md
+++ b/docs/docs-participate/token/voting.md
@@ -47,7 +47,7 @@ If you want governance participation without staking, you can lock tokens direct
 
 To lock tokens for voting, visit the [Governance section of the Staking Dashboard](https://stake.aztec.network/governance). Connect your wallet, choose the amount to lock, and confirm the transaction. After depositing, your voting power will be active for any proposals that enter the voting phase after your deposit.
 
-Note that locked governance tokens do not earn staking rewards and are subject to a withdrawal delay (~1.6 days on testnet, ~14.6 days on mainnet).
+Note that locked governance tokens do not earn staking rewards and are subject to a withdrawal delay (~1.6 days on testnet, ~38 days on mainnet).
 
 ## How Voting Works
 
@@ -57,7 +57,7 @@ Your voting power is determined by the amount of tokens you have locked in the G
 
 - **Locking Required**: You must lock tokens in the Governance contract to activate voting power
 - **No Slashing on Votes**: Locked voting tokens are not subject to slashing (unlike staked tokens)
-- **Withdrawal Delay**: After voting, there's a delay before you can withdraw tokens to prevent governance attacks (approximately 1.6 days on testnet, 14.6 days on mainnet)
+- **Withdrawal Delay**: After voting, there's a delay before you can withdraw tokens to prevent governance attacks (~1.6 days on testnet, ~38 days on mainnet)
 
 ### Voting Timeline
 

--- a/docs/docs/networks.md
+++ b/docs/docs/networks.md
@@ -76,7 +76,7 @@ The developer SDK/aztec-nr version (used for writing and compiling contracts) ma
 | **Proposer Quorum** | 600/1000 | 60/100 |
 | **Voting Delay** | 3 days | 12 hours |
 | **Voting Duration** | 7 days | 24 hours |
-| **Execution Delay** | 7 days | 12 hours |
+| **Execution Delay** | 30 days | 12 hours |
 | **Slashing Quorum** | 65% | 33% |
 | **Slashing Round Size** | 128 epochs | 64 epochs |
 

--- a/docs/network_versioned_docs/version-v4.2.0/operators/sequencer-management/governance-participation.md
+++ b/docs/network_versioned_docs/version-v4.2.0/operators/sequencer-management/governance-participation.md
@@ -90,7 +90,7 @@ The governance process follows these stages:
 2. **Proposal Creation**: After reaching quorum, anyone can submit the payload as an official proposal.
 3. **Voting Delay** (3 days): A mandatory waiting period before voting opens (allows time for community review).
 4. **Voting Period** (7 days): Users who hold stake in the network vote on the proposal using their staked tokens. A proposal passes if it receives at least 20% quorum, 2/3 of votes are "yea", and a minimum of 500 validators' worth of voting power is cast.
-5. **Execution Delay** (7 days): After passing the vote, another mandatory delay before execution (allows time for node upgrades).
+5. **Execution Delay** (30 days): After passing the vote, another mandatory delay before execution (allows time for node upgrades).
 6. **Execution**: Anyone can execute the proposal, which applies the changes. There is a 7-day grace period after the execution delay during which the proposal can still be executed.
 
 ## Signaling Support for a Payload


### PR DESCRIPTION
## Summary

- `networks.md`: Execution Delay 7 → 30 days on mainnet
- `governance-participation.md` (current and `version-v4.2.0`): Execution Delay 7 → 30 days
- `voting.md`: mainnet withdrawal delay ~14.6 → ~38 days
- `staking.md`: note that the governance withdrawal delay applies when unstaking tokens that are also in the GSE

Split out from #22425 so these doc fixes can land independently of the API-docs discoverability infra changes.

## Test plan

- [ ] Confirm the values match on-chain governance parameters for mainnet