### PR TITLE
fix(ci): swap slack_notify args in CLI acceptance test

### DIFF
--- a/.github/workflows/aztec-cli-acceptance-test.yml
+++ b/.github/workflows/aztec-cli-acceptance-test.yml
@@ -49,8 +49,9 @@ jobs:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
         run: |
           export CI=1
-          ./ci3/slack_notify "#team-fairies" \
-            "Aztec CLI Acceptance Test passed for version ${VERSION} :white_check_mark:"
+          ./ci3/slack_notify \
+            "Aztec CLI Acceptance Test passed for version ${VERSION} :white_check_mark:" \
+            "#team-fairies"
 
       - name: Notify Slack and dispatch ClaudeBox on failure
         if: failure() && github.event_name != 'workflow_dispatch'


### PR DESCRIPTION
## Summary

- The `slack_notify` script expects `(text, channel)` but the CLI acceptance test workflow was passing `(channel, text)`, so the success notification was silently posting to a nonexistent Slack channel.
- The failure notification uses `slack_notify_with_claudebox_kickoff` which has the opposite convention `(channel, text)` and was correct.