### PR TITLE
fix(docs): tag aztec-nr-api records so they pass the search filter

### DIFF
--- a/.github/workflows/docs-typesense.yml
+++ b/.github/workflows/docs-typesense.yml
@@ -35,13 +35,41 @@ jobs:
           # ~12k to 48 records) into a loud CI failure.
           MIN_HITS: "5000"
         run: |
-          set -o pipefail
+          set -euo pipefail
+
+          # Derive the version-specific docusaurus_tag values from the docs version
+          # configs and append them to the api-nr start_url's docusaurus_tag array.
+          # Each plugin instance produces a tag of the form `docs-${pluginId}-${versionName}`.
+          # The unversioned tags (participate, root, default) are already in the static
+          # config; this step adds entries for `developer` and `network` which bump on
+          # release. Without this, the api-nr records would lose contextual search
+          # visibility every time mainnet/testnet versions change.
+          extra_tags=$(jq -nc \
+            --slurpfile dev docs/developer_version_config.json \
+            --slurpfile net docs/network_version_config.json \
+            '[
+              ("docs-developer-" + ($dev[0].mainnet // "")),
+              ("docs-developer-" + ($dev[0].testnet // "")),
+              ("docs-network-"   + ($net[0].mainnet // "")),
+              ("docs-network-"   + ($net[0].testnet // ""))
+             ] | map(select(. != "docs-developer-" and . != "docs-network-")) | unique')
+          echo "Derived docusaurus_tag values: $extra_tags"
+
+          config_json=$(jq -c --argjson extra "$extra_tags" '
+            .start_urls |= map(
+              if .selectors_key == "api-nr"
+              then .extra_attributes.docusaurus_tag = ((.extra_attributes.docusaurus_tag // []) + $extra | unique)
+              else .
+              end
+            )
+          ' docs/typesense.config.json)
+
           docker run \
             -e "TYPESENSE_API_KEY=${{ secrets.TYPESENSE_API_KEY }}" \
             -e "TYPESENSE_HOST=${{ secrets.TYPESENSE_HOST }}" \
             -e "TYPESENSE_PORT=443" \
             -e "TYPESENSE_PROTOCOL=https" \
-            -e "CONFIG=$(cat docs/typesense.config.json | jq -r tostring)" \
+            -e "CONFIG=$config_json" \
             typesense/docsearch-scraper:0.11.0 2>&1 | tee scraper.log
 
           nb_hits=$(grep -oE 'Nb hits: *[0-9]+' scraper.log | tail -1 | grep -oE '[0-9]+' || true)

--- a/docs/typesense.config.json
+++ b/docs/typesense.config.json
@@ -8,8 +8,6 @@
       "extra_attributes": {
         "language": "en",
         "docusaurus_tag": [
-          "docs-developer-v4.2.0",
-          "docs-network-v4.2.0",
           "docs-participate-current",
           "docs-root-current",
           "default"

--- a/docs/typesense.config.json
+++ b/docs/typesense.config.json
@@ -4,7 +4,17 @@
     {
       "url": "https://docs.aztec.network/aztec-nr-api/mainnet/",
       "selectors_key": "api-nr",
-      "page_rank": 2
+      "page_rank": 2,
+      "extra_attributes": {
+        "language": "en",
+        "docusaurus_tag": [
+          "docs-developer-v4.2.0",
+          "docs-network-v4.2.0",
+          "docs-participate-current",
+          "docs-root-current",
+          "default"
+        ]
+      }
     },
     {
       "url": "https://docs.aztec.network/",
@@ -55,6 +65,76 @@
       "url",
       "url_without_anchor",
       "type"
+    ],
+    "field_definitions": [
+      { "name": "anchor", "type": "string", "optional": true },
+      { "name": "content", "type": "string", "optional": true },
+      { "name": "url", "type": "string", "facet": true },
+      {
+        "name": "url_without_anchor",
+        "type": "string",
+        "facet": true,
+        "optional": true
+      },
+      {
+        "name": "version",
+        "type": "string[]",
+        "facet": true,
+        "optional": true
+      },
+      {
+        "name": "hierarchy.lvl0",
+        "type": "string",
+        "facet": true,
+        "optional": true
+      },
+      {
+        "name": "hierarchy.lvl1",
+        "type": "string",
+        "facet": true,
+        "optional": true
+      },
+      {
+        "name": "hierarchy.lvl2",
+        "type": "string",
+        "facet": true,
+        "optional": true
+      },
+      {
+        "name": "hierarchy.lvl3",
+        "type": "string",
+        "facet": true,
+        "optional": true
+      },
+      {
+        "name": "hierarchy.lvl4",
+        "type": "string",
+        "facet": true,
+        "optional": true
+      },
+      {
+        "name": "hierarchy.lvl5",
+        "type": "string",
+        "facet": true,
+        "optional": true
+      },
+      {
+        "name": "hierarchy.lvl6",
+        "type": "string",
+        "facet": true,
+        "optional": true
+      },
+      { "name": "type", "type": "string", "facet": true, "optional": true },
+      {
+        "name": "docusaurus_tag",
+        "type": "string*",
+        "facet": true,
+        "optional": true
+      },
+      { "name": ".*_tag", "type": "string", "facet": true, "optional": true },
+      { "name": "language", "type": "string", "facet": true, "optional": true },
+      { "name": "tags", "type": "string[]", "facet": true, "optional": true },
+      { "name": "item_priority", "type": "int64" }
     ]
   },
   "conversation_id": ["833762294"],


### PR DESCRIPTION
## Summary

Third in the series fixing search after #22861. Previous PRs (#23042, #23049) successfully indexed 14,773 records from 2,222 aztec-nr-api pages, but **users still don't see those records in the dropdown search**.

## Root cause

The `docusaurus-theme-search-typesense` package ANDs a contextual filter into every search query:

```ts
// docusaurus-theme-search-typesense/src/client/useTypesenseContextualFacetFilters.ts
const languageFilter = `language:=${locale}`;
const tagsFilter = `docusaurus_tag:=[${tags.join(',')}]`;
return [languageFilter, tagsFilter].filter(Boolean).join(' && ');
```

The api-nr records have neither `language` nor `docusaurus_tag` set, because the typesense-docsearch-scraper only stamps those onto records scraped from docusaurus pages (it reads `<meta name="docsearch:docusaurus_tag" content="...">` tags). Rustdoc-style nargo-doc pages don't emit those metas, so every api-nr record is missing the fields the theme filters on, so every api-nr record is filtered out of every dropdown query.

## Fix

Three coordinated changes:

### 1. `extra_attributes` on the api-nr start_url (`docs/typesense.config.json`)

Stamp every api-nr record with the attributes the theme expects:

```json
"extra_attributes": {
  "language": "en",
  "docusaurus_tag": [
    "docs-participate-current",
    "docs-root-current",
    "default"
  ]
}
```

These cover the three unversioned plugin contexts. The two versioned ones (`docs-developer-${version}` and `docs-network-${version}`) are appended dynamically by the workflow (see #3) so the static config doesn't go stale on version bumps.

Typesense's `docusaurus_tag:=[<context-tag>]` matches if the record's array contains the context tag, so the api-nr records will satisfy the filter from any plugin context.

### 2. `field_definitions` schema override (`docs/typesense.config.json`)

The scraper's default schema (`scraper/src/typesense_helper.py` v0.11.0) declares the wildcard `.*_tag` as `string`, so sending an array for `docusaurus_tag` would be rejected at import time. `field_definitions` overrides this — but it REPLACES the entire default schema rather than merging, so the full default field list is reproduced verbatim with one targeted change: `docusaurus_tag` is added with type `string*` (accepts both string and array) before the `.*_tag` wildcard. Existing docusaurus records continue to work because they pass `docusaurus_tag` as a single string from a meta tag, and `string*` accepts that too.

### 3. Derive versioned tags at scrape time (`.github/workflows/docs-typesense.yml`)

Read `developer_version_config.json` and `network_version_config.json`, build the `docs-developer-${mainnet}`, `docs-developer-${testnet}`, `docs-network-${mainnet}`, `docs-network-${testnet}` strings (dropping empty/duplicates), and use `jq` to append them to the api-nr start_url's `docusaurus_tag` array before passing the config to the scraper. This way the static JSON never holds version-specific values that need manual updating.

The workflow run also switches to `set -euo pipefail` so a `jq` derivation failure aborts the run rather than feeding an empty config to docker.

## Caveats

- Existing 14,773 api-nr records in the production collection are stale until the next scraper run rewrites them. The scraper alias-swaps to a fresh collection on each run, so no manual purge is needed.

## Test plan

- [ ] Manually dispatch `Docs Scraper` workflow on this branch via `workflow_dispatch`.
- [ ] Confirm scraper run reports `Nb hits` ≈ 27,000 (no regression in record count).
- [ ] Confirm no schema-validation errors in the run log.
- [ ] Confirm the workflow log echoes the derived `docusaurus_tag` values matching the current docs versions (e.g. `docs-developer-v4.2.0`, `docs-network-v4.2.0`).
- [ ] After merge, search docs.aztec.network from the homepage, /developers/, and /operate/ for an Aztec.nr identifier (e.g. `ContractClassId`, `balance_set`, `compute_log_tag`) and confirm API reference pages appear in the dropdown in all three contexts.