### PR TITLE
fix(slasher): anchor watcher scans at archiver synced L2 slot

### DIFF
--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -756,6 +756,7 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, AztecNodeDeb
         if (config.slashBroadcastedInvalidCheckpointProposalPenalty > 0n) {
           broadcastedInvalidCheckpointProposalWatcher = new BroadcastedInvalidCheckpointProposalWatcher(
             p2pClient,
+            archiver,
             epochCache,
             config,
           );

--- a/yarn-project/aztec-node/src/sentinel/sentinel.test.ts
+++ b/yarn-project/aztec-node/src/sentinel/sentinel.test.ts
@@ -108,6 +108,32 @@ describe('sentinel', () => {
     await kvStore.close();
   });
 
+  describe('init', () => {
+    beforeEach(() => {
+      archiver.getBlockNumber.mockResolvedValue(BlockNumber(0));
+    });
+
+    it('floors initialSlot at the archiver synced L2 slot when available', async () => {
+      const syncedSlot = SlotNumber(7);
+      epochCache.getSlotNow.mockReturnValue(SlotNumber(20));
+      archiver.getSyncedL2SlotNumber.mockResolvedValue(syncedSlot);
+
+      await sentinel.callProductionInit();
+
+      expect(sentinel.getInitialSlot()).toEqual(syncedSlot);
+    });
+
+    it('falls back to the wallclock slot when the archiver is not yet synced', async () => {
+      const wallclockSlot = SlotNumber(20);
+      epochCache.getSlotNow.mockReturnValue(wallclockSlot);
+      archiver.getSyncedL2SlotNumber.mockResolvedValue(undefined);
+
+      await sentinel.callProductionInit();
+
+      expect(sentinel.getInitialSlot()).toEqual(wallclockSlot);
+    });
+  });
+
   describe('getSlotActivity', () => {
     let signers: Secp256k1Signer[];
     let validators: EthAddress[];
@@ -1002,6 +1028,11 @@ class TestSentinel extends Sentinel {
   public override init() {
     this.initialSlot = this.epochCache.getEpochAndSlotNow().slot;
     return Promise.resolve();
+  }
+
+  /** Invokes the production Sentinel.init() so tests can assert its initialSlot logic. */
+  public callProductionInit() {
+    return super.init();
   }
 
   public override getSlotActivity(slot: SlotNumber, epoch: EpochNumber, proposer: EthAddress, committee: EthAddress[]) {

--- a/yarn-project/aztec-node/src/sentinel/sentinel.ts
+++ b/yarn-project/aztec-node/src/sentinel/sentinel.ts
@@ -377,8 +377,7 @@ export class Sentinel extends (EventEmitter as new () => WatcherEmitter) impleme
    *
    * `currentSlot` is anchored to the archiver's last synced L2 slot rather than the wallclock,
    * so the per-slot lag (`isReadyToProcess`) and the end-of-epoch buffer (`processEpochEnds`)
-   * advance with archiver progress and don't speculate ahead of where L1 actually is. Falls
-   * back to the wallclock if the archiver isn't ready yet (cold start).
+   * advance with archiver.
    */
   public async work() {
     const currentSlot = await this.getCurrentSlot();

--- a/yarn-project/aztec-node/src/sentinel/sentinel.ts
+++ b/yarn-project/aztec-node/src/sentinel/sentinel.ts
@@ -185,12 +185,29 @@ export class Sentinel extends (EventEmitter as new () => WatcherEmitter) impleme
     this.runningPromise.start();
   }
 
-  /** Loads initial slot and initializes blockstream. We will not process anything at or before the initial slot. */
+  /**
+   * Loads initial slot and initializes blockstream. We will not process anything at or before
+   * the initial slot. Floors at the archiver's synced L2 slot so the sentinel keeps making
+   * forward progress when L1 is advancing but L2 has no activity (the synced slot is driven by
+   * L1 sync, not by L2 blocks). Falls back to the wallclock if the archiver isn't ready yet
+   * (cold start).
+   */
   protected async init() {
-    this.initialSlot = this.epochCache.getSlotNow();
+    this.initialSlot = await this.getCurrentSlot();
     const startingBlock = BlockNumber(await this.archiver.getBlockNumber());
     this.logger.info(`Starting validator sentinel with initial slot ${this.initialSlot} and block ${startingBlock}`);
     this.blockStream = new L2BlockStream(this.archiver, this.l2TipsStore, this, this.logger, { startingBlock });
+  }
+
+  /**
+   * Returns the L2 slot the sentinel should treat as "current": the archiver's last fully
+   * synced L2 slot, falling back to the wallclock slot when the archiver isn't ready yet
+   * (cold start). Anchoring to the synced slot keeps timing arithmetic (initial floor,
+   * per-slot lag, end-of-epoch buffer, stats-range fallback) from speculating ahead of where
+   * L1 actually is.
+   */
+  protected async getCurrentSlot(): Promise<SlotNumber> {
+    return (await this.archiver.getSyncedL2SlotNumber()) ?? this.epochCache.getSlotNow();
   }
 
   public stop() {
@@ -357,9 +374,14 @@ export class Sentinel extends (EventEmitter as new () => WatcherEmitter) impleme
    * Process data for two L2 slots ago.
    * Note that we do not process historical data, since we rely on p2p data for processing,
    * and we don't have that data if we were offline during the period.
+   *
+   * `currentSlot` is anchored to the archiver's last synced L2 slot rather than the wallclock,
+   * so the per-slot lag (`isReadyToProcess`) and the end-of-epoch buffer (`processEpochEnds`)
+   * advance with archiver progress and don't speculate ahead of where L1 actually is. Falls
+   * back to the wallclock if the archiver isn't ready yet (cold start).
    */
   public async work() {
-    const currentSlot = this.epochCache.getSlotNow();
+    const currentSlot = await this.getCurrentSlot();
     try {
       // Manually sync the block stream to ensure we have the latest data.
       // Note we never `start` the blockstream, so it loops at the same pace as we do.
@@ -592,7 +614,7 @@ export class Sentinel extends (EventEmitter as new () => WatcherEmitter) impleme
       ? fromEntries(await Promise.all(validators.map(async v => [v.toString(), await this.store.getHistory(v)])))
       : await this.store.getHistories();
 
-    const slotNow = this.epochCache.getSlotNow();
+    const slotNow = await this.getCurrentSlot();
     fromSlot ??= SlotNumber(Math.max((this.lastProcessedSlot ?? slotNow) - this.store.getHistoryLength(), 0));
     toSlot ??= this.lastProcessedSlot ?? slotNow;
 
@@ -620,7 +642,7 @@ export class Sentinel extends (EventEmitter as new () => WatcherEmitter) impleme
       return undefined;
     }
 
-    const slotNow = this.epochCache.getSlotNow();
+    const slotNow = await this.getCurrentSlot();
     const effectiveFromSlot =
       fromSlot ?? SlotNumber(Math.max((this.lastProcessedSlot ?? slotNow) - this.store.getHistoryLength(), 0));
     const effectiveToSlot = toSlot ?? this.lastProcessedSlot ?? slotNow;

--- a/yarn-project/slasher/src/watchers/broadcasted_invalid_checkpoint_proposal_watcher.test.ts
+++ b/yarn-project/slasher/src/watchers/broadcasted_invalid_checkpoint_proposal_watcher.test.ts
@@ -2,6 +2,7 @@ import type { EpochCacheInterface } from '@aztec/epoch-cache';
 import { IndexWithinCheckpoint, SlotNumber } from '@aztec/foundation/branded-types';
 import { Secp256k1Signer } from '@aztec/foundation/crypto/secp256k1-signer';
 import { Fr } from '@aztec/foundation/curves/bn254';
+import type { L2BlockSource } from '@aztec/stdlib/block';
 import { EmptyL1RollupConstants } from '@aztec/stdlib/epoch-helpers';
 import type { P2PClient } from '@aztec/stdlib/interfaces/server';
 import type { BlockProposal, CheckpointProposalCore } from '@aztec/stdlib/p2p';
@@ -22,15 +23,18 @@ import { BroadcastedInvalidCheckpointProposalWatcher } from './broadcasted_inval
 
 describe('BroadcastedInvalidCheckpointProposalWatcher', () => {
   let p2pClient: MockProxy<Pick<P2PClient, 'getProposalsForSlot'>>;
-  let epochCache: MockProxy<Pick<EpochCacheInterface, 'getCurrentAndNextSlot' | 'getL1Constants'>>;
+  let l2BlockSource: MockProxy<Pick<L2BlockSource, 'getSyncedL2SlotNumber'>>;
+  let epochCache: MockProxy<Pick<EpochCacheInterface, 'getSlotNow' | 'getL1Constants'>>;
   let config: SlasherConfig;
   let watcher: BroadcastedInvalidCheckpointProposalWatcher;
   let handler: jest.MockedFunction<(args: WantToSlashArgs[]) => void>;
 
   beforeEach(() => {
     p2pClient = mock<Pick<P2PClient, 'getProposalsForSlot'>>();
-    epochCache = mock<Pick<EpochCacheInterface, 'getCurrentAndNextSlot' | 'getL1Constants'>>();
-    epochCache.getCurrentAndNextSlot.mockReturnValue({ currentSlot: SlotNumber(12), nextSlot: SlotNumber(13) });
+    l2BlockSource = mock<Pick<L2BlockSource, 'getSyncedL2SlotNumber'>>();
+    l2BlockSource.getSyncedL2SlotNumber.mockResolvedValue(SlotNumber(12));
+    epochCache = mock<Pick<EpochCacheInterface, 'getSlotNow' | 'getL1Constants'>>();
+    epochCache.getSlotNow.mockReturnValue(SlotNumber(12));
     epochCache.getL1Constants.mockReturnValue({
       ...EmptyL1RollupConstants,
       epochDuration: 8,
@@ -40,7 +44,7 @@ describe('BroadcastedInvalidCheckpointProposalWatcher', () => {
       ...DefaultSlasherConfig,
       slashBroadcastedInvalidCheckpointProposalPenalty: 11n,
     };
-    watcher = new BroadcastedInvalidCheckpointProposalWatcher(p2pClient, epochCache, config, 4);
+    watcher = new BroadcastedInvalidCheckpointProposalWatcher(p2pClient, l2BlockSource, epochCache, config, 4);
     handler = jest.fn();
     watcher.on(WANT_TO_SLASH_EVENT, handler);
   });
@@ -218,12 +222,61 @@ describe('BroadcastedInvalidCheckpointProposalWatcher', () => {
     expect(handler).toHaveBeenCalledTimes(1);
   });
 
+  it('anchors the scan at the archiver synced L2 slot, not the wallclock', async () => {
+    p2pClient.getProposalsForSlot.mockResolvedValue({ blockProposals: [], checkpointProposals: [] });
+    l2BlockSource.getSyncedL2SlotNumber.mockResolvedValue(SlotNumber(9));
+    epochCache.getSlotNow.mockReturnValue(SlotNumber(20));
+
+    await watcher.scan();
+
+    expect(p2pClient.getProposalsForSlot.mock.calls.map(([slot]) => slot)).toEqual([
+      SlotNumber(4),
+      SlotNumber(5),
+      SlotNumber(6),
+      SlotNumber(7),
+    ]);
+  });
+
+  it('falls back to the wallclock when the archiver has not yet synced', async () => {
+    p2pClient.getProposalsForSlot.mockResolvedValue({ blockProposals: [], checkpointProposals: [] });
+    l2BlockSource.getSyncedL2SlotNumber.mockResolvedValue(undefined);
+    epochCache.getSlotNow.mockReturnValue(SlotNumber(12));
+
+    await watcher.scan();
+
+    expect(p2pClient.getProposalsForSlot.mock.calls.map(([slot]) => slot)).toEqual([
+      SlotNumber(7),
+      SlotNumber(8),
+      SlotNumber(9),
+      SlotNumber(10),
+    ]);
+  });
+
+  it('does not expand the scan window when L1 stalls but wallclock keeps moving', async () => {
+    p2pClient.getProposalsForSlot.mockResolvedValue({ blockProposals: [], checkpointProposals: [] });
+    l2BlockSource.getSyncedL2SlotNumber.mockResolvedValue(SlotNumber(12));
+    epochCache.getSlotNow.mockReturnValue(SlotNumber(12));
+
+    await watcher.scan();
+    p2pClient.getProposalsForSlot.mockClear();
+    epochCache.getSlotNow.mockReturnValue(SlotNumber(50));
+
+    await watcher.scan();
+
+    expect(p2pClient.getProposalsForSlot.mock.calls.map(([slot]) => slot)).toEqual([
+      SlotNumber(7),
+      SlotNumber(8),
+      SlotNumber(9),
+      SlotNumber(10),
+    ]);
+  });
+
   it('only expands beyond the lookback for newly closed slots', async () => {
     p2pClient.getProposalsForSlot.mockResolvedValue({ blockProposals: [], checkpointProposals: [] });
 
     await watcher.scan();
     p2pClient.getProposalsForSlot.mockClear();
-    epochCache.getCurrentAndNextSlot.mockReturnValue({ currentSlot: SlotNumber(13), nextSlot: SlotNumber(14) });
+    l2BlockSource.getSyncedL2SlotNumber.mockResolvedValue(SlotNumber(13));
 
     await watcher.scan();
 

--- a/yarn-project/slasher/src/watchers/broadcasted_invalid_checkpoint_proposal_watcher.ts
+++ b/yarn-project/slasher/src/watchers/broadcasted_invalid_checkpoint_proposal_watcher.ts
@@ -79,10 +79,7 @@ export class BroadcastedInvalidCheckpointProposalWatcher
 
   /**
    * Scans newly closed slots, plus a small lookback for late-arriving proposals. Anchors
-   * `currentSlot` at the archiver's last synced L2 slot rather than the wallclock so the scan
-   * doesn't speculate ahead of where L1 has actually closed (e.g. an L1 stall would otherwise
-   * cause us to walk slots whose L1 windows haven't ingested yet). Falls back to the wallclock
-   * if the archiver isn't ready (cold start).
+   * `currentSlot` at the archiver's last synced L2 slot.
    */
   public async scan(): Promise<void> {
     if (this.config.slashBroadcastedInvalidCheckpointProposalPenalty <= 0n) {

--- a/yarn-project/slasher/src/watchers/broadcasted_invalid_checkpoint_proposal_watcher.ts
+++ b/yarn-project/slasher/src/watchers/broadcasted_invalid_checkpoint_proposal_watcher.ts
@@ -4,6 +4,7 @@ import { merge, pick } from '@aztec/foundation/collection';
 import type { EthAddress } from '@aztec/foundation/eth-address';
 import { type Logger, createLogger } from '@aztec/foundation/log';
 import { RunningPromise } from '@aztec/foundation/running-promise';
+import type { L2BlockSource } from '@aztec/stdlib/block';
 import type { P2PClient, SlasherConfig } from '@aztec/stdlib/interfaces/server';
 import type { BlockProposal, CheckpointProposalCore } from '@aztec/stdlib/p2p';
 import { OffenseType } from '@aztec/stdlib/slashing';
@@ -46,7 +47,8 @@ export class BroadcastedInvalidCheckpointProposalWatcher
 
   constructor(
     private readonly p2pClient: P2PProposalsForSlotSource,
-    private readonly epochCache: Pick<EpochCacheInterface, 'getCurrentAndNextSlot' | 'getL1Constants'>,
+    private readonly l2BlockSource: Pick<L2BlockSource, 'getSyncedL2SlotNumber'>,
+    private readonly epochCache: Pick<EpochCacheInterface, 'getSlotNow' | 'getL1Constants'>,
     config: BroadcastedInvalidCheckpointProposalWatcherConfig,
     scanSlotLookback = DEFAULT_SCAN_SLOT_LOOKBACK,
   ) {
@@ -75,13 +77,19 @@ export class BroadcastedInvalidCheckpointProposalWatcher
     return this.runningPromise.stop();
   }
 
-  /** Scans newly closed slots, plus a small lookback for late-arriving proposals. */
+  /**
+   * Scans newly closed slots, plus a small lookback for late-arriving proposals. Anchors
+   * `currentSlot` at the archiver's last synced L2 slot rather than the wallclock so the scan
+   * doesn't speculate ahead of where L1 has actually closed (e.g. an L1 stall would otherwise
+   * cause us to walk slots whose L1 windows haven't ingested yet). Falls back to the wallclock
+   * if the archiver isn't ready (cold start).
+   */
   public async scan(): Promise<void> {
     if (this.config.slashBroadcastedInvalidCheckpointProposalPenalty <= 0n) {
       return;
     }
 
-    const { currentSlot } = this.epochCache.getCurrentAndNextSlot();
+    const currentSlot = (await this.l2BlockSource.getSyncedL2SlotNumber()) ?? this.epochCache.getSlotNow();
     if (currentSlot <= SlotNumber(SCAN_SLOT_LAG)) {
       return;
     }


### PR DESCRIPTION
## Summary

A-709 audit found two slashing watchers that drove their periodic scans off the wallclock rather than the archiver's last fully-synced L2 slot. An L1 stall (e.g. the fusaka scenario) would let them speculate into slots whose L1 windows had not yet been ingested, producing false-positive slashes or scanning gaps. This PR moves both onto `archiver.getSyncedL2SlotNumber() ?? epochCache.getSlotNow()`, matching the pattern already in `DataWithholdingWatcher`.

## Changes

- `Sentinel` — all four `getSlotNow()` call sites (`init`, `work`, `computeStats`, `getValidatorStats`) now go through a new `getCurrentSlot()` helper that prefers the archiver synced slot, with wallclock fallback only at cold start. The redundant synced gate inside `isReadyToProcess` is kept as a defensive guard for the fallback path.
- `BroadcastedInvalidCheckpointProposalWatcher` — constructor now takes a `Pick<L2BlockSource, 'getSyncedL2SlotNumber'>` (wired to `archiver` at the construction site); `scan()` uses it instead of `epochCache.getCurrentAndNextSlot()`.

## Audit

Other `WANT_TO_SLASH` emitters were checked and already synced-safe:

- `DataWithholdingWatcher` — already uses synced slot.
- `AttestationsBlockWatcher` — event-driven from archiver `InvalidAttestationsCheckpointDetected`.
- `validator-client` emitters (`BROADCASTED_INVALID_BLOCK_PROPOSAL`, `ATTESTED_TO_INVALID_CHECKPOINT_PROPOSAL`, `DUPLICATE_PROPOSAL`, `DUPLICATE_ATTESTATION`) — event-driven from live p2p observations.

## Test plan

- Sentinel: added a new `describe('init')` with two red/green cases covering synced-slot floor and wallclock fallback. Red/green verified.
- Watcher: added three new tests — anchors at synced slot, falls back to wallclock when synced is undefined, does not expand window when L1 stalls but wallclock keeps moving. Red/green verified by surgically reverting the synced-slot read.
- Full sentinel suite (48 tests) and watcher suite (12 tests) pass; `slasher` and `aztec-node` TypeScript builds clean.