### PR TITLE
refactor(pxe): avoid expensive toTx() call when computing tx hash

### DIFF
--- a/yarn-project/pxe/src/pxe.ts
+++ b/yarn-project/pxe/src/pxe.ts
@@ -832,6 +832,9 @@ export class PXE {
         // storing the tags here prevents linkage of txs sent from the same PXE.
         const taggingIndexRangesUsedInTheTx = privateExecutionResult.entrypoint.taggingIndexRanges;
         if (taggingIndexRangesUsedInTheTx.length > 0) {
+          // Avoiding txProvingResult.toTx() because it walks the PrivateCallExecutionResult tree
+          // to collect logs that don't affect the tx hash. Tx.computeTxHash({ data: publicInputs })
+          // is equivalent — only `data` contributes to the hash.
           const txHash = await Tx.computeTxHash({ data: publicInputs });
 
           await this.senderTaggingStore.storePendingIndexes(taggingIndexRangesUsedInTheTx, txHash, jobId);

--- a/yarn-project/pxe/src/pxe.ts
+++ b/yarn-project/pxe/src/pxe.ts
@@ -832,10 +832,7 @@ export class PXE {
         // storing the tags here prevents linkage of txs sent from the same PXE.
         const taggingIndexRangesUsedInTheTx = privateExecutionResult.entrypoint.taggingIndexRanges;
         if (taggingIndexRangesUsedInTheTx.length > 0) {
-          // Avoiding txProvingResult.toTx() because it walks the PrivateCallExecutionResult tree
-          // to collect logs that don't affect the tx hash. Tx.computeTxHash({ data: publicInputs })
-          // is equivalent — only `data` contributes to the hash.
-          const txHash = await Tx.computeTxHash({ data: publicInputs });
+          const txHash = await txProvingResult.getTxHash();
 
           await this.senderTaggingStore.storePendingIndexes(taggingIndexRangesUsedInTheTx, txHash, jobId);
           this.log.debug(`Stored used tagging index ranges as sender for the tx`, {

--- a/yarn-project/pxe/src/pxe.ts
+++ b/yarn-project/pxe/src/pxe.ts
@@ -832,8 +832,7 @@ export class PXE {
         // storing the tags here prevents linkage of txs sent from the same PXE.
         const taggingIndexRangesUsedInTheTx = privateExecutionResult.entrypoint.taggingIndexRanges;
         if (taggingIndexRangesUsedInTheTx.length > 0) {
-          // TODO(benesjan): The following is an expensive operation. Figure out a way to avoid it.
-          const txHash = (await txProvingResult.toTx()).txHash;
+          const txHash = await Tx.computeTxHash({ data: publicInputs });
 
           await this.senderTaggingStore.storePendingIndexes(taggingIndexRangesUsedInTheTx, txHash, jobId);
           this.log.debug(`Stored used tagging index ranges as sender for the tx`, {

--- a/yarn-project/stdlib/src/tx/proven_tx.ts
+++ b/yarn-project/stdlib/src/tx/proven_tx.ts
@@ -13,6 +13,7 @@ import {
 } from './private_execution_result.js';
 import { type ProvingStats, ProvingTimingsSchema } from './profiling.js';
 import { Tx } from './tx.js';
+import type { TxHash } from './tx_hash.js';
 
 export class TxProvingResult {
   constructor(
@@ -21,6 +22,11 @@ export class TxProvingResult {
     public chonkProof: ChonkProof,
     public stats?: ProvingStats,
   ) {}
+
+  getTxHash(): Promise<TxHash> {
+    // Equivalent to `(await this.toTx()).txHash` but skips walking the execution result tree to collect logs.
+    return Tx.computeTxHash({ data: this.publicInputs });
+  }
 
   async toTx(): Promise<Tx> {
     const contractClassLogs = collectSortedContractClassLogs(this.privateExecutionResult);


### PR DESCRIPTION
## Summary

- Replace `(await txProvingResult.toTx()).txHash` with `await Tx.computeTxHash({ data: publicInputs })` in `proveTx`, and remove the corresponding TODO.

## Why this is safe and worth doing

`TxProvingResult.toTx()` passes `this.publicInputs` directly as `data` to `Tx.create` ([proven_tx.ts:28-29](https://github.com/AztecProtocol/aztec-packages/blob/8394df561e/yarn-project/stdlib/src/tx/proven_tx.ts#L28-L29)). `Tx.create` computes the hash via `Tx.computeTxHash(fields)` ([tx.ts:159](https://github.com/AztecProtocol/aztec-packages/blob/8394df561e/yarn-project/stdlib/src/tx/tx.ts#L159)), which only reads `fields.data` ([tx.ts:151-155](https://github.com/AztecProtocol/aztec-packages/blob/8394df561e/yarn-project/stdlib/src/tx/tx.ts#L151-L155)). So calling `Tx.computeTxHash({ data: publicInputs })` produces the same hash while skipping work that doesn't contribute to it:

- Walking the nested `PrivateCallExecutionResult` tree to collect and sort contract class logs
- Constructing a full `Tx` (with proof, logs, calldata) only to read one field and discard the rest

A short version of this rationale lives inline in `pxe.ts`.