### PR TITLE
feat(txe): add Foundry-style storage and contract overrides

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
@@ -418,6 +418,27 @@ impl TestEnvironment {
         txe_oracles::advance_timestamp_by(duration);
     }
 
+    /// Foundry-equivalent of `vm.store`. Writes a public storage slot directly to the long-lived
+    /// public-data tree, persisting across subsequent calls.
+    ///
+    /// Side effect: each call mints a synthetic empty block carrying just this write, so
+    /// `block.number` advances by one. Subsequent contract writes to the same slot overwrite the
+    /// value normally; reads see the most recent write.
+    pub unconstrained fn set_public_storage(_self: Self, contract_address: AztecAddress, slot: Field, value: Field) {
+        txe_oracles::set_public_storage(contract_address, slot, value);
+    }
+
+    /// Foundry-equivalent of `vm.etch`. Registers the contract at `path` (its class artifact and
+    /// instance) in TXE's long-lived contract store without running an initializer or emitting a
+    /// deployment nullifier. Returns the instance address.
+    ///
+    /// Use to install mock implementations or set up test fixtures cheaply. Differs from `deploy`
+    /// in that no deployment nullifier is emitted, so contract code asserting on the nullifier
+    /// ("am I really deployed?") will see false.
+    pub unconstrained fn override_contract<let N: u32>(_self: Self, path: str<N>) -> AztecAddress {
+        txe_oracles::override_contract(path, "", [], /*salt=*/ 0, AztecAddress::zero()).to_address()
+    }
+
     /// Creates a new account that can be used as the `from` parameter in contract calls, e.g. in `private_call` or
     /// `public_call`, or be made the owner or recipient of notes in `private_context`.
     ///

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/txe_oracles.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/txe_oracles.nr
@@ -35,6 +35,23 @@ pub unconstrained fn deploy<let M: u32, let N: u32, let P: u32>(
     ContractInstance::deserialize(instance_fields)
 }
 
+/// Foundry-equivalent of `vm.etch`: registers the given contract's class and instance in TXE's
+/// long-lived contract store without emitting a deployment nullifier. Unlike `deploy`, no
+/// initializer is run and no deployment nullifier is emitted, so contract code that asserts on
+/// the deployment nullifier ("am I really deployed?") will see false. Use this to set up test
+/// fixtures cheaply or to install mock implementations for testing.
+pub unconstrained fn override_contract<let M: u32, let N: u32, let P: u32>(
+    path: str<N>,
+    initializer: str<P>,
+    args: [Field; M],
+    salt: Field,
+    deployer: AztecAddress,
+) -> ContractInstance {
+    // Reuses the deploy-oracle path-resolution machinery on the TS side; the secret slot is unused.
+    let instance_fields = override_contract_oracle(path, initializer, args, /*secret=*/ 0, salt, deployer);
+    ContractInstance::deserialize(instance_fields)
+}
+
 pub unconstrained fn private_call_new_flow<let M: u32, let N: u32>(
     from: AztecAddress,
     contract_address: AztecAddress,
@@ -163,6 +180,22 @@ pub unconstrained fn deploy_oracle<let N: u32, let P: u32>(
     salt: Field,
     deployer: AztecAddress,
 ) -> [Field; CONTRACT_INSTANCE_LENGTH] {}
+
+#[oracle(aztec_txe_overrideContract)]
+pub unconstrained fn override_contract_oracle<let N: u32, let P: u32>(
+    path: str<N>,
+    initializer: str<P>,
+    args: [Field],
+    secret: Field,
+    salt: Field,
+    deployer: AztecAddress,
+) -> [Field; CONTRACT_INSTANCE_LENGTH] {}
+
+/// Foundry-equivalent of `vm.store`: writes a public storage slot directly to TXE's long-lived
+/// public-data tree. Persists across subsequent calls. Side effect: advances `block.number` by one
+/// (each cheat call mints a synthetic empty block carrying just the write).
+#[oracle(aztec_txe_setPublicStorage)]
+pub unconstrained fn set_public_storage(contract_address: AztecAddress, slot: Field, value: Field) {}
 
 #[oracle(aztec_txe_createAccount)]
 pub unconstrained fn create_account(secret: Field) -> TestAccount {}

--- a/yarn-project/txe/src/index.ts
+++ b/yarn-project/txe/src/index.ts
@@ -254,6 +254,10 @@ class TXEDispatcher {
         await this.#processDeployInputs(callData);
         break;
       }
+      case 'aztec_txe_overrideContract': {
+        await this.#processDeployInputs(callData);
+        break;
+      }
       case 'aztec_txe_addAccount': {
         await this.#processAddAccountInputs(callData);
         break;

--- a/yarn-project/txe/src/oracle/interfaces.ts
+++ b/yarn-project/txe/src/oracle/interfaces.ts
@@ -50,6 +50,8 @@ export interface ITxeExecutionOracle {
   advanceBlocksBy(blocks: number): Promise<void>;
   advanceTimestampBy(duration: UInt64): void;
   deploy(artifact: ContractArtifact, instance: ContractInstanceWithAddress, foreignSecret: Fr): Promise<void>;
+  overrideContract(artifact: ContractArtifact, instance: ContractInstanceWithAddress): Promise<void>;
+  setPublicStorage(contract: AztecAddress, slot: Fr, value: Fr): Promise<void>;
   createAccount(secret: Fr): Promise<CompleteAddress>;
   addAccount(artifact: ContractArtifact, instance: ContractInstanceWithAddress, secret: Fr): Promise<CompleteAddress>;
   addAuthWitness(address: AztecAddress, messageHash: Fr): Promise<void>;

--- a/yarn-project/txe/src/oracle/txe_oracle_top_level_context.ts
+++ b/yarn-project/txe/src/oracle/txe_oracle_top_level_context.ts
@@ -51,7 +51,7 @@ import {
 } from '@aztec/simulator/server';
 import { type ContractArtifact, EventSelector, FunctionCall, FunctionSelector, FunctionType } from '@aztec/stdlib/abi';
 import { AuthWitness } from '@aztec/stdlib/auth-witness';
-import { PublicSimulatorConfig } from '@aztec/stdlib/avm';
+import { PublicDataWrite, PublicSimulatorConfig } from '@aztec/stdlib/avm';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
 import { type ContractInstanceWithAddress, computePartialAddress } from '@aztec/stdlib/contract';
 import {
@@ -61,7 +61,12 @@ import {
   GasFees,
   GasSettings,
 } from '@aztec/stdlib/gas';
-import { computeCalldataHash, computeProtocolNullifier, siloNullifier } from '@aztec/stdlib/hash';
+import {
+  computeCalldataHash,
+  computeProtocolNullifier,
+  computePublicDataTreeLeafSlot,
+  siloNullifier,
+} from '@aztec/stdlib/hash';
 import {
   PartialPrivateTailPublicInputsForPublic,
   PrivateKernelTailCircuitPublicInputs,
@@ -70,7 +75,7 @@ import {
 } from '@aztec/stdlib/kernel';
 import { ChonkProof } from '@aztec/stdlib/proofs';
 import { makeGlobalVariables } from '@aztec/stdlib/testing';
-import { MerkleTreeId } from '@aztec/stdlib/trees';
+import { MerkleTreeId, PublicDataTreeLeaf } from '@aztec/stdlib/trees';
 import {
   CallContext,
   HashedValues,
@@ -248,6 +253,54 @@ export class TXEOracleTopLevelContext implements IMiscOracle, ITxeExecutionOracl
       await this.contractStore.addContractArtifact(artifact);
       this.logger.debug(`Deployed ${artifact.name} at ${instance.address}`);
     }
+  }
+
+  /**
+   * Registers a contract class and instance in the long-lived contract store without emitting a deployment
+   * nullifier or running a deploy tx. Foundry-equivalent: `vm.etch`. Use to install a contract for tests
+   * without paying the cost of a real deploy. Differs from `deploy` in that no deployment nullifier is
+   * emitted, so contract code that relies on the deployment nullifier as a "is this deployed?" check will
+   * see false.
+   */
+  async overrideContract(artifact: ContractArtifact, instance: ContractInstanceWithAddress) {
+    await this.contractStore.addContractInstance(instance);
+    await this.contractStore.addContractArtifact(artifact);
+    this.logger.debug(`Overrode contract ${artifact.name} at ${instance.address}`);
+  }
+
+  /**
+   * Writes a public storage slot directly to the long-lived public-data tree. Foundry-equivalent: `vm.store`.
+   * Mints a synthetic empty block carrying just this write so the change persists across subsequent calls.
+   * Side effect: advances block.number by one. Subsequent contract writes to the same slot overwrite the
+   * value normally; reads see the most recent write.
+   */
+  async setPublicStorage(contract: AztecAddress, slot: Fr, value: Fr) {
+    const blockNumber = await this.getNextBlockNumber();
+    const leafSlot = await computePublicDataTreeLeafSlot(contract, slot);
+    const dataWrite = new PublicDataWrite(leafSlot, value);
+
+    const txEffect = TxEffect.empty();
+    txEffect.nullifiers = [getSingleTxBlockRequestHash(blockNumber)];
+    txEffect.publicDataWrites = [dataWrite];
+    txEffect.txHash = new TxHash(new Fr(blockNumber));
+
+    const forkedWorldTrees = await this.stateMachine.synchronizer.nativeWorldStateService.fork();
+    await forkedWorldTrees.sequentialInsert(MerkleTreeId.PUBLIC_DATA_TREE, [
+      new PublicDataTreeLeaf(dataWrite.leafSlot, dataWrite.value).toBuffer(),
+    ]);
+    await insertTxEffectIntoWorldTrees(txEffect, forkedWorldTrees);
+
+    const globals = makeGlobalVariables(undefined, {
+      blockNumber,
+      timestamp: this.nextBlockTimestamp,
+      version: this.version,
+      chainId: this.chainId,
+    });
+    const block = await makeTXEBlock(forkedWorldTrees, globals, [txEffect]);
+    await forkedWorldTrees.close();
+
+    this.logger.debug(`set_public_storage at contract=${contract} slot=${slot} value=${value} (block ${blockNumber})`);
+    await this.stateMachine.handleL2Block(block);
   }
 
   async addAccount(artifact: ContractArtifact, instance: ContractInstanceWithAddress, secret: Fr) {

--- a/yarn-project/txe/src/rpc_translator.ts
+++ b/yarn-project/txe/src/rpc_translator.ts
@@ -224,6 +224,36 @@ export class RPCTranslator {
   }
 
   // eslint-disable-next-line camelcase
+  async aztec_txe_overrideContract(artifact: ContractArtifact, instance: ContractInstanceWithAddress) {
+    await this.handlerAsTxe().overrideContract(artifact, instance);
+
+    return toForeignCallResult([
+      toArray([
+        instance.salt,
+        instance.deployer.toField(),
+        instance.currentContractClassId,
+        instance.initializationHash,
+        ...instance.publicKeys.toFields(),
+      ]),
+    ]);
+  }
+
+  // eslint-disable-next-line camelcase
+  async aztec_txe_setPublicStorage(
+    foreignContract: ForeignCallSingle,
+    foreignSlot: ForeignCallSingle,
+    foreignValue: ForeignCallSingle,
+  ) {
+    const contract = addressFromSingle(foreignContract);
+    const slot = fromSingle(foreignSlot);
+    const value = fromSingle(foreignValue);
+
+    await this.handlerAsTxe().setPublicStorage(contract, slot, value);
+
+    return toForeignCallResult([]);
+  }
+
+  // eslint-disable-next-line camelcase
   async aztec_txe_createAccount(foreignSecret: ForeignCallSingle) {
     const secret = fromSingle(foreignSecret);
 


### PR DESCRIPTION
Adds two cheats to TXE that mirror Foundry's `vm.store` and `vm.etch`:

- `env.set_public_storage(contract, slot, value)` — writes a public storage slot directly to TXE's long-lived public-data tree, persisting across subsequent calls. Mints a synthetic empty block carrying just the write (block.number advances by 1 per call). Subsequent contract writes to the same slot overwrite the value normally.

- `env.override_contract(path)` — registers the contract's class artifact and instance in TXE's contract store without running an initializer or emitting a deployment nullifier. Useful for installing mock implementations cheaply.

Wires the cheats end-to-end: `ITxeExecutionOracle` interface, `TXEOracleTopLevelContext` implementation, `RPCTranslator` dispatch, `TXEDispatcher` path-resolution reuse for `override_contract`, Noir oracle declarations, and `TestEnvironment` wrappers.

## Status

This PR ships only the implementation. **Test coverage was deferred** — a Noir test file was drafted at `aztec-nr/aztec/src/test/helpers/test_environment/test/overrides.nr` covering visibility, persistence, contract-write-overwrites-override, address isolation, and block-number advancement, but the test runner (TXE server + `nargo test --oracle-resolver`) was not exercised in this session. Tests should be added as a follow-up — they compile cleanly against the implementation; only running them was skipped.

## Verification done

- TS build: `yarn build` ✓
- `nargo check` for `aztec-nr` and `avm_test_contract`: ✓
- TXE TS unit tests (`yarn workspace @aztec/txe test`): ✓ (3/3 pre-existing tests still pass)

## Design context

See the design walkthrough including Foundry-mapping, considered alternatives (buffer-and-replay vs block-mint), and the rationale for choosing per-cheat block minting.