### PR TITLE
chore(prover-node): track estimated L1 fee when proof publishing is disabled

### DIFF
--- a/spartan/metrics/grafana/dashboards/aztec_provers.json
+++ b/spartan/metrics/grafana/dashboards/aztec_provers.json
@@ -2622,6 +2622,384 @@
       ],
       "title": "Circuit Sizes",
       "type": "bargauge"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 127
+      },
+      "id": 37,
+      "panels": [],
+      "title": "Estimated L1 Submission Fees (proof publishing disabled)",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "default": true,
+        "type": "prometheus",
+        "uid": "${data_source}"
+      },
+      "description": "Estimated total L1 fee a prover-node would have paid to submit each epoch proof, when PROVER_NODE_DISABLE_PROOF_PUBLISH is enabled. Computed as gasLimit * (baseFee + priorityFee).",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 6,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "Ξ"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 128
+      },
+      "id": 38,
+      "interval": "5m",
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "sum"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.2.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${data_source}"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(aztec_prover_node_estimated_submission_total_fee_eth_sum{k8s_namespace_name=\"$namespace\"}[$__rate_interval])) / clamp_min(sum(increase(aztec_prover_node_estimated_submission_total_fee_eth_count{k8s_namespace_name=\"$namespace\"}[$__rate_interval])), 1)",
+          "legendFormat": "Mean per epoch",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Estimated total L1 fee per proof submission (mean per epoch)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "default": true,
+        "type": "prometheus",
+        "uid": "${data_source}"
+      },
+      "description": "Estimated effective gas price (baseFee + priorityFee) the prover would have used at the time the proof was finalized.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "gwei"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 128
+      },
+      "id": 39,
+      "interval": "5m",
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.2.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${data_source}"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(aztec_prover_node_estimated_submission_gas_price_gwei_sum{k8s_namespace_name=\"$namespace\"}[$__rate_interval])) / clamp_min(sum(increase(aztec_prover_node_estimated_submission_gas_price_gwei_count{k8s_namespace_name=\"$namespace\"}[$__rate_interval])), 1)",
+          "legendFormat": "Mean per epoch",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Estimated effective gas price (mean per epoch)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "default": true,
+        "type": "prometheus",
+        "uid": "${data_source}"
+      },
+      "description": "Estimated gas the proof submission tx would have consumed (from eth_estimateGas against the rollup contract).",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 136
+      },
+      "id": 40,
+      "interval": "5m",
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.2.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${data_source}"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(aztec_prover_node_estimated_submission_gas_sum{k8s_namespace_name=\"$namespace\"}[$__rate_interval])) / clamp_min(sum(increase(aztec_prover_node_estimated_submission_gas_count{k8s_namespace_name=\"$namespace\"}[$__rate_interval])), 1)",
+          "legendFormat": "Mean per epoch",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Estimated gas per proof submission (mean per epoch)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "default": true,
+        "type": "prometheus",
+        "uid": "${data_source}"
+      },
+      "description": "Cumulative ETH that would have been spent on proof submissions in the displayed time range, summed across all prover replicas. Use this to project mainnet proving cost.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 6,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "Ξ"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 136
+      },
+      "id": 41,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.2.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${data_source}"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(aztec_prover_node_estimated_submission_total_fee_eth_sum{k8s_namespace_name=\"$namespace\"}[$__range]))",
+          "legendFormat": "Cumulative",
+          "range": false,
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Cumulative estimated L1 cost (selected range)",
+      "type": "stat"
     }
   ],
   "refresh": "30s",

--- a/yarn-project/prover-node/src/actions/rerun-epoch-proving-job.ts
+++ b/yarn-project/prover-node/src/actions/rerun-epoch-proving-job.ts
@@ -35,7 +35,10 @@ export async function rerunEpochProvingJob(
   const archiver = await createArchiverStore(config);
   const publicProcessorFactory = new PublicProcessorFactory(archiver, undefined, undefined, log.getBindings());
 
-  const publisher = { submitEpochProof: () => Promise.resolve(true) };
+  const publisher = {
+    submitEpochProof: () => Promise.resolve(true),
+    analyzeEpochProofSubmission: () => Promise.resolve(),
+  };
   const l2BlockSourceForReorgDetection = undefined;
   const deadline = undefined;
 

--- a/yarn-project/prover-node/src/job/epoch-proving-job.test.ts
+++ b/yarn-project/prover-node/src/job/epoch-proving-job.test.ts
@@ -231,13 +231,29 @@ describe('epoch-proving-job', () => {
     expect(prover.cancel).toHaveBeenCalled();
   });
 
-  it('skips publishing when skipSubmitProof is enabled', async () => {
+  it('analyzes estimated fees and does not publish when skipSubmitProof is enabled', async () => {
+    publisher.analyzeEpochProofSubmission.mockResolvedValue(undefined);
+
     const job = createJob({ skipSubmitProof: true });
     await job.run();
 
     expect(job.getState()).toEqual('completed');
     expect(prover.finalizeEpoch).toHaveBeenCalled();
     expect(publisher.submitEpochProof).not.toHaveBeenCalled();
+    expect(publisher.analyzeEpochProofSubmission).toHaveBeenCalledWith(
+      expect.objectContaining({ epochNumber, proof, publicInputs, attestations: attestations.map(a => a.toViem()) }),
+    );
+  });
+
+  it('completes successfully even if fee analysis fails when skipSubmitProof is enabled', async () => {
+    publisher.analyzeEpochProofSubmission.mockRejectedValue(new Error('fee analysis failed'));
+
+    const job = createJob({ skipSubmitProof: true });
+    await job.run();
+
+    expect(job.getState()).toEqual('completed');
+    expect(publisher.submitEpochProof).not.toHaveBeenCalled();
+    expect(publisher.analyzeEpochProofSubmission).toHaveBeenCalled();
   });
 
   it('inserts L1 to L2 messages into the message tree only for the first block of each checkpoint', async () => {

--- a/yarn-project/prover-node/src/job/epoch-proving-job.ts
+++ b/yarn-project/prover-node/src/job/epoch-proving-job.ts
@@ -58,7 +58,7 @@ export class EpochProvingJob implements Traceable {
     private dbProvider: Pick<ForkMerkleTreeOperations, 'fork'>,
     private prover: EpochProver,
     private publicProcessorFactory: PublicProcessorFactory,
-    private publisher: Pick<ProverNodePublisher, 'submitEpochProof'>,
+    private publisher: Pick<ProverNodePublisher, 'submitEpochProof' | 'analyzeEpochProofSubmission'>,
     private l2BlockSource: L2BlockSource | undefined,
     private metrics: ProverNodeJobMetrics,
     private deadline: Date | undefined,
@@ -270,8 +270,21 @@ export class EpochProvingJob implements Traceable {
 
       if (this.config.skipSubmitProof) {
         this.log.info(
-          `Proof publishing is disabled. Dropping valid proof for epoch ${epochNumber} (checkpoints ${fromCheckpoint} to ${toCheckpoint})`,
+          `Proof publishing is disabled. Analyzing estimated L1 fees for epoch ${epochNumber} (checkpoints ${fromCheckpoint} to ${toCheckpoint})`,
         );
+        try {
+          await this.publisher.analyzeEpochProofSubmission({
+            fromCheckpoint,
+            toCheckpoint,
+            epochNumber,
+            publicInputs,
+            proof,
+            batchedBlobInputs,
+            attestations,
+          });
+        } catch (err) {
+          this.log.warn(`Failed to analyze estimated L1 fees for epoch ${epochNumber}`, err);
+        }
         this.state = 'completed';
         this.metrics.recordProvingJob(executionTime, timer.ms(), epochSizeCheckpoints, epochSizeBlocks, epochSizeTxs);
         return;

--- a/yarn-project/prover-node/src/metrics.ts
+++ b/yarn-project/prover-node/src/metrics.ts
@@ -140,6 +140,13 @@ export class ProverNodeRewardsMetrics {
   };
 }
 
+export type EstimatedSubmitProofStats = {
+  gasLimit: bigint;
+  baseFeePerGas: bigint;
+  maxPriorityFeePerGas: bigint;
+  estimatedTotalFee: bigint;
+};
+
 export class ProverNodePublisherMetrics {
   gasPrice: Histogram;
   txCount: UpDownCounter;
@@ -150,6 +157,10 @@ export class ProverNodePublisherMetrics {
   txBlobDataGasUsed: Histogram;
   txBlobDataGasCost: Histogram;
   txTotalFee: Histogram;
+
+  private txGasEstimated: Histogram;
+  private gasPriceEstimated: Histogram;
+  private txTotalFeeEstimated: Histogram;
 
   private senderBalance: Gauge;
   private meter: Meter;
@@ -182,6 +193,12 @@ export class ProverNodePublisherMetrics {
 
     this.txTotalFee = this.meter.createHistogram(Metrics.L1_PUBLISHER_TX_TOTAL_FEE);
 
+    this.txGasEstimated = this.meter.createHistogram(Metrics.PROVER_NODE_ESTIMATED_SUBMISSION_GAS);
+
+    this.gasPriceEstimated = this.meter.createHistogram(Metrics.PROVER_NODE_ESTIMATED_SUBMISSION_GAS_PRICE);
+
+    this.txTotalFeeEstimated = this.meter.createHistogram(Metrics.PROVER_NODE_ESTIMATED_SUBMISSION_TOTAL_FEE);
+
     this.senderBalance = this.meter.createGauge(Metrics.L1_PUBLISHER_BALANCE);
   }
 
@@ -194,6 +211,26 @@ export class ProverNodePublisherMetrics {
 
   recordSubmitProof(durationMs: number, stats: L1PublishProofStats) {
     this.recordTx(durationMs, stats);
+  }
+
+  public recordEstimatedSubmitProof(stats: EstimatedSubmitProofStats) {
+    const attributes = { [Attributes.L1_TX_TYPE]: 'submitProof' } as const;
+
+    this.txGasEstimated.record(Number(stats.gasLimit), attributes);
+
+    try {
+      this.gasPriceEstimated.record(
+        parseInt(formatEther(stats.baseFeePerGas + stats.maxPriorityFeePerGas, 'gwei'), 10),
+      );
+    } catch {
+      // ignore
+    }
+
+    try {
+      this.txTotalFeeEstimated.record(parseFloat(formatEther(stats.estimatedTotalFee)));
+    } catch {
+      // ignore
+    }
   }
 
   public recordSenderBalance(wei: bigint, senderAddress: string) {

--- a/yarn-project/prover-node/src/prover-node-publisher.test.ts
+++ b/yarn-project/prover-node/src/prover-node-publisher.test.ts
@@ -199,6 +199,65 @@ describe('prover-node-publisher', () => {
     },
   );
 
+  it('analyzeEpochProofSubmission validates, estimates, and does not send tx', async () => {
+    const fromCheckpoint = 33;
+    const toCheckpoint = 64;
+
+    rollup.getTips.mockResolvedValue({ pending: CheckpointNumber(65), proven: CheckpointNumber(32) });
+
+    const checkpoints = Array.from({ length: 100 }, () => RootRollupPublicInputs.random());
+    rollup.getCheckpoint.mockImplementation((n: CheckpointNumber) =>
+      Promise.resolve({
+        archive: checkpoints[n - 1].endArchiveRoot,
+        attestationsHash: Buffer32.ZERO,
+        payloadDigest: Buffer32.ZERO,
+        headerHash: Buffer32.ZERO,
+        blobCommitmentsHash: Buffer32.ZERO,
+        outHash: '0x',
+        slotNumber: SlotNumber(0),
+        feeHeader: { excessMana: 0n, manaUsed: 0n, ethPerFeeAsset: 0n, congestionCost: 0n, proverCost: 0n },
+      }),
+    );
+
+    const ourPublicInputs = RootRollupPublicInputs.random();
+    ourPublicInputs.previousArchiveRoot = checkpoints[fromCheckpoint - 2].endArchiveRoot;
+    ourPublicInputs.endArchiveRoot = checkpoints[toCheckpoint - 1].endArchiveRoot;
+    rollup.getEpochProofPublicInputs.mockResolvedValue([...ourPublicInputs.toFields()]);
+
+    jest.spyOn(l1Utils, 'getSenderAddress').mockReturnValue(EthAddress.random());
+    jest.spyOn(l1Utils, 'estimateGas').mockResolvedValue(500_000n);
+    jest
+      .spyOn(l1Utils, 'getGasPrice')
+      .mockResolvedValue({ maxFeePerGas: 20_000_000_000n, maxPriorityFeePerGas: 1_000_000_000n });
+    (l1Utils as any).client = {
+      getBlock: jest
+        .fn<() => Promise<{ baseFeePerGas: bigint }>>()
+        .mockResolvedValue({ baseFeePerGas: 10_000_000_000n }),
+    };
+
+    const batchedBlob = new BatchedBlob(
+      ourPublicInputs.blobPublicInputs.blobCommitmentsHash,
+      ourPublicInputs.blobPublicInputs.z,
+      ourPublicInputs.blobPublicInputs.y,
+      ourPublicInputs.blobPublicInputs.c,
+      ourPublicInputs.blobPublicInputs.c.negate(),
+    );
+
+    await publisher.analyzeEpochProofSubmission({
+      epochNumber: EpochNumber(2),
+      fromCheckpoint: CheckpointNumber(fromCheckpoint),
+      toCheckpoint: CheckpointNumber(toCheckpoint),
+      publicInputs: ourPublicInputs,
+      proof: Proof.empty(),
+      batchedBlobInputs: batchedBlob,
+      attestations: [],
+    });
+
+    expect(l1Utils.estimateGas).toHaveBeenCalled();
+    expect(l1Utils.getGasPrice).toHaveBeenCalled();
+    expect(l1Utils.sendAndMonitorTransaction).not.toHaveBeenCalled();
+  });
+
   it('handles reverted txs correctly', async () => {
     const checkpoints = [RootRollupPublicInputs.random(), RootRollupPublicInputs.random()];
 

--- a/yarn-project/prover-node/src/prover-node-publisher.ts
+++ b/yarn-project/prover-node/src/prover-node-publisher.ts
@@ -19,9 +19,9 @@ import type { L1PublishProofStats } from '@aztec/stdlib/stats';
 import { type TelemetryClient, getTelemetryClient } from '@aztec/telemetry-client';
 
 import { inspect } from 'util';
-import { type Hex, type TransactionReceipt, encodeFunctionData } from 'viem';
+import { type Hex, type TransactionReceipt, encodeFunctionData, formatEther, formatGwei } from 'viem';
 
-import { ProverNodePublisherMetrics } from './metrics.js';
+import { type EstimatedSubmitProofStats, ProverNodePublisherMetrics } from './metrics.js';
 
 /** Arguments to the submitEpochProof method of the rollup contract */
 export type L1SubmitEpochProofArgs = {
@@ -208,6 +208,74 @@ export class ProverNodePublisher {
         `Root rollup public inputs mismatch:\nRollup:  ${fmt(rollupPublicInputs)}\nComputed:${fmt(argsPublicInputs)}`,
       );
     }
+  }
+
+  /**
+   * Estimates what submitting the epoch proof would have cost on L1 without actually sending it.
+   * Runs the same validation as `submitEpochProof`, encodes the calldata, estimates gas, and records metrics.
+   * Used when proof publishing is disabled (e.g. PROVER_NODE_DISABLE_PROOF_PUBLISH=true on mainnet).
+   */
+  public async analyzeEpochProofSubmission(args: {
+    epochNumber: EpochNumber;
+    fromCheckpoint: CheckpointNumber;
+    toCheckpoint: CheckpointNumber;
+    publicInputs: RootRollupPublicInputs;
+    proof: Proof;
+    batchedBlobInputs: BatchedBlob;
+    attestations: ViemCommitteeAttestation[];
+  }): Promise<void> {
+    const { epochNumber, fromCheckpoint, toCheckpoint } = args;
+
+    await this.validateEpochProofSubmission(args);
+
+    const data = this.encodeSubmitEpochProofCalldata(args);
+    const senderAddress = this.l1TxUtils.getSenderAddress();
+
+    const [gasLimit, gasPrice, latestBlock] = await Promise.all([
+      this.l1TxUtils.estimateGas(senderAddress.toString() as `0x${string}`, { to: this.rollupContract.address, data }),
+      this.l1TxUtils.getGasPrice(),
+      this.l1TxUtils.client.getBlock({ blockTag: 'latest' }),
+    ]);
+
+    const baseFeePerGas = latestBlock.baseFeePerGas ?? 0n;
+    const { maxPriorityFeePerGas } = gasPrice;
+
+    const effectiveFeePerGas = baseFeePerGas + maxPriorityFeePerGas;
+    const estimatedTotalFee = gasLimit * effectiveFeePerGas;
+
+    const stats: EstimatedSubmitProofStats = {
+      gasLimit,
+      baseFeePerGas,
+      maxPriorityFeePerGas,
+      estimatedTotalFee,
+    };
+
+    this.log.info(`Estimated epoch proof submission cost (not submitted)`, {
+      epochNumber,
+      fromCheckpoint,
+      toCheckpoint,
+      gasLimit: gasLimit.toString(),
+      baseFeePerGas: formatGwei(baseFeePerGas),
+      maxPriorityFeePerGas: formatGwei(maxPriorityFeePerGas),
+      estimatedTotalFeeEth: formatEther(estimatedTotalFee),
+    });
+
+    this.metrics.recordEstimatedSubmitProof(stats);
+  }
+
+  private encodeSubmitEpochProofCalldata(args: {
+    fromCheckpoint: CheckpointNumber;
+    toCheckpoint: CheckpointNumber;
+    publicInputs: RootRollupPublicInputs;
+    proof: Proof;
+    batchedBlobInputs: BatchedBlob;
+    attestations: ViemCommitteeAttestation[];
+  }): Hex {
+    return encodeFunctionData({
+      abi: RollupAbi,
+      functionName: 'submitEpochRootProof',
+      args: [this.getSubmitEpochProofArgs(args)],
+    });
   }
 
   private async sendSubmitEpochProofTx(args: {

--- a/yarn-project/telemetry-client/src/metrics.ts
+++ b/yarn-project/telemetry-client/src/metrics.ts
@@ -717,6 +717,24 @@ export const L1_PUBLISHER_TX_TOTAL_FEE: MetricDefinition = {
   unit: 'eth',
   valueType: ValueType.DOUBLE,
 };
+export const PROVER_NODE_ESTIMATED_SUBMISSION_GAS: MetricDefinition = {
+  name: 'aztec.prover_node.estimated_submission.gas',
+  description: 'Estimated gas for a proof submission tx (proof publishing disabled, not actually sent)',
+  unit: 'gas',
+  valueType: ValueType.INT,
+};
+export const PROVER_NODE_ESTIMATED_SUBMISSION_GAS_PRICE: MetricDefinition = {
+  name: 'aztec.prover_node.estimated_submission.gas_price',
+  description: 'Estimated effective gas price for a proof submission tx (proof publishing disabled, not actually sent)',
+  unit: 'gwei',
+  valueType: ValueType.DOUBLE,
+};
+export const PROVER_NODE_ESTIMATED_SUBMISSION_TOTAL_FEE: MetricDefinition = {
+  name: 'aztec.prover_node.estimated_submission.total_fee',
+  description: 'Estimated total L1 fee for a proof submission tx (proof publishing disabled, not actually sent)',
+  unit: 'eth',
+  valueType: ValueType.DOUBLE,
+};
 
 export const L1_BLOCK_HEIGHT: MetricDefinition = {
   name: 'aztec.l1.block_height',


### PR DESCRIPTION
When `PROVER_NODE_DISABLE_PROOF_PUBLISH=true` (as set on mainnet), the prover node previously finalized the proof and then silently dropped it. This PR changes that path to:

- Run the same on-chain validation as a real submission (`validateEpochProofSubmission`) — catches public-input mismatches early
- Encode the proof submission calldata and call `l1TxUtils.estimateGas` to get an accurate gas limit
- Fetch the current gas price via `l1TxUtils.getGasPrice()` and the latest block's `baseFeePerGas`
- Compute `estimatedTotalFee = gasLimit * (baseFee + priorityFee)` and record it

Three new metrics are emitted under `aztec.prover_node.estimated_submission.*`:
- `gas` — estimated gas limit for the proof submission tx
- `gas_price` — estimated effective gas price (gwei)
- `total_fee` — estimated total fee (ETH)

This gives us visibility into what a mainnet prover would have paid per epoch, enabling profitability analysis against the rewards tracked by `aztec.prover_node.rewards_per_epoch`.

Fixes [A-929](https://linear.app/aztec-labs/issue/A-929/track-proof-submission-fee-estimate-in-fisherman-prover-node)