### PR TITLE
feat(archiver): handle multiple proposed checkpoints

### DIFF
--- a/yarn-project/archiver/src/archiver-sync.test.ts
+++ b/yarn-project/archiver/src/archiver-sync.test.ts
@@ -29,7 +29,7 @@ import { type MockProxy, mock } from 'jest-mock-extended';
 import type { GetBlockReturnType } from 'viem';
 
 import { Archiver, type ArchiverEmitter } from './archiver.js';
-import { L1ToL2MessagesNotReadyError } from './errors.js';
+import { BlockOrCheckpointSlotExpiredError, L1ToL2MessagesNotReadyError } from './errors.js';
 import type { ArchiverInstrumentation } from './modules/instrumentation.js';
 import { ArchiverL1Synchronizer } from './modules/l1_synchronizer.js';
 import { KVArchiverDataStore } from './store/kv_archiver_store.js';
@@ -1522,7 +1522,7 @@ describe('Archiver Sync', () => {
       });
 
       // Try to add the block for the past slot - should be rejected
-      await expect(archiver.addBlock(pastSlotBlocks[0])).rejects.toThrow(/past slot/);
+      await expect(archiver.addBlock(pastSlotBlocks[0])).rejects.toThrow(BlockOrCheckpointSlotExpiredError);
     }, 10_000);
 
     it('adds missing blocks when checkpoint has more blocks than local', async () => {

--- a/yarn-project/archiver/src/archiver-sync.test.ts
+++ b/yarn-project/archiver/src/archiver-sync.test.ts
@@ -1867,7 +1867,7 @@ describe('Archiver Sync', () => {
         totalManaUsed: 0n,
         feeAssetPriceModifier: 0n,
       };
-      await archiver.setProposedCheckpoint(proposedCheckpoint);
+      await archiver.addProposedCheckpoint(proposedCheckpoint);
 
       // Advance L1 to block 2 (still in slot 1) — proposed checkpoint is still current
       fake.setL1BlockNumber(2n);
@@ -1878,7 +1878,7 @@ describe('Archiver Sync', () => {
       expect(await archiver.getBlockNumber()).toEqual(lastProvisionalBlockNumber);
 
       // Proposed checkpoint should still be set
-      expect(await archiverStore.blockStore.getProposedCheckpointOnly()).toBeDefined();
+      expect(await archiverStore.blockStore.getLastProposedCheckpoint()).toBeDefined();
 
       // Proposed tip should be ahead of the checkpointed tip
       const tips = await archiver.getL2Tips();
@@ -1928,7 +1928,7 @@ describe('Archiver Sync', () => {
         totalManaUsed: 0n,
         feeAssetPriceModifier: 0n,
       };
-      await archiver.setProposedCheckpoint(proposedCheckpoint);
+      await archiver.addProposedCheckpoint(proposedCheckpoint);
 
       // Advance L1 to block 4 (slot 2), ending slot 1 without checkpoint on L1
       fake.setL1BlockNumber(4n);
@@ -1948,7 +1948,7 @@ describe('Archiver Sync', () => {
       expect(await archiver.getSynchedCheckpointNumber()).toEqual(CheckpointNumber(1));
 
       // Proposed checkpoint should be cleared, so proposed tip falls back to checkpointed tip
-      expect(await archiverStore.blockStore.getProposedCheckpointOnly()).toBeUndefined();
+      expect(await archiverStore.blockStore.getLastProposedCheckpoint()).toBeUndefined();
       const tips = await archiver.getL2Tips();
       expect(tips.proposedCheckpoint.checkpoint.number).toEqual(tips.checkpointed.checkpoint.number);
       expect(tips.proposedCheckpoint.block.number).toEqual(tips.checkpointed.block.number);

--- a/yarn-project/archiver/src/archiver.ts
+++ b/yarn-project/archiver/src/archiver.ts
@@ -25,12 +25,13 @@ import {
   getEpochAtSlot,
   getSlotAtNextL1Block,
   getSlotRangeForEpoch,
+  getTimestampForSlot,
   getTimestampRangeForEpoch,
 } from '@aztec/stdlib/epoch-helpers';
 import { type TelemetryClient, type Traceable, type Tracer, trackSpan } from '@aztec/telemetry-client';
 
 import { type ArchiverConfig, mapArchiverConfig } from './config.js';
-import { BlockAlreadyCheckpointedError, NoBlobBodiesFoundError } from './errors.js';
+import { BlockAlreadyCheckpointedError, BlockOrCheckpointSlotExpiredError, NoBlobBodiesFoundError } from './errors.js';
 import { validateAndLogHistoricalLogsAvailability } from './l1/validate_historical_logs.js';
 import { validateAndLogTraceAvailability } from './l1/validate_trace.js';
 import { ArchiverDataSourceBase } from './modules/data_source_base.js';
@@ -45,7 +46,16 @@ export type { ArchiverEmitter };
 
 /** Request to add a block to the archiver, queued for processing by the sync loop. */
 type AddBlockRequest = {
+  type: 'block';
   block: L2Block;
+  resolve: () => void;
+  reject: (err: Error) => void;
+};
+
+/** Request to add a proposed checkpoint to the archiver, queued for processing by the sync loop. */
+type AddProposedCheckpointRequest = {
+  type: 'checkpoint';
+  checkpoint: ProposedCheckpointInput;
   resolve: () => void;
   reject: (err: Error) => void;
 };
@@ -75,8 +85,8 @@ export class Archiver extends ArchiverDataSourceBase implements L2BlockSink, Tra
   private initialSyncComplete: boolean = false;
   private initialSyncPromise: PromiseWithResolvers<void>;
 
-  /** Queue of blocks to be added to the store, processed by the sync loop. */
-  private blockQueue: AddBlockRequest[] = [];
+  /** Queue of blocks and checkpoints to be added to the store, processed by the sync loop. */
+  private inboundQueue: (AddBlockRequest | AddProposedCheckpointRequest)[] = [];
 
   /** Helper to handle updates to the store */
   private readonly updater: ArchiverDataStoreUpdater;
@@ -209,6 +219,14 @@ export class Archiver extends ArchiverDataSourceBase implements L2BlockSink, Tra
     return this.runningPromise.trigger();
   }
 
+  public trySyncImmediate() {
+    try {
+      return this.syncImmediate();
+    } catch (err) {
+      this.log.error(`Failed to trigger immediate archiver sync: ${err}`, err);
+    }
+  }
+
   /**
    * Queues a block to be added to the archiver store and triggers processing.
    * The block will be processed by the sync loop.
@@ -217,63 +235,85 @@ export class Archiver extends ArchiverDataSourceBase implements L2BlockSink, Tra
    * @returns A promise that resolves when the block has been added to the store, or rejects on error.
    */
   public addBlock(block: L2Block): Promise<void> {
-    return new Promise<void>((resolve, reject) => {
-      this.blockQueue.push({ block, resolve, reject });
-      this.log.debug(`Queued block ${block.number} for processing`);
-      // Trigger an immediate sync, but don't wait for it - the promise resolves when the block is processed
-      this.syncImmediate().catch(err => {
-        this.log.error(`Sync immediate call failed: ${err}`);
-      });
-    });
-  }
-
-  public async setProposedCheckpoint(pending: ProposedCheckpointInput): Promise<void> {
-    await this.updater.setProposedCheckpoint(pending);
+    const promise = promiseWithResolvers<void>();
+    this.inboundQueue.push({ block, ...promise, type: 'block' });
+    this.log.debug(`Queued block ${block.number} for processing`);
+    void this.trySyncImmediate();
+    return promise.promise;
   }
 
   /**
-   * Processes all queued blocks, adding them to the store.
-   * Called at the beginning of each sync iteration.
-   * Blocks are processed in the order they were queued.
+   * Queues a new proposed checkpoint into the archiver store.
+   * Checks that the checkpoint is not for an L2 slot already synced from L1.
+   * Resolves once the checkpoint has been processed.
    */
-  private async processQueuedBlocks(): Promise<void> {
-    if (this.blockQueue.length === 0) {
+  public addProposedCheckpoint(pending: ProposedCheckpointInput): Promise<void> {
+    const promise = promiseWithResolvers<void>();
+    this.inboundQueue.push({ checkpoint: pending, ...promise, type: 'checkpoint' });
+    this.log.debug(`Queued checkpoint ${pending.checkpointNumber} for processing`);
+    void this.trySyncImmediate();
+    return promise.promise;
+  }
+
+  /**
+   * Processes all queued blocks and checkpoints, adding them to the store.
+   * Called at the beginning of each sync iteration.
+   * Items are processed in the order they were queued.
+   */
+  private async processInboundQueue(): Promise<void> {
+    if (this.inboundQueue.length === 0) {
       return;
     }
 
-    // Take all blocks from the queue
-    const queuedItems = this.blockQueue.splice(0, this.blockQueue.length);
-    this.log.debug(`Processing ${queuedItems.length} queued block(s)`);
+    // Take all items from the queue
+    const queuedItems = this.inboundQueue.splice(0, this.inboundQueue.length);
+    this.log.debug(`Processing ${queuedItems.length} queued inbound items`);
 
     // Calculate slot threshold for validation
     const l1Timestamp = this.synchronizer.getL1Timestamp();
     const slotAtNextL1Block =
       l1Timestamp === undefined ? undefined : getSlotAtNextL1Block(l1Timestamp, this.l1Constants);
 
-    // Process each block individually to properly resolve/reject each promise
-    for (const { block, resolve, reject } of queuedItems) {
-      const blockSlot = block.header.globalVariables.slotNumber;
-      if (slotAtNextL1Block !== undefined && blockSlot < slotAtNextL1Block) {
+    // Helpers for manipulating blocks and checkpoints in the queue
+    const getSlot: (item: AddBlockRequest | AddProposedCheckpointRequest) => SlotNumber = item =>
+      item.type === 'block' ? item.block.header.globalVariables.slotNumber : item.checkpoint.header.slotNumber;
+    const getNumber: (item: AddBlockRequest | AddProposedCheckpointRequest) => number = item =>
+      item.type === 'block' ? item.block.number : item.checkpoint.checkpointNumber;
+
+    // Process each item individually to properly resolve/reject each promise
+    for (const item of queuedItems) {
+      const { resolve, reject, type } = item;
+      const itemSlot = getSlot(item);
+      const itemNumber = getNumber(item);
+      if (slotAtNextL1Block !== undefined && itemSlot < slotAtNextL1Block) {
+        const nextSlotTimestamp = getTimestampForSlot(slotAtNextL1Block, this.l1Constants);
         this.log.warn(
-          `Rejecting proposed block ${block.number} for past slot ${blockSlot} (current is ${slotAtNextL1Block})`,
-          { block: block.toBlockInfo(), l1Timestamp, slotAtNextL1Block },
+          `Rejecting proposed ${type} ${itemNumber} for past slot ${itemSlot} (current ${slotAtNextL1Block})`,
+          { number: itemNumber, type, l1Timestamp, slotAtNextL1Block, nextSlotTimestamp },
         );
-        reject(new Error(`Block ${block.number} is for past slot ${blockSlot} (current is ${slotAtNextL1Block})`));
+        reject(new BlockOrCheckpointSlotExpiredError(itemSlot, nextSlotTimestamp, l1Timestamp));
         continue;
       }
 
       try {
-        const [durationMs] = await elapsed(() => this.updater.addProposedBlock(block));
-        this.instrumentation.processNewProposedBlock(durationMs, block);
-        this.log.debug(`Added block ${block.number} to store`);
+        if (type === 'block') {
+          const [durationMs] = await elapsed(() => this.updater.addProposedBlock(item.block));
+          this.instrumentation.processNewProposedBlock(durationMs, item.block);
+        } else {
+          await this.updater.addProposedCheckpoint(item.checkpoint);
+        }
+        this.log.debug(`Added ${type} ${itemNumber} to store`);
         resolve();
       } catch (err: any) {
         if (err instanceof BlockAlreadyCheckpointedError) {
-          this.log.debug(`Proposed block ${block.number} matches already checkpointed block, ignoring late proposal`);
+          this.log.debug(`Proposed block ${itemNumber} matches already checkpointed block, ignoring late proposal`);
           resolve();
           continue;
         }
-        this.log.error(`Failed to add block ${block.number} to store: ${err.message}`);
+        this.log.error(`Failed to add ${type} ${itemNumber} to store: ${err.message}`, err, {
+          number: itemNumber,
+          type,
+        });
         reject(err);
       }
     }
@@ -289,7 +329,7 @@ export class Archiver extends ArchiverDataSourceBase implements L2BlockSink, Tra
   @trackSpan('Archiver.sync')
   private async sync() {
     // Process any queued blocks first, before doing L1 sync
-    await this.processQueuedBlocks();
+    await this.processInboundQueue();
     // Now perform L1 sync
     await this.syncFromL1();
   }

--- a/yarn-project/archiver/src/errors.ts
+++ b/yarn-project/archiver/src/errors.ts
@@ -1,14 +1,17 @@
+import type { BlockNumber, CheckpointNumber } from '@aztec/foundation/branded-types';
 import type { Fr } from '@aztec/foundation/schemas';
 
 export class NoBlobBodiesFoundError extends Error {
   constructor(l2BlockNum: number) {
     super(`No blob bodies found for block ${l2BlockNum}`);
+    this.name = 'NoBlobBodiesFoundError';
   }
 }
 
 export class BlockNumberNotSequentialError extends Error {
   constructor(newBlockNumber: number, previous: number | undefined) {
     super(`Cannot insert new block ${newBlockNumber} given previous block number is ${previous ?? 'undefined'}`);
+    this.name = 'BlockNumberNotSequentialError';
   }
 }
 
@@ -22,18 +25,29 @@ export class InitialCheckpointNumberNotSequentialError extends Error {
         previousCheckpointNumber ?? 'undefined'
       }`,
     );
+    this.name = 'InitialCheckpointNumberNotSequentialError';
+  }
+}
+
+export class BlockCheckpointNumberNotSequentialError extends Error {
+  constructor(
+    blockNumber: BlockNumber,
+    blockCheckpointNumber: CheckpointNumber,
+    previous: CheckpointNumber | undefined,
+  ) {
+    super(
+      `Cannot insert new block ${blockNumber} for checkpoint ${blockCheckpointNumber} given previous checkpoint number is ${previous ?? 'undefined'}`,
+    );
+    this.name = 'BlockCheckpointNumberNotSequentialError';
   }
 }
 
 export class CheckpointNumberNotSequentialError extends Error {
-  constructor(
-    newCheckpointNumber: number,
-    previous: number | undefined,
-    source: 'confirmed' | 'proposed' = 'confirmed',
-  ) {
+  constructor(newCheckpointNumber: CheckpointNumber, previous: CheckpointNumber | undefined) {
     super(
-      `Cannot insert new checkpoint ${newCheckpointNumber} given previous ${source} checkpoint number is ${previous ?? 'undefined'}`,
+      `Cannot insert new checkpoint ${newCheckpointNumber} given previous checkpoint number is ${previous ?? 'undefined'}`,
     );
+    this.name = 'CheckpointNumberNotSequentialError';
   }
 }
 
@@ -42,6 +56,7 @@ export class BlockIndexNotSequentialError extends Error {
     super(
       `Cannot insert new block at checkpoint index ${newBlockIndex} given previous block index is ${previousBlockIndex ?? 'undefined'}`,
     );
+    this.name = 'BlockIndexNotSequentialError';
   }
 }
 
@@ -55,18 +70,21 @@ export class BlockArchiveNotConsistentError extends Error {
     super(
       `Cannot insert new block number ${newBlockNumber} with archive ${newBlockArchive.toString()} previous block number is ${previousBlockNumber ?? 'undefined'}, previous archive is ${previousBlockArchive?.toString() ?? 'undefined'}`,
     );
+    this.name = 'BlockArchiveNotConsistentError';
   }
 }
 
 export class CheckpointNotFoundError extends Error {
   constructor(checkpointNumber: number) {
     super(`Failed to find expected checkpoint number ${checkpointNumber}`);
+    this.name = 'CheckpointNotFoundError';
   }
 }
 
 export class BlockNotFoundError extends Error {
   constructor(blockNumber: number) {
     super(`Failed to find expected block number ${blockNumber}`);
+    this.name = 'BlockNotFoundError';
   }
 }
 
@@ -119,16 +137,31 @@ export class ProposedCheckpointStaleError extends Error {
   }
 }
 
-/** Thrown when a proposed checkpoint number is not the expected confirmed + 1. */
+/** Thrown when a proposed checkpoint number is not the expected latestTip + 1. */
 export class ProposedCheckpointNotSequentialError extends Error {
   constructor(
     public readonly proposedCheckpointNumber: number,
-    public readonly confirmedCheckpointNumber: number,
+    public readonly latestTipNumber: number,
   ) {
     super(
-      `Proposed checkpoint ${proposedCheckpointNumber} is not sequential: expected ${confirmedCheckpointNumber + 1} (confirmed + 1)`,
+      `Proposed checkpoint ${proposedCheckpointNumber} is not sequential: expected ${latestTipNumber + 1} (latest tip + 1, where tip is highest of confirmed or pending)`,
     );
     this.name = 'ProposedCheckpointNotSequentialError';
+  }
+}
+
+/** Thrown when a proposed checkpoint or block L2 slot has already expired on L1. */
+export class BlockOrCheckpointSlotExpiredError extends Error {
+  constructor(
+    public readonly slot: number,
+    public readonly nextSlotStart: bigint,
+    public readonly l1TimestampSynced: bigint | undefined,
+  ) {
+    super(
+      `Checkpoint or block for slot ${slot} is expired: L1 synced to ${l1TimestampSynced} which is past the next slot start ${nextSlotStart}. ` +
+        `If the checkpoint still lands via a late L1 tx, the archiver will pick it up via normal L1-sync (not the pending-queue shortcut).`,
+    );
+    this.name = 'BlockOrCheckpointSlotExpiredError';
   }
 }
 

--- a/yarn-project/archiver/src/modules/data_source_base.ts
+++ b/yarn-project/archiver/src/modules/data_source_base.ts
@@ -163,12 +163,12 @@ export abstract class ArchiverDataSourceBase
     return this.store.getSettledTxReceipt(txHash, this.l1Constants);
   }
 
-  public getProposedCheckpoint(): Promise<CommonCheckpointData | undefined> {
-    return this.store.getProposedCheckpoint();
+  public getLastCheckpoint(): Promise<CommonCheckpointData | undefined> {
+    return this.store.getLastCheckpoint();
   }
 
-  public getProposedCheckpointOnly(): Promise<ProposedCheckpointData | undefined> {
-    return this.store.getProposedCheckpointOnly();
+  public getLastProposedCheckpoint(): Promise<ProposedCheckpointData | undefined> {
+    return this.store.getLastProposedCheckpoint();
   }
 
   public isPendingChainInvalid(): Promise<boolean> {

--- a/yarn-project/archiver/src/modules/data_store_updater.ts
+++ b/yarn-project/archiver/src/modules/data_store_updater.ts
@@ -100,6 +100,7 @@ export class ArchiverDataStoreUpdater {
       attestations: CommitteeAttestation[];
       checkpoint: PublishedCheckpoint;
     },
+    evictProposedFrom?: CheckpointNumber,
   ): Promise<ReconcileCheckpointsResult> {
     for (const checkpoint of checkpoints) {
       validateCheckpoint(checkpoint.checkpoint, { rollupManaLimit: this.opts?.rollupManaLimit });
@@ -126,14 +127,17 @@ export class ArchiverDataStoreUpdater {
         this.store.addLogs(newBlocks),
         // Unroll all logs emitted during the retrieved blocks and extract any contract classes and instances from them
         ...newBlocks.map(block => this.addContractDataToDb(block)),
-        // Promote the proposed checkpoint if requested
+        // Promote the proposed checkpoint if requested (uses explicit checkpoint number)
         promoteProposed
           ? this.store.promoteProposedToCheckpointed(
+              promoteProposed.checkpoint.checkpoint.number,
               promoteProposed.l1,
               promoteProposed.attestations,
               promoteProposed.checkpoint.checkpoint.archive.root,
             )
           : undefined,
+        // Evict pending checkpoints that diverged from what L1 mined
+        evictProposedFrom !== undefined ? this.store.evictProposedCheckpointsFrom(evictProposedFrom) : undefined,
       ]);
 
       await this.l2TipsCache?.refresh();
@@ -142,9 +146,9 @@ export class ArchiverDataStoreUpdater {
     return result;
   }
 
-  public async setProposedCheckpoint(proposedCheckpoint: ProposedCheckpointInput) {
+  public async addProposedCheckpoint(proposedCheckpoint: ProposedCheckpointInput) {
     const result = await this.store.transactionAsync(async () => {
-      await this.store.setProposedCheckpoint(proposedCheckpoint);
+      await this.store.addProposedCheckpoint(proposedCheckpoint);
       await this.l2TipsCache?.refresh();
     });
 
@@ -245,8 +249,8 @@ export class ArchiverDataStoreUpdater {
 
       const result = await this.removeBlocksAfter(blockNumber);
 
-      // Clear the proposed checkpoint if it exists, since its blocks have been pruned
-      await this.store.deleteProposedCheckpoint();
+      // Clear all pending proposed checkpoints since their blocks have been pruned
+      await this.store.deleteProposedCheckpoints();
 
       await this.l2TipsCache?.refresh();
       return result;

--- a/yarn-project/archiver/src/modules/l1_synchronizer.ts
+++ b/yarn-project/archiver/src/modules/l1_synchronizer.ts
@@ -777,11 +777,14 @@ export class ArchiverL1Synchronizer implements Traceable {
         },
       );
 
-      // Check if the last checkpoint matches the proposed one (so we can skip blob fetch).
-      // We only check the last one because the proposed checkpoint is always the most recent one,
-      // and if it's in a multi-checkpoint batch it will always be last (sorted by L1 block number).
+      // Check if the last checkpoint matches a local pending entry (so we can skip blob fetch).
+      // We only check the last one; if it matches, the blob fetch is skipped for that entry.
+      // TODO(palla/pipelining): We may have more than a single checkpoint to promote
       const lastCalldataCheckpoint = calldataCheckpoints[calldataCheckpoints.length - 1];
-      const checkpointToPromote = await this.tryBuildPublishedCheckpointFromProposed(lastCalldataCheckpoint);
+      const promoteResult = await this.tryBuildPublishedCheckpointFromProposed(lastCalldataCheckpoint);
+      const checkpointToPromote = promoteResult && !('diverged' in promoteResult) ? promoteResult : undefined;
+      const evictProposedFrom =
+        promoteResult && 'diverged' in promoteResult ? promoteResult.fromCheckpointNumber : undefined;
 
       // Then fetch blobs in parallel and build the full published checkpoints
       const toFetchBlobs = checkpointToPromote ? calldataCheckpoints.slice(0, -1) : calldataCheckpoints;
@@ -904,6 +907,7 @@ export class ArchiverL1Synchronizer implements Traceable {
                 attestations: lastCalldataCheckpoint.attestations,
                 checkpoint: maybeValidCheckpointToPromote,
               },
+              evictProposedFrom,
             ),
           ),
         );
@@ -975,17 +979,24 @@ export class ArchiverL1Synchronizer implements Traceable {
     return { ...rollupStatus, lastRetrievedCheckpoint, lastL1BlockWithCheckpoint };
   }
 
-  /** Checks if this checkpoint matches the local proposed one, and if so, loads local data to build a synthetic published checkpoint. */
+  /**
+   * Checks if a specific checkpoint matches a local pending entry, and if so, loads local data to build
+   * a synthetic published checkpoint (skipping blob fetch).
+   *
+   * Returns { diverged: true, fromCheckpointNumber } when the L1 checkpoint does NOT match local pending
+   * data for that number, so the caller can evict the entire pending suffix >= fromCheckpointNumber
+   * (those entries chain off the now-invalid local state) within the same addCheckpoints transaction.
+   */
   private async tryBuildPublishedCheckpointFromProposed(
     calldataCheckpoint: RetrievedCheckpointFromCalldata | undefined,
-  ): Promise<PublishedCheckpoint | undefined> {
-    const proposed = await this.store.getProposedCheckpointOnly();
-    if (
-      this.config.skipPromoteProposedCheckpointDuringL1Sync ||
-      !proposed ||
-      !calldataCheckpoint ||
-      proposed.checkpointNumber !== calldataCheckpoint.checkpointNumber
-    ) {
+  ): Promise<PublishedCheckpoint | { diverged: true; fromCheckpointNumber: CheckpointNumber } | undefined> {
+    if (this.config.skipPromoteProposedCheckpointDuringL1Sync || !calldataCheckpoint) {
+      return undefined;
+    }
+
+    // Look up the specific pending entry for the checkpoint being mined, not just the tip
+    const proposed = await this.store.getProposedCheckpointByNumber(calldataCheckpoint.checkpointNumber);
+    if (!proposed) {
       return undefined;
     }
 
@@ -1004,7 +1015,8 @@ export class ArchiverL1Synchronizer implements Traceable {
           calldataArchiveRoot: calldataCheckpoint.archiveRoot.toString(),
         },
       );
-      return undefined;
+      // Return a divergence signal so the caller can evict pending >= this number
+      return { diverged: true, fromCheckpointNumber: proposed.checkpointNumber };
     }
 
     this.log.debug(

--- a/yarn-project/archiver/src/store/block_store.ts
+++ b/yarn-project/archiver/src/store/block_store.ts
@@ -209,8 +209,11 @@ export class BlockStore {
       // Accept the block if either the confirmed checkpoint or a pending checkpoint matches
       // the expected predecessor. We look for a pending entry at exactly blockCheckpointNumber - 1.
       const expectedCheckpointNumber = blockCheckpointNumber - 1;
-      if (!opts.force && latestCheckpointNumber !== expectedCheckpointNumber) {
-        throw new BlockCheckpointNumberNotSequentialError(blockNumber, blockCheckpointNumber, latestCheckpointNumber);
+      const hasPendingAtExpected = await this.#proposedCheckpoints.hasAsync(expectedCheckpointNumber);
+      if (!opts.force && latestCheckpointNumber !== expectedCheckpointNumber && !hasPendingAtExpected) {
+        const [latestPendingKey] = await toArray(this.#proposedCheckpoints.keysAsync({ reverse: true, limit: 1 }));
+        const previous = CheckpointNumber(Math.max(latestCheckpointNumber, latestPendingKey ?? 0));
+        throw new BlockCheckpointNumberNotSequentialError(blockNumber, blockCheckpointNumber, previous);
       }
 
       // Extract the previous block if there is one and see if it is for the same checkpoint or not

--- a/yarn-project/archiver/src/store/block_store.ts
+++ b/yarn-project/archiver/src/store/block_store.ts
@@ -45,6 +45,7 @@ import {
 import {
   BlockAlreadyCheckpointedError,
   BlockArchiveNotConsistentError,
+  BlockCheckpointNumberNotSequentialError,
   BlockIndexNotSequentialError,
   BlockNotFoundError,
   BlockNumberNotSequentialError,
@@ -56,7 +57,6 @@ import {
   ProposedCheckpointArchiveRootMismatchError,
   ProposedCheckpointNotSequentialError,
   ProposedCheckpointPromotionNotSequentialError,
-  ProposedCheckpointStaleError,
 } from '../errors.js';
 
 export { TxReceipt, type TxEffect, type TxHash } from '@aztec/stdlib/tx';
@@ -101,7 +101,10 @@ export class BlockStore {
   /** Map block number to block data */
   #blocks: AztecAsyncMap<number, BlockStorage>;
 
-  /** Map checkpoint number to checkpoint data */
+  /** Map keyed by checkpoint number holding proposed (locally-validated, not yet L1-confirmed) checkpoints. */
+  #proposedCheckpoints: AztecAsyncMap<number, ProposedCheckpointStorage>;
+
+  /** Map checkpoint number to checkpoint data for mined checkpoints only */
   #checkpoints: AztecAsyncMap<number, CheckpointStorage>;
 
   /** Map slot number to checkpoint number, for looking up checkpoints by slot range. */
@@ -134,9 +137,6 @@ export class BlockStore {
   /** Index mapping block archive to block number */
   #blockArchiveIndex: AztecAsyncMap<string, number>;
 
-  /** Singleton: assumes max 1-deep pipeline. For deeper pipelining, replace with a map keyed by checkpoint number. */
-  #proposedCheckpoint: AztecAsyncSingleton<ProposedCheckpointStorage>;
-
   #log = createLogger('archiver:block_store');
 
   constructor(private db: AztecAsyncKVStore) {
@@ -152,7 +152,7 @@ export class BlockStore {
     this.#pendingChainValidationStatus = db.openSingleton('archiver_pending_chain_validation_status');
     this.#checkpoints = db.openMap('archiver_checkpoints');
     this.#slotToCheckpoint = db.openMap('archiver_slot_to_checkpoint');
-    this.#proposedCheckpoint = db.openSingleton('proposed_checkpoint_data');
+    this.#proposedCheckpoints = db.openMap('archiver_proposed_checkpoints');
   }
 
   /**
@@ -188,8 +188,7 @@ export class BlockStore {
 
       // Extract the latest block and checkpoint numbers
       const previousBlockNumber = await this.getLatestL2BlockNumber();
-      const proposedCheckpointNumber = await this.getProposedCheckpointNumber();
-      const previousCheckpointNumber = await this.getLatestCheckpointNumber();
+      const latestCheckpointNumber = await this.getLatestCheckpointNumber();
 
       // Verify we're not overwriting checkpointed blocks
       const lastCheckpointedBlockNumber = await this.getCheckpointedL2BlockNumber();
@@ -207,19 +206,11 @@ export class BlockStore {
         throw new BlockNumberNotSequentialError(blockNumber, previousBlockNumber);
       }
 
-      // The same check as above but for checkpoints. Accept the block if either the confirmed
-      // checkpoint or the pending (locally validated but not yet confirmed) checkpoint matches.
+      // Accept the block if either the confirmed checkpoint or a pending checkpoint matches
+      // the expected predecessor. We look for a pending entry at exactly blockCheckpointNumber - 1.
       const expectedCheckpointNumber = blockCheckpointNumber - 1;
-      if (
-        !opts.force &&
-        previousCheckpointNumber !== expectedCheckpointNumber &&
-        proposedCheckpointNumber !== expectedCheckpointNumber
-      ) {
-        const [reported, source]: [CheckpointNumber, 'confirmed' | 'proposed'] =
-          proposedCheckpointNumber > previousCheckpointNumber
-            ? [proposedCheckpointNumber, 'proposed']
-            : [previousCheckpointNumber, 'confirmed'];
-        throw new CheckpointNumberNotSequentialError(blockCheckpointNumber, reported, source);
+      if (!opts.force && latestCheckpointNumber !== expectedCheckpointNumber) {
+        throw new BlockCheckpointNumberNotSequentialError(blockNumber, blockCheckpointNumber, latestCheckpointNumber);
       }
 
       // Extract the previous block if there is one and see if it is for the same checkpoint or not
@@ -326,11 +317,10 @@ export class BlockStore {
 
         // Update slot-to-checkpoint index
         await this.#slotToCheckpoint.set(checkpoint.checkpoint.header.slotNumber, checkpoint.checkpoint.number);
-      }
 
-      // Clear the proposed checkpoint if any of the confirmed checkpoints match or supersede it
-      const lastConfirmedCheckpointNumber = checkpoints[checkpoints.length - 1].checkpoint.number;
-      await this.clearProposedCheckpointIfSuperseded(lastConfirmedCheckpointNumber);
+        // Remove proposed checkpoint if it exists, since L1 is authoritative
+        await this.#proposedCheckpoints.delete(checkpoint.checkpoint.number);
+      }
 
       await this.#lastSynchedL1Block.set(checkpoints[checkpoints.length - 1].l1.blockNumber);
       return true;
@@ -391,24 +381,27 @@ export class BlockStore {
       return undefined;
     }
 
-    const previousCheckpointData = await this.getCheckpointData(previousCheckpointNumber);
-    if (previousCheckpointData === undefined) {
+    // Check across both proposed and mined checkpoints
+    const predecessor =
+      (await this.getProposedCheckpointByNumber(previousCheckpointNumber)) ??
+      (await this.getCheckpointData(previousCheckpointNumber));
+
+    if (!predecessor) {
       throw new CheckpointNotFoundError(previousCheckpointNumber);
     }
 
-    const previousBlockNumber = BlockNumber(previousCheckpointData.startBlock + previousCheckpointData.blockCount - 1);
+    const previousBlockNumber = BlockNumber(predecessor.startBlock + predecessor.blockCount - 1);
     const previousBlock = await this.getBlock(previousBlockNumber);
     if (previousBlock === undefined) {
       throw new BlockNotFoundError(previousBlockNumber);
     }
-
     return previousBlock;
   }
 
   /**
    * Validates that blocks are sequential, have correct indexes, and chain via archive roots.
    * This is the same validation used for both confirmed checkpoints (addCheckpoints) and
-   * proposed checkpoints (setProposedCheckpoint).
+   * proposed checkpoints (addProposedCheckpoint).
    */
   private validateCheckpointBlocks(blocks: L2Block[], previousBlock: L2Block | undefined): void {
     for (const block of blocks) {
@@ -535,11 +528,8 @@ export class BlockStore {
         this.#log.debug(`Removed checkpoint ${c}`);
       }
 
-      // Clear any proposed checkpoint that was orphaned by the removal (its base chain no longer exists)
-      const proposedCheckpointNumber = await this.getProposedCheckpointNumber();
-      if (proposedCheckpointNumber > checkpointNumber) {
-        await this.#proposedCheckpoint.delete();
-      }
+      // Evict all pending checkpoints > checkpointNumber (their base chain no longer exists)
+      await this.evictProposedCheckpointsFrom(CheckpointNumber(checkpointNumber + 1));
 
       return { blocksRemoved };
     });
@@ -688,28 +678,34 @@ export class BlockStore {
   }
 
   async hasProposedCheckpoint(): Promise<boolean> {
-    const proposed = await this.#proposedCheckpoint.getAsync();
-    return proposed !== undefined;
+    const [key] = await toArray(this.#proposedCheckpoints.keysAsync({ limit: 1 }));
+    return key !== undefined;
   }
 
-  /** Deletes the proposed checkpoint from storage. */
-  async deleteProposedCheckpoint(): Promise<void> {
-    await this.#proposedCheckpoint.delete();
+  /** Deletes all pending proposed checkpoints from storage. */
+  async deleteProposedCheckpoints(): Promise<void> {
+    for await (const key of this.#proposedCheckpoints.keysAsync()) {
+      await this.#proposedCheckpoints.delete(key);
+    }
   }
 
   /**
-   * Promotes the proposed checkpoint singleton to a confirmed checkpoint entry.
-   * This persists the checkpoint to the store, clears the proposed singleton, and updates the L1 sync point.
-   * Should only be called after the checkpoint has been validated.
-   * @param expectedArchiveRoot - The archive root to match against the proposed checkpoint, to guard against races.
+   * Promotes a specific pending checkpoint to a confirmed checkpoint entry.
+   * This persists the checkpoint to the store, removes only that pending entry, and updates the L1 sync point.
+   * Remaining pending entries (e.g. N+1, N+2) are left intact — they chain off the just-promoted one.
+   * @param checkpointNumber - The checkpoint number to promote.
+   * @param l1 - L1 published data for the checkpoint.
+   * @param attestations - Committee attestations.
+   * @param expectedArchiveRoot - Archive root guard against races.
    */
   async promoteProposedToCheckpointed(
+    checkpointNumber: CheckpointNumber,
     l1: L1PublishedData,
     attestations: CommitteeAttestation[],
     expectedArchiveRoot: Fr,
   ): Promise<void> {
     return await this.db.transactionAsync(async () => {
-      const proposed = await this.getProposedCheckpointOnly();
+      const proposed = await this.getProposedCheckpointByNumber(checkpointNumber);
       if (!proposed) {
         throw new NoProposedCheckpointToPromoteError();
       }
@@ -738,43 +734,70 @@ export class BlockStore {
       // Update the slot-to-checkpoint index
       await this.#slotToCheckpoint.set(proposed.header.slotNumber, proposed.checkpointNumber);
 
-      // Clear the proposed checkpoint singleton
-      await this.#proposedCheckpoint.delete();
+      // Remove only this pending entry — remaining entries N+1, N+2, ... stay valid
+      await this.#proposedCheckpoints.delete(proposed.checkpointNumber);
 
       // Update the last synced L1 block
       await this.#lastSynchedL1Block.set(l1.blockNumber);
     });
   }
 
-  /** Clears the proposed checkpoint if the given confirmed checkpoint number supersedes it. */
-  async clearProposedCheckpointIfSuperseded(confirmedCheckpointNumber: CheckpointNumber): Promise<void> {
-    const proposedCheckpointNumber = await this.getProposedCheckpointNumber();
-    if (proposedCheckpointNumber <= confirmedCheckpointNumber) {
-      await this.#proposedCheckpoint.delete();
-    }
-  }
-
-  /** Returns the proposed checkpoint data, or undefined if no proposed checkpoint exists. No fallback to confirmed. */
-  async getProposedCheckpointOnly(): Promise<ProposedCheckpointData | undefined> {
-    const stored = await this.#proposedCheckpoint.getAsync();
-    if (!stored) {
+  /**
+   * Returns the latest pending checkpoint (highest-numbered entry), or undefined if none.
+   * No fallback to confirmed.
+   */
+  async getLastProposedCheckpoint(): Promise<ProposedCheckpointData | undefined> {
+    const [key] = await toArray(this.#proposedCheckpoints.keysAsync({ reverse: true, limit: 1 }));
+    if (key === undefined) {
       return undefined;
     }
-    return this.convertToProposedCheckpointData(stored);
+    const stored = await this.#proposedCheckpoints.getAsync(key);
+    return stored ? this.convertToProposedCheckpointData(stored) : undefined;
+  }
+
+  /** Returns the pending checkpoint for a specific checkpoint number, or undefined if not found. */
+  async getProposedCheckpointByNumber(n: CheckpointNumber): Promise<ProposedCheckpointData | undefined> {
+    const stored = await this.#proposedCheckpoints.getAsync(n);
+    return stored ? this.convertToProposedCheckpointData(stored) : undefined;
+  }
+
+  /** Returns all pending checkpoints in ascending checkpoint-number order. */
+  async getProposedCheckpoints(): Promise<ProposedCheckpointData[]> {
+    const results: ProposedCheckpointData[] = [];
+    for await (const [, stored] of this.#proposedCheckpoints.entriesAsync()) {
+      results.push(this.convertToProposedCheckpointData(stored));
+    }
+    return results;
   }
 
   /**
-   * Gets the checkpoint at the proposed tip
-   * - pending checkpoint if it exists
-   * - fallsback to latest confirmed checkpoint otherwise
-   * @returns CommonCheckpointData
+   * Evicts all pending checkpoints with checkpoint number >= fromNumber.
+   * Used for divergent-mined-checkpoint cleanup: when L1 mines checkpoint N with a different archive,
+   * all pending >= N must be evicted since they chain off the now-invalid pending N.
    */
-  async getProposedCheckpoint(): Promise<CommonCheckpointData | undefined> {
-    const stored = await this.#proposedCheckpoint.getAsync();
-    if (!stored) {
+  async evictProposedCheckpointsFrom(fromNumber: CheckpointNumber): Promise<void> {
+    const keysToDelete: number[] = [];
+    for await (const key of this.#proposedCheckpoints.keysAsync()) {
+      if (key >= fromNumber) {
+        keysToDelete.push(key);
+      }
+    }
+    for (const key of keysToDelete) {
+      await this.#proposedCheckpoints.delete(key);
+    }
+  }
+
+  /**
+   * Gets the checkpoint at the proposed tip:
+   * - latest pending checkpoint if any exist
+   * - fallsback to latest confirmed checkpoint otherwise
+   */
+  async getLastCheckpoint(): Promise<CommonCheckpointData | undefined> {
+    const latest = await this.getLastProposedCheckpoint();
+    if (!latest) {
       return this.getCheckpointData(await this.getLatestCheckpointNumber());
     }
-    return this.convertToProposedCheckpointData(stored);
+    return latest;
   }
 
   private convertToProposedCheckpointData(stored: ProposedCheckpointStorage): ProposedCheckpointData {
@@ -795,7 +818,7 @@ export class BlockStore {
    * @returns CheckpointNumber
    */
   async getProposedCheckpointNumber(): Promise<CheckpointNumber> {
-    const proposed = await this.getProposedCheckpoint();
+    const proposed = await this.getLastCheckpoint();
     if (!proposed) {
       return await this.getLatestCheckpointNumber();
     }
@@ -807,7 +830,7 @@ export class BlockStore {
    * @returns BlockNumber
    */
   async getProposedCheckpointL2BlockNumber(): Promise<BlockNumber> {
-    const proposed = await this.getProposedCheckpoint();
+    const proposed = await this.getLastCheckpoint();
     if (!proposed) {
       return await this.getCheckpointedL2BlockNumber();
     }
@@ -1188,20 +1211,25 @@ export class BlockStore {
     return this.#lastSynchedL1Block.set(l1BlockNumber);
   }
 
-  /** Sets the proposed checkpoint (not yet L1-confirmed). Only accepts confirmed + 1.
-   *  Computes archive and checkpointOutHash from the stored blocks. */
-  async setProposedCheckpoint(proposed: ProposedCheckpointInput) {
+  /**
+   * Adds a proposed checkpoint to the pending queue.
+   * Accepts proposed.checkpointNumber === latestTip + 1, where latestTip is the highest of
+   * confirmed and the highest pending checkpoint number.
+   * Computes archive and checkpointOutHash from the stored blocks.
+   */
+  async addProposedCheckpoint(proposed: ProposedCheckpointInput) {
     return await this.db.transactionAsync(async () => {
-      const current = await this.getProposedCheckpointNumber();
-      if (proposed.checkpointNumber <= current) {
-        throw new ProposedCheckpointStaleError(proposed.checkpointNumber, current);
-      }
       const confirmed = await this.getLatestCheckpointNumber();
-      if (proposed.checkpointNumber !== confirmed + 1) {
-        throw new ProposedCheckpointNotSequentialError(proposed.checkpointNumber, confirmed);
+      const [latestPendingKey] = await toArray(this.#proposedCheckpoints.keysAsync({ reverse: true, limit: 1 }));
+      const latestTip = CheckpointNumber(
+        latestPendingKey !== undefined ? Math.max(latestPendingKey, confirmed) : confirmed,
+      );
+
+      if (proposed.checkpointNumber !== latestTip + 1) {
+        throw new ProposedCheckpointNotSequentialError(proposed.checkpointNumber, latestTip);
       }
 
-      // Ensure the previous checkpoint + blocks exist
+      // Ensure the predecessor block (from pending or confirmed chain) exists
       const previousBlock = await this.getPreviousCheckpointBlock(proposed.checkpointNumber);
       const blocks: L2Block[] = [];
       for (let i = 0; i < proposed.blockCount; i++) {
@@ -1216,7 +1244,7 @@ export class BlockStore {
       const archive = blocks[blocks.length - 1].archive;
       const checkpointOutHash = Checkpoint.getCheckpointOutHash(blocks);
 
-      await this.#proposedCheckpoint.set({
+      await this.#proposedCheckpoints.set(proposed.checkpointNumber, {
         header: proposed.header.toBuffer(),
         archive: archive.toBuffer(),
         checkpointOutHash: checkpointOutHash.toBuffer(),

--- a/yarn-project/archiver/src/store/kv_archiver_store.test.ts
+++ b/yarn-project/archiver/src/store/kv_archiver_store.test.ts
@@ -3621,8 +3621,8 @@ describe('KVArchiverDataStore', () => {
   });
 
   describe('proposedCheckpointNumber', () => {
-    /** Adds proposed blocks to the store so setProposedCheckpoint can validate them.
-     *  Uses force: true to skip addProposedBlock's own chaining checks (we only want to test setProposedCheckpoint). */
+    /** Adds proposed blocks to the store so addProposedCheckpoint can validate them.
+     *  Uses force: true to skip addProposedBlock's own chaining checks (we only want to test addProposedCheckpoint). */
     async function addBlocksForProposedCheckpoint(
       startBlock: number,
       blockCount: number,
@@ -3649,7 +3649,7 @@ describe('KVArchiverDataStore', () => {
 
     it('stores and retrieves proposed checkpoint number', async () => {
       await addBlocksForProposedCheckpoint(1, 1, 1);
-      await store.blockStore.setProposedCheckpoint({
+      await store.blockStore.addProposedCheckpoint({
         checkpointNumber: CheckpointNumber(1),
         header: CheckpointHeader.empty(),
         startBlock: BlockNumber(1),
@@ -3663,7 +3663,7 @@ describe('KVArchiverDataStore', () => {
 
     it('stores and retrieves proposed checkpoint data with fee fields', async () => {
       await addBlocksForProposedCheckpoint(1, 1, 1);
-      await store.blockStore.setProposedCheckpoint({
+      await store.blockStore.addProposedCheckpoint({
         checkpointNumber: CheckpointNumber(1),
         header: CheckpointHeader.empty(),
         startBlock: BlockNumber(1),
@@ -3671,7 +3671,7 @@ describe('KVArchiverDataStore', () => {
         totalManaUsed: 12345n,
         feeAssetPriceModifier: -75n,
       });
-      const pending = await store.blockStore.getProposedCheckpointOnly();
+      const pending = await store.blockStore.getLastProposedCheckpoint();
       expect(pending).toBeDefined();
       expect(pending!.checkpointNumber).toBe(1);
       expect(pending!.totalManaUsed).toBe(12345n);
@@ -3690,7 +3690,7 @@ describe('KVArchiverDataStore', () => {
       await addBlocksForProposedCheckpoint(2, 1, 2, checkpoint1.checkpoint.blocks[0].archive);
 
       // Set proposed checkpoint to 2 (attested but not yet on L1)
-      await store.blockStore.setProposedCheckpoint({
+      await store.blockStore.addProposedCheckpoint({
         checkpointNumber: CheckpointNumber(2),
         header: CheckpointHeader.empty(),
         startBlock: BlockNumber(2),
@@ -3725,7 +3725,7 @@ describe('KVArchiverDataStore', () => {
 
       // Try to set proposed checkpoint to 3 (confirmed=1, expected=2)
       await expect(
-        store.blockStore.setProposedCheckpoint({
+        store.blockStore.addProposedCheckpoint({
           checkpointNumber: CheckpointNumber(3),
           header: CheckpointHeader.empty(),
           startBlock: BlockNumber(1),
@@ -3747,10 +3747,9 @@ describe('KVArchiverDataStore', () => {
       );
       await store.addCheckpoints([checkpoint1]);
 
-      // Try to set proposed checkpoint to 1 (confirmed=1, expected=2).
-      // With fallback behavior, getProposedCheckpointNumber returns 1 (confirmed), so this triggers the stale check.
+      // Try to set proposed checkpoint to 1 (confirmed=1, expected=2). Not sequential.
       await expect(
-        store.blockStore.setProposedCheckpoint({
+        store.blockStore.addProposedCheckpoint({
           checkpointNumber: CheckpointNumber(1),
           header: CheckpointHeader.empty(),
           startBlock: BlockNumber(1),
@@ -3758,7 +3757,7 @@ describe('KVArchiverDataStore', () => {
           totalManaUsed: 100n,
           feeAssetPriceModifier: 50n,
         }),
-      ).rejects.toThrow('Stale');
+      ).rejects.toThrow('not sequential');
 
       // Proposed checkpoint should remain unset
       expect(await store.blockStore.hasProposedCheckpoint()).toBe(false);
@@ -3784,7 +3783,7 @@ describe('KVArchiverDataStore', () => {
       await addBlocksForProposedCheckpoint(3, 1, 3, checkpoint2.checkpoint.blocks[0].archive);
 
       // Set proposed checkpoint to 3
-      await store.blockStore.setProposedCheckpoint({
+      await store.blockStore.addProposedCheckpoint({
         checkpointNumber: CheckpointNumber(3),
         header: CheckpointHeader.empty(),
         startBlock: BlockNumber(3),
@@ -3819,7 +3818,7 @@ describe('KVArchiverDataStore', () => {
       await addBlocksForProposedCheckpoint(3, 1, 3, checkpoint2.checkpoint.blocks[0].archive);
 
       // Set pending to 3 (confirmed=2, 3===2+1 ✓)
-      await store.blockStore.setProposedCheckpoint({
+      await store.blockStore.addProposedCheckpoint({
         checkpointNumber: CheckpointNumber(3),
         header: CheckpointHeader.empty(),
         startBlock: BlockNumber(3),
@@ -3846,7 +3845,7 @@ describe('KVArchiverDataStore', () => {
       await addBlocksForProposedCheckpoint(2, 1, 2, checkpoint1.checkpoint.blocks[0].archive);
 
       // Set proposed checkpoint to 2 (attested but not on L1 yet)
-      await store.blockStore.setProposedCheckpoint({
+      await store.blockStore.addProposedCheckpoint({
         checkpointNumber: CheckpointNumber(2),
         header: CheckpointHeader.empty(),
         startBlock: BlockNumber(2),
@@ -3879,7 +3878,7 @@ describe('KVArchiverDataStore', () => {
       await addBlocksForProposedCheckpoint(2, 1, 2, checkpoint1.checkpoint.blocks[0].archive);
 
       // Set proposed checkpoint to 2
-      await store.blockStore.setProposedCheckpoint({
+      await store.blockStore.addProposedCheckpoint({
         checkpointNumber: CheckpointNumber(2),
         header: CheckpointHeader.empty(),
         startBlock: BlockNumber(2),
@@ -3951,7 +3950,7 @@ describe('KVArchiverDataStore', () => {
       await addBlocksForProposedCheckpoint(2, 1, 2, checkpoint1.checkpoint.blocks[0].archive);
 
       // Set proposed checkpoint
-      await store.blockStore.setProposedCheckpoint({
+      await store.blockStore.addProposedCheckpoint({
         checkpointNumber: CheckpointNumber(2),
         header: CheckpointHeader.empty(),
         startBlock: BlockNumber(2),
@@ -3977,7 +3976,7 @@ describe('KVArchiverDataStore', () => {
 
       // Add blocks and set proposed checkpoint 2
       await addBlocksForProposedCheckpoint(2, 1, 2, checkpoint1.checkpoint.blocks[0].archive);
-      await store.blockStore.setProposedCheckpoint({
+      await store.blockStore.addProposedCheckpoint({
         checkpointNumber: CheckpointNumber(2),
         header: CheckpointHeader.empty(),
         startBlock: BlockNumber(2),
@@ -4024,7 +4023,7 @@ describe('KVArchiverDataStore', () => {
       await store.addProposedBlock(block2, { force: true });
 
       // Set proposed checkpoint 2
-      await store.blockStore.setProposedCheckpoint({
+      await store.blockStore.addProposedCheckpoint({
         checkpointNumber: CheckpointNumber(2),
         header: CheckpointHeader.empty(),
         startBlock: BlockNumber(2),
@@ -4033,7 +4032,7 @@ describe('KVArchiverDataStore', () => {
         feeAssetPriceModifier: 50n,
       });
 
-      const proposed = await store.getProposedCheckpointOnly();
+      const proposed = await store.getLastProposedCheckpoint();
       return { checkpoint1, proposed: proposed! };
     }
 
@@ -4042,24 +4041,24 @@ describe('KVArchiverDataStore', () => {
       const l1 = makeL1PublishedData(20);
       const attestations = [CommitteeAttestation.random()];
 
-      await store.promoteProposedToCheckpointed(l1, attestations, proposed.archive.root);
+      await store.promoteProposedToCheckpointed(CheckpointNumber(2), l1, attestations, proposed.archive.root);
 
       expect(await store.blockStore.hasProposedCheckpoint()).toBe(false);
       expect(await store.blockStore.getLatestCheckpointNumber()).toBe(2);
     });
 
     it('throws when no proposed checkpoint exists', async () => {
-      await expect(store.promoteProposedToCheckpointed(makeL1PublishedData(20), [], Fr.random())).rejects.toThrow(
-        'no proposed checkpoint exists',
-      );
+      await expect(
+        store.promoteProposedToCheckpointed(CheckpointNumber(2), makeL1PublishedData(20), [], Fr.random()),
+      ).rejects.toThrow('no proposed checkpoint exists');
     });
 
     it('throws on archive root mismatch', async () => {
       await setupProposedCheckpoint();
 
-      await expect(store.promoteProposedToCheckpointed(makeL1PublishedData(20), [], Fr.random())).rejects.toThrow(
-        'archive root mismatch',
-      );
+      await expect(
+        store.promoteProposedToCheckpointed(CheckpointNumber(2), makeL1PublishedData(20), [], Fr.random()),
+      ).rejects.toThrow('archive root mismatch');
 
       // Proposed checkpoint should still exist (transaction rolled back)
       expect(await store.blockStore.hasProposedCheckpoint()).toBe(true);
@@ -4102,7 +4101,7 @@ describe('KVArchiverDataStore', () => {
       await store.addProposedBlock(block2, { force: true });
 
       // Set proposed checkpoint
-      await store.blockStore.setProposedCheckpoint({
+      await store.blockStore.addProposedCheckpoint({
         checkpointNumber: CheckpointNumber(2),
         header: CheckpointHeader.empty(),
         startBlock: BlockNumber(2),

--- a/yarn-project/archiver/src/store/kv_archiver_store.test.ts
+++ b/yarn-project/archiver/src/store/kv_archiver_store.test.ts
@@ -45,6 +45,7 @@ import { type IndexedTxEffect, TxHash } from '@aztec/stdlib/tx';
 import {
   BlockAlreadyCheckpointedError,
   BlockArchiveNotConsistentError,
+  BlockCheckpointNumberNotSequentialError,
   BlockIndexNotSequentialError,
   BlockNumberNotSequentialError,
   CannotOverwriteCheckpointedBlockError,
@@ -1173,7 +1174,7 @@ describe('KVArchiverDataStore', () => {
         indexWithinCheckpoint: IndexWithinCheckpoint(0),
       });
 
-      await expect(store.addProposedBlock(block3)).rejects.toThrow(CheckpointNumberNotSequentialError);
+      await expect(store.addProposedBlock(block3)).rejects.toThrow(BlockCheckpointNumberNotSequentialError);
     });
 
     it('allows blocks with the same checkpoint number for the current checkpoint', async () => {
@@ -1246,7 +1247,7 @@ describe('KVArchiverDataStore', () => {
         indexWithinCheckpoint: IndexWithinCheckpoint(0),
       });
 
-      await expect(store.addProposedBlock(block1)).rejects.toThrow(CheckpointNumberNotSequentialError);
+      await expect(store.addProposedBlock(block1)).rejects.toThrow(BlockCheckpointNumberNotSequentialError);
     });
 
     it('allows adding more blocks to the same checkpoint in separate calls', async () => {
@@ -1328,7 +1329,7 @@ describe('KVArchiverDataStore', () => {
         indexWithinCheckpoint: IndexWithinCheckpoint(0),
         lastArchive: block3.archive,
       });
-      await expect(store.addProposedBlock(block4)).rejects.toThrow(CheckpointNumberNotSequentialError);
+      await expect(store.addProposedBlock(block4)).rejects.toThrow(BlockCheckpointNumberNotSequentialError);
     });
 
     it('force option bypasses checkpoint number validation', async () => {
@@ -3896,8 +3897,8 @@ describe('KVArchiverDataStore', () => {
       });
 
       await expect(store.addProposedBlock(block3)).rejects.toThrow(
-        // Error should report the proposed checkpoint number (2), not the confirmed one (1)
-        'Cannot insert new checkpoint 4 given previous proposed checkpoint number is 2',
+        // Error should report the latest known checkpoint number (the pending one, 2), not the confirmed (1)
+        'Cannot insert new block 3 for checkpoint 4 given previous checkpoint number is 2',
       );
     });
 
@@ -3919,7 +3920,7 @@ describe('KVArchiverDataStore', () => {
       });
 
       await expect(store.addProposedBlock(block2)).rejects.toThrow(
-        'Cannot insert new checkpoint 4 given previous confirmed checkpoint number is 1',
+        'Cannot insert new block 2 for checkpoint 4 given previous checkpoint number is 1',
       );
     });
 

--- a/yarn-project/archiver/src/store/kv_archiver_store.ts
+++ b/yarn-project/archiver/src/store/kv_archiver_store.ts
@@ -626,13 +626,13 @@ export class KVArchiverDataStore implements ContractDataSource {
   }
 
   /** Returns the checkpoint data at the proposed tip */
-  public getProposedCheckpoint(): Promise<CommonCheckpointData | undefined> {
-    return this.#blockStore.getProposedCheckpoint();
+  public getLastCheckpoint(): Promise<CommonCheckpointData | undefined> {
+    return this.#blockStore.getLastCheckpoint();
   }
 
   /** Returns the proposed checkpoint data, or undefined if no proposed checkpoint exists. No fallback to confirmed. */
-  public getProposedCheckpointOnly(): Promise<ProposedCheckpointData | undefined> {
-    return this.#blockStore.getProposedCheckpointOnly();
+  public getLastProposedCheckpoint(): Promise<ProposedCheckpointData | undefined> {
+    return this.#blockStore.getLastProposedCheckpoint();
   }
 
   /**
@@ -640,26 +640,48 @@ export class KVArchiverDataStore implements ContractDataSource {
    * @param proposedCheckpoint
    * @returns
    */
-  public setProposedCheckpoint(proposedCheckpoint: ProposedCheckpointInput): Promise<void> {
-    return this.#blockStore.setProposedCheckpoint(proposedCheckpoint);
+  public addProposedCheckpoint(proposedCheckpoint: ProposedCheckpointInput): Promise<void> {
+    return this.#blockStore.addProposedCheckpoint(proposedCheckpoint);
   }
 
-  /** Deletes the proposed checkpoint from storage. */
-  public deleteProposedCheckpoint(): Promise<void> {
-    return this.#blockStore.deleteProposedCheckpoint();
+  /** Deletes all pending proposed checkpoints from storage. */
+  public deleteProposedCheckpoints(): Promise<void> {
+    return this.#blockStore.deleteProposedCheckpoints();
+  }
+
+  /** Returns the pending checkpoint for a specific checkpoint number, or undefined if not found. */
+  public getProposedCheckpointByNumber(n: CheckpointNumber): Promise<ProposedCheckpointData | undefined> {
+    return this.#blockStore.getProposedCheckpointByNumber(n);
+  }
+
+  /** Returns all pending checkpoints in ascending checkpoint-number order. */
+  public getProposedCheckpoints(): Promise<ProposedCheckpointData[]> {
+    return this.#blockStore.getProposedCheckpoints();
   }
 
   /**
-   * Promotes the proposed checkpoint to a confirmed checkpoint entry.
+   * Evicts all pending checkpoints with checkpoint number >= fromNumber.
+   * Used for divergent-mined-checkpoint cleanup.
+   */
+  public evictProposedCheckpointsFrom(fromNumber: CheckpointNumber): Promise<void> {
+    return this.#blockStore.evictProposedCheckpointsFrom(fromNumber);
+  }
+
+  /**
+   * Promotes a specific pending checkpoint to a confirmed checkpoint entry.
    * Should only be called after the checkpoint has been validated.
+   * @param checkpointNumber - The checkpoint number to promote.
+   * @param l1 - L1 published data for the checkpoint.
+   * @param attestations - Committee attestations.
    * @param expectedArchiveRoot - The archive root to match against the proposed checkpoint, to guard against races.
    */
   public promoteProposedToCheckpointed(
+    checkpointNumber: CheckpointNumber,
     l1: L1PublishedData,
     attestations: CommitteeAttestation[],
     expectedArchiveRoot: Fr,
   ): Promise<void> {
-    return this.#blockStore.promoteProposedToCheckpointed(l1, attestations, expectedArchiveRoot);
+    return this.#blockStore.promoteProposedToCheckpointed(checkpointNumber, l1, attestations, expectedArchiveRoot);
   }
 
   /**

--- a/yarn-project/archiver/src/store/l2_tips_cache.ts
+++ b/yarn-project/archiver/src/store/l2_tips_cache.ts
@@ -108,7 +108,7 @@ export class L2TipsCache {
   private async getCheckpointIdForProposedCheckpoint(
     checkpointedBlockData: Pick<BlockData, 'checkpointNumber'>,
   ): Promise<CheckpointId> {
-    const checkpointData = await this.blockStore.getProposedCheckpointOnly();
+    const checkpointData = await this.blockStore.getLastProposedCheckpoint();
     if (!checkpointData) {
       return this.getCheckpointIdForBlock(checkpointedBlockData);
     }

--- a/yarn-project/archiver/src/test/mock_l2_block_source.ts
+++ b/yarn-project/archiver/src/test/mock_l2_block_source.ts
@@ -558,11 +558,11 @@ export class MockL2BlockSource implements L2BlockSource, ContractDataSource {
     return Promise.resolve({ valid: true });
   }
 
-  getProposedCheckpoint(): Promise<ProposedCheckpointData | undefined> {
+  getLastCheckpoint(): Promise<ProposedCheckpointData | undefined> {
     return Promise.resolve(undefined);
   }
 
-  getProposedCheckpointOnly(): Promise<ProposedCheckpointData | undefined> {
+  getLastProposedCheckpoint(): Promise<ProposedCheckpointData | undefined> {
     return Promise.resolve(undefined);
   }
 

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.test.ts
@@ -315,7 +315,7 @@ describe('sequencer', () => {
       getCheckpointsForEpoch: mockFn().mockResolvedValue([]),
       getCheckpointsDataForEpoch: mockFn().mockResolvedValue([]),
       getSyncedL2SlotNumber: mockFn().mockResolvedValue(SlotNumber(Number.MAX_SAFE_INTEGER)),
-      getProposedCheckpoint: mockFn().mockResolvedValue(undefined),
+      getLastCheckpoint: mockFn().mockResolvedValue(undefined),
     });
 
     l1ToL2MessageSource = mock<L1ToL2MessageSource>({
@@ -1060,7 +1060,7 @@ describe('sequencer', () => {
         checkpointNumber: CheckpointNumber(1),
         indexWithinCheckpoint: IndexWithinCheckpoint(0),
       } satisfies BlockData);
-      l2BlockSource.getProposedCheckpoint.mockResolvedValue({
+      l2BlockSource.getLastCheckpoint.mockResolvedValue({
         checkpointNumber: CheckpointNumber(1),
       } as any);
 
@@ -1121,7 +1121,7 @@ describe('sequencer', () => {
         checkpointNumber: CheckpointNumber(3),
         indexWithinCheckpoint: IndexWithinCheckpoint(0),
       } satisfies BlockData);
-      l2BlockSource.getProposedCheckpoint.mockResolvedValue({
+      l2BlockSource.getLastCheckpoint.mockResolvedValue({
         checkpointNumber: CheckpointNumber(2),
       } as any);
 

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.ts
@@ -377,7 +377,7 @@ export class Sequencer extends (EventEmitter as new () => TypedEventEmitter<Sequ
       // and the archive at that checkpoint so L1 simulation sees the correct chain tip.
       const parentCheckpointNumber = CheckpointNumber(checkpointNumber - 1);
       l1SimulationOverridesBuilder.forPendingCheckpoint(parentCheckpointNumber).withPendingArchive(syncedTo.archive);
-      this.metrics.recordPipelineDepth(1);
+      this.metrics.recordPipelineDepth(syncedTo.checkpointNumber - syncedTo.checkpointedCheckpointNumber);
 
       this.log.verbose(
         `Building on top of proposed checkpoint (pending=${syncedTo.proposedCheckpointData?.checkpointNumber})`,
@@ -581,7 +581,7 @@ export class Sequencer extends (EventEmitter as new () => TypedEventEmitter<Sequ
       this.p2pClient.getStatus().then(p2p => p2p.syncedToL2Block),
       this.l1ToL2MessageSource.getL2Tips().then(t => ({ proposed: t.proposed, checkpointed: t.checkpointed })),
       this.l2BlockSource.getPendingChainValidationStatus(),
-      this.l2BlockSource.getProposedCheckpointOnly(),
+      this.l2BlockSource.getLastProposedCheckpoint(),
     ] as const);
 
     const [worldState, l2Tips, p2p, l1ToL2MessageSourceTips, pendingChainValidationStatus, proposedCheckpointData] =

--- a/yarn-project/stdlib/src/block/l2_block_source.ts
+++ b/yarn-project/stdlib/src/block/l2_block_source.ts
@@ -230,10 +230,10 @@ export interface L2BlockSource {
   getPendingChainValidationStatus(): Promise<ValidateCheckpointResult>;
 
   /** Returns the checkpoint at the proposed chain tip. */
-  getProposedCheckpoint(): Promise<CommonCheckpointData | undefined>;
+  getLastCheckpoint(): Promise<CommonCheckpointData | undefined>;
 
   /** Returns proposed checkpoint, if set, undefined if not*/
-  getProposedCheckpointOnly(): Promise<ProposedCheckpointData | undefined>;
+  getLastProposedCheckpoint(): Promise<ProposedCheckpointData | undefined>;
 
   /** Force a sync. */
   syncImmediate(): Promise<void>;

--- a/yarn-project/stdlib/src/interfaces/archiver.test.ts
+++ b/yarn-project/stdlib/src/interfaces/archiver.test.ts
@@ -358,8 +358,8 @@ describe('ArchiverApiSchema', () => {
     expect(result).toBe(1n);
   });
 
-  it('getProposedCheckpoint', async () => {
-    const result = await context.client.getProposedCheckpoint();
+  it('getLastCheckpoint', async () => {
+    const result = await context.client.getLastCheckpoint();
     expect(result).toEqual({
       checkpointNumber: 1,
       header: expect.any(CheckpointHeader),
@@ -372,8 +372,8 @@ describe('ArchiverApiSchema', () => {
     });
   });
 
-  it('getProposedCheckpointOnly', async () => {
-    const result = await context.client.getProposedCheckpointOnly();
+  it('getLastProposedCheckpoint', async () => {
+    const result = await context.client.getLastProposedCheckpoint();
     expect(result).toEqual({
       checkpointNumber: 1,
       header: expect.any(CheckpointHeader),
@@ -419,10 +419,10 @@ class MockArchiver implements ArchiverApi {
   getPendingChainValidationStatus(): Promise<ValidateCheckpointResult> {
     return Promise.resolve({ valid: true });
   }
-  getProposedCheckpoint(): Promise<ProposedCheckpointData | undefined> {
-    return this.getProposedCheckpointOnly();
+  getLastCheckpoint(): Promise<ProposedCheckpointData | undefined> {
+    return this.getLastProposedCheckpoint();
   }
-  getProposedCheckpointOnly(): Promise<ProposedCheckpointData | undefined> {
+  getLastProposedCheckpoint(): Promise<ProposedCheckpointData | undefined> {
     return Promise.resolve({
       checkpointNumber: CheckpointNumber(1),
       header: CheckpointHeader.random(),

--- a/yarn-project/stdlib/src/interfaces/archiver.ts
+++ b/yarn-project/stdlib/src/interfaces/archiver.ts
@@ -158,8 +158,8 @@ export const ArchiverApiSchema: ApiSchemaFor<ArchiverApi> = {
     .args()
     .returns(z.object({ genesisArchiveRoot: schemas.Fr })),
   getL1Timestamp: z.function().args().returns(schemas.BigInt.optional()),
-  getProposedCheckpoint: z.function().args().returns(ProposedCheckpointDataSchema.optional()),
-  getProposedCheckpointOnly: z.function().args().returns(ProposedCheckpointDataSchema.optional()),
+  getLastCheckpoint: z.function().args().returns(ProposedCheckpointDataSchema.optional()),
+  getLastProposedCheckpoint: z.function().args().returns(ProposedCheckpointDataSchema.optional()),
   syncImmediate: z.function().args().returns(z.void()),
   isPendingChainInvalid: z.function().args().returns(z.boolean()),
   getPendingChainValidationStatus: z.function().args().returns(ValidateCheckpointResultSchema),

--- a/yarn-project/validator-client/src/proposal_handler.test.ts
+++ b/yarn-project/validator-client/src/proposal_handler.test.ts
@@ -189,8 +189,8 @@ describe('ProposalHandler checkpoint validation', () => {
         checkpointHandler = handler;
       });
 
-      const archiver = mock<Pick<Archiver, 'setProposedCheckpoint' | 'getL1Constants'>>();
-      archiver.setProposedCheckpoint.mockResolvedValue(undefined);
+      const archiver = mock<Pick<Archiver, 'addProposedCheckpoint' | 'getL1Constants'>>();
+      archiver.addProposedCheckpoint.mockResolvedValue(undefined);
 
       const blockData = {
         checkpointNumber: CheckpointNumber(3),
@@ -206,7 +206,7 @@ describe('ProposalHandler checkpoint validation', () => {
       handler.register(p2p, true, archiver);
       await checkpointHandler!(proposal, {} as any);
 
-      expect(archiver.setProposedCheckpoint).toHaveBeenCalled();
+      expect(archiver.addProposedCheckpoint).toHaveBeenCalled();
       expect(metrics.recordCheckpointProposalToPipelinedStateDuration).toHaveBeenCalledWith(expect.any(Number));
     });
   });

--- a/yarn-project/validator-client/src/proposal_handler.ts
+++ b/yarn-project/validator-client/src/proposal_handler.ts
@@ -96,7 +96,7 @@ export class ProposalHandler {
   };
 
   /** Archiver reference for setting proposed checkpoints (pipelining). Set via register(). */
-  private archiver?: Pick<Archiver, 'setProposedCheckpoint' | 'getL1Constants'>;
+  private archiver?: Pick<Archiver, 'addProposedCheckpoint' | 'getL1Constants'>;
 
   /** Returns current validator addresses for own-proposal detection. Set via register(). */
   private getOwnValidatorAddresses?: () => string[];
@@ -132,7 +132,7 @@ export class ProposalHandler {
   register(
     p2pClient: P2P,
     shouldReexecute: boolean,
-    archiver?: Pick<Archiver, 'setProposedCheckpoint' | 'getL1Constants'>,
+    archiver?: Pick<Archiver, 'addProposedCheckpoint' | 'getL1Constants'>,
     getOwnValidatorAddresses?: () => string[],
   ): ProposalHandler {
     this.archiver = archiver;
@@ -985,7 +985,7 @@ export class ProposalHandler {
       return false;
     }
 
-    await this.archiver.setProposedCheckpoint({
+    await this.archiver.addProposedCheckpoint({
       header: proposal.checkpointHeader,
       checkpointNumber: blockData.checkpointNumber,
       startBlock: BlockNumber(blockData.header.getBlockNumber() - blockData.indexWithinCheckpoint),
@@ -1023,7 +1023,7 @@ export class ProposalHandler {
     }
 
     if (blockData) {
-      await this.archiver.setProposedCheckpoint({
+      await this.archiver.addProposedCheckpoint({
         header: proposal.checkpointHeader,
         checkpointNumber: blockData.checkpointNumber,
         startBlock: BlockNumber(blockData.header.getBlockNumber() - blockData.indexWithinCheckpoint),


### PR DESCRIPTION
Updates the archiver data store model so that we can account for more than a single proposed checkpoint. Under pipelining, it's possible we receive the proposal for the next checkpoint before we've managed to sync the previous one from L1, thus having two checkpoints unmined.

Also fixes `addProposedCheckpoint` in the archiver so that it goes through the queue, instead of potentially injecting it in the middle of an L1 sync.

Next steps is to review the archiver and node APIs that return checkpoints, and unify whether we return proposed checkpoints along mined checkpoints or not. Related to #22781.

Fixes A-910
