### PR TITLE
feat: optimize get next app tag as sender

### DIFF
--- a/yarn-project/pxe/src/tagging/sender_sync/sync_sender_tagging_indexes.test.ts
+++ b/yarn-project/pxe/src/tagging/sender_sync/sync_sender_tagging_indexes.test.ts
@@ -318,7 +318,9 @@ describe('syncSenderTaggingIndexes', () => {
 
     expect(await taggingStore.getLastFinalizedIndex(secret, 'test')).toBe(pendingIndex);
     expect(await taggingStore.getLastUsedIndex(secret, 'test')).toBe(pendingIndex);
-    // Receipt is fetched in parallel with the logs query for this single known-pending entry.
+    // Window 1 finalizes the seeded entry; window 2 finds nothing and breaks → 2 logs calls.
+    expect(aztecNode.getPrivateLogsByTags).toHaveBeenCalledTimes(2);
+    // Single receipt call, issued in parallel with window 1's logs query.
     expect(aztecNode.getTxReceipt).toHaveBeenCalledTimes(1);
     expect(aztecNode.getTxReceipt).toHaveBeenCalledWith(pendingTxHash);
   });
@@ -336,6 +338,8 @@ describe('syncSenderTaggingIndexes', () => {
 
     await syncSenderTaggingIndexes(secret, aztecNode, taggingStore, MOCK_ANCHOR_BLOCK_HASH, 'test');
 
+    // Single window iteration: empty result breaks the loop immediately.
+    expect(aztecNode.getPrivateLogsByTags).toHaveBeenCalledTimes(1);
     expect(aztecNode.getTxReceipt).not.toHaveBeenCalled();
   });
 
@@ -387,6 +391,10 @@ describe('syncSenderTaggingIndexes', () => {
 
     expect(await taggingStore.getLastFinalizedIndex(secret, 'test')).toBe(newlyDiscoveredIndex);
     expect(await taggingStore.getLastUsedIndex(secret, 'test')).toBe(newlyDiscoveredIndex);
+    // Window 1 reconciles both pendings; window 2 finds nothing and breaks → 2 logs calls.
+    expect(aztecNode.getPrivateLogsByTags).toHaveBeenCalledTimes(2);
+    // One parallel receipt call for the known pending, one sequential follow-up for the newly discovered.
+    expect(aztecNode.getTxReceipt).toHaveBeenCalledTimes(2);
     expect(aztecNode.getTxReceipt).toHaveBeenCalledWith(preExistingTxHash);
     expect(aztecNode.getTxReceipt).toHaveBeenCalledWith(newlyDiscoveredTxHash);
   });
@@ -430,6 +438,9 @@ describe('syncSenderTaggingIndexes', () => {
     await syncSenderTaggingIndexes(secret, aztecNode, taggingStore, MOCK_ANCHOR_BLOCK_HASH, 'test');
 
     expect(await taggingStore.getLastFinalizedIndex(secret, 'test')).toBe(pendingIndex);
+    // Window 1 finalizes the rediscovered entry; window 2 finds nothing and breaks → 2 logs calls.
+    expect(aztecNode.getPrivateLogsByTags).toHaveBeenCalledTimes(2);
+    // Only the parallel receipt call fires — the rediscovered hash is filtered out of the second-pass query.
     expect(aztecNode.getTxReceipt).toHaveBeenCalledTimes(1);
     expect(aztecNode.getTxReceipt).toHaveBeenCalledWith(pendingTxHash);
   });

--- a/yarn-project/pxe/src/tagging/sender_sync/sync_sender_tagging_indexes.test.ts
+++ b/yarn-project/pxe/src/tagging/sender_sync/sync_sender_tagging_indexes.test.ts
@@ -278,6 +278,162 @@ describe('syncSenderTaggingIndexes', () => {
     expect(await taggingStore.getLastUsedIndex(secret, 'test')).toBe(pendingAndFinalizedIndex);
   });
 
+  /**
+   * Covers the dominant wallet-resimulation scenario: a tx was sent (or previously discovered) in an earlier sync,
+   * so the pending entry is already in the store. A subsequent sync against an anchor block where that tx is now
+   * finalized must still advance the finalized index even though no new logs are found in the window.
+   */
+  it('finalizes pre-existing pending entries even when no new logs are found', async () => {
+    await setUp();
+
+    const pendingIndex = 4;
+    const pendingTxHash = TxHash.random();
+
+    // Seed the store with a pending entry, mirroring what a prior sync (or a tx sent from this PXE) would have written.
+    await taggingStore.storePendingIndexes(
+      [{ extendedSecret: secret, lowestIndex: pendingIndex, highestIndex: pendingIndex }],
+      pendingTxHash,
+      'test',
+    );
+
+    // No new logs surfaced in this window.
+    aztecNode.getPrivateLogsByTags.mockImplementation((tags: SiloedTag[]) => {
+      return Promise.resolve(tags.map(() => []));
+    });
+
+    // The seeded tx is now finalized onchain.
+    aztecNode.getTxReceipt.mockResolvedValue(
+      new TxReceipt(
+        pendingTxHash,
+        TxStatus.FINALIZED,
+        TxExecutionResult.SUCCESS,
+        undefined,
+        undefined,
+        undefined,
+        BlockNumber(14),
+      ),
+    );
+
+    await syncSenderTaggingIndexes(secret, aztecNode, taggingStore, MOCK_ANCHOR_BLOCK_HASH, 'test');
+
+    expect(await taggingStore.getLastFinalizedIndex(secret, 'test')).toBe(pendingIndex);
+    expect(await taggingStore.getLastUsedIndex(secret, 'test')).toBe(pendingIndex);
+    // Receipt is fetched in parallel with the logs query for this single known-pending entry.
+    expect(aztecNode.getTxReceipt).toHaveBeenCalledTimes(1);
+    expect(aztecNode.getTxReceipt).toHaveBeenCalledWith(pendingTxHash);
+  });
+
+  /**
+   * When the store has no pending entries and the logs query returns nothing, the sync should not issue any
+   * receipt RPC at all.
+   */
+  it('does not call getTxReceipt when no pending entries exist and no new logs are found', async () => {
+    await setUp();
+
+    aztecNode.getPrivateLogsByTags.mockImplementation((tags: SiloedTag[]) => {
+      return Promise.resolve(tags.map(() => []));
+    });
+
+    await syncSenderTaggingIndexes(secret, aztecNode, taggingStore, MOCK_ANCHOR_BLOCK_HASH, 'test');
+
+    expect(aztecNode.getTxReceipt).not.toHaveBeenCalled();
+  });
+
+  /**
+   * Mixed window: one pending entry is already in the store, and the logs query surfaces a different pending tx
+   * at another index in the same window. Both must have their status reconciled in one sync call.
+   */
+  it('fetches receipts for both pre-existing and newly discovered pending in the same window', async () => {
+    await setUp();
+
+    const preExistingIndex = 3;
+    const newlyDiscoveredIndex = 7;
+    const preExistingTxHash = TxHash.random();
+    const newlyDiscoveredTxHash = TxHash.random();
+    const newlyDiscoveredTag = await computeSiloedTagForIndex(newlyDiscoveredIndex);
+
+    await taggingStore.storePendingIndexes(
+      [{ extendedSecret: secret, lowestIndex: preExistingIndex, highestIndex: preExistingIndex }],
+      preExistingTxHash,
+      'test',
+    );
+
+    aztecNode.getPrivateLogsByTags.mockImplementation((tags: SiloedTag[]) => {
+      return Promise.resolve(
+        tags.map((tag: SiloedTag) =>
+          tag.equals(newlyDiscoveredTag) ? [makeLog(newlyDiscoveredTxHash, newlyDiscoveredTag.value)] : [],
+        ),
+      );
+    });
+
+    aztecNode.getTxReceipt.mockImplementation((hash: TxHash) => {
+      if (hash.equals(preExistingTxHash) || hash.equals(newlyDiscoveredTxHash)) {
+        return Promise.resolve(
+          new TxReceipt(
+            hash,
+            TxStatus.FINALIZED,
+            TxExecutionResult.SUCCESS,
+            undefined,
+            undefined,
+            undefined,
+            BlockNumber(14),
+          ),
+        );
+      }
+      throw new Error(`Unexpected tx hash: ${hash.toString()}`);
+    });
+
+    await syncSenderTaggingIndexes(secret, aztecNode, taggingStore, MOCK_ANCHOR_BLOCK_HASH, 'test');
+
+    expect(await taggingStore.getLastFinalizedIndex(secret, 'test')).toBe(newlyDiscoveredIndex);
+    expect(await taggingStore.getLastUsedIndex(secret, 'test')).toBe(newlyDiscoveredIndex);
+    expect(aztecNode.getTxReceipt).toHaveBeenCalledWith(preExistingTxHash);
+    expect(aztecNode.getTxReceipt).toHaveBeenCalledWith(newlyDiscoveredTxHash);
+  });
+
+  /**
+   * When the logs query re-discovers a tx hash that is already pending in the store (idempotent re-write),
+   * we must not double-fetch its receipt — the diff between known and newly-discovered pending must filter it out.
+   */
+  it('does not re-fetch receipts when the logs query rediscovers a pre-existing pending tx', async () => {
+    await setUp();
+
+    const pendingIndex = 5;
+    const pendingTxHash = TxHash.random();
+    const pendingTag = await computeSiloedTagForIndex(pendingIndex);
+
+    await taggingStore.storePendingIndexes(
+      [{ extendedSecret: secret, lowestIndex: pendingIndex, highestIndex: pendingIndex }],
+      pendingTxHash,
+      'test',
+    );
+
+    // Logs query returns the same tx for the same tag — `storePendingIndexes` will treat this as a no-op duplicate.
+    aztecNode.getPrivateLogsByTags.mockImplementation((tags: SiloedTag[]) => {
+      return Promise.resolve(
+        tags.map((tag: SiloedTag) => (tag.equals(pendingTag) ? [makeLog(pendingTxHash, pendingTag.value)] : [])),
+      );
+    });
+
+    aztecNode.getTxReceipt.mockResolvedValue(
+      new TxReceipt(
+        pendingTxHash,
+        TxStatus.FINALIZED,
+        TxExecutionResult.SUCCESS,
+        undefined,
+        undefined,
+        undefined,
+        BlockNumber(14),
+      ),
+    );
+
+    await syncSenderTaggingIndexes(secret, aztecNode, taggingStore, MOCK_ANCHOR_BLOCK_HASH, 'test');
+
+    expect(await taggingStore.getLastFinalizedIndex(secret, 'test')).toBe(pendingIndex);
+    expect(aztecNode.getTxReceipt).toHaveBeenCalledTimes(1);
+    expect(aztecNode.getTxReceipt).toHaveBeenCalledWith(pendingTxHash);
+  });
+
   it('handles a partially reverted transaction', async () => {
     await setUp();
 

--- a/yarn-project/pxe/src/tagging/sender_sync/sync_sender_tagging_indexes.ts
+++ b/yarn-project/pxe/src/tagging/sender_sync/sync_sender_tagging_indexes.ts
@@ -4,7 +4,11 @@ import type { ExtendedDirectionalAppTaggingSecret } from '@aztec/stdlib/logs';
 
 import type { SenderTaggingStore } from '../../storage/tagging_store/sender_tagging_store.js';
 import { UNFINALIZED_TAGGING_INDEXES_WINDOW_LEN } from '../constants.js';
-import { getStatusChangeOfPending } from './utils/get_status_change_of_pending.js';
+import {
+  EMPTY_STATUS_CHANGE,
+  getStatusChangeOfPending,
+  mergeStatusChanges,
+} from './utils/get_status_change_of_pending.js';
 import { loadAndStoreNewTaggingIndexes } from './utils/load_and_store_new_tagging_indexes.js';
 
 /**
@@ -52,19 +56,38 @@ export async function syncSenderTaggingIndexes(
   let newFinalizedIndex = undefined;
 
   while (true) {
-    // Load and store indexes for the current window. These indexes may already exist in the database if txs using
-    // them were previously sent from this PXE. Any duplicates are handled by the tagging data provider.
-    await loadAndStoreNewTaggingIndexes(secret, start, end, aztecNode, taggingStore, anchorBlockHash, jobId);
+    // Pending tx hashes already in the store for this window (from prior syncs or txs this PXE itself sent).
+    // Reading these before issuing any RPC lets us fetch their receipts in parallel with the logs query below.
+    const knownPendingTxHashes = await taggingStore.getTxHashesOfPendingIndexes(secret, start, end, jobId);
 
-    // Retrieve all indexes within the current window from storage and update their status accordingly.
-    const pendingTxHashes = await taggingStore.getTxHashesOfPendingIndexes(secret, start, end, jobId);
-    if (pendingTxHashes.length === 0) {
+    // Fire the logs query and the known-pending receipts query in parallel
+    const [, statusOfKnown] = await Promise.all([
+      loadAndStoreNewTaggingIndexes(secret, start, end, aztecNode, taggingStore, anchorBlockHash, jobId),
+      knownPendingTxHashes.length > 0
+        ? getStatusChangeOfPending(knownPendingTxHashes, aztecNode)
+        : Promise.resolve(EMPTY_STATUS_CHANGE),
+    ]);
+
+    // Re-read pending tx hashes after the logs query writes any newly-discovered ones to the store.
+    const allPendingTxHashes = await taggingStore.getTxHashesOfPendingIndexes(secret, start, end, jobId);
+    if (allPendingTxHashes.length === 0) {
       break;
     }
 
-    const { txHashesToFinalize, txHashesToDrop, txHashesWithExecutionReverted } = await getStatusChangeOfPending(
-      pendingTxHashes,
-      aztecNode,
+    // Receipts for pending tx hashes that the logs query just surfaced still need a sequential follow-up call.
+    // `storePendingIndexes` is idempotent on (secret, txHash), so a re-discovered hash stays classified as known
+    // and is not re-fetched here.
+    const knownSet = new Set(knownPendingTxHashes.map(h => h.toString()));
+    const newPendingTxHashes = allPendingTxHashes.filter(h => !knownSet.has(h.toString()));
+
+    const statusOfNew =
+      newPendingTxHashes.length > 0
+        ? await getStatusChangeOfPending(newPendingTxHashes, aztecNode)
+        : EMPTY_STATUS_CHANGE;
+
+    const { txHashesToFinalize, txHashesToDrop, txHashesWithExecutionReverted } = mergeStatusChanges(
+      statusOfKnown,
+      statusOfNew,
     );
 
     await taggingStore.dropPendingIndexes(txHashesToDrop, jobId);

--- a/yarn-project/pxe/src/tagging/sender_sync/utils/get_status_change_of_pending.ts
+++ b/yarn-project/pxe/src/tagging/sender_sync/utils/get_status_change_of_pending.ts
@@ -1,18 +1,33 @@
 import type { AztecNode } from '@aztec/stdlib/interfaces/server';
 import { TxHash, TxStatus } from '@aztec/stdlib/tx';
 
+/** Classification of a batch of pending tx hashes by the status change implied by their receipts. */
+export type StatusChange = {
+  txHashesToFinalize: TxHash[];
+  txHashesToDrop: TxHash[];
+  txHashesWithExecutionReverted: TxHash[];
+};
+
+export const EMPTY_STATUS_CHANGE: StatusChange = {
+  txHashesToFinalize: [],
+  txHashesToDrop: [],
+  txHashesWithExecutionReverted: [],
+};
+
+/** Concatenates two status changes field-by-field. */
+export function mergeStatusChanges(a: StatusChange, b: StatusChange): StatusChange {
+  return {
+    txHashesToFinalize: [...a.txHashesToFinalize, ...b.txHashesToFinalize],
+    txHashesToDrop: [...a.txHashesToDrop, ...b.txHashesToDrop],
+    txHashesWithExecutionReverted: [...a.txHashesWithExecutionReverted, ...b.txHashesWithExecutionReverted],
+  };
+}
+
 /**
  * Based on receipts obtained from `aztecNode` returns which pending transactions changed their status to finalized,
  * dropped, or execution-reverted (but mined).
  */
-export async function getStatusChangeOfPending(
-  pending: TxHash[],
-  aztecNode: AztecNode,
-): Promise<{
-  txHashesToFinalize: TxHash[];
-  txHashesToDrop: TxHash[];
-  txHashesWithExecutionReverted: TxHash[];
-}> {
+export async function getStatusChangeOfPending(pending: TxHash[], aztecNode: AztecNode): Promise<StatusChange> {
   // Get receipts for all pending tx hashes.
   const receipts = await Promise.all(pending.map(pendingTxHash => aztecNode.getTxReceipt(pendingTxHash)));
 


### PR DESCRIPTION
## Summary

Cuts the round-trip cost of `aztec_prv_getNextAppTagAsSender` by firing the logs query and the receipts query for already-known pending tx hashes in parallel.

A second-pass receipt query still runs when the logs query surfaces previously-unseen pending tx hashes, but only for those.

## Changes

- `sync_sender_tagging_indexes.ts`: pre-fetch known-pending tx hashes from the store, then `Promise.all([loadAndStoreNewTaggingIndexes, getStatusChangeOfPending(known)])`. Diff against the post-load store snapshot to find newly-discovered pending and fetch their receipts in a conditional follow-up call.
- `get_status_change_of_pending.ts`: exports `StatusChange`, `EMPTY_STATUS_CHANGE`, `mergeStatusChanges` for use by the sync loop.
- Tests: four new cases covering pre-existing-pending finalization, the no-pending no-logs RPC-skip path, mixed known/newly-discovered pending in one window, and idempotent rediscovery.
