### PR TITLE
fix(stdlib): initialize BarretenbergSync at chonk_proof module load

### DIFF
--- a/yarn-project/stdlib/src/proofs/chonk_proof.test.ts
+++ b/yarn-project/stdlib/src/proofs/chonk_proof.test.ts
@@ -1,3 +1,4 @@
+import { BarretenbergSync } from '@aztec/bb.js';
 import { CHONK_PROOF_LENGTH } from '@aztec/constants';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { numToUInt32BE } from '@aztec/foundation/serialize';
@@ -5,6 +6,10 @@ import { numToUInt32BE } from '@aztec/foundation/serialize';
 import { ChonkProof, ChonkProofWithPublicInputs } from './chonk_proof.js';
 
 describe('ChonkProof', () => {
+  it('initializes BarretenbergSync at module load so sync deserialization works', () => {
+    expect(() => BarretenbergSync.getSingleton()).not.toThrow();
+  });
+
   it('should throw error with incorrect length', () => {
     const fields = Array.from({ length: CHONK_PROOF_LENGTH + 1 }, () => Fr.random());
     expect(() => new ChonkProof(fields)).toThrow(`Invalid ChonkProof length: ${CHONK_PROOF_LENGTH + 1}`);

--- a/yarn-project/stdlib/src/proofs/chonk_proof.ts
+++ b/yarn-project/stdlib/src/proofs/chonk_proof.ts
@@ -6,6 +6,12 @@ import { Fr } from '@aztec/foundation/curves/bn254';
 import { bufferSchemaFor } from '@aztec/foundation/schemas';
 import { BufferReader, numToUInt32BE, serializeToBuffer } from '@aztec/foundation/serialize';
 
+// ChonkProof.fromCompressedBytes uses BarretenbergSync synchronously, which throws if the
+// singleton has not been initialized. Tx.fromBuffer is sync and called from many code paths
+// (RPC handlers, P2P deserialization), so we cannot make initialization lazy. Init at module
+// load so any process that imports ChonkProof can deserialize compressed proofs.
+await BarretenbergSync.initSingleton();
+
 /**
  * Serialization format detection for ChonkProof is size-based:
  *   - UNCOMPRESSED (legacy): [field_count=1632: uint32] [fields...]  → total ≈ 52KB (>= 40KB)


### PR DESCRIPTION
## Summary

`ChonkProof.fromCompressedBytes` calls `BarretenbergSync.getSingleton()` synchronously. `Tx.fromBuffer` reaches this path from RPC handlers and P2P deserialization, so initialization can't be made lazy.

Without an explicit init, a fresh process — e.g. a remote `aztec-node` receiving a compressed `Tx` over `aztecNode.sendTx` JSON-RPC — throws `First call BarretenbergSync.initSingleton() on @aztec/bb.js module.`

This regression was introduced by #21306 (`feat: wire chonk proof compression through bbjs API for network serialization`), which made compressed proofs the new wire format. Compressed proofs are emitted by every prover, so any node deserializing tx traffic eventually trips it.

The failure broke the nightly `block_capacity` benchmark on `merge-train/spartan`: http://ci.aztec-labs.com/3be8e772c7a68ae9.

## Fix

Add a top-level `await BarretenbergSync.initSingleton()` in `chonk_proof.ts` so any process that imports `ChonkProof` has the singleton ready before the first sync call. Same pattern as `foundation/src/crypto/sync/index.ts`.

## Test plan

- New unit test in `chonk_proof.test.ts` asserts `BarretenbergSync.getSingleton()` does not throw immediately after importing `ChonkProof`. Verified the test fails without the fix and passes with it.
- Existing `chonk_proof.test.ts` cases continue to pass.