### PR TITLE
refactor: `getPackageVersion` fn cleanup

### DIFF
--- a/yarn-project/aztec-node/src/aztec-node/server.test.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.test.ts
@@ -43,11 +43,10 @@ import { getPackageVersion } from '@aztec/stdlib/update-checker';
 import type { ValidatorClient } from '@aztec/validator-client';
 
 import { jest } from '@jest/globals';
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { mkdtempSync, rmSync, writeFileSync } from 'fs';
 import { type MockProxy, mock } from 'jest-mock-extended';
 import { tmpdir } from 'os';
-import { dirname, join, resolve } from 'path';
-import { fileURLToPath } from 'url';
+import { join } from 'path';
 import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts';
 
 import { blockResponseFromL2Block } from './block_response_helpers.js';
@@ -203,7 +202,7 @@ describe('aztec node', () => {
       globalVariablesBuilder,
       feeProvider,
       epochCache,
-      getPackageVersion() ?? '',
+      getPackageVersion(),
       new TestCircuitVerifier(),
       new TestCircuitVerifier(),
     );
@@ -332,13 +331,8 @@ describe('aztec node', () => {
 
     describe('node info', () => {
       it('returns the correct node version', async () => {
-        const releasePleaseVersionFile = readFileSync(
-          resolve(dirname(fileURLToPath(import.meta.url)), '../../../../.release-please-manifest.json'),
-        ).toString();
-        const releasePleaseVersion = JSON.parse(releasePleaseVersionFile)['.'];
-
         const nodeInfo = await node.getNodeInfo();
-        expect(nodeInfo.nodeVersion).toBe(releasePleaseVersion);
+        expect(nodeInfo.nodeVersion).toBe(getPackageVersion());
       });
     });
 
@@ -756,7 +750,7 @@ describe('aztec node', () => {
           globalVariablesBuilder,
           feeProvider,
           epochCache,
-          getPackageVersion() ?? '',
+          getPackageVersion(),
           new TestCircuitVerifier(),
           new TestCircuitVerifier(),
           undefined,
@@ -947,7 +941,7 @@ describe('aztec node', () => {
           globalVariablesBuilder,
           feeProvider,
           epochCache,
-          getPackageVersion() ?? '',
+          getPackageVersion(),
           new TestCircuitVerifier(),
           new TestCircuitVerifier(),
           undefined,
@@ -1019,7 +1013,7 @@ describe('aztec node', () => {
         globalVariablesBuilder,
         mock<FeeProvider>(),
         epochCache,
-        getPackageVersion() ?? '',
+        getPackageVersion(),
         new TestCircuitVerifier(),
         new TestCircuitVerifier(),
       );

--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -508,7 +508,7 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, AztecNodeDeb
   ): Promise<AztecNodeService> {
     const config = { ...inputConfig }; // Copy the config so we dont mutate the input object
     const log = deps.logger ?? createLogger('node');
-    const packageVersion = getPackageVersion() ?? '';
+    const packageVersion = getPackageVersion();
     const telemetry = deps.telemetry ?? getTelemetryClient();
     const dateProvider = deps.dateProvider ?? new DateProvider();
     const ethereumChain = createEthereumChain(config.l1RpcUrls, config.l1ChainId);

--- a/yarn-project/aztec/src/bin/index.ts
+++ b/yarn-project/aztec/src/bin/index.ts
@@ -47,7 +47,7 @@ async function main() {
   await enrichEnvironmentWithNetworkConfig(networkName);
   enrichEnvironmentWithChainName(networkName);
 
-  const cliVersion = getPackageVersion() ?? 'unknown';
+  const cliVersion = getPackageVersion();
   let program = new Command('aztec');
   program.description('Aztec command line interface').version(cliVersion).enablePositionalOptions();
   program = injectAztecCommands(program, userLog, debugLogger);

--- a/yarn-project/aztec/src/cli/aztec_start_action.ts
+++ b/yarn-project/aztec/src/cli/aztec_start_action.ts
@@ -29,7 +29,7 @@ export async function aztecStart(options: any, userLog: LogFn, debugLogger: Logg
   if (options.localNetwork) {
     const localNetwork = extractNamespacedOptions(options, 'localNetwork');
     userLog(`${splash}\n${github}\n\n`);
-    userLog(`Setting up Aztec local network ${packageVersion ?? 'unknown'}, please stand by...`);
+    userLog(`Setting up Aztec local network ${packageVersion}, please stand by...`);
 
     const { node, stop } = await createLocalNetwork(
       {

--- a/yarn-project/aztec/src/cli/cmds/utils/warn_if_aztec_version_mismatch.test.ts
+++ b/yarn-project/aztec/src/cli/cmds/utils/warn_if_aztec_version_mismatch.test.ts
@@ -1,3 +1,5 @@
+import { DEV_VERSION } from '@aztec/stdlib/update-checker';
+
 import { afterEach, beforeEach, describe, expect, it } from '@jest/globals';
 import { mkdir, rm, writeFile } from 'fs/promises';
 import { tmpdir } from 'os';
@@ -136,13 +138,14 @@ describe('warnIfAztecVersionMismatch', () => {
     expect(logMessages.filter(m => m.includes('WARNING'))).toHaveLength(0);
   });
 
-  it('warns when the CLI version is not available', async () => {
-    await makePackage(tempDir, 'project', 'contract');
+  it('skips the check when running from a monorepo checkout', async () => {
+    await makePackage(tempDir, 'project', 'contract', {
+      aztec: '{ git = "https://github.com/AztecProtocol/aztec-nr", tag = "v1.2.3", directory = "aztec" }',
+    });
 
-    await warnIfAztecVersionMismatch(log, '');
+    await warnIfAztecVersionMismatch(log, DEV_VERSION);
 
-    expect(logMessages).toHaveLength(1);
-    expect(logMessages[0]).toContain('CLI version not found');
+    expect(logMessages).toHaveLength(0);
   });
 
   it('does not warn when the project has no aztec dependency', async () => {

--- a/yarn-project/aztec/src/cli/cmds/utils/warn_if_aztec_version_mismatch.ts
+++ b/yarn-project/aztec/src/cli/cmds/utils/warn_if_aztec_version_mismatch.ts
@@ -1,5 +1,5 @@
 import type { LogFn } from '@aztec/foundation/log';
-import { getPackageVersion } from '@aztec/stdlib/update-checker';
+import { DEV_VERSION, getPackageVersion } from '@aztec/stdlib/update-checker';
 
 import TOML from '@iarna/toml';
 import { readFile } from 'fs/promises';
@@ -28,8 +28,7 @@ function isAztecNrGitUrl(gitUrl: string): boolean {
 /** Warns if any aztec-nr git dependency in a crate's Nargo.toml has a tag that doesn't match the CLI version. */
 export async function warnIfAztecVersionMismatch(log: LogFn, cliVersion?: string): Promise<void> {
   const version = cliVersion ?? getPackageVersion();
-  if (!version) {
-    log(`WARNING: aztec CLI version not found. Skipping dependency compatibility check.`);
+  if (version === DEV_VERSION) {
     return;
   }
 

--- a/yarn-project/aztec/src/cli/util.ts
+++ b/yarn-project/aztec/src/cli/util.ts
@@ -311,7 +311,7 @@ export async function setupVersionChecker(
   const checks: Array<VersionCheck> = [];
   checks.push({
     name: 'node',
-    currentVersion: getPackageVersion() ?? 'unknown',
+    currentVersion: getPackageVersion(),
     getLatestVersion: async () => {
       const cfg = await getNetworkConfig(network, cacheDir);
       return cfg?.nodeVersion;

--- a/yarn-project/cli-wallet/src/bin/index.ts
+++ b/yarn-project/cli-wallet/src/bin/index.ts
@@ -73,7 +73,7 @@ function injectInternalCommands(program: Command, log: LogFn, db: WalletDB) {
 
 /** CLI wallet main entrypoint */
 async function main() {
-  const walletVersion = getPackageVersion() ?? '0.0.0';
+  const walletVersion = getPackageVersion();
 
   const db = WalletDB.getInstance();
   const walletAndNodeWrapper = new CliWalletAndNodeWrapper();

--- a/yarn-project/stdlib/src/update-checker/package_version.ts
+++ b/yarn-project/stdlib/src/update-checker/package_version.ts
@@ -3,28 +3,16 @@ import { fileURLToPath } from '@aztec/foundation/url';
 import { readFileSync } from 'fs';
 import { dirname, resolve } from 'path';
 
-/** Returns the package version from the release-please manifest or the package.json, or undefined if not found. */
-export function getPackageVersion(): string | undefined {
+/** Placeholder version returned when running from a local monorepo checkout rather than an npm-installed package. */
+export const DEV_VERSION = 'dev';
+
+/**
+ * Returns the package version from the stdlib `package.json`, or `DEV_VERSION` when the version is the `0.1.0`
+ * placeholder (which indicates a local monorepo checkout rather than an npm-installed package).
+ */
+export function getPackageVersion(): string {
   const dir = dirname(fileURLToPath(import.meta.url));
-
-  // Try the release-please manifest first (works in dev/repo checkout).
-  try {
-    const releasePleaseManifestPath = resolve(dir, '../../../../.release-please-manifest.json');
-    return JSON.parse(readFileSync(releasePleaseManifestPath).toString())['.'];
-  } catch {
-    // Not in a repo checkout, fall through.
-  }
-
-  // Fall back to the stdlib package.json version (works in npm-installed packages).
-  try {
-    const packageJsonPath = resolve(dir, '../../package.json');
-    const version = JSON.parse(readFileSync(packageJsonPath).toString()).version;
-    if (version && version !== '0.1.0') {
-      return version;
-    }
-  } catch {
-    // No package.json found either.
-  }
-
-  return undefined;
+  const packageJsonPath = resolve(dir, '../../package.json');
+  const version = JSON.parse(readFileSync(packageJsonPath).toString()).version;
+  return version === '0.1.0' ? DEV_VERSION : version;
 }

--- a/yarn-project/txe/src/state_machine/index.ts
+++ b/yarn-project/txe/src/state_machine/index.ts
@@ -59,7 +59,7 @@ export class TXEStateMachine {
       new TXEGlobalVariablesBuilder(),
       new TXEFeeProvider(),
       new MockEpochCache(),
-      getPackageVersion() ?? '',
+      getPackageVersion(),
       new TestCircuitVerifier(),
       new TestCircuitVerifier(),
       undefined,


### PR DESCRIPTION
[This other PR](https://github.com/AztecProtocol/aztec-packages/pull/22941) of mine was motivation for this because there we need to stamp aztec version into contract artifact and the current `getPackageVersion` was not helpful in that because it failed to resolve the actual version (e.g. `v4.3.0-nightly.20260427` instead of `v4.3.0`). To workaround this I will no longer read the version from `.release-please-manifest.json` and will read it from package.json instead where the version is stamped during a release. If the code is not run from a release the version is simply populated with "dev" which seems better then returning undefined and forcing the callsites to deal with it.

Bothering Adam and Alex with a review here since you are the only people that seemed to have touched the function.

## AI  Summary

- `getPackageVersion` previously read from `.release-please-manifest.json`, which holds the *next* stable target (currently `5.0.0`) — not the actually-installed/built version. So nightlies and stable releases reported a stale version.
- It now reads from the stdlib `package.json` (which release tooling stamps at publish time) and substitutes `DEV_VERSION` (`'dev'`) for the `0.1.0` placeholder used in a monorepo checkout.
- Return type narrowed from `string | undefined` to `string`, and the now-dead `?? '<fallback>'` chains in callers (`aztec-node`, `aztec` CLI, `cli-wallet`, `txe`) are dropped.
- `warnIfAztecVersionMismatch` gets an early return on `DEV_VERSION` so monorepo checkouts no longer spam warnings about every aztec-nr dep tag mismatch (previously it would compare against `v5.0.0`, now it would have compared against `vdev` — both wrong).

`.release-please-manifest.json` is left in place for now since release tooling may still consume it; removing it can be a separate change.

Context from #21382 review thread: https://github.com/AztecProtocol/aztec-packages/pull/21382/files#r3182335186