### PR TITLE
fix(sequencer): bounded sweep instead of event scan for governance proposal check

### DIFF
--- a/yarn-project/ethereum/src/contracts/empire_base.ts
+++ b/yarn-project/ethereum/src/contracts/empire_base.ts
@@ -22,8 +22,6 @@ export interface IEmpireBase {
     signerAddress: Hex,
     signer: (msg: TypedDataDefinition) => Promise<Hex>,
   ): Promise<L1TxRequest>;
-  /** Checks if a payload was ever submitted to governance via submitRoundWinner. */
-  hasPayloadBeenProposed(payload: Hex, fromBlock: bigint): Promise<boolean>;
 }
 
 export function encodeSignal(payload: Hex): Hex {

--- a/yarn-project/ethereum/src/contracts/governance.test.ts
+++ b/yarn-project/ethereum/src/contracts/governance.test.ts
@@ -1,16 +1,27 @@
 import { createExtendedL1Client, getPublicClient } from '@aztec/ethereum/client';
 import { Fr } from '@aztec/foundation/curves/bn254';
+import { EthAddress } from '@aztec/foundation/eth-address';
 import { createLogger } from '@aztec/foundation/log';
+import { TestDateProvider } from '@aztec/foundation/timer';
+import { GovernanceAbi } from '@aztec/l1-artifacts/GovernanceAbi';
 
+import { type Hex, encodeFunctionData, parseEventLogs } from 'viem';
 import { type PrivateKeyAccount, privateKeyToAccount } from 'viem/accounts';
 import { foundry } from 'viem/chains';
 
 import { DefaultL1ContractsConfig } from '../config.js';
 import { deployAztecL1Contracts } from '../deploy_aztec_l1_contracts.js';
+import { EthCheatCodes } from '../test/eth_cheat_codes.js';
 import type { Anvil } from '../test/start_anvil.js';
 import { startAnvil } from '../test/start_anvil.js';
 import type { ExtendedViemWalletClient, ViemClient } from '../types.js';
-import { GovernanceContract, ReadOnlyGovernanceContract } from './governance.js';
+import {
+  type GovernanceConfiguration,
+  GovernanceContract,
+  MAX_PROPOSAL_LIFETIME_SECONDS,
+  ProposalState,
+  ReadOnlyGovernanceContract,
+} from './governance.js';
 
 describe('Governance', () => {
   let anvil: Anvil;
@@ -18,10 +29,12 @@ describe('Governance', () => {
   let privateKey: PrivateKeyAccount;
   let publicClient: ViemClient;
   let walletClient: ExtendedViemWalletClient;
+  let cheatCodes: EthCheatCodes;
 
   let vkTreeRoot: Fr;
   let protocolContractsHash: Fr;
   let governanceAddress: `0x${string}`;
+  let governanceProposerAddress: `0x${string}`;
 
   beforeAll(async () => {
     // this is the 6th address that gets funded by the junk mnemonic
@@ -34,6 +47,7 @@ describe('Governance', () => {
 
     walletClient = createExtendedL1Client([rpcUrl], privateKey, foundry);
     publicClient = getPublicClient({ l1RpcUrls: [rpcUrl], l1ChainId: 31337 });
+    cheatCodes = new EthCheatCodes([rpcUrl], new TestDateProvider());
 
     const deployed = await deployAztecL1Contracts(rpcUrl, privateKeyRaw, foundry.id, {
       ...DefaultL1ContractsConfig,
@@ -44,6 +58,7 @@ describe('Governance', () => {
     });
 
     governanceAddress = deployed.l1ContractAddresses.governanceAddress.toString() as `0x${string}`;
+    governanceProposerAddress = deployed.l1ContractAddresses.governanceProposerAddress.toString() as `0x${string}`;
   });
 
   afterAll(async () => {
@@ -51,30 +66,287 @@ describe('Governance', () => {
   });
 
   describe('ReadOnlyGovernanceContract', () => {
-    let readOnlyGovernance: ReadOnlyGovernanceContract;
+    let governance: ReadOnlyGovernanceContract;
 
     beforeEach(() => {
-      readOnlyGovernance = new ReadOnlyGovernanceContract(governanceAddress, publicClient);
+      governance = new ReadOnlyGovernanceContract(governanceAddress, publicClient);
     });
 
     it('can be instantiated with public client but not wallet methods', () => {
-      expect(readOnlyGovernance).toBeDefined();
-      expect(readOnlyGovernance.client).toBe(publicClient);
+      expect(governance).toBeDefined();
+      expect(governance.client).toBe(publicClient);
 
       // Verify wallet-specific methods are not available
-      expect(readOnlyGovernance).not.toHaveProperty('deposit');
-      expect(readOnlyGovernance).not.toHaveProperty('proposeWithLock');
-      expect(readOnlyGovernance).not.toHaveProperty('vote');
-      expect(readOnlyGovernance).not.toHaveProperty('executeProposal');
+      expect(governance).not.toHaveProperty('deposit');
+      expect(governance).not.toHaveProperty('proposeWithLock');
+      expect(governance).not.toHaveProperty('vote');
+      expect(governance).not.toHaveProperty('executeProposal');
     });
 
     it('has all read-only methods', () => {
-      expect(readOnlyGovernance.getGovernanceProposerAddress).toBeDefined();
-      expect(readOnlyGovernance.getConfiguration).toBeDefined();
-      expect(readOnlyGovernance.getProposal).toBeDefined();
-      expect(readOnlyGovernance.getProposalState).toBeDefined();
-      expect(readOnlyGovernance.awaitProposalActive).toBeDefined();
-      expect(readOnlyGovernance.awaitProposalExecutable).toBeDefined();
+      expect(governance.getGovernanceProposerAddress).toBeDefined();
+      expect(governance.getConfiguration).toBeDefined();
+      expect(governance.getProposal).toBeDefined();
+      expect(governance.getProposalState).toBeDefined();
+      expect(governance.getProposalCount).toBeDefined();
+      expect(governance.hasActiveProposalWithPayload).toBeDefined();
+      expect(governance.awaitProposalActive).toBeDefined();
+      expect(governance.awaitProposalExecutable).toBeDefined();
+    });
+
+    it('gets configuration', async () => {
+      const config = await governance.getConfiguration();
+      expect(config).toBeDefined();
+      expect(config.proposeConfig.lockDelay).toBeGreaterThan(0n);
+      expect(config.proposeConfig.lockAmount).toBeGreaterThan(0n);
+      expect(config.votingDelay).toBeGreaterThan(0n);
+      expect(config.votingDuration).toBeGreaterThan(0n);
+      expect(config.executionDelay).toBeGreaterThan(0n);
+      expect(config.gracePeriod).toBeGreaterThan(0n);
+      expect(config.quorum).toBeGreaterThan(0n);
+      expect(config.requiredYeaMargin).toBeGreaterThan(0n);
+      expect(config.minimumVotes).toBeGreaterThan(0n);
+    });
+
+    describe('hasActiveProposalWithPayload', () => {
+      // Runtime bytecode for a contract whose only behavior is: ignore calldata, return `original`
+      // (zero-padded to 32 bytes). This is a stand-in for `IProposerPayload.getOriginalPayload()`.
+      // The point is to faithfully exercise the 'getOriginalPayload' path.
+      //
+      //   PUSH20 <original>   // 0x73 <20 bytes>
+      //   PUSH1  0x00
+      //   MSTORE              // mem[0..31] = 000...000<original>
+      //   PUSH1  0x20
+      //   PUSH1  0x00
+      //   RETURN              // return mem[0..31]
+      const buildMockWrapperBytecode = (original: EthAddress): Hex =>
+        `0x73${original.toString().toLowerCase().replace(/^0x/, '')}60005260206000f3`;
+
+      // A wrapper that always reverts when called. Stands in for proposals created via
+      // `Governance.proposeWithLock`, which bypass GSEPayload entirely -- the payload stored on the
+      // proposal won't have a `getOriginalPayload()` selector and the call will revert. The sweep
+      // must treat this as "no match" and continue rather than aborting.
+      //   PUSH1 0x00
+      //   PUSH1 0x00
+      //   REVERT
+      const REVERTING_WRAPPER_BYTECODE: Hex = '0x60006000fd';
+
+      // Etches `code` at a random address and returns the address as a Hex string
+      const etchCode = async (code: Hex) => {
+        const addr = EthAddress.random();
+        await cheatCodes.etch(addr, code);
+        return addr.toString() as `0x${string}`;
+      };
+
+      // Calls `Governance.propose(wrapper)` from the impersonated `governanceProposer`. Returns the
+      // resulting proposal id by parsing the `Proposed` event from the receipt. Anvil accepts
+      // unsigned transactions from impersonated accounts via `eth_sendTransaction`, so we don't need
+      // a separate wallet client.
+      const proposeAsProposer = async (wrapperAddress: Hex): Promise<bigint> => {
+        const data = encodeFunctionData({
+          abi: GovernanceAbi,
+          functionName: 'propose',
+          args: [wrapperAddress],
+        });
+        const txHash = (await cheatCodes.rpcCall('eth_sendTransaction', [
+          { from: governanceProposerAddress, to: governanceAddress, data, gas: '0x100000' },
+        ])) as Hex;
+        const receipt = await walletClient.waitForTransactionReceipt({ hash: txHash });
+        expect(receipt.status).toBe('success');
+        const [proposed] = parseEventLogs({ abi: GovernanceAbi, eventName: 'Proposed', logs: receipt.logs });
+        if (!proposed) {
+          throw new Error('Proposed event not found in receipt');
+        }
+        return proposed.args.proposalId;
+      };
+
+      // Returns the latest L1 block timestamp as a bigint
+      const nowOnChain = () => publicClient.getBlock({ includeTransactions: false }).then(b => b.timestamp);
+
+      beforeAll(async () => {
+        await cheatCodes.startImpersonating(governanceProposerAddress);
+      });
+
+      afterAll(async () => {
+        await cheatCodes.stopImpersonating(governanceProposerAddress);
+      });
+
+      it('returns false on a fresh governance with no proposals', async () => {
+        const proposalCount = await governance.getProposalCount();
+        expect(proposalCount).toBe(0n);
+        const arbitraryPayload = EthAddress.random().toString();
+        await expect(governance.hasActiveProposalWithPayload(arbitraryPayload)).resolves.toBe(false);
+      });
+
+      it('returns true when a live proposal unwraps to the queried payload', async () => {
+        const original = EthAddress.random();
+        const wrapper = await etchCode(buildMockWrapperBytecode(original));
+
+        const proposalId = await proposeAsProposer(wrapper);
+
+        // The proposal is freshly created, so it should be in `Pending` state
+        await expect(governance.getProposalState(proposalId)).resolves.toBe(ProposalState.Pending);
+        await expect(governance.hasActiveProposalWithPayload(original.toString())).resolves.toBe(true);
+      });
+
+      it('returns false when no live proposal references the queried payload', async () => {
+        // Create a proposal for a different payload than the one we query.
+        const proposalOriginal = EthAddress.random();
+        const wrapper = await etchCode(buildMockWrapperBytecode(proposalOriginal));
+        await proposeAsProposer(wrapper);
+
+        const queriedPayload = EthAddress.random();
+        await expect(governance.hasActiveProposalWithPayload(queriedPayload.toString())).resolves.toBe(false);
+      });
+
+      it('returns false once the matching proposal reaches a terminal state', async () => {
+        // No tokens were ever deposited, so no votes can be cast. Once the active phase ends with no
+        // yea votes the proposal transitions to `Rejected`, which is terminal -- and at that point
+        // re-signaling/re-proposing is allowed, so `hasActiveProposalWithPayload` must report false.
+        const original = EthAddress.random();
+        const wrapper = await etchCode(buildMockWrapperBytecode(original));
+        const proposalId = await proposeAsProposer(wrapper);
+
+        // Pending while the queried payload is in Pending.
+        await expect(governance.hasActiveProposalWithPayload(original.toString())).resolves.toBe(true);
+
+        // Warp past the active phase so the proposal becomes terminal. We use the proposal's own
+        // frozen config (creation + votingDelay + votingDuration + 1) rather than the live config,
+        // because each proposal stores its own snapshot.
+        const proposal = await governance.getProposal(proposalId);
+        const activeThrough = proposal.creation + proposal.config.votingDelay + proposal.config.votingDuration;
+        await cheatCodes.warp(Number(activeThrough + 1n));
+
+        await expect(governance.getProposalState(proposalId)).resolves.toBe(ProposalState.Rejected);
+        await expect(governance.hasActiveProposalWithPayload(original.toString())).resolves.toBe(false);
+      });
+
+      it('skips proposals whose payload reverts on getOriginalPayload (proposeWithLock-style)', async () => {
+        // `Governance.proposeWithLock` bypasses GSEPayload, so the payload stored on such a proposal
+        // is the original IPayload contract directly -- it has no `getOriginalPayload()` selector and
+        // the unwrap call reverts. The sweep must treat that as "no match" and keep iterating instead
+        // of aborting the whole call.
+        const revertingWrapper = await etchCode(REVERTING_WRAPPER_BYTECODE);
+        await proposeAsProposer(revertingWrapper);
+
+        const original = EthAddress.random();
+        const wrapper = await etchCode(buildMockWrapperBytecode(original));
+        const proposalId = await proposeAsProposer(wrapper);
+
+        // The proposal is freshly created, so it should be in `Pending` state
+        await expect(governance.getProposalState(proposalId)).resolves.toBe(ProposalState.Pending);
+        await expect(governance.hasActiveProposalWithPayload(original.toString())).resolves.toBe(true);
+      });
+
+      it('finds a live proposal among multiple unrelated proposals', async () => {
+        // Create three proposals; the *middle* one is the one we want to find. This exercises the
+        // descent loop's matching logic and confirms that hitting non-matching proposals (newer ones
+        // here, since we walk newest -> oldest) doesn't short-circuit the search.
+        const irrelevantOriginal1 = EthAddress.random();
+        const irrelevantOriginal2 = EthAddress.random();
+        const targetOriginal = EthAddress.random();
+
+        const targetWrapper = await etchCode(buildMockWrapperBytecode(targetOriginal));
+        await proposeAsProposer(targetWrapper);
+
+        const noiseWrapper1 = await etchCode(buildMockWrapperBytecode(irrelevantOriginal1));
+        await proposeAsProposer(noiseWrapper1);
+
+        const noiseWrapper2 = await etchCode(buildMockWrapperBytecode(irrelevantOriginal2));
+        await proposeAsProposer(noiseWrapper2);
+
+        await expect(governance.hasActiveProposalWithPayload(targetOriginal.toString())).resolves.toBe(true);
+      });
+
+      it('matches case-insensitively against the original payload address', async () => {
+        // Ethereum addresses are case-insensitive (mixed case is only used for EIP-55 checksums).
+        // Callers may pass either form, so the comparison must lowercase both sides.
+        const original = EthAddress.random();
+        const wrapper = await etchCode(buildMockWrapperBytecode(original));
+        await proposeAsProposer(wrapper);
+
+        const upperHex = ('0x' + original.toString().slice(2).toUpperCase()) as Hex;
+        await expect(governance.hasActiveProposalWithPayload(upperHex)).resolves.toBe(true);
+      });
+
+      it('early-stops on the protocol-wide lifetime cap and returns false for old proposals', async () => {
+        // Even if a proposal is "live" in the sense that no terminal-state transition has been
+        // recorded, once its creation timestamp is more than 4 * TIME_UPPER (= 360 days) in the past
+        // it cannot possibly still be in Pending/Active/Queued/Executable, because each phase is
+        // capped at TIME_UPPER = 90 days. We don't even get as far as `getProposalState` for those
+        // -- the descent loop short-circuits on `proposal.creation < hardCutoff`.
+        const original = EthAddress.random();
+        const wrapper = await etchCode(buildMockWrapperBytecode(original));
+        await proposeAsProposer(wrapper);
+
+        // Live initially.
+        await expect(governance.hasActiveProposalWithPayload(original.toString())).resolves.toBe(true);
+
+        // Warp beyond 4 * 90 days so the proposal's creation falls outside the hard cutoff.
+        const FOUR_TIME_UPPER = 4n * 90n * 24n * 3600n;
+        const target = (await nowOnChain()) + FOUR_TIME_UPPER + 60n;
+        await cheatCodes.warp(Number(target));
+
+        // We don't assert on getProposalState here; it would return `Rejected` (no votes cast in the
+        // active phase), but the early-stop in `hasActiveProposalWithPayload` is meant to fire even
+        // if it were stuck in some non-terminal state, so we test the boolean directly.
+        await expect(governance.hasActiveProposalWithPayload(original.toString())).resolves.toBe(false);
+
+        // Sanity: the older live proposals from earlier tests are also past the cutoff now, so the
+        // sweep should report false for any payload, including the dummy one.
+        await expect(governance.hasActiveProposalWithPayload(EthAddress.random().toString())).resolves.toBe(false);
+      });
+    });
+
+    describe('Configuration time bounds (sync check for MAX_PROPOSAL_LIFETIME_SECONDS)', () => {
+      // Mirrors `ConfigurationLib.TIME_UPPER` in `l1-contracts/src/governance/libraries/ConfigurationLib.sol`
+      // If any of the tests below fail due to a change of constants in the Governance contract, we must update
+      // the value of MAX_PROPOSAL_LIFETIME_SECONDS in the governance contract wrapper here in ts-land.
+      const TIME_UPPER = 90n * 24n * 3600n;
+
+      let governance: ReadOnlyGovernanceContract;
+      let baselineConfig: GovernanceConfiguration;
+
+      beforeAll(async () => {
+        governance = new ReadOnlyGovernanceContract(governanceAddress, publicClient);
+        baselineConfig = await governance.getConfiguration();
+      });
+
+      // Probes `updateConfiguration` via `eth_call` impersonating the Governance contract itself.
+      // `updateConfiguration` is gated by an `onlySelf` modifier, so we set `from = governanceAddress`.
+      // `eth_call` does not commit state, so this leaves the deployment untouched between probes.
+      const probeUpdateConfiguration = async (config: GovernanceConfiguration) => {
+        const data = encodeFunctionData({
+          abi: GovernanceAbi,
+          functionName: 'updateConfiguration',
+          args: [config],
+        });
+        try {
+          await cheatCodes.rpcCall('eth_call', [{ from: governanceAddress, to: governanceAddress, data }, 'latest']);
+          return { ok: true as const };
+        } catch (err) {
+          return { ok: false as const, err };
+        }
+      };
+
+      // Iterate the four fields whose upper bound feeds MAX_PROPOSAL_LIFETIME_SECONDS. Each is named
+      // explicitly so the failure message points at the exact field that drifted from the assumption.
+      const TIME_BOUNDED_FIELDS = ['votingDelay', 'votingDuration', 'executionDelay', 'gracePeriod'] as const;
+
+      it.each(TIME_BOUNDED_FIELDS)('accepts %s = TIME_UPPER', async field => {
+        const result = await probeUpdateConfiguration({ ...baselineConfig, [field]: TIME_UPPER });
+        expect(result.ok).toBe(true);
+      });
+
+      it.each(TIME_BOUNDED_FIELDS)('rejects %s = TIME_UPPER + 1', async field => {
+        const result = await probeUpdateConfiguration({ ...baselineConfig, [field]: TIME_UPPER + 1n });
+        expect(result.ok).toBe(false);
+      });
+
+      it('the ts hard cap matches the protocol-wide upper bound', () => {
+        const expected = 4n * TIME_UPPER;
+        expect(MAX_PROPOSAL_LIFETIME_SECONDS).toBe(expected);
+      });
     });
   });
 
@@ -101,6 +373,8 @@ describe('Governance', () => {
       expect(governance.getConfiguration).toBeDefined();
       expect(governance.getProposal).toBeDefined();
       expect(governance.getProposalState).toBeDefined();
+      expect(governance.getProposalCount).toBeDefined();
+      expect(governance.hasActiveProposalWithPayload).toBeDefined();
       expect(governance.awaitProposalActive).toBeDefined();
       expect(governance.awaitProposalExecutable).toBeDefined();
     });
@@ -110,21 +384,5 @@ describe('Governance', () => {
         new GovernanceContract(governanceAddress, publicClient as any);
       }).toThrow();
     });
-  });
-
-  it('gets configuration', async () => {
-    const governance = new GovernanceContract(governanceAddress, walletClient);
-    expect(governance).toBeDefined();
-    const config = await governance.getConfiguration();
-    expect(config).toBeDefined();
-    expect(config.proposeConfig.lockDelay).toBeGreaterThan(0n);
-    expect(config.proposeConfig.lockAmount).toBeGreaterThan(0n);
-    expect(config.votingDelay).toBeGreaterThan(0n);
-    expect(config.votingDuration).toBeGreaterThan(0n);
-    expect(config.executionDelay).toBeGreaterThan(0n);
-    expect(config.gracePeriod).toBeGreaterThan(0n);
-    expect(config.quorum).toBeGreaterThan(0n);
-    expect(config.requiredYeaMargin).toBeGreaterThan(0n);
-    expect(config.minimumVotes).toBeGreaterThan(0n);
   });
 });

--- a/yarn-project/ethereum/src/contracts/governance.ts
+++ b/yarn-project/ethereum/src/contracts/governance.ts
@@ -17,6 +17,21 @@ import type { L1ContractAddresses } from '../l1_contract_addresses.js';
 import { createL1TxUtils } from '../l1_tx_utils/index.js';
 import { type ExtendedViemWalletClient, type ViemClient, isExtendedClient } from '../types.js';
 
+// Minimal ABI for IProposerPayload (`l1-contracts/src/governance/interfaces/IProposerPayload.sol`).
+// The GovernanceProposer wraps every original payload in a GSEPayload before submitting it to
+// Governance, so `Proposal.payload` on the Governance contract is the wrapper address rather than
+// the original. We only need `getOriginalPayload` to recover the underlying payload, so we inline
+// the ABI here instead of generating a full artifact.
+const ProposerPayloadAbi = [
+  {
+    type: 'function',
+    name: 'getOriginalPayload',
+    inputs: [],
+    outputs: [{ type: 'address' }],
+    stateMutability: 'view',
+  },
+] as const;
+
 export type L1GovernanceContractAddresses = Pick<
   L1ContractAddresses,
   'governanceAddress' | 'rollupAddress' | 'registryAddress' | 'governanceProposerAddress'
@@ -32,6 +47,98 @@ export enum ProposalState {
   Executed,
   Dropped,
   Expired,
+}
+
+/** Vote tallies on a single proposal. Both fields are mutated by `Governance.vote`. */
+export interface Ballot {
+  yea: bigint;
+  nay: bigint;
+}
+
+/**
+ * Snapshot of the timing/quorum parameters that govern a single proposal's lifecycle. Each proposal
+ * stores its own copy at creation time (see `_propose` in Governance.sol), so this snapshot is
+ * immutable for the lifetime of the proposal even if the global `Configuration` changes later.
+ */
+export interface ProposalConfiguration {
+  votingDelay: bigint;
+  votingDuration: bigint;
+  executionDelay: bigint;
+  gracePeriod: bigint;
+  quorum: bigint;
+  requiredYeaMargin: bigint;
+  minimumVotes: bigint;
+}
+
+/** Parameters for `Governance.proposeWithLock`. Stored only in the global Configuration, never on a proposal. */
+export interface ProposeWithLockConfiguration {
+  lockDelay: bigint;
+  lockAmount: bigint;
+}
+
+/**
+ * Live, mutable governance configuration. `proposeConfig` is the lock configuration used by
+ * `proposeWithLock`; the remaining fields are the same shape as `ProposalConfiguration` and are
+ * snapshotted onto each new proposal at creation time.
+ */
+export interface GovernanceConfiguration extends ProposalConfiguration {
+  proposeConfig: ProposeWithLockConfiguration;
+}
+
+/**
+ * A governance proposal augmented with its live (computed) state.
+ *
+ * Mutability:
+ * - `config`, `payload`, `proposer`, `creation` are immutable for the lifetime of the proposal.
+ * - `cachedState` is the raw value stored on-chain. It is only written when a proposal is explicitly
+ *   executed or dropped, so for time-derived terminal states (Rejected, Expired) it remains at the
+ *   value that was current when the proposal was created.
+ * - `state` is the computed state returned by `Governance.getProposalState`. This is the value
+ *   callers almost always want -- it reflects time-derived transitions that `cachedState` does not.
+ * - `summedBallot` is mutated by every `Governance.vote` call while the proposal is Active.
+ *
+ * Once `state` is in a terminal phase (`Executed`/`Rejected`/`Dropped`/`Expired`) the entire struct
+ * is provably immutable on-chain (no further votes can be cast and no state-mutating call to
+ * `execute`/`dropProposal` can succeed), and the wrapper memoizes it.
+ */
+export interface Proposal {
+  config: ProposalConfiguration;
+  cachedState: ProposalState;
+  state: ProposalState;
+  payload: EthAddress;
+  proposer: EthAddress;
+  creation: bigint;
+  summedBallot: Ballot;
+}
+
+/** Set of `ProposalState` values for which a proposal is fully immutable on-chain. */
+const TERMINAL_PROPOSAL_STATES: ReadonlySet<ProposalState> = new Set([
+  ProposalState.Executed,
+  ProposalState.Rejected,
+  ProposalState.Dropped,
+  ProposalState.Expired,
+]);
+
+// Hard upper bound on the wall-clock lifetime of any Governance proposal, in seconds.
+// Each proposal stores its own snapshot of `ProposalConfiguration` at creation time and progresses
+// through Pending -> Active -> Queued -> Executable using those frozen durations
+// (see `ProposalLib.{pendingThrough,activeThrough,queuedThrough,executableThrough}`). Each of those
+// four durations is bounded by `ConfigurationLib.TIME_UPPER = 90 days` (validated in
+// `ConfigurationLib.assertValid`), so no proposal can be live for more than 4 * 90 days regardless
+// of what config it was created under. Once past this point, the proposal is guaranteed to be in a
+// terminal state (Executed / Rejected / Dropped / Expired).
+export const MAX_PROPOSAL_LIFETIME_SECONDS = 4n * 90n * 24n * 3600n;
+
+/**
+ * Validates a number returned by an on-chain `ProposalState` enum field and narrows it to the
+ * `ProposalState` enum. Throws if the value is out of range.
+ */
+function asProposalState(raw: number): ProposalState {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-enum-comparison
+  if (raw < 0 || raw > ProposalState.Expired) {
+    throw new Error(`Invalid proposal state: ${raw}`);
+  }
+  return raw as ProposalState;
 }
 
 export function extractProposalIdFromLogs(logs: Log[]): bigint {
@@ -50,6 +157,22 @@ export function extractProposalIdFromLogs(logs: Log[]): bigint {
 export class ReadOnlyGovernanceContract {
   protected readonly governanceContract: GetContractReturnType<typeof GovernanceAbi, ViemClient>;
 
+  /**
+   * Cache of fully-resolved proposals keyed by id. We populate this lazily and only retain entries
+   * whose state is provably terminal -- once `cachedState` is `Executed` or `Dropped` the on-chain
+   * proposal struct is frozen and safe to memoize indefinitely. Other state transitions (e.g.
+   * Pending -> Active, or accumulating votes) leave the cache untouched and force a fresh fetch.
+   */
+  private readonly proposalCache: Map<bigint, Proposal> = new Map();
+
+  /**
+   * Cache of `IProposerPayload.getOriginalPayload()` results keyed by wrapper address. The wrapper
+   * contract's bytecode is immutable, so this mapping never changes -- a value of `undefined`
+   * encodes a proposal whose payload doesn't implement `getOriginalPayload` (e.g. proposeWithLock
+   * proposals) and should be treated as "no original".
+   */
+  private readonly originalPayloadCache: Map<Hex, Hex | undefined> = new Map();
+
   constructor(
     address: Hex,
     public readonly client: ViemClient,
@@ -65,21 +188,155 @@ export class ReadOnlyGovernanceContract {
     return EthAddress.fromString(await this.governanceContract.read.governanceProposer());
   }
 
-  public getConfiguration() {
-    return this.governanceContract.read.getConfiguration();
+  public async getConfiguration(): Promise<GovernanceConfiguration> {
+    const raw = await this.governanceContract.read.getConfiguration();
+    return {
+      proposeConfig: {
+        lockDelay: raw.proposeConfig.lockDelay,
+        lockAmount: raw.proposeConfig.lockAmount,
+      },
+      votingDelay: raw.votingDelay,
+      votingDuration: raw.votingDuration,
+      executionDelay: raw.executionDelay,
+      gracePeriod: raw.gracePeriod,
+      quorum: raw.quorum,
+      requiredYeaMargin: raw.requiredYeaMargin,
+      minimumVotes: raw.minimumVotes,
+    };
   }
 
-  public getProposal(proposalId: bigint) {
-    return this.governanceContract.read.getProposal([proposalId]);
-  }
-
-  public async getProposalState(proposalId: bigint): Promise<ProposalState> {
-    const state = await this.governanceContract.read.getProposalState([proposalId]);
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-enum-comparison
-    if (state < 0 || state > ProposalState.Expired) {
-      throw new Error(`Invalid proposal state: ${state}`);
+  /**
+   * Fetches a proposal by id together with its live state, returning the mapped {@link Proposal}
+   * type. Issues `getProposal` and `getProposalState` in parallel so the result carries both the
+   * raw stored `cachedState` and the time-derived `state` -- callers can use whichever they need
+   * without an extra round-trip.
+   *
+   * Backed by an in-memory cache that retains entries only when `state` is in one of the four
+   * terminal phases (`Executed` / `Rejected` / `Dropped` / `Expired`). At that point the entire
+   * proposal struct is provably immutable on-chain (no further votes can be cast and no
+   * state-mutating call can succeed), so caching is safe forever. Non-terminal states force a
+   * fresh fetch on every call so callers always see fresh `state` and `summedBallot` values.
+   */
+  public async getProposal(proposalId: bigint): Promise<Proposal> {
+    const cached = this.proposalCache.get(proposalId);
+    if (cached !== undefined) {
+      return cached;
     }
-    return state as ProposalState;
+    const [raw, rawState] = await Promise.all([
+      this.governanceContract.read.getProposal([proposalId]),
+      this.governanceContract.read.getProposalState([proposalId]),
+    ]);
+    const proposal: Proposal = {
+      config: {
+        votingDelay: raw.config.votingDelay,
+        votingDuration: raw.config.votingDuration,
+        executionDelay: raw.config.executionDelay,
+        gracePeriod: raw.config.gracePeriod,
+        quorum: raw.config.quorum,
+        requiredYeaMargin: raw.config.requiredYeaMargin,
+        minimumVotes: raw.config.minimumVotes,
+      },
+      cachedState: asProposalState(raw.cachedState),
+      state: asProposalState(rawState),
+      payload: EthAddress.fromString(raw.payload),
+      proposer: EthAddress.fromString(raw.proposer),
+      creation: raw.creation,
+      summedBallot: { yea: raw.summedBallot.yea, nay: raw.summedBallot.nay },
+    };
+    if (TERMINAL_PROPOSAL_STATES.has(proposal.state)) {
+      this.proposalCache.set(proposalId, proposal);
+    }
+    return proposal;
+  }
+
+  /**
+   * Returns the live state of a proposal as computed by `Governance.getProposalState`. Prefer
+   * {@link getProposal} when you also need any other proposal data -- it returns this same value
+   * via {@link Proposal.state} alongside the rest of the struct in a single round-trip.
+   */
+  public async getProposalState(proposalId: bigint): Promise<ProposalState> {
+    return asProposalState(await this.governanceContract.read.getProposalState([proposalId]));
+  }
+
+  public getProposalCount(): Promise<bigint> {
+    return this.governanceContract.read.proposalCount();
+  }
+
+  /**
+   * Checks whether the given original payload is currently the subject of a live (non-terminal)
+   * Governance proposal. Returns true only if a proposal references this payload and is still in
+   * Pending, Active, Queued, or Executable state. Terminal proposals (Executed, Rejected, Dropped,
+   * Expired) are ignored, because once a proposal reaches a terminal state the same original
+   * payload may legitimately be re-signaled and re-submitted via the GovernanceProposer (each round
+   * is independent and there is no payload-level uniqueness check on-chain).
+   *
+   * Implemented as a bounded view-call sweep over `Governance.proposals` rather than an event scan,
+   * because `eth_getLogs` over the full deployment history of a long-lived rollup exceeds typical
+   * RPC block-range caps. The number of proposals (`proposalCount`) is small in practice, and we
+   * walk newest -> oldest with a hard early-stop on the protocol-wide proposal lifetime cap.
+   */
+  public async hasActiveProposalWithPayload(payload: Hex): Promise<boolean> {
+    const proposalCount = await this.getProposalCount();
+    if (proposalCount === 0n) {
+      return false;
+    }
+
+    // Anything created before this cutoff is guaranteed terminal regardless of its frozen config.
+    const block = await this.client.getBlock();
+    const hardCutoff = block.timestamp - MAX_PROPOSAL_LIFETIME_SECONDS;
+
+    const target = payload.toLowerCase() as Hex;
+
+    // Proposals are append-only with monotonically non-decreasing creation timestamps, so iterating
+    // from newest -> oldest lets us early-stop as soon as we cross the lifetime cutoff.
+    for (let id = proposalCount - 1n; id >= 0n; id--) {
+      const proposal = await this.getProposal(id);
+
+      // Hard early-stop: every older proposal is also older than the cutoff and therefore terminal.
+      if (proposal.creation < hardCutoff) {
+        return false;
+      }
+
+      const original = await this.getOriginalPayload(proposal.payload);
+      if (original === undefined || original.toLowerCase() !== target) {
+        continue;
+      }
+
+      // The wrapper unwraps to our payload. Only treat this as "already proposed" if the proposal
+      // is still live -- terminal states allow re-proposing the same payload in a later round.
+      if (TERMINAL_PROPOSAL_STATES.has(proposal.state)) {
+        continue;
+      }
+
+      return true;
+    }
+
+    return false;
+  }
+
+  /**
+   * Resolves the original payload behind a `GSEPayload` wrapper. Returns `undefined` if the
+   * wrapper does not implement `IProposerPayload.getOriginalPayload` (e.g. proposals created via
+   * `Governance.proposeWithLock`, which bypass GSEPayload entirely and store the raw `IPayload`
+   * directly). Results are memoized indefinitely because deployed wrapper bytecode is immutable.
+   */
+  private async getOriginalPayload(wrapper: EthAddress): Promise<Hex | undefined> {
+    const key = wrapper.toString();
+    if (this.originalPayloadCache.has(key)) {
+      return this.originalPayloadCache.get(key);
+    }
+    let original: Hex | undefined;
+    try {
+      original = await this.client.readContract({
+        address: key,
+        abi: ProposerPayloadAbi,
+        functionName: 'getOriginalPayload',
+      });
+    } catch {
+      original = undefined;
+    }
+    this.originalPayloadCache.set(key, original);
+    return original;
   }
 
   public async awaitProposalActive({ proposalId, logger }: { proposalId: bigint; logger: Logger }) {

--- a/yarn-project/ethereum/src/contracts/governance_proposer.ts
+++ b/yarn-project/ethereum/src/contracts/governance_proposer.ts
@@ -15,7 +15,7 @@ import {
 import type { L1TxRequest, L1TxUtils } from '../l1_tx_utils/index.js';
 import type { ViemClient } from '../types.js';
 import { type IEmpireBase, encodeSignal, encodeSignalWithSignature, signSignalWithSig } from './empire_base.js';
-import { extractProposalIdFromLogs } from './governance.js';
+import { ReadOnlyGovernanceContract, extractProposalIdFromLogs } from './governance.js';
 
 export class GovernanceProposerContract implements IEmpireBase {
   private readonly proposer: GetContractReturnType<typeof GovernanceProposerAbi, ViemClient>;
@@ -110,10 +110,27 @@ export class GovernanceProposerContract implements IEmpireBase {
     };
   }
 
-  /** Checks if a payload was ever submitted to governance via submitRoundWinner. */
-  public async hasPayloadBeenProposed(payload: Hex, fromBlock: bigint): Promise<boolean> {
-    const events = await this.proposer.getEvents.PayloadSubmitted({ payload }, { fromBlock, strict: true });
-    return events.length > 0;
+  /**
+   * Resolves the Governance contract this proposer submits winners to. Lazily reads
+   * `GovernanceProposer.getGovernance()` (which itself looks the address up via the registry) and
+   * memoizes the resulting wrapper.
+   */
+  @memoize
+  public async getGovernance(): Promise<ReadOnlyGovernanceContract> {
+    const address = await this.proposer.read.getGovernance();
+    return new ReadOnlyGovernanceContract(address, this.client);
+  }
+
+  /**
+   * Returns true iff the given original payload is currently the subject of a live (non-terminal)
+   * Governance proposal. Delegates to `ReadOnlyGovernanceContract.hasActiveProposalWithPayload`, which
+   * implements the actual sweep against the Governance contract -- this method exists only as a
+   * convenience wrapper so callers that already hold a GovernanceProposer reference don't have to
+   * resolve the Governance address themselves.
+   */
+  public async hasActiveProposalWithPayload(payload: Hex): Promise<boolean> {
+    const governance = await this.getGovernance();
+    return governance.hasActiveProposalWithPayload(payload);
   }
 
   public async submitRoundWinner(

--- a/yarn-project/sequencer-client/src/publisher/sequencer-publisher.test.ts
+++ b/yarn-project/sequencer-client/src/publisher/sequencer-publisher.test.ts
@@ -654,9 +654,10 @@ describe('SequencerPublisher', () => {
     ).toEqual(false);
   });
 
-  it.each<GetCodeReturnType>([undefined])('does not signal for payload with empty code', async code => {
+  it('does not signal for payload with empty code', async () => {
     const { govPayload } = mockGovernancePayload();
-    l1TxUtils.getCode.mockReturnValue(Promise.resolve(code));
+    l1TxUtils.getCode.mockReturnValue(Promise.resolve(undefined));
+    ``;
 
     expect(
       await publisher.enqueueGovernanceCastSignal(
@@ -670,7 +671,7 @@ describe('SequencerPublisher', () => {
 
   it('stops signalling when payload was previously proposed', async () => {
     const { govPayload } = mockGovernancePayload();
-    governanceProposerContract.hasPayloadBeenProposed.mockResolvedValue(true);
+    governanceProposerContract.hasActiveProposalWithPayload.mockResolvedValue(true);
 
     expect(
       await publisher.enqueueGovernanceCastSignal(
@@ -684,7 +685,7 @@ describe('SequencerPublisher', () => {
 
   it('continues signalling when payload was NOT proposed', async () => {
     const { govPayload } = mockGovernancePayload();
-    governanceProposerContract.hasPayloadBeenProposed.mockResolvedValue(false);
+    governanceProposerContract.hasActiveProposalWithPayload.mockResolvedValue(false);
 
     expect(
       await publisher.enqueueGovernanceCastSignal(
@@ -696,47 +697,13 @@ describe('SequencerPublisher', () => {
     ).toEqual(true);
   });
 
-  it('caches proposed result and prevents repeated L1 calls', async () => {
+  it('re-checks on every call without caching, so re-signaling resumes if a proposal becomes terminal', async () => {
     const { govPayload } = mockGovernancePayload();
-    governanceProposerContract.hasPayloadBeenProposed.mockResolvedValue(true);
-
-    await publisher.enqueueGovernanceCastSignal(
-      govPayload,
-      SlotNumber(2),
-      EthAddress.fromString(testHarnessAttesterAccount.address),
-      msg => testHarnessAttesterAccount.signTypedData(msg),
-    );
-
-    await publisher.enqueueGovernanceCastSignal(
-      govPayload,
-      SlotNumber(3),
-      EthAddress.fromString(testHarnessAttesterAccount.address),
-      msg => testHarnessAttesterAccount.signTypedData(msg),
-    );
-
-    expect(governanceProposerContract.hasPayloadBeenProposed).toHaveBeenCalledTimes(1);
-  });
-
-  it('retries on transient RPC failure and succeeds', async () => {
-    const { govPayload } = mockGovernancePayload();
-    governanceProposerContract.hasPayloadBeenProposed
-      .mockRejectedValueOnce(new Error('RPC error'))
-      .mockRejectedValueOnce(new Error('RPC error'))
-      .mockResolvedValueOnce(false);
-
-    expect(
-      await publisher.enqueueGovernanceCastSignal(
-        govPayload,
-        SlotNumber(2),
-        EthAddress.fromString(testHarnessAttesterAccount.address),
-        msg => testHarnessAttesterAccount.signTypedData(msg),
-      ),
-    ).toEqual(true);
-  });
-
-  it('fails closed on persistent RPC failure', async () => {
-    const { govPayload } = mockGovernancePayload();
-    governanceProposerContract.hasPayloadBeenProposed.mockRejectedValue(new Error('RPC error'));
+    // Simulates a payload that has a live proposal in slot 2 but whose proposal becomes terminal
+    // (Dropped/Rejected/Expired/Executed) by slot 3. The contracts allow re-signaling the same
+    // payload in a later round once the previous proposal is dead, so the publisher must re-check
+    // each slot rather than cache the first `true` result indefinitely.
+    governanceProposerContract.hasActiveProposalWithPayload.mockResolvedValueOnce(true).mockResolvedValueOnce(false);
 
     expect(
       await publisher.enqueueGovernanceCastSignal(
@@ -746,13 +713,41 @@ describe('SequencerPublisher', () => {
         msg => testHarnessAttesterAccount.signTypedData(msg),
       ),
     ).toEqual(false);
+
+    expect(
+      await publisher.enqueueGovernanceCastSignal(
+        govPayload,
+        SlotNumber(3),
+        EthAddress.fromString(testHarnessAttesterAccount.address),
+        msg => testHarnessAttesterAccount.signTypedData(msg),
+      ),
+    ).toEqual(true);
+
+    expect(governanceProposerContract.hasActiveProposalWithPayload).toHaveBeenCalledTimes(2);
   });
 
-  it('does not cache false result and re-checks on subsequent calls', async () => {
+  it('fails open on persistent RPC failure and signals anyway', async () => {
+    // Failing closed (skipping the signal) on transient RPC errors would let a flaky L1 endpoint
+    // silence governance participation entirely. Failing open at worst produces a duplicate signal
+    // that the contract simply counts alongside others in the round.
     const { govPayload } = mockGovernancePayload();
-    governanceProposerContract.hasPayloadBeenProposed.mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+    governanceProposerContract.hasActiveProposalWithPayload.mockRejectedValue(new Error('RPC error'));
 
-    // First call: not proposed, signalling proceeds
+    expect(
+      await publisher.enqueueGovernanceCastSignal(
+        govPayload,
+        SlotNumber(2),
+        EthAddress.fromString(testHarnessAttesterAccount.address),
+        msg => testHarnessAttesterAccount.signTypedData(msg),
+      ),
+    ).toEqual(true);
+  });
+
+  it('re-checks each call (no caching of false results)', async () => {
+    const { govPayload } = mockGovernancePayload();
+    governanceProposerContract.hasActiveProposalWithPayload.mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+
+    // First call: no live proposal, signalling proceeds
     expect(
       await publisher.enqueueGovernanceCastSignal(
         govPayload,
@@ -762,7 +757,7 @@ describe('SequencerPublisher', () => {
       ),
     ).toEqual(true);
 
-    // Second call: now proposed, signalling stops
+    // Second call: live proposal now exists, signalling stops
     expect(
       await publisher.enqueueGovernanceCastSignal(
         govPayload,
@@ -772,6 +767,6 @@ describe('SequencerPublisher', () => {
       ),
     ).toEqual(false);
 
-    expect(governanceProposerContract.hasPayloadBeenProposed).toHaveBeenCalledTimes(2);
+    expect(governanceProposerContract.hasActiveProposalWithPayload).toHaveBeenCalledTimes(2);
   });
 });

--- a/yarn-project/sequencer-client/src/publisher/sequencer-publisher.ts
+++ b/yarn-project/sequencer-client/src/publisher/sequencer-publisher.ts
@@ -5,7 +5,6 @@ import type { L1ContractsConfig } from '@aztec/ethereum/config';
 import {
   FeeAssetPriceOracle,
   type GovernanceProposerContract,
-  type IEmpireBase,
   MULTI_CALL_3_ADDRESS,
   Multicall3,
   RollupContract,
@@ -36,7 +35,6 @@ import { TimeoutError } from '@aztec/foundation/error';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { Signature, type ViemSignature } from '@aztec/foundation/eth-signature';
 import { type Logger, createLogger } from '@aztec/foundation/log';
-import { makeBackoff, retry } from '@aztec/foundation/retry';
 import { InterruptibleSleep } from '@aztec/foundation/sleep';
 import { bufferToHex } from '@aztec/foundation/string';
 import { type DateProvider, Timer } from '@aztec/foundation/timer';
@@ -150,7 +148,6 @@ export class SequencerPublisher {
   protected lastActions: Partial<Record<Action, SlotNumber>> = {};
 
   private isPayloadEmptyCache: Map<string, boolean> = new Map<string, boolean>();
-  private payloadProposedCache: Set<string> = new Set<string>();
 
   protected log: Logger;
   protected ethereumSlotDuration: bigint;
@@ -904,7 +901,7 @@ export class SequencerPublisher {
     slotNumber: SlotNumber,
     signalType: GovernanceSignalAction,
     payload: EthAddress,
-    base: IEmpireBase,
+    base: GovernanceProposerContract,
     signerAddress: EthAddress,
     signer: (msg: TypedDataDefinition) => Promise<`0x${string}`>,
   ): Promise<boolean> {
@@ -935,29 +932,23 @@ export class SequencerPublisher {
       return false;
     }
 
-    // Check if payload was already submitted to governance
-    const cacheKey = payload.toString();
-    if (!this.payloadProposedCache.has(cacheKey)) {
-      try {
-        const l1StartBlock = await this.rollupContract.getL1StartBlock();
-        const proposed = await retry(
-          () => base.hasPayloadBeenProposed(payload.toString(), l1StartBlock),
-          'Check if payload was proposed',
-          makeBackoff([0, 1, 2]),
-          this.log,
-          true,
-        );
-        if (proposed) {
-          this.payloadProposedCache.add(cacheKey);
-        }
-      } catch (err) {
-        this.log.warn(`Failed to check if payload ${payload} was proposed after retries, skipping signal`, err);
-        return false;
-      }
+    // Skip signaling if there is already a live (non-terminal) Governance proposal for this
+    // payload. This is intentionally not cached: a previously-live proposal may transition to
+    // a terminal state (Dropped/Rejected/Expired/Executed), at which point we may want to re-signal
+    // the same payload in a future round.
+    let proposed = false;
+    try {
+      proposed = await base.hasActiveProposalWithPayload(payload.toString());
+    } catch (err) {
+      // We deliberately swallow the error and proceed to signal. Failing closed (skipping the
+      // signal) on transient RPC errors would let a flaky L1 endpoint silence governance
+      // participation entirely; failing open at worst produces a duplicate signal that the
+      // contract will simply count alongside others in the round.
+      this.log.error(`Failed to check if payload ${payload} was already proposed (signalling anyway)`, err);
     }
 
-    if (this.payloadProposedCache.has(cacheKey)) {
-      this.log.info(`Payload ${payload} was already proposed to governance, stopping signals`);
+    if (proposed) {
+      this.log.info(`Payload ${payload} has a live governance proposal, stopping signals`);
       return false;
     }
 


### PR DESCRIPTION
## Motivation

`hasPayloadBeenProposed` (now `hasActiveProposalWithPayload`) used `eth_getLogs` over the rollup's full L1 deployment range to find prior `PayloadSubmitted` events. On long-lived rollups that range exceeds typical RPC provider block-range caps and the call times out, silently breaking the sequencer's "stop signaling for an already-proposed payload" logic. The previous in-memory cache also permanently blacklisted any payload it saw as proposed once, which is wrong: each round on `EmpireBase` is independent and the same payload can legitimately be re-signaled and re-submitted after a prior proposal becomes Dropped/Rejected/Expired/Executed.

## Approach

Replace the log scan with a bounded view-call sweep over `Governance.proposals`. The sweep walks newest -> oldest using `proposalCount`, unwraps each proposal's `GSEPayload` via `getOriginalPayload()`, and treats only `Pending`/`Active`/`Queued`/`Executable` as "in an active proposal" -- terminal states allow re-signaling. The descent has a hard early-stop on the protocol-wide proposal lifetime cap (`4 * ConfigurationLib.TIME_UPPER = 360 days`), which is safe regardless of per-proposal frozen configs because every config field is bounded by `TIME_UPPER` on-chain. Two in-memory caches absorb the per-call cost over time: terminal proposals (provably immutable on-chain) and wrapper -> original payload unwraps (immutable bytecode).

## Changes

- **ethereum/contracts/governance**: New `hasActiveProposalWithPayload(payload)` and `getProposalCount()` on `ReadOnlyGovernanceContract`. Inlines a minimal `IProposerPayload` ABI (just `getOriginalPayload`) to avoid generating a full artifact. Handles `proposeWithLock`-style proposals (no GSEPayload wrapper) by catching the unwrap revert and skipping.
- **ethereum/contracts/governance (types)**: Adds explicit types (`Proposal`, `ProposalConfiguration`, `GovernanceConfiguration`, `ProposeWithLockConfiguration`, `Ballot`) and maps the viem return shapes of `getProposal` / `getConfiguration` onto them. `Proposal` now carries both `cachedState` (raw stored) and `state` (live, time-derived from `getProposalState`); `getProposal` issues both reads in parallel so callers don't need a separate state RPC.
- **ethereum/contracts/governance (caching)**: Adds two memoization layers on `ReadOnlyGovernanceContract`. Proposals are cached when `state` is in any of the four terminal phases (Executed/Rejected/Dropped/Expired) -- once terminal the entire struct is provably immutable on-chain. Wrapper unwraps are keyed by wrapper address and cached forever (deployed bytecode is immutable). `GovernanceProposerContract` already memoizes its `getGovernance()`, so the same `ReadOnlyGovernanceContract` instance (and its caches) is reused across slots in the sequencer publisher.
- **ethereum/contracts/governance_proposer**: Drops the event-based `hasPayloadBeenProposed`. Adds a memoized `getGovernance()` accessor and a thin `hasActiveProposalWithPayload` delegate that resolves the Governance address via the on-chain registry lookup.
- **ethereum/contracts/empire_base**: Removes `hasPayloadBeenProposed` from `IEmpireBase` -- it's a Governance concern, not a generic empire concern (slasher doesn't need it).
- **sequencer-client/publisher**: Removes the permanent `payloadProposedCache` so the publisher re-checks every slot, allowing re-signaling once a prior proposal is terminal. Switches the failure mode from fail-closed to fail-open (a flaky L1 endpoint should not silence governance participation; a duplicate signal is harmless). Narrows the helper's `base` param from `IEmpireBase` to `GovernanceProposerContract` since this code path is governance-only.
- **ethereum/contracts (tests)**: New `hasActiveProposalWithPayload` describe block hitting a real anvil-deployed Governance. Impersonates the `governanceProposer`, calls `Governance.propose` directly, and etches hand-rolled mock wrapper bytecode at chosen addresses to drive (wrapper, original) pairs. Covers: empty governance, live match, no match, terminal state via warp, reverting wrapper (proposeWithLock-style), descent past unrelated proposals, case-insensitive match, and the 360-day hard cutoff via warp. Also adds a sync-guard describe block that probes `Governance.updateConfiguration` via impersonated `eth_call` to assert each of `votingDelay`/`votingDuration`/`executionDelay`/`gracePeriod` accepts `TIME_UPPER` and rejects `TIME_UPPER + 1` -- if those caps change on-chain, this trips and `MAX_PROPOSAL_LIFETIME_SECONDS` must be revisited.
- **sequencer-client/publisher (tests)**: Replaces the cache test with a "re-checks each call so re-signaling resumes after terminal" test. Updates the RPC-failure semantics test from fail-closed to fail-open.