### PR TITLE
fix(aztec test): anchor contract log filter to avoid framework spam

### DIFF
--- a/yarn-project/aztec/scripts/aztec.sh
+++ b/yarn-project/aztec/scripts/aztec.sh
@@ -23,7 +23,7 @@ case $cmd in
     # Attempt to compile, no-op if there are no changes
     node --no-warnings "$script_dir/../dest/bin/index.js" compile
 
-    export LOG_LEVEL="${LOG_LEVEL:-"error;trace:contract"}"
+    export LOG_LEVEL="${LOG_LEVEL:-"error;trace:^contract:"}"
     aztec start --txe --port 8081 &
     server_pid=$!
     trap 'kill $server_pid &>/dev/null || true' EXIT


### PR DESCRIPTION
## Summary

The default `LOG_LEVEL` for `aztec test` is `error;trace:contract`, intended to surface `println`/`debug_log` output from Noir user contracts (whose loggers are named `contract:Name(addr)` since #22027).

`getLogLevelFromFilters` in `foundation/src/log/log-filters.ts` matches filters via unanchored `RegExp.test`, so `contract` also matches any framework logger whose name *contains* "contract" as a substring — e.g. `simulator:contract_provider_for_cpp` and `txe:contract_sync`. The result is a flood of trace/debug output during `aztec test` runs.

Example spam seen today with defaults:

```
[13:09:56.527] TRACE: simulator:contract_provider_for_cpp Contract provider callback: getContractClass(0x03bab3b2484869300223c1f3aaf03a923b81f0a0943757d39f7b8d4946a4e80c)
[13:09:56.539] DEBUG: txe:contract_sync Wiping contract sync cache (1 entries)
[13:09:56.546] TRACE: simulator:contract_provider_for_cpp Contract provider callback: getContractInstance(0x230040c121741509d2aa2cefa9d9a31b648dd05932ac9325849a1ef9f0ae850a)
[13:09:56.552] DEBUG: txe:contract_sync Wiping contract sync cache (1 entries)
[13:09:56.555] DEBUG: txe:contract_sync Contract 0x29b3f6ea465629ac3087612a293f6dfd3f31e345b91559b766f658c48b0e2d96 synced
[13:09:56.574] DEBUG: txe:contract_sync Wiping contract sync cache (1 entries)
[13:09:56.611] TRACE: simulator:contract_provider_for_cpp Contract provider callback: getContractInstance(0x230040c121741509d2aa2cefa9d9a31b648dd05932ac9325849a1ef9f0ae850a)
[13:09:56.612] TRACE: simulator:contract_provider_for_cpp Contract provider callback: getContractInstance(0x230040c121741509d2aa2cefa9d9a31b648dd05932ac9325849a1ef9f0ae850a)
[13:09:56.685] DEBUG: txe:contract_sync Syncing contract 0x16aba66a0879d78c12d8fc5a9c911c954756fb36f22af1a88fd113dc819b462d
[13:09:56.702] DEBUG: txe:contract_sync Wiping contract sync cache (0 entries)
[13:09:56.709] DEBUG: txe:contract_sync Wiping contract sync cache (1 entries)
[13:09:56.711] TRACE: simulator:contract_provider_for_cpp Contract provider callback: commitCheckpoint
[13:09:56.729] DEBUG: txe:contract_sync Wiping contract sync cache (0 entries)
[13:09:56.790] TRACE: simulator:contract_provider_for_cpp Contract provider callback: getContractInstance(0x230040c121741509d2aa2cefa9d9a31b648dd05932ac9325849a1ef9f0ae850a)
[13:09:56.796] DEBUG: txe:contract_sync Wiping contract sync cache (1 entries)
[13:09:56.797] TRACE: simulator:contract_provider_for_cpp Contract provider callback: addContracts
[13:09:56.797] TRACE: simulator:contract_provider_for_cpp Calling contractsDB.addContracts
[13:09:56.801] TRACE: simulator:contract_provider_for_cpp Contract provider callback: createCheckpoint
[13:09:56.802] TRACE: simulator:contract_provider_for_cpp Contract provider callback: addContracts
[13:09:56.802] TRACE: simulator:contract_provider_for_cpp Calling contractsDB.addContracts
[13:09:56.805] TRACE: simulator:contract_provider_for_cpp Contract provider callback: getContractInstance(0x21fef0a3b913c62a10a0b22974b921f0245e6a6d030d00e7db46ccce7ed0960e)
[13:09:56.821] DEBUG: txe:contract_sync Syncing contract 0x28aa70094cc85d571719a5f75e6a640ce0b61708ade5749d21262b333f7f1375
[13:09:56.859] DEBUG: txe:contract_sync Wiping contract sync cache (0 entries)
[13:09:56.865] TRACE: simulator:contract_provider_for_cpp Contract provider callback: commitCheckpoint
[13:09:56.870] TRACE: simulator:contract_provider_for_cpp Contract provider callback: getContractClass(0x15f2dc8b74f53c4d416f998a91843cc39e8eb4523893d5868d170ba7e930d703)
[13:09:56.883] TRACE: simulator:contract_provider_for_cpp Contract provider callback: addContracts
[13:09:56.883] TRACE: simulator:contract_provider_for_cpp Calling contractsDB.addContracts
[13:09:56.883] TRACE: simulator:contract_provider_for_cpp Contract provider callback: commitCheckpoint
[13:09:56.886] TRACE: simulator:contract_provider_for_cpp Contract provider callback: createCheckpoint
^C[13:09:56.894] TRACE: simulator:contract_provider_for_cpp Contract provider callback: addContracts
[13:09:56.894] TRACE: simulator:contract_provider_for_cpp Calling contractsDB.addContracts
```

## Fix

Anchor the filter to `^contract:` so it matches only user-contract loggers (named `contract:Name(addr)`) and not framework modules that happen to contain "contract" somewhere in their name.

This is a minimal/local fix. There's an argument that there is an underlying issue: `getLogLevelFromFilters` using unanchored `RegExp.test`.

**If we think that `getLogLevelFromFilters` should be anchored, we can do the following. DO WE WANT THIS?**
```ts
// yarn-project/foundation/src/log/log-filters.ts
-       const regex = new RegExp(filterModule);
+       const regex = new RegExp('^' + filterModule);
```

One-line change that anchors every filter at the start of the module name, matching the semantics of the existing `startsWith` fallback and how callers actually write filters. Users who wrote genuine regex (`foo.*bar`) still work as `^foo.*bar`; substring-match users would need to prepend `.*`.

## Test plan

- Run `aztec test` on a Noir contract test suite and confirm `simulator:contract_provider_for_cpp` and `txe:contract_sync` are silent at the default level.
- Confirm `contract:Name(addr)` user-contract logs still appear at trace level.

🤖 Generated with help from [Claude Code](https://claude.com/claude-code)