### PR TITLE
fix(sequencer): bind vote-only multicalls to target slot under pipelining

### DIFF
--- a/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.ts
+++ b/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.ts
@@ -198,9 +198,18 @@ export class CheckpointProposalJob implements Traceable {
 
     if (!broadcast) {
       await Promise.all(votesPromises);
-      // Still submit votes even without a checkpoint
+      // Still submit votes even without a checkpoint.
+      // Under proposer pipelining, vote-offenses signatures are EIP-712-bound to `targetSlot`
+      // (the pipelined slot in which the multicall is expected to mine). Submitting at the
+      // wall-clock time would let the multicall mine in a different L2 slot, causing
+      // signature verification to fail silently inside Multicall3. Delay submission to the
+      // start of `targetSlot` so the tx mines in the slot the vote was signed for.
       if (!this.config.fishermanMode) {
-        this.pendingL1Submission = this.publisher.sendRequestsAt(this.dateProvider.nowAsDate()).then(() => {});
+        const isPipelining = this.epochCache.isProposerPipeliningEnabled();
+        const submitAfter = isPipelining
+          ? new Date(Number(getTimestampForSlot(this.targetSlot, this.l1Constants)) * 1000)
+          : this.dateProvider.nowAsDate();
+        this.pendingL1Submission = this.publisher.sendRequestsAt(submitAfter).then(() => {});
       }
       return undefined;
     }

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.ts
@@ -14,7 +14,7 @@ import type { SlasherClientInterface } from '@aztec/slasher';
 import type { BlockData, L2BlockSink, L2BlockSource, ValidateCheckpointResult } from '@aztec/stdlib/block';
 import type { Checkpoint, ProposedCheckpointData } from '@aztec/stdlib/checkpoint';
 import type { ChainConfig } from '@aztec/stdlib/config';
-import { getSlotStartBuildTimestamp } from '@aztec/stdlib/epoch-helpers';
+import { getSlotStartBuildTimestamp, getTimestampForSlot } from '@aztec/stdlib/epoch-helpers';
 import {
   type ResolvedSequencerConfig,
   type SequencerConfig,
@@ -785,7 +785,20 @@ export class Sequencer extends (EventEmitter as new () => TypedEventEmitter<Sequ
     }
 
     this.log.info(`Voting in slot ${slot} despite sync failure`, { slot });
-    await publisher.sendRequests();
+    // Under proposer pipelining, votes are EIP-712-signed for `targetSlot` (the pipelined slot
+    // in which the multicall is expected to mine). Submitting immediately would let the
+    // multicall mine in the wall-clock slot, causing signature verification to fail silently
+    // inside Multicall3. Delay submission to the start of `targetSlot` so the tx mines in the
+    // slot the votes were signed for. We fire-and-forget so we don't block the sequencer's
+    // work loop while waiting for the target slot to start.
+    if (this.epochCache.isProposerPipeliningEnabled()) {
+      const submitAfter = new Date(Number(getTimestampForSlot(targetSlot, this.l1Constants)) * 1000);
+      void publisher.sendRequestsAt(submitAfter).catch(err => {
+        this.log.error(`Failed to publish votes despite sync failure for slot ${slot}`, err, { slot });
+      });
+    } else {
+      await publisher.sendRequests();
+    }
   }
 
   /**


### PR DESCRIPTION
Slashing votes are EIP-712-signed for `targetSlot` (the pipelined proposal slot, not the wall-clock slot) and submitted via Multicall3.aggregate3 with allowFailure: true. The contract verifies the signature against getCurrentSlot() derived from block.timestamp, so the multicall must mine in the slot the vote was signed for or the inner sub-call reverts silently and VoteCast is never emitted.

Two paths in the sequencer were sending vote-only multicalls without delaying submission to the target-slot start:

  1. CheckpointProposalJob.execute() if (!broadcast) branch — proposer enqueued votes but did not build a checkpoint.
  2. Sequencer.tryVoteWhenSyncFails — proposer enqueued votes in a slot where archiver sync had not caught up.

Both now route through `sendRequestsAt(getTimestampForSlot(targetSlot))` when proposer pipelining is enabled. The sync-failure path uses fire-and-forget so the wait does not block the sequencer's work loop.
