### PR TITLE
fix: fork closure in epoch proving jobs

### DIFF
--- a/yarn-project/foundation/src/timer/index.ts
+++ b/yarn-project/foundation/src/timer/index.ts
@@ -1,4 +1,4 @@
 export * from './date.js';
 export { elapsed, elapsedSync } from './elapsed.js';
-export { TimeoutTask, executeTimeout, timeoutPromise } from './timeout.js';
+export { TimeoutTask, execWithSignal, executeTimeout, timeoutPromise } from './timeout.js';
 export { Timer } from './timer.js';

--- a/yarn-project/foundation/src/timer/timeout.test.ts
+++ b/yarn-project/foundation/src/timer/timeout.test.ts
@@ -1,7 +1,7 @@
 import { jest } from '@jest/globals';
 
 import { sleep } from '../sleep/index.js';
-import { executeTimeout } from './timeout.js';
+import { execWithSignal, executeTimeout } from './timeout.js';
 
 describe('timeout', () => {
   it('execs within timeout', async () => {
@@ -24,5 +24,33 @@ describe('timeout', () => {
     await expect(executeTimeout(() => sleep(500), -100, 'Timed out!')).rejects.toThrow(
       /The value of .* is out of range/,
     );
+  });
+
+  it('execs with a non-aborted signal', async () => {
+    const controller = new AbortController();
+    await expect(execWithSignal(() => sleep(20).then(() => 'ok'), controller.signal)).resolves.toEqual('ok');
+  });
+
+  it('rejects with custom error when signal aborts', async () => {
+    const controller = new AbortController();
+    const promise = execWithSignal(
+      () => sleep(500),
+      controller.signal,
+      () => new Error('Aborted!'),
+    );
+
+    controller.abort();
+
+    await expect(promise).rejects.toThrow('Aborted!');
+  });
+
+  it('execs with AbortSignal.timeout', async () => {
+    await expect(
+      execWithSignal(
+        () => sleep(500),
+        AbortSignal.timeout(20),
+        signal => new Error(signal.reason?.name ?? 'Aborted'),
+      ),
+    ).rejects.toThrow('TimeoutError');
   });
 });

--- a/yarn-project/foundation/src/timer/timeout.ts
+++ b/yarn-project/foundation/src/timer/timeout.ts
@@ -92,6 +92,37 @@ export async function executeTimeout<T>(
   return await task.exec();
 }
 
+function defaultSignalError(signal: AbortSignal) {
+  if (signal.reason instanceof Error) {
+    return signal.reason;
+  }
+
+  return new Error(signal.reason ? String(signal.reason) : 'Operation aborted');
+}
+
+/** Executes a function until it completes or the given signal aborts. */
+export async function execWithSignal<T>(
+  fn: (signal: AbortSignal) => Promise<T>,
+  signal: AbortSignal,
+  errorFn: (signal: AbortSignal) => Error = defaultSignalError,
+) {
+  if (signal.aborted) {
+    throw errorFn(signal);
+  }
+
+  const abortPromise = promiseWithResolvers<never>();
+  const abortListener = () => abortPromise.reject(errorFn(signal));
+  signal.addEventListener('abort', abortListener, { once: true });
+
+  try {
+    return await Promise.race<T>([fn(signal), abortPromise.promise]);
+  } finally {
+    if (abortListener) {
+      signal.removeEventListener('abort', abortListener);
+    }
+  }
+}
+
 /** Returns a promise that rejects after the given timeout */
 export function timeoutPromise(timeoutMs: number, errorMessage?: string) {
   const promise = promiseWithResolvers<never>();

--- a/yarn-project/prover-node/src/job/epoch-proving-job.test.ts
+++ b/yarn-project/prover-node/src/job/epoch-proving-job.test.ts
@@ -26,6 +26,12 @@ import type { EpochProvingJobData } from './epoch-proving-job-data.js';
 import { EpochProvingJob } from './epoch-proving-job.js';
 
 describe('epoch-proving-job', () => {
+  const mockFork = () => {
+    const fork = mock<MerkleTreeWriteOperations>();
+    fork[Symbol.asyncDispose].mockImplementation(() => fork.close());
+    return fork;
+  };
+
   // Dependencies
   let prover: MockProxy<EpochProver>;
   let publisher: MockProxy<ProverNodePublisher>;
@@ -86,7 +92,7 @@ describe('epoch-proving-job', () => {
     l2BlockSource = mock<L2BlockSource>();
     worldState = mock<WorldStateSynchronizer>();
     publicProcessorFactory = mock<PublicProcessorFactory>();
-    db = mock<MerkleTreeWriteOperations>();
+    db = mockFork();
     publicProcessor = mock<PublicProcessor>();
     metrics = new ProverNodeJobMetrics(
       getTelemetryClient().getMeter('EpochProvingJob'),
@@ -199,6 +205,62 @@ describe('epoch-proving-job', () => {
     expect(publisher.submitEpochProof).not.toHaveBeenCalled();
   });
 
+  it('waits for in-flight checkpoint processing to settle after a block processing failure', async () => {
+    const forkDbs = times(NUM_BLOCKS, () => mockFork());
+    let nextFork = 0;
+    worldState.fork.mockImplementation(() => Promise.resolve(forkDbs[nextFork++]));
+    prover.startNewBlock.mockResolvedValue(undefined);
+
+    let processCalls = 0;
+    let resolveSecondProcessStarted!: () => void;
+    const secondProcessStarted = new Promise<void>(resolve => {
+      resolveSecondProcessStarted = resolve;
+    });
+    let releaseSecondProcess!: () => void;
+    const secondProcessMayFinish = new Promise<void>(resolve => {
+      releaseSecondProcess = resolve;
+    });
+
+    publicProcessorFactory.create.mockImplementation(() => {
+      const processor = mock<PublicProcessor>();
+      processor.process.mockImplementation(async txs => {
+        const txsArray = await toArray(txs);
+        processCalls++;
+
+        if (processCalls === 1) {
+          await secondProcessStarted;
+          throw new Error('Failed to process tx');
+        }
+
+        if (processCalls === 2) {
+          resolveSecondProcessStarted();
+          await secondProcessMayFinish;
+        }
+
+        const processedTxs = await Promise.all(txsArray.map(tx => mock<ProcessedTx>({ hash: tx.getTxHash() })));
+        return [processedTxs, [], txsArray, [], []];
+      });
+      return processor;
+    });
+
+    const job = createJob({ parallelBlockLimit: 2 });
+    const runPromise = job.run();
+
+    await secondProcessStarted;
+    const runResolvedBeforeSecondProcessFinished = await Promise.race([
+      runPromise.then(() => true),
+      sleep(50).then(() => false),
+    ]);
+
+    releaseSecondProcess();
+    await runPromise;
+
+    expect(runResolvedBeforeSecondProcessFinished).toBe(false);
+    expect(job.getState()).toEqual('failed');
+    expect(forkDbs[1].close).toHaveBeenCalled();
+    expect(publisher.submitEpochProof).not.toHaveBeenCalled();
+  });
+
   it('times out if deadline is hit', async () => {
     prover.startNewBlock.mockImplementation(() => sleep(200));
     const deadline = new Date(Date.now() + 100);
@@ -216,6 +278,42 @@ describe('epoch-proving-job', () => {
     await job.stop();
 
     expect(job.getState()).toEqual('stopped');
+    expect(publisher.submitEpochProof).not.toHaveBeenCalled();
+  });
+
+  it('aborts public processing when stopped externally', async () => {
+    prover.startNewBlock.mockResolvedValue(undefined);
+
+    let processStarted!: () => void;
+    const processStartedPromise = new Promise<void>(resolve => {
+      processStarted = resolve;
+    });
+    let abortSignal: AbortSignal | undefined;
+
+    publicProcessor.process.mockImplementation(async (txs, opts) => {
+      const signal = opts?.signal;
+      if (!signal) {
+        throw new Error('Expected public processor abort signal');
+      }
+      abortSignal = signal;
+      processStarted();
+      await new Promise<void>(resolve => signal.addEventListener('abort', () => resolve(), { once: true }));
+
+      const txsArray = await toArray(txs);
+      const processedTxs = await Promise.all(txsArray.map(tx => mock<ProcessedTx>({ hash: tx.getTxHash() })));
+      return [processedTxs, [], txsArray, [], []];
+    });
+
+    const job = createJob({ parallelBlockLimit: 1 });
+    const runPromise = job.run();
+
+    await processStartedPromise;
+    await job.stop();
+    await runPromise;
+
+    expect(abortSignal?.aborted).toBe(true);
+    expect(job.getState()).toEqual('stopped');
+    expect(prover.addTxs).not.toHaveBeenCalled();
     expect(publisher.submitEpochProof).not.toHaveBeenCalled();
   });
 

--- a/yarn-project/prover-node/src/job/epoch-proving-job.ts
+++ b/yarn-project/prover-node/src/job/epoch-proving-job.ts
@@ -46,6 +46,7 @@ export class EpochProvingJob implements Traceable {
   private uuid: string;
 
   private runPromise: Promise<void> | undefined;
+  private abortController = new AbortController();
   private epochCheckPromise: RunningPromise | undefined;
   private deadlineTimeoutHandler: NodeJS.Timeout | undefined;
 
@@ -170,7 +171,7 @@ export class EpochProvingJob implements Traceable {
           ? AVM_MAX_CONCURRENT_SIMULATIONS
           : this.checkpoints.length;
 
-      await asyncPool(parallelism, this.checkpoints, async checkpoint => {
+      await this.processCheckpoints(parallelism, async checkpoint => {
         this.checkState();
         const checkpointTimer = new Timer();
 
@@ -228,22 +229,26 @@ export class EpochProvingJob implements Traceable {
 
           // Process public fns. L1 to L2 messages are only inserted for the first block of a checkpoint,
           // as the fork for subsequent blocks already includes them from the previous block's synced state.
-          const db = await this.createFork(
-            BlockNumber(block.number - 1),
-            blockIndex === 0 ? l1ToL2Messages : undefined,
-          );
-          const config = PublicSimulatorConfig.from({
-            proverId: this.prover.getProverId().toField(),
-            skipFeeEnforcement: false,
-            collectDebugLogs: false,
-            collectHints: true,
-            collectPublicInputs: true,
-            collectStatistics: false,
-          });
-          const publicProcessor = this.publicProcessorFactory.create(db, globalVariables, config);
-          const processed = await this.processTxs(publicProcessor, txs);
-          await this.prover.addTxs(processed);
-          await db.close();
+          {
+            await using db = await this.createFork(
+              BlockNumber(block.number - 1),
+              blockIndex === 0 ? l1ToL2Messages : undefined,
+            );
+            this.checkState();
+            const config = PublicSimulatorConfig.from({
+              proverId: this.prover.getProverId().toField(),
+              skipFeeEnforcement: false,
+              collectDebugLogs: false,
+              collectHints: true,
+              collectPublicInputs: true,
+              collectStatistics: false,
+            });
+            const publicProcessor = this.publicProcessorFactory.create(db, globalVariables, config);
+            const processed = await this.processTxs(publicProcessor, txs);
+            this.checkState();
+            await this.prover.addTxs(processed);
+          }
+          this.checkState();
           this.log.verbose(`Processed all ${txs.length} txs for block ${block.number}`, {
             blockNumber: block.number,
             blockHash: (await block.hash()).toString(),
@@ -337,7 +342,9 @@ export class EpochProvingJob implements Traceable {
    */
   private async createFork(blockNumber: BlockNumber, l1ToL2Messages: Fr[] | undefined) {
     this.log.verbose(`Creating fork at ${blockNumber}`, { blockNumber });
-    const db = await this.dbProvider.fork(blockNumber);
+    // temporary stack to control fork lifetime
+    await using cleanup = new AsyncDisposableStack();
+    const db = cleanup.use(await this.dbProvider.fork(blockNumber));
 
     if (l1ToL2Messages !== undefined) {
       this.log.verbose(`Inserting ${l1ToL2Messages.length} L1 to L2 messages in fork`, {
@@ -347,7 +354,42 @@ export class EpochProvingJob implements Traceable {
       await appendL1ToL2MessagesToTree(db, l1ToL2Messages);
     }
 
+    // everything run succesfully so we can release this stack and give control of the fork's lifetime to the caller
+    cleanup.move();
     return db;
+  }
+
+  private async processCheckpoints(
+    parallelism: number,
+    processCheckpoint: (checkpoint: Checkpoint) => Promise<void>,
+  ): Promise<void> {
+    let hasError = false;
+    let firstError: unknown;
+
+    await asyncPool(Math.max(parallelism, 1), this.checkpoints, async checkpoint => {
+      if (hasError || this.abortController.signal.aborted) {
+        return;
+      }
+
+      try {
+        this.checkState();
+        await processCheckpoint(checkpoint);
+      } catch (err) {
+        if (!hasError) {
+          hasError = true;
+          firstError = err;
+          this.failProcessing();
+        }
+      }
+    });
+
+    if (hasError) {
+      throw firstError;
+    }
+
+    if (this.abortController.signal.aborted) {
+      this.checkState();
+    }
   }
 
   private progressState(state: EpochProvingJobState) {
@@ -363,10 +405,22 @@ export class EpochProvingJob implements Traceable {
 
   public async stop(state: EpochProvingJobTerminalState = 'stopped') {
     this.state = state;
-    this.prover.cancel();
+    this.interruptProcessing();
     if (this.runPromise) {
       await this.runPromise;
     }
+  }
+
+  private failProcessing() {
+    if (!EpochProvingJobTerminalState.includes(this.state)) {
+      this.state = 'failed';
+    }
+    this.interruptProcessing();
+  }
+
+  private interruptProcessing() {
+    this.abortController.abort();
+    this.prover.cancel();
   }
 
   private scheduleDeadlineStop() {
@@ -444,7 +498,11 @@ export class EpochProvingJob implements Traceable {
 
   private async processTxs(publicProcessor: PublicProcessor, txs: Tx[]): Promise<ProcessedTx[]> {
     const { deadline } = this;
-    const [processedTxs, failedTxs] = await publicProcessor.process(txs, { deadline });
+    const [processedTxs, failedTxs] = await publicProcessor.process(txs, {
+      deadline,
+      signal: this.abortController.signal,
+    });
+    this.checkState();
 
     if (failedTxs.length) {
       const failedTxHashes = await Promise.all(failedTxs.map(({ tx }) => tx.getTxHash()));

--- a/yarn-project/simulator/src/public/public_processor/public_processor.test.ts
+++ b/yarn-project/simulator/src/public/public_processor/public_processor.test.ts
@@ -21,14 +21,14 @@ import { strict as assert } from 'assert';
 import { type MockProxy, mock } from 'jest-mock-extended';
 
 import { PublicContractsDB } from '../public_db_sources.js';
-import type { PublicTxSimulator } from '../public_tx_simulator/public_tx_simulator.js';
+import type { PublicTxSimulatorInterface } from '../public_tx_simulator/index.js';
 import { GuardedMerkleTreeOperations } from './guarded_merkle_tree.js';
 import { PublicProcessor } from './public_processor.js';
 
 describe('public_processor', () => {
   let merkleTree: MockProxy<MerkleTreeWriteOperations>;
   let contractsDB: PublicContractsDB;
-  let publicTxSimulator: MockProxy<PublicTxSimulator>;
+  let publicTxSimulator: MockProxy<Required<PublicTxSimulatorInterface>>;
 
   let mockedEnqueuedCallsResult: PublicTxResult;
 
@@ -78,7 +78,7 @@ describe('public_processor', () => {
   beforeEach(() => {
     merkleTree = mock<MerkleTreeWriteOperations>();
     contractsDB = new PublicContractsDB(mock<ContractDataSource>());
-    publicTxSimulator = mock();
+    publicTxSimulator = mock<Required<PublicTxSimulatorInterface>>();
 
     const stateReference = StateReference.empty();
     mockedEnqueuedCallsResult = PublicTxResult.empty();
@@ -237,6 +237,32 @@ describe('public_processor', () => {
 
       expect(processed).toEqual([]);
       expect(failed.length).toBe(1);
+    });
+
+    it('aborts in-flight tx processing and cancels the simulator', async function () {
+      const tx = await mockTxWithPublicCalls();
+      const controller = new AbortController();
+
+      let finishSimulation!: () => void;
+      const simulationFinished = new Promise<void>(resolve => {
+        finishSimulation = resolve;
+      });
+
+      publicTxSimulator.simulate.mockImplementation(async () => {
+        controller.abort();
+        await simulationFinished;
+        return mockedEnqueuedCallsResult;
+      });
+      publicTxSimulator.cancel.mockImplementation(() => {
+        finishSimulation();
+        return Promise.resolve();
+      });
+
+      const [processed, failed] = await processor.process([tx], { signal: controller.signal });
+
+      expect(processed).toEqual([]);
+      expect(failed).toEqual([]);
+      expect(publicTxSimulator.cancel).toHaveBeenCalled();
     });
 
     // Flakey timing test that's totally dependent on system load/architecture etc.

--- a/yarn-project/simulator/src/public/public_processor/public_processor.ts
+++ b/yarn-project/simulator/src/public/public_processor/public_processor.ts
@@ -3,7 +3,7 @@ import { padArrayEnd } from '@aztec/foundation/collection';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { type Logger, type LoggerBindings, createLogger } from '@aztec/foundation/log';
 import { sleep } from '@aztec/foundation/sleep';
-import { DateProvider, Timer, elapsed, executeTimeout } from '@aztec/foundation/timer';
+import { DateProvider, Timer, elapsed, execWithSignal } from '@aztec/foundation/timer';
 import { ProtocolContractAddress } from '@aztec/protocol-contracts';
 import { ContractClassPublishedEvent } from '@aztec/protocol-contracts/class-registry';
 import { computeFeePayerBalanceLeafSlot, computeFeePayerBalanceStorageSlot } from '@aztec/protocol-contracts/fee-juice';
@@ -123,6 +123,17 @@ class PublicProcessorTimeoutError extends Error {
   }
 }
 
+class PublicProcessorAbortError extends Error {
+  constructor(message: string = 'Aborted while processing tx') {
+    super(message);
+    this.name = 'PublicProcessorAbortError';
+  }
+}
+
+function isPublicProcessorInterruptError(err: any) {
+  return err?.name === 'PublicProcessorTimeoutError' || err?.name === 'PublicProcessorAbortError';
+}
+
 /**
  * Converts Txs lifted from the P2P module into ProcessedTx objects by executing
  * any public function calls in them. Txs with private calls only are unaffected.
@@ -159,7 +170,7 @@ export class PublicProcessor implements Traceable {
     limits: PublicProcessorLimits = {},
     validator: PublicProcessorValidator = {},
   ): Promise<[ProcessedTx[], FailedTx[], Tx[], NestedProcessReturnValues[], DebugLog[]]> {
-    const { maxTransactions, deadline, maxBlockGas, maxBlobFields, isBuildingProposal } = limits;
+    const { maxTransactions, deadline, maxBlockGas, maxBlobFields, isBuildingProposal, signal } = limits;
     const { preprocessValidator, nullifierCache } = validator;
     const result: ProcessedTx[] = [];
     const usedTxs: Tx[] = [];
@@ -182,9 +193,13 @@ export class PublicProcessor implements Traceable {
         break;
       }
 
-      // Bail if we've hit the deadline
+      // Bail if we've hit the deadline or have been interrupted.
       if (deadline && this.dateProvider.now() > +deadline) {
         this.log.warn(`Stopping tx processing due to timeout.`);
+        break;
+      }
+      if (signal?.aborted) {
+        this.log.warn(`Stopping tx processing due to abort signal.`);
         break;
       }
 
@@ -240,7 +255,7 @@ export class PublicProcessor implements Traceable {
 
       try {
         const [txProcessingTimeMs, [processedTx, returnValues, txDebugLogs]] = await elapsed(() =>
-          this.processTx(tx, deadline),
+          this.processTx(tx, deadline, signal),
         );
 
         // Inject a fake processing failure after N txs if requested
@@ -311,15 +326,11 @@ export class PublicProcessor implements Traceable {
         // Commit the tx-level contracts checkpoint on success
         this.contractsDB.commitCheckpoint();
       } catch (err: any) {
-        if (err?.name === 'PublicProcessorTimeoutError') {
-          this.log.warn(`Stopping tx processing due to timeout.`);
-          // We hit the transaction execution deadline.
-          // There may still be a transaction executing on a worker thread (C++ via NAPI).
-          // Signal cancellation AND WAIT for the simulation to actually stop.
-          // This is critical because C++ might be in the middle of a slow operation (e.g., pad_trees)
-          // and won't check the cancellation flag until that operation completes.
-          // Without waiting, we'd proceed to revert checkpoints while C++ is still writing to state.
-          // Wait for C++ to stop gracefully.
+        if (isPublicProcessorInterruptError(err)) {
+          const interruptReason = err.name === 'PublicProcessorTimeoutError' ? 'timeout' : 'abort signal';
+          this.log.warn(`Stopping tx processing due to ${interruptReason}.`);
+          // The tx may still be executing on a worker thread (C++ via NAPI).
+          // Signal cancellation AND WAIT for the simulation to actually stop before touching fork checkpoints.
           await this.publicTxSimulator.cancel?.();
 
           // Now stop the guarded fork to prevent any further TS-side access to the world state.
@@ -407,9 +418,10 @@ export class PublicProcessor implements Traceable {
   private async processTx(
     tx: Tx,
     deadline: Date | undefined,
+    signal: AbortSignal | undefined,
   ): Promise<[ProcessedTx, NestedProcessReturnValues[], DebugLog[]]> {
     const [time, [processedTx, returnValues, debugLogs]] = await elapsed(() =>
-      this.processTxWithinDeadline(tx, deadline),
+      this.processTxWithinDeadline(tx, deadline, signal),
     );
 
     this.log.verbose(
@@ -463,10 +475,11 @@ export class PublicProcessor implements Traceable {
     this.metrics.recordTreeInsertions(Number(treeInsertionEnd - treeInsertionStart) / 1_000);
   }
 
-  /** Processes the given tx within deadline. Returns timeout if deadline is hit. */
+  /** Processes the given tx within deadline or until the signal is aborted. */
   private async processTxWithinDeadline(
     tx: Tx,
     deadline: Date | undefined,
+    signal: AbortSignal | undefined,
   ): Promise<[ProcessedTx, NestedProcessReturnValues[] | undefined, DebugLog[]]> {
     const innerProcessFn: () => Promise<[ProcessedTx, NestedProcessReturnValues[] | undefined, DebugLog[]]> =
       tx.hasPublicCalls() ? () => this.processTxWithPublicCalls(tx) : () => this.processPrivateOnlyTx(tx);
@@ -483,27 +496,38 @@ export class PublicProcessor implements Traceable {
           }
         : innerProcessFn;
 
-    if (!deadline) {
+    const processingSignal = this.getProcessingSignal(tx, deadline, signal);
+    if (!processingSignal) {
       return await processFn();
     }
 
-    const txHash = tx.getTxHash();
+    return await execWithSignal(
+      () => processFn(),
+      processingSignal,
+      signal =>
+        signal.reason?.name === 'TimeoutError' ? new PublicProcessorTimeoutError() : new PublicProcessorAbortError(),
+    );
+  }
+
+  private getProcessingSignal(tx: Tx, deadline: Date | undefined, signal: AbortSignal | undefined) {
+    if (!deadline) {
+      return signal;
+    }
+
     const timeout = +deadline - this.dateProvider.now();
     if (timeout <= 0) {
       throw new PublicProcessorTimeoutError();
     }
 
+    const txHash = tx.getTxHash();
     this.log.debug(`Processing tx ${txHash.toString()} within ${timeout}ms`, {
       deadline: deadline.toISOString(),
       now: new Date(this.dateProvider.now()).toISOString(),
       txHash,
     });
 
-    return await executeTimeout(
-      () => processFn(),
-      timeout,
-      () => new PublicProcessorTimeoutError(),
-    );
+    const timeoutSignal = AbortSignal.timeout(timeout);
+    return signal ? AbortSignal.any([signal, timeoutSignal]) : timeoutSignal;
   }
 
   /**

--- a/yarn-project/stdlib/src/interfaces/block-builder.ts
+++ b/yarn-project/stdlib/src/interfaces/block-builder.ts
@@ -45,6 +45,8 @@ export type PublicProcessorLimits = {
   maxBlobFields?: number;
   /** Deadline for processing the txs. Processor will stop as soon as it hits this time. */
   deadline?: Date;
+  /** Signal for interrupting processing before the deadline. */
+  signal?: AbortSignal;
   /** Whether this processor is building a proposal (as opposed to re-executing one). Skipping txs due to gas or blob limits is only done during proposal building. */
   isBuildingProposal?: boolean;
 };


### PR DESCRIPTION
Handle fork lifetime correctly around checkpoints that might be cancelled part way through processing.