### PR TITLE
chore: bump max size

### DIFF
--- a/playground/vite.config.ts
+++ b/playground/vite.config.ts
@@ -137,9 +137,10 @@ export default defineConfig(({ mode }) => {
         // - AD: bumped from 1600 => 1680 as we now have a 20kb msgpack lib in bb.js and other logic got us 50kb higher, adding some wiggle room.
         // - MW: bumped from 1700 => 1750 after adding the noble curves pkg to foundation required for blob batching calculations.
         // - 2026-05-08: bumped from 1750 => 1800 after merge of next into merge-train/fairies brought in barretenberg changes (optimized Poseidon2, n1 apps) that nudged bb.js over the prior limit (1750.02 KB).
+        // - 2026-05-12: bumped from 1800 => 1850 after merge train brought bundle to 1801.31 KB.
         {
           pattern: /assets\/index-.*\.js$/,
-          maxSizeKB: 1800,
+          maxSizeKB: 1850,
           description: 'Main entrypoint, hard limit',
         },
         // Bump log:


### PR DESCRIPTION
bump maxSizeKB likely due to multi-app kernels