### PR TITLE
fix: dedup attestation pool by payload hash

### DIFF
--- a/yarn-project/aztec-node/src/sentinel/sentinel.ts
+++ b/yarn-project/aztec-node/src/sentinel/sentinel.ts
@@ -1,5 +1,11 @@
 import type { EpochCache } from '@aztec/epoch-cache';
-import { BlockNumber, CheckpointNumber, EpochNumber, SlotNumber } from '@aztec/foundation/branded-types';
+import {
+  BlockNumber,
+  CheckpointNumber,
+  CheckpointProposalHash,
+  EpochNumber,
+  SlotNumber,
+} from '@aztec/foundation/branded-types';
 import { countWhile, filterAsync, fromEntries, getEntries, mapValues } from '@aztec/foundation/collection';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { createLogger } from '@aztec/foundation/log';
@@ -23,7 +29,7 @@ import {
 } from '@aztec/stdlib/block';
 import type { ChainConfig } from '@aztec/stdlib/config';
 import { getEpochAtSlot, getSlotRangeForEpoch, getTimestampForSlot } from '@aztec/stdlib/epoch-helpers';
-import type { CoordinationSignatureContext } from '@aztec/stdlib/p2p';
+import { ConsensusPayload, type CoordinationSignatureContext } from '@aztec/stdlib/p2p';
 import type {
   SingleValidatorStats,
   ValidatorStats,
@@ -64,7 +70,13 @@ export class Sentinel extends (EventEmitter as new () => WatcherEmitter) impleme
   protected lastProcessedSlot: SlotNumber | undefined;
   protected slotNumberToCheckpoint: Map<
     SlotNumber,
-    { checkpointNumber: CheckpointNumber; archive: string; attestors: EthAddress[] }
+    {
+      checkpointNumber: CheckpointNumber;
+      archive: string;
+      /** Hex keccak256 of the consensus payload bytes; used to fetch matching p2p attestations. */
+      proposalPayloadHash: CheckpointProposalHash;
+      attestors: EthAddress[];
+    }
   > = new Map();
 
   constructor(
@@ -124,11 +136,17 @@ export class Sentinel extends (EventEmitter as new () => WatcherEmitter) impleme
     }
     const checkpoint = event.checkpoint;
 
-    // Store mapping from slot to archive, checkpoint number, and attestors
+    // Store mapping from slot to archive, checkpoint number, attestors, and the consensus payload
+    // hash (used to query matching p2p attestations regardless of feeAssetPriceModifier variants).
+    const signatureContext = this.getSignatureContext();
+    const proposalPayloadHash = CheckpointProposalHash.fromBuffer(
+      ConsensusPayload.fromCheckpoint(checkpoint.checkpoint, signatureContext).getPayloadHash(),
+    );
     this.slotNumberToCheckpoint.set(checkpoint.checkpoint.header.slotNumber, {
       checkpointNumber: checkpoint.checkpoint.number,
       archive: checkpoint.checkpoint.archive.root.toString(),
-      attestors: getAttestationInfoFromPublishedCheckpoint(checkpoint, this.getSignatureContext())
+      proposalPayloadHash,
+      attestors: getAttestationInfoFromPublishedCheckpoint(checkpoint, signatureContext)
         .filter(a => a.status === 'recovered-from-signature')
         .map(a => a.address!),
     });
@@ -372,7 +390,7 @@ export class Sentinel extends (EventEmitter as new () => WatcherEmitter) impleme
     // We gather from both p2p (contains the ones seen on the p2p layer) and archiver
     // (contains the ones synced from mined checkpoints, which we may have missed from p2p).
     const checkpoint = this.slotNumberToCheckpoint.get(slot);
-    const p2pAttested = await this.p2p.getCheckpointAttestationsForSlot(slot, checkpoint?.archive);
+    const p2pAttested = await this.p2p.getCheckpointAttestationsForSlot(slot, checkpoint?.proposalPayloadHash);
     // Filter out attestations with invalid signatures
     const p2pAttestors = p2pAttested.map(a => a.getSender()).filter((s): s is EthAddress => s !== undefined);
     const attestors = new Set(

--- a/yarn-project/foundation/src/branded-types/buffer32_hash.ts
+++ b/yarn-project/foundation/src/branded-types/buffer32_hash.ts
@@ -1,42 +1,38 @@
-import type { BaseBuffer32 } from '../buffer/buffer32.js';
-import { Buffer32 } from '../buffer/buffer32.js';
 import type { Branded } from './types.js';
 
-/** A branded Buffer32 representing a block proposal hash, used for p2p deduplication. */
-export type BlockProposalHash = Branded<BaseBuffer32, 'BlockProposalHash'>;
+/**
+ * A branded `0x`-prefixed hex string representing a checkpoint proposal payload hash.
+ *
+ * A `CheckpointProposal` and the matching `CheckpointAttestation` sign the same
+ * `ConsensusPayload`, so they share this hash type. Used by the p2p attestation
+ * pool to dedup signed payloads and detect equivocations.
+ */
+export type CheckpointProposalHash = Branded<`0x${string}`, 'CheckpointProposalHash'>;
 
-/** Creates a BlockProposalHash from a BaseBuffer32. */
-export function BlockProposalHash(buf: BaseBuffer32): BlockProposalHash {
-  return buf as BlockProposalHash;
+/** Brands a `0x`-prefixed hex string as a CheckpointProposalHash. */
+export function CheckpointProposalHash(s: `0x${string}`): CheckpointProposalHash {
+  return s as CheckpointProposalHash;
 }
 
-/** Creates a BlockProposalHash from a raw Buffer. */
-BlockProposalHash.fromBuffer = function (buf: Buffer): BlockProposalHash {
-  return new Buffer32(buf) as unknown as BlockProposalHash;
-};
-
-/** A branded Buffer32 representing a checkpoint proposal hash, used for p2p deduplication. */
-export type CheckpointProposalHash = Branded<BaseBuffer32, 'CheckpointProposalHash'>;
-
-/** Creates a CheckpointProposalHash from a BaseBuffer32. */
-export function CheckpointProposalHash(buf: BaseBuffer32): CheckpointProposalHash {
-  return buf as CheckpointProposalHash;
-}
-
-/** Creates a CheckpointProposalHash from a raw Buffer. */
+/** Constructs a CheckpointProposalHash from a raw 32-byte hash buffer. */
 CheckpointProposalHash.fromBuffer = function (buf: Buffer): CheckpointProposalHash {
-  return new Buffer32(buf) as unknown as CheckpointProposalHash;
+  return `0x${buf.toString('hex')}` as CheckpointProposalHash;
 };
 
-/** A branded Buffer32 representing a checkpoint attestation hash, used for p2p deduplication. */
-export type CheckpointAttestationHash = Branded<BaseBuffer32, 'CheckpointAttestationHash'>;
+/**
+ * A branded `0x`-prefixed hex string representing a block proposal payload hash.
+ *
+ * Used by the p2p attestation pool to dedup signed payloads at a given
+ * `(slot, indexWithinCheckpoint)` and detect equivocations.
+ */
+export type BlockProposalHash = Branded<`0x${string}`, 'BlockProposalHash'>;
 
-/** Creates a CheckpointAttestationHash from a BaseBuffer32. */
-export function CheckpointAttestationHash(buf: BaseBuffer32): CheckpointAttestationHash {
-  return buf as CheckpointAttestationHash;
+/** Brands a `0x`-prefixed hex string as a BlockProposalHash. */
+export function BlockProposalHash(s: `0x${string}`): BlockProposalHash {
+  return s as BlockProposalHash;
 }
 
-/** Creates a CheckpointAttestationHash from a raw Buffer. */
-CheckpointAttestationHash.fromBuffer = function (buf: Buffer): CheckpointAttestationHash {
-  return new Buffer32(buf) as unknown as CheckpointAttestationHash;
+/** Constructs a BlockProposalHash from a raw 32-byte hash buffer. */
+BlockProposalHash.fromBuffer = function (buf: Buffer): BlockProposalHash {
+  return `0x${buf.toString('hex')}` as BlockProposalHash;
 };

--- a/yarn-project/foundation/src/branded-types/index.ts
+++ b/yarn-project/foundation/src/branded-types/index.ts
@@ -1,5 +1,5 @@
 export { BlockNumber, BlockNumberSchema, BlockNumberPositiveSchema } from './block_number.js';
-export { BlockProposalHash, CheckpointAttestationHash, CheckpointProposalHash } from './buffer32_hash.js';
+export { BlockProposalHash, CheckpointProposalHash } from './buffer32_hash.js';
 export { CheckpointNumber, CheckpointNumberSchema, CheckpointNumberPositiveSchema } from './checkpoint_number.js';
 export { EpochNumber, EpochNumberSchema } from './epoch.js';
 export { IndexWithinCheckpoint, IndexWithinCheckpointSchema } from './index_within_checkpoint.js';

--- a/yarn-project/p2p/src/client/p2p_client.ts
+++ b/yarn-project/p2p/src/client/p2p_client.ts
@@ -1,5 +1,10 @@
 import type { EpochCacheInterface } from '@aztec/epoch-cache';
-import { BlockNumber, CheckpointNumber, SlotNumber } from '@aztec/foundation/branded-types';
+import {
+  BlockNumber,
+  CheckpointNumber,
+  type CheckpointProposalHash,
+  SlotNumber,
+} from '@aztec/foundation/branded-types';
 import { createLogger } from '@aztec/foundation/log';
 import { RunningPromise } from '@aztec/foundation/promise';
 import { DateProvider } from '@aztec/foundation/timer';
@@ -379,10 +384,10 @@ export class P2PClient extends WithTracer implements P2P {
 
   public async getCheckpointAttestationsForSlot(
     slot: SlotNumber,
-    proposalId?: string,
+    proposalPayloadHash?: CheckpointProposalHash,
   ): Promise<CheckpointAttestation[]> {
-    return await (proposalId
-      ? this.attestationPool.getCheckpointAttestationsForSlotAndProposal(slot, proposalId)
+    return await (proposalPayloadHash
+      ? this.attestationPool.getCheckpointAttestationsForSlotAndProposal(slot, proposalPayloadHash)
       : this.attestationPool.getCheckpointAttestationsForSlot(slot));
   }
 

--- a/yarn-project/p2p/src/client/test/p2p_client.integration_batch_txs.test.ts
+++ b/yarn-project/p2p/src/client/test/p2p_client.integration_batch_txs.test.ts
@@ -221,7 +221,7 @@ describe('p2p client integration batch txs', () => {
     const peerIds = clients.map(client => (client as any).p2pService.node.peerId);
     connectionSampler.getPeerListSortedByConnectionCountAsc.mockReturnValue(peerIds);
 
-    attestationPool.getBlockProposal.mockResolvedValue(blockProposal);
+    attestationPool.getBlockProposalByArchive.mockResolvedValue(blockProposal);
 
     // Client 0 is missing all transactions
     const missingTxHashes = txHashes;

--- a/yarn-project/p2p/src/client/test/p2p_client.integration_block_txs.test.ts
+++ b/yarn-project/p2p/src/client/test/p2p_client.integration_block_txs.test.ts
@@ -108,7 +108,7 @@ describe('p2p client integration block txs protocol ', () => {
     txs = await Promise.all(times(5, i => createMockTxWithMetadata(p2pBaseConfig, i)));
     txHashes = await Promise.all(txs.map(tx => tx.getTxHash()));
     blockProposal = await createBlockProposal(BlockNumber(blockNumber), archiveRoot, txHashes);
-    attestationPool.getBlockProposal.mockResolvedValue(blockProposal);
+    attestationPool.getBlockProposalByArchive.mockResolvedValue(blockProposal);
   });
 
   afterEach(async () => {
@@ -153,7 +153,7 @@ describe('p2p client integration block txs protocol ', () => {
   };
 
   it('responds with NOT_FOUND when peer does not have the requested block proposal', async () => {
-    attestationPool.getBlockProposal.mockResolvedValue(undefined);
+    attestationPool.getBlockProposalByArchive.mockResolvedValue(undefined);
     const missing = new TxHashArray(...Array.from({ length: 4 }, () => TxHash.random()));
 
     const blockProposal = await createBlockProposal(blockNumber, Fr.random(), missing);
@@ -326,7 +326,7 @@ describe('p2p client integration block txs protocol ', () => {
 
   it('responds with txs when peer does not have proposal but has txs (includeFullTxHashes=true)', async () => {
     // Peer doesn't have the block proposal
-    attestationPool.getBlockProposal.mockResolvedValue(undefined);
+    attestationPool.getBlockProposalByArchive.mockResolvedValue(undefined);
 
     // But peer has some of the requested txs in their pool
     const availableTxs = [txs[1], txs[3]];
@@ -355,7 +355,7 @@ describe('p2p client integration block txs protocol ', () => {
 
   it('responds with partial txs when peer does not have proposal (includeFullTxHashes=true)', async () => {
     // Peer doesn't have the block proposal
-    attestationPool.getBlockProposal.mockResolvedValue(undefined);
+    attestationPool.getBlockProposalByArchive.mockResolvedValue(undefined);
 
     // Peer has only one of the requested txs
     const availableTx = txs[2];
@@ -384,7 +384,7 @@ describe('p2p client integration block txs protocol ', () => {
 
   it('responds with empty txs when peer does not have proposal or txs (includeFullTxHashes=true)', async () => {
     // Peer doesn't have the block proposal
-    attestationPool.getBlockProposal.mockResolvedValue(undefined);
+    attestationPool.getBlockProposalByArchive.mockResolvedValue(undefined);
 
     // Peer also doesn't have any of the requested txs
     txPool.getTxsByHash.mockResolvedValue([]);
@@ -403,7 +403,7 @@ describe('p2p client integration block txs protocol ', () => {
 
   it('still responds with NOT_FOUND when peer does not have proposal and includeFullTxHashes=false', async () => {
     // Peer doesn't have the block proposal
-    attestationPool.getBlockProposal.mockResolvedValue(undefined);
+    attestationPool.getBlockProposalByArchive.mockResolvedValue(undefined);
 
     // Even if peer has the txs in pool
     const hashToTx = new Map(txs.map((tx, i) => [txHashes[i].toString(), tx]));

--- a/yarn-project/p2p/src/mem_pools/attestation_pool/attestation_pool.ts
+++ b/yarn-project/p2p/src/mem_pools/attestation_pool/attestation_pool.ts
@@ -1,5 +1,4 @@
-import { IndexWithinCheckpoint, SlotNumber } from '@aztec/foundation/branded-types';
-import { Fr } from '@aztec/foundation/curves/bn254';
+import type { BlockProposalHash, CheckpointProposalHash, SlotNumber } from '@aztec/foundation/branded-types';
 import { toArray } from '@aztec/foundation/iterable';
 import { createLogger } from '@aztec/foundation/log';
 import type { AztecAsyncKVStore, AztecAsyncMap, AztecAsyncMultiMap } from '@aztec/kv-store';
@@ -15,14 +14,14 @@ import { PoolInstrumentation, PoolName, type PoolStatsCallback } from '../instru
 
 /** Result of trying to add an item (proposal or attestation) to the pool */
 export type TryAddResult = {
-  /** Whether the item was added */
+  /** Whether the item was added to a main store. False when the slot/position/(slot,signer) already had a stored entry, even if a new equivocation hash was tracked. */
   added: boolean;
-  /** Whether the exact item already existed */
+  /** Whether the exact signed payload (matched by payload hash) already existed in the pool. */
   alreadyExists: boolean;
-  /** Count of items for the position. Meaning varies by method:
-   *  - tryAddBlockProposal: proposals at (slot, indexWithinCheckpoint)
-   *  - tryAddCheckpointProposal: proposals at slot
-   *  - tryAddCheckpointAttestation: attestations by this signer for this slot */
+  /** Number of distinct signed-payload hashes seen for the position. Meaning varies by method:
+   *  - tryAddBlockProposal: distinct payload hashes at (slot, indexWithinCheckpoint)
+   *  - tryAddCheckpointProposal: distinct payload hashes at slot
+   *  - tryAddCheckpointAttestation: distinct payload hashes by this signer for this slot */
   count: number;
 };
 
@@ -35,7 +34,7 @@ export const MAX_ATTESTATIONS_PER_SLOT_AND_SIGNER = 2;
 export type AttestationPoolApi = Pick<
   AttestationPool,
   | 'tryAddBlockProposal'
-  | 'getBlockProposal'
+  | 'getBlockProposalByArchive'
   | 'tryAddCheckpointProposal'
   | 'getCheckpointProposal'
   | 'addOwnCheckpointAttestations'
@@ -52,31 +51,46 @@ export type AttestationPoolApi = Pick<
  *
  * Attestations and proposals observed via the p2p network are stored for requests
  * from the validator to produce a block, or to serve to other peers.
+ *
+ * Equivocation detection: each main store holds at most one entry per equivocation
+ * position (one checkpoint proposal per slot, one block proposal per (slot, position),
+ * one attestation per (slot, signer)). Distinct *signed payload hashes* arriving at
+ * the same position are tracked in the matching index multimap so the equivocation
+ * count reaches 2 even when archive collides on `feeAssetPriceModifier` variants.
  */
 export class AttestationPool {
   private metrics: PoolInstrumentation<CheckpointAttestation>;
 
-  // Checkpoint attestations from attestation key (slot-proposalId-signer) to serialized CheckpointAttestation
-  // Keys are lexicographically sortable allowing range queries by slot or by (slot, proposalId)
-  private checkpointAttestations: AztecAsyncMap<string, Buffer>;
+  // Checkpoint attestations from `${paddedSlot}-${signer}` to serialized CheckpointAttestation.
+  // Stores the first attestation seen per (slot, signer); subsequent distinct payload
+  // hashes from the same signer are tracked only in `attestationHashesPerSlotAndSigner`
+  // for equivocation detection.
+  private attestationPerSlotAndSigner: AztecAsyncMap<string, Buffer>;
 
-  // Checkpoint proposals from proposal archive to serialized CheckpointProposal
-  private checkpointProposals: AztecAsyncMap<string, Buffer>;
+  // Distinct payload hashes seen per (slot, signer) for tracking attestation equivocations.
+  // Key: `${paddedSlot}-${signerAddress}`, Value: CheckpointProposalHash (`0x`-prefixed hex)
+  private attestationHashesPerSlotAndSigner: AztecAsyncMultiMap<string, CheckpointProposalHash>;
 
-  // Checkpoint proposals indexed by slot for querying all proposals in a slot
-  // Key: slot number, Value: proposal archive strings
-  private checkpointProposalsForSlot: AztecAsyncMultiMap<number, string>;
+  // Checkpoint proposals from slot number to serialized CheckpointProposal.
+  // Stores the first proposal seen per slot.
+  private checkpointProposalPerSlot: AztecAsyncMap<number, Buffer>;
 
-  // Block proposals from proposal archive to serialized BlockProposal
-  private blockProposals: AztecAsyncMap<string, Buffer>;
+  // Distinct payload hashes seen per slot. Hash collision = duplicate.
+  // Hash count reaching 2 = equivocation.
+  // Key: slot number, Value: CheckpointProposalHash (`0x`-prefixed hex)
+  private checkpointProposalHashesPerSlot: AztecAsyncMultiMap<number, CheckpointProposalHash>;
 
-  // Block proposals indexed by slot and index-within-checkpoint for duplicate detection
-  // Key: (slot << 10) | indexWithinCheckpoint, Value: archive string
-  private blockProposalsForSlotAndIndex: AztecAsyncMultiMap<number, string>;
+  // Block proposals from positionKey to serialized BlockProposal.
+  // Stores the first proposal seen per (slot, indexWithinCheckpoint).
+  private blockProposalPerSlotAndIndex: AztecAsyncMap<number, Buffer>;
 
-  // Checkpoint attestations indexed by (slot, signer) for tracking attestations per (slot, signer) for duplicate detection
-  // Key: `${Fr(slot).toString()}-${signerAddress}` string (padded for lexicographic ordering), Value: `proposalId` strings
-  private checkpointAttestationsPerSlotAndSigner: AztecAsyncMultiMap<string, string>;
+  // Distinct payload hashes seen per (slot, indexWithinCheckpoint).
+  // Key: slot * (1 << INDEX_BITS) + indexWithinCheckpoint, Value: BlockProposalHash (`0x`-prefixed hex)
+  private blockProposalHashesPerSlotAndIndex: AztecAsyncMultiMap<number, BlockProposalHash>;
+
+  // Secondary index from archive root to positionKey, so that the block-txs req/resp
+  // handler can still resolve a stored proposal by archive root.
+  private blockProposalSlotAndIndexPerArchive: AztecAsyncMap<string, number>;
 
   constructor(
     private store: AztecAsyncKVStore,
@@ -84,75 +98,64 @@ export class AttestationPool {
     private log = createLogger('aztec:attestation_pool'),
   ) {
     // Initialize block proposal storage
-    this.blockProposals = store.openMap('proposals');
-    this.blockProposalsForSlotAndIndex = store.openMultiMap('block_proposals_for_slot_and_index');
+    this.blockProposalPerSlotAndIndex = store.openMap('proposals');
+    this.blockProposalHashesPerSlotAndIndex = store.openMultiMap('block_proposals_for_slot_and_index');
+    this.blockProposalSlotAndIndexPerArchive = store.openMap('block_proposals_by_archive');
 
     // Initialize checkpoint attestations storage
-    this.checkpointAttestations = store.openMap('checkpoint_attestations');
-    this.checkpointAttestationsPerSlotAndSigner = store.openMultiMap('checkpoint_attestations_per_slot_and_signer');
+    this.attestationPerSlotAndSigner = store.openMap('checkpoint_attestations');
+    this.attestationHashesPerSlotAndSigner = store.openMultiMap('checkpoint_attestations_per_slot_and_signer');
 
     // Initialize checkpoint proposal storage
-    this.checkpointProposals = store.openMap('checkpoint_proposals');
-    this.checkpointProposalsForSlot = store.openMultiMap('checkpoint_proposals_for_slot');
+    this.checkpointProposalPerSlot = store.openMap('checkpoint_proposals');
+    this.checkpointProposalHashesPerSlot = store.openMultiMap('checkpoint_proposals_for_slot');
 
     this.metrics = new PoolInstrumentation(telemetry, PoolName.ATTESTATION_POOL, this.poolStats);
   }
 
   private poolStats: PoolStatsCallback = async () => {
     return {
-      itemCount: await this.checkpointAttestations.sizeAsync(),
+      itemCount: await this.attestationPerSlotAndSigner.sizeAsync(),
     };
   };
 
   /** Returns whether the pool is empty. */
   public async isEmpty(): Promise<boolean> {
-    for await (const _ of this.checkpointAttestations.entriesAsync()) {
+    for await (const _ of this.attestationPerSlotAndSigner.entriesAsync()) {
       return false;
     }
-    for await (const _ of this.blockProposals.entriesAsync()) {
+    for await (const _ of this.blockProposalPerSlotAndIndex.entriesAsync()) {
       return false;
     }
     return true;
-  }
-
-  private getProposalKey(slot: number | bigint | Fr | string, proposalId: Fr | string | Buffer): string {
-    const slotStr = typeof slot === 'string' ? slot : new Fr(slot).toString();
-    const proposalIdStr =
-      typeof proposalId === 'string'
-        ? proposalId
-        : Buffer.isBuffer(proposalId)
-          ? Fr.fromBuffer(proposalId).toString()
-          : proposalId.toString();
-
-    return `${slotStr}-${proposalIdStr}`;
-  }
-
-  private getAttestationKey(slot: number | bigint | Fr | string, proposalId: Fr | string, address: string): string {
-    return `${this.getProposalKey(slot, proposalId)}-${address}`;
-  }
-
-  /** Returns range bounds for querying all attestations for a given slot. */
-  private getAttestationKeyRangeForSlot(slot: SlotNumber): { start: string; end: string } {
-    const slotStr = new Fr(slot).toString();
-    return { start: `${slotStr}-`, end: `${slotStr}-Z` }; // 'Z' sorts after any hex character
-  }
-
-  /** Returns range bounds for querying all attestations for a given (slot, proposalId). */
-  private getAttestationKeyRangeForProposal(slot: SlotNumber, proposalId: string): { start: string; end: string } {
-    const proposalKey = this.getProposalKey(slot, proposalId);
-    return { start: `${proposalKey}-`, end: `${proposalKey}-Z` };
-  }
-
-  /** Creates a key for the per-signer-per-slot attestation index. Uses padded slot for lexicographic ordering. */
-  private getSlotSignerKey(slot: SlotNumber, signerAddress: string): string {
-    const slotStr = new Fr(slot).toString();
-    return `${slotStr}-${signerAddress}`;
   }
 
   /** Number of bits reserved for indexWithinCheckpoint in position keys. */
   private static readonly INDEX_BITS = 10;
   /** Maximum indexWithinCheckpoint value (2^10 - 1 = 1023). */
   private static readonly MAX_INDEX = (1 << AttestationPool.INDEX_BITS) - 1;
+  /** Decimal digits used to left-pad slot numbers in string keys.
+   * 10 digits ≈ 3500 years at 36 s/slot, leaving ample headroom. */
+  private static readonly SLOT_PAD_DIGITS = 10;
+
+  /** Fixed-width decimal slot string for use in composite string keys. */
+  private slotPaddedKey(slot: SlotNumber | number): string {
+    return slot.toString().padStart(AttestationPool.SLOT_PAD_DIGITS, '0');
+  }
+
+  /** Key for the per-(slot, signer) attestation main store and equivocation index. */
+  private getSlotSignerKey(slot: SlotNumber, signerAddress: string): string {
+    return `${this.slotPaddedKey(slot)}-${signerAddress}`;
+  }
+
+  /**
+   * Returns range bounds for querying all attestations for a given slot.
+   * Fixed-width padding ensures the slot prefix sorts cleanly, so using the next
+   * slot's prefix as the upper bound captures exactly the current slot's entries.
+   */
+  private getAttestationKeyRangeForSlot(slot: SlotNumber): { start: string; end: string } {
+    return { start: `${this.slotPaddedKey(slot)}-`, end: `${this.slotPaddedKey(slot + 1)}-` };
+  }
 
   /** Creates a position key for block proposals: slot * 1024 + indexWithinCheckpoint.
    * Uses multiplication instead of bit-shift to avoid 32-bit signed integer overflow
@@ -166,50 +169,64 @@ export class AttestationPool {
     return slot * (1 << AttestationPool.INDEX_BITS) + indexWithinCheckpoint;
   }
 
+  /** Returns true if the multimap already contains the given value for the given key. */
+  private async multimapHasValue<TKey extends number | string, TValue extends string>(
+    map: AztecAsyncMultiMap<TKey, TValue>,
+    key: TKey,
+    value: TValue,
+  ): Promise<boolean> {
+    const values = await toArray(map.getValuesAsync(key));
+    return values.includes(value);
+  }
+
   /**
    * Attempts to add a block proposal to the pool.
    *
-   * This method performs validation and addition in a single call:
-   * - Checks if the proposal already exists (returns alreadyExists: true if so)
-   * - Checks if the position has reached the proposal cap (returns added: false if so)
-   * - Adds the proposal if validation passes
+   * - Detects duplicates by signed-payload hash (not archive); a re-broadcast of the
+   *   exact same signed payload returns `alreadyExists: true`.
+   * - Distinct payload hashes at the same `(slot, indexWithinCheckpoint)` are tracked
+   *   in the equivocation index. The first hash also stores the proposal bytes; later
+   *   distinct hashes only bump `count` so libp2p can fire its duplicate callback.
    *
    * @param blockProposal - The block proposal to add
    * @returns Result indicating whether the proposal was added and duplicate detection info
    */
   public async tryAddBlockProposal(blockProposal: BlockProposal): Promise<TryAddResult> {
     return await this.store.transactionAsync(async () => {
-      const proposalId = blockProposal.archive.toString();
+      const positionKey = this.getBlockPositionKey(blockProposal.slotNumber, blockProposal.indexWithinCheckpoint);
+      const payloadHash = blockProposal.getPayloadHash();
 
-      // Check if already exists
-      const alreadyExists = await this.blockProposals.hasAsync(proposalId);
-      if (alreadyExists) {
-        const count = await this.getBlockProposalCountForPosition(
-          blockProposal.slotNumber,
-          blockProposal.indexWithinCheckpoint,
-        );
+      // Hash already tracked => exact same signed payload was already received.
+      if (await this.multimapHasValue(this.blockProposalHashesPerSlotAndIndex, positionKey, payloadHash)) {
+        const count = await this.blockProposalHashesPerSlotAndIndex.getValueCountAsync(positionKey);
         return { added: false, alreadyExists: true, count };
       }
 
-      // Get current count for position and check cap, do not add if exceeded
-      const count = await this.getBlockProposalCountForPosition(
-        blockProposal.slotNumber,
-        blockProposal.indexWithinCheckpoint,
-      );
-
+      // Cap reached for this position (no more new payload hashes accepted).
+      const count = await this.blockProposalHashesPerSlotAndIndex.getValueCountAsync(positionKey);
       if (count >= MAX_BLOCK_PROPOSALS_PER_POSITION) {
         return { added: false, alreadyExists: false, count };
       }
 
-      // Add the proposal
-      await this.addBlockProposal(blockProposal);
+      // Track the new payload hash for equivocation detection.
+      await this.blockProposalHashesPerSlotAndIndex.set(positionKey, payloadHash);
+
+      // Only the first distinct payload at this position is stored; later equivocations
+      // are detected via the multimap but their payload bytes are not retained.
+      const alreadyHasStored = await this.blockProposalPerSlotAndIndex.hasAsync(positionKey);
+      if (!alreadyHasStored) {
+        await this.blockProposalPerSlotAndIndex.set(positionKey, blockProposal.withoutSignedTxs().toBuffer());
+        await this.blockProposalSlotAndIndexPerArchive.set(blockProposal.archive.toString(), positionKey);
+      }
 
       this.log.debug(
         `Added block proposal for slot ${blockProposal.slotNumber} and index ${blockProposal.indexWithinCheckpoint}`,
         {
-          proposalId,
+          archive: blockProposal.archive.toString(),
+          payloadHash,
           slotNumber: blockProposal.slotNumber,
           indexWithinCheckpoint: blockProposal.indexWithinCheckpoint,
+          stored: !alreadyHasStored,
         },
       );
 
@@ -217,60 +234,60 @@ export class AttestationPool {
     });
   }
 
-  /** Gets the count of block proposals for a given position (slot, indexWithinCheckpoint). */
-  private getBlockProposalCountForPosition(
-    slot: SlotNumber,
-    indexWithinCheckpoint: IndexWithinCheckpoint,
-  ): Promise<number> {
-    const positionKey = this.getBlockPositionKey(slot, indexWithinCheckpoint);
-    return this.blockProposalsForSlotAndIndex.getValueCountAsync(positionKey);
-  }
-
-  /** Internal method - must be called within a transaction. */
-  private async addBlockProposal(blockProposal: BlockProposal): Promise<void> {
-    const proposalId = blockProposal.archive.toString();
-    // Strip signedTxs before storing to avoid persisting full tx data
-    await this.blockProposals.set(proposalId, blockProposal.withoutSignedTxs().toBuffer());
-
-    // Index by slot and position for duplicate detection
-    const positionKey = this.getBlockPositionKey(blockProposal.slotNumber, blockProposal.indexWithinCheckpoint);
-    await this.blockProposalsForSlotAndIndex.set(positionKey, proposalId);
-  }
-
   /**
-   * Get block proposal by its ID.
+   * Get block proposal by archive root.
    *
-   * @param id - The ID of the block proposal to retrieve. The ID is proposal.payload.archive
+   * Resolves the archive root to its `(slot, indexWithinCheckpoint)` via a secondary
+   * index, then fetches the stored proposal (if any). Returns the *first* proposal
+   * seen at that position, even if a later equivocating payload was tracked.
+   * Validates that the stored proposal's archive matches the requested one before
+   * returning, guarding against secondary-index corruption or position-key reuse.
    *
-   * @return The block proposal if it exists, otherwise undefined.
+   * @param archiveRoot - The archive root to look up
+   * @return The block proposal if it exists and its archive matches, otherwise undefined.
    */
-  public async getBlockProposal(id: string): Promise<BlockProposal | undefined> {
-    const buffer = await this.blockProposals.getAsync(id);
+  public async getBlockProposalByArchive(archiveRoot: string): Promise<BlockProposal | undefined> {
+    const positionKey = await this.blockProposalSlotAndIndexPerArchive.getAsync(archiveRoot);
+    if (positionKey === undefined) {
+      return undefined;
+    }
+    const buffer = await this.blockProposalPerSlotAndIndex.getAsync(positionKey);
+    if (!buffer || buffer.length === 0) {
+      return undefined;
+    }
+    let proposal: BlockProposal;
     try {
-      if (buffer && buffer.length > 0) {
-        return BlockProposal.fromBuffer(buffer);
-      }
+      proposal = BlockProposal.fromBuffer(buffer);
     } catch {
       return undefined;
     }
-
-    return undefined;
+    const storedArchive = proposal.archive.toString();
+    if (storedArchive !== archiveRoot) {
+      this.log.warn(`Stored block proposal archive does not match requested archive root`, {
+        requestedArchive: archiveRoot,
+        storedArchive,
+        positionKey,
+      });
+      return undefined;
+    }
+    return proposal;
   }
 
   /** Checks if any block proposals exist for a given slot (at index 0). */
   public async hasBlockProposalsForSlot(slot: SlotNumber): Promise<boolean> {
     const positionKey = this.getBlockPositionKey(slot, 0);
-    const count = await this.blockProposalsForSlotAndIndex.getValueCountAsync(positionKey);
+    const count = await this.blockProposalHashesPerSlotAndIndex.getValueCountAsync(positionKey);
     return count > 0;
   }
 
   /**
    * Attempts to add a checkpoint proposal to the pool.
    *
-   * This method performs validation and addition in a single call:
-   * - Checks if the proposal already exists (returns alreadyExists: true if so)
-   * - Checks if the slot has reached the proposal cap (returns added: false if so)
-   * - Adds the proposal if validation passes
+   * - Detects duplicates by signed-payload hash (not archive); a re-broadcast of the
+   *   exact same signed payload returns `alreadyExists: true`.
+   * - Distinct payload hashes at the same slot are tracked in the equivocation index.
+   *   Only the first distinct payload's bytes are stored; later distinct hashes bump
+   *   `count` so libp2p can fire its duplicate callback.
    *
    * Note: This method only handles the CheckpointProposalCore. If the original
    * CheckpointProposal contains a lastBlock, the caller should extract it via
@@ -280,56 +297,52 @@ export class AttestationPool {
    * @returns Result indicating whether the proposal was added and duplicate detection info
    */
   public async tryAddCheckpointProposal(proposal: CheckpointProposalCore): Promise<TryAddResult> {
-    const result = await this.store.transactionAsync(async () => {
-      const proposalId = proposal.archive.toString();
+    return await this.store.transactionAsync(async () => {
+      const slot = proposal.slotNumber;
+      const payloadHash = proposal.getPayloadHash();
 
-      // Check if already exists
-      const alreadyExists = await this.checkpointProposals.hasAsync(proposalId);
-      if (alreadyExists) {
-        const count = await this.checkpointProposalsForSlot.getValueCountAsync(proposal.slotNumber);
+      if (await this.multimapHasValue(this.checkpointProposalHashesPerSlot, slot, payloadHash)) {
+        const count = await this.checkpointProposalHashesPerSlot.getValueCountAsync(slot);
         return { added: false, alreadyExists: true, count };
       }
 
-      // Get current count for slot and check cap
-      const count = await this.checkpointProposalsForSlot.getValueCountAsync(proposal.slotNumber);
+      const count = await this.checkpointProposalHashesPerSlot.getValueCountAsync(slot);
       if (count >= MAX_CHECKPOINT_PROPOSALS_PER_SLOT) {
         return { added: false, alreadyExists: false, count };
       }
 
-      // Add the proposal if cap not exceeded
-      await this.addCheckpointProposal(proposal);
+      // Track the new payload hash for equivocation detection.
+      await this.checkpointProposalHashesPerSlot.set(slot, payloadHash);
 
-      this.log.debug(`Added checkpoint proposal for slot ${proposal.slotNumber}`, {
-        proposalId,
-        slotNumber: proposal.slotNumber,
+      // Only the first distinct payload at this slot is stored; later equivocations
+      // are detected via the multimap but their payload bytes are not retained.
+      const alreadyHasStored = await this.checkpointProposalPerSlot.hasAsync(slot);
+      if (!alreadyHasStored) {
+        await this.checkpointProposalPerSlot.set(slot, proposal.toBuffer());
+      }
+
+      this.log.debug(`Added checkpoint proposal for slot ${slot}`, {
+        archive: proposal.archive.toString(),
+        payloadHash,
+        slotNumber: slot,
+        stored: !alreadyHasStored,
       });
 
       return { added: true, alreadyExists: false, count: count + 1 };
     });
-
-    return result;
-  }
-
-  /** Internal method - must be called within a transaction. */
-  private async addCheckpointProposal(proposal: CheckpointProposalCore): Promise<void> {
-    const slotKey = proposal.slotNumber;
-    const proposalId = proposal.archive.toString();
-
-    await this.checkpointProposalsForSlot.set(slotKey, proposalId);
-    await this.checkpointProposals.set(proposalId, proposal.toBuffer());
   }
 
   /**
-   * Get checkpoint proposal by its ID.
+   * Get the (first) checkpoint proposal stored for the given slot.
    *
    * Returns a CheckpointProposalCore (without lastBlock info) since the lastBlock
    * is extracted and stored separately as a BlockProposal when added.
    *
-   * @param id - The ID of the checkpoint proposal to retrieve (proposal.archive)
-   * @return The checkpoint proposal core if it exists, otherwise undefined.
+   * @param slot - The slot to look up
+   * @return The checkpoint proposal core if one is stored, otherwise undefined.
    */
-  public async getCheckpointProposal(id: string): Promise<CheckpointProposalCore | undefined> {
-    const buffer = await this.checkpointProposals.getAsync(id);
+  public async getCheckpointProposal(slot: SlotNumber): Promise<CheckpointProposalCore | undefined> {
+    const buffer = await this.checkpointProposalPerSlot.getAsync(slot);
     try {
       if (buffer && buffer.length > 0) {
         return CheckpointProposal.fromBuffer(buffer);
@@ -343,13 +356,13 @@ export class AttestationPool {
 
   /**
    * Adds own checkpoint attestations to the pool.
-   * Skips validations on number of checkpoint attestations stored for the given slot.
+   * Skips per-signer cap and equivocation tracking; the caller is trusted.
+   * Each (slot, signer) gets a single stored attestation; later additions overwrite.
    */
   public async addOwnCheckpointAttestations(attestations: CheckpointAttestation[]): Promise<void> {
     await this.store.transactionAsync(async () => {
       for (const attestation of attestations) {
         const slotNumber = attestation.payload.header.slotNumber;
-        const proposalId = attestation.archive.toString();
         const sender = attestation.getSender();
 
         // Skip attestations with invalid signatures
@@ -357,22 +370,30 @@ export class AttestationPool {
           this.log.warn(`Skipping own checkpoint attestation with invalid signature for slot ${slotNumber}`, {
             signature: attestation.signature.toString(),
             slotNumber,
-            proposalId,
+            archive: attestation.archive.toString(),
           });
           continue;
         }
 
         const address = sender.toString();
-        const ownKey = this.getAttestationKey(slotNumber, proposalId, address);
+        const ownKey = this.getSlotSignerKey(slotNumber, address);
+        const payloadHash = attestation.getPayloadHash();
 
-        await this.checkpointAttestations.set(ownKey, attestation.toBuffer());
+        await this.attestationPerSlotAndSigner.set(ownKey, attestation.toBuffer());
         this.metrics.trackMempoolItemAdded(ownKey);
+
+        // Track our own payload hash so that an equivocating attestation from another
+        // peer at the same (slot, signer) is detected as a duplicate.
+        if (!(await this.multimapHasValue(this.attestationHashesPerSlotAndSigner, ownKey, payloadHash))) {
+          await this.attestationHashesPerSlotAndSigner.set(ownKey, payloadHash);
+        }
 
         this.log.debug(`Added own checkpoint attestation for slot ${slotNumber} from ${address}`, {
           signature: attestation.signature.toString(),
           slotNumber,
           address,
-          proposalId,
+          archive: attestation.archive.toString(),
+          payloadHash,
         });
       }
     });
@@ -381,6 +402,10 @@ export class AttestationPool {
   /**
    * Get all checkpoint attestations for a given slot.
    *
+   * Returns one attestation per (slot, signer) — the first seen for each signer.
+   * Later equivocating attestations from the same signer are tracked in the index
+   * but their bytes are not retained.
+   *
    * @param slot - The slot to query
    * @return CheckpointAttestations
    */
@@ -388,7 +413,7 @@ export class AttestationPool {
     const range = this.getAttestationKeyRangeForSlot(slot);
     const attestations: CheckpointAttestation[] = [];
 
-    for await (const [_, buf] of this.checkpointAttestations.entriesAsync(range)) {
+    for await (const [_, buf] of this.attestationPerSlotAndSigner.entriesAsync(range)) {
       attestations.push(CheckpointAttestation.fromBuffer(buf));
     }
 
@@ -396,24 +421,19 @@ export class AttestationPool {
   }
 
   /**
-   * Get checkpoint attestations for slot and given proposal.
+   * Get checkpoint attestations for a slot whose signed payload matches the given
+   * proposal payload hash.
    *
    * @param slot - The slot to query
-   * @param proposalId - The proposal to query
-   * @return CheckpointAttestations
+   * @param proposalPayloadHash - Hex-encoded keccak256 of the target proposal's signed payload
+   * @return CheckpointAttestations whose `getPayloadHash()` matches `proposalPayloadHash`
    */
   public async getCheckpointAttestationsForSlotAndProposal(
     slot: SlotNumber,
-    proposalId: string,
+    proposalPayloadHash: CheckpointProposalHash,
   ): Promise<CheckpointAttestation[]> {
-    const range = this.getAttestationKeyRangeForProposal(slot, proposalId);
-    const attestations: CheckpointAttestation[] = [];
-
-    for await (const [_, buf] of this.checkpointAttestations.entriesAsync(range)) {
-      attestations.push(CheckpointAttestation.fromBuffer(buf));
-    }
-
-    return attestations;
+    const all = await this.getCheckpointAttestationsForSlot(slot);
+    return all.filter(att => att.getPayloadHash() === proposalPayloadHash);
   }
 
   /**
@@ -427,43 +447,46 @@ export class AttestationPool {
     let numberOfBlockProposals = 0;
 
     await this.store.transactionAsync(async () => {
-      // Delete checkpoint attestations with slot < oldestSlot
-      // Attestation keys start with Fr(slot).toString(), so we use end bound of Fr(oldestSlot).toString()
-      const attestationEndKey = new Fr(oldestSlot).toString();
-      for await (const key of this.checkpointAttestations.keysAsync({ end: attestationEndKey })) {
-        await this.checkpointAttestations.delete(key);
+      const oldestSlotPadded = this.slotPaddedKey(oldestSlot);
+
+      // Delete checkpoint attestations whose key < `${oldestSlotPadded}-`. Fixed-width
+      // decimal padding means the slot prefix sorts strictly before any key at that slot.
+      for await (const key of this.attestationPerSlotAndSigner.keysAsync({ end: `${oldestSlotPadded}-` })) {
+        await this.attestationPerSlotAndSigner.delete(key);
         this.metrics.trackMempoolItemRemoved(key);
         numberOfAttestations++;
       }
 
-      // Clean up per-signer-per-slot index. Keys are formatted as `${Fr(slot).toString()}-${signerAddress}`.
-      // Since Fr pads to fixed-width hex, Fr(oldestSlot) is lexicographically greater than any key with
-      // a smaller slot (even with the signer suffix), so using it as the exclusive end bound is correct.
-      const slotSignerEndKey = new Fr(oldestSlot).toString();
-      for await (const key of this.checkpointAttestationsPerSlotAndSigner.keysAsync({ end: slotSignerEndKey })) {
-        await this.checkpointAttestationsPerSlotAndSigner.delete(key);
+      // Clean up per-signer-per-slot index using the same end bound.
+      for await (const key of this.attestationHashesPerSlotAndSigner.keysAsync({ end: `${oldestSlotPadded}-` })) {
+        await this.attestationHashesPerSlotAndSigner.delete(key);
       }
 
-      // Delete checkpoint proposals for slots < oldestSlot, using checkpointProposalsForSlot as index
-      for await (const slot of this.checkpointProposalsForSlot.keysAsync({ end: oldestSlot })) {
-        const proposalIds = await toArray(this.checkpointProposalsForSlot.getValuesAsync(slot));
-        for (const proposalId of proposalIds) {
-          await this.checkpointProposals.delete(proposalId);
+      // Delete checkpoint proposals for slots < oldestSlot.
+      for await (const slot of this.checkpointProposalHashesPerSlot.keysAsync({ end: oldestSlot })) {
+        await this.checkpointProposalHashesPerSlot.delete(slot);
+        if (await this.checkpointProposalPerSlot.hasAsync(slot)) {
+          await this.checkpointProposalPerSlot.delete(slot);
           numberOfCheckpointProposals++;
         }
-        await this.checkpointProposalsForSlot.delete(slot);
       }
 
-      // Delete block proposals for slots < oldestSlot, using blockProposalsForSlotAndIndex as index
-      // Key format: (slot << INDEX_BITS) | indexWithinCheckpoint
+      // Delete block proposals for slots < oldestSlot, using blockProposalHashesPerSlotAndIndex as index.
+      // Key format: slot * (1 << INDEX_BITS) + indexWithinCheckpoint
       const blockPositionEndKey = oldestSlot * (1 << AttestationPool.INDEX_BITS);
-      for await (const positionKey of this.blockProposalsForSlotAndIndex.keysAsync({ end: blockPositionEndKey })) {
-        const proposalIds = await toArray(this.blockProposalsForSlotAndIndex.getValuesAsync(positionKey));
-        for (const proposalId of proposalIds) {
-          await this.blockProposals.delete(proposalId);
+      for await (const positionKey of this.blockProposalHashesPerSlotAndIndex.keysAsync({ end: blockPositionEndKey })) {
+        await this.blockProposalHashesPerSlotAndIndex.delete(positionKey);
+        const stored = await this.blockProposalPerSlotAndIndex.getAsync(positionKey);
+        if (stored) {
+          try {
+            const proposal = BlockProposal.fromBuffer(stored);
+            await this.blockProposalSlotAndIndexPerArchive.delete(proposal.archive.toString());
+          } catch {
+            // ignore decode errors when cleaning up
+          }
+          await this.blockProposalPerSlotAndIndex.delete(positionKey);
           numberOfBlockProposals++;
         }
-        await this.blockProposalsForSlotAndIndex.delete(positionKey);
       }
     });
 
@@ -478,18 +501,19 @@ export class AttestationPool {
   /**
    * Attempts to add a checkpoint attestation to the pool.
    *
-   * This method performs validation and addition in a single call:
-   * - Checks if the attestation already exists (returns alreadyExists: true if so)
-   * - Checks if this signer has reached the per-signer attestation cap for this slot
-   * - Adds the attestation if validation passes
+   * - Detects duplicates by signed-payload hash (not archive); a re-broadcast of the
+   *   exact same signed payload from the same signer returns `alreadyExists: true`.
+   * - Distinct payload hashes from the same (slot, signer) are tracked in the
+   *   equivocation index. The first one's bytes are stored; later distinct hashes
+   *   bump `count` so libp2p can fire its duplicate callback.
    *
    * @param attestation - The checkpoint attestation to add
-   * @returns Result indicating whether the attestation was added, existence info, and count of
-   *          attestations by this signer for this slot (for equivocation detection)
+   * @returns Result indicating whether the attestation was added, existence info,
+   *          and number of distinct payload hashes by this signer for this slot
+   *          (for equivocation detection).
    */
   public async tryAddCheckpointAttestation(attestation: CheckpointAttestation): Promise<TryAddResult> {
     const slotNumber = attestation.payload.header.slotNumber;
-    const proposalId = attestation.archive.toString();
     const sender = attestation.getSender();
 
     if (!sender) {
@@ -497,28 +521,23 @@ export class AttestationPool {
     }
 
     const signerAddress = sender.toString();
+    const slotSignerKey = this.getSlotSignerKey(slotNumber, signerAddress);
+    const payloadHash = attestation.getPayloadHash();
 
     return await this.store.transactionAsync(async () => {
-      const key = this.getAttestationKey(slotNumber, proposalId, signerAddress);
-      const alreadyExists = await this.checkpointAttestations.hasAsync(key);
-
-      // Get count of attestations by this signer for this slot (for duplicate detection)
-      const signerAttestationCount = await this.getSignerAttestationCountForSlot(slotNumber, signerAddress);
-
-      if (alreadyExists) {
-        return {
-          added: false,
-          alreadyExists: true,
-          count: signerAttestationCount,
-        };
+      if (await this.multimapHasValue(this.attestationHashesPerSlotAndSigner, slotSignerKey, payloadHash)) {
+        const count = await this.attestationHashesPerSlotAndSigner.getValueCountAsync(slotSignerKey);
+        return { added: false, alreadyExists: true, count };
       }
 
-      // Check if this signer has exceeded the per-signer cap for this slot
+      const signerAttestationCount = await this.attestationHashesPerSlotAndSigner.getValueCountAsync(slotSignerKey);
+
       if (signerAttestationCount >= MAX_ATTESTATIONS_PER_SLOT_AND_SIGNER) {
         this.log.debug(`Rejecting attestation: signer ${signerAddress} exceeded per-slot cap for slot ${slotNumber}`, {
           slotNumber,
           signerAddress,
-          proposalId,
+          archive: attestation.archive.toString(),
+          payloadHash,
           signerAttestationCount,
         });
         return {
@@ -528,34 +547,32 @@ export class AttestationPool {
         };
       }
 
-      // Add the attestation
-      await this.checkpointAttestations.set(key, attestation.toBuffer());
-      this.metrics.trackMempoolItemAdded(key);
+      // Track the new payload hash for equivocation detection.
+      await this.attestationHashesPerSlotAndSigner.set(slotSignerKey, payloadHash);
 
-      // Track this attestation in the per-signer-per-slot index for duplicate detection
-      const slotSignerKey = this.getSlotSignerKey(slotNumber, signerAddress);
-      await this.checkpointAttestationsPerSlotAndSigner.set(slotSignerKey, proposalId);
+      // Only the first distinct payload at (slot, signer) is stored; later
+      // equivocations are detected via the multimap but their bytes are not retained.
+      const alreadyHasStored = await this.attestationPerSlotAndSigner.hasAsync(slotSignerKey);
+      if (!alreadyHasStored) {
+        await this.attestationPerSlotAndSigner.set(slotSignerKey, attestation.toBuffer());
+        this.metrics.trackMempoolItemAdded(slotSignerKey);
+      }
 
       this.log.debug(`Added checkpoint attestation for slot ${slotNumber} from ${signerAddress}`, {
         signature: attestation.signature.toString(),
         slotNumber,
         address: signerAddress,
-        proposalId,
+        archive: attestation.archive.toString(),
+        payloadHash,
+        stored: !alreadyHasStored,
       });
 
-      // Return the new count
       return {
         added: true,
         alreadyExists: false,
         count: signerAttestationCount + 1,
       };
     });
-  }
-
-  /** Gets the count of attestations by a specific signer for a given slot. */
-  private async getSignerAttestationCountForSlot(slot: SlotNumber, signerAddress: string): Promise<number> {
-    const slotSignerKey = this.getSlotSignerKey(slot, signerAddress);
-    return await this.checkpointAttestationsPerSlotAndSigner.getValueCountAsync(slotSignerKey);
   }
 }
 

--- a/yarn-project/p2p/src/mem_pools/attestation_pool/attestation_pool_test_suite.ts
+++ b/yarn-project/p2p/src/mem_pools/attestation_pool/attestation_pool_test_suite.ts
@@ -28,9 +28,16 @@ export function describeAttestationPool(getAttestationPool: () => AttestationPoo
     signers = Array.from({ length: NUMBER_OF_SIGNERS_PER_TEST }, () => Secp256k1Signer.random());
   });
 
+  /**
+   * Build attestations from each signer over the *same* signed payload (same header,
+   * archive, feeAssetPriceModifier). Required by the new pool, which deduplicates by
+   * payload hash and treats attestations from different signers as distinct entries
+   * only when the payload itself matches.
+   */
   const createCheckpointAttestationsForSlot = (slotNumber: number, archive?: Fr) => {
     const archiveToUse = archive ?? Fr.random();
-    return signers.map(signer => mockCheckpointAttestation(signer, slotNumber, archiveToUse));
+    const sharedHeader = CheckpointHeader.random({ slotNumber: SlotNumber(slotNumber) });
+    return signers.map(signer => mockCheckpointAttestation(signer, slotNumber, archiveToUse, sharedHeader));
   };
 
   const mockBlockProposalForPool = (
@@ -59,13 +66,17 @@ export function describeAttestationPool(getAttestationPool: () => AttestationPoo
     it('should add attestations to pool', async () => {
       const slotNumber = 420;
       const archive = Fr.random();
-      const attestations = signers.slice(0, -1).map(signer => mockCheckpointAttestation(signer, slotNumber, archive));
+      const sharedHeader = CheckpointHeader.random({ slotNumber: SlotNumber(slotNumber) });
+      const attestations = signers
+        .slice(0, -1)
+        .map(signer => mockCheckpointAttestation(signer, slotNumber, archive, sharedHeader));
+      const payloadHash = attestations[0].getPayloadHash();
 
       await ap.addOwnCheckpointAttestations(attestations);
 
       const retrievedAttestations = await ap.getCheckpointAttestationsForSlotAndProposal(
         SlotNumber(slotNumber),
-        archive.toString(),
+        payloadHash,
       );
       expect(retrievedAttestations.length).toBe(attestations.length);
       compareCheckpointAttestations(retrievedAttestations, attestations);
@@ -75,11 +86,16 @@ export function describeAttestationPool(getAttestationPool: () => AttestationPoo
       compareCheckpointAttestations(retrievedAttestationsForSlot, attestations);
 
       // Add another one
-      const newAttestation = mockCheckpointAttestation(signers[NUMBER_OF_SIGNERS_PER_TEST - 1], slotNumber, archive);
+      const newAttestation = mockCheckpointAttestation(
+        signers[NUMBER_OF_SIGNERS_PER_TEST - 1],
+        slotNumber,
+        archive,
+        sharedHeader,
+      );
       await ap.addOwnCheckpointAttestations([newAttestation]);
       const retrievedAttestationsAfterAdd = await ap.getCheckpointAttestationsForSlotAndProposal(
         SlotNumber(slotNumber),
-        archive.toString(),
+        payloadHash,
       );
       expect(retrievedAttestationsAfterAdd.length).toBe(attestations.length + 1);
       compareCheckpointAttestations(retrievedAttestationsAfterAdd, [...attestations, newAttestation]);
@@ -92,7 +108,7 @@ export function describeAttestationPool(getAttestationPool: () => AttestationPoo
 
       const retreivedAttestationsAfterDelete = await ap.getCheckpointAttestationsForSlotAndProposal(
         SlotNumber(slotNumber),
-        archive.toString(),
+        payloadHash,
       );
       expect(retreivedAttestationsAfterDelete.length).toBe(0);
     });
@@ -108,13 +124,14 @@ export function describeAttestationPool(getAttestationPool: () => AttestationPoo
       for (let i = 0; i < NUMBER_OF_SIGNERS_PER_TEST; i++) {
         attestations.push(mockCheckpointAttestation(signer, slotNumber, archive, header));
       }
+      const payloadHash = attestations[0].getPayloadHash();
 
       // Add them to store and check we end up with only one
       await ap.addOwnCheckpointAttestations(attestations);
 
       const retreivedAttestations = await ap.getCheckpointAttestationsForSlotAndProposal(
         SlotNumber(slotNumber),
-        archive.toString(),
+        payloadHash,
       );
       expect(retreivedAttestations.length).toBe(1);
       expect(retreivedAttestations[0].toBuffer()).toEqual(attestations[0].toBuffer());
@@ -122,9 +139,7 @@ export function describeAttestationPool(getAttestationPool: () => AttestationPoo
 
       // Try adding them on another operation and check they are still not duplicated
       await ap.addOwnCheckpointAttestations([attestations[0]]);
-      expect(
-        await ap.getCheckpointAttestationsForSlotAndProposal(SlotNumber(slotNumber), archive.toString()),
-      ).toHaveLength(1);
+      expect(await ap.getCheckpointAttestationsForSlotAndProposal(SlotNumber(slotNumber), payloadHash)).toHaveLength(1);
     });
 
     it('should store attestations by differing slot', async () => {
@@ -135,9 +150,9 @@ export function describeAttestationPool(getAttestationPool: () => AttestationPoo
 
       for (const attestation of attestations) {
         const slot = attestation.payload.header.slotNumber;
-        const archive = attestation.archive.toString();
+        const payloadHash = attestation.getPayloadHash();
 
-        const retreivedAttestations = await ap.getCheckpointAttestationsForSlotAndProposal(slot, archive);
+        const retreivedAttestations = await ap.getCheckpointAttestationsForSlotAndProposal(slot, payloadHash);
         expect(retreivedAttestations.length).toBe(1);
         expect(retreivedAttestations[0].toBuffer()).toEqual(attestation.toBuffer());
         expect(retreivedAttestations[0].payload.header.slotNumber).toEqual(slot);
@@ -153,9 +168,9 @@ export function describeAttestationPool(getAttestationPool: () => AttestationPoo
 
       for (const attestation of attestations) {
         const slot = attestation.payload.header.slotNumber;
-        const proposalId = attestation.archive.toString();
+        const payloadHash = attestation.getPayloadHash();
 
-        const retreivedAttestations = await ap.getCheckpointAttestationsForSlotAndProposal(slot, proposalId);
+        const retreivedAttestations = await ap.getCheckpointAttestationsForSlotAndProposal(slot, payloadHash);
         expect(retreivedAttestations.length).toBe(1);
         expect(retreivedAttestations[0].toBuffer()).toEqual(attestation.toBuffer());
         expect(retreivedAttestations[0].payload.header.slotNumber).toEqual(slot);
@@ -164,21 +179,25 @@ export function describeAttestationPool(getAttestationPool: () => AttestationPoo
 
     it('should delete attestations older than a given slot', async () => {
       const slotNumbers = [1, 2, 3, 69, 72, 74, 88, 420];
-      const attestations = (
-        await Promise.all(slotNumbers.map(slotNumber => createCheckpointAttestationsForSlot(slotNumber)))
-      ).flat();
-      const proposalId = attestations[0].archive.toString();
+      const attestationsPerSlot = await Promise.all(
+        slotNumbers.map(slotNumber => createCheckpointAttestationsForSlot(slotNumber)),
+      );
+      const attestations = attestationsPerSlot.flat();
+      const payloadHashForSlot1 = attestationsPerSlot[0][0].getPayloadHash();
 
       await ap.addOwnCheckpointAttestations(attestations);
 
-      const attestationsForSlot1 = await ap.getCheckpointAttestationsForSlotAndProposal(SlotNumber(1), proposalId);
+      const attestationsForSlot1 = await ap.getCheckpointAttestationsForSlotAndProposal(
+        SlotNumber(1),
+        payloadHashForSlot1,
+      );
       expect(attestationsForSlot1.length).toBe(signers.length);
 
       await ap.deleteOlderThan(SlotNumber(73));
 
       const attestationsForSlot1AfterDelete = await ap.getCheckpointAttestationsForSlotAndProposal(
         SlotNumber(1),
-        proposalId,
+        payloadHashForSlot1,
       );
       expect(attestationsForSlot1AfterDelete.length).toBe(0);
     });
@@ -189,7 +208,6 @@ export function describeAttestationPool(getAttestationPool: () => AttestationPoo
       const slotNumber = 420;
       const archive = Fr.random();
       const proposal = await mockBlockProposalForPool(signers[0], slotNumber, archive);
-      const proposalId = proposal.archive.toString();
 
       const result = await ap.tryAddBlockProposal(proposal);
 
@@ -197,7 +215,7 @@ export function describeAttestationPool(getAttestationPool: () => AttestationPoo
       expect(result.alreadyExists).toBe(false);
       expect(result.count).toBe(1);
 
-      const retrievedProposal = await ap.getBlockProposal(proposalId);
+      const retrievedProposal = await ap.getBlockProposalByArchive(proposal.archive.toString());
 
       expect(retrievedProposal).toBeDefined();
       expect(retrievedProposal!).toEqual(proposal);
@@ -205,31 +223,27 @@ export function describeAttestationPool(getAttestationPool: () => AttestationPoo
 
     it('should return undefined for non-existent block proposal', async () => {
       const nonExistentId = Fr.random().toString();
-      const retrievedProposal = await ap.getBlockProposal(nonExistentId);
+      const retrievedProposal = await ap.getBlockProposalByArchive(nonExistentId);
       expect(retrievedProposal).toBeUndefined();
     });
 
-    it('should return alreadyExists when adding proposal with same id', async () => {
+    it('should return alreadyExists when re-adding the same signed payload', async () => {
       const slotNumber = 420;
       const archive = Fr.random();
-      const proposal1 = await mockBlockProposalForPool(signers[0], slotNumber, archive);
-      const proposalId = proposal1.archive.toString();
+      const proposal = await mockBlockProposalForPool(signers[0], slotNumber, archive);
 
-      const result1 = await ap.tryAddBlockProposal(proposal1);
+      const result1 = await ap.tryAddBlockProposal(proposal);
       expect(result1.added).toBe(true);
       expect(result1.alreadyExists).toBe(false);
 
-      // Create a new proposal with same archive but different signer
-      const proposal2 = await mockBlockProposalForPool(signers[1], slotNumber, archive);
-
-      const result2 = await ap.tryAddBlockProposal(proposal2);
+      // Re-broadcasting the exact same proposal yields alreadyExists.
+      const result2 = await ap.tryAddBlockProposal(proposal);
       expect(result2.added).toBe(false);
       expect(result2.alreadyExists).toBe(true);
 
-      // Should still have the first proposal
-      const retrievedProposal = await ap.getBlockProposal(proposalId);
+      const retrievedProposal = await ap.getBlockProposalByArchive(proposal.archive.toString());
       expect(retrievedProposal).toBeDefined();
-      expect(retrievedProposal!.toBuffer()).toEqual(proposal1.toBuffer());
+      expect(retrievedProposal!.toBuffer()).toEqual(proposal.toBuffer());
       expect(retrievedProposal!.getSender()?.toString()).toBe(signers[0].address.toString());
     });
   });
@@ -239,12 +253,13 @@ export function describeAttestationPool(getAttestationPool: () => AttestationPoo
       signer: Secp256k1Signer,
       slotNumber: number,
       archive: Fr = Fr.random(),
+      checkpointHeader?: CheckpointHeader,
     ): Promise<CheckpointProposalCore> => {
-      const checkpointHeader = makeCheckpointHeader(1, { slotNumber: SlotNumber(slotNumber) });
+      const headerToUse = checkpointHeader ?? makeCheckpointHeader(1, { slotNumber: SlotNumber(slotNumber) });
       const blockHeader = makeBlockHeader(1);
       const proposal = await makeCheckpointProposal({
         signer,
-        checkpointHeader,
+        checkpointHeader: headerToUse,
         archiveRoot: archive,
         lastBlock: { blockHeader },
       });
@@ -256,7 +271,6 @@ export function describeAttestationPool(getAttestationPool: () => AttestationPoo
       const slotNumber = 420;
       const archive = Fr.random();
       const proposal = await mockCheckpointProposalForPool(signers[0], slotNumber, archive);
-      const proposalId = proposal.archive.toString();
 
       const result = await ap.tryAddCheckpointProposal(proposal);
 
@@ -264,7 +278,7 @@ export function describeAttestationPool(getAttestationPool: () => AttestationPoo
       expect(result.alreadyExists).toBe(false);
       expect(result.count).toBe(1);
 
-      const retrievedProposal = await ap.getCheckpointProposal(proposalId);
+      const retrievedProposal = await ap.getCheckpointProposal(SlotNumber(slotNumber));
 
       expect(retrievedProposal).toBeDefined();
       expect(retrievedProposal!.toBuffer()).toEqual(proposal.toBuffer());
@@ -281,54 +295,100 @@ export function describeAttestationPool(getAttestationPool: () => AttestationPoo
         archiveRoot: archive,
         // No lastBlock
       });
-      const proposalId = proposal.archive.toString();
 
       // Add the checkpoint core - block extraction is now caller responsibility
       await ap.tryAddCheckpointProposal(proposal.toCore());
 
       // The checkpoint proposal should be stored
-      const retrievedCheckpointProposal = await ap.getCheckpointProposal(proposalId);
+      const retrievedCheckpointProposal = await ap.getCheckpointProposal(SlotNumber(slotNumber));
       expect(retrievedCheckpointProposal).toBeDefined();
 
       // No block proposal was extracted (it had none anyway)
-      const retrievedBlockProposal = await ap.getBlockProposal(proposalId);
+      const retrievedBlockProposal = await ap.getBlockProposalByArchive(proposal.archive.toString());
       expect(retrievedBlockProposal).toBeUndefined();
     });
 
     it('should return undefined for non-existent checkpoint proposal', async () => {
-      const nonExistentId = Fr.random().toString();
-      const retrievedProposal = await ap.getCheckpointProposal(nonExistentId);
+      const retrievedProposal = await ap.getCheckpointProposal(SlotNumber(99999));
       expect(retrievedProposal).toBeUndefined();
     });
 
-    it('should return alreadyExists when adding proposal with same id', async () => {
+    it('should return alreadyExists when re-adding the same signed payload', async () => {
       const slotNumber = 420;
       const archive = Fr.random();
-      const proposal1 = await mockCheckpointProposalForPool(signers[0], slotNumber, archive);
-      const proposalId = proposal1.archive.toString();
+      const proposal = await mockCheckpointProposalForPool(signers[0], slotNumber, archive);
 
-      const result1 = await ap.tryAddCheckpointProposal(proposal1);
+      const result1 = await ap.tryAddCheckpointProposal(proposal);
       expect(result1.added).toBe(true);
       expect(result1.alreadyExists).toBe(false);
 
-      // Create a new proposal with same archive but different signer
-      const proposal2 = await mockCheckpointProposalForPool(signers[1], slotNumber, archive);
-
-      const result2 = await ap.tryAddCheckpointProposal(proposal2);
+      // Re-broadcasting the exact same signed payload yields alreadyExists.
+      const result2 = await ap.tryAddCheckpointProposal(proposal);
       expect(result2.added).toBe(false);
       expect(result2.alreadyExists).toBe(true);
 
-      // Should still have the first proposal
-      const retrievedProposal = await ap.getCheckpointProposal(proposalId);
+      // Should still have the first proposal stored at the slot
+      const retrievedProposal = await ap.getCheckpointProposal(SlotNumber(slotNumber));
       expect(retrievedProposal).toBeDefined();
-      expect(retrievedProposal!.toBuffer()).toEqual(proposal1.toBuffer());
+      expect(retrievedProposal!.toBuffer()).toEqual(proposal.toBuffer());
       expect(retrievedProposal!.getSender()?.toString()).toBe(signers[0].address.toString());
+    });
+
+    it('should treat distinct payloads at the same slot as equivocations (count = 2)', async () => {
+      const slotNumber = 420;
+      // Two proposals at the same slot but with different headers (distinct payloads).
+      const proposal1 = await mockCheckpointProposalForPool(signers[0], slotNumber, Fr.random());
+      const proposal2 = await mockCheckpointProposalForPool(signers[0], slotNumber, Fr.random());
+
+      const result1 = await ap.tryAddCheckpointProposal(proposal1);
+      expect(result1.added).toBe(true);
+      expect(result1.count).toBe(1);
+
+      const result2 = await ap.tryAddCheckpointProposal(proposal2);
+      // The second distinct payload is tracked as an equivocation, count goes to 2,
+      // but its bytes are not retained — the first proposal stays in the main store.
+      expect(result2.added).toBe(true);
+      expect(result2.alreadyExists).toBe(false);
+      expect(result2.count).toBe(2);
+
+      const retrievedProposal = await ap.getCheckpointProposal(SlotNumber(slotNumber));
+      expect(retrievedProposal!.toBuffer()).toEqual(proposal1.toBuffer());
+    });
+
+    it('should detect equivocation when only feeAssetPriceModifier differs', async () => {
+      const slotNumber = 420;
+      const archive = Fr.random();
+      // Same checkpoint header + archive, but two different feeAssetPriceModifier values.
+      // This is the audit-finding scenario: archive collides but the signed payload differs.
+      const sharedHeader = makeCheckpointHeader(1, { slotNumber: SlotNumber(slotNumber) });
+      const proposalA = await makeCheckpointProposal({
+        signer: signers[0],
+        checkpointHeader: sharedHeader,
+        archiveRoot: archive,
+        feeAssetPriceModifier: 50n,
+      });
+      const proposalB = await makeCheckpointProposal({
+        signer: signers[0],
+        checkpointHeader: sharedHeader,
+        archiveRoot: archive,
+        feeAssetPriceModifier: -50n,
+      });
+
+      const result1 = await ap.tryAddCheckpointProposal(proposalA.toCore());
+      expect(result1.count).toBe(1);
+
+      const result2 = await ap.tryAddCheckpointProposal(proposalB.toCore());
+      // The fix: archive collision no longer hides the equivocation; payload-hash dedup
+      // sees the distinct feeMod and bumps `count` to 2 so libp2p can fire the slash callback.
+      expect(result2.added).toBe(true);
+      expect(result2.alreadyExists).toBe(false);
+      expect(result2.count).toBe(2);
     });
 
     it('should return added=false when exceeding capacity', async () => {
       const slotNumber = 420;
 
-      // Add MAX_CHECKPOINT_PROPOSALS_PER_SLOT proposals
+      // Add MAX_CHECKPOINT_PROPOSALS_PER_SLOT distinct proposals.
       for (let i = 0; i < MAX_CHECKPOINT_PROPOSALS_PER_SLOT; i++) {
         const proposal = await mockCheckpointProposalForPool(signers[i % NUMBER_OF_SIGNERS_PER_TEST], slotNumber);
         const result = await ap.tryAddCheckpointProposal(proposal);
@@ -336,7 +396,7 @@ export function describeAttestationPool(getAttestationPool: () => AttestationPoo
         expect(result.count).toBe(i + 1);
       }
 
-      // The next proposal should not be added
+      // The next proposal should not be added.
       const extraProposal = await mockCheckpointProposalForPool(signers[0], slotNumber);
       const result = await ap.tryAddCheckpointProposal(extraProposal);
       expect(result.added).toBe(false);
@@ -571,17 +631,17 @@ export function describeAttestationPool(getAttestationPool: () => AttestationPoo
         await ap.tryAddBlockProposal(newProposal);
 
         // Verify both proposals exist
-        expect(await ap.getBlockProposal(oldProposal.archive.toString())).toBeDefined();
-        expect(await ap.getBlockProposal(newProposal.archive.toString())).toBeDefined();
+        expect(await ap.getBlockProposalByArchive(oldProposal.archive.toString())).toBeDefined();
+        expect(await ap.getBlockProposalByArchive(newProposal.archive.toString())).toBeDefined();
 
         // Delete slots older than newSlot (should delete oldSlot)
         await ap.deleteOlderThan(SlotNumber(newSlot));
 
         // Old proposal should be deleted from storage
-        expect(await ap.getBlockProposal(oldProposal.archive.toString())).toBeUndefined();
+        expect(await ap.getBlockProposalByArchive(oldProposal.archive.toString())).toBeUndefined();
 
         // New proposal should still exist
-        expect(await ap.getBlockProposal(newProposal.archive.toString())).toBeDefined();
+        expect(await ap.getBlockProposalByArchive(newProposal.archive.toString())).toBeDefined();
       });
     });
 
@@ -590,12 +650,13 @@ export function describeAttestationPool(getAttestationPool: () => AttestationPoo
         signer: Secp256k1Signer,
         slotNumber: number,
         archive: Fr = Fr.random(),
+        checkpointHeader?: CheckpointHeader,
       ): Promise<CheckpointProposalCore> => {
-        const checkpointHeader = makeCheckpointHeader(1, { slotNumber: SlotNumber(slotNumber) });
+        const headerToUse = checkpointHeader ?? makeCheckpointHeader(1, { slotNumber: SlotNumber(slotNumber) });
         const blockHeader = makeBlockHeader(1);
         const proposal = await makeCheckpointProposal({
           signer,
-          checkpointHeader,
+          checkpointHeader: headerToUse,
           archiveRoot: archive,
           lastBlock: { blockHeader },
         });

--- a/yarn-project/p2p/src/msg_validators/attestation_validator/fisherman_attestation_validator.test.ts
+++ b/yarn-project/p2p/src/msg_validators/attestation_validator/fisherman_attestation_validator.test.ts
@@ -148,7 +148,7 @@ describe('FishermanAttestationValidator', () => {
       const result = await validator.validate(mockAttestation);
       expect(result).toEqual({ result: 'accept' });
 
-      expect(attestationPool.getCheckpointProposal).toHaveBeenCalledWith(mockAttestation.archive.toString());
+      expect(attestationPool.getCheckpointProposal).toHaveBeenCalledWith(mockAttestation.payload.header.slotNumber);
     });
 
     it('returns low tolerance error if attestation payload does not match proposal payload', async () => {
@@ -173,7 +173,7 @@ describe('FishermanAttestationValidator', () => {
       const result = await validator.validate(mockAttestation);
       expect(result).toEqual({ result: 'reject', severity: PeerErrorSeverity.LowToleranceError });
 
-      expect(attestationPool.getCheckpointProposal).toHaveBeenCalledWith(mockAttestation.archive.toString());
+      expect(attestationPool.getCheckpointProposal).toHaveBeenCalledWith(mockAttestation.payload.header.slotNumber);
     });
 
     it('returns accept if proposal is not found yet (attestation arrived before proposal)', async () => {
@@ -189,7 +189,7 @@ describe('FishermanAttestationValidator', () => {
       const result = await validator.validate(mockAttestation);
       expect(result).toEqual({ result: 'accept' });
 
-      expect(attestationPool.getCheckpointProposal).toHaveBeenCalledWith(mockAttestation.archive.toString());
+      expect(attestationPool.getCheckpointProposal).toHaveBeenCalledWith(mockAttestation.payload.header.slotNumber);
     });
 
     it('detects payload mismatch with different archive roots', async () => {

--- a/yarn-project/p2p/src/msg_validators/attestation_validator/fisherman_attestation_validator.ts
+++ b/yarn-project/p2p/src/msg_validators/attestation_validator/fisherman_attestation_validator.ts
@@ -64,8 +64,7 @@ export class FishermanAttestationValidator extends CheckpointAttestationValidato
       return { result: 'accept' };
     }
 
-    const proposalId = message.archive.toString();
-    const proposal = await this.attestationPool.getCheckpointProposal(proposalId);
+    const proposal = await this.attestationPool.getCheckpointProposal(message.payload.header.slotNumber);
 
     if (proposal) {
       // Compare the attestation payload with the proposal payload
@@ -94,9 +93,7 @@ export class FishermanAttestationValidator extends CheckpointAttestationValidato
       }
     } else {
       // We might receive attestations before proposals in some cases
-      this.logger.debug(
-        `Received attestation for slot ${slotNumberBigInt} but proposal not found yet. ` + `Proposal ID: ${proposalId}`,
-      );
+      this.logger.debug(`Received attestation for slot ${slotNumberBigInt} but proposal not found yet.`);
     }
 
     return { result: 'accept' };

--- a/yarn-project/p2p/src/services/libp2p/libp2p_service.test.ts
+++ b/yarn-project/p2p/src/services/libp2p/libp2p_service.test.ts
@@ -9,11 +9,12 @@ import type { L2BlockSource } from '@aztec/stdlib/block';
 import type { ContractDataSource } from '@aztec/stdlib/contract';
 import { GasFees } from '@aztec/stdlib/gas';
 import type { ClientProtocolCircuitVerifier } from '@aztec/stdlib/interfaces/server';
-import { BlockProposal, PeerErrorSeverity } from '@aztec/stdlib/p2p';
+import { BlockProposal, type CheckpointAttestation, PeerErrorSeverity } from '@aztec/stdlib/p2p';
 import {
   TEST_COORDINATION_SIGNATURE_CONTEXT,
   makeBlockHeader,
   makeBlockProposal,
+  makeCheckpointAttestation,
   makeCheckpointHeader,
   makeCheckpointProposal,
   mockTx,
@@ -327,10 +328,10 @@ describe('LibP2PService', () => {
 
     /** Sets up the mempools with a mock attestation pool that returns a proposal with given tx hashes. */
     function setProposalTxHashes(svc: TestLibP2PService, txHashes: string[]): void {
-      // Create a partial mock of the attestation pool that only implements getBlockProposal.
+      // Create a partial mock of the attestation pool that only implements getBlockProposalByArchive.
       // The validation code only accesses `txHashes` from the returned proposal.
       const mockAttestationPool: MockAttestationPoolForTests = {
-        getBlockProposal: (_: string) =>
+        getBlockProposalByArchive: (_: string) =>
           Promise.resolve({
             txHashes: txHashes.map(s => ({ toString: () => s })),
           }),
@@ -491,7 +492,7 @@ describe('LibP2PService', () => {
 
       // No proposal available - mock attestationPool to return undefined
       const mockAttestationPool: MockAttestationPoolForTests = {
-        getBlockProposal: (_: string) => Promise.resolve(undefined),
+        getBlockProposalByArchive: (_: string) => Promise.resolve(undefined),
       };
       service.setAttestationPool(mockAttestationPool);
 
@@ -557,7 +558,7 @@ describe('LibP2PService', () => {
       expect(reportMessageValidationResultSpy).toHaveBeenCalledWith('msg-1', MOCK_PEER_ID, TopicValidatorResult.Accept);
 
       // Verify block was stored in attestation pool
-      const stored = await attestationPool.getBlockProposal(proposal.archive.toString());
+      const stored = await attestationPool.getBlockProposalByArchive(proposal.archive.toString());
       expect(stored).toBeDefined();
     });
 
@@ -732,6 +733,46 @@ describe('LibP2PService', () => {
       // Verify message was rejected
       expect(reportMessageValidationResultSpy).toHaveBeenCalledWith('msg-1', MOCK_PEER_ID, TopicValidatorResult.Reject);
     });
+
+    // Regression for A-1013: payloads sharing (slot, position, archive) but differing on another
+    // signed field (e.g. inHash) used to dedup by archive only and silently drop the second one.
+    // The pool now dedups by signed-payload hash, so the equivocation surfaces.
+    it('same archive but different signed payload triggers slash callback', async () => {
+      const blockHeader = makeBlockHeader(1, { slotNumber: targetSlot });
+      const indexWithinCheckpoint = IndexWithinCheckpoint(0);
+      const sharedArchive = Fr.random();
+
+      const proposal1 = await makeBlockProposal({
+        signer,
+        blockHeader,
+        indexWithinCheckpoint,
+        inHash: Fr.fromString('0x1'),
+        archiveRoot: sharedArchive,
+      });
+      await service.processBlockFromPeer(proposal1.toBuffer(), 'msg-1', mockPeerId);
+      expect(duplicateProposalCallback).not.toHaveBeenCalled();
+
+      const proposal2 = await makeBlockProposal({
+        signer,
+        blockHeader,
+        indexWithinCheckpoint,
+        inHash: Fr.fromString('0x2'),
+        archiveRoot: sharedArchive,
+      });
+      expect(proposal2.archive.toString()).toBe(proposal1.archive.toString());
+      expect(proposal2.getPayloadHash()).not.toEqual(proposal1.getPayloadHash());
+
+      await service.processBlockFromPeer(proposal2.toBuffer(), 'msg-2', mockPeerId);
+
+      expect(reportMessageValidationResultSpy).toHaveBeenCalledWith('msg-2', MOCK_PEER_ID, TopicValidatorResult.Accept);
+      expect(blockReceivedCallback).toHaveBeenCalledTimes(1); // only the first one
+      expect(duplicateProposalCallback).toHaveBeenCalledTimes(1);
+      expect(duplicateProposalCallback).toHaveBeenCalledWith({
+        slot: targetSlot,
+        proposer: signer.address,
+        type: 'block',
+      });
+    });
   });
 
   describe('handleGossipedCheckpointProposal', () => {
@@ -796,7 +837,7 @@ describe('LibP2PService', () => {
       expect(reportMessageValidationResultSpy).toHaveBeenCalledWith('msg-1', MOCK_PEER_ID, TopicValidatorResult.Accept);
 
       // Verify checkpoint was stored in attestation pool
-      const stored = await attestationPool.getCheckpointProposal(proposal.archive.toString());
+      const stored = await attestationPool.getCheckpointProposal(proposal.slotNumber);
       expect(stored).toBeDefined();
     });
 
@@ -861,10 +902,12 @@ describe('LibP2PService', () => {
       expect(mockTxPool.protectTxs).toHaveBeenCalledTimes(1);
 
       // Verify both were stored in attestation pool
-      const storedCheckpoint = await attestationPool.getCheckpointProposal(proposal.archive.toString());
+      const storedCheckpoint = await attestationPool.getCheckpointProposal(proposal.slotNumber);
       expect(storedCheckpoint).toBeDefined();
 
-      const storedBlock = await attestationPool.getBlockProposal(proposal.getBlockProposal()!.archive.toString());
+      const storedBlock = await attestationPool.getBlockProposalByArchive(
+        proposal.getBlockProposal()!.archive.toString(),
+      );
       expect(storedBlock).toBeDefined();
     });
 
@@ -921,7 +964,9 @@ describe('LibP2PService', () => {
       expect(receivedBlock.archive.toString()).toBe(extraProposal.getBlockProposal()!.archive.toString());
 
       // The lastBlock is stored in the attestation pool
-      const storedBlock = await attestationPool.getBlockProposal(extraProposal.getBlockProposal()!.archive.toString());
+      const storedBlock = await attestationPool.getBlockProposalByArchive(
+        extraProposal.getBlockProposal()!.archive.toString(),
+      );
       expect(storedBlock).toBeDefined();
 
       // Txs were marked as non-evictable since the block was processed
@@ -991,6 +1036,147 @@ describe('LibP2PService', () => {
       expect(allNodesCheckpointReceivedCallback).toHaveBeenCalledTimes(1);
       expect(allNodesCheckpointReceivedCallback).toHaveBeenCalledWith(expect.any(Object), expect.anything());
     });
+
+    // Regression for A-1013: payloads sharing (slot, archive) but differing on feeAssetPriceModifier
+    // used to dedup by archive only and silently drop the second one. The pool now dedups by
+    // signed-payload hash, so the equivocation surfaces.
+    it('same archive but different feeAssetPriceModifier triggers slash callback', async () => {
+      const sharedHeader = makeCheckpointHeader(1, { slotNumber: targetSlot });
+      const sharedArchive = Fr.random();
+
+      const checkpoint1 = await makeCheckpointProposal({
+        signer,
+        checkpointHeader: sharedHeader,
+        archiveRoot: sharedArchive,
+        feeAssetPriceModifier: 50n,
+      });
+      await service.handleGossipedCheckpointProposal(checkpoint1.toBuffer(), 'msg-1', mockPeerId);
+      expect(duplicateProposalCallback).not.toHaveBeenCalled();
+
+      const checkpoint2 = await makeCheckpointProposal({
+        signer,
+        checkpointHeader: sharedHeader,
+        archiveRoot: sharedArchive,
+        feeAssetPriceModifier: -50n,
+      });
+      expect(checkpoint2.archive.toString()).toBe(checkpoint1.archive.toString());
+      expect(checkpoint2.getPayloadHash()).not.toEqual(checkpoint1.getPayloadHash());
+
+      await service.handleGossipedCheckpointProposal(checkpoint2.toBuffer(), 'msg-2', mockPeerId);
+
+      expect(reportMessageValidationResultSpy).toHaveBeenCalledWith('msg-2', MOCK_PEER_ID, TopicValidatorResult.Accept);
+      expect(allNodesCheckpointReceivedCallback).toHaveBeenCalledTimes(1); // only the first one
+      expect(validatorCheckpointReceivedCallback).toHaveBeenCalledTimes(1);
+      expect(duplicateProposalCallback).toHaveBeenCalledTimes(1);
+      expect(duplicateProposalCallback).toHaveBeenCalledWith({
+        slot: targetSlot,
+        proposer: signer.address,
+        type: 'checkpoint',
+      });
+    });
+  });
+
+  // Regression for A-1013
+  describe('validateAndStoreCheckpointAttestation', () => {
+    let attestationPool: AttestationPool;
+    let mockEpochCache: MockProxy<EpochCacheInterface>;
+    let proposerSigner: Secp256k1Signer;
+    let duplicateAttestationCallback: jest.Mock;
+
+    const targetSlot = SlotNumber(100);
+    const nextSlot = SlotNumber(101);
+
+    beforeEach(() => {
+      proposerSigner = Secp256k1Signer.random();
+      attestationPool = new AttestationPool(openTmpStore(true));
+      const mockTxPool = mock<TxPoolV2>();
+      mockTxPool.protectTxs.mockResolvedValue([]);
+
+      mockEpochCache = mock<EpochCacheInterface>();
+      mockEpochCache.getProposerAttesterAddressInSlot.mockResolvedValue(proposerSigner.address);
+      mockEpochCache.getTargetAndNextSlot.mockReturnValue({ targetSlot, nextSlot });
+      mockEpochCache.getTargetSlot.mockReturnValue(targetSlot);
+      mockEpochCache.isInCommittee.mockResolvedValue(true);
+
+      mockPeerManager = mock<PeerManagerInterface>();
+      reportMessageValidationResultSpy = jest.fn();
+
+      service = createTestLibP2PServiceWithPools(
+        mockPeerManager,
+        reportMessageValidationResultSpy,
+        attestationPool,
+        mockTxPool,
+        mockEpochCache,
+      );
+
+      duplicateAttestationCallback = jest.fn();
+      service.registerDuplicateAttestationCallback(duplicateAttestationCallback);
+    });
+
+    // Regression for A-1013: attestations sharing (slot, signer, archive) but differing on
+    // feeAssetPriceModifier used to dedup by archive only. The pool now dedups by signed-payload
+    // hash, so the equivocation surfaces.
+    it('same signer + same archive + different feeAssetPriceModifier triggers slash callback', async () => {
+      const attesterSigner = Secp256k1Signer.random();
+      const sharedHeader = makeCheckpointHeader(1, { slotNumber: targetSlot });
+      const sharedArchive = Fr.random();
+
+      const attestation1 = makeCheckpointAttestation({
+        header: sharedHeader,
+        archive: sharedArchive,
+        feeAssetPriceModifier: 50n,
+        attesterSigner,
+        proposerSigner,
+      });
+      await service.validateAndStoreCheckpointAttestation(mockPeerId, attestation1);
+      expect(duplicateAttestationCallback).not.toHaveBeenCalled();
+
+      const attestation2 = makeCheckpointAttestation({
+        header: sharedHeader,
+        archive: sharedArchive,
+        feeAssetPriceModifier: -50n,
+        attesterSigner,
+        proposerSigner,
+      });
+      expect(attestation2.archive.toString()).toBe(attestation1.archive.toString());
+      expect(attestation2.getPayloadHash()).not.toEqual(attestation1.getPayloadHash());
+
+      await service.validateAndStoreCheckpointAttestation(mockPeerId, attestation2);
+
+      expect(duplicateAttestationCallback).toHaveBeenCalledTimes(1);
+      expect(duplicateAttestationCallback).toHaveBeenCalledWith({
+        slot: targetSlot,
+        attester: attesterSigner.address,
+      });
+    });
+
+    it('different signers are not equivocations and do not trigger slash callback', async () => {
+      const attesterA = Secp256k1Signer.random();
+      const attesterB = Secp256k1Signer.random();
+      const sharedHeader = makeCheckpointHeader(1, { slotNumber: targetSlot });
+      const sharedArchive = Fr.random();
+
+      const attestationA = makeCheckpointAttestation({
+        header: sharedHeader,
+        archive: sharedArchive,
+        feeAssetPriceModifier: 50n,
+        attesterSigner: attesterA,
+        proposerSigner,
+      });
+      await service.validateAndStoreCheckpointAttestation(mockPeerId, attestationA);
+
+      const attestationB = makeCheckpointAttestation({
+        header: sharedHeader,
+        archive: sharedArchive,
+        feeAssetPriceModifier: -50n,
+        attesterSigner: attesterB,
+        proposerSigner,
+      });
+      await service.validateAndStoreCheckpointAttestation(mockPeerId, attestationB);
+
+      // Two distinct signers are not an equivocation; the pool tracks per-(slot, signer).
+      expect(duplicateAttestationCallback).not.toHaveBeenCalled();
+    });
   });
 });
 
@@ -1000,11 +1186,11 @@ interface MockTx {
 }
 
 /**
- * Minimal attestation pool interface for tests that only need getBlockProposal.
+ * Minimal attestation pool interface for tests that only need getBlockProposalByArchive.
  * This allows creating partial mocks without implementing the full AttestationPool interface.
  */
 interface MockAttestationPoolForTests {
-  getBlockProposal(id: string): Promise<{ txHashes: { toString(): string }[] } | undefined>;
+  getBlockProposalByArchive(id: string): Promise<{ txHashes: { toString(): string }[] } | undefined>;
 }
 
 /** Options for creating a test LibP2PService instance. */
@@ -1148,6 +1334,11 @@ class TestLibP2PService extends LibP2PService {
   /** Exposes the protected handleGossipedCheckpointProposal for testing. */
   public override handleGossipedCheckpointProposal(payloadData: Buffer, msgId: string, source: PeerId): Promise<void> {
     return super.handleGossipedCheckpointProposal(payloadData, msgId, source);
+  }
+
+  /** Exposes the protected validateAndStoreCheckpointAttestation for testing. */
+  public override validateAndStoreCheckpointAttestation(peerId: PeerId, attestation: CheckpointAttestation) {
+    return super.validateAndStoreCheckpointAttestation(peerId, attestation);
   }
 
   /** Override to use the mock. */

--- a/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
+++ b/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
@@ -1535,7 +1535,7 @@ export class LibP2PService extends WithTracer implements P2PService {
       }
 
       // Given proposal (should have locally), ensure returned txs are valid subset and match request indices
-      const proposal = await this.mempools.attestationPool.getBlockProposal(request.archiveRoot.toString());
+      const proposal = await this.mempools.attestationPool.getBlockProposalByArchive(request.archiveRoot.toString());
       if (proposal) {
         // Build intersected indices
         const intersectIdx = request.txIndices.getTrueIndices().filter(i => response.txIndices.isSet(i));

--- a/yarn-project/p2p/src/services/reqresp/protocols/block_txs/block_txs_handler.test.ts
+++ b/yarn-project/p2p/src/services/reqresp/protocols/block_txs/block_txs_handler.test.ts
@@ -45,7 +45,7 @@ describe('reqRespBlockTxsHandler', () => {
     txPool = mock<TxPoolV2>();
     peerId = mock<PeerId>();
 
-    attestationPool.getBlockProposal.mockResolvedValue(undefined);
+    attestationPool.getBlockProposalByArchive.mockResolvedValue(undefined);
     archiver.getBlock.mockResolvedValue(undefined);
     txPool.getTxsByHash.mockResolvedValue([]);
     txPool.hasTxs.mockResolvedValue([]);
@@ -91,7 +91,7 @@ describe('reqRespBlockTxsHandler', () => {
       const proposal = await createBlockProposal(txHashes);
       const txs = txHashes.map(h => makeTx(h));
 
-      attestationPool.getBlockProposal.mockResolvedValue(proposal);
+      attestationPool.getBlockProposalByArchive.mockResolvedValue(proposal);
       txPool.hasTxs.mockResolvedValue([true, true, true]);
       txPool.getTxsByHash.mockResolvedValue(txs);
 
@@ -107,7 +107,7 @@ describe('reqRespBlockTxsHandler', () => {
       const txHashes = [TxHash.random(), TxHash.random(), TxHash.random()];
       const proposal = await createBlockProposal(txHashes);
 
-      attestationPool.getBlockProposal.mockResolvedValue(proposal);
+      attestationPool.getBlockProposalByArchive.mockResolvedValue(proposal);
       txPool.hasTxs.mockResolvedValue([true, false, true]);
       txPool.getTxsByHash.mockResolvedValue([makeTx(txHashes[0]), undefined, makeTx(txHashes[2])]);
 
@@ -122,7 +122,7 @@ describe('reqRespBlockTxsHandler', () => {
       const txHashes = [TxHash.random(), TxHash.random()];
       const proposal = await createBlockProposal(txHashes);
 
-      attestationPool.getBlockProposal.mockResolvedValue(proposal);
+      attestationPool.getBlockProposalByArchive.mockResolvedValue(proposal);
       txPool.hasTxs.mockResolvedValue([true, false]);
       txPool.getTxsByHash.mockResolvedValue([makeTx(txHashes[0]), undefined]);
 
@@ -150,7 +150,7 @@ describe('reqRespBlockTxsHandler', () => {
       expect(response.txs.length).toBe(3);
       expect(response.txIndices.getTrueIndices()).toEqual([0, 1, 2]);
 
-      expect(attestationPool.getBlockProposal).toHaveBeenCalledWith(block.archive.root.toString());
+      expect(attestationPool.getBlockProposalByArchive).toHaveBeenCalledWith(block.archive.root.toString());
       expect(archiver.getBlock).toHaveBeenCalledWith({ archive: block.archive.root });
     });
 
@@ -168,7 +168,7 @@ describe('reqRespBlockTxsHandler', () => {
       expect(response.txs.length).toBe(2);
       expect(response.txIndices.getTrueIndices()).toEqual([0, 2]);
 
-      expect(attestationPool.getBlockProposal).toHaveBeenCalledWith(block.archive.root.toString());
+      expect(attestationPool.getBlockProposalByArchive).toHaveBeenCalledWith(block.archive.root.toString());
       expect(archiver.getBlock).toHaveBeenCalledWith({ archive: block.archive.root });
     });
 
@@ -177,14 +177,14 @@ describe('reqRespBlockTxsHandler', () => {
       const proposal = await createBlockProposal(txHashes);
       const txs = txHashes.map(h => makeTx(h));
 
-      attestationPool.getBlockProposal.mockResolvedValue(proposal);
+      attestationPool.getBlockProposalByArchive.mockResolvedValue(proposal);
       txPool.hasTxs.mockResolvedValue([true, true]);
       txPool.getTxsByHash.mockResolvedValue(txs);
 
       const request = new BlockTxsRequest(proposal.archive, new TxHashArray(), BitVector.init(2, [0, 1]));
       await callHandler(request);
 
-      expect(attestationPool.getBlockProposal).toHaveBeenCalledWith(proposal.archive.toString());
+      expect(attestationPool.getBlockProposalByArchive).toHaveBeenCalledWith(proposal.archive.toString());
       expect(archiver.getBlock).not.toHaveBeenCalled();
     });
   });

--- a/yarn-project/p2p/src/services/reqresp/protocols/block_txs/block_txs_handler.ts
+++ b/yarn-project/p2p/src/services/reqresp/protocols/block_txs/block_txs_handler.ts
@@ -37,7 +37,7 @@ export function reqRespBlockTxsHandler(
       throw new ReqRespStatusError(ReqRespStatus.BADLY_FORMED_REQUEST, { cause: err });
     }
     // First try attestation pool, then fall back to archiver
-    let txHashes = (await attestationPool.getBlockProposal(request.archiveRoot.toString()))?.txHashes;
+    let txHashes = (await attestationPool.getBlockProposalByArchive(request.archiveRoot.toString()))?.txHashes;
     if (!txHashes) {
       txHashes = (await archiver.getBlock({ archive: request.archiveRoot }))?.body.txEffects.map(
         effect => effect.txHash,

--- a/yarn-project/p2p/src/test-helpers/testbench-utils.ts
+++ b/yarn-project/p2p/src/test-helpers/testbench-utils.ts
@@ -1,4 +1,5 @@
 import type { EpochCacheInterface } from '@aztec/epoch-cache';
+import type { CheckpointProposalHash } from '@aztec/foundation/branded-types';
 import { EpochNumber, SlotNumber } from '@aztec/foundation/branded-types';
 import type { Logger } from '@aztec/foundation/log';
 import type { L2Block, L2BlockId } from '@aztec/stdlib/block';
@@ -225,7 +226,7 @@ export class InMemoryAttestationPool {
     return Promise.resolve({ added: true, alreadyExists: false, count: 1 });
   }
 
-  getBlockProposal(id: string): Promise<BlockProposal | undefined> {
+  getBlockProposalByArchive(id: string): Promise<BlockProposal | undefined> {
     return Promise.resolve(this.proposals.get(id));
   }
 
@@ -233,7 +234,7 @@ export class InMemoryAttestationPool {
     return Promise.resolve({ added: true, alreadyExists: false, count: 1 });
   }
 
-  getCheckpointProposal(_id: string): Promise<CheckpointProposalCore | undefined> {
+  getCheckpointProposal(_slot: SlotNumber): Promise<CheckpointProposalCore | undefined> {
     return Promise.resolve(undefined);
   }
 
@@ -247,7 +248,7 @@ export class InMemoryAttestationPool {
 
   getCheckpointAttestationsForSlotAndProposal(
     _slot: SlotNumber,
-    _proposalId: string,
+    _proposalPayloadHash: CheckpointProposalHash,
   ): Promise<CheckpointAttestation[]> {
     return Promise.resolve([]);
   }

--- a/yarn-project/stdlib/src/interfaces/p2p.test.ts
+++ b/yarn-project/stdlib/src/interfaces/p2p.test.ts
@@ -1,4 +1,4 @@
-import { SlotNumber } from '@aztec/foundation/branded-types';
+import { CheckpointProposalHash, SlotNumber } from '@aztec/foundation/branded-types';
 import { type JsonRpcTestContext, createJsonRpcTestSetup } from '@aztec/foundation/json-rpc/test';
 
 import { CheckpointAttestation } from '../p2p/checkpoint_attestation.js';
@@ -27,7 +27,10 @@ describe('P2PApiSchema', () => {
   });
 
   it('getCheckpointAttestationsForSlot', async () => {
-    const attestations = await context.client.getCheckpointAttestationsForSlot(SlotNumber(1), 'proposalId');
+    const attestations = await context.client.getCheckpointAttestationsForSlot(
+      SlotNumber(1),
+      CheckpointProposalHash('0xdeadbeef'),
+    );
     expect(attestations).toEqual([CheckpointAttestation.empty()]);
     expect(attestations[0]).toBeInstanceOf(CheckpointAttestation);
   });
@@ -65,9 +68,12 @@ const peers: PeerInfo[] = [
 ];
 
 class MockP2P implements P2PApi {
-  getCheckpointAttestationsForSlot(slot: SlotNumber, proposalId?: string): Promise<CheckpointAttestation[]> {
+  getCheckpointAttestationsForSlot(
+    slot: SlotNumber,
+    proposalId?: CheckpointProposalHash,
+  ): Promise<CheckpointAttestation[]> {
     expect(slot).toEqual(SlotNumber(1));
-    expect(proposalId).toEqual('proposalId');
+    expect(proposalId).toEqual(CheckpointProposalHash('0xdeadbeef'));
     return Promise.resolve([CheckpointAttestation.empty()]);
   }
 

--- a/yarn-project/stdlib/src/interfaces/p2p.ts
+++ b/yarn-project/stdlib/src/interfaces/p2p.ts
@@ -1,4 +1,4 @@
-import type { SlotNumber } from '@aztec/foundation/branded-types';
+import type { CheckpointProposalHash, SlotNumber } from '@aztec/foundation/branded-types';
 
 import { z } from 'zod';
 
@@ -49,13 +49,19 @@ export interface P2PApi {
   getPeers(includePending?: boolean): Promise<PeerInfo[]>;
 
   /**
-   * Queries the Attestation pool for checkpoint attestations for the given slot
+   * Queries the Attestation pool for checkpoint attestations for the given slot.
    *
    * @param slot - the slot to query
-   * @param proposalId - the proposal id to query, or undefined to query all proposals for the slot
+   * @param proposalPayloadHash - hex-encoded keccak256 of the target proposal's signed
+   *        payload (`CheckpointProposal.getPayloadHash()`). When provided, only
+   *        attestations whose own signed payload hashes to the same value are returned.
+   *        When omitted, all attestations for the slot are returned.
    * @returns CheckpointAttestations
    */
-  getCheckpointAttestationsForSlot(slot: SlotNumber, proposalId?: string): Promise<CheckpointAttestation[]>;
+  getCheckpointAttestationsForSlot(
+    slot: SlotNumber,
+    proposalPayloadHash?: CheckpointProposalHash,
+  ): Promise<CheckpointAttestation[]>;
 }
 
 export interface P2PClient extends P2PApi {
@@ -66,7 +72,10 @@ export interface P2PClient extends P2PApi {
 export const P2PApiSchema: ApiSchemaFor<P2PApi> = {
   getCheckpointAttestationsForSlot: z
     .function()
-    .args(schemas.SlotNumber, optional(z.string()))
+    .args(
+      schemas.SlotNumber,
+      optional(z.string().regex(/^0x[0-9a-fA-F]+$/) as unknown as z.ZodType<CheckpointProposalHash>),
+    )
     .returns(z.array(CheckpointAttestation.schema)),
   getPendingTxs: z
     .function()

--- a/yarn-project/stdlib/src/p2p/block_proposal.ts
+++ b/yarn-project/stdlib/src/p2p/block_proposal.ts
@@ -5,7 +5,7 @@ import {
   IndexWithinCheckpoint,
   SlotNumber,
 } from '@aztec/foundation/branded-types';
-import type { BaseBuffer32 } from '@aztec/foundation/buffer';
+import { type BaseBuffer32, Buffer32 } from '@aztec/foundation/buffer';
 import { keccak256 } from '@aztec/foundation/crypto/keccak';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import type { EthAddress } from '@aztec/foundation/eth-address';
@@ -92,7 +92,7 @@ export class BlockProposal extends Gossipable implements Signable {
   }
 
   override generateP2PMessageIdentifier(): Promise<BaseBuffer32> {
-    return Promise.resolve(BlockProposalHash.fromBuffer(keccak256(this.signature.toBuffer())));
+    return Promise.resolve(new Buffer32(this.getPayloadHashBuffer()));
   }
 
   get archive(): Fr {
@@ -135,6 +135,21 @@ export class BlockProposal extends Gossipable implements Signable {
       this.txHashes.length,
       this.txHashes,
     ]);
+  }
+
+  private getPayloadHashBuffer(): Buffer {
+    return keccak256(this.getPayloadToSign());
+  }
+
+  /**
+   * Returns a keccak256 hash of the signed payload.
+   * Used by the attestation pool to dedup distinct signed payloads at the same
+   * (slot, indexWithinCheckpoint) regardless of archive collisions.
+   * The hash deliberately excludes the signature so non-deterministic ECDSA
+   * re-signs of the same payload do not look like equivocation.
+   */
+  getPayloadHash(): BlockProposalHash {
+    return BlockProposalHash.fromBuffer(this.getPayloadHashBuffer());
   }
 
   static async createProposalFromSigner(

--- a/yarn-project/stdlib/src/p2p/checkpoint_attestation.ts
+++ b/yarn-project/stdlib/src/p2p/checkpoint_attestation.ts
@@ -1,6 +1,5 @@
-import { CheckpointAttestationHash, SlotNumber } from '@aztec/foundation/branded-types';
-import type { BaseBuffer32 } from '@aztec/foundation/buffer';
-import { keccak256 } from '@aztec/foundation/crypto/keccak';
+import { CheckpointProposalHash, type SlotNumber } from '@aztec/foundation/branded-types';
+import { type BaseBuffer32, Buffer32 } from '@aztec/foundation/buffer';
 import type { Fr } from '@aztec/foundation/curves/bn254';
 import type { EthAddress } from '@aztec/foundation/eth-address';
 import { Signature } from '@aztec/foundation/eth-signature';
@@ -14,8 +13,6 @@ import { ConsensusPayload } from './consensus_payload.js';
 import { Gossipable } from './gossipable.js';
 import { type CoordinationSignatureContext, recoverCoordinationSigner } from './signature_utils.js';
 import { TopicType } from './topic_type.js';
-
-export type { CheckpointAttestationHash } from '@aztec/foundation/branded-types';
 
 /**
  * CheckpointAttestation
@@ -53,7 +50,7 @@ export class CheckpointAttestation extends Gossipable {
   }
 
   override generateP2PMessageIdentifier(): Promise<BaseBuffer32> {
-    return Promise.resolve(CheckpointAttestationHash.fromBuffer(keccak256(this.signature.toBuffer())));
+    return Promise.resolve(new Buffer32(this.payload.getPayloadHash()));
   }
 
   get archive(): Fr {
@@ -102,6 +99,14 @@ export class CheckpointAttestation extends Gossipable {
 
   getPayload(): Buffer {
     return this.payload.getPayloadToSign();
+  }
+
+  /**
+   * Returns a keccak256 hash of the signed consensus payload.
+   * Used to dedup distinct signed payloads. Returns same hash than the corresponding proposal.
+   */
+  getPayloadHash(): CheckpointProposalHash {
+    return CheckpointProposalHash.fromBuffer(this.payload.getPayloadHash());
   }
 
   toBuffer(): Buffer {

--- a/yarn-project/stdlib/src/p2p/checkpoint_proposal.ts
+++ b/yarn-project/stdlib/src/p2p/checkpoint_proposal.ts
@@ -4,8 +4,7 @@ import {
   IndexWithinCheckpoint,
   SlotNumber,
 } from '@aztec/foundation/branded-types';
-import type { BaseBuffer32 } from '@aztec/foundation/buffer';
-import { keccak256 } from '@aztec/foundation/crypto/keccak';
+import { type BaseBuffer32, Buffer32 } from '@aztec/foundation/buffer';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import type { EthAddress } from '@aztec/foundation/eth-address';
 import { Signature } from '@aztec/foundation/eth-signature';
@@ -21,6 +20,7 @@ import { BlockHeader } from '../tx/block_header.js';
 import { TxHash } from '../tx/index.js';
 import type { Tx } from '../tx/tx.js';
 import { BlockProposal } from './block_proposal.js';
+import { ConsensusPayload } from './consensus_payload.js';
 import { Gossipable } from './gossipable.js';
 import {
   type CoordinationSignatureContext,
@@ -105,7 +105,7 @@ export class CheckpointProposal extends Gossipable implements Signable {
   }
 
   override generateP2PMessageIdentifier(): Promise<BaseBuffer32> {
-    return Promise.resolve(CheckpointProposalHash.fromBuffer(keccak256(this.signature.toBuffer())));
+    return Promise.resolve(new Buffer32(this.toConsensusPayload().getPayloadHash()));
   }
 
   get slotNumber(): SlotNumber {
@@ -162,6 +162,24 @@ export class CheckpointProposal extends Gossipable implements Signable {
    */
   getPayloadToSign(): Buffer {
     return serializeToBuffer([this.checkpointHeader, this.archive, serializeSignedBigInt(this.feeAssetPriceModifier)]);
+  }
+
+  /**
+   * Returns a content-addressed keccak256 hash of the consensus payload
+   * (header + archive + feeAssetPriceModifier + signatureContext).
+   *
+   * Used by the attestation pool to dedup distinct signed payloads at the same slot
+   * regardless of archive/header collisions on `feeAssetPriceModifier` variants.
+   * The hash deliberately excludes the signature so non-deterministic ECDSA
+   * re-signs of the same payload do not look like equivocation.
+   */
+  getPayloadHash(): CheckpointProposalHash {
+    return CheckpointProposalHash.fromBuffer(this.toConsensusPayload().getPayloadHash());
+  }
+
+  /** Returns the ConsensusPayload that an attester would sign for this proposal. */
+  toConsensusPayload(): ConsensusPayload {
+    return new ConsensusPayload(this.checkpointHeader, this.archive, this.feeAssetPriceModifier, this.signatureContext);
   }
 
   static async createProposalFromSigner(

--- a/yarn-project/stdlib/src/p2p/consensus_payload.ts
+++ b/yarn-project/stdlib/src/p2p/consensus_payload.ts
@@ -1,3 +1,4 @@
+import { keccak256 } from '@aztec/foundation/crypto/keccak';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { schemas } from '@aztec/foundation/schemas';
 import { BufferReader, serializeSignedBigInt, serializeToBuffer } from '@aztec/foundation/serialize';
@@ -67,6 +68,14 @@ export class ConsensusPayload implements Signable {
     const encodedData = encodeAbiParameters(abi, [[archiveRoot, [this.feeAssetPriceModifier], headerHash]] as const);
 
     return hexToBuffer(encodedData);
+  }
+
+  /**
+   * Returns a keccak256 hash of the signed payload (header + archive + feeAssetPriceModifier).
+   * Used by the attestation pool to dedup distinct signed payloads.
+   */
+  getPayloadHash(): Buffer {
+    return keccak256(this.getPayloadToSign());
   }
 
   toBuffer(): Buffer {

--- a/yarn-project/txe/src/state_machine/dummy_p2p_client.ts
+++ b/yarn-project/txe/src/state_machine/dummy_p2p_client.ts
@@ -1,4 +1,4 @@
-import type { SlotNumber } from '@aztec/foundation/branded-types';
+import type { CheckpointProposalHash, SlotNumber } from '@aztec/foundation/branded-types';
 import type {
   AuthRequest,
   ENR,
@@ -147,7 +147,10 @@ export class DummyP2P implements P2P {
     throw new Error('DummyP2P does not implement "getTxsByHash"');
   }
 
-  public getCheckpointAttestationsForSlot(_slot: SlotNumber, _proposalId?: string): Promise<CheckpointAttestation[]> {
+  public getCheckpointAttestationsForSlot(
+    _slot: SlotNumber,
+    _proposalPayloadHash?: CheckpointProposalHash,
+  ): Promise<CheckpointAttestation[]> {
     throw new Error('DummyP2P does not implement "getCheckpointAttestationsForSlot"');
   }
 

--- a/yarn-project/validator-client/src/proposal_handler.test.ts
+++ b/yarn-project/validator-client/src/proposal_handler.test.ts
@@ -211,6 +211,30 @@ describe('ProposalHandler checkpoint validation', () => {
       expect(blockSource.syncImmediate).toHaveBeenCalled();
     });
 
+    // Regression for A-1013: cache used to key by (archive, slot) which let two proposals at the
+    // same slot+archive but with a different feeAssetPriceModifier share the same cache entry.
+    it('does not cache across proposals that share archive and slot but differ in feeAssetPriceModifier', async () => {
+      blockSource.getBlockData.mockResolvedValue(undefined);
+      const sharedHeader = makeCheckpointHeader(0, { slotNumber: SlotNumber(1) });
+      const sharedArchive = Fr.random();
+
+      const proposalA = await makeProposal({
+        checkpointHeader: sharedHeader,
+        archiveRoot: sharedArchive,
+        feeAssetPriceModifier: 50n,
+      });
+      await handler.handleCheckpointProposal(proposalA, proposalInfo);
+      blockSource.syncImmediate.mockClear();
+
+      const proposalB = await makeProposal({
+        checkpointHeader: sharedHeader,
+        archiveRoot: sharedArchive,
+        feeAssetPriceModifier: -50n,
+      });
+      await handler.handleCheckpointProposal(proposalB, proposalInfo);
+      expect(blockSource.syncImmediate).toHaveBeenCalled();
+    });
+
     it('returns block_fetch_error when getBlockData throws', async () => {
       blockSource.getBlockData.mockRejectedValue(new Error('db connection failed'));
 

--- a/yarn-project/validator-client/src/proposal_handler.ts
+++ b/yarn-project/validator-client/src/proposal_handler.ts
@@ -4,7 +4,12 @@ import { type Blob, encodeCheckpointBlobDataFromBlocks, getBlobsPerL1Block } fro
 import { INITIAL_L2_BLOCK_NUM } from '@aztec/constants';
 import type { EpochCache } from '@aztec/epoch-cache';
 import { validateFeeAssetPriceModifier } from '@aztec/ethereum/contracts';
-import { BlockNumber, CheckpointNumber, SlotNumber } from '@aztec/foundation/branded-types';
+import {
+  BlockNumber,
+  CheckpointNumber,
+  type CheckpointProposalHash,
+  SlotNumber,
+} from '@aztec/foundation/branded-types';
 import { pick } from '@aztec/foundation/collection';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { TimeoutError } from '@aztec/foundation/error';
@@ -88,10 +93,11 @@ type CheckpointComputationResult =
 export class ProposalHandler {
   public readonly tracer: Tracer;
 
-  /** Cached last checkpoint validation result to avoid double-validation on validator nodes. */
+  /** Cached last checkpoint validation result to avoid double-validation on validator nodes.
+   *  Keyed by signed-payload hash so two proposals at the same (slot, archive) but with a
+   *  different `feeAssetPriceModifier` (or any other signed field) are validated independently. */
   private lastCheckpointValidationResult?: {
-    archive: Fr;
-    slotNumber: SlotNumber;
+    payloadHash: CheckpointProposalHash;
     result: CheckpointProposalValidationResult;
   };
 
@@ -735,13 +741,10 @@ export class ProposalHandler {
     proposalInfo: LogData,
   ): Promise<CheckpointProposalValidationResult> {
     const slot = proposal.slotNumber;
+    const payloadHash = proposal.getPayloadHash();
 
-    // Check cache: same archive+slot means we already validated this proposal
-    if (
-      this.lastCheckpointValidationResult &&
-      this.lastCheckpointValidationResult.archive.equals(proposal.archive) &&
-      this.lastCheckpointValidationResult.slotNumber === slot
-    ) {
+    // Check cache: same signed-payload hash means we already validated this exact proposal.
+    if (this.lastCheckpointValidationResult && this.lastCheckpointValidationResult.payloadHash === payloadHash) {
       this.log.debug(`Returning cached validation result for checkpoint proposal at slot ${slot}`, proposalInfo);
       return this.lastCheckpointValidationResult.result;
     }
@@ -750,7 +753,7 @@ export class ProposalHandler {
     if (!proposer) {
       this.log.warn(`Received checkpoint proposal with invalid signature for slot ${proposal.slotNumber}`);
       const result: CheckpointProposalValidationResult = { isValid: false, reason: 'invalid_signature' };
-      this.lastCheckpointValidationResult = { archive: proposal.archive, slotNumber: slot, result };
+      this.lastCheckpointValidationResult = { payloadHash, result };
       return result;
     }
 
@@ -759,12 +762,12 @@ export class ProposalHandler {
         `Received checkpoint proposal with invalid feeAssetPriceModifier ${proposal.feeAssetPriceModifier} for slot ${proposal.slotNumber}`,
       );
       const result: CheckpointProposalValidationResult = { isValid: false, reason: 'invalid_fee_asset_price_modifier' };
-      this.lastCheckpointValidationResult = { archive: proposal.archive, slotNumber: slot, result };
+      this.lastCheckpointValidationResult = { payloadHash, result };
       return result;
     }
 
     const result = await this.validateCheckpointProposal(proposal, proposalInfo);
-    this.lastCheckpointValidationResult = { archive: proposal.archive, slotNumber: slot, result };
+    this.lastCheckpointValidationResult = { payloadHash, result };
 
     // Upload blobs to filestore if validation passed (fire and forget)
     if (result.isValid) {

--- a/yarn-project/validator-client/src/validator.test.ts
+++ b/yarn-project/validator-client/src/validator.test.ts
@@ -261,8 +261,9 @@ describe('ValidatorClient', () => {
         makeCheckpointAttestation({ signer: attestor1, archive, header: proposal.checkpointHeader }),
         makeCheckpointAttestation({ signer: attestor2, archive, header: proposal.checkpointHeader }),
       ];
-      p2pClient.getCheckpointAttestationsForSlot.mockImplementation((slot, proposalId) => {
-        if (proposal.slotNumber === slot && proposalId === proposal.archive.toString()) {
+      const expectedPayloadHash = proposal.getPayloadHash();
+      p2pClient.getCheckpointAttestationsForSlot.mockImplementation((slot, proposalPayloadHash) => {
+        if (proposal.slotNumber === slot && proposalPayloadHash === expectedPayloadHash) {
           return Promise.resolve(expectedAttestations);
         }
         return Promise.resolve([]);
@@ -294,41 +295,36 @@ describe('ValidatorClient', () => {
       expect(addCheckpointAttestationsSpy.mock.calls[0][0]).toHaveLength(2);
     });
 
-    it('should filter out attestations with mismatched payload', async () => {
+    it('forwards the proposal payload hash to the pool so mismatched attestations are filtered out', async () => {
       const signer = Secp256k1Signer.random();
       const attestor1 = Secp256k1Signer.random();
-      const attestor2 = Secp256k1Signer.random();
 
       const archive = Fr.random();
       const txHashes = [0, 1, 2, 3, 4, 5].map(() => TxHash.random());
 
       const proposal = await makeCheckpointProposal({ signer, archiveRoot: archive, lastBlock: { txHashes } });
 
-      // Create attestations - one with matching payload, one with mismatched
+      // The pool is responsible for filtering by payload hash; the validator just forwards it.
+      // We mock the pool to return the matching attestation only when queried with the right hash.
       const validAttestation = makeCheckpointAttestation({
         signer: attestor1,
         archive,
         header: proposal.checkpointHeader,
       });
-      const invalidAttestation = makeCheckpointAttestation({
-        signer: attestor2,
-        archive: Fr.random(),
-        header: proposal.checkpointHeader,
-      });
 
-      p2pClient.getCheckpointAttestationsForSlot.mockImplementation((slot, proposalId) =>
-        proposal.slotNumber === slot && proposalId === proposal.archive.toString()
-          ? Promise.resolve([validAttestation, invalidAttestation])
+      const expectedPayloadHash = proposal.getPayloadHash();
+      p2pClient.getCheckpointAttestationsForSlot.mockImplementation((slot, proposalPayloadHash) =>
+        proposal.slotNumber === slot && proposalPayloadHash === expectedPayloadHash
+          ? Promise.resolve([validAttestation])
           : Promise.resolve([]),
       );
 
-      // Perform the query - should timeout but we're testing the filtering behavior
+      // Only one matching attestation is returned, but the validator needs 2 -> times out.
       await expect(
         validatorClient.collectAttestations(proposal, 2, new Date(dateProvider.now() + 1000), CheckpointNumber(1)),
       ).rejects.toThrow(AttestationTimeoutError);
 
-      // Verify that getCheckpointAttestationsForSlot was called (meaning the loop ran)
-      expect(p2pClient.getCheckpointAttestationsForSlot).toHaveBeenCalled();
+      expect(p2pClient.getCheckpointAttestationsForSlot).toHaveBeenCalledWith(proposal.slotNumber, expectedPayloadHash);
     });
   });
 

--- a/yarn-project/validator-client/src/validator.ts
+++ b/yarn-project/validator-client/src/validator.ts
@@ -881,33 +881,21 @@ export class ValidatorClient extends (EventEmitter as new () => WatcherEmitter) 
 
     await this.collectOwnAttestations(proposal, checkpointNumber);
 
-    const proposalId = proposal.archive.toString();
+    const proposalPayloadHash = proposal.getPayloadHash();
     const myAddresses = this.getValidatorAddresses();
 
     let attestations: CheckpointAttestation[] = [];
     while (true) {
-      // Filter out attestations with a mismatching archive. This should NOT happen since we have verified
-      // the proposer signature (ie our own) before accepting the attestation into the pool via the p2p client.
-      const collectedAttestations = (await this.p2pClient.getCheckpointAttestationsForSlot(slot, proposalId)).filter(
-        attestation => {
-          if (!attestation.archive.equals(proposal.archive)) {
-            this.log.warn(
-              `Received attestation for slot ${slot} with mismatched archive from ${attestation
-                .getSender()
-                ?.toString()}`,
-              { attestationArchive: attestation.archive.toString(), proposalArchive: proposal.archive.toString() },
-            );
-            return false;
-          }
-          return true;
-        },
-      );
+      // The pool already filters by proposal payload hash; if any attestation slips through with a
+      // mismatched payload hash, drop it defensively. Equivocations are emitted as separate slash
+      // events from libp2p_service.
+      const collectedAttestations = await this.p2pClient.getCheckpointAttestationsForSlot(slot, proposalPayloadHash);
 
       // Log new attestations we collected
       const oldSenders = attestations.map(attestation => attestation.getSender());
       for (const collected of collectedAttestations) {
         const collectedSender = collected.getSender();
-        // Skip attestations with invalid signatures
+        // Skip attestations with invalid signatures. Should not happen as we don't add invalid attestations to our pool.
         if (!collectedSender) {
           this.log.warn(`Skipping attestation with invalid signature for slot ${slot}`);
           continue;


### PR DESCRIPTION
Closes a slashing-soundness gap in the checkpoint attestation pool: two different checkpoint proposals (or attestations) at the same slot with identical archive root were considered equal in the attestation pool, since the pool keyed on `archive`. So we'd never slash for `DUPLICATE_PROPOSAL` / `DUPLICATE_ATTESTATION`.

There were two scenarios where two different proposals could have the same archiveroot: a malicious or buggy node that sent two proposals with the same root but different content (ie an archive root that doesn't follow from the payload, ie an invalid one), or a malicious or buggy node that sent two equal proposals but with different `feeAssetPriceModifier` which is not covered by the archive root.

Fixes A-1013

## Pool changes

- **Dedup by payload hash, not by archive.** Each equivocation position has two stores: a main store that keeps the *first* full entry seen at that position, and a parallel multimap that tracks the *set of distinct signed-payload hashes* seen there. A second distinct hash arriving at the same position bumps the multimap count to 2, which trips `tryAdd*`'s `count` and lets libp2p fire its duplicate callback / `WANT_TO_SLASH_EVENT`. Bytes of the equivocating payload are not retained.
  - `attestationPerSlotAndSigner` (full) + `attestationHashesPerSlotAndSigner` (hashes), keyed by `(slot, signer)`.
  - `checkpointProposalPerSlot` (full) + `checkpointProposalHashesPerSlot` (hashes), keyed by slot.
  - `blockProposalPerSlotAndIndex` (full) + `blockProposalHashesPerSlotAndIndex` (hashes), keyed by `(slot, indexWithinCheckpoint)`.
- Hash is `keccak256(getPayloadToSign())`, **never over the signature**, so non-deterministic ECDSA re-signs of the same payload do not look like equivocation.
- `CheckpointProposal.getPayloadHash()` hashes through the `ConsensusPayload` form so a checkpoint proposal's hash matches the hashes of the attestations that signed it (proposers and attesters sign different byte layouts of the same logical content).
- Secondary `blockProposalSlotAndIndexPerArchive` index keeps `getBlockProposalByArchive(archive)` (used by the block-txs req/resp protocol) resolving by archive root without a wire-protocol change. The lookup now validates that the stored proposal's archive matches the requested one and warns + returns `undefined` on mismatch.
- On-disk kv-store map names are unchanged; only the in-memory field names and the *value format* (now `0x`-prefixed payload-hash hex) are new.

## Branded payload-hash types

- `CheckpointProposalHash` and `BlockProposalHash` introduced as `Branded<0x${string}>` in `foundation/branded-types`, so the two cannot be confused at the TS type level. `CheckpointAttestation.getPayloadHash()` returns `CheckpointProposalHash` (the attestation and its proposal sign the same payload).
- `generateP2PMessageIdentifier()` on `CheckpointProposal` / `CheckpointAttestation` / `BlockProposal` now derives from the **same bytes** as `getPayloadHash()` (returning `Buffer32` rather than the `0x`-string), so libp2p's gossip dedup identity and the attestation pool's dedup identity agree. A shared `getPayloadHashBuffer()` helper on `BlockProposal` avoids double-hashing.

## Handler cache (validator-client)

- `ProposalHandler.lastCheckpointValidationResult` now keys by `CheckpointProposalHash` instead of `(archive, slot)`. Without this fix, two proposals at the same slot+archive with a differing `feeAssetPriceModifier` would have shared a cached validation result and the second proposal would have skipped re-validation.

## API renames

- `AttestationPool.getCheckpointProposal(slot)` — was `getCheckpointProposal(archive)`.
- `AttestationPool.getBlockProposalByArchive(archive)` — was `getBlockProposal(archive)`; now validates the resolved proposal's archive matches.
- `AttestationPool.getCheckpointAttestationsForSlotAndProposal(slot, proposalPayloadHash)` — was `(slot, archive)`.
- `P2PApi.getCheckpointAttestationsForSlot(slot, proposalPayloadHash?)`.
- Sentinel stores `proposalPayloadHash` alongside archive; validator client passes `proposal.getPayloadHash()` to filter attestations.

## Tests

- New pool-level test verifies same-archive-different-`feeAssetPriceModifier` is recognised as an equivocation.
- New libp2p_service tests verify the equivocation surfaces all the way to the slash callback for checkpoint proposals, attestations (incl. negative test for two distinct signers), and block proposals.
- New proposal_handler test verifies the cache is not shared across proposals that differ only on `feeAssetPriceModifier`.
