### PR TITLE
fix(e2e): wait for first checkpoint in fee_asset_price_oracle_gossip test

### DIFF
--- a/yarn-project/end-to-end/src/e2e_p2p/fee_asset_price_oracle_gossip.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/fee_asset_price_oracle_gossip.test.ts
@@ -168,10 +168,23 @@ describe('e2e_p2p_network', () => {
     const initialOnChainPrice = await rollup.getEthPerFeeAsset();
     t.logger.info(`Initial on-chain price: ${initialOnChainPrice}, target oracle price: ${targetOraclePrice}`);
 
-    // Gather signers from attestations downloaded from L1
-    const blockNumber = await nodes[0].getBlockNumber();
+    // Gather signers from attestations downloaded from L1. setupAccount() no longer sends a tx,
+    // so when the test reaches here no checkpoint may have been published yet; wait for the
+    // archiver to index the first published checkpoint before reading attestations.
     const dataStore = (nodes[0] as AztecNodeService).getBlockSource() as Archiver;
-    const [publishedCheckpoint] = await dataStore.getCheckpoints(CheckpointNumber.fromBlockNumber(blockNumber), 1);
+    t.logger.warn('Waiting for first checkpoint to be published and indexed by the archiver');
+    const publishedCheckpoint = await retryUntil(
+      async () => {
+        const blockNumbers = await Promise.all(nodes.map(node => node.getBlockNumber()));
+        const checkpointNumber = (await t.monitor.run()).checkpointNumber;
+        t.logger.info(`Current block numbers ${blockNumbers} (checkpoint number on L1 is ${checkpointNumber})`);
+        const [checkpoint] = await dataStore.getCheckpoints(CheckpointNumber(1), 1);
+        return checkpoint;
+      },
+      'published checkpoint to be indexed',
+      120,
+      1,
+    );
     const payload = ConsensusPayload.fromCheckpoint(publishedCheckpoint.checkpoint);
     const attestations = publishedCheckpoint.attestations
       .filter(a => !a.signature.isEmpty())


### PR DESCRIPTION
## Summary

- `e2e_p2p/fee_asset_price_oracle_gossip.test.ts` was failing with `TypeError: Cannot read properties of undefined (reading 'checkpoint')`.
- Root cause: `setupAccount()` no longer sends an L2 tx (it just registers a hardcoded account in PXE), so `targetBlock = aztecNode.getBlockNumber()` is `0` and the existing `retryUntil` is trivially satisfied. The test then queries `dataStore.getCheckpoints(...)` before any checkpoint has been published/indexed, gets `[]` back, and crashes on destructure.
- Fix: wrap the `getCheckpoints` call in a `retryUntil` (120s timeout, ample for a ~48s checkpoint cadence at `slotDuration=24` × 2 blocks) that waits until the archiver has indexed the first published checkpoint. Query `CheckpointNumber(0)` directly — `fromBlockNumber` is deprecated and any published checkpoint is sufficient to validate the attestation signers.

Failure: https://ci.aztec-labs.com/logs/acab993c3a6c25c5

## Test plan

- [ ] CI run of `e2e_p2p/fee_asset_price_oracle_gossip.test.ts` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)