### PR TITLE
chore: remove orphan --archiver flag usages from start invocations

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,7 +54,7 @@ services:
           fi;
         done;
 
-        node /usr/src/yarn-project/aztec/dest/bin/index.js start --node --archiver
+        node /usr/src/yarn-project/aztec/dest/bin/index.js start --node
       '
     volumes:
       - aztec:/var/lib/aztec

--- a/docs/docs-operate/operators/monitoring/troubleshooting.md
+++ b/docs/docs-operate/operators/monitoring/troubleshooting.md
@@ -35,7 +35,6 @@ services:
       /usr/src/yarn-project/aztec/dest/bin/index.js
       start
       --node
-      --archiver
       --network #release_network
     networks:
       - aztec

--- a/docs/docs-operate/operators/reference/cli-reference.md
+++ b/docs/docs-operate/operators/reference/cli-reference.md
@@ -26,7 +26,7 @@ tags:
 **Configuration notes:**
 
 - The environment variable name corresponding to each flag is shown as $ENV_VAR on the right hand side.
-- If two subsystems can contain the same configuration option, only one needs to be provided. For example, `--archiver.blobSinkUrl` and `--sequencer.blobSinkUrl` point to the same value if the node is started with both the `--archiver` and `--sequencer` options.
+- If two subsystems can contain the same configuration option, only one needs to be provided. For example, `--archiver.blobSinkUrl` and `--sequencer.blobSinkUrl` point to the same value.
 
 ```bash
   MISC
@@ -118,9 +118,6 @@ tags:
           Starts Aztec Node with options
 
   ARCHIVER
-
-    --archiver
-          Starts Aztec Archiver with options
 
     --archiver.blobSinkUrl <value>                                                                                                         ($BLOB_SINK_URL)
           The URL of the blob sink

--- a/docs/docs-operate/operators/setup/running-a-node.md
+++ b/docs/docs-operate/operators/setup/running-a-node.md
@@ -96,7 +96,6 @@ services:
       /usr/src/yarn-project/aztec/dest/bin/index.js
       start
       --node
-      --archiver
       --network #release_network
     networks:
       - aztec

--- a/docs/docs-operate/operators/setup/running-a-prover.md
+++ b/docs/docs-operate/operators/setup/running-a-prover.md
@@ -155,7 +155,6 @@ services:
       /usr/src/yarn-project/aztec/dest/bin/index.js
       start
       --prover-node
-      --archiver
       --network #release_network
     depends_on:
       prover-broker:

--- a/docs/docs-operate/operators/setup/sequencer-setup.md
+++ b/docs/docs-operate/operators/setup/sequencer-setup.md
@@ -410,7 +410,6 @@ services:
       /usr/src/yarn-project/aztec/dest/bin/index.js
       start
       --node
-      --archiver
       --sequencer
       --network #release_network
     networks:

--- a/spartan/aztec-node/README.md
+++ b/spartan/aztec-node/README.md
@@ -40,7 +40,6 @@ node:
 
   startCmd:
     - --node
-    - --archiver
 
   startupProbe:
     # -- Period seconds
@@ -91,7 +90,6 @@ node:
 
   startCmd:
     - --node
-    - --archiver
     - --sequencer
 
   startupProbe:
@@ -144,7 +142,7 @@ service:
 | node.l1ConsensusUrls | [] | L1 consensus host URLs (comma-separated list) |
 | node.l1ConsensusHostApiKeys | [] | API keys for L1 consensus hosts |
 | node.l1ConsensusHostApiKeyHeaders | [] | API key headers for L1 consensus hosts |
-| node.startCmd | ["--node", "--archiver"] | Startup command for the node |
+| node.startCmd | ["--node"] | Startup command for the node |
 | node.remoteUrl.archiver | - | Remote URL for archiver |
 | node.remoteUrl.proverBroker | - | Remote URL for prover broker |
 | node.remoteUrl.proverCoordinationNodes | [] | Remote URLs for prover coordination nodes |

--- a/spartan/aztec-node/values.yaml
+++ b/spartan/aztec-node/values.yaml
@@ -78,7 +78,6 @@ node:
 
   startCmd:
     - --node
-    - --archiver
 
   image:
     repository: ""

--- a/spartan/aztec-prover-stack/values.yaml
+++ b/spartan/aztec-prover-stack/values.yaml
@@ -39,7 +39,6 @@ node:
 
     startCmd:
       - --prover-node
-      - --archiver
 
     configMap:
       envEnabled: true

--- a/spartan/aztec-validator/values.yaml
+++ b/spartan/aztec-validator/values.yaml
@@ -40,7 +40,6 @@ validator:
 
     startCmd:
       - --node
-      - --archiver
       - --sequencer
 
   web3signerUrl: ""

--- a/spartan/terraform/deploy-aztec-infra/values/archive.yaml
+++ b/spartan/terraform/deploy-aztec-infra/values/archive.yaml
@@ -3,4 +3,3 @@ node:
     OTEL_SERVICE_NAME: "archival-node"
   startCmd:
     - --node
-    - --archiver

--- a/spartan/terraform/deploy-aztec-infra/values/blob-sink.yaml
+++ b/spartan/terraform/deploy-aztec-infra/values/blob-sink.yaml
@@ -16,4 +16,3 @@ node:
 
   startCmd:
     - --node
-    - --archiver

--- a/spartan/terraform/deploy-aztec-infra/values/full-node.yaml
+++ b/spartan/terraform/deploy-aztec-infra/values/full-node.yaml
@@ -16,4 +16,3 @@ node:
 
   startCmd:
     - --node
-    - --archiver

--- a/spartan/terraform/deploy-aztec-infra/values/rpc.yaml
+++ b/spartan/terraform/deploy-aztec-infra/values/rpc.yaml
@@ -19,4 +19,3 @@ node:
 
   startCmd:
     - --node
-    - --archiver

--- a/yarn-project/aztec/src/cli/aztec_start_options.ts
+++ b/yarn-project/aztec/src/cli/aztec_start_options.ts
@@ -268,11 +268,7 @@ export const aztecStartOptions: { [key: string]: AztecStartOption[] } = {
       defaultValue: undefined,
       env: undefined,
     },
-    ...getOptions(
-      'proverBroker',
-      // filter out archiver options from prover node options as they're passed separately in --archiver
-      proverBrokerConfigMappings,
-    ),
+    ...getOptions('proverBroker', proverBrokerConfigMappings),
   ],
   'PROVER AGENT': [
     {

--- a/yarn-project/aztec/src/cli/cmds/start_bot.ts
+++ b/yarn-project/aztec/src/cli/cmds/start_bot.ts
@@ -21,11 +21,9 @@ export async function startBot(
   services: NamespacedApiHandlers,
   userLog: LogFn,
 ) {
-  const { proverNode, archiver, sequencer, p2pBootstrap, txe, prover } = options;
-  if (proverNode || archiver || sequencer || p2pBootstrap || txe || prover) {
-    userLog(
-      `Starting a bot with --prover-node, --prover, --archiver, --sequencer, --p2p-bootstrap, or --txe is not supported.`,
-    );
+  const { proverNode, sequencer, p2pBootstrap, txe, prover } = options;
+  if (proverNode || sequencer || p2pBootstrap || txe || prover) {
+    userLog(`Starting a bot with --prover-node, --prover, --sequencer, --p2p-bootstrap, or --txe is not supported.`);
     process.exit(1);
   }
 


### PR DESCRIPTION
## Motivation

The top-level `--archiver` flag was removed from `aztec start`, but several scripts, Helm/Terraform values, and docs still pass it. Leaving these in place would break node and prover startup once they pick up the new CLI.

## Approach

Grepped the repo for bare `--archiver` (excluding nested `--archiver.<option>` flags, which are still valid) and removed every occurrence from start commands, docs, and the bot CLI handler. Also dropped the now-stale check for an `archiver` option in `start_bot.ts` and a stray comment in `aztec_start_options.ts`.

## Changes

- **docker-compose.yml**: drop `--archiver` from the node entrypoint
- **spartan (helm + terraform values)**: remove `--archiver` from `aztec-node`, `aztec-validator`, `aztec-prover-stack`, and the `full-node`, `rpc`, `archive`, `blob-sink` terraform values; update `aztec-node/README.md` examples and options table
- **yarn-project/aztec**: drop `archiver` from the unsupported-flags check in `start_bot.ts`; remove stale comment in `aztec_start_options.ts`
- **docs/docs-operate**: drop `--archiver` from the node/prover/sequencer setup, troubleshooting, and CLI reference pages; reword the reference prose to use `--archiver.blobSinkUrl` as the example

Versioned snapshots under `docs/network_versioned_docs/version-v4.2.0/` are intentionally left untouched.