### PR TITLE
refactor(pxe): skip redundant getBlock RPC when querying at anchor block

### DIFF
--- a/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
@@ -995,6 +995,11 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
 
   /** Runs a query concurrently with a validation that the block hash is not ahead of the anchor block. */
   async #queryWithBlockHashNotAfterAnchor<T>(blockHash: BlockHash, query: () => Promise<T>): Promise<T> {
+    const anchorHash = await this.anchorBlockHeader.hash();
+    if (blockHash.equals(anchorHash)) {
+      return query();
+    }
+
     const [response] = await Promise.all([
       query(),
       (async () => {
@@ -1006,7 +1011,7 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
 
         if (header.getBlockNumber() > this.anchorBlockHeader.getBlockNumber()) {
           throw new Error(
-            `Made a node query with a reference block hash ${blockHash} with block number ${header.getBlockNumber()}, which is ahead of the anchor block number ${this.anchorBlockHeader.getBlockNumber()} (from anchor block hash ${await this.anchorBlockHeader.hash()}).`,
+            `Made a node query with a reference block hash ${blockHash} with block number ${header.getBlockNumber()}, which is ahead of the anchor block number ${this.anchorBlockHeader.getBlockNumber()} (from anchor block hash ${anchorHash}).`,
           );
         }
       })(),


### PR DESCRIPTION
## Why

During tx simulation, `#queryWithBlockHashNotAfterAnchor` fires a `getBlock` RPC on every oracle call to validate the queried block isn't ahead of the anchor. In practice, 5 of the 6 call sites always pass the anchor block hash itself, making this validation a no-op.

## The fix

Before running the full validation, compare the incoming `blockHash` against the anchor block's own hash. If they match, skip the `getBlock` RPC entirely and run the query directly — a block can never be ahead of itself, so the validation is a tautology.

When the hashes don't match (e.g. `getFromPublicStorage` called with a historical block header from `get_block_header_at()`), the original validation path runs unchanged.

### Details

`BlockHeader.hash()` caches its result internally via `_cachedHash`, so repeated calls to `this.anchorBlockHeader.hash()` are effectively free after the first computation.