### PR TITLE
feat(aztec.js): cheatcode helpers for contract overrides

### DIFF
--- a/docs/docs-developers/docs/aztec-js/how_to_test.md
+++ b/docs/docs-developers/docs/aztec-js/how_to_test.md
@@ -124,6 +124,13 @@ const result = await contract.methods.upgraded_method().simulate({ stateOverride
 
 Use this to test code paths that only execute after an upgrade, without orchestrating the full delayed-mutable upgrade flow.
 
+### Lower-level primitives
+
+For composing override blobs by hand, two `spoof*` helpers are exposed:
+
+- `spoofContractClassPublish(class)` returns `{ contractClasses: [class] }`. Useful for testing against a class that hasn't been published.
+- `spoofContractInstancePublish(instance)` returns `{ contractInstances: [instance] }`. Throws if the instance's `currentContractClassId` differs from its `originalContractClassId` — divergence requires a coherent registry-storage override, which only `fastForwardContractUpdate` produces.
+
 ## Further reading
 
 - [How to read contract data](./how_to_read_data.md)

--- a/docs/docs-developers/docs/resources/migration_notes.md
+++ b/docs/docs-developers/docs/resources/migration_notes.md
@@ -36,6 +36,8 @@ const stateOverrides = await fastForwardContractUpdate({
 const result = await contract.methods.upgraded_method().simulate({ stateOverrides });
 ```
 
+Two lower-level primitives, `spoofContractClassPublish` and `spoofContractInstancePublish`, expose direct construction of contract DB overrides for power users.
+
 ### [PXE] `proveTx` takes an options bag
 
 `PXE.proveTx` used to accept `scopes` as a positional argument; it now takes an options bag consistent with `simulateTx` and `profileTx`, and adds an optional `senderForTags` field. Update direct callers:

--- a/yarn-project/aztec.js/src/api/contract.ts
+++ b/yarn-project/aztec.js/src/api/contract.ts
@@ -75,6 +75,11 @@ export {
 export { waitForProven, type WaitForProvenOpts, DefaultWaitForProvenOpts } from '../contract/wait_for_proven.js';
 export { getGasLimits } from '../contract/get_gas_limits.js';
 export { fastForwardContractUpdate } from '../contract/fastforward_contract_update.js';
+export {
+  type ContractStateOverrides,
+  spoofContractClassPublish,
+  spoofContractInstancePublish,
+} from '../contract/contract_simulation_overrides.js';
 
 export {
   type PartialAddress,

--- a/yarn-project/aztec.js/src/contract/contract_simulation_overrides.test.ts
+++ b/yarn-project/aztec.js/src/contract/contract_simulation_overrides.test.ts
@@ -1,0 +1,36 @@
+import { Fr } from '@aztec/foundation/curves/bn254';
+import { AztecAddress } from '@aztec/stdlib/aztec-address';
+import { SerializableContractInstance } from '@aztec/stdlib/contract';
+
+import { spoofContractClassPublish, spoofContractInstancePublish } from './contract_simulation_overrides.js';
+
+describe('contract simulation override helpers', () => {
+  describe('spoofContractClassPublish', () => {
+    it('returns the class wrapped in contractClasses', () => {
+      const klass = { id: Fr.random() } as any;
+      expect(spoofContractClassPublish(klass)).toEqual({ contractClasses: [klass] });
+    });
+  });
+
+  describe('spoofContractInstancePublish', () => {
+    it('returns the instance wrapped in contractInstances when current == original class', async () => {
+      const classId = Fr.random();
+      const instance = (
+        await SerializableContractInstance.random({ currentContractClassId: classId, originalContractClassId: classId })
+      ).withAddress(await AztecAddress.random());
+
+      expect(spoofContractInstancePublish(instance)).toEqual({ contractInstances: [instance] });
+    });
+
+    it('throws when current and original class IDs differ', async () => {
+      const instance = (
+        await SerializableContractInstance.random({
+          currentContractClassId: Fr.random(),
+          originalContractClassId: Fr.random(),
+        })
+      ).withAddress(await AztecAddress.random());
+
+      expect(() => spoofContractInstancePublish(instance)).toThrow(/fastForwardContractUpdate/);
+    });
+  });
+});

--- a/yarn-project/aztec.js/src/contract/contract_simulation_overrides.ts
+++ b/yarn-project/aztec.js/src/contract/contract_simulation_overrides.ts
@@ -1,0 +1,51 @@
+import type { ContractClassPublic, ContractInstanceWithAddress } from '@aztec/stdlib/contract';
+import type { StateOverrides } from '@aztec/stdlib/interfaces/client';
+
+/**
+ * Subset of `StateOverrides` containing only contract class/instance fields. The cheatcode helpers
+ * below produce values of this type for spreading into a `stateOverrides` argument.
+ */
+export type ContractStateOverrides = Pick<StateOverrides, 'contractClasses' | 'contractInstances'>;
+
+/**
+ * Cheatcode-style primitives for building `ContractStateOverrides` blobs to pass into
+ * `simulate({ stateOverrides: { ... } })`.
+ *
+ * Each helper produces an override blob that, when applied during simulation, makes the simulator
+ * behave as if the corresponding on-chain action had occurred — without actually running it. The
+ * helpers themselves perform no state changes; they only build the blob.
+ *
+ * For simulating a contract upgrade end-to-end (instance + registry storage), see the higher-level
+ * `fastForwardContractUpdate` helper instead — these primitives compose the contract DB side only.
+ *
+ * Naming mirrors the real on-chain action being spoofed:
+ * - `spoofContractClassPublish` ↔ `publishContractClass`
+ * - `spoofContractInstancePublish` ↔ `publishInstance`
+ */
+
+/** Builds an override blob that pretends `contractClass` was published on the class registry. */
+export function spoofContractClassPublish(contractClass: ContractClassPublic): ContractStateOverrides {
+  return { contractClasses: [contractClass] };
+}
+
+/**
+ * Builds an override blob that pretends `instance` was published on the instance registry.
+ *
+ * Validates that the instance's `currentContractClassId` matches its `originalContractClassId`. The
+ * AVM's UpdateCheck (run during witgen/proving) verifies that any divergence between current and
+ * original class IDs is backed by a consistent entry in the registry's delayed-public-mutable
+ * storage. To inject an instance whose current class differs from its original, use
+ * `fastForwardContractUpdate` instead — it produces both the instance and registry storage
+ * overrides as a coherent set.
+ *
+ * @throws If `instance.currentContractClassId` differs from `instance.originalContractClassId`.
+ */
+export function spoofContractInstancePublish(instance: ContractInstanceWithAddress): ContractStateOverrides {
+  if (!instance.currentContractClassId.equals(instance.originalContractClassId)) {
+    throw new Error(
+      `Cannot spoof publish of instance ${instance.address} with currentContractClassId != originalContractClassId; ` +
+        `use fastForwardContractUpdate to spoof an upgraded instance instead`,
+    );
+  }
+  return { contractInstances: [instance] };
+}


### PR DESCRIPTION
## Summary

Adds two low-level cheatcode primitives for building `ContractStateOverrides` blobs:

- `spoofContractClassPublish(class)` ↔ `publishContractClass`
- `spoofContractInstancePublish(instance)` ↔ `publishInstance`

`spoofContractInstancePublish` validates that the instance's current and original class IDs match. Divergence requires a coherent registry-storage override; use `fastForwardContractUpdate` (#22905) for that case.

Earlier-draft helpers `spoofContractDeployment`, `spoofContractUpdate`, and `spoofContractUpdateWithClassId` are dropped: deployment needs nullifier overrides which aren't plumbed yet, and the update helpers are fully subsumed by `fastForwardContractUpdate` in #22905.

Stacks above #22833.