### PR TITLE
test(e2e): equivocation recovery under proposer pipelining

### DIFF
--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_equivocation.test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_equivocation.test.ts
@@ -1,0 +1,279 @@
+import type { AztecNodeService } from '@aztec/aztec-node';
+import { EthAddress } from '@aztec/aztec.js/addresses';
+import { Fr } from '@aztec/aztec.js/fields';
+import type { Logger } from '@aztec/aztec.js/log';
+import { asyncMap } from '@aztec/foundation/async-map';
+import { CheckpointNumber, SlotNumber } from '@aztec/foundation/branded-types';
+import { times } from '@aztec/foundation/collection';
+import { SecretValue } from '@aztec/foundation/config';
+import { retryUntil } from '@aztec/foundation/retry';
+import { bufferToHex } from '@aztec/foundation/string';
+import { getTimestampForSlot } from '@aztec/stdlib/epoch-helpers';
+import { tryStop } from '@aztec/stdlib/interfaces/server';
+
+import { jest } from '@jest/globals';
+import { privateKeyToAccount } from 'viem/accounts';
+
+import { getPrivateKeyFromIndex } from '../fixtures/utils.js';
+import { EpochsTestContext } from './epochs_test.js';
+
+jest.setTimeout(1000 * 60 * 15);
+
+const NODE_COUNT = 4;
+
+/**
+ * E2E test for the equivocation recovery scenario under proposer pipelining.
+ *
+ * Two conflicting checkpoint proposals are gossiped during the same slot:
+ * - Node A (holds all 4 validator keys) publishes the "real" checkpoint to L1
+ *   but never broadcasts via gossipsub (`skipBroadcastProposals + skipIncomingProposals`).
+ * - The "X" node (B or C, whichever holds the slot proposer's key) broadcasts an
+ *   alternative checkpoint that reaches B/C/D via gossipsub but never lands on L1
+ *   (`skipPublishingCheckpointsPercent: 100`).
+ *
+ * The test verifies that L1 sync overrides the gossip-only proposal on all observer
+ * nodes (B, C, D) once A's L1-confirmed checkpoint propagates via the archiver.
+ */
+describe('e2e_epochs/epochs_equivocation', () => {
+  let logger: Logger;
+  let test: EpochsTestContext;
+  let nodes: AztecNodeService[];
+
+  afterEach(async () => {
+    jest.restoreAllMocks();
+    await test?.teardown();
+  });
+
+  it('L1-confirmed checkpoint overrides gossip-only equivocating proposal', async () => {
+    // Build 4 validators (V1..V4) using getPrivateKeyFromIndex(i+3), same convention as other epoch tests.
+    const validators = times(NODE_COUNT, i => {
+      const privateKey = bufferToHex(getPrivateKeyFromIndex(i + 3)!);
+      const attester = EthAddress.fromString(privateKeyToAccount(privateKey).address);
+      return { attester, withdrawer: attester, privateKey, bn254SecretKey: new SecretValue(Fr.random().toBigInt()) };
+    });
+
+    // Timing calculation for 3 blocks per checkpoint with 8s sub-slots:
+    // - initializationOffset = 0.5s (test mode, ethereumSlotDuration < 8)
+    // - 3 blocks x 8s = 24s
+    // - checkpointFinalization = 0.5s (assemble) + 0 (p2p in test) + 2s (L1 publish) = 2.5s
+    // - finalBlockDuration = 8s (re-execution)
+    // - Total: 0.5 + 24 + 8 + 2.5 = 35s => use 36s
+    test = await EpochsTestContext.setup({
+      numberOfAccounts: 0,
+      initialValidators: validators,
+      enableProposerPipelining: true,
+      inboxLag: 2,
+      mockGossipSubNetwork: true,
+      disableAnvilTestWatcher: true,
+      startProverNode: false,
+      aztecEpochDuration: 4,
+      aztecProofSubmissionEpochs: 1024,
+      enforceTimeTable: true,
+      ethereumSlotDuration: 6,
+      aztecSlotDuration: 36,
+      blockDurationMs: 8000,
+      attestationPropagationTime: 0.5,
+      l1PublishingTime: 2,
+      aztecTargetCommitteeSize: 4,
+      skipInitialSequencer: true,
+    });
+
+    logger = test.logger;
+
+    // We set different coinbase addresses so different nodes produce different blocks
+    const coinbaseA = EthAddress.fromNumber(0xa);
+    const coinbaseB = EthAddress.fromNumber(0xb);
+    const coinbaseC = EthAddress.fromNumber(0xc);
+
+    // The private keys held by each node:
+    // A: all 4 keys → self-attests with all validators, reaches quorum without inbound attestations
+    // B: V1 + V2
+    // C: V3 + V4
+    // D: no validator keys (RPC-only observer)
+    const keysA = validators.map(v => v.privateKey as `0x${string}`);
+    const keysB = [validators[0].privateKey, validators[1].privateKey] as `0x${string}`[];
+    const keysC = [validators[2].privateKey, validators[3].privateKey] as `0x${string}`[];
+
+    // All sequencers start with dontStartSequencer so we can warp the clock first.
+    nodes = await asyncMap(
+      [
+        {
+          keys: keysA,
+          coinbase: coinbaseA,
+          extraOpts: { skipIncomingProposals: true, skipBroadcastProposals: true },
+        },
+        {
+          keys: keysB,
+          coinbase: coinbaseB,
+          extraOpts: { skipPublishingCheckpointsPercent: 100 },
+        },
+        {
+          keys: keysC,
+          coinbase: coinbaseC,
+          extraOpts: { skipPublishingCheckpointsPercent: 100 },
+        },
+      ],
+      ({ keys, coinbase, extraOpts }) =>
+        test.createValidatorNode(keys, {
+          dontStartSequencer: true,
+          coinbase,
+          buildCheckpointIfEmpty: true,
+          minTxsPerBlock: 0,
+          ...extraOpts,
+        }),
+    );
+
+    // Node D: non-validator observer node
+    const nodeD = await test.createNonValidatorNode({ buildCheckpointIfEmpty: true, minTxsPerBlock: 0 });
+    nodes.push(nodeD);
+    const [nodeB, nodeC] = nodes.slice(1);
+
+    logger.warn('All nodes created', { nodes: nodes.length });
+
+    // Determine the next proposer slot by scanning upcoming slots.
+    // Since A holds all 4 keys and B/C each hold 2, the slot proposer is always held by A
+    // and exactly one of B or C. We identify which one (X) and use its coinbase in assertions.
+    const { slot: currentSlot } = test.epochCache.getEpochAndSlotNow();
+    // Pick a target slot 2 ahead so there's room for the pipelining build window to engage.
+    // With pipelining, the sequencer builds slot (targetSlot+1) while the clock is at targetSlot,
+    // so the proposer we care about is for targetSlot+1 (the submission slot).
+    const targetSlot = SlotNumber(currentSlot + 2);
+    const submissionSlot = SlotNumber(targetSlot + 1);
+
+    const attesterAddresses = validators.map(v => EthAddress.fromString(privateKeyToAccount(v.privateKey).address));
+    logger.warn('Validator attester addresses', {
+      V1: attesterAddresses[0],
+      V2: attesterAddresses[1],
+      V3: attesterAddresses[2],
+      V4: attesterAddresses[3],
+    });
+    logger.warn('Validator-to-node assignment', { A: 'V1,V2,V3,V4', B: 'V1,V2', C: 'V3,V4', D: 'none' });
+
+    const proposerAttester = await test.epochCache.getProposerAttesterAddressInSlot(submissionSlot);
+    if (!proposerAttester) {
+      throw new Error(`No proposer found for slot ${submissionSlot}`);
+    }
+    logger.warn(`Expected proposer for submission slot`, { submissionSlot, proposerAttester });
+
+    // Warp to one L1 slot before the target L2 slot so pipelining's build window engages.
+    const slotStartTimestamp = getTimestampForSlot(targetSlot, test.constants);
+    const warpTo = slotStartTimestamp - BigInt(test.L1_BLOCK_TIME_IN_S);
+    logger.warn(`Warping to L1 timestamp ${warpTo} (one L1 slot before L2 slot ${targetSlot})`);
+    await test.context.cheatCodes.eth.warp(Number(warpTo), { resetBlockInterval: true });
+
+    // Start all sequencers now that the clock is warped.
+    const sequencers = nodes.slice(0, 3).map(n => n.getSequencer()!);
+    const { failEvents } = test.watchSequencerEvents(sequencers, i => ({ validator: ['A', 'B', 'C'][i] }));
+    await Promise.all(sequencers.map(s => s.start()));
+    logger.warn('All sequencers started');
+
+    // Wait until each of B, C, D sees a proposed block for submissionSlot with coinbase B or C.
+    // This confirms the gossip-only equivocating proposal from B or C has propagated.
+    // REFACTOR: This is candidate for a "wait until all nodes see a block with these properties" helper in the test context.
+    const gossipTimeout = test.L2_SLOT_DURATION_IN_S * 4;
+    await Promise.all(
+      [nodeB, nodeC, nodeD].map(async (node, idx) => {
+        const nodeName = ['B', 'C', 'D'][idx];
+        let observedCoinbase: EthAddress | undefined;
+        await retryUntil(
+          async () => {
+            const block = await node.getBlock('proposed');
+            if (!block) {
+              return false;
+            }
+            const slot = block.header.globalVariables.slotNumber;
+            const cb = block.header.globalVariables.coinbase;
+            if (slot === submissionSlot && (cb.equals(coinbaseB) || cb.equals(coinbaseC))) {
+              observedCoinbase = cb;
+              return true;
+            }
+            return false;
+          },
+          `${nodeName} sees gossip-only proposed block for slot ${submissionSlot}`,
+          gossipTimeout,
+          0.5,
+        );
+        logger.warn(`Node ${nodeName} observed gossip-only coinbase for slot ${submissionSlot}`, { observedCoinbase });
+      }),
+    );
+
+    // Now wait until each of B, C, D has a checkpointed block for submissionSlot with coinbaseA.
+    // This confirms A's L1-confirmed checkpoint has overridden the gossip-only proposal.
+    // REFACTOR: This is candidate for a "wait until all nodes see a block with these properties" helper in the test context.
+    const overrideTimeout = test.L2_SLOT_DURATION_IN_S * 4;
+    logger.warn(`Waiting for L1-sync override on B, C, D (timeout=${overrideTimeout}s)`);
+    await Promise.all(
+      [nodeB, nodeC, nodeD].map(async (node, idx) => {
+        const nodeName = ['B', 'C', 'D'][idx];
+        await retryUntil(
+          async () => {
+            const block = await node.getBlock('checkpointed');
+            if (!block) {
+              return false;
+            }
+            const slot = block.header.globalVariables.slotNumber;
+            const cb = block.header.globalVariables.coinbase;
+            return slot >= submissionSlot && cb.equals(coinbaseA);
+          },
+          `${nodeName} checkpointed block for slot ${submissionSlot} with coinbaseA`,
+          overrideTimeout,
+          0.5,
+        );
+      }),
+    );
+
+    // Assert no spurious failures on B, C.
+    // Node A (index 2) generates lots of proposer-rollup-check-failed noise because it has
+    // skipIncomingProposals set and can't build a valid checkpoint for slot 2.
+    // Nodes B (index 3) and C (index 4) generate checkpoint-publish-failed at the submission slot
+    // because skipPublishingCheckpointsPercent: 100 causes their publish to be intentionally skipped.
+    const observerFailEvents = failEvents.filter(
+      e =>
+        e.sequencerIndex !== 2 && // node A
+        !(e.type === 'proposer-rollup-check-failed' && e.reason === 'Rollup contract check failed') &&
+        !(e.type === 'checkpoint-publish-failed' && e.slot === submissionSlot), // expected skip-publish from B/C
+    );
+    if (observerFailEvents.length > 0) {
+      logger.error('Unexpected fail events on observer sequencers', observerFailEvents);
+    }
+    expect(observerFailEvents).toEqual([]);
+
+    // Then heal. Stop A, re-enable checkpoint publishing on B and C, expect chain to advance.
+    logger.warn('Stopping node A and re-enabling publishing on B and C');
+    await tryStop(nodes[0], logger);
+
+    const baseline = test.monitor.checkpointNumber;
+    logger.warn(`Checkpoint baseline after equivocation: ${baseline}`);
+
+    await nodes[1].setConfig({ skipPublishingCheckpointsPercent: 0 });
+    await nodes[2].setConfig({ skipPublishingCheckpointsPercent: 0 });
+
+    const healTarget = CheckpointNumber(baseline + 2);
+    const healTimeout = test.L2_SLOT_DURATION_IN_S * 8;
+    logger.warn(`Waiting for checkpoint ${healTarget} (timeout=${healTimeout}s)`);
+    await test.waitUntilCheckpointNumber(healTarget, healTimeout);
+
+    expect(test.monitor.checkpointNumber).toBeGreaterThanOrEqual(healTarget);
+    logger.warn(`Network healed: checkpoint ${test.monitor.checkpointNumber}`);
+
+    // REFACTOR: This is candidate for a "wait until all nodes sync to a chain tip with these properties" helper in the test context.
+    await Promise.all(
+      [nodeB, nodeC, nodeD].map((node, idx) =>
+        retryUntil(
+          async () => {
+            const tips = await node.getL2Tips();
+            return tips.checkpointed.checkpoint.number >= healTarget;
+          },
+          `${'BCD'[idx]} synced to checkpoint ${healTarget}`,
+          healTimeout,
+          0.5,
+        ),
+      ),
+    );
+
+    // TODO(A-980): assert the equivocating proposer of the first slot is eventually slashed
+    // for the DUPLICATE_PROPOSAL offense. Slasher is currently disabled in the harness
+    // (slasherEnabled: false) and enabling it requires plumbing offense submission and
+    // waiting for the slasher's offense window.
+  });
+});

--- a/yarn-project/p2p/src/config.ts
+++ b/yarn-project/p2p/src/config.ts
@@ -216,6 +216,9 @@ export interface P2PConfig
 
   /** Minimum percentage fee increase required to replace an existing tx via RPC (0 = no bump). */
   priceBumpPercentage: bigint;
+
+  /** Drop incoming block and checkpoint proposals at the libp2p dispatch layer (for testing only) */
+  skipIncomingProposals?: boolean;
 }
 
 export const DEFAULT_P2P_PORT = 40400;
@@ -516,6 +519,10 @@ export const p2pConfigMappings: ConfigMappingsType<P2PConfig> = {
   broadcastEquivocatedProposals: {
     description:
       'Broadcast block proposals even when a conflicting proposal for the same slot already exists in the pool (for testing purposes only).',
+    ...booleanConfigHelper(false),
+  },
+  skipIncomingProposals: {
+    description: 'Drop incoming block and checkpoint proposals at the libp2p dispatch layer (for testing only)',
     ...booleanConfigHelper(false),
   },
   minTxPoolAgeMs: {

--- a/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
+++ b/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
@@ -1,6 +1,6 @@
 import type { EpochCacheInterface } from '@aztec/epoch-cache';
 import { BlockNumber, type SlotNumber } from '@aztec/foundation/branded-types';
-import { maxBy } from '@aztec/foundation/collection';
+import { maxBy, merge } from '@aztec/foundation/collection';
 import { type Logger, createLibp2pComponentLogger, createLogger } from '@aztec/foundation/log';
 import { RunningPromise } from '@aztec/foundation/running-promise';
 import { Timer } from '@aztec/foundation/timer';
@@ -271,8 +271,9 @@ export class LibP2PService extends WithTracer implements P2PService {
     };
   }
 
-  public updateConfig(config: Partial<P2PReqRespConfig>) {
+  public updateConfig(config: Partial<P2PReqRespConfig & Pick<P2PConfig, 'skipIncomingProposals'>>) {
     this.reqresp.updateConfig(config);
+    this.config = merge(this.config, config);
   }
 
   /**
@@ -849,6 +850,15 @@ export class LibP2PService extends WithTracer implements P2PService {
 
     // Process the message, optionally within a linked span for trace propagation
     const processMessage = async () => {
+      if (
+        this.config.skipIncomingProposals &&
+        (msg.topic === this.topicStrings[TopicType.block_proposal] ||
+          msg.topic === this.topicStrings[TopicType.checkpoint_proposal])
+      ) {
+        this.logger.warn(`Ignoring incoming proposal (skipIncomingProposals is set)`, { topic: msg.topic });
+        this.node.services.pubsub.reportMessageValidationResult(msgId, source.toString(), TopicValidatorResult.Ignore);
+        return;
+      }
       if (msg.topic === this.topicStrings[TopicType.tx]) {
         await this.handleGossipedTx(p2pMessage.payload, msgId, source);
       } else if (msg.topic === this.topicStrings[TopicType.checkpoint_attestation]) {

--- a/yarn-project/sequencer-client/src/config.ts
+++ b/yarn-project/sequencer-client/src/config.ts
@@ -228,6 +228,10 @@ export const sequencerConfigMappings: ConfigMappingsType<SequencerConfig> = {
     description: 'Percent probability (0 - 100) of sequencer skipping checkpoint publishing (testing only)',
     ...numberConfigHelper(DefaultSequencerConfig.skipPublishingCheckpointsPercent),
   },
+  skipBroadcastProposals: {
+    description: 'Skip broadcasting checkpoint and block proposals via gossipsub when proposer (for testing only)',
+    ...booleanConfigHelper(false),
+  },
   ...pickConfigMappings(p2pConfigMappings, ['txPublicSetupAllowListExtend']),
 };
 

--- a/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.ts
+++ b/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.ts
@@ -640,8 +640,10 @@ export class CheckpointProposalJob implements Traceable {
       );
 
       const blockProposedAt = this.dateProvider.now();
-      await this.p2pClient.broadcastCheckpointProposal(proposal);
-      this.checkpointMetrics.noteCheckpointBroadcast(this.dateProvider.now());
+      if (!this.config.skipBroadcastProposals) {
+        await this.p2pClient.broadcastCheckpointProposal(proposal);
+        this.checkpointMetrics.noteCheckpointBroadcast(this.dateProvider.now());
+      }
 
       // Return immediately after broadcast — attestation collection happens in the background
       return { checkpoint, proposal, blockProposedAt };
@@ -762,7 +764,9 @@ export class CheckpointProposalJob implements Traceable {
       }
 
       // Once we have a signed proposal and the archiver agreed with our proposed block, then we broadcast it.
-      proposal && (await this.p2pClient.broadcastProposal(proposal));
+      if (proposal && !this.config.skipBroadcastProposals) {
+        await this.p2pClient.broadcastProposal(proposal);
+      }
 
       // Wait until the next block's start time
       await this.waitUntilNextSubslot(timingInfo.deadline);

--- a/yarn-project/stdlib/src/interfaces/aztec-node-admin.ts
+++ b/yarn-project/stdlib/src/interfaces/aztec-node-admin.ts
@@ -81,6 +81,8 @@ export type AztecNodeAdminConfig = Omit<ValidatorClientFullConfig, 'l1Contracts'
     'archiverPollingIntervalMS' | 'archiverBatchSize' | 'skipValidateCheckpointAttestations'
   > & {
     maxPendingTxCount: number;
+    // Keep in sync with P2PConfig.skipIncomingProposals (circular dep prevents Pick<P2PConfig, ...> here)
+    skipIncomingProposals?: boolean;
   };
 
 export const AztecNodeAdminConfigSchema = SequencerConfigSchema.merge(ProverConfigSchema)
@@ -93,7 +95,7 @@ export const AztecNodeAdminConfigSchema = SequencerConfigSchema.merge(ProverConf
       skipValidateCheckpointAttestations: true,
     }),
   )
-  .merge(z.object({ maxPendingTxCount: z.number() }));
+  .merge(z.object({ maxPendingTxCount: z.number(), skipIncomingProposals: z.boolean().optional() }));
 
 export const AztecNodeAdminApiSchema: ApiSchemaFor<AztecNodeAdmin> = {
   getConfig: z.function().returns(AztecNodeAdminConfigSchema),

--- a/yarn-project/stdlib/src/interfaces/configs.ts
+++ b/yarn-project/stdlib/src/interfaces/configs.ts
@@ -83,6 +83,8 @@ export interface SequencerConfig {
   minBlocksForCheckpoint?: number;
   /** Skip publishing checkpoint proposals probability (for testing checkpoint prunes only) */
   skipPublishingCheckpointsPercent?: number;
+  /** Skip broadcasting checkpoint and block proposals via gossipsub when proposer (for testing only) */
+  skipBroadcastProposals?: boolean;
 }
 
 export const SequencerConfigSchema = zodFor<SequencerConfig>()(
@@ -124,6 +126,7 @@ export const SequencerConfigSchema = zodFor<SequencerConfig>()(
     skipPushProposedBlocksToArchiver: z.boolean().optional(),
     minBlocksForCheckpoint: z.number().positive().optional(),
     skipPublishingCheckpointsPercent: z.number().gte(0).lte(100).optional(),
+    skipBroadcastProposals: z.boolean().optional(),
   }),
 );
 
@@ -145,7 +148,8 @@ type SequencerConfigOptionalKeys =
   | 'maxTxsPerCheckpoint'
   | 'maxL2BlockGas'
   | 'maxDABlockGas'
-  | 'redistributeCheckpointBudget';
+  | 'redistributeCheckpointBudget'
+  | 'skipBroadcastProposals';
 
 export type ResolvedSequencerConfig = Prettify<
   Required<Omit<SequencerConfig, SequencerConfigOptionalKeys>> & Pick<SequencerConfig, SequencerConfigOptionalKeys>


### PR DESCRIPTION
Adds a new e2e test that checks that the network can recover from a checkpoint posted to L1 that differs from the one broadcasted via p2p.

Fixes A-870