### PR TITLE
fix(pxe): sync target contract before cross-contract utility call

### DIFF
--- a/noir-projects/noir-contracts/contracts/test/nested_utility_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/nested_utility_contract/src/main.nr
@@ -3,12 +3,23 @@
 
 use aztec::macros::aztec;
 
+mod pow_note;
 mod test;
 
 #[aztec]
 pub contract NestedUtility {
-    use aztec::macros::functions::external;
-    use aztec::protocol::address::AztecAddress;
+    use aztec::macros::{functions::external, storage::storage};
+    use aztec::{
+        messages::message_delivery::MessageDelivery,
+        protocol::address::AztecAddress,
+        state_vars::{Owned, PrivateMutable},
+    };
+    use crate::pow_note::PowNote;
+
+    #[storage]
+    struct Storage<Context> {
+        pow_args: Owned<PrivateMutable<PowNote, Context>, Context>,
+    }
 
     #[external("utility")]
     unconstrained fn pow_utility(x: Field, n: u32) -> Field {
@@ -22,6 +33,31 @@ pub contract NestedUtility {
     #[external("utility")]
     unconstrained fn delegate_pow_utility(target: AztecAddress, x: Field, n: u32) -> Field {
         self.call(NestedUtility::at(target).pow_utility(x, n))
+    }
+
+    /// Stores the base and exponent for pow in a private note.
+    #[external("private")]
+    fn set_pow_args(x: Field, n: Field) {
+        let owner = self.msg_sender();
+        self.storage.pow_args.at(owner).initialize_or_replace(|_| PowNote { x, n }).deliver(
+            MessageDelivery.ONCHAIN_CONSTRAINED,
+        );
+    }
+
+    /// Reads x and n from storage and computes x^n.
+    #[external("utility")]
+    unconstrained fn pow_from_storage(owner: AztecAddress) -> Field {
+        let note = self.storage.pow_args.at(owner).view_note();
+        self.call_self.pow_utility(note.x, note.n as u32)
+    }
+
+    /// Cross-contract version: calls pow_from_storage on the target contract.
+    #[external("utility")]
+    unconstrained fn delegate_pow_from_storage(
+        target: AztecAddress,
+        owner: AztecAddress,
+    ) -> Field {
+        self.call(NestedUtility::at(target).pow_from_storage(owner))
     }
 
     #[external("private")]

--- a/noir-projects/noir-contracts/contracts/test/nested_utility_contract/src/pow_note.nr
+++ b/noir-projects/noir-contracts/contracts/test/nested_utility_contract/src/pow_note.nr
@@ -1,0 +1,8 @@
+use aztec::{macros::notes::note, protocol::traits::{Deserialize, Packable, Serialize}};
+
+#[derive(Deserialize, Eq, Packable, Serialize)]
+#[note]
+pub struct PowNote {
+    pub x: Field,
+    pub n: Field,
+}

--- a/yarn-project/end-to-end/src/e2e_nested_utility_calls.test.ts
+++ b/yarn-project/end-to-end/src/e2e_nested_utility_calls.test.ts
@@ -153,4 +153,18 @@ describe('authorizeUtilityCall hook', () => {
       callerContext: 'private',
     });
   });
+
+  it('syncs target contract notes on cross-contract utility call', async () => {
+    hookAllows = true;
+
+    // Store x=2, n=10 as private notes on contract B.
+    await contractB.methods.set_pow_args(2n, 10n).send({ from: defaultAccountAddress });
+
+    // Cross-contract call from A → B: B must be synced before the nested utility call
+    // so that B's notes (set above) are discovered.
+    const { result: crossContractResult } = await contractA.methods
+      .delegate_pow_from_storage(contractB.address, defaultAccountAddress)
+      .simulate({ from: defaultAccountAddress });
+    expect(crossContractResult).toEqual(2n ** 10n);
+  });
 });

--- a/yarn-project/pxe/src/contract_function_simulator/contract_function_simulator.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/contract_function_simulator.ts
@@ -337,6 +337,10 @@ export class ContractFunctionSimulator {
       throw new Error(`Cannot run ${entryPointArtifact.functionType} function as utility`);
     }
 
+    const utilityExecutor = async (syncCall: FunctionCall, execScopes: AztecAddress[]) => {
+      await this.runUtility(syncCall, [], anchorBlockHeader, execScopes, jobId);
+    };
+
     const oracle = new UtilityExecutionOracle({
       contractAddress: call.to,
       authWitnesses: authwits,
@@ -358,6 +362,7 @@ export class ContractFunctionSimulator {
       scopes,
       simulator: this.simulator,
       hooks: this.hooks,
+      utilityExecutor,
     });
 
     try {

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/oracle_version_is_checked.test.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/oracle_version_is_checked.test.ts
@@ -214,6 +214,7 @@ describe('Oracle Version Check test suite', () => {
         scopes: [],
         l2TipsStore,
         simulator,
+        utilityExecutor: () => Promise.resolve(),
       });
     });
 

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution_oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution_oracle.ts
@@ -6,7 +6,6 @@ import { toACVMWitness } from '@aztec/simulator/client';
 import {
   type FunctionAbi,
   type FunctionArtifact,
-  type FunctionCall,
   FunctionSelector,
   type NoteSelector,
   countArgumentsSize,
@@ -41,8 +40,6 @@ export type PrivateExecutionOracleArgs = Omit<UtilityExecutionOracleArgs, 'contr
   argsHash: Fr;
   txContext: TxContext;
   callContext: CallContext;
-  /** Needed to trigger contract synchronization before nested calls */
-  utilityExecutor: (call: FunctionCall, scopes: AztecAddress[]) => Promise<void>;
   executionCache: HashedValuesCache;
   noteCache: ExecutionNoteCache;
   taggingIndexCache: ExecutionTaggingIndexCache;
@@ -74,7 +71,6 @@ export class PrivateExecutionOracle extends UtilityExecutionOracle implements IP
   private readonly argsHash: Fr;
   private readonly txContext: TxContext;
   private readonly callContext: CallContext;
-  private readonly utilityExecutor: (call: FunctionCall, scopes: AztecAddress[]) => Promise<void>;
   private readonly executionCache: HashedValuesCache;
   private readonly noteCache: ExecutionNoteCache;
   private readonly taggingIndexCache: ExecutionTaggingIndexCache;
@@ -95,7 +91,6 @@ export class PrivateExecutionOracle extends UtilityExecutionOracle implements IP
     this.argsHash = args.argsHash;
     this.txContext = args.txContext;
     this.callContext = args.callContext;
-    this.utilityExecutor = args.utilityExecutor;
     this.executionCache = args.executionCache;
     this.noteCache = args.noteCache;
     this.taggingIndexCache = args.taggingIndexCache;

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution.test.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution.test.ts
@@ -35,7 +35,7 @@ import type { RecipientTaggingStore } from '../../storage/tagging_store/recipien
 import type { SenderAddressBookStore } from '../../storage/tagging_store/sender_address_book_store.js';
 import type { SenderTaggingStore } from '../../storage/tagging_store/sender_tagging_store.js';
 import { ContractFunctionSimulator } from '../contract_function_simulator.js';
-import { UtilityExecutionOracle } from './utility_execution_oracle.js';
+import { UtilityExecutionOracle, type UtilityExecutionOracleArgs } from './utility_execution_oracle.js';
 
 describe('Utility Execution test suite', () => {
   const simulator = new WASMSimulator();
@@ -328,27 +328,7 @@ describe('Utility Execution test suite', () => {
 
       scope = await AztecAddress.random();
 
-      utilityExecutionOracle = new UtilityExecutionOracle({
-        contractAddress,
-        authWitnesses: [],
-        capsules: [],
-        anchorBlockHeader,
-        contractStore,
-        noteStore,
-        keyStore,
-        addressStore,
-        aztecNode,
-        recipientTaggingStore,
-        senderAddressBookStore,
-        capsuleService: new CapsuleService(capsuleStore, [scope]),
-        privateEventStore,
-        messageContextService,
-        contractSyncService,
-        jobId: 'test-job-id',
-        scopes: [scope],
-        l2TipsStore,
-        simulator,
-      });
+      utilityExecutionOracle = makeOracle({ contractAddress, scopes: [scope] });
     });
 
     describe('Respects synced block number', () => {
@@ -393,29 +373,13 @@ describe('Utility Execution test suite', () => {
         const transientScoped = [Fr.random()];
         const persisted = [Fr.random()];
 
-        utilityExecutionOracle = new UtilityExecutionOracle({
+        utilityExecutionOracle = makeOracle({
           contractAddress,
-          authWitnesses: [],
+          scopes: [scope],
           capsules: [
             new Capsule(contractAddress, slot, transientGlobal),
             new Capsule(contractAddress, slot, transientScoped, scope),
           ],
-          anchorBlockHeader,
-          contractStore,
-          noteStore,
-          keyStore,
-          addressStore,
-          aztecNode,
-          recipientTaggingStore,
-          senderAddressBookStore,
-          capsuleService: new CapsuleService(capsuleStore, [scope]),
-          privateEventStore,
-          messageContextService,
-          contractSyncService,
-          jobId: 'test-job-id',
-          scopes: [scope],
-          l2TipsStore,
-          simulator,
         });
 
         capsuleStore.getCapsule.mockResolvedValueOnce(persisted);
@@ -577,31 +541,8 @@ describe('Utility Execution test suite', () => {
         const contractAddressA = await AztecAddress.random();
         const contractAddressB = await AztecAddress.random();
 
-        const makeOracle = (addr: AztecAddress) =>
-          new UtilityExecutionOracle({
-            contractAddress: addr,
-            authWitnesses: [],
-            capsules: [],
-            anchorBlockHeader,
-            contractStore,
-            noteStore,
-            keyStore,
-            addressStore,
-            aztecNode,
-            recipientTaggingStore,
-            senderAddressBookStore,
-            capsuleService: new CapsuleService(capsuleStore, []),
-            privateEventStore,
-            messageContextService,
-            contractSyncService,
-            jobId: 'test-job-id',
-            scopes: [],
-            l2TipsStore,
-            simulator,
-          });
-
-        const oracleA = makeOracle(contractAddressA);
-        const oracleB = makeOracle(contractAddressB);
+        const oracleA = makeOracle({ contractAddress: contractAddressA });
+        const oracleB = makeOracle({ contractAddress: contractAddressB });
 
         const secretA = await oracleA.getSharedSecret(owner, ephPk, contractAddressA);
         const secretB = await oracleB.getSharedSecret(owner, ephPk, contractAddressB);
@@ -622,5 +563,32 @@ describe('Utility Execution test suite', () => {
         await expect(utilityExecutionOracle.getSharedSecret(owner, ephPk, wrongAddress)).rejects.toThrow(/expected/);
       });
     });
+
+    const makeOracle = (overrides?: Partial<UtilityExecutionOracleArgs>) => {
+      const scopes = overrides?.scopes ?? [];
+      return new UtilityExecutionOracle({
+        contractAddress,
+        authWitnesses: [],
+        capsules: [],
+        anchorBlockHeader,
+        contractStore,
+        noteStore,
+        keyStore,
+        addressStore,
+        aztecNode,
+        recipientTaggingStore,
+        senderAddressBookStore,
+        capsuleService: new CapsuleService(capsuleStore, scopes),
+        privateEventStore,
+        messageContextService,
+        contractSyncService,
+        jobId: 'test-job-id',
+        scopes,
+        l2TipsStore,
+        simulator,
+        utilityExecutor: () => Promise.resolve(),
+        ...overrides,
+      });
+    };
   });
 });

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
@@ -16,7 +16,7 @@ import {
   toACVMWitness,
   witnessMapToFields,
 } from '@aztec/simulator/client';
-import { FunctionSelector } from '@aztec/stdlib/abi';
+import { type FunctionCall, FunctionSelector } from '@aztec/stdlib/abi';
 import type { AuthWitness } from '@aztec/stdlib/auth-witness';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
 import { BlockHash, type L2TipsProvider } from '@aztec/stdlib/block';
@@ -81,6 +81,8 @@ export type UtilityExecutionOracleArgs = {
   scopes: AztecAddress[];
   simulator: CircuitSimulator;
   hooks?: ExecutionHooks;
+  /** Needed to trigger contract synchronization before nested cross-contract calls. */
+  utilityExecutor: (call: FunctionCall, scopes: AztecAddress[]) => Promise<void>;
 };
 
 /**
@@ -119,6 +121,7 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
   protected readonly scopes: AztecAddress[];
   protected readonly simulator: CircuitSimulator;
   protected readonly hooks: ExecutionHooks | undefined;
+  protected readonly utilityExecutor: (call: FunctionCall, scopes: AztecAddress[]) => Promise<void>;
 
   constructor(args: UtilityExecutionOracleArgs) {
     this.contractAddress = args.contractAddress;
@@ -142,6 +145,7 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
     this.scopes = args.scopes;
     this.simulator = args.simulator;
     this.hooks = args.hooks;
+    this.utilityExecutor = args.utilityExecutor;
   }
 
   public assertCompatibleOracleVersion(major: number, minor: number): void {
@@ -949,6 +953,15 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
             `See https://docs.aztec.network/errors/11`,
         );
       }
+
+      await this.contractSyncService.ensureContractSynced(
+        targetContractAddress,
+        functionSelector,
+        this.utilityExecutor,
+        this.anchorBlockHeader,
+        this.jobId,
+        this.scopes,
+      );
     }
 
     this.logger.debug(
@@ -976,6 +989,7 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
       scopes: this.scopes,
       simulator: this.simulator,
       hooks: this.hooks,
+      utilityExecutor: this.utilityExecutor,
       log: this.logger,
     });
 

--- a/yarn-project/txe/src/oracle/txe_oracle_top_level_context.ts
+++ b/yarn-project/txe/src/oracle/txe_oracle_top_level_context.ts
@@ -771,6 +771,9 @@ export class TXEOracleTopLevelContext implements IMiscOracle, ITxeExecutionOracl
     try {
       const anchorBlockHeader = await this.stateMachine.anchorBlockStore.getBlockHeader();
       const simulator = new WASMSimulator();
+      const utilityExecutor = async (syncCall: FunctionCall, execScopes: AztecAddress[]) => {
+        await this.executeUtilityCall(syncCall, execScopes, jobId);
+      };
       const oracle = new UtilityExecutionOracle({
         contractAddress: call.to,
         authWitnesses: [],
@@ -794,6 +797,7 @@ export class TXEOracleTopLevelContext implements IMiscOracle, ITxeExecutionOracl
         hooks: composeHooks({
           authorizeUtilityCall: this.buildAuthorizeUtilityCallHook('utility', authorizedUtilityCallTargets),
         }),
+        utilityExecutor,
       });
       const acirExecutionResult = await simulator
         .executeUserCircuit(toACVMWitness(0, call.args), entryPointArtifact, new Oracle(oracle).toACIRCallback())

--- a/yarn-project/txe/src/txe_session.ts
+++ b/yarn-project/txe/src/txe_session.ts
@@ -562,6 +562,7 @@ export class TXESession implements TXESessionStateHandler {
       jobId: this.currentJobId,
       scopes: await this.keyStore.getAccounts(),
       simulator: new WASMSimulator(),
+      utilityExecutor: this.utilityExecutorForContractSync(anchorBlockHeader),
     });
 
     this.state = { name: 'UTILITY' };
@@ -661,6 +662,7 @@ export class TXESession implements TXESessionStateHandler {
           jobId: this.currentJobId,
           scopes,
           simulator,
+          utilityExecutor: this.utilityExecutorForContractSync(anchorBlock),
         });
         await simulator
           .executeUserCircuit(toACVMWitness(0, call.args), entryPointArtifact, new Oracle(oracle).toACIRCallback())


### PR DESCRIPTION
## Summary

PR #22822 added support for cross-contract utility calls, but neglected to sync the target contract's private state before dispatching the call. As a result, the callee may observe stale state and return incorrect results.

The fix mirrors the private execution oracle path: after the authorization check in the utility execution oracle, run `ensureContractSynced` on the target contract before invoking the nested utility.

Fixes F-654