### PR TITLE
fix(world-state): treat historical block 0 queries as historical, not latest

### DIFF
--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/common/interfaces/dbs.cpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/common/interfaces/dbs.cpp
@@ -205,14 +205,14 @@ void FuzzerWorldStateManager::initialize_world_state()
 
 WorldStateRevision FuzzerWorldStateManager::get_current_revision() const
 {
-    return WorldStateRevision{ .forkId = fork_ids.top(), .blockNumber = 0, .includeUncommitted = true };
+    return WorldStateRevision{ .forkId = fork_ids.top(), .includeUncommitted = true };
 }
 
 WorldStateRevision FuzzerWorldStateManager::fork()
 {
     auto fork_id = ws->create_fork(std::nullopt);
     fork_ids.push(fork_id);
-    return WorldStateRevision{ .forkId = fork_id, .blockNumber = 0, .includeUncommitted = true };
+    return WorldStateRevision{ .forkId = fork_id, .includeUncommitted = true };
 }
 void FuzzerWorldStateManager::reset_world_state()
 {

--- a/barretenberg/cpp/src/barretenberg/world_state/types.hpp
+++ b/barretenberg/cpp/src/barretenberg/world_state/types.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <limits>
 #include <utility>
 #include <variant>
 
@@ -32,14 +33,25 @@ using TreeStateReference = std::pair<bb::fr, bb::crypto::merkle_tree::index_t>;
 using StateReference = std::unordered_map<MerkleTreeId, TreeStateReference>;
 
 struct WorldStateRevision {
+    // Sentinel value for `blockNumber` indicating "not pinned to any historical block;
+    // use the latest committed state of the underlying tree". This is distinct from
+    // `blockNumber == 0`, which means "pin to block 0 (the initial / genesis state)".
+    // We use the maximum uint32_t rather than 0 because 0 is a valid historical block
+    // number (the genesis header), and overloading 0 caused silent regressions where
+    // genesis-anchored witnesses would return the current tip instead of genesis.
+    static constexpr block_number_t LATEST = std::numeric_limits<block_number_t>::max();
+
     index_t forkId{ 0 };
-    block_number_t blockNumber{ 0 };
+    block_number_t blockNumber{ LATEST };
     bool includeUncommitted{ false };
 
     SERIALIZATION_FIELDS(forkId, blockNumber, includeUncommitted)
 
     static WorldStateRevision committed() { return WorldStateRevision{ .includeUncommitted = false }; }
     static WorldStateRevision uncommitted() { return WorldStateRevision{ .includeUncommitted = true }; }
+
+    // True when the revision is pinned to a specific historical block rather than the latest state.
+    bool is_historical() const { return blockNumber != LATEST; }
 
     bool operator==(const WorldStateRevision& other) const = default;
 };

--- a/barretenberg/cpp/src/barretenberg/world_state/world_state.cpp
+++ b/barretenberg/cpp/src/barretenberg/world_state/world_state.cpp
@@ -312,7 +312,7 @@ TreeMetaResponse WorldState::get_tree_info(const WorldStateRevision& revision, M
                 signal.signal_level(0);
             };
 
-            if (revision.blockNumber) {
+            if (revision.is_historical()) {
                 wrapper.tree->get_meta_data(revision.blockNumber, revision.includeUncommitted, callback);
             } else {
                 wrapper.tree->get_meta_data(revision.includeUncommitted, callback);
@@ -351,7 +351,7 @@ void WorldState::get_all_tree_info(const WorldStateRevision& revision, std::arra
         };
         std::visit(
             [&callback, &revision](auto&& wrapper) {
-                if (revision.blockNumber) {
+                if (revision.is_historical()) {
                     wrapper.tree->get_meta_data(revision.blockNumber, revision.includeUncommitted, callback);
                 } else {
                     wrapper.tree->get_meta_data(revision.includeUncommitted, callback);
@@ -414,7 +414,7 @@ StateReference WorldState::get_state_reference(const WorldStateRevision& revisio
         };
         std::visit(
             [&callback, &revision](auto&& wrapper) {
-                if (revision.blockNumber) {
+                if (revision.is_historical()) {
                     wrapper.tree->get_meta_data(revision.blockNumber, revision.includeUncommitted, callback);
                 } else {
                     wrapper.tree->get_meta_data(revision.includeUncommitted, callback);
@@ -456,7 +456,7 @@ fr_sibling_path WorldState::get_sibling_path(const WorldStateRevision& revision,
                 signal.signal_level(0);
             };
 
-            if (revision.blockNumber) {
+            if (revision.is_historical()) {
                 wrapper.tree->get_sibling_path(leaf_index, revision.blockNumber, callback, revision.includeUncommitted);
             } else {
                 wrapper.tree->get_sibling_path(leaf_index, callback, revision.includeUncommitted);
@@ -488,7 +488,7 @@ void WorldState::get_block_numbers_for_leaf_indices(const WorldStateRevision& re
                 signal.signal_level();
             };
 
-            if (revision.blockNumber) {
+            if (revision.is_historical()) {
                 wrapper.tree->find_block_numbers(leafIndices, revision.blockNumber, callback);
             } else {
                 wrapper.tree->find_block_numbers(leafIndices, callback);
@@ -701,14 +701,14 @@ GetLowIndexedLeafResponse WorldState::find_low_leaf_index(const WorldStateRevisi
     };
 
     if (const auto* wrapper = std::get_if<TreeWithStore<NullifierTree>>(&fork->_trees.at(tree_id))) {
-        if (revision.blockNumber != 0U) {
+        if (revision.is_historical()) {
             wrapper->tree->find_low_leaf(leaf_key, revision.blockNumber, revision.includeUncommitted, callback);
         } else {
             wrapper->tree->find_low_leaf(leaf_key, revision.includeUncommitted, callback);
         }
 
     } else if (const auto* wrapper = std::get_if<TreeWithStore<PublicDataTree>>(&fork->_trees.at(tree_id))) {
-        if (revision.blockNumber != 0U) {
+        if (revision.is_historical()) {
             wrapper->tree->find_low_leaf(leaf_key, revision.blockNumber, revision.includeUncommitted, callback);
         } else {
             wrapper->tree->find_low_leaf(leaf_key, revision.includeUncommitted, callback);

--- a/barretenberg/cpp/src/barretenberg/world_state/world_state.cpp
+++ b/barretenberg/cpp/src/barretenberg/world_state/world_state.cpp
@@ -207,7 +207,7 @@ uint64_t WorldState::create_fork(const std::optional<block_number_t>& blockNumbe
     block_number_t blockNumberForFork = 0;
     if (!blockNumber.has_value()) {
         // we are forking at latest
-        WorldStateRevision revision{ .forkId = CANONICAL_FORK_ID, .blockNumber = 0, .includeUncommitted = false };
+        WorldStateRevision revision{ .forkId = CANONICAL_FORK_ID, .includeUncommitted = false };
         TreeMetaResponse archiveMeta = get_tree_info(revision, MerkleTreeId::ARCHIVE);
         blockNumberForFork = archiveMeta.meta.unfinalizedBlockHeight;
     } else {
@@ -739,7 +739,7 @@ WorldStateStatusFull WorldState::unwind_blocks(const block_number_t& toBlockNumb
     // Ensure no uncommitted state
     rollback();
 
-    WorldStateRevision revision{ .forkId = CANONICAL_FORK_ID, .blockNumber = 0, .includeUncommitted = false };
+    WorldStateRevision revision{ .forkId = CANONICAL_FORK_ID, .includeUncommitted = false };
     std::array<TreeMeta, NUM_TREES> responses;
     get_all_tree_info(revision, responses);
 
@@ -773,7 +773,7 @@ WorldStateStatusFull WorldState::unwind_blocks(const block_number_t& toBlockNumb
 
 WorldStateStatusFull WorldState::remove_historical_blocks(const block_number_t& toBlockNumber)
 {
-    WorldStateRevision revision{ .forkId = CANONICAL_FORK_ID, .blockNumber = 0, .includeUncommitted = false };
+    WorldStateRevision revision{ .forkId = CANONICAL_FORK_ID, .includeUncommitted = false };
     std::array<TreeMeta, NUM_TREES> responses;
     get_all_tree_info(revision, responses);
 
@@ -1015,7 +1015,7 @@ bool WorldState::is_archive_tip(const WorldStateRevision& revision, const bb::fr
 
 void WorldState::get_status_summary(WorldStateStatusSummary& status) const
 {
-    WorldStateRevision revision{ .forkId = CANONICAL_FORK_ID, .blockNumber = 0, .includeUncommitted = false };
+    WorldStateRevision revision{ .forkId = CANONICAL_FORK_ID, .includeUncommitted = false };
     std::array<TreeMeta, NUM_TREES> responses;
     get_all_tree_info(revision, responses);
     get_status_summary_from_meta_responses(status, responses);
@@ -1050,7 +1050,7 @@ bool WorldState::is_same_state_reference(const WorldStateRevision& revision, con
 
 void WorldState::validate_trees_are_equally_synched()
 {
-    WorldStateRevision revision{ .forkId = CANONICAL_FORK_ID, .blockNumber = 0, .includeUncommitted = false };
+    WorldStateRevision revision{ .forkId = CANONICAL_FORK_ID, .includeUncommitted = false };
     std::array<TreeMeta, NUM_TREES> responses;
     get_all_tree_info(revision, responses);
 
@@ -1215,7 +1215,7 @@ void WorldState::revert_all_checkpoints_to(const uint64_t& forkId, uint32_t dept
 
 WorldStateStatusFull WorldState::attempt_tree_resync()
 {
-    WorldStateRevision revision{ .forkId = CANONICAL_FORK_ID, .blockNumber = 0, .includeUncommitted = false };
+    WorldStateRevision revision{ .forkId = CANONICAL_FORK_ID, .includeUncommitted = false };
     std::array<TreeMeta, NUM_TREES> responses;
     get_all_tree_info(revision, responses);
 

--- a/barretenberg/cpp/src/barretenberg/world_state/world_state.hpp
+++ b/barretenberg/cpp/src/barretenberg/world_state/world_state.hpp
@@ -455,7 +455,7 @@ std::optional<crypto::merkle_tree::IndexedLeaf<T>> WorldState::get_indexed_leaf(
             signal.signal_level(0);
         };
 
-        if (rev.blockNumber) {
+        if (rev.is_historical()) {
             wrapper->tree->get_leaf(leaf, rev.blockNumber, rev.includeUncommitted, callback);
         } else {
             wrapper->tree->get_leaf(leaf, rev.includeUncommitted, callback);
@@ -499,7 +499,7 @@ std::optional<T> WorldState::get_leaf(const WorldStateRevision& revision,
             signal.signal_level();
         };
 
-        if (revision.blockNumber) {
+        if (revision.is_historical()) {
             wrapper.tree->get_leaf(leaf_index, revision.blockNumber, revision.includeUncommitted, callback);
         } else {
             wrapper.tree->get_leaf(leaf_index, revision.includeUncommitted, callback);
@@ -520,7 +520,7 @@ std::optional<T> WorldState::get_leaf(const WorldStateRevision& revision,
                 signal.signal_level();
             };
 
-        if (revision.blockNumber) {
+        if (revision.is_historical()) {
             wrapper.tree->get_leaf(leaf_index, revision.blockNumber, revision.includeUncommitted, callback);
         } else {
             wrapper.tree->get_leaf(leaf_index, revision.includeUncommitted, callback);
@@ -551,7 +551,7 @@ void WorldState::find_leaf_indices(const WorldStateRevision& rev,
     };
     if constexpr (std::is_same_v<bb::fr, T>) {
         const auto& wrapper = std::get<TreeWithStore<FrTree>>(fork->_trees.at(id));
-        if (rev.blockNumber) {
+        if (rev.is_historical()) {
             wrapper.tree->find_leaf_indices_from(
                 leaves, start_index, rev.blockNumber, rev.includeUncommitted, callback);
         } else {
@@ -563,7 +563,7 @@ void WorldState::find_leaf_indices(const WorldStateRevision& rev,
         using Tree = ContentAddressedIndexedTree<Store, HashPolicy>;
 
         auto& wrapper = std::get<TreeWithStore<Tree>>(fork->_trees.at(id));
-        if (rev.blockNumber) {
+        if (rev.is_historical()) {
             wrapper.tree->find_leaf_indices_from(
                 leaves, start_index, rev.blockNumber, rev.includeUncommitted, callback);
         } else {
@@ -598,7 +598,7 @@ void WorldState::find_sibling_paths(const WorldStateRevision& rev,
     };
     if constexpr (std::is_same_v<bb::fr, T>) {
         const auto& wrapper = std::get<TreeWithStore<FrTree>>(fork->_trees.at(id));
-        if (rev.blockNumber) {
+        if (rev.is_historical()) {
             wrapper.tree->find_leaf_sibling_paths(leaves, rev.blockNumber, rev.includeUncommitted, callback);
         } else {
             wrapper.tree->find_leaf_sibling_paths(leaves, rev.includeUncommitted, callback);
@@ -609,7 +609,7 @@ void WorldState::find_sibling_paths(const WorldStateRevision& rev,
         using Tree = ContentAddressedIndexedTree<Store, HashPolicy>;
 
         auto& wrapper = std::get<TreeWithStore<Tree>>(fork->_trees.at(id));
-        if (rev.blockNumber) {
+        if (rev.is_historical()) {
             wrapper.tree->find_leaf_sibling_paths(leaves, rev.blockNumber, rev.includeUncommitted, callback);
         } else {
             wrapper.tree->find_leaf_sibling_paths(leaves, rev.includeUncommitted, callback);

--- a/yarn-project/aztec-node/src/aztec-node/server.test.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.test.ts
@@ -637,12 +637,14 @@ describe('aztec node', () => {
         await expect(node.getWorldState(blockHash)).rejects.toThrow(/not found in world state at block number/);
       });
 
-      it('returns snapshot at block 0 for initial header hash', async () => {
+      it('returns committed db for initial header hash', async () => {
+        // Block 0 has no historical snapshot in world state, so we must return committed directly.
+        // The hash equality with the known genesis header means there is no reorg risk.
         const initialBlockHash = await initialHeader.hash();
 
         const result = await node.getWorldState(initialBlockHash);
-        expect(worldState.getSnapshot).toHaveBeenCalledWith(BlockNumber.ZERO);
-        expect(result).toBe(snapshotMerkleTreeOps);
+        expect(result).toBe(merkleTreeOps);
+        expect(worldState.getSnapshot).not.toHaveBeenCalled();
       });
     });
 

--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -1714,18 +1714,19 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, AztecNodeDeb
     if (BlockHash.isBlockHash(block)) {
       const initialBlockHash = await this.#getInitialHeaderHash();
       if (block.equals(initialBlockHash)) {
-        // The block source doesn't store the initial header, but the archive tree at index 0 does —
-        // so resolve the block number to zero and fall through to the snapshot + archive-root check below.
-        blockNumber = BlockNumber.ZERO;
-      } else {
-        const header = await this.blockSource.getBlockHeaderByHash(block);
-        if (!header) {
-          throw new Error(
-            `Block hash ${block.toString()} not found when querying world state. If the node API has been queried with anchor block hash possibly a reorg has occurred.`,
-          );
-        }
-        blockNumber = header.getBlockNumber();
+        // Block 0 has no historical snapshot in world state — its state only lives in the
+        // committed/uncommitted view via the tree's initial values. Since the anchor hash matches
+        // the known genesis hash, there is no reorg risk here and we can safely return committed.
+        this.log.debug(`Using committed db for block hash matching genesis header`);
+        return this.worldStateSynchronizer.getCommitted();
       }
+      const header = await this.blockSource.getBlockHeaderByHash(block);
+      if (!header) {
+        throw new Error(
+          `Block hash ${block.toString()} not found when querying world state. If the node API has been queried with anchor block hash possibly a reorg has occurred.`,
+        );
+      }
+      blockNumber = header.getBlockNumber();
     } else {
       blockNumber = block as BlockNumber;
     }

--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -1742,8 +1742,9 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, AztecNodeDeb
     if (BlockHash.isBlockHash(block)) {
       const blockHash = await snapshot.getLeafValue(MerkleTreeId.ARCHIVE, BigInt(blockNumber));
       if (!blockHash || !block.equals(blockHash)) {
+        const initialBlockHash = await this.#getInitialHeaderHash();
         throw new Error(
-          `Block hash ${block.toString()} not found in world state at block number ${blockNumber}. If the node API has been queried with anchor block hash possibly a reorg has occurred.`,
+          `Block hash ${block.toString()} not found in world state at block number ${blockNumber} (world state has ${blockHash?.toString() ?? 'no hash'} at that index, genesis header hash is ${initialBlockHash.toString()}). If the node API has been queried with anchor block hash possibly a reorg has occurred.`,
         );
       }
     }

--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -1714,18 +1714,18 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, AztecNodeDeb
     if (BlockHash.isBlockHash(block)) {
       const initialBlockHash = await this.#getInitialHeaderHash();
       if (block.equals(initialBlockHash)) {
-        // Block source doesn't handle initial header so we need to handle the case separately.
-        return this.worldStateSynchronizer.getSnapshot(BlockNumber.ZERO);
+        // The block source doesn't store the initial header, but the archive tree at index 0 does —
+        // so resolve the block number to zero and fall through to the snapshot + archive-root check below.
+        blockNumber = BlockNumber.ZERO;
+      } else {
+        const header = await this.blockSource.getBlockHeaderByHash(block);
+        if (!header) {
+          throw new Error(
+            `Block hash ${block.toString()} not found when querying world state. If the node API has been queried with anchor block hash possibly a reorg has occurred.`,
+          );
+        }
+        blockNumber = header.getBlockNumber();
       }
-
-      const header = await this.blockSource.getBlockHeaderByHash(block);
-      if (!header) {
-        throw new Error(
-          `Block hash ${block.toString()} not found when querying world state. If the node API has been queried with anchor block hash possibly a reorg has occurred.`,
-        );
-      }
-
-      blockNumber = header.getBlockNumber();
     } else {
       blockNumber = block as BlockNumber;
     }

--- a/yarn-project/pxe/src/pxe.ts
+++ b/yarn-project/pxe/src/pxe.ts
@@ -371,14 +371,13 @@ export class PXE {
   async #executePrivate(
     contractFunctionSimulator: ContractFunctionSimulator,
     txRequest: TxExecutionRequest,
+    anchorBlockHeader: BlockHeader,
     scopes: AztecAddress[],
     jobId: string,
   ): Promise<PrivateExecutionResult> {
     const { origin: contractAddress, functionSelector } = txRequest;
 
     try {
-      const anchorBlockHeader = await this.anchorBlockStore.getBlockHeader();
-
       await this.contractSyncService.ensureContractSynced(
         contractAddress,
         functionSelector,
@@ -483,9 +482,9 @@ export class PXE {
     txExecutionRequest: TxExecutionRequest,
     proofCreator: PrivateKernelProver,
     privateExecutionResult: PrivateExecutionResult,
+    anchorBlockHeader: BlockHeader,
     config: PrivateKernelExecutionProverConfig,
   ): Promise<PrivateKernelExecutionProofOutput<PrivateKernelTailCircuitPublicInputs>> {
-    const anchorBlockHeader = await this.anchorBlockStore.getBlockHeader();
     const kernelOracle = new PrivateKernelOracle(this.contractStore, this.keyStore, this.node, anchorBlockHeader);
     const kernelTraceProver = new PrivateKernelExecutionProver(
       kernelOracle,
@@ -750,16 +749,23 @@ export class PXE {
       try {
         const syncTimer = new Timer();
         await this.blockStateSynchronizer.sync();
+        const anchorBlockHeader = await this.anchorBlockStore.getBlockHeader();
         const syncTime = syncTimer.ms();
         const contractFunctionSimulator = this.#getSimulatorForTx();
-        privateExecutionResult = await this.#executePrivate(contractFunctionSimulator, txRequest, scopes, jobId);
+        privateExecutionResult = await this.#executePrivate(
+          contractFunctionSimulator,
+          txRequest,
+          anchorBlockHeader,
+          scopes,
+          jobId,
+        );
 
         const {
           publicInputs,
           chonkProof,
           executionSteps,
           timings: { proving } = {},
-        } = await this.#prove(txRequest, this.proofCreator, privateExecutionResult, {
+        } = await this.#prove(txRequest, this.proofCreator, privateExecutionResult, anchorBlockHeader, {
           simulate: false,
           skipFeeEnforcement: false,
           profileMode: 'none',
@@ -842,15 +848,23 @@ export class PXE {
         );
         const syncTimer = new Timer();
         await this.blockStateSynchronizer.sync();
+        const anchorBlockHeader = await this.anchorBlockStore.getBlockHeader();
         const syncTime = syncTimer.ms();
 
         const contractFunctionSimulator = this.#getSimulatorForTx();
-        const privateExecutionResult = await this.#executePrivate(contractFunctionSimulator, txRequest, scopes, jobId);
+        const privateExecutionResult = await this.#executePrivate(
+          contractFunctionSimulator,
+          txRequest,
+          anchorBlockHeader,
+          scopes,
+          jobId,
+        );
 
         const { executionSteps, timings: { proving } = {} } = await this.#prove(
           txRequest,
           this.proofCreator,
           privateExecutionResult,
+          anchorBlockHeader,
           {
             simulate: skipProofGeneration,
             skipFeeEnforcement: false,
@@ -940,6 +954,7 @@ export class PXE {
         );
         const syncTimer = new Timer();
         await this.blockStateSynchronizer.sync();
+        const anchorBlockHeader = await this.anchorBlockStore.getBlockHeader();
         const syncTime = syncTimer.ms();
 
         const overriddenContracts = overrides?.contracts ? new Set(Object.keys(overrides.contracts)) : undefined;
@@ -959,7 +974,13 @@ export class PXE {
         }
 
         // Execution of private functions only; no proving, and no kernel logic.
-        const privateExecutionResult = await this.#executePrivate(contractFunctionSimulator, txRequest, scopes, jobId);
+        const privateExecutionResult = await this.#executePrivate(
+          contractFunctionSimulator,
+          txRequest,
+          anchorBlockHeader,
+          scopes,
+          jobId,
+        );
 
         let publicInputs: PrivateKernelTailCircuitPublicInputs | undefined;
         let executionSteps: PrivateExecutionStep[] = [];
@@ -972,11 +993,17 @@ export class PXE {
           ));
         } else {
           // Kernel logic, plus proving of all private functions and kernels.
-          ({ publicInputs, executionSteps } = await this.#prove(txRequest, this.proofCreator, privateExecutionResult, {
-            simulate: true,
-            skipFeeEnforcement,
-            profileMode: 'none',
-          }));
+          ({ publicInputs, executionSteps } = await this.#prove(
+            txRequest,
+            this.proofCreator,
+            privateExecutionResult,
+            anchorBlockHeader,
+            {
+              simulate: true,
+              skipFeeEnforcement,
+              profileMode: 'none',
+            },
+          ));
         }
 
         const privateSimulationResult = new PrivateSimulationResult(privateExecutionResult, publicInputs);

--- a/yarn-project/stdlib/src/world-state/world_state_revision.ts
+++ b/yarn-project/stdlib/src/world-state/world_state_revision.ts
@@ -1,6 +1,14 @@
 import { z } from 'zod';
 
 export class WorldStateRevision {
+  /**
+   * Sentinel `blockNumber` meaning "not pinned to any historical block; use the latest committed
+   * state of the underlying tree". Mirrors the `WorldStateRevision::LATEST` constant on the C++
+   * side (defined as `std::numeric_limits<uint32_t>::max()`). Distinct from `blockNumber === 0`,
+   * which pins to the initial / genesis state.
+   */
+  public static readonly LATEST = 0xffffffff;
+
   constructor(
     public readonly forkId: number,
     public readonly blockNumber: number,
@@ -12,7 +20,7 @@ export class WorldStateRevision {
   }
 
   static empty() {
-    return new WorldStateRevision(0, 0, false);
+    return new WorldStateRevision(0, WorldStateRevision.LATEST, false);
   }
 
   static get schema() {

--- a/yarn-project/world-state/src/native/native_world_state.ts
+++ b/yarn-project/world-state/src/native/native_world_state.ts
@@ -176,7 +176,7 @@ export class NativeWorldStateService implements MerkleTreeDatabase {
       this.initialHeader!,
       new WorldStateRevision(
         /*forkId=*/ resp.forkId,
-        /* blockNumber=*/ BlockNumber.ZERO,
+        /* blockNumber=*/ WorldStateRevision.LATEST,
         /* includeUncommitted=*/ true,
       ),
       opts,


### PR DESCRIPTION
## Summary

- The C++ world state overloaded `WorldStateRevision.blockNumber == 0` as "use latest committed state" via `if (revision.blockNumber)` checks, rather than pinning to block 0. This silently returned the current tip instead of the genesis tree for any genesis-anchored query, once the node advanced past genesis.
- `AztecNodeService.getWorldState` had a short-circuit that mapped initial-header queries directly to `getSnapshot(BlockNumber.ZERO)` and bypassed the archive-root double-check that would otherwise catch the mismatch.
- Any PXE holding its anchor at the initial header (e.g., `syncChainTip: 'checkpointed'` before the first checkpoint commits) produced private-kernel proofs that failed with `Proving public value inclusion failed`: the public-data-tree witness came from the node's advanced tip while the circuit validated it against the initial header's root.

## How PXE ends up querying block zero

1. **PXE seeds its anchor from the initial header.** On first run, `BlockSynchronizer.doSync` (`pxe/src/block_synchronizer/block_synchronizer.ts:178-181`) sees no stored anchor and calls `node.getBlockHeader(BlockNumber.ZERO)`. It stores the resulting header — whose hash is the initial-header hash and whose tree roots are the genesis roots.
2. **`syncChainTip: 'checkpointed'` keeps it pinned.** `handleBlockStreamEvent` (`block_synchronizer.ts:60-74`) only advances the anchor on `chain-checkpointed` events; `blocks-added` is ignored. Until a checkpoint commits on L1 — which takes seconds or longer after sequencers start — the PXE's anchor stays at the initial header.
3. **`proveTx` hands that anchor to the kernel oracle.** After the sync at the top of `proveTx`, the PXE reads the anchor and passes its hash into `new PrivateKernelOracle(..., anchorBlockHash)`. Every oracle call (`getPublicDataWitness`, `getPublicStorageAt`, etc.) uses that hash.
4. **The kernel oracle hits the node with the initial-header hash.** `PrivateKernelOracle.getUpdatedClassIdHints` (`pxe/src/private_kernel/private_kernel_oracle.ts:121-150`) issues `node.getPublicDataWitness(initialHeaderHash, hashLeafSlot)` plus a matching `getPublicStorageAt` read, both pinned to the same hash.
5. **The node short-circuits the initial header.** `AztecNodeService.getWorldState` (`aztec-node/src/aztec-node/server.ts:1714-1719`, pre-fix) recognised the initial-header hash and returned `worldStateSynchronizer.getSnapshot(BlockNumber.ZERO)` directly, skipping the archive-tree reorg check below.
6. **`getSnapshot(0)` builds a revision with `blockNumber = 0`.** `NativeWorldState.getSnapshot` (`world-state/src/native/native_world_state.ts:157-163`) constructed `new WorldStateRevision(forkId=0, blockNumber=0, includeUncommitted=false)` and handed it to the `MerkleTreesFacade`, which forwards it unchanged on every native call.
7. **Native C++ treated `blockNumber == 0` as "latest".** In `barretenberg/cpp/src/barretenberg/world_state/world_state.cpp` every tree op (`get_meta_data`, `get_sibling_path`, `find_low_leaf`, etc.) checked `if (revision.blockNumber)` / `if (revision.blockNumber != 0U)` — zero is falsy, so the code fell into the "no block pin, use latest committed" branch. The returned sibling path, low-leaf preimage, next-index and next-slot were all taken against the current tip.
8. **The circuit mismatched.** Back in Noir (`noir-protocol-circuits/crates/types/src/data/storage_read.nr:41` via `delayed_public_mutable/with_hash.nr`), the membership hash is compared against `historical_header.state.partial.public_data_tree.root` — the genesis root from the PXE's anchor. The oracle-supplied witness was computed against the advanced tip's root. Pre-sequencer the tip happens to equal genesis so it "works"; once block 1 lands they diverge and `assert(is_leaf_in_tree, ...)` fires.

## Fix

- Add an explicit `WorldStateRevision::LATEST` sentinel (`std::numeric_limits<uint32_t>::max()` in C++; mirrored in TS) and an `is_historical()` helper. Replace every `if (revision.blockNumber)` call site in `world_state.cpp` with `if (revision.is_historical())`. Zero now correctly means "pin to block 0".
- Update TS `WorldStateRevision.empty()` and `NativeWorldState.fork()` to pass `LATEST` where the old "0 means latest" semantics were relied on. `getSnapshot(blockNumber)` passes the number through unchanged, so `getSnapshot(0)` now genuinely pins to block 0.
- In `AztecNodeService.getWorldState`, replace the initial-header early return with a block-number resolution to `BlockNumber.ZERO` that falls through to the standard snapshot + archive-root double-check. The archive tree at index 0 stores the initial-header hash (per the assertion in `native_world_state.ts:143`), so the check works uniformly for block 0 too.
- Defensively capture the anchor header once per `proveTx` / `simulateTx` / `profileTx` in `pxe/src/pxe.ts` and thread it through to both `#executePrivate` and `#prove`, rather than re-reading `anchorBlockStore` independently in each call. This cannot drift today (both live inside the same job-queue slot), but makes the invariant explicit and type-checked going forward.

## Test plan

- [x] `yarn build` from `yarn-project`.
- [ ] CI runs full suite, including world-state and e2e tests that exercise `syncChainTip: 'checkpointed'`.
- [ ] Confirm `e2e_epochs/epochs_mbps_redistribution` second test stops emitting `Proving public value inclusion failed` errors once the full stack (including rebuilt `bb`) is deployed.