### PR TITLE
feat(ci): run aztec-cli acceptance test on macOS

### DIFF
--- a/.github/workflows/aztec-cli-acceptance-test.yml
+++ b/.github/workflows/aztec-cli-acceptance-test.yml
@@ -36,13 +36,6 @@ jobs:
         with:
           ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
-      # Node is only used to run the .ts harness in run-test.sh, which needs >=22.18 for TS
-      # type-stripping. The aztec CLI installer manages its own node version independently.
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22
-
       - name: Run Aztec CLI acceptance test
         timeout-minutes: 30
         run: ./aztec-up/test/aztec-cli-acceptance-test/run-test.sh

--- a/.github/workflows/aztec-cli-acceptance-test.yml
+++ b/.github/workflows/aztec-cli-acceptance-test.yml
@@ -18,7 +18,11 @@ on:
 
 jobs:
   release-acceptance:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false # Don't cancel the other OS if one fails.
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'workflow_run'
@@ -43,8 +47,20 @@ jobs:
         timeout-minutes: 30
         run: ./aztec-up/test/aztec-cli-acceptance-test/run-test.sh
 
+  notify:
+    needs: release-acceptance
+    if: always() && github.event_name != 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    env:
+      VERSION: ${{ github.event.inputs.version || github.event.workflow_run.head_branch }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+
       - name: Notify Slack on success
-        if: success() && github.event_name != 'workflow_dispatch'
+        if: needs.release-acceptance.result == 'success'
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
         run: |
@@ -54,7 +70,7 @@ jobs:
             "#team-fairies"
 
       - name: Notify Slack and dispatch ClaudeBox on failure
-        if: failure() && github.event_name != 'workflow_dispatch'
+        if: needs.release-acceptance.result == 'failure'
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}

--- a/aztec-up/test/aztec-cli-acceptance-test/run-test.sh
+++ b/aztec-up/test/aztec-cli-acceptance-test/run-test.sh
@@ -2,7 +2,8 @@
 # Launcher for the Aztec CLI acceptance test.
 #
 # Steps:
-#   1. Install Node via NVM if not present (skipped with SKIP_INSTALL=1)
+#   1. Install NVM and the latest LTS Node (skipped with SKIP_INSTALL=1). NVM is required by the
+#      aztec installer to upgrade Node when the system version is too old.
 #   2. Install the Aztec toolchain via the public installer (skipped with SKIP_INSTALL=1)
 #   3. Run aztec-cli-acceptance-test.ts which exercises the installed toolchain end-to-end
 #
@@ -20,14 +21,17 @@ else
     echo "ERROR: VERSION must be set when SKIP_INSTALL is not 1." >&2
     exit 1
   fi
-  if ! command -v node &>/dev/null; then
-    echo ">>> Installing Node via NVM"
+  if [ ! -f "$HOME/.nvm/nvm.sh" ]; then
+    echo ">>> Installing NVM"
     curl -sL https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh -o /tmp/nvm-install.sh
     PROFILE=/dev/null bash /tmp/nvm-install.sh
-    export NVM_DIR="$HOME/.nvm"
-    set +eu; . "$NVM_DIR/nvm.sh"; set -eu
-    nvm install --lts
   fi
+
+  # Install latest LTS node, since we need it to run the acceptance test correctly
+  export NVM_DIR="$HOME/.nvm"
+  set +eu; . "$NVM_DIR/nvm.sh"; set -eu
+  echo ">>> Installing latest LTS Node via NVM"
+  nvm install --lts
   echo ">>> Installing aztec ${VERSION}"
   NO_NEW_SHELL=1 VERSION="${VERSION}" bash <(curl -sL https://install.aztec.network)
 fi


### PR DESCRIPTION
## Summary

- Adds `macos-latest` to the `aztec-cli-acceptance-test` workflow via `strategy.matrix` so the full dev onboarding test runs on both Ubuntu and macOS in parallel, with `fail-fast: false` so one OS failure doesn't cancel the other.
- Splits Slack notifications into a downstream `notify` job (`needs: release-acceptance` + `always()`) so a single consolidated message fires after both matrix entries finish.
- Moves all Node setup into `run-test.sh`: it now installs NVM if missing and `nvm install --lts` unconditionally, then `aztec-up`'s `install_node` can upgrade further via the same NVM if needed. This makes the runner self-contained and unblocks macOS, where the GitHub Actions image ships without NVM (the previous `setup-node` step put Node 22 in PATH but left `aztec-up` with no way to satisfy its `>=24.12.0` requirement).

Fixes F-566