### PR TITLE
fix(aztec-cli): release TXE port and kill bb children on shutdown

### DIFF
--- a/yarn-project/aztec/scripts/aztec.sh
+++ b/yarn-project/aztec/scripts/aztec.sh
@@ -24,18 +24,9 @@ case $cmd in
     node --no-warnings "$script_dir/../dest/bin/index.js" compile
 
     export LOG_LEVEL="${LOG_LEVEL:-"error;trace:contract"}"
-    # Enable job control so the backgrounded TXE gets its own process group.
-    # Signalling the group on cleanup reaches node + any bb descendants, which
-    # otherwise get orphaned to init and keep the port bound after Ctrl-C.
-    set -m
     aztec start --txe --port 8081 &
     server_pid=$!
-    set +m
-    function cleanup {
-      kill -TERM -- "-$server_pid" &>/dev/null || true
-      wait "$server_pid" 2>/dev/null || true
-    }
-    trap cleanup EXIT
+    trap 'kill $server_pid &>/dev/null || true' EXIT
     if ! command -v nc &>/dev/null; then
       echo "Error: 'nc' (netcat) is required but not installed." >&2
       exit 1

--- a/yarn-project/aztec/scripts/aztec.sh
+++ b/yarn-project/aztec/scripts/aztec.sh
@@ -24,9 +24,23 @@ case $cmd in
     node --no-warnings "$script_dir/../dest/bin/index.js" compile
 
     export LOG_LEVEL="${LOG_LEVEL:-"error;trace:contract"}"
+    # Enable job control so the backgrounded TXE gets its own process group.
+    # Signalling the group on cleanup reaches node + any bb descendants, which
+    # otherwise get orphaned to init and keep port 8081 bound after Ctrl-C.
+    set -m
     aztec start --txe --port 8081 &
     server_pid=$!
-    trap 'kill $server_pid &>/dev/null || true' EXIT
+    set +m
+    cleanup() {
+      kill -s TERM -- "-$server_pid" 2>/dev/null || true
+      for _ in 1 2 3 4 5; do
+        kill -s 0 -- "-$server_pid" 2>/dev/null || break
+        sleep 0.2
+      done
+      kill -s KILL -- "-$server_pid" 2>/dev/null || true
+      wait "$server_pid" 2>/dev/null || true
+    }
+    trap cleanup EXIT INT TERM HUP
     if ! command -v nc &>/dev/null; then
       echo "Error: 'nc' (netcat) is required but not installed." >&2
       exit 1

--- a/yarn-project/aztec/scripts/aztec.sh
+++ b/yarn-project/aztec/scripts/aztec.sh
@@ -31,16 +31,11 @@ case $cmd in
     aztec start --txe --port 8081 &
     server_pid=$!
     set +m
-    cleanup() {
-      kill -s TERM -- "-$server_pid" 2>/dev/null || true
-      for _ in 1 2 3 4 5; do
-        kill -s 0 -- "-$server_pid" 2>/dev/null || break
-        sleep 0.2
-      done
-      kill -s KILL -- "-$server_pid" 2>/dev/null || true
+    function cleanup {
+      kill -TERM -- "-$server_pid" &>/dev/null || true
       wait "$server_pid" 2>/dev/null || true
     }
-    trap cleanup EXIT INT TERM HUP
+    trap cleanup EXIT
     if ! command -v nc &>/dev/null; then
       echo "Error: 'nc' (netcat) is required but not installed." >&2
       exit 1

--- a/yarn-project/aztec/scripts/aztec.sh
+++ b/yarn-project/aztec/scripts/aztec.sh
@@ -26,7 +26,7 @@ case $cmd in
     export LOG_LEVEL="${LOG_LEVEL:-"error;trace:contract"}"
     # Enable job control so the backgrounded TXE gets its own process group.
     # Signalling the group on cleanup reaches node + any bb descendants, which
-    # otherwise get orphaned to init and keep port 8081 bound after Ctrl-C.
+    # otherwise get orphaned to init and keep the port bound after Ctrl-C.
     set -m
     aztec start --txe --port 8081 &
     server_pid=$!

--- a/yarn-project/aztec/src/cli/aztec_start_action.ts
+++ b/yarn-project/aztec/src/cli/aztec_start_action.ts
@@ -81,7 +81,7 @@ export async function aztecStart(options: any, userLog: LogFn, debugLogger: Logg
       await startProverBroker(options, signalHandlers, services, userLog);
     } else if (options.txe) {
       const { startTXE } = await import('./cmds/start_txe.js');
-      await startTXE(options, debugLogger);
+      await startTXE(options, signalHandlers, debugLogger);
     } else if (options.sequencer) {
       userLog(`Cannot run a standalone sequencer without a node`);
       process.exit(1);

--- a/yarn-project/aztec/src/cli/cmds/start_txe.ts
+++ b/yarn-project/aztec/src/cli/cmds/start_txe.ts
@@ -2,14 +2,16 @@ import { startHttpRpcServer } from '@aztec/foundation/json-rpc/server';
 import type { Logger } from '@aztec/foundation/log';
 import { createTXERpcServer } from '@aztec/txe';
 
-export async function startTXE(options: any, debugLogger: Logger) {
+export async function startTXE(options: any, signalHandlers: Array<() => Promise<void>>, debugLogger: Logger) {
   debugLogger.info(`Setting up TXE...`);
 
   const txeServer = createTXERpcServer(debugLogger);
-  const { port } = await startHttpRpcServer(txeServer, {
+  const httpServer = await startHttpRpcServer(txeServer, {
     port: options.port,
     timeoutMs: 1e3 * 60 * 5,
   });
 
-  debugLogger.info(`TXE listening on port ${port}`);
+  signalHandlers.push(() => new Promise<void>(resolve => httpServer.close(() => resolve())));
+
+  debugLogger.info(`TXE listening on port ${httpServer.port}`);
 }

--- a/yarn-project/bb-prover/src/bb/execute.ts
+++ b/yarn-project/bb-prover/src/bb/execute.ts
@@ -103,6 +103,16 @@ export function executeBB(
       }, timeout);
     }
 
+    // Forward termination signals so bb doesn't survive as an orphan when the node parent exits.
+    const forwardSignal = (signal: NodeJS.Signals) => {
+      if (bb.pid) {
+        bb.kill(signal);
+      }
+    };
+    process.on('SIGINT', forwardSignal);
+    process.on('SIGTERM', forwardSignal);
+    process.on('SIGHUP', forwardSignal);
+
     readline.createInterface({ input: bb.stdout }).on('line', logger);
     readline.createInterface({ input: bb.stderr }).on('line', logger);
 
@@ -110,6 +120,9 @@ export function executeBB(
       if (timeoutId) {
         clearTimeout(timeoutId);
       }
+      process.off('SIGINT', forwardSignal);
+      process.off('SIGTERM', forwardSignal);
+      process.off('SIGHUP', forwardSignal);
       if (resultParser(exitCode)) {
         resolve({ status: BB_RESULT.SUCCESS, exitCode, signal });
       } else {


### PR DESCRIPTION
## Summary

Ctrl-C (or any SIGINT/SIGTERM) during `aztec test` could leave the TXE node still listening on its port and in-flight `bb` children still running, blocking subsequent runs with `EADDRINUSE`. Fixes #22725.

## Why it happens

Two gaps in the TXE shutdown path:

1. `startTXE` (`yarn-project/aztec/src/cli/cmds/start_txe.ts`) bound the HTTP listener but registered **no** shutdown callback with the outer `signalHandlers` array that `aztecStart` passes to `installSignalHandlers` (`yarn-project/aztec/src/cli/aztec_start_action.ts:94`). Every other `start*` function in that file (`startNode`, `startBot`, `startArchiver`, `startP2PBootstrap`, `startProverAgent`, `startProverBroker`) already wires itself in this way — TXE was the odd one out. The listener could outlive `process.exit` under adversarial timing and hold the port.
2. `executeBB` (`yarn-project/bb-prover/src/bb/execute.ts:90`) spawned `bb` with no signal plumbing. If the node parent received SIGINT/SIGTERM, those signals were not propagated to `bb`, so the child became an orphan under init.

## Changes

- **`startTXE`**: accept `signalHandlers`, push `() => httpServer.close()` so the port is released cleanly on SIGINT/SIGTERM. Brings TXE in line with the other `start*` functions.
- **`aztec_start_action`**: pass `signalHandlers` into `startTXE`.
- **`executeBB`**: forward SIGINT/SIGTERM/SIGHUP to the spawned `bb` child, removing the handlers on close so they don't leak across calls.

## Test plan

- [x] `yarn build` passes for touched packages.
- [x] `yarn format` + `yarn lint` clean for `aztec` and `bb-prover`.
- [ ] Manual: run `aztec test --workspace`, Ctrl-C mid-run, confirm no orphaned `node`/`bb` processes and that re-running starts cleanly.
- [ ] Manual: `pkill -TERM -f 'aztec start --txe'` mid-run, same check.