### PR TITLE
fix(prover-client): prevent race between epoch cleanup and batch writes

### DIFF
--- a/yarn-project/foundation/src/queue/batch_queue.ts
+++ b/yarn-project/foundation/src/queue/batch_queue.ts
@@ -28,6 +28,7 @@ export class BatchQueue<T, K extends string | number> {
   private container = new FifoMemoryQueue<Batch<T, K>>();
   private currentBatch?: Batch<T, K>;
   private runningPromise?: Promise<void>;
+  private latestBatchPromise: Promise<void> = Promise.resolve();
 
   constructor(
     private processBatch: (items: Array<T>, key: K) => void | Promise<void>,
@@ -67,6 +68,7 @@ export class BatchQueue<T, K extends string | number> {
       this.flushCurrentBatch();
     }
 
+    this.latestBatchPromise = currentBatch.deferred.promise;
     return currentBatch.deferred.promise;
   }
 
@@ -91,6 +93,16 @@ export class BatchQueue<T, K extends string | number> {
     }
 
     this.runningPromise = this.container.process(this.execProcessor);
+  }
+
+  /**
+   * Flushes the current batch and waits for all queued items (including the flushed batch) to be processed.
+   * New items may be added while draining. Returns a promise that resolves once all items enqueued before
+   * the call to `drain()` have been committed.
+   */
+  public async drain(): Promise<void> {
+    this.flushCurrentBatch();
+    await this.latestBatchPromise.catch(() => {});
   }
 
   /**

--- a/yarn-project/prover-client/src/proving_broker/proving_broker_database/persisted.ts
+++ b/yarn-project/prover-client/src/proving_broker/proving_broker_database/persisted.ts
@@ -87,6 +87,8 @@ export class KVBrokerDatabase implements ProvingBrokerDatabase {
 
   public readonly tracer: Tracer;
 
+  private deletedEpochs = new Set<number>();
+
   private constructor(
     private epochs: Map<number, SingleEpochDatabase>,
     private config: ProverBrokerConfig,
@@ -113,6 +115,10 @@ export class KVBrokerDatabase implements ProvingBrokerDatabase {
 
   // exposed for testing
   public async commitWrites(items: Array<ProvingJob | [ProvingJobId, ProvingJobSettledResult]>, epochNumber: number) {
+    if (this.deletedEpochs.has(epochNumber)) {
+      return;
+    }
+
     const jobsToAdd = items.filter((item): item is ProvingJob => 'id' in item);
     const resultsToAdd = items.filter((item): item is [ProvingJobId, ProvingJobSettledResult] => Array.isArray(item));
 
@@ -181,14 +187,21 @@ export class KVBrokerDatabase implements ProvingBrokerDatabase {
   }))
   async deleteAllProvingJobsOlderThanEpoch(epochNumber: EpochNumber): Promise<void> {
     const oldEpochs = Array.from(this.epochs.keys()).filter(e => e < Number(epochNumber));
+    if (oldEpochs.length === 0) {
+      return;
+    }
+    for (const old of oldEpochs) {
+      this.deletedEpochs.add(old);
+    }
+    await this.batchQueue.drain();
     for (const old of oldEpochs) {
       const db = this.epochs.get(old);
       if (!db) {
         continue;
       }
       this.logger.verbose(`Deleting broker database for epoch ${old}`);
-      await db.delete();
       this.epochs.delete(old);
+      await db.delete();
     }
   }
 


### PR DESCRIPTION
- `deleteAllProvingJobsOlderThanEpoch` was closing/deleting LMDB epoch stores while `BatchQueue.execProcessor` could still be executing a write to the same store, causing intermittent `Store is closed` errors in CI.
- The fix marks epochs as deleted synchronously, drains the batch queue so any in-flight write to those epochs completes (or is skipped via the new `deletedEpochs` guard), then closes and deletes the stores.
- Adds `BatchQueue.drain()` to flush the current batch and await completion of all previously-queued batches without stopping the queue.