### PR TITLE
chore(p2p): drop unused ENR xxhash versioning path

### DIFF
--- a/yarn-project/p2p/src/versioning.test.ts
+++ b/yarn-project/p2p/src/versioning.test.ts
@@ -1,11 +1,12 @@
 import { EthAddress } from '@aztec/foundation/eth-address';
 import type { ChainConfig } from '@aztec/stdlib/config';
+import { checkCompressedComponentVersion, compressComponentVersions } from '@aztec/stdlib/versioning';
 
 import type { SignableENR } from '@nethermindeth/enr';
 import { type MockProxy, mock } from 'jest-mock-extended';
 
 import { AZTEC_ENR_KEY } from './types/index.js';
-import { checkAztecEnrVersion, setAztecEnrKey } from './versioning.js';
+import { setAztecEnrKey } from './versioning.js';
 
 describe('versioning', () => {
   let enr: MockProxy<SignableENR>;
@@ -29,14 +30,16 @@ describe('versioning', () => {
     };
   });
 
-  it.each([true, false])('sets and compares versions with xxhash=%s', (useXxHash: boolean) => {
-    const versions = setAztecEnrKey(enr, chainConfig, useXxHash);
+  it('sets and compares compressed versions on ENR', () => {
+    const versions = setAztecEnrKey(enr, chainConfig);
     expect(versions.l1ChainId).toEqual(1);
     expect(versions.rollupVersion).toEqual(3);
     expect(versions.l1RollupAddress).toEqual(chainConfig.l1Contracts.rollupAddress);
-    expect(versionSet).toHaveLength(useXxHash ? 8 : 33);
+    expect(Buffer.from(versionSet!).toString()).toEqual(compressComponentVersions(versions));
 
-    checkAztecEnrVersion(versionSet, versions);
-    expect(() => checkAztecEnrVersion(versionSet, { ...versions, l1ChainId: 3 })).toThrow();
+    checkCompressedComponentVersion(Buffer.from(versionSet!).toString(), versions);
+    expect(() =>
+      checkCompressedComponentVersion(Buffer.from(versionSet!).toString(), { ...versions, l1ChainId: 3 }),
+    ).toThrow();
   });
 });

--- a/yarn-project/p2p/src/versioning.ts
+++ b/yarn-project/p2p/src/versioning.ts
@@ -1,22 +1,11 @@
-import { toBufferBE } from '@aztec/foundation/bigint-buffer';
 import { getVKTreeRoot } from '@aztec/noir-protocol-circuits-types/vk-tree';
 import { protocolContractsHash } from '@aztec/protocol-contracts';
 import type { ChainConfig } from '@aztec/stdlib/config';
-import {
-  type ComponentsVersions,
-  checkCompressedComponentVersion,
-  compressComponentVersions,
-  getComponentsVersionsFromConfig,
-} from '@aztec/stdlib/versioning';
+import { compressComponentVersions, getComponentsVersionsFromConfig } from '@aztec/stdlib/versioning';
 
 import type { SignableENR } from '@nethermindeth/enr';
-import xxhashFactory from 'xxhash-wasm';
 
 import { AZTEC_ENR_CLIENT_VERSION_KEY, AZTEC_ENR_KEY } from './types/index.js';
-
-const USE_XX_HASH = false; // Enable to reduce the size of the ENR record for production
-const XX_HASH_LEN = 8;
-const xxhash = await xxhashFactory();
 
 /** Returns the component versions based on config and this build. */
 export function getVersions(config: ChainConfig) {
@@ -24,10 +13,9 @@ export function getVersions(config: ChainConfig) {
 }
 
 /** Sets the aztec key on the ENR record with versioning info. */
-export function setAztecEnrKey(enr: SignableENR, config: ChainConfig, useXxHash = USE_XX_HASH) {
+export function setAztecEnrKey(enr: SignableENR, config: ChainConfig) {
   const versions = getVersions(config);
-  const value = versionsToEnrValue(versions, useXxHash);
-  enr.set(AZTEC_ENR_KEY, value);
+  enr.set(AZTEC_ENR_KEY, Buffer.from(compressComponentVersions(versions)));
   return versions;
 }
 
@@ -36,22 +24,4 @@ export function setAztecClientVersionEnrKey(enr: SignableENR, clientVersion: str
   if (clientVersion) {
     enr.set(AZTEC_ENR_CLIENT_VERSION_KEY, Buffer.from(clientVersion));
   }
-}
-
-/** Checks the given value from an ENR record against the expected versions. */
-export function checkAztecEnrVersion(enrValue: Buffer, expectedVersions: ComponentsVersions) {
-  if (enrValue.length === XX_HASH_LEN) {
-    const expected = versionsToEnrValue(expectedVersions, true);
-    if (!Buffer.from(enrValue).equals(expected)) {
-      throw new Error(`Expected ENR version ${expected.toString('hex')} but received ${enrValue.toString('hex')}`);
-    }
-  } else {
-    const actual = Buffer.from(enrValue).toString();
-    checkCompressedComponentVersion(actual, expectedVersions);
-  }
-}
-
-function versionsToEnrValue(versions: ComponentsVersions, useXxHash: boolean) {
-  const compressed = compressComponentVersions(versions);
-  return useXxHash ? toBufferBE(xxhash.h64(compressed), XX_HASH_LEN) : Buffer.from(compressed);
 }


### PR DESCRIPTION
## Summary
Removes dead code from `p2p/src/versioning.ts`:

- `USE_XX_HASH` was never `true` outside tests; production ENRs always used the compressed string from `compressComponentVersions`.
- Peer discovery already validates with `checkCompressedComponentVersion` in `discV5_service.ts`; `checkAztecEnrVersion` was only used from tests.
- Drops `xxhash-wasm` / `toBufferBE` from this module (gossip `encoding.ts` still uses xxhash for message IDs).

## Testing
`yarn test src/versioning.test.ts` in `yarn-project/p2p`.