### PR TITLE
docs: clarify why verify_bn254_crs_integrity has a single call site

### DIFF
--- a/barretenberg/cpp/src/barretenberg/srs/factories/get_bn254_crs.cpp
+++ b/barretenberg/cpp/src/barretenberg/srs/factories/get_bn254_crs.cpp
@@ -69,6 +69,18 @@ size_t round_up_to_chunk_boundary(size_t num_points)
  * @details Verifies all complete chunks in parallel across available cores with early-exit
  * on first mismatch. Also verifies the partial last chunk (if present) so every downloaded byte
  * is covered. Uses std::span to avoid per-chunk memory allocation.
+ *
+ * @note Intentionally invoked from a single site — `download_bn254_g1_data` below — and not from
+ * the cache-hit, MemBn254Crs ctor, or `bbapi::SrsInitSrs` paths. This is the only path that
+ * (a) fetches CRS bytes over plain HTTP, and (b) does not consume bytes that have already been
+ * hash-verified upstream:
+ *   - the cache-hit paths (uncompressed and compressed) read bytes that were verified by this
+ *     function on a previous run before being cached;
+ *   - `bbapi::SrsInitSrs` (bb.js / WASM) receives bytes that bb.js itself fetched over HTTPS,
+ *     where TLS provides transport integrity;
+ *   - `MemBn254Crs` is constructed in-process from already-validated points.
+ * Therefore re-anchoring at every additional call site is redundant; this anchor exists
+ * specifically to compensate for the plain-HTTP fetch on the fresh-download path.
  */
 void verify_bn254_crs_integrity(const std::vector<uint8_t>& data)
 {


### PR DESCRIPTION
## Summary

Resolves [AztecProtocol/barretenberg#2910](https://github.com/AztecProtocol/barretenberg-claude/issues/2910) (audit finding: SHA-256 chunk-hash anchor only invoked on the fresh-download path).

The audit observation is factually correct — `verify_bn254_crs_integrity` runs only inside `download_bn254_g1_data`, and the cache-hit, `MemBn254Crs` ctor, and `bbapi::SrsInitSrs` paths skip it. But the design is intentional, not a gap. This PR documents the rationale inline so a future reader (or auditor) can verify the trust model from the source.

## The trust model

The fresh HTTP download is the only ingress that lacks transport integrity AND does not consume already-verified bytes. Other paths get integrity from elsewhere:

| Path | Why no chunk hash here is fine |
|---|---|
| Uncompressed cache hit | Bytes were verified by `verify_bn254_crs_integrity` on a prior run before being cached locally |
| Compressed cache hit | Same — the compressed file itself was hashed at download time |
| `bbapi::SrsInitSrs` (WASM / bb.js) | bb.js fetches the SRS over **HTTPS**, where TLS provides transport integrity |
| `MemBn254Crs` ctor | Constructed in-process from already-validated points |

Re-running the chunk-hash check at every call site would be redundant. The single anchor exists specifically to compensate for the plain-HTTP fetch on the C++ fresh-download path.

Per @ludamad in #2910:
> this is fine and intended.
> The bbjs code path uses https
> Hmm. I guess we need it open for *some* resolution, but the resolution is to comment this code.

## Test plan
- [x] No behavioral change — comment-only.
- [x] Builds clean (no test runs needed; nothing executable changed).