### PR TITLE
fix(aztec-node): include upcoming checkpoint's L1 to L2 messages in simulatePublicCalls

### DIFF
--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -3,7 +3,12 @@ import { BBCircuitVerifier, BatchChonkVerifier, QueuedIVCVerifier } from '@aztec
 import { TestCircuitVerifier } from '@aztec/bb-prover/test';
 import { type BlobClientInterface, createBlobClientWithFileStores } from '@aztec/blob-client/client';
 import { Blob } from '@aztec/blob-lib';
-import { ARCHIVE_HEIGHT, type L1_TO_L2_MSG_TREE_HEIGHT, type NOTE_HASH_TREE_HEIGHT } from '@aztec/constants';
+import {
+  ARCHIVE_HEIGHT,
+  INITIAL_L2_BLOCK_NUM,
+  type L1_TO_L2_MSG_TREE_HEIGHT,
+  type NOTE_HASH_TREE_HEIGHT,
+} from '@aztec/constants';
 import { EpochCache, type EpochCacheInterface } from '@aztec/epoch-cache';
 import { createEthereumChain } from '@aztec/ethereum/chain';
 import { getPublicClient, makeL1HttpTransport } from '@aztec/ethereum/client';
@@ -99,7 +104,7 @@ import {
 } from '@aztec/stdlib/interfaces/server';
 import type { DebugLogStore, LogFilter, SiloedTag, Tag, TxScopedL2Log } from '@aztec/stdlib/logs';
 import { InMemoryDebugLogStore, NullDebugLogStore } from '@aztec/stdlib/logs';
-import { InboxLeaf, type L1ToL2MessageSource } from '@aztec/stdlib/messaging';
+import { InboxLeaf, type L1ToL2MessageSource, appendL1ToL2MessagesToTree } from '@aztec/stdlib/messaging';
 import type { Offense } from '@aztec/stdlib/slashing';
 import type { NullifierLeafPreimage, PublicDataTreeLeafPreimage } from '@aztec/stdlib/trees';
 import { MerkleTreeId, NullifierMembershipWitness, PublicDataWitness } from '@aztec/stdlib/trees';
@@ -1483,8 +1488,32 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, AztecNodeDeb
 
     // Ensure world-state has caught up with the latest block we loaded from the archiver
     await this.worldStateSynchronizer.syncImmediate(latestBlockNumber);
-    const merkleTreeFork = await this.worldStateSynchronizer.fork();
+
+    // Compute the slot a proposer would actually target under pipelining, then compare with the
+    // latest block's slot: if they differ the simulated block opens a new checkpoint, and we must
+    // mirror the L1→L2 message insertion the on-chain proposer will perform so that AVM opcodes
+    // l1_to_l2_msg_exists / consume_l1_to_l2_message see the same tree state as on-chain.
+    const { slot: targetSlot } = this.epochCache.getTargetEpochAndSlotInNextL1Slot();
+    const latestBlockData = await this.blockSource.getBlockData({ number: latestBlockNumber });
+    const isGenesis = latestBlockNumber === BlockNumber(INITIAL_L2_BLOCK_NUM - 1);
+    if (latestBlockData === undefined && !isGenesis) {
+      throw new Error(`Failed to load block data for latest block ${latestBlockNumber}`);
+    }
+    const isNewCheckpoint = isGenesis || targetSlot > latestBlockData!.header.getSlot();
+    const nextCheckpointMessages = isNewCheckpoint
+      ? await this.l1ToL2MessageSource.getL1ToL2Messages(
+          CheckpointNumber((latestBlockData?.checkpointNumber ?? CheckpointNumber.ZERO) + 1),
+        )
+      : undefined;
+
+    // Pin the fork to the captured `latestBlockNumber` so background sync advancing between
+    // `syncImmediate` and `fork` cannot leave the fork at a newer block than our checkpoint
+    // boundary calculation.
+    const merkleTreeFork = await this.worldStateSynchronizer.fork(latestBlockNumber);
     try {
+      if (nextCheckpointMessages !== undefined) {
+        await appendL1ToL2MessagesToTree(merkleTreeFork, nextCheckpointMessages);
+      }
       await applyPublicDataOverrides(merkleTreeFork, overrides?.publicStorage);
       const config = PublicSimulatorConfig.from({
         skipFeeEnforcement,

--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -1489,22 +1489,28 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, AztecNodeDeb
     // Ensure world-state has caught up with the latest block we loaded from the archiver
     await this.worldStateSynchronizer.syncImmediate(latestBlockNumber);
 
-    // Compute the slot a proposer would actually target under pipelining, then compare with the
-    // latest block's slot: if they differ the simulated block opens a new checkpoint, and we must
-    // mirror the L1→L2 message insertion the on-chain proposer will perform so that AVM opcodes
+    // When pipelining is enabled, the simulated block lands at the pipelining target slot,
+    // which may open a new checkpoint relative to the latest block. In that case mirror the
+    // L1→L2 message insertion the on-chain proposer will perform so that AVM opcodes
     // l1_to_l2_msg_exists / consume_l1_to_l2_message see the same tree state as on-chain.
-    const { slot: targetSlot } = this.epochCache.getTargetEpochAndSlotInNextL1Slot();
-    const latestBlockData = await this.blockSource.getBlockData({ number: latestBlockNumber });
-    const isGenesis = latestBlockNumber === BlockNumber(INITIAL_L2_BLOCK_NUM - 1);
-    if (latestBlockData === undefined && !isGenesis) {
-      throw new Error(`Failed to load block data for latest block ${latestBlockNumber}`);
-    }
-    const isNewCheckpoint = isGenesis || targetSlot > latestBlockData!.header.getSlot();
-    const nextCheckpointMessages = isNewCheckpoint
-      ? await this.l1ToL2MessageSource.getL1ToL2Messages(
+    // When pipelining is disabled, simulate against the current checkpoint state (which is
+    // the pre-fix behaviour). This also avoids requesting messages for an unsealed checkpoint
+    // in low-inbox-lag setups that don't enable pipelining.
+    let nextCheckpointMessages: Fr[] | undefined;
+    if (this.epochCache.isProposerPipeliningEnabled()) {
+      const { slot: targetSlot } = this.epochCache.getTargetEpochAndSlotInNextL1Slot();
+      const latestBlockData = await this.blockSource.getBlockData({ number: latestBlockNumber });
+      const isGenesis = latestBlockNumber === BlockNumber(INITIAL_L2_BLOCK_NUM - 1);
+      if (latestBlockData === undefined && !isGenesis) {
+        throw new Error(`Failed to load block data for latest block ${latestBlockNumber}`);
+      }
+      const isNewCheckpoint = isGenesis || targetSlot > latestBlockData!.header.getSlot();
+      if (isNewCheckpoint) {
+        nextCheckpointMessages = await this.l1ToL2MessageSource.getL1ToL2Messages(
           CheckpointNumber((latestBlockData?.checkpointNumber ?? CheckpointNumber.ZERO) + 1),
-        )
-      : undefined;
+        );
+      }
+    }
 
     // Pin the fork to the captured `latestBlockNumber` so background sync advancing between
     // `syncImmediate` and `fork` cannot leave the fork at a newer block than our checkpoint

--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -3,12 +3,7 @@ import { BBCircuitVerifier, BatchChonkVerifier, QueuedIVCVerifier } from '@aztec
 import { TestCircuitVerifier } from '@aztec/bb-prover/test';
 import { type BlobClientInterface, createBlobClientWithFileStores } from '@aztec/blob-client/client';
 import { Blob } from '@aztec/blob-lib';
-import {
-  ARCHIVE_HEIGHT,
-  INITIAL_L2_BLOCK_NUM,
-  type L1_TO_L2_MSG_TREE_HEIGHT,
-  type NOTE_HASH_TREE_HEIGHT,
-} from '@aztec/constants';
+import { ARCHIVE_HEIGHT, type L1_TO_L2_MSG_TREE_HEIGHT, type NOTE_HASH_TREE_HEIGHT } from '@aztec/constants';
 import { EpochCache, type EpochCacheInterface } from '@aztec/epoch-cache';
 import { createEthereumChain } from '@aztec/ethereum/chain';
 import { getPublicClient, makeL1HttpTransport } from '@aztec/ethereum/client';
@@ -1461,7 +1456,8 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, AztecNodeDeb
     }
 
     const txHash = tx.getTxHash();
-    const latestBlockNumber = await this.blockSource.getBlockNumber();
+    const l2Tips = await this.blockSource.getL2Tips();
+    const latestBlockNumber = l2Tips.proposed.number;
     const blockNumber = BlockNumber.add(latestBlockNumber, 1);
 
     // If sequencer is not initialized, we just set these values to zero for simulation.
@@ -1473,6 +1469,7 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, AztecNodeDeb
       coinbase,
       feeRecipient,
     );
+
     const publicProcessorFactory = new PublicProcessorFactory(
       this.contractDataSource,
       new DateProvider(),
@@ -1489,74 +1486,63 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, AztecNodeDeb
     // Ensure world-state has caught up with the latest block we loaded from the archiver
     await this.worldStateSynchronizer.syncImmediate(latestBlockNumber);
 
-    // When pipelining is enabled, the simulated block lands at the pipelining target slot,
-    // which may open a new checkpoint relative to the latest block. In that case mirror the
-    // L1→L2 message insertion the on-chain proposer will perform so that AVM opcodes
-    // l1_to_l2_msg_exists / consume_l1_to_l2_message see the same tree state as on-chain.
-    // When pipelining is disabled, simulate against the current checkpoint state (which is
-    // the pre-fix behaviour). This also avoids requesting messages for an unsealed checkpoint
-    // in low-inbox-lag setups that don't enable pipelining.
-    let nextCheckpointMessages: Fr[] | undefined;
-    if (this.epochCache.isProposerPipeliningEnabled()) {
-      const { slot: targetSlot } = this.epochCache.getTargetEpochAndSlotInNextL1Slot();
-      const latestBlockData = await this.blockSource.getBlockData({ number: latestBlockNumber });
-      const isGenesis = latestBlockNumber === BlockNumber(INITIAL_L2_BLOCK_NUM - 1);
-      if (latestBlockData === undefined && !isGenesis) {
-        throw new Error(`Failed to load block data for latest block ${latestBlockNumber}`);
-      }
-      const isNewCheckpoint = isGenesis || targetSlot > latestBlockData!.header.getSlot();
-      if (isNewCheckpoint) {
-        nextCheckpointMessages = await this.l1ToL2MessageSource.getL1ToL2Messages(
-          CheckpointNumber((latestBlockData?.checkpointNumber ?? CheckpointNumber.ZERO) + 1),
-        );
-      }
-    }
+    // If we detect the next block would start a new checkpoint, then insert L1-to-L2 messages into
+    // the world state tree so simulation can take them into account. We detect if the next block would
+    // start a new checkpoint by checking if the proposed checkpoint's block number matches the latest block number,
+    // which means the next block would be the first block of the next checkpoint.
+    const nextCheckpointMessages: Fr[] | undefined =
+      l2Tips.proposedCheckpoint.block.number === l2Tips.proposed.number
+        ? await this.l1ToL2MessageSource.getL1ToL2Messages(
+            CheckpointNumber((l2Tips.proposedCheckpoint.checkpoint.number ?? CheckpointNumber.ZERO) + 1),
+          )
+        : undefined;
 
-    // Pin the fork to the captured `latestBlockNumber` so background sync advancing between
-    // `syncImmediate` and `fork` cannot leave the fork at a newer block than our checkpoint
-    // boundary calculation.
-    const merkleTreeFork = await this.worldStateSynchronizer.fork(latestBlockNumber);
-    try {
-      if (nextCheckpointMessages !== undefined) {
-        await appendL1ToL2MessagesToTree(merkleTreeFork, nextCheckpointMessages);
-      }
-      await applyPublicDataOverrides(merkleTreeFork, overrides?.publicStorage);
-      const config = PublicSimulatorConfig.from({
-        skipFeeEnforcement,
-        collectDebugLogs: true,
-        collectHints: false,
-        collectCallMetadata: true,
-        collectStatistics: false,
-        collectionLimits: CollectionLimitsConfig.from({
-          maxDebugLogMemoryReads: this.config.rpcSimulatePublicMaxDebugLogMemoryReads,
-        }),
-      });
-      const contractsDB = new PublicContractsDB(this.contractDataSource, this.log.getBindings());
-      if (overrides?.contracts) {
-        contractsDB.addContracts(Object.values(overrides.contracts).map(({ instance }) => instance));
-      }
-      const processor = publicProcessorFactory.create(merkleTreeFork, newGlobalVariables, config, contractsDB);
+    // Request a new fork of the world state at the latest block number, and apply any overrides and next checkpoint messages to it before simulation
+    await using merkleTreeFork = await this.worldStateSynchronizer.fork(latestBlockNumber);
 
-      // REFACTOR: Consider merging ProcessReturnValues into ProcessedTx
-      const [processedTxs, failedTxs, _usedTxs, returns, debugLogs] = await processor.process([tx]);
-      // REFACTOR: Consider returning the error rather than throwing
-      if (failedTxs.length) {
-        this.log.warn(`Simulated tx ${txHash} fails: ${failedTxs[0].error}`, { txHash });
-        throw failedTxs[0].error;
-      }
-
-      const [processedTx] = processedTxs;
-      return new PublicSimulationOutput(
-        processedTx.revertReason,
-        processedTx.globalVariables,
-        processedTx.txEffect,
-        returns,
-        processedTx.gasUsed,
-        debugLogs,
+    if (nextCheckpointMessages !== undefined) {
+      this.log.debug(
+        `Appending ${nextCheckpointMessages.length} L1-to-L2 messages to the world state tree for the next checkpoint`,
+        { checkpointNumber: l2Tips.proposedCheckpoint.checkpoint.number + 1 },
       );
-    } finally {
-      await merkleTreeFork.close();
+      await appendL1ToL2MessagesToTree(merkleTreeFork, nextCheckpointMessages);
     }
+    await applyPublicDataOverrides(merkleTreeFork, overrides?.publicStorage);
+
+    const config = PublicSimulatorConfig.from({
+      skipFeeEnforcement,
+      collectDebugLogs: true,
+      collectHints: false,
+      collectCallMetadata: true,
+      collectStatistics: false,
+      collectionLimits: CollectionLimitsConfig.from({
+        maxDebugLogMemoryReads: this.config.rpcSimulatePublicMaxDebugLogMemoryReads,
+      }),
+    });
+
+    const contractsDB = new PublicContractsDB(this.contractDataSource, this.log.getBindings());
+    if (overrides?.contracts) {
+      contractsDB.addContracts(Object.values(overrides.contracts).map(({ instance }) => instance));
+    }
+    const processor = publicProcessorFactory.create(merkleTreeFork, newGlobalVariables, config, contractsDB);
+
+    // REFACTOR: Consider merging ProcessReturnValues into ProcessedTx
+    const [processedTxs, failedTxs, _usedTxs, returns, debugLogs] = await processor.process([tx]);
+    // REFACTOR: Consider returning the error rather than throwing
+    if (failedTxs.length) {
+      this.log.warn(`Simulated tx ${txHash} fails: ${failedTxs[0].error}`, { txHash });
+      throw failedTxs[0].error;
+    }
+
+    const [processedTx] = processedTxs;
+    return new PublicSimulationOutput(
+      processedTx.revertReason,
+      processedTx.globalVariables,
+      processedTx.txEffect,
+      returns,
+      processedTx.gasUsed,
+      debugLogs,
+    );
   }
 
   public async isValidTx(

--- a/yarn-project/end-to-end/src/e2e_cross_chain_messaging/l1_to_l2.test.ts
+++ b/yarn-project/end-to-end/src/e2e_cross_chain_messaging/l1_to_l2.test.ts
@@ -166,13 +166,19 @@ describe('e2e_cross_chain_messaging l1_to_l2', () => {
       const [message1Index] = (await aztecNode.getL1ToL2MessageMembershipWitness('latest', message1Hash))!;
       expect(actualMessage1Index.toBigInt()).toBe(message1Index);
 
+      const consumeAndSend = async (index: Fr) => {
+        const call = getConsumeMethod(scope)(message.content, secret, crossChainTestHarness.ethAccount, index);
+        if (scope === 'public') {
+          // Public consumption simulates through aztecNode.simulatePublicCalls; this exercises
+          // the path that mirrors the upcoming checkpoint's L1→L2 message insertion onto the
+          // simulation fork.
+          await call.simulate({ from: user1Address });
+        }
+        await call.send({ from: user1Address });
+      };
+
       // We consume the L1 to L2 message using the test contract either from private or public
-      await getConsumeMethod(scope)(
-        message.content,
-        secret,
-        crossChainTestHarness.ethAccount,
-        actualMessage1Index,
-      ).send({ from: user1Address });
+      await consumeAndSend(actualMessage1Index);
 
       // We send and consume the exact same message the second time to test that oracles correctly return the new
       // non-nullified message
@@ -191,12 +197,7 @@ describe('e2e_cross_chain_messaging l1_to_l2', () => {
 
       // Now we consume the message again. Everything should pass because oracle should return the duplicate message
       // which is not nullified
-      await getConsumeMethod(scope)(
-        message.content,
-        secret,
-        crossChainTestHarness.ethAccount,
-        actualMessage2Index,
-      ).send({ from: user1Address });
+      await consumeAndSend(actualMessage2Index);
     },
     120_000,
   );

--- a/yarn-project/end-to-end/src/e2e_cross_chain_messaging/l1_to_l2.test.ts
+++ b/yarn-project/end-to-end/src/e2e_cross_chain_messaging/l1_to_l2.test.ts
@@ -166,19 +166,16 @@ describe('e2e_cross_chain_messaging l1_to_l2', () => {
       const [message1Index] = (await aztecNode.getL1ToL2MessageMembershipWitness('latest', message1Hash))!;
       expect(actualMessage1Index.toBigInt()).toBe(message1Index);
 
-      const consumeAndSend = async (index: Fr) => {
+      const sendConsumeMsgTx = async (index: Fr) => {
         const call = getConsumeMethod(scope)(message.content, secret, crossChainTestHarness.ethAccount, index);
         if (scope === 'public') {
-          // Public consumption simulates through aztecNode.simulatePublicCalls; this exercises
-          // the path that mirrors the upcoming checkpoint's L1→L2 message insertion onto the
-          // simulation fork.
           await call.simulate({ from: user1Address });
         }
         await call.send({ from: user1Address });
       };
 
       // We consume the L1 to L2 message using the test contract either from private or public
-      await consumeAndSend(actualMessage1Index);
+      await sendConsumeMsgTx(actualMessage1Index);
 
       // We send and consume the exact same message the second time to test that oracles correctly return the new
       // non-nullified message
@@ -197,7 +194,7 @@ describe('e2e_cross_chain_messaging l1_to_l2', () => {
 
       // Now we consume the message again. Everything should pass because oracle should return the duplicate message
       // which is not nullified
-      await consumeAndSend(actualMessage2Index);
+      await sendConsumeMsgTx(actualMessage2Index);
     },
     120_000,
   );

--- a/yarn-project/prover-client/src/light/lightweight_checkpoint_builder.ts
+++ b/yarn-project/prover-client/src/light/lightweight_checkpoint_builder.ts
@@ -1,7 +1,5 @@
 import { SpongeBlob, computeBlobsHashFromBlobs, encodeCheckpointEndMarker, getBlobsPerL1Block } from '@aztec/blob-lib';
-import { NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP } from '@aztec/constants';
 import { type CheckpointNumber, IndexWithinCheckpoint } from '@aztec/foundation/branded-types';
-import { padArrayEnd } from '@aztec/foundation/collection';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { type Logger, type LoggerBindings, createLogger } from '@aztec/foundation/log';
 import { elapsed } from '@aztec/foundation/timer';
@@ -10,6 +8,7 @@ import { Checkpoint } from '@aztec/stdlib/checkpoint';
 import type { MerkleTreeWriteOperations } from '@aztec/stdlib/interfaces/server';
 import {
   accumulateCheckpointOutHashes,
+  appendL1ToL2MessagesToTree,
   computeCheckpointOutHash,
   computeInHashFromL1ToL2Messages,
 } from '@aztec/stdlib/messaging';
@@ -69,10 +68,7 @@ export class LightweightCheckpointBuilder {
     feeAssetPriceModifier: bigint = 0n,
   ): Promise<LightweightCheckpointBuilder> {
     // Insert l1-to-l2 messages into the tree.
-    await db.appendLeaves(
-      MerkleTreeId.L1_TO_L2_MESSAGE_TREE,
-      padArrayEnd<Fr, number>(l1ToL2Messages, Fr.ZERO, NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP),
-    );
+    await appendL1ToL2MessagesToTree(db, l1ToL2Messages);
 
     return new LightweightCheckpointBuilder(
       checkpointNumber,
@@ -116,6 +112,10 @@ export class LightweightCheckpointBuilder {
       numExistingBlocks: existingBlocks.length,
       blockNumbers: existingBlocks.map(b => b.header.getBlockNumber()),
     });
+
+    if (existingBlocks.length === 0) {
+      throw new Error(`Cannot resume checkpoint ${checkpointNumber} with no existing blocks`);
+    }
 
     // Validate block order and consistency
     for (let i = 1; i < existingBlocks.length; i++) {

--- a/yarn-project/prover-client/src/orchestrator/orchestrator.ts
+++ b/yarn-project/prover-client/src/orchestrator/orchestrator.ts
@@ -3,11 +3,9 @@ import {
   L1_TO_L2_MSG_SUBTREE_HEIGHT,
   L1_TO_L2_MSG_SUBTREE_ROOT_SIBLING_PATH_LENGTH,
   NESTED_RECURSIVE_ROLLUP_HONK_PROOF_LENGTH,
-  NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP,
   NUM_BASE_PARITY_PER_ROOT_PARITY,
 } from '@aztec/constants';
 import { BlockNumber, EpochNumber } from '@aztec/foundation/branded-types';
-import { padArrayEnd } from '@aztec/foundation/collection';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { AbortError } from '@aztec/foundation/error';
 import { type Logger, type LoggerBindings, createLogger } from '@aztec/foundation/log';
@@ -27,6 +25,7 @@ import type {
   ReadonlyWorldStateAccess,
   ServerCircuitProver,
 } from '@aztec/stdlib/interfaces/server';
+import { appendL1ToL2MessagesToTree } from '@aztec/stdlib/messaging';
 import type { Proof } from '@aztec/stdlib/proofs';
 import {
   type BaseRollupHints,
@@ -642,13 +641,6 @@ export class ProvingOrchestrator implements EpochProver {
   }
 
   private async updateL1ToL2MessageTree(l1ToL2Messages: Fr[], db: MerkleTreeWriteOperations) {
-    const l1ToL2MessagesPadded = padArrayEnd<Fr, number>(
-      l1ToL2Messages,
-      Fr.ZERO,
-      NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP,
-      'Too many L1 to L2 messages',
-    );
-
     const lastL1ToL2MessageTreeSnapshot = await getTreeSnapshot(MerkleTreeId.L1_TO_L2_MESSAGE_TREE, db);
     const lastL1ToL2MessageSubtreeRootSiblingPath = assertLength(
       await getSubtreeSiblingPath(MerkleTreeId.L1_TO_L2_MESSAGE_TREE, L1_TO_L2_MSG_SUBTREE_HEIGHT, db),
@@ -656,7 +648,7 @@ export class ProvingOrchestrator implements EpochProver {
     );
 
     // Update the local trees to include the new l1 to l2 messages
-    await db.appendLeaves(MerkleTreeId.L1_TO_L2_MESSAGE_TREE, l1ToL2MessagesPadded);
+    await appendL1ToL2MessagesToTree(db, l1ToL2Messages);
 
     const newL1ToL2MessageTreeSnapshot = await getTreeSnapshot(MerkleTreeId.L1_TO_L2_MESSAGE_TREE, db);
     const newL1ToL2MessageSubtreeRootSiblingPath = assertLength(

--- a/yarn-project/prover-node/src/job/epoch-proving-job.ts
+++ b/yarn-project/prover-node/src/job/epoch-proving-job.ts
@@ -1,7 +1,5 @@
-import { NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP } from '@aztec/constants';
 import { asyncPool } from '@aztec/foundation/async-pool';
 import { BlockNumber, EpochNumber } from '@aztec/foundation/branded-types';
-import { padArrayEnd } from '@aztec/foundation/collection';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { type Logger, type LoggerBindings, createLogger } from '@aztec/foundation/log';
 import { RunningPromise, promiseWithResolvers } from '@aztec/foundation/promise';
@@ -20,8 +18,8 @@ import {
   EpochProvingJobTerminalState,
   type ForkMerkleTreeOperations,
 } from '@aztec/stdlib/interfaces/server';
+import { appendL1ToL2MessagesToTree } from '@aztec/stdlib/messaging';
 import { CheckpointConstantData } from '@aztec/stdlib/rollup';
-import { MerkleTreeId } from '@aztec/stdlib/trees';
 import type { ProcessedTx, Tx } from '@aztec/stdlib/tx';
 import { Attributes, type Traceable, type Tracer, trackSpan } from '@aztec/telemetry-client';
 
@@ -346,13 +344,7 @@ export class EpochProvingJob implements Traceable {
         blockNumber,
         l1ToL2Messages: l1ToL2Messages.map(m => m.toString()),
       });
-      const l1ToL2MessagesPadded = padArrayEnd<Fr, number>(
-        l1ToL2Messages,
-        Fr.ZERO,
-        NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP,
-        'Too many L1 to L2 messages',
-      );
-      await db.appendLeaves(MerkleTreeId.L1_TO_L2_MESSAGE_TREE, l1ToL2MessagesPadded);
+      await appendL1ToL2MessagesToTree(db, l1ToL2Messages);
     }
 
     return db;

--- a/yarn-project/stdlib/src/messaging/append_l1_to_l2_messages.ts
+++ b/yarn-project/stdlib/src/messaging/append_l1_to_l2_messages.ts
@@ -1,0 +1,21 @@
+import { NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP } from '@aztec/constants';
+import { padArrayEnd } from '@aztec/foundation/collection';
+import { Fr } from '@aztec/foundation/curves/bn254';
+
+import type { MerkleTreeWriteOperations } from '../interfaces/merkle_tree_operations.js';
+import { MerkleTreeId } from '../trees/merkle_tree_id.js';
+
+/**
+ * Pads `l1ToL2Messages` to `NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP` and appends them to the
+ * L1→L2 message tree of `db`. Use whenever a fork at "state before the first block of a
+ * checkpoint" needs to mirror what the world-state synchronizer inserts at sync time.
+ */
+export async function appendL1ToL2MessagesToTree(db: MerkleTreeWriteOperations, l1ToL2Messages: Fr[]): Promise<void> {
+  const padded = padArrayEnd<Fr, number>(
+    l1ToL2Messages,
+    Fr.ZERO,
+    NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP,
+    'Too many L1 to L2 messages',
+  );
+  await db.appendLeaves(MerkleTreeId.L1_TO_L2_MESSAGE_TREE, padded);
+}

--- a/yarn-project/stdlib/src/messaging/index.ts
+++ b/yarn-project/stdlib/src/messaging/index.ts
@@ -1,3 +1,4 @@
+export * from './append_l1_to_l2_messages.js';
 export * from './in_hash.js';
 export * from './inbox_leaf.js';
 export * from './l1_to_l2_message.js';


### PR DESCRIPTION
## Motivation

`simulatePublicCalls` forks the world state at the latest synced block but never inserted the L1 to L2 messages that would be added at the start of the next checkpoint, if the next block falls in a new checkpoint.

## Approach

If the last proposed block matches the last block in the last proposed checkpoint (read it carefully, I promise it makes sense), then the last proposed block is the last block in its checkpoint, so the next block will land on a new checkpoint, so we add the L1 to L2 messages to the world-state fork before simulating.