### PR TITLE
refactor(pxe): short-circuit block header lookup at anchor block

### DIFF
--- a/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
@@ -307,6 +307,11 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
       throw new Error(`Block number ${blockNumber} is higher than current block ${anchorBlockNumber}`);
     }
 
+    // Most contracts query state at the "current" block, which is the anchor. Skip the RPC when we can.
+    if (blockNumber === anchorBlockNumber) {
+      return this.anchorBlockHeader;
+    }
+
     const block = await this.aztecNode.getBlock(blockNumber);
     return block?.header;
   }
@@ -995,6 +1000,7 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
 
   /** Runs a query concurrently with a validation that the block hash is not ahead of the anchor block. */
   async #queryWithBlockHashNotAfterAnchor<T>(blockHash: BlockHash, query: () => Promise<T>): Promise<T> {
+    // Most contracts query state at the "current" block, which is the anchor. Skip the validation when we can.
     const anchorHash = await this.anchorBlockHeader.hash();
     if (blockHash.equals(anchorHash)) {
       return query();


### PR DESCRIPTION
## Summary

- Skip the `aztecNode.getBlock` RPC in `getBlockHeader` when the requested block number matches the anchor — the anchor's header is already in memory.
- Most utility executions query state at the anchor block, so this avoids a redundant round-trip on the hot path.