### PR TITLE
feat(bb): paired-SIMD WASM Montgomery + R=2^256 unification

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,6 +134,11 @@ bb-cpp-wasm:
 bb-cpp-wasm-threads:
 	$(call build,$@,barretenberg/cpp,build_preset wasm-threads)
 
+# BB C++ WASM Threads SIMD - Multi-threaded WebAssembly build with relaxed-simd.
+# Test-only: bb.js currently bundles bb-cpp-wasm-threads (no relaxed-simd).
+bb-cpp-wasm-threads-simd:
+	$(call build,$@,barretenberg/cpp,build_preset wasm-threads-simd)
+
 # Cross-compile object phases (parallel with avm-transpiler cross-compile)
 bb-cpp-cross-arm64-linux-objects: bb-cpp-yarn
 	$(call build,$@,barretenberg/cpp,build_cross_objects arm64-linux)
@@ -241,6 +246,9 @@ bb-cpp-native-tests: bb-cpp-native
 bb-cpp-wasm-threads-tests: bb-cpp-wasm-threads
 	$(call test,$@,barretenberg/cpp,wasm_threads)
 
+bb-cpp-wasm-threads-simd-tests: bb-cpp-wasm-threads-simd
+	$(call test,$@,barretenberg/cpp,wasm_threads_simd)
+
 bb-cpp-asan-tests: bb-cpp-asan
 	$(call test,$@,barretenberg/cpp,asan)
 
@@ -267,7 +275,7 @@ bb-rs-tests: bb-rs
 
 bb-tests: bb-cpp-native-tests bb-acir-tests bb-ts-tests bb-sol-tests bb-bbup-tests bb-docs-tests bb-rs-tests
 
-bb-full-tests: bb-cpp-wasm-threads-tests bb-cpp-asan-tests bb-cpp-smt-tests
+bb-full-tests: bb-cpp-wasm-threads-tests bb-cpp-wasm-threads-simd-tests bb-cpp-asan-tests bb-cpp-smt-tests
 
 #==============================================================================
 # .claude tooling

--- a/barretenberg/cpp/CMakePresets.json
+++ b/barretenberg/cpp/CMakePresets.json
@@ -448,6 +448,16 @@
       }
     },
     {
+      "name": "wasm-threads-simd",
+      "displayName": "Build for WASM with Threads and SIMD",
+      "description": "Build for WASM with Threads and SIMD (msimd128, mrelaxed-simd)",
+      "inherits": "wasm-threads",
+      "binaryDir": "build-wasm-threads-simd",
+      "cacheVariables": {
+        "CMAKE_CXX_FLAGS": "-DBB_NO_EXCEPTIONS -msimd128 -mrelaxed-simd"
+      }
+    },
+    {
       "name": "xray",
       "displayName": "Build with multi-threaded XRay Profiling",
       "description": "Build with Clang and enable multi-threaded LLVM XRay for profiling",
@@ -793,6 +803,22 @@
       ]
     },
     {
+      "name": "wasm-threads-simd",
+      "configurePreset": "wasm-threads-simd",
+      "inheritConfigureEnvironment": true,
+      "jobs": 0,
+      "targets": [
+        "barretenberg.wasm",
+        "barretenberg.wasm.gz",
+        "barretenberg-debug.wasm",
+        "ecc_tests",
+        "montmul_bench",
+        "ultra_honk_bench",
+        "chonk_bench",
+        "bb"
+      ]
+    },
+    {
       "name": "xray",
       "configurePreset": "xray",
       "inherits": "default"
@@ -911,6 +937,11 @@
     {
       "name": "wasm",
       "configurePreset": "wasm",
+      "inheritConfigureEnvironment": true
+    },
+    {
+      "name": "wasm-threads-simd",
+      "configurePreset": "wasm-threads-simd",
       "inheritConfigureEnvironment": true
     }
   ]

--- a/barretenberg/cpp/bootstrap.sh
+++ b/barretenberg/cpp/bootstrap.sh
@@ -273,6 +273,11 @@ function test_cmds_wasm_threads {
   echo "$hash barretenberg/cpp/scripts/wasmtime.sh barretenberg/cpp/build-wasm-threads/bin/ecc_tests"
 }
 
+function test_cmds_wasm_threads_simd {
+  # Exercises the relaxed-simd-gated paths (paired_mul / paired_sqr)
+  echo "$hash barretenberg/cpp/scripts/wasmtime.sh barretenberg/cpp/build-wasm-threads-simd/bin/ecc_tests"
+}
+
 function test_cmds_asan {
   local prefix="$hash:CPUS=4:MEM=8g"
 
@@ -302,6 +307,7 @@ function test_cmds {
     test_cmds_native
     if [ "$CI_FULL" -eq 1 ]; then
       test_cmds_wasm_threads
+      test_cmds_wasm_threads_simd
       test_cmds_asan
       test_cmds_smt
     fi

--- a/barretenberg/cpp/src/barretenberg/commitment_schemes/ipa/ipa.hpp
+++ b/barretenberg/cpp/src/barretenberg/commitment_schemes/ipa/ipa.hpp
@@ -286,8 +286,10 @@ template <typename Curve_, size_t log_poly_length = CONST_ECCVM_LOG_N> class IPA
                 round_size,
                 [&](size_t j) {
                     BB_BENCH_TRACY_NAME("IPA::fold_vecs");
-                    a_vec.at(j) += round_challenge * a_vec[round_size + j];
-                    b_vec[j] += round_challenge_inv * b_vec[round_size + j];
+                    const auto [a_scaled, b_scaled] = Fr::paired_mul(
+                        round_challenge, a_vec[round_size + j], round_challenge_inv, b_vec[round_size + j]);
+                    a_vec.at(j) += a_scaled;
+                    b_vec[j] += b_scaled;
                 },
                 thread_heuristics::FF_ADDITION_COST * 2 + thread_heuristics::FF_MULTIPLICATION_COST * 2);
         }

--- a/barretenberg/cpp/src/barretenberg/common/compiler_hints.hpp
+++ b/barretenberg/cpp/src/barretenberg/common/compiler_hints.hpp
@@ -25,6 +25,16 @@
 #define BB_UNLIKELY(x) x
 #endif
 
+// Force the compiler to fully unroll the immediately following loop. Used for short, fixed-bound
+// loops in tight arithmetic kernels where unrolling exposes ILP.
+#ifdef __clang__
+#define BB_FORCE_UNROLL _Pragma("clang loop unroll(full)")
+#elif defined(__GNUC__)
+#define BB_FORCE_UNROLL _Pragma("GCC unroll 16")
+#else
+#define BB_FORCE_UNROLL
+#endif
+
 // Opinionated feature: functionally equivalent to [[maybe_unused]] but clearly
 // marks things DEFINITELY unused. Aims to be more readable, at the tradeoff of being a custom thingy.
 #define BB_UNUSED [[maybe_unused]]

--- a/barretenberg/cpp/src/barretenberg/ecc/curves/bn254/fq.hpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/curves/bn254/fq.hpp
@@ -86,13 +86,6 @@ class Bn254FqParams {
     static constexpr uint64_t modulus_wasm_7 = 0xe5c2634;
     static constexpr uint64_t modulus_wasm_8 = 0x30644e;
 
-    // A little-endian representation of R^2 modulo the modulus (R=2^261 mod modulus) split into 4 64-bit words
-    // We use 2^261 in wasm, because 261=29*9, the 9 29-bit limbs used for arithmetic in
-    static constexpr uint64_t r_squared_wasm_0 = 0xe1a2a074659bac10UL;
-    static constexpr uint64_t r_squared_wasm_1 = 0x639855865406005aUL;
-    static constexpr uint64_t r_squared_wasm_2 = 0xff54c5802d3e2632UL;
-    static constexpr uint64_t r_squared_wasm_3 = 0x2a11a68c34ea65a6UL;
-
     // 2^(-29) mod Modulus
     // Used in the reduction mechanism, see field_docs.md
     // Instead of computing k, we multiply the lowest limb by this value and then add to the following 10 limbs.
@@ -106,25 +99,6 @@ class Bn254FqParams {
     static constexpr uint64_t r_inv_wasm_6 = 0x16626d2;
     static constexpr uint64_t r_inv_wasm_7 = 0xb8bab0f;
     static constexpr uint64_t r_inv_wasm_8 = 0x6d7c4;
-
-    // A little-endian representation of the cube root of 1 in Fq in Montgomery form for wasm (R=2^261 mod modulus)
-    // split into 4 64-bit words
-    static constexpr uint64_t cube_root_wasm_0 = 0x62b1a3a46a337995UL;
-    static constexpr uint64_t cube_root_wasm_1 = 0xadc97d2722e2726eUL;
-    static constexpr uint64_t cube_root_wasm_2 = 0x64ee82ede2db85faUL;
-    static constexpr uint64_t cube_root_wasm_3 = 0x0c0afea1488a03bbUL;
-
-    // Not used for Fq, but required for all field types
-    static constexpr uint64_t primitive_root_wasm_0 = 0x0000000000000000UL;
-    static constexpr uint64_t primitive_root_wasm_1 = 0x0000000000000000UL;
-    static constexpr uint64_t primitive_root_wasm_2 = 0x0000000000000000UL;
-    static constexpr uint64_t primitive_root_wasm_3 = 0x0000000000000000UL;
-
-    // Coset generators in Montgomery form for R=2^261 mod Modulus. Used in FFT-based proving systems
-    static constexpr uint64_t coset_generator_wasm_0 = 0xeb8a8ec140766463ULL;
-    static constexpr uint64_t coset_generator_wasm_1 = 0xf2b1f20626a3da49ULL;
-    static constexpr uint64_t coset_generator_wasm_2 = 0xf905ef8d84d5fea4ULL;
-    static constexpr uint64_t coset_generator_wasm_3 = 0x2958a27c02b7cd5fULL;
 
     // Parameters used for quickly splitting a scalar into two endomorphism scalars for faster scalar multiplication
     // For specifics on how these have been derived, see ecc/fields/endomorphim_scalars.py

--- a/barretenberg/cpp/src/barretenberg/ecc/curves/bn254/fq.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/curves/bn254/fq.test.cpp
@@ -21,11 +21,9 @@ auto& engine = numeric::get_debug_randomness();
 
 // ================================
 // Fixed Compile-Time Tests (field-specific expected values)
-// These tests use hardcoded expected values that are only valid for native builds (R = 2^256).
-// WASM uses R = 2^261.
+// These tests use hardcoded expected values for the unified Montgomery radix R = 2^256.
 // ================================
 
-#if defined(__SIZEOF_INT128__) && !defined(__wasm__)
 TEST(BN254Fq, CompileTimeMultiplication)
 {
     constexpr fq a{ 0x83aa80986c4f06f8, 0xbd01cce5e3b3afc3, 0x1cba208cb70aa13b, 0x2a582eb35a932e0d };
@@ -64,7 +62,6 @@ TEST(BN254Fq, CompileTimeSubtraction)
     constexpr fq result = a - b;
     static_assert(result == expected);
 }
-#endif
 
 TEST(BN254Fq, CompileTimeInversion)
 {

--- a/barretenberg/cpp/src/barretenberg/ecc/curves/bn254/fq12.hpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/curves/bn254/fq12.hpp
@@ -35,7 +35,6 @@ namespace bb {
  */
 struct Bn254Fq12Params {
 
-#if defined(__SIZEOF_INT128__) && !defined(__wasm__)
     static constexpr fq2 frobenius_coefficients_1{
         { 0xaf9ba69633144907UL, 0xca6b1d7387afb78aUL, 0x11bded5ef08a2087UL, 0x02f34d751a1f3a7cUL },
         { 0xa222ae234c492d72UL, 0xd00f02a4565de15bUL, 0xdc2ff3a253dfc926UL, 0x10a75716b3899551UL }
@@ -50,22 +49,6 @@ struct Bn254Fq12Params {
         { 0x365316184e46d97dUL, 0x0af7129ed4c96d9fUL, 0x659da72fca1009b5UL, 0x08116d8983a20d23UL },
         { 0xb1df4af7c39c1939UL, 0x3d9f02878a73bf7fUL, 0x9b2220928caf0ae0UL, 0x26684515eff054a6UL }
     };
-#else
-    static constexpr fq2 frobenius_coefficients_1{
-        { 0xb75446af8a0c2399UL, 0xb5e243df8d8526c8UL, 0x7f6d66278fc2b89bUL, 0x2e05603062b5af58UL },
-        { 0xaeefbf6e3bc6cc33UL, 0x7f50c04b4ed87762UL, 0x9a8b7572eb6a58d4UL, 0x9b83e6c410c870UL }
-    };
-
-    static constexpr fq2 frobenius_coefficients_2{
-        { 0xd96ee8726e4983b2UL, 0xe9b7ed6a458f581eUL, 0x5361c2c89ea5d262UL, 0x24594fd198a79c6eUL },
-        { 0UL, 0UL, 0UL, 0UL }
-    };
-
-    static constexpr fq2 frobenius_coefficients_3{
-        { 0x9dc006978e6a3d3dUL, 0x695b3f038ef4bf24UL, 0x1a238968ba7a7ccdUL, 0x103828f20e49839cUL },
-        { 0x5cbbb0bd4f4e6b31UL, 0xe83ce8be1b5b282bUL, 0x646d437ef03fbae3UL, 0x133cf9860031f0c0UL }
-    };
-#endif
 };
 
 using fq12 = field12<fq2, fq6, Bn254Fq12Params>;

--- a/barretenberg/cpp/src/barretenberg/ecc/curves/bn254/fq12.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/curves/bn254/fq12.test.cpp
@@ -90,7 +90,6 @@ TEST(fq12, SubCheckAgainstConstants)
 TEST(fq12, MulCheckAgainstConstants)
 {
 
-#if defined(__SIZEOF_INT128__) && !defined(__wasm__)
     fq12 a = { { { { 0xd43e9f8be859502b, 0x26a42a1a95cee1ef, 0x3d63c085c1892b32, 0x2e5beaf431211a76 },
                    { 0x5f32ad7cee215ff5, 0xce967fda9424120e, 0x10ea4e52628bac33, 0x51b85ee9671b7f3 } },
                  { { 0x95f8e84e0ff94a83, 0x6c6fb2cf3c73b30a, 0x28e8e13841f714a8, 0x2a3412f681e31b4d },
@@ -127,46 +126,6 @@ TEST(fq12, MulCheckAgainstConstants)
                           { 0xeaf256aa7a6b49b5, 0xeaa1b56258e3194e, 0xde3b531fd4fe961b, 0x26a0b5c35ce4be53 } },
                         { { 0x1f7661fa7dd7d68c, 0x71c1360fdb272200, 0x3fdb8fcc1dbfd160, 0x1ba330295e24399b },
                           { 0x5c93a291c6579918, 0x6536baab9e09bc80, 0x93ad9959edff4c64, 0x138af9a14abfeb1e } } } };
-#else
-    fq12 a = { { { { 0x7c0386cfac84570eUL, 0x135ac6487c86816dUL, 0x130fe55503fd0b4dUL, 0x1fbc2d0fc05289e4UL },
-                   { 0x31f40b593ab506cbUL, 0xc4bbb9e4b2ce224UL, 0xf458f928ccf17d61UL, 0x1243d27a2aa21de4UL } },
-                 { { 0x67ae435929fa99e3UL, 0x93501c918a76046dUL, 0xaca4ccc8963e432eUL, 0x2bee18b27c27853eUL },
-                   { 0xd0c6730507d0d015UL, 0xd41cfd656c0a9059UL, 0xb292659d53fa0444UL, 0x2e8f0ac98edef6fdUL } },
-                 { { 0x700740aa0efd0e50UL, 0x2c5e9c0660931b42UL, 0x188425137ce80beUL, 0x15a745139a2d95a4UL },
-                   { 0xc270eebcc77b120eUL, 0x8dd2034c9f5e661dUL, 0xd0cacb8be3443ebbUL, 0x2206cf8406979618UL } } },
-               { { { 0x14beeea0c29cf256UL, 0xec331baf4a9d8e57UL, 0x84c18cf8f3dfd61cUL, 0x172f849c8867a6a3UL },
-                   { 0x49c8f77c0173904UL, 0xa7ec5eadf91525UL, 0xb6af342102d7f350UL, 0x1931766a4a4de218UL } },
-                 { { 0x1d05943f42ce34b6UL, 0x2ec4bdddbaed0295UL, 0xf29903765d9d2a7UL, 0x180626982a98bb32UL },
-                   { 0x16cef1562b3f9cbfUL, 0x564982ca86391192UL, 0x338241cef0f07d6eUL, 0x2eceb2ea88b46fcdUL } },
-                 { { 0x16d7e01a042c1c8dUL, 0x6ccf62b19f1db7abUL, 0xdf7b7fb19a040d7bUL, 0x17278879d86f5ffaUL },
-                   { 0xb80f047affe4ba5aUL, 0xd4768f74c5e34883UL, 0x413437ff1a222a7UL, 0x1c9f79ff1e326bd6UL } } } };
-    fq12 b = { { { { 0x8b6d20fcb2e4cfe1UL, 0xd90b5af04637d61UL, 0xe5213491fb1c8ddUL, 0x22c31d57c6199047UL },
-                   { 0x5d5e4792797a849fUL, 0xef0fb5048682755eUL, 0x4262903127b8490UL, 0x1c5a05774b7b87c2UL } },
-                 { { 0x6afefb11e053997dUL, 0xa9425cc6d3438879UL, 0xc589bf0a479257f6UL, 0x2f265a3f46125967UL },
-                   { 0x16d32bf792576ea5UL, 0x838faa5f1ec28d7dUL, 0xf78fe731049b021dUL, 0x2b0eaaf50224c689UL } },
-                 { { 0x37aff72139bcccfcUL, 0xb3d22b3397a55baeUL, 0xf3efabf7233a8667UL, 0x3dbff83c87691bcUL },
-                   { 0x25f36df6da3ba93dUL, 0x2939ccbc8f01881dUL, 0x10a81e15af7aed31UL, 0x2e518a473abafad5UL } } },
-               { { { 0xad5021ea46c06b79UL, 0xb7b76193fc41efe1UL, 0xa69eed0eb6ec2c57UL, 0x2c89ae19e58186bUL },
-                   { 0xae75112332f4de13UL, 0x374e8d70552ca0d8UL, 0x68e87f702af0ecf1UL, 0x95ede632701dd39UL } },
-                 { { 0x6de7a94aa7bc5726UL, 0x7874ee4c3c04b1cUL, 0x9a6e5d3e5875115dUL, 0x651f42a42021fb7UL },
-                   { 0x555a79f9e6ea299bUL, 0xd504f95c1ecbea79UL, 0xe97d114d516cef0bUL, 0x2d27cfdd54e9f124UL } },
-                 { { 0x8b3ae5f063f26da4UL, 0xf797224bfa14f904UL, 0xcdcd9c93aa02adfbUL, 0x25d073040d79eb5dUL },
-                   { 0xf84a169b376e11UL, 0xac1f29c1236def7cUL, 0xc84235bd3c78d593UL, 0x11668081e4c22e74UL } } } };
-    fq12 expected = {
-        { { { 0xe1692f3291c79addUL, 0x75a0f3f9cb5b780fUL, 0x94fc10049567941cUL, 0x2cbd84240c99322dUL },
-            { 0xec0b5c231d51cf6eUL, 0xaf66fb345ef4b557UL, 0x684bd6749e20d417UL, 0x6acb8ccf83a8a5aUL } },
-          { { 0x4b5bfec7495191d9UL, 0xaaf3b2fb8c9417b3UL, 0x9e8cc0788452ef36UL, 0x150f0c9b2bd490d9UL },
-            { 0xd38c4d68e8d61244UL, 0x7854bc167c3f883UL, 0xe422e992b4fd0935UL, 0x2e2ee820869b7371UL } },
-          { { 0x9458ec7554a72a3eUL, 0x611f6d973e483feaUL, 0x3f8ea4f8370c8826UL, 0x189afef00f4165e6UL },
-            { 0x8a57858c6746a623UL, 0x5c2f5d8907db836eUL, 0x18aa628b09f8cc39UL, 0x301cdc8e2edb165bUL } } },
-        { { { 0xe339df6c6902f315UL, 0xbcf4e508382eec7UL, 0x1a86782e58331768UL, 0x15a3a1d93ce727deUL },
-            { 0x9d3911edc9a69069UL, 0xacf7dd9e1ee36b27UL, 0xd3c0532725cf9a45UL, 0x1c7c570ac4e21c68UL } },
-          { { 0x434490153d5b55f1UL, 0x3e3b2fb04143f767UL, 0x8960b1eb0cea5302UL, 0x2ebbac70edefc529UL },
-            { 0x7f1d271429347ab1UL, 0x88934417e9466212UL, 0xc7939527fa312259UL, 0x1a4b0f339ebf2668UL } },
-          { { 0xb48265b482310282UL, 0x910d43c20ce40215UL, 0x5cd12ae9ce1f579UL, 0xd588117ef09f079UL },
-            { 0xc0edc126a51743acUL, 0x8cc656a2dbe2116cUL, 0xd1efe6afadd96829UL, 0x2cab86c6c9a9e1ddUL } } }
-    };
-#endif
 
     fq12 result = a * b;
     EXPECT_EQ(result, expected);
@@ -176,7 +135,6 @@ TEST(fq12, SparseMulCheckAgainstConstants)
 {
     fq12::ell_coeffs ell;
 
-#if defined(__SIZEOF_INT128__) && !defined(__wasm__)
     fq12 a = { { { { 0x472e65066d5d00e3, 0xd35147f048cc3b15, 0xb7a9aafbfc298c58, 0x3905463add8c9a2f },
                    { 0xdec4ece2f569ec88, 0x9a081a157e39b6ed, 0xfc51bb6b4b3880c0, 0x2ddceafb16a16476 } },
                  { { 0x275d05338f5b9a3, 0x727afc5b10a7333f, 0x3b0d7f3e9ebb8e6a, 0x3ab5c561cd99c099 },
@@ -207,40 +165,6 @@ TEST(fq12, SparseMulCheckAgainstConstants)
                           { 0x83d2ac92b96e3d59, 0xa86210b27499db4e, 0x2803a767a08e8df8, 0x3dcfb2cbf6cabfd4 } },
                         { { 0xcf8e0a5f6bbb085f, 0x4bd90884781a1a2c, 0xbfe17a10d901ed53, 0x3661cda6ad4d8742 },
                           { 0x464986de3c267aa3, 0xebe2b417b64ef133, 0x514763d3f8f819a8, 0x3c3fea7527bb962c } } } };
-#else
-    fq12 a = { { { { 0x35186180618f811dUL, 0x8474970501151c3fUL, 0x519b4c1ecd7fc593UL, 0x222970c125671fefUL },
-                   { 0xcccd31b14e97e2aeUL, 0x7fd8c5a589e1212eUL, 0xf0cf420639e7bd1bUL, 0xfdc2dec705bc9fbUL } },
-                 { { 0x61e53f02fc299bd6UL, 0xd229b9cc940256e9UL, 0x5c58ebc9e3eaf69UL, 0x27d5072c45da4cf6UL },
-                   { 0x7f0d1c58556a9ca8UL, 0x132672ac75fbf500UL, 0x8429bc1b126cac1aUL, 0x29b2fa7aea7f447cUL } },
-                 { { 0xba362462baeba3bUL, 0x39d2ad60af1109e1UL, 0x32eb7a127642090aUL, 0x306c332e09563554UL },
-                   { 0xfee21cab983f1487UL, 0x862c82b11ce0ccdaUL, 0xfa5a47141e2b7c87UL, 0x1ad0e019fb1a4b89UL } } },
-               { { { 0xea64b40baf069b62UL, 0xa2c0e5b6e3b56f79UL, 0xb8bd866b5c7493d8UL, 0x2c5b6f1bed930fb3UL },
-                   { 0x765e1522747d3b63UL, 0x85a1a4692f367e85UL, 0x8dd10f4c0507f088UL, 0x342af2e20635dfc3UL } },
-                 { { 0xcb02c9793f901a12UL, 0xf4e0662d4a19469fUL, 0x85af8f425a2c3e18UL, 0x5f0c5464a358a7cUL },
-                   { 0xa51286fbed1c0b94UL, 0x1d269f9c2ca7108fUL, 0x584e43551addb9edUL, 0x2200003433ddd8d4UL } },
-                 { { 0xcb02b7f36f5e1917UL, 0xfc4f397a632869aUL, 0x6943b08b3d8691f1UL, 0x383c711053cc7feUL },
-                   { 0x7e532f599e5b182cUL, 0x5bb8ecd54e157f4bUL, 0x70f0160a761156baUL, 0x33eacee27f7f6f8dUL } } } };
-    ell.o = { { 0x396824f9423c9e2aUL, 0x112f54f68c0af42aUL, 0x8b647f1044c7410dUL, 0x55cfbff2ea815f0UL },
-              { 0x910f584748dac517UL, 0x1c9fe3a800bfba17UL, 0x4f5477f9cb4e715eUL, 0x28b4bb3ec47f2ad0UL } };
-    ell.w = { { 0xc5795b43903afe81UL, 0x854f4d8204fb4206UL, 0xccce2acb2edc4871UL, 0x283b1e4618827cbdUL },
-              { 0xab5eec20ea0a4e2aUL, 0x41a2890bba394b74UL, 0x943671019c19dfb1UL, 0x1632db7439b726b5UL } };
-    ell.vw = { { 0x94c2987400a16253UL, 0xa5d9e5051b206145UL, 0x9e15a0b02eb2d09eUL, 0x249126ddc099b98cUL },
-               { 0x16c8aa8b705e7912UL, 0x5254ffd3dcfd63c7UL, 0x2f5ff41aed824b29UL, 0x5e92aefbdbc02f5UL } };
-    fq12 expected = {
-        { { { 0xac407cf40656cf85UL, 0x53c4e45c7d91d7bbUL, 0x24fc4059030b458dUL, 0xc608988d828a6acUL },
-            { 0x70a009bbaa4dd445UL, 0x9472f7a5c065ba98UL, 0x4a1e4282cf71e65cUL, 0x261f89c5ef771b94UL } },
-          { { 0x73edb5dcea89d202UL, 0xa467bd8e2e7b0a2dUL, 0xdd53bfb2448cf1b6UL, 0xea940f7541be43aUL },
-            { 0x19140fd77d13dc20UL, 0x8134af178e654002UL, 0x99649e06de6062d1UL, 0x7dfb5eb77c46e77UL } },
-          { { 0x6327000dfe5eb0acUL, 0x38add03e55bd84edUL, 0x6cf2b74e0d92fd29UL, 0x4634a06b3ee61d6UL },
-            { 0xbf2b7a4d30e7f2e0UL, 0x1c7ea1b6c91cac8cUL, 0xc501259c02f3c0efUL, 0x19391b58f2c7b488UL } } },
-        { { { 0xb52a6266ad4d64c6UL, 0xf4b9ee05496e6a85UL, 0x8df70576c6512b21UL, 0xf2a083ab58b24d9UL },
-            { 0x6df2accfac5c3c80UL, 0x4578ab0439eaea36UL, 0x639be73611f43a89UL, 0x29b485ed76427947UL } },
-          { { 0xb320f772d092e959UL, 0xeac1dc82d05defe2UL, 0xf216b293fa0477baUL, 0x244135793b992890UL },
-            { 0x153faec55a401808UL, 0x60096f964173c3bfUL, 0x33ea086fd59bf075UL, 0x2a4a178ba996f400UL } },
-          { { 0xb94e24cdde4a6b2bUL, 0xc46f7eadbbb4944aUL, 0xc935ba276b8e959dUL, 0x2e82fb20dfe802a3UL },
-            { 0xa03b844c89c4be8fUL, 0x679f46cfe0884ae4UL, 0x14b1dbb1644ebedbUL, 0x28b55b24a8e35f2fUL } } }
-    };
-#endif
 
     a.self_sparse_mul(ell);
     fq12 result = a;
@@ -249,7 +173,6 @@ TEST(fq12, SparseMulCheckAgainstConstants)
 
 TEST(fq12, SqrCheckAgainstConstants)
 {
-#if defined(__SIZEOF_INT128__) && !defined(__wasm__)
     fq12 a = { { { { 0xef9d68a7df0715fd, 0xfda8aff4030523cf, 0xd09b1482069c0972, 0x252195422f351b07 },
                    { 0x3192057a31dec453, 0xe1c2dd8879191e47, 0xe90a8a00c9b29c5b, 0x1db75f06dff5dd5e } },
                  { { 0xdb01b2dbb451df8f, 0x42d8923147ae4171, 0xd1264f3077ab1733, 0x2fbabfe2fbc0c62f },
@@ -274,34 +197,6 @@ TEST(fq12, SqrCheckAgainstConstants)
                           { 0x19ea0ed62e5093c2, 0xcf288a69b5a24352, 0xa9bdc89dd4491b7d, 0x447edc7b33f3d1c } },
                         { { 0xceb417494bece8e, 0x7f3d84971a20d351, 0x31679ed74c101d91, 0x1bb2c06842073c0c },
                           { 0x6db2993066e5fd73, 0x2c08c9fd6c3b5483, 0x3b32d43ab22d6cea, 0x3df72d32906f5f0 } } } };
-#else
-    fq12 a = { { { { 0x509ff2d7952b00f8UL, 0x80f400de95f97cc0UL, 0xcbdc0724af60e599UL, 0x1acb4d80c9fc5d10UL },
-                   { 0xbbd649942a91be1bUL, 0xf9c0c84462b1c06aUL, 0x735c138d99b9fc89UL, 0x1f7a0e55480cc8c4UL } },
-                 { { 0x184564b253194647UL, 0x2665e8d5000a721UL, 0xd31174f546b93313UL, 0x1b327c76331660ecUL },
-                   { 0xcf1585c76f7e33faUL, 0xd42af737f2d68572UL, 0x3b4f1daaf9248cf2UL, 0x28102c8df7cb8188UL } },
-                 { { 0xfd34a1893271a08dUL, 0xa8bb3e8ddf935064UL, 0xaf2e701ff4238744UL, 0x112cb808f50649edUL },
-                   { 0xfa6a796e73099831UL, 0xc33d172135fc08f1UL, 0xffc1f0839ae21c08UL, 0xd5487b930349686UL } } },
-               { { { 0xa138da16197ba208UL, 0x131b351230ea78f4UL, 0x67d421144983327fUL, 0x301ad90db1293961UL },
-                   { 0x2aaf49d5664bf971UL, 0x41de301d76480c2UL, 0xf1b7cd92f25da91eUL, 0x266ad04894fb98a1UL } },
-                 { { 0x5430ab66ae7c441eUL, 0x56b0046a411a6a05UL, 0x769a94899a38a9a8UL, 0x47009b2bb1105a4UL },
-                   { 0x90e78ec3428acf7fUL, 0x494d36f303578d13UL, 0xf860c04788d78bd4UL, 0xbff46fe73771bc5UL } },
-                 { { 0x4deef8f7b5691d29UL, 0x4ca2a905e4dc7c9UL, 0xd346bb2f908bf92dUL, 0x4e7f53251024a06UL },
-                   { 0x506c4af6c096a839UL, 0xb66ec8f49dcd25d7UL, 0x1d956454caa9c224UL, 0x80fd62496656a00UL } } } };
-    fq12 expected = {
-        { { { 0x444065edd96c27eUL, 0x441edd1fb7593b4dUL, 0xebca21f0aba5b86aUL, 0x1a0f7150178bce4UL },
-            { 0xd6944c6d8a9a1326UL, 0xebe3e1c083a9070aUL, 0x90085ed26d41b187UL, 0x270dbc63380d166fUL } },
-          { { 0x6ff64bb4265979c2UL, 0x934f9a7229efd61bUL, 0xf2633f5fc77c71cdUL, 0x794a11250897c9UL },
-            { 0x4c16eb3426ead093UL, 0xc6b10f92e5172d17UL, 0x722cc34bab735deeUL, 0x2ef62e8e932612a9UL } },
-          { { 0xe5eb6b4fe61af24bUL, 0xf4ad92e89647ddbeUL, 0xf07438f58235164fUL, 0x2ddf71d5540c3861UL },
-            { 0x1f892a5ed0dbc0bfUL, 0xdea7e0ca077a8f66UL, 0x561aba1a7909c0acUL, 0x2296a5f0bb3fca3UL } } },
-        { { { 0xb33c0e27dc05cf5eUL, 0x9b5ac27c7f9f3fafUL, 0xb34ce34b0ddc0e33UL, 0x8d34950d591462UL },
-            { 0x6633d2139211d6feUL, 0x1c194cb263ca6182UL, 0x280ced1e54e99b63UL, 0x78892452fa76a9eUL } },
-          { { 0x8ffaebac35d5999eUL, 0x8e3226d773c7cac4UL, 0x180b0a89641fbc37UL, 0xd165c35b4cefb88UL },
-            { 0xc500c29819187db2UL, 0xb60e7813e364d528UL, 0xc718884d8620befeUL, 0x28351c10a5846341UL } },
-          { { 0x631e54f75f1002c2UL, 0x409714a9ec1a2c33UL, 0x374ef41466eb7b9bUL, 0xf4a88f46b6a3e97UL },
-            { 0x3e120ddf2bc5b3d2UL, 0x52166a8ab686fb53UL, 0xf5b9fbe942aaec8aUL, 0x1b25bd7f5e7b7db3UL } } }
-    };
-#endif
 
     fq12 result = a.sqr();
     EXPECT_EQ(result, expected);
@@ -309,7 +204,6 @@ TEST(fq12, SqrCheckAgainstConstants)
 
 TEST(fq12, FrobeniusMapThree)
 {
-#if defined(__SIZEOF_INT128__) && !defined(__wasm__)
     fq12 a = { { { { 0x9a56f1e63b1f0db8, 0xd629a6c847f6cedd, 0x4a179c053a91458b, 0xa84c02b0b6d7470 },
                    { 0xffa3e17eab3609a1, 0x6a97b9cf5c3fe152, 0x8996248da177be9f, 0x113bd2d7f24591d } },
                  { { 0x572c4fd8a85cc3b, 0x48197102a98815e8, 0x3a1d00190e8ee460, 0x8c0a0ce9c093781 },
@@ -334,34 +228,6 @@ TEST(fq12, FrobeniusMapThree)
                           { 0x373dde8dfb6dceb3, 0xa0feac44ec583fb4, 0x257146bc7ad7d5c2, 0x1ee0a5c45a91938b } },
                         { { 0xf8c975188dd668a5, 0xfa38a6144e0c5451, 0x8ebdddc91016c224, 0x13fe7e09fe48aefb },
                           { 0x2ce375ffd1c12d33, 0xc2099e064cd9724d, 0x9c54b742a4d8bd59, 0x1c79d60ac5202c8c } } } };
-#else
-    fq12 a = { { { { 0xe21af43e50f3c756UL, 0x382c59a08c2f1c63UL, 0xf111de6049209f49UL, 0x2e3e2eb02684cd0eUL },
-                   { 0xf47c2fd566c13420UL, 0x52f739eb87fc2a5fUL, 0x32c491b42ef7d3edUL, 0x2277a5afe48b23b1UL } },
-                 { { 0x81b5e33f164894fdUL, 0xda70b7e26c9c83eUL, 0xaa0ea6914a55d235UL, 0x261e91951b2ecf56UL },
-                   { 0x8777f8c814c07822UL, 0xb1d30aee8bbb4fdbUL, 0xd68096f26bc12a63UL, 0x226bdb647a45d0b3UL } },
-                 { { 0xe196e3bdeadc85f8UL, 0xfc4ead6ed1903f55UL, 0x35fbc522dfecf6e5UL, 0x2ea7141ed2d4f68aUL },
-                   { 0x5018998ba882e541UL, 0x1f2f49ebb929119UL, 0x10bf13b591b51304UL, 0x2715b1dab0519809UL } } },
-               { { { 0x41dfb519bce7a2a2UL, 0x57e69632d7d5db93UL, 0x63059436226719c0UL, 0x1382e9227bb12da2UL },
-                   { 0x78a2f4b9c37bba73UL, 0x9f5fa1370c59e023UL, 0x36960dd11dca7d4eUL, 0x1bb2293869e6eeaaUL } },
-                 { { 0xa7bb52bda67d2ce5UL, 0xd12b03267bae96bUL, 0x45ead6d4c0922699UL, 0x357633e5fd4e57bUL },
-                   { 0xf6caeb876f66196eUL, 0x5c88f8b1ea233a64UL, 0x6d24d190eef310f6UL, 0x2fa0d06ea9b6d35dUL } },
-                 { { 0x4bed4d1891ba154fUL, 0x2bf8026dae838260UL, 0xdcbd5388441e5626UL, 0xee0668e4e2fb0f6UL },
-                   { 0x8723a4e98854ba0bUL, 0x4d22e9a149ea8618UL, 0x5dda9a16aa96fb0aUL, 0x2fef151f315f190UL } } } };
-    fq12 expected = {
-        { { { 0xe21af43e50f3c756UL, 0x382c59a08c2f1c63UL, 0xf111de6049209f49UL, 0x2e3e2eb02684cd0eUL },
-            { 0x47a45c4171bbc927UL, 0x448a30a5e075a02dUL, 0x858bb40252898470UL, 0xdeca8c2fca67c78UL } },
-          { { 0xd358397e360f2515UL, 0xfd6900b5784eb831UL, 0x64b0f2a74cb5b985UL, 0x303bdfa5683f19d3UL },
-            { 0xee96f5c48ada25b8UL, 0xb17d89d5ee0965adUL, 0x5d90f2b14f0a7867UL, 0x11089d3bd9d1812fUL } },
-          { { 0x8b4a37515d2483f4UL, 0xe2f2f3d7704a8333UL, 0x82a719484b992a0cUL, 0x8358f71dd30b350UL },
-            { 0xff959db32aa39cd3UL, 0xb246a2f8b40c4889UL, 0xb9d5613c61fc64c3UL, 0x127acef64f2e0dfbUL } } },
-        { { { 0xc2603367444cbf36UL, 0x4cebd20389e5d4eeUL, 0xcb3f9abc665e6992UL, 0x1290194e45a92b01UL },
-            { 0x7c9e4c6727aa44d7UL, 0x7e9de180a367babUL, 0x500cb6ac8f91a2a0UL, 0x1f7ac11ce8c52bb3UL } },
-          { { 0x3796fd3f2e8f6cddUL, 0xb93f0f07868dcf79UL, 0x69a0645a73c08c82UL, 0x665f5d67055274UL },
-            { 0x3530dff683f60cd4UL, 0x49b935416224237eUL, 0x47e3654d3cdfd104UL, 0x143e9791ba51ee22UL } },
-          { { 0xb8785e8bc743805UL, 0x9582592773c34113UL, 0x7ba82edd6f46c7deUL, 0xab7c56a5990bd53UL },
-            { 0x6224e65eff5bd762UL, 0x9a1a4290432e0bb7UL, 0x94f2017f7fff74a3UL, 0x282d3d44ce884ea4UL } } }
-    };
-#endif
 
     fq12 result = a.frobenius_map_three();
     EXPECT_EQ(result, expected);
@@ -369,7 +235,6 @@ TEST(fq12, FrobeniusMapThree)
 
 TEST(fq12, FrobeniusMapTwo)
 {
-#if defined(__SIZEOF_INT128__) && !defined(__wasm__)
     fq12 a = { { { { 0x52c2cc6e77bfe9bb, 0xd03d98cc3fd6d95, 0xfaeb6d6577aa9a30, 0x1ea38b81330e34df },
                    { 0x1f55d493000a14f3, 0x1db7ec50e2f5a356, 0xf3cfcc74b91481ae, 0x256fe76342b33dbb } },
                  { { 0xf3e95f622620a0f9, 0xe297badf08d73c22, 0x4df25d06ae059cfb, 0x16db699bc5bbddcb },
@@ -394,34 +259,7 @@ TEST(fq12, FrobeniusMapTwo)
                           { 0x2461a96edf6a6749, 0xe0c7f9244e8d0ed1, 0xb55df0a79cb9ac2c, 0xa357103af082354 } },
                         { { 0xe1148c424a589341, 0x40ab0d25fb7fd0d1, 0x7909a54a9569db90, 0x99bde98bbc4352f },
                           { 0xfaa4fdcf224e38ee, 0x42b25f170bf5f577, 0xc13bf097c75be619, 0xbcb9923cbd60387 } } } };
-#else
-    fq12 a = { { { { 0xa5ce9c060e396dd4UL, 0xca5ede3c56c9dfa1UL, 0xf7283a6cd7385eb1UL, 0xc9b4f2cc9e618bcUL },
-                   { 0x47ad703bb58adfb8UL, 0x82db8c7a94096d86UL, 0x3273057afe6fecfdUL, 0x249591a339c0b395UL } },
-                 { { 0xf743b6ee14c147f7UL, 0x72621d5bfc3ca617UL, 0xf1978b242a1f7200UL, 0x58c9abd859356f7UL },
-                   { 0x9fc148e808531ae4UL, 0x7e33428ce1e43d80UL, 0x8246ca0b17d04b6cUL, 0x13266ecc9ef22872UL } },
-                 { { 0xef813b9466e4f00dUL, 0x41be0a62083cce0UL, 0xb4bbcf52f290d43cUL, 0x255bcc4ea029409dUL },
-                   { 0xdef7a848a4ded44eUL, 0xcd9fc4819661004fUL, 0x28353ecc041c3066UL, 0x27a6a7890b897c1cUL } } },
-               { { { 0x569b1e1b9916eab7UL, 0x77f844752482d618UL, 0xc8d2dfa5b90c75a1UL, 0x2b91d0892e6f3036UL },
-                   { 0xd83a28cd569274d7UL, 0xacd31b4648059115UL, 0x2d291841a5f79fffUL, 0x8853bfca3cd9a50UL } },
-                 { { 0xe904f05380da0bc2UL, 0xc9a74003c930b32fUL, 0x5a9981596b16c136UL, 0x2eea5b92180eb16eUL },
-                   { 0x18aea6c3fe1e03d1UL, 0xb8ac570097aafb8UL, 0x5e73d309f353e4f3UL, 0xc1004ae4756f68dUL } },
-                 { { 0x370079d737c6ed86UL, 0x298c4ec1f2b51e25UL, 0xdfc6f1416cbf760bUL, 0x2d5c11050cbe98d1UL },
-                   { 0x1462ea1f533b22a9UL, 0xb5262fc0a622613eUL, 0x6685b2cda9398a5cUL, 0x2fc6212886ea733aUL } } } };
-    fq12 expected = {
-        { { { 0xa5ce9c060e396dd4UL, 0xca5ede3c56c9dfa1UL, 0xf7283a6cd7385eb1UL, 0xc9b4f2cc9e618bcUL },
-            { 0x47ad703bb58adfb8UL, 0x82db8c7a94096d86UL, 0x3273057afe6fecfdUL, 0x249591a339c0b395UL } },
-          { { 0x9828994245688eeaUL, 0xe5a280f898969f11UL, 0xb4b0ecd3af49dcc6UL, 0x21670b00576e3cafUL },
-            { 0xd343da039e48db0eUL, 0xb3b4e737ecb54579UL, 0x1608becbcac11801UL, 0x8a492bd585ba0e3UL } },
-          { { 0x249b9eedf5fd4d00UL, 0x61c05dafd482a437UL, 0x3e9c9f9aeb106d88UL, 0x9073e4985688fa5UL },
-            { 0x264823249f36c1a0UL, 0xa7ad4a28f1311aeeUL, 0xa802735777a625bUL, 0x182813dd5fc55593UL } } },
-        { { { 0x91e56d561fc65bf4UL, 0x91c74e7a38170c9bUL, 0xf8da19ddb4129b39UL, 0x4a864abc1999de1UL },
-            { 0xf9dbb5cb6765f02eUL, 0x484221af215c12f1UL, 0x9dae4490f9df3878UL, 0x22d6e5b80da4cc69UL } },
-          { { 0x531b9bc357a2f185UL, 0xcdda2a8d9f41175dUL, 0x5db6c45d166a9726UL, 0x179f2e0c922eebbUL },
-            { 0x2371e552da5ef976UL, 0x8bf6a5215ef71ad5UL, 0x59dc72ac8e2d736aUL, 0x245449c499daa99cUL } },
-          { { 0xb9ce3fc038247876UL, 0x88592556fd4f5aecUL, 0xcf53070ba4335fd6UL, 0x1121fc66315ce4f4UL },
-            { 0xafbbe5445e5c30cfUL, 0x31c1f8e7a3a22522UL, 0x1d4c2afb60f35899UL, 0x26b4ff5552650fd4UL } } }
-    };
-#endif
+
     fq12 result = a.frobenius_map_two();
     EXPECT_EQ(result, expected);
 }
@@ -429,7 +267,6 @@ TEST(fq12, FrobeniusMapTwo)
 TEST(fq12, FrobeniusMapOne)
 {
 
-#if defined(__SIZEOF_INT128__) && !defined(__wasm__)
     fq12 a = { { { { 0x6c9edca7f0d6f6e, 0x7bb482de96b01e0, 0xb04fc4b2b2ea7e6, 0x4d9efc00ceb8323 },
                    { 0xb55c2222935ee583, 0x9c114ab89499b4da, 0x771cb5cabe1f458a, 0x1c3f0ac5303a5935 } },
                  { { 0x524feabf94af29ea, 0x95573536ab8b6ced, 0x524e16790930912c, 0x280d5af94a3424d0 },
@@ -454,34 +291,6 @@ TEST(fq12, FrobeniusMapOne)
                           { 0x6602e7e93a714d67, 0x7398f14acf72c7e0, 0x8028d203d5e4928, 0x7d1fad57418b580 } },
                         { { 0xcba1922169de670, 0xcd20689212638b5e, 0x8dbbc53af7639bbb, 0x57a19a043d38c39 },
                           { 0x2b2d3090bfb1118b, 0xa752e789e316e0c7, 0xc1c4d33385bc3e10, 0x2610936b5468ba45 } } } };
-#else
-    fq12 a = { { { { 0x24dc150b5836f5ebUL, 0x30e4c608f40adc59UL, 0x37aeb841e150f3a8UL, 0xa110ca8f9db83e4UL },
-                   { 0x713a6ab73312e162UL, 0xdb0fd8d93b365d68UL, 0xedf1d282a8d07abeUL, 0x20d3d49231cde3bfUL } },
-                 { { 0x2eaf1da09933840aUL, 0x47c1d410d5df0b52UL, 0x919bba97feef2c11UL, 0x177b677e677a55cdUL },
-                   { 0xf888f6cf22cba791UL, 0xf820cd3640d260ebUL, 0x32742ec8e28152aeUL, 0x36fc6b21931e9e2UL } },
-                 { { 0x779044381bcbd101UL, 0x3f5ba296ae5db8faUL, 0xc2dbbc1691c8456aUL, 0x12d18799d91da0dUL },
-                   { 0xd089a63726293a6aUL, 0x77cd64002c1c4bcaUL, 0xd76a11cb5f5c0da6UL, 0x21add603f21af96eUL } } },
-               { { { 0x8dcabcf31424c06fUL, 0x16bac862dc9fed95UL, 0xc1ae831f305040e5UL, 0x1e6200dce1120d3dUL },
-                   { 0xd1f5ad6845446895UL, 0x74526d8ca424b736UL, 0x849b3d172cc8381fUL, 0x12e88895f9e2a0d4UL } },
-                 { { 0x85cc8318ddbe2910UL, 0x961fb2e5108e0e4fUL, 0x781905321776e776UL, 0x2e8093940b560716UL },
-                   { 0x8b2ce4303baba4d9UL, 0x866a756e2161f73eUL, 0x1b230d82dbc3d550UL, 0x210f44fb356348c0UL } },
-                 { { 0xc57933e5530111baUL, 0xe45d80ed27b8a6b4UL, 0x7feeb0f2e09ca2cbUL, 0x1fdb773784242816UL },
-                   { 0xb5580ae30b1f6bf0UL, 0x51e1fbe74aad988dUL, 0x1a4e45b3185c094bUL, 0x1d0f5f64f6aa211aUL } } } };
-    fq12 expected = {
-        { { { 0x24dc150b5836f5ebUL, 0x30e4c608f40adc59UL, 0x37aeb841e150f3a8UL, 0xa110ca8f9db83e4UL },
-            { 0xcae6215fa56a1be5UL, 0xbc7191b82d3b6d24UL, 0xca5e7333d8b0dd9eUL, 0xf9079e0af63bc69UL } },
-          { { 0x2691a685eb8b9e52UL, 0xc66888725d4805e4UL, 0xfc9cca7897e98f66UL, 0xbba94db29fe53ddUL },
-            { 0x9f81e7019e774940UL, 0x36c0b8a5a6682687UL, 0x430a3924d0194d94UL, 0x2e938f15bd7f14a6UL } },
-          { { 0x74e35b32ad2905fUL, 0x35afc43add46aeedUL, 0xb0309a03e6a3fe42UL, 0x3f0424b1202b900UL },
-            { 0x1d98151eed9dceaeUL, 0x13f07d5ab22bb4fUL, 0xe14df7a387f2a2cfUL, 0x1ba0ba8d43259443UL } } },
-        { { { 0x4d7742f9a326103fUL, 0x4f500f51726e60e7UL, 0xcce27ad8fe9043c1UL, 0x45db038f7fc875bUL },
-            { 0x675053d4c95fe601UL, 0x8dc76ffbc91ef3feUL, 0x4b7246a3829a5be1UL, 0x2a53c42803e89a45UL } },
-          { { 0xef087aab854dca2UL, 0x6de4ca5802af8bfaUL, 0xcc29efb20b2d894dUL, 0x2fef6cff0a2d4495UL },
-            { 0x93ba40b513b8ba7dUL, 0x7d971482e420074aUL, 0x66c0477724426b3aUL, 0x849d2701d1e8f30UL } },
-          { { 0xe2e17ffe4a45d62bUL, 0xdd88d28e131c0c19UL, 0x8e87d63b67ef6e60UL, 0x1e1648afd6dca6b4UL },
-            { 0x867863dcd1ed7571UL, 0x1eb989092fbf511aUL, 0x38c3979e11e620f1UL, 0x846c4328f3ea4a5UL } } }
-    };
-#endif
 
     fq12 result = a.frobenius_map_one();
     EXPECT_EQ(result, expected);

--- a/barretenberg/cpp/src/barretenberg/ecc/curves/bn254/fq2.hpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/curves/bn254/fq2.hpp
@@ -27,7 +27,6 @@ namespace bb {
  *   and store them as frobenius_on_twisted_curve_x and frobenius_on_twisted_curve_y.
  */
 struct Bn254Fq2Params {
-#if defined(__SIZEOF_INT128__) && !defined(__wasm__)
     static constexpr fq twist_coeff_b_0{
         0x3bf938e377b802a8UL, 0x020b1b273633535dUL, 0x26b7edf049755260UL, 0x2514c6324384a86dUL
     };
@@ -46,26 +45,6 @@ struct Bn254Fq2Params {
     static constexpr fq frobenius_on_twisted_curve_y_1{
         0xa1d77ce45ffe77c7UL, 0x07affd117826d1dbUL, 0x6d16bd27bb7edc6bUL, 0x2c87200285defeccUL
     };
-#else
-    static constexpr fq twist_coeff_b_0{
-        0xdc19fa4aab489658UL, 0xd416744fbbf6e69UL, 0x8f7734ed0a8a033aUL, 0x19316b8353ee09bbUL
-    };
-    static constexpr fq twist_coeff_b_1{
-        0x1cfd999a3b9fece0UL, 0xbe166fb279c1a7c7UL, 0xe93a1ba45580154cUL, 0x283739c94d11a9baUL
-    };
-    static constexpr fq frobenius_on_twisted_curve_x_0{
-        0xecdea09b24a59190UL, 0x17db8ffeae2fe1c2UL, 0xbb09c97c6dabac4dUL, 0x2492b3d41d289af3UL
-    };
-    static constexpr fq frobenius_on_twisted_curve_x_1{
-        0xf1663598f1142ef1UL, 0x77ec057e0bf56062UL, 0xdd0baaecb677a631UL, 0x135e4e31d284d463UL
-    };
-    static constexpr fq frobenius_on_twisted_curve_y_0{
-        0xf46e7f60db1f0678UL, 0x31fc2eba5bcc5c3eUL, 0xedb3adc3086a2411UL, 0x1d46bd0f837817bcUL
-    };
-    static constexpr fq frobenius_on_twisted_curve_y_1{
-        0x6b3fbdf579a647d5UL, 0xcc568fb62ff64974UL, 0xc1bfbf4ac4348ac6UL, 0x15871d4d3940b4d3UL
-    };
-#endif
 };
 
 using fq2 = field2<fq, Bn254Fq2Params>;

--- a/barretenberg/cpp/src/barretenberg/ecc/curves/bn254/fq2.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/curves/bn254/fq2.test.cpp
@@ -13,62 +13,58 @@ using namespace bb;
 
 TEST(fq2, MulCheckAgainstConstants)
 {
-#if defined(__SIZEOF_INT128__) && !defined(__wasm__)
     fq2 a = { { 0xd673ba38b8c4bc86, 0x860cd1cb9e2f0c85, 0x3185f9f9166177b7, 0xd043f963ced2529 },
               { 0xd4d2fad9a3de5d98, 0x260f72ca434ef415, 0xca5c20c435accb2d, 0x122a54f828a07ffe } };
     fq2 b = { { 0x37710e0986ad0fab, 0xd9b1f41ba9d3bd92, 0xf71f600e90104795, 0x24e1f6018a4d85c6 },
               { 0x5e65448f225b0f60, 0x7783aecd5d7bfa84, 0xc7a76eed72d68723, 0xc8f427c031af99a } };
     fq2 expected = { { 0x1652ca66b00ad519, 0x6619a315656ea7c7, 0x1d8491b044e9a08f, 0xcbe6d11bff2e56b },
                      { 0x9694fb422eff4e79, 0xebdbcf03e8539a17, 0xc4787fb63b8d10e8, 0x1a5cc397aae8811f } };
-#else
-    fq2 a = { { 0xed72e66054afa688UL, 0x58ee4e882533c50UL, 0x6e3d116ec0243404UL, 0x1d657f309417a3d8UL },
-              { 0xc8d8ca2255efd3acUL, 0xa7dd5a778489041bUL, 0xa7c0d3f8a3894141UL, 0x96f1a285bc7de4UL } };
-    fq2 b = { { 0x4b149f0c89ea36b8UL, 0x21c85d36fccb509UL, 0x9c6578b5dde8a9f5UL, 0x12d7656c2d09b4f5UL },
-              { 0xeba4312d877a01c8UL, 0x346a85206bf0fc21UL, 0x326baffa4ec62182UL, 0xec5dbe959d2320bUL } };
-    fq2 expected = { { 0xe954ec1f3d72b8e8UL, 0x7290e216a46a478UL, 0xee10085491294f00UL, 0x14ab2ea0f4cfac15UL },
-                     { 0xd4761ac17f9cfd69UL, 0x6be1ccd51ae4cf91UL, 0x51bb55a8d80b3ee6UL, 0x14ef3d5468c48133UL } };
-#endif
 
     fq2 result = a * b;
     EXPECT_EQ(result, expected);
 }
 
+TEST(fq2, PairedMul)
+{
+    const fq2 a = fq2::random_element();
+    const fq2 b = fq2::random_element();
+    const fq2 c = fq2::random_element();
+    const fq2 d = fq2::random_element();
+    const auto [o1, o2] = fq2::paired_mul(a, b, c, d);
+    EXPECT_EQ(o1, a * b);
+    EXPECT_EQ(o2, c * d);
+}
+
 TEST(fq2, SqrCheckAgainstConstants)
 {
-#if defined(__SIZEOF_INT128__) && !defined(__wasm__)
     fq2 a = { { 0x26402fd760069ee8, 0x17828cf3bf7dd3e3, 0x4e7449f7b1149987, 0x102f6467805d7298 },
               { 0xa2a31bf895eaf6f8, 0xf0c88d415c372b16, 0xa65ccca8b7806691, 0x1b51e4526673451f } };
     fq2 expected = { { 0xb51c9049894c45f3, 0xf8ef65c0244dfc90, 0x42c37c0f7d09aacb, 0x64ddfb845b2901f },
                      { 0x9e176fa8cdca97b1, 0xd04ae89dab7da31e, 0x637b83e950322d50, 0x155cccfadafc70b4 } };
-#else
-    fq2 a = { { 0x6ec082078bf1f83aUL, 0x54374c9db4892e0UL, 0x9b6685d51385bd3bUL, 0x22017c733fbe1168UL },
-              { 0x1a19a57784951002UL, 0x71f829f22ee524e6UL, 0xd5f4ae41d4f49ba9UL, 0x32f0638f8eb6105UL } };
-    fq2 expected = { { 0xb30fd8d5c794c944UL, 0xbfe70dbee7f867e1UL, 0x772e6b159b2ff808UL, 0x82abd3d318b8341UL },
-                     { 0x79264bd9e27d1c3eUL, 0xc0493fc1b97b501aUL, 0x5b0cad2ef132d4fbUL, 0x61d55130ed75444UL } };
-#endif
 
     fq2 result = a.sqr();
     EXPECT_EQ(result, expected);
 }
 
+TEST(fq2, PairedSqr)
+{
+    const fq2 a = fq2::random_element();
+    const fq2 b = fq2::random_element();
+    const auto [o1, o2] = fq2::paired_sqr(a, b);
+    EXPECT_EQ(o1, a.sqr());
+    EXPECT_EQ(o2, b.sqr());
+}
+
 TEST(fq2, AddCheckAgainstConstants)
 {
 
-#if defined(__SIZEOF_INT128__) && !defined(__wasm__)
     fq2 a = { { 0x517c157ce1664f30, 0x114ba401b0996437, 0x11b9ae2d856012e8, 0xcc19341ea7cf685 },
               { 0x17c6020dde15fdc0, 0x310bc25961b2f002, 0xa766e7e94a865c0d, 0x20176bc8e6b82863 } };
     fq2 b = { { 0xffad1c8ac38be684, 0x2a953b27cb1f541d, 0xfc12b9dfe76a0f12, 0x434c570deb975a6 },
               { 0x87430d4b17897ace, 0x33ab4d0e55e8932a, 0xe4465ff65990dd31, 0x83db0b3c55f9e9f } };
     fq2 expected = { { 0x51293207a4f235b4, 0x3be0df297bb8b855, 0xdcc680d6cca21fa, 0x10f658b2c9366c2c },
                      { 0x9f090f58f59f788e, 0x64b70f67b79b832c, 0x8bad47dfa417393e, 0x28551c7cac17c703 } };
-#else
-    fq2 a = { { 0x4e7e4ee568e1fbc8UL, 0x6d692baacf9e3280UL, 0x74b397fc9ff79a15UL, 0x150ff4a64611cf54UL },
-              { 0xa14c3dc007ef12dUL, 0xb3da8d3ea50862adUL, 0xce474530b12f41f8UL, 0xab309b05df2e908UL } };
-    fq2 b = { { 0x7d62792ac082d5f2UL, 0x23a48fd69306eea5UL, 0x11b6b08fea3f318aUL, 0x25d0113614cb748cUL },
-              { 0xbbbeecf0b6be675dUL, 0x7fe28cf3b2d9708eUL, 0xef3aa23aaa94ec52UL, 0x15c08e3a45fbb32bUL } };
-    fq2 expected = { { 0x8fc03bf950e7d473UL, 0xf98c50effa335698UL, 0xce1a02d608b57341UL, 0xa7bb76979aba3b6UL },
-                     { 0xc5d3b0ccb73d588aUL, 0x33bd1a3257e1d33bUL, 0xbd81e76b5bc42e4bUL, 0x207397eaa3ee9c34UL } };
-#endif
+
     fq2 result = a + b;
     EXPECT_EQ(result, expected);
 }
@@ -76,21 +72,12 @@ TEST(fq2, AddCheckAgainstConstants)
 TEST(fq2, SubCheckAgainstConstants)
 {
 
-#if defined(__SIZEOF_INT128__) && !defined(__wasm__)
     fq2 a = { { 0x3212c3a7d7886da5, 0xcea893f4addae4aa, 0x5c8bfca7a7ed01be, 0x1a8e9dfecd598ef1 },
               { 0x4a8d9e6443fda462, 0x93248a3fde6374e7, 0xf4a6c52f75c0fc2e, 0x270aaabb4ae43370 } };
     fq2 b = { { 0x875cef17b3b46751, 0xbba7211cb92b554b, 0xa4790f1657f85606, 0x74e61182f5b5068 },
               { 0x8a84fff282dfd5a3, 0x77986fd41c21a7a3, 0xdc7072908fe375a9, 0x2e98a18c7d570269 } };
     fq2 expected = { { 0xaab5d49023d40654, 0x130172d7f4af8f5e, 0xb812ed914ff4abb8, 0x13403ce69dfe3e88 },
                      { 0xfc292a88999acc06, 0xb30d84fd2ab397d0, 0xd0869855675edee2, 0x28d657a1aebed130 } };
-#else
-    fq2 a = { { 0x442f277690c0e2e9UL, 0xc57a6aedcbce21e5UL, 0x542af3d6640959a2UL, 0x1b2a8a38b6e63b66UL },
-              { 0x72861e4d5b7fd051UL, 0x98eddfc89951d51eUL, 0x9501d71c127de4aeUL, 0x2789ae315eadca0bUL } };
-    fq2 b = { { 0xfb1bb29b1498f504UL, 0x16de795183a37f3bUL, 0xade0cbf0f9055f61UL, 0x283ae93a66a38c6dUL },
-              { 0x44cf93a2fd55060eUL, 0x31e37d7946df37e4UL, 0xf4a626aecf465a37UL, 0x27530019470f8857UL } };
-    fq2 expected = { { 0x853400f254a4eb2cUL, 0x461d5c2db09c6d36UL, 0x5e9a6d9bec85529fUL, 0x2353ef7131744f22UL },
-                     { 0x2db68aaa5e2aca43UL, 0x670a624f52729d3aUL, 0xa05bb06d43378a77UL, 0x36ae18179e41b3UL } };
-#endif
 
     fq2 result = a - b;
     EXPECT_EQ(result, expected);

--- a/barretenberg/cpp/src/barretenberg/ecc/curves/bn254/fq6.hpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/curves/bn254/fq6.hpp
@@ -36,7 +36,6 @@ namespace bb {
  */
 struct Bn254Fq6Params {
 
-#if defined(__SIZEOF_INT128__) && !defined(__wasm__)
     static constexpr fq2 frobenius_coeffs_c1_1{
         { 0xb5773b104563ab30UL, 0x347f91c8a9aa6454UL, 0x7a007127242e0991UL, 0x1956bcd8118214ecUL },
         { 0x6e849f1ea0aa4757UL, 0xaa1c7b6d89f89141UL, 0xb6e713cdfae0ca3aUL, 0x26694fbb4e82ebc3UL }
@@ -66,36 +65,6 @@ struct Bn254Fq6Params {
         { 0x448a93a57b6762dfUL, 0xbfd62df528fdeadfUL, 0xd858f5d00e9bd47aUL, 0x06b03d4d3476ec58UL },
         { 0x2b19daf4bcc936d1UL, 0xa1a54e7a56f4299fUL, 0xb533eee05adeaef1UL, 0x170c812b84dda0b2UL }
     };
-#else
-    static constexpr fq2 frobenius_coeffs_c1_1{
-        { 0xecdea09b24a59190UL, 0x17db8ffeae2fe1c2UL, 0xbb09c97c6dabac4dUL, 0x2492b3d41d289af3UL },
-        { 0xf1663598f1142ef1UL, 0x77ec057e0bf56062UL, 0xdd0baaecb677a631UL, 0x135e4e31d284d463UL }
-    };
-
-    static constexpr fq2 frobenius_coeffs_c1_2{
-        { 0x8aeb638758ccb791UL, 0xee27476838ae0f5bUL, 0x5fc8441d09282bUL, 0x169119a8426a57f9UL }, { 0UL, 0UL, 0UL, 0UL }
-    };
-
-    static constexpr fq2 frobenius_coeffs_c1_3{
-        { 0x4738e103136caecdUL, 0xf491475bc376b8c3UL, 0x1f4034a3a97cbee8UL, 0xcad5f8fef61ccd7UL },
-        { 0x2f41c395e6e485d6UL, 0x997230c70242aa46UL, 0xeae16f2184887ab5UL, 0x266696f73bcfc9b2UL }
-    };
-
-    static constexpr fq2 frobenius_coeffs_c2_1{
-        { 0x227346b0b081f85eUL, 0x6e51a67130492bb5UL, 0x7e20162e52b19e16UL, 0x1677516f2343bb4bUL },
-        { 0x18b280852f616a78UL, 0x25433712bde06eceUL, 0xb00a58256b9a0e66UL, 0x6f9f8e111971bbdUL }
-    };
-
-    static constexpr fq2 frobenius_coeffs_c2_2{
-        { 0x62b1a3a46a337995UL, 0xadc97d2722e2726eUL, 0x64ee82ede2db85faUL, 0xc0afea1488a03bbUL },
-        { 0UL, 0UL, 0UL, 0UL }
-    };
-
-    static constexpr fq2 frobenius_coeffs_c2_3{
-        { 0xa0d044540af866c4UL, 0x9cc0145f7df631b3UL, 0x29dda327cd752de1UL, 0x14766fdb0a170a74UL },
-        { 0xdd532940e9d402f7UL, 0x541490c5bfda559eUL, 0xd9c9c659c541b0b8UL, 0xbaf8cb569cbb3e4UL }
-    };
-#endif
 
     static inline constexpr fq2 mul_by_non_residue(const fq2& a)
     {

--- a/barretenberg/cpp/src/barretenberg/ecc/curves/bn254/fq6.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/curves/bn254/fq6.test.cpp
@@ -54,7 +54,6 @@ TEST(fq6, SubCheckAgainstConstants)
 
 TEST(fq6, MulCheckAgainstConstants)
 {
-#if defined(__SIZEOF_INT128__) && !defined(__wasm__)
     fq6 a{ { { 0xa7e3494fc528b8c8, 0xc8c8906c9682e43f, 0xc6e76fc21152721c, 0x12a4c3ee3ff10dbd },
              { 0x887ce62a3ae2a578, 0x70caee28e1942bac, 0xc1a58242c34ff94f, 0x0b154d910b492542 } },
            { { 0x8c885006cc08667a, 0xee0b6c4a0dbb9592, 0xa755229d6272b51e, 0x2629b93f67eb8dd6 },
@@ -73,26 +72,6 @@ TEST(fq6, MulCheckAgainstConstants)
                     { 0x4b2fbc422420f06a, 0x3a8e5b388fdedd1f, 0x06006b4471134540, 0x0d4fee4f7966d63d } },
                   { { 0x4ffcbaa876979a1c, 0x32b7c1ef7d251306, 0x1b4e0712f969804e, 0x200592dfe71b710f },
                     { 0xe3eb378754bfb1ac, 0x6b517c1cae53d784, 0xd1b29c0eb1e4d46f, 0x08b42f13fdd14172 } } };
-#else
-    fq6 a{ { { 0x2ae298e67f3b39acUL, 0xff010ec1eb070956UL, 0x392ab3b4183e1f35UL, 0xfe4d0656fce35c4UL },
-             { 0x6ab8f0a770e9c20fUL, 0xf4d3db225768ebb4UL, 0x2a7e605adf75bf5eUL, 0xfeb8cfd40c94734UL } },
-           { { 0xb1dc529e5cd81351UL, 0xf5ca210e8455ea86UL, 0xeacd84d9a8b502b9UL, 0xb6b7eb4ff9916c1UL },
-             { 0xdb94de41ad3b48d0UL, 0x5953eb9473583fe8UL, 0xa603759c9ad36f81UL, 0x229e55e6aa957e6UL } },
-           { { 0x3c0c61a8882bdd6cUL, 0xd8fe0e66857b4d54UL, 0xb39ce4d438c3eb07UL, 0x2c6333d09ff65713UL },
-             { 0x79d7e64184f4cbb1UL, 0x46523cfdd9722bd8UL, 0xdb3fdb38faf61435UL, 0xe8198361076a5a5UL } } };
-    fq6 b{ { { 0x1ac3b1e7ec8a731cUL, 0xbb7de52d99e73d29UL, 0x4caac2356d446d23UL, 0x929876b197c1767UL },
-             { 0x46e1737df8be5c58UL, 0x3d2d14ad3aa1890cUL, 0x659c80230fad0fa0UL, 0xd47f2fbefb5fbabUL } },
-           { { 0x8b4d2a252c11fd02UL, 0x415b985e57d8c07aUL, 0x864441c79f72d7b5UL, 0x143306f7ce4da3aeUL },
-             { 0xd76ea5fe36f41c42UL, 0xc546a55497cb7e0aUL, 0x6027b6dc6f841d13UL, 0x2d7f5a564d5981b5UL } },
-           { { 0xf8fced7f8d6ce98UL, 0x46d85360675c5f7bUL, 0x663867cd6a61f912UL, 0x1c3fbd1c4728ce2fUL },
-             { 0xd7681e6bff8abe8bUL, 0x951b03f1bffa2c2fUL, 0x66fd7a89c9ec33b2UL, 0xc425d325d08a85fUL } } };
-    fq6 expected{ { { 0xccc2041ef7e674a1UL, 0xf2f0e47f82792d77UL, 0xb4b9f006110451c9UL, 0xdae59051f5a8c62UL },
-                    { 0x9482d60673539368UL, 0x42c40af4541687e4UL, 0x67c6919c35403c12UL, 0xb8254cf01cba09eUL } },
-                  { { 0x3b942b02bf094a1UL, 0xff838144f8716d23UL, 0x8530532ec620bef1UL, 0x25d5c85a56786593UL },
-                    { 0x84f3278dc0362308UL, 0x95c01286b84d4f7fUL, 0xfd8b3ada165de51aUL, 0x26db5658234dc652UL } },
-                  { { 0x10ebd72f10b27cadUL, 0xe95a8002134cc334UL, 0x4b2b2a668d93ca18UL, 0x877ec906a5bfe77UL },
-                    { 0x50c434785d85431dUL, 0x74a86ebec041fbdaUL, 0x9cc22545b513d419UL, 0x24905a4154300d89UL } } };
-#endif
 
     fq6 result = a * b;
     EXPECT_EQ(result, expected);
@@ -100,7 +79,6 @@ TEST(fq6, MulCheckAgainstConstants)
 
 TEST(fq6, SqrCheckAgainstConstants)
 {
-#if defined(__SIZEOF_INT128__) && !defined(__wasm__)
     fq6 a{ { { 0xe337aaa063afce6, 0xff4b5477485eb20, 0xef6dcf13b3855ef8, 0x14554c38da988ece },
              { 0x6a70e65e71431416, 0xd21f95045c45f422, 0x2a17b6c6ff517884, 0x1b01ad6487a3ff16 } },
            { { 0xea39618e9f05e1f, 0x63e9b0f7803072a6, 0xebe5538a2c75c89, 0x5312aad2ac95dcf },
@@ -113,20 +91,6 @@ TEST(fq6, SqrCheckAgainstConstants)
                     { 0xd48ac80d8e6e52b5, 0x1791b8c4145bc2d3, 0x35c456444cdcf9be, 0x1eddd29d77366c08 } },
                   { { 0x56f1f8acbaed1118, 0xdd74b8bb2e47de74, 0x97525aa49c65f0fd, 0x15bbf236e098fa0f },
                     { 0xad97a94142524aeb, 0x42a508523527268b, 0x4c9c5f213de06ca8, 0x73fa6bc31efa2f2 } } };
-#else
-    fq6 a{ { { 0xb8c83817c906c025UL, 0x4d043f8c42f61ad5UL, 0x91a65831dd1a6241UL, 0x15918b45e38cb7bfUL },
-             { 0x4ff37e49c815b109UL, 0x345a8ce3993010ecUL, 0x5a237c150983263UL, 0x298c76f000344000UL } },
-           { { 0x20111ed8b494cc0bUL, 0xb6b1df3bccb8f51aUL, 0xaed9d5f0d4678813UL, 0x14f86a4cb596d964UL },
-             { 0x69bc7d9504b28c8fUL, 0xe0d8603ce6221c7bUL, 0x23ca4fa0d532663fUL, 0x1a80d9d5b362f1a2UL } },
-           { { 0x25eb400748a0cf37UL, 0x89d64fd9d5bf6d15UL, 0x5d26ffdaa12d840cUL, 0x2569403a2168757UL },
-             { 0xcdec65e163c03266UL, 0xd10e3957cf3b72b0UL, 0xec521e4d37493492UL, 0x129d95f2098a2ca4UL } } };
-    fq6 expected{ { { 0x3c4bcc8dcefcaceeUL, 0x34ab9174317f1e3aUL, 0x1ef0e16468a08463UL, 0x15d11e13ea53477bUL },
-                    { 0xa863e40cfbb3daa5UL, 0xce21a9ece91fa28dUL, 0x18f8b8d5131d5b16UL, 0x217cae35f576c1cUL } },
-                  { { 0xc9c6c70ba08b73c0UL, 0xcad2cccbf550a886UL, 0xfc81330087d97569UL, 0x887ec11880851c1UL },
-                    { 0xdece0fe8e4068d14UL, 0x1c1ac52662948771UL, 0x524556477d845073UL, 0x13e432b54eecfdc4UL } },
-                  { { 0x94776c5786cc491eUL, 0x6583437212c2bad1UL, 0xd5e7849877ab4a9dUL, 0x1201fc93c2687faaUL },
-                    { 0xc272f7cce8556844UL, 0xf69b6001031da740UL, 0xb24acd4db6083391UL, 0x26639dbab92ddda2UL } } };
-#endif
 
     fq6 result = a.sqr();
     EXPECT_EQ(result, expected);

--- a/barretenberg/cpp/src/barretenberg/ecc/curves/bn254/fr.hpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/curves/bn254/fr.hpp
@@ -87,13 +87,6 @@ class Bn254FrParams {
     static constexpr uint64_t modulus_wasm_7 = 0xe5c2634;
     static constexpr uint64_t modulus_wasm_8 = 0x30644e;
 
-    // A little-endian representation of R^2 modulo the modulus (R=2^261 mod modulus) split into 4 64-bit words
-    // We use 2^261 in wasm, because 261=29*9, the 9 29-bit limbs used for arithmetic
-    static constexpr uint64_t r_squared_wasm_0 = 0x38c2e14b45b69bd4UL;
-    static constexpr uint64_t r_squared_wasm_1 = 0x0ffedb1885883377UL;
-    static constexpr uint64_t r_squared_wasm_2 = 0x7840f9f0abc6e54dUL;
-    static constexpr uint64_t r_squared_wasm_3 = 0x0a054a3e848b0f05UL;
-
     // 2^(-29) mod Modulus
     // Used in the reduction mechanism, see field_docs.md
     // Instead of computing k, we multiply the lowest limb by this value and then add to the following 10 limbs.
@@ -107,26 +100,6 @@ class Bn254FrParams {
     static constexpr uint64_t r_inv_wasm_6 = 0x11f74a6c;
     static constexpr uint64_t r_inv_wasm_7 = 0x6fdaecb;
     static constexpr uint64_t r_inv_wasm_8 = 0x183227;
-
-    // A little-endian representation of the cubic root of 1 in Fr in Montgomery form for wasm (R=2^261 mod modulus)
-    // split into 4 64-bit words
-    static constexpr uint64_t cube_root_wasm_0 = 0x7334a1ce7065364dUL;
-    static constexpr uint64_t cube_root_wasm_1 = 0xae21578e4a14d22aUL;
-    static constexpr uint64_t cube_root_wasm_2 = 0xcea2148a96b51265UL;
-    static constexpr uint64_t cube_root_wasm_3 = 0x0038f7edf614a198UL;
-
-    // A little-endian representation of the primitive root of 1 Fr in Montgomery form for wasm (R=2^261 mod modulus)
-    // split into 4 64-bit words
-    static constexpr uint64_t primitive_root_wasm_0 = 0x2faf11711a27b370UL;
-    static constexpr uint64_t primitive_root_wasm_1 = 0xc23fe9fced28f1b8UL;
-    static constexpr uint64_t primitive_root_wasm_2 = 0x43a0fc9bbe2af541UL;
-    static constexpr uint64_t primitive_root_wasm_3 = 0x05d90b5719653a4fUL;
-
-    // Coset generators in Montgomery form for R=2^261 mod Modulus. Used in FFT-based proving systems
-    static constexpr uint64_t coset_generator_wasm_0 = 0xab46711cdffffcb2ULL;
-    static constexpr uint64_t coset_generator_wasm_1 = 0x2476607dbd2dfff1ULL;
-    static constexpr uint64_t coset_generator_wasm_2 = 0xe6b99ee0068dfc25ULL;
-    static constexpr uint64_t coset_generator_wasm_3 = 0x1484c05bce00b620ULL;
 
     // Parameters used for quickly splitting a scalar into two endomorphism scalars for faster scalar multiplication
     // For specifics on how these have been derived, see ecc/fields/endomorphim_scalars.py

--- a/barretenberg/cpp/src/barretenberg/ecc/curves/bn254/fr.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/curves/bn254/fr.test.cpp
@@ -19,11 +19,9 @@ auto& engine = numeric::get_debug_randomness();
 
 // ================================
 // Fixed Compile-Time Tests (field-specific expected values)
-// These tests use hardcoded expected values that are only valid for native builds (R = 2^256).
-// WASM uses R = 2^261.
+// These tests use hardcoded expected values for the unified Montgomery radix R = 2^256.
 // ================================
 
-#if defined(__SIZEOF_INT128__) && !defined(__wasm__)
 TEST(BN254Fr, CompileTimeMultiplication)
 {
     constexpr fr a{ 0x20565a572c565a66, 0x7bccd0f01f5f7bff, 0x63ec2beaad64711f, 0x624953caaf44a814 };
@@ -62,7 +60,6 @@ TEST(BN254Fr, CompileTimeSubtraction)
     constexpr fr result = a - b;
     static_assert(result == expected);
 }
-#endif
 
 TEST(BN254Fr, CompileTimeInversion)
 {

--- a/barretenberg/cpp/src/barretenberg/ecc/curves/bn254/g1.hpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/curves/bn254/g1.hpp
@@ -18,17 +18,9 @@ struct Bn254G1Params {
 
     // Generator = (1, sqrt(4)) = (1, 2)
     static constexpr fq one_x = fq::one();
-#if defined(__SIZEOF_INT128__) && !defined(__wasm__)
     static constexpr fq one_y{ 0xa6ba871b8b1e1b3aUL, 0x14f1d651eb8e167bUL, 0xccdd46def0f28c58UL, 0x1c14ef83340fbe5eUL };
-#else
-    static constexpr fq one_y{ 0x9d0709d62af99842UL, 0xf7214c0419c29186UL, 0xa603f5090339546dUL, 0x1b906c52ac7a88eaUL };
-#endif
     static constexpr fq a{ 0UL, 0UL, 0UL, 0UL };
-#if defined(__SIZEOF_INT128__) && !defined(__wasm__)
     static constexpr fq b{ 0x7a17caa950ad28d7UL, 0x1f6ac17ae15521b9UL, 0x334bea4e696bd284UL, 0x2a1f6744ce179d8eUL };
-#else
-    static constexpr fq b{ 0xeb8a8ec140766463UL, 0xf2b1f20626a3da49UL, 0xf905ef8d84d5fea4UL, 0x2958a27c02b7cd5fUL };
-#endif
 };
 
 using g1 = group<fq, fr, Bn254G1Params>;

--- a/barretenberg/cpp/src/barretenberg/ecc/curves/bn254/g2.hpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/curves/bn254/g2.hpp
@@ -16,21 +16,10 @@ struct Bn254G2Params {
     static constexpr bool can_hash_to_curve = false;
     static constexpr bool has_a = false;
 
-#if defined(__SIZEOF_INT128__) && !defined(__wasm__)
     static constexpr fq2 one_x{ { 0x8e83b5d102bc2026, 0xdceb1935497b0172, 0xfbb8264797811adf, 0x19573841af96503b },
                                 { 0xafb4737da84c6140, 0x6043dd5a5802d8c4, 0x09e950fc52a02f86, 0x14fef0833aea7b6b } };
     static constexpr fq2 one_y{ { 0x619dfa9d886be9f6, 0xfe7fd297f59e9b78, 0xff9e1a62231b7dfe, 0x28fd7eebae9e4206 },
                                 { 0x64095b56c71856ee, 0xdc57f922327d3cbb, 0x55f935be33351076, 0x0da4a0e693fd6482 } };
-#else
-    static constexpr fq2 one_x{
-        { 0xe6df8b2cfb43050UL, 0x254c7d92a843857eUL, 0xf2006d8ad80dd622UL, 0x24a22107dfb004e3UL },
-        { 0xe8e7528c0b334b65UL, 0x56e941e8b293cf69UL, 0xe1169545c074740bUL, 0x2ac61491edca4b42UL }
-    };
-    static constexpr fq2 one_y{
-        { 0xdc508d48384e8843UL, 0xd55415a8afd31226UL, 0x834bf204bacb6e00UL, 0x51b9758138c5c79UL },
-        { 0x64067e0b46a5f641UL, 0x37726529a3a77875UL, 0x4454445bd915f391UL, 0x10d5ac894edeed3UL }
-    };
-#endif
     static constexpr fq2 a = fq2::zero();
     static constexpr fq2 b = fq2::twist_coeff_b();
 };

--- a/barretenberg/cpp/src/barretenberg/ecc/curves/field_params_constants.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/curves/field_params_constants.test.cpp
@@ -233,21 +233,6 @@ TYPED_TEST_P(FieldConstantsTest, WasmModulusConsistency)
     EXPECT_EQ(wasm_modulus.hi, uint256_t(0));
 }
 
-// Verify R_wasm^2 mod p, where R_wasm = 2^261 = 2^(29*9).
-TYPED_TEST_P(FieldConstantsTest, WasmRSquared)
-{
-    using Params = typename TypeParam::Params;
-    uint256_t mod{ Params::modulus_0, Params::modulus_1, Params::modulus_2, Params::modulus_3 };
-    uint512_t R_wasm = uint512_t(1) << 261;
-    uint512_t R_wasm_mod = R_wasm % mod;
-    uint512_t expected = (R_wasm_mod * R_wasm_mod) % mod;
-    uint256_t actual{
-        Params::r_squared_wasm_0, Params::r_squared_wasm_1, Params::r_squared_wasm_2, Params::r_squared_wasm_3
-    };
-    EXPECT_EQ(expected.lo, actual);
-    EXPECT_EQ(expected.hi, uint256_t(0));
-}
-
 // Verify r_inv_wasm_{0-8} = 2^{-29} mod p, stored as 9 x 29-bit limbs.
 // Also verify each limb fits in 29 bits, and that it is smaller than the modulus
 TYPED_TEST_P(FieldConstantsTest, WasmPowMinus29)
@@ -269,65 +254,6 @@ TYPED_TEST_P(FieldConstantsTest, WasmPowMinus29)
     EXPECT_LT(r_inv_wasm, uint512_t(mod));
 }
 
-// Verify cube_root_wasm is the same field element as cube_root_native but in WASM Montgomery form.
-// Since R_wasm = 2^261 and R_native = 2^256, converting native -> WASM multiplies by 2^5 = 32.
-TYPED_TEST_P(FieldConstantsTest, WasmCubeRootConsistency)
-{
-    if constexpr (!TypeParam::has_cube_root) {
-        GTEST_SKIP() << "Cube root is not used for this field";
-    } else {
-        using Params = typename TypeParam::Params;
-        uint256_t mod{ Params::modulus_0, Params::modulus_1, Params::modulus_2, Params::modulus_3 };
-        uint256_t cube_root_native{
-            Params::cube_root_0, Params::cube_root_1, Params::cube_root_2, Params::cube_root_3
-        };
-        uint256_t cube_root_wasm{
-            Params::cube_root_wasm_0, Params::cube_root_wasm_1, Params::cube_root_wasm_2, Params::cube_root_wasm_3
-        };
-        // R_wasm / R_native = 2^261 / 2^256 = 2^5 = 32
-        uint512_t expected = (uint512_t(cube_root_native) * 32) % mod;
-        EXPECT_EQ(expected.lo, cube_root_wasm);
-    }
-}
-
-// Verify primitive_root_wasm is the same field element as primitive_root_native in WASM Montgomery form.
-TYPED_TEST_P(FieldConstantsTest, WasmPrimitiveRootConsistency)
-{
-    if constexpr (!TypeParam::has_primitive_root) {
-        GTEST_SKIP() << "Primitive root is not used for this field";
-    } else {
-        using Params = typename TypeParam::Params;
-        uint256_t mod{ Params::modulus_0, Params::modulus_1, Params::modulus_2, Params::modulus_3 };
-        uint256_t primitive_root_native{
-            Params::primitive_root_0, Params::primitive_root_1, Params::primitive_root_2, Params::primitive_root_3
-        };
-        uint256_t primitive_root_wasm{ Params::primitive_root_wasm_0,
-                                       Params::primitive_root_wasm_1,
-                                       Params::primitive_root_wasm_2,
-                                       Params::primitive_root_wasm_3 };
-        // R_wasm / R_native = 2^261 / 2^256 = 2^5 = 32
-        uint512_t expected = (uint512_t(primitive_root_native) * 32) % mod;
-        EXPECT_EQ(expected.lo, primitive_root_wasm);
-    }
-}
-
-// Verify coset_generator_wasm is the same field element as coset_generator_native in WASM Montgomery form.
-TYPED_TEST_P(FieldConstantsTest, CosetGeneratorConsistency)
-{
-    using Params = typename TypeParam::Params;
-    uint256_t mod{ Params::modulus_0, Params::modulus_1, Params::modulus_2, Params::modulus_3 };
-    uint256_t coset_generator_native{
-        Params::coset_generator_0, Params::coset_generator_1, Params::coset_generator_2, Params::coset_generator_3
-    };
-    uint256_t coset_generator_wasm{ Params::coset_generator_wasm_0,
-                                    Params::coset_generator_wasm_1,
-                                    Params::coset_generator_wasm_2,
-                                    Params::coset_generator_wasm_3 };
-    // R_wasm / R_native = 2^261 / 2^256 = 2^5 = 32
-    uint512_t expected = (static_cast<uint512_t>(coset_generator_native) * 32) % mod;
-    EXPECT_EQ(expected, static_cast<uint512_t>(coset_generator_wasm));
-}
-
 REGISTER_TYPED_TEST_SUITE_P(FieldConstantsTest,
                             Modulus,
                             RSquared,
@@ -337,11 +263,7 @@ REGISTER_TYPED_TEST_SUITE_P(FieldConstantsTest,
                             PrimitiveRootOfUnity,
                             CosetGenerator,
                             WasmModulusConsistency,
-                            WasmRSquared,
-                            WasmPowMinus29,
-                            WasmCubeRootConsistency,
-                            WasmPrimitiveRootConsistency,
-                            CosetGeneratorConsistency);
+                            WasmPowMinus29);
 
 using FieldTestTypes = ::testing::Types<Bn254FqTestConfig,
                                         Bn254FrTestConfig,

--- a/barretenberg/cpp/src/barretenberg/ecc/curves/grumpkin/grumpkin.hpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/curves/grumpkin/grumpkin.hpp
@@ -24,24 +24,14 @@ struct G1Params {
     static constexpr bool USE_ENDOMORPHISM = true;
     static constexpr bool can_hash_to_curve = true;
     static constexpr bool has_a = false;
-#if defined(__SIZEOF_INT128__) && !defined(__wasm__)
     static constexpr bb::fr b{ 0xdd7056026000005a, 0x223fa97acb319311, 0xcc388229877910c0, 0x34394632b724eaa };
-#else
-    static constexpr bb::fr b{ 0x2646d52420000b3eUL, 0xf78d5ec872bf8119UL, 0x166fb9c3ec1f6749UL, 0x7a9ef7fabe69506UL };
-#endif
     static constexpr bb::fr a{ 0UL, 0UL, 0UL, 0UL };
 
     // generator point = (x, y) = (1, sqrt(-16)) = (1, -4i)
     static constexpr bb::fr one_x = bb::fr::one();
-#if defined(__SIZEOF_INT128__) && !defined(__wasm__)
     static constexpr bb::fr one_y{
         0x11b2dff1448c41d8UL, 0x23d3446f21c77dc3UL, 0xaa7b8cf435dfafbbUL, 0x14b34cf69dc25d68UL
     };
-#else
-    static constexpr bb::fr one_y{
-        0xc3e285a561883af3UL, 0x6fc5c2360a850101UL, 0xf35e144228647aa9UL, 0x2151a2fe48c68af6UL
-    };
-#endif
 };
 using g1 = bb::group<bb::fr, bb::fq, G1Params>;
 

--- a/barretenberg/cpp/src/barretenberg/ecc/curves/secp256k1/secp256k1.hpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/curves/secp256k1/secp256k1.hpp
@@ -85,13 +85,6 @@ struct FqParams {
     static constexpr uint64_t modulus_wasm_7 = 0x1fffffff;
     static constexpr uint64_t modulus_wasm_8 = 0xffffff;
 
-    // A little-endian representation of R^2 modulo the modulus (R=2^261 mod modulus) split into 4 64-bit words
-    // We use 2^261 in wasm, because 261=29*9, the 9 29-bit limbs used for arithmetic in
-    static constexpr uint64_t r_squared_wasm_0 = 0x001e88003a428400UL;
-    static constexpr uint64_t r_squared_wasm_1 = 0x0000000000000400UL;
-    static constexpr uint64_t r_squared_wasm_2 = 0x0000000000000000UL;
-    static constexpr uint64_t r_squared_wasm_3 = 0x0000000000000000UL;
-
     // 2^(-29) mod Modulus
     // Used in the reduction mechanism, see field_docs.md
     // Instead of computing k, we multiply the lowest limb by this value and then add to the following 10 limbs.
@@ -105,26 +98,6 @@ struct FqParams {
     static constexpr uint64_t r_inv_wasm_6 = 0x1fffffff;
     static constexpr uint64_t r_inv_wasm_7 = 0x10ffffff;
     static constexpr uint64_t r_inv_wasm_8 = 0x9129a9;
-
-    // A little-endian representation of the cube root of 1 in Fq in Montgomery form for wasm (R=2^261 mod modulus)
-    // split into 4 64-bit words
-    static constexpr uint64_t cube_root_wasm_0 = 0x1486c3a0d03162ffUL;
-    static constexpr uint64_t cube_root_wasm_1 = 0x7fbc2c63897015ebUL;
-    static constexpr uint64_t cube_root_wasm_2 = 0x1d312f1a05c720a0UL;
-    static constexpr uint64_t cube_root_wasm_3 = 0x4946d5d79767aa7fUL;
-
-    // Not used in secp256k1, since this is not for proving systems
-    static constexpr uint64_t primitive_root_wasm_0 = 0x0000000000000000UL;
-    static constexpr uint64_t primitive_root_wasm_1 = 0x0000000000000000UL;
-    static constexpr uint64_t primitive_root_wasm_2 = 0x0000000000000000UL;
-    static constexpr uint64_t primitive_root_wasm_3 = 0x0000000000000000UL;
-
-    // Coset generators in Montgomery form for R=2^261 mod Modulus. Used in FFT-based proving systems, don't really need
-    // them here
-    static constexpr uint64_t coset_generator_wasm_0 = 0x0000006000016e60ULL;
-    static constexpr uint64_t coset_generator_wasm_1 = 0;
-    static constexpr uint64_t coset_generator_wasm_2 = 0;
-    static constexpr uint64_t coset_generator_wasm_3 = 0;
 
     // For consistency with bb::fq, if we ever represent an element of bb::secp256k1::fq in the public inputs, we do so
     // as a bigfield element, so with 4 public inputs
@@ -184,7 +157,7 @@ struct FrParams {
     static constexpr uint64_t primitive_root_2 = 0UL;
     static constexpr uint64_t primitive_root_3 = 0UL;
 
-    // Coset generators in Montgomery form for R=2^261 mod Modulus. Used in FFT-based proving systems, don't really need
+    // Coset generators in Montgomery form for R=2^256 mod Modulus. Used in FFT-based proving systems, don't really need
     // them here
     static constexpr uint64_t coset_generator_0 = 0x40e4273feef0b9bbULL;
     static constexpr uint64_t coset_generator_1 = 0x5a95af7e9394ded5ULL;
@@ -203,13 +176,6 @@ struct FrParams {
     static constexpr uint64_t modulus_wasm_7 = 0x1fffffff;
     static constexpr uint64_t modulus_wasm_8 = 0xffffff;
 
-    // A little-endian representation of R^2 modulo the modulus (R=2^261 mod modulus) split into 4 64-bit words
-    // We use 2^261 in wasm, because 261=29*9, the 9 29-bit limbs used for arithmetic in
-    static constexpr uint64_t r_squared_wasm_0 = 0x63e601a3c9f6ab4bUL;
-    static constexpr uint64_t r_squared_wasm_1 = 0xa2b6456d46702f57UL;
-    static constexpr uint64_t r_squared_wasm_2 = 0x5fd7916f341f1cefUL;
-    static constexpr uint64_t r_squared_wasm_3 = 0x9c7356071a6f179aUL;
-
     // 2^(-29) mod Modulus
     // Used in the reduction mechanism, see field_docs.md
     // Instead of computing k, we multiply the lowest limb by this value and then add to the following 10 limbs.
@@ -223,19 +189,6 @@ struct FrParams {
     static constexpr uint64_t r_inv_wasm_6 = 0x1fffffff;
     static constexpr uint64_t r_inv_wasm_7 = 0x1effffff;
     static constexpr uint64_t r_inv_wasm_8 = 0xac4589;
-
-    // A little-endian representation of the cube root of 1 in Fr in Montgomery form for wasm (R=2^261 mod modulus)
-    // split into 4 64-bit words
-    static constexpr uint64_t cube_root_wasm_0 = 0x9185b639102f0736UL;
-    static constexpr uint64_t cube_root_wasm_1 = 0x47a854ad9ffc4748UL;
-    static constexpr uint64_t cube_root_wasm_2 = 0x752cc0ca4d2fb232UL;
-    static constexpr uint64_t cube_root_wasm_3 = 0x650802f0ab1ac72eUL;
-
-    // Not used in secp256k1
-    static constexpr uint64_t primitive_root_wasm_0 = 0x0000000000000000UL;
-    static constexpr uint64_t primitive_root_wasm_1 = 0x0000000000000000UL;
-    static constexpr uint64_t primitive_root_wasm_2 = 0x0000000000000000UL;
-    static constexpr uint64_t primitive_root_wasm_3 = 0x0000000000000000UL;
 
     // Not needed, since there is no endomorphism for secp256k1
     static constexpr uint64_t endo_minus_b1_lo = 0x6F547FA90ABFE4C3ULL;
@@ -252,13 +205,6 @@ struct FrParams {
 
     static constexpr uint64_t endo_g2_lo = 0xE86C90E49284EB15ULL;
     static constexpr uint64_t endo_g2_mid = 0x3086D221A7D46BCDULL;
-
-    // Coset generators in Montgomery form for R=2^261 mod Modulus. Used in FFT-based proving systems, don't really need
-    // them here
-    static constexpr uint64_t coset_generator_wasm_0 = 0x1c84e7fdde173760ULL;
-    static constexpr uint64_t coset_generator_wasm_1 = 0x52b5efd2729bdaa8ULL;
-    static constexpr uint64_t coset_generator_wasm_2 = 0x00000000000000cbULL;
-    static constexpr uint64_t coset_generator_wasm_3 = 0x0000000000000000ULL;
 
     // For consistency with bb::fq, if we ever represent an element of bb::secp256k1::fr in the public inputs, we do so
     // as a bigfield element, so with 4 public inputs

--- a/barretenberg/cpp/src/barretenberg/ecc/curves/secp256r1/secp256r1.hpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/curves/secp256r1/secp256r1.hpp
@@ -83,13 +83,6 @@ struct FqParams {
     static constexpr uint64_t modulus_wasm_7 = 0x1fe00000;
     static constexpr uint64_t modulus_wasm_8 = 0xffffff;
 
-    // A little-endian representation of R^2 modulo the modulus (R=2^261 mod modulus) split into 4 64-bit words
-    // We use 2^261 in wasm, because 261=29*9, the 9 29-bit limbs used for arithmetic
-    static constexpr uint64_t r_squared_wasm_0 = 0x0000000000000c00UL;
-    static constexpr uint64_t r_squared_wasm_1 = 0xffffeffffffffc00UL;
-    static constexpr uint64_t r_squared_wasm_2 = 0xfffffffffffffbffUL;
-    static constexpr uint64_t r_squared_wasm_3 = 0x000013fffffff7ffUL;
-
     // 2^(-29) mod Modulus
     // Used in the reduction mechanism, see field_docs.md
     // Instead of computing k, we multiply the lowest limb by this value and then add to the following 10 limbs.
@@ -103,25 +96,6 @@ struct FqParams {
     static constexpr uint64_t r_inv_wasm_6 = 0x1fe00000;
     static constexpr uint64_t r_inv_wasm_7 = 0xffffff;
     static constexpr uint64_t r_inv_wasm_8 = 0x0;
-
-    // Not used for secp256r1
-    static constexpr uint64_t cube_root_wasm_0 = 0x0000000000000000UL;
-    static constexpr uint64_t cube_root_wasm_1 = 0x0000000000000000UL;
-    static constexpr uint64_t cube_root_wasm_2 = 0x0000000000000000UL;
-    static constexpr uint64_t cube_root_wasm_3 = 0x0000000000000000UL;
-
-    // Not used for secp256r1
-    static constexpr uint64_t primitive_root_wasm_0 = 0x0000000000000000UL;
-    static constexpr uint64_t primitive_root_wasm_1 = 0x0000000000000000UL;
-    static constexpr uint64_t primitive_root_wasm_2 = 0x0000000000000000UL;
-    static constexpr uint64_t primitive_root_wasm_3 = 0x0000000000000000UL;
-
-    // Coset generators in Montgomery form for R=2^261 mod Modulus. Used in FFT-based proving systems, don't really need
-    // them here
-    static constexpr uint64_t coset_generator_wasm_0 = 0x0000000000000060ULL;
-    static constexpr uint64_t coset_generator_wasm_1 = 0xffffffa000000000ULL;
-    static constexpr uint64_t coset_generator_wasm_2 = 0xffffffffffffffffULL;
-    static constexpr uint64_t coset_generator_wasm_3 = 0x0000005fffffff9fULL;
 
     // For consistency with bb::fq, if we ever represent an element of bb::secp256r1::fq in the public inputs, we do so
     // as a bigfield element, so with 4 public inputs
@@ -199,13 +173,6 @@ struct FrParams {
     static constexpr uint64_t modulus_wasm_7 = 0x1fe00000;
     static constexpr uint64_t modulus_wasm_8 = 0xffffff;
 
-    // A little-endian representation of R^2 modulo the modulus (R=2^261 mod modulus) split into 4 64-bit words
-    // We use 2^261 in wasm, because 261=29*9, the 9 29-bit limbs used for arithmetic
-    static constexpr uint64_t r_squared_wasm_0 = 0x45e9cfeeb48d9ef5UL;
-    static constexpr uint64_t r_squared_wasm_1 = 0x1f11fc5bb2d31a99UL;
-    static constexpr uint64_t r_squared_wasm_2 = 0x16c8e4adafb16586UL;
-    static constexpr uint64_t r_squared_wasm_3 = 0x84b6556a65587f06UL;
-
     // 2^(-29) mod Modulus
     // Used in the reduction mechanism, see field_docs.md
     // Instead of computing k, we multiply the lowest limb by this value and then add to the following 5 limbs.
@@ -219,25 +186,6 @@ struct FrParams {
     static constexpr uint64_t r_inv_wasm_6 = 0x1621c017;
     static constexpr uint64_t r_inv_wasm_7 = 0xef1ff43;
     static constexpr uint64_t r_inv_wasm_8 = 0x7005e2;
-
-    // Not used for secp256r1
-    static constexpr uint64_t cube_root_wasm_0 = 0x0000000000000000UL;
-    static constexpr uint64_t cube_root_wasm_1 = 0x0000000000000000UL;
-    static constexpr uint64_t cube_root_wasm_2 = 0x0000000000000000UL;
-    static constexpr uint64_t cube_root_wasm_3 = 0x0000000000000000UL;
-
-    // Not used for secp256r1
-    static constexpr uint64_t primitive_root_wasm_0 = 0x0000000000000000UL;
-    static constexpr uint64_t primitive_root_wasm_1 = 0x0000000000000000UL;
-    static constexpr uint64_t primitive_root_wasm_2 = 0x0000000000000000UL;
-    static constexpr uint64_t primitive_root_wasm_3 = 0x0000000000000000UL;
-
-    // Coset generators in Montgomery form for R=2^261 mod Modulus. Used in FFT-based proving systems, don't really need
-    // them here
-    static constexpr uint64_t coset_generator_wasm_0 = 0xbd6e9563293f5920ULL;
-    static constexpr uint64_t coset_generator_wasm_1 = 0xb5e4a80dcb554baaULL;
-    static constexpr uint64_t coset_generator_wasm_2 = 0x000000000000003aULL;
-    static constexpr uint64_t coset_generator_wasm_3 = 0x000000dfffffff20ULL;
 
     // For consistency with bb::fq, if we ever represent an element of bb::secp256r1::fq in the public inputs, we do so
     // as a bigfield element, so with 4 public inputs

--- a/barretenberg/cpp/src/barretenberg/ecc/curves/secp256r1/secp256r1.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/curves/secp256r1/secp256r1.test.cpp
@@ -50,7 +50,6 @@ TEST(secp256r1, AdditionSubtractionRegressionCheck)
     EXPECT_EQ(fq3, fq4);
 }
 
-#if defined(__SIZEOF_INT128__) && !defined(__wasm__)
 TEST(secp256r1, MontgomeryMulBigBug)
 {
     secp256r1::fr a;
@@ -62,7 +61,6 @@ TEST(secp256r1, MontgomeryMulBigBug)
     secp256r1::fr expected(uint256_t{ 0x57abc6aa0349c084, 0x65b21b232a4cb7a5, 0x5ba781948b0fcd6e, 0xd6e9e0644bda12f7 });
     EXPECT_EQ((a_sqr == expected), true);
 }
-#endif
 
 TEST(secp256r1, CheckPrecomputedGenerators)
 {

--- a/barretenberg/cpp/src/barretenberg/ecc/fields/field.hpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/fields/field.hpp
@@ -9,8 +9,9 @@
 /**
  * @brief Include order of header-only field class is structured to ensure linter/language server can resolve paths.
  *        Declarations are defined in "field_declarations.hpp", definitions in "field_impl.hpp" (which includes
- *        declarations header) Spectialized definitions are in "field_impl_generic.hpp" and "field_impl_x64.hpp"
- *        (which include "field_impl.hpp")
+ *        declarations header). Specialized definitions are in "field_impl_generic.hpp",
+ *        "paired_field_impl_generic.hpp" and "field_impl_x64.hpp" (which include "field_impl.hpp")
  */
 #include "./field_impl_generic.hpp"
 #include "./field_impl_x64.hpp"
+#include "./paired_field_impl_generic.hpp"

--- a/barretenberg/cpp/src/barretenberg/ecc/fields/field2.hpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/fields/field2.hpp
@@ -19,10 +19,9 @@ template <class base, class T> constexpr field2<base, T> field2<base, T>::operat
 {
     // no funny primes please! we assume -1 is not a quadratic residue
     static_assert((base::modulus.data[0] & 0x3UL) == 0x3UL);
-    base t1 = c0 * other.c0;
-    base t2 = c1 * other.c1;
-    base t3 = c0 + c1;
-    base t4 = other.c0 + other.c1;
+    const auto [t1, t2] = base::paired_mul(c0, other.c0, c1, other.c1);
+    const base t3 = c0 + c1;
+    const base t4 = other.c0 + other.c1;
 
     return { t1 - t2, t3 * t4 - (t1 + t2) };
 }
@@ -73,8 +72,8 @@ template <class base, class T> constexpr field2<base, T> field2<base, T>::operat
 
 template <class base, class T> constexpr field2<base, T> field2<base, T>::sqr() const noexcept
 {
-    base t1 = (c0 * c1);
-    return { (c0 + c1) * (c0 - c1), t1 + t1 };
+    const auto [t1, t2] = base::paired_mul(c0, c1, c0 + c1, c0 - c1);
+    return { t2, t1 + t1 };
 }
 
 template <class base, class T> constexpr void field2<base, T>::self_sqr() noexcept
@@ -86,24 +85,30 @@ template <class base, class T> constexpr void field2<base, T>::self_sqr() noexce
 // is in canonical form [0, p) rather than the coarse internal representation [0, 2p).
 template <class base, class T> constexpr field2<base, T> field2<base, T>::to_montgomery_form() const noexcept
 {
-    return { c0.to_montgomery_form_reduced(), c1.to_montgomery_form_reduced() };
+    field2 result = *this;
+    result.self_to_montgomery_form();
+    return result;
 }
 
 template <class base, class T> constexpr field2<base, T> field2<base, T>::from_montgomery_form() const noexcept
 {
-    return { c0.from_montgomery_form_reduced(), c1.from_montgomery_form_reduced() };
+    field2 result = *this;
+    result.self_from_montgomery_form();
+    return result;
 }
 
 template <class base, class T> constexpr void field2<base, T>::self_to_montgomery_form() noexcept
 {
-    c0.self_to_montgomery_form_reduced();
-    c1.self_to_montgomery_form_reduced();
+    const auto [n0, n1] = base::paired_to_montgomery_form_reduced(c0, c1);
+    c0 = n0;
+    c1 = n1;
 }
 
 template <class base, class T> constexpr void field2<base, T>::self_from_montgomery_form() noexcept
 {
-    c0.self_from_montgomery_form_reduced();
-    c1.self_from_montgomery_form_reduced();
+    const auto [n0, n1] = base::paired_from_montgomery_form_reduced(c0, c1);
+    c0 = n0;
+    c1 = n1;
 }
 
 template <class base, class T> constexpr field2<base, T> field2<base, T>::reduce_once() const noexcept
@@ -152,8 +157,10 @@ template <class base, class T> constexpr field2<base, T> field2<base, T>::pow(co
 
 template <class base, class T> constexpr field2<base, T> field2<base, T>::invert() const noexcept
 {
-    base t3 = (c0.sqr() + c1.sqr()).invert();
-    return { c0 * t3, -(c1 * t3) };
+    const auto [s0, s1] = base::paired_sqr(c0, c1);
+    const base t3 = (s0 + s1).invert();
+    const auto [m0, m1] = base::paired_mul(c0, t3, c1, t3);
+    return { m0, -m1 };
 }
 
 template <class base, class T>

--- a/barretenberg/cpp/src/barretenberg/ecc/fields/field2_declarations.hpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/fields/field2_declarations.hpp
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "barretenberg/numeric/uint256/uint256.hpp"
+#include <array>
 
 // forward declare RNG
 namespace bb::numeric {
@@ -104,6 +105,20 @@ template <class base_field, class Params> struct alignas(32) field2 {
 
     constexpr void self_to_montgomery_form() noexcept;
     constexpr void self_from_montgomery_form() noexcept;
+
+    // Paired Montgomery operations matching the base-field API. For field2
+    // we forward to the standard single-element ops.
+    static constexpr std::array<field2, 2> paired_mul(const field2& a,
+                                                      const field2& b,
+                                                      const field2& c,
+                                                      const field2& d) noexcept
+    {
+        return { a * b, c * d };
+    }
+    static constexpr std::array<field2, 2> paired_sqr(const field2& a, const field2& b) noexcept
+    {
+        return { a.sqr(), b.sqr() };
+    }
 
     constexpr void self_conditional_negate(uint64_t predicate) noexcept;
 

--- a/barretenberg/cpp/src/barretenberg/ecc/fields/field_declarations.hpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/fields/field_declarations.hpp
@@ -71,8 +71,20 @@ template <class Params_> struct alignas(32) field {
     static constexpr size_t PUBLIC_INPUTS_SIZE = Params::PUBLIC_INPUTS_SIZE;
 
 #if defined(__wasm__) || !defined(__SIZEOF_INT128__)
+// Limb layout for the WASM Montgomery backend.
 #define WASM_NUM_LIMBS 9
 #define WASM_LIMB_BITS 29
+// Bits zeroed by the final Montgomery reduction step to complete R = 2^256.
+#define WASM_FINAL_REDUCE_BITS 24
+// Residue width left untouched by the final Montgomery reduction of the final lower limb.
+#define WASM_FINAL_REMAINDER_BITS (WASM_LIMB_BITS - WASM_FINAL_REDUCE_BITS)
+
+    static_assert(8 * WASM_LIMB_BITS + WASM_FINAL_REDUCE_BITS == 256, "WASM reduction widths must total 256 bits");
+
+    // Typed bit masks derived from the widths above.
+    static constexpr uint64_t WASM_LIMB_MASK = (1ULL << WASM_LIMB_BITS) - 1;
+    static constexpr uint64_t WASM_FINAL_REDUCE_MASK = (1ULL << WASM_FINAL_REDUCE_BITS) - 1;
+    static constexpr uint64_t WASM_FINAL_REMAINDER_MASK = (1ULL << WASM_FINAL_REMAINDER_BITS) - 1;
 #endif
 
     // We don't initialize data in the default constructor since we'd lose a lot of time on huge array initializations.
@@ -233,14 +245,10 @@ template <class Params_> struct alignas(32) field {
 
     static constexpr uint256_t modulus =
         uint256_t{ Params::modulus_0, Params::modulus_1, Params::modulus_2, Params::modulus_3 };
-#if defined(__SIZEOF_INT128__) && !defined(__wasm__)
     static constexpr uint256_t r_squared_uint{
         Params_::r_squared_0, Params_::r_squared_1, Params_::r_squared_2, Params_::r_squared_3
     };
-#else
-    static constexpr uint256_t r_squared_uint{
-        Params_::r_squared_wasm_0, Params_::r_squared_wasm_1, Params_::r_squared_wasm_2, Params_::r_squared_wasm_3
-    };
+#if defined(__wasm__) || !defined(__SIZEOF_INT128__)
     static constexpr std::array<uint64_t, 9> wasm_modulus = { Params::modulus_wasm_0, Params::modulus_wasm_1,
                                                               Params::modulus_wasm_2, Params::modulus_wasm_3,
                                                               Params::modulus_wasm_4, Params::modulus_wasm_5,
@@ -256,15 +264,9 @@ template <class Params_> struct alignas(32) field {
     {
         // endomorphism i.e. lambda * [P] = (beta * x, y)
         if constexpr (Params::cube_root_0 != 0) {
-#if defined(__SIZEOF_INT128__) && !defined(__wasm__)
             constexpr field result{
                 Params::cube_root_0, Params::cube_root_1, Params::cube_root_2, Params::cube_root_3
             };
-#else
-            constexpr field result{
-                Params::cube_root_wasm_0, Params::cube_root_wasm_1, Params::cube_root_wasm_2, Params::cube_root_wasm_3
-            };
-#endif
             return result;
         } else {
             constexpr field two_inv = field(2).invert();
@@ -277,29 +279,31 @@ template <class Params_> struct alignas(32) field {
     static constexpr field zero() { return field(0, 0, 0, 0); }
     static constexpr field neg_one() { return -field(1); }
     static constexpr field one() { return field(1); }
+    // R^2 mod p as a raw field literal (NOT Montgomery form). Used as the rhs of a Montgomery
+    // multiplication to enter Montgomery form: mul(a, R^2) ≡ a*R (mod p).
+    static constexpr field r_squared()
+    {
+        return field(r_squared_uint.data[0], r_squared_uint.data[1], r_squared_uint.data[2], r_squared_uint.data[3]);
+    }
+    // Raw integer 1 (NOT Montgomery form). Used as the rhs of a Montgomery multiplication
+    // to strip the R factor, i.e. to leave Montgomery form: mul(a*R, 1) ≡ a (mod p).
+    static constexpr field one_raw() { return field(1, 0, 0, 0); }
 
     static constexpr field coset_generator()
     {
-#if defined(__SIZEOF_INT128__) && !defined(__wasm__)
-        const field result{
+        return field{
             Params::coset_generator_0,
             Params::coset_generator_1,
             Params::coset_generator_2,
             Params::coset_generator_3,
         };
-#else
-        const field result{
-            Params::coset_generator_0,
-            Params::coset_generator_1,
-            Params::coset_generator_2,
-            Params::coset_generator_3,
-        };
-#endif
-
-        return result;
     }
 
     BB_INLINE constexpr field operator*(const field& other) const noexcept;
+    BB_INLINE static constexpr std::array<field, 2> paired_mul(const field& a,
+                                                               const field& b,
+                                                               const field& c,
+                                                               const field& d) noexcept;
     BB_INLINE constexpr field operator+(const field& other) const noexcept;
     BB_INLINE constexpr field operator-(const field& other) const noexcept;
     BB_INLINE constexpr field operator-() const noexcept;
@@ -325,12 +329,20 @@ template <class Params_> struct alignas(32) field {
     BB_INLINE constexpr bool operator!=(const field& other) const noexcept;
 
     BB_INLINE constexpr field to_montgomery_form() const noexcept;
+    BB_INLINE static constexpr std::array<field, 2> paired_to_montgomery_form(const field& a, const field& b) noexcept;
     BB_INLINE constexpr field from_montgomery_form() const noexcept;
+    BB_INLINE static constexpr std::array<field, 2> paired_from_montgomery_form(const field& a,
+                                                                                const field& b) noexcept;
     // Reduced versions guarantee output is in canonical form [0, p)
     BB_INLINE constexpr field to_montgomery_form_reduced() const noexcept;
+    BB_INLINE static constexpr std::array<field, 2> paired_to_montgomery_form_reduced(const field& a,
+                                                                                      const field& b) noexcept;
     BB_INLINE constexpr field from_montgomery_form_reduced() const noexcept;
+    BB_INLINE static constexpr std::array<field, 2> paired_from_montgomery_form_reduced(const field& a,
+                                                                                        const field& b) noexcept;
 
     BB_INLINE constexpr field sqr() const noexcept;
+    BB_INLINE static constexpr std::array<field, 2> paired_sqr(const field& a, const field& b) noexcept;
     BB_INLINE constexpr void self_sqr() & noexcept;
 
     BB_INLINE constexpr field pow(const uint256_t& exponent) const noexcept;
@@ -543,37 +555,22 @@ template <class Params_> struct alignas(32) field {
     static constexpr uint256_t twice_not_modulus = -twice_modulus;
 
 #if defined(__wasm__) || !defined(__SIZEOF_INT128__)
-    BB_INLINE static constexpr void wasm_madd(uint64_t& left_limb,
+    BB_INLINE static constexpr void wasm_madd(uint64_t left_limb,
                                               const std::array<uint64_t, WASM_NUM_LIMBS>& right_limbs,
-                                              uint64_t& result_0,
-                                              uint64_t& result_1,
-                                              uint64_t& result_2,
-                                              uint64_t& result_3,
-                                              uint64_t& result_4,
-                                              uint64_t& result_5,
-                                              uint64_t& result_6,
-                                              uint64_t& result_7,
-                                              uint64_t& result_8);
-    BB_INLINE static constexpr void wasm_reduce(uint64_t& result_0,
-                                                uint64_t& result_1,
-                                                uint64_t& result_2,
-                                                uint64_t& result_3,
-                                                uint64_t& result_4,
-                                                uint64_t& result_5,
-                                                uint64_t& result_6,
-                                                uint64_t& result_7,
-                                                uint64_t& result_8);
-    BB_INLINE static constexpr void wasm_reduce_yuval(uint64_t& result_0,
-                                                      uint64_t& result_1,
-                                                      uint64_t& result_2,
-                                                      uint64_t& result_3,
-                                                      uint64_t& result_4,
-                                                      uint64_t& result_5,
-                                                      uint64_t& result_6,
-                                                      uint64_t& result_7,
-                                                      uint64_t& result_8,
-                                                      uint64_t& result_9);
+                                              std::span<uint64_t, WASM_NUM_LIMBS> result);
+    BB_INLINE static constexpr void wasm_reduce_29(std::span<uint64_t, WASM_NUM_LIMBS> result);
+    BB_INLINE static constexpr void wasm_reduce_24(std::span<uint64_t, WASM_NUM_LIMBS> result);
+    BB_INLINE static constexpr void wasm_reduce_yuval(std::span<uint64_t, WASM_NUM_LIMBS + 1> result);
+    BB_INLINE static constexpr std::array<uint64_t, 4> wasm_reduce_and_pack(
+        std::array<uint64_t, 2 * WASM_NUM_LIMBS - 1>& temp);
     BB_INLINE static constexpr std::array<uint64_t, WASM_NUM_LIMBS> wasm_convert(const uint64_t* data);
+
+    template <size_t N>
+    BB_INLINE static constexpr std::array<uint64_t, 2 * N - 1> wasm_schoolbook_mul(const std::array<uint64_t, N>& a,
+                                                                                   const std::array<uint64_t, N>& b);
+
+    BB_INLINE static constexpr std::array<uint64_t, 2 * WASM_NUM_LIMBS - 1> wasm_karatsuba_mul(
+        const std::array<uint64_t, WASM_NUM_LIMBS>& left, const std::array<uint64_t, WASM_NUM_LIMBS>& right);
 #endif
     BB_INLINE static constexpr std::pair<uint64_t, uint64_t> mul_wide(uint64_t a, uint64_t b) noexcept;
 

--- a/barretenberg/cpp/src/barretenberg/ecc/fields/field_docs.md
+++ b/barretenberg/cpp/src/barretenberg/ecc/fields/field_docs.md
@@ -4,17 +4,15 @@ Barretenberg has its own implementation of finite field arithmetic. The implemen
 
 ## Field arithmetic
 ### Introduction to Montgomery form {#field_docs_montgomery_explainer}
-We use Montgomery multiplication to speed up field multiplication. For an original element  $ a \in \mathbb F_p$ the element is represented internally as $$ a⋅R\ mod\ p$$ where $R = 2^d\ mod\ p$. The chosen $d$ depends on the build configuration:
-1. $d=29⋅9=261$ for builds that don't support the `uint128_t` type, for example, for WASM build
-2. $d=64⋅4=256$ for standard builds (x86_64).
+We use Montgomery multiplication to speed up field multiplication. For an element $a \in \mathbb F_p$, the element is represented internally as $$a \cdot R \mod p$$ where $R = 2^d$ and $d = 256$ on every backend (x86_64: $4 \times 64 = 256$, generic 64-bit: $4 \times 64 = 256$, and WASM: $8 \times 29 + 24 = 256$ for the standard path, $5 \times 51 + 1 = 256$ for the paired path). Note that WASM uses a different internal representation during Montgomery multiplication, but the canonical 4 × 64-bit Montgomery form at input and output is preserved on all backends. Consequently, Montgomery-form constants (`r_squared`, `cube_root`, `coset_generator`) are shared across all builds.
 
 The goal of using Montgomery form is to avoid heavy division modulo $p$. To compute a representative of element $$c = a⋅b\ mod\ p$$ we compute $$c⋅R = (a⋅R)⋅(b⋅R) / R\ mod\ p,$$ but we use an efficient division trick to avoid the naive modular division. Let's look into the standard 4⋅64 case:
 1. First, we compute the value $$c_r=c⋅R⋅R = aR⋅bR$$ in integers and get a value with 8 64-bit limbs
 2. Then we take the lowest limb of $c_r$ (i.e., $c_r[0]$) and multiply it by a special _precomputed_ value $$r_{inv} = -1 ⋅ p^{-1}\ mod\  2^{64}$$ As a result we get $$k = r_{inv}⋅ c_r[0]\ mod\ 2^{64}$$
 3. Next we update $c_r$ in integers by adding $k⋅p$: $$c_r += k⋅p$$ You might notice that the value of $c_r\ mod\ p$ hasn't changed, since we've added a multiple of the modulus. At the same time, if we look at the expression modulo $2^{64}$: $$c_r + k⋅p = c_r + c_r⋅r_{inv}⋅p = c_r + c_r⋅ (-1)⋅p^{-1}⋅p = c_r - c_r = 0\ mod\ 2^{64}.$$ The result is equivalent modulo $p$, but we zeroed out the lowest limb
-4. We perform the same operation for $c_r[1]$, but instead of adding $k⋅p$, we add $2^{64}⋅k⋅p$. In the implementation, instead of adding $k⋅ p$ to limbs of $c_r$ starting with zero, we just start with limb 1. This ensures that $c_r[1]=0$. We then perform the same operation for 2 more limbs.
+4. We perform the same operation for $c_r[1]$, but instead of adding $k⋅p$, we add $2^{64}⋅k⋅p$. In the implementation, instead of adding $k⋅ p$ to limbs of $c_r$ starting with zero, we just start with limb 1. This ensures that $c_r[1]=0$. We then perform the same operation for the remaining low limbs, $c_r[2]$ and $c_r[3]$.
 5. At this stage the array $c_r$ has the property that the first 4 limbs of the total 8 limbs are zero. So if we treat the 4 high limbs as a separate integer $c_{r.high}$, $$c_r = c_{r.high}⋅2^{256}=c_{r.high}⋅R\ mod\ p \Rightarrow c_{r.high} = c\cdot R\ mod\ p$$ and we can get the evaluation simply by taking the 4 high limbs of $c_r$.
-6. The previous step has reduced the intermediate value of $cR$ to range $[0,2p)$, so we must check if it is more than $p$ and subtract the modulus once if it overflows.
+6. For our 256-bit fields, the previous step has reduced the intermediate value enough that conditionally subtracting one copy of $p$ is sufficient to bring it into the valid range $[0, 2^{256})$. For our 254-bit fields, the result is already in the coarse range $[0,2p)$, so no additional reduction is needed.
 
 On a high level, what we are doing is iteratively adding a multiple of $p$ until the current bottom limb is zero, then shifting by a limb (amounting to dividing by $2^{64}$).
 #### Bounds analysis
@@ -29,61 +27,200 @@ $$aR\cdot bR + k_{0,1,2,3}p \le (2p-1)^2+(2^{256}-1)p = 2^{256}p+4p^2-5p+1 \Righ
 
 **N.B.** In the code we refer to this form, when the limbs are only constrained to be in the range $[0,2p)$, as the coarse-representation.
 
-### Yuval reduction
-For our 254-bit multiplication in WASM, we use a reduction technique found by Yuval. For a reference, please see this [hackmd](https://hackmd.io/@Ingonyama/Barret-Montgomery).
+### WASM reduction primitives
+For WASM backends it is useful to separate the primitive reduction steps from the full multiplication pipelines that use them. In this subsection we use $\beta$ for the radix of the current reduction step, $x$ for the accumulator before the step, $x_0 = x \mod \beta$ for its lowest radix-$\beta$ digit, and $x'$ for the value after the step.
 
-Recall that in standard Montgomery reduction, we zero out the lowest limb by adding a carefully chosen multiple of the modulus $p$. In particular, if we were to use standard Montgomery reduction given our limb-decomposition for WASM: given an accumulator $x = \sum_{i=0}^{n} \text{result}_i \cdot 2^{29i}$, we compute $k = \text{result}_0 \cdot (-p^{-1}) \mod 2^{29}$ and add $k \cdot p$ to $x$. This makes the lowest 29 bits zero (since $\text{result}_0 + k \cdot p_0 \equiv 0 \mod 2^{29}$), allowing us to "shift right" by discarding the zeroed limb.
-
-Yuval's method takes a different approach. Instead of adding a multiple of $p$ to zero out the low bits, we directly compute the equivalent value after the divide by $2^{29}$ step. Given the same accumulator $x$, we want to find $x / 2^{29} \mod p$. We can rewrite this as:
-$$x / 2^{29} = (x - \text{result}_0) / 2^{29} + \text{result}_0 / 2^{29} \mod p.$$
-
-The first term $(x - \text{result}_0) / 2^{29}$ is simply the higher limbs shifted down. The second term requires computing $\text{result}_0 \cdot 2^{-29} \mod p$, which we precompute as `r_inv_wasm` (stored in 9 limbs).
-
-So instead of computing $k = \text{result}_0 \cdot (-p^{-1})$ and adding $k \cdot p$ (9 multiply-accumulates), we compute $\text{result}_0 \cdot r\_inv\_wasm$ and add it to the higher limbs (also 9 multiply-accumulates). The key insight is that both approaches require the same number of operations, but Yuval's method avoids the need for a separate "zero out and shift" step—the shift is implicit in how we interpret the result.
-
-In code, `wasm_reduce_yuval` implements this as:
-```cpp
-result_1 += result_0_masked * wasm_r_inv[0] + (result_0 >> 29);
-result_2 += result_0_masked * wasm_r_inv[1];
-// ... and so on for result_3 through result_9
-```
-
-The term `(result_0 >> 29)` handles any overflow bits in `result_0` beyond the lowest 29 bits, propagating them to `result_1`. After this operation, `result_0` is effectively discarded, and `result_1` through `result_9` hold the Montgomery-reduced value.
-
-#### Structure of WASM Montgomery multiplication
-
-In 254-bit WASM multiplication, the full Montgomery reduction requires 9 limb-reductions (to divide by $2^{261} = 2^{29 \cdot 9}$). **We apply Yuval's method for the first 8 reductions, and standard Montgomery reduction for the 9th (final) reduction.**
-
-Why not use Yuval for all 9? The key issue is that Yuval's method takes a 10-limb input and produces a 10-limb output (the reduced value spans 9 limbs, shifted up by one position). If we used Yuval for the 9th reduction, we would end up with a 10-limb result instead of the desired 9-limb result. The standard Montgomery reduction (`wasm_reduce`), by contrast, takes 9 limbs and produces 9 limbs (with the lowest limb zeroed and discardable), giving us exactly the 9-limb output we need.
+#### Ordinary Montgomery reduction
+This is the same Montgomery reduction pattern explained in [Introduction to Montgomery form](#field_docs_montgomery_explainer). We compute
+$$m = x_0 \cdot (-p^{-1}) \mod \beta$$
+and form
+$$x' = \frac{x + m \cdot p}{\beta} \mod p.$$
+By construction,
+$$x_0 + m \cdot p \equiv 0 \mod \beta,$$
+so the division by $\beta$ is exact.
 
 #### Bounds analysis
+Let $B$ be any upper bound on the current accumulator $x$ before this reduction step. Since $m < \beta$, we have $m \cdot p < \beta \cdot p$, and therefore
+$$x' < \frac{B}{\beta} + p.$$
+This is the local bound used by every ordinary Montgomery reduction step in the WASM backends.
 
+The three concrete instances are:
+1. `wasm_reduce_29`, with $\beta = 2^{29}$.
+2. `wasm_reduce_24`, with $\beta = 2^{24}$. This is the same step, but only 24 bits are removed from the total shift; the remaining 5 bits of the surrounding 29-bit limb stay live and are packed into the final 4 × 64-bit output.
+3. The paired ordinary Montgomery reduction, with $\beta = 2^{51}$. After the rho folds, the paired backend applies this same step twice.
+
+#### Yuval reduction
+For our 254-bit WASM multiplication we also use a reduction technique found by Yuval. For a reference, please see this [hackmd](https://hackmd.io/@Ingonyama/Barret-Montgomery). Here we specialize to $\beta = 2^{29}$.
+
+Instead of adding a multiple of $p$ to zero out $x_0$, Yuval's method rewrites the divide-by-$\beta$ step directly:
+$$\frac{x}{\beta} = \frac{x - x_0}{\beta} + x_0 \cdot \beta^{-1} \mod p.$$
+Thus
+$$x' = \frac{x - x_0}{\beta} + x_0 \cdot \beta^{-1} \mod p.$$
+In the implementation, the factor $\beta^{-1} \mod p$ is precomputed as `r_inv_wasm`.
+
+#### Bounds analysis
+Since $x_0 < \beta$ and $\beta^{-1} \mod p < p$, the correction term satisfies
+$$x_0 \cdot \beta^{-1} \mod p < \beta \cdot p.$$
+Therefore, if $x < B$ before the Yuval step, then
+$$x' < \frac{B}{\beta} + \beta \cdot p.$$
+Compared with the ordinary Montgomery bound $\frac{B}{\beta} + p$, this leaves much looser slack. That looser slack is exactly why Yuval is useful locally, but cannot be used for every step if the final result is to remain in the coarse range $[0, 2p)$.
+
+#### Paired rho-fold reduction
+On the relaxed-SIMD paired path the first part of reduction is conceptually analogous to Yuval's idea: instead of zeroing a low limb with a multiple of $p$, we replace the bottom limbs by precomputed multiples of inverse powers of the radix.
+
+Let
+$$x = \sum_{k=0}^{9} t_k \cdot \beta^k.$$
+For each $k \in \{0, 1, 2\}$ we precompute
+$$\rho_{2-k} = \beta^{k-3} \mod p,$$
+so that
+$$t_k \cdot \beta^k \equiv (t_k \cdot \rho_{2-k}) \cdot \beta^3 \mod p.$$
+Applying this identity to $t_0$, $t_1$, and $t_2$ gives
+$$x = t_0 + t_1 \beta + t_2 \beta^2 + t_3 \beta^3 + \cdots + t_9 \beta^9$$
+$$\equiv (t_0 \rho_2 + t_1 \rho_1 + t_2 \rho_0)\beta^3 + t_3 \beta^3 + t_4 \beta^4 + \cdots + t_9 \beta^9 \mod p$$
+$$= \beta^3 \left( t_0 \rho_2 + t_1 \rho_1 + t_2 \rho_0 + t_3 + t_4 \beta + \cdots + t_9 \beta^6 \right) \mod p.$$
+If we define the resulting 7-limb high window by
+$$y = t_0 \rho_2 + t_1 \rho_1 + t_2 \rho_0 + t_3 + t_4 \beta + \cdots + t_9 \beta^6,$$
+then
+$$x \equiv \beta^3 \cdot y \mod p,$$
+so after the rho folds we can drop the bottom three limbs and continue with the high window $y$, which represents the value $x / \beta^3 \mod p$.
+Because the three folds do not share inputs, they can be computed in parallel and then combined with a balanced add tree.
+
+#### Bounds analysis
+Since the paired kernel is only used on coarse inputs, we have
+$$x < (2p)^2 = 4p^2.$$
+After the preceding carry-propagation phase, the folded limbs satisfy $0 \le t_0, t_1, t_2 < \beta$, while the rho constants satisfy $0 \le \rho_{2-k} < p$. Hence the three rho corrections contribute less than $3 \beta \cdot p$ in total, and the carried high window contributes less than $x / \beta^3$. Therefore
+$$y < \frac{x}{\beta^3} + 3 \beta \cdot p < \frac{4p^2}{\beta^3} + 3 \beta \cdot p.$$
+Assuming
+$$p < \frac{\beta^5}{2} - \beta^4.$$
+we get
+$$\frac{4p^2}{\beta^3} < \frac{4p}{\beta^3}\left(\frac{\beta^5}{2} - \beta^4\right) = 2 \beta^2 \cdot p - 4 \beta \cdot p.$$
+Substituting this into the generic rho-fold bound gives
+$$y < \left(2 \beta^2 \cdot p - 4 \beta \cdot p\right) + 3 \beta \cdot p = 2 \beta^2 \cdot p - \beta \cdot p.$$
+So the rho folds preserve the residue modulo $p$, but they do **not** yet produce the final coarse bound. This is why the paired backend then applies two ordinary Montgomery reductions with $\beta = 2^{51}$, each producing the bounds $x' < B / \beta + p$.
+
+#### Paired parity fix and halving
+Let $x$ denote the intermediate value after those two ordinary Montgomery reduction steps.
+
+The paired kernel's internal Montgomery factor is
+$$R_{\text{kernel}} = \beta^5 = 2^{255},$$
+so after the rho folds and two ordinary Montgomery reduction steps we have reduced by 255 bits rather than 256. The last bit is handled by a parity fix followed by a fused halving-and-repack step.
+
+If $x$ is even, we can just shift by 1. If $x$ is odd, we add $p$, and since $p$ is odd, $x + p$ is then even and still congruent to $x$ modulo $p$. Hence we can also shift by 1 to get the final form. This fused final shift is done by `pack_to_4x64_shr_1`.
+
+#### Bounds analysis
+If the input to this stage satisfies
+$$x < B,$$
+then after the optional add-$p$ step we have
+$$x + 0 \text{ or } p < B + p.$$
+After the final halving,
+$$x' = \frac{x + 0 \text{ or } p}{2} < \frac{B + p}{2}.$$
+In particular, if $x < 3p$, then $x' < 2p$. Likewise, if $x < 2p + p / \beta$, then
+$$x' < \frac{3p + p / \beta}{2} < 2p.$$
+This is what closes the paired pipeline back to the same coarse Montgomery range $[0, 2p)$ used by the rest of the small-modulus field code.
+
+### WASM Montgomery multiplication pipelines
+All WASM multiplication backends must achieve a net division by
+$$R = 2^{256},$$
+but they do so with different combinations of the primitives above:
+1. For 254-bit fields in the standard 9 × 29-bit backend: 7 Yuval steps, 1 ordinary Montgomery reduction with $\beta = 2^{29}$, and 1 final ordinary Montgomery reduction with $\beta = 2^{24}$.
+2. For 256-bit fields in the standard 9 × 29-bit backend: 8 ordinary Montgomery reductions with $\beta = 2^{29}$ and 1 final ordinary Montgomery reduction with $\beta = 2^{24}$.
+3. For the relaxed-SIMD paired backend: 3 rho folds, 2 ordinary Montgomery reduction steps, and 1 parity/halving step.
+
+#### Regular WASM multiplication (small moduli)
+For our 254-bit WASM multiplication the cumulative shift across all reductions must equal $R = 2^{256}$. We achieve this with 9 reduction steps whose widths sum to 256:
+$$256 = 7 \cdot 29 + 29 + 24.$$
+The multiplication that produces the 17-limb intermediate is a Karatsuba 5+4 split (`wasm_karatsuba_mul`) that costs 66 multiplications instead of the naive 81. The reduction chain then applies 7 `wasm_reduce_yuval` steps, 1 `wasm_reduce_29` step, and 1 `wasm_reduce_24` step.
+
+Why not use Yuval for all 8 of the 29-bit steps? Because Yuval's local slack is $2^{29} \cdot p$, whereas ordinary Montgomery's local slack is only $p$. Seven Yuval steps are still acceptable, but replacing the eighth 29-bit step with an ordinary Montgomery reduction is what tightens the running bound enough that the final 24-bit step lands back in $[0, 2p)$.
+
+#### Bounds analysis
 We must verify that the output is in $[0, 2p)$ (the coarse representation) without requiring an additional subtraction of $p$.
 
-After the 9 multiply-adds, we have $aR \cdot bR$ stored across 17 limbs. Since both $aR$ and $bR$ are in $[0, 2p)$, this product is at most $4p^2$.
+After the Karatsuba multiplication, we have $aR \cdot bR$ stored across 17 relaxed 29-bit limbs. Since both multiplicands are in coarse Montgomery form, we have
+$$aR < 2p,\qquad bR < 2p,\qquad aR \cdot bR < 4p^2.$$
 
-After 8 Yuval reductions and 1 standard reduction, we have computed:
-$$\frac{aR \cdot bR + k_0 \cdot r_{inv} + k_1 \cdot r_{inv} + \cdots + k_7 \cdot r_{inv} + k_8 \cdot p}{2^{261}}$$
+As explained above, each Yuval correction `u * r_inv_wasm` can be bounded by $u \cdot p$.
 
-where each $k_i$ is the masked low 29 bits at reduction step $i$. By construction:
-- $k_0 < 2^{29}$
-- $k_1 < 2^{58}$ (since it includes carries from the previous step)
-- For $i < 8$, we have $k_i < 2^{29(i+1)}$
-- The sum $\sum_{i=0}^{7} k_i < 2^{232}$ (geometric series)
-- $k_8 < 2^{261} - 2^{232}$
+Let $K$ be the total correction coefficient after expressing every correction term at the common pre-division-by-$2^{256}$ scale. We decompose it as
+$$K = K_{\mathrm{Yuval}} + K_{29} + K_{24},$$
+where
+$$K_{\mathrm{Yuval}} = \sum_{i=0}^{6} u_i 2^{29i}, \qquad K_{29} = v 2^{203}, \qquad K_{24} = w 2^{232},$$
+with
+$$0 \le u_i < 2^{29}, \qquad 0 \le v < 2^{29}, \qquad 0 \le w < 2^{24}.$$
 
-Since $r_{inv} = 2^{-29} \mod p < p$, the total added via Yuval reductions is bounded by $(2^{232} - 1) \cdot p$. The final standard reduction adds at most $(2^{261} - 2^{232}) \cdot p$.
+The seven Yuval steps occupy the seven disjoint 29-bit windows covering bit positions $0$ through $202$, so
+$$K_{\mathrm{Yuval}} < \sum_{i=0}^{6} (2^{29} - 1)2^{29i} = 2^{203} - 1 < 2^{203}.$$
+The eighth step is an ordinary Montgomery correction in the next 29-bit window, covering bit positions $203$ through $231$, so
+$$K_{29} < (2^{29} - 1)2^{203} = 2^{232} - 2^{203}.$$
+The final 24-bit correction occupies the remaining bit positions $232$ through $255$, so
+$$K_{24} < (2^{24} - 1)2^{232} = 2^{256} - 2^{232}.$$
+Therefore
+$$K < 2^{203} + (2^{232} - 2^{203}) + (2^{256} - 2^{232}) = 2^{256}.$$
 
-Therefore, the numerator is bounded by:
-$$4p^2 + (2^{232} - 1) \cdot p + (2^{261} - 2^{232}) \cdot p < 4p^2 + 2^{261} \cdot p$$
+So after all 9 steps the result is bounded by
+$$\frac{aR \cdot bR + K \cdot p}{2^{256}} < \frac{4p^2 + 2^{256} \cdot p}{2^{256}} = p + \frac{4p^2}{2^{256}}.$$
+For 254-bit primes, $p < 2^{254}$, so $4p < 2^{256}$ and hence
+$$\frac{4p^2}{2^{256}} = \frac{(4p) \cdot p}{2^{256}} < p.$$
+Thus the final result is less than $2p$, which is exactly the desired coarse range. No additional reduction is required.
 
-Dividing by $2^{261}$:
-$$\frac{4p^2 + 2^{261} \cdot p}{2^{261}} = p + \frac{4p^2}{2^{261}}$$
+#### Big-modulus WASM multiplication
+For 256-bit fields we do not have a dedicated paired kernel and the standard WASM backend therefore uses only ordinary Montgomery reductions: 8 steps of `wasm_reduce_29` followed by 1 step of `wasm_reduce_24`.
 
-For 254-bit primes, $p < 2^{254}$, so $4p^2 < 4 \cdot 2^{508} = 2^{510}$, and:
-$$\frac{4p^2}{2^{261}} < 1 $$
+This is the same large-modulus Montgomery logic as the native 4 × 64-bit code, but expressed in 9 × 29-bit limbs. The key difference from the 254-bit case is that the inputs are only known to be arbitrary 256-bit values, so the final target range is $[0, 2^{256})$, not $[0, 2p)$.
 
-Thus the result is less than $p + 1$, which is of course in the coarse representation range $[0, 2p)$. No additional reduction is required.
+#### Bounds analysis
+Let the two inputs be arbitrary 256-bit values in Montgomery form. Then
+$$aR < 2^{256}, \qquad bR < 2^{256}, \qquad aR \cdot bR < 2^{512}.$$
+
+As above, let $K$ be the total correction coefficient after expressing every correction term at the common pre-division-by-$2^{256}$ scale. We decompose it as
+$$K = K_{29} + K_{24},$$
+where
+$$K_{29} = \sum_{i=0}^{7} u_i 2^{29i}, \qquad K_{24} = w 2^{232},$$
+with
+$$0 \le u_i < 2^{29}, \qquad 0 \le w < 2^{24}.$$
+
+The eight ordinary 29-bit reductions occupy bit positions $0$ through $231$, so
+$$K_{29} < \sum_{i=0}^{7} (2^{29} - 1)2^{29i} = 2^{232} - 1 < 2^{232}.$$
+The final 24-bit correction occupies bit positions $232$ through $255$, so
+$$K_{24} < (2^{24} - 1)2^{232} = 2^{256} - 2^{232}.$$
+Therefore
+$$K < 2^{232} + (2^{256} - 2^{232}) = 2^{256}.$$
+Therefore the reduced result is bounded by
+$$\frac{aR \cdot bR + K \cdot p}{2^{256}} < \frac{2^{512} + 2^{256} \cdot p}{2^{256}} = 2^{256} + p.$$
+So a single conditional subtraction of $p$ is sufficient to bring the result back into the valid 256-bit range $[0, 2^{256})$.
+
+#### Paired WASM multiplication
+On WASM targets that enable relaxed-SIMD (`__wasm_relaxed_simd__`), we additionally expose a paired kernel that computes two independent Montgomery products in a single pass by using the two SIMD lanes. On non-relaxed-SIMD builds, or when the modulus is 256-bit (secp curves), this dispatches to two ordinary single-lane multiplications.
+
+The paired API surface is `paired_mul`, `paired_sqr`, `paired_to_montgomery_form`, and `paired_from_montgomery_form(_reduced)`.
+
+The paired kernel is restricted to small moduli. At representation level, the 5 × 51-bit layout can only hold values below $2^{255}$, so we must have
+$$2p < 2^{255}, \qquad \text{i.e. } p < 2^{254}.$$
+In the current implementation we impose the slightly stronger bound
+$$p < 2^{254} - 2^{204},$$
+because this is the largest threshold for which the paired coarse-output proof closes uniformly.
+
+It uses 5 × 51-bit limbs rather than 9 × 29-bit limbs, which reduces the number of cross-limb multiplications compared with the standard WASM path. This is possible because the relaxed-FMA path uses `ez_mul`, which computes a 51 × 51 limb product. It does so by using two relaxed FMAs together with carefully chosen IEEE-754 bias constants (`C1 = 2^{103}`, `C2 = C1 + 2^{52} + 2^{51}`) to recover the high and low 51-bit halves of each 51 × 51 product without an integer multiplication. After packing the inputs into the 5 × 51-bit layout and converting them to `f64x2`, the kernel runs a 5 × 5 schoolbook multiplication. Because of the extra FMA overhead, the paired kernel is in roughly the same performance range as the regular WASM path; however, since it works in SIMD, it computes two products at once. We could not simply convert the standard WASM kernel to SIMD, because that would require a natural lane-wise 64 × 64 → 64 multiplication path, which WASM SIMD does not provide in the form we need. This is why we use the standard 9 × 29-bit layout for a single product and the 5 × 51-bit layout for the paired product.
+
+The internal Montgomery factor of the 5 × 51-bit layout is
+$$R_{\mathrm{kernel}} = (2^{51})^5 = 2^{255},$$
+so one further step is needed to convert to the outer Montgomery factor $R = 2^{256}$:
+
+`reduce_and_finalize_paired_rne` first propagates signed carries through $t_0, t_1, t_2, t_3$, then 3 rho folds remove the bottom 3 limbs at once, then 2 ordinary Montgomery reductions remove 2 more 51-bit limbs, and finally a parity fix plus a fused halving/repack step converts from $R_{\mathrm{kernel}} = 2^{255}$ to the outer Montgomery factor $R = 2^{256}$. The two $m$-factors in the ordinary Montgomery phase are still computed with scalar 64-bit multiplications, because `wasm_i64x2_mul` is not attractive on current engines for this step.
+
+#### Bounds analysis
+The paired kernel is only used on coarse inputs, so
+$$aR < 2p,\qquad bR < 2p,\qquad aR \cdot bR < 4p^2.$$
+By the rho-fold bound above, and because we specifically choose the modulus bound
+$$p < \frac{\beta^5}{2} - \beta^4,$$
+the live window after the three rho folds satisfies
+$$y < 2 \beta^2 p - \beta p.$$
+
+Applying the ordinary Montgomery local bound $x' < x/\beta + p$ twice gives
+$$2 \beta^2 p - \beta p \;\longrightarrow\; 2 \beta p \;\longrightarrow\; 3p.$$
+The final parity fix adds at most one more copy of $p$, and the fused halving then yields
+$$\frac{3p + p}{2} = 2p.$$
+Since every preceding inequality is strict, the actual output is strictly less than $2p$. Thus the final 4 × 64-bit output is in coarse Montgomery form $[0, 2p)$, as required. No conditional subtraction is needed.
 
 ### Converting to and from Montgomery form
 Obviously we want to avoid using standard form division when converting between forms, so we use Montgomery form to convert to Montgomery form. If we look at a value $a\ mod\ p$ we can notice that this is the Montgomery form of $a\cdot R^{-1}\ mod\ p$, so if we want to get $aR$ from it, we need to multiply it by the Montgomery form of $R\ mod\ p$, which is $R\cdot R\ mod\ p$. So using Montgomery multiplication we compute
@@ -110,9 +247,11 @@ The assembly implementation for x86_64 is optimized. There are 2 versions:
 
 Implementation for WASM:
 
-We use 9 29-bit limbs for computation (storage stays the same) and we change the Montgomery form. The reason for a different architecture is that WASM doesn't have:
-1. 128-bit result 64*64 bit multiplication
+We use 9 29-bit limbs for computation while keeping the canonical 4 × 64-bit storage and the same $R = 2^{256}$ Montgomery form as native. The reason for the different internal limb width is that WASM doesn't have:
+1. 64 × 64-bit multiplication with a 128-bit result
 2. 64-bit addition with carry
+
+On WASM targets that also expose relaxed SIMD, there is also a *paired* implementation that computes two independent Montgomery products at once using a 5 × 51-bit `f64x2` SIMD pipeline. It is an opt-in API surface (`paired_mul`, `paired_sqr`, …); the standard `montgomery_mul` still uses the 9 × 29-bit pipeline. We could not simply convert the standard WASM kernel to SIMD, because that would require a natural lane-wise 64 × 64 → 128 multiplication path, which WASM SIMD does not provide in the form we need. This is why we use the standard 9 × 29-bit layout for a single product and the 5 × 51-bit layout for the paired product.
 
 In the past we implemented a version with 32-bit limbs, but as a result, when we accumulated limb products we always had to split 64-bit results of 32-bit multiplication back into 32-bit chunks. Had we not, the addition of 2 64-bit products would have lost the carry flag and the result would be incorrect. There were 2 issues with this:
 1. This spawned in a lot of masking operations
@@ -135,7 +274,7 @@ Conversion from field elements exists only to unsigned integers and bools. The v
 
 ## Field parameters
 
-The field template is instantiated with field parameter classes, for example, class bb::Bn254FqParams. Each such class contains at least the modulus (in 64-bit and 29-bit form), r_inv (used to efficient reductions) and 2 versions of r_squared used for converting to Montgomery form (64-bit and WASM/29-bit version). r_squared and other parameters (such as cube_root, primitive_root and coset_generator) are defined for wasm separately, because the values represent an element already in Montgomery form.
+The field template is instantiated with field parameter classes, for example, class bb::Bn254FqParams. Each such class contains at least the modulus (in 64-bit and 29-bit form), r_inv (used for efficient reductions; the WASM Yuval-style reduction uses an additional `r_inv_wasm = 2^{-29} mod p` precomputation in 9 × 29-bit form), and r_squared used for converting to Montgomery form. Since $R = 2^{256}$ is shared across native and WASM, r_squared is a single value (no separate WASM version), and likewise cube_root, primitive_root and coset_generator — values already in Montgomery form — are defined once and used by every backend.
 
 ## Helpful python snippets
 
@@ -210,11 +349,8 @@ def parse_field_params(s):
     parameter_dictionary['primitive_root']=recover_element_from_parts('primitive_root',64)
 
     parameter_dictionary['modulus_wasm']=recover_element_from_parts('modulus_wasm',29)
-    parameter_dictionary['r_squared_wasm']=recover_element_from_parts('r_squared_wasm',64)
-    parameter_dictionary['cube_root_wasm']=recover_element_from_parts('cube_root_wasm',64)
-    parameter_dictionary['primitive_root_wasm']=recover_element_from_parts('primitive_root_wasm',64)
+    parameter_dictionary['r_inv_wasm']=recover_element_from_parts('r_inv_wasm',29)
     parameter_dictionary={**parameter_dictionary,**recover_multiple_arrays('coset_generators')}
-    parameter_dictionary={**parameter_dictionary,**recover_multiple_arrays('coset_generators_wasm')}
     parameter_dictionary['endo_g1_lo']=recover_single_value_if_present('endo_g1_lo')
     parameter_dictionary['endo_g1_mid']=recover_single_value_if_present('endo_g1_mid')
     parameter_dictionary['endo_g1_hi']=recover_single_value_if_present('endo_g1_hi')
@@ -227,17 +363,9 @@ def parse_field_params(s):
 
     assert(parameter_dictionary['modulus']==parameter_dictionary['modulus_wasm']) # Check modulus representations are equivalent
     modulus=parameter_dictionary['modulus']
-    r_wasm_divided_by_r_regular=2**(261-256)
-    assert(parameter_dictionary['r_squared']==pow(2,512,modulus)) # Check r_squared
-    assert(parameter_dictionary['r_squared_wasm']==pow(2,9*29*2,modulus)) # Check r_squared_wasm
-    assert(parameter_dictionary['cube_root']*r_wasm_divided_by_r_regular%modulus==parameter_dictionary['cube_root_wasm'])
+    assert(parameter_dictionary['r_squared']==pow(2,512,modulus)) # Check r_squared (R = 2^256)
+    assert(parameter_dictionary['r_inv_wasm']*(1<<29)%modulus==1) # Check r_inv_wasm = 2^{-29} mod p
     assert(pow(parameter_dictionary['cube_root']*pow(2,-256,modulus),3,modulus)==1) # Check cubic root
-    assert(pow(parameter_dictionary['cube_root_wasm']*pow(2,-29*9,modulus),3,modulus)==1) # Check cubic root for wasm
-    assert(parameter_dictionary['primitive_root']*r_wasm_divided_by_r_regular%modulus==parameter_dictionary['primitive_root_wasm']) # Check primitive roots are equivalent
-    for i in range(8):
-        regular_coset_generator=reconstruct_field_from_4_parts([parameter_dictionary[f'coset_generators_{j}'][i] for j in range(4)])
-        wasm_coset_generator=reconstruct_field_from_4_parts([parameter_dictionary[f'coset_generators_wasm_{j}'][i] for j in range(4)])
-        assert(regular_coset_generator*r_wasm_divided_by_r_regular%modulus == wasm_coset_generator)
 
     return parameter_dictionary
 ```

--- a/barretenberg/cpp/src/barretenberg/ecc/fields/field_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/fields/field_impl.hpp
@@ -284,28 +284,34 @@ template <class T> constexpr bool field<T>::operator!=(const field& other) const
 
 template <class T> constexpr field<T> field<T>::to_montgomery_form() const noexcept
 {
-    constexpr field r_squared =
-        field{ r_squared_uint.data[0], r_squared_uint.data[1], r_squared_uint.data[2], r_squared_uint.data[3] };
-    return *this * r_squared;
+    return *this * r_squared();
+}
+
+template <class T>
+constexpr std::array<field<T>, 2> field<T>::paired_to_montgomery_form(const field& a, const field& b) noexcept
+{
+    return paired_mul(a, r_squared(), b, r_squared());
 }
 
 template <class T> constexpr field<T> field<T>::from_montgomery_form() const noexcept
 {
-    constexpr field one_raw{ 1, 0, 0, 0 };
-    return operator*(one_raw);
+    return *this * one_raw();
+}
+
+template <class T>
+constexpr std::array<field<T>, 2> field<T>::paired_from_montgomery_form(const field& a, const field& b) noexcept
+{
+    return paired_mul(a, one_raw(), b, one_raw());
 }
 
 template <class T> constexpr void field<T>::self_to_montgomery_form() & noexcept
 {
-    constexpr field r_squared =
-        field{ r_squared_uint.data[0], r_squared_uint.data[1], r_squared_uint.data[2], r_squared_uint.data[3] };
-    *this *= r_squared;
+    *this *= r_squared();
 }
 
 template <class T> constexpr void field<T>::self_from_montgomery_form() & noexcept
 {
-    constexpr field one_raw{ 1, 0, 0, 0 };
-    *this *= one_raw;
+    *this *= one_raw();
 }
 
 // Reduced versions - guarantee canonical form [0, p)
@@ -314,9 +320,27 @@ template <class T> constexpr field<T> field<T>::to_montgomery_form_reduced() con
     return to_montgomery_form().reduce_once();
 }
 
+template <class T>
+constexpr std::array<field<T>, 2> field<T>::paired_to_montgomery_form_reduced(const field& a, const field& b) noexcept
+{
+    auto out = paired_to_montgomery_form(a, b);
+    out[0].self_reduce_once();
+    out[1].self_reduce_once();
+    return out;
+}
+
 template <class T> constexpr field<T> field<T>::from_montgomery_form_reduced() const noexcept
 {
     return from_montgomery_form().reduce_once();
+}
+
+template <class T>
+constexpr std::array<field<T>, 2> field<T>::paired_from_montgomery_form_reduced(const field& a, const field& b) noexcept
+{
+    auto out = paired_from_montgomery_form(a, b);
+    out[0].self_reduce_once();
+    out[1].self_reduce_once();
+    return out;
 }
 
 template <class T> constexpr void field<T>::self_to_montgomery_form_reduced() & noexcept
@@ -360,22 +384,37 @@ template <class T> constexpr void field<T>::self_reduce_once() & noexcept
 
 template <class T> constexpr field<T> field<T>::pow(const uint256_t& exponent) const noexcept
 {
-    field accumulator{ data[0], data[1], data[2], data[3] };
-    field to_mul{ data[0], data[1], data[2], data[3] };
-    const uint64_t maximum_set_bit = exponent.get_msb();
+    if (exponent == uint256_t(0)) {
+        return one();
+    }
+    if (*this == zero()) {
+        return zero();
+    }
 
-    for (int i = static_cast<int>(maximum_set_bit) - 1; i >= 0; --i) {
-        accumulator.self_sqr();
-        if (exponent.get_bit(static_cast<uint64_t>(i))) {
-            accumulator *= to_mul;
+    // Right-to-left binary: per set bit, (result*base, base*base) are independent and fuse into one paired_mul.
+    field result = one();
+    field base{ data[0], data[1], data[2], data[3] };
+    const uint64_t msb = exponent.get_msb();
+
+    for (uint64_t i = 0; i < msb; ++i) {
+        if (exponent.get_bit(i)) {
+            // On relaxed-SIMD WASM, fuse (result*base, base*base) into one paired_mul
+            // pipeline. On other targets, an explicit mul + self_sqr is faster because
+            // paired_mul's fallback would replace the faster squaring with multiplying.
+            // PERF: a fused mul_sqr primitive could subsume both branches.
+#if defined(__wasm_relaxed_simd__) && defined(__wasm__)
+            std::tie(result, base) = paired_mul(result, base, base, base);
+#else
+            result *= base;
+            base.self_sqr();
+#endif
+        } else {
+            base.self_sqr();
         }
     }
-    if (exponent == uint256_t(0)) {
-        accumulator = one();
-    } else if (*this == zero()) {
-        accumulator = zero();
-    }
-    return accumulator;
+    // MSB is always set; final fold is a single multiply.
+    result *= base;
+    return result;
 }
 
 template <class T> constexpr field<T> field<T>::pow(const uint64_t exponent) const noexcept
@@ -758,11 +797,7 @@ template <class T> constexpr bool field<T>::is_zero() const noexcept
 
 template <class T> constexpr field<T> field<T>::get_root_of_unity(size_t subgroup_size) noexcept
 {
-#if defined(__SIZEOF_INT128__) && !defined(__wasm__)
     field r{ T::primitive_root_0, T::primitive_root_1, T::primitive_root_2, T::primitive_root_3 };
-#else
-    field r{ T::primitive_root_wasm_0, T::primitive_root_wasm_1, T::primitive_root_wasm_2, T::primitive_root_wasm_3 };
-#endif
     for (size_t i = primitive_root_log_size(); i > subgroup_size; --i) {
         r.self_sqr();
     }

--- a/barretenberg/cpp/src/barretenberg/ecc/fields/field_impl_generic.hpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/fields/field_impl_generic.hpp
@@ -451,121 +451,78 @@ template <class T> constexpr field<T> field<T>::montgomery_mul_big(const field& 
     return { r0, r1, r2, r3 };
 #else
 
-    // Convert 4 64-bit limbs to 9 29-bit limbs
+    // Convert 4 64-bit limbs to 9 29-bit limbs.
     auto left = wasm_convert(data);
     auto right = wasm_convert(other.data);
-    constexpr uint64_t mask = 0x1fffffff;
-    uint64_t temp_0 = 0;
-    uint64_t temp_1 = 0;
-    uint64_t temp_2 = 0;
-    uint64_t temp_3 = 0;
-    uint64_t temp_4 = 0;
-    uint64_t temp_5 = 0;
-    uint64_t temp_6 = 0;
-    uint64_t temp_7 = 0;
-    uint64_t temp_8 = 0;
-    uint64_t temp_9 = 0;
-    uint64_t temp_10 = 0;
-    uint64_t temp_11 = 0;
-    uint64_t temp_12 = 0;
-    uint64_t temp_13 = 0;
-    uint64_t temp_14 = 0;
-    uint64_t temp_15 = 0;
-    uint64_t temp_16 = 0;
-    uint64_t temp_17 = 0;
-    // Compute left[0] * right and replace with a representative modulo p that zeros out the lowest
-    // 29 bits. In other words, after first reduction: temp_1..temp_8 hold the partial Montgomery product after
-    // processing left[0]. temp_0 has been "consumed" (its information propagated via carry to temp_1).
-    // Multiply-add 0th limb of the left argument by all 9 limbs of the right arguemnt
-    wasm_madd(left[0], right, temp_0, temp_1, temp_2, temp_3, temp_4, temp_5, temp_6, temp_7, temp_8);
-    // Instantly Montgomery reduce
-    wasm_reduce(temp_0, temp_1, temp_2, temp_3, temp_4, temp_5, temp_6, temp_7, temp_8);
-    //  Continue for other limbs
-    wasm_madd(left[1], right, temp_1, temp_2, temp_3, temp_4, temp_5, temp_6, temp_7, temp_8, temp_9);
-    wasm_reduce(temp_1, temp_2, temp_3, temp_4, temp_5, temp_6, temp_7, temp_8, temp_9);
-    wasm_madd(left[2], right, temp_2, temp_3, temp_4, temp_5, temp_6, temp_7, temp_8, temp_9, temp_10);
-    wasm_reduce(temp_2, temp_3, temp_4, temp_5, temp_6, temp_7, temp_8, temp_9, temp_10);
-    wasm_madd(left[3], right, temp_3, temp_4, temp_5, temp_6, temp_7, temp_8, temp_9, temp_10, temp_11);
-    wasm_reduce(temp_3, temp_4, temp_5, temp_6, temp_7, temp_8, temp_9, temp_10, temp_11);
-    wasm_madd(left[4], right, temp_4, temp_5, temp_6, temp_7, temp_8, temp_9, temp_10, temp_11, temp_12);
-    wasm_reduce(temp_4, temp_5, temp_6, temp_7, temp_8, temp_9, temp_10, temp_11, temp_12);
-    wasm_madd(left[5], right, temp_5, temp_6, temp_7, temp_8, temp_9, temp_10, temp_11, temp_12, temp_13);
-    wasm_reduce(temp_5, temp_6, temp_7, temp_8, temp_9, temp_10, temp_11, temp_12, temp_13);
-    wasm_madd(left[6], right, temp_6, temp_7, temp_8, temp_9, temp_10, temp_11, temp_12, temp_13, temp_14);
-    wasm_reduce(temp_6, temp_7, temp_8, temp_9, temp_10, temp_11, temp_12, temp_13, temp_14);
-    wasm_madd(left[7], right, temp_7, temp_8, temp_9, temp_10, temp_11, temp_12, temp_13, temp_14, temp_15);
-    wasm_reduce(temp_7, temp_8, temp_9, temp_10, temp_11, temp_12, temp_13, temp_14, temp_15);
-    wasm_madd(left[8], right, temp_8, temp_9, temp_10, temp_11, temp_12, temp_13, temp_14, temp_15, temp_16);
-    wasm_reduce(temp_8, temp_9, temp_10, temp_11, temp_12, temp_13, temp_14, temp_15, temp_16);
-    // MontgomeryMul(left, right) := (left * right) / R mod p.
-    // Then, after the add/reduce sequence, we have the following: MontgomeryMul(left, right) ≡ \sum_{i=0}^8 temp_{i+9}
-    // * 2^{29 * i} mod p. In particular, the information we want is stored in {t_9, ..., t_16}. However, these t_i are
-    // not yet 29 bits.
+    std::array<uint64_t, 17> temp{};
+
+    // 9-step Montgomery reduction chain computes (left * right) / R mod p, R = 2^256.
+    // Each iteration multiply-adds left[i] × right and zeros 29 bits via wasm_reduce_29; the final
+    // step uses wasm_reduce_24 so the total zeroed bits sum to 256 (equivalent to div by R = 2^256)
+    BB_FORCE_UNROLL
+    for (size_t i = 0; i < 8; ++i) {
+        const std::span<uint64_t, WASM_NUM_LIMBS> window{ &temp[i], WASM_NUM_LIMBS };
+        wasm_madd(left[i], right, window);
+        wasm_reduce_29(window);
+    }
+    const std::span<uint64_t, WASM_NUM_LIMBS> last_window{ &temp[8], WASM_NUM_LIMBS };
+    wasm_madd(left[8], right, last_window);
+    wasm_reduce_24(last_window);
+
+    // Post-reduction bound:
+    //   T₀ = aR·bR < p² (aR, bR < p), to which at step i we add 2^prefix_i · k_i · p, where k_i
+    //   is bounded by 2^29 for i = 0..7, 2^24 for i = 8, and prefix_i = i * 29 for i = 0..8.
+    //   As k = Σ k_i · 2^prefix_i for i = 0..8 < R, hence:
+    //   (T₀ + [Σ 2^prefix_i · k_i · p for i = 0..8]) / R < (p² + R · p) / R < 2p < 2^257  as p < R.
+    // Since result < 2p, a single conditional subtraction of p suffices to bring it into [0, p).
     //
-    // Moreover, we claim that the value \sum_{i=0}^8 temp_{i+9} is less than than p + 2^{512-261} = p +
-    // 2^{251}. The reasoning is again generic: we have computed aR * bR + k_{0, 1, .., 8}p. Each aR and bR are, by
-    // assumption, 256 bits, and each k is 29 bits: k_0 is at most 2^29 - 1, k_1 is at most 2^58 - 2^29, etc.
-    // Telescoping, this means that the sum is upper-bounded by 2^512 + (2^261 - 1) * p. As we are taking the "high"
-    // part, we are simply trying to upper-bound this sum divided by 2^261. In particular, this shows that we have to do
-    // at most one subtraction to make the result 256 bits.
-    //
-    // After all multiplications and additions, convert relaxed form to strict (i.e., force all limbs to be
-    // 29 bits)
-    temp_10 += temp_9 >> WASM_LIMB_BITS;
-    temp_9 &= mask;
-    temp_11 += temp_10 >> WASM_LIMB_BITS;
-    temp_10 &= mask;
-    temp_12 += temp_11 >> WASM_LIMB_BITS;
-    temp_11 &= mask;
-    temp_13 += temp_12 >> WASM_LIMB_BITS;
-    temp_12 &= mask;
-    temp_14 += temp_13 >> WASM_LIMB_BITS;
-    temp_13 &= mask;
-    temp_15 += temp_14 >> WASM_LIMB_BITS;
-    temp_14 &= mask;
-    temp_16 += temp_15 >> WASM_LIMB_BITS;
-    temp_15 &= mask;
-    temp_17 += temp_16 >> WASM_LIMB_BITS;
-    temp_16 &= mask;
+    // Layout in temp[8..16] after the chain:
+    //   temp[8]:     5 bits at positions 24..28 (bits 0..23 zeroed by wasm_reduce_24,
+    //                bits 29+ already propagated to temp[9])
+    //   temp[9..15]: 29 bits each,
+    //   temp[16]:    49 bits (unmasked as bound < 2^49 follows from result < 2^257)
+    temp[8] &= WASM_LIMB_MASK;
+    BB_FORCE_UNROLL
+    for (size_t i = 9; i < 16; ++i) {
+        temp[i + 1] += temp[i] >> WASM_LIMB_BITS;
+        temp[i] &= WASM_LIMB_MASK;
+    }
 
-    uint64_t r_temp_0;
-    uint64_t r_temp_1;
-    uint64_t r_temp_2;
-    uint64_t r_temp_3;
-    uint64_t r_temp_4;
-    uint64_t r_temp_5;
-    uint64_t r_temp_6;
-    uint64_t r_temp_7;
-    uint64_t r_temp_8;
+    // Re-align the (5, 7×29, 49) layout into the canonical (8×29, 25) form: each new limb takes
+    // 5 high bits from temp[8 + i] (positions 24..28) and 24 low bits from temp[9 + i].
+    // PERF: an alternative would be a per-curve (5, 7×29, 49) wasm_modulus_r256 layout, skipping
+    // the realignment at the cost of an additional constant.
+    std::array<uint64_t, 9> v;
+    BB_FORCE_UNROLL
+    for (size_t i = 0; i < 8; ++i) {
+        v[i] = ((temp[8 + i] >> WASM_FINAL_REDUCE_BITS) | (temp[9 + i] << WASM_FINAL_REMAINDER_BITS)) & WASM_LIMB_MASK;
+    }
+    v[8] = temp[16] >> WASM_FINAL_REDUCE_BITS; // bits 232..256 (25 bits incl. overflow)
 
-    r_temp_0 = temp_9 - wasm_modulus[0];
-    r_temp_1 = temp_10 - wasm_modulus[1] - ((r_temp_0) >> 63);
-    r_temp_2 = temp_11 - wasm_modulus[2] - ((r_temp_1) >> 63);
-    r_temp_3 = temp_12 - wasm_modulus[3] - ((r_temp_2) >> 63);
-    r_temp_4 = temp_13 - wasm_modulus[4] - ((r_temp_3) >> 63);
-    r_temp_5 = temp_14 - wasm_modulus[5] - ((r_temp_4) >> 63);
-    r_temp_6 = temp_15 - wasm_modulus[6] - ((r_temp_5) >> 63);
-    r_temp_7 = temp_16 - wasm_modulus[7] - ((r_temp_6) >> 63);
-    r_temp_8 = temp_17 - wasm_modulus[8] - ((r_temp_7) >> 63);
+    // Subtract wasm_modulus from v with a borrow chain. `r_v[i-1] >> 63` extracts the borrow
+    // bit: it is 1 iff the prior unsigned subtraction underflowed (its high bit got set on wrap).
+    std::array<uint64_t, 9> r_v;
+    r_v[0] = v[0] - wasm_modulus[0];
+    BB_FORCE_UNROLL
+    for (size_t i = 1; i < 9; ++i) {
+        r_v[i] = v[i] - wasm_modulus[i] - (r_v[i - 1] >> 63);
+    }
 
-    // Depending on whether the subtraction underflowed, choose original value or the result of subtraction
-    uint64_t new_mask = 0 - (r_temp_8 >> 63);
-    uint64_t inverse_mask = (~new_mask) & mask;
-    temp_9 = (temp_9 & new_mask) | (r_temp_0 & inverse_mask);
-    temp_10 = (temp_10 & new_mask) | (r_temp_1 & inverse_mask);
-    temp_11 = (temp_11 & new_mask) | (r_temp_2 & inverse_mask);
-    temp_12 = (temp_12 & new_mask) | (r_temp_3 & inverse_mask);
-    temp_13 = (temp_13 & new_mask) | (r_temp_4 & inverse_mask);
-    temp_14 = (temp_14 & new_mask) | (r_temp_5 & inverse_mask);
-    temp_15 = (temp_15 & new_mask) | (r_temp_6 & inverse_mask);
-    temp_16 = (temp_16 & new_mask) | (r_temp_7 & inverse_mask);
-    temp_17 = (temp_17 & new_mask) | (r_temp_8 & inverse_mask);
+    // Constant-time conditional reduction: keep v[i] if r_v underflowed (v < modulus), else use r_v[i].
+    const uint64_t keep_orig_mask = 0 - (r_v[8] >> 63);
+    const uint64_t take_sub_mask = ~keep_orig_mask;
+    std::array<uint64_t, 9> out;
+    BB_FORCE_UNROLL
+    for (size_t i = 0; i < 8; ++i) {
+        out[i] = (v[i] & keep_orig_mask) | (r_v[i] & take_sub_mask & WASM_LIMB_MASK);
+    }
+    out[8] = (v[8] & keep_orig_mask) | (r_v[8] & take_sub_mask & WASM_FINAL_REDUCE_MASK);
 
-    // Convert back to 4 64-bit limbs
-    return { (temp_9 << 0) | (temp_10 << 29) | (temp_11 << 58),
-             (temp_11 >> 6) | (temp_12 << 23) | (temp_13 << 52),
-             (temp_13 >> 12) | (temp_14 << 17) | (temp_15 << 46),
-             (temp_15 >> 18) | (temp_16 << 11) | (temp_17 << 40) };
+    // Pack 9 limbs (8×29 + 1×24) into 4 64-bit limbs.
+    return { (out[0] << 0) | (out[1] << 29) | (out[2] << 58),
+             (out[2] >> 6) | (out[3] << 23) | (out[4] << 52),
+             (out[4] >> 12) | (out[5] << 17) | (out[6] << 46),
+             (out[6] >> 18) | (out[7] << 11) | (out[8] << 40) };
 
 #endif
 }
@@ -573,32 +530,88 @@ template <class T> constexpr field<T> field<T>::montgomery_mul_big(const field& 
 #if defined(__wasm__) || !defined(__SIZEOF_INT128__)
 
 /**
- * @brief Multiply left limb by a sequence of 9 limbs and accumulate into result variables
+ * @brief N×N schoolbook for relaxed-29-bit limbs (each limb ≤ 2^30 - 1).
+ */
+template <class T>
+template <size_t N>
+constexpr std::array<uint64_t, 2 * N - 1> field<T>::wasm_schoolbook_mul(const std::array<uint64_t, N>& a,
+                                                                        const std::array<uint64_t, N>& b)
+{
+    // Output column k (k ∈ [0, 2N-1)) sums all products a[i]*b[j] with 0 ≤ i,j < N and i+j = k,
+    // which is maximised at the middle column k = N-1 with N products. As each limb is ≤ (2^30 - 1),
+    // to avoid uint64_t overflow we need N * (2^30 - 1)^2 < 2^64, giving N ≤ 16.
+    static_assert(N >= 1 && N <= 16, "wasm_schoolbook_mul: N must be in [1, 16]");
+
+    std::array<uint64_t, 2 * N - 1> out{};
+    BB_FORCE_UNROLL
+    for (size_t i = 0; i < N; ++i) {
+        BB_FORCE_UNROLL
+        for (size_t j = 0; j < N; ++j) {
+            out[i + j] += a[i] * b[j];
+        }
+    }
+    return out;
+}
+
+/**
+ * @brief 9×9 Karatsuba product (5+4 split) over relaxed 29-bit limbs (66 muls vs. 81 naive schoolbook).
+ */
+template <class T>
+constexpr std::array<uint64_t, 2 * WASM_NUM_LIMBS - 1> field<T>::wasm_karatsuba_mul(
+    const std::array<uint64_t, WASM_NUM_LIMBS>& left, const std::array<uint64_t, WASM_NUM_LIMBS>& right)
+{
+    const std::array<uint64_t, 5> left_lo = { left[0], left[1], left[2], left[3], left[4] };
+    const std::array<uint64_t, 5> right_lo = { right[0], right[1], right[2], right[3], right[4] };
+    const std::array<uint64_t, 4> left_hi = { left[5], left[6], left[7], left[8] };
+    const std::array<uint64_t, 4> right_hi = { right[5], right[6], right[7], right[8] };
+
+    // Pad the 4-limb high half with a 0 at index 4 so left_sum / right_sum stay 5 limbs.
+    const std::array<uint64_t, 5> left_sum = {
+        left[0] + left[5], left[1] + left[6], left[2] + left[7], left[3] + left[8], left[4]
+    };
+    const std::array<uint64_t, 5> right_sum = {
+        right[0] + right[5], right[1] + right[6], right[2] + right[7], right[3] + right[8], right[4]
+    };
+
+    const auto pl = wasm_schoolbook_mul<5>(left_lo, right_lo);
+    const auto ph = wasm_schoolbook_mul<4>(left_hi, right_hi);
+    // left_sum / right_sum entries are sums of two 29-bit limbs (≤ 2^30 - 1), within the schoolbook limb size.
+    const auto pc = wasm_schoolbook_mul<5>(left_sum, right_sum);
+
+    // out[k] = pl[k] + (pc - pl - ph)[k-5] + ph[k-10]; ph has only 7 limbs so indices 12, 13 drop the - ph term.
+    return { pl[0],
+             pl[1],
+             pl[2],
+             pl[3],
+             pl[4],
+             pl[5] + (pc[0] - pl[0] - ph[0]),
+             pl[6] + (pc[1] - pl[1] - ph[1]),
+             pl[7] + (pc[2] - pl[2] - ph[2]),
+             pl[8] + (pc[3] - pl[3] - ph[3]),
+             pc[4] - pl[4] - ph[4],
+             (pc[5] - pl[5] - ph[5]) + ph[0],
+             (pc[6] - pl[6] - ph[6]) + ph[1],
+             (pc[7] - pl[7]) + ph[2],
+             (pc[8] - pl[8]) + ph[3],
+             ph[4],
+             ph[5],
+             ph[6] };
+}
+
+/**
+ * @brief Multiply left limb by a sequence of 9 limbs and accumulate into result[0..8].
  *
  * @note There is no carrying in this method.
  */
 template <class T>
-constexpr void field<T>::wasm_madd(uint64_t& left_limb,
+constexpr void field<T>::wasm_madd(uint64_t left_limb,
                                    const std::array<uint64_t, WASM_NUM_LIMBS>& right_limbs,
-                                   uint64_t& result_0,
-                                   uint64_t& result_1,
-                                   uint64_t& result_2,
-                                   uint64_t& result_3,
-                                   uint64_t& result_4,
-                                   uint64_t& result_5,
-                                   uint64_t& result_6,
-                                   uint64_t& result_7,
-                                   uint64_t& result_8)
+                                   std::span<uint64_t, WASM_NUM_LIMBS> result)
 {
-    result_0 += left_limb * right_limbs[0];
-    result_1 += left_limb * right_limbs[1];
-    result_2 += left_limb * right_limbs[2];
-    result_3 += left_limb * right_limbs[3];
-    result_4 += left_limb * right_limbs[4];
-    result_5 += left_limb * right_limbs[5];
-    result_6 += left_limb * right_limbs[6];
-    result_7 += left_limb * right_limbs[7];
-    result_8 += left_limb * right_limbs[8];
+    BB_FORCE_UNROLL
+    for (size_t i = 0; i < WASM_NUM_LIMBS; ++i) {
+        result[i] += left_limb * right_limbs[i];
+    }
 }
 
 /**
@@ -613,37 +626,41 @@ constexpr void field<T>::wasm_madd(uint64_t& left_limb,
  * No other carries are propagated, hence the limbs remain in "relaxed form".
  *
  * @note In particular, the limbs are in "relaxed form", i.e., they are not strictly constrained to be 29 bits.
- * @note This function is called 9 times during Montgomery multiplication (once per limb), where the initial inputs are
- * 58 bits, and the alternation between wasm_madd and wasm_reduce keeps the accumulated values safely within 64 bits.
+ * @note This function is called 8 times during the R=2^256 WASM reduction chain
+ * (the 9th step uses wasm_reduce_24), where the initial inputs are 58 bits and
+ * the alternation between wasm_madd and wasm_reduce_29 keeps the accumulated
+ * values safely within 64 bits.
  * @note We only propagate the carry from result_0 to result_1 because result_0 is effectively discarded after
  * this operation (it's not used in subsequent iterations), while result_1 through result_8 continue accumulating. The
  * methods calling this method will be responsible for strictifying the result again.
  * @note For our application, we require bounds on the output limbs (especially result_8). For information on how we
  * deduce these, please see where this method is called.
  */
-template <class T>
-constexpr void field<T>::wasm_reduce(uint64_t& result_0,
-                                     uint64_t& result_1,
-                                     uint64_t& result_2,
-                                     uint64_t& result_3,
-                                     uint64_t& result_4,
-                                     uint64_t& result_5,
-                                     uint64_t& result_6,
-                                     uint64_t& result_7,
-                                     uint64_t& result_8)
+template <class T> constexpr void field<T>::wasm_reduce_29(std::span<uint64_t, WASM_NUM_LIMBS> result)
 {
-    constexpr uint64_t mask = 0x1fffffff;
-    constexpr uint64_t r_inv = T::r_inv & mask; //  -(modulus ^ { -1 }) modulo 2 ^ WASM_LIMB_BITS
-    uint64_t k = (result_0 * r_inv) & mask;
-    result_0 += k * wasm_modulus[0];
-    result_1 += k * wasm_modulus[1] + (result_0 >> WASM_LIMB_BITS);
-    result_2 += k * wasm_modulus[2];
-    result_3 += k * wasm_modulus[3];
-    result_4 += k * wasm_modulus[4];
-    result_5 += k * wasm_modulus[5];
-    result_6 += k * wasm_modulus[6];
-    result_7 += k * wasm_modulus[7];
-    result_8 += k * wasm_modulus[8];
+    constexpr uint64_t r_inv = T::r_inv & WASM_LIMB_MASK; // -(modulus^{-1}) modulo 2^WASM_LIMB_BITS
+    uint64_t k = (result[0] * r_inv) & WASM_LIMB_MASK;
+    result[0] += k * wasm_modulus[0];
+    result[1] += k * wasm_modulus[1] + (result[0] >> WASM_LIMB_BITS);
+    BB_FORCE_UNROLL
+    for (size_t i = 2; i < WASM_NUM_LIMBS; ++i) {
+        result[i] += k * wasm_modulus[i];
+    }
+}
+
+/**
+ * @brief Like wasm_reduce_29 but zeroes only the lowest 24 bits of result_0 (bits 24..28 are kept as result data).
+ */
+template <class T> constexpr void field<T>::wasm_reduce_24(std::span<uint64_t, WASM_NUM_LIMBS> result)
+{
+    constexpr uint64_t r_inv = T::r_inv & WASM_FINAL_REDUCE_MASK; // -(modulus^{-1}) modulo 2^WASM_FINAL_REDUCE_BITS
+    uint64_t k = (result[0] * r_inv) & WASM_FINAL_REDUCE_MASK;
+    result[0] += k * wasm_modulus[0];
+    result[1] += k * wasm_modulus[1] + (result[0] >> WASM_LIMB_BITS); // Carry shifts by the limb width.
+    BB_FORCE_UNROLL
+    for (size_t i = 2; i < WASM_NUM_LIMBS; ++i) {
+        result[i] += k * wasm_modulus[i];
+    }
 }
 
 /**
@@ -666,29 +683,14 @@ constexpr void field<T>::wasm_reduce(uint64_t& result_0,
  *
  * @note For a reference, please see: https://hackmd.io/@Ingonyama/Barret-Montgomery
  */
-template <class T>
-constexpr void field<T>::wasm_reduce_yuval(uint64_t& result_0,
-                                           uint64_t& result_1,
-                                           uint64_t& result_2,
-                                           uint64_t& result_3,
-                                           uint64_t& result_4,
-                                           uint64_t& result_5,
-                                           uint64_t& result_6,
-                                           uint64_t& result_7,
-                                           uint64_t& result_8,
-                                           uint64_t& result_9)
+template <class T> constexpr void field<T>::wasm_reduce_yuval(std::span<uint64_t, WASM_NUM_LIMBS + 1> result)
 {
-    constexpr uint64_t mask = 0x1fffffff;
-    const uint64_t result_0_masked = result_0 & mask;
-    result_1 += result_0_masked * wasm_r_inv[0] + (result_0 >> WASM_LIMB_BITS);
-    result_2 += result_0_masked * wasm_r_inv[1];
-    result_3 += result_0_masked * wasm_r_inv[2];
-    result_4 += result_0_masked * wasm_r_inv[3];
-    result_5 += result_0_masked * wasm_r_inv[4];
-    result_6 += result_0_masked * wasm_r_inv[5];
-    result_7 += result_0_masked * wasm_r_inv[6];
-    result_8 += result_0_masked * wasm_r_inv[7];
-    result_9 += result_0_masked * wasm_r_inv[8];
+    const uint64_t result_0_masked = result[0] & WASM_LIMB_MASK;
+    result[1] += result_0_masked * wasm_r_inv[0] + (result[0] >> WASM_LIMB_BITS);
+    BB_FORCE_UNROLL
+    for (size_t i = 2; i < WASM_NUM_LIMBS + 1; ++i) {
+        result[i] += result_0_masked * wasm_r_inv[i - 1];
+    }
 }
 /**
  * @brief Convert 4 64-bit limbs into 9 29-bit limbs
@@ -696,15 +698,51 @@ constexpr void field<T>::wasm_reduce_yuval(uint64_t& result_0,
  */
 template <class T> constexpr std::array<uint64_t, WASM_NUM_LIMBS> field<T>::wasm_convert(const uint64_t* data)
 {
-    return { data[0] & 0x1fffffff,
-             (data[0] >> WASM_LIMB_BITS) & 0x1fffffff,
+    return { data[0] & WASM_LIMB_MASK,
+             (data[0] >> WASM_LIMB_BITS) & WASM_LIMB_MASK,
              ((data[0] >> 58) & 0x3f) | ((data[1] & 0x7fffff) << 6),
-             (data[1] >> 23) & 0x1fffffff,
+             (data[1] >> 23) & WASM_LIMB_MASK,
              ((data[1] >> 52) & 0xfff) | ((data[2] & 0x1ffff) << 12),
-             (data[2] >> 17) & 0x1fffffff,
+             (data[2] >> 17) & WASM_LIMB_MASK,
              ((data[2] >> 46) & 0x3ffff) | ((data[3] & 0x7ff) << 18),
-             (data[3] >> 11) & 0x1fffffff,
-             (data[3] >> 40) & 0x1fffffff };
+             (data[3] >> 11) & WASM_LIMB_MASK,
+             (data[3] >> 40) & WASM_LIMB_MASK };
+}
+
+/**
+ * @brief Reduce a 17-limb relaxed-29-bit accumulator by R = 2^256 and pack into canonical 4 × 64-bit
+ * Montgomery limbs. Shared by `montgomery_mul` and `montgomery_square` (small-modulus path).
+ *
+ * @details The reduction is 7 Yuval-style 29-bit + 1 standard Montgomery 29-bit + 1 final 24-bit
+ * Montgomery (7*29 + 29 + 24 = 256). The Montgomery step at `temp[7]` tightens the running bound
+ * (Yuval slack is 2^29*p vs. p for Montgomery); a final Yuval is impossible because its 10-limb
+ * output would overflow the limb window. See field_docs.md for the full bounds derivation; the
+ * post-reduction value is in [0, 2p) so no conditional subtraction is needed for coarse form.
+ */
+template <class T>
+constexpr std::array<uint64_t, 4> field<T>::wasm_reduce_and_pack(std::array<uint64_t, 2 * WASM_NUM_LIMBS - 1>& temp)
+{
+    BB_FORCE_UNROLL
+    for (size_t i = 0; i < 7; ++i) {
+        wasm_reduce_yuval(std::span<uint64_t, WASM_NUM_LIMBS + 1>{ &temp[i], WASM_NUM_LIMBS + 1 });
+    }
+    wasm_reduce_29(std::span<uint64_t, WASM_NUM_LIMBS>{ &temp[7], WASM_NUM_LIMBS });
+    wasm_reduce_24(std::span<uint64_t, WASM_NUM_LIMBS>{ &temp[8], WASM_NUM_LIMBS });
+
+    // wasm_reduce_24 leaves bits 0..23 zero and bits 29+ already propagated to temp[9]; shift
+    // the 5 result bits at positions 24..28 down to positions 0..4 so temp[8] packs uniformly.
+    temp[8] = (temp[8] >> WASM_FINAL_REDUCE_BITS) & WASM_FINAL_REMAINDER_MASK;
+    BB_FORCE_UNROLL
+    for (size_t i = 9; i < 16; ++i) {
+        temp[i + 1] += temp[i] >> WASM_LIMB_BITS;
+        temp[i] &= WASM_LIMB_MASK;
+    }
+
+    // Pack: temp[8] is 5 bits, temp[9..15] are 29-bit, temp[16] holds at most 48 bits.
+    return { temp[8] | (temp[9] << 5) | (temp[10] << 34) | (temp[11] << 63),
+             (temp[11] >> 1) | (temp[12] << 28) | (temp[13] << 57),
+             (temp[13] >> 7) | (temp[14] << 22) | (temp[15] << 51),
+             (temp[15] >> 13) | (temp[16] << 16) };
 }
 #endif
 template <class T> constexpr field<T> field<T>::montgomery_mul(const field& other) const noexcept
@@ -767,133 +805,13 @@ template <class T> constexpr field<T> field<T>::montgomery_mul(const field& othe
     }
 #else
 
-    // Convert 4 64-bit limbs to 9 29-bit ones
-    auto left = wasm_convert(data);
-    auto right = wasm_convert(other.data);
-    constexpr uint64_t mask = 0x1fffffff;
-
-    // Karatsuba multiplication: split 9 limbs into 5 (lo) + 4 (hi).
-    // P_lo = left[0..4] * right[0..4]  (25 muls)
-    // P_hi = left[5..8] * right[5..8]  (16 muls)
-    // P_cross = (left_lo + left_hi) * (right_lo + right_hi)  (25 muls)
-    // P_mid = P_cross - P_lo - P_hi
-    // Total: 66 muls vs 81 for schoolbook 9x9.
-
-    // P_lo = left[0..4] * right[0..4] — 5x5 schoolbook
-    uint64_t pl0 = left[0] * right[0];
-    uint64_t pl1 = left[0] * right[1] + left[1] * right[0];
-    uint64_t pl2 = left[0] * right[2] + left[1] * right[1] + left[2] * right[0];
-    uint64_t pl3 = left[0] * right[3] + left[1] * right[2] + left[2] * right[1] + left[3] * right[0];
-    uint64_t pl4 =
-        left[0] * right[4] + left[1] * right[3] + left[2] * right[2] + left[3] * right[1] + left[4] * right[0];
-    uint64_t pl5 = left[1] * right[4] + left[2] * right[3] + left[3] * right[2] + left[4] * right[1];
-    uint64_t pl6 = left[2] * right[4] + left[3] * right[3] + left[4] * right[2];
-    uint64_t pl7 = left[3] * right[4] + left[4] * right[3];
-    uint64_t pl8 = left[4] * right[4];
-
-    // P_hi = left[5..8] * right[5..8] — 4x4 schoolbook
-    uint64_t ph0 = left[5] * right[5];
-    uint64_t ph1 = left[5] * right[6] + left[6] * right[5];
-    uint64_t ph2 = left[5] * right[7] + left[6] * right[6] + left[7] * right[5];
-    uint64_t ph3 = left[5] * right[8] + left[6] * right[7] + left[7] * right[6] + left[8] * right[5];
-    uint64_t ph4 = left[6] * right[8] + left[7] * right[7] + left[8] * right[6];
-    uint64_t ph5 = left[7] * right[8] + left[8] * right[7];
-    uint64_t ph6 = left[8] * right[8];
-
-    // Sums for the cross product (left_lo + left_hi, right_lo + right_hi)
-    uint64_t sl0 = left[0] + left[5];
-    uint64_t sl1 = left[1] + left[6];
-    uint64_t sl2 = left[2] + left[7];
-    uint64_t sl3 = left[3] + left[8];
-    uint64_t sl4 = left[4];
-    uint64_t sr0 = right[0] + right[5];
-    uint64_t sr1 = right[1] + right[6];
-    uint64_t sr2 = right[2] + right[7];
-    uint64_t sr3 = right[3] + right[8];
-    uint64_t sr4 = right[4];
-
-    // P_cross = sum_left * sum_right — 5x5 schoolbook
-    uint64_t pc0 = sl0 * sr0;
-    uint64_t pc1 = sl0 * sr1 + sl1 * sr0;
-    uint64_t pc2 = sl0 * sr2 + sl1 * sr1 + sl2 * sr0;
-    uint64_t pc3 = sl0 * sr3 + sl1 * sr2 + sl2 * sr1 + sl3 * sr0;
-    uint64_t pc4 = sl0 * sr4 + sl1 * sr3 + sl2 * sr2 + sl3 * sr1 + sl4 * sr0;
-    uint64_t pc5 = sl1 * sr4 + sl2 * sr3 + sl3 * sr2 + sl4 * sr1;
-    uint64_t pc6 = sl2 * sr4 + sl3 * sr3 + sl4 * sr2;
-    uint64_t pc7 = sl3 * sr4 + sl4 * sr3;
-    uint64_t pc8 = sl4 * sr4;
-
-    // Combine: temp[k] = P_lo[k] + P_mid[k-5] + P_hi[k-10]
-    // where P_mid = P_cross - P_lo - P_hi
-    uint64_t temp_0 = pl0;
-    uint64_t temp_1 = pl1;
-    uint64_t temp_2 = pl2;
-    uint64_t temp_3 = pl3;
-    uint64_t temp_4 = pl4;
-    uint64_t temp_5 = pl5 + (pc0 - pl0 - ph0);
-    uint64_t temp_6 = pl6 + (pc1 - pl1 - ph1);
-    uint64_t temp_7 = pl7 + (pc2 - pl2 - ph2);
-    uint64_t temp_8 = pl8 + (pc3 - pl3 - ph3);
-    uint64_t temp_9 = pc4 - pl4 - ph4;
-    uint64_t temp_10 = (pc5 - pl5 - ph5) + ph0;
-    uint64_t temp_11 = (pc6 - pl6 - ph6) + ph1;
-    uint64_t temp_12 = (pc7 - pl7) + ph2;
-    uint64_t temp_13 = (pc8 - pl8) + ph3;
-    uint64_t temp_14 = ph4;
-    uint64_t temp_15 = ph5;
-    uint64_t temp_16 = ph6;
-
-    // At this point, the value aR * bR is contained in \sum_{i=0}^16 temp_{i}*2^{29*i}. Note that this value is no
-    // greater than 4p^2 as aR and bR are both less than 2p.
-    wasm_reduce_yuval(temp_0, temp_1, temp_2, temp_3, temp_4, temp_5, temp_6, temp_7, temp_8, temp_9);
-    wasm_reduce_yuval(temp_1, temp_2, temp_3, temp_4, temp_5, temp_6, temp_7, temp_8, temp_9, temp_10);
-    wasm_reduce_yuval(temp_2, temp_3, temp_4, temp_5, temp_6, temp_7, temp_8, temp_9, temp_10, temp_11);
-    wasm_reduce_yuval(temp_3, temp_4, temp_5, temp_6, temp_7, temp_8, temp_9, temp_10, temp_11, temp_12);
-    wasm_reduce_yuval(temp_4, temp_5, temp_6, temp_7, temp_8, temp_9, temp_10, temp_11, temp_12, temp_13);
-    wasm_reduce_yuval(temp_5, temp_6, temp_7, temp_8, temp_9, temp_10, temp_11, temp_12, temp_13, temp_14);
-    wasm_reduce_yuval(temp_6, temp_7, temp_8, temp_9, temp_10, temp_11, temp_12, temp_13, temp_14, temp_15);
-    wasm_reduce_yuval(temp_7, temp_8, temp_9, temp_10, temp_11, temp_12, temp_13, temp_14, temp_15, temp_16);
-
-    // The first 8 limbs are reduced using Yuval's method, the last one is reduced using the regular method
-    // The reason for this is that Yuval's method produces a 10-limb representation of the reduced limb, which is then
-    // added to the higher limbs. If we do this for the last limb we reduce, we'll get a 10-limb representation instead
-    // of a 9-limb one, so we'll have to reduce it again in some other way.
-    wasm_reduce(temp_8, temp_9, temp_10, temp_11, temp_12, temp_13, temp_14, temp_15, temp_16);
-    // We must now reason about the current value of \sum_{i=0}^8 temp_{i+8} from the original assumptions.
-    // Following the algorithm, this is aR * bR + k_{0, 1, ..., 7}*r_inv_wasm + k_8p. Here, k_0 < 2^29-1, k_1 < 2^58 -
-    // 2^29, and so on, until k_8 < 2^261 - 2^232. Moreover, r_inv_wasm < p. (From the definition, it is the value of
-    // 2^{-29} mod p, and our choice of limb-representation is smaller than p. In fact, it is empirically smaller than
-    // p/2 for Fq and Fr.)
-    //
-    // Therefore, this whole sum is bounded by 4p^2 + (2^261 - 1)*p. Dividing by 2^261 and taking
-    // the integral part (corresponding to taking the top half of the limbs), and noting that 4p^2 / 2^261 << 1, we
-    // conclude that the result is in [0, p]. In particular, this implies that we are safely in [0, 2p), as desired.
-    //
-    // Note that the above analysis is soft, and it is overwhelmingly likely that the result is in [0, p). However, the
-    // only guarantee we require is that it is in [0, 2p), as with 254-bit fields we work with the coarse
-    // representation.
-
-    // Convert result to unrelaxed form (all limbs are 29 bits)
-    temp_10 += temp_9 >> WASM_LIMB_BITS;
-    temp_9 &= mask;
-    temp_11 += temp_10 >> WASM_LIMB_BITS;
-    temp_10 &= mask;
-    temp_12 += temp_11 >> WASM_LIMB_BITS;
-    temp_11 &= mask;
-    temp_13 += temp_12 >> WASM_LIMB_BITS;
-    temp_12 &= mask;
-    temp_14 += temp_13 >> WASM_LIMB_BITS;
-    temp_13 &= mask;
-    temp_15 += temp_14 >> WASM_LIMB_BITS;
-    temp_14 &= mask;
-    temp_16 += temp_15 >> WASM_LIMB_BITS;
-    temp_15 &= mask;
-
-    // Convert back to 4 64-bit limbs form
-    return { (temp_9 << 0) | (temp_10 << 29) | (temp_11 << 58),
-             (temp_11 >> 6) | (temp_12 << 23) | (temp_13 << 52),
-             (temp_13 >> 12) | (temp_14 << 17) | (temp_15 << 46),
-             (temp_15 >> 18) | (temp_16 << 11) };
+    // Convert 4 64-bit limbs to 9 29-bit ones, multiply in relaxed form (Karatsuba 5+4),
+    // then reduce by R = 2^256 and pack back to coarse form [0, 2p).
+    const auto left = wasm_convert(data);
+    const auto right = wasm_convert(other.data);
+    auto temp = wasm_karatsuba_mul(left, right);
+    auto out = wasm_reduce_and_pack(temp);
+    return { out[0], out[1], out[2], out[3] };
 #endif
 }
 /**
@@ -964,151 +882,87 @@ template <class T> constexpr field<T> field<T>::montgomery_square() const noexce
 #else
     // Convert from 4 64-bit limbs to 9 29-bit ones
     auto left = wasm_convert(data);
-    constexpr uint64_t mask = 0x1fffffff;
-    uint64_t temp_0 = 0;
-    uint64_t temp_1 = 0;
-    uint64_t temp_2 = 0;
-    uint64_t temp_3 = 0;
-    uint64_t temp_4 = 0;
-    uint64_t temp_5 = 0;
-    uint64_t temp_6 = 0;
-    uint64_t temp_7 = 0;
-    uint64_t temp_8 = 0;
-    uint64_t temp_9 = 0;
-    uint64_t temp_10 = 0;
-    uint64_t temp_11 = 0;
-    uint64_t temp_12 = 0;
-    uint64_t temp_13 = 0;
-    uint64_t temp_14 = 0;
-    uint64_t temp_15 = 0;
-    uint64_t temp_16 = 0;
+    std::array<uint64_t, 2 * WASM_NUM_LIMBS - 1> temp{};
     uint64_t acc;
-    // Perform multiplications, but accumulated results for limb k=i+j so that we can double them at the same time
-    temp_0 += left[0] * left[0];
+    temp[0] += left[0] * left[0];
     acc = 0;
     acc += left[0] * left[1];
-    temp_1 += (acc << 1);
+    temp[1] += (acc << 1);
     acc = 0;
     acc += left[0] * left[2];
-    temp_2 += left[1] * left[1];
-    temp_2 += (acc << 1);
+    temp[2] += left[1] * left[1];
+    temp[2] += (acc << 1);
     acc = 0;
     acc += left[0] * left[3];
     acc += left[1] * left[2];
-    temp_3 += (acc << 1);
+    temp[3] += (acc << 1);
     acc = 0;
     acc += left[0] * left[4];
     acc += left[1] * left[3];
-    temp_4 += left[2] * left[2];
-    temp_4 += (acc << 1);
+    temp[4] += left[2] * left[2];
+    temp[4] += (acc << 1);
     acc = 0;
     acc += left[0] * left[5];
     acc += left[1] * left[4];
     acc += left[2] * left[3];
-    temp_5 += (acc << 1);
+    temp[5] += (acc << 1);
     acc = 0;
     acc += left[0] * left[6];
     acc += left[1] * left[5];
     acc += left[2] * left[4];
-    temp_6 += left[3] * left[3];
-    temp_6 += (acc << 1);
+    temp[6] += left[3] * left[3];
+    temp[6] += (acc << 1);
     acc = 0;
     acc += left[0] * left[7];
     acc += left[1] * left[6];
     acc += left[2] * left[5];
     acc += left[3] * left[4];
-    temp_7 += (acc << 1);
+    temp[7] += (acc << 1);
     acc = 0;
     acc += left[0] * left[8];
     acc += left[1] * left[7];
     acc += left[2] * left[6];
     acc += left[3] * left[5];
-    temp_8 += left[4] * left[4];
-    temp_8 += (acc << 1);
+    temp[8] += left[4] * left[4];
+    temp[8] += (acc << 1);
     acc = 0;
     acc += left[1] * left[8];
     acc += left[2] * left[7];
     acc += left[3] * left[6];
     acc += left[4] * left[5];
-    temp_9 += (acc << 1);
+    temp[9] += (acc << 1);
     acc = 0;
     acc += left[2] * left[8];
     acc += left[3] * left[7];
     acc += left[4] * left[6];
-    temp_10 += left[5] * left[5];
-    temp_10 += (acc << 1);
+    temp[10] += left[5] * left[5];
+    temp[10] += (acc << 1);
     acc = 0;
     acc += left[3] * left[8];
     acc += left[4] * left[7];
     acc += left[5] * left[6];
-    temp_11 += (acc << 1);
+    temp[11] += (acc << 1);
     acc = 0;
     acc += left[4] * left[8];
     acc += left[5] * left[7];
-    temp_12 += left[6] * left[6];
-    temp_12 += (acc << 1);
+    temp[12] += left[6] * left[6];
+    temp[12] += (acc << 1);
     acc = 0;
     acc += left[5] * left[8];
     acc += left[6] * left[7];
-    temp_13 += (acc << 1);
+    temp[13] += (acc << 1);
     acc = 0;
     acc += left[6] * left[8];
-    temp_14 += left[7] * left[7];
-    temp_14 += (acc << 1);
+    temp[14] += left[7] * left[7];
+    temp[14] += (acc << 1);
     acc = 0;
     acc += left[7] * left[8];
-    temp_15 += (acc << 1);
-    temp_16 += left[8] * left[8];
+    temp[15] += (acc << 1);
+    temp[16] += left[8] * left[8];
 
-    // Perform reductions
-
-    wasm_reduce_yuval(temp_0, temp_1, temp_2, temp_3, temp_4, temp_5, temp_6, temp_7, temp_8, temp_9);
-    wasm_reduce_yuval(temp_1, temp_2, temp_3, temp_4, temp_5, temp_6, temp_7, temp_8, temp_9, temp_10);
-    wasm_reduce_yuval(temp_2, temp_3, temp_4, temp_5, temp_6, temp_7, temp_8, temp_9, temp_10, temp_11);
-    wasm_reduce_yuval(temp_3, temp_4, temp_5, temp_6, temp_7, temp_8, temp_9, temp_10, temp_11, temp_12);
-    wasm_reduce_yuval(temp_4, temp_5, temp_6, temp_7, temp_8, temp_9, temp_10, temp_11, temp_12, temp_13);
-    wasm_reduce_yuval(temp_5, temp_6, temp_7, temp_8, temp_9, temp_10, temp_11, temp_12, temp_13, temp_14);
-    wasm_reduce_yuval(temp_6, temp_7, temp_8, temp_9, temp_10, temp_11, temp_12, temp_13, temp_14, temp_15);
-    wasm_reduce_yuval(temp_7, temp_8, temp_9, temp_10, temp_11, temp_12, temp_13, temp_14, temp_15, temp_16);
-
-    // In case there is some unforseen edge case encountered in wasm multiplications, we can quickly restore previous
-    // functionality. Comment all "wasm_reduce_yuval" and uncomment the following:
-
-    // wasm_reduce(temp_0, temp_1, temp_2, temp_3, temp_4, temp_5, temp_6, temp_7, temp_8);
-    // wasm_reduce(temp_1, temp_2, temp_3, temp_4, temp_5, temp_6, temp_7, temp_8, temp_9);
-    // wasm_reduce(temp_2, temp_3, temp_4, temp_5, temp_6, temp_7, temp_8, temp_9, temp_10);
-    // wasm_reduce(temp_3, temp_4, temp_5, temp_6, temp_7, temp_8, temp_9, temp_10, temp_11);
-    // wasm_reduce(temp_4, temp_5, temp_6, temp_7, temp_8, temp_9, temp_10, temp_11, temp_12);
-    // wasm_reduce(temp_5, temp_6, temp_7, temp_8, temp_9, temp_10, temp_11, temp_12, temp_13);
-    // wasm_reduce(temp_6, temp_7, temp_8, temp_9, temp_10, temp_11, temp_12, temp_13, temp_14);
-    // wasm_reduce(temp_7, temp_8, temp_9, temp_10, temp_11, temp_12, temp_13, temp_14, temp_15);
-
-    // The first 8 limbs are reduced using Yuval's method, the last one is reduced using the regular method
-    // The reason for this is that Yuval's method produces a 10-limb representation of the reduced limb, which is then
-    // added to the higher limbs. If we do this for the last limb we reduce, we'll get a 10-limb representation instead
-    // of a 9-limb one, so we'll have to reduce it again in some other way.
-    wasm_reduce(temp_8, temp_9, temp_10, temp_11, temp_12, temp_13, temp_14, temp_15, temp_16);
-
-    // Convert to unrelaxed 29-bit form
-    temp_10 += temp_9 >> WASM_LIMB_BITS;
-    temp_9 &= mask;
-    temp_11 += temp_10 >> WASM_LIMB_BITS;
-    temp_10 &= mask;
-    temp_12 += temp_11 >> WASM_LIMB_BITS;
-    temp_11 &= mask;
-    temp_13 += temp_12 >> WASM_LIMB_BITS;
-    temp_12 &= mask;
-    temp_14 += temp_13 >> WASM_LIMB_BITS;
-    temp_13 &= mask;
-    temp_15 += temp_14 >> WASM_LIMB_BITS;
-    temp_14 &= mask;
-    temp_16 += temp_15 >> WASM_LIMB_BITS;
-    temp_15 &= mask;
-    // Convert to 4 64-bit form
-    return { (temp_9 << 0) | (temp_10 << 29) | (temp_11 << 58),
-             (temp_11 >> 6) | (temp_12 << 23) | (temp_13 << 52),
-             (temp_13 >> 12) | (temp_14 << 17) | (temp_15 << 46),
-             (temp_15 >> 18) | (temp_16 << 11) };
+    // Shared with montgomery_mul: reduce by R = 2^256 and pack into canonical form.
+    auto out = wasm_reduce_and_pack(temp);
+    return { out[0], out[1], out[2], out[3] };
 #endif
 }
 
@@ -1139,81 +993,26 @@ template <class T> constexpr struct field<T>::wide_array field<T>::mul_512(const
     return { r0, r1, r2, r3, r4, r5, r6, carry_2 };
 #else
     // Convert from 4 64-bit limbs to 9 29-bit limbs
-    auto left = wasm_convert(data);
-    auto right = wasm_convert(other.data);
-    constexpr uint64_t mask = 0x1fffffff;
-    uint64_t temp_0 = 0;
-    uint64_t temp_1 = 0;
-    uint64_t temp_2 = 0;
-    uint64_t temp_3 = 0;
-    uint64_t temp_4 = 0;
-    uint64_t temp_5 = 0;
-    uint64_t temp_6 = 0;
-    uint64_t temp_7 = 0;
-    uint64_t temp_8 = 0;
-    uint64_t temp_9 = 0;
-    uint64_t temp_10 = 0;
-    uint64_t temp_11 = 0;
-    uint64_t temp_12 = 0;
-    uint64_t temp_13 = 0;
-    uint64_t temp_14 = 0;
-    uint64_t temp_15 = 0;
-    uint64_t temp_16 = 0;
-
-    // Multiply-add all limbs
-    wasm_madd(left[0], right, temp_0, temp_1, temp_2, temp_3, temp_4, temp_5, temp_6, temp_7, temp_8);
-    wasm_madd(left[1], right, temp_1, temp_2, temp_3, temp_4, temp_5, temp_6, temp_7, temp_8, temp_9);
-    wasm_madd(left[2], right, temp_2, temp_3, temp_4, temp_5, temp_6, temp_7, temp_8, temp_9, temp_10);
-    wasm_madd(left[3], right, temp_3, temp_4, temp_5, temp_6, temp_7, temp_8, temp_9, temp_10, temp_11);
-    wasm_madd(left[4], right, temp_4, temp_5, temp_6, temp_7, temp_8, temp_9, temp_10, temp_11, temp_12);
-    wasm_madd(left[5], right, temp_5, temp_6, temp_7, temp_8, temp_9, temp_10, temp_11, temp_12, temp_13);
-    wasm_madd(left[6], right, temp_6, temp_7, temp_8, temp_9, temp_10, temp_11, temp_12, temp_13, temp_14);
-    wasm_madd(left[7], right, temp_7, temp_8, temp_9, temp_10, temp_11, temp_12, temp_13, temp_14, temp_15);
-    wasm_madd(left[8], right, temp_8, temp_9, temp_10, temp_11, temp_12, temp_13, temp_14, temp_15, temp_16);
+    const auto left = wasm_convert(data);
+    const auto right = wasm_convert(other.data);
+    auto temp = wasm_karatsuba_mul(left, right);
 
     // Convert to unrelaxed 29-bit form
-    temp_1 += temp_0 >> WASM_LIMB_BITS;
-    temp_0 &= mask;
-    temp_2 += temp_1 >> WASM_LIMB_BITS;
-    temp_1 &= mask;
-    temp_3 += temp_2 >> WASM_LIMB_BITS;
-    temp_2 &= mask;
-    temp_4 += temp_3 >> WASM_LIMB_BITS;
-    temp_3 &= mask;
-    temp_5 += temp_4 >> WASM_LIMB_BITS;
-    temp_4 &= mask;
-    temp_6 += temp_5 >> WASM_LIMB_BITS;
-    temp_5 &= mask;
-    temp_7 += temp_6 >> WASM_LIMB_BITS;
-    temp_6 &= mask;
-    temp_8 += temp_7 >> WASM_LIMB_BITS;
-    temp_7 &= mask;
-    temp_9 += temp_8 >> WASM_LIMB_BITS;
-    temp_8 &= mask;
-    temp_10 += temp_9 >> WASM_LIMB_BITS;
-    temp_9 &= mask;
-    temp_11 += temp_10 >> WASM_LIMB_BITS;
-    temp_10 &= mask;
-    temp_12 += temp_11 >> WASM_LIMB_BITS;
-    temp_11 &= mask;
-    temp_13 += temp_12 >> WASM_LIMB_BITS;
-    temp_12 &= mask;
-    temp_14 += temp_13 >> WASM_LIMB_BITS;
-    temp_13 &= mask;
-    temp_15 += temp_14 >> WASM_LIMB_BITS;
-    temp_14 &= mask;
-    temp_16 += temp_15 >> WASM_LIMB_BITS;
-    temp_15 &= mask;
+    BB_FORCE_UNROLL
+    for (size_t i = 0; i < 16; ++i) {
+        temp[i + 1] += temp[i] >> WASM_LIMB_BITS;
+        temp[i] &= WASM_LIMB_MASK;
+    }
 
     // Convert to 8 64-bit limbs
-    return { (temp_0 << 0) | (temp_1 << 29) | (temp_2 << 58),
-             (temp_2 >> 6) | (temp_3 << 23) | (temp_4 << 52),
-             (temp_4 >> 12) | (temp_5 << 17) | (temp_6 << 46),
-             (temp_6 >> 18) | (temp_7 << 11) | (temp_8 << 40),
-             (temp_8 >> 24) | (temp_9 << 5) | (temp_10 << 34) | (temp_11 << 63),
-             (temp_11 >> 1) | (temp_12 << 28) | (temp_13 << 57),
-             (temp_13 >> 7) | (temp_14 << 22) | (temp_15 << 51),
-             (temp_15 >> 13) | (temp_16 << 16) };
+    return { (temp[0] << 0) | (temp[1] << 29) | (temp[2] << 58),
+             (temp[2] >> 6) | (temp[3] << 23) | (temp[4] << 52),
+             (temp[4] >> 12) | (temp[5] << 17) | (temp[6] << 46),
+             (temp[6] >> 18) | (temp[7] << 11) | (temp[8] << 40),
+             (temp[8] >> 24) | (temp[9] << 5) | (temp[10] << 34) | (temp[11] << 63),
+             (temp[11] >> 1) | (temp[12] << 28) | (temp[13] << 57),
+             (temp[13] >> 7) | (temp[14] << 22) | (temp[15] << 51),
+             (temp[15] >> 13) | (temp[16] << 16) };
 #endif
 }
 

--- a/barretenberg/cpp/src/barretenberg/ecc/fields/paired_field_impl_generic.hpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/fields/paired_field_impl_generic.hpp
@@ -1,0 +1,463 @@
+#pragma once
+
+#include "field_declarations.hpp"
+
+#include <array>
+#include <bit>
+#include <cstdint>
+#include <span>
+#include <type_traits>
+
+#if defined(__wasm_relaxed_simd__) && defined(__wasm__)
+#include <wasm_simd128.h>
+
+namespace bb {
+namespace detail {
+
+// Relaxed-SIMD paired RNE helpers for WASM paired multiplication in the
+// modulus range covered by the paired coarse-output proof.
+// Uses the 5x51 limbs representations to efficiently compute the limb multiplication
+// using floating point SIMD multiply and add operation.
+
+inline constexpr uint64_t WASM_PAIRED_LIMB_BITS = 51;
+inline constexpr uint64_t WASM_PAIRED_LIMB_MASK = (1ULL << WASM_PAIRED_LIMB_BITS) - 1;
+// 5 limbs * 51 bits = 255 bits, enough to hold any value < 2^255 (modulus has < 2^254).
+inline constexpr size_t WASM_PAIRED_NUM_LIMBS = 5;
+// The paired end-to-end bound closes exactly when p < 2^254 - 2^204 = (2^62 - 2^12) * 2^192,
+// so the top limb of a largest safe field modulus is 2^62 - 2^12 - 1. This covers the
+// BN254 / Grumpkin field parameters.
+inline constexpr uint64_t WASM_PAIRED_MAX_MODULUS_3 = MODULUS_TOP_LIMB_LARGE_THRESHOLD - (1ULL << 12) - 1;
+
+// Type-level predicate: true when the runtime supports relaxed-SIMD AND the field's
+// modulus fits within the paired-bound proof's range. Drives the single guard in
+// paired_mul / paired_sqr.
+template <class Params> inline constexpr bool supports_paired_simd = Params::modulus_3 <= WASM_PAIRED_MAX_MODULUS_3;
+
+// Anchors for the Emmart-Zheng two-FMA integer multiply: for a,b < 2^51 we
+// have a*b < 2^102, and the two FMAs split that 102-bit product into
+//   p_hi = a*b + C1 + delta
+//   p_lo = a*b + (C2 - p_hi) = (C2 - C1) - delta
+// where p_hi contributes the high 51 bits and p_lo the low 51 bits after the
+// anchor bias is cancelled in the integer accumulator.
+inline constexpr double C1_D = 0x1p103;
+inline constexpr double C2_D = C1_D + 0x1p52 + 0x1p51;
+
+// Each p_lo / p_hi lane, when reinterpreted as int64, carries a constant
+// IEEE-754 bias: P_LO_BIAS from C2-C1 and P_HI_BIAS from C1. Those biases
+// are deterministic and additive, so they accumulate in every column at a
+// rate fixed by the pipeline schedule (schoolbook 5x5, 3 rho folds, 2 CIOS
+// rounds). make_initial() seeds the columns with the negation of that total
+// bias, so it cancels exactly when the column finishes summing.
+inline constexpr std::array<uint64_t, 2 * WASM_PAIRED_NUM_LIMBS> LO_BIAS_COUNTS = { 1, 2, 3, 8, 10, 9, 8, 7, 2, 0 };
+inline constexpr std::array<uint64_t, 2 * WASM_PAIRED_NUM_LIMBS> HI_BIAS_COUNTS = { 0, 1, 2, 3, 8, 10, 9, 8, 7, 2 };
+
+// Repack an x < 2^255 (4x64 little-endian) into the paired-RNE 5x51 layout.
+BB_INLINE constexpr std::array<uint64_t, WASM_PAIRED_NUM_LIMBS> split_to_5x51(std::span<const uint64_t, 4> l) noexcept
+{
+    return {
+        l[0] & WASM_PAIRED_LIMB_MASK,
+        ((l[0] >> 51) | (l[1] << 13)) & WASM_PAIRED_LIMB_MASK,
+        ((l[1] >> 38) | (l[2] << 26)) & WASM_PAIRED_LIMB_MASK,
+        ((l[2] >> 25) | (l[3] << 39)) & WASM_PAIRED_LIMB_MASK,
+        (l[3] >> 12) & WASM_PAIRED_LIMB_MASK,
+    };
+}
+
+// Inverse of split_to_5x51, with a fused >>1 (kernel R=2^255 → outer R=2^256).
+BB_INLINE constexpr std::array<uint64_t, 4> pack_to_4x64_shr_1(
+    const std::array<uint64_t, WASM_PAIRED_NUM_LIMBS>& l) noexcept
+{
+    return {
+        (l[0] >> 1) | (l[1] << 50),
+        (l[1] >> 14) | (l[2] << 37),
+        (l[2] >> 27) | (l[3] << 24),
+        (l[3] >> 40) | (l[4] << 11),
+    };
+}
+
+// Returns -p0^{-1} mod 2^WASM_PAIRED_LIMB_BITS (the Montgomery scalar n' for the 5x51 layout).
+// Hensel iteration x ← x*(2 - p0*x) doubles the correct low bits each step, so 6 rounds from
+// x=1 (correct mod 2 since p0 is odd) reach 64 bits, which we then mask down to 51.
+constexpr uint64_t compute_r_inv_local(uint64_t p0) noexcept
+{
+    uint64_t x = 1;
+    for (int i = 0; i < 6; ++i) {
+        x = x * (2 - p0 * x);
+    }
+    return -x & WASM_PAIRED_LIMB_MASK;
+}
+
+// Computes 2^{-limb_bits} mod p by iteratively dividing by 2 and conditionally adding p.
+constexpr uint256_t compute_div_r_inv_local(const uint256_t& p, unsigned limb_bits) noexcept
+{
+    uint256_t result(1);
+    for (unsigned i = 0; i < limb_bits; ++i) {
+        uint64_t carry = 0;
+        // If `result` is odd, add p (≡ 0 mod p) to flip parity without changing the residue.
+        if ((result.data[0] & 1) != 0) {
+            uint256_t sum = result + p;
+            carry = (sum < result) ? 1ULL : 0ULL;
+            result = sum;
+        }
+        // Halve the (now-even) result by shifting all 4 limbs right by 1; the +p overflow re-enters at bit 255.
+        result = uint256_t((result.data[0] >> 1) | (result.data[1] << 63),
+                           (result.data[1] >> 1) | (result.data[2] << 63),
+                           (result.data[2] >> 1) | (result.data[3] << 63),
+                           (result.data[3] >> 1) | (carry << 63));
+    }
+    return result;
+}
+
+template <class Params> struct paired_rne_constants {
+    // Field modulus repacked into the 5x51 layout.
+    static constexpr std::array<uint64_t, WASM_PAIRED_NUM_LIMBS> u51_p = split_to_5x51(field<Params>::modulus.data);
+    // Montgomery scalar n' = -p^{-1} mod 2^51, used by the two CIOS rounds.
+    static constexpr uint64_t u51_np0 = compute_r_inv_local(field<Params>::modulus.data[0]);
+    // rho[k-1] = beta^{-k} mod p (with beta = 2^51), used for parallel reductions.
+    static constexpr std::array<std::array<uint64_t, WASM_PAIRED_NUM_LIMBS>, 4> rho = []() constexpr {
+        std::array<std::array<uint64_t, WASM_PAIRED_NUM_LIMBS>, 4> out{};
+        for (unsigned k = 1; k <= 4; ++k) {
+            out[k - 1] = split_to_5x51(
+                compute_div_r_inv_local(field<Params>::modulus, static_cast<unsigned>(WASM_PAIRED_LIMB_BITS) * k).data);
+        }
+        return out;
+    }();
+};
+
+// Per-column initial value that cancels the anchor bias left behind by
+// accumulating the `low_count` p_lo terms and `high_count` p_hi terms.
+BB_INLINE constexpr int64_t make_initial(uint64_t low_count, uint64_t high_count) noexcept
+{
+    constexpr uint64_t P_HI_BIAS = 0x4660000000000000ULL;
+    constexpr uint64_t P_LO_BIAS = 0x4338000000000000ULL;
+    const uint64_t val = high_count * P_HI_BIAS + low_count * P_LO_BIAS;
+    return -static_cast<int64_t>(val);
+}
+
+BB_INLINE v128_t fma_v(v128_t a, v128_t b, v128_t c) noexcept
+{
+    return __builtin_wasm_relaxed_madd_f64x2(a, b, c);
+}
+
+// Emmart-Zheng FMA pair: returns { p_hi, p_lo } — the anchor-biased high and low halves
+// of a*b. Both lanes carry the IEEE-754 bias from C1 and (C2 - C1) that make_initial() cancels.
+BB_INLINE std::array<v128_t, 2> ez_mul(v128_t a, v128_t b) noexcept
+{
+    const v128_t C1_V = wasm_f64x2_const_splat(C1_D);
+    const v128_t C2_V = wasm_f64x2_const_splat(C2_D);
+    const v128_t p_hi = fma_v(a, b, C1_V);
+    const v128_t p_lo = fma_v(a, b, wasm_f64x2_sub(C2_V, p_hi));
+    return { p_hi, p_lo };
+}
+
+// Streaming schoolbook row: accumulates a * bs[0..N-1] into the mutable span ts[0..N].
+// Sibling of smult_noinit_paired_v128 below, which returns a fresh array instead.
+// Streams hi forward so each ts slot is written exactly once.
+template <size_t N>
+BB_INLINE void mul_accum_paired_row(v128_t a, const std::array<v128_t, N>& bs, std::span<v128_t, N + 1> ts) noexcept
+{
+    static_assert(N >= 1, "mul_accum_paired_row requires at least one b limb");
+    // h_prev=0 so j=0's add(h_prev, l) folds to `l`.
+    v128_t h_prev = wasm_i64x2_const_splat(0);
+    BB_FORCE_UNROLL
+    for (size_t j = 0; j < N; ++j) {
+        auto [h, l] = ez_mul(a, bs[j]);
+        ts[j] = wasm_i64x2_add(ts[j], wasm_i64x2_add(h_prev, l));
+        h_prev = h;
+    }
+    ts[N] = wasm_i64x2_add(ts[N], h_prev);
+}
+
+// Lane-parallel i64x2 -> f64x2 conversion without an explicit cast
+// instruction. ORing with the IEEE-754 bits of 2^52 yields exactly 2^52 + u in
+// f64 for each lane, then subtraction removes the bias. Requires u < 2^52.
+BB_INLINE v128_t i2f_v128(v128_t u) noexcept
+{
+    const v128_t bias = wasm_i64x2_const_splat(0x4330000000000000LL);
+    return wasm_f64x2_sub(wasm_v128_or(u, bias), bias);
+}
+
+// Streaming schoolbook row with a compile-time multiplicand V: returns s * V as a fresh
+// (NUM_LIMBS+1)-limb array. Sibling of mul_accum_paired_row above, which accumulates into
+// a runtime span instead. Streams hi forward to so each out slot is written exactly once.
+template <std::array<uint64_t, WASM_PAIRED_NUM_LIMBS> V>
+BB_INLINE std::array<v128_t, WASM_PAIRED_NUM_LIMBS + 1> smult_noinit_paired_v128(v128_t s_vec_u64) noexcept
+{
+    const v128_t s_f = i2f_v128(s_vec_u64);
+    std::array<v128_t, WASM_PAIRED_NUM_LIMBS + 1> out;
+    // h_prev=0 so k=0's add(h_prev, l) folds to `l`.
+    v128_t h_prev = wasm_i64x2_const_splat(0);
+    BB_FORCE_UNROLL
+    for (size_t k = 0; k < WASM_PAIRED_NUM_LIMBS; ++k) {
+        auto [h, l] = ez_mul(s_f, wasm_f64x2_splat(static_cast<double>(V[k])));
+        out[k] = wasm_i64x2_add(h_prev, l);
+        h_prev = h;
+    }
+    out[WASM_PAIRED_NUM_LIMBS] = h_prev;
+    return out;
+}
+
+// One carry-propagation pass: bits past 51 in each of t[0..NUM_LIMBS-2] are folded into
+// t[i+1]. The top limb t[NUM_LIMBS-1] is left wider — pack_to_4x64_shr_1 consumes it directly.
+BB_INLINE std::array<v128_t, WASM_PAIRED_NUM_LIMBS> redundant_carry_paired_v128(
+    const std::array<v128_t, WASM_PAIRED_NUM_LIMBS>& t) noexcept
+{
+    const v128_t WASM_PAIRED_LIMB_MASK_V = wasm_i64x2_const_splat(static_cast<int64_t>(WASM_PAIRED_LIMB_MASK));
+    std::array<v128_t, WASM_PAIRED_NUM_LIMBS> res{};
+    v128_t borrow = wasm_i64x2_const_splat(0);
+    BB_FORCE_UNROLL
+    for (size_t i = 0; i < WASM_PAIRED_NUM_LIMBS - 1; ++i) {
+        const v128_t tmp = wasm_i64x2_add(t[i], borrow);
+        res[i] = wasm_v128_and(tmp, WASM_PAIRED_LIMB_MASK_V);
+        borrow = wasm_i64x2_shr(tmp, 51);
+    }
+    res[WASM_PAIRED_NUM_LIMBS - 1] = wasm_i64x2_add(t[WASM_PAIRED_NUM_LIMBS - 1], borrow);
+    return res;
+}
+
+// Per-lane constant-time conditional add: if a lane's lowest bit is set, add
+// B to that lane, otherwise leave it unchanged.
+template <std::array<uint64_t, WASM_PAIRED_NUM_LIMBS> B>
+BB_INLINE std::array<v128_t, WASM_PAIRED_NUM_LIMBS> reduce_ct_paired_v128(
+    const std::array<v128_t, WASM_PAIRED_NUM_LIMBS>& a) noexcept
+{
+    const v128_t lsb = wasm_v128_and(a[0], wasm_i64x2_const_splat(1));
+    const v128_t mask = wasm_i64x2_neg(lsb);
+    std::array<v128_t, WASM_PAIRED_NUM_LIMBS> res;
+    BB_FORCE_UNROLL
+    for (size_t i = 0; i < WASM_PAIRED_NUM_LIMBS; ++i) {
+        const v128_t bi = wasm_i64x2_splat(static_cast<int64_t>(B[i]));
+        res[i] = wasm_i64x2_add(a[i], wasm_v128_and(bi, mask));
+    }
+    return res;
+}
+
+// Reduces a paired column accumulator t_in (each lane holding the schoolbook
+// output of a*b with both inputs in relaxed Montgomery form < 2*p, so per-lane
+// value < 4*p^2 in the 5x51 layout) modulo R = 2^256, and returns a pair of
+// field<Params> — one per SIMD lane. Output is in relaxed Montgomery form
+// (< 2*p), matching the rest of the lazy-reduction field API.
+//
+// The five reduction phases are:
+//   1. Signed carry propagation through t[0..3], normalizing the low half so
+//      phase 2 can mask off 51-bit chunks cleanly.
+//   2. Three rho folds: t[0..2] are pulled into the 7-limb high window via the
+//      precomputed beta^{-k} factors (rho[0..2]); t[3] enters at its natural
+//      beta^3 position with no extra fold.
+//   3. Two CIOS rounds. Each picks m = ss_low * u51_np0 mod 2^51, adds m*p to
+//      the live window, then propagates the dropped limb's carry forward. This
+//      strips the bottom two 51-bit limbs and brings the value into [0, 2*p)
+//      under the kernel R = 2^255.
+//   4. Constant-time conditional add of p (so ss is even) and one carry
+//      normalization pass — preparation for the halving step that converts
+//      kernel R = 2^255 to outer R = 2^256.
+//   5. Lane split and 5x51 -> 4x64 repack via pack_to_4x64_shr_1, whose fused
+//      >>1 performs the halving from phase 4. The output remains in relaxed
+//      Montgomery form (< 2*p).
+template <class Params>
+BB_INLINE std::array<field<Params>, 2> reduce_and_finalize_paired_rne(
+    const std::array<v128_t, 2 * WASM_PAIRED_NUM_LIMBS>& t_in) noexcept
+{
+    using constants = paired_rne_constants<Params>;
+
+    // Phase 1: propagate signed carries through t[0..3]. The rho folds in
+    // phase 2 mask t[0..2] to 51 bits, so we must push their high bits up
+    // first or they'd be silently dropped.
+    const v128_t t0 = t_in[0];
+    const v128_t t1 = wasm_i64x2_add(t_in[1], wasm_i64x2_shr(t0, 51));
+    const v128_t t2 = wasm_i64x2_add(t_in[2], wasm_i64x2_shr(t1, 51));
+    const v128_t t3 = wasm_i64x2_add(t_in[3], wasm_i64x2_shr(t2, 51));
+
+    // Phase 2: for k = 0, 1, 2, add to the high limbs of t_in (positions β^3..β^9)
+    //   t_k * β^k ≡ (t_k * β^{k-3}) * β^3  (mod p).
+    // Since t_in = Σ_{k=0}^{9} t_k * β^k, applying this identity to k = 0, 1, 2
+    // gives
+    //   t_in ≡ β^3 * Σ_{k=0}^{9} t_k * β^{k-3}  (mod p),
+    // so we can drop the bottom 3 limbs (153 bits) and keep working on the
+    // 7-limb β^3..β^9 window. The three folds share no inputs, so they can
+    // be computed in parallel.
+    const v128_t WASM_PAIRED_LIMB_MASK_V = wasm_i64x2_const_splat(static_cast<int64_t>(WASM_PAIRED_LIMB_MASK));
+
+    const std::array<std::array<v128_t, WASM_PAIRED_NUM_LIMBS + 1>, 3> r = {
+        smult_noinit_paired_v128<constants::rho[2]>(wasm_v128_and(t0, WASM_PAIRED_LIMB_MASK_V)),
+        smult_noinit_paired_v128<constants::rho[1]>(wasm_v128_and(t1, WASM_PAIRED_LIMB_MASK_V)),
+        smult_noinit_paired_v128<constants::rho[0]>(wasm_v128_and(t2, WASM_PAIRED_LIMB_MASK_V)),
+    };
+
+    const std::array<v128_t, 7> t_high = { t3, t_in[4], t_in[5], t_in[6], t_in[7], t_in[8], t_in[9] };
+    std::array<v128_t, 7> ss;
+    // Tree-balanced add per limb: (r0+r1) and (t_high+r2) first, then sum.
+    BB_FORCE_UNROLL
+    for (size_t k = 0; k < WASM_PAIRED_NUM_LIMBS + 1; ++k) {
+        const v128_t r01 = wasm_i64x2_add(r[0][k], r[1][k]);
+        const v128_t t_plus_r2 = wasm_i64x2_add(t_high[k], r[2][k]);
+        ss[k] = wasm_i64x2_add(r01, t_plus_r2);
+    }
+    ss[6] = t_high[6];
+
+    // Phase 3: ss ≡ t_in/β^3 (mod p), but its integer value is on the order of
+    // β^2 * p as phase 2 preserved the residue without shrinking magnitude.
+    // Two CIOS reductions tighten ss to ~2p. Each step computes
+    //   m = ss[i] * np0 mod β
+    // then performs ss ← (ss + m * p) / β, with bound transform
+    //   ss < B ⇒ ss < B/β + p.
+    // Chaining from ~β^2 * p: β p + p → 2p + p/β. Phase 5's halving absorbs
+    // the residual p/β slack into the final < 2p contract.
+    BB_FORCE_UNROLL
+    for (size_t i = 0; i < 2; ++i) {
+        const uint64_t s_lane0 = static_cast<uint64_t>(wasm_i64x2_extract_lane(ss[i], 0));
+        const uint64_t s_lane1 = static_cast<uint64_t>(wasm_i64x2_extract_lane(ss[i], 1));
+        const uint64_t m_lane0 = (s_lane0 * constants::u51_np0) & WASM_PAIRED_LIMB_MASK;
+        const uint64_t m_lane1 = (s_lane1 * constants::u51_np0) & WASM_PAIRED_LIMB_MASK;
+        const v128_t m = wasm_i64x2_make(static_cast<int64_t>(m_lane0), static_cast<int64_t>(m_lane1));
+        const auto mp = smult_noinit_paired_v128<constants::u51_p>(m);
+        BB_FORCE_UNROLL
+        for (size_t k = 0; k < WASM_PAIRED_NUM_LIMBS + 1; ++k) {
+            ss[i + k] = wasm_i64x2_add(ss[i + k], mp[k]);
+        }
+        ss[i + 1] = wasm_i64x2_add(ss[i + 1], wasm_i64x2_shr(ss[i], 51));
+    }
+
+    // Phase 4: prepare ss[2..6] for halving. ss ≡ t_in / 2^255 (mod p); we
+    // want ss / 2 to land at outer R = 2^256. If ss is odd, add p (p is odd
+    // ⇒ ss + p is even and ≡ ss mod p), then normalize via carry propagation.
+    const std::array<v128_t, WASM_PAIRED_NUM_LIMBS> s_arr = { ss[2], ss[3], ss[4], ss[5], ss[6] };
+    const std::array<v128_t, WASM_PAIRED_NUM_LIMBS> s_reduced = reduce_ct_paired_v128<constants::u51_p>(s_arr);
+    const std::array<v128_t, WASM_PAIRED_NUM_LIMBS> normalized = redundant_carry_paired_v128(s_reduced);
+
+    // Phase 5: extract per-lane scalar 5x51 arrays and repack to 4x64 via
+    // pack_to_4x64_shr_1, whose fused >>1 performs the halve prepared in
+    // phase 4 (kernel R = 2^255 → outer R = 2^256).
+    std::array<uint64_t, WASM_PAIRED_NUM_LIMBS> out1_u255;
+    std::array<uint64_t, WASM_PAIRED_NUM_LIMBS> out2_u255;
+    BB_FORCE_UNROLL
+    for (size_t k = 0; k < WASM_PAIRED_NUM_LIMBS; ++k) {
+        out1_u255[k] = static_cast<uint64_t>(wasm_i64x2_extract_lane(normalized[k], 0));
+        out2_u255[k] = static_cast<uint64_t>(wasm_i64x2_extract_lane(normalized[k], 1));
+    }
+
+    const auto out1 = pack_to_4x64_shr_1(out1_u255);
+    const auto out2 = pack_to_4x64_shr_1(out2_u255);
+    return { field<Params>{ out1[0], out1[1], out1[2], out1[3] }, field<Params>{ out2[0], out2[1], out2[2], out2[3] } };
+}
+
+// Pack two field elements (4x64) into the paired 5x51 SIMD layout: lane 0
+// carries lane0's limbs, lane 1 carries lane1's. Inputs are converted to
+// f64 via the bias trick (see i2f_v128) so they can feed ez_mul directly.
+template <class Params>
+BB_INLINE std::array<v128_t, WASM_PAIRED_NUM_LIMBS> pack_paired_lanes(const field<Params>& lane0,
+                                                                      const field<Params>& lane1) noexcept
+{
+    const auto l0 = split_to_5x51(lane0.data);
+    const auto l1 = split_to_5x51(lane1.data);
+    std::array<v128_t, WASM_PAIRED_NUM_LIMBS> out;
+    BB_FORCE_UNROLL
+    for (size_t k = 0; k < WASM_PAIRED_NUM_LIMBS; ++k) {
+        out[k] = i2f_v128(wasm_i64x2_make(static_cast<int64_t>(l0[k]), static_cast<int64_t>(l1[k])));
+    }
+    return out;
+}
+
+} // namespace detail
+} // namespace bb
+
+#endif
+
+namespace bb {
+
+template <class T>
+constexpr std::array<field<T>, 2> field<T>::paired_mul(const field& a,
+                                                       const field& b,
+                                                       const field& c,
+                                                       const field& d) noexcept
+{
+#if defined(__wasm_relaxed_simd__) && defined(__wasm__)
+    // The 5×51 layout itself only requires p < 2^254, but the current
+    // implementation-level coarse-output proof closes only for the top-limb
+    // range captured by WASM_PAIRED_MAX_MODULUS_3. Larger moduli fall back to
+    // the ordinary single-lane path.
+    if constexpr (T::modulus_3 <= detail::WASM_PAIRED_MAX_MODULUS_3) {
+        if (!std::is_constant_evaluated()) {
+            using namespace detail;
+
+            // Pack inputs into paired 5x51 SIMD lanes — lane 0 holds (a, b), lane 1 holds (c, d).
+            const auto a_vecs = pack_paired_lanes<T>(a, c);
+            const auto b_vecs = pack_paired_lanes<T>(b, d);
+
+            // Seed the 10 column accumulators with the FMA bias-cancellation values.
+            std::array<v128_t, 2 * WASM_PAIRED_NUM_LIMBS> ts;
+            BB_FORCE_UNROLL
+            for (size_t k = 0; k < 2 * WASM_PAIRED_NUM_LIMBS; ++k) {
+                ts[k] = wasm_i64x2_splat(make_initial(LO_BIAS_COUNTS[k], HI_BIAS_COUNTS[k]));
+            }
+
+            // 5x5 schoolbook: each row streams its p_hi forward into the next column,
+            // so every column is touched exactly once per row.
+            mul_accum_paired_row(a_vecs[0], b_vecs, std::span(ts).subspan<0, 6>());
+            mul_accum_paired_row(a_vecs[1], b_vecs, std::span(ts).subspan<1, 6>());
+            mul_accum_paired_row(a_vecs[2], b_vecs, std::span(ts).subspan<2, 6>());
+            mul_accum_paired_row(a_vecs[3], b_vecs, std::span(ts).subspan<3, 6>());
+            mul_accum_paired_row(a_vecs[4], b_vecs, std::span(ts).subspan<4, 6>());
+
+            return reduce_and_finalize_paired_rne<T>(ts);
+        }
+    }
+#endif
+    return { a * b, c * d };
+}
+
+template <class T> constexpr std::array<field<T>, 2> field<T>::paired_sqr(const field& a, const field& b) noexcept
+{
+#if defined(__wasm_relaxed_simd__) && defined(__wasm__)
+    // The 5×51 layout itself only requires p < 2^254, but the current
+    // implementation-level coarse-output proof closes only for the top-limb
+    // range captured by WASM_PAIRED_MAX_MODULUS_3. Larger moduli fall back to
+    // the ordinary single-lane path.
+    if constexpr (T::modulus_3 <= detail::WASM_PAIRED_MAX_MODULUS_3) {
+        if (!std::is_constant_evaluated()) {
+            using namespace detail;
+
+            // Pack inputs into paired 5x51 SIMD lanes — lane 0 holds a, lane 1 holds b.
+            const auto a_vecs = pack_paired_lanes<T>(a, b);
+
+            // Triangular schoolbook: accumulate off-diagonal a_i * a_j (i < j) products
+            // first, double them with an i64x2 self-add, then add the five diagonal
+            // a_i * a_i products. Bias seeds go in last so the doubling step doesn't
+            // double them.
+            std::array<v128_t, 2 * WASM_PAIRED_NUM_LIMBS> ts{};
+            mul_accum_paired_row(a_vecs[0],
+                                 std::array<v128_t, 4>{ a_vecs[1], a_vecs[2], a_vecs[3], a_vecs[4] },
+                                 std::span(ts).subspan<1, 5>());
+            mul_accum_paired_row(
+                a_vecs[1], std::array<v128_t, 3>{ a_vecs[2], a_vecs[3], a_vecs[4] }, std::span(ts).subspan<3, 4>());
+            mul_accum_paired_row(
+                a_vecs[2], std::array<v128_t, 2>{ a_vecs[3], a_vecs[4] }, std::span(ts).subspan<5, 3>());
+            mul_accum_paired_row(a_vecs[3], std::array<v128_t, 1>{ a_vecs[4] }, std::span(ts).subspan<7, 2>());
+
+            BB_FORCE_UNROLL
+            for (size_t k = 1; k < 2 * WASM_PAIRED_NUM_LIMBS - 1; ++k) {
+                ts[k] = wasm_i64x2_add(ts[k], ts[k]);
+            }
+
+            mul_accum_paired_row(a_vecs[0], std::array<v128_t, 1>{ a_vecs[0] }, std::span(ts).subspan<0, 2>());
+            mul_accum_paired_row(a_vecs[1], std::array<v128_t, 1>{ a_vecs[1] }, std::span(ts).subspan<2, 2>());
+            mul_accum_paired_row(a_vecs[2], std::array<v128_t, 1>{ a_vecs[2] }, std::span(ts).subspan<4, 2>());
+            mul_accum_paired_row(a_vecs[3], std::array<v128_t, 1>{ a_vecs[3] }, std::span(ts).subspan<6, 2>());
+            mul_accum_paired_row(a_vecs[4], std::array<v128_t, 1>{ a_vecs[4] }, std::span(ts).subspan<8, 2>());
+
+            // Add bias seeds. The doubled off-diagonals + diagonals produce the same
+            // per-column p_lo / p_hi histogram as a full 5x5 multiplication, so
+            // LO_BIAS_COUNTS / HI_BIAS_COUNTS apply unchanged.
+            BB_FORCE_UNROLL
+            for (size_t k = 0; k < 2 * WASM_PAIRED_NUM_LIMBS; ++k) {
+                ts[k] = wasm_i64x2_add(ts[k], wasm_i64x2_splat(make_initial(LO_BIAS_COUNTS[k], HI_BIAS_COUNTS[k])));
+            }
+
+            return reduce_and_finalize_paired_rne<T>(ts);
+        }
+    }
+#endif
+    return { a.sqr(), b.sqr() };
+}
+
+} // namespace bb

--- a/barretenberg/cpp/src/barretenberg/ecc/fields/parameter_helper.py
+++ b/barretenberg/cpp/src/barretenberg/ecc/fields/parameter_helper.py
@@ -106,15 +106,7 @@ def parse_field_params(s):
     # WASM parameters
     parameter_dictionary['modulus_wasm']=recover_element_from_parts('modulus_wasm',29)
 
-    parameter_dictionary['r_squared_wasm']=recover_element_from_parts('r_squared_wasm',64)
-
     parameter_dictionary['r_inv_wasm']=recover_element_from_parts('r_inv_wasm',29)
-
-    parameter_dictionary['cube_root_wasm']=recover_element_from_parts('cube_root_wasm',64)
-
-    parameter_dictionary['primitive_root_wasm']=recover_element_from_parts('primitive_root_wasm',64)
-
-    parameter_dictionary['coset_generator_wasm']=recover_element_from_parts('coset_generator_wasm',64)
 
     # Endomorphism parameters
     parameter_dictionary['endo_g1_lo']=recover_single_value_if_present('endo_g1_lo')
@@ -129,21 +121,11 @@ def parse_field_params(s):
 
     assert(parameter_dictionary['modulus']==parameter_dictionary['modulus_wasm']) # Check modulus representations are equivalent
     modulus=parameter_dictionary['modulus']
-    r_wasm_divided_by_r_regular=2**(261-256)
     assert(parameter_dictionary['r_squared']==pow(2,512,modulus)) # Check r_squared
-    assert(parameter_dictionary['r_squared_wasm']==pow(2,9*29*2,modulus)) # Check r_squared_wasm
-    assert(parameter_dictionary['cube_root']*r_wasm_divided_by_r_regular%modulus==parameter_dictionary['cube_root_wasm'] or
-            parameter_dictionary['cube_root']==0)
     assert(pow(parameter_dictionary['cube_root']*pow(2,-256,modulus),3,modulus)==1 or
             parameter_dictionary['cube_root']==0) # Check cubic root
-    assert(pow(parameter_dictionary['cube_root_wasm']*pow(2,-29*9,modulus),3,modulus)==1 or
-            parameter_dictionary['cube_root_wasm']==0) # Check cubic root for wasm
-    assert(parameter_dictionary['primitive_root']*r_wasm_divided_by_r_regular%modulus==parameter_dictionary['primitive_root_wasm']) # Check pritimitve roots are equivalent
     assert(parameter_dictionary['r_inv_x64']*(1<<64)%parameter_dictionary['modulus']==1)
     assert(parameter_dictionary['r_inv_wasm']*(1<<29)%parameter_dictionary['modulus']==1)
-    regular_coset_generator=parameter_dictionary['coset_generator']
-    wasm_coset_generator=parameter_dictionary['coset_generator_wasm']
-    assert(regular_coset_generator*r_wasm_divided_by_r_regular%modulus == wasm_coset_generator)
 
     return parameter_dictionary
 

--- a/barretenberg/cpp/src/barretenberg/ecc/fields/prime_field.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/fields/prime_field.test.cpp
@@ -31,23 +31,17 @@ auto& engine = numeric::get_debug_randomness();
 // Helper to create a field element whose internal (Montgomery) representation has exactly
 // the given limbs. This is done by constructing from the value and then calling
 // from_montgomery_form() to make the limbs directly represent the desired pattern.
-// Also verifies that the internal representation matches the expected limbs (on non-WASM only,
-// since WASM uses different internal representation during computation).
+// Also verifies that the internal representation matches the expected limbs.
 template <typename F> F create_element_with_limbs(uint64_t l0, uint64_t l1, uint64_t l2, uint64_t l3)
 {
     uint256_t val{ l0, l1, l2, l3 };
     F result(val);
     result.self_from_montgomery_form_reduced();
 
-// On WASM, the internal Montgomery multiplication uses 29-bit limbs and may produce
-// different (but equivalent) representations. Skip limb verification on WASM.
-#if defined(__SIZEOF_INT128__) && !defined(__wasm__)
-    // Verify the internal representation matches expected limbs
     EXPECT_EQ(result.data[0], l0);
     EXPECT_EQ(result.data[1], l1);
     EXPECT_EQ(result.data[2], l2);
     EXPECT_EQ(result.data[3], l3);
-#endif
 
     return result;
 }
@@ -202,6 +196,18 @@ TYPED_TEST(PrimeFieldTest, MultiplicationModular)
     EXPECT_EQ(uint256_t(c), expected);
 }
 
+TYPED_TEST(PrimeFieldTest, PairedMul)
+{
+    using F = TypeParam;
+    const F a = F::random_element();
+    const F b = F::random_element();
+    const F c = F::random_element();
+    const F d = F::random_element();
+    const auto [o1, o2] = F::paired_mul(a, b, c, d);
+    EXPECT_EQ(o1, a * b);
+    EXPECT_EQ(o2, c * d);
+}
+
 TYPED_TEST(PrimeFieldTest, SquaringModular)
 {
     using F = TypeParam;
@@ -215,6 +221,16 @@ TYPED_TEST(PrimeFieldTest, SquaringModular)
     uint256_t expected = (c_512 % uint512_t(F::modulus)).lo;
 
     EXPECT_EQ(uint256_t(c), expected);
+}
+
+TYPED_TEST(PrimeFieldTest, PairedSqr)
+{
+    using F = TypeParam;
+    const F a = F::random_element();
+    const F b = F::random_element();
+    const auto [o1, o2] = F::paired_sqr(a, b);
+    EXPECT_EQ(o1, a.sqr());
+    EXPECT_EQ(o2, b.sqr());
 }
 
 TYPED_TEST(PrimeFieldTest, Uint256Roundtrip)
@@ -239,6 +255,41 @@ TYPED_TEST(PrimeFieldTest, MontgomeryRoundtrip)
     F a = F::random_element();
     F b = a.from_montgomery_form().to_montgomery_form();
     EXPECT_EQ(a, b);
+}
+
+TYPED_TEST(PrimeFieldTest, PairedToMontgomeryForm)
+{
+    using F = TypeParam;
+
+    // Use random Montgomery-encoded field elements directly as random field elements.
+    // They may be coarse [0, 2p), but to_montgomery_form accepts valid internal residues.
+    F a = F::random_element();
+    F b = F::random_element();
+
+    F expected_a = a;
+    F expected_b = b;
+    expected_a.self_to_montgomery_form();
+    expected_b.self_to_montgomery_form();
+
+    const auto [out_a, out_b] = F::paired_to_montgomery_form(a, b);
+    EXPECT_EQ(out_a, expected_a);
+    EXPECT_EQ(out_b, expected_b);
+}
+
+TYPED_TEST(PrimeFieldTest, PairedFromMontgomeryForm)
+{
+    using F = TypeParam;
+    const F a = F::random_element();
+    const F b = F::random_element();
+
+    F expected_a = a;
+    F expected_b = b;
+    expected_a.self_from_montgomery_form();
+    expected_b.self_from_montgomery_form();
+
+    const auto [out_a, out_b] = F::paired_from_montgomery_form(a, b);
+    EXPECT_EQ(out_a, expected_a);
+    EXPECT_EQ(out_b, expected_b);
 }
 
 // ================================
@@ -551,7 +602,7 @@ TYPED_TEST(PrimeFieldTest, BoundaryArithmetic)
     using F = TypeParam;
     constexpr std::array<uint64_t, 3> offsets = { 1, 2, 3 };
 
-    for (uint64_t offset : offsets) {
+    for (const auto& offset : offsets) {
         F a;
         if constexpr (F::modulus.data[3] >= MODULUS_TOP_LIMB_LARGE_THRESHOLD) {
             // 256-bit fields: construct element with internal representation near 2^256 - offset.
@@ -599,6 +650,42 @@ TYPED_TEST(PrimeFieldTest, BoundaryArithmetic)
         F sq = a.sqr();
         uint512_t expected_sq = (uint512_t(a_val) * uint512_t(a_val)) % uint512_t(F::modulus);
         EXPECT_EQ(uint256_t(sq), expected_sq.lo) << "Sqr failed for offset " << offset;
+    }
+}
+
+TYPED_TEST(PrimeFieldTest, PairedBoundaryMul)
+{
+    using F = TypeParam;
+    constexpr std::array<uint64_t, 3> offsets = { 1, 2, 3 };
+
+    for (const auto& offset : offsets) {
+        F a;
+        if constexpr (F::modulus.data[3] >= MODULUS_TOP_LIMB_LARGE_THRESHOLD) {
+            // 256-bit fields: construct element with internal representation near 2^256 - offset.
+            // (p - offset) + (2^256 - p) = 2^256 - offset, which has field value -offset.
+            uint256_t two_256_minus_p = uint256_t(0) - F::modulus;
+            F two_256_minus_p_elt(two_256_minus_p);
+            two_256_minus_p_elt.self_from_montgomery_form_reduced();
+            F p_minus_offset(F::modulus - offset);
+            p_minus_offset.self_from_montgomery_form_reduced();
+            a = p_minus_offset + two_256_minus_p_elt;
+        } else {
+            // 254-bit fields: construct element with internal representation near 2p - (offset + 1).
+            // (p - 1) + (p - offset) = 2p - (offset + 1), which has field value -(offset + 1).
+            F p_minus_one(F::modulus - 1);
+            p_minus_one.self_from_montgomery_form_reduced();
+            F p_minus_offset(F::modulus - offset);
+            p_minus_offset.self_from_montgomery_form_reduced();
+            a = p_minus_one + p_minus_offset;
+        }
+
+        F b = F::random_element();
+        F c = F::random_element();
+        F d = a;
+
+        const auto [o1, o2] = F::paired_mul(a, b, c, d);
+        EXPECT_EQ(o1, a * b) << "lane 0 mismatch for offset " << offset;
+        EXPECT_EQ(o2, c * d) << "lane 1 mismatch for offset " << offset;
     }
 }
 

--- a/barretenberg/cpp/src/barretenberg/ecc/groups/element_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/groups/element_impl.hpp
@@ -91,20 +91,12 @@ template <class Fq, class Fr, class T> constexpr void element<Fq, Fr, T>::self_d
         }
     }
 
-    // T0 = x*x
-    Fq T0 = x.sqr();
+    // T0 = x*x ; T1 = y*y
+    auto [T0, T1] = Fq::paired_sqr(x, y);
 
-    // T1 = y*y
-    Fq T1 = y.sqr();
-
-    // T2 = T1*T1 = y*y*y*y
-    Fq T2 = T1.sqr();
-
-    // T1 = T1 + x = x + y*y
-    T1 += x;
-
-    // T1 = T1 * T1
-    T1.self_sqr();
+    // T2 = T1*T1 = y*y*y*y ; T1 = (T1 + x)^2
+    Fq T2;
+    std::tie(T2, T1) = Fq::paired_sqr(T1, T1 + x);
 
     // T3 = T0 + T2 = xx + y*y*y*y
     Fq T3 = T0 + T2;
@@ -122,15 +114,11 @@ template <class Fq, class Fr, class T> constexpr void element<Fq, Fr, T>::self_d
         T3 += (T::a * z.sqr().sqr());
     }
 
-    // z2 = 2*y*z
-    z += z;
-    z *= y;
+    // z2 = 2*y*z ; x2 = T3*T3
+    std::tie(z, x) = Fq::paired_mul(z + z, y, T3, T3);
 
     // T0 = 2T1
     T0 = T1 + T1;
-
-    // x2 = T3*T3
-    x = T3.sqr();
 
     // x2 = x2 - 2T1
     x -= T0;
@@ -176,14 +164,15 @@ constexpr element<Fq, Fr, T> element<Fq, Fr, T>::operator+=(const affine_element
     // T0 = z1.z1
     Fq T0 = z.sqr();
 
-    // T1 = x2.t0 - x1 = x2.z1.z1 - x1
-    Fq T1 = other.x * T0;
+    // T1 = x2.t0 = x2.z1.z1 ; T2 = T0.z1 = z1.z1.z1
+    auto [T1, T2] = Fq::paired_mul(other.x, T0, z, T0);
+    // T1 = T1 - x1
     T1 -= x;
 
-    // T2 = T0.z1 = z1.z1.z1
-    // T2 = T2.y2 - y1 = y2.z1.z1.z1 - y1
-    Fq T2 = z * T0;
-    T2 *= other.y;
+    // T2 = T2.y2 = y2.z1.z1.z1 ; T3 = T1*T1 = HH
+    Fq T3;
+    std::tie(T2, T3) = Fq::paired_mul(T2, other.y, T1, T1);
+    // T2 = T2 - y1
     T2 -= y;
 
     if (__builtin_expect(T1.is_zero(), 0)) {
@@ -200,44 +189,37 @@ constexpr element<Fq, Fr, T> element<Fq, Fr, T>::operator+=(const affine_element
     T2 += T2;
     z += T1;
 
-    // T3 = T1*T1 = HH
-    Fq T3 = T1.sqr();
-
     // z3 = z3 - z1z1 - HH
     T0 += T3;
 
-    // z3 = (z1 + H)*(z1 + H)
-    z.self_sqr();
+    // z3 = (z1 + H)*(z1 + H) ; R_sq = R*R
+    Fq R_sq;
+    std::tie(z, R_sq) = Fq::paired_sqr(z, T2);
     z -= T0;
 
     // T3 = 4HH
     T3 += T3;
     T3 += T3;
 
-    // T1 = T1*T3 = 4HHH
-    T1 *= T3;
-
-    // T3 = T3 * x1 = 4HH*x1
-    T3 *= x;
+    // T1 = T1*T3 = 4HHH ; T3 = T3 * x1 = 4HH*x1
+    std::tie(T1, T3) = Fq::paired_mul(T1, T3, T3, x);
 
     // T0 = 2T3
     T0 = T3 + T3;
 
     // T0 = T0 + T1 = 2(4HH*x1) + 4HHH
     T0 += T1;
-    x = T2.sqr();
+    x = R_sq;
 
-    // x3 = x3 - T0 = R*R - 8HH*x1 -4HHH
+    // x3 = x3 - T0 = R*R - 8HH*x1 - 4HHH
     x -= T0;
 
     // T3 = T3 - x3 = 4HH*x1 - x3
     T3 -= x;
 
-    T1 *= y;
+    // T1 = T1 * y1 = 4HHH*y1 ; y = T2 * T3 = R*(4HH*x1 - x3)
+    std::tie(T1, T3) = Fq::paired_mul(T1, y, T3, T2);
     T1 += T1;
-
-    // T3 = T2 * T3 = R*(4HH*x1 - x3)
-    T3 *= T2;
 
     // y3 = T3 - T1
     y = T3 - T1;
@@ -297,14 +279,19 @@ constexpr element<Fq, Fr, T> element<Fq, Fr, T>::operator+=(const element& other
             return *this;
         }
     }
-    Fq Z1Z1(z.sqr());
-    Fq Z2Z2(other.z.sqr());
-    Fq S2(Z1Z1 * z);
-    Fq U2(Z1Z1 * other.x);
-    S2 *= other.y;
-    Fq U1(Z2Z2 * x);
-    Fq S1(Z2Z2 * other.z);
-    S1 *= y;
+    // Z1Z1 = z1*z1 ; Z2Z2 = z2*z2
+    auto [Z1Z1, Z2Z2] = Fq::paired_sqr(z, other.z);
+
+    // S2 = Z1Z1*z1 = z1.z1.z1 ; U2 = Z1Z1*x2
+    Fq S2, U2;
+    std::tie(S2, U2) = Fq::paired_mul(Z1Z1, z, Z1Z1, other.x);
+
+    // S1 = Z2Z2*z2 = z2.z2.z2 ; U1 = Z2Z2*x1
+    Fq S1, U1;
+    std::tie(S1, U1) = Fq::paired_mul(Z2Z2, other.z, Z2Z2, x);
+
+    // S2 = S2*y2 = y2.z1.z1.z1 ; S1 = S1*y1 = y1.z2.z2.z2
+    std::tie(S2, S1) = Fq::paired_mul(S2, other.y, S1, y);
 
     Fq F(S2 - S1);
 
@@ -321,29 +308,26 @@ constexpr element<Fq, Fr, T> element<Fq, Fr, T>::operator+=(const element& other
 
     F += F;
 
-    Fq I(H + H);
-    I.self_sqr();
+    // I = (2H)^2 = 4HH ; x = (2F)^2 = R*R
+    Fq I;
+    std::tie(I, x) = Fq::paired_sqr(H + H, F);
 
-    Fq J(H * I);
-
-    U1 *= I;
+    // J = H*I = 4HHH ; U1 = U1*I
+    Fq J;
+    std::tie(J, U1) = Fq::paired_mul(H, I, U1, I);
 
     U2 = U1 + U1;
     U2 += J;
 
-    x = F.sqr();
-
     x -= U2;
 
-    J *= S1;
+    // J = J*S1 ; y = (U1-x)*F
+    std::tie(J, y) = Fq::paired_mul(J, S1, U1 - x, F);
     J += J;
-
-    y = U1 - x;
-
-    y *= F;
 
     y -= J;
 
+    // z3 = ((z1+z2)^2 - Z1Z1 - Z2Z2) * H
     z += other.z;
 
     Z1Z1 += Z2Z2;
@@ -685,42 +669,119 @@ __attribute__((always_inline)) inline void batch_affine_add_interleaved(AffineEl
                                                                         const size_t num_points,
                                                                         Fq* scratch_space) noexcept
 {
-    Fq batch_inversion_accumulator = Fq::one();
+    // Pair-stride: two independent accumulators let each iteration's two `acc *= dx`
+    // fold into one paired_mul (faster than two singles); tail handles odd pair counts.
+    Fq acc0 = Fq::one();
+    Fq acc1 = Fq::one();
+
+    const size_t num_pairs = num_points >> 1;
+    // Round down to an even pair count; odd remainder runs through the tail handlers.
+    const size_t num_unrolled_pairs = num_pairs & ~1ULL;
 
     // Forward pass: accumulate (x2 - x1) products for batch inversion
-    for (size_t i = 0; i < num_points; i += 2) {
+    for (size_t i = 0; i < num_unrolled_pairs * 2; i += 4) {
         scratch_space[i >> 1] = points[i].x + points[i + 1].x; // x1 + x2 (saved for later)
         points[i + 1].x -= points[i].x;                        // x2 - x1
         points[i + 1].y -= points[i].y;                        // y2 - y1
-        points[i + 1].y *= batch_inversion_accumulator;
-        batch_inversion_accumulator *= points[i + 1].x;
+
+        scratch_space[(i + 2) >> 1] = points[i + 2].x + points[i + 3].x; // x1 + x2 (saved for later)
+        points[i + 3].x -= points[i + 2].x;                              // x2 - x1
+        points[i + 3].y -= points[i + 2].y;                              // y2 - y1
+
+        {
+            const auto [r0, r1] = Fq::paired_mul(points[i + 1].y, acc0, points[i + 3].y, acc1);
+            points[i + 1].y = r0;
+            points[i + 3].y = r1;
+        }
+        {
+            const auto [r0, r1] = Fq::paired_mul(acc0, points[i + 1].x, acc1, points[i + 3].x);
+            acc0 = r0;
+            acc1 = r1;
+        }
     }
 
-    if (batch_inversion_accumulator == Fq::zero()) {
+    // Forward tail: odd leftover pair (folded into acc0 to keep acc1 lane balanced).
+    if (num_pairs & 1) {
+        size_t i = num_unrolled_pairs * 2;
+        scratch_space[i >> 1] = points[i].x + points[i + 1].x; // x1 + x2 (saved for later)
+        points[i + 1].x -= points[i].x;                        // x2 - x1
+        points[i + 1].y -= points[i].y;                        // y2 - y1
+        points[i + 1].y *= acc0;
+        acc0 *= points[i + 1].x;
+    }
+
+    // Recover per-lane inverses of each accumulator with one inversion:
+    //   1/acc0 = acc1 / (acc0 * acc1) ; 1/acc1 = acc0 / (acc0 * acc1)
+    Fq combined_acc = acc0 * acc1;
+    if (combined_acc == Fq::zero()) {
         throw_or_abort("attempted to invert zero in batch_affine_add_interleaved");
     }
-    batch_inversion_accumulator = batch_inversion_accumulator.invert();
+    combined_acc = combined_acc.invert();
+    Fq inv_acc0 = combined_acc * acc1;
+    Fq inv_acc1 = combined_acc * acc0;
 
     // Backward pass: complete inversions and compute additions
-    for (size_t i = num_points - 2; i < num_points; i -= 2) {
+    // Backward tail: same odd leftover, applied through inv_acc0 (mirrors the forward tail).
+    if (num_pairs & 1) {
+        size_t i = num_unrolled_pairs * 2;
         // lambda = (y2 - y1) / (x2 - x1)
-        points[i + 1].y *= batch_inversion_accumulator;
-        batch_inversion_accumulator *= points[i + 1].x;
+        points[i + 1].y *= inv_acc0;
+        inv_acc0 *= points[i + 1].x;
         points[i + 1].x = points[i + 1].y.sqr();
         // x3 = lambda^2 - (x1 + x2)
         points[(i + num_points) >> 1].x = points[i + 1].x - scratch_space[i >> 1];
-
-        if (i >= 2) {
-            __builtin_prefetch(points + i - 2);
-            __builtin_prefetch(points + i - 1);
-            __builtin_prefetch(points + ((i + num_points - 2) >> 1));
-            __builtin_prefetch(scratch_space + ((i - 2) >> 1));
-        }
 
         // y3 = lambda * (x1 - x3) - y1
         points[i].x -= points[(i + num_points) >> 1].x;
         points[i].x *= points[i + 1].y;
         points[(i + num_points) >> 1].y = points[i].x - points[i].y;
+    }
+
+    // Backward pass: recover inverses in reverse order (Montgomery's trick: process the later
+    // pair (i+3) before the earlier (i+1) so each iteration unwinds one product from inv_acc).
+    // Loop variable `i_plus_4` stays positive to avoid size_t underflow when the loop exits.
+    for (size_t i_plus_4 = num_unrolled_pairs * 2; i_plus_4 > 0; i_plus_4 -= 4) {
+        size_t i = i_plus_4 - 4;
+
+        // lambda = (y2 - y1) / (x2 - x1)
+        {
+            const auto [r0, r1] = Fq::paired_mul(points[i + 3].y, inv_acc1, points[i + 1].y, inv_acc0);
+            points[i + 3].y = r0;
+            points[i + 1].y = r1;
+        }
+        {
+            const auto [r0, r1] = Fq::paired_mul(inv_acc1, points[i + 3].x, inv_acc0, points[i + 1].x);
+            inv_acc1 = r0;
+            inv_acc0 = r1;
+        }
+
+        const auto [lambda_sq_hi, lambda_sq_lo] = Fq::paired_sqr(points[i + 3].y, points[i + 1].y);
+
+        // x3 = lambda^2 - (x1 + x2)
+        const Fq x3_hi = lambda_sq_hi - scratch_space[(i + 2) >> 1];
+        const Fq x3_lo = lambda_sq_lo - scratch_space[i >> 1];
+
+        if (i >= 4) {
+            __builtin_prefetch(points + i - 4);
+            __builtin_prefetch(points + i - 3);
+            __builtin_prefetch(points + i - 2);
+            __builtin_prefetch(points + i - 1);
+            __builtin_prefetch(points + ((i + num_points - 4) >> 1));
+            __builtin_prefetch(points + ((i + num_points - 2) >> 1));
+            __builtin_prefetch(scratch_space + ((i - 4) >> 1));
+            __builtin_prefetch(scratch_space + ((i - 2) >> 1));
+        }
+
+        // y3 = lambda * (x1 - x3) - y1
+        const Fq t1 = points[i + 2].x - x3_hi;
+        const Fq t0 = points[i].x - x3_lo;
+
+        const auto [y3_hi, y3_lo] = Fq::paired_mul(t1, points[i + 3].y, t0, points[i + 1].y);
+
+        points[(i + 2 + num_points) >> 1].x = x3_hi;
+        points[(i + num_points) >> 1].x = x3_lo;
+        points[(i + 2 + num_points) >> 1].y = y3_hi - points[i + 2].y;
+        points[(i + num_points) >> 1].y = y3_lo - points[i].y;
     }
 }
 

--- a/barretenberg/cpp/src/barretenberg/ecc/scalar_multiplication/scalar_multiplication.cpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/scalar_multiplication/scalar_multiplication.cpp
@@ -54,14 +54,28 @@ void MSM<Curve>::transform_scalar_and_get_nonzero_scalar_indices(std::span<typen
         }
         std::vector<uint32_t>& thread_scalar_indices = thread_indices[chunk.thread_index];
         thread_scalar_indices.reserve(range.size());
-        for (size_t i : range) {
-            BB_ASSERT_DEBUG(i < scalars.size());
-            auto& scalar = scalars[i];
-            scalar.self_from_montgomery_form_reduced();
 
-            if (!scalar.is_zero()) {
-                thread_scalar_indices.push_back(static_cast<uint32_t>(i));
+        const auto record_if_nonzero = [&](size_t k) {
+            if (!scalars[k].is_zero()) {
+                thread_scalar_indices.push_back(static_cast<uint32_t>(k));
             }
+        };
+
+        // Pair-stride: paired Montgomery conversion is faster than two singles; tail handles odd-length chunks.
+        const size_t range_start = range.front();
+        const size_t range_end = range_start + range.size();
+        BB_ASSERT_DEBUG(range_end <= scalars.size());
+        size_t i = range_start;
+        for (; i + 1 < range_end; i += 2) {
+            const auto [r0, r1] = ScalarField::paired_from_montgomery_form_reduced(scalars[i], scalars[i + 1]);
+            scalars[i] = r0;
+            scalars[i + 1] = r1;
+            record_if_nonzero(i);
+            record_if_nonzero(i + 1);
+        }
+        if (i < range_end) {
+            scalars[i].self_from_montgomery_form_reduced();
+            record_if_nonzero(i);
         }
     });
 
@@ -505,7 +519,15 @@ std::vector<typename Curve::AffineElement> MSM<Curve>::batch_multi_scalar_mul(
         for (auto& scalar_span : scalars) {
             parallel_for_range(scalar_span.size(), [&](size_t start, size_t end) {
                 BB_BENCH_TRACY_NAME("MSM::scalars_to_montgomery/chunk");
-                for (size_t i = start; i < end; ++i) {
+
+                // Pair-stride: paired Montgomery conversion is faster than two singles; tail handles odd-length chunks.
+                size_t i = start;
+                for (; i + 1 < end; i += 2) {
+                    const auto [r0, r1] = ScalarField::paired_to_montgomery_form(scalar_span[i], scalar_span[i + 1]);
+                    scalar_span[i] = r0;
+                    scalar_span[i + 1] = r1;
+                }
+                if (i < end) {
                     scalar_span[i].self_to_montgomery_form();
                 }
             });

--- a/barretenberg/cpp/src/barretenberg/polynomials/polynomial.cpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/polynomial.cpp
@@ -277,10 +277,25 @@ void Polynomial<Fr>::add_scaled_chunk(const ThreadChunk& chunk,
                                       PolynomialSpan<const Fr> other,
                                       const Fr& scaling_factor)
 {
-    // Iterate over the chunk of the other polynomial's range
-    for (size_t offset : chunk.range(other.size())) {
-        size_t index = other.start_index + offset;
-        at(index) += scaling_factor * other[index];
+    auto range = chunk.range(other.size());
+    if (range.empty()) {
+        return;
+    }
+    const size_t range_start = range.front();
+    const size_t range_end = range_start + range.size();
+
+    // Pair-stride: paired_mul is faster than two singles; tail handles odd-length chunks.
+    size_t i = range_start;
+    for (; i + 1 < range_end; i += 2) {
+        const size_t index0 = other.start_index + i;
+        const size_t index1 = other.start_index + i + 1;
+        const auto [product0, product1] = Fr::paired_mul(scaling_factor, other[index0], scaling_factor, other[index1]);
+        at(index0) += product0;
+        at(index1) += product1;
+    }
+    if (i < range_end) {
+        const size_t index0 = other.start_index + i;
+        at(index0) += scaling_factor * other[index0];
     }
 }
 

--- a/barretenberg/cpp/src/barretenberg/polynomials/univariate.hpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/univariate.hpp
@@ -169,15 +169,28 @@ template <class Fr, size_t domain_end> class Univariate {
     }
     Univariate& operator*=(const Univariate& other)
     {
-        for (size_t i = 0; i < LENGTH; ++i) {
-            evaluations[i] *= other.evaluations[i];
+        // Pair-stride: paired_mul is faster than two singles; tail elides at compile time for even LENGTH.
+        for (size_t i = 0; i + 1 < LENGTH; i += 2) {
+            const auto [r0, r1] =
+                Fr::paired_mul(evaluations[i], other.evaluations[i], evaluations[i + 1], other.evaluations[i + 1]);
+            evaluations[i] = r0;
+            evaluations[i + 1] = r1;
+        }
+        if constexpr (LENGTH % 2 == 1) {
+            evaluations[LENGTH - 1] *= other.evaluations[LENGTH - 1];
         }
         return *this;
     }
     Univariate& self_sqr()
     {
-        for (size_t i = 0; i < LENGTH; ++i) {
-            evaluations[i].self_sqr();
+        // Pair-stride: paired_sqr is faster than two singles; tail elides at compile time for even LENGTH.
+        for (size_t i = 0; i + 1 < LENGTH; i += 2) {
+            const auto [r0, r1] = Fr::paired_sqr(evaluations[i], evaluations[i + 1]);
+            evaluations[i] = r0;
+            evaluations[i + 1] = r1;
+        }
+        if constexpr (LENGTH % 2 == 1) {
+            evaluations[LENGTH - 1].self_sqr();
         }
         return *this;
     }
@@ -281,8 +294,15 @@ template <class Fr, size_t domain_end> class Univariate {
 
     Univariate& operator*=(const UnivariateView<Fr, domain_end>& view)
     {
-        for (size_t i = 0; i < LENGTH; ++i) {
-            evaluations[i] *= view.evaluations[i];
+        // Pair-stride: paired_mul is faster than two singles; tail elides at compile time for even LENGTH.
+        for (size_t i = 0; i + 1 < LENGTH; i += 2) {
+            const auto [r0, r1] =
+                Fr::paired_mul(evaluations[i], view.evaluations[i], evaluations[i + 1], view.evaluations[i + 1]);
+            evaluations[i] = r0;
+            evaluations[i + 1] = r1;
+        }
+        if constexpr (LENGTH % 2 == 1) {
+            evaluations[LENGTH - 1] *= view.evaluations[LENGTH - 1];
         }
         return *this;
     }

--- a/barretenberg/cpp/src/barretenberg/sumcheck/sumcheck.hpp
+++ b/barretenberg/cpp/src/barretenberg/sumcheck/sumcheck.hpp
@@ -675,8 +675,22 @@ template <typename Flavor> class SumcheckProver {
         parallel_for(source_view.size(), [&](size_t j) {
             BB_BENCH_TRACY_NAME("Sumcheck::partially_evaluate");
             const auto& poly = source_view[j];
-            size_t limit = poly.end_index();
-            for (size_t i = 0; i < limit; i += 2) {
+            const size_t limit = poly.end_index();
+            size_t i = 0;
+
+            // Pair-stride: paired_mul is faster than two singles; fuses two consecutive folds per iteration.
+            for (; i + 3 < limit; i += 4) {
+                const auto& base0 = poly[i];
+                const auto& base1 = poly[i + 2];
+                const FF delta0 = poly[i + 1] - base0;
+                const FF delta1 = poly[i + 3] - base1;
+
+                const auto [product0, product1] = FF::paired_mul(round_challenge, delta0, round_challenge, delta1);
+                dest_view[j].at(i >> 1) = base0 + product0;
+                dest_view[j].at((i + 2) >> 1) = base1 + product1;
+            }
+            // Tail: handles the final limit % 4 ∈ {1, 2, 3} remaining elements after the pair-stride loop.
+            for (; i < limit; i += 2) {
                 dest_view[j].at(i >> 1) = poly[i] + round_challenge * (poly[i + 1] - poly[i]);
             }
             dest_view[j].shrink_end_index((limit / 2) + (limit % 2));


### PR DESCRIPTION
## Summary

This PR reimplements WASM Montgomery multiplication, as a result reducing WASM Chonk proving time by **~19.8%** on `ChonkBench/Full/2` on a reference machine. The SIMD paired-multiplier design draws on World Foundation's [Provekit `rne::batched`](https://github.com/worldfnd/provekit/blob/main/skyscraper/bn254-multiplier/src/rne/batched.rs) Rust implementation of the same Emmart-Zheng anchored-FMA technique for BN254 with some adjustments to the reduction pipeline. 

The PR largely consists of two parts:

1. **Moving WASM Montgomery `R` to `2^256`.** The WASM `int29` backend previously used `R = 2^261` rather than the `R = 2^256` used by the native Montgomery. While `R = 2^261` simplified the reduction logic, it also required duplicating the Montgomery-form constants across the two versions. This PR transitions WASM to `R = 2^256`, matching native R, which lets us remove a lot of unnecessary backend-conditional code spread across 15+ files.
2. **Adding a new SIMD-paired Montgomery multiplier and applying it across the proving stack.** New paired WASM Montgomery kernels (`paired_mul`, `paired_sqr`) compute two independent Montgomery products in one relaxed-SIMD pipeline, and are almost as quick as a single original WASM Montgomery multiplication. This PR then wires the paired path into every call site that sits on the proving hot path (full list below).

## Reading guide

For the description of the new reduction strategy and the analysis of the new paired implementation, see:

- `barretenberg/cpp/src/barretenberg/ecc/fields/field_docs.md`

The most relevant sections are:

- `### WASM reduction primitives`
- `#### Paired rho-fold reduction`
- `#### Paired parity fix and halving`
- `### WASM Montgomery multiplication pipelines`
- `#### Paired WASM multiplication`

## Performance

> [!IMPORTANT]
> The benchmarks below were measured with **relaxed-SIMD enabled** (`-msimd128 -mrelaxed-simd`, reachable via the `wasm-threads-simd` CMake preset, or `make bb-cpp-wasm-threads-simd` from the repo root). The default `wasm-threads` build does **not** enable relaxed-SIMD, so the paired kernel will fall back to scalar and shows no speedup.
>
> See *Future work* below for the build-infrastructure adjustments needed to surface this win on Aztec's perf dashboard and in bb.js.

**Setup:** Wasmtime runtime, threads enabled (4), M1 Pro. 20 reps per benchmark.

| Metric | Before | After | Δ |
|---|---|---|---|
| Wallclock (`ChonkBench/Full/2`) | 24.68 s ± 1.6% | 19.80 s ± 0.7% | **−19.8%** |

### Per-proof-stage breakdown

The majority of wins come from the application of the new `paired_mul` and `paired_sqr` functions.

| Stage | Before | After | Δ |
|---|---|---|---|
| MSM `batch_multi_scalar_mul` (per-call) | 14.01 s | 10.13 s | **−27.7%** |
| MSM `evaluate_work_units` (cumulative across threads) | 50.17 s | 36.34 s | **−27.6%** |
| MSM `scalars_to_montgomery/chunk` | 414.9 ms | 199.9 ms | **−51.8%** |
| MSM `convert_scalars` (`from_montgomery_form_reduced`) | 394.8 ms | 310.2 ms | −21.4% |
| Sumcheck `partially_evaluate` | 2.85 s | 1.93 s | **−32.3%** |
| Polynomial `add_scaled` | 512.6 ms | 324.4 ms | **−36.7%** |
| `compute_univariate_with_row_skipping/chunk` | 4.55 s | 3.74 s | −17.8% |
| `CommitmentKey::commit` | 5.80 s | 4.21 s | −27.4% |
| Chonk `accumulate_and_fold` | 14.33 s | 11.01 s | −23.2% |

Note: some lower-level speedups also drive higher-level stage speedups — for example, the MSM `batch_multi_scalar_mul` win propagates into `CommitmentKey::commit`. The per-stage numbers should not be summed.

## Where paired_mul / paired_sqr is applied

| Subsystem | File | Operation |
|---|---|---|
| Field tower | `field2.hpp` | `Fq2::mul`, `Fq2::sqr` — paired in coefficient products |
| Field conversions | `field_impl.hpp`, `paired_field_impl_generic.hpp` | `paired_to_montgomery_form`, `paired_from_montgomery_form`, `_reduced` variants |
| Field exponentiation | `field_impl.hpp::pow` | Right-to-left binary exponentiation; per set bit fuses `(result*base, base*base)` into one `paired_mul`, with `mul + self_sqr` fallback on non-SIMD targets |
| EC point arithmetic | `element_impl.hpp::batch_affine_add_interleaved` | Forward/backward Montgomery batch inversion folds via paired_mul; pair-stride accumulators |
| MSM scalar transforms | `scalar_multiplication.cpp` | `transform_scalar_and_get_nonzero_scalar_indices` (in-Montgomery convert), `scalars_to_montgomery` (post-MSM restore) |
| Polynomial arithmetic | `polynomial.cpp::add_scaled_chunk` | `paired_mul(scaling_factor, x_a, scaling_factor, x_b)` |
| Univariate arithmetic | `univariate.hpp` | `operator*=(Univariate)`, `operator*=(View)`, `self_sqr` — compile-time tail via `if constexpr` since `LENGTH` is a template parameter |
| Sumcheck | `sumcheck.hpp::partially_evaluate` | Stride-4 cascade fusing two folds per iteration into one paired_mul |
| IPA | `ipa.hpp` | Vector folding inner loop |

## Future work: build infrastructure

This PR is intentionally scoped to the algorithmic changes and does not propose to switch the bb.js bundle to the SIMD preset. Doing so directly would break support on some platforms (notably Safari, which doesn't enable relaxed-SIMD without experimental flags; see [caniuse](https://caniuse.com/mdn-webassembly_relaxed-simd)). A solution is a delivery mechanism that handles SIMD-capable and non-SIMD-capable platforms gracefully, however it likely needs wider discussion on the right approach. If the direction of this PR is validated as useful, we will follow up with a delivery-mechanism PR to bring the speedup to end users and the dashboard.

That means that currently neither the `bb.js` users nor Aztec's performance dashboard will pick up the speedup automatically after this PR lands. To reproduce locally, build with the `wasm-threads-simd` preset (or `make bb-cpp-wasm-threads-simd` from the repo root).



