### PR TITLE
refactor(world-state): always index block 0 regardless of initial tree size

### DIFF
--- a/barretenberg/cpp/src/barretenberg/crypto/merkle_tree/node_store/cached_content_addressed_tree_store.hpp
+++ b/barretenberg/cpp/src/barretenberg/crypto/merkle_tree/node_store/cached_content_addressed_tree_store.hpp
@@ -700,9 +700,7 @@ template <typename LeafValueType> void ContentAddressedCachedTreeStore<LeafValue
             // would throw. The payload captures the tree's initial root/size before any blocks have been committed.
             BlockPayload genesisBlock{ .size = meta.initialSize, .blockNumber = 0, .root = meta.initialRoot };
             dataStore_->write_block_data(0, genesisBlock, *tx);
-            if (meta.initialSize > 0) {
-                dataStore_->write_block_index_data(0, meta.initialSize, *tx);
-            }
+            dataStore_->write_block_index_data(0, meta.initialSize, *tx);
 
             tx->commit();
         } catch (std::exception& e) {


### PR DESCRIPTION
## Motivation

Follow-up to #22711 addressing a review flag from PhilWindle: `commit_genesis_state` only wrote a block-index entry for block 0 when `initialSize > 0`. This created a minor asymmetry with the regular commit path, which writes `write_block_index_data` unconditionally for every block (including zero-size blocks).

## Approach

Drop the `if (meta.initialSize > 0)` guard so genesis state is indexed the same way as any other block. The read API (`find_block_for_index`) uses `get_value_or_greater(index + 1)`, so a `sizeAtBlock=0` entry is unreachable and the extra write is harmless — it just restores the invariant that every committed block appears in the index-to-block database.

## Changes

- **barretenberg (cached_content_addressed_tree_store)**: remove the `initialSize > 0` guard around the block-0 `write_block_index_data` call so the genesis commit matches the regular commit path.