### PR TITLE
claude poc: configurable per-block gas fees in TXE

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
@@ -1,5 +1,5 @@
 use crate::protocol::{
-    abis::{function_selector::FunctionSelector, gas_settings::GasSettings},
+    abis::{function_selector::FunctionSelector, gas_fees::GasFees, gas_settings::GasSettings},
     address::AztecAddress,
     traits::{Deserialize, FromField, Packable, Serialize},
 };
@@ -449,6 +449,36 @@ impl TestEnvironment {
     /// `set_next_block_timestamp`).
     pub unconstrained fn set_gas_settings(_self: Self, gas_settings: GasSettings) {
         txe_oracles::set_gas_settings(gas_settings);
+    }
+
+    /// Sets the per-block `gas_fees` (the "actual" L2/DA gas price) used by all subsequent TXE
+    /// blocks, including blocks mined by `mine_block`/`mine_block_at` and blocks produced by
+    /// `call_private` / `call_public`. The setting persists until overwritten - this mirrors
+    /// `set_next_block_timestamp` (both are properties of the next block, chosen by the sequencer
+    /// in production).
+    ///
+    /// The default is zero. Tests that exercise public-side fee logic - e.g. an FPC computing
+    /// `gas_used * min_fee_per_l2_gas` in its `pay_fee` teardown - should call this before the
+    /// contract call so that `context.min_fee_per_l2_gas()` and `context.min_fee_per_da_gas()`
+    /// return realistic values.
+    ///
+    /// # Sample usage
+    /// ```noir
+    /// env.set_block_gas_fees(GasFees::new(/* fee_per_da_gas */ 7, /* fee_per_l2_gas */ 11));
+    /// env.call_public(account, MyFPC::at(addr).pay_fee());
+    /// ```
+    ///
+    /// # Relationship to `set_gas_settings`
+    /// This is independent of `set_gas_settings`. `set_gas_settings` controls the user's stated
+    /// max budget read from `tx_context.gas_settings` in private. `set_block_gas_fees` controls
+    /// the block's actual price read from `globals.gas_fees` in public. To exercise an FPC end
+    /// to end (private setup + public teardown), call both.
+    ///
+    /// # Limitations
+    /// This setter is only callable from the top-level test context, not from within a
+    /// `private_context` / `public_context` / `utility_context` closure.
+    pub unconstrained fn set_block_gas_fees(_self: Self, gas_fees: GasFees) {
+        txe_oracles::set_block_gas_fees(gas_fees);
     }
 
     /// Creates a new account that can be used as the `from` parameter in contract calls, e.g. in `private_call` or

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/txe_oracles.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/txe_oracles.nr
@@ -4,7 +4,7 @@ use crate::{
 };
 
 use crate::protocol::{
-    abis::{function_selector::FunctionSelector, gas_settings::GasSettings},
+    abis::{function_selector::FunctionSelector, gas_fees::GasFees, gas_settings::GasSettings},
     address::AztecAddress,
     constants::{
         CONTRACT_INSTANCE_LENGTH, MAX_NOTE_HASHES_PER_TX, MAX_NULLIFIERS_PER_TX, NULL_MSG_SENDER_CONTRACT_ADDRESS,
@@ -172,6 +172,26 @@ pub unconstrained fn set_gas_settings(gas_settings: GasSettings) {
 /// know the struct shape (mirrors the capsule pattern in `crate::oracle::capsules`).
 #[oracle(aztec_txe_setGasSettings)]
 unconstrained fn set_gas_settings_oracle<let N: u32>(serialized_gas_settings: [Field; N]) {}
+
+/// Sets the per-block `gas_fees` (the "actual" L2/DA gas price the AVM exposes via
+/// `min_fee_per_l2_gas` / `min_fee_per_da_gas`) used by all subsequent TXE blocks - blocks mined
+/// explicitly via `mine_block`/`mine_block_at` and blocks produced by transaction-producing flows
+/// (`call_private`, `call_public`, ...). The setting persists until overwritten.
+///
+/// The default is zero, matching prior TXE behavior. Tests that exercise public-side fee math
+/// (e.g. an FPC's `pay_fee` teardown computing `gas_used * min_fee_per_l2_gas`) should call this
+/// before the contract call.
+///
+/// Note: this is independent of `set_gas_settings`. `set_gas_settings` controls the *user's stated
+/// max budget* (read from `tx_context.gas_settings` in private). `set_block_gas_fees` controls the
+/// *block's actual price* (read from `globals.gas_fees` in public). In a real network the two are
+/// related (the AVM computes effective fees from both), but they are configured independently here.
+pub unconstrained fn set_block_gas_fees(gas_fees: GasFees) {
+    set_block_gas_fees_oracle(gas_fees.serialize());
+}
+
+#[oracle(aztec_txe_setBlockGasFees)]
+unconstrained fn set_block_gas_fees_oracle<let N: u32>(serialized_gas_fees: [Field; N]) {}
 
 #[oracle(aztec_txe_deploy)]
 pub unconstrained fn deploy_oracle<let N: u32, let P: u32>(

--- a/noir-projects/noir-contracts/contracts/test/test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/test_contract/src/main.nr
@@ -136,6 +136,14 @@ pub contract Test {
         self.context.gas_settings()
     }
 
+    /// Returns the per-block fees observed by a public function: `(min_fee_per_da_gas,
+    /// min_fee_per_l2_gas)`. Used by TXE tests of `env.set_block_gas_fees` to confirm the
+    /// configured block fees reach `context.min_fee_per_*_gas()`.
+    #[external("public")]
+    fn echo_block_gas_fees() -> [u128; 2] {
+        [self.context.min_fee_per_da_gas(), self.context.min_fee_per_l2_gas()]
+    }
+
     #[external("public")]
     #[only_self]
     fn dummy_public_call() {}

--- a/noir-projects/noir-contracts/contracts/test/test_contract/src/test.nr
+++ b/noir-projects/noir-contracts/contracts/test/test_contract/src/test.nr
@@ -1,3 +1,4 @@
+mod block_gas_fees;
 mod macro_id_allocation;
 mod deployment_proofs;
 mod gas_settings;

--- a/noir-projects/noir-contracts/contracts/test/test_contract/src/test/block_gas_fees.nr
+++ b/noir-projects/noir-contracts/contracts/test/test_contract/src/test/block_gas_fees.nr
@@ -1,0 +1,101 @@
+use crate::Test;
+use aztec::{protocol::abis::gas_fees::GasFees, test::helpers::test_environment::TestEnvironment};
+
+global CUSTOM_FEES: GasFees = GasFees { fee_per_da_gas: 7, fee_per_l2_gas: 11 };
+
+#[test]
+unconstrained fn default_block_gas_fees_are_zero() {
+    // Documents the (intentional) default. If this changes, every TXE test that previously read
+    // `min_fee_per_l2_gas` / `min_fee_per_da_gas` had its semantics change too.
+    let mut env = TestEnvironment::new();
+    let sender = env.create_light_account();
+    let contract_address =
+        env.deploy("Test").with_private_initializer(sender, Test::interface().initialize());
+    let test_contract = Test::at(contract_address);
+
+    let observed: [u128; 2] = env.call_public(sender, test_contract.echo_block_gas_fees());
+
+    assert_eq(observed[0], 0, "default min_fee_per_da_gas should be zero");
+    assert_eq(observed[1], 0, "default min_fee_per_l2_gas should be zero");
+}
+
+#[test]
+unconstrained fn set_block_gas_fees_propagates_to_call_public() {
+    let mut env = TestEnvironment::new();
+    let sender = env.create_light_account();
+    let contract_address =
+        env.deploy("Test").with_private_initializer(sender, Test::interface().initialize());
+    let test_contract = Test::at(contract_address);
+
+    env.set_block_gas_fees(CUSTOM_FEES);
+    let observed: [u128; 2] = env.call_public(sender, test_contract.echo_block_gas_fees());
+
+    assert_eq(observed[0], CUSTOM_FEES.fee_per_da_gas);
+    assert_eq(observed[1], CUSTOM_FEES.fee_per_l2_gas);
+}
+
+#[test]
+unconstrained fn set_block_gas_fees_persists_across_call_public_invocations() {
+    // Mirrors `set_next_block_timestamp` semantics: the value sticks until overwritten.
+    let mut env = TestEnvironment::new();
+    let sender = env.create_light_account();
+    let contract_address =
+        env.deploy("Test").with_private_initializer(sender, Test::interface().initialize());
+    let test_contract = Test::at(contract_address);
+
+    env.set_block_gas_fees(CUSTOM_FEES);
+
+    let first: [u128; 2] = env.call_public(sender, test_contract.echo_block_gas_fees());
+    let second: [u128; 2] = env.call_public(sender, test_contract.echo_block_gas_fees());
+
+    assert_eq(first[0], CUSTOM_FEES.fee_per_da_gas);
+    assert_eq(first[1], CUSTOM_FEES.fee_per_l2_gas);
+    assert_eq(second[0], CUSTOM_FEES.fee_per_da_gas);
+    assert_eq(second[1], CUSTOM_FEES.fee_per_l2_gas);
+}
+
+#[test]
+unconstrained fn set_block_gas_fees_can_be_overwritten() {
+    let mut env = TestEnvironment::new();
+    let sender = env.create_light_account();
+    let contract_address =
+        env.deploy("Test").with_private_initializer(sender, Test::interface().initialize());
+    let test_contract = Test::at(contract_address);
+
+    env.set_block_gas_fees(CUSTOM_FEES);
+    let _: [u128; 2] = env.call_public(sender, test_contract.echo_block_gas_fees());
+
+    let other_fees = GasFees { fee_per_da_gas: 13, fee_per_l2_gas: 17 };
+    env.set_block_gas_fees(other_fees);
+
+    let observed: [u128; 2] = env.call_public(sender, test_contract.echo_block_gas_fees());
+    assert_eq(observed[0], other_fees.fee_per_da_gas);
+    assert_eq(observed[1], other_fees.fee_per_l2_gas);
+}
+
+#[test]
+unconstrained fn set_block_gas_fees_is_independent_of_set_gas_settings() {
+    // The two setters configure independent pieces of state - `set_gas_settings` writes to the
+    // private-side `tx_context.gas_settings`, `set_block_gas_fees` writes to the public-side
+    // `globals.gas_fees`. Neither one bleeds into the other.
+    let mut env = TestEnvironment::new();
+    let sender = env.create_light_account();
+    let contract_address =
+        env.deploy("Test").with_private_initializer(sender, Test::interface().initialize());
+    let test_contract = Test::at(contract_address);
+
+    env.set_block_gas_fees(CUSTOM_FEES);
+
+    // The private-side `context.gas_settings()` should still reflect the (untouched) default,
+    // not the configured block fees.
+    let private_observed = env.call_private(sender, test_contract.echo_gas_settings());
+    assert(
+        private_observed.max_fees_per_gas.is_empty(),
+        "set_block_gas_fees must not affect tx_context.gas_settings.max_fees_per_gas",
+    );
+
+    // The public-side `min_fee_per_*_gas()` should reflect the configured block fees.
+    let public_observed: [u128; 2] = env.call_public(sender, test_contract.echo_block_gas_fees());
+    assert_eq(public_observed[0], CUSTOM_FEES.fee_per_da_gas);
+    assert_eq(public_observed[1], CUSTOM_FEES.fee_per_l2_gas);
+}

--- a/yarn-project/txe/src/oracle/interfaces.ts
+++ b/yarn-project/txe/src/oracle/interfaces.ts
@@ -6,7 +6,7 @@ import { BlockNumber } from '@aztec/foundation/branded-types';
 import type { Fr } from '@aztec/foundation/curves/bn254';
 import type { EventSelector, FunctionSelector } from '@aztec/stdlib/abi';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
-import type { GasSettings } from '@aztec/stdlib/gas';
+import type { GasFees, GasSettings } from '@aztec/stdlib/gas';
 import type { UInt64 } from '@aztec/stdlib/types';
 
 // These interfaces complement the ones defined in PXE, and combined with those contain the full list of oracles used by
@@ -51,6 +51,7 @@ export interface ITxeExecutionOracle {
   advanceBlocksBy(blocks: number): Promise<void>;
   advanceTimestampBy(duration: UInt64): void;
   setGasSettings(gasSettings: GasSettings): void;
+  setBlockGasFees(gasFees: GasFees): void;
   deploy(artifact: ContractArtifact, instance: ContractInstanceWithAddress, foreignSecret: Fr): Promise<void>;
   createAccount(secret: Fr): Promise<CompleteAddress>;
   addAccount(artifact: ContractArtifact, instance: ContractInstanceWithAddress, secret: Fr): Promise<CompleteAddress>;

--- a/yarn-project/txe/src/oracle/txe_oracle_top_level_context.ts
+++ b/yarn-project/txe/src/oracle/txe_oracle_top_level_context.ts
@@ -105,6 +105,12 @@ export const DEFAULT_TXE_GAS_SETTINGS = new GasSettings(
   GasFees.empty(),
 );
 
+/**
+ * The default per-block `GasFees` used by TXE blocks when the test does not call
+ * `env.set_block_gas_fees`. Zero, preserving prior TXE behavior for existing tests.
+ */
+export const DEFAULT_TXE_BLOCK_GAS_FEES = GasFees.empty();
+
 export class TXEOracleTopLevelContext implements IMiscOracle, ITxeExecutionOracle {
   isMisc = true as const;
   isTxe = true as const;
@@ -128,6 +134,7 @@ export class TXEOracleTopLevelContext implements IMiscOracle, ITxeExecutionOracl
     private chainId: Fr,
     private authwits: Map<string, AuthWitness>,
     private currentGasSettings: GasSettings,
+    private currentBlockGasFees: GasFees,
   ) {
     this.logger = createLogger('txe:top_level_context');
     this.logger.debug('Entering Top Level Context');
@@ -252,6 +259,15 @@ export class TXEOracleTopLevelContext implements IMiscOracle, ITxeExecutionOracl
     return this.currentGasSettings;
   }
 
+  setBlockGasFees(gasFees: GasFees) {
+    this.logger.debug(`updating block gas fees`, { gasFees });
+    this.currentBlockGasFees = gasFees;
+  }
+
+  getBlockGasFees(): GasFees {
+    return this.currentBlockGasFees;
+  }
+
   async deploy(artifact: ContractArtifact, instance: ContractInstanceWithAddress, secret: Fr) {
     // Emit deployment nullifier
     await this.mineBlock({
@@ -324,6 +340,7 @@ export class TXEOracleTopLevelContext implements IMiscOracle, ITxeExecutionOracl
       timestamp: this.nextBlockTimestamp,
       version: this.version,
       chainId: this.chainId,
+      gasFees: this.currentBlockGasFees,
     });
     const block = await makeTXEBlock(forkedWorldTrees, globals, [txEffect]);
 
@@ -472,7 +489,7 @@ export class TXEOracleTopLevelContext implements IMiscOracle, ITxeExecutionOracl
     globals.timestamp = this.nextBlockTimestamp;
     globals.chainId = this.chainId;
     globals.version = this.version;
-    globals.gasFees = GasFees.empty();
+    globals.gasFees = this.currentBlockGasFees;
 
     const forkedWorldTrees = await this.stateMachine.synchronizer.nativeWorldStateService.fork();
 
@@ -589,7 +606,7 @@ export class TXEOracleTopLevelContext implements IMiscOracle, ITxeExecutionOracl
     globals.timestamp = this.nextBlockTimestamp;
     globals.chainId = this.chainId;
     globals.version = this.version;
-    globals.gasFees = GasFees.empty();
+    globals.gasFees = this.currentBlockGasFees;
 
     const forkedWorldTrees = await this.stateMachine.synchronizer.nativeWorldStateService.fork();
 
@@ -807,9 +824,9 @@ export class TXEOracleTopLevelContext implements IMiscOracle, ITxeExecutionOracl
     }
   }
 
-  close(): [bigint, Map<string, AuthWitness>, GasSettings] {
+  close(): [bigint, Map<string, AuthWitness>, GasSettings, GasFees] {
     this.logger.debug('Exiting Top Level Context');
-    return [this.nextBlockTimestamp, this.authwits, this.currentGasSettings];
+    return [this.nextBlockTimestamp, this.authwits, this.currentGasSettings, this.currentBlockGasFees];
   }
 
   private async getLastBlockNumber(): Promise<BlockNumber> {

--- a/yarn-project/txe/src/rpc_translator.ts
+++ b/yarn-project/txe/src/rpc_translator.ts
@@ -10,7 +10,7 @@ import {
 } from '@aztec/pxe/simulator';
 import { type ContractArtifact, EventSelector, FunctionSelector, NoteSelector } from '@aztec/stdlib/abi';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
-import { GasSettings } from '@aztec/stdlib/gas';
+import { GasFees, GasSettings } from '@aztec/stdlib/gas';
 
 import type { IAvmExecutionOracle, ITxeExecutionOracle } from './oracle/interfaces.js';
 import type { TXESessionStateHandler } from './txe_session.js';
@@ -208,6 +208,15 @@ export class RPCTranslator {
     const gasSettings = GasSettings.fromFields(fromArray(foreignSerializedGasSettings));
 
     this.handlerAsTxe().setGasSettings(gasSettings);
+
+    return toForeignCallResult([]);
+  }
+
+  // eslint-disable-next-line camelcase
+  aztec_txe_setBlockGasFees(foreignSerializedGasFees: ForeignCallArray) {
+    const gasFees = GasFees.fromFields(fromArray(foreignSerializedGasFees));
+
+    this.handlerAsTxe().setBlockGasFees(gasFees);
 
     return toForeignCallResult([]);
   }

--- a/yarn-project/txe/src/txe_session.ts
+++ b/yarn-project/txe/src/txe_session.ts
@@ -38,7 +38,7 @@ import {
 import { FunctionCall, FunctionSelector, FunctionType } from '@aztec/stdlib/abi';
 import type { AuthWitness } from '@aztec/stdlib/auth-witness';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
-import type { GasSettings } from '@aztec/stdlib/gas';
+import type { GasFees, GasSettings } from '@aztec/stdlib/gas';
 import { computeProtocolNullifier } from '@aztec/stdlib/hash';
 import { PrivateContextInputs } from '@aztec/stdlib/kernel';
 import { makeGlobalVariables } from '@aztec/stdlib/testing';
@@ -49,7 +49,11 @@ import { z } from 'zod';
 import { DEFAULT_ADDRESS } from './constants.js';
 import type { IAvmExecutionOracle, ITxeExecutionOracle } from './oracle/interfaces.js';
 import { TXEOraclePublicContext } from './oracle/txe_oracle_public_context.js';
-import { DEFAULT_TXE_GAS_SETTINGS, TXEOracleTopLevelContext } from './oracle/txe_oracle_top_level_context.js';
+import {
+  DEFAULT_TXE_BLOCK_GAS_FEES,
+  DEFAULT_TXE_GAS_SETTINGS,
+  TXEOracleTopLevelContext,
+} from './oracle/txe_oracle_top_level_context.js';
 import { RPCTranslator } from './rpc_translator.js';
 import { TXEArchiver } from './state_machine/archiver.js';
 import { TXEStateMachine } from './state_machine/index.js';
@@ -211,6 +215,7 @@ export class TXESession implements TXESessionStateHandler {
     private version: Fr,
     private nextBlockTimestamp: bigint,
     private currentGasSettings: GasSettings = DEFAULT_TXE_GAS_SETTINGS,
+    private currentBlockGasFees: GasFees = DEFAULT_TXE_BLOCK_GAS_FEES,
   ) {}
 
   static async init(contractStore: ContractStore) {
@@ -265,6 +270,7 @@ export class TXESession implements TXESessionStateHandler {
       chainId,
       new Map(),
       DEFAULT_TXE_GAS_SETTINGS,
+      DEFAULT_TXE_BLOCK_GAS_FEES,
     );
     await topLevelOracleHandler.advanceBlocksBy(1);
 
@@ -418,6 +424,7 @@ export class TXESession implements TXESessionStateHandler {
       this.chainId,
       this.authwits,
       this.currentGasSettings,
+      this.currentBlockGasFees,
     );
 
     this.state = { name: 'TOP_LEVEL' };
@@ -586,7 +593,7 @@ export class TXESession implements TXESessionStateHandler {
     // level context is re-created. This is because authwits create a temporary utility context that'd otherwise reset
     // the authwits if not persisted, so we'd not be able to pass more than one per execution.
     // Ideally authwits would be passed alongside a contract call instead of pre-seeded.
-    [this.nextBlockTimestamp, this.authwits, this.currentGasSettings] = (
+    [this.nextBlockTimestamp, this.authwits, this.currentGasSettings, this.currentBlockGasFees] = (
       this.oracleHandler as TXEOracleTopLevelContext
     ).close();
   }


### PR DESCRIPTION
## Summary

Stacked on top of #22849 (`env.set_gas_settings`).

Adds the second piece of the FPC-test puzzle: a Noir TXE API for setting the per-block actual gas price.

```noir
let mut env = TestEnvironment::new();

// User's stated max budget (private side, from #22849):
env.set_gas_settings(realistic_gas_settings);

// Block's actual price (this PR, public side):
env.set_block_gas_fees(GasFees::new(/* fee_per_da_gas */ 7, /* fee_per_l2_gas */ 11));

env.call_private(account, fpc.full_flow_with_public_teardown());
// inside the public teardown, context.min_fee_per_l2_gas() == 11
```

## Why this is a separate setter, not part of `set_gas_settings`

The two configure independent pieces of state for independent purposes:

- `tx_context.gas_settings.max_fees_per_gas` — the user's stated *willingness to pay* (intent), set by the wallet, read in private via `context.gas_settings()`. Used by FPC setup phase.
- `globals.gas_fees` — the network's *actual price* this block, set by the sequencer, read in public via `context.min_fee_per_l2_gas()` / `context.min_fee_per_da_gas()`. Used by FPC teardown phase.

In production these are related (the AVM's effective fee uses both), but they originate from different actors. Keeping the TXE setters independent matches that.

## Why a persistent setter is the right shape here (vs. `set_gas_settings`)

The stack-base PR (`set_gas_settings`) is arguably better as a per-call arg, since `gas_settings` is a per-tx wallet-side property. `block_gas_fees` is genuinely chain state — every existing chain-state knob in TXE uses the persistent-setter pattern:

| Property | Production source | TXE API style |
|----------|-------------------|---------------|
| `nextBlockTimestamp` | sequencer (clock) | persistent setter (`set_next_block_timestamp`) |
| `globals.gas_fees` | sequencer (fee market) | persistent setter (this PR) |
| `gas_settings` | wallet (per-tx) | per-call arg in production; setter in #22849 (debatable) |

So this PR matches an established TXE convention exactly: held on `TXEOracleTopLevelContext`, threaded through `close()`, used identically by `mineBlock`, `privateCallNewFlow`'s globals, and `publicCallNewFlow`'s globals.

## Implementation notes

- Three TS sites previously hardcoded `GasFees.empty()` (one in `mineBlock`, two in the call flows). All three now read from `currentBlockGasFees`.
- Wire format follows the same capsule pattern as #22849: Noir serializes `GasFees` to a flat field array, TS decodes via `GasFees.fromFields`.
- Default = `DEFAULT_TXE_BLOCK_GAS_FEES = GasFees.empty()`. Existing tests are bit-for-bit unchanged.
- The `TXEFeeProvider` in the state machine still returns zero fees — it's wired to a code path the TXE call flows bypass, so it doesn't need updating for this PoC. If a future change makes the call flows go through it, a one-line update wires it up.

## Tests

Five new Noir tests in `noir-projects/noir-contracts/contracts/test/test_contract/src/test/block_gas_fees.nr`:

- `default_block_gas_fees_are_zero` — regression / documentation of the unchanged default.
- `set_block_gas_fees_propagates_to_call_public` — the headline case: `context.min_fee_per_*_gas()` reads the configured value.
- `set_block_gas_fees_persists_across_call_public_invocations` — documents persistence semantics.
- `set_block_gas_fees_can_be_overwritten` — second call replaces the first.
- `set_block_gas_fees_is_independent_of_set_gas_settings` — proves the two setters don't bleed into each other.

A new `echo_block_gas_fees` public function on `test_contract` returns `[min_fee_per_da_gas, min_fee_per_l2_gas]` so the test can inspect what the public callee saw.

## Test plan

- CI runs the new Noir tests against a live TXE server.
- CI re-runs all existing TXE tests to confirm the default-preservation claim.

## Generated note

PoC by Claude. Together with #22849 this enables full FPC tests in TXE -- the private setup phase that validates the user's max budget, plus the public teardown phase that computes the actual fee charged.