### PR TITLE
fix(p2p): chunk archive of mined txs on block finalization (A-969)

### DIFF
--- a/yarn-project/p2p/src/mem_pools/tx_pool_v2/tx_pool_v2.test.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool_v2/tx_pool_v2.test.ts
@@ -3139,6 +3139,24 @@ describe('TxPoolV2', () => {
       expect(await pool.getArchivedTxByHash(txs[3].getTxHash())).toBeDefined();
       expect(await pool.getArchivedTxByHash(txs[4].getTxHash())).toBeDefined();
     });
+
+    it('archives and deletes all mined txs across many chunks when finalizing a single block', async () => {
+      // Use a count larger than the internal FINALIZE_BLOCK_CHUNK_SIZE (100) so we exercise
+      // the chunked path of handleFinalizedBlock.
+      const txCount = 250;
+      await pool.updateConfig({ archivedTxLimit: txCount });
+
+      const txs = await timesAsync(txCount, i => mockTx(i + 1));
+      await pool.addPendingTxs(txs);
+      await pool.handleMinedBlock(makeBlock(txs, slot1Header));
+
+      await pool.handleFinalizedBlock(slot1Header);
+
+      for (const tx of txs) {
+        expect(await pool.getTxStatus(tx.getTxHash())).toBe('deleted');
+        expect(await pool.getArchivedTxByHash(tx.getTxHash())).toBeDefined();
+      }
+    });
   });
 
   describe('nullifier index consistency', () => {

--- a/yarn-project/p2p/src/mem_pools/tx_pool_v2/tx_pool_v2_impl.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool_v2/tx_pool_v2_impl.ts
@@ -647,14 +647,11 @@ export class TxPoolV2Impl {
     // Step 1: Find mined txs at or before finalized block
     const minedTxsToFinalize = this.#indices.findTxsMinedAtOrBefore(blockNumber);
 
-    // Step 2: Process in chunks. Hydrating an entire epoch's worth of mined txs at once would
-    // OOM under load (~23k txs/epoch at 10 TPS). Each chunk is hydrated, archived, and deleted
-    // before moving on so peak memory is bounded.
-    const archiveEnabled = this.#archive.isEnabled();
-    for (let i = 0; i < minedTxsToFinalize.length; i += FINALIZE_BLOCK_CHUNK_SIZE) {
-      const chunk = minedTxsToFinalize.slice(i, i + FINALIZE_BLOCK_CHUNK_SIZE);
-
-      if (archiveEnabled) {
+    // Step 2: Archive in chunks if archiving is enabled. Hydrating an entire epoch's worth of
+    // mined txs at once would OOM under load. When archiving is disabled there is no need to hydrate the txs at all.
+    if (this.#archive.isEnabled()) {
+      for (let i = 0; i < minedTxsToFinalize.length; i += FINALIZE_BLOCK_CHUNK_SIZE) {
+        const chunk = minedTxsToFinalize.slice(i, i + FINALIZE_BLOCK_CHUNK_SIZE);
         const txsToArchive: Tx[] = [];
         for (const txHashStr of chunk) {
           const buffer = await this.#txsDB.getAsync(txHashStr);
@@ -666,12 +663,14 @@ export class TxPoolV2Impl {
           await this.#archive.archiveTxs(txsToArchive);
         }
       }
-
-      await this.#store.transactionAsync(() => this.#deleteTxsBatch(chunk));
     }
 
-    // Step 3: Finalize soft-deleted txs once all mined txs are gone.
-    await this.#store.transactionAsync(() => this.#deletedPool.finalizeBlock(blockNumber));
+    // Step 3: Delete mined txs from the active pool and finalize soft-deleted txs in one
+    // transaction. Only tx hashes are touched here, so memory is bounded and atomicity is preserved.
+    await this.#store.transactionAsync(async () => {
+      await this.#deleteTxsBatch(minedTxsToFinalize);
+      await this.#deletedPool.finalizeBlock(blockNumber);
+    });
 
     if (minedTxsToFinalize.length > 0) {
       this.#log.info(`Finalized ${minedTxsToFinalize.length} mined txs from blocks up to ${blockNumber}`, {

--- a/yarn-project/p2p/src/mem_pools/tx_pool_v2/tx_pool_v2_impl.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool_v2/tx_pool_v2_impl.ts
@@ -41,6 +41,13 @@ import { type TxMetaData, type TxState, buildTxMetaData, checkNullifierConflict 
 import { TxPoolIndices } from './tx_pool_indices.js';
 
 /**
+ * Maximum number of full transactions to load into memory at once when finalizing a block.
+ * Bounds peak memory while archiving and hard-deleting mined txs (~23k txs/epoch at 10 TPS would
+ * otherwise OOM the node).
+ */
+const FINALIZE_BLOCK_CHUNK_SIZE = 100;
+
+/**
  * Callbacks for the implementation to notify the outer class about events and metrics.
  */
 export interface TxPoolV2Callbacks {
@@ -640,29 +647,31 @@ export class TxPoolV2Impl {
     // Step 1: Find mined txs at or before finalized block
     const minedTxsToFinalize = this.#indices.findTxsMinedAtOrBefore(blockNumber);
 
-    await this.#store.transactionAsync(async () => {
-      // Step 2: Collect mined txs for archiving (before deletion)
-      const txsToArchive: Tx[] = [];
-      if (this.#archive.isEnabled()) {
-        for (const txHashStr of minedTxsToFinalize) {
+    // Step 2: Process in chunks. Hydrating an entire epoch's worth of mined txs at once would
+    // OOM under load (~23k txs/epoch at 10 TPS). Each chunk is hydrated, archived, and deleted
+    // before moving on so peak memory is bounded.
+    const archiveEnabled = this.#archive.isEnabled();
+    for (let i = 0; i < minedTxsToFinalize.length; i += FINALIZE_BLOCK_CHUNK_SIZE) {
+      const chunk = minedTxsToFinalize.slice(i, i + FINALIZE_BLOCK_CHUNK_SIZE);
+
+      if (archiveEnabled) {
+        const txsToArchive: Tx[] = [];
+        for (const txHashStr of chunk) {
           const buffer = await this.#txsDB.getAsync(txHashStr);
           if (buffer) {
             txsToArchive.push(Tx.fromBuffer(buffer));
           }
         }
+        if (txsToArchive.length > 0) {
+          await this.#archive.archiveTxs(txsToArchive);
+        }
       }
 
-      // Step 3: Delete mined txs from active pool
-      await this.#deleteTxsBatch(minedTxsToFinalize);
+      await this.#store.transactionAsync(() => this.#deleteTxsBatch(chunk));
+    }
 
-      // Step 4: Finalize soft-deleted txs
-      await this.#deletedPool.finalizeBlock(blockNumber);
-
-      // Step 5: Archive mined txs
-      if (txsToArchive.length > 0) {
-        await this.#archive.archiveTxs(txsToArchive);
-      }
-    });
+    // Step 3: Finalize soft-deleted txs once all mined txs are gone.
+    await this.#store.transactionAsync(() => this.#deletedPool.finalizeBlock(blockNumber));
 
     if (minedTxsToFinalize.length > 0) {
       this.#log.info(`Finalized ${minedTxsToFinalize.length} mined txs from blocks up to ${blockNumber}`, {


### PR DESCRIPTION
## Summary

`handleFinalizedBlock` was hydrating every mined-finalized tx into a single in-memory array before archiving and deleting them.

This change processes the mined txs in chunks of 100. Peak memory is bounded regardless of epoch size. The deleted-pool finalize step runs once at the end after all chunks are processed.

Fixes A-969.

## Test plan

- New unit test `archives and deletes all mined txs across many chunks when finalizing a single block` that finalizes 250 txs in a single call (above the 100-tx chunk size) and checks that all are archived and marked deleted.
- All 239 existing `tx_pool_v2.test.ts` cases still pass.