### PR TITLE
test(e2e): migrate simple epoch tests to pipelining

### DIFF
--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_first_slot.test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_first_slot.test.ts
@@ -29,8 +29,7 @@ jest.setTimeout(1000 * 60 * 10);
 
 const NODE_COUNT = 8;
 const COMMITTEE_SIZE = 3;
-const TX_COUNT = 2;
-const EPOCH = EpochNumber(4);
+const TX_COUNT = 8;
 
 // Spawns NODE_COUNT validator nodes, connected via a mocked gossip sub network, but sets
 // committee size to 3. Warps to immediately before the beginning of an epoch, and checks
@@ -54,6 +53,7 @@ describe('e2e_epochs/epochs_first_slot', () => {
     });
 
     // Setup context with the given set of validators, no reorgs, mocked gossip sub network, and no anvil test watcher.
+    // We expect 4 blocks per checkpoint with this config
     test = await EpochsTestContext.setup({
       numberOfAccounts: 0,
       initialValidators: validators,
@@ -62,6 +62,8 @@ describe('e2e_epochs/epochs_first_slot', () => {
       aztecProofSubmissionEpochs: 1024,
       aztecEpochDuration: 32,
       aztecSlotDurationInL1Slots: 3,
+      ethereumSlotDuration: 12,
+      blockDurationMs: 6000,
       startProverNode: false,
       aztecTargetCommitteeSize: COMMITTEE_SIZE,
       enforceTimeTable: true,
@@ -70,6 +72,8 @@ describe('e2e_epochs/epochs_first_slot', () => {
       attestationPropagationTime: 0.5,
       archiverPollingIntervalMS: 200,
       skipInitialSequencer: true,
+      enableProposerPipelining: true,
+      inboxLag: 2,
     });
 
     ({ context, logger } = test);
@@ -110,9 +114,18 @@ describe('e2e_epochs/epochs_first_slot', () => {
     const sequencers = nodes.map(node => node.getSequencer()!);
     const { failEvents } = test.watchSequencerEvents(sequencers, i => ({ validator: validators[i].attester }));
 
-    // Warp to before the first slot of an epoch, so that the sequencers are ready to build blocks.
-    const [epochStart] = getTimestampRangeForEpoch(EPOCH, test.constants);
-    await test.context.cheatCodes.eth.warp(Number(epochStart) - test.L1_BLOCK_TIME_IN_S, {
+    // Jump to the beginning of two epochs from now
+    const currentEpoch = (await test.monitor.run()).l2EpochNumber;
+    const epoch = EpochNumber(currentEpoch + 2);
+
+    // Warp so that the next pipelined build cycle targets the first slot of the epoch. Under
+    // proposer pipelining the build window starts one L2 slot earlier than the target slot
+    // so we want wall-clock to enter `firstSlot - 1` (the last slot of the previous epoch) before
+    // the next L1 block. Subtracting `L2_SLOT_DURATION + L1_BLOCK_TIME` puts us one L1 block before that
+    // build slot starts, so the proposer for `firstSlot` gets the full build window available
+    // before the epoch boundary is crossed on L1.
+    const [epochStart] = getTimestampRangeForEpoch(epoch, test.constants);
+    await test.context.cheatCodes.eth.warp(Number(epochStart) - test.L2_SLOT_DURATION_IN_S - test.L1_BLOCK_TIME_IN_S, {
       resetBlockInterval: true,
     });
 
@@ -126,7 +139,7 @@ describe('e2e_epochs/epochs_first_slot', () => {
     logger.warn(`All txs have been mined`);
 
     // Check that the first two slots of the epoch have a block
-    const [firstSlot] = getSlotRangeForEpoch(EPOCH, test.constants);
+    const [firstSlot] = getSlotRangeForEpoch(epoch, test.constants);
     const secondSlot = SlotNumber(firstSlot + 1);
     logger.warn(`Waiting until blocks are synced for slots ${firstSlot} and ${secondSlot}`);
     await retryUntil(
@@ -141,12 +154,6 @@ describe('e2e_epochs/epochs_first_slot', () => {
       1,
     );
 
-    // Expect no failures from sequencers during block building.
-    // The following error is marked as a flake on the test ignore patterns,
-    // so we can have this test run for a while before it breaks CI on a recoverable error.
-    if (failEvents.length > 0) {
-      logger.error(`Failed events from sequencers`, failEvents);
-    }
-    expect(failEvents).toEqual([]);
+    test.assertNoFailuresFromSequencers(failEvents);
   });
 });

--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_missed_l1_publish.test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_missed_l1_publish.test.ts
@@ -374,6 +374,10 @@ describe('e2e_epochs/epochs_missed_l1_publish', () => {
       ) {
         return false;
       }
+      // Expected
+      if (e.type === 'pipelined-checkpoint-discarded') {
+        return false;
+      }
       return true;
     });
     if (unexpectedFailEvents.length > 0) {

--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_simple_block_building.test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_simple_block_building.test.ts
@@ -23,7 +23,7 @@ import { EpochsTestContext } from './epochs_test.js';
 jest.setTimeout(1000 * 60 * 10);
 
 const NODE_COUNT = 3;
-const TX_COUNT = 3;
+const TX_COUNT = 8;
 
 // Sets up a lightweight RPC-only node without any account deployment, registers a test contract
 // locally, then spawns NODE_COUNT validator nodes connected via a mocked gossip sub network.
@@ -53,9 +53,13 @@ describe('e2e_epochs/epochs_simple_block_building', () => {
       mockGossipSubNetwork: true,
       disableAnvilTestWatcher: true,
       aztecProofSubmissionEpochs: 1024,
+      aztecSlotDurationInL1Slots: 3,
+      ethereumSlotDuration: 12,
+      blockDurationMs: 6000,
       startProverNode: false,
       enforceTimeTable: true,
       skipInitialSequencer: true,
+      enableProposerPipelining: true,
       inboxLag: 2,
     });
 
@@ -100,12 +104,7 @@ describe('e2e_epochs/epochs_simple_block_building', () => {
     );
     logger.warn(`All txs have been mined`);
 
-    // Expect no failures from sequencers during block building.
-    // The following error is marked as a flake on the test ignore patterns,
-    // so we can have this test run for a while before it breaks CI on a recoverable error.
-    if (failEvents.length > 0) {
-      logger.error(`Failed events from sequencers`, failEvents);
-    }
-    expect(failEvents).toEqual([]);
+    // Expect no failures from sequencers during block building
+    test.assertNoFailuresFromSequencers(failEvents);
   });
 });

--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_test.ts
@@ -497,6 +497,7 @@ export class EpochsTestContext {
   public watchSequencerEvents(
     sequencers: SequencerClient[],
     getMetadata: (i: number) => Record<string, any> = () => ({}),
+    additionalFailEventKeys: (keyof SequencerEvents)[] = [],
   ) {
     const stateChanges: TrackedSequencerEvent[] = [];
     const failEvents: TrackedSequencerEvent[] = [];
@@ -507,6 +508,10 @@ export class EpochsTestContext {
       'block-build-failed',
       'checkpoint-publish-failed',
       'proposer-rollup-check-failed',
+      'checkpoint-error',
+      'checkpoint-publish-failed',
+      'pipelined-checkpoint-discarded',
+      ...additionalFailEventKeys,
     ];
 
     const makeEvent = (
@@ -544,5 +549,12 @@ export class EpochsTestContext {
     });
 
     return { failEvents, stateChanges };
+  }
+
+  public assertNoFailuresFromSequencers(failEvents: TrackedSequencerEvent[]) {
+    if (failEvents.length > 0) {
+      this.logger.error(`Failed events from sequencers`, failEvents);
+    }
+    expect(failEvents).toEqual([]);
   }
 }

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.ts
@@ -181,17 +181,15 @@ export class Sequencer extends (EventEmitter as new () => TypedEventEmitter<Sequ
     try {
       await this.work();
     } catch (err) {
-      this.emit('checkpoint-error', { error: err as Error });
-      if (err instanceof SequencerTooSlowError) {
-        // Log as warn only if we had to abort halfway through the block proposal
-        const logLvl = [SequencerState.INITIALIZING_CHECKPOINT, SequencerState.PROPOSER_CHECK].includes(
-          err.proposedState,
-        )
-          ? ('debug' as const)
-          : ('warn' as const);
-        this.log[logLvl](err.message, { now: this.dateProvider.nowInSeconds() });
+      if (
+        err instanceof SequencerTooSlowError &&
+        [SequencerState.INITIALIZING_CHECKPOINT, SequencerState.PROPOSER_CHECK].includes(err.proposedState)
+      ) {
+        // No need to alert if we just didn't get to start in time
+        this.log.debug(err.message, { now: this.dateProvider.nowInSeconds() });
       } else {
         // Re-throw other errors
+        this.emit('checkpoint-error', { error: err as Error });
         throw err;
       }
     } finally {


### PR DESCRIPTION
Enable pipelining on `epochs_first_slot` and `simple_block_building`