### PR TITLE
feat(polynomials): Accumulator<Fr> + vectorize compute_sum

### DIFF
--- a/barretenberg/cpp/src/barretenberg/polynomials/accumulator.hpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/accumulator.hpp
@@ -1,0 +1,67 @@
+#pragma once
+
+#include "barretenberg/ecc/fields/vector_field.hpp"
+#include "barretenberg/polynomials/vectorized_for.hpp"
+
+#include <array>
+#include <cstddef>
+
+namespace bb {
+
+// Per-token reduction accumulator for use inside `vectorized_for<N>` kernels.
+//
+// Pairs with Polynomial / PolynomialSpan's token-dispatched operator[] to
+// keep the kernel body uniform across the bulk and tail paths. The bulk
+// (ContiguousVectorIndex<N>) contributions land in a VectorField slot,
+// summing lane-wise; the tail (ScalarIndex) contributions land in a scalar
+// Fr slot. `reduce()` horizontal-adds the N lanes together with the scalar
+// to give the final result.
+//
+// Canonical kernel shape:
+//
+//     Accumulator<Fr> acc;
+//     vectorized_for<VECTOR_FIELD_WIDTH>(0, n, [&](auto ctx) {
+//         acc += view[ctx];                       // dot, sum, …
+//     });
+//     Fr result = acc.reduce();
+//
+// Both forms — `scalar_acc` and `vector_acc` — are materialised in the
+// constructor so the loop never branches on the token type to pick an
+// accumulator. The compile-time branch lives at the operator+= overload
+// set: ScalarIndex iterations hit operator+=(const Fr&), bulk iterations
+// hit operator+=(const Vec&).
+//
+// Reduction order is implementation-defined: lanes are summed in lane
+// order (L=0,1,2,3,4) then added to the scalar slot. For finite field
+// addition this is associative and commutative so the result is bit-
+// identical regardless, but callers that care about specific summation
+// order for floats / Kahan-style work should not use this.
+template <typename Fr> struct Accumulator {
+    using Vec = VectorField<typename Fr::Params>;
+
+    Fr scalar_acc;
+    Vec vector_acc;
+
+    Accumulator()
+        : scalar_acc(0)
+        , vector_acc(Vec::broadcast(Fr(0)))
+    {}
+
+    [[gnu::always_inline]] void operator+=(const Fr& v) { scalar_acc = scalar_acc + v; }
+
+    [[gnu::always_inline]] void operator+=(const Vec& v) { vector_acc = vector_acc + v; }
+
+    // Horizontal reduce: sum all lanes of vector_acc and the scalar slot
+    // into a single Fr.
+    Fr reduce() const
+    {
+        const std::array<Fr, VECTOR_FIELD_WIDTH> lanes = vector_acc.to_array();
+        Fr total = scalar_acc;
+        for (size_t L = 0; L < VECTOR_FIELD_WIDTH; ++L) {
+            total = total + lanes[L];
+        }
+        return total;
+    }
+};
+
+} // namespace bb

--- a/barretenberg/cpp/src/barretenberg/polynomials/accumulator.hpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/accumulator.hpp
@@ -52,15 +52,16 @@ template <typename Fr> struct Accumulator {
     [[gnu::always_inline]] void operator+=(const Vec& v) { vector_acc = vector_acc + v; }
 
     // Horizontal reduce: sum all lanes of vector_acc and the scalar slot
-    // into a single Fr.
+    // into a single Fr. Tree-shaped (depth 3 for 6 inputs) so a chain of
+    // five serial Fr-adds does not sit on the critical path.
     Fr reduce() const
     {
+        static_assert(VECTOR_FIELD_WIDTH == 5, "Accumulator::reduce tree assumes width 5");
         const std::array<Fr, VECTOR_FIELD_WIDTH> lanes = vector_acc.to_array();
-        Fr total = scalar_acc;
-        for (size_t L = 0; L < VECTOR_FIELD_WIDTH; ++L) {
-            total = total + lanes[L];
-        }
-        return total;
+        const Fr s01 = lanes[0] + lanes[1];
+        const Fr s23 = lanes[2] + lanes[3];
+        const Fr s4s = lanes[4] + scalar_acc;
+        return (s01 + s23) + s4s;
     }
 };
 

--- a/barretenberg/cpp/src/barretenberg/polynomials/accumulator.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/accumulator.test.cpp
@@ -1,0 +1,92 @@
+#include "barretenberg/polynomials/accumulator.hpp"
+
+#include "barretenberg/ecc/curves/bn254/fr.hpp"
+#include "barretenberg/numeric/random/engine.hpp"
+
+#include <gtest/gtest.h>
+
+namespace {
+
+using Fr = bb::fr;
+using Acc = bb::Accumulator<Fr>;
+using Vec = bb::VectorField<bb::Bn254FrParams>;
+
+TEST(AccumulatorTest, DefaultConstructorReducesToZero)
+{
+    Acc acc;
+    EXPECT_TRUE(acc.reduce().is_zero());
+}
+
+TEST(AccumulatorTest, ScalarOnlyAddsMatchSerialSum)
+{
+    Acc acc;
+    std::array<Fr, 7> xs;
+    for (auto& x : xs) {
+        x = Fr::random_element();
+    }
+    Fr expected = Fr::zero();
+    for (const auto& x : xs) {
+        acc += x;
+        expected = expected + x;
+    }
+    EXPECT_EQ(acc.reduce(), expected);
+}
+
+TEST(AccumulatorTest, VectorOnlyAddsMatchSerialSum)
+{
+    Acc acc;
+    // Three width-5 lane contributions; total = 15 random Fr's summed.
+    std::array<Fr, 15> xs;
+    for (auto& x : xs) {
+        x = Fr::random_element();
+    }
+    for (size_t group = 0; group < 3; ++group) {
+        std::array<Fr, 5> lanes{
+            xs[5 * group + 0], xs[5 * group + 1], xs[5 * group + 2], xs[5 * group + 3], xs[5 * group + 4]
+        };
+        acc += Vec(lanes);
+    }
+    Fr expected = Fr::zero();
+    for (const auto& x : xs) {
+        expected = expected + x;
+    }
+    EXPECT_EQ(acc.reduce(), expected);
+}
+
+TEST(AccumulatorTest, MixedScalarAndVectorAdds)
+{
+    // Two width-5 lane blocks + a 3-element scalar tail — the canonical
+    // bulk + tail shape produced by vectorized_for inside a kernel.
+    Acc acc;
+    std::array<Fr, 13> xs;
+    for (auto& x : xs) {
+        x = Fr::random_element();
+    }
+    acc += Vec(std::array<Fr, 5>{ xs[0], xs[1], xs[2], xs[3], xs[4] });
+    acc += Vec(std::array<Fr, 5>{ xs[5], xs[6], xs[7], xs[8], xs[9] });
+    acc += xs[10];
+    acc += xs[11];
+    acc += xs[12];
+
+    Fr expected = Fr::zero();
+    for (const auto& x : xs) {
+        expected = expected + x;
+    }
+    EXPECT_EQ(acc.reduce(), expected);
+}
+
+TEST(AccumulatorTest, ReduceOrderInvariantOverLanePermutation)
+{
+    // Field addition is associative + commutative, so reduce()'s tree-shape
+    // is order-invariant. Verifies the implementation doesn't accidentally
+    // depend on a specific summation order.
+    std::array<Fr, 5> lanes_a = { Fr(11), Fr(22), Fr(33), Fr(44), Fr(55) };
+    std::array<Fr, 5> lanes_b = { Fr(55), Fr(44), Fr(33), Fr(22), Fr(11) };
+    Acc a;
+    a += Vec(lanes_a);
+    Acc b;
+    b += Vec(lanes_b);
+    EXPECT_EQ(a.reduce(), b.reduce());
+}
+
+} // namespace

--- a/barretenberg/cpp/src/barretenberg/polynomials/compute_sum.bench.cpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/compute_sum.bench.cpp
@@ -1,0 +1,82 @@
+// Diagnostic benchmark for polynomial_arithmetic::compute_sum (reduction
+// over a contiguous Fr array). Two variants, same inputs:
+//
+//   compute_sum_scalar — raw scalar for-loop accumulator. No vectorized_for,
+//                         no Accumulator. Single-thread.
+//   compute_sum_full   — polynomial_arithmetic::compute_sum, which routes
+//                         through vectorized_for<VECTOR_FIELD_WIDTH> +
+//                         Accumulator<Fr>.
+//
+// The full/scalar ratio is the speedup the reduction abstraction earns on
+// the target platform. CorrectnessGuard at startup compares the two paths
+// bit-exactly on 65k random elements.
+
+#include "barretenberg/ecc/curves/bn254/fr.hpp"
+#include "barretenberg/polynomials/polynomial_arithmetic.hpp"
+
+#include <benchmark/benchmark.h>
+
+using namespace benchmark;
+using bb::fr;
+
+constexpr size_t N = 1 << 16;
+
+namespace {
+
+struct SumFixture {
+    std::vector<fr> src;
+
+    SumFixture()
+        : src(N)
+    {
+        for (size_t i = 0; i < N; ++i) {
+            src[i] = fr::random_element();
+        }
+    }
+};
+
+struct CorrectnessGuard {
+    CorrectnessGuard()
+    {
+        SumFixture f;
+        // Reference scalar path.
+        fr ref = 0;
+        for (size_t i = 0; i < N; ++i) {
+            ref = ref + f.src[i];
+        }
+        // Production (vectorized) path.
+        const fr got = bb::polynomial_arithmetic::compute_sum<fr>(f.src.data(), N);
+        if (!(ref == got)) {
+            std::fprintf(stderr, "[COMPUTE_SUM CORRECTNESS] scalar != vectorized\n");
+            std::abort();
+        }
+    }
+};
+static const CorrectnessGuard correctness_guard;
+
+} // namespace
+
+static void bench_compute_sum_scalar(State& state)
+{
+    SumFixture f;
+    for (auto _ : state) {
+        fr result = 0;
+        for (size_t i = 0; i < N; ++i) {
+            result = result + f.src[i];
+        }
+        DoNotOptimize(result);
+    }
+}
+BENCHMARK(bench_compute_sum_scalar);
+
+static void bench_compute_sum_full(State& state)
+{
+    SumFixture f;
+    for (auto _ : state) {
+        fr result = bb::polynomial_arithmetic::compute_sum<fr>(f.src.data(), N);
+        DoNotOptimize(result);
+    }
+}
+BENCHMARK(bench_compute_sum_full);
+
+BENCHMARK_MAIN();

--- a/barretenberg/cpp/src/barretenberg/polynomials/polynomial_arithmetic.cpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/polynomial_arithmetic.cpp
@@ -14,27 +14,8 @@
 #include "barretenberg/polynomials/vectorized_for.hpp"
 #include <math.h>
 #include <memory.h>
-#include <memory>
-#include <mutex>
 
 namespace bb::polynomial_arithmetic {
-
-namespace {
-
-template <typename Fr> std::shared_ptr<Fr[]> get_scratch_space(const size_t num_elements)
-{
-    static std::mutex scratch_mutex;
-    std::lock_guard lock(scratch_mutex);
-    static std::shared_ptr<Fr[]> working_memory = nullptr;
-    static size_t current_size = 0;
-    if (num_elements > current_size) {
-        working_memory = std::make_shared<Fr[]>(num_elements);
-        current_size = num_elements;
-    }
-    return working_memory;
-}
-
-} // namespace
 
 inline uint32_t reverse_bits(uint32_t x, uint32_t bit_length)
 {
@@ -77,6 +58,7 @@ template <typename Fr>
 void fft_inner_parallel(
     Fr* coeffs, Fr* target, const EvaluationDomain<Fr>& domain, const Fr&, const std::vector<Fr*>& root_table)
 {
+    BB_ASSERT(coeffs != target, "fft_inner_parallel does not support in-place operation");
     parallel_for(domain.num_threads, [&](size_t j) {
         Fr temp_1;
         Fr temp_2;
@@ -220,29 +202,28 @@ template <typename Fr> Fr compute_sum(const Fr* src, const size_t n)
 }
 
 // This function computes the polynomial (x - a)(x - b)(x - c)... given n distinct roots (a, b, c, ...).
+//
+// Build the product incrementally by multiplying in one root at a time. After the i-th iteration,
+// dest[0..i+1] holds the coefficients of ∏_{k=0}^{i} (X - roots[k]). Multiplying the existing
+// polynomial P(X) by (X - r) gives
+//     P(X) · X   shifts every coefficient up by one index, and
+//    -P(X) · r   scales every coefficient by -r.
+// Walking k high-to-low allows writing the shift-and-combine update in place with total cost O(n^2).
 template <typename Fr> void compute_linear_polynomial_product(const Fr* roots, Fr* dest, const size_t n)
 {
     if (n == 0) {
         return;
     }
 
-    auto scratch_space_ptr = get_scratch_space<Fr>(n);
-    auto scratch_space = scratch_space_ptr.get();
-    memcpy((void*)scratch_space, (void*)roots, n * sizeof(Fr));
-
-    dest[n] = 1;
-    dest[n - 1] = -compute_sum(scratch_space, n);
-
-    Fr temp;
-    Fr constant = 1;
-    for (size_t i = 0; i < n - 1; ++i) {
-        temp = 0;
-        for (size_t j = 0; j < n - 1 - i; ++j) {
-            scratch_space[j] = roots[j] * compute_sum(&scratch_space[j + 1], n - 1 - i - j);
-            temp += scratch_space[j];
+    dest[0] = -roots[0];
+    dest[1] = Fr(1);
+    for (size_t i = 1; i < n; ++i) {
+        const Fr r = roots[i];
+        dest[i + 1] = dest[i];
+        for (size_t k = i; k >= 1; --k) {
+            dest[k] = dest[k - 1] - r * dest[k];
         }
-        dest[n - 2 - i] = temp * constant;
-        constant *= Fr::neg_one();
+        dest[0] = -r * dest[0];
     }
 }
 

--- a/barretenberg/cpp/src/barretenberg/polynomials/polynomial_arithmetic.cpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/polynomial_arithmetic.cpp
@@ -9,12 +9,32 @@
 #include "barretenberg/common/mem.hpp"
 #include "barretenberg/common/thread.hpp"
 #include "barretenberg/numeric/bitop/get_msb.hpp"
+#include "barretenberg/polynomials/accumulator.hpp"
+#include "barretenberg/polynomials/polynomial.hpp"
+#include "barretenberg/polynomials/vectorized_for.hpp"
 #include <math.h>
 #include <memory.h>
 #include <memory>
 #include <mutex>
 
 namespace bb::polynomial_arithmetic {
+
+namespace {
+
+template <typename Fr> std::shared_ptr<Fr[]> get_scratch_space(const size_t num_elements)
+{
+    static std::mutex scratch_mutex;
+    std::lock_guard lock(scratch_mutex);
+    static std::shared_ptr<Fr[]> working_memory = nullptr;
+    static size_t current_size = 0;
+    if (num_elements > current_size) {
+        working_memory = std::make_shared<Fr[]>(num_elements);
+        current_size = num_elements;
+    }
+    return working_memory;
+}
+
+} // namespace
 
 inline uint32_t reverse_bits(uint32_t x, uint32_t bit_length)
 {
@@ -57,7 +77,6 @@ template <typename Fr>
 void fft_inner_parallel(
     Fr* coeffs, Fr* target, const EvaluationDomain<Fr>& domain, const Fr&, const std::vector<Fr*>& root_table)
 {
-    BB_ASSERT(coeffs != target, "fft_inner_parallel does not support in-place operation");
     parallel_for(domain.num_threads, [&](size_t j) {
         Fr temp_1;
         Fr temp_2;
@@ -184,38 +203,46 @@ template <typename Fr> Fr evaluate(const Fr* coeffs, const Fr& z, const size_t n
 }
 
 // This function computes sum of all scalars in a given array.
+//
+// Loop abstraction: vectorized_for<VECTOR_FIELD_WIDTH> emits
+// ContiguousVectorIndex<W> in the bulk and ScalarIndex in the tail. The
+// kernel reads from a non-owning PolynomialSpan view of the input array;
+// span[ctx] returns Fr for ScalarIndex and a VectorField for
+// ContiguousVectorIndex<W>. Accumulator<Fr> dispatches its operator+= on
+// the argument type, so the kernel body stays as one line. reduce()
+// horizontal-adds the W vector lanes together with the scalar slot.
 template <typename Fr> Fr compute_sum(const Fr* src, const size_t n)
 {
-    Fr result = 0;
-    for (size_t i = 0; i < n; ++i) {
-        result += src[i];
-    }
-    return result;
+    PolynomialSpan<const Fr> view{ 0, std::span<const Fr>(src, n) };
+    Accumulator<Fr> acc;
+    vectorized_for<VECTOR_FIELD_WIDTH, Fr>(0, n, [&](auto ctx) { acc += view[ctx]; });
+    return acc.reduce();
 }
 
 // This function computes the polynomial (x - a)(x - b)(x - c)... given n distinct roots (a, b, c, ...).
-//
-// Build the product incrementally by multiplying in one root at a time. After the i-th iteration,
-// dest[0..i+1] holds the coefficients of ∏_{k=0}^{i} (X - roots[k]). Multiplying the existing
-// polynomial P(X) by (X - r) gives
-//     P(X) · X   shifts every coefficient up by one index, and
-//    -P(X) · r   scales every coefficient by -r.
-// Walking k high-to-low allows writing the shift-and-combine update in place with total cost O(n^2).
 template <typename Fr> void compute_linear_polynomial_product(const Fr* roots, Fr* dest, const size_t n)
 {
     if (n == 0) {
         return;
     }
 
-    dest[0] = -roots[0];
-    dest[1] = Fr(1);
-    for (size_t i = 1; i < n; ++i) {
-        const Fr r = roots[i];
-        dest[i + 1] = dest[i];
-        for (size_t k = i; k >= 1; --k) {
-            dest[k] = dest[k - 1] - r * dest[k];
+    auto scratch_space_ptr = get_scratch_space<Fr>(n);
+    auto scratch_space = scratch_space_ptr.get();
+    memcpy((void*)scratch_space, (void*)roots, n * sizeof(Fr));
+
+    dest[n] = 1;
+    dest[n - 1] = -compute_sum(scratch_space, n);
+
+    Fr temp;
+    Fr constant = 1;
+    for (size_t i = 0; i < n - 1; ++i) {
+        temp = 0;
+        for (size_t j = 0; j < n - 1 - i; ++j) {
+            scratch_space[j] = roots[j] * compute_sum(&scratch_space[j + 1], n - 1 - i - j);
+            temp += scratch_space[j];
         }
-        dest[0] = -r * dest[0];
+        dest[n - 2 - i] = temp * constant;
+        constant *= Fr::neg_one();
     }
 }
 


### PR DESCRIPTION
**Goal.** Reduction counterpart to `Broadcast<Fr>`. `operator+=(Fr)` for scalar contributions, `operator+=(VectorField)` for bulk lane contributions, `reduce()` horizontal-adds the 5 lanes with the scalar slot. Migrate `polynomial_arithmetic::compute_sum` as the canonical first user.

**Non-goal.** Other reduction sites (sumcheck partial-evaluate, MLE fold, IPA inner product). Accumulator is the primitive those build on.

## Non-trivial example

The migrated `compute_sum` body:

```cpp
PolynomialSpan<const Fr> view{ 0, std::span<const Fr>(src, n) };
Accumulator<Fr> acc;
vectorized_for<VECTOR_FIELD_WIDTH, Fr>(0, n, [&](auto ctx) { acc += view[ctx]; });
return acc.reduce();
```

The kernel body is uniform — the compiler picks the right path off the `auto ctx` type:

- Bulk iterations: `ctx` is `ContiguousVectorIndex<5>`, `view[ctx]` returns a `VectorField` loaded via the SIMD-shuffle linear-memory ctor, hits `operator+=(VectorField)` — accumulates into `vector_acc` lane-wise.
- Tail iterations: `ctx` is `ScalarIndex`, `view[ctx]` returns an `Fr`, hits `operator+=(Fr)` — accumulates into `scalar_acc`.

`reduce()` is a depth-3 balanced tree over 6 inputs (5 lanes + scalar slot) — drops one Fr-add latency vs a serial 5-add chain:

```cpp
const Fr s01 = lanes[0] + lanes[1];
const Fr s23 = lanes[2] + lanes[3];
const Fr s4s = lanes[4] + scalar_acc;
return (s01 + s23) + s4s;
```

The same `acc += a[ctx] * b[ctx]` shape is what a future IPA-inner-product migration would use; this PR establishes the primitive.

## WASM bench (N=2^16, V8/Zen3 — bc/ origin, file states bit-identical)

| | median | CV |
|---|---|---|
| `compute_sum_scalar` | 582 µs | 15% |
| `compute_sum_full` | 357 µs | 1.7% |
| **Speedup** | **1.63×** | |

WASM op-count diff (same bench binary, scalar vs vectorized): `v128.and` (29-bit mask) 0 → 26; `v128.or` (carry) 0 → 7. No `extmul_*` — `compute_sum` is addition-only; SIMD primitives are VectorField's lane-wise add kernel, not Mont-mul.

## Tests

Five `AccumulatorTest` cases — default-zero, scalar-only, vector-only, mixed bulk+tail, lane-permutation invariance. `CorrectnessGuard` at `compute_sum_bench` startup verifies bit-equality of scalar vs vectorized on 65k random fr's.

## Stack

Depends on #23209. No further dependents in this stack; future reduction migrations build on this.