### PR TITLE
chore: remove orphan `--pxe` flag from `aztec start`

### DIFF
--- a/spartan/aztec-bot/values.yaml
+++ b/spartan/aztec-bot/values.yaml
@@ -93,7 +93,6 @@ bot:
 
     startCmd:
       - --bot
-      - --pxe
 
     hostNetwork: false
 

--- a/yarn-project/aztec/src/cli/aztec_start_options.ts
+++ b/yarn-project/aztec/src/cli/aztec_start_options.ts
@@ -326,15 +326,7 @@ export const aztecStartOptions: { [key: string]: AztecStartOption[] } = {
     },
     ...getOptions('bot', botConfigMappings),
   ],
-  PXE: [
-    {
-      flag: '--pxe',
-      description: 'Starts Aztec PXE with options',
-      defaultValue: undefined,
-      env: undefined,
-    },
-    ...getOptions('pxe', allPxeConfigMappings),
-  ],
+  PXE: [...getOptions('pxe', allPxeConfigMappings)],
   TXE: [
     {
       flag: '--txe',

--- a/yarn-project/aztec/src/cli/cmds/start_prover_agent.ts
+++ b/yarn-project/aztec/src/cli/cmds/start_prover_agent.ts
@@ -24,8 +24,8 @@ export async function startProverAgent(
   services: NamespacedApiHandlers,
   userLog: LogFn,
 ) {
-  if (options.node || options.sequencer || options.pxe || options.p2pBootstrap || options.txe) {
-    userLog(`Starting a prover agent with --node, --sequencer, --pxe, --p2p-bootstrap, or --txe is not supported.`);
+  if (options.node || options.sequencer || options.p2pBootstrap || options.txe) {
+    userLog(`Starting a prover agent with --node, --sequencer, --p2p-bootstrap, or --txe is not supported.`);
     process.exit(1);
   }
 

--- a/yarn-project/aztec/src/cli/cmds/start_prover_broker.ts
+++ b/yarn-project/aztec/src/cli/cmds/start_prover_broker.ts
@@ -24,8 +24,8 @@ export async function startProverBroker(
   services: NamespacedApiHandlers,
   userLog: LogFn,
 ): Promise<{ broker: ProvingJobBroker; config: ProverBrokerConfig }> {
-  if (options.node || options.sequencer || options.pxe || options.p2pBootstrap || options.txe) {
-    userLog(`Starting a prover broker with --node, --sequencer, --pxe, --p2p-bootstrap, or --txe is not supported.`);
+  if (options.node || options.sequencer || options.p2pBootstrap || options.txe) {
+    userLog(`Starting a prover broker with --node, --sequencer, --p2p-bootstrap, or --txe is not supported.`);
     process.exit(1);
   }
 


### PR DESCRIPTION
The `--pxe` flag has had no handler since #17228 dropped the PXE JSON-RPC server; passing it produced "No module specified to start" and exited 1. This just drops the flag.