### PR TITLE
fix(pxe): only skip sync for stub overrides, not on-chain class overrides

### DIFF
--- a/yarn-project/pxe/src/pxe.ts
+++ b/yarn-project/pxe/src/pxe.ts
@@ -1013,9 +1013,20 @@ export class PXE {
         const contractFunctionSimulator = this.#getSimulatorForTx(overrides);
 
         if (hasOverriddenContracts) {
-          // Overridden contracts don't have a sync function, so calling sync on them would fail.
-          // We exclude them so the sync service skips them entirely.
-          this.contractSyncService.setExcludedFromSync(jobId, overriddenContracts);
+          // Skip sync for overrides whose class isn't published on chain (typically local-only stubs
+          // such as account stubs registered via pxe.registerContractClass). Their artifacts may be
+          // partial and break sync's nested utility execution. Overrides whose class is published
+          // on chain (e.g. fastForwardContractUpdate) have full artifacts and need sync to load
+          // pre-existing notes for the contract.
+          const stubAddresses = new Set<string>();
+          for (const [addrStr, override] of Object.entries(overrides!.contracts!)) {
+            if (!(await this.node.getContractClass(override.instance.currentContractClassId))) {
+              stubAddresses.add(addrStr);
+            }
+          }
+          if (stubAddresses.size > 0) {
+            this.contractSyncService.setExcludedFromSync(jobId, stubAddresses);
+          }
         }
 
         // Execution of private functions only; no proving, and no kernel logic.


### PR DESCRIPTION
## Summary

PXE skips sync for any contract that appears in `SimulationOverrides.contracts`. The skip was added to defend against a hostile no-op `sync_state` in account stubs (`simulated_*_account_contract`); without it, sync would trigger their `assert(false)`. The blanket skip is too coarse: it also blocks pre-existing notes from being loaded for *real* contract overrides (e.g. `fastForwardContractUpdate`), causing private calls that read prior state to fail with "Failed to get a note".

## Fix

Narrow the skip to overrides whose class id isn't published on chain. On-chain classes have full artifacts and need sync (upgrade-sim flow). Off-chain-only classes (account stubs registered via `pxe.registerContractClass`) keep being skipped — the existing behavior they need.

## Test plan

- [x] `e2e_kernelless_simulation` (account stub overrides): 7/7 pass
- [x] `e2e_contract_updates` (upgrade-sim via `fastForwardContractUpdate`, including the new private-dispatch test upstack): 6/6 pass