### PR TITLE
fix(aztec-up): explicit exit in CLI acceptance test harness

### DIFF
--- a/aztec-up/test/aztec-cli-acceptance-test/aztec-cli-acceptance-test.ts
+++ b/aztec-up/test/aztec-cli-acceptance-test/aztec-cli-acceptance-test.ts
@@ -72,10 +72,14 @@ if (result.ok) {
   log(`All steps PASSED (${msToSecs(Date.now() - totalStart)}s total)`);
   console.log(`TEST_RESULT=pass version=${result.aztecVersion}`);
   rmSync(TMP_DIR, { recursive: true, force: true });
+  // Explicit exit fires the 'exit' handler registered in startLocalNetwork(), which SIGTERMs the
+  // long-running `aztec start --local-network` child. Without this, the child keeps Node's event
+  // loop alive — the handler never fires and the process hangs until the CI timeout cancels it.
+  process.exit(0);
 } else {
   reportFailure(result.stepName, result.aztecVersion, result.error);
   leaveTmpDirForInspection();
-  process.exitCode = 1;
+  process.exit(1);
 }
 
 async function main(): Promise<RunResult> {


### PR DESCRIPTION
## Summary

The Aztec CLI Acceptance Test workflow was timing out at 30 minutes despite the harness reporting `TEST_RESULT=pass` after ~2.5 min. Example: [run 25735107748](https://github.com/AztecProtocol/aztec-packages/actions/runs/25735107748/job/75569917180).

## Root cause

`aztec-cli-acceptance-test.ts` spawns `aztec start --local-network` and registers `process.on('exit', () => proc.kill('SIGTERM'))` to clean it up. The script then falls off the end of top-level await without calling `process.exit`. Node therefore waits for the event loop to drain — but the long-running child keeps it alive, the `'exit'` handler never fires, and the process hangs until GitHub's 30-minute job timeout cancels it. The CI cleanup line `Terminate orphan process: pid (4538) (node)` confirmed the unkilled child.

## Fix

Explicit `process.exit(0)` / `process.exit(1)` after the success and failure branches. Calling `process.exit` synchronously fires the `'exit'` handler, which SIGTERMs the child and lets Node terminate.