### PR TITLE
refactor(aztec-nr)!: remove array-based emit log unsafe APIs, rename BoundedVec variants

### DIFF
--- a/docs/docs-developers/docs/resources/migration_notes.md
+++ b/docs/docs-developers/docs/resources/migration_notes.md
@@ -9,6 +9,28 @@ Aztec is in active development. Each version may introduce breaking changes that
 
 ## TBD
 
+### [Aztec.nr] `emit_private_log_unsafe` / `emit_raw_note_log_unsafe` now take `BoundedVec`
+
+The old array-based `emit_private_log_unsafe(tag, log: [Field; N], length)` and `emit_raw_note_log_unsafe(tag, log: [Field; N], length, note_hash_counter)` have been removed. The temporary `_vec_unsafe` variants introduced in a prior release have been renamed to take their place.
+
+```diff
+- context.emit_private_log_unsafe(tag, log_array, length);
++ context.emit_private_log_unsafe(tag, bounded_vec_log);
+
+- context.emit_raw_note_log_unsafe(tag, log_array, length, note_hash_counter);
++ context.emit_raw_note_log_unsafe(tag, bounded_vec_log, note_hash_counter);
+```
+
+If you were already using `emit_private_log_vec_unsafe` / `emit_raw_note_log_vec_unsafe`, simply drop the `_vec` from the function name:
+
+```diff
+- context.emit_private_log_vec_unsafe(tag, log);
++ context.emit_private_log_unsafe(tag, log);
+
+- context.emit_raw_note_log_vec_unsafe(tag, log, note_hash_counter);
++ context.emit_raw_note_log_unsafe(tag, log, note_hash_counter);
+```
+
 ### [bb.js / accounts / aztec.nr] Schnorr signatures switched to Poseidon2
 
 The Schnorr challenge hash function changed from `blake2s(pedersen(R.x, pubkey.x, pubkey.y) ‖ message)` to `Poseidon2(DST, R.x, pubkey.x, pubkey.y, message)`, where `DST = poseidon2_hash_bytes("schnorr_grumpkin_poseidon2")` is a domain separation tag binding signatures to this scheme. The change applies end-to-end across the native signer (`bb`), `@aztec/bb.js`, the noir verifier library (`noir-lang/schnorr` v0.2.0 → v0.4.0), and both standard Schnorr account contracts. The auth witness on-wire shape also changes from `[u8; 64]` (the serialized `(s, e)` bytes) to `[Field; 4]` (`[s.lo, s.hi, e.lo, e.hi]`, each scalar split into two 128-bit limbs).

--- a/noir-projects/aztec-nr/aztec/src/context/private_context.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/private_context.nr
@@ -894,13 +894,10 @@ impl PrivateContext {
     /// filter for relevant logs without scanning all of them.
     /// * `log` - The log data that will be publicly broadcast (so make sure it's already been encrypted before you
     /// call this function). Private logs are bounded in size (`PRIVATE_LOG_CIPHERTEXT_LEN`), to encourage all logs
-    /// from all smart contracts look identical.
-    /// * `length` - The actual length of `log` (measured in number of Fields). Although the input log has a max
-    /// size of `PRIVATE_LOG_CIPHERTEXT_LEN`, the latter values of the array might all be 0's for small logs. This
-    /// `length` should reflect the trimmed length of the array. The protocol's kernel circuits can then append
-    /// random fields as "padding" after the `length`, so that the logs of this smart contract look
-    /// indistinguishable from (the same length as) the logs of all other applications. It's up to wallets how much
-    /// padding to apply, so ideally all wallets should agree on standards for this.
+    /// from all smart contracts look identical. The protocol's kernel circuits can then append random fields as
+    /// "padding" after the log's length, so that the logs of this smart contract look indistinguishable from (the
+    /// same length as) the logs of all other applications. It's up to wallets how much padding to apply, so
+    /// ideally all wallets should agree on standards for this.
     ///
     /// ## Safety
     ///
@@ -909,67 +906,34 @@ impl PrivateContext {
     /// happen to share a raw tag value become indistinguishable. Prefer the higher-level APIs
     /// ([`crate::messages::message_delivery::MessageDelivery`] for messages, `self.emit(event)` for events) which
     /// handle tagging automatically.
-    // TODO(F-555): remove this function in favor of `emit_private_log_vec_unsafe`
-    #[deprecated("use `emit_private_log_vec_unsafe` instead")]
-    pub fn emit_private_log_unsafe(&mut self, tag: Field, log: [Field; PRIVATE_LOG_CIPHERTEXT_LEN], length: u32) {
-        let counter = self.next_counter();
-        let full_log = [tag].concat(log);
-        self.private_logs.push(PrivateLogData { log: PrivateLog::new(full_log, length + 1), note_hash_counter: 0 }
-            .count(counter));
+    pub fn emit_private_log_unsafe(&mut self, tag: Field, log: BoundedVec<Field, PRIVATE_LOG_CIPHERTEXT_LEN>) {
+        self.emit_raw_note_log_unsafe(tag, log, 0);
     }
 
-    /// `BoundedVec`-based variant of [`emit_private_log_unsafe`](PrivateContext::emit_private_log_unsafe).
-    ///
-    /// See [`emit_private_log_unsafe`](PrivateContext::emit_private_log_unsafe) for the full description of private
-    /// log semantics.
-    // TODO(F-555): once `emit_private_log_unsafe` is removed, rename this function to drop the `_vec` suffix.
-    pub fn emit_private_log_vec_unsafe(&mut self, tag: Field, log: BoundedVec<Field, PRIVATE_LOG_CIPHERTEXT_LEN>) {
-        self.emit_raw_note_log_vec_unsafe(tag, log, 0);
-    }
-
-    // TODO: rename.
     /// Emits a private log that is explicitly tied to a newly-emitted note_hash, to convey to the kernel: "this log
     /// relates to this note".
     ///
     /// This linkage is important in case the note gets squashed (due to being read later in this same tx), since we
     /// can then squash the log as well.
     ///
-    /// See `emit_private_log_unsafe` for more info about private log emission.
+    /// See [`emit_private_log_unsafe`](PrivateContext::emit_private_log_unsafe) for more info about private log
+    /// emission.
     ///
     /// # Arguments
-    /// * `tag` - A tag placed at `fields[0]`. See `emit_private_log_unsafe`.
-    /// * `log` - The log data as an array of Field elements
-    /// * `length` - The actual length of the `log` (measured in number of Fields).
+    /// * `tag` - A tag placed at `fields[0]`. See
+    ///   [`emit_private_log_unsafe`](PrivateContext::emit_private_log_unsafe).
+    /// * `log` - The log data as a `BoundedVec` of Field elements.
     /// * `note_hash_counter` - The side-effect counter that was assigned to the new note_hash when it was pushed to
     /// this `PrivateContext`.
     ///
     /// Important: If your application logic requires the log to always be emitted regardless of note squashing,
-    /// consider using `emit_private_log_unsafe` instead, or emitting additional events.
+    /// consider using [`emit_private_log_unsafe`](PrivateContext::emit_private_log_unsafe) instead, or emitting
+    /// additional events.
     ///
     /// ## Safety
     ///
     /// Same as [`PrivateContext::emit_private_log_unsafe`]: the `tag` should be domain-separated.
-    // TODO(F-555): remove this function in favor of `emit_raw_note_log_vec_unsafe`
-    #[deprecated("use `emit_raw_note_log_vec_unsafe` instead")]
     pub fn emit_raw_note_log_unsafe(
-        &mut self,
-        tag: Field,
-        log: [Field; PRIVATE_LOG_CIPHERTEXT_LEN],
-        length: u32,
-        note_hash_counter: u32,
-    ) {
-        let counter = self.next_counter();
-        let full_log = [tag].concat(log);
-        let private_log = PrivateLogData { log: PrivateLog::new(full_log, length + 1), note_hash_counter };
-        self.private_logs.push(private_log.count(counter));
-    }
-
-    /// `BoundedVec`-based variant of [`emit_raw_note_log_unsafe`](PrivateContext::emit_raw_note_log_unsafe).
-    ///
-    /// See [`emit_raw_note_log_unsafe`](PrivateContext::emit_raw_note_log_unsafe) for the full description of
-    /// note-tied private log semantics.
-    // TODO(F-555): once `emit_raw_note_log_unsafe` is removed, rename this function to drop the `_vec` suffix.
-    pub fn emit_raw_note_log_vec_unsafe(
         &mut self,
         tag: Field,
         log: BoundedVec<Field, PRIVATE_LOG_CIPHERTEXT_LEN>,

--- a/noir-projects/aztec-nr/aztec/src/messages/message_delivery.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/message_delivery.nr
@@ -241,9 +241,9 @@ pub fn do_private_message_delivery<Env, let MESSAGE_PLAINTEXT_LEN: u32>(
         if maybe_note_hash_counter.is_some() {
             // We associate the log with the note's side effect counter, so that if the note ends up being squashed in
             // the current transaction, the log will be removed as well.
-            context.emit_raw_note_log_vec_unsafe(log_tag, log, maybe_note_hash_counter.unwrap());
+            context.emit_raw_note_log_unsafe(log_tag, log, maybe_note_hash_counter.unwrap());
         } else {
-            context.emit_private_log_vec_unsafe(log_tag, log);
+            context.emit_private_log_unsafe(log_tag, log);
         }
     }
 }

--- a/noir-projects/aztec-nr/uint-note/src/uint_note.nr
+++ b/noir-projects/aztec-nr/uint-note/src/uint_note.nr
@@ -228,7 +228,7 @@ impl PartialUintNote {
         // inserted in public as the public values are provided and the note hash computed.
         let log_tag = compute_log_tag(self.commitment, DOM_SEP__NOTE_COMPLETION_LOG_TAG);
         let payload = BoundedVec::from_array([storage_slot, value.to_field()]);
-        context.emit_private_log_vec_unsafe(log_tag, payload);
+        context.emit_private_log_unsafe(log_tag, payload);
         context.push_note_hash(self.compute_complete_note_hash(storage_slot, value));
     }
 

--- a/noir-projects/noir-contracts/contracts/account/simulated_ecdsa_account_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/account/simulated_ecdsa_account_contract/src/main.nr
@@ -51,7 +51,7 @@ pub contract SimulatedEcdsaAccount {
         // and is therefore never nullified, so in practice the log will never be squashed. We
         // pass the note hash counter anyway for correctness.
         let dummy_log: [Field; MESSAGE_CIPHERTEXT_LEN] = [seed + 2; MESSAGE_CIPHERTEXT_LEN];
-        self.context.emit_raw_note_log_vec_unsafe(
+        self.context.emit_raw_note_log_unsafe(
             seed + 3,
             BoundedVec::from_array(dummy_log),
             self.context.side_effect_counter,

--- a/noir-projects/noir-contracts/contracts/account/simulated_schnorr_account_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/account/simulated_schnorr_account_contract/src/main.nr
@@ -53,7 +53,7 @@ pub contract SimulatedSchnorrAccount {
         // and is therefore never nullified, so in practice the log will never be squashed. We
         // pass the note hash counter anyway for correctness.
         let dummy_log: [Field; MESSAGE_CIPHERTEXT_LEN] = [seed + 2; MESSAGE_CIPHERTEXT_LEN];
-        self.context.emit_raw_note_log_vec_unsafe(
+        self.context.emit_raw_note_log_unsafe(
             seed + 3,
             BoundedVec::from_array(dummy_log),
             self.context.side_effect_counter,

--- a/noir-projects/noir-contracts/contracts/message_discovery/handshake_registry_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/message_discovery/handshake_registry_contract/src/main.nr
@@ -83,7 +83,7 @@ pub contract HandshakeRegistry {
         );
 
         // TODO(F-653): Encrypt `eph_pk.x` to keep the log private
-        self.context.emit_private_log_vec_unsafe(log_tag, BoundedVec::from_array([eph_pk.x]));
+        self.context.emit_private_log_unsafe(log_tag, BoundedVec::from_array([eph_pk.x]));
 
         note.siloed_for(self.msg_sender())
     }

--- a/noir-projects/noir-contracts/contracts/test/benchmarking_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/benchmarking_contract/src/main.nr
@@ -113,7 +113,7 @@ pub contract Benchmarking {
             for j in 0..PRIVATE_LOG_CIPHERTEXT_LEN {
                 log.push(random_seed + (i * MAX_PRIVATE_LOGS_PER_CALL + j) as Field);
             }
-            self.context.emit_private_log_vec_unsafe(0, log);
+            self.context.emit_private_log_unsafe(0, log);
         }
     }
 

--- a/noir-projects/noir-contracts/contracts/test/test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/test_contract/src/main.nr
@@ -316,7 +316,7 @@ pub contract Test {
 
             // Emit a log with non-encrypted content for testing purpose.
             let leaky_log = BoundedVec::from_array(event.serialize());
-            self.context.emit_private_log_vec_unsafe(tag, leaky_log);
+            self.context.emit_private_log_unsafe(tag, leaky_log);
         }
     }
 

--- a/noir-projects/noir-contracts/contracts/test/test_log_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/test_log_contract/src/main.nr
@@ -47,7 +47,7 @@ pub contract TestLog {
     /// Emits a single private log with the given raw tag and a one-field payload.
     #[external("private")]
     fn emit_raw_private_log(tag: Field, payload: Field) {
-        self.context.emit_private_log_vec_unsafe(tag, BoundedVec::from_array([payload]));
+        self.context.emit_private_log_unsafe(tag, BoundedVec::from_array([payload]));
     }
 
     /// Emits three private logs with payloads of different lengths (1, 3, and 5 fields). Used to
@@ -61,9 +61,9 @@ pub contract TestLog {
         tag3: Field,
         payload3: [Field; 5],
     ) {
-        self.context.emit_private_log_vec_unsafe(tag1, BoundedVec::from_array([payload1]));
-        self.context.emit_private_log_vec_unsafe(tag2, BoundedVec::from_array(payload2));
-        self.context.emit_private_log_vec_unsafe(tag3, BoundedVec::from_array(payload3));
+        self.context.emit_private_log_unsafe(tag1, BoundedVec::from_array([payload1]));
+        self.context.emit_private_log_unsafe(tag2, BoundedVec::from_array(payload2));
+        self.context.emit_private_log_unsafe(tag3, BoundedVec::from_array(payload3));
     }
 
     #[external("private")]


### PR DESCRIPTION
## Summary

- Remove the deprecated `emit_private_log_unsafe(tag, [Field; N], length)` and `emit_raw_note_log_unsafe(tag, [Field; N], length, note_hash_counter)` array-based functions from `PrivateContext`.
- Rename `emit_private_log_vec_unsafe` → `emit_private_log_unsafe` and `emit_raw_note_log_vec_unsafe` → `emit_raw_note_log_unsafe`, dropping the `_vec` suffix now that the old signatures are gone.
- Update all in-tree callers and add migration notes.

Fixes F-555