### PR TITLE
chore(ci): gitignore bb-chonk-inputs.tar.gz to fix rebuild-patterns race

### DIFF
--- a/barretenberg/.gitignore
+++ b/barretenberg/.gitignore
@@ -9,6 +9,11 @@ cmake-build-debug
 *_opt.pil
 bench-out
 
+# Transient artifact downloaded/extracted by test_chonk_standalone_vks_havent_changed.sh.
+# If left untracked it trips ci3's rebuild-patterns check, since two .rebuild_patterns
+# files (barretenberg/cpp and barretenberg/sol) include `^barretenberg/cpp/scripts/`.
+cpp/scripts/bb-chonk-inputs.tar.gz
+
 # Generated code from msgpack schema (run `yarn generate` in ts/)
 rust/barretenberg-rs/src/generated_types.rs
 rust/barretenberg-rs/src/api.rs


### PR DESCRIPTION
## Summary

\`test_chonk_standalone_vks_havent_changed.sh\` downloads the pinned IVC inputs tarball into its own working directory (relative path), which resolves to \`barretenberg/cpp/scripts/bb-chonk-inputs.tar.gz\`. Both \`barretenberg/cpp/.rebuild_patterns\` and \`barretenberg/sol/.rebuild_patterns\` include \`^barretenberg/cpp/scripts/\`, so during the small window the tarball is on disk any concurrent \`cache_content_hash\` call that uses those patterns aborts with:

\`\`\`
ERROR: Noticed changes to rebuild patterns during CI run: barretenberg/cpp/scripts/bb-chonk-inputs.tar.gz
\`\`\`

## Why it's a real race

The script \`trap\`s cleanup on EXIT/SIGINT, so the file is normally short-lived — but on a hard kill (OOM, runner reboot) the leak is permanent for that runner. Gitignoring the file makes \`git ls-files --others --exclude-standard\` skip it regardless, fixing both the live race and the hard-kill edge case.

## Recent occurrence

Took out the merge queue for #23040: example_uniswap / aave_bridge / bob_token_contract Noir compiles failed in the docs build during the retry; the missing artifacts surfaced ~11 minutes later as

\`\`\`
ERROR: Compiled artifact not found: /root/aztec-packages/docs/target/example_uniswap-ExampleUniswap.json
\`\`\`

## Why not move the tarball to mktemp

That would also work, but a 1-line gitignore is minimal and defends against any future relative-path writers in \`barretenberg/cpp/scripts/\` that hit the same pattern.

## Test plan
- This fix can only be exercised by the race itself; no unit test possible. Verified by reading the code path in \`ci3/cache_content_hash\` and the script.