### PR TITLE
fix(foundation): Fix Zod serde for Buffer32

### DIFF
--- a/yarn-project/foundation/src/buffer/buffer32.ts
+++ b/yarn-project/foundation/src/buffer/buffer32.ts
@@ -90,7 +90,7 @@ export class Buffer32 extends BaseBuffer32 {
     if (buffer.length != 28) {
       throw new Error(`Expected Buffer32 input buffer to be 28 bytes`);
     }
-    const padded = Buffer.concat([Buffer.alloc(this.SIZE - 28), buffer]);
+    const padded = Buffer.concat([Buffer.alloc(Buffer32.SIZE - 28), buffer]);
     return new Buffer32(padded);
   }
 
@@ -99,8 +99,8 @@ export class Buffer32 extends BaseBuffer32 {
     if (str.startsWith('0x')) {
       str = str.slice(2);
     }
-    if (str.length !== this.SIZE * 2) {
-      throw new Error(`Expected string to be ${this.SIZE * 2} characters long, but was ${str.length}`);
+    if (str.length !== Buffer32.SIZE * 2) {
+      throw new Error(`Expected string to be ${Buffer32.SIZE * 2} characters long, but was ${str.length}`);
     }
     return new Buffer32(Buffer.from(str, 'hex'));
   }

--- a/yarn-project/foundation/src/schemas/schemas.test.ts
+++ b/yarn-project/foundation/src/schemas/schemas.test.ts
@@ -1,6 +1,16 @@
+import { Buffer32 } from '../buffer/buffer32.js';
 import { schemas } from './schemas.js';
 
 describe('schemas', () => {
+  describe('Buffer32', () => {
+    it('parses a valid hex string into a Buffer32', () => {
+      const buffer32 = Buffer32.random();
+      const parsed = schemas.Buffer32.parse(buffer32.toString());
+      expect(parsed).toBeInstanceOf(Buffer32);
+      expect(parsed.equals(buffer32)).toBe(true);
+    });
+  });
+
   describe('Boolean', () => {
     it('accepts a boolean value', () => {
       expect(schemas.Boolean.parse(true)).toEqual(true);


### PR DESCRIPTION
## Summary

- `Buffer32.fromString` and `fromBuffer28` referenced `this.SIZE`, which broke when the static method was called with a different `this` (e.g. passed unbound to `z.transform` in `schemas.Buffer32`, where `this.SIZE` became `undefined` and the length check threw `"Expected string to be NaN characters long, but was 64"`).
- Replace remaining `this.SIZE` uses with `Buffer32.SIZE` so the static methods don't depend on call-site binding. The rest of the class already used `Buffer32.SIZE` — this just removes the mix.
- Add a regression test that round-trips a random `Buffer32` through `schemas.Buffer32`.