### PR TITLE
refactor(pxe)!: drop V1 oracle remnants, simplify nullifier witness

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/oracle/get_membership_witness.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/get_membership_witness.nr
@@ -11,7 +11,7 @@ unconstrained fn get_note_hash_membership_witness_oracle(
     note_hash: Field,
 ) -> MembershipWitness<NOTE_HASH_TREE_HEIGHT> {}
 
-#[oracle(aztec_utl_getBlockHashMembershipWitnessV2)]
+#[oracle(aztec_utl_getBlockHashMembershipWitness)]
 unconstrained fn get_block_hash_membership_witness_oracle(
     anchor_block_hash: Field,
     block_hash: Field,

--- a/noir-projects/aztec-nr/aztec/src/oracle/get_nullifier_membership_witness.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/get_nullifier_membership_witness.nr
@@ -2,32 +2,14 @@ use crate::protocol::{
     abis::{block_header::BlockHeader, nullifier_leaf_preimage::NullifierLeafPreimage},
     constants::NULLIFIER_TREE_HEIGHT,
     merkle_tree::MembershipWitness,
-    traits::{Deserialize, Hash, Serialize},
+    traits::Hash,
 };
-
-// This internal type matches the oracle response. This module's functions (e.g.
-// [`get_low_nullifier_membership_witness`]) wrap the oracle call and convert this into their respective
-// return types.
-// TODO(F-554): Remove once the TypeScript side serializes preimage and witness separately, as an
-// oracle interface breaking change.
-#[derive(Deserialize, Eq, Serialize)]
-struct RawNullifierMembershipWitness {
-    index: Field,
-    leaf_preimage: NullifierLeafPreimage,
-    path: [Field; NULLIFIER_TREE_HEIGHT],
-}
-
-impl RawNullifierMembershipWitness {
-    fn into_split(self) -> (NullifierLeafPreimage, MembershipWitness<NULLIFIER_TREE_HEIGHT>) {
-        (self.leaf_preimage, MembershipWitness { leaf_index: self.index, sibling_path: self.path })
-    }
-}
 
 #[oracle(aztec_utl_getLowNullifierMembershipWitness)]
 unconstrained fn get_low_nullifier_membership_witness_oracle(
     _block_hash: Field,
     _nullifier: Field,
-) -> RawNullifierMembershipWitness {}
+) -> (NullifierLeafPreimage, MembershipWitness<NULLIFIER_TREE_HEIGHT>) {}
 
 /// Returns a leaf preimage and membership witness for the low nullifier of `nullifier` in the nullifier tree whose
 /// root is defined in `block_header`.
@@ -40,14 +22,14 @@ pub unconstrained fn get_low_nullifier_membership_witness(
     nullifier: Field,
 ) -> (NullifierLeafPreimage, MembershipWitness<NULLIFIER_TREE_HEIGHT>) {
     let block_hash = block_header.hash();
-    get_low_nullifier_membership_witness_oracle(block_hash, nullifier).into_split()
+    get_low_nullifier_membership_witness_oracle(block_hash, nullifier)
 }
 
 #[oracle(aztec_utl_getNullifierMembershipWitness)]
 unconstrained fn get_nullifier_membership_witness_oracle(
     _block_hash: Field,
     _nullifier: Field,
-) -> RawNullifierMembershipWitness {}
+) -> (NullifierLeafPreimage, MembershipWitness<NULLIFIER_TREE_HEIGHT>) {}
 
 /// Returns a leaf preimage and membership witness for `nullifier` in the nullifier tree whose root is defined in
 /// `block_header`.
@@ -58,5 +40,5 @@ pub unconstrained fn get_nullifier_membership_witness(
     nullifier: Field,
 ) -> (NullifierLeafPreimage, MembershipWitness<NULLIFIER_TREE_HEIGHT>) {
     let block_hash = block_header.hash();
-    get_nullifier_membership_witness_oracle(block_hash, nullifier).into_split()
+    get_nullifier_membership_witness_oracle(block_hash, nullifier)
 }

--- a/noir-projects/aztec-nr/aztec/src/oracle/version.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/version.nr
@@ -10,7 +10,7 @@
 /// the PXE and used to provide helpful error messages if a contract calls an oracle that doesn't exist. We don't throw
 /// immediately if AZTEC_NR_MINOR > PXE_MINOR because if a contract is updated to use a newer Aztec.nr dependency
 /// without actually using any of the new oracles then there is no reason to throw.
-pub global ORACLE_VERSION_MAJOR: Field = 24;
+pub global ORACLE_VERSION_MAJOR: Field = 25;
 pub global ORACLE_VERSION_MINOR: Field = 0;
 
 /// Asserts that the version of the oracle is compatible with the version expected by the contract.
@@ -26,7 +26,7 @@ unconstrained fn assert_compatible_oracle_version_wrapper() {
     assert_compatible_oracle_version_oracle(ORACLE_VERSION_MAJOR, ORACLE_VERSION_MINOR);
 }
 
-#[oracle(aztec_utl_assertCompatibleOracleVersionV2)]
+#[oracle(aztec_utl_assertCompatibleOracleVersion)]
 unconstrained fn assert_compatible_oracle_version_oracle(major: Field, minor: Field) {}
 
 mod test {

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment/test/misc.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment/test/misc.nr
@@ -45,7 +45,7 @@ unconstrained fn private_public_and_utility_context_share_default_chain_id() {
 
 #[test]
 unconstrained fn oracle_version_is_checked_upon_env_creation() {
-    let mock = OracleMock::mock("aztec_utl_assertCompatibleOracleVersionV2");
+    let mock = OracleMock::mock("aztec_utl_assertCompatibleOracleVersion");
 
     let _env = TestEnvironment::new();
 

--- a/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/oracle/version.nr
+++ b/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/oracle/version.nr
@@ -10,7 +10,7 @@
 /// the PXE and used to provide helpful error messages if a contract calls an oracle that doesn't exist. We don't throw
 /// immediately if AZTEC_NR_MINOR > PXE_MINOR because if a contract is updated to use a newer Aztec.nr dependency
 /// without actually using any of the new oracles then there is no reason to throw.
-pub global ORACLE_VERSION_MAJOR: Field = 24;
+pub global ORACLE_VERSION_MAJOR: Field = 25;
 pub global ORACLE_VERSION_MINOR: Field = 0;
 
 /// Asserts that the version of the oracle is compatible with the version expected by the contract.
@@ -26,7 +26,7 @@ unconstrained fn assert_compatible_oracle_version_wrapper() {
     assert_compatible_oracle_version_oracle(ORACLE_VERSION_MAJOR, ORACLE_VERSION_MINOR);
 }
 
-#[oracle(aztec_utl_assertCompatibleOracleVersionV2)]
+#[oracle(aztec_utl_assertCompatibleOracleVersion)]
 unconstrained fn assert_compatible_oracle_version_oracle(major: Field, minor: Field) {}
 
 mod test {

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/oracle.ts
@@ -177,7 +177,7 @@ export class Oracle {
   }
 
   // eslint-disable-next-line camelcase
-  aztec_utl_assertCompatibleOracleVersionV2([major]: ACVMField[], [minor]: ACVMField[]) {
+  aztec_utl_assertCompatibleOracleVersion([major]: ACVMField[], [minor]: ACVMField[]) {
     this.handlerAsMisc().assertCompatibleOracleVersion(
       Fr.fromString(major).toNumber(),
       Fr.fromString(minor).toNumber(),
@@ -246,27 +246,8 @@ export class Oracle {
     return witness.toNoirRepresentation();
   }
 
-  // TODO(https://linear.app/aztec-labs/issue/F-651): drop this
   // eslint-disable-next-line camelcase
   async aztec_utl_getBlockHashMembershipWitness(
-    [anchorBlockHash]: ACVMField[],
-    [blockHash]: ACVMField[],
-  ): Promise<(ACVMField | ACVMField[])[]> {
-    const parsedAnchorBlockHash = BlockHash.fromString(anchorBlockHash);
-    const parsedBlockHash = BlockHash.fromString(blockHash);
-
-    const witness = await this.handlerAsUtility().getBlockHashMembershipWitness(parsedAnchorBlockHash, parsedBlockHash);
-    if (!witness) {
-      throw new Error(
-        `Block hash ${parsedBlockHash.toString()} not found in the archive tree at anchor block ${parsedAnchorBlockHash.toString()}.`,
-      );
-    }
-    return witness.toNoirRepresentation();
-  }
-
-  // TODO(https://linear.app/aztec-labs/issue/F-651): rename to aztec_utl_getBlockHashMembershipWitness
-  // eslint-disable-next-line camelcase
-  async aztec_utl_getBlockHashMembershipWitnessV2(
     [anchorBlockHash]: ACVMField[],
     [blockHash]: ACVMField[],
   ): Promise<(ACVMField | ACVMField[])[]> {

--- a/yarn-project/pxe/src/oracle_version.ts
+++ b/yarn-project/pxe/src/oracle_version.ts
@@ -10,7 +10,7 @@
 /// used to provide helpful error messages if a contract calls an oracle that doesn't exist. We don't throw immediately
 /// if AZTEC_NR_MINOR > PXE_MINOR because if a contract is updated to use a newer Aztec.nr dependency without actually
 /// using any of the new oracles then there is no reason to throw.
-export const ORACLE_VERSION_MAJOR = 24;
+export const ORACLE_VERSION_MAJOR = 25;
 export const ORACLE_VERSION_MINOR = 0;
 
 /// This hash is computed from the Oracle interface and is used to detect when that interface changes. When it does,
@@ -19,4 +19,4 @@ export const ORACLE_VERSION_MINOR = 0;
 /// - increment only `ORACLE_VERSION_MINOR` if the change is additive (a new oracle was added).
 ///
 /// These constants must be kept in sync between this file and `noir-projects/aztec-nr/aztec/src/oracle/version.nr`.
-export const ORACLE_INTERFACE_HASH = '1555668cb0f79db50fe6e496488106594344a20bb1a9fa5d30374bed0070a761';
+export const ORACLE_INTERFACE_HASH = '47e38a49abc0fa5eaaa1f270a98b8e8c9d78e0f71099119ebf326aab354e4563';

--- a/yarn-project/stdlib/src/trees/nullifier_membership_witness.ts
+++ b/yarn-project/stdlib/src/trees/nullifier_membership_witness.ts
@@ -58,7 +58,7 @@ export class NullifierMembershipWitness {
    * @returns A field array representation of a nullifier witness.
    */
   public toFields(): Fr[] {
-    return [new Fr(this.index), ...this.leafPreimage.toFields(), ...this.siblingPath.toFields()];
+    return [...this.leafPreimage.toFields(), new Fr(this.index), ...this.siblingPath.toFields()];
   }
 
   /**
@@ -67,8 +67,8 @@ export class NullifierMembershipWitness {
   public toNoirRepresentation(): (string | string[])[] {
     // TODO(#12874): remove the stupid as string conversion by modifying ForeignCallOutput type in acvm.js
     return [
-      new Fr(this.index).toString() as string,
       ...(this.leafPreimage.toFields().map(fr => fr.toString()) as string[]),
+      new Fr(this.index).toString() as string,
       this.siblingPath.toFields().map(fr => fr.toString()) as string[],
     ];
   }

--- a/yarn-project/stdlib/src/trees/nullifier_membership_witness.ts
+++ b/yarn-project/stdlib/src/trees/nullifier_membership_witness.ts
@@ -58,7 +58,7 @@ export class NullifierMembershipWitness {
    * @returns A field array representation of a nullifier witness.
    */
   public toFields(): Fr[] {
-    return [...this.leafPreimage.toFields(), new Fr(this.index), ...this.siblingPath.toFields()];
+    return [new Fr(this.index), ...this.leafPreimage.toFields(), ...this.siblingPath.toFields()];
   }
 
   /**

--- a/yarn-project/stdlib/src/trees/nullifier_membership_witness.ts
+++ b/yarn-project/stdlib/src/trees/nullifier_membership_witness.ts
@@ -53,17 +53,7 @@ export class NullifierMembershipWitness {
     return new MembershipWitness(NULLIFIER_TREE_HEIGHT, this.index, this.siblingPath.toTuple());
   }
 
-  /**
-   * Returns a field array representation of a nullifier witness.
-   * @returns A field array representation of a nullifier witness.
-   */
-  public toFields(): Fr[] {
-    return [new Fr(this.index), ...this.leafPreimage.toFields(), ...this.siblingPath.toFields()];
-  }
-
-  /**
-   * Returns a representation of the nullifier membership witness as expected by intrinsic Noir deserialization.
-   */
+  /** Serializes as `(NullifierLeafPreimage, MembershipWitness)` to match the Noir oracle return type. */
   public toNoirRepresentation(): (string | string[])[] {
     // TODO(#12874): remove the stupid as string conversion by modifying ForeignCallOutput type in acvm.js
     return [

--- a/yarn-project/txe/src/rpc_translator.ts
+++ b/yarn-project/txe/src/rpc_translator.ts
@@ -302,7 +302,7 @@ export class RPCTranslator {
   // PXE oracles
 
   // eslint-disable-next-line camelcase
-  aztec_utl_assertCompatibleOracleVersionV2(foreignMajor: ForeignCallSingle, foreignMinor: ForeignCallSingle) {
+  aztec_utl_assertCompatibleOracleVersion(foreignMajor: ForeignCallSingle, foreignMinor: ForeignCallSingle) {
     const major = fromSingle(foreignMajor).toNumber();
     const minor = fromSingle(foreignMinor).toNumber();
 
@@ -808,28 +808,8 @@ export class RPCTranslator {
     return toForeignCallResult(witness.toNoirRepresentation());
   }
 
-  // TODO(https://linear.app/aztec-labs/issue/F-651): drop this
   // eslint-disable-next-line camelcase
   async aztec_utl_getBlockHashMembershipWitness(
-    foreignAnchorBlockHash: ForeignCallSingle,
-    foreignBlockHash: ForeignCallSingle,
-  ) {
-    const anchorBlockHash = blockHashFromSingle(foreignAnchorBlockHash);
-    const blockHash = blockHashFromSingle(foreignBlockHash);
-
-    const witness = await this.handlerAsUtility().getBlockHashMembershipWitness(anchorBlockHash, blockHash);
-
-    if (!witness) {
-      throw new Error(
-        `Block hash ${blockHash.toString()} not found in the archive tree at anchor block ${anchorBlockHash.toString()}.`,
-      );
-    }
-    return toForeignCallResult(witness.toNoirRepresentation());
-  }
-
-  // TODO(https://linear.app/aztec-labs/issue/F-651): rename to aztec_utl_getBlockHashMembershipWitness
-  // eslint-disable-next-line camelcase
-  async aztec_utl_getBlockHashMembershipWitnessV2(
     foreignAnchorBlockHash: ForeignCallSingle,
     foreignBlockHash: ForeignCallSingle,
   ) {


### PR DESCRIPTION
## Summary

- Drop the V1 `getBlockHashMembershipWitness` oracle handler and rename `getBlockHashMembershipWitnessV2` to its canonical name.
- Rename `assertCompatibleOracleVersionV2` back to `assertCompatibleOracleVersion`.
- Remove the `RawNullifierMembershipWitness` shim — the oracle now returns `(NullifierLeafPreimage, MembershipWitness)` directly. `NullifierMembershipWitness.toNoirRepresentation()` and `toFields()` are reordered to match Noir's fixed tuple layout (preimage fields, then index, then sibling path).
- Bump `ORACLE_VERSION_MAJOR` 24 → 25.

Fixes F-651
Fixes F-546
Fixes F-554