### PR TITLE
chore: reject non-canonical x coordinate (native affine_element)

### DIFF
--- a/barretenberg/cpp/src/barretenberg/ecc/groups/affine_element.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/groups/affine_element.test.cpp
@@ -247,6 +247,30 @@ template <typename G1> class TestAffineElement : public testing::Test {
         EXPECT_NE(P < Q, Q < P);
     }
 
+    // Regression test: from_compressed must reject non-canonical encodings (x_coordinate >= modulus).
+    // Without the range check, Fq(x) silently reduces mod p, so distinct compressed bytestrings whose
+    // x values differ by a multiple of p would decompress to the same point (encoding malleability).
+    static void test_point_compression_non_canonical_x()
+    {
+        using Fq = typename G1::Fq;
+        // x1 = 1 and x2 = 1 + p both fit in 255 bits because p_BN254 < 2^254 and p_Grumpkin < 2^254.
+        // They are distinct as 255-bit integers but equal mod p.
+        uint256_t x1 = uint256_t(1);
+        uint256_t x2 = uint256_t(1) + Fq::modulus;
+        ASSERT_NE(x1, x2);
+        ASSERT_LT(x2, uint256_t(1) << 255);
+
+        affine_element pt1 = affine_element::from_compressed(x1);
+        affine_element pt2 = affine_element::from_compressed(x2);
+
+        // Canonical input (x = 1) decompresses to a valid point on these curves.
+        EXPECT_TRUE(pt1.on_curve());
+        // Non-canonical input must return the (0, 0) sentinel rather than the same point as x1.
+        EXPECT_EQ(pt2.x, Fq::zero());
+        EXPECT_EQ(pt2.y, Fq::zero());
+        EXPECT_NE(pt1, pt2);
+    }
+
     // Verify that from_compressed with an x that has no y on the curve returns the (0,0) sentinel.
     static void test_point_compression_invalid_x()
     {
@@ -887,6 +911,16 @@ TYPED_TEST(TestAffineElement, PointCompressionInvalidX)
         GTEST_SKIP(); // from_compressed is not used on large-modulus curves
     } else {
         TestFixture::test_point_compression_invalid_x();
+    }
+}
+
+// Regression test: from_compressed must reject non-canonical x >= modulus.
+TYPED_TEST(TestAffineElement, PointCompressionNonCanonicalX)
+{
+    if constexpr (TypeParam::Fq::modulus.data[3] >= MODULUS_TOP_LIMB_LARGE_THRESHOLD) {
+        GTEST_SKIP(); // from_compressed is not used on large-modulus curves
+    } else {
+        TestFixture::test_point_compression_non_canonical_x();
     }
 }
 

--- a/barretenberg/cpp/src/barretenberg/ecc/groups/affine_element_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/groups/affine_element_impl.hpp
@@ -24,6 +24,13 @@ constexpr affine_element<Fq, Fr, T> affine_element<Fq, Fr, T>::from_compressed(c
     x_coordinate.data[3] = x_coordinate.data[3] & (~UINT256_TOP_LIMB_MSB);
     bool y_bit = compressed.get_bit(255);
 
+    // Reject non-canonical encodings: the lower 255 bits encode x. If x_coordinate >= Fq::modulus,
+    // Fq(x_coordinate) silently reduces mod p, so two distinct compressed bytestrings differing by
+    // a multiple of p would decompress to the same point (encoding malleability).
+    if (x_coordinate >= Fq::modulus) {
+        return affine_element(Fq::zero(), Fq::zero());
+    }
+
     Fq x = Fq(x_coordinate);
     Fq y2 = (x.sqr() * x + T::b);
     if constexpr (T::has_a) {

--- a/barretenberg/cpp/src/barretenberg/eccvm/eccvm_fixed_vk.hpp
+++ b/barretenberg/cpp/src/barretenberg/eccvm/eccvm_fixed_vk.hpp
@@ -25,13 +25,13 @@ class ECCVMHardcodedVKAndHash {
     using BF = curve::Grumpkin::BaseField;
 
     // Precomputed VK hash (hash of all commitments below). Update via ECCVMTests::FixedVK if commitments change.
-    static BF vk_hash() { return BF(uint256_t("0x103f7a122fe63075eb8b9c6019cbd3cbe55b5775400799b12c63b31643515ff3")); }
+    static BF vk_hash() { return BF(uint256_t("0x032ece6c493f6e74ca8847127f189f8e759021e53df9820a88985e41e400fde2")); }
 
     static std::vector<Commitment> get_all()
     {
         return { // lagrange_first (at row NUM_DISABLED_ROWS_IN_SUMCHECK)
-                 Commitment(uint256_t("0x040948748b49a15e319d8ae97062ce125445f612bbf4265776490dafe4a75aa7"),
-                            uint256_t("0x0674e7fcc6e6685f250a218ab444bef48b9772e3fb32425d579c4430f919828b")),
+                 Commitment(uint256_t("0x1227d829cc03e51a2cc68ca0e08381c02b78c484f4092a10584ef78381a31968"),
+                            uint256_t("0x10b233eb875fed8834f6235ed737946b68c0c7ed258053cd943dcc69212d90d6")),
 
                  // lagrange_second (hiding op row)
                  Commitment(uint256_t("0x1976c760e4bde34db58394888baeda91f57bcdddf60aec28b721b10aac55f555"),
@@ -42,8 +42,8 @@ class ECCVMHardcodedVKAndHash {
                             uint256_t("0x0d04425c0f370a7aaace3cf41f9b2380079c95fa26f9f83b5fd5e26813dbd289")),
 
                  // lagrange_last (at dyadic_size - 1)
-                 Commitment(uint256_t("0x07099c9989bd2212d634a00180d59f1dd1279c5c3d220583ad4acfbfb180ae60"),
-                            uint256_t("0x2fa02a4987281b3b310bb8d9724c36a20eec491acfd3be7e7f3dcf8d8bec8848"))
+                 Commitment(uint256_t("0x23a271e0e1d99d2a526cc8c06df7edf7c86e9cb985e577affb5a64b9daf24401"),
+                            uint256_t("0x12a74c457ae1f9bd6076c308f47a006deb82adfd576be1266cde1cdc0d008cd1"))
         };
     }
 };

--- a/barretenberg/cpp/src/barretenberg/srs/factories/crs_factory.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/srs/factories/crs_factory.test.cpp
@@ -61,7 +61,7 @@ void check_grumpkin_consistency(const fs::path& crs_download_path, size_t num_po
     // read G1
     std::vector<Grumpkin::AffineElement> points(num_points);
     auto data =
-        read_file(bb::srs::bb_crs_path() / "grumpkin_g1.flat.dat", num_points * sizeof(Grumpkin::AffineElement));
+        read_file(bb::srs::bb_crs_path() / "grumpkin_g1_v2.flat.dat", num_points * sizeof(Grumpkin::AffineElement));
 
     for (size_t i = 0; i < num_points; ++i) {
         points[i] = from_buffer<Grumpkin::AffineElement>(data, i * sizeof(g1::affine_element));

--- a/barretenberg/cpp/src/barretenberg/srs/factories/get_grumpkin_crs.cpp
+++ b/barretenberg/cpp/src/barretenberg/srs/factories/get_grumpkin_crs.cpp
@@ -13,7 +13,7 @@ std::vector<curve::Grumpkin::AffineElement> get_grumpkin_g1_data(const std::file
 {
     std::filesystem::create_directories(path);
 
-    auto g1_path = path / "grumpkin_g1.flat.dat";
+    auto g1_path = path / "grumpkin_g1_v2.flat.dat";
     auto lock_path = path / "crs.lock";
     // Acquire exclusive lock to prevent simultaneous generation/writes
     FileLockGuard lock(lock_path.string());

--- a/barretenberg/crs/bootstrap.sh
+++ b/barretenberg/crs/bootstrap.sh
@@ -98,14 +98,14 @@ function build {
     download_with_fallback "$g2" "g2.dat"
   fi
 
-  # TODO: This grumpkin CRS in S3 still has the 28 byte header on it. Remove.
-  # And if we ever need more than transcript00.dat, concatenate to single file like we did with bn254 above.
+  # grumpkin_g1_v2.dat: regenerated after affine_element::from_compressed started rejecting
+  # non-canonical x coordinates, so it must match binaries built with that fix.
   crs_size=$((2**18))
   crs_size_bytes=$((crs_size*64))
-  gg1=$crs_path/grumpkin_g1.flat.dat
+  gg1=$crs_path/grumpkin_g1_v2.flat.dat
   if [ ! -f "$gg1" ] || [ $(stat -c%s "$gg1") -lt $crs_size_bytes ]; then
     echo "Downloading grumpkin crs of size: ${crs_size} ($((crs_size_bytes/(1024*1024)))MB)"
-    download_with_fallback "$gg1" "grumpkin_g1.dat" "bytes=0-$((crs_size_bytes-1))"
+    download_with_fallback "$gg1" "grumpkin_g1_v2.dat" "bytes=0-$((crs_size_bytes-1))"
   fi
 }
 

--- a/barretenberg/scripts/download_bb_crs.sh
+++ b/barretenberg/scripts/download_bb_crs.sh
@@ -56,12 +56,12 @@ if [ ! -f "$g2" ]; then
   download_with_fallback "$g2" "g2.dat"
 fi
 
-# TODO: This grumpkin CRS in S3 still has the 28 byte header on it. Remove.
-# And if we ever need more than transcript00.dat, concatenate to single file like we did with bn254 above.
+# grumpkin_g1_v2.dat: regenerated after affine_element::from_compressed started rejecting
+# non-canonical x coordinates, so it must match binaries built with that fix.
 crs_size=$((2**18))
 crs_size_bytes=$((crs_size*64))
-gg1=$crs_path/grumpkin_g1.flat.dat
+gg1=$crs_path/grumpkin_g1_v2.flat.dat
 if [ ! -f "$gg1" ] || [ $(stat -c%s "$gg1") -lt $crs_size_bytes ]; then
   echo "Downloading grumpkin crs of size: ${crs_size} ($((crs_size_bytes/(1024*1024)))MB)"
-  download_with_fallback "$gg1" "grumpkin_g1.dat" "bytes=0-$((crs_size_bytes-1))"
+  download_with_fallback "$gg1" "grumpkin_g1_v2.dat" "bytes=0-$((crs_size_bytes-1))"
 fi

--- a/barretenberg/ts/src/crs/browser/cached_net_crs.ts
+++ b/barretenberg/ts/src/crs/browser/cached_net_crs.ts
@@ -83,13 +83,13 @@ export class CachedNetGrumpkinCrs {
    */
   async init() {
     // Check if data is in IndexedDB
-    const g1Data = await get('grumpkinG1Data');
+    const g1Data = await get('grumpkinG1DataV2');
     const netGrumpkinCrs = new NetGrumpkinCrs(this.numPoints);
     const g1DataLength = this.numPoints * 64;
 
     if (!g1Data || g1Data.length < g1DataLength) {
       this.g1Data = await netGrumpkinCrs.downloadG1Data();
-      await set('grumpkinG1Data', this.g1Data);
+      await set('grumpkinG1DataV2', this.g1Data);
     } else {
       this.g1Data = g1Data;
     }

--- a/barretenberg/ts/src/crs/net_crs.ts
+++ b/barretenberg/ts/src/crs/net_crs.ts
@@ -188,8 +188,8 @@ export class NetGrumpkinCrs {
     };
 
     return await fetchWithFallback(
-      `${CRS_PRIMARY_HOST}/grumpkin_g1.dat`,
-      `${CRS_FALLBACK_HOST}/grumpkin_g1.dat`,
+      `${CRS_PRIMARY_HOST}/grumpkin_g1_v2.dat`,
+      `${CRS_FALLBACK_HOST}/grumpkin_g1_v2.dat`,
       options,
     );
   }

--- a/barretenberg/ts/src/crs/node/index.ts
+++ b/barretenberg/ts/src/crs/node/index.ts
@@ -130,7 +130,7 @@ export class GrumpkinCrs {
   async init(): Promise<void> {
     mkdirSync(this.path, { recursive: true });
 
-    const g1FileSize = await stat(this.path + '/grumpkin_g1.flat.dat')
+    const g1FileSize = await stat(this.path + '/grumpkin_g1_v2.flat.dat')
       .then(stats => stats.size)
       .catch(() => 0);
 
@@ -143,7 +143,7 @@ export class GrumpkinCrs {
     const crs = new NetGrumpkinCrs(this.numPoints);
     const stream = await crs.streamG1Data();
 
-    await finished(Readable.fromWeb(stream as any).pipe(createWriteStream(this.path + '/grumpkin_g1.flat.dat')));
+    await finished(Readable.fromWeb(stream as any).pipe(createWriteStream(this.path + '/grumpkin_g1_v2.flat.dat')));
     writeFileSync(this.path + '/grumpkin_size', String(crs.numPoints));
   }
 
@@ -152,6 +152,6 @@ export class GrumpkinCrs {
    * @returns The points data.
    */
   getG1Data(): Uint8Array {
-    return readFileSync(this.path + '/grumpkin_g1.flat.dat');
+    return readFileSync(this.path + '/grumpkin_g1_v2.flat.dat');
   }
 }

--- a/release-image/bootstrap.sh
+++ b/release-image/bootstrap.sh
@@ -7,7 +7,7 @@ function prepare_crs {
   echo_header "prepare crs for prover-agent image"
   local crs_src=${CRS_PATH:-$HOME/.bb-crs}
 
-  if [ ! -f "$crs_src/bn254_g1_compressed.dat" ]; then
+  if [ ! -f "$crs_src/bn254_g1_compressed.dat" ] || [ ! -f "$crs_src/grumpkin_g1_v2.flat.dat" ]; then
     # this assumes we pull the required number of points for proving the biggest circuit
     echo "CRS not found at $crs_src, downloading..."
     $root/barretenberg/scripts/download_bb_crs.sh
@@ -17,7 +17,7 @@ function prepare_crs {
   mkdir -p crs
   cp "$crs_src/bn254_g1_compressed.dat" crs/
   cp "$crs_src/bn254_g2.dat" crs/
-  cp "$crs_src/grumpkin_g1.flat.dat" crs/
+  cp "$crs_src/grumpkin_g1_v2.flat.dat" crs/
   # Normalize timestamps so COPY --link produces an identical layer across builds
   for f in crs/*; do touch -t 197001010000 "$f"; done
   echo "CRS files staged in crs/ ($(du -sh crs | cut -f1))"


### PR DESCRIPTION
Fix for [finding 2](https://cantina.xyz/code/3dc4ffe5-40f6-4d08-926c-b17315a5bedb/findings/2) from ecc-groups audit. Basically rejects non-canonical x-coordinate encodings in `affine_element::from_compressed`.

Since grumpkin SRS generation used this function, we need to regenerate the grumpkin SRS.