### PR TITLE
feat(fuzz): side effect machine expansion

### DIFF
--- a/noir-projects/protocol-fuzzer/.prettierrc.json
+++ b/noir-projects/protocol-fuzzer/.prettierrc.json
@@ -1,0 +1,6 @@
+{
+  "singleQuote": true,
+  "trailingComma": "all",
+  "printWidth": 120,
+  "arrowParens": "avoid"
+}

--- a/noir-projects/protocol-fuzzer/NIGHTLY_SANDBOX_INSTRUCTIONS.md
+++ b/noir-projects/protocol-fuzzer/NIGHTLY_SANDBOX_INSTRUCTIONS.md
@@ -1,7 +1,7 @@
 # Protocol Fuzzer: Running with Nightly Docker Sandbox
 
 > **For local development** (no Docker), use `setup-local.sh` instead. It starts
-> anvil, the Aztec node, compiles contracts, and launches the bridge — all on the
+> anvil, the Aztec node, compiles contracts, and launches the bridge -- all on the
 > host. See `README.md` for quick-start instructions.
 
 ## Overview
@@ -10,8 +10,9 @@ The protocol fuzzer has two state machines:
 
 - **token**: Fuzzes the Token contract (mint/burn/transfer, public and private).
   Works with any Aztec sandbox -- no special setup needed.
-- **side-effect**: Fuzzes note lifecycle, nullifier emission, and cross-contract calls via
-  custom `SideEffect` and `Parent` contracts. **Requires the nightly sandbox.**
+- **side-effect**: Fuzzes note lifecycle, nullifier emission, L2->L1 messages, private logs,
+  key validation requests, public teardown, and cross-contract calls via custom `SideEffect`
+  and `Parent` contracts. **Requires the nightly sandbox.**
 
 Both machines talk to the sandbox via a persistent Node.js HTTP bridge (`wallet-bridge.mjs`)
 that keeps a single CLIWallet instance alive across requests.
@@ -22,7 +23,7 @@ The side-effect machine deploys custom contracts that must be version-compatible
 sandbox (PXE, sequencer, L1 contracts), the wallet CLI, and the compiled artifact format.
 
 The `latest` Docker image ships an older nargo that stack-overflows on current aztec-nr.
-Dated nightly images (e.g. `5.0.0-nightly.20260224`) have a matching nargo but the wallet
+Dated nightly images (e.g. `5.0.0-nightly.20260512`) have a matching nargo but the wallet
 is broken (missing `inquirer` npm package). The contracts must be compiled against the
 **nightly's aztec-nr**, not the repo's current branch, because oracle interfaces may differ
 between versions (the setup script auto-detects when they match).
@@ -42,9 +43,9 @@ By default the script uses the last tested nightly tag (`KNOWN_GOOD_TAG` in the 
 To try a newer nightly, use `find-latest-nightly.sh` to query Docker Hub:
 
 ```bash
-bash find-latest-nightly.sh                # prints e.g. 5.0.0-nightly.20260225
+bash find-latest-nightly.sh                # prints e.g. 5.0.0-nightly.20260512
 bash setup-nightly-sandbox.sh --latest     # auto-discovers and uses the newest tag
-NIGHTLY_IMAGE=aztecprotocol/aztec:5.0.0-nightly.20260225 bash setup-nightly-sandbox.sh  # specific tag
+NIGHTLY_IMAGE=aztecprotocol/aztec:5.0.0-nightly.20260512 bash setup-nightly-sandbox.sh  # specific tag
 ```
 
 Then run the fuzzer:
@@ -99,7 +100,7 @@ If the automated script doesn't work, follow these steps.
 Match the nightly image's nargo hash to an aztec-packages commit:
 
 ```bash
-docker run --rm --entrypoint "" aztecprotocol/aztec:5.0.0-nightly.20260224 \
+docker run --rm --entrypoint "" aztecprotocol/aztec:5.0.0-nightly.20260512 \
   /usr/src/noir/noir-repo/target/release/nargo --version
 # e.g. 7d07e187fb04d79f5a7cf41501d2c12bc2b1d5d2
 
@@ -133,7 +134,7 @@ docker run -d --rm --name aztec-sandbox-nightly \
   -e AZTEC_EPOCH_DURATION=4 \
   -e SEQ_ENFORCE_TIME_TABLE=false \
   --entrypoint "" \
-  aztecprotocol/aztec:5.0.0-nightly.20260224 \
+  aztecprotocol/aztec:5.0.0-nightly.20260512 \
   bash -c '/opt/foundry/bin/anvil --host 0.0.0.0 --port 8545 & \
   sleep 2 && node --no-warnings /usr/src/yarn-project/aztec/dest/bin/index.js start --local-network --l1-rpc-urls http://127.0.0.1:8545'
 ```
@@ -245,12 +246,16 @@ RUST_LOG=debug cargo run -- side-effect --max-steps 5
 
 ### SideEffect contract (`contracts/side_effect_contract/`)
 
-Custom contract for testing note lifecycle and nullifier operations:
+Custom contract for testing side-effect processing:
 - `call_create_note` / `call_create_and_complete_partial_note` -- create notes
 - `call_destroy_note` -- get notes sorted by value ASC, destroy the smallest
 - `call_view_notes_many` / `call_get_notes_many` -- query notes (returns `[u128; 2]`)
 - `emit_nullifier` / `test_settled_nullifier_inclusion` -- nullifier operations
 - `test_note_inclusion` -- prove note exists in the tree
+- `send_l2_to_l1_message` -- emit an L2->L1 message
+- `emit_private_log` -- emit a private log with tag and content
+- `request_ovsk_app` -- exercise key validation request
+- `test_setting_teardown` / `dummy_public_call` -- exercise public teardown execution
 
 ### Parent contract (`contracts/parent_contract/`)
 
@@ -260,6 +265,10 @@ Forwards private calls to the SideEffect contract for cross-contract call testin
 - `forward_test_note_inclusion`
 - `forward_emit_nullifier`
 - `forward_test_settled_nullifier_inclusion`
+- `forward_send_l2_to_l1_message`
+- `forward_emit_private_log`
+- `forward_request_ovsk_app`
+- `forward_test_setting_teardown`
 
 The fuzzer randomly chooses between direct calls and via-parent calls to exercise
 both code paths.
@@ -332,7 +341,7 @@ on the first request. The Rust fuzzer resolves aliases (`accounts:test0`,
 
 ### Version matrix (as of 2026-02-25)
 
-| Component | latest image | dated nightly (20260224) | repo (next branch) |
+| Component | latest image | dated nightly (20260512) | repo (next branch) |
 |-----------|-------------|--------------------------|-------------------|
 | nargo | beta.11 | beta.19 | beta.19 |
 | aztec-nr API | old | current | current |

--- a/noir-projects/protocol-fuzzer/README.md
+++ b/noir-projects/protocol-fuzzer/README.md
@@ -8,7 +8,11 @@ Two machines are available:
   operations (public and private), tracking balances and total supply.
 - **side-effect** -- deploys custom `SideEffect` and `Parent` contracts, then fuzzes
   note lifecycle (create, destroy, view, get, partial notes), nullifier emission,
-  and cross-contract calls, verifying note inclusion and nullifier uniqueness.
+  L2->L1 messages, private logs, key validation requests, public teardown calls,
+  and cross-contract calls. Verifies note values against the model, nullifier
+  uniqueness, L2->L1 message hashes in TxEffect, and private logs against the
+  model (each emission discoverable via siloed tag, plus per-tag completeness:
+  no earlier log gets dropped or overwritten).
 
 ## Running
 
@@ -34,7 +38,7 @@ cargo run -- side-effect --max-steps 100
 ```
 The nightly script places artifacts at `/tmp/` inside the container (the default `--artifacts-dir`).
 
-See `SANDBOX_INSTRUCTIONS.md` for manual nightly steps and troubleshooting.
+See `NIGHTLY_SANDBOX_INSTRUCTIONS.md` for manual nightly steps and troubleshooting.
 
 To replay a specific failure seed:
 
@@ -51,26 +55,37 @@ cargo run -- side-effect --max-steps 100000 --seed 0x5a7211231dcd6500
 --max-steps N         Max fuzzing steps (default: 400)
 --max-batch-size N    Max parallel sends per batch (default: 8)
 --artifacts-dir DIR   Contract artifact directory (side-effect only, default: /tmp)
+--include-one-shots   Include RequestOvskApp and TestSettingTeardown in the
+                      random command pool (side-effect only; off by default
+                      -- they always succeed and have no parameters to vary)
 ```
 
 > **Note:** `--artifacts-dir` is resolved on the host and sent as-is to the bridge.
 > For **local** setup the bridge runs on the host, so use the real path (e.g.
 > `contracts/target`). For **nightly Docker** the bridge runs inside the container,
-> so the path must be valid inside it — the default `/tmp` works because the nightly
+> so the path must be valid inside it -- the default `/tmp` works because the nightly
 > script places artifacts at `/tmp/*.json` inside the container.
 
 ### Parallel batching
 
-Consecutive non-conflicting state-changing commands are batched and fired concurrently,
-landing in the same block. This reduces N sequential transactions from N*5s to ~5s.
-Non-state-changing commands (queries) always flush the pending batch first since they
-need to observe prior committed state. Note that "query" here means "doesn't change
-model state" — some queries are still on-chain sends (e.g. `TestNoteInclusion` exercises
-kernel verification but doesn't alter the fuzzer's model).
+Consecutive non-conflicting commands are batched and fired concurrently, landing in the
+same block. This reduces N sequential transactions from N*5s to ~5s.
+
+Commands fall into three categories (see `changes_model()` / `flushes_batch()` in `machine.rs`):
+
+- **Stateful sends** -- create notes, emit nullifiers, send L2->L1 messages, emit private logs.
+  Batched together when non-conflicting.
+- **Queries** -- view/get notes, test note/nullifier inclusion. Flush the pending batch first
+  since they need to observe prior committed state. Some are on-chain sends (e.g.
+  `TestNoteInclusion` exercises kernel verification) but still flush the batch.
+- **Kernel exercisers** -- key validation (`RequestOvskApp`), public teardown
+  (`TestSettingTeardown`). On-chain sends that don't change model state and don't need the
+  batch flushed -- they batch freely with other sends.
 
 Conflict rules (conservative -- false positives only reduce batch size):
 - **token**: two commands on the same token conflict (shared total supply)
-- **side-effect**: two commands on the same (storage_slot, owner) or same nullifier value conflict
+- **side-effect**: two commands on the same (storage_slot, owner) or same nullifier value conflict;
+  L2->L1 messages, private logs, key validation, and teardown are conflict-free with all sends
 
 ## Smoke Tests
 
@@ -89,19 +104,26 @@ Environment variables for tests:
 
 ## Contracts
 
-Contract sources live in `contracts/` within this crate, not in `noir-contracts/`. They
-must be compiled against the **nightly sandbox's aztec-nr**, not the repo's current branch,
-because the two have incompatible APIs (e.g. `RetrievedNote` / `destroy_note_unsafe` vs
-`ConfirmedNote` / `destroy_note`). Compiling against the repo's aztec-nr produces artifacts
-with oracle calls (like `utilityLog`) that the nightly PXE doesn't support.
+Contract sources live in `contracts/` within this crate, not in `noir-contracts/`.
 
-- **SideEffect** (`contracts/side_effect_contract/`) -- note lifecycle, nullifier ops
+- **SideEffect** (`contracts/side_effect_contract/`) -- note lifecycle, nullifier ops,
+  L2->L1 messages, private logs, key validation, public teardown
 - **Parent** (`contracts/parent_contract/`) -- forwards calls to SideEffect for
   cross-contract call testing
 
-Artifacts are built by `setup-local.sh` or `setup-nightly-sandbox.sh` and placed in
-`contracts/target/`. Pre-built artifacts are checked into git for convenience.
+Contracts must be compiled against the same aztec-nr as the node they'll be
+deployed to:
 
-The nightly setup script auto-detects the nightly commit by matching the container's
-nargo hash against `origin/next`. See `SANDBOX_INSTRUCTIONS.md` for the full build
-pipeline, version matrix, and troubleshooting.
+- **Local setup** uses the repo's current aztec-nr (the noir submodule + `noir-projects/aztec-nr/`).
+  `setup-local.sh` invokes the locally-built nargo + bb.
+- **Nightly Docker setup** compiles inside the container against the nightly image's
+  aztec-nr (which may diverge from `next`). `setup-nightly-sandbox.sh` extracts the
+  nightly's aztec-nr source by auto-detecting the matching nargo hash on `origin/next`,
+  then compiles there.
+
+Mixing them fails at deploy: artifacts compiled with one aztec-nr produce different
+class IDs / VK sizes than the other expects. Build artifacts land in `contracts/target/`
+(host) and `/tmp/` (container) and are not tracked in git.
+
+See `NIGHTLY_SANDBOX_INSTRUCTIONS.md` for the full nightly build pipeline, version
+matrix, and troubleshooting.

--- a/noir-projects/protocol-fuzzer/contracts/parent_contract/src/main.nr
+++ b/noir-projects/protocol-fuzzer/contracts/parent_contract/src/main.nr
@@ -1,12 +1,19 @@
 use aztec::macros::aztec;
 
+/// Forwarding contract for cross-contract call testing.
+///
+/// Each `forward_*` function calls the corresponding function on the
+/// `SideEffect` contract via `call_private_function`. This exercises the
+/// kernel's nested private call handling: the side effects (note hashes,
+/// nullifiers, logs, etc.) originate from the child's call context, not the
+/// parent's, which tests that the protocol correctly attributes them.
 #[aztec]
 pub contract Parent {
     use aztec::{
         macros::functions::{external, initializer},
         protocol::{
             abis::function_selector::FunctionSelector,
-            address::AztecAddress,
+            address::{AztecAddress, EthAddress},
             traits::ToField,
         },
     };
@@ -15,8 +22,6 @@ pub contract Parent {
     #[external("private")]
     fn initialize() {}
 
-    // Forward a call to call_create_note(u128, AztecAddress, Field) on the target contract.
-    // Emits a note hash in the child call context.
     #[external("private")]
     fn forward_call_create_note(
         target: AztecAddress,
@@ -33,7 +38,6 @@ pub contract Parent {
         );
     }
 
-    // Forward a call to emit_nullifier(Field) on the target contract.
     #[external("private")]
     fn forward_emit_nullifier(target: AztecAddress, nullifier: Field) {
         let selector =
@@ -41,7 +45,6 @@ pub contract Parent {
         let _ = self.context.call_private_function(target, selector, [nullifier]);
     }
 
-    // Forward a call to test_settled_nullifier_inclusion(Field) on the target contract.
     #[external("private")]
     fn forward_test_settled_nullifier_inclusion(target: AztecAddress, nullifier: Field) {
         let selector =
@@ -49,7 +52,6 @@ pub contract Parent {
         let _ = self.context.call_private_function(target, selector, [nullifier]);
     }
 
-    // Forward a call to call_destroy_note(AztecAddress, Field) on the target contract.
     #[external("private")]
     fn forward_call_destroy_note(
         target: AztecAddress,
@@ -65,7 +67,6 @@ pub contract Parent {
         );
     }
 
-    // Forward a call to test_note_inclusion(AztecAddress, Field) on the target contract.
     #[external("private")]
     fn forward_test_note_inclusion(
         target: AztecAddress,
@@ -79,5 +80,45 @@ pub contract Parent {
             selector,
             [owner.to_field(), storage_slot],
         );
+    }
+
+    #[external("private")]
+    fn forward_send_l2_to_l1_message(
+        target: AztecAddress,
+        content: Field,
+        recipient: EthAddress,
+    ) {
+        let selector =
+            comptime { FunctionSelector::from_signature("send_l2_to_l1_message(Field,(Field))") };
+        let _ = self.context.call_private_function(
+            target,
+            selector,
+            [content, recipient.to_field()],
+        );
+    }
+
+    #[external("private")]
+    fn forward_emit_private_log(target: AztecAddress, tag: Field, content: Field) {
+        let selector =
+            comptime { FunctionSelector::from_signature("emit_private_log(Field,Field)") };
+        let _ = self.context.call_private_function(target, selector, [tag, content]);
+    }
+
+    #[external("private")]
+    fn forward_request_ovsk_app(target: AztecAddress, account: AztecAddress) {
+        let selector =
+            comptime { FunctionSelector::from_signature("request_ovsk_app((Field))") };
+        let _ = self.context.call_private_function(
+            target,
+            selector,
+            [account.to_field()],
+        );
+    }
+
+    #[external("private")]
+    fn forward_test_setting_teardown(target: AztecAddress) {
+        let selector =
+            comptime { FunctionSelector::from_signature("test_setting_teardown()") };
+        let _ = self.context.call_private_function(target, selector, []);
     }
 }

--- a/noir-projects/protocol-fuzzer/contracts/side_effect_contract/src/main.nr
+++ b/noir-projects/protocol-fuzzer/contracts/side_effect_contract/src/main.nr
@@ -11,9 +11,13 @@ use aztec::macros::aztec;
 /// - Note hashes: `call_create_note`, `call_create_and_complete_partial_note`
 /// - Nullifiers (from note destruction): `call_destroy_note`
 /// - Raw nullifier emission: `emit_nullifier`
-/// - Note read requests: `call_get_notes_many`
+/// - Note read requests: `call_get_notes_many`, `test_note_inclusion`
 /// - Unconstrained note queries: `call_view_notes_many`
-/// - Archive inclusion proofs: `test_note_inclusion`, `test_settled_nullifier_inclusion`
+/// - Archive inclusion proofs: `test_settled_nullifier_inclusion`
+/// - L2->L1 messages: `send_l2_to_l1_message`
+/// - Private log emissions: `emit_private_log`
+/// - Key validation requests: `request_ovsk_app`
+/// - Public teardown execution: `test_setting_teardown` / `dummy_public_call`
 ///
 /// Uses `UintNote` with caller-chosen storage slots (no declared storage)
 /// so the fuzzer can exercise multiple independent note sets.
@@ -26,6 +30,7 @@ pub contract SideEffect {
     use aztec::{
         hash::compute_siloed_nullifier,
         history::nullifier::assert_nullifier_existed_by,
+        keys::getters::get_public_keys,
         macros::{
             functions::{external, initializer, noinitcheck},
             storage::storage,
@@ -39,8 +44,15 @@ pub contract SideEffect {
             note_getter_options::{NoteGetterOptions, NoteStatus, PropertySelector, SortOrder},
             note_viewer_options::NoteViewerOptions,
         },
-        protocol::address::AztecAddress,
+        protocol::{
+            abis::function_selector::FunctionSelector,
+            address::{AztecAddress, EthAddress},
+            constants::PRIVATE_LOG_CIPHERTEXT_LEN,
+            traits::Hash,
+        },
     };
+
+    global VALUE_SELECTOR: PropertySelector = PropertySelector { index: 0, offset: 0, length: 32 };
 
     use uint_note::{PartialUintNote, UintNote};
 
@@ -62,14 +74,10 @@ pub contract SideEffect {
         );
     }
 
-    // Partial-note flow: the private phase hashes the owner, storage slot, and
-    // a random nonce into a "partial commitment" (without the value), emits an
-    // encrypted log for the recipient, and enqueues a public call. The public
-    // phase fills in the value, pushes the final note hash, and emits a public
-    // log so the recipient can reconstruct the full note. This lets the value
-    // be determined by public state (e.g. a token swap amount that depends on
-    // the current pool price) while keeping the owner private. Here the value
-    // is known upfront, but we still exercise the cross-phase machinery.
+    // Exercises the partial-note cross-phase flow: the private phase commits to
+    // (owner, storage_slot, nonce) without the value and enqueues a public call
+    // that fills in the value and finalizes the note hash. The fuzzer treats
+    // this as model-equivalent to call_create_note.
     // Value must be non-zero (0 is the "no note found" sentinel).
     #[external("private")]
     fn call_create_and_complete_partial_note(
@@ -91,22 +99,22 @@ pub contract SideEffect {
     fn call_destroy_note(owner: AztecAddress, storage_slot: Field) {
         let options: NoteGetterOptions<UintNote, _, _, _> = NoteGetterOptions::new()
             .set_owner(owner)
-            .sort(PropertySelector { index: 0, offset: 0, length: 32 }, SortOrder.ASC);
+            .sort(VALUE_SELECTOR, SortOrder.ASC);
         let confirmed_notes = get_notes(self.context, storage_slot, options);
 
         destroy_note(self.context, confirmed_notes.get(0));
     }
 
-    // test_note_inclusion: get_notes proves that a settled note exists in the
-    // note hash tree, and a pending note was emitted earlier in the tx. We
-    // assert len == 1 so the tx fails on empty slots, exercising the inclusion
-    // proof path only when a note actually exists.
+    // get_notes returns settled notes (proven via kernel read requests against
+    // the note hash tree) and pending notes (emitted earlier in this tx).
+    // Asserting len == 1 makes the tx fail on empty slots, so a successful
+    // call proves a note exists -- but doesn't distinguish settled from pending.
     #[external("private")]
     fn test_note_inclusion(owner: AztecAddress, storage_slot: Field) {
         let options: NoteGetterOptions<UintNote, _, _, _> = NoteGetterOptions::new()
             .set_owner(owner)
             .set_limit(1)
-            .sort(PropertySelector { index: 0, offset: 0, length: 32 }, SortOrder.ASC);
+            .sort(VALUE_SELECTOR, SortOrder.ASC);
 
         let confirmed_notes = get_notes(self.context, storage_slot, options);
         assert_eq(confirmed_notes.len(), 1);
@@ -125,7 +133,7 @@ pub contract SideEffect {
         let mut options = NoteViewerOptions::new()
             .set_owner(owner)
             .set_offset(offset)
-            .sort(PropertySelector { index: 0, offset: 0, length: 32 }, SortOrder.ASC);
+            .sort(VALUE_SELECTOR, SortOrder.ASC);
         if (active_or_nullified) {
             options = options.set_status(NoteStatus.ACTIVE_OR_NULLIFIED);
         }
@@ -147,7 +155,7 @@ pub contract SideEffect {
         let mut options: NoteGetterOptions<UintNote, _, _, _> = NoteGetterOptions::new()
             .set_owner(owner)
             .set_offset(offset)
-            .sort(PropertySelector { index: 0, offset: 0, length: 32 }, SortOrder.ASC);
+            .sort(VALUE_SELECTOR, SortOrder.ASC);
         if (active_or_nullified) {
             options = options.set_status(NoteStatus.ACTIVE_OR_NULLIFIED);
         }
@@ -159,15 +167,72 @@ pub contract SideEffect {
         [v0, v1]
     }
 
-    // TODO: Add more functions that push data directly to the context (both
-    // private and public) to test more side-effect scenarios -- e.g. pushing
-    // note hashes, log hashes, l2-to-l1 messages directly.
+    // Push a raw nullifier (not linked to any note hash). The kernel siloes it
+    // with the contract address before inserting into the nullifier tree. If the
+    // same value is emitted twice, the second tx fails (duplicate nullifier).
     #[external("private")]
     #[noinitcheck]
     fn emit_nullifier(nullifier: Field) {
         self.context.push_nullifier(nullifier);
     }
 
+    // Send a cross-chain L2->L1 message. The base rollup sha256-hashes
+    // (l2Sender, rollupVersion, l1Recipient, chainId, content) and appends the
+    // hash to TxEffect.l2ToL1Msgs; an L1 contract verifies it against the
+    // rollup outbox.
+    #[external("private")]
+    #[noinitcheck]
+    fn send_l2_to_l1_message(content: Field, recipient: EthAddress) {
+        self.context.message_portal(recipient, content);
+    }
+
+    // Emit a private log with a plaintext tag. Uses `emit_private_log_unsafe`
+    // (bypasses the usual ECDH tag derivation) so the fuzzer can predict the
+    // siloed tag from (contractAddr, tag) and query the node for the log.
+    // Body padded to PRIVATE_LOG_CIPHERTEXT_LEN; only the first field carries
+    // data.
+    #[external("private")]
+    #[noinitcheck]
+    fn emit_private_log(tag: Field, content: Field) {
+        let log = [content].concat([0; PRIVATE_LOG_CIPHERTEXT_LEN - 1]);
+        self.context.emit_private_log_unsafe(tag, log, 1);
+    }
+
+    // Request the app-scoped outgoing viewing secret key (ovsk_app): look up the
+    // account's master outgoing viewing public key (ovpk_m), hash it, and ask the
+    // kernel for the corresponding app-siloed secret. Exercises the kernel's key
+    // validation request path.
+    #[external("private")]
+    #[noinitcheck]
+    fn request_ovsk_app(account: AztecAddress) {
+        let ovpk_m = get_public_keys(account).ovpk_m;
+        let _ = self.context.request_ovsk_app(ovpk_m.hash());
+    }
+
+    // Schedule a public teardown function. Teardown is a special public call
+    // that runs after app logic, even if app logic reverts. Useful for cleanup
+    // (e.g. refunding gas). Here we schedule a no-op (`dummy_public_call`) to
+    // exercise the kernel's teardown plumbing.
+    #[external("private")]
+    #[noinitcheck]
+    fn test_setting_teardown() {
+        self.context.set_public_teardown_function(
+            self.address,
+            comptime { FunctionSelector::from_signature("dummy_public_call()") },
+            [],
+            false,
+        );
+    }
+
+    // No-op public function used as the teardown target by test_setting_teardown.
+    #[external("public")]
+    fn dummy_public_call() {}
+
+    // Verify that a nullifier exists in the nullifier tree at the anchor block.
+    // The nullifier must be siloed (hash of contract address + raw value) because
+    // the tree stores siloed nullifiers. The anchor block header pins the proof
+    // to a specific historical state, so this only works for nullifiers that were
+    // already settled (not pending in the current tx).
     #[external("private")]
     fn test_settled_nullifier_inclusion(nullifier: Field) {
         let header = self.context.get_anchor_block_header();
@@ -175,6 +240,8 @@ pub contract SideEffect {
         assert_nullifier_existed_by(header, siloed);
     }
 
+    // Public counterpart of call_create_and_complete_partial_note -- fills in
+    // the value and finalizes the note hash. See comment on that function.
     #[external("public")]
     fn call_complete_partial_note(partial_note: PartialUintNote, storage_slot: Field, value: u128) {
         partial_note.complete(self.context, self.address, storage_slot, value);

--- a/noir-projects/protocol-fuzzer/rust-toolchain.toml
+++ b/noir-projects/protocol-fuzzer/rust-toolchain.toml
@@ -1,0 +1,5 @@
+[toolchain]
+channel = "1.89.0"
+components = ["rust-src"]
+targets = []
+profile = "default"

--- a/noir-projects/protocol-fuzzer/setup-local.sh
+++ b/noir-projects/protocol-fuzzer/setup-local.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 # Sets up a local Aztec sandbox for use with the protocol fuzzer.
-# No Docker required — everything runs on the host.
+# No Docker required -- everything runs on the host.
 #
 # Prerequisites:
 #   cd $REPO_ROOT && ./bootstrap.sh build yarn-project
@@ -43,7 +43,7 @@ TRANSPILER="${TRANSPILER:-${REPO_ROOT}/avm-transpiler/target/release/avm-transpi
 log()  { echo "==> $*"; }
 die()  { echo "ERROR: $*" >&2; exit 1; }
 
-# PIDs of background processes we start — killed if the script fails partway through.
+# PIDs of background processes we start -- killed if the script fails partway through.
 BG_PIDS=()
 SETUP_COMPLETE=false
 cleanup() {
@@ -51,14 +51,14 @@ cleanup() {
         return
     fi
     if [ ${#BG_PIDS[@]} -gt 0 ]; then
-        log "Setup failed — stopping background processes: ${BG_PIDS[*]}"
+        log "Setup failed -- stopping background processes: ${BG_PIDS[*]}"
         kill "${BG_PIDS[@]}" 2>/dev/null || true
         wait "${BG_PIDS[@]}" 2>/dev/null || true
     fi
 }
 trap cleanup EXIT
 
-# kill_on_port PORT — kill any process listening on this TCP port
+# kill_on_port PORT -- kill any process listening on this TCP port
 kill_on_port() {
     local port=$1 pids
     pids=$(lsof -ti "tcp:${port}" 2>/dev/null || true)

--- a/noir-projects/protocol-fuzzer/setup-nightly-sandbox.sh
+++ b/noir-projects/protocol-fuzzer/setup-nightly-sandbox.sh
@@ -16,7 +16,7 @@ set -euo pipefail
 
 CONTAINER_NAME="aztec-sandbox-nightly"
 # Last nightly tag verified to work with the current contract source code.
-KNOWN_GOOD_TAG="5.0.0-nightly.20260402"
+KNOWN_GOOD_TAG="5.0.0-nightly.20260512"
 WRAPPER_DIR="${HOME}/.local/bin"
 WRAPPER_PATH="${WRAPPER_DIR}/aztec-wallet"
 REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
@@ -213,6 +213,11 @@ for contract_pkg in side_effect_contract parent_contract; do
     docker cp "${CONTAINER_NAME}:/tmp/nightly-build/target/${artifact}.json" \
         "${CONTRACTS_DIR}/target/${artifact}.json"
     log "Artifact copied to contracts/target/${artifact}.json"
+
+    # Also place a copy at /tmp/ inside the container so the default
+    # --artifacts-dir (/tmp) works without the user knowing the build path.
+    docker exec "$CONTAINER_NAME" cp \
+        "/tmp/nightly-build/target/${artifact}.json" "/tmp/${artifact}.json"
 done
 
 # --------------------------------------------------------------------------- #

--- a/noir-projects/protocol-fuzzer/src/main.rs
+++ b/noir-projects/protocol-fuzzer/src/main.rs
@@ -17,7 +17,9 @@ struct Args {
 enum MachineCommand {
     /// Fuzz the Token contract (mint/burn/transfer, public and private)
     Token(TokenArgs),
-    /// Fuzz note lifecycle, nullifier emission, and cross-contract calls
+    /// Fuzz note lifecycle, nullifier emission, L2->L1 messages, private logs,
+    /// and kernel exercisers (key validation, public teardown) -- both direct
+    /// and via a parent contract
     SideEffect(SideEffectArgs),
 }
 
@@ -63,6 +65,11 @@ struct SideEffectArgs {
     /// Directory containing compiled contract artifacts.
     #[arg(long, default_value = "/tmp")]
     artifacts_dir: String,
+    /// Include one-shot kernel exercisers (RequestOvskApp, TestSettingTeardown)
+    /// in the random command pool. They are always smoke-tested at setup
+    /// regardless of this flag.
+    #[arg(long, default_value_t = false)]
+    include_one_shots: bool,
 }
 
 fn parse_hex_u64(s: &str) -> Result<u64, String> {
@@ -111,7 +118,7 @@ fn main() {
             let mut machine = token::TokenMachine::new(Some(&bridge));
             machine.min_tokens = token_args.min_tokens;
             machine.max_tokens = token_args.max_tokens;
-            log::debug!("Starting token machine with parameters: {:?}", &machine);
+            log::debug!("Starting token machine with parameters: {:?}", machine);
             builder.run(|u| {
                 smt::run_batched(
                     u,
@@ -127,10 +134,11 @@ fn main() {
                 storage_slots: se_args.storage_slots,
                 bridge: Some(&bridge),
                 artifacts_dir: se_args.artifacts_dir.clone(),
+                include_one_shots: se_args.include_one_shots,
             };
             log::debug!(
                 "Starting side-effect machine with parameters: {:?}",
-                &machine
+                machine
             );
             builder.run(|u| {
                 smt::run_batched(
@@ -172,21 +180,6 @@ mod integration_tests {
         std::env::var("ARTIFACTS_DIR").unwrap_or_else(|_| "/tmp".to_string())
     }
 
-    /// Verifies the sandbox is reachable and test accounts can be imported.
-    /// Run this first to diagnose setup issues before running heavier tests.
-    /// Prefixed with `_0` so it sorts first alphabetically (`_` < `a` in
-    /// ASCII, and Rust functions are snake_case). #[serial] tests run in
-    /// alphabetical order.
-    #[test]
-    #[ignore = "requires sandbox"]
-    #[serial]
-    fn _0_sandbox_smoke() {
-        let bridge = init_test_env();
-        bridge
-            .import_test_accounts()
-            .expect("import test accounts failed");
-    }
-
     /// Deploys 1 token, runs 5 random operations. Requires a running sandbox.
     #[test]
     #[ignore = "requires sandbox"]
@@ -214,6 +207,7 @@ mod integration_tests {
             storage_slots: 2,
             bridge: Some(bridge),
             artifacts_dir: artifacts_dir(),
+            include_one_shots: false,
         };
         smt::fixed_size_builder(1024).run(|u| smt::run(u, &mut machine, 5))
     }
@@ -281,6 +275,7 @@ mod integration_tests {
             storage_slots: 1,
             bridge: Some(bridge),
             artifacts_dir: artifacts_dir(),
+            include_one_shots: false,
         };
         let state = side_effect::machine::SideEffectState {
             accounts: vec![0, 1, 2],
@@ -338,6 +333,7 @@ mod integration_tests {
                 storage_slots: 3,
                 bridge: None,
                 artifacts_dir: artifacts_dir(),
+                include_one_shots: false,
             };
             let mut state = machine.gen_state(&mut u).unwrap();
             let mut commands = Vec::new();

--- a/noir-projects/protocol-fuzzer/src/side_effect/machine.rs
+++ b/noir-projects/protocol-fuzzer/src/side_effect/machine.rs
@@ -6,11 +6,15 @@ use log::debug;
 
 use super::system::SideEffectSystem;
 use crate::smt::{self, Batchable};
-use crate::wallet::{self, AccountId, Bridge};
+use crate::wallet::{self, AccountId, Bridge, ExecOutput};
 
 pub(crate) type NoteValue = u128;
 pub(crate) type NullifierValue = u128;
 pub(crate) type StorageSlotId = u8;
+pub(crate) type L2ToL1Content = u128;
+pub(crate) type L2ToL1Recipient = u128;
+pub(crate) type LogTag = u128;
+pub(crate) type LogContent = u128;
 
 /// Upper bound on the number of storage slots. Keeps the state space manageable.
 const MAX_STORAGE_SLOTS: usize = 20;
@@ -24,6 +28,14 @@ pub struct SideEffectMachine<'a> {
     /// Directory containing compiled contract JSON artifacts (resolved to
     /// an absolute path in `SideEffectSystem::new`).
     pub artifacts_dir: String,
+    /// Include RequestOvskApp and TestSettingTeardown in the random command pool.
+    /// These are "one-shot" kernel exercisers: they always succeed, have no
+    /// parameters to vary meaningfully, and produce no model state. They are
+    /// smoke-tested at setup (direct + via_parent) in `new_system()` to prove
+    /// the kernel plumbing works; repeating them during fuzzing wastes ~5-13s
+    /// per tx without finding new bugs. Enable with `--include-one-shots` for
+    /// exhaustive runs.
+    pub include_one_shots: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -77,6 +89,34 @@ pub enum SideEffectCommand {
         from: AccountId,
         via_parent: bool,
     },
+    SendL2ToL1Message {
+        content: L2ToL1Content,
+        recipient: L2ToL1Recipient,
+        from: AccountId,
+        via_parent: bool,
+    },
+    EmitPrivateLog {
+        tag: LogTag,
+        content: LogContent,
+        from: AccountId,
+        via_parent: bool,
+    },
+    RequestOvskApp {
+        from: AccountId,
+        via_parent: bool,
+    },
+    TestSettingTeardown {
+        from: AccountId,
+        via_parent: bool,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Category {
+    Stateful,
+    ReadOnlyQuery,
+    AssertionQuery,
+    KernelExerciser,
 }
 
 impl SideEffectCommand {
@@ -90,41 +130,91 @@ impl SideEffectCommand {
             Self::TestNoteInclusion { .. } => "TestNoteInclusion",
             Self::EmitNullifier { .. } => "EmitNullifier",
             Self::TestNullifierInclusion { .. } => "TestNullifierInclusion",
+            Self::SendL2ToL1Message { .. } => "SendL2ToL1Message",
+            Self::EmitPrivateLog { .. } => "EmitPrivateLog",
+            Self::RequestOvskApp { .. } => "RequestOvskApp",
+            Self::TestSettingTeardown { .. } => "TestSettingTeardown",
         }
     }
 
-    /// How to execute on the sandbox: `Simulate` for read-only view/get,
-    /// `Send` for everything else. Note that `TestNoteInclusion` and
-    /// `TestNullifierInclusion` are sends (on-chain kernel verification)
-    /// even though they don't change model state -- see `is_query()`.
-    pub fn verb(&self) -> wallet::Verb {
+    /// Contract method (snake_case, as exported by the Noir contract).
+    pub(crate) fn method_name(&self) -> &'static str {
         match self {
-            Self::ViewNotesMany { .. } | Self::GetNotesMany { .. } => wallet::Verb::Simulate,
+            Self::CreateNote { .. } => "call_create_note",
+            Self::CreateAndCompletePartialNote { .. } => "call_create_and_complete_partial_note",
+            Self::ViewNotesMany { .. } => "call_view_notes_many",
+            Self::GetNotesMany { .. } => "call_get_notes_many",
+            Self::DestroyNote { .. } => "call_destroy_note",
+            Self::TestNoteInclusion { .. } => "test_note_inclusion",
+            Self::EmitNullifier { .. } => "emit_nullifier",
+            Self::TestNullifierInclusion { .. } => "test_settled_nullifier_inclusion",
+            Self::SendL2ToL1Message { .. } => "send_l2_to_l1_message",
+            Self::EmitPrivateLog { .. } => "emit_private_log",
+            Self::RequestOvskApp { .. } => "request_ovsk_app",
+            Self::TestSettingTeardown { .. } => "test_setting_teardown",
+        }
+    }
+
+    /// The account ID this command originates from (used as `msg_sender`).
+    pub(crate) fn from(&self) -> AccountId {
+        match self {
+            Self::CreateNote { from, .. }
+            | Self::CreateAndCompletePartialNote { from, .. }
+            | Self::ViewNotesMany { from, .. }
+            | Self::GetNotesMany { from, .. }
+            | Self::DestroyNote { from, .. }
+            | Self::TestNoteInclusion { from, .. }
+            | Self::EmitNullifier { from, .. }
+            | Self::TestNullifierInclusion { from, .. }
+            | Self::SendL2ToL1Message { from, .. }
+            | Self::EmitPrivateLog { from, .. }
+            | Self::RequestOvskApp { from, .. }
+            | Self::TestSettingTeardown { from, .. } => *from,
+        }
+    }
+
+    /// Bucket each command falls into. Predicates below derive from this so a
+    /// new variant only needs adding here and to the per-field extractors.
+    ///
+    /// - `Stateful`        -- changes model state; sends a tx; batchable.
+    /// - `ReadOnlyQuery`   -- simulates locally; flushes batch to observe prior writes.
+    /// - `AssertionQuery`  -- sends a tx that asserts on committed state; flushes batch.
+    /// - `KernelExerciser` -- sends a tx that exercises kernel plumbing (key
+    ///   validation, public teardown); no model state, doesn't flush.
+    pub(crate) fn category(&self) -> Category {
+        match self {
             Self::CreateNote { .. }
             | Self::CreateAndCompletePartialNote { .. }
             | Self::DestroyNote { .. }
-            | Self::TestNoteInclusion { .. }
             | Self::EmitNullifier { .. }
-            | Self::TestNullifierInclusion { .. } => wallet::Verb::Send,
+            | Self::SendL2ToL1Message { .. }
+            | Self::EmitPrivateLog { .. } => Category::Stateful,
+            Self::ViewNotesMany { .. } | Self::GetNotesMany { .. } => Category::ReadOnlyQuery,
+            Self::TestNoteInclusion { .. } | Self::TestNullifierInclusion { .. } => {
+                Category::AssertionQuery
+            }
+            Self::RequestOvskApp { .. } | Self::TestSettingTeardown { .. } => {
+                Category::KernelExerciser
+            }
         }
     }
 
-    /// Whether this command doesn't change model state (and therefore must
-    /// observe all prior committed state before executing, flushing the batch).
-    /// This is orthogonal to `verb()`: TestNoteInclusion/TestNullifierInclusion
-    /// are queries (`is_query = true`) but sends (`verb = Send`) because they
-    /// exercise on-chain kernel verification without changing the fuzzer's model.
-    pub fn is_query(&self) -> bool {
-        match self {
-            Self::ViewNotesMany { .. }
-            | Self::GetNotesMany { .. }
-            | Self::TestNoteInclusion { .. }
-            | Self::TestNullifierInclusion { .. } => true,
-            Self::CreateNote { .. }
-            | Self::CreateAndCompletePartialNote { .. }
-            | Self::DestroyNote { .. }
-            | Self::EmitNullifier { .. } => false,
+    pub fn verb(&self) -> wallet::Verb {
+        match self.category() {
+            Category::ReadOnlyQuery => wallet::Verb::Simulate,
+            _ => wallet::Verb::Send,
         }
+    }
+
+    pub fn flushes_batch(&self) -> bool {
+        matches!(
+            self.category(),
+            Category::ReadOnlyQuery | Category::AssertionQuery
+        )
+    }
+
+    pub fn changes_model(&self) -> bool {
+        matches!(self.category(), Category::Stateful)
     }
 
     pub(crate) fn via_parent(&self) -> bool {
@@ -133,7 +223,11 @@ impl SideEffectCommand {
             | Self::DestroyNote { via_parent, .. }
             | Self::TestNoteInclusion { via_parent, .. }
             | Self::EmitNullifier { via_parent, .. }
-            | Self::TestNullifierInclusion { via_parent, .. } => *via_parent,
+            | Self::TestNullifierInclusion { via_parent, .. }
+            | Self::SendL2ToL1Message { via_parent, .. }
+            | Self::EmitPrivateLog { via_parent, .. }
+            | Self::RequestOvskApp { via_parent, .. }
+            | Self::TestSettingTeardown { via_parent, .. } => *via_parent,
             Self::CreateAndCompletePartialNote { .. }
             | Self::ViewNotesMany { .. }
             | Self::GetNotesMany { .. } => false,
@@ -166,7 +260,11 @@ impl SideEffectCommand {
             Self::ViewNotesMany { .. }
             | Self::GetNotesMany { .. }
             | Self::EmitNullifier { .. }
-            | Self::TestNullifierInclusion { .. } => None,
+            | Self::TestNullifierInclusion { .. }
+            | Self::SendL2ToL1Message { .. }
+            | Self::EmitPrivateLog { .. }
+            | Self::RequestOvskApp { .. }
+            | Self::TestSettingTeardown { .. } => None,
         }
     }
 
@@ -180,32 +278,39 @@ impl SideEffectCommand {
             | Self::DestroyNote { .. }
             | Self::TestNoteInclusion { .. }
             | Self::ViewNotesMany { .. }
-            | Self::GetNotesMany { .. } => None,
+            | Self::GetNotesMany { .. }
+            | Self::SendL2ToL1Message { .. }
+            | Self::EmitPrivateLog { .. }
+            | Self::RequestOvskApp { .. }
+            | Self::TestSettingTeardown { .. } => None,
         }
     }
 }
 
 impl Batchable for SideEffectCommand {
     fn conflicts(&self, other: &Self) -> bool {
-        // Queries don't change state so they can batch with each other, but a
-        // query/send mix must flush (query needs to observe prior sends).
-        if self.is_query() || other.is_query() {
-            return !(self.is_query() && other.is_query());
+        // Two batch-flushing commands don't conflict (both observe committed state
+        // without interfering), but a flushing + non-flushing pair conflicts (the
+        // flushing command must see prior writes).
+        if self.flushes_batch() || other.flushes_batch() {
+            return !(self.flushes_batch() && other.flushes_batch());
         }
 
         // Same (slot, owner) pair -> conflict.
-        if let (Some(a), Some(b)) = (self.slot_owner(), other.slot_owner()) {
-            if a == b {
-                return true;
-            }
+        if let (Some(a), Some(b)) = (self.slot_owner(), other.slot_owner())
+            && a == b
+        {
+            return true;
         }
 
         // Same nullifier value -> conflict (EmitNullifier(x) vs EmitNullifier(x)
-        // or TestNullifierInclusion(x)).
-        if let (Some(a), Some(b)) = (self.nullifier_val(), other.nullifier_val()) {
-            if a == b {
-                return true;
-            }
+        // or TestNullifierInclusion(x)). Conservative: Test could in principle
+        // batch after Emit, but we don't model the ordering -- the cost is just
+        // smaller batches, not correctness.
+        if let (Some(a), Some(b)) = (self.nullifier_val(), other.nullifier_val())
+            && a == b
+        {
+            return true;
         }
 
         false
@@ -219,6 +324,8 @@ pub struct SideEffectState {
     pub active_notes: HashMap<(StorageSlotId, AccountId), Vec<NoteValue>>,
     pub destroyed_notes: HashMap<(StorageSlotId, AccountId), Vec<NoteValue>>,
     pub emitted_nullifiers: HashSet<NullifierValue>,
+    pub l2_to_l1_messages: Vec<(L2ToL1Content, L2ToL1Recipient)>,
+    pub private_logs: Vec<(LogTag, LogContent)>,
 }
 
 fn choose_account(u: &mut Unstructured, state: &SideEffectState) -> arbitrary::Result<AccountId> {
@@ -254,7 +361,7 @@ fn populated_slots(state: &SideEffectState) -> Vec<(StorageSlotId, AccountId)> {
     slots
 }
 
-fn assert_expected(name: &str, expect_ok: bool, result: &anyhow::Result<String>) {
+fn assert_expected(name: &str, expect_ok: bool, result: &anyhow::Result<ExecOutput>) {
     if expect_ok {
         debug!("{name}: expecting success");
         assert!(
@@ -328,7 +435,7 @@ impl<'a> smt::StateMachine for SideEffectMachine<'a> {
     type System = SideEffectSystem<'a>;
     type State = SideEffectState;
     type Command = SideEffectCommand;
-    type Result = Result<String>;
+    type Result = Result<ExecOutput>;
 
     fn gen_state(&mut self, _u: &mut Unstructured) -> arbitrary::Result<Self::State> {
         let mut state = Self::State {
@@ -353,13 +460,39 @@ impl<'a> smt::StateMachine for SideEffectMachine<'a> {
     ) -> arbitrary::Result<Self::Command> {
         let pop = populated_slots(state);
 
-        // Build command list based on preconditions. Mutations have extra weight
-        // so queries (which flush the parallel batch) are ~15% of commands.
+        // Weighted command generation. Three tiers of fuzzing value:
+        //
+        // 1. HIGH VALUE -- stateful, with failure paths:
+        //    Notes (create/destroy/query/inclusion) and nullifiers (emit/inclusion).
+        //    These maintain model state and verify it against sandbox queries.
+        //    Failure paths (empty-slot destroy, duplicate nullifier) are exercised
+        //    naturally as the random state evolves.
+        //
+        // 2. MEANINGFUL -- always succeed, per-command verification:
+        //    L2->L1 messages and private logs. Always succeed (no preconditions).
+        //    L2->L1 message hash checked against TxEffect when available; private
+        //    log discoverable via siloed tag with correct content, plus per-tag
+        //    completeness against the model.
+        //
+        // 3. ONE-SHOT -- success-only, no model state (opt-in via --include-one-shots):
+        //    RequestOvskApp and TestSettingTeardown. Always succeed with no
+        //    parameters to vary meaningfully. Smoke-tested at setup (direct +
+        //    via_parent) in new_system(); repeating during fuzzing wastes tx
+        //    budget.
         let mut choices = crate::util::weighted_choices(&[
             ("create_note", 8),
             ("create_partial_note", 3),
             ("emit_nullifier", 3),
+            ("send_l2_to_l1_message", 3),
+            ("emit_private_log", 3),
         ]);
+
+        if self.include_one_shots {
+            choices.extend(crate::util::weighted_choices(&[
+                ("request_ovsk_app", 2),
+                ("test_setting_teardown", 2),
+            ]));
+        }
 
         if !pop.is_empty() {
             choices.extend(crate::util::weighted_choices(&[
@@ -455,6 +588,26 @@ impl<'a> smt::StateMachine for SideEffectMachine<'a> {
                     via_parent: bool::arbitrary(u)?,
                 }
             }
+            "send_l2_to_l1_message" => SideEffectCommand::SendL2ToL1Message {
+                content: u128::arbitrary(u)?,
+                recipient: u128::arbitrary(u)?,
+                from: choose_account(u, state)?,
+                via_parent: bool::arbitrary(u)?,
+            },
+            "emit_private_log" => SideEffectCommand::EmitPrivateLog {
+                tag: u128::arbitrary(u)?,
+                content: u128::arbitrary(u)?,
+                from: choose_account(u, state)?,
+                via_parent: bool::arbitrary(u)?,
+            },
+            "request_ovsk_app" => SideEffectCommand::RequestOvskApp {
+                from: choose_account(u, state)?,
+                via_parent: bool::arbitrary(u)?,
+            },
+            "test_setting_teardown" => SideEffectCommand::TestSettingTeardown {
+                from: choose_account(u, state)?,
+                via_parent: bool::arbitrary(u)?,
+            },
             _ => unreachable!(),
         };
 
@@ -476,6 +629,9 @@ impl<'a> smt::StateMachine for SideEffectMachine<'a> {
         system
             .deploy_parent_contract(0)
             .expect("parent contract could not be deployed");
+        system
+            .run_one_shot_smoke_tests()
+            .expect("one-shot smoke tests failed");
         system
     }
 
@@ -508,22 +664,33 @@ impl<'a> smt::StateMachine for SideEffectMachine<'a> {
                 ..
             } => {
                 let key = (*storage_slot, *owner);
-                if let Some(notes) = state.active_notes.get_mut(&key) {
-                    if !notes.is_empty() {
-                        // Contract sorts by value ASC, destroys get(0) (smallest).
-                        let value = notes.remove(0);
-                        state.destroyed_notes.entry(key).or_default().push(value);
-                    }
+                if let Some(notes) = state.active_notes.get_mut(&key)
+                    && !notes.is_empty()
+                {
+                    // Contract sorts by value ASC, destroys get(0) (smallest).
+                    let value = notes.remove(0);
+                    state.destroyed_notes.entry(key).or_default().push(value);
                 }
             }
             EmitNullifier { nullifier, .. } => {
                 state.emitted_nullifiers.insert(*nullifier);
             }
-            // Query commands don't change state
+            SendL2ToL1Message {
+                content, recipient, ..
+            } => {
+                state.l2_to_l1_messages.push((*content, *recipient));
+            }
+            EmitPrivateLog { tag, content, .. } => {
+                state.private_logs.push((*tag, *content));
+            }
             ViewNotesMany { .. }
             | GetNotesMany { .. }
             | TestNoteInclusion { .. }
-            | TestNullifierInclusion { .. } => {}
+            | TestNullifierInclusion { .. }
+            | RequestOvskApp { .. }
+            | TestSettingTeardown { .. } => {
+                debug_assert!(!cmd.changes_model());
+            }
         };
 
         state
@@ -541,6 +708,26 @@ impl<'a> smt::StateMachine for SideEffectMachine<'a> {
         system.execute_command_batch(cmds)
     }
 
+    /// Verify the sandbox result against the model. Per-`Category` strategy:
+    ///
+    /// - **Stateful**:
+    ///   - Notes: success/failure checked here; values verified transitively
+    ///     by subsequent View/GetNotesMany.
+    ///   - Nullifiers: success + duplicate detection; insertion verified
+    ///     transitively by TestNullifierInclusion.
+    ///   - L2->L1 messages: reconstruct the expected hash (via bridge) and
+    ///     check it appears in TxEffect (same check an L1 contract performs).
+    ///   - Private logs: compute the siloed tag, query the node, and verify
+    ///     the just-emitted content is discoverable AND every previously-emitted
+    ///     log with the same tag is still present (per-tag completeness).
+    ///     `emit_private_log_unsafe` uses plaintext tags, so we verify siloing
+    ///     + indexing, not the full ECDH discovery protocol.
+    /// - **ReadOnlyQuery** (View/GetNotesMany): compare returned values to the
+    ///   model's expected notes.
+    /// - **AssertionQuery** (TestNote/NullifierInclusion): expect the tx to
+    ///   succeed iff the asserted condition holds in the model.
+    /// - **KernelExerciser** (RequestOvskApp/TestSettingTeardown): success-only;
+    ///   success proves the kernel plumbing works.
     fn check_result(&self, cmd: &Self::Command, pre_state: &Self::State, result: Self::Result) {
         use SideEffectCommand::*;
 
@@ -557,13 +744,11 @@ impl<'a> smt::StateMachine for SideEffectMachine<'a> {
                 value,
                 ..
             } => {
-                let name = cmd.name();
-                debug!("{name} value={value} owner={owner} slot={storage_slot}");
-                assert!(
-                    result.is_ok(),
-                    "{name} failed for value {value}, owner {owner}, slot {storage_slot}: {:?}",
-                    result.err()
+                debug!(
+                    "{} value={value} owner={owner} slot={storage_slot}",
+                    cmd.name()
                 );
+                assert_expected(cmd.name(), true, &result);
             }
             DestroyNote {
                 owner,
@@ -588,6 +773,89 @@ impl<'a> smt::StateMachine for SideEffectMachine<'a> {
             TestNullifierInclusion { .. } => {
                 assert_expected(cmd.name(), true, &result);
             }
+            SendL2ToL1Message {
+                content, recipient, ..
+            } => {
+                assert_expected(cmd.name(), true, &result);
+                // Recipient-side verification requires the bridge (to compute the
+                // expected hash) and TxEffect data (extracted from the receipt by
+                // the bridge). Either being absent silently skips this check --
+                // unit tests run without a bridge, and the bridge may fail to fetch
+                // TxEffect if the block isn't indexed yet.
+                if let Some(bridge) = self.bridge {
+                    let output = result.as_ref().unwrap();
+                    if let Some(ref effects) = output.tx_effects {
+                        // All sends originate from the SideEffect contract deployed
+                        // under the `test0` alias (see `deploy_side_effect_contract`).
+                        let contract = bridge.resolve("contracts:test0");
+                        let expected_hash = bridge
+                            .compute_l2_to_l1_hash(
+                                &contract,
+                                &recipient.to_string(),
+                                &content.to_string(),
+                            )
+                            .expect("compute_l2_to_l1_hash failed");
+                        let found = effects.l2_to_l1_msg_hashes.contains(&expected_hash);
+                        assert!(
+                            found,
+                            "{}: expected L2->L1 msg hash {} not in TxEffect hashes {:?}",
+                            cmd.name(),
+                            expected_hash,
+                            effects.l2_to_l1_msg_hashes,
+                        );
+                    }
+                }
+            }
+            EmitPrivateLog { tag, content, .. } => {
+                assert_expected(cmd.name(), true, &result);
+                if let Some(bridge) = self.bridge {
+                    let contract = bridge.resolve("contracts:test0");
+                    let logs = bridge
+                        .query_private_logs(&contract, &tag.to_string())
+                        .expect("query_private_logs failed");
+
+                    // Verify the just-emitted log is discoverable.
+                    // log_data[0] = siloed tag (matched by the query), log_data[1] = content
+                    let content_str = content.to_string();
+                    let found = logs
+                        .iter()
+                        .any(|log| log.log_data.len() >= 2 && log.log_data[1] == content_str);
+                    assert!(
+                        found,
+                        "{}: log with tag={tag} content={content} not found via siloed tag query. \
+                         logs={:?}",
+                        cmd.name(),
+                        logs,
+                    );
+
+                    // Verify per-tag completeness: every log the model has previously
+                    // emitted with this tag should still be discoverable. This catches
+                    // issues where the node drops or overwrites earlier logs.
+                    // (pre_state does NOT include the current emission -- that's added
+                    // by next_state after check_result returns.)
+                    let prior_contents: Vec<String> = pre_state
+                        .private_logs
+                        .iter()
+                        .filter(|(t, _)| *t == *tag)
+                        .map(|(_, c)| c.to_string())
+                        .collect();
+                    for expected_content in &prior_contents {
+                        let still_present = logs.iter().any(|log| {
+                            log.log_data.len() >= 2 && log.log_data[1] == *expected_content
+                        });
+                        assert!(
+                            still_present,
+                            "{}: prior log with tag={tag} content={expected_content} no longer \
+                             discoverable after emitting content={content}. logs={:?}",
+                            cmd.name(),
+                            logs,
+                        );
+                    }
+                }
+            }
+            RequestOvskApp { .. } | TestSettingTeardown { .. } => {
+                assert_expected(cmd.name(), true, &result);
+            }
             ViewNotesMany {
                 owner,
                 storage_slot,
@@ -602,12 +870,7 @@ impl<'a> smt::StateMachine for SideEffectMachine<'a> {
                 offset,
                 ..
             } => {
-                let name = cmd.name();
-                assert!(
-                    result.is_ok(),
-                    "{name} failed for owner {owner}, slot {storage_slot}: {:?}",
-                    result.as_ref().err()
-                );
+                assert_expected(cmd.name(), true, &result);
                 let expected = expected_notes(
                     pre_state,
                     *storage_slot,
@@ -615,7 +878,13 @@ impl<'a> smt::StateMachine for SideEffectMachine<'a> {
                     *active_or_nullified,
                     *offset,
                 );
-                check_multi_note_query(name, *storage_slot, *owner, &result.unwrap(), &expected);
+                check_multi_note_query(
+                    cmd.name(),
+                    *storage_slot,
+                    *owner,
+                    &result.unwrap().stdout,
+                    &expected,
+                );
             }
         }
     }
@@ -808,6 +1077,7 @@ mod tests {
             storage_slots: 5,
             bridge: None,
             artifacts_dir: "/tmp".into(),
+            include_one_shots: false,
         }
     }
 
@@ -826,39 +1096,6 @@ mod tests {
         };
         let state = m.next_state(&cmd, state);
         assert_eq!(state.active_notes[&(5, 0)], vec![42]);
-    }
-
-    #[test]
-    fn partial_note_adds_to_active() {
-        let m = machine();
-        let state = make_state();
-        let cmd = SideEffectCommand::CreateAndCompletePartialNote {
-            owner: 1,
-            storage_slot: 10,
-            value: 99,
-            from: 0,
-        };
-        let state = m.next_state(&cmd, state);
-        assert_eq!(state.active_notes[&(10, 1)], vec![99]);
-    }
-
-    #[test]
-    fn destroy_note_removes_first_note() {
-        let m = machine();
-        let mut state = make_state();
-        state.active_notes.insert((5, 0), vec![10, 20, 30]);
-
-        let cmd = SideEffectCommand::DestroyNote {
-            owner: 0,
-            storage_slot: 5,
-            from: 0,
-            via_parent: false,
-        };
-        let state = m.next_state(&cmd, state);
-
-        // First note (10) should be removed, not last (30)
-        assert_eq!(state.active_notes[&(5, 0)], vec![20, 30]);
-        assert_eq!(state.destroyed_notes[&(5, 0)], vec![10]);
     }
 
     #[test]
@@ -1229,6 +1466,156 @@ mod tests {
         assert_eq!(expected_notes(&state, 5, 0, false, 0), vec![20]);
     }
 
+    // -- SendL2ToL1Message / EmitPrivateLog tests --
+
+    #[test]
+    fn send_l2_to_l1_message_tracks_in_model() {
+        let m = machine();
+        let state = make_state();
+        let cmd = SideEffectCommand::SendL2ToL1Message {
+            content: 123,
+            recipient: 456,
+            from: 0,
+            via_parent: false,
+        };
+        let state = m.next_state(&cmd, state);
+        assert_eq!(state.l2_to_l1_messages, vec![(123, 456)]);
+    }
+
+    #[test]
+    fn emit_private_log_tracks_in_model() {
+        let m = machine();
+        let state = make_state();
+        let cmd = SideEffectCommand::EmitPrivateLog {
+            tag: 10,
+            content: 20,
+            from: 1,
+            via_parent: false,
+        };
+        let state = m.next_state(&cmd, state);
+        assert_eq!(state.private_logs, vec![(10, 20)]);
+    }
+
+    #[test]
+    /// L2->L1 and private-log sends mutate their own model lists but must not
+    /// pollute note or nullifier state. (Kernel exercisers are covered by
+    /// `kernel_exercisers_dont_change_any_state`, which is strictly stronger.)
+    fn l2_to_l1_and_private_log_dont_touch_note_or_nullifier_state() {
+        let m = machine();
+        let mut state = make_state();
+        state.active_notes.insert((5, 0), vec![42]);
+        state.emitted_nullifiers.insert(99);
+
+        let cmds = vec![
+            SideEffectCommand::SendL2ToL1Message {
+                content: 1,
+                recipient: 2,
+                from: 0,
+                via_parent: false,
+            },
+            SideEffectCommand::EmitPrivateLog {
+                tag: 3,
+                content: 4,
+                from: 0,
+                via_parent: false,
+            },
+        ];
+
+        for cmd in &cmds {
+            let new_state = m.next_state(cmd, state.clone());
+            assert_eq!(new_state.active_notes, state.active_notes);
+            assert_eq!(new_state.destroyed_notes, state.destroyed_notes);
+            assert_eq!(new_state.emitted_nullifiers, state.emitted_nullifiers);
+        }
+    }
+
+    #[test]
+    fn l2_to_l1_messages_dont_conflict_with_each_other() {
+        let a = SideEffectCommand::SendL2ToL1Message {
+            content: 1,
+            recipient: 2,
+            from: 0,
+            via_parent: false,
+        };
+        let b = SideEffectCommand::SendL2ToL1Message {
+            content: 3,
+            recipient: 4,
+            from: 1,
+            via_parent: false,
+        };
+        assert!(!a.conflicts(&b));
+    }
+
+    #[test]
+    fn private_logs_dont_conflict_with_each_other() {
+        let a = SideEffectCommand::EmitPrivateLog {
+            tag: 1,
+            content: 2,
+            from: 0,
+            via_parent: false,
+        };
+        let b = SideEffectCommand::EmitPrivateLog {
+            tag: 3,
+            content: 4,
+            from: 1,
+            via_parent: false,
+        };
+        assert!(!a.conflicts(&b));
+    }
+
+    #[test]
+    fn l2_to_l1_and_note_dont_conflict() {
+        let a = SideEffectCommand::SendL2ToL1Message {
+            content: 1,
+            recipient: 2,
+            from: 0,
+            via_parent: false,
+        };
+        let b = SideEffectCommand::CreateNote {
+            value: 42,
+            owner: 0,
+            storage_slot: 5,
+            from: 0,
+            via_parent: false,
+        };
+        assert!(!a.conflicts(&b));
+    }
+
+    #[test]
+    fn private_log_and_nullifier_dont_conflict() {
+        let a = SideEffectCommand::EmitPrivateLog {
+            tag: 1,
+            content: 2,
+            from: 0,
+            via_parent: false,
+        };
+        let b = SideEffectCommand::EmitNullifier {
+            nullifier: 42,
+            from: 0,
+            via_parent: false,
+        };
+        assert!(!a.conflicts(&b));
+    }
+
+    #[test]
+    fn l2_to_l1_conflicts_with_query() {
+        let a = SideEffectCommand::SendL2ToL1Message {
+            content: 1,
+            recipient: 2,
+            from: 0,
+            via_parent: false,
+        };
+        let b = SideEffectCommand::ViewNotesMany {
+            owner: 0,
+            storage_slot: 1,
+            active_or_nullified: false,
+            offset: 0,
+            from: 0,
+        };
+        assert!(a.conflicts(&b));
+        assert!(b.conflicts(&a));
+    }
+
     /// CreateNote and CreateAndCompletePartialNote produce equivalent model state.
     #[test]
     fn create_and_partial_create_are_equivalent_in_model() {
@@ -1256,5 +1643,330 @@ mod tests {
         );
 
         assert_eq!(state1.active_notes, state2.active_notes);
+    }
+
+    // -- RequestOvskApp / TestSettingTeardown conflict tests --
+
+    #[test]
+    fn request_ovsk_app_no_conflict_with_send() {
+        let a = SideEffectCommand::RequestOvskApp {
+            from: 0,
+            via_parent: false,
+        };
+        let b = SideEffectCommand::CreateNote {
+            value: 1,
+            owner: 0,
+            storage_slot: 5,
+            from: 0,
+            via_parent: false,
+        };
+        assert!(!a.conflicts(&b));
+    }
+
+    #[test]
+    fn teardown_no_conflict_with_send() {
+        let a = SideEffectCommand::TestSettingTeardown {
+            from: 0,
+            via_parent: false,
+        };
+        let b = SideEffectCommand::CreateNote {
+            value: 1,
+            owner: 0,
+            storage_slot: 5,
+            from: 0,
+            via_parent: false,
+        };
+        assert!(!a.conflicts(&b));
+    }
+
+    #[test]
+    fn request_ovsk_app_conflicts_with_query() {
+        let a = SideEffectCommand::RequestOvskApp {
+            from: 0,
+            via_parent: false,
+        };
+        let b = SideEffectCommand::ViewNotesMany {
+            owner: 0,
+            storage_slot: 1,
+            active_or_nullified: false,
+            offset: 0,
+            from: 0,
+        };
+        assert!(a.conflicts(&b));
+        assert!(b.conflicts(&a));
+    }
+
+    #[test]
+    fn teardown_conflicts_with_query() {
+        let a = SideEffectCommand::TestSettingTeardown {
+            from: 0,
+            via_parent: false,
+        };
+        let b = SideEffectCommand::ViewNotesMany {
+            owner: 0,
+            storage_slot: 1,
+            active_or_nullified: false,
+            offset: 0,
+            from: 0,
+        };
+        assert!(a.conflicts(&b));
+        assert!(b.conflicts(&a));
+    }
+
+    // -- Category -> predicate derivation --
+    //
+    // The exhaustive match in `category()` guarantees every variant is bucketed;
+    // these cases confirm each bucket maps to the right (changes_model,
+    // flushes_batch, verb) triple. One representative per bucket is enough.
+
+    #[test]
+    fn category_predicates() {
+        let cases: &[(SideEffectCommand, Category, bool, bool, wallet::Verb)] = &[
+            (
+                SideEffectCommand::CreateNote {
+                    value: 1,
+                    owner: 0,
+                    storage_slot: 1,
+                    from: 0,
+                    via_parent: false,
+                },
+                Category::Stateful,
+                true,
+                false,
+                wallet::Verb::Send,
+            ),
+            (
+                SideEffectCommand::ViewNotesMany {
+                    owner: 0,
+                    storage_slot: 1,
+                    active_or_nullified: false,
+                    offset: 0,
+                    from: 0,
+                },
+                Category::ReadOnlyQuery,
+                false,
+                true,
+                wallet::Verb::Simulate,
+            ),
+            (
+                SideEffectCommand::TestNoteInclusion {
+                    owner: 0,
+                    storage_slot: 1,
+                    from: 0,
+                    via_parent: false,
+                },
+                Category::AssertionQuery,
+                false,
+                true,
+                wallet::Verb::Send,
+            ),
+            (
+                SideEffectCommand::RequestOvskApp {
+                    from: 0,
+                    via_parent: false,
+                },
+                Category::KernelExerciser,
+                false,
+                false,
+                wallet::Verb::Send,
+            ),
+        ];
+        for (cmd, cat, changes, flushes, verb) in cases {
+            assert_eq!(cmd.category(), *cat, "{}: category", cmd.name());
+            assert_eq!(
+                cmd.changes_model(),
+                *changes,
+                "{}: changes_model",
+                cmd.name()
+            );
+            assert_eq!(
+                cmd.flushes_batch(),
+                *flushes,
+                "{}: flushes_batch",
+                cmd.name()
+            );
+            assert!(
+                matches!(
+                    (cmd.verb(), verb),
+                    (wallet::Verb::Send, wallet::Verb::Send)
+                        | (wallet::Verb::Simulate, wallet::Verb::Simulate)
+                ),
+                "{}: verb",
+                cmd.name()
+            );
+        }
+    }
+
+    // -- L2->L1 / private log accumulation tests --
+
+    #[test]
+    fn multiple_l2_to_l1_messages_accumulate() {
+        let m = machine();
+        let state = make_state();
+        let state = m.next_state(
+            &SideEffectCommand::SendL2ToL1Message {
+                content: 10,
+                recipient: 20,
+                from: 0,
+                via_parent: false,
+            },
+            state,
+        );
+        let state = m.next_state(
+            &SideEffectCommand::SendL2ToL1Message {
+                content: 30,
+                recipient: 40,
+                from: 1,
+                via_parent: false,
+            },
+            state,
+        );
+        assert_eq!(state.l2_to_l1_messages, vec![(10, 20), (30, 40)]);
+    }
+
+    #[test]
+    fn multiple_private_logs_accumulate() {
+        let m = machine();
+        let state = make_state();
+        let state = m.next_state(
+            &SideEffectCommand::EmitPrivateLog {
+                tag: 1,
+                content: 2,
+                from: 0,
+                via_parent: false,
+            },
+            state,
+        );
+        let state = m.next_state(
+            &SideEffectCommand::EmitPrivateLog {
+                tag: 3,
+                content: 4,
+                from: 1,
+                via_parent: false,
+            },
+            state,
+        );
+        assert_eq!(state.private_logs, vec![(1, 2), (3, 4)]);
+    }
+
+    #[test]
+    fn private_logs_same_tag_accumulate() {
+        let m = machine();
+        let state = make_state();
+        let state = m.next_state(
+            &SideEffectCommand::EmitPrivateLog {
+                tag: 42,
+                content: 100,
+                from: 0,
+                via_parent: false,
+            },
+            state,
+        );
+        let state = m.next_state(
+            &SideEffectCommand::EmitPrivateLog {
+                tag: 42,
+                content: 200,
+                from: 0,
+                via_parent: false,
+            },
+            state,
+        );
+        let state = m.next_state(
+            &SideEffectCommand::EmitPrivateLog {
+                tag: 99,
+                content: 300,
+                from: 0,
+                via_parent: false,
+            },
+            state,
+        );
+
+        // Two logs under tag 42, one under tag 99.
+        let tag42: Vec<_> = state
+            .private_logs
+            .iter()
+            .filter(|(t, _)| *t == 42)
+            .map(|(_, c)| *c)
+            .collect();
+        assert_eq!(tag42, vec![100, 200]);
+
+        let tag99: Vec<_> = state
+            .private_logs
+            .iter()
+            .filter(|(t, _)| *t == 99)
+            .map(|(_, c)| *c)
+            .collect();
+        assert_eq!(tag99, vec![300]);
+    }
+
+    #[test]
+    fn l2_to_l1_and_private_log_are_independent() {
+        let m = machine();
+        let state = make_state();
+        let state = m.next_state(
+            &SideEffectCommand::SendL2ToL1Message {
+                content: 10,
+                recipient: 20,
+                from: 0,
+                via_parent: false,
+            },
+            state,
+        );
+        let state = m.next_state(
+            &SideEffectCommand::EmitPrivateLog {
+                tag: 1,
+                content: 2,
+                from: 0,
+                via_parent: false,
+            },
+            state,
+        );
+        assert_eq!(state.l2_to_l1_messages, vec![(10, 20)]);
+        assert_eq!(state.private_logs, vec![(1, 2)]);
+    }
+
+    #[test]
+    fn kernel_exercisers_dont_change_any_state() {
+        let m = machine();
+        let mut state = make_state();
+        state.active_notes.insert((5, 0), vec![42]);
+        state.emitted_nullifiers.insert(99);
+        state.l2_to_l1_messages.push((1, 2));
+        state.private_logs.push((3, 4));
+
+        let cmds = vec![
+            SideEffectCommand::RequestOvskApp {
+                from: 0,
+                via_parent: false,
+            },
+            SideEffectCommand::TestSettingTeardown {
+                from: 0,
+                via_parent: false,
+            },
+        ];
+
+        for cmd in &cmds {
+            let new_state = m.next_state(cmd, state.clone());
+            assert_eq!(new_state.active_notes, state.active_notes, "{}", cmd.name());
+            assert_eq!(
+                new_state.destroyed_notes,
+                state.destroyed_notes,
+                "{}",
+                cmd.name()
+            );
+            assert_eq!(
+                new_state.emitted_nullifiers,
+                state.emitted_nullifiers,
+                "{}",
+                cmd.name()
+            );
+            assert_eq!(
+                new_state.l2_to_l1_messages,
+                state.l2_to_l1_messages,
+                "{}",
+                cmd.name()
+            );
+            assert_eq!(new_state.private_logs, state.private_logs, "{}", cmd.name());
+        }
     }
 }

--- a/noir-projects/protocol-fuzzer/src/side_effect/system.rs
+++ b/noir-projects/protocol-fuzzer/src/side_effect/system.rs
@@ -1,5 +1,5 @@
 use super::machine::SideEffectCommand;
-use crate::wallet::{AccountId, Bridge, WalletCommand};
+use crate::wallet::{AccountId, Bridge, ExecOutput, WalletCommand};
 
 pub struct SideEffectSystem<'a> {
     side_effect_artifact: String,
@@ -13,103 +13,79 @@ const PARENT_CONTRACT: &str = "contracts:parent0";
 impl From<&SideEffectCommand> for WalletCommand {
     fn from(cmd: &SideEffectCommand) -> Self {
         use SideEffectCommand::*;
-        let (method, from, args) = match cmd {
+        let args: Vec<String> = match cmd {
             CreateNote {
                 value,
                 owner,
                 storage_slot,
-                from,
                 ..
-            } => (
-                "call_create_note",
-                format!("accounts:test{from}"),
-                vec![
-                    format!("{value}"),
-                    format!("accounts:test{owner}"),
-                    format!("{storage_slot}"),
-                ],
-            ),
+            } => vec![
+                format!("{value}"),
+                format!("accounts:test{owner}"),
+                format!("{storage_slot}"),
+            ],
             CreateAndCompletePartialNote {
                 owner,
                 storage_slot,
                 value,
-                from,
-            } => (
-                "call_create_and_complete_partial_note",
-                format!("accounts:test{from}"),
-                vec![
-                    format!("accounts:test{owner}"),
-                    format!("{storage_slot}"),
-                    format!("{value}"),
-                ],
-            ),
+                ..
+            } => vec![
+                format!("accounts:test{owner}"),
+                format!("{storage_slot}"),
+                format!("{value}"),
+            ],
             ViewNotesMany {
                 owner,
                 storage_slot,
                 active_or_nullified,
                 offset,
-                from,
-            } => (
-                "call_view_notes_many",
-                format!("accounts:test{from}"),
-                vec![
-                    format!("accounts:test{owner}"),
-                    format!("{storage_slot}"),
-                    format!("{active_or_nullified}"),
-                    format!("{offset}"),
-                ],
-            ),
-            GetNotesMany {
+                ..
+            }
+            | GetNotesMany {
                 owner,
                 storage_slot,
                 active_or_nullified,
                 offset,
-                from,
-            } => (
-                "call_get_notes_many",
-                format!("accounts:test{from}"),
-                vec![
-                    format!("accounts:test{owner}"),
-                    format!("{storage_slot}"),
-                    format!("{active_or_nullified}"),
-                    format!("{offset}"),
-                ],
-            ),
+                ..
+            } => vec![
+                format!("accounts:test{owner}"),
+                format!("{storage_slot}"),
+                format!("{active_or_nullified}"),
+                format!("{offset}"),
+            ],
             DestroyNote {
                 owner,
                 storage_slot,
-                from,
                 ..
-            } => (
-                "call_destroy_note",
-                format!("accounts:test{from}"),
-                vec![format!("accounts:test{owner}"), format!("{storage_slot}")],
-            ),
-            TestNoteInclusion {
+            }
+            | TestNoteInclusion {
                 owner,
                 storage_slot,
-                from,
                 ..
-            } => (
-                "test_note_inclusion",
-                format!("accounts:test{from}"),
-                vec![format!("accounts:test{owner}"), format!("{storage_slot}")],
-            ),
-            EmitNullifier {
-                nullifier, from, ..
-            } => (
-                "emit_nullifier",
-                format!("accounts:test{from}"),
-                vec![format!("{nullifier}")],
-            ),
-            TestNullifierInclusion {
-                nullifier, from, ..
-            } => (
-                "test_settled_nullifier_inclusion",
-                format!("accounts:test{from}"),
-                vec![format!("{nullifier}")],
-            ),
+            } => vec![format!("accounts:test{owner}"), format!("{storage_slot}")],
+            EmitNullifier { nullifier, .. } | TestNullifierInclusion { nullifier, .. } => {
+                vec![format!("{nullifier}")]
+            }
+            SendL2ToL1Message {
+                content, recipient, ..
+            } => vec![
+                format!("{content}"),
+                // EthAddress is a struct { inner: Field }; the CLI's encodeArg
+                // expects a 0x-prefixed 32-byte hex string for single-field structs.
+                format!("0x{recipient:064x}"),
+            ],
+            EmitPrivateLog { tag, content, .. } => vec![format!("{tag}"), format!("{content}")],
+            RequestOvskApp { from, .. } => {
+                // The argument is the owner whose ovsk_app we request; passing
+                // `from` exercises the success path. A mismatched owner would
+                // test the failure path (kernel rejects unauthorized derivation).
+                vec![format!("accounts:test{from}")]
+            }
+            TestSettingTeardown { .. } => vec![],
         };
+
+        let from = format!("accounts:test{}", cmd.from());
+        let method = cmd.method_name();
 
         let (contract, method, args) = if cmd.via_parent() {
             let mut parent_args = vec![CHILD_CONTRACT.to_string()];
@@ -130,14 +106,14 @@ impl From<&SideEffectCommand> for WalletCommand {
 }
 
 impl<'a> SideEffectSystem<'a> {
-    pub(crate) fn execute_command(&self, cmd: &SideEffectCommand) -> anyhow::Result<String> {
+    pub(crate) fn execute_command(&self, cmd: &SideEffectCommand) -> anyhow::Result<ExecOutput> {
         self.bridge.execute(&WalletCommand::from(cmd))
     }
 
     pub(crate) fn execute_command_batch(
         &self,
         cmds: &[SideEffectCommand],
-    ) -> Vec<anyhow::Result<String>> {
+    ) -> Vec<anyhow::Result<ExecOutput>> {
         let wallet_cmds: Vec<WalletCommand> = cmds.iter().map(WalletCommand::from).collect();
         self.bridge.execute_many(&wallet_cmds)
     }
@@ -162,10 +138,40 @@ impl<'a> SideEffectSystem<'a> {
         )
     }
 
+    /// Smoke-test the kernel exercisers during setup: each is run both directly
+    /// and via the parent contract (cross-contract enqueue is a different kernel
+    /// call shape, so it needs its own check). They always succeed and have no
+    /// parameters to vary, so once these four pass, repeating them during
+    /// fuzzing wastes ~5-13s per redundant tx.
+    pub(crate) fn run_one_shot_smoke_tests(&self) -> anyhow::Result<()> {
+        for via_parent in [false, true] {
+            for cmd in [
+                SideEffectCommand::RequestOvskApp {
+                    from: 0,
+                    via_parent,
+                },
+                SideEffectCommand::TestSettingTeardown {
+                    from: 0,
+                    via_parent,
+                },
+            ] {
+                self.execute_command(&cmd)
+                    .map_err(|e| anyhow::anyhow!("one-shot smoke test {:?} failed: {e}", cmd))?;
+            }
+        }
+        Ok(())
+    }
+
     pub(crate) fn new(bridge: &'a Bridge, artifacts_dir: &str) -> Self {
-        let dir = std::path::Path::new(artifacts_dir)
-            .canonicalize()
-            .unwrap_or_else(|e| panic!("cannot resolve artifacts dir {artifacts_dir:?}: {e}"));
+        // Resolve relative paths against the current dir, but tolerate paths
+        // that don't exist on the host: in Docker mode `artifacts_dir` points
+        // inside the container (the bridge will read the file there).
+        let path = std::path::Path::new(artifacts_dir);
+        let dir = if path.is_absolute() {
+            path.to_path_buf()
+        } else {
+            std::env::current_dir().expect("cwd unavailable").join(path)
+        };
         let dir = dir.display();
         Self {
             side_effect_artifact: format!("{dir}/side_effect_contract-SideEffect.json"),

--- a/noir-projects/protocol-fuzzer/src/smt.rs
+++ b/noir-projects/protocol-fuzzer/src/smt.rs
@@ -74,9 +74,11 @@ pub trait StateMachine {
 /// Trait for commands that can be batched for parallel execution.
 pub trait Batchable {
     /// Returns `true` if executing `self` and `other` concurrently could produce
-    /// different results than executing them sequentially.
-    /// Queries (non-state-changing commands) must conflict with sends so they
-    /// observe prior state, but two queries can safely batch together.
+    /// different results than executing them sequentially. Two commands conflict
+    /// when either one must observe the other's effect to be correct, or when
+    /// they touch the same exclusive resource (e.g. the same storage slot).
+    /// Be conservative: false positives only shrink batches, false negatives
+    /// silently corrupt the model.
     fn conflicts(&self, other: &Self) -> bool;
 }
 
@@ -116,7 +118,7 @@ pub fn run_batched<T>(
     max_batch_size: usize,
 ) -> arbitrary::Result<()>
 where
-    T: StateMachine<Result = anyhow::Result<String>>,
+    T: StateMachine,
     T::Command: Batchable,
 {
     let state = t.gen_state(u)?;

--- a/noir-projects/protocol-fuzzer/src/token/machine.rs
+++ b/noir-projects/protocol-fuzzer/src/token/machine.rs
@@ -6,7 +6,7 @@ use log::debug;
 
 use super::system::TokenSystem;
 use crate::smt::{self, Batchable};
-use crate::wallet::{self, AccountId, Bridge};
+use crate::wallet::{self, AccountId, Bridge, ExecOutput};
 
 pub(crate) type TokenId = usize;
 
@@ -127,7 +127,7 @@ impl TokenCommand {
         matches!(self.verb(), wallet::Verb::Simulate)
     }
 
-    fn token_id(&self) -> TokenId {
+    pub(crate) fn token_id(&self) -> TokenId {
         match self {
             Self::MintPublic { token, .. }
             | Self::MintPrivate { token, .. }
@@ -140,6 +140,40 @@ impl TokenCommand {
             | Self::BalanceOfPublic { token, .. }
             | Self::BalanceOfPrivate { token, .. }
             | Self::TotalSupply { token, .. } => *token,
+        }
+    }
+
+    /// Contract method (snake_case, as exported by Token).
+    pub(crate) fn method_name(&self) -> &'static str {
+        match self {
+            Self::MintPublic { .. } => "mint_to_public",
+            Self::MintPrivate { .. } => "mint_to_private",
+            Self::BurnPublic { .. } => "burn_public",
+            Self::BurnPrivate { .. } => "burn_private",
+            Self::TransferPublic { .. } => "transfer_in_public",
+            Self::TransferPrivate { .. } => "transfer_in_private",
+            Self::TransferPublicToPrivate { .. } => "transfer_to_private",
+            Self::TransferPrivateToPublic { .. } => "transfer_to_public",
+            Self::BalanceOfPublic { .. } => "balance_of_public",
+            Self::BalanceOfPrivate { .. } => "balance_of_private",
+            Self::TotalSupply { .. } => "total_supply",
+        }
+    }
+
+    /// The account ID this command originates from (used as `msg_sender`).
+    pub(crate) fn from(&self) -> AccountId {
+        match self {
+            Self::MintPublic { from, .. }
+            | Self::MintPrivate { from, .. }
+            | Self::BurnPublic { from, .. }
+            | Self::BurnPrivate { from, .. }
+            | Self::TransferPublic { from, .. }
+            | Self::TransferPrivate { from, .. }
+            | Self::TransferPublicToPrivate { from, .. }
+            | Self::TransferPrivateToPublic { from, .. }
+            | Self::BalanceOfPublic { from, .. }
+            | Self::BalanceOfPrivate { from, .. }
+            | Self::TotalSupply { from, .. } => *from,
         }
     }
 }
@@ -199,6 +233,42 @@ fn credit(balances: &mut BalanceMap, key: (TokenId, AccountId), amount: TokenAmo
     *balances.entry(key).or_default() += amount;
 }
 
+/// Apply a mint to model state: bumps total supply and the chosen balance map,
+/// silently denying overflows (matching the contract). `is_public` selects the
+/// balance map and the log label.
+fn try_mint(
+    state: &mut TokenState,
+    token: TokenId,
+    amount: TokenAmount,
+    from: AccountId,
+    to: AccountId,
+    is_public: bool,
+) {
+    if state.owners[&token] != from {
+        return;
+    }
+    let supply = *state
+        .total_supply
+        .get(&token)
+        .expect("total supply should be initialized");
+    let balances = if is_public {
+        &mut state.balances_public
+    } else {
+        &mut state.balances_private
+    };
+    let balance = balances.get(&(token, to)).copied().unwrap_or(0);
+    match (supply.checked_add(amount), balance.checked_add(amount)) {
+        (Some(new_supply), Some(new_balance)) => {
+            balances.insert((token, to), new_balance);
+            state.total_supply.insert(token, new_supply);
+        }
+        _ => {
+            let kind = if is_public { "public" } else { "private" };
+            debug!("Overflow minting {amount} of {token} to {to} ({kind}), denied");
+        }
+    }
+}
+
 impl TokenMachine<'_> {
     fn gen_valid_mint(
         &self,
@@ -236,7 +306,7 @@ impl<'a> smt::StateMachine for TokenMachine<'a> {
     type System = TokenSystem<'a>;
     type State = TokenState;
     type Command = TokenCommand;
-    type Result = Result<String>;
+    type Result = Result<ExecOutput>;
 
     fn gen_state(&mut self, u: &mut Unstructured) -> arbitrary::Result<Self::State> {
         let mut state = Self::State {
@@ -416,53 +486,13 @@ impl<'a> smt::StateMachine for TokenMachine<'a> {
                 amount,
                 from,
                 to,
-            } => {
-                if state.owners[token] == *from {
-                    let supply = state
-                        .total_supply
-                        .get(token)
-                        .expect("total supply should be initialized");
-                    let balance = state
-                        .balances_public
-                        .get(&(*token, *to))
-                        .copied()
-                        .unwrap_or(0);
-                    if let (Some(new_supply), Some(new_balance)) =
-                        (supply.checked_add(*amount), balance.checked_add(*amount))
-                    {
-                        state.total_supply.insert(*token, new_supply);
-                        state.balances_public.insert((*token, *to), new_balance);
-                    } else {
-                        debug!("Overflow minting {amount} of {token} to {to} (public), denied");
-                    }
-                }
-            }
+            } => try_mint(&mut state, *token, *amount, *from, *to, true),
             MintPrivate {
                 token,
                 amount,
                 from,
                 to,
-            } => {
-                if state.owners[token] == *from {
-                    let supply = state
-                        .total_supply
-                        .get(token)
-                        .expect("total supply should be initialized");
-                    let balance = state
-                        .balances_private
-                        .get(&(*token, *to))
-                        .copied()
-                        .unwrap_or(0);
-                    if let (Some(new_supply), Some(new_balance)) =
-                        (supply.checked_add(*amount), balance.checked_add(*amount))
-                    {
-                        state.total_supply.insert(*token, new_supply);
-                        state.balances_private.insert((*token, *to), new_balance);
-                    } else {
-                        debug!("Overflow minting {amount} of {token} to {to} (private), denied");
-                    }
-                }
-            }
+            } => try_mint(&mut state, *token, *amount, *from, *to, false),
             BurnPublic {
                 token,
                 amount,
@@ -545,7 +575,7 @@ impl<'a> smt::StateMachine for TokenMachine<'a> {
         match cmd {
             BalanceOfPublic { token, address, .. } => {
                 let output = result.expect("BalanceOfPublic should succeed");
-                let amount = wallet::parse_simulation_result(&output)
+                let amount = wallet::parse_simulation_result(&output.stdout)
                     .expect("failed to parse BalanceOfPublic simulation result");
                 let state_balance = pre_state
                     .balances_public
@@ -564,7 +594,7 @@ impl<'a> smt::StateMachine for TokenMachine<'a> {
                 address,
             } => {
                 let output = result.expect("BalanceOfPrivate should succeed");
-                let amount = wallet::parse_simulation_result(&output)
+                let amount = wallet::parse_simulation_result(&output.stdout)
                     .expect("failed to parse BalanceOfPrivate simulation result");
                 // Private notes are encrypted -- only the owner's PXE can decrypt them.
                 // When from != address, the PXE returns 0.
@@ -584,7 +614,7 @@ impl<'a> smt::StateMachine for TokenMachine<'a> {
             }
             TotalSupply { token, .. } => {
                 let output = result.expect("TotalSupply should succeed");
-                let amount = wallet::parse_simulation_result(&output)
+                let amount = wallet::parse_simulation_result(&output.stdout)
                     .expect("failed to parse TotalSupply simulation result");
                 let state_supply = pre_state.total_supply.get(token).copied().unwrap_or(0);
                 debug!(

--- a/noir-projects/protocol-fuzzer/src/token/system.rs
+++ b/noir-projects/protocol-fuzzer/src/token/system.rs
@@ -1,5 +1,5 @@
 use super::machine::{TokenCommand, TokenId};
-use crate::wallet::{AccountId, Bridge, WalletCommand};
+use crate::wallet::{AccountId, Bridge, ExecOutput, WalletCommand};
 
 pub struct TokenSystem<'a> {
     bridge: &'a Bridge,
@@ -9,163 +9,57 @@ impl From<&TokenCommand> for WalletCommand {
     fn from(cmd: &TokenCommand) -> Self {
         use TokenCommand::*;
         // authwit_nonce is always 0 because msg_sender == from in all commands.
-        let (method, contract, from, args) = match cmd {
-            MintPublic {
-                token,
-                amount,
-                from,
-                to,
-            } => (
-                "mint_to_public",
-                format!("contracts:token{token}"),
+        let args: Vec<String> = match cmd {
+            MintPublic { amount, to, .. } | MintPrivate { amount, to, .. } => {
+                vec![format!("accounts:test{to}"), format!("{amount}")]
+            }
+            BurnPublic { amount, from, .. } | BurnPrivate { amount, from, .. } => vec![
                 format!("accounts:test{from}"),
-                vec![format!("accounts:test{to}"), format!("{amount}")],
-            ),
-            MintPrivate {
-                token,
-                amount,
-                from,
-                to,
-            } => (
-                "mint_to_private",
-                format!("contracts:token{token}"),
-                format!("accounts:test{from}"),
-                vec![format!("accounts:test{to}"), format!("{amount}")],
-            ),
-            BurnPublic {
-                token,
-                amount,
-                from,
-            } => (
-                "burn_public",
-                format!("contracts:token{token}"),
-                format!("accounts:test{from}"),
-                vec![
-                    format!("accounts:test{from}"),
-                    format!("{amount}"),
-                    "0".into(),
-                ],
-            ),
-            BurnPrivate {
-                token,
-                amount,
-                from,
-            } => (
-                "burn_private",
-                format!("contracts:token{token}"),
-                format!("accounts:test{from}"),
-                vec![
-                    format!("accounts:test{from}"),
-                    format!("{amount}"),
-                    "0".into(),
-                ],
-            ),
+                format!("{amount}"),
+                "0".into(),
+            ],
             TransferPublic {
-                token,
-                to,
-                amount,
-                from,
-            } => (
-                "transfer_in_public",
-                format!("contracts:token{token}"),
+                to, amount, from, ..
+            }
+            | TransferPrivate {
+                to, amount, from, ..
+            }
+            | TransferPrivateToPublic {
+                to, amount, from, ..
+            } => vec![
                 format!("accounts:test{from}"),
-                vec![
-                    format!("accounts:test{from}"),
-                    format!("accounts:test{to}"),
-                    format!("{amount}"),
-                    "0".into(),
-                ],
-            ),
-            TransferPrivate {
-                token,
-                to,
-                amount,
-                from,
-            } => (
-                "transfer_in_private",
-                format!("contracts:token{token}"),
-                format!("accounts:test{from}"),
-                vec![
-                    format!("accounts:test{from}"),
-                    format!("accounts:test{to}"),
-                    format!("{amount}"),
-                    "0".into(),
-                ],
-            ),
-            TransferPublicToPrivate {
-                token,
-                to,
-                amount,
-                from,
-            } => (
-                "transfer_to_private",
-                format!("contracts:token{token}"),
-                format!("accounts:test{from}"),
-                vec![format!("accounts:test{to}"), format!("{amount}")],
-            ),
-            TransferPrivateToPublic {
-                token,
-                to,
-                amount,
-                from,
-            } => (
-                "transfer_to_public",
-                format!("contracts:token{token}"),
-                format!("accounts:test{from}"),
-                vec![
-                    format!("accounts:test{from}"),
-                    format!("accounts:test{to}"),
-                    format!("{amount}"),
-                    "0".into(),
-                ],
-            ),
-            BalanceOfPublic {
-                token,
-                from,
-                address,
-            } => (
-                "balance_of_public",
-                format!("contracts:token{token}"),
-                format!("accounts:test{from}"),
-                vec![format!("accounts:test{address}")],
-            ),
-            BalanceOfPrivate {
-                token,
-                from,
-                address,
-            } => (
-                "balance_of_private",
-                format!("contracts:token{token}"),
-                format!("accounts:test{from}"),
-                vec![format!("accounts:test{address}")],
-            ),
-            TotalSupply { token, from } => (
-                "total_supply",
-                format!("contracts:token{token}"),
-                format!("accounts:test{from}"),
-                vec![],
-            ),
+                format!("accounts:test{to}"),
+                format!("{amount}"),
+                "0".into(),
+            ],
+            TransferPublicToPrivate { to, amount, .. } => {
+                vec![format!("accounts:test{to}"), format!("{amount}")]
+            }
+            BalanceOfPublic { address, .. } | BalanceOfPrivate { address, .. } => {
+                vec![format!("accounts:test{address}")]
+            }
+            TotalSupply { .. } => vec![],
         };
 
         WalletCommand {
             verb: cmd.verb(),
-            method: method.to_string(),
-            contract,
-            from,
+            method: cmd.method_name().to_string(),
+            contract: format!("contracts:token{}", cmd.token_id()),
+            from: format!("accounts:test{}", cmd.from()),
             args,
         }
     }
 }
 
 impl<'a> TokenSystem<'a> {
-    pub(crate) fn execute_command(&self, cmd: &TokenCommand) -> anyhow::Result<String> {
+    pub(crate) fn execute_command(&self, cmd: &TokenCommand) -> anyhow::Result<ExecOutput> {
         self.bridge.execute(&WalletCommand::from(cmd))
     }
 
     pub(crate) fn execute_command_batch(
         &self,
         cmds: &[TokenCommand],
-    ) -> Vec<anyhow::Result<String>> {
+    ) -> Vec<anyhow::Result<ExecOutput>> {
         let wallet_cmds: Vec<WalletCommand> = cmds.iter().map(WalletCommand::from).collect();
         self.bridge.execute_many(&wallet_cmds)
     }

--- a/noir-projects/protocol-fuzzer/src/util.rs
+++ b/noir-projects/protocol-fuzzer/src/util.rs
@@ -3,6 +3,6 @@
 pub fn weighted_choices<'a>(entries: &[(&'a str, usize)]) -> Vec<&'a str> {
     entries
         .iter()
-        .flat_map(|&(s, n)| std::iter::repeat(s).take(n))
+        .flat_map(|&(s, n)| std::iter::repeat_n(s, n))
         .collect()
 }

--- a/noir-projects/protocol-fuzzer/src/wallet.rs
+++ b/noir-projects/protocol-fuzzer/src/wallet.rs
@@ -40,17 +40,16 @@ impl AddressBook {
     /// Resolve an alias like `accounts:test0` or `contracts:test0` to a hex
     /// address.  Non-alias strings (plain numbers, hex addresses) pass through.
     fn resolve(&self, alias: &str) -> String {
-        if let Some(rest) = alias.strip_prefix("accounts:test") {
-            if let Ok(id) = rest.parse::<usize>() {
-                if let Some(addr) = self.accounts.get(id) {
-                    return addr.clone();
-                }
-            }
+        if let Some(rest) = alias.strip_prefix("accounts:test")
+            && let Ok(id) = rest.parse::<usize>()
+            && let Some(addr) = self.accounts.get(id)
+        {
+            return addr.clone();
         }
-        if let Some(name) = alias.strip_prefix("contracts:") {
-            if let Some(info) = self.contracts.get(name) {
-                return info.address.clone();
-            }
+        if let Some(name) = alias.strip_prefix("contracts:")
+            && let Some(info) = self.contracts.get(name)
+        {
+            return info.address.clone();
         }
         alias.to_string()
     }
@@ -85,6 +84,22 @@ pub struct WalletCommand {
     pub contract: String,
     pub from: String,
     pub args: Vec<String>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct TxEffects {
+    pub l2_to_l1_msg_hashes: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct PrivateLogData {
+    pub log_data: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ExecOutput {
+    pub stdout: String,
+    pub tx_effects: Option<TxEffects>,
 }
 
 // ---------------------------------------------------------------------------
@@ -162,9 +177,11 @@ impl Bridge {
         }
     }
 
-    /// Execute a wallet command and return stdout.  Retries automatically on
-    /// transient sandbox errors (e.g. block-hash-not-found after a reorg).
-    pub fn execute(&self, cmd: &WalletCommand) -> anyhow::Result<String> {
+    /// Execute a wallet command and return output including optional TxEffect
+    /// data.  Retries automatically on transient sandbox errors -- see
+    /// `is_transient_error` for which messages are retried (currently stale
+    /// world-state reads and reorg notices).
+    pub fn execute(&self, cmd: &WalletCommand) -> anyhow::Result<ExecOutput> {
         let book = self.address_book.lock().unwrap();
         let resolved_from = book.resolve(&cmd.from);
         let resolved_contract = book.resolve(&cmd.contract);
@@ -193,7 +210,8 @@ impl Bridge {
             let result = self.post("/execute", &body)?;
             let stdout = result["stdout"].as_str().unwrap_or("").to_string();
             debug!("bridge execute stdout: {stdout}");
-            Ok(stdout)
+            let tx_effects = parse_tx_effects(&result);
+            Ok(ExecOutput { stdout, tx_effects })
         })
     }
 
@@ -265,7 +283,7 @@ impl Bridge {
 
     /// Execute multiple wallet commands in parallel using scoped threads.
     /// Returns results in the same order as the input commands.
-    pub fn execute_many(&self, cmds: &[WalletCommand]) -> Vec<anyhow::Result<String>> {
+    pub fn execute_many(&self, cmds: &[WalletCommand]) -> Vec<anyhow::Result<ExecOutput>> {
         std::thread::scope(|s| {
             let handles: Vec<_> = cmds
                 .iter()
@@ -274,6 +292,86 @@ impl Bridge {
             handles.into_iter().map(|h| h.join().unwrap()).collect()
         })
     }
+
+    /// Resolve an alias (e.g. `contracts:test0`) to a hex address.
+    pub fn resolve(&self, alias: &str) -> String {
+        self.address_book.lock().unwrap().resolve(alias)
+    }
+
+    /// Query the node for private logs matching the siloed tag derived from
+    /// `contract` and `raw_tag`. The bridge computes the siloed tag via
+    /// `poseidon2_hash_with_separator([contract, rawTag], DOM_SEP)` and
+    /// queries `getPrivateLogsByTags`.
+    pub fn query_private_logs(
+        &self,
+        contract: &str,
+        raw_tag: &str,
+    ) -> anyhow::Result<Vec<PrivateLogData>> {
+        let body = json!({ "contract": contract, "rawTag": raw_tag });
+        let result = self.post("/query-private-logs", &body)?;
+        let logs = result
+            .get("logs")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .map(|log| PrivateLogData {
+                        log_data: log
+                            .get("logData")
+                            .and_then(|f| f.as_array())
+                            .map(|fs| {
+                                fs.iter()
+                                    .filter_map(|f| f.as_str().map(String::from))
+                                    .collect()
+                            })
+                            .unwrap_or_default(),
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+        Ok(logs)
+    }
+
+    /// Compute the L2->L1 message hash that an L1 recipient would check against
+    /// the outbox.  Delegates to the bridge which has access to chain ID and
+    /// rollup version.
+    pub fn compute_l2_to_l1_hash(
+        &self,
+        l2_sender: &str,
+        l1_recipient: &str,
+        content: &str,
+    ) -> anyhow::Result<String> {
+        let body = json!({
+            "l2Sender": l2_sender,
+            "l1Recipient": l1_recipient,
+            "content": content,
+        });
+        let result = self.post("/compute-l2-to-l1-hash", &body)?;
+        result["hash"]
+            .as_str()
+            .map(String::from)
+            .ok_or_else(|| anyhow!("missing 'hash' in response"))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// TxEffect parsing
+// ---------------------------------------------------------------------------
+
+/// Parse the optional `txEffects` field from a bridge JSON response.
+fn parse_tx_effects(result: &serde_json::Value) -> Option<TxEffects> {
+    let effects = result.get("txEffects")?;
+    let l2_to_l1_msg_hashes = effects
+        .get("l2ToL1Msgs")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(String::from))
+                .collect()
+        })
+        .unwrap_or_default();
+    Some(TxEffects {
+        l2_to_l1_msg_hashes,
+    })
 }
 
 // ---------------------------------------------------------------------------
@@ -292,56 +390,47 @@ const MAX_RETRIES: usize = 2;
 
 /// Retry a fallible operation on transient sandbox errors.
 fn with_retry<T>(label: &str, f: impl Fn() -> anyhow::Result<T>) -> anyhow::Result<T> {
-    for attempt in 0..=MAX_RETRIES {
+    let mut attempt = 0;
+    loop {
         match f() {
             Ok(v) => return Ok(v),
             Err(e) if attempt < MAX_RETRIES && is_transient_error(&e) => {
+                attempt += 1;
                 log::warn!(
-                    "Transient error on {label} (attempt {}/{}): {e}, retrying...",
-                    attempt + 1,
-                    MAX_RETRIES
+                    "Transient error on {label} (attempt {attempt}/{MAX_RETRIES}): {e}, retrying..."
                 );
                 std::thread::sleep(Duration::from_secs(2));
             }
             Err(e) => return Err(e),
         }
     }
-    unreachable!()
 }
 
 // ---------------------------------------------------------------------------
 // Parsing helpers
 // ---------------------------------------------------------------------------
 
+fn capture_u128(caps: &regex::Captures, i: usize) -> u128 {
+    caps.get(i)
+        .unwrap()
+        .as_str()
+        .parse()
+        .expect("matched digits should parse as u128")
+}
+
 /// Parse "Simulation result:  12345n" -> Some(12345)
 pub fn parse_simulation_result(stdout: &str) -> Option<u128> {
-    RE_SINGLE.captures(stdout).map(|caps| {
-        caps.get(1)
-            .unwrap()
-            .as_str()
-            .parse::<u128>()
-            .expect("matched digits should parse as u128")
-    })
+    RE_SINGLE
+        .captures(stdout)
+        .map(|caps| capture_u128(&caps, 1))
 }
 
 /// Parse "Simulation result:  [12345n, 67890n]" -> Some([12345, 67890])
 /// Uses (?s) so \s matches newlines (sandbox wraps long arrays across lines).
 pub fn parse_simulation_result_pair(stdout: &str) -> Option<[u128; 2]> {
-    RE_PAIR.captures(stdout).map(|caps| {
-        let a = caps
-            .get(1)
-            .unwrap()
-            .as_str()
-            .parse::<u128>()
-            .expect("matched digits should parse as u128");
-        let b = caps
-            .get(2)
-            .unwrap()
-            .as_str()
-            .parse::<u128>()
-            .expect("matched digits should parse as u128");
-        [a, b]
-    })
+    RE_PAIR
+        .captures(stdout)
+        .map(|caps| [capture_u128(&caps, 1), capture_u128(&caps, 2)])
 }
 
 #[cfg(test)]

--- a/noir-projects/protocol-fuzzer/wallet-bridge.mjs
+++ b/noir-projects/protocol-fuzzer/wallet-bridge.mjs
@@ -23,13 +23,18 @@ const DATA_DIR = process.env.WALLET_DATA_DIRECTORY || join(homedir(), '.aztec/wa
 const { createAztecNodeClient } = await import('@aztec/aztec.js/node');
 const { AztecAddress } = await import('@aztec/aztec.js/addresses');
 const { openStoreAt } = await import('@aztec/kv-store/lmdb-v2');
+const { TxHash } = await import('@aztec/stdlib/tx');
+const { Fr } = await import('@aztec/foundation/curves/bn254');
+const { EthAddress } = await import('@aztec/foundation/eth-address');
+const { computeSiloedPrivateLogFirstField, computeL2ToL1MessageHash } = await import('@aztec/stdlib/hash');
+const { SiloedTag } = await import('@aztec/stdlib/logs');
 
 // Auto-detect CLI path: try container path, then common local locations.
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const candidates = [
-  '/usr/src/yarn-project/cli-wallet/dest',                  // nightly container
-  resolve(__dirname, 'cli-wallet/dest'),                     // symlinked into yarn-project/
-  resolve(__dirname, '../../yarn-project/cli-wallet/dest'),  // original location in protocol-fuzzer/
+  '/usr/src/yarn-project/cli-wallet/dest', // nightly container
+  resolve(__dirname, 'cli-wallet/dest'), // symlinked into yarn-project/
+  resolve(__dirname, '../../yarn-project/cli-wallet/dest'), // original location in protocol-fuzzer/
 ];
 const CLI = candidates.find(p => existsSync(p));
 if (!CLI) throw new Error('Cannot find cli-wallet/dest in any known location');
@@ -41,6 +46,10 @@ const { simulate } = await import(`${CLI}/cmds/simulate.js`);
 const { deploy } = await import(`${CLI}/cmds/deploy.js`);
 
 // Wallet -- lazy-initialized on first request so --prove can be forwarded.
+// Only /import-test-accounts passes `prove` through; /deploy and /execute
+// rely on the wallet already existing with the right prover setting, so the
+// client must call /import-test-accounts first (the Rust fuzzer does this in
+// `new_system`).
 const noop = () => {};
 const node = createAztecNodeClient(NODE_URL);
 const db = WalletDB.getInstance();
@@ -68,7 +77,10 @@ async function capturing(operation) {
 
 const feeOpts = {
   estimateOnly: false,
-  toUserFeeOptions: async () => ({ paymentMethod: undefined, gasSettings: undefined }),
+  toUserFeeOptions: async () => ({
+    paymentMethod: undefined,
+    gasSettings: undefined,
+  }),
 };
 
 // Handlers -- each receives the parsed JSON body and returns a result object.
@@ -85,20 +97,25 @@ const handlers = {
     const w = await ensureWallet();
     const { result: address, stdout } = await capturing(log =>
       deploy(
-        w, node, AztecAddress.fromString(from), artifact,
-        false,                                  /* json */
-        undefined,                              /* publicKeys */
-        Array.isArray(args) ? args : [],        /* args */
-        undefined,                              /* salt */
-        initMethod ?? 'constructor',            /* init */
-        false,                                  /* skipInstancePublication */
-        false,                                  /* skipClassPublication */
-        false,                                  /* skipInitialization */
-        true,                                   /* wait */
-        feeOpts,                                  /* fee */
-        'mined',                                /* waitForStatus */
-        false, 120,                             /* verbose, timeout */
-        { debug: noop, error: noop }, log,      /* debugLogger, log */
+        w,
+        node,
+        AztecAddress.fromString(from),
+        artifact,
+        false /* json */,
+        undefined /* publicKeys */,
+        Array.isArray(args) ? args : [] /* args */,
+        undefined /* salt */,
+        initMethod ?? 'constructor' /* init */,
+        false /* skipInstancePublication */,
+        false /* skipClassPublication */,
+        false /* skipInitialization */,
+        true /* wait */,
+        feeOpts /* fee */,
+        'mined' /* waitForStatus */,
+        false,
+        120 /* verbose, timeout */,
+        { debug: noop, error: noop },
+        log /* debugLogger, log */,
       ),
     );
     return { ok: true, address: address.toString(), stdout };
@@ -114,7 +131,55 @@ const handlers = {
         ? send(w, node, sender, method, callArgs, artifact, target, true, false, feeOpts, [], 'mined', false, log)
         : simulate(w, node, sender, method, callArgs, artifact, target, feeOpts, [], false, log),
     );
-    return { ok: true, stdout };
+    const result = { ok: true, stdout };
+
+    // For sends, extract TxEffect data for verification in the fuzzer.
+    if (verb === 'send') {
+      const hashMatch = stdout.match(/Transaction hash:\s+(0x[a-f0-9]+)/i);
+      if (hashMatch) {
+        try {
+          const effect = await node.getTxEffect(TxHash.fromString(hashMatch[1]));
+          if (effect) {
+            const d = effect.data;
+            result.txEffects = {
+              l2ToL1Msgs: d.l2ToL1Msgs.filter(m => !m.isZero()).map(m => m.toBigInt().toString()),
+            };
+          }
+        } catch (err) {
+          console.warn('Failed to fetch TxEffect:', err.message);
+        }
+      }
+    }
+
+    return result;
+  },
+
+  '/query-private-logs': async ({ contract, rawTag }) => {
+    const contractAddr = AztecAddress.fromString(contract);
+    const tagFr = new Fr(BigInt(rawTag));
+    const siloedFr = await computeSiloedPrivateLogFirstField(contractAddr, tagFr);
+    const siloedTag = new SiloedTag(siloedFr);
+
+    const results = await node.getPrivateLogsByTags([siloedTag]);
+    const logs = (results[0] || []).map(log => ({
+      logData: log.logData.map(f => f.toBigInt().toString()),
+    }));
+
+    return { ok: true, siloedTag: siloedFr.toBigInt().toString(), logs };
+  },
+
+  '/compute-l2-to-l1-hash': async ({ l2Sender, l1Recipient, content }) => {
+    const chainId = new Fr(await node.getChainId());
+    const rollupVersion = new Fr(await node.getVersion());
+    const hash = computeL2ToL1MessageHash({
+      l2Sender: AztecAddress.fromString(l2Sender),
+      l1Recipient: EthAddress.fromField(new Fr(BigInt(l1Recipient))),
+      content: new Fr(BigInt(content)),
+      rollupVersion,
+      chainId,
+    });
+
+    return { ok: true, hash: hash.toBigInt().toString() };
   },
 };
 
@@ -123,7 +188,7 @@ const handlers = {
 function readBody(req) {
   return new Promise(resolve => {
     let data = '';
-    req.on('data', chunk => data += chunk);
+    req.on('data', chunk => (data += chunk));
     req.on('end', () => resolve(data));
   });
 }


### PR DESCRIPTION
Expand side effect contract and fuzzer machine with new operations: L2-to-L1 messages, private logs, key validation, public teardown, exercised directly and via a parent forwarding contract. Also, some refactoring and comment fixes.

Last known nightly sandbox bumped up, several 100-step runs done for testing on both machines (~73s/run for token, ~163s/run for side effect currently).