### PR TITLE
docs: update testnet to v4.2.0 and trim AI tooling guide

### DIFF
--- a/docs/developer_version_config.json
+++ b/docs/developer_version_config.json
@@ -1,3 +1,4 @@
 {
-  "mainnet": "v4.2.0"
+  "mainnet": "v4.2.0",
+  "testnet": "v4.2.0"
 }

--- a/docs/developer_versioned_docs/version-v4.2.0/ai_tooling.md
+++ b/docs/developer_versioned_docs/version-v4.2.0/ai_tooling.md
@@ -65,14 +65,7 @@ Start here if you're unsure what to set up.
 
 ### Claude Code
 
-Install the Aztec and Noir plugins from the marketplace. These include the MCP servers plus additional skills, commands, and agents:
-
-```bash
-/plugin marketplace add critesjosh/aztec-claude-plugin
-/plugin install aztec@aztec-plugins
-```
-
-Or add the MCP servers directly:
+Add the MCP servers directly:
 
 ```bash
 claude mcp add aztec -- npx @aztec/mcp-server@latest
@@ -126,11 +119,10 @@ These resources help you understand Aztec concepts, read docs, or provide additi
 
 ## Aztec and Noir tool reference
 
-| Tool                                                                        | Works with                                            | Description                                                                            |
-| --------------------------------------------------------------------------- | ----------------------------------------------------- | -------------------------------------------------------------------------------------- |
-| [aztec-claude-plugin](https://github.com/critesjosh/aztec-claude-plugin)    | Claude Code                                           | Skills, commands, agents, and MCP server for Aztec contract and TypeScript development |
-| [@aztec/mcp-server](https://github.com/AztecProtocol/mcp-server)            | Any MCP client (Claude Code, Cursor, Windsurf, Codex) | Clones Aztec repos locally, provides code search, doc search, and example discovery    |
-| [noir-claude-plugin](https://github.com/critesjosh/noir-claude-plugin)      | Claude Code                                           | Skills and commands for Noir circuit development                                       |
-| [noir-mcp-server](https://github.com/critesjosh/noir-mcp-server)            | Any MCP client                                        | Clones Noir repos, stdlib, and community libraries; provides search and examples       |
-| [aztec-skills](https://github.com/NethermindEth/aztec-skills)               | Claude Code, Codex                                    | Installable skills for Aztec contracts, deployment, Aztec.js, and testing              |
-| [noir skills](https://github.com/noir-lang/noir/tree/master/.claude/skills) | Claude Code, Codex                                    | Skills for Noir compiler development, SSA debugging, fuzzing, and ACIR optimization    |
+| Tool                                                                        | Works with                                            | Description                                                                         |
+| --------------------------------------------------------------------------- | ----------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| [@aztec/mcp-server](https://github.com/AztecProtocol/mcp-server)            | Any MCP client (Claude Code, Cursor, Windsurf, Codex) | Clones Aztec repos locally, provides code search, doc search, and example discovery |
+| [noir-claude-plugin](https://github.com/critesjosh/noir-claude-plugin)      | Claude Code                                           | Skills and commands for Noir circuit development                                    |
+| [noir-mcp-server](https://github.com/critesjosh/noir-mcp-server)            | Any MCP client                                        | Clones Noir repos, stdlib, and community libraries; provides search and examples    |
+| [aztec-skills](https://github.com/NethermindEth/aztec-skills)               | Claude Code, Codex                                    | Installable skills for Aztec contracts, deployment, Aztec.js, and testing           |
+| [noir skills](https://github.com/noir-lang/noir/tree/master/.claude/skills) | Claude Code, Codex                                    | Skills for Noir compiler development, SSA debugging, fuzzing, and ACIR optimization |

--- a/docs/developer_versioned_docs/version-v4.2.0/getting_started_on_testnet.md
+++ b/docs/developer_versioned_docs/version-v4.2.0/getting_started_on_testnet.md
@@ -32,11 +32,11 @@ If you want to develop and iterate quickly, start with the [local network guide]
 Install the testnet version of the Aztec CLI:
 
 ```bash
-VERSION=4.2.0-aztecnr-rc.2 bash -i <(curl -sL https://install.aztec.network/4.2.0-aztecnr-rc.2)
+VERSION=4.2.0 bash -i <(curl -sL https://install.aztec.network/4.2.0)
 ```
 
 :::warning
-Testnet is version-dependent. It is currently running version `4.2.0-aztecnr-rc.2`. Maintain version consistency when interacting with the testnet to avoid errors.
+Testnet is version-dependent. It is currently running version `4.2.0`. Maintain version consistency when interacting with the testnet to avoid errors.
 :::
 
 This installs:
@@ -80,7 +80,7 @@ aztec-wallet create-account \
 ```
 
 :::note
-The first transaction will take longer as it downloads proving keys. If you see `Timeout awaiting isMined`, the transaction is still processing — this is normal on testnet.
+The first transaction will take longer as it downloads proving keys. If you see `Timeout awaiting isMined`, the transaction is still processing: this is normal on testnet.
 :::
 
 ### Step 4: Deploy a contract

--- a/docs/docs-developers/ai_tooling.md
+++ b/docs/docs-developers/ai_tooling.md
@@ -69,14 +69,7 @@ Start here if you're unsure what to set up.
 
 ### Claude Code
 
-Install the Aztec and Noir plugins from the marketplace. These include the MCP servers plus additional skills, commands, and agents:
-
-```bash
-/plugin marketplace add critesjosh/aztec-claude-plugin
-/plugin install aztec@aztec-plugins
-```
-
-Or add the MCP servers directly:
+Add the MCP servers directly:
 
 ```bash
 claude mcp add aztec -- npx @aztec/mcp-server@latest
@@ -130,11 +123,10 @@ These resources help you understand Aztec concepts, read docs, or provide additi
 
 ## Aztec and Noir tool reference
 
-| Tool                                                                        | Works with                                            | Description                                                                            |
-| --------------------------------------------------------------------------- | ----------------------------------------------------- | -------------------------------------------------------------------------------------- |
-| [aztec-claude-plugin](https://github.com/critesjosh/aztec-claude-plugin)    | Claude Code                                           | Skills, commands, agents, and MCP server for Aztec contract and TypeScript development |
-| [@aztec/mcp-server](https://github.com/AztecProtocol/mcp-server)            | Any MCP client (Claude Code, Cursor, Windsurf, Codex) | Clones Aztec repos locally, provides code search, doc search, and example discovery    |
-| [noir-claude-plugin](https://github.com/critesjosh/noir-claude-plugin)      | Claude Code                                           | Skills and commands for Noir circuit development                                       |
-| [noir-mcp-server](https://github.com/critesjosh/noir-mcp-server)            | Any MCP client                                        | Clones Noir repos, stdlib, and community libraries; provides search and examples       |
-| [aztec-skills](https://github.com/NethermindEth/aztec-skills)               | Claude Code, Codex                                    | Installable skills for Aztec contracts, deployment, Aztec.js, and testing              |
-| [noir skills](https://github.com/noir-lang/noir/tree/master/.claude/skills) | Claude Code, Codex                                    | Skills for Noir compiler development, SSA debugging, fuzzing, and ACIR optimization    |
+| Tool                                                                        | Works with                                            | Description                                                                         |
+| --------------------------------------------------------------------------- | ----------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| [@aztec/mcp-server](https://github.com/AztecProtocol/mcp-server)            | Any MCP client (Claude Code, Cursor, Windsurf, Codex) | Clones Aztec repos locally, provides code search, doc search, and example discovery |
+| [noir-claude-plugin](https://github.com/critesjosh/noir-claude-plugin)      | Claude Code                                           | Skills and commands for Noir circuit development                                    |
+| [noir-mcp-server](https://github.com/critesjosh/noir-mcp-server)            | Any MCP client                                        | Clones Noir repos, stdlib, and community libraries; provides search and examples    |
+| [aztec-skills](https://github.com/NethermindEth/aztec-skills)               | Claude Code, Codex                                    | Installable skills for Aztec contracts, deployment, Aztec.js, and testing           |
+| [noir skills](https://github.com/noir-lang/noir/tree/master/.claude/skills) | Claude Code, Codex                                    | Skills for Noir compiler development, SSA debugging, fuzzing, and ACIR optimization |

--- a/docs/docs-developers/getting_started_on_testnet.md
+++ b/docs/docs-developers/getting_started_on_testnet.md
@@ -80,7 +80,7 @@ aztec-wallet create-account \
 ```
 
 :::note
-The first transaction will take longer as it downloads proving keys. If you see `Timeout awaiting isMined`, the transaction is still processing — this is normal on testnet.
+The first transaction will take longer as it downloads proving keys. If you see `Timeout awaiting isMined`, the transaction is still processing: this is normal on testnet.
 :::
 
 ### Step 4: Deploy a contract

--- a/docs/docs/networks.md
+++ b/docs/docs/networks.md
@@ -80,14 +80,6 @@ The developer SDK/aztec-nr version (used for writing and compiling contracts) ma
 | **Slashing Quorum** | 65% | 33% |
 | **Slashing Round Size** | 128 epochs | 64 epochs |
 
-## Use Case Suitability
-
-| Use Case | Alpha (Mainnet) | Testnet |
-|----------|-------------------|---------|
-| **App Development** | ❌ | ✅ |
-| **Sequencer Testing** | ✅ | ✅ |
-| **Governance Testing** | ✅ | ✅ |
-
 ---
 
 ## Network Selection Guide


### PR DESCRIPTION
## Summary

- Bump testnet version to `v4.2.0` in `developer_version_config.json` and the getting-started-on-testnet install command (from `4.2.0-aztecnr-rc.2`).
- Remove `aztec-claude-plugin` marketplace install block and its row from the Aztec/Noir tool reference table in both the current and `v4.2.0` versioned AI tooling pages.
- Replace em-dashes with colons per style guide in getting-started-on-testnet (current + versioned).
- Drop the "Use Case Suitability" table from `docs/docs/networks.md`.

## Test plan

- [ ] `yarn build` in `docs/` completes without errors
- [ ] Rendered testnet install command shows `VERSION=4.2.0`
- [ ] AI tooling page no longer references `aztec-claude-plugin`