### PR TITLE
chore(aztec-nr): mark emit_event_in_public as #[inline_never] to shrink public dispatch

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/contract_self/contract_self_public.nr
+++ b/noir-projects/aztec-nr/aztec/src/contract_self/contract_self_public.nr
@@ -118,7 +118,7 @@ impl<Storage, CallSelf, CallSelfStatic, CallInternal> ContractSelfPublic<Storage
     ///
     /// Public event emission is achieved by emitting public transaction logs. A total of `N+1` fields are emitted,
     /// where `N` is the serialization length of the event.
-    pub fn emit<Event>(&mut self, event: Event)
+    pub unconstrained fn emit<Event>(&mut self, event: Event)
     where
         Event: EventInterface + Serialize,
     {

--- a/noir-projects/aztec-nr/aztec/src/event/event_emission.nr
+++ b/noir-projects/aztec-nr/aztec/src/event/event_emission.nr
@@ -35,7 +35,8 @@ where
 }
 
 /// Equivalent to `self.emit(event)`: see [`crate::contract_self::ContractSelfPublic::emit`].
-pub fn emit_event_in_public<Event>(context: PublicContext, event: Event)
+#[inline_never]
+pub unconstrained fn emit_event_in_public<Event>(context: PublicContext, event: Event)
 where
     Event: EventInterface + Serialize,
 {


### PR DESCRIPTION
## Summary

Work towards resolving https://github.com/AztecProtocol/aztec-nr/issues/35

- Mark `emit_event_in_public` `#[inline_never]` (and `unconstrained`, required by the attribute) so it stops being copied into every public call site.
- Propagate `unconstrained` to `ContractSelfPublic::emit` so it can still call the helper.
- Mirrors the existing precedent on `assert_is_initialized_public` (`aztec-nr/aztec/src/macros/functions/initialization_utils.nr:100`) from https://github.com/AztecProtocol/aztec-packages/pull/22869

## Bytecode impact
Measured via `nargo compile --inliner-aggressiveness 0` + `bb aztec_process`, reading `public_dispatch` packed bytecode size on `public_fns_with_emit_repro_contract`:

| State             | AVM bytes | Δ              |
|-------------------|-----------|----------------|
| Baseline          | 5,576     | —              |
| `#[inline_never]` | 4,601     | -975 (-17.5%)  |

Roughly 65 bytes saved per emit call site across the 15 functions. Real contracts with many public functions emitting the same event shape should see the same per-site savings.

## Additional Context
- `--inliner-aggressiveness` cannot achieve this on its own: for `public_dispatch` the noirc driver pins aggressiveness to 0 (`noir/noir-repo/compiler/noirc_driver/src/lib.rs:743-744`)
- `ContractSelfPublic::emit` becoming `unconstrained` is a small surface change. All `#[external(\"public\")]` bodies are already unconstrained, so contract code calling `self.emit(...)` directly is unaffected