### PR TITLE
fix(archiver): short-circuit L1 to L2 message rollback at finalized L1 block

### DIFF
--- a/yarn-project/archiver/src/archiver-sync.test.ts
+++ b/yarn-project/archiver/src/archiver-sync.test.ts
@@ -945,6 +945,102 @@ describe('Archiver Sync', () => {
       );
     });
 
+    it('short-circuits rollback at the finalized L1 block', async () => {
+      // Sync two checkpoints worth of messages so we have history to roll back over.
+      const msgs1 = [Fr.random(), Fr.random()];
+      fake.addMessages(CheckpointNumber(1), 100n, msgs1);
+
+      const msgs3 = [Fr.random(), Fr.random(), Fr.random(), Fr.random()];
+      fake.addMessages(CheckpointNumber(3), 101n, msgs3);
+
+      // Mark block 100 as finalized so messages there cannot be reorged.
+      fake.setFinalizedL1BlockNumber(100n);
+      fake.setL1BlockNumber(110n);
+      await archiver.syncImmediate();
+
+      expect(await archiver.getL1ToL2Messages(CheckpointNumber(1))).toHaveLength(2);
+      expect(await archiver.getL1ToL2Messages(CheckpointNumber(3))).toHaveLength(4);
+
+      // Simulate L1 reorg: remove the last 2 messages from checkpoint 3 and add new ones.
+      fake.removeMessagesAfter(4);
+      const msg40 = Fr.random();
+      fake.addMessages(CheckpointNumber(4), 102n, [msg40]);
+
+      fake.setL1BlockNumber(111n);
+
+      // Spy on getMessageSentEventByHash — used by retrieveL1ToL2Message for per-message log queries.
+      const eventByHashSpy = jest.spyOn(inboxContract, 'getMessageSentEventByHash');
+
+      await archiver.syncImmediate();
+
+      // The two checkpoint-1 messages sit at L1 block 100 (≤ finalized). The rollback loop
+      // should stop there without issuing a per-message log query for them.
+      const callsAtFinalizedOrBelow = eventByHashSpy.mock.calls.filter(
+        ([, aroundL1BlockNumber]) => aroundL1BlockNumber <= 100n,
+      );
+      expect(callsAtFinalizedOrBelow).toHaveLength(0);
+
+      expect(await archiver.getL1ToL2Messages(CheckpointNumber(1))).toHaveLength(2);
+      expect(await archiver.getL1ToL2Messages(CheckpointNumber(4))).toHaveLength(1);
+    });
+
+    it('falls back to per-message log queries when finalized block is undefined', async () => {
+      const msgs1 = [Fr.random(), Fr.random()];
+      fake.addMessages(CheckpointNumber(1), 100n, msgs1);
+
+      const msgs3 = [Fr.random(), Fr.random(), Fr.random(), Fr.random()];
+      fake.addMessages(CheckpointNumber(3), 101n, msgs3);
+
+      // No finalized block — simulates a fresh devnet.
+      fake.setFinalizedL1BlockNumber(undefined);
+      fake.setL1BlockNumber(110n);
+      await archiver.syncImmediate();
+
+      // Reorg: remove last 2 messages from checkpoint 3.
+      fake.removeMessagesAfter(4);
+      const msg40 = Fr.random();
+      fake.addMessages(CheckpointNumber(4), 102n, [msg40]);
+      fake.setL1BlockNumber(111n);
+
+      const eventByHashSpy = jest.spyOn(inboxContract, 'getMessageSentEventByHash');
+
+      await archiver.syncImmediate();
+
+      // Without a finalized pointer the synchronizer must use per-message log queries to find the common point.
+      // 2 messages mismatch on remote (msgs3[2], msgs3[3]) and one matches (msgs3[1]) before we break.
+      expect(eventByHashSpy).toHaveBeenCalledTimes(3);
+
+      expect(await archiver.getL1ToL2Messages(CheckpointNumber(1))).toHaveLength(2);
+      expect(await archiver.getL1ToL2Messages(CheckpointNumber(4))).toHaveLength(1);
+    });
+
+    it('persists the finalized L1 block monotonically after message sync', async () => {
+      const msgs1 = [Fr.random(), Fr.random()];
+      fake.addMessages(CheckpointNumber(1), 100n, msgs1);
+
+      fake.setFinalizedL1BlockNumber(95n);
+      fake.setL1BlockNumber(110n);
+      await archiver.syncImmediate();
+
+      const stored1 = await archiverStore.messages.getMessagesFinalizedL1Block();
+      expect(stored1?.l1BlockNumber).toEqual(95n);
+
+      // A second sync where the finalized block has not advanced.
+      fake.setL1BlockNumber(111n);
+      await archiver.syncImmediate();
+
+      const stored2 = await archiverStore.messages.getMessagesFinalizedL1Block();
+      expect(stored2?.l1BlockNumber).toEqual(95n);
+
+      // Now advance the finalized block — the pointer should follow.
+      fake.setFinalizedL1BlockNumber(105n);
+      fake.setL1BlockNumber(112n);
+      await archiver.syncImmediate();
+
+      const stored3 = await archiverStore.messages.getMessagesFinalizedL1Block();
+      expect(stored3?.l1BlockNumber).toEqual(105n);
+    });
+
     // Regression for https://github.com/AztecProtocol/aztec-packages/issues/13604
     it('handles a checkpoint gap due to a spurious L2 prune', async () => {
       expect(await archiver.getBlockNumber()).toEqual(0);

--- a/yarn-project/archiver/src/modules/l1_synchronizer.ts
+++ b/yarn-project/archiver/src/modules/l1_synchronizer.ts
@@ -8,7 +8,7 @@ import { asyncPool } from '@aztec/foundation/async-pool';
 import { maxBigint } from '@aztec/foundation/bigint';
 import { BlockNumber, CheckpointNumber, EpochNumber } from '@aztec/foundation/branded-types';
 import { Buffer16, Buffer32 } from '@aztec/foundation/buffer';
-import { partition, pick } from '@aztec/foundation/collection';
+import { compactArray, partition, pick } from '@aztec/foundation/collection';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { type Logger, createLogger } from '@aztec/foundation/log';
@@ -162,14 +162,26 @@ export class ArchiverL1Synchronizer implements Traceable {
       );
     }
 
+    // Query finalized block on L1
+    const rawFinalizedL1Block = await getFinalizedL1Block(this.publicClient);
+    const finalizedL1Block: L1BlockId | undefined = rawFinalizedL1Block && {
+      l1BlockNumber: rawFinalizedL1Block.number,
+      l1BlockHash: Buffer32.fromString(rawFinalizedL1Block.hash),
+    };
+
     // Load sync point for blocks defaulting to start block
     const { blocksSynchedTo = this.l1Constants.l1StartBlock } = await getArchiverSynchPoint(this.stores);
-    this.log.debug(`Starting new archiver sync iteration`, { blocksSynchedTo, currentL1BlockData });
+    this.log.debug(`Starting new archiver sync iteration`, { blocksSynchedTo, currentL1BlockData, finalizedL1Block });
 
     // Sync L1 to L2 messages. We retry this a few times since there are error conditions that reset the sync point, requiring a new iteration.
     // Note that we cannot just wait for the l1 synchronizer to loop again, since the synchronizer would report as synced up to the current L1
     // block, when that wouldn't be the case, since L1 to L2 messages would need another iteration.
-    await retryTimes(() => this.handleL1ToL2Messages(currentL1BlockData), 'Handling L1 to L2 messages', 3, 0.1);
+    await retryTimes(
+      () => this.handleL1ToL2Messages(currentL1BlockData, finalizedL1Block),
+      'Handling L1 to L2 messages',
+      3,
+      0.1,
+    );
 
     if (currentL1BlockNumber > blocksSynchedTo) {
       // First we retrieve new checkpoints and L2 blocks and store them in the DB. This will also update the
@@ -209,7 +221,7 @@ export class ArchiverL1Synchronizer implements Traceable {
     }
 
     // Update the finalized L2 checkpoint based on L1 finality.
-    await this.updateFinalizedCheckpoint();
+    await this.updateFinalizedCheckpoint(finalizedL1Block);
 
     // After syncing has completed, update the current l1 block number and timestamp,
     // otherwise we risk announcing to the world that we've synced to a given point,
@@ -226,15 +238,14 @@ export class ArchiverL1Synchronizer implements Traceable {
     });
   }
 
-  /** Query L1 for its finalized block and update the finalized checkpoint accordingly. */
-  private async updateFinalizedCheckpoint(): Promise<void> {
+  /** Updates the finalized checkpoint using the pre-fetched finalized L1 block from the current sync iteration. */
+  private async updateFinalizedCheckpoint(finalizedL1Block: L1BlockId | undefined): Promise<void> {
     try {
-      const finalizedL1Block = await getFinalizedL1Block(this.publicClient);
       if (!finalizedL1Block) {
         this.log.trace(`Skipping finalized checkpoint update: L1 has no finalized block yet.`);
         return;
       }
-      const finalizedL1BlockNumber = finalizedL1Block.number;
+      const finalizedL1BlockNumber = finalizedL1Block.l1BlockNumber;
       const finalizedCheckpointNumber = await this.rollup.getProvenCheckpointNumber({
         blockNumber: finalizedL1BlockNumber,
       });
@@ -390,7 +401,10 @@ export class ArchiverL1Synchronizer implements Traceable {
   }
 
   @trackSpan('Archiver.handleL1ToL2Messages')
-  private async handleL1ToL2Messages(currentL1Block: L1BlockId): Promise<boolean> {
+  private async handleL1ToL2Messages(
+    currentL1Block: L1BlockId,
+    finalizedL1Block: L1BlockId | undefined,
+  ): Promise<boolean> {
     // Load the syncpoint, which may have been updated in a previous iteration
     const {
       messagesSynchedTo = {
@@ -410,7 +424,11 @@ export class ArchiverL1Synchronizer implements Traceable {
     const localLastMessage = await this.stores.messages.getLastMessage();
     if (await this.localStateMatches(localLastMessage, remoteMessagesState)) {
       this.log.trace(`Local L1 to L2 messages are already in sync with remote at L1 block ${currentL1BlockNumber}`);
-      await this.stores.messages.setMessageSyncState(currentL1Block, remoteMessagesState.treeInProgress);
+      await this.stores.messages.setMessageSyncState(
+        currentL1Block,
+        remoteMessagesState.treeInProgress,
+        finalizedL1Block,
+      );
       return true;
     }
 
@@ -446,7 +464,11 @@ export class ArchiverL1Synchronizer implements Traceable {
     }
 
     // Advance the syncpoint after a successful sync
-    await this.stores.messages.setMessageSyncState(currentL1Block, remoteMessagesState.treeInProgress);
+    await this.stores.messages.setMessageSyncState(
+      currentL1Block,
+      remoteMessagesState.treeInProgress,
+      finalizedL1Block,
+    );
     return true;
   }
 
@@ -499,6 +521,9 @@ export class ArchiverL1Synchronizer implements Traceable {
   private async rollbackL1ToL2Messages(remoteMessagesState: InboxContractState): Promise<L1BlockId> {
     const { treeInProgress: remoteTreeInProgress, messagesRollingHash: remoteRollingHash } = remoteMessagesState;
 
+    const messagesFinalizedL1Block = await this.stores.messages.getMessagesFinalizedL1Block();
+    const finalizedL1BlockNumber = messagesFinalizedL1Block?.l1BlockNumber;
+
     // Slowly go back through our messages until we find the last common message. We could query the logs in
     // batch as an optimization, but the depth of the reorg should not be deep, and this is a very rare case,
     // so it's fine to query one log at a time.
@@ -516,6 +541,13 @@ export class ArchiverL1Synchronizer implements Traceable {
           `Found common L1 to L2 message at index ${localMsg.index} on L1 block ${localMsg.l1BlockNumber} matching current remote state`,
           logCtx,
         );
+        commonMsg = localMsg;
+        break;
+      }
+
+      // Messages at or below the finalized L1 block cannot have been reorged — accept as common without querying L1.
+      if (finalizedL1BlockNumber !== undefined && localMsg.l1BlockNumber <= finalizedL1BlockNumber) {
+        this.log.info(`Found common L1 to L2 message at finalized L1 block ${localMsg.l1BlockNumber}`, logCtx);
         commonMsg = localMsg;
         break;
       }
@@ -553,12 +585,24 @@ export class ArchiverL1Synchronizer implements Traceable {
 
     // Update the syncpoint so the loop below reprocesses the changed messages. We go to the block before
     // the last common one, so we force reprocessing it, in case new messages were added on that same L1 block
-    // after the last common message.
-    const syncPointL1BlockNumber = commonMsg ? commonMsg.l1BlockNumber - 1n : this.l1Constants.l1StartBlock;
-    const syncPointL1BlockHash = await this.getL1BlockHash(syncPointL1BlockNumber);
+    // after the last common message. Cap at the finalized L1 block: messages at or below finalized cannot
+    // have been reorged, so there is no need to walk back any further than that.
+    const syncPointL1BlockNumber = maxBigint(
+      ...compactArray([
+        commonMsg ? commonMsg.l1BlockNumber - 1n : undefined,
+        finalizedL1BlockNumber,
+        this.l1Constants.l1StartBlock,
+      ]),
+    );
+
+    const syncPointL1BlockHash =
+      syncPointL1BlockNumber === finalizedL1BlockNumber
+        ? messagesFinalizedL1Block!.l1BlockHash
+        : await this.getL1BlockHash(syncPointL1BlockNumber);
+
     const messagesSyncPoint = { l1BlockNumber: syncPointL1BlockNumber, l1BlockHash: syncPointL1BlockHash };
     await this.stores.messages.setMessageSyncState(messagesSyncPoint, remoteTreeInProgress);
-    this.log.verbose(`Updated messages syncpoint to L1 block ${syncPointL1BlockNumber}`, {
+    this.log.verbose(`Updated messages syncpoint to L1 block ${messagesSyncPoint.l1BlockNumber}`, {
       ...messagesSyncPoint,
       remoteTreeInProgress,
     });

--- a/yarn-project/archiver/src/store/message_store.ts
+++ b/yarn-project/archiver/src/store/message_store.ts
@@ -43,6 +43,8 @@ export class MessageStore {
   #totalMessageCount: AztecAsyncSingleton<bigint>;
   /** Stores the checkpoint number whose message tree is currently being filled on L1. */
   #inboxTreeInProgress: AztecAsyncSingleton<bigint>;
+  /** Stores the L1 finalized block as of the last successful message sync. */
+  #messagesFinalizedL1Block: AztecAsyncSingleton<Buffer>;
 
   #log = createLogger('archiver:message_store');
 
@@ -52,6 +54,7 @@ export class MessageStore {
     this.#lastSynchedL1Block = db.openSingleton('archiver_last_l1_block_id');
     this.#totalMessageCount = db.openSingleton('archiver_l1_to_l2_message_count');
     this.#inboxTreeInProgress = db.openSingleton('archiver_inbox_tree_in_progress');
+    this.#messagesFinalizedL1Block = db.openSingleton('archiver_messages_finalized_l1_block');
   }
 
   public async getTotalL1ToL2MessageCount(): Promise<bigint> {
@@ -73,6 +76,26 @@ export class MessageStore {
   public async setSynchedL1Block(l1Block: L1BlockId): Promise<void> {
     const buffer = serializeToBuffer([l1Block.l1BlockNumber, l1Block.l1BlockHash]);
     await this.#lastSynchedL1Block.set(buffer);
+  }
+
+  /** Gets the L1 finalized block as of the last successful message sync. */
+  public async getMessagesFinalizedL1Block(): Promise<L1BlockId | undefined> {
+    const buffer = await this.#messagesFinalizedL1Block.getAsync();
+    if (!buffer) {
+      return undefined;
+    }
+    const reader = BufferReader.asReader(buffer);
+    return { l1BlockNumber: reader.readUInt256(), l1BlockHash: Buffer32.fromBuffer(reader.readBytes(Buffer32.SIZE)) };
+  }
+
+  /** Monotonically advances the persisted L1 finalized block for message sync. Never regresses. */
+  private async maybeAdvanceFinalizedL1Block(l1Block: L1BlockId): Promise<void> {
+    const existing = await this.getMessagesFinalizedL1Block();
+    if (existing && l1Block.l1BlockNumber <= existing.l1BlockNumber) {
+      return;
+    }
+    const buffer = serializeToBuffer([l1Block.l1BlockNumber, l1Block.l1BlockHash]);
+    await this.#messagesFinalizedL1Block.set(buffer);
   }
 
   /**
@@ -185,14 +208,24 @@ export class MessageStore {
     return this.#inboxTreeInProgress.getAsync();
   }
 
-  /** Atomically updates the message sync state: the L1 sync point and the inbox tree-in-progress marker. */
-  public setMessageSyncState(l1Block: L1BlockId, treeInProgress: bigint | undefined): Promise<void> {
+  /**
+   * Atomically updates the message sync state: the L1 sync point, the inbox tree-in-progress marker, and
+   * (optionally) the L1 finalized block as of this sync. The finalized block is advanced monotonically.
+   */
+  public setMessageSyncState(
+    l1Block: L1BlockId,
+    treeInProgress: bigint | undefined,
+    finalizedL1Block?: L1BlockId,
+  ): Promise<void> {
     return this.db.transactionAsync(async () => {
       await this.setSynchedL1Block(l1Block);
       if (treeInProgress !== undefined) {
         await this.#inboxTreeInProgress.set(treeInProgress);
       } else {
         await this.#inboxTreeInProgress.delete();
+      }
+      if (finalizedL1Block !== undefined) {
+        await this.maybeAdvanceFinalizedL1Block(finalizedL1Block);
       }
     });
   }


### PR DESCRIPTION
## Motivation

`L1Synchronizer.rollbackL1ToL2Messages` walks local L1->L2 messages in reverse on any rolling-hash divergence, issuing an `eth_getLogs` round-trip per message until it finds a common point with L1. The walk has no floor, so a misbehaving RPC or a stale node can pay an unbounded penalty for a trivial reorg.

A finalized L1 block gives a free floor: any local message stored at an L1 block at or below finalized cannot have been reorged out and must already match L1. 

This also prevents issues when dealing with an RPC node that prunes old logs, like Reth. Note that a Reth node that prunes old logs won't be able to sync (unless it relies on a recent snapshot), but at least won't be hit by these rollbacks in the event of an L1 reorg.

## Approach

Persist the finalized L1 block as part of the message-sync state on every successful sync, monotonically. In the rollback loop, after the existing rolling-hash equality check and before the per-message log query, accept any local message at or below the persisted finalized block as the common point and break.

## Changes

- **archiver/store/message_store**: New `messagesFinalizedL1Block` singleton with monotonic getter/setter wrapped in a transaction.
- **archiver/store/kv_archiver_store**: Passthrough delegators for the new pointer.
- **archiver/modules/l1_synchronizer**: Single finalized-block fetch threaded into `handleL1ToL2Messages` and `updateFinalizedCheckpoint`; both message-sync success paths persist the pointer; rollback path consults it as a stop condition.
- **archiver (tests)**: Three new cases in `archiver-sync.test.ts` covering short-circuit at finalized, fallback when finalized is unavailable, and monotonic persistence.