### PR TITLE
test(ci): DO NOT MERGE - probe to verify compat-e2e CI job

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/oracle/notes.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/notes.nr
@@ -75,7 +75,7 @@ unconstrained fn notify_nullified_note_oracle_wrapper(nullifier: Field, note_has
 #[oracle(aztec_prv_notifyNullifiedNote)]
 unconstrained fn notify_nullified_note_oracle(_nullifier: Field, _note_hash: Field, _counter: u32) {}
 
-#[oracle(aztec_utl_getNotes)]
+#[oracle(aztec_utl_getNotesRENAMED_COMPAT_TEST)]
 unconstrained fn get_notes_oracle<Note, let M: u32, let MaxNotes: u32>(
     _owner: Option<AztecAddress>,
     _storage_slot: Field,

--- a/noir-projects/aztec-nr/aztec/src/oracle/version.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/version.nr
@@ -11,7 +11,7 @@
 /// immediately if AZTEC_NR_MINOR > PXE_MINOR because if a contract is updated to use a newer Aztec.nr dependency
 /// without actually using any of the new oracles then there is no reason to throw.
 pub global ORACLE_VERSION_MAJOR: Field = 22;
-pub global ORACLE_VERSION_MINOR: Field = 2;
+pub global ORACLE_VERSION_MINOR: Field = 3;
 
 /// Asserts that the version of the oracle is compatible with the version expected by the contract.
 pub fn assert_compatible_oracle_version() {

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/oracle.ts
@@ -343,7 +343,7 @@ export class Oracle {
   }
 
   // eslint-disable-next-line camelcase
-  async aztec_utl_getNotes(
+  async aztec_utl_getNotesRENAMED_COMPAT_TEST(
     [ownerSome]: ACVMField[],
     [ownerValue]: ACVMField[],
     [storageSlot]: ACVMField[],

--- a/yarn-project/pxe/src/oracle_version.ts
+++ b/yarn-project/pxe/src/oracle_version.ts
@@ -11,7 +11,7 @@
 /// if AZTEC_NR_MINOR > PXE_MINOR because if a contract is updated to use a newer Aztec.nr dependency without actually
 /// using any of the new oracles then there is no reason to throw.
 export const ORACLE_VERSION_MAJOR = 22;
-export const ORACLE_VERSION_MINOR = 2;
+export const ORACLE_VERSION_MINOR = 3;
 
 /// This hash is computed from the Oracle interface and is used to detect when that interface changes. When it does,
 /// you need to either:
@@ -19,4 +19,4 @@ export const ORACLE_VERSION_MINOR = 2;
 /// - increment only `ORACLE_VERSION_MINOR` if the change is additive (a new oracle was added).
 ///
 /// These constants must be kept in sync between this file and `noir-projects/aztec-nr/aztec/src/oracle/version.nr`.
-export const ORACLE_INTERFACE_HASH = '193fe3f9fee6a84d26803e636c9746dd805a4f389d44a0618de75c2c5eb4912e';
+export const ORACLE_INTERFACE_HASH = '8de97d1591f7c87a002b4cd471aa45db1d4de40904bfce0be81f7e9b3e476e77';

--- a/yarn-project/txe/src/rpc_translator.ts
+++ b/yarn-project/txe/src/rpc_translator.ts
@@ -454,7 +454,7 @@ export class RPCTranslator {
   }
 
   // eslint-disable-next-line camelcase
-  async aztec_utl_getNotes(
+  async aztec_utl_getNotesRENAMED_COMPAT_TEST(
     foreignOwnerIsSome: ForeignCallSingle,
     foreignOwnerValue: ForeignCallSingle,
     foreignStorageSlot: ForeignCallSingle,


### PR DESCRIPTION
## Summary

**This PR is a CI verification probe — it must NOT be merged.** It deliberately breaks backwards compatibility to confirm that the new `ci-compat-e2e` job (added in #22606) actually catches oracle interface drift, rather than passing silently.

## What it does

Renames `aztec_utl_getNotes` to `aztec_utl_getNotesRENAMED_COMPAT_TEST` on both PXE and Noir sides, plus updates the interface hash.

Files touched:
- `yarn-project/pxe/src/contract_function_simulator/oracle/oracle.ts` — TS handler renamed
- `yarn-project/txe/src/rpc_translator.ts` — TXE handler renamed
- `noir-projects/aztec-nr/aztec/src/oracle/notes.nr` — `#[oracle(...)]` attribute renamed
- `yarn-project/pxe/src/oracle_version.ts` — `ORACLE_INTERFACE_HASH` updated, `ORACLE_VERSION_MINOR` 2 → 3
- `noir-projects/aztec-nr/aztec/src/oracle/version.nr` — `ORACLE_VERSION_MINOR` 2 → 3

## Why minor bump (not major)

A major bump would cause old contracts to fail at the version check oracle, never reaching the renamed handler. The minor bump simulates the realistic accidental-drift scenario: major still matches, contracts pass the version check, then fail at the dispatcher with `Oracle 'aztec_utl_getNotes' not found` — exercising the fallback path at `oracle.ts:138-164`. This is exactly the bug class the compat-e2e job exists to catch.

## Expected outcomes

- Regular `ci` job: **green** (new contracts compile against the renamed oracle, hashes line up)
- `ci-compat-e2e` job: **red** (old artifacts under `.legacy-contracts/v4.2.x` still embed `aztec_utl_getNotes` in their ACIR foreign-call names)

If the compat-e2e job goes green here, the CI infrastructure has a hole and we need to investigate.

## Test plan

- Watch the `ci-compat-e2e` workflow run on this PR
- Confirm it fails with an "Oracle not found" or equivalent error from the legacy contract paths
- Close this PR without merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)