### PR TITLE
chore: update yarn.lock in pull-noir workflow

### DIFF
--- a/.github/workflows/pull-noir.yml
+++ b/.github/workflows/pull-noir.yml
@@ -68,7 +68,13 @@ jobs:
           cd ../..
           # Update Cargo.lock if needed, but don't fail if transpiler no longer builds
           cargo check --manifest-path avm-transpiler/Cargo.toml || true
-          git add noir/noir-repo avm-transpiler/Cargo.lock
+          # Update yarn.lock to pick up any changes to noir's JS packages (versions
+          # or the file: hash of noir_js). --mode=update-lockfile skips linking and
+          # build scripts. Don't fail the workflow if yarn errors out -- a partial
+          # update is still useful for the resulting PR.
+          corepack enable
+          (cd yarn-project && yarn install --mode=update-lockfile) || true
+          git add noir/noir-repo avm-transpiler/Cargo.lock yarn-project/yarn.lock
 
       - name: Check for existing PR
         if: steps.noir_versions.outputs.update_needed == 'true'


### PR DESCRIPTION
## Summary

The nightly `pull-noir` workflow updates the noir submodule and refreshes `avm-transpiler/Cargo.lock`, but doesn't touch `yarn-project/yarn.lock`. When noir's JS package versions bump (or the `file:` hash of `noir_js` changes), the resulting `bump-noir` PR fails CI immediately on a stale lockfile.

This adds a `yarn install --mode=update-lockfile` step inside the existing "Update submodule to latest nightly" job and stages `yarn-project/yarn.lock` alongside the other generated files. The `--mode=update-lockfile` flag skips linking and build scripts -- it just resolves and writes the lockfile.

`|| true` mirrors the existing pattern on `cargo check`: a partial update is still useful for the resulting PR rather than blocking it.

## Test plan

- [ ] Trigger the workflow manually via `workflow_dispatch` and confirm `yarn-project/yarn.lock` updates appear in the resulting `bump-noir` PR