### PR TITLE
feat(aztec-nr)!: add explicit custom_sync_state hook to AztecConfig

### DIFF
--- a/docs/docs-developers/docs/resources/migration_notes.md
+++ b/docs/docs-developers/docs/resources/migration_notes.md
@@ -9,6 +9,40 @@ Aztec is in active development. Each version may introduce breaking changes that
 
 ## TBD
 
+### [Aztec.nr] Defining a custom `sync_state` function now requires `AztecConfig`
+
+Contracts that previously overrode the default `sync_state` by defining their own function with that name will now get a compile error. Use `AztecConfig::custom_sync_state()` instead.
+
+The custom hook receives the same parameters as `do_sync_state` and is responsible for calling it if default behavior is also desired. You can perform work before and/or after the default `do_sync_state` call, or skip it entirely.
+
+```diff
++ unconstrained fn my_custom_sync(
++     contract_address: AztecAddress,
++     compute_note_hash: ComputeNoteHash,
++     compute_note_nullifier: ComputeNoteNullifier,
++     process_custom_message: Option<CustomMessageHandler<()>>,
++     offchain_inbox_sync: Option<OffchainInboxSync<()>>,
++     scope: AztecAddress,
++ ) {
++     // optional: work before default sync
++     do_sync_state(contract_address, compute_note_hash, compute_note_nullifier, process_custom_message, offchain_inbox_sync, scope);
++     // optional: work after default sync
++ }
+
+- #[aztec]
++ #[aztec(::aztec::macros::AztecConfig::new().custom_sync_state(crate::my_custom_sync))]
+  contract MyContract {
+-     use aztec::macros::functions::external;
+-
+-     #[external("utility")]
+-     unconstrained fn sync_state(scope: AztecAddress) {
+-         // custom sync logic
+-     }
+  }
+```
+
+**Impact**: Only contracts that manually defined a `sync_state` function are affected. Contracts using the default macro-generated `sync_state` require no changes.
+
 ### [bb.js / accounts / aztec.nr] Schnorr signatures switched to Poseidon2
 
 The Schnorr challenge hash function changed from `blake2s(pedersen(R.x, pubkey.x, pubkey.y) ‖ message)` to `Poseidon2(DST, R.x, pubkey.x, pubkey.y, message)`, where `DST = poseidon2_hash_bytes("schnorr_grumpkin_poseidon2")` is a domain separation tag binding signatures to this scheme. The change applies end-to-end across the native signer (`bb`), `@aztec/bb.js`, the noir verifier library (`noir-lang/schnorr` v0.2.0 → v0.4.0), and both standard Schnorr account contracts. The auth witness on-wire shape also changes from `[u8; 64]` (the serialized `(s, e)` bytes) to `[Field; 4]` (`[s.lo, s.hi, e.lo, e.hi]`, each scalar split into two 128-bit limbs).

--- a/docs/docs-developers/docs/resources/migration_notes.md
+++ b/docs/docs-developers/docs/resources/migration_notes.md
@@ -20,8 +20,8 @@ The custom hook receives the same parameters as `do_sync_state` and is responsib
 +     contract_address: AztecAddress,
 +     compute_note_hash: ComputeNoteHash,
 +     compute_note_nullifier: ComputeNoteNullifier,
-+     process_custom_message: Option<CustomMessageHandler<()>>,
-+     offchain_inbox_sync: Option<OffchainInboxSync<()>>,
++     process_custom_message: Option<CustomMessageHandler>,
++     offchain_inbox_sync: Option<OffchainInboxSync>,
 +     scope: AztecAddress,
 + ) {
 +     // optional: work before default sync

--- a/noir-projects/aztec-nr/aztec/src/macros/aztec.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/aztec.nr
@@ -34,8 +34,8 @@ use compute_note_hash_and_nullifier::generate_contract_library_methods_compute_n
 /// contract MyContract { ... }
 /// ```
 pub struct AztecConfig {
-    custom_message_handler: Option<CustomMessageHandler<()>>,
-    custom_sync_state: Option<CustomSyncHandler<()>>,
+    custom_message_handler: Option<CustomMessageHandler>,
+    custom_sync_state: Option<CustomSyncHandler>,
 }
 
 impl AztecConfig {
@@ -54,8 +54,9 @@ impl AztecConfig {
     ///
     /// `handler` must be a function that conforms to the
     /// [`crate::messages::discovery::CustomMessageHandler`] type signature.
-    pub comptime fn custom_message_handler(self, handler: CustomMessageHandler<()>) -> Self {
-        Self { custom_message_handler: Option::some(handler), custom_sync_state: self.custom_sync_state }
+    pub comptime fn custom_message_handler(&mut self, handler: CustomMessageHandler) -> Self {
+        self.custom_message_handler = Option::some(handler);
+        *self
     }
 
     /// Overrides the default state synchronization logic.
@@ -67,8 +68,9 @@ impl AztecConfig {
     ///
     /// `handler` must be a function that conforms to the
     /// [`crate::messages::discovery::CustomSyncHandler`] type signature.
-    pub comptime fn custom_sync_state(self, handler: CustomSyncHandler<()>) -> Self {
-        Self { custom_message_handler: self.custom_message_handler, custom_sync_state: Option::some(handler) }
+    pub comptime fn custom_sync_state(&mut self, handler: CustomSyncHandler) -> Self {
+        self.custom_sync_state = Option::some(handler);
+        *self
     }
 }
 
@@ -135,7 +137,7 @@ pub comptime fn aztec(m: Module, args: [AztecConfig]) -> Quoted {
         let handler = config.custom_message_handler.unwrap();
         quote { Option::some($handler) }
     } else {
-        quote { Option::<aztec::messages::discovery::CustomMessageHandler<()>>::none() }
+        quote { Option::<aztec::messages::discovery::CustomMessageHandler>::none() }
     };
 
     let offchain_inbox_sync_option = quote {

--- a/noir-projects/aztec-nr/aztec/src/macros/aztec.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/aztec.nr
@@ -16,7 +16,7 @@ use crate::{
         storage::STORAGE_LAYOUT_NAME,
         utils::{is_fn_contract_library_method, is_fn_external, is_fn_internal, is_fn_test, module_has_storage},
     },
-    messages::discovery::CustomMessageHandler,
+    messages::discovery::{CustomMessageHandler, CustomSyncHandler},
 };
 
 use compute_note_hash_and_nullifier::generate_contract_library_methods_compute_note_hash_and_nullifier;
@@ -24,8 +24,8 @@ use compute_note_hash_and_nullifier::generate_contract_library_methods_compute_n
 /// Configuration for the [`aztec`] macro.
 ///
 /// This type lets users override different parts of the default aztec-nr contract behavior, such
-/// as message handling. These are advanced features that require careful understanding of
-/// the behavior of these systems.
+/// as message handling and state synchronization. These are advanced features that require careful
+/// understanding of the behavior of these systems.
 ///
 /// ## Examples
 ///
@@ -35,6 +35,7 @@ use compute_note_hash_and_nullifier::generate_contract_library_methods_compute_n
 /// ```
 pub struct AztecConfig {
     custom_message_handler: Option<CustomMessageHandler<()>>,
+    custom_sync_state: Option<CustomSyncHandler<()>>,
 }
 
 impl AztecConfig {
@@ -43,7 +44,7 @@ impl AztecConfig {
     /// Calling `new` is equivalent to invoking the [`aztec`] macro with no parameters. The different methods
     /// (e.g. [`AztecConfig::custom_message_handler`]) can then be used to change the default behavior.
     pub comptime fn new() -> Self {
-        Self { custom_message_handler: Option::none() }
+        Self { custom_message_handler: Option::none(), custom_sync_state: Option::none() }
     }
 
     /// Sets a handler for custom messages.
@@ -53,8 +54,21 @@ impl AztecConfig {
     ///
     /// `handler` must be a function that conforms to the
     /// [`crate::messages::discovery::CustomMessageHandler`] type signature.
-    pub comptime fn custom_message_handler(_self: Self, handler: CustomMessageHandler<()>) -> Self {
-        Self { custom_message_handler: Option::some(handler) }
+    pub comptime fn custom_message_handler(self, handler: CustomMessageHandler<()>) -> Self {
+        Self { custom_message_handler: Option::some(handler), custom_sync_state: self.custom_sync_state }
+    }
+
+    /// Overrides the default state synchronization logic.
+    ///
+    /// The generated `sync_state` function will call `handler` instead of
+    /// [`crate::messages::discovery::do_sync_state`]. The handler receives all of the same parameters, so it can
+    /// run custom logic (e.g. fetching and decrypting custom logs) before, after, or instead of calling
+    /// `do_sync_state`.
+    ///
+    /// `handler` must be a function that conforms to the
+    /// [`crate::messages::discovery::CustomSyncHandler`] type signature.
+    pub comptime fn custom_sync_state(self, handler: CustomSyncHandler<()>) -> Self {
+        Self { custom_message_handler: self.custom_message_handler, custom_sync_state: Option::some(handler) }
     }
 }
 
@@ -105,7 +119,7 @@ pub comptime fn aztec(m: Module, args: [AztecConfig]) -> Quoted {
     let fn_abi_exports = create_fn_abi_exports(m);
 
     // We generate `_compute_note_hash`, `_compute_note_nullifier` (and the deprecated
-    // `_compute_note_hash_and_nullifier` wrapper) and `sync_state` functions only if they are not already implemented.
+    // `_compute_note_hash_and_nullifier` wrapper) only if they are not already implemented.
     // If they are implemented we just insert empty quotes.
     let contract_library_method_compute_note_hash_and_nullifier = if !m.functions().any(|f| {
         // Note that we don't test for `_compute_note_hash` or `_compute_note_nullifier` in order to make this simpler
@@ -128,11 +142,21 @@ pub comptime fn aztec(m: Module, args: [AztecConfig]) -> Quoted {
         Option::some(aztec::messages::processing::offchain::sync_inbox)
     };
 
-    let sync_state_fn_and_abi_export = if !m.functions().any(|f| f.name() == quote { sync_state }) {
-        generate_sync_state(process_custom_message_option, offchain_inbox_sync_option)
+    if m.functions().any(|f| f.name() == quote { sync_state }) {
+        panic(
+            "User-defined 'sync_state' is not allowed. Use AztecConfig::custom_sync_state() to customize sync behavior.",
+        );
+    }
+
+    let custom_sync_handler = if config.custom_sync_state.is_some() {
+        let handler = config.custom_sync_state.unwrap();
+        Option::some(quote { $handler })
     } else {
-        quote {}
+        Option::none()
     };
+
+    let sync_state_fn_and_abi_export =
+        generate_sync_state(process_custom_message_option, offchain_inbox_sync_option, custom_sync_handler);
 
     if m.functions().any(|f| f.name() == quote { offchain_receive }) {
         panic(
@@ -223,7 +247,36 @@ comptime fn generate_contract_interface(m: Module) -> Quoted {
 }
 
 /// Generates the `sync_state` utility function that performs message discovery.
-comptime fn generate_sync_state(process_custom_message_option: Quoted, offchain_inbox_sync_option: Quoted) -> Quoted {
+comptime fn generate_sync_state(
+    process_custom_message_option: Quoted,
+    offchain_inbox_sync_option: Quoted,
+    custom_sync_handler: Option<Quoted>,
+) -> Quoted {
+    let body = if custom_sync_handler.is_some() {
+        let handler = custom_sync_handler.unwrap();
+        quote {
+            $handler(
+                address,
+                _compute_note_hash,
+                _compute_note_nullifier,
+                $process_custom_message_option,
+                $offchain_inbox_sync_option,
+                scope,
+            );
+        }
+    } else {
+        quote {
+            aztec::messages::discovery::do_sync_state(
+                address,
+                _compute_note_hash,
+                _compute_note_nullifier,
+                $process_custom_message_option,
+                $offchain_inbox_sync_option,
+                scope,
+            );
+        }
+    };
+
     quote {
         pub struct sync_state_parameters {
             pub scope: aztec::protocol::address::AztecAddress,
@@ -237,14 +290,7 @@ comptime fn generate_sync_state(process_custom_message_option: Quoted, offchain_
         #[aztec::macros::internals_functions_generation::abi_attributes::abi_utility]
         unconstrained fn sync_state(scope: aztec::protocol::address::AztecAddress) {
             let address = aztec::context::UtilityContext::new().this_address();
-            aztec::messages::discovery::do_sync_state(
-                address,
-                _compute_note_hash,
-                _compute_note_nullifier,
-                $process_custom_message_option,
-                $offchain_inbox_sync_option,
-                scope,
-            );
+            $body
         }
     }
 }

--- a/noir-projects/aztec-nr/aztec/src/messages/discovery/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/discovery/mod.nr
@@ -106,6 +106,20 @@ pub type CustomMessageHandler<Env> = unconstrained fn[Env](
 /* message_context */ MessageContext,
 /* scope */ AztecAddress);
 
+/// Custom state synchronization handler.
+///
+/// When set via [`crate::macros::AztecConfig::custom_sync_state`], the generated `sync_state` function will call
+/// this handler instead of [`do_sync_state`]. It receives all of the same parameters, so it can run custom logic
+/// (e.g. fetching and decrypting custom logs) before, after, or instead of calling [`do_sync_state`].
+pub type CustomSyncHandler<Env> = unconstrained fn[Env](
+    /* contract_address */ AztecAddress,
+    /* compute_note_hash */ ComputeNoteHash,
+    /* compute_note_nullifier */ ComputeNoteNullifier,
+    /* process_custom_message */ Option<CustomMessageHandler<()>>,
+    /* offchain_inbox_sync */ Option<OffchainInboxSync<()>>,
+    /* scope */ AztecAddress,
+);
+
 /// Synchronizes the contract's private state with the network.
 ///
 /// As blocks are mined, it is possible for a contract's private state to change (e.g. with new notes being created),

--- a/noir-projects/aztec-nr/aztec/src/messages/discovery/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/discovery/mod.nr
@@ -98,7 +98,7 @@ pub type ComputeNoteHashAndNullifier<Env> = unconstrained fn[Env](/* packed_note
 /// Contracts that emit custom messages (i.e. any with a message type that is not in [`crate::messages::msg_type`])
 /// need to use [`crate::macros::AztecConfig::custom_message_handler`] with a function of this type in order to
 /// process them. They will otherwise be **silently ignored**.
-pub type CustomMessageHandler<Env> = unconstrained fn[Env](
+pub type CustomMessageHandler = unconstrained fn(
 /* contract_address */AztecAddress,
 /* msg_type_id */ u64,
 /* msg_metadata */ u64,
@@ -111,12 +111,12 @@ pub type CustomMessageHandler<Env> = unconstrained fn[Env](
 /// When set via [`crate::macros::AztecConfig::custom_sync_state`], the generated `sync_state` function will call
 /// this handler instead of [`do_sync_state`]. It receives all of the same parameters, so it can run custom logic
 /// (e.g. fetching and decrypting custom logs) before, after, or instead of calling [`do_sync_state`].
-pub type CustomSyncHandler<Env> = unconstrained fn[Env](
+pub type CustomSyncHandler = unconstrained fn(
     /* contract_address */ AztecAddress,
     /* compute_note_hash */ ComputeNoteHash,
     /* compute_note_nullifier */ ComputeNoteNullifier,
-    /* process_custom_message */ Option<CustomMessageHandler<()>>,
-    /* offchain_inbox_sync */ Option<OffchainInboxSync<()>>,
+    /* process_custom_message */ Option<CustomMessageHandler>,
+    /* offchain_inbox_sync */ Option<OffchainInboxSync>,
     /* scope */ AztecAddress,
 );
 
@@ -128,12 +128,12 @@ pub type CustomSyncHandler<Env> = unconstrained fn[Env](
 ///
 /// The private state will be synchronized up to the block that will be used for private transactions (i.e. the anchor
 /// block. This will typically be close to the tip of the chain.
-pub unconstrained fn do_sync_state<CustomMessageHandlerEnv>(
+pub unconstrained fn do_sync_state(
     contract_address: AztecAddress,
     compute_note_hash: ComputeNoteHash,
     compute_note_nullifier: ComputeNoteNullifier,
-    process_custom_message: Option<CustomMessageHandler<CustomMessageHandlerEnv>>,
-    offchain_inbox_sync: Option<OffchainInboxSync<()>>,
+    process_custom_message: Option<CustomMessageHandler>,
+    offchain_inbox_sync: Option<OffchainInboxSync>,
     scope: AztecAddress,
 ) {
     aztecnr_debug_log!("Performing state synchronization");
@@ -219,8 +219,8 @@ mod test {
             logs.push(PendingTaggedLog { log: BoundedVec::new(), context: std::mem::zeroed() });
             assert_eq(logs.len(), 1);
 
-            let no_handler: Option<CustomMessageHandler<()>> = Option::none();
-            let no_inbox_sync: Option<OffchainInboxSync<()>> = Option::none();
+            let no_handler: Option<CustomMessageHandler> = Option::none();
+            let no_inbox_sync: Option<OffchainInboxSync> = Option::none();
             do_sync_state(
                 contract_address,
                 dummy_compute_note_hash,

--- a/noir-projects/aztec-nr/aztec/src/messages/discovery/process_message.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/discovery/process_message.nr
@@ -26,11 +26,11 @@ use crate::protocol::address::AztecAddress;
 ///
 /// Events are processed by computing an event commitment from the serialized event data and its randomness field, then
 /// enqueueing the event data and commitment for validation.
-pub unconstrained fn process_message_ciphertext<CustomMessageHandlerEnv>(
+pub unconstrained fn process_message_ciphertext(
     contract_address: AztecAddress,
     compute_note_hash: ComputeNoteHash,
     compute_note_nullifier: ComputeNoteNullifier,
-    process_custom_message: Option<CustomMessageHandler<CustomMessageHandlerEnv>>,
+    process_custom_message: Option<CustomMessageHandler>,
     message_ciphertext: BoundedVec<Field, MESSAGE_CIPHERTEXT_LEN>,
     message_context: MessageContext,
     recipient: AztecAddress,
@@ -52,11 +52,11 @@ pub unconstrained fn process_message_ciphertext<CustomMessageHandlerEnv>(
     }
 }
 
-pub(crate) unconstrained fn process_message_plaintext<CustomMessageHandlerEnv>(
+pub(crate) unconstrained fn process_message_plaintext(
     contract_address: AztecAddress,
     compute_note_hash: ComputeNoteHash,
     compute_note_nullifier: ComputeNoteNullifier,
-    process_custom_message: Option<CustomMessageHandler<CustomMessageHandlerEnv>>,
+    process_custom_message: Option<CustomMessageHandler>,
     message_plaintext: BoundedVec<Field, MESSAGE_PLAINTEXT_LEN>,
     message_context: MessageContext,
     recipient: AztecAddress,

--- a/noir-projects/aztec-nr/aztec/src/messages/processing/offchain.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/processing/offchain.nr
@@ -48,7 +48,7 @@ global MAX_MSG_TTL: u64 = MAX_TX_LIFETIME + TX_EXPIRATION_TOLERANCE;
 ///
 /// The only current implementation of an `OffchainInboxSync` is [`sync_inbox`], which manages an inbox with expiration
 /// based eviction and automatic transaction context resolution.
-pub type OffchainInboxSync<Env> = unconstrained fn[Env](
+pub type OffchainInboxSync = unconstrained fn(
 /* contract_address */AztecAddress, /* scope */ AztecAddress) -> EphemeralArray<OffchainMessageWithContext>;
 
 /// A message delivered via the `offchain_receive` utility function.

--- a/noir-projects/aztec-nr/aztec/src/messages/processing/offchain.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/processing/offchain.nr
@@ -48,7 +48,7 @@ global MAX_MSG_TTL: u64 = MAX_TX_LIFETIME + TX_EXPIRATION_TOLERANCE;
 ///
 /// The only current implementation of an `OffchainInboxSync` is [`sync_inbox`], which manages an inbox with expiration
 /// based eviction and automatic transaction context resolution.
-pub(crate) type OffchainInboxSync<Env> = unconstrained fn[Env](
+pub type OffchainInboxSync<Env> = unconstrained fn[Env](
 /* contract_address */AztecAddress, /* scope */ AztecAddress) -> EphemeralArray<OffchainMessageWithContext>;
 
 /// A message delivered via the `offchain_receive` utility function.

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
@@ -1318,7 +1318,7 @@ impl TestEnvironment {
             note.compute_nullifier_unconstrained(owner, unique_note_hash)
         };
 
-        let process_custom_message: Option<CustomMessageHandler<()>> = Option::none();
+        let process_custom_message: Option<CustomMessageHandler> = Option::none();
         self.discover_data_in_message_plaintext(
             message_plaintext,
             opts.contract_address,
@@ -1433,7 +1433,7 @@ impl TestEnvironment {
             )
         };
 
-        let process_custom_message: Option<CustomMessageHandler<()>> = Option::none();
+        let process_custom_message: Option<CustomMessageHandler> = Option::none();
         self.discover_data_in_message_plaintext(
             message_plaintext,
             opts.contract_address,
@@ -1444,14 +1444,14 @@ impl TestEnvironment {
         );
     }
 
-    unconstrained fn discover_data_in_message_plaintext<CustomMessageHandlerEnv>(
+    unconstrained fn discover_data_in_message_plaintext(
         self,
         message_plaintext: BoundedVec<Field, MESSAGE_PLAINTEXT_LEN>,
         contract_address: Option<AztecAddress>,
         recipient: Option<AztecAddress>,
         compute_note_hash: ComputeNoteHash,
         compute_note_nullifier: ComputeNoteNullifier,
-        process_custom_message: Option<CustomMessageHandler<CustomMessageHandlerEnv>>,
+        process_custom_message: Option<CustomMessageHandler>,
     ) {
         // This function will emulate the message discovery and processing that would happen in a real contract, based
         // on a message plaintext.

--- a/noir-projects/contract-snapshots/test_programs/compile_failure/user_defined_sync_state/Nargo.toml
+++ b/noir-projects/contract-snapshots/test_programs/compile_failure/user_defined_sync_state/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "user_defined_sync_state"
+type = "contract"
+authors = [""]
+
+[dependencies]
+aztec = { path = "../../../../aztec-nr/aztec" }

--- a/noir-projects/contract-snapshots/test_programs/compile_failure/user_defined_sync_state/src/main.nr
+++ b/noir-projects/contract-snapshots/test_programs/compile_failure/user_defined_sync_state/src/main.nr
@@ -1,0 +1,12 @@
+/// The name `sync_state` is reserved for the function auto-injected by the #[aztec] macro.
+/// Use AztecConfig::custom_sync_state() to customize sync behavior.
+use aztec::macros::aztec;
+
+#[aztec]
+contract UserDefinedSyncState {
+    use aztec::macros::functions::external;
+    use aztec::protocol::address::AztecAddress;
+
+    #[external("private")]
+    fn sync_state(_scope: AztecAddress) {}
+}

--- a/noir-projects/contract-snapshots/tests/snapshots/compile_failure/authorize_once_from_wrong_type/snapshots__stderr.snap
+++ b/noir-projects/contract-snapshots/tests/snapshots/compile_failure/authorize_once_from_wrong_type/snapshots__stderr.snap
@@ -12,7 +12,7 @@ error: Argument from in function foo must be of type AztecAddress, but is of typ
     1: #[aztec]
             at src/main.nr:4:1
     2: aztec
-            at <repo>/noir-projects/aztec-nr/aztec/src/macros/aztec.nr:97:21
+            at <repo>/noir-projects/aztec-nr/aztec/src/macros/aztec.nr:111:21
     3: process_functions
             at <repo>/noir-projects/aztec-nr/aztec/src/macros/internals_functions_generation/mod.nr:48:9
     4: [T]::map
@@ -20,7 +20,7 @@ error: Argument from in function foo must be of type AztecAddress, but is of typ
     5: process_functions
             at <repo>/noir-projects/aztec-nr/aztec/src/macros/internals_functions_generation/mod.nr:48:41
     6: generate_public_external
-            at <repo>/noir-projects/aztec-nr/aztec/src/macros/internals_functions_generation/external/public.nr:134:9
+            at <repo>/noir-projects/aztec-nr/aztec/src/macros/internals_functions_generation/external/public.nr:131:9
     7: create_authorize_once_check
             at <repo>/noir-projects/aztec-nr/aztec/src/macros/internals_functions_generation/external/helpers.nr:72:9
 

--- a/noir-projects/contract-snapshots/tests/snapshots/compile_failure/authorize_once_missing_from_param/snapshots__stderr.snap
+++ b/noir-projects/contract-snapshots/tests/snapshots/compile_failure/authorize_once_missing_from_param/snapshots__stderr.snap
@@ -12,7 +12,7 @@ error: Function foo does not have a from parameter. Please specify which one to 
     1: #[aztec]
             at src/main.nr:4:1
     2: aztec
-            at <repo>/noir-projects/aztec-nr/aztec/src/macros/aztec.nr:97:21
+            at <repo>/noir-projects/aztec-nr/aztec/src/macros/aztec.nr:111:21
     3: process_functions
             at <repo>/noir-projects/aztec-nr/aztec/src/macros/internals_functions_generation/mod.nr:48:9
     4: [T]::map
@@ -20,7 +20,7 @@ error: Function foo does not have a from parameter. Please specify which one to 
     5: process_functions
             at <repo>/noir-projects/aztec-nr/aztec/src/macros/internals_functions_generation/mod.nr:48:41
     6: generate_public_external
-            at <repo>/noir-projects/aztec-nr/aztec/src/macros/internals_functions_generation/external/public.nr:134:9
+            at <repo>/noir-projects/aztec-nr/aztec/src/macros/internals_functions_generation/external/public.nr:131:9
     7: create_authorize_once_check
             at <repo>/noir-projects/aztec-nr/aztec/src/macros/internals_functions_generation/external/helpers.nr:67:9
 

--- a/noir-projects/contract-snapshots/tests/snapshots/compile_failure/authorize_once_missing_nonce_param/snapshots__stderr.snap
+++ b/noir-projects/contract-snapshots/tests/snapshots/compile_failure/authorize_once_missing_nonce_param/snapshots__stderr.snap
@@ -12,7 +12,7 @@ error: Function foo does not have a authwit_nonce. Please specify which one to u
     1: #[aztec]
             at src/main.nr:4:1
     2: aztec
-            at <repo>/noir-projects/aztec-nr/aztec/src/macros/aztec.nr:97:21
+            at <repo>/noir-projects/aztec-nr/aztec/src/macros/aztec.nr:111:21
     3: process_functions
             at <repo>/noir-projects/aztec-nr/aztec/src/macros/internals_functions_generation/mod.nr:48:9
     4: [T]::map
@@ -20,7 +20,7 @@ error: Function foo does not have a authwit_nonce. Please specify which one to u
     5: process_functions
             at <repo>/noir-projects/aztec-nr/aztec/src/macros/internals_functions_generation/mod.nr:48:41
     6: generate_public_external
-            at <repo>/noir-projects/aztec-nr/aztec/src/macros/internals_functions_generation/external/public.nr:134:9
+            at <repo>/noir-projects/aztec-nr/aztec/src/macros/internals_functions_generation/external/public.nr:131:9
     7: create_authorize_once_check
             at <repo>/noir-projects/aztec-nr/aztec/src/macros/internals_functions_generation/external/helpers.nr:81:9
 

--- a/noir-projects/contract-snapshots/tests/snapshots/compile_failure/authorize_once_nonce_wrong_type/snapshots__stderr.snap
+++ b/noir-projects/contract-snapshots/tests/snapshots/compile_failure/authorize_once_nonce_wrong_type/snapshots__stderr.snap
@@ -12,7 +12,7 @@ error: Argument authwit_nonce in function foo must be of type Field, but is of t
     1: #[aztec]
             at src/main.nr:4:1
     2: aztec
-            at <repo>/noir-projects/aztec-nr/aztec/src/macros/aztec.nr:97:21
+            at <repo>/noir-projects/aztec-nr/aztec/src/macros/aztec.nr:111:21
     3: process_functions
             at <repo>/noir-projects/aztec-nr/aztec/src/macros/internals_functions_generation/mod.nr:48:9
     4: [T]::map
@@ -20,7 +20,7 @@ error: Argument authwit_nonce in function foo must be of type Field, but is of t
     5: process_functions
             at <repo>/noir-projects/aztec-nr/aztec/src/macros/internals_functions_generation/mod.nr:48:41
     6: generate_public_external
-            at <repo>/noir-projects/aztec-nr/aztec/src/macros/internals_functions_generation/external/public.nr:134:9
+            at <repo>/noir-projects/aztec-nr/aztec/src/macros/internals_functions_generation/external/public.nr:131:9
     7: create_authorize_once_check
             at <repo>/noir-projects/aztec-nr/aztec/src/macros/internals_functions_generation/external/helpers.nr:86:9
 

--- a/noir-projects/contract-snapshots/tests/snapshots/compile_failure/bob_token/snapshots__stderr.snap
+++ b/noir-projects/contract-snapshots/tests/snapshots/compile_failure/bob_token/snapshots__stderr.snap
@@ -64,9 +64,9 @@ error: Function _assert_is_owner must be marked as either #[external(...)], #[in
     1: #[aztec]
             at src/main.nr:18:1
     2: aztec
-            at <repo>/noir-projects/aztec-nr/aztec/src/macros/aztec.nr:93:5
+            at <repo>/noir-projects/aztec-nr/aztec/src/macros/aztec.nr:107:5
     3: check_each_fn_macroified
-            at <repo>/noir-projects/aztec-nr/aztec/src/macros/aztec.nr:295:13
+            at <repo>/noir-projects/aztec-nr/aztec/src/macros/aztec.nr:341:13
 
 error: cannot find `self` in this scope
    ┌─ src/main.nr:41:9

--- a/noir-projects/contract-snapshots/tests/snapshots/compile_failure/invalid_note/snapshots__stderr.snap
+++ b/noir-projects/contract-snapshots/tests/snapshots/compile_failure/invalid_note/snapshots__stderr.snap
@@ -10,13 +10,13 @@ error: InvalidNote has a packed length of 9 fields, which exceeds the maximum al
    │
    = Call stack:
       1: generate_sync_state
-             at <repo>/noir-projects/aztec-nr/aztec/src/macros/aztec.nr:240:13
+             at <repo>/noir-projects/aztec-nr/aztec/src/macros/aztec.nr:269:13
       2: do_sync_state
-             at <repo>/noir-projects/aztec-nr/aztec/src/messages/discovery/mod.nr:130:5
+             at <repo>/noir-projects/aztec-nr/aztec/src/messages/discovery/mod.nr:144:5
       3: EphemeralArray<T>::for_each
              at <repo>/noir-projects/aztec-nr/aztec/src/ephemeral/mod.nr:99:13
       4: do_sync_state
-             at <repo>/noir-projects/aztec-nr/aztec/src/messages/discovery/mod.nr:139:13
+             at <repo>/noir-projects/aztec-nr/aztec/src/messages/discovery/mod.nr:153:13
       5: process_message_ciphertext
              at <repo>/noir-projects/aztec-nr/aztec/src/messages/discovery/process_message.nr:41:9
       6: process_message_plaintext

--- a/noir-projects/contract-snapshots/tests/snapshots/compile_failure/public_function_selector_collision/snapshots__stderr.snap
+++ b/noir-projects/contract-snapshots/tests/snapshots/compile_failure/public_function_selector_collision/snapshots__stderr.snap
@@ -12,7 +12,7 @@ error: Public function selector collision detected between functions 'fn_selecto
     1: #[aztec]
             at src/main.nr:4:1
     2: aztec
-            at <repo>/noir-projects/aztec-nr/aztec/src/macros/aztec.nr:145:27
+            at <repo>/noir-projects/aztec-nr/aztec/src/macros/aztec.nr:169:27
     3: generate_public_dispatch
             at <repo>/noir-projects/aztec-nr/aztec/src/macros/dispatch.nr:20:19
     4: [T]::map

--- a/noir-projects/contract-snapshots/tests/snapshots/compile_failure/unmacroified_function_in_contract/snapshots__stderr.snap
+++ b/noir-projects/contract-snapshots/tests/snapshots/compile_failure/unmacroified_function_in_contract/snapshots__stderr.snap
@@ -12,8 +12,8 @@ error: Function foo must be marked as either #[external(...)], #[internal(...)],
     1: #[aztec]
             at src/main.nr:4:1
     2: aztec
-            at <repo>/noir-projects/aztec-nr/aztec/src/macros/aztec.nr:93:5
+            at <repo>/noir-projects/aztec-nr/aztec/src/macros/aztec.nr:107:5
     3: check_each_fn_macroified
-            at <repo>/noir-projects/aztec-nr/aztec/src/macros/aztec.nr:295:13
+            at <repo>/noir-projects/aztec-nr/aztec/src/macros/aztec.nr:341:13
 
 Aborting due to 1 previous error

--- a/noir-projects/contract-snapshots/tests/snapshots/compile_failure/user_defined_offchain_receive/snapshots__stderr.snap
+++ b/noir-projects/contract-snapshots/tests/snapshots/compile_failure/user_defined_offchain_receive/snapshots__stderr.snap
@@ -12,6 +12,6 @@ error: User-defined 'offchain_receive' is not allowed. The function is auto-inje
     1: #[aztec]
             at src/main.nr:4:1
     2: aztec
-            at <repo>/noir-projects/aztec-nr/aztec/src/macros/aztec.nr:138:9
+            at <repo>/noir-projects/aztec-nr/aztec/src/macros/aztec.nr:162:9
 
 Aborting due to 1 previous error

--- a/noir-projects/contract-snapshots/tests/snapshots/compile_failure/user_defined_sync_state/snapshots__stderr.snap
+++ b/noir-projects/contract-snapshots/tests/snapshots/compile_failure/user_defined_sync_state/snapshots__stderr.snap
@@ -2,7 +2,7 @@
 source: tests/snapshots.rs
 expression: stderr
 ---
-error: #[aztec] expects 0 or 1 arguments, got 2
+error: User-defined 'sync_state' is not allowed. Use AztecConfig::custom_sync_state() to customize sync behavior.
   ┌─ std/panic.nr:8:12
   │
 8 │     assert(false, message);
@@ -10,8 +10,8 @@ error: #[aztec] expects 0 or 1 arguments, got 2
   │
   = Call stack:
     1: #[aztec]
-            at src/main.nr:4:1
+            at src/main.nr:5:1
     2: aztec
-            at <repo>/noir-projects/aztec-nr/aztec/src/macros/aztec.nr:103:9
+            at <repo>/noir-projects/aztec-nr/aztec/src/macros/aztec.nr:146:9
 
 Aborting due to 1 previous error

--- a/noir-projects/contract-snapshots/tests/snapshots/expand/amm_contract/snapshots__expanded.snap
+++ b/noir-projects/contract-snapshots/tests/snapshots/expand/amm_contract/snapshots__expanded.snap
@@ -1001,7 +1001,7 @@ pub contract AMM {
 
     unconstrained fn sync_state(scope: AztecAddress) {
         let address: AztecAddress = aztec::context::UtilityContext::new().this_address();
-        aztec::messages::discovery::do_sync_state(address, _compute_note_hash, _compute_note_nullifier, Option::<aztec::messages::discovery::CustomMessageHandler<()>>::none(), Option::<unconstrained fn(AztecAddress, AztecAddress) -> aztec::ephemeral::EphemeralArray<aztec::messages::processing::OffchainMessageWithContext>>::some(aztec::messages::processing::offchain::sync_inbox), scope);
+        aztec::messages::discovery::do_sync_state(address, _compute_note_hash, _compute_note_nullifier, Option::<unconstrained fn(AztecAddress, u64, u64, BoundedVec<Field, 11>, aztec::messages::processing::MessageContext, AztecAddress)>::none(), Option::<unconstrained fn(AztecAddress, AztecAddress) -> aztec::ephemeral::EphemeralArray<aztec::messages::processing::OffchainMessageWithContext>>::some(aztec::messages::processing::offchain::sync_inbox), scope);
     }
 
     pub struct offchain_receive_parameters {
@@ -1424,61 +1424,6 @@ pub contract AMM {
             returns_hash.get_preimage()
         }
 
-        pub fn swap_tokens_for_exact_tokens(self, token_in: AztecAddress, token_out: AztecAddress, amount_out: u128, amount_in_max: u128, authwit_nonce: Field) {
-            let mut serialized_params: [Field; 5] = [0_Field; 5];
-            let mut offset: u32 = 0_u32;
-            let serialized_member: [Field; 1] = <AztecAddress as aztec::protocol::traits::Serialize>::serialize(token_in);
-            let serialized_member_len: u32 = <AztecAddress as aztec::protocol::traits::Serialize>::N;
-            for i in 0_u32..serialized_member_len {
-                {
-                    let i_0: u32 = i + offset;
-                    serialized_params[i_0] = serialized_member[i];
-                }
-            };
-            offset = offset + serialized_member_len;
-            let serialized_member: [Field; 1] = <AztecAddress as aztec::protocol::traits::Serialize>::serialize(token_out);
-            let serialized_member_len: u32 = <AztecAddress as aztec::protocol::traits::Serialize>::N;
-            for i in 0_u32..serialized_member_len {
-                {
-                    let i_1: u32 = i + offset;
-                    serialized_params[i_1] = serialized_member[i];
-                }
-            };
-            offset = offset + serialized_member_len;
-            let serialized_member: [Field; 1] = <u128 as aztec::protocol::traits::Serialize>::serialize(amount_out);
-            let serialized_member_len: u32 = <u128 as aztec::protocol::traits::Serialize>::N;
-            for i in 0_u32..serialized_member_len {
-                {
-                    let i_2: u32 = i + offset;
-                    serialized_params[i_2] = serialized_member[i];
-                }
-            };
-            offset = offset + serialized_member_len;
-            let serialized_member: [Field; 1] = <u128 as aztec::protocol::traits::Serialize>::serialize(amount_in_max);
-            let serialized_member_len: u32 = <u128 as aztec::protocol::traits::Serialize>::N;
-            for i in 0_u32..serialized_member_len {
-                {
-                    let i_3: u32 = i + offset;
-                    serialized_params[i_3] = serialized_member[i];
-                }
-            };
-            offset = offset + serialized_member_len;
-            let serialized_member: [Field; 1] = <Field as aztec::protocol::traits::Serialize>::serialize(authwit_nonce);
-            let serialized_member_len: u32 = <Field as aztec::protocol::traits::Serialize>::N;
-            for i in 0_u32..serialized_member_len {
-                {
-                    let i_4: u32 = i + offset;
-                    serialized_params[i_4] = serialized_member[i];
-                }
-            };
-            offset = offset + serialized_member_len;
-            let selector: aztec::protocol::abis::function_selector::FunctionSelector = <aztec::protocol::abis::function_selector::FunctionSelector as aztec::protocol::traits::FromField>::from_field(2620890703_Field);
-            let args_hash: Field = aztec::hash::hash_args(serialized_params);
-            aztec::oracle::execution_cache::store(serialized_params, args_hash);
-            let returns_hash: aztec::context::ReturnsHash = self.context.call_private_function_with_args_hash(self.address, selector, args_hash, false);
-            returns_hash.get_preimage()
-        }
-
         pub fn swap_exact_tokens_for_tokens(self, token_in: AztecAddress, token_out: AztecAddress, amount_in: u128, amount_out_min: u128, authwit_nonce: Field) {
             let mut serialized_params: [Field; 5] = [0_Field; 5];
             let mut offset: u32 = 0_u32;
@@ -1528,6 +1473,61 @@ pub contract AMM {
             };
             offset = offset + serialized_member_len;
             let selector: aztec::protocol::abis::function_selector::FunctionSelector = <aztec::protocol::abis::function_selector::FunctionSelector as aztec::protocol::traits::FromField>::from_field(2960373586_Field);
+            let args_hash: Field = aztec::hash::hash_args(serialized_params);
+            aztec::oracle::execution_cache::store(serialized_params, args_hash);
+            let returns_hash: aztec::context::ReturnsHash = self.context.call_private_function_with_args_hash(self.address, selector, args_hash, false);
+            returns_hash.get_preimage()
+        }
+
+        pub fn swap_tokens_for_exact_tokens(self, token_in: AztecAddress, token_out: AztecAddress, amount_out: u128, amount_in_max: u128, authwit_nonce: Field) {
+            let mut serialized_params: [Field; 5] = [0_Field; 5];
+            let mut offset: u32 = 0_u32;
+            let serialized_member: [Field; 1] = <AztecAddress as aztec::protocol::traits::Serialize>::serialize(token_in);
+            let serialized_member_len: u32 = <AztecAddress as aztec::protocol::traits::Serialize>::N;
+            for i in 0_u32..serialized_member_len {
+                {
+                    let i_0: u32 = i + offset;
+                    serialized_params[i_0] = serialized_member[i];
+                }
+            };
+            offset = offset + serialized_member_len;
+            let serialized_member: [Field; 1] = <AztecAddress as aztec::protocol::traits::Serialize>::serialize(token_out);
+            let serialized_member_len: u32 = <AztecAddress as aztec::protocol::traits::Serialize>::N;
+            for i in 0_u32..serialized_member_len {
+                {
+                    let i_1: u32 = i + offset;
+                    serialized_params[i_1] = serialized_member[i];
+                }
+            };
+            offset = offset + serialized_member_len;
+            let serialized_member: [Field; 1] = <u128 as aztec::protocol::traits::Serialize>::serialize(amount_out);
+            let serialized_member_len: u32 = <u128 as aztec::protocol::traits::Serialize>::N;
+            for i in 0_u32..serialized_member_len {
+                {
+                    let i_2: u32 = i + offset;
+                    serialized_params[i_2] = serialized_member[i];
+                }
+            };
+            offset = offset + serialized_member_len;
+            let serialized_member: [Field; 1] = <u128 as aztec::protocol::traits::Serialize>::serialize(amount_in_max);
+            let serialized_member_len: u32 = <u128 as aztec::protocol::traits::Serialize>::N;
+            for i in 0_u32..serialized_member_len {
+                {
+                    let i_3: u32 = i + offset;
+                    serialized_params[i_3] = serialized_member[i];
+                }
+            };
+            offset = offset + serialized_member_len;
+            let serialized_member: [Field; 1] = <Field as aztec::protocol::traits::Serialize>::serialize(authwit_nonce);
+            let serialized_member_len: u32 = <Field as aztec::protocol::traits::Serialize>::N;
+            for i in 0_u32..serialized_member_len {
+                {
+                    let i_4: u32 = i + offset;
+                    serialized_params[i_4] = serialized_member[i];
+                }
+            };
+            offset = offset + serialized_member_len;
+            let selector: aztec::protocol::abis::function_selector::FunctionSelector = <aztec::protocol::abis::function_selector::FunctionSelector as aztec::protocol::traits::FromField>::from_field(2620890703_Field);
             let args_hash: Field = aztec::hash::hash_args(serialized_params);
             aztec::oracle::execution_cache::store(serialized_params, args_hash);
             let returns_hash: aztec::context::ReturnsHash = self.context.call_private_function_with_args_hash(self.address, selector, args_hash, false);

--- a/noir-projects/contract-snapshots/tests/snapshots/expand/avm_gadgets_test_contract/snapshots__expanded.snap
+++ b/noir-projects/contract-snapshots/tests/snapshots/expand/avm_gadgets_test_contract/snapshots__expanded.snap
@@ -332,7 +332,7 @@ contract AvmGadgetsTest {
 
     unconstrained fn sync_state(scope: aztec::protocol::address::AztecAddress) {
         let address: aztec::protocol::address::AztecAddress = aztec::context::UtilityContext::new().this_address();
-        aztec::messages::discovery::do_sync_state(address, _compute_note_hash, _compute_note_nullifier, Option::<aztec::messages::discovery::CustomMessageHandler<()>>::none(), Option::<unconstrained fn(aztec::protocol::address::AztecAddress, aztec::protocol::address::AztecAddress) -> aztec::ephemeral::EphemeralArray<aztec::messages::processing::OffchainMessageWithContext>>::some(aztec::messages::processing::offchain::sync_inbox), scope);
+        aztec::messages::discovery::do_sync_state(address, _compute_note_hash, _compute_note_nullifier, Option::<unconstrained fn(aztec::protocol::address::AztecAddress, u64, u64, BoundedVec<Field, 11>, aztec::messages::processing::MessageContext, aztec::protocol::address::AztecAddress)>::none(), Option::<unconstrained fn(aztec::protocol::address::AztecAddress, aztec::protocol::address::AztecAddress) -> aztec::ephemeral::EphemeralArray<aztec::messages::processing::OffchainMessageWithContext>>::some(aztec::messages::processing::offchain::sync_inbox), scope);
     }
 
     pub struct offchain_receive_parameters {

--- a/noir-projects/contract-snapshots/tests/snapshots/expand/avm_test_contract/snapshots__expanded.snap
+++ b/noir-projects/contract-snapshots/tests/snapshots/expand/avm_test_contract/snapshots__expanded.snap
@@ -1492,10 +1492,10 @@ pub contract AvmTest {
             aztec::context::calls::PublicCall::<41, 2, ()>::new(self.target_contract, selector, "create_different_nullifier_in_nested_call", serialized_params)
         }
 
-        pub fn call_fee_juice(self) -> aztec::context::calls::PublicCall<14, 0, ()> {
-            let serialized_params: [Field; 0] = [];
-            let selector: FunctionSelector = FunctionSelector::from_field(2734888597_Field);
-            aztec::context::calls::PublicCall::<14, 0, ()>::new(self.target_contract, selector, "call_fee_juice", serialized_params)
+        pub fn nested_call_large_calldata(self, arr: [Field; 300]) -> aztec::context::calls::PublicCall<26, 300, Field> {
+            let serialized_params: [Field; 300] = arr.serialize();
+            let selector: FunctionSelector = FunctionSelector::from_field(14812432_Field);
+            aztec::context::calls::PublicCall::<26, 300, Field>::new(self.target_contract, selector, "nested_call_large_calldata", serialized_params)
         }
 
         pub fn get_transaction_fee(self) -> aztec::context::calls::PublicCall<19, 0, Field> {
@@ -1522,6 +1522,12 @@ pub contract AvmTest {
             aztec::context::calls::PublicStaticCall::<18, 0, u8>::new(self.target_contract, selector, "set_opcode_u8_view", serialized_params)
         }
 
+        pub fn call_fee_juice(self) -> aztec::context::calls::PublicCall<14, 0, ()> {
+            let serialized_params: [Field; 0] = [];
+            let selector: FunctionSelector = FunctionSelector::from_field(2734888597_Field);
+            aztec::context::calls::PublicCall::<14, 0, ()>::new(self.target_contract, selector, "call_fee_juice", serialized_params)
+        }
+
         pub fn assert_nullifier_exists(self, nullifier: Field) -> aztec::context::calls::PublicCall<23, 1, ()> {
             let serialized_params: [Field; 1] = nullifier.serialize();
             let selector: FunctionSelector = FunctionSelector::from_field(2810255355_Field);
@@ -1538,12 +1544,6 @@ pub contract AvmTest {
             let serialized_params: [Field; 0] = [];
             let selector: FunctionSelector = FunctionSelector::from_field(3667472301_Field);
             aztec::context::calls::PublicCall::<13, 0, ()>::new(self.target_contract, selector, "debug_logging", serialized_params)
-        }
-
-        pub fn nested_call_large_calldata(self, arr: [Field; 300]) -> aztec::context::calls::PublicCall<26, 300, Field> {
-            let serialized_params: [Field; 300] = arr.serialize();
-            let selector: FunctionSelector = FunctionSelector::from_field(14812432_Field);
-            aztec::context::calls::PublicCall::<26, 300, Field>::new(self.target_contract, selector, "nested_call_large_calldata", serialized_params)
         }
 
         pub fn external_call_to_divide_by_zero_recovers(self) -> aztec::context::calls::PublicCall<40, 0, ()> {
@@ -1874,7 +1874,7 @@ pub contract AvmTest {
 
     unconstrained fn sync_state(scope: AztecAddress) {
         let address: AztecAddress = aztec::context::UtilityContext::new().this_address();
-        aztec::messages::discovery::do_sync_state(address, _compute_note_hash, _compute_note_nullifier, Option::<aztec::messages::discovery::CustomMessageHandler<()>>::none(), Option::<unconstrained fn(AztecAddress, AztecAddress) -> aztec::ephemeral::EphemeralArray<aztec::messages::processing::OffchainMessageWithContext>>::some(aztec::messages::processing::offchain::sync_inbox), scope);
+        aztec::messages::discovery::do_sync_state(address, _compute_note_hash, _compute_note_nullifier, Option::<unconstrained fn(AztecAddress, u64, u64, BoundedVec<Field, 11>, aztec::messages::processing::MessageContext, AztecAddress)>::none(), Option::<unconstrained fn(AztecAddress, AztecAddress) -> aztec::ephemeral::EphemeralArray<aztec::messages::processing::OffchainMessageWithContext>>::some(aztec::messages::processing::offchain::sync_inbox), scope);
     }
 
     pub struct offchain_receive_parameters {
@@ -2131,34 +2131,6 @@ pub contract AvmTest {
             }
         }
 
-        pub fn add_args_return(self, arg_a: Field, arg_b: Field) -> Field {
-            let mut serialized_params: [Field; 2] = [0_Field; 2];
-            let mut offset: u32 = 0_u32;
-            let serialized_member: [Field; 1] = arg_a.serialize();
-            let serialized_member_len: u32 = <Field as Serialize>::N;
-            for i in 0_u32..serialized_member_len {
-                {
-                    let i_0: u32 = i + offset;
-                    serialized_params[i_0] = serialized_member[i];
-                }
-            };
-            offset = offset + serialized_member_len;
-            let serialized_member: [Field; 1] = arg_b.serialize();
-            let serialized_member_len: u32 = <Field as Serialize>::N;
-            for i in 0_u32..serialized_member_len {
-                {
-                    let i_1: u32 = i + offset;
-                    serialized_params[i_1] = serialized_member[i];
-                }
-            };
-            offset = offset + serialized_member_len;
-            let selector: FunctionSelector = FunctionSelector::from_field(2858633377_Field);
-            // Safety: comment added by `nargo expand`
-            unsafe {
-                aztec::context::calls::PublicCall::<15, 2, Field>::new(self.address, selector, "add_args_return", serialized_params).call(self.context)
-            }
-        }
-
         pub fn variable_base_msm(self, scalar_lo: Field, scalar_hi: Field, scalar2_lo: Field, scalar2_hi: Field) -> Point {
             let mut serialized_params: [Field; 4] = [0_Field; 4];
             let mut offset: u32 = 0_u32;
@@ -2202,6 +2174,34 @@ pub contract AvmTest {
             // Safety: comment added by `nargo expand`
             unsafe {
                 aztec::context::calls::PublicCall::<17, 4, Point>::new(self.address, selector, "variable_base_msm", serialized_params).call(self.context)
+            }
+        }
+
+        pub fn add_args_return(self, arg_a: Field, arg_b: Field) -> Field {
+            let mut serialized_params: [Field; 2] = [0_Field; 2];
+            let mut offset: u32 = 0_u32;
+            let serialized_member: [Field; 1] = arg_a.serialize();
+            let serialized_member_len: u32 = <Field as Serialize>::N;
+            for i in 0_u32..serialized_member_len {
+                {
+                    let i_0: u32 = i + offset;
+                    serialized_params[i_0] = serialized_member[i];
+                }
+            };
+            offset = offset + serialized_member_len;
+            let serialized_member: [Field; 1] = arg_b.serialize();
+            let serialized_member_len: u32 = <Field as Serialize>::N;
+            for i in 0_u32..serialized_member_len {
+                {
+                    let i_1: u32 = i + offset;
+                    serialized_params[i_1] = serialized_member[i];
+                }
+            };
+            offset = offset + serialized_member_len;
+            let selector: FunctionSelector = FunctionSelector::from_field(2858633377_Field);
+            // Safety: comment added by `nargo expand`
+            unsafe {
+                aztec::context::calls::PublicCall::<15, 2, Field>::new(self.address, selector, "add_args_return", serialized_params).call(self.context)
             }
         }
 
@@ -2498,15 +2498,6 @@ pub contract AvmTest {
             }
         }
 
-        pub fn new_nullifier(self, nullifier: Field) {
-            let serialized_params: [Field; 1] = nullifier.serialize();
-            let selector: FunctionSelector = FunctionSelector::from_field(3648851082_Field);
-            // Safety: comment added by `nargo expand`
-            unsafe {
-                aztec::context::calls::PublicCall::<13, 1, ()>::new(self.address, selector, "new_nullifier", serialized_params).call(self.context)
-            }
-        }
-
         pub fn divide_by_zero(self, denominator: u8) -> u8 {
             let serialized_params: [Field; 1] = denominator.serialize();
             let selector: FunctionSelector = FunctionSelector::from_field(815932481_Field);
@@ -2522,6 +2513,15 @@ pub contract AvmTest {
             // Safety: comment added by `nargo expand`
             unsafe {
                 aztec::context::calls::PublicCall::<15, 0, ()>::new(self.address, selector, "emit_public_log", serialized_params).call(self.context)
+            }
+        }
+
+        pub fn new_nullifier(self, nullifier: Field) {
+            let serialized_params: [Field; 1] = nullifier.serialize();
+            let selector: FunctionSelector = FunctionSelector::from_field(3648851082_Field);
+            // Safety: comment added by `nargo expand`
+            unsafe {
+                aztec::context::calls::PublicCall::<13, 1, ()>::new(self.address, selector, "new_nullifier", serialized_params).call(self.context)
             }
         }
 
@@ -2627,15 +2627,6 @@ pub contract AvmTest {
             }
         }
 
-        pub fn returndata_copy_oracle(self) {
-            let serialized_params: [Field; 0] = [];
-            let selector: FunctionSelector = FunctionSelector::from_field(4172530660_Field);
-            // Safety: comment added by `nargo expand`
-            unsafe {
-                aztec::context::calls::PublicCall::<22, 0, ()>::new(self.address, selector, "returndata_copy_oracle", serialized_params).call(self.context)
-            }
-        }
-
         pub fn set_read_storage_single(self, a: Field) -> Field {
             let serialized_params: [Field; 1] = a.serialize();
             let selector: FunctionSelector = FunctionSelector::from_field(1932358992_Field);
@@ -2645,12 +2636,12 @@ pub contract AvmTest {
             }
         }
 
-        pub fn n_new_public_logs(self, num: u32) {
-            let serialized_params: [Field; 1] = num.serialize();
-            let selector: FunctionSelector = FunctionSelector::from_field(2907114368_Field);
+        pub fn returndata_copy_oracle(self) {
+            let serialized_params: [Field; 0] = [];
+            let selector: FunctionSelector = FunctionSelector::from_field(4172530660_Field);
             // Safety: comment added by `nargo expand`
             unsafe {
-                aztec::context::calls::PublicCall::<17, 1, ()>::new(self.address, selector, "n_new_public_logs", serialized_params).call(self.context)
+                aztec::context::calls::PublicCall::<22, 0, ()>::new(self.address, selector, "returndata_copy_oracle", serialized_params).call(self.context)
             }
         }
 
@@ -2697,6 +2688,15 @@ pub contract AvmTest {
             // Safety: comment added by `nargo expand`
             unsafe {
                 aztec::context::calls::PublicCall::<22, 0, Field>::new(self.address, selector, "set_opcode_small_field", serialized_params).call(self.context)
+            }
+        }
+
+        pub fn n_new_public_logs(self, num: u32) {
+            let serialized_params: [Field; 1] = num.serialize();
+            let selector: FunctionSelector = FunctionSelector::from_field(2907114368_Field);
+            // Safety: comment added by `nargo expand`
+            unsafe {
+                aztec::context::calls::PublicCall::<17, 1, ()>::new(self.address, selector, "n_new_public_logs", serialized_params).call(self.context)
             }
         }
 
@@ -2783,12 +2783,12 @@ pub contract AvmTest {
             }
         }
 
-        pub fn call_fee_juice(self) {
-            let serialized_params: [Field; 0] = [];
-            let selector: FunctionSelector = FunctionSelector::from_field(2734888597_Field);
+        pub fn nested_call_large_calldata(self, arr: [Field; 300]) -> Field {
+            let serialized_params: [Field; 300 * 1] = arr.serialize();
+            let selector: FunctionSelector = FunctionSelector::from_field(14812432_Field);
             // Safety: comment added by `nargo expand`
             unsafe {
-                aztec::context::calls::PublicCall::<14, 0, ()>::new(self.address, selector, "call_fee_juice", serialized_params).call(self.context)
+                aztec::context::calls::PublicCall::<26, 300 * 1, Field>::new(self.address, selector, "nested_call_large_calldata", serialized_params).call(self.context)
             }
         }
 
@@ -2819,6 +2819,15 @@ pub contract AvmTest {
             }
         }
 
+        pub fn call_fee_juice(self) {
+            let serialized_params: [Field; 0] = [];
+            let selector: FunctionSelector = FunctionSelector::from_field(2734888597_Field);
+            // Safety: comment added by `nargo expand`
+            unsafe {
+                aztec::context::calls::PublicCall::<14, 0, ()>::new(self.address, selector, "call_fee_juice", serialized_params).call(self.context)
+            }
+        }
+
         pub fn assert_nullifier_exists(self, nullifier: Field) {
             let serialized_params: [Field; 1] = nullifier.serialize();
             let selector: FunctionSelector = FunctionSelector::from_field(2810255355_Field);
@@ -2843,15 +2852,6 @@ pub contract AvmTest {
             // Safety: comment added by `nargo expand`
             unsafe {
                 aztec::context::calls::PublicCall::<13, 0, ()>::new(self.address, selector, "debug_logging", serialized_params).call(self.context)
-            }
-        }
-
-        pub fn nested_call_large_calldata(self, arr: [Field; 300]) -> Field {
-            let serialized_params: [Field; 300 * 1] = arr.serialize();
-            let selector: FunctionSelector = FunctionSelector::from_field(14812432_Field);
-            // Safety: comment added by `nargo expand`
-            unsafe {
-                aztec::context::calls::PublicCall::<26, 300 * 1, Field>::new(self.address, selector, "nested_call_large_calldata", serialized_params).call(self.context)
             }
         }
 
@@ -3871,15 +3871,6 @@ pub contract AvmTest {
             self.context.call_public_function_with_calldata_hash(self.address, calldata_hash, false, false);
         }
 
-        pub fn new_nullifier(self, nullifier: Field) {
-            let serialized_params: [Field; 1] = nullifier.serialize();
-            let selector: FunctionSelector = FunctionSelector::from_field(3648851082_Field);
-            let calldata: [Field; 1 + 1] = [selector.to_field()].concat(serialized_params);
-            let calldata_hash: Field = aztec::hash::hash_calldata_array(calldata);
-            aztec::oracle::execution_cache::store(calldata, calldata_hash);
-            self.context.call_public_function_with_calldata_hash(self.address, calldata_hash, false, false);
-        }
-
         pub fn divide_by_zero(self, denominator: u8) {
             let serialized_params: [Field; 1] = denominator.serialize();
             let selector: FunctionSelector = FunctionSelector::from_field(815932481_Field);
@@ -3893,6 +3884,15 @@ pub contract AvmTest {
             let serialized_params: [Field; 0] = [];
             let selector: FunctionSelector = FunctionSelector::from_field(2033426724_Field);
             let calldata: [Field; 1 + 0] = [selector.to_field()].concat(serialized_params);
+            let calldata_hash: Field = aztec::hash::hash_calldata_array(calldata);
+            aztec::oracle::execution_cache::store(calldata, calldata_hash);
+            self.context.call_public_function_with_calldata_hash(self.address, calldata_hash, false, false);
+        }
+
+        pub fn new_nullifier(self, nullifier: Field) {
+            let serialized_params: [Field; 1] = nullifier.serialize();
+            let selector: FunctionSelector = FunctionSelector::from_field(3648851082_Field);
+            let calldata: [Field; 1 + 1] = [selector.to_field()].concat(serialized_params);
             let calldata_hash: Field = aztec::hash::hash_calldata_array(calldata);
             aztec::oracle::execution_cache::store(calldata, calldata_hash);
             self.context.call_public_function_with_calldata_hash(self.address, calldata_hash, false, false);
@@ -4156,6 +4156,15 @@ pub contract AvmTest {
             self.context.call_public_function_with_calldata_hash(self.address, calldata_hash, false, false);
         }
 
+        pub fn nested_call_large_calldata(self, arr: [Field; 300]) {
+            let serialized_params: [Field; 300 * 1] = arr.serialize();
+            let selector: FunctionSelector = FunctionSelector::from_field(14812432_Field);
+            let calldata: [Field; 1 + (300 * 1)] = [selector.to_field()].concat(serialized_params);
+            let calldata_hash: Field = aztec::hash::hash_calldata_array(calldata);
+            aztec::oracle::execution_cache::store(calldata, calldata_hash);
+            self.context.call_public_function_with_calldata_hash(self.address, calldata_hash, false, false);
+        }
+
         pub fn call_fee_juice(self) {
             let serialized_params: [Field; 0] = [];
             let selector: FunctionSelector = FunctionSelector::from_field(2734888597_Field);
@@ -4214,15 +4223,6 @@ pub contract AvmTest {
             let serialized_params: [Field; 0] = [];
             let selector: FunctionSelector = FunctionSelector::from_field(3667472301_Field);
             let calldata: [Field; 1 + 0] = [selector.to_field()].concat(serialized_params);
-            let calldata_hash: Field = aztec::hash::hash_calldata_array(calldata);
-            aztec::oracle::execution_cache::store(calldata, calldata_hash);
-            self.context.call_public_function_with_calldata_hash(self.address, calldata_hash, false, false);
-        }
-
-        pub fn nested_call_large_calldata(self, arr: [Field; 300]) {
-            let serialized_params: [Field; 300 * 1] = arr.serialize();
-            let selector: FunctionSelector = FunctionSelector::from_field(14812432_Field);
-            let calldata: [Field; 1 + (300 * 1)] = [selector.to_field()].concat(serialized_params);
             let calldata_hash: Field = aztec::hash::hash_calldata_array(calldata);
             aztec::oracle::execution_cache::store(calldata, calldata_hash);
             self.context.call_public_function_with_calldata_hash(self.address, calldata_hash, false, false);

--- a/noir-projects/contract-snapshots/tests/snapshots/expand/public_fns_with_emit_repro_contract/snapshots__expanded.snap
+++ b/noir-projects/contract-snapshots/tests/snapshots/expand/public_fns_with_emit_repro_contract/snapshots__expanded.snap
@@ -308,7 +308,7 @@ pub contract PublicFnsWithEmitRepro {
 
     unconstrained fn sync_state(scope: aztec::protocol::address::AztecAddress) {
         let address: aztec::protocol::address::AztecAddress = aztec::context::UtilityContext::new().this_address();
-        aztec::messages::discovery::do_sync_state(address, _compute_note_hash, _compute_note_nullifier, Option::<aztec::messages::discovery::CustomMessageHandler<()>>::none(), Option::<unconstrained fn(aztec::protocol::address::AztecAddress, aztec::protocol::address::AztecAddress) -> aztec::ephemeral::EphemeralArray<aztec::messages::processing::OffchainMessageWithContext>>::some(aztec::messages::processing::offchain::sync_inbox), scope);
+        aztec::messages::discovery::do_sync_state(address, _compute_note_hash, _compute_note_nullifier, Option::<unconstrained fn(aztec::protocol::address::AztecAddress, u64, u64, BoundedVec<Field, 11>, aztec::messages::processing::MessageContext, aztec::protocol::address::AztecAddress)>::none(), Option::<unconstrained fn(aztec::protocol::address::AztecAddress, aztec::protocol::address::AztecAddress) -> aztec::ephemeral::EphemeralArray<aztec::messages::processing::OffchainMessageWithContext>>::some(aztec::messages::processing::offchain::sync_inbox), scope);
     }
 
     pub struct offchain_receive_parameters {

--- a/noir-projects/contract-snapshots/tests/snapshots/expand/storage_proof_test_contract/snapshots__expanded.snap
+++ b/noir-projects/contract-snapshots/tests/snapshots/expand/storage_proof_test_contract/snapshots__expanded.snap
@@ -309,7 +309,7 @@ contract StorageProofTest {
 
     unconstrained fn sync_state(scope: AztecAddress) {
         let address: AztecAddress = aztec::context::UtilityContext::new().this_address();
-        aztec::messages::discovery::do_sync_state(address, _compute_note_hash, _compute_note_nullifier, Option::<aztec::messages::discovery::CustomMessageHandler<()>>::none(), Option::<unconstrained fn(AztecAddress, AztecAddress) -> aztec::ephemeral::EphemeralArray<aztec::messages::processing::OffchainMessageWithContext>>::some(aztec::messages::processing::offchain::sync_inbox), scope);
+        aztec::messages::discovery::do_sync_state(address, _compute_note_hash, _compute_note_nullifier, Option::<unconstrained fn(AztecAddress, u64, u64, BoundedVec<Field, 11>, aztec::messages::processing::MessageContext, AztecAddress)>::none(), Option::<unconstrained fn(AztecAddress, AztecAddress) -> aztec::ephemeral::EphemeralArray<aztec::messages::processing::OffchainMessageWithContext>>::some(aztec::messages::processing::offchain::sync_inbox), scope);
     }
 
     pub struct offchain_receive_parameters {

--- a/noir-projects/contract-snapshots/tests/snapshots/expand/token_contract/snapshots__expanded.snap
+++ b/noir-projects/contract-snapshots/tests/snapshots/expand/token_contract/snapshots__expanded.snap
@@ -1217,7 +1217,7 @@ pub contract Token {
 
     unconstrained fn sync_state(scope: AztecAddress) {
         let address: AztecAddress = aztec::context::UtilityContext::new().this_address();
-        aztec::messages::discovery::do_sync_state(address, _compute_note_hash, _compute_note_nullifier, Option::<aztec::messages::discovery::CustomMessageHandler<()>>::none(), Option::<unconstrained fn(AztecAddress, AztecAddress) -> aztec::ephemeral::EphemeralArray<aztec::messages::processing::OffchainMessageWithContext>>::some(aztec::messages::processing::offchain::sync_inbox), scope);
+        aztec::messages::discovery::do_sync_state(address, _compute_note_hash, _compute_note_nullifier, Option::<unconstrained fn(AztecAddress, u64, u64, BoundedVec<Field, 11>, aztec::messages::processing::MessageContext, AztecAddress)>::none(), Option::<unconstrained fn(AztecAddress, AztecAddress) -> aztec::ephemeral::EphemeralArray<aztec::messages::processing::OffchainMessageWithContext>>::some(aztec::messages::processing::offchain::sync_inbox), scope);
     }
 
     pub struct offchain_receive_parameters {
@@ -1309,52 +1309,6 @@ pub contract Token {
             }
         }
 
-        pub fn constructor(self, admin: AztecAddress, name: str<31>, symbol: str<31>, decimals: u8) {
-            let mut serialized_params: [Field; 64] = [0_Field; 64];
-            let mut offset: u32 = 0_u32;
-            let serialized_member: [Field; 1] = <AztecAddress as aztec::protocol::traits::Serialize>::serialize(admin);
-            let serialized_member_len: u32 = <AztecAddress as aztec::protocol::traits::Serialize>::N;
-            for i in 0_u32..serialized_member_len {
-                {
-                    let i_0: u32 = i + offset;
-                    serialized_params[i_0] = serialized_member[i];
-                }
-            };
-            offset = offset + serialized_member_len;
-            let serialized_member: [Field; 31] = <str<31> as aztec::protocol::traits::Serialize>::serialize(name);
-            let serialized_member_len: u32 = <str<31> as aztec::protocol::traits::Serialize>::N;
-            for i in 0_u32..serialized_member_len {
-                {
-                    let i_1: u32 = i + offset;
-                    serialized_params[i_1] = serialized_member[i];
-                }
-            };
-            offset = offset + serialized_member_len;
-            let serialized_member: [Field; 31] = <str<31> as aztec::protocol::traits::Serialize>::serialize(symbol);
-            let serialized_member_len: u32 = <str<31> as aztec::protocol::traits::Serialize>::N;
-            for i in 0_u32..serialized_member_len {
-                {
-                    let i_2: u32 = i + offset;
-                    serialized_params[i_2] = serialized_member[i];
-                }
-            };
-            offset = offset + serialized_member_len;
-            let serialized_member: [Field; 1] = <u8 as aztec::protocol::traits::Serialize>::serialize(decimals);
-            let serialized_member_len: u32 = <u8 as aztec::protocol::traits::Serialize>::N;
-            for i in 0_u32..serialized_member_len {
-                {
-                    let i_3: u32 = i + offset;
-                    serialized_params[i_3] = serialized_member[i];
-                }
-            };
-            offset = offset + serialized_member_len;
-            let selector: aztec::protocol::abis::function_selector::FunctionSelector = <aztec::protocol::abis::function_selector::FunctionSelector as aztec::protocol::traits::FromField>::from_field(1578322623_Field);
-            // Safety: comment added by `nargo expand`
-            unsafe {
-                aztec::context::calls::PublicCall::<11, 64, ()>::new(self.address, selector, "constructor", serialized_params).call(self.context)
-            }
-        }
-
         pub fn mint_to_public(self, to: AztecAddress, amount: u128) {
             let mut serialized_params: [Field; 2] = [0_Field; 2];
             let mut offset: u32 = 0_u32;
@@ -1411,6 +1365,52 @@ pub contract Token {
             }
         }
 
+        pub fn constructor(self, admin: AztecAddress, name: str<31>, symbol: str<31>, decimals: u8) {
+            let mut serialized_params: [Field; 64] = [0_Field; 64];
+            let mut offset: u32 = 0_u32;
+            let serialized_member: [Field; 1] = <AztecAddress as aztec::protocol::traits::Serialize>::serialize(admin);
+            let serialized_member_len: u32 = <AztecAddress as aztec::protocol::traits::Serialize>::N;
+            for i in 0_u32..serialized_member_len {
+                {
+                    let i_0: u32 = i + offset;
+                    serialized_params[i_0] = serialized_member[i];
+                }
+            };
+            offset = offset + serialized_member_len;
+            let serialized_member: [Field; 31] = <str<31> as aztec::protocol::traits::Serialize>::serialize(name);
+            let serialized_member_len: u32 = <str<31> as aztec::protocol::traits::Serialize>::N;
+            for i in 0_u32..serialized_member_len {
+                {
+                    let i_1: u32 = i + offset;
+                    serialized_params[i_1] = serialized_member[i];
+                }
+            };
+            offset = offset + serialized_member_len;
+            let serialized_member: [Field; 31] = <str<31> as aztec::protocol::traits::Serialize>::serialize(symbol);
+            let serialized_member_len: u32 = <str<31> as aztec::protocol::traits::Serialize>::N;
+            for i in 0_u32..serialized_member_len {
+                {
+                    let i_2: u32 = i + offset;
+                    serialized_params[i_2] = serialized_member[i];
+                }
+            };
+            offset = offset + serialized_member_len;
+            let serialized_member: [Field; 1] = <u8 as aztec::protocol::traits::Serialize>::serialize(decimals);
+            let serialized_member_len: u32 = <u8 as aztec::protocol::traits::Serialize>::N;
+            for i in 0_u32..serialized_member_len {
+                {
+                    let i_3: u32 = i + offset;
+                    serialized_params[i_3] = serialized_member[i];
+                }
+            };
+            offset = offset + serialized_member_len;
+            let selector: aztec::protocol::abis::function_selector::FunctionSelector = <aztec::protocol::abis::function_selector::FunctionSelector as aztec::protocol::traits::FromField>::from_field(1578322623_Field);
+            // Safety: comment added by `nargo expand`
+            unsafe {
+                aztec::context::calls::PublicCall::<11, 64, ()>::new(self.address, selector, "constructor", serialized_params).call(self.context)
+            }
+        }
+
         pub fn finalize_mint_to_private(self, amount: u128, partial_note: PartialUintNote) {
             let mut serialized_params: [Field; 2] = [0_Field; 2];
             let mut offset: u32 = 0_u32;
@@ -1436,6 +1436,15 @@ pub contract Token {
             // Safety: comment added by `nargo expand`
             unsafe {
                 aztec::context::calls::PublicCall::<24, 2, ()>::new(self.address, selector, "finalize_mint_to_private", serialized_params).call(self.context)
+            }
+        }
+
+        pub fn _reduce_total_supply(self, amount: u128) {
+            let serialized_params: [Field; 1] = <u128 as aztec::protocol::traits::Serialize>::serialize(amount);
+            let selector: aztec::protocol::abis::function_selector::FunctionSelector = <aztec::protocol::abis::function_selector::FunctionSelector as aztec::protocol::traits::FromField>::from_field(2253390209_Field);
+            // Safety: comment added by `nargo expand`
+            unsafe {
+                aztec::context::calls::PublicCall::<20, 1, ()>::new(self.address, selector, "_reduce_total_supply", serialized_params).call(self.context)
             }
         }
 
@@ -1482,15 +1491,6 @@ pub contract Token {
             // Safety: comment added by `nargo expand`
             unsafe {
                 aztec::context::calls::PublicCall::<18, 4, ()>::new(self.address, selector, "transfer_in_public", serialized_params).call(self.context)
-            }
-        }
-
-        pub fn _reduce_total_supply(self, amount: u128) {
-            let serialized_params: [Field; 1] = <u128 as aztec::protocol::traits::Serialize>::serialize(amount);
-            let selector: aztec::protocol::abis::function_selector::FunctionSelector = <aztec::protocol::abis::function_selector::FunctionSelector as aztec::protocol::traits::FromField>::from_field(2253390209_Field);
-            // Safety: comment added by `nargo expand`
-            unsafe {
-                aztec::context::calls::PublicCall::<20, 1, ()>::new(self.address, selector, "_reduce_total_supply", serialized_params).call(self.context)
             }
         }
 
@@ -1598,34 +1598,6 @@ pub contract Token {
     }
 
     impl CallSelf<&mut PrivateContext> {
-        pub fn _recurse_subtract_balance(self, account: AztecAddress, amount: u128) -> u128 {
-            let mut serialized_params: [Field; 2] = [0_Field; 2];
-            let mut offset: u32 = 0_u32;
-            let serialized_member: [Field; 1] = <AztecAddress as aztec::protocol::traits::Serialize>::serialize(account);
-            let serialized_member_len: u32 = <AztecAddress as aztec::protocol::traits::Serialize>::N;
-            for i in 0_u32..serialized_member_len {
-                {
-                    let i_0: u32 = i + offset;
-                    serialized_params[i_0] = serialized_member[i];
-                }
-            };
-            offset = offset + serialized_member_len;
-            let serialized_member: [Field; 1] = <u128 as aztec::protocol::traits::Serialize>::serialize(amount);
-            let serialized_member_len: u32 = <u128 as aztec::protocol::traits::Serialize>::N;
-            for i in 0_u32..serialized_member_len {
-                {
-                    let i_1: u32 = i + offset;
-                    serialized_params[i_1] = serialized_member[i];
-                }
-            };
-            offset = offset + serialized_member_len;
-            let selector: aztec::protocol::abis::function_selector::FunctionSelector = <aztec::protocol::abis::function_selector::FunctionSelector as aztec::protocol::traits::FromField>::from_field(1536394406_Field);
-            let args_hash: Field = aztec::hash::hash_args(serialized_params);
-            aztec::oracle::execution_cache::store(serialized_params, args_hash);
-            let returns_hash: aztec::context::ReturnsHash = self.context.call_private_function_with_args_hash(self.address, selector, args_hash, false);
-            returns_hash.get_preimage()
-        }
-
         pub fn transfer(self, to: AztecAddress, amount: u128) {
             let mut serialized_params: [Field; 2] = [0_Field; 2];
             let mut offset: u32 = 0_u32;
@@ -1648,6 +1620,34 @@ pub contract Token {
             };
             offset = offset + serialized_member_len;
             let selector: aztec::protocol::abis::function_selector::FunctionSelector = <aztec::protocol::abis::function_selector::FunctionSelector as aztec::protocol::traits::FromField>::from_field(1968158567_Field);
+            let args_hash: Field = aztec::hash::hash_args(serialized_params);
+            aztec::oracle::execution_cache::store(serialized_params, args_hash);
+            let returns_hash: aztec::context::ReturnsHash = self.context.call_private_function_with_args_hash(self.address, selector, args_hash, false);
+            returns_hash.get_preimage()
+        }
+
+        pub fn _recurse_subtract_balance(self, account: AztecAddress, amount: u128) -> u128 {
+            let mut serialized_params: [Field; 2] = [0_Field; 2];
+            let mut offset: u32 = 0_u32;
+            let serialized_member: [Field; 1] = <AztecAddress as aztec::protocol::traits::Serialize>::serialize(account);
+            let serialized_member_len: u32 = <AztecAddress as aztec::protocol::traits::Serialize>::N;
+            for i in 0_u32..serialized_member_len {
+                {
+                    let i_0: u32 = i + offset;
+                    serialized_params[i_0] = serialized_member[i];
+                }
+            };
+            offset = offset + serialized_member_len;
+            let serialized_member: [Field; 1] = <u128 as aztec::protocol::traits::Serialize>::serialize(amount);
+            let serialized_member_len: u32 = <u128 as aztec::protocol::traits::Serialize>::N;
+            for i in 0_u32..serialized_member_len {
+                {
+                    let i_1: u32 = i + offset;
+                    serialized_params[i_1] = serialized_member[i];
+                }
+            };
+            offset = offset + serialized_member_len;
+            let selector: aztec::protocol::abis::function_selector::FunctionSelector = <aztec::protocol::abis::function_selector::FunctionSelector as aztec::protocol::traits::FromField>::from_field(1536394406_Field);
             let args_hash: Field = aztec::hash::hash_args(serialized_params);
             aztec::oracle::execution_cache::store(serialized_params, args_hash);
             let returns_hash: aztec::context::ReturnsHash = self.context.call_private_function_with_args_hash(self.address, selector, args_hash, false);
@@ -2067,18 +2067,18 @@ pub contract Token {
     }
 
     impl CallSelfStatic<&mut PrivateContext> {
-        pub fn private_get_name(self) -> FieldCompressedString {
+        pub fn private_get_symbol(self) -> FieldCompressedString {
             let serialized_params: [Field; 0] = [];
-            let selector: aztec::protocol::abis::function_selector::FunctionSelector = <aztec::protocol::abis::function_selector::FunctionSelector as aztec::protocol::traits::FromField>::from_field(3516522363_Field);
+            let selector: aztec::protocol::abis::function_selector::FunctionSelector = <aztec::protocol::abis::function_selector::FunctionSelector as aztec::protocol::traits::FromField>::from_field(1295669651_Field);
             let args_hash: Field = aztec::hash::hash_args(serialized_params);
             aztec::oracle::execution_cache::store(serialized_params, args_hash);
             let returns_hash: aztec::context::ReturnsHash = self.context.call_private_function_with_args_hash(self.address, selector, args_hash, true);
             returns_hash.get_preimage()
         }
 
-        pub fn private_get_symbol(self) -> FieldCompressedString {
+        pub fn private_get_name(self) -> FieldCompressedString {
             let serialized_params: [Field; 0] = [];
-            let selector: aztec::protocol::abis::function_selector::FunctionSelector = <aztec::protocol::abis::function_selector::FunctionSelector as aztec::protocol::traits::FromField>::from_field(1295669651_Field);
+            let selector: aztec::protocol::abis::function_selector::FunctionSelector = <aztec::protocol::abis::function_selector::FunctionSelector as aztec::protocol::traits::FromField>::from_field(3516522363_Field);
             let args_hash: Field = aztec::hash::hash_args(serialized_params);
             aztec::oracle::execution_cache::store(serialized_params, args_hash);
             let returns_hash: aztec::context::ReturnsHash = self.context.call_private_function_with_args_hash(self.address, selector, args_hash, true);

--- a/noir-projects/noir-contracts/Nargo.toml
+++ b/noir-projects/noir-contracts/Nargo.toml
@@ -47,6 +47,7 @@ members = [
     "contracts/test/child_contract",
     "contracts/test/counter/counter_contract",
     "contracts/test/custom_message_contract",
+    "contracts/test/custom_sync_state_contract",
     "contracts/test/ephemeral_child_contract",
     "contracts/test/ephemeral_parent_contract",
     "contracts/test/event_only_contract",

--- a/noir-projects/noir-contracts/contracts/test/custom_sync_state_contract/Nargo.toml
+++ b/noir-projects/noir-contracts/contracts/test/custom_sync_state_contract/Nargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "custom_sync_state_contract"
+authors = [""]
+compiler_version = ">=0.25.0"
+type = "contract"
+
+[dependencies]
+aztec = { path = "../../../../aztec-nr/aztec" }
+field_note = { path = "../../../../aztec-nr/field-note" }

--- a/noir-projects/noir-contracts/contracts/test/custom_sync_state_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/custom_sync_state_contract/src/main.nr
@@ -51,8 +51,8 @@ unconstrained fn my_custom_sync(
     contract_address: AztecAddress,
     compute_note_hash: ComputeNoteHash,
     compute_note_nullifier: ComputeNoteNullifier,
-    process_custom_message: Option<CustomMessageHandler<()>>,
-    offchain_inbox_sync: Option<OffchainInboxSync<()>>,
+    process_custom_message: Option<CustomMessageHandler>,
+    offchain_inbox_sync: Option<OffchainInboxSync>,
     scope: AztecAddress,
 ) {
     let current: Option<Field> =

--- a/noir-projects/noir-contracts/contracts/test/custom_sync_state_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/custom_sync_state_contract/src/main.nr
@@ -1,0 +1,70 @@
+// Tests the custom_sync_state AztecConfig option by registering a hook that counts how many times
+// sync_state is called and then forwards to do_sync_state.
+mod test;
+
+use ::aztec::{
+    messages::discovery::{
+        ComputeNoteHash, ComputeNoteNullifier, CustomMessageHandler, do_sync_state,
+    },
+    messages::processing::offchain::OffchainInboxSync,
+    oracle::capsules,
+    protocol::{address::AztecAddress, hash::sha256_to_field},
+};
+use ::aztec::macros::aztec;
+
+global SYNC_COUNTER_SLOT: Field = sha256_to_field("SYNC_COUNTER".as_bytes());
+
+#[aztec(::aztec::macros::AztecConfig::new().custom_sync_state(crate::my_custom_sync))]
+contract CustomSyncState {
+    use aztec::macros::{
+        functions::{external, initializer},
+        storage::storage,
+    };
+    use aztec::messages::message_delivery::MessageDelivery;
+    use aztec::protocol::address::AztecAddress;
+    use aztec::state_vars::{Owned, PrivateImmutable};
+    use field_note::FieldNote;
+
+    #[storage]
+    struct Storage<Context> {
+        value: Owned<PrivateImmutable<FieldNote, Context>, Context>,
+    }
+
+    #[external("private")]
+    #[initializer]
+    fn constructor(owner: AztecAddress, value: Field) {
+        let note = FieldNote { value };
+        self.storage.value.at(owner).initialize(note).deliver(
+            MessageDelivery.ONCHAIN_UNCONSTRAINED,
+        );
+    }
+
+    #[external("utility")]
+    unconstrained fn read_value(owner: AztecAddress) -> pub Field {
+        self.storage.value.at(owner).view_note().value
+    }
+}
+
+/// Counts how many times `sync_state` is invoked by incrementing a capsule counter, then forwards
+/// to [`do_sync_state`] so that normal note discovery still happens.
+unconstrained fn my_custom_sync(
+    contract_address: AztecAddress,
+    compute_note_hash: ComputeNoteHash,
+    compute_note_nullifier: ComputeNoteNullifier,
+    process_custom_message: Option<CustomMessageHandler<()>>,
+    offchain_inbox_sync: Option<OffchainInboxSync<()>>,
+    scope: AztecAddress,
+) {
+    let current: Option<Field> =
+        capsules::load(contract_address, crate::SYNC_COUNTER_SLOT, scope);
+    let new_count = current.map(|c| c + 1).unwrap_or(1);
+    capsules::store(contract_address, crate::SYNC_COUNTER_SLOT, new_count, scope);
+    do_sync_state(
+        contract_address,
+        compute_note_hash,
+        compute_note_nullifier,
+        process_custom_message,
+        offchain_inbox_sync,
+        scope,
+    );
+}

--- a/noir-projects/noir-contracts/contracts/test/custom_sync_state_contract/src/test.nr
+++ b/noir-projects/noir-contracts/contracts/test/custom_sync_state_contract/src/test.nr
@@ -1,0 +1,42 @@
+use crate::CustomSyncState;
+use aztec::oracle::capsules;
+use aztec::protocol::address::AztecAddress;
+use aztec::test::helpers::test_environment::TestEnvironment;
+
+#[test]
+unconstrained fn test_custom_sync_hook_is_called() {
+    let mut env = TestEnvironment::new();
+    let owner = env.create_light_account();
+    let value: Field = 42;
+
+    let contract_address = env.deploy("CustomSyncState").with_private_initializer(
+        owner,
+        CustomSyncState::interface().constructor(owner, value),
+    );
+    let target = CustomSyncState::at(contract_address);
+
+    // After deploying and calling the private initializer, the hook should have been called once
+    let count = get_sync_count(env, contract_address, owner);
+    assert_eq(count, 1);
+
+    // Reading the note via a utility function triggers another sync
+    let result = env.execute_utility(target.read_value(owner));
+
+    let count = get_sync_count(env, contract_address, owner);
+    assert_eq(count, 2);
+
+    // The note was correctly discovered by do_sync_state (called by the hook)
+    assert_eq(result, value);
+}
+
+unconstrained fn get_sync_count(
+    env: TestEnvironment,
+    contract_address: AztecAddress,
+    scope: AztecAddress,
+) -> Field {
+    env.utility_context_at(contract_address, |_| {
+        let count: Option<Field> =
+            capsules::load(contract_address, crate::SYNC_COUNTER_SLOT, scope);
+        count.unwrap_or(0)
+    })
+}


### PR DESCRIPTION
## Why we are doing this

Contracts that wanted to customize state sync had to override the macro-generated `sync_state` utility by defining a function with that name. The override happened silently — the macro had no way to surface that the default was being replaced, and there was no compile-time signal when the override accidentally shadowed the generated function.

## Our fix

Adds an explicit `AztecConfig::custom_sync_state()` builder that registers a `CustomSyncHandler`. The handler receives the same parameters as the default `do_sync_state` and can wrap, delegate to, or skip it. Defining a function named `sync_state` directly now errors with a message pointing users at the new builder.

The naming follows the existing `CustomMessageHandler` pattern for sibling consistency. A `custom_sync_state_contract` exercises the full flow (deploy + execute_utility) and verifies the handler is invoked in the right scope.

## Migration

See migration_notes.md. Only contracts that previously defined their own `sync_state` function are affected; users of the default macro-generated sync need no changes.

Fixes F-655