### PR TITLE
fix(sequencer): use chainTipsOverride.pending for log context

### DIFF
--- a/yarn-project/sequencer-client/src/sequencer/sequencer.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.ts
@@ -451,7 +451,7 @@ export class Sequencer extends (EventEmitter as new () => TypedEventEmitter<Sequ
       isInvalidating: !!invalidateCheckpoint,
       invalidatingCheckpointNumber: invalidateCheckpoint?.checkpointNumber,
       archiveForCheck: archiveForCheck.toString(),
-      overridePendingCheckpointNumber: simulationOverridesPlan?.pendingCheckpointNumber,
+      overridePendingCheckpointNumber: simulationOverridesPlan?.chainTipsOverride?.pending,
       overrideArchive: simulationOverridesPlan?.pendingCheckpointState?.archive,
       overrideFeeHeader: simulationOverridesPlan?.pendingCheckpointState?.feeHeader,
     };


### PR DESCRIPTION
## Summary

Fixes a build error in `sequencer-client/src/sequencer/sequencer.ts:454`:

```
error TS2551: Property 'pendingCheckpointNumber' does not exist on type 'SimulationOverridesPlan'. Did you mean 'pendingCheckpointState'?
```

The `pendingCheckpointNumber` field was removed from `SimulationOverridesPlan` and replaced with `chainTipsOverride.pending`. The log context in `proposeContext` was still referencing the old field. Updated the reference to use `simulationOverridesPlan?.chainTipsOverride?.pending`, matching the existing usage on line 438.

## Test plan

- `yarn workspace @aztec/sequencer-client build` succeeds