### PR TITLE
docs: link to apiref, not gh, remove stale include code markers

### DIFF
--- a/boxes/boxes/vanilla/contracts/src/main.nr
+++ b/boxes/boxes/vanilla/contracts/src/main.nr
@@ -3,7 +3,6 @@ use aztec::macros::aztec;
 
 #[aztec]
 pub contract PrivateVoting {
-    // docs:start:imports
     use aztec::macros::{functions::{external, initializer, only_self, view}, storage::storage};
     use aztec::protocol::{address::AztecAddress, traits::{Deserialize, Serialize, ToField}};
     use aztec::state_vars::{Map, Owned, PublicImmutable, PublicMutable, SingleUseClaim};
@@ -25,8 +24,6 @@ pub contract PrivateVoting {
         }
     }
 
-    // docs:end:imports
-    // docs:start:storage_struct
     #[storage]
     struct Storage<Context> {
         // admin can start and end elections
@@ -40,15 +37,12 @@ pub contract PrivateVoting {
         // election => voter => single use claim that ensures voter can at most vote once per election
         vote_claims: Map<ElectionId, Owned<SingleUseClaim<Context>, Context>, Context>,
     }
-    // docs:end:storage_struct
 
-    // docs:start:constructor
     #[external("public")]
     #[initializer]
     fn constructor(admin: AztecAddress) {
         self.storage.admin.write(admin);
     }
-    // docs:end:constructor
 
     #[external("private")]
     fn cast_vote(election_id: ElectionId, candidate: Field) {
@@ -56,7 +50,6 @@ pub contract PrivateVoting {
         self.enqueue_self.add_to_tally_public(election_id, candidate);
     }
 
-    // docs:start:nested_map_access
     #[external("public")]
     #[only_self]
     fn add_to_tally_public(election_id: ElectionId, candidate: Field) {
@@ -65,7 +58,6 @@ pub contract PrivateVoting {
         let new_tally = self.storage.tally.at(election_id).at(candidate).read() + 1;
         self.storage.tally.at(election_id).at(candidate).write(new_tally);
     }
-    // docs:end:nested_map_access
 
     #[external("public")]
     fn start_vote(election_id: ElectionId) {

--- a/docs/developer_versioned_docs/version-v4.2.0/docs/aztec-nr/framework-description/advanced/protocol_oracles.md
+++ b/docs/developer_versioned_docs/version-v4.2.0/docs/aztec-nr/framework-description/advanced/protocol_oracles.md
@@ -21,20 +21,15 @@ If we fetch the notes using an oracle call, we can keep the function signature i
 
 Oracles introduce **non-determinism** into a circuit, and thus are `unconstrained`. It is important that any information that is injected into a circuit through an oracle is later constrained for correctness. Otherwise, the circuit will be **under-constrained** and potentially insecure!
 
-`Aztec.nr` has a module dedicated to its oracles. If you are interested, you can view them by following the link below:
-```rust title="oracles-module" showLineNumbers 
-/// Oracles module
-```
-> <sup><sub><a href="https://github.com/AztecProtocol/aztec-packages/blob/v4.2.0/noir-projects/aztec-nr/aztec/src/oracle/mod.nr#L3-L5" target="_blank" rel="noopener noreferrer">Source code: noir-projects/aztec-nr/aztec/src/oracle/mod.nr#L3-L5</a></sub></sup>
-
+`Aztec.nr` has a [module dedicated to its oracles](pathname:///aztec-nr-api/mainnet/noir_aztec/oracle/index.html) where you can browse the full list.
 
 ## Inbuilt oracles
 
-- [`debug_log`](https://github.com/AztecProtocol/aztec-packages/blob/v4.2.0/noir-projects/noir-protocol-circuits/crates/types/src/debug_log.nr) - Provides debug functions that can be used to log information to the console. Read more about debugging [here](../../debugging.md).
-- [`auth_witness`](https://github.com/AztecProtocol/aztec-packages/blob/v4.2.0/noir-projects/aztec-nr/aztec/src/oracle/auth_witness.nr) - Provides a way to fetch the authentication witness for a given address. This is useful when building account contracts to support approve-like functionality.
-- [`get_l1_to_l2_membership_witness`](https://github.com/AztecProtocol/aztec-packages/blob/v4.2.0/noir-projects/aztec-nr/aztec/src/oracle/get_l1_to_l2_membership_witness.nr) - Returns the leaf index and sibling path for an L1 to L2 message, used to prove message existence in cross-chain applications like token bridges.
-- [`notes`](https://github.com/AztecProtocol/aztec-packages/blob/v4.2.0/noir-projects/aztec-nr/aztec/src/oracle/notes.nr) - Provides functions related to notes, such as fetching notes from storage, used behind the scenes for value notes and other pre-built note implementations.
-- [`logs`](https://github.com/AztecProtocol/aztec-packages/blob/v4.2.0/noir-projects/aztec-nr/aztec/src/oracle/logs.nr) - Provides functions to log encrypted and unencrypted data.
+- [`debug_log`](pathname:///aztec-nr-api/mainnet/noir_aztec/protocol/logging/fn.debug_log) - Provides debug functions that can be used to log information to the console. Read more about debugging [here](../../debugging.md).
+- [`auth_witness`](pathname:///aztec-nr-api/mainnet/noir_aztec/oracle/auth_witness/index.html) - Provides a way to fetch the authentication witness for a given address. This is useful when building account contracts to support approve-like functionality.
+- [`get_l1_to_l2_membership_witness`](pathname:///aztec-nr-api/mainnet/noir_aztec/oracle/get_l1_to_l2_membership_witness/index.html) - Returns the leaf index and sibling path for an L1 to L2 message, used to prove message existence in cross-chain applications like token bridges.
+- [`notes`](pathname:///aztec-nr-api/mainnet/noir_aztec/oracle/notes/index.html) - Provides functions related to notes, such as fetching notes from storage, used behind the scenes for value notes and other pre-built note implementations.
+- [`logs`](pathname:///aztec-nr-api/mainnet/noir_aztec/oracle/logs/index.html) - Provides functions to log encrypted and unencrypted data.
 
 Find a full list [on GitHub](https://github.com/AztecProtocol/aztec-packages/tree/v4.2.0/noir-projects/aztec-nr/aztec/src/oracle).
 

--- a/docs/developer_versioned_docs/version-v4.2.0/docs/aztec-nr/testing_contracts.md
+++ b/docs/developer_versioned_docs/version-v4.2.0/docs/aztec-nr/testing_contracts.md
@@ -83,7 +83,7 @@ unconstrained fn test_basic_flow() {
 
 - Tests run in parallel by default
 - Use `unconstrained` functions for faster execution
-- See all `TestEnvironment` methods [here](https://github.com/AztecProtocol/aztec-packages/blob/v4.2.0/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr)
+- See all `TestEnvironment` methods [here](pathname:///aztec-nr-api/mainnet/noir_aztec/test/helpers/test_environment/struct.TestEnvironment)
 
 :::
 

--- a/docs/docs-developers/docs/aztec-nr/framework-description/advanced/protocol_oracles.md
+++ b/docs/docs-developers/docs/aztec-nr/framework-description/advanced/protocol_oracles.md
@@ -21,16 +21,15 @@ If we fetch the notes using an oracle call, we can keep the function signature i
 
 Oracles introduce **non-determinism** into a circuit, and thus are `unconstrained`. It is important that any information that is injected into a circuit through an oracle is later constrained for correctness. Otherwise, the circuit will be **under-constrained** and potentially insecure!
 
-`Aztec.nr` has a module dedicated to its oracles. If you are interested, you can view them by following the link below:
-#include_code oracles-module /noir-projects/aztec-nr/aztec/src/oracle/mod.nr rust
+`Aztec.nr` has a [module dedicated to its oracles](pathname:///aztec-nr-api/#api_ref_version/noir_aztec/oracle/index.html) where you can browse the full list.
 
 ## Inbuilt oracles
 
-- [`debug_log`](https://github.com/AztecProtocol/aztec-packages/blob/#include_aztec_version/noir-projects/noir-protocol-circuits/crates/types/src/debug_log.nr) - Provides debug functions that can be used to log information to the console. Read more about debugging [here](../../debugging.md).
-- [`auth_witness`](https://github.com/AztecProtocol/aztec-packages/blob/#include_aztec_version/noir-projects/aztec-nr/aztec/src/oracle/auth_witness.nr) - Provides a way to fetch the authentication witness for a given address. This is useful when building account contracts to support approve-like functionality.
-- [`get_l1_to_l2_membership_witness`](https://github.com/AztecProtocol/aztec-packages/blob/#include_aztec_version/noir-projects/aztec-nr/aztec/src/oracle/get_l1_to_l2_membership_witness.nr) - Returns the leaf index and sibling path for an L1 to L2 message, used to prove message existence in cross-chain applications like token bridges.
-- [`notes`](https://github.com/AztecProtocol/aztec-packages/blob/#include_aztec_version/noir-projects/aztec-nr/aztec/src/oracle/notes.nr) - Provides functions related to notes, such as fetching notes from storage, used behind the scenes for value notes and other pre-built note implementations.
-- [`logs`](https://github.com/AztecProtocol/aztec-packages/blob/#include_aztec_version/noir-projects/aztec-nr/aztec/src/oracle/logs.nr) - Provides functions to log encrypted and unencrypted data.
+- [`debug_log`](pathname:///aztec-nr-api/#api_ref_version/noir_aztec/protocol/logging/fn.debug_log) - Provides debug functions that can be used to log information to the console. Read more about debugging [here](../../debugging.md).
+- [`auth_witness`](pathname:///aztec-nr-api/#api_ref_version/noir_aztec/oracle/auth_witness/index.html) - Provides a way to fetch the authentication witness for a given address. This is useful when building account contracts to support approve-like functionality.
+- [`get_l1_to_l2_membership_witness`](pathname:///aztec-nr-api/#api_ref_version/noir_aztec/oracle/get_l1_to_l2_membership_witness/index.html) - Returns the leaf index and sibling path for an L1 to L2 message, used to prove message existence in cross-chain applications like token bridges.
+- [`notes`](pathname:///aztec-nr-api/#api_ref_version/noir_aztec/oracle/notes/index.html) - Provides functions related to notes, such as fetching notes from storage, used behind the scenes for value notes and other pre-built note implementations.
+- [`logs`](pathname:///aztec-nr-api/#api_ref_version/noir_aztec/oracle/logs/index.html) - Provides functions to log encrypted and unencrypted data.
 
 Find a full list [on GitHub](https://github.com/AztecProtocol/aztec-packages/tree/#include_aztec_version/noir-projects/aztec-nr/aztec/src/oracle).
 

--- a/docs/docs-developers/docs/aztec-nr/testing_contracts.md
+++ b/docs/docs-developers/docs/aztec-nr/testing_contracts.md
@@ -83,7 +83,7 @@ unconstrained fn test_basic_flow() {
 
 - Tests run in parallel by default
 - Use `unconstrained` functions for faster execution
-- See all `TestEnvironment` methods [here](https://github.com/AztecProtocol/aztec-packages/blob/#include_aztec_version/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr)
+- See all `TestEnvironment` methods [here](pathname:///aztec-nr-api/#api_ref_version/noir_aztec/test/helpers/test_environment/struct.TestEnvironment)
 
 :::
 

--- a/docs/examples/contracts/recursive_verification_contract/Nargo.toml
+++ b/docs/examples/contracts/recursive_verification_contract/Nargo.toml
@@ -1,4 +1,3 @@
-# docs:start:nargo_toml
 [package]
 name = "recursive_verification_contract"
 type = "contract"
@@ -8,4 +7,3 @@ compiler_version = ">=0.25.0"
 [dependencies]
 aztec = { path = "../../../../noir-projects/aztec-nr/aztec" }
 bb_proof_verification = { path = "../../../../barretenberg/noir/bb_proof_verification" }
-# docs:end:nargo_toml

--- a/docs/examples/contracts/recursive_verification_contract/src/main.nr
+++ b/docs/examples/contracts/recursive_verification_contract/src/main.nr
@@ -1,11 +1,8 @@
 // docs:start:full_contract
-// docs:start:contract
 use aztec::macros::aztec;
 
 #[aztec]
 pub contract ValueNotEqual {
-    // docs:end:contract
-    // docs:start:imports
     use aztec::{
         macros::{functions::{external, initializer, only_self, view}, storage::storage},
         oracle::logging::debug_log_format,
@@ -13,26 +10,20 @@ pub contract ValueNotEqual {
         state_vars::{Map, PublicImmutable, PublicMutable},
     };
     use bb_proof_verification::{UltraHonkVerificationKey, UltraHonkZKProof, verify_honk_proof};
-    // docs:end:imports
 
-    // docs:start:storage
     #[storage]
     struct Storage<Context> {
         counters: Map<AztecAddress, PublicMutable<Field, Context>, Context>,
         vk_hash: PublicImmutable<Field, Context>,
     }
-    // docs:end:storage
 
-    // docs:start:constructor
     #[initializer]
     #[external("public")]
     fn constructor(headstart: Field, owner: AztecAddress, vk_hash: Field) {
         self.storage.counters.at(owner).write(headstart);
         self.storage.vk_hash.initialize(vk_hash);
     }
-    // docs:end:constructor
 
-    // docs:start:increment
     #[external("private")]
     fn increment(
         owner: AztecAddress,
@@ -56,23 +47,18 @@ pub contract ValueNotEqual {
         // Enqueue a public function call to update state
         self.enqueue_self._increment_public(owner);
     }
-    // docs:end:increment
 
-    // docs:start:increment_public
     #[only_self]
     #[external("public")]
     fn _increment_public(owner: AztecAddress) {
         let current = self.storage.counters.at(owner).read();
         self.storage.counters.at(owner).write(current + 1);
     }
-    // docs:end:increment_public
 
-    // docs:start:get_counter
     #[view]
     #[external("public")]
     fn get_counter(owner: AztecAddress) -> Field {
         self.storage.counters.at(owner).read()
     }
-    // docs:end:get_counter
 }
 // docs:end:full_contract

--- a/docs/examples/solidity/example_swap/ExampleERC20.sol
+++ b/docs/examples/solidity/example_swap/ExampleERC20.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity >=0.8.27;
 
-// docs:start:example_erc20
 import {ERC20} from "@oz/token/ERC20/ERC20.sol";
 
 /// @title ExampleERC20
@@ -14,4 +13,3 @@ contract ExampleERC20 is ERC20 {
         _mint(to, amount);
     }
 }
-// docs:end:example_erc20

--- a/docs/examples/solidity/example_swap/ExampleTokenPortal.sol
+++ b/docs/examples/solidity/example_swap/ExampleTokenPortal.sol
@@ -62,7 +62,6 @@ contract ExampleTokenPortal {
     }
     // docs:end:deposit_to_aztec_public
 
-    // docs:start:deposit_to_aztec_private
     /// @notice Deposit tokens and send L1->L2 message for private minting on Aztec
     function depositToAztecPrivate(
         uint256 _amount,
@@ -78,7 +77,6 @@ contract ExampleTokenPortal {
 
         return inbox.sendL2Message(actor, contentHash, _secretHash);
     }
-    // docs:end:deposit_to_aztec_private
 
     // docs:start:withdraw
     /// @notice Withdraw tokens after consuming an L2->L1 message.

--- a/docs/examples/ts/recursive_verification/index.ts
+++ b/docs/examples/ts/recursive_verification/index.ts
@@ -1,5 +1,4 @@
 // docs:start:run_recursion
-// docs:start:imports
 import { SponsoredFeePaymentMethod } from "@aztec/aztec.js/fee";
 import type { FieldLike } from "@aztec/aztec.js/abi";
 import { getSponsoredFPCInstance } from "./scripts/sponsored_fpc.js";
@@ -10,9 +9,7 @@ import { NO_FROM } from "@aztec/aztec.js/account";
 import { Fr } from "@aztec/aztec.js/fields";
 import assert from "node:assert";
 import fs from "node:fs";
-// docs:end:imports
 
-// docs:start:sample_data
 if (!fs.existsSync("data.json")) {
   console.error(
     "data.json not found. Run 'yarn data' first to generate proof data.",
@@ -20,11 +17,9 @@ if (!fs.existsSync("data.json")) {
   process.exit(1);
 }
 const data = JSON.parse(fs.readFileSync("data.json", "utf-8"));
-// docs:end:sample_data
 
 export const NODE_URL = process.env.AZTEC_NODE_URL ?? "http://localhost:8080";
 
-// docs:start:setup_wallet
 // Setup sponsored fee payment - the FPC pays transaction fees for us
 const sponsoredFPC = await getSponsoredFPCInstance();
 const sponsoredPaymentMethod = new SponsoredFeePaymentMethod(
@@ -47,9 +42,7 @@ export const setupWallet = async (): Promise<EmbeddedWallet> => {
     throw error;
   }
 };
-// docs:end:setup_wallet
 
-// docs:start:main
 async function main() {
   // Step 1: Setup wallet and create account
   // Accounts in Aztec are smart contracts (account abstraction)
@@ -120,7 +113,6 @@ async function main() {
 
   assert(counterValue === 11n, "Counter should be 11 after verification");
 }
-// docs:end:main
 
 main().catch((error) => {
   console.error(error);

--- a/docs/examples/webapp-tutorial/contracts/src/main.nr
+++ b/docs/examples/webapp-tutorial/contracts/src/main.nr
@@ -1,4 +1,3 @@
-// docs:start:pod-racing-contract
 // Pod Racing Game Contract
 //
 // A two-player competitive racing game where players allocate points across 5 tracks
@@ -32,10 +31,8 @@ pub contract PodRacing {
 
     use crate::{game_round_note::GameRoundNote, race::Race};
 
-    // docs:start:game-constants
     global TOTAL_ROUNDS: u8 = 3;
     global GAME_LENGTH: u32 = 2; // Set to 2 for demo purposes
-    // docs:end:game-constants
 
     // docs:start:storage
     #[storage]
@@ -183,4 +180,3 @@ pub contract PodRacing {
     }
     // docs:end:finalize-game
 }
-// docs:end:pod-racing-contract

--- a/docs/examples/webapp-tutorial/src/App.tsx
+++ b/docs/examples/webapp-tutorial/src/App.tsx
@@ -1,4 +1,3 @@
-// docs:start:app
 // docs:start:app-imports
 import React, { useState } from 'react';
 import type { Wallet } from '@aztec/aztec.js/wallet';
@@ -130,4 +129,3 @@ function App() {
 }
 
 export { App };
-// docs:end:app

--- a/docs/examples/webapp-tutorial/src/components/ErrorBoundary.tsx
+++ b/docs/examples/webapp-tutorial/src/components/ErrorBoundary.tsx
@@ -1,4 +1,3 @@
-// docs:start:error-boundary
 import React from 'react';
 
 interface ErrorBoundaryState {
@@ -46,4 +45,3 @@ export class ErrorBoundary extends React.Component<
     return this.props.children;
   }
 }
-// docs:end:error-boundary

--- a/docs/examples/webapp-tutorial/src/components/GameBoard.tsx
+++ b/docs/examples/webapp-tutorial/src/components/GameBoard.tsx
@@ -1,5 +1,3 @@
-// docs:start:game-board
-// docs:start:game-board-imports
 import React, { useState } from 'react';
 import { AztecAddress } from '@aztec/aztec.js/addresses';
 import type { PodRacingContract } from '../artifacts/PodRacing';
@@ -14,9 +12,7 @@ interface GameBoardProps {
   currentRound: number;
   onRoundPlayed: () => void;
 }
-// docs:end:game-board-imports
 
-// docs:start:game-board-component
 export function GameBoard({
   contract,
   account,
@@ -153,5 +149,3 @@ export function GameBoard({
     </div>
   );
 }
-// docs:end:game-board-component
-// docs:end:game-board

--- a/docs/examples/webapp-tutorial/src/components/GameLobby.tsx
+++ b/docs/examples/webapp-tutorial/src/components/GameLobby.tsx
@@ -1,4 +1,3 @@
-// docs:start:game-lobby
 // docs:start:game-lobby-imports
 import React, { useState } from 'react';
 import { AztecAddress } from '@aztec/aztec.js/addresses';
@@ -14,7 +13,6 @@ interface GameLobbyProps {
 }
 // docs:end:game-lobby-imports
 
-// docs:start:game-lobby-component
 export function GameLobby({ wallet, account, onGameJoined }: GameLobbyProps) {
   const [status, setStatus] = useState('');
   const [isCreating, setIsCreating] = useState(false);
@@ -154,5 +152,3 @@ export function GameLobby({ wallet, account, onGameJoined }: GameLobbyProps) {
     </div>
   );
 }
-// docs:end:game-lobby-component
-// docs:end:game-lobby

--- a/docs/examples/webapp-tutorial/src/components/GameStatus.tsx
+++ b/docs/examples/webapp-tutorial/src/components/GameStatus.tsx
@@ -1,4 +1,3 @@
-// docs:start:game-status
 import React from 'react';
 import { AztecAddress } from '@aztec/aztec.js/addresses';
 
@@ -35,4 +34,3 @@ export function GameStatus({ account, gameId, currentRound }: GameStatusProps) {
   );
 }
 // docs:end:game-status-component
-// docs:end:game-status

--- a/docs/examples/webapp-tutorial/src/components/TxStatus.tsx
+++ b/docs/examples/webapp-tutorial/src/components/TxStatus.tsx
@@ -1,4 +1,3 @@
-// docs:start:tx-status
 import React from 'react';
 
 type TxState = 'idle' | 'sending' | 'proving' | 'confirmed' | 'error';
@@ -33,4 +32,3 @@ export function TxStatus({ state, txHash, error }: TxStatusProps) {
   );
 }
 // docs:end:tx-status-component
-// docs:end:tx-status

--- a/docs/examples/webapp-tutorial/src/components/WalletConnect.tsx
+++ b/docs/examples/webapp-tutorial/src/components/WalletConnect.tsx
@@ -1,4 +1,3 @@
-// docs:start:wallet-connect
 // docs:start:wallet-connect-imports
 import React, { useState, useEffect } from 'react';
 import type { Wallet, GrantedAccountsCapability } from '@aztec/aztec.js/wallet';
@@ -26,7 +25,6 @@ export function WalletConnect({ network, onWalletConnected }: WalletConnectProps
   const [discoveryDone, setDiscoveryDone] = useState(false);
   const { addLog } = useTransactionLog();
 
-  // docs:start:local-connect
   /** Connect using the embedded wallet with a pre-deployed test account */
   async function connectLocal() {
     setLoading(true);
@@ -53,7 +51,6 @@ export function WalletConnect({ network, onWalletConnected }: WalletConnectProps
       setLoading(false);
     }
   }
-  // docs:end:local-connect
 
   // docs:start:remote-connect
   /** Discover and connect to a browser extension wallet */
@@ -199,4 +196,3 @@ export function WalletConnect({ network, onWalletConnected }: WalletConnectProps
   );
 }
 // docs:end:wallet-connect-component
-// docs:end:wallet-connect

--- a/docs/examples/webapp-tutorial/src/config.ts
+++ b/docs/examples/webapp-tutorial/src/config.ts
@@ -4,7 +4,6 @@ import { getPXEConfig } from '@aztec/pxe/config';
 import { createPXE } from '@aztec/pxe/client/lazy';
 
 
-// docs:start:network-type
 export type NetworkType = 'local' | 'remote';
 
 export function getNodeUrl(network: NetworkType): string {
@@ -14,9 +13,7 @@ export function getNodeUrl(network: NetworkType): string {
   // For remote networks, the wallet extension manages the node connection
   return process.env.AZTEC_NODE_URL || 'http://localhost:8080';
 }
-// docs:end:network-type
 
-// docs:start:create-pxe
 /**
  * Creates an in-browser PXE instance connected to an Aztec node.
  * PXE (Private eXecution Environment) runs locally and handles
@@ -33,5 +30,4 @@ export async function createLocalPXE(nodeUrl: string) {
 
   return { pxe, aztecNode };
 }
-// docs:end:create-pxe
 // docs:end:config

--- a/docs/examples/webapp-tutorial/src/contract.ts
+++ b/docs/examples/webapp-tutorial/src/contract.ts
@@ -1,4 +1,3 @@
-// docs:start:contract
 import { AztecAddress } from '@aztec/aztec.js/addresses';
 import type { Wallet } from '@aztec/aztec.js/wallet';
 // @ts-ignore — generated artifact, may not exist until compiled
@@ -6,7 +5,6 @@ import { PodRacingContract, PodRacingContractArtifact } from './artifacts/PodRac
 import { createSponsoredFeePayment } from './fees';
 import { EmbeddedWallet } from './embedded-wallet';
 
-// docs:start:deploy-contract
 /**
  * Deploys a new Pod Racing contract.
  * The deployer becomes the game admin.
@@ -19,9 +17,7 @@ export async function deployContract(wallet: Wallet, deployer: AztecAddress): Pr
   console.log('Pod Racing contract deployed at:', contract.address.toString());
   return contract;
 }
-// docs:end:deploy-contract
 
-// docs:start:attach-contract
 /**
  * Attaches to an existing deployed Pod Racing contract.
  * Registers the contract with PXE so private functions can execute locally.
@@ -35,9 +31,7 @@ export async function attachToContract(
   }
   return PodRacingContract.at(contractAddress, wallet);
 }
-// docs:end:attach-contract
 
-// docs:start:game-actions
 /**
  * Creates a new game with the given game_id.
  */
@@ -124,5 +118,3 @@ export async function finalizeGame(
   console.log('Game finalized, tx hash:', receipt.receipt.txHash.toString());
   return receipt;
 }
-// docs:end:game-actions
-// docs:end:contract

--- a/docs/examples/webapp-tutorial/src/embedded-wallet.ts
+++ b/docs/examples/webapp-tutorial/src/embedded-wallet.ts
@@ -1,4 +1,3 @@
-// docs:start:embedded-wallet
 // docs:start:embedded-wallet-imports
 import { type NoFrom, NO_FROM } from '@aztec/aztec.js/account';
 import { AztecAddress } from '@aztec/aztec.js/addresses';
@@ -143,4 +142,3 @@ export class EmbeddedWallet extends BaseEmbeddedWallet {
   }
   // docs:end:embedded-wallet-class
 }
-// docs:end:embedded-wallet

--- a/docs/examples/webapp-tutorial/src/fees.ts
+++ b/docs/examples/webapp-tutorial/src/fees.ts
@@ -1,4 +1,3 @@
-// docs:start:fees
 import { AztecAddress } from '@aztec/aztec.js/addresses';
 import { getContractInstanceFromInstantiationParams } from '@aztec/aztec.js/contracts';
 import { SponsoredFeePaymentMethod } from '@aztec/aztec.js/fee';
@@ -46,4 +45,3 @@ export async function createSponsoredFeePayment() {
   return new SponsoredFeePaymentMethod(contract.instance.address);
 }
 // docs:end:create-fee-payment
-// docs:end:fees

--- a/docs/examples/webapp-tutorial/src/game-constants.ts
+++ b/docs/examples/webapp-tutorial/src/game-constants.ts
@@ -1,7 +1,5 @@
-// docs:start:game-constants
 /** Shared game constants used by all game UI components. */
 
 export const TRACK_NAMES = ['Straight', 'Canyon', 'Asteroid Field', 'Nebula', 'Wormhole'] as const;
 export const MAX_POINTS_PER_ROUND = 9;
 export const TOTAL_ROUNDS = 3;
-// docs:end:game-constants

--- a/docs/examples/webapp-tutorial/src/wallet-connection.ts
+++ b/docs/examples/webapp-tutorial/src/wallet-connection.ts
@@ -1,4 +1,3 @@
-// docs:start:wallet-connection
 import { Fr } from '@aztec/aztec.js/fields';
 import type { Wallet, AppCapabilities } from '@aztec/aztec.js/wallet';
 import { WalletManager, type WalletProvider } from '@aztec/wallet-sdk/manager';
@@ -111,4 +110,3 @@ export function getAppCapabilities(): AppCapabilities {
   };
 }
 // docs:end:app-capabilities
-// docs:end:wallet-connection

--- a/docs/examples/webapp-tutorial/test-extension/src/account-utils.ts
+++ b/docs/examples/webapp-tutorial/test-extension/src/account-utils.ts
@@ -1,4 +1,3 @@
-// docs:start:account-utils
 /**
  * Shared account contract instantiation logic.
  *
@@ -59,4 +58,3 @@ export async function instantiateAccount(secret: string, salt: string) {
     instance,
   };
 }
-// docs:end:account-utils

--- a/docs/examples/webapp-tutorial/test-extension/src/aztec-imports.ts
+++ b/docs/examples/webapp-tutorial/test-extension/src/aztec-imports.ts
@@ -1,4 +1,3 @@
-// docs:start:aztec-imports
 /**
  * Centralized lazy import cache for Aztec SDK modules.
  *
@@ -124,4 +123,3 @@ export async function getAztecDeploy(): Promise<AztecDeployImports> {
 
   return deployCache;
 }
-// docs:end:aztec-imports

--- a/docs/examples/webapp-tutorial/test-extension/src/background.ts
+++ b/docs/examples/webapp-tutorial/test-extension/src/background.ts
@@ -1,4 +1,3 @@
-// docs:start:background
 /**
  * Background service worker for the Aztec Tutorial Wallet.
  *
@@ -162,7 +161,6 @@ async function sendToOffscreen(message: any, _retried = false): Promise<any> {
 }
 // docs:end:send-to-offscreen
 
-// docs:start:pending-state
 // Store pending transactions, session verifications, and capability requests.
 // Discovery and session tracking uses only the SDK handler.
 let pendingTransactions: PendingTransaction[] = [];
@@ -179,9 +177,7 @@ const capabilitiesApprovedSessions = new Set<string>();
  * This prevents the dApp from bypassing verification by sending messages immediately.
  */
 const queuedMessages: Map<string, { session: ActiveSession; message: any }[]> = new Map();
-// docs:end:pending-state
 
-// docs:start:trusted-origins
 /**
  * Trusted origins persistence for auto-reconnect. (#30)
  *
@@ -229,9 +225,7 @@ async function getStoredCapabilities(origin: string, appId: string): Promise<Arr
   const entry = trusted.find(t => t.origin === origin && t.appId === appId);
   return entry?.grantedCapabilities ?? null;
 }
-// docs:end:trusted-origins
 
-// docs:start:state-persistence
 /**
  * Persists critical state to chrome.storage.session. (#8)
  *
@@ -280,9 +274,7 @@ async function restoreState(): Promise<void> {
     log.warn('[background] Failed to restore state:', err);
   }
 }
-// docs:end:state-persistence
 
-// docs:start:background-tasks
 /**
  * Background task tracker for long-running operations.
  * Tasks survive popup close/reopen. The popup receives real-time updates
@@ -322,9 +314,7 @@ function cleanupTasks() {
     (t) => t.status === 'running' || t.startedAt > cutoff
   );
 }
-// docs:end:background-tasks
 
-// docs:start:popup-port
 /**
  * Persistent port connection to the popup.
  * Allows the background to push real-time updates without polling.
@@ -421,9 +411,7 @@ function getFullState() {
     tasks: backgroundTasks,
   };
 }
-// docs:end:popup-port
 
-// docs:start:auto-lock
 /**
  * Auto-lock via chrome.alarms. (#28)
  * Resets the timer on every popup interaction.
@@ -450,7 +438,6 @@ chrome.alarms.onAlarm.addListener(async (alarm) => {
     pushStateToPopup();
   }
 });
-// docs:end:auto-lock
 
 /**
  * Updates the extension badge to show pending items count.
@@ -783,7 +770,6 @@ chrome.tabs.onRemoved.addListener((tabId) => {
  * Handle messages from popup and offscreen for approvals and account management.
  */
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
-  // docs:start:storage-proxy
   /**
    * Storage proxy for the offscreen document. (#7)
    * Validates that the request comes from the extension itself (not content scripts or external).
@@ -812,7 +798,6 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     }
     return true; // async response (#23)
   }
-  // docs:end:storage-proxy
 
   if (message.target !== MessageTarget.BACKGROUND) {
     return false;
@@ -1215,7 +1200,6 @@ async function handleTransactionApproval(
 }
 // docs:end:popup-messages
 
-// docs:start:lifecycle
 /**
  * Extension lifecycle handlers. (#17)
  */
@@ -1250,5 +1234,3 @@ ensureOffscreenDocument().then(() => {
 }).catch((err) => {
   log.error('[background] Offscreen preload failed (will retry on demand):', err);
 });
-// docs:end:lifecycle
-// docs:end:background

--- a/docs/examples/webapp-tutorial/test-extension/src/config.ts
+++ b/docs/examples/webapp-tutorial/test-extension/src/config.ts
@@ -80,7 +80,6 @@ export const MessageTarget = {
 } as const;
 
 
-// docs:start:logging
 /**
  * Conditional logging. (#26)
  * Strips verbose logs in production while keeping errors visible.
@@ -94,5 +93,4 @@ export const log = {
   warn: (...args: unknown[]) => console.warn(...args),
   error: (...args: unknown[]) => console.error(...args),
 };
-// docs:end:logging
 // docs:end:wallet-config

--- a/docs/examples/webapp-tutorial/test-extension/src/offscreen/offscreen.ts
+++ b/docs/examples/webapp-tutorial/test-extension/src/offscreen/offscreen.ts
@@ -1,4 +1,3 @@
-// docs:start:offscreen
 /** Offscreen document for the Aztec Tutorial Wallet. */
 
 // CRITICAL: console-intercept MUST be the very first import.
@@ -99,7 +98,6 @@ onConsoleInfo((args) => {
   }
 });
 
-// docs:start:master-key
 /**
  * Master CryptoKey — cached in memory after unlock. (#2)
  *
@@ -121,7 +119,6 @@ function getCachedMasterKey(): CryptoKey {
 export function clearCachedKey(): void {
   cachedMasterKey = null;
 }
-// docs:end:master-key
 
 // docs:start:pxe-instance
 /**
@@ -264,7 +261,6 @@ async function getWallet() {
     }
     // docs:end:complete-fee-options
 
-    // docs:start:auto-authwit
     /**
      * Overrides sendTx to auto-extract auth witnesses from offchain effects.
      *
@@ -365,7 +361,6 @@ async function getWallet() {
 
       log.info(`[offscreen] Auth witness extraction complete: ${count} witness(es) from ${effects.length} effect(s)`);
     }
-    // docs:end:auto-authwit
   }
 
   walletInstance = new OffscreenWallet(pxe, node);
@@ -453,7 +448,6 @@ async function handleMessage(message: any): Promise<any> {
 }
 // docs:end:message-handler
 
-// docs:start:handlers
 async function handleGetAccounts() {
   return getAccounts();
 }
@@ -523,9 +517,7 @@ async function handleWalletMethod(method: string, args: any[]): Promise<any> {
   return jsonSafe;
 }
 // docs:end:wallet-method-handler
-// docs:end:handlers
 
-// docs:start:pxe-handlers
 /**
  * Sets the master password for the first time. (#1, #2)
  * Returns the CryptoKey (which we cache), never stores the password.
@@ -777,5 +769,3 @@ async function handleInitPXE(nodeUrl?: string) {
   await ensurePXE(nodeUrl);
   return { success: true };
 }
-// docs:end:pxe-handlers
-// docs:end:offscreen

--- a/docs/examples/webapp-tutorial/test-extension/src/popup/AccountSwitcher.tsx
+++ b/docs/examples/webapp-tutorial/test-extension/src/popup/AccountSwitcher.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 import type { StoredAccount } from './types';
 import { truncateAddress } from './helpers';
 
-// docs:start:account-switcher
 interface AccountSwitcherProps {
   accounts: StoredAccount[];
   activeAccount: string | null;
@@ -50,4 +49,3 @@ export function AccountSwitcher({ accounts, activeAccount, onSelect, onCreateNew
     </div>
   );
 }
-// docs:end:account-switcher

--- a/docs/examples/webapp-tutorial/test-extension/src/popup/ApprovalView.tsx
+++ b/docs/examples/webapp-tutorial/test-extension/src/popup/ApprovalView.tsx
@@ -7,7 +7,6 @@ import type { PendingDiscovery } from '@aztec/wallet-sdk/extension/handlers';
 import type { PendingTransaction, PendingCapabilities, PendingSessionVerification } from '../shared-types';
 import { sendToBackground, truncateAddress } from './helpers';
 
-// docs:start:approvals-view
 interface ApprovalsViewProps {
   discoveries: PendingDiscovery[];
   transactions: PendingTransaction[];
@@ -101,9 +100,7 @@ export function ApprovalsView({
     </div>
   );
 }
-// docs:end:approvals-view
 
-// docs:start:session-verification
 export function SessionVerificationView({ verification, onConfirm, onReject }: {
   verification: PendingSessionVerification;
   onConfirm: () => void;
@@ -141,7 +138,6 @@ export function SessionVerificationView({ verification, onConfirm, onReject }: {
     </div>
   );
 }
-// docs:end:session-verification
 
 // docs:start:connection-approval
 interface ConnectionApprovalProps {
@@ -299,7 +295,6 @@ function TransactionApproval({
 }
 // docs:end:transaction-approval
 
-// docs:start:capabilities-approval
 interface ExpandableSection {
   summary: string;
   items: string[];
@@ -512,4 +507,3 @@ function CapabilitiesApproval({
     </div>
   );
 }
-// docs:end:capabilities-approval

--- a/docs/examples/webapp-tutorial/test-extension/src/popup/CreateAccountView.tsx
+++ b/docs/examples/webapp-tutorial/test-extension/src/popup/CreateAccountView.tsx
@@ -2,7 +2,6 @@ import React, { useState } from 'react';
 
 import { createAndActivateAccount } from './helpers';
 
-// docs:start:create-account-view
 export function CreateAccountView({ onCreated }: { onCreated: () => void }) {
   const [alias, setAlias] = useState('');
   const [creating, setCreating] = useState(false);
@@ -48,4 +47,3 @@ export function CreateAccountView({ onCreated }: { onCreated: () => void }) {
     </div>
   );
 }
-// docs:end:create-account-view

--- a/docs/examples/webapp-tutorial/test-extension/src/popup/Header.tsx
+++ b/docs/examples/webapp-tutorial/test-extension/src/popup/Header.tsx
@@ -3,7 +3,6 @@ import React, { useState, useEffect, useRef } from 'react';
 import { getOriginHost } from '../utils';
 import type { ConnectedSite } from './types';
 
-// docs:start:header
 export function Header({ pendingCount, onApprovalClick, connectedSites, onDisconnect, onSettingsClick }: {
   pendingCount: number;
   onApprovalClick: () => void;
@@ -92,9 +91,7 @@ export function Header({ pendingCount, onApprovalClick, connectedSites, onDiscon
     </div>
   );
 }
-// docs:end:header
 
-// docs:start:sub-header
 export function SubHeader({ title, onBack }: { title: string; onBack: () => void }) {
   return (
     <div className="sub-header">
@@ -105,4 +102,3 @@ export function SubHeader({ title, onBack }: { title: string; onBack: () => void
     </div>
   );
 }
-// docs:end:sub-header

--- a/docs/examples/webapp-tutorial/test-extension/src/popup/LockScreen.tsx
+++ b/docs/examples/webapp-tutorial/test-extension/src/popup/LockScreen.tsx
@@ -3,7 +3,6 @@ import React, { useState } from 'react';
 import { MessageTypes } from '../config';
 import { sendToBackground, waitForTask } from './helpers';
 
-// docs:start:lock-screen
 export function LockScreen({ onUnlocked }: { onUnlocked: () => void }) {
   const [password, setPassword] = useState('');
   const [unlocking, setUnlocking] = useState(false);
@@ -59,4 +58,3 @@ export function LockScreen({ onUnlocked }: { onUnlocked: () => void }) {
     </div>
   );
 }
-// docs:end:lock-screen

--- a/docs/examples/webapp-tutorial/test-extension/src/popup/SettingsPage.tsx
+++ b/docs/examples/webapp-tutorial/test-extension/src/popup/SettingsPage.tsx
@@ -4,7 +4,6 @@ import { MessageTypes, AZTEC_PACKAGES_VERSION } from '../config';
 import type { WalletExportData } from '../shared-types';
 import { sendToBackground, waitForTask } from './helpers';
 
-// docs:start:settings-page
 export function SettingsPage({ onImportStart }: { onImportStart: (data: WalletExportData) => void }) {
   const [exporting, setExporting] = useState(false);
   const [importPreview, setImportPreview] = useState<WalletExportData | null>(null);
@@ -153,4 +152,3 @@ export function SettingsPage({ onImportStart }: { onImportStart: (data: WalletEx
     </div>
   );
 }
-// docs:end:settings-page

--- a/docs/examples/webapp-tutorial/test-extension/src/popup/SetupScreen.tsx
+++ b/docs/examples/webapp-tutorial/test-extension/src/popup/SetupScreen.tsx
@@ -3,7 +3,6 @@ import React, { useState } from 'react';
 import { MessageTypes } from '../config';
 import { sendToBackground, waitForTask, createAndActivateAccount } from './helpers';
 
-// docs:start:setup-screen
 export function SetupScreen({ onComplete, skipAccountCreation = false }: { onComplete: () => void; skipAccountCreation?: boolean }) {
   const [step, setStep] = useState<'password' | 'account'>('password');
   const [password, setPassword] = useState('');
@@ -129,4 +128,3 @@ export function SetupScreen({ onComplete, skipAccountCreation = false }: { onCom
     </div>
   );
 }
-// docs:end:setup-screen

--- a/docs/examples/webapp-tutorial/test-extension/src/popup/helpers.ts
+++ b/docs/examples/webapp-tutorial/test-extension/src/popup/helpers.ts
@@ -26,7 +26,6 @@ export function sendToBackground(message: any): Promise<any> {
 }
 // docs:end:send-message
 
-// docs:start:task-waiting
 /**
  * Registry of pending task promises. (#12)
  *
@@ -72,7 +71,6 @@ export function handleTaskUpdate(task: BackgroundTask) {
     callbacks.reject(new Error(task.error || 'Task failed'));
   }
 }
-// docs:end:task-waiting
 
 // docs:start:helpers
 export function truncateAddress(address: string): string {

--- a/docs/examples/webapp-tutorial/test-extension/src/popup/popup.tsx
+++ b/docs/examples/webapp-tutorial/test-extension/src/popup/popup.tsx
@@ -1,4 +1,3 @@
-// docs:start:popup
 /**
  * Popup UI for the Aztec Tutorial Wallet.
  *
@@ -466,4 +465,3 @@ function App() {
 // Mount the app
 const root = createRoot(document.getElementById('root')!);
 root.render(<App />);
-// docs:end:popup

--- a/docs/examples/webapp-tutorial/test-extension/src/popup/types.ts
+++ b/docs/examples/webapp-tutorial/test-extension/src/popup/types.ts
@@ -1,4 +1,3 @@
-// docs:start:types
 /**
  * Re-export shared types for the popup.
  * The canonical definitions live in shared-types.ts — import from there
@@ -17,4 +16,3 @@ export type {
 
 /** Alias for popup components that display account info. */
 export type { PublicAccountInfo as StoredAccount } from '../shared-types';
-// docs:end:types

--- a/docs/examples/webapp-tutorial/test-extension/src/shared-types.ts
+++ b/docs/examples/webapp-tutorial/test-extension/src/shared-types.ts
@@ -1,4 +1,3 @@
-// docs:start:shared-types
 /**
  * Shared type definitions for the Aztec Tutorial Wallet extension.
  * Single source of truth for types used across background, offscreen, and popup.
@@ -96,4 +95,3 @@ export interface WalletExportData {
 
 /** Popup view state. */
 export type View = 'loading' | 'setup' | 'lock' | 'main' | 'switcher' | 'createAccount' | 'approvals' | 'verifySession' | 'settings';
-// docs:end:shared-types

--- a/docs/examples/webapp-tutorial/test-extension/src/utils.ts
+++ b/docs/examples/webapp-tutorial/test-extension/src/utils.ts
@@ -1,4 +1,3 @@
-// docs:start:utils
 /**
  * Shared utilities for the Aztec Tutorial Wallet extension.
  * Extracted from multiple files to eliminate duplication.
@@ -43,4 +42,3 @@ export function getOriginHost(origin: string): string {
   }
 }
 
-// docs:end:utils

--- a/docs/examples/webapp-tutorial/test-extension/src/wallet/storage.ts
+++ b/docs/examples/webapp-tutorial/test-extension/src/wallet/storage.ts
@@ -1,4 +1,3 @@
-// docs:start:wallet-storage
 /**
  * Encrypted key storage for the Aztec Tutorial Wallet.
  *
@@ -13,7 +12,6 @@
  * hardware security modules, secure enclaves, or platform keychain APIs.
  */
 
-// docs:start:constants
 /** Known plaintext used to verify the master password is correct */
 const VERIFICATION_PLAINTEXT = 'aztec-wallet-verify';
 
@@ -46,9 +44,7 @@ export const STORAGE_KEYS = {
   PASSWORD_DATA: 'aztec_password_data',
   ACTIVE_ACCOUNT: 'aztec_active_account',
 } as const;
-// docs:end:constants
 
-// docs:start:base64-helpers
 /** Encode bytes to base64 */
 function bytesToBase64(bytes: Uint8Array): string {
   return btoa(String.fromCharCode(...bytes));
@@ -58,7 +54,6 @@ function bytesToBase64(bytes: Uint8Array): string {
 function base64ToBytes(b64: string): Uint8Array {
   return Uint8Array.from(atob(b64), (c) => c.charCodeAt(0));
 }
-// docs:end:base64-helpers
 
 // docs:start:derive-master-key
 /**
@@ -143,7 +138,6 @@ export async function decryptWithKey(
 
 import { getChromeRuntime } from '../utils';
 
-// docs:start:storage-proxy
 /**
  * Chrome runtime for messaging (available in offscreen documents).
  * Offscreen documents don't have direct chrome.storage access,
@@ -189,7 +183,6 @@ async function storageSet(data: Record<string, any>): Promise<void> {
     );
   });
 }
-// docs:end:storage-proxy
 
 // docs:start:password-management
 /**
@@ -338,4 +331,3 @@ export async function setActiveAccount(address: string): Promise<void> {
   await storageSet({ [STORAGE_KEYS.ACTIVE_ACCOUNT]: address });
 }
 // docs:end:account-operations
-// docs:end:wallet-storage

--- a/docs/examples/webapp-tutorial/test-extension/src/wallet/wallet-impl.ts
+++ b/docs/examples/webapp-tutorial/test-extension/src/wallet/wallet-impl.ts
@@ -1,4 +1,3 @@
-// docs:start:extension-wallet
 /**
  * Wallet implementation for the Aztec Tutorial Wallet extension.
  *
@@ -152,4 +151,3 @@ export async function markDeployed(address: string): Promise<void> {
 
 // Re-export storage functions for convenience
 export { getActiveAccount, setActiveAccount };
-// docs:end:extension-wallet

--- a/l1-contracts/test/portals/TokenPortal.sol
+++ b/l1-contracts/test/portals/TokenPortal.sol
@@ -79,7 +79,6 @@ contract TokenPortal {
     return (key, index);
   }
 
-  // docs:start:deposit_private
   /**
    * @notice Deposit funds into the portal and adds an L2 message which can only be consumed privately on Aztec
    * @param _amount - The amount to deposit
@@ -90,7 +89,6 @@ contract TokenPortal {
   function depositToAztecPrivate(uint256 _amount, bytes32 _secretHashForL2MessageConsumption)
     external
     returns (bytes32, uint256)
-  // docs:end:deposit_private
   {
     // Preamble
     DataStructures.L2Actor memory actor = DataStructures.L2Actor(l2Bridge, rollupVersion);

--- a/l1-contracts/test/portals/UniswapPortal.sol
+++ b/l1-contracts/test/portals/UniswapPortal.sol
@@ -45,7 +45,6 @@ contract UniswapPortal {
     bytes32 contentHash;
   }
 
-
   /**
    * @notice Exit with funds from L2, perform swap on L1 and deposit output asset to L2 again publicly
    * @dev `msg.value` indicates fee to submit message to inbox. Currently, anyone can call this method on your behalf.
@@ -150,7 +149,6 @@ contract UniswapPortal {
     // Deposit the output asset to the L2 via its portal
     return TokenPortal(_outputTokenPortal).depositToAztecPublic(_aztecRecipient, amountOut, _secretHashForL1ToL2Message);
   }
-
 
   /**
    * @notice Exit with funds from L2, perform swap on L1 and deposit output asset to L2 again privately

--- a/l1-contracts/test/portals/UniswapPortal.sol
+++ b/l1-contracts/test/portals/UniswapPortal.sol
@@ -9,7 +9,6 @@ import {DataStructures} from "@aztec/core/libraries/DataStructures.sol";
 import {DataStructures as PortalDataStructures} from "./DataStructures.sol";
 import {Hash} from "@aztec/core/libraries/crypto/Hash.sol";
 
-// docs:start:setup
 import {TokenPortal} from "./TokenPortal.sol";
 import {ISwapRouter} from "../external/ISwapRouter.sol";
 
@@ -46,9 +45,7 @@ contract UniswapPortal {
     bytes32 contentHash;
   }
 
-  // docs:end:setup
 
-  // docs:start:solidity_uniswap_swap_public
   /**
    * @notice Exit with funds from L2, perform swap on L1 and deposit output asset to L2 again publicly
    * @dev `msg.value` indicates fee to submit message to inbox. Currently, anyone can call this method on your behalf.
@@ -154,9 +151,7 @@ contract UniswapPortal {
     return TokenPortal(_outputTokenPortal).depositToAztecPublic(_aztecRecipient, amountOut, _secretHashForL1ToL2Message);
   }
 
-  // docs:end:solidity_uniswap_swap_public
 
-  // docs:start:solidity_uniswap_swap_private
   /**
    * @notice Exit with funds from L2, perform swap on L1 and deposit output asset to L2 again privately
    * @dev `msg.value` indicates fee to submit message to inbox. Currently, anyone can call this method on your behalf.
@@ -258,4 +253,3 @@ contract UniswapPortal {
     return TokenPortal(_outputTokenPortal).depositToAztecPrivate(amountOut, _secretHashForL1ToL2Message);
   }
 }
-// docs:end:solidity_uniswap_swap_private

--- a/noir-projects/aztec-nr/aztec/src/authwit/account.nr
+++ b/noir-projects/aztec-nr/aztec/src/authwit/account.nr
@@ -52,7 +52,6 @@ impl AccountActions<&mut PrivateContext> {
     /// transaction to be sent with a higher priority fee. This can be used to cancel the first transaction sent,
     /// assuming it hasn't been mined yet.
     ///
-    // docs:start:entrypoint
     pub fn entrypoint(self, app_payload: AppPayload, fee_payment_method: u8, cancellable: bool) {
         let valid_fn = self.is_valid_impl;
 

--- a/noir-projects/aztec-nr/aztec/src/authwit/entrypoint/app.nr
+++ b/noir-projects/aztec-nr/aztec/src/authwit/entrypoint/app.nr
@@ -12,7 +12,6 @@ global ACCOUNT_MAX_CALLS: u32 = 5;
 // - default_entrypoint.ts
 // - account_entrypoint.ts (specifically `getEntrypointAbi()`)
 // - default_multi_call_entrypoint.ts (specifically `getEntrypointAbi()`)
-// docs:start:app-payload-struct
 #[derive(Serialize)]
 pub struct AppPayload {
     function_calls: [FunctionCall; ACCOUNT_MAX_CALLS],

--- a/noir-projects/aztec-nr/aztec/src/oracle/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/mod.nr
@@ -1,9 +1,5 @@
 //! Standard PXE oracles.
 
-// docs:start:oracles-module
-/// Oracles module
-// docs:end:oracles-module
-
 pub mod avm;
 pub mod aes128_decrypt;
 pub mod auth_witness;

--- a/noir-projects/aztec-nr/aztec/src/state_vars/map.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/map.nr
@@ -46,7 +46,6 @@ use crate::state_vars::StateVariable;
 /// The storage slot derivation uses `derive_storage_slot_in_map(base_slot, key)` which computes
 /// `poseidon2_hash([base_slot, key.to_field()])`, ensuring cryptographically secure slot separation.
 ///
-/// docs:start:map
 pub struct Map<K, V, Context> {
     pub context: Context,
     storage_slot: Field,

--- a/noir-projects/aztec-nr/aztec/src/state_vars/private_mutable.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/private_mutable.nr
@@ -285,7 +285,6 @@ where
     /// The kernel will inject a unique nonce into the newly-created note, which means the new note will have a
     /// different nullifier, allowing it to be consumed in the future.
     ///
-    /// docs:start:get_note
     pub fn get_note(self) -> NoteMessage<Note>
     where
         Note: Packable,
@@ -345,7 +344,6 @@ where
     ///
     /// * `Note` - The current note stored in this PrivateMutable.
     ///
-    /// docs:start:view_note
     pub unconstrained fn view_note(self) -> Note
     where
         Note: Packable,

--- a/noir-projects/aztec-nr/uint-note/src/uint_note.nr
+++ b/noir-projects/aztec-nr/uint-note/src/uint_note.nr
@@ -164,12 +164,10 @@ impl NoteType for UintPartialNotePrivateLogContent {
 /// storage slot and value fields have not yet been set. A partial note can be completed in public with the `complete`
 /// function (revealing the storage slot and value to the public), resulting in a UintNote that can be used like any
 /// other one (except of course that its value is known).
-// docs:start:partial_uint_note_def
 #[derive(Packable, Serialize, Deserialize, Eq)]
 pub struct PartialUintNote {
     commitment: Field,
 }
-// docs:end:partial_uint_note_def
 
 global NOTE_COMPLETION_PAYLOAD_LENGTH: u32 = 2;
 

--- a/noir-projects/noir-contracts/contracts/account/schnorr_account_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/account/schnorr_account_contract/src/main.nr
@@ -32,9 +32,7 @@ pub contract SchnorrAccount {
 
     #[storage]
     struct Storage<Context> {
-        // docs:start:public_key
         signing_public_key: SinglePrivateImmutable<PublicKeyNote, Context>,
-        // docs:end:public_key
     }
 
     // Constructs the contract

--- a/noir-projects/noir-contracts/contracts/app/auth_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/auth_contract/src/main.nr
@@ -66,7 +66,6 @@ pub contract Auth {
         self.storage.authorized.schedule_delay_change(new_delay);
     }
 
-    // docs:start:get_current_value_private
     #[external("private")]
     fn do_private_authorized_thing() {
         // Reading a value from authorized in private automatically adds an extra validity condition: the base rollup
@@ -76,7 +75,6 @@ pub contract Auth {
         let authorized = self.storage.authorized.get_current_value();
         assert_eq(authorized, self.msg_sender(), "caller is not authorized");
     }
-    // docs:end:get_current_value_private
 
     #[external("private")]
     #[view]

--- a/noir-projects/noir-contracts/contracts/app/crowdfunding_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/crowdfunding_contract/src/main.nr
@@ -22,14 +22,12 @@ pub contract Crowdfunding {
         who: AztecAddress,
         amount: u128,
     }
-    // docs:start:storage
     #[storage]
     struct Storage<Context> {
         config: PublicImmutable<Config, Context>,
         // Notes emitted to donors when they donate (can be used as proof to obtain rewards, eg in Claim contracts)
         donation_receipts: Owned<PrivateSet<UintNote, Context>, Context>,
     }
-    // docs:end:storage
 
     // TODO(#8367): Ensure deadline is quantized to improve privacy set.
     #[external("public")]

--- a/noir-projects/noir-contracts/contracts/app/escrow_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/escrow_contract/src/main.nr
@@ -13,14 +13,11 @@ pub contract Escrow {
     use address_note::AddressNote;
     use token::Token;
 
-    // docs:start:single_private_immutable_storage
     #[storage]
     struct Storage<Context> {
         owner: SinglePrivateImmutable<AddressNote, Context>,
     }
-    // docs:end:single_private_immutable_storage
 
-    // docs:start:single_private_immutable_initialize
     // Creates a new instance
     #[external("private")]
     #[initializer]
@@ -28,7 +25,6 @@ pub contract Escrow {
         let note = AddressNote { address: owner };
         self.storage.owner.initialize(note).deliver(MessageDelivery.ONCHAIN_CONSTRAINED);
     }
-    // docs:end:single_private_immutable_initialize
 
     // Withdraws balance. Requires that msg.sender is the owner.
     #[external("private")]

--- a/noir-projects/noir-contracts/contracts/app/lending_contract/src/asset.nr
+++ b/noir-projects/noir-contracts/contracts/app/lending_contract/src/asset.nr
@@ -12,7 +12,6 @@ use std::meta::derive;
 ///
 /// Note: Right now we are wasting so many writes. If changing last_updated_ts we will end
 /// up rewriting all the values.
-// docs:start:custom_struct_in_storage
 #[derive(Deserialize, Serialize)]
 pub struct Asset {
     pub interest_accumulator: u128,
@@ -40,7 +39,6 @@ impl Packable for Asset {
         Self { interest_accumulator, last_updated_ts, loan_to_value, oracle }
     }
 }
-// docs:end:custom_struct_in_storage
 
 mod test {
     use super::{Asset, AztecAddress, FromField, Packable};

--- a/noir-projects/noir-contracts/contracts/app/lending_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/lending_contract/src/main.nr
@@ -27,7 +27,6 @@ pub contract Lending {
 
     use aztec::protocol::traits::{FromField, ToField};
 
-    // docs:start:custom_struct_storage_map
     // Storage structure, containing all storage, and specifying what slots they use.
     #[storage]
     struct Storage<Context> {
@@ -39,14 +38,12 @@ pub contract Lending {
         collateral: Map<AztecAddress, PublicMutable<u128, Context>, Context>,
         static_debt: Map<AztecAddress, PublicMutable<u128, Context>, Context>, // abusing keys very heavily
     }
-    // docs:end:custom_struct_storage_map
 
     // Constructs the contract.
     #[external("private")]
     #[initializer]
     fn constructor() {}
 
-    // docs:start:custom_struct_read_write
     #[external("public")]
     fn init(
         oracle: AztecAddress,
@@ -78,7 +75,6 @@ pub contract Lending {
         // docs:end:public_mutable_write
         self.storage.stable_coin.write(stable_coin);
     }
-    // docs:end:custom_struct_read_write
 
     // Create a position.
     #[external("public")]

--- a/noir-projects/noir-contracts/contracts/app/nft_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/nft_contract/src/main.nr
@@ -1,4 +1,3 @@
-// docs:start:imports
 mod types;
 mod test;
 
@@ -26,8 +25,6 @@ pub contract NFT {
     };
     use compressed_string::FieldCompressedString;
 
-    // docs:end:imports
-
     // TODO(#8467): Rename this to Transfer - calling this NFTTransfer to avoid export conflict with the Transfer event
     // in the Token contract.
     // #[event]
@@ -37,7 +34,6 @@ pub contract NFT {
     //     token_id: Field,
     // }
 
-    // docs:start:storage_struct
     #[storage]
     struct Storage<Context> {
         // The symbol of the NFT
@@ -55,9 +51,7 @@ pub contract NFT {
         // A map from token ID to the public owner of the NFT.
         public_owners: Map<Field, PublicMutable<AztecAddress, Context>, Context>,
     }
-    // docs:end:storage_struct
 
-    // docs:start:constructor
     #[external("public")]
     #[initializer]
     fn constructor(admin: AztecAddress, name: str<31>, symbol: str<31>) {
@@ -67,7 +61,6 @@ pub contract NFT {
         self.storage.name.initialize(FieldCompressedString::from_string(name));
         self.storage.symbol.initialize(FieldCompressedString::from_string(symbol));
     }
-    // docs:end:constructor
 
     #[external("public")]
     fn set_admin(new_admin: AztecAddress) {
@@ -75,13 +68,11 @@ pub contract NFT {
         self.storage.admin.write(new_admin);
     }
 
-    // docs:start:set_minter
     #[external("public")]
     fn set_minter(minter: AztecAddress, approve: bool) {
         assert(self.storage.admin.read().eq(self.msg_sender()), "caller is not an admin");
         self.storage.minters.at(minter).write(approve);
     }
-    // docs:end:set_minter
 
     #[external("public")]
     fn mint(to: AztecAddress, token_id: Field) {

--- a/noir-projects/noir-contracts/contracts/app/private_token_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/private_token_contract/src/main.nr
@@ -55,7 +55,6 @@ pub contract PrivateToken {
     // docs:start:note_delivery
     #[external("private")]
     fn mint(amount: u128, recipient: AztecAddress) {
-        // docs:start:owned_single_private_mutable_get_note
         let replacement_note_message = self.storage.admin.get_note();
         let admin = replacement_note_message.get_note().address;
         assert(admin == self.msg_sender(), "Only admin can mint");
@@ -63,7 +62,6 @@ pub contract PrivateToken {
         // We deliver the new note message to the admin using unconstrained delivery, since the admin is motivated to
         // deliver the message to themselves (hence no need to constrain it).
         replacement_note_message.deliver(MessageDelivery.ONCHAIN_UNCONSTRAINED);
-        // docs:end:owned_single_private_mutable_get_note
         // We increase the total supply and once again use unconstrained delivery, since the admin is motivated to
         // deliver the message (he's the owner of the new note as well).
         self

--- a/noir-projects/noir-contracts/contracts/app/private_voting_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/private_voting_contract/src/main.nr
@@ -3,7 +3,6 @@ use aztec::macros::aztec;
 
 #[aztec]
 pub contract PrivateVoting {
-    // docs:start:imports
     use aztec::macros::{functions::{external, initializer, only_self, view}, storage::storage};
     use aztec::protocol::{address::AztecAddress, traits::{Deserialize, Serialize, ToField}};
     use aztec::state_vars::{Map, Owned, PublicImmutable, PublicMutable, SingleUseClaim};
@@ -25,8 +24,6 @@ pub contract PrivateVoting {
         }
     }
 
-    // docs:end:imports
-    // docs:start:storage_struct
     #[storage]
     struct Storage<Context> {
         // admin can start and end elections
@@ -40,15 +37,12 @@ pub contract PrivateVoting {
         // election => voter => single use claim that ensures voter can at most vote once per election
         vote_claims: Map<ElectionId, Owned<SingleUseClaim<Context>, Context>, Context>,
     }
-    // docs:end:storage_struct
 
-    // docs:start:constructor
     #[external("public")]
     #[initializer]
     fn constructor(admin: AztecAddress) {
         self.storage.admin.write(admin);
     }
-    // docs:end:constructor
 
     #[external("private")]
     fn cast_vote(election_id: ElectionId, candidate: Field) {
@@ -56,7 +50,6 @@ pub contract PrivateVoting {
         self.enqueue_self.add_to_tally_public(election_id, candidate);
     }
 
-    // docs:start:nested_map_access
     #[external("public")]
     #[only_self]
     fn add_to_tally_public(election_id: ElectionId, candidate: Field) {
@@ -65,7 +58,6 @@ pub contract PrivateVoting {
         let new_tally = self.storage.tally.at(election_id).at(candidate).read() + 1;
         self.storage.tally.at(election_id).at(candidate).write(new_tally);
     }
-    // docs:end:nested_map_access
 
     #[external("public")]
     fn start_vote(election_id: ElectionId) {

--- a/noir-projects/noir-contracts/contracts/app/token_blacklist_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_blacklist_contract/src/main.nr
@@ -61,7 +61,6 @@ pub contract TokenBlacklist {
         roles: Map<AztecAddress, DelayedPublicMutable<UserFlags, CHANGE_ROLES_DELAY, Context>, Context>,
     }
 
-    // docs:start:constructor
     #[external("public")]
     #[initializer]
     fn constructor(admin: AztecAddress) {
@@ -221,7 +220,6 @@ pub contract TokenBlacklist {
         self.enqueue_self._increase_public_balance(to, amount);
     }
 
-    // docs:start:transfer_private
     #[authorize_once("from", "authwit_nonce")]
     #[external("private")]
     fn transfer(from: AztecAddress, to: AztecAddress, amount: u128, authwit_nonce: Field) {

--- a/noir-projects/noir-contracts/contracts/app/token_bridge_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_bridge_contract/src/main.nr
@@ -114,7 +114,6 @@ pub contract TokenBridge {
         self.call(Token::at(config.token).mint_to_private(recipient, amount));
     }
 
-    // docs:start:exit_to_l1_private
     // Burns the appropriate amount of tokens and creates a L2 to L1 withdraw message privately
     // Requires `msg.sender` (caller of the method) to give approval to the bridge to burn tokens on their behalf using witness signatures
     #[external("private")]
@@ -137,5 +136,4 @@ pub contract TokenBridge {
         // Burn tokens
         self.call(Token::at(token).burn_private(self.msg_sender(), amount, authwit_nonce));
     }
-    // docs:end:exit_to_l1_private
 }

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/main.nr
@@ -1,4 +1,3 @@
-// docs:start:imports
 mod test;
 
 use aztec::macros::aztec;
@@ -33,8 +32,6 @@ pub contract Token {
 
     use balance_set::BalanceSet;
 
-    // docs:end::imports
-
     // In the first transfer iteration we are computing a lot of additional information (validating inputs, retrieving
     // keys, etc.), so the gate count is already relatively high. We therefore only read a few notes to keep the happy
     // case with few constraints.
@@ -51,7 +48,6 @@ pub contract Token {
         amount: u128,
     }
 
-    // docs:start:storage_struct
     #[storage]
     struct Storage<Context> {
         admin: PublicMutable<AztecAddress, Context>,
@@ -63,9 +59,7 @@ pub contract Token {
         name: PublicImmutable<FieldCompressedString, Context>,
         decimals: PublicImmutable<u8, Context>,
     }
-    // docs:end:storage_struct
 
-    // docs:start:constructor
     #[external("public")]
     #[initializer]
     fn constructor(admin: AztecAddress, name: str<31>, symbol: str<31>, decimals: u8) {
@@ -76,7 +70,6 @@ pub contract Token {
         self.storage.symbol.initialize(FieldCompressedString::from_string(symbol));
         self.storage.decimals.initialize(decimals);
     }
-    // docs:end:constructor
 
     #[external("public")]
     fn set_admin(new_admin: AztecAddress) {
@@ -84,7 +77,6 @@ pub contract Token {
         self.storage.admin.write(new_admin);
     }
 
-    // docs:start:public_immutable_read
     #[external("public")]
     #[view]
     fn public_get_name() -> FieldCompressedString {
@@ -96,7 +88,6 @@ pub contract Token {
     fn private_get_name() -> FieldCompressedString {
         self.storage.name.read()
     }
-    // docs:end:public_immutable_read
 
     #[external("public")]
     #[view]
@@ -312,9 +303,7 @@ pub contract Token {
         amount: u128,
         authwit_nonce: Field,
     ) {
-        // docs:start:increase_private_balance
         self.storage.balances.at(from).sub(amount).deliver(MessageDelivery.ONCHAIN_CONSTRAINED);
-        // docs:end:increase_private_balance
         self.storage.balances.at(to).add(amount).deliver(MessageDelivery.ONCHAIN_CONSTRAINED);
     }
     // docs:end:transfer_in_private
@@ -352,14 +341,12 @@ pub contract Token {
     /// us to have it inlined in the `transfer_to_private` function which results in one fewer kernel iteration. Note
     /// that in this case we don't pass `completer` as an argument to this function because in all the callsites we
     /// want to use the message sender as the completer anyway.
-    // docs:start:prepare_private_balance_increase
     #[internal("private")]
     fn _prepare_private_balance_increase(to: AztecAddress) -> PartialUintNote {
         let partial_note = UintNote::partial(to, self.context, to, self.msg_sender());
 
         partial_note
     }
-    // docs:end:prepare_private_balance_increase
 
     /// Finalizes a transfer of token `amount` from public balance of `msg_sender` to a private balance of `to`.
     /// The transfer must be prepared by calling `prepare_private_balance_increase` from `msg_sender` account and
@@ -420,7 +407,6 @@ pub contract Token {
     // In all the flows in this contract, `from` (the account from which we're subtracting the `amount`) and
     // `completer` (the entity that can complete the partial note) are the same so we represent them with a single
     // argument.
-    // docs:start:finalize_transfer_to_private
     #[internal("public")]
     fn _finalize_transfer_to_private(
         from_and_completer: AztecAddress,
@@ -441,7 +427,6 @@ pub contract Token {
             amount,
         );
     }
-    // docs:end:finalize_transfer_to_private
 
     /// Mints token `amount` to a private balance of `to`. Message sender has to have minter permissions (checked
     /// in the enqueued call).

--- a/noir-projects/noir-contracts/contracts/app/uniswap_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/uniswap_contract/src/main.nr
@@ -1,4 +1,3 @@
-// docs:start:uniswap_setup
 mod util;
 
 // Demonstrates how to use portal contracts to swap on L1 Uniswap with funds on L2
@@ -36,9 +35,7 @@ pub contract Uniswap {
     fn constructor(portal_address: EthAddress) {
         self.storage.portal_address.initialize(portal_address);
     }
-    // docs:end:uniswap_setup
 
-    // docs:start:swap_public
     #[external("public")]
     fn swap_public(
         sender: AztecAddress,
@@ -107,9 +104,7 @@ pub contract Uniswap {
         );
         self.context.message_portal(self.storage.portal_address.read(), content_hash);
     }
-    // docs:end:swap_public
 
-    // docs:start:swap_private
     #[external("private")]
     fn swap_private(
         input_asset: AztecAddress, // since private, we pass here and later assert that this is as expected by input_bridge
@@ -175,7 +170,6 @@ pub contract Uniswap {
         );
         self.context.message_portal(self.storage.portal_address.read(), content_hash);
     }
-    // docs:end:swap_private
 
     // docs:start:authwit_uniswap_set
     // This helper method approves the bridge to burn this contract's funds and exits the input asset to L1

--- a/noir-projects/noir-contracts/contracts/app/uniswap_contract/src/util.nr
+++ b/noir-projects/noir-contracts/contracts/app/uniswap_contract/src/util.nr
@@ -1,4 +1,3 @@
-// docs:start:uniswap_public_content_hash
 use aztec::protocol::{address::{AztecAddress, EthAddress}, hash::sha256_to_field, traits::ToField};
 
 // This method computes the L2 to L1 message content hash for the public
@@ -54,9 +53,7 @@ pub fn compute_swap_public_content_hash(
     let content_hash = sha256_to_field(hash_bytes);
     content_hash
 }
-// docs:end:uniswap_public_content_hash
 
-// docs:start:compute_swap_private_content_hash
 // This method computes the L2 to L1 message content hash for the private
 // refer `l1-contracts/test/portals/UniswapPortal.sol` on how L2 to L1 message is expected
 pub fn compute_swap_private_content_hash(
@@ -106,4 +103,3 @@ pub fn compute_swap_private_content_hash(
     let content_hash = sha256_to_field(hash_bytes);
     content_hash
 }
-// docs:end:compute_swap_private_content_hash

--- a/noir-projects/noir-contracts/contracts/fees/fpc_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/fees/fpc_contract/src/main.nr
@@ -82,7 +82,6 @@ pub contract FPC {
     /// - the `max_fee`,
     /// - which FPC has been used to make the payment,
     /// - the asset which was used to make the payment.
-    // docs:start:fee_entrypoint_private
     #[external("private")]
     #[allow_phase_change]
     fn fee_entrypoint_private(max_fee: u128, authwit_nonce: Field) {
@@ -112,11 +111,9 @@ pub contract FPC {
         // End the setup phase, from now on all side effects are revertible
         self.context.end_setup();
     }
-    // docs:end:fee_entrypoint_private
 
     /// Executed as a public teardown function and is responsible for completing the refund in the private fee payment
     /// flow.
-    // docs:start:complete_refund
     #[external("public")]
     #[only_self]
     fn _complete_refund(
@@ -138,7 +135,6 @@ pub contract FPC {
             self.context,
         );
     }
-    // docs:end:complete_refund
 
     /// Pays for the tx fee with msg_sender's public balance of accepted asset (AA). The maximum fee a user is willing
     /// to pay is defined by `max_fee` and is denominated in AA.

--- a/noir-projects/noir-contracts/contracts/test/counter/counter_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/counter/counter_contract/src/main.nr
@@ -1,10 +1,7 @@
-// docs:start:setup
 use aztec::macros::aztec;
 
 #[aztec]
 pub contract Counter {
-    // docs:end:setup
-    // docs:start:imports
     use aztec::{
         macros::{functions::{external, initializer}, storage::storage},
         messages::message_delivery::MessageDelivery,
@@ -13,16 +10,12 @@ pub contract Counter {
         state_vars::Owned,
     };
     use balance_set::BalanceSet;
-    // docs:end:imports
 
-    // docs:start:storage_struct
     #[storage]
     struct Storage<Context> {
         counters: Owned<BalanceSet<Context>, Context>,
     }
-    // docs:end:storage_struct
 
-    // docs:start:constructor
     #[initializer]
     #[external("private")]
     // We can name our initializer anything we want as long as it's marked as aztec(initializer)
@@ -31,15 +24,12 @@ pub contract Counter {
             MessageDelivery.ONCHAIN_CONSTRAINED,
         );
     }
-    // docs:end:constructor
 
-    // docs:start:increment
     #[external("private")]
     fn increment(owner: AztecAddress) {
         debug_log_format("Incrementing counter for owner {0}", [owner.to_field()]);
         self.storage.counters.at(owner).add(1).deliver(MessageDelivery.ONCHAIN_CONSTRAINED);
     }
-    // docs:end:increment
 
     #[external("private")]
     fn increment_twice(owner: AztecAddress) {
@@ -67,12 +57,10 @@ pub contract Counter {
         self.storage.counters.at(owner).sub(1).deliver(MessageDelivery.ONCHAIN_CONSTRAINED);
     }
 
-    // docs:start:get_counter
     #[external("utility")]
     unconstrained fn get_counter(owner: AztecAddress) -> u128 {
         self.storage.counters.at(owner).balance_of()
     }
-    // docs:end:get_counter
 
     #[external("private")]
     fn increment_self_and_other(other_counter: AztecAddress, owner: AztecAddress) {

--- a/noir-projects/noir-contracts/contracts/test/pending_note_hashes_contract/src/filter.nr
+++ b/noir-projects/noir-contracts/contracts/test/pending_note_hashes_contract/src/filter.nr
@@ -1,6 +1,4 @@
-// docs:start:custom_filter_imports
 use aztec::{note::HintedNote, protocol::constants::MAX_NOTE_HASH_READ_REQUESTS_PER_CALL};
-// docs:end:custom_filter_imports
 use field_note::FieldNote;
 
 // docs:start:custom_filter

--- a/noir-projects/noir-protocol-circuits/crates/serde/src/serialization.nr
+++ b/noir-projects/noir-protocol-circuits/crates/serde/src/serialization.nr
@@ -1,6 +1,5 @@
 use crate::{reader::Reader, writer::Writer};
 
-// docs:start:serialize
 /// Trait for serializing Noir types into arrays of Fields.
 ///
 /// An implementation of the Serialize trait has to follow Noir's intrinsic serialization (each member of a struct
@@ -125,7 +124,6 @@ pub comptime fn derive_serialize(s: TypeDefinition) -> Quoted {
     }
 }
 
-// docs:start:deserialize
 /// Trait for deserializing Noir types from arrays of Fields.
 ///
 /// An implementation of the Deserialize trait has to follow Noir's intrinsic serialization (each member of a struct

--- a/yarn-project/cli-wallet/test/flows/basic.sh
+++ b/yarn-project/cli-wallet/test/flows/basic.sh
@@ -6,9 +6,7 @@ test_title "Basic flow"
 
 AMOUNT=42
 
-# docs:start:import-test-accounts
 aztec-wallet import-test-accounts
-# docs:end:import-test-accounts
 aztec-wallet deploy token_contract@Token --args accounts:test0 Test TST 18 -f test0
 aztec-wallet send mint_to_public -ca last --args accounts:test0 $AMOUNT -f test0
 RESULT=$(aztec-wallet simulate balance_of_public -ca last --args accounts:test0 -f test0 | grep "Simulation result:" | awk '{print $3}')

--- a/yarn-project/cli-wallet/test/flows/create_account_pay_native.sh
+++ b/yarn-project/cli-wallet/test/flows/create_account_pay_native.sh
@@ -5,10 +5,8 @@ source shared/setup.sh
 
 test_title "Create an account and deploy using native fee payment with bridging"
 
-# docs:start:bridge-fee-juice
 aztec-wallet create-account -a main --register-only
 aztec-wallet bridge-fee-juice 1000000000000000000000 main --mint --no-wait
-# docs:end:bridge-fee-juice
 
 
 section "Use a pre-funded test account to send dummy txs to force block creations"
@@ -19,9 +17,7 @@ aztec-wallet send increment -ca counter --args accounts:test0 -f test0
 
 section "Deploy main account claiming the fee juice, use it later"
 
-# docs:start:claim-deploy-account
 aztec-wallet deploy-account main --payment method=fee_juice,claim
-# docs:end:claim-deploy-account
 aztec-wallet send increment -ca counter --args accounts:main -f main
 aztec-wallet send increment -ca counter --args accounts:main -f main
 

--- a/yarn-project/end-to-end/src/composed/e2e_local_network_example.test.ts
+++ b/yarn-project/end-to-end/src/composed/e2e_local_network_example.test.ts
@@ -34,7 +34,6 @@ const { AZTEC_NODE_URL = 'http://localhost:8080' } = process.env;
 describe('e2e_local_network_example', () => {
   it('local network example works', async () => {
     ////////////// CREATE THE CLIENT INTERFACE AND CONTACT THE LOCAL NETWORK //////////////
-    // docs:start:setup
     const logger = createLogger('e2e:token');
 
     // We create PXE client connected to the local network URL
@@ -46,8 +45,6 @@ describe('e2e_local_network_example', () => {
     const nodeInfo = await node.getNodeInfo();
 
     logger.info(format('Aztec Local Network Info ', nodeInfo));
-
-    // docs:end:setup
 
     expect(typeof nodeInfo.rollupVersion).toBe('number');
     expect(typeof nodeInfo.l1ChainId).toBe('number');
@@ -182,7 +179,6 @@ describe('e2e_local_network_example', () => {
     ////////////// USE A NEW ACCOUNT TO SEND A TX AND PAY WITH BANANA COIN //////////////
     const amountTransferToBob = 100n;
     const bananaFPCAddress = await registerDeployedBananaFPCInWalletAndGetAddress(wallet);
-    // docs:start:private_fpc_payment
     // The private fee paying method assembled on the app side requires knowledge of the maximum
     // fee the user is willing to pay
     const maxFeesPerGas = (await node.getCurrentMinFees()).mul(1.5);
@@ -191,7 +187,6 @@ describe('e2e_local_network_example', () => {
     const { receipt: receiptForAlice } = await bananaCoin.methods
       .transfer(bob, amountTransferToBob)
       .send({ from: alice, fee: { paymentMethod } });
-    // docs:end:private_fpc_payment
     const transactionFee = receiptForAlice.transactionFee!;
     logger.info(`Transaction fee: ${transactionFee}`);
 
@@ -208,7 +203,6 @@ describe('e2e_local_network_example', () => {
     const amountTransferToAlice = 48n;
 
     const sponsoredFPC = await registerDeployedSponsoredFPCInWalletAndGetAddress(wallet);
-    // docs:start:sponsored_fpc_payment
     const sponsoredPaymentMethod = new SponsoredFeePaymentMethod(sponsoredFPC);
     // The payment method can also be initialized as follows:
     // const sponsoredPaymentMethod = await SponsoredFeePaymentMethod.new(pxe);
@@ -217,7 +211,6 @@ describe('e2e_local_network_example', () => {
     const { receipt: receiptForBob } = await bananaCoin.methods
       .transfer(alice, amountTransferToAlice)
       .send({ from: bob, fee: { paymentMethod: sponsoredPaymentMethod } });
-    // docs:end:sponsored_fpc_payment
     // Check the balances
     const { result: aliceNewBalance } = await bananaCoin.methods.balance_of_private(alice).simulate({ from: alice });
     logger.info(`Alice's new balance: ${aliceNewBalance}`);

--- a/yarn-project/end-to-end/src/composed/e2e_token_bridge_tutorial_test.test.ts
+++ b/yarn-project/end-to-end/src/composed/e2e_token_bridge_tutorial_test.test.ts
@@ -1,5 +1,4 @@
 // This test should only use packages that are published to npm
-// docs:start:imports
 import { EthAddress } from '@aztec/aztec.js/addresses';
 import { waitForProven } from '@aztec/aztec.js/contracts';
 import { L1TokenManager, L1TokenPortalManager } from '@aztec/aztec.js/ethereum';
@@ -25,8 +24,6 @@ import { getContract } from 'viem';
 
 import { TestWallet } from '../test-wallet/test_wallet.js';
 
-// docs:end:imports
-// docs:start:utils
 const MNEMONIC = 'test test test test test test test test test test test junk';
 const { ETHEREUM_HOSTS = 'http://localhost:8545' } = process.env;
 
@@ -71,7 +68,6 @@ async function addMinter(l1TokenContract: EthAddress, l1TokenHandler: EthAddress
   });
   await contract.write.addMinter([l1TokenHandler.toString()]);
 }
-// docs:end:utils
 
 // To run these tests against a local network:
 // 1. Start a local Ethereum node (Anvil):
@@ -85,7 +81,6 @@ async function addMinter(l1TokenContract: EthAddress, l1TokenHandler: EthAddress
 //    yarn test:e2e e2e_token_bridge_tutorial_test.test.ts
 describe('e2e_cross_chain_messaging token_bridge_tutorial_test', () => {
   it('Deploys tokens & bridges to L1 & L2, mints & publicly bridges tokens', async () => {
-    // docs:start:setup
     const logger = createLogger('aztec:token-bridge-tutorial');
     const { wallet, node } = await setupLocalNetwork();
     const [ownerAztecAddress] = await registerInitialLocalNetworkAccountsInWallet(wallet);
@@ -95,10 +90,8 @@ describe('e2e_cross_chain_messaging token_bridge_tutorial_test', () => {
     logger.info(`Inbox Address: ${l1ContractAddresses.inboxAddress}`);
     logger.info(`Outbox Address: ${l1ContractAddresses.outboxAddress}`);
     logger.info(`Rollup Address: ${l1ContractAddresses.rollupAddress}`);
-    // docs:end:setup
 
     // Deploy L2 token contract
-    // docs:start:deploy-l2-token
     const { contract: l2TokenContract } = await TokenContract.deploy(
       wallet,
       ownerAztecAddress,
@@ -109,10 +102,8 @@ describe('e2e_cross_chain_messaging token_bridge_tutorial_test', () => {
       from: ownerAztecAddress,
     });
     logger.info(`L2 token contract deployed at ${l2TokenContract.address}`);
-    // docs:end:deploy-l2-token
 
     // Deploy L1 token contract & mint tokens
-    // docs:start:deploy-l1-token
     const l1TokenContract = await deployTestERC20();
     logger.info('erc20 contract deployed');
 
@@ -120,10 +111,8 @@ describe('e2e_cross_chain_messaging token_bridge_tutorial_test', () => {
     await addMinter(l1TokenContract, feeAssetHandler);
 
     const l1TokenManager = new L1TokenManager(l1TokenContract, feeAssetHandler, l1Client, logger);
-    // docs:end:deploy-l1-token
 
     // Deploy L1 portal contract
-    // docs:start:deploy-portal
     const l1PortalContractAddress = await deployTokenPortal();
     logger.info('L1 portal contract deployed');
 
@@ -132,24 +121,18 @@ describe('e2e_cross_chain_messaging token_bridge_tutorial_test', () => {
       abi: TokenPortalAbi,
       client: l1Client,
     });
-    // docs:end:deploy-portal
     // Deploy L2 bridge contract
-    // docs:start:deploy-l2-bridge
     const { contract: l2BridgeContract } = await TokenBridgeContract.deploy(
       wallet,
       l2TokenContract.address,
       l1PortalContractAddress,
     ).send({ from: ownerAztecAddress });
     logger.info(`L2 token bridge contract deployed at ${l2BridgeContract.address}`);
-    // docs:end:deploy-l2-bridge
 
     // Set Bridge as a minter
-    // docs:start:authorize-l2-bridge
     await l2TokenContract.methods.set_minter(l2BridgeContract.address, true).send({ from: ownerAztecAddress });
-    // docs:end:authorize-l2-bridge
 
     // Initialize L1 portal contract
-    // docs:start:setup-portal
     await l1Portal.write.initialize(
       [l1ContractAddresses.registryAddress.toString(), l1TokenContract.toString(), l2BridgeContract.address.toString()],
       {},
@@ -164,19 +147,15 @@ describe('e2e_cross_chain_messaging token_bridge_tutorial_test', () => {
       l1Client,
       logger,
     );
-    // docs:end:setup-portal
 
-    // docs:start:l1-bridge-public
     const claim = await l1PortalManager.bridgeTokensPublic(ownerAztecAddress, MINT_AMOUNT, true);
 
     // Do 2 unrelated actions because
     // https://github.com/AztecProtocol/aztec-packages/blob/7e9e2681e314145237f95f79ffdc95ad25a0e319/yarn-project/end-to-end/src/shared/cross_chain_test_harness.ts#L354-L355
     await l2TokenContract.methods.mint_to_public(ownerAztecAddress, 0n).send({ from: ownerAztecAddress });
     await l2TokenContract.methods.mint_to_public(ownerAztecAddress, 0n).send({ from: ownerAztecAddress });
-    // docs:end:l1-bridge-public
 
     // Claim tokens publicly on L2
-    // docs:start:claim
     await l2BridgeContract.methods
       .claim_public(ownerAztecAddress, MINT_AMOUNT, claim.claimSecret, claim.messageLeafIndex)
       .send({ from: ownerAztecAddress });
@@ -184,11 +163,9 @@ describe('e2e_cross_chain_messaging token_bridge_tutorial_test', () => {
       .balance_of_public(ownerAztecAddress)
       .simulate({ from: ownerAztecAddress });
     logger.info(`Public L2 balance of ${ownerAztecAddress} is ${balance}`);
-    // docs:end:claim
 
     logger.info('Withdrawing funds from L2');
 
-    // docs:start:setup-withdrawal
     const withdrawAmount = 9n;
     const authwitNonce = Fr.random();
 
@@ -202,9 +179,7 @@ describe('e2e_cross_chain_messaging token_bridge_tutorial_test', () => {
       true,
     );
     await authwit.send();
-    // docs:end:setup-withdrawal
 
-    // docs:start:l2-withdraw
     const l2ToL1Message = await l1PortalManager.getL2ToL1MessageLeaf(
       withdrawAmount,
       EthAddress.fromString(ownerEthAddress),
@@ -220,9 +195,7 @@ describe('e2e_cross_chain_messaging token_bridge_tutorial_test', () => {
       .balance_of_public(ownerAztecAddress)
       .simulate({ from: ownerAztecAddress });
     logger.info(`New L2 balance of ${ownerAztecAddress} is ${newL2Balance}`);
-    // docs:end:l2-withdraw
 
-    // docs:start:l1-withdraw
     const result = await computeL2ToL1MembershipWitness(node, l2ToL1Message, l2TxReceipt.txHash);
     if (!result) {
       throw new Error('L2 to L1 message not found');
@@ -237,7 +210,6 @@ describe('e2e_cross_chain_messaging token_bridge_tutorial_test', () => {
     );
     const newL1Balance = await l1TokenManager.getL1TokenBalance(ownerEthAddress);
     logger.info(`New L1 balance of ${ownerEthAddress} is ${newL1Balance}`);
-    // docs:end:l1-withdraw
     expect(newL1Balance).toBe(withdrawAmount);
   }, 300_000);
 });

--- a/yarn-project/end-to-end/src/composed/uniswap_trade_on_l1_from_l2.test.ts
+++ b/yarn-project/end-to-end/src/composed/uniswap_trade_on_l1_from_l2.test.ts
@@ -9,7 +9,6 @@ const EXPECTED_FORKED_BLOCK = 0; //17514288;
 
 let teardown: () => Promise<void>;
 
-// docs:start:uniswap_setup
 const testSetup = async () => {
   const context = await e2eSetup(2, { stateLoad: dumpedState, startProverNode: true });
 
@@ -17,7 +16,6 @@ const testSetup = async () => {
 
   return context;
 };
-// docs:end:uniswap_setup
 
 const testCleanup = async () => {
   await teardown();

--- a/yarn-project/end-to-end/src/guides/up_quick_start.sh
+++ b/yarn-project/end-to-end/src/guides/up_quick_start.sh
@@ -18,10 +18,8 @@ aztec-wallet() {
 
 aztec-wallet import-test-accounts
 
-# docs:start:declare-accounts
 aztec-wallet create-account -a alice -f test0
 aztec-wallet create-account -a bob -f test0
-# docs:end:declare-accounts
 
 aztec-wallet bridge-fee-juice 1000000000000000000000 accounts:alice --mint --no-wait
 

--- a/yarn-project/end-to-end/src/shared/gas_portal_test_harness.ts
+++ b/yarn-project/end-to-end/src/shared/gas_portal_test_harness.ts
@@ -178,4 +178,3 @@ export class GasBridgingTestHarness implements IGasBridgingTestHarness {
     }
   }
 }
-// docs:end:cross_chain_test_harness

--- a/yarn-project/end-to-end/src/shared/uniswap_l1_l2.ts
+++ b/yarn-project/end-to-end/src/shared/uniswap_l1_l2.ts
@@ -154,7 +154,6 @@ export const uniswapL1L2TestSuite = (
       await cleanup();
     });
 
-    // docs:start:uniswap_private
     it('should uniswap trade on L1 from L2 funds privately (swaps WETH -> DAI)', async () => {
       const wethL1BeforeBalance = await wethCrossChainHarness.getL1BalanceOf(ownerEthAddress);
 
@@ -345,10 +344,8 @@ export const uniswapL1L2TestSuite = (
       logger.info('WETH balance after swap : ', wethL2BalanceAfterSwap.toString());
       logger.info('DAI balance after swap  : ', daiL2BalanceAfterSwap.toString());
     });
-    // docs:end:uniswap_private
 
     // TODO(#7463): reenable look into this failure https://github.com/AztecProtocol/aztec-packages/actions/runs/9912612912/job/27388320150?pr=7462
-    // // docs:start:uniswap_public
     // it('should uniswap trade on L1 from L2 funds publicly (swaps WETH -> DAI)', async () => {
     //   const wethL1BeforeBalance = await wethCrossChainHarness.getL1BalanceOf(ownerEthAddress);
 
@@ -581,7 +578,6 @@ export const uniswapL1L2TestSuite = (
     //   logger.info('WETH balance after swap : ', wethL2BalanceAfterSwap.toString());
     //   logger.info('DAI balance after swap  : ', daiL2BalanceAfterSwap.toString());
     // });
-    // // docs:end:uniswap_public
 
     // Edge cases for the private flow:
     // note - tests for uniswapPortal.sol and minting asset on L2 are covered in other tests.

--- a/yarn-project/pxe/src/contract_function_simulator/contract_function_simulator.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/contract_function_simulator.ts
@@ -309,7 +309,6 @@ export class ContractFunctionSimulator {
     }
   }
 
-  // docs:start:execute_utility_function
   /**
    * Runs a utility function.
    * @param call - The function call to execute.
@@ -384,7 +383,6 @@ export class ContractFunctionSimulator {
       throw createSimulationError(err instanceof Error ? err : new Error('Unknown error during private execution'));
     }
   }
-  // docs:end:execute_utility_function
 
   /**
    * Returns the execution statistics collected during the simulator run.


### PR DESCRIPTION
This fixes some links in the docsite that point to gh files to instead point to apiref pages. I also removed hundred of stale include code markers that are not being included anywhere - remnants of deleted tutorials.

I applied the link fixes to the 4.2.0 docs too.