### PR TITLE
fix(aztec-up): handle CI=true in timeout function

### DIFF
--- a/aztec-up/bin/0.0.1/install
+++ b/aztec-up/bin/0.0.1/install
@@ -49,7 +49,7 @@ function echo_yellow {
 }
 
 function timeout {
-  if [ "${CI:-0}" -eq 1 ]; then
+  if [ "${CI:-0}" = "1" ] || [ "${CI:-0}" = "true" ]; then
     /usr/bin/timeout "$@"
   else
     shift


### PR DESCRIPTION
## Summary

- The `timeout` helper in the per-version installer used `-eq` (integer comparison) to check whether `CI` was set, but GitHub Actions sets `CI=true` (a string). This caused bash to emit `[: true: integer expression expected` and fail to use `/usr/bin/timeout` during CI runs.
- Fix changes the comparison to `= "1" || = "true"` so both conventional and GitHub Actions CI values are handled.