### PR TITLE
fix(archiver): atomic getter for L2 tips

### DIFF
--- a/yarn-project/archiver/src/store/block_store.ts
+++ b/yarn-project/archiver/src/store/block_store.ts
@@ -13,7 +13,10 @@ import {
   BlockHash,
   Body,
   CommitteeAttestation,
+  GENESIS_CHECKPOINT_HEADER_HASH,
   L2Block,
+  type L2TipId,
+  type L2Tips,
   type ValidateCheckpointResult,
   deserializeValidateCheckpointResult,
   serializeValidateCheckpointResult,
@@ -1130,6 +1133,174 @@ export class BlockStore {
   }
 
   /**
+   * Resolves all five L2 chain tips (proposed, proposedCheckpoint, checkpointed, proven, finalized)
+   * in a single read-only transaction so the snapshot is internally consistent. Each underlying
+   * record is read at most once: latest block, latest confirmed checkpoint, and latest pending
+   * checkpoint are each loaded directly (no separate "find the number, then look up data" hop),
+   * the proven/finalized checkpoint singletons are read once and their storage entries are
+   * reused if they coincide with the latest checkpoint, and per-tip block hashes are deduped
+   * when two tips land on the same block (e.g. finalized == proven, or proposedCheckpoint falls
+   * back to checkpointed when no pending checkpoint exists).
+   *
+   * The result is guaranteed to satisfy `finalized <= proven <= checkpointed <= proposed` (by
+   * block number). Genesis is represented by `(INITIAL_L2_BLOCK_NUM - 1)` and the supplied
+   * `genesisBlockHash`, paired with the synthetic genesis checkpoint id.
+   *
+   * @param genesisBlockHash - Block hash to report for the synthetic pre-initial block (used when
+   *   a tip is still at genesis).
+   */
+  async getL2TipsData(genesisBlockHash: BlockHash): Promise<L2Tips> {
+    return await this.db.transactionAsync(async () => {
+      // Define genesis tips
+      const genesisBlockNumber = BlockNumber(INITIAL_L2_BLOCK_NUM - 1);
+      const genesisCheckpointNumber = CheckpointNumber(INITIAL_CHECKPOINT_NUMBER - 1);
+      const genesisBlockId = { number: genesisBlockNumber, hash: genesisBlockHash.toString() };
+      const genesisCheckpointId = {
+        number: genesisCheckpointNumber,
+        hash: GENESIS_CHECKPOINT_HEADER_HASH.toString(),
+      };
+      const genesisTip: L2TipId = { block: genesisBlockId, checkpoint: genesisCheckpointId };
+
+      // Load latest block and checkpoint entries
+      const [latestBlockEntry] = await toArray(this.#blocks.entriesAsync({ reverse: true, limit: 1 }));
+      const [proposedCheckpointEntry] = await toArray(
+        this.#proposedCheckpoints.entriesAsync({ reverse: true, limit: 1 }),
+      );
+      const [latestCheckpointEntry] = await toArray(this.#checkpoints.entriesAsync({ reverse: true, limit: 1 }));
+      const latestCheckpointNumber = latestCheckpointEntry
+        ? CheckpointNumber(latestCheckpointEntry[0])
+        : genesisCheckpointNumber;
+
+      // Load proven and finalized checkpoint number pointers
+      const [provenRaw, finalizedRaw] = await Promise.all([
+        this.#lastProvenCheckpoint.getAsync(),
+        this.#lastFinalizedCheckpoint.getAsync(),
+      ]);
+
+      // Clamp to enforce finalized <= proven <= checkpointed.
+      const provenCheckpointNumber = CheckpointNumber(Math.min(provenRaw ?? 0, latestCheckpointNumber));
+      const finalizedCheckpointNumber = CheckpointNumber(Math.min(finalizedRaw ?? 0, provenCheckpointNumber));
+
+      // Avoid loading the same checkpoint more than once
+      const checkpointStorageCache = new Map<CheckpointNumber, CheckpointStorage>();
+      if (latestCheckpointEntry) {
+        checkpointStorageCache.set(CheckpointNumber(latestCheckpointEntry[0]), latestCheckpointEntry[1]);
+      }
+      const loadCheckpointStorage = async (n: CheckpointNumber): Promise<CheckpointStorage | undefined> => {
+        if (n === 0) {
+          return undefined;
+        }
+        if (!checkpointStorageCache.has(n)) {
+          const checkpointStorage = await this.#checkpoints.getAsync(n);
+          if (!checkpointStorage) {
+            throw new CheckpointNotFoundError(n);
+          }
+          checkpointStorageCache.set(n, checkpointStorage);
+        }
+        return checkpointStorageCache.get(n)!;
+      };
+
+      // Load proven and finalized checkpoint storage entries
+      const provenCheckpoint = await loadCheckpointStorage(provenCheckpointNumber);
+      const finalizedCheckpoint = await loadCheckpointStorage(finalizedCheckpointNumber);
+
+      // Avoid loading the same block hash multiple times when tips land on the same block
+      const blockHashCache = new Map<number, string>();
+      blockHashCache.set(genesisBlockNumber, genesisBlockHash.toString());
+      if (latestBlockEntry) {
+        blockHashCache.set(latestBlockEntry[0], BlockHash.fromBuffer(latestBlockEntry[1].blockHash).toString());
+      }
+      const loadBlockHash = async (n: BlockNumber): Promise<string> => {
+        if (!blockHashCache.has(n)) {
+          const blockStorage = await this.#blocks.getAsync(n);
+          if (!blockStorage) {
+            throw new BlockNotFoundError(n);
+          }
+          const blockHash = BlockHash.fromBuffer(blockStorage.blockHash).toString();
+          blockHashCache.set(n, blockHash);
+        }
+        return blockHashCache.get(n)!;
+      };
+
+      // Build proposed chain tip (this one has block only, no checkpoint)
+      const proposedBlockId =
+        latestBlockEntry === undefined
+          ? genesisBlockId
+          : {
+              number: BlockNumber(latestBlockEntry[0]),
+              hash: BlockHash.fromBuffer(latestBlockEntry[1].blockHash).toString(),
+            };
+
+      // Build other tips from checkpoint data, reading corresponding block data from the cache
+      const buildTipFromCheckpoint = async (
+        stored: ProposedCheckpointStorage | CheckpointStorage | undefined,
+      ): Promise<L2TipId> => {
+        if (!stored) {
+          return genesisTip;
+        }
+        const blockNumber = BlockNumber(stored.startBlock + stored.blockCount - 1);
+        const blockHash = await loadBlockHash(blockNumber);
+        const header = CheckpointHeader.fromBuffer(stored.header);
+        return {
+          block: { number: blockNumber, hash: blockHash },
+          checkpoint: { number: CheckpointNumber(stored.checkpointNumber), hash: header.hash().toString() },
+        };
+      };
+
+      const checkpointedTip = await buildTipFromCheckpoint(latestCheckpointEntry?.[1]);
+      const provenTip = await buildTipFromCheckpoint(provenCheckpoint);
+      const finalizedTip = await buildTipFromCheckpoint(finalizedCheckpoint);
+
+      // Proposed checkpoint falls back to the checkpoint tip if it's not set. And if local storage is
+      // inconsistent and the proposed checkpoint is behind the checkpointed tip, we patch that and
+      // report the checkpointed tip as the proposed checkpoint to maintain the invariant.
+      const proposedCheckpointTip =
+        proposedCheckpointEntry === undefined || proposedCheckpointEntry[0] <= latestCheckpointNumber
+          ? checkpointedTip
+          : await buildTipFromCheckpoint(proposedCheckpointEntry[1]);
+
+      // A checkpointed block past the latest stored block would mean a checkpoint
+      // references blocks that aren't in blocks.
+      if (proposedBlockId.number < checkpointedTip.block.number) {
+        throw new Error(
+          `Inconsistent block store: latest block ${proposedBlockId.number} is behind checkpointed block ${checkpointedTip.block.number}`,
+        );
+      }
+
+      // Assert that checkpoint numbers are increasing
+      if (
+        finalizedTip.checkpoint.number > provenTip.checkpoint.number ||
+        provenTip.checkpoint.number > checkpointedTip.checkpoint.number ||
+        checkpointedTip.checkpoint.number > proposedCheckpointTip.checkpoint.number
+      ) {
+        throw new Error(
+          `Inconsistent checkpoint numbers in chain tips: finalized=${finalizedTip.checkpoint.number} proven=${provenTip.checkpoint.number} checkpointed=${checkpointedTip.checkpoint.number} proposed=${proposedCheckpointTip.checkpoint.number}`,
+        );
+      }
+
+      // Assert block numbers are increasing
+      if (
+        finalizedTip.block.number > provenTip.block.number ||
+        provenTip.block.number > checkpointedTip.block.number ||
+        checkpointedTip.block.number > proposedCheckpointTip.block.number ||
+        proposedCheckpointTip.block.number > proposedBlockId.number
+      ) {
+        throw new Error(
+          `Inconsistent block numbers in chain tips: finalized=${finalizedTip.block.number} proven=${provenTip.block.number} checkpointed=${checkpointedTip.block.number} proposedCheckpoint=${proposedCheckpointTip.block.number} proposed=${proposedBlockId.number}`,
+        );
+      }
+
+      return {
+        proposed: proposedBlockId,
+        proposedCheckpoint: proposedCheckpointTip,
+        checkpointed: checkpointedTip,
+        proven: provenTip,
+        finalized: finalizedTip,
+      };
+    });
+  }
+
+  /**
    * Gets the most recent L1 block processed.
    * @returns The L1 block that published the latest L2 block
    */
@@ -1188,13 +1359,15 @@ export class BlockStore {
   }
 
   async getProvenCheckpointNumber(): Promise<CheckpointNumber> {
-    const [latestCheckpointNumber, provenCheckpointNumber] = await Promise.all([
-      this.getLatestCheckpointNumber(),
-      this.#lastProvenCheckpoint.getAsync(),
-    ]);
-    return (provenCheckpointNumber ?? 0) > latestCheckpointNumber
-      ? latestCheckpointNumber
-      : CheckpointNumber(provenCheckpointNumber ?? 0);
+    return await this.db.transactionAsync(async () => {
+      const [latestCheckpointNumber, provenCheckpointNumber] = await Promise.all([
+        this.getLatestCheckpointNumber(),
+        this.#lastProvenCheckpoint.getAsync(),
+      ]);
+      return (provenCheckpointNumber ?? 0) > latestCheckpointNumber
+        ? latestCheckpointNumber
+        : CheckpointNumber(provenCheckpointNumber ?? 0);
+    });
   }
 
   async setProvenCheckpointNumber(checkpointNumber: CheckpointNumber) {
@@ -1203,13 +1376,15 @@ export class BlockStore {
   }
 
   async getFinalizedCheckpointNumber(): Promise<CheckpointNumber> {
-    const [latestCheckpointNumber, finalizedCheckpointNumber] = await Promise.all([
-      this.getLatestCheckpointNumber(),
-      this.#lastFinalizedCheckpoint.getAsync(),
-    ]);
-    return (finalizedCheckpointNumber ?? 0) > latestCheckpointNumber
-      ? latestCheckpointNumber
-      : CheckpointNumber(finalizedCheckpointNumber ?? 0);
+    return await this.db.transactionAsync(async () => {
+      const [provenCheckpointNumber, finalizedCheckpointNumber] = await Promise.all([
+        this.getProvenCheckpointNumber(),
+        this.#lastFinalizedCheckpoint.getAsync(),
+      ]);
+      return (finalizedCheckpointNumber ?? 0) > provenCheckpointNumber
+        ? provenCheckpointNumber
+        : CheckpointNumber(finalizedCheckpointNumber ?? 0);
+    });
   }
 
   setFinalizedCheckpointNumber(checkpointNumber: CheckpointNumber) {

--- a/yarn-project/archiver/src/store/l2_tips_cache.ts
+++ b/yarn-project/archiver/src/store/l2_tips_cache.ts
@@ -1,12 +1,4 @@
-import { INITIAL_L2_BLOCK_NUM } from '@aztec/constants';
-import { BlockNumber, CheckpointNumber } from '@aztec/foundation/branded-types';
-import {
-  type BlockData,
-  type BlockHash,
-  type CheckpointId,
-  GENESIS_CHECKPOINT_HEADER_HASH,
-  type L2Tips,
-} from '@aztec/stdlib/block';
+import type { BlockHash, L2Tips } from '@aztec/stdlib/block';
 
 import type { BlockStore } from './block_store.js';
 
@@ -20,10 +12,10 @@ export class L2TipsCache {
   #tipsPromise: Promise<L2Tips> | undefined;
 
   /**
-   * Asymmetric by design: the genesis block hash is dynamic — derived from the injected initial header,
-   * which depends on `genesisTimestamp` and any prefilled state. The genesis checkpoint hash is static —
-   * checkpoint 0 is fully synthetic (no real checkpoint header exists at 0), so it stays at the protocol
-   * constant `GENESIS_CHECKPOINT_HEADER_HASH`.
+   * The genesis block hash is dynamic — derived from the injected initial header, which depends on
+   * `genesisTimestamp` and any prefilled state — so it is supplied here rather than read from store.
+   * The genesis checkpoint hash, by contrast, is the static protocol constant and is resolved
+   * inside the block store.
    */
   constructor(
     private blockStore: BlockStore,
@@ -32,115 +24,12 @@ export class L2TipsCache {
 
   /** Returns the cached L2 tips. Loads from the block store on first call. */
   public getL2Tips(): Promise<L2Tips> {
-    return (this.#tipsPromise ??= this.loadFromStore());
+    return (this.#tipsPromise ??= this.blockStore.getL2TipsData(this.initialBlockHash));
   }
 
   /** Reloads the L2 tips from the block store. Should be called after the writer transaction has committed. */
   public async refresh(): Promise<void> {
-    this.#tipsPromise = this.loadFromStore();
+    this.#tipsPromise = this.blockStore.getL2TipsData(this.initialBlockHash);
     await this.#tipsPromise;
-  }
-
-  private async loadFromStore(): Promise<L2Tips> {
-    const [
-      latestBlockNumber,
-      provenBlockNumber,
-      proposedCheckpointBlockNumber,
-      checkpointedBlockNumber,
-      finalizedBlockNumber,
-    ] = await Promise.all([
-      this.blockStore.getLatestL2BlockNumber(),
-      this.blockStore.getProvenBlockNumber(),
-      this.blockStore.getProposedCheckpointL2BlockNumber(),
-      this.blockStore.getCheckpointedL2BlockNumber(),
-      this.blockStore.getFinalizedL2BlockNumber(),
-    ]);
-
-    const genesisBlockHeader = {
-      blockHash: this.initialBlockHash,
-      checkpointNumber: CheckpointNumber.ZERO,
-    } as const;
-    const beforeInitialBlockNumber = BlockNumber(INITIAL_L2_BLOCK_NUM - 1);
-
-    const getBlockData = (blockNumber: BlockNumber) =>
-      blockNumber > beforeInitialBlockNumber
-        ? this.blockStore.getBlockData({ number: blockNumber })
-        : genesisBlockHeader;
-
-    const [latestBlockData, provenBlockData, proposedCheckpointBlockData, checkpointedBlockData, finalizedBlockData] =
-      await Promise.all(
-        [
-          latestBlockNumber,
-          provenBlockNumber,
-          proposedCheckpointBlockNumber,
-          checkpointedBlockNumber,
-          finalizedBlockNumber,
-        ].map(getBlockData),
-      );
-
-    if (
-      !latestBlockData ||
-      !provenBlockData ||
-      !finalizedBlockData ||
-      !checkpointedBlockData ||
-      !proposedCheckpointBlockData
-    ) {
-      throw new Error('Failed to load block data for L2 tips');
-    }
-
-    const [provenCheckpointId, finalizedCheckpointId, proposedCheckpointId, checkpointedCheckpointId] =
-      await Promise.all([
-        this.getCheckpointIdForBlock(provenBlockData),
-        this.getCheckpointIdForBlock(finalizedBlockData),
-        this.getCheckpointIdForProposedCheckpoint(checkpointedBlockData),
-        this.getCheckpointIdForBlock(checkpointedBlockData),
-      ]);
-
-    return {
-      proposed: { number: latestBlockNumber, hash: latestBlockData.blockHash.toString() },
-      proven: {
-        block: { number: provenBlockNumber, hash: provenBlockData.blockHash.toString() },
-        checkpoint: provenCheckpointId,
-      },
-      proposedCheckpoint: {
-        block: { number: proposedCheckpointBlockNumber, hash: proposedCheckpointBlockData.blockHash.toString() },
-        checkpoint: proposedCheckpointId,
-      },
-      finalized: {
-        block: { number: finalizedBlockNumber, hash: finalizedBlockData.blockHash.toString() },
-        checkpoint: finalizedCheckpointId,
-      },
-      checkpointed: {
-        block: { number: checkpointedBlockNumber, hash: checkpointedBlockData.blockHash.toString() },
-        checkpoint: checkpointedCheckpointId,
-      },
-    };
-  }
-
-  private async getCheckpointIdForProposedCheckpoint(
-    checkpointedBlockData: Pick<BlockData, 'checkpointNumber'>,
-  ): Promise<CheckpointId> {
-    const checkpointData = await this.blockStore.getLastProposedCheckpoint();
-    if (!checkpointData) {
-      return this.getCheckpointIdForBlock(checkpointedBlockData);
-    }
-    return {
-      number: checkpointData.checkpointNumber,
-      hash: checkpointData.header.hash().toString(),
-    };
-  }
-
-  private async getCheckpointIdForBlock(blockData: Pick<BlockData, 'checkpointNumber'>): Promise<CheckpointId> {
-    const checkpointData = await this.blockStore.getCheckpointData(blockData.checkpointNumber);
-    if (!checkpointData) {
-      return {
-        number: CheckpointNumber.ZERO,
-        hash: GENESIS_CHECKPOINT_HEADER_HASH.toString(),
-      };
-    }
-    return {
-      number: checkpointData.checkpointNumber,
-      hash: checkpointData.header.hash().toString(),
-    };
   }
 }

--- a/yarn-project/stdlib/src/block/l2_block_stream/l2_tips_store_base.ts
+++ b/yarn-project/stdlib/src/block/l2_block_stream/l2_tips_store_base.ts
@@ -213,11 +213,30 @@ export abstract class L2TipsStoreBase implements L2BlockStreamEventHandler, L2Bl
       await this.saveTag('finalized', event.block);
       const finalizedCheckpointNumber = await this.getCheckpointNumberForBlock(event.block.number);
 
-      await this.deleteBlockHashesBefore(event.block.number);
-      await this.deleteBlockToCheckpointBefore(event.block.number);
+      // Cap the deletion bound at the lowest live tip. This should always be the finalized tip, but
+      // we have hit bugs where this is not the case. Deleting the block hash, block-to-checkpoint mapping,
+      // or enclosing checkpoint object for a live tip would dangle subsequent `getBlockId`/`getCheckpointId`
+      // lookups and lock the block stream into an error loop.
+      const tips = await Promise.all([
+        this.getTip('proposed'),
+        this.getTip('proposedCheckpoint'),
+        this.getTip('checkpointed'),
+        this.getTip('proven'),
+      ]);
+      const liveTipBlocks = tips.filter((t): t is BlockNumber => t !== undefined && t > 0);
+      const safeBlockBound = BlockNumber(Math.min(event.block.number, ...liveTipBlocks));
+      await this.deleteBlockHashesBefore(safeBlockBound);
+      await this.deleteBlockToCheckpointBefore(safeBlockBound);
 
       if (finalizedCheckpointNumber !== undefined) {
-        await this.deleteCheckpointsBefore(finalizedCheckpointNumber);
+        const tipCheckpoints = await Promise.all(liveTipBlocks.map(b => this.getCheckpointNumberForBlock(b)));
+        const safeCheckpointBound = CheckpointNumber(
+          Math.min(
+            finalizedCheckpointNumber,
+            ...tipCheckpoints.filter((c): c is CheckpointNumber => c !== undefined && c > 0),
+          ),
+        );
+        await this.deleteCheckpointsBefore(safeCheckpointBound);
       }
     });
   }


### PR DESCRIPTION
Prevents the archiver from reporting invalid L2 tips by querying all chain tips within a db transaction. Moves the responsibility of assembling the tip data to the block store itself to minimize the number of queries to the db. Clamps proven and finalized tips such that an incorrect L1 sync still results in finalized <= proven <= checkpoints. And adds explicit assertions that tips are ordered.

Also adds a guard in the tips store that prevents from deleting block hashes that are still alive by a given chain tip, instead of assuming that the finalized chain tip is always the oldest one.

This should catch errors where the block stream breaks due to a finalized chain tip running ahead of a proven chain tip.

Note that this PR does NOT enforce ordering at the L2Tips struct itself, since consumers (ie the ones that report the "local" chain tips) may break this contract (see A-1061). This PR is a simpler alternative to #22964. Fixes A-1018.