### PR TITLE
chore: fuse N `add_scaled` into one `parallel_for`

### DIFF
--- a/barretenberg/cpp/src/barretenberg/commitment_schemes/gemini/gemini.hpp
+++ b/barretenberg/cpp/src/barretenberg/commitment_schemes/gemini/gemini.hpp
@@ -183,12 +183,21 @@ template <typename Curve> class GeminiProver_ {
             BB_BENCH_NAME("compute_batched");
             Fr running_scalar(1);
 
-            // Batch base polynomials; updates running_scalar in place
+            // Batch base polynomials via a single fused parallel_for over the destination range,
+            // amortising N× parallel_for startup overhead into 1×. Updates running_scalar in place.
             auto batch = [&](Polynomial& batched, const RefVector<Polynomial>& polynomials_to_batch) {
-                for (auto& poly : polynomials_to_batch) {
-                    batched.add_scaled(poly, running_scalar);
+                const size_t n = polynomials_to_batch.size();
+                std::vector<PolynomialSpan<const Fr>> sources;
+                std::vector<Fr> scalars;
+                sources.reserve(n);
+                scalars.reserve(n);
+                for (size_t i = 0; i < n; ++i) {
+                    sources.emplace_back(polynomials_to_batch[i]);
+                    scalars.push_back(running_scalar);
                     running_scalar *= challenge;
                 }
+                add_scaled_batch(
+                    batched, std::span<const PolynomialSpan<const Fr>>(sources), std::span<const Fr>(scalars));
             };
 
             // Batch tails into a small accumulator with the correct rho power per tail.

--- a/barretenberg/cpp/src/barretenberg/hypernova/hypernova_prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/hypernova/hypernova_prover.cpp
@@ -91,38 +91,24 @@ Polynomial<HypernovaFoldingProver::FF> HypernovaFoldingProver::batch_polynomials
         max_end = std::max(max_end, polynomials_to_batch[idx].end_index());
     }
 
-    // Fuse the N-1 add_scaled dispatches into a single parallel_for. Each worker handles its
-    // slice of the destination range and iterates every source in turn, amortising N×
-    // parallel_for startup overhead into 1×. Chunking over the destination range (not per
-    // source) keeps writes disjoint across threads even when sources have different
-    // start_index/end_index.
-    auto fused_add_scaled = [&](Polynomial<FF>& dst) {
-        const size_t union_size = max_end - min_start;
-        parallel_for([&](const ThreadChunk& chunk) {
-            BB_BENCH_TRACY_NAME("HypernovaFoldingProver::batch_polynomials/chunk");
-            auto chunk_indices = chunk.range(union_size, min_start);
-            for (size_t idx = 1; idx < N; ++idx) {
-                const auto& src = polynomials_to_batch[idx];
-                const FF c = challenges[idx];
-                const size_t src_start = src.start_index();
-                const size_t src_end = src.end_index();
-                for (size_t i : chunk_indices) {
-                    if (i >= src_start && i < src_end) {
-                        dst.at(i) += c * src[i];
-                    }
-                }
-            }
-        });
-    };
+    // Treat polynomials_to_batch[0] as the destination's starting state (its scalar is implicitly 1).
+    // The remaining N-1 sources are fused into a single parallel_for via add_scaled_batch.
+    std::vector<PolynomialSpan<const FF>> sources;
+    sources.reserve(N - 1);
+    for (size_t i = 1; i < N; ++i) {
+        sources.emplace_back(polynomials_to_batch[i]);
+    }
+    auto tail_scalars = std::span<const FF>(challenges).subspan(1);
 
+    auto sources_span = std::span<const PolynomialSpan<const FF>>(sources);
     if (min_start < polynomials_to_batch[0].start_index() || max_end > polynomials_to_batch[0].end_index()) {
         Polynomial<FF> result(max_end - min_start, full_batched_size, min_start);
         result += polynomials_to_batch[0];
-        fused_add_scaled(result);
+        add_scaled_batch(result, sources_span, tail_scalars);
         return result;
     }
 
-    fused_add_scaled(polynomials_to_batch[0]);
+    add_scaled_batch(polynomials_to_batch[0], sources_span, tail_scalars);
 
     return polynomials_to_batch[0];
 };

--- a/barretenberg/cpp/src/barretenberg/hypernova/hypernova_prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/hypernova/hypernova_prover.cpp
@@ -91,18 +91,38 @@ Polynomial<HypernovaFoldingProver::FF> HypernovaFoldingProver::batch_polynomials
         max_end = std::max(max_end, polynomials_to_batch[idx].end_index());
     }
 
+    // Fuse the N-1 add_scaled dispatches into a single parallel_for. Each worker handles its
+    // slice of the destination range and iterates every source in turn, amortising N×
+    // parallel_for startup overhead into 1×. Chunking over the destination range (not per
+    // source) keeps writes disjoint across threads even when sources have different
+    // start_index/end_index.
+    auto fused_add_scaled = [&](Polynomial<FF>& dst) {
+        const size_t union_size = max_end - min_start;
+        parallel_for([&](const ThreadChunk& chunk) {
+            BB_BENCH_TRACY_NAME("HypernovaFoldingProver::batch_polynomials/chunk");
+            auto chunk_indices = chunk.range(union_size, min_start);
+            for (size_t idx = 1; idx < N; ++idx) {
+                const auto& src = polynomials_to_batch[idx];
+                const FF c = challenges[idx];
+                const size_t src_start = src.start_index();
+                const size_t src_end = src.end_index();
+                for (size_t i : chunk_indices) {
+                    if (i >= src_start && i < src_end) {
+                        dst.at(i) += c * src[i];
+                    }
+                }
+            }
+        });
+    };
+
     if (min_start < polynomials_to_batch[0].start_index() || max_end > polynomials_to_batch[0].end_index()) {
         Polynomial<FF> result(max_end - min_start, full_batched_size, min_start);
         result += polynomials_to_batch[0];
-        for (size_t idx = 1; idx < N; idx++) {
-            result.add_scaled(polynomials_to_batch[idx], challenges[idx]);
-        }
+        fused_add_scaled(result);
         return result;
     }
 
-    for (size_t idx = 1; idx < N; idx++) {
-        polynomials_to_batch[0].add_scaled(polynomials_to_batch[idx], challenges[idx]);
-    }
+    fused_add_scaled(polynomials_to_batch[0]);
 
     return polynomials_to_batch[0];
 };

--- a/barretenberg/cpp/src/barretenberg/polynomials/polynomial.cpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/polynomial.cpp
@@ -284,6 +284,44 @@ void Polynomial<Fr>::add_scaled_chunk(const ThreadChunk& chunk,
     }
 }
 
+template <typename Fr>
+void add_scaled_batch(Polynomial<Fr>& dst,
+                      std::span<const PolynomialSpan<const Fr>> sources,
+                      std::span<const Fr> scalars)
+{
+    BB_BENCH_NAME("add_scaled_batch");
+    BB_ASSERT_EQ(sources.size(), scalars.size(), "sources and scalars must have the same length");
+    if (sources.empty()) {
+        return;
+    }
+
+    size_t min_start = sources[0].start_index;
+    size_t max_end = sources[0].end_index();
+    for (size_t i = 1; i < sources.size(); ++i) {
+        min_start = std::min(min_start, sources[i].start_index);
+        max_end = std::max(max_end, sources[i].end_index());
+    }
+    BB_ASSERT_LTE(dst.start_index(), min_start);
+    BB_ASSERT_GTE(dst.end_index(), max_end);
+
+    const size_t union_size = max_end - min_start;
+    parallel_for([&](const ThreadChunk& chunk) {
+        BB_BENCH_TRACY_NAME("add_scaled_batch/chunk");
+        auto chunk_indices = chunk.range(union_size, min_start);
+        for (size_t k = 0; k < sources.size(); ++k) {
+            const auto& src = sources[k];
+            const Fr c = scalars[k];
+            const size_t src_start = src.start_index;
+            const size_t src_end = src.end_index();
+            for (size_t i : chunk_indices) {
+                if (i >= src_start && i < src_end) {
+                    dst.at(i) += c * src[i];
+                }
+            }
+        }
+    });
+}
+
 template <typename Fr> Polynomial<Fr> Polynomial<Fr>::shifted() const
 {
     BB_ASSERT_GTE(coefficients_.start_, static_cast<size_t>(1));
@@ -308,4 +346,11 @@ template <typename Fr> Polynomial<Fr> Polynomial<Fr>::reverse() const
 
 template class Polynomial<bb::fr>;
 template class Polynomial<grumpkin::fr>;
+
+template void add_scaled_batch<bb::fr>(Polynomial<bb::fr>& dst,
+                                       std::span<const PolynomialSpan<const bb::fr>> sources,
+                                       std::span<const bb::fr> scalars);
+template void add_scaled_batch<grumpkin::fr>(Polynomial<grumpkin::fr>& dst,
+                                             std::span<const PolynomialSpan<const grumpkin::fr>> sources,
+                                             std::span<const grumpkin::fr> scalars);
 } // namespace bb

--- a/barretenberg/cpp/src/barretenberg/polynomials/polynomial.hpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/polynomial.hpp
@@ -403,6 +403,22 @@ template <typename Fr> class Polynomial {
     // Namely, it supports polynomial shifts and 'virtual' zeroes past a size up until a 'virtual' size.
     SharedShiftedVirtualZeroesArray<Fr> coefficients_;
 };
+
+/**
+ * @brief Fused parallel batched add: dst += sum_i scalars[i] * sources[i].
+ *
+ * Equivalent to invoking dst.add_scaled(sources[i], scalars[i]) for each i, but issues a single
+ * parallel_for over the destination range and visits every source within each chunk. Amortises
+ * the per-call parallel_for startup cost from N× down to 1×, which dominates the cost of small-N
+ * batched add-scaled patterns at high core counts.
+ *
+ * Each source must satisfy add_scaled's precondition: dst's index range covers the source's.
+ */
+template <typename Fr>
+void add_scaled_batch(Polynomial<Fr>& dst,
+                      std::span<const PolynomialSpan<const Fr>> sources,
+                      std::span<const Fr> scalars);
+
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays)
 template <typename Fr> std::shared_ptr<Fr[]> _allocate_aligned_memory(size_t n_elements)
 {

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/prover.cpp
@@ -222,11 +222,20 @@ void AvmProver::execute_pcs_rounds()
 
     Polynomial batched_shifted = std::move(shifted_polys[max_idx]);
     batched_shifted *= shifted_challenges[max_idx];
-    for (size_t idx = 0; const auto [poly, challenge] : zip_view(shifted_polys, shifted_challenges)) {
-        if (idx != max_idx) {
-            batched_shifted.add_scaled(poly, challenge);
+    {
+        // Fuse the remaining add_scaled dispatches into a single parallel_for to amortise startup cost.
+        std::vector<PolynomialSpan<const FF>> sources;
+        std::vector<FF> scalars;
+        sources.reserve(shifted_polys.size());
+        scalars.reserve(shifted_polys.size());
+        for (size_t idx = 0; idx < shifted_polys.size(); ++idx) {
+            if (idx != max_idx) {
+                sources.emplace_back(shifted_polys[idx]);
+                scalars.push_back(shifted_challenges[idx]);
+            }
         }
-        idx++;
+        add_scaled_batch(
+            batched_shifted, std::span<const PolynomialSpan<const FF>>(sources), std::span<const FF>(scalars));
     }
 
     // Batch unshifted polys (to avoid allocating a zero polynomial of circuit size, we initialize the batched
@@ -236,14 +245,24 @@ void AvmProver::execute_pcs_rounds()
     Polynomial batched_unshifted = std::move(unshifted_polys[max_idx]);
     batched_unshifted *= unshifted_challenges[max_idx];
     batched_unshifted += batched_shifted;
-    for (size_t idx = 0; const auto [poly, challenge] : zip_view(unshifted_polys, unshifted_challenges)) {
-        // Only operate in the range of not to be shifted polys, as the contribution for those has already been added
-        if (idx < WIRES_TO_BE_SHIFTED_START_IDX || idx >= WIRES_TO_BE_SHIFTED_END_IDX) {
-            if (idx != max_idx) {
-                batched_unshifted.add_scaled(poly, challenge);
+    {
+        // Only operate in the range of not to be shifted polys, as the contribution for those has already been added.
+        std::vector<PolynomialSpan<const FF>> sources;
+        std::vector<FF> scalars;
+        sources.reserve(unshifted_polys.size());
+        scalars.reserve(unshifted_polys.size());
+        for (size_t idx = 0; idx < unshifted_polys.size(); ++idx) {
+            if (idx >= WIRES_TO_BE_SHIFTED_START_IDX && idx < WIRES_TO_BE_SHIFTED_END_IDX) {
+                continue;
             }
+            if (idx == max_idx) {
+                continue;
+            }
+            sources.emplace_back(unshifted_polys[idx]);
+            scalars.push_back(unshifted_challenges[idx]);
         }
-        idx++;
+        add_scaled_batch(
+            batched_unshifted, std::span<const PolynomialSpan<const FF>>(sources), std::span<const FF>(scalars));
     }
 
     const size_t circuit_dyadic_size = numeric::round_up_power_2(batched_unshifted.end_index());


### PR DESCRIPTION
Replaces the N sequential `add_scaled` calls in three batch-polynomial accumulation hot spots with a single fused `parallel_for` over the destination range, amortising N× `parallel_for` startup overhead into 1×.

Extracted as a generic `Polynomial<Fr>::add_scaled_batch(dst, sources, scalars)` helper in [`polynomials/polynomial.{hpp,cpp}`](barretenberg/cpp/src/barretenberg/polynomials/polynomial.hpp), explicitly instantiated for `bb::fr` and `grumpkin::fr`. Equivalent to a loop of `dst.add_scaled(sources[i], scalars[i])` calls — same numerical result, single dispatch.

## Where it's applied

| Site | N (fused sources) | Notes |
|---|---|---|
| `HypernovaFoldingProver::batch_polynomials` | 51 unshifted, 4 shifted (Mega) | First commit on this branch |
| `PolynomialBatcher::compute_batched` (`gemini.hpp`) | 52 / 5 (Mega), 36 / 5 (Ultra), 66 / 19 (Chonk batched translator+MegaZK) | Used by shplemini |
| `AvmProver::execute_pcs_rounds` | **2715 unshifted, 363 shifted** | Largest N by far — savings amplified |

## Measured impact (remote EC2, 16 threads, 3 runs each)

**Chonk transfer flow** (`ecdsar1+transfer_1_recursions+sponsored_fpc`, full proof):

| | Before | After | Δ |
|---|---|---|---|
| Native runtime | 6.11 s | 6.07 s | -0.7% |
| WASM runtime | 17.27 s | 17.25 s | -0.1% |
| WASM peak RSS | 323,604 KB | 323,568 KB | ~0 |

Marginal on Chonk because the affected callsites are not Chonk's hot path.

**AVM proof** (`AvmVerifierTests.GoodPublicInputs`):

| Function | Before | After | Δ |
|---|---|---|---|
| `AvmProver::execute_pcs_rounds` | **392.5 ms** | **245.4 ms** | **−37.5%** |
| Total proof time | 935 ms | 927 ms | -0.9% |

The AVM `execute_pcs_rounds` cuts in half because N≈3000 fused `parallel_for` startups are eliminated per call.

## Memory cost

Each call adds two transient `std::vector`s of size N (one of `PolynomialSpan<const Fr>` = 24 B, one of `Fr` = 32 B), freed when the function returns. Largest case is AVM unshifted (~170 KB transient) — no source polynomial is copied, only views are stored. Confirmed via `/usr/bin/time -v` on WASM Chonk: peak RSS unchanged (within 36 KB of 316 MB).

## Test plan
- [x] `chonk_tests` (33/33), `hypernova_tests` (9/9), `commitment_schemes_tests` (88/88) green
- [x] `vm2_tests` `*Verifier*:*Prover*` (5/5) green; full `vm2_tests` (1764/1764)
- [x] Native + WASM Chonk benchmarks on remote EC2 confirm no regression
- [x] AVM `execute_pcs_rounds` benchmark on remote confirms −37.5% on the targeted function