### PR TITLE
chore(dsl): require MemOp index and value to be witnesses

### DIFF
--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_to_constraint_buf.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_to_constraint_buf.cpp
@@ -817,27 +817,19 @@ BlockConstraint memory_init_to_block_constraint(Acir::Opcode::MemoryInit const& 
 
 void add_memory_op_to_block_constraint(Acir::Opcode::MemoryOp const& mem_op, BlockConstraint& block)
 {
-    // Lambda to convert an Acir::Expression to a witness index
-    auto acir_expression_to_witness_or_constant = [](const Acir::Expression& expr) {
-        // Noir gives us witnesses or constants for read/write operations. We use the following assertions to ensure
-        // that the data coming from Noir is in the correct form.
+    // Lambda to convert an Acir::Expression to a witness index. Noir always emits a single unscaled witness term for
+    // memory op indices and values, so anything else is a malformed input.
+    auto acir_expression_to_witness = [](const Acir::Expression& expr) -> uint32_t {
         BB_ASSERT(expr.mul_terms.empty(), "MemoryOp should not have multiplication terms");
-        BB_ASSERT_LTE(expr.linear_combinations.size(), 1U, "MemoryOp should have at most one linear term");
+        BB_ASSERT_EQ(expr.linear_combinations.size(), 1U, "MemoryOp expression must be a single witness");
 
-        const fr a_scaling = expr.linear_combinations.size() == 1
-                                 ? from_buffer_with_bound_checks(std::get<0>(expr.linear_combinations[0]))
-                                 : fr::zero();
+        const fr a_scaling = from_buffer_with_bound_checks(std::get<0>(expr.linear_combinations[0]));
         const fr constant_term = from_buffer_with_bound_checks(expr.q_c);
 
-        bool is_witness = a_scaling == fr::one() && constant_term == fr::zero();
-        bool is_constant = a_scaling == fr::zero();
-        BB_ASSERT(is_witness || is_constant, "MemoryOp expression must be a witness or a constant");
+        BB_ASSERT(a_scaling == fr::one() && constant_term == fr::zero(),
+                  "MemoryOp expression must be a single unscaled witness with no constant term");
 
-        return WitnessOrConstant<bb::fr>{
-            .index = is_witness ? std::get<1>(expr.linear_combinations[0]).value : bb::stdlib::IS_CONSTANT,
-            .value = is_constant ? constant_term : fr::zero(),
-            .is_constant = is_constant,
-        };
+        return std::get<1>(expr.linear_combinations[0]).value;
     };
 
     // Lambda to determine whether a memory operation is a read or write operation
@@ -862,11 +854,11 @@ void add_memory_op_to_block_constraint(Acir::Opcode::MemoryOp const& mem_op, Blo
         block.type = BlockType::RAM;
     }
 
-    // Update the ranges of the index using the array length
-    WitnessOrConstant<bb::fr> index = acir_expression_to_witness_or_constant(mem_op.op.index);
-    WitnessOrConstant<bb::fr> value = acir_expression_to_witness_or_constant(mem_op.op.value);
-
-    MemOp acir_mem_op = MemOp{ .access_type = access_type, .index = index, .value = value };
+    MemOp acir_mem_op = MemOp{
+        .access_type = access_type,
+        .index = acir_expression_to_witness(mem_op.op.index),
+        .value = acir_expression_to_witness(mem_op.op.value),
+    };
     block.trace.push_back(acir_mem_op);
 }
 

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/block_constraint.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/block_constraint.cpp
@@ -94,8 +94,8 @@ void process_ROM_operations(Builder& builder,
 
     rom_table_ct table(&builder, init);
     for (const auto& op : constraint.trace) {
-        field_ct value = to_field_ct(op.value, builder);
-        field_ct index = to_field_ct(op.index, builder);
+        field_ct value = field_ct::from_witness_index(&builder, op.value);
+        field_ct index = field_ct::from_witness_index(&builder, op.index);
 
         switch (op.access_type) {
         case AccessType::Read:
@@ -118,8 +118,8 @@ void process_RAM_operations(Builder& builder,
 
     ram_table_ct table(&builder, init);
     for (const auto& op : constraint.trace) {
-        field_ct value = to_field_ct(op.value, builder);
-        field_ct index = to_field_ct(op.index, builder);
+        field_ct value = field_ct::from_witness_index(&builder, op.value);
+        field_ct index = field_ct::from_witness_index(&builder, op.index);
 
         switch (op.access_type) {
         case AccessType::Read:
@@ -151,8 +151,8 @@ void process_call_data_operations(Builder& builder,
         calldata_array.set_values(init); // Initialize the data in the bus array
 
         for (const auto& op : constraint.trace) {
-            field_ct value = to_field_ct(op.value, builder);
-            field_ct index = to_field_ct(op.index, builder);
+            field_ct value = field_ct::from_witness_index(&builder, op.value);
+            field_ct index = field_ct::from_witness_index(&builder, op.index);
 
             switch (op.access_type) {
             case AccessType::Read:

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/block_constraint.hpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/block_constraint.hpp
@@ -6,7 +6,6 @@
 
 #pragma once
 #include "barretenberg/constants.hpp"
-#include "barretenberg/dsl/acir_format/witness_constant.hpp"
 #include "barretenberg/stdlib/primitives/field/field.hpp"
 #include <cstdint>
 #include <vector>
@@ -27,13 +26,13 @@ enum CallDataType : std::uint32_t {
 };
 
 /**
- * @brief Memory operation. Index and value store the index of the memory location, and value is the value to be read or
- * written.
+ * @brief Memory operation. `index` is the witness index of the memory location, and `value` is the witness index of the
+ * value to be read or written.
  */
 struct MemOp {
     AccessType access_type;
-    WitnessOrConstant<bb::fr> index;
-    WitnessOrConstant<bb::fr> value;
+    uint32_t index;
+    uint32_t value;
 };
 
 enum BlockType : std::uint8_t {

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/block_constraint.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/block_constraint.test.cpp
@@ -20,58 +20,13 @@ namespace {
 auto& engine = numeric::get_debug_randomness();
 } // namespace
 
-/**
- * @brief Utility method to add read/write operations with constant indices/values
- */
-template <AccessType access_type>
-void add_constant_ops(const size_t table_size,
-                      const std::vector<bb::fr>& table_values,
-                      WitnessVector& witness_values,
-                      std::vector<MemOp>& trace)
-{
-    const size_t table_index = static_cast<size_t>(engine.get_random_uint32() % table_size);
-    bb::fr value_fr =
-        access_type == AccessType::Read ? table_values[table_index] : table_values[table_index] + bb::fr(1);
-
-    // Index constant, value witness
-    {
-        WitnessOrConstant<bb::fr> index = WitnessOrConstant<bb::fr>::from_constant(table_index);
-        WitnessOrConstant<bb::fr> value =
-            WitnessOrConstant<bb::fr>::from_index(add_to_witness_and_track_indices(witness_values, value_fr));
-
-        const MemOp read_op = { .access_type = access_type, .index = index, .value = value };
-
-        trace.push_back(read_op);
-    }
-    // Index witness, value constant
-    {
-        WitnessOrConstant<bb::fr> index = WitnessOrConstant<bb::fr>::from_index(
-            add_to_witness_and_track_indices(witness_values, bb::fr(table_index)));
-        WitnessOrConstant<bb::fr> value = WitnessOrConstant<bb::fr>::from_constant(value_fr);
-
-        const MemOp read_op = { .access_type = access_type, .index = index, .value = value };
-
-        trace.push_back(read_op);
-    }
-    // Index constant, value constant
-    {
-        WitnessOrConstant<bb::fr> index = WitnessOrConstant<bb::fr>::from_constant(table_index);
-        WitnessOrConstant<bb::fr> value = WitnessOrConstant<bb::fr>::from_constant(value_fr);
-
-        const MemOp read_op = { .access_type = access_type, .index = index, .value = value };
-
-        trace.push_back(read_op);
-    }
-}
-
-template <typename Builder_, size_t TableSize_, size_t NumReads_, bool PerformConstantOps_> struct ROMTestParams {
+template <typename Builder_, size_t TableSize_, size_t NumReads_> struct ROMTestParams {
     using Builder = Builder_;
     static constexpr size_t table_size = TableSize_;
     static constexpr size_t num_reads = NumReads_;
-    static constexpr bool perform_constant_ops = PerformConstantOps_;
 };
 
-template <typename Builder_, size_t table_size, size_t num_reads, bool perform_constant_ops> class ROMTestingFunctions {
+template <typename Builder_, size_t table_size, size_t num_reads> class ROMTestingFunctions {
   public:
     using AcirConstraint = BlockConstraint;
     using Builder = Builder_;
@@ -125,19 +80,15 @@ template <typename Builder_, size_t table_size, size_t num_reads, bool perform_c
                 // Add value witness
                 bb::fr read_value = table_values[rom_index_to_read];
 
-                WitnessOrConstant<bb::fr> index_for_read = WitnessOrConstant<bb::fr>::from_index(
-                    add_to_witness_and_track_indices(witness_values, bb::fr(rom_index_to_read)));
-                WitnessOrConstant<bb::fr> value_for_read =
-                    WitnessOrConstant<bb::fr>::from_index(add_to_witness_and_track_indices(witness_values, read_value));
+                const uint32_t index_for_read =
+                    add_to_witness_and_track_indices(witness_values, bb::fr(rom_index_to_read));
+                const uint32_t value_for_read = add_to_witness_and_track_indices(witness_values, read_value);
 
                 const MemOp read_op = { .access_type = AccessType::Read,
                                         .index = index_for_read,
                                         .value = value_for_read };
 
                 trace.push_back(read_op);
-            }
-            if constexpr (perform_constant_ops) {
-                add_constant_ops<AccessType::Read>(table_size, table_values, witness_values, trace);
             }
         }
         // Create the MemoryConstraint
@@ -169,26 +120,17 @@ template <typename Builder_, size_t table_size, size_t num_reads, bool perform_c
 };
 template <typename Params>
 class ROMTest : public ::testing::Test,
-                public TestClass<ROMTestingFunctions<typename Params::Builder,
-                                                     Params::table_size,
-                                                     Params::num_reads,
-                                                     Params::perform_constant_ops>> {
+                public TestClass<ROMTestingFunctions<typename Params::Builder, Params::table_size, Params::num_reads>> {
   protected:
     static void SetUpTestSuite() { bb::srs::init_file_crs_factory(bb::srs::bb_crs_path()); }
 };
 
-using ROMTestConfigs = testing::Types<ROMTestParams<UltraCircuitBuilder, 0, 0, false>,
-                                      ROMTestParams<UltraCircuitBuilder, 10, 0, false>,
-                                      ROMTestParams<UltraCircuitBuilder, 10, 0, true>, // Test the case in which there
-                                                                                       // are only constant operations
-                                      ROMTestParams<UltraCircuitBuilder, 10, 20, false>,
-                                      ROMTestParams<UltraCircuitBuilder, 10, 20, true>,
-                                      ROMTestParams<MegaCircuitBuilder, 0, 0, false>,
-                                      ROMTestParams<MegaCircuitBuilder, 10, 0, false>,
-                                      ROMTestParams<MegaCircuitBuilder, 10, 0, true>, // Test the case in which there
-                                                                                      // are only constant operations
-                                      ROMTestParams<MegaCircuitBuilder, 10, 20, false>,
-                                      ROMTestParams<MegaCircuitBuilder, 10, 20, true>>;
+using ROMTestConfigs = testing::Types<ROMTestParams<UltraCircuitBuilder, 0, 0>,
+                                      ROMTestParams<UltraCircuitBuilder, 10, 0>,
+                                      ROMTestParams<UltraCircuitBuilder, 10, 20>,
+                                      ROMTestParams<MegaCircuitBuilder, 0, 0>,
+                                      ROMTestParams<MegaCircuitBuilder, 10, 0>,
+                                      ROMTestParams<MegaCircuitBuilder, 10, 20>>;
 TYPED_TEST_SUITE(ROMTest, ROMTestConfigs);
 
 TYPED_TEST(ROMTest, GenerateVKFromConstraints)
@@ -203,17 +145,14 @@ TYPED_TEST(ROMTest, Tampering)
     TestFixture::test_tampering();
 }
 
-template <typename Builder_, size_t TableSize_, size_t NumReads_, size_t NumWrites_, bool PerformConstantOps_>
-struct RAMTestParams {
+template <typename Builder_, size_t TableSize_, size_t NumReads_, size_t NumWrites_> struct RAMTestParams {
     using Builder = Builder_;
     static constexpr size_t table_size = TableSize_;
     static constexpr size_t num_reads = NumReads_;
     static constexpr size_t num_writes = NumWrites_;
-    static constexpr bool perform_constant_ops = PerformConstantOps_;
 };
 
-template <typename Builder_, size_t table_size, size_t num_reads, size_t num_writes, bool perform_constant_ops>
-class RAMTestingFunctions {
+template <typename Builder_, size_t table_size, size_t num_reads, size_t num_writes> class RAMTestingFunctions {
   public:
     using AcirConstraint = BlockConstraint;
     using Builder = Builder_;
@@ -299,9 +238,7 @@ class RAMTestingFunctions {
                     bb::fr read_value = table_values[ram_index_to_read];
                     const uint32_t value_for_read = add_to_witness_and_track_indices(witness_values, read_value);
 
-                    mem_op = { .access_type = AccessType::Read,
-                               .index = WitnessOrConstant<bb::fr>::from_index(index_for_read),
-                               .value = WitnessOrConstant<bb::fr>::from_index(value_for_read) };
+                    mem_op = { .access_type = AccessType::Read, .index = index_for_read, .value = value_for_read };
                     trace.push_back(mem_op);
                     break;
                 }
@@ -315,17 +252,11 @@ class RAMTestingFunctions {
                     // Update the table_values to reflect this write
                     table_values[ram_index_to_write] = write_value;
 
-                    mem_op = { .access_type = AccessType::Write,
-                               .index = WitnessOrConstant<bb::fr>::from_index(index_to_write),
-                               .value = WitnessOrConstant<bb::fr>::from_index(value_to_write) };
+                    mem_op = { .access_type = AccessType::Write, .index = index_to_write, .value = value_to_write };
                     trace.push_back(mem_op);
                     break;
                 }
                 }
-            }
-            if constexpr (perform_constant_ops) {
-                add_constant_ops<AccessType::Read>(table_size, table_values, witness_values, trace);
-                add_constant_ops<AccessType::Write>(table_size, table_values, witness_values, trace);
             }
         }
 
@@ -349,7 +280,7 @@ class RAMTestingFunctions {
                     // Find a read operation
                     random_read_idx = static_cast<size_t>(engine.get_random_uint32() % (num_reads + num_writes));
                 }
-                const uint32_t witness_idx = memory_constraint.trace[random_read_idx].value.index;
+                const uint32_t witness_idx = memory_constraint.trace[random_read_idx].value;
                 witness_values[witness_idx] += bb::fr(1);
             }
             break;
@@ -360,36 +291,25 @@ class RAMTestingFunctions {
 };
 
 template <typename Params>
-class RAMTest : public ::testing::Test,
-                public TestClass<RAMTestingFunctions<typename Params::Builder,
-                                                     Params::table_size,
-                                                     Params::num_reads,
-                                                     Params::num_writes,
-                                                     Params::perform_constant_ops>> {
+class RAMTest
+    : public ::testing::Test,
+      public TestClass<
+          RAMTestingFunctions<typename Params::Builder, Params::table_size, Params::num_reads, Params::num_writes>> {
   protected:
     static void SetUpTestSuite() { bb::srs::init_file_crs_factory(bb::srs::bb_crs_path()); }
 };
 
 // Failure tests are impossible in the scenario with only writes.
-using RAMTestConfigs =
-    testing::Types<RAMTestParams<UltraCircuitBuilder, 0, 0, 0, false>,
-                   RAMTestParams<UltraCircuitBuilder, 10, 0, 0, false>,
-                   RAMTestParams<UltraCircuitBuilder, 10, 0, 0, true>, // Test the case in which there are only
-                                                                       // constant operations
-                   RAMTestParams<UltraCircuitBuilder, 10, 0, 10, false>,
-                   RAMTestParams<UltraCircuitBuilder, 10, 0, 10, true>,
-                   RAMTestParams<UltraCircuitBuilder, 10, 10, 0, false>,
-                   RAMTestParams<UltraCircuitBuilder, 10, 10, 0, true>,
-                   RAMTestParams<UltraCircuitBuilder, 10, 20, 10, true>,
-                   RAMTestParams<MegaCircuitBuilder, 0, 0, 0, false>,
-                   RAMTestParams<MegaCircuitBuilder, 10, 0, 0, false>,
-                   RAMTestParams<MegaCircuitBuilder, 10, 0, 0, true>, // Test the case in which there are only
-                                                                      // constant operations
-                   RAMTestParams<MegaCircuitBuilder, 10, 0, 10, false>,
-                   RAMTestParams<MegaCircuitBuilder, 10, 0, 10, true>,
-                   RAMTestParams<MegaCircuitBuilder, 10, 10, 0, false>,
-                   RAMTestParams<MegaCircuitBuilder, 10, 10, 0, true>,
-                   RAMTestParams<MegaCircuitBuilder, 10, 20, 10, true>>;
+using RAMTestConfigs = testing::Types<RAMTestParams<UltraCircuitBuilder, 0, 0, 0>,
+                                      RAMTestParams<UltraCircuitBuilder, 10, 0, 0>,
+                                      RAMTestParams<UltraCircuitBuilder, 10, 0, 10>,
+                                      RAMTestParams<UltraCircuitBuilder, 10, 10, 0>,
+                                      RAMTestParams<UltraCircuitBuilder, 10, 20, 10>,
+                                      RAMTestParams<MegaCircuitBuilder, 0, 0, 0>,
+                                      RAMTestParams<MegaCircuitBuilder, 10, 0, 0>,
+                                      RAMTestParams<MegaCircuitBuilder, 10, 0, 10>,
+                                      RAMTestParams<MegaCircuitBuilder, 10, 10, 0>,
+                                      RAMTestParams<MegaCircuitBuilder, 10, 20, 10>>;
 
 TYPED_TEST_SUITE(RAMTest, RAMTestConfigs);
 
@@ -405,16 +325,13 @@ TYPED_TEST(RAMTest, Tampering)
     TestFixture::test_tampering();
 }
 
-template <CallDataType CallDataType_, size_t CallDataSize_, size_t NumReads_, bool PerformConstantOps_>
-struct CallDataTestParams {
+template <CallDataType CallDataType_, size_t CallDataSize_, size_t NumReads_> struct CallDataTestParams {
     static constexpr CallDataType calldata_type = CallDataType_;
     static constexpr size_t calldata_size = CallDataSize_;
     static constexpr size_t num_reads = NumReads_;
-    static constexpr bool perform_constant_ops = PerformConstantOps_;
 };
 
-template <CallDataType calldata_type, size_t calldata_size, size_t num_reads, bool perform_constant_ops>
-class CallDataTestingFunctions {
+template <CallDataType calldata_type, size_t calldata_size, size_t num_reads> class CallDataTestingFunctions {
   public:
     using AcirConstraint = BlockConstraint;
     using Builder = MegaCircuitBuilder;
@@ -471,14 +388,9 @@ class CallDataTestingFunctions {
                 bb::fr read_value = calldata_values[calldata_idx_to_read];
                 const uint32_t value_for_read = add_to_witness_and_track_indices(witness_values, read_value);
 
-                mem_op = { .access_type = AccessType::Read,
-                           .index = WitnessOrConstant<bb::fr>::from_index(index_for_read),
-                           .value = WitnessOrConstant<bb::fr>::from_index(value_for_read) };
+                mem_op = { .access_type = AccessType::Read, .index = index_for_read, .value = value_for_read };
                 trace.push_back(mem_op);
             }
-        }
-        if constexpr (perform_constant_ops) {
-            add_constant_ops<AccessType::Read>(calldata_size, calldata_values, witness_values, trace);
         }
 
         // Create the MemoryConstraint
@@ -499,7 +411,7 @@ class CallDataTestingFunctions {
             // Tamper with a random read value using the recorded witness index
             if constexpr (num_reads > 0) {
                 const size_t random_read_idx = static_cast<size_t>(engine.get_random_uint32() % num_reads);
-                const uint32_t witness_idx = memory_constraint.trace[random_read_idx].index.index;
+                const uint32_t witness_idx = memory_constraint.trace[random_read_idx].index;
                 witness_values[witness_idx] += bb::fr(1);
             }
             break;
@@ -509,21 +421,17 @@ class CallDataTestingFunctions {
     }
 };
 
-using CallDataTestConfigs = testing::Types<CallDataTestParams<CallDataType::KernelCalldata, 0, 0, false>,
-                                           CallDataTestParams<CallDataType::KernelCalldata, 10, 5, false>,
-                                           CallDataTestParams<CallDataType::KernelCalldata, 10, 5, true>,
-                                           CallDataTestParams<CallDataType::FirstAppCalldata, 0, 0, false>,
-                                           CallDataTestParams<CallDataType::FirstAppCalldata, 10, 5, false>,
-                                           CallDataTestParams<CallDataType::FirstAppCalldata, 10, 5, true>,
-                                           CallDataTestParams<CallDataType::SecondAppCalldata, 10, 5, false>,
-                                           CallDataTestParams<CallDataType::ThirdAppCalldata, 10, 5, false>>;
+using CallDataTestConfigs = testing::Types<CallDataTestParams<CallDataType::KernelCalldata, 0, 0>,
+                                           CallDataTestParams<CallDataType::KernelCalldata, 10, 5>,
+                                           CallDataTestParams<CallDataType::FirstAppCalldata, 0, 0>,
+                                           CallDataTestParams<CallDataType::FirstAppCalldata, 10, 5>,
+                                           CallDataTestParams<CallDataType::SecondAppCalldata, 10, 5>,
+                                           CallDataTestParams<CallDataType::ThirdAppCalldata, 10, 5>>;
 
 template <typename Params>
-class CallDataTests : public ::testing::Test,
-                      public TestClass<CallDataTestingFunctions<Params::calldata_type,
-                                                                Params::calldata_size,
-                                                                Params::num_reads,
-                                                                Params::perform_constant_ops>> {
+class CallDataTests
+    : public ::testing::Test,
+      public TestClass<CallDataTestingFunctions<Params::calldata_type, Params::calldata_size, Params::num_reads>> {
   protected:
     static void SetUpTestSuite() { bb::srs::init_file_crs_factory(bb::srs::bb_crs_path()); }
 };

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/opcode_gate_count.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/opcode_gate_count.test.cpp
@@ -476,8 +476,8 @@ TYPED_TEST(OpcodeGateCountTests, BlockRomRead)
     std::vector<MemOp> trace;
     trace.push_back(MemOp{
         .access_type = AccessType::Read,
-        .index = WitnessOrConstant<bb::fr>::from_index(2), // 0
-        .value = WitnessOrConstant<bb::fr>::from_index(3), // 10
+        .index = 2, // 0
+        .value = 3, // 10
     });
 
     BlockConstraint block_constraint{
@@ -512,8 +512,8 @@ TYPED_TEST(OpcodeGateCountTests, BlockRamRead)
     std::vector<MemOp> trace;
     trace.push_back(MemOp{
         .access_type = AccessType::Read,
-        .index = WitnessOrConstant<bb::fr>::from_index(2), // 0
-        .value = WitnessOrConstant<bb::fr>::from_index(3), // 10
+        .index = 2, // 0
+        .value = 3, // 10
     });
 
     BlockConstraint block_constraint{
@@ -548,8 +548,8 @@ TYPED_TEST(OpcodeGateCountTests, BlockRamWrite)
     std::vector<MemOp> trace;
     trace.push_back(MemOp{
         .access_type = AccessType::Write,
-        .index = WitnessOrConstant<bb::fr>::from_index(2), // 0
-        .value = WitnessOrConstant<bb::fr>::from_index(3), // 10
+        .index = 2, // 0
+        .value = 3, // 10
     });
 
     BlockConstraint block_constraint{
@@ -588,8 +588,8 @@ TYPED_TEST(OpcodeGateCountTests, BlockCallData)
     std::vector<MemOp> trace;
     trace.push_back(MemOp{
         .access_type = AccessType::Read,
-        .index = WitnessOrConstant<bb::fr>::from_index(2), // 0
-        .value = WitnessOrConstant<bb::fr>::from_index(3), // 10
+        .index = 2, // 0
+        .value = 3, // 10
     });
 
     // Kernel calldata

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/test_class.hpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/test_class.hpp
@@ -83,14 +83,26 @@ inline Acir::Expression access_type_to_expression(AccessType access_type)
 }
 
 /**
+ * @brief Convert a witness index to an Acir::Expression representing a single unscaled witness term.
+ */
+inline Acir::Expression witness_to_expression(uint32_t witness_index)
+{
+    return Acir::Expression{
+        .mul_terms = {},
+        .linear_combinations = { std::make_tuple(bb::fr::one().to_buffer(), Acir::Witness{ .value = witness_index }) },
+        .q_c = bb::fr::zero().to_buffer(),
+    };
+}
+
+/**
  * @brief Convert an acir_format::MemOp to an Acir::MemOp.
  */
 inline Acir::MemOp mem_op_to_acir_mem_op(const MemOp& mem_op)
 {
     return Acir::MemOp{
         .operation = access_type_to_expression(mem_op.access_type),
-        .index = witness_or_constant_to_expression(mem_op.index),
-        .value = witness_or_constant_to_expression(mem_op.value),
+        .index = witness_to_expression(mem_op.index),
+        .value = witness_to_expression(mem_op.value),
     };
 }
 


### PR DESCRIPTION
## Summary

- `acir_format::MemOp.index` and `MemOp.value` become plain `uint32_t` witness indices instead of `WitnessOrConstant<bb::fr>`.
- The deserializer in `acir_to_constraint_buf.cpp` now asserts the Noir-side `Acir::Expression` is a single unscaled witness, matching what Noir actually emits (see `MemOp::read_at_mem_index` / `write_to_mem_index` in `acvm-repo/acir/src/circuit/opcodes/memory_operation.rs` — both take `Witness`, not `Expression`).
- Drops the `add_constant_ops` helper and `perform_constant_ops` parameterization from ROM/RAM/CallData tests, since the path being exercised never came up in production.

## Test plan

- [ ] `ninja dsl_tests` passes (note: my local build hits a pre-existing gtest cxx11-ABI link error; the affected `.cpp.o` objects compile cleanly)
- [ ] CI green