### PR TITLE
fix: e2e compat should not fail for contracts added after legacy stables

### DIFF
--- a/yarn-project/end-to-end/src/legacy-jest-resolver.cjs
+++ b/yarn-project/end-to-end/src/legacy-jest-resolver.cjs
@@ -95,13 +95,8 @@ module.exports = function legacyResolver(request, options) {
     return resolved;
   }
   if (!fs.existsSync(legacy)) {
-    // Contract was added after this release — there is nothing to compat-test for it. Exit the process cleanly
-    // with code 0 so the test runner reports the run as passed (no false-positive compat coverage is claimed —
-    // the test simply did not run). We exit on the first miss because the suite cannot proceed without this
-    // artifact anyway; one log line is enough to make the skip auditable.
-    //
-    // We use fs.writeSync(2, ...) instead of process.stderr.write so the message is flushed synchronously
-    // before process.exit (process.stderr.write may buffer when stderr is piped to a file, as it is in CI).
+    // Contract was added after this historical release, there is nothing to compat-test for it. Exit the process
+    // cleanly with code 0 so the test runner reports the run as passed.
     fs.writeSync(
       2,
       `[legacy-contracts][jest] artifact ${path.basename(legacy)} not in legacy cache @${version}; ` +

--- a/yarn-project/end-to-end/src/legacy-jest-resolver.cjs
+++ b/yarn-project/end-to-end/src/legacy-jest-resolver.cjs
@@ -11,6 +11,13 @@
 // Cache population lives in install_legacy_contracts.cjs — invoked lazily here for local dev, and eagerly
 // by bootstrap.sh ci-compat-e2e before hermetic test containers (which run with --net=none) launch.
 //
+// Missing artifacts: legacy version directories are immutable, so an artifact missing from the cache means the
+// contract was added after the pinned release — there's nothing to compat-test. Rather than failing or silently
+// falling back to the workspace artifact (which would turn the compat run into a regular e2e run that always
+// passes), we log the miss and exit the process cleanly with code 0. The test never runs, but the per-test CI
+// log captures the explanatory line so the reason is auditable. This keeps the change scoped to this resolver,
+// avoiding a new exit-code contract in the shared ci3 test runner.
+//
 // Activated by env var; passthrough otherwise.
 /* eslint-disable @typescript-eslint/no-require-imports */
 
@@ -88,10 +95,19 @@ module.exports = function legacyResolver(request, options) {
     return resolved;
   }
   if (!fs.existsSync(legacy)) {
-    throw new Error(
-      `[legacy-contracts] artifact ${path.basename(legacy)} not present in legacy cache @${version}; ` +
-        `the contract may have been added after that release. Pin a newer CONTRACT_ARTIFACTS_VERSION or skip this test.`,
+    // Contract was added after this release — there is nothing to compat-test for it. Exit the process cleanly
+    // with code 0 so the test runner reports the run as passed (no false-positive compat coverage is claimed —
+    // the test simply did not run). We exit on the first miss because the suite cannot proceed without this
+    // artifact anyway; one log line is enough to make the skip auditable.
+    //
+    // We use fs.writeSync(2, ...) instead of process.stderr.write so the message is flushed synchronously
+    // before process.exit (process.stderr.write may buffer when stderr is piped to a file, as it is in CI).
+    fs.writeSync(
+      2,
+      `[legacy-contracts][jest] artifact ${path.basename(legacy)} not in legacy cache @${version}; ` +
+        `assumed added after this release. No compat coverage applicable for this version, treating as passed.\n`,
     );
+    process.exit(0);
   }
   if (!seen.has(resolved)) {
     seen.add(resolved);


### PR DESCRIPTION
For example, this failure is a false positive: https://github.com/AztecProtocol/aztec-packages/actions/runs/25204430819/job/73902953105

This happened because the contract used to e2e test nested utility calls didn't exist back in 4.2.0. It's not a failure: it's a test that should trivially pass.

We do however log such cases, in case they help us trace subtler issues in the future.