### PR TITLE
feat(pxe): support nested utility function calls

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/context/calls.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/calls.nr
@@ -250,18 +250,17 @@ impl<let M: u32, let N: u32, T> PublicStaticCall<M, N, T> {
 
 // UtilityCall
 
+#[must_use = "Your utility call needs to be passed into the `self.call(...)` method to be executed (e.g. `self.call(MyContract::at(address).my_utility_function(...args))`"]
 pub struct UtilityCall<let M: u32, let N: u32, T> {
     pub target_contract: AztecAddress,
     pub selector: FunctionSelector,
     pub name: str<M>,
-    args_hash: Field,
     pub args: [Field; N],
     return_type: T,
 }
 
 impl<let M: u32, let N: u32, T> UtilityCall<M, N, T> {
     pub fn new(target_contract: AztecAddress, selector: FunctionSelector, name: str<M>, args: [Field; N]) -> Self {
-        let args_hash = hash_args(args);
-        Self { target_contract, selector, name, args_hash, args, return_type: std::mem::zeroed() }
+        Self { target_contract, selector, name, args, return_type: std::mem::zeroed() }
     }
 }

--- a/noir-projects/aztec-nr/aztec/src/context/calls.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/calls.nr
@@ -250,7 +250,7 @@ impl<let M: u32, let N: u32, T> PublicStaticCall<M, N, T> {
 
 // UtilityCall
 
-#[must_use = "Your utility call needs to be passed into the `self.call(...)` method to be executed (e.g. `self.call(MyContract::at(address).my_utility_function(...args))`"]
+#[must_use = "Your utility call needs to be passed into `self.call(...)` (utility context) or `self.utility.call(...)` (private context) to be executed"]
 pub struct UtilityCall<let M: u32, let N: u32, T> {
     pub target_contract: AztecAddress,
     pub selector: FunctionSelector,

--- a/noir-projects/aztec-nr/aztec/src/contract_self/contract_self_private.nr
+++ b/noir-projects/aztec-nr/aztec/src/contract_self/contract_self_private.nr
@@ -423,7 +423,6 @@ impl PrivateUtility {
     ///
     /// # Example
     /// ```noir
-    /// // Safety: result is unconstrained
     /// unsafe { self.utility.call(Token::at(self.address).get_balance_of(owner)) }
     /// ```
     pub unconstrained fn call<let M: u32, let N: u32, T>(_self: Self, call: UtilityCall<M, N, T>) -> T

--- a/noir-projects/aztec-nr/aztec/src/contract_self/contract_self_private.nr
+++ b/noir-projects/aztec-nr/aztec/src/contract_self/contract_self_private.nr
@@ -1,8 +1,9 @@
 //! The `self` contract value for private execution contexts.
 
 use crate::{
-    context::{calls::{PrivateCall, PrivateStaticCall, PublicCall, PublicStaticCall}, PrivateContext},
+    context::{calls::{PrivateCall, PrivateStaticCall, PublicCall, PublicStaticCall, UtilityCall}, PrivateContext},
     event::{event_emission::emit_event_in_private, event_interface::EventInterface, EventMessage},
+    oracle::call_utility_function::call_utility_function,
 };
 use crate::protocol::{address::AztecAddress, traits::{Deserialize, Serialize}};
 
@@ -108,6 +109,15 @@ pub struct ContractSelfPrivate<Storage, CallSelf, EnqueueSelf, CallSelfStatic, E
     /// self.internal.some_internal_function(args)
     /// ```
     pub internal: CallInternal,
+
+    /// Gateway for calling utility functions from this private context.
+    ///
+    /// Example API:
+    /// ```noir
+    /// // Safety: result is unconstrained
+    /// unsafe { self.utility.call(MyContract::at(address).my_utility_function(args)) }
+    /// ```
+    pub utility: PrivateUtility,
 }
 
 impl<Storage, CallSelf, EnqueueSelf, CallSelfStatic, EnqueueSelfStatic, CallInternal> ContractSelfPrivate<Storage, CallSelf, EnqueueSelf, CallSelfStatic, EnqueueSelfStatic, CallInternal> {
@@ -132,6 +142,7 @@ impl<Storage, CallSelf, EnqueueSelf, CallSelfStatic, EnqueueSelfStatic, CallInte
             call_self_static,
             enqueue_self_static,
             internal,
+            utility: PrivateUtility {},
         }
     }
 
@@ -393,5 +404,33 @@ impl<Storage, CallSelf, EnqueueSelf, CallSelfStatic, EnqueueSelfStatic, CallInte
     ///
     pub fn set_as_teardown_incognito<let M: u32, let N: u32, T>(&mut self, call: PublicCall<M, N, T>) {
         call.set_as_teardown_incognito(self.context)
+    }
+}
+
+/// Gateway for calling utility functions from a private context.
+///
+/// Accessible via `self.utility` in private functions. Results are not part of any circuit
+/// proof; use them to inform logic, not as inputs to constrained assertions.
+// Implemented as a separate empty struct because Noir does not allow passing `&mut PrivateContext`
+// (held by `ContractSelfPrivate`) into unconstrained code. This struct holds no mutable references,
+// so it can be passed freely into `unconstrained` functions.
+pub struct PrivateUtility {}
+
+impl PrivateUtility {
+    /// Makes a utility contract call from a private function.
+    ///
+    /// Note: only same-contract utility calls are currently supported. See TODO(F-29).
+    ///
+    /// # Example
+    /// ```noir
+    /// // Safety: result is unconstrained
+    /// unsafe { self.utility.call(Token::at(self.address).get_balance_of(owner)) }
+    /// ```
+    pub unconstrained fn call<let M: u32, let N: u32, T>(_self: Self, call: UtilityCall<M, N, T>) -> T
+    where
+        T: Deserialize,
+    {
+        let returns = call_utility_function(call.target_contract, call.selector, call.args);
+        Deserialize::deserialize(returns)
     }
 }

--- a/noir-projects/aztec-nr/aztec/src/contract_self/contract_self_utility.nr
+++ b/noir-projects/aztec-nr/aztec/src/contract_self/contract_self_utility.nr
@@ -1,7 +1,8 @@
 //! The `self` contract value for utility execution contexts.
 
-use crate::context::UtilityContext;
-use crate::protocol::address::AztecAddress;
+use crate::context::{calls::UtilityCall, UtilityContext};
+use crate::oracle::call_utility_function::call_utility_function;
+use crate::protocol::{address::AztecAddress, traits::Deserialize};
 
 /// Core interface for interacting with aztec-nr contract features in utility execution contexts.
 ///
@@ -41,5 +42,19 @@ impl<Storage> ContractSelfUtility<Storage> {
     /// This constructor is called automatically by the macro system and should not be called directly.
     pub fn new(context: UtilityContext, storage: Storage) -> Self {
         Self { context, storage, address: context.this_address() }
+    }
+
+    /// Makes a utility contract call from another utility function.
+    ///
+    /// # Example
+    /// ```noir
+    /// self.call(Token::at(address).get_balance_of(owner));
+    /// ```
+    pub unconstrained fn call<let M: u32, let N: u32, T>(_self: Self, call: UtilityCall<M, N, T>) -> T
+    where
+        T: Deserialize,
+    {
+        let returns = call_utility_function(call.target_contract, call.selector, call.args);
+        Deserialize::deserialize(returns)
     }
 }

--- a/noir-projects/aztec-nr/aztec/src/contract_self/contract_self_utility.nr
+++ b/noir-projects/aztec-nr/aztec/src/contract_self/contract_self_utility.nr
@@ -50,11 +50,24 @@ impl<Storage> ContractSelfUtility<Storage> {
     /// ```noir
     /// self.call(Token::at(address).get_balance_of(owner));
     /// ```
-    pub unconstrained fn call<let M: u32, let N: u32, T>(_self: Self, call: UtilityCall<M, N, T>) -> T
+    pub unconstrained fn call<let M: u32, let N: u32, T>(self_contract: Self, call: UtilityCall<M, N, T>) -> T
     where
         T: Deserialize,
     {
+        // TODO(F-29): We want to support cross-contract utility calls, but doing so safely requires wallets to have
+        // a way to authorize which contracts can be called transitively, since those calls may expose private state.
+        // Until that is in place, restrict nested utility calls to the same contract only.
+        assert(call.target_contract == self_contract.address, "Cross-contract utility calls are not yet supported");
         let returns = call_utility_function(call.target_contract, call.selector, call.args);
         Deserialize::deserialize(returns)
     }
+}
+
+#[test(should_fail_with = "Cross-contract utility calls are not yet supported")]
+unconstrained fn test_cross_contract_utility_call_is_rejected() {
+    let self_contract: ContractSelfUtility<()> =
+        ContractSelfUtility { context: std::mem::zeroed(), storage: (), address: AztecAddress { inner: 1 } };
+    let other_contract = AztecAddress { inner: 2 };
+    let call = UtilityCall::<0, 0, Field>::new(other_contract, std::mem::zeroed(), "", []);
+    let _: Field = self_contract.call(call);
 }

--- a/noir-projects/aztec-nr/aztec/src/contract_self/contract_self_utility.nr
+++ b/noir-projects/aztec-nr/aztec/src/contract_self/contract_self_utility.nr
@@ -46,6 +46,8 @@ impl<Storage> ContractSelfUtility<Storage> {
 
     /// Makes a utility contract call from another utility function.
     ///
+    /// Note: only same-contract utility calls are currently supported. See TODO(F-29).
+    ///
     /// # Example
     /// ```noir
     /// self.call(Token::at(address).get_balance_of(owner));

--- a/noir-projects/aztec-nr/aztec/src/contract_self/contract_self_utility.nr
+++ b/noir-projects/aztec-nr/aztec/src/contract_self/contract_self_utility.nr
@@ -50,24 +50,11 @@ impl<Storage> ContractSelfUtility<Storage> {
     /// ```noir
     /// self.call(Token::at(address).get_balance_of(owner));
     /// ```
-    pub unconstrained fn call<let M: u32, let N: u32, T>(self_contract: Self, call: UtilityCall<M, N, T>) -> T
+    pub unconstrained fn call<let M: u32, let N: u32, T>(_self: Self, call: UtilityCall<M, N, T>) -> T
     where
         T: Deserialize,
     {
-        // TODO(F-29): We want to support cross-contract utility calls, but doing so safely requires wallets to have
-        // a way to authorize which contracts can be called transitively, since those calls may expose private state.
-        // Until that is in place, restrict nested utility calls to the same contract only.
-        assert(call.target_contract == self_contract.address, "Cross-contract utility calls are not yet supported");
         let returns = call_utility_function(call.target_contract, call.selector, call.args);
         Deserialize::deserialize(returns)
     }
-}
-
-#[test(should_fail_with = "Cross-contract utility calls are not yet supported")]
-unconstrained fn test_cross_contract_utility_call_is_rejected() {
-    let self_contract: ContractSelfUtility<()> =
-        ContractSelfUtility { context: std::mem::zeroed(), storage: (), address: AztecAddress { inner: 1 } };
-    let other_contract = AztecAddress { inner: 2 };
-    let call = UtilityCall::<0, 0, Field>::new(other_contract, std::mem::zeroed(), "", []);
-    let _: Field = self_contract.call(call);
 }

--- a/noir-projects/aztec-nr/aztec/src/oracle/call_utility_function.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/call_utility_function.nr
@@ -1,0 +1,16 @@
+use crate::protocol::{abis::function_selector::FunctionSelector, address::AztecAddress};
+
+#[oracle(aztec_utl_callUtilityFunction)]
+unconstrained fn call_utility_function_oracle<let M: u32, let N: u32>(
+    _contract_address: AztecAddress,
+    _function_selector: FunctionSelector,
+    _args: [Field; M],
+) -> [Field; N] {}
+
+pub unconstrained fn call_utility_function<let M: u32, let N: u32>(
+    contract_address: AztecAddress,
+    function_selector: FunctionSelector,
+    args: [Field; M],
+) -> [Field; N] {
+    call_utility_function_oracle(contract_address, function_selector, args)
+}

--- a/noir-projects/aztec-nr/aztec/src/oracle/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/mod.nr
@@ -5,6 +5,7 @@ pub mod aes128_decrypt;
 pub mod auth_witness;
 pub mod block_header;
 pub mod call_private_function;
+pub mod call_utility_function;
 pub mod capsules;
 pub mod ephemeral;
 pub mod contract_sync;

--- a/noir-projects/aztec-nr/aztec/src/oracle/version.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/version.nr
@@ -11,7 +11,7 @@
 /// immediately if AZTEC_NR_MINOR > PXE_MINOR because if a contract is updated to use a newer Aztec.nr dependency
 /// without actually using any of the new oracles then there is no reason to throw.
 pub global ORACLE_VERSION_MAJOR: Field = 22;
-pub global ORACLE_VERSION_MINOR: Field = 1;
+pub global ORACLE_VERSION_MINOR: Field = 2;
 
 /// Asserts that the version of the oracle is compatible with the version expected by the contract.
 pub fn assert_compatible_oracle_version() {

--- a/noir-projects/noir-contracts/Nargo.toml
+++ b/noir-projects/noir-contracts/Nargo.toml
@@ -52,6 +52,7 @@ members = [
     "contracts/test/import_test_contract",
     "contracts/test/init_test_contract",
     "contracts/test/invalid_account_contract",
+    "contracts/test/nested_utility_contract",
     "contracts/test/no_constructor_contract",
     "contracts/test/note_hash_and_nullifier/note_hash_and_nullifier_contract",
     "contracts/test/note_getter_contract",

--- a/noir-projects/noir-contracts/contracts/test/nested_utility_contract/Nargo.toml
+++ b/noir-projects/noir-contracts/contracts/test/nested_utility_contract/Nargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "nested_utility_contract"
+authors = [""]
+compiler_version = ">=0.25.0"
+type = "contract"
+
+[dependencies]
+aztec = { path = "../../../../aztec-nr/aztec" }

--- a/noir-projects/noir-contracts/contracts/test/nested_utility_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/nested_utility_contract/src/main.nr
@@ -1,0 +1,17 @@
+// Demonstrates nested utility calls by implementing pow(x, n) = x^n recursively.
+
+use aztec::macros::aztec;
+
+#[aztec]
+pub contract NestedUtility {
+    use aztec::macros::functions::external;
+
+    #[external("utility")]
+    unconstrained fn pow(x: Field, n: u32) -> Field {
+        if n == 0 {
+            1
+        } else {
+            x * self.call(NestedUtility::at(self.address).pow(x, n - 1))
+        }
+    }
+}

--- a/noir-projects/noir-contracts/contracts/test/nested_utility_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/nested_utility_contract/src/main.nr
@@ -1,4 +1,5 @@
-// Demonstrates nested utility calls by implementing pow(x, n) = x^n recursively.
+// Demonstrates nested utility calls by implementing pow_utility(x, n) = x^n recursively,
+// and calling it from a private function via pow_private.
 
 use aztec::macros::aztec;
 
@@ -7,11 +8,20 @@ pub contract NestedUtility {
     use aztec::macros::functions::external;
 
     #[external("utility")]
-    unconstrained fn pow(x: Field, n: u32) -> Field {
+    unconstrained fn pow_utility(x: Field, n: u32) -> Field {
         if n == 0 {
             1
         } else {
-            x * self.call(NestedUtility::at(self.address).pow(x, n - 1))
+            x * self.call(NestedUtility::at(self.address).pow_utility(x, n - 1))
+        }
+    }
+
+    #[external("private")]
+    fn pow_private(x: Field, n: u32) -> Field {
+        // Safety: this is a test contract; the unconstrained result is returned directly
+        // and never used as input to a constrained assertion
+        unsafe {
+            self.utility.call(NestedUtility::at(self.address).pow_utility(x, n))
         }
     }
 }

--- a/yarn-project/end-to-end/src/e2e_nested_utility_calls.test.ts
+++ b/yarn-project/end-to-end/src/e2e_nested_utility_calls.test.ts
@@ -8,8 +8,8 @@ import { setup } from './fixtures/utils.js';
 
 const TIMEOUT = 120_000;
 
-// Verifies that nested utility calls work by implementing pow(x, n) = x^n recursively:
-// pow(x, 0) = 1, pow(x, n) = x * pow(x, n-1).
+// Verifies nested utility calls via pow_utility(x, n) = x^n (recursive utility→utility),
+// and calling it from a private function via pow_private.
 describe('Nested utility calls', () => {
   let contract: NestedUtilityContract;
   jest.setTimeout(TIMEOUT);
@@ -29,13 +29,18 @@ describe('Nested utility calls', () => {
 
   afterAll(() => teardown());
 
-  it('pow(x, 0) returns 1 (base case, no nested call)', async () => {
-    const { result } = await contract.methods.pow(2n, 0).simulate({ from: defaultAccountAddress });
+  it('pow_utility(x, 0) returns 1 (base case, no nested call)', async () => {
+    const { result } = await contract.methods.pow_utility(2n, 0).simulate({ from: defaultAccountAddress });
     expect(result).toEqual(1n);
   });
 
-  it('pow(2, 10) returns 2^10 (10 levels of nesting)', async () => {
-    const { result } = await contract.methods.pow(2n, 10).simulate({ from: defaultAccountAddress });
+  it('pow_utility(2, 10) returns 2^10 (10 levels of nesting)', async () => {
+    const { result } = await contract.methods.pow_utility(2n, 10).simulate({ from: defaultAccountAddress });
+    expect(result).toEqual(2n ** 10n);
+  });
+
+  it('pow_private(2, 10) returns 2^10 (private function calling utility)', async () => {
+    const { result } = await contract.methods.pow_private(2n, 10).simulate({ from: defaultAccountAddress });
     expect(result).toEqual(2n ** 10n);
   });
 });

--- a/yarn-project/end-to-end/src/e2e_nested_utility_calls.test.ts
+++ b/yarn-project/end-to-end/src/e2e_nested_utility_calls.test.ts
@@ -1,0 +1,41 @@
+import { type AztecAddress } from '@aztec/aztec.js/addresses';
+import type { Wallet } from '@aztec/aztec.js/wallet';
+import { NestedUtilityContract } from '@aztec/noir-test-contracts.js/NestedUtility';
+
+import { jest } from '@jest/globals';
+
+import { setup } from './fixtures/utils.js';
+
+const TIMEOUT = 120_000;
+
+// Verifies that nested utility calls work by implementing pow(x, n) = x^n recursively:
+// pow(x, 0) = 1, pow(x, n) = x * pow(x, n-1).
+describe('Nested utility calls', () => {
+  let contract: NestedUtilityContract;
+  jest.setTimeout(TIMEOUT);
+
+  let wallet: Wallet;
+  let defaultAccountAddress: AztecAddress;
+  let teardown: () => Promise<void>;
+
+  beforeAll(async () => {
+    ({
+      teardown,
+      wallet,
+      accounts: [defaultAccountAddress],
+    } = await setup(1));
+    ({ contract } = await NestedUtilityContract.deploy(wallet).send({ from: defaultAccountAddress }));
+  });
+
+  afterAll(() => teardown());
+
+  it('pow(x, 0) returns 1 (base case, no nested call)', async () => {
+    const { result } = await contract.methods.pow(2n, 0).simulate({ from: defaultAccountAddress });
+    expect(result).toEqual(1n);
+  });
+
+  it('pow(2, 10) returns 2^10 (10 levels of nesting)', async () => {
+    const { result } = await contract.methods.pow(2n, 10).simulate({ from: defaultAccountAddress });
+    expect(result).toEqual(2n ** 10n);
+  });
+});

--- a/yarn-project/end-to-end/src/e2e_nested_utility_calls.test.ts
+++ b/yarn-project/end-to-end/src/e2e_nested_utility_calls.test.ts
@@ -1,4 +1,4 @@
-import { type AztecAddress } from '@aztec/aztec.js/addresses';
+import type { AztecAddress } from '@aztec/aztec.js/addresses';
 import type { Wallet } from '@aztec/aztec.js/wallet';
 import { NestedUtilityContract } from '@aztec/noir-test-contracts.js/NestedUtility';
 

--- a/yarn-project/pxe/src/contract_function_simulator/contract_function_simulator.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/contract_function_simulator.ts
@@ -350,6 +350,7 @@ export class ContractFunctionSimulator {
       l2TipsStore: this.l2TipsStore,
       jobId,
       scopes,
+      simulator: this.simulator,
     });
 
     try {

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/interfaces.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/interfaces.ts
@@ -164,6 +164,11 @@ export interface IUtilityExecutionOracle {
   getSharedSecret(address: AztecAddress, ephPk: Point, contractAddress: AztecAddress): Promise<Fr>;
   setContractSyncCacheInvalid(contractAddress: AztecAddress, scopes: AztecAddress[]): void;
   emitOffchainEffect(data: Fr[]): Promise<void>;
+  callUtilityFunction(
+    targetContractAddress: AztecAddress,
+    functionSelector: FunctionSelector,
+    args: Fr[],
+  ): Promise<Fr[]>;
 
   // Ephemeral array methods
   pushEphemeral(slot: Fr, elements: Fr[]): number;

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/interfaces.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/interfaces.ts
@@ -204,6 +204,11 @@ export interface IPrivateExecutionOracle {
     sideEffectCounter: number,
     isStaticCall: boolean,
   ): Promise<{ endSideEffectCounter: Fr; returnsHash: Fr }>;
+  callUtilityFunction(
+    targetContractAddress: AztecAddress,
+    functionSelector: FunctionSelector,
+    args: Fr[],
+  ): Promise<Fr[]>;
   assertValidPublicCalldata(calldataHash: Fr): Promise<void>;
   notifyRevertiblePhaseStart(minRevertibleSideEffectCounter: number): Promise<void>;
   isExecutionInRevertiblePhase(sideEffectCounter: number): Promise<boolean>;

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/oracle.ts
@@ -491,6 +491,20 @@ export class Oracle {
   }
 
   // eslint-disable-next-line camelcase
+  async aztec_utl_callUtilityFunction(
+    [contractAddress]: ACVMField[],
+    [functionSelector]: ACVMField[],
+    args: ACVMField[],
+  ): Promise<ACVMField[][]> {
+    const result = await this.handlerAsUtility().callUtilityFunction(
+      AztecAddress.fromField(Fr.fromString(contractAddress)),
+      FunctionSelector.fromField(Fr.fromString(functionSelector)),
+      args.map(Fr.fromString),
+    );
+    return [result.map(toACVMField)];
+  }
+
+  // eslint-disable-next-line camelcase
   aztec_prv_notifyCreatedContractClassLog(
     [contractAddress]: ACVMField[],
     message: ACVMField[],

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/oracle_version_is_checked.test.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/oracle_version_is_checked.test.ts
@@ -213,6 +213,7 @@ describe('Oracle Version Check test suite', () => {
         jobId: 'test',
         scopes: [],
         l2TipsStore,
+        simulator,
       });
     });
 

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution_oracle.test.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution_oracle.test.ts
@@ -1,5 +1,6 @@
 import { Fr } from '@aztec/foundation/curves/bn254';
 import type { KeyStore } from '@aztec/key-store';
+import { WASMSimulator } from '@aztec/simulator/client';
 import { FunctionSelector } from '@aztec/stdlib/abi';
 import type { AuthWitness } from '@aztec/stdlib/auth-witness';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
@@ -80,6 +81,15 @@ describe('PrivateExecutionOracle', () => {
     });
   });
 
+  describe('callUtilityFunction', () => {
+    it('throws when called from a private context', async () => {
+      const oracle = makeOracle();
+      await expect(
+        oracle.callUtilityFunction(await AztecAddress.random(), FunctionSelector.empty(), []),
+      ).rejects.toThrow('Calling utility functions from private functions is not supported.');
+    });
+  });
+
   const makeOracle = (overrides: Partial<PrivateExecutionOracleArgs> = {}): PrivateExecutionOracle => {
     return new PrivateExecutionOracle({
       argsHash: Fr.ZERO,
@@ -107,6 +117,7 @@ describe('PrivateExecutionOracle', () => {
       l2TipsStore: mock<L2TipsProvider>(),
       jobId: 'test',
       scopes: [],
+      simulator: new WASMSimulator(),
       ...overrides,
     });
   };

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution_oracle.test.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution_oracle.test.ts
@@ -81,15 +81,6 @@ describe('PrivateExecutionOracle', () => {
     });
   });
 
-  describe('callUtilityFunction', () => {
-    it('throws when called from a private context', async () => {
-      const oracle = makeOracle();
-      await expect(
-        oracle.callUtilityFunction(await AztecAddress.random(), FunctionSelector.empty(), []),
-      ).rejects.toThrow('Calling utility functions from private functions is not supported.');
-    });
-  });
-
   const makeOracle = (overrides: Partial<PrivateExecutionOracleArgs> = {}): PrivateExecutionOracle => {
     return new PrivateExecutionOracle({
       argsHash: Fr.ZERO,

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution_oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution_oracle.ts
@@ -105,6 +105,14 @@ export class PrivateExecutionOracle extends UtilityExecutionOracle implements IP
     this.defaultSenderForTags = args.senderForTags;
   }
 
+  public override callUtilityFunction(
+    _targetContractAddress: AztecAddress,
+    _functionSelector: FunctionSelector,
+    _args: Fr[],
+  ): Promise<Fr[]> {
+    return Promise.reject(new Error('Calling utility functions from private functions is not supported.'));
+  }
+
   public getPrivateContextInputs(): PrivateContextInputs {
     return new PrivateContextInputs(
       this.callContext,
@@ -580,14 +588,14 @@ export class PrivateExecutionOracle extends UtilityExecutionOracle implements IP
       log: this.logger,
       scopes: this.scopes,
       senderForTags: this.defaultSenderForTags,
-      simulator: this.simulator!,
+      simulator: this.simulator,
       l2TipsStore: this.l2TipsStore,
     });
 
     const setupTime = simulatorSetupTimer.ms();
 
     const childExecutionResult = await executePrivateFunction(
-      this.simulator!,
+      this.simulator,
       privateExecutionOracle,
       targetArtifact,
       targetContractAddress,

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution_oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution_oracle.ts
@@ -105,14 +105,6 @@ export class PrivateExecutionOracle extends UtilityExecutionOracle implements IP
     this.defaultSenderForTags = args.senderForTags;
   }
 
-  public override callUtilityFunction(
-    _targetContractAddress: AztecAddress,
-    _functionSelector: FunctionSelector,
-    _args: Fr[],
-  ): Promise<Fr[]> {
-    return Promise.reject(new Error('Calling utility functions from private functions is not supported.'));
-  }
-
   public getPrivateContextInputs(): PrivateContextInputs {
     return new PrivateContextInputs(
       this.callContext,

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution_oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution_oracle.ts
@@ -2,7 +2,7 @@ import { MAX_FR_CALLDATA_TO_ALL_ENQUEUED_CALLS, PRIVATE_CONTEXT_INPUTS_LENGTH } 
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { createLogger } from '@aztec/foundation/log';
 import { Timer } from '@aztec/foundation/timer';
-import { type CircuitSimulator, toACVMWitness } from '@aztec/simulator/client';
+import { toACVMWitness } from '@aztec/simulator/client';
 import {
   type FunctionAbi,
   type FunctionArtifact,
@@ -50,7 +50,6 @@ export type PrivateExecutionOracleArgs = Omit<UtilityExecutionOracleArgs, 'contr
   totalPublicCalldataCount?: number;
   sideEffectCounter?: number;
   senderForTags?: AztecAddress;
-  simulator?: CircuitSimulator;
 };
 
 /**
@@ -86,7 +85,6 @@ export class PrivateExecutionOracle extends UtilityExecutionOracle implements IP
   private readonly defaultSenderForTags: AztecAddress | undefined;
   /** Per-call sender-for-tags override, set by `setSenderForTags`. Takes precedence over `defaultSenderForTags`. */
   private currentSenderForTags: AztecAddress | undefined;
-  private readonly simulator?: CircuitSimulator;
 
   constructor(args: PrivateExecutionOracleArgs) {
     super({
@@ -105,7 +103,6 @@ export class PrivateExecutionOracle extends UtilityExecutionOracle implements IP
     this.totalPublicCalldataCount = args.totalPublicCalldataCount ?? 0;
     this.initialSideEffectCounter = args.sideEffectCounter ?? 0;
     this.defaultSenderForTags = args.senderForTags;
-    this.simulator = args.simulator;
   }
 
   public getPrivateContextInputs(): PrivateContextInputs {

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution.test.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution.test.ts
@@ -428,6 +428,16 @@ describe('Utility Execution test suite', () => {
       });
     });
 
+    describe('callUtilityFunction', () => {
+      it('throws when target contract differs from execution context', async () => {
+        const differentAddress = await AztecAddress.random();
+        const selector = FunctionSelector.empty();
+        await expect(utilityExecutionOracle.callUtilityFunction(differentAddress, selector, [])).rejects.toThrow(
+          'Cross-contract utility calls are not yet supported',
+        );
+      });
+    });
+
     describe('invalidateContractSyncCache', () => {
       it('throws when contract address does not match', async () => {
         const otherAddress = await AztecAddress.random();

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution.test.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution.test.ts
@@ -347,6 +347,7 @@ describe('Utility Execution test suite', () => {
         jobId: 'test-job-id',
         scopes: [scope],
         l2TipsStore,
+        simulator,
       });
     });
 
@@ -414,6 +415,7 @@ describe('Utility Execution test suite', () => {
           jobId: 'test-job-id',
           scopes: [scope],
           l2TipsStore,
+          simulator,
         });
 
         capsuleStore.getCapsule.mockResolvedValueOnce(persisted);
@@ -605,6 +607,7 @@ describe('Utility Execution test suite', () => {
             jobId: 'test-job-id',
             scopes: [],
             l2TipsStore,
+            simulator,
           });
 
         const oracleA = makeOracle(contractAddressA);

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
@@ -915,6 +915,15 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
     functionSelector: FunctionSelector,
     args: Fr[],
   ): Promise<Fr[]> {
+    // TODO(F-29): We want to support cross-contract utility calls, but doing so safely requires wallets to have
+    // a way to authorize which contracts can be called transitively, since those calls may expose private state.
+    // Until that is in place, restrict nested utility calls to the same contract only.
+    if (!targetContractAddress.equals(this.contractAddress)) {
+      throw new Error(
+        `Cross-contract utility calls are not yet supported: cannot call ${targetContractAddress} from utility function on ${this.contractAddress}.`,
+      );
+    }
+
     if (!this.simulator) {
       throw new Error(
         `Cannot perform nested utility call from ${this.contractAddress} to ` +

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
@@ -7,6 +7,15 @@ import { LogLevels, type Logger, createLogger } from '@aztec/foundation/log';
 import type { MembershipWitness } from '@aztec/foundation/trees';
 import type { KeyStore } from '@aztec/key-store';
 import { isProtocolContract } from '@aztec/protocol-contracts';
+import {
+  type CircuitSimulator,
+  ExecutionError,
+  extractCallStack,
+  resolveAssertionMessageFromError,
+  toACVMWitness,
+  witnessMapToFields,
+} from '@aztec/simulator/client';
+import { FunctionSelector } from '@aztec/stdlib/abi';
 import type { AuthWitness } from '@aztec/stdlib/auth-witness';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
 import { BlockHash, type L2TipsProvider } from '@aztec/stdlib/block';
@@ -44,6 +53,7 @@ import { UtilityContext } from '../noir-structs/utility_context.js';
 import { pickNotes } from '../pick_notes.js';
 import type { IMiscOracle, IUtilityExecutionOracle, NoteData } from './interfaces.js';
 import { MessageLoadOracleInputs } from './message_load_oracle_inputs.js';
+import { Oracle } from './oracle.js';
 
 /** Args for UtilityExecutionOracle constructor. */
 export type UtilityExecutionOracleArgs = {
@@ -67,6 +77,9 @@ export type UtilityExecutionOracleArgs = {
   jobId: string;
   log?: ReturnType<typeof createLogger>;
   scopes: AztecAddress[];
+  /** ACIR circuit simulator. Optional in contexts (e.g. unit tests) that never invoke nested utilities;
+   * calling without it set will throw at dispatch time. */
+  simulator?: CircuitSimulator;
 };
 
 /**
@@ -103,6 +116,7 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
   protected readonly jobId: string;
   protected logger: ReturnType<typeof createLogger>;
   protected readonly scopes: AztecAddress[];
+  protected readonly simulator?: CircuitSimulator;
 
   constructor(args: UtilityExecutionOracleArgs) {
     this.contractAddress = args.contractAddress;
@@ -124,6 +138,7 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
     this.jobId = args.jobId;
     this.logger = args.log ?? createLogger('simulator:client_view_context');
     this.scopes = args.scopes;
+    this.simulator = args.simulator;
   }
 
   public assertCompatibleOracleVersion(major: number, minor: number): void {
@@ -892,6 +907,70 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
   public emitOffchainEffect(data: Fr[]): Promise<void> {
     this.offchainEffects.push({ data, contractAddress: this.contractAddress });
     return Promise.resolve();
+  }
+
+  /** Executes another utility function from within this one and returns its serialized return values. */
+  public async callUtilityFunction(
+    targetContractAddress: AztecAddress,
+    functionSelector: FunctionSelector,
+    args: Fr[],
+  ): Promise<Fr[]> {
+    if (!this.simulator) {
+      throw new Error(
+        `Cannot perform nested utility call from ${this.contractAddress} to ` +
+          `${targetContractAddress}:${functionSelector}: ` +
+          `UtilityExecutionOracle was constructed without a CircuitSimulator. ` +
+          `Pass one via UtilityExecutionOracleArgs.simulator.`,
+      );
+    }
+
+    this.logger.debug(
+      `Calling nested utility function ${targetContractAddress}:${functionSelector} from ${this.contractAddress}`,
+    );
+
+    const targetArtifact = await this.contractStore.getFunctionArtifactWithDebugMetadata(
+      targetContractAddress,
+      functionSelector,
+    );
+
+    const nestedOracle = new UtilityExecutionOracle({
+      contractAddress: targetContractAddress,
+      authWitnesses: this.authWitnesses,
+      capsules: this.capsules,
+      anchorBlockHeader: this.anchorBlockHeader,
+      contractStore: this.contractStore,
+      noteStore: this.noteStore,
+      keyStore: this.keyStore,
+      addressStore: this.addressStore,
+      aztecNode: this.aztecNode,
+      recipientTaggingStore: this.recipientTaggingStore,
+      senderAddressBookStore: this.senderAddressBookStore,
+      capsuleService: this.capsuleService,
+      privateEventStore: this.privateEventStore,
+      messageContextService: this.messageContextService,
+      contractSyncService: this.contractSyncService,
+      l2TipsStore: this.l2TipsStore,
+      jobId: this.jobId,
+      scopes: this.scopes,
+      simulator: this.simulator,
+      log: this.logger,
+    });
+
+    const initialWitness = toACVMWitness(0, args);
+    const acvmCallback = new Oracle(nestedOracle);
+    const acirExecutionResult = await this.simulator
+      .executeUserCircuit(initialWitness, targetArtifact, acvmCallback.toACIRCallback())
+      .catch((err: Error) => {
+        err.message = resolveAssertionMessageFromError(err, targetArtifact);
+        throw new ExecutionError(
+          err.message,
+          { contractAddress: targetContractAddress, functionSelector },
+          extractCallStack(err, targetArtifact.debug),
+          { cause: err },
+        );
+      });
+
+    return witnessMapToFields(acirExecutionResult.returnWitness);
   }
 
   /** Returns offchain effects collected during execution. */

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
@@ -77,9 +77,7 @@ export type UtilityExecutionOracleArgs = {
   jobId: string;
   log?: ReturnType<typeof createLogger>;
   scopes: AztecAddress[];
-  /** ACIR circuit simulator. Optional in contexts (e.g. unit tests) that never invoke nested utilities;
-   * calling without it set will throw at dispatch time. */
-  simulator?: CircuitSimulator;
+  simulator: CircuitSimulator;
 };
 
 /**
@@ -116,7 +114,7 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
   protected readonly jobId: string;
   protected logger: ReturnType<typeof createLogger>;
   protected readonly scopes: AztecAddress[];
-  protected readonly simulator?: CircuitSimulator;
+  protected readonly simulator: CircuitSimulator;
 
   constructor(args: UtilityExecutionOracleArgs) {
     this.contractAddress = args.contractAddress;
@@ -921,15 +919,6 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
     if (!targetContractAddress.equals(this.contractAddress)) {
       throw new Error(
         `Cross-contract utility calls are not yet supported: cannot call ${targetContractAddress} from utility function on ${this.contractAddress}.`,
-      );
-    }
-
-    if (!this.simulator) {
-      throw new Error(
-        `Cannot perform nested utility call from ${this.contractAddress} to ` +
-          `${targetContractAddress}:${functionSelector}: ` +
-          `UtilityExecutionOracle was constructed without a CircuitSimulator. ` +
-          `Pass one via UtilityExecutionOracleArgs.simulator.`,
       );
     }
 

--- a/yarn-project/pxe/src/oracle_version.ts
+++ b/yarn-project/pxe/src/oracle_version.ts
@@ -11,7 +11,7 @@
 /// if AZTEC_NR_MINOR > PXE_MINOR because if a contract is updated to use a newer Aztec.nr dependency without actually
 /// using any of the new oracles then there is no reason to throw.
 export const ORACLE_VERSION_MAJOR = 22;
-export const ORACLE_VERSION_MINOR = 1;
+export const ORACLE_VERSION_MINOR = 2;
 
 /// This hash is computed from the Oracle interface and is used to detect when that interface changes. When it does,
 /// you need to either:
@@ -19,4 +19,4 @@ export const ORACLE_VERSION_MINOR = 1;
 /// - increment only `ORACLE_VERSION_MINOR` if the change is additive (a new oracle was added).
 ///
 /// These constants must be kept in sync between this file and `noir-projects/aztec-nr/aztec/src/oracle/version.nr`.
-export const ORACLE_INTERFACE_HASH = 'efafa0db2cc1f94e26d794d0079c8f71115261df0c3d0fa8cb5b64f17a12db92';
+export const ORACLE_INTERFACE_HASH = '193fe3f9fee6a84d26803e636c9746dd805a4f389d44a0618de75c2c5eb4912e';

--- a/yarn-project/txe/src/oracle/txe_oracle_top_level_context.ts
+++ b/yarn-project/txe/src/oracle/txe_oracle_top_level_context.ts
@@ -753,6 +753,7 @@ export class TXEOracleTopLevelContext implements IMiscOracle, ITxeExecutionOracl
 
     try {
       const anchorBlockHeader = await this.stateMachine.anchorBlockStore.getBlockHeader();
+      const simulator = new WASMSimulator();
       const oracle = new UtilityExecutionOracle({
         contractAddress: call.to,
         authWitnesses: [],
@@ -772,8 +773,9 @@ export class TXEOracleTopLevelContext implements IMiscOracle, ITxeExecutionOracl
         l2TipsStore: this.stateMachine.node,
         jobId,
         scopes,
+        simulator,
       });
-      const acirExecutionResult = await new WASMSimulator()
+      const acirExecutionResult = await simulator
         .executeUserCircuit(toACVMWitness(0, call.args), entryPointArtifact, new Oracle(oracle).toACIRCallback())
         .catch((err: Error) => {
           err.message = resolveAssertionMessageFromError(err, entryPointArtifact);

--- a/yarn-project/txe/src/txe_session.ts
+++ b/yarn-project/txe/src/txe_session.ts
@@ -478,6 +478,7 @@ export class TXESession implements TXESessionStateHandler {
       jobId: this.currentJobId,
       scopes: await this.keyStore.getAccounts(),
       messageContextService: this.stateMachine.messageContextService,
+      simulator: new WASMSimulator(),
     });
 
     // We store the note and tagging index caches fed into the PrivateExecutionOracle (along with some other auxiliary
@@ -560,6 +561,7 @@ export class TXESession implements TXESessionStateHandler {
       l2TipsStore: this.stateMachine.node,
       jobId: this.currentJobId,
       scopes: await this.keyStore.getAccounts(),
+      simulator: new WASMSimulator(),
     });
 
     this.state = { name: 'UTILITY' };
@@ -638,6 +640,7 @@ export class TXESession implements TXESessionStateHandler {
       }
 
       try {
+        const simulator = new WASMSimulator();
         const oracle = new UtilityExecutionOracle({
           contractAddress: call.to,
           authWitnesses: [],
@@ -657,8 +660,9 @@ export class TXESession implements TXESessionStateHandler {
           l2TipsStore: this.stateMachine.node,
           jobId: this.currentJobId,
           scopes,
+          simulator,
         });
-        await new WASMSimulator()
+        await simulator
           .executeUserCircuit(toACVMWitness(0, call.args), entryPointArtifact, new Oracle(oracle).toACIRCallback())
           .catch((err: Error) => {
             err.message = resolveAssertionMessageFromError(err, entryPointArtifact);


### PR DESCRIPTION
## Summary

Utility functions (`#[external("utility")]`) can now call other utility functions on the same contract via `self.call(MyContract::at(addr).my_utility(args))`. Previously there was no oracle dispatch path for this — the PXE would silently skip the call.

The implementation adds a new `aztec_utl_callUtilityFunction` oracle that dispatches to a child `UtilityExecutionOracle`, running the nested circuit directly. This mirrors how private nested calls work.

## Caveats

Cross-contract utility calls (calling a utility function on a *different* contract) are explicitly rejected. Utility functions can access private state, so allowing them to be called transitively across contract boundaries would expose that state without the wallet having any mechanism to authorize or even know about the transitive call. This is tracked in F-29.

## Tests

- Noir unit test in `contract_self_utility.nr` asserting that a cross-contract call panics with the expected message.
- TypeScript unit test in `utility_execution.test.ts` asserting that `callUtilityFunction` throws when the target contract differs from the execution context.
- E2e test with a `NestedUtility` contract implementing `pow(x, n) = x^n` recursively, verifying 10 levels of nesting.

Fixes F-591