### PR TITLE
refactor: move public_checks caller helpers into aztec-nr (prep for public_checks demotion)

### DIFF
--- a/docs/docs-developers/docs/foundational-topics/call_types.md
+++ b/docs/docs-developers/docs/foundational-topics/call_types.md
@@ -132,7 +132,7 @@ It is also possible to create public functions that can _only_ be invoked by pri
 
 A common pattern is to enqueue public calls to check some validity condition on public state, e.g. that a deadline has not expired or that some public value is set.
 
-#include_code enqueueing /noir-projects/noir-contracts/contracts/protocol/public_checks_contract/src/utils.nr rust
+#include_code enqueueing /noir-projects/aztec-nr/aztec/src/public_checks.nr rust
 
 Note that this reveals what public function is being called on what contract, and perhaps more importantly which contract enqueued the call during private execution.
 To prevent this you can enqueue a call to a public function using `self.enqueue_incognito` that behaves the same as `self.enqueue` but conceals the message sender.
@@ -146,7 +146,7 @@ An example of how a deadline can be checked using the `PublicChecks` contract fo
 
 `privately_check_timestamp` and `privately_check_block_number` are helper functions around the call to the `PublicChecks` contract:
 
-#include_code helper_public_checks_functions /noir-projects/noir-contracts/contracts/protocol/public_checks_contract/src/utils.nr rust
+#include_code helper_public_checks_functions /noir-projects/aztec-nr/aztec/src/public_checks.nr rust
 
 This is what the implementation of the check timestamp functionality looks like:
 

--- a/docs/docs-developers/docs/resources/migration_notes.md
+++ b/docs/docs-developers/docs/resources/migration_notes.md
@@ -9,6 +9,17 @@ Aztec is in active development. Each version may introduce breaking changes that
 
 ## TBD
 
+### [Aztec.nr] `public_checks` helpers moved to `aztec-nr`
+
+The `privately_check_timestamp`, `privately_check_block_number`, and related caller helpers previously in `noir-contracts/contracts/protocol/public_checks_contract/src/utils.nr` are now in `aztec-nr/aztec/src/public_checks.nr`. Consumer contracts should update their imports:
+
+```diff
+- use public_checks::utils::privately_check_timestamp;
++ use aztec::public_checks::privately_check_timestamp;
+```
+
+The on-chain `PublicChecks` contract itself is unchanged in this PR.
+
 ### [Aztec.js] `AccountManager.create` takes an options bag
 
 `AccountManager.create` no longer takes `salt` as a positional argument. The trailing `salt?: Salt` parameter has been folded into a new `AccountManagerCreateOptions` bag alongside `immutablesHash` and `deployer`:

--- a/docs/docs-developers/docs/resources/migration_notes.md
+++ b/docs/docs-developers/docs/resources/migration_notes.md
@@ -18,8 +18,6 @@ The `privately_check_timestamp`, `privately_check_block_number`, and related cal
 + use aztec::public_checks::privately_check_timestamp;
 ```
 
-The deployed `PublicChecks` contract itself is unchanged in this PR.
-
 ### [Aztec.js] `AccountManager.create` takes an options bag
 
 `AccountManager.create` no longer takes `salt` as a positional argument. The trailing `salt?: Salt` parameter has been folded into a new `AccountManagerCreateOptions` bag alongside `immutablesHash` and `deployer`:

--- a/docs/docs-developers/docs/resources/migration_notes.md
+++ b/docs/docs-developers/docs/resources/migration_notes.md
@@ -18,7 +18,7 @@ The `privately_check_timestamp`, `privately_check_block_number`, and related cal
 + use aztec::public_checks::privately_check_timestamp;
 ```
 
-The on-chain `PublicChecks` contract itself is unchanged in this PR.
+The deployed `PublicChecks` contract itself is unchanged in this PR.
 
 ### [Aztec.js] `AccountManager.create` takes an options bag
 

--- a/noir-projects/aztec-nr/aztec/src/lib.nr
+++ b/noir-projects/aztec-nr/aztec/src/lib.nr
@@ -46,6 +46,7 @@ pub use protocol_types as protocol;
 pub(crate) mod logging;
 pub mod utils;
 pub mod authwit;
+pub mod public_checks;
 pub mod macros;
 
 pub mod test;

--- a/noir-projects/aztec-nr/aztec/src/public_checks.nr
+++ b/noir-projects/aztec-nr/aztec/src/public_checks.nr
@@ -1,6 +1,7 @@
-use crate::PublicChecks;
-use aztec::context::PrivateContext;
-use aztec::protocol::constants::PUBLIC_CHECKS_ADDRESS;
+use crate::context::calls::PublicStaticCall;
+use crate::context::PrivateContext;
+use crate::protocol::abis::function_selector::FunctionSelector;
+use crate::protocol::constants::PUBLIC_CHECKS_ADDRESS;
 
 // docs:start:helper_public_checks_functions
 /// Asserts that the current timestamp in the enqueued public call enqueued by `check_timestamp` satisfies
@@ -9,7 +10,14 @@ use aztec::protocol::constants::PUBLIC_CHECKS_ADDRESS;
 /// This conceals an address of the calling contract by setting `context.msg_sender` to the public checks contract
 /// address.
 pub fn privately_check_timestamp(operation: u8, value: u64, context: &mut PrivateContext) {
-    PublicChecks::at(PUBLIC_CHECKS_ADDRESS).check_timestamp(operation, value).enqueue_view_incognito(context);
+    let selector = comptime { FunctionSelector::from_signature("check_timestamp(u8,u64)") };
+    PublicStaticCall::<15, 2, ()>::new(
+        PUBLIC_CHECKS_ADDRESS,
+        selector,
+        "check_timestamp",
+        [operation as Field, value as Field],
+    )
+        .enqueue_view_incognito(context);
 }
 
 /// Asserts that the current block number in the enqueued public call enqueued by `check_block_number` satisfies
@@ -19,7 +27,14 @@ pub fn privately_check_timestamp(operation: u8, value: u64, context: &mut Privat
 /// address.
 pub fn privately_check_block_number(operation: u8, value: u32, context: &mut PrivateContext) {
     // docs:start:enqueueing
-    PublicChecks::at(PUBLIC_CHECKS_ADDRESS).check_block_number(operation, value).enqueue_view_incognito(context);
+    let selector = comptime { FunctionSelector::from_signature("check_block_number(u8,u32)") };
+    PublicStaticCall::<18, 2, ()>::new(
+        PUBLIC_CHECKS_ADDRESS,
+        selector,
+        "check_block_number",
+        [operation as Field, value as Field],
+    )
+        .enqueue_view_incognito(context);
     // docs:end:enqueueing
 }
 // docs:end:helper_public_checks_functions

--- a/noir-projects/noir-contracts/contracts/app/app_subscription_contract/Nargo.toml
+++ b/noir-projects/noir-contracts/contracts/app/app_subscription_contract/Nargo.toml
@@ -7,4 +7,3 @@ type = "contract"
 [dependencies]
 aztec = { path = "../../../../aztec-nr/aztec" }
 token = { path = "../token_contract" }
-public_checks = { path = "../../protocol/public_checks_contract" }

--- a/noir-projects/noir-contracts/contracts/app/app_subscription_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/app_subscription_contract/src/main.nr
@@ -52,7 +52,7 @@ pub contract AppSubscription {
         state_vars::{Owned, PrivateMutable, PublicImmutable},
         utils::comparison::Comparator,
     };
-    use public_checks::utils::privately_check_block_number;
+    use aztec::public_checks::privately_check_block_number;
     use token::Token;
 
     #[storage]

--- a/noir-projects/noir-contracts/contracts/app/crowdfunding_contract/Nargo.toml
+++ b/noir-projects/noir-contracts/contracts/app/crowdfunding_contract/Nargo.toml
@@ -8,4 +8,3 @@ type = "contract"
 aztec = { path = "../../../../aztec-nr/aztec" }
 uint_note = { path = "../../../../aztec-nr/uint-note" }
 token = { path = "../token_contract" }
-public_checks = { path = "../../protocol/public_checks_contract" }

--- a/noir-projects/noir-contracts/contracts/app/crowdfunding_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/crowdfunding_contract/src/main.nr
@@ -13,7 +13,7 @@ pub contract Crowdfunding {
         utils::{array, comparison::Comparator},
     };
     use aztec::note::{constants::MAX_NOTES_PER_PAGE, HintedNote, note_getter_options::NoteStatus};
-    use public_checks::utils::privately_check_timestamp;
+    use aztec::public_checks::privately_check_timestamp;
     use token::Token;
     use uint_note::UintNote;
 

--- a/noir-projects/noir-contracts/contracts/protocol/public_checks_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/protocol/public_checks_contract/src/main.nr
@@ -14,6 +14,7 @@ pub contract PublicChecks {
     // docs:start:check_timestamp
     /// Asserts that the current timestamp satisfies the `operation` with respect
     /// to the `value.
+    /// NOTE: signature is hardcoded in `aztec-nr/aztec/src/public_checks.nr`; keep in sync.
     #[external("public")]
     #[view]
     fn check_timestamp(operation: u8, value: u64) {
@@ -25,6 +26,7 @@ pub contract PublicChecks {
 
     /// Asserts that the current block number satisfies the `operation` with respect
     /// to the `value.
+    /// NOTE: signature is hardcoded in `aztec-nr/aztec/src/public_checks.nr`; keep in sync.
     #[external("public")]
     #[view]
     fn check_block_number(operation: u8, value: u32) {

--- a/noir-projects/noir-contracts/contracts/protocol/public_checks_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/protocol/public_checks_contract/src/main.nr
@@ -1,5 +1,4 @@
 mod test;
-pub mod utils;
 
 use aztec::macros::aztec;
 


### PR DESCRIPTION
Moves PublicChecks caller helpers from public_checks_contract/src/utils.nr into aztec-nr/aztec/src/public_checks.nr. Consumer contracts (app_subscription, crowdfunding) now import from aztec-nr.

Stacked on #23214.