### PR TITLE
chore: dont zero memory in sumcheck and Gemini

### DIFF
--- a/barretenberg/cpp/src/barretenberg/commitment_schemes/gemini/gemini_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/commitment_schemes/gemini/gemini_impl.hpp
@@ -130,7 +130,10 @@ std::vector<typename GeminiProver_<Curve>::Polynomial> GeminiProver_<Curve>::com
         const size_t fold_size = (actual_size + 1) / 2;
 
         // A_l_fold = Aₗ₊₁(X) = (1-uₗ)⋅even(Aₗ)(X) + uₗ⋅odd(Aₗ)(X)
-        fold_polynomials.emplace_back(Polynomial(fold_size));
+        // Skip zero-init: the fold loop below writes every index in [0, fold_size) exactly once
+        // (num_pairs iterations + the actual_size-odd tail).
+        fold_polynomials.emplace_back(
+            Polynomial(fold_size, fold_size, /*start_index=*/0, Polynomial::DontZeroMemory::FLAG));
         actual_size = fold_size;
     }
 

--- a/barretenberg/cpp/src/barretenberg/flavor/partially_evaluated_multivariates.hpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/partially_evaluated_multivariates.hpp
@@ -33,7 +33,9 @@ class PartiallyEvaluatedMultivariatesBase : public AllEntitiesBase {
         for (auto [poly, full_poly] : zip_view(this->get_all(), full_polynomials.get_all())) {
             // After the initial sumcheck round, the new size is CEIL(size/2).
             size_t desired_size = (full_poly.end_index() / 2) + (full_poly.end_index() % 2);
-            poly = Polynomial(desired_size, circuit_size / 2);
+            // Skip zero-init: every allocated coefficient is overwritten by Sumcheck::partially_evaluate
+            // before any read (writes dest[i>>1] for i=0,2,...,end_index-1, covering [0, desired_size)).
+            poly = Polynomial(desired_size, circuit_size / 2, /*start_index=*/0, Polynomial::DontZeroMemory::FLAG);
         }
     }
 };


### PR DESCRIPTION
Don't zero Polynomial memory in Sumcheck just before partially evaluate and Gemini folding