### PR TITLE
fix(world-state): make fork close idempotent for pruned forks

### DIFF
--- a/yarn-project/world-state/src/native/ipc_world_state_instance.ts
+++ b/yarn-project/world-state/src/native/ipc_world_state_instance.ts
@@ -279,28 +279,33 @@ export class IpcWorldState implements NativeWorldStateInstance {
       this.queues.set(forkId, requestQueue);
     }
 
-    const response = await requestQueue.execute(
-      async () => {
-        assert.notEqual(messageType, WorldStateMessageType.CLOSE, 'Use close() to close the IPC instance');
-        assert.equal(this.open, true, 'IPC instance is closed');
-        let response: WorldStateResponse[T];
-        try {
-          response = await this._sendMessage(messageType, body);
-        } catch (error: any) {
-          errorHandler(error.message);
-          throw error;
-        }
-        return responseHandler(response);
-      },
-      messageType,
-      committedOnly,
-    );
-
-    if (messageType === WorldStateMessageType.DELETE_FORK) {
-      await requestQueue.stop();
-      this.queues.delete(forkId);
+    // The per-fork queue is cleaned up in `finally` even on error, so the JS-side queues map cannot outlive
+    // the native fork (e.g. when the native fork was already destroyed by an unwind/historical-prune and
+    // DELETE_FORK rejects with "Fork not found").
+    try {
+      const response = await requestQueue.execute(
+        async () => {
+          assert.notEqual(messageType, WorldStateMessageType.CLOSE, 'Use close() to close the IPC instance');
+          assert.equal(this.open, true, 'IPC instance is closed');
+          let response: WorldStateResponse[T];
+          try {
+            response = await this._sendMessage(messageType, body);
+          } catch (error: any) {
+            errorHandler(error.message);
+            throw error;
+          }
+          return responseHandler(response);
+        },
+        messageType,
+        committedOnly,
+      );
+      return response;
+    } finally {
+      if (messageType === WorldStateMessageType.DELETE_FORK) {
+        await requestQueue.stop();
+        this.queues.delete(forkId);
+      }
     }
-    return response;
   }
 
   async close(): Promise<void> {

--- a/yarn-project/world-state/src/native/merkle_trees_facade.ts
+++ b/yarn-project/world-state/src/native/merkle_trees_facade.ts
@@ -208,6 +208,7 @@ export class MerkleTreesFacade implements MerkleTreeReadOperations {
 
 export class MerkleTreesForkFacade extends MerkleTreesFacade implements MerkleTreeWriteOperations {
   private log = createLogger('world-state:merkle-trees-fork-facade');
+  private closePromise: Promise<void> | undefined;
 
   constructor(
     instance: NativeWorldStateInstance,
@@ -291,14 +292,29 @@ export class MerkleTreesForkFacade extends MerkleTreesFacade implements MerkleTr
     };
   }
 
-  public async close(): Promise<void> {
+  public close(): Promise<void> {
     assert.notEqual(this.revision.forkId, 0, 'Fork ID must be set');
+    // Share the in-flight close promise across duplicate dispose calls so DELETE_FORK is sent at most once.
+    if (this.closePromise) {
+      return this.closePromise;
+    }
+    this.closePromise = this.doClose();
+    return this.closePromise;
+  }
+
+  private async doClose(): Promise<void> {
     try {
       await this.instance.call(WorldStateMessageType.DELETE_FORK, { forkId: this.revision.forkId });
     } catch (err: any) {
       // Ignore errors due to native instance being closed during shutdown.
       // This can happen when validators are still processing block proposals while the node is stopping.
       if (err?.message === 'Native instance is closed') {
+        return;
+      }
+      // Ignore "Fork not found": the native fork was already destroyed by a pending-chain unwind or a
+      // historical prune (both call C++ remove_forks_for_block). Fork IDs are monotonic and never reused,
+      // so swallowing this on close cannot mask a deletion of a different fork.
+      if (err?.message === 'Fork not found') {
         return;
       }
       throw err;
@@ -310,9 +326,6 @@ export class MerkleTreesForkFacade extends MerkleTreesFacade implements MerkleTr
       void sleep(this.opts.closeDelayMs)
         .then(() => this.close())
         .catch(err => {
-          if (err && 'message' in err && err.message === 'Native instance is closed') {
-            return; // Ignore errors due to native instance being closed
-          }
           this.log.warn('Error closing MerkleTreesForkFacade after delay', { err });
         });
     } else {

--- a/yarn-project/world-state/src/native/native_world_state.test.ts
+++ b/yarn-project/world-state/src/native/native_world_state.test.ts
@@ -14,6 +14,7 @@ import { timesAsync } from '@aztec/foundation/collection';
 import { randomBytes } from '@aztec/foundation/crypto/random';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { EthAddress } from '@aztec/foundation/eth-address';
+import { sleep } from '@aztec/foundation/sleep';
 import type { SiblingPath } from '@aztec/foundation/trees';
 import { PublicDataWrite } from '@aztec/stdlib/avm';
 import { L2Block } from '@aztec/stdlib/block';
@@ -936,6 +937,33 @@ describe('NativeWorldState', () => {
           await expect(blockForks[i].getSiblingPath(MerkleTreeId.NULLIFIER_TREE, 0n)).rejects.toThrow('Fork not found');
         }
       }
+    });
+
+    // Regression test for A-1055: a delayed-close fork that the C++ side has already destroyed (via
+    // remove_forks_for_block on an unwind or historical prune) must dispose silently rather than logging a
+    // warning, and its JS-side per-fork queue entry must be cleaned up.
+    it('does not fail when a delayed-close fork is destroyed by a reorg before its close fires', async () => {
+      const baseFork = await ws.fork();
+      for (let i = 0; i < 3; i++) {
+        const { block, messages } = await mockBlock(BlockNumber(i + 1), 1, baseFork);
+        await ws.handleL2BlockAndMessages(block, messages);
+      }
+      await baseFork.close();
+
+      const closeDelayMs = 1000;
+      const delayedFork = await ws.fork(undefined, { closeDelayMs });
+      const forkId = (delayedFork as any).revision.forkId;
+      const warnSpy = jest.spyOn((delayedFork as any).log, 'warn');
+
+      await (delayedFork as any)[Symbol.asyncDispose]();
+
+      await ws.unwindBlocks(BlockNumber.fromBigInt(2n));
+      await expect(delayedFork.getSiblingPath(MerkleTreeId.NULLIFIER_TREE, 0n)).rejects.toThrow('Fork not found');
+
+      await sleep(closeDelayMs * 3);
+
+      expect(warnSpy).not.toHaveBeenCalled();
+      expect((ws as any).instance.queues.has(forkId)).toBe(false);
     });
   });
 

--- a/yarn-project/world-state/src/native/native_world_state_instance.ts
+++ b/yarn-project/world-state/src/native/native_world_state_instance.ts
@@ -184,30 +184,33 @@ export class NativeWorldState implements NativeWorldStateInstance {
       this.queues.set(forkId, requestQueue);
     }
 
-    // Enqueue the request and wait for the response
-    const response = await requestQueue.execute(
-      async () => {
-        assert.notEqual(messageType, WorldStateMessageType.CLOSE, 'Use close() to close the native instance');
-        assert.equal(this.open, true, 'Native instance is closed');
-        let response: WorldStateResponse[T];
-        try {
-          response = await this._sendMessage(messageType, body);
-        } catch (error: any) {
-          errorHandler(error.message);
-          throw error;
-        }
-        return responseHandler(response);
-      },
-      messageType,
-      committedOnly,
-    );
-
-    // If the request was to delete the fork then we clean it up here
-    if (messageType === WorldStateMessageType.DELETE_FORK) {
-      await requestQueue.stop();
-      this.queues.delete(forkId);
+    // Enqueue the request and wait for the response. The per-fork queue is cleaned up in `finally` even on
+    // error, so the JS-side queues map cannot outlive the native fork (e.g. when the native fork was already
+    // destroyed by an unwind/historical-prune and DELETE_FORK rejects with "Fork not found").
+    try {
+      const response = await requestQueue.execute(
+        async () => {
+          assert.notEqual(messageType, WorldStateMessageType.CLOSE, 'Use close() to close the native instance');
+          assert.equal(this.open, true, 'Native instance is closed');
+          let response: WorldStateResponse[T];
+          try {
+            response = await this._sendMessage(messageType, body);
+          } catch (error: any) {
+            errorHandler(error.message);
+            throw error;
+          }
+          return responseHandler(response);
+        },
+        messageType,
+        committedOnly,
+      );
+      return response;
+    } finally {
+      if (messageType === WorldStateMessageType.DELETE_FORK) {
+        await requestQueue.stop();
+        this.queues.delete(forkId);
+      }
     }
-    return response;
   }
 
   /**


### PR DESCRIPTION
## Motivation

Under proposer pipelining, the checkpoint job opens a world-state fork with `closeDelayMs: 12_000`. If a pending-chain unwind or historical prune destroys that fork on the C++ side before the delay fires, `DELETE_FORK` rejects with `"Fork not found"`, producing a stray warn log and leaking the per-fork queue entry in the JS instance — one dead entry per affected pipelined slot.

## Approach

Make `close()` idempotent via an in-flight `closePromise`, and treat `"Fork not found"` as benign on close (same precedent as the existing `"Native instance is closed"` suppression — fork IDs are monotonic and never reused). Also wrap the per-fork queue cleanup in `try/finally` in both the native and IPC instances so the JS-side queue map cannot outlive the native fork on error.

## Changes

- **world-state**: `MerkleTreesForkFacade.close()` is now idempotent and swallows `"Fork not found"`; per-fork queue cleanup in `NativeWorldStateInstance` and `IpcWorldStateInstance` moved to `finally`.
- **world-state (tests)**: Regression test that disposes a `closeDelayMs` fork, triggers an unwind that destroys it on the C++ side, and asserts no warn is logged and the queue entry is cleaned up.

Fixes A-1055