### PR TITLE
feat(sequencer): build optimistically across pruning epoch boundary

### DIFF
--- a/yarn-project/archiver/src/archiver-misc.test.ts
+++ b/yarn-project/archiver/src/archiver-misc.test.ts
@@ -4,15 +4,19 @@ import type { EpochCache, EpochCommitteeInfo } from '@aztec/epoch-cache';
 import { DefaultL1ContractsConfig } from '@aztec/ethereum/config';
 import type { RollupContract } from '@aztec/ethereum/contracts';
 import type { ViemPublicClient } from '@aztec/ethereum/types';
-import { EpochNumber, SlotNumber } from '@aztec/foundation/branded-types';
+import { BlockNumber, CheckpointNumber, EpochNumber, SlotNumber } from '@aztec/foundation/branded-types';
 import { Buffer32 } from '@aztec/foundation/buffer';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { openTmpStore } from '@aztec/kv-store/lmdb-v2';
+import type { L2Tips } from '@aztec/stdlib/block';
+import type { CheckpointData } from '@aztec/stdlib/checkpoint';
 import type { L1RollupConstants } from '@aztec/stdlib/epoch-helpers';
+import { CheckpointHeader } from '@aztec/stdlib/rollup';
 import { BlockHeader } from '@aztec/stdlib/tx';
 import { getTelemetryClient } from '@aztec/telemetry-client';
 
+import { jest } from '@jest/globals';
 import { EventEmitter } from 'events';
 import { type MockProxy, mock } from 'jest-mock-extended';
 
@@ -192,6 +196,93 @@ describe('Archiver misc', () => {
     it('returns epoch 1 when synced to mid epoch 2', async () => {
       synchronizer.getL1Timestamp.mockReturnValue(slotLastL1Block(9));
       expect(await archiver.getSyncedL2EpochNumber()).toEqual(EpochNumber(1));
+    });
+  });
+
+  describe('isPruneDueAtSlot', () => {
+    /**
+     * Builds a fake L2Tips. `pending` is the L1-confirmed pending checkpoint (= `tips.checkpointed`
+     * in production). `proposedCheckpoint` is set to `pending + 1` to catch any implementation that
+     * accidentally reads the local-optimistic proposed checkpoint instead of the L1-confirmed one.
+     */
+    function makeTips(pending: CheckpointNumber, proven: CheckpointNumber): L2Tips {
+      const block = { number: BlockNumber(0), hash: '0x' };
+      const tip = (n: CheckpointNumber) => ({ block, checkpoint: { number: n, hash: '0x' } });
+      const proposedAhead = CheckpointNumber(Number(pending) + 1);
+      return {
+        proposed: block,
+        proposedCheckpoint: tip(proposedAhead),
+        checkpointed: tip(pending),
+        proven: tip(proven),
+        finalized: tip(proven),
+      };
+    }
+
+    /** Builds a fake CheckpointData with only the fields these methods read. */
+    function makeCheckpointData(checkpointNumber: CheckpointNumber, slotNumber: SlotNumber): CheckpointData {
+      return {
+        checkpointNumber,
+        header: CheckpointHeader.empty({ slotNumber }),
+      } as unknown as CheckpointData;
+    }
+
+    /**
+     * Stubs `getL2Tips` and `getCheckpointData` so that the methods under test see a
+     * synthetic chain. Each entry in `checkpoints` maps a checkpoint number to its slot.
+     */
+    function stubChain(args: {
+      pending: CheckpointNumber;
+      proven: CheckpointNumber;
+      checkpoints: Array<{ number: CheckpointNumber; slot: SlotNumber }>;
+    }): void {
+      jest.spyOn(archiver, 'getL2Tips').mockResolvedValue(makeTips(args.pending, args.proven));
+      jest
+        .spyOn(archiver, 'getCheckpointData')
+        .mockImplementation((query: any): Promise<CheckpointData | undefined> => {
+          if ('number' in query) {
+            const entry = args.checkpoints.find(c => c.number === query.number);
+            return Promise.resolve(entry ? makeCheckpointData(entry.number, entry.slot) : undefined);
+          }
+          return Promise.resolve(undefined);
+        });
+    }
+
+    // proofSubmissionEpochs = 1 (from beforeEach). With epochDuration = 4:
+    // epoch 0 = slots 0-3, epoch 1 = slots 4-7, epoch 2 = slots 8-11, epoch 3 = slots 12-15.
+    // Deadline epoch for an epoch K is K + proofSubmissionEpochs + 1 = K + 2.
+    // So a checkpoint in epoch K becomes "prune-due" when the current slot's epoch >= K + 2.
+
+    it('returns false when pending equals proven', async () => {
+      stubChain({ pending: CheckpointNumber(3), proven: CheckpointNumber(3), checkpoints: [] });
+      expect(await archiver.isPruneDueAtSlot(SlotNumber(20))).toBe(false);
+    });
+
+    it('returns false when slot is before the deadline', async () => {
+      // Oldest unproven checkpoint is in epoch 0 (slot 2). Deadline epoch = 2.
+      // Slot 7 is in epoch 1, which is before the deadline.
+      stubChain({
+        pending: CheckpointNumber(2),
+        proven: CheckpointNumber(0),
+        checkpoints: [
+          { number: CheckpointNumber(1), slot: SlotNumber(2) },
+          { number: CheckpointNumber(2), slot: SlotNumber(3) },
+        ],
+      });
+      expect(await archiver.isPruneDueAtSlot(SlotNumber(7))).toBe(false);
+    });
+
+    it('returns true when slot is at or after the deadline', async () => {
+      // Oldest unproven checkpoint is in epoch 0. Deadline epoch = 2.
+      // Slot 8 is the first slot of epoch 2, so the deadline has expired.
+      stubChain({
+        pending: CheckpointNumber(2),
+        proven: CheckpointNumber(0),
+        checkpoints: [
+          { number: CheckpointNumber(1), slot: SlotNumber(2) },
+          { number: CheckpointNumber(2), slot: SlotNumber(3) },
+        ],
+      });
+      expect(await archiver.isPruneDueAtSlot(SlotNumber(8))).toBe(true);
     });
   });
 });

--- a/yarn-project/archiver/src/modules/data_source_base.ts
+++ b/yarn-project/archiver/src/modules/data_source_base.ts
@@ -30,7 +30,14 @@ import {
   PublishedCheckpoint,
 } from '@aztec/stdlib/checkpoint';
 import type { ContractClassPublic, ContractDataSource, ContractInstanceWithAddress } from '@aztec/stdlib/contract';
-import { type L1RollupConstants, getSlotRangeForEpoch } from '@aztec/stdlib/epoch-helpers';
+import {
+  type L1RollupConstants,
+  getEpochAtSlot,
+  getEpochNumberAtTimestamp,
+  getLastL1SlotTimestampForL2Slot,
+  getProofSubmissionDeadlineEpoch,
+  getSlotRangeForEpoch,
+} from '@aztec/stdlib/epoch-helpers';
 import type { GetContractClassLogsResponse, GetPublicLogsResponse } from '@aztec/stdlib/interfaces/client';
 import type { L2LogsSource } from '@aztec/stdlib/interfaces/server';
 import type { LogFilter, SiloedTag, Tag, TxScopedL2Log } from '@aztec/stdlib/logs';
@@ -142,6 +149,29 @@ export abstract class ArchiverDataSourceBase
   abstract isEpochComplete(epochNumber: EpochNumber): Promise<boolean>;
 
   abstract syncImmediate(): Promise<void>;
+
+  public async isPruneDueAtSlot(slot: SlotNumber): Promise<boolean> {
+    if (!this.l1Constants) {
+      throw new Error('isPruneDueAtSlot requires l1Constants');
+    }
+    const tips = await this.getL2Tips();
+    const proven = tips.proven.checkpoint.number;
+    const pending = tips.checkpointed.checkpoint.number;
+    if (pending === proven) {
+      return false;
+    }
+
+    const oldestUnproven = await this.getCheckpointData({ number: CheckpointNumber(Number(proven) + 1) });
+    if (!oldestUnproven) {
+      return false;
+    }
+
+    const slotTs = getLastL1SlotTimestampForL2Slot(slot, this.l1Constants);
+    const slotEpoch = getEpochNumberAtTimestamp(slotTs, this.l1Constants);
+    const oldestUnprovenEpoch = getEpochAtSlot(oldestUnproven.header.slotNumber, this.l1Constants);
+    const deadlineEpoch = getProofSubmissionDeadlineEpoch(oldestUnprovenEpoch, this.l1Constants);
+    return slotEpoch >= deadlineEpoch;
+  }
 
   public getCheckpointNumber(): Promise<CheckpointNumber> {
     return this.stores.blocks.getLatestCheckpointNumber();

--- a/yarn-project/archiver/src/test/mock_l2_block_source.ts
+++ b/yarn-project/archiver/src/test/mock_l2_block_source.ts
@@ -492,6 +492,10 @@ export class MockL2BlockSource implements L2BlockSource, ContractDataSource {
     return Promise.resolve(EmptyL1RollupConstants);
   }
 
+  isPruneDueAtSlot(_slot: SlotNumber): Promise<boolean> {
+    return Promise.resolve(false);
+  }
+
   getGenesisValues(): Promise<{ genesisArchiveRoot: Fr }> {
     return Promise.resolve({ genesisArchiveRoot: this.genesisArchiveRoot ?? new Fr(GENESIS_ARCHIVE_ROOT) });
   }

--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_proof_at_boundary.parallel.test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_proof_at_boundary.parallel.test.ts
@@ -1,20 +1,15 @@
 import type { AztecNodeService } from '@aztec/aztec-node';
-import type { AztecAddress } from '@aztec/aztec.js/addresses';
 import { EthAddress } from '@aztec/aztec.js/addresses';
-import { NO_WAIT } from '@aztec/aztec.js/contracts';
 import { Fr } from '@aztec/aztec.js/fields';
 import type { Logger } from '@aztec/aztec.js/log';
-import { waitForTx } from '@aztec/aztec.js/node';
 import type { Operator } from '@aztec/ethereum/deploy-aztec-l1-contracts';
 import type { Delayer } from '@aztec/ethereum/l1-tx-utils';
 import { asyncMap } from '@aztec/foundation/async-map';
 import { CheckpointNumber, EpochNumber, SlotNumber } from '@aztec/foundation/branded-types';
-import { times, timesAsync } from '@aztec/foundation/collection';
+import { times } from '@aztec/foundation/collection';
 import { SecretValue } from '@aztec/foundation/config';
 import { retryUntil } from '@aztec/foundation/retry';
 import { bufferToHex } from '@aztec/foundation/string';
-import { executeTimeout } from '@aztec/foundation/timer';
-import type { TestContract } from '@aztec/noir-test-contracts.js/Test';
 import type { SequencerClient, SequencerEvents } from '@aztec/sequencer-client';
 import { getEpochAtSlot, getEpochNumberAtTimestamp, getTimestampForSlot } from '@aztec/stdlib/epoch-helpers';
 
@@ -22,7 +17,6 @@ import { jest } from '@jest/globals';
 import { privateKeyToAccount } from 'viem/accounts';
 
 import { type EndToEndContext, getPrivateKeyFromIndex } from '../fixtures/utils.js';
-import { proveInteraction } from '../test-wallet/utils.js';
 import { EpochsTestContext, type EpochsTestOpts } from './epochs_test.js';
 
 jest.setTimeout(1000 * 60 * 10);
@@ -39,8 +33,6 @@ describe('e2e_epochs/epochs_proof_at_boundary', () => {
   let test: EpochsTestContext;
   let validators: (Operator & { privateKey: `0x${string}` })[];
   let nodes: AztecNodeService[];
-  let contract: TestContract;
-  let from: AztecAddress;
   let proverNode: AztecNodeService;
 
   const setupTest = async (
@@ -71,9 +63,6 @@ describe('e2e_epochs/epochs_proof_at_boundary', () => {
     });
 
     ({ context, logger } = test);
-    from = context.accounts[0];
-
-    contract = await test.registerTestContract(context.wallet);
 
     const minTxsPerBlock = validatorOverrides.minTxsPerBlock ?? 0;
     const maxTxsPerBlock = validatorOverrides.maxTxsPerBlock ?? 1;

--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_proof_at_boundary.parallel.test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_proof_at_boundary.parallel.test.ts
@@ -1,0 +1,400 @@
+import type { AztecNodeService } from '@aztec/aztec-node';
+import type { AztecAddress } from '@aztec/aztec.js/addresses';
+import { EthAddress } from '@aztec/aztec.js/addresses';
+import { NO_WAIT } from '@aztec/aztec.js/contracts';
+import { Fr } from '@aztec/aztec.js/fields';
+import type { Logger } from '@aztec/aztec.js/log';
+import { waitForTx } from '@aztec/aztec.js/node';
+import type { Operator } from '@aztec/ethereum/deploy-aztec-l1-contracts';
+import type { Delayer } from '@aztec/ethereum/l1-tx-utils';
+import { asyncMap } from '@aztec/foundation/async-map';
+import { CheckpointNumber, EpochNumber, SlotNumber } from '@aztec/foundation/branded-types';
+import { times, timesAsync } from '@aztec/foundation/collection';
+import { SecretValue } from '@aztec/foundation/config';
+import { retryUntil } from '@aztec/foundation/retry';
+import { bufferToHex } from '@aztec/foundation/string';
+import { executeTimeout } from '@aztec/foundation/timer';
+import type { TestContract } from '@aztec/noir-test-contracts.js/Test';
+import type { SequencerClient, SequencerEvents } from '@aztec/sequencer-client';
+import { getEpochAtSlot, getEpochNumberAtTimestamp, getTimestampForSlot } from '@aztec/stdlib/epoch-helpers';
+
+import { jest } from '@jest/globals';
+import { privateKeyToAccount } from 'viem/accounts';
+
+import { type EndToEndContext, getPrivateKeyFromIndex } from '../fixtures/utils.js';
+import { proveInteraction } from '../test-wallet/utils.js';
+import { EpochsTestContext, type EpochsTestOpts } from './epochs_test.js';
+
+jest.setTimeout(1000 * 60 * 10);
+
+const NODE_COUNT = 3;
+
+type PreparingEvent = Parameters<SequencerEvents['preparing-checkpoint']>[0];
+type PublishedEvent = Parameters<SequencerEvents['checkpoint-published']>[0];
+
+describe('e2e_epochs/epochs_proof_at_boundary', () => {
+  let context: EndToEndContext;
+  let logger: Logger;
+
+  let test: EpochsTestContext;
+  let validators: (Operator & { privateKey: `0x${string}` })[];
+  let nodes: AztecNodeService[];
+  let contract: TestContract;
+  let from: AztecAddress;
+  let proverNode: AztecNodeService;
+
+  const setupTest = async (
+    overrides: Partial<EpochsTestOpts> = {},
+    validatorOverrides: { minTxsPerBlock?: number; maxTxsPerBlock?: number } = {},
+  ) => {
+    validators = times(NODE_COUNT, i => {
+      const privateKey = bufferToHex(getPrivateKeyFromIndex(i + 3)!);
+      const attester = EthAddress.fromString(privateKeyToAccount(privateKey).address);
+      return { attester, withdrawer: attester, privateKey, bn254SecretKey: new SecretValue(Fr.random().toBigInt()) };
+    });
+
+    test = await EpochsTestContext.setup({
+      numberOfAccounts: 0,
+      initialValidators: validators,
+      mockGossipSubNetwork: true,
+      disableAnvilTestWatcher: true,
+      aztecProofSubmissionEpochs: 1024,
+      aztecSlotDurationInL1Slots: 3,
+      ethereumSlotDuration: 12,
+      blockDurationMs: 6000,
+      startProverNode: false,
+      enforceTimeTable: true,
+      skipInitialSequencer: true,
+      enableProposerPipelining: true,
+      inboxLag: 2,
+      ...overrides,
+    });
+
+    ({ context, logger } = test);
+    from = context.accounts[0];
+
+    contract = await test.registerTestContract(context.wallet);
+
+    const minTxsPerBlock = validatorOverrides.minTxsPerBlock ?? 0;
+    const maxTxsPerBlock = validatorOverrides.maxTxsPerBlock ?? 1;
+    logger.warn(`Initial setup complete. Starting ${NODE_COUNT} validator nodes.`);
+    nodes = await asyncMap(validators, ({ privateKey }) =>
+      test.createValidatorNode([privateKey], { minTxsPerBlock, maxTxsPerBlock }),
+    );
+
+    proverNode = await test.createProverNode({
+      cancelTxOnTimeout: false,
+      maxSpeedUpAttempts: 0,
+      dontStart: true,
+    });
+    context.proverNode = proverNode;
+
+    logger.warn(`Test setup completed.`, { validators: validators.map(v => v.attester.toString()) });
+  };
+
+  const collectSequencerEvents = (sequencers: SequencerClient[]) => {
+    const published: PublishedEvent[] = [];
+    const preparing: PreparingEvent[] = [];
+    const publishFailures: Parameters<SequencerEvents['checkpoint-publish-failed']>[0][] = [];
+    const blockProposed: Parameters<SequencerEvents['block-proposed']>[0][] = [];
+
+    for (const sequencer of sequencers) {
+      const seq = sequencer.getSequencer();
+      seq.on('checkpoint-published', args => published.push(args));
+      seq.on('preparing-checkpoint', args => preparing.push(args));
+      seq.on('checkpoint-publish-failed', args => publishFailures.push(args));
+      seq.on('block-proposed', args => blockProposed.push(args));
+    }
+
+    return { published, preparing, publishFailures, blockProposed };
+  };
+
+  const computeBoundarySlot = async () => {
+    await retryUntil(
+      async () => {
+        await test.monitor.run(true);
+        return test.monitor.checkpointNumber >= CheckpointNumber(1);
+      },
+      'first checkpoint mined',
+      120,
+      0.5,
+    );
+
+    const firstCheckpoint = await test.rollup.getCheckpoint(CheckpointNumber(1));
+    const firstCheckpointEpoch = getEpochAtSlot(firstCheckpoint.slotNumber, test.constants);
+    logger.warn(`First checkpoint landed in slot ${firstCheckpoint.slotNumber} (epoch ${firstCheckpointEpoch}).`);
+
+    const nowTs = BigInt(test.context.dateProvider.nowInSeconds());
+    const requiredTs = nowTs + BigInt(test.L2_SLOT_DURATION_IN_S * 2);
+    const minEpochFromTime = EpochNumber(getEpochNumberAtTimestamp(requiredTs - 1n, test.constants) + 1);
+    const boundaryEpoch = EpochNumber(Math.max(firstCheckpointEpoch + 2, Number(minEpochFromTime)));
+    const boundarySlot = SlotNumber(Number(boundaryEpoch) * test.epochDuration);
+    const boundaryTs = getTimestampForSlot(boundarySlot, test.constants);
+    logger.warn(`Targeting boundary at slot ${boundarySlot} (epoch ${boundaryEpoch}, ts ${boundaryTs}).`);
+
+    return { boundarySlot, boundaryEpoch, boundaryTs, firstCheckpointEpoch };
+  };
+
+  const waitPastBoundary = async (boundarySlot: SlotNumber) => {
+    await test.monitor.waitUntilL2Slot(SlotNumber(boundarySlot + 2));
+    await retryUntil(
+      async () => {
+        await test.monitor.run(true);
+        return test.monitor.l2SlotNumber >= boundarySlot + 2;
+      },
+      'archiver caught up past boundary',
+      30,
+      0.5,
+    );
+  };
+
+  const waitForFirstCheckpointAfterBoundary = async (
+    events: ReturnType<typeof collectSequencerEvents>,
+    boundarySlot: SlotNumber,
+  ): Promise<PublishedEvent> => {
+    const result = await retryUntil(
+      () => events.published.find(p => Number(p.slot) > Number(boundarySlot)),
+      'first checkpoint published after boundary',
+      Number(test.L2_SLOT_DURATION_IN_S) * 4,
+      0.5,
+    );
+    if (!result) {
+      throw new Error('No checkpoint was published after the boundary');
+    }
+    logger.warn(`First post-boundary checkpoint published`, result);
+    return result;
+  };
+
+  // Asserts that no propose tx ever reached L1 for the boundary slot: the publisher dropped it at
+  // preCheck. We check both that no `checkpoint-published` fired AND that every publish-failure
+  // event for that slot is missing 'propose' from sentActions / failedActions.
+  const assertBoundaryDidNotPropose = (events: ReturnType<typeof collectSequencerEvents>, boundarySlot: SlotNumber) => {
+    const boundaryPublished = events.published.find(p => Number(p.slot) === Number(boundarySlot));
+    expect(boundaryPublished).toBeUndefined();
+
+    const boundaryFailures = events.publishFailures.filter(e => Number(e.slot) === Number(boundarySlot));
+    expect(boundaryFailures.length).toBeGreaterThan(0);
+    for (const failure of boundaryFailures) {
+      expect(failure.sentActions ?? []).not.toContain('propose');
+      expect(failure.failedActions ?? []).not.toContain('propose');
+    }
+  };
+
+  // Tighter happy-path bound: the proof must land BEFORE the boundary slot's pipelined build kicks
+  // off. With pipelining, the boundary slot's build starts at the start of the previous L2 slot
+  // (i.e. boundaryTs - L2_SLOT_DURATION_IN_S). If the proof's L1 block is strictly earlier than
+  // that, the build at the boundary observes `tips.proven` already advanced and skips the override.
+  const assertProofMinedBeforeBoundaryBuild = async (proofReceipt: { blockNumber: bigint }, boundaryTs: bigint) => {
+    const proofBlock = await test.l1Client.getBlock({ blockNumber: proofReceipt.blockNumber });
+    expect(proofBlock.timestamp).toBeLessThan(boundaryTs - BigInt(test.L2_SLOT_DURATION_IN_S));
+    logger.warn(`Proof tx mined at L1 ts ${proofBlock.timestamp}`, {
+      blockNumber: proofReceipt.blockNumber,
+      boundaryTs,
+    });
+  };
+
+  // Tighter window: proof lands in the L2 slot immediately before the boundary (the pipeline-sleep
+  // window), strictly before the boundary timestamp.
+  const assertProofMinedJustBeforeBoundary = async (proofReceipt: { blockNumber: bigint }, boundaryTs: bigint) => {
+    const proofBlock = await test.l1Client.getBlock({ blockNumber: proofReceipt.blockNumber });
+    expect(proofBlock.timestamp).toBeLessThan(boundaryTs);
+    expect(proofBlock.timestamp).toBeGreaterThan(boundaryTs - BigInt(test.L2_SLOT_DURATION_IN_S));
+    logger.warn(`Proof tx mined at L1 ts ${proofBlock.timestamp}`, {
+      blockNumber: proofReceipt.blockNumber,
+      boundaryTs,
+    });
+  };
+
+  afterEach(async () => {
+    jest.restoreAllMocks();
+    await test?.teardown();
+  });
+
+  it('proof lands during slot build and checkpoint succeeds at boundary', async () => {
+    // The proof for the unproven epoch lands AFTER the boundary slot's pipelined build starts but
+    // BEFORE the publisher's preCheck. The proven-override lets the boundary checkpoint build
+    // before the proof has landed; the preCheck succeeds because the proof arrives in time.
+    await setupTest({ aztecProofSubmissionEpochs: 1 });
+
+    const sequencers = nodes.map(node => node.getSequencer()!);
+    const events = collectSequencerEvents(sequencers);
+
+    const { boundarySlot, boundaryTs } = await computeBoundarySlot();
+
+    const proofMineTarget = boundaryTs - BigInt(test.L1_BLOCK_TIME_IN_S);
+    const proofWaitTimeoutSeconds = Number(proofMineTarget) - test.context.dateProvider.nowInSeconds() + 60;
+
+    // Arm the delayer BEFORE starting the prover so the very first tx the prover submits cannot
+    // escape the delay window.
+    const proverDelayer: Delayer = proverNode.getProverNode()!.getDelayer()!;
+    proverDelayer.pauseNextTxUntilTimestamp(proofMineTarget, proofWaitTimeoutSeconds);
+    await proverNode.getProverNode()!.start();
+    logger.warn(`Scheduled proof tx to mine at L1 timestamp ${proofMineTarget}`, {
+      proofMineTarget,
+      boundarySlot,
+      boundaryTs,
+    });
+
+    await waitPastBoundary(boundarySlot);
+
+    const sentProofTxHashes = proverDelayer.getSentTxHashes();
+    expect(sentProofTxHashes.length).toBeGreaterThan(0);
+    const proofTxHash = sentProofTxHashes[0];
+    const proofReceipt = await test.l1Client.getTransactionReceipt({ hash: proofTxHash });
+    expect(proofReceipt.status).toEqual('success');
+
+    await assertProofMinedJustBeforeBoundary(proofReceipt, boundaryTs);
+
+    const boundaryPublished = events.published.find(p => Number(p.slot) === Number(boundarySlot));
+    expect(boundaryPublished).toBeDefined();
+
+    const boundaryPreparing = events.preparing.filter(p => Number(p.targetSlot) === Number(boundarySlot));
+    expect(boundaryPreparing.some(p => p.provenOverride !== undefined)).toBe(true);
+    expect(boundaryPreparing.some(p => p.hadProposedParent)).toBe(true);
+
+    expect(Number(test.monitor.checkpointNumber)).toBeGreaterThanOrEqual(Number(boundaryPublished!.checkpoint));
+    logger.warn(`Test passed. Final tip checkpoint=${test.monitor.checkpointNumber}`);
+  });
+
+  it('proof lands well before deadline and checkpoint succeeds without override', async () => {
+    // Sanity check: the prover runs on its natural schedule, so the proof lands well before the
+    // boundary epoch. By the time the boundary slot is built `tips.proven` is already advanced,
+    // `isPruneDueAtSlot` returns false, and the proven-override does not fire.
+    await setupTest({ aztecProofSubmissionEpochs: 1 });
+
+    const sequencers = nodes.map(node => node.getSequencer()!);
+    const events = collectSequencerEvents(sequencers);
+
+    const { boundarySlot, boundaryTs } = await computeBoundarySlot();
+
+    const proverDelayer: Delayer = proverNode.getProverNode()!.getDelayer()!;
+    await proverNode.getProverNode()!.start();
+
+    await waitPastBoundary(boundarySlot);
+
+    const sentProofTxHashes = proverDelayer.getSentTxHashes();
+    expect(sentProofTxHashes.length).toBeGreaterThan(0);
+    const proofReceipt = await test.l1Client.getTransactionReceipt({ hash: sentProofTxHashes[0] });
+    expect(proofReceipt.status).toEqual('success');
+    await assertProofMinedBeforeBoundaryBuild(proofReceipt, boundaryTs);
+
+    const boundaryPublished = events.published.find(p => Number(p.slot) === Number(boundarySlot));
+    expect(boundaryPublished).toBeDefined();
+
+    const boundaryPreparing = events.preparing.filter(p => Number(p.targetSlot) === Number(boundarySlot));
+    expect(boundaryPreparing.some(p => p.hadProposedParent)).toBe(true);
+    expect(boundaryPreparing.every(p => p.provenOverride === undefined)).toBe(true);
+
+    expect(Number(test.monitor.checkpointNumber)).toBeGreaterThanOrEqual(Number(boundaryPublished!.checkpoint));
+  });
+
+  it('proof never lands so no checkpoint submission is attempted', async () => {
+    // The boundary slot's build applies the proven-override, but the publisher's preCheck rejects
+    // the propose tx because the proof never landed. After the prune fires on a later slot, a
+    // fresh propose advances the chain and a checkpoint is published in the new epoch.
+    await setupTest({ aztecProofSubmissionEpochs: 1 });
+
+    const sequencers = nodes.map(node => node.getSequencer()!);
+    const events = collectSequencerEvents(sequencers);
+
+    const { boundarySlot, boundaryEpoch } = await computeBoundarySlot();
+
+    // Arm the delayer to drop the proof tx BEFORE starting the prover so it cannot escape.
+    const proverDelayer: Delayer = proverNode.getProverNode()!.getDelayer()!;
+    proverDelayer.cancelNextTx();
+    await proverNode.getProverNode()!.start();
+    logger.warn(`Cancelled prover node's next tx; proof will never land.`);
+
+    await waitPastBoundary(boundarySlot);
+
+    assertBoundaryDidNotPropose(events, boundarySlot);
+
+    const boundaryPreparing = events.preparing.filter(p => Number(p.targetSlot) === Number(boundarySlot));
+    expect(boundaryPreparing.some(p => p.hadProposedParent)).toBe(true);
+    expect(boundaryPreparing.some(p => p.provenOverride !== undefined)).toBe(true);
+
+    // After the boundary fails, the next slot's propose tx triggers the on-chain prune (since the
+    // proof never landed and the deadline has expired) and resets `tips.pending`. The fresh
+    // checkpoint against the genesis archive lands at boundarySlot+1: empirically the next slot's
+    // proposer rebuilds with no proposed parent (the boundary's pipelined parent is invalidated
+    // when its publish fails), the on-chain prune fires in-tx on this propose, and the propose
+    // is accepted in the same slot.
+    const firstPostBoundary = await waitForFirstCheckpointAfterBoundary(events, boundarySlot);
+    expect(Number(firstPostBoundary.slot)).toBe(Number(boundarySlot) + 1);
+    expect(getEpochAtSlot(firstPostBoundary.slot, test.constants)).toBe(boundaryEpoch);
+  });
+
+  it('proof lands without a proposed parent and boundary checkpoint succeeds', async () => {
+    // The slot before the boundary is paused so the boundary slot's build does not see a proposed
+    // parent. The proof still lands well before the deadline, so the proven-override never fires
+    // and the boundary checkpoint is published normally.
+    await setupTest({ aztecProofSubmissionEpochs: 1 });
+
+    const sequencers = nodes.map(node => node.getSequencer()!);
+    const events = collectSequencerEvents(sequencers);
+
+    const { boundarySlot } = await computeBoundarySlot();
+    const slotN = SlotNumber(Number(boundarySlot) - 1);
+    logger.warn(`Pausing proposing for slot ${slotN}`);
+
+    for (const sequencer of sequencers) {
+      sequencer.updateConfig({ pauseProposingForSlots: [slotN] });
+    }
+
+    await proverNode.getProverNode()!.start();
+    const proverDelayer: Delayer = proverNode.getProverNode()!.getDelayer()!;
+
+    await waitPastBoundary(boundarySlot);
+
+    const sentProofTxHashes = proverDelayer.getSentTxHashes();
+    expect(sentProofTxHashes.length).toBeGreaterThan(0);
+    const proofReceipt = await test.l1Client.getTransactionReceipt({ hash: sentProofTxHashes[0] });
+    expect(proofReceipt.status).toEqual('success');
+
+    const boundaryPublished = events.published.find(p => Number(p.slot) === Number(boundarySlot));
+    expect(boundaryPublished).toBeDefined();
+
+    const boundaryPreparing = events.preparing.filter(p => Number(p.targetSlot) === Number(boundarySlot));
+    expect(boundaryPreparing.length).toBeGreaterThan(0);
+    expect(boundaryPreparing.every(p => !p.hadProposedParent)).toBe(true);
+    expect(boundaryPreparing.every(p => p.provenOverride === undefined)).toBe(true);
+
+    expect(Number(test.monitor.checkpointNumber)).toBeGreaterThanOrEqual(Number(boundaryPublished!.checkpoint));
+  });
+
+  it('proof never lands without a proposed parent so no checkpoint submission is attempted', async () => {
+    // Same as the no-parent variant above but with the proof never landing. The proven-override
+    // fires (no parent + prune is due) but the publisher's preCheck rejects the propose, so no
+    // checkpoint is published for the boundary slot.
+    await setupTest({ aztecProofSubmissionEpochs: 1 });
+
+    const sequencers = nodes.map(node => node.getSequencer()!);
+    const events = collectSequencerEvents(sequencers);
+
+    const { boundarySlot } = await computeBoundarySlot();
+    const slotN = SlotNumber(Number(boundarySlot) - 1);
+    logger.warn(`Pausing proposing for slot ${slotN}`);
+
+    for (const sequencer of sequencers) {
+      sequencer.updateConfig({ pauseProposingForSlots: [slotN] });
+    }
+
+    const proverDelayer: Delayer = proverNode.getProverNode()!.getDelayer()!;
+    proverDelayer.cancelNextTx();
+    await proverNode.getProverNode()!.start();
+
+    await waitPastBoundary(boundarySlot);
+
+    assertBoundaryDidNotPropose(events, boundarySlot);
+
+    const boundaryPreparing = events.preparing.filter(p => Number(p.targetSlot) === Number(boundarySlot));
+    expect(boundaryPreparing.length).toBeGreaterThan(0);
+    expect(boundaryPreparing.every(p => !p.hadProposedParent)).toBe(true);
+    expect(boundaryPreparing.some(p => p.provenOverride !== undefined)).toBe(true);
+
+    // See the parent test for the reasoning: the on-chain prune fires in-tx on the next slot's
+    // propose, so the first post-boundary checkpoint lands at boundarySlot+1.
+    const firstPostBoundary = await waitForFirstCheckpointAfterBoundary(events, boundarySlot);
+    expect(Number(firstPostBoundary.slot)).toBe(Number(boundarySlot) + 1);
+  });
+});

--- a/yarn-project/end-to-end/src/e2e_l1_publisher/e2e_l1_publisher.test.ts
+++ b/yarn-project/end-to-end/src/e2e_l1_publisher/e2e_l1_publisher.test.ts
@@ -788,7 +788,7 @@ describe('L1Publisher integration', () => {
       const forcePendingCheckpointNumber = invalidateRequest?.forcePendingCheckpointNumber;
       expect(forcePendingCheckpointNumber).toEqual(0);
       const invalidationSimulationOverridesPlan = new SimulationOverridesBuilder()
-        .forPendingCheckpoint(forcePendingCheckpointNumber ?? CheckpointNumber.ZERO)
+        .withChainTips({ pending: forcePendingCheckpointNumber ?? CheckpointNumber.ZERO })
         .build();
 
       // We cannot propose directly, we need to assume the previous checkpoint is invalidated

--- a/yarn-project/ethereum/src/contracts/chain_state_override.test.ts
+++ b/yarn-project/ethereum/src/contracts/chain_state_override.test.ts
@@ -1,0 +1,67 @@
+import { CheckpointNumber } from '@aztec/foundation/branded-types';
+import { Fr } from '@aztec/foundation/curves/bn254';
+
+import { SimulationOverridesBuilder } from './chain_state_override.js';
+
+describe('SimulationOverridesBuilder', () => {
+  it('returns undefined when no overrides are configured', () => {
+    expect(new SimulationOverridesBuilder().build()).toBeUndefined();
+  });
+
+  it('merges chain tips set across multiple withChainTips calls', () => {
+    const plan = new SimulationOverridesBuilder()
+      .withChainTips({ pending: CheckpointNumber(7) })
+      .withChainTips({ proven: CheckpointNumber(3) })
+      .build();
+
+    expect(plan?.chainTipsOverride).toEqual({ pending: CheckpointNumber(7), proven: CheckpointNumber(3) });
+  });
+
+  it('lets later withChainTips calls overwrite the same half', () => {
+    const plan = new SimulationOverridesBuilder()
+      .withChainTips({ pending: CheckpointNumber(7) })
+      .withChainTips({ pending: CheckpointNumber(8) })
+      .build();
+
+    expect(plan?.chainTipsOverride).toEqual({ pending: CheckpointNumber(8) });
+  });
+
+  it('throws when withPendingArchive is called without a pending chain-tip override', () => {
+    expect(() => new SimulationOverridesBuilder().withPendingArchive(Fr.random())).toThrow(
+      /withChainTips\(\{ pending \}\) must be called/,
+    );
+  });
+
+  it('throws when withPendingArchive is called and only proven is set', () => {
+    expect(() =>
+      new SimulationOverridesBuilder().withChainTips({ proven: CheckpointNumber(3) }).withPendingArchive(Fr.random()),
+    ).toThrow(/withChainTips\(\{ pending \}\) must be called/);
+  });
+
+  it('attaches archive override after pending chain-tip override is set', () => {
+    const archive = Fr.random();
+    const plan = new SimulationOverridesBuilder()
+      .withChainTips({ pending: CheckpointNumber(7) })
+      .withPendingArchive(archive)
+      .build();
+
+    expect(plan?.chainTipsOverride).toEqual({ pending: CheckpointNumber(7) });
+    expect(plan?.pendingCheckpointState?.archive).toEqual(archive);
+  });
+
+  it('SimulationOverridesBuilder.from copies chainTipsOverride', () => {
+    const plan = new SimulationOverridesBuilder()
+      .withChainTips({ pending: CheckpointNumber(7), proven: CheckpointNumber(3) })
+      .build();
+
+    const rebuilt = SimulationOverridesBuilder.from(plan).build();
+    expect(rebuilt?.chainTipsOverride).toEqual({ pending: CheckpointNumber(7), proven: CheckpointNumber(3) });
+  });
+
+  it('merge folds chain tips per-half', () => {
+    const builder = new SimulationOverridesBuilder().withChainTips({ pending: CheckpointNumber(7) });
+    builder.merge({ chainTipsOverride: { proven: CheckpointNumber(3) } });
+    const plan = builder.build();
+    expect(plan?.chainTipsOverride).toEqual({ pending: CheckpointNumber(7), proven: CheckpointNumber(3) });
+  });
+});

--- a/yarn-project/ethereum/src/contracts/chain_state_override.ts
+++ b/yarn-project/ethereum/src/contracts/chain_state_override.ts
@@ -11,16 +11,21 @@ export type PendingCheckpointOverrideState = {
   feeHeader?: FeeHeader;
 };
 
+export type ChainTipsOverride = {
+  pending?: CheckpointNumber;
+  proven?: CheckpointNumber;
+};
+
 /** Describes the simulated L1 rollup state that downstream calls should observe. */
 export type SimulationOverridesPlan = {
-  pendingCheckpointNumber?: CheckpointNumber;
+  chainTipsOverride?: ChainTipsOverride;
   pendingCheckpointState?: PendingCheckpointOverrideState;
   disableBlobCheck?: boolean;
 };
 
 /** Builds a single-checkpoint simulation plan before it is translated into a viem state override. */
 export class SimulationOverridesBuilder {
-  private pendingCheckpointNumber?: CheckpointNumber;
+  private chainTipsOverride?: ChainTipsOverride;
   private pendingCheckpointState?: PendingCheckpointOverrideState;
   private disableBlobCheck = false;
 
@@ -29,13 +34,15 @@ export class SimulationOverridesBuilder {
     return new SimulationOverridesBuilder().merge(plan);
   }
 
-  /** Merges another plan into this builder. Later values win. */
+  /** Merges another plan into this builder. Later values win on a per-half basis for chain tips. */
   public merge(plan: SimulationOverridesPlan | undefined): this {
     if (!plan) {
       return this;
     }
 
-    this.pendingCheckpointNumber = plan.pendingCheckpointNumber;
+    if (plan.chainTipsOverride) {
+      this.chainTipsOverride = { ...(this.chainTipsOverride ?? {}), ...plan.chainTipsOverride };
+    }
     this.pendingCheckpointState = plan.pendingCheckpointState
       ? { ...(this.pendingCheckpointState ?? {}), ...plan.pendingCheckpointState }
       : this.pendingCheckpointState;
@@ -44,9 +51,13 @@ export class SimulationOverridesBuilder {
     return this;
   }
 
-  /** Sets the checkpoint number that archive and fee header overrides should attach to. */
-  public forPendingCheckpoint(pendingCheckpointNumber: CheckpointNumber | undefined): this {
-    this.pendingCheckpointNumber = pendingCheckpointNumber;
+  /**
+   * Sets the pending and/or proven checkpoint number overrides. Subsequent calls merge into the existing
+   * override on a per-half basis, so callers can set pending in one call and proven in another without
+   * clobbering each other.
+   */
+  public withChainTips(override: ChainTipsOverride): this {
+    this.chainTipsOverride = { ...(this.chainTipsOverride ?? {}), ...override };
     return this;
   }
 
@@ -72,20 +83,20 @@ export class SimulationOverridesBuilder {
 
   /** Builds the final plan, or `undefined` when no overrides were configured. */
   public build(): SimulationOverridesPlan | undefined {
-    if (!this.pendingCheckpointState && this.pendingCheckpointNumber === undefined && !this.disableBlobCheck) {
+    if (!this.pendingCheckpointState && !this.chainTipsOverride && !this.disableBlobCheck) {
       return undefined;
     }
 
     return {
-      pendingCheckpointNumber: this.pendingCheckpointNumber,
+      chainTipsOverride: this.chainTipsOverride,
       pendingCheckpointState: this.pendingCheckpointState,
       disableBlobCheck: this.disableBlobCheck || undefined,
     };
   }
 
   private assertPendingCheckpointNumber(): void {
-    if (this.pendingCheckpointNumber === undefined) {
-      throw new Error('pendingCheckpointNumber must be set before attaching archive or fee header overrides');
+    if (this.chainTipsOverride?.pending === undefined) {
+      throw new Error('withChainTips({ pending }) must be called before attaching archive or fee header overrides');
     }
   }
 }
@@ -101,20 +112,18 @@ export async function buildSimulationOverridesStateOverride(
 
   const rollupStateDiff: NonNullable<StateOverride[number]['stateDiff']> = [];
 
-  if (plan.pendingCheckpointNumber !== undefined) {
-    rollupStateDiff.push(
-      ...extractRollupStateDiff(await rollup.makePendingCheckpointNumberOverride(plan.pendingCheckpointNumber)),
-    );
+  if (plan.chainTipsOverride) {
+    rollupStateDiff.push(...extractRollupStateDiff(await rollup.makeChainTipsOverride(plan.chainTipsOverride)));
   }
 
-  if (plan.pendingCheckpointState && plan.pendingCheckpointNumber === undefined) {
-    throw new Error('pendingCheckpointState requires pendingCheckpointNumber to be set');
+  if (plan.pendingCheckpointState && plan.chainTipsOverride?.pending === undefined) {
+    throw new Error('pendingCheckpointState requires chainTipsOverride.pending to be set');
   }
 
   if (plan.pendingCheckpointState?.archive) {
     rollupStateDiff.push(
       ...extractRollupStateDiff(
-        rollup.makeArchiveOverride(plan.pendingCheckpointNumber!, plan.pendingCheckpointState.archive),
+        rollup.makeArchiveOverride(plan.chainTipsOverride!.pending!, plan.pendingCheckpointState.archive),
       ),
     );
   }
@@ -122,7 +131,7 @@ export async function buildSimulationOverridesStateOverride(
   if (plan.pendingCheckpointState?.feeHeader) {
     rollupStateDiff.push(
       ...extractRollupStateDiff(
-        await rollup.makeFeeHeaderOverride(plan.pendingCheckpointNumber!, plan.pendingCheckpointState.feeHeader),
+        await rollup.makeFeeHeaderOverride(plan.chainTipsOverride!.pending!, plan.pendingCheckpointState.feeHeader),
       ),
     );
   }

--- a/yarn-project/ethereum/src/contracts/rollup.test.ts
+++ b/yarn-project/ethereum/src/contracts/rollup.test.ts
@@ -266,52 +266,96 @@ describe('Rollup', () => {
     await anvil?.stop().catch(err => createLogger('cleanup').error(err));
   });
 
-  describe('makePendingCheckpointNumberOverride', () => {
-    it('creates state override that correctly overrides pending checkpoint number', async () => {
-      const testProvenCheckpointNumber = CheckpointNumber(42);
-      const testPendingCheckpointNumber = CheckpointNumber(100);
-      const newPendingCheckpointNumber = CheckpointNumber(150);
+  describe('makeChainTipsOverride', () => {
+    const testProvenCheckpointNumber = CheckpointNumber(42);
+    const testPendingCheckpointNumber = CheckpointNumber(100);
 
-      // Set storage directly using cheat codes
-      // The storage slot stores both values: pending (high 128 bits) | proven (low 128 bits)
+    async function setLiveTips(pending: CheckpointNumber, proven: CheckpointNumber) {
       const storageSlot = RollupContract.stfStorageSlot;
-      const packedValue = (BigInt(testPendingCheckpointNumber) << 128n) | BigInt(testProvenCheckpointNumber);
+      const packedValue = (BigInt(pending) << 128n) | BigInt(proven);
       await cheatCodes.store(EthAddress.fromString(rollupAddress), BigInt(storageSlot), packedValue);
+    }
 
-      // Verify the values were set correctly by calling the getters directly
-      const provenCheckpointNumber = await rollup.getProvenCheckpointNumber();
-      const pendingCheckpointNumber = await rollup.getCheckpointNumber();
+    async function readOverridden(stateOverride: Awaited<ReturnType<RollupContract['makeChainTipsOverride']>>) {
+      const [pendingResult, provenResult] = await Promise.all([
+        publicClient.simulateContract({
+          address: rollupAddress,
+          abi: RollupAbi as Abi,
+          functionName: 'getPendingCheckpointNumber',
+          stateOverride,
+        }),
+        publicClient.simulateContract({
+          address: rollupAddress,
+          abi: RollupAbi as Abi,
+          functionName: 'getProvenCheckpointNumber',
+          stateOverride,
+        }),
+      ]);
+      return {
+        pending: CheckpointNumber.fromBigInt(pendingResult.result),
+        proven: CheckpointNumber.fromBigInt(provenResult.result),
+      };
+    }
 
-      expect(provenCheckpointNumber).toBe(testProvenCheckpointNumber);
-      expect(pendingCheckpointNumber).toBe(testPendingCheckpointNumber);
+    it('emits a single combined state-diff when both pending and proven are set', async () => {
+      await setLiveTips(testPendingCheckpointNumber, testProvenCheckpointNumber);
 
-      // Create the override
-      const stateOverride = await rollup.makePendingCheckpointNumberOverride(newPendingCheckpointNumber);
+      const newPending = CheckpointNumber(150);
+      const newProven = CheckpointNumber(75);
+      const stateOverride = await rollup.makeChainTipsOverride({ pending: newPending, proven: newProven });
 
-      // Test the override using simulateContract
-      const { result: overriddenPendingCheckpointNumber } = await publicClient.simulateContract({
-        address: rollupAddress,
-        abi: RollupAbi as Abi,
-        functionName: 'getPendingCheckpointNumber',
-        stateOverride,
-      });
+      expect(stateOverride).toHaveLength(1);
+      expect(stateOverride[0].stateDiff).toHaveLength(1);
+      expect(stateOverride[0].stateDiff![0].slot).toBe(RollupContract.stfStorageSlot);
+      const expectedValue = (BigInt(newPending) << 128n) | BigInt(newProven);
+      expect(stateOverride[0].stateDiff![0].value).toBe(`0x${expectedValue.toString(16).padStart(64, '0')}`);
 
-      // The overridden value should be the new pending checkpoint number
-      expect(overriddenPendingCheckpointNumber).toBe(BigInt(newPendingCheckpointNumber));
+      const observed = await readOverridden(stateOverride);
+      expect(observed.pending).toBe(newPending);
+      expect(observed.proven).toBe(newProven);
+    });
 
-      // Verify that the proven checkpoint number is preserved in the override
-      const { result: overriddenProvenCheckpointNumber } = await publicClient.simulateContract({
-        address: rollupAddress,
-        abi: RollupAbi as Abi,
-        functionName: 'getProvenCheckpointNumber',
-        stateOverride,
-      });
+    it('preserves the live proven half when only pending is overridden', async () => {
+      await setLiveTips(testPendingCheckpointNumber, testProvenCheckpointNumber);
 
-      expect(CheckpointNumber.fromBigInt(overriddenProvenCheckpointNumber)).toBe(testProvenCheckpointNumber);
+      const newPending = CheckpointNumber(150);
+      const stateOverride = await rollup.makeChainTipsOverride({ pending: newPending });
 
-      // Verify the actual storage hasn't changed
-      const actualPendingCheckpointNumber = await rollup.getCheckpointNumber();
-      expect(actualPendingCheckpointNumber).toBe(testPendingCheckpointNumber);
+      const observed = await readOverridden(stateOverride);
+      expect(observed.pending).toBe(newPending);
+      expect(observed.proven).toBe(testProvenCheckpointNumber);
+    });
+
+    it('preserves the live pending half when only proven is overridden', async () => {
+      await setLiveTips(testPendingCheckpointNumber, testProvenCheckpointNumber);
+
+      const newProven = CheckpointNumber(75);
+      const stateOverride = await rollup.makeChainTipsOverride({ proven: newProven });
+
+      const observed = await readOverridden(stateOverride);
+      expect(observed.pending).toBe(testPendingCheckpointNumber);
+      expect(observed.proven).toBe(newProven);
+    });
+
+    it('returns an empty override when neither pending nor proven is set', async () => {
+      const stateOverride = await rollup.makeChainTipsOverride({});
+      expect(stateOverride).toEqual([]);
+    });
+
+    it('throws when the resulting proven > pending', async () => {
+      await setLiveTips(testPendingCheckpointNumber, testProvenCheckpointNumber);
+
+      await expect(
+        rollup.makeChainTipsOverride({ pending: CheckpointNumber(50), proven: CheckpointNumber(100) }),
+      ).rejects.toThrow(/proven .* > pending/);
+    });
+
+    it('throws when only proven is set and the resulting proven > live pending', async () => {
+      await setLiveTips(CheckpointNumber(10), CheckpointNumber(5));
+
+      await expect(rollup.makeChainTipsOverride({ proven: CheckpointNumber(20) })).rejects.toThrow(
+        /proven .* > pending/,
+      );
     });
   });
 

--- a/yarn-project/ethereum/src/contracts/rollup.ts
+++ b/yarn-project/ethereum/src/contracts/rollup.ts
@@ -844,20 +844,32 @@ export class RollupContract {
   }
 
   /**
-   * Returns a state override that sets the pending checkpoint number to the specified value. Useful for simulations.
-   * Requires querying the current state of the contract to get the current proven checkpoint number, as they are both
-   * stored in the same slot. If the argument is undefined, it returns an empty override.
+   * Returns a state override that sets the pending and/or proven checkpoint numbers. Useful for simulations.
+   * Both values share a single storage slot (pending in the upper 128 bits, proven in the lower 128 bits), so
+   * a single combined override is emitted to avoid the second state-diff clobbering the first. The current live
+   * value is read once to preserve any half not being overridden. Returns an empty override if neither is set.
+   *
+   * Throws if the resulting `proven > pending`, which would crash the simulation: `STFLib.canPruneAtTime` calls
+   * `getEpochForCheckpoint(proven + 1)` whenever `pending != proven`, and that asserts `_n <= tips.pending`.
    */
-  public async makePendingCheckpointNumberOverride(
-    forcePendingCheckpointNumber: CheckpointNumber | undefined,
-  ): Promise<StateOverride> {
-    if (forcePendingCheckpointNumber === undefined) {
+  public async makeChainTipsOverride(override: {
+    pending?: CheckpointNumber;
+    proven?: CheckpointNumber;
+  }): Promise<StateOverride> {
+    if (override.pending === undefined && override.proven === undefined) {
       return [];
     }
     const slot = RollupContract.stfStorageSlot;
     const currentValue = await this.client.getStorageAt({ address: this.address, slot });
-    const currentProvenCheckpointNumber = currentValue ? hexToBigInt(currentValue) & ((1n << 128n) - 1n) : 0n;
-    const newValue = (BigInt(forcePendingCheckpointNumber) << 128n) | currentProvenCheckpointNumber;
+    const currentRaw = currentValue ? hexToBigInt(currentValue) : 0n;
+    const currentPending = currentRaw >> 128n;
+    const currentProven = currentRaw & ((1n << 128n) - 1n);
+    const newPending = override.pending !== undefined ? BigInt(override.pending) : currentPending;
+    const newProven = override.proven !== undefined ? BigInt(override.proven) : currentProven;
+    if (newProven > newPending) {
+      throw new Error(`Invalid chain tips override: proven (${newProven}) > pending (${newPending})`);
+    }
+    const newValue = (newPending << 128n) | newProven;
     return [
       {
         address: this.address,

--- a/yarn-project/ethereum/src/l1_tx_utils/tx_delayer.ts
+++ b/yarn-project/ethereum/src/l1_tx_utils/tx_delayer.ts
@@ -81,7 +81,11 @@ export class Delayer {
 
   public maxInclusionTimeIntoSlot: number | undefined = undefined;
   public ethereumSlotDuration: bigint;
-  public nextWait: { l1Timestamp: bigint } | { l1BlockNumber: bigint } | { indefinitely: true } | undefined = undefined;
+  public nextWait:
+    | { l1Timestamp: bigint; timeoutSeconds?: number }
+    | { l1BlockNumber: bigint; timeoutSeconds?: number }
+    | { indefinitely: true }
+    | undefined = undefined;
   public sentTxHashes: Hex[] = [];
   public cancelledTxs: Hex[] = [];
 
@@ -110,13 +114,13 @@ export class Delayer {
   }
 
   /** Delays the next tx to be sent so it lands on the given L1 block number. */
-  pauseNextTxUntilBlock(l1BlockNumber: number | bigint) {
-    this.nextWait = { l1BlockNumber: BigInt(l1BlockNumber) };
+  pauseNextTxUntilBlock(l1BlockNumber: number | bigint, timeoutSeconds?: number) {
+    this.nextWait = { l1BlockNumber: BigInt(l1BlockNumber), timeoutSeconds };
   }
 
   /** Delays the next tx to be sent so it lands on the given timestamp. */
-  pauseNextTxUntilTimestamp(l1Timestamp: number | bigint) {
-    this.nextWait = { l1Timestamp: BigInt(l1Timestamp) };
+  pauseNextTxUntilTimestamp(l1Timestamp: number | bigint, timeoutSeconds?: number) {
+    this.nextWait = { l1Timestamp: BigInt(l1Timestamp), timeoutSeconds };
   }
 
   /** Delays the next tx to be sent indefinitely. */
@@ -198,9 +202,14 @@ export function wrapClientWithDelayer<T extends ViemClient>(client: T, delayer: 
           // Or wait until the desired block number or timestamp
           wait =
             'l1BlockNumber' in waitUntil
-              ? waitUntilBlock(publicClient, waitUntil.l1BlockNumber - 1n, logger)
+              ? waitUntilBlock(publicClient, waitUntil.l1BlockNumber - 1n, logger, waitUntil.timeoutSeconds)
               : 'l1Timestamp' in waitUntil
-                ? waitUntilL1Timestamp(publicClient, waitUntil.l1Timestamp - delayer.ethereumSlotDuration, logger)
+                ? waitUntilL1Timestamp(
+                    publicClient,
+                    waitUntil.l1Timestamp - delayer.ethereumSlotDuration,
+                    logger,
+                    waitUntil.timeoutSeconds,
+                  )
                 : undefined;
 
           logger.info(`Delaying tx ${txHash} until ${inspect(waitUntil)}`, {

--- a/yarn-project/sequencer-client/src/config.ts
+++ b/yarn-project/sequencer-client/src/config.ts
@@ -235,6 +235,10 @@ export const sequencerConfigMappings: ConfigMappingsType<SequencerConfig> = {
     description: 'Skip broadcasting checkpoint and block proposals via gossipsub when proposer (for testing only)',
     ...booleanConfigHelper(false),
   },
+  pauseProposingForSlots: {
+    description:
+      'List of slots for which the sequencer will not produce a proposal (for testing only). Attestation paths are unaffected.',
+  },
   ...pickConfigMappings(p2pConfigMappings, ['txPublicSetupAllowListExtend']),
 };
 

--- a/yarn-project/sequencer-client/src/publisher/sequencer-publisher.test.ts
+++ b/yarn-project/sequencer-client/src/publisher/sequencer-publisher.test.ts
@@ -6,6 +6,7 @@ import {
   type GovernanceProposerContract,
   Multicall3,
   type RollupContract,
+  type SimulationOverridesPlan,
   type SlashingProposerContract,
 } from '@aztec/ethereum/contracts';
 import {
@@ -15,7 +16,8 @@ import {
   defaultL1TxUtilsConfig,
 } from '@aztec/ethereum/l1-tx-utils';
 import { FormattedViemError } from '@aztec/ethereum/utils';
-import { BlockNumber, EpochNumber, SlotNumber } from '@aztec/foundation/branded-types';
+import { BlockNumber, CheckpointNumber, EpochNumber, SlotNumber } from '@aztec/foundation/branded-types';
+import { Fr } from '@aztec/foundation/curves/bn254';
 import { TimeoutError } from '@aztec/foundation/error';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { sleep } from '@aztec/foundation/sleep';
@@ -459,6 +461,89 @@ describe('SequencerPublisher', () => {
     const result = await publisher.sendRequests();
     expect(result).toEqual(undefined);
     expect(forwardSpy).not.toHaveBeenCalled();
+  });
+
+  it('preCheck closure uses preCheckSimulationOverridesPlan, not the enqueue-time plan', async () => {
+    (publisher.epochCache.isProposerPipeliningEnabled as jest.Mock).mockReturnValue(true);
+
+    const validateSpy = jest.spyOn(publisher, 'validateCheckpointForSubmission').mockResolvedValue(undefined);
+
+    const enqueuePlan: SimulationOverridesPlan = {
+      chainTipsOverride: { pending: CheckpointNumber(7) },
+      pendingCheckpointState: { archive: Fr.random() },
+    };
+    const preCheckPlan: SimulationOverridesPlan = {
+      chainTipsOverride: { pending: CheckpointNumber(8) },
+    };
+
+    await publisher.enqueueProposeCheckpoint(
+      new Checkpoint(l2Block.archive, header, [l2Block], l2Block.checkpointNumber),
+      CommitteeAttestationsAndSigners.empty(testSignatureContext),
+      Signature.empty(),
+      { simulationOverridesPlan: enqueuePlan, preCheckSimulationOverridesPlan: preCheckPlan },
+    );
+
+    // Enqueue-time validation called with the enqueue plan (plus withoutBlobCheck applied).
+    expect(validateSpy).toHaveBeenCalledTimes(1);
+    expect(validateSpy.mock.calls[0][3]).toMatchObject({
+      chainTipsOverride: { pending: CheckpointNumber(7) },
+      disableBlobCheck: true,
+    });
+
+    // The pending preCheck request should now run the preCheck closure with the preCheck plan.
+    const requests: { preCheck?: () => Promise<void> }[] = (publisher as any).requests;
+    expect(requests).toHaveLength(1);
+    const preCheck = requests[0].preCheck;
+    expect(preCheck).toBeDefined();
+
+    validateSpy.mockClear();
+    await preCheck!();
+
+    expect(validateSpy).toHaveBeenCalledTimes(1);
+    expect(validateSpy.mock.calls[0][3]).toMatchObject({
+      chainTipsOverride: { pending: CheckpointNumber(8) },
+      disableBlobCheck: true,
+    });
+    // And not the enqueue plan's archive override.
+    expect(validateSpy.mock.calls[0][3]?.pendingCheckpointState).toBeUndefined();
+  });
+
+  it('preCheck does not fall back to the enqueue plan when preCheckSimulationOverridesPlan is omitted', async () => {
+    (publisher.epochCache.isProposerPipeliningEnabled as jest.Mock).mockReturnValue(true);
+
+    const validateSpy = jest.spyOn(publisher, 'validateCheckpointForSubmission').mockResolvedValue(undefined);
+
+    const enqueuePlan: SimulationOverridesPlan = {
+      chainTipsOverride: { pending: CheckpointNumber(7) },
+      pendingCheckpointState: { archive: Fr.random() },
+    };
+
+    await publisher.enqueueProposeCheckpoint(
+      new Checkpoint(l2Block.archive, header, [l2Block], l2Block.checkpointNumber),
+      CommitteeAttestationsAndSigners.empty(testSignatureContext),
+      Signature.empty(),
+      { simulationOverridesPlan: enqueuePlan },
+    );
+
+    expect(validateSpy).toHaveBeenCalledTimes(1);
+    expect(validateSpy.mock.calls[0][3]).toMatchObject({
+      chainTipsOverride: { pending: CheckpointNumber(7) },
+      disableBlobCheck: true,
+    });
+
+    const requests: { preCheck?: () => Promise<void> }[] = (publisher as any).requests;
+    expect(requests).toHaveLength(1);
+    const preCheck = requests[0].preCheck;
+    expect(preCheck).toBeDefined();
+
+    validateSpy.mockClear();
+    await preCheck!();
+
+    expect(validateSpy).toHaveBeenCalledTimes(1);
+    const preCheckArg = validateSpy.mock.calls[0][3];
+    expect(preCheckArg?.disableBlobCheck).toBe(true);
+    expect(preCheckArg?.chainTipsOverride).toBeUndefined();
+    expect(preCheckArg?.pendingCheckpointState).toBeUndefined();
   });
 
   it('returns errorMsg if forwarder tx reverts', async () => {

--- a/yarn-project/sequencer-client/src/publisher/sequencer-publisher.ts
+++ b/yarn-project/sequencer-client/src/publisher/sequencer-publisher.ts
@@ -120,6 +120,13 @@ export type InvalidateCheckpointRequest = {
 type EnqueueProposeCheckpointOpts = {
   txTimeoutAt?: Date;
   simulationOverridesPlan?: SimulationOverridesPlan;
+  /**
+   * Overrides to apply to the preCheck simulation right before L1 submission.
+   * Intentionally separate from `simulationOverridesPlan`: enqueue-time validation
+   * may need pipelined-parent / pretend-proof-landed overrides, but preCheck must
+   * reflect real L1 state to catch state drift between build and submission.
+   */
+  preCheckSimulationOverridesPlan?: SimulationOverridesPlan;
 };
 
 interface RequestWithExpiry {
@@ -1157,6 +1164,10 @@ export class SequencerPublisher {
       .withoutBlobCheck()
       .build();
 
+    const preCheckSimulationOverridesPlan = SimulationOverridesBuilder.from(opts.preCheckSimulationOverridesPlan)
+      .withoutBlobCheck()
+      .build();
+
     try {
       // @note  This will make sure that we are passing the checks for our header ASSUMING that the data is also made available
       //        This means that we can avoid the simulation issues in later checks.
@@ -1188,7 +1199,7 @@ export class SequencerPublisher {
           checkpoint,
           attestationsAndSigners,
           attestationsAndSignersSignature,
-          simulationOverridesPlan,
+          preCheckSimulationOverridesPlan,
         );
       };
     }

--- a/yarn-project/sequencer-client/src/sequencer/chain_state_overrides.ts
+++ b/yarn-project/sequencer-client/src/sequencer/chain_state_overrides.ts
@@ -9,6 +9,14 @@ type PipelinedParentSimulationOverridesPlanInput = {
   proposedCheckpointData?: ProposedCheckpointData;
   rollup: RollupContract;
   log: Logger;
+  /**
+   * Whether proposer pipelining is enabled. Controls only the parent pending/fee-header
+   * portion of the plan — the proven override below is independent of pipelining because
+   * the boundary build needs it for globals and enqueue-time validation regardless.
+   */
+  pipeliningEnabled: boolean;
+  /** If set, also overrides `tips.proven` so `canPruneAtTime` returns false at the simulation timestamp. */
+  prunePending?: { provenOverride: CheckpointNumber };
 };
 
 type SubmissionSimulationOverridesPlanInput = {
@@ -18,16 +26,29 @@ type SubmissionSimulationOverridesPlanInput = {
   pipeliningEnabled: boolean;
 };
 
-/** Builds the simulated parent checkpoint view used while constructing a pipelined proposal. */
+/**
+ * Builds the simulated chain view used while constructing a checkpoint proposal. May carry:
+ * - A pending parent override + fee header (only when pipelining is enabled).
+ * - A proven override (whenever `prunePending` is set, even with pipelining off — the boundary
+ *   build needs it for the globals builder's mana-min-fee lookup and the enqueue-time
+ *   submission simulation regardless of pipelining).
+ */
 export async function buildPipelinedParentSimulationOverridesPlan(
   input: PipelinedParentSimulationOverridesPlanInput,
 ): Promise<SimulationOverridesPlan | undefined> {
-  const parentCheckpointNumber = CheckpointNumber(input.checkpointNumber - 1);
-  const builder = new SimulationOverridesBuilder().forPendingCheckpoint(parentCheckpointNumber);
+  const builder = new SimulationOverridesBuilder();
 
-  const pendingFeeHeader = await computePipelinedParentFeeHeader(input);
-  if (pendingFeeHeader) {
-    builder.withPendingFeeHeader(pendingFeeHeader);
+  if (input.pipeliningEnabled) {
+    const parentCheckpointNumber = CheckpointNumber(input.checkpointNumber - 1);
+    builder.withChainTips({ pending: parentCheckpointNumber });
+    const pendingFeeHeader = await computePipelinedParentFeeHeader(input);
+    if (pendingFeeHeader) {
+      builder.withPendingFeeHeader(pendingFeeHeader);
+    }
+  }
+
+  if (input.prunePending) {
+    builder.withChainTips({ proven: input.prunePending.provenOverride });
   }
 
   return builder.build();
@@ -38,11 +59,12 @@ export function buildSubmissionSimulationOverridesPlan(
   input: SubmissionSimulationOverridesPlanInput,
 ): SimulationOverridesPlan | undefined {
   const pendingCheckpointNumber =
-    input.invalidateToPendingCheckpointNumber ?? input.pipelinedParentPlan?.pendingCheckpointNumber;
+    input.invalidateToPendingCheckpointNumber ?? input.pipelinedParentPlan?.chainTipsOverride?.pending;
 
-  const builder = SimulationOverridesBuilder.from(input.pipelinedParentPlan).forPendingCheckpoint(
-    pendingCheckpointNumber,
-  );
+  const builder = SimulationOverridesBuilder.from(input.pipelinedParentPlan);
+  if (pendingCheckpointNumber !== undefined) {
+    builder.withChainTips({ pending: pendingCheckpointNumber });
+  }
 
   if (input.pipeliningEnabled && pendingCheckpointNumber !== undefined) {
     builder.withPendingArchive(input.lastArchiveRoot);
@@ -51,8 +73,15 @@ export function buildSubmissionSimulationOverridesPlan(
   return builder.build();
 }
 
+type PipelinedParentFeeHeaderInput = {
+  checkpointNumber: CheckpointNumber;
+  proposedCheckpointData?: ProposedCheckpointData;
+  rollup: RollupContract;
+  log: Logger;
+};
+
 /** Derives the pending parent fee header used during pipelined proposal simulation. */
-export async function computePipelinedParentFeeHeader(input: PipelinedParentSimulationOverridesPlanInput) {
+export async function computePipelinedParentFeeHeader(input: PipelinedParentFeeHeaderInput) {
   if (!input.proposedCheckpointData || input.checkpointNumber < 2) {
     return undefined;
   }

--- a/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.test.ts
@@ -69,7 +69,10 @@ import {
   mockTxIterator,
   setupTxsAndBlock,
 } from '../test/utils.js';
-import { computePipelinedParentFeeHeader } from './chain_state_overrides.js';
+import {
+  buildPipelinedParentSimulationOverridesPlan,
+  computePipelinedParentFeeHeader,
+} from './chain_state_overrides.js';
 import { CheckpointProposalJob } from './checkpoint_proposal_job.js';
 import type { CheckpointProposalJobMetricsRecorder } from './checkpoint_proposal_job_metrics.js';
 import type { SequencerEvents } from './events.js';
@@ -765,6 +768,59 @@ describe('CheckpointProposalJob', () => {
         log: createLogger('test'),
       });
       expect(result).toBeUndefined();
+    });
+  });
+
+  describe('buildPipelinedParentSimulationOverridesPlan', () => {
+    const checkpointNumberUnderTest = CheckpointNumber(2);
+
+    it('sets pending override for the parent checkpoint when pipelining is enabled', async () => {
+      const plan = await buildPipelinedParentSimulationOverridesPlan({
+        checkpointNumber: checkpointNumberUnderTest,
+        proposedCheckpointData: undefined,
+        rollup: publisher.rollupContract,
+        log: createLogger('test'),
+        pipeliningEnabled: true,
+      });
+      expect(plan?.chainTipsOverride?.pending).toEqual(CheckpointNumber(1));
+      expect(plan?.chainTipsOverride?.proven).toBeUndefined();
+    });
+
+    it('returns undefined when pipelining off and no prunePending', async () => {
+      const plan = await buildPipelinedParentSimulationOverridesPlan({
+        checkpointNumber: checkpointNumberUnderTest,
+        proposedCheckpointData: undefined,
+        rollup: publisher.rollupContract,
+        log: createLogger('test'),
+        pipeliningEnabled: false,
+      });
+      expect(plan).toBeUndefined();
+    });
+
+    it('returns plan with proven-only override when pipelining off and prunePending is set', async () => {
+      const plan = await buildPipelinedParentSimulationOverridesPlan({
+        checkpointNumber: checkpointNumberUnderTest,
+        proposedCheckpointData: undefined,
+        rollup: publisher.rollupContract,
+        log: createLogger('test'),
+        pipeliningEnabled: false,
+        prunePending: { provenOverride: CheckpointNumber(0) },
+      });
+      expect(plan?.chainTipsOverride?.pending).toBeUndefined();
+      expect(plan?.chainTipsOverride?.proven).toEqual(CheckpointNumber(0));
+    });
+
+    it('attaches both parent and proven overrides when pipelining on and prunePending is set', async () => {
+      const plan = await buildPipelinedParentSimulationOverridesPlan({
+        checkpointNumber: checkpointNumberUnderTest,
+        proposedCheckpointData: undefined,
+        rollup: publisher.rollupContract,
+        log: createLogger('test'),
+        pipeliningEnabled: true,
+        prunePending: { provenOverride: CheckpointNumber(0) },
+      });
+      expect(plan?.chainTipsOverride?.pending).toEqual(CheckpointNumber(1));
+      expect(plan?.chainTipsOverride?.proven).toEqual(CheckpointNumber(0));
     });
   });
 

--- a/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.ts
+++ b/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.ts
@@ -104,7 +104,11 @@ export class CheckpointProposalJob implements Traceable {
   /** Tracks the fire-and-forget L1 submission promise so it can be awaited during shutdown. */
   private pendingL1Submission: Promise<void> | undefined;
 
-  /** Pipelined parent chain state used while building and later submitting this checkpoint. */
+  /**
+   * Build-time chain state overrides used both during build (globals + invariant checks) and
+   * later for enqueue-time submission validation. May carry the pipelined parent override, the
+   * pretend-proof-landed (`proven`) override at an epoch boundary, or both.
+   */
   private pipelinedParentSimulationOverridesPlan?: SimulationOverridesPlan;
 
   private getSignatureContext(): CoordinationSignatureContext {
@@ -144,6 +148,7 @@ export class CheckpointProposalJob implements Traceable {
     public readonly tracer: Tracer,
     bindings?: LoggerBindings,
     private readonly proposedCheckpointData?: ProposedCheckpointData,
+    private readonly prunePending?: { provenOverride: CheckpointNumber },
   ) {
     this.log = createLogger('sequencer:checkpoint-proposal', {
       ...bindings,
@@ -345,8 +350,15 @@ export class CheckpointProposalJob implements Traceable {
     }
 
     const isPipelining = this.epochCache.isProposerPipeliningEnabled();
-    const submissionSimulationOverridesPlan = buildSubmissionSimulationOverridesPlan({
+    const enqueueSimulationOverridesPlan = buildSubmissionSimulationOverridesPlan({
       pipelinedParentPlan: this.pipelinedParentSimulationOverridesPlan,
+      invalidateToPendingCheckpointNumber: this.invalidateCheckpoint?.forcePendingCheckpointNumber,
+      lastArchiveRoot: checkpoint.header.lastArchiveRoot,
+      pipeliningEnabled: isPipelining,
+    });
+
+    const preCheckSimulationOverridesPlan = buildSubmissionSimulationOverridesPlan({
+      pipelinedParentPlan: undefined,
       invalidateToPendingCheckpointNumber: this.invalidateCheckpoint?.forcePendingCheckpointNumber,
       lastArchiveRoot: checkpoint.header.lastArchiveRoot,
       pipeliningEnabled: isPipelining,
@@ -354,7 +366,8 @@ export class CheckpointProposalJob implements Traceable {
 
     await this.publisher.enqueueProposeCheckpoint(checkpoint, attestations, attestationsSignature, {
       txTimeoutAt,
-      ...(submissionSimulationOverridesPlan ? { simulationOverridesPlan: submissionSimulationOverridesPlan } : {}),
+      simulationOverridesPlan: enqueueSimulationOverridesPlan,
+      preCheckSimulationOverridesPlan,
     });
   }
 
@@ -540,14 +553,14 @@ export class CheckpointProposalJob implements Traceable {
       // When pipelining, force the proposed checkpoint number and fee header to our parent so the
       // fee computation sees the same chain tip that L1 will see once the previous pipelined checkpoint lands.
       const isPipelining = this.epochCache.isProposerPipeliningEnabled();
-      this.pipelinedParentSimulationOverridesPlan = isPipelining
-        ? await buildPipelinedParentSimulationOverridesPlan({
-            checkpointNumber: this.checkpointNumber,
-            proposedCheckpointData: this.proposedCheckpointData,
-            rollup: this.publisher.rollupContract,
-            log: this.log,
-          })
-        : undefined;
+      this.pipelinedParentSimulationOverridesPlan = await buildPipelinedParentSimulationOverridesPlan({
+        checkpointNumber: this.checkpointNumber,
+        proposedCheckpointData: this.proposedCheckpointData,
+        rollup: this.publisher.rollupContract,
+        log: this.log,
+        pipeliningEnabled: isPipelining,
+        prunePending: this.prunePending,
+      });
 
       const checkpointGlobalVariables = await this.globalsBuilder.buildCheckpointGlobalVariables(
         coinbase,

--- a/yarn-project/sequencer-client/src/sequencer/events.ts
+++ b/yarn-project/sequencer-client/src/sequencer/events.ts
@@ -10,6 +10,26 @@ export type SequencerEvents = {
     secondsIntoSlot?: number;
     slot?: SlotNumber;
   }) => void;
+  /**
+   * Emitted by the sequencer once it has decided it is going to attempt to build a
+   * checkpoint for `targetSlot`, after computing the L1 simulation overrides used by
+   * `canProposeAt`. Fired BEFORE the L1 simulation is run, so consumers can observe the
+   * decision regardless of whether the propose ultimately lands.
+   *
+   * - `hadProposedParent` indicates whether the build saw a proposed (pipelined) parent
+   *   checkpoint that hasn't landed on L1 yet.
+   * - `provenOverride` is the assumed proven checkpoint number when the proven-override
+   *   for a pending prune was applied; `undefined` when no override was applied.
+   * - `simulatedPending` is the pending checkpoint passed to L1 simulation (when
+   *   pipelining or invalidating; undefined otherwise).
+   */
+  ['preparing-checkpoint']: (args: {
+    targetSlot: SlotNumber;
+    checkpointNumber: CheckpointNumber;
+    hadProposedParent: boolean;
+    provenOverride: CheckpointNumber | undefined;
+    simulatedPending: CheckpointNumber | undefined;
+  }) => void;
   ['proposer-rollup-check-failed']: (args: { reason: string; slot: SlotNumber }) => void;
   ['block-tx-count-check-failed']: (args: { minTxs: number; availableTxs: number; slot: SlotNumber }) => void;
   ['block-build-failed']: (args: { reason: string; slot: SlotNumber }) => void;

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.test.ts
@@ -393,6 +393,30 @@ describe('sequencer', () => {
       expectPublisherProposeL2Block();
     });
 
+    it('does not build a block when targetSlot is in pauseProposingForSlots', async () => {
+      await setupSingleTxBlock();
+      const targetSlot = block.header.globalVariables.slotNumber;
+      sequencer.updateConfig({ pauseProposingForSlots: [targetSlot] });
+
+      await sequencer.work();
+
+      expect(checkpointBuilder.buildBlockCalls).toHaveLength(0);
+      expect(publisher.canProposeAt).not.toHaveBeenCalled();
+      expect(publisher.enqueueProposeCheckpoint).not.toHaveBeenCalled();
+    });
+
+    it('still builds a block when targetSlot is not in pauseProposingForSlots', async () => {
+      await setupSingleTxBlock();
+      const targetSlot = block.header.globalVariables.slotNumber;
+      const otherSlot = SlotNumber(Number(targetSlot) + 1);
+      sequencer.updateConfig({ pauseProposingForSlots: [otherSlot] });
+
+      await sequencer.work();
+      await sequencer.awaitLastProposalSubmission();
+
+      expectPublisherProposeL2Block();
+    });
+
     it('does not build a block if it does not have enough time left in the slot', async () => {
       await setupSingleTxBlock();
 
@@ -1081,7 +1105,7 @@ describe('sequencer', () => {
       await sequencer.work();
 
       const simulationOverridesPlan = publisher.canProposeAt.mock.calls.at(-1)?.[2];
-      expect(simulationOverridesPlan?.pendingCheckpointNumber).toEqual(CheckpointNumber(1));
+      expect(simulationOverridesPlan?.chainTipsOverride?.pending).toEqual(CheckpointNumber(1));
       expect(simulationOverridesPlan?.pendingCheckpointState?.archive).toEqual(expect.anything());
     });
 
@@ -1173,6 +1197,129 @@ describe('sequencer', () => {
       await sequencer.work();
 
       expect(publisher.canProposeAt.mock.calls.at(-1)?.[2]).toBeUndefined();
+    });
+
+    it('attaches proven override equal to real pending when isPruneDueAtSlot returns true', async () => {
+      await setupSingleTxBlock();
+
+      // No proposed checkpoint, so we exercise the standalone proven override path.
+      // The default `getL2Tips` mock has checkpointed.checkpoint.number == CheckpointNumber.ZERO.
+      l2BlockSource.isPruneDueAtSlot.mockResolvedValue(true);
+
+      await sequencer.work();
+
+      const plan = publisher.canProposeAt.mock.calls.at(-1)?.[2];
+      expect(plan?.chainTipsOverride?.proven).toEqual(CheckpointNumber.ZERO);
+    });
+
+    it('uses the simulated pending as the proven override when the caller overrides pending', async () => {
+      await setupSingleTxBlock();
+
+      // Set up a pipelined parent (pending override = parentCheckpointNumber = 1).
+      const nonGenesisHash = Fr.random().toString();
+      const proposedCheckpointHash = Fr.random().toString();
+      worldState.status.mockResolvedValue({
+        state: WorldStateRunningState.IDLE,
+        syncSummary: {
+          latestBlockNumber: BlockNumber(1),
+          latestBlockHash: nonGenesisHash,
+          finalizedBlockNumber: BlockNumber.ZERO,
+          oldestHistoricBlockNumber: BlockNumber.ZERO,
+          treesAreSynched: true,
+        },
+      } satisfies WorldStateSynchronizerStatus);
+      const tipsWithBlock1 = {
+        proposed: { number: BlockNumber(1), hash: nonGenesisHash },
+        proposedCheckpoint: {
+          block: { number: BlockNumber(1), hash: nonGenesisHash },
+          checkpoint: { number: CheckpointNumber(1), hash: proposedCheckpointHash },
+        },
+        checkpointed: {
+          block: { number: BlockNumber(1), hash: nonGenesisHash },
+          checkpoint: { number: CheckpointNumber.ZERO, hash: GENESIS_CHECKPOINT_HEADER_HASH.toString() },
+        },
+        proven: {
+          block: { number: BlockNumber(1), hash: nonGenesisHash },
+          checkpoint: { number: CheckpointNumber.ZERO, hash: GENESIS_CHECKPOINT_HEADER_HASH.toString() },
+        },
+        finalized: {
+          block: { number: BlockNumber(1), hash: nonGenesisHash },
+          checkpoint: { number: CheckpointNumber.ZERO, hash: GENESIS_CHECKPOINT_HEADER_HASH.toString() },
+        },
+      };
+      l2BlockSource.getL2Tips.mockResolvedValue(tipsWithBlock1);
+      l1ToL2MessageSource.getL2Tips.mockResolvedValue(tipsWithBlock1);
+      p2p.getStatus.mockResolvedValue({
+        syncedToL2Block: { number: BlockNumber(1), hash: nonGenesisHash },
+      } as any);
+      l2BlockSource.getBlockData.mockResolvedValue({
+        header: BlockHeader.empty({ globalVariables: GlobalVariables.empty({ blockNumber: BlockNumber(1) }) }),
+        archive: AppendOnlyTreeSnapshot.empty(),
+        blockHash: BlockHash.ZERO,
+        checkpointNumber: CheckpointNumber(1),
+        indexWithinCheckpoint: IndexWithinCheckpoint(0),
+      } satisfies BlockData);
+      l2BlockSource.getProposedCheckpointData.mockResolvedValue({
+        checkpointNumber: CheckpointNumber(1),
+      } as any);
+
+      // The sequencer sets proven == simulated pending so canPruneAtTime short-circuits to false.
+      l2BlockSource.isPruneDueAtSlot.mockResolvedValue(true);
+
+      await sequencer.work();
+
+      const plan = publisher.canProposeAt.mock.calls.at(-1)?.[2];
+      expect(plan?.chainTipsOverride?.pending).toEqual(CheckpointNumber(1));
+      expect(plan?.chainTipsOverride?.proven).toEqual(CheckpointNumber(1));
+    });
+
+    it('does not attach proven override when isPruneDueAtSlot returns false', async () => {
+      await setupSingleTxBlock();
+
+      l2BlockSource.isPruneDueAtSlot.mockResolvedValue(false);
+
+      await sequencer.work();
+
+      const plan = publisher.canProposeAt.mock.calls.at(-1)?.[2];
+      expect(plan?.chainTipsOverride?.proven).toBeUndefined();
+    });
+
+    it('emits preparing-checkpoint with provenOverride when prune is due', async () => {
+      await setupSingleTxBlock();
+
+      l2BlockSource.isPruneDueAtSlot.mockResolvedValue(true);
+
+      const events: any[] = [];
+      sequencer.on('preparing-checkpoint', args => events.push(args));
+
+      await sequencer.work();
+
+      expect(events).toHaveLength(1);
+      expect(events[0]).toEqual({
+        targetSlot: SlotNumber(2),
+        checkpointNumber: expect.anything(),
+        hadProposedParent: false,
+        provenOverride: CheckpointNumber.ZERO,
+        simulatedPending: undefined,
+      });
+    });
+
+    it('emits preparing-checkpoint without provenOverride when no prune is due', async () => {
+      await setupSingleTxBlock();
+
+      l2BlockSource.isPruneDueAtSlot.mockResolvedValue(false);
+
+      const events: any[] = [];
+      sequencer.on('preparing-checkpoint', args => events.push(args));
+
+      await sequencer.work();
+
+      expect(events).toHaveLength(1);
+      expect(events[0]).toMatchObject({
+        targetSlot: SlotNumber(2),
+        hadProposedParent: false,
+        provenOverride: undefined,
+      });
     });
   });
 

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.ts
@@ -286,6 +286,15 @@ export class Sequencer extends (EventEmitter as new () => TypedEventEmitter<Sequ
       return undefined;
     }
 
+    // Test-only: skip proposing for explicitly paused slots. Attestation paths run in the validator
+    // client and are not gated by this hook, so paused proposers still attest to others' proposals.
+    if (this.config.pauseProposingForSlots?.some(s => s === targetSlot)) {
+      this.log.warn(`Skipping proposal for paused slot ${targetSlot} (test-only pauseProposingForSlots hook)`, {
+        targetSlot,
+      });
+      return undefined;
+    }
+
     // Check all components are synced to latest as seen by the archiver (queries all subsystems)
     const syncedTo = await this.checkSync({ ts, slot });
     if (!syncedTo) {
@@ -383,11 +392,14 @@ export class Sequencer extends (EventEmitter as new () => TypedEventEmitter<Sequ
       // Parent checkpoint hasn't landed on L1 yet. Override both the proposed checkpoint number
       // and the archive at that checkpoint so L1 simulation sees the correct chain tip.
       const parentCheckpointNumber = CheckpointNumber(checkpointNumber - 1);
-      l1SimulationOverridesBuilder.forPendingCheckpoint(parentCheckpointNumber).withPendingArchive(syncedTo.archive);
+      l1SimulationOverridesBuilder
+        .withChainTips({ pending: parentCheckpointNumber })
+        .withPendingArchive(syncedTo.archive);
       this.metrics.recordPipelineDepth(syncedTo.checkpointNumber - syncedTo.checkpointedCheckpointNumber);
 
       this.log.verbose(
-        `Building on top of proposed checkpoint (pending=${syncedTo.proposedCheckpointData?.checkpointNumber})`,
+        `Building on top of proposed checkpoint (pending=${syncedTo.proposedCheckpointData?.checkpointNumber}) for target slot ${targetSlot}`,
+        { targetSlot, parentCheckpointNumber },
       );
       // Clear the invalidation - the proposed checkpoint should handle it.
       invalidateCheckpoint = undefined;
@@ -395,13 +407,37 @@ export class Sequencer extends (EventEmitter as new () => TypedEventEmitter<Sequ
       // After invalidation, L1 will roll back to checkpoint N-1. The archive at N-1 already
       // exists on L1, so we just pass the matching archive (the lastArchive of the invalid checkpoint).
       archiveForCheck = invalidateCheckpoint.lastArchive;
-      l1SimulationOverridesBuilder.forPendingCheckpoint(invalidateCheckpoint.forcePendingCheckpointNumber);
+      l1SimulationOverridesBuilder.withChainTips({ pending: invalidateCheckpoint.forcePendingCheckpointNumber });
       this.metrics.recordPipelineDepth(0);
     } else {
       this.metrics.recordPipelineDepth(0);
     }
 
+    let provenOverride: CheckpointNumber | undefined;
+    if (await this.l2BlockSource.isPruneDueAtSlot(targetSlot)) {
+      // Force `proven == pending` in the simulation so `STFLib.canPruneAtTime` short-circuits
+      // to false. Use the simulated pending if the caller already overrode it, otherwise the
+      // real L1 pending tip.
+      const overriddenPending = l1SimulationOverridesBuilder.build()?.chainTipsOverride?.pending;
+      const realPending = (await this.l2BlockSource.getL2Tips()).checkpointed.checkpoint.number;
+      provenOverride = overriddenPending ?? realPending;
+      l1SimulationOverridesBuilder.withChainTips({ proven: provenOverride });
+      this.log.warn(
+        `applying-proven-override-for-boundary: assuming proof for epoch ending at checkpoint ${provenOverride} lands by target slot ${targetSlot}`,
+        { checkpointNumber, slot, targetSlot, provenOverride, overriddenPending },
+      );
+    }
+
     const simulationOverridesPlan = l1SimulationOverridesBuilder.build();
+
+    this.emit('preparing-checkpoint', {
+      targetSlot,
+      checkpointNumber,
+      hadProposedParent: this.epochCache.isProposerPipeliningEnabled() && syncedTo.hasProposedCheckpoint,
+      provenOverride,
+      simulatedPending: simulationOverridesPlan?.chainTipsOverride?.pending,
+    });
+
     const canProposeCheck = await publisher.canProposeAt(
       archiveForCheck,
       proposer ?? EthAddress.ZERO,
@@ -462,6 +498,7 @@ export class Sequencer extends (EventEmitter as new () => TypedEventEmitter<Sequ
       attestorAddress,
       invalidateCheckpoint,
       syncedTo.proposedCheckpointData,
+      provenOverride !== undefined ? { provenOverride } : undefined,
     );
   }
 
@@ -476,6 +513,7 @@ export class Sequencer extends (EventEmitter as new () => TypedEventEmitter<Sequ
     attestorAddress: EthAddress,
     invalidateCheckpoint: InvalidateCheckpointRequest | undefined,
     proposedCheckpointData?: ProposedCheckpointData,
+    prunePending?: { provenOverride: CheckpointNumber },
   ): CheckpointProposalJob {
     return new CheckpointProposalJob(
       slot,
@@ -509,6 +547,7 @@ export class Sequencer extends (EventEmitter as new () => TypedEventEmitter<Sequ
       this.tracer,
       this.log.getBindings(),
       proposedCheckpointData,
+      prunePending,
     );
   }
 

--- a/yarn-project/stdlib/src/block/l2_block_source.ts
+++ b/yarn-project/stdlib/src/block/l2_block_source.ts
@@ -216,6 +216,13 @@ export interface L2BlockSource {
    */
   getL1Constants(): Promise<L1RollupConstants>;
 
+  /**
+   * Returns true iff `canPruneAtTime` would be true at the latest L1 timestamp inside
+   * the L2 slot's window. Computed entirely from local archiver state (no L1 RPC).
+   * @param slot - The L2 slot to check.
+   */
+  isPruneDueAtSlot(slot: SlotNumber): Promise<boolean>;
+
   /** Returns values for the genesis block */
   getGenesisValues(): Promise<{ genesisArchiveRoot: Fr }>;
 

--- a/yarn-project/stdlib/src/interfaces/archiver.test.ts
+++ b/yarn-project/stdlib/src/interfaces/archiver.test.ts
@@ -328,6 +328,11 @@ describe('ArchiverApiSchema', () => {
     const result = await context.client.getBlocksData({ from: BlockNumber(1), limit: 1 });
     expect(result).toEqual([]);
   });
+
+  it('isPruneDueAtSlot', async () => {
+    const result = await context.client.isPruneDueAtSlot(SlotNumber(1));
+    expect(result).toBe(false);
+  });
 });
 
 describe('BlockQuerySchema', () => {
@@ -602,5 +607,8 @@ class MockArchiver implements ArchiverApi {
   }
   getL1Timestamp(): Promise<bigint> {
     return Promise.resolve(1n);
+  }
+  isPruneDueAtSlot(_slot: SlotNumber): Promise<boolean> {
+    return Promise.resolve(false);
   }
 }

--- a/yarn-project/stdlib/src/interfaces/archiver.ts
+++ b/yarn-project/stdlib/src/interfaces/archiver.ts
@@ -133,6 +133,7 @@ export const ArchiverApiSchema: ApiSchemaFor<ArchiverApi> = {
   getL1ToL2MessageIndex: z.function().args(schemas.Fr).returns(schemas.BigInt.optional()),
   getDebugFunctionName: z.function().args(schemas.AztecAddress, schemas.FunctionSelector).returns(optional(z.string())),
   getL1Constants: z.function().args().returns(L1RollupConstantsSchema),
+  isPruneDueAtSlot: z.function().args(schemas.SlotNumber).returns(z.boolean()),
   getGenesisValues: z
     .function()
     .args()

--- a/yarn-project/stdlib/src/interfaces/configs.ts
+++ b/yarn-project/stdlib/src/interfaces/configs.ts
@@ -1,3 +1,4 @@
+import { type SlotNumber, SlotNumberSchema } from '@aztec/foundation/branded-types';
 import type { EthAddress } from '@aztec/foundation/eth-address';
 import type { Prettify } from '@aztec/foundation/types';
 
@@ -87,6 +88,8 @@ export interface SequencerConfig {
   skipPublishingCheckpointsPercent?: number;
   /** Skip broadcasting checkpoint and block proposals via gossipsub when proposer (for testing only) */
   skipBroadcastProposals?: boolean;
+  /** List of slots for which the sequencer will not produce a proposal (for testing only). Attestation paths are unaffected. */
+  pauseProposingForSlots?: SlotNumber[];
 }
 
 export const SequencerConfigSchema = zodFor<SequencerConfig>()(
@@ -130,6 +133,7 @@ export const SequencerConfigSchema = zodFor<SequencerConfig>()(
     minBlocksForCheckpoint: z.number().positive().optional(),
     skipPublishingCheckpointsPercent: z.number().gte(0).lte(100).optional(),
     skipBroadcastProposals: z.boolean().optional(),
+    pauseProposingForSlots: z.array(SlotNumberSchema).optional(),
   }),
 );
 
@@ -152,7 +156,8 @@ type SequencerConfigOptionalKeys =
   | 'maxL2BlockGas'
   | 'maxDABlockGas'
   | 'redistributeCheckpointBudget'
-  | 'skipBroadcastProposals';
+  | 'skipBroadcastProposals'
+  | 'pauseProposingForSlots';
 
 export type ResolvedSequencerConfig = Prettify<
   Required<Omit<SequencerConfig, SequencerConfigOptionalKeys>> & Pick<SequencerConfig, SequencerConfigOptionalKeys>


### PR DESCRIPTION
## Motivation

At a pruning epoch boundary, today's `canProposeAtTime` simulation pre-emptively reverts when an unproven epoch's deadline is about to expire — even if the proof lands seconds later. The slot is silently skipped. This loses a checkpoint window for no good reason: the publisher's preCheck right before L1 submission is the authoritative gate.

Similarly, the simulation overrides applied to the preCheck flight due to pipelining (as in overriding the pending chain with the last mined slot) meant that we were silently missing the case where the epoch prune did trigger, so we were sending the tx and reverting. This is fixed by having different plans for the first simulation and the right-before-submission simulation. That said, sequencer publisher checks are a bit convoluted now, so I'm making a pass at them to try and simplify in a later PR.

## Approach

Apply a proven-override at the three pre-submission simulation sites (`canProposeAt`, the globals builder, and enqueue-time `validateCheckpointForSubmission`) that forces `pending == proven` so `STFLib.canPruneAtTime` short-circuits to false. Submission's preCheck runs without the override against real L1 state and decides whether to actually send. A new structured `preparing-checkpoint` sequencer event surfaces the override/parent state for tests. Tip storage now goes through a single `makeChainTipsOverride` to avoid same-slot state-diff clobbering.

## Changes

- **archiver**: `isPruneDueAtSlot(slot)` on `L2BlockSource` replicates `STFLib.canPruneAtTime` locally (no L1 RPC).
- **ethereum**: `RollupContract.makeChainTipsOverride({pending?, proven?})` writes a single combined state-diff and guards `proven > pending`. `forPendingCheckpoint(n)` → `withChainTips({pending?, proven?})` on the simulation overrides builder.
- **sequencer-client (publisher)**: `enqueueProposeCheckpoint` accepts `preCheckSimulationOverridesPlan` separately from `simulationOverridesPlan`; the preCheck closure uses it (no fallback) so the parent / proven overrides never reach pre-send validation.
- **sequencer-client (sequencer)**: applies the proven override at the canProposeAt site, plumbs it through `prunePending` to `CheckpointProposalJob` so the globals builder and enqueue-time validation see it. New `pauseProposingForSlots` test-only config.
- **sequencer-client (events)**: new `preparing-checkpoint` event with `targetSlot`, `checkpointNumber`, `hadProposedParent`, `provenOverride`.
- **ethereum (test infra)**: `Delayer.pauseNextTxUntil*` accept a per-call timeout to support boundary tests that need to wait > 180s.
- **end-to-end (new tests)**: `epochs_proof_at_boundary.parallel.test.ts` covers smoke + four boundary scenarios — proof lands during pipeline sleep; proof lands well before deadline; proof never lands (with parent); proof lands / never lands without proposed parent — using structured events and `retryUntil` rather than log greps.
- **stdlib + interfaces**: schemas and configs updated for the new RPC method and the new sequencer config knob.