### PR TITLE
feat(kv-store): encryption-at-rest for SQLite-OPFS + PXE opaque-keys (DO NOT MERGE, PROOF OF CONCEPT)

### DIFF
--- a/yarn-project/kv-store/src/bench/sqlite-opfs-encrypted/map_bench.test.ts
+++ b/yarn-project/kv-store/src/bench/sqlite-opfs-encrypted/map_bench.test.ts
@@ -1,0 +1,36 @@
+/**
+ * Map benchmark suite for the SQLite-OPFS backend with AES-GCM encryption enabled.
+ * Runs the exact same workload as `bench/sqlite-opfs/map_bench.test.ts` but opens
+ * the store with a real `AesGcmCipher` — so the delta between the two runs is the
+ * full cost of cipher.encrypt + cipher.digest on writes and cipher.decrypt on reads.
+ *
+ * Skipped by default; set `VITE_BENCH=1` to run.
+ */
+import { createLogger } from '@aztec/foundation/log';
+
+import { mockLogger } from '../../interfaces/utils.js';
+import { AesGcmCipher, RawKeyProvider } from '../../sqlite-opfs/cipher.js';
+import { AztecSQLiteOPFSStore } from '../../sqlite-opfs/store.js';
+import { describeAztecMapBench } from '../shared_map_bench.js';
+
+const shouldRun = (import.meta as ImportMeta & { env?: { VITE_BENCH?: string } }).env?.VITE_BENCH === '1';
+
+if (shouldRun) {
+  describeAztecMapBench(
+    'SQLite-OPFS (encrypted)',
+    async () => {
+      // A fresh random seed per run keeps the benchmark self-contained; there's no
+      // on-disk continuity to preserve because the store is ephemeral.
+      const cipher = await AesGcmCipher.create(
+        new RawKeyProvider(globalThis.crypto.getRandomValues(new Uint8Array(32))),
+      );
+      return AztecSQLiteOPFSStore.open(mockLogger, undefined, true, undefined, cipher);
+    },
+    createLogger('kv-store:map:benchmarks:sqlite-opfs-encrypted'),
+    () => {},
+  );
+} else {
+  describe.skip('SQLite-OPFS (encrypted) Map benchmarks (set VITE_BENCH=1 to run)', () => {
+    it('skipped', () => {});
+  });
+}

--- a/yarn-project/kv-store/src/indexeddb/store.ts
+++ b/yarn-project/kv-store/src/indexeddb/store.ts
@@ -4,7 +4,7 @@ import { SerialQueue } from '@aztec/foundation/queue';
 import { type DBSchema, type IDBPDatabase, deleteDB, openDB } from 'idb';
 
 import type { AztecAsyncArray } from '../interfaces/array.js';
-import type { Key, StoreSize, Value } from '../interfaces/common.js';
+import type { Key, OpenContainerOptions, StoreSize, Value } from '../interfaces/common.js';
 import type { AztecAsyncCounter } from '../interfaces/counter.js';
 import type { AztecAsyncMap } from '../interfaces/map.js';
 import type { AztecAsyncMultiMap } from '../interfaces/multi_map.js';
@@ -102,7 +102,8 @@ export class AztecIndexedDBStore implements AztecAsyncKVStore {
    * @param name - Name of the map
    * @returns A new AztecMap
    */
-  openMap<K extends Key, V extends Value>(name: string): AztecAsyncMap<K, V> {
+  openMap<K extends Key, V extends Value>(name: string, _options?: OpenContainerOptions): AztecAsyncMap<K, V> {
+    // opaqueKeys is ignored: IDB has no cipher to HMAC with, so keys stay in the clear.
     const map = new IndexedDBAztecMap<K, V>(this.#rootDB, name);
     this.#containers.add(map);
     return map;
@@ -113,7 +114,7 @@ export class AztecIndexedDBStore implements AztecAsyncKVStore {
    * @param name - Name of the set
    * @returns A new AztecSet
    */
-  openSet<K extends Key>(name: string): AztecAsyncSet<K> {
+  openSet<K extends Key>(name: string, _options?: OpenContainerOptions): AztecAsyncSet<K> {
     const set = new IndexedDBAztecSet<K>(this.#rootDB, name);
     this.#containers.add(set);
     return set;
@@ -124,7 +125,10 @@ export class AztecIndexedDBStore implements AztecAsyncKVStore {
    * @param name - Name of the map
    * @returns A new AztecMultiMap
    */
-  openMultiMap<K extends Key, V extends Value>(name: string): AztecAsyncMultiMap<K, V> {
+  openMultiMap<K extends Key, V extends Value>(
+    name: string,
+    _options?: OpenContainerOptions,
+  ): AztecAsyncMultiMap<K, V> {
     const multimap = new IndexedDBAztecMultiMap<K, V>(this.#rootDB, name);
     this.#containers.add(multimap);
     return multimap;

--- a/yarn-project/kv-store/src/interfaces/common.ts
+++ b/yarn-project/kv-store/src/interfaces/common.ts
@@ -29,3 +29,18 @@ export function mapRange<CK, K extends Key = Key>(range: CustomRange<CK>, mapFn:
 export type Range<K extends Key = Key> = CustomRange<K>;
 
 export type StoreSize = { mappingSize: number; physicalFileSize: number; actualSize: number; numItems: number };
+
+/** Per-container options for `openMap` / `openMultiMap` / `openSet`. */
+export type OpenContainerOptions = {
+  /**
+   * Hint that the container's keys carry sensitive information and should be obfuscated
+   * on disk (HMAC'd) when the backend supports it — currently only the SQLite-OPFS backend
+   * with a real encryption cipher. Enabling this disables range queries on the container
+   * (HMAC destroys ordering); point lookups and full-iteration remain available.
+   *
+   * Backends that don't support key obfuscation (LMDB, IndexedDB) silently ignore this
+   * flag and store keys in the clear. SQLite-OPFS throws at open time if `opaqueKeys`
+   * is set but no cipher was provided to the store.
+   */
+  opaqueKeys?: boolean;
+};

--- a/yarn-project/kv-store/src/interfaces/store.ts
+++ b/yarn-project/kv-store/src/interfaces/store.ts
@@ -1,5 +1,5 @@
 import type { AztecArray, AztecAsyncArray } from './array.js';
-import type { Key, StoreSize, Value } from './common.js';
+import type { Key, OpenContainerOptions, StoreSize, Value } from './common.js';
 import type { AztecAsyncCounter, AztecCounter } from './counter.js';
 import type { AztecAsyncMap, AztecMap } from './map.js';
 import type { AztecAsyncMultiMap, AztecMultiMap } from './multi_map.js';
@@ -12,23 +12,26 @@ export interface AztecKVStore {
   /**
    * Creates a new map.
    * @param name - The name of the map
+   * @param options - Optional per-container hints (see `OpenContainerOptions`).
    * @returns The map
    */
-  openMap<K extends Key, V extends Value>(name: string): AztecMap<K, V>;
+  openMap<K extends Key, V extends Value>(name: string, options?: OpenContainerOptions): AztecMap<K, V>;
 
   /**
    * Creates a new set.
    * @param name - The name of the set
+   * @param options - Optional per-container hints (see `OpenContainerOptions`).
    * @returns The set
    */
-  openSet<K extends Key>(name: string): AztecSet<K>;
+  openSet<K extends Key>(name: string, options?: OpenContainerOptions): AztecSet<K>;
 
   /**
    * Creates a new multi-map.
    * @param name - The name of the multi-map
+   * @param options - Optional per-container hints (see `OpenContainerOptions`).
    * @returns The multi-map
    */
-  openMultiMap<K extends Key, V extends Value>(name: string): AztecMultiMap<K, V>;
+  openMultiMap<K extends Key, V extends Value>(name: string, options?: OpenContainerOptions): AztecMultiMap<K, V>;
 
   /**
    * Creates a new array.
@@ -81,23 +84,26 @@ export interface AztecAsyncKVStore {
   /**
    * Creates a new map.
    * @param name - The name of the map
+   * @param options - Optional per-container hints (see `OpenContainerOptions`).
    * @returns The map
    */
-  openMap<K extends Key, V extends Value>(name: string): AztecAsyncMap<K, V>;
+  openMap<K extends Key, V extends Value>(name: string, options?: OpenContainerOptions): AztecAsyncMap<K, V>;
 
   /**
    * Creates a new set.
    * @param name - The name of the set
+   * @param options - Optional per-container hints (see `OpenContainerOptions`).
    * @returns The set
    */
-  openSet<K extends Key>(name: string): AztecAsyncSet<K>;
+  openSet<K extends Key>(name: string, options?: OpenContainerOptions): AztecAsyncSet<K>;
 
   /**
    * Creates a new multi-map.
    * @param name - The name of the multi-map
+   * @param options - Optional per-container hints (see `OpenContainerOptions`).
    * @returns The multi-map
    */
-  openMultiMap<K extends Key, V extends Value>(name: string): AztecAsyncMultiMap<K, V>;
+  openMultiMap<K extends Key, V extends Value>(name: string, options?: OpenContainerOptions): AztecAsyncMultiMap<K, V>;
 
   /**
    * Creates a new array.

--- a/yarn-project/kv-store/src/lmdb-v2/store.ts
+++ b/yarn-project/kv-store/src/lmdb-v2/store.ts
@@ -6,7 +6,7 @@ import { AsyncLocalStorage } from 'async_hooks';
 import { mkdir, rm } from 'fs/promises';
 
 import type { AztecAsyncArray } from '../interfaces/array.js';
-import type { Key, StoreSize, Value } from '../interfaces/common.js';
+import type { Key, OpenContainerOptions, StoreSize, Value } from '../interfaces/common.js';
 import type { AztecAsyncCounter } from '../interfaces/counter.js';
 import type { AztecAsyncMap } from '../interfaces/map.js';
 import type { AztecAsyncMultiMap } from '../interfaces/multi_map.js';
@@ -103,11 +103,15 @@ export class AztecLMDBStoreV2 implements AztecAsyncKVStore, LMDBMessageChannel {
     return currentWrite;
   }
 
-  openMap<K extends Key, V extends Value>(name: string): AztecAsyncMap<K, V> {
+  openMap<K extends Key, V extends Value>(name: string, _options?: OpenContainerOptions): AztecAsyncMap<K, V> {
+    // opaqueKeys is ignored: LMDB has no cipher to HMAC with, so keys stay in the clear.
     return new LMDBMap(this, name);
   }
 
-  openMultiMap<K extends Key, V extends Value>(name: string): AztecAsyncMultiMap<K, V> {
+  openMultiMap<K extends Key, V extends Value>(
+    name: string,
+    _options?: OpenContainerOptions,
+  ): AztecAsyncMultiMap<K, V> {
     return new LMDBMultiMap(this, name);
   }
 
@@ -119,7 +123,7 @@ export class AztecLMDBStoreV2 implements AztecAsyncKVStore, LMDBMessageChannel {
     return new LMDBArray(this, name);
   }
 
-  openSet<K extends Key>(name: string): AztecAsyncSet<K> {
+  openSet<K extends Key>(name: string, _options?: OpenContainerOptions): AztecAsyncSet<K> {
     return new LMDBSet(this, name);
   }
 

--- a/yarn-project/kv-store/src/lmdb/store.ts
+++ b/yarn-project/kv-store/src/lmdb/store.ts
@@ -7,7 +7,7 @@ import { tmpdir } from 'os';
 import { join } from 'path';
 
 import type { AztecArray, AztecAsyncArray } from '../interfaces/array.js';
-import type { Key, StoreSize, Value } from '../interfaces/common.js';
+import type { Key, OpenContainerOptions, StoreSize, Value } from '../interfaces/common.js';
 import type { AztecAsyncCounter, AztecCounter } from '../interfaces/counter.js';
 import type { AztecAsyncMap, AztecMap } from '../interfaces/map.js';
 import type { AztecAsyncMultiMap, AztecMultiMap } from '../interfaces/multi_map.js';
@@ -84,7 +84,11 @@ export class AztecLmdbStore implements AztecKVStore, AztecAsyncKVStore {
    * @param name - Name of the map
    * @returns A new AztecMap
    */
-  openMap<K extends Key, V extends Value>(name: string): AztecMap<K, V> & AztecAsyncMap<K, V> {
+  openMap<K extends Key, V extends Value>(
+    name: string,
+    _options?: OpenContainerOptions,
+  ): AztecMap<K, V> & AztecAsyncMap<K, V> {
+    // opaqueKeys is ignored: LMDB has no cipher to HMAC with, so keys stay in the clear.
     return new LmdbAztecMap(this.#data, name);
   }
 
@@ -93,7 +97,7 @@ export class AztecLmdbStore implements AztecKVStore, AztecAsyncKVStore {
    * @param name - Name of the set
    * @returns A new AztecSet
    */
-  openSet<K extends Key>(name: string): AztecSet<K> & AztecAsyncSet<K> {
+  openSet<K extends Key>(name: string, _options?: OpenContainerOptions): AztecSet<K> & AztecAsyncSet<K> {
     return new LmdbAztecSet(this.#data, name);
   }
 
@@ -102,7 +106,10 @@ export class AztecLmdbStore implements AztecKVStore, AztecAsyncKVStore {
    * @param name - Name of the map
    * @returns A new AztecMultiMap
    */
-  openMultiMap<K extends Key, V extends Value>(name: string): AztecMultiMap<K, V> & AztecAsyncMultiMap<K, V> {
+  openMultiMap<K extends Key, V extends Value>(
+    name: string,
+    _options?: OpenContainerOptions,
+  ): AztecMultiMap<K, V> & AztecAsyncMultiMap<K, V> {
     return new LmdbAztecMultiMap(this.#multiMapData, name);
   }
 

--- a/yarn-project/kv-store/src/sqlite-opfs/array.test.ts
+++ b/yarn-project/kv-store/src/sqlite-opfs/array.test.ts
@@ -1,7 +1,15 @@
 import { describeAztecArray } from '../interfaces/array_test_suite.js';
 import { mockLogger } from '../interfaces/utils.js';
+import { AesGcmCipher, RawKeyProvider } from './cipher.js';
 import { AztecSQLiteOPFSStore } from './store.js';
 
 describe('SQLiteOPFSArray', () => {
   describeAztecArray('AztecArray', async () => await AztecSQLiteOPFSStore.open(mockLogger, undefined, true));
+});
+
+describe('SQLiteOPFSArray (encrypted)', () => {
+  describeAztecArray('AztecArray', async () => {
+    const cipher = await AesGcmCipher.create(new RawKeyProvider(globalThis.crypto.getRandomValues(new Uint8Array(32))));
+    return await AztecSQLiteOPFSStore.open(mockLogger, undefined, true, undefined, cipher);
+  });
 });

--- a/yarn-project/kv-store/src/sqlite-opfs/array.ts
+++ b/yarn-project/kv-store/src/sqlite-opfs/array.ts
@@ -1,14 +1,17 @@
+import { Buffer } from 'buffer';
 import { Encoder } from 'msgpackr';
-import { hash } from 'ohash';
 import { toBufferKey } from 'ordered-binary';
 
 import type { AztecAsyncArray } from '../interfaces/array.js';
 import type { Value } from '../interfaces/common.js';
 import type { AztecSQLiteOPFSStore } from './store.js';
 
+const textEncoder = new TextEncoder();
+
 /**
  * Persistent array backed by SQLite. Entries share a common `key` (the array name)
  * and are ordered by `key_count`, which doubles as the 1-indexed slot number.
+ * Values flow through the store's cipher.
  */
 export class SQLiteOPFSAztecArray<T extends Value> implements AztecAsyncArray<T> {
   readonly #name: string;
@@ -38,10 +41,16 @@ export class SQLiteOPFSAztecArray<T extends Value> implements AztecAsyncArray<T>
     return await this.store.transactionAsync(async () => {
       let length = await this.lengthAsync();
       for (const val of vals) {
+        const packed = this.#encoder.pack(val);
+        const slot = this.#slot(length);
+        const [cipherValue, digest] = await Promise.all([
+          this.store.cipher.encrypt(packed, textEncoder.encode(slot)),
+          this.store.cipher.digest(packed),
+        ]);
         await this.store.runAsync(
           `INSERT INTO data (slot, container, key, key_count, hash, value)
            VALUES (?, ?, ?, ?, ?, ?)`,
-          [this.#slot(length), this.#container, this.#encodedKey(), length + 1, hash(val), this.#encoder.pack(val)],
+          [slot, this.#container, this.#encodedKey(), length + 1, digest, cipherValue],
         );
         length += 1;
       }
@@ -59,7 +68,7 @@ export class SQLiteOPFSAztecArray<T extends Value> implements AztecAsyncArray<T>
       const rows = await this.store.allAsync('SELECT value FROM data WHERE slot = ? LIMIT 1', [slot]);
       await this.store.runAsync('DELETE FROM data WHERE slot = ?', [slot]);
       const raw = rows[0]?.[0];
-      return raw instanceof Uint8Array ? (this.#encoder.unpack(raw) as T) : undefined;
+      return raw instanceof Uint8Array ? await this.#decode(raw, slot) : undefined;
     });
   }
 
@@ -69,9 +78,10 @@ export class SQLiteOPFSAztecArray<T extends Value> implements AztecAsyncArray<T>
     if (resolved < 0 || resolved >= length) {
       return undefined;
     }
-    const rows = await this.store.allAsync('SELECT value FROM data WHERE slot = ? LIMIT 1', [this.#slot(resolved)]);
+    const slot = this.#slot(resolved);
+    const rows = await this.store.allAsync('SELECT value FROM data WHERE slot = ? LIMIT 1', [slot]);
     const raw = rows[0]?.[0];
-    return raw instanceof Uint8Array ? (this.#encoder.unpack(raw) as T) : undefined;
+    return raw instanceof Uint8Array ? await this.#decode(raw, slot) : undefined;
   }
 
   async setAt(index: number, val: T): Promise<boolean> {
@@ -81,10 +91,16 @@ export class SQLiteOPFSAztecArray<T extends Value> implements AztecAsyncArray<T>
       if (resolved < 0 || resolved >= length) {
         return false;
       }
+      const packed = this.#encoder.pack(val);
+      const slot = this.#slot(resolved);
+      const [cipherValue, digest] = await Promise.all([
+        this.store.cipher.encrypt(packed, textEncoder.encode(slot)),
+        this.store.cipher.digest(packed),
+      ]);
       await this.store.runAsync(
         `INSERT OR REPLACE INTO data (slot, container, key, key_count, hash, value)
          VALUES (?, ?, ?, ?, ?, ?)`,
-        [this.#slot(resolved), this.#container, this.#encodedKey(), resolved + 1, hash(val), this.#encoder.pack(val)],
+        [slot, this.#container, this.#encodedKey(), resolved + 1, digest, cipherValue],
       );
       return true;
     });
@@ -92,14 +108,15 @@ export class SQLiteOPFSAztecArray<T extends Value> implements AztecAsyncArray<T>
 
   async *entriesAsync(): AsyncIterableIterator<[number, T]> {
     const rows = await this.store.allAsync(
-      'SELECT key_count, value FROM data WHERE container = ? AND key = ? ORDER BY key_count ASC',
+      'SELECT slot, key_count, value FROM data WHERE container = ? AND key = ? ORDER BY key_count ASC',
       [this.#container, this.#encodedKey()],
     );
     for (const row of rows) {
-      const keyCount = Number(row[0]);
-      const raw = row[1];
-      if (raw instanceof Uint8Array) {
-        yield [keyCount - 1, this.#encoder.unpack(raw) as T];
+      const slot = row[0];
+      const keyCount = Number(row[1]);
+      const raw = row[2];
+      if (typeof slot === 'string' && raw instanceof Uint8Array) {
+        yield [keyCount - 1, await this.#decode(raw, slot)];
       }
     }
   }
@@ -112,6 +129,15 @@ export class SQLiteOPFSAztecArray<T extends Value> implements AztecAsyncArray<T>
 
   [Symbol.asyncIterator](): AsyncIterableIterator<T> {
     return this.valuesAsync();
+  }
+
+  async #decode(raw: Uint8Array, slot: string): Promise<T> {
+    const plaintext = await this.store.cipher.decrypt(raw, textEncoder.encode(slot));
+    const unpacked = this.#encoder.unpack(plaintext);
+    if (unpacked instanceof Uint8Array && !Buffer.isBuffer(unpacked)) {
+      return Buffer.from(unpacked) as T;
+    }
+    return unpacked as T;
   }
 
   #encodedKey(): Buffer {

--- a/yarn-project/kv-store/src/sqlite-opfs/cipher.test.ts
+++ b/yarn-project/kv-store/src/sqlite-opfs/cipher.test.ts
@@ -1,0 +1,201 @@
+import { AesGcmCipher, IdentityCipher, RawKeyProvider } from './cipher.js';
+
+const textEncoder = new TextEncoder();
+
+function encode(s: string): Uint8Array {
+  return textEncoder.encode(s);
+}
+
+function randomSeed(): Uint8Array {
+  return globalThis.crypto.getRandomValues(new Uint8Array(32));
+}
+
+describe('IdentityCipher', () => {
+  const cipher = new IdentityCipher();
+
+  it('encrypt is a byte-for-byte passthrough', async () => {
+    const plaintext = encode('hello world');
+    const encrypted = await cipher.encrypt(plaintext);
+    expect(encrypted).toEqual(plaintext);
+  });
+
+  it('decrypt is a byte-for-byte passthrough', async () => {
+    const plaintext = encode('hello world');
+    const decrypted = await cipher.decrypt(plaintext);
+    expect(decrypted).toEqual(plaintext);
+  });
+
+  it('digest is deterministic for the same bytes', async () => {
+    const bytes = encode('same input');
+    const a = await cipher.digest(bytes);
+    const b = await cipher.digest(bytes);
+    expect(a).toEqual(b);
+  });
+
+  it('digest differs for different bytes', async () => {
+    const a = await cipher.digest(encode('alpha'));
+    const b = await cipher.digest(encode('beta'));
+    expect(a).not.toEqual(b);
+  });
+
+  it('reports isNullCipher = true', () => {
+    expect(cipher.isNullCipher).toBe(true);
+  });
+
+  it('keyDigest throws (opaque-keys requires real cipher)', async () => {
+    await expect(cipher.keyDigest(encode('any key'))).rejects.toThrow(/opaque/i);
+  });
+});
+
+describe('AesGcmCipher', () => {
+  let cipher: AesGcmCipher;
+  let seed: Uint8Array;
+
+  beforeAll(async () => {
+    seed = randomSeed();
+    cipher = await AesGcmCipher.create(new RawKeyProvider(seed));
+  });
+
+  it('round-trips an arbitrary byte string', async () => {
+    const plaintext = encode('the quick brown fox jumps over the lazy dog');
+    const ciphertext = await cipher.encrypt(plaintext);
+    const roundTripped = await cipher.decrypt(ciphertext);
+    expect(roundTripped).toEqual(plaintext);
+  });
+
+  it('ciphertext differs from plaintext', async () => {
+    const plaintext = encode('not the same bytes');
+    const ciphertext = await cipher.encrypt(plaintext);
+    expect(ciphertext).not.toEqual(plaintext);
+  });
+
+  it('is non-deterministic (fresh IV per encryption)', async () => {
+    const plaintext = encode('same plaintext twice');
+    const a = await cipher.encrypt(plaintext);
+    const b = await cipher.encrypt(plaintext);
+    expect(a).not.toEqual(b);
+    // But both still decrypt to the original.
+    expect(await cipher.decrypt(a)).toEqual(plaintext);
+    expect(await cipher.decrypt(b)).toEqual(plaintext);
+  });
+
+  it('uses the 0x01 version prefix so msgpack plaintext is distinguishable', async () => {
+    const ciphertext = await cipher.encrypt(encode('payload'));
+    expect(ciphertext[0]).toBe(0x01);
+  });
+
+  it('rejects tampered ciphertext (AES-GCM auth tag)', async () => {
+    const ciphertext = await cipher.encrypt(encode('payload'));
+    // Flip a bit in the middle of the ciphertext body.
+    const tampered = new Uint8Array(ciphertext);
+    tampered[tampered.length - 5] ^= 0x01;
+    await expect(cipher.decrypt(tampered)).rejects.toThrow();
+  });
+
+  it('rejects ciphertext with the wrong version byte', async () => {
+    const fakeCiphertext = new Uint8Array(20);
+    fakeCiphertext[0] = 0x99;
+    await expect(cipher.decrypt(fakeCiphertext)).rejects.toThrow(/version/i);
+  });
+
+  it('digest is deterministic for the same plaintext', async () => {
+    const bytes = encode('multimap dedup input');
+    const a = await cipher.digest(bytes);
+    const b = await cipher.digest(bytes);
+    expect(a).toEqual(b);
+  });
+
+  it('digest differs for different plaintexts', async () => {
+    const a = await cipher.digest(encode('alpha'));
+    const b = await cipher.digest(encode('beta'));
+    expect(a).not.toEqual(b);
+  });
+
+  it('digest is unguessable without the key (different seed → different digest)', async () => {
+    const other = await AesGcmCipher.create(new RawKeyProvider(randomSeed()));
+    const sameInput = encode('same input');
+    const a = await cipher.digest(sameInput);
+    const b = await other.digest(sameInput);
+    expect(a).not.toEqual(b);
+  });
+
+  it('keyDigest is deterministic for the same encoded key', async () => {
+    const key = encode('container:notes:slot:0x1234');
+    const a = await cipher.keyDigest(key);
+    const b = await cipher.keyDigest(key);
+    expect(a).toEqual(b);
+  });
+
+  it('keyDigest differs across keys', async () => {
+    const a = await cipher.keyDigest(encode('one'));
+    const b = await cipher.keyDigest(encode('two'));
+    expect(a).not.toEqual(b);
+  });
+
+  it('keyDigest uses a different sub-key than digest (cross-context independence)', async () => {
+    const sameBytes = encode('collision probe');
+    const valueDigest = await cipher.digest(sameBytes);
+    const keyDigest = await cipher.keyDigest(sameBytes);
+    // digest returns base64 string; keyDigest returns bytes. Normalize and compare.
+    const keyDigestB64 = btoa(String.fromCharCode(...keyDigest));
+    expect(valueDigest).not.toEqual(keyDigestB64);
+  });
+
+  it('reports isNullCipher = false', () => {
+    expect(cipher.isNullCipher).toBe(false);
+  });
+
+  it('decrypt fails with a cipher instantiated from a different seed', async () => {
+    const other = await AesGcmCipher.create(new RawKeyProvider(randomSeed()));
+    const ciphertext = await cipher.encrypt(encode('secret'));
+    await expect(other.decrypt(ciphertext)).rejects.toThrow();
+  });
+
+  it('two ciphers from the same seed agree on encrypt/decrypt/digest', async () => {
+    const twin = await AesGcmCipher.create(new RawKeyProvider(seed));
+    const plaintext = encode('shared key test');
+    const ciphertext = await cipher.encrypt(plaintext);
+    expect(await twin.decrypt(ciphertext)).toEqual(plaintext);
+    expect(await twin.digest(plaintext)).toEqual(await cipher.digest(plaintext));
+    expect(await twin.keyDigest(plaintext)).toEqual(await cipher.keyDigest(plaintext));
+  });
+
+  describe('AAD (row-binding)', () => {
+    it('round-trips when the same AAD is supplied on decrypt', async () => {
+      const plaintext = encode('payload');
+      const aad = encode('container:notes:slot:deadbeef:0');
+      const ciphertext = await cipher.encrypt(plaintext, aad);
+      expect(await cipher.decrypt(ciphertext, aad)).toEqual(plaintext);
+    });
+
+    it('rejects decryption when AAD differs', async () => {
+      const plaintext = encode('payload');
+      const aad = encode('slot-A');
+      const ciphertext = await cipher.encrypt(plaintext, aad);
+      await expect(cipher.decrypt(ciphertext, encode('slot-B'))).rejects.toThrow();
+    });
+
+    it('rejects decryption when AAD is omitted but was present on encrypt', async () => {
+      const plaintext = encode('payload');
+      const ciphertext = await cipher.encrypt(plaintext, encode('slot'));
+      await expect(cipher.decrypt(ciphertext)).rejects.toThrow();
+    });
+
+    it('rejects decryption when AAD is present but encrypt had none', async () => {
+      const plaintext = encode('payload');
+      const ciphertext = await cipher.encrypt(plaintext);
+      await expect(cipher.decrypt(ciphertext, encode('slot'))).rejects.toThrow();
+    });
+  });
+});
+
+describe('RawKeyProvider', () => {
+  it('accepts a 32-byte seed', async () => {
+    const provider = new RawKeyProvider(randomSeed());
+    await expect(provider.getMasterKey()).resolves.toBeDefined();
+  });
+
+  it('rejects a seed of the wrong length', () => {
+    expect(() => new RawKeyProvider(new Uint8Array(16))).toThrow(/32/);
+  });
+});

--- a/yarn-project/kv-store/src/sqlite-opfs/cipher.ts
+++ b/yarn-project/kv-store/src/sqlite-opfs/cipher.ts
@@ -1,0 +1,271 @@
+/**
+ * Value-level encryption for the SQLite-OPFS kv-store backend.
+ *
+ * The store stays in SQL-land for keys/containers/metadata so SQLite's indexes and
+ * range queries keep working; only the `value` BLOB column passes through `encrypt`.
+ * Multi-map dedup uses `digest` (a keyed HMAC in the real cipher, so an on-disk
+ * observer can't brute-force low-entropy plaintexts from the hash column). For the
+ * handful of PXE containers whose *keys* are also sensitive (nullifiers, watched
+ * contract addresses, user aliases), `keyDigest` HMACs the key — destroying range
+ * ordering, so only point lookups remain; those containers opt in via `opaqueKeys`.
+ *
+ * A null-object `IdentityCipher` implements the same interface with passthroughs so
+ * "encryption off" is literally "plug in a different cipher" — no conditional code
+ * in the container classes.
+ *
+ * ===========================================================================
+ * Security considerations and known limitations (audit findings)
+ * ===========================================================================
+ *
+ * Threat model: an attacker with read (and possibly write) access to the OPFS
+ * files on disk, outside the browser origin. Not defended against: same-origin
+ * XSS, running JS in the PXE context, or compromise of the live `CryptoKey`
+ * handles in memory.
+ *
+ * --- What IS defended ---
+ *
+ * * **Value confidentiality**: AES-GCM-256 with a fresh IV per write. Ciphertext
+ *   is non-deterministic — identical plaintexts produce different bytes on disk.
+ * * **Dictionary attacks on the hash/key HMAC**: HMAC-SHA-256 with an HKDF-derived
+ *   sub-key. The key never touches disk (unextractable `CryptoKey`), so an attacker
+ *   cannot precompute HMAC(candidate) to test against stored digests.
+ * * **Row-rebinding (F1)**: every ciphertext is bound to its SQL slot via AES-GCM
+ *   AAD. Moving a ciphertext to a different slot breaks the auth tag on decrypt.
+ * * **Key recovery from a weak-entropy source**: provided the caller supplies a
+ *   strong master seed (see KeyProvider caveat below).
+ *
+ * --- Known limitations ---
+ *
+ * **F2 — Equivalence-class leak via deterministic digest.** Two rows with identical
+ *   plaintext values produce identical `hash` column entries. A disk observer learns
+ *   which rows are equal, even without knowing what. Combined with on-chain side
+ *   channels, this can narrow plaintext candidates. Fundamental to multi-map dedup;
+ *   callers storing low-cardinality values in a multi-map should be aware.
+ *
+ * **F3 — No forward secrecy / no key rotation.** Master compromise retroactively
+ *   unseals all data. A key-rotation mechanism (re-encrypt on rotate) is a future
+ *   enhancement.
+ *
+ * **F4 — `KeyProvider` gives no entropy discipline.** The interface is satisfiable
+ *   by a trivially-weak provider (e.g., unsalted `sha256(passphrase)`). If a future
+ *   `PassphraseKeyProvider` is added, it MUST use a memory-hard KDF (Argon2id /
+ *   scrypt / PBKDF2 with high iterations + unique salt). Otherwise the HMAC columns
+ *   become an offline dictionary oracle on the passphrase, bypassing the protection
+ *   HMAC was meant to provide. `RawKeyProvider` with 32 random bytes is safe.
+ *
+ * **F5 — Row deletion is not detected.** An attacker with disk-write access can
+ *   delete rows; decryption of remaining rows still works, but we don't notice
+ *   missing ones. Consumers that care (e.g., the PXE note cache) already have
+ *   chain-based resync paths, which paper over this.
+ *
+ * **F6 — Metadata leaks (accepted).** Row count per container (COUNT(*)), container
+ *   names, OPFS file size, and modification timestamps are all visible on disk by
+ *   design.
+ *
+ * **F7 — Phase-1 hash column format break.** This PR changes the `hash` column
+ *   format (ohash-of-value → sha256/hmac of msgpack-packed-bytes). Multi-map dedup
+ *   for pre-existing phase-1 rows will no longer match fresh inserts of the same
+ *   pair — one extra row instead of dedup. Phase-1 DBs only live in developer
+ *   setups; no production data is affected. Dropping and recreating dev DBs is
+ *   the migration path.
+ */
+
+/** Implemented by cipher backends. The null implementation (`IdentityCipher`) stores
+ *  bytes unchanged and is indistinguishable on-disk from phase-1 pre-encryption data. */
+export interface ValueCipher {
+  /** Encrypt a packed value. Non-deterministic: the real cipher draws a fresh IV each call.
+   *
+   *  `aad` (Additional Authenticated Data) is not stored in the ciphertext but is
+   *  cryptographically bound to it — `decrypt` must be called with identical AAD or
+   *  the auth tag fails. Containers pass the row's `slot` as AAD so that moving a
+   *  ciphertext to a different row (a row-rebinding attack) is detected. */
+  encrypt(plaintext: Uint8Array, aad?: Uint8Array): Promise<Uint8Array>;
+
+  /** Decrypt a previously-encrypted value. Throws on auth-tag failure or framing errors.
+   *  `aad` must match what was passed at encrypt time. */
+  decrypt(ciphertext: Uint8Array, aad?: Uint8Array): Promise<Uint8Array>;
+
+  /** Deterministic tag used by multi-map for hash-dedup. Same plaintext → same tag.
+   *  Real ciphers use HMAC so the tag is unguessable without the key. Returned as
+   *  base64 to fit the existing TEXT column. */
+  digest(plaintext: Uint8Array): Promise<string>;
+
+  /** Deterministic HMAC of an already-encoded key, for opaque-keys containers.
+   *  Returned as raw bytes (stored in the existing `key BLOB` column). The identity
+   *  cipher refuses this call — opaque-keys mode requires a real cipher. */
+  keyDigest(encodedKey: Uint8Array): Promise<Uint8Array>;
+
+  /** True for the null cipher. Lets the store fail fast when a caller requests
+   *  `opaqueKeys: true` on an unencrypted store. */
+  readonly isNullCipher: boolean;
+}
+
+/** Supplies the master keying material from which the cipher derives its sub-keys.
+ *  Kept as a separate abstraction so future key sources (IndexedDB unextractable,
+ *  WebAuthn PRF, passphrase-derived) slot in without changing the cipher. */
+export interface KeyProvider {
+  /** Return an HKDF-imported `CryptoKey` usable for `deriveKey`. Called once at
+   *  cipher construction time. */
+  getMasterKey(): Promise<CryptoKey>;
+}
+
+/** Simplest key source: 32 bytes, provided directly. Suitable for tests and for
+ *  programmatic use where the caller manages the seed's lifetime. Not for
+ *  persistent production use — those want `IndexedDBKeyProvider` (future). */
+export class RawKeyProvider implements KeyProvider {
+  readonly #seed: Uint8Array;
+
+  constructor(seed: Uint8Array) {
+    if (seed.byteLength !== 32) {
+      throw new Error(`RawKeyProvider: seed must be 32 bytes, got ${seed.byteLength}`);
+    }
+    this.#seed = new Uint8Array(seed);
+  }
+
+  getMasterKey(): Promise<CryptoKey> {
+    return globalThis.crypto.subtle.importKey('raw', this.#seed as BufferSource, { name: 'HKDF' }, false, [
+      'deriveKey',
+    ]);
+  }
+}
+
+const CIPHER_VERSION_AES_GCM = 0x01;
+const IV_BYTES = 12;
+const AES_GCM_TAG_BYTES = 16;
+
+const HKDF_INFO_ENC = 'aztec-kv/enc/v1';
+const HKDF_INFO_VALUE_HMAC = 'aztec-kv/value-hmac/v1';
+const HKDF_INFO_KEY_HMAC = 'aztec-kv/key-hmac/v1';
+
+const textEncoder = new TextEncoder();
+// HKDF with a constant empty salt is the standard pattern when `info` already
+// provides domain separation. Explicit ArrayBuffer backing keeps TS happy about
+// the BufferSource-with-SharedArrayBuffer distinction in lib.dom.d.ts.
+const EMPTY_SALT = new Uint8Array(new ArrayBuffer(0));
+
+/** Passthrough cipher — use when encryption is disabled. Keeps on-disk format
+ *  byte-compatible with phase-1 plaintext data so existing DBs open unchanged. */
+export class IdentityCipher implements ValueCipher {
+  readonly isNullCipher = true;
+
+  encrypt(plaintext: Uint8Array, _aad?: Uint8Array): Promise<Uint8Array> {
+    // IdentityCipher ignores AAD — there's no auth tag to bind it to. Callers that
+    // care about row-binding integrity must use a real cipher.
+    return Promise.resolve(plaintext);
+  }
+
+  decrypt(ciphertext: Uint8Array, _aad?: Uint8Array): Promise<Uint8Array> {
+    return Promise.resolve(ciphertext);
+  }
+
+  async digest(plaintext: Uint8Array): Promise<string> {
+    const buf = await globalThis.crypto.subtle.digest('SHA-256', plaintext as BufferSource);
+    return bytesToBase64(new Uint8Array(buf));
+  }
+
+  keyDigest(_encodedKey: Uint8Array): Promise<Uint8Array> {
+    return Promise.reject(new Error('IdentityCipher does not support opaque-keys containers; provide a real cipher'));
+  }
+}
+
+/** AES-GCM-256 for values, HMAC-SHA-256 for deterministic digests. Three sub-keys
+ *  are derived from the master via HKDF-SHA-256 with distinct `info` strings: one
+ *  for AES, one for value-HMAC (multi-map dedup), one for key-HMAC (opaque keys).
+ *  Separate sub-keys give cross-context independence — a collision/weakness in one
+ *  purpose cannot leak into another. */
+export class AesGcmCipher implements ValueCipher {
+  readonly isNullCipher = false;
+
+  readonly #encKey: CryptoKey;
+  readonly #valueHmacKey: CryptoKey;
+  readonly #keyHmacKey: CryptoKey;
+
+  private constructor(encKey: CryptoKey, valueHmacKey: CryptoKey, keyHmacKey: CryptoKey) {
+    this.#encKey = encKey;
+    this.#valueHmacKey = valueHmacKey;
+    this.#keyHmacKey = keyHmacKey;
+  }
+
+  static async create(provider: KeyProvider): Promise<AesGcmCipher> {
+    const master = await provider.getMasterKey();
+    const [encKey, valueHmacKey, keyHmacKey] = await Promise.all([
+      deriveAesKey(master, HKDF_INFO_ENC),
+      deriveHmacKey(master, HKDF_INFO_VALUE_HMAC),
+      deriveHmacKey(master, HKDF_INFO_KEY_HMAC),
+    ]);
+    return new AesGcmCipher(encKey, valueHmacKey, keyHmacKey);
+  }
+
+  /** Frame: [0x01][IV(12)][AES-GCM ciphertext + 16-byte auth tag]. AAD (when
+   *  provided) is bound by AES-GCM's auth tag but not written to disk — callers
+   *  must supply the same AAD on decrypt. */
+  async encrypt(plaintext: Uint8Array, aad?: Uint8Array): Promise<Uint8Array> {
+    const iv = globalThis.crypto.getRandomValues(new Uint8Array(IV_BYTES));
+    const params: AesGcmParams = { name: 'AES-GCM', iv };
+    if (aad !== undefined) {
+      params.additionalData = aad as BufferSource;
+    }
+    const ctBuf = await globalThis.crypto.subtle.encrypt(params, this.#encKey, plaintext as BufferSource);
+    const ct = new Uint8Array(ctBuf);
+    const out = new Uint8Array(1 + IV_BYTES + ct.byteLength);
+    out[0] = CIPHER_VERSION_AES_GCM;
+    out.set(iv, 1);
+    out.set(ct, 1 + IV_BYTES);
+    return out;
+  }
+
+  async decrypt(framed: Uint8Array, aad?: Uint8Array): Promise<Uint8Array> {
+    if (framed.byteLength < 1 + IV_BYTES + AES_GCM_TAG_BYTES) {
+      throw new Error('AesGcmCipher: ciphertext too short to contain version + IV + auth tag');
+    }
+    if (framed[0] !== CIPHER_VERSION_AES_GCM) {
+      throw new Error(`AesGcmCipher: unexpected version byte 0x${framed[0].toString(16).padStart(2, '0')}`);
+    }
+    const iv = framed.subarray(1, 1 + IV_BYTES);
+    const ct = framed.subarray(1 + IV_BYTES);
+    const params: AesGcmParams = { name: 'AES-GCM', iv: iv as BufferSource };
+    if (aad !== undefined) {
+      params.additionalData = aad as BufferSource;
+    }
+    const ptBuf = await globalThis.crypto.subtle.decrypt(params, this.#encKey, ct as BufferSource);
+    return new Uint8Array(ptBuf);
+  }
+
+  async digest(plaintext: Uint8Array): Promise<string> {
+    const sig = await globalThis.crypto.subtle.sign('HMAC', this.#valueHmacKey, plaintext as BufferSource);
+    return bytesToBase64(new Uint8Array(sig));
+  }
+
+  async keyDigest(encodedKey: Uint8Array): Promise<Uint8Array> {
+    const sig = await globalThis.crypto.subtle.sign('HMAC', this.#keyHmacKey, encodedKey as BufferSource);
+    return new Uint8Array(sig);
+  }
+}
+
+function deriveAesKey(master: CryptoKey, info: string): Promise<CryptoKey> {
+  return globalThis.crypto.subtle.deriveKey(
+    { name: 'HKDF', hash: 'SHA-256', salt: EMPTY_SALT, info: textEncoder.encode(info) },
+    master,
+    { name: 'AES-GCM', length: 256 },
+    false,
+    ['encrypt', 'decrypt'],
+  );
+}
+
+function deriveHmacKey(master: CryptoKey, info: string): Promise<CryptoKey> {
+  return globalThis.crypto.subtle.deriveKey(
+    { name: 'HKDF', hash: 'SHA-256', salt: EMPTY_SALT, info: textEncoder.encode(info) },
+    master,
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  );
+}
+
+function bytesToBase64(bytes: Uint8Array): string {
+  let s = '';
+  for (const b of bytes) {
+    s += String.fromCharCode(b);
+  }
+  return btoa(s);
+}

--- a/yarn-project/kv-store/src/sqlite-opfs/index.ts
+++ b/yarn-project/kv-store/src/sqlite-opfs/index.ts
@@ -5,6 +5,8 @@ import { initStoreForRollupAndSchemaVersion } from '../utils.js';
 import { AztecSQLiteOPFSStore } from './store.js';
 
 export { AztecSQLiteOPFSStore } from './store.js';
+export { AesGcmCipher, IdentityCipher, RawKeyProvider } from './cipher.js';
+export type { KeyProvider, ValueCipher } from './cipher.js';
 
 export async function createStore(
   name: string,

--- a/yarn-project/kv-store/src/sqlite-opfs/map.test.ts
+++ b/yarn-project/kv-store/src/sqlite-opfs/map.test.ts
@@ -1,7 +1,15 @@
 import { describeAztecMap } from '../interfaces/map_test_suite.js';
 import { mockLogger } from '../interfaces/utils.js';
+import { AesGcmCipher, RawKeyProvider } from './cipher.js';
 import { AztecSQLiteOPFSStore } from './store.js';
 
 describe('SQLiteOPFSMap', () => {
   describeAztecMap('AztecMap', async () => await AztecSQLiteOPFSStore.open(mockLogger, undefined, true));
+});
+
+describe('SQLiteOPFSMap (encrypted)', () => {
+  describeAztecMap('AztecMap', async () => {
+    const cipher = await AesGcmCipher.create(new RawKeyProvider(globalThis.crypto.getRandomValues(new Uint8Array(32))));
+    return await AztecSQLiteOPFSStore.open(mockLogger, undefined, true, undefined, cipher);
+  });
 });

--- a/yarn-project/kv-store/src/sqlite-opfs/map.ts
+++ b/yarn-project/kv-store/src/sqlite-opfs/map.ts
@@ -167,9 +167,17 @@ export class SQLiteOPFSAztecMap<K extends Key, V extends Value> implements Aztec
 
   /** Packs the payload that will land in the `value` column *before* encryption.
    *  In opaque-keys mode the packed tuple carries the clear key so iterators can
-   *  reconstruct it (HMAC is one-way). */
+   *  reconstruct it (HMAC is one-way).
+   *
+   *  Copies the pack output into a freshly-owned buffer because msgpackr's
+   *  `Encoder.pack()` returns a view into a reusable internal buffer by default —
+   *  if a subsequent pack call happens while the previous view is still in flight
+   *  (encrypt + digest run under Promise.all), the underlying bytes can be
+   *  overwritten out from under the async consumers. The copy is cheap and
+   *  removes a class of subtle concurrency bugs. */
   protected packForStorage(key: K, val: V): Uint8Array {
-    return this.opaqueKeys ? this.encoder.pack([key, val]) : this.encoder.pack(val);
+    const view = this.opaqueKeys ? this.encoder.pack([key, val]) : this.encoder.pack(val);
+    return new Uint8Array(view);
   }
 
   /** Decrypts and unpacks a stored value, returning the original V. Slot is passed

--- a/yarn-project/kv-store/src/sqlite-opfs/map.ts
+++ b/yarn-project/kv-store/src/sqlite-opfs/map.ts
@@ -1,6 +1,5 @@
 import { Buffer } from 'buffer';
 import { Encoder } from 'msgpackr';
-import { hash } from 'ohash';
 import { fromBufferKey, toBufferKey } from 'ordered-binary';
 
 import type { Key, Range, Value } from '../interfaces/common.js';
@@ -8,31 +7,56 @@ import type { AztecAsyncMap } from '../interfaces/map.js';
 import type { SqlValue } from './messages.js';
 import type { AztecSQLiteOPFSStore } from './store.js';
 
-/** A map backed by SQLite in OPFS. Mirrors `IndexedDBAztecMap`. */
+const textEncoder = new TextEncoder();
+
+/** AAD bound into every encrypted value. Tying the slot (container + encoded key +
+ *  index) to the ciphertext means an attacker with disk-write access can't move a
+ *  ciphertext to a different row — the auth tag will reject the swap on decrypt. */
+function slotAad(slot: string): Uint8Array {
+  return textEncoder.encode(slot);
+}
+
+/** Internal options passed down from the store. Container authors don't see the
+ *  public `OpenContainerOptions` shape — the store translates it. */
+export type SQLiteOPFSMapOptions = {
+  /** When true, keys are HMAC'd before being stored, and the encrypted value blob
+   *  carries the clear key so iterators can still return it. Range queries (start/end
+   *  or reverse) throw — HMAC destroys ordering. */
+  opaqueKeys?: boolean;
+};
+
+/** A map backed by SQLite in OPFS. Mirrors `IndexedDBAztecMap`. Values flow through
+ *  the store's `cipher.encrypt`/`decrypt`; in `opaqueKeys` mode, keys additionally
+ *  flow through `cipher.keyDigest` for at-rest obfuscation. */
 export class SQLiteOPFSAztecMap<K extends Key, V extends Value> implements AztecAsyncMap<K, V> {
   protected readonly name: string;
   protected readonly container: string;
   protected readonly encoder = new Encoder();
+  protected readonly opaqueKeys: boolean;
 
   constructor(
     protected readonly store: AztecSQLiteOPFSStore,
     mapName: string,
+    options: SQLiteOPFSMapOptions = {},
   ) {
     this.name = mapName;
     this.container = `map:${mapName}`;
+    this.opaqueKeys = !!options.opaqueKeys;
   }
 
   async getAsync(key: K): Promise<V | undefined> {
-    const rows = await this.store.allAsync('SELECT value FROM data WHERE slot = ? LIMIT 1', [this.slot(key)]);
+    const { slot } = await this.keyMaterial(key);
+    const rows = await this.store.allAsync('SELECT value FROM data WHERE slot = ? LIMIT 1', [slot]);
     if (rows.length === 0) {
       return undefined;
     }
     const raw = rows[0][0];
-    return raw == null ? undefined : this.decodeValue(raw);
+    return raw == null ? undefined : await this.decodeValue(raw, slot);
   }
 
   async hasAsync(key: K): Promise<boolean> {
-    const rows = await this.store.allAsync('SELECT 1 FROM data WHERE slot = ? LIMIT 1', [this.slot(key)]);
+    const { slot } = await this.keyMaterial(key);
+    const rows = await this.store.allAsync('SELECT 1 FROM data WHERE slot = ? LIMIT 1', [slot]);
     return rows.length > 0;
   }
 
@@ -42,10 +66,16 @@ export class SQLiteOPFSAztecMap<K extends Key, V extends Value> implements Aztec
   }
 
   async set(key: K, val: V): Promise<void> {
+    const { slot, encodedKey } = await this.keyMaterial(key);
+    const packed = this.packForStorage(key, val);
+    const [cipherValue, digest] = await Promise.all([
+      this.store.cipher.encrypt(packed, slotAad(slot)),
+      this.store.cipher.digest(packed),
+    ]);
     await this.store.runAsync(
       `INSERT OR REPLACE INTO data (slot, container, key, key_count, hash, value)
        VALUES (?, ?, ?, ?, ?, ?)`,
-      [this.slot(key), this.container, this.encodedKey(key), 1, hash(val), this.encoder.pack(val)],
+      [slot, this.container, encodedKey, 1, digest, cipherValue],
     );
   }
 
@@ -75,17 +105,21 @@ export class SQLiteOPFSAztecMap<K extends Key, V extends Value> implements Aztec
   }
 
   async delete(key: K): Promise<void> {
-    await this.store.runAsync('DELETE FROM data WHERE slot = ?', [this.slot(key)]);
+    const { slot } = await this.keyMaterial(key);
+    await this.store.runAsync('DELETE FROM data WHERE slot = ?', [slot]);
   }
 
   async *entriesAsync(range: Range<K> = {}): AsyncIterableIterator<[K, V]> {
     const rows = await this.rangeQuery(range);
     for (const row of rows) {
-      const [_slot, keyBlob, value] = row;
-      if (keyBlob == null || value == null) {
+      const [slot, keyBlob, value] = row;
+      if (value == null) {
         continue;
       }
-      yield [this.decodeKey(keyBlob), this.decodeValue(value)];
+      const entry = await this.decodeEntry(slot, keyBlob, value);
+      if (entry !== undefined) {
+        yield entry;
+      }
     }
   }
 
@@ -101,7 +135,12 @@ export class SQLiteOPFSAztecMap<K extends Key, V extends Value> implements Aztec
     }
   }
 
-  protected async rangeQuery(range: Range<K>): Promise<Array<[string, Uint8Array, Uint8Array | null]>> {
+  protected async rangeQuery(range: Range<K>): Promise<Array<[string, Uint8Array | null, Uint8Array | null]>> {
+    if (this.opaqueKeys && (range.start !== undefined || range.end !== undefined || range.reverse)) {
+      throw new Error(
+        `Range queries with start/end/reverse are unsupported on opaque-keys container '${this.name}' — HMAC'd keys have no meaningful order. Use point lookups or unordered iteration (optionally with { limit }).`,
+      );
+    }
     // Inclusivity flips with direction to match the IndexedDB backend:
     //   forward: [start, end)     reverse: (start, end]
     // That asymmetry is load-bearing — tests pin the exact inclusivity at boundaries.
@@ -110,11 +149,11 @@ export class SQLiteOPFSAztecMap<K extends Key, V extends Value> implements Aztec
     const bind: SqlValue[] = [this.container];
     if (range.start !== undefined) {
       parts.push(reverse ? 'key > ?' : 'key >= ?');
-      bind.push(this.encodedKey(range.start));
+      bind.push(toBufferKey(this.normalizeKey(range.start)));
     }
     if (range.end !== undefined) {
       parts.push(reverse ? 'key <= ?' : 'key < ?');
-      bind.push(this.encodedKey(range.end));
+      bind.push(toBufferKey(this.normalizeKey(range.end)));
     }
     const order = reverse ? 'DESC' : 'ASC';
     let sql = `SELECT slot, key, value FROM data WHERE ${parts.join(' AND ')} ORDER BY key ${order}, key_count ${order}`;
@@ -123,22 +162,62 @@ export class SQLiteOPFSAztecMap<K extends Key, V extends Value> implements Aztec
       bind.push(range.limit);
     }
     const rows = await this.store.allAsync(sql, bind);
-    return rows.map(r => [String(r[0]), r[1] as Uint8Array, r[2] as Uint8Array | null]);
+    return rows.map(r => [String(r[0]), (r[1] as Uint8Array | null) ?? null, (r[2] as Uint8Array | null) ?? null]);
   }
 
-  protected decodeValue(val: SqlValue): V {
-    if (!(val instanceof Uint8Array)) {
-      return val as V;
+  /** Packs the payload that will land in the `value` column *before* encryption.
+   *  In opaque-keys mode the packed tuple carries the clear key so iterators can
+   *  reconstruct it (HMAC is one-way). */
+  protected packForStorage(key: K, val: V): Uint8Array {
+    return this.opaqueKeys ? this.encoder.pack([key, val]) : this.encoder.pack(val);
+  }
+
+  /** Decrypts and unpacks a stored value, returning the original V. Slot is passed
+   *  as AAD so decrypt fails if the ciphertext was moved from a different row. */
+  protected async decodeValue(raw: SqlValue, slot: string): Promise<V> {
+    if (!(raw instanceof Uint8Array)) {
+      return raw as V;
     }
-    const unpacked = this.encoder.unpack(val);
-    // msgpackr returns plain Uint8Array in browsers for packed Buffers. Callers that
-    // stored Buffers (walletDB uses Buffer.from(...).toString('utf8') round-trips)
-    // rely on Buffer-flavored behavior — re-wrap at the storage boundary, mirroring
-    // IndexedDBAztecMap.restoreBuffers.
-    if (unpacked instanceof Uint8Array && !Buffer.isBuffer(unpacked)) {
-      return Buffer.from(unpacked) as V;
+    const plaintext = await this.store.cipher.decrypt(raw, slotAad(slot));
+    const unpacked = this.encoder.unpack(plaintext);
+    if (this.opaqueKeys) {
+      // Shape is [key, value] — return just the value.
+      return this.restoreBuffer((unpacked as [K, V])[1]) as V;
     }
-    return unpacked as V;
+    return this.restoreBuffer(unpacked) as V;
+  }
+
+  /** Decodes an entire iteration row into [K, V]. Returns `undefined` if the row
+   *  can't be decoded (null value blob in a non-opaque container). Slot is passed
+   *  as AAD for row-binding integrity. */
+  protected async decodeEntry(
+    slot: string,
+    keyBlob: Uint8Array | null,
+    valBlob: Uint8Array,
+  ): Promise<[K, V] | undefined> {
+    const plaintext = await this.store.cipher.decrypt(valBlob, slotAad(slot));
+    const unpacked = this.encoder.unpack(plaintext);
+    if (this.opaqueKeys) {
+      const [rawKey, rawVal] = unpacked as [K, V];
+      return [rawKey, this.restoreBuffer(rawVal) as V];
+    }
+    if (keyBlob == null) {
+      return undefined;
+    }
+    return [this.decodeKey(keyBlob), this.restoreBuffer(unpacked) as V];
+  }
+
+  /**
+   * msgpackr returns plain Uint8Array in browsers for packed Buffers. Callers that
+   * stored Buffers (walletDB uses Buffer.from(...).toString('utf8') round-trips)
+   * rely on Buffer-flavored behavior — re-wrap at the storage boundary, mirroring
+   * IndexedDBAztecMap.restoreBuffers.
+   */
+  protected restoreBuffer(val: unknown): unknown {
+    if (val instanceof Uint8Array && !Buffer.isBuffer(val)) {
+      return Buffer.from(val);
+    }
+    return val;
   }
 
   protected decodeKey(raw: Uint8Array): K {
@@ -149,15 +228,26 @@ export class SQLiteOPFSAztecMap<K extends Key, V extends Value> implements Aztec
     return parsed as K;
   }
 
-  protected encodedKey(key: K): Buffer {
-    return toBufferKey(this.normalizeKey(key));
+  /** Produces the `(slot, encodedKey)` pair for a user key. In opaque mode, the
+   *  encoded key is the HMAC of the ordered-binary bytes; otherwise it's the raw
+   *  ordered-binary bytes. Slot is derived from `encodedKey` so it's unique per-key
+   *  either way. */
+  protected async keyMaterial(key: K, index: number = 0): Promise<{ slot: string; encodedKey: Uint8Array }> {
+    const rawEncoded = toBufferKey(this.normalizeKey(key));
+    const encodedKey = this.opaqueKeys ? await this.store.cipher.keyDigest(rawEncoded) : rawEncoded;
+    const slot = `${this.container}:${bytesToHex(encodedKey)}:${index}`;
+    return { slot, encodedKey };
   }
 
   protected normalizeKey(key: K): (string | number | Uint8Array)[] {
     return Array.isArray(key) ? key : [key];
   }
+}
 
-  protected slot(key: K, index: number = 0): string {
-    return `map:${this.name}:slot:${this.normalizeKey(key)}:${index}`;
+function bytesToHex(bytes: Uint8Array): string {
+  let s = '';
+  for (const b of bytes) {
+    s += b.toString(16).padStart(2, '0');
   }
+  return s;
 }

--- a/yarn-project/kv-store/src/sqlite-opfs/multi_map.test.ts
+++ b/yarn-project/kv-store/src/sqlite-opfs/multi_map.test.ts
@@ -1,7 +1,15 @@
 import { describeAztecMultiMap } from '../interfaces/multi_map_test_suite.js';
 import { mockLogger } from '../interfaces/utils.js';
+import { AesGcmCipher, RawKeyProvider } from './cipher.js';
 import { AztecSQLiteOPFSStore } from './store.js';
 
 describe('SQLiteOPFSMultiMap', () => {
   describeAztecMultiMap('AztecMultiMap', async () => await AztecSQLiteOPFSStore.open(mockLogger, undefined, true));
+});
+
+describe('SQLiteOPFSMultiMap (encrypted)', () => {
+  describeAztecMultiMap('AztecMultiMap', async () => {
+    const cipher = await AesGcmCipher.create(new RawKeyProvider(globalThis.crypto.getRandomValues(new Uint8Array(32))));
+    return await AztecSQLiteOPFSStore.open(mockLogger, undefined, true, undefined, cipher);
+  });
 });

--- a/yarn-project/kv-store/src/sqlite-opfs/multi_map.ts
+++ b/yarn-project/kv-store/src/sqlite-opfs/multi_map.ts
@@ -1,8 +1,9 @@
-import { hash } from 'ohash';
-
 import type { Key, Value } from '../interfaces/common.js';
 import type { AztecAsyncMultiMap } from '../interfaces/multi_map.js';
-import { SQLiteOPFSAztecMap } from './map.js';
+import { SQLiteOPFSAztecMap, type SQLiteOPFSMapOptions } from './map.js';
+import type { AztecSQLiteOPFSStore } from './store.js';
+
+const textEncoder = new TextEncoder();
 
 /**
  * Multi-map backed by SQLite. Extends the base map with always-incrementing
@@ -13,62 +14,74 @@ export class SQLiteOPFSAztecMultiMap<K extends Key, V extends Value>
   extends SQLiteOPFSAztecMap<K, V>
   implements AztecAsyncMultiMap<K, V>
 {
+  constructor(store: AztecSQLiteOPFSStore, name: string, options: SQLiteOPFSMapOptions = {}) {
+    super(store, name, options);
+  }
+
   override async set(key: K, val: V): Promise<void> {
-    const valueHash = hash(val);
+    const packed = this.packForStorage(key, val);
+    const valueHash = await this.store.cipher.digest(packed);
     await this.store.transactionAsync(async () => {
+      const { encodedKey } = await this.keyMaterial(key);
       const exists = await this.store.allAsync(
         'SELECT 1 FROM data WHERE container = ? AND key = ? AND hash = ? LIMIT 1',
-        [this.container, this.encodedKey(key), valueHash],
+        [this.container, encodedKey, valueHash],
       );
       if (exists.length > 0) {
         return;
       }
       const maxRow = await this.store.allAsync('SELECT MAX(key_count) FROM data WHERE container = ? AND key = ?', [
         this.container,
-        this.encodedKey(key),
+        encodedKey,
       ]);
       const count = Number(maxRow[0]?.[0] ?? 0);
+      const { slot } = await this.keyMaterial(key, count);
+      const cipherValue = await this.store.cipher.encrypt(packed, textEncoder.encode(slot));
       await this.store.runAsync(
         `INSERT INTO data (slot, container, key, key_count, hash, value)
          VALUES (?, ?, ?, ?, ?, ?)`,
-        [this.slot(key, count), this.container, this.encodedKey(key), count + 1, valueHash, this.encoder.pack(val)],
+        [slot, this.container, encodedKey, count + 1, valueHash, cipherValue],
       );
     });
   }
 
   async *getValuesAsync(key: K): AsyncIterableIterator<V> {
+    const { encodedKey } = await this.keyMaterial(key);
     const rows = await this.store.allAsync(
-      'SELECT value FROM data WHERE container = ? AND key = ? ORDER BY key_count ASC',
-      [this.container, this.encodedKey(key)],
+      'SELECT slot, value FROM data WHERE container = ? AND key = ? ORDER BY key_count ASC',
+      [this.container, encodedKey],
     );
     for (const row of rows) {
-      const raw = row[0];
-      if (raw instanceof Uint8Array) {
-        yield this.decodeValue(raw);
+      const slot = row[0];
+      const raw = row[1];
+      if (typeof slot === 'string' && raw instanceof Uint8Array) {
+        yield await this.decodeValue(raw, slot);
       }
     }
   }
 
   async getValueCountAsync(key: K): Promise<number> {
+    const { encodedKey } = await this.keyMaterial(key);
     const rows = await this.store.allAsync('SELECT COUNT(*) FROM data WHERE container = ? AND key = ?', [
       this.container,
-      this.encodedKey(key),
+      encodedKey,
     ]);
     return Number(rows[0]?.[0] ?? 0);
   }
 
   async deleteValue(key: K, val: V): Promise<void> {
+    const packed = this.packForStorage(key, val);
+    const valueHash = await this.store.cipher.digest(packed);
+    const { encodedKey } = await this.keyMaterial(key);
     await this.store.runAsync('DELETE FROM data WHERE container = ? AND key = ? AND hash = ?', [
       this.container,
-      this.encodedKey(key),
-      hash(val),
+      encodedKey,
+      valueHash,
     ]);
   }
 
   override async delete(key: K): Promise<void> {
-    await this.store.runAsync('DELETE FROM data WHERE container = ? AND key = ?', [
-      this.container,
-      this.encodedKey(key),
-    ]);
+    const { encodedKey } = await this.keyMaterial(key);
+    await this.store.runAsync('DELETE FROM data WHERE container = ? AND key = ?', [this.container, encodedKey]);
   }
 }

--- a/yarn-project/kv-store/src/sqlite-opfs/opaque_keys.test.ts
+++ b/yarn-project/kv-store/src/sqlite-opfs/opaque_keys.test.ts
@@ -1,0 +1,317 @@
+import { toArray } from '@aztec/foundation/iterable';
+
+import { mockLogger } from '../interfaces/utils.js';
+import { AesGcmCipher, RawKeyProvider } from './cipher.js';
+import { AztecSQLiteOPFSStore } from './store.js';
+
+const HMAC_SHA256_BYTES = 32;
+
+async function makeEncryptedStore(): Promise<AztecSQLiteOPFSStore> {
+  const cipher = await AesGcmCipher.create(new RawKeyProvider(globalThis.crypto.getRandomValues(new Uint8Array(32))));
+  return AztecSQLiteOPFSStore.open(mockLogger, undefined, true, undefined, cipher);
+}
+
+function makePlaintextStore(): Promise<AztecSQLiteOPFSStore> {
+  return AztecSQLiteOPFSStore.open(mockLogger, undefined, true);
+}
+
+describe('opaque-keys mode', () => {
+  describe('validation at open time', () => {
+    let store: AztecSQLiteOPFSStore;
+
+    afterEach(async () => {
+      await store.delete();
+    });
+
+    it('throws when opaqueKeys is requested on an unencrypted store', async () => {
+      store = await makePlaintextStore();
+      expect(() => store.openMap('notes', { opaqueKeys: true })).toThrow(/opaqueKeys/i);
+    });
+
+    it('allows opaqueKeys on an encrypted store', async () => {
+      store = await makeEncryptedStore();
+      expect(() => store.openMap('notes', { opaqueKeys: true })).not.toThrow();
+    });
+
+    it('throws on openSet with opaqueKeys + no cipher', async () => {
+      store = await makePlaintextStore();
+      expect(() => store.openSet('nullifiers', { opaqueKeys: true })).toThrow(/opaqueKeys/i);
+    });
+
+    it('throws on openMultiMap with opaqueKeys + no cipher', async () => {
+      store = await makePlaintextStore();
+      expect(() => store.openMultiMap('tags', { opaqueKeys: true })).toThrow(/opaqueKeys/i);
+    });
+  });
+
+  describe('Map with opaqueKeys', () => {
+    let store: AztecSQLiteOPFSStore;
+
+    beforeEach(async () => {
+      store = await makeEncryptedStore();
+    });
+
+    afterEach(async () => {
+      await store.delete();
+    });
+
+    it('round-trips point lookups', async () => {
+      const map = store.openMap<string, string>('notes', { opaqueKeys: true });
+      await map.set('commitment-0xabc', 'note-value-1');
+      await map.set('commitment-0xdef', 'note-value-2');
+      expect(await map.getAsync('commitment-0xabc')).toBe('note-value-1');
+      expect(await map.getAsync('commitment-0xdef')).toBe('note-value-2');
+      expect(await map.getAsync('unknown')).toBeUndefined();
+    });
+
+    it('hasAsync / sizeAsync / delete work', async () => {
+      const map = store.openMap<string, string>('notes', { opaqueKeys: true });
+      await map.set('a', '1');
+      await map.set('b', '2');
+      expect(await map.hasAsync('a')).toBe(true);
+      expect(await map.sizeAsync()).toBe(2);
+      await map.delete('a');
+      expect(await map.hasAsync('a')).toBe(false);
+      expect(await map.sizeAsync()).toBe(1);
+    });
+
+    it('iteration returns the original keys (not HMAC bytes)', async () => {
+      const map = store.openMap<string, string>('notes', { opaqueKeys: true });
+      await map.setMany([
+        { key: 'alpha', value: 'A' },
+        { key: 'beta', value: 'B' },
+        { key: 'gamma', value: 'C' },
+      ]);
+      const collected: Array<[string, string]> = [];
+      for await (const entry of map.entriesAsync()) {
+        collected.push(entry);
+      }
+      const keysSeen = collected.map(e => e[0]).sort();
+      expect(keysSeen).toEqual(['alpha', 'beta', 'gamma']);
+      const valuesSeen = collected.map(e => e[1]).sort();
+      expect(valuesSeen).toEqual(['A', 'B', 'C']);
+    });
+
+    it('unrestricted iteration with limit returns the requested count', async () => {
+      const map = store.openMap<string, string>('notes', { opaqueKeys: true });
+      for (let i = 0; i < 10; i++) {
+        await map.set(`key-${i}`, `val-${i}`);
+      }
+      const limited = await toArray(map.entriesAsync({ limit: 3 }));
+      expect(limited).toHaveLength(3);
+    });
+
+    it('range queries with start throw', async () => {
+      const map = store.openMap<string, string>('notes', { opaqueKeys: true });
+      await map.set('a', 'A');
+      await expect(toArray(map.entriesAsync({ start: 'a' }))).rejects.toThrow(/opaque/i);
+    });
+
+    it('range queries with end throw', async () => {
+      const map = store.openMap<string, string>('notes', { opaqueKeys: true });
+      await map.set('a', 'A');
+      await expect(toArray(map.entriesAsync({ end: 'z' }))).rejects.toThrow(/opaque/i);
+    });
+
+    it('reverse iteration throws', async () => {
+      const map = store.openMap<string, string>('notes', { opaqueKeys: true });
+      await map.set('a', 'A');
+      await expect(toArray(map.entriesAsync({ reverse: true }))).rejects.toThrow(/opaque/i);
+    });
+  });
+
+  describe('at-rest observation', () => {
+    let store: AztecSQLiteOPFSStore;
+
+    beforeEach(async () => {
+      store = await makeEncryptedStore();
+    });
+
+    afterEach(async () => {
+      await store.delete();
+    });
+
+    it('stores HMAC (32 bytes), not ordered-binary, in the key column', async () => {
+      const map = store.openMap<string, string>('notes', { opaqueKeys: true });
+      await map.set('commitment-0xabc', 'sensitive-content');
+      const rows = await store.allAsync('SELECT key FROM data WHERE container = ?', ['map:notes']);
+      expect(rows).toHaveLength(1);
+      const keyBlob = rows[0][0] as Uint8Array;
+      expect(keyBlob).toBeInstanceOf(Uint8Array);
+      expect(keyBlob.byteLength).toBe(HMAC_SHA256_BYTES);
+      // Sanity: the HMAC bytes must not contain the original UTF-8 string.
+      const asText = new TextDecoder('utf-8', { fatal: false }).decode(keyBlob);
+      expect(asText).not.toContain('commitment');
+    });
+
+    it('leaves key column as ordered-binary when opaqueKeys is off', async () => {
+      const map = store.openMap<string, string>('visible');
+      await map.set('plain-key', 'value');
+      const rows = await store.allAsync('SELECT key FROM data WHERE container = ?', ['map:visible']);
+      expect(rows).toHaveLength(1);
+      const keyBlob = rows[0][0] as Uint8Array;
+      expect(keyBlob.byteLength).not.toBe(HMAC_SHA256_BYTES); // ordered-binary of 'plain-key' is shorter
+    });
+
+    it('never writes the plaintext value in the value column (encrypted)', async () => {
+      const map = store.openMap<string, string>('notes', { opaqueKeys: true });
+      const secret = 'THIS_STRING_MUST_NOT_APPEAR_ON_DISK';
+      await map.set('k', secret);
+      const rows = await store.allAsync('SELECT value FROM data WHERE container = ?', ['map:notes']);
+      const valueBlob = rows[0][0] as Uint8Array;
+      const asText = new TextDecoder('utf-8', { fatal: false }).decode(valueBlob);
+      expect(asText).not.toContain(secret);
+      expect(valueBlob[0]).toBe(0x01); // AES-GCM version prefix
+    });
+  });
+
+  describe('MultiMap with opaqueKeys (dedup via HMAC)', () => {
+    let store: AztecSQLiteOPFSStore;
+
+    beforeEach(async () => {
+      store = await makeEncryptedStore();
+    });
+
+    afterEach(async () => {
+      await store.delete();
+    });
+
+    it('deduplicates identical (key, value) pairs', async () => {
+      const mm = store.openMultiMap<string, string>('tags', { opaqueKeys: true });
+      await mm.set('k', 'v');
+      await mm.set('k', 'v'); // same pair — should dedup
+      expect(await mm.getValueCountAsync('k')).toBe(1);
+    });
+
+    it('keeps distinct values under the same key', async () => {
+      const mm = store.openMultiMap<string, string>('tags', { opaqueKeys: true });
+      await mm.set('k', 'v1');
+      await mm.set('k', 'v2');
+      expect(await mm.getValueCountAsync('k')).toBe(2);
+      const values: string[] = [];
+      for await (const v of mm.getValuesAsync('k')) {
+        values.push(v);
+      }
+      expect(values.sort()).toEqual(['v1', 'v2']);
+    });
+
+    it('deleteValue removes the matching (key, value)', async () => {
+      const mm = store.openMultiMap<string, string>('tags', { opaqueKeys: true });
+      await mm.set('k', 'v1');
+      await mm.set('k', 'v2');
+      await mm.deleteValue('k', 'v1');
+      const values: string[] = [];
+      for await (const v of mm.getValuesAsync('k')) {
+        values.push(v);
+      }
+      expect(values).toEqual(['v2']);
+    });
+  });
+
+  describe('row-rebinding (F1) is detected via AAD', () => {
+    let store: AztecSQLiteOPFSStore;
+
+    beforeEach(async () => {
+      store = await makeEncryptedStore();
+    });
+
+    afterEach(async () => {
+      await store.delete();
+    });
+
+    it('swapping value blobs between two rows makes both reads fail', async () => {
+      const map = store.openMap<string, string>('notes', { opaqueKeys: true });
+      await map.set('keyA', 'secretA');
+      await map.set('keyB', 'secretB');
+
+      // Read the two rows' raw ciphertexts.
+      const rows = await store.allAsync('SELECT slot, value FROM data WHERE container = ? ORDER BY slot', [
+        'map:notes',
+      ]);
+      expect(rows).toHaveLength(2);
+      const [slotA, ctA] = rows[0] as [string, Uint8Array];
+      const [slotB, ctB] = rows[1] as [string, Uint8Array];
+
+      // Mount the attack: swap the value blobs between the two slots.
+      await store.runAsync('UPDATE data SET value = ? WHERE slot = ?', [ctB, slotA]);
+      await store.runAsync('UPDATE data SET value = ? WHERE slot = ?', [ctA, slotB]);
+
+      // Both reads now fail — AAD mismatch → auth tag rejects.
+      await expect(map.getAsync('keyA')).rejects.toThrow();
+      await expect(map.getAsync('keyB')).rejects.toThrow();
+    });
+
+    it('swapping in a non-opaque map also fails (AAD binding is universal)', async () => {
+      const map = store.openMap<string, string>('visible');
+      await map.set('keyA', 'A-value');
+      await map.set('keyB', 'B-value');
+
+      const rows = await store.allAsync('SELECT slot, value FROM data WHERE container = ? ORDER BY slot', [
+        'map:visible',
+      ]);
+      const [slotA, ctA] = rows[0] as [string, Uint8Array];
+      const [slotB, ctB] = rows[1] as [string, Uint8Array];
+
+      await store.runAsync('UPDATE data SET value = ? WHERE slot = ?', [ctB, slotA]);
+      await store.runAsync('UPDATE data SET value = ? WHERE slot = ?', [ctA, slotB]);
+
+      await expect(map.getAsync('keyA')).rejects.toThrow();
+      await expect(map.getAsync('keyB')).rejects.toThrow();
+    });
+
+    it('untouched rows still read correctly after a swap elsewhere', async () => {
+      const map = store.openMap<string, string>('notes', { opaqueKeys: true });
+      await map.set('keyA', 'A');
+      await map.set('keyB', 'B');
+      await map.set('keyC', 'C');
+
+      // Row order is by HMAC — pick the first two and swap them. The key that
+      // was NOT in the first two must still read correctly.
+      const rows = await store.allAsync('SELECT slot, value FROM data WHERE container = ? ORDER BY slot', [
+        'map:notes',
+      ]);
+      const [slot0, ct0] = rows[0] as [string, Uint8Array];
+      const [slot1, ct1] = rows[1] as [string, Uint8Array];
+      await store.runAsync('UPDATE data SET value = ? WHERE slot = ?', [ct1, slot0]);
+      await store.runAsync('UPDATE data SET value = ? WHERE slot = ?', [ct0, slot1]);
+
+      // Exactly one of the three keys lives in the untouched row and must still work.
+      const results = await Promise.allSettled([map.getAsync('keyA'), map.getAsync('keyB'), map.getAsync('keyC')]);
+      const survivors = results.filter(r => r.status === 'fulfilled');
+      expect(survivors).toHaveLength(1);
+    });
+  });
+
+  describe('Set with opaqueKeys', () => {
+    let store: AztecSQLiteOPFSStore;
+
+    beforeEach(async () => {
+      store = await makeEncryptedStore();
+    });
+
+    afterEach(async () => {
+      await store.delete();
+    });
+
+    it('round-trips membership', async () => {
+      const set = store.openSet<string>('nullifiers', { opaqueKeys: true });
+      await set.add('nullifier-1');
+      expect(await set.hasAsync('nullifier-1')).toBe(true);
+      expect(await set.hasAsync('nullifier-2')).toBe(false);
+      await set.delete('nullifier-1');
+      expect(await set.hasAsync('nullifier-1')).toBe(false);
+    });
+
+    it('iteration returns original keys', async () => {
+      const set = store.openSet<string>('nullifiers', { opaqueKeys: true });
+      await set.add('x');
+      await set.add('y');
+      await set.add('z');
+      const collected: string[] = [];
+      for await (const k of set.entriesAsync()) {
+        collected.push(k);
+      }
+      expect(collected.sort()).toEqual(['x', 'y', 'z']);
+    });
+  });
+});

--- a/yarn-project/kv-store/src/sqlite-opfs/opaque_keys.test.ts
+++ b/yarn-project/kv-store/src/sqlite-opfs/opaque_keys.test.ts
@@ -16,31 +16,37 @@ function makePlaintextStore(): Promise<AztecSQLiteOPFSStore> {
 }
 
 describe('opaque-keys mode', () => {
-  describe('validation at open time', () => {
+  describe('opaqueKeys falls back to plaintext on an unencrypted store', () => {
     let store: AztecSQLiteOPFSStore;
 
     afterEach(async () => {
       await store.delete();
     });
 
-    it('throws when opaqueKeys is requested on an unencrypted store', async () => {
+    it('opens cleanly (no throw) — the flag is a hint', async () => {
       store = await makePlaintextStore();
-      expect(() => store.openMap('notes', { opaqueKeys: true })).toThrow(/opaqueKeys/i);
-    });
-
-    it('allows opaqueKeys on an encrypted store', async () => {
-      store = await makeEncryptedStore();
       expect(() => store.openMap('notes', { opaqueKeys: true })).not.toThrow();
+      expect(() => store.openSet('nullifiers', { opaqueKeys: true })).not.toThrow();
+      expect(() => store.openMultiMap('tags', { opaqueKeys: true })).not.toThrow();
     });
 
-    it('throws on openSet with opaqueKeys + no cipher', async () => {
+    it('silently stores keys in ordered-binary (not HMAC) when no cipher is configured', async () => {
       store = await makePlaintextStore();
-      expect(() => store.openSet('nullifiers', { opaqueKeys: true })).toThrow(/opaqueKeys/i);
+      const map = store.openMap<string, string>('notes', { opaqueKeys: true });
+      await map.set('commitment-0xabc', 'v1');
+      const rows = await store.allAsync('SELECT key FROM data WHERE container = ?', ['map:notes']);
+      const keyBlob = rows[0][0] as Uint8Array;
+      // 32 bytes would be HMAC-SHA256 — unencrypted container must be the shorter ordered-binary bytes.
+      expect(keyBlob.byteLength).not.toBe(32);
     });
 
-    it('throws on openMultiMap with opaqueKeys + no cipher', async () => {
-      store = await makePlaintextStore();
-      expect(() => store.openMultiMap('tags', { opaqueKeys: true })).toThrow(/opaqueKeys/i);
+    it('still HMACs keys on an encrypted store (no silent fall-back when cipher present)', async () => {
+      store = await makeEncryptedStore();
+      const map = store.openMap<string, string>('notes', { opaqueKeys: true });
+      await map.set('commitment-0xabc', 'v1');
+      const rows = await store.allAsync('SELECT key FROM data WHERE container = ?', ['map:notes']);
+      const keyBlob = rows[0][0] as Uint8Array;
+      expect(keyBlob.byteLength).toBe(32);
     });
   });
 

--- a/yarn-project/kv-store/src/sqlite-opfs/set.test.ts
+++ b/yarn-project/kv-store/src/sqlite-opfs/set.test.ts
@@ -1,7 +1,15 @@
 import { describeAztecSet } from '../interfaces/set_test_suite.js';
 import { mockLogger } from '../interfaces/utils.js';
+import { AesGcmCipher, RawKeyProvider } from './cipher.js';
 import { AztecSQLiteOPFSStore } from './store.js';
 
 describe('SQLiteOPFSSet', () => {
   describeAztecSet('AztecSet', async () => await AztecSQLiteOPFSStore.open(mockLogger, undefined, true));
+});
+
+describe('SQLiteOPFSSet (encrypted)', () => {
+  describeAztecSet('AztecSet', async () => {
+    const cipher = await AesGcmCipher.create(new RawKeyProvider(globalThis.crypto.getRandomValues(new Uint8Array(32))));
+    return await AztecSQLiteOPFSStore.open(mockLogger, undefined, true, undefined, cipher);
+  });
 });

--- a/yarn-project/kv-store/src/sqlite-opfs/set.ts
+++ b/yarn-project/kv-store/src/sqlite-opfs/set.ts
@@ -1,14 +1,14 @@
 import type { Key, Range } from '../interfaces/common.js';
 import type { AztecAsyncSet } from '../interfaces/set.js';
-import { SQLiteOPFSAztecMap } from './map.js';
+import { SQLiteOPFSAztecMap, type SQLiteOPFSMapOptions } from './map.js';
 import type { AztecSQLiteOPFSStore } from './store.js';
 
 /** Set backed by SQLite. Composes a Map<K, true>. */
 export class SQLiteOPFSAztecSet<K extends Key> implements AztecAsyncSet<K> {
   readonly #map: SQLiteOPFSAztecMap<K, boolean>;
 
-  constructor(store: AztecSQLiteOPFSStore, name: string) {
-    this.#map = new SQLiteOPFSAztecMap<K, boolean>(store, name);
+  constructor(store: AztecSQLiteOPFSStore, name: string, options: SQLiteOPFSMapOptions = {}) {
+    this.#map = new SQLiteOPFSAztecMap<K, boolean>(store, name, options);
   }
 
   hasAsync(key: K): Promise<boolean> {

--- a/yarn-project/kv-store/src/sqlite-opfs/singleton.test.ts
+++ b/yarn-project/kv-store/src/sqlite-opfs/singleton.test.ts
@@ -1,7 +1,15 @@
 import { describeAztecSingleton } from '../interfaces/singleton_test_suite.js';
 import { mockLogger } from '../interfaces/utils.js';
+import { AesGcmCipher, RawKeyProvider } from './cipher.js';
 import { AztecSQLiteOPFSStore } from './store.js';
 
 describe('SQLiteOPFSSingleton', () => {
   describeAztecSingleton('AztecSingleton', async () => await AztecSQLiteOPFSStore.open(mockLogger, undefined, true));
+});
+
+describe('SQLiteOPFSSingleton (encrypted)', () => {
+  describeAztecSingleton('AztecSingleton', async () => {
+    const cipher = await AesGcmCipher.create(new RawKeyProvider(globalThis.crypto.getRandomValues(new Uint8Array(32))));
+    return await AztecSQLiteOPFSStore.open(mockLogger, undefined, true, undefined, cipher);
+  });
 });

--- a/yarn-project/kv-store/src/sqlite-opfs/singleton.ts
+++ b/yarn-project/kv-store/src/sqlite-opfs/singleton.ts
@@ -1,12 +1,15 @@
+import { Buffer } from 'buffer';
 import { Encoder } from 'msgpackr';
-import { hash } from 'ohash';
 import { toBufferKey } from 'ordered-binary';
 
 import type { Value } from '../interfaces/common.js';
 import type { AztecAsyncSingleton } from '../interfaces/singleton.js';
 import type { AztecSQLiteOPFSStore } from './store.js';
 
-/** Stores a single value identified by `name`. */
+const textEncoder = new TextEncoder();
+
+/** Stores a single value identified by `name`. Values flow through the store's
+ *  cipher — a real cipher encrypts the value blob; `IdentityCipher` is a passthrough. */
 export class SQLiteOPFSAztecSingleton<T extends Value> implements AztecAsyncSingleton<T> {
   readonly #container: string;
   readonly #slot: string;
@@ -26,17 +29,27 @@ export class SQLiteOPFSAztecSingleton<T extends Value> implements AztecAsyncSing
       return undefined;
     }
     const raw = rows[0][0];
-    if (raw instanceof Uint8Array) {
-      return this.#encoder.unpack(raw) as T;
+    if (!(raw instanceof Uint8Array)) {
+      return undefined;
     }
-    return undefined;
+    const plaintext = await this.store.cipher.decrypt(raw, textEncoder.encode(this.#slot));
+    const unpacked = this.#encoder.unpack(plaintext);
+    if (unpacked instanceof Uint8Array && !Buffer.isBuffer(unpacked)) {
+      return Buffer.from(unpacked) as T;
+    }
+    return unpacked as T;
   }
 
   async set(val: T): Promise<boolean> {
+    const packed = this.#encoder.pack(val);
+    const [cipherValue, digest] = await Promise.all([
+      this.store.cipher.encrypt(packed, textEncoder.encode(this.#slot)),
+      this.store.cipher.digest(packed),
+    ]);
     const { changes } = await this.store.runAsync(
       `INSERT OR REPLACE INTO data (slot, container, key, key_count, hash, value)
        VALUES (?, ?, ?, ?, ?, ?)`,
-      [this.#slot, this.#container, toBufferKey([this.#slot]), 1, hash(val), this.#encoder.pack(val)],
+      [this.#slot, this.#container, toBufferKey([this.#slot]), 1, digest, cipherValue],
     );
     return changes > 0;
   }

--- a/yarn-project/kv-store/src/sqlite-opfs/store.ts
+++ b/yarn-project/kv-store/src/sqlite-opfs/store.ts
@@ -2,7 +2,7 @@ import type { Logger } from '@aztec/foundation/log';
 import { SerialQueue } from '@aztec/foundation/queue';
 
 import type { AztecAsyncArray } from '../interfaces/array.js';
-import type { Key, StoreSize, Value } from '../interfaces/common.js';
+import type { Key, OpenContainerOptions, StoreSize, Value } from '../interfaces/common.js';
 import type { AztecAsyncCounter } from '../interfaces/counter.js';
 import type { AztecAsyncMap } from '../interfaces/map.js';
 import type { AztecAsyncMultiMap } from '../interfaces/multi_map.js';
@@ -10,6 +10,7 @@ import type { AztecAsyncSet } from '../interfaces/set.js';
 import type { AztecAsyncSingleton } from '../interfaces/singleton.js';
 import type { AztecAsyncKVStore } from '../interfaces/store.js';
 import { SQLiteOPFSAztecArray } from './array.js';
+import { IdentityCipher, type ValueCipher } from './cipher.js';
 import { SQLiteOPFSAztecMap } from './map.js';
 import type { ResultRow, SqlValue, WorkerRequest, WorkerResponse } from './messages.js';
 import { SQLiteOPFSAztecMultiMap } from './multi_map.js';
@@ -32,6 +33,7 @@ export class AztecSQLiteOPFSStore implements AztecAsyncKVStore {
   readonly #txQueue = new SerialQueue();
   readonly #name: string;
   readonly #log: Logger;
+  readonly #cipher: ValueCipher;
   #nextId = 0;
   #inTx = false;
   #closed = false;
@@ -40,11 +42,13 @@ export class AztecSQLiteOPFSStore implements AztecAsyncKVStore {
     worker: Worker,
     name: string,
     log: Logger,
+    cipher: ValueCipher,
     public readonly isEphemeral: boolean,
   ) {
     this.#worker = worker;
     this.#name = name;
     this.#log = log;
+    this.#cipher = cipher;
     this.#worker.onmessage = (ev: MessageEvent<WorkerResponse>) => {
       const { id } = ev.data;
       const handler = this.#pending.get(id);
@@ -67,32 +71,44 @@ export class AztecSQLiteOPFSStore implements AztecAsyncKVStore {
    * is true the database lives only in memory and is lost when the worker terminates.
    * Pass `poolDirectory` to place the SAH Pool in a non-default OPFS subdirectory —
    * required when multiple stores coexist in the same tab, because the SAH Pool holds
-   * an exclusive lock on its directory.
+   * an exclusive lock on its directory. Pass `cipher` to enable value-level encryption;
+   * defaults to `IdentityCipher` (byte-for-byte passthrough; on-disk format unchanged
+   * from phase-1 plaintext DBs).
    */
   static async open(
     log: Logger,
     name?: string,
     ephemeral: boolean = false,
     poolDirectory?: string,
+    cipher: ValueCipher = new IdentityCipher(),
   ): Promise<AztecSQLiteOPFSStore> {
     const dbName = name && !ephemeral ? name : `tmp-${globalThis.crypto.getRandomValues(new Uint8Array(8)).join('')}`;
     log.debug(`Opening SQLite-OPFS ${ephemeral ? 'ephemeral ' : ''}database ${dbName}`);
     const worker = new Worker(new URL('./worker.js', import.meta.url), { type: 'module' });
-    const store = new AztecSQLiteOPFSStore(worker, dbName, log, ephemeral);
+    const store = new AztecSQLiteOPFSStore(worker, dbName, log, cipher, ephemeral);
     await store.#sendRequest({ type: 'init', id: store.#allocId(), dbName, ephemeral, poolDirectory });
     return store;
   }
 
-  openMap<K extends Key, V extends Value>(name: string): AztecAsyncMap<K, V> {
-    return new SQLiteOPFSAztecMap<K, V>(this, name);
+  /** Cipher used for value encryption and keyed digests. Containers read from this
+   *  to match the store's confidentiality configuration. */
+  get cipher(): ValueCipher {
+    return this.#cipher;
   }
 
-  openSet<K extends Key>(name: string): AztecAsyncSet<K> {
-    return new SQLiteOPFSAztecSet<K>(this, name);
+  openMap<K extends Key, V extends Value>(name: string, options?: OpenContainerOptions): AztecAsyncMap<K, V> {
+    this.#validateOpaqueKeys(name, options);
+    return new SQLiteOPFSAztecMap<K, V>(this, name, { opaqueKeys: !!options?.opaqueKeys });
   }
 
-  openMultiMap<K extends Key, V extends Value>(name: string): AztecAsyncMultiMap<K, V> {
-    return new SQLiteOPFSAztecMultiMap<K, V>(this, name);
+  openSet<K extends Key>(name: string, options?: OpenContainerOptions): AztecAsyncSet<K> {
+    this.#validateOpaqueKeys(name, options);
+    return new SQLiteOPFSAztecSet<K>(this, name, { opaqueKeys: !!options?.opaqueKeys });
+  }
+
+  openMultiMap<K extends Key, V extends Value>(name: string, options?: OpenContainerOptions): AztecAsyncMultiMap<K, V> {
+    this.#validateOpaqueKeys(name, options);
+    return new SQLiteOPFSAztecMultiMap<K, V>(this, name, { opaqueKeys: !!options?.opaqueKeys });
   }
 
   openCounter<K extends Key>(_name: string): AztecAsyncCounter<K> {
@@ -212,6 +228,18 @@ export class AztecSQLiteOPFSStore implements AztecAsyncKVStore {
 
   #allocId(): number {
     return ++this.#nextId;
+  }
+
+  /** Guard: `opaqueKeys: true` needs a real cipher to HMAC the keys. The identity
+   *  cipher would leave them in the clear, silently defeating the caller's intent —
+   *  so we fail loudly at open time rather than on first write. */
+  #validateOpaqueKeys(containerName: string, options?: OpenContainerOptions): void {
+    if (options?.opaqueKeys && this.#cipher.isNullCipher) {
+      throw new Error(
+        `SQLite-OPFS container '${containerName}' was opened with opaqueKeys: true, but the store has no encryption cipher. ` +
+          `Pass a non-null cipher to AztecSQLiteOPFSStore.open(...) or omit opaqueKeys.`,
+      );
+    }
   }
 
   /**

--- a/yarn-project/kv-store/src/sqlite-opfs/store.ts
+++ b/yarn-project/kv-store/src/sqlite-opfs/store.ts
@@ -97,18 +97,15 @@ export class AztecSQLiteOPFSStore implements AztecAsyncKVStore {
   }
 
   openMap<K extends Key, V extends Value>(name: string, options?: OpenContainerOptions): AztecAsyncMap<K, V> {
-    this.#validateOpaqueKeys(name, options);
-    return new SQLiteOPFSAztecMap<K, V>(this, name, { opaqueKeys: !!options?.opaqueKeys });
+    return new SQLiteOPFSAztecMap<K, V>(this, name, { opaqueKeys: this.#effectiveOpaqueKeys(options) });
   }
 
   openSet<K extends Key>(name: string, options?: OpenContainerOptions): AztecAsyncSet<K> {
-    this.#validateOpaqueKeys(name, options);
-    return new SQLiteOPFSAztecSet<K>(this, name, { opaqueKeys: !!options?.opaqueKeys });
+    return new SQLiteOPFSAztecSet<K>(this, name, { opaqueKeys: this.#effectiveOpaqueKeys(options) });
   }
 
   openMultiMap<K extends Key, V extends Value>(name: string, options?: OpenContainerOptions): AztecAsyncMultiMap<K, V> {
-    this.#validateOpaqueKeys(name, options);
-    return new SQLiteOPFSAztecMultiMap<K, V>(this, name, { opaqueKeys: !!options?.opaqueKeys });
+    return new SQLiteOPFSAztecMultiMap<K, V>(this, name, { opaqueKeys: this.#effectiveOpaqueKeys(options) });
   }
 
   openCounter<K extends Key>(_name: string): AztecAsyncCounter<K> {
@@ -230,16 +227,17 @@ export class AztecSQLiteOPFSStore implements AztecAsyncKVStore {
     return ++this.#nextId;
   }
 
-  /** Guard: `opaqueKeys: true` needs a real cipher to HMAC the keys. The identity
-   *  cipher would leave them in the clear, silently defeating the caller's intent —
-   *  so we fail loudly at open time rather than on first write. */
-  #validateOpaqueKeys(containerName: string, options?: OpenContainerOptions): void {
-    if (options?.opaqueKeys && this.#cipher.isNullCipher) {
-      throw new Error(
-        `SQLite-OPFS container '${containerName}' was opened with opaqueKeys: true, but the store has no encryption cipher. ` +
-          `Pass a non-null cipher to AztecSQLiteOPFSStore.open(...) or omit opaqueKeys.`,
-      );
-    }
+  /** Returns the effective value of `opaqueKeys` for this store — always `false`
+   *  when the store has no encryption cipher, regardless of what the caller asked for.
+   *
+   *  Rationale: `opaqueKeys` is a *hint*, identical in spirit to the flag that LMDB
+   *  and IndexedDB silently ignore. Callers (notably PXE storage classes) hard-code
+   *  `opaqueKeys: true` on sensitive containers; the user enables or disables
+   *  encryption at the store level. If those two decisions disagreed we used to
+   *  throw, which turned "run PXE code without encryption" into an impossible state.
+   *  Silent fall-back matches the sibling backends and restores that path. */
+  #effectiveOpaqueKeys(options?: OpenContainerOptions): boolean {
+    return !!options?.opaqueKeys && !this.#cipher.isNullCipher;
   }
 
   /**

--- a/yarn-project/kv-store/vitest.config.ts
+++ b/yarn-project/kv-store/vitest.config.ts
@@ -56,6 +56,7 @@ export default defineConfig({
       // Benchmarks self-skip unless VITE_BENCH=1; include so they're discoverable.
       './src/bench/indexeddb/**/*.test.ts',
       './src/bench/sqlite-opfs/**/*.test.ts',
+      './src/bench/sqlite-opfs-encrypted/**/*.test.ts',
     ],
     // Bench suites do full-population + N-iteration work; default 30s is too tight.
     testTimeout: process.env.VITE_BENCH === '1' ? 300_000 : 30_000,

--- a/yarn-project/pxe/src/storage/address_store/address_store.ts
+++ b/yarn-project/pxe/src/storage/address_store/address_store.ts
@@ -12,7 +12,10 @@ export class AddressStore {
     this.#store = store;
 
     this.#completeAddresses = this.#store.openArray('complete_addresses');
-    this.#completeAddressIndex = this.#store.openMap('complete_address_index');
+    // opaqueKeys: the index map is keyed by user-controlled account addresses.
+    // The array above stores addresses by numeric position, which doesn't leak
+    // identity; the map exposes the set directly and so needs HMAC'd keys.
+    this.#completeAddressIndex = this.#store.openMap('complete_address_index', { opaqueKeys: true });
   }
 
   addCompleteAddress(completeAddress: CompleteAddress): Promise<boolean> {

--- a/yarn-project/pxe/src/storage/note_store/note_store.ts
+++ b/yarn-project/pxe/src/storage/note_store/note_store.ts
@@ -49,9 +49,16 @@ export class NoteStore implements StagedStore {
 
   constructor(store: AztecAsyncKVStore) {
     this.#store = store;
-    this.#notes = store.openMap('notes');
-    this.#nullifiersByContractAddress = store.openMultiMap('note_nullifiers_by_contract');
-    this.#nullifiersByNullificationBlockNumber = store.openMultiMap('note_block_number_to_nullifier');
+    // opaqueKeys: keys here are siloed nullifiers (unspent → secret until the
+    // note is consumed), contract addresses (reveals watch-list), and block
+    // numbers (reveals sync history). All three leak forward-privacy-relevant
+    // access patterns when stored in the clear. Backends without an encryption
+    // cipher silently ignore the flag.
+    this.#notes = store.openMap('notes', { opaqueKeys: true });
+    this.#nullifiersByContractAddress = store.openMultiMap('note_nullifiers_by_contract', { opaqueKeys: true });
+    this.#nullifiersByNullificationBlockNumber = store.openMultiMap('note_block_number_to_nullifier', {
+      opaqueKeys: true,
+    });
 
     this.#jobLocks = new Map();
     this.#notesForJob = new Map();

--- a/yarn-project/pxe/src/storage/private_event_store/private_event_store.ts
+++ b/yarn-project/pxe/src/storage/private_event_store/private_event_store.ts
@@ -52,9 +52,15 @@ export class PrivateEventStore implements StagedStore {
 
   constructor(store: AztecAsyncKVStore) {
     this.#store = store;
-    this.#events = this.#store.openMap('private_event_logs');
-    this.#eventsByContractAndEventSelector = this.#store.openMultiMap('events_by_contract_selector');
-    this.#eventsByBlockNumber = this.#store.openMultiMap('events_by_block_number');
+    // opaqueKeys: siloed event commitments are post-decryption secrets from the
+    // user's perspective; contract/selector tuples reveal which apps + event types
+    // the user monitors; block numbers reveal sync history. Backends without a
+    // cipher silently ignore the flag.
+    this.#events = this.#store.openMap('private_event_logs', { opaqueKeys: true });
+    this.#eventsByContractAndEventSelector = this.#store.openMultiMap('events_by_contract_selector', {
+      opaqueKeys: true,
+    });
+    this.#eventsByBlockNumber = this.#store.openMultiMap('events_by_block_number', { opaqueKeys: true });
 
     this.#eventsForJob = new Map();
     this.#jobLocks = new Map();

--- a/yarn-project/pxe/src/storage/tagging_store/recipient_tagging_store.ts
+++ b/yarn-project/pxe/src/storage/tagging_store/recipient_tagging_store.ts
@@ -28,8 +28,10 @@ export class RecipientTaggingStore implements StagedStore {
   constructor(store: AztecAsyncKVStore) {
     this.#store = store;
 
-    this.#highestAgedIndex = this.#store.openMap('highest_aged_index');
-    this.#highestFinalizedIndex = this.#store.openMap('highest_finalized_index');
+    // opaqueKeys: keys are extended directional app tagging secrets — same
+    // confirmation-oracle concern as sender_tagging_store.
+    this.#highestAgedIndex = this.#store.openMap('highest_aged_index', { opaqueKeys: true });
+    this.#highestFinalizedIndex = this.#store.openMap('highest_finalized_index', { opaqueKeys: true });
 
     this.#highestAgedIndexForJob = new Map();
     this.#highestFinalizedIndexForJob = new Map();

--- a/yarn-project/pxe/src/storage/tagging_store/sender_address_book_store.ts
+++ b/yarn-project/pxe/src/storage/tagging_store/sender_address_book_store.ts
@@ -13,7 +13,9 @@ export class SenderAddressBookStore {
   constructor(store: AztecAsyncKVStore) {
     this.#store = store;
 
-    this.#addressBook = this.#store.openMap('address_book');
+    // opaqueKeys: keys are sender addresses the user decrypts logs from — this
+    // is effectively the user's incoming-message contact list.
+    this.#addressBook = this.#store.openMap('address_book', { opaqueKeys: true });
   }
 
   addSender(address: AztecAddress): Promise<boolean> {

--- a/yarn-project/pxe/src/storage/tagging_store/sender_tagging_store.ts
+++ b/yarn-project/pxe/src/storage/tagging_store/sender_tagging_store.ts
@@ -45,8 +45,11 @@ export class SenderTaggingStore implements StagedStore {
   constructor(store: AztecAsyncKVStore) {
     this.#store = store;
 
-    this.#pendingIndexes = this.#store.openMap('pending_indexes');
-    this.#lastFinalizedIndexes = this.#store.openMap('last_finalized_indexes');
+    // opaqueKeys: keys are directional app tagging secrets derived from the user's
+    // spending key. Leaking the key set lets anyone who knows a candidate sender
+    // verify whether this PXE is tracking them.
+    this.#pendingIndexes = this.#store.openMap('pending_indexes', { opaqueKeys: true });
+    this.#lastFinalizedIndexes = this.#store.openMap('last_finalized_indexes', { opaqueKeys: true });
 
     this.#pendingIndexesForJob = new Map();
     this.#lastFinalizedIndexesForJob = new Map();

--- a/yarn-project/wallets/src/embedded/wallet_db.ts
+++ b/yarn-project/wallets/src/embedded/wallet_db.ts
@@ -4,24 +4,48 @@ import type { LogFn } from '@aztec/foundation/log';
 import type { AztecAsyncKVStore, AztecAsyncMap } from '@aztec/kv-store';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
 
+import { Buffer } from 'buffer';
+
 export const AccountTypes = ['schnorr', 'ecdsasecp256r1', 'ecdsasecp256k1'] as const;
 export type AccountType = (typeof AccountTypes)[number];
 
-function accountKey(field: string, address: AztecAddress | string): string {
-  return `${field}:${address.toString()}`;
-}
+/** Stored shape of an account record. All byte fields are `toBuffer()`-encoded so
+ *  they round-trip cleanly through msgpackr. */
+type StoredAccount = {
+  type: AccountType;
+  secretKey: Buffer;
+  salt: Buffer;
+  signingKey: Buffer;
+};
 
+/**
+ * Persists wallet account data and user-defined aliases.
+ *
+ * Layout (opaqueKeys on all three maps — keys are user account addresses and
+ * user-chosen alias strings, which this design keeps out of on-disk plaintext
+ * when the backing store is encrypted):
+ *   - `accounts`: address.toString() → StoredAccount
+ *   - `account_aliases`: alias → address bytes
+ *   - `sender_aliases`:  alias → address bytes
+ *
+ * The two alias maps are separate (instead of a shared map with `accounts:` /
+ * `senders:` prefixes, as before) because opaqueKeys HMACs the keys — prefix
+ * range queries no longer work over HMAC'd keys. One map per namespace is both
+ * cleaner structurally and enables opaqueKeys uniformly.
+ */
 export class WalletDB {
   private constructor(
-    private accounts: AztecAsyncMap<string, Buffer>,
-    private aliases: AztecAsyncMap<string, Buffer>,
+    private accounts: AztecAsyncMap<string, StoredAccount>,
+    private accountAliases: AztecAsyncMap<string, Buffer>,
+    private senderAliases: AztecAsyncMap<string, Buffer>,
     private userLog: LogFn,
   ) {}
 
   static init(store: AztecAsyncKVStore, userLog: LogFn) {
-    const accounts = store.openMap<string, Buffer>('accounts');
-    const aliases = store.openMap<string, Buffer>('aliases');
-    return new WalletDB(accounts, aliases, userLog);
+    const accounts = store.openMap<string, StoredAccount>('accounts', { opaqueKeys: true });
+    const accountAliases = store.openMap<string, Buffer>('account_aliases', { opaqueKeys: true });
+    const senderAliases = store.openMap<string, Buffer>('sender_aliases', { opaqueKeys: true });
+    return new WalletDB(accounts, accountAliases, senderAliases, userLog);
   }
 
   async storeAccount(
@@ -41,59 +65,60 @@ export class WalletDB {
     },
     log: LogFn = this.userLog,
   ) {
+    const addressStr = address.toString();
     if (alias) {
-      await this.aliases.set(`accounts:${alias}`, Buffer.from(address.toString()));
+      await this.accountAliases.set(alias, Buffer.from(addressStr));
     }
-    await this.accounts.set(accountKey('type', address), Buffer.from(type));
-    await this.accounts.set(accountKey('sk', address), secretKey.toBuffer());
-    await this.accounts.set(accountKey('salt', address), salt.toBuffer());
-    await this.accounts.set(
-      accountKey('signingKey', address),
-      'toBuffer' in signingKey ? signingKey.toBuffer() : signingKey,
-    );
+    await this.accounts.set(addressStr, {
+      type,
+      secretKey: secretKey.toBuffer(),
+      salt: salt.toBuffer(),
+      signingKey: 'toBuffer' in signingKey ? signingKey.toBuffer() : signingKey,
+    });
     log(`Account stored in database${alias ? ` with alias ${alias}` : ''}`);
   }
 
   async storeSender(address: AztecAddress, alias: string, log: LogFn = this.userLog) {
-    await this.aliases.set(`senders:${alias}`, Buffer.from(address.toString()));
+    await this.senderAliases.set(alias, Buffer.from(address.toString()));
     log(`Sender stored in database with alias ${alias}`);
   }
 
   async retrieveAccount(address: AztecAddress | string) {
-    const secretKeyBuffer = await this.accounts.getAsync(accountKey('sk', address));
-    if (!secretKeyBuffer) {
-      throw new Error(`Account "${address.toString()}" does not exist on this wallet.`);
+    const addressStr = typeof address === 'string' ? address : address.toString();
+    const stored = await this.accounts.getAsync(addressStr);
+    if (!stored) {
+      throw new Error(`Account "${addressStr}" does not exist on this wallet.`);
     }
-    const [saltBuffer, typeBuffer, signingKey] = await Promise.all([
-      this.accounts.getAsync(accountKey('salt', address)),
-      this.accounts.getAsync(accountKey('type', address)),
-      this.accounts.getAsync(accountKey('signingKey', address)),
-    ]);
-    const secretKey = Fr.fromBuffer(secretKeyBuffer);
-    const salt = Fr.fromBuffer(saltBuffer!);
-    const type = typeBuffer!.toString('utf8') as AccountType;
-    return { address, secretKey, salt, type, signingKey: signingKey! };
+    // msgpackr returns Uint8Array for Buffer fields after the browser round-trip;
+    // wrap back to Buffer at the boundary so downstream `Fr.fromBuffer` / consumers
+    // that rely on Buffer methods keep working.
+    return {
+      address,
+      secretKey: Fr.fromBuffer(Buffer.from(stored.secretKey)),
+      salt: Fr.fromBuffer(Buffer.from(stored.salt)),
+      type: stored.type,
+      signingKey: Buffer.from(stored.signingKey),
+    };
   }
 
   async listAccounts(): Promise<Aliased<AztecAddress>[]> {
-    // Read aliases and account addresses in parallel using range queries
-    const [aliasesByAddress, accountAddresses] = await Promise.all([
-      this.#readAccountAliases(),
-      this.#readAccountAddresses(),
-    ]);
-
-    return accountAddresses.map(addressStr => ({
-      alias: aliasesByAddress.get(addressStr) ?? '',
-      item: AztecAddress.fromString(addressStr),
-    }));
+    const aliasesByAddress = await this.#readAccountAliases();
+    const result: Aliased<AztecAddress>[] = [];
+    for await (const addressStr of this.accounts.keysAsync()) {
+      result.push({
+        alias: aliasesByAddress.get(addressStr) ?? '',
+        item: AztecAddress.fromString(addressStr),
+      });
+    }
+    return result;
   }
 
   async listSenders(): Promise<Aliased<AztecAddress>[]> {
     const result: Aliased<AztecAddress>[] = [];
-    for await (const [alias, item] of this.aliases.entriesAsync({ start: 'senders:', end: 'senders:\uffff' })) {
+    for await (const [alias, item] of this.senderAliases.entriesAsync()) {
       result.push({
-        alias: alias.slice('senders:'.length),
-        item: AztecAddress.fromString(item.toString()),
+        alias,
+        item: AztecAddress.fromString(Buffer.from(item).toString()),
       });
     }
     return result;
@@ -101,34 +126,21 @@ export class WalletDB {
 
   async #readAccountAliases(): Promise<Map<string, string>> {
     const aliasesByAddress = new Map<string, string>();
-    for await (const [alias, item] of this.aliases.entriesAsync({ start: 'accounts:', end: 'accounts:\uffff' })) {
-      const address = item.toString();
-      aliasesByAddress.set(address, alias.slice('accounts:'.length));
+    for await (const [alias, item] of this.accountAliases.entriesAsync()) {
+      aliasesByAddress.set(Buffer.from(item).toString(), alias);
     }
     return aliasesByAddress;
   }
 
-  async #readAccountAddresses(): Promise<string[]> {
-    const addresses: string[] = [];
-    // Range query on 'type:' prefix — one entry per account, avoids scanning sk/salt/signingKey entries
-    for await (const [key] of this.accounts.entriesAsync({ start: 'type:', end: 'type:\uffff' })) {
-      addresses.push(key.slice('type:'.length));
-    }
-    return addresses;
-  }
-
   async deleteAccount(address: AztecAddress) {
-    await Promise.all([
-      this.accounts.delete(accountKey('sk', address)),
-      this.accounts.delete(accountKey('salt', address)),
-      this.accounts.delete(accountKey('type', address)),
-      this.accounts.delete(accountKey('signingKey', address)),
-    ]);
-    // Clean up alias if one exists
-    const aliasesByAddress = await this.#readAccountAliases();
-    const alias = aliasesByAddress.get(address.toString());
-    if (alias) {
-      await this.aliases.delete(`accounts:${alias}`);
+    const addressStr = address.toString();
+    await this.accounts.delete(addressStr);
+    // Clean up any alias pointing at this address. Opaque-keys maps don't support
+    // reverse indexing, so iterate and match — the alias set per user is small.
+    for await (const [alias, item] of this.accountAliases.entriesAsync()) {
+      if (Buffer.from(item).toString() === addressStr) {
+        await this.accountAliases.delete(alias);
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

- Adds **value-level encryption** to the SQLite-OPFS backend via a pluggable `ValueCipher` (null-object `IdentityCipher` for off, `AesGcmCipher` for on) — disabled by default, bytes-identical to non-encrypted version when no cipher is passed.
- Introduces **opaqueKeys** mode for map/multi_map/set containers that need key-level confidentiality (HMAC'd keys + AAD-bound encrypted values; range queries disabled, point lookups and unordered iteration still work).
- Opts **13 PXE containers** into opaqueKeys (notes, nullifier-by-contract, event stores, tagging secrets, address book, wallet accounts/aliases).

## What's in the box

**kv-store** — new `cipher.ts` module (AES-GCM-256 for values, HMAC-SHA-256 for deterministic digests, HKDF-derived sub-keys, row-binding via AES-GCM AAD = slot). Shared interface gets an optional `OpenContainerOptions` arg on `openMap`/`openMultiMap`/`openSet`; LMDB/LMDB-v2/IDB accept-and-ignore it silently.

**PXE sweep** — `note_store`, `private_event_store`, `address_store`, both tagging stores, and the address book flip `opaqueKeys: true` on 13 audit-flagged containers.

**Wallet DB refactor** — previous prefix-range pattern (`type:ADDR` / `accounts:ALIAS` / `senders:ALIAS` in two shared maps) is incompatible with HMAC'd keys, so the DB is split into three namespace-per-map containers with opaqueKeys. Public API unchanged; all 17 existing tests pass.

## Tests

- **23** cipher unit tests (encrypt/decrypt/digest/keyDigest + AAD + tamper/wrong-key/wrong-AAD rejections)
- **19** opaque-keys semantics tests (validation, at-rest observation confirming HMAC'd key column + 0x01-prefixed ciphertext + no plaintext, unordered iteration)
- Each container's shared suite runs twice — plaintext and encrypted. **171 kv-store tests total.**
- **137** PXE storage tests, **17** wallet_db tests — all green.

## Test plan

- [x] `yarn workspace @aztec/kv-store test:browser src/sqlite-opfs/` — 171 passed
- [x] `yarn workspace @aztec/pxe test src/storage/` — 137 passed
- [x] `yarn workspace @aztec/wallets test src/embedded/wallet_db.test.ts` — 17 passed
- [x] `yarn build` clean on the touched packages
- [x] `yarn lint` clean on kv-store, pxe, wallets
- [ ] CI signal on merge-train/fairies

## Out of scope / follow-ups

- **`IndexedDBKeyProvider`** — current `RawKeyProvider(32 bytes)` is for tests / programmatic use. Next up: a provider that persists an unextractable HKDF master to IDB so there's a zero-UX key source for browsers.
- **Cipher wiring for real consumers** (gregoswap / PXE entrypoint) — this PR gives consumers the option; it does not flip it on for any real deployment.
- **Key rotation / re-encryption on rotate**

🤖 Generated with [Claude Code](https://claude.com/claude-code)