### PR TITLE
docs: add wallet SDK integration guides for v4.2.0

### DIFF
--- a/docs/developer_versioned_docs/version-v4.2.0/docs/aztec-js/wallet-sdk/_category_.json
+++ b/docs/developer_versioned_docs/version-v4.2.0/docs/aztec-js/wallet-sdk/_category_.json
@@ -1,0 +1,6 @@
+{
+  "label": "Wallet SDK",
+  "position": 9,
+  "collapsible": true,
+  "collapsed": true
+}

--- a/docs/developer_versioned_docs/version-v4.2.0/docs/aztec-js/wallet-sdk/dapp_integration.md
+++ b/docs/developer_versioned_docs/version-v4.2.0/docs/aztec-js/wallet-sdk/dapp_integration.md
@@ -1,0 +1,191 @@
+---
+title: Connecting a dApp to a wallet
+sidebar_position: 1
+tags: [wallet, sdk, dapp]
+description: Discover wallet extensions, establish an encrypted channel, request capabilities, and use the wallet from a dApp on Aztec.
+---
+
+This guide shows how a dApp connects to an Aztec wallet extension using `@aztec/wallet-sdk`. The flow is: discover wallets, establish a secure channel, verify with emojis, request capabilities, then use the wallet.
+
+## Prerequisites
+
+- A wallet extension installed in the browser that implements the Aztec wallet SDK protocol.
+- An Aztec node URL the wallet can connect to.
+
+## Install
+
+```bash
+yarn add @aztec/wallet-sdk@4.2.0 @aztec/aztec.js@4.2.0
+```
+
+Common imports:
+
+```typescript
+import {
+  WalletManager,
+  type WalletProvider,
+  type PendingConnection,
+} from '@aztec/wallet-sdk/manager';
+import { hashToEmoji } from '@aztec/wallet-sdk/crypto';
+import type {
+  Wallet,
+  AppCapabilities,
+  GrantedAccountsCapability,
+} from '@aztec/aztec.js/wallet';
+```
+
+## Step 1: Discover wallets
+
+`WalletManager.configure()` returns a manager configured for one or more provider types. `getAvailableWallets()` broadcasts a discovery request and returns a `DiscoverySession` that streams `WalletProvider` instances as users approve the request inside each extension.
+
+```typescript
+import { Fr } from '@aztec/aztec.js/fields';
+
+const manager = WalletManager.configure({
+  extensions: { enabled: true },
+});
+
+const discovery = manager.getAvailableWallets({
+  appId: 'my-app',
+  // chainInfo is the chain the dApp wants to connect to. Wallets configured
+  // for a different chain will not respond to discovery.
+  chainInfo: { chainId: new Fr(31337), version: new Fr(1) },
+  onWalletDiscovered: (provider) => {
+    console.log(`Found wallet: ${provider.name} (${provider.id})`);
+  },
+});
+
+await discovery.done;
+discovery.cancel();
+```
+
+The `extensions` config also accepts an optional `allowList` and `blockList` of wallet IDs. `chainInfo` typically comes from the connected Aztec node: call `node.getNodeInfo()` to read `l1ChainId` and `rollupVersion`.
+
+To discover web/iframe wallets alongside extensions, pass a `webWallets` block too. Both kinds of provider are returned in the same `DiscoverySession`:
+
+```typescript
+WalletManager.configure({
+  extensions: { enabled: true },
+  webWallets: { urls: ['https://wallet.example.com'] },
+});
+```
+
+Each `WalletProvider` has `id`, `name`, `icon`, optional `metadata`, and the methods used in the next steps. A `WalletProvider` is only emitted after the user explicitly approves the request inside the extension popup, so websites cannot silently enumerate which wallets the user has installed. The session itself completes when discovery times out, the user cancels, or you call `discovery.cancel()`.
+
+## Step 2: Establish a secure channel
+
+Once the user picks a provider, perform the ECDH key exchange:
+
+```typescript
+const pending: PendingConnection = await provider.establishSecureChannel('my-app');
+
+const verificationEmojis = hashToEmoji(pending.verificationHash);
+// Display verificationEmojis to the user. They must match the grid the wallet shows.
+```
+
+`establishSecureChannel` returns a `PendingConnection` with:
+
+- `verificationHash`: hex string both sides compute independently.
+- `confirm()`: finalizes the connection and returns a `Wallet` proxy.
+- `cancel()`: aborts the pending connection.
+
+## Step 3: Emoji verification
+
+Both the dApp and the wallet derive the same 9-emoji grid from the verification hash. Show the emojis prominently and let the user confirm they match before calling `confirm()`:
+
+```typescript
+const wallet: Wallet = await pending.confirm();
+```
+
+If the user reports they do not match, call `pending.cancel()` and start over.
+
+Some wallets choose to remember origins they have approved before, and may streamline the second connection by skipping the emoji step. That is wallet policy, not part of the protocol; the dApp uses the same flow either way.
+
+## Step 4: Request capabilities
+
+After `confirm()` you have a `Wallet` proxy. The SDK does not enforce any permission check on it; capability negotiation is a wallet-policy convention. To play well with wallets that enforce capabilities, build an `AppCapabilities` manifest describing what your app needs and pass it to `requestCapabilities()` before calling privileged methods:
+
+```typescript
+const manifest: AppCapabilities = {
+  version: '1.0',
+  metadata: {
+    name: 'My App',
+    version: '0.1.0',
+    description: 'Example dApp',
+    url: 'https://example.com',
+  },
+  capabilities: [
+    { type: 'accounts', canGet: true, canCreateAuthWit: true },
+    { type: 'simulation', transactions: { scope: '*' }, utilities: { scope: '*' } },
+    { type: 'transaction', scope: '*' },
+  ],
+};
+
+const result = await wallet.requestCapabilities(manifest);
+```
+
+The wallet returns a `WalletCapabilities` object whose `granted` array lists the capabilities the user approved. Capabilities not in `granted` are implicitly denied.
+
+| Capability `type` | Grants | Key fields |
+|---|---|---|
+| `accounts` | Reading accounts, creating auth witnesses | `canGet`, `canCreateAuthWit` |
+| `contracts` | Registering contracts, querying contract metadata | `contracts: '*' \| AztecAddress[]`, `canRegister`, `canGetMetadata` |
+| `contractClasses` | Querying contract class metadata | `classes: '*' \| Fr[]`, `canGetMetadata` |
+| `simulation` | Simulating transactions and utility calls | `transactions.scope`, `utilities.scope` |
+| `transaction` | Sending state-changing transactions | `scope: '*' \| ContractFunctionPattern[]` |
+| `data` | Reading address book and private events | `addressBook`, `privateEvents.contracts` |
+
+The wallet decides which accounts to share. Pull the granted account list from the capability response. This is the recommended way to get the connected accounts at connection time. `wallet.getAccounts()` is for later reads against an already-connected wallet:
+
+```typescript
+const accountsCap = result.granted.find(
+  (c): c is GrantedAccountsCapability => c.type === 'accounts',
+);
+
+if (!accountsCap?.accounts?.length) {
+  throw new Error('No accounts granted by wallet');
+}
+
+const account = accountsCap.accounts[0];
+```
+
+## Step 5: Use the wallet
+
+The `Wallet` instance behaves like any other wallet. Every method call is encrypted in transit, but whether a given call is allowed is up to the wallet, based on what it granted (or did not grant) in step 4:
+
+```typescript
+const accounts = await wallet.getAccounts();
+await wallet.registerContract(contractInstance, contractArtifact);
+
+const receipt = await wallet.sendTx(executionPayload, { from: account.item });
+const simulation = await wallet.simulateTx(executionPayload, { from: account.item });
+
+const authWit = await wallet.createAuthWit(account.item, intent);
+
+const results = await wallet.batch([
+  { name: 'simulateTx', args: [payload1, opts1] },
+  { name: 'simulateTx', args: [payload2, opts2] },
+]);
+```
+
+## Disconnect handling
+
+A wallet can disconnect unexpectedly: the extension might be unloaded, or the user may disconnect from the popup. The `WalletProvider` returned by discovery exposes the disconnect API. Keep the `provider` reference around after `confirm()` so you can register callbacks on it:
+
+```typescript
+const unsubscribe = provider.onDisconnect(() => {
+  // Show a reconnect prompt or fall back to a different wallet.
+});
+
+if (provider.isDisconnected()) {
+  // Handle the disconnected state.
+}
+
+await provider.disconnect();
+```
+
+## Reference
+
+- API reference: [`@aztec/wallet-sdk` reference](pathname:///typescript-api/mainnet/wallet-sdk.md), [`@aztec/aztec.js/wallet` reference](pathname:///typescript-api/mainnet/aztec.js.md).
+- Capability type definitions: [`yarn-project/aztec.js/src/wallet/capabilities.ts`](https://github.com/AztecProtocol/aztec-packages/blob/v4.2.0/yarn-project/aztec.js/src/wallet/capabilities.ts) at v4.2.0.
+- `WalletManager` source: [`yarn-project/wallet-sdk/src/manager/wallet_manager.ts`](https://github.com/AztecProtocol/aztec-packages/blob/v4.2.0/yarn-project/wallet-sdk/src/manager/wallet_manager.ts) at v4.2.0.

--- a/docs/developer_versioned_docs/version-v4.2.0/docs/aztec-js/wallet-sdk/dapp_integration.md
+++ b/docs/developer_versioned_docs/version-v4.2.0/docs/aztec-js/wallet-sdk/dapp_integration.md
@@ -38,8 +38,14 @@ import type {
 
 `WalletManager.configure()` returns a manager configured for one or more provider types. `getAvailableWallets()` broadcasts a discovery request and returns a `DiscoverySession` that streams `WalletProvider` instances as users approve the request inside each extension.
 
+`chainInfo` tells wallets which chain the dApp wants to connect to. Read it from the connected Aztec node so the values track whatever network the user is on:
+
 ```typescript
 import { Fr } from '@aztec/aztec.js/fields';
+import { createAztecNodeClient } from '@aztec/aztec.js/node';
+
+const node = await createAztecNodeClient('http://localhost:8080');
+const { l1ChainId, rollupVersion } = await node.getNodeInfo();
 
 const manager = WalletManager.configure({
   extensions: { enabled: true },
@@ -47,9 +53,10 @@ const manager = WalletManager.configure({
 
 const discovery = manager.getAvailableWallets({
   appId: 'my-app',
-  // chainInfo is the chain the dApp wants to connect to. Wallets configured
-  // for a different chain will not respond to discovery.
-  chainInfo: { chainId: new Fr(31337), version: new Fr(1) },
+  chainInfo: {
+    chainId: new Fr(l1ChainId),
+    version: new Fr(rollupVersion),
+  },
   onWalletDiscovered: (provider) => {
     console.log(`Found wallet: ${provider.name} (${provider.id})`);
   },
@@ -59,7 +66,7 @@ await discovery.done;
 discovery.cancel();
 ```
 
-The `extensions` config also accepts an optional `allowList` and `blockList` of wallet IDs. `chainInfo` typically comes from the connected Aztec node: call `node.getNodeInfo()` to read `l1ChainId` and `rollupVersion`.
+Wallets configured for a different chain will not respond. The `extensions` config also accepts an optional `allowList` and `blockList` of wallet IDs.
 
 To discover web/iframe wallets alongside extensions, pass a `webWallets` block too. Both kinds of provider are returned in the same `DiscoverySession`:
 

--- a/docs/developer_versioned_docs/version-v4.2.0/docs/aztec-js/wallet-sdk/dapp_integration.md
+++ b/docs/developer_versioned_docs/version-v4.2.0/docs/aztec-js/wallet-sdk/dapp_integration.md
@@ -90,7 +90,7 @@ WalletManager.configure({
 });
 ```
 
-Each `WalletProvider` has `id`, `name`, `icon`, optional `metadata`, and the methods used in the next steps. A `WalletProvider` is only emitted after the user explicitly approves the request inside the extension popup, so websites cannot silently enumerate which wallets the user has installed. The session itself completes when discovery times out, the user cancels, or you call `discovery.cancel()`.
+Each `WalletProvider` has `id`, `name`, `icon`, optional `metadata`, and the methods used in the next steps. For extension wallets, a `WalletProvider` is only emitted after the user explicitly approves the request inside the extension popup, so websites cannot silently enumerate which extension wallets the user has installed. Web/iframe wallets respond to the discovery probe automatically without a popup, so a `WalletProvider` from `webWallets` does not imply user approval; only the per-connection emoji step in Step 3 authenticates the wallet to the user. The session itself resolves when discovery times out or you call `discovery.cancel()`; a wallet that rejects the request is silent on the dApp side.
 
 ## Step 2: Establish a secure channel
 
@@ -108,6 +108,8 @@ const verificationEmojis = hashToEmoji(pending.verificationHash);
 - `verificationHash`: hex string both sides compute independently.
 - `confirm()`: finalizes the connection and returns a `Wallet` proxy.
 - `cancel()`: aborts the pending connection.
+
+`establishSecureChannel` rejects if key exchange times out (default 2 seconds) or the wallet never responds. Treat any rejection as a hard reset: call `pending.cancel()` if you held onto the value, drop any `verificationHash` you displayed, and let the user retry from Step 1.
 
 ## Step 3: Emoji verification
 

--- a/docs/developer_versioned_docs/version-v4.2.0/docs/aztec-js/wallet-sdk/dapp_integration.md
+++ b/docs/developer_versioned_docs/version-v4.2.0/docs/aztec-js/wallet-sdk/dapp_integration.md
@@ -9,8 +9,8 @@ This guide shows how a dApp connects to an Aztec wallet extension using `@aztec/
 
 ## Prerequisites
 
-- A wallet extension installed in the browser that implements the Aztec wallet SDK protocol.
-- An Aztec node URL the wallet can connect to.
+- A wallet extension installed in the browser that implements the Aztec wallet SDK protocol, for example [Azguard](https://azguardwallet.io/).
+- An Aztec node URL the wallet can connect to. Run one locally with the [getting started on local network](../../../getting_started_on_local_network.md) guide, or use a public endpoint from [getting started on testnet](../../../getting_started_on_testnet.md).
 
 ## Install
 
@@ -35,6 +35,8 @@ import type {
 ```
 
 ## Step 1: Discover wallets
+
+`WalletManager` is the dApp-side coordinator from `@aztec/wallet-sdk/manager` for finding wallet extensions and brokering the secure-channel handshake with the one the user picks. Configure it once per page load and reuse it for the rest of the flow.
 
 `WalletManager.configure()` returns a manager configured for one or more provider types. `getAvailableWallets()` broadcasts a discovery request and returns a `DiscoverySession` that streams `WalletProvider` instances as users approve the request inside each extension.
 
@@ -112,6 +114,8 @@ const verificationEmojis = hashToEmoji(pending.verificationHash);
 `establishSecureChannel` rejects if key exchange times out (default 2 seconds) or the wallet never responds. Treat any rejection as a hard reset: call `pending.cancel()` if you held onto the value, drop any `verificationHash` you displayed, and let the user retry from Step 1.
 
 ## Step 3: Emoji verification
+
+The emoji grid is how the user confirms the dApp and the wallet completed the key exchange directly with each other, and not with an attacker in the middle. Both sides derive the grid deterministically from the shared secret, so matching emojis on the dApp screen and the wallet popup mean no third party intercepted the handshake. A mismatch means the channel is compromised and must be torn down.
 
 Both the dApp and the wallet derive the same 9-emoji grid from the verification hash. Show the emojis prominently and let the user confirm they match before calling `confirm()`:
 
@@ -211,3 +215,4 @@ await provider.disconnect();
 - API reference: [`@aztec/wallet-sdk` reference](pathname:///typescript-api/mainnet/wallet-sdk.md), [`@aztec/aztec.js/wallet` reference](pathname:///typescript-api/mainnet/aztec.js.md).
 - Capability type definitions: [`yarn-project/aztec.js/src/wallet/capabilities.ts`](https://github.com/AztecProtocol/aztec-packages/blob/v4.2.0/yarn-project/aztec.js/src/wallet/capabilities.ts) at v4.2.0.
 - `WalletManager` source: [`yarn-project/wallet-sdk/src/manager/wallet_manager.ts`](https://github.com/AztecProtocol/aztec-packages/blob/v4.2.0/yarn-project/wallet-sdk/src/manager/wallet_manager.ts) at v4.2.0.
+- Reference wallet implementation: [`AztecProtocol/demo-wallet`](https://github.com/AztecProtocol/demo-wallet). End-to-end open-source wallet showing the other side of the discovery, key exchange, and capability flows described above.

--- a/docs/developer_versioned_docs/version-v4.2.0/docs/aztec-js/wallet-sdk/dapp_integration.md
+++ b/docs/developer_versioned_docs/version-v4.2.0/docs/aztec-js/wallet-sdk/dapp_integration.md
@@ -51,6 +51,8 @@ const manager = WalletManager.configure({
   extensions: { enabled: true },
 });
 
+const providers: WalletProvider[] = [];
+
 const discovery = manager.getAvailableWallets({
   appId: 'my-app',
   chainInfo: {
@@ -58,15 +60,26 @@ const discovery = manager.getAvailableWallets({
     version: new Fr(rollupVersion),
   },
   onWalletDiscovered: (provider) => {
-    console.log(`Found wallet: ${provider.name} (${provider.id})`);
+    providers.push(provider);
+    renderWalletPicker(providers); // your UI hook
   },
 });
-
-await discovery.done;
-discovery.cancel();
 ```
 
-Wallets configured for a different chain will not respond. The `extensions` config also accepts an optional `allowList` and `blockList` of wallet IDs.
+Wallets are streamed via `onWalletDiscovered` as soon as the user approves the request in each extension; do not block on `discovery.done` before showing options. The default discovery timeout is 60 seconds, but you should let the user pick as soon as the first acceptable wallet arrives:
+
+```typescript
+async function onUserPicked(provider: WalletProvider) {
+  discovery.cancel();
+  // proceed to Step 2 with this provider
+}
+```
+
+`discovery.done` is still useful if you want to wait for the timeout to elapse before declaring "no wallets found." Call `discovery.cancel()` once a wallet is selected or the user gives up.
+
+The `extensions` config also accepts an optional `allowList` and `blockList` of wallet IDs to constrain which wallets you will accept.
+
+Chain matching is wallet policy, not enforced by `WalletManager`. The SDK passes `chainInfo` through the discovery message, but it is up to each wallet to inspect it and decline (for example, by refusing approval in its popup) when the user's selected network does not match. Treat any wallet that responds as a candidate and re-check via `wallet.getChainInfo()` after the connection is established if you need a strong guarantee.
 
 To discover web/iframe wallets alongside extensions, pass a `webWallets` block too. Both kinds of provider are returned in the same `DiscoverySession`:
 
@@ -81,7 +94,7 @@ Each `WalletProvider` has `id`, `name`, `icon`, optional `metadata`, and the met
 
 ## Step 2: Establish a secure channel
 
-Once the user picks a provider, perform the ECDH key exchange:
+Once the user picks a provider (the `provider` argument passed to `onUserPicked` above), perform the ECDH key exchange:
 
 ```typescript
 const pending: PendingConnection = await provider.establishSecureChannel('my-app');

--- a/docs/developer_versioned_docs/version-v4.2.0/docs/aztec-js/wallet-sdk/index.md
+++ b/docs/developer_versioned_docs/version-v4.2.0/docs/aztec-js/wallet-sdk/index.md
@@ -1,0 +1,58 @@
+---
+title: Wallet SDK
+sidebar_position: 0
+tags: [wallet, sdk]
+description: How dApps and wallet extensions communicate on Aztec, covering discovery, encrypted channels, capability permissions, and BaseWallet.
+---
+
+The `@aztec/wallet-sdk` package defines the protocol that dApps and wallet extensions use to talk to each other on Aztec. It is analogous to EIP-1193 on Ethereum, with built-in encryption and visual MITM verification.
+
+This section covers both sides of the integration:
+
+- [Connecting a dApp to a wallet](./dapp_integration.md): discovery, secure channel, capabilities, and using the `Wallet` proxy.
+- [Building a wallet extension](./wallet_integration.md): implementing discovery, sessions, message routing, and `BaseWallet`.
+
+For a complete API listing, see the [`@aztec/wallet-sdk` reference](pathname:///typescript-api/mainnet/wallet-sdk.md).
+
+## What the SDK provides
+
+| Feature | Description |
+|---|---|
+| Wallet discovery | dApps broadcast via `window.postMessage`; extensions respond after user approval |
+| ECDH key exchange | P-256 ephemeral key pairs derive a shared secret per session |
+| AES-256-GCM encryption | All wallet method calls and responses are encrypted after key exchange |
+| Emoji verification | A 9-emoji grid (72-bit security) lets the user confirm there is no man-in-the-middle |
+| Capability permissions | dApps declare what they need; wallets grant or deny each capability |
+| Trusted origin reconnect | Wallets may remember origins they have approved before and streamline later reconnects (wallet-managed policy, not framework state) |
+| `BaseWallet` | Abstract class that wallet extensions extend to get `sendTx`, `simulateTx`, `batch`, and more |
+
+## Architecture
+
+```mermaid
+flowchart LR
+    dApp["**dApp**<br/>WalletManager"]
+    CS["**Content Script**<br/>ContentScriptConnectionHandler"]
+    BG["**Background Service Worker**<br/>BackgroundConnectionHandler"]
+    Wallet["**Wallet implementation**<br/>BaseWallet subclass + PXE"]
+
+    dApp <-- "window.postMessage<br/>(discovery only)" --> CS
+    dApp <== "MessagePort<br/>(encrypted payloads)" ==> CS
+    CS <-- "chrome.runtime<br/>(relays encrypted payloads)" --> BG
+    BG -- "persistent port" --> Wallet
+```
+
+Discovery uses `window.postMessage` (unencrypted, public). When the user approves the request, the content script creates a `MessageChannel` and transfers one port to the page. The dApp and the content script share the encrypted channel directly; the content script relays payloads to the background service worker over `chrome.runtime`. Encryption keys live on the dApp and the background, so the content script and `chrome.runtime` only see ciphertext.
+
+## Security model
+
+The protocol has three phases with increasing trust.
+
+1. **Discovery (public).** The dApp broadcasts a request. Extensions only respond after the user explicitly approves the connection in their extension popup. No cryptographic material is exchanged.
+2. **Key exchange (authenticated).** Both sides generate ephemeral ECDH P-256 key pairs. The shared secret is expanded via HKDF into an AES-256-GCM encryption key and an HMAC verification key. A 2-second timeout limits the window for interception.
+3. **Verified channel (encrypted).** The HMAC verification key produces a hash that both sides convert to a 9-emoji grid. The user visually confirms the emojis match on both the dApp and the wallet, defending against man-in-the-middle attacks. After confirmation, all messages are encrypted with AES-256-GCM.
+
+## Where to start
+
+- Building a dApp that needs to connect to a wallet → [Connecting a dApp to a wallet](./dapp_integration.md).
+- Building a browser extension wallet → [Building a wallet extension](./wallet_integration.md).
+- Need a quick conceptual primer on what wallets do → [Wallets foundational topic](../../foundational-topics/wallets.md).

--- a/docs/developer_versioned_docs/version-v4.2.0/docs/aztec-js/wallet-sdk/index.md
+++ b/docs/developer_versioned_docs/version-v4.2.0/docs/aztec-js/wallet-sdk/index.md
@@ -48,8 +48,8 @@ Discovery uses `window.postMessage` (unencrypted, public). When the user approve
 The protocol has three phases with increasing trust.
 
 1. **Discovery (public).** The dApp broadcasts a request. Extensions only respond after the user explicitly approves the connection in their extension popup. No cryptographic material is exchanged.
-2. **Key exchange (authenticated).** Both sides generate ephemeral ECDH P-256 key pairs. The shared secret is expanded via HKDF into an AES-256-GCM encryption key and an HMAC verification key. A 2-second timeout limits the window for interception.
-3. **Verified channel (encrypted).** The HMAC verification key produces a hash that both sides convert to a 9-emoji grid. The user visually confirms the emojis match on both the dApp and the wallet, defending against man-in-the-middle attacks. After confirmation, all messages are encrypted with AES-256-GCM.
+2. **Key exchange (unauthenticated ECDH).** Both sides generate ephemeral ECDH P-256 key pairs and derive a shared secret. The secret is expanded via HKDF into an AES-256-GCM encryption key and a separate HMAC key. A 2-second timeout limits the window for interception. The exchange itself is not authenticated; an attacker who relays it can sit in the middle until phase 3 catches them.
+3. **Verified channel (authenticated, encrypted).** The HMAC key produces a verification hash that both sides convert to the same 9-emoji grid. The user visually confirms the emojis match on the dApp and the wallet, which authenticates the session out of band and defends against man-in-the-middle attacks. After confirmation, all messages are encrypted with AES-256-GCM.
 
 ## Where to start
 

--- a/docs/developer_versioned_docs/version-v4.2.0/docs/aztec-js/wallet-sdk/index.md
+++ b/docs/developer_versioned_docs/version-v4.2.0/docs/aztec-js/wallet-sdk/index.md
@@ -48,8 +48,8 @@ Discovery uses `window.postMessage` (unencrypted, public). When the user approve
 The protocol has three phases with increasing trust.
 
 1. **Discovery (public).** The dApp broadcasts a request. Extensions only respond after the user explicitly approves the connection in their extension popup. No cryptographic material is exchanged.
-2. **Key exchange (unauthenticated ECDH).** Both sides generate ephemeral ECDH P-256 key pairs and derive a shared secret. The secret is expanded via HKDF into an AES-256-GCM encryption key and a separate HMAC key. A 2-second timeout limits the window for interception. The exchange itself is not authenticated; an attacker who relays it can sit in the middle until phase 3 catches them.
-3. **Verified channel (authenticated, encrypted).** The HMAC key produces a verification hash that both sides convert to the same 9-emoji grid. The user visually confirms the emojis match on the dApp and the wallet, which authenticates the session out of band and defends against man-in-the-middle attacks. After confirmation, all messages are encrypted with AES-256-GCM.
+2. **Key exchange (unauthenticated ECDH).** Both sides generate ephemeral ECDH P-256 key pairs and derive a shared secret. The secret is expanded via HKDF into an AES-256-GCM encryption key and a separate HMAC key. All wallet messages exchanged from this point on are encrypted with AES-256-GCM. The exchange itself is not authenticated, though an attacker who relays it can sit in the middle until phase 3 catches them.
+3. **Out-of-band authentication via emoji verification.** The HMAC key produces a verification hash that both sides convert to the same 9-emoji grid. The user visually confirms the emojis match on the dApp and the wallet, which authenticates the encrypted channel out of band and defends against man-in-the-middle attacks. The SDK itself does not gate messages on this confirmation; if you want to defer sensitive operations until the user has matched the emojis, your wallet code must do so.
 
 ## Where to start
 

--- a/docs/developer_versioned_docs/version-v4.2.0/docs/aztec-js/wallet-sdk/index.md
+++ b/docs/developer_versioned_docs/version-v4.2.0/docs/aztec-js/wallet-sdk/index.md
@@ -49,7 +49,7 @@ The protocol has three phases with increasing trust.
 
 1. **Discovery (public).** The dApp broadcasts a request. Extensions only respond after the user explicitly approves the connection in their extension popup. No cryptographic material is exchanged.
 2. **Key exchange (unauthenticated ECDH).** Both sides generate ephemeral ECDH P-256 key pairs and derive a shared secret. The secret is expanded via HKDF into an AES-256-GCM encryption key and a separate HMAC key. All wallet messages exchanged from this point on are encrypted with AES-256-GCM. The exchange itself is not authenticated, though an attacker who relays it can sit in the middle until phase 3 catches them.
-3. **Out-of-band authentication via emoji verification.** The HMAC key produces a verification hash that both sides convert to the same 9-emoji grid. The user visually confirms the emojis match on the dApp and the wallet, which authenticates the encrypted channel out of band and defends against man-in-the-middle attacks. The SDK itself does not gate messages on this confirmation; if you want to defer sensitive operations until the user has matched the emojis, your wallet code must do so.
+3. **Channel authentication via emoji verification.** The HMAC key produces a verification hash that both sides convert to the same 9-emoji grid. The user visually confirms the emojis match on the dApp and the wallet, which authenticates the encrypted channel out of band and defends against man-in-the-middle attacks. The SDK itself does not gate messages on this confirmation; if you want to defer sensitive operations until the user has matched the emojis, your wallet code must do so.
 
 ## Where to start
 

--- a/docs/developer_versioned_docs/version-v4.2.0/docs/aztec-js/wallet-sdk/wallet_integration.md
+++ b/docs/developer_versioned_docs/version-v4.2.0/docs/aztec-js/wallet-sdk/wallet_integration.md
@@ -1,0 +1,195 @@
+---
+title: Building a wallet extension
+sidebar_position: 2
+tags: [wallet, sdk, extension]
+description: Implement the Aztec wallet SDK protocol in a browser extension. Covers discovery, sessions, message routing, and BaseWallet.
+---
+
+This page is a reference for wallet extension developers. It walks through each piece of the integration without prescribing a full project layout. For the canonical source you can browse alongside this guide, see [`yarn-project/wallet-sdk/`](https://github.com/AztecProtocol/aztec-packages/tree/v4.2.0/yarn-project/wallet-sdk) at v4.2.0.
+
+## Components
+
+A typical Manifest V3 extension wallet has three components that use the SDK:
+
+| Component | SDK class | Responsibility |
+|---|---|---|
+| Content script | `ContentScriptConnectionHandler` | Relay messages between the page and the background |
+| Background service worker | `BackgroundConnectionHandler` | Manage sessions, route messages, trigger user approvals |
+| Wallet host (e.g. an offscreen document) | `BaseWallet` subclass | Execute wallet methods (`sendTx`, `simulateTx`, etc.) |
+
+A Manifest V3 service worker has a 5-minute inactivity timeout and limited WASM support. PXE state and proof generation typically live in an offscreen document so they survive longer than the service worker.
+
+## Install
+
+```bash
+yarn add @aztec/wallet-sdk@4.2.0 @aztec/aztec.js@4.2.0 @aztec/pxe@4.2.0
+```
+
+## Content script
+
+The content script never sees encryption keys. Construct a `ContentScriptConnectionHandler` with a transport that knows how to talk to your background service worker, then call `start()`:
+
+```typescript
+import { ContentScriptConnectionHandler } from '@aztec/wallet-sdk/extension/handlers';
+
+const handler = new ContentScriptConnectionHandler({
+  sendToBackground: (message) => chrome.runtime.sendMessage(message),
+  addBackgroundListener: (listener) => chrome.runtime.onMessage.addListener(listener),
+});
+
+handler.start();
+```
+
+## Background service worker
+
+The background script is where most of the SDK integration lives. Construct a `BackgroundConnectionHandler` with your wallet's identity, a transport, and a set of callbacks:
+
+```typescript
+import { BackgroundConnectionHandler } from '@aztec/wallet-sdk/extension/handlers';
+
+const WALLET_CONFIG = {
+  walletId: 'my-wallet',
+  walletName: 'My Aztec Wallet',
+  walletVersion: '1.0.0',
+  // walletIcon is optional. Omit it if you don't have one; dApps render a fallback.
+  walletIcon: 'data:image/png;base64,...',
+};
+
+const transport = {
+  sendToTab: (tabId, message) => chrome.tabs.sendMessage(tabId, message),
+  addContentListener: (handler) => chrome.runtime.onMessage.addListener(handler),
+};
+
+const handler = new BackgroundConnectionHandler(WALLET_CONFIG, transport, callbacks);
+handler.initialize();
+```
+
+Chain selection is per-session, not per-wallet. The dApp passes its target `chainInfo` in the discovery request, and `BackgroundConnectionHandler` exposes it to your callbacks via `PendingDiscovery.chainInfo`.
+
+### Callbacks
+
+The handler exposes four optional callbacks at different protocol stages.
+
+#### `onPendingDiscovery`
+
+Fired when a dApp broadcasts a discovery request. Decide whether to auto-approve (trusted origin) or open the popup so the user can approve:
+
+```typescript
+async onPendingDiscovery({ requestId, origin, tabId }) {
+  // Optional: terminate stale sessions from the same tab on page refresh.
+  for (const s of handler.getActiveSessions()) {
+    if (s.tabId === tabId) handler.terminateSession(s.sessionId);
+  }
+
+  if (await isTrustedOrigin(origin)) {
+    handler.approveDiscovery(requestId);
+  } else {
+    await openApprovalPopup({ requestId, origin });
+    // The popup later calls handler.approveDiscovery(requestId)
+    // or handler.rejectDiscovery(requestId).
+  }
+}
+```
+
+#### `onSessionEstablished`
+
+Fires after ECDH key exchange completes. The session has a `verificationHash` for the emoji grid:
+
+- For trusted origins: confirm the session immediately and restore previously granted capabilities. Persistence and policy are entirely up to your wallet code.
+- For new origins: stash the session and show the emoji grid in the popup so the user can match it against the dApp.
+
+#### `onWalletMessage`
+
+Fires when a dApp sends an encrypted wallet method call. The handler decrypts the payload and immediately invokes your callback. The SDK does not buffer messages by verification state; if you want to defer messages that arrive before the user confirms the emojis, queue them yourself in your callback.
+
+#### `onSessionTerminated`
+
+Fires when a session ends (tab closed, user disconnects, etc.). Use it to clean up extension state.
+
+### Routing wallet calls
+
+For every incoming `onWalletMessage`, decide whether the call needs user approval, then either prompt the user or forward to your wallet implementation. A typical approval matrix:
+
+| Method | Approval needed? | Why |
+|---|---|---|
+| `sendTx` | Yes | State-changing transaction |
+| `batch` containing `sendTx` | Yes | Contains state-changing calls |
+| `requestCapabilities` (first time) | Yes | Grants permissions to the dApp |
+| `simulateTx` | No | Read-only |
+| `executeUtility` | No | Unconstrained call |
+| `getAccounts`, `registerContract` | No | Read-only or background |
+
+For auto-executing methods, forward the call to your wallet host and reply with `handler.sendResponse()`:
+
+```typescript
+await handler.sendResponse(session.sessionId, {
+  messageId: message.messageId,
+  result: someResult,
+  walletId: WALLET_CONFIG.walletId,
+});
+```
+
+For errors, send an error response in the same shape, but with `error` instead of `result`:
+
+```typescript
+await handler.sendResponse(session.sessionId, {
+  messageId: message.messageId,
+  error: 'Something went wrong',
+  walletId: WALLET_CONFIG.walletId,
+});
+```
+
+## Extending `BaseWallet`
+
+`BaseWallet` provides default implementations of `sendTx`, `simulateTx`, `batch`, `createAuthWit`, `registerContract`, `getChainInfo`, and others. Subclass it and supply the two account hooks:
+
+```typescript
+import { BaseWallet, type CompleteFeeOptionsConfig } from '@aztec/wallet-sdk/base-wallet';
+import type { Account } from '@aztec/aztec.js/account';
+import type { Aliased } from '@aztec/aztec.js/wallet';
+import type { AztecAddress } from '@aztec/aztec.js/addresses';
+
+class MyWallet extends BaseWallet {
+  protected async getAccountFromAddress(address: AztecAddress): Promise<Account> {
+    // Look up the Account object for this address from your account store.
+  }
+
+  async getAccounts(): Promise<Aliased<AztecAddress>[]> {
+    // Return all accounts the wallet knows about, with aliases.
+  }
+}
+```
+
+`completeFeeOptions(config: CompleteFeeOptionsConfig)` has a default that uses the sender's fee juice balance. Override it if you want to inject a custom fee payment strategy (for example, paying via a sponsored fee paying contract on every transaction):
+
+```typescript
+protected async completeFeeOptions(config: CompleteFeeOptionsConfig) {
+  const base = await super.completeFeeOptions(config);
+  return {
+    ...base,
+    walletFeePaymentMethod: mySponsoredMethod,
+  };
+}
+```
+
+`requestCapabilities()` is part of the `Wallet` interface but throws "Not implemented" by default in `BaseWallet`. The SDK does not enforce capabilities for you, so a wallet that wants to support capability negotiation must override `requestCapabilities()` (or handle it inside the message-routing layer above) and decide what to grant.
+
+## Session lifecycle
+
+If you want returning users to skip the approval popup, your wallet code can persist the set of trusted origins. Use `chrome.storage.local` if the trust list should survive browser restarts, or `chrome.storage.session` if it should clear when the browser closes. The SDK does not store trust state for you.
+
+Be careful what you scope trust to. Origin alone is rarely enough: a wallet that auto-approves an `origin` for one chain shouldn't auto-approve the same origin on a different chain or under a different `appId`. Storing the tuple `(appId, origin, chainId, rollupVersion)` and checking the full tuple in `onPendingDiscovery` keeps the auto-approve scoped tightly enough. The handler exposes:
+
+- `handler.terminateSession(sessionId)`: end a specific session.
+- `handler.terminateForTab(tabId)`: end every session for a tab.
+- `handler.getPendingDiscoveries()`: list pending discovery requests.
+- `handler.getActiveSessions()`: list active sessions.
+
+The handler's in-memory state (active sessions, pending discoveries) does not survive service worker restarts. dApps will simply re-discover and reconnect; if your wallet recognizes the origin and skips the prompt, the reconnect feels seamless. On extension install or update, clear any persisted "pending" state since sessions never survive a reload.
+
+## Reference
+
+- API reference: [`@aztec/wallet-sdk` reference](pathname:///typescript-api/mainnet/wallet-sdk.md).
+- `BaseWallet` source: [`yarn-project/wallet-sdk/src/base-wallet/base_wallet.ts`](https://github.com/AztecProtocol/aztec-packages/blob/v4.2.0/yarn-project/wallet-sdk/src/base-wallet/base_wallet.ts) at v4.2.0.
+- `BackgroundConnectionHandler` source: [`yarn-project/wallet-sdk/src/extension/handlers/background_connection_handler.ts`](https://github.com/AztecProtocol/aztec-packages/blob/v4.2.0/yarn-project/wallet-sdk/src/extension/handlers/background_connection_handler.ts) at v4.2.0.
+- Wallet SDK README at v4.2.0: [`yarn-project/wallet-sdk/README.md`](https://github.com/AztecProtocol/aztec-packages/blob/v4.2.0/yarn-project/wallet-sdk/README.md).

--- a/docs/developer_versioned_docs/version-v4.2.0/docs/aztec-js/wallet-sdk/wallet_integration.md
+++ b/docs/developer_versioned_docs/version-v4.2.0/docs/aztec-js/wallet-sdk/wallet_integration.md
@@ -108,18 +108,25 @@ Fires when a session ends (tab closed, user disconnects, etc.). Use it to clean 
 
 ### Routing wallet calls
 
-For every incoming `onWalletMessage`, decide whether the call needs user approval, then either prompt the user or forward to your wallet implementation. A typical approval matrix:
+For every incoming `onWalletMessage`, decide whether the call needs user approval, then either prompt the user or forward to your wallet implementation.
 
-| Method | Approval needed? | Why |
+`aztec.js` models privileged methods behind named capabilities (see `AppCapabilities` and `Capability` in `@aztec/aztec.js/wallet`). The expected pattern is: the dApp calls `requestCapabilities` once, your wallet shows the user a single combined dialog, and methods covered by an approved capability can run without further prompting. The matrix below assumes you follow that pattern.
+
+| Method | Approval policy | Capability gating the method |
 |---|---|---|
-| `sendTx` | Yes | State-changing transaction |
-| `batch` containing `sendTx` | Yes | Contains state-changing calls |
-| `requestCapabilities` (first time) | Yes | Grants permissions to the dApp |
-| `simulateTx` | No | Read-only |
-| `executeUtility` | No | Unconstrained call |
-| `getAccounts`, `registerContract` | No | Read-only or background |
+| `requestCapabilities` (first time) | Per-call: prompt the user with the full manifest | n/a (grants the capabilities themselves) |
+| `sendTx` | Per-call confirmation, on top of an approved `transaction` capability | `transaction` |
+| `batch` | Treat as the union of its inner methods | derived from inner methods |
+| `simulateTx`, `profileTx` | Run after an approved `simulation` (with a `transactions` scope) | `simulation.transactions` |
+| `executeUtility` | Run after an approved `simulation` (with a `utilities` scope) | `simulation.utilities` |
+| `getAccounts`, `createAuthWit` | Run after an approved `accounts` capability | `accounts` |
+| `registerContract`, `getContractMetadata` | Run after an approved `contracts` capability | `contracts` |
+| `getContractClassMetadata` | Run after an approved `contractClasses` capability | `contractClasses` |
+| `getAddressBook`, `getPrivateEvents` | Run after an approved `data` capability | `data` |
 
-For auto-executing methods, forward the call to your wallet host and reply with `handler.sendResponse()`:
+The SDK does not enforce any of this — `requestCapabilities` in `BaseWallet` throws "Not implemented" by default, and capability persistence and per-call policy are entirely your wallet's responsibility. A wallet is free to require an extra confirmation for sensitive methods even when a capability is granted (for example, every `sendTx`), or to skip prompts for trusted origins it has remembered.
+
+Once you decide a call may proceed, forward it to your wallet host and reply with `handler.sendResponse()`:
 
 ```typescript
 await handler.sendResponse(session.sessionId, {

--- a/docs/developer_versioned_docs/version-v4.2.0/docs/aztec-js/wallet-sdk/wallet_integration.md
+++ b/docs/developer_versioned_docs/version-v4.2.0/docs/aztec-js/wallet-sdk/wallet_integration.md
@@ -75,28 +75,31 @@ The handler exposes four optional callbacks at different protocol stages.
 Fired when a dApp broadcasts a discovery request. Decide whether to auto-approve (trusted origin) or open the popup so the user can approve:
 
 ```typescript
-async onPendingDiscovery({ requestId, origin, tabId }) {
-  // Optional: terminate stale sessions from the same tab on page refresh.
-  for (const s of handler.getActiveSessions()) {
-    if (s.tabId === tabId) handler.terminateSession(s.sessionId);
-  }
+const callbacks = {
+  async onPendingDiscovery({ requestId, appId, origin, tabId, chainInfo }) {
+    // Optional: terminate stale sessions from the same tab on page refresh.
+    for (const s of handler.getActiveSessions()) {
+      if (s.tabId === tabId) handler.terminateSession(s.sessionId);
+    }
 
-  if (await isTrustedOrigin(origin)) {
-    handler.approveDiscovery(requestId);
-  } else {
-    await openApprovalPopup({ requestId, origin });
-    // The popup later calls handler.approveDiscovery(requestId)
-    // or handler.rejectDiscovery(requestId).
-  }
-}
+    if (await isTrustedOrigin({ appId, origin, chainInfo })) {
+      handler.approveDiscovery(requestId);
+    } else {
+      await openApprovalPopup({ requestId, appId, origin, chainInfo });
+      // The popup later calls handler.approveDiscovery(requestId)
+      // or handler.rejectDiscovery(requestId).
+    }
+  },
+  // onSessionEstablished, onWalletMessage, onSessionTerminated below.
+};
 ```
 
 #### `onSessionEstablished`
 
-Fires after ECDH key exchange completes. The session has a `verificationHash` for the emoji grid:
+Fires after ECDH key exchange completes. The session has a `verificationHash` for the emoji grid. The SDK does not expose a "confirm" call on the wallet side, so what your wallet does at this point is pure policy:
 
-- For trusted origins: confirm the session immediately and restore previously granted capabilities. Persistence and policy are entirely up to your wallet code.
-- For new origins: stash the session and show the emoji grid in the popup so the user can match it against the dApp.
+- For trusted origins: mark the session as trusted in your own state and restore previously granted capabilities. Persistence and policy are entirely up to your wallet code.
+- For new origins: stash the session and show the emoji grid in the popup so the user can match it against the dApp before you treat any incoming message as authorized.
 
 #### `onWalletMessage`
 
@@ -185,7 +188,7 @@ protected async completeFeeOptions(config: CompleteFeeOptionsConfig) {
 
 If you want returning users to skip the approval popup, your wallet code can persist the set of trusted origins. Use `chrome.storage.local` if the trust list should survive browser restarts, or `chrome.storage.session` if it should clear when the browser closes. The SDK does not store trust state for you.
 
-Be careful what you scope trust to. Origin alone is rarely enough: a wallet that auto-approves an `origin` for one chain shouldn't auto-approve the same origin on a different chain or under a different `appId`. Storing the tuple `(appId, origin, chainId, rollupVersion)` and checking the full tuple in `onPendingDiscovery` keeps the auto-approve scoped tightly enough. The handler exposes:
+Be careful what you scope trust to. Origin alone is rarely enough: a wallet that auto-approves an `origin` for one chain shouldn't auto-approve the same origin on a different chain or under a different `appId`. Storing the tuple `(appId, origin, chainInfo.chainId, chainInfo.version)` and checking the full tuple in `onPendingDiscovery` keeps the auto-approve scoped tightly enough (`chainInfo.version` is the L2 rollup version the dApp passed in; the SDK forwards both fields to your callback unchanged). The handler exposes:
 
 - `handler.terminateSession(sessionId)`: end a specific session.
 - `handler.terminateForTab(tabId)`: end every session for a tab.


### PR DESCRIPTION
## Summary

Adds a new **Wallet SDK** section under `aztec-js` in the v4.2.0 developer docs, documenting how dApps and wallet extensions communicate via `@aztec/wallet-sdk`.

Three new pages plus a sidebar category config:

- **`index.md`** — overview of what the SDK provides, architecture diagram (dApp ↔ content script ↔ background ↔ wallet host), and the three-phase security model (discovery → ECDH key exchange → emoji-verified encrypted channel).
- **`dapp_integration.md`** — step-by-step dApp integration: `WalletManager.configure()`, discovery, `establishSecureChannel`, emoji verification, capability negotiation, sending transactions, and disconnect handling.
- **`wallet_integration.md`** — wallet extension reference: content script and background service worker handlers, the four lifecycle callbacks, the wallet-call approval matrix, extending `BaseWallet`, and session/trusted-origin policy.

All source-code links are pinned to the `v4.2.0` tag.

## Test plan

- [ ] `yarn build` in `docs/` succeeds with no broken-link or spellcheck errors
- [ ] `yarn start` renders the new "Wallet SDK" group in the v4.2.0 sidebar under aztec-js
- [ ] Internal cross-links (`./dapp_integration.md`, `./wallet_integration.md`, `../../foundational-topics/wallets.md`) resolve
- [ ] `pathname:///typescript-api/mainnet/wallet-sdk.md` and `aztec.js.md` references load