### PR TITLE
docs(sequencer-client): rewrite top-level and timing READMEs

### DIFF
--- a/yarn-project/sequencer-client/README.md
+++ b/yarn-project/sequencer-client/README.md
@@ -10,7 +10,7 @@ The sequencer does **not** decide what is in the next block on its own. It compo
 
 ### Slots, Blocks, and Checkpoints
 
-The Aztec consensus design splits each Aztec slot into multiple L2 blocks. This is the design originally called [building in chunks](https://github.com/AztecProtocol/engineering-designs/blob/main/docs/building-in-chunks/index.md).
+The Aztec design splits each Aztec slot into multiple L2 blocks:
 
 - **Slot** — a fixed time window (e.g. 72 s) during which one proposer is allowed to build.
 - **Block** — a single batch of transactions, executed and validated as a unit, with its own header.
@@ -26,11 +26,13 @@ There are two tips the sequencer cares about:
 - The **proposed chain** is the set of blocks that have been broadcast over p2p but not yet committed to L1. Both the sequencer and validators push these blocks into the archiver so the rest of the node can serve them.
 - The **checkpointed chain** is the set of checkpoints that have landed on L1, recovered from `CheckpointProposed` events.
 
-Within a slot, the proposer adds blocks to the proposed chain as it goes. Only the last block within the slot is bundled with a `CheckpointProposal` that committee members attest to; intermediate blocks are accepted onto the proposed chain by virtue of the proposer's signature alone, and every node that wants to follow the proposed chain re-executes them. See the [validator client README](../validator-client/README.md) for the consumer side.
+Within a slot, the proposer adds blocks to the proposed chain as it goes. At the end of its slot, it sends a `CheckpointProposal` that committee members attest to; intermediate blocks are accepted onto the proposed chain by virtue of the proposer's signature alone, and every node that wants to follow the proposed chain re-executes them. See the [validator client README](../validator-client/README.md) for the consumer side.
 
 ### Proposer Pipelining
 
-The legacy ("non-pipelined") flow has the proposer for slot `N` build, attest, and publish inside slot `N`. The proposer spends most of `N` collecting attestations and waiting for the L1 transaction to be mined, leaving a long idle window. Pipelining, [proposed in this discussion](https://github.com/AztecProtocol/governance/discussions/8), removes that idle window: the proposer for slot `N` builds blocks during slot `N - 1`, finishes attestation collection before the slot boundary, and submits the L1 transaction at the start of slot `N`.
+The legacy non-pipelined flow had the proposer for slot `N` build, attest, and publish inside slot `N`; so the proposer spent most of `N` collecting attestations and waiting for the L1 transaction to be mined, leaving a long idle window. 
+
+Pipelining removes that idle window: the proposer for slot `N` builds blocks during slot `N - 1`, finishes attestation collection before the slot boundary, and submits the L1 transaction at the start of slot `N`.
 
 Pipelining shifts the work like this:
 
@@ -43,12 +45,9 @@ Pipelining shifts the work like this:
 
 \* The pipelined timing model reserves enough end-of-slot budget for attestations to be in hand by the slot boundary, but the enforced deadline (`checkpointAttestationDeadline`) actually extends to `2 * aztecSlotDuration - l1PublishingTime`, so a late attestation can still spill into the target slot.
 
-In practice, "non-pipelined mode" is being removed; this README treats pipelining as the default. The toggle still exists (`enableProposerPipelining`) because `EpochCache` consults it when looking up the proposer for the next L1 slot — when pipelining is enabled, the sequencer asks the cache for the proposer of `slot + 1` rather than `slot`.
+The non-pipelined mode is being removed; this README treats pipelining as the default. The toggle still exists for lingering tests.
 
-The pipelining flow introduces two failure modes that block building has to handle:
-
-- **Pipeline depth** is bounded to 2 (`checkpointNumber ≤ confirmedCheckpoint + 2`). Building further ahead would require trusting more in-flight parent proposals than the design allows.
-- **Pipelined parent invalidation**: if the parent checkpoint we built on top of fails to land cleanly on L1, the next proposer's work is discarded (`pipelined-checkpoint-discarded` event) and an `invalidate` request is enqueued for the parent.
+Note that, under pipelining, if the parent checkpoint we built on top of fails to land cleanly on L1, the next proposer's work is discarded (`pipelined-checkpoint-discarded` event).
 
 ## Architecture
 

--- a/yarn-project/sequencer-client/README.md
+++ b/yarn-project/sequencer-client/README.md
@@ -4,7 +4,7 @@ The sequencer client is the proposer-side counterpart to the [validator client](
 
 A single instance owns the entire proposer flow for one slot: deciding whether to propose, building several L2 blocks one after another, signing them, gossiping them, collecting attestations from the committee, and submitting the final checkpoint to L1 in one Multicall3 transaction together with governance and slashing votes.
 
-The sequencer does **not** decide what is in the next block on its own. It composes the work of several other subsystems: the [tx pool](../p2p/README.md) supplies transactions, the [validator client](../validator-client/README.md) owns operator keys and contains the `CheckpointBuilder` that actually executes them, the [archiver](../archiver/README.md) provides the L2 chain state needed to anchor each block, the [epoch cache](../epoch-cache/README.md) answers proposer/committee lookups, and the [slasher](../slasher/README.md) supplies offenses to vote on.
+The sequencer does **not** decide what is in the next block on its own. It composes the work of several other subsystems: the [tx pool](../p2p/README.md) supplies transactions, the [validator client](../validator-client/README.md) owns the operator keys and signs proposals, the `CheckpointBuilder` (defined in `@aztec/validator-client`, but constructed and held by the sequencer's `CheckpointProposalJob`) executes the txs, the [archiver](../archiver/README.md) provides the L2 chain state needed to anchor each block, the [epoch cache](../epoch-cache/README.md) answers proposer/committee lookups, and the [slasher](../slasher/README.md) supplies offenses to vote on.
 
 ## Key Concepts
 
@@ -51,35 +51,29 @@ Note that, under pipelining, if the parent checkpoint we built on top of fails t
 
 ## Architecture
 
-```
-       ┌──────────────────────────────────────────────────────────────┐
-       │                          Sequencer                           │
-       │              (state machine, one slot at a time)             │
-       │                                                              │
-       │   work() ──► prepareCheckpointProposal() ──► proposal job    │
-       └─────┬────────────────┬──────────────────┬──────────────────┬─┘
-             │                │                  │                  │
-             ▼                ▼                  ▼                  ▼
-   ┌──────────────────┐  ┌──────────┐  ┌──────────────────┐ ┌────────────────┐
-   │ ValidatorClient  │  │ Epoch    │  │ CheckpointBuilder│ │ Sequencer      │
-   │  (owns keys,     │  │ Cache    │  │ (forked world    │ │ Publisher      │
-   │   HA signer,     │  │ (proposer│  │  state, per-block│ │ (Multicall3    │
-   │   signs the      │  │  +       │  │  execution via   │ │  L1 tx, with   │
-   │   proposals)     │  │  comm.)  │  │  PublicProcessor)│ │  pre-checks)   │
-   └──────────────────┘  └──────────┘  └──────────────────┘ └────────────────┘
-            │                              │                        │
-            │  block + checkpoint          │ pull txs               │
-            │  proposals over p2p          ▼                        ▼
-            │                          ┌──────────┐           ┌────────────┐
-            ├────────────────────────► │   Tx     │           │ L1 Rollup  │
-            │                          │ Provider │           │ Contract   │
-            │  push blocks to          └──────────┘           └────────────┘
-            ▼  proposed chain
-   ┌──────────────────┐
-   │     Archiver     │
-   │   (l2 tips,      │
-   │    addBlock)     │
-   └──────────────────┘
+```mermaid
+flowchart TD
+    Seq["<b>Sequencer</b><br/>state machine, one slot at a time<br/>work() → prepareCheckpointProposal() → CheckpointProposalJob"]
+
+    VC["<b>ValidatorClient</b><br/>operator keys, HA signer<br/>signs block + checkpoint proposals"]
+    EC["<b>EpochCache</b><br/>proposer + committee lookup"]
+    CB["<b>CheckpointBuilder</b><br/>forked world state<br/>per-block execution via PublicProcessor"]
+    Pub["<b>SequencerPublisher</b><br/>Multicall3 L1 tx<br/>with preChecks"]
+
+    P2P["<b>p2pClient</b>"]
+    TP["<b>TxProvider</b><br/>(tx pool)"]
+    Arc["<b>Archiver</b><br/>L2 tips, addBlock"]
+    L1["<b>L1 Rollup Contract</b>"]
+
+    Seq -->|signs proposals| VC
+    Seq -->|proposer / committee| EC
+    Seq -->|builds blocks| CB
+    Seq -->|enqueues actions| Pub
+
+    Seq -->|broadcast block + checkpoint proposals| P2P
+    Seq -->|push to proposed chain| Arc
+    CB -->|pull txs| TP
+    Pub -->|submit Multicall3| L1
 ```
 
 `SequencerClient.new(config, deps)` is the entrypoint and is constructed by the full node. It reads L1 constants (`l1GenesisTime`, `slotDuration`, `rollupManaLimit`) from the rollup contract, builds the publisher factory, validator client wiring, and timetable, then instantiates the `Sequencer`. See `src/client/sequencer-client.ts`.
@@ -114,17 +108,19 @@ The sequencer is a `TypedEventEmitter<SequencerEvents>`. The most useful events 
 | `pipelined-checkpoint-discarded`   | Pipelined parent failed to land; this slot's work is thrown away.     |
 | `checkpoint-error`                 | Catch-all: an exception escaped `work()`.                             |
 
-State enum (`src/sequencer/utils.ts`):
+State enum (`src/sequencer/utils.ts`). The happy-path slot cycle is:
 
 ```
-STOPPED → STOPPING → IDLE → SYNCHRONIZING → PROPOSER_CHECK
-       → INITIALIZING_CHECKPOINT
-       → (WAITING_FOR_TXS ↔ CREATING_BLOCK ↔ WAITING_UNTIL_NEXT_BLOCK)*
-       → ASSEMBLING_CHECKPOINT
-       → COLLECTING_ATTESTATIONS
-       → PUBLISHING_CHECKPOINT
-       → IDLE
+IDLE → SYNCHRONIZING → PROPOSER_CHECK
+     → INITIALIZING_CHECKPOINT
+     → (WAITING_FOR_TXS ↔ CREATING_BLOCK ↔ WAITING_UNTIL_NEXT_BLOCK)*
+     → ASSEMBLING_CHECKPOINT
+     → COLLECTING_ATTESTATIONS
+     → PUBLISHING_CHECKPOINT
+     → IDLE
 ```
+
+Lifecycle transitions sit outside the cycle: `start()` moves `STOPPED → IDLE`, and `stop()` moves the current state through `STOPPING → STOPPED`.
 
 ### CheckpointProposalJob
 
@@ -231,11 +227,11 @@ The configuration object is `SequencerConfig` (`src/sequencer/config.ts` + `src/
 | `minValidTxsPerBlock` | falls back to `minTxsPerBlock` | After execution, discard the block if fewer txs validated. |
 | `maxTxsPerBlock` / `SEQ_MAX_TX_PER_BLOCK` | unset | Hard per-block tx cap (capped at `maxTxsPerCheckpoint` at startup). |
 | `maxTxsPerCheckpoint` / `SEQ_MAX_TX_PER_CHECKPOINT` | unset | Total tx cap across the checkpoint. Enables redistribution when set. |
-| `maxBlocksPerCheckpoint` / `MAX_BLOCKS_PER_CHECKPOINT` | 24 | Hard ceiling beyond what the timetable allows. Also caps the `indexWithinCheckpoint` accepted on inbound block proposals. |
+| `maxBlocksPerCheckpoint` / `MAX_BLOCKS_PER_CHECKPOINT` | 24 | Absolute ceiling on blocks per checkpoint, applied on top of the timetable's `maxNumberOfBlocks`. Also caps the `indexWithinCheckpoint` accepted on inbound block proposals. |
 | `maxL2BlockGas` / `SEQ_MAX_L2_BLOCK_GAS` | unset | Per-block mana cap, capped at `rollupManaLimit`. |
 | `maxDABlockGas` / `SEQ_MAX_DA_BLOCK_GAS` | unset | Per-block DA gas cap, capped at `MAX_PROCESSABLE_DA_GAS_PER_CHECKPOINT`. |
 | `perBlockAllocationMultiplier` / `SEQ_PER_BLOCK_ALLOCATION_MULTIPLIER` | 1.2 | Multiplier passed to the checkpoint builder so early blocks can use slightly more than their even share. |
-| `redistributeCheckpointBudget` / `SEQ_REDISTRIBUTE_CHECKPOINT_BUDGET` | true | Legacy flag. Redistribution is always on during proposal building. |
+| `redistributeCheckpointBudget` / `SEQ_REDISTRIBUTE_CHECKPOINT_BUDGET` | true | Legacy flag, kept for back-compat. Has no effect on proposal building — redistribution is always on. |
 
 ### Timing
 
@@ -246,7 +242,7 @@ The configuration object is `SequencerConfig` (`src/sequencer/config.ts` + `src/
 | `attestationPropagationTime` / `SEQ_ATTESTATION_PROPAGATION_TIME` | 2 s | One-way p2p estimate fed to the timetable. |
 | `l1PublishingTime` / `SEQ_L1_PUBLISHING_TIME_ALLOWANCE_IN_SLOT` | full L1 slot | Time reserved for the L1 tx to land. |
 | `sequencerPollingIntervalMS` / `SEQ_POLLING_INTERVAL_MS` | 500 | Work-loop tick rate. |
-| `enableProposerPipelining` / `SEQ_ENABLE_PROPOSER_PIPELINING` | false | When true, the sequencer builds for `slot + 1`. The flag lives in shared `PipelineConfig` and is read by `EpochCache`, not by the sequencer directly. |
+| `enableProposerPipelining` / `SEQ_ENABLE_PROPOSER_PIPELINING` | false | When true, the sequencer builds for `slot + 1`. The flag lives in shared `PipelineConfig`; both the sequencer's timetable and `EpochCache`'s proposer-of-next-slot lookup read it. |
 
 ### Behavior
 
@@ -258,8 +254,8 @@ The configuration object is `SequencerConfig` (`src/sequencer/config.ts` + `src/
 | `coinbase` / `COINBASE` | proposer addr | Recipient of block rewards. |
 | `feeRecipient` / `FEE_RECIPIENT` | proposer addr | Recipient of tx fees. |
 | `governanceProposerPayload` / `GOVERNANCE_PROPOSER_PAYLOAD_ADDRESS` | unset | Payload signaled in the governance vote each slot. |
-| `secondsBeforeInvalidatingBlockAsCommitteeMember` | 144 | When *not* the proposer, committee members may invalidate a stuck checkpoint after this many seconds into the slot. |
-| `secondsBeforeInvalidatingBlockAsNonCommitteeMember` | 432 | Same for any node — last resort. |
+| `secondsBeforeInvalidatingBlockAsCommitteeMember` / `SEQ_SECONDS_BEFORE_INVALIDATING_BLOCK_AS_COMMITTEE_MEMBER` | 144 | When *not* the proposer, committee members may invalidate a stuck checkpoint after this many seconds into the slot. |
+| `secondsBeforeInvalidatingBlockAsNonCommitteeMember` / `SEQ_SECONDS_BEFORE_INVALIDATING_BLOCK_AS_NON_COMMITTEE_MEMBER` | 432 | Same for any node — last resort. |
 
 The full list (including test/fault-injection hooks like `pauseProposingForSlots` and `skipPublishingCheckpointsPercent`) lives in `src/config.ts`.
 

--- a/yarn-project/sequencer-client/README.md
+++ b/yarn-project/sequencer-client/README.md
@@ -1,45 +1,305 @@
 # Sequencer Client
 
-The sequencer is a module responsible for creating and publishing new rollup blocks. This involves fetching txs from the P2P pool, ordering them, executing any public functions, running them through the rollup circuits, assembling the L2 block, and posting it to the L1 rollup contract along with any contract deployment public data.
+The sequencer client is the proposer-side counterpart to the [validator client](../validator-client/README.md): it builds checkpoints, broadcasts the block and checkpoint proposals that validators attest to, and publishes the resulting checkpoint to L1. It runs on any node whose configured validator address has been selected as proposer for the current (or next) slot.
 
-The client itself is implemented as a continuous loop. After being started, it polls the P2P pool for new txs, assembles a new block if any is found, and goes back to sleep. On every new block assembled, it modifies the world state database to reflect the txs processed, but these changes are only committed once the world state synchronizer sees the new block on L1.
+A single instance owns the entire proposer flow for one slot: deciding whether to propose, building several L2 blocks one after another, signing them, gossiping them, collecting attestations from the committee, and submitting the final checkpoint to L1 in one Multicall3 transaction together with governance and slashing votes.
 
-## Components
+The sequencer does **not** decide what is in the next block on its own. It composes the work of several other subsystems: the [tx pool](../p2p/README.md) supplies transactions, the [validator client](../validator-client/README.md) owns operator keys and contains the `CheckpointBuilder` that actually executes them, the [archiver](../archiver/README.md) provides the L2 chain state needed to anchor each block, the [epoch cache](../epoch-cache/README.md) answers proposer/committee lookups, and the [slasher](../slasher/README.md) supplies offenses to vote on.
 
-_What components are used to build a sequencer client._
+## Key Concepts
 
-- The **block builder** is responsible for assembling an L2 block out of a set of processed transactions (we say a tx has been _processed_ if all its function calls have been executed). This involves running the txs through the base, merge, and rollup circuits, updating the world state trees, and building the L2 block object.
+### Slots, Blocks, and Checkpoints
 
-- The **prover** generates proofs for every circuit used. For the time being, no proofs are being actually generated, so the only implementation is an empty one.
+The Aztec consensus design splits each Aztec slot into multiple L2 blocks. This is the design originally called [building in chunks](https://github.com/AztecProtocol/engineering-designs/blob/main/docs/building-in-chunks/index.md).
 
-- The **publisher** deals with sending L1 transactions to the rollup and contract deployment emitter contracts. It is responsible for assembling the Ethereum tx, choosing reasonable gas settings, and monitoring the tx until it gets mined. Note that the current implementation does not handle unstable network conditions (gas price spikes, reorgs, etc).
+- **Slot** — a fixed time window (e.g. 72 s) during which one proposer is allowed to build.
+- **Block** — a single batch of transactions, executed and validated as a unit, with its own header.
+- **Checkpoint** — the collection of all blocks built within one slot. The proposer commits to a checkpoint on L1 by submitting a `propose` transaction containing the aggregated header, the blocks' tx effects (as blobs), and the committee attestations.
+- **Sub-slot** — a fixed-duration window within the slot during which one block is built. Sub-slots are equal in length and have deadlines fixed relative to the start of the slot.
 
-- The **public processor** executes any public function calls in the transactions. Unlike private function calls, which are resolved in the client, public functions require access to the latest data trees, so they are executed by the sequencer, much like in any non-private L2.
+Several blocks per slot is intentional: it amortizes the fixed L1 cost of a checkpoint over more transactions, and it lets the rest of the network reach a usable state-root much sooner than the full L1 confirmation latency.
 
-- The **simulator** is an interface to the wasm implementations of the circuits used by the sequencer.
+### Proposed vs Checkpointed Chain
 
-- The **sequencer** pulls txs from the P2P pool, orchestrates all the components above to assemble and publish a block, and updates the world state database.
+There are two tips the sequencer cares about:
 
-## Circuits
+- The **proposed chain** is the set of blocks that have been broadcast over p2p but not yet committed to L1. Both the sequencer and validators push these blocks into the archiver so the rest of the node can serve them.
+- The **checkpointed chain** is the set of checkpoints that have landed on L1, recovered from `CheckpointProposed` events.
 
-_What circuits does the sequencer depend on._
+Within a slot, the proposer adds blocks to the proposed chain as it goes. Only the last block within the slot is bundled with a `CheckpointProposal` that committee members attest to; intermediate blocks are accepted onto the proposed chain by virtue of the proposer's signature alone, and every node that wants to follow the proposed chain re-executes them. See the [validator client README](../validator-client/README.md) for the consumer side.
 
-- The **public circuit** is responsible for proving the execution of Brillig (public function bytecode). At the moment, we are using a fake version that actually runs ACIR (intermediate representation for private functions) and does not emit any proofs.
+### Proposer Pipelining
 
-- The **public kernel circuit** then validates the output of the public circuit, and outputs a set of changes to the world state in the same format as the private kernel circuit, meaning we get a standard representation for all txs, regardless of whether public or private functions (or both) were run. The kernel circuits are run iteratively for every recursive call in the transaction.
+The legacy ("non-pipelined") flow has the proposer for slot `N` build, attest, and publish inside slot `N`. The proposer spends most of `N` collecting attestations and waiting for the L1 transaction to be mined, leaving a long idle window. Pipelining, [proposed in this discussion](https://github.com/AztecProtocol/governance/discussions/8), removes that idle window: the proposer for slot `N` builds blocks during slot `N - 1`, finishes attestation collection before the slot boundary, and submits the L1 transaction at the start of slot `N`.
 
-- The **base rollup circuit** aggregates the changes from two txs (more precisely, the outputs from their kernel circuits once all call stacks are emptied) into a single output.
+Pipelining shifts the work like this:
 
-- The **merge rollup circuit** aggregates two outputs from base rollup circuits into a single one. This circuit is executed recursively until only two outputs are left. This setup means that an L2 block needs to contain always a power-of-two number of txs; if there are not enough, then empty txs are added.
+| Phase                              | Non-pipelined | Pipelined        |
+| ---------------------------------- | ------------- | ---------------- |
+| Block building                     | slot `N`      | slot `N - 1`     |
+| Last-block re-execution            | slot `N`      | slot `N - 1`     |
+| Attestation collection             | slot `N`      | slot `N - 1` *   |
+| L1 submission                      | slot `N`      | slot `N`         |
 
-- The **root rollup circuit** consumes two outputs from base or merge rollups and outputs the data to assemble an L2 block. The L1 rollup contract then verifies the proof from this circuit, which implies that all txs included in it were correct.
+\* The pipelined timing model reserves enough end-of-slot budget for attestations to be in hand by the slot boundary, but the enforced deadline (`checkpointAttestationDeadline`) actually extends to `2 * aztecSlotDuration - l1PublishingTime`, so a late attestation can still spill into the target slot.
+
+In practice, "non-pipelined mode" is being removed; this README treats pipelining as the default. The toggle still exists (`enableProposerPipelining`) because `EpochCache` consults it when looking up the proposer for the next L1 slot — when pipelining is enabled, the sequencer asks the cache for the proposer of `slot + 1` rather than `slot`.
+
+The pipelining flow introduces two failure modes that block building has to handle:
+
+- **Pipeline depth** is bounded to 2 (`checkpointNumber ≤ confirmedCheckpoint + 2`). Building further ahead would require trusting more in-flight parent proposals than the design allows.
+- **Pipelined parent invalidation**: if the parent checkpoint we built on top of fails to land cleanly on L1, the next proposer's work is discarded (`pipelined-checkpoint-discarded` event) and an `invalidate` request is enqueued for the parent.
+
+## Architecture
+
+```
+       ┌──────────────────────────────────────────────────────────────┐
+       │                          Sequencer                           │
+       │              (state machine, one slot at a time)             │
+       │                                                              │
+       │   work() ──► prepareCheckpointProposal() ──► proposal job    │
+       └─────┬────────────────┬──────────────────┬──────────────────┬─┘
+             │                │                  │                  │
+             ▼                ▼                  ▼                  ▼
+   ┌──────────────────┐  ┌──────────┐  ┌──────────────────┐ ┌────────────────┐
+   │ ValidatorClient  │  │ Epoch    │  │ CheckpointBuilder│ │ Sequencer      │
+   │  (owns keys,     │  │ Cache    │  │ (forked world    │ │ Publisher      │
+   │   HA signer,     │  │ (proposer│  │  state, per-block│ │ (Multicall3    │
+   │   signs the      │  │  +       │  │  execution via   │ │  L1 tx, with   │
+   │   proposals)     │  │  comm.)  │  │  PublicProcessor)│ │  pre-checks)   │
+   └──────────────────┘  └──────────┘  └──────────────────┘ └────────────────┘
+            │                              │                        │
+            │  block + checkpoint          │ pull txs               │
+            │  proposals over p2p          ▼                        ▼
+            │                          ┌──────────┐           ┌────────────┐
+            ├────────────────────────► │   Tx     │           │ L1 Rollup  │
+            │                          │ Provider │           │ Contract   │
+            │  push blocks to          └──────────┘           └────────────┘
+            ▼  proposed chain
+   ┌──────────────────┐
+   │     Archiver     │
+   │   (l2 tips,      │
+   │    addBlock)     │
+   └──────────────────┘
+```
+
+`SequencerClient.new(config, deps)` is the entrypoint and is constructed by the full node. It reads L1 constants (`l1GenesisTime`, `slotDuration`, `rollupManaLimit`) from the rollup contract, builds the publisher factory, validator client wiring, and timetable, then instantiates the `Sequencer`. See `src/client/sequencer-client.ts`.
+
+### Sequencer (work loop)
+
+`Sequencer` (`src/sequencer/sequencer.ts`) drives one slot at a time using a `RunningPromise` that ticks every `sequencerPollingIntervalMS` (default 500 ms). On each tick it:
+
+1. Asks the [epoch cache](../epoch-cache/README.md) for the slot at the next L1 block, and, when pipelining, for the *target* slot (`slot + 1`). Building runs during the wall-clock slot; the checkpoint commits to the target slot.
+2. Calls `prepareCheckpointProposal`, which:
+   - Dedupes against the last slot we tried to propose for.
+   - Runs `checkSync()` — verifies world-state, l2 block source, p2p, and l1-to-l2 message source agree on the parent tip.
+   - Checks the escape hatch (governance-controlled freeze) for the target epoch.
+   - Calls `checkCanPropose(targetSlot)` to verify one of our configured validator addresses is the elected proposer.
+   - Falls back to `considerInvalidatingCheckpoint()` if we are *not* the proposer but a previous checkpoint is stuck with bad attestations and the slot is far enough along to invalidate (`secondsBeforeInvalidatingBlockAsCommitteeMember` / `…AsNonCommitteeMember`).
+   - Refuses to build further than two checkpoints ahead of the confirmed tip when pipelining.
+   - Builds L1 `eth_call` simulation overrides (so `Rollup.canProposeAt` sees the expected pending tip when we are building on a pipelined parent or invalidating).
+   - Calls `publisher.canProposeAt(...)` — if L1 rejects the simulated propose, abort early.
+3. Constructs a `CheckpointProposalJob` and calls `.execute()`, parking the returned `pendingL1Submission` on the sequencer so `stop()` can await it without re-entering the loop.
+
+Each state transition flows through `setState()`, which calls `timetable.assertTimeLeft()`. If the slot has advanced past the deadline for the new state, this throws `SequencerTooSlowError` and the slot is abandoned.
+
+The sequencer is a `TypedEventEmitter<SequencerEvents>`. The most useful events are:
+
+| Event                              | When emitted                                                          |
+| ---------------------------------- | --------------------------------------------------------------------- |
+| `state-changed`                    | Every `setState()` call.                                              |
+| `preparing-checkpoint`             | After the canPropose check decides to build, before L1 simulation.    |
+| `block-proposed`                   | After `buildSingleBlock` succeeds, before sign + archiver push.       |
+| `checkpoint-published`             | After the L1 submission lands.                                        |
+| `checkpoint-publish-failed`        | Multicall3 tx failed or expired.                                      |
+| `pipelined-checkpoint-discarded`   | Pipelined parent failed to land; this slot's work is thrown away.     |
+| `checkpoint-error`                 | Catch-all: an exception escaped `work()`.                             |
+
+State enum (`src/sequencer/utils.ts`):
+
+```
+STOPPED → STOPPING → IDLE → SYNCHRONIZING → PROPOSER_CHECK
+       → INITIALIZING_CHECKPOINT
+       → (WAITING_FOR_TXS ↔ CREATING_BLOCK ↔ WAITING_UNTIL_NEXT_BLOCK)*
+       → ASSEMBLING_CHECKPOINT
+       → COLLECTING_ATTESTATIONS
+       → PUBLISHING_CHECKPOINT
+       → IDLE
+```
+
+### CheckpointProposalJob
+
+`CheckpointProposalJob` (`src/sequencer/checkpoint_proposal_job.ts`) is the per-slot unit of work. It owns the lifecycle from "we have decided to propose" through "the L1 transaction has been submitted". The contract is:
+
+- `execute()` returns once the checkpoint has been broadcast over p2p (or has failed before that). The L1 submission runs in the background as `pendingL1Submission`.
+- All work scheduled on the publisher (governance vote, slashing actions, propose, invalidate) is enqueued early and then flushed together in a single Multicall3 transaction.
+
+Inside `execute()`:
+
+1. **Vote enqueueing.** `CheckpointVoter.enqueueVotes()` signs and enqueues the governance and slashing vote requests up front. Even if block-building fails, these still go out in the final Multicall3 — they are the proposer's duty for the slot.
+2. **`proposeCheckpoint()`** (blocking, returns a `CheckpointProposal`):
+   - Transitions to `INITIALIZING_CHECKPOINT`. If there is a pending invalidation, enqueue it.
+   - Builds **pipelined-parent simulation overrides**: when building on top of a parent that hasn't landed on L1 yet, the fee-asset price modifier must be computed against the parent fee header we predicted (not the L1 one), so all in-flight checkpoints in the pipeline agree on the same modifier.
+   - Asks the global variables builder for the slot's `CheckpointGlobalVariables` (`coinbase`, `feeRecipient`, `timestamp`, `gasFees`, `chainId`, `version`, `slotNumber`). These are shared across every block within the checkpoint — only `blockNumber` increments.
+   - Computes `inHash` from the L1→L2 messages for the checkpoint, and collects `previousCheckpointOutHashes` for prior checkpoints in the same epoch.
+   - Forks world state at the parent (`closeDelayMs: 12 s`) and asks `FullNodeCheckpointsBuilder` for a `CheckpointBuilder` bound to that fork.
+   - Runs `buildBlocksForCheckpoint()` — the per-block loop, described below.
+   - Transitions to `ASSEMBLING_CHECKPOINT`, asks the builder to `completeCheckpoint()`, validates it against the configured caps, and asks the validator client to sign the `CheckpointProposal` (which bundles the final block proposal so the two travel together).
+   - Broadcasts the `CheckpointProposal` via p2p.
+3. **Attestation collection** (`waitForAttestationsAndEnqueueSubmissionAsync`) runs in the background:
+   - Transitions to `COLLECTING_ATTESTATIONS`. Reads the committee from `EpochCache`, computes the quorum (`2/3 + 1`), and waits for that many attestations on p2p. The validator client adds the proposer's own signature.
+   - If pipelining: `waitForValidParentCheckpointOnL1()` waits for the archiver to confirm the parent we built on top of has landed on L1 with matching hash and valid attestations. If not, the work is dropped (`pipelined-checkpoint-discarded`) and we enqueue an invalidation for the parent so the next proposer doesn't repeat the same mistake.
+   - Computes `submitAfter`: `getTimestampForSlot(targetSlot)` when pipelining (so the Multicall3 mines inside the target slot — EIP-712 signatures are bound to a slot and would silently fail if mined outside it), otherwise "now".
+   - Calls `publisher.sendRequestsAt(submitAfter)`, which sleeps until the deadline, re-runs each request's `preCheck` against fresh L1 state, and submits the bundled Multicall3.
+
+### Per-block loop (`buildBlocksForCheckpoint`)
+
+The per-block loop is the heart of the building flow:
+
+```
+loop:
+  timing = timetable.canStartNextBlock(secondsIntoSlot)
+  if !timing.canStart:                       break
+  if blocksBuilt >= maxBlocksPerCheckpoint:  break
+
+  state = WAITING_FOR_TXS
+  result = checkpointBuilder.buildBlock(
+              pendingTxs, blockNumber, timestamp,
+              { maxTransactions, maxBlockGas, deadline,
+                minValidTxs, maxBlocksPerCheckpoint, perBlockAllocationMultiplier })
+
+  if result is 'insufficient-txs' or 'insufficient-valid-txs':
+    if isLastBlock or no deadline:           break
+    else:                                    continue (try next sub-slot)
+  if result is error:                        halt
+
+  blockProposal = validatorClient.createBlockProposal(block)
+  archiver.addBlock(block)                   // push to proposed chain
+  if not timing.isLastBlock:
+    p2pClient.broadcastProposal(blockProposal)
+  else:
+    blockPendingBroadcast = blockProposal    // shipped with the CheckpointProposal
+
+  state = WAITING_UNTIL_NEXT_BLOCK
+  waitUntilNextSubSlot(timing.deadline)
+```
+
+The deadlines passed to `CheckpointBuilder.buildBlock` are absolute timestamps (`slotStart + timing.deadline`). The builder uses these as hard caps on tx execution, so a slow block cannot eat into the next sub-slot.
+
+`maxBlocksPerCheckpoint` (the timetable's `maxNumberOfBlocks`) and `perBlockAllocationMultiplier` (default 1.2) are passed in opts so that the builder can redistribute the remaining checkpoint budget (L2 gas, DA gas, blob fields, tx count) across the remaining blocks. See [validator-client/README.md § Block Building Limits](../validator-client/README.md#block-building-limits) for the redistribution math; the sequencer only sets the inputs.
+
+### Timetable
+
+`SequencerTimetable` (`src/sequencer/timetable.ts`) is a thin wrapper around `CheckpointTiming` (from `@aztec/stdlib/timetable`). It owns two responsibilities:
+
+- **Sub-slot scheduling**: `canStartNextBlock(secondsIntoSlot)` finds the next sub-slot with at least `minExecutionTime` remaining and returns its deadline and whether it is the last sub-slot. If we are running late, sub-slots are skipped; we never start a block we cannot finish.
+- **Per-state deadlines**: `getMaxAllowedTime(state)` returns the latest seconds-into-slot value a state is allowed to be entered; `assertTimeLeft()` enforces it.
+
+See [`src/sequencer/README.md`](src/sequencer/README.md) for the full timing model, including the pipelining math and the failure-mode walkthroughs.
+
+### SequencerPublisher
+
+`SequencerPublisher` (`src/publisher/sequencer-publisher.ts`) translates "I want to propose a checkpoint" into "submit this Multicall3 transaction to L1". It maintains an ordered queue of `RequestWithExpiry` entries — each one has a label (`propose`, `invalidate-by-*`, `governance-signal`, `vote-offenses`, `execute-slash`), a `preCheck` callback, and an ABI-encoded call. The queue is sorted so invalidations go first and proposes precede votes.
+
+Key entry points:
+
+- `canProposeAt(archive, msgSender, simulationOverridesPlan?)` — eth_call simulation of `Rollup.canProposeAt`. The sequencer runs this before deciding to build.
+- `enqueueProposeCheckpoint(checkpoint, attestations, attestationsSignature, opts)` — adds the propose call, with a `preCheck` that re-validates the proposal against real L1 state when it is finally sent (catches drift between build time and submit time).
+- `enqueueInvalidateCheckpoint`, `enqueueGovernanceCastSignal`, `enqueueSlashingActions` — the rest of the actions a proposer may bundle.
+- `sendRequests()` — immediately flushes the queue as one Multicall3 transaction.
+- `sendRequestsAt(submitAfter)` — sleeps (cancellable) until `submitAfter`, runs each request's `preCheck` (dropping those that fail), and then calls `sendRequests()`, which filters expired requests, sorts the remainder, and submits one Multicall3. Pipelining is implemented entirely by passing `getTimestampForSlot(targetSlot)` here.
+
+`SequencerPublisherFactory` produces one publisher per attempt, wrapping an L1 publisher (EOA + `L1TxUtils`) leased from `PublisherManager`. Leases free the publisher when the job completes so multiple validator addresses on the same node can take turns without conflicts.
+
+### Other components
+
+| Component | File | Responsibility |
+| --- | --- | --- |
+| `CheckpointVoter` | `src/sequencer/checkpoint_voter.ts` | Signs and enqueues governance/slashing votes. Used by both the job and the "vote even though we can't propose" fallbacks. |
+| `GlobalVariableBuilder` | `src/global_variable_builder/` | Computes `CheckpointGlobalVariables` and predicts the per-slot fee asset price modifier. See its [README](src/global_variable_builder/README.md). |
+| `L1TxFailedStore` | `src/publisher/l1_tx_failed_store/` | Persists actions that returned a revert reason so they aren't retried in the same form on the next slot. |
+| `ChainStateOverrides` | `src/sequencer/chain_state_overrides.ts` | Builds the L1 `eth_call` overrides used during the pipelined parent + invalidation simulations. |
+
+## Configuration
+
+The configuration object is `SequencerConfig` (`src/sequencer/config.ts` + `src/publisher/config.ts`). The options that most directly affect block building are:
+
+### Block budgets
+
+| Option / env var | Default | Purpose |
+| --- | --- | --- |
+| `minTxsPerBlock` / `SEQ_MIN_TX_PER_BLOCK` | 1 | Wait for at least this many txs before starting a block. |
+| `minValidTxsPerBlock` | falls back to `minTxsPerBlock` | After execution, discard the block if fewer txs validated. |
+| `maxTxsPerBlock` / `SEQ_MAX_TX_PER_BLOCK` | unset | Hard per-block tx cap (capped at `maxTxsPerCheckpoint` at startup). |
+| `maxTxsPerCheckpoint` / `SEQ_MAX_TX_PER_CHECKPOINT` | unset | Total tx cap across the checkpoint. Enables redistribution when set. |
+| `maxBlocksPerCheckpoint` / `MAX_BLOCKS_PER_CHECKPOINT` | 24 | Hard ceiling beyond what the timetable allows. Also caps the `indexWithinCheckpoint` accepted on inbound block proposals. |
+| `maxL2BlockGas` / `SEQ_MAX_L2_BLOCK_GAS` | unset | Per-block mana cap, capped at `rollupManaLimit`. |
+| `maxDABlockGas` / `SEQ_MAX_DA_BLOCK_GAS` | unset | Per-block DA gas cap, capped at `MAX_PROCESSABLE_DA_GAS_PER_CHECKPOINT`. |
+| `perBlockAllocationMultiplier` / `SEQ_PER_BLOCK_ALLOCATION_MULTIPLIER` | 1.2 | Multiplier passed to the checkpoint builder so early blocks can use slightly more than their even share. |
+| `redistributeCheckpointBudget` / `SEQ_REDISTRIBUTE_CHECKPOINT_BUDGET` | true | Legacy flag. Redistribution is always on during proposal building. |
+
+### Timing
+
+| Option / env var | Default | Purpose |
+| --- | --- | --- |
+| `blockDurationMs` / `SEQ_BLOCK_DURATION_MS` | unset | Length of one sub-slot in ms. `undefined` falls back to single-block-per-slot mode (used by tests / sandbox). |
+| `enforceTimeTable` / `SEQ_ENFORCE_TIME_TABLE` | true | If false, deadlines are not enforced and a single block is built with unbounded time. |
+| `attestationPropagationTime` / `SEQ_ATTESTATION_PROPAGATION_TIME` | 2 s | One-way p2p estimate fed to the timetable. |
+| `l1PublishingTime` / `SEQ_L1_PUBLISHING_TIME_ALLOWANCE_IN_SLOT` | full L1 slot | Time reserved for the L1 tx to land. |
+| `sequencerPollingIntervalMS` / `SEQ_POLLING_INTERVAL_MS` | 500 | Work-loop tick rate. |
+| `enableProposerPipelining` / `SEQ_ENABLE_PROPOSER_PIPELINING` | false | When true, the sequencer builds for `slot + 1`. The flag lives in shared `PipelineConfig` and is read by `EpochCache`, not by the sequencer directly. |
+
+### Behavior
+
+| Option / env var | Default | Purpose |
+| --- | --- | --- |
+| `buildCheckpointIfEmpty` / `SEQ_BUILD_CHECKPOINT_IF_EMPTY` | false | Build and submit even when no txs are available. |
+| `publishTxsWithProposals` / `SEQ_PUBLISH_TXS_WITH_PROPOSALS` | false | Embed full transactions in p2p block proposals (DA fallback for validators). |
+| `fishermanMode` / `FISHERMAN_MODE` | false | Build internally for monitoring; never publish. |
+| `coinbase` / `COINBASE` | proposer addr | Recipient of block rewards. |
+| `feeRecipient` / `FEE_RECIPIENT` | proposer addr | Recipient of tx fees. |
+| `governanceProposerPayload` / `GOVERNANCE_PROPOSER_PAYLOAD_ADDRESS` | unset | Payload signaled in the governance vote each slot. |
+| `secondsBeforeInvalidatingBlockAsCommitteeMember` | 144 | When *not* the proposer, committee members may invalidate a stuck checkpoint after this many seconds into the slot. |
+| `secondsBeforeInvalidatingBlockAsNonCommitteeMember` | 432 | Same for any node — last resort. |
+
+The full list (including test/fault-injection hooks like `pauseProposingForSlots` and `skipPublishingCheckpointsPercent`) lives in `src/config.ts`.
+
+## Failure modes
+
+- **Not the proposer**: `checkCanPropose` returns false → no work done. If a previous checkpoint is stuck with invalid attestations and we are past the configured invalidation threshold, we fall through to `considerInvalidatingCheckpoint` and may still submit an invalidation tx.
+- **Out of sync**: `checkSync` fails → governance/slashing votes still go out via `tryVoteWhenSyncFails`, but no block is built.
+- **Insufficient txs in a sub-slot**: `CheckpointBuilder.buildBlock` returns `insufficient-txs`. The sub-slot is skipped without committing state; the next sub-slot retries. On the last sub-slot, if `buildCheckpointIfEmpty` is true, the block is still built with whatever is available (possibly zero txs).
+- **Sub-slot deadline exceeded**: `CheckpointBuilder` enforces the deadline and stops executing further txs. The block is finalized with whatever fit.
+- **Timetable deadline exceeded**: `assertTimeLeft` throws `SequencerTooSlowError`. The current slot is abandoned and the loop resets to `IDLE`.
+- **Pipelined parent fails on L1**: `waitForValidParentCheckpointOnL1` returns false. The whole proposal is discarded (`pipelined-checkpoint-discarded`), the parent is enqueued for invalidation, and the L1 submission for *this* checkpoint is not sent.
+- **L1 submission reverts or expires**: `checkpoint-publish-failed` is emitted with the individual action results so observability can break down which actions in the Multicall3 went through and which didn't.
+
+## Where to look first
+
+| Question | File |
+| --- | --- |
+| How does the work loop decide whether to propose? | `src/sequencer/sequencer.ts` → `prepareCheckpointProposal`, `checkCanPropose` |
+| How does a checkpoint get built block-by-block? | `src/sequencer/checkpoint_proposal_job.ts` → `proposeCheckpoint`, `buildBlocksForCheckpoint` |
+| How do sub-slot deadlines work? | `src/sequencer/timetable.ts` + `src/sequencer/README.md` |
+| How does an L1 transaction get scheduled and submitted? | `src/publisher/sequencer-publisher.ts` → `sendRequestsAt` |
+| How does pipelining wait for the parent to land? | `src/sequencer/checkpoint_proposal_job.ts` → `waitForValidParentCheckpointOnL1` |
+| How do governance and slashing votes get into the L1 tx? | `src/sequencer/checkpoint_voter.ts` |
+| How are fees predicted for the slot? | `src/global_variable_builder/README.md` |
+| How are full-node services wired together? | `src/client/sequencer-client.ts` |
 
 ## Development
 
-Start by running `bootstrap.sh` in the project root.
+Build, format, lint, and test from `yarn-project/`:
 
-To build the package, run `yarn build` in the root.
+```bash
+yarn workspace @aztec/sequencer-client build
+yarn workspace @aztec/sequencer-client test
+```
 
-To watch for changes, `yarn build:dev`.
+The integration tests of interest are:
 
-To run the tests, execute `yarn test`.
+- `src/sequencer/sequencer.test.ts` — work-loop behavior, escape-hatch and invalidation fallbacks.
+- `src/sequencer/checkpoint_proposal_job.test.ts` — full per-slot job, both pipelined and non-pipelined.
+- `src/sequencer/checkpoint_proposal_job.timing.test.ts` — sub-slot timing and skip behavior under simulated clock drift.
+- `src/sequencer/timetable.test.ts` — pure math against `CheckpointTiming`.
+- `src/publisher/sequencer-publisher.test.ts` — request ordering, `sendRequestsAt`, preCheck re-runs.

--- a/yarn-project/sequencer-client/src/sequencer/README.md
+++ b/yarn-project/sequencer-client/src/sequencer/README.md
@@ -1,600 +1,233 @@
 # Sequencer Timing Model
 
-The Aztec sequencer divides each slot into **fixed-duration sub-slots**. Each sub-slot has a pre-defined start and end time based on an initialization offset (how much time we expect syncing the previous slot will take), the configured block duration, and whether checkpoint finalization is paid for in the current slot or deferred under proposer pipelining.
+This document covers how the sequencer schedules its work within a slot. See the [package README](../../README.md) for the high-level architecture; this one focuses on the timing math and the state-machine deadlines.
 
-**Example: 72-second slot with 8-second sub-slots (non-pipelined)**
-
-```
-0s:  Slot starts
-0-2s: Sync + proposer check (fixed 2s offset)
-
-Sub-slot 1:  2s-10s  → Build Block 1, deadline at 10s
-Sub-slot 2:  10s-18s → Build Block 2, deadline at 18s
-Sub-slot 3:  18s-26s → Build Block 3, deadline at 26s
-Sub-slot 4:  26s-34s → Build Block 4, deadline at 34s
-Sub-slot 5:  34s-42s → Build Block 5 (last block), deadline at 42s
-Sub-slot 6:  42s-50s → Reserved for validators to re-execute Block 5
-
-42s:  Broadcast checkpoint with Block 5
-44s:  Validators receive proposal (2s propagation)
-44-52s: Validators re-execute Block 5 (8s)
-52s:  Validators send attestations
-54s:  Proposer receives attestations (2s propagation)
-54-55s: Finalize checkpoint (1s)
-55-67s: Publish to L1 (12s)
-72s:  Slot ends
-```
-
-Deadlines are fixed relative to slot start, not relative to when work actually completes. If you finish initialization at 1s instead of 2s, you get bonus time for Block 1. If you finish at 3s, you have less time. If you finish at 9s, you skip the first sub-slot altogether and start building for the second one.
-
----
+The model described here is for **proposer pipelining**, the standard mode in production. Non-pipelined scheduling existed historically and is in the process of being removed.
 
 ## Overview
 
-The Aztec sequencer operates in fixed-duration **slots** (typically 72 seconds). During each slot, a designated proposer builds multiple **blocks** containing transactions over multiple **sub-slots**. In the default mode, the same slot also reserves time to collect attestations for the resulting **checkpoint**, finalize it, and publish it to L1 Ethereum. When proposer pipelining is enabled, the slot budget for block building is larger because checkpoint finalization is deferred to the next target slot.
+Block production runs on three nested clocks:
 
-## Key Concepts
+- A **slot** is a fixed window (e.g. 72 s) during which one elected proposer is allowed to build.
+- A slot contains several equal-length **sub-slots** (e.g. 8 s). Each sub-slot owns the budget for one L2 block and has a deadline fixed relative to the slot start.
+- All blocks built within one slot make up one **checkpoint**, which is what eventually goes on L1.
 
-### Slot vs Block vs Checkpoint vs Sub-Slot
+Under pipelining, the proposer for slot `N` does its building inside slot `N - 1` ("build slot"). Slot `N` ("target slot") is only used to mine the L1 transaction. This shifts work like this:
 
-- **Slot**: A fixed time window (e.g., 72 seconds) during which a proposer can build blocks
-- **Block**: A single batch of transactions, executed and validated
-- **Checkpoint**: The collection of all blocks built in a slot, attested by validators and published to L1
-- **Sub-slot**: A fixed-duration time window within a slot (e.g., 8 seconds) during which a block should be built
+| Phase                          | When           |
+| ------------------------------ | -------------- |
+| Initialization                 | slot `N - 1`   |
+| Block building                 | slot `N - 1`   |
+| Checkpoint proposal broadcast  | slot `N - 1`   |
+| Last-block re-execution        | slot `N - 1`   |
+| Attestation collection         | slot `N - 1`   |
+| L1 submission                  | slot `N`       |
 
-In a typical configuration without pipelining, a 72-second slot contains:
-- 1 initialization period (2 seconds)
-- 5 block-building sub-slots (8 seconds each = 40 seconds)
-- 1 last validator re-execution sub-slot (8 seconds)
-- 1 attestation and publishing period (17 seconds)
+The wall-clock slot the sequencer is reasoning about ("build slot") and the slot the checkpoint commits to ("target slot") are always `N - 1` and `N` respectively.
 
-With proposer pipelining enabled, the last validator re-execution sub-slot is still reserved, but L1 publishing is deferred to the target slot and removed from the current slot budget. Attestation collection is completed inside the build slot itself, so the proposer can send the L1 transaction immediately at the target-slot boundary.
+## Sub-slots
 
-### The Fixed Sub-Slot Model
-
-Building multiple blocks per slot uses **fixed sub-slots** with predictable deadlines:
-
-1. **Equal-duration sub-slots**: All sub-slots have the same duration (`BLOCK_DURATION`)
-2. **Fixed deadlines**: Block N deadline = `initializationOffset + N * BLOCK_DURATION`
-3. **Last sub-slot reserved**: The final sub-slot is reserved for validators to re-execute the last block (no block is built during this sub-slot)
-4. **Skip if too late**: If we can't start a block with at least `MIN_EXECUTION_TIME` remaining before its deadline, we immediately start building in the next sub-slot
-
-## Timing Components
-
-Understanding slot timing requires knowing these time constants:
-
-| Component | Example Value | Purpose |
-|-----------|---------------|---------|
-| **Slot Duration** | 72s | Total time available for the entire checkpoint |
-| **Block Duration** | 8s | Duration of each sub-slot (time budget for building one block) |
-| **Initialization Offset** | 2s | Fixed estimate for sync + proposer check |
-| **Propagation Time** | 2s | Time for messages to travel across the P2P network (one-way) |
-| **Finalization Time** | 1s | Time to finalize checkpoint and prepare proposal message |
-| **L1 Publishing Time** | 12s | Time reserved for L1 transaction to land in an Ethereum block |
-| **Min Execution Time** | 3s | Minimum time needed to meaningfully build a block |
-
-These values are configurable but must satisfy certain constraints (explained below). Example values may differ from the ones in the source code.
-
-## Calculating Sub-Slots and Blocks
-
-Given a slot configuration, we calculate how many blocks fit using these formulas:
+Each sub-slot has a fixed start time and a fixed deadline, both relative to the slot start:
 
 ```
-checkpointFinalizationTime = propagationTime
-                           + propagationTime
-                           + finalizationTime
-                           + l1PublishingTime
-
-timeReservedAtEnd (normal mode) = blockDuration               (last sub-slot for reexecution)
-                                + checkpointFinalizationTime
-
-timeReservedAtEnd (pipelining) = assembleTime
-                               + 2 * propagationTime         (proposal out + attestations back)
-                               + blockDuration               (last-block re-execution)
-
-timeAvailableForBlocks = slotDuration - initializationOffset - timeReservedAtEnd
-
-numberOfBlocks = floor(timeAvailableForBlocks / blockDuration)
+subSlotStart[k]    = initializationOffset + (k - 1) * blockDuration
+subSlotDeadline[k] = initializationOffset + k * blockDuration
 ```
 
-**Example with typical values:**
-```
-timeReservedAtEnd = 8s + 2s + 2s + 1s + 12s = 25s
-timeAvailableForBlocks = 72s - 2s - 25s = 45s
-numberOfBlocks = floor(45s / 8s) = 5 blocks
-```
+with `k = 1, 2, ..., maxNumberOfBlocks`. Deadlines do **not** shift based on when the previous block finished. If a block finishes early, the sequencer waits for the next sub-slot to begin (so validators see a regular cadence). If it finishes late, the next block has correspondingly less time.
 
-This means:
-- Sub-slots 1-5: Build blocks 1-5
-- Sub-slot 6: Reserved for validator re-execution of block 5
-- After sub-slot 6: Attestation collection, finalization, and L1 publishing
+`canStartNextBlock(secondsIntoSlot)` walks the sub-slot list and returns the first one with at least `minExecutionTime` left before its deadline. Sub-slots that no longer have enough headroom are skipped entirely.
 
-**The same slot with proposer pipelining enabled:**
-```
-timeReservedAtEnd = 1s + 2*2s + 8s = 13s
-timeAvailableForBlocks = 72s - 2s - 13s = 57s
-numberOfBlocks = floor(57s / 8s) = 7 blocks
-```
+### Number of sub-slots
 
-The extra two block opportunities come from not charging the current slot for L1 publishing. The proposal broadcast, attestation round-trip, and last-block re-execution are now all reserved inside the build slot so that attestations are in hand at the slot boundary.
-
-### Pipelining Mode
-
-When proposer pipelining is enabled, the sequencer uses the current wall-clock slot to build the checkpoint for the **next target slot**, and finishes collecting attestations before the slot boundary so that L1 publishing can happen immediately at the target-slot boundary.
-
-It helps to think in terms of two different slots:
-
-- **Wall-clock slot N-1**: The sequencer initializes checkpoint `N`, builds its blocks, validators re-execute the last block, and attestations are gathered
-- **Target slot N**: The checkpoint is submitted to L1
-
-So the work is split like this:
-
-- **During slot N-1**: Initialization, block building, last-block re-execution, proposal broadcast, and attestation collection
-- **At the start of slot N**: The L1 transaction is submitted — attestations are already in hand
-
-In other words, pipelining moves **block production, block re-execution, proposal broadcast, and attestation collection** into the build slot, while **L1 submission** happens aligned with slot `N`. With default values (72s slot, 6s block, 2s p2p, 1s assemble), the last build-slot block finishes at `T = slotDuration - timeReservedAtEnd = 61s`, the proposer broadcasts the checkpoint at `T=62s` after `assembleTime=1s`, and attestations are in hand by `T=72s` (the slot boundary).
-
-**Example: building checkpoint 12 while wall-clock time is in slot 11**
-```
-Slot 11 (wall clock):
-- Build blocks that will make up checkpoint 12
-- Broadcast checkpoint 12 proposal
-- Validators re-execute the last block of checkpoint 12
-- Collect checkpoint 12 attestations (all complete before slot 11 ends)
-
-Slot 12 (target/submission slot):
-- Submit checkpoint 12 to L1 at the slot boundary
-```
-
-For timetable purposes:
-
-- `maxNumberOfBlocks` is computed by reserving assembly + round-trip p2p + last-block re-execution at the end of the slot
-- `initializeDeadline` no longer subtracts checkpoint finalization time; it only requires enough time for initialization and two execution windows
-
-In code, that means:
+The maximum number of buildable blocks per slot is:
 
 ```
-initializeDeadline (normal mode) =
-  slotDuration - initializationOffset - 2 * minExecutionTime - checkpointFinalizationTime
+timeReservedAtEnd      = checkpointAssembleTime
+                       + 2 * p2pPropagationTime    // proposal out + attestations back
+                       + blockDuration             // last-block re-execution
 
-initializeDeadline (pipelining) =
-  slotDuration - initializationOffset - 2 * minExecutionTime
+timeAvailableForBlocks = aztecSlotDuration
+                       - checkpointInitializationTime
+                       - timeReservedAtEnd
+
+maxNumberOfBlocks      = floor(timeAvailableForBlocks / blockDuration)
 ```
 
-The fixed sub-slot deadlines themselves do not change. Pipelining only changes how much of the slot is considered available for block building, and when the broadcast and attestation windows close.
+The reservation at the end of the slot is sized so that, on the happy path, attestations are in hand by the time the target slot starts. The enforced `COLLECTING_ATTESTATIONS` and `PUBLISHING_CHECKPOINT` deadlines are softer (see the deadline table below) and let a late attestation spill into the target slot. L1 publishing is **not** included in `timeReservedAtEnd` — that is paid for by the target slot.
 
-## The Sequencer's Work
+### Cooldown after the last sub-slot
 
-When elected as proposer for a slot, the sequencer performs these tasks:
+All `maxNumberOfBlocks` sub-slots build a block. The cooldown lives in the `timeReservedAtEnd` window that follows the last sub-slot:
 
-### 1. Initialization Phase
+- 1 × `checkpointAssembleTime` to assemble and sign the checkpoint,
+- 1 × `p2pPropagationTime` for the `CheckpointProposal` to reach the committee,
+- 1 × `blockDuration` for the committee to re-execute the last block,
+- 1 × `p2pPropagationTime` for attestations to come back.
 
-Before building any blocks, the sequencer must:
-- Verify it's the designated proposer
-- Check all subsystems are synced
-- Initialize checkpoint state
-- Prepare global variables
+These four windows total `checkpointAssembleTime + blockDuration + 2 * p2pPropagationTime`, exactly the `timeReservedAtEnd` formula above. The block built in the last sub-slot is *not* broadcast as a regular `BlockProposal`; the proposer holds it as `blockPendingBroadcast` so it travels bundled inside the `CheckpointProposal`.
 
-Note that the initialization phase has a **fixed time budget** (`initializationOffset`, typically 2s). This is an *estimate*, not a deadline. The sequencer will take as long as it needs for initialization, but the sub-slot deadlines remain fixed regardless.
+## Timing constants
 
-### 2. Block Building Loop
+These constants come from `@aztec/stdlib/timetable` (see `stdlib/src/timetable/index.ts`). Some are fixed across the network, some are inputs from configuration.
 
-The sequencer builds blocks in **fixed sub-slots** based on the configured block duration.
+| Constant                          | Source                                  | Typical value | Purpose                                              |
+| --------------------------------- | --------------------------------------- | ------------- | ---------------------------------------------------- |
+| `aztecSlotDuration`               | L1 rollup contract                      | 72 s          | Length of one Aztec slot.                            |
+| `ethereumSlotDuration`            | L1 rollup contract                      | 12 s          | Length of one Ethereum slot.                         |
+| `blockDuration`                   | `blockDurationMs` config                | 6–8 s         | Sub-slot length.                                     |
+| `checkpointInitializationTime`    | constant (`CHECKPOINT_INITIALIZATION_TIME`) | 1 s       | Estimated sync + proposer check time.                |
+| `checkpointAssembleTime`          | constant (`CHECKPOINT_ASSEMBLE_TIME`)   | 1 s           | Time to assemble and sign the checkpoint after the last block. |
+| `p2pPropagationTime`              | `attestationPropagationTime` config     | 2 s           | One-way p2p estimate (proposals, attestations).      |
+| `l1PublishingTime`                | `l1PublishingTime` config               | 12 s          | Time reserved for the L1 tx to land. Used by the target slot, not the build slot. |
+| `minExecutionTime`                | constant (`MIN_EXECUTION_TIME`)         | 2 s           | Minimum headroom to start a block.                   |
+| `initializationOffset`            | `=checkpointInitializationTime`         | 1 s           | Where sub-slot 1 starts.                             |
 
-#### Sub-slot deadline calculation
+## Deadlines
 
-Each sub-slot has a fixed start time and deadline:
+`SequencerTimetable.getMaxAllowedTime(state)` returns the latest second-into-slot a given state is allowed to be entered. `assertTimeLeft()` throws `SequencerTooSlowError` if the slot has already advanced past that deadline. Sub-slot scheduling is measured against the build slot (`slotNow`); state assertions, however, are measured against whichever slot `setState` was called with — for the publishing path that is the target slot, which is why the publishing deadline is allowed to exceed `aztecSlotDuration`.
 
-```
-subSlotStart[N] = initializationOffset + (N - 1) * blockDuration
-subSlotDeadline[N] = initializationOffset + N * blockDuration
-```
+| State                       | Max allowed time (seconds into build slot)                                  |
+| --------------------------- | --------------------------------------------------------------------------- |
+| `PROPOSER_CHECK`            | `initializeDeadline = aztecSlotDuration - (checkpointInitializationTime + 2*minExecutionTime)` |
+| `INITIALIZING_CHECKPOINT`   | same as `PROPOSER_CHECK`                                                    |
+| `WAITING_FOR_TXS`           | `initializeDeadline + checkpointInitializationTime`                         |
+| `CREATING_BLOCK`            | same as `WAITING_FOR_TXS`                                                   |
+| `WAITING_UNTIL_NEXT_BLOCK`  | same as `WAITING_FOR_TXS`                                                   |
+| `ASSEMBLING_CHECKPOINT`     | `aztecSlotDuration` (assembly completes by the build-slot boundary)         |
+| `COLLECTING_ATTESTATIONS`   | same as `ASSEMBLING_CHECKPOINT`                                             |
+| `PUBLISHING_CHECKPOINT`     | `2 * aztecSlotDuration - l1PublishingTime` (extends into the target slot)   |
 
-Where N is the sub-slot number (1-indexed).
+`ASSEMBLING_CHECKPOINT` and `COLLECTING_ATTESTATIONS` must be *entered* before the build-slot boundary; once entered, attestation collection itself has its own `checkpointAttestationDeadline = 2 * aztecSlotDuration - l1PublishingTime`, so a late attestation arriving after the boundary is still accepted. The publishing deadline extends into the target slot because that is when the L1 tx is actually submitted.
 
-**Example with 2s offset and 8s block duration:**
-```
-Sub-slot 1: starts at 2s,  deadline at 10s
-Sub-slot 2: starts at 10s, deadline at 18s
-Sub-slot 3: starts at 18s, deadline at 26s
-Sub-slot 4: starts at 26s, deadline at 34s
-Sub-slot 5: starts at 34s, deadline at 42s
-```
+## Example: 72 s slot, 8 s sub-slots
 
-#### Building a block
-
-For each sub-slot, the sequencer:
-
-1. **Checks if we can start**: If current time is past `deadline - MIN_EXECUTION_TIME`, skip this sub-slot, and start building the block as if it were on the next sub-slot
-2. **Waits for transactions** (if needed): Wait up to the deadline for minimum number of transactions
-3. **Builds block**: Execute transactions until the deadline of the sub-slot
-4. **Signs and broadcasts**: Finalize block and broadcast proposal to validators
-
-**Key point:** The deadline is **fixed** based on the sub-slot number, not based on when the previous block finished.
-
-Note that if a block finishes early, then the sequencer waits until the next sub-slot starts to maintain the regular interval. This prevents "rushing ahead" and keeps the timing predictable. Conversely, if the block finishes later than expected, this "eats into" the time budget for the next block.
-
-#### Waiting for minimum transactions
-
-Before building a block, the sequencer must ensure there are enough transactions in the mempool. This waiting phase has its own timing constraints:
-
-**Configuration:**
-- `minTxsPerBlock`: Minimum number of transactions required (configurable, e.g., 1-4)
-- Polling interval: 500ms (checks mempool every half-second)
-- Deadline: `blockDeadline - 1000ms` (must start building at least 1 second before the block deadline)
-
-**Behavior:**
-1. Check current pending transaction count
-2. If count >= `minTxsPerBlock`, proceed to build immediately
-3. If count < `minTxsPerBlock`, poll every 500ms until either:
-   - Enough transactions arrive (proceed to build)
-   - Deadline is reached (skip building this block)
-
-**Special cases:**
-- **Last block with empty checkpoint allowed**: If `buildCheckpointIfEmpty` is true and this is the last block, skip waiting and force build with 0+ transactions
-- **Non-enforced timetable**: If enforcement is disabled, exit immediately if not enough transactions (don't wait)
-
-**Example:**
-```
-Sub-slot 3 deadline: 26s
-Transaction wait deadline: 25s (26s - 1s)
-Current time: 20s
-
-20.0s: Check mempool → 2 txs (need 4)
-20.5s: Check mempool → 2 txs (need 4)
-21.0s: Check mempool → 4 txs (need 4) ✓ Start building!
-21-26s: Build block with those 4+ transactions
-```
-
-If the deadline (25s) is reached with only 2 transactions, the block is skipped and the sequencer moves to the next sub-slot.
-
-### 3. Last Block and Validator Re-execution
-
-The **last block** is built during the **penultimate sub-slot**. The final sub-slot is reserved for validators to re-execute the last block.
-
-**Why the last sub-slot is reserved:**
-
-Validators execute blocks **sequentially**. While the proposer builds Block N+1, validators are re-executing Block N (with a ~2s delay due to propagation). However, for the **last block**, there's no "Block N+1" to build while validators re-execute. We must wait for them to finish so they can attest.
-
-**Timeline for the last block:**
+With typical pipelining values:
 
 ```
-T:      Last block finishes building, checkpoint proposal broadcast
-        Last sub-slot begins (duration: blockDuration)
-T+2s:   Validators receive proposal (propagation delay)
-T+2s to T+2s+blockDuration: Validators re-execute last block
-T+2s+blockDuration: Validators finish re-execution, send attestations
-T+4s+blockDuration: Proposer receives attestations (propagation delay)
+checkpointInitializationTime = 1s
+blockDuration               = 8s
+checkpointAssembleTime      = 1s
+p2pPropagationTime          = 2s
+l1PublishingTime            = 12s
+
+timeReservedAtEnd      = 1 + 2*2 + 8       = 13s
+timeAvailableForBlocks = 72 - 1 - 13       = 58s
+maxNumberOfBlocks      = floor(58 / 8)     = 7
 ```
 
-**Example with 8s block duration:**
-```
-42s:    Block 5 finishes, checkpoint broadcast, sub-slot 6 starts
-44s:    Validators receive checkpoint (42s + 2s)
-44-52s: Validators re-execute Block 5 (8s)
-52s:    Validators send attestations
-54s:    Proposer receives attestations (52s + 2s)
-```
-
-Note that validators finish at `52s`, which is `2s` after the last sub-slot ends at `50s`. This is expected and accounted for in the `timeReservedAtEnd` calculation.
-
-### 4. Attestation Collection and L1 Publishing
-
-After the last block is built and validators have re-executed it:
-
-1. **Collect attestations**: Wait for validators to send their signatures (arrive at T+4s+blockDuration)
-2. **Finalize checkpoint**: Sign over attestations, assemble final checkpoint (1s)
-3. **Publish to L1**: Submit transaction to Ethereum (needs 12s to land)
-
-**Time reserved:** `2*propagationTime + finalizationTime + l1PublishingTime = 2s + 2s + 1s + 12s = 17s`
-
-In the non-pipelined path, this 17s comes after the last sub-slot, ensuring we have enough time to complete the checkpoint. If the sequencer receives the necessary attestations before the reserved time, the L1 tx is submitted earlier.
-
-With proposer pipelining enabled, this finalization budget is not charged against the current slot when calculating how many blocks fit. The checkpoint is instead queued for submission at the start of the target slot, so proposal broadcast, attestation gathering, and L1 submission happen in slot `N` while block building and block re-execution already happened in slot `N-1`.
-
-## Handling Timing Variations
-
-How does the sequencer timetable handle deviations from the expected times.
-
-### Fast Initialization
-
-**Scenario:** Initialization completes at 1s instead of 2s
+Seven sub-slots, all of which build a block:
 
 ```
-0-1s:   SYNCHRONIZING, PROPOSER_CHECK (1s actual, vs 2s estimate)
-1s:     Ready to build Block 1
-1-10s:  Build Block 1 (9s available vs 8s budgeted)
-10s:    Block 1 deadline
-10-18s: Build Block 2
+Sub-slot 1: starts 1s,  deadline 9s    (Block 1)
+Sub-slot 2: starts 9s,  deadline 17s   (Block 2)
+Sub-slot 3: starts 17s, deadline 25s   (Block 3)
+Sub-slot 4: starts 25s, deadline 33s   (Block 4)
+Sub-slot 5: starts 33s, deadline 41s   (Block 5)
+Sub-slot 6: starts 41s, deadline 49s   (Block 6)
+Sub-slot 7: starts 49s, deadline 57s   (Block 7 — held for the checkpoint proposal)
+
+57s:  Block 7 done, ASSEMBLING_CHECKPOINT (1s)
+58s:  CheckpointProposal broadcast
+60s:  Committee receives proposal (+2s p2p)
+60-68s: Committee re-executes Block 7
+68s:  Committee sends attestations
+70s:  Proposer has the quorum (+2s p2p)
+
+70-72s: Slack
+72s:  Build slot ends → L1 submission starts (target slot begins)
+84s:  L1 tx mined inside the target slot (+12s)
+```
+
+## Parallel execution: proposer vs committee
+
+While the proposer builds block `k+1`, the committee is re-executing block `k`. The pipeline keeps both sides busy except for the cooldown sub-slot.
+
+```
+Time | Proposer                     | Committee
+-----|------------------------------|--------------------------------------
+1s   | Start Block 1                | (idle)
+9s   | Finish Block 1, broadcast    |
+9s   | Start Block 2                |
+11s  |                              | Receive Block 1 (9s + 2s)
+     |                              | Re-execute Block 1
+17s  | Finish Block 2, broadcast    |
+17s  | Start Block 3                |
+19s  |                              | Finish Block 1 (11s + 8s)
+     |                              | Receive Block 2 (17s + 2s)
+     |                              | Re-execute Block 2
 ...
+49s  | Finish Block 6, broadcast    |
+49s  | Start Block 7 (last)         |
+51s  |                              | Receive Block 6 (49s + 2s)
+     |                              | Re-execute Block 6
+57s  | Finish Block 7 (held)        |
+     | ASSEMBLING_CHECKPOINT (1s)   |
+58s  | Broadcast CheckpointProposal |
+59s  |                              | Finish Block 6 (51s + 8s)
+60s  |                              | Receive Block 7 + Checkpoint (58s + 2s)
+     |                              | Re-execute Block 7
+68s  |                              | Send attestations (60s + 8s)
+70s  | Receive attestations         |
+70-72s| Slack                       |
+72s  | L1 tx submitted              |
+84s  | L1 tx mined                  |
 ```
 
-**Result:** Block 1 gets a bonus 1s of execution time. The extra time allows for more transactions or more complex execution.
+**Observations**:
 
-### Slow Initialization
+- Validators always lag the proposer by ~2 s (one p2p hop).
+- For the last block there is no `k+1` to build alongside; once the proposer broadcasts the `CheckpointProposal`, it just waits while the committee re-executes.
+- L1 publishing happens entirely inside the next slot and does not steal time from block building.
 
-**Scenario:** Initialization completes at 3s instead of 2s
+## Handling timing variations
 
-This may happen if the sequencer has a slow L1 RPC endpoint and syncing the previous checkpoint from L1 takes longer than expected.
+### Fast initialization (0.5 s instead of 1 s)
 
-```
-0-3s:   SYNCHRONIZING, PROPOSER_CHECK (3s actual, vs 2s estimate)
-3s:     Ready to build Block 1
-3-10s:  Build Block 1 (7s available vs 8s budgeted)
-10s:    Block 1 deadline
-10-18s: Build Block 2
-...
-```
+Sub-slot 1's deadline is still 9 s, so Block 1 gets a 0.5 s bonus before hitting its deadline. No structural change.
 
-**Result:** Block 1 has 1s less time (7s instead of 8s). Still enough time to build a block, just with fewer transactions or simpler execution.
+### Slow initialization (2 s instead of 1 s)
 
-### Very Slow Initialization
+Block 1 has 7 s of build time instead of 8 s. Still well above `minExecutionTime`, so the block still gets built. No sub-slots are skipped.
 
-**Scenario:** Initialization completes at 9s instead of 2s
+### Very slow initialization (8 s)
 
-While extremely unlikely, we still account for this scenario. We'd expect it to be related to faults to syncing blob data.
+Sub-slot 1's deadline (9 s) is closer than `minExecutionTime` (2 s), so it is skipped entirely. The first attempted block runs in sub-slot 2 with the usual budget. The checkpoint will have one fewer block.
 
-```
-0-9s:   SYNCHRONIZING, PROPOSER_CHECK (9s actual, vs 2s estimate)
-9s:     Ready to build Block 1
-        Check: Can we start Block 1 in sub-slot 1?
-        - Sub-slot 1 deadline: 10s
-        - Current time: 9s
-        - Time available: 1s
-        - MIN_EXECUTION_TIME: 3s
-        - 1s < 3s, so CANNOT use sub-slot 1
+### Block takes longer than its budget
 
-        Use sub-slot 2 instead:
-9s:     Start building Block 1 using sub-slot 2
-9-18s:  Build Block 1 (9s available vs 8s budgeted)
-18s:    Block 1 deadline (sub-slot 2)
-18-26s: Build Block 2 using sub-slot 3
-...
-```
+`CheckpointBuilder` enforces the deadline by stopping public-tx execution; in practice a block can only overrun by the time it takes to finalize the block (typically < 1 s). The next sub-slot starts as scheduled but with proportionally less headroom. If that headroom drops below `minExecutionTime`, the next sub-slot is skipped.
 
-**Result:** Sub-slot 1 is skipped entirely. We build 4 blocks instead of 5 (using sub-slots 2-5). Block 1 gets a bonus 1s of time.
+### Block finishes early
 
-### Block Takes Longer Than Expected
+The sequencer transitions to `WAITING_UNTIL_NEXT_BLOCK` and sleeps until the next sub-slot start. This keeps the cadence regular and gives validators predictable arrival times for re-execution.
 
-**Scenario:** Block 2 takes 9s instead of 8s
+### Block proposal returns insufficient txs
 
-This scenario should not happen since the sequencer forcefully stops the block builder at the given deadline, but we still consider it.
+The current sub-slot is dropped without committing anything. The loop retries on the next sub-slot. If `buildCheckpointIfEmpty` is true, the last sub-slot is forced through with whatever is available, including zero txs.
+
+### Build slot ends before attestations arrive
+
+`assertTimeLeft` will reject `PUBLISHING_CHECKPOINT` if the attestation deadline has passed; the slot is abandoned, and `checkpoint-publish-failed` is emitted. The `PUBLISHING_CHECKPOINT` deadline allows spillover into the target slot (`2 * aztecSlotDuration - l1PublishingTime`) precisely to absorb a small overrun.
+
+### Pipelined parent fails on L1
+
+Before submitting, the job calls `waitForValidParentCheckpointOnL1`. If the parent we built on top of did not land cleanly (wrong archive, missing attestations, etc.) the job discards its checkpoint, emits `pipelined-checkpoint-discarded`, and enqueues an invalidation for the parent so the next proposer doesn't get stuck on the same bad ancestor.
+
+## Configuration constraints
+
+`initializeDeadline` must be positive, so `aztecSlotDuration > checkpointInitializationTime + 2 * minExecutionTime`. With defaults that lower bound is 5 s, far below any realistic slot length.
+
+For multi-block production to make sense, `maxNumberOfBlocks ≥ 2`:
 
 ```
-10s:    Start building Block 2
-19s:    Block 2 finishes (1s late, deadline was 18s)
-19s:    Broadcast Block 2
-        Check: Can we start Block 3?
-        - Block 3 deadline: 26s
-        - Current time: 19s
-        - Time available: 7s
-        - MIN_EXECUTION_TIME: 3s
-        - 7s >= 3s, so CAN start Block 3
-
-19-26s: Build Block 3 (7s available vs 8s budgeted)
-26s:    Block 3 deadline
+aztecSlotDuration ≥ checkpointInitializationTime
+                  + 2 * blockDuration                // two blocks
+                  + checkpointAssembleTime
+                  + 2 * p2pPropagationTime
+                  + blockDuration                    // last-block re-execution window
 ```
 
-**Result:** Block 3 has less time (7s instead of 8s), but we still build it. The delay propagates but doesn't cascade uncontrollably.
+Block duration should be ≥ `minExecutionTime` (otherwise no sub-slot ever has enough headroom). `p2pPropagationTime` should be measured against the deployment's actual p2p latency: it directly determines how much of each slot is spent on the cooldown.
 
-**Extreme case:** If Block 2 finishes at 24s (6s late):
-```
-24s:    Block 2 finishes (6s late)
-        Check: Can we start Block 3 in sub-slot 3?
-        - Sub-slot 3 deadline: 26s
-        - Current time: 24s
-        - Time available: 2s
-        - MIN_EXECUTION_TIME: 3s
-        - 2s < 3s, so CANNOT use sub-slot 3
-
-        Use sub-slot 4 instead:
-24-34s: Build Block 3 using sub-slot 4 (10s available vs 8s budgeted)
-```
-
-**Result:** Sub-slot 3 is skipped, we build Block 3 using sub-slot 4 instead with bonus time.
-
-### Block Finishes Early
-
-**Scenario:** Block 2 finishes at 15s instead of 18s
-
-This can happen if the sequencer hits a block limit (number of txs, gas, size, etc) or runs out of available txs before the sub-slot deadline:
-
-```
-10-15s: Build Block 2 (5s used vs 8s budgeted)
-15s:    Block 2 finished
-15s:    Broadcast Block 2
-        Check: Should we start Block 3 now or wait?
-        - Next sub-slot starts at 18s
-        - Wait until 18s to maintain regular intervals
-
-15-18s: WAITING_UNTIL_NEXT_BLOCK
-18s:    Start building Block 3
-18-26s: Build Block 3
-```
-
-**Result:** We wait until the next sub-slot starts. This prevents "rushing ahead" and maintains consistent block intervals, which is better for validators who are re-executing blocks in parallel.
-
-## Parallel execution between Proposers and Validators
-
-A key aspect of this design is **parallel execution** between proposer and validators.
-
-### Timeline Example (8-second sub-slots)
-
-```
-Time | Proposer                    | Validators
------|----------------------------|---------------------------
-2s   | Start building Block 1     | (idle)
-10s  | Finish Block 1, broadcast  | (idle)
-10s  | Start building Block 2     |
-12s  |                            | Receive Block 1 (10s + 2s)
-     |                            | Start re-executing Block 1
-18s  | Finish Block 2, broadcast  |
-20s  |                            | Finish re-executing Block 1 (12s + 8s)
-     |                            | Receive Block 2 (18s + 2s)
-     |                            | Start re-executing Block 2
-18s  | Start building Block 3     |
-26s  | Finish Block 3, broadcast  |
-28s  |                            | Finish re-executing Block 2 (20s + 8s)
-     |                            | Receive Block 3 (26s + 2s)
-     |                            | Start re-executing Block 3
-...
-42s  | Finish Block 5, broadcast  |
-     | checkpoint proposal        |
-44s  |                            | Finish re-executing Block 4 (36s + 8s)
-     |                            | Receive Block 5 + checkpoint (42s + 2s)
-     |                            | Start re-executing Block 5
-42-54s| COLLECTING_ATTESTATIONS   |
-52s  |                            | Finish re-executing Block 5 (44s + 8s)
-     |                            | Send attestations
-54s  | Receive attestations       | (done)
-54-55s| ASSEMBLING_CHECKPOINT     |
-55s  | PUBLISHING_CHECKPOINT      |
-```
-
-**Key observations:**
-- Validators lag by ~2s (propagation delay)
-- While proposer builds Block N+1, validators re-execute Block N (parallel work)
-- For the last block, proposer waits while validators re-execute
-- The last sub-slot provides the time budget for this waiting period
-
-## Configuration Guidelines
-
-When configuring timing parameters, ensure these constraints are satisfied:
-
-### Minimum Slot Duration
-
-For a valid multi-block configuration without pipelining:
-```
-slotDuration >= initializationOffset
-              + blockDuration * 2                          (at least 2 blocks)
-              + blockDuration                              (last sub-slot)
-              + 2 * propagationTime                        (round-trip)
-              + finalizationTime                           (checkpoint finalization)
-              + l1PublishingTime                           (L1 publishing)
-```
-
-Simplified:
-```
-slotDuration >= initializationOffset + 3*blockDuration + 2*propagationTime + finalizationTime + l1PublishingTime
-```
-
-With proposer pipelining enabled, the same "at least 2 buildable blocks plus the final validator re-execution sub-slot" requirement becomes:
-```
-slotDuration >= initializationOffset + 3*blockDuration
-```
-
-**Example:**
-```
-slotDuration >= 2s + 3*8s + 2*2s + 1s + 12s = 2s + 24s + 4s + 1s + 12s = 43s
-```
-
-For a 72s slot, this leaves `72s - 43s = 29s` of slack, allowing for about 3-4 additional blocks (29s / 8s ≈ 3.6).
-
-### Block Duration Constraints
-
-Block duration should be greater than the min execution time, and ideally a divisor of the time available for building.
-
-```
-blockDuration >= MIN_EXECUTION_TIME (3s practical minimum for meaningful execution)
-```
-
-### Initialization Offset
-
-The initialization offset should be set based on empirical measurements of how long initialization typically takes, with typical values being 1-3 seconds.
-
-**Key point:** This is an *estimate*, not a hard deadline. The sequencer will take as long as needed for initialization. If it takes longer than the offset, the first block just has less time. If it takes less, the first block has bonus time.
-
-### Propagation Time
-
-Should be measured empirically on the actual P2P network, accounting for:
-- Network latency between geographically distributed validators
-- Gossip network propagation (not direct communication)
-- Block/checkpoint size (larger messages take longer)
-
-Typical values: 1-3 seconds
-
-### L1 Publishing Time
-
-Must account for Ethereum slot duration (12s) and blob propagation time:
-- Bare minimum: 8s (Ethereum allows txs up to 4s into the slot)
-- Recommended minimum: 12s (full Ethereum slot)
-- With high blob congestion: 24s (two slots)
-
-## State Machine
-
-The sequencer transitions through these states during a slot:
-
-| State | Time Budget | Purpose |
-|-------|-------------|---------|
-| **SYNCHRONIZING** | No limit | Wait for all subsystems to sync |
-| **PROPOSER_CHECK** | Part of init offset | Verify we're the proposer |
-| **INITIALIZING_CHECKPOINT** | Part of init offset | Set up checkpoint state |
-| **WAITING_FOR_TXS** | Until block deadline | Wait for enough transactions |
-| **CREATING_BLOCK** | Until block deadline | Execute transactions and build block |
-| **WAITING_UNTIL_NEXT_BLOCK** | Until next sub-slot start | Sleep between blocks to maintain intervals |
-| **ASSEMBLING_CHECKPOINT** | assembleTime (1s) | Assemble final checkpoint |
-| **COLLECTING_ATTESTATIONS** | Until L1 publish deadline | Wait for validator signatures |
-| **PUBLISHING_CHECKPOINT** | Until L1 publish deadline | Submit to L1 |
-
-## Complete Example: 72-Second Slot with 8-Second Sub-Slots
-
-Let's walk through a complete slot with the happy path:
-
-```
-T=0s    Slot begins for slot N
-
-T=0-2s  SYNCHRONIZING, PROPOSER_CHECK, INITIALIZING_CHECKPOINT
-        Actual time: 1.8s (slightly faster than 2s estimate)
-
-T=2s    Sub-slot 1 deadline calculation: 2s + 1*8s = 10s
-T=1.8s  Ready to build, start Block 1 immediately
-        Available time: 10s - 1.8s = 8.2s (bonus 0.2s!)
-T=1.8-9.5s  CREATING_BLOCK 1
-T=9.5s  Block 1 complete, broadcast
-T=9.5-10s  Wait for next sub-slot
-
-T=10s   Sub-slot 2 starts, deadline: 2s + 2*8s = 18s
-T=10-17.5s  CREATING_BLOCK 2
-T=17.5s Block 2 complete, broadcast
-T=17.5-18s Wait for next sub-slot
-
-T=18s   Sub-slot 3 starts, deadline: 2s + 3*8s = 26s
-T=18-25s  CREATING_BLOCK 3
-T=25s   Block 3 complete, broadcast
-T=25-26s Wait for next sub-slot
-
-T=26s   Sub-slot 4 starts, deadline: 2s + 4*8s = 34s
-T=26-33.5s  CREATING_BLOCK 4
-T=33.5s Block 4 complete, broadcast
-T=33.5-34s Wait for next sub-slot
-
-T=34s   Sub-slot 5 starts, deadline: 2s + 5*8s = 42s
-T=34-41s  CREATING_BLOCK 5 (last block)
-T=41s   Block 5 complete
-
-T=41s   ASSEMBLING_CHECKPOINT (1s)
-T=42s   Checkpoint proposal broadcast
-        Sub-slot 6 starts (last sub-slot, reserved for validator reexec)
-
-T=44s   Validators receive checkpoint (42s + 2s propagation)
-        Validators start re-executing Block 5
-
-T=52s   Validators finish re-executing Block 5 (44s + 8s)
-        Validators send attestations
-
-T=54s   COLLECTING_ATTESTATIONS
-        Proposer receives attestations (52s + 2s propagation)
-
-T=55s   PUBLISHING_CHECKPOINT
-        Sign over attestations, submit L1 transaction
-
-T=67s   L1 transaction lands in Ethereum block (12s)
-
-T=72s   Slot ends (5s buffer remaining)
-```
-
-**Summary:**
-- Built 5 blocks (sub-slots 1-5)
-- Last sub-slot (6) reserved for validator re-execution
-- Total time: 72s
-- Buffer: 5s (72s - 67s)
+`l1PublishingTime` should fit inside the Ethereum slot the target slot maps to. The default of 12 s lines up with one Ethereum slot; congested deployments may need to increase it (which only affects the `PUBLISHING_CHECKPOINT` deadline, not the number of blocks built).

--- a/yarn-project/sequencer-client/src/sequencer/README.md
+++ b/yarn-project/sequencer-client/src/sequencer/README.md
@@ -2,11 +2,11 @@
 
 This document covers how the sequencer schedules its work within a slot. See the [package README](../../README.md) for the high-level architecture; this one focuses on the timing math and the state-machine deadlines.
 
-The model described here is for **proposer pipelining**, the standard mode in production. Non-pipelined scheduling existed historically and is in the process of being removed.
+The model described here is for **proposer pipelining**, the standard mode in production. Non-pipelined scheduling existed historically.
 
 ## Overview
 
-Block production runs on three nested clocks:
+Block production runs on a cadence of fixed-length **slots** (e.g. 72 s). Each slot has a single elected proposer who is allowed to build during that slot. The proposer can build several blocks within the slot, but all those blocks are part of the same **checkpoint** and commit to the same L2 slot:
 
 - A **slot** is a fixed window (e.g. 72 s) during which one elected proposer is allowed to build.
 - A slot contains several equal-length **sub-slots** (e.g. 8 s). Each sub-slot owns the budget for one L2 block and has a deadline fixed relative to the slot start.

--- a/yarn-project/sequencer-client/src/sequencer/README.md
+++ b/yarn-project/sequencer-client/src/sequencer/README.md
@@ -192,7 +192,7 @@ Block 1 has 7 s of build time instead of 8 s. Still well above `minExecutionTime
 
 ### Very slow initialization (8 s)
 
-Sub-slot 1's deadline (9 s) is closer than `minExecutionTime` (2 s), so it is skipped entirely. The first attempted block runs in sub-slot 2 with the usual budget. The checkpoint will have one fewer block.
+Sub-slot 1's deadline (9 s) is less than `minExecutionTime` (2 s) away, so it is skipped entirely. The first attempted block runs in sub-slot 2 with the usual budget. The checkpoint will have one fewer block.
 
 ### Block takes longer than its budget
 
@@ -208,7 +208,7 @@ The current sub-slot is dropped without committing anything. The loop retries on
 
 ### Build slot ends before attestations arrive
 
-`assertTimeLeft` will reject `PUBLISHING_CHECKPOINT` if the attestation deadline has passed; the slot is abandoned, and `checkpoint-publish-failed` is emitted. The `PUBLISHING_CHECKPOINT` deadline allows spillover into the target slot (`2 * aztecSlotDuration - l1PublishingTime`) precisely to absorb a small overrun.
+`waitForAttestations` enforces `checkpointAttestationDeadline` (`2 * aztecSlotDuration - l1PublishingTime`) and returns `undefined` if the quorum is not in by then. The proposal stays on the proposed chain but no `propose` call is enqueued for L1; governance and slashing votes still go out via `sendRequestsAt`. The publishing-state deadline allows spillover into the target slot precisely to absorb a small overrun while the quorum is still arriving.
 
 ### Pipelined parent fails on L1
 
@@ -228,6 +228,6 @@ aztecSlotDuration ≥ checkpointInitializationTime
                   + blockDuration                    // last-block re-execution window
 ```
 
-Block duration should be ≥ `minExecutionTime` (otherwise no sub-slot ever has enough headroom). `p2pPropagationTime` should be measured against the deployment's actual p2p latency: it directly determines how much of each slot is spent on the cooldown.
+If `blockDuration` is set below `minExecutionTime`, the timing model normalizes `minExecutionTime` down to `blockDuration` rather than rejecting the config (see `normalizeCheckpointTimingConfig` in `stdlib/src/timetable/index.ts`). `p2pPropagationTime` should be measured against the deployment's actual p2p latency: it directly determines how much of each slot is spent on the cooldown.
 
 `l1PublishingTime` should fit inside the Ethereum slot the target slot maps to. The default of 12 s lines up with one Ethereum slot; congested deployments may need to increase it (which only affects the `PUBLISHING_CHECKPOINT` deadline, not the number of blocks built).


### PR DESCRIPTION
## Motivation

The top-level `sequencer-client/README.md` was years out of date — it still referred to single-block-per-slot building and made no mention of proposer pipelining or the multi-block checkpoint model. The timing-model README still documented both pipelined and non-pipelined scheduling even though the non-pipelined mode is about to be removed. New contributors (human or AI) lacked the context they need to make changes to block building.

## Approach

Rewrote the top-level README from scratch following the package's `readme-writer` guidelines: slots / blocks / checkpoints, proposed vs checkpointed chain, an architecture diagram, the `Sequencer` work loop, `CheckpointProposalJob` lifecycle, per-block loop pseudocode, the `SequencerPublisher` Multicall3 bundling and `sendRequestsAt` semantics, events, configuration reference, and failure modes. Trimmed `src/sequencer/README.md` to cover only the pipelined timing model with formulas grounded in `PipelinedCheckpointTimingModel` and a corrected 72 s / 8 s walkthrough. Ran `/codex` for a critical review and fixed all flagged issues (last-sub-slot-is-not-cooldown, event-emit timing, config env-var names, attestation-deadline nuance, `insufficient-valid-txs` handling, publisher `preCheck` semantics).

## Changes

- **sequencer-client**: Replaced `README.md` with an architecture-first rewrite covering pipelining (build slot vs target slot, depth bound of 2, parent-invalidation discard), the per-slot job lifecycle, the publisher's Multicall3 flow, and the full config reference.
- **sequencer-client (sequencer)**: Replaced `src/sequencer/README.md` with a pipelining-only timing model. Documents `timeReservedAtEnd`, `maxNumberOfBlocks`, per-state deadlines, proposer-vs-committee parallel timeline, and timing-variation handling.