### PR TITLE
fix(docs): Noir LSP and binaries installed by the aztec installer 

### DIFF
--- a/docs/developer_versioned_docs/version-v4.2.0/docs/aztec-nr/installation.md
+++ b/docs/developer_versioned_docs/version-v4.2.0/docs/aztec-nr/installation.md
@@ -5,14 +5,24 @@ tags: [local network, sandbox]
 description: Learn how to install and configure the Noir Language Server for a better development experience.
 ---
 
-Install the [Noir Language Support extension](https://marketplace.visualstudio.com/items?itemName=noir-lang.vscode-noir) to get syntax highlighting, syntax error detection and go-to definitions for your Aztec contracts.
+Install the [Noir Language Support extension](https://marketplace.visualstudio.com/items?itemName=noir-lang.vscode-noir) to get syntax highlighting, syntax error detection, and go-to definitions for your Aztec contracts.
 
-Once the extension is installed, check your nargo binary by hovering over Nargo in the status bar on the bottom right of the application window. Click to choose the path to `aztec` (or regular nargo, if you have that installed).
-
-You can print the path of your `aztec` executable by running:
+The extension drives its language server with `nargo`. The Aztec installer installs its own version of `nargo` and adds that directory to your `PATH`, so in most cases you do not need to configure anything else. Verify the binary is on your `PATH`:
 
 ```bash
-which aztec
+which nargo
+# expected: $HOME/.aztec/<path to nargo binary>
 ```
 
-To specify a custom nargo executable, go to the VSCode settings and search for "noir", or click extension settings on the `noir-lang` LSP plugin. Update the `Noir: Nargo Path` field to point to your desired `aztec` executable.
+If you have not installed the Aztec toolchain yet, follow [Getting Started on Local Network](../../getting_started_on_local_network.md) first.
+
+## Configure the extension
+
+Leave the extension's `Noir: Nargo Path` setting empty so it auto-discovers `nargo` from your `PATH`. To confirm, hover over **Nargo** in the VSCode status bar in the bottom right corner — it should show the path under the result from `which nargo`.
+
+If auto-discovery fails, set `Noir: Nargo Path` to the absolute path printed by `which nargo`, then reload the window.
+
+## Troubleshooting
+
+- **LSP reports `startFailed` after setting a custom path**: clear `Noir: Nargo Path`, reload the window, and let auto-discovery take over.
+- **`which nargo` points outside `$HOME/.aztec/current/bin`**: another `nargo` earlier on your `PATH` is shadowing the Aztec-provided one. Either remove it or set `Noir: Nargo Path` explicitly to the Aztec-provided `nargo`.

--- a/docs/developer_versioned_docs/version-v4.2.0/getting_started_on_local_network.md
+++ b/docs/developer_versioned_docs/version-v4.2.0/getting_started_on_local_network.md
@@ -42,11 +42,16 @@ Run:
 VERSION=4.2.0 bash -i <(curl -sL https://install.aztec.network/4.2.0)
 ```
 
-This will install the following tools:
+This will install the following tools and add them to your `PATH`:
 
-- **aztec** - compiles and tests aztec contracts and launches various infrastructure subsystems (full local network, sequencer, prover, pxe, etc) and provides utility commands to interact with the network
+- **nargo** - the Noir programming language compiler and simulator
+- **noir-profiler** - a profiler for analyzing and visualizing Noir programs
+- **bb** - the Barretenberg proving backend
+- **aztec** - compiles and tests Aztec contracts and launches various infrastructure subsystems (full local network, sequencer, prover, PXE, etc.) and provides utility commands to interact with the network
 - **aztec-up** - a version manager for the Aztec toolchain. Use `aztec-up install <version>` to install a new version, `aztec-up use <version>` to switch between installed versions, or `aztec-up list` to see installed versions.
-- **aztec-wallet** - a tool for interacting with the aztec network
+- **aztec-wallet** - a tool for interacting with the Aztec network
+
+For syntax highlighting and LSP support while editing contracts, see the [Noir VSCode Extension guide](./docs/aztec-nr/installation.md).
 
 ### Start the local network
 

--- a/docs/docs-developers/docs/aztec-nr/installation.md
+++ b/docs/docs-developers/docs/aztec-nr/installation.md
@@ -5,14 +5,24 @@ tags: [local network, sandbox]
 description: Learn how to install and configure the Noir Language Server for a better development experience.
 ---
 
-Install the [Noir Language Support extension](https://marketplace.visualstudio.com/items?itemName=noir-lang.vscode-noir) to get syntax highlighting, syntax error detection and go-to definitions for your Aztec contracts.
+Install the [Noir Language Support extension](https://marketplace.visualstudio.com/items?itemName=noir-lang.vscode-noir) to get syntax highlighting, syntax error detection, and go-to definitions for your Aztec contracts.
 
-Once the extension is installed, check your nargo binary by hovering over Nargo in the status bar on the bottom right of the application window. Click to choose the path to `aztec` (or regular nargo, if you have that installed).
-
-You can print the path of your `aztec` executable by running:
+The extension drives its language server with `nargo`. The Aztec installer installs its own version of `nargo` and adds that directory to your `PATH`, so in most cases you do not need to configure anything else. Verify the binary is on your `PATH`:
 
 ```bash
-which aztec
+which nargo
+# expected: $HOME/.aztec/<path to nargo binary>
 ```
 
-To specify a custom nargo executable, go to the VSCode settings and search for "noir", or click extension settings on the `noir-lang` LSP plugin. Update the `Noir: Nargo Path` field to point to your desired `aztec` executable.
+If you have not installed the Aztec toolchain yet, follow [Getting Started on Local Network](../../getting_started_on_local_network.md) first.
+
+## Configure the extension
+
+Leave the extension's `Noir: Nargo Path` setting empty so it auto-discovers `nargo` from your `PATH`. To confirm, hover over **Nargo** in the VSCode status bar in the bottom right corner — it should show the path under the result from `which nargo`.
+
+If auto-discovery fails, set `Noir: Nargo Path` to the absolute path printed by `which nargo`, then reload the window.
+
+## Troubleshooting
+
+- **LSP reports `startFailed` after setting a custom path**: clear `Noir: Nargo Path`, reload the window, and let auto-discovery take over.
+- **`which nargo` points outside `$HOME/.aztec/current/bin`**: another `nargo` earlier on your `PATH` is shadowing the Aztec-provided one. Either remove it or set `Noir: Nargo Path` explicitly to the Aztec-provided `nargo`.

--- a/docs/docs-developers/getting_started_on_local_network.md
+++ b/docs/docs-developers/getting_started_on_local_network.md
@@ -42,11 +42,16 @@ Run:
 VERSION=#include_version_without_prefix bash -i <(curl -sL https://install.aztec.network/#include_version_without_prefix)
 ```
 
-This will install the following tools:
+This will install the following tools and add them to your `PATH`:
 
-- **aztec** - compiles and tests aztec contracts and launches various infrastructure subsystems (full local network, sequencer, prover, pxe, etc) and provides utility commands to interact with the network
+- **nargo** - the Noir programming language compiler and simulator
+- **noir-profiler** - a profiler for analyzing and visualizing Noir programs
+- **bb** - the Barretenberg proving backend
+- **aztec** - compiles and tests Aztec contracts and launches various infrastructure subsystems (full local network, sequencer, prover, PXE, etc.) and provides utility commands to interact with the network
 - **aztec-up** - a version manager for the Aztec toolchain. Use `aztec-up install <version>` to install a new version, `aztec-up use <version>` to switch between installed versions, or `aztec-up list` to see installed versions.
-- **aztec-wallet** - a tool for interacting with the aztec network
+- **aztec-wallet** - a tool for interacting with the Aztec network
+
+For syntax highlighting and LSP support while editing contracts, see the [Noir VSCode Extension guide](./docs/aztec-nr/installation.md).
 
 ### Start the local network
 


### PR DESCRIPTION
## Summary

Stop conflating `aztec` with `nargo` in the Noir LSP setup guide, and list every binary the installer actually provides.

The docs led me down the wrong path while trying to get the LSP working when going through the counter contract tutorial.

- `docs/aztec-nr/installation.md`: rewritten around `nargo` only. Drops the old `which aztec` guidance (which pointed users at `$HOME/.aztec/current/node_modules/.bin/aztec`, unusable as an LSP backend). Recommends leaving `Noir: Nargo Path` empty for auto-discovery; falls back to `which nargo`. Adds troubleshooting for `startFailed` and shadowed `nargo` on `PATH`.
- `getting_started_on_local_network.md`: install list now matches the `aztec-install` output (adds `nargo`, `noir-profiler`, `bb`) and links to the Noir VSCode Extension guide.
