### PR TITLE
fix(pxe): skip registerContractFunctionSignatures when no public fns

### DIFF
--- a/yarn-project/pxe/src/pxe.test.ts
+++ b/yarn-project/pxe/src/pxe.test.ts
@@ -7,7 +7,7 @@ import { AztecLMDBStoreV2, openTmpStore } from '@aztec/kv-store/lmdb-v2';
 import { TestContractArtifact } from '@aztec/noir-test-contracts.js/Test';
 import { BundledProtocolContractsProvider } from '@aztec/protocol-contracts/providers/bundle';
 import { WASMSimulator } from '@aztec/simulator/client';
-import { EventSelector } from '@aztec/stdlib/abi';
+import { EventSelector, FunctionType } from '@aztec/stdlib/abi';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
 import { BlockHash, GENESIS_BLOCK_HEADER_HASH, GENESIS_CHECKPOINT_HEADER_HASH } from '@aztec/stdlib/block';
 import { getContractClassFromArtifact } from '@aztec/stdlib/contract';
@@ -159,6 +159,40 @@ describe('PXE', () => {
     const artifact = randomContractArtifact();
     const instance = await randomContractInstanceWithAddress();
     await expect(pxe.registerContract({ instance, artifact })).rejects.toThrow(/Artifact does not match/i);
+  });
+
+  it('does not call registerContractFunctionSignatures for contracts without public functions', async () => {
+    const { artifact, instance } = await randomDeployedContract();
+    node.registerContractFunctionSignatures.mockClear();
+
+    await pxe.registerContract({ artifact, instance });
+
+    expect(node.registerContractFunctionSignatures).not.toHaveBeenCalled();
+  });
+
+  it('calls registerContractFunctionSignatures for contracts with public functions', async () => {
+    const artifact = randomContractArtifact();
+    artifact.functions = [
+      {
+        name: 'my_public_fn',
+        functionType: FunctionType.PUBLIC,
+        isOnlySelf: false,
+        isStatic: false,
+        isInitializer: false,
+        parameters: [],
+        returnTypes: [],
+        errorTypes: {},
+        bytecode: Buffer.from(''),
+        debugSymbols: '',
+      },
+    ];
+    const contractClass = await getContractClassFromArtifact(artifact);
+    const instance = await randomContractInstanceWithAddress({ contractClassId: contractClass.id });
+    node.registerContractFunctionSignatures.mockClear();
+
+    await pxe.registerContract({ artifact, instance });
+
+    expect(node.registerContractFunctionSignatures).toHaveBeenCalledWith(['my_public_fn()']);
   });
 
   // These tests are meant to quickly exercise PXE as a

--- a/yarn-project/pxe/src/pxe.ts
+++ b/yarn-project/pxe/src/pxe.ts
@@ -693,7 +693,9 @@ export class PXE {
       const publicFunctionSignatures = artifact.functions
         .filter(fn => fn.functionType === FunctionType.PUBLIC)
         .map(fn => decodeFunctionSignature(fn.name, fn.parameters));
-      await this.node.registerContractFunctionSignatures(publicFunctionSignatures);
+      if (publicFunctionSignatures.length > 0) {
+        await this.node.registerContractFunctionSignatures(publicFunctionSignatures);
+      }
     } else {
       // Otherwise, make sure there is an artifact already registered for that class id
       artifact = await this.contractStore.getContractArtifact(instance.currentContractClassId);
@@ -740,7 +742,9 @@ export class PXE {
       const publicFunctionSignatures = artifact.functions
         .filter(fn => fn.functionType === FunctionType.PUBLIC)
         .map(fn => decodeFunctionSignature(fn.name, fn.parameters));
-      await this.node.registerContractFunctionSignatures(publicFunctionSignatures);
+      if (publicFunctionSignatures.length > 0) {
+        await this.node.registerContractFunctionSignatures(publicFunctionSignatures);
+      }
 
       currentInstance.currentContractClassId = contractClass.id;
       await Promise.all([


### PR DESCRIPTION
## Summary

- Skip the `registerContractFunctionSignatures` node call in `registerContract` and `updateContract` when the artifact has no public functions, avoiding an unnecessary RPC for purely-private contracts.
- Add PXE tests covering both the no-public-fn skip case and the public-fn registration case.