### PR TITLE
chore: error log when L1 head timestamp drifts

### DIFF
--- a/yarn-project/archiver/src/modules/l1_synchronizer.ts
+++ b/yarn-project/archiver/src/modules/l1_synchronizer.ts
@@ -152,11 +152,11 @@ export class ArchiverL1Synchronizer implements Traceable {
       return;
     }
 
-    // Warn if the latest L1 block timestamp is too old
+    // Log at error if the latest L1 block timestamp is too old
     const maxAllowedDelay = this.config.maxAllowedEthClientDriftSeconds;
     const now = this.dateProvider.nowInSeconds();
     if (maxAllowedDelay > 0 && Number(currentL1Timestamp) <= now - maxAllowedDelay) {
-      this.log.warn(
+      this.log.error(
         `Latest L1 block ${currentL1BlockNumber} timestamp ${currentL1Timestamp} is too old. Make sure your Ethereum node is synced.`,
         { currentL1BlockNumber, currentL1Timestamp, now, maxAllowedDelay },
       );


### PR DESCRIPTION
Raise severity when the latest L1 block timestamp exceeds `maxAllowedEthClientDriftSeconds` so operators relying on log aggregation see it as an error.

Fixes [A-647](https://linear.app/aztec-labs/issue/A-647/node-switches-to-alternative-consensus-hosts)