### PR TITLE
fix(aztec): fail fast when nc is not installed in aztec test

### DIFF
--- a/yarn-project/aztec/scripts/aztec.sh
+++ b/yarn-project/aztec/scripts/aztec.sh
@@ -27,6 +27,10 @@ case $cmd in
     aztec start --txe --port 8081 &
     server_pid=$!
     trap 'kill $server_pid &>/dev/null || true' EXIT
+    if ! command -v nc &>/dev/null; then
+      echo "Error: 'nc' (netcat) is required but not installed." >&2
+      exit 1
+    fi
     while ! nc -z 127.0.0.1 8081 &>/dev/null; do sleep 0.2; done
     export NARGO_FOREIGN_CALL_TIMEOUT=300000
     nargo test --silence-warnings --oracle-resolver http://127.0.0.1:8081 --test-threads 16 "$@"


### PR DESCRIPTION
## Problem

`aztec test` uses `nc -z` to poll for TXE server readiness, but redirects all output to `/dev/null`. When `nc` is not installed, the "command not found" error is swallowed, the loop treats it as "server not ready yet", and sleeps forever with no output.

Both macOS and most Linux distributions ship with `nc` pre-installed, but some bare Docker images (e.g. `ubuntu:24.04`) do not, which is where this surfaces.

## Fix

Adds a `command -v nc` check before the polling loop, failing immediately with a clear error message if netcat is missing.

Fixes F-571