### PR TITLE
feat: wallet-sdk heartbeat

### DIFF
--- a/docs/examples/webapp-tutorial/test-extension/src/background.ts
+++ b/docs/examples/webapp-tutorial/test-extension/src/background.ts
@@ -15,12 +15,23 @@ import {
   type BackgroundTransport,
   type BackgroundConnectionCallbacks,
   type ActiveSession,
-} from '@aztec/wallet-sdk/extension/handlers';
+} from "@aztec/wallet-sdk/extension/handlers";
 
-import { WALLET_CONFIG, MessageTarget, MessageTypes, AUTO_LOCK_MINUTES, log } from './config';
-import { getErrorMessage } from './utils';
-import { STORAGE_KEYS } from './wallet/storage';
-import type { PendingTransaction, PendingSessionVerification, PendingCapabilities, BackgroundTask } from './shared-types';
+import {
+  WALLET_CONFIG,
+  MessageTarget,
+  MessageTypes,
+  AUTO_LOCK_MINUTES,
+  log,
+} from "./config";
+import { getErrorMessage } from "./utils";
+import { STORAGE_KEYS } from "./wallet/storage";
+import type {
+  PendingTransaction,
+  PendingSessionVerification,
+  PendingCapabilities,
+  BackgroundTask,
+} from "./shared-types";
 
 // docs:start:offscreen-management
 let offscreenCreating: Promise<void> | null = null;
@@ -43,18 +54,18 @@ async function ensureOffscreenDocument(): Promise<void> {
     return;
   }
 
-  const offscreenUrl = chrome.runtime.getURL('dist/offscreen.html');
-  log.debug('[background] Creating offscreen document:', offscreenUrl);
+  const offscreenUrl = chrome.runtime.getURL("dist/offscreen.html");
+  log.debug("[background] Creating offscreen document:", offscreenUrl);
 
   offscreenCreating = chrome.offscreen.createDocument({
     url: offscreenUrl,
     reasons: [chrome.offscreen.Reason.WORKERS],
-    justification: 'Aztec PXE requires long-running WASM operations',
+    justification: "Aztec PXE requires long-running WASM operations",
   });
 
   await offscreenCreating;
   offscreenCreating = null;
-  log.debug('[background] Offscreen document created');
+  log.debug("[background] Offscreen document created");
 }
 // docs:end:offscreen-management
 
@@ -67,26 +78,29 @@ async function ensureOffscreenDocument(): Promise<void> {
  * - No `return true`/`false` landmine for async responses
  */
 let offscreenPort: chrome.runtime.Port | null = null;
-const pendingOffscreenCalls = new Map<string, {
-  resolve: (value: any) => void;
-  reject: (error: Error) => void;
-  timer: ReturnType<typeof setTimeout>;
-}>();
+const pendingOffscreenCalls = new Map<
+  string,
+  {
+    resolve: (value: any) => void;
+    reject: (error: Error) => void;
+    timer: ReturnType<typeof setTimeout>;
+  }
+>();
 let offscreenMessageId = 0;
 
 const OFFSCREEN_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
 
 function connectOffscreenPort() {
-  const port = chrome.runtime.connect({ name: 'offscreen' });
+  const port = chrome.runtime.connect({ name: "offscreen" });
   offscreenPort = port;
 
   port.onMessage.addListener((message: any) => {
     // Progress updates — relay to popup
-    if (message.type === 'task-progress') {
-      const runningTask = backgroundTasks.find((t) => t.status === 'running');
+    if (message.type === "task-progress") {
+      const runningTask = backgroundTasks.find((t) => t.status === "running");
       if (runningTask) {
         runningTask.progress = message.stage;
-        notifyPopup({ type: 'task-update', task: { ...runningTask } });
+        notifyPopup({ type: "task-update", task: { ...runningTask } });
       }
       return;
     }
@@ -100,17 +114,17 @@ function connectOffscreenPort() {
     if (message.success) {
       pending.resolve(message.result);
     } else {
-      pending.reject(new Error(message.error || 'Unknown error'));
+      pending.reject(new Error(message.error || "Unknown error"));
     }
   });
 
   port.onDisconnect.addListener(() => {
-    log.debug('[background] Offscreen port disconnected');
+    log.debug("[background] Offscreen port disconnected");
     offscreenPort = null;
     // Reject all pending calls — sendToOffscreen will retry
     for (const [id, pending] of pendingOffscreenCalls) {
       clearTimeout(pending.timer);
-      pending.reject(new Error('Offscreen port disconnected'));
+      pending.reject(new Error("Offscreen port disconnected"));
       pendingOffscreenCalls.delete(id);
     }
   });
@@ -140,7 +154,7 @@ async function sendToOffscreen(message: any, _retried = false): Promise<any> {
 
     try {
       if (!offscreenPort) {
-        throw new Error('Offscreen port not connected');
+        throw new Error("Offscreen port not connected");
       }
       offscreenPort.postMessage({ ...message, messageId });
     } catch (err: unknown) {
@@ -149,7 +163,7 @@ async function sendToOffscreen(message: any, _retried = false): Promise<any> {
 
       // Port may have disconnected — retry once
       if (!_retried) {
-        log.warn('[background] Offscreen port send failed, retrying...');
+        log.warn("[background] Offscreen port send failed, retrying...");
         offscreenPort = null;
         offscreenCreating = null;
         sendToOffscreen(message, true).then(resolve, reject);
@@ -176,7 +190,8 @@ const capabilitiesApprovedSessions = new Set<string>();
  * The extension must confirm the session before any wallet method calls are processed.
  * This prevents the dApp from bypassing verification by sending messages immediately.
  */
-const queuedMessages: Map<string, { session: ActiveSession; message: any }[]> = new Map();
+const queuedMessages: Map<string, { session: ActiveSession; message: any }[]> =
+  new Map();
 
 /**
  * Trusted origins persistence for auto-reconnect. (#30)
@@ -187,7 +202,7 @@ const queuedMessages: Map<string, { session: ActiveSession; message: any }[]> = 
  * exchange still happens every time for security). Disconnecting a site
  * removes it from the trusted list.
  */
-const TRUSTED_ORIGINS_KEY = 'aztec_trusted_origins';
+const TRUSTED_ORIGINS_KEY = "aztec_trusted_origins";
 
 interface TrustedOrigin {
   origin: string;
@@ -203,26 +218,37 @@ async function getTrustedOrigins(): Promise<TrustedOrigin[]> {
 
 async function addTrustedOrigin(origin: string, appId: string): Promise<void> {
   const trusted = await getTrustedOrigins();
-  if (!trusted.some(t => t.origin === origin && t.appId === appId)) {
+  if (!trusted.some((t) => t.origin === origin && t.appId === appId)) {
     trusted.push({ origin, appId, trustedAt: Date.now() });
     await chrome.storage.local.set({ [TRUSTED_ORIGINS_KEY]: trusted });
   }
 }
 
-async function removeTrustedOrigin(origin: string, appId: string): Promise<void> {
+async function removeTrustedOrigin(
+  origin: string,
+  appId: string,
+): Promise<void> {
   const trusted = await getTrustedOrigins();
-  const filtered = trusted.filter(t => !(t.origin === origin && t.appId === appId));
+  const filtered = trusted.filter(
+    (t) => !(t.origin === origin && t.appId === appId),
+  );
   await chrome.storage.local.set({ [TRUSTED_ORIGINS_KEY]: filtered });
 }
 
-async function isTrustedOrigin(origin: string, appId: string): Promise<boolean> {
+async function isTrustedOrigin(
+  origin: string,
+  appId: string,
+): Promise<boolean> {
   const trusted = await getTrustedOrigins();
-  return trusted.some(t => t.origin === origin && t.appId === appId);
+  return trusted.some((t) => t.origin === origin && t.appId === appId);
 }
 
-async function getStoredCapabilities(origin: string, appId: string): Promise<Array<{ type: string; [key: string]: any }> | null> {
+async function getStoredCapabilities(
+  origin: string,
+  appId: string,
+): Promise<Array<{ type: string; [key: string]: any }> | null> {
   const trusted = await getTrustedOrigins();
-  const entry = trusted.find(t => t.origin === origin && t.appId === appId);
+  const entry = trusted.find((t) => t.origin === origin && t.appId === appId);
   return entry?.grantedCapabilities ?? null;
 }
 
@@ -245,19 +271,24 @@ async function persistState(): Promise<void> {
       sw_pendingTransactions: pendingTransactions,
     });
   } catch (err) {
-    log.warn('[background] Failed to persist state:', err);
+    log.warn("[background] Failed to persist state:", err);
   }
 }
 
 async function restoreState(): Promise<void> {
   try {
     const data = await chrome.storage.session.get([
-      'sw_walletUnlocked',
-      'sw_pendingTransactions',
+      "sw_walletUnlocked",
+      "sw_pendingTransactions",
     ]);
     walletUnlocked = data.sw_walletUnlocked ?? false;
     pendingTransactions = data.sw_pendingTransactions ?? [];
-    log.debug('[background] Restored state: unlocked =', walletUnlocked, ', pendingTx =', pendingTransactions.length);
+    log.debug(
+      "[background] Restored state: unlocked =",
+      walletUnlocked,
+      ", pendingTx =",
+      pendingTransactions.length,
+    );
 
     // Validate: if the offscreen document was torn down, the cached master key is gone.
     // Probe offscreen to confirm — if it fails, the wallet needs re-unlock.
@@ -265,13 +296,15 @@ async function restoreState(): Promise<void> {
       try {
         await sendToOffscreen({ type: MessageTypes.GET_ACCOUNTS });
       } catch {
-        log.warn('[background] Offscreen unreachable after restore — marking wallet as locked');
+        log.warn(
+          "[background] Offscreen unreachable after restore — marking wallet as locked",
+        );
         walletUnlocked = false;
         await persistState();
       }
     }
   } catch (err) {
-    log.warn('[background] Failed to restore state:', err);
+    log.warn("[background] Failed to restore state:", err);
   }
 }
 
@@ -284,22 +317,27 @@ let backgroundTasks: BackgroundTask[] = [];
 
 function startBackgroundTask(type: string, promise: Promise<any>): string {
   const id = `${type}-${Date.now()}`;
-  const task: BackgroundTask = { id, type, status: 'running', startedAt: Date.now() };
+  const task: BackgroundTask = {
+    id,
+    type,
+    status: "running",
+    startedAt: Date.now(),
+  };
   backgroundTasks.push(task);
 
   promise
     .then((result) => {
-      task.status = 'success';
+      task.status = "success";
       task.result = result;
-      notifyPopup({ type: 'task-update', task: { ...task } });
+      notifyPopup({ type: "task-update", task: { ...task } });
     })
     .catch((error) => {
-      task.status = 'error';
+      task.status = "error";
       task.error = getErrorMessage(error);
-      notifyPopup({ type: 'task-update', task: { ...task } });
+      notifyPopup({ type: "task-update", task: { ...task } });
     });
 
-  notifyPopup({ type: 'task-update', task: { ...task } });
+  notifyPopup({ type: "task-update", task: { ...task } });
   return id;
 }
 
@@ -311,7 +349,7 @@ function cleanupTasks() {
   const FIVE_MINUTES = 5 * 60 * 1000;
   const cutoff = Date.now() - FIVE_MINUTES;
   backgroundTasks = backgroundTasks.filter(
-    (t) => t.status === 'running' || t.startedAt > cutoff
+    (t) => t.status === "running" || t.startedAt > cutoff,
   );
 }
 
@@ -323,13 +361,13 @@ function cleanupTasks() {
 let popupPort: chrome.runtime.Port | null = null;
 
 chrome.runtime.onConnect.addListener((port) => {
-  if (port.name !== 'popup') return;
+  if (port.name !== "popup") return;
 
-  log.debug('[background] Popup connected');
+  log.debug("[background] Popup connected");
   popupPort = port;
 
   port.onDisconnect.addListener(() => {
-    log.debug('[background] Popup disconnected');
+    log.debug("[background] Popup disconnected");
     popupPort = null;
   });
 
@@ -348,7 +386,7 @@ function notifyPopup(message: any) {
 }
 
 function pushStateToPopup() {
-  notifyPopup({ type: 'state', data: getFullState() });
+  notifyPopup({ type: "state", data: getFullState() });
 }
 
 /**
@@ -361,15 +399,17 @@ function openPopupWindow() {
     pushStateToPopup();
     return;
   }
-  chrome.windows.create({
-    url: chrome.runtime.getURL('popup/popup.html'),
-    type: 'popup',
-    width: 400,
-    height: 600,
-    focused: true,
-  }).catch((err) => {
-    log.error('[background] Failed to create popup window:', err);
-  });
+  chrome.windows
+    .create({
+      url: chrome.runtime.getURL("popup/popup.html"),
+      type: "popup",
+      width: 400,
+      height: 600,
+      focused: true,
+    })
+    .catch((err) => {
+      log.error("[background] Failed to create popup window:", err);
+    });
 }
 
 /**
@@ -384,8 +424,8 @@ function openPopupWithFallback() {
   }
   chrome.action.openPopup().catch(() => {
     chrome.windows.create({
-      url: chrome.runtime.getURL('popup/popup.html'),
-      type: 'popup',
+      url: chrome.runtime.getURL("popup/popup.html"),
+      type: "popup",
       width: 400,
       height: 600,
       focused: true,
@@ -416,17 +456,19 @@ function getFullState() {
  * Auto-lock via chrome.alarms. (#28)
  * Resets the timer on every popup interaction.
  */
-const AUTO_LOCK_ALARM = 'aztec-auto-lock';
+const AUTO_LOCK_ALARM = "aztec-auto-lock";
 
 function resetAutoLockTimer() {
   if (walletUnlocked) {
-    chrome.alarms.create(AUTO_LOCK_ALARM, { delayInMinutes: AUTO_LOCK_MINUTES });
+    chrome.alarms.create(AUTO_LOCK_ALARM, {
+      delayInMinutes: AUTO_LOCK_MINUTES,
+    });
   }
 }
 
 chrome.alarms.onAlarm.addListener(async (alarm) => {
   if (alarm.name === AUTO_LOCK_ALARM) {
-    log.debug('[background] Auto-lock triggered');
+    log.debug("[background] Auto-lock triggered");
     walletUnlocked = false;
     await persistState();
     // Tell offscreen to clear the cached CryptoKey
@@ -443,9 +485,13 @@ chrome.alarms.onAlarm.addListener(async (alarm) => {
  * Updates the extension badge to show pending items count.
  */
 function updateBadge() {
-  const count = pendingTransactions.length + handler.getPendingDiscoveryCount() + pendingSessionVerifications.length + pendingCapabilities.length;
-  chrome.action.setBadgeText({ text: count > 0 ? count.toString() : '' });
-  chrome.action.setBadgeBackgroundColor({ color: '#FF6B00' });
+  const count =
+    pendingTransactions.length +
+    handler.getPendingDiscoveryCount() +
+    pendingSessionVerifications.length +
+    pendingCapabilities.length;
+  chrome.action.setBadgeText({ text: count > 0 ? count.toString() : "" });
+  chrome.action.setBadgeBackgroundColor({ color: "#FF6B00" });
   pushStateToPopup();
   persistState();
 }
@@ -453,18 +499,32 @@ function updateBadge() {
 // docs:start:transport
 const transport: BackgroundTransport = {
   sendToTab: (tabId, message) => {
-    log.debug('[background] sendToTab:', tabId, message.type, message.sessionId);
+    log.debug(
+      "[background] sendToTab:",
+      tabId,
+      message.type,
+      message.sessionId,
+    );
     chrome.tabs.sendMessage(tabId, message);
   },
   addContentListener: (handler) => {
     chrome.runtime.onMessage.addListener((message, sender) => {
       // Skip targeted messages (popup, offscreen), storage proxy, and progress updates
       if (message.target) return;
-      if (message.type === 'storage-get' || message.type === 'storage-set') return;
+      if (message.type === "storage-get" || message.type === "storage-set")
+        return;
 
-      log.debug('[background] Content message received:', message.origin, message.type, 'from tab:', sender.tab?.id);
+      log.debug(
+        "[background] Content message received:",
+        message.origin,
+        message.type,
+        "from tab:",
+        sender.tab?.id,
+      );
       handler(message, {
-        tab: sender.tab ? { id: sender.tab.id, url: sender.tab.url } : undefined,
+        tab: sender.tab
+          ? { id: sender.tab.id, url: sender.tab.url }
+          : undefined,
       });
     });
   },
@@ -476,18 +536,24 @@ const transport: BackgroundTransport = {
  * or the first account as fallback. Used by both processWalletMessage (for
  * getAccounts/getRegisteredAccounts filtering) and APPROVE_CAPABILITIES.
  */
-async function getGrantableAccounts(): Promise<Array<{ alias: string; item: string }>> {
+async function getGrantableAccounts(): Promise<
+  Array<{ alias: string; item: string }>
+> {
   const [accountsData, activeData] = await Promise.all([
     chrome.storage.local.get(STORAGE_KEYS.ACCOUNTS),
     chrome.storage.local.get(STORAGE_KEYS.ACTIVE_ACCOUNT),
   ]);
   const allAccounts = accountsData[STORAGE_KEYS.ACCOUNTS] || [];
   const activeAddress = activeData[STORAGE_KEYS.ACTIVE_ACCOUNT];
-  const activeAccount = allAccounts.find((a: any) => a.address === activeAddress);
+  const activeAccount = allAccounts.find(
+    (a: any) => a.address === activeAddress,
+  );
   if (activeAccount) {
     return [{ alias: activeAccount.alias, item: activeAccount.address }];
   }
-  return allAccounts.slice(0, 1).map((a: any) => ({ alias: a.alias, item: a.address }));
+  return allAccounts
+    .slice(0, 1)
+    .map((a: any) => ({ alias: a.alias, item: a.address }));
 }
 
 /**
@@ -497,11 +563,17 @@ async function getGrantableAccounts(): Promise<Array<{ alias: string; item: stri
 async function processWalletMessage(session: ActiveSession, message: any) {
   // Allow requestCapabilities to pass through (it's the mechanism for getting approved).
   // Block all other wallet methods until capabilities have been approved for this session.
-  if (message.type !== 'requestCapabilities' && !capabilitiesApprovedSessions.has(session.sessionId)) {
-    log.warn('[background] Rejecting wallet method before capabilities approved:', message.type);
+  if (
+    message.type !== "requestCapabilities" &&
+    !capabilitiesApprovedSessions.has(session.sessionId)
+  ) {
+    log.warn(
+      "[background] Rejecting wallet method before capabilities approved:",
+      message.type,
+    );
     await handler.sendResponse(session.sessionId, {
       messageId: message.messageId,
-      error: 'Capabilities not yet approved. Call requestCapabilities() first.',
+      error: "Capabilities not yet approved. Call requestCapabilities() first.",
       walletId: WALLET_CONFIG.walletId,
     });
     return;
@@ -512,21 +584,23 @@ async function processWalletMessage(session: ActiveSession, message: any) {
   // batch requires approval only if it contains a sendTx (e.g. BatchCall.send()).
   // Read-only batches (simulateTx, executeUtility, etc.) auto-execute.
   const needsApproval =
-    message.type === 'sendTx' ||
-    (message.type === 'batch' &&
+    message.type === "sendTx" ||
+    (message.type === "batch" &&
       Array.isArray(message.args?.[0]) &&
-      message.args[0].some((m: any) => m.name === 'sendTx'));
+      message.args[0].some((m: any) => m.name === "sendTx"));
 
   if (needsApproval) {
     // Extract `from` address from the method args:
     // - sendTx args: [executionPayload, sendOptions] → from is in sendOptions
     // - batch args: [methodsArray] → find the sendTx entry and get from from its opts
-    let from = '';
-    if (message.type === 'sendTx') {
-      from = message.args?.[1]?.from?.toString?.() || '';
-    } else if (message.type === 'batch') {
-      const sendTxMethod = message.args[0].find((m: any) => m.name === 'sendTx');
-      from = sendTxMethod?.args?.[1]?.from?.toString?.() || '';
+    let from = "";
+    if (message.type === "sendTx") {
+      from = message.args?.[1]?.from?.toString?.() || "";
+    } else if (message.type === "batch") {
+      const sendTxMethod = message.args[0].find(
+        (m: any) => m.name === "sendTx",
+      );
+      from = sendTxMethod?.args?.[1]?.from?.toString?.() || "";
     }
 
     const pending: PendingTransaction = {
@@ -541,7 +615,7 @@ async function processWalletMessage(session: ActiveSession, message: any) {
 
     pendingTransactions.push(pending);
     updateBadge();
-    log.debug('[background] Transaction pending approval:', pending.method);
+    log.debug("[background] Transaction pending approval:", pending.method);
 
     openPopupWithFallback();
     return;
@@ -549,23 +623,27 @@ async function processWalletMessage(session: ActiveSession, message: any) {
   // docs:end:approval-check
 
   // Capability requests require user approval — push to pending state.
-  if (message.type === 'requestCapabilities') {
+  if (message.type === "requestCapabilities") {
     // Auto-approve for trusted origins if the requested capabilities match what was previously granted
     const requestedManifest = message.args?.[0];
     const requestedCaps: any[] = requestedManifest?.capabilities || [];
     if (await isTrustedOrigin(session.origin, session.appId)) {
-      const savedCaps = await getStoredCapabilities(session.origin, session.appId);
+      const savedCaps = await getStoredCapabilities(
+        session.origin,
+        session.appId,
+      );
       if (savedCaps) {
         // Verify the requested capability types match the previously approved set
         const requestedTypes = requestedCaps.map((c: any) => c.type).sort();
         const savedTypes = savedCaps.map((c: any) => c.type).sort();
-        const capsMatch = requestedTypes.length === savedTypes.length &&
+        const capsMatch =
+          requestedTypes.length === savedTypes.length &&
           requestedTypes.every((t: string, i: number) => t === savedTypes[i]);
 
         if (capsMatch) {
           const grantedAccounts = await getGrantableAccounts();
           const granted = savedCaps.map((cap: any) => {
-            if (cap.type === 'accounts') {
+            if (cap.type === "accounts") {
               return { ...cap, accounts: grantedAccounts };
             }
             return { ...cap };
@@ -574,17 +652,25 @@ async function processWalletMessage(session: ActiveSession, message: any) {
           await handler.sendResponse(session.sessionId, {
             messageId: message.messageId,
             result: {
-              version: '1.0',
+              version: "1.0",
               granted,
-              wallet: { name: WALLET_CONFIG.walletName, version: WALLET_CONFIG.walletVersion },
+              wallet: {
+                name: WALLET_CONFIG.walletName,
+                version: WALLET_CONFIG.walletVersion,
+              },
             },
             walletId: WALLET_CONFIG.walletId,
           });
           capabilitiesApprovedSessions.add(session.sessionId);
-          log.debug('[background] Auto-approved capabilities for trusted origin:', session.origin);
+          log.debug(
+            "[background] Auto-approved capabilities for trusted origin:",
+            session.origin,
+          );
           return;
         }
-        log.debug('[background] Requested capabilities differ from saved — requiring approval');
+        log.debug(
+          "[background] Requested capabilities differ from saved — requiring approval",
+        );
       }
     }
 
@@ -594,7 +680,10 @@ async function processWalletMessage(session: ActiveSession, message: any) {
       sessionId: session.sessionId,
       messageId: message.messageId,
       origin: session.origin,
-      appMetadata: manifest?.metadata || { name: 'Unknown App', version: '0.0.0' },
+      appMetadata: manifest?.metadata || {
+        name: "Unknown App",
+        version: "0.0.0",
+      },
       capabilities: requestedCaps,
       timestamp: Date.now(),
     };
@@ -615,12 +704,19 @@ async function processWalletMessage(session: ActiveSession, message: any) {
     });
 
     // MetaMask-like behavior: return only the active account for getAccounts
-    if (message.type === 'getAccounts' || message.type === 'getRegisteredAccounts') {
-      const activeData = await chrome.storage.local.get(STORAGE_KEYS.ACTIVE_ACCOUNT);
+    if (
+      message.type === "getAccounts" ||
+      message.type === "getRegisteredAccounts"
+    ) {
+      const activeData = await chrome.storage.local.get(
+        STORAGE_KEYS.ACTIVE_ACCOUNT,
+      );
       const activeAddress = activeData[STORAGE_KEYS.ACTIVE_ACCOUNT];
       if (activeAddress && Array.isArray(result)) {
-        const activeAccount = result.find((acc: any) =>
-          acc.item === activeAddress || acc.item?.toString() === activeAddress
+        const activeAccount = result.find(
+          (acc: any) =>
+            acc.item === activeAddress ||
+            acc.item?.toString() === activeAddress,
         );
         result = activeAccount ? [activeAccount] : result;
       }
@@ -632,7 +728,11 @@ async function processWalletMessage(session: ActiveSession, message: any) {
       walletId: WALLET_CONFIG.walletId,
     });
   })().catch(async (error: any) => {
-    log.error('[background] Error handling wallet message:', message.type, error);
+    log.error(
+      "[background] Error handling wallet message:",
+      message.type,
+      error,
+    );
     await handler.sendResponse(session.sessionId, {
       messageId: message.messageId,
       error: error.message,
@@ -644,13 +744,22 @@ async function processWalletMessage(session: ActiveSession, message: any) {
 // docs:start:callbacks
 const callbacks: BackgroundConnectionCallbacks = {
   onPendingDiscovery: async (discovery) => {
-    log.debug('[background] Pending discovery:', discovery.requestId, 'from', discovery.origin);
+    log.debug(
+      "[background] Pending discovery:",
+      discovery.requestId,
+      "from",
+      discovery.origin,
+    );
 
     // Clean up stale sessions from this tab (e.g. page refresh creates a new
     // discovery while the old session is still in activeSessions).
     for (const session of handler.getActiveSessions()) {
       if (session.tabId === discovery.tabId) {
-        log.debug('[background] Terminating stale session for tab:', discovery.tabId, session.sessionId);
+        log.debug(
+          "[background] Terminating stale session for tab:",
+          discovery.tabId,
+          session.sessionId,
+        );
         capabilitiesApprovedSessions.delete(session.sessionId);
         queuedMessages.delete(session.sessionId);
         handler.terminateSession(session.sessionId);
@@ -658,16 +767,22 @@ const callbacks: BackgroundConnectionCallbacks = {
     }
 
     // Deduplicate: reject any existing discovery from the same tab
-    const existing = handler.getPendingDiscoveries().find(
-      (d) => d.tabId === discovery.tabId && d.requestId !== discovery.requestId
-    );
+    const existing = handler
+      .getPendingDiscoveries()
+      .find(
+        (d) =>
+          d.tabId === discovery.tabId && d.requestId !== discovery.requestId,
+      );
     if (existing) {
       handler.rejectDiscovery(existing.requestId);
     }
 
     // Auto-approve if origin is already trusted (reconnection after page refresh)
     if (await isTrustedOrigin(discovery.origin, discovery.appId)) {
-      log.debug('[background] Auto-approving trusted origin:', discovery.origin);
+      log.debug(
+        "[background] Auto-approving trusted origin:",
+        discovery.origin,
+      );
       handler.approveDiscovery(discovery.requestId);
       return;
     }
@@ -678,14 +793,20 @@ const callbacks: BackgroundConnectionCallbacks = {
   },
 
   onSessionEstablished: async (session: ActiveSession) => {
-    log.debug('[background] Session established:', session.sessionId);
+    log.debug("[background] Session established:", session.sessionId);
 
     // Auto-confirm if origin is already trusted (skip emoji verification)
     if (await isTrustedOrigin(session.origin, session.appId)) {
-      log.debug('[background] Auto-confirming trusted session:', session.sessionId);
+      log.debug(
+        "[background] Auto-confirming trusted session:",
+        session.sessionId,
+      );
 
       // Pre-approve capabilities if previously granted (enables seamless reconnect)
-      const savedCaps = await getStoredCapabilities(session.origin, session.appId);
+      const savedCaps = await getStoredCapabilities(
+        session.origin,
+        session.appId,
+      );
       if (savedCaps) {
         capabilitiesApprovedSessions.add(session.sessionId);
       }
@@ -701,7 +822,10 @@ const callbacks: BackgroundConnectionCallbacks = {
     }
 
     // New origin — require emoji verification
-    log.debug('[background] Awaiting emoji verification for:', session.sessionId);
+    log.debug(
+      "[background] Awaiting emoji verification for:",
+      session.sessionId,
+    );
     // SDK automatically removes the discovery when key exchange completes.
     // Show emojis in approvals so user can compare with the webapp
     pendingSessionVerifications.push({
@@ -730,15 +854,23 @@ const callbacks: BackgroundConnectionCallbacks = {
    * user must confirm before any dApp calls are processed.
    */
   onWalletMessage: async (session: ActiveSession, message: any) => {
-    log.debug('[background] Wallet message:', message.type, 'from session:', session.sessionId);
+    log.debug(
+      "[background] Wallet message:",
+      message.type,
+      "from session:",
+      session.sessionId,
+    );
 
     // Block wallet messages until the user confirms emoji verification in the extension.
     // The dApp's calls (e.g. getAccounts) will wait until the extension user approves.
     const awaitingVerification = pendingSessionVerifications.some(
-      (v) => v.sessionId === session.sessionId
+      (v) => v.sessionId === session.sessionId,
     );
     if (awaitingVerification) {
-      log.debug('[background] Session awaiting verification, queuing message:', message.type);
+      log.debug(
+        "[background] Session awaiting verification, queuing message:",
+        message.type,
+      );
       const queue = queuedMessages.get(session.sessionId) ?? [];
       queue.push({ session, message });
       queuedMessages.set(session.sessionId, queue);
@@ -751,7 +883,11 @@ const callbacks: BackgroundConnectionCallbacks = {
 };
 // docs:end:callbacks
 
-const handler = new BackgroundConnectionHandler(WALLET_CONFIG, transport, callbacks);
+const handler = new BackgroundConnectionHandler(
+  { ...WALLET_CONFIG, logger: log },
+  transport,
+  callbacks,
+);
 handler.initialize();
 
 // Clean up sessions when a tab is closed
@@ -774,27 +910,39 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
    * Storage proxy for the offscreen document. (#7)
    * Validates that the request comes from the extension itself (not content scripts or external).
    */
-  if (message.type === 'storage-get' || message.type === 'storage-set') {
+  if (message.type === "storage-get" || message.type === "storage-set") {
     // Security: only allow storage proxy from extension pages (offscreen, popup) (#7)
     // Content scripts have sender.tab set; extension pages (offscreen, popup) do not.
     if (sender.tab) {
-      log.warn('[background] Rejected storage proxy from content script, tab:', sender.tab.id);
-      sendResponse({ success: false, error: 'Storage proxy not allowed from content scripts' });
+      log.warn(
+        "[background] Rejected storage proxy from content script, tab:",
+        sender.tab.id,
+      );
+      sendResponse({
+        success: false,
+        error: "Storage proxy not allowed from content scripts",
+      });
       return false;
     }
 
-    if (message.type === 'storage-get') {
-      chrome.storage.local.get(message.key).then((result) => {
-        sendResponse({ success: true, result: result[message.key] });
-      }).catch((err) => {
-        sendResponse({ success: false, error: err.message });
-      });
+    if (message.type === "storage-get") {
+      chrome.storage.local
+        .get(message.key)
+        .then((result) => {
+          sendResponse({ success: true, result: result[message.key] });
+        })
+        .catch((err) => {
+          sendResponse({ success: false, error: err.message });
+        });
     } else {
-      chrome.storage.local.set(message.data).then(() => {
-        sendResponse({ success: true });
-      }).catch((err) => {
-        sendResponse({ success: false, error: err.message });
-      });
+      chrome.storage.local
+        .set(message.data)
+        .then(() => {
+          sendResponse({ success: true });
+        })
+        .catch((err) => {
+          sendResponse({ success: false, error: err.message });
+        });
     }
     return true; // async response (#23)
   }
@@ -803,7 +951,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     return false;
   }
 
-  log.debug('[background] Popup message:', message.type);
+  log.debug("[background] Popup message:", message.type);
 
   // Reset auto-lock on any popup interaction (#28)
   resetAutoLockTimer();
@@ -825,37 +973,38 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 
     case MessageTypes.APPROVE_TRANSACTION: {
       const pending = pendingTransactions.find(
-        (t) => t.messageId === message.messageId
+        (t) => t.messageId === message.messageId,
       );
       if (pending) {
         pendingTransactions = pendingTransactions.filter(
-          (t) => t.messageId !== message.messageId
+          (t) => t.messageId !== message.messageId,
         );
         updateBadge();
 
-        const taskId = startBackgroundTask(`tx:${pending.method}`,
-          handleTransactionApproval(pending)
+        const taskId = startBackgroundTask(
+          `tx:${pending.method}`,
+          handleTransactionApproval(pending),
         );
         sendResponse({ success: true, result: { taskId } });
       } else {
-        sendResponse({ success: false, error: 'Transaction not found' });
+        sendResponse({ success: false, error: "Transaction not found" });
       }
       return false;
     }
 
     case MessageTypes.REJECT_TRANSACTION: {
       const pending = pendingTransactions.find(
-        (t) => t.messageId === message.messageId
+        (t) => t.messageId === message.messageId,
       );
       if (pending) {
         handler.sendResponse(pending.sessionId, {
           messageId: pending.messageId,
-          error: 'Transaction rejected by user',
+          error: "Transaction rejected by user",
           walletId: WALLET_CONFIG.walletId,
         });
 
         pendingTransactions = pendingTransactions.filter(
-          (t) => t.messageId !== message.messageId
+          (t) => t.messageId !== message.messageId,
         );
         updateBadge();
       }
@@ -865,56 +1014,67 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 
     case MessageTypes.APPROVE_CAPABILITIES: {
       const pending = pendingCapabilities.find(
-        (c) => c.messageId === message.messageId
+        (c) => c.messageId === message.messageId,
       );
       if (pending) {
         pendingCapabilities = pendingCapabilities.filter(
-          (c) => c.messageId !== message.messageId
+          (c) => c.messageId !== message.messageId,
         );
 
         // Build granted capabilities using the shared active-account helper
-        getGrantableAccounts().then((grantedAccounts) => {
-          const granted = pending.capabilities.map((cap: any) => {
-            if (cap.type === 'accounts') {
-              return { ...cap, accounts: grantedAccounts };
-            }
-            return { ...cap };
-          });
+        getGrantableAccounts()
+          .then((grantedAccounts) => {
+            const granted = pending.capabilities.map((cap: any) => {
+              if (cap.type === "accounts") {
+                return { ...cap, accounts: grantedAccounts };
+              }
+              return { ...cap };
+            });
 
-          return handler.sendResponse(pending.sessionId, {
-            messageId: pending.messageId,
-            result: {
-              version: '1.0',
-              granted,
-              wallet: {
-                name: WALLET_CONFIG.walletName,
-                version: WALLET_CONFIG.walletVersion,
+            return handler.sendResponse(pending.sessionId, {
+              messageId: pending.messageId,
+              result: {
+                version: "1.0",
+                granted,
+                wallet: {
+                  name: WALLET_CONFIG.walletName,
+                  version: WALLET_CONFIG.walletVersion,
+                },
               },
-            },
-            walletId: WALLET_CONFIG.walletId,
-          });
-        }).then(async () => {
-          capabilitiesApprovedSessions.add(pending.sessionId);
+              walletId: WALLET_CONFIG.walletId,
+            });
+          })
+          .then(async () => {
+            capabilitiesApprovedSessions.add(pending.sessionId);
 
-          // Persist granted capabilities for auto-reconnect
-          const approvedSession = handler.getSession(pending.sessionId);
-          if (approvedSession) {
-            const trusted = await getTrustedOrigins();
-            const entry = trusted.find(t => t.origin === approvedSession.origin && t.appId === approvedSession.appId);
-            if (entry) {
-              entry.grantedCapabilities = pending.capabilities.map((cap: any) => ({ ...cap }));
-              await chrome.storage.local.set({ [TRUSTED_ORIGINS_KEY]: trusted });
+            // Persist granted capabilities for auto-reconnect
+            const approvedSession = handler.getSession(pending.sessionId);
+            if (approvedSession) {
+              const trusted = await getTrustedOrigins();
+              const entry = trusted.find(
+                (t) =>
+                  t.origin === approvedSession.origin &&
+                  t.appId === approvedSession.appId,
+              );
+              if (entry) {
+                entry.grantedCapabilities = pending.capabilities.map(
+                  (cap: any) => ({ ...cap }),
+                );
+                await chrome.storage.local.set({
+                  [TRUSTED_ORIGINS_KEY]: trusted,
+                });
+              }
             }
-          }
 
-          updateBadge();
-          sendResponse({ success: true });
-        }).catch((err) => {
-          log.error('[background] Failed to approve capabilities:', err);
-          sendResponse({ success: false, error: getErrorMessage(err) });
-        });
+            updateBadge();
+            sendResponse({ success: true });
+          })
+          .catch((err) => {
+            log.error("[background] Failed to approve capabilities:", err);
+            sendResponse({ success: false, error: getErrorMessage(err) });
+          });
       } else {
-        sendResponse({ success: false, error: 'Capability request not found' });
+        sendResponse({ success: false, error: "Capability request not found" });
         return false;
       }
       return true;
@@ -922,17 +1082,17 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 
     case MessageTypes.REJECT_CAPABILITIES: {
       const pending = pendingCapabilities.find(
-        (c) => c.messageId === message.messageId
+        (c) => c.messageId === message.messageId,
       );
       if (pending) {
         pendingCapabilities = pendingCapabilities.filter(
-          (c) => c.messageId !== message.messageId
+          (c) => c.messageId !== message.messageId,
         );
 
         handler.sendResponse(pending.sessionId, {
           messageId: pending.messageId,
           result: {
-            version: '1.0',
+            version: "1.0",
             granted: [],
             wallet: {
               name: WALLET_CONFIG.walletName,
@@ -952,12 +1112,12 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
       // User confirmed emojis match — session is now fully active.
       // Flush any wallet messages that were queued while awaiting verification.
       pendingSessionVerifications = pendingSessionVerifications.filter(
-        (v) => v.sessionId !== message.sessionId
+        (v) => v.sessionId !== message.sessionId,
       );
       const queued = queuedMessages.get(message.sessionId) ?? [];
       queuedMessages.delete(message.sessionId);
       for (const { session, message: msg } of queued) {
-        log.debug('[background] Flushing queued message:', msg.type);
+        log.debug("[background] Flushing queued message:", msg.type);
         processWalletMessage(session, msg);
       }
 
@@ -975,14 +1135,14 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     case MessageTypes.REJECT_SESSION: {
       // User rejected emoji verification — reject queued messages and terminate the session.
       pendingSessionVerifications = pendingSessionVerifications.filter(
-        (v) => v.sessionId !== message.sessionId
+        (v) => v.sessionId !== message.sessionId,
       );
       const rejected = queuedMessages.get(message.sessionId) ?? [];
       queuedMessages.delete(message.sessionId);
       for (const { session, message: msg } of rejected) {
         handler.sendResponse(session.sessionId, {
           messageId: msg.messageId,
-          error: 'Session verification rejected by user',
+          error: "Session verification rejected by user",
           walletId: WALLET_CONFIG.walletId,
         });
       }
@@ -997,7 +1157,10 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
       // Remove from trusted origins so next connection requires full approval (#30)
       const disconnectedSession = handler.getSession(message.sessionId);
       if (disconnectedSession) {
-        removeTrustedOrigin(disconnectedSession.origin, disconnectedSession.appId);
+        removeTrustedOrigin(
+          disconnectedSession.origin,
+          disconnectedSession.appId,
+        );
       }
       capabilitiesApprovedSessions.delete(message.sessionId);
       handler.terminateSession(message.sessionId);
@@ -1006,7 +1169,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
       return false;
     }
 
-    case 'getPendingItems': {
+    case "getPendingItems": {
       sendResponse({
         success: true,
         result: getFullState(),
@@ -1015,37 +1178,52 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     }
 
     case MessageTypes.GET_ACCOUNTS: {
-      chrome.storage.local.get(STORAGE_KEYS.ACCOUNTS)
+      chrome.storage.local
+        .get(STORAGE_KEYS.ACCOUNTS)
         .then((data) => {
-          const accounts = (data[STORAGE_KEYS.ACCOUNTS] || []).map((acc: any) => ({
-            address: acc.address,
-            alias: acc.alias,
-            isDeployed: acc.isDeployed,
-          }));
+          const accounts = (data[STORAGE_KEYS.ACCOUNTS] || []).map(
+            (acc: any) => ({
+              address: acc.address,
+              alias: acc.alias,
+              isDeployed: acc.isDeployed,
+            }),
+          );
           sendResponse({ success: true, result: accounts });
         })
-        .catch((error) => sendResponse({ success: false, error: error.message }));
+        .catch((error) =>
+          sendResponse({ success: false, error: error.message }),
+        );
       return true; // async (#23)
     }
 
     case MessageTypes.GET_ACTIVE_ACCOUNT: {
-      chrome.storage.local.get(STORAGE_KEYS.ACTIVE_ACCOUNT)
+      chrome.storage.local
+        .get(STORAGE_KEYS.ACTIVE_ACCOUNT)
         .then((data) => {
-          sendResponse({ success: true, result: data[STORAGE_KEYS.ACTIVE_ACCOUNT] || null });
+          sendResponse({
+            success: true,
+            result: data[STORAGE_KEYS.ACTIVE_ACCOUNT] || null,
+          });
         })
-        .catch((error) => sendResponse({ success: false, error: error.message }));
+        .catch((error) =>
+          sendResponse({ success: false, error: error.message }),
+        );
       return true;
     }
 
     case MessageTypes.SET_ACTIVE_ACCOUNT: {
-      chrome.storage.local.set({ [STORAGE_KEYS.ACTIVE_ACCOUNT]: message.address })
+      chrome.storage.local
+        .set({ [STORAGE_KEYS.ACTIVE_ACCOUNT]: message.address })
         .then(() => sendResponse({ success: true }))
-        .catch((error) => sendResponse({ success: false, error: error.message }));
+        .catch((error) =>
+          sendResponse({ success: false, error: error.message }),
+        );
       return true;
     }
 
     case MessageTypes.UNLOCK_WALLET: {
-      const taskId = startBackgroundTask('unlock',
+      const taskId = startBackgroundTask(
+        "unlock",
         sendToOffscreen({
           type: MessageTypes.UNLOCK_WALLET,
           password: message.password,
@@ -1054,14 +1232,15 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
           persistState();
           resetAutoLockTimer();
           return result;
-        })
+        }),
       );
       sendResponse({ success: true, result: { taskId } });
       return false;
     }
 
     case MessageTypes.GET_WALLET_STATUS: {
-      chrome.storage.local.get(STORAGE_KEYS.PASSWORD_DATA)
+      chrome.storage.local
+        .get(STORAGE_KEYS.PASSWORD_DATA)
         .then((data) => {
           sendResponse({
             success: true,
@@ -1071,12 +1250,15 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
             },
           });
         })
-        .catch((error) => sendResponse({ success: false, error: error.message }));
+        .catch((error) =>
+          sendResponse({ success: false, error: error.message }),
+        );
       return true;
     }
 
     case MessageTypes.SETUP_PASSWORD: {
-      const taskId = startBackgroundTask('setup-password',
+      const taskId = startBackgroundTask(
+        "setup-password",
         sendToOffscreen({
           type: MessageTypes.SETUP_PASSWORD,
           password: message.password,
@@ -1085,52 +1267,62 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
           persistState();
           resetAutoLockTimer();
           return result;
-        })
+        }),
       );
       sendResponse({ success: true, result: { taskId } });
       return false;
     }
 
     case MessageTypes.MARK_DEPLOYED: {
-      chrome.storage.local.get(STORAGE_KEYS.ACCOUNTS)
+      chrome.storage.local
+        .get(STORAGE_KEYS.ACCOUNTS)
         .then((data) => {
           const accounts = data[STORAGE_KEYS.ACCOUNTS] || [];
-          const account = accounts.find((a: any) => a.address === message.address);
+          const account = accounts.find(
+            (a: any) => a.address === message.address,
+          );
           if (account) {
             account.isDeployed = true;
-            return chrome.storage.local.set({ [STORAGE_KEYS.ACCOUNTS]: accounts });
+            return chrome.storage.local.set({
+              [STORAGE_KEYS.ACCOUNTS]: accounts,
+            });
           }
         })
         .then(() => sendResponse({ success: true, result: { success: true } }))
-        .catch((error) => sendResponse({ success: false, error: error.message }));
+        .catch((error) =>
+          sendResponse({ success: false, error: error.message }),
+        );
       return true;
     }
 
     case MessageTypes.CREATE_ACCOUNT: {
-      const taskId = startBackgroundTask('create-account',
+      const taskId = startBackgroundTask(
+        "create-account",
         sendToOffscreen({
           type: MessageTypes.CREATE_ACCOUNT,
           alias: message.alias,
-        })
+        }),
       );
       sendResponse({ success: true, result: { taskId } });
       return false;
     }
 
     case MessageTypes.DEPLOY_ACCOUNT: {
-      const taskId = startBackgroundTask('deploy-account',
+      const taskId = startBackgroundTask(
+        "deploy-account",
         sendToOffscreen({
           type: MessageTypes.DEPLOY_ACCOUNT,
           address: message.address,
-        })
+        }),
       );
       sendResponse({ success: true, result: { taskId } });
       return false;
     }
 
     case MessageTypes.EXPORT_WALLET: {
-      const taskId = startBackgroundTask('export-wallet',
-        sendToOffscreen({ type: MessageTypes.EXPORT_WALLET })
+      const taskId = startBackgroundTask(
+        "export-wallet",
+        sendToOffscreen({ type: MessageTypes.EXPORT_WALLET }),
       );
       sendResponse({ success: true, result: { taskId } });
       return false;
@@ -1138,7 +1330,11 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 
     case MessageTypes.IMPORT_WALLET: {
       // Wipe wallet data from chrome.storage.local and lock the wallet
-      chrome.storage.local.remove([STORAGE_KEYS.ACCOUNTS, STORAGE_KEYS.PASSWORD_DATA, STORAGE_KEYS.ACTIVE_ACCOUNT]);
+      chrome.storage.local.remove([
+        STORAGE_KEYS.ACCOUNTS,
+        STORAGE_KEYS.PASSWORD_DATA,
+        STORAGE_KEYS.ACTIVE_ACCOUNT,
+      ]);
       walletUnlocked = false;
       persistState();
       // Tell offscreen to clear cached key
@@ -1148,7 +1344,8 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     }
 
     case MessageTypes.IMPORT_WALLET_ACCOUNTS: {
-      const taskId = startBackgroundTask('import-wallet-accounts',
+      const taskId = startBackgroundTask(
+        "import-wallet-accounts",
         sendToOffscreen({
           type: MessageTypes.IMPORT_WALLET_ACCOUNTS,
           accounts: message.accounts,
@@ -1158,21 +1355,21 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
           persistState();
           resetAutoLockTimer();
           return result;
-        })
+        }),
       );
       sendResponse({ success: true, result: { taskId } });
       return false;
     }
 
     default: {
-      log.warn('[background] Unknown message type:', message.type);
+      log.warn("[background] Unknown message type:", message.type);
       return false;
     }
   }
 });
 
 async function handleTransactionApproval(
-  pending: PendingTransaction
+  pending: PendingTransaction,
 ): Promise<any> {
   try {
     const result = await sendToOffscreen({
@@ -1189,7 +1386,11 @@ async function handleTransactionApproval(
 
     return result;
   } catch (error: any) {
-    log.error('[background] Transaction approval failed:', pending.method, error);
+    log.error(
+      "[background] Transaction approval failed:",
+      pending.method,
+      error,
+    );
     await handler.sendResponse(pending.sessionId, {
       messageId: pending.messageId,
       error: error.message,
@@ -1204,7 +1405,7 @@ async function handleTransactionApproval(
  * Extension lifecycle handlers. (#17)
  */
 chrome.runtime.onInstalled.addListener((details) => {
-  log.debug('[background] Extension installed/updated:', details.reason);
+  log.debug("[background] Extension installed/updated:", details.reason);
 
   // Clear stale pending state — sessions don't survive extension reload
   pendingTransactions = [];
@@ -1214,23 +1415,28 @@ chrome.runtime.onInstalled.addListener((details) => {
   capabilitiesApprovedSessions.clear();
   persistState();
 
-  if (details.reason === 'install') {
+  if (details.reason === "install") {
     // First install — nothing to migrate
-    log.debug('[background] First install, no migration needed');
-  } else if (details.reason === 'update') {
+    log.debug("[background] First install, no migration needed");
+  } else if (details.reason === "update") {
     // Version update — could add migration logic here
-    log.debug('[background] Updated from', details.previousVersion);
+    log.debug("[background] Updated from", details.previousVersion);
   }
 });
 
 // Restore state on service worker startup (#8)
 restoreState().then(() => {
-  log.debug('[background] Service worker initialized');
+  log.debug("[background] Service worker initialized");
 });
 
 // Eagerly preload the offscreen document so WASM and PXE deps are warm
-ensureOffscreenDocument().then(() => {
-  log.debug('[background] Offscreen document preloaded');
-}).catch((err) => {
-  log.error('[background] Offscreen preload failed (will retry on demand):', err);
-});
+ensureOffscreenDocument()
+  .then(() => {
+    log.debug("[background] Offscreen document preloaded");
+  })
+  .catch((err) => {
+    log.error(
+      "[background] Offscreen preload failed (will retry on demand):",
+      err,
+    );
+  });

--- a/yarn-project/wallet-sdk/src/extension/handlers/background_connection_handler.ts
+++ b/yarn-project/wallet-sdk/src/extension/handlers/background_connection_handler.ts
@@ -17,6 +17,7 @@ import {
   type WalletMessage,
   WalletMessageType,
   type WalletResponse,
+  type WalletSdkLogger,
 } from '../../types.js';
 import {
   type BackgroundMessage,
@@ -131,6 +132,8 @@ export interface BackgroundConnectionConfig {
   walletVersion: string;
   /** Optional wallet icon URL. */
   walletIcon?: string;
+  /** Logger used for diagnostics. */
+  logger: WalletSdkLogger;
 }
 
 /**
@@ -149,6 +152,7 @@ export interface BackgroundConnectionConfig {
  *     walletId: 'my-wallet',
  *     walletName: 'My Wallet',
  *     walletVersion: '1.0.0',
+ *     logger: console,
  *   },
  *   {
  *     sendToTab: (tabId, message) => browser.tabs.sendMessage(tabId, message),
@@ -167,12 +171,15 @@ export interface BackgroundConnectionConfig {
 export class BackgroundConnectionHandler {
   private pendingDiscoveries = new Map<string, PendingDiscovery>();
   private activeSessions = new Map<string, ActiveSession>();
+  private log: WalletSdkLogger;
 
   constructor(
     private config: BackgroundConnectionConfig,
     private transport: BackgroundTransport,
     private callbacks: BackgroundConnectionCallbacks = {},
-  ) {}
+  ) {
+    this.log = config.logger;
+  }
 
   initialize(): void {
     this.transport.addContentListener(this.handleMessage);
@@ -198,8 +205,8 @@ export class BackgroundConnectionHandler {
         break;
       case InternalMessageType.KEY_EXCHANGE_REQUEST:
         if (sessionId) {
-          this.handleKeyExchangeRequest(sessionId, content as KeyExchangeRequest).catch(() => {
-            // Key exchange failed - session won't be established
+          this.handleKeyExchangeRequest(sessionId, content as KeyExchangeRequest).catch(err => {
+            this.log.warn('Key exchange failed — session will not be established', { sessionId, err });
           });
         }
         break;
@@ -213,8 +220,30 @@ export class BackgroundConnectionHandler {
           void this.handleEncryptedMessage(sessionId, content as EncryptedPayload);
         }
         break;
+      case InternalMessageType.PING:
+        if (sessionId) {
+          this.handlePing(sessionId);
+        }
+        break;
     }
   };
+
+  /**
+   * Reply to a dApp PING with a PONG. Used as a liveness probe so the dApp can
+   * tell the difference between a slow request and a dead extension.
+   * @param sessionId - The session that sent the PING.
+   */
+  private handlePing(sessionId: string): void {
+    const session = this.activeSessions.get(sessionId);
+    if (!session) {
+      return;
+    }
+    this.transport.sendToTab(session.tabId, {
+      origin: MessageOrigin.BACKGROUND,
+      type: InternalMessageType.PONG,
+      sessionId,
+    });
+  }
 
   getWalletInfo(): WalletInfo {
     return {
@@ -315,8 +344,8 @@ export class BackgroundConnectionHandler {
       });
 
       this.callbacks.onSessionEstablished?.(session);
-    } catch {
-      // Key exchange failed silently - session won't be established
+    } catch (err) {
+      this.log.warn('Key exchange failed — session will not be established', { sessionId, err });
     }
   }
 
@@ -329,8 +358,8 @@ export class BackgroundConnectionHandler {
     try {
       const message = await decrypt<WalletMessage>(session.sharedKey, encrypted);
       this.callbacks.onWalletMessage?.(session, message);
-    } catch {
-      // Decryption failed - ignore malformed message
+    } catch (err) {
+      this.log.warn('Failed to decrypt incoming wallet message', { sessionId, err });
     }
   }
 
@@ -348,8 +377,12 @@ export class BackgroundConnectionHandler {
         sessionId,
         content: encrypted,
       });
-    } catch {
-      // Encryption failed - response won't be sent
+    } catch (err) {
+      this.log.error('Failed to encrypt wallet response — response will not be sent', {
+        sessionId,
+        messageId: response.messageId,
+        err,
+      });
     }
   }
 

--- a/yarn-project/wallet-sdk/src/extension/handlers/content_script_connection_handler.ts
+++ b/yarn-project/wallet-sdk/src/extension/handlers/content_script_connection_handler.ts
@@ -139,8 +139,19 @@ export class ContentScriptConnectionHandler {
       case InternalMessageType.SESSION_DISCONNECTED:
         this.handleSessionDisconnected(sessionId);
         break;
+      case InternalMessageType.PONG:
+        this.handlePong(sessionId);
+        break;
     }
   };
+
+  private handlePong(sessionId: string): void {
+    const connection = this.ports.get(sessionId);
+    if (!connection) {
+      return;
+    }
+    connection.port.postMessage({ type: WalletMessageType.PONG });
+  }
 
   private handleDiscoveryRequest(request: DiscoveryRequest): void {
     this.transport.sendToBackground({
@@ -176,6 +187,13 @@ export class ContentScriptConnectionHandler {
             type: InternalMessageType.DISCONNECT_REQUEST,
             sessionId,
             content: data,
+          });
+          break;
+        case WalletMessageType.PING:
+          this.transport.sendToBackground({
+            origin: MessageOrigin.CONTENT_SCRIPT,
+            type: InternalMessageType.PING,
+            sessionId,
           });
           break;
         default:

--- a/yarn-project/wallet-sdk/src/extension/handlers/internal_message_types.ts
+++ b/yarn-project/wallet-sdk/src/extension/handlers/internal_message_types.ts
@@ -9,11 +9,13 @@ export const InternalMessageType = {
   KEY_EXCHANGE_REQUEST: 'key-exchange-request',
   SECURE_MESSAGE: 'secure-message',
   DISCONNECT_REQUEST: 'disconnect-request',
+  PING: 'ping',
   // Background → Content script
   DISCOVERY_APPROVED: 'discovery-approved',
   KEY_EXCHANGE_RESPONSE: 'key-exchange-response',
   SECURE_RESPONSE: 'secure-response',
   SESSION_DISCONNECTED: 'session-disconnected',
+  PONG: 'pong',
 } as const;
 
 /**

--- a/yarn-project/wallet-sdk/src/extension/provider/extension_wallet.test.ts
+++ b/yarn-project/wallet-sdk/src/extension/provider/extension_wallet.test.ts
@@ -1,0 +1,153 @@
+import type { ChainInfo } from '@aztec/aztec.js/account';
+import { Fr } from '@aztec/foundation/curves/bn254';
+import { jsonStringify } from '@aztec/foundation/json-rpc';
+import { promiseWithResolvers } from '@aztec/foundation/promise';
+import { sleep } from '@aztec/foundation/sleep';
+
+import {
+  type EncryptedPayload,
+  decrypt,
+  deriveSessionKeys,
+  encrypt,
+  exportPublicKey,
+  generateKeyPair,
+  importPublicKey,
+} from '../../crypto.js';
+import { type WalletMessage, WalletMessageType, type WalletResponse } from '../../types.js';
+import { ExtensionWallet } from './extension_wallet.js';
+
+async function makeSharedKeys(): Promise<{ appKey: CryptoKey; walletKey: CryptoKey }> {
+  const appPair = await generateKeyPair();
+  const walletPair = await generateKeyPair();
+
+  const appPub = await exportPublicKey(appPair.publicKey);
+  const walletPub = await exportPublicKey(walletPair.publicKey);
+
+  const appSession = await deriveSessionKeys(appPair, await importPublicKey(walletPub), true);
+  const walletSession = await deriveSessionKeys(walletPair, await importPublicKey(appPub), false);
+
+  return { appKey: appSession.encryptionKey, walletKey: walletSession.encryptionKey };
+}
+
+const chainInfo: ChainInfo = { chainId: new Fr(1), version: new Fr(1) };
+
+// Tight heartbeat tuning so tests run quickly. Real defaults (5s/300s) would take
+// a minute per test.
+const FAST_HEARTBEAT = { intervalMs: 50, deadAfterMs: 250 };
+
+describe('ExtensionWallet heartbeat', () => {
+  it('treats PONG as proof of liveness — no false disconnect on slow but alive peer', async () => {
+    const { appKey, walletKey } = await makeSharedKeys();
+    const channel = new MessageChannel();
+    const walletId = 'test-wallet';
+
+    const requestArrived = promiseWithResolvers<WalletMessage>();
+    let pongs = 0;
+
+    channel.port2.onmessage = async (event: MessageEvent) => {
+      const data = event.data;
+      if (data?.type === WalletMessageType.PING) {
+        pongs++;
+        channel.port2.postMessage({ type: WalletMessageType.PONG });
+        return;
+      }
+      const decoded = await decrypt<WalletMessage>(walletKey, data as EncryptedPayload);
+      requestArrived.resolve(decoded);
+    };
+    channel.port2.start();
+
+    const extWallet = ExtensionWallet.create(
+      walletId,
+      channel.port1,
+      appKey,
+      chainInfo,
+      'test-app',
+      undefined,
+      FAST_HEARTBEAT,
+    );
+    const wallet = extWallet.asWallet();
+
+    const pending = wallet.getChainInfo();
+    pending.catch(() => {});
+    const message = await requestArrived.promise;
+
+    // Let several heartbeat ticks fire while the peer responds with PONGs only —
+    // no real response yet. This is the slow-but-alive-wallet scenario. Wait
+    // ~3× the dead-after window to prove that PONGs alone keep the channel alive.
+    await sleep(FAST_HEARTBEAT.deadAfterMs * 3);
+
+    expect(pongs).toBeGreaterThan(0);
+    expect(extWallet.isDisconnected()).toBe(false);
+
+    // Now have the wallet respond. The dApp must settle the promise — the channel
+    // is alive. We send an error to avoid having to construct a schema-valid
+    // result object; what matters here is that the in-flight promise *settles*
+    // rather than hanging forever after the heartbeat-eligible window passes.
+    const response: WalletResponse = {
+      messageId: message.messageId,
+      error: 'simulated wallet response',
+      walletId,
+    };
+    const encrypted = await encrypt(walletKey, jsonStringify(response));
+    // Wallet side posts on port2 so the dApp receives on port1.
+    channel.port2.postMessage(encrypted);
+
+    await expect(pending).rejects.toThrow(/simulated/);
+
+    channel.port1.close();
+    channel.port2.close();
+  });
+
+  it('declares disconnect when the channel is fully silent past the dead window', async () => {
+    const { appKey } = await makeSharedKeys();
+    const channel = new MessageChannel();
+    // Deliberately do NOT wire up port2 — peer is fully unresponsive.
+    channel.port2.start();
+
+    const extWallet = ExtensionWallet.create(
+      'dead-wallet',
+      channel.port1,
+      appKey,
+      chainInfo,
+      'test-app',
+      undefined,
+      FAST_HEARTBEAT,
+    );
+    const wallet = extWallet.asWallet();
+
+    let disconnected = false;
+    extWallet.onDisconnect(() => {
+      disconnected = true;
+    });
+
+    const pending = wallet.getChainInfo();
+
+    await expect(pending).rejects.toThrow(/disconnected/i);
+    expect(disconnected).toBe(true);
+    expect(extWallet.isDisconnected()).toBe(true);
+
+    channel.port2.close();
+  });
+
+  it('does not start a heartbeat when there are no in-flight requests', async () => {
+    const { appKey } = await makeSharedKeys();
+    const channel = new MessageChannel();
+
+    let pings = 0;
+    channel.port2.onmessage = (event: MessageEvent) => {
+      if (event.data?.type === WalletMessageType.PING) {
+        pings++;
+      }
+    };
+    channel.port2.start();
+
+    ExtensionWallet.create('idle-wallet', channel.port1, appKey, chainInfo, 'test-app', undefined, FAST_HEARTBEAT);
+
+    await sleep(150);
+
+    expect(pings).toBe(0);
+
+    channel.port1.close();
+    channel.port2.close();
+  });
+});

--- a/yarn-project/wallet-sdk/src/extension/provider/extension_wallet.ts
+++ b/yarn-project/wallet-sdk/src/extension/provider/extension_wallet.ts
@@ -6,7 +6,17 @@ import { schemaHasMethod } from '@aztec/foundation/schemas';
 import type { FunctionsOf } from '@aztec/foundation/types';
 
 import { type EncryptedPayload, decrypt, encrypt } from '../../crypto.js';
-import { type DisconnectCallback, type WalletMessage, WalletMessageType, type WalletResponse } from '../../types.js';
+import {
+  DEFAULT_HEARTBEAT_DEAD_AFTER_MS,
+  DEFAULT_HEARTBEAT_INTERVAL_MS,
+  type DisconnectCallback,
+  type HeartbeatOptions,
+  NOOP_LOGGER,
+  type WalletMessage,
+  WalletMessageType,
+  type WalletResponse,
+  type WalletSdkLogger,
+} from '../../types.js';
 
 /**
  * Internal type representing a wallet method call before encryption.
@@ -55,6 +65,11 @@ export class ExtensionWallet {
   private inFlight = new Map<string, PromiseWithResolvers<unknown>>();
   private disconnected = false;
   private disconnectCallbacks: DisconnectCallback[] = [];
+  private heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+  private lastInboundAt = 0;
+  private log: WalletSdkLogger;
+  private heartbeatIntervalMs: number;
+  private heartbeatDeadAfterMs: number;
 
   /**
    * Private constructor - use {@link ExtensionWallet.create} to instantiate.
@@ -63,6 +78,8 @@ export class ExtensionWallet {
    * @param extensionId - The unique identifier of the target wallet extension
    * @param port - The MessagePort for private communication with the wallet
    * @param sharedKey - The derived AES-256-GCM shared key for encryption
+   * @param logger - Optional logger; defaults to a no-op logger
+   * @param heartbeatOptions - Optional heartbeat tuning (mostly useful for tests)
    */
   private constructor(
     private chainInfo: ChainInfo,
@@ -70,7 +87,13 @@ export class ExtensionWallet {
     private extensionId: string,
     private port: MessagePort,
     private sharedKey: CryptoKey,
-  ) {}
+    logger?: WalletSdkLogger,
+    heartbeatOptions?: HeartbeatOptions,
+  ) {
+    this.log = logger ?? NOOP_LOGGER;
+    this.heartbeatIntervalMs = heartbeatOptions?.intervalMs ?? DEFAULT_HEARTBEAT_INTERVAL_MS;
+    this.heartbeatDeadAfterMs = heartbeatOptions?.deadAfterMs ?? DEFAULT_HEARTBEAT_DEAD_AFTER_MS;
+  }
 
   /**
    * Creates a Wallet that communicates with a browser extension
@@ -81,6 +104,8 @@ export class ExtensionWallet {
    * @param sharedKey - The derived AES-256-GCM shared key for encryption
    * @param chainInfo - The chain information (chainId and version) for request context
    * @param appId - Application identifier used to identify the requesting dApp to the wallet
+   * @param logger - Optional logger; defaults to a no-op logger to keep extension/page bundles small
+   * @param heartbeatOptions - Optional override for heartbeat tuning (mostly useful for tests)
    * @returns A Wallet interface where all method calls are encrypted
    *
    * @example
@@ -104,13 +129,17 @@ export class ExtensionWallet {
     sharedKey: CryptoKey,
     chainInfo: ChainInfo,
     appId: string,
+    logger?: WalletSdkLogger,
+    heartbeatOptions?: HeartbeatOptions,
   ): ExtensionWallet {
-    const wallet = new ExtensionWallet(chainInfo, appId, extensionId, port, sharedKey);
+    const wallet = new ExtensionWallet(chainInfo, appId, extensionId, port, sharedKey, logger, heartbeatOptions);
 
     // Set up message handler for encrypted responses and unencrypted control messages
     wallet.port.onmessage = (event: MessageEvent) => {
       const data = event.data;
-      // Check for unencrypted disconnect notification
+      // Any inbound traffic counts as proof of liveness.
+      wallet.lastInboundAt = Date.now();
+
       if (data && typeof data === 'object' && 'type' in data && data.type === WalletMessageType.DISCONNECT) {
         wallet.handleDisconnect();
         return;
@@ -184,8 +213,10 @@ export class ExtensionWallet {
         resolve(result);
       }
       this.inFlight.delete(messageId);
-      // eslint-disable-next-line no-empty
-    } catch {}
+      this.maybeStopHeartbeat();
+    } catch (err) {
+      this.log.warn('Failed to decrypt wallet response', { err });
+    }
   }
 
   /**
@@ -223,7 +254,57 @@ export class ExtensionWallet {
 
     const { promise, resolve, reject } = promiseWithResolvers<unknown>();
     this.inFlight.set(messageId, { promise, resolve, reject });
+    this.startHeartbeat();
     return promise;
+  }
+
+  /**
+   * Start the heartbeat probe loop while at least one request is in flight.
+   * Idempotent — calling while already running is a no-op.
+   *
+   * Heartbeat is opt-in via wire protocol: PINGs are unencrypted control messages
+   * (like DISCONNECT). Older wallets that do not understand PING simply drop it,
+   * which is safe — we only declare disconnect when **no** inbound traffic of any
+   * kind (PONG, encrypted response, DISCONNECT) arrives within the dead window.
+   * A wallet that is processing a slow request will reset the timer when it
+   * eventually responds, so this never causes false disconnects on legacy peers.
+   */
+  private startHeartbeat(): void {
+    if (this.heartbeatTimer !== null || this.disconnected) {
+      return;
+    }
+    this.lastInboundAt = Date.now();
+    this.heartbeatTimer = setInterval(() => this.heartbeatTick(), this.heartbeatIntervalMs);
+  }
+
+  private maybeStopHeartbeat(): void {
+    if (this.inFlight.size === 0 && this.heartbeatTimer !== null) {
+      clearInterval(this.heartbeatTimer);
+      this.heartbeatTimer = null;
+    }
+  }
+
+  private heartbeatTick(): void {
+    if (this.disconnected || this.inFlight.size === 0) {
+      this.maybeStopHeartbeat();
+      return;
+    }
+
+    const idleMs = Date.now() - this.lastInboundAt;
+    if (idleMs >= this.heartbeatDeadAfterMs) {
+      this.log.warn('Wallet channel unresponsive — declaring disconnect', {
+        idleMs,
+        inFlight: this.inFlight.size,
+      });
+      this.handleDisconnect();
+      return;
+    }
+
+    try {
+      this.port.postMessage({ type: WalletMessageType.PING });
+    } catch (err) {
+      this.log.warn('Failed to send heartbeat PING', { err });
+    }
   }
 
   /**
@@ -236,6 +317,11 @@ export class ExtensionWallet {
       return;
     }
     this.disconnected = true;
+
+    if (this.heartbeatTimer !== null) {
+      clearInterval(this.heartbeatTimer);
+      this.heartbeatTimer = null;
+    }
 
     if (this.port) {
       this.port.onmessage = null;

--- a/yarn-project/wallet-sdk/src/iframe/handlers/iframe_connection_handler.ts
+++ b/yarn-project/wallet-sdk/src/iframe/handlers/iframe_connection_handler.ts
@@ -14,7 +14,6 @@
  * so the dApp knows it can send a discovery request.
  */
 import type { ChainInfo } from '@aztec/aztec.js/account';
-import { createLogger } from '@aztec/aztec.js/log';
 import type { Wallet } from '@aztec/aztec.js/wallet';
 import { WalletSchema } from '@aztec/aztec.js/wallet';
 import { jsonStringify } from '@aztec/foundation/json-rpc';
@@ -29,7 +28,7 @@ import {
   generateKeyPair,
   importPublicKey,
 } from '../../crypto.js';
-import { type WalletMessage, WalletMessageType, type WalletResponse } from '../../types.js';
+import { type WalletMessage, WalletMessageType, type WalletResponse, type WalletSdkLogger } from '../../types.js';
 
 /**
  * A pending discovery request from a dApp (before user approval).
@@ -75,6 +74,8 @@ export interface IframeConnectionConfig {
   walletIcon?: string;
   /** Origins allowed to connect. If empty or undefined, all origins are allowed (dev mode). */
   allowedOrigins?: string[];
+  /** Logger used for diagnostics. */
+  logger: WalletSdkLogger;
 }
 
 /**
@@ -105,7 +106,7 @@ export interface IframeConnectionCallbacks {
  * @example
  * ```typescript
  * const handler = new IframeConnectionHandler(
- *   { walletId: 'my-wallet', walletName: 'My Wallet', walletVersion: '1.0.0' },
+ *   { walletId: 'my-wallet', walletName: 'My Wallet', walletVersion: '1.0.0', logger: console },
  *   {
  *     onPendingDiscovery: (session) => showApprovalUI(session),
  *     getWallet: (appId, chainInfo) => createWalletForApp(appId, chainInfo),
@@ -117,12 +118,14 @@ export interface IframeConnectionCallbacks {
 export class IframeConnectionHandler {
   private pendingSessions = new Map<string, PendingSession>();
   private activeSessions = new Map<string, ActiveSession>();
-  private log = createLogger('wallet:iframe-handler');
+  private log: WalletSdkLogger;
 
   constructor(
     private config: IframeConnectionConfig,
     private callbacks: IframeConnectionCallbacks,
-  ) {}
+  ) {
+    this.log = config.logger;
+  }
 
   start(): void {
     window.addEventListener('message', this.handleMessage);
@@ -203,7 +206,18 @@ export class IframeConnectionHandler {
       case WalletMessageType.DISCONNECT:
         this.terminateSession(msg.sessionId);
         break;
+      case WalletMessageType.PING:
+        this.handlePing(msg.sessionId);
+        break;
     }
+  }
+
+  private handlePing(sessionId: string): void {
+    const session = this.activeSessions.get(sessionId);
+    if (!session) {
+      return;
+    }
+    this.postToOrigin(session.origin, { type: WalletMessageType.PONG, sessionId });
   }
 
   private handleDiscoveryRequest(msg: Record<string, unknown>, origin: string): void {

--- a/yarn-project/wallet-sdk/src/iframe/provider/iframe_wallet.ts
+++ b/yarn-project/wallet-sdk/src/iframe/provider/iframe_wallet.ts
@@ -14,7 +14,17 @@ import { schemaHasMethod } from '@aztec/foundation/schemas';
 import type { FunctionsOf } from '@aztec/foundation/types';
 
 import { type EncryptedPayload, decrypt, encrypt } from '../../crypto.js';
-import { type DisconnectCallback, type WalletMessage, WalletMessageType, type WalletResponse } from '../../types.js';
+import {
+  DEFAULT_HEARTBEAT_DEAD_AFTER_MS,
+  DEFAULT_HEARTBEAT_INTERVAL_MS,
+  type DisconnectCallback,
+  type HeartbeatOptions,
+  NOOP_LOGGER,
+  type WalletMessage,
+  WalletMessageType,
+  type WalletResponse,
+  type WalletSdkLogger,
+} from '../../types.js';
 
 /**
  * Internal type representing a wallet method call before encryption.
@@ -46,6 +56,11 @@ export class IframeWallet {
   private disconnected = false;
   private disconnectCallbacks: DisconnectCallback[] = [];
   private messageListener: ((e: MessageEvent) => void) | null = null;
+  private heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+  private lastInboundAt = 0;
+  private log: WalletSdkLogger;
+  private heartbeatIntervalMs: number;
+  private heartbeatDeadAfterMs: number;
 
   private constructor(
     private chainInfo: ChainInfo,
@@ -55,7 +70,13 @@ export class IframeWallet {
     private iframeWindow: Window,
     private walletOrigin: string,
     private sharedKey: CryptoKey,
-  ) {}
+    logger?: WalletSdkLogger,
+    heartbeatOptions?: HeartbeatOptions,
+  ) {
+    this.log = logger ?? NOOP_LOGGER;
+    this.heartbeatIntervalMs = heartbeatOptions?.intervalMs ?? DEFAULT_HEARTBEAT_INTERVAL_MS;
+    this.heartbeatDeadAfterMs = heartbeatOptions?.deadAfterMs ?? DEFAULT_HEARTBEAT_DEAD_AFTER_MS;
+  }
 
   /**
    * Creates a proxied IframeWallet that implements the {@link Wallet} interface.
@@ -71,6 +92,8 @@ export class IframeWallet {
    * @param sharedKey - AES-256-GCM key derived from ECDH key exchange
    * @param chainInfo - Network information (chainId and version)
    * @param appId - Application identifier for the requesting dApp
+   * @param logger - Optional logger; defaults to a no-op logger to keep extension/page bundles small
+   * @param heartbeatOptions - Optional override for heartbeat tuning (mostly useful for tests)
    * @returns A proxied IframeWallet — call `.asWallet()` to get the typed `Wallet`
    */
   static create(
@@ -81,8 +104,20 @@ export class IframeWallet {
     sharedKey: CryptoKey,
     chainInfo: ChainInfo,
     appId: string,
+    logger?: WalletSdkLogger,
+    heartbeatOptions?: HeartbeatOptions,
   ): IframeWallet {
-    const wallet = new IframeWallet(chainInfo, appId, walletId, sessionId, iframeWindow, walletOrigin, sharedKey);
+    const wallet = new IframeWallet(
+      chainInfo,
+      appId,
+      walletId,
+      sessionId,
+      iframeWindow,
+      walletOrigin,
+      sharedKey,
+      logger,
+      heartbeatOptions,
+    );
 
     wallet.messageListener = (event: MessageEvent) => {
       if (event.origin !== walletOrigin) {
@@ -93,9 +128,16 @@ export class IframeWallet {
         return;
       }
 
-      if (msg.type === WalletMessageType.SECURE_RESPONSE && msg.sessionId === sessionId) {
+      if (msg.sessionId !== sessionId) {
+        return;
+      }
+
+      // Any inbound traffic on our session counts as proof of liveness.
+      wallet.lastInboundAt = Date.now();
+
+      if (msg.type === WalletMessageType.SECURE_RESPONSE) {
         void wallet.handleEncryptedResponse(msg.encrypted as EncryptedPayload);
-      } else if (msg.type === WalletMessageType.SESSION_DISCONNECTED && msg.sessionId === sessionId) {
+      } else if (msg.type === WalletMessageType.SESSION_DISCONNECTED) {
         wallet.handleDisconnect();
       }
     };
@@ -148,8 +190,9 @@ export class IframeWallet {
         pending.resolve(result);
       }
       this.inFlight.delete(messageId);
-    } catch {
-      // Decryption errors are silently ignored (message not for us or corrupted)
+      this.maybeStopHeartbeat();
+    } catch (err) {
+      this.log.warn('Failed to decrypt wallet response', { err });
     }
   }
 
@@ -176,7 +219,53 @@ export class IframeWallet {
 
     const { promise, resolve, reject } = promiseWithResolvers<unknown>();
     this.inFlight.set(messageId, { promise, resolve, reject });
+    this.startHeartbeat();
     return promise;
+  }
+
+  /**
+   * Start liveness probing while at least one request is in flight. PINGs are
+   * unencrypted control messages — older wallet handlers that don't understand
+   * them simply drop them, but any inbound traffic (PONG, encrypted response,
+   * disconnect notice) resets the idle timer, so a slow-but-alive legacy wallet
+   * never trips a false disconnect.
+   */
+  private startHeartbeat(): void {
+    if (this.heartbeatTimer !== null || this.disconnected) {
+      return;
+    }
+    this.lastInboundAt = Date.now();
+    this.heartbeatTimer = setInterval(() => this.heartbeatTick(), this.heartbeatIntervalMs);
+  }
+
+  private maybeStopHeartbeat(): void {
+    if (this.inFlight.size === 0 && this.heartbeatTimer !== null) {
+      clearInterval(this.heartbeatTimer);
+      this.heartbeatTimer = null;
+    }
+  }
+
+  private heartbeatTick(): void {
+    if (this.disconnected || this.inFlight.size === 0) {
+      this.maybeStopHeartbeat();
+      return;
+    }
+
+    const idleMs = Date.now() - this.lastInboundAt;
+    if (idleMs >= this.heartbeatDeadAfterMs) {
+      this.log.warn('Iframe wallet channel unresponsive — declaring disconnect', {
+        idleMs,
+        inFlight: this.inFlight.size,
+      });
+      this.handleDisconnect();
+      return;
+    }
+
+    try {
+      this.iframeWindow.postMessage({ type: WalletMessageType.PING, sessionId: this.sessionId }, this.walletOrigin);
+    } catch (err) {
+      this.log.warn('Failed to send heartbeat PING', { err });
+    }
   }
 
   private handleDisconnect(): void {
@@ -184,6 +273,11 @@ export class IframeWallet {
       return;
     }
     this.disconnected = true;
+
+    if (this.heartbeatTimer !== null) {
+      clearInterval(this.heartbeatTimer);
+      this.heartbeatTimer = null;
+    }
 
     if (this.messageListener) {
       window.removeEventListener('message', this.messageListener);

--- a/yarn-project/wallet-sdk/src/types.ts
+++ b/yarn-project/wallet-sdk/src/types.ts
@@ -25,6 +25,13 @@ export enum WalletMessageType {
   SECURE_RESPONSE = 'aztec-wallet-secure-response',
   /** Session disconnected notification */
   SESSION_DISCONNECTED = 'aztec-wallet-session-disconnected',
+  /** Liveness probe sent by the dApp while a request is in flight */
+  PING = 'aztec-wallet-ping',
+  /** Liveness response from the wallet. Any inbound message (including a regular
+   * encrypted response) is treated as proof of liveness, so a missing PONG alone
+   * never trips disconnect — the dApp also resets its liveness timer on traffic.
+   */
+  PONG = 'aztec-wallet-pong',
 }
 
 /**
@@ -143,3 +150,55 @@ export interface KeyExchangeResponse {
  * Callback invoked when a wallet connection is disconnected.
  */
 export type DisconnectCallback = () => void;
+
+/**
+ * Default heartbeat tuning shared by both transports.
+ *
+ * - `intervalMs`: how often the dApp sends PING probes while a request is in flight.
+ * - `deadAfterMs`: how long the channel can stay silent (no PONG, no encrypted
+ *   response, no DISCONNECT) before the dApp declares the wallet unreachable
+ *   and rejects all in-flight requests. Generous enough that long-running
+ *   operations (proveTx, sendTx) on legacy wallets that don't reply to PING
+ *   still succeed — any inbound traffic resets the timer.
+ */
+export const DEFAULT_HEARTBEAT_INTERVAL_MS = 5_000;
+export const DEFAULT_HEARTBEAT_DEAD_AFTER_MS = 300_000;
+
+/** Override knobs for the heartbeat — mostly useful for tests. */
+export interface HeartbeatOptions {
+  /** How often to send PING probes while a request is in flight (ms). */
+  intervalMs?: number;
+  /** Idle ceiling before declaring disconnect (ms). */
+  deadAfterMs?: number;
+}
+
+/**
+ * Minimal logger surface used by the wallet SDK.
+ *
+ * Defined locally so that wallet hosts (browser extensions, iframe wallet pages)
+ * can pass a simple `console`-backed logger without pulling in the full
+ * `@aztec/foundation` logging runtime, which is non-trivial to bundle in those
+ * contexts. Structurally compatible with `Logger` from `@aztec/foundation/log`,
+ * so dApp-side callers can pass that type directly.
+ */
+export interface WalletSdkLogger {
+  /** Diagnostic messages — typically discarded in production. */
+  debug: (message: string, data?: unknown) => void;
+  /** Informational messages — significant lifecycle events. */
+  info: (message: string, data?: unknown) => void;
+  /** Recoverable problems — channel decryption failure, missed heartbeats, etc. */
+  warn: (message: string, data?: unknown) => void;
+  /** Errors that prevent normal operation. */
+  error: (message: string, errOrData?: unknown, data?: unknown) => void;
+}
+
+/**
+ * No-op logger used as the default when callers don't provide one. Discards all
+ * messages — wallet hosts that want diagnostics should pass their own logger.
+ */
+export const NOOP_LOGGER: WalletSdkLogger = {
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+};


### PR DESCRIPTION
Implements a liveness check on wallets, avoiding promises hanging forever. Due to proving taking a long time, the global backwards compatible timer is set to 5min (since every request can refresh the timer), but once we deprecate `v4` we can tighten it. This will be hell to test on real browsers with things like tabs sleeping, but that is out of scope for this initial version.

Closes https://linear.app/aztec-labs/issue/F-510/audit-143-silent-error-swallowing-in-wallet-extension-decryption
Closes https://linear.app/aztec-labs/issue/F-511/audit-142-extensionwalletpostmessage-has-no-timeout-requests-hang


