### PR TITLE
fix(p2p): stream tx pool hydration to bound startup memory (A-968)

### DIFF
--- a/yarn-project/p2p/src/mem_pools/tx_pool_v2/tx_pool_v2_impl.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool_v2/tx_pool_v2_impl.ts
@@ -155,8 +155,7 @@ export class TxPoolV2Impl {
       let txEffect: Awaited<ReturnType<L2BlockSource['getTxEffect']>>;
       try {
         const tx = Tx.fromBuffer(buffer);
-        // Resolve allowed-setup-calls and the tx effect concurrently — both are I/O against
-        // independent sources, so overlapping them roughly halves per-tx hydration latency.
+        // Resolve allowed-setup-calls and the tx effect concurrently
         // getTxEffect failures are non-fatal (we just treat the tx as not-yet-mined), so
         // its rejection is swallowed before the Promise.all so it can't fail-fast the batch.
         const txEffectPromise = this.#l2BlockSource.getTxEffect(tx.getTxHash()).catch(err => {

--- a/yarn-project/p2p/src/mem_pools/tx_pool_v2/tx_pool_v2_impl.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool_v2/tx_pool_v2_impl.ts
@@ -141,9 +141,6 @@ export class TxPoolV2Impl {
     await this.#deletedPool.hydrateFromDatabase();
 
     // Step 1: Stream txs from DB, building metadata and mined status one at a time.
-    // We never hold more than a single full Tx in memory at once (Tx objects can be MBs
-    // with proof data; at 10 TPS the DB may contain 20k+ entries which would OOM the node
-    // if accumulated into a `loaded[]` array up front).
     const minedMetas: TxMetaData[] = [];
     const pendingMetas: TxMetaData[] = [];
     const deserializationErrors: string[] = [];
@@ -155,27 +152,34 @@ export class TxPoolV2Impl {
       }
 
       let meta: TxMetaData;
+      let txEffect: Awaited<ReturnType<L2BlockSource['getTxEffect']>>;
       try {
         const tx = Tx.fromBuffer(buffer);
-        const allowedSetupCalls = await this.#checkAllowedSetupCalls(tx);
+        // Resolve allowed-setup-calls and the tx effect concurrently — both are I/O against
+        // independent sources, so overlapping them roughly halves per-tx hydration latency.
+        // getTxEffect failures are non-fatal (we just treat the tx as not-yet-mined), so
+        // its rejection is swallowed before the Promise.all so it can't fail-fast the batch.
+        const txEffectPromise = this.#l2BlockSource.getTxEffect(tx.getTxHash()).catch(err => {
+          this.#log.warn(`Failed to check mined status for tx ${txHashStr}`, { err });
+          return undefined;
+        });
+        const [allowedSetupCalls, fetchedTxEffect] = await Promise.all([
+          this.#checkAllowedSetupCalls(tx),
+          txEffectPromise,
+        ]);
         meta = await buildTxMetaData(tx, allowedSetupCalls);
+        txEffect = fetchedTxEffect;
       } catch (err) {
         this.#log.warn(`Failed to deserialize tx ${txHashStr}, deleting`, { err });
         deserializationErrors.push(txHashStr);
         continue;
       }
 
-      // Check mined status while we still have the tx in scope
-      try {
-        const txEffect = await this.#l2BlockSource.getTxEffect(TxHash.fromString(meta.txHash));
-        if (txEffect) {
-          meta.minedL2BlockId = {
-            number: txEffect.l2BlockNumber,
-            hash: txEffect.l2BlockHash.toString(),
-          };
-        }
-      } catch (err) {
-        this.#log.warn(`Failed to check mined status for tx ${meta.txHash}`, { err });
+      if (txEffect) {
+        meta.minedL2BlockId = {
+          number: txEffect.l2BlockNumber,
+          hash: txEffect.l2BlockHash.toString(),
+        };
       }
 
       if (meta.minedL2BlockId !== undefined) {

--- a/yarn-project/p2p/src/mem_pools/tx_pool_v2/tx_pool_v2_impl.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool_v2/tx_pool_v2_impl.ts
@@ -140,39 +140,64 @@ export class TxPoolV2Impl {
     // Step 0: Hydrate deleted pool state
     await this.#deletedPool.hydrateFromDatabase();
 
-    // Step 1: Load all transactions from DB (excluding soft-deleted)
-    const { loaded, errors: deserializationErrors } = await this.#loadAllTxsFromDb();
+    // Step 1: Stream txs from DB, building metadata and mined status one at a time.
+    // We never hold more than a single full Tx in memory at once (Tx objects can be MBs
+    // with proof data; at 10 TPS the DB may contain 20k+ entries which would OOM the node
+    // if accumulated into a `loaded[]` array up front).
+    const minedMetas: TxMetaData[] = [];
+    const pendingMetas: TxMetaData[] = [];
+    const deserializationErrors: string[] = [];
 
-    // Step 2: Check mined status for each tx
-    await this.#markMinedStatusBatch(loaded.map(l => l.meta));
+    for await (const [txHashStr, buffer] of this.#txsDB.entriesAsync()) {
+      // Skip soft-deleted transactions - they stay in DB but not in indices
+      if (this.#deletedPool.isSoftDeleted(txHashStr)) {
+        continue;
+      }
 
-    // Step 3: Partition by mined status
-    const mined: TxMetaData[] = [];
-    const nonMined: { tx: Tx; meta: TxMetaData }[] = [];
-    for (const entry of loaded) {
-      if (entry.meta.minedL2BlockId !== undefined) {
-        mined.push(entry.meta);
+      let meta: TxMetaData;
+      try {
+        const tx = Tx.fromBuffer(buffer);
+        const allowedSetupCalls = await this.#checkAllowedSetupCalls(tx);
+        meta = await buildTxMetaData(tx, allowedSetupCalls);
+      } catch (err) {
+        this.#log.warn(`Failed to deserialize tx ${txHashStr}, deleting`, { err });
+        deserializationErrors.push(txHashStr);
+        continue;
+      }
+
+      // Check mined status while we still have the tx in scope
+      try {
+        const txEffect = await this.#l2BlockSource.getTxEffect(TxHash.fromString(meta.txHash));
+        if (txEffect) {
+          meta.minedL2BlockId = {
+            number: txEffect.l2BlockNumber,
+            hash: txEffect.l2BlockHash.toString(),
+          };
+        }
+      } catch (err) {
+        this.#log.warn(`Failed to check mined status for tx ${meta.txHash}`, { err });
+      }
+
+      if (meta.minedL2BlockId !== undefined) {
+        minedMetas.push(meta);
       } else {
-        nonMined.push(entry);
+        pendingMetas.push(meta);
       }
     }
 
-    // Step 4: Validate non-mined transactions
-    const { valid, invalid } = await this.#revalidateMetadata(
-      nonMined.map(e => e.meta),
-      'on startup',
-    );
+    // Step 2: Validate non-mined transactions
+    const { valid, invalid } = await this.#revalidateMetadata(pendingMetas, 'on startup');
 
-    // Step 5: Populate mined indices (these don't need conflict resolution)
-    for (const meta of mined) {
+    // Step 3: Populate mined indices (these don't need conflict resolution)
+    for (const meta of minedMetas) {
       this.#indices.addMined(meta);
     }
 
-    // Step 6: Rebuild pending pool by running pre-add rules for each tx
+    // Step 4: Rebuild pending pool by running pre-add rules for each tx
     // This resolves nullifier conflicts, fee payer balance issues, and pool size limits
     const { rejected } = await this.#rebuildPendingPool(valid);
 
-    // Step 7: Delete invalid and rejected txs from DB only (indices were never populated for these)
+    // Step 5: Delete invalid and rejected txs from DB only (indices were never populated for these)
     const toDelete = [...deserializationErrors, ...invalid, ...rejected];
     if (toDelete.length === 0) {
       return;
@@ -974,51 +999,6 @@ export class TxPoolV2Impl {
       number: txEffect.l2BlockNumber,
       hash: txEffect.l2BlockHash.toString(),
     };
-  }
-
-  /** Loads all transactions from the database, returning loaded txs and deserialization errors */
-  async #loadAllTxsFromDb(): Promise<{
-    loaded: { tx: Tx; meta: TxMetaData }[];
-    errors: string[];
-  }> {
-    const loaded: { tx: Tx; meta: TxMetaData }[] = [];
-    const errors: string[] = [];
-
-    for await (const [txHashStr, buffer] of this.#txsDB.entriesAsync()) {
-      // Skip soft-deleted transactions - they stay in DB but not in indices
-      if (this.#deletedPool.isSoftDeleted(txHashStr)) {
-        continue;
-      }
-
-      try {
-        const tx = Tx.fromBuffer(buffer);
-        const allowedSetupCalls = await this.#checkAllowedSetupCalls(tx);
-        const meta = await buildTxMetaData(tx, allowedSetupCalls);
-        loaded.push({ tx, meta });
-      } catch (err) {
-        this.#log.warn(`Failed to deserialize tx ${txHashStr}, deleting`, { err });
-        errors.push(txHashStr);
-      }
-    }
-
-    return { loaded, errors };
-  }
-
-  /** Queries block source and marks mined status on transaction metadata */
-  async #markMinedStatusBatch(metas: TxMetaData[]): Promise<void> {
-    for (const meta of metas) {
-      try {
-        const txEffect = await this.#l2BlockSource.getTxEffect(TxHash.fromString(meta.txHash));
-        if (txEffect) {
-          meta.minedL2BlockId = {
-            number: txEffect.l2BlockNumber,
-            hash: txEffect.l2BlockHash.toString(),
-          };
-        }
-      } catch (err) {
-        this.#log.warn(`Failed to check mined status for tx ${meta.txHash}`, { err });
-      }
-    }
   }
 
   /**


### PR DESCRIPTION
## Summary

`hydrateFromDatabase` was deserializing every persisted tx into a single `{ tx, meta }[]` array before doing anything else.

Stream the txs DB instead: deserialize, build metadata, and resolve mined status one tx at a time, dropping the Tx reference before moving on. Only the much smaller `TxMetaData` objects accumulate. The previously separate `#loadAllTxsFromDb` and `#markMinedStatusBatch` helpers fold into the streaming loop (they were only used here).

Fixes A-968.

## Test plan

- All 238 existing `tx_pool_v2.test.ts` cases pass (including the hydration / restart suite).
- All 25 `tx_pool_v2.compat.test.ts` cases pass.