### PR TITLE
chore(avm)!: remove hack for bb pilcom to see shifted temp columns

### DIFF
--- a/barretenberg/cpp/pil/vm2/scalar_mul.pil
+++ b/barretenberg/cpp/pil/vm2/scalar_mul.pil
@@ -168,11 +168,6 @@ namespace scalar_mul;
     end * (temp_y - point_y) = 0;
     end * (temp_inf - point_inf) = 0;
 
-    // TODO(#AVM-212) Hack for bb-pilcom to see shifted temp columns
-    temp_x' - temp_x' = 0;
-    temp_y' - temp_y' = 0;
-    temp_inf' - temp_inf' = 0;
-
     #[DOUBLE]
     sel_not_end { temp_x, temp_y, temp_inf, temp_x', temp_y', temp_inf', sel_not_end /* = 1 */ }
     in

--- a/barretenberg/cpp/src/barretenberg/vm2/generated/relations/scalar_mul.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/generated/relations/scalar_mul.hpp
@@ -14,8 +14,8 @@ template <typename FF_> class scalar_mulImpl {
   public:
     using FF = FF_;
 
-    static constexpr std::array<size_t, 29> SUBRELATION_PARTIAL_LENGTHS = { 3, 3, 3, 3, 3, 3, 3, 2, 3, 3, 3, 3, 3, 3, 3,
-                                                                            3, 3, 3, 3, 2, 2, 2, 4, 4, 4, 3, 4, 4, 4 };
+    static constexpr std::array<size_t, 26> SUBRELATION_PARTIAL_LENGTHS = { 3, 3, 3, 3, 3, 3, 3, 2, 3, 3, 3, 3, 3,
+                                                                            3, 3, 3, 3, 3, 3, 4, 4, 4, 3, 4, 4, 4 };
 
     template <typename AllEntities> inline static bool skip(const AllEntities& in)
     {

--- a/barretenberg/cpp/src/barretenberg/vm2/generated/relations/scalar_mul_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/generated/relations/scalar_mul_impl.hpp
@@ -140,71 +140,53 @@ void scalar_mulImpl<FF_>::accumulate(ContainerOverSubrelations& evals,
     }
     {
         using View = typename std::tuple_element_t<19, ContainerOverSubrelations>::View;
-        auto tmp = (static_cast<View>(in.get(C::scalar_mul_temp_x_shift)) -
-                    static_cast<View>(in.get(C::scalar_mul_temp_x_shift)));
-        std::get<19>(evals) += (tmp * scaling_factor);
-    }
-    {
-        using View = typename std::tuple_element_t<20, ContainerOverSubrelations>::View;
-        auto tmp = (static_cast<View>(in.get(C::scalar_mul_temp_y_shift)) -
-                    static_cast<View>(in.get(C::scalar_mul_temp_y_shift)));
-        std::get<20>(evals) += (tmp * scaling_factor);
-    }
-    {
-        using View = typename std::tuple_element_t<21, ContainerOverSubrelations>::View;
-        auto tmp = (static_cast<View>(in.get(C::scalar_mul_temp_inf_shift)) -
-                    static_cast<View>(in.get(C::scalar_mul_temp_inf_shift)));
-        std::get<21>(evals) += (tmp * scaling_factor);
-    }
-    {
-        using View = typename std::tuple_element_t<22, ContainerOverSubrelations>::View;
         auto tmp = static_cast<View>(in.get(C::scalar_mul_end)) *
                    ((static_cast<View>(in.get(C::scalar_mul_point_x)) * static_cast<View>(in.get(C::scalar_mul_bit)) +
                      CView(ecc_INFINITY_X) * (FF(1) - static_cast<View>(in.get(C::scalar_mul_bit)))) -
                     static_cast<View>(in.get(C::scalar_mul_res_x)));
-        std::get<22>(evals) += (tmp * scaling_factor);
+        std::get<19>(evals) += (tmp * scaling_factor);
     }
     {
-        using View = typename std::tuple_element_t<23, ContainerOverSubrelations>::View;
+        using View = typename std::tuple_element_t<20, ContainerOverSubrelations>::View;
         auto tmp = static_cast<View>(in.get(C::scalar_mul_end)) *
                    ((static_cast<View>(in.get(C::scalar_mul_point_y)) * static_cast<View>(in.get(C::scalar_mul_bit)) +
                      CView(ecc_INFINITY_Y) * (FF(1) - static_cast<View>(in.get(C::scalar_mul_bit)))) -
                     static_cast<View>(in.get(C::scalar_mul_res_y)));
-        std::get<23>(evals) += (tmp * scaling_factor);
+        std::get<20>(evals) += (tmp * scaling_factor);
     }
     {
-        using View = typename std::tuple_element_t<24, ContainerOverSubrelations>::View;
+        using View = typename std::tuple_element_t<21, ContainerOverSubrelations>::View;
         auto tmp = static_cast<View>(in.get(C::scalar_mul_end)) *
                    (((static_cast<View>(in.get(C::scalar_mul_point_inf)) - FF(1)) *
                          static_cast<View>(in.get(C::scalar_mul_bit)) +
                      FF(1)) -
                     static_cast<View>(in.get(C::scalar_mul_res_inf)));
+        std::get<21>(evals) += (tmp * scaling_factor);
+    }
+    {
+        using View = typename std::tuple_element_t<22, ContainerOverSubrelations>::View;
+        auto tmp =
+            (static_cast<View>(in.get(C::scalar_mul_should_add)) -
+             static_cast<View>(in.get(C::scalar_mul_sel_not_end)) * static_cast<View>(in.get(C::scalar_mul_bit)));
+        std::get<22>(evals) += (tmp * scaling_factor);
+    }
+    {
+        using View = typename std::tuple_element_t<23, ContainerOverSubrelations>::View;
+        auto tmp = CView(scalar_mul_SHOULD_PASS) * (static_cast<View>(in.get(C::scalar_mul_res_x)) -
+                                                    static_cast<View>(in.get(C::scalar_mul_res_x_shift)));
+        std::get<23>(evals) += (tmp * scaling_factor);
+    }
+    {
+        using View = typename std::tuple_element_t<24, ContainerOverSubrelations>::View;
+        auto tmp = CView(scalar_mul_SHOULD_PASS) * (static_cast<View>(in.get(C::scalar_mul_res_y)) -
+                                                    static_cast<View>(in.get(C::scalar_mul_res_y_shift)));
         std::get<24>(evals) += (tmp * scaling_factor);
     }
     {
         using View = typename std::tuple_element_t<25, ContainerOverSubrelations>::View;
-        auto tmp =
-            (static_cast<View>(in.get(C::scalar_mul_should_add)) -
-             static_cast<View>(in.get(C::scalar_mul_sel_not_end)) * static_cast<View>(in.get(C::scalar_mul_bit)));
-        std::get<25>(evals) += (tmp * scaling_factor);
-    }
-    {
-        using View = typename std::tuple_element_t<26, ContainerOverSubrelations>::View;
-        auto tmp = CView(scalar_mul_SHOULD_PASS) * (static_cast<View>(in.get(C::scalar_mul_res_x)) -
-                                                    static_cast<View>(in.get(C::scalar_mul_res_x_shift)));
-        std::get<26>(evals) += (tmp * scaling_factor);
-    }
-    {
-        using View = typename std::tuple_element_t<27, ContainerOverSubrelations>::View;
-        auto tmp = CView(scalar_mul_SHOULD_PASS) * (static_cast<View>(in.get(C::scalar_mul_res_y)) -
-                                                    static_cast<View>(in.get(C::scalar_mul_res_y_shift)));
-        std::get<27>(evals) += (tmp * scaling_factor);
-    }
-    {
-        using View = typename std::tuple_element_t<28, ContainerOverSubrelations>::View;
         auto tmp = CView(scalar_mul_SHOULD_PASS) * (static_cast<View>(in.get(C::scalar_mul_res_inf)) -
                                                     static_cast<View>(in.get(C::scalar_mul_res_inf_shift)));
-        std::get<28>(evals) += (tmp * scaling_factor);
+        std::get<25>(evals) += (tmp * scaling_factor);
     }
 }
 

--- a/bb-pilcom/bb-pil-backend/src/vm_builder.rs
+++ b/bb-pilcom/bb-pil-backend/src/vm_builder.rs
@@ -157,12 +157,25 @@ fn get_all_col_names<F: FieldElement>(
             .map(|name| sanitize_name(name.as_str()))
             .collect_vec(),
     );
+    // Collect shifted column references from every expression in every identity:
+    // both selectors and tuple expressions on each side. Looking only at
+    // left.selector misses shifts that appear exclusively in lookup/permutation
+    // tuples (e.g. `{ ..., temp_x', temp_y', ... } in ...`).
     let to_be_shifted = sort_cols(
         &get_shifted_polys(
             analyzed
                 .identities_with_inlined_intermediate_polynomials()
                 .iter()
-                .map(|i| i.left.selector.clone().unwrap())
+                .flat_map(|i| {
+                    i.left
+                        .selector
+                        .iter()
+                        .chain(i.left.expressions.iter())
+                        .chain(i.right.selector.iter())
+                        .chain(i.right.expressions.iter())
+                        .cloned()
+                        .collect_vec()
+                })
                 .collect_vec(),
         )
         .iter()


### PR DESCRIPTION
Linear issue [AVM-212](https://linear.app/aztec-labs/issue/AVM-212/remove-hack-for-bb-pilcom-to-see-shifted-temp-columns)