### PR TITLE
fix(ci): rerun squashed PR check on base branch change

### DIFF
--- a/.github/workflows/squashed-pr-check.yml
+++ b/.github/workflows/squashed-pr-check.yml
@@ -2,7 +2,7 @@ name: Squashed PR Check
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, labeled, unlabeled]
+    types: [opened, synchronize, reopened, labeled, unlabeled, edited]
   merge_group:
 
 jobs:


### PR DESCRIPTION
## Motivation

When a PR fails the Squashed PR Check against `next` and the author then changes the base branch to a merge-train (where the check does not apply), the stale failure remained on the PR. This blocked the PR from merging cleanly without manual intervention.

## Approach

Add `edited` to the `pull_request` trigger types. GitHub fires `edited` whenever the base branch (or title/body) changes, so the workflow reruns, the job's `if` guard evaluates false, and the skipped run supersedes the earlier failure status.

## Changes

- **.github/workflows/squashed-pr-check.yml**: include `edited` in the `pull_request` event types so base branch changes retrigger the workflow