### PR TITLE
docs: update stale v4.2.0 references to v4.3.0

### DIFF
--- a/.claude/skills/release-docs/SKILL.md
+++ b/.claude/skills/release-docs/SKILL.md
@@ -145,6 +145,20 @@ updating it is sufficient — you no longer need to edit hardcoded defaults in J
 **Network/operator docs** are updated separately in Step 13 after the version
 snapshot is created (the config update requires the versioned docs directory to exist).
 
+#### Hardcoded version references
+
+Some strings hardcode the version. Grep the source (and after Step 13, the new
+snapshot) for the old version and update each hit. Skip historical references
+(migration-note headings, changelog entries, "in vX, Y was removed" prose).
+
+```bash
+cd docs && grep -rn "<old_version>" src/ docs-developers/ docs-operate/ docs/
+```
+
+Known hits: `src/clientModules/docsgpt.js` (`heroDescription`),
+`developer_versioned_docs/version-v<new>/docs/aztec-js/wallet-sdk/{wallet,dapp}_integration.md`
+(`yarn add @aztec/*@<version>`).
+
 ### Step 6: Generate API Reference Docs
 
 Generate the Aztec.nr and TypeScript API documentation for the new version. The

--- a/.claude/skills/release-docs/SKILL.md
+++ b/.claude/skills/release-docs/SKILL.md
@@ -145,20 +145,6 @@ updating it is sufficient — you no longer need to edit hardcoded defaults in J
 **Network/operator docs** are updated separately in Step 13 after the version
 snapshot is created (the config update requires the versioned docs directory to exist).
 
-#### Hardcoded version references
-
-Some strings hardcode the version. Grep the source (and after Step 13, the new
-snapshot) for the old version and update each hit. Skip historical references
-(migration-note headings, changelog entries, "in vX, Y was removed" prose).
-
-```bash
-cd docs && grep -rn "<old_version>" src/ docs-developers/ docs-operate/ docs/
-```
-
-Known hits: `src/clientModules/docsgpt.js` (`heroDescription`),
-`developer_versioned_docs/version-v<new>/docs/aztec-js/wallet-sdk/{wallet,dapp}_integration.md`
-(`yarn add @aztec/*@<version>`).
-
 ### Step 6: Generate API Reference Docs
 
 Generate the Aztec.nr and TypeScript API documentation for the new version. The
@@ -459,6 +445,22 @@ Verify the new version appears in both `docs/developer_version_config.json` and
 Also verify that macros were resolved in the network versioned snapshot — check
 that `docs/network_versioned_docs/version-v<new_version>/` contains no raw
 `#release_version` or `#release_network` placeholders.
+
+#### Hardcoded version references
+
+Grep source and the new snapshot for the old version and update each hit. Skip
+historical refs (migration-note headings, changelog entries, "in vX, Y was
+removed" prose).
+
+```bash
+cd docs && grep -rn "<old_version>" src/ docs-developers/ docs-operate/ docs/ \
+  developer_versioned_docs/version-v<new_version>/ \
+  network_versioned_docs/version-v<new_version>/
+```
+
+Known hits: `src/clientModules/docsgpt.js` (`heroDescription`),
+`developer_versioned_docs/version-v<new_version>/docs/aztec-js/wallet-sdk/{wallet,dapp}_integration.md`
+(`yarn add @aztec/*@<version>`).
 
 ### Step 14: Review Recent Docs Updates on `next`
 

--- a/docs/developer_versioned_docs/version-v4.3.0/docs/aztec-js/wallet-sdk/dapp_integration.md
+++ b/docs/developer_versioned_docs/version-v4.3.0/docs/aztec-js/wallet-sdk/dapp_integration.md
@@ -15,7 +15,7 @@ This guide shows how a dApp connects to an Aztec wallet extension using `@aztec/
 ## Install
 
 ```bash
-yarn add @aztec/wallet-sdk@4.2.0 @aztec/aztec.js@4.2.0
+yarn add @aztec/wallet-sdk@4.3.0 @aztec/aztec.js@4.3.0
 ```
 
 Common imports:

--- a/docs/developer_versioned_docs/version-v4.3.0/docs/aztec-js/wallet-sdk/wallet_integration.md
+++ b/docs/developer_versioned_docs/version-v4.3.0/docs/aztec-js/wallet-sdk/wallet_integration.md
@@ -22,7 +22,7 @@ A Manifest V3 service worker has a 5-minute inactivity timeout and limited WASM 
 ## Install
 
 ```bash
-yarn add @aztec/wallet-sdk@4.2.0 @aztec/aztec.js@4.2.0 @aztec/pxe@4.2.0
+yarn add @aztec/wallet-sdk@4.3.0 @aztec/aztec.js@4.3.0 @aztec/pxe@4.3.0
 ```
 
 ## Content script

--- a/docs/docs-developers/ai_tooling.md
+++ b/docs/docs-developers/ai_tooling.md
@@ -42,7 +42,7 @@ This is an Aztec smart contract project. Always use the `aztec` CLI wrapper inst
 
 ## Version Compatibility
 
-The Aztec developer SDK/aztec-nr version (used for writing and compiling contracts) may differ from the node version (used by operators to run the network). For example, aztec-nr `4.2.0-aztecnr-rc.2` is compatible with node version `4.1.2`. Check the [Networks page](https://docs.aztec.network/networks) for current network versions. When in doubt, use the version from the developer docs you are reading — it is the correct SDK version for contract development on that network.
+The Aztec developer SDK/aztec-nr version (used for writing and compiling contracts) may differ from the node version (used by operators to run the network). Check the [Networks page](https://docs.aztec.network/networks) for current network versions. When in doubt, use the version from the developer docs you are reading, it is the correct SDK version for contract development on that network.
 
 ## Hashing: Default to Poseidon2
 

--- a/docs/src/clientModules/docsgpt.js
+++ b/docs/src/clientModules/docsgpt.js
@@ -1,28 +1,29 @@
-import ExecutionEnvironment from '@docusaurus/ExecutionEnvironment';
+import ExecutionEnvironment from "@docusaurus/ExecutionEnvironment";
 
 if (ExecutionEnvironment.canUseDOM) {
-  const React = require('react');
-  const ReactDOM = require('react-dom/client');
-  const AztecDocsWidget = require('@site/src/components/AztecDocsWidget').default;
+  const React = require("react");
+  const ReactDOM = require("react-dom/client");
+  const AztecDocsWidget =
+    require("@site/src/components/AztecDocsWidget").default;
 
-  const container = document.createElement('div');
-  container.id = 'docsgpt-widget';
+  const container = document.createElement("div");
+  container.id = "docsgpt-widget";
   document.body.appendChild(container);
 
   const root = ReactDOM.createRoot(container);
   root.render(
     React.createElement(AztecDocsWidget, {
-      apiHost: 'https://aztec.adjacentpossible.dev',
-      apiKey: '44420ab5-6be3-4b30-af35-559c38bfce6d',
-      title: 'Ask about Aztec',
-      heroTitle: 'Aztec Docs Assistant',
+      apiHost: "https://aztec.adjacentpossible.dev",
+      apiKey: "44420ab5-6be3-4b30-af35-559c38bfce6d",
+      title: "Ask about Aztec",
+      heroTitle: "Aztec Docs Assistant",
       heroDescription:
-        'Searches Aztec v4.2.0 developer docs, Aztec.nr, aztec.js SDK, protocol circuits, and more.',
-      theme: 'ink',
-      accent: 'chartreuse',
-      buttonStyle: 'symbol',
-      size: 'roomy',
-      position: 'br',
+        "Searches Aztec v4.3.0 developer docs, Aztec.nr, aztec.js SDK, protocol circuits, and more.",
+      theme: "ink",
+      accent: "chartreuse",
+      buttonStyle: "symbol",
+      size: "roomy",
+      position: "br",
       motif: true,
     }),
   );


### PR DESCRIPTION
## Summary

- Fix the docs assistant widget hero copy that still referenced "Aztec v4.2.0 developer docs". It now reads v4.3.0.
- Drop the stale concrete version pair in `ai_tooling.md`'s version-compatibility note (aztec-nr `4.2.0-aztecnr-rc.2` / node `4.1.2`) and direct readers to the Networks page instead.
- Update hardcoded `yarn add @aztec/*@4.2.0` install snippets in the v4.3.0 wallet-sdk snapshot (`wallet_integration.md`, `dapp_integration.md`) to `@4.3.0`.
- Add a step to the `release-docs` skill that greps for the old version string across `docs/` and lists the known hardcoded sites (widget copy, snapshot install commands) so this isn't missed on future cuts.

Historical references (migration-note section headings, changelog entries, "in v4.2.0, X was removed" prose) are intentionally preserved.

## Test plan

- [x] `yarn spellcheck` passes
- [ ] Verify the docs widget renders the new copy locally / in preview