### PR TITLE
chore: skip zero-init and reserve copy_cycle vectors

### DIFF
--- a/barretenberg/cpp/src/barretenberg/flavor/partially_evaluated_multivariates.hpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/partially_evaluated_multivariates.hpp
@@ -33,7 +33,11 @@ class PartiallyEvaluatedMultivariatesBase : public AllEntitiesBase {
         for (auto [poly, full_poly] : zip_view(this->get_all(), full_polynomials.get_all())) {
             // After the initial sumcheck round, the new size is CEIL(size/2).
             size_t desired_size = (full_poly.end_index() / 2) + (full_poly.end_index() % 2);
-            poly = Polynomial(desired_size, circuit_size / 2);
+            // partial_evaluation writes dest.at(i>>1) for every i = 0, 2, ..., 2*desired_size - 2,
+            // covering the entire [0, desired_size) backing storage before any read. The virtual
+            // tail past desired_size is served by SharedShiftedVirtualZeroesArray's implicit zeros,
+            // so leaving the backing memory uninitialized is safe.
+            poly = Polynomial(desired_size, circuit_size / 2, 0, Polynomial::DontZeroMemory::FLAG);
         }
     }
 };

--- a/barretenberg/cpp/src/barretenberg/flavor/partially_evaluated_multivariates.hpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/partially_evaluated_multivariates.hpp
@@ -33,9 +33,7 @@ class PartiallyEvaluatedMultivariatesBase : public AllEntitiesBase {
         for (auto [poly, full_poly] : zip_view(this->get_all(), full_polynomials.get_all())) {
             // After the initial sumcheck round, the new size is CEIL(size/2).
             size_t desired_size = (full_poly.end_index() / 2) + (full_poly.end_index() % 2);
-            // partially_evaluate writes every cell in [0, desired_size) before any read, and the
-            // virtual tail past desired_size is served by SharedShiftedVirtualZeroesArray's
-            // implicit zeros, so the backing memory can be left uninitialized.
+            // partially_evaluate writes to [0, desired_size) before any read; backing memory can be left uninitialized.
             poly = Polynomial(desired_size, circuit_size / 2, 0, Polynomial::DontZeroMemory::FLAG);
         }
     }

--- a/barretenberg/cpp/src/barretenberg/flavor/partially_evaluated_multivariates.hpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/partially_evaluated_multivariates.hpp
@@ -33,10 +33,9 @@ class PartiallyEvaluatedMultivariatesBase : public AllEntitiesBase {
         for (auto [poly, full_poly] : zip_view(this->get_all(), full_polynomials.get_all())) {
             // After the initial sumcheck round, the new size is CEIL(size/2).
             size_t desired_size = (full_poly.end_index() / 2) + (full_poly.end_index() % 2);
-            // partial_evaluation writes dest.at(i>>1) for every i = 0, 2, ..., 2*desired_size - 2,
-            // covering the entire [0, desired_size) backing storage before any read. The virtual
-            // tail past desired_size is served by SharedShiftedVirtualZeroesArray's implicit zeros,
-            // so leaving the backing memory uninitialized is safe.
+            // partially_evaluate writes every cell in [0, desired_size) before any read, and the
+            // virtual tail past desired_size is served by SharedShiftedVirtualZeroesArray's
+            // implicit zeros, so the backing memory can be left uninitialized.
             poly = Polynomial(desired_size, circuit_size / 2, 0, Polynomial::DontZeroMemory::FLAG);
         }
     }

--- a/barretenberg/cpp/src/barretenberg/polynomials/polynomial.hpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/polynomial.hpp
@@ -126,6 +126,19 @@ template <typename Fr> class Polynomial {
         }
         return p;
     }
+    /**
+     * @brief Utility to create a shiftable polynomial of given size and virtual size whose backing
+     *        memory is left uninitialized.
+     * @details Use only when the caller writes every cell in [NUM_ZERO_ROWS, NUM_ZERO_ROWS + size)
+     *          before any read.
+     */
+    static Polynomial shiftable_dont_zero(size_t size, size_t virtual_size)
+    {
+        return Polynomial(/*actual size*/ size - NUM_ZERO_ROWS,
+                          virtual_size,
+                          /*shiftable offset*/ NUM_ZERO_ROWS,
+                          DontZeroMemory::FLAG);
+    }
     // Allow polynomials to be entirely reset/dormant
     Polynomial() = default;
 

--- a/barretenberg/cpp/src/barretenberg/polynomials/polynomial.hpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/polynomial.hpp
@@ -127,17 +127,13 @@ template <typename Fr> class Polynomial {
         return p;
     }
     /**
-     * @brief Utility to create a shiftable polynomial of given size and virtual size whose backing
-     *        memory is left uninitialized.
+     * @brief Overload of `shiftable` that leaves the backing memory uninitialized.
      * @details Use only when the caller writes every cell in [NUM_ZERO_ROWS, NUM_ZERO_ROWS + size)
      *          before any read.
      */
-    static Polynomial shiftable_dont_zero(size_t size, size_t virtual_size)
+    static Polynomial shiftable(size_t size, size_t virtual_size, DontZeroMemory flag)
     {
-        return Polynomial(/*actual size*/ size - NUM_ZERO_ROWS,
-                          virtual_size,
-                          /*shiftable offset*/ NUM_ZERO_ROWS,
-                          DontZeroMemory::FLAG);
+        return Polynomial(/*actual size*/ size - NUM_ZERO_ROWS, virtual_size, /*shiftable offset*/ NUM_ZERO_ROWS, flag);
     }
     // Allow polynomials to be entirely reset/dormant
     Polynomial() = default;

--- a/barretenberg/cpp/src/barretenberg/trace_to_polynomials/trace_to_polynomials.cpp
+++ b/barretenberg/cpp/src/barretenberg/trace_to_polynomials/trace_to_polynomials.cpp
@@ -59,9 +59,9 @@ std::vector<CyclicPermutation> TraceToPolynomials<Flavor>::populate_wires_and_se
     const size_t num_blocks = blocks_array.size();
 
     // Pre-pass: count copy-cycle sizes per real-variable index so each copy_cycles[i] can be
-    // reserve()d once instead of paying the amortized 1.5x reallocation cost across the
-    // serial concat in phase 1.5. Bounds-checked .at() access here justifies indexing
-    // copy_cycles[real_var_idx] without .at() in phase 1.5.
+    // reserve()d once before the serial concat in phase 1.5, avoiding repeated reallocations.
+    // Bounds-checked .at() access here justifies indexing copy_cycles[real_var_idx] without
+    // .at() in phase 1.5.
     {
         BB_BENCH_NAME("counting copy_cycles");
         std::vector<uint32_t> cycle_counts(builder.real_variable_index.size(), 0);

--- a/barretenberg/cpp/src/barretenberg/trace_to_polynomials/trace_to_polynomials.cpp
+++ b/barretenberg/cpp/src/barretenberg/trace_to_polynomials/trace_to_polynomials.cpp
@@ -58,6 +58,32 @@ std::vector<CyclicPermutation> TraceToPolynomials<Flavor>::populate_wires_and_se
     auto blocks_array = builder.blocks.get();
     const size_t num_blocks = blocks_array.size();
 
+    // Pre-pass: count copy-cycle sizes per real-variable index so each copy_cycles[i] can be
+    // reserve()d once instead of paying the amortized 1.5x reallocation cost across the
+    // serial concat in phase 1.5. Bounds-checked .at() access here justifies dropping bounds
+    // checks on the same indices in phase 1 / phase 1.5.
+    {
+        BB_BENCH_NAME("counting copy_cycles");
+        std::vector<uint32_t> cycle_counts(builder.real_variable_index.size(), 0);
+        for (auto& block : blocks_array) {
+            const uint32_t block_size = static_cast<uint32_t>(block.size());
+            for (uint32_t block_row_idx = 0; block_row_idx < block_size; ++block_row_idx) {
+                for (uint32_t wire_idx = 0; wire_idx < NUM_WIRES; ++wire_idx) {
+                    uint32_t var_idx = block.wires[wire_idx][block_row_idx];
+                    ++cycle_counts.at(builder.real_variable_index.at(var_idx));
+                }
+            }
+        }
+        for (size_t i = 0; i < copy_cycles.size(); ++i) {
+            copy_cycles[i].reserve(cycle_counts[i]);
+        }
+    }
+
+    // Hoist data() pointers so phase 1 and phase 1.5 can skip bounds checks already validated
+    // in the counting pre-pass.
+    const uint32_t* const real_variable_index = builder.real_variable_index.data();
+    const auto* const variables = builder.get_variables().data();
+
     // Phase 1: per-block parallel pass over wires and emit copy-cycle nodes.
     std::vector<std::vector<std::pair<uint32_t, cycle_node>>> per_block_nodes(num_blocks);
     {
@@ -73,11 +99,10 @@ std::vector<CyclicPermutation> TraceToPolynomials<Flavor>::populate_wires_and_se
             for (uint32_t block_row_idx = 0; block_row_idx < block_size; ++block_row_idx) {
                 for (uint32_t wire_idx = 0; wire_idx < NUM_WIRES; ++wire_idx) {
                     uint32_t var_idx = block.wires[wire_idx][block_row_idx]; // an index into the variables array
-                    // Use .at() so out-of-range var_idx is caught instead of producing a silent OOB read.
-                    uint32_t real_var_idx = builder.real_variable_index.at(var_idx);
+                    uint32_t real_var_idx = real_variable_index[var_idx];
                     uint32_t trace_row_idx = block_row_idx + offset;
                     // Insert the real witness values from this block into the wire polys at the correct offset
-                    wires[wire_idx].at(trace_row_idx) = builder.get_variable(var_idx);
+                    wires[wire_idx].at(trace_row_idx) = variables[real_var_idx];
                     local_nodes.emplace_back(real_var_idx, cycle_node{ wire_idx, trace_row_idx });
                 }
             }
@@ -89,7 +114,7 @@ std::vector<CyclicPermutation> TraceToPolynomials<Flavor>::populate_wires_and_se
         BB_BENCH_NAME("fill_copy_cycles");
         for (const auto& block_nodes : per_block_nodes) {
             for (const auto& [real_var_idx, node] : block_nodes) {
-                copy_cycles.at(real_var_idx).emplace_back(node);
+                copy_cycles[real_var_idx].emplace_back(node);
             }
         }
     }

--- a/barretenberg/cpp/src/barretenberg/trace_to_polynomials/trace_to_polynomials.cpp
+++ b/barretenberg/cpp/src/barretenberg/trace_to_polynomials/trace_to_polynomials.cpp
@@ -60,8 +60,8 @@ std::vector<CyclicPermutation> TraceToPolynomials<Flavor>::populate_wires_and_se
 
     // Pre-pass: count copy-cycle sizes per real-variable index so each copy_cycles[i] can be
     // reserve()d once instead of paying the amortized 1.5x reallocation cost across the
-    // serial concat in phase 1.5. Bounds-checked .at() access here justifies dropping bounds
-    // checks on the same indices in phase 1 / phase 1.5.
+    // serial concat in phase 1.5. Bounds-checked .at() access here justifies indexing
+    // copy_cycles[real_var_idx] without .at() in phase 1.5.
     {
         BB_BENCH_NAME("counting copy_cycles");
         std::vector<uint32_t> cycle_counts(builder.real_variable_index.size(), 0);
@@ -79,11 +79,6 @@ std::vector<CyclicPermutation> TraceToPolynomials<Flavor>::populate_wires_and_se
         }
     }
 
-    // Hoist data() pointers so phase 1 and phase 1.5 can skip bounds checks already validated
-    // in the counting pre-pass.
-    const uint32_t* const real_variable_index = builder.real_variable_index.data();
-    const auto* const variables = builder.get_variables().data();
-
     // Phase 1: per-block parallel pass over wires and emit copy-cycle nodes.
     std::vector<std::vector<std::pair<uint32_t, cycle_node>>> per_block_nodes(num_blocks);
     {
@@ -99,10 +94,11 @@ std::vector<CyclicPermutation> TraceToPolynomials<Flavor>::populate_wires_and_se
             for (uint32_t block_row_idx = 0; block_row_idx < block_size; ++block_row_idx) {
                 for (uint32_t wire_idx = 0; wire_idx < NUM_WIRES; ++wire_idx) {
                     uint32_t var_idx = block.wires[wire_idx][block_row_idx]; // an index into the variables array
-                    uint32_t real_var_idx = real_variable_index[var_idx];
+                    // Use .at() so out-of-range var_idx is caught instead of producing a silent OOB read.
+                    uint32_t real_var_idx = builder.real_variable_index.at(var_idx);
                     uint32_t trace_row_idx = block_row_idx + offset;
                     // Insert the real witness values from this block into the wire polys at the correct offset
-                    wires[wire_idx].at(trace_row_idx) = variables[real_var_idx];
+                    wires[wire_idx].at(trace_row_idx) = builder.get_variable(var_idx);
                     local_nodes.emplace_back(real_var_idx, cycle_node{ wire_idx, trace_row_idx });
                 }
             }

--- a/barretenberg/cpp/src/barretenberg/trace_to_polynomials/trace_to_polynomials.cpp
+++ b/barretenberg/cpp/src/barretenberg/trace_to_polynomials/trace_to_polynomials.cpp
@@ -60,8 +60,6 @@ std::vector<CyclicPermutation> TraceToPolynomials<Flavor>::populate_wires_and_se
 
     // Pre-pass: count copy-cycle sizes per real-variable index so each copy_cycles[i] can be
     // reserve()d once before the serial concat in phase 1.5, avoiding repeated reallocations.
-    // Bounds-checked .at() access here justifies indexing copy_cycles[real_var_idx] without
-    // .at() in phase 1.5.
     {
         BB_BENCH_NAME("counting copy_cycles");
         std::vector<uint32_t> cycle_counts(builder.real_variable_index.size(), 0);
@@ -70,6 +68,9 @@ std::vector<CyclicPermutation> TraceToPolynomials<Flavor>::populate_wires_and_se
             for (uint32_t block_row_idx = 0; block_row_idx < block_size; ++block_row_idx) {
                 for (uint32_t wire_idx = 0; wire_idx < NUM_WIRES; ++wire_idx) {
                     uint32_t var_idx = block.wires[wire_idx][block_row_idx];
+                    // var_idx may be untrusted (e.g. from ACIR) so use .at() to catch OOB. This validates real_var_idx
+                    // as an in-range index for both cycle_counts and copy_cycles (same size), which is why phase 1.5
+                    // below can index copy_cycles[real_var_idx] without .at().
                     ++cycle_counts.at(builder.real_variable_index.at(var_idx));
                 }
             }

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/prover_instance.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/prover_instance.cpp
@@ -155,14 +155,13 @@ template <typename Flavor> void ProverInstance_<Flavor>::allocate_permutation_ar
     BB_BENCH_NAME("allocate_permutation_argument_polynomials");
 
     // Sigma and ID polynomials are zero outside the active trace range. Inside the active range,
-    // compute_honk_style_permutation_lagrange_polynomials_from_mapping writes every cell in
-    // [start_index, start_index + size), so we can skip the zero-initialization of the backing
-    // storage. The virtual tail outside the active range remains implicitly zero.
+    // compute_honk_style_permutation_lagrange_polynomials_from_mapping writes every cell, so the
+    // backing memory can be left uninitialized.
     for (auto& sigma : polynomials.get_sigmas()) {
-        sigma = Polynomial::shiftable_dont_zero(trace_active_range_size(), dyadic_size());
+        sigma = Polynomial::shiftable(trace_active_range_size(), dyadic_size(), Polynomial::DontZeroMemory::FLAG);
     }
     for (auto& id : polynomials.get_ids()) {
-        id = Polynomial::shiftable_dont_zero(trace_active_range_size(), dyadic_size());
+        id = Polynomial::shiftable(trace_active_range_size(), dyadic_size(), Polynomial::DontZeroMemory::FLAG);
     }
 
     polynomials.z_perm = Polynomial::shiftable(trace_active_range_size(), dyadic_size(), Flavor::HasZK);

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/prover_instance.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/prover_instance.cpp
@@ -154,12 +154,15 @@ template <typename Flavor> void ProverInstance_<Flavor>::allocate_permutation_ar
 {
     BB_BENCH_NAME("allocate_permutation_argument_polynomials");
 
-    // Sigma and ID polynomials are zero outside the active trace range
+    // Sigma and ID polynomials are zero outside the active trace range. Inside the active range,
+    // compute_honk_style_permutation_lagrange_polynomials_from_mapping writes every cell in
+    // [start_index, start_index + size), so we can skip the zero-initialization of the backing
+    // storage. The virtual tail outside the active range remains implicitly zero.
     for (auto& sigma : polynomials.get_sigmas()) {
-        sigma = Polynomial::shiftable(trace_active_range_size(), dyadic_size());
+        sigma = Polynomial::shiftable_dont_zero(trace_active_range_size(), dyadic_size());
     }
     for (auto& id : polynomials.get_ids()) {
-        id = Polynomial::shiftable(trace_active_range_size(), dyadic_size());
+        id = Polynomial::shiftable_dont_zero(trace_active_range_size(), dyadic_size());
     }
 
     polynomials.z_perm = Polynomial::shiftable(trace_active_range_size(), dyadic_size(), Flavor::HasZK);


### PR DESCRIPTION
Two small mem optimizations targeting alloc-heavy slices of `Chonk::accumulate`:

**Skip zero-init for fully-overwritten polynomials**
- `PartiallyEvaluatedMultivariates`: `partially_evaluate` writes every cell in `[0, desired_size)` before any read; the virtual tail past `desired_size` is served by `SharedShiftedVirtualZeroesArray`'s implicit zeros.
- ProverInstance sigma/id: `compute_honk_style_permutation_lagrange_polynomials_from_mapping` writes every cell in the active range; the virtual tail outside it remains implicitly zero.

Adds an overload `Polynomial::shiftable(size, virtual_size, DontZeroMemory)` that mirrors the existing `shiftable()` factory but leaves the backing memory uninitialized.

**Reserve copy_cycle vectors**
Adds a counting pre-pass over all blocks that tallies copy-cycle sizes per real-variable index, then `reserve()`s each `copy_cycles[i]` once before the serial concat in phase 1.5. Eliminates the amortized realloc cost across the concat.

## Perf (3-run native median, transfer_1+sponsored_fpc, 16 threads)

| Operation                                       | Before (ms) | After (ms) |    Delta |
|-------------------------------------------------|------------:|-----------:|---------:|
| fill_copy_cycles                                |       62.66 |      13.76 |  -78.05% |
| allocate_permutation_argument_polynomials       |       13.96 |       1.81 |  -87.06% |
| Polynomial::zero_init (system-wide)             |      549.71 |     213.84 |  -61.10% |
| Polynomial::Polynomial(size_t,size_t,size_t)    |      163.46 |      81.26 |  -50.29% |
| Chonk::accumulate (warm aggregate)              |     2881.23 |    2835.98 |   -1.57% |
| Chonk::prove                                    |     2119.53 |    2088.02 |   -1.49% |
| ChonkAPI::prove (total wall)                    |     5834.66 |    5757.96 |   -1.31% |