### PR TITLE
refactor(stdlib): remove deprecated RevertCode/TxExecutionResult aliases

### DIFF
--- a/yarn-project/aztec.js/src/utils/node.test.ts
+++ b/yarn-project/aztec.js/src/utils/node.test.ts
@@ -42,7 +42,7 @@ describe('waitForTx', () => {
       const revertedReceipt = new TxReceipt(
         txHash,
         TxStatus.CHECKPOINTED,
-        TxExecutionResult.APP_LOGIC_REVERTED,
+        TxExecutionResult.REVERTED,
         undefined,
         undefined,
         undefined,
@@ -56,7 +56,7 @@ describe('waitForTx', () => {
       const revertedReceipt = new TxReceipt(
         txHash,
         TxStatus.CHECKPOINTED,
-        TxExecutionResult.APP_LOGIC_REVERTED,
+        TxExecutionResult.REVERTED,
         undefined,
         undefined,
         undefined,

--- a/yarn-project/end-to-end/src/e2e_cross_chain_messaging/l1_to_l2.test.ts
+++ b/yarn-project/end-to-end/src/e2e_cross_chain_messaging/l1_to_l2.test.ts
@@ -272,7 +272,7 @@ describe('e2e_cross_chain_messaging l1_to_l2', () => {
             expect(block!.checkpointNumber).toEqual(msgCheckpointNumber);
             expect(block!.indexWithinCheckpoint).toEqual(IndexWithinCheckpoint.ZERO);
           } else {
-            expect(receipt.executionResult).toEqual(TxExecutionResult.APP_LOGIC_REVERTED);
+            expect(receipt.executionResult).toEqual(TxExecutionResult.REVERTED);
           }
         }
         await t.context.watcher.markAsProven();

--- a/yarn-project/end-to-end/src/e2e_deploy_contract/contract_class_registration.test.ts
+++ b/yarn-project/end-to-end/src/e2e_deploy_contract/contract_class_registration.test.ts
@@ -161,7 +161,7 @@ describe('e2e_deploy_contract contract class registration', () => {
           const { receipt } = await contract.methods
             .increment_public_value(whom, 10)
             .send({ from: defaultAccountAddress, wait: { dontThrowOnRevert: true } });
-          expect(receipt.executionResult).toEqual(TxExecutionResult.APP_LOGIC_REVERTED);
+          expect(receipt.executionResult).toEqual(TxExecutionResult.REVERTED);
 
           // Meanwhile we check we didn't increment the value
           expect(
@@ -205,7 +205,7 @@ describe('e2e_deploy_contract contract class registration', () => {
           const { receipt } = await contract.methods
             .public_constructor(whom, 43)
             .send({ from: defaultAccountAddress, wait: { dontThrowOnRevert: true } });
-          expect(receipt.executionResult).toEqual(TxExecutionResult.APP_LOGIC_REVERTED);
+          expect(receipt.executionResult).toEqual(TxExecutionResult.REVERTED);
           expect(
             (await contract.methods.get_public_value(whom).simulate({ from: defaultAccountAddress })).result,
           ).toEqual(0n);
@@ -256,7 +256,7 @@ describe('e2e_deploy_contract contract class registration', () => {
       const { receipt: tx } = await instance.methods
         .increment_public_value_no_init_check(whom, 10)
         .send({ from: defaultAccountAddress, wait: { dontThrowOnRevert: true } });
-      expect(tx.executionResult).toEqual(TxExecutionResult.APP_LOGIC_REVERTED);
+      expect(tx.executionResult).toEqual(TxExecutionResult.REVERTED);
     });
   });
 });

--- a/yarn-project/end-to-end/src/e2e_deploy_contract/legacy.test.ts
+++ b/yarn-project/end-to-end/src/e2e_deploy_contract/legacy.test.ts
@@ -122,7 +122,7 @@ describe('e2e_deploy_contract legacy', () => {
     expect(goodTxReceipt!.blockNumber).toEqual(expect.any(Number));
     expect(badTxReceipt!.blockNumber).toEqual(expect.any(Number));
 
-    expect(badTxReceipt!.executionResult).toEqual(TxExecutionResult.APP_LOGIC_REVERTED);
+    expect(badTxReceipt!.executionResult).toEqual(TxExecutionResult.REVERTED);
 
     const badInstance = await badDeploy.getInstance();
     // But the bad tx did not deploy the class

--- a/yarn-project/end-to-end/src/e2e_double_spend.test.ts
+++ b/yarn-project/end-to-end/src/e2e_double_spend.test.ts
@@ -46,7 +46,7 @@ describe('e2e_double_spend', () => {
       // tx will be included in a block but with app logic reverted
       await expect(
         contract.methods.emit_nullifier_public(nullifier).send({ from: defaultAccountAddress }),
-      ).rejects.toThrow(TxExecutionResult.APP_LOGIC_REVERTED);
+      ).rejects.toThrow(TxExecutionResult.REVERTED);
     });
   });
 });

--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_proof_public_cross_chain.test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_proof_public_cross_chain.test.ts
@@ -98,7 +98,7 @@ describe('e2e_epochs/epochs_proof_public_cross_chain', () => {
         globalLeafIndex.toBigInt(),
       )
       .send({ from: context.accounts[0], wait: { dontThrowOnRevert: true } });
-    expect(failedReceipt.executionResult).toBe(TxExecutionResult.APP_LOGIC_REVERTED);
+    expect(failedReceipt.executionResult).toBe(TxExecutionResult.REVERTED);
 
     logger.info(`Test succeeded`);
   });

--- a/yarn-project/end-to-end/src/e2e_fees/failures.test.ts
+++ b/yarn-project/end-to-end/src/e2e_fees/failures.test.ts
@@ -98,7 +98,7 @@ describe('e2e_fees failures', () => {
         wait: { dontThrowOnRevert: true },
       });
 
-    expect(txReceipt.executionResult).toBe(TxExecutionResult.APP_LOGIC_REVERTED);
+    expect(txReceipt.executionResult).toBe(TxExecutionResult.REVERTED);
 
     const { sequencerBlockRewards } = await t.getBlockRewards();
 
@@ -201,7 +201,7 @@ describe('e2e_fees failures', () => {
         wait: { dontThrowOnRevert: true },
       });
 
-    expect(txReceipt.executionResult).toBe(TxExecutionResult.APP_LOGIC_REVERTED);
+    expect(txReceipt.executionResult).toBe(TxExecutionResult.REVERTED);
     const feeAmount = txReceipt.transactionFee!;
 
     // and thus we paid the fee
@@ -298,7 +298,7 @@ describe('e2e_fees failures', () => {
         },
         wait: { dontThrowOnRevert: true },
       });
-    expect(receipt.executionResult).toEqual(TxExecutionResult.TEARDOWN_REVERTED);
+    expect(receipt.executionResult).toEqual(TxExecutionResult.REVERTED);
     expect(receipt.transactionFee).toBeGreaterThan(0n);
 
     await expectMapping(
@@ -346,7 +346,7 @@ describe('e2e_fees failures', () => {
         wait: { dontThrowOnRevert: true },
       });
 
-    expect(receipt.executionResult).toBe(TxExecutionResult.BOTH_REVERTED);
+    expect(receipt.executionResult).toBe(TxExecutionResult.REVERTED);
     expect(receipt.transactionFee).toBeGreaterThan(0n);
 
     await t.context.watcher.trigger();

--- a/yarn-project/pxe/src/storage/tagging_store/sender_tagging_store.test.ts
+++ b/yarn-project/pxe/src/storage/tagging_store/sender_tagging_store.test.ts
@@ -494,7 +494,7 @@ describe('SenderTaggingStore', () => {
   describe('finalizePendingIndexesOfAPartiallyRevertedTx', () => {
     function makeTxEffect(txHash: TxHash, siloedTags: SiloedTag[]): TxEffect {
       return new TxEffect(
-        RevertCode.APP_LOGIC_REVERTED,
+        RevertCode.REVERTED,
         txHash,
         Fr.ZERO,
         [Fr.random()], // noteHashes (at least 1 nullifier required below, not here)

--- a/yarn-project/pxe/src/tagging/sender_sync/sync_sender_tagging_indexes.test.ts
+++ b/yarn-project/pxe/src/tagging/sender_sync/sync_sender_tagging_indexes.test.ts
@@ -300,12 +300,12 @@ describe('syncSenderTaggingIndexes', () => {
       );
     });
 
-    // Mock getTxReceipt to return FINALIZED with APP_LOGIC_REVERTED
+    // Mock getTxReceipt to return FINALIZED with REVERTED
     aztecNode.getTxReceipt.mockResolvedValue(
       new TxReceipt(
         revertedTxHash,
         TxStatus.FINALIZED,
-        TxExecutionResult.APP_LOGIC_REVERTED,
+        TxExecutionResult.REVERTED,
         undefined,
         undefined,
         undefined,
@@ -315,7 +315,7 @@ describe('syncSenderTaggingIndexes', () => {
 
     // Mock getTxEffect to return a TxEffect where only the tag at index 4 survived (non-revertible phase)
     const txEffect = new TxEffect(
-      RevertCode.APP_LOGIC_REVERTED,
+      RevertCode.REVERTED,
       revertedTxHash,
       Fr.ZERO,
       [Fr.random()], // noteHashes

--- a/yarn-project/pxe/src/tagging/sender_sync/utils/get_status_change_of_pending.test.ts
+++ b/yarn-project/pxe/src/tagging/sender_sync/utils/get_status_change_of_pending.test.ts
@@ -55,7 +55,7 @@ describe('getStatusChangeOfPending', () => {
           new TxReceipt(
             hash,
             TxStatus.FINALIZED,
-            TxExecutionResult.APP_LOGIC_REVERTED,
+            TxExecutionResult.REVERTED,
             undefined,
             undefined,
             undefined,
@@ -67,7 +67,7 @@ describe('getStatusChangeOfPending', () => {
           new TxReceipt(
             hash,
             TxStatus.FINALIZED,
-            TxExecutionResult.TEARDOWN_REVERTED,
+            TxExecutionResult.REVERTED,
             undefined,
             undefined,
             undefined,
@@ -79,7 +79,7 @@ describe('getStatusChangeOfPending', () => {
           new TxReceipt(
             hash,
             TxStatus.FINALIZED,
-            TxExecutionResult.BOTH_REVERTED,
+            TxExecutionResult.REVERTED,
             undefined,
             undefined,
             undefined,

--- a/yarn-project/simulator/docs/avm/public-tx-simulation.md
+++ b/yarn-project/simulator/docs/avm/public-tx-simulation.md
@@ -35,7 +35,7 @@ The app logic phase contains the main application functionality. This is where m
 - State changes from app logic are rolled back
 - Side effects from private's revertible portion are also discarded
 - Teardown still executes
-- The transaction appears on-chain with `APP_LOGIC_REVERTED` status
+- The transaction appears on-chain with `REVERTED` status
 
 ### TEARDOWN Phase (Revertible, Always Runs)
 

--- a/yarn-project/simulator/src/public/public_processor/apps_tests/deployments.test.ts
+++ b/yarn-project/simulator/src/public/public_processor/apps_tests/deployments.test.ts
@@ -249,7 +249,7 @@ describe.each([
     expect(processedTxs[0].revertCode).toEqual(RevertCode.OK);
 
     // Second tx should revert in app logic (failed transfer)
-    expect(processedTxs[1].revertCode).toEqual(RevertCode.APP_LOGIC_REVERTED);
+    expect(processedTxs[1].revertCode).toEqual(RevertCode.REVERTED);
 
     // Third tx should succeed (mint), proving first contract is still accessible
     expect(processedTxs[2].revertCode).toEqual(RevertCode.OK);

--- a/yarn-project/simulator/src/public/public_processor/public_processor.test.ts
+++ b/yarn-project/simulator/src/public/public_processor/public_processor.test.ts
@@ -136,7 +136,7 @@ describe('public_processor', () => {
     it('runs a tx with reverted enqueued public calls', async function () {
       const tx = await mockTxWithPublicCalls();
 
-      mockedEnqueuedCallsResult.revertCode = RevertCode.APP_LOGIC_REVERTED;
+      mockedEnqueuedCallsResult.revertCode = RevertCode.REVERTED;
 
       const [processed, failed] = await processor.process([tx]);
 

--- a/yarn-project/simulator/src/public/public_tx_simulator/public_tx_simulator.test.ts
+++ b/yarn-project/simulator/src/public/public_tx_simulator/public_tx_simulator.test.ts
@@ -691,7 +691,7 @@ describe('public_tx_simulator', () => {
 
     const txResult = await simulator.simulate(tx);
 
-    expect(txResult.revertCode).toEqual(RevertCode.APP_LOGIC_REVERTED);
+    expect(txResult.revertCode).toEqual(RevertCode.REVERTED);
     // tx reports app logic failure
     expect(txResult.findRevertReason()).toEqual(appLogicFailure);
 
@@ -812,7 +812,7 @@ describe('public_tx_simulator', () => {
 
     const txResult = await simulator.simulate(tx);
 
-    expect(txResult.revertCode).toEqual(RevertCode.TEARDOWN_REVERTED);
+    expect(txResult.revertCode).toEqual(RevertCode.REVERTED);
     expect(txResult.findRevertReason()).toEqual(teardownFailure);
 
     const expectedSetupGas = enqueuedCallGasUsed;
@@ -921,7 +921,7 @@ describe('public_tx_simulator', () => {
 
     const txResult = await simulator.simulate(tx);
 
-    expect(txResult.revertCode).toEqual(RevertCode.BOTH_REVERTED);
+    expect(txResult.revertCode).toEqual(RevertCode.REVERTED);
     // tx reports app logic failure
     expect(txResult.findRevertReason()).toEqual(appLogicFailure);
 
@@ -1246,7 +1246,7 @@ describe('public_tx_simulator', () => {
       });
 
       const txResult = await simulator.simulate(tx);
-      expect(txResult.revertCode).toEqual(RevertCode.APP_LOGIC_REVERTED);
+      expect(txResult.revertCode).toEqual(RevertCode.REVERTED);
       const revertReason = txResult.findRevertReason();
       expect(revertReason).toBeDefined();
       expect(revertReason?.getOriginalMessage()).toContain(new NullifierLimitReachedError().message);
@@ -1269,7 +1269,7 @@ describe('public_tx_simulator', () => {
         throw new NoteHashLimitReachedError();
       });
       const txResult = await simulator.simulate(tx);
-      expect(txResult.revertCode).toEqual(RevertCode.APP_LOGIC_REVERTED);
+      expect(txResult.revertCode).toEqual(RevertCode.REVERTED);
       const revertReason = txResult.findRevertReason();
       expect(revertReason).toBeDefined();
       expect(revertReason?.getOriginalMessage()).toContain(new NoteHashLimitReachedError().message);
@@ -1296,7 +1296,7 @@ describe('public_tx_simulator', () => {
       });
 
       const txResult = await simulator.simulate(tx);
-      expect(txResult.revertCode).toEqual(RevertCode.APP_LOGIC_REVERTED);
+      expect(txResult.revertCode).toEqual(RevertCode.REVERTED);
       const revertReason = txResult.findRevertReason();
       expect(revertReason).toBeDefined();
       expect(revertReason?.getOriginalMessage()).toContain(new L2ToL1MessageLimitReachedError().message);

--- a/yarn-project/stdlib/src/avm/revert_code.ts
+++ b/yarn-project/stdlib/src/avm/revert_code.ts
@@ -28,12 +28,6 @@ export class RevertCode {
   }
   static readonly OK: RevertCode = new RevertCode(RevertCodeEnum.OK);
   static readonly REVERTED: RevertCode = new RevertCode(RevertCodeEnum.REVERTED);
-  /** @deprecated Use REVERTED instead. */
-  static readonly APP_LOGIC_REVERTED: RevertCode = RevertCode.REVERTED;
-  /** @deprecated Use REVERTED instead. */
-  static readonly TEARDOWN_REVERTED: RevertCode = RevertCode.REVERTED;
-  /** @deprecated Use REVERTED instead. */
-  static readonly BOTH_REVERTED: RevertCode = RevertCode.REVERTED;
 
   public getCode(): RevertCodeEnum {
     return this.code;

--- a/yarn-project/stdlib/src/tx/tx_receipt.test.ts
+++ b/yarn-project/stdlib/src/tx/tx_receipt.test.ts
@@ -42,22 +42,12 @@ describe('TxReceipt', () => {
     });
 
     it('isSuccess returns false for reverted execution', () => {
-      const receipt = new TxReceipt(
-        TxHash.random(),
-        TxStatus.PROPOSED,
-        TxExecutionResult.APP_LOGIC_REVERTED,
-        undefined,
-      );
+      const receipt = new TxReceipt(TxHash.random(), TxStatus.PROPOSED, TxExecutionResult.REVERTED, undefined);
       expect(receipt.hasExecutionSucceeded()).toBe(false);
     });
 
     it('isReverted returns true for reverted execution', () => {
-      const receipt = new TxReceipt(
-        TxHash.random(),
-        TxStatus.PROPOSED,
-        TxExecutionResult.APP_LOGIC_REVERTED,
-        undefined,
-      );
+      const receipt = new TxReceipt(TxHash.random(), TxStatus.PROPOSED, TxExecutionResult.REVERTED, undefined);
       expect(receipt.hasExecutionReverted()).toBe(true);
     });
 

--- a/yarn-project/stdlib/src/tx/tx_receipt.ts
+++ b/yarn-project/stdlib/src/tx/tx_receipt.ts
@@ -32,15 +32,6 @@ export const SortedTxStatuses: TxStatus[] = [
 export enum TxExecutionResult {
   SUCCESS = 'success',
   REVERTED = 'reverted',
-  /** @deprecated Use REVERTED instead. */
-  // eslint-disable-next-line @typescript-eslint/no-duplicate-enum-values
-  APP_LOGIC_REVERTED = 'reverted',
-  /** @deprecated Use REVERTED instead. */
-  // eslint-disable-next-line @typescript-eslint/no-duplicate-enum-values
-  TEARDOWN_REVERTED = 'reverted',
-  /** @deprecated Use REVERTED instead. */
-  // eslint-disable-next-line @typescript-eslint/no-duplicate-enum-values
-  BOTH_REVERTED = 'reverted',
 }
 
 /**


### PR DESCRIPTION
## Motivation

The `RevertCode` and `TxExecutionResult` types each carried three deprecated aliases (`APP_LOGIC_REVERTED`, `TEARDOWN_REVERTED`, `BOTH_REVERTED`) that all collapse to the same `REVERTED` value. Keeping them around adds noise, requires `no-duplicate-enum-values` eslint suppressions, and lets new code keep reaching for the old names.

## Approach

Removed the deprecated members from both enums and rewrote every call site to use `REVERTED` directly. Tests, fixtures, and a stale doc reference were updated to match.

## Changes

- **stdlib**: Drop deprecated `APP_LOGIC_REVERTED`/`TEARDOWN_REVERTED`/`BOTH_REVERTED` from `RevertCode` and `TxExecutionResult`.
- **simulator, pxe, aztec.js, end-to-end (tests)**: Replace remaining references with `REVERTED`.
- **simulator/docs**: Update a stale `APP_LOGIC_REVERTED` reference in the public-tx-simulation doc.