### PR TITLE
refactor(aztec-nr): Option-returning block hash membership witness oracle

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/oracle/get_membership_witness.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/get_membership_witness.nr
@@ -11,19 +11,17 @@ unconstrained fn get_note_hash_membership_witness_oracle(
     note_hash: Field,
 ) -> MembershipWitness<NOTE_HASH_TREE_HEIGHT> {}
 
-#[oracle(aztec_utl_getBlockHashMembershipWitness)]
+#[oracle(aztec_utl_getBlockHashMembershipWitnessV2)]
 unconstrained fn get_block_hash_membership_witness_oracle(
     anchor_block_hash: Field,
     block_hash: Field,
-) -> MembershipWitness<ARCHIVE_HEIGHT> {}
-
-#[oracle(aztec_utl_isBlockInArchive)]
-unconstrained fn is_block_in_archive_oracle(anchor_block_hash: Field, block_hash: Field) -> bool {}
+) -> Option<MembershipWitness<ARCHIVE_HEIGHT>> {}
 
 // Note: get_nullifier_membership_witness function is implemented in get_nullifier_membership_witness.nr
 
 /// Returns a membership witness for a `note_hash` in the note hash tree whose root is defined in
 // `anchor_block_header`.
+// TODO(https://linear.app/aztec-labs/issue/F-652): add Noir tests for this oracle
 pub unconstrained fn get_note_hash_membership_witness(
     anchor_block_header: BlockHeader,
     note_hash: Field,
@@ -41,14 +39,102 @@ pub unconstrained fn get_block_hash_membership_witness(
     block_hash: Field,
 ) -> MembershipWitness<ARCHIVE_HEIGHT> {
     let anchor_block_hash = anchor_block_header.hash();
+    get_block_hash_membership_witness_oracle(anchor_block_hash, block_hash).expect(
+        f"Block hash {block_hash} not found in the archive tree at anchor block {anchor_block_hash}.",
+    )
+}
+
+/// Same as [`get_block_hash_membership_witness`], but returns `None` instead of erroring when the block is not present
+/// in the archive tree. Intended for callers that need to handle absence (e.g. existence checks via `.is_some()`).
+pub unconstrained fn get_maybe_block_hash_membership_witness(
+    anchor_block_header: BlockHeader,
+    block_hash: Field,
+) -> Option<MembershipWitness<ARCHIVE_HEIGHT>> {
+    let anchor_block_hash = anchor_block_header.hash();
     get_block_hash_membership_witness_oracle(anchor_block_hash, block_hash)
 }
 
-/// Returns `true` if `block_hash` is present in the archive tree whose root is defined in `anchor_block_header`
-/// (i.e. it is an ancestor of the anchor block). Unlike `get_block_hash_membership_witness`, this does not return
-/// the witness and does not fail when the block is absent - it simply returns `false`. Intended for unconstrained
-/// flows that only need existence.
-pub unconstrained fn is_block_in_archive(anchor_block_header: BlockHeader, block_hash: Field) -> bool {
-    let anchor_block_hash = anchor_block_header.hash();
-    is_block_in_archive_oracle(anchor_block_hash, block_hash)
+mod test {
+    use crate::oracle::block_header::get_block_header_at;
+    use crate::protocol::{merkle_tree::root::root_from_sibling_path, traits::Hash};
+    use crate::test::helpers::test_environment::TestEnvironment;
+    use super::{get_block_hash_membership_witness, get_maybe_block_hash_membership_witness};
+
+    #[test]
+    unconstrained fn get_block_hash_membership_witness_returns_valid_witness_for_known_block() {
+        let env = TestEnvironment::new();
+
+        env.mine_block();
+        env.mine_block();
+        env.mine_block();
+        env.mine_block();
+
+        env.private_context(|context| {
+            let anchor = context.anchor_block_header;
+            let target_block_number = anchor.block_number() - 2;
+
+            let target_header = get_block_header_at(target_block_number, *context);
+            let target_hash = target_header.hash();
+
+            let witness = get_block_hash_membership_witness(anchor, target_hash);
+
+            assert_eq(
+                root_from_sibling_path(target_hash, witness.leaf_index, witness.sibling_path),
+                anchor.last_archive.root,
+            );
+        });
+    }
+
+    #[test(should_fail_with = "not found in the archive tree at anchor block")]
+    unconstrained fn get_block_hash_membership_witness_panics_for_unknown_block() {
+        let env = TestEnvironment::new();
+
+        env.mine_block();
+        env.mine_block();
+
+        env.private_context(|context| {
+            let anchor = context.anchor_block_header;
+            let _witness = get_block_hash_membership_witness(anchor, 0xdeadbeef);
+        });
+    }
+
+    #[test]
+    unconstrained fn get_maybe_block_hash_membership_witness_returns_some_for_known_block() {
+        let env = TestEnvironment::new();
+
+        env.mine_block();
+        env.mine_block();
+        env.mine_block();
+        env.mine_block();
+
+        env.private_context(|context| {
+            let anchor = context.anchor_block_header;
+            let target_block_number = anchor.block_number() - 2;
+
+            let target_header = get_block_header_at(target_block_number, *context);
+            let target_hash = target_header.hash();
+
+            let witness = get_maybe_block_hash_membership_witness(anchor, target_hash).expect(
+                f"Expected Some witness for known block hash",
+            );
+
+            assert_eq(
+                root_from_sibling_path(target_hash, witness.leaf_index, witness.sibling_path),
+                anchor.last_archive.root,
+            );
+        });
+    }
+
+    #[test]
+    unconstrained fn get_maybe_block_hash_membership_witness_returns_none_for_unknown_block() {
+        let env = TestEnvironment::new();
+
+        env.mine_block();
+        env.mine_block();
+
+        env.private_context(|context| {
+            let anchor = context.anchor_block_header;
+            assert(get_maybe_block_hash_membership_witness(anchor, 0xdeadbeef).is_none());
+        });
+    }
 }

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/oracle.ts
@@ -1,4 +1,5 @@
 import {
+  ARCHIVE_HEIGHT,
   MAX_CONTRACT_CLASS_LOGS_PER_TX,
   MAX_L2_TO_L1_MSGS_PER_TX,
   MAX_NOTE_HASHES_PER_TX,
@@ -10,6 +11,7 @@ import { BlockNumber } from '@aztec/foundation/branded-types';
 import { padArrayEnd } from '@aztec/foundation/collection';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { Point } from '@aztec/foundation/curves/grumpkin';
+import { MembershipWitness } from '@aztec/foundation/trees';
 import {
   type ACIRCallback,
   type ACVMField,
@@ -248,6 +250,7 @@ export class Oracle {
     return witness.toNoirRepresentation();
   }
 
+  // TODO(https://linear.app/aztec-labs/issue/F-651): drop this
   // eslint-disable-next-line camelcase
   async aztec_utl_getBlockHashMembershipWitness(
     [anchorBlockHash]: ACVMField[],
@@ -265,13 +268,18 @@ export class Oracle {
     return witness.toNoirRepresentation();
   }
 
+  // TODO(https://linear.app/aztec-labs/issue/F-651): rename to aztec_utl_getBlockHashMembershipWitness
   // eslint-disable-next-line camelcase
-  async aztec_utl_isBlockInArchive([anchorBlockHash]: ACVMField[], [blockHash]: ACVMField[]): Promise<ACVMField[]> {
+  async aztec_utl_getBlockHashMembershipWitnessV2(
+    [anchorBlockHash]: ACVMField[],
+    [blockHash]: ACVMField[],
+  ): Promise<(ACVMField | ACVMField[])[]> {
     const parsedAnchorBlockHash = BlockHash.fromString(anchorBlockHash);
     const parsedBlockHash = BlockHash.fromString(blockHash);
 
     const witness = await this.handlerAsUtility().getBlockHashMembershipWitness(parsedAnchorBlockHash, parsedBlockHash);
-    return [toACVMField(witness !== undefined)];
+    const effective = witness ?? MembershipWitness.empty(ARCHIVE_HEIGHT);
+    return [toACVMField(witness !== undefined ? 1 : 0), ...effective.toNoirRepresentation()];
   }
 
   // eslint-disable-next-line camelcase

--- a/yarn-project/pxe/src/oracle_version.ts
+++ b/yarn-project/pxe/src/oracle_version.ts
@@ -19,4 +19,4 @@ export const ORACLE_VERSION_MINOR = 3;
 /// - increment only `ORACLE_VERSION_MINOR` if the change is additive (a new oracle was added).
 ///
 /// These constants must be kept in sync between this file and `noir-projects/aztec-nr/aztec/src/oracle/version.nr`.
-export const ORACLE_INTERFACE_HASH = '9e355056f30b7a510d205fa2794cd0a63e7d9c300953bdf35a23725f1e92f57f';
+export const ORACLE_INTERFACE_HASH = '0649632102f27d1411749e46733b96103eaac948914d328afc4b90d3bf6e5af5';

--- a/yarn-project/txe/src/rpc_translator.ts
+++ b/yarn-project/txe/src/rpc_translator.ts
@@ -1,6 +1,7 @@
 import type { ContractInstanceWithAddress } from '@aztec/aztec.js/contracts';
 import { Fr, Point } from '@aztec/aztec.js/fields';
 import {
+  ARCHIVE_HEIGHT,
   MAX_NOTE_HASHES_PER_TX,
   MAX_NULLIFIERS_PER_TX,
   MAX_PRIVATE_LOGS_PER_TX,
@@ -8,6 +9,7 @@ import {
   PRIVATE_LOG_SIZE_IN_FIELDS,
 } from '@aztec/constants';
 import { BlockNumber } from '@aztec/foundation/branded-types';
+import { MembershipWitness } from '@aztec/foundation/trees';
 import {
   type IMiscOracle,
   type IPrivateExecutionOracle,
@@ -776,6 +778,7 @@ export class RPCTranslator {
     return toForeignCallResult(witness.toNoirRepresentation());
   }
 
+  // TODO(https://linear.app/aztec-labs/issue/F-651): drop this
   // eslint-disable-next-line camelcase
   async aztec_utl_getBlockHashMembershipWitness(
     foreignAnchorBlockHash: ForeignCallSingle,
@@ -794,14 +797,18 @@ export class RPCTranslator {
     return toForeignCallResult(witness.toNoirRepresentation());
   }
 
+  // TODO(https://linear.app/aztec-labs/issue/F-651): rename to aztec_utl_getBlockHashMembershipWitness
   // eslint-disable-next-line camelcase
-  async aztec_utl_isBlockInArchive(foreignAnchorBlockHash: ForeignCallSingle, foreignBlockHash: ForeignCallSingle) {
+  async aztec_utl_getBlockHashMembershipWitnessV2(
+    foreignAnchorBlockHash: ForeignCallSingle,
+    foreignBlockHash: ForeignCallSingle,
+  ) {
     const anchorBlockHash = new BlockHash(fromSingle(foreignAnchorBlockHash));
     const blockHash = new BlockHash(fromSingle(foreignBlockHash));
 
     const witness = await this.handlerAsUtility().getBlockHashMembershipWitness(anchorBlockHash, blockHash);
-
-    return toForeignCallResult([toSingle(new Fr(witness !== undefined))]);
+    const effective = witness ?? MembershipWitness.empty(ARCHIVE_HEIGHT);
+    return toForeignCallResult([toSingle(new Fr(witness !== undefined ? 1 : 0)), ...effective.toNoirRepresentation()]);
   }
 
   // eslint-disable-next-line camelcase


### PR DESCRIPTION
## Summary

- Replaces `aztec_utl_isBlockInArchive` with `aztec_utl_getBlockHashMembershipWitnessV2`, which returns `Option<MembershipWitness<ARCHIVE_HEIGHT>>` instead of a bool. Callers wanting existence-only can use `.is_some()`.
- Exposes a new `get_maybe_block_hash_membership_witness` Noir wrapper for callers that want to handle absence.
- Refactors `get_block_hash_membership_witness` to call the V2 oracle and `.expect()` on the Option, producing a richer panic message that includes the block hash and anchor block hash.
- TXE and PXE handlers updated accordingly. The legacy V1 TS handlers are kept for now and marked with a TODO linking [F-651](https://linear.app/aztec-labs/issue/F-651/replace-aztec-utl-getblockhashmembershipwitness-with-aztec-utl) for follow-up cleanup once Noir-side callers (currently still pointing at the V1 oracle through `get_block_hash_membership_witness`) are migrated.
- Adds direct in-tree Noir tests for both `get_block_hash_membership_witness` and `get_maybe_block_hash_membership_witness` (success path and unknown-hash path).
- Flags `get_note_hash_membership_witness` with a TODO pointing at [F-652](https://linear.app/aztec-labs/issue/F-652/implement-noir-tests-of-aztec-utl-getnotehashmembershipwitness) for analogous test coverage.

Motivation: discussion at https://github.com/AztecProtocol/aztec-packages/pull/22979#discussion_r3225056604 — `aztec_utl_isBlockInArchive` only existed because the witness oracle panicked on miss; the Option-returning V2 collapses that surface and lets callers handle absence in Noir.

## Test plan

- [ ] `nargo test` in `noir-projects/aztec-nr/aztec` — new tests in `oracle::get_membership_witness::test` pass (note: blocked locally by a pre-existing TXE bootstrap issue affecting all `private_context` tests; expect CI to run them cleanly).
- [ ] `yarn build` in `yarn-project` — PXE and TXE packages build cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)