### PR TITLE
fix(spartan): wire SEQ_ENABLE_PROPOSER_PIPELINING to all nodes

### DIFF
--- a/spartan/terraform/deploy-aztec-infra/main.tf
+++ b/spartan/terraform/deploy-aztec-infra/main.tf
@@ -407,6 +407,7 @@ locals {
           "node.node.env.P2P_MAX_PENDING_TX_COUNT"              = var.P2P_MAX_PENDING_TX_COUNT
           "node.node.env.WS_NUM_HISTORIC_CHECKPOINTS"           = var.WS_NUM_HISTORIC_CHECKPOINTS
           "node.node.env.TX_COLLECTION_FILE_STORE_URLS"         = var.TX_COLLECTION_FILE_STORE_URLS
+          "node.node.env.SEQ_ENABLE_PROPOSER_PIPELINING"        = var.SEQ_ENABLE_PROPOSER_PIPELINING
           "node.service.p2p.nodePortEnabled"                    = var.P2P_NODEPORT_ENABLED
           "node.service.p2p.announcePort"                       = local.p2p_port_prover
           "node.service.p2p.port"                               = local.p2p_port_prover
@@ -489,6 +490,7 @@ locals {
         "node.env.TX_FILE_STORE_ENABLED"              = var.TX_FILE_STORE_ENABLED
         "node.env.TX_FILE_STORE_URL"                  = var.TX_FILE_STORE_URL
         "node.env.TX_COLLECTION_FILE_STORE_URLS"      = var.TX_COLLECTION_FILE_STORE_URLS
+        "node.env.SEQ_ENABLE_PROPOSER_PIPELINING"     = var.SEQ_ENABLE_PROPOSER_PIPELINING
       })
       boot_node_host_path  = "node.env.BOOT_NODE_HOST"
       bootstrap_nodes_path = "node.env.BOOTSTRAP_NODES"
@@ -528,6 +530,7 @@ locals {
         "node.secret.mnemonicIndex"                   = var.FISHERMAN_MNEMONIC_START_INDEX
         "node.env.KEY_INDEX_START"                    = var.FISHERMAN_MNEMONIC_START_INDEX
         "node.env.VALIDATORS_PER_NODE"                = "1"
+        "node.env.SEQ_ENABLE_PROPOSER_PIPELINING"     = var.SEQ_ENABLE_PROPOSER_PIPELINING
         "node.preStartScript"                         = "source /scripts/get-private-key.sh"
       }
       boot_node_host_path  = "node.env.BOOT_NODE_HOST"
@@ -572,6 +575,7 @@ locals {
         "node.env.P2P_MAX_PENDING_TX_COUNT"           = var.P2P_MAX_PENDING_TX_COUNT
         "node.env.WS_NUM_HISTORIC_CHECKPOINTS"        = var.WS_NUM_HISTORIC_CHECKPOINTS
         "node.env.TX_COLLECTION_FILE_STORE_URLS"      = var.TX_COLLECTION_FILE_STORE_URLS
+        "node.env.SEQ_ENABLE_PROPOSER_PIPELINING"     = var.SEQ_ENABLE_PROPOSER_PIPELINING
       }
       boot_node_host_path  = "node.env.BOOT_NODE_HOST"
       bootstrap_nodes_path = "node.env.BOOTSTRAP_NODES"
@@ -614,6 +618,7 @@ locals {
         "node.env.WS_NUM_HISTORIC_CHECKPOINTS"        = var.WS_NUM_HISTORIC_CHECKPOINTS
         "node.env.TX_COLLECTION_FILE_STORE_URLS"      = var.TX_COLLECTION_FILE_STORE_URLS
         "node.env.BLOB_FILE_STORE_URLS"               = var.BLOB_FILE_STORE_URLS
+        "node.env.SEQ_ENABLE_PROPOSER_PIPELINING"     = var.SEQ_ENABLE_PROPOSER_PIPELINING
       }
       boot_node_host_path  = "node.env.BOOT_NODE_HOST"
       bootstrap_nodes_path = "node.env.BOOTSTRAP_NODES"
@@ -650,6 +655,7 @@ locals {
         "node.env.P2P_DROP_TX_CHANCE"                = var.P2P_DROP_TX_CHANCE
         "node.env.P2P_MAX_PENDING_TX_COUNT"          = var.P2P_MAX_PENDING_TX_COUNT
         "node.env.WS_NUM_HISTORIC_CHECKPOINTS"       = var.WS_NUM_HISTORIC_CHECKPOINTS
+        "node.env.SEQ_ENABLE_PROPOSER_PIPELINING"    = var.SEQ_ENABLE_PROPOSER_PIPELINING
       }
       boot_node_host_path  = "node.env.BOOT_NODE_HOST"
       bootstrap_nodes_path = "node.env.BOOTSTRAP_NODES"


### PR DESCRIPTION
## Motivation

`SEQ_ENABLE_PROPOSER_PIPELINING` was only wired to validator releases, but every aztec-node needs it: the archiver explicitly threads `PipelineConfig` through to `epoch-cache`, which uses the pipelining slot offset when computing the current slot/proposer. With the flag set on validators only, prover, rpc, fisherman, full-node, archive, and blob-sink nodes ran with the default (`false`) and disagreed with the proposer about slot timing on networks where pipelining is enabled (e.g. nextnet).

## Approach

Add `SEQ_ENABLE_PROPOSER_PIPELINING = var.SEQ_ENABLE_PROPOSER_PIPELINING` to the `custom_settings` of every helm release that runs an aztec-node in `terraform/deploy-aztec-infra/main.tf`. Bots and the p2p-bootstrap release don't run an archiver, so they're left alone.

## Changes

- **spartan/terraform/deploy-aztec-infra/main.tf**: pass the pipelining flag through to prover, rpc, fisherman, full-node, archive, and blob-sink releases (in addition to validators).