### PR TITLE
feat!: kv-store on SQLite-wasm over OPFS

### DIFF
--- a/yarn-project/kv-store/.mocharc.json
+++ b/yarn-project/kv-store/.mocharc.json
@@ -1,7 +1,7 @@
 {
   "require": "ts-node/register",
   "extensions": ["ts"],
-  "spec": ["./src/**/!(indexeddb|bench)/*.test.ts"],
+  "spec": ["./src/**/!(indexeddb|sqlite-opfs|bench)/*.test.ts"],
   "node-option": ["experimental-specifier-resolution=node", "loader=@swc-node/register/esm"],
   "timeout": 30000
 }

--- a/yarn-project/kv-store/package.json
+++ b/yarn-project/kv-store/package.json
@@ -8,6 +8,7 @@
     "./lmdb": "./dest/lmdb/index.js",
     "./lmdb-v2": "./dest/lmdb-v2/index.js",
     "./indexeddb": "./dest/indexeddb/index.js",
+    "./sqlite-opfs": "./dest/sqlite-opfs/index.js",
     "./stores": "./dest/stores/index.js"
   },
   "scripts": {
@@ -29,6 +30,7 @@
     "@aztec/foundation": "workspace:^",
     "@aztec/native": "workspace:^",
     "@aztec/stdlib": "workspace:^",
+    "@sqlite.org/sqlite-wasm": "3.50.4-build1",
     "idb": "^8.0.0",
     "lmdb": "^3.2.0",
     "msgpackr": "^1.11.2",

--- a/yarn-project/kv-store/package.json
+++ b/yarn-project/kv-store/package.json
@@ -17,6 +17,7 @@
     "clean": "rm -rf ./dest .tsbuildinfo",
     "test:node": "NODE_NO_WARNINGS=1 mocha --config ./.mocharc.json",
     "test:browser": "vitest run --config ./vitest.config.ts",
+    "bench:browser": "VITE_BENCH=1 vitest run --config ./vitest.config.ts src/bench",
     "test": "yarn test:node && yarn test:browser",
     "test:jest": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --passWithNoTests --maxWorkers=${JEST_MAX_WORKERS:-8}"
   },

--- a/yarn-project/kv-store/src/bench/indexeddb/map_bench.test.ts
+++ b/yarn-project/kv-store/src/bench/indexeddb/map_bench.test.ts
@@ -1,0 +1,26 @@
+/**
+ * Map benchmark suite for the IndexedDB backend. Runs in vitest-browser.
+ * Skipped by default; set `VITE_BENCH=1` to run (or invoke this file directly
+ * via `yarn test:browser src/bench/indexeddb/map_bench.test.ts`).
+ */
+import { createLogger } from '@aztec/foundation/log';
+
+import { AztecIndexedDBStore } from '../../indexeddb/store.js';
+import { mockLogger } from '../../interfaces/utils.js';
+import { describeAztecMapBench } from '../shared_map_bench.js';
+
+const shouldRun = (import.meta as ImportMeta & { env?: { VITE_BENCH?: string } }).env?.VITE_BENCH === '1';
+
+if (shouldRun) {
+  describeAztecMapBench(
+    'IndexedDB',
+    () => AztecIndexedDBStore.open(mockLogger, undefined, true),
+    createLogger('kv-store:map:benchmarks:indexeddb'),
+    // Browser bench: nothing to write to disk; shared reporter already logs via logger.
+    () => {},
+  );
+} else {
+  describe.skip('IndexedDB Map benchmarks (set VITE_BENCH=1 to run)', () => {
+    it('skipped', () => {});
+  });
+}

--- a/yarn-project/kv-store/src/bench/map_bench.test.ts
+++ b/yarn-project/kv-store/src/bench/map_bench.test.ts
@@ -1,136 +1,21 @@
 import { createLogger } from '@aztec/foundation/log';
-import { Timer } from '@aztec/foundation/timer';
 
 import { mkdir, writeFile } from 'fs/promises';
 import path from 'path';
 
-import type { Key } from '../interfaces/common.js';
 import { openTmpStore } from '../lmdb-v2/factory.js';
-import { LMDBMap } from '../lmdb-v2/map.js';
-import type { AztecLMDBStoreV2 } from '../lmdb-v2/store.js';
+import { type BenchResult, describeAztecMapBench } from './shared_map_bench.js';
 
-describe('LMDBMap benchmarks', () => {
-  const logger = createLogger('kv-store:map:benchmarks');
-  let store: AztecLMDBStoreV2;
-  let map: LMDBMap<Key, string>;
+const logger = createLogger('kv-store:map:benchmarks:lmdb-v2');
 
-  const results: { name: string; value: number; unit: string }[] = [];
+async function nodeReporter(results: BenchResult[]): Promise<void> {
+  if (process.env.BENCH_OUTPUT) {
+    await mkdir(path.dirname(process.env.BENCH_OUTPUT), { recursive: true });
+    await writeFile(process.env.BENCH_OUTPUT, JSON.stringify(results, null, 2));
+  } else if (process.env.BENCH_OUTPUT_MD) {
+    const md = results.map(r => `${r.name}: ${r.value.toFixed(2)} ${r.unit}`).join('\n');
+    await writeFile(process.env.BENCH_OUTPUT_MD, md);
+  }
+}
 
-  const toPrettyString = () => {
-    return results.map(({ name, value, unit }) => `Map/${name}: ${value.toFixed(2)} ${unit}`).join('\n');
-  };
-
-  const toGithubActionBenchmarkJSON = (indent = 2) => {
-    const prefixed = results.map(({ name, value, unit }) => ({ name: `Map/${name}`, value, unit }));
-    return JSON.stringify(prefixed, null, indent);
-  };
-
-  beforeEach(async () => {
-    store = await openTmpStore('test');
-    map = new LMDBMap(store, 'test');
-  });
-
-  afterEach(async () => {
-    await store.delete();
-  });
-
-  afterAll(async () => {
-    if (process.env.BENCH_OUTPUT) {
-      await mkdir(path.dirname(process.env.BENCH_OUTPUT), { recursive: true });
-      await writeFile(process.env.BENCH_OUTPUT, toGithubActionBenchmarkJSON());
-    } else if (process.env.BENCH_OUTPUT_MD) {
-      await writeFile(process.env.BENCH_OUTPUT_MD, toPrettyString());
-    } else {
-      logger.info(`\n`); // sometimes jest tests obscure the last line(s)
-      logger.info(toPrettyString());
-      logger.info(`\n`);
-    }
-  });
-
-  const generateKeyValuePairs = (count: number, offset = 0) => {
-    const keys = Array.from({ length: count }, (_, i) => `key-${i + offset}`);
-    const values = Array.from({ length: count }, (_, i) => `value-${i + offset}`);
-    return keys.map((key, i) => ({ key: key, value: values[i] }));
-  };
-
-  it('adds individual values', async () => {
-    const pairs = generateKeyValuePairs(1000);
-
-    const timer = new Timer();
-    for (let i = 0; i < pairs.length; i++) {
-      await map.set(pairs[i].key, pairs[i].value);
-    }
-    const duration = timer.ms() / pairs.length;
-    results.push({
-      name: 'Individual insertion',
-      unit: 'ms',
-      value: duration,
-    });
-  });
-
-  it('adds batched values', async () => {
-    const pairs = Array.from({ length: 100 }, (_, i) => generateKeyValuePairs(1000, i * 1000));
-
-    const timer = new Timer();
-    for (let i = 0; i < pairs.length; i++) {
-      await map.setMany(pairs[i]);
-    }
-    const duration = timer.ms() / pairs.length;
-    results.push({
-      name: `Batch insertion of ${pairs[0].length} items`,
-      unit: 'ms',
-      value: duration,
-    });
-  });
-
-  it('reads individual values', async () => {
-    const pairs = generateKeyValuePairs(10000);
-    await map.setMany(pairs);
-
-    const timer = new Timer();
-    for (let i = 0; i < pairs.length; i++) {
-      await map.getAsync(pairs[i].key);
-    }
-    const duration = (timer.ms() * 1000) / pairs.length;
-    results.push({
-      name: 'Individual read',
-      unit: 'us',
-      value: duration,
-    });
-  });
-
-  it('reads via a cursor', async () => {
-    const pairs = generateKeyValuePairs(10000);
-    await map.setMany(pairs);
-
-    const timer = new Timer();
-    const iterator = map.entriesAsync();
-    for await (const _ of iterator) {
-      // do nothing
-    }
-    const duration = (timer.ms() * 1000) / pairs.length;
-    results.push({
-      name: `Iterator per item read of ${pairs.length} items`,
-      unit: 'us',
-      value: duration,
-    });
-  });
-
-  it('reads the size of the map', async () => {
-    const numIterations = 1000;
-    const numItems = 10000;
-    const pairs = generateKeyValuePairs(numItems);
-    await map.setMany(pairs);
-
-    const timer = new Timer();
-    for (let i = 0; i < numIterations; i++) {
-      await map.sizeAsync();
-    }
-    const duration = (timer.ms() * 1000) / numIterations;
-    results.push({
-      name: `Read size of ${pairs.length} items`,
-      unit: 'us',
-      value: duration,
-    });
-  });
-});
+describeAztecMapBench('LMDB-v2', () => openTmpStore('test'), logger, nodeReporter);

--- a/yarn-project/kv-store/src/bench/shared_map_bench.ts
+++ b/yarn-project/kv-store/src/bench/shared_map_bench.ts
@@ -1,4 +1,4 @@
-import { type Logger } from '@aztec/foundation/log';
+import type { Logger } from '@aztec/foundation/log';
 import { Timer } from '@aztec/foundation/timer';
 
 import type { Key } from '../interfaces/common.js';

--- a/yarn-project/kv-store/src/bench/shared_map_bench.ts
+++ b/yarn-project/kv-store/src/bench/shared_map_bench.ts
@@ -1,0 +1,111 @@
+import { type Logger } from '@aztec/foundation/log';
+import { Timer } from '@aztec/foundation/timer';
+
+import type { Key } from '../interfaces/common.js';
+import type { AztecAsyncMap } from '../interfaces/map.js';
+import type { AztecAsyncKVStore } from '../interfaces/store.js';
+
+/** One benchmark measurement. */
+export type BenchResult = {
+  /** Benchmark name (includes the backend prefix for disambiguation). */
+  name: string;
+  value: number;
+  unit: 'ms' | 'us';
+};
+
+export type BenchReporter = (results: BenchResult[]) => void | Promise<void>;
+
+/**
+ * Runs the standard Map benchmark suite against any `AztecAsyncKVStore` backend,
+ * populates `results`, and calls `reporter` in `afterAll`.
+ *
+ * Kept free of Node-only deps (`fs`, `path`) so the same runner works under
+ * vitest-browser for IndexedDB and SQLite-OPFS.
+ */
+export function describeAztecMapBench(
+  backendPrefix: string,
+  getStore: () => Promise<AztecAsyncKVStore>,
+  logger: Logger,
+  reporter: BenchReporter,
+) {
+  describe(`${backendPrefix} Map benchmarks`, () => {
+    let store: AztecAsyncKVStore;
+    let map: AztecAsyncMap<Key, string>;
+
+    const results: BenchResult[] = [];
+
+    const generateKeyValuePairs = (count: number, offset = 0) => {
+      const keys = Array.from({ length: count }, (_, i) => `key-${i + offset}`);
+      const values = Array.from({ length: count }, (_, i) => `value-${i + offset}`);
+      return keys.map((key, i) => ({ key, value: values[i] }));
+    };
+
+    const record = (name: string, value: number, unit: BenchResult['unit']) => {
+      results.push({ name: `${backendPrefix}/Map/${name}`, value, unit });
+    };
+
+    beforeEach(async () => {
+      store = await getStore();
+      map = store.openMap<Key, string>('test');
+    });
+
+    afterEach(async () => {
+      await store.delete();
+    });
+
+    afterAll(async () => {
+      const pretty = results.map(r => `${r.name}: ${r.value.toFixed(2)} ${r.unit}`).join('\n');
+      logger.info(`\n${pretty}\n`);
+      await reporter(results);
+    });
+
+    it('adds individual values', async () => {
+      const pairs = generateKeyValuePairs(1000);
+      const timer = new Timer();
+      for (const pair of pairs) {
+        await map.set(pair.key, pair.value);
+      }
+      record('Individual insertion', timer.ms() / pairs.length, 'ms');
+    });
+
+    it('adds batched values', async () => {
+      const batches = Array.from({ length: 100 }, (_, i) => generateKeyValuePairs(1000, i * 1000));
+      const timer = new Timer();
+      for (const batch of batches) {
+        await map.setMany(batch);
+      }
+      record(`Batch insertion of ${batches[0].length} items`, timer.ms() / batches.length, 'ms');
+    });
+
+    it('reads individual values', async () => {
+      const pairs = generateKeyValuePairs(10000);
+      await map.setMany(pairs);
+      const timer = new Timer();
+      for (const pair of pairs) {
+        await map.getAsync(pair.key);
+      }
+      record('Individual read', (timer.ms() * 1000) / pairs.length, 'us');
+    });
+
+    it('reads via a cursor', async () => {
+      const pairs = generateKeyValuePairs(10000);
+      await map.setMany(pairs);
+      const timer = new Timer();
+      for await (const _ of map.entriesAsync()) {
+        // consume
+      }
+      record(`Iterator per item read of ${pairs.length} items`, (timer.ms() * 1000) / pairs.length, 'us');
+    });
+
+    it('reads the size of the map', async () => {
+      const numIterations = 1000;
+      const pairs = generateKeyValuePairs(10000);
+      await map.setMany(pairs);
+      const timer = new Timer();
+      for (let i = 0; i < numIterations; i++) {
+        await map.sizeAsync();
+      }
+      record(`Read size of ${pairs.length} items`, (timer.ms() * 1000) / numIterations, 'us');
+    });
+  });
+}

--- a/yarn-project/kv-store/src/bench/sqlite-opfs/map_bench.test.ts
+++ b/yarn-project/kv-store/src/bench/sqlite-opfs/map_bench.test.ts
@@ -1,0 +1,25 @@
+/**
+ * Map benchmark suite for the SQLite-OPFS backend. Runs in vitest-browser.
+ * Skipped by default; set `VITE_BENCH=1` to run (or invoke this file directly
+ * via `yarn test:browser src/bench/sqlite-opfs/map_bench.test.ts`).
+ */
+import { createLogger } from '@aztec/foundation/log';
+
+import { mockLogger } from '../../interfaces/utils.js';
+import { AztecSQLiteOPFSStore } from '../../sqlite-opfs/store.js';
+import { describeAztecMapBench } from '../shared_map_bench.js';
+
+const shouldRun = (import.meta as ImportMeta & { env?: { VITE_BENCH?: string } }).env?.VITE_BENCH === '1';
+
+if (shouldRun) {
+  describeAztecMapBench(
+    'SQLite-OPFS',
+    () => AztecSQLiteOPFSStore.open(mockLogger, undefined, true),
+    createLogger('kv-store:map:benchmarks:sqlite-opfs'),
+    () => {},
+  );
+} else {
+  describe.skip('SQLite-OPFS Map benchmarks (set VITE_BENCH=1 to run)', () => {
+    it('skipped', () => {});
+  });
+}

--- a/yarn-project/kv-store/src/sqlite-opfs/array.test.ts
+++ b/yarn-project/kv-store/src/sqlite-opfs/array.test.ts
@@ -1,0 +1,7 @@
+import { describeAztecArray } from '../interfaces/array_test_suite.js';
+import { mockLogger } from '../interfaces/utils.js';
+import { AztecSQLiteOPFSStore } from './store.js';
+
+describe('SQLiteOPFSArray', () => {
+  describeAztecArray('AztecArray', async () => await AztecSQLiteOPFSStore.open(mockLogger, undefined, true));
+});

--- a/yarn-project/kv-store/src/sqlite-opfs/array.ts
+++ b/yarn-project/kv-store/src/sqlite-opfs/array.ts
@@ -1,0 +1,124 @@
+import { Encoder } from 'msgpackr';
+import { hash } from 'ohash';
+import { toBufferKey } from 'ordered-binary';
+
+import type { AztecAsyncArray } from '../interfaces/array.js';
+import type { Value } from '../interfaces/common.js';
+import type { AztecSQLiteOPFSStore } from './store.js';
+
+/**
+ * Persistent array backed by SQLite. Entries share a common `key` (the array name)
+ * and are ordered by `key_count`, which doubles as the 1-indexed slot number.
+ */
+export class SQLiteOPFSAztecArray<T extends Value> implements AztecAsyncArray<T> {
+  readonly #name: string;
+  readonly #container: string;
+  readonly #encoder = new Encoder();
+
+  constructor(
+    private readonly store: AztecSQLiteOPFSStore,
+    name: string,
+  ) {
+    this.#name = name;
+    this.#container = `array:${name}`;
+  }
+
+  async lengthAsync(): Promise<number> {
+    const rows = await this.store.allAsync('SELECT COUNT(*) FROM data WHERE container = ? AND key = ?', [
+      this.#container,
+      this.#encodedKey(),
+    ]);
+    return Number(rows[0]?.[0] ?? 0);
+  }
+
+  async push(...vals: T[]): Promise<number> {
+    if (vals.length === 0) {
+      return this.lengthAsync();
+    }
+    return await this.store.transactionAsync(async () => {
+      let length = await this.lengthAsync();
+      for (const val of vals) {
+        await this.store.runAsync(
+          `INSERT INTO data (slot, container, key, key_count, hash, value)
+           VALUES (?, ?, ?, ?, ?, ?)`,
+          [this.#slot(length), this.#container, this.#encodedKey(), length + 1, hash(val), this.#encoder.pack(val)],
+        );
+        length += 1;
+      }
+      return length;
+    });
+  }
+
+  async pop(): Promise<T | undefined> {
+    return await this.store.transactionAsync(async () => {
+      const length = await this.lengthAsync();
+      if (length === 0) {
+        return undefined;
+      }
+      const slot = this.#slot(length - 1);
+      const rows = await this.store.allAsync('SELECT value FROM data WHERE slot = ? LIMIT 1', [slot]);
+      await this.store.runAsync('DELETE FROM data WHERE slot = ?', [slot]);
+      const raw = rows[0]?.[0];
+      return raw instanceof Uint8Array ? (this.#encoder.unpack(raw) as T) : undefined;
+    });
+  }
+
+  async atAsync(index: number): Promise<T | undefined> {
+    const length = await this.lengthAsync();
+    const resolved = index < 0 ? length + index : index;
+    if (resolved < 0 || resolved >= length) {
+      return undefined;
+    }
+    const rows = await this.store.allAsync('SELECT value FROM data WHERE slot = ? LIMIT 1', [this.#slot(resolved)]);
+    const raw = rows[0]?.[0];
+    return raw instanceof Uint8Array ? (this.#encoder.unpack(raw) as T) : undefined;
+  }
+
+  async setAt(index: number, val: T): Promise<boolean> {
+    return await this.store.transactionAsync(async () => {
+      const length = await this.lengthAsync();
+      const resolved = index < 0 ? length + index : index;
+      if (resolved < 0 || resolved >= length) {
+        return false;
+      }
+      await this.store.runAsync(
+        `INSERT OR REPLACE INTO data (slot, container, key, key_count, hash, value)
+         VALUES (?, ?, ?, ?, ?, ?)`,
+        [this.#slot(resolved), this.#container, this.#encodedKey(), resolved + 1, hash(val), this.#encoder.pack(val)],
+      );
+      return true;
+    });
+  }
+
+  async *entriesAsync(): AsyncIterableIterator<[number, T]> {
+    const rows = await this.store.allAsync(
+      'SELECT key_count, value FROM data WHERE container = ? AND key = ? ORDER BY key_count ASC',
+      [this.#container, this.#encodedKey()],
+    );
+    for (const row of rows) {
+      const keyCount = Number(row[0]);
+      const raw = row[1];
+      if (raw instanceof Uint8Array) {
+        yield [keyCount - 1, this.#encoder.unpack(raw) as T];
+      }
+    }
+  }
+
+  async *valuesAsync(): AsyncIterableIterator<T> {
+    for await (const [, val] of this.entriesAsync()) {
+      yield val;
+    }
+  }
+
+  [Symbol.asyncIterator](): AsyncIterableIterator<T> {
+    return this.valuesAsync();
+  }
+
+  #encodedKey(): Buffer {
+    return toBufferKey([this.#name]);
+  }
+
+  #slot(index: number): string {
+    return `array:${this.#name}:slot:${index}`;
+  }
+}

--- a/yarn-project/kv-store/src/sqlite-opfs/index.ts
+++ b/yarn-project/kv-store/src/sqlite-opfs/index.ts
@@ -1,0 +1,27 @@
+import { type Logger, createLogger } from '@aztec/foundation/log';
+import type { DataStoreConfig } from '@aztec/stdlib/kv-store';
+
+import { initStoreForRollupAndSchemaVersion } from '../utils.js';
+import { AztecSQLiteOPFSStore } from './store.js';
+
+export { AztecSQLiteOPFSStore } from './store.js';
+
+export async function createStore(
+  name: string,
+  config: DataStoreConfig,
+  schemaVersion: number | undefined = undefined,
+  log: Logger = createLogger('kv-store'),
+) {
+  const { dataDirectory } = config;
+  log.info(
+    dataDirectory
+      ? `Creating ${name} SQLite-OPFS data store with map size ${config.dataStoreMapSizeKb} KB`
+      : `Creating ${name} ephemeral SQLite-OPFS data store with map size ${config.dataStoreMapSizeKb} KB`,
+  );
+  const store = await AztecSQLiteOPFSStore.open(createLogger('kv-store:sqlite-opfs'), name, false);
+  return initStoreForRollupAndSchemaVersion(store, schemaVersion, config.l1Contracts?.rollupAddress, log);
+}
+
+export function openTmpStore(ephemeral: boolean = false): Promise<AztecSQLiteOPFSStore> {
+  return AztecSQLiteOPFSStore.open(createLogger('kv-store:sqlite-opfs'), undefined, ephemeral);
+}

--- a/yarn-project/kv-store/src/sqlite-opfs/map.test.ts
+++ b/yarn-project/kv-store/src/sqlite-opfs/map.test.ts
@@ -1,0 +1,7 @@
+import { describeAztecMap } from '../interfaces/map_test_suite.js';
+import { mockLogger } from '../interfaces/utils.js';
+import { AztecSQLiteOPFSStore } from './store.js';
+
+describe('SQLiteOPFSMap', () => {
+  describeAztecMap('AztecMap', async () => await AztecSQLiteOPFSStore.open(mockLogger, undefined, true));
+});

--- a/yarn-project/kv-store/src/sqlite-opfs/map.ts
+++ b/yarn-project/kv-store/src/sqlite-opfs/map.ts
@@ -1,0 +1,154 @@
+import { Encoder } from 'msgpackr';
+import { hash } from 'ohash';
+import { fromBufferKey, toBufferKey } from 'ordered-binary';
+
+import type { Key, Range, Value } from '../interfaces/common.js';
+import type { AztecAsyncMap } from '../interfaces/map.js';
+import type { SqlValue } from './messages.js';
+import type { AztecSQLiteOPFSStore } from './store.js';
+
+/** A map backed by SQLite in OPFS. Mirrors `IndexedDBAztecMap`. */
+export class SQLiteOPFSAztecMap<K extends Key, V extends Value> implements AztecAsyncMap<K, V> {
+  protected readonly name: string;
+  protected readonly container: string;
+  protected readonly encoder = new Encoder();
+
+  constructor(
+    protected readonly store: AztecSQLiteOPFSStore,
+    mapName: string,
+  ) {
+    this.name = mapName;
+    this.container = `map:${mapName}`;
+  }
+
+  async getAsync(key: K): Promise<V | undefined> {
+    const rows = await this.store.allAsync('SELECT value FROM data WHERE slot = ? LIMIT 1', [this.slot(key)]);
+    if (rows.length === 0) {
+      return undefined;
+    }
+    const raw = rows[0][0];
+    return raw == null ? undefined : this.decodeValue(raw);
+  }
+
+  async hasAsync(key: K): Promise<boolean> {
+    const rows = await this.store.allAsync('SELECT 1 FROM data WHERE slot = ? LIMIT 1', [this.slot(key)]);
+    return rows.length > 0;
+  }
+
+  async sizeAsync(): Promise<number> {
+    const rows = await this.store.allAsync('SELECT COUNT(*) FROM data WHERE container = ?', [this.container]);
+    return Number(rows[0]?.[0] ?? 0);
+  }
+
+  async set(key: K, val: V): Promise<void> {
+    await this.store.runAsync(
+      `INSERT OR REPLACE INTO data (slot, container, key, key_count, hash, value)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+      [this.slot(key), this.container, this.encodedKey(key), 1, hash(val), this.encoder.pack(val)],
+    );
+  }
+
+  async setMany(entries: { key: K; value: V }[]): Promise<void> {
+    if (entries.length === 0) {
+      return;
+    }
+    await this.store.transactionAsync(async () => {
+      for (const { key, value } of entries) {
+        await this.set(key, value);
+      }
+    });
+  }
+
+  swap(_key: K, _fn: (val: V | undefined) => V): Promise<void> {
+    throw new Error('Not implemented');
+  }
+
+  async setIfNotExists(key: K, val: V): Promise<boolean> {
+    return await this.store.transactionAsync(async () => {
+      if (await this.hasAsync(key)) {
+        return false;
+      }
+      await this.set(key, val);
+      return true;
+    });
+  }
+
+  async delete(key: K): Promise<void> {
+    await this.store.runAsync('DELETE FROM data WHERE slot = ?', [this.slot(key)]);
+  }
+
+  async *entriesAsync(range: Range<K> = {}): AsyncIterableIterator<[K, V]> {
+    const rows = await this.rangeQuery(range);
+    for (const row of rows) {
+      const [_slot, keyBlob, value] = row;
+      if (keyBlob == null || value == null) {
+        continue;
+      }
+      yield [this.decodeKey(keyBlob), this.decodeValue(value)];
+    }
+  }
+
+  async *valuesAsync(range: Range<K> = {}): AsyncIterableIterator<V> {
+    for await (const [, value] of this.entriesAsync(range)) {
+      yield value;
+    }
+  }
+
+  async *keysAsync(range: Range<K> = {}): AsyncIterableIterator<K> {
+    for await (const [key] of this.entriesAsync(range)) {
+      yield key;
+    }
+  }
+
+  protected async rangeQuery(range: Range<K>): Promise<Array<[string, Uint8Array, Uint8Array | null]>> {
+    // Inclusivity flips with direction to match the IndexedDB backend:
+    //   forward: [start, end)     reverse: (start, end]
+    // That asymmetry is load-bearing — tests pin the exact inclusivity at boundaries.
+    const reverse = !!range.reverse;
+    const parts: string[] = ['container = ?'];
+    const bind: SqlValue[] = [this.container];
+    if (range.start !== undefined) {
+      parts.push(reverse ? 'key > ?' : 'key >= ?');
+      bind.push(this.encodedKey(range.start));
+    }
+    if (range.end !== undefined) {
+      parts.push(reverse ? 'key <= ?' : 'key < ?');
+      bind.push(this.encodedKey(range.end));
+    }
+    const order = reverse ? 'DESC' : 'ASC';
+    let sql = `SELECT slot, key, value FROM data WHERE ${parts.join(' AND ')} ORDER BY key ${order}, key_count ${order}`;
+    if (range.limit !== undefined) {
+      sql += ' LIMIT ?';
+      bind.push(range.limit);
+    }
+    const rows = await this.store.allAsync(sql, bind);
+    return rows.map(r => [String(r[0]), r[1] as Uint8Array, r[2] as Uint8Array | null]);
+  }
+
+  protected decodeValue(val: SqlValue): V {
+    if (val instanceof Uint8Array) {
+      return this.encoder.unpack(val) as V;
+    }
+    return val as V;
+  }
+
+  protected decodeKey(raw: Uint8Array): K {
+    const parsed = fromBufferKey(Buffer.from(raw));
+    if (Array.isArray(parsed)) {
+      return (parsed.length > 1 ? parsed : parsed[0]) as K;
+    }
+    return parsed as K;
+  }
+
+  protected encodedKey(key: K): Buffer {
+    return toBufferKey(this.normalizeKey(key));
+  }
+
+  protected normalizeKey(key: K): (string | number | Uint8Array)[] {
+    return Array.isArray(key) ? key : [key];
+  }
+
+  protected slot(key: K, index: number = 0): string {
+    return `map:${this.name}:slot:${this.normalizeKey(key)}:${index}`;
+  }
+}

--- a/yarn-project/kv-store/src/sqlite-opfs/map.ts
+++ b/yarn-project/kv-store/src/sqlite-opfs/map.ts
@@ -1,3 +1,4 @@
+import { Buffer } from 'buffer';
 import { Encoder } from 'msgpackr';
 import { hash } from 'ohash';
 import { fromBufferKey, toBufferKey } from 'ordered-binary';

--- a/yarn-project/kv-store/src/sqlite-opfs/map.ts
+++ b/yarn-project/kv-store/src/sqlite-opfs/map.ts
@@ -127,10 +127,18 @@ export class SQLiteOPFSAztecMap<K extends Key, V extends Value> implements Aztec
   }
 
   protected decodeValue(val: SqlValue): V {
-    if (val instanceof Uint8Array) {
-      return this.encoder.unpack(val) as V;
+    if (!(val instanceof Uint8Array)) {
+      return val as V;
     }
-    return val as V;
+    const unpacked = this.encoder.unpack(val);
+    // msgpackr returns plain Uint8Array in browsers for packed Buffers. Callers that
+    // stored Buffers (walletDB uses Buffer.from(...).toString('utf8') round-trips)
+    // rely on Buffer-flavored behavior — re-wrap at the storage boundary, mirroring
+    // IndexedDBAztecMap.restoreBuffers.
+    if (unpacked instanceof Uint8Array && !Buffer.isBuffer(unpacked)) {
+      return Buffer.from(unpacked) as V;
+    }
+    return unpacked as V;
   }
 
   protected decodeKey(raw: Uint8Array): K {

--- a/yarn-project/kv-store/src/sqlite-opfs/messages.ts
+++ b/yarn-project/kv-store/src/sqlite-opfs/messages.ts
@@ -16,12 +16,13 @@ export type WorkerRequest =
   | { type: 'deleteDb'; id: number; dbName: string }
   | { type: 'run'; id: number; sql: string; bind?: SqlValue[] }
   | { type: 'all'; id: number; sql: string; bind?: SqlValue[] }
+  | { type: 'export'; id: number }
   | { type: 'begin'; id: number }
   | { type: 'commit'; id: number }
   | { type: 'rollback'; id: number };
 
 export type WorkerResponse =
-  | { type: 'ok'; id: number; rows?: ResultRow[]; changes?: number }
+  | { type: 'ok'; id: number; rows?: ResultRow[]; changes?: number; bytes?: Uint8Array }
   | { type: 'err'; id: number; message: string };
 
 export type WorkerRequestType = WorkerRequest['type'];

--- a/yarn-project/kv-store/src/sqlite-opfs/messages.ts
+++ b/yarn-project/kv-store/src/sqlite-opfs/messages.ts
@@ -11,7 +11,7 @@ export type SqlValue = string | number | bigint | null | Uint8Array;
 export type ResultRow = SqlValue[];
 
 export type WorkerRequest =
-  | { type: 'init'; id: number; dbName: string; ephemeral: boolean }
+  | { type: 'init'; id: number; dbName: string; ephemeral: boolean; poolDirectory?: string }
   | { type: 'close'; id: number }
   | { type: 'deleteDb'; id: number; dbName: string }
   | { type: 'run'; id: number; sql: string; bind?: SqlValue[] }

--- a/yarn-project/kv-store/src/sqlite-opfs/messages.ts
+++ b/yarn-project/kv-store/src/sqlite-opfs/messages.ts
@@ -1,0 +1,27 @@
+/**
+ * RPC protocol between the main thread and the SQLite worker.
+ * All requests carry a unique `id`; responses echo the same id so the main thread
+ * can resolve the right pending promise.
+ */
+
+/** Matches `@sqlite.org/sqlite-wasm`'s internal SqlValue type. Boolean is not a native SQLite type. */
+export type SqlValue = string | number | bigint | null | Uint8Array;
+
+/** A row returned in 'array' rowMode — one value per column, in select order. */
+export type ResultRow = SqlValue[];
+
+export type WorkerRequest =
+  | { type: 'init'; id: number; dbName: string; ephemeral: boolean }
+  | { type: 'close'; id: number }
+  | { type: 'deleteDb'; id: number; dbName: string }
+  | { type: 'run'; id: number; sql: string; bind?: SqlValue[] }
+  | { type: 'all'; id: number; sql: string; bind?: SqlValue[] }
+  | { type: 'begin'; id: number }
+  | { type: 'commit'; id: number }
+  | { type: 'rollback'; id: number };
+
+export type WorkerResponse =
+  | { type: 'ok'; id: number; rows?: ResultRow[]; changes?: number }
+  | { type: 'err'; id: number; message: string };
+
+export type WorkerRequestType = WorkerRequest['type'];

--- a/yarn-project/kv-store/src/sqlite-opfs/multi_map.test.ts
+++ b/yarn-project/kv-store/src/sqlite-opfs/multi_map.test.ts
@@ -1,0 +1,7 @@
+import { describeAztecMultiMap } from '../interfaces/multi_map_test_suite.js';
+import { mockLogger } from '../interfaces/utils.js';
+import { AztecSQLiteOPFSStore } from './store.js';
+
+describe('SQLiteOPFSMultiMap', () => {
+  describeAztecMultiMap('AztecMultiMap', async () => await AztecSQLiteOPFSStore.open(mockLogger, undefined, true));
+});

--- a/yarn-project/kv-store/src/sqlite-opfs/multi_map.ts
+++ b/yarn-project/kv-store/src/sqlite-opfs/multi_map.ts
@@ -1,0 +1,74 @@
+import { hash } from 'ohash';
+
+import type { Key, Value } from '../interfaces/common.js';
+import type { AztecAsyncMultiMap } from '../interfaces/multi_map.js';
+import { SQLiteOPFSAztecMap } from './map.js';
+
+/**
+ * Multi-map backed by SQLite. Extends the base map with always-incrementing
+ * `key_count` per-key so the same slot is never reused across deletions — this
+ * matches the IndexedDB backend's sparse-multi-map semantics.
+ */
+export class SQLiteOPFSAztecMultiMap<K extends Key, V extends Value>
+  extends SQLiteOPFSAztecMap<K, V>
+  implements AztecAsyncMultiMap<K, V>
+{
+  override async set(key: K, val: V): Promise<void> {
+    const valueHash = hash(val);
+    await this.store.transactionAsync(async () => {
+      const exists = await this.store.allAsync(
+        'SELECT 1 FROM data WHERE container = ? AND key = ? AND hash = ? LIMIT 1',
+        [this.container, this.encodedKey(key), valueHash],
+      );
+      if (exists.length > 0) {
+        return;
+      }
+      const maxRow = await this.store.allAsync('SELECT MAX(key_count) FROM data WHERE container = ? AND key = ?', [
+        this.container,
+        this.encodedKey(key),
+      ]);
+      const count = Number(maxRow[0]?.[0] ?? 0);
+      await this.store.runAsync(
+        `INSERT INTO data (slot, container, key, key_count, hash, value)
+         VALUES (?, ?, ?, ?, ?, ?)`,
+        [this.slot(key, count), this.container, this.encodedKey(key), count + 1, valueHash, this.encoder.pack(val)],
+      );
+    });
+  }
+
+  async *getValuesAsync(key: K): AsyncIterableIterator<V> {
+    const rows = await this.store.allAsync(
+      'SELECT value FROM data WHERE container = ? AND key = ? ORDER BY key_count ASC',
+      [this.container, this.encodedKey(key)],
+    );
+    for (const row of rows) {
+      const raw = row[0];
+      if (raw instanceof Uint8Array) {
+        yield this.decodeValue(raw);
+      }
+    }
+  }
+
+  async getValueCountAsync(key: K): Promise<number> {
+    const rows = await this.store.allAsync('SELECT COUNT(*) FROM data WHERE container = ? AND key = ?', [
+      this.container,
+      this.encodedKey(key),
+    ]);
+    return Number(rows[0]?.[0] ?? 0);
+  }
+
+  async deleteValue(key: K, val: V): Promise<void> {
+    await this.store.runAsync('DELETE FROM data WHERE container = ? AND key = ? AND hash = ?', [
+      this.container,
+      this.encodedKey(key),
+      hash(val),
+    ]);
+  }
+
+  override async delete(key: K): Promise<void> {
+    await this.store.runAsync('DELETE FROM data WHERE container = ? AND key = ?', [
+      this.container,
+      this.encodedKey(key),
+    ]);
+  }
+}

--- a/yarn-project/kv-store/src/sqlite-opfs/set.test.ts
+++ b/yarn-project/kv-store/src/sqlite-opfs/set.test.ts
@@ -1,0 +1,7 @@
+import { describeAztecSet } from '../interfaces/set_test_suite.js';
+import { mockLogger } from '../interfaces/utils.js';
+import { AztecSQLiteOPFSStore } from './store.js';
+
+describe('SQLiteOPFSSet', () => {
+  describeAztecSet('AztecSet', async () => await AztecSQLiteOPFSStore.open(mockLogger, undefined, true));
+});

--- a/yarn-project/kv-store/src/sqlite-opfs/set.ts
+++ b/yarn-project/kv-store/src/sqlite-opfs/set.ts
@@ -1,0 +1,29 @@
+import type { Key, Range } from '../interfaces/common.js';
+import type { AztecAsyncSet } from '../interfaces/set.js';
+import { SQLiteOPFSAztecMap } from './map.js';
+import type { AztecSQLiteOPFSStore } from './store.js';
+
+/** Set backed by SQLite. Composes a Map<K, true>. */
+export class SQLiteOPFSAztecSet<K extends Key> implements AztecAsyncSet<K> {
+  readonly #map: SQLiteOPFSAztecMap<K, boolean>;
+
+  constructor(store: AztecSQLiteOPFSStore, name: string) {
+    this.#map = new SQLiteOPFSAztecMap<K, boolean>(store, name);
+  }
+
+  hasAsync(key: K): Promise<boolean> {
+    return this.#map.hasAsync(key);
+  }
+
+  add(key: K): Promise<void> {
+    return this.#map.set(key, true);
+  }
+
+  delete(key: K): Promise<void> {
+    return this.#map.delete(key);
+  }
+
+  async *entriesAsync(range: Range<K> = {}): AsyncIterableIterator<K> {
+    yield* this.#map.keysAsync(range);
+  }
+}

--- a/yarn-project/kv-store/src/sqlite-opfs/singleton.test.ts
+++ b/yarn-project/kv-store/src/sqlite-opfs/singleton.test.ts
@@ -1,0 +1,7 @@
+import { describeAztecSingleton } from '../interfaces/singleton_test_suite.js';
+import { mockLogger } from '../interfaces/utils.js';
+import { AztecSQLiteOPFSStore } from './store.js';
+
+describe('SQLiteOPFSSingleton', () => {
+  describeAztecSingleton('AztecSingleton', async () => await AztecSQLiteOPFSStore.open(mockLogger, undefined, true));
+});

--- a/yarn-project/kv-store/src/sqlite-opfs/singleton.ts
+++ b/yarn-project/kv-store/src/sqlite-opfs/singleton.ts
@@ -1,0 +1,48 @@
+import { Encoder } from 'msgpackr';
+import { hash } from 'ohash';
+import { toBufferKey } from 'ordered-binary';
+
+import type { Value } from '../interfaces/common.js';
+import type { AztecAsyncSingleton } from '../interfaces/singleton.js';
+import type { AztecSQLiteOPFSStore } from './store.js';
+
+/** Stores a single value identified by `name`. */
+export class SQLiteOPFSAztecSingleton<T extends Value> implements AztecAsyncSingleton<T> {
+  readonly #container: string;
+  readonly #slot: string;
+  readonly #encoder = new Encoder();
+
+  constructor(
+    private readonly store: AztecSQLiteOPFSStore,
+    name: string,
+  ) {
+    this.#container = `singleton:${name}`;
+    this.#slot = `singleton:${name}:value`;
+  }
+
+  async getAsync(): Promise<T | undefined> {
+    const rows = await this.store.allAsync('SELECT value FROM data WHERE slot = ? LIMIT 1', [this.#slot]);
+    if (rows.length === 0) {
+      return undefined;
+    }
+    const raw = rows[0][0];
+    if (raw instanceof Uint8Array) {
+      return this.#encoder.unpack(raw) as T;
+    }
+    return undefined;
+  }
+
+  async set(val: T): Promise<boolean> {
+    const { changes } = await this.store.runAsync(
+      `INSERT OR REPLACE INTO data (slot, container, key, key_count, hash, value)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+      [this.#slot, this.#container, toBufferKey([this.#slot]), 1, hash(val), this.#encoder.pack(val)],
+    );
+    return changes > 0;
+  }
+
+  async delete(): Promise<boolean> {
+    await this.store.runAsync('DELETE FROM data WHERE slot = ?', [this.#slot]);
+    return true;
+  }
+}

--- a/yarn-project/kv-store/src/sqlite-opfs/store.ts
+++ b/yarn-project/kv-store/src/sqlite-opfs/store.ts
@@ -171,6 +171,19 @@ export class AztecSQLiteOPFSStore implements AztecAsyncKVStore {
   }
 
   /**
+   * Returns a raw SQLite image (bytes suitable for writing as a `.sqlite` file and
+   * opening in any SQLite tool). Works only for non-ephemeral DBs because the OPFS
+   * SAH Pool has to be initialized. Useful for inspection/debugging.
+   */
+  async exportDb(): Promise<Uint8Array> {
+    const resp = await this.#sendRequest({ type: 'export', id: this.#allocId() });
+    if (!('bytes' in resp) || !resp.bytes) {
+      throw new Error('exportDb: worker returned no bytes');
+    }
+    return resp.bytes;
+  }
+
+  /**
    * Runs a write statement (INSERT/UPDATE/DELETE/DDL). If called inside a
    * `transactionAsync` block, bypasses the queue; otherwise acquires it so the
    * op runs in its own auto-commit.

--- a/yarn-project/kv-store/src/sqlite-opfs/store.ts
+++ b/yarn-project/kv-store/src/sqlite-opfs/store.ts
@@ -1,0 +1,197 @@
+import type { Logger } from '@aztec/foundation/log';
+import { SerialQueue } from '@aztec/foundation/queue';
+
+import type { AztecAsyncArray } from '../interfaces/array.js';
+import type { Key, StoreSize, Value } from '../interfaces/common.js';
+import type { AztecAsyncCounter } from '../interfaces/counter.js';
+import type { AztecAsyncMap } from '../interfaces/map.js';
+import type { AztecAsyncMultiMap } from '../interfaces/multi_map.js';
+import type { AztecAsyncSet } from '../interfaces/set.js';
+import type { AztecAsyncSingleton } from '../interfaces/singleton.js';
+import type { AztecAsyncKVStore } from '../interfaces/store.js';
+import { SQLiteOPFSAztecArray } from './array.js';
+import { SQLiteOPFSAztecMap } from './map.js';
+import type { ResultRow, SqlValue, WorkerRequest, WorkerResponse } from './messages.js';
+import { SQLiteOPFSAztecMultiMap } from './multi_map.js';
+import { SQLiteOPFSAztecSet } from './set.js';
+import { SQLiteOPFSAztecSingleton } from './singleton.js';
+
+/**
+ * Main-thread handle for a SQLite database persisted to OPFS via the `opfs-sahpool`
+ * VFS. Owns a dedicated Web Worker (the SAH Pool VFS requires Worker context) and
+ * routes every SQL op through it via typed postMessage RPC.
+ *
+ * Transaction ordering is guaranteed by a `SerialQueue` on the main thread combined
+ * with an `#inTx` flag: outside a `transactionAsync` block, each op acquires the
+ * queue for its own auto-commit; inside a block, the outer call holds the queue and
+ * nested ops bypass it to avoid deadlock.
+ */
+export class AztecSQLiteOPFSStore implements AztecAsyncKVStore {
+  readonly #worker: Worker;
+  readonly #pending = new Map<number, { resolve: (r: WorkerResponse) => void; reject: (err: Error) => void }>();
+  readonly #txQueue = new SerialQueue();
+  readonly #name: string;
+  readonly #log: Logger;
+  #nextId = 0;
+  #inTx = false;
+  #closed = false;
+
+  private constructor(
+    worker: Worker,
+    name: string,
+    log: Logger,
+    public readonly isEphemeral: boolean,
+  ) {
+    this.#worker = worker;
+    this.#name = name;
+    this.#log = log;
+    this.#worker.onmessage = (ev: MessageEvent<WorkerResponse>) => {
+      const { id } = ev.data;
+      const handler = this.#pending.get(id);
+      if (!handler) {
+        this.#log.warn(`SQLite worker: no pending handler for id ${id}`);
+        return;
+      }
+      this.#pending.delete(id);
+      handler.resolve(ev.data);
+    };
+    this.#worker.onerror = ev => {
+      this.#log.error(`SQLite worker crashed: ${ev.message}`);
+      for (const { reject } of this.#pending.values()) {
+        reject(new Error(`SQLite worker crashed: ${ev.message}`));
+      }
+      this.#pending.clear();
+    };
+    this.#txQueue.start();
+  }
+
+  /**
+   * Opens (or creates) a SQLite database stored in the OPFS SAH Pool. When `ephemeral`
+   * is true the database lives only in memory and is lost when the worker terminates.
+   */
+  static async open(log: Logger, name?: string, ephemeral: boolean = false): Promise<AztecSQLiteOPFSStore> {
+    const dbName = name && !ephemeral ? name : `tmp-${globalThis.crypto.getRandomValues(new Uint8Array(8)).join('')}`;
+    log.debug(`Opening SQLite-OPFS ${ephemeral ? 'ephemeral ' : ''}database ${dbName}`);
+    const worker = new Worker(new URL('./worker.js', import.meta.url), { type: 'module' });
+    const store = new AztecSQLiteOPFSStore(worker, dbName, log, ephemeral);
+    await store.#sendRequest({ type: 'init', id: store.#allocId(), dbName, ephemeral });
+    return store;
+  }
+
+  openMap<K extends Key, V extends Value>(name: string): AztecAsyncMap<K, V> {
+    return new SQLiteOPFSAztecMap<K, V>(this, name);
+  }
+
+  openSet<K extends Key>(name: string): AztecAsyncSet<K> {
+    return new SQLiteOPFSAztecSet<K>(this, name);
+  }
+
+  openMultiMap<K extends Key, V extends Value>(name: string): AztecAsyncMultiMap<K, V> {
+    return new SQLiteOPFSAztecMultiMap<K, V>(this, name);
+  }
+
+  openCounter<K extends Key>(_name: string): AztecAsyncCounter<K> {
+    throw new Error('Method not implemented.');
+  }
+
+  openArray<T extends Value>(name: string): AztecAsyncArray<T> {
+    return new SQLiteOPFSAztecArray<T>(this, name);
+  }
+
+  openSingleton<T extends Value>(name: string): AztecAsyncSingleton<T> {
+    return new SQLiteOPFSAztecSingleton<T>(this, name);
+  }
+
+  async transactionAsync<T>(callback: () => Promise<T>): Promise<T> {
+    return this.#txQueue.put(async () => {
+      this.#inTx = true;
+      await this.#sendRequest({ type: 'begin', id: this.#allocId() });
+      try {
+        const result = await callback();
+        await this.#sendRequest({ type: 'commit', id: this.#allocId() });
+        return result;
+      } catch (err) {
+        await this.#sendRequest({ type: 'rollback', id: this.#allocId() }).catch(rollbackErr =>
+          this.#log.warn(`SQLite ROLLBACK failed: ${rollbackErr instanceof Error ? rollbackErr.message : rollbackErr}`),
+        );
+        throw err;
+      } finally {
+        this.#inTx = false;
+      }
+    });
+  }
+
+  async clear(): Promise<void> {
+    await this.runAsync('DELETE FROM data');
+  }
+
+  async delete(): Promise<void> {
+    if (this.#closed) {
+      return;
+    }
+    this.#closed = true;
+    await this.#txQueue.end();
+    await this.#sendRequest({ type: 'deleteDb', id: this.#allocId(), dbName: this.#name }).catch(err =>
+      this.#log.warn(`SQLite deleteDb failed: ${err instanceof Error ? err.message : err}`),
+    );
+    this.#worker.terminate();
+  }
+
+  estimateSize(): Promise<StoreSize> {
+    return Promise.resolve({ mappingSize: 0, physicalFileSize: 0, actualSize: 0, numItems: 0 });
+  }
+
+  async close(): Promise<void> {
+    if (this.#closed) {
+      return;
+    }
+    this.#closed = true;
+    await this.#txQueue.end();
+    await this.#sendRequest({ type: 'close', id: this.#allocId() }).catch(() => {});
+    this.#worker.terminate();
+  }
+
+  backupTo(_dstPath: string, _compact?: boolean): Promise<void> {
+    throw new Error('Method not implemented.');
+  }
+
+  /**
+   * Runs a write statement (INSERT/UPDATE/DELETE/DDL). If called inside a
+   * `transactionAsync` block, bypasses the queue; otherwise acquires it so the
+   * op runs in its own auto-commit.
+   */
+  async runAsync(sql: string, bind?: SqlValue[]): Promise<{ changes: number }> {
+    const send = () =>
+      this.#sendRequest({ type: 'run', id: this.#allocId(), sql, bind }).then(r => ({
+        changes: 'changes' in r ? (r.changes ?? 0) : 0,
+      }));
+    return this.#inTx ? send() : this.#txQueue.put(send);
+  }
+
+  /** Runs a SELECT statement and returns rows in array row-mode. */
+  async allAsync(sql: string, bind?: SqlValue[]): Promise<ResultRow[]> {
+    const send = () =>
+      this.#sendRequest({ type: 'all', id: this.#allocId(), sql, bind }).then(r => ('rows' in r ? (r.rows ?? []) : []));
+    return this.#inTx ? send() : this.#txQueue.put(send);
+  }
+
+  #allocId(): number {
+    return ++this.#nextId;
+  }
+
+  #sendRequest(req: WorkerRequest): Promise<WorkerResponse> {
+    return new Promise<WorkerResponse>((resolve, reject) => {
+      this.#pending.set(req.id, {
+        resolve: resp => {
+          if (resp.type === 'err') {
+            reject(new Error(resp.message));
+          } else {
+            resolve(resp);
+          }
+        },
+        reject,
+      });
+      this.#worker.postMessage(req);
+    });
+  }
+}

--- a/yarn-project/kv-store/src/sqlite-opfs/store.ts
+++ b/yarn-project/kv-store/src/sqlite-opfs/store.ts
@@ -57,10 +57,7 @@ export class AztecSQLiteOPFSStore implements AztecAsyncKVStore {
     };
     this.#worker.onerror = ev => {
       this.#log.error(`SQLite worker crashed: ${ev.message}`);
-      for (const { reject } of this.#pending.values()) {
-        reject(new Error(`SQLite worker crashed: ${ev.message}`));
-      }
-      this.#pending.clear();
+      this.#rejectPending(`SQLite worker crashed: ${ev.message}`);
     };
     this.#txQueue.start();
   }
@@ -150,6 +147,7 @@ export class AztecSQLiteOPFSStore implements AztecAsyncKVStore {
       this.#log.warn(`SQLite deleteDb failed: ${err instanceof Error ? err.message : err}`),
     );
     this.#worker.terminate();
+    this.#rejectPending('SQLite store deleted');
   }
 
   /**
@@ -172,6 +170,7 @@ export class AztecSQLiteOPFSStore implements AztecAsyncKVStore {
     await this.#txQueue.end();
     await this.#sendRequest({ type: 'close', id: this.#allocId() }).catch(() => {});
     this.#worker.terminate();
+    this.#rejectPending('SQLite store closed');
   }
 
   backupTo(_dstPath: string, _compact?: boolean): Promise<void> {
@@ -213,6 +212,22 @@ export class AztecSQLiteOPFSStore implements AztecAsyncKVStore {
 
   #allocId(): number {
     return ++this.#nextId;
+  }
+
+  /**
+   * Reject any in-flight requests with `reason`, so callers awaiting a response to a
+   * request sent to a now-terminated worker don't hang forever. Called from
+   * close()/delete() and from the worker.onerror handler.
+   */
+  #rejectPending(reason: string): void {
+    if (this.#pending.size === 0) {
+      return;
+    }
+    const err = new Error(reason);
+    for (const { reject } of this.#pending.values()) {
+      reject(err);
+    }
+    this.#pending.clear();
   }
 
   #sendRequest(req: WorkerRequest): Promise<WorkerResponse> {

--- a/yarn-project/kv-store/src/sqlite-opfs/store.ts
+++ b/yarn-project/kv-store/src/sqlite-opfs/store.ts
@@ -103,6 +103,13 @@ export class AztecSQLiteOPFSStore implements AztecAsyncKVStore {
   }
 
   async transactionAsync<T>(callback: () => Promise<T>): Promise<T> {
+    // Nested calls join the outer transaction — SQLite does not support nested BEGIN,
+    // and re-acquiring the SerialQueue while the outer call holds it would deadlock.
+    // Errors in the nested callback propagate to the outer catch, which rolls back the
+    // whole thing (the standard "nested tx = savepoint-free join" semantic).
+    if (this.#inTx) {
+      return callback();
+    }
     return this.#txQueue.put(async () => {
       this.#inTx = true;
       await this.#sendRequest({ type: 'begin', id: this.#allocId() });

--- a/yarn-project/kv-store/src/sqlite-opfs/store.ts
+++ b/yarn-project/kv-store/src/sqlite-opfs/store.ts
@@ -68,13 +68,21 @@ export class AztecSQLiteOPFSStore implements AztecAsyncKVStore {
   /**
    * Opens (or creates) a SQLite database stored in the OPFS SAH Pool. When `ephemeral`
    * is true the database lives only in memory and is lost when the worker terminates.
+   * Pass `poolDirectory` to place the SAH Pool in a non-default OPFS subdirectory —
+   * required when multiple stores coexist in the same tab, because the SAH Pool holds
+   * an exclusive lock on its directory.
    */
-  static async open(log: Logger, name?: string, ephemeral: boolean = false): Promise<AztecSQLiteOPFSStore> {
+  static async open(
+    log: Logger,
+    name?: string,
+    ephemeral: boolean = false,
+    poolDirectory?: string,
+  ): Promise<AztecSQLiteOPFSStore> {
     const dbName = name && !ephemeral ? name : `tmp-${globalThis.crypto.getRandomValues(new Uint8Array(8)).join('')}`;
     log.debug(`Opening SQLite-OPFS ${ephemeral ? 'ephemeral ' : ''}database ${dbName}`);
     const worker = new Worker(new URL('./worker.js', import.meta.url), { type: 'module' });
     const store = new AztecSQLiteOPFSStore(worker, dbName, log, ephemeral);
-    await store.#sendRequest({ type: 'init', id: store.#allocId(), dbName, ephemeral });
+    await store.#sendRequest({ type: 'init', id: store.#allocId(), dbName, ephemeral, poolDirectory });
     return store;
   }
 

--- a/yarn-project/kv-store/src/sqlite-opfs/store.ts
+++ b/yarn-project/kv-store/src/sqlite-opfs/store.ts
@@ -107,7 +107,7 @@ export class AztecSQLiteOPFSStore implements AztecAsyncKVStore {
     return new SQLiteOPFSAztecSingleton<T>(this, name);
   }
 
-  async transactionAsync<T>(callback: () => Promise<T>): Promise<T> {
+  transactionAsync<T>(callback: () => Promise<T>): Promise<T> {
     // Nested calls join the outer transaction — SQLite does not support nested BEGIN,
     // and re-acquiring the SerialQueue while the outer call holds it would deadlock.
     // Errors in the nested callback propagate to the outer catch, which rolls back the
@@ -195,7 +195,7 @@ export class AztecSQLiteOPFSStore implements AztecAsyncKVStore {
    * `transactionAsync` block, bypasses the queue; otherwise acquires it so the
    * op runs in its own auto-commit.
    */
-  async runAsync(sql: string, bind?: SqlValue[]): Promise<{ changes: number }> {
+  runAsync(sql: string, bind?: SqlValue[]): Promise<{ changes: number }> {
     const send = () =>
       this.#sendRequest({ type: 'run', id: this.#allocId(), sql, bind }).then(r => ({
         changes: 'changes' in r ? (r.changes ?? 0) : 0,
@@ -204,7 +204,7 @@ export class AztecSQLiteOPFSStore implements AztecAsyncKVStore {
   }
 
   /** Runs a SELECT statement and returns rows in array row-mode. */
-  async allAsync(sql: string, bind?: SqlValue[]): Promise<ResultRow[]> {
+  allAsync(sql: string, bind?: SqlValue[]): Promise<ResultRow[]> {
     const send = () =>
       this.#sendRequest({ type: 'all', id: this.#allocId(), sql, bind }).then(r => ('rows' in r ? (r.rows ?? []) : []));
     return this.#inTx ? send() : this.#txQueue.put(send);

--- a/yarn-project/kv-store/src/sqlite-opfs/store.ts
+++ b/yarn-project/kv-store/src/sqlite-opfs/store.ts
@@ -152,6 +152,14 @@ export class AztecSQLiteOPFSStore implements AztecAsyncKVStore {
     this.#worker.terminate();
   }
 
+  /**
+   * Placeholder — returns zeros to mirror the IndexedDB backend. SQLite exposes real
+   * numbers cheaply via `PRAGMA page_count` / `page_size` / `freelist_count` and
+   * `SELECT COUNT(*) FROM data`, which would populate `physicalFileSize`, `actualSize`,
+   * and `numItems` meaningfully (`mappingSize` stays 0 — it's an LMDB mmap concept).
+   * Upgrade when any caller actually consumes these values; all current consumers
+   * tolerate zeros.
+   */
   estimateSize(): Promise<StoreSize> {
     return Promise.resolve({ mappingSize: 0, physicalFileSize: 0, actualSize: 0, numItems: 0 });
   }

--- a/yarn-project/kv-store/src/sqlite-opfs/worker.ts
+++ b/yarn-project/kv-store/src/sqlite-opfs/worker.ts
@@ -58,6 +58,16 @@ function handleClose(): void {
   dbPath = undefined;
 }
 
+async function handleExport(): Promise<Uint8Array> {
+  if (!db || !dbPath) {
+    throw new Error('SQLite worker: no database open to export');
+  }
+  if (!pool) {
+    throw new Error('SQLite worker: no SAH Pool available (ephemeral DBs cannot be exported)');
+  }
+  return pool.exportFile(dbPath);
+}
+
 async function handleDeleteDb(dbName: string): Promise<void> {
   const path = normalizeDbPath(dbName);
   if (db && dbPath === path) {
@@ -121,6 +131,10 @@ function respond(msg: WorkerResponse): void {
       case 'all': {
         const rows = selectAll(req.sql, req.bind);
         return respond({ type: 'ok', id: req.id, rows });
+      }
+      case 'export': {
+        const bytes = await handleExport();
+        return respond({ type: 'ok', id: req.id, bytes });
       }
       case 'begin':
         runSql('BEGIN');

--- a/yarn-project/kv-store/src/sqlite-opfs/worker.ts
+++ b/yarn-project/kv-store/src/sqlite-opfs/worker.ts
@@ -18,32 +18,34 @@ const SCHEMA_SQL = `
   CREATE UNIQUE INDEX IF NOT EXISTS idx_container_key_hash ON data(container, key, hash);
 `;
 
-const SAH_POOL_DIRECTORY = '.aztec-kv';
+const DEFAULT_SAH_POOL_DIRECTORY = '.aztec-kv';
 const SAH_POOL_VFS_NAME = 'aztec-kv-opfs';
 
 let sqlite3: Sqlite3Static | undefined;
 let pool: SAHPoolUtil | undefined;
+let poolDirectory: string | undefined;
 let db: Database | undefined;
 let dbPath: string | undefined;
 
-async function ensurePool(): Promise<SAHPoolUtil> {
+async function ensurePool(directory: string): Promise<SAHPoolUtil> {
   sqlite3 ??= await sqlite3InitModule({ printErr: console.error });
   if (!pool) {
+    poolDirectory = directory;
     pool = await sqlite3.installOpfsSAHPoolVfs({
       name: SAH_POOL_VFS_NAME,
-      directory: SAH_POOL_DIRECTORY,
+      directory,
       initialCapacity: 8,
     });
   }
   return pool;
 }
 
-async function handleInit(dbName: string, ephemeral: boolean): Promise<void> {
+async function handleInit(dbName: string, ephemeral: boolean, directory?: string): Promise<void> {
   sqlite3 ??= await sqlite3InitModule({ printErr: console.error });
   if (ephemeral) {
     db = new sqlite3.oo1.DB(':memory:', 'c');
   } else {
-    const p = await ensurePool();
+    const p = await ensurePool(directory ?? DEFAULT_SAH_POOL_DIRECTORY);
     dbPath = normalizeDbPath(dbName);
     db = new p.OpfsSAHPoolDb(dbPath);
   }
@@ -63,7 +65,7 @@ async function handleDeleteDb(dbName: string): Promise<void> {
     db = undefined;
     dbPath = undefined;
   }
-  const p = await ensurePool();
+  const p = await ensurePool(poolDirectory ?? DEFAULT_SAH_POOL_DIRECTORY);
   try {
     p.unlink(path);
   } catch {
@@ -104,7 +106,7 @@ function respond(msg: WorkerResponse): void {
   try {
     switch (req.type) {
       case 'init':
-        await handleInit(req.dbName, req.ephemeral);
+        await handleInit(req.dbName, req.ephemeral, req.poolDirectory);
         return respond({ type: 'ok', id: req.id });
       case 'close':
         handleClose();

--- a/yarn-project/kv-store/src/sqlite-opfs/worker.ts
+++ b/yarn-project/kv-store/src/sqlite-opfs/worker.ts
@@ -1,0 +1,141 @@
+/// <reference lib="webworker" />
+import sqlite3InitModule, { type Database, type SAHPoolUtil, type Sqlite3Static } from '@sqlite.org/sqlite-wasm';
+
+import type { ResultRow, SqlValue, WorkerRequest, WorkerResponse } from './messages.js';
+
+const SCHEMA_SQL = `
+  CREATE TABLE IF NOT EXISTS data (
+    slot TEXT NOT NULL PRIMARY KEY,
+    container TEXT NOT NULL,
+    key BLOB NOT NULL,
+    key_count INTEGER NOT NULL,
+    hash TEXT NOT NULL,
+    value BLOB
+  ) WITHOUT ROWID;
+
+  CREATE INDEX IF NOT EXISTS idx_container_key ON data(container, key);
+  CREATE UNIQUE INDEX IF NOT EXISTS idx_container_key_count ON data(container, key, key_count);
+  CREATE UNIQUE INDEX IF NOT EXISTS idx_container_key_hash ON data(container, key, hash);
+`;
+
+const SAH_POOL_DIRECTORY = '.aztec-kv';
+const SAH_POOL_VFS_NAME = 'aztec-kv-opfs';
+
+let sqlite3: Sqlite3Static | undefined;
+let pool: SAHPoolUtil | undefined;
+let db: Database | undefined;
+let dbPath: string | undefined;
+
+async function ensurePool(): Promise<SAHPoolUtil> {
+  sqlite3 ??= await sqlite3InitModule({ printErr: console.error });
+  if (!pool) {
+    pool = await sqlite3.installOpfsSAHPoolVfs({
+      name: SAH_POOL_VFS_NAME,
+      directory: SAH_POOL_DIRECTORY,
+      initialCapacity: 8,
+    });
+  }
+  return pool;
+}
+
+async function handleInit(dbName: string, ephemeral: boolean): Promise<void> {
+  sqlite3 ??= await sqlite3InitModule({ printErr: console.error });
+  if (ephemeral) {
+    db = new sqlite3.oo1.DB(':memory:', 'c');
+  } else {
+    const p = await ensurePool();
+    dbPath = normalizeDbPath(dbName);
+    db = new p.OpfsSAHPoolDb(dbPath);
+  }
+  runSql(SCHEMA_SQL);
+}
+
+function handleClose(): void {
+  db?.close();
+  db = undefined;
+  dbPath = undefined;
+}
+
+async function handleDeleteDb(dbName: string): Promise<void> {
+  const path = normalizeDbPath(dbName);
+  if (db && dbPath === path) {
+    db.close();
+    db = undefined;
+    dbPath = undefined;
+  }
+  const p = await ensurePool();
+  try {
+    p.unlink(path);
+  } catch {
+    // File may not exist; ignore.
+  }
+}
+
+function requireDb(): Database {
+  if (!db) {
+    throw new Error('SQLite worker: no database open');
+  }
+  return db;
+}
+
+function runSql(sql: string, bind?: SqlValue[]): { changes: number } {
+  const conn = requireDb();
+  conn.exec({ sql, bind });
+  return { changes: conn.changes() };
+}
+
+function selectAll(sql: string, bind?: SqlValue[]): ResultRow[] {
+  const conn = requireDb();
+  const rows: ResultRow[] = [];
+  conn.exec({ sql, bind, rowMode: 'array', resultRows: rows });
+  return rows;
+}
+
+function normalizeDbPath(dbName: string): string {
+  return dbName.startsWith('/') ? dbName : `/${dbName}`;
+}
+
+function respond(msg: WorkerResponse): void {
+  (self as DedicatedWorkerGlobalScope).postMessage(msg);
+}
+
+(self as DedicatedWorkerGlobalScope).onmessage = async (ev: MessageEvent<WorkerRequest>) => {
+  const req = ev.data;
+  try {
+    switch (req.type) {
+      case 'init':
+        await handleInit(req.dbName, req.ephemeral);
+        return respond({ type: 'ok', id: req.id });
+      case 'close':
+        handleClose();
+        return respond({ type: 'ok', id: req.id });
+      case 'deleteDb':
+        await handleDeleteDb(req.dbName);
+        return respond({ type: 'ok', id: req.id });
+      case 'run': {
+        const { changes } = runSql(req.sql, req.bind);
+        return respond({ type: 'ok', id: req.id, changes });
+      }
+      case 'all': {
+        const rows = selectAll(req.sql, req.bind);
+        return respond({ type: 'ok', id: req.id, rows });
+      }
+      case 'begin':
+        runSql('BEGIN');
+        return respond({ type: 'ok', id: req.id });
+      case 'commit':
+        runSql('COMMIT');
+        return respond({ type: 'ok', id: req.id });
+      case 'rollback':
+        runSql('ROLLBACK');
+        return respond({ type: 'ok', id: req.id });
+      default: {
+        const _exhaustive: never = req;
+        throw new Error(`Unknown request: ${JSON.stringify(_exhaustive)}`);
+      }
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    respond({ type: 'err', id: req.id, message });
+  }
+};

--- a/yarn-project/kv-store/src/sqlite-opfs/worker.ts
+++ b/yarn-project/kv-store/src/sqlite-opfs/worker.ts
@@ -28,7 +28,7 @@ let db: Database | undefined;
 let dbPath: string | undefined;
 
 async function ensurePool(directory: string): Promise<SAHPoolUtil> {
-  sqlite3 ??= await sqlite3InitModule({ printErr: console.error });
+  sqlite3 ??= await sqlite3InitModule();
   if (!pool) {
     poolDirectory = directory;
     pool = await sqlite3.installOpfsSAHPoolVfs({
@@ -41,7 +41,7 @@ async function ensurePool(directory: string): Promise<SAHPoolUtil> {
 }
 
 async function handleInit(dbName: string, ephemeral: boolean, directory?: string): Promise<void> {
-  sqlite3 ??= await sqlite3InitModule({ printErr: console.error });
+  sqlite3 ??= await sqlite3InitModule();
   if (ephemeral) {
     db = new sqlite3.oo1.DB(':memory:', 'c');
   } else {
@@ -65,7 +65,7 @@ async function handleExport(): Promise<Uint8Array> {
   if (!pool) {
     throw new Error('SQLite worker: no SAH Pool available (ephemeral DBs cannot be exported)');
   }
-  return pool.exportFile(dbPath);
+  return await pool.exportFile(dbPath);
 }
 
 async function handleDeleteDb(dbName: string): Promise<void> {

--- a/yarn-project/kv-store/vitest.config.ts
+++ b/yarn-project/kv-store/vitest.config.ts
@@ -50,7 +50,15 @@ export default defineConfig({
   test: {
     globals: true,
     reporters: ['verbose'],
-    include: ['./src/indexeddb/**/*.test.ts', './src/sqlite-opfs/**/*.test.ts'],
+    include: [
+      './src/indexeddb/**/*.test.ts',
+      './src/sqlite-opfs/**/*.test.ts',
+      // Benchmarks self-skip unless VITE_BENCH=1; include so they're discoverable.
+      './src/bench/indexeddb/**/*.test.ts',
+      './src/bench/sqlite-opfs/**/*.test.ts',
+    ],
+    // Bench suites do full-population + N-iteration work; default 30s is too tight.
+    testTimeout: process.env.VITE_BENCH === '1' ? 300_000 : 30_000,
     // Run test files sequentially to avoid race conditions in browser module loading
     fileParallelism: false,
     browser: {
@@ -76,7 +84,6 @@ export default defineConfig({
         },
       ],
     },
-    testTimeout: 30000,
     teardownTimeout: 10000,
     globalSetup: './vitest.global-setup.ts',
   },

--- a/yarn-project/kv-store/vitest.config.ts
+++ b/yarn-project/kv-store/vitest.config.ts
@@ -43,11 +43,14 @@ export default defineConfig({
       'idb-keyval',
       'comlink',
     ],
+    // sqlite-wasm ships its own .wasm asset loader; let Vite serve it as a static asset
+    // rather than pre-bundling, per the upstream docs' recommendation.
+    exclude: ['@sqlite.org/sqlite-wasm'],
   },
   test: {
     globals: true,
     reporters: ['verbose'],
-    include: ['./src/indexeddb/**/*.test.ts'],
+    include: ['./src/indexeddb/**/*.test.ts', './src/sqlite-opfs/**/*.test.ts'],
     // Run test files sequentially to avoid race conditions in browser module loading
     fileParallelism: false,
     browser: {

--- a/yarn-project/wallets/src/embedded/embedded_wallet.ts
+++ b/yarn-project/wallets/src/embedded/embedded_wallet.ts
@@ -7,6 +7,7 @@ import type { DefaultAccountEntrypointOptions } from '@aztec/entrypoints/account
 import { DefaultEntrypoint } from '@aztec/entrypoints/default';
 import { Fq, Fr } from '@aztec/foundation/curves/bn254';
 import type { Logger } from '@aztec/foundation/log';
+import type { AztecAsyncKVStore } from '@aztec/kv-store';
 import type { PXEConfig, PXECreationOptions } from '@aztec/pxe/client/lazy';
 import type { PXE } from '@aztec/pxe/server';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
@@ -43,6 +44,12 @@ export function splitPxeOptions(pxe?: EmbeddedWalletPXEOptions): {
   return { config, creation: { loggers, loggerActorLabel, proverOrOptions, store, simulator } };
 }
 
+/** Options for the EmbeddedWallet's own DB (accounts, senders — distinct from PXE state). */
+export type EmbeddedWalletDBOptions = {
+  /** Override the wallet DB backend. If omitted, an IndexedDB (browser) / LMDB (node) store is created. */
+  store?: AztecAsyncKVStore;
+};
+
 export type EmbeddedWalletOptions = {
   /** Parent logger. Child loggers are derived via createChild() for each subsystem. */
   logger?: Logger;
@@ -50,6 +57,8 @@ export type EmbeddedWalletOptions = {
   ephemeral?: boolean;
   /** PXE configuration and dependency overrides (custom store, prover, simulator). */
   pxe?: EmbeddedWalletPXEOptions;
+  /** Wallet DB dependency overrides (custom store). */
+  walletDb?: EmbeddedWalletDBOptions;
   /**
    * Override PXE configuration.
    * @deprecated Use `pxe` instead.

--- a/yarn-project/wallets/src/embedded/entrypoints/browser.ts
+++ b/yarn-project/wallets/src/embedded/entrypoints/browser.ts
@@ -53,18 +53,20 @@ export class BrowserEmbeddedWallet extends EmbeddedWallet {
 
     const pxe = await createPXE(aztecNode, pxeConfig, pxeOptions);
 
-    const walletDBStore = options.ephemeral
-      ? await openTmpStore(true)
-      : await createStore(
-          'wallet_data',
-          {
-            dataDirectory: `wallet_data_${l1Contracts.rollupAddress}`,
-            dataStoreMapSizeKb: pxeConfig.dataStoreMapSizeKb,
-            l1Contracts,
-          },
-          1,
-          rootLogger.createChild('wallet:data'),
-        );
+    const walletDBStore =
+      options.walletDb?.store ??
+      (options.ephemeral
+        ? await openTmpStore(true)
+        : await createStore(
+            'wallet_data',
+            {
+              dataDirectory: `wallet_data_${l1Contracts.rollupAddress}`,
+              dataStoreMapSizeKb: pxeConfig.dataStoreMapSizeKb,
+              l1Contracts,
+            },
+            1,
+            rootLogger.createChild('wallet:data'),
+          ));
     const walletDB = WalletDB.init(walletDBStore, rootLogger.createChild('wallet:db').info);
 
     return new this(pxe, aztecNode, walletDB, new LazyAccountContractsProvider(), rootLogger) as T;

--- a/yarn-project/wallets/src/embedded/entrypoints/node.ts
+++ b/yarn-project/wallets/src/embedded/entrypoints/node.ts
@@ -54,24 +54,26 @@ export class NodeEmbeddedWallet extends EmbeddedWallet {
 
     const pxe = await createPXE(aztecNode, pxeConfig, pxeOptions);
 
-    const walletDBStore = options.ephemeral
-      ? await openTmpStore(
-          `wallet_data_${l1Contracts.rollupAddress}`,
-          true,
-          undefined,
-          undefined,
-          rootLogger.createChild('wallet:data').getBindings(),
-        )
-      : await createStore(
-          'wallet_data',
-          1,
-          {
-            dataDirectory: `wallet_data_${l1Contracts.rollupAddress}`,
-            dataStoreMapSizeKb: pxeConfig.dataStoreMapSizeKb,
-            l1Contracts,
-          },
-          rootLogger.createChild('wallet:data').getBindings(),
-        );
+    const walletDBStore =
+      options.walletDb?.store ??
+      (options.ephemeral
+        ? await openTmpStore(
+            `wallet_data_${l1Contracts.rollupAddress}`,
+            true,
+            undefined,
+            undefined,
+            rootLogger.createChild('wallet:data').getBindings(),
+          )
+        : await createStore(
+            'wallet_data',
+            1,
+            {
+              dataDirectory: `wallet_data_${l1Contracts.rollupAddress}`,
+              dataStoreMapSizeKb: pxeConfig.dataStoreMapSizeKb,
+              l1Contracts,
+            },
+            rootLogger.createChild('wallet:data').getBindings(),
+          ));
     const walletDB = WalletDB.init(walletDBStore, rootLogger.createChild('wallet:db').info);
 
     return new this(pxe, aztecNode, walletDB, new BundleAccountContractsProvider(), rootLogger) as T;

--- a/yarn-project/yarn.lock
+++ b/yarn-project/yarn.lock
@@ -1623,7 +1623,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@aztec/noir-noir_codegen@portal:../noir/packages/noir_codegen::locator=%40aztec%2Faztec3-packages%40workspace%3A."
   dependencies:
-    "@aztec/noir-types": "npm:1.0.0-beta.19"
+    "@aztec/noir-types": "npm:1.0.0-beta.20"
     glob: "npm:^13.0.6"
     ts-command-line-args: "npm:^2.5.1"
   bin:
@@ -1632,14 +1632,14 @@ __metadata:
   linkType: soft
 
 "@aztec/noir-noir_js@file:../noir/packages/noir_js::locator=%40aztec%2Faztec3-packages%40workspace%3A.":
-  version: 1.0.0-beta.19
-  resolution: "@aztec/noir-noir_js@file:../noir/packages/noir_js#../noir/packages/noir_js::hash=c0ce11&locator=%40aztec%2Faztec3-packages%40workspace%3A."
+  version: 1.0.0-beta.20
+  resolution: "@aztec/noir-noir_js@file:../noir/packages/noir_js#../noir/packages/noir_js::hash=6edf14&locator=%40aztec%2Faztec3-packages%40workspace%3A."
   dependencies:
-    "@aztec/noir-acvm_js": "npm:1.0.0-beta.19"
-    "@aztec/noir-noirc_abi": "npm:1.0.0-beta.19"
-    "@aztec/noir-types": "npm:1.0.0-beta.19"
+    "@aztec/noir-acvm_js": "npm:1.0.0-beta.20"
+    "@aztec/noir-noirc_abi": "npm:1.0.0-beta.20"
+    "@aztec/noir-types": "npm:1.0.0-beta.20"
     pako: "npm:^2.1.0"
-  checksum: 10/8e144df7c33c34852a2e26dfff1efeb6d28b7d55e121f4047f53beee09fc73d5b3ba610e1abd108eb55911e084f346e0d101beb8830d916a79883bc6a78d0b6e
+  checksum: 10/8f8e5f43a6ff2382a3826804c90c8053d5033a4b8d1d1119600938807fa41c04ab19652dccaa5397dd303080c8e64b1d871262c28ef01415a13424dd5bf2e892
   languageName: node
   linkType: hard
 
@@ -1647,7 +1647,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@aztec/noir-noirc_abi@portal:../noir/packages/noirc_abi::locator=%40aztec%2Faztec3-packages%40workspace%3A."
   dependencies:
-    "@aztec/noir-types": "npm:1.0.0-beta.19"
+    "@aztec/noir-types": "npm:1.0.0-beta.20"
   languageName: node
   linkType: soft
 

--- a/yarn-project/yarn.lock
+++ b/yarn-project/yarn.lock
@@ -1481,6 +1481,7 @@ __metadata:
     "@aztec/native": "workspace:^"
     "@aztec/stdlib": "workspace:^"
     "@jest/globals": "npm:^30.0.0"
+    "@sqlite.org/sqlite-wasm": "npm:3.50.4-build1"
     "@types/chai": "npm:^5.0.1"
     "@types/chai-as-promised": "npm:^8.0.1"
     "@types/jest": "npm:^30.0.0"
@@ -1622,7 +1623,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@aztec/noir-noir_codegen@portal:../noir/packages/noir_codegen::locator=%40aztec%2Faztec3-packages%40workspace%3A."
   dependencies:
-    "@aztec/noir-types": "npm:1.0.0-beta.20"
+    "@aztec/noir-types": "npm:1.0.0-beta.19"
     glob: "npm:^13.0.6"
     ts-command-line-args: "npm:^2.5.1"
   bin:
@@ -1631,14 +1632,14 @@ __metadata:
   linkType: soft
 
 "@aztec/noir-noir_js@file:../noir/packages/noir_js::locator=%40aztec%2Faztec3-packages%40workspace%3A.":
-  version: 1.0.0-beta.20
-  resolution: "@aztec/noir-noir_js@file:../noir/packages/noir_js#../noir/packages/noir_js::hash=6edf14&locator=%40aztec%2Faztec3-packages%40workspace%3A."
+  version: 1.0.0-beta.19
+  resolution: "@aztec/noir-noir_js@file:../noir/packages/noir_js#../noir/packages/noir_js::hash=c0ce11&locator=%40aztec%2Faztec3-packages%40workspace%3A."
   dependencies:
-    "@aztec/noir-acvm_js": "npm:1.0.0-beta.20"
-    "@aztec/noir-noirc_abi": "npm:1.0.0-beta.20"
-    "@aztec/noir-types": "npm:1.0.0-beta.20"
+    "@aztec/noir-acvm_js": "npm:1.0.0-beta.19"
+    "@aztec/noir-noirc_abi": "npm:1.0.0-beta.19"
+    "@aztec/noir-types": "npm:1.0.0-beta.19"
     pako: "npm:^2.1.0"
-  checksum: 10/8f8e5f43a6ff2382a3826804c90c8053d5033a4b8d1d1119600938807fa41c04ab19652dccaa5397dd303080c8e64b1d871262c28ef01415a13424dd5bf2e892
+  checksum: 10/8e144df7c33c34852a2e26dfff1efeb6d28b7d55e121f4047f53beee09fc73d5b3ba610e1abd108eb55911e084f346e0d101beb8830d916a79883bc6a78d0b6e
   languageName: node
   linkType: hard
 
@@ -1646,7 +1647,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@aztec/noir-noirc_abi@portal:../noir/packages/noirc_abi::locator=%40aztec%2Faztec3-packages%40workspace%3A."
   dependencies:
-    "@aztec/noir-types": "npm:1.0.0-beta.20"
+    "@aztec/noir-types": "npm:1.0.0-beta.19"
   languageName: node
   linkType: soft
 
@@ -6942,6 +6943,15 @@ __metadata:
   dependencies:
     tslib: "npm:^2.6.2"
   checksum: 10/26acc5b818d219ec049c1877857afc783dd9c4cb62234b61d1c18b1465ec731ec0aea902bdf6f58f730a4bf72d9564559b1fb14c94ceaafe3d41f6923745a97c
+  languageName: node
+  linkType: hard
+
+"@sqlite.org/sqlite-wasm@npm:3.50.4-build1":
+  version: 3.50.4-build1
+  resolution: "@sqlite.org/sqlite-wasm@npm:3.50.4-build1"
+  bin:
+    sqlite-wasm: bin/index.js
+  checksum: 10/5c486213552029065d8b90de823186465972d9a71b921e2303a6834d271e66fd5c2181c63c4452c2847e0745e8fde4b25b5f6baacf53f377093b16e27bacb2a6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Experimental support for SQLite as a backend to kv-store, with the goal of eventually abandoning IndexedDB