### PR TITLE
docs: add map and state variable docs 

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/state_vars/map.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/map.nr
@@ -14,8 +14,7 @@ use crate::state_vars::StateVariable;
 /// complex containers: an array could be implemented as a `Map` with indices as keys.
 ///
 /// Note that some private state variables, such as [`PrivateMutable`](crate::state_vars::PrivateMutable) and
-/// [`PrivateSet`](crate::state_vars::PrivateSet) cannot be wrapped in a `Map` with an `AztecAddress` to represent
-/// e.g. a per-account private configuration value or set of notes. These types implement the
+/// [`PrivateSet`](crate::state_vars::PrivateSet) cannot be wrapped in a `Map`. These types implement the
 /// [`OwnedStateVariable`](crate::state_vars::OwnedStateVariable) trait, and as such should instead be wrapped using the
 /// [`Owned`](crate::state_vars::Owned) container, which can be thought of as a specialization of `Map` for private
 /// state 'owned' by a single account.

--- a/noir-projects/aztec-nr/aztec/src/state_vars/map.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/map.nr
@@ -3,49 +3,89 @@ use crate::state_vars::StateVariable;
 
 /// A key-value container for state variables.
 ///
-/// A key-value storage container that maps keys to state variables, similar to Solidity mappings.
+/// A `Map` wraps another state variable type (the 'value') and creates independent instances of it for each key,
+/// resulting in effectively as many state variables as there are key values. This behavior is similar to a Solidity
+/// `mapping (K => V)`.
 ///
-/// `Map` enables you to associate keys (like addresses or other identifiers) with state variables in your Aztec smart
-/// contract. This is conceptually similar to Solidity's `mapping(K => V)` syntax, where you can store and retrieve
-/// values by their associated keys.
+/// ## Use Cases
 ///
-/// You can declare a state variable contained within a Map in your contract's
-/// [`storage`](crate::macros::storage::storage) struct.
+/// Any scenario in which a fixed number of variables is insufficient to represent contract state requires `Map` e.g.
+/// per-election configuration in a voting contract, per-user state, etc. `Map` also composes naturally into more
+/// complex containers: an array could be implemented as a `Map` with indices as keys.
 ///
-/// For example, you might use `Map<AztecAddress, PublicMutable<FieldNote, Context>, Context>` to track token balances
-/// for different users, similar to how you'd use `mapping(address => uint256)` in Solidity.
+/// Note that some private state variables, such as [`PrivateMutable`](crate::state_vars::PrivateMutable) and
+/// [`PrivateSet`](crate::state_vars::PrivateSet) cannot be wrapped in a `Map` with an `AztecAddress` to represent
+/// e.g. a per-account private configuration value or set of notes. These types implement the
+/// [`OwnedStateVariable`](crate::state_vars::OwnedStateVariable) trait, and as such should instead be wrapped using the
+/// [`Owned`](crate::state_vars::Owned) container, which can be thought of as a specialization of `Map` for private
+/// state 'owned' by a single account.
 ///
-/// > Aside: the verbose `Context` in the declaration is a consequence of > leveraging Noir's regular syntax for
-/// generics to ensure that certain > state variable methods can only be called in some contexts (private, > public,
-/// utility).
+/// ## Examples
 ///
-/// The methods of Map are:
-/// - `at` (access state variable for a given key) (see the method's own doc comments for more info).
+/// Since `Map` is also a [`StateVariable`], it is declared in the contract's
+/// [`#[storage]`](crate::macros::storage::storage) struct along with all others:
 ///
-/// ## Generic Parameters
-/// - `K`: The key type (must implement `ToField` trait for hashing)
-/// - `V`: The value type:
-/// - any Aztec state variable (variable that implements the StateVariable trait):
-/// - `PublicMutable`
-/// - `PublicImmutable`
-/// - `DelayedPublicMutable`
-/// - `Map`
-/// - `Context`: The execution context (handles private/public function contexts)
+/// ```noir
+/// #[storage]
+/// struct Storage<C> {
+///     is_admin: Map<AztecAddress, PublicMutable<bool, C>, C>,
+///     vote_tallies: Map<ElectionId, PublicMutable<u128, C>, C>,
+/// }
+/// ```
 ///
-/// ## Usage Maps are typically declared in your contract's [`storage`](crate::macros::storage::storage) struct and accessed using the `at(key)` method to get the state variable for a specific key. The resulting state variable can then be read from or written to using its own methods.
+/// ### Multiple `Map`s
 ///
-/// Note that maps cannot be used with owned state variables (variables that implement the OwnedStateVariable trait) -
-/// those need to be wrapped in an `Owned` state variable instead.
+/// There is no limit to how many `Map` containers a contract can have, and `Map`s can themselves wrap other `Map`s,
+/// resulting in nested layouts.
 ///
-/// ## Advanced Internally, `Map` uses a single base storage slot to represent the mapping itself, similar to Solidity's approach. Individual key-value pairs are stored at derived storage slots computed by hashing the base storage slot with the key using Poseidon2. This ensures:
-/// - No storage slot collisions between different keys
-/// - Uniform distribution of storage slots across the storage space
-/// - Compatibility with Aztec's storage tree structure
-/// - Gas-efficient storage access patterns similar to Solidity mappings
+/// ```noir
+/// #[storage]
+/// struct Storage<C> {
+///     // A nested map where the first key is an address and the second a `Year` type, such that
+///     // self.storage.user_yearly_config.at(user).at(year) results in distinct `UserConfig` variables for each
+///     // `(user, year)` tuple.
+///     user_yearly_config: Map<AztecAddress, Map<Year, UserConfig<C>, C>, C>,
+/// }
+/// ```
 ///
-/// The storage slot derivation uses `derive_storage_slot_in_map(base_slot, key)` which computes
-/// `poseidon2_hash([base_slot, key.to_field()])`, ensuring cryptographically secure slot separation.
+/// ## Requirements
 ///
+/// The value type `V` must implement the [`StateVariable`] trait. The key type `K` must implement the [`ToField`] trait
+/// in such a way that the `Field` representation is unique for each key.
+///
+/// For key types that cannot be converted into a `Field`, consider wrapping them in a type that implements `ToField` as
+/// the hash of the key.
+///
+/// ```noir
+/// struct MyKey {
+///     a: Field,
+///     b: Field,
+/// }
+///
+/// struct MyKeyWrapper {
+///     inner: MyKey,
+/// }
+///
+/// impl ToField for MyKeyWrapper {
+///     fn to_field(self) -> Field {
+///         poseidon2_hash([self.inner.a, self.inner.b])
+///     }
+/// }
+///
+/// #[storage]
+/// struct Storage<C> {
+///     a: Map<MyKeyWrapper, PublicMutable<bool, C>, C>,
+/// }
+/// ```
+///
+/// ## Implementation Details
+///
+/// Like all other state variables, `Map` gets assigned a unique storage slot. It uses this value to derive unique
+/// storage slots for each key, resulting in independent state variables. Nothing gets stored at `Map`'s storage slot.
+/// This is equivalent to Solidity's implementation of `mapping`.
+///
+/// Because the storage slot derivation is done using a hash function, it is not possible to compute the key (preimage)
+/// used to obtain a given derived state variable slot.
 pub struct Map<K, V, Context> {
     pub context: Context,
     storage_slot: Field,
@@ -66,35 +106,20 @@ impl<K, V, Context> StateVariable<1, Context> for Map<K, V, Context> {
 }
 
 impl<K, V, Context> Map<K, V, Context> {
-    /// Returns the state variable associated with the given key.
+    /// Returns the state variable for a key.
     ///
-    /// This is equivalent to accessing `mapping[`key`]` in Solidity. It returns the state variable instance for the
-    /// specified key, which can then be used to read or write the value at that key.
+    /// This derives a unique storage slot for `key` and returns a state variable of type `V` at that slot. It is
+    /// equivalent to accessing a `mapping` via the `[]` operator in Solidity (e.g. `balances[user]` would be
+    /// `balances.at(user)`).
     ///
-    /// Unlike Solidity mappings which return the value directly, this returns the state variable wrapper (like
-    /// PublicMutable, nested Map etc.) that you then call methods on to interact with the actual value.
-    ///
-    /// # Arguments
-    ///
-    /// * `key` - The key to look up in the map. Must implement the ToField trait (which most basic Noir & Aztec types
-    /// do).
-    ///
-    /// # Returns
-    ///
-    /// * `V` - The state variable instance for this key. You can then call methods like `.read()`, `.write()`,
-    /// `.get_note()`, etc. on this depending on the specific state variable type.
-    ///
-    /// # Example
+    /// ## Example
     ///
     /// ```noir
-    /// // Get a user's balance (assuming PrivateMutable<FieldNote>)
-    /// let user_balance = self.storage.balances.at(user_address);
-    /// let current_note = user_balance.get_note();
-    ///
-    /// // Update the balance
-    /// user_balance.replace(new_note);
+    /// #[external("utility")]
+    /// fn get_election_vote_tallies(election: ElectionId) -> u128 {
+    ///     self.storage.vote_tallies.at(election).read()
+    /// }
     /// ```
-    ///
     pub fn at<let N: u32>(self, key: K) -> V
     where
         K: ToField,

--- a/noir-projects/aztec-nr/aztec/src/state_vars/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/mod.nr
@@ -1,3 +1,4 @@
+// noir-fmt:ignore
 //! Storage for contract state.
 //!
 //! Contracts store their state in _state variables_. In Solidity, a state variable is simply any value declared inside
@@ -7,6 +8,81 @@
 //! Due to Aztec contracts being able to store both public and private state, there are many more different types of
 //! state variables, each with their nuance and use cases. Understanding these is key to understanding how a contract
 //! works.
+//!
+//! ## Declaration
+//!
+//! All of a contract's state variables, both public and private, are declared in a single place: as members of a struct
+//! to which the [`#[storage]`](crate::macros::storage::storage) macro is applied.
+//!
+//! ```noir
+//! #[storage]
+//! struct Storage<C> {
+//!     a: PublicMutable<bool, C>,
+//!     b: Map<AztecAddress, DelayedPublicMutable<u128, C>, C>,
+//!     c: Owned<PrivateSet<UintNote, C>, C>,
+//! }
+//! ```
+//!
+//! ## Choosing a State Variable
+//!
+//! The very first question to answer is whether the contents of the variable should be _public_ (everyone in the
+//! network can see their contents, like Solidity state variables), or _private_ (only some people know what is stored
+//! in them).
+//!
+//! ### Public State Variables
+//!
+//! Public state variables typically store their contents in the public storage tree, and can therefore only be written
+//! to by public contract functions.
+//!
+//! | State Variable                                                    | Mutable?            | Readable in Private? | Writable in Private? | Example Use Case                                                                   |
+//! | ----------------------------------------------------------------- | ------------------- | -------------------- | -------------------- | ---------------------------------------------------------------------------------- |
+//! | [`PublicMutable`](crate::state_vars::PublicMutable)               | yes                 | no                   | no                   | Configuration of admins, global state (e.g. token total supply, total votes)       |
+//! | [`PublicImmutable`](crate::state_vars::PublicImmutable)           | no                  | yes                  | no                   | Fixed configuration, one-way actions (e.g. initialization settings for a proposal) |
+//! | [`DelayedPublicMutable`](crate::state_vars::DelayedPublicMutable) | yes (after a delay) | yes                  | no                   | Non time sensitive system configuration                                            |
+//!
+//! ### Private State Variables
+//!
+//! Private state variables typically store their contents in the note and nullifier trees, and are therefore mainly
+//! interacted with from private contract functions.
+//!
+//! | State Variable                                            | Mutable? | Cost to Read? | Writable by Third Parties? | Example Use Case                                                                                               |
+//! | --------------------------------------------------------- | -------- | ------------- | -------------------------- | -------------------------------------------------------------------------------------------------------------- |
+//! | [`PrivateMutable`](crate::state_vars::PrivateMutable)     | yes      | yes           | no                         | Mutable user state only accessible by them (e.g. user settings or keys)                                        |
+//! | [`PrivateImmutable`](crate::state_vars::PrivateImmutable) | no       | no            | no                         | Fixed configuration, one-way actions (e.g. initialization settings for a proposal)                             |
+//! | [`PrivateSet`](crate::state_vars::PrivateSet)             | yes      | yes           | yes                        | Aggregated state others can add to, e.g. token balance (set of amount notes), NFT collections (set of NFT ids) |
+//!
+//! ## Storage Slots
+//!
+//! Each state variable in a contract gets assigned a unique storage slot, which isolates the different variables so
+//! that reads and writes to one do not interfere with others.
+//!
+//! Storage slot allocation is automatic and cannot be overridden. A state variable's storage slot can be queried via
+//! [`crate::state_vars::StateVariable::get_storage_slot`].
+//!
+//! ```noir
+//! #[storage]
+//! struct Storage<C> {
+//!     a: PublicMutable<bool, C>,
+//! }
+//!
+//! #[external("utility")]
+//! fn get_a_storage_slot() -> Field {
+//!     self.storage.a.get_storage_slot()
+//! }
+//! ```
+//!
+//! ## The Context Parameter
+//!
+//! All state variables take a generic `Context` parameter, which will be set to one of
+//! [`PrivateContext`](crate::context::PrivateContext), [`PublicContext`](crate::context::PublicContext) or
+//! [`UtilityContext`](crate::context::UtilityContext) depending on the contract function type. This leads to some
+//! unfortunate boilerplate when declaring contract storage.
+//!
+//! Different methods are available depending on the context, reflecting that certain actions can only be performed in
+//! some or other context. For example, [`PublicMutable`](crate::state_vars::PublicMutable)'s
+//! [`read`](crate::state_vars::PublicMutable::read) function is available under both `PublicContext` and
+//! `UtilityContext`, but not `PrivateContext` since `PublicMutable` cannot be read from private functions. Similarly,
+//! [`write`](crate::state_vars::PublicMutable::write) is only available in `PublicContext`.
 //!
 //! ## Packing for Efficient Access
 //!
@@ -19,8 +95,7 @@
 //! manually implemented - see the [`Packable`](crate::protocol::traits::Packable)'s docs on how to do this.
 //!
 //! ```noir
-//! // Inefficient reads and writes - each bool is assigned a distinct storage slot, so reading or writing both
-//! requires
+//! // Inefficient reads and writes - each bool is assigned a distinct storage slot, so reading or writing both requires
 //! // executing `SLOAD` or `SSTORE` twice.
 //! #[storage]
 //! struct Storage<C> {
@@ -28,7 +103,7 @@
 //!     b: PublicMutable<bool, C>,
 //! }
 //!
-//! // By storing the booleans in a single struct and implementing the Packable trait with tight packing, we can now
+//! // By storing the booleans in a single struct and implementing the Packable trait with tight packing, we can instead
 //! // read and write both values in a single `SLOAD` or `SSTORE` opcode.
 //! struct TwoBooleans {
 //!     a: bool,

--- a/noir-projects/aztec-nr/aztec/src/state_vars/public_mutable.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/public_mutable.nr
@@ -52,7 +52,7 @@ mod test;
 ///
 /// ## Examples
 ///
-/// Declaring a `PublicMutable` in the contract's [`storage`](crate::macros::storage::storage) struct requires
+/// Declaring a `PublicMutable` in the contract's [`#[storage]`](crate::macros::storage::storage) struct requires
 /// specifying the type `T` that is stored in the variable:
 ///
 /// ```noir

--- a/noir-projects/aztec-nr/aztec/src/state_vars/state_variable.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/state_variable.nr
@@ -1,24 +1,15 @@
-/// A trait that defines the common interface for all Aztec state variables. State variables are variables that can be
-/// stored in the contract's storage. Examples of state variables are `Owned`, `PublicMutable`, `Map` or
-/// `DelayedPublicMutable`.
+/// A container for contract state.
 ///
-/// # Type Parameters
-///
-/// * `N` - A compile-time constant that determines how many storage slots need to be reserved for this state variable.
-/// * `Context` - The execution context type (e.g., `PublicContext`, `PrivateContext`, `UtilityContext`). The context
-/// determines which methods of the state variable are available and controls whether the variable can be accessed in
-/// public, private or utility functions.
-///
+/// All contract state is stored in state variables, and all state variables implement the `StateVariable` trait. For
+/// more information on the different types of state variables see the [`state_vars`](crate::state_vars) module.
 pub trait StateVariable<let N: u32, Context> {
-    /// Initializes a new state variable at a given storage slot.
+    /// Creates a state variable.
     ///
-    /// This function is automatically called within the [`storage`](crate::macros::storage::storage) macro and needs
-    /// to
-    /// be manually called only when [`storage_no_init`](crate::macros::storage::storage_no_init) is used.
-    ///
+    /// This function is automatically called by aztec-nr as the [`self`](crate::contract_self) object is created. Users
+    /// are expected to only ever need to invoke it when using the
+    /// [`#[storage_no_init]`](crate::macros::storage::storage_no_init) macro.
     fn new(context: Context, storage_slot: Field) -> Self;
 
-    /// Returns the storage slot at which the state variable is placed. Typically used only when testing the contract
-    /// or when using a lower-level API like `get_notes` function.
+    /// Returns the state variable's storage slot.
     fn get_storage_slot(self) -> Field;
 }

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/tests/private_kernel_reset/reset_output_validator/propagated_note_hashes_tests.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/tests/private_kernel_reset/reset_output_validator/propagated_note_hashes_tests.nr
@@ -1,6 +1,6 @@
 use crate::tests::private_kernel_reset::{NOTE_HASH_SILOING_AMOUNT, TestBuilder};
-use protocol_test_utils::swap_items;
 use super::rebuild_bounded_vec;
+use protocol_test_utils::swap_items;
 
 #[test]
 fn previous_note_hashes_sorted() {

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/tests/private_kernel_reset/reset_output_validator/propagated_nullifiers_tests.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/tests/private_kernel_reset/reset_output_validator/propagated_nullifiers_tests.nr
@@ -1,6 +1,6 @@
 use crate::tests::private_kernel_reset::{NULLIFIER_SILOING_AMOUNT, TestBuilder};
-use protocol_test_utils::swap_items;
 use super::rebuild_bounded_vec;
+use protocol_test_utils::swap_items;
 
 #[test]
 fn previous_nullifiers_sorted() {

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/tests/private_kernel_reset/reset_output_validator/propagated_private_logs_tests.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/tests/private_kernel_reset/reset_output_validator/propagated_private_logs_tests.nr
@@ -1,6 +1,6 @@
 use crate::tests::private_kernel_reset::{PRIVATE_LOG_SILOING_AMOUNT, TestBuilder};
-use protocol_test_utils::swap_items;
 use super::rebuild_bounded_vec;
+use protocol_test_utils::swap_items;
 
 #[test]
 fn previous_private_logs_sorted() {
@@ -158,7 +158,8 @@ fn with_padded_private_logs() {
         builder.previous_kernel.private_logs.pop().innermost().log;
 
     // BoundedVec.pop() no longer zeroes vacated slots; rebuild with clean storage.
-    builder.previous_kernel.private_logs = rebuild_bounded_vec(builder.previous_kernel.private_logs);
+    builder.previous_kernel.private_logs =
+        rebuild_bounded_vec(builder.previous_kernel.private_logs);
 
     builder.output.append_siloed_private_logs(1);
     builder.output.append_padded_private_logs(2);
@@ -189,7 +190,8 @@ fn total_private_logs_more_than_capped_size() {
         builder.previous_kernel.private_logs.pop().innermost().log;
 
     // BoundedVec.pop() no longer zeroes vacated slots; rebuild with clean storage.
-    builder.previous_kernel.private_logs = rebuild_bounded_vec(builder.previous_kernel.private_logs);
+    builder.previous_kernel.private_logs =
+        rebuild_bounded_vec(builder.previous_kernel.private_logs);
 
     builder.output.append_siloed_private_logs(PRIVATE_LOG_SILOING_AMOUNT);
     builder.output.append_padded_private_logs(1);


### PR DESCRIPTION
These contain a basic explainer on some state variable concepts, add some missing bits there (like a table with different kinds of statevars and their usecases), and greatly expands on (completes) `Map` documentation.