### PR TITLE
fix(archiver): move L2 tips cache refresh out of write transactions

### DIFF
--- a/yarn-project/archiver/src/modules/data_store_updater.test.ts
+++ b/yarn-project/archiver/src/modules/data_store_updater.test.ts
@@ -7,12 +7,15 @@ import { AztecAddress } from '@aztec/stdlib/aztec-address';
 import { L2Block } from '@aztec/stdlib/block';
 import { ContractClassLog, PrivateLog } from '@aztec/stdlib/logs';
 import '@aztec/stdlib/testing/jest';
+import { BlockHeader } from '@aztec/stdlib/tx';
 
+import { jest } from '@jest/globals';
 import { readFileSync } from 'fs';
 import { dirname, resolve } from 'path';
 import { fileURLToPath } from 'url';
 
 import { type ArchiverDataStores, createArchiverDataStores } from '../store/data_stores.js';
+import { L2TipsCache } from '../store/l2_tips_cache.js';
 import { makeCheckpoint, makePublishedCheckpoint } from '../test/mock_structs.js';
 import { ArchiverDataStoreUpdater } from './data_store_updater.js';
 
@@ -213,6 +216,31 @@ describe('ArchiverDataStoreUpdater', () => {
       // Verify logs are removed
       const publicLogsAfter = await store.logs.getPublicLogs({});
       expect(publicLogsAfter.logs.length).toBe(0);
+    });
+  });
+
+  describe('l2 tips cache refresh', () => {
+    it('does not refresh the cache when the writer transaction aborts', async () => {
+      const initialBlockHash = await BlockHeader.empty().hash();
+      const tipsCache = new L2TipsCache(store.blocks, initialBlockHash);
+      const updaterWithCache = new ArchiverDataStoreUpdater(store, tipsCache);
+
+      const tipsBefore = await tipsCache.getL2Tips();
+
+      const block = await L2Block.random(BlockNumber(1), {
+        checkpointNumber: CheckpointNumber(1),
+        indexWithinCheckpoint: IndexWithinCheckpoint(0),
+      });
+
+      const failure = new Error('forced failure inside writer transaction');
+      const addProposedBlockSpy = jest.spyOn(store.blocks, 'addProposedBlock').mockRejectedValueOnce(failure);
+
+      await expect(updaterWithCache.addProposedBlock(block)).rejects.toBe(failure);
+
+      const tipsAfter = await tipsCache.getL2Tips();
+      expect(tipsAfter).toEqual(tipsBefore);
+
+      addProposedBlockSpy.mockRestore();
     });
   });
 });

--- a/yarn-project/archiver/src/modules/data_store_updater.ts
+++ b/yarn-project/archiver/src/modules/data_store_updater.ts
@@ -74,9 +74,9 @@ export class ArchiverDataStoreUpdater {
         this.addContractDataToDb(block),
       ]);
 
-      await this.l2TipsCache?.refresh();
       return opResults.every(Boolean);
     });
+    await this.l2TipsCache?.refresh();
     return result;
   }
 
@@ -144,18 +144,17 @@ export class ArchiverDataStoreUpdater {
           : undefined,
       ]);
 
-      await this.l2TipsCache?.refresh();
       return { prunedBlocks, lastAlreadyInsertedBlockNumber };
     });
+    await this.l2TipsCache?.refresh();
     return result;
   }
 
   public async addProposedCheckpoint(proposedCheckpoint: ProposedCheckpointInput) {
     const result = await this.stores.db.transactionAsync(async () => {
       await this.stores.blocks.addProposedCheckpoint(proposedCheckpoint);
-      await this.l2TipsCache?.refresh();
     });
-
+    await this.l2TipsCache?.refresh();
     return result;
   }
 
@@ -256,9 +255,9 @@ export class ArchiverDataStoreUpdater {
       // Clear all pending proposed checkpoints since their blocks have been pruned
       await this.stores.blocks.deleteProposedCheckpoints();
 
-      await this.l2TipsCache?.refresh();
       return result;
     });
+    await this.l2TipsCache?.refresh();
     return result;
   }
 
@@ -289,7 +288,7 @@ export class ArchiverDataStoreUpdater {
    * @returns True if the operation is successful.
    */
   public async removeCheckpointsAfter(checkpointNumber: CheckpointNumber): Promise<boolean> {
-    return await this.stores.db.transactionAsync(async () => {
+    const result = await this.stores.db.transactionAsync(async () => {
       const { blocksRemoved = [] } = await this.stores.blocks.removeCheckpointsAfter(checkpointNumber);
 
       const opResults = await Promise.all([
@@ -300,9 +299,10 @@ export class ArchiverDataStoreUpdater {
         this.stores.logs.deleteLogs(blocksRemoved),
       ]);
 
-      await this.l2TipsCache?.refresh();
       return opResults.every(Boolean);
     });
+    await this.l2TipsCache?.refresh();
+    return result;
   }
 
   /**
@@ -312,8 +312,8 @@ export class ArchiverDataStoreUpdater {
   public async setProvenCheckpointNumber(checkpointNumber: CheckpointNumber): Promise<void> {
     await this.stores.db.transactionAsync(async () => {
       await this.stores.blocks.setProvenCheckpointNumber(checkpointNumber);
-      await this.l2TipsCache?.refresh();
     });
+    await this.l2TipsCache?.refresh();
   }
 
   /**
@@ -323,8 +323,8 @@ export class ArchiverDataStoreUpdater {
   public async setFinalizedCheckpointNumber(checkpointNumber: CheckpointNumber): Promise<void> {
     await this.stores.db.transactionAsync(async () => {
       await this.stores.blocks.setFinalizedCheckpointNumber(checkpointNumber);
-      await this.l2TipsCache?.refresh();
     });
+    await this.l2TipsCache?.refresh();
   }
 
   /** Extracts and stores contract data from a single block. */

--- a/yarn-project/archiver/src/store/l2_tips_cache.ts
+++ b/yarn-project/archiver/src/store/l2_tips_cache.ts
@@ -13,7 +13,8 @@ import type { BlockStore } from './block_store.js';
 /**
  * In-memory cache for L2 chain tips (proposed, checkpointed, proven, finalized).
  * Populated from the BlockStore on first access, then kept up-to-date by the ArchiverDataStoreUpdater.
- * Refresh calls should happen within the store transaction that mutates block data to ensure consistency.
+ * Refresh calls should happen *after* the store transaction that mutates block data has committed,
+ * so the cache loads from committed state and is never replaced if the writer aborts.
  */
 export class L2TipsCache {
   #tipsPromise: Promise<L2Tips> | undefined;
@@ -34,7 +35,7 @@ export class L2TipsCache {
     return (this.#tipsPromise ??= this.loadFromStore());
   }
 
-  /** Reloads the L2 tips from the block store. Should be called within the store transaction that mutates data. */
+  /** Reloads the L2 tips from the block store. Should be called after the writer transaction has committed. */
   public async refresh(): Promise<void> {
     this.#tipsPromise = this.loadFromStore();
     await this.#tipsPromise;


### PR DESCRIPTION
Move every `l2TipsCache.refresh()` call in `ArchiverDataStoreUpdater` out of the surrounding `db.transactionAsync` callback and into the post-commit code path. This addresses two issues with the previous in-transaction refresh:

1. **Mid-tx visibility.** `L2TipsCache.refresh()` reassigns its internal `#tipsPromise` synchronously, which was observable to other callers before LMDB committed. A concurrent reader calling `getL2Tips()` after the reassignment but before commit would pick up a promise loaded against in-flight tx state, while a sibling read on the store directly outside the tx still saw pre-commit state.
2. **No rollback on tx abort.** If the LMDB transaction threw or aborted, the cache was already replaced with a promise loaded against in-flight writes that would never commit. Future readers saw a cache reflecting rolled-back state.

Refresh now runs after the writer transaction has fully committed, so it loads from the committed store and is never replaced when the writer aborts.

## Notes

- This intentionally leaves a narrow JS-side race window between LMDB commit returning and `refresh()` finishing its `loadFromStore`.
