### PR TITLE
chore: Accumulated backports to v4

### DIFF
--- a/.github/workflows/ci3.yml
+++ b/.github/workflows/ci3.yml
@@ -121,7 +121,7 @@ jobs:
           if [ -n "${SLACK_BOT_TOKEN}" ]; then
             read -r -d '' data <<EOF || true
             {
-              "channel": "#team-alpha",
+              "channel": "#backports",
               "text": "CI3 failed on backport PR: <${{ github.event.pull_request.html_url }}|#${{ github.event.pull_request.number }} - ${{ github.event.pull_request.title }}>\n<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Run>"
             }
           EOF

--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_l1_reorgs.parallel.test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_l1_reorgs.parallel.test.ts
@@ -442,8 +442,9 @@ describe('e2e_epochs/epochs_l1_reorgs', () => {
       );
 
     it('updates L1 to L2 messages changed due to an L1 reorg', async () => {
-      // Send L2 txs to trigger multi-block checkpoints
+      // Send L2 txs to trigger multi-block checkpoints and wait for them to land in a checkpoint
       await sendTransactions(TX_COUNT, 100);
+      await test.waitUntilCheckpointNumber(CheckpointNumber(2), L2_SLOT_DURATION_IN_S * 4);
 
       // Send 3 messages and wait for archiver sync
       logger.warn(`Sending 3 cross chain messages`);


### PR DESCRIPTION

BEGIN_COMMIT_OVERRIDE
chore: route backport CI failure notifications to #backports channel (#21779)
END_COMMIT_OVERRIDE