### PR TITLE
docs: fix issues with Creating Accounts page

### DIFF
--- a/docs/developer_versioned_docs/version-v4.2.0/docs/aztec-js/how_to_create_account.md
+++ b/docs/developer_versioned_docs/version-v4.2.0/docs/aztec-js/how_to_create_account.md
@@ -15,7 +15,7 @@ This guide shows you how to create and deploy a new account on Aztec.
 ## Install dependencies
 
 ```bash
-yarn add @aztec/aztec.js@4.2.0 @aztec/wallets@4.2.0
+yarn add @aztec/aztec.js@4.2.0 @aztec/wallets@4.2.0 @aztec/noir-contracts.js@4.2.0
 ```
 
 ## Create a new account
@@ -78,7 +78,7 @@ await deployMethod.send({
 
 
 :::info
-See the [guide on fees](./how_to_pay_fees.md#sponsored-fpc) for setting up the Sponsored FPC.
+See the [guide on fees](./how_to_pay_fees.md#sponsored-fpc) for more details on the Sponsored FPC and what this snippet means.
 :::
 
 ### Using Fee Juice

--- a/docs/developer_versioned_docs/version-v4.2.0/docs/aztec-js/how_to_create_account.md
+++ b/docs/developer_versioned_docs/version-v4.2.0/docs/aztec-js/how_to_create_account.md
@@ -83,7 +83,23 @@ See the [guide on fees](./how_to_pay_fees.md#sponsored-fpc) for more details on 
 
 ### Using Fee Juice
 
-If your account has Fee Juice from a [bridge from L1](./how_to_pay_fees.md#bridge-fee-juice-from-l1), you can claim it and deploy in one step using `FeeJuicePaymentMethodWithClaim`:
+If your account has Fee Juice from a [bridge from L1](./how_to_pay_fees.md#bridge-fee-juice-from-l1), you can claim it and deploy in one step using `FeeJuicePaymentMethodWithClaim`.
+
+Create a new Schnorr account for this path:
+
+```typescript title="create_fee_juice_account" showLineNumbers
+// `feeJuiceAccount` is just another Schnorr account — the same kind as
+// `newAccount` above. It gets its own name here so both deploy paths
+// can coexist in one example; in your own code, pick whichever name fits.
+const feeJuiceSecret = Fr.random();
+const feeJuiceSalt = Fr.random();
+const feeJuiceAccount = await wallet.createSchnorrAccount(
+  feeJuiceSecret,
+  feeJuiceSalt,
+);
+```
+
+Claim the bridged Fee Juice and deploy in one step:
 
 ```typescript title="bridge_fee_juice_claim" showLineNumbers 
 import { FeeJuicePaymentMethodWithClaim } from "@aztec/aztec.js/fee";
@@ -108,10 +124,12 @@ The `from: NO_FROM` signals that this transaction should be executed without acc
 
 ## Verify deployment
 
-Confirm the account was deployed successfully:
+Confirm the account was deployed successfully. Substitute the account variable for whichever path you used above (`newAccount` for the Sponsored FPC path, `feeJuiceAccount` for the Fee Juice path):
 
 ```typescript title="verify_account_deployment" showLineNumbers 
-const metadata = await wallet.getContractMetadata(feeJuiceAccount.address);
+// `newAccount` refers to whichever account you just deployed —
+// either the Sponsored FPC account or `feeJuiceAccount` from the Fee Juice path.
+const metadata = await wallet.getContractMetadata(newAccount.address);
 console.log("Account deployed:", metadata.initializationStatus);
 ```
 > <sup><sub><a href="https://github.com/AztecProtocol/aztec-packages/blob/v4.2.0/docs/examples/ts/aztecjs_connection/index.ts#L167-L170" target="_blank" rel="noopener noreferrer">Source code: docs/examples/ts/aztecjs_connection/index.ts#L167-L170</a></sub></sup>

--- a/docs/docs-developers/docs/aztec-js/how_to_create_account.md
+++ b/docs/docs-developers/docs/aztec-js/how_to_create_account.md
@@ -15,7 +15,7 @@ This guide shows you how to create and deploy a new account on Aztec.
 ## Install dependencies
 
 ```bash
-yarn add @aztec/aztec.js@#include_version_without_prefix @aztec/wallets@#include_version_without_prefix
+yarn add @aztec/aztec.js@#include_version_without_prefix @aztec/wallets@#include_version_without_prefix @aztec/noir-contracts.js@#include_version_without_prefix
 ```
 
 ## Create a new account
@@ -41,7 +41,7 @@ If your account doesn't have Fee Juice, use the [Sponsored FPC](./how_to_pay_fee
 #include_code deploy_account_sponsored_fpc /docs/examples/ts/aztecjs_connection/index.ts typescript
 
 :::info
-See the [guide on fees](./how_to_pay_fees.md#sponsored-fpc) for setting up the Sponsored FPC.
+See the [guide on fees](./how_to_pay_fees.md#sponsored-fpc) for more details on the Sponsored FPC and what this snippet means.
 :::
 
 ### Using Fee Juice

--- a/docs/docs-developers/docs/aztec-js/how_to_create_account.md
+++ b/docs/docs-developers/docs/aztec-js/how_to_create_account.md
@@ -46,7 +46,13 @@ See the [guide on fees](./how_to_pay_fees.md#sponsored-fpc) for more details on 
 
 ### Using Fee Juice
 
-If your account has Fee Juice from a [bridge from L1](./how_to_pay_fees.md#bridge-fee-juice-from-l1), you can claim it and deploy in one step using `FeeJuicePaymentMethodWithClaim`:
+If your account has Fee Juice from a [bridge from L1](./how_to_pay_fees.md#bridge-fee-juice-from-l1), you can claim it and deploy in one step using `FeeJuicePaymentMethodWithClaim`.
+
+Create a new Schnorr account for this path:
+
+#include_code create_fee_juice_account /docs/examples/ts/aztecjs_connection/index.ts typescript
+
+Claim the bridged Fee Juice and deploy in one step:
 
 #include_code bridge_fee_juice_claim /docs/examples/ts/aztecjs_connection/index.ts typescript
 
@@ -56,7 +62,7 @@ The `from: NO_FROM` signals that this transaction should be executed without acc
 
 ## Verify deployment
 
-Confirm the account was deployed successfully:
+Confirm the account was deployed successfully. Substitute the account variable for whichever path you used above (`newAccount` for the Sponsored FPC path, `feeJuiceAccount` for the Fee Juice path):
 
 #include_code verify_account_deployment /docs/examples/ts/aztecjs_connection/index.ts typescript
 

--- a/docs/examples/ts/aztecjs_connection/index.ts
+++ b/docs/examples/ts/aztecjs_connection/index.ts
@@ -81,13 +81,17 @@ await deployMethod.send({
 });
 // docs:end:deploy_account_sponsored_fpc
 
-// Create a separate account to deploy with Fee Juice bridged from L1
+// docs:start:create_fee_juice_account
+// `feeJuiceAccount` is just another Schnorr account — the same kind as
+// `newAccount` above. It gets its own name here so both deploy paths
+// can coexist in one example; in your own code, pick whichever name fits.
 const feeJuiceSecret = Fr.random();
 const feeJuiceSalt = Fr.random();
 const feeJuiceAccount = await wallet.createSchnorrAccount(
   feeJuiceSecret,
   feeJuiceSalt,
 );
+// docs:end:create_fee_juice_account
 
 // docs:start:bridge_fee_juice_setup
 import { createExtendedL1Client } from "@aztec/ethereum/client";
@@ -165,6 +169,11 @@ await deployMethodBridged.send({
 // docs:end:bridge_fee_juice_claim
 
 // docs:start:verify_account_deployment
-const metadata = await wallet.getContractMetadata(feeJuiceAccount.address);
+// `newAccount` refers to whichever account you just deployed —
+// either the Sponsored FPC account or `feeJuiceAccount` from the Fee Juice path.
+const metadata = await wallet.getContractMetadata(newAccount.address);
 console.log("Account deployed:", metadata.initializationStatus);
 // docs:end:verify_account_deployment
+
+const feeJuiceMetadata = await wallet.getContractMetadata(feeJuiceAccount.address);
+console.log("Fee Juice account deployed:", feeJuiceMetadata.initializationStatus);


### PR DESCRIPTION
## Summary

Three issues on `/developers/docs/aztec-js/how_to_create_account` that block users following the guide end-to-end.

**1. Install command missing `@aztec/noir-contracts.js`.** The Sponsored FPC snippet imports `@aztec/noir-contracts.js/SponsoredFPC`, but the Install dependencies section only lists `@aztec/aztec.js` and `@aztec/wallets`. Users hit `Cannot find module '@aztec/noir-contracts.js/SponsoredFPC'`. Other pages (`aztecjs-getting-started.md`, `aztec-js/index.md`) already list this package.

**2. Misleading info-note wording.** The note below the Sponsored FPC snippet says "See the guide on fees for **setting up** the Sponsored FPC." The Sponsored FPC is a canonical protocol contract that's already deployed — the snippet just registers its artifact with the PXE. "Setting up" implies the user needs to deploy or configure something they don't. Reworded to "for more details on the Sponsored FPC and what this snippet means."

**3. Invisible `feeJuiceAccount` in Verify deployment.** The `bridge_fee_juice_claim` and `verify_account_deployment` snippets reference `feeJuiceAccount`, but that variable was created between `docs:start`/`docs:end` markers in the shared example file — so it never made it into the rendered page. Users following the Sponsored FPC path hit `ReferenceError: feeJuiceAccount is not defined` at the verify step.

Fix:
- Wrap the second account's `createSchnorrAccount` call in a new `docs:start:create_fee_juice_account` block in the example so it's extracted into the Fee Juice section, with a reader-facing comment explaining it's just another Schnorr account with a distinct name to let both paths coexist in one example.
- Switch `verify_account_deployment` to reference `newAccount` (the variable already introduced earlier on the page), with a comment noting the substitution for users who took the Fee Juice path.
- Add a plain extra `getContractMetadata` call for `feeJuiceAccount` outside the docs block so the runnable example still exercises both deployments end-to-end.

## Files changed

- `docs/examples/ts/aztecjs_connection/index.ts` — new `create_fee_juice_account` docs block; `verify_account_deployment` now uses `newAccount` with inline comment; extra non-extracted verification keeps test coverage of the Fee Juice path.
- `docs/developer_versioned_docs/version-v4.2.0/docs/aztec-js/how_to_create_account.md` — install line gains `@aztec/noir-contracts.js@4.2.0`; info note reworded; new inline `create_fee_juice_account` code block; verify snippet updated.
- `docs/docs-developers/docs/aztec-js/how_to_create_account.md` — same edits, using the `#include_code` macro and `#include_version_without_prefix` where applicable.

## Test plan

- [ ] Install command on the rendered page lists three packages including `@aztec/noir-contracts.js`.
- [ ] Info note below the Sponsored FPC snippet no longer reads "setting up the Sponsored FPC."
- [ ] The Fee Juice section now shows a code block introducing `feeJuiceAccount`.
- [ ] Copying the Sponsored FPC snippets end-to-end (create → deploy → verify) runs without `Cannot find module` or `ReferenceError` errors.