### PR TITLE
fix(ci): skip acceptance test for canary -commit. tags

### DIFF
--- a/.github/workflows/aztec-cli-acceptance-test.yml
+++ b/.github/workflows/aztec-cli-acceptance-test.yml
@@ -21,7 +21,9 @@ jobs:
     runs-on: ubuntu-latest
     if: >-
       github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
+      (github.event_name == 'workflow_run'
+       && github.event.workflow_run.conclusion == 'success'
+       && !contains(github.event.workflow_run.head_branch, '-commit.'))
     timeout-minutes: 30
     env:
       VERSION: ${{ github.event.inputs.version || github.event.workflow_run.head_branch }}


### PR DESCRIPTION
## Problem

The acceptance test workflow fires whenever CI3 succeeds on any `v*` branch, including development canary tags like `v0.0.1-commit.<sha>`. However, those canary tags are intentionally excluded from the publishing pipeline (`!contains(github.ref_name, '-commit.')`), so the installer probe hits the install endpoint for an artifact that was never published and fails with a 404.

## Fix

Add a matching `!contains(..., '-commit.')` guard to the acceptance test job's `if:` condition so the workflow only runs for refs whose artifacts are actually published.