### PR TITLE
chore(ci): restore OIDC in ci-release-publish (revert #23192)

### DIFF
--- a/.github/workflows/ci3.yml
+++ b/.github/workflows/ci3.yml
@@ -499,6 +499,9 @@ jobs:
   ci-release-publish:
     runs-on: ubuntu-latest
     environment: master
+    permissions:
+      id-token: write
+      contents: read
     needs: [ci, ci-compat-e2e]
     if: |
       startsWith(github.ref, 'refs/tags/v')
@@ -514,10 +517,16 @@ jobs:
         with:
           ref: ${{ github.sha }}
 
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
+          aws-region: us-east-2
+          role-session-name: ci3-release-publish-${{ github.run_id }}
+          role-duration-seconds: 21600
+
       - name: Run Release Publish
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           GITHUB_TOKEN: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
           BUILD_INSTANCE_SSH_KEY: ${{ secrets.BUILD_INSTANCE_SSH_KEY }}
           GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}


### PR DESCRIPTION
## Summary
- Restores OIDC-based AWS auth in the `ci-release-publish` job, reverting #23192.
- Re-adds the `permissions: id-token: write / contents: read` block and the `aws-actions/configure-aws-credentials` step using `secrets.AWS_OIDC_ROLE_ARN`.
- Removes the static `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` env vars that #23192 reintroduced as a workaround.

## Context
#23192 forward-ported #23167 to `next` (v5) as a temporary measure to unblock nightlies. This PR moves v5 back onto OIDC now that the underlying issue should be resolved.

## Test plan
- [ ] Confirm a tagged release publish run on this branch authenticates to AWS successfully via OIDC before merging.