### PR TITLE
feat: Updated slash conditions on block proposals

### DIFF
--- a/yarn-project/validator-client/src/proposal_handler.ts
+++ b/yarn-project/validator-client/src/proposal_handler.ts
@@ -46,6 +46,7 @@ import type { FullNodeCheckpointsBuilder } from './checkpoint_builder.js';
 import type { ValidatorMetrics } from './metrics.js';
 
 export type BlockProposalValidationFailureReason =
+  | 'invalid_signature'
   | 'invalid_proposal'
   | 'parent_block_not_found'
   | 'block_source_not_synced'
@@ -338,7 +339,7 @@ export class ProposalHandler {
     // Reject proposals with invalid signatures
     if (!proposer) {
       this.log.warn(`Received proposal with invalid signature for slot ${slotNumber}`);
-      return { isValid: false, reason: 'invalid_proposal' };
+      return { isValid: false, reason: 'invalid_signature' };
     }
 
     const proposalInfo = {

--- a/yarn-project/validator-client/src/validator.ts
+++ b/yarn-project/validator-client/src/validator.ts
@@ -79,6 +79,10 @@ const MAX_TRACKED_BAD_ATTESTATIONS = 10_000;
 const SLASHABLE_BLOCK_PROPOSAL_VALIDATION_RESULT: BlockProposalValidationFailureReason[] = [
   'state_mismatch',
   'failed_txs',
+  'global_variables_mismatch',
+  'invalid_proposal',
+  'parent_block_wrong_slot',
+  'in_hash_mismatch',
 ];
 
 const SLASHABLE_CHECKPOINT_PROPOSAL_VALIDATION_RESULT: Record<CheckpointProposalValidationFailureReason, boolean> = {


### PR DESCRIPTION
This PR does 2 things.

1. Updates the slashable set of block proposal failures.
2. Introduces a new 'invalid_signature' block proposal failure which is not slashable.
