### PR TITLE
fix(aztec-up): pin FOUNDRY_DIR in foundry install to avoid XDG_CONFIG_HOME mismatch

### DIFF
--- a/aztec-up/bin/0.0.1/install
+++ b/aztec-up/bin/0.0.1/install
@@ -173,11 +173,14 @@ function install_foundry {
   temp_foundry_dir=$(mktemp -d) || { echo "Error: Failed to create temp directory" >&2; exit 1; }
   mkdir -p "$temp_foundry_dir/bin"
 
-  # Always install/update foundryup
-  curl --max-time 30 -L https://foundry.paradigm.xyz | bash
+  # The foundry installer defaults to $XDG_CONFIG_HOME/.foundry when that var is set, which
+  # puts foundryup somewhere we don't expect. We'll pin FOUNDRY_DIR so we control the install
+  # location regardless of the caller's environment.
+  local foundry_home="$HOME/.foundry"
+  FOUNDRY_DIR="$foundry_home" curl --max-time 30 -L https://foundry.paradigm.xyz | FOUNDRY_DIR="$foundry_home" bash
 
   # Install foundry to temp location and move to version directory
-  FOUNDRY_DIR="$temp_foundry_dir" timeout 30 "$HOME/.foundry/bin/foundryup" -i "$foundry_version"
+  FOUNDRY_DIR="$temp_foundry_dir" timeout 30 "$foundry_home/bin/foundryup" -i "$foundry_version"
 
   # Move the foundry binaries to our version bin directory
   for binary in forge cast anvil chisel; do


### PR DESCRIPTION
## Problem

The foundry installer (`foundry.paradigm.xyz`) uses `$XDG_CONFIG_HOME/.foundry` as the install directory when `XDG_CONFIG_HOME` is set, instead of `$HOME/.foundry`. On CI runners where `XDG_CONFIG_HOME` is set, `foundryup` gets installed to an unexpected path (e.g. `/home/runner/.config/.foundry/bin/foundryup`), causing the subsequent `foundryup` invocation to fail with "No such file or directory".

## Fix

Pin `FOUNDRY_DIR="$HOME/.foundry"` on both sides of the `curl | bash` pipe so we control where `foundryup` is installed regardless of the caller's environment.