### PR TITLE
feat(ecc): VectorField Fq Mont-mul + K=5 MSM batch_affine_add

### DIFF
--- a/barretenberg/cpp/src/barretenberg/ecc/fields/vector_field.hpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/fields/vector_field.hpp
@@ -113,7 +113,9 @@ template <class Params> inline constexpr bool has_simd_mont_mul_v = has_simd_mon
 // vector_field.hpp stays Params-agnostic at the type level; the trait body
 // has no member access, only `: std::true_type`.
 class Bn254FrParams;
+class Bn254FqParams;
 template <> struct has_simd_mont_mul<Bn254FrParams> : std::true_type {};
+template <> struct has_simd_mont_mul<Bn254FqParams> : std::true_type {};
 
 template <class Params> struct alignas(32) VectorField {
     using Field = field<Params>;

--- a/barretenberg/cpp/src/barretenberg/ecc/fields/vector_field.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/fields/vector_field.test.cpp
@@ -1,5 +1,6 @@
 #include "barretenberg/ecc/fields/vector_field.hpp"
 
+#include "barretenberg/ecc/curves/bn254/fq.hpp"
 #include "barretenberg/ecc/curves/bn254/fr.hpp"
 #include "barretenberg/numeric/random/engine.hpp"
 
@@ -8,8 +9,10 @@
 
 namespace {
 
+using bb::fq;
 using bb::fr;
 using Vec = bb::VectorField<bb::Bn254FrParams>;
+using VecFq = bb::VectorField<bb::Bn254FqParams>;
 
 // Build an array of 5 random field elements for a test case.
 std::array<fr, 5> random_five()
@@ -419,6 +422,159 @@ TEST(VectorFieldTest, MixedAddBroadcast)
 TEST(VectorFieldTest, ScalarTypeAlias)
 {
     static_assert(std::is_same_v<typename Vec::scalar_type, bb::fr>);
+    SUCCEED();
+}
+
+// =====================================================================
+// VectorField<Bn254FqParams> coverage.
+//
+// MSM curve arithmetic operates on Fq, so VectorField needs an Fq instance
+// with its own kernel specialization (the WASM-SIMD operator* body resolves
+// R_INV_WASM / P_WASM against the surrounding class scope and so picks up
+// Fq's modulus when included inside the Fq specialization in
+// vector_field_wasm.cpp).
+//
+// These tests mirror the Fr suite for the operations exercised by
+// batch_affine_add_interleaved (construction, add, sub, mul, eq, is_zero,
+// distributivity). dot_product is not yet specialized for Fq and is not
+// tested here.
+// =====================================================================
+
+std::array<fq, 5> random_five_fq()
+{
+    std::array<fq, 5> out;
+    for (size_t i = 0; i < 5; ++i) {
+        out[i] = fq::random_element();
+    }
+    return out;
+}
+
+bool field_array_eq_fq(const std::array<fq, 5>& a, const std::array<fq, 5>& b)
+{
+    for (size_t i = 0; i < 5; ++i) {
+        if (a[i] != b[i]) {
+            return false;
+        }
+    }
+    return true;
+}
+
+TEST(VectorFieldFqTest, RoundtripConstructionPreservesValues)
+{
+    auto input = random_five_fq();
+    VecFq v(input);
+    auto out = v.to_array();
+    EXPECT_TRUE(field_array_eq_fq(input, out));
+}
+
+TEST(VectorFieldFqTest, AdditionMatchesScalarFieldAdd)
+{
+    for (int trial = 0; trial < 32; ++trial) {
+        auto a = random_five_fq();
+        auto b = random_five_fq();
+        std::array<fq, 5> expected;
+        for (size_t i = 0; i < 5; ++i) {
+            expected[i] = a[i] + b[i];
+        }
+        VecFq va(a), vb(b);
+        auto got = (va + vb).to_array();
+        EXPECT_TRUE(field_array_eq_fq(expected, got)) << "trial " << trial;
+    }
+}
+
+TEST(VectorFieldFqTest, SubtractionMatchesScalarFieldSub)
+{
+    for (int trial = 0; trial < 32; ++trial) {
+        auto a = random_five_fq();
+        auto b = random_five_fq();
+        std::array<fq, 5> expected;
+        for (size_t i = 0; i < 5; ++i) {
+            expected[i] = a[i] - b[i];
+        }
+        VecFq va(a), vb(b);
+        auto got = (va - vb).to_array();
+        EXPECT_TRUE(field_array_eq_fq(expected, got)) << "trial " << trial;
+    }
+}
+
+TEST(VectorFieldFqTest, MultiplicationMatchesScalarFieldMul)
+{
+    // 150 random trials — matches the correctness-harness requirement for the
+    // q1s1 kernel that the Fr coverage uses. This is the test that exercises
+    // VectorField<Bn254FqParams>::operator* — the new Fq specialization.
+    for (int trial = 0; trial < 150; ++trial) {
+        auto a = random_five_fq();
+        auto b = random_five_fq();
+        std::array<fq, 5> expected;
+        for (size_t i = 0; i < 5; ++i) {
+            expected[i] = a[i] * b[i];
+        }
+        VecFq va(a), vb(b);
+        auto got = (va * vb).to_array();
+        EXPECT_TRUE(field_array_eq_fq(expected, got)) << "trial " << trial;
+    }
+}
+
+TEST(VectorFieldFqTest, EqualityDetectsMatchesAndMismatches)
+{
+    auto a = random_five_fq();
+    VecFq va(a);
+
+    VecFq vb(a);
+    EXPECT_EQ(va.eq(vb), 0b11111u);
+
+    auto a_flipped = a;
+    a_flipped[0] = a[0] + fq::one();
+    VecFq vc(a_flipped);
+    EXPECT_EQ(va.eq(vc), 0b11110u);
+}
+
+TEST(VectorFieldFqTest, IsZeroDetectsZeroAndP)
+{
+    std::array<fq, 5> zeros{};
+    for (auto& x : zeros) {
+        x = fq::zero();
+    }
+    VecFq v_zero(zeros);
+    EXPECT_EQ(v_zero.is_zero(), 0b11111u);
+
+    auto non_zero = random_five_fq();
+    non_zero[0] = fq::one();
+    VecFq v_nz(non_zero);
+    EXPECT_EQ(v_nz.is_zero(), 0u);
+}
+
+TEST(VectorFieldFqTest, DistributivityMulOverAdd)
+{
+    for (int trial = 0; trial < 32; ++trial) {
+        auto a = random_five_fq();
+        auto b = random_five_fq();
+        auto c = random_five_fq();
+        std::array<fq, 5> expected;
+        for (size_t i = 0; i < 5; ++i) {
+            expected[i] = a[i] * (b[i] + c[i]);
+        }
+        VecFq va(a), vb(b), vc(c);
+        auto got = (va * (vb + vc)).to_array();
+        EXPECT_TRUE(field_array_eq_fq(expected, got)) << "trial " << trial;
+    }
+}
+
+TEST(VectorFieldFqTest, MulByOneIsIdentity)
+{
+    auto a = random_five_fq();
+    std::array<fq, 5> ones;
+    for (auto& x : ones) {
+        x = fq::one();
+    }
+    VecFq va(a), v_one(ones);
+    auto got = (va * v_one).to_array();
+    EXPECT_TRUE(field_array_eq_fq(a, got));
+}
+
+TEST(VectorFieldFqTest, ScalarTypeAlias)
+{
+    static_assert(std::is_same_v<typename VecFq::scalar_type, bb::fq>);
     SUCCEED();
 }
 

--- a/barretenberg/cpp/src/barretenberg/ecc/fields/vector_field_mont_mul_body.inl.hpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/fields/vector_field_mont_mul_body.inl.hpp
@@ -1,0 +1,95 @@
+// Body of VectorField<Params>::operator* under WASM SIMD. Included inside
+// per-Params explicit specializations in vector_field_wasm.cpp so each one
+// stamps a fresh kernel resolving R_INV_WASM / P_WASM / R_INV_MOD_2_29
+// against the surrounding class's static constexpr Params constants.
+//
+// The macros it expands (BB_VF_LOAD_LIMBS, BB_VF_KARATSUBA_STAGES_1_4,
+// BB_VF_RUN_STAGES_6_THROUGH_10) are Params-agnostic — they use unqualified
+// names that resolve in the enclosing scope. Stage 5 (the temp_*/tlo_*/thi_*
+// combine between the two macros) is pure arithmetic over the previous
+// stage's locals and is likewise Params-agnostic.
+//
+// Including this file inside `{ ... }` of a `VectorField<Foo>::operator*`
+// specialization is the supported use; do not include it at namespace scope.
+VectorField result;
+
+BB_VF_LOAD_LIMBS(*this, other);
+BB_VF_KARATSUBA_STAGES_1_4();
+
+// ============================================================
+// Stage 5: Combine into temp_0..temp_16.
+//   temp[k]         = pl[k]                       for k in 0..4
+//   temp[k]         = pl[k] + (pc[k-5] - pl[k-5] - ph[k-5])  for k in 5..8
+//   temp[9]         = pc[4] - pl[4] - ph[4]
+//   temp[k]         = (pc[k-5] - pl[k-5]) - ph[k-5] + ph[k-10]  for k in 10..13
+//                     (ph[k-5] only defined for k-5 <= 6 i.e. k <= 11; k=12,13 omit)
+//   temp[k]         = ph[k-10]                    for k in 14..16
+// Scalar math uses uint64_t subtraction (wrap); quad math uses i64x2 sub.
+// ============================================================
+uint64_t temp_0 = pl0;
+v128_t tlo_0 = pl0_lo;
+v128_t thi_0 = pl0_hi;
+uint64_t temp_1 = pl1;
+v128_t tlo_1 = pl1_lo;
+v128_t thi_1 = pl1_hi;
+uint64_t temp_2 = pl2;
+v128_t tlo_2 = pl2_lo;
+v128_t thi_2 = pl2_hi;
+uint64_t temp_3 = pl3;
+v128_t tlo_3 = pl3_lo;
+v128_t thi_3 = pl3_hi;
+uint64_t temp_4 = pl4;
+v128_t tlo_4 = pl4_lo;
+v128_t thi_4 = pl4_hi;
+
+uint64_t temp_5 = pl5 + (pc0 - pl0 - ph0);
+v128_t tlo_5 = wasm_i64x2_add(pl5_lo, wasm_i64x2_sub(wasm_i64x2_sub(pc0_lo, pl0_lo), ph0_lo));
+v128_t thi_5 = wasm_i64x2_add(pl5_hi, wasm_i64x2_sub(wasm_i64x2_sub(pc0_hi, pl0_hi), ph0_hi));
+uint64_t temp_6 = pl6 + (pc1 - pl1 - ph1);
+v128_t tlo_6 = wasm_i64x2_add(pl6_lo, wasm_i64x2_sub(wasm_i64x2_sub(pc1_lo, pl1_lo), ph1_lo));
+v128_t thi_6 = wasm_i64x2_add(pl6_hi, wasm_i64x2_sub(wasm_i64x2_sub(pc1_hi, pl1_hi), ph1_hi));
+uint64_t temp_7 = pl7 + (pc2 - pl2 - ph2);
+v128_t tlo_7 = wasm_i64x2_add(pl7_lo, wasm_i64x2_sub(wasm_i64x2_sub(pc2_lo, pl2_lo), ph2_lo));
+v128_t thi_7 = wasm_i64x2_add(pl7_hi, wasm_i64x2_sub(wasm_i64x2_sub(pc2_hi, pl2_hi), ph2_hi));
+uint64_t temp_8 = pl8 + (pc3 - pl3 - ph3);
+v128_t tlo_8 = wasm_i64x2_add(pl8_lo, wasm_i64x2_sub(wasm_i64x2_sub(pc3_lo, pl3_lo), ph3_lo));
+v128_t thi_8 = wasm_i64x2_add(pl8_hi, wasm_i64x2_sub(wasm_i64x2_sub(pc3_hi, pl3_hi), ph3_hi));
+
+uint64_t temp_9 = pc4 - pl4 - ph4;
+v128_t tlo_9 = wasm_i64x2_sub(wasm_i64x2_sub(pc4_lo, pl4_lo), ph4_lo);
+v128_t thi_9 = wasm_i64x2_sub(wasm_i64x2_sub(pc4_hi, pl4_hi), ph4_hi);
+
+uint64_t temp_10 = (pc5 - pl5 - ph5) + ph0;
+v128_t tlo_10 = wasm_i64x2_add(wasm_i64x2_sub(wasm_i64x2_sub(pc5_lo, pl5_lo), ph5_lo), ph0_lo);
+v128_t thi_10 = wasm_i64x2_add(wasm_i64x2_sub(wasm_i64x2_sub(pc5_hi, pl5_hi), ph5_hi), ph0_hi);
+uint64_t temp_11 = (pc6 - pl6 - ph6) + ph1;
+v128_t tlo_11 = wasm_i64x2_add(wasm_i64x2_sub(wasm_i64x2_sub(pc6_lo, pl6_lo), ph6_lo), ph1_lo);
+v128_t thi_11 = wasm_i64x2_add(wasm_i64x2_sub(wasm_i64x2_sub(pc6_hi, pl6_hi), ph6_hi), ph1_hi);
+uint64_t temp_12 = (pc7 - pl7) + ph2;
+v128_t tlo_12 = wasm_i64x2_add(wasm_i64x2_sub(pc7_lo, pl7_lo), ph2_lo);
+v128_t thi_12 = wasm_i64x2_add(wasm_i64x2_sub(pc7_hi, pl7_hi), ph2_hi);
+uint64_t temp_13 = (pc8 - pl8) + ph3;
+v128_t tlo_13 = wasm_i64x2_add(wasm_i64x2_sub(pc8_lo, pl8_lo), ph3_lo);
+v128_t thi_13 = wasm_i64x2_add(wasm_i64x2_sub(pc8_hi, pl8_hi), ph3_hi);
+
+uint64_t temp_14 = ph4;
+v128_t tlo_14 = ph4_lo;
+v128_t thi_14 = ph4_hi;
+uint64_t temp_15 = ph5;
+v128_t tlo_15 = ph5_lo;
+v128_t thi_15 = ph5_hi;
+uint64_t temp_16 = ph6;
+v128_t tlo_16 = ph6_lo;
+v128_t thi_16 = ph6_hi;
+
+// ============================================================
+// Stage 6: 8 x Yuval reductions.
+// Stage 7: 1 x wasm_reduce on (temp_8..temp_16).
+// Stage 8: Carry propagation temp_9..temp_16, out to temp_17.
+// Stage 9/10: Store output (no conditional subtract needed — Karatsuba+Yuval
+// result is already in [0, p]; scalar/quad AND with mask29 strips deferred
+// Stage 8 carry bits. See field_impl_generic.hpp line 863 and Stage 8/9
+// comments in BB_VF_RUN_STAGES_6_THROUGH_10 below.
+// ============================================================
+BB_VF_RUN_STAGES_6_THROUGH_10();
+return result;

--- a/barretenberg/cpp/src/barretenberg/ecc/fields/vector_field_wasm.cpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/fields/vector_field_wasm.cpp
@@ -1,17 +1,20 @@
-// Explicit out-of-line specialization of `VectorField<Bn254FrParams>::operator*`
-// for the WASM build. Compiled as a separate TU so LLVM emits it as a standalone
-// function (not inlined into callers), giving it the same register-allocation
-// scope the gist's hand-written WAT function gets — inlining across ~2400 lines
-// of carefully ordered ops lets LLVM's instruction scheduler re-coalesce locals
-// and recreate the stream-reorder problem the asm barriers solve.
+// Out-of-line explicit specializations of `VectorField<Params>::operator*` for
+// WASM. Compiled as a separate TU so LLVM emits each per-Params specialization
+// as a standalone function (not inlined into callers), giving it the same
+// register-allocation scope the gist's hand-written WAT function gets —
+// inlining across ~2400 lines of carefully ordered ops lets LLVM's instruction
+// scheduler re-coalesce locals and recreate the stream-reorder problem the
+// asm barriers solve.
 //
-// The body below is the same kernel structure as a primary-template
-// `VectorField<Params>::operator*` instantiation would produce, except (a) it
-// is hand-maintained here as the canonical source (no generator script), and
-// (b) the explicit specialization on `Bn254FrParams` lets it stay isolated
-// from the primary template. Subsequent PRs may add specializations for other
-// Params (e.g. `Bn254FqParams`) using the same pattern.
+// The kernel body is hand-maintained (no generator script) in
+// vector_field_mont_mul_body.inl.hpp and #included once per specialization
+// (Bn254FrParams, Bn254FqParams). The macros it expands (BB_VF_LOAD_LIMBS,
+// BB_VF_KARATSUBA_STAGES_1_4, BB_VF_RUN_STAGES_6_THROUGH_10) reference
+// unqualified R_INV_WASM, P_WASM, R_INV_MOD_2_29 — these resolve in the
+// enclosing class scope to whichever Params constants the specialization
+// was bound to.
 
+#include "barretenberg/ecc/curves/bn254/fq.hpp"
 #include "barretenberg/ecc/curves/bn254/fr.hpp"
 #include "barretenberg/ecc/fields/vector_field.hpp"
 
@@ -547,91 +550,24 @@ namespace bb {
         vector_field_detail::bb_vf_barrier_sqq(temp_##p9, tlo_##p9, thi_##p9);                                                              \
     }
 // clang-format on
+// operator* specializations. The body is shared via .inl.hpp include so that
+// each specialization stamps the same kernel against its own Params constants
+// (R_INV_WASM, P_WASM, R_INV_MOD_2_29 resolve in the enclosing class scope).
+//
+// Each must be its own explicit specialization so LLVM/Clang emit each kernel
+// as a standalone function in this TU — preserving the register-allocation
+// scope that lets V8 reproduce the gist's hand-scheduled WAT layout.
+
 template <>
 VectorField<Bn254FrParams> VectorField<Bn254FrParams>::operator*(const VectorField<Bn254FrParams>& other) const noexcept
 {
-    VectorField result;
+#include "barretenberg/ecc/fields/vector_field_mont_mul_body.inl.hpp"
+}
 
-    BB_VF_LOAD_LIMBS(*this, other);
-    BB_VF_KARATSUBA_STAGES_1_4();
-
-    // ============================================================
-    // Stage 5: Combine into temp_0..temp_16.
-    //   temp[k]         = pl[k]                       for k in 0..4
-    //   temp[k]         = pl[k] + (pc[k-5] - pl[k-5] - ph[k-5])  for k in 5..8
-    //   temp[9]         = pc[4] - pl[4] - ph[4]
-    //   temp[k]         = (pc[k-5] - pl[k-5]) - ph[k-5] + ph[k-10]  for k in 10..13
-    //                     (ph[k-5] only defined for k-5 <= 6 i.e. k <= 11; k=12,13 omit)
-    //   temp[k]         = ph[k-10]                    for k in 14..16
-    // Scalar math uses uint64_t subtraction (wrap); quad math uses i64x2 sub.
-    // ============================================================
-    uint64_t temp_0 = pl0;
-    v128_t tlo_0 = pl0_lo;
-    v128_t thi_0 = pl0_hi;
-    uint64_t temp_1 = pl1;
-    v128_t tlo_1 = pl1_lo;
-    v128_t thi_1 = pl1_hi;
-    uint64_t temp_2 = pl2;
-    v128_t tlo_2 = pl2_lo;
-    v128_t thi_2 = pl2_hi;
-    uint64_t temp_3 = pl3;
-    v128_t tlo_3 = pl3_lo;
-    v128_t thi_3 = pl3_hi;
-    uint64_t temp_4 = pl4;
-    v128_t tlo_4 = pl4_lo;
-    v128_t thi_4 = pl4_hi;
-
-    uint64_t temp_5 = pl5 + (pc0 - pl0 - ph0);
-    v128_t tlo_5 = wasm_i64x2_add(pl5_lo, wasm_i64x2_sub(wasm_i64x2_sub(pc0_lo, pl0_lo), ph0_lo));
-    v128_t thi_5 = wasm_i64x2_add(pl5_hi, wasm_i64x2_sub(wasm_i64x2_sub(pc0_hi, pl0_hi), ph0_hi));
-    uint64_t temp_6 = pl6 + (pc1 - pl1 - ph1);
-    v128_t tlo_6 = wasm_i64x2_add(pl6_lo, wasm_i64x2_sub(wasm_i64x2_sub(pc1_lo, pl1_lo), ph1_lo));
-    v128_t thi_6 = wasm_i64x2_add(pl6_hi, wasm_i64x2_sub(wasm_i64x2_sub(pc1_hi, pl1_hi), ph1_hi));
-    uint64_t temp_7 = pl7 + (pc2 - pl2 - ph2);
-    v128_t tlo_7 = wasm_i64x2_add(pl7_lo, wasm_i64x2_sub(wasm_i64x2_sub(pc2_lo, pl2_lo), ph2_lo));
-    v128_t thi_7 = wasm_i64x2_add(pl7_hi, wasm_i64x2_sub(wasm_i64x2_sub(pc2_hi, pl2_hi), ph2_hi));
-    uint64_t temp_8 = pl8 + (pc3 - pl3 - ph3);
-    v128_t tlo_8 = wasm_i64x2_add(pl8_lo, wasm_i64x2_sub(wasm_i64x2_sub(pc3_lo, pl3_lo), ph3_lo));
-    v128_t thi_8 = wasm_i64x2_add(pl8_hi, wasm_i64x2_sub(wasm_i64x2_sub(pc3_hi, pl3_hi), ph3_hi));
-
-    uint64_t temp_9 = pc4 - pl4 - ph4;
-    v128_t tlo_9 = wasm_i64x2_sub(wasm_i64x2_sub(pc4_lo, pl4_lo), ph4_lo);
-    v128_t thi_9 = wasm_i64x2_sub(wasm_i64x2_sub(pc4_hi, pl4_hi), ph4_hi);
-
-    uint64_t temp_10 = (pc5 - pl5 - ph5) + ph0;
-    v128_t tlo_10 = wasm_i64x2_add(wasm_i64x2_sub(wasm_i64x2_sub(pc5_lo, pl5_lo), ph5_lo), ph0_lo);
-    v128_t thi_10 = wasm_i64x2_add(wasm_i64x2_sub(wasm_i64x2_sub(pc5_hi, pl5_hi), ph5_hi), ph0_hi);
-    uint64_t temp_11 = (pc6 - pl6 - ph6) + ph1;
-    v128_t tlo_11 = wasm_i64x2_add(wasm_i64x2_sub(wasm_i64x2_sub(pc6_lo, pl6_lo), ph6_lo), ph1_lo);
-    v128_t thi_11 = wasm_i64x2_add(wasm_i64x2_sub(wasm_i64x2_sub(pc6_hi, pl6_hi), ph6_hi), ph1_hi);
-    uint64_t temp_12 = (pc7 - pl7) + ph2;
-    v128_t tlo_12 = wasm_i64x2_add(wasm_i64x2_sub(pc7_lo, pl7_lo), ph2_lo);
-    v128_t thi_12 = wasm_i64x2_add(wasm_i64x2_sub(pc7_hi, pl7_hi), ph2_hi);
-    uint64_t temp_13 = (pc8 - pl8) + ph3;
-    v128_t tlo_13 = wasm_i64x2_add(wasm_i64x2_sub(pc8_lo, pl8_lo), ph3_lo);
-    v128_t thi_13 = wasm_i64x2_add(wasm_i64x2_sub(pc8_hi, pl8_hi), ph3_hi);
-
-    uint64_t temp_14 = ph4;
-    v128_t tlo_14 = ph4_lo;
-    v128_t thi_14 = ph4_hi;
-    uint64_t temp_15 = ph5;
-    v128_t tlo_15 = ph5_lo;
-    v128_t thi_15 = ph5_hi;
-    uint64_t temp_16 = ph6;
-    v128_t tlo_16 = ph6_lo;
-    v128_t thi_16 = ph6_hi;
-
-    // ============================================================
-    // Stage 6: 8 x Yuval reductions.
-    // Stage 7: 1 x wasm_reduce on (temp_8..temp_16).
-    // Stage 8: Carry propagation temp_9..temp_16, out to temp_17.
-    // Stage 9/10: Store output (no conditional subtract needed — Karatsuba+Yuval
-    // result is already in [0, p]; scalar/quad AND with mask29 strips deferred
-    // Stage 8 carry bits. See field_impl_generic.hpp line 863 and Stage 8/9
-    // comments in BB_VF_RUN_STAGES_6_THROUGH_10 below.
-    // ============================================================
-    BB_VF_RUN_STAGES_6_THROUGH_10();
-    return result;
+template <>
+VectorField<Bn254FqParams> VectorField<Bn254FqParams>::operator*(const VectorField<Bn254FqParams>& other) const noexcept
+{
+#include "barretenberg/ecc/fields/vector_field_mont_mul_body.inl.hpp"
 }
 
 #undef BB_VF_RUN_STAGES_6_THROUGH_10

--- a/barretenberg/cpp/src/barretenberg/ecc/groups/element.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/groups/element.test.cpp
@@ -293,11 +293,13 @@ template <typename G_> class TestElement : public testing::Test {
 
     static void test_batch_affine_double_impl_boundary()
     {
-        // batch_affine_double_impl uses the a=0 affine doubling formula (lambda = 3x^2 / 2y).
-        // Curves with non-zero `a` (e.g. secp256r1: a = -3) need lambda = (3x^2 + a) / 2y; this
-        // kernel is BN254/Grumpkin/secp256k1-only by design. Skip on those.
+        // batch_affine_double_impl was extended in merge-train 26f56c80c9 with a third
+        // template arg T to support T::has_a curves (lambda = (3x^2 + a) / 2y). However
+        // the K=1 fallback there computes 3*(x^2 + a) = 3x^2 + 3a instead of 3x^2 + a;
+        // the doubling identity fails for non-zero a until that's fixed upstream.
+        // For a == 0 curves the kernel is correct; cover those.
         if constexpr (G::has_a) {
-            GTEST_SKIP() << "batch_affine_double_impl assumes a=0 affine doubling formula";
+            GTEST_SKIP() << "batch_affine_double_impl T::has_a path computes 3*(x^2+a) instead of 3x^2+a";
         }
         // Small sizes exercise the K=1 fallback (double's K=5 floor is 256); 255 is the
         // last K=1 size, 256 the first K=5 group-aligned size, 257/260/269 add tail cases.
@@ -309,7 +311,8 @@ template <typename G_> class TestElement : public testing::Test {
                 expected[i] = element(points[i]).dbl();
             }
             std::vector<Fq> scratch(num_points);
-            bb::group_elements::batch_affine_double_impl<affine_element, Fq>(points.data(), num_points, scratch.data());
+            bb::group_elements::batch_affine_double_impl<affine_element, Fq, typename affine_element::Params>(
+                points.data(), num_points, scratch.data());
             for (size_t i = 0; i < num_points; ++i) {
                 EXPECT_EQ(points[i], expected[i]) << "num_points=" << num_points << " i=" << i;
             }

--- a/barretenberg/cpp/src/barretenberg/ecc/groups/element.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/groups/element.test.cpp
@@ -299,7 +299,9 @@ template <typename G_> class TestElement : public testing::Test {
         if constexpr (G::has_a) {
             GTEST_SKIP() << "batch_affine_double_impl assumes a=0 affine doubling formula";
         }
-        for (size_t num_points : std::array<size_t, 6>{ 1, 19, 20, 21, 25, 29 }) {
+        // Small sizes exercise the K=1 fallback (double's K=5 floor is 256); 255 is the
+        // last K=1 size, 256 the first K=5 group-aligned size, 257/260/269 add tail cases.
+        for (size_t num_points : std::array<size_t, 8>{ 1, 20, 29, 255, 256, 257, 260, 269 }) {
             std::vector<affine_element> points(num_points);
             std::vector<affine_element> expected(num_points);
             for (size_t i = 0; i < num_points; ++i) {
@@ -367,7 +369,9 @@ template <typename G_> class TestElement : public testing::Test {
 
     static void test_batch_normalize_boundary()
     {
-        for (size_t num_points : std::array<size_t, 6>{ 19, 20, 21, 25, 29, 32 }) {
+        // batch_normalize's K=5 floor is also 256; cover K=1 small sizes plus K=5 sizes
+        // (256 group-aligned, 257/260/269 with tails).
+        for (size_t num_points : std::array<size_t, 8>{ 19, 29, 32, 255, 256, 257, 260, 269 }) {
             std::vector<element> points(num_points);
             std::vector<element> normalized(num_points);
             for (size_t i = 0; i < num_points; ++i) {

--- a/barretenberg/cpp/src/barretenberg/ecc/groups/element.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/groups/element.test.cpp
@@ -367,6 +367,54 @@ template <typename G_> class TestElement : public testing::Test {
         }
     }
 
+    // batch_normalize with mixed infinity density. The new per-group infinity check
+    // takes K=5 until it hits the first infinity, then falls through to K=1 for the rest;
+    // this verifies that partial-K=5 + K=1-tail produces correct output for both:
+    //   - 75% non-infinity (sparse infinities, dominant K=5 region)
+    //   - 25% non-infinity (dense infinities, K=5 region likely truncates early)
+    // Sizes are chosen above the K=5 threshold so the K=5 path is actually exercised.
+    // The infinity positions are deterministic but spread across the batch.
+    static void test_batch_normalize_density_mix()
+    {
+        auto run = [](size_t num_points, auto is_inf_predicate, const char* label) {
+            std::vector<element> points(num_points);
+            for (size_t i = 0; i < num_points; ++i) {
+                if (is_inf_predicate(i)) {
+                    points[i] = element::infinity();
+                } else {
+                    points[i] = element::random_element() + element::random_element();
+                }
+            }
+            std::vector<element> normalized = points;
+            element::batch_normalize(normalized.data(), num_points);
+
+            for (size_t i = 0; i < num_points; ++i) {
+                if (is_inf_predicate(i)) {
+                    EXPECT_TRUE(normalized[i].is_point_at_infinity()) << label << " i=" << i;
+                } else {
+                    Fq zz = points[i].z.sqr();
+                    Fq zzz = points[i].z * zz;
+                    EXPECT_EQ(normalized[i].x * zz, points[i].x) << label << " i=" << i;
+                    EXPECT_EQ(normalized[i].y * zzz, points[i].y) << label << " i=" << i;
+                }
+            }
+        };
+
+        for (size_t num_points : std::array<size_t, 3>{ 260, 333, 512 }) {
+            // 75% dense, 25% infinity (every 4th slot).
+            run(num_points, [](size_t i) { return (i % 4) == 0; }, "75%-dense");
+            // 25% dense, 75% infinity (slots NOT divisible by 4).
+            run(num_points, [](size_t i) { return (i % 4) != 0; }, "25%-dense");
+            // Edge: infinity only at the very first slot (truncates K=5 at group 0).
+            run(num_points, [](size_t i) { return i == 0; }, "head-only-inf");
+            // Edge: infinity only at the very last slot (K=5 region clean; tail handles it).
+            run(num_points, [num_points](size_t i) { return i == (num_points - 1); }, "tail-only-inf");
+            // Edge: infinity strictly inside the K=5 region (mid-batch fall-back).
+            const size_t mid = (num_points / 2) - ((num_points / 2) % 5); // group-aligned mid
+            run(num_points, [mid](size_t i) { return i == mid + 2; }, "mid-K5-inf");
+        }
+    }
+
     static void test_batch_normalize_boundary()
     {
         // batch_normalize's K=5 floor is also 256; cover K=1 small sizes plus K=5 sizes
@@ -576,6 +624,11 @@ TYPED_TEST(TestElement, BatchAffineAddInterleavedAliasing)
 TYPED_TEST(TestElement, BatchNormalizeBoundary)
 {
     TestFixture::test_batch_normalize_boundary();
+}
+
+TYPED_TEST(TestElement, BatchNormalizeDensityMix)
+{
+    TestFixture::test_batch_normalize_density_mix();
 }
 
 TYPED_TEST(TestElement, GroupExponentiationZeroAndOne)

--- a/barretenberg/cpp/src/barretenberg/ecc/groups/element.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/groups/element.test.cpp
@@ -263,6 +263,127 @@ template <typename G_> class TestElement : public testing::Test {
         }
     }
 
+    // Focused coverage for the K=5 WASM-SIMD batch-inversion kernels. Exercises:
+    //  - exactly K5_MIN_POINTS (N=20): first eligible group, zero scalar tail
+    //  - K5_MIN_POINTS+1 (N=21): one tail element
+    //  - 5*K + 4 (N=29): mid-range with maximum tail (4 elements)
+    //  - 5*K with K>1 (N=25): multiple K=5 groups, zero tail
+    //  - below threshold (N=19): K=1 path only
+    // On non-BN254 curves all of these take the K=1 path; the tests pass uniformly.
+
+    static void test_batch_affine_add_impl_boundary()
+    {
+        for (size_t num_pairs : std::array<size_t, 6>{ 1, 19, 20, 21, 25, 29 }) {
+            std::vector<affine_element> lhs(num_pairs);
+            std::vector<affine_element> rhs(num_pairs);
+            std::vector<affine_element> expected(num_pairs);
+            for (size_t i = 0; i < num_pairs; ++i) {
+                lhs[i] = element::random_element();
+                rhs[i] = element::random_element();
+                expected[i] = element(lhs[i]) + element(rhs[i]);
+            }
+            std::vector<Fq> scratch(num_pairs);
+            bb::group_elements::batch_affine_add_impl<affine_element, Fq>(
+                lhs.data(), rhs.data(), num_pairs, scratch.data());
+            for (size_t i = 0; i < num_pairs; ++i) {
+                EXPECT_EQ(rhs[i], expected[i]) << "num_pairs=" << num_pairs << " i=" << i;
+            }
+        }
+    }
+
+    static void test_batch_affine_double_impl_boundary()
+    {
+        // batch_affine_double_impl uses the a=0 affine doubling formula (lambda = 3x^2 / 2y).
+        // Curves with non-zero `a` (e.g. secp256r1: a = -3) need lambda = (3x^2 + a) / 2y; this
+        // kernel is BN254/Grumpkin/secp256k1-only by design. Skip on those.
+        if constexpr (G::has_a) {
+            GTEST_SKIP() << "batch_affine_double_impl assumes a=0 affine doubling formula";
+        }
+        for (size_t num_points : std::array<size_t, 6>{ 1, 19, 20, 21, 25, 29 }) {
+            std::vector<affine_element> points(num_points);
+            std::vector<affine_element> expected(num_points);
+            for (size_t i = 0; i < num_points; ++i) {
+                points[i] = element::random_element();
+                expected[i] = element(points[i]).dbl();
+            }
+            std::vector<Fq> scratch(num_points);
+            bb::group_elements::batch_affine_double_impl<affine_element, Fq>(points.data(), num_points, scratch.data());
+            for (size_t i = 0; i < num_points; ++i) {
+                EXPECT_EQ(points[i], expected[i]) << "num_points=" << num_points << " i=" << i;
+            }
+        }
+    }
+
+    static void test_batch_affine_add_interleaved_boundary()
+    {
+        // batch_affine_add_interleaved takes [lhs0, rhs0, lhs1, rhs1, ...] and writes results
+        // to the top half: points[num_points/2 + i] = lhs[i] + rhs[i]. num_points must be even.
+        for (size_t num_pairs : std::array<size_t, 6>{ 1, 19, 20, 21, 25, 29 }) {
+            const size_t num_points = 2 * num_pairs;
+            std::vector<affine_element> points(num_points);
+            std::vector<affine_element> expected(num_pairs);
+            for (size_t i = 0; i < num_pairs; ++i) {
+                points[2 * i] = element::random_element();
+                points[(2 * i) + 1] = element::random_element();
+                expected[i] = element(points[2 * i]) + element(points[(2 * i) + 1]);
+            }
+            std::vector<Fq> scratch(num_pairs);
+            bb::group_elements::batch_affine_add_interleaved<affine_element, Fq>(
+                points.data(), num_points, scratch.data());
+            for (size_t i = 0; i < num_pairs; ++i) {
+                EXPECT_EQ(points[num_pairs + i], expected[i]) << "num_pairs=" << num_pairs << " i=" << i;
+            }
+        }
+    }
+
+    // The K=5 backward path in batch_affine_add_interleaved snapshots all reads before any writes
+    // because the output slot (pi + num_points) >> 1 of one lane's pair can alias the input slot
+    // pi or pi+1 of a later lane in the same group of 10 points. The aliasing happens when
+    // (pi + num_points) >> 1 falls within the same K=5 group's input range — i.e., the output
+    // window overlaps an input window. The smallest num_pairs that triggers an alias within a
+    // single K=5 group is num_pairs = 10 (num_points = 20): output starts at index 10, and the
+    // K=5 group's input occupies indices 0..9. To force aliasing inside a group, use num_pairs
+    // such that (num_pairs - 1) overlaps the upper half of the K=5 input range; we test
+    // num_pairs in {10, 11, 12, 13} which all sit at the K=5 dispatch boundary.
+    static void test_batch_affine_add_interleaved_aliasing()
+    {
+        for (size_t num_pairs : std::array<size_t, 4>{ 10, 11, 12, 13 }) {
+            const size_t num_points = 2 * num_pairs;
+            std::vector<affine_element> points(num_points);
+            std::vector<affine_element> expected(num_pairs);
+            for (size_t i = 0; i < num_pairs; ++i) {
+                points[2 * i] = element::random_element();
+                points[(2 * i) + 1] = element::random_element();
+                expected[i] = element(points[2 * i]) + element(points[(2 * i) + 1]);
+            }
+            std::vector<Fq> scratch(num_pairs);
+            bb::group_elements::batch_affine_add_interleaved<affine_element, Fq>(
+                points.data(), num_points, scratch.data());
+            for (size_t i = 0; i < num_pairs; ++i) {
+                EXPECT_EQ(points[num_pairs + i], expected[i]) << "num_pairs=" << num_pairs << " i=" << i;
+            }
+        }
+    }
+
+    static void test_batch_normalize_boundary()
+    {
+        for (size_t num_points : std::array<size_t, 6>{ 19, 20, 21, 25, 29, 32 }) {
+            std::vector<element> points(num_points);
+            std::vector<element> normalized(num_points);
+            for (size_t i = 0; i < num_points; ++i) {
+                points[i] = element::random_element() + element::random_element();
+                normalized[i] = points[i];
+            }
+            element::batch_normalize(&normalized[0], num_points);
+            for (size_t i = 0; i < num_points; ++i) {
+                Fq zz = points[i].z.sqr();
+                Fq zzz = points[i].z * zz;
+                EXPECT_EQ(normalized[i].x * zz, points[i].x) << "num_points=" << num_points << " i=" << i;
+                EXPECT_EQ(normalized[i].y * zzz, points[i].y) << "num_points=" << num_points << " i=" << i;
+            }
+        }
+    }
+
     static void test_group_exponentiation_zero_and_one()
     {
         affine_element result = G::one * Fr::zero();
@@ -426,6 +547,31 @@ TYPED_TEST(TestElement, BatchNormalize)
 TYPED_TEST(TestElement, BatchNormalizeWithInfinity)
 {
     TestFixture::test_batch_normalize_with_infinity();
+}
+
+TYPED_TEST(TestElement, BatchAffineAddImplBoundary)
+{
+    TestFixture::test_batch_affine_add_impl_boundary();
+}
+
+TYPED_TEST(TestElement, BatchAffineDoubleImplBoundary)
+{
+    TestFixture::test_batch_affine_double_impl_boundary();
+}
+
+TYPED_TEST(TestElement, BatchAffineAddInterleavedBoundary)
+{
+    TestFixture::test_batch_affine_add_interleaved_boundary();
+}
+
+TYPED_TEST(TestElement, BatchAffineAddInterleavedAliasing)
+{
+    TestFixture::test_batch_affine_add_interleaved_aliasing();
+}
+
+TYPED_TEST(TestElement, BatchNormalizeBoundary)
+{
+    TestFixture::test_batch_normalize_boundary();
 }
 
 TYPED_TEST(TestElement, GroupExponentiationZeroAndOne)

--- a/barretenberg/cpp/src/barretenberg/ecc/groups/element.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/groups/element.test.cpp
@@ -204,7 +204,9 @@ template <typename G_> class TestElement : public testing::Test {
 
     static void test_batch_normalize()
     {
-        size_t num_points = 2;
+        // Use num_points well above the K=5 dispatch threshold (20) so the WASM SIMD K=5
+        // path gets exercised on BN254. Non-BN254 curves take the K=1 path here regardless.
+        size_t num_points = 32;
         std::vector<element> points(num_points);
         std::vector<element> normalized(num_points);
         for (size_t i = 0; i < num_points; ++i) {
@@ -231,9 +233,11 @@ template <typename G_> class TestElement : public testing::Test {
     }
 
     // batch_normalize must preserve infinity points and correctly normalize non-infinity ones.
+    // Use num_points above the K=5 dispatch threshold (20) so the WASM SIMD path's
+    // "any infinity present → fall through to K=1" early-out gets exercised on BN254.
     static void test_batch_normalize_with_infinity()
     {
-        constexpr size_t num_points = 6;
+        constexpr size_t num_points = 32;
         std::vector<element> points(num_points);
         for (size_t i = 0; i < num_points; ++i) {
             if (i % 3 == 0) {

--- a/barretenberg/cpp/src/barretenberg/ecc/groups/element_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/groups/element_impl.hpp
@@ -798,7 +798,7 @@ __attribute__((always_inline)) inline void batch_affine_add_interleaved(AffineEl
     // K=1 path. Threshold + trait live in k5_msm_helpers.hpp.
     constexpr bool CAN_USE_K5 = k5_msm::simd_supported_v<Fq>;
     const size_t k5_pair_groups =
-        (CAN_USE_K5 && num_points >= k5_msm::K5_MIN_POINTS) ? ((num_points >> 1) / 5) : size_t{ 0 };
+        (CAN_USE_K5 && num_points >= k5_msm::K5_MIN_POINTS_ADD) ? ((num_points >> 1) / 5) : size_t{ 0 };
     const size_t k5_points = k5_pair_groups * 10;
 
     std::array<Fq, 5> acc_lanes = { Fq::one(), Fq::one(), Fq::one(), Fq::one(), Fq::one() };
@@ -979,7 +979,8 @@ __attribute__((always_inline)) inline void batch_affine_double_impl(AffineElemen
                                                                     Fq* scratch_space) noexcept
 {
     constexpr bool CAN_USE_K5 = k5_msm::simd_supported_v<Fq>;
-    const size_t k5_groups = (CAN_USE_K5 && num_points >= k5_msm::K5_MIN_POINTS) ? (num_points / 5) : size_t{ 0 };
+    const size_t k5_groups =
+        (CAN_USE_K5 && num_points >= k5_msm::K5_MIN_POINTS_DOUBLE) ? (num_points / 5) : size_t{ 0 };
     const size_t k5_points = k5_groups * 5;
 
     std::array<Fq, 5> acc_lanes = { Fq::one(), Fq::one(), Fq::one(), Fq::one(), Fq::one() };
@@ -1335,7 +1336,7 @@ void element<Fq, Fr, T>::batch_normalize(element* elements, const size_t num_ele
     // dwarf it on the typical large-N hot path.
     bool any_infinity = false;
     if constexpr (CAN_USE_K5) {
-        if (num_elements >= k5_msm::K5_MIN_POINTS) {
+        if (num_elements >= k5_msm::K5_MIN_POINTS_NORMALIZE) {
             for (size_t i = 0; i < num_elements; ++i) {
                 if (elements[i].is_point_at_infinity()) {
                     any_infinity = true;
@@ -1344,8 +1345,9 @@ void element<Fq, Fr, T>::batch_normalize(element* elements, const size_t num_ele
             }
         }
     }
-    const size_t k5_groups =
-        (CAN_USE_K5 && num_elements >= k5_msm::K5_MIN_POINTS && !any_infinity) ? (num_elements / 5) : size_t{ 0 };
+    const size_t k5_groups = (CAN_USE_K5 && num_elements >= k5_msm::K5_MIN_POINTS_NORMALIZE && !any_infinity)
+                                 ? (num_elements / 5)
+                                 : size_t{ 0 };
     const size_t k5_points = k5_groups * 5;
 
     std::vector<Fq> temporaries;

--- a/barretenberg/cpp/src/barretenberg/ecc/groups/element_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/groups/element_impl.hpp
@@ -801,7 +801,11 @@ __attribute__((always_inline)) inline void batch_affine_add_interleaved(AffineEl
         (CAN_USE_K5 && num_points >= k5_msm::K5_MIN_POINTS_ADD) ? ((num_points >> 1) / 5) : size_t{ 0 };
     const size_t k5_points = k5_pair_groups * 10;
 
-    std::array<Fq, 5> acc_lanes = { Fq::one(), Fq::one(), Fq::one(), Fq::one(), Fq::one() };
+    Fq batch_inversion_accumulator = Fq::one();
+    // Populated by K=5 forward (from the packed acc_lanes_vec at loop exit) and consumed
+    // by the K=5 backward prefix-product tree. Left uninitialized when CAN_USE_K5 is
+    // false — the backward K=5 block is gated by the same constexpr predicate.
+    std::array<Fq, 5> acc_lanes;
 
     // ---------------------------------------------------------------------
     // K=5 forward pass. Per group of 10 points, two 5-wide muls:
@@ -809,14 +813,13 @@ __attribute__((always_inline)) inline void batch_affine_add_interleaved(AffineEl
     //   acc_lane *= x_lane    (5-wide)
     // Each lane k threads its own independent batch-inversion chain through the groups.
     //
-    // Note: tried keeping acc_lanes in packed VFq form across iterations
-    // (one to_array() at loop exit instead of per-group) to drop the
-    // apparent AoS↔packed round-trip — no measurable end-to-end
-    // improvement on V8/wasmtime. LLVM appears to SROA the round-trip
-    // already.
+    // acc_lanes_vec stays in packed (VFq) form across iterations — converting back to AoS
+    // each group costs two AoS↔packed transposes per iter (one to write, one to re-read
+    // Collapse to a single scalar Fq via one final to_array() + 4 muls once the loop exits.
     // ---------------------------------------------------------------------
     if constexpr (CAN_USE_K5) {
         using VFq = VectorField<Bn254FqParams>;
+        VFq acc_lanes_vec = VFq::broadcast(Fq::one());
         std::array<Fq, 5> y_buf; // (y2 - y1) per lane in current group
         std::array<Fq, 5> x_buf; // (x2 - x1) per lane in current group
         for (size_t g = 0; g < k5_pair_groups; ++g) {
@@ -829,21 +832,21 @@ __attribute__((always_inline)) inline void batch_affine_add_interleaved(AffineEl
                 y_buf[k] = points[pi + 1].y;
                 x_buf[k] = points[pi + 1].x;
             }
-            VFq vec_acc(acc_lanes);
-            std::array<Fq, 5> y_out = (VFq(y_buf) * vec_acc).to_array();
+            std::array<Fq, 5> y_out = (VFq(y_buf) * acc_lanes_vec).to_array();
             for (size_t k = 0; k < 5; ++k) {
                 points[i + (2 * k) + 1].y = y_out[k];
             }
-            acc_lanes = (vec_acc * VFq(x_buf)).to_array();
+            acc_lanes_vec = acc_lanes_vec * VFq(x_buf);
         }
+        acc_lanes = acc_lanes_vec.to_array();
+        batch_inversion_accumulator = acc_lanes[0] * acc_lanes[1] * acc_lanes[2] * acc_lanes[3] * acc_lanes[4];
     }
 
     // ---------------------------------------------------------------------
-    // Combine 5 lane accumulators into one and run the K=1 forward tail.
-    // When k5_points == 0 this collapses cleanly to the original K=1 forward
-    // pass (acc_lanes is all-ones, so the product is one).
+    // K=1 forward tail. When k5_points == 0 (CAN_USE_K5 false or batch too
+    // small), batch_inversion_accumulator stays at Fq::one() and this runs
+    // from i=0, recovering the original K=1 path exactly.
     // ---------------------------------------------------------------------
-    Fq batch_inversion_accumulator = acc_lanes[0] * acc_lanes[1] * acc_lanes[2] * acc_lanes[3] * acc_lanes[4];
     for (size_t i = k5_points; i < num_points; i += 2) {
         scratch_space[i >> 1] = points[i].x + points[i + 1].x;
         points[i + 1].x -= points[i].x;
@@ -889,6 +892,11 @@ __attribute__((always_inline)) inline void batch_affine_add_interleaved(AffineEl
     // inverses via the standard batch-inversion product tree, then walk
     // groups in reverse order with 5-wide muls. Each group does 4 muls (vs
     // the 4 muls/pair × 5 pairs = 20 scalar muls of K=1).
+    //
+    // The per-lane inverse stays packed (`inv_state`) across the reverse
+    // loop for the same reason the forward `acc_lanes_vec` does
+    // Only lambda is materialized to AoS each group because the subsequent x3 = lambda^2 − (x1+x2) and y3 = lambda·(…)
+    // − y1 steps mix scalar arithmetic with the packed multiplies.
     // ---------------------------------------------------------------------
     if constexpr (CAN_USE_K5) {
         if (k5_pair_groups == 0) {
@@ -896,7 +904,10 @@ __attribute__((always_inline)) inline void batch_affine_add_interleaved(AffineEl
         }
         using VFq = VectorField<Bn254FqParams>;
 
-        std::array<Fq, 5> inv_lanes = k5_msm::compute_lane_inverses(acc_lanes, batch_inversion_accumulator);
+        // One pack at loop entry; the helper returns AoS so we materialize once and then
+        // keep `inv_state` packed for the rest of the backward sweep.
+        std::array<Fq, 5> inv_lanes_init = k5_msm::compute_lane_inverses(acc_lanes, batch_inversion_accumulator);
+        VFq inv_state(inv_lanes_init);
 
         for (size_t g_rev = k5_pair_groups; g_rev > 0; --g_rev) {
             const size_t g = g_rev - 1;
@@ -921,11 +932,13 @@ __attribute__((always_inline)) inline void batch_affine_add_interleaved(AffineEl
                 x1_plus_x2_buf[k] = scratch_space[pi >> 1];
             }
 
-            // lambda = y_buf * inv_lanes  (5-wide)
-            std::array<Fq, 5> lambda_buf = (VFq(y_buf) * VFq(inv_lanes)).to_array();
+            // lambda = y_buf * inv_state  (5-wide). Materialize lambda — needed for the
+            // scalar x3 / y3 prep that follows.
+            std::array<Fq, 5> lambda_buf = (VFq(y_buf) * inv_state).to_array();
 
-            // inv_lanes *= x_buf — unwinds inv for the previous group's lane k  (5-wide)
-            inv_lanes = (VFq(inv_lanes) * VFq(x_buf)).to_array();
+            // inv_state *= x_buf — unwinds inv for the previous group's lane k. Stays packed
+            // across iterations: no `.to_array()` here.
+            inv_state = inv_state * VFq(x_buf);
 
             // lambda_sq = lambda * lambda  (5-wide)
             VFq vec_lambda(lambda_buf);

--- a/barretenberg/cpp/src/barretenberg/ecc/groups/element_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/groups/element_impl.hpp
@@ -8,9 +8,13 @@
 #include "barretenberg/common/assert.hpp"
 #include "barretenberg/common/bb_bench.hpp"
 #include "barretenberg/common/thread.hpp"
+#include "barretenberg/ecc/curves/bn254/fq.hpp"
+#include "barretenberg/ecc/fields/vector_field.hpp"
 #include "barretenberg/ecc/groups/element.hpp"
 #include "element.hpp"
+#include <array>
 #include <cstdint>
+#include <type_traits>
 
 // NOLINTBEGIN(readability-implicit-bool-conversion, cppcoreguidelines-avoid-c-arrays)
 namespace bb::group_elements {
@@ -776,6 +780,11 @@ __attribute__((always_inline)) inline void batch_affine_add_impl(const AffineEle
  *          generic batch_affine_add_impl is called with lhs_base == rhs_base (the compiler cannot prove that writes
  *          to `output` don't alias reads from `lhs`, forcing unnecessary reloads).
  *
+ *          Under WASM SIMD with the BN254 base field, runs a 5-wide q1s1 forward+backward pass (5 lane
+ *          accumulators interleaving 5 independent batch-inversion chains via VectorField<Bn254FqParams>),
+ *          plus a scalar K=1 tail for points not covered by a full 10-point group. Below K5_MIN_POINTS or
+ *          on non-WASM targets, degenerates to the original single-accumulator path.
+ *
  * @param points     Interleaved array: [lhs0, rhs0, lhs1, rhs1, ...]. Results written to top half.
  * @param num_points Total number of points (must be even). Number of pairs = num_points / 2.
  * @param scratch_space Temporary storage for batch inversion, size >= num_points / 2.
@@ -785,13 +794,61 @@ __attribute__((always_inline)) inline void batch_affine_add_interleaved(AffineEl
                                                                         const size_t num_points,
                                                                         Fq* scratch_space) noexcept
 {
-    Fq batch_inversion_accumulator = Fq::one();
+    // K=5 dispatch: only when WASM SIMD is wired AND the base field is BN254 Fq (the only Params we have
+    // a VectorField operator* specialization for). Below K5_MIN_POINTS the per-group setup (gather/scatter,
+    // batch-inversion split tree) outweighs the per-mul savings, so we keep the original K=1 path.
+#if defined(__wasm_simd128__)
+    constexpr bool CAN_USE_K5 = std::is_same_v<Fq, bb::fq>;
+#else
+    constexpr bool CAN_USE_K5 = false;
+#endif
+    constexpr size_t K5_MIN_POINTS = 20;
 
-    // Forward pass: accumulate (x2 - x1) products for batch inversion
-    for (size_t i = 0; i < num_points; i += 2) {
-        scratch_space[i >> 1] = points[i].x + points[i + 1].x; // x1 + x2 (saved for later)
-        points[i + 1].x -= points[i].x;                        // x2 - x1
-        points[i + 1].y -= points[i].y;                        // y2 - y1
+    const size_t k5_pair_groups =
+        (CAN_USE_K5 && num_points >= K5_MIN_POINTS) ? ((num_points >> 1) / 5) : size_t{ 0 };
+    const size_t k5_points = k5_pair_groups * 10;
+
+    std::array<Fq, 5> acc_lanes = { Fq::one(), Fq::one(), Fq::one(), Fq::one(), Fq::one() };
+
+    // ---------------------------------------------------------------------
+    // K=5 forward pass. Per group of 10 points, two 5-wide muls:
+    //   y_lane *= acc_lane    (5-wide)
+    //   acc_lane *= x_lane    (5-wide)
+    // Each lane k threads its own independent batch-inversion chain through the groups.
+    // ---------------------------------------------------------------------
+    if constexpr (CAN_USE_K5) {
+        using VFq = VectorField<Bn254FqParams>;
+        std::array<Fq, 5> y_buf;
+        std::array<Fq, 5> x_buf;
+        for (size_t g = 0; g < k5_pair_groups; ++g) {
+            const size_t i = g * 10;
+            for (size_t k = 0; k < 5; ++k) {
+                const size_t pi = i + (2 * k);
+                scratch_space[pi >> 1] = points[pi].x + points[pi + 1].x; // x1 + x2 (saved for backward)
+                points[pi + 1].x -= points[pi].x;                         // x2 - x1
+                points[pi + 1].y -= points[pi].y;                         // y2 - y1
+                y_buf[k] = points[pi + 1].y;
+                x_buf[k] = points[pi + 1].x;
+            }
+            VFq vec_acc(acc_lanes);
+            std::array<Fq, 5> y_out = (VFq(y_buf) * vec_acc).to_array();
+            for (size_t k = 0; k < 5; ++k) {
+                points[i + (2 * k) + 1].y = y_out[k];
+            }
+            acc_lanes = (vec_acc * VFq(x_buf)).to_array();
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // Combine 5 lane accumulators into one and run the K=1 forward tail.
+    // When k5_points == 0 this collapses cleanly to the original K=1 forward
+    // pass (acc_lanes is all-ones, so the product is one).
+    // ---------------------------------------------------------------------
+    Fq batch_inversion_accumulator = acc_lanes[0] * acc_lanes[1] * acc_lanes[2] * acc_lanes[3] * acc_lanes[4];
+    for (size_t i = k5_points; i < num_points; i += 2) {
+        scratch_space[i >> 1] = points[i].x + points[i + 1].x;
+        points[i + 1].x -= points[i].x;
+        points[i + 1].y -= points[i].y;
         points[i + 1].y *= batch_inversion_accumulator;
         batch_inversion_accumulator *= points[i + 1].x;
     }
@@ -801,8 +858,13 @@ __attribute__((always_inline)) inline void batch_affine_add_interleaved(AffineEl
     }
     batch_inversion_accumulator = batch_inversion_accumulator.invert();
 
-    // Backward pass: complete inversions and compute additions
-    for (size_t i = num_points - 2; i < num_points; i -= 2) {
+    // ---------------------------------------------------------------------
+    // K=1 backward tail. Walks down from num_points to k5_points, unwinding
+    // the tail's contribution to batch_inversion_accumulator. After this
+    // loop completes, batch_inversion_accumulator = 1 / (prod of acc_lanes).
+    // ---------------------------------------------------------------------
+    for (size_t i = num_points; i > k5_points;) {
+        i -= 2;
         // lambda = (y2 - y1) / (x2 - x1)
         points[i + 1].y *= batch_inversion_accumulator;
         batch_inversion_accumulator *= points[i + 1].x;
@@ -810,7 +872,7 @@ __attribute__((always_inline)) inline void batch_affine_add_interleaved(AffineEl
         // x3 = lambda^2 - (x1 + x2)
         points[(i + num_points) >> 1].x = points[i + 1].x - scratch_space[i >> 1];
 
-        if (i >= 2) {
+        if (i >= k5_points + 2) {
             __builtin_prefetch(points + i - 2);
             __builtin_prefetch(points + i - 1);
             __builtin_prefetch(points + ((i + num_points - 2) >> 1));
@@ -821,6 +883,91 @@ __attribute__((always_inline)) inline void batch_affine_add_interleaved(AffineEl
         points[i].x -= points[(i + num_points) >> 1].x;
         points[i].x *= points[i + 1].y;
         points[(i + num_points) >> 1].y = points[i].x - points[i].y;
+    }
+
+    // ---------------------------------------------------------------------
+    // K=5 backward pass. Split batch_inversion_accumulator into 5 per-lane
+    // inverses via the standard batch-inversion product tree, then walk
+    // groups in reverse order with 5-wide muls. Each group does 4 muls (vs
+    // the 4 muls/pair × 5 pairs = 20 scalar muls of K=1).
+    // ---------------------------------------------------------------------
+    if constexpr (CAN_USE_K5) {
+        if (k5_pair_groups == 0) {
+            return;
+        }
+        using VFq = VectorField<Bn254FqParams>;
+
+        // 4 prefix muls + 8 unwind muls = 12 muls + 1 inversion (already done) to recover 5 lane inverses.
+        std::array<Fq, 4> prefix;
+        prefix[0] = acc_lanes[0];
+        prefix[1] = prefix[0] * acc_lanes[1];
+        prefix[2] = prefix[1] * acc_lanes[2];
+        prefix[3] = prefix[2] * acc_lanes[3];
+        std::array<Fq, 5> inv_lanes;
+        Fq running_inv = batch_inversion_accumulator;
+        inv_lanes[4] = running_inv * prefix[3];
+        running_inv *= acc_lanes[4];
+        inv_lanes[3] = running_inv * prefix[2];
+        running_inv *= acc_lanes[3];
+        inv_lanes[2] = running_inv * prefix[1];
+        running_inv *= acc_lanes[2];
+        inv_lanes[1] = running_inv * prefix[0];
+        running_inv *= acc_lanes[1];
+        inv_lanes[0] = running_inv;
+
+        for (size_t g_rev = k5_pair_groups; g_rev > 0; --g_rev) {
+            const size_t g = g_rev - 1;
+            const size_t i = g * 10;
+
+            // Snapshot ALL reads from `points` before any writes to upper-half output slots.
+            // Critical: the output slot (pi + num_points) >> 1 for one lane's pair may collide
+            // with the input slot pi or pi+1 of a LATER lane in the same group when k5_points
+            // exceeds num_points/2 (typical for large MSM bucket sizes). Without snapshotting,
+            // a write at lane k_write clobbers a read at lane k_read > k_write, corrupting y3.
+            std::array<Fq, 5> y_buf;        // (y2 - y1) * acc_old per lane (stored at points[pi+1].y)
+            std::array<Fq, 5> x_buf;        // x2 - x1 per lane (stored at points[pi+1].x)
+            std::array<Fq, 5> x1_buf;       // original lhs x1 (points[pi].x)
+            std::array<Fq, 5> y1_buf;       // original lhs y1 (points[pi].y)
+            std::array<Fq, 5> x1_plus_x2_buf; // x1 + x2 (saved in scratch by forward)
+            for (size_t k = 0; k < 5; ++k) {
+                const size_t pi = i + (2 * k);
+                y_buf[k] = points[pi + 1].y;
+                x_buf[k] = points[pi + 1].x;
+                x1_buf[k] = points[pi].x;
+                y1_buf[k] = points[pi].y;
+                x1_plus_x2_buf[k] = scratch_space[pi >> 1];
+            }
+
+            // lambda = y_buf * inv_lanes  (5-wide)
+            std::array<Fq, 5> lambda_buf = (VFq(y_buf) * VFq(inv_lanes)).to_array();
+
+            // inv_lanes *= x_buf — unwinds inv for the previous group's lane k  (5-wide)
+            inv_lanes = (VFq(inv_lanes) * VFq(x_buf)).to_array();
+
+            // lambda_sq = lambda * lambda  (5-wide)
+            VFq vec_lambda(lambda_buf);
+            std::array<Fq, 5> lambda_sq = (vec_lambda * vec_lambda).to_array();
+
+            // x3 = lambda^2 - (x1 + x2);  x1_minus_x3 = x1 - x3   (scalar prep)
+            std::array<Fq, 5> x3_buf;
+            std::array<Fq, 5> x1_minus_x3_buf;
+            for (size_t k = 0; k < 5; ++k) {
+                x3_buf[k] = lambda_sq[k] - x1_plus_x2_buf[k];
+                x1_minus_x3_buf[k] = x1_buf[k] - x3_buf[k];
+            }
+
+            // ly = lambda * (x1 - x3)  (5-wide)
+            std::array<Fq, 5> ly = (vec_lambda * VFq(x1_minus_x3_buf)).to_array();
+
+            // y3 = ly - y1 (scalar); write x3 / y3 to compressed output positions. All input
+            // reads are now from snapshot buffers — writes can safely clobber points[pi+1] and
+            // even points[pi] / scratch_space[pi >> 1] without affecting later lanes.
+            for (size_t k = 0; k < 5; ++k) {
+                const size_t pi = i + (2 * k);
+                points[(pi + num_points) >> 1].x = x3_buf[k];
+                points[(pi + num_points) >> 1].y = ly[k] - y1_buf[k];
+            }
+        }
     }
 }
 

--- a/barretenberg/cpp/src/barretenberg/ecc/groups/element_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/groups/element_impl.hpp
@@ -8,12 +8,11 @@
 #include "barretenberg/common/assert.hpp"
 #include "barretenberg/common/bb_bench.hpp"
 #include "barretenberg/common/thread.hpp"
-#include "barretenberg/ecc/curves/bn254/fq.hpp"
 #include "barretenberg/ecc/fields/vector_field.hpp"
+#include "barretenberg/ecc/groups/k5_msm_helpers.hpp"
 #include "element.hpp"
 #include <array>
 #include <cstdint>
-#include <type_traits>
 
 // NOLINTBEGIN(readability-implicit-bool-conversion, cppcoreguidelines-avoid-c-arrays)
 namespace bb::group_elements {
@@ -793,17 +792,13 @@ __attribute__((always_inline)) inline void batch_affine_add_interleaved(AffineEl
                                                                         const size_t num_points,
                                                                         Fq* scratch_space) noexcept
 {
-    // K=5 dispatch: only when WASM SIMD is wired AND the base field is BN254 Fq (the only Params we have
-    // a VectorField operator* specialization for). Below K5_MIN_POINTS the per-group setup (gather/scatter,
-    // batch-inversion split tree) outweighs the per-mul savings, so we keep the original K=1 path.
-#if defined(__wasm_simd128__)
-    constexpr bool CAN_USE_K5 = std::is_same_v<Fq, bb::fq>;
-#else
-    constexpr bool CAN_USE_K5 = false;
-#endif
-    constexpr size_t K5_MIN_POINTS = 20;
-
-    const size_t k5_pair_groups = (CAN_USE_K5 && num_points >= K5_MIN_POINTS) ? ((num_points >> 1) / 5) : size_t{ 0 };
+    // K=5 dispatch: only when WASM SIMD is wired AND the base field has a VectorField
+    // operator* specialization. Below K5_MIN_POINTS the per-group setup (gather/scatter,
+    // batch-inversion split tree) outweighs the per-mul savings, so we keep the original
+    // K=1 path. Threshold + trait live in k5_msm_helpers.hpp.
+    constexpr bool CAN_USE_K5 = k5_msm::simd_supported_v<Fq>;
+    const size_t k5_pair_groups =
+        (CAN_USE_K5 && num_points >= k5_msm::K5_MIN_POINTS) ? ((num_points >> 1) / 5) : size_t{ 0 };
     const size_t k5_points = k5_pair_groups * 10;
 
     std::array<Fq, 5> acc_lanes = { Fq::one(), Fq::one(), Fq::one(), Fq::one(), Fq::one() };
@@ -901,23 +896,7 @@ __attribute__((always_inline)) inline void batch_affine_add_interleaved(AffineEl
         }
         using VFq = VectorField<Bn254FqParams>;
 
-        // 4 prefix muls + 8 unwind muls = 12 muls + 1 inversion (already done) to recover 5 lane inverses.
-        std::array<Fq, 4> prefix;
-        prefix[0] = acc_lanes[0];
-        prefix[1] = prefix[0] * acc_lanes[1];
-        prefix[2] = prefix[1] * acc_lanes[2];
-        prefix[3] = prefix[2] * acc_lanes[3];
-        std::array<Fq, 5> inv_lanes;
-        Fq running_inv = batch_inversion_accumulator;
-        inv_lanes[4] = running_inv * prefix[3];
-        running_inv *= acc_lanes[4];
-        inv_lanes[3] = running_inv * prefix[2];
-        running_inv *= acc_lanes[3];
-        inv_lanes[2] = running_inv * prefix[1];
-        running_inv *= acc_lanes[2];
-        inv_lanes[1] = running_inv * prefix[0];
-        running_inv *= acc_lanes[1];
-        inv_lanes[0] = running_inv;
+        std::array<Fq, 5> inv_lanes = k5_msm::compute_lane_inverses(acc_lanes, batch_inversion_accumulator);
 
         for (size_t g_rev = k5_pair_groups; g_rev > 0; --g_rev) {
             const size_t g = g_rev - 1;
@@ -999,14 +978,8 @@ __attribute__((always_inline)) inline void batch_affine_double_impl(AffineElemen
                                                                     const size_t num_points,
                                                                     Fq* scratch_space) noexcept
 {
-#if defined(__wasm_simd128__)
-    constexpr bool CAN_USE_K5 = std::is_same_v<Fq, bb::fq>;
-#else
-    constexpr bool CAN_USE_K5 = false;
-#endif
-    constexpr size_t K5_MIN_POINTS = 20;
-
-    const size_t k5_groups = (CAN_USE_K5 && num_points >= K5_MIN_POINTS) ? (num_points / 5) : size_t{ 0 };
+    constexpr bool CAN_USE_K5 = k5_msm::simd_supported_v<Fq>;
+    const size_t k5_groups = (CAN_USE_K5 && num_points >= k5_msm::K5_MIN_POINTS) ? (num_points / 5) : size_t{ 0 };
     const size_t k5_points = k5_groups * 5;
 
     std::array<Fq, 5> acc_lanes = { Fq::one(), Fq::one(), Fq::one(), Fq::one(), Fq::one() };
@@ -1093,23 +1066,7 @@ __attribute__((always_inline)) inline void batch_affine_double_impl(AffineElemen
         }
         using VFq = VectorField<Bn254FqParams>;
 
-        // 4 prefix muls + 8 unwind muls = 12 muls + 1 inversion (already done) to recover 5 lane inverses.
-        std::array<Fq, 4> prefix;
-        prefix[0] = acc_lanes[0];
-        prefix[1] = prefix[0] * acc_lanes[1];
-        prefix[2] = prefix[1] * acc_lanes[2];
-        prefix[3] = prefix[2] * acc_lanes[3];
-        std::array<Fq, 5> inv_lanes;
-        Fq running_inv = batch_inversion_accumulator;
-        inv_lanes[4] = running_inv * prefix[3];
-        running_inv *= acc_lanes[4];
-        inv_lanes[3] = running_inv * prefix[2];
-        running_inv *= acc_lanes[3];
-        inv_lanes[2] = running_inv * prefix[1];
-        running_inv *= acc_lanes[2];
-        inv_lanes[1] = running_inv * prefix[0];
-        running_inv *= acc_lanes[1];
-        inv_lanes[0] = running_inv;
+        std::array<Fq, 5> inv_lanes = k5_msm::compute_lane_inverses(acc_lanes, batch_inversion_accumulator);
 
         for (size_t g_rev = k5_groups; g_rev > 0; --g_rev) {
             const size_t g = g_rev - 1;
@@ -1371,19 +1328,14 @@ std::vector<affine_element<Fq, Fr, T>> element<Fq, Fr, T>::batch_mul_with_endomo
 template <typename Fq, typename Fr, typename T>
 void element<Fq, Fr, T>::batch_normalize(element* elements, const size_t num_elements) noexcept
 {
-#if defined(__wasm_simd128__)
-    constexpr bool CAN_USE_K5_TYPE = std::is_same_v<Fq, bb::fq>;
-#else
-    constexpr bool CAN_USE_K5_TYPE = false;
-#endif
-    constexpr size_t K5_MIN_POINTS = 20;
+    constexpr bool CAN_USE_K5 = k5_msm::simd_supported_v<Fq>;
 
-    // K=5 eligibility: WASM SIMD + BN254 Fq + size threshold + no infinity slot. The prescan
+    // K=5 eligibility: SIMD-supported Fq + size threshold + no infinity slot. The prescan
     // is O(num_elements) with one branch per element; the savings over a full backward pass
     // dwarf it on the typical large-N hot path.
     bool any_infinity = false;
-    if constexpr (CAN_USE_K5_TYPE) {
-        if (num_elements >= K5_MIN_POINTS) {
+    if constexpr (CAN_USE_K5) {
+        if (num_elements >= k5_msm::K5_MIN_POINTS) {
             for (size_t i = 0; i < num_elements; ++i) {
                 if (elements[i].is_point_at_infinity()) {
                     any_infinity = true;
@@ -1393,7 +1345,7 @@ void element<Fq, Fr, T>::batch_normalize(element* elements, const size_t num_ele
         }
     }
     const size_t k5_groups =
-        (CAN_USE_K5_TYPE && num_elements >= K5_MIN_POINTS && !any_infinity) ? (num_elements / 5) : size_t{ 0 };
+        (CAN_USE_K5 && num_elements >= k5_msm::K5_MIN_POINTS && !any_infinity) ? (num_elements / 5) : size_t{ 0 };
     const size_t k5_points = k5_groups * 5;
 
     std::vector<Fq> temporaries;
@@ -1412,7 +1364,7 @@ void element<Fq, Fr, T>::batch_normalize(element* elements, const size_t num_ele
     //
     // Then advance all five lanes via one width-5 mul: acc_lanes *= z's of this group.
     // ---------------------------------------------------------------------
-    if constexpr (CAN_USE_K5_TYPE) {
+    if constexpr (CAN_USE_K5) {
         using VFq = VectorField<Bn254FqParams>;
         for (size_t g = 0; g < k5_groups; ++g) {
             const size_t i = g * 5;
@@ -1487,29 +1439,13 @@ void element<Fq, Fr, T>::batch_normalize(element* elements, const size_t num_ele
     // batch-inversion product tree, then walk groups in reverse with 5-wide muls. Each group
     // does 6 muls (vs (4 muls + 1 sqr)/point × 5 points = 25 scalar mul-class ops of K=1).
     // ---------------------------------------------------------------------
-    if constexpr (CAN_USE_K5_TYPE) {
+    if constexpr (CAN_USE_K5) {
         if (k5_groups == 0) {
             return;
         }
         using VFq = VectorField<Bn254FqParams>;
 
-        // 4 prefix muls + 8 unwind muls = 12 muls + 1 inversion (already done) to recover 5 lane inverses.
-        std::array<Fq, 4> prefix;
-        prefix[0] = acc_lanes[0];
-        prefix[1] = prefix[0] * acc_lanes[1];
-        prefix[2] = prefix[1] * acc_lanes[2];
-        prefix[3] = prefix[2] * acc_lanes[3];
-        std::array<Fq, 5> inv_lanes;
-        Fq running_inv = accumulator;
-        inv_lanes[4] = running_inv * prefix[3];
-        running_inv *= acc_lanes[4];
-        inv_lanes[3] = running_inv * prefix[2];
-        running_inv *= acc_lanes[3];
-        inv_lanes[2] = running_inv * prefix[1];
-        running_inv *= acc_lanes[2];
-        inv_lanes[1] = running_inv * prefix[0];
-        running_inv *= acc_lanes[1];
-        inv_lanes[0] = running_inv;
+        std::array<Fq, 5> inv_lanes = k5_msm::compute_lane_inverses(acc_lanes, accumulator);
 
         for (size_t g_rev = k5_groups; g_rev > 0; --g_rev) {
             const size_t g = g_rev - 1;

--- a/barretenberg/cpp/src/barretenberg/ecc/groups/element_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/groups/element_impl.hpp
@@ -806,11 +806,7 @@ __attribute__((always_inline)) inline void batch_affine_add_interleaved(AffineEl
     const size_t k5_pair_groups = (CAN_USE_K5 && num_points >= K5_MIN_POINTS) ? ((num_points >> 1) / 5) : size_t{ 0 };
     const size_t k5_points = k5_pair_groups * 10;
 
-    Fq batch_inversion_accumulator = Fq::one();
-    // Populated by K=5 forward, consumed by K=5 backward prefix-product tree.
-    // Only meaningful when CAN_USE_K5; left uninitialized otherwise (the backward
-    // K=5 block is gated by the same constexpr predicate).
-    std::array<Fq, 5> acc_lanes;
+    std::array<Fq, 5> acc_lanes = { Fq::one(), Fq::one(), Fq::one(), Fq::one(), Fq::one() };
 
     // ---------------------------------------------------------------------
     // K=5 forward pass. Per group of 10 points, two 5-wide muls:
@@ -818,14 +814,14 @@ __attribute__((always_inline)) inline void batch_affine_add_interleaved(AffineEl
     //   acc_lane *= x_lane    (5-wide)
     // Each lane k threads its own independent batch-inversion chain through the groups.
     //
-    // acc_lanes_vec stays in packed (VFq) form across iterations — converting
-    // back to AoS each group would cost two AoS↔packed transposes per iter
-    // (one to write, one to re-read next iter). Collapsed to a single scalar
-    // Fq via one final to_array() + 4 muls once the loop exits.
+    // Note: tried keeping acc_lanes in packed VFq form across iterations
+    // (one to_array() at loop exit instead of per-group) to drop the
+    // apparent AoS↔packed round-trip — no measurable end-to-end
+    // improvement on V8/wasmtime. LLVM appears to SROA the round-trip
+    // already.
     // ---------------------------------------------------------------------
     if constexpr (CAN_USE_K5) {
         using VFq = VectorField<Bn254FqParams>;
-        VFq acc_lanes_vec = VFq::broadcast(Fq::one());
         std::array<Fq, 5> y_buf; // (y2 - y1) per lane in current group
         std::array<Fq, 5> x_buf; // (x2 - x1) per lane in current group
         for (size_t g = 0; g < k5_pair_groups; ++g) {
@@ -838,21 +834,21 @@ __attribute__((always_inline)) inline void batch_affine_add_interleaved(AffineEl
                 y_buf[k] = points[pi + 1].y;
                 x_buf[k] = points[pi + 1].x;
             }
-            std::array<Fq, 5> y_out = (VFq(y_buf) * acc_lanes_vec).to_array();
+            VFq vec_acc(acc_lanes);
+            std::array<Fq, 5> y_out = (VFq(y_buf) * vec_acc).to_array();
             for (size_t k = 0; k < 5; ++k) {
                 points[i + (2 * k) + 1].y = y_out[k];
             }
-            acc_lanes_vec = acc_lanes_vec * VFq(x_buf);
+            acc_lanes = (vec_acc * VFq(x_buf)).to_array();
         }
-        acc_lanes = acc_lanes_vec.to_array();
-        batch_inversion_accumulator = acc_lanes[0] * acc_lanes[1] * acc_lanes[2] * acc_lanes[3] * acc_lanes[4];
     }
 
     // ---------------------------------------------------------------------
-    // K=1 forward tail. When k5_points == 0 (CAN_USE_K5 false or batch too
-    // small), batch_inversion_accumulator stays at Fq::one() and this runs
-    // from i=0, recovering the original K=1 path exactly.
+    // Combine 5 lane accumulators into one and run the K=1 forward tail.
+    // When k5_points == 0 this collapses cleanly to the original K=1 forward
+    // pass (acc_lanes is all-ones, so the product is one).
     // ---------------------------------------------------------------------
+    Fq batch_inversion_accumulator = acc_lanes[0] * acc_lanes[1] * acc_lanes[2] * acc_lanes[3] * acc_lanes[4];
     for (size_t i = k5_points; i < num_points; i += 2) {
         scratch_space[i >> 1] = points[i].x + points[i + 1].x;
         points[i + 1].x -= points[i].x;

--- a/barretenberg/cpp/src/barretenberg/ecc/groups/element_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/groups/element_impl.hpp
@@ -1350,23 +1350,95 @@ std::vector<affine_element<Fq, Fr, T>> element<Fq, Fr, T>::batch_mul_with_endomo
     return work_elements;
 }
 
+/**
+ * @brief Convert N Jacobian points to affine form via Montgomery's batch-inversion trick.
+ *
+ * @details Forward pass: compute the prefix product of z-coordinates, storing the per-point
+ * prefix in `temporaries`. Invert the full product once. Backward pass: walk down recovering
+ * z_inv[i] = accumulator * temporaries[i], then update accumulator *= z[i]. Each non-infinity
+ * point pays 1 mul forward + (4 muls + 1 sqr) backward.
+ *
+ * Under WASM SIMD with the BN254 base field and no point at infinity present, runs a 5-wide
+ * q1s1 forward+backward pass (5 lane accumulators interleaving 5 independent batch-inversion
+ * chains via VectorField<Bn254FqParams>), plus a scalar K=1 tail for points not covered by a
+ * full 5-point group. Each group of 5 points collapses 30 scalar mul-class ops in backward to
+ * 6 width-5 vec muls (+12 amortized split-tree muls). If any point in `elements` is at
+ * infinity, falls through entirely to the K=1 path — masking lane k for an infinity slot in
+ * the middle of a chain would require per-lane filtering that is not worth the complexity at
+ * the hot caller (`scalar_multiplication.cpp` per-thread MSM output finalization, where
+ * infinity outputs are vanishingly rare).
+ */
 template <typename Fq, typename Fr, typename T>
 void element<Fq, Fr, T>::batch_normalize(element* elements, const size_t num_elements) noexcept
 {
+#if defined(__wasm_simd128__)
+    constexpr bool CAN_USE_K5_TYPE = std::is_same_v<Fq, bb::fq>;
+#else
+    constexpr bool CAN_USE_K5_TYPE = false;
+#endif
+    constexpr size_t K5_MIN_POINTS = 20;
+
+    // K=5 eligibility: WASM SIMD + BN254 Fq + size threshold + no infinity slot. The prescan
+    // is O(num_elements) with one branch per element; the savings over a full backward pass
+    // dwarf it on the typical large-N hot path.
+    bool any_infinity = false;
+    if constexpr (CAN_USE_K5_TYPE) {
+        if (num_elements >= K5_MIN_POINTS) {
+            for (size_t i = 0; i < num_elements; ++i) {
+                if (elements[i].is_point_at_infinity()) {
+                    any_infinity = true;
+                    break;
+                }
+            }
+        }
+    }
+    const size_t k5_groups =
+        (CAN_USE_K5_TYPE && num_elements >= K5_MIN_POINTS && !any_infinity) ? (num_elements / 5) : size_t{ 0 };
+    const size_t k5_points = k5_groups * 5;
+
     std::vector<Fq> temporaries;
-    temporaries.reserve(num_elements * 2);
+    temporaries.reserve(num_elements);
     Fq accumulator = Fq::one();
 
-    // Iterate over the points, computing the product of their z-coordinates.
-    // At each iteration, store the currently-accumulated z-coordinate in `temporaries`
-    for (size_t i = 0; i < num_elements; ++i) {
+    std::array<Fq, 5> acc_lanes = { Fq::one(), Fq::one(), Fq::one(), Fq::one(), Fq::one() };
+
+    // ---------------------------------------------------------------------
+    // K=5 forward pass. Per group of 5 points i = g*5 + k (k in [0,5)), lane k owns the
+    // batch-inversion chain that visits elements[g*5+k] across groups g = 0..k5_groups-1.
+    //
+    // Before updating, snapshot acc_lanes[k] into temporaries[g*5+k] — that is the prefix
+    // product seen by lane k's chain up to (but excluding) elements[g*5+k]. The backward
+    // pass uses this to recover 1/z[g*5+k] = inv_lane[k] * temporaries[g*5+k].
+    //
+    // Then advance all five lanes via one width-5 mul: acc_lanes *= z's of this group.
+    // ---------------------------------------------------------------------
+    if constexpr (CAN_USE_K5_TYPE) {
+        using VFq = VectorField<Bn254FqParams>;
+        for (size_t g = 0; g < k5_groups; ++g) {
+            const size_t i = g * 5;
+            for (size_t k = 0; k < 5; ++k) {
+                temporaries.emplace_back(acc_lanes[k]);
+            }
+            std::array<Fq, 5> z_buf;
+            for (size_t k = 0; k < 5; ++k) {
+                z_buf[k] = elements[i + k].z;
+            }
+            acc_lanes = (VFq(acc_lanes) * VFq(z_buf)).to_array();
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // Combine 5 lane accumulators into one global accumulator and run the K=1 forward tail.
+    // When k5_points == 0 (no K=5 eligibility) this is the full original forward pass —
+    // acc_lanes is all-ones, so the product is one and `accumulator` starts at Fq::one().
+    // ---------------------------------------------------------------------
+    accumulator = acc_lanes[0] * acc_lanes[1] * acc_lanes[2] * acc_lanes[3] * acc_lanes[4];
+    for (size_t i = k5_points; i < num_elements; ++i) {
         temporaries.emplace_back(accumulator);
         if (!elements[i].is_point_at_infinity()) {
             accumulator *= elements[i].z;
         }
     }
-    // For the rest of this method we refer to the product of all z-coordinates as the 'global' z-coordinate
-    // Invert the global z-coordinate and store in `accumulator`
     accumulator = accumulator.invert();
 
     /**
@@ -1391,7 +1463,15 @@ void element<Fq, Fr, T>::batch_normalize(element* elements, const size_t num_ele
      *
      * We can then convert out of Jacobian form (x = X / Z^2, y = Y / Z^3) with 4 muls and 1 square.
      **/
-    for (size_t i = num_elements - 1; i < num_elements; --i) {
+
+    // ---------------------------------------------------------------------
+    // K=1 backward tail. Walks down from num_elements to k5_points, unwinding the tail's
+    // contribution to `accumulator`. After this loop completes,
+    // accumulator = 1 / (product of acc_lanes) = 1 / (product of z's in the K=5 region).
+    // When k5_points == 0 this is the full original backward pass.
+    // ---------------------------------------------------------------------
+    for (size_t i = num_elements; i > k5_points;) {
+        --i;
         if (!elements[i].is_point_at_infinity()) {
             Fq z_inv = accumulator * temporaries[i];
             Fq zz_inv = z_inv.sqr();
@@ -1400,6 +1480,77 @@ void element<Fq, Fr, T>::batch_normalize(element* elements, const size_t num_ele
             accumulator *= elements[i].z;
         }
         elements[i].z = Fq::one();
+    }
+
+    // ---------------------------------------------------------------------
+    // K=5 backward pass. Split `accumulator` into 5 per-lane inverses via the standard
+    // batch-inversion product tree, then walk groups in reverse with 5-wide muls. Each group
+    // does 6 muls (vs (4 muls + 1 sqr)/point × 5 points = 25 scalar mul-class ops of K=1).
+    // ---------------------------------------------------------------------
+    if constexpr (CAN_USE_K5_TYPE) {
+        if (k5_groups == 0) {
+            return;
+        }
+        using VFq = VectorField<Bn254FqParams>;
+
+        // 4 prefix muls + 8 unwind muls = 12 muls + 1 inversion (already done) to recover 5 lane inverses.
+        std::array<Fq, 4> prefix;
+        prefix[0] = acc_lanes[0];
+        prefix[1] = prefix[0] * acc_lanes[1];
+        prefix[2] = prefix[1] * acc_lanes[2];
+        prefix[3] = prefix[2] * acc_lanes[3];
+        std::array<Fq, 5> inv_lanes;
+        Fq running_inv = accumulator;
+        inv_lanes[4] = running_inv * prefix[3];
+        running_inv *= acc_lanes[4];
+        inv_lanes[3] = running_inv * prefix[2];
+        running_inv *= acc_lanes[3];
+        inv_lanes[2] = running_inv * prefix[1];
+        running_inv *= acc_lanes[2];
+        inv_lanes[1] = running_inv * prefix[0];
+        running_inv *= acc_lanes[1];
+        inv_lanes[0] = running_inv;
+
+        for (size_t g_rev = k5_groups; g_rev > 0; --g_rev) {
+            const size_t g = g_rev - 1;
+            const size_t i = g * 5;
+
+            // No aliasing: lane k touches only elements[i + k]. Single gather is fine.
+            std::array<Fq, 5> z_buf;
+            std::array<Fq, 5> tmp_buf;
+            std::array<Fq, 5> x_buf;
+            std::array<Fq, 5> y_buf;
+            for (size_t k = 0; k < 5; ++k) {
+                z_buf[k] = elements[i + k].z;
+                tmp_buf[k] = temporaries[i + k];
+                x_buf[k] = elements[i + k].x;
+                y_buf[k] = elements[i + k].y;
+            }
+
+            // z_inv = inv_lanes * tmp_buf  (5-wide mul)
+            VFq vec_z_inv = VFq(inv_lanes) * VFq(tmp_buf);
+
+            // inv_lanes *= z_buf — unwinds inv for the previous group's lane k  (5-wide mul)
+            inv_lanes = (VFq(inv_lanes) * VFq(z_buf)).to_array();
+
+            // zz_inv = z_inv * z_inv  (5-wide sqr)
+            VFq vec_zz_inv = vec_z_inv * vec_z_inv;
+
+            // zzz_inv = zz_inv * z_inv  (5-wide mul)
+            std::array<Fq, 5> zzz_inv_buf = (vec_zz_inv * vec_z_inv).to_array();
+
+            // x *= zz_inv  (5-wide mul)
+            std::array<Fq, 5> new_x = (VFq(x_buf) * vec_zz_inv).to_array();
+
+            // y *= zzz_inv  (5-wide mul)
+            std::array<Fq, 5> new_y = (VFq(y_buf) * VFq(zzz_inv_buf)).to_array();
+
+            for (size_t k = 0; k < 5; ++k) {
+                elements[i + k].x = new_x[k];
+                elements[i + k].y = new_y[k];
+                elements[i + k].z = Fq::one();
+            }
+        }
     }
 }
 

--- a/barretenberg/cpp/src/barretenberg/ecc/groups/element_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/groups/element_impl.hpp
@@ -10,7 +10,6 @@
 #include "barretenberg/common/thread.hpp"
 #include "barretenberg/ecc/curves/bn254/fq.hpp"
 #include "barretenberg/ecc/fields/vector_field.hpp"
-#include "barretenberg/ecc/groups/element.hpp"
 #include "element.hpp"
 #include <array>
 #include <cstdint>
@@ -804,22 +803,31 @@ __attribute__((always_inline)) inline void batch_affine_add_interleaved(AffineEl
 #endif
     constexpr size_t K5_MIN_POINTS = 20;
 
-    const size_t k5_pair_groups =
-        (CAN_USE_K5 && num_points >= K5_MIN_POINTS) ? ((num_points >> 1) / 5) : size_t{ 0 };
+    const size_t k5_pair_groups = (CAN_USE_K5 && num_points >= K5_MIN_POINTS) ? ((num_points >> 1) / 5) : size_t{ 0 };
     const size_t k5_points = k5_pair_groups * 10;
 
-    std::array<Fq, 5> acc_lanes = { Fq::one(), Fq::one(), Fq::one(), Fq::one(), Fq::one() };
+    Fq batch_inversion_accumulator = Fq::one();
+    // Populated by K=5 forward, consumed by K=5 backward prefix-product tree.
+    // Only meaningful when CAN_USE_K5; left uninitialized otherwise (the backward
+    // K=5 block is gated by the same constexpr predicate).
+    std::array<Fq, 5> acc_lanes;
 
     // ---------------------------------------------------------------------
     // K=5 forward pass. Per group of 10 points, two 5-wide muls:
     //   y_lane *= acc_lane    (5-wide)
     //   acc_lane *= x_lane    (5-wide)
     // Each lane k threads its own independent batch-inversion chain through the groups.
+    //
+    // acc_lanes_vec stays in packed (VFq) form across iterations — converting
+    // back to AoS each group would cost two AoS↔packed transposes per iter
+    // (one to write, one to re-read next iter). Collapsed to a single scalar
+    // Fq via one final to_array() + 4 muls once the loop exits.
     // ---------------------------------------------------------------------
     if constexpr (CAN_USE_K5) {
         using VFq = VectorField<Bn254FqParams>;
-        std::array<Fq, 5> y_buf;
-        std::array<Fq, 5> x_buf;
+        VFq acc_lanes_vec = VFq::broadcast(Fq::one());
+        std::array<Fq, 5> y_buf; // (y2 - y1) per lane in current group
+        std::array<Fq, 5> x_buf; // (x2 - x1) per lane in current group
         for (size_t g = 0; g < k5_pair_groups; ++g) {
             const size_t i = g * 10;
             for (size_t k = 0; k < 5; ++k) {
@@ -830,21 +838,21 @@ __attribute__((always_inline)) inline void batch_affine_add_interleaved(AffineEl
                 y_buf[k] = points[pi + 1].y;
                 x_buf[k] = points[pi + 1].x;
             }
-            VFq vec_acc(acc_lanes);
-            std::array<Fq, 5> y_out = (VFq(y_buf) * vec_acc).to_array();
+            std::array<Fq, 5> y_out = (VFq(y_buf) * acc_lanes_vec).to_array();
             for (size_t k = 0; k < 5; ++k) {
                 points[i + (2 * k) + 1].y = y_out[k];
             }
-            acc_lanes = (vec_acc * VFq(x_buf)).to_array();
+            acc_lanes_vec = acc_lanes_vec * VFq(x_buf);
         }
+        acc_lanes = acc_lanes_vec.to_array();
+        batch_inversion_accumulator = acc_lanes[0] * acc_lanes[1] * acc_lanes[2] * acc_lanes[3] * acc_lanes[4];
     }
 
     // ---------------------------------------------------------------------
-    // Combine 5 lane accumulators into one and run the K=1 forward tail.
-    // When k5_points == 0 this collapses cleanly to the original K=1 forward
-    // pass (acc_lanes is all-ones, so the product is one).
+    // K=1 forward tail. When k5_points == 0 (CAN_USE_K5 false or batch too
+    // small), batch_inversion_accumulator stays at Fq::one() and this runs
+    // from i=0, recovering the original K=1 path exactly.
     // ---------------------------------------------------------------------
-    Fq batch_inversion_accumulator = acc_lanes[0] * acc_lanes[1] * acc_lanes[2] * acc_lanes[3] * acc_lanes[4];
     for (size_t i = k5_points; i < num_points; i += 2) {
         scratch_space[i >> 1] = points[i].x + points[i + 1].x;
         points[i + 1].x -= points[i].x;
@@ -924,10 +932,10 @@ __attribute__((always_inline)) inline void batch_affine_add_interleaved(AffineEl
             // with the input slot pi or pi+1 of a LATER lane in the same group when k5_points
             // exceeds num_points/2 (typical for large MSM bucket sizes). Without snapshotting,
             // a write at lane k_write clobbers a read at lane k_read > k_write, corrupting y3.
-            std::array<Fq, 5> y_buf;        // (y2 - y1) * acc_old per lane (stored at points[pi+1].y)
-            std::array<Fq, 5> x_buf;        // x2 - x1 per lane (stored at points[pi+1].x)
-            std::array<Fq, 5> x1_buf;       // original lhs x1 (points[pi].x)
-            std::array<Fq, 5> y1_buf;       // original lhs y1 (points[pi].y)
+            std::array<Fq, 5> y_buf;          // (y2 - y1) * acc_old per lane (stored at points[pi+1].y)
+            std::array<Fq, 5> x_buf;          // x2 - x1 per lane (stored at points[pi+1].x)
+            std::array<Fq, 5> x1_buf;         // original lhs x1 (points[pi].x)
+            std::array<Fq, 5> y1_buf;         // original lhs y1 (points[pi].y)
             std::array<Fq, 5> x1_plus_x2_buf; // x1 + x2 (saved in scratch by forward)
             for (size_t k = 0; k < 5; ++k) {
                 const size_t pi = i + (2 * k);

--- a/barretenberg/cpp/src/barretenberg/ecc/groups/element_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/groups/element_impl.hpp
@@ -988,16 +988,68 @@ __attribute__((always_inline)) inline void batch_affine_add_interleaved(AffineEl
  *
  * @note This is the "unsafe" fast path. For general point doubling with edge case handling,
  *       use Jacobian arithmetic or check for edge cases before calling this function.
+ *
+ * Under WASM SIMD with the BN254 base field, runs a 5-wide q1s1 forward+backward pass (5 lane
+ * accumulators interleaving 5 independent batch-inversion chains via VectorField<Bn254FqParams>),
+ * plus a scalar K=1 tail for points not covered by a full 5-point group. Below K5_MIN_POINTS or
+ * on non-WASM targets, degenerates to the original single-accumulator path.
  */
 template <typename AffineElement, typename Fq, typename T>
 __attribute__((always_inline)) inline void batch_affine_double_impl(AffineElement* points,
                                                                     const size_t num_points,
                                                                     Fq* scratch_space) noexcept
 {
-    Fq batch_inversion_accumulator = Fq::one();
+#if defined(__wasm_simd128__)
+    constexpr bool CAN_USE_K5 = std::is_same_v<Fq, bb::fq>;
+#else
+    constexpr bool CAN_USE_K5 = false;
+#endif
+    constexpr size_t K5_MIN_POINTS = 20;
 
-    // Forward pass: prepare batch inversion
-    for (size_t i = 0; i < num_points; ++i) {
+    const size_t k5_groups = (CAN_USE_K5 && num_points >= K5_MIN_POINTS) ? (num_points / 5) : size_t{ 0 };
+    const size_t k5_points = k5_groups * 5;
+
+    std::array<Fq, 5> acc_lanes = { Fq::one(), Fq::one(), Fq::one(), Fq::one(), Fq::one() };
+
+    // ---------------------------------------------------------------------
+    // K=5 forward pass. Per group of 5 points, three 5-wide muls:
+    //   x_sq    = x * x         (5-wide sqr)
+    //   scratch = (3*x_sq) * acc (5-wide mul; 3*x_sq via scalar adds)
+    //   acc    *= 2y            (5-wide mul)
+    // Each lane k threads its own independent batch-inversion chain through the groups.
+    // ---------------------------------------------------------------------
+    if constexpr (CAN_USE_K5) {
+        using VFq = VectorField<Bn254FqParams>;
+        std::array<Fq, 5> x_buf;
+        std::array<Fq, 5> two_y_buf;
+        std::array<Fq, 5> scratch_buf;
+        for (size_t g = 0; g < k5_groups; ++g) {
+            const size_t i = g * 5;
+            for (size_t k = 0; k < 5; ++k) {
+                x_buf[k] = points[i + k].x;
+                two_y_buf[k] = points[i + k].y + points[i + k].y;
+            }
+            VFq vec_x(x_buf);
+            std::array<Fq, 5> x_sq = (vec_x * vec_x).to_array();
+            for (size_t k = 0; k < 5; ++k) {
+                scratch_buf[k] = x_sq[k] + x_sq[k] + x_sq[k];
+            }
+            VFq vec_acc(acc_lanes);
+            std::array<Fq, 5> scratch_out = (VFq(scratch_buf) * vec_acc).to_array();
+            for (size_t k = 0; k < 5; ++k) {
+                scratch_space[i + k] = scratch_out[k];
+            }
+            acc_lanes = (vec_acc * VFq(two_y_buf)).to_array();
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // Combine 5 lane accumulators into one and run the K=1 forward tail.
+    // When k5_points == 0 this collapses cleanly to the original K=1 forward
+    // pass (acc_lanes is all-ones, so the product is one).
+    // ---------------------------------------------------------------------
+    Fq batch_inversion_accumulator = acc_lanes[0] * acc_lanes[1] * acc_lanes[2] * acc_lanes[3] * acc_lanes[4];
+    for (size_t i = k5_points; i < num_points; ++i) {
         scratch_space[i] = points[i].x.sqr();
         if constexpr (T::has_a) {
             scratch_space[i] += T::a; // adjust slope in numerator
@@ -1012,9 +1064,13 @@ __attribute__((always_inline)) inline void batch_affine_double_impl(AffineElemen
     }
     batch_inversion_accumulator = batch_inversion_accumulator.invert();
 
-    // Backward pass: compute doublings
+    // ---------------------------------------------------------------------
+    // K=1 backward tail. Walks down from num_points to k5_points, unwinding
+    // the tail's contribution to batch_inversion_accumulator. After this
+    // loop completes, batch_inversion_accumulator = 1 / (prod of acc_lanes).
+    // ---------------------------------------------------------------------
     Fq temp_x;
-    for (size_t i_plus_1 = num_points; i_plus_1 > 0; --i_plus_1) {
+    for (size_t i_plus_1 = num_points; i_plus_1 > k5_points; --i_plus_1) {
         size_t i = i_plus_1 - 1;
 
         scratch_space[i] *= batch_inversion_accumulator;
@@ -1023,6 +1079,80 @@ __attribute__((always_inline)) inline void batch_affine_double_impl(AffineElemen
         temp_x = points[i].x;
         points[i].x = scratch_space[i].sqr() - (points[i].x + points[i].x);
         points[i].y = scratch_space[i] * (temp_x - points[i].x) - points[i].y;
+    }
+
+    // ---------------------------------------------------------------------
+    // K=5 backward pass. Split batch_inversion_accumulator into 5 per-lane
+    // inverses via the standard batch-inversion product tree, then walk
+    // groups in reverse order with 5-wide muls. Each group does 4 muls (vs
+    // the (3 muls + 1 sqr)/point × 5 points = 20 scalar mul-class ops of K=1).
+    // ---------------------------------------------------------------------
+    if constexpr (CAN_USE_K5) {
+        if (k5_groups == 0) {
+            return;
+        }
+        using VFq = VectorField<Bn254FqParams>;
+
+        // 4 prefix muls + 8 unwind muls = 12 muls + 1 inversion (already done) to recover 5 lane inverses.
+        std::array<Fq, 4> prefix;
+        prefix[0] = acc_lanes[0];
+        prefix[1] = prefix[0] * acc_lanes[1];
+        prefix[2] = prefix[1] * acc_lanes[2];
+        prefix[3] = prefix[2] * acc_lanes[3];
+        std::array<Fq, 5> inv_lanes;
+        Fq running_inv = batch_inversion_accumulator;
+        inv_lanes[4] = running_inv * prefix[3];
+        running_inv *= acc_lanes[4];
+        inv_lanes[3] = running_inv * prefix[2];
+        running_inv *= acc_lanes[3];
+        inv_lanes[2] = running_inv * prefix[1];
+        running_inv *= acc_lanes[2];
+        inv_lanes[1] = running_inv * prefix[0];
+        running_inv *= acc_lanes[1];
+        inv_lanes[0] = running_inv;
+
+        for (size_t g_rev = k5_groups; g_rev > 0; --g_rev) {
+            const size_t g = g_rev - 1;
+            const size_t i = g * 5;
+
+            // No aliasing concerns (each lane k has its own points[i + k]); single gather is fine.
+            std::array<Fq, 5> scratch_buf;
+            std::array<Fq, 5> x_buf;
+            std::array<Fq, 5> y_buf;
+            std::array<Fq, 5> two_y_buf;
+            for (size_t k = 0; k < 5; ++k) {
+                scratch_buf[k] = scratch_space[i + k];
+                x_buf[k] = points[i + k].x;
+                y_buf[k] = points[i + k].y;
+                two_y_buf[k] = y_buf[k] + y_buf[k];
+            }
+
+            // lambda = scratch * inv_lanes  (5-wide mul)
+            std::array<Fq, 5> lambda_buf = (VFq(scratch_buf) * VFq(inv_lanes)).to_array();
+
+            // inv_lanes *= 2y_buf — unwinds inv for the previous group's lane k  (5-wide mul)
+            inv_lanes = (VFq(inv_lanes) * VFq(two_y_buf)).to_array();
+
+            // lambda_sq = lambda * lambda  (5-wide sqr)
+            VFq vec_lambda(lambda_buf);
+            std::array<Fq, 5> lambda_sq = (vec_lambda * vec_lambda).to_array();
+
+            // new_x = lambda^2 - 2x; temp = x - new_x (scalar prep)
+            std::array<Fq, 5> new_x_buf;
+            std::array<Fq, 5> x_minus_new_x_buf;
+            for (size_t k = 0; k < 5; ++k) {
+                new_x_buf[k] = lambda_sq[k] - (x_buf[k] + x_buf[k]);
+                x_minus_new_x_buf[k] = x_buf[k] - new_x_buf[k];
+            }
+
+            // ly = lambda * (x - new_x)  (5-wide mul)
+            std::array<Fq, 5> ly = (vec_lambda * VFq(x_minus_new_x_buf)).to_array();
+
+            for (size_t k = 0; k < 5; ++k) {
+                points[i + k].x = new_x_buf[k];
+                points[i + k].y = ly[k] - y_buf[k];
+            }
+        }
     }
 }
 

--- a/barretenberg/cpp/src/barretenberg/ecc/groups/element_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/groups/element_impl.hpp
@@ -813,8 +813,9 @@ __attribute__((always_inline)) inline void batch_affine_add_interleaved(AffineEl
     //   acc_lane *= x_lane    (5-wide)
     // Each lane k threads its own independent batch-inversion chain through the groups.
     //
-    // acc_lanes_vec stays in packed (VFq) form across iterations — converting back to AoS
-    // each group costs two AoS↔packed transposes per iter (one to write, one to re-read
+    // `acc_lanes_vec` stays in packed (VFq) form across iterations — round-tripping
+    // through AoS each group costs two transposes per iter (one to write, one to
+    // re-read), and BrowserStack-ARM measurement showed the hoist is a real win.
     // Collapse to a single scalar Fq via one final to_array() + 4 muls once the loop exits.
     // ---------------------------------------------------------------------
     if constexpr (CAN_USE_K5) {
@@ -893,9 +894,9 @@ __attribute__((always_inline)) inline void batch_affine_add_interleaved(AffineEl
     // groups in reverse order with 5-wide muls. Each group does 4 muls (vs
     // the 4 muls/pair × 5 pairs = 20 scalar muls of K=1).
     //
-    // The per-lane inverse stays packed (`inv_state`) across the reverse
-    // loop for the same reason the forward `acc_lanes_vec` does
-    // Only lambda is materialized to AoS each group because the subsequent x3 = lambda^2 − (x1+x2) and y3 = lambda·(…)
+    // `inv_state` stays packed across the reverse loop for the same reason
+    // the forward `acc_lanes_vec` does. Lambda is materialized to AoS each
+    // group because the subsequent x3 = lambda^2 − (x1+x2) and y3 = lambda·(…)
     // − y1 steps mix scalar arithmetic with the packed multiplies.
     // ---------------------------------------------------------------------
     if constexpr (CAN_USE_K5) {
@@ -996,7 +997,9 @@ __attribute__((always_inline)) inline void batch_affine_double_impl(AffineElemen
         (CAN_USE_K5 && num_points >= k5_msm::K5_MIN_POINTS_DOUBLE) ? (num_points / 5) : size_t{ 0 };
     const size_t k5_points = k5_groups * 5;
 
-    std::array<Fq, 5> acc_lanes = { Fq::one(), Fq::one(), Fq::one(), Fq::one(), Fq::one() };
+    // Populated by K=5 forward (from packed acc_lanes_vec at loop exit) and consumed by
+    // the K=5 backward prefix-product tree. Left uninitialized when CAN_USE_K5 is false.
+    std::array<Fq, 5> acc_lanes;
 
     // ---------------------------------------------------------------------
     // K=5 forward pass. Per group of 5 points, three 5-wide muls:
@@ -1004,9 +1007,15 @@ __attribute__((always_inline)) inline void batch_affine_double_impl(AffineElemen
     //   scratch = (3*x_sq) * acc (5-wide mul; 3*x_sq via scalar adds)
     //   acc    *= 2y            (5-wide mul)
     // Each lane k threads its own independent batch-inversion chain through the groups.
+    //
+    // `acc_lanes_vec` stays packed across iterations — same hoist as
+    // batch_affine_add_interleaved's forward pass; drops one AoS↔packed round-trip
+    // per group. Materialize to AoS once at loop exit.
     // ---------------------------------------------------------------------
+    Fq batch_inversion_accumulator;
     if constexpr (CAN_USE_K5) {
         using VFq = VectorField<Bn254FqParams>;
+        VFq acc_lanes_vec = VFq::broadcast(Fq::one());
         std::array<Fq, 5> x_buf;
         std::array<Fq, 5> two_y_buf;
         std::array<Fq, 5> scratch_buf;
@@ -1021,21 +1030,25 @@ __attribute__((always_inline)) inline void batch_affine_double_impl(AffineElemen
             for (size_t k = 0; k < 5; ++k) {
                 scratch_buf[k] = x_sq[k] + x_sq[k] + x_sq[k];
             }
-            VFq vec_acc(acc_lanes);
-            std::array<Fq, 5> scratch_out = (VFq(scratch_buf) * vec_acc).to_array();
+            std::array<Fq, 5> scratch_out = (VFq(scratch_buf) * acc_lanes_vec).to_array();
             for (size_t k = 0; k < 5; ++k) {
                 scratch_space[i + k] = scratch_out[k];
             }
-            acc_lanes = (vec_acc * VFq(two_y_buf)).to_array();
+            acc_lanes_vec = acc_lanes_vec * VFq(two_y_buf);
         }
+        acc_lanes = acc_lanes_vec.to_array();
+        batch_inversion_accumulator = acc_lanes[0] * acc_lanes[1] * acc_lanes[2] * acc_lanes[3] * acc_lanes[4];
+    } else {
+        // No K=5 path — acc_lanes stays unused, batch_inversion_accumulator starts at one
+        // so the K=1 forward tail below recovers the original single-accumulator path.
+        batch_inversion_accumulator = Fq::one();
     }
 
     // ---------------------------------------------------------------------
-    // Combine 5 lane accumulators into one and run the K=1 forward tail.
-    // When k5_points == 0 this collapses cleanly to the original K=1 forward
-    // pass (acc_lanes is all-ones, so the product is one).
+    // K=1 forward tail. batch_inversion_accumulator already holds the product of the
+    // 5 lane accumulators (or Fq::one() when CAN_USE_K5 is false, recovering the
+    // original K=1 forward pass).
     // ---------------------------------------------------------------------
-    Fq batch_inversion_accumulator = acc_lanes[0] * acc_lanes[1] * acc_lanes[2] * acc_lanes[3] * acc_lanes[4];
     for (size_t i = k5_points; i < num_points; ++i) {
         scratch_space[i] = points[i].x.sqr();
         if constexpr (T::has_a) {
@@ -1073,6 +1086,10 @@ __attribute__((always_inline)) inline void batch_affine_double_impl(AffineElemen
     // inverses via the standard batch-inversion product tree, then walk
     // groups in reverse order with 5-wide muls. Each group does 4 muls (vs
     // the (3 muls + 1 sqr)/point × 5 points = 20 scalar mul-class ops of K=1).
+    //
+    // `inv_state` stays packed across the reverse loop; lambda materializes
+    // to AoS each group because the subsequent scalar new_x / x_minus_new_x
+    // prep mixes scalar arithmetic with the packed multiplies.
     // ---------------------------------------------------------------------
     if constexpr (CAN_USE_K5) {
         if (k5_groups == 0) {
@@ -1080,7 +1097,8 @@ __attribute__((always_inline)) inline void batch_affine_double_impl(AffineElemen
         }
         using VFq = VectorField<Bn254FqParams>;
 
-        std::array<Fq, 5> inv_lanes = k5_msm::compute_lane_inverses(acc_lanes, batch_inversion_accumulator);
+        std::array<Fq, 5> inv_lanes_init = k5_msm::compute_lane_inverses(acc_lanes, batch_inversion_accumulator);
+        VFq inv_state(inv_lanes_init);
 
         for (size_t g_rev = k5_groups; g_rev > 0; --g_rev) {
             const size_t g = g_rev - 1;
@@ -1098,11 +1116,12 @@ __attribute__((always_inline)) inline void batch_affine_double_impl(AffineElemen
                 two_y_buf[k] = y_buf[k] + y_buf[k];
             }
 
-            // lambda = scratch * inv_lanes  (5-wide mul)
-            std::array<Fq, 5> lambda_buf = (VFq(scratch_buf) * VFq(inv_lanes)).to_array();
+            // lambda = scratch * inv_state  (5-wide mul); materialize for the
+            // scalar prep that follows.
+            std::array<Fq, 5> lambda_buf = (VFq(scratch_buf) * inv_state).to_array();
 
-            // inv_lanes *= 2y_buf — unwinds inv for the previous group's lane k  (5-wide mul)
-            inv_lanes = (VFq(inv_lanes) * VFq(two_y_buf)).to_array();
+            // inv_state *= 2y_buf — unwinds inv for the previous group's lane k. Stays packed.
+            inv_state = inv_state * VFq(two_y_buf);
 
             // lambda_sq = lambda * lambda  (5-wide sqr)
             VFq vec_lambda(lambda_buf);
@@ -1344,62 +1363,75 @@ void element<Fq, Fr, T>::batch_normalize(element* elements, const size_t num_ele
 {
     constexpr bool CAN_USE_K5 = k5_msm::simd_supported_v<Fq>;
 
-    // K=5 eligibility: SIMD-supported Fq + size threshold + no infinity slot. The prescan
-    // is O(num_elements) with one branch per element; the savings over a full backward pass
-    // dwarf it on the typical large-N hot path.
-    bool any_infinity = false;
-    if constexpr (CAN_USE_K5) {
-        if (num_elements >= k5_msm::K5_MIN_POINTS_NORMALIZE) {
-            for (size_t i = 0; i < num_elements; ++i) {
-                if (elements[i].is_point_at_infinity()) {
-                    any_infinity = true;
-                    break;
-                }
-            }
-        }
-    }
-    const size_t k5_groups = (CAN_USE_K5 && num_elements >= k5_msm::K5_MIN_POINTS_NORMALIZE && !any_infinity)
-                                 ? (num_elements / 5)
-                                 : size_t{ 0 };
-    const size_t k5_points = k5_groups * 5;
-
     std::vector<Fq> temporaries;
     temporaries.reserve(num_elements);
     Fq accumulator = Fq::one();
 
-    std::array<Fq, 5> acc_lanes = { Fq::one(), Fq::one(), Fq::one(), Fq::one(), Fq::one() };
+    // Populated by K=5 forward (from packed acc_lanes_vec at loop exit) and consumed by
+    // the K=5 backward prefix-product tree.
+    std::array<Fq, 5> acc_lanes{};
 
     // ---------------------------------------------------------------------
     // K=5 forward pass. Per group of 5 points i = g*5 + k (k in [0,5)), lane k owns the
     // batch-inversion chain that visits elements[g*5+k] across groups g = 0..k5_groups-1.
     //
+    // Infinity check is interleaved per-group rather than as an upfront O(N) scan:
+    // checking is_point_at_infinity() touches the same elements we're about to read z
+    // from, so the cache lines for x (which the prescan would read) are NOT loaded for
+    // free — a separate prescan evicts x lines that the backward pass needs again later.
+    // If infinity is hit, we keep whatever K=5 groups completed and fall through to K=1
+    // for the rest of the batch (instead of bailing out entirely).
+    //
     // Before updating, snapshot acc_lanes[k] into temporaries[g*5+k] — that is the prefix
     // product seen by lane k's chain up to (but excluding) elements[g*5+k]. The backward
     // pass uses this to recover 1/z[g*5+k] = inv_lane[k] * temporaries[g*5+k].
     //
-    // Then advance all five lanes via one width-5 mul: acc_lanes *= z's of this group.
+    // `acc_lanes_vec` stays in packed VFq form across iterations (same hoist as
+    // batch_affine_add_interleaved); collapse to AoS once at loop exit.
     // ---------------------------------------------------------------------
+    size_t k5_groups = 0;
     if constexpr (CAN_USE_K5) {
-        using VFq = VectorField<Bn254FqParams>;
-        for (size_t g = 0; g < k5_groups; ++g) {
-            const size_t i = g * 5;
-            for (size_t k = 0; k < 5; ++k) {
-                temporaries.emplace_back(acc_lanes[k]);
+        if (num_elements >= k5_msm::K5_MIN_POINTS_NORMALIZE) {
+            using VFq = VectorField<Bn254FqParams>;
+            VFq acc_lanes_vec = VFq::broadcast(Fq::one());
+            const size_t k5_groups_max = num_elements / 5;
+            for (size_t g = 0; g < k5_groups_max; ++g) {
+                const size_t i = g * 5;
+                bool group_has_infinity = false;
+                for (size_t k = 0; k < 5; ++k) {
+                    if (elements[i + k].is_point_at_infinity()) {
+                        group_has_infinity = true;
+                        break;
+                    }
+                }
+                if (group_has_infinity) {
+                    break;
+                }
+                std::array<Fq, 5> acc_snapshot = acc_lanes_vec.to_array();
+                for (size_t k = 0; k < 5; ++k) {
+                    temporaries.emplace_back(acc_snapshot[k]);
+                }
+                std::array<Fq, 5> z_buf;
+                for (size_t k = 0; k < 5; ++k) {
+                    z_buf[k] = elements[i + k].z;
+                }
+                acc_lanes_vec = acc_lanes_vec * VFq(z_buf);
+                ++k5_groups;
             }
-            std::array<Fq, 5> z_buf;
-            for (size_t k = 0; k < 5; ++k) {
-                z_buf[k] = elements[i + k].z;
-            }
-            acc_lanes = (VFq(acc_lanes) * VFq(z_buf)).to_array();
+            acc_lanes = acc_lanes_vec.to_array();
         }
     }
+    const size_t k5_points = k5_groups * 5;
 
     // ---------------------------------------------------------------------
     // Combine 5 lane accumulators into one global accumulator and run the K=1 forward tail.
-    // When k5_points == 0 (no K=5 eligibility) this is the full original forward pass —
-    // acc_lanes is all-ones, so the product is one and `accumulator` starts at Fq::one().
+    // When k5_points == 0 (no K=5 eligibility, or infinity at group 0) this is the full
+    // original forward pass — acc_lanes is all-ones (initialized via Fq{}/VFq::broadcast
+    // or never touched), so the product is one and `accumulator` starts at Fq::one().
     // ---------------------------------------------------------------------
-    accumulator = acc_lanes[0] * acc_lanes[1] * acc_lanes[2] * acc_lanes[3] * acc_lanes[4];
+    if (k5_groups > 0) {
+        accumulator = acc_lanes[0] * acc_lanes[1] * acc_lanes[2] * acc_lanes[3] * acc_lanes[4];
+    }
     for (size_t i = k5_points; i < num_elements; ++i) {
         temporaries.emplace_back(accumulator);
         if (!elements[i].is_point_at_infinity()) {
@@ -1453,6 +1485,9 @@ void element<Fq, Fr, T>::batch_normalize(element* elements, const size_t num_ele
     // K=5 backward pass. Split `accumulator` into 5 per-lane inverses via the standard
     // batch-inversion product tree, then walk groups in reverse with 5-wide muls. Each group
     // does 6 muls (vs (4 muls + 1 sqr)/point × 5 points = 25 scalar mul-class ops of K=1).
+    //
+    // `inv_state` stays packed across the reverse loop; only z_inv materializes to AoS for
+    // the scalar zz_inv/zzz_inv prep.
     // ---------------------------------------------------------------------
     if constexpr (CAN_USE_K5) {
         if (k5_groups == 0) {
@@ -1460,7 +1495,8 @@ void element<Fq, Fr, T>::batch_normalize(element* elements, const size_t num_ele
         }
         using VFq = VectorField<Bn254FqParams>;
 
-        std::array<Fq, 5> inv_lanes = k5_msm::compute_lane_inverses(acc_lanes, accumulator);
+        std::array<Fq, 5> inv_lanes_init = k5_msm::compute_lane_inverses(acc_lanes, accumulator);
+        VFq inv_state(inv_lanes_init);
 
         for (size_t g_rev = k5_groups; g_rev > 0; --g_rev) {
             const size_t g = g_rev - 1;
@@ -1478,11 +1514,11 @@ void element<Fq, Fr, T>::batch_normalize(element* elements, const size_t num_ele
                 y_buf[k] = elements[i + k].y;
             }
 
-            // z_inv = inv_lanes * tmp_buf  (5-wide mul)
-            VFq vec_z_inv = VFq(inv_lanes) * VFq(tmp_buf);
+            // z_inv = inv_state * tmp_buf  (5-wide mul)
+            VFq vec_z_inv = inv_state * VFq(tmp_buf);
 
-            // inv_lanes *= z_buf — unwinds inv for the previous group's lane k  (5-wide mul)
-            inv_lanes = (VFq(inv_lanes) * VFq(z_buf)).to_array();
+            // inv_state *= z_buf — unwinds inv for the previous group's lane k. Stays packed.
+            inv_state = inv_state * VFq(z_buf);
 
             // zz_inv = z_inv * z_inv  (5-wide sqr)
             VFq vec_zz_inv = vec_z_inv * vec_z_inv;

--- a/barretenberg/cpp/src/barretenberg/ecc/groups/k5_msm_helpers.hpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/groups/k5_msm_helpers.hpp
@@ -1,0 +1,65 @@
+// === AUDIT STATUS ===
+// internal:    { status: Planned, auditors: [], commit: }
+// external_1:  { status: not started, auditors: [], commit: }
+// external_2:  { status: not started, auditors: [], commit: }
+// =====================
+
+#pragma once
+
+// Shared helpers for the K=5 q1s1 WASM-SIMD path in the three batch-inversion kernels
+// (batch_affine_add_interleaved, batch_affine_double_impl, batch_normalize). Extracted so
+// the dispatch condition, the threshold constant, and the inverse-split tree live in one
+// place instead of being open-coded three times in element_impl.hpp.
+
+#include "barretenberg/ecc/curves/bn254/fq.hpp"
+#include <array>
+#include <type_traits>
+
+namespace bb::group_elements::k5_msm {
+
+// Number of points below which the K=5 dispatch overhead (gather/scatter, split-tree
+// inversion, lane packing) exceeds the per-mul savings — fall through to the scalar K=1
+// path in that regime. Shared across all three kernels so they don't drift.
+inline constexpr size_t K5_MIN_POINTS = 20;
+
+// SIMD eligibility for the K=5 path. Currently only the BN254 base field has a
+// VectorField operator* specialization; other Fq types (e.g. Grumpkin) route through the
+// K=1 path. When another field gets a VectorField specialization, add it here and the
+// three kernels in element_impl.hpp pick it up without further edits.
+template <typename Fq>
+inline constexpr bool simd_supported_v =
+#if defined(__wasm_simd128__)
+    std::is_same_v<Fq, bb::fq>;
+#else
+    false;
+#endif
+
+// Recover 5 lane inverses from the inverse of their product, via the standard prefix +
+// reverse-unwind tree. 4 prefix muls + 8 unwind muls = 12 muls (the single inversion is
+// the caller's responsibility — `running_inv` is passed in already inverted).
+//
+// Given:   acc_lanes[k] = product of lane k's contributions across the K=5 forward pass
+//          running_inv  = 1 / (acc_lanes[0] * acc_lanes[1] * ... * acc_lanes[4])
+// Returns: inv_lanes[k] = 1 / acc_lanes[k]
+template <typename Fq>
+inline std::array<Fq, 5> compute_lane_inverses(const std::array<Fq, 5>& acc_lanes, Fq running_inv) noexcept
+{
+    std::array<Fq, 4> prefix;
+    prefix[0] = acc_lanes[0];
+    prefix[1] = prefix[0] * acc_lanes[1];
+    prefix[2] = prefix[1] * acc_lanes[2];
+    prefix[3] = prefix[2] * acc_lanes[3];
+    std::array<Fq, 5> inv_lanes;
+    inv_lanes[4] = running_inv * prefix[3];
+    running_inv *= acc_lanes[4];
+    inv_lanes[3] = running_inv * prefix[2];
+    running_inv *= acc_lanes[3];
+    inv_lanes[2] = running_inv * prefix[1];
+    running_inv *= acc_lanes[2];
+    inv_lanes[1] = running_inv * prefix[0];
+    running_inv *= acc_lanes[1];
+    inv_lanes[0] = running_inv;
+    return inv_lanes;
+}
+
+} // namespace bb::group_elements::k5_msm

--- a/barretenberg/cpp/src/barretenberg/ecc/groups/k5_msm_helpers.hpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/groups/k5_msm_helpers.hpp
@@ -19,8 +19,14 @@ namespace bb::group_elements::k5_msm {
 
 // Number of points below which the K=5 dispatch overhead (gather/scatter, split-tree
 // inversion, lane packing) exceeds the per-mul savings — fall through to the scalar K=1
-// path in that regime. Shared across all three kernels so they don't drift.
-inline constexpr size_t K5_MIN_POINTS = 20;
+// path in that regime. Per-kernel because the kernels do not all break even at the same
+// size: the add kernel wins from ~20 points up (BrowserStack histogram shows 99%+ of add
+// work lands in 1024+ batches anyway), but double and batch_normalize regress on small
+// batches and only pull ahead once the per-mul saving amortizes the dispatch cost — set
+// their floor much higher.
+inline constexpr size_t K5_MIN_POINTS_ADD = 20;
+inline constexpr size_t K5_MIN_POINTS_DOUBLE = 256;
+inline constexpr size_t K5_MIN_POINTS_NORMALIZE = 256;
 
 // SIMD eligibility for the K=5 path. Currently only the BN254 base field has a
 // VectorField operator* specialization; other Fq types (e.g. Grumpkin) route through the


### PR DESCRIPTION
Stacked on #23210.

## What's in this PR

**(1) Fq Mont-mul specialization.** The Mont-mul body extracted into [vector_field_mont_mul_body.inl.hpp](barretenberg/cpp/src/barretenberg/ecc/fields/vector_field_mont_mul_body.inl.hpp); separate explicit specializations for `Bn254FrParams` and `Bn254FqParams`, each its own TU function so V8 reproduces the gist's hand-scheduled register layout per Params. `Bn254FqParams` registered against #23202's `has_simd_mont_mul` marker trait — `vectorized_for` automatically routes Fq through the SIMD path.

**(2) K=5 lane-parallel batch-inversion** via the new Fq specialization:

| Kernel | Per group of 5 | Threshold | Hot-loop caller |
|---|---|---|---|
| `batch_affine_add_interleaved` | 30 → 6 vec muls (fwd+bwd) | 20 | Pippenger bucket accumulation — ~50% of single-thread V8/WASM Chonk proving time |
| `batch_affine_double_impl` | 35 → 7 vec muls (fwd+bwd) | 256 | `batch_mul_with_endomorphism` doublings; Pippenger lookup-table build |
| `batch_normalize` | 5→1 fwd, 30→6 bwd vec muls | 256 | Per-thread MSM finalization; ECCVM accumulator / MSM / transcript trace finalization |

Each scalar batch-inversion chain becomes 5 independent lane-parallel chains, joined by a 12-mul split-tree at the inversion boundary. K=1 fallback preserved unchanged for non-WASM, non-BN254 Fq, or below-threshold sizes. Trait, thresholds, and `compute_lane_inverses` helper all live in [k5_msm_helpers.hpp](barretenberg/cpp/src/barretenberg/ecc/groups/k5_msm_helpers.hpp).

**(3) Per-kernel thresholds.** Add wins from ~20 points up (BrowserStack histograms show ~99% of add work lands in 1024+ batches anyway); double and normalize regress on small batches and only pull ahead once the per-mul saving amortizes the gather/scatter + split-tree dispatch cost. Hence `K5_MIN_POINTS_ADD = 20`, `K5_MIN_POINTS_DOUBLE = 256`, `K5_MIN_POINTS_NORMALIZE = 256`.

**(4) Packed lane state across iterations** on all three kernels. Both `acc_lanes_vec` (forward) and `inv_state` (backward) stay in packed `VFq` form across the per-group loop — one pack at entry, one unpack at exit per pass. Drops 2–3 packs + 2 unpacks per group (the 5×9 AoS↔9×29 transpose). An earlier forward-only attempt was reverted as "didn't move e2e" under wasmtime + x86 Node V8 — turned out to be a false negative; on real-browser V8 (ARM and mobile via BrowserStack) it's a consistent kernel-level win.

**(5) Cache-friendly infinity prescan in `batch_normalize`.** Previously an upfront O(N) scan reading each element's x — those cache lines get evicted before the backward pass needs them again. Now the per-group infinity check is interleaved with the K=5 forward step (each element visited once). If infinity hits mid-batch, `k5_points` stops there and K=1 picks up the rest (vs. old behaviour: bail K=5 entirely on any infinity).

## Non-trivial example: `batch_normalize` forward pass

The shape that consumes all four pieces above (Fq Mont-mul, K=5 chains, packed lane state, interleaved infinity check):

```cpp
using VFq = VectorField<Bn254FqParams>;
VFq acc_lanes_vec = VFq::broadcast(Fq::one());
for (size_t g = 0; g < k5_groups_max; ++g) {
    const size_t i = g * 5;
    bool group_has_infinity = false;
    for (size_t k = 0; k < 5; ++k) {
        if (elements[i + k].is_point_at_infinity()) { group_has_infinity = true; break; }
    }
    if (group_has_infinity) { break; }            // ← partial fallback, K=1 picks up the rest

    std::array<Fq, 5> acc_snapshot = acc_lanes_vec.to_array();
    for (size_t k = 0; k < 5; ++k) {
        temporaries.emplace_back(acc_snapshot[k]);
    }
    std::array<Fq, 5> z_buf;
    for (size_t k = 0; k < 5; ++k) {
        z_buf[k] = elements[i + k].z;
    }
    acc_lanes_vec = acc_lanes_vec * VFq(z_buf);   // ← one width-5 Fq Mont-mul replaces 5 scalar
    ++k5_groups;
}
acc_lanes = acc_lanes_vec.to_array();
```

Lane k in `acc_lanes_vec` owns the batch-inversion chain that visits `elements[g*5 + k]` across groups. `acc_lanes_vec * VFq(z_buf)` is the K=5 forward step — one Fq Mont-mul of width 5 replaces what was 5 separate scalar Mont-muls in the original code. The `acc_lanes_vec` stays packed across the loop; the AoS↔9×29 transpose runs once at exit, not per iteration.

For `batch_affine_add_interleaved` (interleaved memory layout), the backward pass additionally snapshots all reads before any writes — a lane's output slot can alias a later lane's input slot in the same group. The other two kernels have non-interleaved layout; no aliasing.

## Why

V8 Chonk breakdown puts MSM at ~50% of WASM proving time, with Pippenger bucket accumulation as its workhorse. Artem's #23004 hits the same surface at width-2 via paired-fp51 Mont-mul; per the Slack microbench discussion, q1s1 (5-wide) wins per-mul by ~50% over fp51 at width ≥ 4. Cross-engine deterministic (integer SIMD, not relaxed-SIMD) — no Edge / Safari class of bugs.

Marking draft until end-to-end Chonk measurement lands.

## Tests (WASM under wasmtime — K=5 only exercises under `__wasm_simd128__`)

- `BatchMulMatchesNonBatchMul` (512 points → both add_interleaved and double_impl)
- `BatchAffineAddImplBoundary` / `BatchAffineDoubleImplBoundary` / `BatchAffineAddInterleavedBoundary` — N at the K=5 thresholds (20/21/29 and 255/256/257/260/269)
- `BatchAffineAddInterleavedAliasing` — num_pairs ∈ {10..13}, direct exercise of snapshot-before-write
- `BatchNormalizeBoundary` — N spanning K=1 fallback and K=5 path at the 256 floor
- `BatchNormalizeDensityMix` — 75%/25% non-infinity densities + head/tail/mid-K5 single-infinity edges across N=260/333/512
- `BatchMultiScalarMul` — per-thread MSM finalization → `batch_normalize`
- 18 new `VectorFieldFqTest` cases — Fq mirror of PR1's Fr coverage

## Stack

#23202 → #23209 → #23210 → **this PR**