### PR TITLE
fix: install node 22 for aztec-cli acceptance test

### DIFF
--- a/.github/workflows/aztec-cli-acceptance-test.yml
+++ b/.github/workflows/aztec-cli-acceptance-test.yml
@@ -31,6 +31,13 @@ jobs:
         with:
           ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
+      # Node is only used to run the .ts harness in run-test.sh, which needs >=22.18 for TS
+      # type-stripping. The aztec CLI installer manages its own node version independently.
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
       - name: Run Aztec CLI acceptance test
         run: ./aztec-up/test/aztec-cli-acceptance-test/run-test.sh
 


### PR DESCRIPTION
## Summary

- The acceptance test runs a `.ts` harness via `run-test.sh` that relies on Node's TS type-stripping, which requires Node >=22.18.
- The runner's default Node was too old, so the workflow now installs Node 22 before running the test. The `aztec` CLI installer continues to manage its own Node version independently.