### PR TITLE
fix(avm): AVM gadget fuzzers fixes

### DIFF
--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/harness/ecc.fuzzer.cpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/harness/ecc.fuzzer.cpp
@@ -114,11 +114,25 @@ struct EccFuzzerInput {
 
     static EccFuzzerInput from_buffer(const uint8_t* buffer)
     {
+        // Note: we cannot use AffinePoint::serialize_from_buffer() because this now throws if the point is not on the
+        // curve. We want to test such points so have to deserialize manually:
+        auto read_point = [](const uint8_t* src) -> AffinePoint {
+            bool is_point_at_infinity =
+                std::all_of(src, src + (sizeof(Fq) * 2), [](uint8_t val) { return val == 255; });
+            if (is_point_at_infinity) {
+                return AffinePoint::infinity();
+            }
+            AffinePoint result;
+            read(src, result.x);
+            read(src, result.y);
+            return result;
+        };
+
         EccFuzzerInput input;
         size_t offset = 0;
-        input.p = AffinePoint::serialize_from_buffer(buffer + offset);
+        input.p = read_point(buffer + offset);
         offset += sizeof(AffinePoint);
-        input.q = AffinePoint::serialize_from_buffer(buffer + offset);
+        input.q = read_point(buffer + offset);
         offset += sizeof(AffinePoint);
         input.scalar = Fq::serialize_from_buffer(buffer + offset);
         offset += sizeof(Fq);

--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/run_fuzzer.sh
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/run_fuzzer.sh
@@ -145,9 +145,9 @@ fi
 
 # Set build directory based on command
 if [ "$COMMAND" = "coverage" ]; then
-    BUILD_DIR="$CPP_DIR/build-coverage"
-    BUILD_PRESET="clang20-coverage"
-    BUILD_CMAKE_FLAGS="-DCOVERAGE_AVM=ON -DFUZZING=ON -DFUZZING_AVM=ON"
+    BUILD_DIR="$CPP_DIR/build-fuzzing-avm-cov"
+    BUILD_PRESET="fuzzing-avm"
+    BUILD_CMAKE_FLAGS="-DCOVERAGE=ON -DCOVERAGE_AVM=ON"
 else
     BUILD_DIR="$CPP_DIR/build-fuzzing-avm"
     BUILD_PRESET="fuzzing-avm"
@@ -170,9 +170,9 @@ build_fuzzer() {
     if [ ! -f "$BUILD_DIR/CMakeCache.txt" ]; then
         echo "Configuring cmake..."
         if [ -n "$BUILD_CMAKE_FLAGS" ]; then
-            cmake --preset "$BUILD_PRESET" $BUILD_CMAKE_FLAGS
+            cmake --preset "$BUILD_PRESET" -B "$BUILD_DIR" $BUILD_CMAKE_FLAGS
         else
-            cmake --preset "$BUILD_PRESET"
+            cmake --preset "$BUILD_PRESET" -B "$BUILD_DIR"
         fi
     fi
 
@@ -314,13 +314,14 @@ if [ "$COMMAND" = "coverage" ] && [ -f "$LLVM_PROFILE_FILE" ]; then
     echo "=========================================="
 
     COVERAGE_DATA="$COVERAGE_OUTPUT_DIR/bb_avm.profdata"
-    # Merge all profraw and profdata files in coverage directory
-    COVERAGE_FILES=("$COVERAGE_OUTPUT_DIR"/*.profraw "$COVERAGE_OUTPUT_DIR"/*.profdata)
+    # Merge all profraw and profdata files in coverage directory (skip globs that match nothing)
+    COVERAGE_FILES=()
+    for f in "$COVERAGE_OUTPUT_DIR"/*.profraw "$COVERAGE_OUTPUT_DIR"/*.profdata; do
+        [ -f "$f" ] && COVERAGE_FILES+=("$f")
+    done
     echo "Merging coverage files:"
     for f in "${COVERAGE_FILES[@]}"; do
-        if [ -f "$f" ]; then
-            echo "  $f"
-        fi
+        echo "  $f"
     done
     echo ""
     llvm-profdata-20 merge -sparse "${COVERAGE_FILES[@]}" -o "$COVERAGE_DATA"


### PR DESCRIPTION
This brings a couple of small fixes so we can build the coverage tool and use the ecc fuzzer.

- The coverage tool wasn't building due to the use of zig. Claude provided this fix and the build command now uses the standard preset:
```
BEFORE:     * cmake --preset clang20-coverage -DFUZZING=ON -DFUZZING_AVM=ON
AFTER:  cmake --preset fuzzing-avm -DCOVERAGE=ON -DCOVERAGE_AVM=ON 
```
Now `run_fuzzer.sh coverage <gadget>` works again :tada:

 - Now that `AffinePoint::serialize_from_buffer` throws if the point is not on the curve (part of #21920), the ecc fuzzer (which deliberately constructs and tests points not on the curve) must use a custom deserializer which doesn't throw.

