### PR TITLE
fix: format txe_oracle_version assert_eq in misc.nr

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment/test/misc.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment/test/misc.nr
@@ -60,8 +60,5 @@ unconstrained fn txe_oracle_version_is_checked_upon_env_creation() {
     let _env = TestEnvironment::new();
 
     assert_eq(mock.times_called(), 1);
-    assert_eq(
-        mock.get_last_params::<(Field, Field)>(),
-        (TXE_ORACLE_VERSION_MAJOR, TXE_ORACLE_VERSION_MINOR),
-    );
+    assert_eq(mock.get_last_params::<(Field, Field)>(), (TXE_ORACLE_VERSION_MAJOR, TXE_ORACLE_VERSION_MINOR));
 }


### PR DESCRIPTION
## Summary
- Fixes the `noir_format` CI failure on PR #23291 by collapsing the `assert_eq` in `txe_oracle_version_is_checked_upon_env_creation` onto a single line, matching what `nargo fmt` produces.