### PR TITLE
fix(ci): move CLI acceptance test timeout from job to step

### DIFF
--- a/.github/workflows/aztec-cli-acceptance-test.yml
+++ b/.github/workflows/aztec-cli-acceptance-test.yml
@@ -24,7 +24,6 @@ jobs:
       (github.event_name == 'workflow_run'
        && github.event.workflow_run.conclusion == 'success'
        && !contains(github.event.workflow_run.head_branch, '-commit.'))
-    timeout-minutes: 30
     env:
       VERSION: ${{ github.event.inputs.version || github.event.workflow_run.head_branch }}
     steps:
@@ -41,6 +40,7 @@ jobs:
           node-version: 22
 
       - name: Run Aztec CLI acceptance test
+        timeout-minutes: 30
         run: ./aztec-up/test/aztec-cli-acceptance-test/run-test.sh
 
       - name: Notify Slack on success


### PR DESCRIPTION
## Summary

When the Aztec CLI Acceptance Test workflow hung past its 30-minute limit ([example run](https://github.com/AztecProtocol/aztec-packages/actions/runs/25735107748)), nothing landed in `#team-fairies`. The job was killed but no Slack notification fired.

## Why

The two Slack steps gate on:
```yaml
if: success() && ...   # success notify
if: failure() && ...   # failure notify
```

`timeout-minutes` at the **job** level makes the conclusion `cancelled` on expiry. `success()` is false (a step was cancelled), and `failure()` is also false (cancelled ≠ failed). Both notification steps get skipped.

`timeout-minutes` at the **step** level makes the step's conclusion `failure` instead — which the existing `failure()`-gated notify already handles.

Manual cancellations and "superseded by newer run" still come through as `cancelled` and stay silent — that's the desired behavior for those cases; we don't want to ping the channel every time someone re-runs the workflow.