### PR TITLE
chore: low-hanging chonk prover fixes from profiling

### DIFF
--- a/barretenberg/cpp/src/barretenberg/chonk/chonk.cpp
+++ b/barretenberg/cpp/src/barretenberg/chonk/chonk.cpp
@@ -457,10 +457,20 @@ void Chonk::accumulate_hiding_kernel(ClientCircuit& circuit, const std::shared_p
     for (auto& block : circuit.blocks.get()) {
         block.free_data();
     }
-    hiding_vk = std::make_shared<MegaZKVerificationKey>(hiding_prover_inst->get_precomputed());
+    // MegaZKFlavor inherits VerificationKey from MegaFlavor unchanged, so MegaZKVerificationKey
+    // and MegaVerificationKey are the same type. Reuse the caller-supplied precomputed VK when
+    // present to skip the 31 sequential commitments in the NativeVerificationKey_ ctor.
+    static_assert(
+        std::is_same_v<MegaVerificationKey, MegaZKVerificationKey>,
+        "hiding-kernel precomputed VK reuse relies on MegaZKFlavor inheriting VerificationKey from MegaFlavor");
+    if (precomputed_vk) {
+        hiding_vk = precomputed_vk;
+    } else {
+        hiding_vk = std::make_shared<MegaZKVerificationKey>(hiding_prover_inst->get_precomputed());
+    }
 
     // Push VK to queue so get_hiding_kernel_vk_and_hash() can find it.
-    VerifierInputs queue_entry{ {}, precomputed_vk, QUEUE_TYPE::MEGA, /*is_kernel=*/true };
+    VerifierInputs queue_entry{ {}, hiding_vk, QUEUE_TYPE::MEGA, /*is_kernel=*/true };
     verification_queue.push_back(queue_entry);
     num_circuits_accumulated++;
 }

--- a/barretenberg/cpp/src/barretenberg/honk/composer/permutation_lib.hpp
+++ b/barretenberg/cpp/src/barretenberg/honk/composer/permutation_lib.hpp
@@ -134,44 +134,47 @@ PermutationMapping<Flavor::NUM_WIRES> compute_permutation_mapping(
     // Represents the idx of a variable in circuit_constructor.variables
     std::span<const uint32_t> real_variable_tags = circuit_constructor.real_variable_tags;
 
-    // Go through each cycle
-    for (size_t cycle_idx = 0; cycle_idx < wire_copy_cycles.size(); ++cycle_idx) {
-        // We go through the cycle and fill-out/modify `mapping`. Following the generalized permutation algorithm, we
-        // take separate care of first/last node handling.
-        const CyclicPermutation& cycle = wire_copy_cycles[cycle_idx];
-        const auto cycle_size = cycle.size();
-        if (cycle_size == 0) {
-            continue;
-        }
+    // Cycles are disjoint by construction of the generalized permutation argument: every (gate_idx, wire_idx) position
+    // belongs to exactly one variable, hence to exactly one cycle. Per-(col, row) writes from different cycles never
+    // alias, so parallelising across cycle_idx is safe without per-thread staging or merge.
+    parallel_for_heuristic(
+        wire_copy_cycles.size(),
+        [&](size_t cycle_idx) {
+            const CyclicPermutation& cycle = wire_copy_cycles[cycle_idx];
+            const auto cycle_size = cycle.size();
+            if (cycle_size == 0) {
+                return;
+            }
 
-        const cycle_node& first_node = cycle[0];
-        const cycle_node& last_node = cycle[cycle_size - 1];
+            const cycle_node& first_node = cycle[0];
+            const cycle_node& last_node = cycle[cycle_size - 1];
 
-        const auto first_row = static_cast<ptrdiff_t>(first_node.gate_idx);
-        const auto first_col = first_node.wire_idx;
-        const auto last_row = static_cast<ptrdiff_t>(last_node.gate_idx);
-        const auto last_col = last_node.wire_idx;
+            const auto first_row = static_cast<ptrdiff_t>(first_node.gate_idx);
+            const auto first_col = first_node.wire_idx;
+            const auto last_row = static_cast<ptrdiff_t>(last_node.gate_idx);
+            const auto last_col = last_node.wire_idx;
 
-        // First node: id gets tagged with the cycle's variable tag
-        mapping.ids[first_col].is_tag[first_row] = true;
-        mapping.ids[first_col].row_idx[first_row] = real_variable_tags[cycle_idx];
+            // First node: id gets tagged with the cycle's variable tag
+            mapping.ids[first_col].is_tag[first_row] = true;
+            mapping.ids[first_col].row_idx[first_row] = real_variable_tags[cycle_idx];
 
-        // Last node: sigma gets tagged and points to tau(tag) instead of wrapping to first node
-        mapping.sigmas[last_col].is_tag[last_row] = true;
-        mapping.sigmas[last_col].row_idx[last_row] = circuit_constructor.tau().at(real_variable_tags[cycle_idx]);
+            // Last node: sigma gets tagged and points to tau(tag) instead of wrapping to first node
+            mapping.sigmas[last_col].is_tag[last_row] = true;
+            mapping.sigmas[last_col].row_idx[last_row] = circuit_constructor.tau().at(real_variable_tags[cycle_idx]);
 
-        // All nodes except the last: sigma points to the next node in the cycle
-        for (size_t node_idx = 0; node_idx + 1 < cycle_size; ++node_idx) {
-            const cycle_node& current_node = cycle[node_idx];
-            const cycle_node& next_node = cycle[node_idx + 1];
+            // All nodes except the last: sigma points to the next node in the cycle
+            for (size_t node_idx = 0; node_idx + 1 < cycle_size; ++node_idx) {
+                const cycle_node& current_node = cycle[node_idx];
+                const cycle_node& next_node = cycle[node_idx + 1];
 
-            const auto current_row = static_cast<ptrdiff_t>(current_node.gate_idx);
-            const auto current_col = current_node.wire_idx;
-            // Point current node to next node.
-            mapping.sigmas[current_col].row_idx[current_row] = next_node.gate_idx;
-            mapping.sigmas[current_col].col_idx[current_row] = static_cast<uint8_t>(next_node.wire_idx);
-        }
-    }
+                const auto current_row = static_cast<ptrdiff_t>(current_node.gate_idx);
+                const auto current_col = current_node.wire_idx;
+                // Point current node to next node.
+                mapping.sigmas[current_col].row_idx[current_row] = next_node.gate_idx;
+                mapping.sigmas[current_col].col_idx[current_row] = static_cast<uint8_t>(next_node.wire_idx);
+            }
+        },
+        /*heuristic_cost=*/thread_heuristics::FF_COPY_COST * 8);
 
     // Add information about public inputs so that the cycles can be altered later; See the construction of the
     // permutation polynomials for details. This _only_ effects sigma_0, the 0th sigma polynomial, as the structure of

--- a/barretenberg/cpp/src/barretenberg/trace_to_polynomials/trace_to_polynomials.cpp
+++ b/barretenberg/cpp/src/barretenberg/trace_to_polynomials/trace_to_polynomials.cpp
@@ -6,6 +6,7 @@
 
 #include "trace_to_polynomials.hpp"
 #include "barretenberg/common/assert.hpp"
+#include "barretenberg/common/thread.hpp"
 #include "barretenberg/constants.hpp"
 #include "barretenberg/ext/starknet/flavor/ultra_starknet_flavor.hpp"
 #include "barretenberg/ext/starknet/flavor/ultra_starknet_zk_flavor.hpp"
@@ -52,45 +53,68 @@ std::vector<CyclicPermutation> TraceToPolynomials<Flavor>::populate_wires_and_se
     RefArray<Polynomial, NUM_WIRES> wires = polynomials.get_wires();
     auto selectors = polynomials.get_selectors();
 
-    // For each block in the trace, populate wire polys, copy cycles and selector polys
-    for (auto& block : builder.blocks.get()) {
-        const uint32_t offset = block.trace_offset();
-        const uint32_t block_size = static_cast<uint32_t>(block.size());
+    // Two-phase parallelisation. Phase 1 fans out over blocks to populate wires and emit copy-cycle
+    // nodes; phase 2 fans out over a flattened (block, selector) task list to fill selectors.
+    auto blocks_array = builder.blocks.get();
+    const size_t num_blocks = blocks_array.size();
 
-        // Update wire polynomials and copy cycles
-        // NB: The order of row/column loops is arbitrary but needs to be row/column to match old copy_cycle code
-        {
-            BB_BENCH_NAME("populating wires and copy_cycles");
+    // Phase 1: per-block parallel pass over wires and emit copy-cycle nodes.
+    std::vector<std::vector<std::pair<uint32_t, cycle_node>>> per_block_nodes(num_blocks);
+    {
+        BB_BENCH_NAME("populate_wires_and_emit_cycles");
+        parallel_for(num_blocks, [&](size_t block_idx) {
+            auto& block = blocks_array[block_idx];
+            const uint32_t offset = block.trace_offset();
+            const uint32_t block_size = static_cast<uint32_t>(block.size());
+            auto& local_nodes = per_block_nodes[block_idx];
+            local_nodes.reserve(static_cast<size_t>(block_size) * NUM_WIRES);
 
+            // NB: The order of row/column loops is arbitrary but needs to be row/column to match old copy_cycle code.
             for (uint32_t block_row_idx = 0; block_row_idx < block_size; ++block_row_idx) {
                 for (uint32_t wire_idx = 0; wire_idx < NUM_WIRES; ++wire_idx) {
                     uint32_t var_idx = block.wires[wire_idx][block_row_idx]; // an index into the variables array
-                    // Use .at() for bounds checking - fuzzer found OOB with malformed ACIR
+                    // Use .at() so out-of-range var_idx is caught instead of producing a silent OOB read.
                     uint32_t real_var_idx = builder.real_variable_index.at(var_idx);
                     uint32_t trace_row_idx = block_row_idx + offset;
                     // Insert the real witness values from this block into the wire polys at the correct offset
                     wires[wire_idx].at(trace_row_idx) = builder.get_variable(var_idx);
-                    // Add the address of the witness value to its corresponding copy cycle
-                    // Note that the copy_cycles are indexed by real_variable_indices.
-                    copy_cycles.at(real_var_idx).emplace_back(cycle_node{ wire_idx, trace_row_idx });
+                    local_nodes.emplace_back(real_var_idx, cycle_node{ wire_idx, trace_row_idx });
                 }
             }
-        }
+        });
+    }
 
-        {
-            BB_BENCH_NAME("populating selectors");
-            RefVector<Selector<FF>> block_selectors = block.get_selectors();
-            // Insert the selector values for this block into the selector polynomials at the correct offset
-            // TODO(https://github.com/AztecProtocol/barretenberg/issues/398): implicit arithmetization/flavor
-            // consistency
-            for (size_t selector_idx = 0; selector_idx < block_selectors.size(); selector_idx++) {
-                auto& selector = block_selectors[selector_idx];
-                for (size_t row_idx = 0; row_idx < block_size; ++row_idx) {
-                    size_t trace_row_idx = row_idx + offset;
-                    selectors[selector_idx].set_if_valid_index(trace_row_idx, selector[row_idx]);
-                }
+    // Phase 1.5: Serial concat in block order to preserve cycle-node ordering within each variable's cycle list.
+    {
+        BB_BENCH_NAME("fill_copy_cycles");
+        for (const auto& block_nodes : per_block_nodes) {
+            for (const auto& [real_var_idx, node] : block_nodes) {
+                copy_cycles.at(real_var_idx).emplace_back(node);
             }
         }
+    }
+
+    // Phase 2: parallel selector filling across a flattened (block_idx, selector_idx) task list.
+    {
+        BB_BENCH_NAME("populate_selectors");
+        std::vector<std::pair<size_t, size_t>> selector_tasks;
+        for (size_t block_idx = 0; block_idx < num_blocks; ++block_idx) {
+            const size_t num_selectors = blocks_array[block_idx].get_selectors().size();
+            for (size_t selector_idx = 0; selector_idx < num_selectors; ++selector_idx) {
+                selector_tasks.emplace_back(block_idx, selector_idx);
+            }
+        }
+        parallel_for(selector_tasks.size(), [&](size_t task_idx) {
+            const auto [block_idx, selector_idx] = selector_tasks[task_idx];
+            auto& block = blocks_array[block_idx];
+            const size_t offset = block.trace_offset();
+            const size_t block_size = block.size();
+            RefVector<Selector<FF>> block_selectors = block.get_selectors();
+            auto& selector = block_selectors[selector_idx];
+            for (size_t row_idx = 0; row_idx < block_size; ++row_idx) {
+                selectors[selector_idx].set_if_valid_index(row_idx + offset, selector[row_idx]);
+            }
+        });
     }
 
     return copy_cycles;


### PR DESCRIPTION
A handful of profiling-driven trims for Chonk client-IVC. Each commit targets one zone, no behaviour change.

## Per-commit gains

Each row is the commit applied **alone** on top of `merge-train/barretenberg`, measured on `ecdsar1+transfer_1_recursions+sponsored_fpc`, 16-thread remote bench, single sample per build.

| Commit | Target zone | Native baseline | Native Δ | WASM baseline | WASM Δ |
|---|---|---:|---:|---:|---:|
| W2: reuse precomputed VK in `Chonk::accumulate_hiding_kernel` | hiding kernel | 121 ms | **−104 ms** | 343 ms | **−301 ms** |
| W3: parallelise `construct_trace_data` over trace blocks¹ | construct_trace_data | 135 ms | **−34 ms** | 373 ms | **−116 ms** |
| W6: parallelise `compute_permutation_mapping` cycle loop | compute_permutation_mapping | 36 ms | **−11 ms** | 61 ms | **−23 ms** |

¹ W3 splits the work into two parallel phases: Phase 1 fans out per-block (wires + copy-cycle node emission), Phase 2 fans out over a flattened `(block, selector)` task list so the threadpool can load-balance selector filling across blocks regardless of per-block size skew. The single-pass-per-block structure that the original W3 used was WASM-only; the flattened selector phase is what unlocks the native gain.

² End-to-end numbers below were measured with the original W4 commit included; subtract W4's per-commit Δ (−17 ms native, −71 ms WASM) for the W4-less stack, or roll #22893 in for the up-to-date total.

## End-to-end (full stack on top of baseline)

| Zone | Native baseline | Native Δ | WASM baseline | WASM Δ |
|---|---:|---:|---:|---:|
| `Chonk::accumulate` (×11 per proof) | 3292 ms | **−103 ms** (3.1%)² | 9172 ms | **−532 ms** (5.8%)² |
| `ChonkAPI::prove` (full E2E) | 6236 ms | **−121 ms** (2%)² | 16728 ms | **−532 ms** (3.2%)² |

A fifth change (fold ECCVM masking poly into wire batch) was prototyped but didn't show measurable impact under the new "masking at top of trace" model, so it was dropped.

The original W4 (fuse N `add_scaled` in `HypernovaFoldingProver::batch_polynomials`) has been split out into #22893, where it's extracted into a shared `Polynomial::add_scaled_batch` helper and applied to the PCS poly batcher and AVM prover.

## Test plan
- [x] `chonk_tests` (33/33), `eccvm_tests` (44/44), `ultra_honk_tests` (283/283), `hypernova_tests` (9/9) green locally
- [x] Profiled native + WASM with `/profile-chonk` on remote bench machine
