### PR TITLE
fix: avoid npm uplink for aztec-up local publishes

### DIFF
--- a/aztec-up/bootstrap.sh
+++ b/aztec-up/bootstrap.sh
@@ -29,6 +29,11 @@ uplinks:
     url: https://registry.npmjs.org/
 
 packages:
+  "@aztec/*":
+    access: \$all
+    publish: \$all
+    unpublish: \$all
+
   "@*/*":
     access: \$all
     publish: \$all

--- a/aztec-up/bootstrap.sh
+++ b/aztec-up/bootstrap.sh
@@ -20,6 +20,9 @@ function build {
   echo
 
   # Create Verdaccio config.
+  # publish.allow_offline lets verdaccio accept publishes when the npmjs
+  # uplink is briefly unreachable, instead of returning 503. We never want
+  # the upstream existence check to gate these local fake-publishes.
   cat > /tmp/verdaccio-config.yaml <<EOF
 storage: $PWD/verdaccio-storage
 max_body_size: 1000mb
@@ -28,7 +31,18 @@ uplinks:
   npmjs:
     url: https://registry.npmjs.org/
 
+publish:
+  allow_offline: true
+
 packages:
+  # @aztec/viem is a third-party fork published to npm, not built locally.
+  # Match it before @aztec/* so it falls through to the npmjs uplink.
+  "@aztec/viem":
+    access: \$all
+    publish: \$all
+    unpublish: \$all
+    proxy: npmjs
+
   "@aztec/*":
     access: \$all
     publish: \$all


### PR DESCRIPTION
Summary:
- Keep @aztec/* local in the aztec-up Verdaccio build registry so publishing Aztec packages does not depend on npmjs uplink health.
- Continue proxying other scoped and unscoped packages to npmjs for dependency cache priming.

CI failure investigated:
- PR #23344 failed ./bootstrap.sh, ci/x-full-no-test-cache, and npm publish contexts.
- Downloaded logs with yarn ci dlog: f5535395aab63996, 1779189592567743, and 51444ba79e6c8a4a.
- The direct npm publish log failed with E503: one of the uplinks is down, refuse to publish, while publishing @aztec/protocol-contracts to local Verdaccio.

Validation:
- bash -n aztec-up/bootstrap.sh