### PR TITLE
fix(archiver): reconcile local blocks with L1 checkpoints by block number

### DIFF
--- a/yarn-project/archiver/src/modules/data_store_updater.test.ts
+++ b/yarn-project/archiver/src/modules/data_store_updater.test.ts
@@ -6,6 +6,7 @@ import { ContractInstancePublishedEvent } from '@aztec/protocol-contracts/instan
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
 import { L2Block } from '@aztec/stdlib/block';
 import { ContractClassLog, PrivateLog } from '@aztec/stdlib/logs';
+import { CheckpointHeader } from '@aztec/stdlib/rollup';
 import '@aztec/stdlib/testing/jest';
 import { BlockHeader } from '@aztec/stdlib/tx';
 
@@ -120,6 +121,134 @@ describe('ArchiverDataStoreUpdater', () => {
       // Verify the contract data from the local block was removed
       expect(await store.contractClasses.getContractClass(contractClassId)).toBeUndefined();
       expect(await store.contractInstances.getContractInstance(instanceAddress, timestamp)).toBeUndefined();
+    });
+
+    it('reconciles a local proposed block with an L1 checkpoint at the same block number but different slot', async () => {
+      // Regression for issue fixed at https://github.com/AztecProtocol/aztec-packages/pull/23461
+      // Local proposed block 1 at slot 125, containing a deployed contract instance.
+      const localBlock = await L2Block.random(BlockNumber(1), {
+        checkpointNumber: CheckpointNumber(1),
+        indexWithinCheckpoint: IndexWithinCheckpoint(0),
+        slotNumber: SlotNumber(125),
+      });
+      localBlock.body.txEffects[0].contractClassLogs = [contractClassLog];
+      localBlock.body.txEffects[0].privateLogs = [
+        PrivateLog.fromBuffer(getSampleContractInstancePublishedEventPayload()),
+      ];
+      await updater.addProposedBlock(localBlock);
+
+      const timestamp = localBlock.header.globalVariables.timestamp + 1n;
+      expect(await store.contractInstances.getContractInstance(instanceAddress, timestamp)).toBeDefined();
+
+      // L1 confirmed a different block 1 at slot 124, containing the SAME deployed contract instance
+      // (the same user tx ended up on chain, just signed by a different proposer at a different slot).
+      // Without the fix the prune step misses the conflict because the slot does not match, and
+      // re-applying the L1 block's contract data throws "Contract instance ... already exists".
+      const l1Block = await L2Block.random(BlockNumber(1), {
+        checkpointNumber: CheckpointNumber(1),
+        indexWithinCheckpoint: IndexWithinCheckpoint(0),
+        slotNumber: SlotNumber(124),
+      });
+      l1Block.body.txEffects[0].contractClassLogs = [contractClassLog];
+      l1Block.body.txEffects[0].privateLogs = [PrivateLog.fromBuffer(getSampleContractInstancePublishedEventPayload())];
+      expect(l1Block.archive.root.equals(localBlock.archive.root)).toBe(false);
+
+      const published = makePublishedCheckpoint(makeCheckpoint([l1Block]), 10);
+
+      await expect(updater.addCheckpoints([published])).resolves.not.toThrow();
+
+      // The L1 block must end up persisted, with its contract instance reachable.
+      const storedBlock = await store.blocks.getBlock({ number: BlockNumber(1) });
+      expect(storedBlock?.archive.root.equals(l1Block.archive.root)).toBe(true);
+      expect(await store.contractInstances.getContractInstance(instanceAddress, timestamp)).toBeDefined();
+    });
+
+    it('evicts higher-numbered proposed checkpoints that chain off pruned blocks on conflict', async () => {
+      // Local builds: block 1 (slot 125, checkpoint 1) → proposed checkpoint 1
+      //               block 2 (slot 126, checkpoint 2) → proposed checkpoint 2
+      // block_store.addCheckpoints already deletes the proposed entry at the same number it stores,
+      // so the eviction code matters specifically for higher-numbered proposed checkpoints whose
+      // referenced blocks were pruned by the conflict.
+      const localBlock1 = await L2Block.random(BlockNumber(1), {
+        checkpointNumber: CheckpointNumber(1),
+        indexWithinCheckpoint: IndexWithinCheckpoint(0),
+        slotNumber: SlotNumber(125),
+      });
+      await updater.addProposedBlock(localBlock1);
+      await store.blocks.addProposedCheckpoint({
+        checkpointNumber: CheckpointNumber(1),
+        header: CheckpointHeader.empty(),
+        startBlock: BlockNumber(1),
+        blockCount: 1,
+        totalManaUsed: 0n,
+        feeAssetPriceModifier: 0n,
+      });
+
+      const localBlock2 = await L2Block.random(BlockNumber(2), {
+        checkpointNumber: CheckpointNumber(2),
+        indexWithinCheckpoint: IndexWithinCheckpoint(0),
+        slotNumber: SlotNumber(126),
+        lastArchive: localBlock1.archive,
+      });
+      await updater.addProposedBlock(localBlock2);
+      await store.blocks.addProposedCheckpoint({
+        checkpointNumber: CheckpointNumber(2),
+        header: CheckpointHeader.empty(),
+        startBlock: BlockNumber(2),
+        blockCount: 1,
+        totalManaUsed: 0n,
+        feeAssetPriceModifier: 0n,
+      });
+
+      expect(await store.blocks.getProposedCheckpointNumber()).toBe(2);
+
+      // L1 publishes a conflicting block 1. Pruning takes out both local blocks; both proposed
+      // checkpoints must be evicted (proposed 1 by block_store.addCheckpoints, proposed 2 by us).
+      const l1Block = await L2Block.random(BlockNumber(1), {
+        checkpointNumber: CheckpointNumber(1),
+        indexWithinCheckpoint: IndexWithinCheckpoint(0),
+        slotNumber: SlotNumber(124),
+      });
+      expect(l1Block.archive.root.equals(localBlock1.archive.root)).toBe(false);
+
+      await updater.addCheckpoints([makePublishedCheckpoint(makeCheckpoint([l1Block]), 10)]);
+
+      expect(await store.blocks.getLastProposedCheckpoint()).toBeUndefined();
+    });
+
+    it('preserves a speculative local block at a later slot when L1 confirms the matching previous block', async () => {
+      // Local proposes block 1 at slot 100 and a speculative block 2 at slot 101 built atop it.
+      // Pipelining: block 2 is the start of proposed checkpoint 2 and must not be pruned just
+      // because L1 confirmed a checkpoint that only contains block 1.
+      const localBlock1 = await L2Block.random(BlockNumber(1), {
+        checkpointNumber: CheckpointNumber(1),
+        indexWithinCheckpoint: IndexWithinCheckpoint(0),
+        slotNumber: SlotNumber(100),
+      });
+      await updater.addProposedBlock(localBlock1);
+
+      await store.blocks.addProposedCheckpoint({
+        checkpointNumber: CheckpointNumber(1),
+        header: CheckpointHeader.empty(),
+        startBlock: BlockNumber(1),
+        blockCount: 1,
+        totalManaUsed: 0n,
+        feeAssetPriceModifier: 0n,
+      });
+
+      const localBlock2 = await L2Block.random(BlockNumber(2), {
+        checkpointNumber: CheckpointNumber(2),
+        indexWithinCheckpoint: IndexWithinCheckpoint(0),
+        slotNumber: SlotNumber(101),
+        lastArchive: localBlock1.archive,
+      });
+      await updater.addProposedBlock(localBlock2);
+
+      // L1 confirms checkpoint 1 with the same block 1 as local. Speculative block 2 must survive.
+      await updater.addCheckpoints([makePublishedCheckpoint(makeCheckpoint([localBlock1]), 10)]);
+
+      const storedBlock2 = await store.blocks.getBlock({ number: BlockNumber(2) });
+      expect(storedBlock2?.archive.root.equals(localBlock2.archive.root)).toBe(true);
     });
 
     it('removes contract data when checkpoints are unwound', async () => {

--- a/yarn-project/archiver/src/modules/data_store_updater.ts
+++ b/yarn-project/archiver/src/modules/data_store_updater.ts
@@ -160,9 +160,17 @@ export class ArchiverDataStoreUpdater {
 
   /**
    * Checks for local proposed blocks that do not match the ones to be checkpointed and prunes them.
-   * This method handles multiple checkpoints but returns after pruning the first conflict found.
-   * This is correct because pruning from the first conflict point removes all subsequent blocks,
-   * and when checkpoints are added afterward, they include all the correct blocks.
+   * Conflict detection is keyed on `blockNumber`: when a local proposed block and an L1
+   * checkpointed block share a block number but live at different slots (e.g. a different proposer
+   * mined the same block number one slot earlier), we still treat them as a conflict and prune.
+   * The trailing per-checkpoint prune that handles "local has extra trailing blocks within the
+   * same slot as the published checkpoint" remains scoped by slot to preserve pipelining: local
+   * blocks that live at a later slot than the checkpoint being processed represent speculation
+   * atop the just-confirmed tip (and may be referenced by a pending proposed checkpoint), so we
+   * leave them in place. This method handles multiple checkpoints but returns after pruning the
+   * first conflict found. This is correct because pruning from the first conflict point removes
+   * all subsequent blocks, and when checkpoints are added afterward, they include all the correct
+   * blocks.
    */
   private async pruneMismatchingLocalBlocks(checkpoints: PublishedCheckpoint[]): Promise<ReconcileCheckpointsResult> {
     const [lastCheckpointedBlockNumber, lastBlockNumber] = await Promise.all([
@@ -176,7 +184,7 @@ export class ArchiverDataStoreUpdater {
     }
 
     // Get all uncheckpointed local blocks
-    const uncheckpointedLocalBlocks = await this.stores.blocks.getBlocks({
+    const uncheckpointedLocalBlocks = await this.stores.blocks.getBlocksData({
       from: BlockNumber.add(lastCheckpointedBlockNumber, 1),
       limit: lastBlockNumber - lastCheckpointedBlockNumber,
     });
@@ -186,19 +194,19 @@ export class ArchiverDataStoreUpdater {
     for (const publishedCheckpoint of checkpoints) {
       const checkpointBlocks = publishedCheckpoint.checkpoint.blocks;
       const slot = publishedCheckpoint.checkpoint.slot;
-      const localBlocksInSlot = uncheckpointedLocalBlocks.filter(b => b.slot === slot);
 
       if (checkpointBlocks.length === 0) {
         this.log.warn(`Checkpoint ${publishedCheckpoint.checkpoint.number} for slot ${slot} has no blocks`);
         continue;
       }
 
-      // Find the first checkpoint block that conflicts with an existing local block and prune local afterwards
+      // Find the first checkpoint block that conflicts with an existing local block and prune local afterwards.
+      // Conflict detection joins on block number only — same block number at a different slot is still a conflict.
       for (const checkpointBlock of checkpointBlocks) {
         const blockNumber = checkpointBlock.number;
-        const existingBlock = localBlocksInSlot.find(b => b.number === blockNumber);
+        const existingBlock = uncheckpointedLocalBlocks.find(b => b.header.getBlockNumber() === blockNumber);
         const blockInfos = {
-          existingBlock: existingBlock?.toBlockInfo(),
+          existingBlock: existingBlock?.header.toInspect(),
           checkpointBlock: checkpointBlock.toBlockInfo(),
         };
 
@@ -210,20 +218,24 @@ export class ArchiverDataStoreUpdater {
         } else {
           this.log.info(`Conflict detected at block ${blockNumber} between checkpointed and local block`, blockInfos);
           const prunedBlocks = await this.removeBlocksAfter(BlockNumber(blockNumber - 1));
+          await this.evictProposedCheckpointsForPrunedBlocks(prunedBlocks);
           return { prunedBlocks, lastAlreadyInsertedBlockNumber };
         }
       }
 
-      // If local has more blocks than the checkpoint (e.g., local has [2,3,4] but checkpoint has [2,3]),
-      // we need to prune the extra local blocks so they match what was checkpointed
+      // If the sequencer locally proposed extra blocks within this checkpoint's slot (e.g. local has
+      // [N, N+1] but L1 confirmed just [N]), prune the extras. Scoped to the checkpoint's slot so we
+      // do not throw away speculative blocks at later slots that belong to a pending proposed checkpoint.
       const lastCheckpointBlockNumber = checkpointBlocks.at(-1)!.number;
-      const lastLocalBlockNumber = localBlocksInSlot.at(-1)?.number;
+      const localBlocksInSlot = uncheckpointedLocalBlocks.filter(b => b.header.getSlot() === slot);
+      const lastLocalBlockNumber = localBlocksInSlot.at(-1)?.header.getBlockNumber();
 
       if (lastLocalBlockNumber !== undefined && lastLocalBlockNumber > lastCheckpointBlockNumber) {
         this.log.warn(
           `Local chain for slot ${slot} ends at block ${lastLocalBlockNumber} but checkpoint ends at ${lastCheckpointBlockNumber}. Pruning blocks after block ${lastCheckpointBlockNumber}.`,
         );
         const prunedBlocks = await this.removeBlocksAfter(lastCheckpointBlockNumber);
+        await this.evictProposedCheckpointsForPrunedBlocks(prunedBlocks);
         return { prunedBlocks, lastAlreadyInsertedBlockNumber };
       }
     }
@@ -259,6 +271,19 @@ export class ArchiverDataStoreUpdater {
     });
     await this.l2TipsCache?.refresh();
     return result;
+  }
+
+  /**
+   * Evicts pending proposed checkpoints that referenced any of the just-pruned blocks. Pruned
+   * blocks invalidate all proposed checkpoints from the lowest pruned block's checkpoint number
+   * onwards: those checkpoints either reference the pruned blocks directly or chain off them.
+   */
+  private async evictProposedCheckpointsForPrunedBlocks(prunedBlocks: L2Block[]): Promise<void> {
+    if (prunedBlocks.length === 0) {
+      return;
+    }
+    const fromCheckpointNumber = prunedBlocks[0].checkpointNumber;
+    await this.stores.blocks.evictProposedCheckpointsFrom(fromCheckpointNumber);
   }
 
   /**


### PR DESCRIPTION
## Motivation

When the sequencer locally proposed block N at slot S1 and L1 mined a different block N at slot S2 (same block number, different slot), the archiver's reconciliation in `pruneMismatchingLocalBlocks` joined local↔checkpoint blocks by slot and missed the conflict. The local block was never pruned and the subsequent re-apply of L1's block N threw `Contract instance ... already exists, cannot add again at block N`. The archiver's serial queue then retried in a loop and wedged the data store — this is the cause of the e2e flake at `yarn-project/end-to-end/src/composed/ha/e2e_ha_full.test.ts:693`.

## Approach

`pruneMismatchingLocalBlocks` now keys conflict detection on `blockNumber` only, so a same-number-different-slot block is correctly detected as a conflict and pruned. The per-checkpoint trailing prune (which handles "local has extra blocks at the same slot as the published checkpoint") stays scoped by slot so speculative blocks at later slots that belong to a pending proposed checkpoint are preserved — this keeps the pipelining model in `promoteProposedToCheckpointed` intact. After any prune, pending proposed checkpoints from the offending checkpoint number onwards are evicted so they do not dangle while referencing removed blocks.

## Changes

- **archiver**: `pruneMismatchingLocalBlocks` joins by `blockNumber` only; trailing slot-scoped prune unchanged; new `evictProposedCheckpointsForPrunedBlocks` helper clears stale pending proposed checkpoints after a prune.
- **archiver (tests)**: four new regression tests in `data_store_updater.test.ts` covering the e2e_ha scenario, the prune-by-number path without contract data, pipelining preservation, and eviction of higher-numbered proposed checkpoints chaining off pruned blocks.