### PR TITLE
ci: revert ci-compat-e2e to AWS access keys

### DIFF
--- a/.github/workflows/ci3.yml
+++ b/.github/workflows/ci3.yml
@@ -456,9 +456,6 @@ jobs:
   # Escape hatch: ci-skip-compat-e2e label makes failures non-blocking on release PRs.
   ci-compat-e2e:
     runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      contents: read
     needs: [ci]
     if: |
       always()
@@ -478,17 +475,11 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
-      - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
-          aws-region: us-east-2
-          role-session-name: ci3-compat-e2e-${{ github.run_id }}
-          role-duration-seconds: 21600 # 6h – covers AWS_SHUTDOWN_TIME (300 min) + 60 min buffer
-
       - name: Run Backwards Compatibility E2E Tests
         timeout-minutes: 330
         env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           GITHUB_TOKEN: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
           BUILD_INSTANCE_SSH_KEY: ${{ secrets.BUILD_INSTANCE_SSH_KEY }}
           GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}


### PR DESCRIPTION
## Summary

- Forward-port of #23211 (from `backport-to-v4-next-staging`) onto `merge-train/fairies`.
- Drops OIDC auth from `ci-compat-e2e` and runs with `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` instead. The OIDC role (`pipeline-exec-aztecprotocol-aztec-packages-heads-next`) has no `ec2:RunInstances` policy attached, so spot requests time out and the on-demand fallback fails with `UnauthorizedOperation`. The job has been failing silently on every v4 nightly since #22930 because `continue-on-error` for `-nightly.` tags masked it.
- Mirrors the existing ci-release-publish workaround already on `next` (2681b235d6 / forward-port of #23167).

Example failure from v4 line: https://github.com/AztecProtocol/aztec-packages/actions/runs/25737242295/job/75580441745

## Test plan

- [ ] CI3 on this PR runs to green.
- [ ] Add the `ci-compat-e2e` label here to exercise the compat-e2e job end-to-end and confirm EC2 spot/on-demand provisioning succeeds with static credentials.

🤖 Generated with [Claude Code](https://claude.com/claude-code)