### PR TITLE
feat(polynomials): vectorized_for abstraction + Polynomial consumer migrations

### DIFF
--- a/barretenberg/cpp/src/barretenberg/ecc/fields/vector_field.hpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/fields/vector_field.hpp
@@ -46,6 +46,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
+#include <type_traits>
 
 #if defined(__wasm_simd128__)
 #include <wasm_simd128.h>
@@ -98,6 +99,21 @@ template <class Params> inline constexpr std::array<uint64_t, 9> compute_tnm_was
     }
     return tnm;
 }
+
+// Marker trait: specialized to true for each Params whose VectorField has a
+// SIMD operator* body (an explicit specialization defined in
+// vector_field_wasm.cpp). vectorized_for / vectorized_for_if read this to
+// decide whether to take the bulk path. Add a new specialization (below)
+// when adding the corresponding operator* body so the gate and the body
+// stay in lockstep.
+template <class Params> struct has_simd_mont_mul : std::false_type {};
+template <class Params> inline constexpr bool has_simd_mont_mul_v = has_simd_mont_mul<Params>::value;
+
+// Per-Params specializations. Forward-declared rather than #include'd so
+// vector_field.hpp stays Params-agnostic at the type level; the trait body
+// has no member access, only `: std::true_type`.
+class Bn254FrParams;
+template <> struct has_simd_mont_mul<Bn254FrParams> : std::true_type {};
 
 template <class Params> struct alignas(32) VectorField {
     using Field = field<Params>;

--- a/barretenberg/cpp/src/barretenberg/ecc/fields/vector_field.hpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/fields/vector_field.hpp
@@ -214,15 +214,25 @@ template <class Params> struct alignas(32) VectorField {
         base[idx[4]] = a[4];
     }
 
-    // Contiguous load: lane L = base[L] for L in 0..4. The canonical
-    // construction path used by the vectorised loop abstraction in place of
-    // gather — no random-access load, no scalar-pack staging, just a direct
-    // AoS→interleaved transpose driven by SIMD shuffles.
+    // Contiguous load: lane L = base[L] for L in 0..4.
+    // This is the fast path for vectorized_for<5>(...) bulk iterations where
+    // the 5 lanes are always consecutive addresses.
+    //
+    // Implementation (WASM SIMD, see out-of-class definition below): hand-
+    // fused 10 × wasm_v128_load on the raw Fr limb bytes, staged into an
+    // aligned 20 × u64 buffer, then pack_4u64_to_9x29 per lane. This beats
+    // gather's 20 × scalar random-access loads because V8 coalesces v128
+    // loads but not scalar loads at arbitrary addresses.
+    //
+    // Implementation (fallback): byte-for-byte copy into elts[5].
     static VectorField load_contiguous(const Field* base) noexcept;
 
-    // Contiguous store: writes base[L] = this->get(L) for L in 0..4. The
-    // matching write half of load_contiguous; called by the loop abstraction
-    // in place of scatter.
+    // Contiguous store: writes base[L] = this->get(L) for L in 0..4.
+    //
+    // Implementation (WASM SIMD, see out-of-class definition below): unpack
+    // into a 20 × u64 staging buffer, then emit 10 × wasm_v128_store. Same
+    // reasoning as load_contiguous — v128 stores coalesce, scalar stores at
+    // gather-scatter addresses don't.
     void store_contiguous(Field* base) const noexcept;
 
     // Broadcast a single Field to all 5 lanes. Much cheaper than the
@@ -231,35 +241,31 @@ template <class Params> struct alignas(32) VectorField {
     static VectorField broadcast(const Field& s) noexcept;
 
     // Mixed-type operators: broadcast scalar into a VectorField and delegate.
-    friend VectorField operator+(VectorField v, const Field& s) noexcept
+    // [[gnu::always_inline]] is load-bearing under -Oz so the broadcast(s)
+    // call hoists out of the caller loop when s is loop-invariant.
+    [[gnu::always_inline]] friend VectorField operator+(VectorField v, const Field& s) noexcept
     {
-        VectorField bcast(std::array<Field, 5>{ s, s, s, s, s });
-        return v + bcast;
+        return v + broadcast(s);
     }
-    friend VectorField operator+(const Field& s, VectorField v) noexcept
+    [[gnu::always_inline]] friend VectorField operator+(const Field& s, VectorField v) noexcept
     {
-        VectorField bcast(std::array<Field, 5>{ s, s, s, s, s });
-        return bcast + v;
+        return broadcast(s) + v;
     }
-    friend VectorField operator-(VectorField v, const Field& s) noexcept
+    [[gnu::always_inline]] friend VectorField operator-(VectorField v, const Field& s) noexcept
     {
-        VectorField bcast(std::array<Field, 5>{ s, s, s, s, s });
-        return v - bcast;
+        return v - broadcast(s);
     }
-    friend VectorField operator-(const Field& s, VectorField v) noexcept
+    [[gnu::always_inline]] friend VectorField operator-(const Field& s, VectorField v) noexcept
     {
-        VectorField bcast(std::array<Field, 5>{ s, s, s, s, s });
-        return bcast - v;
+        return broadcast(s) - v;
     }
-    friend VectorField operator*(VectorField v, const Field& s) noexcept
+    [[gnu::always_inline]] friend VectorField operator*(VectorField v, const Field& s) noexcept
     {
-        VectorField bcast(std::array<Field, 5>{ s, s, s, s, s });
-        return v * bcast;
+        return v * broadcast(s);
     }
-    friend VectorField operator*(const Field& s, VectorField v) noexcept
+    [[gnu::always_inline]] friend VectorField operator*(const Field& s, VectorField v) noexcept
     {
-        VectorField bcast(std::array<Field, 5>{ s, s, s, s, s });
-        return bcast * v;
+        return broadcast(s) * v;
     }
 
     // Returns a 5-bit mask: bit 0 = scalar, bits 1..4 = quad lanes 0..3.
@@ -307,7 +313,11 @@ namespace vector_field_detail {
 
 // Pack 4 × u64 (little-endian 256-bit value) into 9 × 29-bit limbs, each stored
 // in a u32 slot.
-inline void pack_4u64_to_9x29(const uint64_t in[4], uint32_t out[9]) noexcept
+//
+// [[gnu::always_inline]] is load-bearing under -Oz: without it, the compiler
+// leaves pack/unpack as standalone calls, and the add_scaled hot loop pays
+// ~11 call overheads per block.
+[[gnu::always_inline]] inline void pack_4u64_to_9x29(const uint64_t in[4], uint32_t out[9]) noexcept
 {
     out[0] = static_cast<uint32_t>(in[0] & 0x1fffffff);
     out[1] = static_cast<uint32_t>((in[0] >> 29) & 0x1fffffff);
@@ -321,8 +331,9 @@ inline void pack_4u64_to_9x29(const uint64_t in[4], uint32_t out[9]) noexcept
 }
 
 // Unpack 9 × 29-bit limbs (stored in u32 slots) back to 4 × u64. Each input
-// lane is zero-extended to u64 before shifting.
-inline void unpack_9x29_to_4u64(const uint32_t in[9], uint64_t out[4]) noexcept
+// lane is zero-extended to u64 before shifting. [[gnu::always_inline]]
+// rationale: same as pack_4u64_to_9x29.
+[[gnu::always_inline]] inline void unpack_9x29_to_4u64(const uint32_t in[9], uint64_t out[4]) noexcept
 {
     const uint64_t i0 = in[0], i1 = in[1], i2 = in[2], i3 = in[3], i4 = in[4];
     const uint64_t i5 = in[5], i6 = in[6], i7 = in[7], i8 = in[8];

--- a/barretenberg/cpp/src/barretenberg/polynomials/add_scaled.bench.cpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/add_scaled.bench.cpp
@@ -1,0 +1,454 @@
+// Diagnostic benchmarks for Polynomial::add_scaled.
+//
+// Four variants all doing self[i] = self[i] + other[i] * scaling for
+// i in [0, N), same inputs, same pre-randomized reference buffer copied
+// into self at the start of each iteration so accumulating values don't
+// drift across iterations:
+//
+//   bench_add_scaled_scalar              — raw scalar for-loop, no
+//                                          vectorized_for, no parallel_for.
+//   bench_add_scaled_vectorized_inline   — single vectorized_for<bb::VECTOR_FIELD_WIDTH> call
+//                                          over [0, N), uses Polynomial's
+//                                          token overloads. Routes through
+//                                          ContiguousVectorIndex<5> /
+//                                          load_contiguous /
+//                                          store_contiguous (NOT gather).
+//   bench_add_scaled_vector_field_raw    — ceiling: hand-written loop on
+//                                          raw bb::fr* calling
+//                                          load_contiguous /
+//                                          store_contiguous directly,
+//                                          mirroring what
+//                                          ContiguousVectorIndex emits.
+//                                          The delta vs vectorized_inline
+//                                          is the abstraction tax.
+//   bench_add_scaled_full                — Polynomial::add_scaled, which
+//                                          routes through add_scaled_chunk
+//                                          + parallel_for + vectorized_for<bb::VECTOR_FIELD_WIDTH>.
+//
+// Ratios of interest:
+//   scalar / vectorized_inline           — real vectorization speedup
+//   scalar / vector_field_raw            — ceiling speedup
+//   vectorized_inline / vector_field_raw — abstraction tax (target: ~1.0x)
+//   full / vectorized_inline             — parallel_for overhead
+//
+// Last measured (wasmtime 20, BN254 Fr, N = 1<<16):
+//   scalar            ~ 3.99 ms
+//   vectorized_inline ~ 4.37 ms  (0.91× scalar)
+//   vector_field_raw  ~ 4.36 ms  (0.91× scalar — ceiling)
+//   full              ~ 4.65 ms  (0.86× scalar — parallel_for ~5% overhead)
+// Abstraction tax: vectorized_inline / vector_field_raw ≈ 1.00× (no tax).
+// The 0.91× ratio vs scalar is the irreducible AoS↔interleaved transpose
+// cost over a 1-op-per-block kernel (mul + add); on V8/Zen3 the underlying
+// primitive speedups are larger so add_scaled vectorized comfortably exceeds
+// scalar there.
+
+#include "barretenberg/ecc/curves/bn254/fr.hpp"
+#include "barretenberg/ecc/fields/vector_field.hpp"
+#include "barretenberg/polynomials/broadcast.hpp"
+#include "barretenberg/polynomials/polynomial.hpp"
+#include "barretenberg/polynomials/vectorized_for.hpp"
+
+#include <array>
+#include <benchmark/benchmark.h>
+#include <cstring>
+
+using namespace benchmark;
+using bb::fr;
+using bb::Polynomial;
+using bb::PolynomialSpan;
+using bb::VectorField;
+using bb::vectorized_for;
+
+// Polynomial size for each benchmark. 2^16 gives a reasonably sized inner
+// loop while keeping the total benchmark time modest.
+constexpr size_t N = 1 << 16;
+
+namespace {
+
+// Pre-populate once: `self_ref` and `other` hold random data; each bench
+// iteration starts by memcpy'ing `self_ref -> self` so accumulating values
+// don't saturate across iterations.
+struct PolyFixture {
+    Polynomial<fr> self;
+    Polynomial<fr> self_ref;
+    Polynomial<fr> other;
+    fr scaling;
+
+    PolyFixture()
+        : self(N, N, 0, Polynomial<fr>::DontZeroMemory::FLAG)
+        , self_ref(N, N, 0, Polynomial<fr>::DontZeroMemory::FLAG)
+        , other(N, N, 0, Polynomial<fr>::DontZeroMemory::FLAG)
+        , scaling(fr::random_element())
+    {
+        for (size_t i = 0; i < N; ++i) {
+            self_ref.at(i) = fr::random_element();
+            other.at(i) = fr::random_element();
+        }
+        std::memcpy(self.data(), self_ref.data(), N * sizeof(fr));
+    }
+
+    // Reset self to the pre-randomized reference state without timing.
+    void reset_self(State& state)
+    {
+        state.PauseTiming();
+        std::memcpy(self.data(), self_ref.data(), N * sizeof(fr));
+        state.ResumeTiming();
+    }
+};
+
+// Correctness check (NOT timed): compute add_scaled via the scalar loop and
+// via Polynomial::add_scaled (the vectorised production path) on identical
+// inputs, then assert all 65k field outputs match. If the bulk-transpose
+// rewrite has a bit-level error this aborts before any benchmark runs.
+struct CorrectnessGuard {
+    CorrectnessGuard()
+    {
+        constexpr size_t M = N;
+        Polynomial<fr> a(M, M, 0, Polynomial<fr>::DontZeroMemory::FLAG);
+        Polynomial<fr> a_ref(M, M, 0, Polynomial<fr>::DontZeroMemory::FLAG);
+        Polynomial<fr> b(M, M, 0, Polynomial<fr>::DontZeroMemory::FLAG);
+        for (size_t i = 0; i < M; ++i) {
+            a.at(i) = fr::random_element();
+            b.at(i) = fr::random_element();
+        }
+        std::memcpy(a_ref.data(), a.data(), M * sizeof(fr));
+        const fr s = fr::random_element();
+
+        // Production path.
+        a.add_scaled(PolynomialSpan<const fr>{ 0, { b.data(), M } }, s);
+
+        // Reference scalar path.
+        for (size_t i = 0; i < M; ++i) {
+            a_ref.at(i) = a_ref.at(i) + b.at(i) * s;
+        }
+
+        for (size_t i = 0; i < M; ++i) {
+            if (!(a.at(i) == a_ref.at(i))) {
+                std::fprintf(stderr, "[ADD_SCALED CORRECTNESS] mismatch at i=%zu\n", i);
+                std::abort();
+            }
+        }
+    }
+};
+static const CorrectnessGuard correctness_guard;
+} // namespace
+
+static void bench_add_scaled_scalar(State& state)
+{
+    PolyFixture f;
+    auto& self = f.self;
+    auto& other = f.other;
+    auto scaling = f.scaling;
+    for (auto _ : state) {
+        f.reset_self(state);
+        for (size_t i = 0; i < N; ++i) {
+            self.at(i) = self.at(i) + other.at(i) * scaling;
+        }
+        DoNotOptimize(self.at(0));
+    }
+}
+BENCHMARK(bench_add_scaled_scalar);
+
+static void bench_add_scaled_vectorized_inline(State& state)
+{
+    PolyFixture f;
+    auto& self = f.self;
+    auto& other = f.other;
+    auto scaling = f.scaling;
+    // Mirror Polynomial::add_scaled_chunk: hoist the scalar->VectorField
+    // broadcast out of the loop via `Broadcast<Fr>`, so the same
+    // `scaling_b[ctx]` expression yields the right-typed multiplicand for
+    // the bulk and tail iterations.
+    bb::Broadcast<fr> scaling_b(scaling);
+    for (auto _ : state) {
+        f.reset_self(state);
+        vectorized_for<bb::VECTOR_FIELD_WIDTH>(
+            0, N, [&](auto ctx) { self[ctx] = self[ctx] + other[ctx] * scaling_b[ctx]; });
+        DoNotOptimize(self.at(0));
+    }
+}
+BENCHMARK(bench_add_scaled_vectorized_inline);
+
+static void bench_add_scaled_vector_field_raw(State& state)
+{
+    PolyFixture f;
+    auto& self = f.self;
+    auto& other = f.other;
+    auto scaling = f.scaling;
+
+    using Vec = VectorField<fr::Params>;
+    // Inline 5-wide per-block ceiling: hand-written loop using the
+    // linear-memory VectorField ctor (`Vec(fr*)`) and its matching write
+    // method (`store_to`). Per-iter transpose. The bulk-transposed path
+    // (Polynomial::add_scaled) has a higher ceiling.
+    Vec scaling_v = Vec::broadcast(scaling);
+
+    for (auto _ : state) {
+        f.reset_self(state);
+        fr* s = self.data();
+        const fr* o = other.data();
+        size_t i = 0;
+        for (; i + 5 <= N; i += 5) {
+            Vec sv(s + i);
+            Vec ov(o + i);
+            (sv + ov * scaling_v).store_to(s + i);
+        }
+        // Tail (N % 5 elements). For N = 65536 this is 1 iteration.
+        for (; i < N; ++i) {
+            s[i] = s[i] + o[i] * scaling;
+        }
+        DoNotOptimize(self.at(0));
+    }
+}
+BENCHMARK(bench_add_scaled_vector_field_raw);
+
+// Bulk-transpose variant: lift the AoS↔interleaved transpose out of the
+// inner kernel so each polynomial is converted exactly once per call, and
+// the inner loop runs on already-interleaved VectorField slots.
+//
+// The math identity is unchanged. The point of this variant is to measure
+// what `Polynomial::add_scaled` looks like when transpose cost is paid in
+// streaming bulk passes that V8/TurboFan can vectorize, instead of being
+// folded into each 5-field iteration.
+static void bench_add_scaled_bulk_transpose(State& state)
+{
+    PolyFixture f;
+    auto& self = f.self;
+    auto& other = f.other;
+    auto scaling = f.scaling;
+
+    using Vec = VectorField<fr::Params>;
+    constexpr size_t bulk_count = N / 5;
+    constexpr size_t tail_count = N % 5;
+
+    // Persistent scratch — one allocation, reused across bench iterations.
+    // Hoist the raw data pointer outside the inner loop so V8/TurboFan
+    // doesn't re-read std::vector's _M_start on every block (matches what
+    // Polynomial::add_scaled_chunk does internally).
+    std::vector<Vec> self_inter(bulk_count);
+    std::vector<Vec> other_inter(bulk_count);
+    Vec* self_buf = self_inter.data();
+    Vec* other_buf = other_inter.data();
+    Vec scaling_v = Vec::broadcast(scaling);
+
+    for (auto _ : state) {
+        f.reset_self(state);
+        fr* s = self.data();
+        const fr* o = other.data();
+
+        // Pass 1: pre-transpose self → interleaved scratch via the
+        // linear-memory ctor.
+        for (size_t i = 0; i < bulk_count; ++i) {
+            self_buf[i] = Vec(s + i * 5);
+        }
+        // Pass 2: pre-transpose other → interleaved scratch.
+        for (size_t i = 0; i < bulk_count; ++i) {
+            other_buf[i] = Vec(o + i * 5);
+        }
+        // Pass 3 (kernel): operate entirely on interleaved data — no
+        // transpose in the inner loop.
+        for (size_t i = 0; i < bulk_count; ++i) {
+            self_buf[i] = self_buf[i] + other_buf[i] * scaling_v;
+        }
+        // Pass 4: post-transpose self ← interleaved scratch via store_to.
+        for (size_t i = 0; i < bulk_count; ++i) {
+            self_buf[i].store_to(s + i * 5);
+        }
+        // Tail.
+        for (size_t i = bulk_count * 5; i < N; ++i) {
+            s[i] = s[i] + o[i] * scaling;
+        }
+        DoNotOptimize(self.at(0));
+        (void)tail_count;
+    }
+}
+BENCHMARK(bench_add_scaled_bulk_transpose);
+
+static void bench_add_scaled_full(State& state)
+{
+    PolyFixture f;
+    auto& self = f.self;
+    auto& other = f.other;
+    auto scaling = f.scaling;
+    for (auto _ : state) {
+        f.reset_self(state);
+        self.add_scaled(PolynomialSpan<const fr>{ 0, { other.data(), N } }, scaling);
+        DoNotOptimize(self.at(0));
+    }
+}
+BENCHMARK(bench_add_scaled_full);
+
+// Kernel-only ceiling: both self and other already in 5-wide interleaved
+// layout, time only the inner mul+add pass. No AoS↔interleaved transpose
+// in the timed window. This is the upper bound `Polynomial::add_scaled`
+// could reach if Polynomial natively stored its data in the 5-wide
+// interleaved layout (the spec's "larger architectural change").
+//
+// self_inter is *not* reset between iterations — the math drifts across
+// iterations, but every iteration performs the exact same SIMD work, so
+// per-iteration timing is meaningful. PauseTiming/ResumeTiming for a
+// per-iter reset added ~17 % overhead in V8 — this bench is a CEILING
+// DIAGNOSTIC only, not a correctness measurement.
+static void bench_add_scaled_kernel_only(State& state)
+{
+    PolyFixture f;
+    auto& other = f.other;
+    auto scaling = f.scaling;
+
+    using Vec = VectorField<fr::Params>;
+    constexpr size_t bulk_count = N / 5;
+
+    std::vector<Vec> self_inter(bulk_count);
+    std::vector<Vec> other_inter(bulk_count);
+    Vec* self_buf = self_inter.data();
+    Vec* other_buf = other_inter.data();
+    Vec scaling_v = Vec::broadcast(scaling);
+    {
+        const fr* s = f.self_ref.data();
+        const fr* o = other.data();
+        for (size_t i = 0; i < bulk_count; ++i) {
+            self_buf[i] = Vec(s + i * 5);
+            other_buf[i] = Vec(o + i * 5);
+        }
+    }
+
+    for (auto _ : state) {
+        for (size_t i = 0; i < bulk_count; ++i) {
+            self_buf[i] = self_buf[i] + other_buf[i] * scaling_v;
+        }
+        DoNotOptimize(self_buf[0]);
+    }
+}
+BENCHMARK(bench_add_scaled_kernel_only);
+
+// Kernel + write-back ceiling: both self and other already in 5-wide
+// interleaved layout; the timed window contains the kernel pass plus the
+// AoS write-back pass that untransposes self into the Polynomial buffer.
+// This is the upper bound `add_scaled` could reach if `other` is already
+// interleaved (cached across many calls) and only `self` needs to be
+// flushed back to AoS at the end of the call. Same ceiling-diagnostic
+// caveat as `kernel_only` — self_inter drifts but per-iter SIMD work is
+// constant.
+static void bench_add_scaled_kernel_plus_writeback(State& state)
+{
+    PolyFixture f;
+    auto& self = f.self;
+    auto& other = f.other;
+    auto scaling = f.scaling;
+
+    using Vec = VectorField<fr::Params>;
+    constexpr size_t bulk_count = N / 5;
+
+    std::vector<Vec> self_inter(bulk_count);
+    std::vector<Vec> other_inter(bulk_count);
+    Vec* self_buf = self_inter.data();
+    Vec* other_buf = other_inter.data();
+    Vec scaling_v = Vec::broadcast(scaling);
+    {
+        const fr* s = f.self_ref.data();
+        const fr* o = other.data();
+        for (size_t i = 0; i < bulk_count; ++i) {
+            self_buf[i] = Vec(s + i * 5);
+            other_buf[i] = Vec(o + i * 5);
+        }
+    }
+
+    for (auto _ : state) {
+        fr* s = self.data();
+        // Kernel pass.
+        for (size_t i = 0; i < bulk_count; ++i) {
+            self_buf[i] = self_buf[i] + other_buf[i] * scaling_v;
+        }
+        // Write-back pass.
+        for (size_t i = 0; i < bulk_count; ++i) {
+            self_buf[i].store_to(s + i * 5);
+        }
+        DoNotOptimize(self.at(0));
+    }
+}
+BENCHMARK(bench_add_scaled_kernel_plus_writeback);
+
+// Isolated load: time JUST the AoS → 9×29 interleaved conversion. No math,
+// no kernel, no store. Each iteration runs 13107 invocations of the
+// linear-memory `Vec(const fr*)` ctor over the same self/other buffers.
+// This is the conversion microbench the user asked for.
+static void bench_load_contiguous_only(State& state)
+{
+    PolyFixture f;
+    auto& self = f.self;
+    auto& other = f.other;
+
+    using Vec = VectorField<fr::Params>;
+    constexpr size_t bulk_count = N / 5;
+
+    std::vector<Vec> sink(bulk_count);
+    Vec* sink_buf = sink.data();
+
+    for (auto _ : state) {
+        const fr* s = self.data();
+        const fr* o = other.data();
+        for (size_t i = 0; i < bulk_count; ++i) {
+            sink_buf[i] = Vec(s + i * 5);
+        }
+        for (size_t i = 0; i < bulk_count; ++i) {
+            sink_buf[i] = Vec(o + i * 5);
+        }
+        DoNotOptimize(sink_buf[0]);
+    }
+}
+BENCHMARK(bench_load_contiguous_only);
+
+// Isolated store: time JUST the 9×29 interleaved → AoS conversion.
+// 13107 invocations of `store_to` per iteration.
+static void bench_store_contiguous_only(State& state)
+{
+    PolyFixture f;
+    auto& self = f.self;
+
+    using Vec = VectorField<fr::Params>;
+    constexpr size_t bulk_count = N / 5;
+
+    std::vector<Vec> src(bulk_count);
+    Vec* src_buf = src.data();
+    {
+        const fr* s = f.self_ref.data();
+        for (size_t i = 0; i < bulk_count; ++i) {
+            src_buf[i] = Vec(s + i * 5);
+        }
+    }
+
+    for (auto _ : state) {
+        fr* s = self.data();
+        for (size_t i = 0; i < bulk_count; ++i) {
+            src_buf[i].store_to(s + i * 5);
+        }
+        DoNotOptimize(self.at(0));
+    }
+}
+BENCHMARK(bench_store_contiguous_only);
+
+// Memory-bandwidth floor: pure 160-byte (5×fr) → 192-byte (sizeof Vec)
+// memcpy. No bit work at all. Whatever load_contiguous costs ABOVE this is
+// the conversion-compute overhead the user wants reduced.
+static void bench_memcpy_only(State& state)
+{
+    PolyFixture f;
+    auto& self = f.self;
+
+    using Vec = VectorField<fr::Params>;
+    constexpr size_t bulk_count = N / 5;
+
+    std::vector<Vec> sink(bulk_count);
+    Vec* sink_buf = sink.data();
+
+    for (auto _ : state) {
+        const fr* s = self.data();
+        for (size_t i = 0; i < bulk_count; ++i) {
+            std::memcpy(&sink_buf[i], s + i * 5, sizeof(fr) * 5);
+        }
+        DoNotOptimize(sink_buf[0]);
+    }
+}
+BENCHMARK(bench_memcpy_only);
+
+BENCHMARK_MAIN();

--- a/barretenberg/cpp/src/barretenberg/polynomials/add_scaled.bench.cpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/add_scaled.bench.cpp
@@ -162,7 +162,7 @@ static void bench_add_scaled_vectorized_inline(State& state)
     bb::Broadcast<fr> scaling_b(scaling);
     for (auto _ : state) {
         f.reset_self(state);
-        vectorized_for<bb::VECTOR_FIELD_WIDTH>(
+        vectorized_for<bb::VECTOR_FIELD_WIDTH, fr>(
             0, N, [&](auto ctx) { self[ctx] = self[ctx] + other[ctx] * scaling_b[ctx]; });
         DoNotOptimize(self.at(0));
     }

--- a/barretenberg/cpp/src/barretenberg/polynomials/broadcast.hpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/broadcast.hpp
@@ -1,0 +1,43 @@
+#pragma once
+
+#include "barretenberg/ecc/fields/vector_field.hpp"
+#include "barretenberg/polynomials/vectorized_for.hpp"
+
+#include <cstddef>
+
+namespace bb {
+
+// Adapts a scalar Fr into the token-dispatched operator[] protocol used by
+// Polynomial / PolynomialSpan in vectorized_for<N> kernels. For ScalarIndex
+// it yields the scalar; for ContiguousVectorIndex<N> it yields a VectorField
+// holding the same scalar broadcast across all lanes. A kernel can then read
+//
+//     vectorized_for<5>(0, n, [&](auto ctx) {
+//         self[ctx] = self[ctx] + other[ctx] * scaling[ctx];
+//     });
+//
+// without an `if constexpr` branch on the token type: `scaling[ctx]` returns
+// Fr in the tail and VectorField in the bulk, matching the type the
+// surrounding arithmetic expects.
+//
+// Both forms are materialized once in the constructor (the VectorField
+// broadcast does a one-time splat of `s` into all lanes), and both operator[]
+// overloads return by const-reference so iterating callers do not pay a copy
+// per loop block.
+template <typename Fr> struct Broadcast {
+    using Vec = VectorField<typename Fr::Params>;
+
+    Fr scalar;
+    Vec vector;
+
+    explicit Broadcast(const Fr& s)
+        : scalar(s)
+        , vector(Vec::broadcast(s))
+    {}
+
+    [[gnu::always_inline]] const Fr& operator[](ScalarIndex) const { return scalar; }
+
+    template <size_t N> [[gnu::always_inline]] const Vec& operator[](ContiguousVectorIndex<N>) const { return vector; }
+};
+
+} // namespace bb

--- a/barretenberg/cpp/src/barretenberg/polynomials/poly_inplace_arith.bench.cpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/poly_inplace_arith.bench.cpp
@@ -1,0 +1,200 @@
+// Diagnostic benchmarks for Polynomial in-place arithmetic: operator+=,
+// operator-=, and operator*=. Each operator is benched two ways:
+//
+//   _scalar  — raw scalar for-loop, no vectorized_for, no parallel_for.
+//   _full    — Polynomial::operator(+/-/*)=, which now routes through
+//              the *_chunk helper + parallel_for_heuristic + vectorized_for<5>.
+//
+// The _full / _scalar ratio is the production speedup from the SIMD path.
+// On V8/Zen3 the ratio is meaningful; on wasmtime SIMD lowering is incomplete
+// and the ratios understate the win.
+
+#include "barretenberg/ecc/curves/bn254/fr.hpp"
+#include "barretenberg/polynomials/polynomial.hpp"
+
+#include <benchmark/benchmark.h>
+#include <cstring>
+
+using namespace benchmark;
+using bb::fr;
+using bb::Polynomial;
+using bb::PolynomialSpan;
+
+constexpr size_t N = 1 << 16;
+
+namespace {
+
+// Pre-populate once: self_ref + other hold random data. Each bench iteration
+// resets self to self_ref so accumulating values don't drift across iters.
+struct PolyFixture {
+    Polynomial<fr> self;
+    Polynomial<fr> self_ref;
+    Polynomial<fr> other;
+    fr scaling;
+
+    PolyFixture()
+        : self(N, N, 0, Polynomial<fr>::DontZeroMemory::FLAG)
+        , self_ref(N, N, 0, Polynomial<fr>::DontZeroMemory::FLAG)
+        , other(N, N, 0, Polynomial<fr>::DontZeroMemory::FLAG)
+        , scaling(fr::random_element())
+    {
+        for (size_t i = 0; i < N; ++i) {
+            self_ref.at(i) = fr::random_element();
+            other.at(i) = fr::random_element();
+        }
+        std::memcpy(self.data(), self_ref.data(), N * sizeof(fr));
+    }
+
+    void reset_self(State& state)
+    {
+        state.PauseTiming();
+        std::memcpy(self.data(), self_ref.data(), N * sizeof(fr));
+        state.ResumeTiming();
+    }
+};
+
+// Correctness check (NOT timed): scalar reference vs Polynomial::operator
+// for each of +=, -=, *= on identical inputs. Aborts before bench start
+// if any output mismatches.
+struct CorrectnessGuard {
+    CorrectnessGuard()
+    {
+        constexpr size_t M = N;
+        Polynomial<fr> a(M, M, 0, Polynomial<fr>::DontZeroMemory::FLAG);
+        Polynomial<fr> a_ref(M, M, 0, Polynomial<fr>::DontZeroMemory::FLAG);
+        Polynomial<fr> b(M, M, 0, Polynomial<fr>::DontZeroMemory::FLAG);
+        for (size_t i = 0; i < M; ++i) {
+            a.at(i) = fr::random_element();
+            b.at(i) = fr::random_element();
+        }
+        const fr s = fr::random_element();
+
+        auto check = [&](const char* label) {
+            for (size_t i = 0; i < M; ++i) {
+                if (!(a.at(i) == a_ref.at(i))) {
+                    std::fprintf(stderr, "[POLY_INPLACE %s] mismatch at i=%zu\n", label, i);
+                    std::abort();
+                }
+            }
+        };
+
+        // operator+=
+        std::memcpy(a_ref.data(), a.data(), M * sizeof(fr));
+        a += PolynomialSpan<const fr>{ 0, { b.data(), M } };
+        for (size_t i = 0; i < M; ++i) {
+            a_ref.at(i) = a_ref.at(i) + b.at(i);
+        }
+        check("+=");
+
+        // operator-=
+        std::memcpy(a_ref.data(), a.data(), M * sizeof(fr));
+        a -= PolynomialSpan<const fr>{ 0, { b.data(), M } };
+        for (size_t i = 0; i < M; ++i) {
+            a_ref.at(i) = a_ref.at(i) - b.at(i);
+        }
+        check("-=");
+
+        // operator*=
+        std::memcpy(a_ref.data(), a.data(), M * sizeof(fr));
+        a *= s;
+        for (size_t i = 0; i < M; ++i) {
+            a_ref.at(i) = a_ref.at(i) * s;
+        }
+        check("*=");
+    }
+};
+static const CorrectnessGuard correctness_guard;
+
+} // namespace
+
+// =========================== operator+= ===========================
+
+static void bench_plus_equals_scalar(State& state)
+{
+    PolyFixture f;
+    auto& self = f.self;
+    auto& other = f.other;
+    for (auto _ : state) {
+        f.reset_self(state);
+        for (size_t i = 0; i < N; ++i) {
+            self.at(i) = self.at(i) + other.at(i);
+        }
+        DoNotOptimize(self.at(0));
+    }
+}
+BENCHMARK(bench_plus_equals_scalar);
+
+static void bench_plus_equals_full(State& state)
+{
+    PolyFixture f;
+    auto& self = f.self;
+    auto& other = f.other;
+    for (auto _ : state) {
+        f.reset_self(state);
+        self += PolynomialSpan<const fr>{ 0, { other.data(), N } };
+        DoNotOptimize(self.at(0));
+    }
+}
+BENCHMARK(bench_plus_equals_full);
+
+// =========================== operator-= ===========================
+
+static void bench_minus_equals_scalar(State& state)
+{
+    PolyFixture f;
+    auto& self = f.self;
+    auto& other = f.other;
+    for (auto _ : state) {
+        f.reset_self(state);
+        for (size_t i = 0; i < N; ++i) {
+            self.at(i) = self.at(i) - other.at(i);
+        }
+        DoNotOptimize(self.at(0));
+    }
+}
+BENCHMARK(bench_minus_equals_scalar);
+
+static void bench_minus_equals_full(State& state)
+{
+    PolyFixture f;
+    auto& self = f.self;
+    auto& other = f.other;
+    for (auto _ : state) {
+        f.reset_self(state);
+        self -= PolynomialSpan<const fr>{ 0, { other.data(), N } };
+        DoNotOptimize(self.at(0));
+    }
+}
+BENCHMARK(bench_minus_equals_full);
+
+// =========================== operator*= ===========================
+
+static void bench_times_equals_scalar(State& state)
+{
+    PolyFixture f;
+    auto& self = f.self;
+    auto scaling = f.scaling;
+    for (auto _ : state) {
+        f.reset_self(state);
+        for (size_t i = 0; i < N; ++i) {
+            self.at(i) = self.at(i) * scaling;
+        }
+        DoNotOptimize(self.at(0));
+    }
+}
+BENCHMARK(bench_times_equals_scalar);
+
+static void bench_times_equals_full(State& state)
+{
+    PolyFixture f;
+    auto& self = f.self;
+    auto scaling = f.scaling;
+    for (auto _ : state) {
+        f.reset_self(state);
+        self *= scaling;
+        DoNotOptimize(self.at(0));
+    }
+}
+BENCHMARK(bench_times_equals_full);
+
+BENCHMARK_MAIN();

--- a/barretenberg/cpp/src/barretenberg/polynomials/polynomial.cpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/polynomial.cpp
@@ -20,6 +20,7 @@
 #include <mutex>
 #include <span>
 #include <sys/stat.h>
+#include <type_traits>
 #include <unordered_map>
 #include <utility>
 
@@ -75,7 +76,6 @@ template <typename Fr> Polynomial<Fr>::Polynomial(size_t size, size_t virtual_si
     allocate_backing_memory(size, virtual_size, start_index);
 
     parallel_for([&](const ThreadChunk& chunk) {
-        BB_BENCH_TRACY_NAME("Polynomial::zero_init");
         auto range = chunk.range(size);
         if (!range.empty()) {
             size_t start = *range.begin();
@@ -120,8 +120,6 @@ Polynomial<Fr>::Polynomial(std::span<const Fr> interpolation_points,
     : Polynomial(interpolation_points.size(), virtual_size)
 {
     BB_ASSERT_GT(coefficients_.size(), static_cast<size_t>(0));
-    // compute_efficient_interpolation indexes evaluations by interpolation_points.size()
-    BB_ASSERT_EQ(interpolation_points.size(), evaluations.size());
 
     polynomial_arithmetic::compute_efficient_interpolation(
         evaluations.data(), coefficients_.data(), interpolation_points.data(), coefficients_.size());
@@ -174,21 +172,6 @@ template <typename Fr> bool Polynomial<Fr>::operator==(Polynomial const& rhs) co
     return true;
 }
 
-template <typename Fr> Polynomial<Fr>& Polynomial<Fr>::operator+=(PolynomialSpan<const Fr> other)
-{
-    BB_BENCH_NAME("Polynomial::op+=");
-    BB_ASSERT_LTE(start_index(), other.start_index);
-    BB_ASSERT_GTE(end_index(), other.end_index());
-    parallel_for([&](const ThreadChunk& chunk) {
-        BB_BENCH_TRACY_NAME("Polynomial::op+=/chunk");
-        for (size_t offset : chunk.range(other.size())) {
-            size_t i = offset + other.start_index;
-            at(i) += other[i];
-        }
-    });
-    return *this;
-}
-
 template <typename Fr> Fr Polynomial<Fr>::evaluate(const Fr& z) const
 {
     // Evaluate only the backing data; virtual zeroes beyond backing contribute nothing.
@@ -205,38 +188,6 @@ template <typename Fr> Fr Polynomial<Fr>::evaluate_mle(std::span<const Fr> evalu
     return _evaluate_mle(evaluation_points, coefficients_, shift);
 }
 
-template <typename Fr> Polynomial<Fr>& Polynomial<Fr>::operator-=(PolynomialSpan<const Fr> other)
-{
-    BB_BENCH_NAME("Polynomial::op-=");
-    BB_ASSERT_LTE(start_index(), other.start_index);
-    BB_ASSERT_GTE(end_index(), other.end_index());
-    parallel_for([&](const ThreadChunk& chunk) {
-        BB_BENCH_TRACY_NAME("Polynomial::op-=/chunk");
-        for (size_t offset : chunk.range(other.size())) {
-            size_t i = offset + other.start_index;
-            at(i) -= other[i];
-        }
-    });
-    return *this;
-}
-
-template <typename Fr> Polynomial<Fr>& Polynomial<Fr>::operator*=(const Fr& scaling_factor)
-{
-    BB_BENCH_NAME("Polynomial::op*=");
-    parallel_for([scaling_factor, this](const ThreadChunk& chunk) {
-        BB_BENCH_TRACY_NAME("Polynomial::op*=/chunk");
-        multiply_chunk(chunk, scaling_factor);
-    });
-    return *this;
-}
-
-template <typename Fr> void Polynomial<Fr>::multiply_chunk(const ThreadChunk& chunk, const Fr& scaling_factor)
-{
-    for (size_t i : chunk.range(size())) {
-        data()[i] *= scaling_factor;
-    }
-}
-
 template <typename Fr> Polynomial<Fr> Polynomial<Fr>::create_non_parallel_zero_init(size_t size, size_t virtual_size)
 {
     Polynomial p(size, virtual_size, Polynomial<Fr>::DontZeroMemory::FLAG);
@@ -247,41 +198,42 @@ template <typename Fr> Polynomial<Fr> Polynomial<Fr>::create_non_parallel_zero_i
 template <typename Fr> void Polynomial<Fr>::shrink_end_index(const size_t new_end_index)
 {
     BB_ASSERT_LTE(new_end_index, end_index());
-    // Preserve the SharedShiftedVirtualZeroesArray invariant start_ <= end_; without this,
-    // end_ < start_ would silently underflow size() to SIZE_MAX.
-    BB_ASSERT_GTE(new_end_index, start_index());
     coefficients_.end_ = new_end_index;
 }
 
 template <typename Fr> Polynomial<Fr> Polynomial<Fr>::full() const
 {
-    Polynomial result;
+    Polynomial result = *this;
     // Make 0..virtual_size usable
     result.coefficients_ = _clone(coefficients_, virtual_size() - end_index(), start_index());
     return result;
 }
 
-template <typename Fr> void Polynomial<Fr>::add_scaled(PolynomialSpan<const Fr> other, const Fr& scaling_factor)
+// add_scaled / add_scaled_chunk are defined inline in polynomial.hpp so
+// that callers (including the V8/TurboFan-jitted WASM bench) can inline
+// them and avoid a real WASM function-call boundary that V8 would not
+// otherwise elide.
+
+template <typename Fr> Polynomial<Fr> Polynomial<Fr>::shifted() const
 {
-    BB_BENCH_NAME("Polynomial::add_scaled");
-    BB_ASSERT_LTE(start_index(), other.start_index);
-    BB_ASSERT_GTE(end_index(), other.end_index());
-    parallel_for([&other, scaling_factor, this](const ThreadChunk& chunk) {
-        BB_BENCH_TRACY_NAME("Polynomial::add_scaled/chunk");
-        add_scaled_chunk(chunk, other, scaling_factor);
-    });
+    BB_ASSERT_GTE(coefficients_.start_, static_cast<size_t>(1));
+    Polynomial result;
+    result.coefficients_ = coefficients_;
+    result.coefficients_.start_ -= 1;
+    result.coefficients_.end_ -= 1;
+    return result;
 }
 
-template <typename Fr>
-void Polynomial<Fr>::add_scaled_chunk(const ThreadChunk& chunk,
-                                      PolynomialSpan<const Fr> other,
-                                      const Fr& scaling_factor)
+template <typename Fr> Polynomial<Fr> Polynomial<Fr>::reverse() const
 {
-    // Iterate over the chunk of the other polynomial's range
-    for (size_t offset : chunk.range(other.size())) {
-        size_t index = other.start_index + offset;
-        at(index) += scaling_factor * other[index];
+    const size_t end_index = this->end_index();
+    const size_t start_index = this->start_index();
+    const size_t poly_size = this->size();
+    Polynomial reversed(/*size=*/poly_size, /*virtual_size=*/end_index);
+    for (size_t idx = end_index; idx > start_index; --idx) {
+        reversed.at(end_index - idx) = this->at(idx - 1);
     }
+    return reversed;
 }
 
 template <typename Fr>
@@ -330,31 +282,8 @@ void add_scaled_batch(Polynomial<Fr>& dst,
     });
 }
 
-template <typename Fr> Polynomial<Fr> Polynomial<Fr>::shifted() const
-{
-    BB_ASSERT_GTE(coefficients_.start_, static_cast<size_t>(1));
-    Polynomial result;
-    result.coefficients_ = coefficients_;
-    result.coefficients_.start_ -= 1;
-    result.coefficients_.end_ -= 1;
-    return result;
-}
-
-template <typename Fr> Polynomial<Fr> Polynomial<Fr>::reverse() const
-{
-    const size_t end_index = this->end_index();
-    const size_t start_index = this->start_index();
-    const size_t poly_size = this->size();
-    Polynomial reversed(/*size=*/poly_size, /*virtual_size=*/end_index);
-    for (size_t idx = end_index; idx > start_index; --idx) {
-        reversed.at(end_index - idx) = this->at(idx - 1);
-    }
-    return reversed;
-}
-
 template class Polynomial<bb::fr>;
 template class Polynomial<grumpkin::fr>;
-
 template void add_scaled_batch<bb::fr>(Polynomial<bb::fr>& dst,
                                        std::span<const PolynomialSpan<const bb::fr>> sources,
                                        std::span<const bb::fr> scalars);

--- a/barretenberg/cpp/src/barretenberg/polynomials/polynomial.cpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/polynomial.cpp
@@ -120,6 +120,8 @@ Polynomial<Fr>::Polynomial(std::span<const Fr> interpolation_points,
     : Polynomial(interpolation_points.size(), virtual_size)
 {
     BB_ASSERT_GT(coefficients_.size(), static_cast<size_t>(0));
+    // compute_efficient_interpolation indexes evaluations by interpolation_points.size()
+    BB_ASSERT_EQ(interpolation_points.size(), evaluations.size());
 
     polynomial_arithmetic::compute_efficient_interpolation(
         evaluations.data(), coefficients_.data(), interpolation_points.data(), coefficients_.size());
@@ -198,12 +200,14 @@ template <typename Fr> Polynomial<Fr> Polynomial<Fr>::create_non_parallel_zero_i
 template <typename Fr> void Polynomial<Fr>::shrink_end_index(const size_t new_end_index)
 {
     BB_ASSERT_LTE(new_end_index, end_index());
+    // Without this lower-bound check, end_ < start_ would silently underflow size().
+    BB_ASSERT_GTE(new_end_index, start_index());
     coefficients_.end_ = new_end_index;
 }
 
 template <typename Fr> Polynomial<Fr> Polynomial<Fr>::full() const
 {
-    Polynomial result = *this;
+    Polynomial result;
     // Make 0..virtual_size usable
     result.coefficients_ = _clone(coefficients_, virtual_size() - end_index(), start_index());
     return result;

--- a/barretenberg/cpp/src/barretenberg/polynomials/polynomial.hpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/polynomial.hpp
@@ -102,6 +102,80 @@ template <typename Fr> struct PolynomialSpan {
  *
  * @tparam Fr the finite field type.
  */
+// Hidden-friend binary-operator wall stamped on both vector proxy types
+// (VectorWriteProxyT and ContiguousVectorWriteProxyT) so kernels written as
+//   p[ctx] = p[ctx] + other[ctx] * scalar;
+// resolve every operand combination (proxy×proxy, proxy×Value+reversed,
+// proxy×Scalar+reversed) through ADL on the proxy types. Defined as a
+// macro because there is no shared base — the two proxies materialise the
+// `Value` differently (gather vs. linear-memory ctor) and live in distinct
+// scopes inside the Polynomial template.
+//
+// Marked [[gnu::always_inline]] on every line: under -Oz V8/TurboFan leaves
+// unmarked proxy ops as standalone WASM functions, defeating the linear-
+// memory / gather primitives and adding ~0.7ms per 65k-field pass.
+#define BB_VECTOR_PROXY_BINARY_OPS(Proxy, Value, Scalar)                                                               \
+    [[gnu::always_inline]] friend Value operator+(const Proxy& a, const Proxy& b) noexcept                             \
+    {                                                                                                                  \
+        return Value(a) + Value(b);                                                                                    \
+    }                                                                                                                  \
+    [[gnu::always_inline]] friend Value operator-(const Proxy& a, const Proxy& b) noexcept                             \
+    {                                                                                                                  \
+        return Value(a) - Value(b);                                                                                    \
+    }                                                                                                                  \
+    [[gnu::always_inline]] friend Value operator*(const Proxy& a, const Proxy& b) noexcept                             \
+    {                                                                                                                  \
+        return Value(a) * Value(b);                                                                                    \
+    }                                                                                                                  \
+    [[gnu::always_inline]] friend Value operator+(const Proxy& a, const Value& b) noexcept                             \
+    {                                                                                                                  \
+        return Value(a) + b;                                                                                           \
+    }                                                                                                                  \
+    [[gnu::always_inline]] friend Value operator+(const Value& a, const Proxy& b) noexcept                             \
+    {                                                                                                                  \
+        return a + Value(b);                                                                                           \
+    }                                                                                                                  \
+    [[gnu::always_inline]] friend Value operator-(const Proxy& a, const Value& b) noexcept                             \
+    {                                                                                                                  \
+        return Value(a) - b;                                                                                           \
+    }                                                                                                                  \
+    [[gnu::always_inline]] friend Value operator-(const Value& a, const Proxy& b) noexcept                             \
+    {                                                                                                                  \
+        return a - Value(b);                                                                                           \
+    }                                                                                                                  \
+    [[gnu::always_inline]] friend Value operator*(const Proxy& a, const Value& b) noexcept                             \
+    {                                                                                                                  \
+        return Value(a) * b;                                                                                           \
+    }                                                                                                                  \
+    [[gnu::always_inline]] friend Value operator*(const Value& a, const Proxy& b) noexcept                             \
+    {                                                                                                                  \
+        return a * Value(b);                                                                                           \
+    }                                                                                                                  \
+    [[gnu::always_inline]] friend Value operator+(const Proxy& a, const Scalar& s) noexcept                            \
+    {                                                                                                                  \
+        return Value(a) + s;                                                                                           \
+    }                                                                                                                  \
+    [[gnu::always_inline]] friend Value operator+(const Scalar& s, const Proxy& a) noexcept                            \
+    {                                                                                                                  \
+        return s + Value(a);                                                                                           \
+    }                                                                                                                  \
+    [[gnu::always_inline]] friend Value operator-(const Proxy& a, const Scalar& s) noexcept                            \
+    {                                                                                                                  \
+        return Value(a) - s;                                                                                           \
+    }                                                                                                                  \
+    [[gnu::always_inline]] friend Value operator-(const Scalar& s, const Proxy& a) noexcept                            \
+    {                                                                                                                  \
+        return s - Value(a);                                                                                           \
+    }                                                                                                                  \
+    [[gnu::always_inline]] friend Value operator*(const Proxy& a, const Scalar& s) noexcept                            \
+    {                                                                                                                  \
+        return Value(a) * s;                                                                                           \
+    }                                                                                                                  \
+    [[gnu::always_inline]] friend Value operator*(const Scalar& s, const Proxy& a) noexcept                            \
+    {                                                                                                                  \
+        return s * Value(a);                                                                                           \
+    }
+
 template <typename Fr> class Polynomial {
   public:
     using FF = Fr;
@@ -381,93 +455,25 @@ template <typename Fr> class Polynomial {
         friend Fr operator*(const ScalarWriteProxy& a, const Fr& b) noexcept { return Fr(a) * b; }
         friend Fr operator*(const Fr& a, const ScalarWriteProxy& b) noexcept { return a * Fr(b); }
     };
+    // Write-proxy for VectorIndex<5> on a mutable Polynomial. Sparse / gather
+    // counterpart to ContiguousVectorWriteProxyT — assignment routes through
+    // `VectorField::scatter` (per-lane scalar stores at random indices), and
+    // the implicit conversion through `VectorField::gather`. Same inline
+    // discipline as the contiguous proxy (see comment above the macro).
     template <typename Params_> struct VectorWriteProxyT {
         Polynomial* self;
         std::array<size_t, 5> idx;
-        VectorWriteProxyT& operator=(const VectorField<Params_>& v)
+        [[gnu::always_inline]] VectorWriteProxyT& operator=(const VectorField<Params_>& v)
         {
             v.scatter(self->data() - self->start_index(), idx);
             return *this;
         }
-        operator VectorField<Params_>() const
+        [[gnu::always_inline]] operator VectorField<Params_>() const
         {
             return VectorField<Params_>::gather(self->data() - self->start_index(), idx);
         }
 
-        // Hidden-friend binary operators that take the proxy directly.
-        //
-        // VectorField's member operators are not candidates when the LHS is
-        // a proxy (member ops do not admit UDC on the implicit object
-        // parameter). Defining free-function operators that accept the
-        // proxy types explicitly gives overload resolution a candidate
-        // reachable via ADL from proxy arguments. Each forwards by
-        // materialising the proxy(ies) into VectorField(s) and delegating
-        // to the existing VectorField operator(s).
-        //
-        // Parameter types include the proxy itself, so these signatures do
-        // not collide with the same-named friends declared inside
-        // VectorField (which accept VectorField×VectorField or
-        // VectorField×Field).
-        friend VectorField<Params_> operator+(const VectorWriteProxyT& a, const VectorWriteProxyT& b) noexcept
-        {
-            return VectorField<Params_>(a) + VectorField<Params_>(b);
-        }
-        friend VectorField<Params_> operator-(const VectorWriteProxyT& a, const VectorWriteProxyT& b) noexcept
-        {
-            return VectorField<Params_>(a) - VectorField<Params_>(b);
-        }
-        friend VectorField<Params_> operator*(const VectorWriteProxyT& a, const VectorWriteProxyT& b) noexcept
-        {
-            return VectorField<Params_>(a) * VectorField<Params_>(b);
-        }
-        friend VectorField<Params_> operator+(const VectorWriteProxyT& a, const VectorField<Params_>& b) noexcept
-        {
-            return VectorField<Params_>(a) + b;
-        }
-        friend VectorField<Params_> operator+(const VectorField<Params_>& a, const VectorWriteProxyT& b) noexcept
-        {
-            return a + VectorField<Params_>(b);
-        }
-        friend VectorField<Params_> operator-(const VectorWriteProxyT& a, const VectorField<Params_>& b) noexcept
-        {
-            return VectorField<Params_>(a) - b;
-        }
-        friend VectorField<Params_> operator-(const VectorField<Params_>& a, const VectorWriteProxyT& b) noexcept
-        {
-            return a - VectorField<Params_>(b);
-        }
-        friend VectorField<Params_> operator*(const VectorWriteProxyT& a, const VectorField<Params_>& b) noexcept
-        {
-            return VectorField<Params_>(a) * b;
-        }
-        friend VectorField<Params_> operator*(const VectorField<Params_>& a, const VectorWriteProxyT& b) noexcept
-        {
-            return a * VectorField<Params_>(b);
-        }
-        friend VectorField<Params_> operator+(const VectorWriteProxyT& a, const Fr& s) noexcept
-        {
-            return VectorField<Params_>(a) + s;
-        }
-        friend VectorField<Params_> operator+(const Fr& s, const VectorWriteProxyT& a) noexcept
-        {
-            return s + VectorField<Params_>(a);
-        }
-        friend VectorField<Params_> operator-(const VectorWriteProxyT& a, const Fr& s) noexcept
-        {
-            return VectorField<Params_>(a) - s;
-        }
-        friend VectorField<Params_> operator-(const Fr& s, const VectorWriteProxyT& a) noexcept
-        {
-            return s - VectorField<Params_>(a);
-        }
-        friend VectorField<Params_> operator*(const VectorWriteProxyT& a, const Fr& s) noexcept
-        {
-            return VectorField<Params_>(a) * s;
-        }
-        friend VectorField<Params_> operator*(const Fr& s, const VectorWriteProxyT& a) noexcept
-        {
-            return s * VectorField<Params_>(a);
-        }
+        BB_VECTOR_PROXY_BINARY_OPS(VectorWriteProxyT, VectorField<Params_>, Fr)
     };
 
     // Write-proxy for ContiguousVectorIndex<5> on a mutable Polynomial.
@@ -476,11 +482,6 @@ template <typename Fr> class Polynomial {
     // without the per-lane scalar stores `scatter` does. Also implicitly
     // converts to VectorField via the linear-memory ctor so a kernel can
     // read and write through the same token.
-    //
-    // All operations are [[gnu::always_inline]] so -Oz builds still inline
-    // the proxy into the bulk kernel. Without this, -Oz leaves the proxy
-    // ops as standalone calls, defeating the linear-memory primitives and
-    // adding ~0.7ms per 65k-field pass.
     template <typename Params_> struct ContiguousVectorWriteProxyT {
         Polynomial* self;
         size_t base;
@@ -494,86 +495,7 @@ template <typename Fr> class Polynomial {
             return VectorField<Params_>(self->data() - self->start_index() + base);
         }
 
-        // Hidden-friend binary operators that take the proxy directly.
-        // Mirror VectorWriteProxyT so kernels written against mutable
-        // Polynomials using `self[ctx] = self[ctx] + other[ctx] * scalar;`
-        // resolve the RHS through these forwarders when either operand is
-        // a proxy.
-        [[gnu::always_inline]] friend VectorField<Params_> operator+(const ContiguousVectorWriteProxyT& a,
-                                                                     const ContiguousVectorWriteProxyT& b) noexcept
-        {
-            return VectorField<Params_>(a) + VectorField<Params_>(b);
-        }
-        [[gnu::always_inline]] friend VectorField<Params_> operator-(const ContiguousVectorWriteProxyT& a,
-                                                                     const ContiguousVectorWriteProxyT& b) noexcept
-        {
-            return VectorField<Params_>(a) - VectorField<Params_>(b);
-        }
-        [[gnu::always_inline]] friend VectorField<Params_> operator*(const ContiguousVectorWriteProxyT& a,
-                                                                     const ContiguousVectorWriteProxyT& b) noexcept
-        {
-            return VectorField<Params_>(a) * VectorField<Params_>(b);
-        }
-        [[gnu::always_inline]] friend VectorField<Params_> operator+(const ContiguousVectorWriteProxyT& a,
-                                                                     const VectorField<Params_>& b) noexcept
-        {
-            return VectorField<Params_>(a) + b;
-        }
-        [[gnu::always_inline]] friend VectorField<Params_> operator+(const VectorField<Params_>& a,
-                                                                     const ContiguousVectorWriteProxyT& b) noexcept
-        {
-            return a + VectorField<Params_>(b);
-        }
-        [[gnu::always_inline]] friend VectorField<Params_> operator-(const ContiguousVectorWriteProxyT& a,
-                                                                     const VectorField<Params_>& b) noexcept
-        {
-            return VectorField<Params_>(a) - b;
-        }
-        [[gnu::always_inline]] friend VectorField<Params_> operator-(const VectorField<Params_>& a,
-                                                                     const ContiguousVectorWriteProxyT& b) noexcept
-        {
-            return a - VectorField<Params_>(b);
-        }
-        [[gnu::always_inline]] friend VectorField<Params_> operator*(const ContiguousVectorWriteProxyT& a,
-                                                                     const VectorField<Params_>& b) noexcept
-        {
-            return VectorField<Params_>(a) * b;
-        }
-        [[gnu::always_inline]] friend VectorField<Params_> operator*(const VectorField<Params_>& a,
-                                                                     const ContiguousVectorWriteProxyT& b) noexcept
-        {
-            return a * VectorField<Params_>(b);
-        }
-        [[gnu::always_inline]] friend VectorField<Params_> operator+(const ContiguousVectorWriteProxyT& a,
-                                                                     const Fr& s) noexcept
-        {
-            return VectorField<Params_>(a) + s;
-        }
-        [[gnu::always_inline]] friend VectorField<Params_> operator+(const Fr& s,
-                                                                     const ContiguousVectorWriteProxyT& a) noexcept
-        {
-            return s + VectorField<Params_>(a);
-        }
-        [[gnu::always_inline]] friend VectorField<Params_> operator-(const ContiguousVectorWriteProxyT& a,
-                                                                     const Fr& s) noexcept
-        {
-            return VectorField<Params_>(a) - s;
-        }
-        [[gnu::always_inline]] friend VectorField<Params_> operator-(const Fr& s,
-                                                                     const ContiguousVectorWriteProxyT& a) noexcept
-        {
-            return s - VectorField<Params_>(a);
-        }
-        [[gnu::always_inline]] friend VectorField<Params_> operator*(const ContiguousVectorWriteProxyT& a,
-                                                                     const Fr& s) noexcept
-        {
-            return VectorField<Params_>(a) * s;
-        }
-        [[gnu::always_inline]] friend VectorField<Params_> operator*(const Fr& s,
-                                                                     const ContiguousVectorWriteProxyT& a) noexcept
-        {
-            return s * VectorField<Params_>(a);
-        }
+        BB_VECTOR_PROXY_BINARY_OPS(ContiguousVectorWriteProxyT, VectorField<Params_>, Fr)
     };
 
     // Scalar read via token: delegates to the size_t overload.

--- a/barretenberg/cpp/src/barretenberg/polynomials/polynomial.hpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/polynomial.hpp
@@ -241,6 +241,11 @@ template <typename Fr> class Polynomial {
         }
         return p;
     }
+    /**
+     * @brief Overload of `shiftable` that leaves the backing memory uninitialized.
+     * @details Use only when the caller writes every cell in [NUM_ZERO_ROWS, NUM_ZERO_ROWS + size)
+     *          before any read.
+     */
     static Polynomial shiftable(size_t size, size_t virtual_size, DontZeroMemory flag)
     {
         return Polynomial(/*actual size*/ size - NUM_ZERO_ROWS, virtual_size, /*shiftable offset*/ NUM_ZERO_ROWS, flag);
@@ -792,6 +797,16 @@ template <typename Fr>
     return *this;
 }
 
+/**
+ * @brief Fused parallel batched add: dst += sum_i scalars[i] * sources[i].
+ *
+ * Equivalent to invoking dst.add_scaled(sources[i], scalars[i]) for each i, but issues a single
+ * parallel_for over the destination range and visits every source within each chunk. Amortises
+ * the per-call parallel_for startup cost from N× down to 1×, which dominates the cost of small-N
+ * batched add-scaled patterns at high core counts.
+ *
+ * Each source must satisfy add_scaled's precondition: dst's index range covers the source's.
+ */
 template <typename Fr>
 void add_scaled_batch(Polynomial<Fr>& dst,
                       std::span<const PolynomialSpan<const Fr>> sources,

--- a/barretenberg/cpp/src/barretenberg/polynomials/polynomial.hpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/polynomial.hpp
@@ -13,9 +13,13 @@
 #include "barretenberg/common/type_traits.hpp"
 #include "barretenberg/common/zip_view.hpp"
 #include "barretenberg/constants.hpp"
+#include "barretenberg/ecc/fields/vector_field.hpp"
+#include "barretenberg/polynomials/broadcast.hpp"
 #include "barretenberg/polynomials/shared_shifted_virtual_zeroes_array.hpp"
+#include "barretenberg/polynomials/vectorized_for.hpp"
 #include "evaluation_domain.hpp"
 #include "polynomial_arithmetic.hpp"
+#include <array>
 #include <cstddef>
 #include <fstream>
 #include <ranges>
@@ -46,6 +50,32 @@ template <typename Fr> struct PolynomialSpan {
         BB_ASSERT_DEBUG(index < end_index());
         return span[index - start_index];
     }
+
+    // Read-only token-indexed accessors, mirroring Polynomial's scalar/vector
+    // read overloads. No write proxies: a PolynomialSpan<const Fr> is
+    // read-only, and the non-const PolynomialSpan<Fr> use sites we care
+    // about all pass through the implicit conversion to
+    // PolynomialSpan<const Fr> before reaching the kernel.
+    using element_type = std::remove_const_t<Fr>;
+    element_type operator[](ScalarIndex ctx) const { return (*this)[ctx.i]; }
+    template <size_t N, typename U = element_type> VectorField<typename U::Params> operator[](VectorIndex<N> ctx) const
+    {
+        static_assert(N == VECTOR_FIELD_WIDTH, "VectorField is fixed-width; N must equal VECTOR_FIELD_WIDTH");
+        return VectorField<typename U::Params>::gather(this->span.data() - this->start_index, ctx.idx);
+    }
+
+    // Contiguous vector read: lane L = this->span[base - start_index + L].
+    // Routes through the linear-memory `VectorField(const Field*)` ctor —
+    // the loop abstraction's primary load primitive, which uses SIMD
+    // shuffles to AoS→interleaved transpose without the per-lane scalar
+    // loads `gather` does.
+    template <size_t N, typename U = element_type>
+    [[gnu::always_inline]] VectorField<typename U::Params> operator[](ContiguousVectorIndex<N> ctx) const
+    {
+        static_assert(N == VECTOR_FIELD_WIDTH, "VectorField is fixed-width; N must equal VECTOR_FIELD_WIDTH");
+        return VectorField<typename U::Params>(this->span.data() - this->start_index + ctx.base);
+    }
+
     PolynomialSpan subspan(size_t offset, size_t length)
     {
         if (offset > span.size()) { // Return a null span
@@ -137,11 +167,6 @@ template <typename Fr> class Polynomial {
         }
         return p;
     }
-    /**
-     * @brief Overload of `shiftable` that leaves the backing memory uninitialized.
-     * @details Use only when the caller writes every cell in [NUM_ZERO_ROWS, NUM_ZERO_ROWS + size)
-     *          before any read.
-     */
     static Polynomial shiftable(size_t size, size_t virtual_size, DontZeroMemory flag)
     {
         return Polynomial(/*actual size*/ size - NUM_ZERO_ROWS, virtual_size, /*shiftable offset*/ NUM_ZERO_ROWS, flag);
@@ -260,32 +285,38 @@ template <typename Fr> class Polynomial {
      * @param other q(X)
      * @param scaling_factor scaling factor by which all coefficients of q(X) are multiplied
      */
-    void add_scaled(PolynomialSpan<const Fr> other, const Fr& scaling_factor);
+    [[gnu::always_inline]] void add_scaled(PolynomialSpan<const Fr> other, const Fr& scaling_factor);
 
-    void add_scaled_chunk(const ThreadChunk& chunk, PolynomialSpan<const Fr> other, const Fr& scaling_factor);
+    [[gnu::always_inline]] void add_scaled_chunk(const ThreadChunk& chunk,
+                                                 PolynomialSpan<const Fr> other,
+                                                 const Fr& scaling_factor);
 
     /**
      * @brief adds the polynomial q(X) 'other'.
      *
      * @param other q(X)
      */
-    Polynomial& operator+=(PolynomialSpan<const Fr> other);
+    [[gnu::always_inline]] Polynomial& operator+=(PolynomialSpan<const Fr> other);
+
+    [[gnu::always_inline]] void add_chunk(const ThreadChunk& chunk, PolynomialSpan<const Fr> other);
 
     /**
      * @brief subtracts the polynomial q(X) 'other'.
      *
      * @param other q(X)
      */
-    Polynomial& operator-=(PolynomialSpan<const Fr> other);
+    [[gnu::always_inline]] Polynomial& operator-=(PolynomialSpan<const Fr> other);
+
+    [[gnu::always_inline]] void subtract_chunk(const ThreadChunk& chunk, PolynomialSpan<const Fr> other);
 
     /**
      * @brief sets this = p(X) to s⋅p(X)
      *
      * @param scaling_factor s
      */
-    Polynomial& operator*=(const Fr& scaling_factor);
+    [[gnu::always_inline]] Polynomial& operator*=(const Fr& scaling_factor);
 
-    void multiply_chunk(const ThreadChunk& chunk, const Fr& scaling_factor);
+    [[gnu::always_inline]] void multiply_chunk(const ThreadChunk& chunk, const Fr& scaling_factor);
 
     std::size_t size() const { return coefficients_.size(); }
     std::size_t virtual_size() const { return coefficients_.virtual_size(); }
@@ -308,11 +339,283 @@ template <typename Fr> class Polynomial {
     const Fr& operator[](size_t i) { return get(i); }
     const Fr& operator[](size_t i) const { return get(i); }
 
+    // ---- Index-token overloads (see vectorized_for.hpp) ----
+    //
+    // Gated on Fr exposing a Params typedef (true for native field<Params>,
+    // not for stdlib::field_t). This avoids pulling VectorField into circuit
+    // instantiations and also dodges an include cycle risk for stdlib types.
+
+    // Write-proxies: returned by non-const operator[] on index tokens so
+    // assignment routes through at() (the correct mutable accessor that
+    // respects the virtual/shifted buffer layout). Each proxy also implicitly
+    // converts back to the read type so a kernel written against a mutable
+    // Polynomial can read and write through the same token:
+    //   p[ctx] = p[ctx] + p[ctx];
+    // The assignment picks operator= and the RHS uses of p[ctx] convert to
+    // the value type.
+    struct ScalarWriteProxy {
+        Polynomial* self;
+        size_t i;
+        ScalarWriteProxy& operator=(const Fr& v)
+        {
+            self->at(i) = v;
+            return *this;
+        }
+        operator Fr() const { return self->at(i); }
+
+        // Hidden-friend binary operators that take the proxy directly.
+        //
+        // Fr's binary operators are class members and are not candidates
+        // when the LHS is a proxy. Defining free operators that accept the
+        // proxy type explicitly gives overload resolution a candidate
+        // reachable via ADL from proxy arguments. Each forwards by reading
+        // the Fr value through `at()` (via the operator Fr() conversion)
+        // and delegating to Fr's member operator.
+        friend Fr operator+(const ScalarWriteProxy& a, const ScalarWriteProxy& b) noexcept { return Fr(a) + Fr(b); }
+        friend Fr operator-(const ScalarWriteProxy& a, const ScalarWriteProxy& b) noexcept { return Fr(a) - Fr(b); }
+        friend Fr operator*(const ScalarWriteProxy& a, const ScalarWriteProxy& b) noexcept { return Fr(a) * Fr(b); }
+        friend Fr operator+(const ScalarWriteProxy& a, const Fr& b) noexcept { return Fr(a) + b; }
+        friend Fr operator+(const Fr& a, const ScalarWriteProxy& b) noexcept { return a + Fr(b); }
+        friend Fr operator-(const ScalarWriteProxy& a, const Fr& b) noexcept { return Fr(a) - b; }
+        friend Fr operator-(const Fr& a, const ScalarWriteProxy& b) noexcept { return a - Fr(b); }
+        friend Fr operator*(const ScalarWriteProxy& a, const Fr& b) noexcept { return Fr(a) * b; }
+        friend Fr operator*(const Fr& a, const ScalarWriteProxy& b) noexcept { return a * Fr(b); }
+    };
+    template <typename Params_> struct VectorWriteProxyT {
+        Polynomial* self;
+        std::array<size_t, 5> idx;
+        VectorWriteProxyT& operator=(const VectorField<Params_>& v)
+        {
+            v.scatter(self->data() - self->start_index(), idx);
+            return *this;
+        }
+        operator VectorField<Params_>() const
+        {
+            return VectorField<Params_>::gather(self->data() - self->start_index(), idx);
+        }
+
+        // Hidden-friend binary operators that take the proxy directly.
+        //
+        // VectorField's member operators are not candidates when the LHS is
+        // a proxy (member ops do not admit UDC on the implicit object
+        // parameter). Defining free-function operators that accept the
+        // proxy types explicitly gives overload resolution a candidate
+        // reachable via ADL from proxy arguments. Each forwards by
+        // materialising the proxy(ies) into VectorField(s) and delegating
+        // to the existing VectorField operator(s).
+        //
+        // Parameter types include the proxy itself, so these signatures do
+        // not collide with the same-named friends declared inside
+        // VectorField (which accept VectorField×VectorField or
+        // VectorField×Field).
+        friend VectorField<Params_> operator+(const VectorWriteProxyT& a, const VectorWriteProxyT& b) noexcept
+        {
+            return VectorField<Params_>(a) + VectorField<Params_>(b);
+        }
+        friend VectorField<Params_> operator-(const VectorWriteProxyT& a, const VectorWriteProxyT& b) noexcept
+        {
+            return VectorField<Params_>(a) - VectorField<Params_>(b);
+        }
+        friend VectorField<Params_> operator*(const VectorWriteProxyT& a, const VectorWriteProxyT& b) noexcept
+        {
+            return VectorField<Params_>(a) * VectorField<Params_>(b);
+        }
+        friend VectorField<Params_> operator+(const VectorWriteProxyT& a, const VectorField<Params_>& b) noexcept
+        {
+            return VectorField<Params_>(a) + b;
+        }
+        friend VectorField<Params_> operator+(const VectorField<Params_>& a, const VectorWriteProxyT& b) noexcept
+        {
+            return a + VectorField<Params_>(b);
+        }
+        friend VectorField<Params_> operator-(const VectorWriteProxyT& a, const VectorField<Params_>& b) noexcept
+        {
+            return VectorField<Params_>(a) - b;
+        }
+        friend VectorField<Params_> operator-(const VectorField<Params_>& a, const VectorWriteProxyT& b) noexcept
+        {
+            return a - VectorField<Params_>(b);
+        }
+        friend VectorField<Params_> operator*(const VectorWriteProxyT& a, const VectorField<Params_>& b) noexcept
+        {
+            return VectorField<Params_>(a) * b;
+        }
+        friend VectorField<Params_> operator*(const VectorField<Params_>& a, const VectorWriteProxyT& b) noexcept
+        {
+            return a * VectorField<Params_>(b);
+        }
+        friend VectorField<Params_> operator+(const VectorWriteProxyT& a, const Fr& s) noexcept
+        {
+            return VectorField<Params_>(a) + s;
+        }
+        friend VectorField<Params_> operator+(const Fr& s, const VectorWriteProxyT& a) noexcept
+        {
+            return s + VectorField<Params_>(a);
+        }
+        friend VectorField<Params_> operator-(const VectorWriteProxyT& a, const Fr& s) noexcept
+        {
+            return VectorField<Params_>(a) - s;
+        }
+        friend VectorField<Params_> operator-(const Fr& s, const VectorWriteProxyT& a) noexcept
+        {
+            return s - VectorField<Params_>(a);
+        }
+        friend VectorField<Params_> operator*(const VectorWriteProxyT& a, const Fr& s) noexcept
+        {
+            return VectorField<Params_>(a) * s;
+        }
+        friend VectorField<Params_> operator*(const Fr& s, const VectorWriteProxyT& a) noexcept
+        {
+            return s * VectorField<Params_>(a);
+        }
+    };
+
+    // Write-proxy for ContiguousVectorIndex<5> on a mutable Polynomial.
+    // Holds {self, base} and assignment stores via VectorField::store_to,
+    // which uses the SIMD-shuffle path for AoS→interleaved write-back
+    // without the per-lane scalar stores `scatter` does. Also implicitly
+    // converts to VectorField via the linear-memory ctor so a kernel can
+    // read and write through the same token.
+    //
+    // All operations are [[gnu::always_inline]] so -Oz builds still inline
+    // the proxy into the bulk kernel. Without this, -Oz leaves the proxy
+    // ops as standalone calls, defeating the linear-memory primitives and
+    // adding ~0.7ms per 65k-field pass.
+    template <typename Params_> struct ContiguousVectorWriteProxyT {
+        Polynomial* self;
+        size_t base;
+        [[gnu::always_inline]] ContiguousVectorWriteProxyT& operator=(const VectorField<Params_>& v)
+        {
+            v.store_to(self->data() - self->start_index() + base);
+            return *this;
+        }
+        [[gnu::always_inline]] operator VectorField<Params_>() const
+        {
+            return VectorField<Params_>(self->data() - self->start_index() + base);
+        }
+
+        // Hidden-friend binary operators that take the proxy directly.
+        // Mirror VectorWriteProxyT so kernels written against mutable
+        // Polynomials using `self[ctx] = self[ctx] + other[ctx] * scalar;`
+        // resolve the RHS through these forwarders when either operand is
+        // a proxy.
+        [[gnu::always_inline]] friend VectorField<Params_> operator+(const ContiguousVectorWriteProxyT& a,
+                                                                     const ContiguousVectorWriteProxyT& b) noexcept
+        {
+            return VectorField<Params_>(a) + VectorField<Params_>(b);
+        }
+        [[gnu::always_inline]] friend VectorField<Params_> operator-(const ContiguousVectorWriteProxyT& a,
+                                                                     const ContiguousVectorWriteProxyT& b) noexcept
+        {
+            return VectorField<Params_>(a) - VectorField<Params_>(b);
+        }
+        [[gnu::always_inline]] friend VectorField<Params_> operator*(const ContiguousVectorWriteProxyT& a,
+                                                                     const ContiguousVectorWriteProxyT& b) noexcept
+        {
+            return VectorField<Params_>(a) * VectorField<Params_>(b);
+        }
+        [[gnu::always_inline]] friend VectorField<Params_> operator+(const ContiguousVectorWriteProxyT& a,
+                                                                     const VectorField<Params_>& b) noexcept
+        {
+            return VectorField<Params_>(a) + b;
+        }
+        [[gnu::always_inline]] friend VectorField<Params_> operator+(const VectorField<Params_>& a,
+                                                                     const ContiguousVectorWriteProxyT& b) noexcept
+        {
+            return a + VectorField<Params_>(b);
+        }
+        [[gnu::always_inline]] friend VectorField<Params_> operator-(const ContiguousVectorWriteProxyT& a,
+                                                                     const VectorField<Params_>& b) noexcept
+        {
+            return VectorField<Params_>(a) - b;
+        }
+        [[gnu::always_inline]] friend VectorField<Params_> operator-(const VectorField<Params_>& a,
+                                                                     const ContiguousVectorWriteProxyT& b) noexcept
+        {
+            return a - VectorField<Params_>(b);
+        }
+        [[gnu::always_inline]] friend VectorField<Params_> operator*(const ContiguousVectorWriteProxyT& a,
+                                                                     const VectorField<Params_>& b) noexcept
+        {
+            return VectorField<Params_>(a) * b;
+        }
+        [[gnu::always_inline]] friend VectorField<Params_> operator*(const VectorField<Params_>& a,
+                                                                     const ContiguousVectorWriteProxyT& b) noexcept
+        {
+            return a * VectorField<Params_>(b);
+        }
+        [[gnu::always_inline]] friend VectorField<Params_> operator+(const ContiguousVectorWriteProxyT& a,
+                                                                     const Fr& s) noexcept
+        {
+            return VectorField<Params_>(a) + s;
+        }
+        [[gnu::always_inline]] friend VectorField<Params_> operator+(const Fr& s,
+                                                                     const ContiguousVectorWriteProxyT& a) noexcept
+        {
+            return s + VectorField<Params_>(a);
+        }
+        [[gnu::always_inline]] friend VectorField<Params_> operator-(const ContiguousVectorWriteProxyT& a,
+                                                                     const Fr& s) noexcept
+        {
+            return VectorField<Params_>(a) - s;
+        }
+        [[gnu::always_inline]] friend VectorField<Params_> operator-(const Fr& s,
+                                                                     const ContiguousVectorWriteProxyT& a) noexcept
+        {
+            return s - VectorField<Params_>(a);
+        }
+        [[gnu::always_inline]] friend VectorField<Params_> operator*(const ContiguousVectorWriteProxyT& a,
+                                                                     const Fr& s) noexcept
+        {
+            return VectorField<Params_>(a) * s;
+        }
+        [[gnu::always_inline]] friend VectorField<Params_> operator*(const Fr& s,
+                                                                     const ContiguousVectorWriteProxyT& a) noexcept
+        {
+            return s * VectorField<Params_>(a);
+        }
+    };
+
+    // Scalar read via token: delegates to the size_t overload.
+    Fr operator[](ScalarIndex ctx) const { return (*this)[ctx.i]; }
+
+    // Vector read via token: lane L = (*this)[ctx.idx[L]].
+    // Templated on U = Fr so that Fr::Params is only resolved lazily when
+    // this member is instantiated — avoids hard errors when Polynomial is
+    // instantiated with a type (e.g. stdlib::field_t) that has no Params.
+    template <size_t N, typename U = Fr> VectorField<typename U::Params> operator[](VectorIndex<N> ctx) const
+    {
+        static_assert(N == VECTOR_FIELD_WIDTH, "VectorField is fixed-width; N must equal VECTOR_FIELD_WIDTH");
+        return VectorField<typename U::Params>::gather(this->data() - this->start_index(), ctx.idx);
+    }
+
+    // Contiguous vector read via token: lane L = (*this)[ctx.base + L].
+    // Routes through the linear-memory `VectorField(const Field*)` ctor.
+    template <size_t N, typename U = Fr>
+    [[gnu::always_inline]] VectorField<typename U::Params> operator[](ContiguousVectorIndex<N> ctx) const
+    {
+        static_assert(N == VECTOR_FIELD_WIDTH, "VectorField is fixed-width; N must equal VECTOR_FIELD_WIDTH");
+        return VectorField<typename U::Params>(this->data() - this->start_index() + ctx.base);
+    }
+
+    // Non-const LHS overloads return write-proxies.
+    ScalarWriteProxy operator[](ScalarIndex ctx) { return ScalarWriteProxy{ this, ctx.i }; }
+    template <size_t N, typename U = Fr> VectorWriteProxyT<typename U::Params> operator[](VectorIndex<N> ctx)
+    {
+        static_assert(N == VECTOR_FIELD_WIDTH, "VectorField is fixed-width; N must equal VECTOR_FIELD_WIDTH");
+        return VectorWriteProxyT<typename U::Params>{ this, ctx.idx };
+    }
+    template <size_t N, typename U = Fr>
+    [[gnu::always_inline]] ContiguousVectorWriteProxyT<typename U::Params> operator[](ContiguousVectorIndex<N> ctx)
+    {
+        static_assert(N == VECTOR_FIELD_WIDTH, "VectorField is fixed-width; N must equal VECTOR_FIELD_WIDTH");
+        return ContiguousVectorWriteProxyT<typename U::Params>{ this, ctx.base };
+    }
+
     static Polynomial random(size_t size, size_t start_index = 0)
     {
         BB_BENCH_NAME("generate random polynomial");
 
-        BB_ASSERT_GTE(size, start_index);
         return random(size - start_index, size, start_index);
     }
 
@@ -433,16 +736,140 @@ template <typename Fr> class Polynomial {
     SharedShiftedVirtualZeroesArray<Fr> coefficients_;
 };
 
-/**
- * @brief Fused parallel batched add: dst += sum_i scalars[i] * sources[i].
- *
- * Equivalent to invoking dst.add_scaled(sources[i], scalars[i]) for each i, but issues a single
- * parallel_for over the destination range and visits every source within each chunk. Amortises
- * the per-call parallel_for startup cost from N× down to 1×, which dominates the cost of small-N
- * batched add-scaled patterns at high core counts.
- *
- * Each source must satisfy add_scaled's precondition: dst's index range covers the source's.
- */
+// Inline definitions for `add_scaled` / `add_scaled_chunk`.
+// Bodies live in the header so that callers (notably the V8/TurboFan-jitted
+// WASM code) can inline them and recover the per-iter `vector_field_raw`
+// ceiling — the polynomial.cpp definition added a real WASM function-call
+// boundary that V8 was not eliding.
+
+template <typename Fr>
+[[gnu::always_inline]] inline void Polynomial<Fr>::add_scaled_chunk(const ThreadChunk& chunk,
+                                                                    PolynomialSpan<const Fr> other,
+                                                                    const Fr& scaling_factor)
+{
+    auto range = chunk.range(other.size());
+    if (range.empty()) {
+        return;
+    }
+    const size_t lo = *range.begin() + other.start_index;
+    const size_t hi = lo + range.size();
+
+    // Loop abstraction: `vectorized_for<VECTOR_FIELD_WIDTH>` emits ContiguousVectorIndex<5>
+    // for the bulk pass and ScalarIndex for the tail. The kernel reads/writes
+    // through Polynomial / PolynomialSpan's index-token operator[], which
+    // route through the linear-memory `VectorField(const Field*)` ctor and
+    // its matching `store_to` write method (no gather/scatter). The proxy
+    // ops are [[gnu::always_inline]] so the abstraction lowers to the same
+    // SIMD-shuffle pack/op/unpack sequence as a hand-written tight loop.
+    //
+    // Scaling is wrapped in a `Broadcast<Fr>` so the same `scaling[ctx]`
+    // expression yields a scalar Fr in the tail path and a broadcast
+    // VectorField in the bulk path; both forms are materialized once in
+    // the Broadcast constructor.
+    const Broadcast<Fr> scaling(scaling_factor);
+    vectorized_for<VECTOR_FIELD_WIDTH, Fr>(
+        lo, hi, [&](auto ctx) { (*this)[ctx] = (*this)[ctx] + other[ctx] * scaling[ctx]; });
+}
+
+template <typename Fr>
+[[gnu::always_inline]] inline void Polynomial<Fr>::add_scaled(PolynomialSpan<const Fr> other, const Fr& scaling_factor)
+{
+    BB_ASSERT_LTE(start_index(), other.start_index);
+    BB_ASSERT_GTE(end_index(), other.end_index());
+    // Outer thread split. The template `parallel_for_heuristic` short-circuits
+    // below its work threshold by invoking `func(ThreadChunk{0, 1})` directly,
+    // so the small-range / single-thread case still reaches add_scaled_chunk's
+    // tight `vectorized_for<VECTOR_FIELD_WIDTH>` loop without parallel_for overhead.
+    [[clang::always_inline]] parallel_for_heuristic(
+        other.size(),
+        [&other, scaling_factor, this](const ThreadChunk& chunk) {
+            [[clang::always_inline]] add_scaled_chunk(chunk, other, scaling_factor);
+        },
+        thread_heuristics::FF_ADDITION_COST + thread_heuristics::FF_MULTIPLICATION_COST);
+}
+
+// Inline definitions for `operator+=` / `add_chunk` — pointwise polynomial
+// addition. Bodies in the header for the same V8/TurboFan inlining reason
+// `add_scaled_chunk` was lifted up: a polynomial.cpp definition introduces
+// a real WASM function-call boundary that V8 was not eliding.
+template <typename Fr>
+[[gnu::always_inline]] inline void Polynomial<Fr>::add_chunk(const ThreadChunk& chunk, PolynomialSpan<const Fr> other)
+{
+    auto range = chunk.range(other.size());
+    if (range.empty()) {
+        return;
+    }
+    const size_t lo = *range.begin() + other.start_index;
+    const size_t hi = lo + range.size();
+    vectorized_for<VECTOR_FIELD_WIDTH, Fr>(lo, hi, [&](auto ctx) { (*this)[ctx] = (*this)[ctx] + other[ctx]; });
+}
+
+template <typename Fr>
+[[gnu::always_inline]] inline Polynomial<Fr>& Polynomial<Fr>::operator+=(PolynomialSpan<const Fr> other)
+{
+    BB_ASSERT_LTE(start_index(), other.start_index);
+    BB_ASSERT_GTE(end_index(), other.end_index());
+    [[clang::always_inline]] parallel_for_heuristic(
+        other.size(),
+        [&other, this](const ThreadChunk& chunk) { [[clang::always_inline]] add_chunk(chunk, other); },
+        thread_heuristics::FF_ADDITION_COST);
+    return *this;
+}
+
+// Inline definitions for `operator-=` / `subtract_chunk`.
+template <typename Fr>
+[[gnu::always_inline]] inline void Polynomial<Fr>::subtract_chunk(const ThreadChunk& chunk,
+                                                                  PolynomialSpan<const Fr> other)
+{
+    auto range = chunk.range(other.size());
+    if (range.empty()) {
+        return;
+    }
+    const size_t lo = *range.begin() + other.start_index;
+    const size_t hi = lo + range.size();
+    vectorized_for<VECTOR_FIELD_WIDTH, Fr>(lo, hi, [&](auto ctx) { (*this)[ctx] = (*this)[ctx] - other[ctx]; });
+}
+
+template <typename Fr>
+[[gnu::always_inline]] inline Polynomial<Fr>& Polynomial<Fr>::operator-=(PolynomialSpan<const Fr> other)
+{
+    BB_ASSERT_LTE(start_index(), other.start_index);
+    BB_ASSERT_GTE(end_index(), other.end_index());
+    [[clang::always_inline]] parallel_for_heuristic(
+        other.size(),
+        [&other, this](const ThreadChunk& chunk) { [[clang::always_inline]] subtract_chunk(chunk, other); },
+        thread_heuristics::FF_ADDITION_COST);
+    return *this;
+}
+
+// Inline definitions for `operator*=` / `multiply_chunk` — pointwise scalar
+// multiply. Broadcast<Fr> exposes `scaling_factor` through the same
+// token-dispatched operator[] protocol Polynomial uses.
+template <typename Fr>
+[[gnu::always_inline]] inline void Polynomial<Fr>::multiply_chunk(const ThreadChunk& chunk, const Fr& scaling_factor)
+{
+    auto range = chunk.range(size());
+    if (range.empty()) {
+        return;
+    }
+    const size_t lo = *range.begin() + start_index();
+    const size_t hi = lo + range.size();
+    const Broadcast<Fr> scaling(scaling_factor);
+    vectorized_for<VECTOR_FIELD_WIDTH, Fr>(lo, hi, [&](auto ctx) { (*this)[ctx] = (*this)[ctx] * scaling[ctx]; });
+}
+
+template <typename Fr>
+[[gnu::always_inline]] inline Polynomial<Fr>& Polynomial<Fr>::operator*=(const Fr& scaling_factor)
+{
+    [[clang::always_inline]] parallel_for_heuristic(
+        size(),
+        [scaling_factor, this](const ThreadChunk& chunk) {
+            [[clang::always_inline]] multiply_chunk(chunk, scaling_factor);
+        },
+        thread_heuristics::FF_MULTIPLICATION_COST);
+    return *this;
+}
+
 template <typename Fr>
 void add_scaled_batch(Polynomial<Fr>& dst,
                       std::span<const PolynomialSpan<const Fr>> sources,
@@ -481,13 +908,13 @@ Fr_ _evaluate_mle(std::span<const Fr_> evaluation_points,
     const size_t dim = numeric::get_msb(coefficients.end_ - 1) + 1; // Round up to next power of 2
 
     // To simplify handling of edge cases, we assume that the index space is always a power of 2
-    BB_ASSERT_EQ(coefficients.virtual_size(), 1UL << n);
+    BB_ASSERT_EQ(coefficients.virtual_size(), static_cast<size_t>(1 << n));
 
     // We first fold over dim rounds l = 0,...,dim-1.
     // in round l, n_l is the size of the buffer containing the Polynomial partially evaluated
     // at u₀,..., u_l.
     // In round 0, this is half the size of dim
-    size_t n_l = 1UL << (dim - 1);
+    size_t n_l = 1 << (dim - 1);
 
     // temporary buffer of half the size of the Polynomial
     auto tmp_ptr = _allocate_aligned_memory<Fr_>(n_l);
@@ -514,7 +941,7 @@ Fr_ _evaluate_mle(std::span<const Fr_> evaluation_points,
 
     // partially evaluate the dim-1 remaining points
     for (size_t l = 1; l < dim; ++l) {
-        n_l = 1UL << (dim - l - 1);
+        n_l = 1 << (dim - l - 1);
         u_l = evaluation_points[l];
         for (size_t i = 0; i < n_l; ++i) {
             tmp[i] = tmp[i * 2] + u_l * (tmp[(i * 2) + 1] - tmp[i * 2]);

--- a/barretenberg/cpp/src/barretenberg/polynomials/polynomial.hpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/polynomial.hpp
@@ -615,7 +615,7 @@ template <typename Fr> class Polynomial {
     static Polynomial random(size_t size, size_t start_index = 0)
     {
         BB_BENCH_NAME("generate random polynomial");
-
+        BB_ASSERT_GTE(size, start_index);
         return random(size - start_index, size, start_index);
     }
 
@@ -908,13 +908,13 @@ Fr_ _evaluate_mle(std::span<const Fr_> evaluation_points,
     const size_t dim = numeric::get_msb(coefficients.end_ - 1) + 1; // Round up to next power of 2
 
     // To simplify handling of edge cases, we assume that the index space is always a power of 2
-    BB_ASSERT_EQ(coefficients.virtual_size(), static_cast<size_t>(1 << n));
+    BB_ASSERT_EQ(coefficients.virtual_size(), 1UL << n);
 
     // We first fold over dim rounds l = 0,...,dim-1.
     // in round l, n_l is the size of the buffer containing the Polynomial partially evaluated
     // at u₀,..., u_l.
     // In round 0, this is half the size of dim
-    size_t n_l = 1 << (dim - 1);
+    size_t n_l = 1UL << (dim - 1);
 
     // temporary buffer of half the size of the Polynomial
     auto tmp_ptr = _allocate_aligned_memory<Fr_>(n_l);
@@ -941,7 +941,7 @@ Fr_ _evaluate_mle(std::span<const Fr_> evaluation_points,
 
     // partially evaluate the dim-1 remaining points
     for (size_t l = 1; l < dim; ++l) {
-        n_l = 1 << (dim - l - 1);
+        n_l = 1UL << (dim - l - 1);
         u_l = evaluation_points[l];
         for (size_t i = 0; i < n_l; ++i) {
             tmp[i] = tmp[i * 2] + u_l * (tmp[(i * 2) + 1] - tmp[i * 2]);

--- a/barretenberg/cpp/src/barretenberg/polynomials/polynomial.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/polynomial.test.cpp
@@ -132,6 +132,99 @@ TEST(Polynomial, AddScaledVectorizedMatchesScalar)
     }
 }
 
+// Parity tests for the vectorized operator+=, operator-=, operator*=
+// migrations. Each pairs an in-place operation against an iterated scalar
+// reference over a span whose length is deliberately not a multiple of
+// VECTOR_FIELD_WIDTH=5, so both bulk and tail paths fire.
+TEST(Polynomial, AddAssignVectorizedMatchesScalar)
+{
+    using FF = bb::fr;
+    using Poly = bb::Polynomial<FF>;
+    constexpr size_t SELF_SIZE = 30;
+    constexpr size_t SELF_VSIZE = 32;
+    constexpr size_t SELF_START = 2;
+    constexpr size_t OTHER_SIZE = 13;
+    constexpr size_t OTHER_VSIZE = 32;
+    constexpr size_t OTHER_START = 5;
+
+    Poly self(SELF_SIZE, SELF_VSIZE, SELF_START);
+    Poly other(OTHER_SIZE, OTHER_VSIZE, OTHER_START);
+    for (size_t i = SELF_START; i < SELF_START + SELF_SIZE; ++i) {
+        self.at(i) = FF((i * 11) + 1);
+    }
+    for (size_t i = OTHER_START; i < OTHER_START + OTHER_SIZE; ++i) {
+        other.at(i) = FF((i * 17) + 3);
+    }
+    Poly self_ref = self;
+
+    self += other;
+
+    for (size_t i = OTHER_START; i < OTHER_START + OTHER_SIZE; ++i) {
+        self_ref.at(i) = self_ref.at(i) + other.at(i);
+    }
+    for (size_t i = SELF_START; i < SELF_START + SELF_SIZE; ++i) {
+        EXPECT_EQ(self.at(i), self_ref.at(i)) << "i=" << i;
+    }
+}
+
+TEST(Polynomial, SubtractAssignVectorizedMatchesScalar)
+{
+    using FF = bb::fr;
+    using Poly = bb::Polynomial<FF>;
+    constexpr size_t SELF_SIZE = 30;
+    constexpr size_t SELF_VSIZE = 32;
+    constexpr size_t SELF_START = 2;
+    constexpr size_t OTHER_SIZE = 13;
+    constexpr size_t OTHER_VSIZE = 32;
+    constexpr size_t OTHER_START = 5;
+
+    Poly self(SELF_SIZE, SELF_VSIZE, SELF_START);
+    Poly other(OTHER_SIZE, OTHER_VSIZE, OTHER_START);
+    for (size_t i = SELF_START; i < SELF_START + SELF_SIZE; ++i) {
+        self.at(i) = FF((i * 11) + 1);
+    }
+    for (size_t i = OTHER_START; i < OTHER_START + OTHER_SIZE; ++i) {
+        other.at(i) = FF((i * 17) + 3);
+    }
+    Poly self_ref = self;
+
+    self -= other;
+
+    for (size_t i = OTHER_START; i < OTHER_START + OTHER_SIZE; ++i) {
+        self_ref.at(i) = self_ref.at(i) - other.at(i);
+    }
+    for (size_t i = SELF_START; i < SELF_START + SELF_SIZE; ++i) {
+        EXPECT_EQ(self.at(i), self_ref.at(i)) << "i=" << i;
+    }
+}
+
+TEST(Polynomial, MultiplyAssignVectorizedMatchesScalar)
+{
+    using FF = bb::fr;
+    using Poly = bb::Polynomial<FF>;
+    // 17 elements covers a full 5-wide block plus a non-trivial tail (12 → 2),
+    // and the start offset keeps the buffer's contiguous range unaligned.
+    constexpr size_t SIZE = 17;
+    constexpr size_t VSIZE = 24;
+    constexpr size_t START = 3;
+
+    Poly p(SIZE, VSIZE, START);
+    for (size_t i = START; i < START + SIZE; ++i) {
+        p.at(i) = FF((i * 13) + 5);
+    }
+    Poly p_ref = p;
+    FF scalar = FF(11);
+
+    p *= scalar;
+
+    for (size_t i = START; i < START + SIZE; ++i) {
+        p_ref.at(i) = p_ref.at(i) * scalar;
+    }
+    for (size_t i = START; i < START + SIZE; ++i) {
+        EXPECT_EQ(p.at(i), p_ref.at(i)) << "i=" << i;
+    }
+}
+
 // evaluate_mle on a 0-variable MLE returns the constant coefficient.
 TEST(Polynomial, EvaluateMleSingleCoefficientEmptyPoints)
 {

--- a/barretenberg/cpp/src/barretenberg/polynomials/polynomial.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/polynomial.test.cpp
@@ -96,6 +96,42 @@ TEST(Polynomial, Indices)
     EXPECT_EQ(std::get<1>(*poly.indexed_values().begin()), poly[poly.start_index()]);
 }
 
+TEST(Polynomial, AddScaledVectorizedMatchesScalar)
+{
+    using FF = bb::fr;
+    using Poly = bb::Polynomial<FF>;
+
+    // self: logical indices [2, 32); other: logical indices [5, 18).
+    // Overlap region is other's range [5, 18) — 13 elements, not a multiple
+    // of 5 (exercises both the bulk and the tail of vectorized_for).
+    constexpr size_t SELF_SIZE = 30;
+    constexpr size_t SELF_VSIZE = 32;
+    constexpr size_t SELF_START = 2;
+    constexpr size_t OTHER_SIZE = 13;
+    constexpr size_t OTHER_VSIZE = 32;
+    constexpr size_t OTHER_START = 5;
+
+    Poly self(SELF_SIZE, SELF_VSIZE, SELF_START);
+    Poly other(OTHER_SIZE, OTHER_VSIZE, OTHER_START);
+    for (size_t i = SELF_START; i < SELF_START + SELF_SIZE; ++i) {
+        self.at(i) = FF((i * 11) + 1);
+    }
+    for (size_t i = OTHER_START; i < OTHER_START + OTHER_SIZE; ++i) {
+        other.at(i) = FF((i * 17) + 3);
+    }
+    Poly self_ref = self;
+    FF scalar = FF(7);
+
+    self.add_scaled(other, scalar);
+
+    for (size_t i = OTHER_START; i < OTHER_START + OTHER_SIZE; ++i) {
+        self_ref.at(i) = self_ref.at(i) + scalar * other.at(i);
+    }
+    for (size_t i = SELF_START; i < SELF_START + SELF_SIZE; ++i) {
+        EXPECT_EQ(self.at(i), self_ref.at(i)) << "i=" << i;
+    }
+}
+
 // evaluate_mle on a 0-variable MLE returns the constant coefficient.
 TEST(Polynomial, EvaluateMleSingleCoefficientEmptyPoints)
 {

--- a/barretenberg/cpp/src/barretenberg/polynomials/vectorized_for.hpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/vectorized_for.hpp
@@ -1,0 +1,181 @@
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <type_traits>
+
+namespace bb {
+
+// Forward decl — matches the one in vector_field.hpp. Used by
+// `simd_supported_v` below to gate the SIMD bulk path of vectorized_for.
+class Bn254FrParams;
+
+// Compile-time trait: does VectorField<Fr::Params>::operator* exist on this
+// target? Today only Bn254FrParams has a SIMD Mont-mul body, so any other Fr
+// (e.g. bb::fq = field<Bn254FqParams>, used by ECCVM/Translator polynomials)
+// must take the scalar path even under WASM SIMD, otherwise vectorized_for's
+// bulk emit would instantiate an undefined operator*.
+template <typename Fr> inline constexpr bool simd_supported_v = std::is_same_v<typename Fr::Params, Bn254FrParams>;
+
+// Number of field elements per ContiguousVectorIndex<N> / VectorIndex<N>
+// token, equal to VectorField's q1s1 lane count (4 SIMD lanes + 1 scalar
+// field on the integer pipe). Naming the constant lets call sites be
+// explicit about *why* the literal 5 appears, but it does NOT by itself
+// make the surrounding code width-agnostic — the actual width is baked
+// into:
+//   * VectorField::gather / scatter signatures (std::array<size_t, 5>)
+//   * VectorField's load/store-array helpers (std::array<Field, 5>)
+//   * VectorWriteProxyT::idx in polynomial.hpp
+//   * VectorField's q1s1 Mont-mul kernel itself
+// Changing the value requires touching all of the above; do not assume
+// the templates carry it through transparently. The vectorized_for /
+// vectorized_for_if loop functions and the operator[] dispatch on tokens
+// are the only pieces that are genuinely parameterized on N today.
+inline constexpr size_t VECTOR_FIELD_WIDTH = 5;
+
+struct ScalarIndex {
+    size_t i;
+};
+
+template <size_t N> struct VectorIndex {
+    std::array<size_t, N> idx;
+};
+
+// ContiguousVectorIndex<N> marks an N-wide block of consecutive indices
+// [base, base+N). The bulk path of vectorized_for<N> emits this so kernels
+// can route through Polynomial's contiguous-load overloads, which fuse the
+// N scalar loads into raw SIMD loads of the underlying Fr limb bytes.
+//
+// vectorized_for_if<N> still emits VectorIndex<N> because its lane indices
+// are not consecutive.
+template <size_t N> struct ContiguousVectorIndex {
+    size_t base;
+};
+
+constexpr ScalarIndex shift(ScalarIndex ctx, size_t d)
+{
+    return ScalarIndex{ ctx.i + d };
+}
+
+template <size_t N> constexpr VectorIndex<N> shift(VectorIndex<N> ctx, size_t d)
+{
+    VectorIndex<N> out{};
+    for (size_t k = 0; k < N; ++k) {
+        out.idx[k] = ctx.idx[k] + d;
+    }
+    return out;
+}
+
+template <size_t N> constexpr ContiguousVectorIndex<N> shift(ContiguousVectorIndex<N> ctx, size_t d)
+{
+    return ContiguousVectorIndex<N>{ ctx.base + d };
+}
+
+// Design note (native vs WASM):
+//
+// The point of emitting ContiguousVectorIndex<N> tokens in the bulk is to
+// route the kernel through Polynomial's vector operator[], which on WASM
+// resolves to VectorField's q1s1 SIMD primitives (the win).
+//
+// On native, VectorField has no SIMD — its fallback stores `Field elts[N]`
+// and loops over `elts` scalar-by-scalar inside every operator. The bulk
+// path therefore costs (i) loading N Fr's into the struct, (ii) doing N
+// scalar ops on the struct, (iii) writing N Fr's back. For cheap ops
+// (+, -) this round-trip costs more than the work it saves; we measured a
+// ~13% slowdown on `+=`/`-=` at 2^16 elements vs a plain scalar loop.
+//
+// So on native, we degenerate to plain scalar: every iteration emits a
+// ScalarIndex. The kernel still compiles uniformly (its generic lambda
+// just gets one fewer instantiation on this target). This recovers full
+// scalar-loop performance on native without forcing kernels to grow
+// `if constexpr (is_wasm)` branches at every call site.
+//
+// Perf cliff to be aware of: this only degrades the IMPLICIT path through
+// `vectorized_for<N>`. Direct user code that mints
+// `ContiguousVectorIndex<N>{...}` tokens by hand still hits VectorField's
+// native fallback and pays the round-trip. That's intentional — opting
+// into the SIMD shape explicitly is a "you know what you're doing" signal,
+// and we'd rather keep the abstraction surface honest than silently
+// rewrite explicit token use under the hood.
+template <size_t N, typename Fr, typename K>
+[[gnu::always_inline]] inline void vectorized_for(size_t start, size_t end, K&& kernel)
+{
+#if defined(__wasm_simd128__)
+    if constexpr (simd_supported_v<Fr>) {
+        size_t i = start;
+        // Bulk: emit ContiguousVectorIndex<N> so the kernel routes through the
+        // fast contiguous-load path.
+        //
+        // The kernel call sites are tagged with `[[clang::always_inline]]` as a
+        // statement attribute (clang 12+) so that under -Oz the generic lambda's
+        // `operator()` is inlined into the bulk loop instead of being emitted as
+        // a standalone WASM function and called once per N-wide block. This
+        // keeps the kernel body resident in the caller's TurboFan compilation
+        // unit so V8 can register-allocate the SIMD lanes across blocks.
+        while (i + N <= end) {
+            [[clang::always_inline]] kernel(ContiguousVectorIndex<N>{ i });
+            i += N;
+        }
+        // Tail
+        while (i < end) {
+            [[clang::always_inline]] kernel(ScalarIndex{ i });
+            ++i;
+        }
+    } else {
+        // SIMD not supported for this Fr (e.g. bb::fq under ECCVM/Translator).
+        // Degenerate to scalar so the kernel body never instantiates against
+        // VectorField<NonBn254FrParams>::operator*, which is undefined.
+        for (size_t i = start; i < end; ++i) {
+            [[clang::always_inline]] kernel(ScalarIndex{ i });
+        }
+    }
+#else
+    // Native: plain scalar — see design note above.
+    for (size_t i = start; i < end; ++i) {
+        [[clang::always_inline]] kernel(ScalarIndex{ i });
+    }
+#endif
+}
+
+template <size_t N, typename Fr, typename P, typename K>
+void vectorized_for_if(size_t start, size_t end, P&& predicate, K&& kernel)
+{
+#if defined(__wasm_simd128__)
+    if constexpr (simd_supported_v<Fr>) {
+        VectorIndex<N> buf{};
+        size_t count = 0;
+        for (size_t i = start; i < end; ++i) {
+            if (predicate(i)) {
+                buf.idx[count++] = i;
+                if (count == N) {
+                    kernel(buf);
+                    count = 0;
+                }
+            }
+        }
+        // Drain leftovers scalar-by-scalar
+        for (size_t k = 0; k < count; ++k) {
+            kernel(ScalarIndex{ buf.idx[k] });
+        }
+    } else {
+        // SIMD not supported for this Fr — scalar-only path.
+        for (size_t i = start; i < end; ++i) {
+            if (predicate(i)) {
+                kernel(ScalarIndex{ i });
+            }
+        }
+    }
+#else
+    // Native: plain scalar — see design note on vectorized_for above.
+    // Same reasoning applies: VectorIndex<N> on native routes through
+    // VectorField::gather, which is a struct-round-trip wrapper around N
+    // scalar reads.
+    for (size_t i = start; i < end; ++i) {
+        if (predicate(i)) {
+            kernel(ScalarIndex{ i });
+        }
+    }
+#endif
+}
+
+} // namespace bb

--- a/barretenberg/cpp/src/barretenberg/polynomials/vectorized_for.hpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/vectorized_for.hpp
@@ -1,21 +1,20 @@
 #pragma once
 
+#include "barretenberg/ecc/fields/vector_field.hpp"
+
 #include <array>
 #include <cstddef>
 #include <type_traits>
 
 namespace bb {
 
-// Forward decl — matches the one in vector_field.hpp. Used by
-// `simd_supported_v` below to gate the SIMD bulk path of vectorized_for.
-class Bn254FrParams;
-
-// Compile-time trait: does VectorField<Fr::Params>::operator* exist on this
-// target? Today only Bn254FrParams has a SIMD Mont-mul body, so any other Fr
-// (e.g. bb::fq = field<Bn254FqParams>, used by ECCVM/Translator polynomials)
-// must take the scalar path even under WASM SIMD, otherwise vectorized_for's
-// bulk emit would instantiate an undefined operator*.
-template <typename Fr> inline constexpr bool simd_supported_v = std::is_same_v<typename Fr::Params, Bn254FrParams>;
+// Compile-time trait: does VectorField<Fr::Params> have a SIMD operator*
+// body on this target? Delegates to `has_simd_mont_mul_v`, which is
+// specialized in vector_field.hpp next to each operator* declaration.
+// Adding a new Params with a SIMD body widens this trait automatically —
+// no edits needed here. Fr's without a body (e.g. stdlib::field_t today)
+// take the scalar path even under WASM SIMD.
+template <typename Fr> inline constexpr bool simd_supported_v = has_simd_mont_mul_v<typename Fr::Params>;
 
 // Number of field elements per ContiguousVectorIndex<N> / VectorIndex<N>
 // token, equal to VectorField's q1s1 lane count (4 SIMD lanes + 1 scalar

--- a/barretenberg/cpp/src/barretenberg/polynomials/vectorized_for.hpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/vectorized_for.hpp
@@ -137,6 +137,18 @@ template <size_t N, typename Fr, typename K>
 #endif
 }
 
+// Sparse variant of vectorized_for. Walks [start, end), invokes `predicate(i)` for each i,
+// and gathers indices that pass into a VectorIndex<N> buffer; once full, dispatches one
+// kernel call with the gather token. Leftover indices at the end run scalar-by-scalar.
+//
+// Same V8/TurboFan perf cliff applies as in vectorized_for above: both the predicate lambda
+// and the kernel lambda need to inline through this template. The bulk call site is tagged
+// here only for the kernel — the predicate body should be inline-friendly by construction
+// (a small function-of-i, not a polymorphic dispatcher).
+//
+// VectorIndex<N> routes through VectorField::gather (random-access scalar reads), so the
+// per-bulk savings come from amortizing kernel call overhead, not from contiguous-SIMD
+// loads. For dense ranges where every i passes the predicate, prefer vectorized_for.
 template <size_t N, typename Fr, typename P, typename K>
 void vectorized_for_if(size_t start, size_t end, P&& predicate, K&& kernel)
 {

--- a/barretenberg/cpp/src/barretenberg/polynomials/vectorized_for.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/vectorized_for.test.cpp
@@ -1,0 +1,329 @@
+#include "barretenberg/polynomials/vectorized_for.hpp"
+
+#include "barretenberg/ecc/curves/bn254/fr.hpp"
+#include "barretenberg/ecc/fields/vector_field.hpp"
+#include "barretenberg/polynomials/polynomial.hpp"
+
+#include <gtest/gtest.h>
+#include <vector>
+
+namespace {
+
+using bb::ContiguousVectorIndex;
+using bb::ScalarIndex;
+using bb::shift;
+using bb::VECTOR_FIELD_WIDTH;
+using bb::VectorIndex;
+using bb::vectorized_for;
+using bb::vectorized_for_if;
+using Fr = bb::fr;
+using Vec = bb::VectorField<bb::Bn254FrParams>;
+using Poly = bb::Polynomial<Fr>;
+
+TEST(VectorizedForTest, ScalarIndexShift)
+{
+    EXPECT_EQ(shift(ScalarIndex{ 7 }, 3).i, 10u);
+}
+
+TEST(VectorizedForTest, VectorIndexShift)
+{
+    auto out = shift(VectorIndex<5>{ { 0, 1, 2, 3, 4 } }, 10);
+    std::array<size_t, 5> expected{ 10, 11, 12, 13, 14 };
+    for (size_t k = 0; k < 5; ++k) {
+        EXPECT_EQ(out.idx[k], expected[k]) << "lane " << k;
+    }
+}
+
+TEST(VectorizedForTest, ConstexprShift)
+{
+    static_assert(shift(ScalarIndex{ 1 }, 2).i == 3);
+    static_assert(shift(VectorIndex<3>{ { 1, 2, 3 } }, 5).idx[2] == 8);
+    SUCCEED();
+}
+
+TEST(VectorizedFor, ContiguousVectorIndexShift)
+{
+    EXPECT_EQ(shift(ContiguousVectorIndex<5>{ 7 }, 3).base, 10u);
+}
+
+TEST(VectorizedForTest, PolynomialScalarReadWrite)
+{
+    Poly p(8);
+    std::array<Fr, 8> known;
+    for (size_t i = 0; i < 8; ++i) {
+        known[i] = Fr::random_element();
+        p.at(i) = known[i];
+    }
+
+    // Read via ScalarIndex on a mutable Polynomial: the proxy implicitly
+    // converts to Fr.
+    Fr r = p[ScalarIndex{ 3 }];
+    EXPECT_EQ(r, known[3]);
+
+    // Write via ScalarIndex.
+    Fr v = Fr(42);
+    p[ScalarIndex{ 5 }] = v;
+    EXPECT_EQ(p[5], v);
+}
+
+TEST(VectorizedForTest, PolynomialVectorReadRoundTrip)
+{
+    Poly p(16);
+    for (size_t i = 0; i < 16; ++i) {
+        p.at(i) = Fr::random_element();
+    }
+
+    std::array<size_t, 5> idx{ 3, 0, 7, 15, 9 };
+    // Read via VectorIndex on a mutable Polynomial: the proxy implicitly
+    // converts to VectorField.
+    Vec v = p[VectorIndex<5>{ idx }];
+    for (size_t L = 0; L < 5; ++L) {
+        EXPECT_EQ(v.get(L), p[idx[L]]) << "lane " << L;
+    }
+}
+
+TEST(VectorizedForTest, PolynomialVectorWrite)
+{
+    Poly p(16); // Zero-initialized by the (size_t) ctor.
+
+    std::array<Fr, 5> vals{
+        Fr::random_element(), Fr::random_element(), Fr::random_element(), Fr::random_element(), Fr::random_element()
+    };
+    Vec v(vals);
+
+    std::array<size_t, 5> idx{ 2, 5, 1, 8, 0 };
+    p[VectorIndex<5>{ idx }] = v;
+
+    // Target positions match.
+    for (size_t L = 0; L < 5; ++L) {
+        EXPECT_EQ(p[idx[L]], vals[L]) << "lane " << L;
+    }
+
+    // Untouched positions remain zero.
+    for (size_t i = 0; i < 16; ++i) {
+        bool is_target = false;
+        for (size_t L = 0; L < 5; ++L) {
+            if (idx[L] == i) {
+                is_target = true;
+                break;
+            }
+        }
+        if (!is_target) {
+            EXPECT_TRUE(p[i].is_zero()) << "position " << i;
+        }
+    }
+}
+
+TEST(VectorizedForTest, VectorizedForPointwiseMulExact)
+{
+    constexpr size_t SIZE = 20;
+    Poly a(SIZE), b(SIZE), out(SIZE);
+    for (size_t i = 0; i < SIZE; ++i) {
+        a.at(i) = Fr(i * 7 + 3);
+        b.at(i) = Fr(i * 11 + 5);
+    }
+
+    vectorized_for<VECTOR_FIELD_WIDTH>(0, SIZE, [&](auto ctx) { out[ctx] = a[ctx] * b[ctx]; });
+
+    for (size_t i = 0; i < SIZE; ++i) {
+        Fr ref = a[i] * b[i];
+        EXPECT_EQ(out[i], ref) << "i=" << i;
+    }
+}
+
+TEST(VectorizedForTest, VectorizedForTailExercised)
+{
+    constexpr size_t SIZE = 23;
+    Poly a(SIZE), b(SIZE), out(SIZE);
+    for (size_t i = 0; i < SIZE; ++i) {
+        a.at(i) = Fr(i * 7 + 3);
+        b.at(i) = Fr(i * 11 + 5);
+    }
+
+    vectorized_for<VECTOR_FIELD_WIDTH>(0, SIZE, [&](auto ctx) { out[ctx] = a[ctx] * b[ctx]; });
+
+    for (size_t i = 0; i < SIZE; ++i) {
+        Fr ref = a[i] * b[i];
+        EXPECT_EQ(out[i], ref) << "i=" << i;
+    }
+}
+
+TEST(VectorizedForTest, VectorizedForNonZeroStart)
+{
+    constexpr size_t SIZE = 16;
+    Poly a(SIZE), out(SIZE); // out zero-initialized.
+    for (size_t i = 0; i < SIZE; ++i) {
+        a.at(i) = Fr(i * 13 + 1);
+    }
+
+    vectorized_for<VECTOR_FIELD_WIDTH>(3, 14, [&](auto ctx) { out[ctx] = a[ctx] + a[ctx]; });
+
+    for (size_t i = 0; i < 3; ++i) {
+        EXPECT_TRUE(out[i].is_zero()) << "i=" << i;
+    }
+    for (size_t i = 3; i < 14; ++i) {
+        Fr ref = a[i] + a[i];
+        EXPECT_EQ(out[i], ref) << "i=" << i;
+    }
+    for (size_t i = 14; i < SIZE; ++i) {
+        EXPECT_TRUE(out[i].is_zero()) << "i=" << i;
+    }
+}
+
+TEST(VectorizedForTest, VectorizedForEmptyRange)
+{
+    size_t counter = 0;
+    vectorized_for<VECTOR_FIELD_WIDTH>(5, 5, [&](auto) { ++counter; });
+    EXPECT_EQ(counter, 0u);
+
+    counter = 0;
+    vectorized_for<VECTOR_FIELD_WIDTH>(5, 7, [&](auto) { ++counter; });
+    EXPECT_EQ(counter, 2u);
+}
+
+TEST(VectorizedForTest, VectorizedForSelfReadMutable)
+{
+    constexpr size_t SIZE = 20;
+    Poly p(SIZE);
+    std::array<Fr, SIZE> original;
+    for (size_t i = 0; i < SIZE; ++i) {
+        original[i] = Fr(i * 7 + 3);
+        p.at(i) = original[i];
+    }
+
+    vectorized_for<VECTOR_FIELD_WIDTH>(0, SIZE, [&](auto ctx) { p[ctx] = p[ctx] + p[ctx]; });
+
+    for (size_t i = 0; i < SIZE; ++i) {
+        Fr ref = original[i] + original[i];
+        EXPECT_EQ(p[i], ref) << "i=" << i;
+    }
+}
+
+TEST(VectorizedForTest, VectorizedForSelfReadMutableTail)
+{
+    constexpr size_t SIZE = 23;
+    Poly p(SIZE);
+    std::array<Fr, SIZE> original;
+    for (size_t i = 0; i < SIZE; ++i) {
+        original[i] = Fr(i * 7 + 3);
+        p.at(i) = original[i];
+    }
+
+    vectorized_for<VECTOR_FIELD_WIDTH>(0, SIZE, [&](auto ctx) { p[ctx] = p[ctx] + p[ctx]; });
+
+    for (size_t i = 0; i < SIZE; ++i) {
+        Fr ref = original[i] + original[i];
+        EXPECT_EQ(p[i], ref) << "i=" << i;
+    }
+}
+
+TEST(VectorizedForTest, MixedKernelSelfPlusOther)
+{
+    constexpr size_t SIZE = 20;
+    Poly self(SIZE), other(SIZE);
+    std::array<Fr, SIZE> self_orig, other_vals;
+    for (size_t i = 0; i < SIZE; ++i) {
+        self_orig[i] = Fr(i * 13 + 1);
+        other_vals[i] = Fr(i * 17 + 2);
+        self.at(i) = self_orig[i];
+        other.at(i) = other_vals[i];
+    }
+    Fr scalar = Fr(7);
+
+    vectorized_for<VECTOR_FIELD_WIDTH>(0, SIZE, [&](auto ctx) { self[ctx] = self[ctx] + other[ctx] * scalar; });
+
+    for (size_t i = 0; i < SIZE; ++i) {
+        Fr ref = self_orig[i] + other_vals[i] * scalar;
+        EXPECT_EQ(self[i], ref) << "i=" << i;
+    }
+}
+
+TEST(VectorizedForTest, VectorizedForIfEvenIndices)
+{
+    constexpr size_t SIZE = 32;
+    Poly p(SIZE);
+    for (size_t i = 0; i < SIZE; ++i) {
+        p.at(i) = Fr(i);
+    }
+
+    vectorized_for_if<VECTOR_FIELD_WIDTH>(
+        0, SIZE, [](size_t i) { return (i % 2) == 0; }, [&](auto ctx) { p[ctx] = p[ctx] + p[ctx]; });
+
+    for (size_t i = 0; i < SIZE; ++i) {
+        if (i % 2 == 0) {
+            EXPECT_EQ(p[i], Fr(2 * i)) << "i=" << i;
+        } else {
+            EXPECT_EQ(p[i], Fr(i)) << "i=" << i;
+        }
+    }
+}
+
+TEST(VectorizedForTest, VectorizedForIfAllMatch)
+{
+    constexpr size_t SIZE = 25;
+    Poly p(SIZE);
+    std::array<Fr, SIZE> original;
+    for (size_t i = 0; i < SIZE; ++i) {
+        original[i] = Fr(i * 3 + 1);
+        p.at(i) = original[i];
+    }
+
+    vectorized_for_if<VECTOR_FIELD_WIDTH>(
+        0, SIZE, [](size_t) { return true; }, [&](auto ctx) { p[ctx] = p[ctx] + p[ctx]; });
+
+    for (size_t i = 0; i < SIZE; ++i) {
+        EXPECT_EQ(p[i], original[i] + original[i]) << "i=" << i;
+    }
+}
+
+TEST(VectorizedForTest, VectorizedForIfNoneMatch)
+{
+    size_t counter = 0;
+    vectorized_for_if<VECTOR_FIELD_WIDTH>(0, 20, [](size_t) { return false; }, [&](auto) { ++counter; });
+    EXPECT_EQ(counter, 0u);
+}
+
+TEST(VectorizedForTest, VectorizedForIfTailOnly)
+{
+    constexpr size_t SIZE = 10;
+    Poly p(SIZE);
+    std::array<Fr, SIZE> original;
+    for (size_t i = 0; i < SIZE; ++i) {
+        original[i] = Fr(i * 11 + 7);
+        p.at(i) = original[i];
+    }
+
+    auto pred = [](size_t i) { return i == 1 || i == 4 || i == 7; };
+    size_t kernel_calls = 0;
+    vectorized_for_if<VECTOR_FIELD_WIDTH>(0, SIZE, pred, [&](auto ctx) {
+        ++kernel_calls;
+        p[ctx] = p[ctx] + p[ctx];
+    });
+
+    EXPECT_EQ(kernel_calls, 3u);
+    for (size_t i = 0; i < SIZE; ++i) {
+        if (pred(i)) {
+            EXPECT_EQ(p[i], original[i] + original[i]) << "i=" << i;
+        } else {
+            EXPECT_EQ(p[i], original[i]) << "i=" << i;
+        }
+    }
+}
+
+TEST(VectorizedForTest, VectorizedForIfPredicateCallOrder)
+{
+    std::vector<size_t> log;
+    vectorized_for_if<VECTOR_FIELD_WIDTH>(
+        5,
+        17,
+        [&](size_t i) {
+            log.push_back(i);
+            return false;
+        },
+        [&](auto) { /* never invoked */ });
+
+    std::vector<size_t> expected{ 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 };
+    EXPECT_EQ(log, expected);
+}
+
+} // namespace

--- a/barretenberg/cpp/src/barretenberg/polynomials/vectorized_for.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/vectorized_for.test.cpp
@@ -123,7 +123,7 @@ TEST(VectorizedForTest, VectorizedForPointwiseMulExact)
         b.at(i) = Fr(i * 11 + 5);
     }
 
-    vectorized_for<VECTOR_FIELD_WIDTH>(0, SIZE, [&](auto ctx) { out[ctx] = a[ctx] * b[ctx]; });
+    vectorized_for<VECTOR_FIELD_WIDTH, Fr>(0, SIZE, [&](auto ctx) { out[ctx] = a[ctx] * b[ctx]; });
 
     for (size_t i = 0; i < SIZE; ++i) {
         Fr ref = a[i] * b[i];
@@ -140,7 +140,7 @@ TEST(VectorizedForTest, VectorizedForTailExercised)
         b.at(i) = Fr(i * 11 + 5);
     }
 
-    vectorized_for<VECTOR_FIELD_WIDTH>(0, SIZE, [&](auto ctx) { out[ctx] = a[ctx] * b[ctx]; });
+    vectorized_for<VECTOR_FIELD_WIDTH, Fr>(0, SIZE, [&](auto ctx) { out[ctx] = a[ctx] * b[ctx]; });
 
     for (size_t i = 0; i < SIZE; ++i) {
         Fr ref = a[i] * b[i];
@@ -156,7 +156,7 @@ TEST(VectorizedForTest, VectorizedForNonZeroStart)
         a.at(i) = Fr(i * 13 + 1);
     }
 
-    vectorized_for<VECTOR_FIELD_WIDTH>(3, 14, [&](auto ctx) { out[ctx] = a[ctx] + a[ctx]; });
+    vectorized_for<VECTOR_FIELD_WIDTH, Fr>(3, 14, [&](auto ctx) { out[ctx] = a[ctx] + a[ctx]; });
 
     for (size_t i = 0; i < 3; ++i) {
         EXPECT_TRUE(out[i].is_zero()) << "i=" << i;
@@ -173,11 +173,11 @@ TEST(VectorizedForTest, VectorizedForNonZeroStart)
 TEST(VectorizedForTest, VectorizedForEmptyRange)
 {
     size_t counter = 0;
-    vectorized_for<VECTOR_FIELD_WIDTH>(5, 5, [&](auto) { ++counter; });
+    vectorized_for<VECTOR_FIELD_WIDTH, Fr>(5, 5, [&](auto) { ++counter; });
     EXPECT_EQ(counter, 0u);
 
     counter = 0;
-    vectorized_for<VECTOR_FIELD_WIDTH>(5, 7, [&](auto) { ++counter; });
+    vectorized_for<VECTOR_FIELD_WIDTH, Fr>(5, 7, [&](auto) { ++counter; });
     EXPECT_EQ(counter, 2u);
 }
 
@@ -191,7 +191,7 @@ TEST(VectorizedForTest, VectorizedForSelfReadMutable)
         p.at(i) = original[i];
     }
 
-    vectorized_for<VECTOR_FIELD_WIDTH>(0, SIZE, [&](auto ctx) { p[ctx] = p[ctx] + p[ctx]; });
+    vectorized_for<VECTOR_FIELD_WIDTH, Fr>(0, SIZE, [&](auto ctx) { p[ctx] = p[ctx] + p[ctx]; });
 
     for (size_t i = 0; i < SIZE; ++i) {
         Fr ref = original[i] + original[i];
@@ -209,7 +209,7 @@ TEST(VectorizedForTest, VectorizedForSelfReadMutableTail)
         p.at(i) = original[i];
     }
 
-    vectorized_for<VECTOR_FIELD_WIDTH>(0, SIZE, [&](auto ctx) { p[ctx] = p[ctx] + p[ctx]; });
+    vectorized_for<VECTOR_FIELD_WIDTH, Fr>(0, SIZE, [&](auto ctx) { p[ctx] = p[ctx] + p[ctx]; });
 
     for (size_t i = 0; i < SIZE; ++i) {
         Fr ref = original[i] + original[i];
@@ -230,7 +230,7 @@ TEST(VectorizedForTest, MixedKernelSelfPlusOther)
     }
     Fr scalar = Fr(7);
 
-    vectorized_for<VECTOR_FIELD_WIDTH>(0, SIZE, [&](auto ctx) { self[ctx] = self[ctx] + other[ctx] * scalar; });
+    vectorized_for<VECTOR_FIELD_WIDTH, Fr>(0, SIZE, [&](auto ctx) { self[ctx] = self[ctx] + other[ctx] * scalar; });
 
     for (size_t i = 0; i < SIZE; ++i) {
         Fr ref = self_orig[i] + other_vals[i] * scalar;
@@ -246,7 +246,7 @@ TEST(VectorizedForTest, VectorizedForIfEvenIndices)
         p.at(i) = Fr(i);
     }
 
-    vectorized_for_if<VECTOR_FIELD_WIDTH>(
+    vectorized_for_if<VECTOR_FIELD_WIDTH, Fr>(
         0, SIZE, [](size_t i) { return (i % 2) == 0; }, [&](auto ctx) { p[ctx] = p[ctx] + p[ctx]; });
 
     for (size_t i = 0; i < SIZE; ++i) {
@@ -268,7 +268,7 @@ TEST(VectorizedForTest, VectorizedForIfAllMatch)
         p.at(i) = original[i];
     }
 
-    vectorized_for_if<VECTOR_FIELD_WIDTH>(
+    vectorized_for_if<VECTOR_FIELD_WIDTH, Fr>(
         0, SIZE, [](size_t) { return true; }, [&](auto ctx) { p[ctx] = p[ctx] + p[ctx]; });
 
     for (size_t i = 0; i < SIZE; ++i) {
@@ -279,7 +279,7 @@ TEST(VectorizedForTest, VectorizedForIfAllMatch)
 TEST(VectorizedForTest, VectorizedForIfNoneMatch)
 {
     size_t counter = 0;
-    vectorized_for_if<VECTOR_FIELD_WIDTH>(0, 20, [](size_t) { return false; }, [&](auto) { ++counter; });
+    vectorized_for_if<VECTOR_FIELD_WIDTH, Fr>(0, 20, [](size_t) { return false; }, [&](auto) { ++counter; });
     EXPECT_EQ(counter, 0u);
 }
 
@@ -295,7 +295,7 @@ TEST(VectorizedForTest, VectorizedForIfTailOnly)
 
     auto pred = [](size_t i) { return i == 1 || i == 4 || i == 7; };
     size_t kernel_calls = 0;
-    vectorized_for_if<VECTOR_FIELD_WIDTH>(0, SIZE, pred, [&](auto ctx) {
+    vectorized_for_if<VECTOR_FIELD_WIDTH, Fr>(0, SIZE, pred, [&](auto ctx) {
         ++kernel_calls;
         p[ctx] = p[ctx] + p[ctx];
     });
@@ -313,7 +313,7 @@ TEST(VectorizedForTest, VectorizedForIfTailOnly)
 TEST(VectorizedForTest, VectorizedForIfPredicateCallOrder)
 {
     std::vector<size_t> log;
-    vectorized_for_if<VECTOR_FIELD_WIDTH>(
+    vectorized_for_if<VECTOR_FIELD_WIDTH, Fr>(
         5,
         17,
         [&](size_t i) {


### PR DESCRIPTION
**Goal.** Expose VectorField's SIMD primitives to algorithm kernels. Migrate the obvious Polynomial consumers: `add_scaled`, `operator+=`, `operator-=`, `operator*=`.

**Non-goal.** Reduction-shaped kernels. The Accumulator counterpart lives in #23210.

## The abstraction

- **`vectorized_for<N>(start, end, kernel)`** — bulk + scalar-tail loop. On WASM (BN254 Fr/Fq) the bulk emits `ContiguousVectorIndex<N>` tokens; on native or non-supported Fr, degenerates to `ScalarIndex` per element (`VectorField`'s native fallback is a struct round-trip that loses ~13% on `+=`/`-=` at 2^16 vs a plain scalar loop, so the degenerate path keeps kernels target-agnostic without imposing that cost).
- **Token-dispatched `operator[]`** on `Polynomial` / `PolynomialSpan` — bridges tokens to VectorField (gather/scatter for sparse, linear-memory ctor / `store_to` for contiguous, plus write proxies on the mutable side).
- **`Broadcast<Fr>`** — exposes a scalar through the same `operator[]` protocol, so kernels can write `self[ctx] = self[ctx] + other[ctx] * scaling[ctx]` uniformly across bulk and tail without an `if constexpr` branch on token type.

## Non-trivial example

This is the actual migrated `Polynomial::add_scaled_chunk`:

```cpp
const Broadcast<Fr> scaling(scaling_factor);
vectorized_for<VECTOR_FIELD_WIDTH, Fr>(lo, hi, [&](auto ctx) {
    (*this)[ctx] = (*this)[ctx] + other[ctx] * scaling[ctx];
});
```

The same kernel body covers three execution paths the compiler picks via the `auto ctx` type:

| Path | `ctx` token | What `(*this)[ctx]` resolves to | Per-iter work |
|---|---|---|---|
| WASM bulk | `ContiguousVectorIndex<5>` | linear-memory `VectorField` load + `store_to` write-proxy | one VF mul + one VF add over 5 lanes |
| WASM tail | `ScalarIndex` | `Fr&` reference via scalar proxy | one scalar Mont-mul + one scalar add |
| Native | `ScalarIndex` | (same) | scalar — VF's native fallback is a struct round-trip; degenerating avoids paying it |

`Broadcast<Fr>::operator[](ContiguousVectorIndex<5>)` returns `VectorField::broadcast(scaling_factor)`, so the bulk `other[ctx] * scaling[ctx]` is a real vec×vec mul; `operator[](ScalarIndex)` returns the scalar itself for the tail.

## Write-proxy operator wall

Both vector proxies (`VectorWriteProxyT`, `ContiguousVectorWriteProxyT`) need a 15-op hidden-friend wall (proxy×proxy, proxy×Value+reversed, proxy×Scalar+reversed) so kernel expressions resolve every operand combination via ADL. One macro `BB_VECTOR_PROXY_BINARY_OPS(Proxy, Value, Scalar)` stamps both. All ops marked `[[gnu::always_inline]]` — under -Oz V8 leaves un-marked proxy ops as standalone WASM functions, defeating the linear-memory primitives and adding ~0.7ms per 65k-field pass.

## SIMD gate

`simd_supported_v<Fr>` routes through `has_simd_mont_mul<Params>` (defined in #23202). PR2 marks `Bn254FrParams`; #23353 adds `Bn254FqParams`. Other Fr (e.g. `stdlib::field_t`) silently take the scalar path.

## Consumer migrations

- `Polynomial::add_scaled` — `vectorized_for<VECTOR_FIELD_WIDTH>` + `Broadcast<Fr>`. Definition inlined into the header so V8 inlines across the TU boundary (a `polynomial.cpp` body introduced a real WASM function-call boundary V8 was not eliding, and gave away the kernel-level parity).
- `Polynomial::operator+=` / `-=` / `*=` — same shape via `add_chunk` / `subtract_chunk` / `multiply_chunk`.

## Benches

- `add_scaled.bench.cpp` — diagnostic suite (scalar, vectorized, raw ceiling, transpose-only, load-only, ...). Startup `CorrectnessGuard` runs production `add_scaled` against a scalar reference on 65k random fr's.
- `poly_inplace_arith.bench.cpp` — same shape for the three migrated in-place ops, with matching `CorrectnessGuard`.

## Tests

- `AddScaledVectorizedMatchesScalar` — `add_scaled` vs scalar reference over a span whose length is not a multiple of `VECTOR_FIELD_WIDTH` (exercises bulk + tail).
- `AddAssignVectorizedMatchesScalar`, `SubtractAssignVectorizedMatchesScalar`, `MultiplyAssignVectorizedMatchesScalar` — same shape for the in-place operators.

## WASM evidence (N=2^16, V8/Zen3, from bc/ origin branch — file states bit-identical)

- `add_scaled` vectorized matches `vector_field_raw` ceiling within noise → 0× abstraction tax.
- operator+=/-=/*=: WASM SIMD path plumbed end-to-end. Op-count diff (same bench binary, scalar vs vectorized): `extmul_low/high_i32x4` 0/0 → 146/146; `i64x2.add` / `v128.and` 0/0 → 306/245.

## Stack

Depends on #23202. #23210 depends on this.