### PR TITLE
chore: fix MQ failure notifications

### DIFF
--- a/.claude/skills/merge-trains/SKILL.md
+++ b/.claude/skills/merge-trains/SKILL.md
@@ -18,7 +18,7 @@ A merge train is an automated batching system (inspired by [Rust rollups](https:
 | `merge-train/ci` | CI infrastructure / ci3 | `#help-ci` |
 | `merge-train/docs` | Documentation | `#dev-rels` |
 | `merge-train/fairies` | aztec-nr | `#team-fairies` |
-| `merge-train/spartan` | Spartan / infra / yarn-project sequencer and prover orchestration | `#e-team-alpha` |
+| `merge-train/spartan` | Spartan / infra / yarn-project sequencer and prover orchestration | `#team-alpha` |
 
 ## How to Use a Merge Train
 

--- a/ci3/slack_notify_with_claudebox_kickoff
+++ b/ci3/slack_notify_with_claudebox_kickoff
@@ -7,6 +7,8 @@ set -eu
 # Requires: SLACK_BOT_TOKEN
 # Optional: CLAUDEBOX_REPO (default: AztecProtocol/aztec-packages)
 
+NO_CD=1 source "$(git rev-parse --show-toplevel)/ci3/source_base"
+
 if [[ "${CI:-}" != "1" ]]; then
   echo "Not in CI — skipping slack_notify_with_claudebox_kickoff"
   exit 0


### PR DESCRIPTION
The slack notify script would refuse to run with `CI=true` (Github Actions default value). `source_base` normalises `CI=1/0`