### PR TITLE
refactor(l1-tx-utils): use DateProvider for fail-fast timeout check

### DIFF
--- a/yarn-project/ethereum/src/l1_tx_utils/l1_tx_utils.ts
+++ b/yarn-project/ethereum/src/l1_tx_utils/l1_tx_utils.ts
@@ -213,6 +213,19 @@ export class L1TxUtils extends ReadOnlyL1TxUtils {
     return await this.signTransaction(txRequest as TransactionSerializable);
   }
 
+  private async checkInterruptedOrTimedOut(gasConfig: Pick<L1TxConfig, 'txTimeoutAt'>): Promise<Date> {
+    if (this.interrupted) {
+      throw new InterruptError(`Transaction sending is interrupted`);
+    }
+    const now = new Date(await this.getL1Timestamp());
+    if (gasConfig.txTimeoutAt && now > gasConfig.txTimeoutAt) {
+      throw new TimeoutError(
+        `Transaction timed out before sending (now ${now.toISOString()} > timeoutAt ${gasConfig.txTimeoutAt.toISOString()})`,
+      );
+    }
+    return now;
+  }
+
   /**
    * Sends a transaction with gas estimation and pricing
    * @param request - The transaction request (to, data, value)
@@ -225,22 +238,14 @@ export class L1TxUtils extends ReadOnlyL1TxUtils {
     blobInputs?: L1BlobInputs,
     stateChange: TxUtilsState = TxUtilsState.SENT,
   ): Promise<{ txHash: Hex; state: L1TxState }> {
-    if (this.interrupted) {
-      throw new InterruptError(`Transaction sending is interrupted`);
-    }
-
-    // Fail fast before doing any work (gas estimation, balance check) if the caller's deadline
-    // has already passed. The same check is repeated after gas estimation in case it took long
-    // enough to push us past the deadline.
-    if (gasConfigOverrides?.txTimeoutAt && new Date() > gasConfigOverrides.txTimeoutAt) {
-      throw new TimeoutError(
-        `Transaction timed out before sending (now ${new Date().toISOString()} > timeoutAt ${gasConfigOverrides.txTimeoutAt.toISOString()})`,
-      );
-    }
-
     try {
       const gasConfig = merge(this.config, gasConfigOverrides);
       const account = this.getSenderAddress().toString();
+
+      // Fail fast before doing any work (gas estimation, balance check) if we've been interrupted
+      // or if the caller's deadline has already passed. The same check is repeated after gas
+      // estimation in case it took long enough to push us past the deadline.
+      await this.checkInterruptedOrTimedOut(gasConfig);
 
       let gasLimit: bigint;
       if (this.debugMaxGasLimit) {
@@ -254,16 +259,7 @@ export class L1TxUtils extends ReadOnlyL1TxUtils {
 
       const gasPrice = await this.getGasPrice(gasConfig, !!blobInputs);
 
-      if (this.interrupted) {
-        throw new InterruptError(`Transaction sending is interrupted`);
-      }
-
-      const now = new Date(await this.getL1Timestamp());
-      if (gasConfig.txTimeoutAt && now > gasConfig.txTimeoutAt) {
-        throw new TimeoutError(
-          `Transaction timed out before sending (now ${now.toISOString()} > timeoutAt ${gasConfig.txTimeoutAt.toISOString()})`,
-        );
-      }
+      const now = await this.checkInterruptedOrTimedOut(gasConfig);
 
       let txHash: Hex;
       let nonce: number;


### PR DESCRIPTION
Addresses [Phil's review comment](https://github.com/AztecProtocol/aztec-packages/pull/23165#discussion_r3235804064) on #23165: uses the injected `DateProvider` instead of `new Date()` for the pre-gas-estimation timeout check in `L1TxUtils.sendTransaction`, so tests can drive the clock.