### PR TITLE
feat(pxe): deduplicate class ID verification per contract

### DIFF
--- a/yarn-project/pxe/src/contract_sync/contract_sync_service.test.ts
+++ b/yarn-project/pxe/src/contract_sync/contract_sync_service.test.ts
@@ -225,6 +225,53 @@ describe('ContractSyncService', () => {
     });
   });
 
+  describe('class ID verification deduplication', () => {
+    const contract2 = AztecAddress.fromBigInt(300n);
+
+    it('verifies class ID only once per contract across scope batches', async () => {
+      await service.ensureContractSynced(contractAddress, null, utilityExecutor, anchorBlockHeader, jobId, [scopeA]);
+      await service.ensureContractSynced(contractAddress, null, utilityExecutor, anchorBlockHeader, jobId, [scopeB]);
+      expectVerifiedContracts(contractAddress);
+    });
+
+    it('verifies class ID separately for different contracts', async () => {
+      await service.ensureContractSynced(contractAddress, null, utilityExecutor, anchorBlockHeader, jobId, [scopeA]);
+      await service.ensureContractSynced(contract2, null, utilityExecutor, anchorBlockHeader, jobId, [scopeA]);
+      expectVerifiedContracts(contractAddress, contract2);
+    });
+
+    it('re-verifies class ID after wipe', async () => {
+      await service.ensureContractSynced(contractAddress, null, utilityExecutor, anchorBlockHeader, jobId, [scopeA]);
+      service.wipe();
+      await service.ensureContractSynced(contractAddress, null, utilityExecutor, anchorBlockHeader, jobId, [scopeB]);
+      expectVerifiedContracts(contractAddress, contractAddress);
+    });
+
+    it('re-verifies class ID after discardStaged', async () => {
+      await service.ensureContractSynced(contractAddress, null, utilityExecutor, anchorBlockHeader, jobId, [scopeA]);
+      await service.discardStaged(jobId);
+      await service.ensureContractSynced(contractAddress, null, utilityExecutor, anchorBlockHeader, jobId, [scopeA]);
+      expectVerifiedContracts(contractAddress, contractAddress);
+    });
+
+    it('re-verifies class ID after verification failure', async () => {
+      contractStore.getContractInstance.mockRejectedValueOnce(new Error('node unavailable'));
+      await expect(
+        service.ensureContractSynced(contractAddress, null, utilityExecutor, anchorBlockHeader, jobId, [scopeA]),
+      ).rejects.toThrow('node unavailable');
+
+      await service.ensureContractSynced(contractAddress, null, utilityExecutor, anchorBlockHeader, jobId, [scopeA]);
+      expectVerifiedContracts(contractAddress, contractAddress);
+    });
+
+    it('does not re-verify class ID when only scope cache is invalidated', async () => {
+      await service.ensureContractSynced(contractAddress, null, utilityExecutor, anchorBlockHeader, jobId, [scopeA]);
+      service.invalidateContractForScopes(contractAddress, [scopeA]);
+      await service.ensureContractSynced(contractAddress, null, utilityExecutor, anchorBlockHeader, jobId, [scopeA]);
+      expectVerifiedContracts(contractAddress);
+    });
+  });
+
   describe('invalidateContractForScopes', () => {
     const contract2 = AztecAddress.fromBigInt(300n);
 
@@ -334,6 +381,14 @@ describe('ContractSyncService', () => {
       const [call, actualScopes] = utilityExecutor.mock.calls[i];
       expect(call.to).toEqual(expected[i][0]);
       expect(actualScopes).toEqual(expected[i][1]);
+    }
+  };
+
+  /** Asserts that class ID verification was triggered for each contract address in the given sequence. */
+  const expectVerifiedContracts = (...addresses: AztecAddress[]) => {
+    expect(contractStore.getContractInstance).toHaveBeenCalledTimes(addresses.length);
+    for (let i = 0; i < addresses.length; i++) {
+      expect(contractStore.getContractInstance).toHaveBeenNthCalledWith(i + 1, addresses[i]);
     }
   };
 

--- a/yarn-project/pxe/src/contract_sync/contract_sync_service.ts
+++ b/yarn-project/pxe/src/contract_sync/contract_sync_service.ts
@@ -27,6 +27,10 @@ export class ContractSyncService implements StagedStore {
   // The value is a promise that resolves when the contract is synced.
   private syncedContracts: Map<string, Promise<void>> = new Map();
 
+  // Tracks class ID verification per contract. Keyed by contract address only (no scope), since
+  // class ID verification is scope-independent. Cleared on wipe/discard.
+  private verifiedClassIds: Map<string, Promise<void>> = new Map();
+
   // Per-job excluded contract addresses - these contracts should not be synced.
   private excludedFromSync: Map<string, Set<string>> = new Map();
 
@@ -101,6 +105,7 @@ export class ContractSyncService implements StagedStore {
   wipe(): void {
     this.log.debug(`Wiping contract sync cache (${this.syncedContracts.size} entries)`);
     this.syncedContracts.clear();
+    this.verifiedClassIds.clear();
   }
 
   commit(jobId: string): Promise<void> {
@@ -113,6 +118,7 @@ export class ContractSyncService implements StagedStore {
     // We clear the synced contracts cache here because, when the job is discarded, any associated database writes from
     // the sync are also undone.
     this.syncedContracts.clear();
+    this.verifiedClassIds.clear();
     this.excludedFromSync.delete(jobId);
     return Promise.resolve();
   }
@@ -138,7 +144,7 @@ export class ContractSyncService implements StagedStore {
     }
 
     this.log.debug(`Syncing contract ${contractAddress} for ${scopesToSync.length} scope(s)`);
-    const verifyPromise = verifyFn();
+    const verifyPromise = this.#getOrStartVerification(contractAddress, verifyFn);
 
     for (const scope of scopesToSync) {
       const key = toKey(contractAddress, scope);
@@ -150,6 +156,21 @@ export class ContractSyncService implements StagedStore {
         });
       this.syncedContracts.set(key, promise);
     }
+  }
+
+  /** Returns the cached verification promise for a contract, starting a new one if needed. Evicts from cache on failure so retries re-verify. */
+  #getOrStartVerification(contractAddress: AztecAddress, verifyFn: () => Promise<void>): Promise<void> {
+    const contractKey = contractAddress.toString();
+    const cached = this.verifiedClassIds.get(contractKey);
+    if (cached) {
+      return cached;
+    }
+    const promise = verifyFn().catch(err => {
+      this.verifiedClassIds.delete(contractKey);
+      throw err;
+    });
+    this.verifiedClassIds.set(contractKey, promise);
+    return promise;
   }
 
   /** Runs fn while holding a slot in #syncSlot, bounding total concurrent scope syncs. */


### PR DESCRIPTION
## Summary

- Adds a `verifiedClassIds` cache to `ContractSyncService` so class ID verification (scope-independent) runs only once per contract address across multiple `ensureContractSynced` calls with different scopes.
- Clears the cache on `wipe()` and `discardStaged()`, and evicts a contract on failure so retries re-verify.