### PR TITLE
feat(aztec-nr)!: introduce SenderForTags, remove set_sender_for_tags oracle (F-564)

### DIFF
--- a/boxes/boxes/react/src/contracts/src/main.nr
+++ b/boxes/boxes/react/src/contracts/src/main.nr
@@ -21,14 +21,14 @@ contract BoxReact {
         let new_number = FieldNote { value: number };
 
         self.storage.numbers.at(owner).initialize(new_number).deliver(
-            MessageDelivery.ONCHAIN_CONSTRAINED,
+            MessageDelivery::onchain_constrained(),
         );
     }
 
     #[external("private")]
     fn setNumber(number: Field, owner: AztecAddress) {
         self.storage.numbers.at(owner).replace(|_old| FieldNote { value: number }).deliver(
-            MessageDelivery.ONCHAIN_CONSTRAINED,
+            MessageDelivery::onchain_constrained(),
         );
     }
 

--- a/boxes/boxes/vite/src/contracts/src/main.nr
+++ b/boxes/boxes/vite/src/contracts/src/main.nr
@@ -21,14 +21,14 @@ contract BoxReact {
         let new_number = FieldNote { value: number };
 
         self.storage.numbers.at(owner).initialize(new_number).deliver(
-            MessageDelivery.ONCHAIN_CONSTRAINED,
+            MessageDelivery::onchain_constrained(),
         );
     }
 
     #[external("private")]
     fn setNumber(number: Field, owner: AztecAddress) {
         self.storage.numbers.at(owner).replace(|_old| FieldNote { value: number }).deliver(
-            MessageDelivery.ONCHAIN_CONSTRAINED,
+            MessageDelivery::onchain_constrained(),
         );
     }
 

--- a/docs/examples/contracts/bob_token_contract/src/main.nr
+++ b/docs/examples/contracts/bob_token_contract/src/main.nr
@@ -86,7 +86,7 @@ pub contract BobToken {
         self.enqueue_self._deduct_public_balance(sender, amount);
         // Add to private balance
         self.storage.private_balances.at(sender).add(amount as u128).deliver(
-            MessageDelivery.ONCHAIN_CONSTRAINED,
+            MessageDelivery::onchain_constrained(),
         );
     }
     // docs:end:public_to_private
@@ -107,11 +107,11 @@ pub contract BobToken {
         let sender = self.msg_sender();
         // Spend sender's notes (consumes existing notes)
         self.storage.private_balances.at(sender).sub(amount as u128).deliver(
-            MessageDelivery.ONCHAIN_CONSTRAINED,
+            MessageDelivery::onchain_constrained(),
         );
         // Create new notes for recipient
         self.storage.private_balances.at(to).add(amount as u128).deliver(
-            MessageDelivery.ONCHAIN_CONSTRAINED,
+            MessageDelivery::onchain_constrained(),
         );
     }
     // docs:end:transfer_private
@@ -144,7 +144,7 @@ pub contract BobToken {
 
         // If check passes, mint tokens privately
         self.storage.private_balances.at(employee).add(amount as u128).deliver(
-            MessageDelivery.ONCHAIN_CONSTRAINED,
+            MessageDelivery::onchain_constrained(),
         );
     }
     // docs:end:mint_private
@@ -155,7 +155,7 @@ pub contract BobToken {
         let sender = self.msg_sender();
         // Remove from private balance
         self.storage.private_balances.at(sender).sub(amount as u128).deliver(
-            MessageDelivery.ONCHAIN_CONSTRAINED,
+            MessageDelivery::onchain_constrained(),
         );
         // Enqueue public credit
         self.enqueue_self._credit_public_balance(sender, amount);

--- a/docs/examples/contracts/counter_contract/src/main.nr
+++ b/docs/examples/contracts/counter_contract/src/main.nr
@@ -28,7 +28,7 @@ pub contract Counter {
     // We can name our initializer anything we want as long as it's marked as aztec(initializer)
     fn initialize(headstart: u64, owner: AztecAddress) {
         self.storage.counters.at(owner).add(headstart as u128).deliver(
-            MessageDelivery.ONCHAIN_CONSTRAINED,
+            MessageDelivery::onchain_constrained(),
         );
     }
     // docs:end:constructor
@@ -37,7 +37,7 @@ pub contract Counter {
     #[external("private")]
     fn increment(owner: AztecAddress) {
         debug_log_format("Incrementing counter for owner {0}", [owner.to_field()]);
-        self.storage.counters.at(owner).add(1).deliver(MessageDelivery.ONCHAIN_CONSTRAINED);
+        self.storage.counters.at(owner).add(1).deliver(MessageDelivery::onchain_constrained());
     }
     // docs:end:increment
 

--- a/docs/examples/contracts/nft/src/main.nr
+++ b/docs/examples/contracts/nft/src/main.nr
@@ -57,7 +57,7 @@ pub contract NFTPunk {
 
         // we create an NFT note and insert it to the PrivateSet - a collection of notes meant to be read in private
         let new_nft = NFTNote { token_id };
-        self.storage.owners.at(to).insert(new_nft).deliver(MessageDelivery.ONCHAIN_CONSTRAINED);
+        self.storage.owners.at(to).insert(new_nft).deliver(MessageDelivery::onchain_constrained());
 
         // calling the internal public function above to indicate that the NFT is taken
         self.enqueue_self._mark_nft_exists(token_id, true);

--- a/docs/examples/webapp-tutorial/contracts/src/main.nr
+++ b/docs/examples/webapp-tutorial/contracts/src/main.nr
@@ -95,7 +95,7 @@ pub contract PodRacing {
             .at(game_id)
             .at(player)
             .insert(GameRoundNote::new(track1, track2, track3, track4, track5, round, player))
-            .deliver(MessageDelivery.ONCHAIN_CONSTRAINED);
+            .deliver(MessageDelivery::onchain_constrained());
 
         self.enqueue(PodRacing::at(self.context.this_address()).validate_and_play_round(
             player,

--- a/noir-projects/aztec-nr/aztec/src/contract_self/contract_self_private.nr
+++ b/noir-projects/aztec-nr/aztec/src/contract_self/contract_self_private.nr
@@ -167,8 +167,8 @@ impl<Storage, CallSelf, EnqueueSelf, CallSelfStatic, EnqueueSelfStatic, CallInte
     ///     let from = self.msg_sender();
     ///
     ///     let message: EventMessage = self.emit(Transfer { from, to, amount });
-    ///     message.deliver_to(from, MessageDelivery.OFFCHAIN);
-    ///     message.deliver_to(to, MessageDelivery.ONCHAIN_CONSTRAINED);
+    ///     message.deliver_to(from, MessageDelivery::offchain());
+    ///     message.deliver_to(to, MessageDelivery::onchain_constrained());
     /// }
     /// ```
     ///

--- a/noir-projects/aztec-nr/aztec/src/event/event_message.nr
+++ b/noir-projects/aztec-nr/aztec/src/event/event_message.nr
@@ -1,7 +1,10 @@
 use crate::{
     context::PrivateContext,
     event::{event_emission::NewEvent, event_interface::EventInterface},
-    messages::{logs::event::encode_private_event_message, message_delivery::do_private_message_delivery},
+    messages::{
+        logs::event::encode_private_event_message,
+        message_delivery::{do_private_message_delivery, MessageDelivery},
+    },
 };
 use crate::protocol::{address::AztecAddress, traits::Serialize};
 
@@ -35,9 +38,8 @@ where
     ///
     /// The message is first encrypted to the recipient's public key, ensuring no other actor can read it.
     ///
-    /// The `delivery_mode` must be one of [`crate::messages::message_delivery::MessageDeliveryEnum`], and will inform
-    /// costs (both proving time and TX fees) as well as delivery guarantees. This value must be a compile-time
-    /// constant.
+    /// `delivery_mode` must be constructed via one of the [`MessageDelivery`] named constructors and will inform
+    /// costs (both proving time and TX fees), delivery guarantees.
     ///
     /// # Invalid Recipients
     ///
@@ -45,7 +47,7 @@ where
     /// normal. This prevents both 'king of the hill' attacks (where a sender would otherwise fail to deliver a message
     /// to an invalid recipient) and forced privacy leaks (where an invalid recipient results in a unique transaction
     /// fingerprint, e.g. one lacking the private logs that would correspond to message delivery).
-    pub fn deliver_to(self, recipient: AztecAddress, delivery_mode: u8) {
+    pub fn deliver_to(self, recipient: AztecAddress, delivery_mode: MessageDelivery) {
         // Technical note: we're about to call a closure that needs access to `new_event`, but we can't pass `self` to
         // it because the closure might execute in unconstrained mode, and since `self` contains a mutable reference to
         // `context` this would cause for a mutable reference to cross the constrained-unconstrained barrier, which is

--- a/noir-projects/aztec-nr/aztec/src/messages/logs/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/logs/mod.nr
@@ -2,4 +2,5 @@ pub mod arithmetic_generics_utils;
 pub mod event;
 pub mod note;
 pub mod partial_note;
+pub mod sender_for_tags;
 pub mod utils;

--- a/noir-projects/aztec-nr/aztec/src/messages/logs/sender_for_tags.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/logs/sender_for_tags.nr
@@ -1,0 +1,69 @@
+use crate::oracle::notes::get_sender_for_tags;
+use crate::protocol::{address::AztecAddress, traits::FromField};
+
+/// Selects the sender identity used when deriving a discovery tag for a private log.
+///
+/// Discovery tags are derived from a shared secret between a sender and a recipient, so every log must pick a
+/// sender address. This struct is passed to
+/// [`MessageDelivery`](crate::messages::message_delivery::MessageDelivery) constructors.
+pub struct SenderForTags {
+    variant: u8,
+    explicit_sender: AztecAddress,
+}
+
+global VARIANT_EXPLICIT: u8 = 0;
+global VARIANT_TX_DEFAULT: u8 = 1;
+
+impl SenderForTags {
+    /// Uses `sender` for the discovery tag. E.g. account contracts tag notes with their own address.
+    pub fn explicit(sender: AztecAddress) -> Self {
+        Self { variant: VARIANT_EXPLICIT, explicit_sender: sender }
+    }
+
+    /// Uses the default sender selected by the wallet for this transaction (typically the account that sent
+    /// the tx). The right choice for most application contracts.
+    pub fn tx_default() -> Self {
+        Self { variant: VARIANT_TX_DEFAULT, explicit_sender: AztecAddress::from_field(0) }
+    }
+
+    /// Resolves the sender identity to use for a discovery tag.
+    pub(crate) unconstrained fn resolve(self) -> AztecAddress {
+        if self.variant == VARIANT_EXPLICIT {
+            self.explicit_sender
+        } else {
+            get_sender_for_tags().expect(
+                f"`SenderForTags::tx_default` was used but the wallet did not supply a sender when building the transaction. Either pass `sendMessagesAs` in the wallet options or pick an explicit sender at the emission site.",
+            )
+        }
+    }
+}
+
+mod test {
+    use crate::protocol::{address::AztecAddress, traits::FromField};
+    use super::SenderForTags;
+    use std::test::OracleMock;
+
+    #[test(should_fail_with = "`SenderForTags::tx_default` was used but the wallet did not supply a sender")]
+    unconstrained fn tx_default_with_no_wallet_default_panics() {
+        let _ = OracleMock::mock("aztec_prv_getSenderForTags").returns(Option::<AztecAddress>::none());
+        let _ = SenderForTags::tx_default().resolve();
+    }
+
+    #[test]
+    unconstrained fn tx_default_uses_wallet_supplied_sender() {
+        let sender = AztecAddress::from_field(1);
+        assert_eq(
+            unsafe {
+                let _ = OracleMock::mock("aztec_prv_getSenderForTags").returns(Option::some(sender));
+                SenderForTags::tx_default().resolve()
+            },
+            sender,
+        );
+    }
+
+    #[test]
+    unconstrained fn explicit_uses_provided_sender() {
+        let sender = AztecAddress::from_field(7);
+        assert_eq(SenderForTags::explicit(sender).resolve(), sender);
+    }
+}

--- a/noir-projects/aztec-nr/aztec/src/messages/logs/utils.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/logs/utils.nr
@@ -1,48 +1,39 @@
-use crate::oracle::notes::{get_next_app_tag_as_sender, get_sender_for_tags};
+use crate::messages::logs::sender_for_tags::SenderForTags;
+use crate::oracle::notes::get_next_app_tag_as_sender;
 use crate::protocol::address::AztecAddress;
 
 // TODO(#14565): Add constrained tagging
-/// Returns the next discovery tag for a private log sent to `recipient`.
+/// Returns the next discovery tag for a private log sent to `recipient` using `sender_for_tags` as the sender
+/// identity.
 ///
 /// Private logs are encrypted, so the recipient cannot tell which logs are meant for it just by looking at them.
 /// To solve this, sender and recipient derive a shared secret from their keys, and from that secret they produce a
 /// sequence of one-time tags (tag_0, tag_1, ...). The recipient scans for these tags because it can compute the same
 /// sequence. This function returns the next raw (not domain-separated) tag in the sequence.
-pub(crate) fn compute_discovery_tag(recipient: AztecAddress) -> Field {
+pub(crate) fn compute_discovery_tag(recipient: AztecAddress, sender_for_tags: SenderForTags) -> Field {
     // Safety: we assume that the sender wants for the recipient to find the tagged note, and therefore that they will
     // cooperate and use the correct tag. Usage of a bad tag will result in the recipient not being able to find the
     // note automatically.
     unsafe {
-        let sender = get_sender_for_tags().expect(
-            f"Sender for tags is not set when emitting a private log. Set it by calling `set_sender_for_tags(...)`.",
-        );
+        let sender = sender_for_tags.resolve();
         get_next_app_tag_as_sender(sender, recipient)
     }
 }
 
 mod test {
-    use crate::oracle::notes::set_sender_for_tags;
+    use crate::messages::logs::sender_for_tags::SenderForTags;
     use crate::protocol::{address::AztecAddress, traits::FromField};
     use crate::test::helpers::test_environment::TestEnvironment;
     use super::compute_discovery_tag;
     use std::test::OracleMock;
 
-    #[test(should_fail_with = "Sender for tags is not set")]
-    unconstrained fn no_tag_sender() {
-        let recipient = AztecAddress::from_field(2);
-        let _ = OracleMock::mock("aztec_prv_getSenderForTags").returns(Option::<AztecAddress>::none());
-        let _ = OracleMock::mock("aztec_prv_getNextAppTagAsSender").returns(42);
-        let _ = compute_discovery_tag(recipient);
-    }
-
     #[test]
-    unconstrained fn returns_oracle_tag() {
+    unconstrained fn returns_tag_from_oracle() {
         let sender = AztecAddress::from_field(1);
         let recipient = AztecAddress::from_field(2);
         let expected_tag = 42;
-        let _ = OracleMock::mock("aztec_prv_getSenderForTags").returns(Option::some(sender));
         let _ = OracleMock::mock("aztec_prv_getNextAppTagAsSender").returns(expected_tag);
-        assert_eq(compute_discovery_tag(recipient), expected_tag);
+        assert_eq(compute_discovery_tag(recipient, SenderForTags::explicit(sender)), expected_tag);
     }
 
     #[test]
@@ -52,13 +43,11 @@ mod test {
         let sender = env.create_light_account();
 
         env.private_context(|_context| {
-            set_sender_for_tags(sender);
-
             // The recipient is an invalid address
             let recipient = AztecAddress { inner: 3 };
             assert(!recipient.is_valid());
 
-            let _ = compute_discovery_tag(recipient);
+            let _ = compute_discovery_tag(recipient, SenderForTags::explicit(sender));
         });
     }
 }

--- a/noir-projects/aztec-nr/aztec/src/messages/message_delivery.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/message_delivery.nr
@@ -2,17 +2,31 @@ use crate::{
     context::PrivateContext,
     messages::{
         encryption::{aes128::AES128, message_encryption::MessageEncryption},
-        logs::utils::compute_discovery_tag,
+        logs::{sender_for_tags::SenderForTags, utils::compute_discovery_tag},
         offchain_messages::deliver_offchain_message,
     },
     utils::remove_constraints::remove_constraints_if,
 };
 use crate::protocol::{address::AztecAddress, constants::DOM_SEP__UNCONSTRAINED_MSG_LOG_TAG, hash::compute_log_tag};
 
-/// Placeholder struct until Noir adds `enum` support.
+global VARIANT_OFFCHAIN: u8 = 1;
+global VARIANT_ONCHAIN_UNCONSTRAINED: u8 = 2;
+global VARIANT_ONCHAIN_CONSTRAINED: u8 = 3;
+
+/// Specifies how to deliver a message to a recipient.
 ///
-/// See [`MessageDelivery`] instead.
-pub struct MessageDeliveryEnum {
+/// All messages are delivered encrypted to their recipient's public address key, so no other account will be able to
+/// read their contents. This type configures which **guarantees** exist regarding delivery, and in the on-chain
+/// unconstrained case, which sender identity is used to derive the discovery tag.
+pub struct MessageDelivery {
+    /// The delivery-mode discriminator. Must be a compile-time constant because it drives dead-code elimination in
+    /// [`do_private_message_delivery`].
+    pub(crate) variant: u8,
+    /// The tagging identity used when deriving the discovery tag for on-chain deliveries.
+    pub(crate) sender_for_tags: SenderForTags,
+}
+
+impl MessageDelivery {
     /// Delivers the message fully off-chain, with no guarantees whatsoever.
     ///
     /// ## Use Cases
@@ -59,7 +73,9 @@ pub struct MessageDeliveryEnum {
     /// No information is revelead on-chain about sender, recipient, or the message contents. The message itself
     /// reveals no information about the sender or recipient, and requires knowledge of the recipient's private address
     /// keys in order to obtain the plaintext.
-    pub OFFCHAIN: u8,
+    pub fn offchain() -> Self {
+        Self { variant: VARIANT_OFFCHAIN, sender_for_tags: SenderForTags::tx_default() }
+    }
 
     /// Delivers the message on-chain, but with no guarantees on the content.
     ///
@@ -109,7 +125,21 @@ pub struct MessageDeliveryEnum {
     ///
     /// Identifying that a log corresponds to a message between a given sender and recipient requires, among other
     /// things, knowledge of both of their addresses **and** either the sender's or recipient's private address key.
-    pub ONCHAIN_UNCONSTRAINED: u8,
+    ///
+    /// ## Sender for tags
+    ///
+    /// The discovery tag is derived from the transaction-wide default sender-for-tags (typically the account the
+    /// wallet signed with). Use [`onchain_unconstrained_with_sender`](Self::onchain_unconstrained_with_sender) to
+    /// override.
+    pub fn onchain_unconstrained() -> Self {
+        Self { variant: VARIANT_ONCHAIN_UNCONSTRAINED, sender_for_tags: SenderForTags::tx_default() }
+    }
+
+    /// Same as [`onchain_unconstrained`](Self::onchain_unconstrained), but the discovery tag is derived from the
+    /// supplied [`SenderForTags`] instead of the wallet default.
+    pub fn onchain_unconstrained_with_sender(sender_for_tags: SenderForTags) -> Self {
+        Self { variant: VARIANT_ONCHAIN_UNCONSTRAINED, sender_for_tags }
+    }
 
     /// Delivers the message on-chain, guaranteeing the recipient will receive the correct content.
     ///
@@ -120,8 +150,8 @@ pub struct MessageDeliveryEnum {
     /// ## Use Cases
     ///
     /// This delivery method is suitable for all use cases, since it always works as expected. It is however the most
-    /// costly method, and there are multiple scenarios where alternatives such as [`MessageDeliveryEnum::OFFCHAIN`] or
-    /// [`MessageDeliveryEnum::ONCHAIN_UNCONSTRAINED`] will suffice.
+    /// costly method, and there are multiple scenarios where alternatives such as [`offchain`](Self::offchain) or
+    /// [`onchain_unconstrained`](Self::onchain_unconstrained) will suffice.
     ///
     /// If the sender cannot be relied on to correctly send the message to the recipient (e.g. because they have no
     /// incentive to do so, such as when paying a fee to a protocol, creating the change note after spending a third
@@ -160,25 +190,23 @@ pub struct MessageDeliveryEnum {
     ///
     /// Identifying that a log corresponds to a message between a given sender and recipient requires, among other
     /// things, knowledge of both of their addresses **and** either the sender's or recipient's private address key.
-    pub ONCHAIN_CONSTRAINED: u8,
-}
+    ///
+    /// ## Sender for tags
+    ///
+    /// Until constrained tagging is implemented (#14565), this mode still derives the discovery tag from the
+    /// transaction-wide default sender-for-tags. Once #14565 lands, constrained delivery will use a handshake-based
+    /// tagging secret and the sender will be ignored for this variant.
+    pub fn onchain_constrained() -> Self {
+        Self { variant: VARIANT_ONCHAIN_CONSTRAINED, sender_for_tags: SenderForTags::tx_default() }
+    }
 
-/// Specifies how to deliver a message to a recipient.
-///
-/// All messages are delivered encrypted to their recipient's public address key, so no other account will be able to
-/// read their contents. This enum instead configures which **guarantees** exist regarding delivery.
-///
-/// There are two aspects to delivery guarantees:
-/// - the medium on which the message is sent (off-chain or on-chain)
-/// - whether the contract constrains the message to be constructed correctly
-///
-/// For scenarios where the sender is incentivized to deliver the message correctly, use
-/// [`MessageDeliveryEnum::OFFCHAIN`] (the cheapest delivery option, but requiring that sender and recipient can
-/// communicate off-chain) or [`MessageDeliveryEnum::ONCHAIN_UNCONSTRAINED`]. If the sender cannot be trusted to send
-/// the
-/// message to the recipient, use [`MessageDeliveryEnum::ONCHAIN_CONSTRAINED`].
-pub global MessageDelivery: MessageDeliveryEnum =
-    MessageDeliveryEnum { OFFCHAIN: 1, ONCHAIN_UNCONSTRAINED: 2, ONCHAIN_CONSTRAINED: 3 };
+    /// Same as [`onchain_constrained`](Self::onchain_constrained), but the (currently-unconstrained) discovery tag is
+    /// derived from the supplied [`SenderForTags`] instead of the wallet default. This override will be removed once
+    /// #14565 lands and constrained tagging uses handshake-based secrets.
+    pub fn onchain_constrained_with_sender(sender_for_tags: SenderForTags) -> Self {
+        Self { variant: VARIANT_ONCHAIN_CONSTRAINED, sender_for_tags }
+    }
+}
 
 /// Performs private delivery of a message to `recipient` according to `delivery_mode`.
 ///
@@ -191,8 +219,6 @@ pub global MessageDelivery: MessageDeliveryEnum =
 /// emitted in the current transaction. This is typically only used for note messages: since the note will not actually
 /// be created, there is no point in delivering the message.
 ///
-/// `delivery_mode` must be one of [`MessageDeliveryEnum`].
-///
 /// ## Privacy
 ///
 /// The emitted log always has the same length regardless of `MESSAGE_PLAINTEXT_LEN`, because all message ciphertexts
@@ -202,18 +228,18 @@ pub fn do_private_message_delivery<Env, let MESSAGE_PLAINTEXT_LEN: u32>(
     encode_into_message_plaintext: fn[Env]() -> [Field; MESSAGE_PLAINTEXT_LEN],
     maybe_note_hash_counter: Option<u32>,
     recipient: AztecAddress,
-    delivery_mode: u8,
+    delivery_mode: MessageDelivery,
 ) {
-    // This function relies on `delivery_mode` being a constant in order to reduce circuit constraints when
-    // unconstrained usage is requested. If `delivery_mode` were a runtime value the compiler would be unable to
-    // perform dead-code elimination.
-    assert_constant(delivery_mode);
+    // Both variant fields must be compile-time constants. `delivery_mode.variant` drives code-path selection in
+    // constrained code (enabling dead-code elimination).
+    assert_constant(delivery_mode.variant);
+    assert_constant(delivery_mode.sender_for_tags.variant);
 
     // The following maps out the 3 dimensions across which we configure message delivery.
-    let constrained_encryption = delivery_mode == MessageDelivery.ONCHAIN_CONSTRAINED;
-    let deliver_as_offchain_message = delivery_mode == MessageDelivery.OFFCHAIN;
+    let constrained_encryption = delivery_mode.variant == VARIANT_ONCHAIN_CONSTRAINED;
+    let deliver_as_offchain_message = delivery_mode.variant == VARIANT_OFFCHAIN;
     // TODO(#14565): Add constrained tagging
-    let _constrained_tagging = delivery_mode == MessageDelivery.ONCHAIN_CONSTRAINED;
+    let _constrained_tagging = delivery_mode.variant == VARIANT_ONCHAIN_CONSTRAINED;
 
     let contract_address = context.this_address();
 
@@ -227,8 +253,9 @@ pub fn do_private_message_delivery<Env, let MESSAGE_PLAINTEXT_LEN: u32>(
     } else {
         // TODO(#14565): constrained tagging is not yet implemented. Both modes currently use the unconstrained
         // domain separator because the discovery tag always comes from an oracle. Once constrained tagging lands,
-        // this should branch on `constrained_tagging` to select the appropriate separator.
-        let discovery_tag = compute_discovery_tag(recipient);
+        // this should branch on `constrained_tagging` to select the appropriate separator, and drop the
+        // sender-for-tags input for the constrained branch.
+        let discovery_tag = compute_discovery_tag(recipient, delivery_mode.sender_for_tags);
         let log_tag = compute_log_tag(discovery_tag, DOM_SEP__UNCONSTRAINED_MSG_LOG_TAG);
 
         // We forbid this value not being constant to avoid predicating the context calls below, which might result in

--- a/noir-projects/aztec-nr/aztec/src/note/note_message.nr
+++ b/noir-projects/aztec-nr/aztec/src/note/note_message.nr
@@ -1,6 +1,9 @@
 use crate::{
     context::PrivateContext,
-    messages::{logs::note::encode_private_note_message, message_delivery::do_private_message_delivery},
+    messages::{
+        logs::note::encode_private_note_message,
+        message_delivery::{do_private_message_delivery, MessageDelivery},
+    },
     note::{lifecycle::NewNote, note_interface::NoteType},
 };
 use crate::protocol::{address::AztecAddress, traits::Packable};
@@ -32,9 +35,8 @@ where
     ///
     /// The message is first encrypted to the owner's public key, ensuring no other actor can read it.
     ///
-    /// The `delivery_mode` must be one of [`crate::messages::message_delivery::MessageDeliveryEnum`], and will inform
-    /// costs (both proving time and TX fees) as well as delivery guarantees. This value must be a compile-time
-    /// constant.
+    /// `delivery_mode` must be constructed via one of the [`MessageDelivery`] named constructors and will inform
+    /// costs (both proving time and TX fees), delivery guarantees.
     ///
     /// To deliver the message to a recipient that is not the note's owner, use [`deliver_to`](NoteMessage::deliver_to)
     /// instead.
@@ -45,7 +47,7 @@ where
     /// as normal. This prevents both 'king of the hill' attacks (where a sender would otherwise fail to deliver a note
     /// to an invalid recipient) and forced privacy leaks (where an invalid recipient results in a unique transaction
     /// fingerprint, e.g. one lacking the private logs that would correspond to message delivery).
-    pub fn deliver(self, delivery_mode: u8) {
+    pub fn deliver(self, delivery_mode: MessageDelivery) {
         self.deliver_to(self.new_note.owner, delivery_mode);
     }
 
@@ -63,7 +65,7 @@ where
     /// institutional contract may require to have some actor receive all notes created for compliance purposes. Or a
     /// low value application like a game might deliver all notes offchain to a centralized server that then serves
     /// them via the app, bypassing the need for contract sync and improving UX.
-    pub fn deliver_to(self, recipient: AztecAddress, delivery_mode: u8) {
+    pub fn deliver_to(self, recipient: AztecAddress, delivery_mode: MessageDelivery) {
         // Technical note: we're about to call a closure that needs access to `new_note`, but we can't pass `self` to
         // it because the closure might execute in unconstrained mode, and since `self` contains a mutable reference to
         // `context` this would cause for a mutable reference to cross the constrained-unconstrained barrier, which is
@@ -126,10 +128,9 @@ where
 
     /// Same as [`NoteMessage::deliver`], except the message will only be delivered if it actually exists.
     ///
-    /// Messages delivered using [`crate::messages::message_delivery::MessageDeliveryEnum::ONCHAIN_CONSTRAINED`] will
-    /// pay
-    /// proving costs regardless of whether the message exists or not.
-    pub fn deliver(self, delivery_mode: u8) {
+    /// Messages delivered using [`MessageDelivery::onchain_constrained`] will pay proving costs regardless of whether
+    /// the message exists or not.
+    pub fn deliver(self, delivery_mode: MessageDelivery) {
         if self.maybe_new_note.is_some() {
             NoteMessage::new(self.maybe_new_note.unwrap_unchecked(), self.context).deliver(delivery_mode);
         }
@@ -137,10 +138,9 @@ where
 
     /// Same as [`NoteMessage::deliver_to`], except the message will only be delivered if it actually exists.
     ///
-    /// Messages delivered using [`crate::messages::message_delivery::MessageDeliveryEnum::ONCHAIN_CONSTRAINED`] will
-    /// pay
-    /// proving costs regardless of whether the message exists or not.
-    pub fn deliver_to(self, recipient: AztecAddress, delivery_mode: u8) {
+    /// Messages delivered using [`MessageDelivery::onchain_constrained`] will pay proving costs regardless of whether
+    /// the message exists or not.
+    pub fn deliver_to(self, recipient: AztecAddress, delivery_mode: MessageDelivery) {
         if self.maybe_new_note.is_some() {
             NoteMessage::new(self.maybe_new_note.unwrap_unchecked(), self.context).deliver_to(recipient, delivery_mode);
         }

--- a/noir-projects/aztec-nr/aztec/src/oracle/notes.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/notes.nr
@@ -190,33 +190,14 @@ pub unconstrained fn get_next_app_tag_as_sender(sender: AztecAddress, recipient:
 #[oracle(aztec_prv_getNextAppTagAsSender)]
 unconstrained fn get_next_app_tag_as_sender_oracle(_sender: AztecAddress, _recipient: AztecAddress) -> Field {}
 
-/// Gets the sender for tags.
+/// Returns the transaction-wide sender-for-tags supplied by the wallet when building the tx, if any.
 ///
-/// This unconstrained value is used as the sender when computing an unconstrained shared secret for a tag in order to
-/// emit a log. Constrained tagging should not use this as there is no guarantee that the recipient knows about the
-/// sender, and hence about the shared secret.
-///
-/// The value persists through nested calls, meaning all calls down the stack will use the same 'senderForTags' value
-/// (unless it is replaced).
-pub unconstrained fn get_sender_for_tags() -> Option<AztecAddress> {
+/// This is an internal helper used to resolve [`crate::messages::logs::sender_for_tags::SenderForTags::tx_default`].
+/// Contract code should not call this directly; pick a [`crate::messages::logs::sender_for_tags::SenderForTags`]
+/// variant at the log emission site instead.
+pub(crate) unconstrained fn get_sender_for_tags() -> Option<AztecAddress> {
     get_sender_for_tags_oracle()
 }
 
 #[oracle(aztec_prv_getSenderForTags)]
 unconstrained fn get_sender_for_tags_oracle() -> Option<AztecAddress> {}
-
-/// Sets the sender for tags.
-///
-/// This unconstrained value is used as the sender when computing an unconstrained shared secret for a tag in order to
-/// emit a log. Constrained tagging should not use this as there is no guarantee that the recipient knows about the
-/// sender, and hence about the shared secret.
-///
-/// Account contracts typically set this value before calling other contracts. The value persists through nested calls,
-/// meaning all calls down the stack will use the same 'senderForTags' value (unless it is replaced by another call to
-/// this setter).
-pub unconstrained fn set_sender_for_tags(sender_for_tags: AztecAddress) {
-    set_sender_for_tags_oracle(sender_for_tags);
-}
-
-#[oracle(aztec_prv_setSenderForTags)]
-unconstrained fn set_sender_for_tags_oracle(_sender_for_tags: AztecAddress) {}

--- a/noir-projects/aztec-nr/uint-note/src/uint_note.nr
+++ b/noir-projects/aztec-nr/uint-note/src/uint_note.nr
@@ -123,7 +123,7 @@ impl UintNote {
             || encode_partial_note_private_message(private_log_content, owner, randomness, commitment),
             Option::none(),
             recipient,
-            MessageDelivery.ONCHAIN_UNCONSTRAINED,
+            MessageDelivery::onchain_unconstrained(),
         );
 
         let partial_note = PartialUintNote { commitment };

--- a/noir-projects/noir-contracts-comp-failures/contracts/invalid_event/src/main.nr
+++ b/noir-projects/noir-contracts-comp-failures/contracts/invalid_event/src/main.nr
@@ -13,7 +13,7 @@ contract InvalidEventContract {
     fn trigger_event_check() {
         self.emit(InvalidEvent {}).deliver_to(
             self.msg_sender(),
-            MessageDelivery.ONCHAIN_UNCONSTRAINED,
+            MessageDelivery::onchain_unconstrained(),
         );
     }
 }

--- a/noir-projects/noir-contracts/contracts/account/ecdsa_k_account_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/account/ecdsa_k_account_contract/src/main.nr
@@ -11,11 +11,8 @@ pub contract EcdsaKAccount {
             functions::{allow_phase_change, external, initializer, noinitcheck, view},
             storage::storage,
         },
-        messages::message_delivery::MessageDelivery,
-        oracle::{
-            auth_witness::get_auth_witness_as_bytes,
-            notes::{get_sender_for_tags, set_sender_for_tags},
-        },
+        messages::{logs::sender_for_tags::SenderForTags, message_delivery::MessageDelivery},
+        oracle::auth_witness::get_auth_witness_as_bytes,
         state_vars::SinglePrivateImmutable,
     };
 
@@ -32,26 +29,13 @@ pub contract EcdsaKAccount {
     fn constructor(signing_pub_key_x: [u8; 32], signing_pub_key_y: [u8; 32]) {
         let pub_key_note = EcdsaPublicKeyNote { x: signing_pub_key_x, y: signing_pub_key_y };
 
-        // Safety: The sender for tags is only used to compute unconstrained shared secrets for emitting logs.
-        // Since this value is only used for unconstrained tagging and not for any constrained logic,
-        // it is safe to load from an unconstrained context.
-        // TODO(#15752): Improve the sender_for_tags handling here when the original sender is undefined.
-        let original_sender = unsafe { get_sender_for_tags().unwrap_or(self.address) };
-
         // We set the sender for tags to this contract because we don't want to force the user corresponding to this
         // account to add the account deployer as a sender to their PXE. By setting it to this contract, user's PXE
         // will manage to find the note even if the account deployer is not registered as a sender (i.e
         // `pxe.registerSender(accountDeployer)` was not called)
-
-        // Safety: Comment from above applies here as well.
-        unsafe { set_sender_for_tags(self.address) };
-        // The note message gets delivered to the note owner which is set by the SinglePrivateImmutable to be this
-        // contract.
         self.storage.signing_public_key.initialize(pub_key_note).deliver(
-            MessageDelivery.ONCHAIN_CONSTRAINED,
+            MessageDelivery::onchain_constrained_with_sender(SenderForTags::explicit(self.address)),
         );
-        // Safety: Comment from above applies here as well.
-        unsafe { set_sender_for_tags(original_sender) };
     }
 
     // @dev: If you globally change the entrypoint signature don't forget to update account_entrypoint.ts file (specifically `getEntrypointAbi()`)
@@ -60,11 +44,6 @@ pub contract EcdsaKAccount {
     #[noinitcheck]
     #[allow_phase_change]
     fn entrypoint(app_payload: AppPayload, fee_payment_method: u8, cancellable: bool) {
-        // Safety: The sender for tags is only used to compute unconstrained shared secrets for emitting logs.
-        // Since this value is only used for unconstrained tagging and not for any constrained logic,
-        // it is safe to set from a constrained context.
-        unsafe { set_sender_for_tags(self.address) };
-
         let actions = AccountActions::init(self.context, is_valid_impl);
         actions.entrypoint(app_payload, fee_payment_method, cancellable);
     }

--- a/noir-projects/noir-contracts/contracts/account/ecdsa_r_account_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/account/ecdsa_r_account_contract/src/main.nr
@@ -10,11 +10,8 @@ pub contract EcdsaRAccount {
             functions::{allow_phase_change, external, initializer, noinitcheck, view},
             storage::storage,
         },
-        messages::message_delivery::MessageDelivery,
-        oracle::{
-            auth_witness::get_auth_witness_as_bytes,
-            notes::{get_sender_for_tags, set_sender_for_tags},
-        },
+        messages::{logs::sender_for_tags::SenderForTags, message_delivery::MessageDelivery},
+        oracle::auth_witness::get_auth_witness_as_bytes,
         state_vars::SinglePrivateImmutable,
     };
 
@@ -31,26 +28,13 @@ pub contract EcdsaRAccount {
     fn constructor(signing_pub_key_x: [u8; 32], signing_pub_key_y: [u8; 32]) {
         let pub_key_note = EcdsaPublicKeyNote { x: signing_pub_key_x, y: signing_pub_key_y };
 
-        // Safety: The sender for tags is only used to compute unconstrained shared secrets for emitting logs.
-        // Since this value is only used for unconstrained tagging and not for any constrained logic,
-        // it is safe to load from an unconstrained context.
-        // TODO(#15752): Improve the sender_for_tags handling here when the original sender is undefined.
-        let original_sender = unsafe { get_sender_for_tags().unwrap_or(self.address) };
-
         // We set the sender for tags to this contract because we don't want to force the user corresponding to this
         // account to add the account deployer as a sender to their PXE. By setting it to this contract, user's PXE
         // will manage to find the note even if the account deployer is not registered as a sender (i.e
         // `pxe.registerSender(accountDeployer)` was not called)
-
-        // Safety: Comment from above applies here as well.
-        unsafe { set_sender_for_tags(self.address) };
-        // The note message gets delivered to the note owner which is set by the SinglePrivateImmutable to be this
-        // contract.
         self.storage.signing_public_key.initialize(pub_key_note).deliver(
-            MessageDelivery.ONCHAIN_CONSTRAINED,
+            MessageDelivery::onchain_constrained_with_sender(SenderForTags::explicit(self.address)),
         );
-        // Safety: Comment from above applies here as well.
-        unsafe { set_sender_for_tags(original_sender) };
     }
 
     // @dev: If you globally change the entrypoint signature don't forget to update account_entrypoint.ts file (specifically `getEntrypointAbi()`)
@@ -59,11 +43,6 @@ pub contract EcdsaRAccount {
     #[noinitcheck]
     #[allow_phase_change]
     fn entrypoint(app_payload: AppPayload, fee_payment_method: u8, cancellable: bool) {
-        // Safety: The sender for tags is only used to compute unconstrained shared secrets for emitting logs.
-        // Since this value is only used for unconstrained tagging and not for any constrained logic,
-        // it is safe to set from a constrained context.
-        unsafe { set_sender_for_tags(self.address) };
-
         let actions = AccountActions::init(self.context, is_valid_impl);
         actions.entrypoint(app_payload, fee_payment_method, cancellable);
     }

--- a/noir-projects/noir-contracts/contracts/account/schnorr_account_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/account/schnorr_account_contract/src/main.nr
@@ -18,11 +18,10 @@ pub contract SchnorrAccount {
             functions::{allow_phase_change, external, initializer, noinitcheck, view},
             storage::storage,
         },
-        messages::message_delivery::MessageDelivery,
+        messages::{logs::sender_for_tags::SenderForTags, message_delivery::MessageDelivery},
         oracle::{
             auth_witness::get_auth_witness_as_bytes,
             get_nullifier_membership_witness::get_low_nullifier_membership_witness,
-            notes::{get_sender_for_tags, set_sender_for_tags},
         },
         protocol::address::AztecAddress,
         state_vars::SinglePrivateImmutable,
@@ -41,26 +40,13 @@ pub contract SchnorrAccount {
     fn constructor(signing_pub_key_x: Field, signing_pub_key_y: Field) {
         let pub_key_note = PublicKeyNote { x: signing_pub_key_x, y: signing_pub_key_y };
 
-        // Safety: The sender for tags is only used to compute unconstrained shared secrets for emitting logs.
-        // Since this value is only used for unconstrained tagging and not for any constrained logic,
-        // it is safe to load from an unconstrained context.
-        // TODO(#15752): Improve the sender_for_tags handling here when the original sender is undefined.
-        let original_sender = unsafe { get_sender_for_tags().unwrap_or(self.address) };
-
         // We set the sender for tags to this contract because we don't want to force the user corresponding to this
         // account to add the account deployer as a sender to their PXE. By setting it to this contract, user's PXE
         // will manage to find the note even if the account deployer is not registered as a sender (i.e
         // `pxe.registerSender(accountDeployer)` was not called)
-
-        // Safety: Comment from above applies here as well.
-        unsafe { set_sender_for_tags(self.address) };
-        // The note message gets delivered to the note owner which is set by the SinglePrivateImmutable to be this
-        // contract.
         self.storage.signing_public_key.initialize(pub_key_note).deliver(
-            MessageDelivery.ONCHAIN_CONSTRAINED,
+            MessageDelivery::onchain_constrained_with_sender(SenderForTags::explicit(self.address)),
         );
-        // Safety: Comment from above applies here as well.
-        unsafe { set_sender_for_tags(original_sender) };
     }
 
     // @dev: If you globally change the entrypoint signature don't forget to update account_entrypoint.ts file (specifically `getEntrypointAbi()`).
@@ -69,11 +55,6 @@ pub contract SchnorrAccount {
     #[noinitcheck]
     #[allow_phase_change]
     fn entrypoint(app_payload: AppPayload, fee_payment_method: u8, cancellable: bool) {
-        // Safety: The sender for tags is only used to compute unconstrained shared secrets for emitting logs.
-        // Since this value is only used for unconstrained tagging and not for any constrained logic,
-        // it is safe to set from a constrained context.
-        unsafe { set_sender_for_tags(self.address) };
-
         let actions = AccountActions::init(self.context, is_valid_impl);
         actions.entrypoint(app_payload, fee_payment_method, cancellable);
     }

--- a/noir-projects/noir-contracts/contracts/account/schnorr_hardcoded_account_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/account/schnorr_hardcoded_account_contract/src/main.nr
@@ -7,7 +7,7 @@ pub contract SchnorrHardcodedAccount {
         authwit::{account::AccountActions, entrypoint::app::AppPayload},
         context::PrivateContext,
         macros::functions::{allow_phase_change, external, view},
-        oracle::{auth_witness::get_auth_witness_as_bytes, notes::set_sender_for_tags},
+        oracle::auth_witness::get_auth_witness_as_bytes,
     };
     use std::embedded_curve_ops::EmbeddedCurvePoint;
 
@@ -20,11 +20,6 @@ pub contract SchnorrHardcodedAccount {
     #[external("private")]
     #[allow_phase_change]
     fn entrypoint(app_payload: AppPayload, fee_payment_method: u8, cancellable: bool) {
-        // Safety: The sender for tags is only used to compute unconstrained shared secrets for emitting logs.
-        // Since this value is only used for unconstrained tagging and not for any constrained logic,
-        // it is safe to set from a constrained context.
-        unsafe { set_sender_for_tags(self.address) };
-
         let actions = AccountActions::init(self.context, is_valid_impl);
         actions.entrypoint(app_payload, fee_payment_method, cancellable);
     }

--- a/noir-projects/noir-contracts/contracts/account/simulated_ecdsa_account_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/account/simulated_ecdsa_account_contract/src/main.nr
@@ -11,7 +11,7 @@ pub contract SimulatedEcdsaAccount {
         context::PrivateContext,
         macros::functions::{allow_phase_change, external, view},
         messages::encoding::MESSAGE_CIPHERTEXT_LEN,
-        oracle::{notes::set_sender_for_tags, random::random},
+        oracle::random::random,
     };
 
     // Stub constructor matching the EcdsaKAccount / EcdsaRAccount constructor signature.
@@ -50,10 +50,6 @@ pub contract SimulatedEcdsaAccount {
     #[external("private")]
     #[allow_phase_change]
     fn entrypoint(app_payload: AppPayload, fee_payment_method: u8, cancellable: bool) {
-        // Safety: The sender for tags is only used to compute unconstrained shared secrets for
-        // emitting logs. It is not used in any constrained logic, so it is safe to set here.
-        unsafe { set_sender_for_tags(self.address) };
-
         let actions = AccountActions::init(self.context, is_valid_impl);
         actions.entrypoint(app_payload, fee_payment_method, cancellable);
     }

--- a/noir-projects/noir-contracts/contracts/account/simulated_schnorr_account_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/account/simulated_schnorr_account_contract/src/main.nr
@@ -11,7 +11,7 @@ pub contract SimulatedSchnorrAccount {
         context::PrivateContext,
         macros::functions::{allow_phase_change, external, view},
         messages::encoding::MESSAGE_CIPHERTEXT_LEN,
-        oracle::{notes::set_sender_for_tags, random::random},
+        oracle::random::random,
     };
 
     // Stub constructor matching the SchnorrAccount constructor signature.
@@ -50,10 +50,6 @@ pub contract SimulatedSchnorrAccount {
     #[external("private")]
     #[allow_phase_change]
     fn entrypoint(app_payload: AppPayload, fee_payment_method: u8, cancellable: bool) {
-        // Safety: The sender for tags is only used to compute unconstrained shared secrets for
-        // emitting logs. It is not used in any constrained logic, so it is safe to set here.
-        unsafe { set_sender_for_tags(self.address) };
-
         let actions = AccountActions::init(self.context, is_valid_impl);
         actions.entrypoint(app_payload, fee_payment_method, cancellable);
     }

--- a/noir-projects/noir-contracts/contracts/app/app_subscription_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/app_subscription_contract/src/main.nr
@@ -45,12 +45,12 @@ pub contract AppSubscription {
     use aztec::{
         authwit::auth::assert_current_call_valid_authwit,
         macros::{functions::{allow_phase_change, external, initializer}, storage::storage},
-        messages::message_delivery::MessageDelivery,
-        oracle::notes::set_sender_for_tags,
+        messages::{logs::sender_for_tags::SenderForTags, message_delivery::MessageDelivery},
         protocol::address::AztecAddress,
         state_vars::{Owned, PrivateMutable, PublicImmutable},
         utils::comparison::Comparator,
     };
+
     use public_checks::utils::privately_check_block_number;
     use token::Token;
 
@@ -68,19 +68,14 @@ pub contract AppSubscription {
     #[external("private")]
     #[allow_phase_change]
     fn entrypoint(payload: DAppPayload, user_address: AztecAddress) {
-        // Safety: The sender for tags is only used to compute unconstrained shared secrets for emitting logs.
-        // Since this value is only used for unconstrained tagging and not for any constrained logic,
-        // it is safe to set from a constrained context.
-        // We set the sender for tags to the user address because we don't want to force the user
-        // to add this contract as a sender to their PXE. By setting it to the user address, user's PXE
-        // will manage to find the notes even if this contract is not registered as a sender
-        unsafe { set_sender_for_tags(user_address) };
-
         // This function takes a generic argument that corresponds to the number of params
         // the parent takes. See aztec-nr/src/authwit/auth.nr for more details.
         assert_current_call_valid_authwit::<2>(self.context, user_address);
 
         let user_expiry_block_number = &mut 0;
+        // We set the sender for tags to the user address because we don't want to force the user
+        // to add this contract as a sender to their PXE. By setting it to the user address, user's PXE
+        // will manage to find the notes even if this contract is not registered as a sender
         self
             .storage
             .subscriptions
@@ -94,7 +89,9 @@ pub contract AppSubscription {
                     remaining_txs: note.remaining_txs - 1,
                 }
             })
-            .deliver(MessageDelivery.ONCHAIN_CONSTRAINED);
+            .deliver(MessageDelivery::onchain_constrained_with_sender(SenderForTags::explicit(
+                user_address,
+            )));
 
         self.context.set_as_fee_payer();
 
@@ -165,7 +162,7 @@ pub contract AppSubscription {
             .initialize_or_replace(|_| {
                 SubscriptionNote { expiry_block_number, remaining_txs: tx_count }
             })
-            .deliver(MessageDelivery.ONCHAIN_CONSTRAINED);
+            .deliver(MessageDelivery::onchain_constrained());
         // docs:end:owned_private_mutable_initialize
     }
 

--- a/noir-projects/noir-contracts/contracts/app/card_game_contract/src/cards.nr
+++ b/noir-projects/noir-contracts/contracts/app/card_game_contract/src/cards.nr
@@ -161,7 +161,7 @@ impl Deck<&mut PrivateContext> {
         for card in cards {
             let card_note = CardNote::from_card(card);
             self.owned_set.at(owner).insert(card_note.note).deliver(
-                MessageDelivery.ONCHAIN_CONSTRAINED,
+                MessageDelivery::onchain_constrained(),
             );
             inserted_cards = inserted_cards.push_back(card_note);
         }

--- a/noir-projects/noir-contracts/contracts/app/crowdfunding_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/crowdfunding_contract/src/main.nr
@@ -60,7 +60,7 @@ pub contract Crowdfunding {
         // We don't constrain encryption because the donor is sending the note to himself. And hence by performing
         // encryption incorrectly would harm himself only.
         self.storage.donation_receipts.at(donor).insert(note).deliver(
-            MessageDelivery.ONCHAIN_UNCONSTRAINED,
+            MessageDelivery::onchain_unconstrained(),
         );
     }
 

--- a/noir-projects/noir-contracts/contracts/app/escrow_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/escrow_contract/src/main.nr
@@ -23,7 +23,7 @@ pub contract Escrow {
     #[initializer]
     fn constructor(owner: AztecAddress) {
         let note = AddressNote { address: owner };
-        self.storage.owner.initialize(note).deliver(MessageDelivery.ONCHAIN_CONSTRAINED);
+        self.storage.owner.initialize(note).deliver(MessageDelivery::onchain_constrained());
     }
 
     // Withdraws balance. Requires that msg.sender is the owner.

--- a/noir-projects/noir-contracts/contracts/app/nft_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/nft_contract/src/main.nr
@@ -245,7 +245,7 @@ pub contract NFT {
 
         let new_note = NFTNote { token_id };
 
-        nfts.at(to).insert(new_note).deliver(MessageDelivery.ONCHAIN_CONSTRAINED);
+        nfts.at(to).insert(new_note).deliver(MessageDelivery::onchain_constrained());
     }
 
     #[authorize_once("from", "authwit_nonce")]

--- a/noir-projects/noir-contracts/contracts/app/nft_contract/src/types/nft_note.nr
+++ b/noir-projects/noir-contracts/contracts/app/nft_contract/src/types/nft_note.nr
@@ -135,7 +135,7 @@ impl NFTNote {
             },
             Option::none(),
             recipient,
-            MessageDelivery.ONCHAIN_UNCONSTRAINED,
+            MessageDelivery::onchain_unconstrained(),
         );
 
         let partial_note = PartialNFTNote { commitment };

--- a/noir-projects/noir-contracts/contracts/app/private_token_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/private_token_contract/src/main.nr
@@ -37,18 +37,18 @@ pub contract PrivateToken {
         // privileges to someone else which requires being able to nullify the note. We use constrained onchain message
         // delivery because we don't know if the party deploying this contract is incentivized to deliver the note.
         self.storage.admin.initialize(AddressNote { address: admin }, admin).deliver(
-            MessageDelivery.ONCHAIN_CONSTRAINED,
+            MessageDelivery::onchain_constrained(),
         );
 
         // Mint the initial admin balance to the admin.
         self.storage.balances.at(admin).add(initial_admin_balance).deliver(
-            MessageDelivery.ONCHAIN_CONSTRAINED,
+            MessageDelivery::onchain_constrained(),
         );
         self
             .storage
             .total_supply
             .initialize(UintNote { value: initial_admin_balance }, admin)
-            .deliver(MessageDelivery.ONCHAIN_CONSTRAINED);
+            .deliver(MessageDelivery::onchain_constrained());
     }
 
     // Mints `amount` of tokens to `owner`.
@@ -61,17 +61,19 @@ pub contract PrivateToken {
 
         // We deliver the new note message to the admin using unconstrained delivery, since the admin is motivated to
         // deliver the message to themselves (hence no need to constrain it).
-        replacement_note_message.deliver(MessageDelivery.ONCHAIN_UNCONSTRAINED);
+        replacement_note_message.deliver(MessageDelivery::onchain_unconstrained());
         // We increase the total supply and once again use unconstrained delivery, since the admin is motivated to
         // deliver the message (he's the owner of the new note as well).
         self
             .storage
             .total_supply
             .replace(|current| UintNote { value: current.value + amount }, admin)
-            .deliver(MessageDelivery.ONCHAIN_UNCONSTRAINED);
+            .deliver(MessageDelivery::onchain_unconstrained());
 
         // At last we mint the tokens to the recipient.
-        self.storage.balances.at(recipient).add(amount).deliver(MessageDelivery.ONCHAIN_CONSTRAINED);
+        self.storage.balances.at(recipient).add(amount).deliver(
+            MessageDelivery::onchain_constrained(),
+        );
     }
     // docs:end:note_delivery
 
@@ -92,15 +94,17 @@ pub contract PrivateToken {
                 },
                 new_admin,
             )
-            .deliver(MessageDelivery.ONCHAIN_CONSTRAINED);
+            .deliver(MessageDelivery::onchain_constrained());
     }
     // docs:end:owned_single_private_mutable_replace
 
     // Transfers `amount` of tokens from `sender` to a `recipient`.
     #[external("private")]
     fn transfer(amount: u128, sender: AztecAddress, recipient: AztecAddress) {
-        self.storage.balances.at(sender).sub(amount).deliver(MessageDelivery.ONCHAIN_CONSTRAINED);
-        self.storage.balances.at(recipient).add(amount).deliver(MessageDelivery.ONCHAIN_CONSTRAINED);
+        self.storage.balances.at(sender).sub(amount).deliver(MessageDelivery::onchain_constrained());
+        self.storage.balances.at(recipient).add(amount).deliver(
+            MessageDelivery::onchain_constrained(),
+        );
     }
 
     // Helper function to get the balance of a user.

--- a/noir-projects/noir-contracts/contracts/app/simple_token_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/simple_token_contract/src/main.nr
@@ -130,7 +130,7 @@ pub contract SimpleToken {
         amount: u128,
         authwit_nonce: Field,
     ) {
-        self.storage.balances.at(from).sub(amount).deliver(MessageDelivery.ONCHAIN_CONSTRAINED);
+        self.storage.balances.at(from).sub(amount).deliver(MessageDelivery::onchain_constrained());
         self.enqueue_self._increase_public_balance(to, amount);
     }
 
@@ -139,19 +139,19 @@ pub contract SimpleToken {
         let from = self.msg_sender();
 
         let change = self.internal.subtract_balance(from, amount, INITIAL_TRANSFER_CALL_MAX_NOTES);
-        self.storage.balances.at(from).add(change).deliver(MessageDelivery.ONCHAIN_UNCONSTRAINED);
-        self.storage.balances.at(to).add(amount).deliver(MessageDelivery.ONCHAIN_UNCONSTRAINED);
+        self.storage.balances.at(from).add(change).deliver(MessageDelivery::onchain_unconstrained());
+        self.storage.balances.at(to).add(amount).deliver(MessageDelivery::onchain_unconstrained());
 
         self.emit(Transfer { from, to, amount }).deliver_to(
             to,
-            MessageDelivery.ONCHAIN_UNCONSTRAINED,
+            MessageDelivery::onchain_unconstrained(),
         );
     }
 
     #[authorize_once("from", "authwit_nonce")]
     #[external("private")]
     fn burn_private(from: AztecAddress, amount: u128, authwit_nonce: Field) {
-        self.storage.balances.at(from).sub(amount).deliver(MessageDelivery.ONCHAIN_CONSTRAINED);
+        self.storage.balances.at(from).sub(amount).deliver(MessageDelivery::onchain_constrained());
         self.enqueue_self._reduce_total_supply(amount);
     }
 

--- a/noir-projects/noir-contracts/contracts/app/token_blacklist_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_blacklist_contract/src/main.nr
@@ -204,7 +204,7 @@ pub contract TokenBlacklist {
         assert(notes.len() == 1, "note not popped");
 
         // Add the token note to user's balances set
-        self.storage.balances.at(to).add(amount).deliver(MessageDelivery.ONCHAIN_CONSTRAINED);
+        self.storage.balances.at(to).add(amount).deliver(MessageDelivery::onchain_constrained());
     }
 
     #[authorize_once("from", "authwit_nonce")]
@@ -215,7 +215,7 @@ pub contract TokenBlacklist {
         let to_roles = self.storage.roles.at(to).get_current_value();
         assert(!to_roles.is_blacklisted, "Blacklisted: Recipient");
 
-        self.storage.balances.at(from).sub(amount).deliver(MessageDelivery.ONCHAIN_CONSTRAINED);
+        self.storage.balances.at(from).sub(amount).deliver(MessageDelivery::onchain_constrained());
 
         self.enqueue_self._increase_public_balance(to, amount);
     }
@@ -228,8 +228,8 @@ pub contract TokenBlacklist {
         let to_roles = self.storage.roles.at(to).get_current_value();
         assert(!to_roles.is_blacklisted, "Blacklisted: Recipient");
 
-        self.storage.balances.at(from).sub(amount).deliver(MessageDelivery.ONCHAIN_UNCONSTRAINED);
-        self.storage.balances.at(to).add(amount).deliver(MessageDelivery.ONCHAIN_UNCONSTRAINED);
+        self.storage.balances.at(from).sub(amount).deliver(MessageDelivery::onchain_unconstrained());
+        self.storage.balances.at(to).add(amount).deliver(MessageDelivery::onchain_unconstrained());
     }
 
     #[authorize_once("from", "authwit_nonce")]
@@ -238,7 +238,7 @@ pub contract TokenBlacklist {
         let from_roles = self.storage.roles.at(from).get_current_value();
         assert(!from_roles.is_blacklisted, "Blacklisted: Sender");
 
-        self.storage.balances.at(from).sub(amount).deliver(MessageDelivery.ONCHAIN_CONSTRAINED);
+        self.storage.balances.at(from).sub(amount).deliver(MessageDelivery::onchain_constrained());
 
         self.enqueue_self._reduce_total_supply(amount);
     }

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/main.nr
@@ -187,7 +187,7 @@ pub contract Token {
         amount: u128,
         authwit_nonce: Field,
     ) {
-        self.storage.balances.at(from).sub(amount).deliver(MessageDelivery.ONCHAIN_CONSTRAINED);
+        self.storage.balances.at(from).sub(amount).deliver(MessageDelivery::onchain_constrained());
         self.enqueue_self._increase_public_balance(to, amount);
     }
 
@@ -213,7 +213,7 @@ pub contract Token {
         amount: u128,
         authwit_nonce: Field,
     ) -> PartialUintNote {
-        self.storage.balances.at(from).sub(amount).deliver(MessageDelivery.ONCHAIN_CONSTRAINED);
+        self.storage.balances.at(from).sub(amount).deliver(MessageDelivery::onchain_constrained());
         self.enqueue_self._increase_public_balance(to, amount);
 
         // We prepare the private balance increase (the partial note for the change).
@@ -231,8 +231,8 @@ pub contract Token {
         // note for `from` with the change amount, e.g. if `amount` is 10 and two notes are nullified with amounts 8 and
         // 5, then the change will be 3 (since 8 + 5 - 10 = 3).
         let change = self.internal.subtract_balance(from, amount, INITIAL_TRANSFER_CALL_MAX_NOTES);
-        self.storage.balances.at(from).add(change).deliver(MessageDelivery.ONCHAIN_UNCONSTRAINED);
-        self.storage.balances.at(to).add(amount).deliver(MessageDelivery.ONCHAIN_UNCONSTRAINED);
+        self.storage.balances.at(from).add(change).deliver(MessageDelivery::onchain_unconstrained());
+        self.storage.balances.at(to).add(amount).deliver(MessageDelivery::onchain_unconstrained());
 
         // We don't constrain encryption of the note log in `transfer` (unlike in `transfer_in_private`) because the transfer
         // function is only designed to be used in situations where the event is not strictly necessary (e.g. payment to
@@ -240,7 +240,7 @@ pub contract Token {
         // note).
         self.emit(Transfer { from, to, amount }).deliver_to(
             to,
-            MessageDelivery.ONCHAIN_UNCONSTRAINED,
+            MessageDelivery::onchain_unconstrained(),
         );
     }
 
@@ -303,15 +303,15 @@ pub contract Token {
         amount: u128,
         authwit_nonce: Field,
     ) {
-        self.storage.balances.at(from).sub(amount).deliver(MessageDelivery.ONCHAIN_CONSTRAINED);
-        self.storage.balances.at(to).add(amount).deliver(MessageDelivery.ONCHAIN_CONSTRAINED);
+        self.storage.balances.at(from).sub(amount).deliver(MessageDelivery::onchain_constrained());
+        self.storage.balances.at(to).add(amount).deliver(MessageDelivery::onchain_constrained());
     }
     // docs:end:transfer_in_private
 
     #[authorize_once("from", "authwit_nonce")]
     #[external("private")]
     fn burn_private(from: AztecAddress, amount: u128, authwit_nonce: Field) {
-        self.storage.balances.at(from).sub(amount).deliver(MessageDelivery.ONCHAIN_CONSTRAINED);
+        self.storage.balances.at(from).sub(amount).deliver(MessageDelivery::onchain_constrained());
         self.enqueue_self._reduce_total_supply(amount);
     }
 
@@ -381,7 +381,7 @@ pub contract Token {
         authwit_nonce: Field,
     ) {
         // First we subtract the `amount` from the private balance of `from`
-        self.storage.balances.at(from).sub(amount).deliver(MessageDelivery.ONCHAIN_CONSTRAINED);
+        self.storage.balances.at(from).sub(amount).deliver(MessageDelivery::onchain_constrained());
 
         partial_note.complete_from_private(
             self.context,

--- a/noir-projects/noir-contracts/contracts/test/benchmarking_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/benchmarking_contract/src/main.nr
@@ -34,7 +34,7 @@ pub contract Benchmarking {
     #[external("private")]
     fn create_note(owner: AztecAddress, value: Field) {
         let note = FieldNote { value };
-        self.storage.notes.at(owner).insert(note).deliver(MessageDelivery.ONCHAIN_CONSTRAINED);
+        self.storage.notes.at(owner).insert(note).deliver(MessageDelivery::onchain_constrained());
     }
     // Deletes a note at a specific index in the set and creates a new one with the same value.
     // We explicitly pass in the note index so we can ensure we consume different notes when sending
@@ -47,7 +47,7 @@ pub contract Benchmarking {
         let mut getter_options = NoteGetterOptions::new();
         let notes = owner_notes.pop_notes(getter_options.set_limit(1).set_offset(index));
         let note = notes.get(0);
-        owner_notes.insert(note).deliver(MessageDelivery.ONCHAIN_CONSTRAINED);
+        owner_notes.insert(note).deliver(MessageDelivery::onchain_constrained());
     }
 
     // Reads and writes to public storage and enqueues a call to another public function.

--- a/noir-projects/noir-contracts/contracts/test/child_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/child_contract/src/main.nr
@@ -52,7 +52,7 @@ pub contract Child {
         let note = FieldNote { value: new_value };
 
         self.storage.private_values.at(owner).insert(note).deliver(
-            MessageDelivery.ONCHAIN_CONSTRAINED,
+            MessageDelivery::onchain_constrained(),
         );
         new_value
     }

--- a/noir-projects/noir-contracts/contracts/test/counter/counter_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/counter/counter_contract/src/main.nr
@@ -21,14 +21,14 @@ pub contract Counter {
     // We can name our initializer anything we want as long as it's marked as aztec(initializer)
     fn initialize(headstart: u64, owner: AztecAddress) {
         self.storage.counters.at(owner).add(headstart as u128).deliver(
-            MessageDelivery.ONCHAIN_CONSTRAINED,
+            MessageDelivery::onchain_constrained(),
         );
     }
 
     #[external("private")]
     fn increment(owner: AztecAddress) {
         debug_log_format("Incrementing counter for owner {0}", [owner.to_field()]);
-        self.storage.counters.at(owner).add(1).deliver(MessageDelivery.ONCHAIN_CONSTRAINED);
+        self.storage.counters.at(owner).add(1).deliver(MessageDelivery::onchain_constrained());
     }
 
     #[external("private")]
@@ -37,8 +37,8 @@ pub contract Counter {
             "Incrementing counter twice for owner {0}",
             [owner.to_field()],
         );
-        self.storage.counters.at(owner).add(1).deliver(MessageDelivery.ONCHAIN_CONSTRAINED);
-        self.storage.counters.at(owner).add(1).deliver(MessageDelivery.ONCHAIN_CONSTRAINED);
+        self.storage.counters.at(owner).add(1).deliver(MessageDelivery::onchain_constrained());
+        self.storage.counters.at(owner).add(1).deliver(MessageDelivery::onchain_constrained());
     }
 
     #[external("private")]
@@ -47,14 +47,14 @@ pub contract Counter {
             "Incrementing and decrementing counter for owner {0}",
             [owner.to_field()],
         );
-        self.storage.counters.at(owner).add(1).deliver(MessageDelivery.ONCHAIN_CONSTRAINED);
-        self.storage.counters.at(owner).sub(1).deliver(MessageDelivery.ONCHAIN_CONSTRAINED);
+        self.storage.counters.at(owner).add(1).deliver(MessageDelivery::onchain_constrained());
+        self.storage.counters.at(owner).sub(1).deliver(MessageDelivery::onchain_constrained());
     }
 
     #[external("private")]
     fn decrement(owner: AztecAddress) {
         debug_log_format("Decrementing counter for owner {0}", [owner.to_field()]);
-        self.storage.counters.at(owner).sub(1).deliver(MessageDelivery.ONCHAIN_CONSTRAINED);
+        self.storage.counters.at(owner).sub(1).deliver(MessageDelivery::onchain_constrained());
     }
 
     #[external("utility")]
@@ -66,7 +66,7 @@ pub contract Counter {
     fn increment_self_and_other(other_counter: AztecAddress, owner: AztecAddress) {
         debug_log_format("Incrementing counter for other {0}", [owner.to_field()]);
 
-        self.storage.counters.at(owner).add(1).deliver(MessageDelivery.ONCHAIN_CONSTRAINED);
+        self.storage.counters.at(owner).add(1).deliver(MessageDelivery::onchain_constrained());
 
         self.call(Counter::at(other_counter).increment(owner));
     }

--- a/noir-projects/noir-contracts/contracts/test/custom_message_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/custom_message_contract/src/main.nr
@@ -178,7 +178,7 @@ contract CustomMessage {
             || msg0,
             Option::none(),
             recipient,
-            MessageDelivery.ONCHAIN_UNCONSTRAINED,
+            MessageDelivery::onchain_unconstrained(),
         );
 
         // Part 1: randomness (message_id) and remaining event fields
@@ -192,7 +192,7 @@ contract CustomMessage {
             || msg1,
             Option::none(),
             recipient,
-            MessageDelivery.ONCHAIN_UNCONSTRAINED,
+            MessageDelivery::onchain_unconstrained(),
         );
     }
 }

--- a/noir-projects/noir-contracts/contracts/test/event_only_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/event_only_contract/src/main.nr
@@ -17,6 +17,6 @@ contract EventOnly {
     #[external("private")]
     fn emit_event_for_msg_sender(value: Field) {
         let sender = self.msg_sender();
-        self.emit(TestEvent { value }).deliver_to(sender, MessageDelivery.ONCHAIN_UNCONSTRAINED);
+        self.emit(TestEvent { value }).deliver_to(sender, MessageDelivery::onchain_unconstrained());
     }
 }

--- a/noir-projects/noir-contracts/contracts/test/no_constructor_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/no_constructor_contract/src/main.nr
@@ -32,7 +32,7 @@ pub contract NoConstructor {
         let note = FieldNote { value };
 
         self.storage.private_mutable.at(owner).initialize(note).deliver(
-            MessageDelivery.ONCHAIN_CONSTRAINED,
+            MessageDelivery::onchain_constrained(),
         );
     }
 

--- a/noir-projects/noir-contracts/contracts/test/note_getter_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/note_getter_contract/src/main.nr
@@ -30,7 +30,7 @@ pub contract NoteGetter {
         let owner = self.msg_sender();
         let note = FieldNote { value };
 
-        self.storage.set.at(owner).insert(note).deliver(MessageDelivery.ONCHAIN_CONSTRAINED);
+        self.storage.set.at(owner).insert(note).deliver(MessageDelivery::onchain_constrained());
     }
 
     #[external("utility")]
@@ -52,7 +52,9 @@ pub contract NoteGetter {
         let owner = self.msg_sender();
         let note = PackedNote { high, low };
 
-        self.storage.packed_set.at(owner).insert(note).deliver(MessageDelivery.ONCHAIN_CONSTRAINED);
+        self.storage.packed_set.at(owner).insert(note).deliver(
+            MessageDelivery::onchain_constrained(),
+        );
     }
 
     #[external("utility")]

--- a/noir-projects/noir-contracts/contracts/test/offchain_effect_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/offchain_effect_contract/src/main.nr
@@ -50,7 +50,7 @@ contract OffchainEffect {
 
     #[external("private")]
     fn emit_event_as_offchain_message_for_msg_sender(a: u64, b: u64, c: u64) {
-        self.emit(TestEvent { a, b, c }).deliver_to(self.msg_sender(), MessageDelivery.OFFCHAIN);
+        self.emit(TestEvent { a, b, c }).deliver_to(self.msg_sender(), MessageDelivery::offchain());
     }
 
     #[external("private")]
@@ -59,7 +59,7 @@ contract OffchainEffect {
 
         self.storage.balances.at(owner).insert(note).deliver_to(
             self.msg_sender(),
-            MessageDelivery.OFFCHAIN,
+            MessageDelivery::offchain(),
         );
     }
 

--- a/noir-projects/noir-contracts/contracts/test/offchain_payment_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/offchain_payment_contract/src/main.nr
@@ -19,7 +19,9 @@ contract OffchainPayment {
     #[external("private")]
     fn mint(amount: u128, recipient: AztecAddress) {
         // Minted notes are delivered onchain to ensure the recipient can always discover them.
-        self.storage.balances.at(recipient).add(amount).deliver(MessageDelivery.ONCHAIN_CONSTRAINED);
+        self.storage.balances.at(recipient).add(amount).deliver(
+            MessageDelivery::onchain_constrained(),
+        );
     }
 
     #[external("private")]
@@ -27,9 +29,9 @@ contract OffchainPayment {
         let sender = self.msg_sender();
 
         // Sender change note and recipient note are both delivered offchain.
-        self.storage.balances.at(sender).sub(amount).deliver(MessageDelivery.OFFCHAIN);
+        self.storage.balances.at(sender).sub(amount).deliver(MessageDelivery::offchain());
 
-        self.storage.balances.at(recipient).add(amount).deliver(MessageDelivery.OFFCHAIN);
+        self.storage.balances.at(recipient).add(amount).deliver(MessageDelivery::offchain());
     }
 
     #[external("utility")]

--- a/noir-projects/noir-contracts/contracts/test/pending_note_hashes_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/pending_note_hashes_contract/src/main.nr
@@ -49,7 +49,7 @@ pub contract PendingNoteHashes {
 
         // Insert note
         // docs:start:private_set_insert
-        owner_balance.insert(note).deliver(MessageDelivery.ONCHAIN_CONSTRAINED);
+        owner_balance.insert(note).deliver(MessageDelivery::onchain_constrained());
         // docs:end:private_set_insert
 
         let options = NoteGetterOptions::with_filter(filter_notes_min_sum, amount);
@@ -95,7 +95,7 @@ pub contract PendingNoteHashes {
         let note = FieldNote { value: amount };
 
         // Insert note
-        owner_balance.insert(note).deliver(MessageDelivery.ONCHAIN_CONSTRAINED);
+        owner_balance.insert(note).deliver(MessageDelivery::onchain_constrained());
     }
 
     // Nested/inner function to create and insert a note
@@ -110,7 +110,7 @@ pub contract PendingNoteHashes {
         let note = FieldNote::unpack([amount.to_field()]);
 
         // Insert note
-        owner_balance.insert(note).deliver(MessageDelivery.ONCHAIN_CONSTRAINED);
+        owner_balance.insert(note).deliver(MessageDelivery::onchain_constrained());
     }
 
     // Nested/inner function to create and insert a note
@@ -124,10 +124,10 @@ pub contract PendingNoteHashes {
         // Insert note
         let message = owner_balance.insert(note);
 
-        message.deliver(MessageDelivery.ONCHAIN_CONSTRAINED);
+        message.deliver(MessageDelivery::onchain_constrained());
 
         // Deliver note message again
-        message.deliver(MessageDelivery.ONCHAIN_CONSTRAINED);
+        message.deliver(MessageDelivery::onchain_constrained());
     }
 
     // Nested/inner function to get a note and confirm it matches the expected value
@@ -345,7 +345,7 @@ pub contract PendingNoteHashes {
             let recipient_balance = self.storage.balances.at(recipient);
 
             let note = FieldNote { value: i as Field };
-            recipient_balance.insert(note).deliver(MessageDelivery.ONCHAIN_CONSTRAINED);
+            recipient_balance.insert(note).deliver(MessageDelivery::onchain_constrained());
         }
     }
 

--- a/noir-projects/noir-contracts/contracts/test/private_init_test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/private_init_test_contract/src/main.nr
@@ -22,7 +22,7 @@ pub contract PrivateInitTest {
     fn initialize(initial_value: Field) {
         let owner = self.msg_sender();
         self.storage.value.at(owner).initialize(FieldNote { value: initial_value }).deliver(
-            MessageDelivery.ONCHAIN_CONSTRAINED,
+            MessageDelivery::onchain_constrained(),
         );
     }
 
@@ -30,7 +30,7 @@ pub contract PrivateInitTest {
     fn private_init_check_write_value(new_value: Field) {
         let owner = self.msg_sender();
         self.storage.value.at(owner).replace(|_old| FieldNote { value: new_value }).deliver(
-            MessageDelivery.ONCHAIN_CONSTRAINED,
+            MessageDelivery::onchain_constrained(),
         );
     }
 

--- a/noir-projects/noir-contracts/contracts/test/scope_test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/scope_test_contract/src/main.nr
@@ -29,7 +29,7 @@ pub contract ScopeTest {
     #[external("private")]
     fn create_note(owner: AztecAddress, value: Field) {
         let note = FieldNote { value };
-        self.storage.note.at(owner).initialize(note).deliver(MessageDelivery.ONCHAIN_CONSTRAINED);
+        self.storage.note.at(owner).initialize(note).deliver(MessageDelivery::onchain_constrained());
     }
 
     /// Reads the note owned by the specified owner and returns its value.

--- a/noir-projects/noir-contracts/contracts/test/spam_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/spam_contract/src/main.nr
@@ -27,7 +27,7 @@ pub contract Spam {
         let caller = self.msg_sender();
 
         for _ in 0..MAX_NOTE_HASHES_PER_CALL {
-            self.storage.balances.at(caller).add(1).deliver(MessageDelivery.ONCHAIN_UNCONSTRAINED);
+            self.storage.balances.at(caller).add(1).deliver(MessageDelivery::onchain_unconstrained());
         }
 
         for i in 0..MAX_NULLIFIERS_PER_CALL {

--- a/noir-projects/noir-contracts/contracts/test/state_vars_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/state_vars_contract/src/main.nr
@@ -101,7 +101,7 @@ pub contract StateVars {
         let new_note = FieldNote { value };
 
         self.storage.private_immutable.at(owner).initialize(new_note).deliver(
-            MessageDelivery.ONCHAIN_CONSTRAINED,
+            MessageDelivery::onchain_constrained(),
         );
     }
 
@@ -111,7 +111,7 @@ pub contract StateVars {
         let private_mutable = FieldNote { value };
 
         self.storage.private_mutable.at(owner).initialize(private_mutable).deliver(
-            MessageDelivery.ONCHAIN_CONSTRAINED,
+            MessageDelivery::onchain_constrained(),
         );
     }
 
@@ -119,7 +119,7 @@ pub contract StateVars {
     fn update_private_mutable(randomness: Field, value: Field) {
         let owner = self.msg_sender();
         self.storage.private_mutable.at(owner).replace(|_old_note| FieldNote { value }).deliver(
-            MessageDelivery.ONCHAIN_CONSTRAINED,
+            MessageDelivery::onchain_constrained(),
         );
     }
 
@@ -135,7 +135,7 @@ pub contract StateVars {
                 let new_value = old_note.value + 1;
                 FieldNote { value: new_value }
             })
-            .deliver(MessageDelivery.ONCHAIN_CONSTRAINED);
+            .deliver(MessageDelivery::onchain_constrained());
     }
 
     #[external("utility")]

--- a/noir-projects/noir-contracts/contracts/test/stateful_test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/stateful_test_contract/src/main.nr
@@ -41,7 +41,7 @@ pub contract StatefulTest {
     fn create_note(owner: AztecAddress, value: Field) {
         if (value != 0) {
             let note = FieldNote { value };
-            self.storage.notes.at(owner).insert(note).deliver(MessageDelivery.ONCHAIN_CONSTRAINED);
+            self.storage.notes.at(owner).insert(note).deliver(MessageDelivery::onchain_constrained());
         }
     }
 
@@ -50,7 +50,7 @@ pub contract StatefulTest {
     fn create_note_no_init_check(owner: AztecAddress, value: Field) {
         if (value != 0) {
             let note = FieldNote { value };
-            self.storage.notes.at(owner).insert(note).deliver(MessageDelivery.ONCHAIN_CONSTRAINED);
+            self.storage.notes.at(owner).insert(note).deliver(MessageDelivery::onchain_constrained());
         }
     }
 
@@ -62,7 +62,7 @@ pub contract StatefulTest {
         let _ = self.storage.notes.at(sender).pop_notes(NoteGetterOptions::new().set_limit(2));
 
         self.storage.notes.at(recipient).insert(FieldNote { value: 92 }).deliver(
-            MessageDelivery.ONCHAIN_CONSTRAINED,
+            MessageDelivery::onchain_constrained(),
         );
     }
 

--- a/noir-projects/noir-contracts/contracts/test/static_child_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/static_child_contract/src/main.nr
@@ -47,7 +47,7 @@ pub contract StaticChild {
     fn private_illegal_set_value(new_value: Field, owner: AztecAddress) -> Field {
         let note = FieldNote { value: new_value };
         self.storage.a_private_value.at(owner).insert(note).deliver(
-            MessageDelivery.ONCHAIN_CONSTRAINED,
+            MessageDelivery::onchain_constrained(),
         );
         new_value
     }
@@ -58,7 +58,7 @@ pub contract StaticChild {
         let note = FieldNote { value: new_value };
 
         self.storage.a_private_value.at(owner).insert(note).deliver(
-            MessageDelivery.ONCHAIN_CONSTRAINED,
+            MessageDelivery::onchain_constrained(),
         );
         new_value
     }

--- a/noir-projects/noir-contracts/contracts/test/test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/test_contract/src/main.nr
@@ -142,7 +142,7 @@ pub contract Test {
     ) {
         let note = UintNote { value };
         create_note(self.context, owner, storage_slot, note).deliver(
-            MessageDelivery.ONCHAIN_CONSTRAINED,
+            MessageDelivery::onchain_constrained(),
         );
 
         if make_tx_hybrid {
@@ -339,7 +339,7 @@ pub contract Test {
             value4: fields[4],
         };
 
-        self.emit(event).deliver_to(owner, MessageDelivery.ONCHAIN_UNCONSTRAINED);
+        self.emit(event).deliver_to(owner, MessageDelivery::onchain_unconstrained());
 
         // this contract has reached max number of functions, so using this one fn
         // to test nested and non nested encrypted logs

--- a/noir-projects/noir-contracts/contracts/test/test_log_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/test_log_contract/src/main.nr
@@ -45,17 +45,17 @@ pub contract TestLog {
     fn emit_encrypted_events(other: AztecAddress, preimages: [Field; 4]) {
         let event0 = ExampleEvent0 { value0: preimages[0], value1: preimages[1] };
 
-        self.emit(event0).deliver_to(self.msg_sender(), MessageDelivery.ONCHAIN_CONSTRAINED);
+        self.emit(event0).deliver_to(self.msg_sender(), MessageDelivery::onchain_constrained());
 
         // We duplicate the emission, but swapping the sender and recipient:
-        self.emit(event0).deliver_to(other, MessageDelivery.ONCHAIN_CONSTRAINED);
+        self.emit(event0).deliver_to(other, MessageDelivery::onchain_constrained());
 
         let event1 = ExampleEvent1 {
             value2: AztecAddress::from_field(preimages[2]),
             value3: preimages[3] as u8,
         };
 
-        self.emit(event1).deliver_to(self.msg_sender(), MessageDelivery.ONCHAIN_CONSTRAINED);
+        self.emit(event1).deliver_to(self.msg_sender(), MessageDelivery::onchain_constrained());
     }
 
     #[external("public")]
@@ -90,12 +90,12 @@ pub contract TestLog {
 
         self.emit(ExampleEvent0 { value0: random_value_0, value1: random_value_1 }).deliver_to(
             other,
-            MessageDelivery.ONCHAIN_UNCONSTRAINED,
+            MessageDelivery::onchain_unconstrained(),
         );
 
         self.emit(ExampleEvent0 { value0: random_value_2, value1: random_value_3 }).deliver_to(
             other,
-            MessageDelivery.ONCHAIN_UNCONSTRAINED,
+            MessageDelivery::onchain_unconstrained(),
         );
 
         if num_nested_calls > 0 {

--- a/noir-projects/noir-contracts/contracts/test/updatable_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/updatable_contract/src/main.nr
@@ -28,7 +28,7 @@ contract Updatable {
         let owner = self.msg_sender();
         let note = FieldNote { value: initial_value };
         self.storage.private_value.at(owner).initialize(note).deliver(
-            MessageDelivery.ONCHAIN_CONSTRAINED,
+            MessageDelivery::onchain_constrained(),
         );
         self.enqueue_self._initialize_public_value(initial_value);
     }

--- a/noir-projects/noir-contracts/contracts/test/updated_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/updated_contract/src/main.nr
@@ -28,7 +28,7 @@ contract Updated {
         let owner = self.msg_sender();
 
         self.storage.private_value.at(owner).replace(|_old| FieldNote { value: 27 }).deliver(
-            MessageDelivery.ONCHAIN_CONSTRAINED,
+            MessageDelivery::onchain_constrained(),
         );
     }
 

--- a/noir-projects/protocol-fuzzer/contracts/side_effect_contract/src/main.nr
+++ b/noir-projects/protocol-fuzzer/contracts/side_effect_contract/src/main.nr
@@ -58,7 +58,7 @@ pub contract SideEffect {
         assert(value != 0, "note value must be non-zero");
         let note = UintNote { value };
         create_note(self.context, owner, storage_slot, note).deliver(
-            MessageDelivery.ONCHAIN_CONSTRAINED,
+            MessageDelivery::onchain_constrained(),
         );
     }
 

--- a/yarn-project/aztec.js/src/contract/interaction_options.ts
+++ b/yarn-project/aztec.js/src/contract/interaction_options.ts
@@ -120,6 +120,13 @@ export type SendInteractionOptionsWithoutWait = RequestInteractionOptions & {
    * its own private notes.
    */
   additionalScopes?: AztecAddress[];
+  /**
+   * Overrides the sender address used to derive discovery tags for private messages (notes, events, logs).
+   * Recipients use these tags to find messages addressed to them.
+   *
+   * Defaults to `from`. Only needed when `from === NO_FROM`, since there is no account address to derive tags from.
+   */
+  sendMessagesAs?: AztecAddress;
 };
 
 /**

--- a/yarn-project/aztec.js/src/wallet/deploy_account_method.ts
+++ b/yarn-project/aztec.js/src/wallet/deploy_account_method.ts
@@ -23,6 +23,7 @@ import {
   type InteractionWaitOptions,
   NO_FROM,
   type ProfileInteractionOptions,
+  type SendInteractionOptionsWithoutWait,
 } from '../contract/interaction_options.js';
 import type { FeePaymentMethod } from '../fee/fee_payment_method.js';
 import { AccountEntrypointMetaPaymentMethod } from './account_entrypoint_meta_payment_method.js';
@@ -72,6 +73,12 @@ export type DeployAccountOptions<W extends InteractionWaitOptions = undefined> =
  * for account contracts that is fixed in the constructor
  */
 export type SimulateDeployAccountOptions = Omit<SimulateDeployOptions, 'contractAddressSalt'>;
+
+/** Fields from any interaction option shape that `DeployAccountMethod.prepareDeployOptions` reads or sets. */
+type DeployAccountInteractionOptions = Pick<
+  SendInteractionOptionsWithoutWait,
+  'additionalScopes' | 'from' | 'sendMessagesAs'
+>;
 
 /**
  * Modified version of the DeployMethod used to deploy account contracts. Supports deploying
@@ -184,30 +191,35 @@ export class DeployAccountMethod<TContract extends ContractBase = Contract> exte
   protected override convertDeployOptionsToSendOptions<W extends DeployInteractionWaitOptions>(
     options: DeployOptions<W>,
   ): SendOptions<W> {
-    return super.convertDeployOptionsToSendOptions(this.injectContractAddressIntoScopes(options));
+    return super.convertDeployOptionsToSendOptions(this.prepareDeployOptions(options));
   }
 
   protected override convertDeployOptionsToSimulateOptions(options: SimulateDeployOptions): SimulateOptions {
-    return super.convertDeployOptionsToSimulateOptions(this.injectContractAddressIntoScopes(options));
+    return super.convertDeployOptionsToSimulateOptions(this.prepareDeployOptions(options));
   }
 
   protected override convertDeployOptionsToProfileOptions(
     options: DeployOptionsWithoutWait & ProfileInteractionOptions,
   ): ProfileOptions {
-    return super.convertDeployOptionsToProfileOptions(this.injectContractAddressIntoScopes(options));
+    return super.convertDeployOptionsToProfileOptions(this.prepareDeployOptions(options));
   }
 
   /**
-   * Injects the contract's own address into scopes so the constructor can access its own keys.
-   * @param options - The deploy options to augment with the contract address.
+   * Augments deploy options so that the PXE has the context it needs to simulate/prove the deploy.
+   *
+   * - Injects the contract's own address into scopes so the constructor can access its own keys.
+   * - When `from === NO_FROM` (self-paid deploy), supplies the to-be-deployed address as `sendMessagesAs`. Without
+   *   this, fee-payment calls would have no sender for message tagging, and any private log they emit would fail
+   *   the "Sender for tags is not set" assertion.
+   * @param options - The deploy options to augment.
    */
-  // eslint-disable-next-line jsdoc/require-jsdoc
-  private injectContractAddressIntoScopes<T extends { additionalScopes?: AztecAddress[] }>(options: T): T {
+  private prepareDeployOptions<T extends DeployAccountInteractionOptions>(options: T): T {
     if (!this.address) {
       throw new Error('Instance not yet constructed. This is a bug!');
     }
     const existing = options.additionalScopes ?? [];
-    return { ...options, additionalScopes: [...existing, this.address] };
+    const sendMessagesAs = options.sendMessagesAs ?? (options.from === NO_FROM ? this.address : undefined);
+    return { ...options, additionalScopes: [...existing, this.address], sendMessagesAs };
   }
 
   /**

--- a/yarn-project/cli-wallet/src/utils/wallet.ts
+++ b/yarn-project/cli-wallet/src/utils/wallet.ts
@@ -100,7 +100,10 @@ export class CLIWallet extends BaseWallet {
     increasedFee: InteractionFeeOptions,
   ): Promise<TxProvingResult> {
     const cancellationTxRequest = await this.createCancellationTxExecutionRequest(from, txNonce, increasedFee);
-    return await this.pxe.proveTx(cancellationTxRequest, this.scopesFrom(from));
+    return await this.pxe.proveTx(cancellationTxRequest, {
+      scopes: this.scopesFrom(from),
+      senderForTags: from,
+    });
   }
 
   override async getAccountFromAddress(address: AztecAddress) {
@@ -235,7 +238,7 @@ export class CLIWallet extends BaseWallet {
     executionPayload: ExecutionPayload,
     opts: SimulateViaEntrypointOptions,
   ): Promise<TxSimulationResultWithAppOffset> {
-    const { from, feeOptions, additionalScopes } = opts;
+    const { from, feeOptions, additionalScopes, sendMessagesAs } = opts;
     const scopes = this.scopesFrom(from, additionalScopes);
     const feeExecutionPayload = await feeOptions.walletFeePaymentMethod?.getExecutionPayload();
     const finalExecutionPayload = feeExecutionPayload
@@ -273,6 +276,7 @@ export class CLIWallet extends BaseWallet {
       skipTxValidation: true,
       overrides,
       scopes,
+      senderForTags: this.senderForTagsFrom(from, sendMessagesAs),
     });
     const appCallOffset = await this.computeAppCallOffset(from, feeOptions);
     return TxSimulationResultWithAppOffset.fromResultAndOffset(result, appCallOffset);

--- a/yarn-project/end-to-end/src/test-wallet/test_wallet.ts
+++ b/yarn-project/end-to-end/src/test-wallet/test_wallet.ts
@@ -258,7 +258,7 @@ export class TestWallet extends BaseWallet {
     executionPayload: ExecutionPayload,
     opts: SimulateViaEntrypointOptions,
   ): Promise<TxSimulationResultWithAppOffset> {
-    const { from, feeOptions, additionalScopes, skipTxValidation, skipFeeEnforcement } = opts;
+    const { from, feeOptions, additionalScopes, skipTxValidation, skipFeeEnforcement, sendMessagesAs } = opts;
     const scopes = this.scopesFrom(from, additionalScopes);
     const skipKernels = this.simulationMode !== 'full';
     const useOverride = this.simulationMode === 'kernelless-override';
@@ -308,6 +308,7 @@ export class TestWallet extends BaseWallet {
       skipTxValidation,
       overrides,
       scopes,
+      senderForTags: this.senderForTagsFrom(from, sendMessagesAs),
     });
     const appCallOffset = await this.computeAppCallOffset(from, feeOptions);
     return TxSimulationResultWithAppOffset.fromResultAndOffset(result, appCallOffset);
@@ -320,7 +321,10 @@ export class TestWallet extends BaseWallet {
       gasSettings: opts.fee?.gasSettings,
     });
     const txRequest = await this.createTxExecutionRequestFromPayloadAndFee(exec, opts.from, fee);
-    const txProvingResult = await this.pxe.proveTx(txRequest, this.scopesFrom(opts.from, opts.additionalScopes));
+    const txProvingResult = await this.pxe.proveTx(txRequest, {
+      scopes: this.scopesFrom(opts.from, opts.additionalScopes),
+      senderForTags: this.senderForTagsFrom(opts.from, opts.sendMessagesAs),
+    });
     return new ProvenTx(
       this.aztecNode,
       await txProvingResult.toTx(),

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/interfaces.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/interfaces.ts
@@ -208,6 +208,5 @@ export interface IPrivateExecutionOracle {
   notifyRevertiblePhaseStart(minRevertibleSideEffectCounter: number): Promise<void>;
   isExecutionInRevertiblePhase(sideEffectCounter: number): Promise<boolean>;
   getSenderForTags(): Promise<AztecAddress | undefined>;
-  setSenderForTags(senderForTags: AztecAddress): Promise<void>;
   getNextAppTagAsSender(sender: AztecAddress, recipient: AztecAddress): Promise<Tag>;
 }

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/oracle.ts
@@ -852,10 +852,4 @@ export class Oracle {
     // Return [1, address] for Some(address), [0, 0] for None
     return sender ? [toACVMField(1n), toACVMField(sender)] : [toACVMField(0n), toACVMField(0n)];
   }
-
-  // eslint-disable-next-line camelcase
-  async aztec_prv_setSenderForTags([senderForTags]: ACVMField[]): Promise<ACVMField[]> {
-    await this.handlerAsPrivate().setSenderForTags(AztecAddress.fromField(Fr.fromString(senderForTags)));
-    return [];
-  }
 }

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution_oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution_oracle.ts
@@ -82,7 +82,11 @@ export class PrivateExecutionOracle extends UtilityExecutionOracle implements IP
   private readonly senderTaggingStore: SenderTaggingStore;
   private totalPublicCalldataCount: number;
   private readonly initialSideEffectCounter: number;
-  private senderForTags?: AztecAddress;
+  /**
+   * The transaction-wide sender-for-tags supplied by the wallet when building the tx. Returned as-is by
+   * `getSenderForTags` to resolve `SenderForTags::tx_default()` on the Noir side.
+   */
+  private readonly senderForTags: AztecAddress | undefined;
   private readonly simulator?: CircuitSimulator;
 
   constructor(args: PrivateExecutionOracleArgs) {
@@ -172,33 +176,13 @@ export class PrivateExecutionOracle extends UtilityExecutionOracle implements IP
   }
 
   /**
-   * Get the sender for tags.
+   * Returns the transaction-wide sender-for-tags supplied by the wallet when building the tx.
    *
-   * This unconstrained value is used as the sender when computing an unconstrained shared secret
-   * for a tag in order to emit a log. Constrained tagging should not use this as there is no
-   * guarantee that the recipient knows about the sender, and hence about the shared secret.
-   *
-   * The value persists through nested calls, meaning all calls down the stack will use the same
-   * 'senderForTags' value (unless it is replaced).
+   * Used by the Noir-side `SenderForTags::tx_default()` resolution path. Contracts that want to override the
+   * sender for a specific log pick a non-default `SenderForTags` variant at the emission site.
    */
   public getSenderForTags(): Promise<AztecAddress | undefined> {
     return Promise.resolve(this.senderForTags);
-  }
-
-  /**
-   * Set the sender for tags.
-   *
-   * This unconstrained value is used as the sender when computing an unconstrained shared secret
-   * for a tag in order to emit a log. Constrained tagging should not use this as there is no
-   * guarantee that the recipient knows about the sender, and hence about the shared secret.
-   *
-   * Account contracts typically set this value before calling other contracts. The value persists
-   * through nested calls, meaning all calls down the stack will use the same 'senderForTags'
-   * value (unless it is replaced by another call to this setter).
-   */
-  public setSenderForTags(senderForTags: AztecAddress): Promise<void> {
-    this.senderForTags = senderForTags;
-    return Promise.resolve();
   }
 
   /**

--- a/yarn-project/pxe/src/pxe.ts
+++ b/yarn-project/pxe/src/pxe.ts
@@ -89,6 +89,14 @@ export type PackedPrivateEvent = InTx & {
   eventSelector: EventSelector;
 };
 
+/** Options for PXE.proveTx. */
+export type ProveTxOpts = {
+  /** Addresses whose private state and keys are accessible during private execution. */
+  scopes: AztecAddress[];
+  /** Sender address PXE uses when deriving discovery tags for private messages (notes, events, logs) this tx emits. */
+  senderForTags?: AztecAddress;
+};
+
 /** Options for PXE.profileTx. */
 export type ProfileTxOpts = {
   /** The profiling mode to use. */
@@ -97,6 +105,8 @@ export type ProfileTxOpts = {
   skipProofGeneration?: boolean;
   /** Addresses whose private state and keys are accessible during private execution. */
   scopes: AztecAddress[];
+  /** Sender address PXE uses when deriving discovery tags for private messages (notes, events, logs) this tx emits. */
+  senderForTags?: AztecAddress;
 };
 
 /** Options for PXE.simulateTx. */
@@ -113,6 +123,8 @@ export type SimulateTxOpts = {
   overrides?: SimulationOverrides;
   /** Addresses whose private state and keys are accessible during private execution */
   scopes: AztecAddress[];
+  /** Sender address PXE uses when deriving discovery tags for private messages (notes, events, logs) this tx emits. */
+  senderForTags?: AztecAddress;
 };
 
 /** Options for PXE.executeUtility. */
@@ -368,12 +380,19 @@ export class PXE {
 
   // Executes the entrypoint private function, as well as all nested private
   // functions that might arise.
-  async #executePrivate(
-    contractFunctionSimulator: ContractFunctionSimulator,
-    txRequest: TxExecutionRequest,
-    scopes: AztecAddress[],
-    jobId: string,
-  ): Promise<PrivateExecutionResult> {
+  async #executePrivate({
+    contractFunctionSimulator,
+    txRequest,
+    scopes,
+    jobId,
+    senderForTags,
+  }: {
+    contractFunctionSimulator: ContractFunctionSimulator;
+    txRequest: TxExecutionRequest;
+    scopes: AztecAddress[];
+    jobId: string;
+    senderForTags: AztecAddress | undefined;
+  }): Promise<PrivateExecutionResult> {
     const { origin: contractAddress, functionSelector } = txRequest;
 
     try {
@@ -395,6 +414,7 @@ export class PXE {
         anchorBlockHeader,
         scopes,
         jobId,
+        senderForTags,
       });
       this.log.debug(`Private simulation completed for ${contractAddress.toString()}:${functionSelector}`);
       return result;
@@ -741,7 +761,7 @@ export class PXE {
    * @throws If contract code not found, or public simulation reverts.
    * Also throws if simulatePublic is true and public simulation reverts.
    */
-  public proveTx(txRequest: TxExecutionRequest, scopes: AztecAddress[]): Promise<TxProvingResult> {
+  public proveTx(txRequest: TxExecutionRequest, { scopes, senderForTags }: ProveTxOpts): Promise<TxProvingResult> {
     let privateExecutionResult: PrivateExecutionResult;
     // We disable proving concurrently mostly out of caution, since it accesses some of our stores. Proving is so
     // computationally demanding that it'd be rare for someone to try to do it concurrently regardless.
@@ -752,7 +772,13 @@ export class PXE {
         await this.blockStateSynchronizer.sync();
         const syncTime = syncTimer.ms();
         const contractFunctionSimulator = this.#getSimulatorForTx();
-        privateExecutionResult = await this.#executePrivate(contractFunctionSimulator, txRequest, scopes, jobId);
+        privateExecutionResult = await this.#executePrivate({
+          contractFunctionSimulator,
+          txRequest,
+          scopes,
+          jobId,
+          senderForTags,
+        });
 
         const {
           publicInputs,
@@ -822,7 +848,7 @@ export class PXE {
    */
   public profileTx(
     txRequest: TxExecutionRequest,
-    { profileMode, skipProofGeneration = true, scopes }: ProfileTxOpts,
+    { profileMode, skipProofGeneration = true, scopes, senderForTags }: ProfileTxOpts,
   ): Promise<TxProfileResult> {
     // We disable concurrent profiles for consistency with simulateTx.
     return this.#putInJobQueue(async jobId => {
@@ -845,7 +871,13 @@ export class PXE {
         const syncTime = syncTimer.ms();
 
         const contractFunctionSimulator = this.#getSimulatorForTx();
-        const privateExecutionResult = await this.#executePrivate(contractFunctionSimulator, txRequest, scopes, jobId);
+        const privateExecutionResult = await this.#executePrivate({
+          contractFunctionSimulator,
+          txRequest,
+          scopes,
+          jobId,
+          senderForTags,
+        });
 
         const { executionSteps, timings: { proving } = {} } = await this.#prove(
           txRequest,
@@ -918,6 +950,7 @@ export class PXE {
       skipKernels = true,
       overrides,
       scopes,
+      senderForTags,
     }: SimulateTxOpts,
   ): Promise<TxSimulationResult> {
     // We disable concurrent simulations since those might execute oracles which read and write to the PXE stores (e.g.
@@ -959,7 +992,13 @@ export class PXE {
         }
 
         // Execution of private functions only; no proving, and no kernel logic.
-        const privateExecutionResult = await this.#executePrivate(contractFunctionSimulator, txRequest, scopes, jobId);
+        const privateExecutionResult = await this.#executePrivate({
+          contractFunctionSimulator,
+          txRequest,
+          scopes,
+          jobId,
+          senderForTags,
+        });
 
         let publicInputs: PrivateKernelTailCircuitPublicInputs | undefined;
         let executionSteps: PrivateExecutionStep[] = [];

--- a/yarn-project/txe/src/rpc_translator.ts
+++ b/yarn-project/txe/src/rpc_translator.ts
@@ -1352,15 +1352,6 @@ export class RPCTranslator {
   }
 
   // eslint-disable-next-line camelcase
-  async aztec_prv_setSenderForTags(foreignSenderForTags: ForeignCallSingle) {
-    const senderForTags = AztecAddress.fromField(fromSingle(foreignSenderForTags));
-
-    await this.handlerAsPrivate().setSenderForTags(senderForTags);
-
-    return toForeignCallResult([]);
-  }
-
-  // eslint-disable-next-line camelcase
   async aztec_prv_getNextAppTagAsSender(foreignSender: ForeignCallSingle, foreignRecipient: ForeignCallSingle) {
     const sender = AztecAddress.fromField(fromSingle(foreignSender));
     const recipient = AztecAddress.fromField(fromSingle(foreignRecipient));

--- a/yarn-project/wallet-sdk/src/base-wallet/base_wallet.ts
+++ b/yarn-project/wallet-sdk/src/base-wallet/base_wallet.ts
@@ -85,7 +85,7 @@ export type FeeOptions = {
 /** Options for `simulateViaEntrypoint`. */
 export type SimulateViaEntrypointOptions = Pick<
   SimulateOptions,
-  'from' | 'additionalScopes' | 'skipTxValidation' | 'skipFeeEnforcement'
+  'from' | 'additionalScopes' | 'skipTxValidation' | 'skipFeeEnforcement' | 'sendMessagesAs'
 > & {
   /** Fee options for the entrypoint */
   feeOptions: FeeOptions;
@@ -129,6 +129,16 @@ export abstract class BaseWallet implements Wallet {
     const allScopes = from === NO_FROM ? additionalScopes : [from, ...additionalScopes];
     const scopeSet = new Set(allScopes.map(address => address.toString()));
     return [...scopeSet].map(AztecAddress.fromString);
+  }
+
+  /**
+   * Picks the sender address PXE should tag private messages with. Returns `undefined` when there is no signing
+   * account (`from === NO_FROM`) and no explicit override.
+   * @param from - Tx sender, or `NO_FROM`.
+   * @param sendMessagesAs - Explicit override.
+   */
+  protected senderForTagsFrom(from: AztecAddress | NoFrom, sendMessagesAs?: AztecAddress): AztecAddress | undefined {
+    return sendMessagesAs ?? (from === NO_FROM ? undefined : from);
   }
 
   protected abstract getAccountFromAddress(address: AztecAddress): Promise<Account>;
@@ -353,6 +363,7 @@ export abstract class BaseWallet implements Wallet {
       skipTxValidation: opts.skipTxValidation,
       skipFeeEnforcement: opts.skipFeeEnforcement,
       scopes: this.scopesFrom(opts.from, opts.additionalScopes),
+      senderForTags: this.senderForTagsFrom(opts.from, opts.sendMessagesAs),
     });
     const appCallOffset = await this.computeAppCallOffset(opts.from, opts.feeOptions);
     return TxSimulationResultWithAppOffset.fromResultAndOffset(result, appCallOffset);
@@ -425,6 +436,7 @@ export abstract class BaseWallet implements Wallet {
             additionalScopes: opts.additionalScopes,
             skipTxValidation: opts.skipTxValidation,
             skipFeeEnforcement: opts.skipFeeEnforcement ?? true,
+            sendMessagesAs: opts.sendMessagesAs,
           })
         : Promise.resolve(null),
     ]);
@@ -444,6 +456,7 @@ export abstract class BaseWallet implements Wallet {
       profileMode: opts.profileMode,
       skipProofGeneration: opts.skipProofGeneration ?? true,
       scopes: this.scopesFrom(opts.from, opts.additionalScopes),
+      senderForTags: this.senderForTagsFrom(opts.from, opts.sendMessagesAs),
     });
   }
 
@@ -458,7 +471,10 @@ export abstract class BaseWallet implements Wallet {
       congestionEstimate: opts.fee?.congestionEstimate,
     });
     const txRequest = await this.createTxExecutionRequestFromPayloadAndFee(executionPayload, opts.from, feeOptions);
-    const provenTx = await this.pxe.proveTx(txRequest, this.scopesFrom(opts.from, opts.additionalScopes));
+    const provenTx = await this.pxe.proveTx(txRequest, {
+      scopes: this.scopesFrom(opts.from, opts.additionalScopes),
+      senderForTags: this.senderForTagsFrom(opts.from, opts.sendMessagesAs),
+    });
     const offchainOutput = extractOffchainOutput(
       provenTx.getOffchainEffects(),
       provenTx.publicInputs.constants.anchorBlockHeader.globalVariables.timestamp,

--- a/yarn-project/wallets/src/embedded/embedded_wallet.ts
+++ b/yarn-project/wallets/src/embedded/embedded_wallet.ts
@@ -239,7 +239,7 @@ export class EmbeddedWallet extends BaseWallet {
     executionPayload: ExecutionPayload,
     opts: SimulateViaEntrypointOptions,
   ): Promise<TxSimulationResultWithAppOffset> {
-    const { from, feeOptions, additionalScopes, skipTxValidation, skipFeeEnforcement } = opts;
+    const { from, feeOptions, additionalScopes, skipTxValidation, skipFeeEnforcement, sendMessagesAs } = opts;
     const scopes = this.scopesFrom(from, additionalScopes);
 
     const feeExecutionPayload = await feeOptions.walletFeePaymentMethod?.getExecutionPayload();
@@ -280,6 +280,7 @@ export class EmbeddedWallet extends BaseWallet {
       skipTxValidation,
       overrides,
       scopes,
+      senderForTags: this.senderForTagsFrom(from, sendMessagesAs),
     });
     const appCallOffset = await this.computeAppCallOffset(from, feeOptions);
     return TxSimulationResultWithAppOffset.fromResultAndOffset(result, appCallOffset);


### PR DESCRIPTION
## Problem

Private log discovery relies on a sender-recipient shared secret: the sender tags a log so the recipient can find it by scanning for known tags. The sender identity used for this came from `set_sender_for_tags`, TX-wide mutable state that any contract in the call stack could overwrite — silently redirecting all subsequent tag derivation to an arbitrary address.

#22672 addressed this by scoping `set_sender_for_tags` overrides to the calling contract only, so they no longer leak to subcalls. The wallet also gained a `sendMessagesAs` option to seed the sender before execution begins. This fixed the trust issue, but `set_sender_for_tags` remained as ambient global state. The sender used for any given log was determined by a side-effecting call somewhere else in the call stack, rather than at the emission site — making transaction flows hard to reason about.

## Our fix

This PR takes a different approach: instead of scoping ambient state, we eliminate it. `set_sender_for_tags` is removed entirely. Sender selection moves to the log emission site via a new `SenderForTags` struct passed directly to `MessageDelivery`:

- `SenderForTags::explicit(address)` — for call sites that know their sender (e.g. account contracts tagging their own notes)
- `SenderForTags::tx_default()` — for application contracts that delegate sender selection to the wallet; reads from the oracle the wallet seeds via `sendMessagesAs`

`MessageDelivery` is refactored from a global constant struct with `u8` fields to a proper struct type with named constructors (`MessageDelivery::offchain()`, `MessageDelivery::onchain_constrained()`, etc.). On-chain variants accept an optional `SenderForTags` override via `_with_sender` constructors, giving call sites explicit per-log control over which sender is used for tag derivation. This also gives us more flexibility for future features — for example, using a different sender identity per message type, or integrating handshake-based tagging when constrained tagging lands (#14565).

The wallet-side `sendMessagesAs` option from #22672 is preserved. `DeployAccountMethod` injects the to-be-deployed address as `sendMessagesAs` for `NO_FROM` self-paid deploys, so fee-payment calls have a sender even without an account entrypoint.

## Breaking changes

- `MessageDelivery.OFFCHAIN` → `MessageDelivery::offchain()`, same for `ONCHAIN_UNCONSTRAINED` and `ONCHAIN_CONSTRAINED`
- `NoteMessage::deliver(u8)` / `deliver_to(addr, u8)` → takes `MessageDelivery` instead of `u8`
- `EventMessage::deliver_to(addr, u8)` → same
- `set_sender_for_tags` oracle removed; account contracts use `SenderForTags::explicit(self.address)` at the emission site instead

This is not ready to merge as-is — posting for early feedback on the approach before we go further.

Fixes F-564