### PR TITLE
fix(aztec-up): Do not leak node_modules/.bin into the PATH

### DIFF
--- a/aztec-up/bin/0.0.1/aztec-install
+++ b/aztec-up/bin/0.0.1/aztec-install
@@ -186,7 +186,7 @@ function update_path_env_var {
   # We need:
   # - $AZTEC_HOME/current/bin for version-specific tools (nargo, aztec, bb, ...)
   # - $AZTEC_HOME/bin for shared tools like aztec-up
-  # node_modules/.bin is intentionally NOT added: the per-version installer
+  # - $AZTEC_HOME/current/node_modules/.bin is intentionally NOT added: the per-version installer
   # symlinks the @aztec-owned bins into current/bin, so adding node_modules/.bin
   # would only expose transitive npm deps (jest, tsc, ...) and shadow user tools.
   local path_line="export PATH=\"\$HOME/.aztec/current/bin:\$HOME/.aztec/bin:\$PATH\""

--- a/aztec-up/bin/0.0.1/aztec-install
+++ b/aztec-up/bin/0.0.1/aztec-install
@@ -183,10 +183,13 @@ function install_aztec_up {
 
 # Updates appropriate shell script to ensure the paths are in PATH.
 function update_path_env_var {
-  # We need both:
-  # - $AZTEC_HOME/current/bin and $AZTEC_HOME/current/node_modules/.bin for version-specific tools
+  # We need:
+  # - $AZTEC_HOME/current/bin for version-specific tools (nargo, aztec, bb, ...)
   # - $AZTEC_HOME/bin for shared tools like aztec-up
-  local path_line="export PATH=\"\$HOME/.aztec/current/bin:\$HOME/.aztec/current/node_modules/.bin:\$HOME/.aztec/bin:\$PATH\""
+  # node_modules/.bin is intentionally NOT added: the per-version installer
+  # symlinks the @aztec-owned bins into current/bin, so adding node_modules/.bin
+  # would only expose transitive npm deps (jest, tsc, ...) and shadow user tools.
+  local path_line="export PATH=\"\$HOME/.aztec/current/bin:\$HOME/.aztec/bin:\$PATH\""
 
   # Determine the user's shell.
   local shell_profile=""

--- a/aztec-up/bin/0.0.1/aztec-up
+++ b/aztec-up/bin/0.0.1/aztec-up
@@ -549,8 +549,10 @@ function cmd_env {
 
   local version_dir="$AZTEC_HOME/versions/$resolved_version"
 
-  # Output PATH export with relevant bin directories
-  echo "export PATH=\"$version_dir/bin:$version_dir/node_modules/.bin:\$PATH\""
+  # Output PATH export with relevant bin directories.
+  # node_modules/.bin is intentionally excluded -- the per-version installer
+  # symlinks @aztec-owned bins into bin/, keeping transitive npm deps off PATH.
+  echo "export PATH=\"$version_dir/bin:\$PATH\""
 }
 
 # Main entry point

--- a/aztec-up/bin/0.0.1/install
+++ b/aztec-up/bin/0.0.1/install
@@ -197,6 +197,25 @@ function install_aztec_packages {
   npm install @aztec/aztec@$VERSION @aztec/cli-wallet@$VERSION @aztec/bb.js@$VERSION --prefix "$version_path"
 }
 
+function symlink_aztec_bins {
+  set -euo pipefail
+  # Populate version_bin_path with symlinks to @aztec-owned bins only. Adding
+  # node_modules/.bin wholesale to PATH would shadow user-installed tools
+  # (jest, tsc, semver, ...) with Aztec's transitive dependencies.
+  local npm_bin_dir="$version_path/node_modules/.bin"
+  [ -d "$npm_bin_dir" ] || return 0
+
+  local bin_link bin_name target
+  for bin_link in "$npm_bin_dir"/*; do
+    [ -L "$bin_link" ] || continue
+    target=$(readlink "$bin_link")
+    # npm writes relative symlinks like ../@aztec/aztec/... for scoped packages.
+    [[ "$target" == ../@aztec/* ]] || continue
+    bin_name=$(basename "$bin_link")
+    ln -sfn "../node_modules/.bin/$bin_name" "$version_bin_path/$bin_name"
+  done
+}
+
 function main {
   # Create version directory
   mkdir -p "$version_bin_path"
@@ -228,6 +247,9 @@ function main {
   echo -n "Installing aztec packages... "
   dump_fail retry install_aztec_packages
   echo_green "done."
+
+  # Expose only @aztec-owned bins on PATH (drops transitive npm deps).
+  symlink_aztec_bins
 }
 
 main "$@"

--- a/aztec-up/bin/0.0.1/install
+++ b/aztec-up/bin/0.0.1/install
@@ -212,6 +212,10 @@ function symlink_aztec_bins {
     # npm writes relative symlinks like ../@aztec/aztec/... for scoped packages.
     [[ "$target" == ../@aztec/* ]] || continue
     bin_name=$(basename "$bin_link")
+    if [ -e "$version_bin_path/$bin_name" ] && [ ! -L "$version_bin_path/$bin_name" ]; then
+      echo_yellow "refusing to overwrite non-symlink $bin_name; @aztec package bin collides with a hand-installed toolchain binary" >&2
+      exit 1
+    fi
     ln -sfn "../node_modules/.bin/$bin_name" "$version_bin_path/$bin_name"
   done
 }
@@ -249,7 +253,9 @@ function main {
   echo_green "done."
 
   # Expose only @aztec-owned bins on PATH (drops transitive npm deps).
-  symlink_aztec_bins
+  echo -n "Making aztec commands available... "
+  dump_fail retry symlink_aztec_bins
+  echo_green "done."
 }
 
 main "$@"

--- a/docs/docs-developers/docs/resources/migration_notes.md
+++ b/docs/docs-developers/docs/resources/migration_notes.md
@@ -16,7 +16,7 @@ The `aztec-up` installer used to add `$HOME/.aztec/current/node_modules/.bin` to
 If you had an Aztec version installed before this release, your shell profile (`~/.bashrc` or `~/.zshrc`) still contains the old `PATH` line. Re-run the installer once (replacing `[VERSION]` with whichever toolchain version you're on, e.g. `4.2.0`) to replace it:
 
 ```bash
-VERSION=[VERSION] bash -i <(curl -sL https://install.aztec.network/[VERSION])
+VERSION=[VERSION] bash -i <(curl -sL https://install.aztec.network)
 ```
 
 Open a fresh shell and confirm the leak is gone:

--- a/docs/docs-developers/docs/resources/migration_notes.md
+++ b/docs/docs-developers/docs/resources/migration_notes.md
@@ -9,6 +9,24 @@ Aztec is in active development. Each version may introduce breaking changes that
 
 ## TBD
 
+### [CLI] `aztec-up` no longer exposes transitive npm bins on PATH
+
+The `aztec-up` installer used to add `$HOME/.aztec/current/node_modules/.bin` to your shell `PATH`, which put ~40 transitive npm bins (`jest`, `tsc`, `tsserver`, `semver`, `uuid`, `json5`, ...) onto your interactive shell and silently shadowed your own installed versions of those tools. Only the seven `@aztec/*`-owned bins (`aztec`, `aztec-wallet`, `bb`, `bb-cli`, `blob-client`, `noir-codegen`, `txe`) are now exposed.
+
+If you had an Aztec version installed before this release, your shell profile (`~/.bashrc` or `~/.zshrc`) still contains the old `PATH` line. Re-run the installer once (replacing `[VERSION]` with whichever toolchain version you're on, e.g. `4.2.0`) to replace it:
+
+```bash
+VERSION=[VERSION] bash -i <(curl -sL https://install.aztec.network/[VERSION])
+```
+
+Open a fresh shell and confirm the leak is gone:
+
+```bash
+echo $PATH
+```
+
+`$HOME/.aztec/current/node_modules/.bin` should no longer appear in the output. You'll also see your own `jest`, `tsc`, etc. again instead of the ones bundled with the Aztec toolchain.
+
 ### [Protocol] Domain separators introduced for merkle-node, block-headers, and blob hashes
 
 Several protocol hashes that previously used bare `poseidon2_hash` are now domain-separated via `poseidon2_hash_with_separator`. This is a security hardening change — it prevents a value produced by one hash context from being reinterpreted in another (e.g. a sibling path from one tree being transported to another).


### PR DESCRIPTION
## Summary

The `aztec-up` installer adds `$HOME/.aztec/current/node_modules/.bin` to the user's shell PATH. That directory contains the bin entries of every transitive npm dependency of the Aztec packages, so ~40 third-party bins (`jest`, `tsc`, `tsserver`, `semver`, `uuid`, `json5`, `pino`, `mime`, `rlp`, ...) end up on PATH, silently shadowing user-installed versions.

This PR exposes only the 7 intended `@aztec/*`-owned bins and drops `node_modules/.bin` from the PATH line.

## Why

Two problems with the current setup:

1. **DX / correctness.** A developer with `jest@29` pinned locally silently runs Aztec's bundled `jest@30` when typing `jest`, producing confusing errors (e.g. the renamed `--testPathPattern` flag). Same trap for `tsc`, `semver`, etc. The user has no way to enumerate what's been shadowed without reading the dep tree.
2. **Invocation surface.** Install-time trust is unchanged — every package in the graph already runs code via `postinstall` or when Aztec uses it — but putting transitive bins on PATH adds a new invocation vector: a compromised transitive bin can fire on normal dev activity (`jest`, `tsc`) rather than only when Aztec calls it. Notably, that bypasses `--ignore-scripts`-style defenses and is stealthier than a postinstall payload. Standard package managers (`npm install -g`, `pipx`, `brew`, `cargo install`) do not expose transitive bins on PATH; they symlink only the package's declared entry points.

Context: https://gist.github.com/AztecBot/fc2f40d50592c468429f922921a271f2 and https://www.notion.so/aztecnetwork/Getting-Started-Token-Tutorial-Walk-Through-348a1f6b0e35806a884edc16742866b9

## Changes

- `aztec-up/bin/0.0.1/install` — new `symlink_aztec_bins` function, called after `install_aztec_packages`. Iterates `node_modules/.bin/*`, keeps only symlinks whose target starts with `../@aztec/`, and re-links them into `$version_path/bin/` using relative paths (`../node_modules/.bin/<name>`). No hard-coded list: the set of exposed bins follows whatever `@aztec/*` packages declare.
- `aztec-up/bin/0.0.1/aztec-install` — drops `$HOME/.aztec/current/node_modules/.bin` from the shell-profile PATH export.
- `aztec-up/bin/0.0.1/aztec-up` — drops `node_modules/.bin` from `aztec-up env` output so per-project `.aztecrc` switching also skips the leak.

Each version's `bin/` stays self-contained, so `aztec-up use <ver>` flips the entire bin set atomically via the `current` symlink — same mechanism as today.

## Verification

Ran the new `symlink_aztec_bins` function against an existing `~/.aztec/current` install, mirrored into a throwaway `AZTEC_HOME`:

```
=== Bins exposed in version bin/ ===
aztec aztec-wallet bb bb-cli blob-client noir-codegen txe

=== Symlink resolution ===
aztec         -> .../node_modules/@aztec/aztec/scripts/aztec.sh
aztec-wallet  -> .../node_modules/@aztec/cli-wallet/dest/bin/index.js
bb            -> .../node_modules/@aztec/bb.js/dest/node/bin/index.js
bb-cli        -> .../node_modules/@aztec/bb-prover/dest/bb/index.js
blob-client   -> .../node_modules/@aztec/blob-client/dest/client/bin/index.js
noir-codegen  -> .../node_modules/@aztec/noir-noir_codegen/lib/main.js
txe           -> .../node_modules/@aztec/txe/dest/bin/index.js

=== Transitive bins absent from version bin/ ===
jest tsc tsserver semver uuid json5 pino pino-pretty mime rlp  (all absent)

=== Exec through the chain ===
PATH=$THROWAWAY_BIN:... aztec-wallet --help  →  prints help OK
```

7 bins exposed vs. 40 before; all resolve; end-to-end execution works.

## Confirmed non-regressions

Audited Aztec production CLI code for bare-name shell-outs that could rely on transitive bins being on PATH:

- `yarn-project/aztec/scripts/aztec.sh` — shells out to `anvil`, `nargo`, `nc`, and itself. `anvil`/`nargo` live in `current/bin/` (installed by `aztec-install`), `nc` is system. Unaffected.
- `yarn-project/aztec/src/cli/cmds/compile.ts` / `profile_gates.ts` — resolve `bb` via `findBbBinary()` (absolute path from `@aztec/bb.js`), fall back to bare `'bb'` which remains reachable as a new symlink in `current/bin/`.
- `yarn-project/cli/src/cmds/misc/update/npm.ts` — intentionally invokes user's system `npm`/`pnpm`/`yarn`. Unaffected.

No other bare-name invocations of transitive bins.

## Migration

Fresh installs and `aztec-up install <ver>` pick up the fix automatically. Existing users still have the old `export PATH=…:current/node_modules/.bin:…` line in their shell profile; that gets rewritten the next time they run `aztec-install` (the existing dedup at `aztec-install:210` strips old entries). Worth flagging in release notes.