### PR TITLE
feat: Improve add_scaled_batch

### DIFF
--- a/barretenberg/cpp/src/barretenberg/polynomials/polynomial.cpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/polynomial.cpp
@@ -308,21 +308,23 @@ void add_scaled_batch(Polynomial<Fr>& dst,
     parallel_for([&](const ThreadChunk& chunk) {
         BB_BENCH_TRACY_NAME("add_scaled_batch/chunk");
         auto chunk_indices = chunk.range(union_size, min_start);
+        if (chunk_indices.empty()) {
+            return;
+        }
+        auto chunk_start = chunk_indices.front();
+        auto chunk_end = chunk_indices.back();
+
         for (size_t k = 0; k < sources.size(); ++k) {
             const auto& src = sources[k];
             const Fr c = scalars[k];
             const size_t src_start = src.start_index;
             const size_t src_end = src.end_index();
 
-            auto first_idx = chunk_indices.front();
-            auto last_idx = chunk_indices.back();
-            if (last_idx < src_start || first_idx >= src_end) {
-                continue; // This chunk does not overlap with the source polynomial
-            }
-            for (size_t i : chunk_indices) {
-                if (i >= src_start && i < src_end) {
-                    dst.at(i) += c * src[i];
-                }
+            const size_t idx_start = std::max(chunk_start, src_start);
+            const size_t idx_end = std::min(chunk_end + 1, src_end);
+
+            for (size_t i = idx_start; i < idx_end; ++i) {
+                dst.at(i) += c * src[i];
             }
         }
     });

--- a/barretenberg/cpp/src/barretenberg/polynomials/polynomial.cpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/polynomial.cpp
@@ -313,6 +313,12 @@ void add_scaled_batch(Polynomial<Fr>& dst,
             const Fr c = scalars[k];
             const size_t src_start = src.start_index;
             const size_t src_end = src.end_index();
+
+            auto first_idx = chunk_indices.front();
+            auto last_idx = chunk_indices.back();
+            if (last_idx < src_start || first_idx >= src_end) {
+                continue; // This chunk does not overlap with the source polynomial
+            }
             for (size_t i : chunk_indices) {
                 if (i >= src_start && i < src_end) {
                     dst.at(i) += c * src[i];

--- a/barretenberg/cpp/src/barretenberg/polynomials/polynomial.cpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/polynomial.cpp
@@ -316,7 +316,7 @@ void add_scaled_batch(Polynomial<Fr>& dst,
 
         for (size_t k = 0; k < sources.size(); ++k) {
             const auto& src = sources[k];
-            const Fr c = scalars[k];
+            const Fr& c = scalars[k];
             const size_t src_start = src.start_index;
             const size_t src_end = src.end_index();
 

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/prover.cpp
@@ -239,7 +239,9 @@ void AvmProver::execute_pcs_rounds()
                         continue;
                     }
 
-                    for (size_t idx = sources[poly_id].start_index(); idx < sources[poly_id].end_index(); idx++) {
+                    const size_t start_idx = sources[poly_id].start_index();
+                    const size_t end_idx = sources[poly_id].end_index();
+                    for (size_t idx = start_idx; idx < end_idx; idx++) {
                         batched_polys[slot_id].at(idx) += scalars[poly_id] * sources[poly_id][idx];
                     }
                 }

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/prover.cpp
@@ -216,27 +216,47 @@ void AvmProver::execute_pcs_rounds()
         return static_cast<size_t>(std::distance(polys.begin(), it));
     };
 
+    auto add_scaled_batched =
+        [](Polynomial& dst, const std::span<Polynomial>& sources, const std::span<FF>& scalars, const size_t skip_idx) {
+            const size_t num_slots = bb::get_num_cpus();
+            std::vector<Polynomial> batched_polys(num_slots);
+            for (auto& poly : batched_polys) {
+                poly = Polynomial(dst.size(), dst.virtual_size(), dst.start_index());
+            }
+
+            // Chunks are consumed dynamically via an atomic counter: faster threads naturally pick up
+            // more chunks while the slot they write to stays fixed for the life of their outer task.
+            std::atomic<size_t> next_poly(0);
+
+            // Accumulate polynomials: each thread picks up the next available polynomial
+            parallel_for(num_slots, [&](size_t slot_id) {
+                while (true) {
+                    const size_t poly_id = next_poly.fetch_add(1, std::memory_order_relaxed);
+                    if (poly_id >= sources.size()) {
+                        break;
+                    }
+                    if (poly_id == skip_idx) {
+                        continue;
+                    }
+
+                    for (size_t idx = sources[poly_id].start_index(); idx < sources[poly_id].end_index(); idx++) {
+                        batched_polys[slot_id].at(idx) += scalars[poly_id] * sources[poly_id][idx];
+                    }
+                }
+            });
+
+            for (const auto& poly : batched_polys) {
+                dst += poly;
+            }
+        };
+
     // Batch to be shifted polys in their to_be_shifted form
     // Search for poly with largest end index to avoid allocating a zero polynomial of circuit size
     size_t max_idx = index_of_max_end_index(shifted_polys);
 
     Polynomial batched_shifted = std::move(shifted_polys[max_idx]);
     batched_shifted *= shifted_challenges[max_idx];
-    {
-        // Fuse the remaining add_scaled dispatches into a single parallel_for to amortise startup cost.
-        std::vector<PolynomialSpan<const FF>> sources;
-        std::vector<FF> scalars;
-        sources.reserve(shifted_polys.size());
-        scalars.reserve(shifted_polys.size());
-        for (size_t idx = 0; idx < shifted_polys.size(); ++idx) {
-            if (idx != max_idx) {
-                sources.emplace_back(shifted_polys[idx]);
-                scalars.push_back(shifted_challenges[idx]);
-            }
-        }
-        add_scaled_batch(
-            batched_shifted, std::span<const PolynomialSpan<const FF>>(sources), std::span<const FF>(scalars));
-    }
+    add_scaled_batched(batched_shifted, shifted_polys, shifted_challenges, max_idx);
 
     // Batch unshifted polys (to avoid allocating a zero polynomial of circuit size, we initialize the batched
     // polynomial with the polynomial of the largest size)
@@ -245,25 +265,15 @@ void AvmProver::execute_pcs_rounds()
     Polynomial batched_unshifted = std::move(unshifted_polys[max_idx]);
     batched_unshifted *= unshifted_challenges[max_idx];
     batched_unshifted += batched_shifted;
-    {
-        // Only operate in the range of not to be shifted polys, as the contribution for those has already been added.
-        std::vector<PolynomialSpan<const FF>> sources;
-        std::vector<FF> scalars;
-        sources.reserve(unshifted_polys.size());
-        scalars.reserve(unshifted_polys.size());
-        for (size_t idx = 0; idx < unshifted_polys.size(); ++idx) {
-            if (idx >= WIRES_TO_BE_SHIFTED_START_IDX && idx < WIRES_TO_BE_SHIFTED_END_IDX) {
-                continue;
-            }
-            if (idx == max_idx) {
-                continue;
-            }
-            sources.emplace_back(unshifted_polys[idx]);
-            scalars.push_back(unshifted_challenges[idx]);
-        }
-        add_scaled_batch(
-            batched_unshifted, std::span<const PolynomialSpan<const FF>>(sources), std::span<const FF>(scalars));
-    }
+    add_scaled_batched(batched_unshifted,
+                       unshifted_polys.subspan(0, WIRES_TO_BE_SHIFTED_START_IDX),
+                       unshifted_challenges.subspan(0, WIRES_TO_BE_SHIFTED_START_IDX),
+                       max_idx);
+    add_scaled_batched(batched_unshifted,
+                       unshifted_polys.subspan(WIRES_TO_BE_SHIFTED_END_IDX),
+                       unshifted_challenges.subspan(WIRES_TO_BE_SHIFTED_END_IDX),
+                       max_idx > WIRES_TO_BE_SHIFTED_END_IDX ? max_idx - WIRES_TO_BE_SHIFTED_END_IDX
+                                                             : unshifted_polys.size());
 
     const size_t circuit_dyadic_size = numeric::round_up_power_2(batched_unshifted.end_index());
 
@@ -308,5 +318,4 @@ HonkProof AvmProver::construct_proof()
 
     return export_proof();
 }
-
 } // namespace bb::avm2


### PR DESCRIPTION
Two improvements:
 1. `add_scaled_batch` was iterating over all polys to be batched and processing indices based on the range of the destination poly (the biggest of the polys to be batched). This PR adds a skipping condition that speeds up the function: we only iterate over the poly to be batched
 2. Write a bespoke `add_batch_scaled` for use in the AVM with dynamic allocation of threads: each thread picks up the new available poly and works with it. This makes optimal usage of the fact that many polys in the AVM are small.

Link to AVM bulk test: http://ci.aztec-labs.com/1df80aa9b6ae0088. The PCS component is `446ms` down from ~`600ms`