### PR TITLE
chore: kv store test fully on vitest

### DIFF
--- a/yarn-project/kv-store/.mocharc.json
+++ b/yarn-project/kv-store/.mocharc.json
@@ -1,7 +1,0 @@
-{
-  "require": "ts-node/register",
-  "extensions": ["ts"],
-  "spec": ["./src/**/!(indexeddb|sqlite-opfs|bench)/*.test.ts"],
-  "node-option": ["experimental-specifier-resolution=node", "loader=@swc-node/register/esm"],
-  "timeout": 30000
-}

--- a/yarn-project/kv-store/package.json
+++ b/yarn-project/kv-store/package.json
@@ -15,10 +15,10 @@
     "build": "yarn clean && ../scripts/tsc.sh",
     "build:dev": "../scripts/tsc.sh --watch",
     "clean": "rm -rf ./dest .tsbuildinfo",
-    "test:node": "NODE_NO_WARNINGS=1 mocha --config ./.mocharc.json",
+    "test:node": "vitest run --project node",
     "test:browser": "bash scripts/run-browser-tests.sh",
-    "bench:browser": "VITE_BENCH=1 vitest run --config ./vitest.config.ts src/bench",
-    "test": "yarn test:node && yarn test:browser",
+    "bench:browser": "VITE_BENCH=1 vitest run --project browser src/bench",
+    "test": "vitest run",
     "test:jest": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --passWithNoTests --maxWorkers=${JEST_MAX_WORKERS:-8}"
   },
   "inherits": [
@@ -39,28 +39,18 @@
     "ordered-binary": "^1.5.3"
   },
   "devDependencies": {
-    "@jest/globals": "^30.0.0",
-    "@types/chai": "^5.0.1",
-    "@types/chai-as-promised": "^8.0.1",
     "@types/jest": "^30.0.0",
-    "@types/mocha": "^10.0.10",
-    "@types/mocha-each": "^2.0.4",
     "@types/node": "^22.15.17",
-    "@types/sinon": "^17.0.3",
     "@typescript/native-preview": "7.0.0-dev.20260113.1",
     "@vitest/browser-playwright": "^4.0.0",
     "buffer": "^6.0.3",
-    "chai": "^5.1.2",
-    "chai-as-promised": "^8.0.1",
     "jest": "^30.0.0",
-    "mocha": "^10.8.2",
-    "mocha-each": "^2.0.1",
     "playwright": "1.49.0",
-    "sinon": "^19.0.2",
-    "ts-node": "^10.9.1",
     "typescript": "^5.3.3",
     "util": "^0.12.5",
-    "vitest": "^4.0.0"
+    "vitest": "^4.0.0",
+    "@jest/globals": "^30.0.0",
+    "ts-node": "^10.9.1"
   },
   "files": [
     "dest",

--- a/yarn-project/kv-store/package.local.json
+++ b/yarn-project/kv-store/package.local.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "test": "yarn test:node && yarn test:browser",
+    "test": "vitest run",
     "test:browser": "bash scripts/run-browser-tests.sh"
   }
 }

--- a/yarn-project/kv-store/scripts/run_test.sh
+++ b/yarn-project/kv-store/scripts/run_test.sh
@@ -1,20 +1,10 @@
 #!/usr/bin/env bash
-# Runs a single kv-store test file. Dispatches to vitest+chromium for
-# browser tests (under src/indexeddb or src/sqlite-opfs) and to mocha for
-# everything else. Emitted by yarn-project/kv-store/bootstrap.sh test_cmds
-# for CI per-file fan-out and runnable directly for local reproduction:
-#
-#   yarn-project/kv-store/scripts/run_test.sh src/lmdb-v2/store.test.ts
+# Runs a single kv-store test file via vitest. The vitest config
+# (vitest.config.ts, projects array) determines whether the file runs
+# in node or browser environment based on its path.
 source $(git rev-parse --show-toplevel)/ci3/source
 
 test=${1:?"Usage: $0 <test-file relative to kv-store/>"}
 cd ..
 
-case "$test" in
-  src/indexeddb/*|src/sqlite-opfs/*)
-    exec yarn vitest run --config ./vitest.config.ts "$test"
-    ;;
-  *)
-    NODE_NO_WARNINGS=1 exec yarn mocha --config ./.mocharc.json "$test"
-    ;;
-esac
+NODE_NO_WARNINGS=1 exec yarn vitest run --config ./vitest.config.ts "$test"

--- a/yarn-project/kv-store/src/indexeddb/version_management.test.ts
+++ b/yarn-project/kv-store/src/indexeddb/version_management.test.ts
@@ -1,8 +1,6 @@
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { DatabaseVersion } from '@aztec/stdlib/database-version/version';
 
-import { expect } from 'chai';
-
 import { mockLogger } from '../interfaces/utils.js';
 import { initStoreForRollupAndSchemaVersion } from '../utils.js';
 import { AztecIndexedDBStore } from './store.js';
@@ -31,8 +29,8 @@ describe('IndexedDB Version Management', () => {
         const stored = await versionSingleton.getAsync();
 
         const storedVersion = DatabaseVersion.fromBuffer(Buffer.from(stored!, 'utf-8'));
-        expect(storedVersion.schemaVersion).to.equal(schemaVersion);
-        expect(storedVersion.rollupAddress.toString()).to.equal(rollupAddress.toString());
+        expect(storedVersion.schemaVersion).toBe(schemaVersion);
+        expect(storedVersion.rollupAddress.toString()).toBe(rollupAddress.toString());
       });
     });
 
@@ -46,7 +44,7 @@ describe('IndexedDB Version Management', () => {
         await initStoreForRollupAndSchemaVersion(store, schemaVersion, rollupAddress, mockLogger);
 
         // Data should still exist
-        expect(await testMap.getAsync('key')).to.equal('value');
+        expect(await testMap.getAsync('key')).toBe('value');
       });
     });
 
@@ -60,7 +58,7 @@ describe('IndexedDB Version Management', () => {
         const newRollupAddress = EthAddress.random();
         await initStoreForRollupAndSchemaVersion(store, schemaVersion, newRollupAddress, mockLogger);
 
-        expect(await testMap.getAsync('key')).to.be.undefined;
+        expect(await testMap.getAsync('key')).toBeUndefined();
       });
     });
 
@@ -73,7 +71,7 @@ describe('IndexedDB Version Management', () => {
 
         await initStoreForRollupAndSchemaVersion(store, schemaVersion + 1, rollupAddress, mockLogger);
 
-        expect(await testMap.getAsync('key')).to.be.undefined;
+        expect(await testMap.getAsync('key')).toBeUndefined();
       });
 
       it('clears store when schema version decreases', async () => {
@@ -84,7 +82,7 @@ describe('IndexedDB Version Management', () => {
 
         await initStoreForRollupAndSchemaVersion(store, schemaVersion - 1, rollupAddress, mockLogger);
 
-        expect(await testMap.getAsync('key')).to.be.undefined;
+        expect(await testMap.getAsync('key')).toBeUndefined();
       });
     });
 
@@ -98,7 +96,7 @@ describe('IndexedDB Version Management', () => {
 
         await initStoreForRollupAndSchemaVersion(store, schemaVersion, rollupAddress, mockLogger);
 
-        expect(await testMap.getAsync('key')).to.be.undefined;
+        expect(await testMap.getAsync('key')).toBeUndefined();
       });
 
       it('clears store when version has wrong structure', async () => {
@@ -110,7 +108,7 @@ describe('IndexedDB Version Management', () => {
 
         await initStoreForRollupAndSchemaVersion(store, schemaVersion, rollupAddress, mockLogger);
 
-        expect(await testMap.getAsync('key')).to.be.undefined;
+        expect(await testMap.getAsync('key')).toBeUndefined();
       });
     });
 
@@ -126,13 +124,13 @@ describe('IndexedDB Version Management', () => {
         // Init with new version management should clear the old data
         await initStoreForRollupAndSchemaVersion(store, schemaVersion, rollupAddress, mockLogger);
 
-        expect(await testMap.getAsync('key')).to.be.undefined;
+        expect(await testMap.getAsync('key')).toBeUndefined();
 
         const versionSingleton = store.openSingleton<string>('dbVersion');
         const stored = await versionSingleton.getAsync();
         const storedVersion = DatabaseVersion.fromBuffer(Buffer.from(stored!, 'utf-8'));
-        expect(storedVersion.schemaVersion).to.equal(schemaVersion);
-        expect(storedVersion.rollupAddress.toString()).to.equal(rollupAddress.toString());
+        expect(storedVersion.schemaVersion).toBe(schemaVersion);
+        expect(storedVersion.rollupAddress.toString()).toBe(rollupAddress.toString());
       });
 
       it('clears store with old format even if rollup address matches', async () => {
@@ -145,7 +143,7 @@ describe('IndexedDB Version Management', () => {
 
         await initStoreForRollupAndSchemaVersion(store, schemaVersion, rollupAddress, mockLogger);
 
-        expect(await testMap.getAsync('key')).to.be.undefined;
+        expect(await testMap.getAsync('key')).toBeUndefined();
       });
     });
   });

--- a/yarn-project/kv-store/src/interfaces/array_test_suite.ts
+++ b/yarn-project/kv-store/src/interfaces/array_test_suite.ts
@@ -1,7 +1,5 @@
 import { toArray } from '@aztec/foundation/iterable';
 
-import { expect } from 'chai';
-
 import type { AztecArray, AztecAsyncArray } from './array.js';
 import type { AztecAsyncKVStore, AztecKVStore } from './store.js';
 import { isSyncStore } from './utils.js';
@@ -53,12 +51,12 @@ export function describeAztecArray(
       await arr.push(2);
       await arr.push(3);
 
-      expect(await length()).to.equal(3);
+      expect(await length()).toBe(3);
 
-      expect(await arr.pop()).to.equal(3);
-      expect(await arr.pop()).to.equal(2);
-      expect(await arr.pop()).to.equal(1);
-      expect(await arr.pop()).to.equal(undefined);
+      expect(await arr.pop()).toBe(3);
+      expect(await arr.pop()).toBe(2);
+      expect(await arr.pop()).toBe(1);
+      expect(await arr.pop()).toBe(undefined);
     });
 
     it('should be able to get values by index', async () => {
@@ -66,14 +64,14 @@ export function describeAztecArray(
       await arr.push(2);
       await arr.push(3);
 
-      expect(await at(0)).to.equal(1);
-      expect(await at(1)).to.equal(2);
-      expect(await at(2)).to.equal(3);
-      expect(await at(3)).to.equal(undefined);
-      expect(await at(-1)).to.equal(3);
-      expect(await at(-2)).to.equal(2);
-      expect(await at(-3)).to.equal(1);
-      expect(await at(-4)).to.equal(undefined);
+      expect(await at(0)).toBe(1);
+      expect(await at(1)).toBe(2);
+      expect(await at(2)).toBe(3);
+      expect(await at(3)).toBe(undefined);
+      expect(await at(-1)).toBe(3);
+      expect(await at(-2)).toBe(2);
+      expect(await at(-3)).toBe(1);
+      expect(await at(-4)).toBe(undefined);
     });
 
     it('should be able to set values by index', async () => {
@@ -81,27 +79,27 @@ export function describeAztecArray(
       await arr.push(2);
       await arr.push(3);
 
-      expect(await arr.setAt(0, 4)).to.equal(true);
-      expect(await arr.setAt(1, 5)).to.equal(true);
-      expect(await arr.setAt(2, 6)).to.equal(true);
+      expect(await arr.setAt(0, 4)).toBe(true);
+      expect(await arr.setAt(1, 5)).toBe(true);
+      expect(await arr.setAt(2, 6)).toBe(true);
 
-      expect(await arr.setAt(3, 7)).to.equal(false);
+      expect(await arr.setAt(3, 7)).toBe(false);
 
-      expect(await at(0)).to.equal(4);
-      expect(await at(1)).to.equal(5);
-      expect(await at(2)).to.equal(6);
-      expect(await at(3)).to.equal(undefined);
+      expect(await at(0)).toBe(4);
+      expect(await at(1)).toBe(5);
+      expect(await at(2)).toBe(6);
+      expect(await at(3)).toBe(undefined);
 
-      expect(await arr.setAt(-1, 8)).to.equal(true);
-      expect(await arr.setAt(-2, 9)).to.equal(true);
-      expect(await arr.setAt(-3, 10)).to.equal(true);
+      expect(await arr.setAt(-1, 8)).toBe(true);
+      expect(await arr.setAt(-2, 9)).toBe(true);
+      expect(await arr.setAt(-3, 10)).toBe(true);
 
-      expect(await arr.setAt(-4, 11)).to.equal(false);
+      expect(await arr.setAt(-4, 11)).toBe(false);
 
-      expect(await at(-1)).to.equal(8);
-      expect(await at(-2)).to.equal(9);
-      expect(await at(-3)).to.equal(10);
-      expect(await at(-4)).to.equal(undefined);
+      expect(await at(-1)).toBe(8);
+      expect(await at(-2)).toBe(9);
+      expect(await at(-3)).toBe(10);
+      expect(await at(-4)).toBe(undefined);
     });
 
     it('should be able to iterate over values', async () => {
@@ -109,8 +107,8 @@ export function describeAztecArray(
       await arr.push(2);
       await arr.push(3);
 
-      expect(await values()).to.deep.equal([1, 2, 3]);
-      expect(await entries()).to.deep.equal([
+      expect(await values()).toEqual([1, 2, 3]);
+      expect(await entries()).toEqual([
         [0, 1],
         [1, 2],
         [2, 3],
@@ -123,8 +121,8 @@ export function describeAztecArray(
       await arr.push(3);
 
       const arr2 = store.openArray<number>('test');
-      expect(await length(arr2)).to.equal(3);
-      expect(await values(arr2)).to.deep.equal(await values());
+      expect(await length(arr2)).toBe(3);
+      expect(await values(arr2)).toEqual(await values());
     });
   });
 }

--- a/yarn-project/kv-store/src/interfaces/map_test_suite.ts
+++ b/yarn-project/kv-store/src/interfaces/map_test_suite.ts
@@ -1,7 +1,5 @@
 import { toArray } from '@aztec/foundation/iterable';
 
-import { expect } from 'chai';
-
 import type { Key, Range } from './common.js';
 import type { AztecAsyncMap, AztecMap } from './map.js';
 import type { AztecAsyncKVStore, AztecKVStore } from './store.js';
@@ -59,9 +57,9 @@ export function describeAztecMap(
       await map.set('foo', 'bar');
       await map.set('baz', 'qux');
 
-      expect(await get('foo')).to.equal('bar');
-      expect(await get('baz')).to.equal('qux');
-      expect(await get('quux')).to.equal(undefined);
+      expect(await get('foo')).toBe('bar');
+      expect(await get('baz')).toBe('qux');
+      expect(await get('quux')).toBe(undefined);
     });
 
     it('should be able to set many values', async () => {
@@ -69,7 +67,7 @@ export function describeAztecMap(
       await map.setMany(pairs);
 
       for (const { key, value } of pairs) {
-        expect(await get(key)).to.equal(value);
+        expect(await get(key)).toBe(value);
       }
     });
 
@@ -77,14 +75,14 @@ export function describeAztecMap(
       await map.set('foo', 'bar');
       await map.set('foo', 'baz');
 
-      expect(await get('foo')).to.equal('baz');
+      expect(await get('foo')).toBe('baz');
     });
 
     it('should be able to set values if they do not exist', async () => {
-      expect(await map.setIfNotExists('foo', 'bar')).to.equal(true);
-      expect(await map.setIfNotExists('foo', 'baz')).to.equal(false);
+      expect(await map.setIfNotExists('foo', 'bar')).toBe(true);
+      expect(await map.setIfNotExists('foo', 'baz')).toBe(false);
 
-      expect(await get('foo')).to.equal('bar');
+      expect(await get('foo')).toBe('bar');
     });
 
     it('should be able to delete values', async () => {
@@ -93,56 +91,56 @@ export function describeAztecMap(
 
       await map.delete('foo');
 
-      expect(await get('foo')).to.equal(undefined);
-      expect(await get('baz')).to.equal('qux');
+      expect(await get('foo')).toBe(undefined);
+      expect(await get('baz')).toBe('qux');
     });
 
     it('should be able to return size of the map', async () => {
       await map.set('foo', 'bar');
-      expect(await size()).to.equal(1);
+      expect(await size()).toBe(1);
       await map.set('baz', 'qux');
-      expect(await size()).to.equal(2);
+      expect(await size()).toBe(2);
 
       await map.delete('foo');
-      expect(await size()).to.equal(1);
+      expect(await size()).toBe(1);
     });
 
     it('returns 0 for empty map size', async () => {
-      expect(await size()).to.equal(0);
+      expect(await size()).toBe(0);
     });
 
     it('calculates size correctly across multiple operations', async () => {
-      expect(await size()).to.equal(0);
+      expect(await size()).toBe(0);
 
       // Add items
       await map.set('a', 'value1');
       await map.set('b', 'value2');
       await map.set('c', 'value3');
-      expect(await size()).to.equal(3);
+      expect(await size()).toBe(3);
 
       // Update existing (size should not change)
       await map.set('b', 'updated');
-      expect(await size()).to.equal(3);
+      expect(await size()).toBe(3);
 
       // Delete some
       await map.delete('a');
-      expect(await size()).to.equal(2);
+      expect(await size()).toBe(2);
 
       // Delete all
       await map.delete('b');
       await map.delete('c');
-      expect(await size()).to.equal(0);
+      expect(await size()).toBe(0);
     });
 
     it('should be able to iterate over entries when there are no keys', async () => {
-      expect(await entries()).to.deep.equal([]);
+      expect(await entries()).toEqual([]);
     });
 
     it('should be able to iterate over entries', async () => {
       await map.set('foo', 'bar');
       await map.set('baz', 'qux');
 
-      expect(await entries()).to.deep.equal([
+      expect(await entries()).toEqual([
         ['baz', 'qux'],
         ['foo', 'bar'],
       ]);
@@ -152,21 +150,21 @@ export function describeAztecMap(
       await map.set('foo', 'bar');
       await map.set('baz', 'quux');
 
-      expect(await values()).to.deep.equal(['quux', 'bar']);
+      expect(await values()).toEqual(['quux', 'bar']);
     });
 
     it('should be able to iterate over keys', async () => {
       await map.set('foo', 'bar');
       await map.set('baz', 'qux');
 
-      expect(await keys()).to.deep.equal(['baz', 'foo']);
+      expect(await keys()).toEqual(['baz', 'foo']);
     });
 
     it('should be able to iterate over string keys that represent numbers', async () => {
       await map.set('0x22', 'bar');
       await map.set('0x31', 'qux');
 
-      expect(await keys()).to.deep.equal(['0x22', '0x31']);
+      expect(await keys()).toEqual(['0x22', '0x31']);
     });
 
     for (const [name, data] of [
@@ -186,14 +184,14 @@ export function describeAztecMap(
         await map.set(c, 'c');
         await map.set(d, 'd');
 
-        expect(await keys()).to.deep.equal([a, b, c, d]);
-        expect(await keys({ start: b, end: c })).to.deep.equal([b]);
-        expect(await keys({ start: b })).to.deep.equal([b, c, d]);
-        expect(await keys({ end: c })).to.deep.equal([a, b]);
-        expect(await keys({ start: b, end: c, reverse: true })).to.deep.equal([c]);
-        expect(await keys({ start: b, limit: 1 })).to.deep.equal([b]);
-        expect(await keys({ start: b, reverse: true })).to.deep.equal([d, c]);
-        expect(await keys({ end: b, reverse: true })).to.deep.equal([b, a]);
+        expect(await keys()).toEqual([a, b, c, d]);
+        expect(await keys({ start: b, end: c })).toEqual([b]);
+        expect(await keys({ start: b })).toEqual([b, c, d]);
+        expect(await keys({ end: c })).toEqual([a, b]);
+        expect(await keys({ start: b, end: c, reverse: true })).toEqual([c]);
+        expect(await keys({ start: b, limit: 1 })).toEqual([b]);
+        expect(await keys({ start: b, reverse: true })).toEqual([d, c]);
+        expect(await keys({ end: b, reverse: true })).toEqual([b, a]);
       });
     }
   });

--- a/yarn-project/kv-store/src/interfaces/multi_map_test_suite.ts
+++ b/yarn-project/kv-store/src/interfaces/multi_map_test_suite.ts
@@ -1,7 +1,5 @@
 import { toArray } from '@aztec/foundation/iterable';
 
-import { expect } from 'chai';
-
 import type { Key, Range } from './common.js';
 import type { AztecAsyncMultiMap, AztecMultiMap } from './multi_map.js';
 import type { AztecAsyncKVStore, AztecKVStore } from './store.js';
@@ -72,16 +70,16 @@ export function describeAztecMultiMap(
       await multiMap.set('foo', 'bar');
       await multiMap.set('baz', 'qux');
 
-      expect(await get('foo')).to.equal('bar');
-      expect(await get('baz')).to.equal('qux');
-      expect(await get('quux')).to.equal(undefined);
+      expect(await get('foo')).toBe('bar');
+      expect(await get('baz')).toBe('qux');
+      expect(await get('quux')).toBe(undefined);
     });
 
     it('should be able to set values if they do not exist', async () => {
-      expect(await multiMap.setIfNotExists('foo', 'bar')).to.equal(true);
-      expect(await multiMap.setIfNotExists('foo', 'baz')).to.equal(false);
+      expect(await multiMap.setIfNotExists('foo', 'bar')).toBe(true);
+      expect(await multiMap.setIfNotExists('foo', 'baz')).toBe(false);
 
-      expect(await get('foo')).to.equal('bar');
+      expect(await get('foo')).toBe('bar');
     });
 
     it('should be able to delete values', async () => {
@@ -90,61 +88,61 @@ export function describeAztecMultiMap(
 
       await multiMap.delete('foo');
 
-      expect(await get('foo')).to.equal(undefined);
-      expect(await get('baz')).to.equal('qux');
+      expect(await get('foo')).toBe(undefined);
+      expect(await get('baz')).toBe('qux');
     });
 
     it('should be able to get size of the map', async () => {
       await multiMap.set('foo', 'bar');
-      expect(await size()).to.equal(1);
+      expect(await size()).toBe(1);
       await multiMap.set('baz', 'qux');
-      expect(await size()).to.equal(2);
+      expect(await size()).toBe(2);
 
       await multiMap.delete('foo');
-      expect(await size()).to.equal(1);
+      expect(await size()).toBe(1);
     });
 
     it('returns 0 for empty multimap size', async () => {
-      expect(await size()).to.equal(0);
+      expect(await size()).toBe(0);
     });
 
     it('calculates size correctly with multiple values per key', async () => {
-      expect(await size()).to.equal(0);
+      expect(await size()).toBe(0);
 
       // Add multiple values for same key
       await multiMap.set('key1', 'value1');
-      expect(await size()).to.equal(1);
+      expect(await size()).toBe(1);
       await multiMap.set('key1', 'value2');
-      expect(await size()).to.equal(2);
+      expect(await size()).toBe(2);
       await multiMap.set('key1', 'value3');
-      expect(await size()).to.equal(3);
+      expect(await size()).toBe(3);
 
       // Add values for different key
       await multiMap.set('key2', 'value4');
-      expect(await size()).to.equal(4);
+      expect(await size()).toBe(4);
 
       // Delete one value from key1
       await multiMap.deleteValue('key1', 'value2');
-      expect(await size()).to.equal(3);
+      expect(await size()).toBe(3);
 
       // Delete entire key
       await multiMap.delete('key1');
-      expect(await size()).to.equal(1);
+      expect(await size()).toBe(1);
 
       // Delete last key
       await multiMap.delete('key2');
-      expect(await size()).to.equal(0);
+      expect(await size()).toBe(0);
     });
 
     it('should be able to iterate over entries when there are no keys', async () => {
-      expect(await entries()).to.deep.equal([]);
+      expect(await entries()).toEqual([]);
     });
 
     it('should be able to iterate over entries', async () => {
       await multiMap.set('foo', 'bar');
       await multiMap.set('baz', 'qux');
 
-      expect(await entries()).to.deep.equal([
+      expect(await entries()).toEqual([
         ['baz', 'qux'],
         ['foo', 'bar'],
       ]);
@@ -154,28 +152,28 @@ export function describeAztecMultiMap(
       await multiMap.set('foo', 'bar');
       await multiMap.set('baz', 'quux');
 
-      expect(await values()).to.deep.equal(['quux', 'bar']);
+      expect(await values()).toEqual(['quux', 'bar']);
     });
 
     it('should be able to iterate over keys', async () => {
       await multiMap.set('foo', 'bar');
       await multiMap.set('baz', 'qux');
 
-      expect(await keys()).to.deep.equal(['baz', 'foo']);
+      expect(await keys()).toEqual(['baz', 'foo']);
     });
 
     it('should be able to get multiple values for a single key', async () => {
       await multiMap.set('foo', 'bar');
       await multiMap.set('foo', 'baz');
 
-      expect(await getValues('foo')).to.deep.equal(['bar', 'baz']);
+      expect(await getValues('foo')).toEqual(['bar', 'baz']);
     });
 
     it('should ignore multiple identical values', async () => {
       await multiMap.set('foo', 'bar');
       await multiMap.set('foo', 'bar');
 
-      expect(await getValues('foo')).to.deep.equal(['bar']);
+      expect(await getValues('foo')).toEqual(['bar']);
     });
 
     it('should be able to delete individual values for a single key', async () => {
@@ -185,22 +183,22 @@ export function describeAztecMultiMap(
 
       await multiMap.deleteValue('foo', '2');
 
-      expect(await getValues('foo')).to.deep.equal(['1', '3']);
+      expect(await getValues('foo')).toEqual(['1', '3']);
     });
 
     it('should be able to get size of the map with duplicate keys', async () => {
       await multiMap.set('foo', '1');
       await multiMap.set('foo', '2');
       await multiMap.set('foo', '3');
-      expect(await size()).to.equal(3);
+      expect(await size()).toBe(3);
 
       await multiMap.set('bar', '1');
       await multiMap.set('bar', '2');
       await multiMap.set('bar', '3');
-      expect(await size()).to.equal(6);
+      expect(await size()).toBe(6);
 
       await multiMap.deleteValue('foo', '2');
-      expect(await size()).to.equal(5);
+      expect(await size()).toBe(5);
     });
 
     it('should be able to delete the last and first values for a key', async () => {
@@ -210,11 +208,11 @@ export function describeAztecMultiMap(
 
       await multiMap.deleteValue('foo', '1');
 
-      expect(await getValues('foo')).to.deep.equal(['2', '3']);
+      expect(await getValues('foo')).toEqual(['2', '3']);
 
       await multiMap.deleteValue('foo', '3');
 
-      expect(await getValues('foo')).to.deep.equal(['2']);
+      expect(await getValues('foo')).toEqual(['2']);
     });
 
     it('should be able to fully clear a key', async () => {
@@ -226,7 +224,7 @@ export function describeAztecMultiMap(
       await multiMap.deleteValue('foo', '3');
       await multiMap.deleteValue('foo', '2');
 
-      expect(await getValues('foo')).to.deep.equal([]);
+      expect(await getValues('foo')).toEqual([]);
     });
 
     it('should be able to insert after deletion', async () => {
@@ -237,12 +235,12 @@ export function describeAztecMultiMap(
       await multiMap.deleteValue('foo', '2');
       await multiMap.set('foo', 'bar');
 
-      expect(await getValues('foo')).to.deep.equal(['1', '3', 'bar']);
+      expect(await getValues('foo')).toEqual(['1', '3', 'bar']);
 
       // Delete the just-added entry
       await multiMap.deleteValue('foo', 'bar');
 
-      expect(await getValues('foo')).to.deep.equal(['1', '3']);
+      expect(await getValues('foo')).toEqual(['1', '3']);
 
       // Reinsert the initially deleted key
       await multiMap.set('foo', '2');
@@ -250,7 +248,7 @@ export function describeAztecMultiMap(
       // LMDB and IndexedDB behave differently here, the former ordering by value and the latter by insertion. This is
       // fine because there is no expectation for values in a multimap to be ordered.
       const values = (await getValues('foo')).sort((a, b) => a.localeCompare(b));
-      expect(values).to.deep.equal(['1', '2', '3']);
+      expect(values).toEqual(['1', '2', '3']);
 
       // Fully clear the key
       await multiMap.deleteValue('foo', '1');
@@ -260,7 +258,7 @@ export function describeAztecMultiMap(
       // Insert some more
       await multiMap.set('foo', 'baz');
       await multiMap.set('foo', 'qux');
-      expect(await getValues('foo')).to.deep.equal(['baz', 'qux']);
+      expect(await getValues('foo')).toEqual(['baz', 'qux']);
     });
 
     it('supports range queries', async () => {
@@ -269,29 +267,29 @@ export function describeAztecMultiMap(
       await multiMap.set('c', 'c');
       await multiMap.set('d', 'd');
 
-      expect(await keys({ start: 'b', end: 'c' })).to.deep.equal(['b']);
-      expect(await keys({ start: 'b' })).to.deep.equal(['b', 'c', 'd']);
-      expect(await keys({ end: 'c' })).to.deep.equal(['a', 'b']);
-      expect(await keys({ start: 'b', end: 'c', reverse: true })).to.deep.equal(['c']);
-      expect(await keys({ start: 'b', limit: 1 })).to.deep.equal(['b']);
-      expect(await keys({ start: 'b', reverse: true })).to.deep.equal(['d', 'c']);
-      expect(await keys({ end: 'b', reverse: true })).to.deep.equal(['b', 'a']);
+      expect(await keys({ start: 'b', end: 'c' })).toEqual(['b']);
+      expect(await keys({ start: 'b' })).toEqual(['b', 'c', 'd']);
+      expect(await keys({ end: 'c' })).toEqual(['a', 'b']);
+      expect(await keys({ start: 'b', end: 'c', reverse: true })).toEqual(['c']);
+      expect(await keys({ start: 'b', limit: 1 })).toEqual(['b']);
+      expect(await keys({ start: 'b', reverse: true })).toEqual(['d', 'c']);
+      expect(await keys({ end: 'b', reverse: true })).toEqual(['b', 'a']);
     });
 
     it('returns 0 for missing key', async () => {
-      expect(await getValueCount('missing')).to.equal(0);
+      expect(await getValueCount('missing')).toBe(0);
     });
 
     it('counts a single value', async () => {
       await multiMap.set('foo', 'bar');
-      expect(await getValueCount('foo')).to.equal(1);
+      expect(await getValueCount('foo')).toBe(1);
     });
 
     it('counts multiple distinct values for same key', async () => {
       await multiMap.set('foo', 'bar');
       await multiMap.set('foo', 'baz');
       await multiMap.set('foo', 'qux');
-      expect(await getValueCount('foo')).to.equal(3);
+      expect(await getValueCount('foo')).toBe(3);
     });
 
     it('does not increase count for duplicate inserts', async () => {
@@ -299,42 +297,42 @@ export function describeAztecMultiMap(
       await multiMap.set('foo', 'bar');
       await multiMap.set('foo', 'baz');
       await multiMap.set('foo', 'baz');
-      expect(await getValueCount('foo')).to.equal(2);
-      expect(await getValues('foo')).to.have.members(['bar', 'baz']);
+      expect(await getValueCount('foo')).toBe(2);
+      expect((await getValues('foo')).sort()).toEqual(['bar', 'baz'].sort());
     });
 
     it('decrements when deleting a single value', async () => {
       await multiMap.set('foo', '1');
       await multiMap.set('foo', '2');
       await multiMap.set('foo', '3');
-      expect(await getValueCount('foo')).to.equal(3);
+      expect(await getValueCount('foo')).toBe(3);
       await multiMap.deleteValue('foo', '2');
-      expect(await getValueCount('foo')).to.equal(2);
-      expect(await getValues('foo')).to.have.members(['1', '3']);
+      expect(await getValueCount('foo')).toBe(2);
+      expect((await getValues('foo')).sort()).toEqual(['1', '3'].sort());
     });
 
     it('does not change count when deleting a non-existent value', async () => {
       await multiMap.set('foo', '1');
       await multiMap.set('foo', '3');
-      expect(await getValueCount('foo')).to.equal(2);
+      expect(await getValueCount('foo')).toBe(2);
       await multiMap.deleteValue('foo', '2');
-      expect(await getValueCount('foo')).to.equal(2);
+      expect(await getValueCount('foo')).toBe(2);
     });
 
     it('clears all values when deleting a key', async () => {
       await multiMap.set('foo', 'bar');
       await multiMap.set('foo', 'baz');
-      expect(await getValueCount('foo')).to.equal(2);
+      expect(await getValueCount('foo')).toBe(2);
       await multiMap.delete('foo');
-      expect(await getValueCount('foo')).to.equal(0);
-      expect(await getValues('foo')).to.deep.equal([]);
+      expect(await getValueCount('foo')).toBe(0);
+      expect(await getValues('foo')).toEqual([]);
     });
 
     it('count equals enumerated values length', async () => {
       await multiMap.set('foo', '1');
       await multiMap.set('foo', '2');
       const vals = await getValues('foo');
-      expect(await getValueCount('foo')).to.equal(vals.length);
+      expect(await getValueCount('foo')).toBe(vals.length);
     });
 
     it('sum of per-key counts equals total size', async () => {
@@ -348,27 +346,27 @@ export function describeAztecMultiMap(
       const uniqueKeys = Array.from(new Set(allKeys));
       const counts = await Promise.all(uniqueKeys.map(k => getValueCount(k)));
       const sum = counts.reduce((s, n) => s + n, 0);
-      expect(sum).to.equal(await size());
+      expect(sum).toBe(await size());
     });
 
     it('supports sparse slots: delete middle, reinsert new, count remains correct', async () => {
       await multiMap.set('foo', '1');
       await multiMap.set('foo', '2');
       await multiMap.set('foo', '3');
-      expect(await getValueCount('foo')).to.equal(3);
+      expect(await getValueCount('foo')).toBe(3);
       await multiMap.deleteValue('foo', '2');
-      expect(await getValueCount('foo')).to.equal(2);
+      expect(await getValueCount('foo')).toBe(2);
       await multiMap.set('foo', '4');
-      expect(await getValueCount('foo')).to.equal(3);
-      expect(await getValues('foo')).to.have.members(['1', '3', '4']);
+      expect(await getValueCount('foo')).toBe(3);
+      expect((await getValues('foo')).sort()).toEqual(['1', '3', '4'].sort());
     });
 
     it('multiple keys are independent', async () => {
       await multiMap.set('foo', '1');
       await multiMap.set('foo', '2');
       await multiMap.set('bar', '3');
-      expect(await getValueCount('foo')).to.equal(2);
-      expect(await getValueCount('bar')).to.equal(1);
+      expect(await getValueCount('foo')).toBe(2);
+      expect(await getValueCount('bar')).toBe(1);
     });
   });
 }

--- a/yarn-project/kv-store/src/interfaces/set_test_suite.ts
+++ b/yarn-project/kv-store/src/interfaces/set_test_suite.ts
@@ -1,7 +1,5 @@
 import { toArray } from '@aztec/foundation/iterable';
 
-import { expect } from 'chai';
-
 import type { Range } from './common.js';
 import type { AztecAsyncSet, AztecSet } from './set.js';
 import type { AztecAsyncKVStore, AztecKVStore } from './store.js';
@@ -41,9 +39,9 @@ export function describeAztecSet(
       await set.add('foo');
       await set.add('baz');
 
-      expect(await has('foo')).to.equal(true);
-      expect(await has('baz')).to.equal(true);
-      expect(await has('bar')).to.equal(false);
+      expect(await has('foo')).toBe(true);
+      expect(await has('baz')).toBe(true);
+      expect(await has('bar')).toBe(false);
     });
 
     it('should be able to delete values', async () => {
@@ -52,15 +50,15 @@ export function describeAztecSet(
 
       await set.delete('foo');
 
-      expect(await has('foo')).to.equal(false);
-      expect(await has('baz')).to.equal(true);
+      expect(await has('foo')).toBe(false);
+      expect(await has('baz')).toBe(true);
     });
 
     it('should be able to iterate over entries', async () => {
       await set.add('baz');
       await set.add('foo');
 
-      expect(await entries()).to.deep.equal(['baz', 'foo']);
+      expect(await entries()).toEqual(['baz', 'foo']);
     });
 
     it('supports range queries', async () => {
@@ -69,13 +67,13 @@ export function describeAztecSet(
       await set.add('c');
       await set.add('d');
 
-      expect(await entries({ start: 'b', end: 'c' })).to.deep.equal(['b']);
-      expect(await entries({ start: 'b' })).to.deep.equal(['b', 'c', 'd']);
-      expect(await entries({ end: 'c' })).to.deep.equal(['a', 'b']);
-      expect(await entries({ start: 'b', end: 'c', reverse: true })).to.deep.equal(['c']);
-      expect(await entries({ start: 'b', limit: 1 })).to.deep.equal(['b']);
-      expect(await entries({ start: 'b', reverse: true })).to.deep.equal(['d', 'c']);
-      expect(await entries({ end: 'b', reverse: true })).to.deep.equal(['b', 'a']);
+      expect(await entries({ start: 'b', end: 'c' })).toEqual(['b']);
+      expect(await entries({ start: 'b' })).toEqual(['b', 'c', 'd']);
+      expect(await entries({ end: 'c' })).toEqual(['a', 'b']);
+      expect(await entries({ start: 'b', end: 'c', reverse: true })).toEqual(['c']);
+      expect(await entries({ start: 'b', limit: 1 })).toEqual(['b']);
+      expect(await entries({ start: 'b', reverse: true })).toEqual(['d', 'c']);
+      expect(await entries({ end: 'b', reverse: true })).toEqual(['b', 'a']);
     });
   });
 }

--- a/yarn-project/kv-store/src/interfaces/singleton_test_suite.ts
+++ b/yarn-project/kv-store/src/interfaces/singleton_test_suite.ts
@@ -1,5 +1,3 @@
-import { expect } from 'chai';
-
 import type { AztecAsyncSingleton, AztecSingleton } from './singleton.js';
 import type { AztecAsyncKVStore, AztecKVStore } from './store.js';
 import { isSyncStore } from './utils.js';
@@ -29,18 +27,18 @@ export function describeAztecSingleton(
     }
 
     it('returns undefined if the value is not set', async () => {
-      expect(await get()).to.equal(undefined);
+      expect(await get()).toBe(undefined);
     });
 
     it('should be able to set and get values', async () => {
-      expect(await singleton.set('foo')).to.equal(true);
-      expect(await get()).to.equal('foo');
+      expect(await singleton.set('foo')).toBe(true);
+      expect(await get()).toBe('foo');
     });
 
     it('overwrites the value if it is set again', async () => {
-      expect(await singleton.set('foo')).to.equal(true);
-      expect(await singleton.set('bar')).to.equal(true);
-      expect(await get()).to.equal('bar');
+      expect(await singleton.set('foo')).toBe(true);
+      expect(await singleton.set('bar')).toBe(true);
+      expect(await get()).toBe('bar');
     });
   });
 }

--- a/yarn-project/kv-store/src/lmdb-v2/close.test.ts
+++ b/yarn-project/kv-store/src/lmdb-v2/close.test.ts
@@ -1,7 +1,5 @@
 import { randomBytes } from '@aztec/foundation/crypto/random';
 
-import { expect } from 'chai';
-
 import type { AztecAsyncMap } from '../interfaces/map.js';
 import { openTmpStore } from './factory.js';
 import { AztecLMDBStoreV2 } from './store.js';
@@ -51,8 +49,8 @@ describe('Clean shutdown', () => {
     const closeSuccess = await close;
 
     // The fact that we are here suggests that everything completed success fully. There were no unrecoverable errors within the NAPI module
-    expect(numSuccessfulReads).greaterThanOrEqual(0);
-    expect(numSuccessfulReads).lessThanOrEqual(reads.length + reads2.length);
-    expect(closeSuccess).to.equal(true);
+    expect(numSuccessfulReads).toBeGreaterThanOrEqual(0);
+    expect(numSuccessfulReads).toBeLessThanOrEqual(reads.length + reads2.length);
+    expect(closeSuccess).toBe(true);
   });
 });

--- a/yarn-project/kv-store/src/lmdb-v2/read_transaction.test.ts
+++ b/yarn-project/kv-store/src/lmdb-v2/read_transaction.test.ts
@@ -1,6 +1,8 @@
 import { toArray } from '@aztec/foundation/iterable';
 import { promiseWithResolvers } from '@aztec/foundation/promise';
 
+import { vi } from 'vitest';
+
 import {
   CURSOR_PAGE_SIZE,
   Database,
@@ -11,7 +13,7 @@ import {
 import { ReadTransaction } from './read_transaction.js';
 
 describe('ReadTransaction', () => {
-  let channel: { sendMessage: ReturnType<typeof vi.fn> } & LMDBMessageChannel;
+  let channel: { sendMessage: ReturnType<typeof vi.fn<(...args: any[]) => any>> } & LMDBMessageChannel;
   let tx: ReadTransaction;
 
   beforeEach(() => {

--- a/yarn-project/kv-store/src/lmdb-v2/read_transaction.test.ts
+++ b/yarn-project/kv-store/src/lmdb-v2/read_transaction.test.ts
@@ -1,9 +1,6 @@
 import { toArray } from '@aztec/foundation/iterable';
 import { promiseWithResolvers } from '@aztec/foundation/promise';
 
-import { expect } from 'chai';
-import { type SinonStubbedInstance, stub } from 'sinon';
-
 import {
   CURSOR_PAGE_SIZE,
   Database,
@@ -14,158 +11,159 @@ import {
 import { ReadTransaction } from './read_transaction.js';
 
 describe('ReadTransaction', () => {
-  let channel: SinonStubbedInstance<LMDBMessageChannel>;
+  let channel: { sendMessage: ReturnType<typeof vi.fn> } & LMDBMessageChannel;
   let tx: ReadTransaction;
 
   beforeEach(() => {
-    channel = stub<LMDBMessageChannel>({
-      sendMessage: () => {},
-    } as any);
+    channel = { sendMessage: vi.fn() } as any;
     tx = new ReadTransaction(channel);
   });
 
   it('sends GET requests', async () => {
     const getDeferred = promiseWithResolvers<LMDBResponseBody[LMDBMessageType.GET]>();
 
-    channel.sendMessage.returns(getDeferred.promise);
+    channel.sendMessage.mockReturnValue(getDeferred.promise);
 
     const resp = tx.get(Buffer.from('test_key1'));
 
-    expect(
-      channel.sendMessage.calledWith(LMDBMessageType.GET, {
-        db: Database.DATA,
-        keys: [Buffer.from('test_key1')],
-      }),
-    ).to.be.true;
+    expect(channel.sendMessage).toHaveBeenCalledWith(LMDBMessageType.GET, {
+      db: Database.DATA,
+      keys: [Buffer.from('test_key1')],
+    });
 
     getDeferred.resolve({
       values: [[Buffer.from('foo')]],
     });
 
-    expect(await resp).to.deep.eq(Buffer.from('foo'));
+    expect(await resp).toEqual(Buffer.from('foo'));
   });
 
   it('iterates the database', async () => {
-    channel.sendMessage.onCall(0).resolves({
-      cursor: 42,
-      entries: [[Buffer.from('foo'), [Buffer.from('a value')]]],
-      done: false,
-    });
-    channel.sendMessage.onCall(1).resolves({
-      entries: [[Buffer.from('quux'), [Buffer.from('another value')]]],
-      done: true,
-    });
-    channel.sendMessage.onCall(2).resolves({
-      ok: true,
-    });
+    channel.sendMessage
+      .mockResolvedValueOnce({
+        cursor: 42,
+        entries: [[Buffer.from('foo'), [Buffer.from('a value')]]],
+        done: false,
+      })
+      .mockResolvedValueOnce({
+        entries: [[Buffer.from('quux'), [Buffer.from('another value')]]],
+        done: true,
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+      });
 
     const iterable = tx.iterate(Buffer.from('foo'));
     const entries = await toArray(iterable);
 
-    expect(entries).to.deep.eq([
+    expect(entries).toEqual([
       [Buffer.from('foo'), Buffer.from('a value')],
       [Buffer.from('quux'), Buffer.from('another value')],
     ]);
 
-    expect(
-      channel.sendMessage.calledWith(LMDBMessageType.START_CURSOR, {
-        db: Database.DATA,
-        key: Buffer.from('foo'),
-        count: CURSOR_PAGE_SIZE,
-        onePage: false,
-        reverse: false,
-      }),
-    ).to.be.true;
+    expect(channel.sendMessage).toHaveBeenCalledWith(LMDBMessageType.START_CURSOR, {
+      db: Database.DATA,
+      key: Buffer.from('foo'),
+      count: CURSOR_PAGE_SIZE,
+      onePage: false,
+      reverse: false,
+    });
 
-    expect(
-      channel.sendMessage.calledWith(LMDBMessageType.ADVANCE_CURSOR, {
-        cursor: 42,
-        count: CURSOR_PAGE_SIZE,
-      }),
-    ).to.be.true;
+    expect(channel.sendMessage).toHaveBeenCalledWith(LMDBMessageType.ADVANCE_CURSOR, {
+      cursor: 42,
+      count: CURSOR_PAGE_SIZE,
+    });
 
-    expect(
-      channel.sendMessage.calledWith(LMDBMessageType.CLOSE_CURSOR, {
-        cursor: 42,
-      }),
-    ).to.be.true;
+    expect(channel.sendMessage).toHaveBeenCalledWith(LMDBMessageType.CLOSE_CURSOR, {
+      cursor: 42,
+    });
   });
 
   it('closes the cursor early', async () => {
-    channel.sendMessage.onCall(0).resolves({
-      cursor: 42,
-      entries: [[Buffer.from('foo'), [Buffer.from('a value')]]],
-      done: false,
+    channel.sendMessage.mockImplementation((type: LMDBMessageType, _body: any) => {
+      if (type === LMDBMessageType.START_CURSOR) {
+        return Promise.resolve({
+          cursor: 42,
+          entries: [[Buffer.from('foo'), [Buffer.from('a value')]]],
+          done: false,
+        });
+      }
+      if (type === LMDBMessageType.ADVANCE_CURSOR) {
+        return Promise.reject(new Error('SHOULD NOT BE CALLED'));
+      }
+      if (type === LMDBMessageType.CLOSE_CURSOR) {
+        return Promise.resolve({ ok: true });
+      }
+      return Promise.resolve({});
     });
 
-    channel.sendMessage
-      .withArgs(LMDBMessageType.ADVANCE_CURSOR, { cursor: 42, count: CURSOR_PAGE_SIZE })
-      .rejects(new Error('SHOULD NOT BE CALLED'));
-
-    channel.sendMessage.withArgs(LMDBMessageType.CLOSE_CURSOR, { cursor: 42 }).resolves({ ok: true });
-
     for await (const entry of tx.iterate(Buffer.from('foo'))) {
-      expect(entry).to.deep.eq([Buffer.from('foo'), Buffer.from('a value')]);
+      expect(entry).toEqual([Buffer.from('foo'), Buffer.from('a value')]);
       break;
     }
 
-    expect(
-      channel.sendMessage.calledWith(LMDBMessageType.CLOSE_CURSOR, {
-        cursor: 42,
-      }),
-    ).to.be.true;
+    expect(channel.sendMessage).toHaveBeenCalledWith(LMDBMessageType.CLOSE_CURSOR, {
+      cursor: 42,
+    });
   });
 
   it('closes the cursor even if in the case of an error', async () => {
-    channel.sendMessage.onCall(0).resolves({
-      cursor: 42,
-      entries: [[Buffer.from('foo'), [Buffer.from('a value')]]],
-      done: false,
+    channel.sendMessage.mockImplementation((type: LMDBMessageType, _body: any) => {
+      if (type === LMDBMessageType.START_CURSOR) {
+        return Promise.resolve({
+          cursor: 42,
+          entries: [[Buffer.from('foo'), [Buffer.from('a value')]]],
+          done: false,
+        });
+      }
+      if (type === LMDBMessageType.ADVANCE_CURSOR) {
+        return Promise.reject(new Error('SHOULD NOT BE CALLED'));
+      }
+      if (type === LMDBMessageType.CLOSE_CURSOR) {
+        return Promise.resolve({ ok: true });
+      }
+      return Promise.resolve({});
     });
-
-    channel.sendMessage
-      .withArgs(LMDBMessageType.ADVANCE_CURSOR, { cursor: 42, count: CURSOR_PAGE_SIZE })
-      .rejects(new Error('SHOULD NOT BE CALLED'));
-
-    channel.sendMessage.withArgs(LMDBMessageType.CLOSE_CURSOR, { cursor: 42 }).resolves({ ok: true });
 
     try {
       for await (const entry of tx.iterate(Buffer.from('foo'))) {
-        expect(entry).to.deep.eq([Buffer.from('foo'), Buffer.from('a value')]);
+        expect(entry).toEqual([Buffer.from('foo'), Buffer.from('a value')]);
         throw new Error();
       }
     } catch {
       // no op
     }
 
-    expect(
-      channel.sendMessage.calledWith(LMDBMessageType.CLOSE_CURSOR, {
-        cursor: 42,
-      }),
-    ).to.be.true;
+    expect(channel.sendMessage).toHaveBeenCalledWith(LMDBMessageType.CLOSE_CURSOR, {
+      cursor: 42,
+    });
   });
 
   it('handles empty cursors', async () => {
-    channel.sendMessage
-      .withArgs(LMDBMessageType.START_CURSOR, {
-        key: Buffer.from('foo'),
-        reverse: false,
-        count: CURSOR_PAGE_SIZE,
-        db: Database.DATA,
-        onePage: false,
-      })
-      .resolves({
-        cursor: null,
-        entries: [],
-        done: true,
-      });
+    channel.sendMessage.mockImplementation((type: LMDBMessageType, body: any) => {
+      if (
+        type === LMDBMessageType.START_CURSOR &&
+        Buffer.from('foo').equals(body.key) &&
+        body.reverse === false &&
+        body.count === CURSOR_PAGE_SIZE &&
+        body.db === Database.DATA &&
+        body.onePage === false
+      ) {
+        return Promise.resolve({
+          cursor: null,
+          entries: [],
+          done: true,
+        });
+      }
+      return Promise.resolve({});
+    });
 
     const arr = await toArray(tx.iterate(Buffer.from('foo')));
-    expect(arr).to.deep.eq([]);
+    expect(arr).toEqual([]);
   });
 
   it('after close it does not accept requests', async () => {
     tx.close();
-    await expect(tx.get(Buffer.from('foo'))).eventually.to.be.rejectedWith(Error, 'Transaction is closed');
+    await expect(tx.get(Buffer.from('foo'))).rejects.toThrow('Transaction is closed');
   });
 });

--- a/yarn-project/kv-store/src/lmdb-v2/store.test.ts
+++ b/yarn-project/kv-store/src/lmdb-v2/store.test.ts
@@ -1,11 +1,9 @@
 import { promiseWithResolvers } from '@aztec/foundation/promise';
 import { sleep } from '@aztec/foundation/sleep';
 
-import { expect } from 'chai';
 import { mkdtemp } from 'fs/promises';
 import { tmpdir } from 'os';
 import { join } from 'path';
-import { stub } from 'sinon';
 
 import { openStoreAt, openTmpStore } from './factory.js';
 import type { ReadTransaction } from './read_transaction.js';
@@ -27,8 +25,8 @@ describe('AztecLMDBStoreV2', () => {
   it('returns undefined for unset keys', async () => {
     const tx = store.getReadTx();
     try {
-      expect(await tx.get(Buffer.from('foo'))).to.be.undefined;
-      expect(await tx.getIndex(Buffer.from('foo'))).to.deep.eq([]);
+      expect(await tx.get(Buffer.from('foo'))).toBeUndefined();
+      expect(await tx.getIndex(Buffer.from('foo'))).toEqual([]);
     } finally {
       tx.close();
     }
@@ -63,7 +61,7 @@ describe('AztecLMDBStoreV2', () => {
     };
 
     // before doing any writes, we should have an empty db
-    expect(await getValues()).to.deep.eq({
+    expect(await getValues()).toEqual({
       data: undefined,
       index: [],
     });
@@ -74,13 +72,13 @@ describe('AztecLMDBStoreV2', () => {
       await writeTx.setIndex(Buffer.from('foo'), Buffer.from('bar'), Buffer.from('baz'));
 
       // the write tx should make the writes visible immediately
-      expect(await getValues(writeTx)).to.deep.eq({
+      expect(await getValues(writeTx)).toEqual({
         data: Buffer.from('bar'),
         index: [Buffer.from('bar'), Buffer.from('baz')],
       });
 
       // even without access to the tx, the writes should still be visible in this context
-      expect(await getValues()).to.deep.eq({
+      expect(await getValues()).toEqual({
         data: Buffer.from('bar'),
         index: [Buffer.from('bar'), Buffer.from('baz')],
       });
@@ -92,7 +90,7 @@ describe('AztecLMDBStoreV2', () => {
     });
 
     // we don't know a write is happening, so we should get an empty result back
-    expect(await getValues()).to.deep.eq({
+    expect(await getValues()).toEqual({
       data: undefined,
       index: [],
     });
@@ -101,7 +99,7 @@ describe('AztecLMDBStoreV2', () => {
     await writeChecks.promise;
 
     // to batch is ready but uncommmitted, we should still see empty data
-    expect(await getValues()).to.deep.eq({
+    expect(await getValues()).toEqual({
       data: undefined,
       index: [],
     });
@@ -110,7 +108,7 @@ describe('AztecLMDBStoreV2', () => {
     await writeCommitted;
 
     // now we should see the db update
-    expect(await getValues()).to.deep.eq({
+    expect(await getValues()).toEqual({
       data: Buffer.from('bar'),
       index: [Buffer.from('bar'), Buffer.from('baz')],
     });
@@ -132,7 +130,7 @@ describe('AztecLMDBStoreV2', () => {
     }
 
     await Promise.all(promises);
-    expect(Buffer.from((await store.getReadTx().get(key))!).readUint32BE()).to.eq(rounds);
+    expect(Buffer.from((await store.getReadTx().get(key))!).readUint32BE()).toBe(rounds);
   });
 
   it('guards against too many cursors being opened at the same time', async () => {
@@ -151,29 +149,29 @@ describe('AztecLMDBStoreV2', () => {
     }
 
     // the first few iterators should be fine
-    await expect(Promise.all(cursors.slice(0, -1).map(it => it.next()))).eventually.to.deep.eq([
+    await expect(Promise.all(cursors.slice(0, -1).map(it => it.next()))).resolves.toEqual([
       { value: [Buffer.from('1'), Buffer.from('1')], done: false },
       { value: [Buffer.from('1'), Buffer.from('1')], done: false },
       { value: [Buffer.from('1'), Buffer.from('1')], done: false },
     ]);
 
     // this promise should be blocked until we release a cursor
-    const fn = stub();
-    cursors.at(-1)!.next().then(fn, fn);
+    const fn = vi.fn();
+    void cursors.at(-1)!.next().then(fn, fn);
 
-    expect(fn.notCalled).to.be.true;
+    expect(fn).not.toHaveBeenCalled();
     await sleep(100);
-    expect(fn.notCalled).to.be.true;
+    expect(fn).not.toHaveBeenCalled();
 
     // but we can still do regular reads
-    await expect(readTx.get(Buffer.from('99'))).eventually.to.deep.eq(Buffer.from('99'));
+    await expect(readTx.get(Buffer.from('99'))).resolves.toEqual(Buffer.from('99'));
 
     // early-return one of the cursors
     await cursors[0].return!();
 
     // this should have unblocked the last cursor from progressing
     await sleep(10);
-    expect(fn.calledWith({ value: [Buffer.from('1'), Buffer.from('1')], done: false })).to.be.true;
+    expect(fn).toHaveBeenCalledWith({ value: [Buffer.from('1'), Buffer.from('1')], done: false });
 
     for (let i = 1; i < testMaxReaders; i++) {
       await cursors[i].return!();
@@ -186,13 +184,13 @@ describe('AztecLMDBStoreV2', () => {
     const key = Buffer.from('foo');
     const value = Buffer.from('bar');
     await store.transactionAsync(tx => tx.set(key, value));
-    expect(Buffer.from((await store.getReadTx().get(key))!).toString()).to.eq('bar');
+    expect(Buffer.from((await store.getReadTx().get(key))!).toString()).toBe('bar');
 
     const backupDir = await mkdtemp(join(tmpdir(), 'lmdb-store-test-backup'));
     await store.backupTo(backupDir, true);
 
     const store2 = await openStoreAt(backupDir);
-    expect(Buffer.from((await store2.getReadTx().get(key))!).toString()).to.eq('bar');
+    expect(Buffer.from((await store2.getReadTx().get(key))!).toString()).toBe('bar');
     await store2.close();
     await store2.delete();
   });
@@ -204,7 +202,7 @@ describe('AztecLMDBStoreV2', () => {
         await AztecLMDBStoreV2.new(dataDir, 0);
         expect.fail('Expected an error for zero map size');
       } catch (e: any) {
-        expect(e.message).to.include('Map size must be a positive number');
+        expect(e.message).toContain('Map size must be a positive number');
       }
     });
 
@@ -214,7 +212,7 @@ describe('AztecLMDBStoreV2', () => {
         await AztecLMDBStoreV2.new(dataDir, -1);
         expect.fail('Expected an error for negative map size');
       } catch (e: any) {
-        expect(e.message).to.include('Map size must be a positive number');
+        expect(e.message).toContain('Map size must be a positive number');
       }
     });
   });

--- a/yarn-project/kv-store/src/lmdb-v2/store.test.ts
+++ b/yarn-project/kv-store/src/lmdb-v2/store.test.ts
@@ -4,6 +4,7 @@ import { sleep } from '@aztec/foundation/sleep';
 import { mkdtemp } from 'fs/promises';
 import { tmpdir } from 'os';
 import { join } from 'path';
+import { vi } from 'vitest';
 
 import { openStoreAt, openTmpStore } from './factory.js';
 import type { ReadTransaction } from './read_transaction.js';
@@ -200,7 +201,7 @@ describe('AztecLMDBStoreV2', () => {
       const dataDir = await mkdtemp(join(tmpdir(), 'lmdb-map-size-test-'));
       try {
         await AztecLMDBStoreV2.new(dataDir, 0);
-        expect.fail('Expected an error for zero map size');
+        throw new Error('Expected an error for zero map size');
       } catch (e: any) {
         expect(e.message).toContain('Map size must be a positive number');
       }
@@ -210,7 +211,7 @@ describe('AztecLMDBStoreV2', () => {
       const dataDir = await mkdtemp(join(tmpdir(), 'lmdb-map-size-test-'));
       try {
         await AztecLMDBStoreV2.new(dataDir, -1);
-        expect.fail('Expected an error for negative map size');
+        throw new Error('Expected an error for negative map size');
       } catch (e: any) {
         expect(e.message).toContain('Map size must be a positive number');
       }

--- a/yarn-project/kv-store/src/lmdb-v2/write_transaction.test.ts
+++ b/yarn-project/kv-store/src/lmdb-v2/write_transaction.test.ts
@@ -1,22 +1,17 @@
 import { toArray } from '@aztec/foundation/iterable';
 
-import { expect } from 'chai';
-import { type SinonStubbedInstance, stub } from 'sinon';
-
 import { type Batch, CURSOR_PAGE_SIZE, Database, type LMDBMessageChannel, LMDBMessageType } from './message.js';
 import { WriteTransaction } from './write_transaction.js';
 
 describe('WriteTransaction', () => {
-  let channel: SinonStubbedInstance<LMDBMessageChannel>;
+  let channel: { sendMessage: ReturnType<typeof vi.fn> } & LMDBMessageChannel;
   let tx: WriteTransaction;
 
   beforeEach(() => {
-    channel = stub<LMDBMessageChannel>({
-      sendMessage: () => {},
-    } as any);
+    channel = { sendMessage: vi.fn() } as any;
     tx = new WriteTransaction(channel);
 
-    channel.sendMessage.resolves({ ok: true });
+    channel.sendMessage.mockResolvedValue({ ok: true });
   });
 
   it('accumulatest writes', async () => {
@@ -26,112 +21,117 @@ describe('WriteTransaction', () => {
     await tx.remove(Buffer.from('baz'));
 
     await tx.commit();
-    expect(
-      channel.sendMessage.calledWith(LMDBMessageType.BATCH, {
-        batches: new Map<string, Batch>([
-          [
-            Database.INDEX,
-            {
-              removeEntries: [[Buffer.from('bar'), [Buffer.from('1'), Buffer.from('2')]]],
-              addEntries: [[Buffer.from('foo'), [Buffer.from('1'), Buffer.from('2'), Buffer.from('3')]]],
-            },
-          ],
-          [
-            Database.DATA,
-            {
-              removeEntries: [[Buffer.from('baz'), null]],
-              addEntries: [[Buffer.from('foo'), [Buffer.from('a')]]],
-            },
-          ],
-        ]),
-      }),
-    ).to.be.true;
+    expect(channel.sendMessage).toHaveBeenCalledWith(LMDBMessageType.BATCH, {
+      batches: new Map<string, Batch>([
+        [
+          Database.INDEX,
+          {
+            removeEntries: [[Buffer.from('bar'), [Buffer.from('1'), Buffer.from('2')]]],
+            addEntries: [[Buffer.from('foo'), [Buffer.from('1'), Buffer.from('2'), Buffer.from('3')]]],
+          },
+        ],
+        [
+          Database.DATA,
+          {
+            removeEntries: [[Buffer.from('baz'), null]],
+            addEntries: [[Buffer.from('foo'), [Buffer.from('a')]]],
+          },
+        ],
+      ]),
+    });
   });
 
   it('correctly manages index batch', async () => {
     await tx.setIndex(Buffer.from('foo'), Buffer.from('1'), Buffer.from('2'), Buffer.from('3'));
-    expect(tx.indexBatch).to.deep.eq({
+    expect(tx.indexBatch).toEqual({
       removeEntries: [],
       addEntries: [[Buffer.from('foo'), [Buffer.from('1'), Buffer.from('2'), Buffer.from('3')]]],
     });
 
     await tx.setIndex(Buffer.from('foo'), Buffer.from('4'));
-    expect(tx.indexBatch).to.deep.eq({
+    expect(tx.indexBatch).toEqual({
       removeEntries: [],
       addEntries: [[Buffer.from('foo'), [Buffer.from('1'), Buffer.from('2'), Buffer.from('3'), Buffer.from('4')]]],
     });
 
     await tx.removeIndex(Buffer.from('foo'), Buffer.from('5'));
-    expect(tx.indexBatch).to.deep.eq({
+    expect(tx.indexBatch).toEqual({
       removeEntries: [[Buffer.from('foo'), [Buffer.from('5')]]],
       addEntries: [[Buffer.from('foo'), [Buffer.from('1'), Buffer.from('2'), Buffer.from('3'), Buffer.from('4')]]],
     });
 
     await tx.removeIndex(Buffer.from('foo'), Buffer.from('1'), Buffer.from('2'), Buffer.from('6'));
-    expect(tx.indexBatch).to.deep.eq({
+    expect(tx.indexBatch).toEqual({
       removeEntries: [[Buffer.from('foo'), [Buffer.from('1'), Buffer.from('2'), Buffer.from('5'), Buffer.from('6')]]],
       addEntries: [[Buffer.from('foo'), [Buffer.from('3'), Buffer.from('4')]]],
     });
 
     await tx.removeIndex(Buffer.from('foo'));
-    expect(tx.indexBatch).to.deep.eq({
+    expect(tx.indexBatch).toEqual({
       removeEntries: [[Buffer.from('foo'), null]],
       addEntries: [],
     });
 
     await tx.removeIndex(Buffer.from('foo'), Buffer.from('2'));
-    expect(tx.indexBatch).to.deep.eq({
+    expect(tx.indexBatch).toEqual({
       removeEntries: [[Buffer.from('foo'), [Buffer.from('2')]]],
       addEntries: [],
     });
     await tx.setIndex(Buffer.from('foo'), Buffer.from('2'));
-    expect(tx.indexBatch).to.deep.eq({
+    expect(tx.indexBatch).toEqual({
       removeEntries: [],
       addEntries: [[Buffer.from('foo'), [Buffer.from('2')]]],
     });
   });
 
   it('correctly meanages pending data reads', async () => {
-    channel.sendMessage.resolves({ values: [null] });
-    expect(await tx.get(Buffer.from('foo'))).to.deep.eq(undefined);
+    channel.sendMessage.mockResolvedValue({ values: [null] });
+    expect(await tx.get(Buffer.from('foo'))).toEqual(undefined);
 
     await tx.set(Buffer.from('foo'), Buffer.from('1'));
-    expect(await tx.get(Buffer.from('foo'))).to.deep.eq(Buffer.from('1'));
+    expect(await tx.get(Buffer.from('foo'))).toEqual(Buffer.from('1'));
 
     await tx.set(Buffer.from('foo'), Buffer.from('2'));
-    expect(await tx.get(Buffer.from('foo'))).to.deep.eq(Buffer.from('2'));
+    expect(await tx.get(Buffer.from('foo'))).toEqual(Buffer.from('2'));
 
     await tx.remove(Buffer.from('foo'));
-    expect(await tx.get(Buffer.from('foo'))).to.deep.eq(undefined);
+    expect(await tx.get(Buffer.from('foo'))).toEqual(undefined);
   });
 
   it('correctly meanages pending index reads', async () => {
-    channel.sendMessage.resolves({ values: [[Buffer.from('1')]] });
-    expect(await tx.getIndex(Buffer.from('foo'))).to.deep.eq([Buffer.from('1')]);
+    channel.sendMessage.mockResolvedValue({ values: [[Buffer.from('1')]] });
+    expect(await tx.getIndex(Buffer.from('foo'))).toEqual([Buffer.from('1')]);
 
     await tx.setIndex(Buffer.from('foo'), Buffer.from('1'));
-    expect(await tx.getIndex(Buffer.from('foo'))).to.deep.eq([Buffer.from('1')]);
+    expect(await tx.getIndex(Buffer.from('foo'))).toEqual([Buffer.from('1')]);
 
     await tx.setIndex(Buffer.from('foo'), Buffer.from('2'));
-    expect(await tx.getIndex(Buffer.from('foo'))).to.deep.eq([Buffer.from('1'), Buffer.from('2')]);
+    expect(await tx.getIndex(Buffer.from('foo'))).toEqual([Buffer.from('1'), Buffer.from('2')]);
 
     await tx.removeIndex(Buffer.from('foo'), Buffer.from('1'));
-    expect(await tx.getIndex(Buffer.from('foo'))).to.deep.eq([Buffer.from('2')]);
+    expect(await tx.getIndex(Buffer.from('foo'))).toEqual([Buffer.from('2')]);
 
     await tx.removeIndex(Buffer.from('foo'));
-    expect(await tx.getIndex(Buffer.from('foo'))).to.deep.eq([]);
+    expect(await tx.getIndex(Buffer.from('foo'))).toEqual([]);
   });
 
   it('correctly iterates over pending data', async () => {
-    channel.sendMessage.withArgs(LMDBMessageType.START_CURSOR).resolves({ cursor: null, entries: [] });
-    channel.sendMessage.withArgs(LMDBMessageType.ADVANCE_CURSOR).rejects(new Error('Cursor empty'));
+    channel.sendMessage.mockImplementation((type: LMDBMessageType) => {
+      if (type === LMDBMessageType.START_CURSOR) {
+        return Promise.resolve({ cursor: null, entries: [] });
+      }
+      if (type === LMDBMessageType.ADVANCE_CURSOR) {
+        return Promise.reject(new Error('Cursor empty'));
+      }
+      return Promise.resolve({ ok: true });
+    });
 
     await tx.set(Buffer.from('foo'), Buffer.from('1'));
     await tx.set(Buffer.from('bar'), Buffer.from('2'));
     await tx.set(Buffer.from('baz'), Buffer.from('3'));
 
     const entries = await toArray(tx.iterate(Buffer.from('bar')));
-    expect(entries).to.deep.eq([
+    expect(entries).toEqual([
       [Buffer.from('bar'), Buffer.from('2')],
       [Buffer.from('baz'), Buffer.from('3')],
       [Buffer.from('foo'), Buffer.from('1')],
@@ -139,33 +139,47 @@ describe('WriteTransaction', () => {
   });
 
   it('correctly iterates over uncommitted and committed data', async () => {
-    channel.sendMessage.withArgs(LMDBMessageType.START_CURSOR).resolves({
-      cursor: 42,
-      entries: [[Buffer.from('bar'), [Buffer.from('3')]]],
+    channel.sendMessage.mockImplementation((type: LMDBMessageType) => {
+      if (type === LMDBMessageType.START_CURSOR) {
+        return Promise.resolve({
+          cursor: 42,
+          entries: [[Buffer.from('bar'), [Buffer.from('3')]]],
+        });
+      }
+      if (type === LMDBMessageType.ADVANCE_CURSOR) {
+        return Promise.resolve({ entries: [[Buffer.from('baz'), [Buffer.from('3')]]], done: true });
+      }
+      return Promise.resolve({ ok: true });
     });
-    channel.sendMessage
-      .withArgs(LMDBMessageType.ADVANCE_CURSOR, { cursor: 42, count: CURSOR_PAGE_SIZE })
-      .resolves({ entries: [[Buffer.from('baz'), [Buffer.from('3')]]], done: true });
 
     await tx.set(Buffer.from('foo'), Buffer.from('1'));
     await tx.set(Buffer.from('bar'), Buffer.from('2'));
 
     const entries = await toArray(tx.iterate(Buffer.from('bar')));
-    expect(entries).to.deep.eq([
+    expect(entries).toEqual([
       [Buffer.from('bar'), Buffer.from('2')],
       [Buffer.from('baz'), Buffer.from('3')],
       [Buffer.from('foo'), Buffer.from('1')],
     ]);
+    expect(channel.sendMessage).toHaveBeenCalledWith(LMDBMessageType.ADVANCE_CURSOR, {
+      cursor: 42,
+      count: CURSOR_PAGE_SIZE,
+    });
   });
 
   it('correctly iterates over overritten data', async () => {
-    channel.sendMessage.withArgs(LMDBMessageType.START_CURSOR).resolves({
-      cursor: 42,
-      entries: [[Buffer.from('baz'), [Buffer.from('3')]]],
+    channel.sendMessage.mockImplementation((type: LMDBMessageType) => {
+      if (type === LMDBMessageType.START_CURSOR) {
+        return Promise.resolve({
+          cursor: 42,
+          entries: [[Buffer.from('baz'), [Buffer.from('3')]]],
+        });
+      }
+      if (type === LMDBMessageType.ADVANCE_CURSOR) {
+        return Promise.resolve({ entries: [[Buffer.from('foo'), [Buffer.from('1')]]], done: true });
+      }
+      return Promise.resolve({ ok: true });
     });
-    channel.sendMessage
-      .withArgs(LMDBMessageType.ADVANCE_CURSOR, { cursor: 42, count: CURSOR_PAGE_SIZE })
-      .resolves({ entries: [[Buffer.from('foo'), [Buffer.from('1')]]], done: true });
 
     await tx.remove(Buffer.from('foo'));
     await tx.set(Buffer.from('bar'), Buffer.from('2'));
@@ -173,21 +187,30 @@ describe('WriteTransaction', () => {
     await tx.set(Buffer.from('quux'), Buffer.from('123'));
 
     const entries = await toArray(tx.iterate(Buffer.from('bar')));
-    expect(entries).to.deep.eq([
+    expect(entries).toEqual([
       [Buffer.from('bar'), Buffer.from('2')],
       [Buffer.from('baz'), Buffer.from('42')],
       [Buffer.from('quux'), Buffer.from('123')],
     ]);
+    expect(channel.sendMessage).toHaveBeenCalledWith(LMDBMessageType.ADVANCE_CURSOR, {
+      cursor: 42,
+      count: CURSOR_PAGE_SIZE,
+    });
   });
 
   it('correctly iterates until end key', async () => {
-    channel.sendMessage.withArgs(LMDBMessageType.START_CURSOR).resolves({
-      cursor: 42,
-      entries: [[Buffer.from('bar'), [Buffer.from('1')]]],
+    channel.sendMessage.mockImplementation((type: LMDBMessageType) => {
+      if (type === LMDBMessageType.START_CURSOR) {
+        return Promise.resolve({
+          cursor: 42,
+          entries: [[Buffer.from('bar'), [Buffer.from('1')]]],
+        });
+      }
+      if (type === LMDBMessageType.ADVANCE_CURSOR) {
+        return Promise.resolve({ entries: [[Buffer.from('baz'), [Buffer.from('3')]]], done: true });
+      }
+      return Promise.resolve({ ok: true });
     });
-    channel.sendMessage
-      .withArgs(LMDBMessageType.ADVANCE_CURSOR)
-      .resolves({ entries: [[Buffer.from('baz'), [Buffer.from('3')]]], done: true });
 
     await tx.remove(Buffer.from('foo'));
     await tx.set(Buffer.from('bar'), Buffer.from('2'));
@@ -195,16 +218,21 @@ describe('WriteTransaction', () => {
     await tx.set(Buffer.from('quux'), Buffer.from('123'));
 
     const entries = await toArray(tx.iterate(Buffer.from('bar'), Buffer.from('foo')));
-    expect(entries).to.deep.eq([
+    expect(entries).toEqual([
       [Buffer.from('bar'), Buffer.from('2')],
       [Buffer.from('baz'), Buffer.from('42')],
     ]);
   });
 
   it('correctly iterates in reverse', async () => {
-    channel.sendMessage.withArgs(LMDBMessageType.START_CURSOR).resolves({
-      cursor: null,
-      entries: [[Buffer.from('baz'), [Buffer.from('3')]]],
+    channel.sendMessage.mockImplementation((type: LMDBMessageType) => {
+      if (type === LMDBMessageType.START_CURSOR) {
+        return Promise.resolve({
+          cursor: null,
+          entries: [[Buffer.from('baz'), [Buffer.from('3')]]],
+        });
+      }
+      return Promise.resolve({ ok: true });
     });
 
     await tx.remove(Buffer.from('foo'));
@@ -213,7 +241,7 @@ describe('WriteTransaction', () => {
     await tx.set(Buffer.from('quux'), Buffer.from('123'));
 
     const entries = await toArray(tx.iterate(Buffer.from('quux'), undefined, true));
-    expect(entries).to.deep.eq([
+    expect(entries).toEqual([
       [Buffer.from('quux'), Buffer.from('123')],
       [Buffer.from('baz'), Buffer.from('42')],
       [Buffer.from('bar'), Buffer.from('2')],
@@ -221,13 +249,18 @@ describe('WriteTransaction', () => {
   });
 
   it('correctly iterates in reverse with end key', async () => {
-    channel.sendMessage.withArgs(LMDBMessageType.START_CURSOR).resolves({
-      cursor: 42,
-      entries: [[Buffer.from('baz'), [Buffer.from('3')]]],
+    channel.sendMessage.mockImplementation((type: LMDBMessageType) => {
+      if (type === LMDBMessageType.START_CURSOR) {
+        return Promise.resolve({
+          cursor: 42,
+          entries: [[Buffer.from('baz'), [Buffer.from('3')]]],
+        });
+      }
+      if (type === LMDBMessageType.ADVANCE_CURSOR) {
+        return Promise.resolve({ entries: [[Buffer.from('bar'), [Buffer.from('3')]]], done: true });
+      }
+      return Promise.resolve({ ok: true });
     });
-    channel.sendMessage
-      .withArgs(LMDBMessageType.ADVANCE_CURSOR)
-      .resolves({ entries: [[Buffer.from('bar'), [Buffer.from('3')]]], done: true });
 
     await tx.remove(Buffer.from('foo'));
     await tx.set(Buffer.from('bar'), Buffer.from('2'));
@@ -235,17 +268,24 @@ describe('WriteTransaction', () => {
     await tx.set(Buffer.from('quux'), Buffer.from('123'));
 
     const entries = await toArray(tx.iterate(Buffer.from('quux'), Buffer.from('baz'), true));
-    expect(entries).to.deep.eq([[Buffer.from('quux'), Buffer.from('123')]]);
+    expect(entries).toEqual([[Buffer.from('quux'), Buffer.from('123')]]);
   });
 
   it('correctly iterates over pending index data', async () => {
-    channel.sendMessage.withArgs(LMDBMessageType.START_CURSOR).resolves({
-      cursor: 42,
-      entries: [[Buffer.from('baz'), [Buffer.from('3'), Buffer.from('6')]]],
-    });
-    channel.sendMessage.withArgs(LMDBMessageType.ADVANCE_CURSOR).resolves({
-      entries: [[Buffer.from('foo'), [Buffer.from('2'), Buffer.from('4'), Buffer.from('8')]]],
-      done: true,
+    channel.sendMessage.mockImplementation((type: LMDBMessageType) => {
+      if (type === LMDBMessageType.START_CURSOR) {
+        return Promise.resolve({
+          cursor: 42,
+          entries: [[Buffer.from('baz'), [Buffer.from('3'), Buffer.from('6')]]],
+        });
+      }
+      if (type === LMDBMessageType.ADVANCE_CURSOR) {
+        return Promise.resolve({
+          entries: [[Buffer.from('foo'), [Buffer.from('2'), Buffer.from('4'), Buffer.from('8')]]],
+          done: true,
+        });
+      }
+      return Promise.resolve({ ok: true });
     });
 
     await tx.setIndex(Buffer.from('foo'), Buffer.from('1'));
@@ -254,7 +294,7 @@ describe('WriteTransaction', () => {
     await tx.setIndex(Buffer.from('baz'), Buffer.from('42'));
 
     const entries = await toArray(tx.iterateIndex(Buffer.from('bar')));
-    expect(entries).to.deep.eq([
+    expect(entries).toEqual([
       [Buffer.from('bar'), [Buffer.from('2'), Buffer.from('3')]],
       [Buffer.from('baz'), [Buffer.from('3'), Buffer.from('42'), Buffer.from('6')]],
       [Buffer.from('foo'), [Buffer.from('1'), Buffer.from('2'), Buffer.from('4')]],
@@ -262,8 +302,15 @@ describe('WriteTransaction', () => {
   });
 
   it('correctly iterates over pending index data up to end key', async () => {
-    channel.sendMessage.withArgs(LMDBMessageType.START_CURSOR).resolves({ cursor: null, entries: [], done: true });
-    channel.sendMessage.withArgs(LMDBMessageType.ADVANCE_CURSOR).rejects(new Error('Should not bew called'));
+    channel.sendMessage.mockImplementation((type: LMDBMessageType) => {
+      if (type === LMDBMessageType.START_CURSOR) {
+        return Promise.resolve({ cursor: null, entries: [], done: true });
+      }
+      if (type === LMDBMessageType.ADVANCE_CURSOR) {
+        return Promise.reject(new Error('Should not bew called'));
+      }
+      return Promise.resolve({ ok: true });
+    });
 
     await tx.setIndex(Buffer.from('foo'), Buffer.from('1'));
     await tx.removeIndex(Buffer.from('foo'), Buffer.from('8'));
@@ -271,17 +318,24 @@ describe('WriteTransaction', () => {
     await tx.setIndex(Buffer.from('baz'), Buffer.from('42'));
 
     const entries = await toArray(tx.iterateIndex(Buffer.from('bar'), Buffer.from('baz')));
-    expect(entries).to.deep.eq([[Buffer.from('bar'), [Buffer.from('2'), Buffer.from('3')]]]);
+    expect(entries).toEqual([[Buffer.from('bar'), [Buffer.from('2'), Buffer.from('3')]]]);
   });
 
   it('correctly iterates over pending index data in reverse', async () => {
-    channel.sendMessage.withArgs(LMDBMessageType.START_CURSOR).resolves({
-      cursor: 42,
-      entries: [[Buffer.from('foo'), [Buffer.from('2'), Buffer.from('4'), Buffer.from('8')]]],
-    });
-    channel.sendMessage.withArgs(LMDBMessageType.ADVANCE_CURSOR).resolves({
-      entries: [[Buffer.from('baz'), [Buffer.from('3'), Buffer.from('6')]]],
-      done: true,
+    channel.sendMessage.mockImplementation((type: LMDBMessageType) => {
+      if (type === LMDBMessageType.START_CURSOR) {
+        return Promise.resolve({
+          cursor: 42,
+          entries: [[Buffer.from('foo'), [Buffer.from('2'), Buffer.from('4'), Buffer.from('8')]]],
+        });
+      }
+      if (type === LMDBMessageType.ADVANCE_CURSOR) {
+        return Promise.resolve({
+          entries: [[Buffer.from('baz'), [Buffer.from('3'), Buffer.from('6')]]],
+          done: true,
+        });
+      }
+      return Promise.resolve({ ok: true });
     });
 
     await tx.setIndex(Buffer.from('foo'), Buffer.from('1'));
@@ -291,7 +345,7 @@ describe('WriteTransaction', () => {
     await tx.setIndex(Buffer.from('quux'), Buffer.from('1123'));
 
     const entries = await toArray(tx.iterateIndex(Buffer.from('foo'), undefined, true));
-    expect(entries).to.deep.eq([
+    expect(entries).toEqual([
       [Buffer.from('foo'), [Buffer.from('1'), Buffer.from('2'), Buffer.from('4')]],
       [Buffer.from('baz'), [Buffer.from('3'), Buffer.from('42'), Buffer.from('6')]],
       [Buffer.from('bar'), [Buffer.from('2'), Buffer.from('3')]],
@@ -299,13 +353,20 @@ describe('WriteTransaction', () => {
   });
 
   it('correctly iterates over pending index data in reverse up to given end key', async () => {
-    channel.sendMessage.withArgs(LMDBMessageType.START_CURSOR).resolves({
-      cursor: 42,
-      entries: [[Buffer.from('foo'), [Buffer.from('2'), Buffer.from('4'), Buffer.from('8')]]],
-    });
-    channel.sendMessage.withArgs(LMDBMessageType.ADVANCE_CURSOR).resolves({
-      entries: [[Buffer.from('baz'), [Buffer.from('3'), Buffer.from('6')]]],
-      done: true,
+    channel.sendMessage.mockImplementation((type: LMDBMessageType) => {
+      if (type === LMDBMessageType.START_CURSOR) {
+        return Promise.resolve({
+          cursor: 42,
+          entries: [[Buffer.from('foo'), [Buffer.from('2'), Buffer.from('4'), Buffer.from('8')]]],
+        });
+      }
+      if (type === LMDBMessageType.ADVANCE_CURSOR) {
+        return Promise.resolve({
+          entries: [[Buffer.from('baz'), [Buffer.from('3'), Buffer.from('6')]]],
+          done: true,
+        });
+      }
+      return Promise.resolve({ ok: true });
     });
 
     await tx.setIndex(Buffer.from('foo'), Buffer.from('1'));
@@ -315,7 +376,7 @@ describe('WriteTransaction', () => {
     await tx.setIndex(Buffer.from('quux'), Buffer.from('1123'));
 
     const entries = await toArray(tx.iterateIndex(Buffer.from('foo'), Buffer.from('bar'), true));
-    expect(entries).to.deep.eq([
+    expect(entries).toEqual([
       [Buffer.from('foo'), [Buffer.from('1'), Buffer.from('2'), Buffer.from('4')]],
       [Buffer.from('baz'), [Buffer.from('3'), Buffer.from('42'), Buffer.from('6')]],
     ]);
@@ -324,11 +385,11 @@ describe('WriteTransaction', () => {
   it('refuses to commit if closed', async () => {
     await tx.set(Buffer.from('foo'), Buffer.from('1'));
     tx.close();
-    await expect(tx.commit()).eventually.to.be.rejectedWith(Error, 'Transaction is closed');
+    await expect(tx.commit()).rejects.toThrow('Transaction is closed');
   });
 
   it('maintains sorted order in removeEntries for consistent reads', async () => {
-    channel.sendMessage.resolves({ values: [null] });
+    channel.sendMessage.mockResolvedValue({ values: [null] });
 
     // Set up multiple keys
     await tx.set(Buffer.from('aaa'), Buffer.from('1'));
@@ -342,17 +403,17 @@ describe('WriteTransaction', () => {
     await tx.remove(Buffer.from('ccc')); // This should be inserted in middle
 
     // Verify removeEntries is properly sorted
-    expect(tx.dataBatch.removeEntries).to.have.lengthOf(3);
-    expect(tx.dataBatch.removeEntries[0][0]).to.deep.equal(Buffer.from('aaa'));
-    expect(tx.dataBatch.removeEntries[1][0]).to.deep.equal(Buffer.from('ccc'));
-    expect(tx.dataBatch.removeEntries[2][0]).to.deep.equal(Buffer.from('ddd'));
+    expect(tx.dataBatch.removeEntries).toHaveLength(3);
+    expect(tx.dataBatch.removeEntries[0][0]).toEqual(Buffer.from('aaa'));
+    expect(tx.dataBatch.removeEntries[1][0]).toEqual(Buffer.from('ccc'));
+    expect(tx.dataBatch.removeEntries[2][0]).toEqual(Buffer.from('ddd'));
 
     // All reads should return undefined due to removal
-    expect(await tx.get(Buffer.from('aaa'))).to.be.undefined;
-    expect(await tx.get(Buffer.from('ccc'))).to.be.undefined;
-    expect(await tx.get(Buffer.from('ddd'))).to.be.undefined;
+    expect(await tx.get(Buffer.from('aaa'))).toBeUndefined();
+    expect(await tx.get(Buffer.from('ccc'))).toBeUndefined();
+    expect(await tx.get(Buffer.from('ddd'))).toBeUndefined();
 
     // Existing key should still be readable
-    expect(await tx.get(Buffer.from('bbb'))).to.deep.equal(Buffer.from('2'));
+    expect(await tx.get(Buffer.from('bbb'))).toEqual(Buffer.from('2'));
   });
 });

--- a/yarn-project/kv-store/src/lmdb-v2/write_transaction.test.ts
+++ b/yarn-project/kv-store/src/lmdb-v2/write_transaction.test.ts
@@ -1,10 +1,12 @@
 import { toArray } from '@aztec/foundation/iterable';
 
+import { vi } from 'vitest';
+
 import { type Batch, CURSOR_PAGE_SIZE, Database, type LMDBMessageChannel, LMDBMessageType } from './message.js';
 import { WriteTransaction } from './write_transaction.js';
 
 describe('WriteTransaction', () => {
-  let channel: { sendMessage: ReturnType<typeof vi.fn> } & LMDBMessageChannel;
+  let channel: { sendMessage: ReturnType<typeof vi.fn<(...args: any[]) => any>> } & LMDBMessageChannel;
   let tx: WriteTransaction;
 
   beforeEach(() => {

--- a/yarn-project/kv-store/src/lmdb/counter.test.ts
+++ b/yarn-project/kv-store/src/lmdb/counter.test.ts
@@ -87,7 +87,7 @@ describe('LmdbAztecCounter', () => {
     });
   });
 
-  it.each([
+  it.each<[Array<[string | number | [number, string], number]>, Array<[string | number | [number, string], number]>]>([
     [
       [
         ['c', 2342],
@@ -128,7 +128,7 @@ describe('LmdbAztecCounter', () => {
         [[11, 'b'], 1],
       ],
     ],
-  ])('iterates in key order', async (insertOrder: [string, number][], expectedOrder) => {
+  ])('iterates in key order', async (insertOrder, expectedOrder) => {
     const counter = new LmdbAztecCounter(db, 'test');
     await Promise.all(insertOrder.map(([key, value]) => counter.update(key, value as number)));
     expect(await toArray(counter.entries())).toEqual(expectedOrder);

--- a/yarn-project/kv-store/src/lmdb/counter.test.ts
+++ b/yarn-project/kv-store/src/lmdb/counter.test.ts
@@ -1,17 +1,12 @@
 import { randomBytes } from '@aztec/foundation/crypto/random';
 import { toArray } from '@aztec/foundation/iterable';
 
-import { expect, use } from 'chai';
-import chaiAsPromised from 'chai-as-promised';
 import fs from 'fs/promises';
 import { type Database, open } from 'lmdb';
-import forEach from 'mocha-each';
 import { tmpdir } from 'os';
 import path from 'path';
 
 import { LmdbAztecCounter } from './counter.js';
-
-use(chaiAsPromised);
 
 describe('LmdbAztecCounter', () => {
   let db: Database;
@@ -29,26 +24,26 @@ describe('LmdbAztecCounter', () => {
     await fs.rm(dir, { recursive: true, force: true, maxRetries: 3 });
   });
 
-  forEach([
+  describe.each([
     ['floating point number', () => Math.random()],
     ['integers', () => (Math.random() * 1000) | 0],
     ['strings', () => randomBytes(8).toString('hex')],
     ['strings', () => [Math.random(), randomBytes(8).toString('hex')]],
-  ]).describe('counts occurrences of %s values', (_, genKey) => {
+  ])('counts occurrences of %s values', (_, genKey) => {
     let counter: LmdbAztecCounter<ReturnType<typeof genKey>>;
     beforeEach(() => {
       counter = new LmdbAztecCounter(db, 'test');
     });
 
     it('returns 0 for unknown keys', () => {
-      expect(counter.get(genKey())).to.equal(0);
+      expect(counter.get(genKey())).toBe(0);
     });
 
     it('increments values', async () => {
       const key = genKey();
       await counter.update(key, 1);
 
-      expect(counter.get(key)).to.equal(1);
+      expect(counter.get(key)).toBe(1);
     });
 
     it('decrements values', async () => {
@@ -56,14 +51,14 @@ describe('LmdbAztecCounter', () => {
       await counter.update(key, 1);
       await counter.update(key, -1);
 
-      expect(counter.get(key)).to.equal(0);
+      expect(counter.get(key)).toBe(0);
     });
 
     it('throws when decrementing below zero', async () => {
       const key = genKey();
       await counter.update(key, 1);
 
-      await expect(counter.update(key, -2)).to.be.rejected;
+      await expect(counter.update(key, -2)).rejects.toThrow();
     });
 
     it('increments values by a delta', async () => {
@@ -71,7 +66,7 @@ describe('LmdbAztecCounter', () => {
       await counter.update(key, 1);
       await counter.update(key, 2);
 
-      expect(counter.get(key)).to.equal(3);
+      expect(counter.get(key)).toBe(3);
     });
 
     it('resets the counter', async () => {
@@ -80,7 +75,7 @@ describe('LmdbAztecCounter', () => {
       await counter.update(key, 2);
       await counter.set(key, 0);
 
-      expect(counter.get(key)).to.equal(0);
+      expect(counter.get(key)).toBe(0);
     });
 
     it('iterates over entries', async () => {
@@ -88,11 +83,11 @@ describe('LmdbAztecCounter', () => {
       await counter.update(key, 1);
       await counter.update(key, 2);
 
-      expect(await toArray(counter.entries())).to.deep.equal([[key, 3]]);
+      expect(await toArray(counter.entries())).toEqual([[key, 3]]);
     });
   });
 
-  forEach([
+  it.each([
     [
       [
         ['c', 2342],
@@ -133,9 +128,9 @@ describe('LmdbAztecCounter', () => {
         [[11, 'b'], 1],
       ],
     ],
-  ]).it('iterates in key order', async (insertOrder: [string, number][], expectedOrder) => {
+  ])('iterates in key order', async (insertOrder: [string, number][], expectedOrder) => {
     const counter = new LmdbAztecCounter(db, 'test');
     await Promise.all(insertOrder.map(([key, value]) => counter.update(key, value as number)));
-    expect(await toArray(counter.entries())).to.deep.equal(expectedOrder);
+    expect(await toArray(counter.entries())).toEqual(expectedOrder);
   });
 });

--- a/yarn-project/kv-store/src/lmdb/store.test.ts
+++ b/yarn-project/kv-store/src/lmdb/store.test.ts
@@ -1,7 +1,5 @@
 import { toArray } from '@aztec/foundation/iterable';
 
-import { expect } from 'chai';
-
 import { openTmpStore } from './index.js';
 import type { AztecLmdbStore } from './store.js';
 
@@ -26,13 +24,13 @@ describe('AztecLmdbStore', () => {
       await map.set('key1', 'value1');
       await map.set('key2', 'value2');
 
-      expect(map.get('key1')).to.equal('value1');
-      expect(map.get('key2')).to.equal('value2');
+      expect(map.get('key1')).toBe('value1');
+      expect(map.get('key2')).toBe('value2');
 
       await store.clear();
 
-      expect(map.get('key1')).to.be.undefined;
-      expect(map.get('key2')).to.be.undefined;
+      expect(map.get('key1')).toBeUndefined();
+      expect(map.get('key2')).toBeUndefined();
     });
 
     it('removes all data from multimaps', async () => {
@@ -41,23 +39,23 @@ describe('AztecLmdbStore', () => {
       await multiMap.set('key1', 'value2');
 
       const valuesBefore = await toArray(multiMap.getValues('key1'));
-      expect(valuesBefore.length).to.be.greaterThan(0);
+      expect(valuesBefore.length).toBeGreaterThan(0);
 
       await store.clear();
 
       const valuesAfter = await toArray(multiMap.getValues('key1'));
-      expect(valuesAfter).to.deep.equal([]);
+      expect(valuesAfter).toEqual([]);
     });
 
     it('removes all data from singletons', async () => {
       const singleton = store.openSingleton<string>('test-singleton');
       await singleton.set('hello');
 
-      expect(singleton.get()).to.equal('hello');
+      expect(singleton.get()).toBe('hello');
 
       await store.clear();
 
-      expect(singleton.get()).to.be.undefined;
+      expect(singleton.get()).toBeUndefined();
     });
 
     it('removes all data from all sub-databases at once', async () => {
@@ -75,11 +73,11 @@ describe('AztecLmdbStore', () => {
 
       await store.clear();
 
-      expect(map.get('mk')).to.be.undefined;
-      expect(await toArray(multiMap.getValues('mmk'))).to.deep.equal([]);
-      expect(singleton.get()).to.be.undefined;
-      expect(counter.get('ck')).to.equal(0);
-      expect(set.has('sk')).to.equal(false);
+      expect(map.get('mk')).toBeUndefined();
+      expect(await toArray(multiMap.getValues('mmk'))).toEqual([]);
+      expect(singleton.get()).toBeUndefined();
+      expect(counter.get('ck')).toBe(0);
+      expect(set.has('sk')).toBe(false);
     });
 
     it('allows writing new data after clear', async () => {
@@ -89,8 +87,8 @@ describe('AztecLmdbStore', () => {
       await store.clear();
 
       await map.set('key2', 'value2');
-      expect(map.get('key1')).to.be.undefined;
-      expect(map.get('key2')).to.equal('value2');
+      expect(map.get('key1')).toBeUndefined();
+      expect(map.get('key2')).toBe('value2');
     });
   });
 

--- a/yarn-project/kv-store/vitest.config.ts
+++ b/yarn-project/kv-store/vitest.config.ts
@@ -16,15 +16,6 @@ export default defineConfig({
   define: {
     'process.env': {},
   },
-  resolve: {
-    alias: {
-      // Browser stubs for modules that pull in Barretenberg WASM.
-      '@aztec/foundation/eth-address': path.resolve(__dirname, 'browser-stubs/eth-address.js'),
-      '@aztec/foundation/log': path.resolve(__dirname, 'browser-stubs/foundation-log.js'),
-      buffer: path.resolve(__dirname, 'browser-stubs/buffer.js'),
-      util: path.resolve(__dirname, 'browser-stubs/util.js'),
-    },
-  },
   optimizeDeps: {
     include: [
       'chai',
@@ -49,43 +40,73 @@ export default defineConfig({
   },
   test: {
     globals: true,
-    reporters: ['verbose'],
-    include: [
-      './src/indexeddb/**/*.test.ts',
-      './src/sqlite-opfs/**/*.test.ts',
-      // Benchmarks self-skip unless VITE_BENCH=1; include so they're discoverable.
-      './src/bench/indexeddb/**/*.test.ts',
-      './src/bench/sqlite-opfs/**/*.test.ts',
-      './src/bench/sqlite-opfs-encrypted/**/*.test.ts',
-    ],
     // Bench suites do full-population + N-iteration work; default 30s is too tight.
     testTimeout: process.env.VITE_BENCH === '1' ? 300_000 : 30_000,
     // Run test files sequentially to avoid race conditions in browser module loading
     fileParallelism: false,
-    browser: {
-      enabled: true,
-      provider: playwright(),
-      headless: true,
-      instances: [
-        {
-          browser: 'chromium',
-          launch: {
-            args: [
-              '--no-sandbox',
-              '--disable-setuid-sandbox',
-              '--disable-dev-shm-usage',
-              '--disable-gpu',
-              '--disable-software-rasterizer',
-            ],
-            timeout: 30_000,
-          },
-          context: {
-            actionTimeout: 10_000,
+    teardownTimeout: 10_000,
+    globalSetup: './vitest.global-setup.ts',
+    projects: [
+      {
+        extends: true,
+        test: {
+          name: 'node',
+          environment: 'node',
+          include: [
+            './src/lmdb/**/*.test.ts',
+            './src/lmdb-v2/**/*.test.ts',
+            './src/stores/**/*.test.ts',
+            './src/interfaces/**/*.test.ts',
+          ],
+        },
+      },
+      {
+        extends: true,
+        resolve: {
+          alias: {
+            // Browser stubs for modules that pull in Barretenberg WASM.
+            '@aztec/foundation/eth-address': path.resolve(__dirname, 'browser-stubs/eth-address.js'),
+            '@aztec/foundation/log': path.resolve(__dirname, 'browser-stubs/foundation-log.js'),
+            buffer: path.resolve(__dirname, 'browser-stubs/buffer.js'),
+            util: path.resolve(__dirname, 'browser-stubs/util.js'),
           },
         },
-      ],
-    },
-    teardownTimeout: 10000,
-    globalSetup: './vitest.global-setup.ts',
+        test: {
+          name: 'browser',
+          include: [
+            './src/indexeddb/**/*.test.ts',
+            './src/sqlite-opfs/**/*.test.ts',
+            // Benchmarks self-skip unless VITE_BENCH=1; include so they're discoverable.
+            './src/bench/indexeddb/**/*.test.ts',
+            './src/bench/sqlite-opfs/**/*.test.ts',
+            './src/bench/sqlite-opfs-encrypted/**/*.test.ts',
+          ],
+          reporters: ['verbose'],
+          browser: {
+            enabled: true,
+            provider: playwright(),
+            headless: true,
+            instances: [
+              {
+                browser: 'chromium',
+                launch: {
+                  args: [
+                    '--no-sandbox',
+                    '--disable-setuid-sandbox',
+                    '--disable-dev-shm-usage',
+                    '--disable-gpu',
+                    '--disable-software-rasterizer',
+                  ],
+                  timeout: 30_000,
+                },
+                context: {
+                  actionTimeout: 10_000,
+                },
+              },
+            ],
+          },
+        },
+      },
+    ],
   },
 });

--- a/yarn-project/stdlib/package.json
+++ b/yarn-project/stdlib/package.json
@@ -129,7 +129,8 @@
     "jest-mock-extended": "^4.0.0",
     "prettier": "^3.5.3",
     "ts-node": "^10.9.1",
-    "typescript": "^5.3.3"
+    "typescript": "^5.3.3",
+    "vitest": "^4.0.0"
   },
   "files": [
     "dest",

--- a/yarn-project/stdlib/src/block/test/l2_tips_store_test_suite.ts
+++ b/yarn-project/stdlib/src/block/test/l2_tips_store_test_suite.ts
@@ -10,7 +10,7 @@ import {
 } from '@aztec/stdlib/block';
 import { Checkpoint, L1PublishedData, PublishedCheckpoint } from '@aztec/stdlib/checkpoint';
 
-import { jestExpect as expect } from '@jest/expect';
+import { expect } from 'vitest';
 
 import { GENESIS_BLOCK_HEADER_HASH } from '../block_hash.js';
 import type { L2TipsStore } from '../l2_block_stream/index.js';

--- a/yarn-project/yarn.lock
+++ b/yarn-project/yarn.lock
@@ -1482,28 +1482,18 @@ __metadata:
     "@aztec/sqlite3mc-wasm": "workspace:^"
     "@aztec/stdlib": "workspace:^"
     "@jest/globals": "npm:^30.0.0"
-    "@types/chai": "npm:^5.0.1"
-    "@types/chai-as-promised": "npm:^8.0.1"
     "@types/jest": "npm:^30.0.0"
-    "@types/mocha": "npm:^10.0.10"
-    "@types/mocha-each": "npm:^2.0.4"
     "@types/node": "npm:^22.15.17"
-    "@types/sinon": "npm:^17.0.3"
     "@typescript/native-preview": "npm:7.0.0-dev.20260113.1"
     "@vitest/browser-playwright": "npm:^4.0.0"
     buffer: "npm:^6.0.3"
-    chai: "npm:^5.1.2"
-    chai-as-promised: "npm:^8.0.1"
     idb: "npm:^8.0.0"
     jest: "npm:^30.0.0"
     lmdb: "npm:^3.2.0"
-    mocha: "npm:^10.8.2"
-    mocha-each: "npm:^2.0.1"
     msgpackr: "npm:^1.11.2"
     ohash: "npm:^2.0.11"
     ordered-binary: "npm:^1.5.3"
     playwright: "npm:1.49.0"
-    sinon: "npm:^19.0.2"
     ts-node: "npm:^10.9.1"
     typescript: "npm:^5.3.3"
     util: "npm:^0.12.5"
@@ -2113,6 +2103,7 @@ __metadata:
     tslib: "npm:^2.4.0"
     typescript: "npm:^5.3.3"
     viem: "npm:@aztec/viem@2.38.2"
+    vitest: "npm:^4.0.0"
     zod: "npm:^3.23.8"
   languageName: unknown
   linkType: soft
@@ -6325,30 +6316,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sinonjs/fake-timers@npm:^13.0.0, @sinonjs/fake-timers@npm:^13.0.1, @sinonjs/fake-timers@npm:^13.0.2":
+"@sinonjs/fake-timers@npm:^13.0.0":
   version: 13.0.5
   resolution: "@sinonjs/fake-timers@npm:13.0.5"
   dependencies:
     "@sinonjs/commons": "npm:^3.0.1"
   checksum: 10/11ee417968fc4dce1896ab332ac13f353866075a9d2a88ed1f6258f17cc4f7d93e66031b51fcddb8c203aa4d53fd980b0ae18aba06269f4682164878a992ec3f
-  languageName: node
-  linkType: hard
-
-"@sinonjs/samsam@npm:^8.0.1":
-  version: 8.0.2
-  resolution: "@sinonjs/samsam@npm:8.0.2"
-  dependencies:
-    "@sinonjs/commons": "npm:^3.0.1"
-    lodash.get: "npm:^4.4.2"
-    type-detect: "npm:^4.1.0"
-  checksum: 10/58ca9752e8e835a09ed275f8edf8da2720fe95c0c02f6bcb90ad7f86fdceb393f35f744194b705dd94216228646ec0aedbb814e245eb869b940dcf1266b7a533
-  languageName: node
-  linkType: hard
-
-"@sinonjs/text-encoding@npm:^0.7.3":
-  version: 0.7.3
-  resolution: "@sinonjs/text-encoding@npm:0.7.3"
-  checksum: 10/f0cc89bae36e7ce159187dece7800b78831288f1913e9ae8cf8a878da5388232d2049740f6f4a43ec4b43b8ad1beb55f919f45eb9a577adb4a2a6eacb27b25fc
   languageName: node
   linkType: hard
 
@@ -7371,24 +7344,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/chai-as-promised@npm:^8.0.1":
-  version: 8.0.1
-  resolution: "@types/chai-as-promised@npm:8.0.1"
-  dependencies:
-    "@types/chai": "npm:*"
-  checksum: 10/827f7d8d5af15761e4b4c0ef08134e12835b28b6da91dd75e4d3e76c856cee9f3dd8bef45d4c1219237951e3e588c3f70d7271b38e626415126c63b057bf2fba
-  languageName: node
-  linkType: hard
-
-"@types/chai@npm:*, @types/chai@npm:^5.0.1":
-  version: 5.0.1
-  resolution: "@types/chai@npm:5.0.1"
-  dependencies:
-    "@types/deep-eql": "npm:*"
-  checksum: 10/0f829d4f4be06d6a32c9d89ac08c356df89bafc4b923d8b7fd56cf78d681f5fddfe7aa3391b747f076c57129428f4df694026f344ad3bf8bda65e2ca50c0fd37
-  languageName: node
-  linkType: hard
-
 "@types/chai@npm:^5.2.2":
   version: 5.2.3
   resolution: "@types/chai@npm:5.2.3"
@@ -7884,22 +7839,6 @@ __metadata:
   version: 1.2.5
   resolution: "@types/minimist@npm:1.2.5"
   checksum: 10/477047b606005058ab0263c4f58097136268007f320003c348794f74adedc3166ffc47c80ec3e94687787f2ab7f4e72c468223946e79892cf0fd9e25e9970a90
-  languageName: node
-  linkType: hard
-
-"@types/mocha-each@npm:^2.0.4":
-  version: 2.0.4
-  resolution: "@types/mocha-each@npm:2.0.4"
-  dependencies:
-    "@types/mocha": "npm:*"
-  checksum: 10/2588284db079e2d0a17735c8fb5c12cba9feabf2de55c9ab49e1f3b38cc522691d30ed3abb1bcb21c087b27f373e3f4123ef7bd8d9a4f95cef38f6c8045c71f3
-  languageName: node
-  linkType: hard
-
-"@types/mocha@npm:*, @types/mocha@npm:^10.0.10":
-  version: 10.0.10
-  resolution: "@types/mocha@npm:10.0.10"
-  checksum: 10/4e3b61ed5112add86891a5dd3ebdd087714f5e1784a63d47a96424c0825058fd07074e85e43573462f751636c92808fc18a5f3862fe45e649ea98fdc5a3ee2ea
   languageName: node
   linkType: hard
 
@@ -9367,13 +9306,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ansi-colors@npm:^4.1.3":
-  version: 4.1.3
-  resolution: "ansi-colors@npm:4.1.3"
-  checksum: 10/43d6e2fc7b1c6e4dc373de708ee76311ec2e0433e7e8bd3194e7ff123ea6a747428fc61afdcf5969da5be3a5f0fd054602bec56fc0ebe249ce2fcde6e649e3c2
-  languageName: node
-  linkType: hard
-
 "ansi-escapes@npm:^4.3.2":
   version: 4.3.2
   resolution: "ansi-escapes@npm:4.3.2"
@@ -10099,13 +10031,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"browser-stdout@npm:^1.3.1":
-  version: 1.3.1
-  resolution: "browser-stdout@npm:1.3.1"
-  checksum: 10/ac70a84e346bb7afc5045ec6f22f6a681b15a4057447d4cc1c48a25c6dedb302a49a46dd4ddfb5cdd9c96e0c905a8539be1b98ae7bc440512152967009ec7015
-  languageName: node
-  linkType: hard
-
 "browserify-aes@npm:^1.0.4, browserify-aes@npm:^1.2.0":
   version: 1.2.0
   resolution: "browserify-aes@npm:1.2.0"
@@ -10500,7 +10425,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"camelcase@npm:^6.0.0, camelcase@npm:^6.3.0":
+"camelcase@npm:^6.3.0":
   version: 6.3.0
   resolution: "camelcase@npm:6.3.0"
   checksum: 10/8c96818a9076434998511251dcb2761a94817ea17dbdc37f47ac080bd088fc62c7369429a19e2178b993497132c8cbcf5cc1f44ba963e76782ba469c0474938d
@@ -10525,30 +10450,6 @@ __metadata:
   version: 2.1.1
   resolution: "catering@npm:2.1.1"
   checksum: 10/4669c9fa5f3a73273535fb458a964d8aba12dc5102d8487049cf03623bef3cdff4b5d9f92ff04c00f1001057a7cc7df6e700752ac622c2a7baf7bcff34166683
-  languageName: node
-  linkType: hard
-
-"chai-as-promised@npm:^8.0.1":
-  version: 8.0.1
-  resolution: "chai-as-promised@npm:8.0.1"
-  dependencies:
-    check-error: "npm:^2.0.0"
-  peerDependencies:
-    chai: ">= 2.1.2 < 6"
-  checksum: 10/1938d9f00b1ae197b47c01a9ff8455d3719bc4638103fa5ad254a32e27bc663ba8530fecfa840309e254c2a52ef171c194b7fb25615f8c5d33022d64456f07f9
-  languageName: node
-  linkType: hard
-
-"chai@npm:^5.1.2":
-  version: 5.1.2
-  resolution: "chai@npm:5.1.2"
-  dependencies:
-    assertion-error: "npm:^2.0.1"
-    check-error: "npm:^2.1.1"
-    deep-eql: "npm:^5.0.1"
-    loupe: "npm:^3.1.0"
-    pathval: "npm:^2.0.0"
-  checksum: 10/e8c2bbc83cb5a2f87130d93056d4cfbbe04106e12aa798b504816dbe3fa538a9f68541b472e56cbf0f54558b501d7e31867d74b8218abcd5a8cc8ba536fba46c
   languageName: node
   linkType: hard
 
@@ -10637,14 +10538,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"check-error@npm:^2.0.0, check-error@npm:^2.1.1":
-  version: 2.1.1
-  resolution: "check-error@npm:2.1.1"
-  checksum: 10/d785ed17b1d4a4796b6e75c765a9a290098cf52ff9728ce0756e8ffd4293d2e419dd30c67200aee34202463b474306913f2fcfaf1890641026d9fc6966fea27a
-  languageName: node
-  linkType: hard
-
-"chokidar@npm:^3.5.2, chokidar@npm:^3.5.3, chokidar@npm:^3.6.0":
+"chokidar@npm:^3.5.2, chokidar@npm:^3.6.0":
   version: 3.6.0
   resolution: "chokidar@npm:3.6.0"
   dependencies:
@@ -10751,17 +10645,6 @@ __metadata:
     execa: "npm:^5.1.1"
     is-wsl: "npm:^2.2.0"
   checksum: 10/c4c374082ae3f44be6078e378b546a002461d5231461be21b0ca1a6a764eec5936e2fded9542a8ac120bad91e58999666f2dd3022ae3fae09de0dd6334f943e3
-  languageName: node
-  linkType: hard
-
-"cliui@npm:^7.0.2":
-  version: 7.0.4
-  resolution: "cliui@npm:7.0.4"
-  dependencies:
-    string-width: "npm:^4.2.0"
-    strip-ansi: "npm:^6.0.0"
-    wrap-ansi: "npm:^7.0.0"
-  checksum: 10/db858c49af9d59a32d603987e6fddaca2ce716cd4602ba5a2bb3a5af1351eebe82aba8dff3ef3e1b331f7fa9d40ca66e67bdf8e7c327ce0ea959747ead65c0ef
   languageName: node
   linkType: hard
 
@@ -11641,13 +11524,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"decamelize@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "decamelize@npm:4.0.0"
-  checksum: 10/b7d09b82652c39eead4d6678bb578e3bebd848add894b76d0f6b395bc45b2d692fb88d977e7cfb93c4ed6c119b05a1347cef261174916c2e75c0a8ca57da1809
-  languageName: node
-  linkType: hard
-
 "decompress-response@npm:^6.0.0":
   version: 6.0.0
   resolution: "decompress-response@npm:6.0.0"
@@ -11666,13 +11542,6 @@ __metadata:
     babel-plugin-macros:
       optional: true
   checksum: 10/f100cb11001309f2185c4334c6f29e5323c1e73b7b75e3b1893bc71ef53cd13fb80534efc8fa7163a891ede633e310a9c600ba38c363cc9d14a72f238fe47078
-  languageName: node
-  linkType: hard
-
-"deep-eql@npm:^5.0.1":
-  version: 5.0.2
-  resolution: "deep-eql@npm:5.0.2"
-  checksum: 10/a529b81e2ef8821621d20a36959a0328873a3e49d393ad11f8efe8559f31239494c2eb889b80342808674c475802ba95b9d6c4c27641b9a029405104c1b59fcf
   languageName: node
   linkType: hard
 
@@ -11926,20 +11795,6 @@ __metadata:
   version: 4.0.2
   resolution: "diff@npm:4.0.2"
   checksum: 10/ec09ec2101934ca5966355a229d77afcad5911c92e2a77413efda5455636c4cf2ce84057e2d7715227a2eeeda04255b849bd3ae3a4dd22eb22e86e76456df069
-  languageName: node
-  linkType: hard
-
-"diff@npm:^5.2.0":
-  version: 5.2.0
-  resolution: "diff@npm:5.2.0"
-  checksum: 10/01b7b440f83a997350a988e9d2f558366c0f90f15be19f4aa7f1bb3109a4e153dfc3b9fbf78e14ea725717017407eeaa2271e3896374a0181e8f52445740846d
-  languageName: node
-  linkType: hard
-
-"diff@npm:^7.0.0":
-  version: 7.0.0
-  resolution: "diff@npm:7.0.0"
-  checksum: 10/e9b8e48d054c9c0c093c65ce8e2637af94b35f2427001607b14e5e0589e534ea3413a7f91ebe6d7c5a1494ace49cb7c7c3972f442ddd96a4767ff091999a082e
   languageName: node
   linkType: hard
 
@@ -13823,19 +13678,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob@npm:^8.1.0":
-  version: 8.1.0
-  resolution: "glob@npm:8.1.0"
-  dependencies:
-    fs.realpath: "npm:^1.0.0"
-    inflight: "npm:^1.0.4"
-    inherits: "npm:2"
-    minimatch: "npm:^5.0.1"
-    once: "npm:^1.3.0"
-  checksum: 10/9aab1c75eb087c35dbc41d1f742e51d0507aa2b14c910d96fb8287107a10a22f4bbdce26fc0a3da4c69a20f7b26d62f1640b346a4f6e6becfff47f335bb1dc5e
-  languageName: node
-  linkType: hard
-
 "glob@npm:~11.1.0":
   version: 11.1.0
   resolution: "glob@npm:11.1.0"
@@ -14962,13 +14804,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-unicode-supported@npm:^0.1.0":
-  version: 0.1.0
-  resolution: "is-unicode-supported@npm:0.1.0"
-  checksum: 10/a2aab86ee7712f5c2f999180daaba5f361bdad1efadc9610ff5b8ab5495b86e4f627839d085c6530363c6d6d4ecbde340fb8e54bdb83da4ba8e0865ed5513c52
-  languageName: node
-  linkType: hard
-
 "is-wsl@npm:^1.1.0":
   version: 1.1.0
   resolution: "is-wsl@npm:1.1.0"
@@ -16031,13 +15866,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"just-extend@npm:^6.2.0":
-  version: 6.2.0
-  resolution: "just-extend@npm:6.2.0"
-  checksum: 10/1f487b074b9e5773befdd44dc5d1b446f01f24f7d4f1f255d51c0ef7f686e8eb5f95d983b792b9ca5c8b10cd7e60a924d64103725759eddbd7f18bcb22743f92
-  languageName: node
-  linkType: hard
-
 "jwa@npm:^2.0.1":
   version: 2.0.1
   resolution: "jwa@npm:2.0.1"
@@ -16429,13 +16257,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash.get@npm:^4.4.2":
-  version: 4.4.2
-  resolution: "lodash.get@npm:4.4.2"
-  checksum: 10/2a4925f6e89bc2c010a77a802d1ba357e17ed1ea03c2ddf6a146429f2856a216663e694a6aa3549a318cbbba3fd8b7decb392db457e6ac0b83dc745ed0a17380
-  languageName: node
-  linkType: hard
-
 "lodash.groupby@npm:^4.6.0":
   version: 4.6.0
   resolution: "lodash.groupby@npm:4.6.0"
@@ -16499,27 +16320,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"log-symbols@npm:^4.1.0":
-  version: 4.1.0
-  resolution: "log-symbols@npm:4.1.0"
-  dependencies:
-    chalk: "npm:^4.1.0"
-    is-unicode-supported: "npm:^0.1.0"
-  checksum: 10/fce1497b3135a0198803f9f07464165e9eb83ed02ceb2273930a6f8a508951178d8cf4f0378e9d28300a2ed2bc49050995d2bd5f53ab716bb15ac84d58c6ef74
-  languageName: node
-  linkType: hard
-
 "long@npm:^5.0.0":
   version: 5.2.3
   resolution: "long@npm:5.2.3"
   checksum: 10/9167ec6947a825b827c30da169a7384eec6c0c9ec2f0b9c74da2e93d81159bbe39fb09c3f13dae9721d4b807ccfa09797a7dd1012f5d478e3e33ca3c78b608e6
-  languageName: node
-  linkType: hard
-
-"loupe@npm:^3.1.0":
-  version: 3.1.2
-  resolution: "loupe@npm:3.1.2"
-  checksum: 10/8f5734e53fb64cd914aa7d986e01b6d4c2e3c6c56dcbd5428d71c2703f0ab46b5ab9f9eeaaf2b485e8a1c43f865bdd16ec08ae1a661c8f55acdbd9f4d59c607a
   languageName: node
   linkType: hard
 
@@ -16971,7 +16775,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:^5.0.1, minimatch@npm:^5.1.6":
+"minimatch@npm:^5.0.1":
   version: 5.1.9
   resolution: "minimatch@npm:5.1.9"
   dependencies:
@@ -17110,46 +16914,6 @@ __metadata:
   bin:
     mkdirp: dist/cjs/src/bin.js
   checksum: 10/16fd79c28645759505914561e249b9a1f5fe3362279ad95487a4501e4467abeb714fd35b95307326b8fd03f3c7719065ef11a6f97b7285d7888306d1bd2232ba
-  languageName: node
-  linkType: hard
-
-"mocha-each@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "mocha-each@npm:2.0.1"
-  dependencies:
-    sprintf-js: "npm:^1.0.3"
-  checksum: 10/13d561ec1070bf1301bb9a21a75bb0c8eb159c4f848fa530b4cbfbe189f842e938ed716dc3f9ec963dd039230596b19ffdf8de3c63d8da0d14dbc792e5d4888a
-  languageName: node
-  linkType: hard
-
-"mocha@npm:^10.8.2":
-  version: 10.8.2
-  resolution: "mocha@npm:10.8.2"
-  dependencies:
-    ansi-colors: "npm:^4.1.3"
-    browser-stdout: "npm:^1.3.1"
-    chokidar: "npm:^3.5.3"
-    debug: "npm:^4.3.5"
-    diff: "npm:^5.2.0"
-    escape-string-regexp: "npm:^4.0.0"
-    find-up: "npm:^5.0.0"
-    glob: "npm:^8.1.0"
-    he: "npm:^1.2.0"
-    js-yaml: "npm:^4.1.0"
-    log-symbols: "npm:^4.1.0"
-    minimatch: "npm:^5.1.6"
-    ms: "npm:^2.1.3"
-    serialize-javascript: "npm:^6.0.2"
-    strip-json-comments: "npm:^3.1.1"
-    supports-color: "npm:^8.1.1"
-    workerpool: "npm:^6.5.1"
-    yargs: "npm:^16.2.0"
-    yargs-parser: "npm:^20.2.9"
-    yargs-unparser: "npm:^2.0.0"
-  bin:
-    _mocha: bin/_mocha
-    mocha: bin/mocha.js
-  checksum: 10/903bbffcb195ef9d36b27db54e3462c5486de1397289e0953735b3530397a139336c452bcf5188c663496c660d2285bbb6c7213290d36d536ad647b6145cb917
   languageName: node
   linkType: hard
 
@@ -17423,19 +17187,6 @@ __metadata:
   version: 2.0.2
   resolution: "netmask@npm:2.0.2"
   checksum: 10/375cabe898a5832816958664f26206f0a1e9f3605aa1816bfce803e060ff20f9d6ce56a2377e46f1470938358c31c27b3a8086f4a5e3ef678896147884d63ffa
-  languageName: node
-  linkType: hard
-
-"nise@npm:^6.1.1":
-  version: 6.1.1
-  resolution: "nise@npm:6.1.1"
-  dependencies:
-    "@sinonjs/commons": "npm:^3.0.1"
-    "@sinonjs/fake-timers": "npm:^13.0.1"
-    "@sinonjs/text-encoding": "npm:^0.7.3"
-    just-extend: "npm:^6.2.0"
-    path-to-regexp: "npm:^8.1.0"
-  checksum: 10/2d3175587cf0a351e2c91eb643fdc59d266de39f394a3ac0bace38571749d1e7f25341d763899245139b8f0d2ee048b2d3387d75ecf94c4897e947d5fc881eea
   languageName: node
   linkType: hard
 
@@ -18240,7 +17991,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"path-to-regexp@npm:^8.0.0, path-to-regexp@npm:^8.1.0":
+"path-to-regexp@npm:^8.0.0":
   version: 8.2.0
   resolution: "path-to-regexp@npm:8.2.0"
   checksum: 10/23378276a172b8ba5f5fb824475d1818ca5ccee7bbdb4674701616470f23a14e536c1db11da9c9e6d82b82c556a817bbf4eee6e41b9ed20090ef9427cbb38e13
@@ -18265,13 +18016,6 @@ __metadata:
   version: 2.0.3
   resolution: "pathe@npm:2.0.3"
   checksum: 10/01e9a69928f39087d96e1751ce7d6d50da8c39abf9a12e0ac2389c42c83bc76f78c45a475bd9026a02e6a6f79be63acc75667df855862fe567d99a00a540d23d
-  languageName: node
-  linkType: hard
-
-"pathval@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "pathval@npm:2.0.0"
-  checksum: 10/b91575bf9cdf01757afd7b5e521eb8a0b874a49bc972d08e0047cfea0cd3c019f5614521d4bc83d2855e3fcc331db6817dfd533dd8f3d90b16bc76fad2450fc1
   languageName: node
   linkType: hard
 
@@ -20048,20 +19792,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sinon@npm:^19.0.2":
-  version: 19.0.2
-  resolution: "sinon@npm:19.0.2"
-  dependencies:
-    "@sinonjs/commons": "npm:^3.0.1"
-    "@sinonjs/fake-timers": "npm:^13.0.2"
-    "@sinonjs/samsam": "npm:^8.0.1"
-    diff: "npm:^7.0.0"
-    nise: "npm:^6.1.1"
-    supports-color: "npm:^7.2.0"
-  checksum: 10/0be47968e9352269d0bdd26cdae7ae4e67d94fa007e8417d1e66ac95ba8537214edc770aff01b0f5a6f07588a1f7d3c947fff9366d799db85d3a4c405b875460
-  languageName: node
-  linkType: hard
-
 "sirv@npm:^3.0.2":
   version: 3.0.2
   resolution: "sirv@npm:3.0.2"
@@ -20338,13 +20068,6 @@ __metadata:
   version: 4.2.0
   resolution: "split2@npm:4.2.0"
   checksum: 10/09bbefc11bcf03f044584c9764cd31a252d8e52cea29130950b26161287c11f519807c5e54bd9e5804c713b79c02cefe6a98f4688630993386be353e03f534ab
-  languageName: node
-  linkType: hard
-
-"sprintf-js@npm:^1.0.3":
-  version: 1.1.3
-  resolution: "sprintf-js@npm:1.1.3"
-  checksum: 10/e7587128c423f7e43cc625fe2f87e6affdf5ca51c1cc468e910d8aaca46bb44a7fbcfa552f787b1d3987f7043aeb4527d1b99559e6621e01b42b3f45e5a24cbb
   languageName: node
   linkType: hard
 
@@ -20778,7 +20501,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"supports-color@npm:^7.1.0, supports-color@npm:^7.2.0":
+"supports-color@npm:^7.1.0":
   version: 7.2.0
   resolution: "supports-color@npm:7.2.0"
   dependencies:
@@ -21370,13 +21093,6 @@ __metadata:
   version: 4.0.8
   resolution: "type-detect@npm:4.0.8"
   checksum: 10/5179e3b8ebc51fce1b13efb75fdea4595484433f9683bbc2dca6d99789dba4e602ab7922d2656f2ce8383987467f7770131d4a7f06a26287db0615d2f4c4ce7d
-  languageName: node
-  linkType: hard
-
-"type-detect@npm:^4.1.0":
-  version: 4.1.0
-  resolution: "type-detect@npm:4.1.0"
-  checksum: 10/e363bf0352427a79301f26a7795a27718624c49c576965076624eb5495d87515030b207217845f7018093adcbe169b2d119bb9b7f1a31a92bfbb1ab9639ca8dd
   languageName: node
   linkType: hard
 
@@ -22487,13 +22203,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"workerpool@npm:^6.5.1":
-  version: 6.5.1
-  resolution: "workerpool@npm:6.5.1"
-  checksum: 10/b1b00139fe62f2ebec556a2af8085bf6e7502ad26cf2a4dcb34fb4408b2e68aa12c88b0a50cb463b24f2806d60fa491fc0da933b56ec3b53646aeec0025d14cb
-  languageName: node
-  linkType: hard
-
 "wrap-ansi-cjs@npm:wrap-ansi@^7.0.0, wrap-ansi@npm:^7.0.0":
   version: 7.0.0
   resolution: "wrap-ansi@npm:7.0.0"
@@ -22629,29 +22338,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yargs-parser@npm:^20.2.2, yargs-parser@npm:^20.2.9":
-  version: 20.2.9
-  resolution: "yargs-parser@npm:20.2.9"
-  checksum: 10/0188f430a0f496551d09df6719a9132a3469e47fe2747208b1dd0ab2bb0c512a95d0b081628bbca5400fb20dbf2fabe63d22badb346cecadffdd948b049f3fcc
-  languageName: node
-  linkType: hard
-
 "yargs-parser@npm:^21.1.1":
   version: 21.1.1
   resolution: "yargs-parser@npm:21.1.1"
   checksum: 10/9dc2c217ea3bf8d858041252d43e074f7166b53f3d010a8c711275e09cd3d62a002969a39858b92bbda2a6a63a585c7127014534a560b9c69ed2d923d113406e
-  languageName: node
-  linkType: hard
-
-"yargs-unparser@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "yargs-unparser@npm:2.0.0"
-  dependencies:
-    camelcase: "npm:^6.0.0"
-    decamelize: "npm:^4.0.0"
-    flat: "npm:^5.0.2"
-    is-plain-obj: "npm:^2.1.0"
-  checksum: 10/68f9a542c6927c3768c2f16c28f71b19008710abd6b8f8efbac6dcce26bbb68ab6503bed1d5994bdbc2df9a5c87c161110c1dfe04c6a3fe5c6ad1b0e15d9a8a3
   languageName: node
   linkType: hard
 
@@ -22667,21 +22357,6 @@ __metadata:
     y18n: "npm:^5.0.5"
     yargs-parser: "npm:^21.1.1"
   checksum: 10/abb3e37678d6e38ea85485ed86ebe0d1e3464c640d7d9069805ea0da12f69d5a32df8e5625e370f9c96dd1c2dc088ab2d0a4dd32af18222ef3c4224a19471576
-  languageName: node
-  linkType: hard
-
-"yargs@npm:^16.2.0":
-  version: 16.2.0
-  resolution: "yargs@npm:16.2.0"
-  dependencies:
-    cliui: "npm:^7.0.2"
-    escalade: "npm:^3.1.1"
-    get-caller-file: "npm:^2.0.5"
-    require-directory: "npm:^2.1.1"
-    string-width: "npm:^4.2.0"
-    y18n: "npm:^5.0.5"
-    yargs-parser: "npm:^20.2.2"
-  checksum: 10/807fa21211d2117135d557f95fcd3c3d390530cda2eca0c840f1d95f0f40209dcfeb5ec18c785a1f3425896e623e3b2681e8bb7b6600060eda1c3f4804e7957e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Deprecates mocha as a test runner for kv-store (we currently half part in mocha part in vitest). The seemingly off-topic change in stdlib stems from L2TipsStore tests being generated from there but consumed from kv-store. It's a bit of a strange pattern that maybe we should reconsider.