### PR TITLE
fix(aztec-up): install manifest-pinned Node version instead of LTS

### DIFF
--- a/aztec-up/bin/0.0.1/install
+++ b/aztec-up/bin/0.0.1/install
@@ -123,13 +123,13 @@ function install_node {
   # Need to install - check if nvm is available
   if [ ! -f "$HOME/.nvm/nvm.sh" ]; then
     echo "Minimum Node.js version $node_min_version not found (got $node_installed_version)."
-    echo "Installation: nvm install --lts && nvm alias default lts/*"
+    echo "Installation: nvm install $node_min_version && nvm alias default $node_min_version"
     exit 1
   fi
 
   . "$HOME/.nvm/nvm.sh"
-  nvm install --lts
-  nvm alias default lts/*
+  nvm install "$node_min_version"
+  nvm alias default "$node_min_version"
 }
 
 function install_versions_file {


### PR DESCRIPTION
## Summary

`install_node` runs `nvm install --lts && nvm alias default lts/*` when the host Node doesn't meet the manifest's minimum. That installs whatever Node version is *currently* tagged LTS, not the version pinned in `versions` for the release being installed.

Today this happens to be safe — current LTS is 24.x and the manifest says `node: 24.12.0`. But it's coincidence: the moment a release pins a non-LTS line (or an LTS slips behind), the installer silently runs the rest of the install on the wrong Node and the failure manifests far away from `install_node`.

## Fix

Install the version named in the manifest, instead of `--lts`:

```diff
-  nvm install --lts
-  nvm alias default lts/*
+  nvm install "$node_min_version"
+  nvm alias default "$node_min_version"
```

(Same change applied to the error-message hint for hosts without nvm.)