### PR TITLE
fix(stdlib): clamp L2Tips ordering

### DIFF
--- a/yarn-project/archiver/src/store/block_store.test.ts
+++ b/yarn-project/archiver/src/store/block_store.test.ts
@@ -2833,4 +2833,72 @@ describe('BlockStore', () => {
       expect(await blockStore.getBlock({ number: BlockNumber(2) })).toBeUndefined();
     });
   });
+
+  describe('L2TipsCache clamping regression', () => {
+    it('does not throw when provenBlockNumber > latestBlockNumber and returns clamped tips', async () => {
+      // Seed a checkpoint with block 2, then remove the block data to simulate
+      // the transient window where proven > latest (L1-derived proven vs block-data sync lag).
+      const checkpoint = makePublishedCheckpoint(
+        await Checkpoint.random(CheckpointNumber(1), { numBlocks: 2, startBlockNumber: 1 }),
+        10,
+      );
+      await blockStore.addCheckpoints([checkpoint]);
+      await blockStore.setProvenCheckpointNumber(CheckpointNumber(1));
+
+      // Remove all block data — proven checkpoint still says block 2 but #blocks is empty.
+      await blockStore.removeBlocksAfter(BlockNumber(0));
+
+      expect(await blockStore.getLatestL2BlockNumber()).toBe(0);
+      expect(await blockStore.getProvenBlockNumber()).toBe(2);
+
+      const cache = new L2TipsCache(blockStore, GENESIS_BLOCK_HEADER_HASH);
+      const resolved = await cache.getL2Tips();
+
+      expect(resolved.proposed.number).toBe(0);
+      expect(resolved.proven.block.number).toBe(0);
+      expect(resolved.finalized.block.number).toBe(0);
+      expect(resolved.checkpointed.block.number).toBe(0);
+      expect(resolved.proposedCheckpoint.block.number).toBe(0);
+      expect(resolved.proven.block.number).toBeLessThanOrEqual(resolved.proposed.number);
+      expect(resolved.finalized.block.number).toBeLessThanOrEqual(resolved.proven.block.number);
+    });
+
+    it('falls back proposedCheckpoint to checkpointed when its block number is past proposed', async () => {
+      // Seed: a confirmed checkpoint at block 1, a proposed block 2, and a pending
+      // proposed checkpoint covering block 2. Then remove block 2 so the pending
+      // proposed checkpoint's block number is past the latest available block.
+      const checkpoint1 = makePublishedCheckpoint(
+        await Checkpoint.random(CheckpointNumber(1), { numBlocks: 1, startBlockNumber: 1 }),
+        10,
+      );
+      await blockStore.addCheckpoints([checkpoint1]);
+
+      const block2 = await L2Block.random(BlockNumber(2), {
+        checkpointNumber: CheckpointNumber(2),
+        indexWithinCheckpoint: IndexWithinCheckpoint(0),
+        lastArchive: checkpoint1.checkpoint.blocks[0].archive,
+      });
+      await blockStore.addProposedBlock(block2, { force: true });
+      await blockStore.addProposedCheckpoint({
+        checkpointNumber: CheckpointNumber(2),
+        header: CheckpointHeader.empty(),
+        startBlock: BlockNumber(2),
+        blockCount: 1,
+        totalManaUsed: 100n,
+        feeAssetPriceModifier: 50n,
+      });
+      await blockStore.removeBlocksAfter(BlockNumber(1));
+
+      expect(await blockStore.getLatestL2BlockNumber()).toBe(1);
+      expect(await blockStore.getProposedCheckpointL2BlockNumber()).toBe(2);
+
+      const cache = new L2TipsCache(blockStore, GENESIS_BLOCK_HEADER_HASH);
+      const resolved = await cache.getL2Tips();
+
+      // Whole proposedCheckpoint tip falls back to checkpointed (no mixed pair of
+      // proposed block + stale pending checkpoint identity).
+      expect(resolved.proposed.number).toBe(1);
+      expect(resolved.proposedCheckpoint).toEqual(resolved.checkpointed);
+    });
+  });
 });

--- a/yarn-project/archiver/src/store/l2_tips_cache.ts
+++ b/yarn-project/archiver/src/store/l2_tips_cache.ts
@@ -5,7 +5,10 @@ import {
   type BlockHash,
   type CheckpointId,
   GENESIS_CHECKPOINT_HEADER_HASH,
+  type L2BlockId,
+  type L2TipId,
   type L2Tips,
+  clampL2TipNumbers,
 } from '@aztec/stdlib/block';
 
 import type { BlockStore } from './block_store.js';
@@ -42,13 +45,7 @@ export class L2TipsCache {
   }
 
   private async loadFromStore(): Promise<L2Tips> {
-    const [
-      latestBlockNumber,
-      provenBlockNumber,
-      proposedCheckpointBlockNumber,
-      checkpointedBlockNumber,
-      finalizedBlockNumber,
-    ] = await Promise.all([
+    const [rawProposed, rawProven, rawProposedCheckpoint, rawCheckpointed, rawFinalized] = await Promise.all([
       this.blockStore.getLatestL2BlockNumber(),
       this.blockStore.getProvenBlockNumber(),
       this.blockStore.getProposedCheckpointL2BlockNumber(),
@@ -56,91 +53,78 @@ export class L2TipsCache {
       this.blockStore.getFinalizedL2BlockNumber(),
     ]);
 
-    const genesisBlockHeader = {
-      blockHash: this.initialBlockHash,
-      checkpointNumber: CheckpointNumber.ZERO,
-    } as const;
-    const beforeInitialBlockNumber = BlockNumber(INITIAL_L2_BLOCK_NUM - 1);
+    // Tip block numbers are populated from independent sources, so during sync they can violate
+    // `finalized ≤ ... ≤ proposed`. Clamp before resolving block data to avoid 'block not found'.
+    const clamped = clampL2TipNumbers({
+      proposed: rawProposed,
+      proposedCheckpoint: rawProposedCheckpoint,
+      checkpointed: rawCheckpointed,
+      proven: rawProven,
+      finalized: rawFinalized,
+    });
 
-    const getBlockData = (blockNumber: BlockNumber) =>
-      blockNumber > beforeInitialBlockNumber
-        ? this.blockStore.getBlockData({ number: blockNumber })
-        : genesisBlockHeader;
+    const [proposed, proven, checkpointed, finalized] = await Promise.all([
+      this.resolveBlockId(clamped.proposed),
+      this.resolveTipId(clamped.proven),
+      this.resolveTipId(clamped.checkpointed),
+      this.resolveTipId(clamped.finalized),
+    ]);
 
-    const [latestBlockData, provenBlockData, proposedCheckpointBlockData, checkpointedBlockData, finalizedBlockData] =
-      await Promise.all(
-        [
-          latestBlockNumber,
-          provenBlockNumber,
-          proposedCheckpointBlockNumber,
-          checkpointedBlockNumber,
-          finalizedBlockNumber,
-        ].map(getBlockData),
-      );
+    // If the pending proposed checkpoint pointed past the latest proposed block, its stored
+    // checkpoint identity references a block we haven't synced. Fall back to `checkpointed`
+    // entirely rather than emitting a mixed (proposed block, stale checkpoint identity) pair.
+    const proposedCheckpoint: L2TipId =
+      rawProposedCheckpoint > rawProposed
+        ? checkpointed
+        : {
+            block: await this.resolveBlockId(clamped.proposedCheckpoint),
+            checkpoint: await this.resolveProposedCheckpointId(checkpointed.checkpoint),
+          };
 
-    if (
-      !latestBlockData ||
-      !provenBlockData ||
-      !finalizedBlockData ||
-      !checkpointedBlockData ||
-      !proposedCheckpointBlockData
-    ) {
-      throw new Error('Failed to load block data for L2 tips');
+    return { proposed, proven, checkpointed, finalized, proposedCheckpoint };
+  }
+
+  private async resolveBlockId(blockNumber: BlockNumber): Promise<L2BlockId> {
+    if (blockNumber < INITIAL_L2_BLOCK_NUM) {
+      return { number: BlockNumber.ZERO, hash: this.initialBlockHash.toString() };
     }
+    const blockData = await this.blockStore.getBlockData({ number: blockNumber });
+    if (!blockData) {
+      throw new Error(`Failed to load block data for L2 tip at block ${blockNumber}`);
+    }
+    return { number: blockNumber, hash: blockData.blockHash.toString() };
+  }
 
-    const [provenCheckpointId, finalizedCheckpointId, proposedCheckpointId, checkpointedCheckpointId] =
-      await Promise.all([
-        this.getCheckpointIdForBlock(provenBlockData),
-        this.getCheckpointIdForBlock(finalizedBlockData),
-        this.getCheckpointIdForProposedCheckpoint(checkpointedBlockData),
-        this.getCheckpointIdForBlock(checkpointedBlockData),
-      ]);
-
+  private async resolveTipId(blockNumber: BlockNumber): Promise<L2TipId> {
+    if (blockNumber < INITIAL_L2_BLOCK_NUM) {
+      return {
+        block: { number: BlockNumber.ZERO, hash: this.initialBlockHash.toString() },
+        checkpoint: { number: CheckpointNumber.ZERO, hash: GENESIS_CHECKPOINT_HEADER_HASH.toString() },
+      };
+    }
+    const blockData = await this.blockStore.getBlockData({ number: blockNumber });
+    if (!blockData) {
+      throw new Error(`Failed to load block data for L2 tip at block ${blockNumber}`);
+    }
     return {
-      proposed: { number: latestBlockNumber, hash: latestBlockData.blockHash.toString() },
-      proven: {
-        block: { number: provenBlockNumber, hash: provenBlockData.blockHash.toString() },
-        checkpoint: provenCheckpointId,
-      },
-      proposedCheckpoint: {
-        block: { number: proposedCheckpointBlockNumber, hash: proposedCheckpointBlockData.blockHash.toString() },
-        checkpoint: proposedCheckpointId,
-      },
-      finalized: {
-        block: { number: finalizedBlockNumber, hash: finalizedBlockData.blockHash.toString() },
-        checkpoint: finalizedCheckpointId,
-      },
-      checkpointed: {
-        block: { number: checkpointedBlockNumber, hash: checkpointedBlockData.blockHash.toString() },
-        checkpoint: checkpointedCheckpointId,
-      },
+      block: { number: blockNumber, hash: blockData.blockHash.toString() },
+      checkpoint: await this.getCheckpointIdForBlock(blockData),
     };
   }
 
-  private async getCheckpointIdForProposedCheckpoint(
-    checkpointedBlockData: Pick<BlockData, 'checkpointNumber'>,
-  ): Promise<CheckpointId> {
-    const checkpointData = await this.blockStore.getLastProposedCheckpoint();
-    if (!checkpointData) {
-      return this.getCheckpointIdForBlock(checkpointedBlockData);
+  private async resolveProposedCheckpointId(checkpointedFallback: CheckpointId): Promise<CheckpointId> {
+    const proposed = await this.blockStore.getLastProposedCheckpoint();
+    if (!proposed) {
+      return checkpointedFallback;
     }
-    return {
-      number: checkpointData.checkpointNumber,
-      hash: checkpointData.header.hash().toString(),
-    };
+    return { number: proposed.checkpointNumber, hash: proposed.header.hash().toString() };
   }
 
   private async getCheckpointIdForBlock(blockData: Pick<BlockData, 'checkpointNumber'>): Promise<CheckpointId> {
     const checkpointData = await this.blockStore.getCheckpointData(blockData.checkpointNumber);
     if (!checkpointData) {
-      return {
-        number: CheckpointNumber.ZERO,
-        hash: GENESIS_CHECKPOINT_HEADER_HASH.toString(),
-      };
+      return { number: CheckpointNumber.ZERO, hash: GENESIS_CHECKPOINT_HEADER_HASH.toString() };
     }
-    return {
-      number: checkpointData.checkpointNumber,
-      hash: checkpointData.header.hash().toString(),
-    };
+    return { number: checkpointData.checkpointNumber, hash: checkpointData.header.hash().toString() };
   }
 }

--- a/yarn-project/archiver/src/test/mock_l2_block_source.ts
+++ b/yarn-project/archiver/src/test/mock_l2_block_source.ts
@@ -176,12 +176,19 @@ export class MockL2BlockSource implements L2BlockSource, ContractDataSource {
   }
 
   public setProvenBlockNumber(provenBlockNumber: number) {
+    // Proving requires the enclosing checkpoint to have been published first, so the
+    // checkpointed tip must always be at least as advanced as proven. Cascading here keeps
+    // the mock consistent with the production `finalized ≤ proven ≤ checkpointed ≤ ...`
+    // invariant enforced at producers and the RPC boundary.
+    if (provenBlockNumber > this.checkpointedBlockNumber) {
+      this.setCheckpointedBlockNumber(provenBlockNumber);
+    }
     this.provenBlockNumber = provenBlockNumber;
   }
 
   public setFinalizedBlockNumber(finalizedBlockNumber: number) {
     if (finalizedBlockNumber > this.provenBlockNumber) {
-      this.provenBlockNumber = finalizedBlockNumber;
+      this.setProvenBlockNumber(finalizedBlockNumber);
     }
     this.finalizedBlockNumber = finalizedBlockNumber;
   }

--- a/yarn-project/stdlib/src/block/l2_block_source.test.ts
+++ b/yarn-project/stdlib/src/block/l2_block_source.test.ts
@@ -1,0 +1,167 @@
+import { BlockNumber, CheckpointNumber } from '@aztec/foundation/branded-types';
+
+import { clampL2TipNumbers, isL2TipsOrdered } from './l2_block_source.js';
+
+const BN = BlockNumber;
+const CN = CheckpointNumber;
+
+describe('clampL2TipNumbers', () => {
+  it('returns same object reference when already ordered', () => {
+    const input = {
+      proposed: BN(10),
+      proposedCheckpoint: BN(8),
+      checkpointed: BN(6),
+      proven: BN(4),
+      finalized: BN(2),
+    };
+    const result = clampL2TipNumbers(input);
+    expect(result).toBe(input);
+  });
+
+  it('clamps proven to checkpointed when proven > checkpointed', () => {
+    const result = clampL2TipNumbers({
+      proposed: BN(10),
+      proposedCheckpoint: BN(8),
+      checkpointed: BN(6),
+      proven: BN(8),
+      finalized: BN(2),
+    });
+    expect(result.proven).toBe(6);
+    expect(result.checkpointed).toBe(6);
+    expect(result.proposedCheckpoint).toBe(8);
+    expect(result.proposed).toBe(10);
+    expect(result.finalized).toBe(2);
+  });
+
+  it('clamps finalized to proven when finalized > proven', () => {
+    const result = clampL2TipNumbers({
+      proposed: BN(10),
+      proposedCheckpoint: BN(8),
+      checkpointed: BN(6),
+      proven: BN(4),
+      finalized: BN(6),
+    });
+    expect(result.finalized).toBe(4);
+    expect(result.proven).toBe(4);
+    expect(result.checkpointed).toBe(6);
+  });
+
+  it('cascades violations top-down', () => {
+    const result = clampL2TipNumbers({
+      proposed: BN(5),
+      proposedCheckpoint: BN(8),
+      checkpointed: BN(10),
+      proven: BN(12),
+      finalized: BN(14),
+    });
+    expect(result.proposed).toBe(5);
+    expect(result.proposedCheckpoint).toBe(5);
+    expect(result.checkpointed).toBe(5);
+    expect(result.proven).toBe(5);
+    expect(result.finalized).toBe(5);
+  });
+
+  it('clamps only top field when only proposedCheckpoint > proposed', () => {
+    const result = clampL2TipNumbers({
+      proposed: BN(5),
+      proposedCheckpoint: BN(7),
+      checkpointed: BN(4),
+      proven: BN(3),
+      finalized: BN(2),
+    });
+    expect(result.proposedCheckpoint).toBe(5);
+    expect(result.checkpointed).toBe(4);
+    expect(result.proven).toBe(3);
+    expect(result.finalized).toBe(2);
+  });
+
+  it('does not modify hashes on equal block numbers (hash divergence is a no-op)', () => {
+    const input = {
+      proposed: BN(5),
+      proposedCheckpoint: BN(5),
+      checkpointed: BN(5),
+      proven: BN(5),
+      finalized: BN(5),
+    };
+    const result = clampL2TipNumbers(input);
+    expect(result).toBe(input);
+  });
+});
+
+describe('isL2TipsOrdered', () => {
+  const tip = (block: number, checkpoint?: number) => ({
+    block: { number: BN(block) },
+    ...(checkpoint !== undefined ? { checkpoint: { number: CN(checkpoint) } } : {}),
+  });
+
+  it('returns true for ordered block numbers', () => {
+    expect(
+      isL2TipsOrdered({
+        proposed: { number: BN(10) },
+        proposedCheckpoint: tip(8),
+        checkpointed: tip(6),
+        proven: tip(4),
+        finalized: tip(2),
+      }),
+    ).toBe(true);
+  });
+
+  it('returns false when block numbers violate ordering', () => {
+    expect(
+      isL2TipsOrdered({
+        proposed: { number: BN(5) },
+        proposedCheckpoint: tip(8),
+        checkpointed: tip(6),
+        proven: tip(4),
+        finalized: tip(2),
+      }),
+    ).toBe(false);
+  });
+
+  it('returns true when a tip is omitted (e.g. ChainTips omits proposedCheckpoint)', () => {
+    expect(
+      isL2TipsOrdered({
+        proposed: { number: BN(10) },
+        checkpointed: tip(6),
+        proven: tip(4),
+        finalized: tip(2),
+      }),
+    ).toBe(true);
+  });
+
+  it('returns true for ordered checkpoint numbers', () => {
+    expect(
+      isL2TipsOrdered({
+        proposed: { number: BN(10) },
+        proposedCheckpoint: tip(8, 4),
+        checkpointed: tip(6, 3),
+        proven: tip(4, 2),
+        finalized: tip(2, 1),
+      }),
+    ).toBe(true);
+  });
+
+  it('returns false when checkpoint numbers violate ordering', () => {
+    expect(
+      isL2TipsOrdered({
+        proposed: { number: BN(10) },
+        proposedCheckpoint: tip(8, 4),
+        checkpointed: tip(6, 3),
+        proven: tip(4, 5),
+        finalized: tip(2, 1),
+      }),
+    ).toBe(false);
+  });
+
+  it('ignores missing checkpoint fields and only checks present ones', () => {
+    // proven has no checkpoint; finalized does. Checkpoint ordering still validates among present ones.
+    expect(
+      isL2TipsOrdered({
+        proposed: { number: BN(10) },
+        checkpointed: tip(6, 3),
+        proven: tip(4),
+        finalized: tip(2, 1),
+      }),
+    ).toBe(true);
+  });
+});

--- a/yarn-project/stdlib/src/block/l2_block_source.test.ts
+++ b/yarn-project/stdlib/src/block/l2_block_source.test.ts
@@ -18,7 +18,7 @@ describe('clampL2TipNumbers', () => {
     expect(result).toBe(input);
   });
 
-  it('clamps proven to checkpointed when proven > checkpointed', () => {
+  it('clamps proven down to checkpointed when proven > checkpointed', () => {
     const result = clampL2TipNumbers({
       proposed: BN(10),
       proposedCheckpoint: BN(8),
@@ -27,13 +27,13 @@ describe('clampL2TipNumbers', () => {
       finalized: BN(2),
     });
     expect(result.proven).toBe(6);
+    expect(result.finalized).toBe(2);
     expect(result.checkpointed).toBe(6);
     expect(result.proposedCheckpoint).toBe(8);
     expect(result.proposed).toBe(10);
-    expect(result.finalized).toBe(2);
   });
 
-  it('clamps finalized to proven when finalized > proven', () => {
+  it('clamps finalized down to proven when finalized > proven', () => {
     const result = clampL2TipNumbers({
       proposed: BN(10),
       proposedCheckpoint: BN(8),
@@ -46,7 +46,7 @@ describe('clampL2TipNumbers', () => {
     expect(result.checkpointed).toBe(6);
   });
 
-  it('cascades violations top-down', () => {
+  it('cascades violations top-down through the full ordering', () => {
     const result = clampL2TipNumbers({
       proposed: BN(5),
       proposedCheckpoint: BN(8),
@@ -61,7 +61,7 @@ describe('clampL2TipNumbers', () => {
     expect(result.finalized).toBe(5);
   });
 
-  it('clamps only top field when only proposedCheckpoint > proposed', () => {
+  it('clamps only the offending field when only one tip is above its tier', () => {
     const result = clampL2TipNumbers({
       proposed: BN(5),
       proposedCheckpoint: BN(7),
@@ -73,18 +73,6 @@ describe('clampL2TipNumbers', () => {
     expect(result.checkpointed).toBe(4);
     expect(result.proven).toBe(3);
     expect(result.finalized).toBe(2);
-  });
-
-  it('does not modify hashes on equal block numbers (hash divergence is a no-op)', () => {
-    const input = {
-      proposed: BN(5),
-      proposedCheckpoint: BN(5),
-      checkpointed: BN(5),
-      proven: BN(5),
-      finalized: BN(5),
-    };
-    const result = clampL2TipNumbers(input);
-    expect(result).toBe(input);
   });
 });
 

--- a/yarn-project/stdlib/src/block/l2_block_source.ts
+++ b/yarn-project/stdlib/src/block/l2_block_source.ts
@@ -323,6 +323,69 @@ export type L2Tips = {
   finalized: L2TipId;
 };
 
+/** Block numbers for each tip of the L2 chain. */
+export type L2TipNumbers = Record<L2BlockTag, BlockNumber>;
+
+const L2_TIP_TAGS_DESCENDING: readonly L2BlockTag[] = [
+  'proposed',
+  'proposedCheckpoint',
+  'checkpointed',
+  'proven',
+  'finalized',
+] as const;
+
+/**
+ * Clamps each tip's block number to the next-higher tier to enforce
+ * `finalized ≤ proven ≤ checkpointed ≤ proposedCheckpoint ≤ proposed`.
+ * Call this *before* resolving block/checkpoint data so producers don't
+ * throw when they look up data for a tip whose blocks haven't been synced yet.
+ */
+export function clampL2TipNumbers<T extends L2TipNumbers>(numbers: T): T {
+  let bound = numbers.proposed;
+  let clamped: T | undefined;
+  for (const tag of L2_TIP_TAGS_DESCENDING) {
+    if (numbers[tag] > bound) {
+      (clamped ??= { ...numbers })[tag] = bound;
+    } else {
+      bound = numbers[tag];
+    }
+  }
+  return clamped ?? numbers;
+}
+
+/**
+ * Returns true iff `tips` satisfies the descending-tip ordering invariant on both block
+ * numbers and (when present) checkpoint numbers.
+ */
+export function isL2TipsOrdered(tips: {
+  [K in L2BlockTag]?:
+    | { number: BlockNumber }
+    | { block: { number: BlockNumber }; checkpoint?: { number: CheckpointNumber } };
+}): boolean {
+  let blockBound: BlockNumber | undefined;
+  let checkpointBound: CheckpointNumber | undefined;
+  for (const tag of L2_TIP_TAGS_DESCENDING) {
+    const tip = tips[tag];
+    if (!tip) {
+      continue;
+    }
+    const blockNumber = 'number' in tip ? tip.number : tip.block.number;
+    if (blockBound !== undefined && blockNumber > blockBound) {
+      return false;
+    }
+    blockBound = blockNumber;
+
+    const checkpointNumber = 'block' in tip ? tip.checkpoint?.number : undefined;
+    if (checkpointNumber !== undefined) {
+      if (checkpointBound !== undefined && checkpointNumber > checkpointBound) {
+        return false;
+      }
+      checkpointBound = checkpointNumber;
+    }
+  }
+  return true;
+}
+
 export const GENESIS_CHECKPOINT_HEADER_HASH = CheckpointHeader.empty().hash();
 
 /** Identifies a block by number and hash. */
@@ -360,12 +423,17 @@ const L2TipIdSchema = z.object({
   checkpoint: L2CheckpointIdSchema,
 });
 
-export const L2TipsSchema = z.object({
+/** Base Zod object for `L2Tips` without ordering refinement. Exported so derived schemas can call `.omit()`. */
+export const L2TipsBaseSchema = z.object({
   proposed: L2BlockIdSchema,
   checkpointed: L2TipIdSchema,
   proposedCheckpoint: L2TipIdSchema,
   proven: L2TipIdSchema,
   finalized: L2TipIdSchema,
+});
+
+export const L2TipsSchema = L2TipsBaseSchema.refine(isL2TipsOrdered, {
+  message: 'L2Tips ordering violated: finalized ≤ proven ≤ checkpointed ≤ proposedCheckpoint ≤ proposed',
 });
 
 export enum L2BlockSourceEvents {

--- a/yarn-project/stdlib/src/block/l2_block_source.ts
+++ b/yarn-project/stdlib/src/block/l2_block_source.ts
@@ -336,9 +336,10 @@ const L2_TIP_TAGS_DESCENDING: readonly L2BlockTag[] = [
 
 /**
  * Clamps each tip's block number to the next-higher tier to enforce
- * `finalized ≤ proven ≤ checkpointed ≤ proposedCheckpoint ≤ proposed`.
- * Call this *before* resolving block/checkpoint data so producers don't
- * throw when they look up data for a tip whose blocks haven't been synced yet.
+ * `finalized ≤ proven ≤ checkpointed ≤ proposedCheckpoint ≤ proposed`. Call this *before*
+ * resolving block/checkpoint data so producers don't throw when they look up data for a tip
+ * whose blocks haven't been synced yet. Acts as a safety net on top of producer-side ordering:
+ * sources / event handlers should keep tips ordered; this guards against transient races.
  */
 export function clampL2TipNumbers<T extends L2TipNumbers>(numbers: T): T {
   let bound = numbers.proposed;

--- a/yarn-project/stdlib/src/block/l2_block_stream/l2_block_stream.test.ts
+++ b/yarn-project/stdlib/src/block/l2_block_stream/l2_block_stream.test.ts
@@ -843,9 +843,12 @@ describe('L2BlockStream', () => {
         expect(checkpointEvents).toHaveLength(5);
       });
 
-      it('skips Loop 1 entirely when startingBlock is past the checkpointed tip', async () => {
+      it('emits a single catch-up checkpoint when startingBlock is past the checkpointed tip', async () => {
         // proposed=15, checkpointed=9 (ckpt 3 covers blocks 7-9). startingBlock=12 is past the
-        // checkpointed tip, in the proposed range. Loop 1 must skip without an RPC for block 12.
+        // checkpointed tip, in the proposed range. Loop 1 must skip without an RPC for block 12,
+        // but the stream still emits one chain-checkpointed for the latest source-checkpointed
+        // so local.checkpointed catches up — otherwise a later chain-proven event would leave
+        // local state with `proven > checkpointed`.
         setRemoteTipsMultiBlock(15, 9);
         blockStream = new TestL2BlockStream(blockSource, localData, handler, undefined, {
           batchSize: 10,
@@ -854,9 +857,9 @@ describe('L2BlockStream', () => {
 
         await blockStream.work();
 
-        // No chain-checkpointed events because startingBlock is past the checkpointed tip.
         const checkpointEvents = handler.events.filter(e => e.type === 'chain-checkpointed');
-        expect(checkpointEvents).toHaveLength(0);
+        expect(checkpointEvents).toHaveLength(1);
+        expect(checkpointEvents[0]).toEqual(expectCheckpointed(3));
         // Loop 1 must not query block 12 — past-the-tip is decided from sourceTips alone.
         const loop1Calls = blockSource.getBlockData.mock.calls.filter(
           c => 'number' in c[0] && (c[0] as { number: number }).number === 12,

--- a/yarn-project/stdlib/src/block/l2_block_stream/l2_block_stream.ts
+++ b/yarn-project/stdlib/src/block/l2_block_stream/l2_block_stream.ts
@@ -4,7 +4,7 @@ import { createLogger } from '@aztec/foundation/log';
 import { RunningPromise } from '@aztec/foundation/running-promise';
 
 import type { PublishedCheckpoint } from '../../checkpoint/published_checkpoint.js';
-import { type L2BlockId, type L2BlockSource, makeL2BlockId } from '../l2_block_source.js';
+import { type L2BlockId, type L2BlockSource, type L2TipId, makeL2BlockId } from '../l2_block_source.js';
 import type { L2BlockStreamEvent, L2BlockStreamEventHandler, L2BlockStreamLocalDataProvider } from './interfaces.js';
 
 /** Maximum number of checkpoints to prefetch at once during sync. Matches MAX_RPC_CHECKPOINTS_LEN. */
@@ -132,6 +132,16 @@ export class L2BlockStream {
       ) {
         if (startingBlock > sourceTips.checkpointed.block.number) {
           // startingBlock is past all checkpointed blocks; skip Loop 1 entirely.
+          // Reconcile local.checkpointed to source.checkpointed in a single catch-up event so
+          // subsequent chain-proven / chain-finalized advances in this poll cycle preserve the
+          // local ordering invariant (`checkpointed ≥ proven ≥ finalized`). Without this, a
+          // chain-proven event at or below source.checkpointed.block.number would leave the
+          // local store with `proven > checkpointed`, which the cross-tier clamp in
+          // `getL2Tips()` would then mask by reporting proven=local.checkpointed — making the
+          // block stream re-emit chain-proven on every poll.
+          if (!this.opts.ignoreCheckpoints) {
+            await this.emitCatchUpCheckpointEvent(sourceTips.checkpointed);
+          }
           nextCheckpointToEmit = CheckpointNumber(sourceTips.checkpointed.checkpoint.number + 1);
         } else {
           const startingBlockData = await this.l2BlockSource.getBlockData({ number: startingBlock });
@@ -305,6 +315,41 @@ export class L2BlockStream {
       .getBlockData({ number: blockNumber })
       .then(d => d?.header.hash())
       .then(hash => hash?.toString());
+  }
+
+  /**
+   * Emits a single `chain-checkpointed` event for the source's current `checkpointed` tip.
+   * Used by the startingBlock fast-forward path to reconcile local.checkpointed when historical
+   * chain-checkpointed emission is skipped. Validates that the fetched checkpoint matches the
+   * source's reported tip (same checkpoint number, same last-block hash) before emitting.
+   */
+  private async emitCatchUpCheckpointEvent(sourceCheckpointed: L2TipId): Promise<void> {
+    const [checkpoint] = await this.l2BlockSource.getCheckpoints({
+      from: sourceCheckpointed.checkpoint.number,
+      limit: 1,
+    });
+    if (!checkpoint || checkpoint.checkpoint.number !== sourceCheckpointed.checkpoint.number) {
+      this.log.warn(`Could not fetch source-checkpointed checkpoint for catch-up`, {
+        requestedCheckpointNumber: sourceCheckpointed.checkpoint.number,
+        fetchedCheckpointNumber: checkpoint?.checkpoint.number,
+      });
+      return;
+    }
+    const lastBlock = checkpoint.checkpoint.blocks.at(-1)!;
+    if (lastBlock.number !== sourceCheckpointed.block.number) {
+      this.log.warn(`Catch-up checkpoint last block does not match source-checkpointed tip`, {
+        checkpointNumber: checkpoint.checkpoint.number,
+        lastBlockInCheckpoint: lastBlock.number,
+        sourceCheckpointedBlock: sourceCheckpointed.block.number,
+      });
+      return;
+    }
+    const lastBlockHash = (await lastBlock.hash()).toString();
+    await this.emitEvent({
+      type: 'chain-checkpointed',
+      checkpoint,
+      block: makeL2BlockId(lastBlock.number, lastBlockHash),
+    });
   }
 
   private async emitEvent(event: L2BlockStreamEvent) {

--- a/yarn-project/stdlib/src/block/l2_block_stream/l2_block_stream.ts
+++ b/yarn-project/stdlib/src/block/l2_block_stream/l2_block_stream.ts
@@ -140,7 +140,14 @@ export class L2BlockStream {
           // `getL2Tips()` would then mask by reporting proven=local.checkpointed — making the
           // block stream re-emit chain-proven on every poll.
           if (!this.opts.ignoreCheckpoints) {
-            await this.emitCatchUpCheckpointEvent(sourceTips.checkpointed);
+            const caughtUp = await this.emitCatchUpCheckpointEvent(sourceTips.checkpointed);
+            if (!caughtUp) {
+              // Validation failed (mismatch between source.checkpointed tip and the fetched
+              // checkpoint, likely a transient source-side reorg/race). Abort this poll cycle
+              // rather than continuing on to proven/finalized emission, which would create the
+              // very invariant break we're trying to prevent. Next poll will retry.
+              return;
+            }
           }
           nextCheckpointToEmit = CheckpointNumber(sourceTips.checkpointed.checkpoint.number + 1);
         } else {
@@ -321,9 +328,11 @@ export class L2BlockStream {
    * Emits a single `chain-checkpointed` event for the source's current `checkpointed` tip.
    * Used by the startingBlock fast-forward path to reconcile local.checkpointed when historical
    * chain-checkpointed emission is skipped. Validates that the fetched checkpoint matches the
-   * source's reported tip (same checkpoint number, same last-block hash) before emitting.
+   * source's reported tip (same checkpoint number, same last-block number and hash) before
+   * emitting. Returns true if the catch-up event was emitted, false if validation failed and
+   * the caller should abort this poll cycle.
    */
-  private async emitCatchUpCheckpointEvent(sourceCheckpointed: L2TipId): Promise<void> {
+  private async emitCatchUpCheckpointEvent(sourceCheckpointed: L2TipId): Promise<boolean> {
     const [checkpoint] = await this.l2BlockSource.getCheckpoints({
       from: sourceCheckpointed.checkpoint.number,
       limit: 1,
@@ -333,7 +342,7 @@ export class L2BlockStream {
         requestedCheckpointNumber: sourceCheckpointed.checkpoint.number,
         fetchedCheckpointNumber: checkpoint?.checkpoint.number,
       });
-      return;
+      return false;
     }
     const lastBlock = checkpoint.checkpoint.blocks.at(-1)!;
     if (lastBlock.number !== sourceCheckpointed.block.number) {
@@ -342,14 +351,28 @@ export class L2BlockStream {
         lastBlockInCheckpoint: lastBlock.number,
         sourceCheckpointedBlock: sourceCheckpointed.block.number,
       });
-      return;
+      return false;
     }
     const lastBlockHash = (await lastBlock.hash()).toString();
+    if (lastBlockHash !== sourceCheckpointed.block.hash) {
+      // getL2Tips() and getCheckpoints() are separate reads on the source; during a source-side
+      // reorg/cache race the two views can disagree on the block hash at the same number.
+      // Emitting an event with a hash the source doesn't agree with would plant inconsistent
+      // state in the local store. Bail and let the next poll re-resolve.
+      this.log.warn(`Catch-up checkpoint last block hash does not match source-checkpointed tip`, {
+        checkpointNumber: checkpoint.checkpoint.number,
+        lastBlockNumber: lastBlock.number,
+        fetchedHash: lastBlockHash,
+        sourceCheckpointedHash: sourceCheckpointed.block.hash,
+      });
+      return false;
+    }
     await this.emitEvent({
       type: 'chain-checkpointed',
       checkpoint,
       block: makeL2BlockId(lastBlock.number, lastBlockHash),
     });
+    return true;
   }
 
   private async emitEvent(event: L2BlockStreamEvent) {

--- a/yarn-project/stdlib/src/block/l2_block_stream/l2_tips_memory_store.test.ts
+++ b/yarn-project/stdlib/src/block/l2_block_stream/l2_tips_memory_store.test.ts
@@ -17,12 +17,21 @@ const makeCheckpoint = (blockNumber: number, checkpointNumber: number) =>
     },
   }) as unknown as PublishedCheckpoint;
 
-describe('L2TipsMemoryStore clamping', () => {
+describe('L2TipsMemoryStore', () => {
   let store: L2TipsMemoryStore;
 
   beforeEach(() => {
     store = new L2TipsMemoryStore(new BlockHash(new Fr(0)));
   });
+
+  const addBlocks = (...numbers: number[]) =>
+    store.handleBlockStreamEvent({
+      type: 'blocks-added',
+      blocks: numbers.map(n => ({
+        number: BlockNumber(n),
+        hash: () => Promise.resolve(new BlockHash(new Fr(n))),
+      })) as any,
+    });
 
   it('returns genesis tips when store is empty', async () => {
     const tips = await store.getL2Tips();
@@ -33,70 +42,32 @@ describe('L2TipsMemoryStore clamping', () => {
     expect(tips.proposedCheckpoint.block.number).toBe(0);
   });
 
-  it('clamps proven to proposed when chain-proven advances past local block data', async () => {
-    // Simulate: local store has proposed=3, but receives a chain-proven event for block 5
-    // (which hasn't been downloaded yet). getL2Tips() should clamp without throwing.
-    await store.handleBlockStreamEvent({
-      type: 'blocks-added',
-      blocks: [
-        { number: BlockNumber(1), hash: () => Promise.resolve(new BlockHash(new Fr(1))) },
-        { number: BlockNumber(2), hash: () => Promise.resolve(new BlockHash(new Fr(2))) },
-        { number: BlockNumber(3), hash: () => Promise.resolve(new BlockHash(new Fr(3))) },
-      ] as any,
-    });
+  it('clamps proven to checkpointed when chain-proven runs ahead of chain-checkpointed', async () => {
+    // The cross-tier cascade ensures `proven ≤ checkpointed` even when the block stream emits
+    // chain-proven before chain-checkpointed catches up for the same block. The L2BlockStream's
+    // startingBlock-skip path is responsible for reconciling local.checkpointed first; this
+    // clamp guards against any remaining transient inconsistency.
+    await addBlocks(1, 2, 3);
+    await store.handleBlockStreamEvent({ type: 'chain-proven', block: makeBlockId(3) });
 
-    // Directly write a proven tip higher than what's in the block store.
-    // This simulates the L1-derived proven advancing before block-data sync.
-    await store.handleBlockStreamEvent({
-      type: 'chain-proven',
-      block: makeBlockId(5),
-    });
-
-    // getL2Tips() must not throw and proven must be clamped to proposed.
     const tips = await store.getL2Tips();
     expect(tips.proposed.number).toBe(3);
-    expect(tips.proven.block.number).toBeLessThanOrEqual(tips.proposed.number);
+    expect(tips.checkpointed.block.number).toBe(0);
+    expect(tips.proven.block.number).toBe(0);
   });
 
-  it('satisfies ordering invariant after checkpoint and proven events', async () => {
-    // Add blocks 1-3 and checkpoint them.
-    await store.handleBlockStreamEvent({
-      type: 'blocks-added',
-      blocks: [
-        { number: BlockNumber(1), hash: () => Promise.resolve(new BlockHash(new Fr(1))) },
-        { number: BlockNumber(2), hash: () => Promise.resolve(new BlockHash(new Fr(2))) },
-        { number: BlockNumber(3), hash: () => Promise.resolve(new BlockHash(new Fr(3))) },
-      ] as any,
-    });
-
-    await store.handleBlockStreamEvent({
-      type: 'chain-checkpointed',
-      block: makeBlockId(3),
-      checkpoint: makeCheckpoint(3, 1),
-    });
-
-    await store.handleBlockStreamEvent({
-      type: 'chain-proven',
-      block: makeBlockId(3),
-    });
+  it('clamps proven to proposed when chain-proven advances past local block data', async () => {
+    await addBlocks(1, 2, 3);
+    await store.handleBlockStreamEvent({ type: 'chain-proven', block: makeBlockId(5) });
 
     const tips = await store.getL2Tips();
-    expect(tips.finalized.block.number).toBeLessThanOrEqual(tips.proven.block.number);
-    expect(tips.proven.block.number).toBeLessThanOrEqual(tips.checkpointed.block.number);
-    expect(tips.checkpointed.block.number).toBeLessThanOrEqual(tips.proposedCheckpoint.block.number);
-    expect(tips.proposedCheckpoint.block.number).toBeLessThanOrEqual(tips.proposed.number);
+    expect(tips.proposed.number).toBe(3);
+    expect(tips.proven.block.number).toBeLessThanOrEqual(3);
   });
 
   it('does not prune block hashes or checkpoints still referenced by a tip behind finalized', async () => {
-    // Seed: blocks 1-3 added, checkpoint 1 at block 3 known, proven and checkpointed both at 3.
-    await store.handleBlockStreamEvent({
-      type: 'blocks-added',
-      blocks: [
-        { number: BlockNumber(1), hash: () => Promise.resolve(new BlockHash(new Fr(1))) },
-        { number: BlockNumber(2), hash: () => Promise.resolve(new BlockHash(new Fr(2))) },
-        { number: BlockNumber(3), hash: () => Promise.resolve(new BlockHash(new Fr(3))) },
-      ] as any,
-    });
+    // Seed: blocks 1-3 added, checkpoint 1 at block 3, proven and checkpointed both at 3.
+    await addBlocks(1, 2, 3);
     await store.handleBlockStreamEvent({
       type: 'chain-checkpointed',
       block: makeBlockId(3),
@@ -107,10 +78,11 @@ describe('L2TipsMemoryStore clamping', () => {
     // Finalize advances ahead of the existing proven/checkpointed tips (transient ordering).
     await store.handleBlockStreamEvent({ type: 'chain-finalized', block: makeBlockId(5) });
 
-    // getL2Tips must not throw: proven/checkpointed at block 3 still need their block hash
-    // *and* their enclosing checkpoint (1) preserved despite the finalized prune.
+    // Despite the finalized prune, block 3's hash and checkpoint 1 must remain reachable —
+    // proven/checkpointed still point at them. Without the delete guard, getL2Tips would throw.
     const tips = await store.getL2Tips();
-    expect(tips.finalized.block.number).toBeLessThanOrEqual(tips.proven.block.number);
-    expect(tips.proven.block.number).toBeLessThanOrEqual(tips.checkpointed.block.number);
+    expect(tips.proven.block.number).toBe(3);
+    expect(tips.checkpointed.block.number).toBe(3);
+    expect(tips.checkpointed.checkpoint.number).toBe(1);
   });
 });

--- a/yarn-project/stdlib/src/block/l2_block_stream/l2_tips_memory_store.test.ts
+++ b/yarn-project/stdlib/src/block/l2_block_stream/l2_tips_memory_store.test.ts
@@ -1,0 +1,116 @@
+import { BlockNumber, CheckpointNumber } from '@aztec/foundation/branded-types';
+import { Fr } from '@aztec/foundation/curves/bn254';
+
+import type { PublishedCheckpoint } from '../../checkpoint/published_checkpoint.js';
+import { BlockHash } from '../block_hash.js';
+import type { L2BlockId } from '../l2_block_source.js';
+import { L2TipsMemoryStore } from './l2_tips_memory_store.js';
+
+const makeHash = (n: number) => new Fr(n).toString();
+const makeBlockId = (n: number): L2BlockId => ({ number: BlockNumber(n), hash: makeHash(n) });
+const makeCheckpoint = (blockNumber: number, checkpointNumber: number) =>
+  ({
+    checkpoint: {
+      number: CheckpointNumber(checkpointNumber),
+      hash: () => new Fr(checkpointNumber),
+      blocks: [{ number: BlockNumber(blockNumber) }],
+    },
+  }) as unknown as PublishedCheckpoint;
+
+describe('L2TipsMemoryStore clamping', () => {
+  let store: L2TipsMemoryStore;
+
+  beforeEach(() => {
+    store = new L2TipsMemoryStore(new BlockHash(new Fr(0)));
+  });
+
+  it('returns genesis tips when store is empty', async () => {
+    const tips = await store.getL2Tips();
+    expect(tips.proposed.number).toBe(0);
+    expect(tips.proven.block.number).toBe(0);
+    expect(tips.finalized.block.number).toBe(0);
+    expect(tips.checkpointed.block.number).toBe(0);
+    expect(tips.proposedCheckpoint.block.number).toBe(0);
+  });
+
+  it('clamps proven to proposed when chain-proven advances past local block data', async () => {
+    // Simulate: local store has proposed=3, but receives a chain-proven event for block 5
+    // (which hasn't been downloaded yet). getL2Tips() should clamp without throwing.
+    await store.handleBlockStreamEvent({
+      type: 'blocks-added',
+      blocks: [
+        { number: BlockNumber(1), hash: () => Promise.resolve(new BlockHash(new Fr(1))) },
+        { number: BlockNumber(2), hash: () => Promise.resolve(new BlockHash(new Fr(2))) },
+        { number: BlockNumber(3), hash: () => Promise.resolve(new BlockHash(new Fr(3))) },
+      ] as any,
+    });
+
+    // Directly write a proven tip higher than what's in the block store.
+    // This simulates the L1-derived proven advancing before block-data sync.
+    await store.handleBlockStreamEvent({
+      type: 'chain-proven',
+      block: makeBlockId(5),
+    });
+
+    // getL2Tips() must not throw and proven must be clamped to proposed.
+    const tips = await store.getL2Tips();
+    expect(tips.proposed.number).toBe(3);
+    expect(tips.proven.block.number).toBeLessThanOrEqual(tips.proposed.number);
+  });
+
+  it('satisfies ordering invariant after checkpoint and proven events', async () => {
+    // Add blocks 1-3 and checkpoint them.
+    await store.handleBlockStreamEvent({
+      type: 'blocks-added',
+      blocks: [
+        { number: BlockNumber(1), hash: () => Promise.resolve(new BlockHash(new Fr(1))) },
+        { number: BlockNumber(2), hash: () => Promise.resolve(new BlockHash(new Fr(2))) },
+        { number: BlockNumber(3), hash: () => Promise.resolve(new BlockHash(new Fr(3))) },
+      ] as any,
+    });
+
+    await store.handleBlockStreamEvent({
+      type: 'chain-checkpointed',
+      block: makeBlockId(3),
+      checkpoint: makeCheckpoint(3, 1),
+    });
+
+    await store.handleBlockStreamEvent({
+      type: 'chain-proven',
+      block: makeBlockId(3),
+    });
+
+    const tips = await store.getL2Tips();
+    expect(tips.finalized.block.number).toBeLessThanOrEqual(tips.proven.block.number);
+    expect(tips.proven.block.number).toBeLessThanOrEqual(tips.checkpointed.block.number);
+    expect(tips.checkpointed.block.number).toBeLessThanOrEqual(tips.proposedCheckpoint.block.number);
+    expect(tips.proposedCheckpoint.block.number).toBeLessThanOrEqual(tips.proposed.number);
+  });
+
+  it('does not prune block hashes or checkpoints still referenced by a tip behind finalized', async () => {
+    // Seed: blocks 1-3 added, checkpoint 1 at block 3 known, proven and checkpointed both at 3.
+    await store.handleBlockStreamEvent({
+      type: 'blocks-added',
+      blocks: [
+        { number: BlockNumber(1), hash: () => Promise.resolve(new BlockHash(new Fr(1))) },
+        { number: BlockNumber(2), hash: () => Promise.resolve(new BlockHash(new Fr(2))) },
+        { number: BlockNumber(3), hash: () => Promise.resolve(new BlockHash(new Fr(3))) },
+      ] as any,
+    });
+    await store.handleBlockStreamEvent({
+      type: 'chain-checkpointed',
+      block: makeBlockId(3),
+      checkpoint: makeCheckpoint(3, 1),
+    });
+    await store.handleBlockStreamEvent({ type: 'chain-proven', block: makeBlockId(3) });
+
+    // Finalize advances ahead of the existing proven/checkpointed tips (transient ordering).
+    await store.handleBlockStreamEvent({ type: 'chain-finalized', block: makeBlockId(5) });
+
+    // getL2Tips must not throw: proven/checkpointed at block 3 still need their block hash
+    // *and* their enclosing checkpoint (1) preserved despite the finalized prune.
+    const tips = await store.getL2Tips();
+    expect(tips.finalized.block.number).toBeLessThanOrEqual(tips.proven.block.number);
+    expect(tips.proven.block.number).toBeLessThanOrEqual(tips.checkpointed.block.number);
+  });
+});

--- a/yarn-project/stdlib/src/block/l2_block_stream/l2_tips_store_base.ts
+++ b/yarn-project/stdlib/src/block/l2_block_stream/l2_tips_store_base.ts
@@ -80,10 +80,10 @@ export abstract class L2TipsStoreBase implements L2BlockStreamEventHandler, L2Bl
         tipOrZero('proposedCheckpoint'),
       ]);
 
-      // Data-availability clamp only: tips ahead of `proposed` would lack block data and throw
-      // below. We deliberately do NOT enforce cross-tier ordering here so that callers like the
-      // L2BlockStream see the stored value of each tip (otherwise it would re-emit chain-*
-      // events forever because local always reports `0` for the clamped tip).
+      // Enforce `finalized ≤ proven ≤ checkpointed ≤ proposedCheckpoint ≤ proposed` before
+      // resolving block/checkpoint data. Tips ahead of `proposed` would lack block data and
+      // throw in `getBlockId` below; tips violating cross-tier ordering would leak through to
+      // RPC consumers and fail schema validation.
       const {
         proposed: proposedNumber,
         finalized: finalizedNumber,

--- a/yarn-project/stdlib/src/block/l2_block_stream/l2_tips_store_base.ts
+++ b/yarn-project/stdlib/src/block/l2_block_stream/l2_tips_store_base.ts
@@ -71,27 +71,26 @@ export abstract class L2TipsStoreBase implements L2BlockStreamEventHandler, L2Bl
 
   public getL2Tips(): Promise<L2Tips> {
     return this.runInTransaction(async () => {
-      const [rawProposed, rawFinalized, rawProven, rawCheckpointed, rawProposedCheckpoint] = await Promise.all([
-        this.getTip('proposed'),
-        this.getTip('finalized'),
-        this.getTip('proven'),
-        this.getTip('checkpointed'),
-        this.getTip('proposedCheckpoint'),
+      const tipOrZero = async (tag: L2BlockTag): Promise<BlockNumber> => (await this.getTip(tag)) ?? BlockNumber.ZERO;
+      const [proposed, finalized, proven, checkpointed, proposedCheckpoint] = await Promise.all([
+        tipOrZero('proposed'),
+        tipOrZero('finalized'),
+        tipOrZero('proven'),
+        tipOrZero('checkpointed'),
+        tipOrZero('proposedCheckpoint'),
       ]);
 
+      // Data-availability clamp only: tips ahead of `proposed` would lack block data and throw
+      // below. We deliberately do NOT enforce cross-tier ordering here so that callers like the
+      // L2BlockStream see the stored value of each tip (otherwise it would re-emit chain-*
+      // events forever because local always reports `0` for the clamped tip).
       const {
         proposed: proposedNumber,
         finalized: finalizedNumber,
         proven: provenNumber,
         checkpointed: checkpointedNumber,
         proposedCheckpoint: proposedCheckpointNumber,
-      } = clampL2TipNumbers({
-        proposed: rawProposed ?? BlockNumber.ZERO,
-        finalized: rawFinalized ?? BlockNumber.ZERO,
-        proven: rawProven ?? BlockNumber.ZERO,
-        checkpointed: rawCheckpointed ?? BlockNumber.ZERO,
-        proposedCheckpoint: rawProposedCheckpoint ?? BlockNumber.ZERO,
-      });
+      } = clampL2TipNumbers({ proposed, finalized, proven, checkpointed, proposedCheckpoint });
 
       const [proposedBlockId, finalizedBlockId, provenBlockId, checkpointedBlockId, proposedCheckpointBlockId] =
         await Promise.all([

--- a/yarn-project/stdlib/src/block/l2_block_stream/l2_tips_store_base.ts
+++ b/yarn-project/stdlib/src/block/l2_block_stream/l2_tips_store_base.ts
@@ -9,6 +9,7 @@ import {
   type L2BlockId,
   type L2BlockTag,
   type L2Tips,
+  clampL2TipNumbers,
 } from '../l2_block_source.js';
 import type { L2BlockStreamEvent, L2BlockStreamEventHandler, L2BlockStreamLocalDataProvider } from './interfaces.js';
 
@@ -70,21 +71,43 @@ export abstract class L2TipsStoreBase implements L2BlockStreamEventHandler, L2Bl
 
   public getL2Tips(): Promise<L2Tips> {
     return this.runInTransaction(async () => {
+      const [rawProposed, rawFinalized, rawProven, rawCheckpointed, rawProposedCheckpoint] = await Promise.all([
+        this.getTip('proposed'),
+        this.getTip('finalized'),
+        this.getTip('proven'),
+        this.getTip('checkpointed'),
+        this.getTip('proposedCheckpoint'),
+      ]);
+
+      const {
+        proposed: proposedNumber,
+        finalized: finalizedNumber,
+        proven: provenNumber,
+        checkpointed: checkpointedNumber,
+        proposedCheckpoint: proposedCheckpointNumber,
+      } = clampL2TipNumbers({
+        proposed: rawProposed ?? BlockNumber.ZERO,
+        finalized: rawFinalized ?? BlockNumber.ZERO,
+        proven: rawProven ?? BlockNumber.ZERO,
+        checkpointed: rawCheckpointed ?? BlockNumber.ZERO,
+        proposedCheckpoint: rawProposedCheckpoint ?? BlockNumber.ZERO,
+      });
+
       const [proposedBlockId, finalizedBlockId, provenBlockId, checkpointedBlockId, proposedCheckpointBlockId] =
         await Promise.all([
-          this.getBlockId('proposed'),
-          this.getBlockId('finalized'),
-          this.getBlockId('proven'),
-          this.getBlockId('checkpointed'),
-          this.getBlockId('proposedCheckpoint'),
+          this.getBlockId(proposedNumber),
+          this.getBlockId(finalizedNumber),
+          this.getBlockId(provenNumber),
+          this.getBlockId(checkpointedNumber),
+          this.getBlockId(proposedCheckpointNumber),
         ]);
 
       const [finalizedCheckpointId, provenCheckpointId, checkpointedCheckpointId, proposedCheckpointId] =
         await Promise.all([
-          this.getCheckpointId('finalized'),
-          this.getCheckpointId('proven'),
-          this.getCheckpointId('checkpointed'),
-          this.getCheckpointId('proposedCheckpoint'),
+          this.getCheckpointId(finalizedNumber),
+          this.getCheckpointId(provenNumber),
+          this.getCheckpointId(checkpointedNumber),
+          this.getCheckpointId(proposedCheckpointNumber),
         ]);
 
       return {
@@ -124,9 +147,8 @@ export abstract class L2TipsStoreBase implements L2BlockStreamEventHandler, L2Bl
 
   // Private implementation
 
-  private async getBlockId(tag: L2BlockTag): Promise<L2BlockId> {
-    const blockNumber = await this.getTip(tag);
-    if (blockNumber === undefined || blockNumber === 0) {
+  private async getBlockId(blockNumber: BlockNumber): Promise<L2BlockId> {
+    if (blockNumber === 0) {
       return { number: BlockNumber.ZERO, hash: this.initialBlockHash.toString() };
     }
     const blockHash = await this.getStoredBlockHash(blockNumber);
@@ -136,9 +158,8 @@ export abstract class L2TipsStoreBase implements L2BlockStreamEventHandler, L2Bl
     return { number: blockNumber, hash: blockHash };
   }
 
-  private async getCheckpointId(tag: L2BlockTag): Promise<CheckpointId> {
-    const blockNumber = await this.getTip(tag);
-    if (blockNumber === undefined || blockNumber === 0) {
+  private async getCheckpointId(blockNumber: BlockNumber): Promise<CheckpointId> {
+    if (blockNumber === 0) {
       return { number: CheckpointNumber.ZERO, hash: GENESIS_CHECKPOINT_HEADER_HASH.toString() };
     }
     const checkpointNumber = await this.getCheckpointNumberForBlock(blockNumber);
@@ -174,8 +195,8 @@ export abstract class L2TipsStoreBase implements L2BlockStreamEventHandler, L2Bl
       await this.saveCheckpoint(event.checkpoint);
       // proposedCheckpoint is always >= checkpointed. If checkpointed has caught up
       // or surpassed it, advance proposedCheckpoint to match.
-      const proposedCheckpointBlock = await this.getBlockId('proposedCheckpoint');
-      if (event.block.number > proposedCheckpointBlock.number) {
+      const proposedCheckpointNumber = (await this.getTip('proposedCheckpoint')) ?? BlockNumber.ZERO;
+      if (event.block.number > proposedCheckpointNumber) {
         await this.saveTag('proposedCheckpoint', event.block);
       }
     });
@@ -189,8 +210,8 @@ export abstract class L2TipsStoreBase implements L2BlockStreamEventHandler, L2Bl
       await this.saveTag('proposed', event.block);
       await this.saveTag('checkpointed', event.block);
       await this.saveTag('proposedCheckpoint', event.block);
-      const storeProven = await this.getBlockId('proven');
-      if (storeProven.number > event.block.number) {
+      const storeProvenNumber = (await this.getTip('proven')) ?? BlockNumber.ZERO;
+      if (storeProvenNumber > event.block.number) {
         await this.saveTag('proven', event.block);
       }
     });
@@ -213,11 +234,30 @@ export abstract class L2TipsStoreBase implements L2BlockStreamEventHandler, L2Bl
       await this.saveTag('finalized', event.block);
       const finalizedCheckpointNumber = await this.getCheckpointNumberForBlock(event.block.number);
 
-      await this.deleteBlockHashesBefore(event.block.number);
-      await this.deleteBlockToCheckpointBefore(event.block.number);
+      // Cap the deletion bound at the lowest live tip. This should always be the finalized tip, but
+      // we have hit bugs where this is not the case. Deleting the block hash, block-to-checkpoint mapping,
+      // or enclosing checkpoint object for a live tip would dangle subsequent `getBlockId`/`getCheckpointId`
+      // lookups and lock the block stream into an error loop.
+      const tips = await Promise.all([
+        this.getTip('proposed'),
+        this.getTip('proposedCheckpoint'),
+        this.getTip('checkpointed'),
+        this.getTip('proven'),
+      ]);
+      const liveTipBlocks = tips.filter((t): t is BlockNumber => t !== undefined && t > 0);
+      const safeBlockBound = BlockNumber(Math.min(event.block.number, ...liveTipBlocks));
+      await this.deleteBlockHashesBefore(safeBlockBound);
+      await this.deleteBlockToCheckpointBefore(safeBlockBound);
 
       if (finalizedCheckpointNumber !== undefined) {
-        await this.deleteCheckpointsBefore(finalizedCheckpointNumber);
+        const tipCheckpoints = await Promise.all(liveTipBlocks.map(b => this.getCheckpointNumberForBlock(b)));
+        const safeCheckpointBound = CheckpointNumber(
+          Math.min(
+            finalizedCheckpointNumber,
+            ...tipCheckpoints.filter((c): c is CheckpointNumber => c !== undefined && c > 0),
+          ),
+        );
+        await this.deleteCheckpointsBefore(safeCheckpointBound);
       }
     });
   }

--- a/yarn-project/stdlib/src/interfaces/chain_tips.ts
+++ b/yarn-project/stdlib/src/interfaces/chain_tips.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-import { type L2BlockTag, type L2Tips, L2TipsSchema } from '../block/l2_block_source.js';
+import { type L2BlockTag, type L2Tips, L2TipsBaseSchema, isL2TipsOrdered } from '../block/l2_block_source.js';
 
 /**
  * Public chain-tip selectors usable in RPC requests.
@@ -21,4 +21,6 @@ export const ChainTipSchema = z.union([
  */
 export type ChainTips = Omit<L2Tips, 'proposedCheckpoint'>;
 
-export const ChainTipsSchema = L2TipsSchema.omit({ proposedCheckpoint: true });
+export const ChainTipsSchema = L2TipsBaseSchema.omit({ proposedCheckpoint: true }).refine(isL2TipsOrdered, {
+  message: 'Incorrect ordering for chain tip numbers',
+});


### PR DESCRIPTION
`L2Tips` has five fields that should satisfy `finalized ≤ proven ≤ checkpointed ≤ proposedCheckpoint ≤ proposed` by block number. Consumers trust this invariant, but we have run into issues where this doesn't hold and bricks the node.

This PR adds a helper to clamp each tip to the next, so that the invariant never breaks.

Fixes A-1018