### PR TITLE
chore: numeric audit response

### DIFF
--- a/barretenberg/cpp/src/barretenberg/numeric/random/engine.cpp
+++ b/barretenberg/cpp/src/barretenberg/numeric/random/engine.cpp
@@ -6,7 +6,9 @@
 
 #include "engine.hpp"
 #include "barretenberg/common/assert.hpp"
+#include "barretenberg/common/throw_or_abort.hpp"
 #include <array>
+#include <cerrno>
 #include <cstring>
 #include <functional>
 #include <memory>
@@ -82,6 +84,9 @@ template <size_t size_in_unsigned_ints> std::array<unsigned int, size_in_unsigne
         }
         size_t bytes_left = RANDOM_BUFFER_SIZE;
         uint8_t* current_offset = random_buffer_wrapper.buffer.get();
+        // Bound EINTR retries so a pathological signal storm cannot mask a genuine fault.
+        constexpr int MAX_EINTR_RETRIES = 16;
+        int eintr_retries = 0;
         // Sample until we fill the buffer
         while (bytes_left != 0) {
 #if defined(__wasm__) || defined(__APPLE__)
@@ -106,11 +111,20 @@ template <size_t size_in_unsigned_ints> std::array<unsigned int, size_in_unsigne
             // Sample from urandom on native
             auto read_bytes = getrandom(current_offset, bytes_left, 0);
 #endif
-            // If we read something, update the leftover
-            if (read_bytes != -1) {
+            if (read_bytes > 0) {
                 current_offset += read_bytes;
                 bytes_left -= static_cast<size_t>(read_bytes);
+                continue;
             }
+            // read_bytes <= 0: failure or EOF. On platforms that report EINTR via errno, retry a
+            // bounded number of times; any other failure (including read_bytes == 0, e.g. a
+            // sealed/stubbed urandom returning EOF) is fatal.
+#if !defined(_WIN32)
+            if (read_bytes == -1 && errno == EINTR && eintr_retries++ < MAX_EINTR_RETRIES) {
+                continue;
+            }
+#endif
+            throw_or_abort("CSPRNG read failed: cannot retrieve entropy from system source");
         }
         random_buffer_wrapper.offset = 0;
     }

--- a/barretenberg/cpp/src/barretenberg/numeric/uint128/uint128.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/numeric/uint128/uint128.test.cpp
@@ -78,6 +78,9 @@ TEST(uint128, DivAndMod)
         b.data[3] = (i > 0) ? 0 : b.data[3];
         b.data[2] = (i > 1) ? 0 : b.data[2];
         b.data[1] = (i > 2) ? 0 : b.data[1];
+        if (b == 0) {
+            b = 1;
+        }
         uint128_t q = a / b;
         uint128_t r = a % b;
 
@@ -89,17 +92,9 @@ TEST(uint128, DivAndMod)
     }
 
     uint128_t a = engine.get_random_uint128();
-    uint128_t b = 0;
-
+    uint128_t b = a;
     uint128_t q = a / b;
     uint128_t r = a % b;
-
-    EXPECT_EQ(q, uint128_t(0));
-    EXPECT_EQ(r, uint128_t(0));
-
-    b = a;
-    q = a / b;
-    r = a % b;
 
     EXPECT_EQ(q, uint128_t(1));
     EXPECT_EQ(r, uint128_t(0));

--- a/barretenberg/cpp/src/barretenberg/numeric/uint128/uint128_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/numeric/uint128/uint128_impl.hpp
@@ -167,7 +167,9 @@ constexpr std::pair<uint128_t, uint128_t> uint128_t::mul_extended(const uint128_
  */
 constexpr uint128_t uint128_t::slice(const uint64_t start, const uint64_t end) const
 {
-    BB_ASSERT_DEBUG(start <= end);
+    // Plain assert is used here because BB_ASSERT_DEBUG defines a std::ostringstream, which is
+    // a non-literal type and therefore disallowed in the body of a constexpr function before C++23.
+    assert(start <= end);
     const uint64_t range = end - start;
     const uint128_t mask = (range == 128) ? -uint128_t(1) : (uint128_t(1) << range) - 1;
     return ((*this) >> start) & mask;

--- a/barretenberg/cpp/src/barretenberg/numeric/uint128/uint128_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/numeric/uint128/uint128_impl.hpp
@@ -163,6 +163,7 @@ constexpr std::pair<uint128_t, uint128_t> uint128_t::mul_extended(const uint128_
  */
 constexpr uint128_t uint128_t::slice(const uint64_t start, const uint64_t end) const
 {
+    BB_ASSERT_DEBUG(start <= end);
     const uint64_t range = end - start;
     const uint128_t mask = (range == 128) ? -uint128_t(1) : (uint128_t(1) << range) - 1;
     return ((*this) >> start) & mask;

--- a/barretenberg/cpp/src/barretenberg/numeric/uint128/uint128_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/numeric/uint128/uint128_impl.hpp
@@ -9,6 +9,7 @@
 #include "../bitop/get_msb.hpp"
 #include "./uint128.hpp"
 #include "barretenberg/common/assert.hpp"
+#include "barretenberg/common/throw_or_abort.hpp"
 namespace bb::numeric {
 
 constexpr std::pair<uint32_t, uint32_t> uint128_t::mul_wide(const uint32_t a, const uint32_t b)
@@ -83,7 +84,10 @@ constexpr uint32_t uint128_t::mac_discard_hi(const uint32_t a,
 
 constexpr std::pair<uint128_t, uint128_t> uint128_t::divmod(const uint128_t& b) const
 {
-    if (*this == 0 || b == 0) {
+    if (b == 0) {
+        throw_or_abort("uint128_t::divmod: divisor must be nonzero");
+    }
+    if (*this == 0) {
         return { 0, 0 };
     }
     if (b == 1) {

--- a/barretenberg/cpp/src/barretenberg/numeric/uint256/uint256.hpp
+++ b/barretenberg/cpp/src/barretenberg/numeric/uint256/uint256.hpp
@@ -63,7 +63,7 @@ class alignas(32) uint256_t {
     {}
     constexpr uint256_t(uint256_t&& other) noexcept = default;
 
-    explicit constexpr uint256_t(const std::string& input) noexcept
+    explicit constexpr uint256_t(const std::string& input)
     {
         /* Quick and dirty conversion from a single character to its hex equivelent */
         constexpr auto HexCharToInt = [](uint8_t Input) {

--- a/barretenberg/cpp/src/barretenberg/numeric/uint256/uint256.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/numeric/uint256/uint256.test.cpp
@@ -97,6 +97,9 @@ TEST(uint256, DivAndMod)
         b.data[3] = (i > 0) ? 0 : b.data[3];
         b.data[2] = (i > 1) ? 0 : b.data[2];
         b.data[1] = (i > 2) ? 0 : b.data[1];
+        if (b == 0) {
+            b = 1;
+        }
         uint256_t q = a / b;
         uint256_t r = a % b;
 
@@ -108,17 +111,9 @@ TEST(uint256, DivAndMod)
     }
 
     uint256_t a = engine.get_random_uint256();
-    uint256_t b = 0;
-
+    uint256_t b = a;
     uint256_t q = a / b;
     uint256_t r = a % b;
-
-    EXPECT_EQ(q, uint256_t(0));
-    EXPECT_EQ(r, uint256_t(0));
-
-    b = a;
-    q = a / b;
-    r = a % b;
 
     EXPECT_EQ(q, uint256_t(1));
     EXPECT_EQ(r, uint256_t(0));

--- a/barretenberg/cpp/src/barretenberg/numeric/uint256/uint256_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/numeric/uint256/uint256_impl.hpp
@@ -134,7 +134,10 @@ constexpr std::array<uint64_t, WASM_NUM_LIMBS> uint256_t::wasm_convert(const uin
 #endif
 constexpr std::pair<uint256_t, uint256_t> uint256_t::divmod(const uint256_t& b) const
 {
-    if (*this == 0 || b == 0) {
+    if (b == 0) {
+        throw_or_abort("uint256_t::divmod: divisor must be nonzero");
+    }
+    if (*this == 0) {
         return { 0, 0 };
     }
     if (b == 1) {
@@ -189,7 +192,10 @@ constexpr std::pair<uint256_t, uint256_t> uint256_t::divmod(const uint256_t& b) 
  */
 constexpr std::pair<uint256_t, uint64_t> uint256_t::divmod(uint64_t b) const
 {
-    if (*this == 0 || b == 0) {
+    if (b == 0) {
+        throw_or_abort("uint256_t::divmod: divisor must be nonzero");
+    }
+    if (*this == 0) {
         return { 0, 0 };
     }
     if (b == 1) {

--- a/barretenberg/cpp/src/barretenberg/numeric/uint256/uint256_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/numeric/uint256/uint256_impl.hpp
@@ -329,7 +329,7 @@ constexpr std::pair<uint256_t, uint256_t> uint256_t::mul_extended(const uint256_
  */
 constexpr uint256_t uint256_t::slice(const uint64_t start, const uint64_t end) const
 {
-    assert(start < end);
+    BB_ASSERT_DEBUG(start <= end);
     const uint64_t range = end - start;
     const uint256_t mask = (range == 256) ? -uint256_t(1) : (uint256_t(1) << range) - 1;
     return ((*this) >> start) & mask;

--- a/barretenberg/cpp/src/barretenberg/numeric/uint256/uint256_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/numeric/uint256/uint256_impl.hpp
@@ -335,7 +335,9 @@ constexpr std::pair<uint256_t, uint256_t> uint256_t::mul_extended(const uint256_
  */
 constexpr uint256_t uint256_t::slice(const uint64_t start, const uint64_t end) const
 {
-    BB_ASSERT_DEBUG(start <= end);
+    // Plain assert is used here because BB_ASSERT_DEBUG defines a std::ostringstream, which is
+    // a non-literal type and therefore disallowed in the body of a constexpr function before C++23.
+    assert(start <= end);
     const uint64_t range = end - start;
     const uint256_t mask = (range == 256) ? -uint256_t(1) : (uint256_t(1) << range) - 1;
     return ((*this) >> start) & mask;

--- a/barretenberg/cpp/src/barretenberg/numeric/uintx/uintx.hpp
+++ b/barretenberg/cpp/src/barretenberg/numeric/uintx/uintx.hpp
@@ -80,7 +80,9 @@ template <class base_uint> class uintx {
      */
     constexpr uintx slice(const uint64_t start, const uint64_t end) const
     {
-        BB_ASSERT_DEBUG(start <= end);
+        // Plain assert is used here because BB_ASSERT_DEBUG defines a std::ostringstream, which is
+        // a non-literal type and therefore disallowed in the body of a constexpr function before C++23.
+        assert(start <= end);
         const uint64_t range = end - start;
         const uintx mask = (uintx(1) << range) - 1;
         return ((*this) >> start) & mask;

--- a/barretenberg/cpp/src/barretenberg/numeric/uintx/uintx.hpp
+++ b/barretenberg/cpp/src/barretenberg/numeric/uintx/uintx.hpp
@@ -80,6 +80,7 @@ template <class base_uint> class uintx {
      */
     constexpr uintx slice(const uint64_t start, const uint64_t end) const
     {
+        BB_ASSERT_DEBUG(start <= end);
         const uint64_t range = end - start;
         const uintx mask = (uintx(1) << range) - 1;
         return ((*this) >> start) & mask;

--- a/barretenberg/cpp/src/barretenberg/numeric/uintx/uintx_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/numeric/uintx/uintx_impl.hpp
@@ -63,7 +63,8 @@ std::pair<uintx<base_uint>, uintx<base_uint>> uintx<base_uint>::divmod_base(cons
 /**
  * Computes invmod. Only for internal usage within the class.
  * This is an insecure version of the algorithm that doesn't take into account the 0 case and cases when modulus is
- *close to the top margin.
+ * close to the top margin. Requires *this and modulus to be coprime; the postcondition asserts this via the
+ * extended-Euclidean gcd that lives in r1 after loop exit.
  *
  * @param modulus The modulus of the ring
  *
@@ -86,6 +87,7 @@ template <class base_uint> uintx<base_uint> uintx<base_uint>::unsafe_invmod(cons
         r1 = r2;
         r2 = temp_r1 - q * r2;
     }
+    BB_ASSERT(r1 == uintx(1));
 
     if (t1 > modulus) {
         return modulus + t1;

--- a/barretenberg/cpp/src/barretenberg/numeric/uintx/uintx_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/numeric/uintx/uintx_impl.hpp
@@ -63,8 +63,8 @@ std::pair<uintx<base_uint>, uintx<base_uint>> uintx<base_uint>::divmod_base(cons
 /**
  * Computes invmod. Only for internal usage within the class.
  * This is an insecure version of the algorithm that doesn't take into account the 0 case and cases when modulus is
- * close to the top margin. Requires *this and modulus to be coprime; the postcondition asserts this via the
- * extended-Euclidean gcd that lives in r1 after loop exit.
+ * close to the top margin. The result is only meaningful when *this and modulus are coprime; non-coprime inputs
+ * return an unspecified value (callers must guarantee coprimality or guard against the result being used).
  *
  * @param modulus The modulus of the ring
  *
@@ -87,7 +87,6 @@ template <class base_uint> uintx<base_uint> uintx<base_uint>::unsafe_invmod(cons
         r1 = r2;
         r2 = temp_r1 - q * r2;
     }
-    BB_ASSERT(r1 == uintx(1));
 
     if (t1 > modulus) {
         return modulus + t1;

--- a/barretenberg/cpp/src/barretenberg/numeric/uintx/uintx_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/numeric/uintx/uintx_impl.hpp
@@ -106,9 +106,7 @@ template <class base_uint> uintx<base_uint> uintx<base_uint>::unsafe_invmod(cons
 template <class base_uint> uintx<base_uint> uintx<base_uint>::invmod(const uintx& modulus) const
 {
     BB_ASSERT((*this) != 0);
-    if (modulus == 0) {
-        return 0;
-    }
+    BB_ASSERT(modulus != 0);
     if (modulus.get_msb() >= (2 * base_uint::length() - 1)) {
         uintx<uintx<base_uint>> a_expanded(*this);
         uintx<uintx<base_uint>> modulus_expanded(modulus);


### PR DESCRIPTION
Addresses external audit [findings](https://cantina.xyz/code/53bf9e53-db08-46a1-88d7-63dc995c5102/findings) for numeric module (all low or informational).