### PR TITLE
fix(release-image): stamp stdlib/package.json with release version

### DIFF
--- a/release-image/Dockerfile
+++ b/release-image/Dockerfile
@@ -18,5 +18,8 @@ WORKDIR "/usr/src/yarn-project"
 # Ensure the correct version shows in aztec --version
 ARG VERSION
 RUN echo '{".": "'$VERSION'"}' > /usr/src/.release-please-manifest.json
+# Stamp the version into stdlib/package.json, which getPackageVersion() reads at runtime.
+RUN jq --arg v "$VERSION" '.version = $v' /usr/src/yarn-project/stdlib/package.json > /tmp/p.json \
+    && mv /tmp/p.json /usr/src/yarn-project/stdlib/package.json
 
 ENTRYPOINT ["node", "--no-warnings", "/usr/src/yarn-project/aztec/dest/bin/index.js"]


### PR DESCRIPTION
## Summary

The aztec node Docker image was returning `"dev"` from `getNodeVersion()` in 4.3.0-rc.1. Root cause: PR #22941 switched `getPackageVersion()` to read the version from `yarn-project/stdlib/package.json`, but `release-image/Dockerfile` was only updated to stamp `.release-please-manifest.json` (which the old implementation consumed). `stdlib/package.json` kept the `0.1.0` placeholder inside the image, which `getPackageVersion()` substitutes with `DEV_VERSION` (`"dev"`).

This adds a second stamp step in the Dockerfile that rewrites `.version` in `yarn-project/stdlib/package.json` using `jq` (already installed in the release-image base). The existing `.release-please-manifest.json` stamp is left alone for now since other tooling may still consume it.

Only `stdlib/package.json` needs stamping for the version-reporting bug: `getPackageVersion()` resolves `../../package.json` from `stdlib/dest/update-checker/`, so it always reads the stdlib package regardless of which CLI invokes it (`aztec --version`, `getNodeVersion`, contract-artifact stamping, etc).

The npm publish path is unaffected — `ci3/deploy_npm` already calls `ci3/release_prep_package_json` before `npm publish`, so npm consumers got the correct version all along. The Docker path was the only release surface that missed the rename.

## Test plan

- [ ] CI release-image build passes with the new `RUN jq …` step.
- [ ] Run the resulting image with `VERSION=4.3.0-rc.X` and confirm `aztec --version` and a node's `getNodeVersion` RPC both return the stamped version instead of `"dev"`.