### PR TITLE
refactor(pxe): batch RPC calls for note and event validation

### DIFF
--- a/yarn-project/foundation/src/collection/array.test.ts
+++ b/yarn-project/foundation/src/collection/array.test.ts
@@ -13,6 +13,7 @@ import {
   stdDev,
   times,
   unique,
+  uniqueBy,
   variance,
 } from './array.js';
 
@@ -140,6 +141,24 @@ describe('compactArray', () => {
 describe('unique', () => {
   it('works with bigints', () => {
     expect(unique([1n, 2n, 1n])).toEqual([1n, 2n]);
+  });
+});
+
+describe('uniqueBy', () => {
+  it('keeps the first occurrence per key', () => {
+    const items = [
+      { id: 'a', n: 1 },
+      { id: 'b', n: 2 },
+      { id: 'a', n: 3 },
+    ];
+    expect(uniqueBy(items, x => x.id)).toEqual([
+      { id: 'a', n: 1 },
+      { id: 'b', n: 2 },
+    ]);
+  });
+
+  it('returns an empty array for an empty input', () => {
+    expect(uniqueBy([], x => x)).toEqual([]);
   });
 });
 

--- a/yarn-project/foundation/src/collection/array.ts
+++ b/yarn-project/foundation/src/collection/array.ts
@@ -139,6 +139,26 @@ export function unique<T>(arr: T[]): T[] {
 }
 
 /**
+ * Removes duplicates from the given array using a key function. The first occurrence of each key is kept.
+ * @param arr - The array.
+ * @param keyFn - A function that returns a primitive key for each element. Elements with the same key are
+ *               considered duplicates.
+ * @returns A new array.
+ */
+export function uniqueBy<T, K extends string | number | bigint>(arr: T[], keyFn: (item: T) => K): T[] {
+  const seen = new Set<K>();
+  const result: T[] = [];
+  for (const item of arr) {
+    const key = keyFn(item);
+    if (!seen.has(key)) {
+      seen.add(key);
+      result.push(item);
+    }
+  }
+  return result;
+}
+
+/**
  * Removes all undefined elements from the array.
  * @param arr - The array.
  * @returns A new array.

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
@@ -634,10 +634,6 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
    *
    * This function is an auxiliary to support legacy (capsule backed) and new (ephemeral array backed) versions of the
    * `validateAndStoreEnqueuedNotesAndEvents` oracle.
-   *
-   * Tx effects are pre-fetched and de-duplicated here so that multiple notes/events from the same transaction share
-   * a single `getTxEffect` round-trip. The note service then performs a single batched `findLeavesIndexes` call across
-   * all the request nullifiers, instead of one per note.
    */
   async #processValidationRequests(
     noteValidationRequests: NoteValidationRequest[],

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
@@ -1,5 +1,6 @@
 import type { ARCHIVE_HEIGHT, NOTE_HASH_TREE_HEIGHT } from '@aztec/constants';
 import type { BlockNumber } from '@aztec/foundation/branded-types';
+import { uniqueBy } from '@aztec/foundation/collection';
 import { Aes128 } from '@aztec/foundation/crypto/aes128';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { Point } from '@aztec/foundation/curves/grumpkin';
@@ -28,7 +29,7 @@ import { MessageContext, deriveAppSiloedSharedSecret } from '@aztec/stdlib/logs'
 import { getNonNullifiedL1ToL2MessageWitness } from '@aztec/stdlib/messaging';
 import type { NoteStatus } from '@aztec/stdlib/note';
 import { MerkleTreeId, type NullifierMembershipWitness, PublicDataWitness } from '@aztec/stdlib/trees';
-import type { BlockHeader, Capsule, OffchainEffect } from '@aztec/stdlib/tx';
+import type { BlockHeader, Capsule, IndexedTxEffect, OffchainEffect, TxHash } from '@aztec/stdlib/tx';
 
 import { createContractLogger, logContractMessage, stripAztecnrLogPrefix } from '../../contract_logging.js';
 import type { ContractSyncService } from '../../contract_sync/contract_sync_service.js';
@@ -633,42 +634,28 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
    *
    * This function is an auxiliary to support legacy (capsule backed) and new (ephemeral array backed) versions of the
    * `validateAndStoreEnqueuedNotesAndEvents` oracle.
+   *
+   * Tx effects are pre-fetched and de-duplicated here so that multiple notes/events from the same transaction share
+   * a single `getTxEffect` round-trip. The note service then performs a single batched `findLeavesIndexes` call across
+   * all the request nullifiers, instead of one per note.
    */
   async #processValidationRequests(
     noteValidationRequests: NoteValidationRequest[],
     eventValidationRequests: EventValidationRequest[],
     scope: AztecAddress,
   ) {
+    const txEffects = await this.#fetchTxEffects([
+      ...noteValidationRequests.map(r => r.txHash),
+      ...eventValidationRequests.map(r => r.txHash),
+    ]);
+
     const noteService = new NoteService(this.noteStore, this.aztecNode, this.anchorBlockHeader, this.jobId);
-    const noteStorePromises = noteValidationRequests.map(request =>
-      noteService.validateAndStoreNote(
-        request.contractAddress,
-        request.owner,
-        request.storageSlot,
-        request.randomness,
-        request.noteNonce,
-        request.content,
-        request.noteHash,
-        request.nullifier,
-        request.txHash,
-        scope,
-      ),
-    );
-
     const eventService = new EventService(this.anchorBlockHeader, this.aztecNode, this.privateEventStore, this.jobId);
-    const eventStorePromises = eventValidationRequests.map(request =>
-      eventService.validateAndStoreEvent(
-        request.contractAddress,
-        request.eventTypeId,
-        request.randomness,
-        request.serializedEvent,
-        request.eventCommitment,
-        request.txHash,
-        scope,
-      ),
-    );
 
-    await Promise.all([...noteStorePromises, ...eventStorePromises]);
+    await Promise.all([
+      noteService.validateAndStoreNotes(noteValidationRequests, scope, txEffects),
+      eventService.validateAndStoreEvents(eventValidationRequests, scope, txEffects),
+    ]);
   }
 
   public async getLogsByTag(
@@ -974,6 +961,20 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
   /** Returns offchain effects collected during execution. */
   public getOffchainEffects(): OffchainEffect[] {
     return this.offchainEffects;
+  }
+
+  /**
+   * Fetches tx effects for the given hashes in parallel, deduplicating repeated hashes so each tx is only requested
+   * once. Returns a map keyed by `TxHash.toString()`; hashes for which the node has no tx effect are omitted.
+   */
+  async #fetchTxEffects(txHashes: TxHash[]): Promise<Map<string, IndexedTxEffect>> {
+    const uniqueTxHashes = uniqueBy(txHashes, h => h.toString());
+    const fetched = await Promise.all(uniqueTxHashes.map(h => this.aztecNode.getTxEffect(h)));
+    return new Map(
+      uniqueTxHashes
+        .map((h, i): [string, IndexedTxEffect | undefined] => [h.toString(), fetched[i]])
+        .filter((entry): entry is [string, IndexedTxEffect] => entry[1] !== undefined),
+    );
   }
 
   /** Runs a query concurrently with a validation that the block hash is not ahead of the anchor block. */

--- a/yarn-project/pxe/src/events/event_service.test.ts
+++ b/yarn-project/pxe/src/events/event_service.test.ts
@@ -12,10 +12,11 @@ import { type IndexedTxEffect, TxEffect } from '@aztec/stdlib/tx';
 
 import { mock } from 'jest-mock-extended';
 
+import { EventValidationRequest } from '../contract_function_simulator/noir-structs/event_validation_request.js';
 import { PrivateEventStore } from '../storage/private_event_store/private_event_store.js';
 import { EventService } from './event_service.js';
 
-describe('validateAndStoreEvent', () => {
+describe('validateAndStoreEvents', () => {
   let blockNumber: BlockNumber;
   let eventSelector: EventSelector;
   let randomness: Fr;
@@ -66,11 +67,10 @@ describe('validateAndStoreEvent', () => {
 
     /* Happy path context conditions:
      ** - PXE is sync'd to _at least_ block including tx
-     ** - Node returns the corresponding tx effect and the tx effect includes the event commitment
+     ** - Caller provides the corresponding tx effect via the prefetched map and the tx effect includes the event
+     **   commitment.
      */
     const anchorBlockHeader = makeBlockHeader(0, { blockNumber });
-
-    aztecNode.getTxEffect.mockImplementation(() => Promise.resolve(indexedTxEffect));
 
     logger = mock<Logger>();
     eventService = new EventService(anchorBlockHeader, aztecNode, privateEventStore, 'test', logger);
@@ -80,34 +80,33 @@ describe('validateAndStoreEvent', () => {
     overrides: {
       eventContent?: Fr[];
       eventCommitment?: Fr;
+      txEffectsMap?: Map<string, IndexedTxEffect>;
     } = {},
   ) {
-    await eventService.validateAndStoreEvent(
+    const request = new EventValidationRequest(
       contractAddress,
       eventSelector,
       randomness,
-      overrides.eventContent || eventContent,
-      overrides.eventCommitment || eventCommitment,
+      overrides.eventContent ?? eventContent,
+      overrides.eventCommitment ?? eventCommitment,
       txEffect.txHash,
-      recipient,
     );
+
+    const map = overrides.txEffectsMap ?? defaultTxEffectsMap();
+    await eventService.validateAndStoreEvents([request], recipient, map);
 
     await privateEventStore.commit('test');
   }
 
   it('should throw when tx does not exist or has no effects', async () => {
-    aztecNode.getTxEffect.mockImplementation(() => Promise.resolve(undefined));
-    await expect(runStoreEvent).rejects.toThrow(/Could not find tx effect for tx hash/);
+    const txEffectsMap = new Map();
+    await expect(() => runStoreEvent({ txEffectsMap })).rejects.toThrow(/Could not find tx effect for tx hash/);
   });
 
   it('should throw when tx block has not yet been synchronized', async () => {
-    indexedTxEffect = {
-      ...indexedTxEffect,
-      l2BlockNumber: BlockNumber(blockNumber + 1),
-    };
-    aztecNode.getTxEffect.mockImplementation(() => Promise.resolve(indexedTxEffect));
-
-    await expect(runStoreEvent).rejects.toThrow(
+    const laterIndexedTxEffect = { ...indexedTxEffect, l2BlockNumber: BlockNumber(blockNumber + 1) };
+    const txEffectsMap = new Map([[txEffect.txHash.toString(), laterIndexedTxEffect]]);
+    await expect(() => runStoreEvent({ txEffectsMap })).rejects.toThrow(
       /Obtained a newer tx effect for .* for an event validation request than the anchor block/,
     );
   });
@@ -159,4 +158,8 @@ describe('validateAndStoreEvent', () => {
     expect(result.length).toEqual(1);
     expect(result[0].packedEvent).toEqual(eventContent);
   });
+
+  function defaultTxEffectsMap() {
+    return new Map([[txEffect.txHash.toString(), indexedTxEffect]]);
+  }
 });

--- a/yarn-project/pxe/src/events/event_service.ts
+++ b/yarn-project/pxe/src/events/event_service.ts
@@ -44,8 +44,14 @@ export class EventService {
     txEffects: Map<string, IndexedTxEffect>,
     anchorBlockNumber: number,
   ): Promise<void> {
-    const { contractAddress, eventTypeId: selector, randomness, serializedEvent: content, eventCommitment, txHash } =
-      request;
+    const {
+      contractAddress,
+      eventTypeId: selector,
+      randomness,
+      serializedEvent: content,
+      eventCommitment,
+      txHash,
+    } = request;
 
     // Defense-in-depth: the built-in private-event path derives this commitment from content before enqueueing, but
     // unconstrained PXE-side code (e.g. a custom message handler) can reach this oracle with arbitrary

--- a/yarn-project/pxe/src/events/event_service.ts
+++ b/yarn-project/pxe/src/events/event_service.ts
@@ -1,11 +1,10 @@
-import type { Fr } from '@aztec/foundation/curves/bn254';
 import { createLogger } from '@aztec/foundation/log';
-import type { EventSelector } from '@aztec/stdlib/abi';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
 import { computePrivateEventCommitment, siloNullifier } from '@aztec/stdlib/hash';
 import type { AztecNode } from '@aztec/stdlib/interfaces/server';
-import type { BlockHeader, TxHash } from '@aztec/stdlib/tx';
+import type { BlockHeader, IndexedTxEffect } from '@aztec/stdlib/tx';
 
+import type { EventValidationRequest } from '../contract_function_simulator/noir-structs/event_validation_request.js';
 import { PrivateEventStore } from '../storage/private_event_store/private_event_store.js';
 
 export class EventService {
@@ -17,15 +16,37 @@ export class EventService {
     private readonly log = createLogger('pxe:event_service'),
   ) {}
 
-  public async validateAndStoreEvent(
-    contractAddress: AztecAddress,
-    selector: EventSelector,
-    randomness: Fr,
-    content: Fr[],
-    eventCommitment: Fr,
-    txHash: TxHash,
+  /**
+   * Validates and stores a batch of private events against pre-fetched tx effects.
+   *
+   * @param requests - The events to validate and store.
+   * @param scope - The scope under which the events are being stored.
+   * @param txEffects - Pre-fetched tx effects keyed by `TxHash.toString()`. Must contain entries for every request's
+   *                   txHash; missing entries are treated as a node bug and cause an error.
+   */
+  public async validateAndStoreEvents(
+    requests: EventValidationRequest[],
     scope: AztecAddress,
+    txEffects: Map<string, IndexedTxEffect>,
   ): Promise<void> {
+    if (requests.length === 0) {
+      return;
+    }
+
+    const anchorBlockNumber = this.anchorBlockHeader.getBlockNumber();
+
+    await Promise.all(requests.map(req => this.#validateAndStoreEvent(req, scope, txEffects, anchorBlockNumber)));
+  }
+
+  async #validateAndStoreEvent(
+    request: EventValidationRequest,
+    scope: AztecAddress,
+    txEffects: Map<string, IndexedTxEffect>,
+    anchorBlockNumber: number,
+  ): Promise<void> {
+    const { contractAddress, eventTypeId: selector, randomness, serializedEvent: content, eventCommitment, txHash } =
+      request;
+
     // Defense-in-depth: the built-in private-event path derives this commitment from content before enqueueing, but
     // unconstrained PXE-side code (e.g. a custom message handler) can reach this oracle with arbitrary
     // (content, commitment) pairs. Without this check it could bind arbitrary content to a legitimate tx nullifier,
@@ -42,13 +63,9 @@ export class EventService {
     // (and thus we're less concerned about being ahead of the synced block), we use the synced block number to
     // maintain consistent behavior in the PXE. Additionally, events should never be ahead of the synced block here
     // since `fetchTaggedLogs` only processes logs up to the synced block.
-    const [siloedEventCommitment, txEffect] = await Promise.all([
-      siloNullifier(contractAddress, eventCommitment),
-      this.aztecNode.getTxEffect(txHash),
-    ]);
+    const siloedEventCommitment = await siloNullifier(contractAddress, eventCommitment);
 
-    const anchorBlockNumber = this.anchorBlockHeader.getBlockNumber();
-
+    const txEffect = txEffects.get(txHash.toString());
     if (!txEffect) {
       // We error out instead of just logging a warning and skipping the event because this would indicate a bug. This
       // is because the node has already served info about this tx either when obtaining the log (TxScopedL2Log contain

--- a/yarn-project/pxe/src/notes/note_service.test.ts
+++ b/yarn-project/pxe/src/notes/note_service.test.ts
@@ -15,6 +15,7 @@ import { type IndexedTxEffect, TxEffect, TxHash } from '@aztec/stdlib/tx';
 import { jest } from '@jest/globals';
 import { mock } from 'jest-mock-extended';
 
+import { NoteValidationRequest } from '../contract_function_simulator/noir-structs/note_validation_request.js';
 import { NoteStore } from '../storage/note_store/note_store.js';
 import { NoteService } from './note_service.js';
 
@@ -195,7 +196,7 @@ describe('NoteService', () => {
     expect(getNotesSpy).toHaveBeenCalledWith(expect.objectContaining({ contractAddress }), 'test');
   });
 
-  describe('validateAndStoreNote', () => {
+  describe('validateAndStoreNotes', () => {
     // Recipient is different from the owner because recipient refers to the
     // recipient of the message containing the note, while owner refers to the
     // owner of the note.
@@ -213,6 +214,8 @@ describe('NoteService', () => {
     let txEffect: TxEffect;
     let indexedTxEffect: IndexedTxEffect;
     let blockNumber: BlockNumber;
+
+    let buildRequest: (overrides?: Partial<NoteValidationRequest>) => NoteValidationRequest;
 
     // beforeEach sets up the happy path case, so error modes are tested
     // by minimally failing happy path conditions
@@ -244,34 +247,32 @@ describe('NoteService', () => {
 
       /* Happy path context conditions:
        ** - PXE is sync'd to _at least_ block including tx
-       ** - Node knows tx effect
+       ** - Node knows tx effect (passed in via the prefetched map)
        ** - Node knows unique note hash (and siloed nullifier if requested)
        */
       setSyncedBlockNumber(blockNumber);
 
-      aztecNode.getTxEffect.mockImplementation(queryTxHash =>
-        Promise.resolve(queryTxHash == txHash ? indexedTxEffect : undefined),
-      );
+      buildRequest = (overrides = {}) =>
+        new NoteValidationRequest(
+          overrides.contractAddress ?? contractAddress,
+          overrides.owner ?? owner,
+          overrides.storageSlot ?? storageSlot,
+          overrides.randomness ?? randomness,
+          overrides.noteNonce ?? noteNonce,
+          overrides.content ?? content,
+          overrides.noteHash ?? noteHash,
+          overrides.nullifier ?? nullifier,
+          overrides.txHash ?? txHash,
+        );
 
-      aztecNode.findLeavesIndexes.mockImplementation((_queryBlockParam, _treeId, _leaves) => {
-        // By default the note is not yet nullified.
-        return Promise.resolve([undefined]);
+      aztecNode.findLeavesIndexes.mockImplementation((_queryBlockParam, _treeId, leaves) => {
+        // By default the notes are not yet nullified.
+        return Promise.resolve(leaves.map(() => undefined));
       });
     });
 
     it('should store note if it exists in a tx effect', async () => {
-      await noteService.validateAndStoreNote(
-        contractAddress,
-        owner,
-        storageSlot,
-        randomness,
-        noteNonce,
-        content,
-        noteHash,
-        nullifier,
-        txHash,
-        recipient.address,
-      );
+      await noteService.validateAndStoreNotes([buildRequest()], recipient.address, defaultTxEffectsMap());
 
       // Verify note was stored
       const notes = await noteStore.getNotes({ contractAddress, scopes: [recipient.address] }, 'test');
@@ -292,34 +293,20 @@ describe('NoteService', () => {
 
     it('should throw if tx hash does not exist', async () => {
       await expect(
-        noteService.validateAndStoreNote(
-          contractAddress,
-          owner,
-          storageSlot,
-          randomness,
-          noteNonce,
-          content,
-          noteHash,
-          nullifier,
-          TxHash.random(),
+        noteService.validateAndStoreNotes(
+          [buildRequest({ txHash: TxHash.random() })],
           recipient.address,
+          defaultTxEffectsMap(),
         ),
       ).rejects.toThrow(/Could not find tx effect/);
     });
 
     it('should throw if note was not emitted in the tx', async () => {
       await expect(
-        noteService.validateAndStoreNote(
-          contractAddress,
-          owner,
-          storageSlot,
-          randomness,
-          noteNonce,
-          content,
-          Fr.random(), // note hash
-          nullifier,
-          txHash,
+        noteService.validateAndStoreNotes(
+          [buildRequest({ noteHash: Fr.random() })],
           recipient.address,
+          defaultTxEffectsMap(),
         ),
       ).rejects.toThrow(/is not present in tx/);
     });
@@ -328,19 +315,42 @@ describe('NoteService', () => {
       setSyncedBlockNumber(BlockNumber(blockNumber - 1));
 
       await expect(
-        noteService.validateAndStoreNote(
-          contractAddress,
-          owner,
-          storageSlot,
-          randomness,
-          noteNonce,
-          content,
-          noteHash,
-          nullifier,
-          txHash,
-          recipient.address,
-        ),
+        noteService.validateAndStoreNotes([buildRequest()], recipient.address, defaultTxEffectsMap()),
       ).rejects.toThrow(/Obtained a newer tx effect for .* for a note validation request than the anchor block/);
+    });
+
+    it('should batch findLeavesIndexes across notes', async () => {
+      // Two notes from the same tx so we can reuse the indexedTxEffect; each carries its own unique note hash.
+      const otherNoteHash = Fr.random();
+      const otherNullifier = Fr.random();
+      const otherNoteNonce = Fr.random();
+      const otherUniqueNoteHash = await computeUniqueNoteHash(
+        otherNoteNonce,
+        await siloNoteHash(contractAddress, otherNoteHash),
+      );
+
+      const sharedTxEffect: IndexedTxEffect = {
+        ...indexedTxEffect,
+        data: TxEffect.from({
+          ...indexedTxEffect.data,
+          noteHashes: [uniqueNoteHash, otherUniqueNoteHash],
+        }),
+      };
+      const map = new Map([[txHash.toString(), sharedTxEffect]]);
+
+      await noteService.validateAndStoreNotes(
+        [
+          buildRequest(),
+          buildRequest({ noteHash: otherNoteHash, nullifier: otherNullifier, noteNonce: otherNoteNonce }),
+        ],
+        recipient.address,
+        map,
+      );
+
+      // Both notes should have been looked up in a single batched call.
+      expect(aztecNode.findLeavesIndexes).toHaveBeenCalledTimes(1);
+      const [, , leaves] = aztecNode.findLeavesIndexes.mock.calls[0];
+      expect(leaves).toHaveLength(2);
     });
 
     it('should nullify note if nullifier index is found', async () => {
@@ -349,24 +359,14 @@ describe('NoteService', () => {
 
       // Override the mock to return a nullifier index (indicating the note has been nullified)
       aztecNode.findLeavesIndexes.mockImplementation((_queryBlockNum, treeId, leaves) => {
-        if (treeId == MerkleTreeId.NULLIFIER_TREE && leaves[0].equals(siloedNullifier)) {
-          return Promise.resolve([nullifierIndex]);
-        }
-        return Promise.resolve([undefined]);
+        return Promise.resolve(
+          leaves.map(leaf =>
+            treeId == MerkleTreeId.NULLIFIER_TREE && leaf.equals(siloedNullifier) ? nullifierIndex : undefined,
+          ),
+        );
       });
 
-      await noteService.validateAndStoreNote(
-        contractAddress,
-        owner,
-        storageSlot,
-        randomness,
-        noteNonce,
-        content,
-        noteHash,
-        nullifier,
-        txHash,
-        recipient.address,
-      );
+      await noteService.validateAndStoreNotes([buildRequest()], recipient.address, defaultTxEffectsMap());
 
       const verifyNoteNullifiedInJobContext = async (jobId: string) => {
         // Now we verify that the note is stored as nullified by checking it can be retrieved only with
@@ -398,5 +398,9 @@ describe('NoteService', () => {
       await noteStore.commit('test');
       await verifyNoteNullifiedInJobContext('fresh-job');
     });
+
+    function defaultTxEffectsMap() {
+      return new Map([[txHash.toString(), indexedTxEffect]]);
+    }
   });
 });

--- a/yarn-project/pxe/src/notes/note_service.ts
+++ b/yarn-project/pxe/src/notes/note_service.ts
@@ -1,7 +1,7 @@
 import { chunk } from '@aztec/foundation/collection';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
-import type { DataInBlock } from '@aztec/stdlib/block';
+import { BlockHash, type DataInBlock } from '@aztec/stdlib/block';
 import { computeUniqueNoteHash, siloNoteHash, siloNullifier } from '@aztec/stdlib/hash';
 import { type AztecNode, MAX_RPC_LEN } from '@aztec/stdlib/interfaces/client';
 import { Note, NoteDao, NoteStatus } from '@aztec/stdlib/note';
@@ -219,13 +219,11 @@ export class NoteService {
     }
   }
 
-  async #findNullifierIndexes(anchorBlockHash: Fr, siloedNullifiers: Fr[]) {
+  async #findNullifierIndexes(anchorBlockHash: BlockHash, siloedNullifiers: Fr[]) {
     const batches = chunk(siloedNullifiers, MAX_RPC_LEN);
     return (
       await Promise.all(
-        batches.map(batch =>
-          this.aztecNode.findLeavesIndexes(anchorBlockHash, MerkleTreeId.NULLIFIER_TREE, batch),
-        ),
+        batches.map(batch => this.aztecNode.findLeavesIndexes(anchorBlockHash, MerkleTreeId.NULLIFIER_TREE, batch)),
       )
     ).flat();
   }

--- a/yarn-project/pxe/src/notes/note_service.ts
+++ b/yarn-project/pxe/src/notes/note_service.ts
@@ -1,3 +1,4 @@
+import { chunk } from '@aztec/foundation/collection';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
 import type { DataInBlock } from '@aztec/stdlib/block';
@@ -5,8 +6,9 @@ import { computeUniqueNoteHash, siloNoteHash, siloNullifier } from '@aztec/stdli
 import { type AztecNode, MAX_RPC_LEN } from '@aztec/stdlib/interfaces/client';
 import { Note, NoteDao, NoteStatus } from '@aztec/stdlib/note';
 import { MerkleTreeId } from '@aztec/stdlib/trees';
-import type { BlockHeader, TxHash } from '@aztec/stdlib/tx';
+import type { BlockHeader, IndexedTxEffect } from '@aztec/stdlib/tx';
 
+import type { NoteValidationRequest } from '../contract_function_simulator/noir-structs/note_validation_request.js';
 import type { NoteStore } from '../storage/note_store/note_store.js';
 
 export class NoteService {
@@ -80,24 +82,7 @@ export class NoteService {
     }
 
     const nullifiersToCheck = contractNotes.map(note => note.siloedNullifier);
-    const nullifierBatches = nullifiersToCheck.reduce(
-      (acc, nullifier) => {
-        if (acc[acc.length - 1].length < MAX_RPC_LEN) {
-          acc[acc.length - 1].push(nullifier);
-        } else {
-          acc.push([nullifier]);
-        }
-        return acc;
-      },
-      [[]] as Fr[][],
-    );
-    const nullifierIndexes = (
-      await Promise.all(
-        nullifierBatches.map(batch =>
-          this.aztecNode.findLeavesIndexes(anchorBlockHash, MerkleTreeId.NULLIFIER_TREE, batch),
-        ),
-      )
-    ).flat();
+    const nullifierIndexes = await this.#findNullifierIndexes(anchorBlockHash, nullifiersToCheck);
 
     const foundNullifiers = nullifiersToCheck
       .map((nullifier, i) => {
@@ -110,30 +95,34 @@ export class NoteService {
     await this.noteStore.applyNullifiers(foundNullifiers, this.jobId);
   }
 
-  public async validateAndStoreNote(
-    contractAddress: AztecAddress,
-    owner: AztecAddress,
-    storageSlot: Fr,
-    randomness: Fr,
-    noteNonce: Fr,
-    content: Fr[],
-    noteHash: Fr,
-    nullifier: Fr,
-    txHash: TxHash,
+  /**
+   * Validates and stores a batch of notes against pre-fetched tx effects.
+   *
+   * For each request we must verify that:
+   *  - the note actually exists in the corresponding tx effect (and thus in the note hash tree), and
+   *  - the note has not already been nullified.
+   *
+   * Failing to do either would result in circuits getting either non-existent notes and failing to produce inclusion
+   * proofs for them, or getting nullified notes and producing duplicate nullifiers, both of which are catastrophic
+   * failure modes.
+   *
+   * Note that adding a note and removing it is *not* equivalent to never adding it in the first place. A nullifier
+   * emitted in a block that comes after note creation might result in the note being de-nullified by a chain reorg,
+   * so we must store both the note hash and nullifier block information.
+   *
+   * @param requests - The notes to validate and store.
+   * @param scope - The scope under which the notes are being stored.
+   * @param txEffects - Pre-fetched tx effects keyed by `TxHash.toString()`. Must contain entries for every request's
+   *                   txHash; missing entries are treated as a node bug and cause an error.
+   */
+  public async validateAndStoreNotes(
+    requests: NoteValidationRequest[],
     scope: AztecAddress,
+    txEffects: Map<string, IndexedTxEffect>,
   ): Promise<void> {
-    // We are going to store the new note in the NoteStore, which will let us later return it via `getNotes`.
-    // There's two things we need to check before we do this however:
-    //  - we must make sure the note does actually exist in the note hash tree
-    //  - we need to check if the note has already been nullified
-    //
-    // Failing to do either of the above would result in circuits getting either non-existent notes and failing to
-    // produce inclusion proofs for them, or getting nullified notes and producing duplicate nullifiers, both of which
-    // are catastrophic failure modes.
-    //
-    // Note that adding a note and removing it is *not* equivalent to never adding it in the first place. A nullifier
-    // emitted in a block that comes after note creation might result in the note being de-nullified by a chain reorg,
-    // so we must store both the note hash and nullifier block information.
+    if (requests.length === 0) {
+      return;
+    }
 
     // We avoid making node queries at 'latest' since we don't want to process notes or nullifiers that only exist ahead
     // in time of the locally synced state.
@@ -146,61 +135,98 @@ export class NoteService {
 
     // By computing siloed and unique note hashes ourselves we prevent contracts from interfering with the note storage
     // of other contracts, which would constitute a security breach.
-    const uniqueNoteHash = await computeUniqueNoteHash(noteNonce, await siloNoteHash(contractAddress, noteHash));
-    const siloedNullifier = await siloNullifier(contractAddress, nullifier);
-
-    const [txEffect, [nullifierIndex]] = await Promise.all([
-      this.aztecNode.getTxEffect(txHash),
-      this.aztecNode.findLeavesIndexes(anchorBlockHash, MerkleTreeId.NULLIFIER_TREE, [siloedNullifier]),
-    ]);
-    if (!txEffect) {
-      // We error out instead of just logging a warning and skipping the note because this would indicate a bug. This
-      // is because the node has already served info about this tx either when obtaining the log (TxScopedL2Log contain
-      // tx info) or when getting metadata for the offchain message (before the message got passed to `process_log`).
-      throw new Error(`Could not find tx effect for tx hash ${txHash} when processing a note.`);
-    }
-
-    if (txEffect.l2BlockNumber > anchorBlockNumber) {
-      // If the message was delivered onchain, this would indicate a bug: log sync should never load logs from blocks
-      // newer than the anchor block. If the note came via an offchain message, it would likely also be a bug, since we
-      // sync a new anchor block before calling `process_message`. For this not to be a bug, the message would need to
-      // come from a newer block than the anchor served by the node, implying the node isn't properly synced.
-      //     We therefore error out here rather than assuming the offchain message was constructed by a malicious
-      // sender with the intention of bricking recipient's PXE (if we assumed that we would just ignore the message).
-      throw new Error(
-        `Obtained a newer tx effect for ${txHash} for a note validation request than the anchor block ${anchorBlockNumber}. This is a bug as we should not ever be processing a note from a newer block than the anchor block.`,
-      );
-    }
-
-    // Find the index of the note hash in the noteHashes array to determine note ordering within the tx
-    const noteIndexInTx = txEffect.data.noteHashes.findIndex(nh => nh.equals(uniqueNoteHash));
-    if (noteIndexInTx === -1) {
-      // Similar to the comment above - we error out as this would indicate a bug in nonce discovery.
-      throw new Error(`Note hash ${noteHash} (uniqued as ${uniqueNoteHash}) is not present in tx ${txHash}`);
-    }
-
-    const noteDao = new NoteDao(
-      new Note(content),
-      contractAddress,
-      owner,
-      storageSlot,
-      randomness,
-      noteNonce,
-      noteHash,
-      siloedNullifier,
-      txHash,
-      txEffect.l2BlockNumber,
-      txEffect.l2BlockHash.toString(),
-      txEffect.txIndexInBlock,
-      noteIndexInTx,
+    const computed = await Promise.all(
+      requests.map(async ({ contractAddress, noteHash, nullifier, noteNonce }) => {
+        const [siloedNoteHash, siloedNullifier] = await Promise.all([
+          siloNoteHash(contractAddress, noteHash),
+          siloNullifier(contractAddress, nullifier),
+        ]);
+        const uniqueNoteHash = await computeUniqueNoteHash(noteNonce, siloedNoteHash);
+        return { uniqueNoteHash, siloedNullifier };
+      }),
     );
 
-    await this.noteStore.addNotes([noteDao], scope, this.jobId);
+    const nullifierIndexes = await this.#findNullifierIndexes(
+      anchorBlockHash,
+      computed.map(c => c.siloedNullifier),
+    );
 
-    if (nullifierIndex !== undefined) {
-      // We found nullifier index which implies that the note has already been nullified.
-      const { data: _, ...blockHashAndNum } = nullifierIndex;
-      await this.noteStore.applyNullifiers([{ data: siloedNullifier, ...blockHashAndNum }], this.jobId);
+    const noteDaos: NoteDao[] = [];
+    const foundNullifiers: DataInBlock<Fr>[] = [];
+
+    for (let i = 0; i < requests.length; i++) {
+      const { contractAddress, owner, storageSlot, randomness, noteNonce, content, noteHash, txHash } = requests[i];
+      const { uniqueNoteHash, siloedNullifier } = computed[i];
+      const nullifierIndex = nullifierIndexes[i];
+
+      const txEffect = txEffects.get(txHash.toString());
+      if (!txEffect) {
+        // We error out instead of just logging a warning and skipping the note because this would indicate a bug. This
+        // is because the node has already served info about this tx either when obtaining the log (TxScopedL2Log
+        // contain tx info) or when getting metadata for the offchain message (before the message got passed to
+        // `process_log`).
+        throw new Error(`Could not find tx effect for tx hash ${txHash} when processing a note.`);
+      }
+
+      if (txEffect.l2BlockNumber > anchorBlockNumber) {
+        // If the message was delivered onchain, this would indicate a bug: log sync should never load logs from blocks
+        // newer than the anchor block. If the note came via an offchain message, it would likely also be a bug, since
+        // we sync a new anchor block before calling `process_message`. For this not to be a bug, the message would
+        // need to come from a newer block than the anchor served by the node, implying the node isn't properly synced.
+        //     We therefore error out here rather than assuming the offchain message was constructed by a malicious
+        // sender with the intention of bricking recipient's PXE (if we assumed that we would just ignore the message).
+        throw new Error(
+          `Obtained a newer tx effect for ${txHash} for a note validation request than the anchor block ${anchorBlockNumber}. This is a bug as we should not ever be processing a note from a newer block than the anchor block.`,
+        );
+      }
+
+      // Find the index of the note hash in the noteHashes array to determine note ordering within the tx
+      const noteIndexInTx = txEffect.data.noteHashes.findIndex(nh => nh.equals(uniqueNoteHash));
+      if (noteIndexInTx === -1) {
+        // Similar to the comment above - we error out as this would indicate a bug in nonce discovery.
+        throw new Error(`Note hash ${noteHash} (uniqued as ${uniqueNoteHash}) is not present in tx ${txHash}`);
+      }
+
+      noteDaos.push(
+        new NoteDao(
+          new Note(content),
+          contractAddress,
+          owner,
+          storageSlot,
+          randomness,
+          noteNonce,
+          noteHash,
+          siloedNullifier,
+          txHash,
+          txEffect.l2BlockNumber,
+          txEffect.l2BlockHash.toString(),
+          txEffect.txIndexInBlock,
+          noteIndexInTx,
+        ),
+      );
+
+      if (nullifierIndex !== undefined) {
+        // We found a nullifier index which implies that the note has already been nullified.
+        const { data: _, ...blockHashAndNum } = nullifierIndex;
+        foundNullifiers.push({ data: siloedNullifier, ...blockHashAndNum });
+      }
     }
+
+    await this.noteStore.addNotes(noteDaos, scope, this.jobId);
+
+    if (foundNullifiers.length > 0) {
+      await this.noteStore.applyNullifiers(foundNullifiers, this.jobId);
+    }
+  }
+
+  async #findNullifierIndexes(anchorBlockHash: Fr, siloedNullifiers: Fr[]) {
+    const batches = chunk(siloedNullifiers, MAX_RPC_LEN);
+    return (
+      await Promise.all(
+        batches.map(batch =>
+          this.aztecNode.findLeavesIndexes(anchorBlockHash, MerkleTreeId.NULLIFIER_TREE, batch),
+        ),
+      )
+    ).flat();
   }
 }


### PR DESCRIPTION
## Summary

- Refactors note and event validation in the PXE to prefetch tx effects once per unique tx hash and pass them as a map to batch methods, eliminating redundant RPC calls when multiple notes/events share a transaction
- Consolidates nullifier lookups into a chunked batch helper, replacing per-note RPC calls with a single batched call
- Adds a `uniqueBy` utility to the foundation collection library for deduplicating arrays by a key function