### PR TITLE
test(e2e): switch fee_settings to organic fee bumps under pipelining

### DIFF
--- a/yarn-project/end-to-end/src/e2e_fees/fee_settings.test.ts
+++ b/yarn-project/end-to-end/src/e2e_fees/fee_settings.test.ts
@@ -235,8 +235,8 @@ describe('e2e_fees fee settings', () => {
       // skipped between the bump and recovery — that's the positive signal that a pipelined
       // header was actually dropped, distinguishing the A-1057 recovery path from a chain that
       // silently absorbed the governance write without exercising the failure case.
-      const checkpointBefore = await aztecNode.getBlockNumber('checkpointed');
-      const slotBefore = (await aztecNode.getCheckpoint(CheckpointNumber(checkpointBefore)))!.header.slotNumber;
+      const checkpointBefore = await aztecNode.getCheckpointNumber('checkpointed');
+      const slotBefore = (await aztecNode.getCheckpoint(checkpointBefore))!.header.slotNumber;
 
       t.logger.info(`Bumping provingCostPerMana at checkpointed=${checkpointBefore} (slot ${slotBefore})`);
       await cheatCodes.rollup.bumpProvingCostPerMana(current => (current * 120n) / 100n);
@@ -245,10 +245,10 @@ describe('e2e_fees fee settings', () => {
       // 6 slot windows before insisting the chain has made forward progress past the bump. With
       // pipelining + minTxsPerBlock=0 an idle chain still emits empty checkpoints, so the
       // `checkpointed` tip must strictly advance.
-      const RECOVERY_TARGET = CheckpointNumber(checkpointBefore + 3);
+      const RECOVERY_TARGET = CheckpointNumber.add(checkpointBefore, 3);
       const RECOVERY_BUDGET_SECONDS = AZTEC_SLOT_DURATION * 6;
       await retryUntil(
-        async () => (await aztecNode.getBlockNumber('checkpointed')) >= RECOVERY_TARGET,
+        async () => (await aztecNode.getCheckpointNumber('checkpointed')) >= RECOVERY_TARGET,
         `chain advances at least ${RECOVERY_TARGET - checkpointBefore} checkpoints past governance bump`,
         RECOVERY_BUDGET_SECONDS,
         1,

--- a/yarn-project/end-to-end/src/e2e_fees/fee_settings.test.ts
+++ b/yarn-project/end-to-end/src/e2e_fees/fee_settings.test.ts
@@ -1,7 +1,7 @@
 import type { AztecAddress } from '@aztec/aztec.js/addresses';
 import type { AztecNode } from '@aztec/aztec.js/node';
 import { CheatCodes } from '@aztec/aztec/testing';
-import type { BlockNumber } from '@aztec/foundation/branded-types';
+import { BlockNumber, CheckpointNumber } from '@aztec/foundation/branded-types';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { retryUntil } from '@aztec/foundation/retry';
 import { TestContract } from '@aztec/noir-test-contracts.js/Test';
@@ -24,7 +24,27 @@ describe('e2e_fees fee settings', () => {
   let gasSettings: Partial<GasSettings>;
   let testContract: TestContract;
   let testContractDeployBlock: BlockNumber;
-  const t = new FeesTest('fee_juice', 1);
+
+  // Run under proposer pipelining. `manaTarget` is set just above the largest setup tx
+  // (account deploy ~6.5M mana, so manaLimit = 2 * manaTarget = 8M covers it). `walletMinFeePadding: 30`
+  // matches PR #23150's pipelining-aware default — under pipelining the proposer's fee evolves up to ~20x
+  // between PXE snapshot and inclusion for setup txs, so the 5x default is no longer sufficient.
+  // (Test-body txs explicitly call `wallet.setMinFeePadding(...)` so they don't use the wallet default.)
+  const AZTEC_SLOT_DURATION = 12;
+  const t = new FeesTest('fee_juice', 1, {
+    enableProposerPipelining: true,
+    inboxLag: 2,
+    minTxsPerBlock: 0,
+    aztecSlotDuration: AZTEC_SLOT_DURATION,
+    ethereumSlotDuration: 4,
+    aztecProofSubmissionEpochs: 640,
+    walletMinFeePadding: 30,
+    manaTarget: 4_000_000n,
+  });
+
+  // FeesTest.setup chains many dependent txs which run at the pipelined cadence (one per L2 slot);
+  // the default 300s jest hook timeout is not enough.
+  jest.setTimeout(600_000);
 
   beforeAll(async () => {
     await t.setup();
@@ -43,12 +63,45 @@ describe('e2e_fees fee settings', () => {
   });
 
   describe('setting max fee per gas', () => {
-    const bumpL2Fees = async () => {
+    // Drive an organic L2 fee bump via an L1 base-fee spike. On mainnet, L1 base fees fluctuate
+    // organically with L1 demand and dominate `feePerL2Gas` (the rollup's L1 gas oracle samples
+    // L1 base fee into `post` at every successful rotation and the L2 manaMinFee is derived from
+    // it). We simulate that by setting the next L1 block's base fee to a multiple of the current
+    // one and forcing an oracle rotation via the cheatcode-callable `Rollup.updateL1GasFeeOracle`.
+    // Unlike `bumpProvingCostPerMana` (the only-owner governance write previously used here), this
+    // does NOT mutate `FeeStore.config`, so it does not trigger the `Rollup__InvalidManaMinFee`
+    // recovery race that pipelined proposers hit when governance config mutates between header
+    // build and L1 submission.
+    //
+    // Congestion via heavy L2 txs was considered: each `emit_nullifier_public` is only ~570k mana,
+    // and at `manaTarget=4M` the sequencer takes ~3 of those per checkpoint (~1.88M mana — well
+    // below target), so excessMana stays at zero and the congestion-multiplier channel never
+    // engages. The L1 base-fee channel is both more reliable here and a closer analogue to
+    // mainnet behaviour (L1 base fee swings happen routinely; sustained L2 congestion is rarer).
+    const inflateL2FeesViaL1BaseFee = async () => {
       const before = await aztecNode.getCurrentMinFees();
       t.logger.info(`Initial L2 min fees are ${inspect(before)}`, { minFees: before.toInspect() });
-      await cheatCodes.rollup.bumpProvingCostPerMana(current => (current * 120n) / 100n);
+
+      // Read current L1 base fee and bump to ~3x; this keeps the resulting L2 fee bump within the
+      // ~6x window the test assertions require (bump must be >1x to make the no-padding tx fail
+      // and <6x for `DEFAULT_MIN_FEE_PADDING=5` to still cover it). The oracle rotation deadband
+      // (`LIFETIME - LAG = 3` L2 slots between successful rotations, see FeeLib.sol:170) means
+      // our `updateL1GasFeeOracle` call may be rejected if a recent sequencer propose already
+      // rotated it; we retry on every iteration so eventually one of them lands.
+      const latestL1Block = await cheatCodes.eth.publicClient.getBlock();
+      const currentL1BaseFee = latestL1Block.baseFeePerGas ?? 1_000_000_000n;
+      const targetL1BaseFee = currentL1BaseFee * 3n;
+      t.logger.info(`Targeting L1 base fee ${targetL1BaseFee} (current ${currentL1BaseFee})`);
+
       return await retryUntil(
         async () => {
+          await cheatCodes.eth.setNextBlockBaseFeePerGas(targetL1BaseFee);
+          await cheatCodes.eth.mine();
+          try {
+            await cheatCodes.rollup.updateL1GasFeeOracle();
+          } catch {
+            // Rotation deadband closed — try again on the next iteration.
+          }
           const after = await aztecNode.getCurrentMinFees();
           t.logger.info(`L2 min fees are now ${inspect(after)}`, {
             minFeesBefore: before.toInspect(),
@@ -56,8 +109,8 @@ describe('e2e_fees fee settings', () => {
           });
           return after.feePerL2Gas > before.feePerL2Gas ? after : undefined;
         },
-        'L2 min fee increase',
-        5,
+        'L2 min fee organic increase (L1 base fee bump)',
+        60,
         1,
       );
     };
@@ -93,7 +146,8 @@ describe('e2e_fees fee settings', () => {
     };
 
     const prepareTxsWithMockedMinFees = async (noPaddingMinFees: GasFees, defaultPaddingMinFees: GasFees) => {
-      // Mock getPredictedMinFees (used by the wallet) and getCurrentMinFees (used by bumpL2Fees and other callers).
+      // Mock getPredictedMinFees (used by the wallet) and getCurrentMinFees (used by inflateL2FeesViaCongestion
+      // and other callers).
       const getPredictedMinFeesSpy = jest
         .spyOn(aztecNode, 'getPredictedMinFees')
         .mockResolvedValueOnce([noPaddingMinFees])
@@ -124,8 +178,8 @@ describe('e2e_fees fee settings', () => {
         ),
       ).toBe(true);
 
-      // Now bump the L2 fees before we actually send them
-      const bumpedMinFees = await bumpL2Fees();
+      // Now bump the L2 fees organically (L1 base fee spike) before we actually send them
+      const bumpedMinFees = await inflateL2FeesViaL1BaseFee();
       expect(stableMinFees.feePerL2Gas).toBeLessThan(bumpedMinFees.feePerL2Gas);
       expect(stableMinFees.mul(1 + DEFAULT_MIN_FEE_PADDING).feePerL2Gas).toBeGreaterThan(bumpedMinFees.feePerL2Gas);
 
@@ -148,7 +202,7 @@ describe('e2e_fees fee settings', () => {
         ),
       ).toBe(true);
 
-      const bumpedMinFees = await bumpL2Fees();
+      const bumpedMinFees = await inflateL2FeesViaL1BaseFee();
       expect(lowerMinFees.feePerL2Gas).toBeLessThan(bumpedMinFees.feePerL2Gas);
       expect(higherMinFees.feePerL2Gas).toBeGreaterThan(bumpedMinFees.feePerL2Gas);
       expect(lowerMinFees.mul(1 + DEFAULT_MIN_FEE_PADDING).feePerL2Gas).toBeGreaterThan(bumpedMinFees.feePerL2Gas);
@@ -157,6 +211,39 @@ describe('e2e_fees fee settings', () => {
       // accidentally prepared against an earlier, higher fee snapshot than the padded tx.
       await expect(txWithNoPadding.send()).resolves.toBeDefined();
       await expect(txWithDefaultPadding.send()).resolves.toBeDefined();
+    });
+
+    // Regression test for A-1057. Under pipelining, the proposer for slot N starts building the
+    // checkpoint header (and bakes `manaMinFee` into `gasFees.feePerL2Gas`) during slot N-1. If
+    // governance executes `setProvingCostPerMana` or `updateManaTarget` between that build and the
+    // L1 submission, L1 recomputes `manaMinFee` from the post-mutation `FeeStore.config` and the
+    // submitted header reverts with `Rollup__InvalidManaMinFee`. The chain should eat the
+    // in-flight checkpoint and the next pipelined proposer should produce a header that validates,
+    // resuming normal block production. This test exercises that path end-to-end: bump once, then
+    // verify the chain advances and a fresh tx still mines.
+    it('recovers after a governance fee-config bump invalidates a pipelined checkpoint', async () => {
+      // Take a fresh checkpoint baseline so we measure progress strictly post-bump.
+      const checkpointBefore = await aztecNode.getBlockNumber('checkpointed');
+
+      t.logger.info(`Bumping provingCostPerMana with checkpointed=${checkpointBefore}`);
+      await cheatCodes.rollup.bumpProvingCostPerMana(current => (current * 120n) / 100n);
+
+      // At most a couple of pipelined headers were built against the pre-bump config; allow up to
+      // 6 slot windows (i.e. 6 retry windows of one slot each) before insisting the chain has made
+      // forward progress past the bump. With pipelining + minTxsPerBlock=0 an idle chain still
+      // emits empty checkpoints, so the `checkpointed` tip must strictly advance.
+      const RECOVERY_TARGET = CheckpointNumber(checkpointBefore + 3);
+      const RECOVERY_BUDGET_SECONDS = AZTEC_SLOT_DURATION * 6;
+      await retryUntil(
+        async () => (await aztecNode.getBlockNumber('checkpointed')) >= RECOVERY_TARGET,
+        `chain advances at least ${RECOVERY_TARGET - checkpointBefore} checkpoints past governance bump`,
+        RECOVERY_BUDGET_SECONDS,
+        1,
+      );
+
+      // Fresh tx prepared against the post-bump fee snapshot still mines under default padding.
+      const tx = await proveTx(undefined);
+      await expect(tx.send()).resolves.toBeDefined();
     });
   });
 });

--- a/yarn-project/end-to-end/src/e2e_fees/fee_settings.test.ts
+++ b/yarn-project/end-to-end/src/e2e_fees/fee_settings.test.ts
@@ -82,15 +82,19 @@ describe('e2e_fees fee settings', () => {
       const before = await aztecNode.getCurrentMinFees();
       t.logger.info(`Initial L2 min fees are ${inspect(before)}`, { minFees: before.toInspect() });
 
-      // Read current L1 base fee and bump to ~3x; this keeps the resulting L2 fee bump within the
-      // ~6x window the test assertions require (bump must be >1x to make the no-padding tx fail
-      // and <6x for `DEFAULT_MIN_FEE_PADDING=5` to still cover it). The oracle rotation deadband
-      // (`LIFETIME - LAG = 3` L2 slots between successful rotations, see FeeLib.sol:170) means
-      // our `updateL1GasFeeOracle` call may be rejected if a recent sequencer propose already
-      // rotated it; we retry on every iteration so eventually one of them lands.
+      // Bump next L1 block base fee to ~3x current with a 0.1 gwei floor. Two constraints shape
+      // the target: (1) the L2 fee bump must land in (1.1x, 6x) of `before` so the magnitude
+      // assertions in the callers hold (>10% rise; under DEFAULT_MIN_FEE_PADDING=5's 6x cap),
+      // and (2) the L2 rotation compares the new oracle `post` against the previously snapshotted
+      // value — anvil's natural EIP-1559 decay between rotations means "3x current L1" can be
+      // *below* the previous snapshot if decay has been aggressive, in which case the L2 fee
+      // would drop. The 0.1 gwei floor guarantees the new snapshot exceeds typical decayed values.
+      // The oracle rotation deadband (`LIFETIME - LAG = 3` L2 slots between successful rotations,
+      // see FeeLib.sol:170) silently no-ops `updateL1GasFeeOracle` until the window opens, so we
+      // retry on every iteration until one of them lands and produces a rise.
       const latestL1Block = await cheatCodes.eth.publicClient.getBlock();
       const currentL1BaseFee = latestL1Block.baseFeePerGas ?? 1_000_000_000n;
-      const targetL1BaseFee = currentL1BaseFee * 3n;
+      const targetL1BaseFee = currentL1BaseFee * 3n > 100_000_000n ? currentL1BaseFee * 3n : 100_000_000n;
       t.logger.info(`Targeting L1 base fee ${targetL1BaseFee} (current ${currentL1BaseFee})`);
 
       return await retryUntil(
@@ -178,9 +182,12 @@ describe('e2e_fees fee settings', () => {
         ),
       ).toBe(true);
 
-      // Now bump the L2 fees organically (L1 base fee spike) before we actually send them
+      // Now bump the L2 fees organically (L1 base fee spike) before we actually send them.
+      // Require the bump to be at least 10% — a "any-positive-rise" check is satisfied by 1 wei
+      // and doesn't prove a meaningful fee shift was handled.
       const bumpedMinFees = await inflateL2FeesViaL1BaseFee();
       expect(stableMinFees.feePerL2Gas).toBeLessThan(bumpedMinFees.feePerL2Gas);
+      expect(bumpedMinFees.feePerL2Gas).toBeGreaterThan((stableMinFees.feePerL2Gas * 11n) / 10n);
       expect(stableMinFees.mul(1 + DEFAULT_MIN_FEE_PADDING).feePerL2Gas).toBeGreaterThan(bumpedMinFees.feePerL2Gas);
 
       // And check that the no-padding does not get mined, but the default padding is good enough
@@ -204,6 +211,7 @@ describe('e2e_fees fee settings', () => {
 
       const bumpedMinFees = await inflateL2FeesViaL1BaseFee();
       expect(lowerMinFees.feePerL2Gas).toBeLessThan(bumpedMinFees.feePerL2Gas);
+      expect(bumpedMinFees.feePerL2Gas).toBeGreaterThan((lowerMinFees.feePerL2Gas * 11n) / 10n);
       expect(higherMinFees.feePerL2Gas).toBeGreaterThan(bumpedMinFees.feePerL2Gas);
       expect(lowerMinFees.mul(1 + DEFAULT_MIN_FEE_PADDING).feePerL2Gas).toBeGreaterThan(bumpedMinFees.feePerL2Gas);
 
@@ -222,16 +230,21 @@ describe('e2e_fees fee settings', () => {
     // resuming normal block production. This test exercises that path end-to-end: bump once, then
     // verify the chain advances and a fresh tx still mines.
     it('recovers after a governance fee-config bump invalidates a pipelined checkpoint', async () => {
-      // Take a fresh checkpoint baseline so we measure progress strictly post-bump.
+      // Take a fresh checkpoint baseline so we measure progress strictly post-bump, and capture
+      // the slot of `checkpointBefore` so we can assert below that at least one L2 slot was
+      // skipped between the bump and recovery — that's the positive signal that a pipelined
+      // header was actually dropped, distinguishing the A-1057 recovery path from a chain that
+      // silently absorbed the governance write without exercising the failure case.
       const checkpointBefore = await aztecNode.getBlockNumber('checkpointed');
+      const slotBefore = (await aztecNode.getCheckpoint(CheckpointNumber(checkpointBefore)))!.header.slotNumber;
 
-      t.logger.info(`Bumping provingCostPerMana with checkpointed=${checkpointBefore}`);
+      t.logger.info(`Bumping provingCostPerMana at checkpointed=${checkpointBefore} (slot ${slotBefore})`);
       await cheatCodes.rollup.bumpProvingCostPerMana(current => (current * 120n) / 100n);
 
       // At most a couple of pipelined headers were built against the pre-bump config; allow up to
-      // 6 slot windows (i.e. 6 retry windows of one slot each) before insisting the chain has made
-      // forward progress past the bump. With pipelining + minTxsPerBlock=0 an idle chain still
-      // emits empty checkpoints, so the `checkpointed` tip must strictly advance.
+      // 6 slot windows before insisting the chain has made forward progress past the bump. With
+      // pipelining + minTxsPerBlock=0 an idle chain still emits empty checkpoints, so the
+      // `checkpointed` tip must strictly advance.
       const RECOVERY_TARGET = CheckpointNumber(checkpointBefore + 3);
       const RECOVERY_BUDGET_SECONDS = AZTEC_SLOT_DURATION * 6;
       await retryUntil(
@@ -240,6 +253,21 @@ describe('e2e_fees fee settings', () => {
         RECOVERY_BUDGET_SECONDS,
         1,
       );
+
+      // Healthy pipelining produces one checkpoint per L2 slot, so an advance of 3 checkpoints
+      // covers exactly 3 slots. If a pipelined header was invalidated and dropped (the A-1057
+      // path), the recovery span will cover at least one extra slot. A passing assertion here
+      // proves the test exercised the invalidation+recovery flow rather than landing the bump
+      // outside the vulnerable window.
+      const slotAfter = (await aztecNode.getCheckpoint(RECOVERY_TARGET))!.header.slotNumber;
+      const slotSpan = slotAfter - slotBefore;
+      t.logger.info(`Recovery spanned ${slotSpan} slots for ${RECOVERY_TARGET - checkpointBefore} checkpoints`, {
+        slotBefore,
+        slotAfter,
+        checkpointBefore,
+        recoveryTarget: RECOVERY_TARGET,
+      });
+      expect(slotSpan).toBeGreaterThan(RECOVERY_TARGET - checkpointBefore);
 
       // Fresh tx prepared against the post-bump fee snapshot still mines under default padding.
       const tx = await proveTx(undefined);

--- a/yarn-project/ethereum/src/contracts/multicall.ts
+++ b/yarn-project/ethereum/src/contracts/multicall.ts
@@ -9,7 +9,6 @@ import {
   type RequiredBy,
   type StateOverride,
   type TransactionReceipt,
-  decodeErrorResult,
   decodeFunctionResult,
   encodeFunctionData,
   multicall3Abi,
@@ -17,6 +16,7 @@ import {
 
 import type { L1BlobInputs, L1TxConfig, L1TxRequest, L1TxUtils } from '../l1_tx_utils/index.js';
 import type { ExtendedViemWalletClient } from '../types.js';
+import { tryDecodeRevertReason } from '../utils.js';
 
 export const MULTI_CALL_3_ADDRESS = '0xcA11bde05977b3631167028862bE2a173976CA11' as const;
 
@@ -172,16 +172,8 @@ export class Multicall3 {
       if (entry.success) {
         return { success: true, returnData: entry.returnData };
       }
-      let revertReason: string | undefined;
       const abi = requests[i].abi;
-      if (abi && entry.returnData && entry.returnData !== '0x') {
-        try {
-          const decodedError = decodeErrorResult({ abi, data: entry.returnData });
-          revertReason = `${decodedError.errorName}(${decodedError.args?.join(', ') ?? ''})`;
-        } catch {
-          // Decoding failed; leave revertReason undefined so the caller can log the raw returnData.
-        }
-      }
+      const revertReason = abi ? tryDecodeRevertReason(entry.returnData, abi) : undefined;
       return { success: false, returnData: entry.returnData, revertReason };
     });
 

--- a/yarn-project/ethereum/src/utils.ts
+++ b/yarn-project/ethereum/src/utils.ts
@@ -276,6 +276,24 @@ function stripAbis(obj: any) {
   });
 }
 
+/**
+ * Best-effort decode of a raw revert payload (`0x...`) against an ABI.
+ * Returns a human-readable `ErrorName(arg1, arg2, ...)` string, or `undefined` if the selector
+ * is unknown or the payload is empty. Use to surface decoded error names alongside the raw
+ * payload in log lines for operators.
+ */
+export function tryDecodeRevertReason(data: Hex | undefined, abi: Abi): string | undefined {
+  if (!data || data === '0x') {
+    return undefined;
+  }
+  try {
+    const decoded = decodeErrorResult({ abi, data });
+    return `${decoded.errorName}(${decoded.args?.join(', ') ?? ''})`;
+  } catch {
+    return undefined;
+  }
+}
+
 export function tryGetCustomErrorName(err: any) {
   try {
     // See https://viem.sh/docs/contract/simulateContract#handling-custom-errors

--- a/yarn-project/sequencer-client/src/publisher/sequencer-publisher.test.ts
+++ b/yarn-project/sequencer-client/src/publisher/sequencer-publisher.test.ts
@@ -452,25 +452,37 @@ describe('SequencerPublisher', () => {
     it('stops rotating once txTimeoutAt elapses mid-rotation', async () => {
       // First forward throws; getNextPublisher rotates to a new publisher; but by then the
       // deadline has elapsed and the rotation loop should bail before the second forward call.
-      const futureTimeout = new Date(Date.now() + 100); // will elapse during the await below
-      forwardSpy.mockImplementationOnce(async () => {
-        await new Promise(resolve => setTimeout(resolve, 200));
-        throw new Error('RPC error on first');
-      });
-      getNextPublisher.mockResolvedValueOnce(secondL1TxUtils);
+      // Use jest fake timers to control `Date.now()` deterministically — the rotation loop
+      // checks the deadline via `new Date() > txConfig.txTimeoutAt`, so faking the system clock
+      // is the cleanest way to model "deadline elapses mid-rotation" without racing wall-clock
+      // setTimeout against CI host speed.
+      jest.useFakeTimers({ doNotFake: ['nextTick', 'queueMicrotask', 'setImmediate'] });
+      try {
+        jest.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+        const futureTimeout = new Date(Date.now() + 1000);
+        forwardSpy.mockImplementationOnce(() => {
+          // Simulate enough wall-clock advance during the forward to push past the deadline,
+          // so the loop's next deadline check bails before the second attempt.
+          jest.setSystemTime(Date.now() + 5000);
+          return Promise.reject(new Error('RPC error on first'));
+        });
+        getNextPublisher.mockResolvedValueOnce(secondL1TxUtils);
 
-      await rotatingPublisher.enqueueProposeCheckpoint(
-        new Checkpoint(l2Block.archive, header, [l2Block], l2Block.checkpointNumber),
-        CommitteeAttestationsAndSigners.empty(testSignatureContext),
-        Signature.empty(),
-        { txTimeoutAt: futureTimeout },
-      );
-      const result = await rotatingPublisher.sendRequests();
+        await rotatingPublisher.enqueueProposeCheckpoint(
+          new Checkpoint(l2Block.archive, header, [l2Block], l2Block.checkpointNumber),
+          CommitteeAttestationsAndSigners.empty(testSignatureContext),
+          Signature.empty(),
+          { txTimeoutAt: futureTimeout },
+        );
+        const result = await rotatingPublisher.sendRequests();
 
-      expect(result).toBeUndefined();
-      // forward was attempted exactly once (the first publisher); rotation was aborted before
-      // the second attempt because the deadline had passed.
-      expect(forwardSpy).toHaveBeenCalledTimes(1);
+        expect(result).toBeUndefined();
+        // forward was attempted exactly once (the first publisher); rotation was aborted before
+        // the second attempt because the deadline had passed.
+        expect(forwardSpy).toHaveBeenCalledTimes(1);
+      } finally {
+        jest.useRealTimers();
+      }
     });
 
     it('does not rotate when forward throws MulticallForwarderRevertedError (on-chain failure)', async () => {

--- a/yarn-project/sequencer-client/src/publisher/sequencer-publisher.ts
+++ b/yarn-project/sequencer-client/src/publisher/sequencer-publisher.ts
@@ -23,7 +23,13 @@ import {
   type TransactionStats,
   WEI_CONST,
 } from '@aztec/ethereum/l1-tx-utils';
-import { FormattedViemError, formatViemError, mergeAbis, tryExtractEvent } from '@aztec/ethereum/utils';
+import {
+  FormattedViemError,
+  formatViemError,
+  mergeAbis,
+  tryDecodeRevertReason,
+  tryExtractEvent,
+} from '@aztec/ethereum/utils';
 import { CheckpointNumber, SlotNumber } from '@aztec/foundation/branded-types';
 import { trimmedBytesLength } from '@aztec/foundation/buffer';
 import { pick } from '@aztec/foundation/collection';
@@ -154,6 +160,13 @@ export class SequencerPublisher {
   private bundleSimulator: SequencerBundleSimulator;
   public epochCache: EpochCache;
   private failedTxStore?: Promise<L1TxFailedStore | undefined>;
+
+  /**
+   * ABI used to decode raw revert payloads from dropped bundle entries when the original
+   * request did not carry an abi (e.g. the propose request). Merges every contract the
+   * publisher can route to so any of their custom errors decode against it.
+   */
+  private readonly revertDecoderAbi: Abi = mergeAbis([RollupAbi, SlashingProposerAbi, EmpireBaseAbi, ErrorsAbi]);
 
   protected lastActions: Partial<Record<Action, SlotNumber>> = {};
 
@@ -497,9 +510,11 @@ export class SequencerPublisher {
   /** Logs entries dropped by bundle simulation as warnings on the publisher's logger. */
   private logDroppedInSim(dropped: DroppedRequest[]): void {
     for (const drop of dropped) {
+      const revertReasonDecoded = drop.revertReason ?? tryDecodeRevertReason(drop.returnData, this.revertDecoderAbi);
       this.log.warn('Bundle entry dropped: action reverted in sim', {
         action: drop.request.action,
-        revertReason: drop.revertReason ?? drop.returnData,
+        revertReason: revertReasonDecoded ?? drop.returnData,
+        revertReasonDecoded,
         returnData: drop.returnData,
       });
     }


### PR DESCRIPTION
## Motivation

Under proposer pipelining, a sequencer builds slot N's checkpoint header (and bakes `manaMinFee` into `gasFees.feePerL2Gas`) during slot N-1. If governance executes `setProvingCostPerMana` or `updateManaTarget` between that build and the L1 submission, L1 recomputes `manaMinFee` from the post-mutation `FeeStore.config` and the submitted header reverts with `Rollup__InvalidManaMinFee`. The `e2e_fees/fee_settings` suite used `bumpProvingCostPerMana` — exactly that governance path — as its fee-spike mechanism, which made it hostile to pipelining and didn't reflect any organic mainnet fee channel. The publisher's bundle-simulator drop log also stopped decoding revert payloads in PR #23165, leaving operators staring at raw `0x...` data.

## Approach

Drive the fee spike via an L1 base-fee bump (`setNextBlockBaseFeePerGas` + `updateL1GasFeeOracle`) — the dominant `feePerL2Gas` channel and a closer analogue to organic mainnet behaviour. Enable pipelining for the suite via the `FeesTest` constructor (`enableProposerPipelining`, `inboxLag`, `manaTarget`, `walletMinFeePadding`, etc.). Add an explicit recovery test that bumps governance and asserts the chain advances past the invalidated checkpoint and that a fresh tx still mines. Restore decoded revert names in `logDroppedInSim` by merging the relevant ABIs and routing through a shared `tryDecodeRevertReason` helper.

## Changes

- **end-to-end (tests)**: Rewrite `fee_settings.test.ts` to run under pipelining, replace the governance fee spike with an organic L1-base-fee bump, and add a recovery test for the governance-mutation race.
- **ethereum**: Add `tryDecodeRevertReason(data, abi)` in `utils.ts` and route `Multicall3` through it (deduplicating the existing in-place decoder).
- **sequencer-client**: In `logDroppedInSim`, decode unknown revert payloads against a merged `[RollupAbi, SlashingProposerAbi, EmpireBaseAbi, ErrorsAbi]` ABI and emit both the readable form and the raw payload.

Fixes A-1057