### PR TITLE
fix(docs): hard-navigate api-nr search results out of the SPA

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -315,6 +315,11 @@ const config = {
           ],
           apiKey: "gpH8o2YnqsOEj2jgtIMTULbtHi1kZ2X3", // public search-only api key, safe to commit
         },
+        // aztec-nr-api pages live in /static/ as raw HTML, not React Router
+        // routes. Without this, the dropdown calls history.push() and the SPA
+        // 404s on click. Matching the regex makes the theme use
+        // window.location.href for a real page load that Netlify resolves.
+        externalUrlRegex: "/aztec-nr-api/",
       },
       colorMode: {
         defaultMode: "light",


### PR DESCRIPTION
## Problem

Search results for aztec-nr-api pages 404 in the browser even though the underlying static HTML exists and a direct fetch returns 200.

Repro: search the docs dropdown for an Aztec.nr identifier (e.g. `SerializeToColumns`), click an api-nr hit, get the Docusaurus 404 page. Curling the same URL works:

```
$ curl -sI https://docs.aztec.network/aztec-nr-api/mainnet/protocol_types/proof/traits/trait.serializetocolumns | head -1
HTTP/2 200
```

So the index from #23097 is correct (14,773 api-nr records visible under `docusaurus_tag:=[default]`, confirmed in the May 8 scraper run); the file is reachable; the 404 is purely client-side.

## Root cause

`aztec-nr-api/` pages are static HTML generated by `nargo doc` and dropped into `docs/static/aztec-nr-api/`. Netlify serves them as raw files. Docusaurus does **not** register them as React Router routes.

`docusaurus-theme-search-typesense` decides between SPA navigation and full page load via `externalUrlRegex` ([SearchBar/index.tsx#L169-L197](https://github.com/typesense/docusaurus-theme-search-typesense/blob/main/src/theme/SearchBar/index.tsx#L169)):

```ts
// transformItems: keep absolute URL only if it matches the regex,
// otherwise strip to a relative path
if (isRegexpStringMatch(externalUrlRegex, item.url)) return item;
return { ...item, url: withBaseUrl(`${url.pathname}${url.hash}`) };

// navigator: hard-nav only if itemUrl matches the regex
if (isRegexpStringMatch(externalUrlRegex, itemUrl)) {
  window.location.href = itemUrl;
} else {
  history.push(itemUrl);
}
```

`externalUrlRegex` is unset in `docs/docusaurus.config.js`, so api-nr clicks go through `history.push`, which dispatches to React Router, which has no matching route for `/aztec-nr-api/...` and renders the SPA's 404. The static file on disk is never requested.

## Fix

Set `externalUrlRegex: "/aztec-nr-api/"` in the typesense theme config. `isRegexpStringMatch` does a case-insensitive substring match (`new RegExp(s, 'gi').test(value)`), so this:

- matches the absolute URL during `transformItems` → URL stays absolute,
- matches the URL during `navigate` → uses `window.location.href` → real page load → Netlify serves the static file.

Regular Docusaurus results don't match the regex and continue using `history.push`, preserving SPA navigation for in-app routes.

The slashes (`/aztec-nr-api/`) prevent accidental substring matches if a future doc slug ever contained "aztec-nr-api".

## Verification

Pre-fix repro is the user-reported bug; post-fix verification requires the deployed Netlify preview. After this lands and a preview is built, manually:

- [ ] Search the dropdown from the homepage, /developers/, /operate/, and /participate/ for an Aztec.nr identifier (e.g. `SerializeToColumns`, `address_note`).
- [ ] Click an api-nr result; confirm the page loads (not the 404).
- [ ] Click a regular Docusaurus result; confirm SPA navigation still feels instant (no full page reload).

## Notes

- Only `aztec-nr-api/` is currently indexed in `docs/typesense.config.json`. `static/typescript-api/` is not crawled by the Typesense scraper, so it doesn't need to be in the regex.
- This is the third PR in the search-fix series after #22861 → #23042 → #23058 → #23097. #23097 fixed indexing (records exist in Typesense); this one fixes click-through (records resolve in the browser).