### PR TITLE
refactor(archiver)!: unify L2BlockSource checkpoint lookups via query objects

### DIFF
--- a/docs/docs-developers/docs/resources/migration_notes.md
+++ b/docs/docs-developers/docs/resources/migration_notes.md
@@ -50,7 +50,7 @@ The Aztec Node JSON-RPC surface for fetching blocks and checkpoints has been con
 | `getProvenBlockNumber()` | `getBlockNumber('proven')` |
 | `getCheckpointedBlockNumber()` | `getBlockNumber('checkpointed')` |
 
-**Deprecated but still present** (scheduled for removal once internal consumers of the archiver shape are rewired): `getL2Tips` (use `getChainTips`), `getBlockHeader` (use `getBlock(param).then(r => r?.header)`), `getCheckpointedBlocks` (use `getBlocks(from, limit, { includeL1PublishInfo: true, includeAttestations: true })`), `getCheckpointsDataForEpoch` (use `getCheckpoints(from, limit)` over the epoch's checkpoint range). Do not adopt these in new code.
+**Deprecated but still present** (scheduled for removal once internal consumers of the archiver shape are rewired): `getL2Tips` (use `getChainTips`), `getBlockHeader` (use `getBlock(param).then(r => r?.header)`), `getCheckpointedBlocks` (use `getBlocks(from, limit, { includeL1PublishInfo: true, includeAttestations: true })`). Do not adopt these in new code. (`getCheckpointsDataForEpoch` was previously listed here; see the dedicated checkpoint-API entry below for its removal.)
 
 **New response shapes:** `BlockResponse` always carries `header`, `archive`, `hash`, `number`, `checkpointNumber`, and `indexWithinCheckpoint`. `body`, `l1` (an `L1PublishInfo` discriminated union), and `attestations` are present only when the matching include option is set. `CheckpointResponse` mirrors this for checkpoints, with `blocks` gated on `includeBlocks`, and always carries `feeAssetPriceModifier` as a base field. The response types are generic over the options object, so passing a literal `{ includeTransactions: true }` narrows the return type and `response.body` becomes non-optional.
 
@@ -79,11 +79,64 @@ The Aztec Node JSON-RPC surface for fetching blocks and checkpoints has been con
 
 `getBlockHeader`, `getCheckpointedBlocks`, `getCheckpointsDataForEpoch`, and `getL2Tips` continue to work in this release but are deprecated; migrate to the replacements above.
 
-**Chain-tip selectors:** `getBlockNumber` and `getCheckpointNumber` now accept an optional `ChainTip` argument (`'proposed' | 'checkpointed' | 'proven' | 'finalized'`). Note the semantic difference: on the block side `'proposed'` means the latest proposed block (chain head), whereas on the checkpoint side `'proposed'` resolves to the latest L1-confirmed checkpoint. Pre-L1-confirmation checkpoints are not exposed over RPC.
+**Chain-tip selectors:** `getBlockNumber` and `getCheckpointNumber` now accept an optional `ChainTip` argument (`'proposed' | 'checkpointed' | 'proven' | 'finalized'`). The `'proposed'` semantics are described in the dedicated checkpoint-API entry below — they were tightened in this release to mean "the proposed-tip checkpoint" rather than "the latest L1-confirmed checkpoint."
 
 **Block parameter variants:** `BlockParameter` now also accepts a block hash, an archive root, and chain-tip names. The existing `number | 'latest'` forms continue to work — `'latest'` is an alias for `'proposed'`.
 
 **Impact**: Source changes are required anywhere the removed methods are called. Type changes are required anywhere `L2Block` / `BlockHeader` / `CheckpointedL2Block` were consumed from the RPC — those call sites now receive `BlockResponse` / `CheckpointResponse` and must request the fields they need via `options`. Production nodes will reject JSON-RPC calls to the removed method names.
+
+### [Aztec Node] Checkpoint RPC: `'proposed'` is now strictly proposed; `'latest'` removed; `getCheckpointsData` takes a query
+
+Follow-up to the unified-RPC change above. Tightens the checkpoint-side API surface: removes the old positional / per-shape entrypoints, drops the wire-level alias that conflated proposed and confirmed checkpoints, and replaces the deprecated epoch-only `getCheckpointsDataForEpoch` method with a unified query-shaped `getCheckpointsData` that mirrors the block-side API.
+
+**`getCheckpointsDataForEpoch(epoch)` removed.** The previously-deprecated method is gone. Use `getCheckpointsData({ epoch })` instead. The new `getCheckpointsData` also accepts a contiguous range:
+
+```diff
+- const cps = await node.getCheckpointsDataForEpoch(epoch);
++ const cps = await node.getCheckpointsData({ epoch });
+
+  // New: contiguous range
++ const cps = await node.getCheckpointsData({ from: 1, limit: 5 });
+```
+
+**`'latest'` removed from `CheckpointParameter`.** The `'latest'` literal previously accepted by `getCheckpoint('latest', options)` is no longer valid. Use `'checkpointed'` to address the latest confirmed checkpoint, or `'proposed'` for the proposed-tip semantics described below. (Block-side `'latest'` in `BlockParameter` is unaffected.)
+
+```diff
+- await node.getCheckpoint('latest');
++ await node.getCheckpoint('checkpointed');
+```
+
+**`'proposed'` semantics changed.** Previously `'proposed'` on the checkpoint side aliased to "latest L1-confirmed checkpoint" — a documented foot-gun. After this release:
+
+- `getCheckpoint('proposed')` resolves to the proposed-tip checkpoint number and looks it up confirmed-first, then falls back to the proposed-checkpoint store. When a proposed entry exists at that number it is returned; when none exists, the proposed-tip falls back to the confirmed tip and the call returns the latest confirmed checkpoint. Returns `undefined` only when neither store has the resolved number.
+- `getCheckpointNumber('proposed')` returns the proposed-tip checkpoint number, falling back to the latest confirmed checkpoint number when no proposed entry exists. Return type stays `Promise<CheckpointNumber>`.
+
+If you want the latest L1-confirmed checkpoint regardless of proposed state, switch the call to `'checkpointed'`:
+
+```diff
+- const cp = await node.getCheckpoint('proposed');
+- const n  = await node.getCheckpointNumber('proposed');
++ const cp = await node.getCheckpoint('checkpointed');
++ const n  = await node.getCheckpointNumber('checkpointed');
+```
+
+**By-number / by-slot lookups gain a confirmed→proposed fallback.** `getCheckpoint({ number: N })` and `getCheckpoint({ slot: S })` now check the confirmed store first, then fall back to the proposed store. Tag-based lookups (`'checkpointed'`, `'proven'`, `'finalized'`) do not fall back — those tags name confirmed-only positions.
+
+**Throws on a proposed match + L1/attestations.** Proposed checkpoints have no L1 publish info or committee attestations (those data points only exist after L1 confirmation). The throw fires only when the lookup actually lands on a proposed entry — i.e. the confirmed store missed and the proposed store hit. When the proposed-tip falls back to the confirmed tip (no proposed entry exists), `'proposed' + includeAttestations` returns the latest confirmed checkpoint with attestations rather than throwing:
+
+```ts
+// Throws BadRequestError when a proposed entry exists at the resolved number:
+await node.getCheckpoint('proposed', { includeAttestations: true });
+await node.getCheckpoint('proposed', { includeL1PublishInfo: true });
+
+// And when a by-number / by-slot lookup falls back to a proposed entry:
+await node.getCheckpoint({ number: N }, { includeAttestations: true });
+// → throws if N is matched only in the proposed store
+```
+
+If your code asks for `includeAttestations` / `includeL1PublishInfo` and might land on a proposed entry, gate the call on `getCheckpoint(param)` first, then re-issue with the include flags only after confirming the result is from the confirmed store (e.g. by checking that the tag-based equivalent returns the same checkpoint number).
+
+**Impact**: Wallet, indexer, and tooling code that called `node.getCheckpoint('proposed')` or `node.getCheckpoint('latest')` will need to update their tag. Any code relying on the old "proposed = latest confirmed" alias should switch to `'checkpointed'`. Code that combined `'proposed'` (or by-number/by-slot fallbacks) with `includeAttestations` / `includeL1PublishInfo` will now throw at runtime; gate those flags as described above.
 
 ### [Aztec Node] `feeAssetPriceModifier` now correctly populated on confirmed checkpoints
 

--- a/yarn-project/archiver/src/archiver-store.test.ts
+++ b/yarn-project/archiver/src/archiver-store.test.ts
@@ -15,6 +15,7 @@ import { EthAddress } from '@aztec/foundation/eth-address';
 import { openTmpStore } from '@aztec/kv-store/lmdb-v2';
 import { L2Block } from '@aztec/stdlib/block';
 import type { L1RollupConstants } from '@aztec/stdlib/epoch-helpers';
+import { CheckpointHeader } from '@aztec/stdlib/rollup';
 import { makeStateReference } from '@aztec/stdlib/testing';
 import { AppendOnlyTreeSnapshot } from '@aztec/stdlib/trees';
 import { BlockHeader } from '@aztec/stdlib/tx';
@@ -132,7 +133,7 @@ describe('Archiver Store', () => {
       const testCheckpoints = await makeChainedCheckpoints(3, { previousArchive: genesisArchive });
       await archiverStore.blocks.addCheckpoints(testCheckpoints);
 
-      const result = await archiver.getCheckpoints(CheckpointNumber(1), 10);
+      const result = await archiver.getCheckpoints({ from: CheckpointNumber(1), limit: 10 });
 
       expect(result.length).toBe(3);
       expect(result.map(c => c.checkpoint.number)).toEqual([1, 2, 3]);
@@ -148,7 +149,7 @@ describe('Archiver Store', () => {
       const testCheckpoints = await makeChainedCheckpoints(3, { previousArchive: genesisArchive });
       await archiverStore.blocks.addCheckpoints(testCheckpoints);
 
-      const result = await archiver.getCheckpoints(CheckpointNumber(1), 2);
+      const result = await archiver.getCheckpoints({ from: CheckpointNumber(1), limit: 2 });
 
       expect(result.length).toBe(2);
       expect(result.map(c => c.checkpoint.number)).toEqual([1, 2]);
@@ -159,20 +160,20 @@ describe('Archiver Store', () => {
       const testCheckpoints = await makeChainedCheckpoints(3, { previousArchive: genesisArchive });
       await archiverStore.blocks.addCheckpoints(testCheckpoints);
 
-      const result = await archiver.getCheckpoints(CheckpointNumber(2), 10);
+      const result = await archiver.getCheckpoints({ from: CheckpointNumber(2), limit: 10 });
 
       expect(result.length).toBe(2);
       expect(result.map(c => c.checkpoint.number)).toEqual([2, 3]);
     });
 
     it('returns empty array when no checkpoints exist', async () => {
-      const result = await archiver.getCheckpoints(CheckpointNumber(1), 10);
+      const result = await archiver.getCheckpoints({ from: CheckpointNumber(1), limit: 10 });
 
       expect(result).toEqual([]);
     });
   });
 
-  describe('getCheckpointsForEpoch', () => {
+  describe('getCheckpoints({ epoch })', () => {
     it('returns checkpoints for a specific epoch based on slot numbers', async () => {
       // l1Constants has epochDuration: 4, so epoch 0 has slots 0-3, epoch 1 has slots 4-7
       const genesisArchive = new AppendOnlyTreeSnapshot(genesisArchiveRoot, 1);
@@ -186,13 +187,13 @@ describe('Archiver Store', () => {
       });
       await archiverStore.blocks.addCheckpoints(testCheckpoints);
 
-      const epoch0Checkpoints = await archiver.getCheckpointsForEpoch(EpochNumber(0));
+      const epoch0Checkpoints = await archiver.getCheckpointsData({ epoch: EpochNumber(0) });
       expect(epoch0Checkpoints.length).toBe(2);
-      expect(epoch0Checkpoints.map(c => c.number)).toEqual([1, 2]);
+      expect(epoch0Checkpoints.map(c => c.checkpointNumber)).toEqual([1, 2]);
 
-      const epoch1Checkpoints = await archiver.getCheckpointsForEpoch(EpochNumber(1));
+      const epoch1Checkpoints = await archiver.getCheckpointsData({ epoch: EpochNumber(1) });
       expect(epoch1Checkpoints.length).toBe(1);
-      expect(epoch1Checkpoints.map(c => c.number)).toEqual([3]);
+      expect(epoch1Checkpoints.map(c => c.checkpointNumber)).toEqual([3]);
     });
 
     it('returns empty array for epoch with no checkpoints', async () => {
@@ -203,7 +204,7 @@ describe('Archiver Store', () => {
       });
       await archiverStore.blocks.addCheckpoints(testCheckpoints);
 
-      const epoch1Checkpoints = await archiver.getCheckpointsForEpoch(EpochNumber(1));
+      const epoch1Checkpoints = await archiver.getCheckpointsData({ epoch: EpochNumber(1) });
       expect(epoch1Checkpoints).toEqual([]);
     });
 
@@ -220,9 +221,306 @@ describe('Archiver Store', () => {
       });
       await archiverStore.blocks.addCheckpoints(testCheckpoints);
 
-      const epoch0Checkpoints = await archiver.getCheckpointsForEpoch(EpochNumber(0));
+      const epoch0Checkpoints = await archiver.getCheckpointsData({ epoch: EpochNumber(0) });
       expect(epoch0Checkpoints.length).toBe(3);
-      expect(epoch0Checkpoints.map(c => c.number)).toEqual([1, 2, 3]);
+      expect(epoch0Checkpoints.map(c => c.checkpointNumber)).toEqual([1, 2, 3]);
+    });
+  });
+
+  describe('getCheckpoint', () => {
+    it('returns checkpoint by number', async () => {
+      const genesisArchive = new AppendOnlyTreeSnapshot(genesisArchiveRoot, 1);
+      const testCheckpoints = await makeChainedCheckpoints(3, { previousArchive: genesisArchive });
+      await archiverStore.blocks.addCheckpoints(testCheckpoints);
+
+      const result = await archiver.getCheckpoint({ number: CheckpointNumber(2) });
+      expect(result).toBeDefined();
+      expect(result!.checkpoint.number).toBe(2);
+    });
+
+    it('returns undefined for unknown checkpoint number', async () => {
+      const genesisArchive = new AppendOnlyTreeSnapshot(genesisArchiveRoot, 1);
+      const testCheckpoints = await makeChainedCheckpoints(2, { previousArchive: genesisArchive });
+      await archiverStore.blocks.addCheckpoints(testCheckpoints);
+
+      const result = await archiver.getCheckpoint({ number: CheckpointNumber(99) });
+      expect(result).toBeUndefined();
+    });
+
+    it('returns checkpoint by slot', async () => {
+      const genesisArchive = new AppendOnlyTreeSnapshot(genesisArchiveRoot, 1);
+      const targetSlot = SlotNumber(7);
+      const testCheckpoints = await makeChainedCheckpoints(2, {
+        previousArchive: genesisArchive,
+        makeCheckpointOptions: cpNumber => ({
+          slotNumber: cpNumber === CheckpointNumber(1) ? SlotNumber(3) : targetSlot,
+        }),
+      });
+      await archiverStore.blocks.addCheckpoints(testCheckpoints);
+
+      const result = await archiver.getCheckpoint({ slot: targetSlot });
+      expect(result).toBeDefined();
+      expect(result!.checkpoint.number).toBe(2);
+    });
+
+    it('returns undefined for unknown slot', async () => {
+      const genesisArchive = new AppendOnlyTreeSnapshot(genesisArchiveRoot, 1);
+      const testCheckpoints = await makeChainedCheckpoints(1, {
+        previousArchive: genesisArchive,
+        makeCheckpointOptions: () => ({ slotNumber: SlotNumber(5) }),
+      });
+      await archiverStore.blocks.addCheckpoints(testCheckpoints);
+
+      const result = await archiver.getCheckpoint({ slot: SlotNumber(99) });
+      expect(result).toBeUndefined();
+    });
+
+    it('returns the latest checkpointed checkpoint for tag=checkpointed', async () => {
+      const genesisArchive = new AppendOnlyTreeSnapshot(genesisArchiveRoot, 1);
+      const testCheckpoints = await makeChainedCheckpoints(3, { previousArchive: genesisArchive });
+      await archiverStore.blocks.addCheckpoints(testCheckpoints);
+
+      const result = await archiver.getCheckpoint({ tag: 'checkpointed' });
+      expect(result).toBeDefined();
+      expect(result!.checkpoint.number).toBe(3);
+    });
+
+    it('returns the proven checkpoint for tag=proven when one exists', async () => {
+      const genesisArchive = new AppendOnlyTreeSnapshot(genesisArchiveRoot, 1);
+      const testCheckpoints = await makeChainedCheckpoints(3, { previousArchive: genesisArchive });
+      await archiverStore.blocks.addCheckpoints(testCheckpoints);
+      await archiverStore.blocks.setProvenCheckpointNumber(CheckpointNumber(2));
+
+      const result = await archiver.getCheckpoint({ tag: 'proven' });
+      expect(result).toBeDefined();
+      expect(result!.checkpoint.number).toBe(2);
+    });
+
+    it('returns undefined for tag=proven when no checkpoints exist', async () => {
+      // proven tip is checkpoint 0 (genesis), getCheckpoint returns undefined for number=0
+      const result = await archiver.getCheckpoint({ tag: 'proven' });
+      expect(result).toBeUndefined();
+    });
+
+    it('returns the finalized checkpoint for tag=finalized when one exists', async () => {
+      const genesisArchive = new AppendOnlyTreeSnapshot(genesisArchiveRoot, 1);
+      const testCheckpoints = await makeChainedCheckpoints(3, { previousArchive: genesisArchive });
+      await archiverStore.blocks.addCheckpoints(testCheckpoints);
+      await archiverStore.blocks.setProvenCheckpointNumber(CheckpointNumber(3));
+      await archiverStore.blocks.setFinalizedCheckpointNumber(CheckpointNumber(1));
+
+      const result = await archiver.getCheckpoint({ tag: 'finalized' });
+      expect(result).toBeDefined();
+      expect(result!.checkpoint.number).toBe(1);
+    });
+
+    it('returns undefined for tag=finalized when no checkpoints exist', async () => {
+      const result = await archiver.getCheckpoint({ tag: 'finalized' });
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('getCheckpointData', () => {
+    it('returns checkpoint data by number', async () => {
+      const genesisArchive = new AppendOnlyTreeSnapshot(genesisArchiveRoot, 1);
+      const testCheckpoints = await makeChainedCheckpoints(3, { previousArchive: genesisArchive });
+      await archiverStore.blocks.addCheckpoints(testCheckpoints);
+
+      const result = await archiver.getCheckpointData({ number: CheckpointNumber(2) });
+      expect(result).toBeDefined();
+      expect(result!.checkpointNumber).toBe(2);
+      expect(result!.l1).toBeDefined();
+    });
+
+    it('returns undefined for unknown checkpoint number', async () => {
+      const result = await archiver.getCheckpointData({ number: CheckpointNumber(99) });
+      expect(result).toBeUndefined();
+    });
+
+    it('returns checkpoint data by slot', async () => {
+      const genesisArchive = new AppendOnlyTreeSnapshot(genesisArchiveRoot, 1);
+      const targetSlot = SlotNumber(11);
+      const testCheckpoints = await makeChainedCheckpoints(2, {
+        previousArchive: genesisArchive,
+        makeCheckpointOptions: cpNumber => ({
+          slotNumber: cpNumber === CheckpointNumber(1) ? SlotNumber(2) : targetSlot,
+        }),
+      });
+      await archiverStore.blocks.addCheckpoints(testCheckpoints);
+
+      const result = await archiver.getCheckpointData({ slot: targetSlot });
+      expect(result).toBeDefined();
+      expect(result!.checkpointNumber).toBe(2);
+    });
+
+    it('returns undefined for unknown slot', async () => {
+      const result = await archiver.getCheckpointData({ slot: SlotNumber(999) });
+      expect(result).toBeUndefined();
+    });
+
+    it('returns the latest checkpointed data for tag=checkpointed', async () => {
+      const genesisArchive = new AppendOnlyTreeSnapshot(genesisArchiveRoot, 1);
+      const testCheckpoints = await makeChainedCheckpoints(3, { previousArchive: genesisArchive });
+      await archiverStore.blocks.addCheckpoints(testCheckpoints);
+
+      const result = await archiver.getCheckpointData({ tag: 'checkpointed' });
+      expect(result).toBeDefined();
+      expect(result!.checkpointNumber).toBe(3);
+    });
+
+    it('returns the proven checkpoint data for tag=proven', async () => {
+      const genesisArchive = new AppendOnlyTreeSnapshot(genesisArchiveRoot, 1);
+      const testCheckpoints = await makeChainedCheckpoints(3, { previousArchive: genesisArchive });
+      await archiverStore.blocks.addCheckpoints(testCheckpoints);
+      await archiverStore.blocks.setProvenCheckpointNumber(CheckpointNumber(2));
+
+      const result = await archiver.getCheckpointData({ tag: 'proven' });
+      expect(result).toBeDefined();
+      expect(result!.checkpointNumber).toBe(2);
+    });
+
+    it('returns the finalized checkpoint data for tag=finalized', async () => {
+      const genesisArchive = new AppendOnlyTreeSnapshot(genesisArchiveRoot, 1);
+      const testCheckpoints = await makeChainedCheckpoints(3, { previousArchive: genesisArchive });
+      await archiverStore.blocks.addCheckpoints(testCheckpoints);
+      await archiverStore.blocks.setProvenCheckpointNumber(CheckpointNumber(3));
+      await archiverStore.blocks.setFinalizedCheckpointNumber(CheckpointNumber(2));
+
+      const result = await archiver.getCheckpointData({ tag: 'finalized' });
+      expect(result).toBeDefined();
+      expect(result!.checkpointNumber).toBe(2);
+    });
+
+    it('returns undefined for tags when chain is empty', async () => {
+      expect(await archiver.getCheckpointData({ tag: 'proven' })).toBeUndefined();
+      expect(await archiver.getCheckpointData({ tag: 'finalized' })).toBeUndefined();
+    });
+  });
+
+  describe('getCheckpoints / getCheckpointsData', () => {
+    it('getCheckpoints returns the right slice from from+limit', async () => {
+      const genesisArchive = new AppendOnlyTreeSnapshot(genesisArchiveRoot, 1);
+      const testCheckpoints = await makeChainedCheckpoints(5, { previousArchive: genesisArchive });
+      await archiverStore.blocks.addCheckpoints(testCheckpoints);
+
+      const result = await archiver.getCheckpoints({ from: CheckpointNumber(2), limit: 3 });
+      expect(result.length).toBe(3);
+      expect(result.map(c => c.checkpoint.number)).toEqual([2, 3, 4]);
+    });
+
+    it('getCheckpointsData returns the right slice from from+limit', async () => {
+      const genesisArchive = new AppendOnlyTreeSnapshot(genesisArchiveRoot, 1);
+      const testCheckpoints = await makeChainedCheckpoints(5, { previousArchive: genesisArchive });
+      await archiverStore.blocks.addCheckpoints(testCheckpoints);
+
+      const result = await archiver.getCheckpointsData({ from: CheckpointNumber(3), limit: 2 });
+      expect(result.length).toBe(2);
+      expect(result.map(c => c.checkpointNumber)).toEqual([3, 4]);
+    });
+
+    it('getCheckpoints returns [] for empty range', async () => {
+      const result = await archiver.getCheckpoints({ from: CheckpointNumber(1), limit: 10 });
+      expect(result).toEqual([]);
+    });
+
+    it('getCheckpointsData returns [] for unknown epoch', async () => {
+      const genesisArchive = new AppendOnlyTreeSnapshot(genesisArchiveRoot, 1);
+      // checkpoint 1 in epoch 0 (slot 1, epochDuration=4)
+      const testCheckpoints = await makeChainedCheckpoints(1, {
+        previousArchive: genesisArchive,
+        makeCheckpointOptions: () => ({ slotNumber: SlotNumber(1) }),
+      });
+      await archiverStore.blocks.addCheckpoints(testCheckpoints);
+
+      const result = await archiver.getCheckpointsData({ epoch: EpochNumber(5) });
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('getProposedCheckpointData', () => {
+    async function addProposedCheckpoint(
+      checkpointNumber: CheckpointNumber,
+      slotNumber: SlotNumber,
+      startBlock: BlockNumber,
+    ) {
+      const block = await L2Block.random(startBlock, {
+        checkpointNumber,
+        indexWithinCheckpoint: IndexWithinCheckpoint(0),
+      });
+      await archiverStore.blocks.addProposedBlock(block, { force: true });
+      await archiverStore.blocks.addProposedCheckpoint({
+        checkpointNumber,
+        header: CheckpointHeader.random({ slotNumber }),
+        startBlock,
+        blockCount: 1,
+        totalManaUsed: 100n,
+        feeAssetPriceModifier: 0n,
+      });
+    }
+
+    it('returns the latest proposed entry when called with no args', async () => {
+      await addProposedCheckpoint(CheckpointNumber(1), SlotNumber(3), BlockNumber(1));
+
+      const result = await archiver.getProposedCheckpointData();
+      expect(result).toBeDefined();
+      expect(result!.checkpointNumber).toBe(1);
+    });
+
+    it('returns undefined when no proposed entry exists (no args)', async () => {
+      const result = await archiver.getProposedCheckpointData();
+      expect(result).toBeUndefined();
+    });
+
+    it('returns the latest proposed entry for tag=proposed', async () => {
+      await addProposedCheckpoint(CheckpointNumber(1), SlotNumber(5), BlockNumber(1));
+
+      const result = await archiver.getProposedCheckpointData({ tag: 'proposed' });
+      expect(result).toBeDefined();
+      expect(result!.checkpointNumber).toBe(1);
+    });
+
+    it('returns matching proposed entry by number', async () => {
+      await addProposedCheckpoint(CheckpointNumber(1), SlotNumber(2), BlockNumber(1));
+
+      const result = await archiver.getProposedCheckpointData({ number: CheckpointNumber(1) });
+      expect(result).toBeDefined();
+      expect(result!.checkpointNumber).toBe(1);
+    });
+
+    it('returns undefined for number that has no proposed entry', async () => {
+      await addProposedCheckpoint(CheckpointNumber(1), SlotNumber(2), BlockNumber(1));
+
+      const result = await archiver.getProposedCheckpointData({ number: CheckpointNumber(99) });
+      expect(result).toBeUndefined();
+    });
+
+    it('returns matching proposed entry by slot', async () => {
+      const targetSlot = SlotNumber(7);
+      await addProposedCheckpoint(CheckpointNumber(1), targetSlot, BlockNumber(1));
+
+      const result = await archiver.getProposedCheckpointData({ slot: targetSlot });
+      expect(result).toBeDefined();
+      expect(result!.checkpointNumber).toBe(1);
+      expect(result!.header.slotNumber).toBe(targetSlot);
+    });
+
+    it('returns undefined for slot that has no proposed entry', async () => {
+      await addProposedCheckpoint(CheckpointNumber(1), SlotNumber(3), BlockNumber(1));
+
+      const result = await archiver.getProposedCheckpointData({ slot: SlotNumber(999) });
+      expect(result).toBeUndefined();
+    });
+
+    it('never falls back to confirmed checkpoints', async () => {
+      const genesisArchive = new AppendOnlyTreeSnapshot(genesisArchiveRoot, 1);
+      const confirmedCheckpoints = await makeChainedCheckpoints(2, { previousArchive: genesisArchive });
+      await archiverStore.blocks.addCheckpoints(confirmedCheckpoints);
+
+      // No proposed checkpoint exists — all queries should return undefined
+      expect(await archiver.getProposedCheckpointData()).toBeUndefined();
+      expect(await archiver.getProposedCheckpointData({ tag: 'proposed' })).toBeUndefined();
+      expect(await archiver.getProposedCheckpointData({ number: CheckpointNumber(1) })).toBeUndefined();
+      expect(await archiver.getProposedCheckpointData({ number: CheckpointNumber(2) })).toBeUndefined();
     });
   });
 
@@ -614,7 +912,7 @@ describe('Archiver Store', () => {
       // Block 3 is the last block of checkpoint 1 — should succeed
       await archiver.rollbackTo(BlockNumber(3));
 
-      expect(await archiver.getSynchedCheckpointNumber()).toEqual(CheckpointNumber(1));
+      expect(await archiver.getCheckpointNumber()).toEqual(CheckpointNumber(1));
 
       // Verify sync points are set to checkpoint 1's L1 block number (10)
       const synchPoint = await getArchiverSynchPoint(archiverStore);
@@ -661,7 +959,7 @@ describe('Archiver Store', () => {
       // Roll back to block 2 (end of checkpoint 1), which is before proven block 4
       await archiver.rollbackTo(BlockNumber(2));
 
-      expect(await archiver.getSynchedCheckpointNumber()).toEqual(CheckpointNumber(1));
+      expect(await archiver.getCheckpointNumber()).toEqual(CheckpointNumber(1));
       expect(await archiver.getProvenCheckpointNumber()).toEqual(CheckpointNumber(1));
     });
 
@@ -681,7 +979,7 @@ describe('Archiver Store', () => {
       // Roll back to block 4 (end of checkpoint 2), which is after proven block 2
       await archiver.rollbackTo(BlockNumber(4));
 
-      expect(await archiver.getSynchedCheckpointNumber()).toEqual(CheckpointNumber(2));
+      expect(await archiver.getCheckpointNumber()).toEqual(CheckpointNumber(2));
       expect(await archiver.getProvenCheckpointNumber()).toEqual(CheckpointNumber(1));
     });
 
@@ -702,7 +1000,7 @@ describe('Archiver Store', () => {
       // Roll back to block 2 (end of checkpoint 1), which is before finalized block 4
       await archiver.rollbackTo(BlockNumber(2));
 
-      expect(await archiver.getSynchedCheckpointNumber()).toEqual(CheckpointNumber(1));
+      expect(await archiver.getCheckpointNumber()).toEqual(CheckpointNumber(1));
       expect(await archiver.getFinalizedL2BlockNumber()).toEqual(BlockNumber(2));
     });
 
@@ -723,7 +1021,7 @@ describe('Archiver Store', () => {
       // Roll back to block 4 (end of checkpoint 2), which is after finalized block 2
       await archiver.rollbackTo(BlockNumber(4));
 
-      expect(await archiver.getSynchedCheckpointNumber()).toEqual(CheckpointNumber(2));
+      expect(await archiver.getCheckpointNumber()).toEqual(CheckpointNumber(2));
       expect(await archiver.getFinalizedL2BlockNumber()).toEqual(BlockNumber(2));
     });
   });

--- a/yarn-project/archiver/src/archiver-sync.test.ts
+++ b/yarn-project/archiver/src/archiver-sync.test.ts
@@ -171,7 +171,7 @@ describe('Archiver Sync', () => {
 
   describe('basic sync', () => {
     it('syncs l1 to l2 messages and checkpoints', async () => {
-      expect(await archiver.getSynchedCheckpointNumber()).toEqual(CheckpointNumber(0));
+      expect(await archiver.getCheckpointNumber()).toEqual(CheckpointNumber(0));
 
       // Add first checkpoint (creates messages automatically, L1 block 98 for messages, 101 for checkpoint)
       const { checkpoint: cp1, messages: msgs1 } = await fake.addCheckpoint(CheckpointNumber(1), {
@@ -200,7 +200,7 @@ describe('Archiver Sync', () => {
 
       logger.warn('Expecting checkpoint 1');
       await archiver.syncImmediate();
-      expect(await archiver.getSynchedCheckpointNumber()).toEqual(CheckpointNumber(1));
+      expect(await archiver.getCheckpointNumber()).toEqual(CheckpointNumber(1));
 
       // Verify messages for checkpoint 1
       expect(await archiver.getL1ToL2Messages(CheckpointNumber(1))).toEqual(msgs1);
@@ -247,9 +247,9 @@ describe('Archiver Sync', () => {
       expect(await archiver.getProvenCheckpointNumber()).toBe(CheckpointNumber(1));
 
       // Get published checkpoints
-      expect((await archiver.getCheckpoints(CheckpointNumber(1), 100)).map(b => b.checkpoint.number)).toEqual([
-        1, 2, 3,
-      ]);
+      expect(
+        (await archiver.getCheckpoints({ from: CheckpointNumber(1), limit: 100 })).map(b => b.checkpoint.number),
+      ).toEqual([1, 2, 3]);
     }, 30_000);
 
     it('ignores checkpoint 3 because it has been pruned', async () => {
@@ -431,7 +431,7 @@ describe('Archiver Sync', () => {
       expect(await archiver.getCheckpointNumber()).toEqual(CheckpointNumber(1));
 
       // Verify the checkpoint was synced successfully
-      const syncedCheckpoints = await archiver.getCheckpoints(CheckpointNumber(1), 1);
+      const syncedCheckpoints = await archiver.getCheckpoints({ from: CheckpointNumber(1), limit: 1 });
       expect(syncedCheckpoints).toBeDefined();
       expect(syncedCheckpoints.length).toBeGreaterThan(0);
       expect(syncedCheckpoints[0]).toBeDefined();
@@ -484,7 +484,7 @@ describe('Archiver Sync', () => {
       await archiver.syncImmediate();
 
       // Should have processed the checkpoint without attempting to fetch any messages
-      expect(await archiver.getSynchedCheckpointNumber()).toEqual(CheckpointNumber(1));
+      expect(await archiver.getCheckpointNumber()).toEqual(CheckpointNumber(1));
       expect(inboxContract.getMessageSentEvents).not.toHaveBeenCalled();
     });
   });
@@ -823,7 +823,7 @@ describe('Archiver Sync', () => {
       expect(await archiver.getCheckpointNumber()).toEqual(CheckpointNumber(3));
 
       // And checkpoint 2 should return the proper one
-      const [checkpoint2] = await archiver.getCheckpoints(CheckpointNumber(2), 1);
+      const [checkpoint2] = await archiver.getCheckpoints({ from: CheckpointNumber(2), limit: 1 });
       expect(checkpoint2.checkpoint.number).toEqual(2);
       expect(checkpoint2.checkpoint.archive.root.toString()).toEqual(goodCp2.archive.root.toString());
       expect(checkpoint2.attestations.length).toEqual(3);
@@ -892,7 +892,7 @@ describe('Archiver Sync', () => {
       // Verify data from checkpoint 2 is removed
       const txHash = cp2.blocks[0].body.txEffects[0].txHash;
       expect(await archiver.getTxEffect(txHash)).resolves.toBeUndefined;
-      expect(await archiver.getCheckpoints(CheckpointNumber(2), 1)).toEqual([]);
+      expect(await archiver.getCheckpoints({ from: CheckpointNumber(2), limit: 1 })).toEqual([]);
 
       expect((await archiver.getPublicLogs({ fromBlock: 2, toBlock: 3 })).logs).toEqual([]);
       expect((await archiver.getContractClassLogs({ fromBlock: 2, toBlock: 3 })).logs).toEqual([]);
@@ -1164,8 +1164,8 @@ describe('Archiver Sync', () => {
       expect(tips.checkpointed.checkpoint.number).toEqual(CheckpointNumber(1));
 
       // Data from checkpoints 2 and 3 should be removed
-      expect(await archiver.getCheckpoints(CheckpointNumber(2), 1)).toEqual([]);
-      expect(await archiver.getCheckpoints(CheckpointNumber(3), 1)).toEqual([]);
+      expect(await archiver.getCheckpoints({ from: CheckpointNumber(2), limit: 1 })).toEqual([]);
+      expect(await archiver.getCheckpoints({ from: CheckpointNumber(3), limit: 1 })).toEqual([]);
 
       archiver.events.off(L2BlockSourceEvents.L2PruneUnproven, pruneSpy);
     }, 15_000);
@@ -1507,7 +1507,7 @@ describe('Archiver Sync', () => {
       fake.setL1BlockNumber(100n);
       await archiver.syncImmediate();
 
-      expect(await archiver.getSynchedCheckpointNumber()).toEqual(CheckpointNumber(1));
+      expect(await archiver.getCheckpointNumber()).toEqual(CheckpointNumber(1));
       const lastBlockInCheckpoint1 = cp1.blocks[cp1.blocks.length - 1].number;
 
       // Verify L2Tips after syncing checkpoint 1: proposed and checkpointed should both be at checkpoint 1
@@ -1531,7 +1531,7 @@ describe('Archiver Sync', () => {
       // Verify blocks are retrievable but not yet checkpointed
       const lastBlockInCheckpoint2 = cp2.blocks[cp2.blocks.length - 1].number;
       expect(await archiver.getBlockNumber()).toEqual(lastBlockInCheckpoint2);
-      expect(await archiver.getSynchedCheckpointNumber()).toEqual(CheckpointNumber(1));
+      expect(await archiver.getCheckpointNumber()).toEqual(CheckpointNumber(1));
       expect((await archiver.getBlock({ number: cp2.blocks[0].number }))!.equals(cp2.blocks[0])).toBe(true);
 
       // Verify L2Tips after adding blocks: proposed advances but checkpointed stays at checkpoint 1
@@ -1562,7 +1562,7 @@ describe('Archiver Sync', () => {
       expect(pruneSpy).not.toHaveBeenCalled();
 
       // Now the blocks should be checkpointed
-      expect(await archiver.getSynchedCheckpointNumber()).toEqual(CheckpointNumber(2));
+      expect(await archiver.getCheckpointNumber()).toEqual(CheckpointNumber(2));
 
       // Verify L2Tips after syncing checkpoint 2: proposed and checkpointed should both be at checkpoint 2
       const tipsAfterCheckpoint2 = await archiver.getL2Tips();
@@ -1591,7 +1591,7 @@ describe('Archiver Sync', () => {
       fake.setL1BlockNumber(100n);
       await archiver.syncImmediate();
 
-      expect(await archiver.getSynchedCheckpointNumber()).toEqual(CheckpointNumber(1));
+      expect(await archiver.getCheckpointNumber()).toEqual(CheckpointNumber(1));
       const blockAlreadySyncedFromCheckpoint = cp1.blocks[cp1.blocks.length - 1];
 
       // Now try and add one of the blocks via the addProposedBlock method. It should throw
@@ -1615,7 +1615,7 @@ describe('Archiver Sync', () => {
       fake.setL1BlockNumber(4n);
       await archiver.syncImmediate();
 
-      expect(await archiver.getSynchedCheckpointNumber()).toEqual(CheckpointNumber(1));
+      expect(await archiver.getCheckpointNumber()).toEqual(CheckpointNumber(1));
 
       // Now advance L1 significantly to slot 10 (L1 block 20)
       // Current slot = floor(20 / 2) = 10
@@ -1645,7 +1645,7 @@ describe('Archiver Sync', () => {
       fake.setL1BlockNumber(100n);
       await archiver.syncImmediate();
 
-      expect(await archiver.getSynchedCheckpointNumber()).toEqual(CheckpointNumber(1));
+      expect(await archiver.getCheckpointNumber()).toEqual(CheckpointNumber(1));
 
       // Create checkpoint 2 on L1 with 2 blocks (not yet visible)
       const { checkpoint: cp2 } = await fake.addCheckpoint(CheckpointNumber(2), {
@@ -1676,7 +1676,7 @@ describe('Archiver Sync', () => {
       expect(await archiver.getBlockNumber()).toEqual(lastBlockInCheckpoint2);
 
       // Verify we can retrieve both blocks
-      const syncedCheckpoints = await archiver.getCheckpoints(CheckpointNumber(2), 1);
+      const syncedCheckpoints = await archiver.getCheckpoints({ from: CheckpointNumber(2), limit: 1 });
       expect(syncedCheckpoints[0].checkpoint.blocks.length).toEqual(2);
     }, 15_000);
 
@@ -1686,7 +1686,7 @@ describe('Archiver Sync', () => {
       fake.setL1BlockNumber(100n);
       await archiver.syncImmediate();
 
-      expect(await archiver.getSynchedCheckpointNumber()).toEqual(CheckpointNumber(1));
+      expect(await archiver.getCheckpointNumber()).toEqual(CheckpointNumber(1));
 
       // Create checkpoint 2 on L1 (NOT visible yet - L1 block is far in the future)
       const { checkpoint: cp2 } = await fake.addCheckpoint(CheckpointNumber(2), { l1BlockNumber: 5000n });
@@ -1707,7 +1707,7 @@ describe('Archiver Sync', () => {
       expect(await archiver.getBlockNumber()).toEqual(lastBlockInCheckpoint3);
 
       // Still at checkpoint 1 (checkpoints 2 and 3 not synced yet)
-      expect(await archiver.getSynchedCheckpointNumber()).toEqual(CheckpointNumber(1));
+      expect(await archiver.getCheckpointNumber()).toEqual(CheckpointNumber(1));
 
       // Advance L1 to make BOTH checkpoints visible at once
       fake.setL1BlockNumber(5010n);
@@ -1722,7 +1722,7 @@ describe('Archiver Sync', () => {
       expect(await archiver.getBlockNumber()).toEqual(lastBlockInCheckpoint3);
 
       // Assert: Both checkpoints are synced
-      expect(await archiver.getSynchedCheckpointNumber()).toEqual(CheckpointNumber(3));
+      expect(await archiver.getCheckpointNumber()).toEqual(CheckpointNumber(3));
     }, 15_000);
 
     it('prunes and replaces local blocks when checkpoint has different blocks', async () => {
@@ -1733,7 +1733,7 @@ describe('Archiver Sync', () => {
       fake.setL1BlockNumber(80n);
       await archiver.syncImmediate();
 
-      expect(await archiver.getSynchedCheckpointNumber()).toEqual(CheckpointNumber(1));
+      expect(await archiver.getCheckpointNumber()).toEqual(CheckpointNumber(1));
 
       // Create blocks for checkpoint 2 locally (not yet on L1)
       const provisionalBlocks = await fake.makeBlocks(CheckpointNumber(2), {
@@ -1749,7 +1749,7 @@ describe('Archiver Sync', () => {
       // Verify blocks are visible but not checkpointed
       const lastBlockInCheckpoint2 = provisionalBlocks[provisionalBlocks.length - 1].number;
       expect(await archiver.getBlockNumber()).toEqual(lastBlockInCheckpoint2);
-      expect(await archiver.getSynchedCheckpointNumber()).toEqual(CheckpointNumber(1));
+      expect(await archiver.getCheckpointNumber()).toEqual(CheckpointNumber(1));
 
       // Now create a DIFFERENT checkpoint 2 on L1 (different blocks)
       const { checkpoint: differentCp2 } = await fake.addCheckpoint(CheckpointNumber(2), {
@@ -1777,7 +1777,7 @@ describe('Archiver Sync', () => {
       );
 
       // Verify blocks were replaced with L1 checkpoint's blocks
-      const syncedCheckpoints = await archiver.getCheckpoints(CheckpointNumber(2), 1);
+      const syncedCheckpoints = await archiver.getCheckpoints({ from: CheckpointNumber(2), limit: 1 });
       expect(syncedCheckpoints[0].checkpoint.archive.root.toString()).toEqual(differentCp2.archive.root.toString());
     }, 15_000);
 
@@ -1789,7 +1789,7 @@ describe('Archiver Sync', () => {
       fake.setL1BlockNumber(80n);
       await archiver.syncImmediate();
 
-      expect(await archiver.getSynchedCheckpointNumber()).toEqual(CheckpointNumber(1));
+      expect(await archiver.getCheckpointNumber()).toEqual(CheckpointNumber(1));
 
       // Create 2 provisional blocks locally (not on L1)
       const provisionalBlocks = await fake.makeBlocks(CheckpointNumber(2), {
@@ -1830,7 +1830,7 @@ describe('Archiver Sync', () => {
       );
 
       // Verify only the L1 checkpoint's single block is now present
-      const syncedCheckpoints = await archiver.getCheckpoints(CheckpointNumber(2), 1);
+      const syncedCheckpoints = await archiver.getCheckpoints({ from: CheckpointNumber(2), limit: 1 });
       expect(syncedCheckpoints[0].checkpoint.blocks.length).toEqual(1);
       expect(syncedCheckpoints[0].checkpoint.archive.root.toString()).toEqual(differentCp2.archive.root.toString());
     }, 15_000);
@@ -1850,7 +1850,7 @@ describe('Archiver Sync', () => {
       fake.setL1BlockNumber(1n);
       await archiver.syncImmediate();
 
-      expect(await archiver.getSynchedCheckpointNumber()).toEqual(CheckpointNumber(1));
+      expect(await archiver.getCheckpointNumber()).toEqual(CheckpointNumber(1));
 
       const lastBlockInCheckpoint1 = cp1.blocks[cp1.blocks.length - 1].number;
 
@@ -1899,7 +1899,7 @@ describe('Archiver Sync', () => {
 
       // Block number should revert to last checkpointed block
       expect(await archiver.getBlockNumber()).toEqual(lastBlockInCheckpoint1);
-      expect(await archiver.getSynchedCheckpointNumber()).toEqual(CheckpointNumber(1));
+      expect(await archiver.getCheckpointNumber()).toEqual(CheckpointNumber(1));
     }, 15_000);
 
     it('does nothing when slot ends without local blocks', async () => {
@@ -1917,7 +1917,7 @@ describe('Archiver Sync', () => {
       fake.setL1BlockNumber(1n);
       await archiver.syncImmediate();
 
-      expect(await archiver.getSynchedCheckpointNumber()).toEqual(CheckpointNumber(1));
+      expect(await archiver.getCheckpointNumber()).toEqual(CheckpointNumber(1));
       const lastBlockInCheckpoint1 = cp1.blocks[cp1.blocks.length - 1].number;
 
       // Do NOT add any provisional blocks for slot 1
@@ -1932,7 +1932,7 @@ describe('Archiver Sync', () => {
 
       // Block number should remain at last checkpointed block
       expect(await archiver.getBlockNumber()).toEqual(lastBlockInCheckpoint1);
-      expect(await archiver.getSynchedCheckpointNumber()).toEqual(CheckpointNumber(1));
+      expect(await archiver.getCheckpointNumber()).toEqual(CheckpointNumber(1));
     }, 15_000);
 
     it('does not prune blocks covered by a pending checkpoint in current slot', async () => {
@@ -1950,7 +1950,7 @@ describe('Archiver Sync', () => {
       fake.setL1BlockNumber(1n);
       await archiver.syncImmediate();
 
-      expect(await archiver.getSynchedCheckpointNumber()).toEqual(CheckpointNumber(1));
+      expect(await archiver.getCheckpointNumber()).toEqual(CheckpointNumber(1));
       const lastBlockInCheckpoint1 = cp1.blocks[cp1.blocks.length - 1].number;
 
       // Create provisional blocks for slot 1
@@ -2011,7 +2011,7 @@ describe('Archiver Sync', () => {
       fake.setL1BlockNumber(1n);
       await archiver.syncImmediate();
 
-      expect(await archiver.getSynchedCheckpointNumber()).toEqual(CheckpointNumber(1));
+      expect(await archiver.getCheckpointNumber()).toEqual(CheckpointNumber(1));
       const lastBlockInCheckpoint1 = cp1.blocks[cp1.blocks.length - 1].number;
 
       // Create provisional blocks for slot 1
@@ -2054,7 +2054,7 @@ describe('Archiver Sync', () => {
 
       // Block number should revert to last checkpointed block
       expect(await archiver.getBlockNumber()).toEqual(lastBlockInCheckpoint1);
-      expect(await archiver.getSynchedCheckpointNumber()).toEqual(CheckpointNumber(1));
+      expect(await archiver.getCheckpointNumber()).toEqual(CheckpointNumber(1));
 
       // Proposed checkpoint should be cleared, so proposed tip falls back to checkpointed tip
       expect(await archiverStore.blocks.getLastProposedCheckpoint()).toBeUndefined();

--- a/yarn-project/archiver/src/archiver.ts
+++ b/yarn-project/archiver/src/archiver.ts
@@ -208,7 +208,7 @@ export class Archiver extends ArchiverDataSourceBase implements L2BlockSink, Tra
     const { blocksSynchedTo = l1StartBlock, messagesSynchedTo = l1StartBlock } = await getArchiverSynchPoint(
       this.stores,
     );
-    const currentL2Checkpoint = await this.getSynchedCheckpointNumber();
+    const currentL2Checkpoint = await this.getCheckpointNumber();
     this.log.info(
       `Starting archiver sync to rollup contract ${this.rollup.address} from L1 block ${blocksSynchedTo} and L2 checkpoint ${currentL2Checkpoint}`,
       { blocksSynchedTo, messagesSynchedTo, currentL2Checkpoint },

--- a/yarn-project/archiver/src/modules/data_source_base.ts
+++ b/yarn-project/archiver/src/modules/data_source_base.ts
@@ -17,13 +17,15 @@ import {
   type BlockTag,
   type BlocksQuery,
   Body,
+  type CheckpointQuery,
+  type CheckpointsQuery,
   L2Block,
   type L2Tips,
+  type ProposedCheckpointQuery,
 } from '@aztec/stdlib/block';
 import {
   Checkpoint,
   type CheckpointData,
-  type CommonCheckpointData,
   type ProposedCheckpointData,
   PublishedCheckpoint,
 } from '@aztec/stdlib/checkpoint';
@@ -33,7 +35,6 @@ import type { GetContractClassLogsResponse, GetPublicLogsResponse } from '@aztec
 import type { L2LogsSource } from '@aztec/stdlib/interfaces/server';
 import type { LogFilter, SiloedTag, Tag, TxScopedL2Log } from '@aztec/stdlib/logs';
 import type { L1ToL2MessageSource } from '@aztec/stdlib/messaging';
-import type { CheckpointHeader } from '@aztec/stdlib/rollup';
 import { AppendOnlyTreeSnapshot } from '@aztec/stdlib/trees';
 import type { BlockHeader, IndexedTxEffect, TxHash, TxReceipt } from '@aztec/stdlib/tx';
 import type { UInt64 } from '@aztec/stdlib/types';
@@ -146,10 +147,6 @@ export abstract class ArchiverDataSourceBase
     return this.stores.blocks.getLatestCheckpointNumber();
   }
 
-  public getSynchedCheckpointNumber(): Promise<CheckpointNumber> {
-    return this.stores.blocks.getLatestCheckpointNumber();
-  }
-
   public getProvenCheckpointNumber(): Promise<CheckpointNumber> {
     return this.stores.blocks.getProvenCheckpointNumber();
   }
@@ -182,38 +179,90 @@ export abstract class ArchiverDataSourceBase
     return this.stores.blocks.getFinalizedL2BlockNumber();
   }
 
-  public async getCheckpointHeader(number: CheckpointNumber | 'latest'): Promise<CheckpointHeader | undefined> {
-    if (number === 'latest') {
-      number = await this.stores.blocks.getLatestCheckpointNumber();
+  /**
+   * Resolves a {@link CheckpointQuery} to a concrete `CheckpointNumber`, or undefined when the
+   * query refers to a position that has no checkpoint yet (e.g. `{ slot }` not found).
+   */
+  private resolveCheckpointQuery(query: CheckpointQuery): Promise<CheckpointNumber | undefined> {
+    if ('number' in query) {
+      return Promise.resolve(query.number);
     }
-    if (number === 0) {
+    if ('slot' in query) {
+      return this.stores.blocks.getCheckpointNumberBySlot(query.slot);
+    }
+    // tag variant
+    switch (query.tag) {
+      case 'checkpointed':
+        return this.stores.blocks.getLatestCheckpointNumber();
+      case 'proven':
+        return this.stores.blocks.getProvenCheckpointNumber();
+      case 'finalized':
+        return this.stores.blocks.getFinalizedCheckpointNumber();
+    }
+  }
+
+  /**
+   * Resolves a {@link CheckpointsQuery} to a concrete `{from, limit}` pair used by BlockStore,
+   * or undefined when the epoch has no checkpoints.
+   */
+  private async resolveCheckpointsQuery(
+    query: CheckpointsQuery,
+  ): Promise<{ from: CheckpointNumber; limit: number } | undefined> {
+    if ('from' in query) {
+      return query;
+    }
+    const numbers = await this.getCheckpointNumbersForEpoch(query.epoch);
+    if (numbers.length === 0) {
       return undefined;
     }
-    const checkpoint = await this.stores.blocks.getCheckpointData(number);
-    if (!checkpoint) {
+    return { from: numbers[0], limit: numbers.length };
+  }
+
+  public async getCheckpoint(query: CheckpointQuery): Promise<PublishedCheckpoint | undefined> {
+    const number = await this.resolveCheckpointQuery(query);
+    if (number === undefined || number === 0) {
       return undefined;
     }
-    return checkpoint.header;
-  }
-
-  public async getLastBlockNumberInCheckpoint(checkpointNumber: CheckpointNumber): Promise<BlockNumber | undefined> {
-    const checkpointData = await this.stores.blocks.getCheckpointData(checkpointNumber);
-    if (!checkpointData) {
+    const data = await this.stores.blocks.getCheckpointData(number);
+    if (!data) {
       return undefined;
     }
-    return BlockNumber(checkpointData.startBlock + checkpointData.blockCount - 1);
+    return this.getPublishedCheckpointFromCheckpointData(data);
   }
 
-  public getCheckpointData(checkpointNumber: CheckpointNumber): Promise<CheckpointData | undefined> {
-    return this.stores.blocks.getCheckpointData(checkpointNumber);
+  public async getCheckpoints(query: CheckpointsQuery): Promise<PublishedCheckpoint[]> {
+    const resolved = await this.resolveCheckpointsQuery(query);
+    if (!resolved) {
+      return [];
+    }
+    const checkpoints = await this.stores.blocks.getRangeOfCheckpoints(resolved.from, resolved.limit);
+    return Promise.all(checkpoints.map(ch => this.getPublishedCheckpointFromCheckpointData(ch)));
   }
 
-  public getCheckpointDataRange(from: CheckpointNumber, limit: number): Promise<CheckpointData[]> {
-    return this.stores.blocks.getRangeOfCheckpoints(from, limit);
+  public async getCheckpointData(query: CheckpointQuery): Promise<CheckpointData | undefined> {
+    const number = await this.resolveCheckpointQuery(query);
+    if (number === undefined || number === 0) {
+      return undefined;
+    }
+    return this.stores.blocks.getCheckpointData(number);
   }
 
-  public getCheckpointNumberBySlot(slot: SlotNumber): Promise<CheckpointNumber | undefined> {
-    return this.stores.blocks.getCheckpointNumberBySlot(slot);
+  public async getCheckpointsData(query: CheckpointsQuery): Promise<CheckpointData[]> {
+    const resolved = await this.resolveCheckpointsQuery(query);
+    if (!resolved) {
+      return [];
+    }
+    return this.stores.blocks.getRangeOfCheckpoints(resolved.from, resolved.limit);
+  }
+
+  public getProposedCheckpointData(query?: ProposedCheckpointQuery): Promise<ProposedCheckpointData | undefined> {
+    if (!query || 'tag' in query) {
+      return this.stores.blocks.getLastProposedCheckpoint();
+    }
+    if ('number' in query) {
+      return this.stores.blocks.getProposedCheckpointByNumber(query.number);
+    }
+    return this.stores.blocks.getProposedCheckpointBySlot(query.slot);
   }
 
   public getTxEffect(txHash: TxHash): Promise<IndexedTxEffect | undefined> {
@@ -222,14 +271,6 @@ export abstract class ArchiverDataSourceBase
 
   public getSettledTxReceipt(txHash: TxHash): Promise<TxReceipt | undefined> {
     return this.stores.blocks.getSettledTxReceipt(txHash, this.l1Constants);
-  }
-
-  public getLastCheckpoint(): Promise<CommonCheckpointData | undefined> {
-    return this.stores.blocks.getLastCheckpoint();
-  }
-
-  public getLastProposedCheckpoint(): Promise<ProposedCheckpointData | undefined> {
-    return this.stores.blocks.getLastProposedCheckpoint();
   }
 
   public isPendingChainInvalid(): Promise<boolean> {
@@ -310,11 +351,6 @@ export abstract class ArchiverDataSourceBase
     return this.stores.messages.getL1ToL2MessageIndex(l1ToL2Message);
   }
 
-  public async getCheckpoints(checkpointNumber: CheckpointNumber, limit: number): Promise<PublishedCheckpoint[]> {
-    const checkpoints = await this.stores.blocks.getRangeOfCheckpoints(checkpointNumber, limit);
-    return Promise.all(checkpoints.map(ch => this.getPublishedCheckpointFromCheckpointData(ch)));
-  }
-
   private async getPublishedCheckpointFromCheckpointData(checkpoint: CheckpointData): Promise<PublishedCheckpoint> {
     const blocksForCheckpoint = await this.stores.blocks.getBlocksForCheckpoint(checkpoint.checkpointNumber);
     if (!blocksForCheckpoint) {
@@ -334,25 +370,8 @@ export abstract class ArchiverDataSourceBase
     return this.stores.blocks.getBlocksForSlot(slotNumber);
   }
 
-  public async getCheckpointsForEpoch(epochNumber: EpochNumber): Promise<Checkpoint[]> {
-    const checkpointsData = await this.getCheckpointsDataForEpoch(epochNumber);
-    return Promise.all(
-      checkpointsData.map(data => this.getPublishedCheckpointFromCheckpointData(data).then(p => p.checkpoint)),
-    );
-  }
-
-  /** Returns checkpoint data for all checkpoints whose slot falls within the given epoch. */
-  public getCheckpointsDataForEpoch(epochNumber: EpochNumber): Promise<CheckpointData[]> {
-    if (!this.l1Constants) {
-      throw new Error('L1 constants not set');
-    }
-
-    const [start, end] = getSlotRangeForEpoch(epochNumber, this.l1Constants);
-    return this.stores.blocks.getCheckpointDataForSlotRange(start, end);
-  }
-
   /** Returns just the checkpoint numbers for all checkpoints whose slot falls within the given epoch. */
-  public getCheckpointNumbersForEpoch(epochNumber: EpochNumber): Promise<CheckpointNumber[]> {
+  private getCheckpointNumbersForEpoch(epochNumber: EpochNumber): Promise<CheckpointNumber[]> {
     if (!this.l1Constants) {
       throw new Error('L1 constants not set');
     }

--- a/yarn-project/archiver/src/store/block_store.test.ts
+++ b/yarn-project/archiver/src/store/block_store.test.ts
@@ -2611,6 +2611,65 @@ describe('BlockStore', () => {
     });
   });
 
+  describe('getProposedCheckpointBySlot', () => {
+    async function addBlocksForProposed(
+      startBlock: number,
+      blockCount: number,
+      checkpointNumber: number,
+      previousArchive?: AppendOnlyTreeSnapshot,
+    ): Promise<void> {
+      for (let i = 0; i < blockCount; i++) {
+        const opts: Parameters<typeof L2Block.random>[1] = {
+          checkpointNumber: CheckpointNumber(checkpointNumber),
+          indexWithinCheckpoint: IndexWithinCheckpoint(i),
+        };
+        if (i === 0 && previousArchive) {
+          (opts as any).lastArchive = previousArchive;
+        }
+        const block = await L2Block.random(BlockNumber(startBlock + i), opts);
+        await blockStore.addProposedBlock(block, { force: true });
+      }
+    }
+
+    it('returns the proposed entry whose header slot matches', async () => {
+      await addBlocksForProposed(1, 1, 1);
+      const targetSlot = SlotNumber(42);
+      await blockStore.addProposedCheckpoint({
+        checkpointNumber: CheckpointNumber(1),
+        header: CheckpointHeader.random({ slotNumber: targetSlot }),
+        startBlock: BlockNumber(1),
+        blockCount: 1,
+        totalManaUsed: 100n,
+        feeAssetPriceModifier: 0n,
+      });
+
+      const result = await blockStore.getProposedCheckpointBySlot(targetSlot);
+      expect(result).toBeDefined();
+      expect(result!.checkpointNumber).toBe(1);
+      expect(result!.header.slotNumber).toBe(targetSlot);
+    });
+
+    it('returns undefined if no proposed entry has that slot', async () => {
+      await addBlocksForProposed(1, 1, 1);
+      await blockStore.addProposedCheckpoint({
+        checkpointNumber: CheckpointNumber(1),
+        header: CheckpointHeader.random({ slotNumber: SlotNumber(10) }),
+        startBlock: BlockNumber(1),
+        blockCount: 1,
+        totalManaUsed: 100n,
+        feeAssetPriceModifier: 0n,
+      });
+
+      const result = await blockStore.getProposedCheckpointBySlot(SlotNumber(999));
+      expect(result).toBeUndefined();
+    });
+
+    it('returns undefined when no proposed checkpoints exist', async () => {
+      const result = await blockStore.getProposedCheckpointBySlot(SlotNumber(1));
+      expect(result).toBeUndefined();
+    });
+  });
+
   describe('removeBlocksAfterBlock', () => {
     it('removes blocks with number > given blockNumber', async () => {
       // Create blocks for initial checkpoint

--- a/yarn-project/archiver/src/store/block_store.ts
+++ b/yarn-project/archiver/src/store/block_store.ts
@@ -798,6 +798,21 @@ export class BlockStore {
   }
 
   /**
+   * Returns the pending checkpoint whose header slot matches the given slot, or undefined if not found.
+   * Iterates `#proposedCheckpoints` rather than reading an index because the map carries 0–1 entries
+   * in normal operation (bounded by the proposer pipelining window). Returns the first match.
+   */
+  async getProposedCheckpointBySlot(slot: SlotNumber): Promise<ProposedCheckpointData | undefined> {
+    for await (const [, stored] of this.#proposedCheckpoints.entriesAsync()) {
+      const header = CheckpointHeader.fromBuffer(stored.header);
+      if (header.slotNumber === slot) {
+        return this.convertToProposedCheckpointData(stored);
+      }
+    }
+    return undefined;
+  }
+
+  /**
    * Evicts all pending checkpoints with checkpoint number >= fromNumber.
    * Used for divergent-mined-checkpoint cleanup: when L1 mines checkpoint N with a different archive,
    * all pending >= N must be evicted since they chain off the now-invalid pending N.

--- a/yarn-project/archiver/src/test/mock_l2_block_source.ts
+++ b/yarn-project/archiver/src/test/mock_l2_block_source.ts
@@ -20,11 +20,14 @@ import {
   type BlockTag,
   type BlocksQuery,
   Body,
+  type CheckpointQuery,
+  type CheckpointsQuery,
   GENESIS_BLOCK_HEADER_HASH,
   GENESIS_CHECKPOINT_HEADER_HASH,
   L2Block,
   type L2BlockSource,
   type L2Tips,
+  type ProposedCheckpointQuery,
   type ValidateCheckpointResult,
 } from '@aztec/stdlib/block';
 import {
@@ -273,8 +276,16 @@ export class MockL2BlockSource implements L2BlockSource, ContractDataSource {
     return Promise.resolve(BlockNumber(this.proposedCheckpointBlockNumber));
   }
 
-  public getCheckpoints(from: CheckpointNumber, limit: number) {
-    const checkpoints = this.checkpointList.slice(from - 1, from - 1 + limit);
+  public getCheckpoint(query: CheckpointQuery): Promise<PublishedCheckpoint | undefined> {
+    const checkpoint = this.resolveCheckpointQuery(query);
+    if (!checkpoint) {
+      return Promise.resolve(undefined);
+    }
+    return Promise.resolve(new PublishedCheckpoint(checkpoint, this.mockL1DataForCheckpoint(checkpoint), []));
+  }
+
+  public getCheckpoints(query: CheckpointsQuery): Promise<PublishedCheckpoint[]> {
+    const checkpoints = this.resolveCheckpointsQuery(query);
     return Promise.resolve(
       checkpoints.map(checkpoint => new PublishedCheckpoint(checkpoint, this.mockL1DataForCheckpoint(checkpoint), [])),
     );
@@ -285,41 +296,65 @@ export class MockL2BlockSource implements L2BlockSource, ContractDataSource {
     return Promise.resolve(checkpoint);
   }
 
-  public getCheckpointData(_n: CheckpointNumber): Promise<CheckpointData | undefined> {
-    return Promise.resolve(undefined);
+  public getCheckpointData(query: CheckpointQuery): Promise<CheckpointData | undefined> {
+    const checkpoint = this.resolveCheckpointQuery(query);
+    if (!checkpoint) {
+      return Promise.resolve(undefined);
+    }
+    return Promise.resolve(this.checkpointToData(checkpoint));
   }
 
-  public getCheckpointDataRange(_from: CheckpointNumber, _limit: number): Promise<CheckpointData[]> {
-    return Promise.resolve([]);
+  public getCheckpointsData(query: CheckpointsQuery): Promise<CheckpointData[]> {
+    const checkpoints = this.resolveCheckpointsQuery(query);
+    return Promise.resolve(checkpoints.map(c => this.checkpointToData(c)));
   }
 
-  public getCheckpointNumberBySlot(_slot: SlotNumber): Promise<CheckpointNumber | undefined> {
-    return Promise.resolve(undefined);
-  }
-
-  getCheckpointsForEpoch(epochNumber: EpochNumber): Promise<Checkpoint[]> {
-    return Promise.resolve(this.getCheckpointsInEpoch(epochNumber));
-  }
-
-  getCheckpointsDataForEpoch(epochNumber: EpochNumber): Promise<CheckpointData[]> {
-    const checkpoints = this.getCheckpointsInEpoch(epochNumber);
-    return Promise.resolve(
-      checkpoints.map(
-        (checkpoint): CheckpointData => ({
-          checkpointNumber: checkpoint.number,
-          header: checkpoint.header,
-          archive: checkpoint.archive,
-          checkpointOutHash: computeCheckpointOutHash(
-            checkpoint.blocks.map(b => b.body.txEffects.map(tx => tx.l2ToL1Msgs)),
-          ),
-          startBlock: checkpoint.blocks[0].number,
-          blockCount: checkpoint.blocks.length,
-          feeAssetPriceModifier: checkpoint.feeAssetPriceModifier,
-          attestations: [],
-          l1: this.mockL1DataForCheckpoint(checkpoint),
-        }),
+  private checkpointToData(checkpoint: Checkpoint): CheckpointData {
+    return {
+      checkpointNumber: checkpoint.number,
+      header: checkpoint.header,
+      archive: checkpoint.archive,
+      checkpointOutHash: computeCheckpointOutHash(
+        checkpoint.blocks.map(b => b.body.txEffects.map(tx => tx.l2ToL1Msgs)),
       ),
-    );
+      startBlock: checkpoint.blocks[0].number,
+      blockCount: checkpoint.blocks.length,
+      feeAssetPriceModifier: checkpoint.feeAssetPriceModifier,
+      attestations: [],
+      l1: this.mockL1DataForCheckpoint(checkpoint),
+    };
+  }
+
+  private resolveCheckpointQuery(query: CheckpointQuery): Checkpoint | undefined {
+    if ('number' in query) {
+      return this.checkpointList[query.number - 1];
+    }
+    if ('slot' in query) {
+      return this.checkpointList.find(c => c.header.slotNumber === query.slot);
+    }
+    switch (query.tag) {
+      case 'checkpointed':
+        return this.checkpointList[this.checkpointList.length - 1];
+      case 'proven': {
+        const provenCheckpoint = this.checkpointList.filter(c =>
+          c.blocks.some(b => b.number <= this.provenBlockNumber),
+        );
+        return provenCheckpoint.at(-1);
+      }
+      case 'finalized': {
+        const finalizedCheckpoint = this.checkpointList.filter(c =>
+          c.blocks.some(b => b.number <= this.finalizedBlockNumber),
+        );
+        return finalizedCheckpoint.at(-1);
+      }
+    }
+  }
+
+  private resolveCheckpointsQuery(query: CheckpointsQuery): Checkpoint[] {
+    if ('from' in query) {
+      return this.checkpointList.slice(query.from - 1, query.from - 1 + query.limit);
+    }
+    return this.getCheckpointsInEpoch(query.epoch);
   }
 
   getBlocksForSlot(slotNumber: SlotNumber): Promise<L2Block[]> {
@@ -608,11 +643,7 @@ export class MockL2BlockSource implements L2BlockSource, ContractDataSource {
     return Promise.resolve({ valid: true });
   }
 
-  getLastCheckpoint(): Promise<ProposedCheckpointData | undefined> {
-    return Promise.resolve(undefined);
-  }
-
-  getLastProposedCheckpoint(): Promise<ProposedCheckpointData | undefined> {
+  getProposedCheckpointData(_query?: ProposedCheckpointQuery): Promise<ProposedCheckpointData | undefined> {
     return Promise.resolve(undefined);
   }
 

--- a/yarn-project/aztec-node/src/aztec-node/block_response_helpers.ts
+++ b/yarn-project/aztec-node/src/aztec-node/block_response_helpers.ts
@@ -1,6 +1,11 @@
 import { BlockNumber } from '@aztec/foundation/branded-types';
 import { type BlockData, type CommitteeAttestation, L2Block } from '@aztec/stdlib/block';
-import type { CheckpointData, L1PublishedData, PublishedCheckpoint } from '@aztec/stdlib/checkpoint';
+import type {
+  CheckpointData,
+  L1PublishedData,
+  ProposedCheckpointData,
+  PublishedCheckpoint,
+} from '@aztec/stdlib/checkpoint';
 import {
   type BlockIncludeOptions,
   type BlockResponse,
@@ -111,6 +116,46 @@ export function checkpointResponseFromCheckpointData(
   }
   if (options.includeAttestations) {
     (response as CheckpointResponse).attestations = cd.attestations;
+  }
+  return response;
+}
+
+/**
+ * Projects a {@link ProposedCheckpointData} into a {@link CheckpointResponse}.
+ * Pure projection — caller pre-fetches `blocks` via `blockSource.getBlocks(...)` when
+ * `options.includeBlocks` is true. Throws if `includeL1PublishInfo` or `includeAttestations`
+ * is requested (proposed checkpoints have no L1 publish info or attestations).
+ */
+export async function projectProposedToCheckpointResponse(
+  proposed: ProposedCheckpointData,
+  options: CheckpointIncludeOptions,
+  blocks?: L2Block[],
+): Promise<CheckpointResponse> {
+  if (options.includeL1PublishInfo || options.includeAttestations) {
+    throw new Error('Proposed checkpoints have no L1 publish info or attestations');
+  }
+  const response: CheckpointResponse = {
+    number: proposed.checkpointNumber,
+    header: proposed.header,
+    archive: proposed.archive,
+    checkpointOutHash: proposed.checkpointOutHash,
+    startBlock: proposed.startBlock,
+    blockCount: proposed.blockCount,
+    feeAssetPriceModifier: proposed.feeAssetPriceModifier,
+  };
+  if (options.includeBlocks) {
+    if (!blocks) {
+      throw new Error('Blocks must be supplied when includeBlocks is true');
+    }
+    (response as CheckpointResponse).blocks = await Promise.all(
+      blocks.map(block =>
+        blockResponseFromL2Block(block, {
+          includeTransactions: options.includeTransactions,
+          includeL1PublishInfo: false,
+          includeAttestations: false,
+        }),
+      ),
+    );
   }
   return response;
 }

--- a/yarn-project/aztec-node/src/aztec-node/server.test.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.test.ts
@@ -29,14 +29,22 @@ import {
   type BlockQuery,
   L2Block,
   type L2BlockSource,
+  type L2Tips,
 } from '@aztec/stdlib/block';
+import type { CheckpointData, ProposedCheckpointData } from '@aztec/stdlib/checkpoint';
 import type { ContractDataSource } from '@aztec/stdlib/contract';
 import { EmptyL1RollupConstants } from '@aztec/stdlib/epoch-helpers';
 import { GasFees } from '@aztec/stdlib/gas';
 import type { L2LogsSource, MerkleTreeReadOperations, WorldStateSynchronizer } from '@aztec/stdlib/interfaces/server';
 import type { L1ToL2MessageSource } from '@aztec/stdlib/messaging';
+import { CheckpointHeader } from '@aztec/stdlib/rollup';
 import { mockTx } from '@aztec/stdlib/testing';
-import { MerkleTreeId, PublicDataTreeLeaf, PublicDataTreeLeafPreimage } from '@aztec/stdlib/trees';
+import {
+  AppendOnlyTreeSnapshot,
+  MerkleTreeId,
+  PublicDataTreeLeaf,
+  PublicDataTreeLeafPreimage,
+} from '@aztec/stdlib/trees';
 import type { FeeProvider } from '@aztec/stdlib/tx';
 import {
   BlockHeader,
@@ -1119,6 +1127,254 @@ describe('aztec node', () => {
       // First checkpoint (slot 0): 1 block with 1 tx with 1 message
       // Second checkpoint (slot 1): 1 block with 1 tx with 1 message
       expect(result).toEqual([[[[msg1]]], [[[msg2]]]]);
+    });
+  });
+
+  /** Builds an L2Tips stub with the given checkpoint numbers per tip. */
+  function makeTips(args: {
+    proposedCheckpoint?: CheckpointNumber;
+    checkpointed?: CheckpointNumber;
+    proven?: CheckpointNumber;
+    finalized?: CheckpointNumber;
+  }): L2Tips {
+    const emptyBlockId = { number: BlockNumber(0), hash: '' };
+    const makeTipId = (n: CheckpointNumber) => ({ block: emptyBlockId, checkpoint: { number: n, hash: '' } });
+    return {
+      proposed: emptyBlockId,
+      checkpointed: makeTipId(args.checkpointed ?? CheckpointNumber(0)),
+      proposedCheckpoint: makeTipId(args.proposedCheckpoint ?? CheckpointNumber(0)),
+      proven: makeTipId(args.proven ?? CheckpointNumber(0)),
+      finalized: makeTipId(args.finalized ?? CheckpointNumber(0)),
+    };
+  }
+
+  describe('getCheckpoint', () => {
+    /** Builds a minimal ProposedCheckpointData stub. */
+    function makeProposedCheckpointData(
+      checkpointNumber: CheckpointNumber,
+      slotNumber: SlotNumber,
+    ): ProposedCheckpointData {
+      return {
+        checkpointNumber,
+        header: CheckpointHeader.random({ slotNumber }),
+        archive: AppendOnlyTreeSnapshot.empty(),
+        checkpointOutHash: Fr.ZERO,
+        startBlock: BlockNumber(Number(checkpointNumber)),
+        blockCount: 1,
+        totalManaUsed: 0n,
+        feeAssetPriceModifier: 0n,
+      };
+    }
+
+    /** Builds a minimal CheckpointData stub. */
+    function makeCheckpointData(checkpointNumber: CheckpointNumber): CheckpointData {
+      return {
+        checkpointNumber,
+        header: CheckpointHeader.empty(),
+        archive: AppendOnlyTreeSnapshot.empty(),
+        checkpointOutHash: Fr.ZERO,
+        startBlock: BlockNumber(Number(checkpointNumber)),
+        blockCount: 1,
+        feeAssetPriceModifier: 0n,
+        attestations: [],
+        l1: { blockNumber: 10n, blockTimestamp: 1000n, blockHash: '0x0000' } as any,
+      };
+    }
+
+    describe('throw guards', () => {
+      it('throws BadRequestError when "proposed" resolves to a proposed entry and includeL1PublishInfo is requested', async () => {
+        l2BlockSource.getL2Tips.mockResolvedValue(makeTips({ proposedCheckpoint: CheckpointNumber(5) }));
+        l2BlockSource.getCheckpointData.mockResolvedValue(undefined);
+        l2BlockSource.getProposedCheckpointData.mockResolvedValue(
+          makeProposedCheckpointData(CheckpointNumber(5), SlotNumber(10)),
+        );
+
+        await expect(node.getCheckpoint('proposed', { includeL1PublishInfo: true })).rejects.toThrow(BadRequestError);
+      });
+
+      it('throws BadRequestError when "proposed" resolves to a proposed entry and includeAttestations is requested', async () => {
+        l2BlockSource.getL2Tips.mockResolvedValue(makeTips({ proposedCheckpoint: CheckpointNumber(5) }));
+        l2BlockSource.getCheckpointData.mockResolvedValue(undefined);
+        l2BlockSource.getProposedCheckpointData.mockResolvedValue(
+          makeProposedCheckpointData(CheckpointNumber(5), SlotNumber(10)),
+        );
+
+        await expect(node.getCheckpoint('proposed', { includeAttestations: true })).rejects.toThrow(BadRequestError);
+      });
+
+      it('throws BadRequestError when number lookup resolves to a proposed entry and includeL1PublishInfo is requested', async () => {
+        l2BlockSource.getCheckpointData.mockResolvedValue(undefined);
+        l2BlockSource.getProposedCheckpointData.mockResolvedValue(
+          makeProposedCheckpointData(CheckpointNumber(5), SlotNumber(10)),
+        );
+
+        await expect(
+          node.getCheckpoint({ number: CheckpointNumber(5) }, { includeL1PublishInfo: true }),
+        ).rejects.toThrow(BadRequestError);
+      });
+
+      it('throws BadRequestError when slot lookup resolves to a proposed entry and includeAttestations is requested', async () => {
+        l2BlockSource.getCheckpointData.mockResolvedValue(undefined);
+        l2BlockSource.getProposedCheckpointData.mockResolvedValue(
+          makeProposedCheckpointData(CheckpointNumber(3), SlotNumber(7)),
+        );
+
+        await expect(node.getCheckpoint({ slot: SlotNumber(7) }, { includeAttestations: true })).rejects.toThrow(
+          BadRequestError,
+        );
+      });
+    });
+
+    describe('fallback semantics', () => {
+      it('getCheckpoint("proposed") returns the projected proposed entry when one exists at the proposed-tip number', async () => {
+        l2BlockSource.getL2Tips.mockResolvedValue(makeTips({ proposedCheckpoint: CheckpointNumber(2) }));
+        l2BlockSource.getCheckpointData.mockResolvedValue(undefined);
+        const proposed = makeProposedCheckpointData(CheckpointNumber(2), SlotNumber(5));
+        l2BlockSource.getProposedCheckpointData.mockResolvedValue(proposed);
+
+        const result = await node.getCheckpoint('proposed');
+        expect(result).toBeDefined();
+        expect(result!.number).toEqual(CheckpointNumber(2));
+      });
+
+      it('getCheckpoint("proposed") returns the latest confirmed checkpoint when no proposed entry exists', async () => {
+        // When no proposed entry exists, the proposedCheckpoint tip falls back to the confirmed tip.
+        l2BlockSource.getL2Tips.mockResolvedValue(
+          makeTips({ proposedCheckpoint: CheckpointNumber(3), checkpointed: CheckpointNumber(3) }),
+        );
+        const confirmed = makeCheckpointData(CheckpointNumber(3));
+        l2BlockSource.getCheckpointData.mockResolvedValue(confirmed);
+
+        const result = await node.getCheckpoint('proposed');
+        expect(result).toBeDefined();
+        expect(result!.number).toEqual(CheckpointNumber(3));
+      });
+
+      it('getCheckpoint({ number }) returns the confirmed entry when one exists', async () => {
+        const confirmed = makeCheckpointData(CheckpointNumber(3));
+        l2BlockSource.getCheckpointData.mockResolvedValue(confirmed);
+        l2BlockSource.getProposedCheckpointData.mockResolvedValue(
+          makeProposedCheckpointData(CheckpointNumber(3), SlotNumber(99)),
+        );
+
+        const result = await node.getCheckpoint({ number: CheckpointNumber(3) });
+        // The confirmed entry should be returned; proposed should not be reached
+        expect(result).toBeDefined();
+        expect(result!.number).toEqual(CheckpointNumber(3));
+        // l1 is not included by default — confirm no throw and correct shape
+        expect(result!.l1).toBeUndefined();
+      });
+
+      it('getCheckpoint({ number }) falls back to proposed entry when no confirmed match', async () => {
+        l2BlockSource.getCheckpointData.mockResolvedValue(undefined);
+        const proposed = makeProposedCheckpointData(CheckpointNumber(4), SlotNumber(8));
+        l2BlockSource.getProposedCheckpointData.mockResolvedValue(proposed);
+
+        const result = await node.getCheckpoint({ number: CheckpointNumber(4) });
+        expect(result).toBeDefined();
+        expect(result!.number).toEqual(CheckpointNumber(4));
+      });
+
+      it('getCheckpoint({ slot }) falls back to proposed entry when no confirmed match', async () => {
+        l2BlockSource.getCheckpointData.mockResolvedValue(undefined);
+        const proposed = makeProposedCheckpointData(CheckpointNumber(5), SlotNumber(11));
+        l2BlockSource.getProposedCheckpointData.mockResolvedValue(proposed);
+
+        const result = await node.getCheckpoint({ slot: SlotNumber(11) });
+        expect(result).toBeDefined();
+        expect(result!.number).toEqual(CheckpointNumber(5));
+      });
+
+      it('getCheckpoint("checkpointed") returns the confirmed entry at the checkpointed tip', async () => {
+        l2BlockSource.getL2Tips.mockResolvedValue(makeTips({ checkpointed: CheckpointNumber(2) }));
+        const confirmed = makeCheckpointData(CheckpointNumber(2));
+        l2BlockSource.getCheckpointData.mockResolvedValue(confirmed);
+
+        const result = await node.getCheckpoint('checkpointed');
+        expect(result).toBeDefined();
+        expect(result!.number).toEqual(CheckpointNumber(2));
+      });
+
+      it('getCheckpoint("checkpointed") returns undefined when neither store has the resolved number', async () => {
+        l2BlockSource.getL2Tips.mockResolvedValue(makeTips({ checkpointed: CheckpointNumber(2) }));
+        l2BlockSource.getCheckpointData.mockResolvedValue(undefined);
+        l2BlockSource.getProposedCheckpointData.mockResolvedValue(undefined);
+
+        const result = await node.getCheckpoint('checkpointed');
+        expect(result).toBeUndefined();
+      });
+
+      it('getCheckpoint("proven") returns the confirmed entry at the proven tip', async () => {
+        l2BlockSource.getL2Tips.mockResolvedValue(makeTips({ proven: CheckpointNumber(4) }));
+        const confirmed = makeCheckpointData(CheckpointNumber(4));
+        l2BlockSource.getCheckpointData.mockResolvedValue(confirmed);
+
+        const result = await node.getCheckpoint('proven');
+        expect(result).toBeDefined();
+        expect(result!.number).toEqual(CheckpointNumber(4));
+      });
+
+      it('getCheckpoint("proven") returns undefined when neither store has the resolved number', async () => {
+        l2BlockSource.getL2Tips.mockResolvedValue(makeTips({ proven: CheckpointNumber(4) }));
+        l2BlockSource.getCheckpointData.mockResolvedValue(undefined);
+        l2BlockSource.getProposedCheckpointData.mockResolvedValue(undefined);
+
+        const result = await node.getCheckpoint('proven');
+        expect(result).toBeUndefined();
+      });
+
+      it('getCheckpoint("finalized") returns undefined when neither store has the resolved number', async () => {
+        l2BlockSource.getL2Tips.mockResolvedValue(makeTips({ finalized: CheckpointNumber(6) }));
+        l2BlockSource.getCheckpointData.mockResolvedValue(undefined);
+        l2BlockSource.getProposedCheckpointData.mockResolvedValue(undefined);
+
+        const result = await node.getCheckpoint('finalized');
+        expect(result).toBeUndefined();
+      });
+
+      it('getCheckpoint({ number }) returns undefined when neither confirmed nor proposed exist', async () => {
+        l2BlockSource.getCheckpointData.mockResolvedValue(undefined);
+        l2BlockSource.getProposedCheckpointData.mockResolvedValue(undefined);
+
+        const result = await node.getCheckpoint({ number: CheckpointNumber(99) });
+        expect(result).toBeUndefined();
+      });
+    });
+
+    describe('includeBlocks on a proposed match', () => {
+      it('pre-fetches inner blocks and passes them into the projected response', async () => {
+        l2BlockSource.getCheckpointData.mockResolvedValue(undefined);
+        const proposed = makeProposedCheckpointData(CheckpointNumber(2), SlotNumber(5));
+        l2BlockSource.getProposedCheckpointData.mockResolvedValue(proposed);
+
+        const fakeBlock = L2Block.empty();
+        l2BlockSource.getBlocks.mockResolvedValue([fakeBlock]);
+
+        const result = await node.getCheckpoint({ number: CheckpointNumber(2) }, { includeBlocks: true });
+        expect(result).toBeDefined();
+        expect(result!.blocks).toBeDefined();
+        expect(result!.blocks!.length).toBe(1);
+      });
+    });
+  });
+
+  describe('getCheckpointNumber', () => {
+    it('returns the proposed checkpoint number from proposedCheckpoint tip', async () => {
+      l2BlockSource.getL2Tips.mockResolvedValue(
+        makeTips({ proposedCheckpoint: CheckpointNumber(7), checkpointed: CheckpointNumber(5) }),
+      );
+
+      const result = await node.getCheckpointNumber('proposed');
+      expect(result).toEqual(CheckpointNumber(7));
+    });
+
+    it('returns the proposedCheckpoint tip number when it equals the confirmed checkpoint (fallback already baked in)', async () => {
+      l2BlockSource.getL2Tips.mockResolvedValue(
+        makeTips({ proposedCheckpoint: CheckpointNumber(5), checkpointed: CheckpointNumber(5) }),
+      );
+
+      const result = await node.getCheckpointNumber('proposed');
+      expect(result).toEqual(CheckpointNumber(5));
     });
   });
 });

--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -53,13 +53,14 @@ import {
   BlockHash,
   type BlockParameter,
   BlockTag,
+  type CheckpointsQuery,
   type CommitteeAttestation,
   type DataInBlock,
   type L2BlockSource,
   type NormalizedBlockParameter,
   inspectBlockParameter,
 } from '@aztec/stdlib/block';
-import { L1PublishedData } from '@aztec/stdlib/checkpoint';
+import { type CheckpointData, L1PublishedData, type PublishedCheckpoint } from '@aztec/stdlib/checkpoint';
 import type {
   ContractClassPublic,
   ContractDataSource,
@@ -143,6 +144,7 @@ import {
   blockResponseFromL2Block,
   checkpointResponseFromCheckpointData,
   checkpointResponseFromPublishedCheckpoint,
+  projectProposedToCheckpointResponse,
 } from './block_response_helpers.js';
 import { type AztecNodeConfig, createKeyStoreForValidator } from './config.js';
 import { NodeMetrics } from './node_metrics.js';
@@ -240,8 +242,8 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, AztecNodeDeb
     );
   }
 
-  public getCheckpointsDataForEpoch(epoch: EpochNumber) {
-    return this.blockSource.getCheckpointsDataForEpoch(epoch);
+  public getCheckpointsData(query: CheckpointsQuery) {
+    return this.blockSource.getCheckpointsData(query);
   }
 
   public getBlockNumber(tip?: ChainTip): Promise<BlockNumber> {
@@ -259,16 +261,17 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, AztecNodeDeb
   }
 
   public async getCheckpointNumber(tip?: ChainTip): Promise<CheckpointNumber> {
+    const tips = await this.blockSource.getL2Tips();
     switch (tip) {
       case undefined:
-      case 'proposed':
       case 'checkpointed':
-        return await this.blockSource.getCheckpointNumber();
+        return tips.checkpointed.checkpoint.number;
+      case 'proposed':
+        return tips.proposedCheckpoint.checkpoint.number;
       case 'proven':
-      case 'finalized': {
-        const tips = await this.blockSource.getL2Tips();
-        return tip === 'proven' ? tips.proven.checkpoint.number : tips.finalized.checkpoint.number;
-      }
+        return tips.proven.checkpoint.number;
+      case 'finalized':
+        return tips.finalized.checkpoint.number;
     }
   }
 
@@ -318,17 +321,32 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, AztecNodeDeb
     return BlockTag.includes(value as BlockTag);
   }
 
+  /**
+   * Resolves a {@link CheckpointParameter} into a concrete `{ number }` or `{ slot }` query.
+   *
+   * Tag-based parameters (`'proposed'`, `'checkpointed'`, `'proven'`, `'finalized'`) are
+   * translated up-front to the corresponding tip's checkpoint number via {@link L2BlockSource.getL2Tips}.
+   * After resolution the unified {@link getCheckpoint} flow can perform a single
+   * confirmed→proposed lookup against either store.
+   */
   private async resolveCheckpointParameter(
     param: CheckpointParameter,
-  ): Promise<{ number?: CheckpointNumber; slot?: SlotNumber }> {
+  ): Promise<{ number: CheckpointNumber } | { slot: SlotNumber }> {
     if (typeof param === 'number') {
       return { number: param as CheckpointNumber };
     }
-    if (param === 'latest') {
-      return { number: await this.blockSource.getCheckpointNumber() };
-    }
     if (this.isChainTip(param)) {
-      return { number: await this.getCheckpointNumber(param) };
+      const tips = await this.blockSource.getL2Tips();
+      switch (param) {
+        case 'proposed':
+          return { number: tips.proposedCheckpoint.checkpoint.number };
+        case 'checkpointed':
+          return { number: tips.checkpointed.checkpoint.number };
+        case 'proven':
+          return { number: tips.proven.checkpoint.number };
+        case 'finalized':
+          return { number: tips.finalized.checkpoint.number };
+      }
     }
     if (typeof param === 'object' && param !== null) {
       if ('number' in param) {
@@ -345,7 +363,7 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, AztecNodeDeb
   async #getCheckpointContext(
     checkpointNumber: CheckpointNumber,
   ): Promise<{ l1?: L1PublishedData; attestations?: CommitteeAttestation[] } | undefined> {
-    const checkpoint = await this.blockSource.getCheckpointData(checkpointNumber);
+    const checkpoint = await this.blockSource.getCheckpointData({ number: checkpointNumber });
     if (!checkpoint) {
       return undefined;
     }
@@ -412,26 +430,33 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, AztecNodeDeb
     param: CheckpointParameter,
     options: Opts = {} as Opts,
   ): Promise<CheckpointResponse<Opts> | undefined> {
-    const resolved = await this.resolveCheckpointParameter(param);
-    let checkpointNumber = resolved.number;
-    if (checkpointNumber === undefined && resolved.slot !== undefined) {
-      checkpointNumber = await this.blockSource.getCheckpointNumberBySlot(resolved.slot);
+    const query = await this.resolveCheckpointParameter(param);
+
+    // Try the confirmed store first.
+    const confirmed = options.includeBlocks
+      ? await this.blockSource.getCheckpoint(query)
+      : await this.blockSource.getCheckpointData(query);
+    if (confirmed) {
+      return (await (options.includeBlocks
+        ? checkpointResponseFromPublishedCheckpoint(confirmed as PublishedCheckpoint, options)
+        : checkpointResponseFromCheckpointData(confirmed as CheckpointData, options))) as CheckpointResponse<Opts>;
     }
-    if (checkpointNumber === undefined) {
-      return undefined;
-    }
-    if (options.includeBlocks) {
-      const [checkpoint] = await this.blockSource.getCheckpoints(checkpointNumber, 1);
-      if (!checkpoint) {
-        return undefined;
+
+    // Fall back to the proposed store.
+    const proposed = await this.blockSource.getProposedCheckpointData(query);
+    if (proposed) {
+      if (options.includeAttestations || options.includeL1PublishInfo) {
+        throw new BadRequestError(
+          `Options includeL1PublishInfo or includeAttestations cannot be satisfied for a proposed checkpoint`,
+        );
       }
-      return (await checkpointResponseFromPublishedCheckpoint(checkpoint, options)) as CheckpointResponse<Opts>;
+      const blocks = options.includeBlocks
+        ? await this.blockSource.getBlocks({ from: proposed.startBlock, limit: proposed.blockCount })
+        : undefined;
+      return (await projectProposedToCheckpointResponse(proposed, options, blocks)) as CheckpointResponse<Opts>;
     }
-    const data = await this.blockSource.getCheckpointData(checkpointNumber);
-    if (!data) {
-      return undefined;
-    }
-    return checkpointResponseFromCheckpointData(data, options) as CheckpointResponse<Opts>;
+
+    return undefined;
   }
 
   public async getCheckpoints<Opts extends CheckpointIncludeOptions = {}>(
@@ -440,12 +465,12 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, AztecNodeDeb
     options: Opts = {} as Opts,
   ): Promise<CheckpointResponse<Opts>[]> {
     if (options.includeBlocks) {
-      const checkpoints = await this.blockSource.getCheckpoints(from, limit);
+      const checkpoints = await this.blockSource.getCheckpoints({ from, limit });
       return (await Promise.all(
         checkpoints.map(cp => checkpointResponseFromPublishedCheckpoint(cp, options)),
       )) as CheckpointResponse<Opts>[];
     }
-    const datas = await this.blockSource.getCheckpointDataRange(from, limit);
+    const datas = await this.blockSource.getCheckpointsData({ from, limit });
     return datas.map(d => checkpointResponseFromCheckpointData(d, options)) as CheckpointResponse<Opts>[];
   }
 

--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_mbps.parallel.test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_mbps.parallel.test.ts
@@ -145,7 +145,7 @@ describe('e2e_epochs/epochs_mbps', () => {
     const waitTimeout = test.L2_SLOT_DURATION_IN_S * 3;
     await retryUntil(
       async () => {
-        const checkpoints = await archiver.getCheckpoints(CheckpointNumber(1), 50);
+        const checkpoints = await archiver.getCheckpoints({ from: CheckpointNumber(1), limit: 50 });
         return checkpoints.some(pc => pc.checkpoint.blocks.length >= targetBlockCount) || undefined;
       },
       `checkpoint with at least ${targetBlockCount} blocks`,
@@ -153,7 +153,7 @@ describe('e2e_epochs/epochs_mbps', () => {
       0.5,
     );
 
-    const checkpoints = await archiver.getCheckpoints(CheckpointNumber(1), 50);
+    const checkpoints = await archiver.getCheckpoints({ from: CheckpointNumber(1), limit: 50 });
     logger.warn(`Retrieved ${checkpoints.length} checkpoints from archiver`, {
       checkpoints: checkpoints.map(pc => pc.checkpoint.getStats()),
     });
@@ -308,7 +308,7 @@ describe('e2e_epochs/epochs_mbps', () => {
     const multiBlockCheckpoint = await assertMultipleBlocksPerSlot(EXPECTED_BLOCKS_PER_CHECKPOINT, logger);
 
     // Verify L2→L1 messages are in the blocks
-    const checkpoints = await archiver.getCheckpoints(CheckpointNumber(1), 50);
+    const checkpoints = await archiver.getCheckpoints({ from: CheckpointNumber(1), limit: 50 });
     const allBlocks = checkpoints.flatMap(pc => pc.checkpoint.blocks);
     const allL2ToL1Messages = allBlocks.flatMap(block => block.body.txEffects.flatMap(txEffect => txEffect.l2ToL1Msgs));
     logger.warn(`Found ${allL2ToL1Messages.length} L2→L1 message(s) across all blocks`, { allL2ToL1Messages });

--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_mbps.pipeline.parallel.test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_mbps.pipeline.parallel.test.ts
@@ -115,7 +115,7 @@ describe('e2e_epochs/epochs_mbps_pipeline', () => {
 
   /** Retrieves all checkpoints from the archiver, checks that one has the target block count, and returns its number. */
   async function assertMultipleBlocksPerSlot(targetBlockCount: number, logger: Logger): Promise<CheckpointNumber> {
-    const checkpoints = await archiver.getCheckpoints(CheckpointNumber(1), 50);
+    const checkpoints = await archiver.getCheckpoints({ from: CheckpointNumber(1), limit: 50 });
     logger.warn(`Retrieved ${checkpoints.length} checkpoints from archiver`, {
       checkpoints: checkpoints.map(pc => pc.checkpoint.getStats()),
     });
@@ -162,7 +162,7 @@ describe('e2e_epochs/epochs_mbps_pipeline', () => {
     blockProposedEvents: { blockNumber: BlockNumber; slot: SlotNumber; buildSlot: SlotNumber }[],
     logger: Logger,
   ) {
-    const checkpoints = await archiver.getCheckpoints(CheckpointNumber(1), 50);
+    const checkpoints = await archiver.getCheckpoints({ from: CheckpointNumber(1), limit: 50 });
     const allBlocks = checkpoints.flatMap(pc => pc.checkpoint.blocks);
 
     logger.warn(`assertProposerPipelining: ${allBlocks.length} blocks, ${blockProposedEvents.length} events`, {

--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_mbps_redistribution.test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_mbps_redistribution.test.ts
@@ -311,7 +311,7 @@ describe('e2e_epochs/epochs_mbps_redistribution', () => {
 
     await retryUntil(
       async () => {
-        const checkpoints = await archiver.getCheckpoints(CheckpointNumber(1), 50);
+        const checkpoints = await archiver.getCheckpoints({ from: CheckpointNumber(1), limit: 50 });
         for (const pc of checkpoints) {
           if (pc.checkpoint.number <= lastSeenCheckpoint) {
             continue;

--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_test.ts
@@ -465,7 +465,7 @@ export class EpochsTestContext {
   /** Verifies at least one checkpoint has the target number of blocks (for MBPS validation). */
   public async assertMultipleBlocksPerSlot(targetBlockCount: number) {
     const archiver = (this.context.aztecNode as AztecNodeService).getBlockSource() as Archiver;
-    const checkpoints = await archiver.getCheckpoints(CheckpointNumber(1), 50);
+    const checkpoints = await archiver.getCheckpoints({ from: CheckpointNumber(1), limit: 50 });
 
     this.logger.warn(`Retrieved ${checkpoints.length} checkpoints from archiver`, {
       checkpoints: checkpoints.map(pc => pc.checkpoint.getStats()),

--- a/yarn-project/end-to-end/src/e2e_l1_publisher/e2e_l1_publisher.test.ts
+++ b/yarn-project/end-to-end/src/e2e_l1_publisher/e2e_l1_publisher.test.ts
@@ -52,6 +52,7 @@ import {
   type BlockQuery,
   type BlocksQuery,
   Body,
+  type CheckpointsQuery,
   type CommitteeAttestation,
   CommitteeAttestationsAndSigners,
   L2Block,
@@ -249,9 +250,10 @@ describe('L1Publisher integration', () => {
         }
         return Promise.resolve(undefined);
       },
-      async getCheckpoints(checkpointNumber, _limit) {
+      async getCheckpoints(query: CheckpointsQuery) {
         // Test uses 1-block-per-checkpoint, so we find block by checkpoint number
-        const block = blocks.find(b => Number(b.number) === Number(checkpointNumber));
+        const from = 'from' in query ? query.from : undefined;
+        const block = from !== undefined ? blocks.find(b => Number(b.number) === Number(from)) : undefined;
         if (!block) {
           return Promise.resolve([]);
         }
@@ -259,7 +261,7 @@ describe('L1Publisher integration', () => {
           block.archive,
           CheckpointHeader.random({ lastArchiveRoot: block.header.lastArchive.root }),
           [block],
-          checkpointNumber,
+          from!,
         );
         return [
           new PublishedCheckpoint(

--- a/yarn-project/end-to-end/src/e2e_multi_validator/e2e_multi_validator_node.test.ts
+++ b/yarn-project/end-to-end/src/e2e_multi_validator/e2e_multi_validator_node.test.ts
@@ -124,7 +124,7 @@ describe('e2e_multi_validator_node', () => {
 
     const dataStore = (aztecNode as AztecNodeService).getBlockSource() as Archiver;
     const blockData = await dataStore.getBlockData({ number: BlockNumber(tx.blockNumber!) });
-    const [publishedCheckpoint] = await dataStore.getCheckpoints(blockData!.checkpointNumber, 1);
+    const [publishedCheckpoint] = await dataStore.getCheckpoints({ from: blockData!.checkpointNumber, limit: 1 });
     const signatureContext = {
       chainId: config.l1ChainId,
       rollupAddress: deployL1ContractsValues.l1ContractAddresses.rollupAddress,
@@ -186,7 +186,7 @@ describe('e2e_multi_validator_node', () => {
 
     const dataStore = (aztecNode as AztecNodeService).getBlockSource() as Archiver;
     const blockData = await dataStore.getBlockData({ number: BlockNumber(tx.blockNumber!) });
-    const [publishedCheckpoint] = await dataStore.getCheckpoints(blockData!.checkpointNumber, 1);
+    const [publishedCheckpoint] = await dataStore.getCheckpoints({ from: blockData!.checkpointNumber, limit: 1 });
     const signatureContext = {
       chainId: config.l1ChainId,
       rollupAddress: deployL1ContractsValues.l1ContractAddresses.rollupAddress,

--- a/yarn-project/end-to-end/src/e2e_p2p/fee_asset_price_oracle_gossip.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/fee_asset_price_oracle_gossip.test.ts
@@ -178,7 +178,7 @@ describe('e2e_p2p_network', () => {
         const blockNumbers = await Promise.all(nodes.map(node => node.getBlockNumber()));
         const checkpointNumber = (await t.monitor.run()).checkpointNumber;
         t.logger.info(`Current block numbers ${blockNumbers} (checkpoint number on L1 is ${checkpointNumber})`);
-        const [checkpoint] = await dataStore.getCheckpoints(CheckpointNumber(1), 1);
+        const [checkpoint] = await dataStore.getCheckpoints({ from: CheckpointNumber(1), limit: 1 });
         return checkpoint;
       },
       'published checkpoint to be indexed',

--- a/yarn-project/end-to-end/src/e2e_p2p/gossip_network.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/gossip_network.test.ts
@@ -188,7 +188,7 @@ describe('e2e_p2p_network', () => {
     const blockNumber = receipt.blockNumber!;
     const dataStore = (nodes[0] as AztecNodeService).getBlockSource() as Archiver;
     const blockData = await dataStore.getBlockData({ number: BlockNumber(blockNumber) });
-    const [publishedCheckpoint] = await dataStore.getCheckpoints(blockData!.checkpointNumber, 1);
+    const [publishedCheckpoint] = await dataStore.getCheckpoints({ from: blockData!.checkpointNumber, limit: 1 });
     const signatureContext = {
       chainId: t.ctx.aztecNodeConfig.l1ChainId,
       rollupAddress: t.ctx.deployL1ContractsValues.l1ContractAddresses.rollupAddress,

--- a/yarn-project/end-to-end/src/e2e_p2p/gossip_network_no_cheat.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/gossip_network_no_cheat.test.ts
@@ -247,7 +247,7 @@ describe('e2e_p2p_network', () => {
     const blockNumber = await nodes[0].getTxReceipt(txsSentViaDifferentNodes[0][0]).then(r => r.blockNumber!);
     const dataStore = (nodes[0] as AztecNodeService).getBlockSource() as Archiver;
     const blockData = await dataStore.getBlockData({ number: BlockNumber(blockNumber) });
-    const [publishedCheckpoint] = await dataStore.getCheckpoints(blockData!.checkpointNumber, 1);
+    const [publishedCheckpoint] = await dataStore.getCheckpoints({ from: blockData!.checkpointNumber, limit: 1 });
     const signatureContext = {
       chainId: t.ctx.aztecNodeConfig.l1ChainId,
       rollupAddress: t.ctx.deployL1ContractsValues.l1ContractAddresses.rollupAddress,

--- a/yarn-project/end-to-end/src/e2e_p2p/preferred_gossip_network.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/preferred_gossip_network.test.ts
@@ -357,7 +357,7 @@ describe('e2e_p2p_preferred_network', () => {
     const blockNumber = receipts[0].blockNumber!;
     const dataStore = (nodes[0] as AztecNodeService).getBlockSource() as Archiver;
     const blockData = await dataStore.getBlockData({ number: BlockNumber(blockNumber) });
-    const [publishedCheckpoint] = await dataStore.getCheckpoints(blockData!.checkpointNumber, 1);
+    const [publishedCheckpoint] = await dataStore.getCheckpoints({ from: blockData!.checkpointNumber, limit: 1 });
     const signatureContext = {
       chainId: t.ctx.aztecNodeConfig.l1ChainId,
       rollupAddress: t.ctx.deployL1ContractsValues.l1ContractAddresses.rollupAddress,

--- a/yarn-project/prover-node/src/prover-node.test.ts
+++ b/yarn-project/prover-node/src/prover-node.test.ts
@@ -149,10 +149,14 @@ describe('prover-node', () => {
       attestations: [CommitteeAttestation.random()],
     } as PublishedCheckpoint;
 
+    const publishedCheckpoints: PublishedCheckpoint[] = [
+      ...checkpoints.slice(0, -1).map(cp => ({ checkpoint: cp, attestations: [] }) as unknown as PublishedCheckpoint),
+      lastPublishedCheckpoint,
+    ];
+
     l1GenesisTime = Math.floor(Date.now() / 1000) - 3600;
     l2BlockSource.getL1Constants.mockResolvedValue({ ...EmptyL1RollupConstants, l1GenesisTime: BigInt(l1GenesisTime) });
-    l2BlockSource.getCheckpointsForEpoch.mockResolvedValue(checkpoints);
-    l2BlockSource.getCheckpoints.mockResolvedValue([lastPublishedCheckpoint]);
+    l2BlockSource.getCheckpoints.mockResolvedValue(publishedCheckpoints);
     const latestBlockNumber = BlockNumber.fromCheckpointNumber(checkpoints.at(-1)!.number);
     const latestHash = checkpoints.at(-1)!.hash().toString();
     const genesisTipId = {
@@ -214,7 +218,7 @@ describe('prover-node', () => {
   });
 
   it('does not start a proof if there are no checkpoints in the epoch', async () => {
-    l2BlockSource.getCheckpointsForEpoch.mockResolvedValue([]);
+    l2BlockSource.getCheckpoints.mockResolvedValue([]);
     await proverNode.handleEpochReadyToProve(EpochNumber.fromBigInt(10n));
     expect(proverNode.totalJobCount).toEqual(0);
   });

--- a/yarn-project/prover-node/src/prover-node.ts
+++ b/yarn-project/prover-node/src/prover-node.ts
@@ -312,24 +312,19 @@ export class ProverNode implements EpochMonitorHandler, ProverNodeApi, Traceable
 
   @trackSpan('ProverNode.gatherEpochData', epochNumber => ({ [Attributes.EPOCH_NUMBER]: epochNumber }))
   private async gatherEpochData(epochNumber: EpochNumber): Promise<EpochProvingJobData> {
-    const checkpoints = await this.gatherCheckpoints(epochNumber);
+    const publishedCheckpoints = await this.l2BlockSource.getCheckpoints({ epoch: epochNumber });
+    if (publishedCheckpoints.length === 0) {
+      throw new EmptyEpochError(epochNumber);
+    }
+    const checkpoints = publishedCheckpoints.map(p => p.checkpoint);
+    const attestations = publishedCheckpoints.at(-1)?.attestations ?? [];
     const txArray = await this.gatherTxs(epochNumber, checkpoints);
     const txs = new Map<string, Tx>(txArray.map(tx => [tx.getTxHash().toString(), tx]));
     const l1ToL2Messages = await this.gatherMessages(epochNumber, checkpoints);
     const [firstBlock] = checkpoints[0].blocks;
     const previousBlockHeader = await this.gatherPreviousBlockHeader(epochNumber, firstBlock.number - 1);
-    const [lastPublishedCheckpoint] = await this.l2BlockSource.getCheckpoints(checkpoints.at(-1)!.number, 1);
-    const attestations = lastPublishedCheckpoint?.attestations ?? [];
 
     return { checkpoints, txs, l1ToL2Messages, epochNumber, previousBlockHeader, attestations };
-  }
-
-  private async gatherCheckpoints(epochNumber: EpochNumber) {
-    const checkpoints = await this.l2BlockSource.getCheckpointsForEpoch(epochNumber);
-    if (checkpoints.length === 0) {
-      throw new EmptyEpochError(epochNumber);
-    }
-    return checkpoints;
   }
 
   private async gatherTxs(epochNumber: EpochNumber, checkpoints: Checkpoint[]) {

--- a/yarn-project/pxe/src/block_synchronizer/block_stream_source.ts
+++ b/yarn-project/pxe/src/block_synchronizer/block_stream_source.ts
@@ -1,6 +1,12 @@
-import type { CheckpointNumber } from '@aztec/foundation/branded-types';
 import { Fr } from '@aztec/foundation/curves/bn254';
-import { type BlockData, type BlockQuery, type BlocksQuery, L2Block, type L2BlockSource } from '@aztec/stdlib/block';
+import {
+  type BlockData,
+  type BlockQuery,
+  type BlocksQuery,
+  type CheckpointsQuery,
+  L2Block,
+  type L2BlockSource,
+} from '@aztec/stdlib/block';
 import { Checkpoint, L1PublishedData, PublishedCheckpoint } from '@aztec/stdlib/checkpoint';
 import type { AztecNode } from '@aztec/stdlib/interfaces/client';
 
@@ -42,7 +48,11 @@ export function blockStreamSourceFromAztecNode(
       return responses.map(r => new L2Block(r.archive, r.header, r.body!, r.checkpointNumber, r.indexWithinCheckpoint));
     },
 
-    async getCheckpoints(from: CheckpointNumber, limit: number): Promise<PublishedCheckpoint[]> {
+    async getCheckpoints(query: CheckpointsQuery): Promise<PublishedCheckpoint[]> {
+      if (!('from' in query)) {
+        throw new Error('getCheckpoints with epoch query not supported via AztecNode RPC');
+      }
+      const { from, limit } = query;
       const responses = await node.getCheckpoints(from, limit, {
         includeBlocks: true,
         includeTransactions: true,

--- a/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.test.ts
@@ -234,7 +234,7 @@ describe('CheckpointProposalJob', () => {
     l1ToL2MessageSource.getL1ToL2Messages.mockResolvedValue(Array(4).fill(Fr.ZERO));
 
     l2BlockSource = mock<L2BlockSource>();
-    l2BlockSource.getCheckpointsDataForEpoch.mockResolvedValue([]);
+    l2BlockSource.getCheckpointsData.mockResolvedValue([]);
 
     blockSink = mock<L2BlockSink>();
     blockSink.addBlock.mockResolvedValue(undefined);
@@ -460,7 +460,7 @@ describe('CheckpointProposalJob', () => {
       );
 
       // Mock l2BlockSource to return the previous checkpoints
-      l2BlockSource.getCheckpointsDataForEpoch.mockResolvedValue(previousCheckpointsData);
+      l2BlockSource.getCheckpointsData.mockResolvedValue(previousCheckpointsData);
 
       // Build block successfully
       const { txs, block } = await setupTxsAndBlock(p2p, globalVariables, 1, chainId);
@@ -497,7 +497,7 @@ describe('CheckpointProposalJob', () => {
       );
 
       // Mock l2BlockSource to return all three checkpoints as data
-      l2BlockSource.getCheckpointsDataForEpoch.mockResolvedValue([
+      l2BlockSource.getCheckpointsData.mockResolvedValue([
         toCheckpointData(previousCheckpoint),
         toCheckpointData(currentCheckpoint),
         toCheckpointData(futureCheckpoint),
@@ -529,7 +529,7 @@ describe('CheckpointProposalJob', () => {
       checkpointNumber = CheckpointNumber(2);
       const previousCheckpoint = await Checkpoint.random(CheckpointNumber(1));
 
-      l2BlockSource.getCheckpointsDataForEpoch.mockResolvedValue([toCheckpointData(previousCheckpoint)]);
+      l2BlockSource.getCheckpointsData.mockResolvedValue([toCheckpointData(previousCheckpoint)]);
 
       job = createCheckpointProposalJob({ slotNow, targetSlot, targetEpoch });
       job.setTimetable(
@@ -548,8 +548,8 @@ describe('CheckpointProposalJob', () => {
 
       await job.execute();
 
-      // Verify getCheckpointsDataForEpoch was called with targetEpoch (1), not the wall-clock epoch (0)
-      expect(l2BlockSource.getCheckpointsDataForEpoch).toHaveBeenCalledWith(targetEpoch);
+      // Verify getCheckpointsData was called with targetEpoch (1), not the wall-clock epoch (0)
+      expect(l2BlockSource.getCheckpointsData).toHaveBeenCalledWith({ epoch: targetEpoch });
     });
   });
 

--- a/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.timing.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.timing.test.ts
@@ -435,7 +435,7 @@ describe('CheckpointProposalJob Timing Tests', () => {
     l1ToL2MessageSource.getL1ToL2Messages.mockResolvedValue(Array(4).fill(Fr.ZERO));
 
     l2BlockSource = mock<L2BlockSource>();
-    l2BlockSource.getCheckpointsDataForEpoch.mockResolvedValue([]);
+    l2BlockSource.getCheckpointsData.mockResolvedValue([]);
 
     blockSink = mock<L2BlockSink>();
     blockSink.addBlock.mockResolvedValue(undefined);

--- a/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.ts
+++ b/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.ts
@@ -561,7 +561,7 @@ export class CheckpointProposalJob implements Traceable {
       const inHash = computeInHashFromL1ToL2Messages(l1ToL2Messages);
 
       // Collect the out hashes of all the checkpoints before this one in the same epoch
-      const previousCheckpointOutHashes = (await this.l2BlockSource.getCheckpointsDataForEpoch(this.targetEpoch))
+      const previousCheckpointOutHashes = (await this.l2BlockSource.getCheckpointsData({ epoch: this.targetEpoch }))
         .filter(c => c.checkpointNumber < this.checkpointNumber)
         .map(c => c.checkpointOutHash);
 

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.test.ts
@@ -317,10 +317,9 @@ describe('sequencer', () => {
       getL1Timestamp: mockFn().mockResolvedValue(1000n),
       isPendingChainInvalid: mockFn().mockResolvedValue(false),
       getPendingChainValidationStatus: mockFn().mockResolvedValue({ valid: true }),
-      getCheckpointsForEpoch: mockFn().mockResolvedValue([]),
-      getCheckpointsDataForEpoch: mockFn().mockResolvedValue([]),
+      getCheckpointsData: mockFn().mockResolvedValue([]),
       getSyncedL2SlotNumber: mockFn().mockResolvedValue(SlotNumber(Number.MAX_SAFE_INTEGER)),
-      getLastCheckpoint: mockFn().mockResolvedValue(undefined),
+      getProposedCheckpointData: mockFn().mockResolvedValue(undefined),
     });
 
     l1ToL2MessageSource = mock<L1ToL2MessageSource>({
@@ -1075,7 +1074,7 @@ describe('sequencer', () => {
         checkpointNumber: CheckpointNumber(1),
         indexWithinCheckpoint: IndexWithinCheckpoint(0),
       } satisfies BlockData);
-      l2BlockSource.getLastCheckpoint.mockResolvedValue({
+      l2BlockSource.getProposedCheckpointData.mockResolvedValue({
         checkpointNumber: CheckpointNumber(1),
       } as any);
 
@@ -1136,7 +1135,7 @@ describe('sequencer', () => {
         checkpointNumber: CheckpointNumber(3),
         indexWithinCheckpoint: IndexWithinCheckpoint(0),
       } satisfies BlockData);
-      l2BlockSource.getLastCheckpoint.mockResolvedValue({
+      l2BlockSource.getProposedCheckpointData.mockResolvedValue({
         checkpointNumber: CheckpointNumber(2),
       } as any);
 

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.ts
@@ -607,7 +607,7 @@ export class Sequencer extends (EventEmitter as new () => TypedEventEmitter<Sequ
       this.p2pClient.getStatus().then(p2p => p2p.syncedToL2Block),
       this.l1ToL2MessageSource.getL2Tips().then(t => ({ proposed: t.proposed, checkpointed: t.checkpointed })),
       this.l2BlockSource.getPendingChainValidationStatus(),
-      this.l2BlockSource.getLastProposedCheckpoint(),
+      this.l2BlockSource.getProposedCheckpointData(),
     ] as const);
 
     const [worldState, l2Tips, p2p, l1ToL2MessageSourceTips, pendingChainValidationStatus, proposedCheckpointData] =

--- a/yarn-project/slasher/src/watchers/epoch_prune_watcher.test.ts
+++ b/yarn-project/slasher/src/watchers/epoch_prune_watcher.test.ts
@@ -253,8 +253,8 @@ describe('EpochPruneWatcher', () => {
 
 class MockL2BlockSource {
   public readonly events = new EventEmitter();
-  public getCheckpointsForEpoch = () => [];
-  public getCheckpointsDataForEpoch = () => [];
+  public getCheckpoints = () => [];
+  public getCheckpointsData = () => [];
 
   constructor() {}
 }

--- a/yarn-project/slasher/src/watchers/epoch_prune_watcher.ts
+++ b/yarn-project/slasher/src/watchers/epoch_prune_watcher.ts
@@ -132,7 +132,7 @@ export class EpochPruneWatcher extends (EventEmitter as new () => WatcherEmitter
     const blocksByCheckpoint = chunkBy(sortedBlocks, b => b.checkpointNumber);
 
     // Get prior checkpoints in the epoch (in case this was a partial prune) to extract the out hashes
-    const priorCheckpointOutHashes = (await this.l2BlockSource.getCheckpointsDataForEpoch(epochNumber))
+    const priorCheckpointOutHashes = (await this.l2BlockSource.getCheckpointsData({ epoch: epochNumber }))
       .filter(c => c.checkpointNumber < sortedBlocks[0].checkpointNumber)
       .map(c => c.checkpointOutHash);
     let previousCheckpointOutHashes: Fr[] = [...priorCheckpointOutHashes];

--- a/yarn-project/stdlib/src/block/l2_block_source.ts
+++ b/yarn-project/stdlib/src/block/l2_block_source.ts
@@ -6,6 +6,7 @@ import {
   type EpochNumber,
   EpochNumberSchema,
   type SlotNumber,
+  SlotNumberSchema,
 } from '@aztec/foundation/branded-types';
 import type { Fr } from '@aztec/foundation/curves/bn254';
 import type { EthAddress } from '@aztec/foundation/eth-address';
@@ -14,8 +15,7 @@ import type { TypedEventEmitter } from '@aztec/foundation/types';
 
 import { z } from 'zod';
 
-import type { Checkpoint } from '../checkpoint/checkpoint.js';
-import type { CheckpointData, CommonCheckpointData, ProposedCheckpointData } from '../checkpoint/checkpoint_data.js';
+import type { CheckpointData, ProposedCheckpointData } from '../checkpoint/checkpoint_data.js';
 import type { PublishedCheckpoint } from '../checkpoint/published_checkpoint.js';
 import type { L1RollupConstants } from '../epoch-helpers/index.js';
 import { CheckpointHeader } from '../rollup/checkpoint_header.js';
@@ -54,6 +54,39 @@ export const BlocksQuerySchema: z.ZodType<BlocksQuery, z.ZodTypeDef, unknown> = 
     .object({ from: BlockNumberSchema, limit: z.number().int().min(1), onlyCheckpointed: z.boolean().optional() })
     .strict(),
   z.object({ epoch: EpochNumberSchema, onlyCheckpointed: z.literal(true) }).strict(),
+]);
+
+/** Lookup a single confirmed checkpoint by checkpoint number, slot, or chain-tip tag. */
+export type CheckpointQuery =
+  | { number: CheckpointNumber }
+  | { slot: SlotNumber }
+  | { tag: 'checkpointed' | 'proven' | 'finalized' };
+
+/** Query a range of confirmed checkpoints by start/limit or by epoch. */
+export type CheckpointsQuery = { from: CheckpointNumber; limit: number } | { epoch: EpochNumber };
+
+/**
+ * Lookup a proposed (archiver-internal, not-yet-L1-confirmed) checkpoint.
+ * Distinct from CheckpointQuery because proposed checkpoints have a different shape
+ * (no l1, no attestations, but carries totalManaUsed) and live in their own LMDB map.
+ */
+export type ProposedCheckpointQuery = { number: CheckpointNumber } | { slot: SlotNumber } | { tag: 'proposed' };
+
+export const CheckpointQuerySchema: z.ZodType<CheckpointQuery, z.ZodTypeDef, unknown> = z.union([
+  z.object({ number: CheckpointNumberSchema }).strict(),
+  z.object({ slot: SlotNumberSchema }).strict(),
+  z.object({ tag: z.union([z.literal('checkpointed'), z.literal('proven'), z.literal('finalized')]) }).strict(),
+]);
+
+export const CheckpointsQuerySchema: z.ZodType<CheckpointsQuery, z.ZodTypeDef, unknown> = z.union([
+  z.object({ from: CheckpointNumberSchema, limit: z.number().int().min(1) }).strict(),
+  z.object({ epoch: EpochNumberSchema }).strict(),
+]);
+
+export const ProposedCheckpointQuerySchema: z.ZodType<ProposedCheckpointQuery, z.ZodTypeDef, unknown> = z.union([
+  z.object({ number: CheckpointNumberSchema }).strict(),
+  z.object({ slot: SlotNumberSchema }).strict(),
+  z.object({ tag: z.literal('proposed') }).strict(),
 ]);
 
 /**
@@ -112,47 +145,32 @@ export interface L2BlockSource {
   getFinalizedL2BlockNumber(): Promise<BlockNumber>;
 
   /**
-   * Retrieves a collection of checkpoints.
-   * @param checkpointNumber The first checkpoint to be retrieved.
-   * @param limit The number of checkpoints to be retrieved.
-   * @returns The collection of complete checkpoints.
+   * Gets a single confirmed checkpoint matching the given query.
+   * Heavy shape: includes nested full `L2Block`s with transaction bodies.
+   * @param query - Lookup by checkpoint number, slot, or chain-tip tag.
    */
-  getCheckpoints(checkpointNumber: CheckpointNumber, limit: number): Promise<PublishedCheckpoint[]>;
+  getCheckpoint(query: CheckpointQuery): Promise<PublishedCheckpoint | undefined>;
 
   /**
-   * Gets the checkpoints for a given epoch
-   * @param epochNumber - Epoch for which we want checkpoint data
+   * Gets a collection of confirmed checkpoints matching the given query.
+   * Heavy shape: includes nested full `L2Block`s with transaction bodies.
+   * @param query - Range by start/limit or by epoch.
    */
-  getCheckpointsForEpoch(epochNumber: EpochNumber): Promise<Checkpoint[]>;
-
-  /**
-   * Gets lightweight checkpoint metadata for a given epoch, without fetching full block data.
-   * @param epochNumber - Epoch for which we want checkpoint data
-   */
-  getCheckpointsDataForEpoch(epochNumber: EpochNumber): Promise<CheckpointData[]>;
+  getCheckpoints(query: CheckpointsQuery): Promise<PublishedCheckpoint[]>;
 
   /**
    * Gets lightweight checkpoint metadata for a single checkpoint.
    * Cheap passthrough for metadata-only queries (no block body reads).
-   * @param checkpointNumber - The checkpoint number to retrieve.
-   * @returns The requested checkpoint data (or undefined if not found).
+   * @param query - Lookup by checkpoint number, slot, or chain-tip tag.
    */
-  getCheckpointData(checkpointNumber: CheckpointNumber): Promise<CheckpointData | undefined>;
+  getCheckpointData(query: CheckpointQuery): Promise<CheckpointData | undefined>;
 
   /**
-   * Gets up to `limit` amount of checkpoint metadata entries starting from `from`.
+   * Gets a collection of lightweight checkpoint metadata entries matching the given query.
    * Cheap passthrough for metadata-only queries (no block body reads).
-   * @param from - The first checkpoint number to return (inclusive).
-   * @param limit - The maximum number of checkpoints to return.
+   * @param query - Range by start/limit or by epoch.
    */
-  getCheckpointDataRange(from: CheckpointNumber, limit: number): Promise<CheckpointData[]>;
-
-  /**
-   * Looks up the checkpoint number that contains the given slot.
-   * @param slot - The slot number to look up.
-   * @returns The checkpoint number (or undefined if not found).
-   */
-  getCheckpointNumberBySlot(slot: SlotNumber): Promise<CheckpointNumber | undefined>;
+  getCheckpointsData(query: CheckpointsQuery): Promise<CheckpointData[]>;
 
   /**
    * Gets a tx effect.
@@ -222,11 +240,13 @@ export interface L2BlockSource {
    */
   getPendingChainValidationStatus(): Promise<ValidateCheckpointResult>;
 
-  /** Returns the checkpoint at the proposed chain tip. */
-  getLastCheckpoint(): Promise<CommonCheckpointData | undefined>;
-
-  /** Returns proposed checkpoint, if set, undefined if not*/
-  getLastProposedCheckpoint(): Promise<ProposedCheckpointData | undefined>;
+  /**
+   * Looks up a proposed (archiver-internal, not-yet-L1-confirmed) checkpoint.
+   * Returns the latest proposed entry when called with no args or `{ tag: 'proposed' }`.
+   * With `{ number }` or `{ slot }`, returns the matching entry or undefined.
+   * Never falls back to confirmed checkpoints.
+   */
+  getProposedCheckpointData(query?: ProposedCheckpointQuery): Promise<ProposedCheckpointData | undefined>;
 
   /** Force a sync. */
   syncImmediate(): Promise<void>;

--- a/yarn-project/stdlib/src/block/l2_block_stream/l2_block_stream.test.ts
+++ b/yarn-project/stdlib/src/block/l2_block_stream/l2_block_stream.test.ts
@@ -134,8 +134,12 @@ describe('L2BlockStream', () => {
 
     // Returns published checkpoints - each checkpoint contains just the one block for simplicity
     // Respects the limit parameter and returns up to `limit` checkpoints
-    blockSource.getCheckpoints.mockImplementation((checkpointNumber: CheckpointNumber, limit: number) =>
-      Promise.resolve(
+    blockSource.getCheckpoints.mockImplementation(query => {
+      if (!('from' in query)) {
+        return Promise.resolve([]);
+      }
+      const { from: checkpointNumber, limit } = query;
+      return Promise.resolve(
         compactArray(
           times(limit, i => {
             const cpNum = checkpointNumber + i;
@@ -150,8 +154,8 @@ describe('L2BlockStream', () => {
                 } as unknown as PublishedCheckpoint);
           }),
         ),
-      ),
-    );
+      );
+    });
   });
 
   describe('with mock local data provider', () => {
@@ -492,7 +496,11 @@ describe('L2BlockStream', () => {
       });
 
       // Returns published checkpoints with multiple blocks each, respecting the limit parameter
-      blockSource.getCheckpoints.mockImplementation((checkpointNumber: CheckpointNumber, limit: number) => {
+      blockSource.getCheckpoints.mockImplementation(query => {
+        if (!('from' in query)) {
+          return Promise.resolve([]);
+        }
+        const { from: checkpointNumber, limit } = query;
         const checkpoints: PublishedCheckpoint[] = [];
         for (let i = 0; i < limit; i++) {
           const cpNum = CheckpointNumber(checkpointNumber + i);
@@ -891,9 +899,9 @@ describe('L2BlockStream', () => {
         // Should have fetched all 3 checkpoints in a single call (Loop 2 makes 1 call with limit 10)
         // Even though we requested 10, only 3 exist - verify we handle this correctly
         const calls = blockSource.getCheckpoints.mock.calls;
-        const loop2Calls = calls.filter(([_, limit]) => limit === 10);
+        const loop2Calls = calls.filter(([query]) => 'limit' in query && query.limit === 10);
         expect(loop2Calls.length).toBe(1);
-        expect(loop2Calls[0][0]).toBe(1); // Starting from checkpoint 1
+        expect((loop2Calls[0][0] as { from: number }).from).toBe(1); // Starting from checkpoint 1
 
         // All 3 checkpoints should be emitted correctly (not 10)
         const checkpointEvents = handler.events.filter(e => e.type === 'chain-checkpointed');
@@ -926,9 +934,9 @@ describe('L2BlockStream', () => {
 
         // Loop 2 should start fetching from checkpoint 3 (block 7 is in checkpoint 3)
         const calls = blockSource.getCheckpoints.mock.calls;
-        const loop2Calls = calls.filter(([_, limit]) => limit === 10);
+        const loop2Calls = calls.filter(([query]) => 'limit' in query && query.limit === 10);
         expect(loop2Calls.length).toBe(1);
-        expect(loop2Calls[0][0]).toBe(3); // Starting from checkpoint 3, not 1
+        expect((loop2Calls[0][0] as { from: number }).from).toBe(3); // Starting from checkpoint 3, not 1
 
         // Should only emit blocks 7-15 and checkpoints 3-5 (not 1-2, those are already local)
         expect(handler.events).toEqual([
@@ -960,9 +968,9 @@ describe('L2BlockStream', () => {
 
         // Should start prefetching from checkpoint 3
         const calls = blockSource.getCheckpoints.mock.calls;
-        const loop2Calls = calls.filter(([_, limit]) => limit === 10);
+        const loop2Calls = calls.filter(([query]) => 'limit' in query && query.limit === 10);
         expect(loop2Calls.length).toBe(1);
-        expect(loop2Calls[0][0]).toBe(3); // Starting from checkpoint 3
+        expect((loop2Calls[0][0] as { from: number }).from).toBe(3); // Starting from checkpoint 3
 
         // Should emit only blocks 8-9 from checkpoint 3 (block 7 is already local)
         expect(handler.events).toEqual([
@@ -993,11 +1001,11 @@ describe('L2BlockStream', () => {
 
         // Should have made 3 calls with limit 2 to fetch 5 checkpoints
         const calls = blockSource.getCheckpoints.mock.calls;
-        const loop2Calls = calls.filter(([_, limit]) => limit === 2);
+        const loop2Calls = calls.filter(([query]) => 'limit' in query && query.limit === 2);
         expect(loop2Calls.length).toBe(3); // ceil(5/2) = 3
-        expect(loop2Calls[0][0]).toBe(1); // First batch: checkpoints 1-2
-        expect(loop2Calls[1][0]).toBe(3); // Second batch: checkpoints 3-4
-        expect(loop2Calls[2][0]).toBe(5); // Third batch: checkpoint 5
+        expect((loop2Calls[0][0] as { from: number }).from).toBe(1); // First batch: checkpoints 1-2
+        expect((loop2Calls[1][0] as { from: number }).from).toBe(3); // Second batch: checkpoints 3-4
+        expect((loop2Calls[2][0] as { from: number }).from).toBe(5); // Third batch: checkpoint 5
 
         // All 5 checkpoints should be emitted
         const checkpointEvents = handler.events.filter(e => e.type === 'chain-checkpointed');
@@ -1017,7 +1025,7 @@ describe('L2BlockStream', () => {
 
         // Should have used default limit of 50 for Loop 2 calls
         const calls = blockSource.getCheckpoints.mock.calls;
-        const loop2Calls = calls.filter(([_, limit]) => limit === 50);
+        const loop2Calls = calls.filter(([query]) => 'limit' in query && query.limit === 50);
         expect(loop2Calls.length).toBeGreaterThanOrEqual(1);
       });
     });

--- a/yarn-project/stdlib/src/block/l2_block_stream/l2_block_stream.ts
+++ b/yarn-project/stdlib/src/block/l2_block_stream/l2_block_stream.ts
@@ -160,7 +160,7 @@ export class L2BlockStream {
       if (!this.opts.ignoreCheckpoints) {
         let loop1Iterations = 0;
         while (nextCheckpointToEmit <= sourceTips.checkpointed.checkpoint.number) {
-          const checkpoints = await this.l2BlockSource.getCheckpoints(nextCheckpointToEmit, 1);
+          const checkpoints = await this.l2BlockSource.getCheckpoints({ from: nextCheckpointToEmit, limit: 1 });
           if (checkpoints.length === 0) {
             break;
           }
@@ -205,7 +205,10 @@ export class L2BlockStream {
         // Refill the prefetch buffer when exhausted
         if (prefetchIdx >= prefetchedCheckpoints.length) {
           const prefetchLimit = this.opts.checkpointPrefetchLimit ?? CHECKPOINT_PREFETCH_LIMIT;
-          prefetchedCheckpoints = await this.l2BlockSource.getCheckpoints(nextCheckpointNumber, prefetchLimit);
+          prefetchedCheckpoints = await this.l2BlockSource.getCheckpoints({
+            from: nextCheckpointNumber,
+            limit: prefetchLimit,
+          });
           prefetchIdx = 0;
           if (prefetchedCheckpoints.length === 0) {
             break;

--- a/yarn-project/stdlib/src/interfaces/archiver.test.ts
+++ b/yarn-project/stdlib/src/interfaces/archiver.test.ts
@@ -15,7 +15,10 @@ import {
   BlockQuerySchema,
   type BlocksQuery,
   BlocksQuerySchema,
+  type CheckpointQuery,
+  type CheckpointsQuery,
   type L2Tips,
+  type ProposedCheckpointQuery,
 } from '../block/l2_block_source.js';
 import type { ValidateCheckpointResult } from '../block/validate_block_result.js';
 import { Checkpoint } from '../checkpoint/checkpoint.js';
@@ -107,12 +110,28 @@ describe('ArchiverApiSchema', () => {
     expect(result).toEqual(BlockNumber(0));
   });
 
+  it('getCheckpoint', async () => {
+    const response = await context.client.getCheckpoint({ number: CheckpointNumber(1) });
+    expect(response).toBeDefined();
+    expect(response!.checkpoint.constructor.name).toEqual('Checkpoint');
+    expect(response!.attestations[0]).toBeInstanceOf(CommitteeAttestation);
+    expect(response!.l1).toBeDefined();
+  });
+
   it('getCheckpoints', async () => {
-    const response = await context.client.getCheckpoints(CheckpointNumber(1), BlockNumber(1));
+    const response = await context.client.getCheckpoints({ from: CheckpointNumber(1), limit: 1 });
     expect(response).toHaveLength(1);
     expect(response[0].checkpoint.constructor.name).toEqual('Checkpoint');
     expect(response[0].attestations[0]).toBeInstanceOf(CommitteeAttestation);
     expect(response[0].l1).toBeDefined();
+  });
+
+  it('getCheckpointsData', async () => {
+    const result = await context.client.getCheckpointsData({ epoch: EpochNumber(1) });
+    expect(result).toHaveLength(1);
+    expect(result[0].checkpointNumber).toBeDefined();
+    expect(result[0].checkpointOutHash).toBeDefined();
+    expect(result[0].attestations[0]).toBeInstanceOf(CommitteeAttestation);
   });
 
   it('getTxEffect', async () => {
@@ -133,19 +152,6 @@ describe('ArchiverApiSchema', () => {
   it('getSyncedL2EpochNumber', async () => {
     const result = await context.client.getSyncedL2EpochNumber();
     expect(result).toBe(EpochNumber(1));
-  });
-
-  it('getCheckpointsForEpoch', async () => {
-    const result = await context.client.getCheckpointsForEpoch(EpochNumber(1));
-    expect(result).toEqual([expect.any(Checkpoint)]);
-  });
-
-  it('getCheckpointsDataForEpoch', async () => {
-    const result = await context.client.getCheckpointsDataForEpoch(EpochNumber(1));
-    expect(result).toHaveLength(1);
-    expect(result[0].checkpointNumber).toBeDefined();
-    expect(result[0].checkpointOutHash).toBeDefined();
-    expect(result[0].attestations[0]).toBeInstanceOf(CommitteeAttestation);
   });
 
   it('getBlocksForSlot', async () => {
@@ -269,22 +275,8 @@ describe('ArchiverApiSchema', () => {
     expect(result).toBe(1n);
   });
 
-  it('getLastCheckpoint', async () => {
-    const result = await context.client.getLastCheckpoint();
-    expect(result).toEqual({
-      checkpointNumber: 1,
-      header: expect.any(CheckpointHeader),
-      archive: expect.any(AppendOnlyTreeSnapshot),
-      checkpointOutHash: expect.any(Fr),
-      blockCount: 1,
-      startBlock: 1,
-      totalManaUsed: 1n,
-      feeAssetPriceModifier: 1n,
-    });
-  });
-
-  it('getLastProposedCheckpoint', async () => {
-    const result = await context.client.getLastProposedCheckpoint();
+  it('getProposedCheckpointData', async () => {
+    const result = await context.client.getProposedCheckpointData();
     expect(result).toEqual({
       checkpointNumber: 1,
       header: expect.any(CheckpointHeader),
@@ -308,17 +300,7 @@ describe('ArchiverApiSchema', () => {
   });
 
   it('getCheckpointData', async () => {
-    const result = await context.client.getCheckpointData(CheckpointNumber(1));
-    expect(result).toBeUndefined();
-  });
-
-  it('getCheckpointDataRange', async () => {
-    const result = await context.client.getCheckpointDataRange(CheckpointNumber(1), 10);
-    expect(result).toEqual([]);
-  });
-
-  it('getCheckpointNumberBySlot', async () => {
-    const result = await context.client.getCheckpointNumberBySlot(SlotNumber(1));
+    const result = await context.client.getCheckpointData({ number: CheckpointNumber(1) });
     expect(result).toBeUndefined();
   });
 
@@ -410,10 +392,7 @@ class MockArchiver implements ArchiverApi {
   getPendingChainValidationStatus(): Promise<ValidateCheckpointResult> {
     return Promise.resolve({ valid: true });
   }
-  getLastCheckpoint(): Promise<ProposedCheckpointData | undefined> {
-    return this.getLastProposedCheckpoint();
-  }
-  getLastProposedCheckpoint(): Promise<ProposedCheckpointData | undefined> {
+  getProposedCheckpointData(_query?: ProposedCheckpointQuery): Promise<ProposedCheckpointData | undefined> {
     return Promise.resolve({
       checkpointNumber: CheckpointNumber(1),
       header: CheckpointHeader.random(),
@@ -463,10 +442,17 @@ class MockArchiver implements ArchiverApi {
   getBlocksData(_query: BlocksQuery): Promise<BlockData[]> {
     return Promise.resolve([]);
   }
-  async getCheckpoints(from: CheckpointNumber, _limit: number): Promise<PublishedCheckpoint[]> {
+  async getCheckpoint(_query: CheckpointQuery): Promise<PublishedCheckpoint | undefined> {
+    return PublishedCheckpoint.from({
+      checkpoint: await Checkpoint.random(CheckpointNumber(1)),
+      attestations: [CommitteeAttestation.random()],
+      l1: new L1PublishedData(1n, 0n, `0x`),
+    });
+  }
+  async getCheckpoints(_query: CheckpointsQuery): Promise<PublishedCheckpoint[]> {
     return [
       PublishedCheckpoint.from({
-        checkpoint: await Checkpoint.random(CheckpointNumber(from)),
+        checkpoint: await Checkpoint.random(CheckpointNumber(1)),
         attestations: [CommitteeAttestation.random()],
         l1: new L1PublishedData(1n, 0n, `0x`),
       }),
@@ -491,12 +477,10 @@ class MockArchiver implements ArchiverApi {
   getSyncedL2EpochNumber(): Promise<EpochNumber | undefined> {
     return Promise.resolve(EpochNumber(1));
   }
-  async getCheckpointsForEpoch(epochNumber: EpochNumber): Promise<Checkpoint[]> {
-    expect(epochNumber).toEqual(EpochNumber(1));
-    return [await Checkpoint.random(CheckpointNumber(1))];
+  getCheckpointData(_query: CheckpointQuery): Promise<CheckpointData | undefined> {
+    return Promise.resolve(undefined);
   }
-  async getCheckpointsDataForEpoch(epochNumber: EpochNumber): Promise<CheckpointData[]> {
-    expect(epochNumber).toEqual(EpochNumber(1));
+  async getCheckpointsData(_query: CheckpointsQuery): Promise<CheckpointData[]> {
     const checkpoint = await Checkpoint.random(CheckpointNumber(1));
     return [
       {
@@ -511,15 +495,6 @@ class MockArchiver implements ArchiverApi {
         l1: L1PublishedData.random(),
       },
     ];
-  }
-  getCheckpointData(_n: CheckpointNumber): Promise<CheckpointData | undefined> {
-    return Promise.resolve(undefined);
-  }
-  getCheckpointDataRange(_from: CheckpointNumber, _limit: number): Promise<CheckpointData[]> {
-    return Promise.resolve([]);
-  }
-  getCheckpointNumberBySlot(_slot: SlotNumber): Promise<CheckpointNumber | undefined> {
-    return Promise.resolve(undefined);
   }
   async getBlocksForSlot(slotNumber: SlotNumber): Promise<L2Block[]> {
     expect(slotNumber).toEqual(SlotNumber(1));

--- a/yarn-project/stdlib/src/interfaces/archiver.ts
+++ b/yarn-project/stdlib/src/interfaces/archiver.ts
@@ -6,9 +6,16 @@ import { z } from 'zod';
 
 import { BlockDataSchema } from '../block/block_data.js';
 import { L2Block } from '../block/l2_block.js';
-import { BlockQuerySchema, BlocksQuerySchema, type L2BlockSource, L2TipsSchema } from '../block/l2_block_source.js';
+import {
+  BlockQuerySchema,
+  BlocksQuerySchema,
+  CheckpointQuerySchema,
+  CheckpointsQuerySchema,
+  type L2BlockSource,
+  L2TipsSchema,
+  ProposedCheckpointQuerySchema,
+} from '../block/l2_block_source.js';
 import { ValidateCheckpointResultSchema } from '../block/validate_block_result.js';
-import { Checkpoint } from '../checkpoint/checkpoint.js';
 import { CheckpointDataSchema, ProposedCheckpointDataSchema } from '../checkpoint/checkpoint_data.js';
 import { PublishedCheckpoint } from '../checkpoint/published_checkpoint.js';
 import {
@@ -93,22 +100,14 @@ export const ArchiverApiSchema: ApiSchemaFor<ArchiverApi> = {
   getCheckpointedL2BlockNumber: z.function().args().returns(BlockNumberSchema),
   getCheckpointNumber: z.function().args().returns(CheckpointNumberSchema),
   getFinalizedL2BlockNumber: z.function().args().returns(BlockNumberSchema),
-  getCheckpoints: z
-    .function()
-    .args(CheckpointNumberSchema, schemas.Integer)
-    .returns(z.array(PublishedCheckpoint.schema)),
-  getCheckpointData: z.function().args(CheckpointNumberSchema).returns(CheckpointDataSchema.optional()),
-  getCheckpointDataRange: z
-    .function()
-    .args(CheckpointNumberSchema, schemas.Integer)
-    .returns(z.array(CheckpointDataSchema)),
-  getCheckpointNumberBySlot: z.function().args(schemas.SlotNumber).returns(CheckpointNumberSchema.optional()),
+  getCheckpoint: z.function().args(CheckpointQuerySchema).returns(PublishedCheckpoint.schema.optional()),
+  getCheckpoints: z.function().args(CheckpointsQuerySchema).returns(z.array(PublishedCheckpoint.schema)),
+  getCheckpointData: z.function().args(CheckpointQuerySchema).returns(CheckpointDataSchema.optional()),
+  getCheckpointsData: z.function().args(CheckpointsQuerySchema).returns(z.array(CheckpointDataSchema)),
   getTxEffect: z.function().args(TxHash.schema).returns(indexedTxSchema().optional()),
   getSettledTxReceipt: z.function().args(TxHash.schema).returns(TxReceipt.schema.optional()),
   getSyncedL2SlotNumber: z.function().args().returns(schemas.SlotNumber.optional()),
   getSyncedL2EpochNumber: z.function().args().returns(EpochNumberSchema.optional()),
-  getCheckpointsForEpoch: z.function().args(EpochNumberSchema).returns(z.array(Checkpoint.schema)),
-  getCheckpointsDataForEpoch: z.function().args(EpochNumberSchema).returns(z.array(CheckpointDataSchema)),
   getBlocksForSlot: z.function().args(schemas.SlotNumber).returns(z.array(L2Block.schema)),
   isEpochComplete: z.function().args(EpochNumberSchema).returns(z.boolean()),
   getL2Tips: z.function().args().returns(L2TipsSchema),
@@ -139,8 +138,10 @@ export const ArchiverApiSchema: ApiSchemaFor<ArchiverApi> = {
     .args()
     .returns(z.object({ genesisArchiveRoot: schemas.Fr })),
   getL1Timestamp: z.function().args().returns(schemas.BigInt.optional()),
-  getLastCheckpoint: z.function().args().returns(ProposedCheckpointDataSchema.optional()),
-  getLastProposedCheckpoint: z.function().args().returns(ProposedCheckpointDataSchema.optional()),
+  getProposedCheckpointData: z
+    .function()
+    .args(optional(ProposedCheckpointQuerySchema))
+    .returns(ProposedCheckpointDataSchema.optional()),
   syncImmediate: z.function().args().returns(z.void()),
   isPendingChainInvalid: z.function().args().returns(z.boolean()),
   getPendingChainValidationStatus: z.function().args().returns(ValidateCheckpointResultSchema),

--- a/yarn-project/stdlib/src/interfaces/aztec-node.test.ts
+++ b/yarn-project/stdlib/src/interfaces/aztec-node.test.ts
@@ -15,7 +15,8 @@ import type { ContractArtifact } from '../abi/abi.js';
 import { AztecAddress } from '../aztec-address/index.js';
 import type { DataInBlock } from '../block/in_block.js';
 import { BlockHash, type BlockParameter } from '../block/index.js';
-import type { L2Tips } from '../block/l2_block_source.js';
+import type { CheckpointsQuery, L2Tips } from '../block/l2_block_source.js';
+import type { CheckpointData } from '../checkpoint/checkpoint_data.js';
 import {
   type ContractClassPublic,
   type ContractInstanceWithAddress,
@@ -253,8 +254,13 @@ describe('AztecNodeApiSchema', () => {
     expect(response).toEqual([]);
   });
 
-  it('getCheckpointsDataForEpoch', async () => {
-    const response = await context.client.getCheckpointsDataForEpoch(EpochNumber(1));
+  it('getCheckpointsData (epoch)', async () => {
+    const response = await context.client.getCheckpointsData({ epoch: EpochNumber(1) });
+    expect(response).toEqual([]);
+  });
+
+  it('getCheckpointsData (range)', async () => {
+    const response = await context.client.getCheckpointsData({ from: CheckpointNumber(1), limit: 1 });
     expect(response).toEqual([]);
   });
 
@@ -578,7 +584,7 @@ class MockAztecNode implements AztecNode {
     return Promise.resolve([]);
   }
 
-  getCheckpointsDataForEpoch(_epochNumber: EpochNumber) {
+  getCheckpointsData(_query: CheckpointsQuery): Promise<CheckpointData[]> {
     return Promise.resolve([]);
   }
 

--- a/yarn-project/stdlib/src/interfaces/aztec-node.ts
+++ b/yarn-project/stdlib/src/interfaces/aztec-node.ts
@@ -22,7 +22,7 @@ import type { AztecAddress } from '../aztec-address/index.js';
 import { BlockHash } from '../block/block_hash.js';
 import { type BlockParameter, BlockParameterSchema } from '../block/block_parameter.js';
 import { type DataInBlock, dataInBlockSchemaFor } from '../block/in_block.js';
-import { type L2Tips, L2TipsSchema } from '../block/l2_block_source.js';
+import { type CheckpointsQuery, CheckpointsQuerySchema, type L2Tips, L2TipsSchema } from '../block/l2_block_source.js';
 import { type CheckpointData, CheckpointDataSchema } from '../checkpoint/checkpoint_data.js';
 import {
   type ContractClassPublic,
@@ -227,8 +227,11 @@ export interface AztecNode {
   getBlockHeader(number: BlockNumber | 'latest'): Promise<BlockHeader | undefined>;
   /** @deprecated Scheduled for removal; use `getBlocks(from, limit, { includeL1PublishInfo: true, includeAttestations: true })`. */
   getCheckpointedBlocks(from: BlockNumber, limit: number): Promise<BlockResponse[]>;
-  /** @deprecated Scheduled for removal; use `getCheckpoints(from, limit)` over an explicit checkpoint range. */
-  getCheckpointsDataForEpoch(epoch: EpochNumber): Promise<CheckpointData[]>;
+  /**
+   * Gets lightweight checkpoint metadata for a contiguous range or for an entire epoch.
+   * @param query - Either `{ from, limit }` or `{ epoch }`.
+   */
+  getCheckpointsData(query: CheckpointsQuery): Promise<CheckpointData[]>;
 
   /**
    * Unified block fetch. Returns the block identified by `param`, with optional fields controlled
@@ -569,7 +572,7 @@ export const AztecNodeApiSchema: ApiSchemaFor<AztecNode> = {
     .args(BlockNumberPositiveSchema, z.number().gt(0).lte(MAX_RPC_BLOCKS_LEN))
     .returns(z.array(BlockResponseSchema)),
 
-  getCheckpointsDataForEpoch: z.function().args(EpochNumberSchema).returns(z.array(CheckpointDataSchema)),
+  getCheckpointsData: z.function().args(CheckpointsQuerySchema).returns(z.array(CheckpointDataSchema)),
 
   getBlock: z
     .function()

--- a/yarn-project/stdlib/src/interfaces/checkpoint_parameter.ts
+++ b/yarn-project/stdlib/src/interfaces/checkpoint_parameter.ts
@@ -7,15 +7,13 @@ import { ChainTipSchema } from './chain_tips.js';
 /**
  * Selector for a checkpoint in RPC calls.
  *
- * Accepts a numeric checkpoint number (or `{ number }`), a slot number (`{ slot }`), a chain-tip
- * name (e.g. `'proven'`), or `'latest'` (alias for `'proposed'` — on the checkpoint side, this
- * means the most recent confirmed checkpoint).
+ * Accepts a numeric checkpoint number (or `{ number }`), a slot number (`{ slot }`),
+ * or a chain-tip name (e.g. `'proposed'`, `'proven'`).
  */
 export const CheckpointParameterSchema = z.union([
   z.object({ number: CheckpointNumberSchema }).strict(),
   z.object({ slot: SlotNumberSchema }).strict(),
   ChainTipSchema,
-  z.literal('latest'),
   CheckpointNumberSchema,
 ]);
 

--- a/yarn-project/stdlib/src/messaging/l2_to_l1_membership.ts
+++ b/yarn-project/stdlib/src/messaging/l2_to_l1_membership.ts
@@ -113,10 +113,7 @@ export type L2ToL1MembershipWitness = {
  * @returns The membership witness and epoch number, or undefined if the tx is not yet in a block/epoch.
  */
 export async function computeL2ToL1MembershipWitness(
-  node: Pick<
-    AztecNode,
-    'getL2ToL1Messages' | 'getTxReceipt' | 'getTxEffect' | 'getBlock' | 'getCheckpointsDataForEpoch'
-  >,
+  node: Pick<AztecNode, 'getL2ToL1Messages' | 'getTxReceipt' | 'getTxEffect' | 'getBlock' | 'getCheckpointsData'>,
   message: Fr,
   txHash: TxHash,
   messageIndexInTx?: number,
@@ -130,7 +127,7 @@ export async function computeL2ToL1MembershipWitness(
     node.getL2ToL1Messages(epochNumber),
     node.getBlock(blockNumber),
     node.getTxEffect(txHash),
-    node.getCheckpointsDataForEpoch(epochNumber),
+    node.getCheckpointsData({ epoch: epochNumber }),
   ]);
 
   if (messagesInEpoch.length === 0 || !block || !txEffect) {

--- a/yarn-project/validator-client/src/proposal_handler.test.ts
+++ b/yarn-project/validator-client/src/proposal_handler.test.ts
@@ -55,7 +55,7 @@ describe('ProposalHandler checkpoint validation', () => {
 
   beforeEach(() => {
     blockSource = mock<L2BlockSource & L2BlockSink>();
-    blockSource.getCheckpointsDataForEpoch.mockResolvedValue([]);
+    blockSource.getCheckpointsData.mockResolvedValue([]);
     blockSource.getBlocksForSlot.mockResolvedValue([]);
     blockSource.syncImmediate.mockResolvedValue(undefined);
 

--- a/yarn-project/validator-client/src/proposal_handler.ts
+++ b/yarn-project/validator-client/src/proposal_handler.ts
@@ -343,7 +343,7 @@ export class ProposalHandler {
 
     // Collect the out hashes of all the checkpoints before this one in the same epoch
     const epoch = getEpochAtSlot(slotNumber, this.epochCache.getL1Constants());
-    const previousCheckpointOutHashes = (await this.blockSource.getCheckpointsDataForEpoch(epoch))
+    const previousCheckpointOutHashes = (await this.blockSource.getCheckpointsData({ epoch }))
       .filter(c => c.checkpointNumber < checkpointNumber)
       .map(c => c.checkpointOutHash);
 
@@ -853,7 +853,7 @@ export class ProposalHandler {
 
     // Collect the out hashes of all the checkpoints before this one in the same epoch
     const epoch = getEpochAtSlot(slot, this.epochCache.getL1Constants());
-    const previousCheckpointOutHashes = (await this.blockSource.getCheckpointsDataForEpoch(epoch))
+    const previousCheckpointOutHashes = (await this.blockSource.getCheckpointsData({ epoch }))
       .filter(c => c.checkpointNumber < checkpointNumber)
       .map(c => c.checkpointOutHash);
 

--- a/yarn-project/validator-client/src/validator.test.ts
+++ b/yarn-project/validator-client/src/validator.test.ts
@@ -152,7 +152,7 @@ describe('ValidatorClient', () => {
 
     blockSource = mock<L2BlockSource & L2BlockSink>();
     blockSource.getBlocks.mockResolvedValue([]);
-    blockSource.getCheckpointsDataForEpoch.mockResolvedValue([]);
+    blockSource.getCheckpointsData.mockResolvedValue([]);
     blockSource.getBlocksForSlot.mockResolvedValue([]);
     blockSource.getSyncedL2SlotNumber.mockResolvedValue(SlotNumber(Number.MAX_SAFE_INTEGER));
     blockSource.syncImmediate.mockResolvedValue(undefined);

--- a/yarn-project/world-state/src/synchronizer/server_world_state_synchronizer.ts
+++ b/yarn-project/world-state/src/synchronizer/server_world_state_synchronizer.ts
@@ -422,15 +422,13 @@ export class ServerWorldStateSynchronizer
       return;
     }
     // Retrieve the historic checkpoint
-    const historicCheckpoints = await this.l2BlockSource.getCheckpoints(
-      CheckpointNumber(newHistoricCheckpointNumber),
-      1,
-    );
-    if (historicCheckpoints.length === 0 || historicCheckpoints[0] === undefined) {
+    const historicCheckpoint = await this.l2BlockSource.getCheckpoint({
+      number: CheckpointNumber(newHistoricCheckpointNumber),
+    });
+    if (!historicCheckpoint) {
       this.log.warn(`Failed to retrieve checkpoint number ${newHistoricCheckpointNumber} from Archiver`);
       return;
     }
-    const historicCheckpoint = historicCheckpoints[0];
     if (historicCheckpoint.checkpoint.blocks.length === 0 || historicCheckpoint.checkpoint.blocks[0] === undefined) {
       this.log.warn(`Retrieved checkpoint number ${newHistoricCheckpointNumber} has no blocks!`);
       return;


### PR DESCRIPTION
## Motivation

Clean up the checkpoint side of `L2BlockSource`. PR #22809 already collapsed the block-side API into 4 query-shaped methods over 2 return types; the checkpoint surface was left with the pre-refactor sprawl (9 narrow methods over 4 return shapes, parallel by-number / by-range / by-epoch entrypoints, and a wire-level alias that conflated proposed and confirmed checkpoints). This change applies the same simplification.

Fixes A-979

## Approach

`L2BlockSource` checkpoint methods reduce to 4 query-shaped readers (`getCheckpoint`, `getCheckpoints`, `getCheckpointData`, `getCheckpointsData`) over 2 return shapes (`PublishedCheckpoint`, `CheckpointData`), plus a polymorphic `getProposedCheckpointData(query?)` for the proposed-only path. Three new query types live next to `BlockQuery`/`BlocksQuery`. On-disk format and `BlockStore` primitives are unchanged — the simplification is at the API boundary. The public RPC's `getCheckpoint` keeps the same wire signature but gains a confirmed→proposed fallback (for `{number}`/`{slot}`/`'proposed'` lookups) and `BadRequestError` guards for incompatible `include*` flags.

## API surface change

### Methods removed from `L2BlockSource`

`getCheckpoints(from, limit)`, `getCheckpointData(n)`, `getCheckpointDataRange(from, limit)`, `getCheckpointsForEpoch(epoch)`, `getCheckpointsDataForEpoch(epoch)`, `getCheckpointNumberBySlot(slot)`, `getLastCheckpoint()`, `getLastProposedCheckpoint()`. Dead methods on `data_source_base` also removed: `getCheckpointHeader`, `getLastBlockNumberInCheckpoint`, `getSynchedCheckpointNumber`.

### Methods added to `L2BlockSource`

```ts
getCheckpoint(query: CheckpointQuery): Promise<PublishedCheckpoint | undefined>
getCheckpoints(query: CheckpointsQuery): Promise<PublishedCheckpoint[]>
getCheckpointData(query: CheckpointQuery): Promise<CheckpointData | undefined>
getCheckpointsData(query: CheckpointsQuery): Promise<CheckpointData[]>
getProposedCheckpointData(query?: ProposedCheckpointQuery): Promise<ProposedCheckpointData | undefined>

type CheckpointQuery         = { number } | { slot } | { tag: 'checkpointed' | 'proven' | 'finalized' }
type CheckpointsQuery        = { from, limit } | { epoch }
type ProposedCheckpointQuery = { number } | { slot } | { tag: 'proposed' }
```

### Public RPC (`AztecNode`) wire-level changes

- `getCheckpointsDataForEpoch(epoch)` removed; `getCheckpointsData(query: CheckpointsQuery)` added (range or epoch).
- `'latest'` removed from `CheckpointParameter`.
- `'proposed'` semantics changed: previously aliased to "latest L1-confirmed checkpoint" (a documented foot-gun); now `getCheckpoint('proposed')` strictly targets the proposed-checkpoint store, and `getCheckpointNumber('proposed')` returns the proposed-tip number with confirmed fallback.
- `getCheckpoint({ number }) / ({ slot })` now check confirmed first then fall back to proposed; tag-based lookups (`'checkpointed'` / `'proven'` / `'finalized'`) do not fall back.
- `getCheckpoint('proposed', { includeL1PublishInfo: true | includeAttestations: true })` and the same flags on a by-number/by-slot lookup that resolves to a proposed entry now throw `BadRequestError` (proposed checkpoints have no L1 publish info or attestations).

### Types kept

`CheckpointData`, `CommonCheckpointData` (structural base of `CheckpointData` / `ProposedCheckpointInput`), `ProposedCheckpointData`, `ProposedCheckpointInput`, `PublishedCheckpoint`, `Checkpoint`. No structural-type deletions.

Migration guidance for wallet/SDK consumers is in `docs/docs-developers/docs/resources/migration_notes.md`.

## Changes

- **stdlib**: New query types (`CheckpointQuery`, `CheckpointsQuery`, `ProposedCheckpointQuery`) + Zod schemas in `block/l2_block_source.ts`. `'latest'` literal removed from `interfaces/checkpoint_parameter.ts`. `NormalizedCheckpointDispatch` type for the server's parameter normalizer. `ArchiverApiSchema` and `AztecNode` schema updated. `computeL2ToL1MembershipWitness` switched to the new query shape.
- **archiver**: `data_source_base` adds `resolveCheckpointQuery` / `resolveCheckpointsQuery` mirroring the block-side helpers, implements the 4 confirmed methods plus the polymorphic proposed lookup. `BlockStore` adds `getProposedCheckpointBySlot(slot)`. `MockArchiver` and `mock_l2_block_source` updated to match the new interface.
- **aztec-node**: `server.ts` adds the confirmed→proposed fallback flow with the two `BadRequestError` guards in `getCheckpoint`, sources all tips from a single `getL2Tips()` call in `getCheckpointNumber`, and routes the public RPC through the new internal methods. New pure-projection helper `projectProposedToCheckpointResponse` in `block_response_helpers.ts`.
- **consumer migrations**: prover-node (collapses two checkpoint fetches into one `getCheckpoints({ epoch })`), world-state, slasher, sequencer (`checkpoint_proposal_job`, `sequencer`), validator (`proposal_handler`), `L2BlockStream`, pxe `block_stream_source`, telemetry wrapper, and 10 e2e files updated to the new query shapes.
- **tests**: 48 new `it()` blocks covering each query discriminant, the throw guards, the confirmed→proposed fallback, the polymorphic `getProposedCheckpointData` dispatch, and `BlockStore.getProposedCheckpointBySlot`.
- **docs**: `migration_notes.md` updated with the breaking changes for downstream wallet/SDK consumers.