### PR TITLE
fix: use actual size in logderiv inverse calc to fix regression

### DIFF
--- a/barretenberg/cpp/src/barretenberg/eccvm/eccvm.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/eccvm/eccvm.test.cpp
@@ -150,7 +150,7 @@ void complete_proving_key_for_test(bb::RelationParameters<FF>& relation_paramete
     // Compute z_perm and inverse polynomial for our logarithmic-derivative lookup method
     // Skip the disabled head region to preserve masking values
     compute_logderivative_inverse<FF, ECCVMFlavor::LookupRelation, ECCVMFlavor::ProverPolynomials, true>(
-        pk->polynomials, relation_parameters, pk->circuit_size, ECCVMFlavor::TRACE_OFFSET);
+        pk->polynomials, relation_parameters, ECCVMFlavor::TRACE_OFFSET);
     compute_grand_products<ECCVMFlavor>(pk->polynomials, relation_parameters);
 
     // Generate gate challenges

--- a/barretenberg/cpp/src/barretenberg/eccvm/eccvm_prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/eccvm/eccvm_prover.cpp
@@ -105,7 +105,7 @@ void ECCVMProver::execute_log_derivative_commitments_round()
     compute_logderivative_inverse<typename Flavor::FF,
                                   typename Flavor::LookupRelation,
                                   typename Flavor::ProverPolynomials,
-                                  true>(key->polynomials, relation_parameters, key->circuit_size, Flavor::TRACE_OFFSET);
+                                  true>(key->polynomials, relation_parameters, Flavor::TRACE_OFFSET);
     auto& li = key->polynomials.lookup_inverses;
     transcript->send_to_verifier(commitment_labels.lookup_inverses, key->commitment_key.commit(li));
 }

--- a/barretenberg/cpp/src/barretenberg/eccvm/eccvm_relation_corruption.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/eccvm/eccvm_relation_corruption.test.cpp
@@ -119,8 +119,7 @@ RelationParameters<FF> compute_full_relation_params(ProverPolynomials& polynomia
         .eccvm_set_permutation_delta = eccvm_set_permutation_delta,
     };
 
-    const size_t num_rows = polynomials.get_polynomial_size();
-    compute_logderivative_inverse<FF, ECCVMLookupRelation<FF>>(polynomials, params, num_rows, Flavor::TRACE_OFFSET);
+    compute_logderivative_inverse<FF, ECCVMLookupRelation<FF>>(polynomials, params, Flavor::TRACE_OFFSET);
     compute_grand_product<Flavor, ECCVMSetRelation<FF>>(polynomials, params);
     polynomials.z_perm_shift = Polynomial(polynomials.z_perm.shifted());
 

--- a/barretenberg/cpp/src/barretenberg/eccvm/eccvm_trace_checker.cpp
+++ b/barretenberg/cpp/src/barretenberg/eccvm/eccvm_trace_checker.cpp
@@ -45,7 +45,7 @@ bool ECCVMTraceChecker::check(Builder& builder,
 #endif
     const size_t num_rows = polynomials.get_polynomial_size();
     // Skip the disabled head region to preserve masking values
-    compute_logderivative_inverse<FF, ECCVMLookupRelation<FF>>(polynomials, params, num_rows, Flavor::TRACE_OFFSET);
+    compute_logderivative_inverse<FF, ECCVMLookupRelation<FF>>(polynomials, params, Flavor::TRACE_OFFSET);
     compute_grand_product<Flavor, ECCVMSetRelation<FF>>(polynomials, params);
 
     polynomials.z_perm_shift = Polynomial(polynomials.z_perm.shifted());

--- a/barretenberg/cpp/src/barretenberg/honk/proof_system/logderivative_library.hpp
+++ b/barretenberg/cpp/src/barretenberg/honk/proof_system/logderivative_library.hpp
@@ -30,10 +30,7 @@ namespace bb {
  *
  */
 template <typename FF, typename Relation, typename Polynomials, bool UseMultithreading = false>
-void compute_logderivative_inverse(Polynomials& polynomials,
-                                   auto& relation_parameters,
-                                   const size_t circuit_size,
-                                   const size_t start_index = 0)
+void compute_logderivative_inverse(Polynomials& polynomials, auto& relation_parameters, const size_t start_index = 0)
 {
     using Accumulator = typename Relation::ValueAccumulator0;
     constexpr size_t NUM_LOOKUP_TERMS = Relation::NUM_LOOKUP_TERMS;
@@ -43,7 +40,6 @@ void compute_logderivative_inverse(Polynomials& polynomials,
     const size_t offset = std::max(inverse_polynomial.start_index(), start_index);
     // Clamp to the polynomial's actual (non-virtual) data extent; beyond end_index() everything is virtual zero.
     const size_t actual_size = inverse_polynomial.end_index() > offset ? inverse_polynomial.end_index() - offset : 0;
-    (void)circuit_size;
     const auto compute_inverses = [&](size_t start, size_t end) {
         for (size_t i = start; i < end; ++i) {
             const size_t row_idx = i + offset;

--- a/barretenberg/cpp/src/barretenberg/honk/proof_system/logderivative_library.hpp
+++ b/barretenberg/cpp/src/barretenberg/honk/proof_system/logderivative_library.hpp
@@ -41,9 +41,9 @@ void compute_logderivative_inverse(Polynomials& polynomials,
 
     auto& inverse_polynomial = Relation::get_inverse_polynomial(polynomials);
     const size_t offset = std::max(inverse_polynomial.start_index(), start_index);
-    const size_t num_rows = circuit_size - offset;
     // Clamp to the polynomial's actual (non-virtual) data extent; beyond end_index() everything is virtual zero.
     const size_t actual_size = inverse_polynomial.end_index() > offset ? inverse_polynomial.end_index() - offset : 0;
+    (void)circuit_size;
     const auto compute_inverses = [&](size_t start, size_t end) {
         for (size_t i = start; i < end; ++i) {
             const size_t row_idx = i + offset;
@@ -66,19 +66,16 @@ void compute_logderivative_inverse(Polynomials& polynomials,
             });
             inverse_polynomial.at(row_idx) = denominator;
         }
-        // Batch invert only the range we wrote to, clamped to actual (non-virtual) data
-        const size_t clamped_start = std::min(start, actual_size);
-        const size_t clamped_end = std::min(end, actual_size);
-        if (clamped_start < clamped_end) {
-            FF* ffstart = &inverse_polynomial.data()[clamped_start + offset - inverse_polynomial.start_index()];
-            std::span<FF> to_invert(ffstart, clamped_end - clamped_start);
+        if (start < end) {
+            FF* ffstart = &inverse_polynomial.data()[start + offset - inverse_polynomial.start_index()];
+            std::span<FF> to_invert(ffstart, end - start);
             // Note: zeroes are ignored as they are not used anyway
             FF::batch_invert(to_invert);
         }
     };
     if constexpr (UseMultithreading) {
         parallel_for([&](const ThreadChunk& chunk) {
-            auto range = chunk.range(num_rows);
+            auto range = chunk.range(actual_size);
             if (!range.empty()) {
                 size_t start = *range.begin();
                 size_t end = start + range.size();
@@ -86,7 +83,7 @@ void compute_logderivative_inverse(Polynomials& polynomials,
             }
         });
     } else {
-        compute_inverses(0, num_rows);
+        compute_inverses(0, actual_size);
     }
 }
 

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/check_circuit.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/check_circuit.cpp
@@ -81,7 +81,7 @@ void run_check_circuit(AvmFlavor::ProverPolynomials& polys, size_t num_rows, boo
                                           Relation::Settings::DST_SELECTOR);
 
             // Compute logderivs.
-            bb::compute_logderivative_inverse<typename AvmFlavor::FF, Relation>(polys, params, num_rows);
+            bb::compute_logderivative_inverse<typename AvmFlavor::FF, Relation>(polys, params);
 
             // Check the logderivative relation
             typename Relation::SumcheckArrayOfValuesOverSubrelations lookup_result{};

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/prover.cpp
@@ -129,7 +129,7 @@ void AvmProver::execute_log_derivative_inverse_round()
 
             AVM_TRACK_TIME(std::string("prove/log_derivative_inverse_round/") + std::string(Relation::NAME),
                            (compute_logderivative_inverse<FF, Relation, Flavor::ProverPolynomials, false>(
-                               prover_polynomials, relation_parameters, ProvingKey::circuit_size)));
+                               prover_polynomials, relation_parameters)));
         });
     });
 


### PR DESCRIPTION
Fixes accidentally introduces dyadic size dependence in log-deriv inverse calculation