### PR TITLE
fix(release-image): stamp aztec_version in published contract artifacts

### DIFF
--- a/ci3/release_prep_package_json
+++ b/ci3/release_prep_package_json
@@ -22,3 +22,13 @@ for deps in dependencies devDependencies peerDependencies; do
     mv tmp.json package.json
   done
 done
+
+# Stamp aztec_version into any published noir contract artifacts in artifacts/*.json. The build-time stamp in
+# noir-projects/noir-contracts/bootstrap.sh writes "dev"; $version here is the authoritative release version about to
+# be written to package.json. We cannot stamp real version in bootstrap because there we don't have access to it.
+if [ -d artifacts ]; then
+  for f in artifacts/*.json; do
+    [ -e "$f" ] || continue
+    jq --arg v "$version" '.aztec_version = $v' "$f" >$tmp && mv $tmp "$f"
+  done
+fi

--- a/noir-projects/noir-contracts/bootstrap.sh
+++ b/noir-projects/noir-contracts/bootstrap.sh
@@ -93,19 +93,16 @@ function get_contract_path {
 }
 export -f get_contract_path
 
-# Stamps the aztec version into a contract artifact JSON in place. Mirrors stampAztecVersion in
-# yarn-project/aztec/src/cli/cmds/compile.ts so monorepo-built artifacts match those produced by `aztec compile`.
-# On release builds (REF_NAME is valid semver) the tag without the leading "v" is used; otherwise "dev".
-function stamp_aztec_version {
+# Stamps "dev" (DEV_VERSION) as the artifact's aztec_version - that is the expected version of a locally checked out
+# monorepo. The real release version is applied at publish time by whichever path owns it:
+# ci3/release_prep_package_json for npm packages, release-image/Dockerfile for the docker image.
+function stamp_dev_aztec_version {
   local json_path=$1
-  # "dev" here corresponds to DEV_VERSION in yarn-project/stdlib/src/update-checker/dev_version.ts.
-  local version="dev"
-  semver check "$REF_NAME" 2>/dev/null && version="${REF_NAME#v}"
   local tmp=$(mktemp)
-  jq --arg v "$version" '.aztec_version = $v' "$json_path" > "$tmp"
+  jq '.aztec_version = "dev"' "$json_path" > "$tmp"
   mv "$tmp" "$json_path"
 }
-export -f stamp_aztec_version
+export -f stamp_dev_aztec_version
 
 # This compiles a noir contract, transpiles public functions, strips internal prefixes,
 # and generates verification keys for private functions via 'bb aztec_process'.
@@ -127,9 +124,9 @@ function compile {
     $BB aztec_process -i $json_path
     cache_upload contract-$contract_hash.tar.gz $json_path
   fi
-  # Stamp the current version after the cache block so the field always matches the build's version, whether
-  # the artifact came from a fresh compile or a cache hit.
-  stamp_aztec_version "$json_path"
+  # Stamp the version after the cache block so the field is always present, whether the artifact came from a fresh
+  # compile or a cache hit.
+  stamp_dev_aztec_version "$json_path"
 }
 export -f compile
 

--- a/release-image/Dockerfile
+++ b/release-image/Dockerfile
@@ -22,10 +22,9 @@ RUN echo '{".": "'$VERSION'"}' > /usr/src/.release-please-manifest.json
 RUN jq --arg v "$VERSION" '.version = $v' /usr/src/yarn-project/stdlib/package.json > /tmp/p.json \
     && mv /tmp/p.json /usr/src/yarn-project/stdlib/package.json
 
-# Re-stamp aztec_version in published contract artifacts. Mirrors stamp_aztec_version() in
-# noir-projects/noir-contracts/bootstrap.sh and stampAztecVersion() in
-# yarn-project/aztec/src/cli/cmds/compile.ts. Needed because artifacts are compiled in an earlier
-# build stage where REF_NAME isn't set, leaving them with aztec_version: "dev".
+# Stamp aztec_version into the shipped contract artifacts. The build-time stamp in
+# noir-projects/noir-contracts/bootstrap.sh writes "dev" unconditionally; $VERSION here is the authoritative release
+# version for this image.
 RUN for dir in \
         /usr/src/yarn-project/accounts/artifacts \
         /usr/src/yarn-project/noir-contracts.js/artifacts \

--- a/release-image/Dockerfile
+++ b/release-image/Dockerfile
@@ -22,4 +22,17 @@ RUN echo '{".": "'$VERSION'"}' > /usr/src/.release-please-manifest.json
 RUN jq --arg v "$VERSION" '.version = $v' /usr/src/yarn-project/stdlib/package.json > /tmp/p.json \
     && mv /tmp/p.json /usr/src/yarn-project/stdlib/package.json
 
+# Re-stamp aztec_version in published contract artifacts. Mirrors stamp_aztec_version() in
+# noir-projects/noir-contracts/bootstrap.sh and stampAztecVersion() in
+# yarn-project/aztec/src/cli/cmds/compile.ts. Needed because artifacts are compiled in an earlier
+# build stage where REF_NAME isn't set, leaving them with aztec_version: "dev".
+RUN for dir in \
+        /usr/src/yarn-project/accounts/artifacts \
+        /usr/src/yarn-project/noir-contracts.js/artifacts \
+        /usr/src/yarn-project/noir-test-contracts.js/artifacts; do \
+      for f in "$dir"/*.json; do \
+        jq --arg v "$VERSION" '.aztec_version = $v' "$f" > /tmp/a.json && mv /tmp/a.json "$f"; \
+      done; \
+    done
+
 ENTRYPOINT ["node", "--no-warnings", "/usr/src/yarn-project/aztec/dest/bin/index.js"]

--- a/yarn-project/end-to-end/src/fixtures/setup.ts
+++ b/yarn-project/end-to-end/src/fixtures/setup.ts
@@ -54,6 +54,7 @@ import { type ContractInstanceWithAddress, getContractInstanceFromInstantiationP
 import type { AztecNodeAdmin, AztecNodeDebug } from '@aztec/stdlib/interfaces/client';
 import { tryStop } from '@aztec/stdlib/interfaces/server';
 import type { PublicDataTreeLeaf } from '@aztec/stdlib/trees';
+import { DEV_VERSION } from '@aztec/stdlib/update-checker';
 import {
   type TelemetryClient,
   type TelemetryClientConfig,
@@ -280,6 +281,15 @@ function assertContractArtifactsVersion() {
   if (aztecVersion === ARTIFACT_VERSION_BEFORE_INJECTION) {
     createLogger('e2e:setup').info(
       `Skipping artifact version check: artifact predates version injection (CONTRACT_ARTIFACTS_VERSION=${expected})`,
+    );
+    return;
+  }
+  // TODO(F-557): Remove once v4.3.0 drops off the compat matrix. The v4.3.0 release shipped with
+  // aztec_version: "dev" baked into the published artifact JSONs because release-image/Dockerfile
+  // did not re-stamp them. Fixed for future releases by the artifact restamp step in that Dockerfile.
+  if (expected === '4.3.0' && aztecVersion === DEV_VERSION) {
+    createLogger('e2e:setup').warn(
+      `Skipping artifact version check: v4.3.0 artifacts shipped with aztec_version="dev"`,
     );
     return;
   }

--- a/yarn-project/end-to-end/src/fixtures/setup.ts
+++ b/yarn-project/end-to-end/src/fixtures/setup.ts
@@ -284,9 +284,8 @@ function assertContractArtifactsVersion() {
     );
     return;
   }
-  // TODO(F-557): Remove once v4.3.0 drops off the compat matrix. The v4.3.0 release shipped with
-  // aztec_version: "dev" baked into the published artifact JSONs because release-image/Dockerfile
-  // did not re-stamp them. Fixed for future releases by the artifact restamp step in that Dockerfile.
+  // TODO(F-557): Remove once v4.3.0 drops off the compat matrix. The v4.3.0 npm release shipped with
+  // aztec_version: "dev" baked into the artifact JSONs because of a bug.
   if (expected === '4.3.0' && aztecVersion === DEV_VERSION) {
     createLogger('e2e:setup').warn(
       `Skipping artifact version check: v4.3.0 artifacts shipped with aztec_version="dev"`,


### PR DESCRIPTION
## Summary

The v4.3.0 release shipped contract artifact JSONs with `aztec_version: "dev"` baked in which resulted in a failure in ci-compat-e2e as there we check the artifact version matches the expected tested version that is injected in via an env var.

On [npm.js](https://www.npmjs.com/package/@aztec/noir-contracts.js?activeTab=code) we see "dev" in the artifact:

<img width="554" height="74" alt="image" src="https://github.com/user-attachments/assets/a4947ea0-d50e-482f-8c97-fad0bcbc2ae2" />

The issue seems to be caused by REF_NAME not being correctly populated when doing the release which then results in "dev" being stamped into the released artifacts instead of the real version.

The fix is to re-stamp the version into artifact when we are doing the release. It seems kinds 💩 tho