### PR TITLE
docs: fix v4.2.0 counter tutorial and debug logging references

### DIFF
--- a/docs/developer_versioned_docs/version-v4.2.0/docs/aztec-nr/debugging.md
+++ b/docs/developer_versioned_docs/version-v4.2.0/docs/aztec-nr/debugging.md
@@ -31,7 +31,7 @@ Log values from your contract using `debug_log`:
 
 ```rust
 // Import debug logging
-use dep::aztec::oracle::debug_log::{ debug_log, debug_log_format };
+use dep::aztec::oracle::logging::{ debug_log, debug_log_format };
 
 // Log simple messages
 debug_log("checkpoint reached");
@@ -69,6 +69,8 @@ LOG_LEVEL="info;debug:simulator:client_execution_context;debug:simulator:client_
 - `level:module` - Sets level for a specific module
 - `level:module:submodule` - Sets level for a specific submodule
 
+**The default-level filter must be the first segment.** A bare `level:module` with no preceding default (e.g. `LOG_LEVEL="warn:simulator"`) is invalid and throws `Invalid log level`, because the parser reads everything before the first `;` as the default level. To filter only specific modules, lead with a default level — use `silent` to suppress everything else.
+
 ```bash
 # Default level only
 LOG_LEVEL="debug"
@@ -78,6 +80,9 @@ LOG_LEVEL="info;debug:simulator;debug:execution"
 
 # Default level + specific submodule overrides
 LOG_LEVEL="info;debug:simulator:client_execution_context;debug:simulator:client_view_context"
+
+# Silence everything except one module
+LOG_LEVEL="silent;debug:simulator"
 ```
 
 :::
@@ -205,7 +210,7 @@ LOG_LEVEL=verbose aztec start --local-network
 ### Common debug imports
 
 ```rust
-use dep::aztec::oracle::debug_log::{ debug_log, debug_log_format };
+use dep::aztec::oracle::logging::{ debug_log, debug_log_format };
 ```
 
 ### Check contract registration

--- a/docs/developer_versioned_docs/version-v4.2.0/docs/tutorials/contract_tutorials/counter_contract.md
+++ b/docs/developer_versioned_docs/version-v4.2.0/docs/tutorials/contract_tutorials/counter_contract.md
@@ -22,7 +22,7 @@ This tutorial is compatible with the Aztec version `v4.2.0`. Install the correct
 Run this to create a new contract project:
 
 ```bash
-aztec new --contract counter
+aztec new counter
 ```
 
 Your structure should look like this:

--- a/docs/developer_versioned_docs/version-v4.2.0/docs/tutorials/contract_tutorials/counter_contract.md
+++ b/docs/developer_versioned_docs/version-v4.2.0/docs/tutorials/contract_tutorials/counter_contract.md
@@ -90,7 +90,7 @@ use balance_set::BalanceSet;
 - `messages::message_delivery::MessageDelivery`
   Imports `MessageDelivery` for specifying how note delivery should be handled (e.g., constrained onchain delivery).
 
-- `oracle::debug_log::debug_log_format`
+- `oracle::logging::debug_log_format`
   Imports a debug logging utility for printing formatted messages during contract execution.
 
 - `protocol::{address::AztecAddress, traits::ToField}`

--- a/docs/docs-developers/docs/aztec-nr/logging.md
+++ b/docs/docs-developers/docs/aztec-nr/logging.md
@@ -113,7 +113,7 @@ The `LOG_LEVEL` environment variable uses a semicolon-delimited format:
 <default_level>;<level>:<module1>,<module2>;<level>:<module3>
 ```
 
-- **First segment**: the default log level for all modules
+- **First segment (required)**: the default log level for all modules. A bare `level:module` with no preceding default (e.g. `LOG_LEVEL="warn:simulator"`) is invalid and throws `Invalid log level` — the parser always reads the segment before the first `;` as the default level. To filter only specific modules, start with `silent` (e.g. `LOG_LEVEL="silent;debug:simulator"`)
 - **Remaining segments**: `level:module` pairs that override the default for specific modules
 - Modules are comma-separated within a segment
 - The `aztec:` prefix is automatically stripped from module names

--- a/docs/docs-developers/docs/tutorials/contract_tutorials/counter_contract.md
+++ b/docs/docs-developers/docs/tutorials/contract_tutorials/counter_contract.md
@@ -82,7 +82,7 @@ pub contract Counter {
 - `messages::message_delivery::MessageDelivery`
   Imports `MessageDelivery` for specifying how note delivery should be handled (e.g., constrained onchain delivery).
 
-- `oracle::debug_log::debug_log_format`
+- `oracle::logging::debug_log_format`
   Imports a debug logging utility for printing formatted messages during contract execution.
 
 - `protocol::{address::AztecAddress, traits::ToField}`


### PR DESCRIPTION
## Summary

Three stale/confusing bits in v4.2.0 developer docs that trip up users following the Counter/Token tutorials.

**1. `aztec new --contract counter` fails**

The tutorial at `/developers/docs/tutorials/contract_tutorials/counter_contract` (Alpha / v4.2.0) instructs:

```bash
aztec new --contract counter
```

This fails with `error: the argument '--contract' cannot be used multiple times` — the `aztec new` wrapper (`yarn-project/aztec/scripts/new.sh`) already auto-injects `--contract` into the underlying `nargo new` call. The unversioned source was already correct; only the v4.2.0 snapshot retained the duplicate flag.

**2. `use aztec::oracle::debug_log::{...}` fails to compile**

The `debug_log` module was renamed to `logging` (see `migration_notes.md` entry "[Aztec.nr] `debug_log` module renamed to `logging`"), but `debugging.md` still showed the old path:

```rust
use dep::aztec::oracle::debug_log::{ debug_log, debug_log_format };
```

Users hit `error: Could not resolve 'debug_log' in path` from nargo. In the counter tutorial the code sample already uses the correct `oracle::logging::debug_log_format`, but the description bullet below it still named the old `oracle::debug_log::debug_log_format` path — fixed so they match.

**3. `LOG_LEVEL` filter-format docs miss the required default**

The "Log filter format" note implies `level:module` is a standalone filter (bullet list `- \`level\``, `- \`level:module\``, ...). In reality the parser always reads the segment before the first `;` as the default level, so `LOG_LEVEL="warn:simulator"` throws `Invalid log level: warn:simulator`. Reworded to call out that the default segment is required, and added a `silent;debug:simulator` example for the "filter one module only" case. Same clarification applied to the unversioned `logging.md` syntax-reference section.

## Changes

- `docs/developer_versioned_docs/version-v4.2.0/docs/tutorials/contract_tutorials/counter_contract.md`: `aztec new --contract counter` -> `aztec new counter`; fix `oracle::debug_log` bullet
- `docs/developer_versioned_docs/version-v4.2.0/docs/aztec-nr/debugging.md`: `oracle::debug_log` -> `oracle::logging` in both code samples; rewrite `LOG_LEVEL` info box
- `docs/docs-developers/docs/tutorials/contract_tutorials/counter_contract.md`: fix `oracle::debug_log` bullet on unversioned source
- `docs/docs-developers/docs/aztec-nr/logging.md`: clarify that the default-level segment is required in `LOG_LEVEL`

## Test plan

- [ ] At `/developers/docs/tutorials/contract_tutorials/counter_contract` (Alpha v4.2.0), confirm command is `aztec new counter`
- [ ] At `/developers/docs/aztec-nr/debugging` (Alpha v4.2.0), confirm import path is `aztec::oracle::logging::{...}` and the `LOG_LEVEL` note explicitly calls out the required default segment
- [ ] Copying the counter import block compiles against `aztec-nr` v4.2.0