### PR TITLE
chore: Add decider to benchmark components

### DIFF
--- a/barretenberg/cpp/scripts/extract_component_benchmarks.py
+++ b/barretenberg/cpp/scripts/extract_component_benchmarks.py
@@ -31,7 +31,7 @@ try:
     benchmarks = []
 
     # Key components to track (case-insensitive matching)
-    key_components = ["sumcheck", "pcs", "pippenger", "commitment", "circuit", "oink", "compute"]
+    key_components = ["sumcheck", "pcs", "pippenger", "commitment", "circuit", "oink", "compute", "decider"]
 
     for op_name, entries in data.items():
         # Check if this is a key component we want to track

--- a/barretenberg/cpp/scripts/extract_component_benchmarks.py
+++ b/barretenberg/cpp/scripts/extract_component_benchmarks.py
@@ -31,7 +31,7 @@ try:
     benchmarks = []
 
     # Key components to track (case-insensitive matching)
-    key_components = ["sumcheck", "pcs", "pippenger", "commitment", "circuit", "oink", "compute", "decider"]
+    key_components = ["sumcheck", "pcs", "pippenger", "commitment", "circuit", "oink", "compute", "decider", "BatchMergeProver", "BatchMergeVerifier"]
 
     for op_name, entries in data.items():
         # Check if this is a key component we want to track


### PR DESCRIPTION
The HypernovaDecider is not showing up in our benchmark breakdown. This PR adds it do the components.

It also adds the BatchMerge prover/verifier