### PR TITLE
chore(ci): side-stepping OIDC to unblock nightlies

### DIFF
--- a/.github/workflows/ci3.yml
+++ b/.github/workflows/ci3.yml
@@ -350,9 +350,6 @@ jobs:
   ci-release-publish:
     runs-on: ubuntu-latest
     environment: master
-    permissions:
-      id-token: write
-      contents: read
     needs: [ci, ci-compat-e2e]
     if: |
       startsWith(github.ref, 'refs/tags/v')
@@ -368,16 +365,10 @@ jobs:
         with:
           ref: ${{ github.sha }}
 
-      - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
-          aws-region: us-east-2
-          role-session-name: ci3-release-publish-${{ github.run_id }}
-          role-duration-seconds: 21600
-
       - name: Run Release Publish
         env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           GITHUB_TOKEN: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
           BUILD_INSTANCE_SSH_KEY: ${{ secrets.BUILD_INSTANCE_SSH_KEY }}
           GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}


### PR DESCRIPTION
A workaround that should hopefully unblock nightlies that are currently not getting released. For more context see [this comment](https://aztecprotocol.slack.com/archives/C08HLF3J941/p1778532048823649?thread_ts=1778248294.466559&cid=C08HLF3J941) on slack.

## Summary
- Reverts the OIDC-based AWS auth in the `ci-release-publish` job back to using `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` secrets on the v4 backport line.
- Drops the `permissions: id-token: write` block and the `aws-actions/configure-aws-credentials` step that the OIDC flow required.