### PR TITLE
feat: giving old rollups pensions

### DIFF
--- a/l1-contracts/src/core/libraries/rollup/RewardLib.sol
+++ b/l1-contracts/src/core/libraries/rollup/RewardLib.sol
@@ -165,14 +165,11 @@ library RewardLib {
           // Cache the reward distributor contract
           IRewardDistributor distributor = rewardStorage.config.rewardDistributor;
 
-          if (address(this) == distributor.canonicalRollup()) {
-            uint256 amountToClaim =
-              Math.min(checkpointRewardsDesired, rollupStore.config.feeAsset.balanceOf(address(distributor)));
+          uint256 amountToClaim = Math.min(checkpointRewardsDesired, distributor.availableTo(address(this)));
 
-            if (amountToClaim > 0) {
-              distributor.claim(address(this), amountToClaim);
-              checkpointRewardsAvailable = amountToClaim;
-            }
+          if (amountToClaim > 0) {
+            distributor.claim(address(this), amountToClaim);
+            checkpointRewardsAvailable = amountToClaim;
           }
         }
 

--- a/l1-contracts/src/governance/RewardDistributor.sol
+++ b/l1-contracts/src/governance/RewardDistributor.sol
@@ -19,19 +19,39 @@ contract RewardDistributor is IRewardDistributor {
   IERC20 public immutable ASSET;
   IRegistry public immutable REGISTRY;
 
+  mapping(address => uint256) public specificOld;
+  uint256 public aggregateDebt;
+
   constructor(IERC20 _asset, IRegistry _registry) {
     ASSET = _asset;
     REGISTRY = _registry;
   }
 
+  function subsidizeOld(address _rollup, uint256 _amount) external {
+    ASSET.safeTransferFrom(msg.sender, address(this), _amount);
+    specificOld[_rollup] += _amount;
+    aggregateDebt += _amount;
+  }
+
+  function availableTo(address _rollup) public view returns (uint256) {
+    return _rollup != canonicalRollup() ? specificOld[_rollup] : ASSET.balanceOf(address(this)) - aggregateDebt;
+  }
+
   function claim(address _to, uint256 _amount) external override(IRewardDistributor) {
-    require(msg.sender == canonicalRollup(), Errors.RewardDistributor__InvalidCaller(msg.sender, canonicalRollup()));
+    require(_amount <= availableTo(msg.sender), Errors.RewardDistributor__InvalidCaller(msg.sender, canonicalRollup()));
+    if (msg.sender != canonicalRollup()) {
+      specificOld[msg.sender] -= _amount;
+      aggregateDebt -= _amount;
+    }
     ASSET.safeTransfer(_to, _amount);
   }
 
   function recover(address _asset, address _to, uint256 _amount) external override(IRewardDistributor) {
     address owner = Ownable(address(REGISTRY)).owner();
     require(msg.sender == owner, Errors.RewardDistributor__InvalidCaller(msg.sender, owner));
+    if (_asset == address(ASSET)) {
+      require(_amount <= availableTo(canonicalRollup()), "Amount exceeds canonical subsidy");
+    }
     IERC20(_asset).safeTransfer(_to, _amount);
   }
 

--- a/l1-contracts/src/governance/interfaces/IRewardDistributor.sol
+++ b/l1-contracts/src/governance/interfaces/IRewardDistributor.sol
@@ -5,4 +5,6 @@ interface IRewardDistributor {
   function claim(address _to, uint256 _amount) external;
   function recover(address _asset, address _to, uint256 _amount) external;
   function canonicalRollup() external view returns (address);
+  function availableTo(address _rollup) external view returns (uint256);
+  function subsidizeOld(address _rollup, uint256 _amount) external;
 }

--- a/l1-contracts/test/Rollup.t.sol
+++ b/l1-contracts/test/Rollup.t.sol
@@ -40,6 +40,15 @@ import {RollupBuilder} from "./builder/RollupBuilder.sol";
 import {Ownable} from "@oz/access/Ownable.sol";
 import {AttestationLib, CommitteeAttestations} from "@aztec/core/libraries/rollup/AttestationLib.sol";
 import {AttestationLibHelper} from "@test/helper_libraries/AttestationLibHelper.sol";
+import {IHaveVersion} from "@aztec/governance/interfaces/IRegistry.sol";
+
+// Minimal IHaveVersion implementation used to register a fresh canonical rollup so
+// that the rollup under test becomes "old" (non-canonical).
+contract SecondRollup {
+  function getVersion() external view returns (uint256) {
+    return uint256(keccak256(abi.encodePacked(bytes("aztec_rollup_v2"), block.chainid, address(this))));
+  }
+}
 
 // solhint-disable comprehensive-interface
 
@@ -550,6 +559,68 @@ contract RollupTest is RollupBase {
 
     assertEq(rollup.getPendingCheckpointNumber(), 1, "Invalid pending checkpoint number");
     assertEq(rollup.getProvenCheckpointNumber(), _toProve ? 1 : 0, "Invalid proven checkpoint number");
+  }
+
+  // Demonstrates that an old (non-canonical) rollup can be subsidized via
+  // RewardDistributor.subsidizeOld and still receive checkpoint rewards when it proves an epoch.
+  function testOldRollupReceivesSubsidyAndRewards() public setUpFor("mixed_checkpoint_1") {
+    // Sanity: `rollup` is currently the canonical rollup.
+    assertEq(address(registry.getCanonicalRollup()), address(rollup), "rollup should be canonical at setup");
+    uint256 checkpointReward = rollup.getCheckpointReward();
+    assertGt(checkpointReward, 0, "checkpoint reward should be non-zero for this test to be meaningful");
+
+    // Promote a new canonical rollup; the original one becomes "old".
+    IHaveVersion newCanonical = IHaveVersion(address(new SecondRollup()));
+    registry.addRollup(newCanonical);
+    assertEq(address(registry.getCanonicalRollup()), address(newCanonical), "new canonical not registered");
+    assertTrue(address(rollup) != address(newCanonical), "rollup is still canonical");
+
+    // Before subsidizing, the old rollup has no claim on the distributor.
+    assertEq(rewardDistributor.availableTo(address(rollup)), 0, "old rollup should start with 0 availableTo");
+
+    // Snapshot the canonical's availableTo for later comparison: subsidizing the old rollup
+    // must not reduce what is available to the new canonical (aggregateDebt isolates it).
+    uint256 canonicalAvailableBefore = rewardDistributor.availableTo(address(newCanonical));
+
+    // Subsidize the old rollup with enough to cover one full checkpoint reward + extra headroom.
+    uint256 subsidy = checkpointReward * 2;
+    deal(address(testERC20), address(this), subsidy);
+    testERC20.approve(address(rewardDistributor), subsidy);
+    rewardDistributor.subsidizeOld(address(rollup), subsidy);
+
+    assertEq(rewardDistributor.availableTo(address(rollup)), subsidy, "subsidy not credited to old rollup");
+    assertEq(
+      rewardDistributor.availableTo(address(newCanonical)),
+      canonicalAvailableBefore,
+      "canonical availability should be unaffected by old-rollup subsidy"
+    );
+
+    // `_proveCheckpoints` hardcodes the sequencer coinbase as bytes20("sequencer") in its
+    // fees array, so that is the address credited with the sequencer share.
+    address sequencerCoinbase = address(bytes20("sequencer"));
+    uint256 sequencerRewardsBefore = rollup.getSequencerRewards(sequencerCoinbase);
+
+    // Run a normal propose + prove on the old rollup. handleRewardsAndFees will call
+    // distributor.availableTo(old rollup) and distributor.claim(...) against the subsidy.
+    _proposeCheckpoint("mixed_checkpoint_1", 1);
+    _proveCheckpoints("mixed_checkpoint_", 1, 1, address(0x1234));
+
+    // The old rollup's subsidy should have been drawn down by exactly one checkpoint reward.
+    assertEq(
+      rewardDistributor.availableTo(address(rollup)),
+      subsidy - checkpointReward,
+      "subsidy not drawn by checkpoint reward"
+    );
+
+    // Rewards must have actually landed in the old rollup's reward accounting.
+    Epoch epoch = rollup.getCheckpoint(1).slotNumber.epochFromSlot();
+    uint256 sequencerRewardsGained = rollup.getSequencerRewards(sequencerCoinbase) - sequencerRewardsBefore;
+    uint256 proverRewardsGained = rollup.getCollectiveProverRewardsForEpoch(epoch);
+    assertGe(
+      sequencerRewardsGained + proverRewardsGained,
+      checkpointReward,
+      "old rollup did not accrue at least checkpointReward across sequencer + prover"
+    );
   }
 
   function testConsecutiveMixedCheckpoints(uint256 _checkpointsToProve) public setUpFor("mixed_checkpoint_1") {

--- a/l1-contracts/test/benchmark/happy.t.sol
+++ b/l1-contracts/test/benchmark/happy.t.sol
@@ -95,6 +95,12 @@ contract FakeCanonical is IRewardDistributor {
   function updateRegistry(IRegistry _registry) external {}
 
   function recover(address _asset, address _to, uint256 _amount) external {}
+
+  function subsidizeOld(address, uint256) external {}
+
+  function availableTo(address) external pure returns (uint256) {
+    return type(uint256).max;
+  }
 }
 
 contract BenchmarkRollupTest is FeeModelTestPoints, DecoderBase {

--- a/l1-contracts/test/compression/PreHeating.t.sol
+++ b/l1-contracts/test/compression/PreHeating.t.sol
@@ -92,6 +92,12 @@ contract FakeCanonical is IRewardDistributor {
   function updateRegistry(IRegistry _registry) external {}
 
   function recover(address _asset, address _to, uint256 _amount) external {}
+
+  function availableTo(address) external view returns (uint256) {
+    return type(uint256).max;
+  }
+
+  function subsidizeOld(address _rollup, uint256 _amount) external {}
 }
 
 /**

--- a/l1-contracts/test/rollup/libraries/rewardlib/RewardLibWrapper.sol
+++ b/l1-contracts/test/rollup/libraries/rewardlib/RewardLibWrapper.sol
@@ -45,6 +45,10 @@ contract FakeRewardDistributor {
     feeAsset.transfer(_to, _amount);
   }
 
+  function availableTo(address _rollup) external view returns (uint256) {
+    return _rollup == canonicalRollup ? feeAsset.balanceOf(address(this)) : 0;
+  }
+
   function nuke() external {
     canonicalRollup = address(0);
   }


### PR DESCRIPTION
There was discussions around giving pensions to old out of date rollups, so here is a speedrun showcase of it. 

Requires minimal changes to the rollup (without those it won't get the pension as no longer canonical skips).

