### PR TITLE
test: skip tx_stats_bench 10 TPS sub-test on merge-train/fairies

### DIFF
--- a/yarn-project/end-to-end/src/bench/tx_stats_bench.test.ts
+++ b/yarn-project/end-to-end/src/bench/tx_stats_bench.test.ts
@@ -248,7 +248,12 @@ describe('transaction benchmarks', () => {
     TIMEOUT,
   );
 
-  it(
+  // TODO(#23083): Skipped while a flake under heavy bb-prover concurrency is investigated.
+  // Under 8x parallel IVC verifications (each spawning a bb subprocess via the bb.js
+  // NativeUnixSocket backend) at least one verification intermittently returns valid:false on
+  // the bench host. The serial sub-tests above pass cleanly. Re-enable once the underlying
+  // verifier-under-load interaction is fixed.
+  it.skip(
     'verifies transactions at 10 TPS',
     async () => {
       const seconds = 60;


### PR DESCRIPTION
## Motivation

Cherry-pick of #23092 onto `merge-train/fairies`. The same `verifies transactions at 10 TPS` flake in `tx_stats_bench.test.ts:268` that #23092 skips on `merge-train/spartan` is now blocking PRs based on `merge-train/fairies` (e.g. seen on the `mv/f-637-public-self-creator` branch in `ci-full`):

```
● transaction benchmarks › verifies transactions at 10 TPS
  expect(received).toBe(expected) // Object.is equality
  Expected: true
  Received: false
    at toBe (bench/tx_stats_bench.test.ts:268:69)
```

#23092 has the full analysis: under 8x parallel IVC verifications (each spawning a bb subprocess via the bb.js `NativeUnixSocket` backend introduced in #21564), at least one verification intermittently returns `valid:false`. None of the merge-train commits triggering the failure touch the bb-prover IVC verifier path.

## Notes

- Re-enable `it.skip` → `it` once the bb.js backend's concurrent-verifier interaction (`withVerifierInstance` lifecycle) is hardened.