### PR TITLE
fix(aztec-up): fall back to no timeout when /usr/bin/timeout absent (macOS)

### DIFF
--- a/aztec-up/bin/0.0.1/install
+++ b/aztec-up/bin/0.0.1/install
@@ -55,9 +55,16 @@ function echo_yellow {
 }
 
 function timeout {
-  if { [ "${CI:-0}" = "1" ] || [ "${CI:-0}" = "true" ]; } && [ -x /usr/bin/timeout ]; then
+  if [ -x /usr/bin/timeout ]; then
+    # Prefer coreutils `timeout` when available. Absolute path avoids re-entering this function.
     /usr/bin/timeout "$@"
+  elif perl -e1 2>/dev/null; then
+    # Fall back to perl's `alarm` when /usr/bin/timeout is missing.
+    local duration=$1
+    shift
+    perl -e "alarm $duration; exec @ARGV" -- "$@"
   else
+    # No timeout backend available -- run unguarded rather than fail the install.
     shift
     "$@"
   fi

--- a/aztec-up/bin/0.0.1/install
+++ b/aztec-up/bin/0.0.1/install
@@ -64,7 +64,7 @@ function timeout {
     # Prefer coreutils `timeout` when available. Absolute path avoids re-entering this function.
     /usr/bin/timeout "$@"
   elif perl -e1 2>/dev/null; then
-    # Fall back to perl's `alarm` when /usr/bin/timeout is missing (e.g. stock macOS).
+    # Fall back to perl's `alarm` when /usr/bin/timeout is missing.
     local duration=$1
     shift
     perl -e "alarm $duration; exec @ARGV" -- "$@"

--- a/aztec-up/bin/0.0.1/install
+++ b/aztec-up/bin/0.0.1/install
@@ -55,7 +55,7 @@ function echo_yellow {
 }
 
 function timeout {
-  if [ "${CI:-0}" = "1" ] || [ "${CI:-0}" = "true" ]; then
+  if { [ "${CI:-0}" = "1" ] || [ "${CI:-0}" = "true" ]; } && [ -x /usr/bin/timeout ]; then
     /usr/bin/timeout "$@"
   else
     shift

--- a/aztec-up/bin/0.0.1/install
+++ b/aztec-up/bin/0.0.1/install
@@ -55,11 +55,16 @@ function echo_yellow {
 }
 
 function timeout {
+  if [ "${CI:-0}" != "1" ] && [ "${CI:-0}" != "true" ]; then
+    shift
+    "$@"
+    return
+  fi
   if [ -x /usr/bin/timeout ]; then
     # Prefer coreutils `timeout` when available. Absolute path avoids re-entering this function.
     /usr/bin/timeout "$@"
   elif perl -e1 2>/dev/null; then
-    # Fall back to perl's `alarm` when /usr/bin/timeout is missing.
+    # Fall back to perl's `alarm` when /usr/bin/timeout is missing (e.g. stock macOS).
     local duration=$1
     shift
     perl -e "alarm $duration; exec @ARGV" -- "$@"


### PR DESCRIPTION
## Problem

The aztec-up installer wraps `foundryup` in a `timeout` shell function. The previous implementation only worked on Linux: it gated the call on `CI=true` and invoked `/usr/bin/timeout` directly. `/usr/bin/timeout` ships with GNU coreutils and is absent on stock macOS, so on a macOS GitHub Actions runner (`CI=true` is auto-set) the installer aborted in `install_foundry` with:

```
bash: line 59: /usr/bin/timeout: No such file or directory
```

## Fix

Rework the `timeout` function so it picks a working backend at runtime. The CI gate is preserved — non-CI runs continue to execute unguarded, matching prior behavior:

- Prefer `/usr/bin/timeout` when present (Linux via coreutils).
- Fall back to `perl -e 'alarm ...; exec ...'` when `/usr/bin/timeout` is missing. Perl ships preinstalled on macOS and GitHub's Ubuntu runners, so the guard remains effective there.
- If neither backend is available, run the command unguarded rather than fail the install — the timeout exists to bound a \`foundryup\` hang in CI, not to gate the install itself.

Verified the three branches in containers (coreutils path, perl path, neither): timeouts fire at the expected duration, exit codes propagate, and the unguarded branch passes through completion.