### PR TITLE
fix: closing db, correct stub side effects

### DIFF
--- a/noir-projects/noir-contracts/contracts/account/simulated_ecdsa_account_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/account/simulated_ecdsa_account_contract/src/main.nr
@@ -28,11 +28,14 @@ pub contract SimulatedEcdsaAccount {
         // used for any security purpose.
         let seed = unsafe { random() };
 
-        // Emit the initialization nullifier for the signing_public_key SinglePrivateImmutable.
+        // Emit the initialization nullifier for the contract itself.
         self.context.push_nullifier(seed);
 
+        // Emit the initialization nullifier for the signing_public_key SinglePrivateImmutable.
+        self.context.push_nullifier(seed + 1);
+
         // Emit the note hash for the signing key note.
-        self.context.push_note_hash(seed + 1);
+        self.context.push_note_hash(seed + 2);
 
         // Emit a private log tied to the note hash, matching the length of a real note delivery
         // log (MESSAGE_CIPHERTEXT_LEN fields). The signing key note is a SinglePrivateImmutable

--- a/noir-projects/noir-contracts/contracts/account/simulated_schnorr_account_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/account/simulated_schnorr_account_contract/src/main.nr
@@ -28,11 +28,14 @@ pub contract SimulatedSchnorrAccount {
         // security purpose.
         let seed = unsafe { random() };
 
-        // Emit the initialization nullifier for the signing_public_key SinglePrivateImmutable.
+        // Emit the initialization nullifier for the contract itself.
         self.context.push_nullifier(seed);
 
+        // Emit the initialization nullifier for the signing_public_key SinglePrivateImmutable.
+        self.context.push_nullifier(seed + 1);
+
         // Emit the note hash for the signing key note.
-        self.context.push_note_hash(seed + 1);
+        self.context.push_note_hash(seed + 2);
 
         // Emit a private log tied to the note hash, matching the length of a real note delivery
         // log (MESSAGE_CIPHERTEXT_LEN fields). The signing key note is a SinglePrivateImmutable

--- a/yarn-project/end-to-end/src/e2e_kernelless_simulation.test.ts
+++ b/yarn-project/end-to-end/src/e2e_kernelless_simulation.test.ts
@@ -1,8 +1,13 @@
+import { EcdsaKAccountContract } from '@aztec/accounts/ecdsa';
+import { SchnorrAccountContract } from '@aztec/accounts/schnorr';
+import { NO_FROM } from '@aztec/aztec.js/account';
 import { AztecAddress } from '@aztec/aztec.js/addresses';
 import { CallAuthorizationRequest } from '@aztec/aztec.js/authorization';
 import { Fr } from '@aztec/aztec.js/fields';
 import type { Logger } from '@aztec/aztec.js/log';
 import type { AztecNode } from '@aztec/aztec.js/node';
+import { randomBytes } from '@aztec/foundation/crypto/random';
+import { Fq } from '@aztec/foundation/curves/bn254';
 import { AMMContract } from '@aztec/noir-contracts.js/AMM';
 import { type TokenContract, TokenContractArtifact } from '@aztec/noir-contracts.js/Token';
 import { AuthWitTestContract, AuthWitTestContractArtifact } from '@aztec/noir-test-contracts.js/AuthWitTest';
@@ -418,6 +423,62 @@ describe('Kernelless simulation', () => {
 
       expect(noteHashMembershipWitnessSpy).toHaveBeenCalled();
       noteHashMembershipWitnessSpy.mockRestore();
+    });
+  });
+
+  describe('account contract deployment', () => {
+    it('simulates Schnorr account deployment and gas matches with-kernels counterpart', async () => {
+      const signingKey = Fq.random();
+      const accountManager = await wallet.createAccount({
+        secret: Fr.random(),
+        salt: Fr.random(),
+        contract: new SchnorrAccountContract(signingKey),
+        type: 'schnorr',
+      });
+      const deployMethod = await accountManager.getDeployMethod();
+      const deployOptions = { from: NO_FROM, skipClassPublication: true };
+
+      wallet.setSimulationMode('kernelless-override');
+      const kernellessResult = await deployMethod.simulate(deployOptions);
+      const kernellessGas = kernellessResult.estimatedGas!;
+
+      wallet.setSimulationMode('full');
+      const withKernelsResult = await deployMethod.simulate(deployOptions);
+      const withKernelsGas = withKernelsResult.estimatedGas!;
+
+      logger.info(`Schnorr kernelless gas: L2=${kernellessGas.gasLimits.l2Gas} DA=${kernellessGas.gasLimits.daGas}`);
+      logger.info(
+        `Schnorr with kernels gas: L2=${withKernelsGas.gasLimits.l2Gas} DA=${withKernelsGas.gasLimits.daGas}`,
+      );
+
+      expect(kernellessGas.gasLimits.daGas).toEqual(withKernelsGas.gasLimits.daGas);
+      expect(kernellessGas.gasLimits.l2Gas).toEqual(withKernelsGas.gasLimits.l2Gas);
+    });
+
+    it('simulates ECDSA account deployment and gas matches with-kernels counterpart', async () => {
+      const signingKey = randomBytes(32);
+      const accountManager = await wallet.createAccount({
+        secret: Fr.random(),
+        salt: Fr.random(),
+        contract: new EcdsaKAccountContract(signingKey),
+        type: 'ecdsasecp256k1',
+      });
+      const deployMethod = await accountManager.getDeployMethod();
+      const deployOptions = { from: NO_FROM, skipClassPublication: true };
+
+      wallet.setSimulationMode('kernelless-override');
+      const kernellessResult = await deployMethod.simulate(deployOptions);
+      const kernellessGas = kernellessResult.estimatedGas!;
+
+      wallet.setSimulationMode('full');
+      const withKernelsResult = await deployMethod.simulate(deployOptions);
+      const withKernelsGas = withKernelsResult.estimatedGas!;
+
+      logger.info(`ECDSA kernelless gas: L2=${kernellessGas.gasLimits.l2Gas} DA=${kernellessGas.gasLimits.daGas}`);
+      logger.info(`ECDSA with kernels gas: L2=${withKernelsGas.gasLimits.l2Gas} DA=${withKernelsGas.gasLimits.daGas}`);
+
+      expect(kernellessGas.gasLimits.daGas).toEqual(withKernelsGas.gasLimits.daGas);
+      expect(kernellessGas.gasLimits.l2Gas).toEqual(withKernelsGas.gasLimits.l2Gas);
     });
   });
 });

--- a/yarn-project/wallets/src/embedded/embedded_wallet.ts
+++ b/yarn-project/wallets/src/embedded/embedded_wallet.ts
@@ -360,7 +360,8 @@ export class EmbeddedWallet extends BaseWallet {
     this.estimatedGasPadding = value ?? DEFAULT_ESTIMATED_GAS_PADDING;
   }
 
-  stop() {
-    return this.pxe.stop();
+  async stop(): Promise<void> {
+    await this.pxe.stop();
+    await this.walletDB.close();
   }
 }

--- a/yarn-project/wallets/src/embedded/entrypoints/browser.ts
+++ b/yarn-project/wallets/src/embedded/entrypoints/browser.ts
@@ -67,7 +67,7 @@ export class BrowserEmbeddedWallet extends EmbeddedWallet {
             1,
             rootLogger.createChild('wallet:data'),
           ));
-    const walletDB = WalletDB.init(walletDBStore, rootLogger.createChild('wallet:db').info);
+    const walletDB = new WalletDB(walletDBStore, rootLogger.createChild('wallet:db').info);
 
     return new this(pxe, aztecNode, walletDB, new LazyAccountContractsProvider(), rootLogger) as T;
   }

--- a/yarn-project/wallets/src/embedded/entrypoints/node.ts
+++ b/yarn-project/wallets/src/embedded/entrypoints/node.ts
@@ -74,7 +74,7 @@ export class NodeEmbeddedWallet extends EmbeddedWallet {
             },
             rootLogger.createChild('wallet:data').getBindings(),
           ));
-    const walletDB = WalletDB.init(walletDBStore, rootLogger.createChild('wallet:db').info);
+    const walletDB = new WalletDB(walletDBStore, rootLogger.createChild('wallet:db').info);
 
     return new this(pxe, aztecNode, walletDB, new BundleAccountContractsProvider(), rootLogger) as T;
   }

--- a/yarn-project/wallets/src/embedded/wallet_db.test.ts
+++ b/yarn-project/wallets/src/embedded/wallet_db.test.ts
@@ -10,7 +10,7 @@ describe('WalletDB', () => {
 
   beforeEach(async () => {
     const store = await openTmpStore('wallet-db-test');
-    db = WalletDB.init(store, () => {});
+    db = new WalletDB(store, () => {});
   });
 
   function makeAccountData(type: AccountType = 'schnorr', alias?: string) {

--- a/yarn-project/wallets/src/embedded/wallet_db.ts
+++ b/yarn-project/wallets/src/embedded/wallet_db.ts
@@ -12,16 +12,15 @@ function accountKey(field: string, address: AztecAddress | string): string {
 }
 
 export class WalletDB {
-  private constructor(
-    private accounts: AztecAsyncMap<string, Buffer>,
-    private aliases: AztecAsyncMap<string, Buffer>,
-    private userLog: LogFn,
-  ) {}
+  private accounts: AztecAsyncMap<string, Buffer>;
+  private aliases: AztecAsyncMap<string, Buffer>;
 
-  static init(store: AztecAsyncKVStore, userLog: LogFn) {
-    const accounts = store.openMap<string, Buffer>('accounts');
-    const aliases = store.openMap<string, Buffer>('aliases');
-    return new WalletDB(accounts, aliases, userLog);
+  constructor(
+    private store: AztecAsyncKVStore,
+    private userLog: LogFn,
+  ) {
+    this.accounts = store.openMap<string, Buffer>('accounts');
+    this.aliases = store.openMap<string, Buffer>('aliases');
   }
 
   async storeAccount(
@@ -130,5 +129,9 @@ export class WalletDB {
     if (alias) {
       await this.aliases.delete(`accounts:${alias}`);
     }
+  }
+
+  async close() {
+    await this.store.close();
   }
 }


### PR DESCRIPTION
The ecosystem-in-a-box repo highlighted these two issues:

* The walletdb is not being closed when stopping the embedded wallet
* There was a missing nullifier in the constructor of the stub accounts, which skewed gas measurements in kernelless mode
