### PR TITLE
fix(archiver): restore pending block height metric under pipelining

### DIFF
--- a/yarn-project/archiver/src/modules/instrumentation.ts
+++ b/yarn-project/archiver/src/modules/instrumentation.ts
@@ -136,7 +136,7 @@ export class ArchiverInstrumentation {
     }
 
     this.syncDurationPerCheckpoint.record(Math.ceil(syncTimePerCheckpoint));
-    this.blockHeight.record(Math.max(...blocks.map(b => b.number)));
+    this.blockHeight.record(Math.max(...blocks.map(b => b.number)), { [Attributes.STATUS]: 'checkpointed' });
     this.checkpointHeight.record(Math.max(...blocks.map(b => b.checkpointNumber)));
     this.syncBlockCount.add(blocks.length);
   }

--- a/yarn-project/archiver/src/modules/l1_synchronizer.ts
+++ b/yarn-project/archiver/src/modules/l1_synchronizer.ts
@@ -973,10 +973,10 @@ export class ArchiverL1Synchronizer implements Traceable {
           ),
         );
 
-        if (checkpointsToAdd.length > 0) {
+        if (validCheckpoints.length > 0) {
           this.instrumentation.processNewCheckpointedBlocks(
-            processDuration / checkpointsToAdd.length,
-            checkpointsToAdd.flatMap(c => c.checkpoint.blocks),
+            processDuration / validCheckpoints.length,
+            validCheckpoints.flatMap(c => c.checkpoint.blocks),
           );
         }
 


### PR DESCRIPTION
## Motivation

The `aztec.archiver.block_height` series with no status attribute (rendered as the "Pending chain" line on the network, prover, and fisherman Grafana dashboards) stopped being published a couple of weeks ago. With pipelining enabled every checkpoint arriving from L1 already has its blocks in the proposed store, so the L1 synchronizer always took the new promotion fast path introduced in #22716, leaving `checkpointsToAdd` empty and skipping the metric call.

## Approach

Record the checkpointed block-height metrics across all valid checkpoints in the batch instead of only the ones routed through `addCheckpoints`, so the promoted checkpoint contributes too. The duration is averaged over the full batch since `addCheckpoints` performs the work for both paths in a single transaction.

## Changes

- **archiver (`l1_synchronizer.ts`)**: Move the `processNewCheckpointedBlocks` call to use `validCheckpoints` rather than `checkpointsToAdd`, restoring the empty-status `block_height`, `checkpoint_height`, `sync_block_count`, and `sync_per_checkpoint` series under pipelining.