### PR TITLE
fix(e2e): backport epochs l1 reorgs test deflake (#20999)

### DIFF
--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_l1_reorgs.parallel.test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_l1_reorgs.parallel.test.ts
@@ -442,8 +442,9 @@ describe('e2e_epochs/epochs_l1_reorgs', () => {
       );
 
     it('updates L1 to L2 messages changed due to an L1 reorg', async () => {
-      // Send L2 txs to trigger multi-block checkpoints
+      // Send L2 txs to trigger multi-block checkpoints and wait for them to land in a checkpoint
       await sendTransactions(TX_COUNT, 100);
+      await test.waitUntilCheckpointNumber(CheckpointNumber(2), L2_SLOT_DURATION_IN_S * 4);
 
       // Send 3 messages and wait for archiver sync
       logger.warn(`Sending 3 cross chain messages`);


### PR DESCRIPTION
## Summary

Backport of #20999 to fix flaky e2e test `e2e_epochs/epochs_l1_reorgs > updates L1 to L2 messages changed due to an L1 reorg` on `backport-to-v4-staging`.

The test sends L2 txs to trigger multi-block checkpoints, but did not wait for them to land in a checkpoint before proceeding, causing `assertMultipleBlocksPerSlot` to fail intermittently. Adopts the same `waitUntilCheckpointNumber` pattern already used in the sibling `handles missed message inserted by an L1 reorg` test.

Observed failure: http://ci.aztec-labs.com/17fa3667c0ba92e6

Original PR: #20999 (already on `v4-next` and `next`).

## Test plan

- CI run of e2e_epochs/epochs_l1_reorgs against this branch