### PR TITLE
test(e2e): fail epochs tests on proposer-rollup-check-failed

### DIFF
--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_high_tps_block_building.test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_high_tps_block_building.test.ts
@@ -212,17 +212,10 @@ describe('e2e_epochs/epochs_high_tps_block_building', () => {
     expect(Math.max(...blocks.map(b => b.body!.txEffects.length))).toEqual(TXS_PER_BLOCK);
     expect(Math.max(...checkpoints.map(c => c.length))).toEqual(BLOCKS_PER_CHECKPOINT);
 
-    // Expect no failures from sequencers during block building. Filter out the self-proposal 'Rollup contract
-    // check failed' spam: when a validator proposes two consecutive checkpoints, the archiver's sequentiality
-    // guard rejects persisting the second proposed checkpoint until the first is confirmed on L1, so the next
-    // pipelining cycle falls through without simulation overrides and canProposeAt reverts until state catches
-    // up. Tracked in A-910.
-    const significantFailEvents = failEvents.filter(
-      e => !(e.type === 'proposer-rollup-check-failed' && e.reason === 'Rollup contract check failed'),
-    );
-    if (significantFailEvents.length > 0) {
-      logger.error(`Failed events from sequencers`, significantFailEvents);
+    // Expect no failures from sequencers during block building
+    if (failEvents.length > 0) {
+      logger.error(`Failed events from sequencers`, failEvents);
     }
-    expect(significantFailEvents).toEqual([]);
+    expect(failEvents).toEqual([]);
   });
 });

--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_missed_l1_publish.test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_missed_l1_publish.test.ts
@@ -352,9 +352,6 @@ describe('e2e_epochs/epochs_missed_l1_publish', () => {
       ) {
         return false;
       }
-      if (e.type === 'proposer-rollup-check-failed') {
-        return false;
-      }
       return true;
     });
     if (unexpectedFailEvents.length > 0) {


### PR DESCRIPTION
These sequencer errors were ignored in some tests. Removing that since this error should not happen. If it does, it's cause for analysis.