### PR TITLE
feat: deploy method refactor 2

### DIFF
--- a/playground/src/components/contract/components/CreateContractDialog.tsx
+++ b/playground/src/components/contract/components/CreateContractDialog.tsx
@@ -115,11 +115,16 @@ export function CreateContractDialog({
       if (publiclyDeploy) {
         const postDeployCtor = (instance: ContractInstanceWithAddress, wallet: Wallet) =>
           Contract.at(instance.address, contractArtifact, wallet);
-        deployMethod = DeployMethod.create(wallet, contractArtifact, postDeployCtor, parameters, initializer?.name, {
-          publicKeys: contract.publicKeys,
-          salt: contract.salt,
-          deployer: from,
-        });
+        deployMethod = DeployMethod.create(
+          wallet,
+          {
+            artifact: contractArtifact,
+            postDeployCtor,
+            args: parameters,
+            constructorNameOrArtifact: initializer?.name,
+          },
+          { publicKeys: contract.publicKeys, salt: contract.salt, deployer: from },
+        );
         opts = {
           from,
           fee: { paymentMethod: feePaymentMethod },

--- a/playground/src/components/contract/components/CreateContractDialog.tsx
+++ b/playground/src/components/contract/components/CreateContractDialog.tsx
@@ -115,7 +115,7 @@ export function CreateContractDialog({
       if (publiclyDeploy) {
         const postDeployCtor = (instance: ContractInstanceWithAddress, wallet: Wallet) =>
           Contract.at(instance.address, contractArtifact, wallet);
-        deployMethod = new DeployMethod(wallet, contractArtifact, postDeployCtor, parameters, initializer?.name, {
+        deployMethod = DeployMethod.create(wallet, contractArtifact, postDeployCtor, parameters, initializer?.name, {
           publicKeys: contract.publicKeys,
           salt: contract.salt,
           deployer: from,

--- a/yarn-project/aztec.js/src/api/contract.ts
+++ b/yarn-project/aztec.js/src/api/contract.ts
@@ -71,6 +71,7 @@ export {
   DeployMethod,
   type RequestDeployOptions,
   type SimulateDeployOptions,
+  UniversalDeployMethod,
 } from '../contract/deploy_method.js';
 export { waitForProven, type WaitForProvenOpts, DefaultWaitForProvenOpts } from '../contract/wait_for_proven.js';
 export { getGasLimits } from '../contract/get_gas_limits.js';

--- a/yarn-project/aztec.js/src/contract/contract.ts
+++ b/yarn-project/aztec.js/src/contract/contract.ts
@@ -43,6 +43,10 @@ export class Contract extends ContractBase {
   ) {
     const postDeployCtor = (instance: ContractInstanceWithAddress, wallet: Wallet) =>
       Contract.at(instance.address, artifact, wallet);
-    return DeployMethod.create(wallet, artifact, postDeployCtor, args, constructorName, instantiation);
+    return DeployMethod.create(
+      wallet,
+      { artifact, postDeployCtor, args, constructorNameOrArtifact: constructorName },
+      instantiation,
+    );
   }
 }

--- a/yarn-project/aztec.js/src/contract/contract.ts
+++ b/yarn-project/aztec.js/src/contract/contract.ts
@@ -43,6 +43,6 @@ export class Contract extends ContractBase {
   ) {
     const postDeployCtor = (instance: ContractInstanceWithAddress, wallet: Wallet) =>
       Contract.at(instance.address, artifact, wallet);
-    return new DeployMethod(wallet, artifact, postDeployCtor, args, constructorName, instantiation);
+    return DeployMethod.create(wallet, artifact, postDeployCtor, args, constructorName, instantiation);
   }
 }

--- a/yarn-project/aztec.js/src/contract/deploy_method.test.ts
+++ b/yarn-project/aztec.js/src/contract/deploy_method.test.ts
@@ -14,48 +14,33 @@ import { NO_FROM } from './interaction_options.js';
 
 describe('DeployMethod', () => {
   let wallet: MockProxy<Wallet>;
-
   beforeEach(() => {
     wallet = mock<Wallet>();
     wallet.registerContract.mockResolvedValue({} as ContractInstanceWithAddress);
     wallet.getContractClassMetadata.mockResolvedValue({ isContractClassPubliclyRegistered: true } as any);
     wallet.getContractMetadata.mockResolvedValue({ isContractPubliclyDeployed: true } as any);
-  });
-
-  /** Builds a `TxSimulationResultWithAppOffset` mock that satisfies what `DeployMethod.simulate` reads. */
+  }); /** Builds a `TxSimulationResultWithAppOffset` mock that satisfies what `DeployMethod.simulate` reads. */
   const makeSimulateResult = (offchainEffects: OffchainEffect[] = [], anchorBlockTimestamp = 0n) => {
     const txSimResult = mock<TxSimulationResultWithAppOffset>();
     Object.defineProperty(txSimResult, 'offchainEffects', { value: offchainEffects });
     Object.defineProperty(txSimResult, 'publicInputs', {
-      value: {
-        constants: { anchorBlockHeader: { globalVariables: { timestamp: anchorBlockTimestamp } } },
-      },
+      value: { constants: { anchorBlockHeader: { globalVariables: { timestamp: anchorBlockTimestamp } } } },
     });
     Object.defineProperty(txSimResult, 'stats', { value: {} });
-    Object.defineProperty(txSimResult, 'gasUsed', {
-      value: { totalGas: Gas.empty(), teardownGas: Gas.empty() },
-    });
+    Object.defineProperty(txSimResult, 'gasUsed', { value: { totalGas: Gas.empty(), teardownGas: Gas.empty() } });
     return txSimResult;
   };
-
   it('should extract offchain messages with anchor block timestamp on simulate', async () => {
     const recipient = await AztecAddress.random();
     const contractAddress = await AztecAddress.random();
     const msgPayload = [Fr.random(), Fr.random()];
     const anchorBlockTimestamp = 42000n;
-
     const offchainEffects: OffchainEffect[] = [
-      {
-        data: [OFFCHAIN_MESSAGE_IDENTIFIER, recipient.toField(), ...msgPayload],
-        contractAddress,
-      },
+      { data: [OFFCHAIN_MESSAGE_IDENTIFIER, recipient.toField(), ...msgPayload], contractAddress },
     ];
-
     wallet.simulateTx.mockResolvedValue(makeSimulateResult(offchainEffects, anchorBlockTimestamp));
-
     const deploy = Contract.deploy(wallet, testContractArtifact, []);
     const result = await deploy.simulate({ from: await AztecAddress.random() });
-
     expect(result.offchainMessages).toHaveLength(1);
     expect(result.offchainMessages[0]).toEqual({
       recipient,
@@ -65,12 +50,10 @@ describe('DeployMethod', () => {
     });
     expect(result.offchainEffects).toEqual([]);
   });
-
   describe('deployer locking and address stability', () => {
     let alice: AztecAddress;
     let bob: AztecAddress;
     const salt = new Fr(0x1234n);
-
     beforeEach(async () => {
       alice = await AztecAddress.random();
       bob = await AztecAddress.random();
@@ -81,13 +64,11 @@ describe('DeployMethod', () => {
         receipt: { txHash: { hash: 'tx-hash' } },
       } as any);
     });
-
     /**
      * Computes the expected address for our test artifact under the given deployer/salt, using
      * the same protocol-level helper that `DeployMethod` calls internally. Tests assert against
      * this value to confirm `DeployMethod` produces the canonical address.
-     */
-    const expectedAddress = async (deployer: AztecAddress) =>
+     */ const expectedAddress = async (deployer: AztecAddress) =>
       (
         await getContractInstanceFromInstantiationParams(testContractArtifact, {
           constructorArgs: [],
@@ -97,34 +78,26 @@ describe('DeployMethod', () => {
           constructorArtifact: undefined,
         })
       ).address;
-
     it('matches the standalone instantiation helper when locked at construction with deployer', async () => {
       const deploy = Contract.deploy(wallet, testContractArtifact, [], undefined, { salt, deployer: alice });
       const expected = await expectedAddress(alice);
       expect(await deploy.getAddress()).toEqual(expected);
     });
-
     it('matches the standalone instantiation helper when locked at construction with universalDeploy', async () => {
       const deploy = Contract.deploy(wallet, testContractArtifact, [], undefined, { salt, universalDeploy: true });
       const expected = await expectedAddress(AztecAddress.ZERO);
       expect(await deploy.getAddress()).toEqual(expected);
     });
-
     it('keeps the address stable across simulate then send when lazy-locking from `from`', async () => {
       const deploy = Contract.deploy(wallet, testContractArtifact, [], undefined, { salt });
-
       const expected = await expectedAddress(alice);
-
       await deploy.simulate({ from: alice });
       const afterSimulate = await deploy.getAddress();
-
       await deploy.send({ from: alice });
       const afterSend = await deploy.getAddress();
-
       expect(afterSimulate).toEqual(afterSend);
       expect(afterSimulate).toEqual(expected);
     });
-
     it('throws on getInstance / getAddress / getPartialAddress before any send-side call when nothing is locked', async () => {
       const deploy = Contract.deploy(wallet, testContractArtifact, [], undefined, { salt });
       // `getInstance` throws synchronously; `getAddress` / `getPartialAddress` are async and reject.
@@ -132,34 +105,28 @@ describe('DeployMethod', () => {
       await expect(deploy.getAddress()).rejects.toThrow(/deployer is not yet locked/);
       await expect(deploy.getPartialAddress()).rejects.toThrow(/deployer is not yet locked/);
     });
-
     it('rejects mutually exclusive `deployer` and `universalDeploy` at construction', () => {
       expect(() =>
         Contract.deploy(wallet, testContractArtifact, [], undefined, { salt, deployer: alice, universalDeploy: true }),
       ).toThrow(/mutually exclusive/);
     });
-
     it('throws when send-time `from` would imply a different deployer than the one locked at construction', async () => {
       const deploy = Contract.deploy(wallet, testContractArtifact, [], undefined, { salt, deployer: alice });
       await expect(deploy.send({ from: bob })).rejects.toThrow(/Deployer for this DeployMethod is locked/);
     });
-
     it('allows any sender when locked to universal at construction, and the address is stable', async () => {
       const deploy = Contract.deploy(wallet, testContractArtifact, [], undefined, { salt, universalDeploy: true });
       const expected = await expectedAddress(AztecAddress.ZERO);
-
       await expect(deploy.send({ from: alice })).resolves.toBeDefined();
       expect(await deploy.getAddress()).toEqual(expected);
       await expect(deploy.send({ from: bob })).resolves.toBeDefined();
       expect(await deploy.getAddress()).toEqual(expected);
     });
-
     it('throws on a second lock `from` after lazy-locking from the first', async () => {
       const deploy = Contract.deploy(wallet, testContractArtifact, [], undefined, { salt });
       await deploy.simulate({ from: alice });
       await expect(deploy.send({ from: bob })).rejects.toThrow(/Deployer for this DeployMethod is locked/);
     });
-
     it('locks to universal when `from` is NO_FROM', async () => {
       const deploy = Contract.deploy(wallet, testContractArtifact, [], undefined, { salt });
       await deploy.send({ from: NO_FROM });

--- a/yarn-project/aztec.js/src/contract/deploy_method.test.ts
+++ b/yarn-project/aztec.js/src/contract/deploy_method.test.ts
@@ -19,7 +19,9 @@ describe('DeployMethod', () => {
     wallet.registerContract.mockResolvedValue({} as ContractInstanceWithAddress);
     wallet.getContractClassMetadata.mockResolvedValue({ isContractClassPubliclyRegistered: true } as any);
     wallet.getContractMetadata.mockResolvedValue({ isContractPubliclyDeployed: true } as any);
-  }); /** Builds a `TxSimulationResultWithAppOffset` mock that satisfies what `DeployMethod.simulate` reads. */
+  });
+
+  /** Builds a `TxSimulationResultWithAppOffset` mock that satisfies what `DeployMethod.simulate` reads. */
   const makeSimulateResult = (offchainEffects: OffchainEffect[] = [], anchorBlockTimestamp = 0n) => {
     const txSimResult = mock<TxSimulationResultWithAppOffset>();
     Object.defineProperty(txSimResult, 'offchainEffects', { value: offchainEffects });
@@ -30,6 +32,7 @@ describe('DeployMethod', () => {
     Object.defineProperty(txSimResult, 'gasUsed', { value: { totalGas: Gas.empty(), teardownGas: Gas.empty() } });
     return txSimResult;
   };
+
   it('should extract offchain messages with anchor block timestamp on simulate', async () => {
     const recipient = await AztecAddress.random();
     const contractAddress = await AztecAddress.random();
@@ -50,10 +53,12 @@ describe('DeployMethod', () => {
     });
     expect(result.offchainEffects).toEqual([]);
   });
+
   describe('deployer locking and address stability', () => {
     let alice: AztecAddress;
     let bob: AztecAddress;
     const salt = new Fr(0x1234n);
+
     beforeEach(async () => {
       alice = await AztecAddress.random();
       bob = await AztecAddress.random();
@@ -64,11 +69,13 @@ describe('DeployMethod', () => {
         receipt: { txHash: { hash: 'tx-hash' } },
       } as any);
     });
+
     /**
      * Computes the expected address for our test artifact under the given deployer/salt, using
      * the same protocol-level helper that `DeployMethod` calls internally. Tests assert against
      * this value to confirm `DeployMethod` produces the canonical address.
-     */ const expectedAddress = async (deployer: AztecAddress) =>
+     */
+    const expectedAddress = async (deployer: AztecAddress) =>
       (
         await getContractInstanceFromInstantiationParams(testContractArtifact, {
           constructorArgs: [],
@@ -78,16 +85,19 @@ describe('DeployMethod', () => {
           constructorArtifact: undefined,
         })
       ).address;
+
     it('matches the standalone instantiation helper when locked at construction with deployer', async () => {
       const deploy = Contract.deploy(wallet, testContractArtifact, [], undefined, { salt, deployer: alice });
       const expected = await expectedAddress(alice);
       expect(await deploy.getAddress()).toEqual(expected);
     });
+
     it('matches the standalone instantiation helper when locked at construction with universalDeploy', async () => {
       const deploy = Contract.deploy(wallet, testContractArtifact, [], undefined, { salt, universalDeploy: true });
       const expected = await expectedAddress(AztecAddress.ZERO);
       expect(await deploy.getAddress()).toEqual(expected);
     });
+
     it('keeps the address stable across simulate then send when lazy-locking from `from`', async () => {
       const deploy = Contract.deploy(wallet, testContractArtifact, [], undefined, { salt });
       const expected = await expectedAddress(alice);
@@ -98,6 +108,7 @@ describe('DeployMethod', () => {
       expect(afterSimulate).toEqual(afterSend);
       expect(afterSimulate).toEqual(expected);
     });
+
     it('throws on getInstance / getAddress / getPartialAddress before any send-side call when nothing is locked', async () => {
       const deploy = Contract.deploy(wallet, testContractArtifact, [], undefined, { salt });
       // `getInstance` throws synchronously; `getAddress` / `getPartialAddress` are async and reject.
@@ -105,15 +116,18 @@ describe('DeployMethod', () => {
       await expect(deploy.getAddress()).rejects.toThrow(/deployer is not yet locked/);
       await expect(deploy.getPartialAddress()).rejects.toThrow(/deployer is not yet locked/);
     });
+
     it('rejects mutually exclusive `deployer` and `universalDeploy` at construction', () => {
       expect(() =>
         Contract.deploy(wallet, testContractArtifact, [], undefined, { salt, deployer: alice, universalDeploy: true }),
       ).toThrow(/mutually exclusive/);
     });
+
     it('throws when send-time `from` would imply a different deployer than the one locked at construction', async () => {
       const deploy = Contract.deploy(wallet, testContractArtifact, [], undefined, { salt, deployer: alice });
       await expect(deploy.send({ from: bob })).rejects.toThrow(/Deployer for this DeployMethod is locked/);
     });
+
     it('allows any sender when locked to universal at construction, and the address is stable', async () => {
       const deploy = Contract.deploy(wallet, testContractArtifact, [], undefined, { salt, universalDeploy: true });
       const expected = await expectedAddress(AztecAddress.ZERO);
@@ -122,11 +136,13 @@ describe('DeployMethod', () => {
       await expect(deploy.send({ from: bob })).resolves.toBeDefined();
       expect(await deploy.getAddress()).toEqual(expected);
     });
+
     it('throws on a second lock `from` after lazy-locking from the first', async () => {
       const deploy = Contract.deploy(wallet, testContractArtifact, [], undefined, { salt });
       await deploy.simulate({ from: alice });
       await expect(deploy.send({ from: bob })).rejects.toThrow(/Deployer for this DeployMethod is locked/);
     });
+
     it('locks to universal when `from` is NO_FROM', async () => {
       const deploy = Contract.deploy(wallet, testContractArtifact, [], undefined, { salt });
       await deploy.send({ from: NO_FROM });

--- a/yarn-project/aztec.js/src/contract/deploy_method.ts
+++ b/yarn-project/aztec.js/src/contract/deploy_method.ts
@@ -70,7 +70,7 @@ export type DeployInstantiationOptions = {
 };
 
 /**
- * Address-derivation inputs shared by all flavors. {@link BoundInstantiationOptions},
+ * Address-derivation inputs shared by all deploy methods. {@link BoundInstantiationOptions},
  * {@link UniversalInstantiationOptions}, and {@link PendingInstantiationOptions} narrow this
  * shape to forbid the fields that don't apply to a given flavor at the type level.
  */
@@ -770,7 +770,7 @@ export class PendingDeployMethod<TContract extends ContractBase = ContractBase> 
   }
 
   /**
-   * Returns the locked deployer once promotion has happened. Throws while still pending — the
+   * Returns the locked deployer once it has happened. Throws while still pending — the
    * address would otherwise differ from what `send()` ends up deploying.
    */
   public getDeployerAddress(): AztecAddress {

--- a/yarn-project/aztec.js/src/contract/deploy_method.ts
+++ b/yarn-project/aztec.js/src/contract/deploy_method.ts
@@ -70,6 +70,52 @@ export type DeployInstantiationOptions = {
 };
 
 /**
+ * Address-derivation inputs shared by all flavors. {@link OwnedInstantiationOptions},
+ * {@link UniversalInstantiationOptions}, and {@link PendingInstantiationOptions} narrow this
+ * shape to forbid the fields that don't apply to a given flavor at the type level.
+ */
+type SharedInstantiationOptions = {
+  /** Salt used to derive the contract address. Defaults to a random Fr. */
+  salt?: Fr;
+  /** Public keys mixed into the address. Defaults to `PublicKeys.default()`. */
+  publicKeys?: PublicKeys;
+};
+
+/**
+ * Narrowed `DeployInstantiationOptions` accepted by {@link OwnedDeployMethod}: requires a
+ * concrete `deployer` and forbids `universalDeploy`. The runtime check that `deployer` is
+ * non-zero stays as defense in depth (it's a value-level invariant the type system can't model).
+ */
+export type OwnedInstantiationOptions = SharedInstantiationOptions & {
+  /** Concrete deployer mixed into the address preimage. Required, must be non-zero. */
+  deployer: AztecAddress;
+  /** Forbidden on `OwnedDeployMethod`; use `UniversalDeployMethod` for universal deploys. */
+  universalDeploy?: never;
+};
+
+/**
+ * Narrowed `DeployInstantiationOptions` accepted by {@link UniversalDeployMethod}: forbids
+ * `deployer` and requires `universalDeploy: true` (so the call site reads as a universal deploy).
+ */
+export type UniversalInstantiationOptions = SharedInstantiationOptions & {
+  /** Forbidden on `UniversalDeployMethod`; use `OwnedDeployMethod` if you need a concrete deployer. */
+  deployer?: never;
+  /** Marks this as a universal deploy. Required for clarity at the call site. */
+  universalDeploy: true;
+};
+
+/**
+ * Narrowed `DeployInstantiationOptions` accepted by {@link PendingDeployMethod}: forbids both
+ * `deployer` and `universalDeploy`. The deploy is locked from the first send-time `from` instead.
+ */
+export type PendingInstantiationOptions = SharedInstantiationOptions & {
+  /** Forbidden on `PendingDeployMethod`; use `OwnedDeployMethod` for a concrete deployer. */
+  deployer?: never;
+  /** Forbidden on `PendingDeployMethod`; use `UniversalDeployMethod` for a universal deploy. */
+  universalDeploy?: never;
+};
+
+/**
  * Options for deploying a contract on the Aztec network.
  * Controls publication and registration policy for this deployment. Address-affecting parameters
  * (salt, deployer, publicKeys, constructor and args) are passed at construction time.
@@ -258,24 +304,44 @@ export abstract class DeployMethod<TContract extends ContractBase = ContractBase
     if (instantiation.deployer !== undefined && instantiation.universalDeploy) {
       throw new Error('DeployInstantiationOptions: `deployer` and `universalDeploy` are mutually exclusive.');
     }
-    const ctorArgs = [
+    const { salt, publicKeys, deployer, universalDeploy } = instantiation;
+    if (universalDeploy) {
+      return new UniversalDeployMethod<TContract>(
+        wallet,
+        artifact,
+        postDeployCtor,
+        args,
+        constructorNameOrArtifact,
+        { salt, publicKeys, universalDeploy: true },
+        authWitnesses,
+        capsules,
+        extraHashedArgs,
+      );
+    }
+    if (deployer !== undefined) {
+      return new OwnedDeployMethod<TContract>(
+        wallet,
+        artifact,
+        postDeployCtor,
+        args,
+        constructorNameOrArtifact,
+        { salt, publicKeys, deployer },
+        authWitnesses,
+        capsules,
+        extraHashedArgs,
+      );
+    }
+    return new PendingDeployMethod<TContract>(
       wallet,
       artifact,
       postDeployCtor,
       args,
       constructorNameOrArtifact,
-      instantiation,
+      { salt, publicKeys },
       authWitnesses,
       capsules,
       extraHashedArgs,
-    ] as const;
-    if (instantiation.universalDeploy) {
-      return new UniversalDeployMethod<TContract>(...ctorArgs);
-    }
-    if (instantiation.deployer !== undefined) {
-      return new OwnedDeployMethod<TContract>(...ctorArgs);
-    }
-    return new PendingDeployMethod<TContract>(...ctorArgs);
+    );
   }
 
   /**
@@ -602,16 +668,15 @@ export class OwnedDeployMethod<TContract extends ContractBase = ContractBase> ex
     wallet: Wallet,
     artifact: ContractArtifact,
     postDeployCtor: (instance: ContractInstanceWithAddress, wallet: Wallet) => TContract,
-    args: any[] = [],
-    constructorNameOrArtifact?: string | FunctionArtifact,
-    instantiation: DeployInstantiationOptions = {},
+    args: any[],
+    constructorNameOrArtifact: string | FunctionArtifact | undefined,
+    instantiation: OwnedInstantiationOptions,
     authWitnesses: AuthWitness[] = [],
     capsules: Capsule[] = [],
     extraHashedArgs: HashedValues[] = [],
   ) {
-    if (instantiation.deployer === undefined) {
-      throw new Error('OwnedDeployMethod requires `deployer` in instantiation options.');
-    }
+    // `OwnedInstantiationOptions` requires a `deployer` and forbids `universalDeploy` at the type
+    // level. We still reject `AztecAddress.ZERO` here because the type system can't model it.
     if (instantiation.deployer.equals(AztecAddress.ZERO)) {
       throw new Error(
         'OwnedDeployMethod requires a non-zero `deployer`; use `UniversalDeployMethod` (`{ universalDeploy: true }`) for universal deploys.',
@@ -668,16 +733,15 @@ export class UniversalDeployMethod<TContract extends ContractBase = ContractBase
     wallet: Wallet,
     artifact: ContractArtifact,
     postDeployCtor: (instance: ContractInstanceWithAddress, wallet: Wallet) => TContract,
-    args: any[] = [],
-    constructorNameOrArtifact?: string | FunctionArtifact,
-    instantiation: DeployInstantiationOptions = {},
+    args: any[],
+    constructorNameOrArtifact: string | FunctionArtifact | undefined,
+    instantiation: UniversalInstantiationOptions,
     authWitnesses: AuthWitness[] = [],
     capsules: Capsule[] = [],
     extraHashedArgs: HashedValues[] = [],
   ) {
-    if (instantiation.deployer !== undefined) {
-      throw new Error('UniversalDeployMethod cannot accept a `deployer`; use `OwnedDeployMethod` instead.');
-    }
+    // `UniversalInstantiationOptions` forbids `deployer` and requires `universalDeploy: true` at
+    // the type level — no runtime check is needed.
     super(
       wallet,
       artifact,
@@ -733,18 +797,15 @@ export class PendingDeployMethod<TContract extends ContractBase = ContractBase> 
     wallet: Wallet,
     artifact: ContractArtifact,
     postDeployCtor: (instance: ContractInstanceWithAddress, wallet: Wallet) => TContract,
-    args: any[] = [],
-    constructorNameOrArtifact?: string | FunctionArtifact,
-    instantiation: DeployInstantiationOptions = {},
+    args: any[],
+    constructorNameOrArtifact: string | FunctionArtifact | undefined,
+    instantiation: PendingInstantiationOptions = {},
     authWitnesses: AuthWitness[] = [],
     capsules: Capsule[] = [],
     extraHashedArgs: HashedValues[] = [],
   ) {
-    if (instantiation.deployer !== undefined || instantiation.universalDeploy) {
-      throw new Error(
-        'PendingDeployMethod cannot accept `deployer` or `universalDeploy: true`; use `OwnedDeployMethod` or `UniversalDeployMethod` instead.',
-      );
-    }
+    // `PendingInstantiationOptions` forbids both `deployer` and `universalDeploy` at the type
+    // level — no runtime check is needed.
     super(
       wallet,
       artifact,
@@ -805,25 +866,32 @@ export class PendingDeployMethod<TContract extends ContractBase = ContractBase> 
   #promoteFrom(
     from: SendInteractionOptionsWithoutWait['from'] | undefined,
   ): OwnedDeployMethod<TContract> | UniversalDeployMethod<TContract> {
-    const ctorArgs = [
-      this.wallet,
-      this.artifact,
-      this.postDeployCtor,
-      this.args,
-      this.constructorArtifact?.name,
-    ] as const;
-    const tail = [this.authWitnesses, this.capsules, this.extraHashedArgs] as const;
+    const { wallet, artifact, postDeployCtor, args, salt, publicKeys, authWitnesses, capsules, extraHashedArgs } =
+      this;
+    const constructorName = this.constructorArtifact?.name;
     if (from === undefined || from === NO_FROM) {
       return new UniversalDeployMethod<TContract>(
-        ...ctorArgs,
-        { salt: this.salt, publicKeys: this.publicKeys, universalDeploy: true },
-        ...tail,
+        wallet,
+        artifact,
+        postDeployCtor,
+        args,
+        constructorName,
+        { salt, publicKeys, universalDeploy: true },
+        authWitnesses,
+        capsules,
+        extraHashedArgs,
       );
     }
     return new OwnedDeployMethod<TContract>(
-      ...ctorArgs,
-      { salt: this.salt, publicKeys: this.publicKeys, deployer: from },
-      ...tail,
+      wallet,
+      artifact,
+      postDeployCtor,
+      args,
+      constructorName,
+      { salt, publicKeys, deployer: from },
+      authWitnesses,
+      capsules,
+      extraHashedArgs,
     );
   }
 }

--- a/yarn-project/aztec.js/src/contract/deploy_method.ts
+++ b/yarn-project/aztec.js/src/contract/deploy_method.ts
@@ -70,7 +70,7 @@ export type DeployInstantiationOptions = {
 };
 
 /**
- * Address-derivation inputs shared by all flavors. {@link OwnedInstantiationOptions},
+ * Address-derivation inputs shared by all flavors. {@link BoundInstantiationOptions},
  * {@link UniversalInstantiationOptions}, and {@link PendingInstantiationOptions} narrow this
  * shape to forbid the fields that don't apply to a given flavor at the type level.
  */
@@ -82,14 +82,14 @@ type SharedInstantiationOptions = {
 };
 
 /**
- * Narrowed `DeployInstantiationOptions` accepted by {@link OwnedDeployMethod}: requires a
+ * Narrowed `DeployInstantiationOptions` accepted by {@link BoundDeployMethod}: requires a
  * concrete `deployer` and forbids `universalDeploy`. The runtime check that `deployer` is
  * non-zero stays as defense in depth (it's a value-level invariant the type system can't model).
  */
-export type OwnedInstantiationOptions = SharedInstantiationOptions & {
+export type BoundInstantiationOptions = SharedInstantiationOptions & {
   /** Concrete deployer mixed into the address preimage. Required, must be non-zero. */
   deployer: AztecAddress;
-  /** Forbidden on `OwnedDeployMethod`; use `UniversalDeployMethod` for universal deploys. */
+  /** Forbidden on `BoundDeployMethod`; use `UniversalDeployMethod` for universal deploys. */
   universalDeploy?: never;
 };
 
@@ -98,7 +98,7 @@ export type OwnedInstantiationOptions = SharedInstantiationOptions & {
  * `deployer` and requires `universalDeploy: true` (so the call site reads as a universal deploy).
  */
 export type UniversalInstantiationOptions = SharedInstantiationOptions & {
-  /** Forbidden on `UniversalDeployMethod`; use `OwnedDeployMethod` if you need a concrete deployer. */
+  /** Forbidden on `UniversalDeployMethod`; use `BoundDeployMethod` if you need a concrete deployer. */
   deployer?: never;
   /** Marks this as a universal deploy. Required for clarity at the call site. */
   universalDeploy: true;
@@ -109,16 +109,41 @@ export type UniversalInstantiationOptions = SharedInstantiationOptions & {
  * `deployer` and `universalDeploy`. The deploy is locked from the first send-time `from` instead.
  */
 export type PendingInstantiationOptions = SharedInstantiationOptions & {
-  /** Forbidden on `PendingDeployMethod`; use `OwnedDeployMethod` for a concrete deployer. */
+  /** Forbidden on `PendingDeployMethod`; use `BoundDeployMethod` for a concrete deployer. */
   deployer?: never;
   /** Forbidden on `PendingDeployMethod`; use `UniversalDeployMethod` for a universal deploy. */
   universalDeploy?: never;
 };
 
 /**
+ * Identifies *which contract* is being deployed and *with what initializer*.
+ */
+export type DeployMethodContract<TContract extends ContractBase = ContractBase> = {
+  /** Build artifact of the contract being deployed. */
+  artifact: ContractArtifact;
+  /** Factory invoked after deployment to produce the typed contract handle. */
+  postDeployCtor: (instance: ContractInstanceWithAddress, wallet: Wallet) => TContract;
+  /** Encoded constructor arguments for the contract. Defaults to `[]`. */
+  args?: any[];
+  /** Name (or full artifact) of the initializer to call. */
+  constructorNameOrArtifact?: string | FunctionArtifact;
+};
+
+/**
+ * Execution-payload metadata propagated through `request` / `send` / `simulate` / `profile`.
+ */
+export type DeployMethodPayload = {
+  /** Auth witnesses propagated to the deploy interaction. */
+  authWitnesses?: AuthWitness[];
+  /** Capsules propagated to the deploy interaction. */
+  capsules?: Capsule[];
+  /** Extra hashed args propagated to the deploy interaction. */
+  extraHashedArgs?: HashedValues[];
+};
+
+/**
  * Options for deploying a contract on the Aztec network.
- * Controls publication and registration policy for this deployment. Address-affecting parameters
- * (salt, deployer, publicKeys, constructor and args) are passed at construction time.
+ * Controls publication and registration policy for this deployment.
  */
 export type RequestDeployOptions = RequestInteractionOptions & {
   /** Skip contract class publication. */
@@ -187,7 +212,7 @@ export type DeployReturn<TContract extends ContractBase, W extends InteractionWa
  * Umbrella type for a contract deployment interaction.
  *
  * `DeployMethod` is abstract: callers always interact with one of three concrete flavors —
- * {@link OwnedDeployMethod}, {@link UniversalDeployMethod}, or {@link PendingDeployMethod} —
+ * {@link BoundDeployMethod}, {@link UniversalDeployMethod}, or {@link PendingDeployMethod} —
  * picked by {@link DeployMethod.create} based on the supplied {@link DeployInstantiationOptions}.
  * The flavors only differ in their initial deployer-lock state; the full API
  * (`request` / `send` / `simulate` / `profile` / `getInstance` / `getAddress` /
@@ -225,26 +250,31 @@ export abstract class DeployMethod<TContract extends ContractBase = ContractBase
 
   /** Constructor function to call. */
   protected constructorArtifact: FunctionAbi | undefined;
+  /** Build artifact of the contract being deployed. */
+  protected readonly artifact: ContractArtifact;
+  /** Factory invoked after deployment to produce the typed contract handle. */
+  protected readonly postDeployCtor: (instance: ContractInstanceWithAddress, wallet: Wallet) => TContract;
+  /** Encoded constructor arguments for the contract. */
+  protected readonly args: any[];
+  /** Extra hashed args propagated through `with(...)` and into the deploy payload. */
+  protected readonly extraHashedArgs: HashedValues[];
 
   protected constructor(
     wallet: Wallet,
-    protected artifact: ContractArtifact,
-    protected postDeployCtor: (instance: ContractInstanceWithAddress, wallet: Wallet) => TContract,
-    protected args: any[] = [],
-    constructorNameOrArtifact?: string | FunctionArtifact,
-    salt?: Fr,
-    publicKeys?: PublicKeys,
-    authWitnesses: AuthWitness[] = [],
-    capsules: Capsule[] = [],
-    protected extraHashedArgs: HashedValues[] = [],
+    contract: DeployMethodContract<TContract>,
+    salt: Fr | undefined,
+    publicKeys: PublicKeys | undefined,
+    payload: DeployMethodPayload = {},
   ) {
-    super(wallet, authWitnesses, capsules);
-    this.constructorArtifact = getInitializer(artifact, constructorNameOrArtifact);
+    super(wallet, payload.authWitnesses ?? [], payload.capsules ?? []);
+    this.artifact = contract.artifact;
+    this.postDeployCtor = contract.postDeployCtor;
+    this.args = contract.args ?? [];
+    this.constructorArtifact = getInitializer(contract.artifact, contract.constructorNameOrArtifact);
     this.salt = salt ?? Fr.random();
     this.publicKeys = publicKeys ?? PublicKeys.default();
+    this.extraHashedArgs = payload.extraHashedArgs ?? [];
   }
-
-  // ---- Hooks specialized by each flavor (Owned / Universal / Pending) -----------------------
 
   /**
    * The address that will be mixed into the contract's address preimage. Owned returns the
@@ -263,7 +293,7 @@ export abstract class DeployMethod<TContract extends ContractBase = ContractBase
    *
    * @param from - The send-time `from` value (`AztecAddress`, `NO_FROM`, or `undefined`).
    */
-  public abstract lockOrAssertDeployer(from: SendInteractionOptionsWithoutWait['from'] | undefined): void;
+  public abstract lockDeployer(from: SendInteractionOptionsWithoutWait['from'] | undefined): void;
 
   /**
    * Returns the {@link DeployInstantiationOptions} that match this flavor. Used by `with(...)` to
@@ -273,33 +303,23 @@ export abstract class DeployMethod<TContract extends ContractBase = ContractBase
 
   /**
    * Constructs the right concrete `DeployMethod` flavor for the supplied instantiation options:
-   * - `{ deployer: <addr> }` → {@link OwnedDeployMethod}
+   * - `{ deployer: <addr> }` → {@link BoundDeployMethod}
    * - `{ universalDeploy: true }` → {@link UniversalDeployMethod}
    * - neither set → {@link PendingDeployMethod}
    *
    * Mixing `deployer` and `universalDeploy` throws. Returns the umbrella `DeployMethod<T>` type so
    * callers can use the result generically without narrowing.
    *
-   * @param wallet - Wallet used to send/simulate the deploy tx.
-   * @param artifact - Build artifact of the contract being deployed.
-   * @param postDeployCtor - Factory invoked after deployment to produce the typed contract handle.
-   * @param args - Encoded constructor arguments for the contract.
-   * @param constructorNameOrArtifact - Name (or full artifact) of the initializer to call.
-   * @param instantiation - Address-affecting parameters: salt, deployer / universalDeploy, publicKeys.
-   * @param authWitnesses - Auth witnesses propagated to the deploy interaction.
-   * @param capsules - Capsules propagated to the deploy interaction.
-   * @param extraHashedArgs - Extra hashed args propagated to the deploy interaction.
+   * @param wallet - Wallet used to send / simulate the deploy tx.
+   * @param contract - The contract being deployed (artifact, factory, args, initializer).
+   * @param instantiation - Address-affecting parameters (salt, deployer / universalDeploy, publicKeys). Defaults to pending.
+   * @param payload - Auth witnesses, capsules, and extra hashed args propagated to the deploy. Defaults to empty.
    */
   public static create<TContract extends ContractBase>(
     wallet: Wallet,
-    artifact: ContractArtifact,
-    postDeployCtor: (instance: ContractInstanceWithAddress, wallet: Wallet) => TContract,
-    args: any[] = [],
-    constructorNameOrArtifact?: string | FunctionArtifact,
+    contract: DeployMethodContract<TContract>,
     instantiation: DeployInstantiationOptions = {},
-    authWitnesses: AuthWitness[] = [],
-    capsules: Capsule[] = [],
-    extraHashedArgs: HashedValues[] = [],
+    payload: DeployMethodPayload = {},
   ): DeployMethod<TContract> {
     if (instantiation.deployer !== undefined && instantiation.universalDeploy) {
       throw new Error('DeployInstantiationOptions: `deployer` and `universalDeploy` are mutually exclusive.');
@@ -308,40 +328,15 @@ export abstract class DeployMethod<TContract extends ContractBase = ContractBase
     if (universalDeploy) {
       return new UniversalDeployMethod<TContract>(
         wallet,
-        artifact,
-        postDeployCtor,
-        args,
-        constructorNameOrArtifact,
+        contract,
         { salt, publicKeys, universalDeploy: true },
-        authWitnesses,
-        capsules,
-        extraHashedArgs,
+        payload,
       );
     }
     if (deployer !== undefined) {
-      return new OwnedDeployMethod<TContract>(
-        wallet,
-        artifact,
-        postDeployCtor,
-        args,
-        constructorNameOrArtifact,
-        { salt, publicKeys, deployer },
-        authWitnesses,
-        capsules,
-        extraHashedArgs,
-      );
+      return new BoundDeployMethod<TContract>(wallet, contract, { salt, publicKeys, deployer }, payload);
     }
-    return new PendingDeployMethod<TContract>(
-      wallet,
-      artifact,
-      postDeployCtor,
-      args,
-      constructorNameOrArtifact,
-      { salt, publicKeys },
-      authWitnesses,
-      capsules,
-      extraHashedArgs,
-    );
+    return new PendingDeployMethod<TContract>(wallet, contract, { salt, publicKeys }, payload);
   }
 
   /**
@@ -505,7 +500,7 @@ export abstract class DeployMethod<TContract extends ContractBase = ContractBase
   ): Promise<DeployReturn<TContract, W>>;
   // eslint-disable-next-line jsdoc/require-jsdoc
   public override async send(options: DeployOptions<InteractionWaitOptions>): Promise<any> {
-    this.lockOrAssertDeployer(options.from);
+    this.lockDeployer(options.from);
     const executionPayload = await this.request(options);
     const sendOptions = this.convertDeployOptionsToSendOptions(options);
 
@@ -563,7 +558,7 @@ export abstract class DeployMethod<TContract extends ContractBase = ContractBase
    * estimations (if requested via options), execution statistics and emitted offchain effects
    */
   public async simulate(options: SimulateDeployOptions): Promise<SimulationResult> {
-    this.lockOrAssertDeployer(options.from);
+    this.lockDeployer(options.from);
     const executionPayload = await this.request(options);
     const simulatedTx = await this.wallet.simulateTx(
       executionPayload,
@@ -592,7 +587,7 @@ export abstract class DeployMethod<TContract extends ContractBase = ContractBase
    * @returns An object containing the function return value and profile result.
    */
   public async profile(options: DeployOptionsWithoutWait & ProfileInteractionOptions): Promise<TxProfileResult> {
-    this.lockOrAssertDeployer(options.from);
+    this.lockDeployer(options.from);
     const executionPayload = await this.request(options);
     return await this.wallet.profileTx(executionPayload, this.convertDeployOptionsToProfileOptions(options));
   }
@@ -641,14 +636,18 @@ export abstract class DeployMethod<TContract extends ContractBase = ContractBase
   }): DeployMethod<TContract> {
     return DeployMethod.create(
       this.wallet,
-      this.artifact,
-      this.postDeployCtor,
-      this.args,
-      this.constructorArtifact?.name,
+      {
+        artifact: this.artifact,
+        postDeployCtor: this.postDeployCtor,
+        args: this.args,
+        constructorNameOrArtifact: this.constructorArtifact?.name,
+      },
       this.cloneInstantiation(),
-      this.authWitnesses.concat(authWitnesses),
-      this.capsules.concat(capsules),
-      this.extraHashedArgs.concat(extraHashedArgs),
+      {
+        authWitnesses: this.authWitnesses.concat(authWitnesses),
+        capsules: this.capsules.concat(capsules),
+        extraHashedArgs: this.extraHashedArgs.concat(extraHashedArgs),
+      },
     );
   }
 }
@@ -660,40 +659,24 @@ export abstract class DeployMethod<TContract extends ContractBase = ContractBase
  * Sending from a different account throws — letting it through would silently produce a deployed
  * address different from the one `getAddress()` reported.
  */
-export class OwnedDeployMethod<TContract extends ContractBase = ContractBase> extends DeployMethod<TContract> {
+export class BoundDeployMethod<TContract extends ContractBase = ContractBase> extends DeployMethod<TContract> {
   /** The address baked into the address preimage. Read-only — set at construction. */
   public readonly deployer: AztecAddress;
 
   public constructor(
     wallet: Wallet,
-    artifact: ContractArtifact,
-    postDeployCtor: (instance: ContractInstanceWithAddress, wallet: Wallet) => TContract,
-    args: any[],
-    constructorNameOrArtifact: string | FunctionArtifact | undefined,
-    instantiation: OwnedInstantiationOptions,
-    authWitnesses: AuthWitness[] = [],
-    capsules: Capsule[] = [],
-    extraHashedArgs: HashedValues[] = [],
+    contract: DeployMethodContract<TContract>,
+    instantiation: BoundInstantiationOptions,
+    payload: DeployMethodPayload = {},
   ) {
-    // `OwnedInstantiationOptions` requires a `deployer` and forbids `universalDeploy` at the type
+    // `BoundInstantiationOptions` requires a `deployer` and forbids `universalDeploy` at the type
     // level. We still reject `AztecAddress.ZERO` here because the type system can't model it.
     if (instantiation.deployer.equals(AztecAddress.ZERO)) {
       throw new Error(
-        'OwnedDeployMethod requires a non-zero `deployer`; use `UniversalDeployMethod` (`{ universalDeploy: true }`) for universal deploys.',
+        'BoundDeployMethod requires a non-zero `deployer`; use `UniversalDeployMethod` (`{ universalDeploy: true }`) for universal deploys.',
       );
     }
-    super(
-      wallet,
-      artifact,
-      postDeployCtor,
-      args,
-      constructorNameOrArtifact,
-      instantiation.salt,
-      instantiation.publicKeys,
-      authWitnesses,
-      capsules,
-      extraHashedArgs,
-    );
+    super(wallet, contract, instantiation.salt, instantiation.publicKeys, payload);
     this.deployer = instantiation.deployer;
   }
 
@@ -706,7 +689,7 @@ export class OwnedDeployMethod<TContract extends ContractBase = ContractBase> ex
    * Throws unless `from` matches the locked deployer; the deployer is part of the address.
    * @param from - The send-time `from` value (`AztecAddress`, `NO_FROM`, or `undefined`).
    */
-  public lockOrAssertDeployer(from: SendInteractionOptionsWithoutWait['from'] | undefined): void {
+  public lockDeployer(from: SendInteractionOptionsWithoutWait['from'] | undefined): void {
     if (from === undefined || from === NO_FROM || !this.deployer.equals(from)) {
       const sender = from === undefined ? '<unspecified>' : from === NO_FROM ? 'NO_FROM' : from.toString();
       throw new Error(
@@ -731,27 +714,13 @@ export class OwnedDeployMethod<TContract extends ContractBase = ContractBase> ex
 export class UniversalDeployMethod<TContract extends ContractBase = ContractBase> extends DeployMethod<TContract> {
   public constructor(
     wallet: Wallet,
-    artifact: ContractArtifact,
-    postDeployCtor: (instance: ContractInstanceWithAddress, wallet: Wallet) => TContract,
-    args: any[],
-    constructorNameOrArtifact: string | FunctionArtifact | undefined,
+    contract: DeployMethodContract<TContract>,
     instantiation: UniversalInstantiationOptions,
-    authWitnesses: AuthWitness[] = [],
-    capsules: Capsule[] = [],
-    extraHashedArgs: HashedValues[] = [],
+    payload: DeployMethodPayload = {},
   ) {
-    super(
-      wallet,
-      artifact,
-      postDeployCtor,
-      args,
-      constructorNameOrArtifact,
-      instantiation.salt,
-      instantiation.publicKeys,
-      authWitnesses,
-      capsules,
-      extraHashedArgs,
-    );
+    // `UniversalInstantiationOptions` forbids `deployer` and requires `universalDeploy: true` at
+    // the type level — no runtime check is needed.
+    super(wallet, contract, instantiation.salt, instantiation.publicKeys, payload);
   }
 
   /** Universal deploys are anchored at `AztecAddress.ZERO`; the sender does not enter the preimage. */
@@ -763,7 +732,7 @@ export class UniversalDeployMethod<TContract extends ContractBase = ContractBase
    * Universal deploys accept any sender, including `NO_FROM` / `undefined`.
    * @param _from - Ignored.
    */
-  public lockOrAssertDeployer(_from: SendInteractionOptionsWithoutWait['from'] | undefined): void {
+  public lockDeployer(_from: SendInteractionOptionsWithoutWait['from'] | undefined): void {
     // No-op.
   }
 
@@ -775,7 +744,7 @@ export class UniversalDeployMethod<TContract extends ContractBase = ContractBase
 
 /**
  * Deploy method whose deployer is not yet decided. The first `send` / `simulate` / `profile` call
- * promotes this into an {@link OwnedDeployMethod} or {@link UniversalDeployMethod} (depending on
+ * promotes this into an {@link BoundDeployMethod} or {@link UniversalDeployMethod} (depending on
  * whether `options.from` is an address or `NO_FROM` / `undefined`); subsequent calls reuse that
  * promotion and reject mismatching `from` values.
  *
@@ -787,35 +756,17 @@ export class PendingDeployMethod<TContract extends ContractBase = ContractBase> 
   /**
    * The locked sibling created on the first send-side call. Once set, all flavor-specific
    * decisions (sender compatibility, address derivation, clone shape) delegate to it, so a second
-   * call with a mismatched `from` is rejected by `OwnedDeployMethod.lockOrAssertDeployer`.
+   * call with a mismatched `from` is rejected by `BoundDeployMethod.lockDeployer`.
    */
-  #promoted?: OwnedDeployMethod<TContract> | UniversalDeployMethod<TContract>;
+  #locked?: BoundDeployMethod<TContract> | UniversalDeployMethod<TContract>;
 
   public constructor(
     wallet: Wallet,
-    artifact: ContractArtifact,
-    postDeployCtor: (instance: ContractInstanceWithAddress, wallet: Wallet) => TContract,
-    args: any[],
-    constructorNameOrArtifact: string | FunctionArtifact | undefined,
+    contract: DeployMethodContract<TContract>,
     instantiation: PendingInstantiationOptions = {},
-    authWitnesses: AuthWitness[] = [],
-    capsules: Capsule[] = [],
-    extraHashedArgs: HashedValues[] = [],
+    payload: DeployMethodPayload = {},
   ) {
-    // `PendingInstantiationOptions` forbids both `deployer` and `universalDeploy` at the type
-    // level — no runtime check is needed.
-    super(
-      wallet,
-      artifact,
-      postDeployCtor,
-      args,
-      constructorNameOrArtifact,
-      instantiation.salt,
-      instantiation.publicKeys,
-      authWitnesses,
-      capsules,
-      extraHashedArgs,
-    );
+    super(wallet, contract, instantiation.salt, instantiation.publicKeys, payload);
   }
 
   /**
@@ -823,7 +774,7 @@ export class PendingDeployMethod<TContract extends ContractBase = ContractBase> 
    * address would otherwise differ from what `send()` ends up deploying.
    */
   public getDeployerAddress(): AztecAddress {
-    if (!this.#promoted) {
+    if (!this.#locked) {
       throw new Error(
         'Cannot resolve contract address: deployer is not yet locked. Pass `deployer: <address>` ' +
           'or `universalDeploy: true` as the instantiation option when constructing the deploy ' +
@@ -831,7 +782,7 @@ export class PendingDeployMethod<TContract extends ContractBase = ContractBase> 
           '`.simulate` / `.profile` first to lock the deployer from the sender. ',
       );
     }
-    return this.#promoted.getDeployerAddress();
+    return this.#locked.getDeployerAddress();
   }
 
   /**
@@ -840,55 +791,46 @@ export class PendingDeployMethod<TContract extends ContractBase = ContractBase> 
    * sibling's own policy, not a duplicate one here.
    * @param from - The send-time `from` value (`AztecAddress`, `NO_FROM`, or `undefined`).
    */
-  public lockOrAssertDeployer(from: SendInteractionOptionsWithoutWait['from'] | undefined): void {
-    if (!this.#promoted) {
-      this.#promoted = this.#promoteFrom(from);
+  public lockDeployer(from: SendInteractionOptionsWithoutWait['from'] | undefined): void {
+    if (!this.#locked) {
+      this.#locked = this.#promoteFrom(from);
       return;
     }
-    this.#promoted.lockOrAssertDeployer(from);
+    this.#locked.lockDeployer(from);
   }
 
   /** Re-emits this method's `DeployInstantiationOptions` for `with(...)` to consume. */
   public cloneInstantiation(): DeployInstantiationOptions {
-    if (!this.#promoted) {
+    if (!this.#locked) {
       return { salt: this.salt, publicKeys: this.publicKeys };
     }
-    return this.#promoted.cloneInstantiation();
+    return this.#locked.cloneInstantiation();
   }
 
   /**
    * Builds the locked sibling implied by a send-time `from`: an `AztecAddress` becomes
-   * {@link OwnedDeployMethod}; `NO_FROM` / `undefined` becomes {@link UniversalDeployMethod}.
+   * {@link BoundDeployMethod}; `NO_FROM` / `undefined` becomes {@link UniversalDeployMethod}.
    * @param from - The send-time `from` value.
    */
   #promoteFrom(
     from: SendInteractionOptionsWithoutWait['from'] | undefined,
-  ): OwnedDeployMethod<TContract> | UniversalDeployMethod<TContract> {
+  ): BoundDeployMethod<TContract> | UniversalDeployMethod<TContract> {
     const { wallet, artifact, postDeployCtor, args, salt, publicKeys, authWitnesses, capsules, extraHashedArgs } = this;
-    const constructorName = this.constructorArtifact?.name;
-    if (from === undefined || from === NO_FROM) {
-      return new UniversalDeployMethod<TContract>(
-        wallet,
-        artifact,
-        postDeployCtor,
-        args,
-        constructorName,
-        { salt, publicKeys, universalDeploy: true },
-        authWitnesses,
-        capsules,
-        extraHashedArgs,
-      );
-    }
-    return new OwnedDeployMethod<TContract>(
-      wallet,
+    const contract: DeployMethodContract<TContract> = {
       artifact,
       postDeployCtor,
       args,
-      constructorName,
-      { salt, publicKeys, deployer: from },
-      authWitnesses,
-      capsules,
-      extraHashedArgs,
-    );
+      constructorNameOrArtifact: this.constructorArtifact?.name,
+    };
+    const payload: DeployMethodPayload = { authWitnesses, capsules, extraHashedArgs };
+    if (from === undefined || from === NO_FROM) {
+      return new UniversalDeployMethod<TContract>(
+        wallet,
+        contract,
+        { salt, publicKeys, universalDeploy: true },
+        payload,
+      );
+    }
+    return new BoundDeployMethod<TContract>(wallet, contract, { salt, publicKeys, deployer: from }, payload);
   }
 }

--- a/yarn-project/aztec.js/src/contract/deploy_method.ts
+++ b/yarn-project/aztec.js/src/contract/deploy_method.ts
@@ -138,8 +138,15 @@ export type DeployReturn<TContract extends ContractBase, W extends InteractionWa
   : DeployResultMined<TContract>;
 
 /**
- * Contract interaction for deployment.
- * Handles class publication, instance publication, and initialization of the contract.
+ * Umbrella type for a contract deployment interaction.
+ *
+ * `DeployMethod` is abstract: callers always interact with one of three concrete flavors —
+ * {@link OwnedDeployMethod}, {@link UniversalDeployMethod}, or {@link PendingDeployMethod} —
+ * picked by {@link DeployMethod.create} based on the supplied {@link DeployInstantiationOptions}.
+ * The flavors only differ in their initial deployer-lock state; the full API
+ * (`request` / `send` / `simulate` / `profile` / `getInstance` / `getAddress` /
+ * `getPartialAddress` / `register` / `with`) lives on this base, so consumers can type
+ * variables as `DeployMethod<T>` and treat all three uniformly.
  *
  * The deployer (and therefore the deployed address) is locked once and never changes. Locking
  * happens either at construction (via `deployer` or `universalDeploy: true` in the instantiation
@@ -159,101 +166,127 @@ export type DeployReturn<TContract extends ContractBase, W extends InteractionWa
  * functions (private and utility) can be interacted-with immediately, without any
  * "deployment tx".
  */
-export class DeployMethod<TContract extends ContractBase = ContractBase> extends BaseContractInteraction {
+export abstract class DeployMethod<TContract extends ContractBase = ContractBase> extends BaseContractInteraction {
   /** Salt used in the address preimage. */
   protected readonly salt: Fr;
-  /**
-   * Deployer mixed into the address preimage. `undefined` until locked, either by `deployer` /
-   * `universalDeploy: true` at construction, or by the first call to `request` / `send` /
-   * `simulate` / `profile` which locks it from `options.from` (NO_FROM/undefined → ZERO,
-   * AztecAddress → that address). `AztecAddress.ZERO` indicates a universal deployment. Once
-   * locked, never changes; subsequent calls with an incompatible `from` throw.
-   */
-  protected deployer: AztecAddress | undefined;
   /** Public keys mixed into the address preimage. */
   protected readonly publicKeys: PublicKeys;
 
-  /** Cached instance promise; resolved once after the deployer is locked. */
-  private instancePromise?: Promise<ContractInstanceWithAddress>;
-  /** Resolved value of `instancePromise`, populated synchronously once the promise settles. */
-  private resolvedInstance?: ContractInstanceWithAddress;
+  /** Cached instance promise; resolved once the deployer is known. */
+  #instancePromise?: Promise<ContractInstanceWithAddress>;
+  /** Resolved value of `#instancePromise`, populated synchronously once the promise settles. */
+  #resolvedInstance?: ContractInstanceWithAddress;
 
   /** Constructor function to call. */
   protected constructorArtifact: FunctionAbi | undefined;
 
-  constructor(
+  protected constructor(
     wallet: Wallet,
     protected artifact: ContractArtifact,
     protected postDeployCtor: (instance: ContractInstanceWithAddress, wallet: Wallet) => TContract,
     protected args: any[] = [],
     constructorNameOrArtifact?: string | FunctionArtifact,
-    instantiation: DeployInstantiationOptions = {},
+    salt?: Fr,
+    publicKeys?: PublicKeys,
     authWitnesses: AuthWitness[] = [],
     capsules: Capsule[] = [],
     protected extraHashedArgs: HashedValues[] = [],
   ) {
     super(wallet, authWitnesses, capsules);
     this.constructorArtifact = getInitializer(artifact, constructorNameOrArtifact);
-    this.salt = instantiation.salt ?? Fr.random();
-    this.publicKeys = instantiation.publicKeys ?? PublicKeys.default();
+    this.salt = salt ?? Fr.random();
+    this.publicKeys = publicKeys ?? PublicKeys.default();
+  }
+
+  // ---- Hooks specialized by each flavor (Owned / Universal / Pending) -----------------------
+
+  /**
+   * The address that will be mixed into the contract's address preimage. Owned returns the
+   * concrete deployer; Universal returns `AztecAddress.ZERO`; Pending throws unless a prior
+   * `send` / `simulate` / `profile` call has already locked it.
+   */
+  public abstract getDeployerAddress(): AztecAddress;
+
+  /**
+   * Reconciles a send-time `from` with the deploy's deployer. Owned asserts an exact match;
+   * Universal accepts anything; Pending uses the first call to lock its deployer (transitioning
+   * into an Owned/Universal sibling), then defers to that sibling's assertion on subsequent calls.
+   *
+   * The "locks-or-asserts" name is intentional: only Pending mutates state, and only on its first
+   * invocation. Owned and Universal are pure assertions.
+   *
+   * @param from - The send-time `from` value (`AztecAddress`, `NO_FROM`, or `undefined`).
+   */
+  public abstract lockOrAssertDeployer(from: SendInteractionOptionsWithoutWait['from'] | undefined): void;
+
+  /**
+   * Returns the {@link DeployInstantiationOptions} that match this flavor. Used by `with(...)` to
+   * spawn a sibling instance carrying the same lock state.
+   */
+  public abstract cloneInstantiation(): DeployInstantiationOptions;
+
+  /**
+   * Constructs the right concrete `DeployMethod` flavor for the supplied instantiation options:
+   * - `{ deployer: <addr> }` → {@link OwnedDeployMethod}
+   * - `{ universalDeploy: true }` → {@link UniversalDeployMethod}
+   * - neither set → {@link PendingDeployMethod}
+   *
+   * Mixing `deployer` and `universalDeploy` throws. Returns the umbrella `DeployMethod<T>` type so
+   * callers can use the result generically without narrowing.
+   *
+   * @param wallet - Wallet used to send/simulate the deploy tx.
+   * @param artifact - Build artifact of the contract being deployed.
+   * @param postDeployCtor - Factory invoked after deployment to produce the typed contract handle.
+   * @param args - Encoded constructor arguments for the contract.
+   * @param constructorNameOrArtifact - Name (or full artifact) of the initializer to call.
+   * @param instantiation - Address-affecting parameters: salt, deployer / universalDeploy, publicKeys.
+   * @param authWitnesses - Auth witnesses propagated to the deploy interaction.
+   * @param capsules - Capsules propagated to the deploy interaction.
+   * @param extraHashedArgs - Extra hashed args propagated to the deploy interaction.
+   */
+  public static create<TContract extends ContractBase>(
+    wallet: Wallet,
+    artifact: ContractArtifact,
+    postDeployCtor: (instance: ContractInstanceWithAddress, wallet: Wallet) => TContract,
+    args: any[] = [],
+    constructorNameOrArtifact?: string | FunctionArtifact,
+    instantiation: DeployInstantiationOptions = {},
+    authWitnesses: AuthWitness[] = [],
+    capsules: Capsule[] = [],
+    extraHashedArgs: HashedValues[] = [],
+  ): DeployMethod<TContract> {
     if (instantiation.deployer !== undefined && instantiation.universalDeploy) {
       throw new Error('DeployInstantiationOptions: `deployer` and `universalDeploy` are mutually exclusive.');
     }
+    const ctorArgs = [
+      wallet,
+      artifact,
+      postDeployCtor,
+      args,
+      constructorNameOrArtifact,
+      instantiation,
+      authWitnesses,
+      capsules,
+      extraHashedArgs,
+    ] as const;
     if (instantiation.universalDeploy) {
-      this.deployer = AztecAddress.ZERO;
-    } else if (instantiation.deployer !== undefined) {
-      this.deployer = instantiation.deployer;
+      return new UniversalDeployMethod<TContract>(...ctorArgs);
     }
+    if (instantiation.deployer !== undefined) {
+      return new OwnedDeployMethod<TContract>(...ctorArgs);
+    }
+    return new PendingDeployMethod<TContract>(...ctorArgs);
   }
 
   /**
-   * Locks the deployer from a send-time `from` value. If the deployer is already locked, this
-   * verifies that `from` is compatible with the locked value and throws otherwise. A locked
-   * universal deployer (`AztecAddress.ZERO`) is compatible with any `from`, since "universal"
-   * means the address does not depend on the sender.
-   *
-   * @param from - The send-time `from` value (AztecAddress, NO_FROM, or undefined).
-   */
-  protected lockDeployerFromSendOptions(from: SendInteractionOptionsWithoutWait['from'] | undefined): void {
-    const fromAsDeployer: AztecAddress = from === undefined || from === NO_FROM ? AztecAddress.ZERO : from;
-    if (this.deployer === undefined) {
-      this.deployer = fromAsDeployer;
-      return;
-    }
-    if (this.deployer.equals(AztecAddress.ZERO)) {
-      return;
-    }
-    if (!this.deployer.equals(fromAsDeployer)) {
-      throw new Error(
-        `Deployer for this DeployMethod is locked to ${this.deployer.toString()}; cannot send from ${fromAsDeployer.toString()} ` +
-          `because that would imply a different deployer than the one used to derive the address. ` +
-          `Pass \`deployer: ${this.deployer.toString()}\` at construction if you need a different sender.`,
-      );
-    }
-  }
-
-  /**
-   * Returns the execution payload that allows this operation to happen on chain.
-   *
-   * Requires the deployer to be locked already (either at construction via `deployer` /
-   * `universalDeploy: true`, or as a side effect of a prior `send` / `simulate` / `profile` call,
-   * which lock from `options.from`). Throws otherwise — `request` is purely about payload
-   * construction and does not look at sender information.
+   * Returns the execution payload that allows this operation to happen on chain. Requires the
+   * deployer to be known — call `getDeployerAddress()` first; on a `PendingDeployMethod` this
+   * throws unless a prior `send` / `simulate` / `profile` has already locked the deployer.
    *
    * @param options - Configuration options.
    * @returns The execution payload for this operation
    */
   public async request(options: RequestDeployOptions = {}): Promise<ExecutionPayload> {
-    if (this.deployer === undefined) {
-      throw new Error(
-        'Cannot build deploy execution payload: deployer is not yet locked. Pass `deployer: <address>` ' +
-          'or `universalDeploy: true` as the instantiation option when constructing the deploy ' +
-          '(e.g. `MyContract.deploy(wallet, ...args, { deployer: alice })`), or call `.send` / ' +
-          '`.simulate` / `.profile` first to lock the deployer from the sender. When wrapping a ' +
-          'DeployMethod inside a BatchCall, lock the deployer at construction since BatchCall ' +
-          'invokes `request()` directly.',
-      );
-    }
     const publication = await this.getPublicationExecutionPayload(options);
 
     if (!options?.skipRegistration) {
@@ -406,7 +439,7 @@ export class DeployMethod<TContract extends ContractBase = ContractBase> extends
   ): Promise<DeployReturn<TContract, W>>;
   // eslint-disable-next-line jsdoc/require-jsdoc
   public override async send(options: DeployOptions<InteractionWaitOptions>): Promise<any> {
-    this.lockDeployerFromSendOptions(options.from);
+    this.lockOrAssertDeployer(options.from);
     const executionPayload = await this.request(options);
     const sendOptions = this.convertDeployOptionsToSendOptions(options);
 
@@ -433,37 +466,27 @@ export class DeployMethod<TContract extends ContractBase = ContractBase> extends
    * Builds the contract instance and returns it. The instance is computed once and cached for
    * the lifetime of this DeployMethod; subsequent calls return the same instance.
    *
-   * Requires the deployer to have been locked. The deployer is locked either by passing
-   * `deployer` / `universalDeploy: true` at construction, or by a prior call to
-   * `request` / `send` / `simulate` / `profile` (which lock from `options.from`). Calling
-   * `getInstance()` before the deployer is locked throws, because the address is otherwise
-   * ambiguous and would silently change once the user finally invokes a send.
+   * On a {@link PendingDeployMethod} this throws unless a prior `send` / `simulate` / `profile`
+   * call has already locked the deployer — otherwise the resolved address could silently differ
+   * from the eventually-deployed one.
    *
    * @returns An instance object.
    */
   public getInstance(): Promise<ContractInstanceWithAddress> {
-    if (this.deployer === undefined) {
-      throw new Error(
-        'Cannot resolve contract instance: deployer is not yet locked. Pass `deployer: <address>` ' +
-          'or `universalDeploy: true` as the instantiation option when constructing the deploy ' +
-          '(e.g. `MyContract.deploy(wallet, ...args, { deployer: alice })`), or call `.send` / ' +
-          '`.simulate` / `.profile` first to lock the deployer from the sender.',
-      );
-    }
-    const deployer = this.deployer;
-    if (!this.instancePromise) {
-      this.instancePromise = getContractInstanceFromInstantiationParams(this.artifact, {
+    const deployer = this.getDeployerAddress();
+    if (!this.#instancePromise) {
+      this.#instancePromise = getContractInstanceFromInstantiationParams(this.artifact, {
         constructorArgs: this.args,
         salt: this.salt,
         publicKeys: this.publicKeys,
         constructorArtifact: this.constructorArtifact,
         deployer,
       }).then(instance => {
-        this.resolvedInstance = instance;
+        this.#resolvedInstance = instance;
         return instance;
       });
     }
-    return this.instancePromise;
+    return this.#instancePromise;
   }
 
   /**
@@ -474,7 +497,7 @@ export class DeployMethod<TContract extends ContractBase = ContractBase> extends
    * estimations (if requested via options), execution statistics and emitted offchain effects
    */
   public async simulate(options: SimulateDeployOptions): Promise<SimulationResult> {
-    this.lockDeployerFromSendOptions(options.from);
+    this.lockOrAssertDeployer(options.from);
     const executionPayload = await this.request(options);
     const simulatedTx = await this.wallet.simulateTx(
       executionPayload,
@@ -503,7 +526,7 @@ export class DeployMethod<TContract extends ContractBase = ContractBase> extends
    * @returns An object containing the function return value and profile result.
    */
   public async profile(options: DeployOptionsWithoutWait & ProfileInteractionOptions): Promise<TxProfileResult> {
-    this.lockDeployerFromSendOptions(options.from);
+    this.lockOrAssertDeployer(options.from);
     const executionPayload = await this.request(options);
     return await this.wallet.profileTx(executionPayload, this.convertDeployOptionsToProfileOptions(options));
   }
@@ -524,14 +547,17 @@ export class DeployMethod<TContract extends ContractBase = ContractBase> extends
    * been awaited (e.g. `request()` invoked it). Not part of the public API.
    */
   protected getCachedInstanceOrThrow(): ContractInstanceWithAddress {
-    if (!this.resolvedInstance) {
+    if (!this.#resolvedInstance) {
       throw new Error('Contract instance has not been computed yet. Call getInstance() first.');
     }
-    return this.resolvedInstance;
+    return this.#resolvedInstance;
   }
 
   /**
-   * Augments this DeployMethod with additional metadata, such as authWitnesses and capsules.
+   * Augments this DeployMethod with additional metadata, such as authWitnesses and capsules. The
+   * deployer lock is preserved: a Pending that has not yet been locked stays Pending; a Pending
+   * that has already locked, along with Owned and Universal, returns the matching locked flavor
+   * so the cloned method deploys at the same address as `this`.
    * @param options - An object containing the metadata to add to the interaction
    * @returns A new DeployMethod with the added metadata, but calling the same original function in the same manner
    */
@@ -546,8 +572,8 @@ export class DeployMethod<TContract extends ContractBase = ContractBase> extends
     capsules?: Capsule[];
     /** The extra hashed args to add to the deployment */
     extraHashedArgs?: HashedValues[];
-  }): DeployMethod {
-    return new DeployMethod(
+  }): DeployMethod<TContract> {
+    return DeployMethod.create(
       this.wallet,
       this.artifact,
       this.postDeployCtor,
@@ -559,20 +585,245 @@ export class DeployMethod<TContract extends ContractBase = ContractBase> extends
       this.extraHashedArgs.concat(extraHashedArgs),
     );
   }
+}
+
+/**
+ * Deploy method whose deployer is fixed at construction to a concrete {@link AztecAddress}. The
+ * deployer is mixed into the address preimage, so the contract address is fully determined.
+ *
+ * Sending from a different account throws — letting it through would silently produce a deployed
+ * address different from the one `getAddress()` reported.
+ */
+export class OwnedDeployMethod<TContract extends ContractBase = ContractBase> extends DeployMethod<TContract> {
+  /** The address baked into the address preimage. Read-only — set at construction. */
+  public readonly deployer: AztecAddress;
+
+  public constructor(
+    wallet: Wallet,
+    artifact: ContractArtifact,
+    postDeployCtor: (instance: ContractInstanceWithAddress, wallet: Wallet) => TContract,
+    args: any[] = [],
+    constructorNameOrArtifact?: string | FunctionArtifact,
+    instantiation: DeployInstantiationOptions = {},
+    authWitnesses: AuthWitness[] = [],
+    capsules: Capsule[] = [],
+    extraHashedArgs: HashedValues[] = [],
+  ) {
+    if (instantiation.deployer === undefined) {
+      throw new Error('OwnedDeployMethod requires `deployer` in instantiation options.');
+    }
+    if (instantiation.deployer.equals(AztecAddress.ZERO)) {
+      throw new Error(
+        'OwnedDeployMethod requires a non-zero `deployer`; use `UniversalDeployMethod` (`{ universalDeploy: true }`) for universal deploys.',
+      );
+    }
+    super(
+      wallet,
+      artifact,
+      postDeployCtor,
+      args,
+      constructorNameOrArtifact,
+      instantiation.salt,
+      instantiation.publicKeys,
+      authWitnesses,
+      capsules,
+      extraHashedArgs,
+    );
+    this.deployer = instantiation.deployer;
+  }
+
+  /** Returns the locked deployer baked into the address preimage. */
+  public getDeployerAddress(): AztecAddress {
+    return this.deployer;
+  }
 
   /**
-   * Returns the instantiation options to pass to a freshly-constructed copy of this DeployMethod
-   * (e.g. via `with(...)`). Encodes the current locked-deployer state: a locked AztecAddress.ZERO
-   * deployer becomes `universalDeploy: true`; an undefined deployer stays unset so the new copy can
-   * still infer it from the first send.
+   * Throws unless `from` matches the locked deployer; the deployer is part of the address.
+   * @param from - The send-time `from` value (`AztecAddress`, `NO_FROM`, or `undefined`).
    */
-  protected cloneInstantiation(): DeployInstantiationOptions {
-    if (this.deployer === undefined) {
+  public lockOrAssertDeployer(from: SendInteractionOptionsWithoutWait['from'] | undefined): void {
+    if (from === undefined || from === NO_FROM || !this.deployer.equals(from)) {
+      const sender = from === undefined ? '<unspecified>' : from === NO_FROM ? 'NO_FROM' : from.toString();
+      throw new Error(
+        `Deployer for this DeployMethod is locked to ${this.deployer.toString()}; cannot send from ${sender} ` +
+          `because that would imply a different deployer than the one used to derive the address. ` +
+          `Pass \`from: ${this.deployer.toString()}\` to send from the locked deployer, or reconstruct the ` +
+          `deploy with a different \`deployer\` if you need a different sender.`,
+      );
+    }
+  }
+
+  /** Re-emits this method's `DeployInstantiationOptions` for `with(...)` to consume. */
+  public cloneInstantiation(): DeployInstantiationOptions {
+    return { salt: this.salt, publicKeys: this.publicKeys, deployer: this.deployer };
+  }
+}
+
+/**
+ * Deploy method whose deployer is fixed at construction to {@link AztecAddress.ZERO} (universal
+ * deploy). The address does not depend on the sender, so any account may sign the deploy tx.
+ */
+export class UniversalDeployMethod<TContract extends ContractBase = ContractBase> extends DeployMethod<TContract> {
+  public constructor(
+    wallet: Wallet,
+    artifact: ContractArtifact,
+    postDeployCtor: (instance: ContractInstanceWithAddress, wallet: Wallet) => TContract,
+    args: any[] = [],
+    constructorNameOrArtifact?: string | FunctionArtifact,
+    instantiation: DeployInstantiationOptions = {},
+    authWitnesses: AuthWitness[] = [],
+    capsules: Capsule[] = [],
+    extraHashedArgs: HashedValues[] = [],
+  ) {
+    if (instantiation.deployer !== undefined) {
+      throw new Error('UniversalDeployMethod cannot accept a `deployer`; use `OwnedDeployMethod` instead.');
+    }
+    super(
+      wallet,
+      artifact,
+      postDeployCtor,
+      args,
+      constructorNameOrArtifact,
+      instantiation.salt,
+      instantiation.publicKeys,
+      authWitnesses,
+      capsules,
+      extraHashedArgs,
+    );
+  }
+
+  /** Universal deploys are anchored at `AztecAddress.ZERO`; the sender does not enter the preimage. */
+  public getDeployerAddress(): AztecAddress {
+    return AztecAddress.ZERO;
+  }
+
+  /**
+   * Universal deploys accept any sender, including `NO_FROM` / `undefined`.
+   * @param _from - Ignored.
+   */
+  public lockOrAssertDeployer(_from: SendInteractionOptionsWithoutWait['from'] | undefined): void {
+    // No-op.
+  }
+
+  /** Re-emits this method's `DeployInstantiationOptions` for `with(...)` to consume. */
+  public cloneInstantiation(): DeployInstantiationOptions {
+    return { salt: this.salt, publicKeys: this.publicKeys, universalDeploy: true };
+  }
+}
+
+/**
+ * Deploy method whose deployer is not yet decided. The first `send` / `simulate` / `profile` call
+ * promotes this into an {@link OwnedDeployMethod} or {@link UniversalDeployMethod} (depending on
+ * whether `options.from` is an address or `NO_FROM` / `undefined`); subsequent calls reuse that
+ * promotion and reject mismatching `from` values.
+ *
+ * Reading the address (`getInstance` / `getAddress` / `getPartialAddress`) or building a payload
+ * (`request`) before the promotion happens throws — the address would otherwise be ambiguous and
+ * could differ from what `send()` ends up deploying.
+ */
+export class PendingDeployMethod<TContract extends ContractBase = ContractBase> extends DeployMethod<TContract> {
+  /**
+   * The locked sibling created on the first send-side call. Once set, all flavor-specific
+   * decisions (sender compatibility, address derivation, clone shape) delegate to it, so a second
+   * call with a mismatched `from` is rejected by `OwnedDeployMethod.lockOrAssertDeployer`.
+   */
+  #promoted?: OwnedDeployMethod<TContract> | UniversalDeployMethod<TContract>;
+
+  public constructor(
+    wallet: Wallet,
+    artifact: ContractArtifact,
+    postDeployCtor: (instance: ContractInstanceWithAddress, wallet: Wallet) => TContract,
+    args: any[] = [],
+    constructorNameOrArtifact?: string | FunctionArtifact,
+    instantiation: DeployInstantiationOptions = {},
+    authWitnesses: AuthWitness[] = [],
+    capsules: Capsule[] = [],
+    extraHashedArgs: HashedValues[] = [],
+  ) {
+    if (instantiation.deployer !== undefined || instantiation.universalDeploy) {
+      throw new Error(
+        'PendingDeployMethod cannot accept `deployer` or `universalDeploy: true`; use `OwnedDeployMethod` or `UniversalDeployMethod` instead.',
+      );
+    }
+    super(
+      wallet,
+      artifact,
+      postDeployCtor,
+      args,
+      constructorNameOrArtifact,
+      instantiation.salt,
+      instantiation.publicKeys,
+      authWitnesses,
+      capsules,
+      extraHashedArgs,
+    );
+  }
+
+  /**
+   * Returns the locked deployer once promotion has happened. Throws while still pending — the
+   * address would otherwise differ from what `send()` ends up deploying.
+   */
+  public getDeployerAddress(): AztecAddress {
+    if (!this.#promoted) {
+      throw new Error(
+        'Cannot resolve contract address: deployer is not yet locked. Pass `deployer: <address>` ' +
+          'or `universalDeploy: true` as the instantiation option when constructing the deploy ' +
+          '(e.g. `MyContract.deploy(wallet, ...args, { deployer: alice })`), or call `.send` / ' +
+          '`.simulate` / `.profile` first to lock the deployer from the sender. ',
+      );
+    }
+    return this.#promoted.getDeployerAddress();
+  }
+
+  /**
+   * On the first call, promotes this pending method into a locked sibling and remembers it. On
+   * subsequent calls, defers to the locked sibling — so a mismatched `from` is rejected by the
+   * sibling's own policy, not a duplicate one here.
+   * @param from - The send-time `from` value (`AztecAddress`, `NO_FROM`, or `undefined`).
+   */
+  public lockOrAssertDeployer(from: SendInteractionOptionsWithoutWait['from'] | undefined): void {
+    if (!this.#promoted) {
+      this.#promoted = this.#promoteFrom(from);
+      return;
+    }
+    this.#promoted.lockOrAssertDeployer(from);
+  }
+
+  /** Re-emits this method's `DeployInstantiationOptions` for `with(...)` to consume. */
+  public cloneInstantiation(): DeployInstantiationOptions {
+    if (!this.#promoted) {
       return { salt: this.salt, publicKeys: this.publicKeys };
     }
-    if (this.deployer.equals(AztecAddress.ZERO)) {
-      return { salt: this.salt, publicKeys: this.publicKeys, universalDeploy: true };
+    return this.#promoted.cloneInstantiation();
+  }
+
+  /**
+   * Builds the locked sibling implied by a send-time `from`: an `AztecAddress` becomes
+   * {@link OwnedDeployMethod}; `NO_FROM` / `undefined` becomes {@link UniversalDeployMethod}.
+   * @param from - The send-time `from` value.
+   */
+  #promoteFrom(
+    from: SendInteractionOptionsWithoutWait['from'] | undefined,
+  ): OwnedDeployMethod<TContract> | UniversalDeployMethod<TContract> {
+    const ctorArgs = [
+      this.wallet,
+      this.artifact,
+      this.postDeployCtor,
+      this.args,
+      this.constructorArtifact?.name,
+    ] as const;
+    const tail = [this.authWitnesses, this.capsules, this.extraHashedArgs] as const;
+    if (from === undefined || from === NO_FROM) {
+      return new UniversalDeployMethod<TContract>(
+        ...ctorArgs,
+        { salt: this.salt, publicKeys: this.publicKeys, universalDeploy: true },
+        ...tail,
+      );
     }
-    return { salt: this.salt, publicKeys: this.publicKeys, deployer: this.deployer };
+    return new OwnedDeployMethod<TContract>(
+      ...ctorArgs,
+      { salt: this.salt, publicKeys: this.publicKeys, deployer: from },
+      ...tail,
+    );
   }
 }

--- a/yarn-project/aztec.js/src/contract/deploy_method.ts
+++ b/yarn-project/aztec.js/src/contract/deploy_method.ts
@@ -740,8 +740,6 @@ export class UniversalDeployMethod<TContract extends ContractBase = ContractBase
     capsules: Capsule[] = [],
     extraHashedArgs: HashedValues[] = [],
   ) {
-    // `UniversalInstantiationOptions` forbids `deployer` and requires `universalDeploy: true` at
-    // the type level — no runtime check is needed.
     super(
       wallet,
       artifact,
@@ -866,8 +864,7 @@ export class PendingDeployMethod<TContract extends ContractBase = ContractBase> 
   #promoteFrom(
     from: SendInteractionOptionsWithoutWait['from'] | undefined,
   ): OwnedDeployMethod<TContract> | UniversalDeployMethod<TContract> {
-    const { wallet, artifact, postDeployCtor, args, salt, publicKeys, authWitnesses, capsules, extraHashedArgs } =
-      this;
+    const { wallet, artifact, postDeployCtor, args, salt, publicKeys, authWitnesses, capsules, extraHashedArgs } = this;
     const constructorName = this.constructorArtifact?.name;
     if (from === undefined || from === NO_FROM) {
       return new UniversalDeployMethod<TContract>(

--- a/yarn-project/aztec.js/src/deployment/contract_deployer.ts
+++ b/yarn-project/aztec.js/src/deployment/contract_deployer.ts
@@ -31,6 +31,6 @@ export class ContractDeployer {
   public deploy(args?: any[], instantiation?: DeployInstantiationOptions) {
     const postDeployCtor = (instance: ContractInstanceWithAddress, wallet: Wallet) =>
       Contract.at(instance.address, this.artifact, wallet);
-    return new DeployMethod(this.wallet, this.artifact, postDeployCtor, args, this.constructorName, instantiation);
+    return DeployMethod.create(this.wallet, this.artifact, postDeployCtor, args, this.constructorName, instantiation);
   }
 }

--- a/yarn-project/aztec.js/src/deployment/contract_deployer.ts
+++ b/yarn-project/aztec.js/src/deployment/contract_deployer.ts
@@ -31,6 +31,10 @@ export class ContractDeployer {
   public deploy(args?: any[], instantiation?: DeployInstantiationOptions) {
     const postDeployCtor = (instance: ContractInstanceWithAddress, wallet: Wallet) =>
       Contract.at(instance.address, this.artifact, wallet);
-    return DeployMethod.create(this.wallet, this.artifact, postDeployCtor, args, this.constructorName, instantiation);
+    return DeployMethod.create(
+      this.wallet,
+      { artifact: this.artifact, postDeployCtor, args, constructorNameOrArtifact: this.constructorName },
+      instantiation,
+    );
   }
 }

--- a/yarn-project/aztec.js/src/wallet/deploy_account_method.ts
+++ b/yarn-project/aztec.js/src/wallet/deploy_account_method.ts
@@ -94,15 +94,10 @@ export class DeployAccountMethod<TContract extends ContractBase = Contract> exte
   ) {
     super(
       wallet,
-      artifact,
-      postDeployCtor,
-      args,
-      constructorNameOrArtifact,
+      { artifact, postDeployCtor, args, constructorNameOrArtifact },
       // Account contracts are always deployed universally.
       { salt, universalDeploy: true, publicKeys },
-      authWitnesses,
-      capsules,
-      extraHashedArgs,
+      { authWitnesses, capsules, extraHashedArgs },
     );
   }
 

--- a/yarn-project/aztec.js/src/wallet/deploy_account_method.ts
+++ b/yarn-project/aztec.js/src/wallet/deploy_account_method.ts
@@ -11,11 +11,11 @@ import type { Account } from '../account/account.js';
 import type { Contract } from '../contract/contract.js';
 import type { ContractBase } from '../contract/contract_base.js';
 import {
-  DeployMethod,
   type DeployOptions,
   type DeployOptionsWithoutWait,
   type RequestDeployOptions,
   type SimulateDeployOptions,
+  UniversalDeployMethod,
 } from '../contract/deploy_method.js';
 import {
   type FeePaymentMethodOption,
@@ -78,7 +78,7 @@ type DeployAccountInteractionOptions = Pick<
  * Modified version of the DeployMethod used to deploy account contracts. Supports deploying
  * contracts that can pay for their own fee, plus some preconfigured options to avoid errors.
  */
-export class DeployAccountMethod<TContract extends ContractBase = Contract> extends DeployMethod<TContract> {
+export class DeployAccountMethod<TContract extends ContractBase = Contract> extends UniversalDeployMethod<TContract> {
   constructor(
     publicKeys: PublicKeys,
     wallet: Wallet,

--- a/yarn-project/builder/src/contract-interface-gen/typescript.ts
+++ b/yarn-project/builder/src/contract-interface-gen/typescript.ts
@@ -107,7 +107,7 @@ function generateDeploy(input: ContractArtifact) {
    *                       Salt defaults to a random value; the deployer is locked lazily from the first send-time \`from\`.
    */
   public static deploy(wallet: Wallet, ${args ? `${args}, ` : ''}instantiation?: DeployInstantiationOptions) {
-    return new DeployMethod<${contractName}>(wallet, ${artifactName}, (instance, wallet) => ${contractName}.at(instance.address, wallet), ${argsForwarding}, undefined, instantiation);
+    return DeployMethod.create<${contractName}>(wallet, ${artifactName}, (instance, wallet) => ${contractName}.at(instance.address, wallet), ${argsForwarding}, undefined, instantiation);
   }
 
   /**
@@ -117,7 +117,7 @@ function generateDeploy(input: ContractArtifact) {
     opts: { method?: M; wallet: Wallet; instantiation?: DeployInstantiationOptions },
     ...args: Parameters<${contractName}['methods'][M]>
   ) {
-    return new DeployMethod<${contractName}>(
+    return DeployMethod.create<${contractName}>(
       opts.wallet,
       ${artifactName},
       (instance, wallet) => ${contractName}.at(instance.address, wallet),

--- a/yarn-project/builder/src/contract-interface-gen/typescript.ts
+++ b/yarn-project/builder/src/contract-interface-gen/typescript.ts
@@ -107,7 +107,15 @@ function generateDeploy(input: ContractArtifact) {
    *                       Salt defaults to a random value; the deployer is locked lazily from the first send-time \`from\`.
    */
   public static deploy(wallet: Wallet, ${args ? `${args}, ` : ''}instantiation?: DeployInstantiationOptions) {
-    return DeployMethod.create<${contractName}>(wallet, ${artifactName}, (instance, wallet) => ${contractName}.at(instance.address, wallet), ${argsForwarding}, undefined, instantiation);
+    return DeployMethod.create<${contractName}>(
+      wallet,
+      {
+        artifact: ${artifactName},
+        postDeployCtor: (instance, wallet) => ${contractName}.at(instance.address, wallet),
+        args: ${argsForwarding},
+      },
+      instantiation,
+    );
   }
 
   /**
@@ -119,10 +127,12 @@ function generateDeploy(input: ContractArtifact) {
   ) {
     return DeployMethod.create<${contractName}>(
       opts.wallet,
-      ${artifactName},
-      (instance, wallet) => ${contractName}.at(instance.address, wallet),
-      args,
-      opts.method ?? 'constructor',
+      {
+        artifact: ${artifactName},
+        postDeployCtor: (instance, wallet) => ${contractName}.at(instance.address, wallet),
+        args,
+        constructorNameOrArtifact: opts.method ?? 'constructor',
+      },
       opts.instantiation,
     );
   }


### PR DESCRIPTION
## Summary

Splits `DeployMethod` into an abstract umbrella type plus three concrete flavors that encode the deployer-lock state at the type level instead of branching on a nullable field.

- `DeployMethod<T>` — abstract base, the type consumers use generically (`let d: DeployMethod<MyContract> = ...`).
- `BoundDeployMethod` — locked to a concrete `deployer`.
- `UniversalDeployMethod` — locked to `AztecAddress.ZERO` (any sender).
- `PendingDeployMethod` — promotes into a `Bound`/`Universal` sibling on the first `send` / `simulate` / `profile` call.

The three flavor-specific decisions (`getDeployerAddress`, `lockOrAssertDeployer`, `cloneInstantiation`) are now abstract methods rather than `if (this.deployer === undefined / equals(ZERO) / else)` branches in the base.

## Compile-time guarantees

Each subclass takes a narrowed instantiation type:

- `BoundInstantiationOptions` — `deployer` required, `universalDeploy: never`.
- `UniversalInstantiationOptions` — `universalDeploy: true` required, `deployer: never`.
- `PendingInstantiationOptions` — both `never`.

`new BoundDeployMethod(..., { universalDeploy: true })` is now a TypeScript error. The runtime mutual-exclusion checks in subclass constructors are gone; the only runtime guard left is `BoundDeployMethod` rejecting `AztecAddress.ZERO` (a value-level invariant the type system can't model).

## Constructor shape

Subclass constructors take named bundles instead of 9 positionals:

```ts
new BoundDeployMethod(wallet, contract, instantiation, payload?)
//                            ^               ^             ^
//   { artifact, postDeployCtor, args, constructorNameOrArtifact }
//                            { salt, publicKeys, deployer }
//                            { authWitnesses, capsules, extraHashedArgs }
```

`DeployMethod.create` follows the same shape. `Contract.deploy(wallet, artifact, args, constructorName, instantiation)` and `MyContract.deploy(wallet, ...args, instantiation?)` (codegen) are **unchanged** — the bundle reshape stops at the `create` boundary.

## Other changes

- `DeployAccountMethod` now extends `UniversalDeployMethod` (account contracts are always universal).