### PR TITLE
fix(docs): correct llms.txt links for versioned developer docs

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -264,12 +264,16 @@ const config = {
       {
         generateLLMsTxt: true,
         generateLLMsFullTxt: true,
-        docsDir: `developer_versioned_docs/version-${mainnetDeveloperVersion || developerTestnetVersion}/`,
+        docsDir: `developer_versioned_docs/version-${mainnetDeveloperVersion || developerTestnetVersion}`,
         title: "Aztec Protocol Documentation",
         excludeImports: true,
         version: mainnetDeveloperVersion || developerTestnetVersion,
+        addMdExtension: false,
         pathTransformation: {
-          ignorePaths: ["docs"],
+          ignorePaths: [
+            `developer_versioned_docs/version-${mainnetDeveloperVersion || developerTestnetVersion}`,
+          ],
+          addPaths: ["developers"],
         },
       },
     ],

--- a/docs/package.json
+++ b/docs/package.json
@@ -42,7 +42,7 @@
     "@docusaurus/tsconfig": "3.9.1",
     "@tsconfig/docusaurus": "^1.0.7",
     "cspell": "^8.19.4",
-    "docusaurus-plugin-llms": "^0.2.0",
+    "docusaurus-plugin-llms": "^0.4.0",
     "dotenv": "^16.6.1",
     "netlify-cli": "^24.0.1"
   },

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -10072,7 +10072,7 @@ __metadata:
     "@tsconfig/docusaurus": "npm:^1.0.7"
     clsx: "npm:^2.1.1"
     cspell: "npm:^8.19.4"
-    docusaurus-plugin-llms: "npm:^0.2.0"
+    docusaurus-plugin-llms: "npm:^0.4.0"
     docusaurus-theme-search-typesense: "npm:0.25.0"
     dotenv: "npm:^16.6.1"
     netlify-cli: "npm:^24.0.1"
@@ -13047,16 +13047,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"docusaurus-plugin-llms@npm:^0.2.0":
-  version: 0.2.2
-  resolution: "docusaurus-plugin-llms@npm:0.2.2"
+"docusaurus-plugin-llms@npm:^0.4.0":
+  version: 0.4.0
+  resolution: "docusaurus-plugin-llms@npm:0.4.0"
   dependencies:
     gray-matter: "npm:^4.0.3"
     minimatch: "npm:^9.0.3"
     yaml: "npm:^2.8.1"
   peerDependencies:
     "@docusaurus/core": ^3.0.0
-  checksum: 10c0/9fced1f053fce6ef7acc44a27837b2a44f7fc2635b4b32fc02f3980e65ec587a9d0b62ff83cdadbbad6be53bc161cd4baf904d07d1d6a15630b55592d15bf553
+  checksum: 10c0/bd47226c7b631a30af77d9693c6c2bb206487496932b3092b59f6e9e89c546188b397da05321aa33a7ca1def69366286fdd60ad4a5de6ff45e0d6212a34beb60
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Fix broken links in the autogenerated `llms.txt` and `llms-full.txt` files produced by `docusaurus-plugin-llms`.

- Bump `docusaurus-plugin-llms` from `^0.2.0` to `^0.4.0` to use route-based URL resolution.
- Drop trailing slash on `docsDir` so the plugin can correctly strip the versioned-docs prefix when matching files against Docusaurus routes.
- Set `addMdExtension: false` since the site serves HTML, not raw `.md`.
- Update `pathTransformation` (used as fallback) to ignore the versioned-docs path and prepend `developers` so URLs resolve to `https://docs.aztec.network/developers/...`.

## Test plan

- [x] `yarn build` produces `build/llms.txt` and `build/llms-full.txt`
- [x] All entries in `llms.txt` use `https://docs.aztec.network/developers/...`
- [x] No `developer_versioned_docs` or `version-vX.Y.Z` segments leak into URLs
- [x] No `.md` suffixes on generated links
- [x] Spot-checked a sample link (`/developers/docs/aztec-js/aztec_js_reference`) returns 200