### PR TITLE
refactor(pxe): use findLeavesIndexes for read request verification

### DIFF
--- a/yarn-project/end-to-end/src/e2e_kernelless_simulation.test.ts
+++ b/yarn-project/end-to-end/src/e2e_kernelless_simulation.test.ts
@@ -15,6 +15,7 @@ import { GenericProxyContract } from '@aztec/noir-test-contracts.js/GenericProxy
 import { PendingNoteHashesContract } from '@aztec/noir-test-contracts.js/PendingNoteHashes';
 import { type AbiDecoded, decodeFromAbi, getFunctionArtifact } from '@aztec/stdlib/abi';
 import { computeOuterAuthWitHash } from '@aztec/stdlib/auth-witness';
+import { MerkleTreeId } from '@aztec/stdlib/trees';
 
 import { jest } from '@jest/globals';
 
@@ -412,7 +413,7 @@ describe('Kernelless simulation', () => {
       });
 
       // Spy on the node API that generateSimulatedProvingResult uses to verify settled read requests
-      const noteHashMembershipWitnessSpy = jest.spyOn(aztecNode, 'getNoteHashMembershipWitness');
+      const findLeavesIndexesSpy = jest.spyOn(aztecNode, 'findLeavesIndexes');
 
       wallet.setSimulationMode('kernelless-override');
       await expect(
@@ -421,8 +422,12 @@ describe('Kernelless simulation', () => {
         }),
       ).resolves.toBeDefined();
 
-      expect(noteHashMembershipWitnessSpy).toHaveBeenCalled();
-      noteHashMembershipWitnessSpy.mockRestore();
+      expect(findLeavesIndexesSpy).toHaveBeenCalledWith(
+        expect.anything(),
+        MerkleTreeId.NOTE_HASH_TREE,
+        expect.anything(),
+      );
+      findLeavesIndexesSpy.mockRestore();
     });
   });
 

--- a/yarn-project/pxe/src/contract_function_simulator/contract_function_simulator.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/contract_function_simulator.ts
@@ -53,7 +53,6 @@ import {
   siloNullifier,
 } from '@aztec/stdlib/hash';
 import type { AztecNode } from '@aztec/stdlib/interfaces/server';
-import { MerkleTreeId } from '@aztec/stdlib/trees';
 import {
   ClaimedLengthArray,
   PartialPrivateTailPublicInputsForPublic,
@@ -77,6 +76,7 @@ import {
 import { PrivateLog } from '@aztec/stdlib/logs';
 import { ScopedL2ToL1Message } from '@aztec/stdlib/messaging';
 import { ChonkProof } from '@aztec/stdlib/proofs';
+import { MerkleTreeId } from '@aztec/stdlib/trees';
 import {
   BlockHeader,
   CallContext,

--- a/yarn-project/pxe/src/contract_function_simulator/contract_function_simulator.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/contract_function_simulator.ts
@@ -53,6 +53,7 @@ import {
   siloNullifier,
 } from '@aztec/stdlib/hash';
 import type { AztecNode } from '@aztec/stdlib/interfaces/server';
+import { MerkleTreeId } from '@aztec/stdlib/trees';
 import {
   ClaimedLengthArray,
   PartialPrivateTailPublicInputsForPublic,
@@ -758,7 +759,7 @@ function squashTransientSideEffects(
  * at the tx's anchor block, mimicking the behavior of the kernels
  */
 async function verifyReadRequests(
-  node: Pick<AztecNode, 'getNoteHashMembershipWitness' | 'getNullifierMembershipWitness'>,
+  node: Pick<AztecNode, 'findLeavesIndexes'>,
   anchorBlockHash: BlockParameter,
   noteHashReadRequests: ScopedReadRequest[],
   nullifierReadRequests: ScopedReadRequest[],
@@ -791,13 +792,25 @@ async function verifyReadRequests(
     }
   }
 
-  const [noteHashWitnesses, nullifierWitnesses] = await Promise.all([
-    Promise.all(settledNoteHashReads.map(({ value }) => node.getNoteHashMembershipWitness(anchorBlockHash, value))),
-    Promise.all(settledNullifierReads.map(({ value }) => node.getNullifierMembershipWitness(anchorBlockHash, value))),
+  const [noteHashResults, nullifierResults] = await Promise.all([
+    settledNoteHashReads.length > 0
+      ? node.findLeavesIndexes(
+          anchorBlockHash,
+          MerkleTreeId.NOTE_HASH_TREE,
+          settledNoteHashReads.map(({ value }) => value),
+        )
+      : [],
+    settledNullifierReads.length > 0
+      ? node.findLeavesIndexes(
+          anchorBlockHash,
+          MerkleTreeId.NULLIFIER_TREE,
+          settledNullifierReads.map(({ value }) => value),
+        )
+      : [],
   ]);
 
   for (let i = 0; i < settledNoteHashReads.length; i++) {
-    if (!noteHashWitnesses[i]) {
+    if (!noteHashResults[i]) {
       throw new Error(
         `Note hash read request at index ${settledNoteHashReads[i].index} is reading an unknown note hash: ${settledNoteHashReads[i].value}`,
       );
@@ -805,7 +818,7 @@ async function verifyReadRequests(
   }
 
   for (let i = 0; i < settledNullifierReads.length; i++) {
-    if (!nullifierWitnesses[i]) {
+    if (!nullifierResults[i]) {
       throw new Error(
         `Nullifier read request at index ${settledNullifierReads[i].index} is reading an unknown nullifier: ${settledNullifierReads[i].value}`,
       );


### PR DESCRIPTION
## Summary

- Replace per-read-request `getNoteHashMembershipWitness` / `getNullifierMembershipWitness` calls with a single batched `findLeavesIndexes` call per tree when verifying settled read requests in `verifyReadRequests`.
- We only need existence here, not the witness, so the cheaper batched lookup suffices.