### PR TITLE
fix: handle missing L1 finalized block on devnets

### DIFF
--- a/yarn-project/archiver/src/archiver-sync.test.ts
+++ b/yarn-project/archiver/src/archiver-sync.test.ts
@@ -1336,6 +1336,24 @@ describe('Archiver Sync', () => {
       expect(tips.finalized.block.number).toEqual(lastBlockInCp1);
     });
 
+    it('leaves finalized checkpoint untouched when L1 has no finalized block yet', async () => {
+      await fake.addCheckpoint(CheckpointNumber(1), {
+        l1BlockNumber: 70n,
+        messagesL1BlockNumber: 50n,
+        numL1ToL2Messages: 3,
+      });
+
+      fake.markCheckpointAsProven(CheckpointNumber(1));
+      fake.setL1BlockNumber(101n);
+      fake.setFinalizedL1BlockNumber(undefined);
+
+      await expect(archiver.syncImmediate()).resolves.not.toThrow();
+
+      const tips = await archiver.getL2Tips();
+      expect(tips.finalized.checkpoint.number).toEqual(CheckpointNumber(0));
+      expect(tips.finalized.block.number).toEqual(BlockNumber(0));
+    });
+
     it('does not advance finalized checkpoint when finalized L1 block is before the proven checkpoint', async () => {
       await fake.addCheckpoint(CheckpointNumber(1), {
         l1BlockNumber: 70n,

--- a/yarn-project/archiver/src/modules/l1_synchronizer.ts
+++ b/yarn-project/archiver/src/modules/l1_synchronizer.ts
@@ -2,6 +2,7 @@ import type { BlobClientInterface } from '@aztec/blob-client/client';
 import { EpochCache } from '@aztec/epoch-cache';
 import { InboxContract, type InboxContractState, RollupContract } from '@aztec/ethereum/contracts';
 import type { L1BlockId } from '@aztec/ethereum/l1-types';
+import { getFinalizedL1Block } from '@aztec/ethereum/queries';
 import type { ViemPublicClient, ViemPublicDebugClient } from '@aztec/ethereum/types';
 import { asyncPool } from '@aztec/foundation/async-pool';
 import { maxBigint } from '@aztec/foundation/bigint';
@@ -215,7 +216,11 @@ export class ArchiverL1Synchronizer implements Traceable {
   /** Query L1 for its finalized block and update the finalized checkpoint accordingly. */
   private async updateFinalizedCheckpoint(): Promise<void> {
     try {
-      const finalizedL1Block = await this.publicClient.getBlock({ blockTag: 'finalized', includeTransactions: false });
+      const finalizedL1Block = await getFinalizedL1Block(this.publicClient);
+      if (!finalizedL1Block) {
+        this.log.trace(`Skipping finalized checkpoint update: L1 has no finalized block yet.`);
+        return;
+      }
       const finalizedL1BlockNumber = finalizedL1Block.number;
       const finalizedCheckpointNumber = await this.rollup.getProvenCheckpointNumber({
         blockNumber: finalizedL1BlockNumber,

--- a/yarn-project/archiver/src/test/fake_l1_state.ts
+++ b/yarn-project/archiver/src/test/fake_l1_state.ts
@@ -151,8 +151,10 @@ export class FakeL1State {
   // Computed from checkpoints based on L1 block visibility
   private pendingCheckpointNumber: CheckpointNumber = CheckpointNumber(0);
 
-  // The L1 block number reported as "finalized" (defaults to the start block)
-  private finalizedL1BlockNumber: bigint;
+  // The L1 block number reported as "finalized" (defaults to the start block).
+  // `undefined` simulates the startup window on a fresh devnet where
+  // `getBlock({ blockTag: 'finalized' })` fails with "finalized block not found".
+  private finalizedL1BlockNumber: bigint | undefined;
 
   constructor(private readonly config: FakeL1StateConfig) {
     this.l1BlockNumber = config.l1StartBlock;
@@ -288,8 +290,11 @@ export class FakeL1State {
     this.updatePendingCheckpointNumber();
   }
 
-  /** Sets the L1 block number that will be reported as "finalized". */
-  setFinalizedL1BlockNumber(blockNumber: bigint): void {
+  /**
+   * Sets the L1 block number that will be reported as "finalized". Pass `undefined` to
+   * simulate a chain that does not yet have a finalized block (devnet startup).
+   */
+  setFinalizedL1BlockNumber(blockNumber: bigint | undefined): void {
     this.finalizedL1BlockNumber = blockNumber;
   }
 
@@ -519,6 +524,11 @@ export class FakeL1State {
     publicClient.getBlock.mockImplementation((async (args: { blockNumber?: bigint; blockTag?: string } = {}) => {
       let blockNum: bigint;
       if (args.blockTag === 'finalized') {
+        if (this.finalizedL1BlockNumber === undefined) {
+          throw Object.assign(new Error('finalized block not found'), {
+            details: 'finalized block not found',
+          });
+        }
         blockNum = this.finalizedL1BlockNumber;
       } else {
         blockNum = args.blockNumber ?? (await publicClient.getBlockNumber());

--- a/yarn-project/epoch-cache/src/epoch_cache.test.ts
+++ b/yarn-project/epoch-cache/src/epoch_cache.test.ts
@@ -478,6 +478,32 @@ describe('EpochCache', () => {
       await epochCache.getCommittee(epoch1Slot);
       expect(epochCache.isFinalized(EpochNumber(1))).toBe(true);
     });
+
+    it('treats entries as not finalized when L1 has no finalized block yet', async () => {
+      const epoch1Slot = SlotNumber(EPOCH_DURATION);
+      const epoch1Ts = l1GenesisTime + BigInt(EPOCH_DURATION * SLOT_DURATION);
+      const latestTs = epoch1Ts + 10000n;
+
+      client.getBlock.mockImplementation((args: any) => {
+        if (args?.blockTag === 'finalized') {
+          return Promise.reject(new Error('finalized block not found'));
+        }
+        return Promise.resolve({ timestamp: latestTs, number: 100n, hash: '0xddd' } as any);
+      });
+
+      rollupContract.getCommitteeAt.mockResolvedValue(testCommittee);
+      rollupContract.getSampleSeedAt.mockResolvedValue(Buffer32.fromBigInt(42n));
+
+      const result = await epochCache.getCommittee(epoch1Slot);
+      expect(result.committee).toEqual(testCommittee);
+      expect(epochCache.isFinalized(EpochNumber(1))).toBe(false);
+
+      // Advance past TTL; should re-query since entry is not finalized.
+      jest.setSystemTime(Date.now() + SLOT_DURATION * 1000);
+      rollupContract.getCommitteeAt.mockClear();
+      await epochCache.getCommittee(epoch1Slot);
+      expect(rollupContract.getCommitteeAt).toHaveBeenCalledTimes(0); // lightweight refresh
+    });
   });
 
   describe('proposer pipelining', () => {

--- a/yarn-project/epoch-cache/src/epoch_cache.ts
+++ b/yarn-project/epoch-cache/src/epoch_cache.ts
@@ -1,6 +1,7 @@
 import { createEthereumChain } from '@aztec/ethereum/chain';
 import { makeL1HttpTransport } from '@aztec/ethereum/client';
 import { NoCommitteeError, RollupContract } from '@aztec/ethereum/contracts';
+import { getFinalizedL1Block } from '@aztec/ethereum/queries';
 import { EpochNumber, SlotNumber } from '@aztec/foundation/branded-types';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { type Logger, createLogger } from '@aztec/foundation/log';
@@ -388,7 +389,7 @@ export class EpochCache implements EpochCacheInterface {
   private async refreshStaleEntry(stale: CachedEpochEntry, epoch: EpochNumber, ts: bigint): Promise<CachedEpochEntry> {
     const [blockAtOriginal, l1FinalizedBlock, latestBlock] = await Promise.all([
       this.rollup.client.getBlock({ blockNumber: stale.lastQueryL1BlockNumber, includeTransactions: false }),
-      this.rollup.client.getBlock({ blockTag: 'finalized', includeTransactions: false }),
+      getFinalizedL1Block(this.rollup.client),
       this.rollup.client.getBlock({ includeTransactions: false }),
     ]);
 
@@ -396,7 +397,9 @@ export class EpochCache implements EpochCacheInterface {
       // No reorg: the data is still valid. Check if we can now mark it as finalized.
       const samplingTs = this.getSamplingTimestamp(epoch);
       const finalized =
-        !!(stale.data.committee && stale.data.committee.length > 0) && samplingTs <= l1FinalizedBlock.timestamp;
+        !!(stale.data.committee && stale.data.committee.length > 0) &&
+        l1FinalizedBlock !== undefined &&
+        samplingTs <= l1FinalizedBlock.timestamp;
 
       const refreshed: CachedEpochEntry = {
         ...stale,
@@ -429,13 +432,13 @@ export class EpochCache implements EpochCacheInterface {
   private async fetchAndCache(
     epoch: EpochNumber,
     ts: bigint,
-    prefetched?: { latestBlock: L1BlockInfo; finalizedBlock: { timestamp: bigint } },
+    prefetched?: { latestBlock: L1BlockInfo; finalizedBlock: { timestamp: bigint } | undefined },
   ): Promise<CachedEpochEntry> {
     const [committee, seedBuffer, latestBlock, finalizedBlock, isEscapeHatchOpen] = await Promise.all([
       this.rollup.getCommitteeAt(ts),
       this.rollup.getSampleSeedAt(ts),
       prefetched?.latestBlock ?? this.rollup.client.getBlock({ includeTransactions: false }),
-      prefetched?.finalizedBlock ?? this.rollup.client.getBlock({ blockTag: 'finalized', includeTransactions: false }),
+      prefetched !== undefined ? prefetched.finalizedBlock : getFinalizedL1Block(this.rollup.client),
       this.rollup.isEscapeHatchOpen(epoch),
     ]);
 
@@ -450,8 +453,9 @@ export class EpochCache implements EpochCacheInterface {
     }
 
     // Empty committees are never marked finalized so they always get re-queried after TTL.
+    // If L1 has no finalized block yet (devnet startup), entries stay unfinalized.
     const hasCommittee = !!(committee && committee.length > 0);
-    const finalized = hasCommittee && samplingTs <= finalizedBlock.timestamp;
+    const finalized = hasCommittee && finalizedBlock !== undefined && samplingTs <= finalizedBlock.timestamp;
     const data: EpochCommitteeInfo = { committee, seed: seedBuffer.toBigInt(), epoch, isEscapeHatchOpen };
     const entry: CachedEpochEntry = {
       data,

--- a/yarn-project/ethereum/src/queries.test.ts
+++ b/yarn-project/ethereum/src/queries.test.ts
@@ -1,0 +1,70 @@
+import { type MockProxy, mock } from 'jest-mock-extended';
+import { BaseError, RpcRequestError } from 'viem';
+
+import { getFinalizedL1Block, isFinalizedBlockTagNotFoundError } from './queries.js';
+import type { ViemPublicClient } from './types.js';
+
+describe('isFinalizedBlockTagNotFoundError', () => {
+  const makeRpcError = (code: number, message: string) =>
+    new RpcRequestError({
+      body: {},
+      error: { code, message },
+      url: 'http://localhost:8545',
+    });
+
+  it.each([
+    ['geth finalized', -32000, 'finalized block not found'],
+    ['geth safe', -32000, 'safe block not found'],
+    ['reth finalized', -32001, 'block not found: finalized'],
+    ['reth safe', -32001, 'block not found: safe'],
+    ['nethermind', -39001, 'Unknown block error'],
+    ['besu', -39001, 'Unknown block'],
+    ['erigon finalized', -39001, 'block "finalized" not available (head block: 5)'],
+    ['erigon safe', -39001, 'block "safe" not available (head block: 5)'],
+  ])('matches %s', (_name, code, message) => {
+    const viemErr = new BaseError('Request failed', { cause: makeRpcError(code, message) });
+    expect(isFinalizedBlockTagNotFoundError(viemErr)).toBe(true);
+  });
+
+  it('matches a plain Error whose message says the safe block is missing', () => {
+    expect(isFinalizedBlockTagNotFoundError(new Error('safe block not found'))).toBe(true);
+  });
+
+  it('matches a nested cause chain', () => {
+    const inner = new Error('finalized block not found');
+    const mid = Object.assign(new Error('rpc error'), { cause: inner });
+    const outer = Object.assign(new Error('wrapped'), { cause: mid });
+    expect(isFinalizedBlockTagNotFoundError(outer)).toBe(true);
+  });
+
+  it('does not match unrelated errors', () => {
+    expect(isFinalizedBlockTagNotFoundError(new Error('reverted: returned no data'))).toBe(false);
+    expect(isFinalizedBlockTagNotFoundError(null)).toBe(false);
+    expect(isFinalizedBlockTagNotFoundError(undefined)).toBe(false);
+  });
+});
+
+describe('getFinalizedL1Block', () => {
+  let client: MockProxy<ViemPublicClient>;
+
+  beforeEach(() => {
+    client = mock<ViemPublicClient>();
+  });
+
+  it('returns the finalized block on happy path', async () => {
+    const block = { number: 42n, timestamp: 100n, hash: '0xabc' } as any;
+    client.getBlock.mockResolvedValue(block);
+    await expect(getFinalizedL1Block(client)).resolves.toBe(block);
+  });
+
+  it('returns undefined when L1 has no finalized block', async () => {
+    client.getBlock.mockRejectedValue(new Error('finalized block not found'));
+    await expect(getFinalizedL1Block(client)).resolves.toBeUndefined();
+  });
+
+  it('rethrows unrelated errors', async () => {
+    const err = new Error('connection refused');
+    client.getBlock.mockRejectedValue(err);
+    await expect(getFinalizedL1Block(client)).rejects.toBe(err);
+  });
+});

--- a/yarn-project/ethereum/src/queries.ts
+++ b/yarn-project/ethereum/src/queries.ts
@@ -1,11 +1,77 @@
 import { EthAddress } from '@aztec/foundation/eth-address';
 
+import { BaseError, type Block } from 'viem';
+
 import { DefaultL1ContractsConfig, type L1ContractsConfig } from './config.js';
 import { ReadOnlyGovernanceContract } from './contracts/governance.js';
 import { GovernanceProposerContract } from './contracts/governance_proposer.js';
 import { InboxContract } from './contracts/inbox.js';
 import { RollupContract } from './contracts/rollup.js';
-import type { ViemPublicClient } from './types.js';
+import type { ViemClient, ViemPublicClient } from './types.js';
+
+/**
+ * Returns the L1 finalized block, or `undefined` if the chain does not yet have one
+ * (common on freshly started devnets). Rethrows any other RPC error.
+ */
+export async function getFinalizedL1Block(client: ViemClient): Promise<Block<bigint, false, 'finalized'> | undefined> {
+  try {
+    return await client.getBlock({ blockTag: 'finalized', includeTransactions: false });
+  } catch (err) {
+    if (isFinalizedBlockTagNotFoundError(err)) {
+      return undefined;
+    }
+    throw err;
+  }
+}
+
+// Error messages returned by popular Ethereum execution clients when
+// eth_getBlockByNumber / eth_call is called with blockTag "finalized" or
+// "safe" and no such block has been produced yet:
+//
+//   geth       "finalized block not found"
+//              "safe block not found"
+//   reth       "block not found: finalized"
+//              "block not found: safe"
+//   nethermind "Unknown block error"           (same for both tags)
+//   besu       "Unknown block"
+//   erigon     'block "finalized" not available (head block: N)'
+//              'block "safe" not available (head block: N)'
+//
+// A combined regex covers all five:
+const FINALIZED_BLOCK_TAG_NOT_FOUND_MESSAGE_RE =
+  /(finalized|safe) block not found|block not found: (finalized|safe)|unknown block|block "(finalized|safe)" not available/i;
+
+/**
+ * Returns true if the error originates from an RPC call that failed because
+ * the "finalized" (or "safe") block tag is not yet available on the chain.
+ */
+export function isFinalizedBlockTagNotFoundError(err: unknown): boolean {
+  if (!err) {
+    return false;
+  }
+
+  if (err instanceof BaseError) {
+    const hit = err.walk((e: any) => matchesFinalizedBlockTagNotFound(e));
+    if (hit) {
+      return true;
+    }
+  }
+
+  for (let cur: any = err, i = 0; cur && i < 10; cur = cur.cause, i++) {
+    if (matchesFinalizedBlockTagNotFound(cur)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function matchesFinalizedBlockTagNotFound(e: any): boolean {
+  if (!e) {
+    return false;
+  }
+  const text = `${e.details ?? ''} ${e.message ?? ''} ${e.shortMessage ?? ''}`;
+  return FINALIZED_BLOCK_TAG_NOT_FOUND_MESSAGE_RE.test(text);
+}
 
 /** Reads the L1ContractsConfig from L1 contracts. */
 export async function getL1ContractsConfig(


### PR DESCRIPTION
## Motivation

On freshly-started L1 devnets (anvil, local geth/reth/nethermind) there is a startup window during which the `finalized` block tag is not yet available — calls like `getBlock({ blockTag: 'finalized' })` fail with a JSON-RPC error instead of returning a block. The archiver currently logs noisy warnings during this window and epoch-cache would crash dereferencing the missing block's timestamp.

## Approach

Added a shared `getFinalizedL1Block` helper in `@aztec/ethereum/queries` that returns `undefined` when the chain has no finalized block yet, distinguishing that specific failure from other RPC errors by walking the viem error chain for the `"finalized|safe block not found"` message (the code `-32000` surfaced by geth/reth/nethermind). All three production call sites now handle `undefined` gracefully: the archiver skips the finalized checkpoint update, and epoch-cache treats entries as "not finalized yet" so they continue to refresh on TTL until the L1 chain catches up.

## Changes

- **ethereum**: New `getFinalizedL1Block` helper and `isFinalizedBlockTagNotFoundError` predicate in `queries.ts`.
- **archiver**: `updateFinalizedCheckpoint` uses the helper and returns early with a trace log instead of warning; removed the old `"returned no data"` substring workaround.
- **epoch-cache**: `refreshStaleEntry` and `fetchAndCache` use the helper and guard the `samplingTs <= finalizedBlock.timestamp` comparison so entries stay unfinalized when L1 has none yet.
- **tests**: Unit tests for the helper/predicate, an archiver sync test using `FakeL1State` configured with no finalized block, and an epoch-cache test asserting entries stay unfinalized and keep refreshing.