### PR TITLE
chore(p2p): remove skipped validation result option

### DIFF
--- a/yarn-project/p2p/src/msg_validators/tx_validator/aggregate_tx_validator.test.ts
+++ b/yarn-project/p2p/src/msg_validators/tx_validator/aggregate_tx_validator.test.ts
@@ -7,8 +7,8 @@ describe('AggregateTxValidator', () => {
   it('allows txs that pass all validation', async () => {
     const txs = await Promise.all([mockTx(0), mockTx(1), mockTx(2), mockTx(3), mockTx(4)]);
     const agg = new AggregateTxValidator(
-      new TxDenyList([txs[0].getTxHash(), txs[1].getTxHash(), txs[4].getTxHash()], []),
-      new TxDenyList([txs[2].getTxHash(), txs[4].getTxHash()], []),
+      new TxDenyList([txs[0].getTxHash(), txs[1].getTxHash(), txs[4].getTxHash()]),
+      new TxDenyList([txs[2].getTxHash(), txs[4].getTxHash()]),
     );
 
     await expect(agg.validateTx(txs[0])).resolves.toEqual({ result: 'invalid', reason: ['Denied'] });
@@ -18,35 +18,15 @@ describe('AggregateTxValidator', () => {
     await expect(agg.validateTx(txs[4])).resolves.toEqual({ result: 'invalid', reason: ['Denied', 'Denied'] });
   });
 
-  it('aggregate skipped txs ', async () => {
-    const txs = await Promise.all([mockTx(0), mockTx(1), mockTx(2), mockTx(3), mockTx(4)]);
-    const agg = new AggregateTxValidator(
-      new TxDenyList([txs[0].getTxHash()], []),
-      new TxDenyList([txs[4].getTxHash()], [txs[1].getTxHash(), txs[2].getTxHash()]),
-      new TxDenyList([], [txs[4].getTxHash()]),
-    );
-
-    await expect(agg.validateTx(txs[0])).resolves.toEqual({ result: 'invalid', reason: ['Denied'] });
-    await expect(agg.validateTx(txs[1])).resolves.toEqual({ result: 'skipped', reason: ['Skipped'] });
-    await expect(agg.validateTx(txs[2])).resolves.toEqual({ result: 'skipped', reason: ['Skipped'] });
-    await expect(agg.validateTx(txs[3])).resolves.toEqual({ result: 'valid' });
-    await expect(agg.validateTx(txs[4])).resolves.toEqual({ result: 'invalid', reason: ['Denied', 'Skipped'] });
-  });
-
   class TxDenyList implements TxValidator<AnyTx> {
     denyList: Set<string>;
-    skippedList: Set<string>;
 
-    constructor(deniedTxHashes: TxHash[], skippedTxHashes: TxHash[]) {
+    constructor(deniedTxHashes: TxHash[]) {
       this.denyList = new Set(deniedTxHashes.map(hash => hash.toString()));
-      this.skippedList = new Set(skippedTxHashes.map(hash => hash.toString()));
     }
 
     validateTx(tx: AnyTx): Promise<TxValidationResult> {
       const txHash = 'txHash' in tx ? tx.txHash : tx.hash;
-      if (this.skippedList.has(txHash.toString())) {
-        return Promise.resolve({ result: 'skipped', reason: ['Skipped'] });
-      }
       if (this.denyList.has(txHash.toString())) {
         return Promise.resolve({ result: 'invalid', reason: ['Denied'] });
       }

--- a/yarn-project/p2p/src/msg_validators/tx_validator/aggregate_tx_validator.ts
+++ b/yarn-project/p2p/src/msg_validators/tx_validator/aggregate_tx_validator.ts
@@ -11,22 +11,13 @@ export class AggregateTxValidator<T> implements TxValidator<T> {
   }
 
   async validateTx(tx: T): Promise<TxValidationResult> {
-    const aggregate: { result: string; reason?: string[] } = { result: 'valid', reason: [] };
+    const reasons: string[] = [];
     for (const validator of this.validators) {
       const result = await validator.validateTx(tx);
       if (result.result === 'invalid') {
-        aggregate.result = 'invalid';
-        aggregate.reason!.push(...result.reason);
-      } else if (result.result === 'skipped') {
-        if (aggregate.result === 'valid') {
-          aggregate.result = 'skipped';
-        }
-        aggregate.reason!.push(...result.reason);
+        reasons.push(...result.reason);
       }
     }
-    if (aggregate.result === 'valid') {
-      delete aggregate.reason;
-    }
-    return aggregate as TxValidationResult;
+    return reasons.length > 0 ? { result: 'invalid', reason: reasons } : { result: 'valid' };
   }
 }

--- a/yarn-project/simulator/src/public/public_processor/public_processor.ts
+++ b/yarn-project/simulator/src/public/public_processor/public_processor.ts
@@ -226,11 +226,6 @@ export class PublicProcessor implements Traceable {
           failed.push({ tx, error: new Error(`Tx failed preprocess validation: ${reason}`) });
           returns.push(new NestedProcessReturnValues([]));
           continue;
-        } else if (result.result === 'skipped') {
-          const reason = result.reason.join(', ');
-          this.log.debug(`Skipping tx ${txHash.toString()} due to pre-process validation: ${reason}`);
-          returns.push(new NestedProcessReturnValues([]));
-          continue;
         } else {
           this.log.trace(`Tx ${txHash.toString()} is valid before processing.`);
         }

--- a/yarn-project/stdlib/src/tx/validator/tx_validator.ts
+++ b/yarn-project/stdlib/src/tx/validator/tx_validator.ts
@@ -15,10 +15,7 @@ export function hasPublicCalls(tx: AnyTx): boolean {
   return tx.data.numberOfPublicCallRequests() > 0;
 }
 
-export type TxValidationResult =
-  | { result: 'valid' }
-  | { result: 'invalid'; reason: string[] }
-  | { result: 'skipped'; reason: string[] };
+export type TxValidationResult = { result: 'valid' } | { result: 'invalid'; reason: string[] };
 
 export interface TxValidator<T = AnyTx> {
   validateTx(tx: T): Promise<TxValidationResult>;
@@ -28,6 +25,5 @@ export const TxValidationResultSchema = zodFor<TxValidationResult>()(
   z.discriminatedUnion('result', [
     z.object({ result: z.literal('valid') }),
     z.object({ result: z.literal('invalid'), reason: z.array(z.string()) }),
-    z.object({ result: z.literal('skipped'), reason: z.array(z.string()) }),
   ]),
 );


### PR DESCRIPTION
It was only there for historical reasons and no prod validator could return "skipped".
See https://github.com/AztecProtocol/aztec-packages/pull/22118 .
