### PR TITLE
feat!: make get_shared_secrets batched oracle call

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/oracle/shared_secret.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/shared_secret.nr
@@ -1,7 +1,7 @@
 use crate::ephemeral::EphemeralArray;
 use crate::protocol::address::aztec_address::AztecAddress;
 use crate::protocol::point::Point;
-use std::hash::sha256_to_field;
+use crate::protocol::hash::sha256_to_field;
 
 global GET_SHARED_SECRETS_REQUEST_SLOT: Field =
     sha256_to_field("AZTEC_NR::GET_SHARED_SECRETS_REQUEST_SLOT".as_bytes());
@@ -130,7 +130,7 @@ mod test {
         });
     }
 
-    fn mock_get_shared_secrets(response_values: [Field; N]) -> Field {
+    fn mock_get_shared_secrets<let N: u32>(response_values: [Field; N]) -> Field {
         let response_slot: Field = 99;
         let response_array: EphemeralArray<Field> = EphemeralArray::at(response_slot);
         for value in response_values {

--- a/noir-projects/aztec-nr/aztec/src/oracle/shared_secret.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/shared_secret.nr
@@ -78,7 +78,7 @@ mod test {
 
             let pk_a = point_from_x_coord(1).unwrap();
             let pk_b = point_from_x_coord(2).unwrap();
-            let pk_c = point_from_x_coord(3).unwrap();
+            let pk_c = point_from_x_coord(8).unwrap();
 
             let _: BoundedVec<Field, 3> = get_shared_secrets(
                 AztecAddress::from_field(1),

--- a/noir-projects/aztec-nr/aztec/src/oracle/shared_secret.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/shared_secret.nr
@@ -1,7 +1,5 @@
 use crate::ephemeral::EphemeralArray;
-use crate::protocol::address::aztec_address::AztecAddress;
-use crate::protocol::point::Point;
-use crate::protocol::hash::sha256_to_field;
+use crate::protocol::{address::AztecAddress, hash::sha256_to_field, point::Point};
 
 global GET_SHARED_SECRETS_REQUEST_SLOT: Field =
     sha256_to_field("AZTEC_NR::GET_SHARED_SECRETS_REQUEST_SLOT".as_bytes());
@@ -19,7 +17,7 @@ pub unconstrained fn get_shared_secret(
     eph_pk: Point,
     contract_address: AztecAddress,
 ) -> Field {
-    get_shared_secrets(address, BoundedVec::from_array([eph_pk]), contract_address).get(0)
+    get_shared_secrets::<1>(address, BoundedVec::from_array([eph_pk]), contract_address).get(0)
 }
 
 /// Returns app-siloed shared secrets between `address` and someone who knows the secret keys behind the given
@@ -65,9 +63,9 @@ pub unconstrained fn get_shared_secrets<let N: u32>(
 }
 
 mod test {
-    use crate::oracle::shared_secret::{GET_SHARED_SECRETS_REQUEST_SLOT, get_shared_secrets};
     use crate::ephemeral::EphemeralArray;
-    use crate::protocol::address::aztec_address::AztecAddress;
+    use crate::oracle::shared_secret::{GET_SHARED_SECRETS_REQUEST_SLOT, get_shared_secrets};
+    use crate::protocol::{address::AztecAddress, traits::FromField};
     use crate::test::helpers::test_environment::TestEnvironment;
     use crate::utils::point::point_from_x_coord;
     use std::test::OracleMock;
@@ -82,7 +80,7 @@ mod test {
             let pk_b = point_from_x_coord(2).unwrap();
             let pk_c = point_from_x_coord(3).unwrap();
 
-            let _ = get_shared_secrets(
+            let _: BoundedVec<Field, 3> = get_shared_secrets(
                 AztecAddress::from_field(1),
                 BoundedVec::from_array([pk_a, pk_b, pk_c]),
                 AztecAddress::from_field(2),
@@ -103,7 +101,7 @@ mod test {
             let _ = mock_get_shared_secrets([111, 222, 333]);
 
             let pk = point_from_x_coord(1).unwrap();
-            let results = get_shared_secrets(
+            let results: BoundedVec<Field, 3> = get_shared_secrets(
                 AztecAddress::from_field(1),
                 BoundedVec::from_array([pk, pk, pk]),
                 AztecAddress::from_field(2),
@@ -122,7 +120,7 @@ mod test {
             let _ = mock_get_shared_secrets([111, 222]);
 
             let pk = point_from_x_coord(1).unwrap();
-            let _ = get_shared_secrets(
+            let _: BoundedVec<Field, 1> = get_shared_secrets(
                 AztecAddress::from_field(1),
                 BoundedVec::from_array([pk]),
                 AztecAddress::from_field(2),
@@ -130,7 +128,7 @@ mod test {
         });
     }
 
-    fn mock_get_shared_secrets<let N: u32>(response_values: [Field; N]) -> Field {
+    unconstrained fn mock_get_shared_secrets<let N: u32>(response_values: [Field; N]) -> Field {
         let response_slot: Field = 99;
         let response_array: EphemeralArray<Field> = EphemeralArray::at(response_slot);
         for value in response_values {

--- a/noir-projects/aztec-nr/aztec/src/oracle/shared_secret.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/shared_secret.nr
@@ -1,17 +1,31 @@
+use crate::ephemeral::EphemeralArray;
 use crate::protocol::address::aztec_address::AztecAddress;
 use crate::protocol::point::Point;
+use std::hash::sha256_to_field;
 
-#[oracle(aztec_utl_getSharedSecret)]
-unconstrained fn get_shared_secret_oracle(
+global GET_SHARED_SECRETS_REQUEST_SLOT: Field =
+    sha256_to_field("AZTEC_NR::GET_SHARED_SECRETS_REQUEST_SLOT".as_bytes());
+
+#[oracle(aztec_utl_getSharedSecrets)]
+unconstrained fn get_shared_secrets_oracle(
     address: AztecAddress,
-    ephPk: Point,
+    eph_pks_slot: Field,
     contract_address: AztecAddress,
 ) -> Field {}
 
-/// Returns an app-siloed shared secret between `address` and someone who knows the secret key behind an ephemeral
-/// public key `ephPk`.
+/// Convenience wrapper around [`get_shared_secrets`] for a single ephemeral public key.
+pub unconstrained fn get_shared_secret(
+    address: AztecAddress,
+    eph_pk: Point,
+    contract_address: AztecAddress,
+) -> Field {
+    get_shared_secrets(address, BoundedVec::from_array([eph_pk]), contract_address).get(0)
+}
+
+/// Returns app-siloed shared secrets between `address` and someone who knows the secret keys behind the given
+/// ephemeral public keys.
 ///
-/// The returned value is a Field `s_app`, computed as:
+/// Each returned Field `s_app` is computed as:
 ///
 /// ```text
 /// S     = address_secret * ephPk          (raw ECDH point)
@@ -27,6 +41,102 @@ unconstrained fn get_shared_secret_oracle(
 ///
 /// Callers derive indexed subkeys from `s_app` via
 /// [`derive_shared_secret_subkey`](crate::keys::ecdh_shared_secret::derive_shared_secret_subkey).
-pub unconstrained fn get_shared_secret(address: AztecAddress, ephPk: Point, contract_address: AztecAddress) -> Field {
-    get_shared_secret_oracle(address, ephPk, contract_address)
+pub unconstrained fn get_shared_secrets<let N: u32>(
+    address: AztecAddress,
+    eph_pks: BoundedVec<Point, N>,
+    contract_address: AztecAddress,
+) -> BoundedVec<Field, N> {
+    let request_array: EphemeralArray<Point> =
+        EphemeralArray::at(GET_SHARED_SECRETS_REQUEST_SLOT).clear();
+    eph_pks.for_each(|pk| request_array.push(pk));
+
+    let response_slot = get_shared_secrets_oracle(address, request_array.slot, contract_address);
+    let response_array: EphemeralArray<Field> = EphemeralArray::at(response_slot);
+    assert(
+        response_array.len() == eph_pks.len(),
+        "get_shared_secrets: response length does not match request length",
+    );
+
+    let mut results: BoundedVec<Field, N> = BoundedVec::new();
+    for i in 0..eph_pks.len() {
+        results.push(response_array.get(i));
+    }
+    results
+}
+
+mod test {
+    use crate::oracle::shared_secret::{GET_SHARED_SECRETS_REQUEST_SLOT, get_shared_secrets};
+    use crate::ephemeral::EphemeralArray;
+    use crate::protocol::address::aztec_address::AztecAddress;
+    use crate::test::helpers::test_environment::TestEnvironment;
+    use crate::utils::point::point_from_x_coord;
+    use std::test::OracleMock;
+
+    #[test]
+    unconstrained fn preserves_ephemeral_key_ordering() {
+        let env = TestEnvironment::new();
+        env.utility_context(|_| {
+            let _ = mock_get_shared_secrets([100, 200, 300]);
+
+            let pk_a = point_from_x_coord(1).unwrap();
+            let pk_b = point_from_x_coord(2).unwrap();
+            let pk_c = point_from_x_coord(3).unwrap();
+
+            let _ = get_shared_secrets(
+                AztecAddress::from_field(1),
+                BoundedVec::from_array([pk_a, pk_b, pk_c]),
+                AztecAddress::from_field(2),
+            );
+
+            let request_array: EphemeralArray<_> =
+                EphemeralArray::at(GET_SHARED_SECRETS_REQUEST_SLOT);
+            assert_eq(request_array.get(0), pk_a);
+            assert_eq(request_array.get(1), pk_b);
+            assert_eq(request_array.get(2), pk_c);
+        });
+    }
+
+    #[test]
+    unconstrained fn returns_secrets_in_order() {
+        let env = TestEnvironment::new();
+        env.utility_context(|_| {
+            let _ = mock_get_shared_secrets([111, 222, 333]);
+
+            let pk = point_from_x_coord(1).unwrap();
+            let results = get_shared_secrets(
+                AztecAddress::from_field(1),
+                BoundedVec::from_array([pk, pk, pk]),
+                AztecAddress::from_field(2),
+            );
+
+            assert_eq(results.get(0), 111);
+            assert_eq(results.get(1), 222);
+            assert_eq(results.get(2), 333);
+        });
+    }
+
+    #[test(should_fail_with = "response length does not match request length")]
+    unconstrained fn cannot_return_mismatched_length() {
+        let env = TestEnvironment::new();
+        env.utility_context(|_| {
+            let _ = mock_get_shared_secrets([111, 222]);
+
+            let pk = point_from_x_coord(1).unwrap();
+            let _ = get_shared_secrets(
+                AztecAddress::from_field(1),
+                BoundedVec::from_array([pk]),
+                AztecAddress::from_field(2),
+            );
+        });
+    }
+
+    fn mock_get_shared_secrets(response_values: [Field; N]) -> Field {
+        let response_slot: Field = 99;
+        let response_array: EphemeralArray<Field> = EphemeralArray::at(response_slot);
+        for value in response_values {
+            response_array.push(value);
+        }
+        let _ = OracleMock::mock("aztec_utl_getSharedSecrets").returns(response_slot);
+        response_slot
+    }
 }

--- a/noir-projects/aztec-nr/aztec/src/oracle/version.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/version.nr
@@ -10,8 +10,8 @@
 /// the PXE and used to provide helpful error messages if a contract calls an oracle that doesn't exist. We don't throw
 /// immediately if AZTEC_NR_MINOR > PXE_MINOR because if a contract is updated to use a newer Aztec.nr dependency
 /// without actually using any of the new oracles then there is no reason to throw.
-pub global ORACLE_VERSION_MAJOR: Field = 22;
-pub global ORACLE_VERSION_MINOR: Field = 3;
+pub global ORACLE_VERSION_MAJOR: Field = 23;
+pub global ORACLE_VERSION_MINOR: Field = 0;
 
 /// Asserts that the version of the oracle is compatible with the version expected by the contract.
 pub fn assert_compatible_oracle_version() {

--- a/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/oracle/version.nr
+++ b/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/oracle/version.nr
@@ -10,8 +10,8 @@
 /// the PXE and used to provide helpful error messages if a contract calls an oracle that doesn't exist. We don't throw
 /// immediately if AZTEC_NR_MINOR > PXE_MINOR because if a contract is updated to use a newer Aztec.nr dependency
 /// without actually using any of the new oracles then there is no reason to throw.
-pub global ORACLE_VERSION_MAJOR: Field = 22;
-pub global ORACLE_VERSION_MINOR: Field = 1;
+pub global ORACLE_VERSION_MAJOR: Field = 23;
+pub global ORACLE_VERSION_MINOR: Field = 0;
 
 /// Asserts that the version of the oracle is compatible with the version expected by the contract.
 pub fn assert_compatible_oracle_version() {

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/interfaces.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/interfaces.ts
@@ -1,7 +1,6 @@
 import type { ARCHIVE_HEIGHT, L1_TO_L2_MSG_TREE_HEIGHT, NOTE_HASH_TREE_HEIGHT } from '@aztec/constants';
 import type { BlockNumber } from '@aztec/foundation/branded-types';
 import { Fr } from '@aztec/foundation/curves/bn254';
-import { Point } from '@aztec/foundation/curves/grumpkin';
 import { MembershipWitness } from '@aztec/foundation/trees';
 import type { FunctionSelector, NoteSelector } from '@aztec/stdlib/abi';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
@@ -162,7 +161,7 @@ export interface IUtilityExecutionOracle {
     scope: AztecAddress,
   ): Promise<void>;
   decryptAes128(ciphertext: Buffer, iv: Buffer, symKey: Buffer): Promise<Buffer>;
-  getSharedSecret(address: AztecAddress, ephPk: Point, contractAddress: AztecAddress): Promise<Fr>;
+  getSharedSecrets(address: AztecAddress, ephPksSlot: Fr, contractAddress: AztecAddress): Promise<Fr>;
   setContractSyncCacheInvalid(contractAddress: AztecAddress, scopes: AztecAddress[]): void;
   emitOffchainEffect(data: Fr[]): Promise<void>;
   callUtilityFunction(

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/oracle.ts
@@ -10,7 +10,6 @@ import {
 import { BlockNumber } from '@aztec/foundation/branded-types';
 import { padArrayEnd } from '@aztec/foundation/collection';
 import { Fr } from '@aztec/foundation/curves/bn254';
-import { Point } from '@aztec/foundation/curves/grumpkin';
 import { MembershipWitness } from '@aztec/foundation/trees';
 import {
   type ACIRCallback,
@@ -883,19 +882,17 @@ export class Oracle {
   }
 
   // eslint-disable-next-line camelcase
-  async aztec_utl_getSharedSecret(
+  async aztec_utl_getSharedSecrets(
     [address]: ACVMField[],
-    [ephPKField0]: ACVMField[],
-    [ephPKField1]: ACVMField[],
-    [ephPKField2]: ACVMField[],
+    [ephPksSlot]: ACVMField[],
     [contractAddress]: ACVMField[],
   ): Promise<ACVMField[]> {
-    const secret = await this.handlerAsUtility().getSharedSecret(
+    const responseSlot = await this.handlerAsUtility().getSharedSecrets(
       AztecAddress.fromField(Fr.fromString(address)),
-      Point.fromFields([ephPKField0, ephPKField1, ephPKField2].map(Fr.fromString)),
+      Fr.fromString(ephPksSlot),
       AztecAddress.fromField(Fr.fromString(contractAddress)),
     );
-    return [toACVMField(secret)];
+    return [toACVMField(responseSlot)];
   }
 
   // eslint-disable-next-line camelcase

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution.test.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution.test.ts
@@ -523,13 +523,13 @@ describe('Utility Execution test suite', () => {
       });
     });
 
-    describe('getSharedSecret', () => {
+    describe('getSharedSecrets', () => {
       it('returns different shared secrets for different contract addresses', async () => {
         // Generate a deterministic ephemeral public key
         const ephSk = GrumpkinScalar.random();
         const ephPk = await Grumpkin.mul(Grumpkin.generator, ephSk);
 
-        // Derive keys so we can mock getMasterSecretKey (used by getSharedSecret)
+        // Derive keys so we can mock getMasterSecretKey (used by getSharedSecrets)
         const { masterIncomingViewingSecretKey: ownerIvskM } = await deriveKeys(ownerSecretKey);
         keyStore.getMasterSecretKey.mockImplementation((publicKey: Point) => {
           if (publicKey.equals(ownerCompleteAddress.publicKeys.masterIncomingViewingPublicKey)) {
@@ -544,8 +544,15 @@ describe('Utility Execution test suite', () => {
         const oracleA = makeOracle({ contractAddress: contractAddressA });
         const oracleB = makeOracle({ contractAddress: contractAddressB });
 
-        const secretA = await oracleA.getSharedSecret(owner, ephPk, contractAddressA);
-        const secretB = await oracleB.getSharedSecret(owner, ephPk, contractAddressB);
+        const slotA = Fr.random();
+        oracleA.pushEphemeral(slotA, ephPk.toFields());
+        const responseSlotA = await oracleA.getSharedSecrets(owner, slotA, contractAddressA);
+        const [secretA] = oracleA.getEphemeral(responseSlotA, 0);
+
+        const slotB = Fr.random();
+        oracleB.pushEphemeral(slotB, ephPk.toFields());
+        const responseSlotB = await oracleB.getSharedSecrets(owner, slotB, contractAddressB);
+        const [secretB] = oracleB.getEphemeral(responseSlotB, 0);
 
         // After app-siloing, different contracts must get different shared secrets for the same
         // (address, ephPk) pair. This prevents cross-contract decryption attacks.
@@ -559,8 +566,10 @@ describe('Utility Execution test suite', () => {
         const { masterIncomingViewingSecretKey: ownerIvskM } = await deriveKeys(ownerSecretKey);
         keyStore.getMasterSecretKey.mockResolvedValue(ownerIvskM);
 
+        const slot = Fr.random();
+        utilityExecutionOracle.pushEphemeral(slot, ephPk.toFields());
         const wrongAddress = await AztecAddress.random();
-        await expect(utilityExecutionOracle.getSharedSecret(owner, ephPk, wrongAddress)).rejects.toThrow(/expected/);
+        await expect(utilityExecutionOracle.getSharedSecrets(owner, slot, wrongAddress)).rejects.toThrow(/expected/);
       });
     });
 

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
@@ -867,16 +867,16 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
   }
 
   /**
-   * Retrieves the app-siloed shared secret for a given address and ephemeral public key.
-   * @param address - The address to get the secret for.
-   * @param ephPk - The ephemeral public key to get the secret for.
+   * Retrieves app-siloed shared secrets for multiple ephemeral public keys stored in an ephemeral array.
+   * @param address - The recipient address.
+   * @param ephPksSlot - Ephemeral array slot containing the serialized Points.
    * @param contractAddress - The contract address for app-siloing (validated against execution context).
-   * @returns The app-siloed shared secret as a Field.
+   * @returns The slot of a new ephemeral array containing the computed shared secrets.
    */
-  public async getSharedSecret(address: AztecAddress, ephPk: Point, contractAddress: AztecAddress): Promise<Fr> {
+  public async getSharedSecrets(address: AztecAddress, ephPksSlot: Fr, contractAddress: AztecAddress): Promise<Fr> {
     if (!contractAddress.equals(this.contractAddress)) {
       throw new Error(
-        `getSharedSecret called with contract address ${contractAddress}, expected ${this.contractAddress}`,
+        `getSharedSecrets called with contract address ${contractAddress}, expected ${this.contractAddress}`,
       );
     }
     const recipientCompleteAddress = await this.getCompleteAddressOrFail(address);
@@ -884,7 +884,15 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
       recipientCompleteAddress.publicKeys.masterIncomingViewingPublicKey,
     );
     const addressSecret = await computeAddressSecret(await recipientCompleteAddress.getPreaddress(), ivskM);
-    return deriveAppSiloedSharedSecret(addressSecret, ephPk, this.contractAddress);
+
+    const ephPkFields = this.ephemeralArrayService.readArrayAt(ephPksSlot);
+    const secrets = await Promise.all(
+      ephPkFields.map(fields =>
+        deriveAppSiloedSharedSecret(addressSecret, Point.fromFields(fields), this.contractAddress),
+      ),
+    );
+
+    return this.ephemeralArrayService.newArray(secrets.map(s => [s]));
   }
 
   public pushEphemeral(slot: Fr, elements: Fr[]): number {

--- a/yarn-project/pxe/src/oracle_version.ts
+++ b/yarn-project/pxe/src/oracle_version.ts
@@ -10,8 +10,8 @@
 /// used to provide helpful error messages if a contract calls an oracle that doesn't exist. We don't throw immediately
 /// if AZTEC_NR_MINOR > PXE_MINOR because if a contract is updated to use a newer Aztec.nr dependency without actually
 /// using any of the new oracles then there is no reason to throw.
-export const ORACLE_VERSION_MAJOR = 22;
-export const ORACLE_VERSION_MINOR = 3;
+export const ORACLE_VERSION_MAJOR = 23;
+export const ORACLE_VERSION_MINOR = 0;
 
 /// This hash is computed from the Oracle interface and is used to detect when that interface changes. When it does,
 /// you need to either:
@@ -19,4 +19,4 @@ export const ORACLE_VERSION_MINOR = 3;
 /// - increment only `ORACLE_VERSION_MINOR` if the change is additive (a new oracle was added).
 ///
 /// These constants must be kept in sync between this file and `noir-projects/aztec-nr/aztec/src/oracle/version.nr`.
-export const ORACLE_INTERFACE_HASH = '0649632102f27d1411749e46733b96103eaac948914d328afc4b90d3bf6e5af5';
+export const ORACLE_INTERFACE_HASH = 'a357cbd50afcf13dc79fb892da59e5955a5dd1f7fa3a1f329928e2ac8e90a039';

--- a/yarn-project/txe/src/rpc_translator.ts
+++ b/yarn-project/txe/src/rpc_translator.ts
@@ -1,5 +1,5 @@
 import type { ContractInstanceWithAddress } from '@aztec/aztec.js/contracts';
-import { Fr, Point } from '@aztec/aztec.js/fields';
+import { Fr } from '@aztec/aztec.js/fields';
 import {
   ARCHIVE_HEIGHT,
   MAX_NOTE_HASHES_PER_TX,
@@ -1152,24 +1152,18 @@ export class RPCTranslator {
   }
 
   // eslint-disable-next-line camelcase
-  async aztec_utl_getSharedSecret(
+  async aztec_utl_getSharedSecrets(
     foreignAddress: ForeignCallSingle,
-    foreignEphPKField0: ForeignCallSingle,
-    foreignEphPKField1: ForeignCallSingle,
-    foreignEphPKField2: ForeignCallSingle,
+    foreignEphPksSlot: ForeignCallSingle,
     foreignContractAddress: ForeignCallSingle,
   ) {
     const address = AztecAddress.fromField(fromSingle(foreignAddress));
-    const ephPK = Point.fromFields([
-      fromSingle(foreignEphPKField0),
-      fromSingle(foreignEphPKField1),
-      fromSingle(foreignEphPKField2),
-    ]);
+    const ephPksSlot = fromSingle(foreignEphPksSlot);
     const contractAddress = AztecAddress.fromField(fromSingle(foreignContractAddress));
 
-    const secret = await this.handlerAsUtility().getSharedSecret(address, ephPK, contractAddress);
+    const responseSlot = await this.handlerAsUtility().getSharedSecrets(address, ephPksSlot, contractAddress);
 
-    return toForeignCallResult([toSingle(secret)]);
+    return toForeignCallResult([toSingle(responseSlot)]);
   }
 
   // eslint-disable-next-line camelcase


### PR DESCRIPTION
## Why we are doing this

As part of constrained delivery, computing multiple shared secrets for multiple ephemeral public keys is needed. The existing oracle only supported a single eph key per call, requiring repeated round-trips for multi-key scenarios.

## Our fix

`aztec_utl_getSharedSecret` has been replaced by `aztec_utl_getSharedSecrets`, which accepts a batch of ephemeral public keys via an `EphemeralArray` slot and returns the corresponding secrets. The oracle major version has been bumped to 23.

The existing `get_shared_secret` Noir function is preserved as a thin wrapper around `get_shared_secrets`, so single-key callers are unaffected. The new `get_shared_secrets` function accepts a `BoundedVec<Point, N>` and returns a `BoundedVec<Field, N>`.

Fixes F-656