### PR TITLE
chore: better encrypted sqlite ergonomics

### DIFF
--- a/playground/vite.config.ts
+++ b/playground/vite.config.ts
@@ -45,7 +45,12 @@ const chunkSizeValidator = (limits: ChunkSizeLimit[]): Plugin => {
     configResolved(resolvedConfig) {
       config = resolvedConfig;
     },
-    closeBundle() {
+    // `writeBundle` is documented to fire AFTER the output bundle has been
+    // written to disk, whereas `closeBundle` (which we used previously) is the
+    // last hook to run and can fire before any chunks have been flushed in
+    // current vite/rollup versions — manifesting as ENOENT on `scandir 'dist'`
+    // for a build that otherwise transformed all modules cleanly.
+    writeBundle() {
       const outDir = this.meta?.watchMode ? null : 'dist';
       if (!outDir) return; // Skip in watch mode
 

--- a/yarn-project/kv-store/src/sqlite-opfs/encrypted_store.test.ts
+++ b/yarn-project/kv-store/src/sqlite-opfs/encrypted_store.test.ts
@@ -6,6 +6,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { mockLogger } from '../interfaces/utils.js';
+import { SqliteEncryptionError } from './errors.js';
 import { AztecSQLiteOPFSStore } from './store.js';
 
 function randomKey(): Uint8Array {
@@ -24,16 +25,16 @@ function cloneKey(k: Uint8Array): Uint8Array {
 describe('AztecSQLiteOPFSStore with encryption', () => {
   it('rejects keys that are not 32 bytes', async () => {
     const short = new Uint8Array(16);
-    await expect(AztecSQLiteOPFSStore.open(mockLogger, undefined, true, undefined, short)).rejects.toThrow(
-      /encryptionKey must be 32 bytes/,
-    );
+    const promise = AztecSQLiteOPFSStore.open(mockLogger, undefined, true, undefined, short);
+    await expect(promise).rejects.toThrow(SqliteEncryptionError);
+    await expect(promise).rejects.toMatchObject({ code: 'invalid_key_length' });
   });
 
   it('rejects encryption on ephemeral (:memory:) stores', async () => {
     const key = randomKey();
-    await expect(AztecSQLiteOPFSStore.open(mockLogger, undefined, true, undefined, key)).rejects.toThrow(
-      /not supported for ephemeral/,
-    );
+    const promise = AztecSQLiteOPFSStore.open(mockLogger, undefined, true, undefined, key);
+    await expect(promise).rejects.toThrow(SqliteEncryptionError);
+    await expect(promise).rejects.toMatchObject({ code: 'encryption_not_supported_for_ephemeral' });
   });
 
   it('round-trips values with the same key (persistent)', async () => {
@@ -51,7 +52,7 @@ describe('AztecSQLiteOPFSStore with encryption', () => {
     await b.delete();
   });
 
-  it('fails to open with the wrong key', async () => {
+  it('fails to open with the wrong key (throws SqliteEncryptionError, code=decrypt_failed)', async () => {
     const key = randomKey();
     const name = `test-wrong-${Date.now()}`;
     const dir = `/test-wrong-pool-${Date.now()}`;
@@ -59,17 +60,20 @@ describe('AztecSQLiteOPFSStore with encryption', () => {
     await a.openMap<string, string>('m').set('k1', 'v1');
     await a.close();
 
-    await expect(async () => {
-      const b = await AztecSQLiteOPFSStore.open(mockLogger, name, false, dir, randomKey());
-      await b.openMap<string, string>('m').getAsync('k1');
-      await b.close();
-    }).rejects.toThrow();
+    let caught: unknown;
+    try {
+      await AztecSQLiteOPFSStore.open(mockLogger, name, false, dir, randomKey());
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(SqliteEncryptionError);
+    expect((caught as SqliteEncryptionError).code).toBe('decrypt_failed');
 
     const c = await AztecSQLiteOPFSStore.open(mockLogger, name, false, dir, cloneKey(key));
     await c.delete();
   });
 
-  it('fails to open an encrypted DB without a key', async () => {
+  it('fails to open an encrypted DB without a key (throws SqliteEncryptionError, code=decrypt_failed)', async () => {
     const key = randomKey();
     const name = `test-nokey-${Date.now()}`;
     const dir = `/test-nokey-pool-${Date.now()}`;
@@ -77,11 +81,14 @@ describe('AztecSQLiteOPFSStore with encryption', () => {
     await a.openMap<string, string>('m').set('k1', 'v1');
     await a.close();
 
-    await expect(async () => {
-      const b = await AztecSQLiteOPFSStore.open(mockLogger, name, false, dir);
-      await b.openMap<string, string>('m').getAsync('k1');
-      await b.close();
-    }).rejects.toThrow();
+    let caught: unknown;
+    try {
+      await AztecSQLiteOPFSStore.open(mockLogger, name, false, dir);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(SqliteEncryptionError);
+    expect((caught as SqliteEncryptionError).code).toBe('decrypt_failed');
 
     const c = await AztecSQLiteOPFSStore.open(mockLogger, name, false, dir, cloneKey(key));
     await c.delete();

--- a/yarn-project/kv-store/src/sqlite-opfs/errors.ts
+++ b/yarn-project/kv-store/src/sqlite-opfs/errors.ts
@@ -1,0 +1,56 @@
+/**
+ * Typed error surface for sqlite3mc-backed page-level encryption failures.
+ *
+ * Three concrete failure modes are surfaced:
+ *
+ *   - `invalid_key_length`: caller-side pre-flight (key not 32 bytes).
+ *   - `encryption_not_supported_for_ephemeral`: caller-side pre-flight (encryption
+ *     was requested on an ephemeral `:memory:` store, which sqlite3mc does not
+ *     support).
+ *   - `decrypt_failed`: runtime failure raised when sqlite3mc cannot decode page 1
+ *     of an existing database. Covers both "wrong key supplied" and "no key
+ *     supplied to an encrypted DB"; sqlite3mc does not distinguish them on the
+ *     wire, so neither do we. If a future sqlite3mc release exposes finer-grained
+ *     codes, splitting `decrypt_failed` is a non-breaking change: existing
+ *     consumers matching `'decrypt_failed'` keep working, new consumers can match
+ *     finer codes.
+ */
+export type SqliteEncryptionErrorCode =
+  | 'invalid_key_length'
+  | 'encryption_not_supported_for_ephemeral'
+  | 'decrypt_failed';
+
+/**
+ * Error thrown by sqlite-opfs when an encryption operation fails. Replaces the
+ * previous pattern of consumers having to string-match sqlite3mc's "file is not
+ * a database" family of messages — match on `code` instead.
+ */
+export class SqliteEncryptionError extends Error {
+  readonly code: SqliteEncryptionErrorCode;
+
+  constructor(code: SqliteEncryptionErrorCode, message: string, opts?: { cause?: unknown }) {
+    super(message, opts?.cause !== undefined ? { cause: opts.cause } : undefined);
+    this.name = 'SqliteEncryptionError';
+    this.code = code;
+  }
+}
+
+/**
+ * Strings raised by sqlite3mc when page 1 cannot be decoded. Pinned by tests in
+ * encrypted_store.test.ts — if a future sqlite3mc bump changes them, those
+ * tests fail loudly rather than letting decrypt failures silently regress to a
+ * generic `Error`.
+ */
+const SQLITE3MC_DECRYPT_ERROR_PATTERNS: readonly RegExp[] = [
+  /file is not a database/i,
+  /file is encrypted or is not a database/i,
+];
+
+/**
+ * Returns `true` if `message` matches one of the known sqlite3mc decrypt-failure
+ * strings. Used by the SQLite worker to tag err responses so the main thread can
+ * re-hydrate them as {@link SqliteEncryptionError} with code `'decrypt_failed'`.
+ */
+export function isDecryptFailureMessage(message: string): boolean {
+  return SQLITE3MC_DECRYPT_ERROR_PATTERNS.some(p => p.test(message));
+}

--- a/yarn-project/kv-store/src/sqlite-opfs/errors.ts
+++ b/yarn-project/kv-store/src/sqlite-opfs/errors.ts
@@ -4,16 +4,10 @@
  * Three concrete failure modes are surfaced:
  *
  *   - `invalid_key_length`: caller-side pre-flight (key not 32 bytes).
- *   - `encryption_not_supported_for_ephemeral`: caller-side pre-flight (encryption
- *     was requested on an ephemeral `:memory:` store, which sqlite3mc does not
- *     support).
- *   - `decrypt_failed`: runtime failure raised when sqlite3mc cannot decode page 1
- *     of an existing database. Covers both "wrong key supplied" and "no key
- *     supplied to an encrypted DB"; sqlite3mc does not distinguish them on the
- *     wire, so neither do we. If a future sqlite3mc release exposes finer-grained
- *     codes, splitting `decrypt_failed` is a non-breaking change: existing
- *     consumers matching `'decrypt_failed'` keep working, new consumers can match
- *     finer codes.
+ *   - `encryption_not_supported_for_ephemeral`: caller-side pre-flight (encryption was requested on an ephemeral
+ *     `:memory:` store, which sqlite3mc does not support).
+ *   - `decrypt_failed`: runtime failure raised when sqlite3mc cannot decode page 1 of an existing database. Covers
+ *     both "wrong key supplied" and "no key supplied to an encrypted DB".
  */
 export type SqliteEncryptionErrorCode =
   | 'invalid_key_length'
@@ -21,10 +15,8 @@ export type SqliteEncryptionErrorCode =
   | 'decrypt_failed';
 
 /**
- * Error thrown by sqlite-opfs when an encryption operation fails. Replaces the
- * previous pattern of consumers having to string-match sqlite3mc's "file is not
- * a database" family of messages — match on `code` instead.
- */
+ * Error thrown by sqlite-opfs when an encryption operation fails.
+ **/
 export class SqliteEncryptionError extends Error {
   readonly code: SqliteEncryptionErrorCode;
 
@@ -36,11 +28,8 @@ export class SqliteEncryptionError extends Error {
 }
 
 /**
- * Strings raised by sqlite3mc when page 1 cannot be decoded. Pinned by tests in
- * encrypted_store.test.ts — if a future sqlite3mc bump changes them, those
- * tests fail loudly rather than letting decrypt failures silently regress to a
- * generic `Error`.
- */
+ * Strings raised by sqlite3mc when page 1 cannot be decoded.
+ **/
 const SQLITE3MC_DECRYPT_ERROR_PATTERNS: readonly RegExp[] = [
   /file is not a database/i,
   /file is encrypted or is not a database/i,
@@ -48,9 +37,8 @@ const SQLITE3MC_DECRYPT_ERROR_PATTERNS: readonly RegExp[] = [
 
 /**
  * Returns `true` if `message` matches one of the known sqlite3mc decrypt-failure
- * strings. Used by the SQLite worker to tag err responses so the main thread can
- * re-hydrate them as {@link SqliteEncryptionError} with code `'decrypt_failed'`.
- */
+ * strings.
+ **/
 export function isDecryptFailureMessage(message: string): boolean {
   return SQLITE3MC_DECRYPT_ERROR_PATTERNS.some(p => p.test(message));
 }

--- a/yarn-project/kv-store/src/sqlite-opfs/index.ts
+++ b/yarn-project/kv-store/src/sqlite-opfs/index.ts
@@ -5,6 +5,8 @@ import { initStoreForRollupAndSchemaVersion } from '../utils.js';
 import { AztecSQLiteOPFSStore } from './store.js';
 
 export { AztecSQLiteOPFSStore } from './store.js';
+export { SqliteEncryptionError } from './errors.js';
+export type { SqliteEncryptionErrorCode } from './errors.js';
 
 export async function createStore(
   name: string,

--- a/yarn-project/kv-store/src/sqlite-opfs/messages.ts
+++ b/yarn-project/kv-store/src/sqlite-opfs/messages.ts
@@ -3,6 +3,7 @@
  * All requests carry a unique `id`; responses echo the same id so the main thread
  * can resolve the right pending promise.
  */
+import type { SqliteEncryptionErrorCode } from './errors.js';
 
 /** Matches `@sqlite.org/sqlite-wasm`'s internal SqlValue type. Boolean is not a native SQLite type. */
 export type SqlValue = string | number | bigint | null | Uint8Array;
@@ -23,6 +24,16 @@ export type WorkerRequest =
 
 export type WorkerResponse =
   | { type: 'ok'; id: number; rows?: ResultRow[]; changes?: number; bytes?: Uint8Array }
-  | { type: 'err'; id: number; message: string };
+  | {
+      type: 'err';
+      id: number;
+      message: string;
+      /**
+       * Set when the worker detected an encryption-shaped failure. The main thread
+       * uses this to re-throw the error as a {@link SqliteEncryptionError} with the
+       * matching code. Absent on non-encryption failures (untyped paths preserved).
+       */
+      encryptionCode?: SqliteEncryptionErrorCode;
+    };
 
 export type WorkerRequestType = WorkerRequest['type'];

--- a/yarn-project/kv-store/src/sqlite-opfs/store.ts
+++ b/yarn-project/kv-store/src/sqlite-opfs/store.ts
@@ -10,6 +10,7 @@ import type { AztecAsyncSet } from '../interfaces/set.js';
 import type { AztecAsyncSingleton } from '../interfaces/singleton.js';
 import type { AztecAsyncKVStore } from '../interfaces/store.js';
 import { SQLiteOPFSAztecArray } from './array.js';
+import { SqliteEncryptionError } from './errors.js';
 import { SQLiteOPFSAztecMap } from './map.js';
 import type { ResultRow, SqlValue, WorkerRequest, WorkerResponse } from './messages.js';
 import { SQLiteOPFSAztecMultiMap } from './multi_map.js';
@@ -86,10 +87,16 @@ export class AztecSQLiteOPFSStore implements AztecAsyncKVStore {
     encryptionKey?: Uint8Array,
   ): Promise<AztecSQLiteOPFSStore> {
     if (encryptionKey !== undefined && encryptionKey.length !== 32) {
-      throw new Error(`encryptionKey must be 32 bytes (got ${encryptionKey.length})`);
+      throw new SqliteEncryptionError(
+        'invalid_key_length',
+        `encryptionKey must be 32 bytes (got ${encryptionKey.length})`,
+      );
     }
     if (encryptionKey !== undefined && ephemeral) {
-      throw new Error('encryptionKey is not supported for ephemeral (:memory:) stores');
+      throw new SqliteEncryptionError(
+        'encryption_not_supported_for_ephemeral',
+        'encryptionKey is not supported for ephemeral (:memory:) stores',
+      );
     }
     const dbName = name && !ephemeral ? name : `tmp-${globalThis.crypto.getRandomValues(new Uint8Array(8)).join('')}`;
     log.debug(
@@ -265,7 +272,14 @@ export class AztecSQLiteOPFSStore implements AztecAsyncKVStore {
       this.#pending.set(req.id, {
         resolve: resp => {
           if (resp.type === 'err') {
-            reject(new Error(resp.message));
+            // Re-hydrate encryption-shaped errors as the typed class so consumers
+            // can pattern-match on `instanceof SqliteEncryptionError`. Plain
+            // errors stay plain — the wire protocol only tags encryption paths.
+            if (resp.encryptionCode !== undefined) {
+              reject(new SqliteEncryptionError(resp.encryptionCode, resp.message));
+            } else {
+              reject(new Error(resp.message));
+            }
           } else {
             resolve(resp);
           }

--- a/yarn-project/kv-store/src/sqlite-opfs/worker.ts
+++ b/yarn-project/kv-store/src/sqlite-opfs/worker.ts
@@ -1,6 +1,7 @@
 /// <reference lib="webworker" />
 import sqlite3InitModule, { type Database, type SAHPoolUtil, type Sqlite3Static } from '@aztec/sqlite3mc-wasm';
 
+import { SqliteEncryptionError, type SqliteEncryptionErrorCode, isDecryptFailureMessage } from './errors.js';
 import type { ResultRow, SqlValue, WorkerRequest, WorkerResponse } from './messages.js';
 
 const SCHEMA_SQL = `
@@ -70,7 +71,10 @@ async function handleInit(
   sqlite3 ??= await sqlite3InitModule();
   const s = sqlite3;
   if (encryptionKey !== undefined && ephemeral) {
-    throw new Error('encryptionKey is not supported for ephemeral (:memory:) stores');
+    throw new SqliteEncryptionError(
+      'encryption_not_supported_for_ephemeral',
+      'encryptionKey is not supported for ephemeral (:memory:) stores',
+    );
   }
   if (ephemeral) {
     db = new s.oo1.DB(':memory:', 'c');
@@ -194,6 +198,34 @@ function respond(msg: WorkerResponse): void {
     }
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
-    respond({ type: 'err', id: req.id, message });
+    respond({ type: 'err', id: req.id, message, encryptionCode: detectEncryptionCode(req, err, message) });
   }
 };
+
+/**
+ * Maps a thrown error during request handling to a typed encryption code, so the
+ * main thread can re-hydrate it as a {@link SqliteEncryptionError}. Returns
+ * `undefined` for non-encryption errors (preserves the existing untyped path).
+ *
+ * Two sources:
+ *   - The error was already a `SqliteEncryptionError` (pre-flight throws inside
+ *     this worker — e.g. ephemeral + encryptionKey). Forward its code as-is.
+ *   - The error came from SQLite/sqlite3mc with a known decrypt-failure message
+ *     during an `init` request. Both "wrong key supplied" and "no key supplied
+ *     to an encrypted DB" surface as SQLITE_NOTADB ("file is not a database") —
+ *     we don't constrain on `req.encryptionKey` because the no-key-on-encrypted-DB
+ *     case is exactly when the caller most needs the typed signal.
+ */
+function detectEncryptionCode(
+  req: WorkerRequest,
+  err: unknown,
+  message: string,
+): SqliteEncryptionErrorCode | undefined {
+  if (err instanceof SqliteEncryptionError) {
+    return err.code;
+  }
+  if (req.type === 'init' && isDecryptFailureMessage(message)) {
+    return 'decrypt_failed';
+  }
+  return undefined;
+}

--- a/yarn-project/wallets/package.json
+++ b/yarn-project/wallets/package.json
@@ -14,6 +14,7 @@
         "default": "./dest/embedded/entrypoints/node.js"
       }
     },
+    "./embedded/store-encryption": "./dest/embedded/store_encryption.js",
     "./testing": "./dest/testing.js"
   },
   "scripts": {

--- a/yarn-project/wallets/src/embedded/entrypoints/browser.ts
+++ b/yarn-project/wallets/src/embedded/entrypoints/browser.ts
@@ -80,12 +80,9 @@ export type { EmbeddedWalletOptions, EmbeddedWalletPXEOptions } from '../embedde
 export { WalletDB } from '../wallet_db.js';
 export type { AccountType } from '../wallet_db.js';
 
-// At-rest encryption is browser-only (sqlite3mc requires Web Workers + OPFS),
-// so the helper is re-exported from this entrypoint only — `entrypoints/node.ts`
-// uses LMDB and does not expose it.
-export { EmbeddedWalletEncryptionError, openEncryptedEmbeddedStores } from '../store_encryption.js';
-export type {
-  EmbeddedStoreName,
-  OpenEncryptedEmbeddedStoresOptions,
-  OpenSqliteEncryptedStoreFn,
-} from '../store_encryption.js';
+// At-rest encryption helpers are intentionally NOT re-exported here. They live
+// on the `@aztec/wallets/embedded/store-encryption` sub-path so consumers
+// (and bundlers) of this entrypoint don't transitively pull in
+// `@aztec/kv-store/sqlite-opfs` and its `new Worker(new URL('./worker.js'))`
+// chain into `@aztec/sqlite3mc-wasm`. Apps that don't use encryption-at-rest
+// (e.g. the playground) should never see sqlite-opfs in their bundle.

--- a/yarn-project/wallets/src/embedded/entrypoints/browser.ts
+++ b/yarn-project/wallets/src/embedded/entrypoints/browser.ts
@@ -79,3 +79,13 @@ export { BrowserEmbeddedWallet as EmbeddedWallet };
 export type { EmbeddedWalletOptions, EmbeddedWalletPXEOptions } from '../embedded_wallet.js';
 export { WalletDB } from '../wallet_db.js';
 export type { AccountType } from '../wallet_db.js';
+
+// At-rest encryption is browser-only (sqlite3mc requires Web Workers + OPFS),
+// so the helper is re-exported from this entrypoint only — `entrypoints/node.ts`
+// uses LMDB and does not expose it.
+export { EmbeddedWalletEncryptionError, openEncryptedEmbeddedStores } from '../store_encryption.js';
+export type {
+  EmbeddedStoreName,
+  OpenEncryptedEmbeddedStoresOptions,
+  OpenSqliteEncryptedStoreFn,
+} from '../store_encryption.js';

--- a/yarn-project/wallets/src/embedded/store_encryption.test.ts
+++ b/yarn-project/wallets/src/embedded/store_encryption.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Tests for the two-store cleanup orchestration in
+ * {@link openEncryptedEmbeddedStores}. Uses the DI seam (`openStore`
+ * parameter) to inject controlled failures — sidesteps the need for a real
+ * `AztecSQLiteOPFSStore`, which requires browser-only Web Workers + OPFS.
+ */
+import type { Logger } from '@aztec/foundation/log';
+import type { AztecSQLiteOPFSStore } from '@aztec/kv-store/sqlite-opfs';
+import { SqliteEncryptionError } from '@aztec/kv-store/sqlite-opfs';
+
+import {
+  EmbeddedWalletEncryptionError,
+  type OpenSqliteEncryptedStoreFn,
+  openEncryptedEmbeddedStores,
+} from './store_encryption.js';
+
+const noopLogger = {
+  debug: () => {},
+  verbose: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  fatal: () => {},
+  trace: () => {},
+  createChild: () => noopLogger,
+  isLevelEnabled: () => false,
+  level: 'info',
+  module: '',
+} as unknown as Logger;
+
+/** Minimal mock store — only needs `close()` because that's all the orchestration touches. */
+function makeMockStore(): { store: AztecSQLiteOPFSStore; closeCalls: number } {
+  let closeCalls = 0;
+  const store = {
+    close: () => {
+      closeCalls++;
+      return Promise.resolve();
+    },
+  } as unknown as AztecSQLiteOPFSStore;
+  return {
+    store,
+    get closeCalls() {
+      return closeCalls;
+    },
+  };
+}
+
+function makeKeyProvider(): { getKey: () => Promise<Uint8Array>; callCount: number } {
+  let callCount = 0;
+  return {
+    getKey: () => {
+      callCount++;
+      return Promise.resolve(new Uint8Array(32));
+    },
+    get callCount() {
+      return callCount;
+    },
+  };
+}
+
+const config = {
+  pxe: { name: 'pxe_data', poolDirectory: '/pxe' },
+  wallet: { name: 'wallet_data', poolDirectory: '/wallet' },
+};
+
+describe('openEncryptedEmbeddedStores', () => {
+  it('returns both stores on the happy path', async () => {
+    const pxe = makeMockStore();
+    const wallet = makeMockStore();
+    const opens: string[] = [];
+    const openStore: OpenSqliteEncryptedStoreFn = (_log, name) => {
+      opens.push(name);
+      return Promise.resolve(name === 'pxe_data' ? pxe.store : wallet.store);
+    };
+
+    const keyProvider = makeKeyProvider();
+    const result = await openEncryptedEmbeddedStores(config, keyProvider.getKey, noopLogger, openStore);
+
+    expect(result.pxeStore).toBe(pxe.store);
+    expect(result.walletStore).toBe(wallet.store);
+    expect(opens).toEqual(['pxe_data', 'wallet_data']);
+    expect(keyProvider.callCount).toBe(2);
+    expect(pxe.closeCalls).toBe(0);
+  });
+
+  it('throws EmbeddedWalletEncryptionError({storeName:"pxe"}) when PXE decrypt fails (no cleanup needed)', async () => {
+    const wallet = makeMockStore();
+    let walletOpenAttempted = false;
+    const decryptError = new SqliteEncryptionError('decrypt_failed', 'file is not a database');
+    const openStore: OpenSqliteEncryptedStoreFn = (_log, name) => {
+      if (name === 'pxe_data') return Promise.reject(decryptError);
+      walletOpenAttempted = true;
+      return Promise.resolve(wallet.store);
+    };
+
+    let caught: unknown;
+    try {
+      await openEncryptedEmbeddedStores(config, makeKeyProvider().getKey, noopLogger, openStore);
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(EmbeddedWalletEncryptionError);
+    expect((caught as EmbeddedWalletEncryptionError).storeName).toBe('pxe');
+    expect((caught as EmbeddedWalletEncryptionError).cause).toBe(decryptError);
+    // Wallet open must NOT be attempted once PXE has failed — short-circuit.
+    expect(walletOpenAttempted).toBe(false);
+  });
+
+  it('closes PXE and throws EmbeddedWalletEncryptionError({storeName:"wallet"}) when wallet decrypt fails', async () => {
+    const pxe = makeMockStore();
+    const decryptError = new SqliteEncryptionError('decrypt_failed', 'file is not a database');
+    const openStore: OpenSqliteEncryptedStoreFn = (_log, name) =>
+      name === 'pxe_data' ? Promise.resolve(pxe.store) : Promise.reject(decryptError);
+
+    let caught: unknown;
+    try {
+      await openEncryptedEmbeddedStores(config, makeKeyProvider().getKey, noopLogger, openStore);
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(EmbeddedWalletEncryptionError);
+    expect((caught as EmbeddedWalletEncryptionError).storeName).toBe('wallet');
+    expect((caught as EmbeddedWalletEncryptionError).cause).toBe(decryptError);
+    expect(pxe.closeCalls).toBe(1);
+  });
+
+  it('does not wrap non-decrypt errors, but still cleans up PXE on wallet-open failure', async () => {
+    const pxe = makeMockStore();
+    const wallet = makeMockStore();
+    const otherError = new Error('disk full');
+    let walletAttempts = 0;
+    const openStore: OpenSqliteEncryptedStoreFn = (_log, name) => {
+      if (name === 'pxe_data') return Promise.resolve(pxe.store);
+      walletAttempts++;
+      // Use the side-effect to suppress the unused warning on `wallet` below.
+      void wallet;
+      return Promise.reject(otherError);
+    };
+
+    let caught: unknown;
+    try {
+      await openEncryptedEmbeddedStores(config, makeKeyProvider().getKey, noopLogger, openStore);
+    } catch (err) {
+      caught = err;
+    }
+
+    // The non-decrypt error propagates raw — no EmbeddedWalletEncryptionError wrap.
+    expect(caught).toBe(otherError);
+    expect(caught).not.toBeInstanceOf(EmbeddedWalletEncryptionError);
+    expect(walletAttempts).toBe(1);
+    // PXE cleanup still happens — the helper's responsibility is "no leaked
+    // resources after a failed open", not just "no leaked resources on decrypt".
+    expect(pxe.closeCalls).toBe(1);
+  });
+
+  it('swallows PXE.close() failures so the original error surfaces unobstructed', async () => {
+    const pxeStore = {
+      close: () => Promise.reject(new Error('worker already dead')),
+    } as unknown as AztecSQLiteOPFSStore;
+    const decryptError = new SqliteEncryptionError('decrypt_failed', 'file is not a database');
+    const openStore: OpenSqliteEncryptedStoreFn = (_log, name) =>
+      name === 'pxe_data' ? Promise.resolve(pxeStore) : Promise.reject(decryptError);
+
+    let caught: unknown;
+    try {
+      await openEncryptedEmbeddedStores(config, makeKeyProvider().getKey, noopLogger, openStore);
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(EmbeddedWalletEncryptionError);
+    expect((caught as EmbeddedWalletEncryptionError).cause).toBe(decryptError);
+  });
+
+  it('calls getEncryptionKey exactly twice (one per store), so a buffer-transfer-detached key is not reused', async () => {
+    const pxe = makeMockStore();
+    const wallet = makeMockStore();
+    const keyProvider = makeKeyProvider();
+    const openStore: OpenSqliteEncryptedStoreFn = (_log, name) =>
+      Promise.resolve(name === 'pxe_data' ? pxe.store : wallet.store);
+
+    await openEncryptedEmbeddedStores(config, keyProvider.getKey, noopLogger, openStore);
+
+    expect(keyProvider.callCount).toBe(2);
+  });
+});

--- a/yarn-project/wallets/src/embedded/store_encryption.test.ts
+++ b/yarn-project/wallets/src/embedded/store_encryption.test.ts
@@ -88,7 +88,9 @@ describe('openEncryptedEmbeddedStores', () => {
     let walletOpenAttempted = false;
     const decryptError = new SqliteEncryptionError('decrypt_failed', 'file is not a database');
     const openStore: OpenSqliteEncryptedStoreFn = (_log, name) => {
-      if (name === 'pxe_data') return Promise.reject(decryptError);
+      if (name === 'pxe_data') {
+        return Promise.reject(decryptError);
+      }
       walletOpenAttempted = true;
       return Promise.resolve(wallet.store);
     };
@@ -132,7 +134,9 @@ describe('openEncryptedEmbeddedStores', () => {
     const otherError = new Error('disk full');
     let walletAttempts = 0;
     const openStore: OpenSqliteEncryptedStoreFn = (_log, name) => {
-      if (name === 'pxe_data') return Promise.resolve(pxe.store);
+      if (name === 'pxe_data') {
+        return Promise.resolve(pxe.store);
+      }
       walletAttempts++;
       // Use the side-effect to suppress the unused warning on `wallet` below.
       void wallet;

--- a/yarn-project/wallets/src/embedded/store_encryption.ts
+++ b/yarn-project/wallets/src/embedded/store_encryption.ts
@@ -1,0 +1,123 @@
+/**
+ * Wallet-layer helpers for opening the embedded wallet's two encrypted stores
+ * (PXE state + walletDB) as a cohesive unit.
+ *
+ * Sits on top of `@aztec/kv-store/sqlite-opfs`'s typed `SqliteEncryptionError`
+ * (which knows about the cipher but not about wallet topology) and adds:
+ *
+ *   - `storeName: 'pxe' | 'wallet'` — telling callers WHICH store failed, which
+ *     matters for recovery UX (PXE state is more disposable than walletDB).
+ *   - Cleanup-on-second-failure — when the wallet store fails to open, the
+ *     already-opened PXE store is closed before the error surfaces, so callers
+ *     don't leak the SAH Pool's OPFS lock.
+ *
+ * Without this helper, every consumer reinvents the same two-store dance.
+ */
+import type { Logger } from '@aztec/foundation/log';
+import { AztecSQLiteOPFSStore, SqliteEncryptionError } from '@aztec/kv-store/sqlite-opfs';
+
+/** Which of the embedded wallet's two stores failed to open. */
+export type EmbeddedStoreName = 'pxe' | 'wallet';
+
+/**
+ * Thrown by {@link openEncryptedEmbeddedStores} when one of the two stores
+ * cannot be decrypted with the supplied key. The original
+ * {@link SqliteEncryptionError} is preserved as `cause`. Use the `storeName`
+ * field to drive recovery decisions:
+ *
+ *   - `'pxe'`  — typically safe to wipe-and-rebuild from L1 events.
+ *   - `'wallet'` — wiping discards the user's account/sender list; prompt the
+ *     user before doing so.
+ */
+export class EmbeddedWalletEncryptionError extends Error {
+  readonly storeName: EmbeddedStoreName;
+
+  constructor(storeName: EmbeddedStoreName, opts: { cause: SqliteEncryptionError }) {
+    super(`Embedded wallet '${storeName}' store could not be decrypted with the provided key`, { cause: opts.cause });
+    this.name = 'EmbeddedWalletEncryptionError';
+    this.storeName = storeName;
+  }
+}
+
+/** Configuration for {@link openEncryptedEmbeddedStores}. */
+export interface OpenEncryptedEmbeddedStoresOptions {
+  pxe: { name: string; poolDirectory?: string };
+  wallet: { name: string; poolDirectory?: string };
+}
+
+/**
+ * Internal seam for tests to inject a fake store opener. Defaults to
+ * `AztecSQLiteOPFSStore.open`. Not part of the public API.
+ *
+ * @internal
+ */
+export type OpenSqliteEncryptedStoreFn = (
+  log: Logger,
+  name: string,
+  poolDirectory: string | undefined,
+  encryptionKey: Uint8Array,
+) => Promise<AztecSQLiteOPFSStore>;
+
+const defaultOpenStore: OpenSqliteEncryptedStoreFn = (log, name, poolDirectory, encryptionKey) =>
+  AztecSQLiteOPFSStore.open(log, name, false, poolDirectory, encryptionKey);
+
+/**
+ * Opens the PXE and wallet stores in sequence, both encrypted with keys
+ * obtained from `getEncryptionKey`. The callback is invoked once per store
+ * (twice total per call) because `AztecSQLiteOPFSStore.open` *transfers* the
+ * key buffer to its worker — a single buffer would detach between the two
+ * opens.
+ *
+ * Failure modes:
+ *
+ *   - PXE store fails to decrypt → throws
+ *     `EmbeddedWalletEncryptionError({ storeName: 'pxe', cause })`. No cleanup
+ *     needed (nothing was opened).
+ *   - Wallet store fails to decrypt → closes the already-opened PXE store
+ *     (best-effort), then throws
+ *     `EmbeddedWalletEncryptionError({ storeName: 'wallet', cause })`.
+ *   - Any non-decrypt error during the wallet open → still closes PXE, then
+ *     re-throws the original error unwrapped (preserves callers' existing
+ *     untyped error handling for non-encryption faults).
+ *
+ * @param config           - Per-store name/poolDirectory.
+ * @param getEncryptionKey - Returns a fresh 32-byte key per call (the buffer
+ *                           detaches on transfer, so each call must allocate).
+ * @param log              - Logger for both stores.
+ * @param openStore        - Internal test seam. Do not pass in production code.
+ */
+export async function openEncryptedEmbeddedStores(
+  config: OpenEncryptedEmbeddedStoresOptions,
+  getEncryptionKey: () => Promise<Uint8Array>,
+  log: Logger,
+  openStore: OpenSqliteEncryptedStoreFn = defaultOpenStore,
+): Promise<{ pxeStore: AztecSQLiteOPFSStore; walletStore: AztecSQLiteOPFSStore }> {
+  const pxeStore = await openOne('pxe', config.pxe, getEncryptionKey, log, openStore);
+  try {
+    const walletStore = await openOne('wallet', config.wallet, getEncryptionKey, log, openStore);
+    return { pxeStore, walletStore };
+  } catch (err) {
+    // Cleanup is best-effort — if close() itself throws (e.g. worker already
+    // dead), swallow it so the original error surfaces unobstructed.
+    await pxeStore.close().catch(() => {});
+    throw err;
+  }
+}
+
+async function openOne(
+  storeName: EmbeddedStoreName,
+  { name, poolDirectory }: { name: string; poolDirectory?: string },
+  getEncryptionKey: () => Promise<Uint8Array>,
+  log: Logger,
+  openStore: OpenSqliteEncryptedStoreFn,
+): Promise<AztecSQLiteOPFSStore> {
+  const key = await getEncryptionKey();
+  try {
+    return await openStore(log, name, poolDirectory, key);
+  } catch (err) {
+    if (err instanceof SqliteEncryptionError && err.code === 'decrypt_failed') {
+      throw new EmbeddedWalletEncryptionError(storeName, { cause: err });
+    }
+    throw err;
+  }
+}

--- a/yarn-project/wallets/src/embedded/store_encryption.ts
+++ b/yarn-project/wallets/src/embedded/store_encryption.ts
@@ -1,17 +1,11 @@
 /**
- * Wallet-layer helpers for opening the embedded wallet's two encrypted stores
- * (PXE state + walletDB) as a cohesive unit.
+ * Wallet-layer helpers for opening the embedded wallet's two encrypted stores (PXE + walletDB) as a cohesive unit.
  *
- * Sits on top of `@aztec/kv-store/sqlite-opfs`'s typed `SqliteEncryptionError`
- * (which knows about the cipher but not about wallet topology) and adds:
+ * Sits on top of `@aztec/kv-store/sqlite-opfs`'s typed `SqliteEncryptionError` and adds:
  *
- *   - `storeName: 'pxe' | 'wallet'` — telling callers WHICH store failed, which
- *     matters for recovery UX (PXE state is more disposable than walletDB).
- *   - Cleanup-on-second-failure — when the wallet store fails to open, the
- *     already-opened PXE store is closed before the error surfaces, so callers
- *     don't leak the SAH Pool's OPFS lock.
- *
- * Without this helper, every consumer reinvents the same two-store dance.
+ *   - `storeName: 'pxe' | 'wallet'`, telling callers WHICH store failed.
+ *   - Cleanup: when the wallet store fails to open, ensures the already-opened PXE store is closed before the error
+ *     surfaces, so callers don't leak the SAH Pool's OPFS lock.
  */
 import type { Logger } from '@aztec/foundation/log';
 import { AztecSQLiteOPFSStore, SqliteEncryptionError } from '@aztec/kv-store/sqlite-opfs';
@@ -20,14 +14,8 @@ import { AztecSQLiteOPFSStore, SqliteEncryptionError } from '@aztec/kv-store/sql
 export type EmbeddedStoreName = 'pxe' | 'wallet';
 
 /**
- * Thrown by {@link openEncryptedEmbeddedStores} when one of the two stores
- * cannot be decrypted with the supplied key. The original
- * {@link SqliteEncryptionError} is preserved as `cause`. Use the `storeName`
- * field to drive recovery decisions:
- *
- *   - `'pxe'`  — typically safe to wipe-and-rebuild from L1 events.
- *   - `'wallet'` — wiping discards the user's account/sender list; prompt the
- *     user before doing so.
+ * Thrown by {@link openEncryptedEmbeddedStores} when one of the two stores cannot be decrypted with the supplied
+ * key. The original {@link SqliteEncryptionError} is preserved as `cause`.
  */
 export class EmbeddedWalletEncryptionError extends Error {
   readonly storeName: EmbeddedStoreName;
@@ -46,8 +34,8 @@ export interface OpenEncryptedEmbeddedStoresOptions {
 }
 
 /**
- * Internal seam for tests to inject a fake store opener. Defaults to
- * `AztecSQLiteOPFSStore.open`. Not part of the public API.
+ * Internal seam for tests to inject a fake store opener. Defaults to `AztecSQLiteOPFSStore.open`. Not part of the
+ * public API.
  *
  * @internal
  */
@@ -62,23 +50,19 @@ const defaultOpenStore: OpenSqliteEncryptedStoreFn = (log, name, poolDirectory, 
   AztecSQLiteOPFSStore.open(log, name, false, poolDirectory, encryptionKey);
 
 /**
- * Opens the PXE and wallet stores in sequence, both encrypted with keys
- * obtained from `getEncryptionKey`. The callback is invoked once per store
- * (twice total per call) because `AztecSQLiteOPFSStore.open` *transfers* the
- * key buffer to its worker — a single buffer would detach between the two
- * opens.
+ * Opens the PXE and wallet stores in sequence, both encrypted with keys obtained from `getEncryptionKey`.
+ *
+ * The callback is invoked once per store (twice total per call) because `AztecSQLiteOPFSStore.open` *transfers*
+ * the key buffer to its worker. A single buffer would detach between the two opens.
  *
  * Failure modes:
  *
- *   - PXE store fails to decrypt → throws
- *     `EmbeddedWalletEncryptionError({ storeName: 'pxe', cause })`. No cleanup
+ *   - PXE store fails to decrypt → throws `EmbeddedWalletEncryptionError({ storeName: 'pxe', cause })`. No cleanup
  *     needed (nothing was opened).
- *   - Wallet store fails to decrypt → closes the already-opened PXE store
- *     (best-effort), then throws
+ *   - Wallet store fails to decrypt → closes the already-opened PXE store then throws
  *     `EmbeddedWalletEncryptionError({ storeName: 'wallet', cause })`.
- *   - Any non-decrypt error during the wallet open → still closes PXE, then
- *     re-throws the original error unwrapped (preserves callers' existing
- *     untyped error handling for non-encryption faults).
+ *   - Any non-decrypt error during the wallet open → still closes PXE, then re-throws the original error unwrapped
+ *     (preserves callers' existing untyped error handling for non-encryption faults).
  *
  * @param config           - Per-store name/poolDirectory.
  * @param getEncryptionKey - Returns a fresh 32-byte key per call (the buffer
@@ -92,19 +76,19 @@ export async function openEncryptedEmbeddedStores(
   log: Logger,
   openStore: OpenSqliteEncryptedStoreFn = defaultOpenStore,
 ): Promise<{ pxeStore: AztecSQLiteOPFSStore; walletStore: AztecSQLiteOPFSStore }> {
-  const pxeStore = await openOne('pxe', config.pxe, getEncryptionKey, log, openStore);
+  const pxeStore = await openOneStore('pxe', config.pxe, getEncryptionKey, log, openStore);
   try {
-    const walletStore = await openOne('wallet', config.wallet, getEncryptionKey, log, openStore);
+    const walletStore = await openOneStore('wallet', config.wallet, getEncryptionKey, log, openStore);
     return { pxeStore, walletStore };
   } catch (err) {
-    // Cleanup is best-effort — if close() itself throws (e.g. worker already
-    // dead), swallow it so the original error surfaces unobstructed.
+    // Cleanup is best-effort — if close() itself throws (e.g. worker already dead), swallow it so the original error
+    // surfaces unobstructed.
     await pxeStore.close().catch(() => {});
     throw err;
   }
 }
 
-async function openOne(
+async function openOneStore(
   storeName: EmbeddedStoreName,
   { name, poolDirectory }: { name: string; poolDirectory?: string },
   getEncryptionKey: () => Promise<Uint8Array>,


### PR DESCRIPTION
Adds some structure to typical decryption errors, and a couple of convenience helpers for orchestrating encrypted store management from embedded wallet, so that the most basic usage is straightforward and downstream projects don't need to rewrite the same lines over and over. 