### PR TITLE
fix(p2p): validate BLOCK_TXS in BatchTxRequester

### DIFF
--- a/yarn-project/p2p/src/client/interface.ts
+++ b/yarn-project/p2p/src/client/interface.ts
@@ -9,11 +9,7 @@ import type { ENR } from '@nethermindeth/enr';
 
 import type { P2PConfig } from '../config.js';
 import type { AuthRequest, StatusMessage } from '../services/index.js';
-import type {
-  ReqRespSubProtocol,
-  ReqRespSubProtocolHandler,
-  ReqRespSubProtocolValidators,
-} from '../services/reqresp/interface.js';
+import type { ReqRespSubProtocol, ReqRespSubProtocolHandler } from '../services/reqresp/interface.js';
 import type {
   DuplicateAttestationInfo,
   DuplicateProposalInfo,
@@ -228,11 +224,7 @@ export type P2P = P2PClient & {
   /** Clears the db. */
   clear(): Promise<void>;
 
-  addReqRespSubProtocol(
-    subProtocol: ReqRespSubProtocol,
-    handler: ReqRespSubProtocolHandler,
-    validator?: ReqRespSubProtocolValidators[ReqRespSubProtocol],
-  ): Promise<void>;
+  addReqRespSubProtocol(subProtocol: ReqRespSubProtocol, handler: ReqRespSubProtocolHandler): Promise<void>;
 
   handleAuthRequestFromPeer(authRequest: AuthRequest, peerId: PeerId): Promise<StatusMessage>;
 

--- a/yarn-project/p2p/src/client/p2p_client.ts
+++ b/yarn-project/p2p/src/client/p2p_client.ts
@@ -39,11 +39,7 @@ import type { AttestationPoolApi, ProposalsForSlot } from '../mem_pools/attestat
 import type { MemPools } from '../mem_pools/interface.js';
 import type { TxPoolV2 } from '../mem_pools/tx_pool_v2/interfaces.js';
 import type { AuthRequest, StatusMessage } from '../services/index.js';
-import {
-  ReqRespSubProtocol,
-  type ReqRespSubProtocolHandler,
-  type ReqRespSubProtocolValidators,
-} from '../services/reqresp/interface.js';
+import { ReqRespSubProtocol, type ReqRespSubProtocolHandler } from '../services/reqresp/interface.js';
 import type {
   DuplicateAttestationInfo,
   DuplicateProposalInfo,
@@ -283,12 +279,8 @@ export class P2PClient extends WithTracer implements P2P {
     return this.syncPromise;
   }
 
-  addReqRespSubProtocol(
-    subProtocol: ReqRespSubProtocol,
-    handler: ReqRespSubProtocolHandler,
-    validator: ReqRespSubProtocolValidators[ReqRespSubProtocol],
-  ): Promise<void> {
-    return this.p2pService.addReqRespSubProtocol(subProtocol, handler, validator);
+  addReqRespSubProtocol(subProtocol: ReqRespSubProtocol, handler: ReqRespSubProtocolHandler): Promise<void> {
+    return this.p2pService.addReqRespSubProtocol(subProtocol, handler);
   }
 
   private initBlockStream(startingBlock?: BlockNumber) {

--- a/yarn-project/p2p/src/client/test/p2p_client.integration_batch_txs.test.ts
+++ b/yarn-project/p2p/src/client/test/p2p_client.integration_batch_txs.test.ts
@@ -53,7 +53,10 @@ describe('p2p client integration batch txs', () => {
     epochCache = mock<EpochCache>();
     worldState = mock<WorldStateSynchronizer>();
     connectionSampler = mock<ConnectionSampler>();
-    mockP2PService = mock<BatchTxRequesterLibP2PService>({ connectionSampler });
+    mockP2PService = mock<BatchTxRequesterLibP2PService>({
+      connectionSampler,
+      validateRequestedBlockTxsConsistency: () => Promise.resolve(true),
+    });
     txValidator = {
       validateRequestedTx: () => Promise.resolve({ result: 'valid' }),
       validateRequestedTxs: txs => Promise.resolve(txs.map(() => ({ result: 'valid' }))),

--- a/yarn-project/p2p/src/services/dummy_service.ts
+++ b/yarn-project/p2p/src/services/dummy_service.ts
@@ -18,7 +18,6 @@ import type {
   ReqRespSubProtocol,
   ReqRespSubProtocolHandler,
   ReqRespSubProtocolHandlers,
-  ReqRespSubProtocolValidators,
   SubProtocolMap,
 } from './reqresp/interface.js';
 import type { GoodByeReason } from './reqresp/protocols/goodbye.js';
@@ -146,11 +145,7 @@ export class DummyP2PService implements P2PService {
     return Promise.resolve();
   }
 
-  addReqRespSubProtocol(
-    _subProtocol: ReqRespSubProtocol,
-    _handler: ReqRespSubProtocolHandler,
-    _validator?: ReqRespSubProtocolValidators[ReqRespSubProtocol],
-  ): Promise<void> {
+  addReqRespSubProtocol(_subProtocol: ReqRespSubProtocol, _handler: ReqRespSubProtocolHandler): Promise<void> {
     return Promise.resolve();
   }
 
@@ -179,6 +174,7 @@ export class DummyP2PService implements P2PService {
       peerScoring: {
         penalizePeer: (_peerId, _penalty) => {},
       },
+      validateRequestedBlockTxsConsistency: () => Promise.resolve(true),
     };
   }
 }
@@ -284,10 +280,7 @@ export class DummyPeerManager implements PeerManagerInterface {
 export class DummyReqResp implements ReqRespInterface {
   updateConfig(_config: Partial<P2PReqRespConfig>): void {}
   setShouldRejectPeer(): void {}
-  start(
-    _subProtocolHandlers: ReqRespSubProtocolHandlers,
-    _subProtocolValidators: ReqRespSubProtocolValidators,
-  ): Promise<void> {
+  start(_subProtocolHandlers: ReqRespSubProtocolHandlers): Promise<void> {
     return Promise.resolve();
   }
   stop(): Promise<void> {
@@ -317,11 +310,7 @@ export class DummyReqResp implements ReqRespInterface {
     };
   }
 
-  addSubProtocol(
-    _subProtocol: ReqRespSubProtocol,
-    _handler: ReqRespSubProtocolHandler,
-    _validator?: ReqRespSubProtocolValidators[ReqRespSubProtocol],
-  ): Promise<void> {
+  addSubProtocol(_subProtocol: ReqRespSubProtocol, _handler: ReqRespSubProtocolHandler): Promise<void> {
     return Promise.resolve();
   }
 }

--- a/yarn-project/p2p/src/services/libp2p/libp2p_service.test.ts
+++ b/yarn-project/p2p/src/services/libp2p/libp2p_service.test.ts
@@ -19,7 +19,7 @@ import {
   makeCheckpointProposal,
   mockTx,
 } from '@aztec/stdlib/testing';
-import { type Tx, TxArray, TxHashArray, type TxValidator } from '@aztec/stdlib/tx';
+import { TxArray, TxHashArray } from '@aztec/stdlib/tx';
 import { type TelemetryClient, getTelemetryClient } from '@aztec/telemetry-client';
 import { ServerWorldStateSynchronizer } from '@aztec/world-state';
 
@@ -316,7 +316,7 @@ describe('LibP2PService', () => {
     });
   });
 
-  describe('validateRequestedBlockTxs', () => {
+  describe('validateRequestedBlockTxsConsistency', () => {
     function makeRequest(archiveRoot: Fr, length: number, indices: number[]): BlockTxsRequest {
       return new BlockTxsRequest(archiveRoot, new TxHashArray(), BitVector.init(length, indices));
     }
@@ -347,7 +347,7 @@ describe('LibP2PService', () => {
       const request = makeRequest(reqHash, 5, [0, 2]);
       const response = makeResponse(otherHash, 5, [0, 2], []);
 
-      const ok = await service.validateRequestedBlockTxs(request, response, mockPeerId);
+      const ok = await service.validateRequestedBlockTxsConsistency(request, response, mockPeerId);
       expect(ok).toBe(false);
       expect(mockPeerManager.penalizePeer).toHaveBeenCalledWith(mockPeerId, PeerErrorSeverity.MidToleranceError);
     });
@@ -357,7 +357,7 @@ describe('LibP2PService', () => {
       const request = makeRequest(hash, 5, [0, 2]);
       const response = makeResponse(hash, 4, [0, 2], []);
 
-      const ok = await service.validateRequestedBlockTxs(request, response, mockPeerId);
+      const ok = await service.validateRequestedBlockTxsConsistency(request, response, mockPeerId);
       expect(ok).toBe(false);
       expect(mockPeerManager.penalizePeer).toHaveBeenCalledWith(mockPeerId, PeerErrorSeverity.MidToleranceError);
     });
@@ -367,7 +367,7 @@ describe('LibP2PService', () => {
       const request = makeRequest(hash, 5, [0, 2, 3]);
       const response = makeResponse(hash, 5, [0, 2, 3], ['0xaaa', '0xaaa']); // duplicate
 
-      const ok = await service.validateRequestedBlockTxs(request, response, mockPeerId);
+      const ok = await service.validateRequestedBlockTxsConsistency(request, response, mockPeerId);
       expect(ok).toBe(false);
       expect(mockPeerManager.penalizePeer).toHaveBeenCalledWith(mockPeerId, PeerErrorSeverity.MidToleranceError);
     });
@@ -378,7 +378,7 @@ describe('LibP2PService', () => {
       const request = makeRequest(hash, 3, [0, 2]);
       const response = makeResponse(hash, 3, [0], ['0x1', '0x2']);
 
-      const ok = await service.validateRequestedBlockTxs(request, response, mockPeerId);
+      const ok = await service.validateRequestedBlockTxsConsistency(request, response, mockPeerId);
       expect(ok).toBe(false);
       expect(mockPeerManager.penalizePeer).toHaveBeenCalledWith(mockPeerId, PeerErrorSeverity.MidToleranceError);
     });
@@ -390,7 +390,7 @@ describe('LibP2PService', () => {
 
       setProposalTxHashes(service, ['0xgood0', '0xgood2', '0xgood4', '0xother', '0xother2']);
 
-      const ok = await service.validateRequestedBlockTxs(request, response, mockPeerId);
+      const ok = await service.validateRequestedBlockTxsConsistency(request, response, mockPeerId);
       expect(ok).toBe(false);
       expect(mockPeerManager.penalizePeer).toHaveBeenCalledWith(mockPeerId, PeerErrorSeverity.LowToleranceError);
     });
@@ -404,7 +404,7 @@ describe('LibP2PService', () => {
 
       setProposalTxHashes(service, ['0xgood0', '0xother1', '0xgood2', '0xother3', '0xgood4']);
 
-      const ok = await service.validateRequestedBlockTxs(request, response, mockPeerId);
+      const ok = await service.validateRequestedBlockTxsConsistency(request, response, mockPeerId);
       expect(ok).toBe(false);
       expect(mockPeerManager.penalizePeer).toHaveBeenCalledWith(mockPeerId, PeerErrorSeverity.LowToleranceError);
     });
@@ -416,9 +416,8 @@ describe('LibP2PService', () => {
 
       setProposalTxHashes(service, ['0xgood0', '0xother1', '0xgood2', '0xother3', '0xgood4']);
 
-      const ok = await service.validateRequestedBlockTxs(request, response, mockPeerId);
+      const ok = await service.validateRequestedBlockTxsConsistency(request, response, mockPeerId);
       expect(ok).toBe(true);
-      expect(service.validateRequestedTxMock).toHaveBeenCalledTimes(3);
     });
 
     it('should accept partial subset when proposal exists and order matches requested indices', async () => {
@@ -429,9 +428,8 @@ describe('LibP2PService', () => {
 
       setProposalTxHashes(service, ['0xgood0', '0xother1', '0xgood2', '0xother3', '0xgood4']);
 
-      const ok = await service.validateRequestedBlockTxs(request, response, mockPeerId);
+      const ok = await service.validateRequestedBlockTxsConsistency(request, response, mockPeerId);
       expect(ok).toBe(true);
-      expect(service.validateRequestedTxMock).toHaveBeenCalledTimes(2);
       expect(mockPeerManager.penalizePeer).not.toHaveBeenCalled();
     });
 
@@ -443,9 +441,8 @@ describe('LibP2PService', () => {
 
       setProposalTxHashes(service, ['0xgood0', '0xother1', '0xgood2', '0xother3', '0xother4']);
 
-      const ok = await service.validateRequestedBlockTxs(request, response, mockPeerId);
+      const ok = await service.validateRequestedBlockTxsConsistency(request, response, mockPeerId);
       expect(ok).toBe(true);
-      expect(service.validateRequestedTxMock).toHaveBeenCalledTimes(0);
       expect(mockPeerManager.penalizePeer).not.toHaveBeenCalled();
     });
 
@@ -455,7 +452,7 @@ describe('LibP2PService', () => {
       const request = makeRequest(hash, 3, [1]);
       const response = makeResponse(hash, 3, [], ['0xsome']);
 
-      const ok = await service.validateRequestedBlockTxs(request, response, mockPeerId);
+      const ok = await service.validateRequestedBlockTxsConsistency(request, response, mockPeerId);
       expect(ok).toBe(false);
       expect(mockPeerManager.penalizePeer).toHaveBeenCalledWith(mockPeerId, PeerErrorSeverity.MidToleranceError);
     });
@@ -468,7 +465,7 @@ describe('LibP2PService', () => {
 
       setProposalTxHashes(service, ['0xgood0', '0xother1', '0xgood2', '0xother3', '0xgood4']);
 
-      const ok = await service.validateRequestedBlockTxs(request, response, mockPeerId);
+      const ok = await service.validateRequestedBlockTxsConsistency(request, response, mockPeerId);
       expect(ok).toBe(false);
       expect(mockPeerManager.penalizePeer).toHaveBeenCalledWith(mockPeerId, PeerErrorSeverity.LowToleranceError);
     });
@@ -481,7 +478,7 @@ describe('LibP2PService', () => {
 
       setProposalTxHashes(service, ['0xgood0', '0xother1', '0xgood2', '0xother3', '0xgood4']);
 
-      const ok = await service.validateRequestedBlockTxs(request, response, mockPeerId);
+      const ok = await service.validateRequestedBlockTxsConsistency(request, response, mockPeerId);
       expect(ok).toBe(false);
       expect(mockPeerManager.penalizePeer).toHaveBeenCalledWith(mockPeerId, PeerErrorSeverity.LowToleranceError);
     });
@@ -498,7 +495,7 @@ describe('LibP2PService', () => {
       };
       service.setAttestationPool(mockAttestationPool);
 
-      const ok = await service.validateRequestedBlockTxs(request, response, mockPeerId);
+      const ok = await service.validateRequestedBlockTxsConsistency(request, response, mockPeerId);
       expect(ok).toBe(false);
       expect(mockPeerManager.penalizePeer).not.toHaveBeenCalled();
     });
@@ -1315,9 +1312,6 @@ interface CreateTestLibP2PServiceOptions {
  * and allows construction with mocked dependencies.
  */
 class TestLibP2PService extends LibP2PService {
-  /** Mocked validateRequestedTx for testing. */
-  public validateRequestedTxMock: jest.Mock;
-
   /** Controls whether first-stage gossip validation passes. Set to false to simulate first-stage failure. */
   public firstStageValidationPasses = true;
 
@@ -1329,9 +1323,6 @@ class TestLibP2PService extends LibP2PService {
 
   /** Controls the severity returned by the failing first-stage validator. */
   public firstStageSeverity: PeerErrorSeverity = PeerErrorSeverity.LowToleranceError;
-
-  /** Stub validator returned by createRequestedTxValidator. */
-  private stubValidator: TxValidator;
 
   /** Exposed epoch cache for test configuration. */
   public testEpochCache: MockProxy<EpochCacheInterface>;
@@ -1387,10 +1378,6 @@ class TestLibP2PService extends LibP2PService {
     this.mockPeerDiscoveryService = resolvedPeerDiscoveryService;
 
     this.testEpochCache = epochCache;
-    this.validateRequestedTxMock = jest.fn(() => Promise.resolve());
-    this.stubValidator = {
-      validateTx: () => Promise.resolve({ result: 'valid' as const }),
-    };
   }
 
   /** Exposes the protected handleNewGossipMessage for testing. */
@@ -1429,13 +1416,13 @@ class TestLibP2PService extends LibP2PService {
     };
   }
 
-  /** Exposes the protected validateRequestedBlockTxs for testing. */
-  public override validateRequestedBlockTxs(
+  /** Exposes the protected validateRequestedBlockTxsConsistency for testing. */
+  public override validateRequestedBlockTxsConsistency(
     request: BlockTxsRequest,
     response: BlockTxsResponse,
     peerId: PeerId,
   ): Promise<boolean> {
-    return super.validateRequestedBlockTxs(request, response, peerId);
+    return super.validateRequestedBlockTxsConsistency(request, response, peerId);
   }
 
   /** Exposes the protected processBlockFromPeer for testing. */
@@ -1451,21 +1438,6 @@ class TestLibP2PService extends LibP2PService {
   /** Exposes the protected validateAndStoreCheckpointAttestation for testing. */
   public override validateAndStoreCheckpointAttestation(peerId: PeerId, attestation: CheckpointAttestation) {
     return super.validateAndStoreCheckpointAttestation(peerId, attestation);
-  }
-
-  /** Override to use the mock. */
-  protected override async validateRequestedTx(
-    tx: Tx,
-    peerId: PeerId,
-    _txValidator: TxValidator,
-    _requested?: Set<`0x${string}`>,
-  ): Promise<void> {
-    await this.validateRequestedTxMock(tx, peerId);
-  }
-
-  /** Override to return the stub validator. */
-  protected override createRequestedTxValidator(): TxValidator {
-    return this.stubValidator;
   }
 
   /** Sets the attestation pool on the mempools for test setup. */

--- a/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
+++ b/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
@@ -25,7 +25,7 @@ import {
   metricsTopicStrToLabels,
 } from '@aztec/stdlib/p2p';
 import { MerkleTreeId } from '@aztec/stdlib/trees';
-import { Tx, type TxHash, type TxValidationResult, type TxValidator } from '@aztec/stdlib/tx';
+import { Tx, type TxValidationResult } from '@aztec/stdlib/tx';
 import type { UInt64 } from '@aztec/stdlib/types';
 import { compressComponentVersions } from '@aztec/stdlib/versioning';
 import {
@@ -74,7 +74,6 @@ import {
   createFirstStageTxValidationsForGossipedTransactions,
   createSecondStageTxValidationsForGossipedTransactions,
   createTxValidatorForBlockProposalReceivedTxs,
-  createTxValidatorForOnDemandReceivedTxs,
 } from '../../msg_validators/tx_validator/factory.js';
 import { GossipSubEvent } from '../../types/index.js';
 import { type PubSubLibp2p, convertToMultiaddr } from '../../util.js';
@@ -93,13 +92,11 @@ import {
   AuthRequest,
   BlockTxsRequest,
   BlockTxsResponse,
-  DEFAULT_SUB_PROTOCOL_VALIDATORS,
   type ReqRespInterface,
   type ReqRespResponse,
   ReqRespSubProtocol,
   type ReqRespSubProtocolHandler,
   type ReqRespSubProtocolHandlers,
-  type ReqRespSubProtocolValidators,
   StatusMessage,
   ValidationError,
   pingHandler,
@@ -568,16 +565,9 @@ export class LibP2PService extends WithTracer implements P2PService {
       requestResponseHandlers[ReqRespSubProtocol.TX] = txHandler.bind(this);
     }
 
-    // Define the sub protocol validators - This is done within this start() method to gain a callback to the existing validateTx function
-    const reqrespSubProtocolValidators = {
-      ...DEFAULT_SUB_PROTOCOL_VALIDATORS,
-      [ReqRespSubProtocol.TX]: this.validateRequestedTxs.bind(this),
-      [ReqRespSubProtocol.BLOCK_TXS]: this.validateRequestedBlockTxs.bind(this),
-    };
-
     await this.peerManager.initializePeers();
 
-    await this.reqresp.start(requestResponseHandlers, reqrespSubProtocolValidators);
+    await this.reqresp.start(requestResponseHandlers);
 
     await this.node.start();
 
@@ -669,12 +659,8 @@ export class LibP2PService extends WithTracer implements P2PService {
     this.logger.info('LibP2P service stopped');
   }
 
-  addReqRespSubProtocol(
-    subProtocol: ReqRespSubProtocol,
-    handler: ReqRespSubProtocolHandler,
-    validator?: ReqRespSubProtocolValidators[ReqRespSubProtocol],
-  ): Promise<void> {
-    return this.reqresp.addSubProtocol(subProtocol, handler, validator);
+  addReqRespSubProtocol(subProtocol: ReqRespSubProtocol, handler: ReqRespSubProtocolHandler): Promise<void> {
+    return this.reqresp.addSubProtocol(subProtocol, handler);
   }
 
   public registerThisValidatorAddresses(address: EthAddress[]): void {
@@ -1521,22 +1507,21 @@ export class LibP2PService extends WithTracer implements P2PService {
   }
 
   /**
-   * Validate the requested block transactions. Allow partial returns.
+   * Validate the requested block transactions request-response consistency.
+   * It does NOT validate the transactions themselves.
    * @param request - The block transactions request.
    * @param response - The block transactions response.
    * @param peerId - The ID of the peer that made the request.
-   * @returns True if the requested block transactions are valid, false otherwise.
+   * @returns True if the request-response is consistent, false otherwise.
    */
-  @trackSpan('Libp2pService.validateRequestedBlockTxs', request => ({
+  @trackSpan('Libp2pService.validateRequestedBlockTxsConsistency', request => ({
     [Attributes.BLOCK_ARCHIVE]: request.archiveRoot.toString(),
   }))
-  protected async validateRequestedBlockTxs(
+  protected async validateRequestedBlockTxsConsistency(
     request: BlockTxsRequest,
     response: BlockTxsResponse,
     peerId: PeerId,
   ): Promise<boolean> {
-    const requestedTxValidator = this.createRequestedTxValidator();
-
     try {
       if (!response.archiveRoot.equals(request.archiveRoot)) {
         this.peerManager.penalizePeer(peerId, PeerErrorSeverity.MidToleranceError);
@@ -1596,7 +1581,6 @@ export class LibP2PService extends WithTracer implements P2PService {
         return false;
       }
 
-      await Promise.all(response.txs.map(tx => this.validateRequestedTx(tx, peerId, requestedTxValidator)));
       return true;
     } catch (e: any) {
       if (e instanceof ValidationError) {
@@ -1607,69 +1591,6 @@ export class LibP2PService extends WithTracer implements P2PService {
 
       return false;
     }
-  }
-
-  /**
-   * Validate a collection of txs that has been requested from a peer.
-   *
-   * The core component of this validator is that each tx hash MUST match the requested tx hash,
-   * In order to perform this check, the tx proof must be verified.
-   *
-   * Note: This function is called from within `ReqResp.sendRequest` as part of the
-   * ReqRespSubProtocol.TX subprotocol validation.
-   *
-   * @param requestedTxHash - The collection of the txs that was requested.
-   * @param responseTx - The collection of txs that was received as a response to the request.
-   * @param peerId - The peer ID of the peer that sent the tx.
-   * @returns True if the whole collection of txs is valid, false otherwise.
-   */
-  @trackSpan('Libp2pService.validateRequestedTx', (requestedTxHash, _responseTx) => ({
-    [Attributes.TX_HASH]: requestedTxHash.toString(),
-  }))
-  private async validateRequestedTxs(requestedTxHash: TxHash[], responseTx: Tx[], peerId: PeerId): Promise<boolean> {
-    const requested = new Set(requestedTxHash.map(h => h.toString()));
-    const requestedTxValidator = this.createRequestedTxValidator();
-
-    //TODO: (mralj) - this is somewhat naive implementation, if single tx is invalid we consider the whole response invalid.
-    // I think we should still extract the valid txs and return them, so that we can still use the response.
-    try {
-      await Promise.all(responseTx.map(tx => this.validateRequestedTx(tx, peerId, requestedTxValidator, requested)));
-      return true;
-    } catch (e: any) {
-      if (e instanceof ValidationError) {
-        this.logger.warn(`Failed to validate requested txs from peer ${peerId.toString()}, reason ${e.message}`);
-      } else {
-        this.logger.error(`Error during validation of requested txs`, e);
-      }
-
-      return false;
-    }
-  }
-
-  protected async validateRequestedTx(
-    tx: Tx,
-    peerId: PeerId,
-    txValidator: TxValidator,
-    requested?: Set<`0x${string}`>,
-  ) {
-    const penalize = (severity: PeerErrorSeverity) => this.peerManager.penalizePeer(peerId, severity);
-    if (requested && !requested.has(tx.getTxHash().toString())) {
-      penalize(PeerErrorSeverity.MidToleranceError);
-      throw new ValidationError(`Received tx with hash ${tx.getTxHash().toString()} that was not requested.`);
-    }
-
-    const { result } = await txValidator.validateTx(tx);
-    if (result === 'invalid') {
-      penalize(PeerErrorSeverity.LowToleranceError);
-      throw new ValidationError(`Received tx with hash ${tx.getTxHash().toString()} that is invalid.`);
-    }
-  }
-
-  protected createRequestedTxValidator(): TxValidator {
-    return createTxValidatorForOnDemandReceivedTxs(this.proofVerifier, {
-      l1ChainId: this.config.l1ChainId,
-      rollupVersion: this.config.rollupVersion,
-    });
   }
 
   private getGasFees(): Promise<GasFees> {
@@ -1689,6 +1610,7 @@ export class LibP2PService extends WithTracer implements P2PService {
         proofVerifier: this.proofVerifier,
       },
       peerScoring: this.peerManager,
+      validateRequestedBlockTxsConsistency: this.validateRequestedBlockTxsConsistency.bind(this),
     };
   }
 

--- a/yarn-project/p2p/src/services/reqresp/batch-tx-requester/batch_tx_requester.test.ts
+++ b/yarn-project/p2p/src/services/reqresp/batch-tx-requester/batch_tx_requester.test.ts
@@ -61,6 +61,7 @@ describe('BatchTxRequester', () => {
       reqResp,
       peerScoring,
     });
+    mockP2PService.validateRequestedBlockTxsConsistency.mockResolvedValue(true);
     txValidator = new AlwaysValidTxValidator();
 
     const signer = Secp256k1Signer.random();
@@ -2017,6 +2018,82 @@ describe('BatchTxRequester', () => {
       // Non-zero archive root mismatch is malicious — peer must be penalised
       const peer0Penalties = peerCollection.peersPenalised.filter(e => e.peerId === peers[0].toString());
       expect(peer0Penalties.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('Response consistency validation', () => {
+    it('marks peer dumb (without penalising) when validateRequestedBlockTxsConsistency rejects the response', async () => {
+      const txCount = TX_BATCH_SIZE;
+      const deadline = 5_000;
+      const missing = Array.from({ length: txCount }, () => TxHash.random());
+
+      blockProposal = await makeBlockProposal({
+        signer: Secp256k1Signer.random(),
+        blockHeader: makeBlockHeader(1, { blockNumber: BlockNumber(1) }),
+        archiveRoot: Fr.random(),
+        txHashes: missing,
+      });
+
+      const peers = await Promise.all([createSecp256k1PeerId(), createSecp256k1PeerId()]);
+      connectionSampler.getPeerListSortedByConnectionCountAsc.mockReturnValue(peers);
+
+      const peerCollection = new TestPeerCollection(
+        new PeerCollection(connectionSampler, undefined, new DateProvider()),
+      );
+
+      // peer0's responses are rejected by consistency validation; peer1's responses pass.
+      const consistencyCallPeerIds: string[] = [];
+      mockP2PService.validateRequestedBlockTxsConsistency.mockImplementation((_req, _resp, peerId) => {
+        consistencyCallPeerIds.push(peerId.toString());
+        return Promise.resolve(peerId.toString() !== peers[0].toString());
+      });
+
+      // Both peers return well-formed responses with the requested txs;
+      // the consistency mock is what decides whether the response is accepted.
+      reqResp.sendRequestToPeer.mockImplementation((_peerId: any, _sub: any, data: any) => {
+        const request = BlockTxsRequest.fromBuffer(data);
+        const requestedIndices = request.txIndices.getTrueIndices();
+        const availableTxs = requestedIndices.map(idx => makeTx(blockProposal.txHashes[idx]));
+
+        return Promise.resolve({
+          status: ReqRespStatus.SUCCESS,
+          data: new BlockTxsResponse(
+            blockProposal.archive,
+            new TxArray(...availableTxs),
+            BitVector.init(txCount, requestedIndices),
+          ).toBuffer(),
+        });
+      });
+
+      const requester = new BatchTxRequester(
+        RequestTracker.create(missing, new Date(Date.now() + deadline)),
+        blockProposal,
+        undefined,
+        mockP2PService,
+        logger,
+        new DateProvider(),
+        {
+          smartParallelWorkerCount: 0,
+          dumbParallelWorkerCount: 2,
+          peerCollection,
+          txValidator,
+        },
+      );
+
+      const results = await BatchTxRequester.collectAllTxs(requester.run());
+
+      // All txs eventually fetched (via peer1).
+      expect(results).toHaveLength(txCount);
+
+      // Consistency validation was invoked for peer0's response.
+      expect(consistencyCallPeerIds).toContain(peers[0].toString());
+
+      // peer0 marked dumb (INTERNAL_ERROR path in handleFailResponseFromPeer)…
+      expect(peerCollection.peersMarkedDumb).toContain(peers[0].toString());
+
+      // …but NOT penalised — failed consistency yields INTERNAL_ERROR, not a penalty cause.
+      const peer0Penalties = peerCollection.peersPenalised.filter(e => e.peerId === peers[0].toString());
+      expect(peer0Penalties).toHaveLength(0);
     });
   });
 });

--- a/yarn-project/p2p/src/services/reqresp/batch-tx-requester/batch_tx_requester.ts
+++ b/yarn-project/p2p/src/services/reqresp/batch-tx-requester/batch_tx_requester.ts
@@ -428,6 +428,15 @@ export class BatchTxRequester {
       }
 
       const blockResponse = BlockTxsResponse.fromBuffer(response.data);
+
+      // Validate response. Peers will be penalised by the validator if they send invalid response.
+      const isValid = await this.p2pService.validateRequestedBlockTxsConsistency(request, blockResponse, peerId);
+      if (!isValid) {
+        this.logger.debug(`Peer ${peerId.toString()} sent invalid response`);
+        this.handleFailResponseFromPeer(peerId, ReqRespStatus.INTERNAL_ERROR);
+        return;
+      }
+
       await this.handleSuccessResponseFromPeer(peerId, blockResponse);
     } catch (err: any) {
       this.logger.error(`Failed to get valid response from peer ${peerId.toString()}: ${err.message}`, {
@@ -445,6 +454,7 @@ export class BatchTxRequester {
    * Handles failed response form the peer
    * There are 3 scenarios
    * - RATE_LIMIT_EXCEEDED: We mark this and don't query this peer again for some_time
+   * - INTERNAL_ERROR: We use this to cover cases where the request-response consistency validation fails.
    * - FAILURE and UNKNOWN: We penalise this, if peer has been penalised this way N times they are not queried again
    *   this implies we will query these peers couple of more times and give them a chance to "redeem" themselves before completely ignoring them
    */
@@ -458,7 +468,8 @@ export class BatchTxRequester {
 
     // NOT_FOUND means the peer pruned its block proposal — it can no longer serve
     // index-based requests, but this is a legitimate state so we don't penalize.
-    if (responseStatus === ReqRespStatus.NOT_FOUND) {
+    // We use INTERNAL_ERROR to cover cases where the request-response consistency validation fails.
+    if (responseStatus === ReqRespStatus.NOT_FOUND || responseStatus === ReqRespStatus.INTERNAL_ERROR) {
       this.peers.markPeerDumb(peerId);
       this.txsMetadata.clearPeerData(peerId);
       return;
@@ -485,7 +496,7 @@ export class BatchTxRequester {
    * Handles received txs.
    * Transactions are validated and then put on async queue
    * to be yielded by main running loop
-   * */
+   */
   private async handleReceivedTxs(peerId: PeerId, txs: TxArray) {
     const newTxs = txs.filter(tx => !this.txsMetadata.alreadyFetched(tx.txHash));
 
@@ -493,7 +504,7 @@ export class BatchTxRequester {
       return;
     }
 
-    //TODO: this validation can be slow, maybe spawn worker just for validation
+    // TODO: this validation can be slow, maybe spawn worker just for validation
     // We could use the async queue for communication.
     const validationResults = await Promise.allSettled(
       newTxs.map(async tx => ({

--- a/yarn-project/p2p/src/services/reqresp/batch-tx-requester/interface.ts
+++ b/yarn-project/p2p/src/services/reqresp/batch-tx-requester/interface.ts
@@ -5,6 +5,7 @@ import type { Tx, TxHash } from '@aztec/stdlib/tx';
 import type { PeerId } from '@libp2p/interface';
 
 import type { ConnectionSampler } from '../connection-sampler/connection_sampler.js';
+import type { BlockTxsRequest, BlockTxsResponse } from '../index.js';
 import type { ReqRespInterface } from '../interface.js';
 import type { IPeerCollection } from './peer_collection.js';
 import type { BatchRequestTxValidatorConfig, IBatchRequestTxValidator } from './tx_validator.js';
@@ -39,6 +40,12 @@ export interface BatchTxRequesterLibP2PService {
   txValidatorConfig: BatchRequestTxValidatorConfig;
   /** Peer scoring for penalizing peers */
   peerScoring: IPeerPenalizer;
+  /** Validate the requested block transactions request-response consistency */
+  validateRequestedBlockTxsConsistency: (
+    request: BlockTxsRequest,
+    response: BlockTxsResponse,
+    peerId: PeerId,
+  ) => Promise<boolean>;
 }
 
 export interface BatchTxRequesterOptions {

--- a/yarn-project/p2p/src/services/reqresp/interface.ts
+++ b/yarn-project/p2p/src/services/reqresp/interface.ts
@@ -78,22 +78,10 @@ export interface ProtocolRateLimitQuota {
   globalLimit: RateLimitQuota;
 }
 
-export const noopValidator = () => Promise.resolve(true);
-
 /**
  * A type mapping from supprotocol to it's handling function
  */
 export type ReqRespSubProtocolHandlers = Record<ReqRespSubProtocol, ReqRespSubProtocolHandler>;
-
-type ResponseValidator<RequestIdentifier, Response> = (
-  request: RequestIdentifier,
-  response: Response,
-  peerId: PeerId,
-) => Promise<boolean>;
-
-export type ReqRespSubProtocolValidators = {
-  [S in ReqRespSubProtocol]: ResponseValidator<any, any>;
-};
 
 /**
  * Protocols that are always allowed without authentication, even when p2pAllowOnlyValidators is enabled.
@@ -112,15 +100,6 @@ export const UNAUTHENTICATED_ALLOWED_PROTOCOLS: ReadonlySet<ReqRespSubProtocol> 
  * Returns true if the peer should be rejected (i.e. p2pAllowOnlyValidators is on and peer is unauthenticated).
  */
 export type ShouldRejectPeer = (peerId: string) => boolean;
-
-export const DEFAULT_SUB_PROTOCOL_VALIDATORS: ReqRespSubProtocolValidators = {
-  [ReqRespSubProtocol.PING]: noopValidator,
-  [ReqRespSubProtocol.STATUS]: noopValidator,
-  [ReqRespSubProtocol.TX]: noopValidator,
-  [ReqRespSubProtocol.GOODBYE]: noopValidator,
-  [ReqRespSubProtocol.AUTH]: noopValidator,
-  [ReqRespSubProtocol.BLOCK_TXS]: noopValidator,
-};
 
 /*
  * Helper class to sub-protocol validation error*/
@@ -244,15 +223,8 @@ export const subProtocolSizeCalculators: Record<ReqRespSubProtocol, ExpectedResp
 };
 
 export interface ReqRespInterface {
-  start(
-    subProtocolHandlers: Partial<ReqRespSubProtocolHandlers>,
-    subProtocolValidators: ReqRespSubProtocolValidators,
-  ): Promise<void>;
-  addSubProtocol(
-    subProtocol: ReqRespSubProtocol,
-    handler: ReqRespSubProtocolHandler,
-    validator?: ReqRespSubProtocolValidators[ReqRespSubProtocol],
-  ): Promise<void>;
+  start(subProtocolHandlers: Partial<ReqRespSubProtocolHandlers>): Promise<void>;
+  addSubProtocol(subProtocol: ReqRespSubProtocol, handler: ReqRespSubProtocolHandler): Promise<void>;
   stop(): Promise<void>;
   sendRequestToPeer(
     peerId: PeerId,

--- a/yarn-project/p2p/src/services/reqresp/reqresp.ts
+++ b/yarn-project/p2p/src/services/reqresp/reqresp.ts
@@ -20,14 +20,12 @@ import {
 } from './config.js';
 import { ConnectionSampler, RandomSampler } from './connection-sampler/connection_sampler.js';
 import {
-  DEFAULT_SUB_PROTOCOL_VALIDATORS,
   type ReqRespInterface,
   type ReqRespResponse,
   ReqRespSubProtocol,
   type ReqRespSubProtocolHandler,
   type ReqRespSubProtocolHandlers,
   type ReqRespSubProtocolRateLimits,
-  type ReqRespSubProtocolValidators,
   type ShouldRejectPeer,
   UNAUTHENTICATED_ALLOWED_PROTOCOLS,
   subProtocolSizeCalculators,
@@ -59,7 +57,6 @@ export class ReqResp implements ReqRespInterface {
   private dialTimeoutMs: number = DEFAULT_REQRESP_DIAL_TIMEOUT_MS;
 
   private subProtocolHandlers: Partial<ReqRespSubProtocolHandlers> = {};
-  private subProtocolValidators: Partial<ReqRespSubProtocolValidators> = {};
 
   private connectionSampler: ConnectionSampler;
   private rateLimiter: RequestResponseRateLimiter;
@@ -122,9 +119,8 @@ export class ReqResp implements ReqRespInterface {
   /**
    * Start the reqresp service
    */
-  async start(subProtocolHandlers: ReqRespSubProtocolHandlers, subProtocolValidators: ReqRespSubProtocolValidators) {
+  async start(subProtocolHandlers: ReqRespSubProtocolHandlers) {
     Object.assign(this.subProtocolHandlers, subProtocolHandlers);
-    Object.assign(this.subProtocolValidators, subProtocolValidators);
 
     // Register streamHandler with libp2p.
     // The streamHandler is responsible for reading the incoming stream, determining the protocol, then triggering the appropriate handler.
@@ -141,13 +137,8 @@ export class ReqResp implements ReqRespInterface {
     this.rateLimiter.start();
   }
 
-  async addSubProtocol(
-    subProtocol: ReqRespSubProtocol,
-    handler: ReqRespSubProtocolHandler,
-    validator: ReqRespSubProtocolValidators[ReqRespSubProtocol] = DEFAULT_SUB_PROTOCOL_VALIDATORS[subProtocol],
-  ): Promise<void> {
+  async addSubProtocol(subProtocol: ReqRespSubProtocol, handler: ReqRespSubProtocolHandler): Promise<void> {
     this.subProtocolHandlers[subProtocol] = handler;
-    this.subProtocolValidators[subProtocol] = validator;
     this.logger.debug(`Registering handler for sub protocol ${subProtocol}`);
     await this.libp2p.handle(
       subProtocol,

--- a/yarn-project/p2p/src/services/service.ts
+++ b/yarn-project/p2p/src/services/service.ts
@@ -17,11 +17,7 @@ import type EventEmitter from 'events';
 import type { BatchTxRequesterLibP2PService } from './reqresp/batch-tx-requester/interface.js';
 import type { P2PReqRespConfig } from './reqresp/config.js';
 import type { StatusMessage } from './reqresp/index.js';
-import type {
-  ReqRespSubProtocol,
-  ReqRespSubProtocolHandler,
-  ReqRespSubProtocolValidators,
-} from './reqresp/interface.js';
+import type { ReqRespSubProtocol, ReqRespSubProtocolHandler } from './reqresp/interface.js';
 import type { AuthRequest, AuthResponse } from './reqresp/protocols/auth.js';
 
 export enum PeerDiscoveryState {
@@ -133,11 +129,7 @@ export interface P2PService {
 
   validateTxsReceivedInBlockProposal(txs: Tx[]): Promise<void>;
 
-  addReqRespSubProtocol(
-    subProtocol: ReqRespSubProtocol,
-    handler: ReqRespSubProtocolHandler,
-    validator?: ReqRespSubProtocolValidators[ReqRespSubProtocol],
-  ): Promise<void>;
+  addReqRespSubProtocol(subProtocol: ReqRespSubProtocol, handler: ReqRespSubProtocolHandler): Promise<void>;
 
   handleAuthRequestFromPeer(authRequest: AuthRequest, peerId: PeerId): Promise<StatusMessage>;
 

--- a/yarn-project/p2p/src/test-helpers/mock-pubsub.ts
+++ b/yarn-project/p2p/src/test-helpers/mock-pubsub.ts
@@ -29,7 +29,6 @@ import type {
   ReqRespSubProtocol,
   ReqRespSubProtocolHandler,
   ReqRespSubProtocolHandlers,
-  ReqRespSubProtocolValidators,
 } from '../services/reqresp/interface.js';
 import { ReqRespStatus } from '../services/reqresp/status.js';
 import { GossipSubEvent } from '../types/index.js';
@@ -104,19 +103,12 @@ class MockReqResp implements ReqRespInterface {
   updateConfig(_config: Partial<P2PReqRespConfig>): void {}
   setShouldRejectPeer(): void {}
 
-  start(
-    subProtocolHandlers: Partial<ReqRespSubProtocolHandlers>,
-    _subProtocolValidators: ReqRespSubProtocolValidators,
-  ): Promise<void> {
+  start(subProtocolHandlers: Partial<ReqRespSubProtocolHandlers>): Promise<void> {
     Object.assign(this.handlers, subProtocolHandlers);
     return Promise.resolve();
   }
 
-  addSubProtocol(
-    subProtocol: ReqRespSubProtocol,
-    handler: ReqRespSubProtocolHandler,
-    _validator?: ReqRespSubProtocolValidators[ReqRespSubProtocol],
-  ): Promise<void> {
+  addSubProtocol(subProtocol: ReqRespSubProtocol, handler: ReqRespSubProtocolHandler): Promise<void> {
     this.handlers[subProtocol] = handler;
     return Promise.resolve();
   }

--- a/yarn-project/p2p/src/test-helpers/reqresp-nodes.ts
+++ b/yarn-project/p2p/src/test-helpers/reqresp-nodes.ts
@@ -43,8 +43,6 @@ import {
   ReqRespSubProtocol,
   type ReqRespSubProtocolHandlers,
   type ReqRespSubProtocolRateLimits,
-  type ReqRespSubProtocolValidators,
-  noopValidator,
 } from '../services/reqresp/interface.js';
 import { pingHandler } from '../services/reqresp/protocols/index.js';
 import { ReqResp } from '../services/reqresp/reqresp.js';
@@ -199,17 +197,6 @@ export const MOCK_SUB_PROTOCOL_HANDLERS: ReqRespSubProtocolHandlers = {
   [ReqRespSubProtocol.BLOCK_TXS]: (_msg: any) => Promise.resolve(Buffer.from('block_txs')),
 };
 
-// By default, all requests are valid
-// If you want to test an invalid response, you can override the validator
-export const MOCK_SUB_PROTOCOL_VALIDATORS: ReqRespSubProtocolValidators = {
-  [ReqRespSubProtocol.PING]: noopValidator,
-  [ReqRespSubProtocol.STATUS]: noopValidator,
-  [ReqRespSubProtocol.TX]: noopValidator,
-  [ReqRespSubProtocol.GOODBYE]: noopValidator,
-  [ReqRespSubProtocol.AUTH]: noopValidator,
-  [ReqRespSubProtocol.BLOCK_TXS]: noopValidator,
-};
-
 /**
  * @param numberOfNodes - the number of nodes to create
  * @returns An array of the created nodes
@@ -222,13 +209,9 @@ export const createNodes = (
   return timesParallel(numberOfNodes, () => createReqResp(peerScoring, rateLimits));
 };
 
-export const startNodes = async (
-  nodes: ReqRespNode[],
-  subProtocolHandlers = MOCK_SUB_PROTOCOL_HANDLERS,
-  subProtocolValidators = MOCK_SUB_PROTOCOL_VALIDATORS,
-) => {
+export const startNodes = async (nodes: ReqRespNode[], subProtocolHandlers = MOCK_SUB_PROTOCOL_HANDLERS) => {
   for (const node of nodes) {
-    await node.req.start(subProtocolHandlers, subProtocolValidators);
+    await node.req.start(subProtocolHandlers);
   }
 };
 

--- a/yarn-project/txe/src/state_machine/dummy_p2p_client.ts
+++ b/yarn-project/txe/src/state_machine/dummy_p2p_client.ts
@@ -13,7 +13,6 @@ import type {
   PeerId,
   ReqRespSubProtocol,
   ReqRespSubProtocolHandler,
-  ReqRespSubProtocolValidators,
   StatusMessage,
 } from '@aztec/p2p';
 import type { EthAddress, L2BlockStreamEvent, L2Tips } from '@aztec/stdlib/block';
@@ -220,11 +219,7 @@ export class DummyP2P implements P2P {
     return Promise.resolve();
   }
 
-  addReqRespSubProtocol(
-    _subProtocol: ReqRespSubProtocol,
-    _handler: ReqRespSubProtocolHandler,
-    _validator?: ReqRespSubProtocolValidators[ReqRespSubProtocol],
-  ): Promise<void> {
+  addReqRespSubProtocol(_subProtocol: ReqRespSubProtocol, _handler: ReqRespSubProtocolHandler): Promise<void> {
     throw new Error('DummyP2P does not implement "addReqRespSubProtocol".');
   }
   handleAuthRequestFromPeer(_authRequest: AuthRequest, _peerId: PeerId): Promise<StatusMessage> {


### PR DESCRIPTION
This PR modifies and clarifies what is validated where:

- `sendRequestToPeer` (from reqresp) is considered a low level method. It does not validate transactions and does only very minimal checks on the request and response objects. It does penalize peers under some circumstances.
- The concept of subprotocol validator is removed from reqresp.
- `BatchTxRequester` now (1) validates the req and response objects; (2) validates the TXs when the response is valid.
- Unused `validateRequestedTx` is dropped in this PR.

Closes https://linear.app/aztec-labs/issue/A-1014/block-txs-reqresp-validator-validaterequestedblocktxs-is-never-invoked .