### PR TITLE
feat(spartan): client-observed inclusion latency for bench-10tps

### DIFF
--- a/.github/workflows/nightly-bench-10tps.yml
+++ b/.github/workflows/nightly-bench-10tps.yml
@@ -5,8 +5,12 @@ on:
     - cron: "30 6 * * *"
   workflow_dispatch:
     inputs:
+      docker_image:
+        description: "Full Docker image (e.g., aztecprotocol/aztec:my-tag). Takes precedence over nightly_tag."
+        required: false
+        type: string
       nightly_tag:
-        description: "Nightly tag to use (e.g., 2.3.4-nightly.20251209). Leave empty to auto-detect."
+        description: "Nightly tag to use (e.g., 2.3.4-nightly.20251209). Ignored if docker_image is set. Leave empty to auto-detect."
         required: false
         type: string
 
@@ -23,21 +27,29 @@ jobs:
         with:
           ref: next
 
-      - name: Determine nightly tag
-        id: nightly-tag
+      - name: Determine docker image
+        id: docker-image
         run: |
-          if [[ -n "${{ inputs.nightly_tag }}" ]]; then
+          if [[ -n "${{ inputs.docker_image }}" ]]; then
+            docker_image="${{ inputs.docker_image }}"
+            image_label="${{ inputs.docker_image }}"
+          elif [[ -n "${{ inputs.nightly_tag }}" ]]; then
             nightly_tag="${{ inputs.nightly_tag }}"
+            docker_image="aztecprotocol/aztec:${nightly_tag}"
+            image_label="${nightly_tag}"
           else
             current_version=$(jq -r '."."' .release-please-manifest.json)
             nightly_tag="${current_version}-nightly.$(date -u +%Y%m%d)"
+            docker_image="aztecprotocol/aztec:${nightly_tag}"
+            image_label="${nightly_tag}"
           fi
-          echo "nightly_tag=$nightly_tag" >> $GITHUB_OUTPUT
-          echo "Using nightly tag: $nightly_tag"
+          echo "docker_image=$docker_image" >> $GITHUB_OUTPUT
+          echo "image_label=$image_label" >> $GITHUB_OUTPUT
+          echo "Using docker image: $docker_image"
 
       - name: Check if Docker image exists
         run: |
-          DOCKER_IMAGE="aztecprotocol/aztec:${{ steps.nightly-tag.outputs.nightly_tag }}"
+          DOCKER_IMAGE="${{ steps.docker-image.outputs.docker_image }}"
           echo "Checking if Docker image exists: $DOCKER_IMAGE"
           if docker manifest inspect "$DOCKER_IMAGE" > /dev/null 2>&1; then
             echo "Docker image exists: $DOCKER_IMAGE"
@@ -60,7 +72,7 @@ jobs:
           AWS_SHUTDOWN_TIME: 240
           NO_SPOT: 1
         run: |
-          ./.github/ci3.sh network-bench-10tps bench-10tps bench-10tps "aztecprotocol/aztec:${{ steps.nightly-tag.outputs.nightly_tag }}"
+          ./.github/ci3.sh network-bench-10tps bench-10tps bench-10tps "${{ steps.docker-image.outputs.docker_image }}"
 
       - name: Cleanup network resources
         if: always()
@@ -80,9 +92,9 @@ jobs:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
         run: |
-          TAG="${{ steps.nightly-tag.outputs.nightly_tag }}"
+          IMAGE="${{ steps.docker-image.outputs.image_label }}"
           RUN_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           ./ci3/slack_notify_with_claudebox_kickoff "#alerts-next-scenario" \
-            "Nightly 10 TPS benchmark FAILED (nightly tag ${TAG}): <${RUN_URL}|View Run> (🤖)" \
-            "Nightly 10 TPS benchmark failed (nightly tag ${TAG}). CI run: ${RUN_URL}. Investigate the benchmark failure and identify the root cause." \
+            "Nightly 10 TPS benchmark FAILED (image ${IMAGE}): <${RUN_URL}|View Run> (🤖)" \
+            "Nightly 10 TPS benchmark failed (image ${IMAGE}). CI run: ${RUN_URL}. Investigate the benchmark failure and identify the root cause." \
             --link "$RUN_URL"

--- a/spartan/bootstrap.sh
+++ b/spartan/bootstrap.sh
@@ -183,8 +183,12 @@ function block_capacity_bench_cmds {
 }
 
 function bench_10tps_cmds {
-  local high_value_tps=10
-  local low_value_tps=0
+  # Mix: 1 tps of high-value + 9 tps of low-value, total still 10 tps. The
+  # high-value lane is what we measure for the headline client-observed
+  # inclusion latency (low-value txs pay near-network-min and are allowed to
+  # fail fee checks, so they would skew the headline if measured).
+  local high_value_tps=1
+  local low_value_tps=9
   local test_duration=${TEST_DURATION_SECONDS:-600} # 10 mins
   local timeout=${BENCH_TIMEOUT_SECONDS:-7200} # account for initial committee formation
   echo "$(hash):TIMEOUT=${timeout} BENCH_RUN_ID=${BENCH_RUN_ID:-} BENCH_OUTPUT=bench-out/n_tps.10tps.bench.json BENCH_SCENARIO=10tps LOW_VALUE_TPS=${low_value_tps} HIGH_VALUE_TPS=${high_value_tps} TEST_DURATION_SECONDS=${test_duration} $root/yarn-project/end-to-end/scripts/run_test.sh simple n_tps.test.ts"
@@ -259,6 +263,7 @@ function bench_10tps {
       --target-tps 10 \
       --workload sha256_hash_1024 \
       --output "$run_json" \
+      --inclusion-records "$metadata" \
       --wait-for-pending-zero \
       --max-pending-wait-seconds "${BENCH_SCRAPE_MAX_PENDING_WAIT_SECONDS:-3600}" \
       || echo "[bench_10tps] scraper failed (non-fatal)"

--- a/spartan/scripts/bench_10tps/bench_output.schema.json
+++ b/spartan/scripts/bench_10tps/bench_output.schema.json
@@ -19,7 +19,9 @@
       "const": "3",
       "description": "Bump when breaking the schema. Old JSONs keep their previous version so the dashboard can render them side-by-side. v3: timeSeries entries carry `series: [{labels, points}]` instead of bare `points` to support per-pod / per-label data."
     },
-    "run": { "$ref": "#/$defs/runMeta" },
+    "run": {
+      "$ref": "#/$defs/runMeta"
+    },
     "summary": {
       "$ref": "#/$defs/summary",
       "description": "Scalar reductions — one number per run. Shown on the dashboard trend page and duplicated into index.json so the index can render headline numbers without fetching every run."
@@ -31,30 +33,42 @@
     "blocks": {
       "type": "array",
       "description": "Per-block records parsed from structured logs (each block emits one `Processed N successful txs and M failed txs ...` info line). Authoritative for per-block facts — Prometheus histograms cannot recover per-block samples.",
-      "items": { "$ref": "#/$defs/blockRecord" }
+      "items": {
+        "$ref": "#/$defs/blockRecord"
+      }
     },
     "events": {
       "type": "array",
       "description": "Discrete occurrences during the run (currently just chain prunes). Typically rendered as annotations on charts.",
-      "items": { "$ref": "#/$defs/event" }
+      "items": {
+        "$ref": "#/$defs/event"
+      }
     },
     "sequencerStateSlots": {
       "type": "array",
       "description": "Per-slot sequencer state time budget reconstructed from structured state-transition logs. Optional for older runs and empty when sequencer debug logs were not enabled.",
-      "items": { "$ref": "#/$defs/sequencerStateSlot" }
+      "items": {
+        "$ref": "#/$defs/sequencerStateSlot"
+      }
     },
     "notes": {
       "type": "array",
-      "items": { "type": "string" },
+      "items": {
+        "type": "string"
+      },
       "description": "Free-form operator notes (e.g. 'ran with doubled prover agents'). Optional."
     }
   },
-
   "$defs": {
     "runMeta": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["runId", "startedAt", "endedAt", "namespace"],
+      "required": [
+        "runId",
+        "startedAt",
+        "endedAt",
+        "namespace"
+      ],
       "properties": {
         "runId": {
           "type": "string",
@@ -80,7 +94,12 @@
           "format": "date-time",
           "description": "Wall-clock time the scraper began querying Prometheus. Typically endedAt + ~90s to let the OTel batch push (60s default) and one Prom scrape (15s) settle."
         },
-        "namespace": { "type": "string", "examples": ["bench-10tps"] },
+        "namespace": {
+          "type": "string",
+          "examples": [
+            "bench-10tps"
+          ]
+        },
         "gcpProject": {
           "type": "string",
           "description": "GCP project containing the GKE container logs."
@@ -97,12 +116,25 @@
           "type": "string",
           "description": "Aztec image tag or digest the validators ran."
         },
-        "targetTps": { "type": "number", "minimum": 0 },
-        "testDurationSeconds": { "type": "integer", "minimum": 0 },
-        "workload": { "type": "string", "examples": ["sha256_hash_1024"] },
+        "targetTps": {
+          "type": "number",
+          "minimum": 0
+        },
+        "testDurationSeconds": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "workload": {
+          "type": "string",
+          "examples": [
+            "sha256_hash_1024"
+          ]
+        },
         "aztecConfig": {
           "type": "object",
-          "additionalProperties": { "type": "string" },
+          "additionalProperties": {
+            "type": "string"
+          },
           "description": "Curated subset of Aztec config env vars captured from a running validator pod. Keys include SEQ_MAX_TX_PER_BLOCK, P2P_MAX_PENDING_TX_COUNT, AZTEC_MANA_TARGET, etc. Lets the dashboard show 'pool=20k vs pool=1000' alongside compared runs."
         },
         "infrastructure": {
@@ -118,12 +150,16 @@
                 "properties": {
                   "instanceTypes": {
                     "type": "array",
-                    "items": { "type": "string" },
+                    "items": {
+                      "type": "string"
+                    },
                     "description": "Distinct Kubernetes node instance types used by this role."
                   },
                   "nodePools": {
                     "type": "array",
-                    "items": { "type": "string" },
+                    "items": {
+                      "type": "string"
+                    },
                     "description": "Distinct node pools used by this role, when exposed as node labels."
                   },
                   "nodes": {
@@ -131,13 +167,27 @@
                     "items": {
                       "type": "object",
                       "additionalProperties": false,
-                      "required": ["role", "podName", "nodeName"],
+                      "required": [
+                        "role",
+                        "podName",
+                        "nodeName"
+                      ],
                       "properties": {
-                        "role": { "type": "string" },
-                        "podName": { "type": "string" },
-                        "nodeName": { "type": "string" },
-                        "instanceType": { "type": "string" },
-                        "nodePool": { "type": "string" }
+                        "role": {
+                          "type": "string"
+                        },
+                        "podName": {
+                          "type": "string"
+                        },
+                        "nodeName": {
+                          "type": "string"
+                        },
+                        "instanceType": {
+                          "type": "string"
+                        },
+                        "nodePool": {
+                          "type": "string"
+                        }
                       }
                     }
                   }
@@ -150,10 +200,14 @@
           "type": "object",
           "additionalProperties": false,
           "properties": {
-            "enabled": { "type": "boolean" },
+            "enabled": {
+              "type": "boolean"
+            },
             "profile": {
               "type": "string",
-              "examples": ["network-requirements"]
+              "examples": [
+                "network-requirements"
+              ]
             }
           }
         },
@@ -172,7 +226,9 @@
               "minimum": 1,
               "description": "PromQL range-query step."
             },
-            "promUrl": { "type": "string" },
+            "promUrl": {
+              "type": "string"
+            },
             "waitForPendingZero": {
               "type": "boolean",
               "description": "Whether live scraping waited for validator pending TxPool depth to reach zero before querying."
@@ -183,18 +239,42 @@
               "description": "Maximum time the scraper was allowed to wait for validator pending TxPool depth to reach zero."
             },
             "pendingAtScrape": {
-              "type": ["number", "null"],
+              "type": [
+                "number",
+                "null"
+              ],
               "minimum": 0,
               "description": "Validator pending TxPool depth observed when scraping started, or null when the pending drain gate was disabled."
             },
             "pendingByRoleAtScrape": {
-              "type": ["object", "null"],
+              "type": [
+                "object",
+                "null"
+              ],
               "description": "Pending TxPool depth by pod role at scrape start. RPC/full-node pending can remain non-zero after validators drain, which indicates load that did not propagate to proposers before expiry.",
               "additionalProperties": false,
               "properties": {
-                "rpc": { "type": ["number", "null"], "minimum": 0 },
-                "validator": { "type": ["number", "null"], "minimum": 0 },
-                "fullNode": { "type": ["number", "null"], "minimum": 0 }
+                "rpc": {
+                  "type": [
+                    "number",
+                    "null"
+                  ],
+                  "minimum": 0
+                },
+                "validator": {
+                  "type": [
+                    "number",
+                    "null"
+                  ],
+                  "minimum": 0
+                },
+                "fullNode": {
+                  "type": [
+                    "number",
+                    "null"
+                  ],
+                  "minimum": 0
+                }
               }
             },
             "pendingWaitTimedOut": {
@@ -205,103 +285,239 @@
         }
       }
     },
-
     "summary": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["headlineKpi", "inclusionTpsMean", "targetTps"],
+      "required": [
+        "headlineKpi",
+        "inclusionTpsMean",
+        "targetTps"
+      ],
       "properties": {
         "headlineKpi": {
-          "type": ["number", "null"],
+          "type": [
+            "number",
+            "null"
+          ],
           "description": "inclusionTpsMean / targetTps. The single number on the dashboard top strip."
         },
-        "targetTps": { "type": "number" },
+        "targetTps": {
+          "type": "number"
+        },
         "inclusionTpsMean": {
-          "type": ["number", "null"],
+          "type": [
+            "number",
+            "null"
+          ],
           "description": "Inclusion throughput over the observed inclusion window. Uses exact block-log throughput when block records are available, otherwise falls back to the Prometheus inclusionTps mean."
         },
         "inclusionTpsPeak": {
-          "type": ["number", "null"],
+          "type": [
+            "number",
+            "null"
+          ],
           "description": "Peak sampled Prometheus rolling inclusion rate over the observed scrape window."
         },
-        "inclusionLatencyP50Ms": { "type": ["number", "null"] },
-        "inclusionLatencyP95Ms": { "type": ["number", "null"] },
-        "inclusionLatencyP99Ms": { "type": ["number", "null"] },
-        "blockBuildDurationP50Ms": { "type": ["number", "null"] },
-        "blockBuildDurationP95Ms": { "type": ["number", "null"] },
-        "publicProcessorTxDurationP50Ms": { "type": ["number", "null"] },
-        "publicProcessorTxDurationP95Ms": { "type": ["number", "null"] },
+        "inclusionLatencyP50Ms": {
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "inclusionLatencyP95Ms": {
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "inclusionLatencyP99Ms": {
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "blockBuildDurationP50Ms": {
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "blockBuildDurationP95Ms": {
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "publicProcessorTxDurationP50Ms": {
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "publicProcessorTxDurationP95Ms": {
+          "type": [
+            "number",
+            "null"
+          ]
+        },
         "totalTxsMined": {
-          "type": ["integer", "null"],
+          "type": [
+            "integer",
+            "null"
+          ],
           "description": "Exact sum from per-block logs. Null when block logs were unavailable and inclusionTpsMean came from Prometheus."
         },
         "totalTxsFailed": {
-          "type": ["integer", "null"],
+          "type": [
+            "integer",
+            "null"
+          ],
           "description": "Exact sum from per-block logs. Null when block logs were unavailable."
         },
         "totalSilentSkipCount": {
-          "type": ["integer", "null"],
+          "type": [
+            "integer",
+            "null"
+          ],
           "description": "Sum of per-block silentlySkippedCount. > 0 means the post-process blob-field revert path fired during the run."
         },
         "totalSilentSkipDurationMs": {
-          "type": ["integer", "null"],
+          "type": [
+            "integer",
+            "null"
+          ],
           "description": "Sum of per-block silentlySkippedDurationMs. Wall-clock 'wasted' on silently-skipped txs across the run."
         },
         "reorgCount": {
-          "type": ["integer", "null"],
+          "type": [
+            "integer",
+            "null"
+          ],
           "description": "Count of `Chain pruned` events during the run."
         },
         "deepestReorgBlocks": {
-          "type": ["integer", "null"],
+          "type": [
+            "integer",
+            "null"
+          ],
           "description": "Max (fromBlock - toBlock) across reorg events. 0 if no reorgs."
         }
       }
     },
-
     "timeSeriesSection": {
       "type": "object",
       "description": "Key = stable slug (used by the dashboard to look up series); value = a series. Slugs decouple the display name from Prometheus metric names (which may be renamed across Aztec versions).",
-      "additionalProperties": { "$ref": "#/$defs/timeSeries" },
+      "additionalProperties": {
+        "$ref": "#/$defs/timeSeries"
+      },
       "properties": {
-        "inclusionTps": { "$ref": "#/$defs/timeSeries" },
-        "ingressTps": { "$ref": "#/$defs/timeSeries" },
-        "mempoolSizeRpc": { "$ref": "#/$defs/timeSeries" },
-        "mempoolSizeValidator": { "$ref": "#/$defs/timeSeries" },
-        "mempoolSizeFullNode": { "$ref": "#/$defs/timeSeries" },
-        "mempoolMinedMax": { "$ref": "#/$defs/timeSeries" },
-        "mempoolEvictedByReasonRate": { "$ref": "#/$defs/timeSeries" },
-        "mempoolRejectedByReasonRate": { "$ref": "#/$defs/timeSeries" },
-        "blockBuildDurationP95": { "$ref": "#/$defs/timeSeries" },
-        "blockBuildDurationP50": { "$ref": "#/$defs/timeSeries" },
-        "publicProcessorTxDurationP95": { "$ref": "#/$defs/timeSeries" },
-        "publicProcessorTxDurationP50": { "$ref": "#/$defs/timeSeries" },
-        "publicProcessorGasRate": { "$ref": "#/$defs/timeSeries" },
-        "checkpointLastBlockToBroadcastP95": { "$ref": "#/$defs/timeSeries" },
-        "checkpointBlockCountMean": { "$ref": "#/$defs/timeSeries" },
-        "checkpointTxCountMean": { "$ref": "#/$defs/timeSeries" },
-        "l1InclusionDelayP95": { "$ref": "#/$defs/timeSeries" },
-        "gossipLatencyP95": { "$ref": "#/$defs/timeSeries" },
+        "inclusionTps": {
+          "$ref": "#/$defs/timeSeries"
+        },
+        "ingressTps": {
+          "$ref": "#/$defs/timeSeries"
+        },
+        "mempoolSizeRpc": {
+          "$ref": "#/$defs/timeSeries"
+        },
+        "mempoolSizeValidator": {
+          "$ref": "#/$defs/timeSeries"
+        },
+        "mempoolSizeFullNode": {
+          "$ref": "#/$defs/timeSeries"
+        },
+        "mempoolMinedMax": {
+          "$ref": "#/$defs/timeSeries"
+        },
+        "mempoolEvictedByReasonRate": {
+          "$ref": "#/$defs/timeSeries"
+        },
+        "mempoolRejectedByReasonRate": {
+          "$ref": "#/$defs/timeSeries"
+        },
+        "blockBuildDurationP95": {
+          "$ref": "#/$defs/timeSeries"
+        },
+        "blockBuildDurationP50": {
+          "$ref": "#/$defs/timeSeries"
+        },
+        "publicProcessorTxDurationP95": {
+          "$ref": "#/$defs/timeSeries"
+        },
+        "publicProcessorTxDurationP50": {
+          "$ref": "#/$defs/timeSeries"
+        },
+        "txMinedDelayP50": {
+          "$ref": "#/$defs/timeSeries"
+        },
+        "txMinedDelayP95": {
+          "$ref": "#/$defs/timeSeries"
+        },
+        "txMinedDelayP99": {
+          "$ref": "#/$defs/timeSeries"
+        },
+        "publicProcessorGasRate": {
+          "$ref": "#/$defs/timeSeries"
+        },
+        "checkpointLastBlockToBroadcastP95": {
+          "$ref": "#/$defs/timeSeries"
+        },
+        "checkpointBlockCountMean": {
+          "$ref": "#/$defs/timeSeries"
+        },
+        "checkpointTxCountMean": {
+          "$ref": "#/$defs/timeSeries"
+        },
+        "l1InclusionDelayP95": {
+          "$ref": "#/$defs/timeSeries"
+        },
+        "gossipLatencyP95": {
+          "$ref": "#/$defs/timeSeries"
+        },
         "peerCountMean": {
           "$ref": "#/$defs/timeSeries",
           "description": "Legacy aggregate peer-count series kept for older run JSONs."
         },
-        "peerCountByRole": { "$ref": "#/$defs/timeSeries" },
-        "peerCountByValidator": { "$ref": "#/$defs/timeSeries" },
-        "attestationsCollectDurationMean": { "$ref": "#/$defs/timeSeries" },
-        "attestationsCollectAllowanceMean": { "$ref": "#/$defs/timeSeries" },
-        "txCollectorTxsFromMempoolRate": { "$ref": "#/$defs/timeSeries" },
-        "txCollectorTxsFromP2pRate": { "$ref": "#/$defs/timeSeries" },
-        "txCollectorMissingRate": { "$ref": "#/$defs/timeSeries" },
-        "txCollectorRequestedFractionMean": { "$ref": "#/$defs/timeSeries" },
-        "txCollectorRequestDelayP95": { "$ref": "#/$defs/timeSeries" },
-        "sequencerStateDurationP95": { "$ref": "#/$defs/timeSeries" }
+        "peerCountByRole": {
+          "$ref": "#/$defs/timeSeries"
+        },
+        "peerCountByValidator": {
+          "$ref": "#/$defs/timeSeries"
+        },
+        "attestationsCollectDurationMean": {
+          "$ref": "#/$defs/timeSeries"
+        },
+        "attestationsCollectAllowanceMean": {
+          "$ref": "#/$defs/timeSeries"
+        },
+        "txCollectorTxsFromMempoolRate": {
+          "$ref": "#/$defs/timeSeries"
+        },
+        "txCollectorTxsFromP2pRate": {
+          "$ref": "#/$defs/timeSeries"
+        },
+        "txCollectorMissingRate": {
+          "$ref": "#/$defs/timeSeries"
+        },
+        "txCollectorRequestedFractionMean": {
+          "$ref": "#/$defs/timeSeries"
+        },
+        "txCollectorRequestDelayP95": {
+          "$ref": "#/$defs/timeSeries"
+        },
+        "sequencerStateDurationP95": {
+          "$ref": "#/$defs/timeSeries"
+        }
       }
     },
-
     "timeSeries": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["metric", "source", "series"],
+      "required": [
+        "metric",
+        "source",
+        "series"
+      ],
       "properties": {
         "metric": {
           "type": "string",
@@ -309,73 +525,112 @@
         },
         "unit": {
           "type": "string",
-          "examples": ["ms", "tps", "mana/s", "count"]
+          "examples": [
+            "ms",
+            "tps",
+            "mana/s",
+            "count"
+          ]
         },
         "source": {
           "type": "string",
-          "const": "promql",
-          "description": "Future-proofing: other series sources may exist (e.g. 'log-aggregated') with different provenance semantics."
+          "enum": [
+            "promql",
+            "client_observed"
+          ],
+          "description": "Provenance: 'promql' = scraped via PromQL from cluster Prometheus; 'client_observed' = computed in this scraper from per-tx records emitted by n_tps.test.ts (e.g. headline tx_mined_delay)."
         },
         "query": {
           "type": "string",
-          "description": "Exact PromQL used. Kept for audit: if a value looks wrong, the query is the first thing to check."
+          "description": "For source=promql: exact PromQL used. For source=client_observed: a human-readable description of the computation. Kept for audit: if a value looks wrong, the query is the first thing to check."
         },
-        "stepSeconds": { "type": "integer", "minimum": 1 },
+        "stepSeconds": {
+          "type": "integer",
+          "minimum": 1
+        },
         "series": {
           "type": "array",
           "description": "One entry per Prometheus series returned by the query. Single-series queries (e.g. inclusionTps) emit one entry with empty labels. Multi-series queries (per-pod, per-topic, per-rejection-reason, etc.) emit one entry per label combination.",
-          "items": { "$ref": "#/$defs/seriesEntry" }
+          "items": {
+            "$ref": "#/$defs/seriesEntry"
+          }
         }
       }
     },
-
     "seriesEntry": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["labels", "points"],
+      "required": [
+        "labels",
+        "points"
+      ],
       "properties": {
         "labels": {
           "type": "object",
-          "additionalProperties": { "type": "string" },
+          "additionalProperties": {
+            "type": "string"
+          },
           "description": "Prometheus labels that disambiguate this series. Empty {} for single-series queries. Common keys: k8s_pod_name, aztec_gossip_topic_name, rejection_reason, aztec_sequencer_state."
         },
         "points": {
           "type": "array",
           "description": "Samples ordered by unixEpoch ascending. Missing samples (Prom didn't scrape in that window) are omitted rather than interpolated — consumers decide how to handle gaps.",
-          "items": { "$ref": "#/$defs/tsPoint" }
+          "items": {
+            "$ref": "#/$defs/tsPoint"
+          }
         }
       }
     },
-
     "tsPoint": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["unixEpoch", "value"],
+      "required": [
+        "unixEpoch",
+        "value"
+      ],
       "properties": {
         "unixEpoch": {
           "type": "integer",
           "description": "Seconds since unix epoch for this sample. Dashboards normalise to time-within-run via unixEpoch - run.startedAt at render time."
         },
         "value": {
-          "type": ["number", "null"],
+          "type": [
+            "number",
+            "null"
+          ],
           "description": "Metric value. null if Prom returned NaN / no data for this step."
         }
       }
     },
-
     "blockRecord": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["blockNumber", "blockNumberInTest", "minedAt"],
+      "required": [
+        "blockNumber",
+        "blockNumberInTest",
+        "minedAt"
+      ],
       "properties": {
-        "blockNumber": { "type": "integer", "minimum": 0 },
+        "blockNumber": {
+          "type": "integer",
+          "minimum": 0
+        },
         "blockNumberInTest": {
           "type": "integer",
           "description": "blockNumber - firstBlockInTest. First block mined after run.startedAt is 0."
         },
-        "minedAt": { "type": "string", "format": "date-time" },
-        "successfulCount": { "type": "integer", "minimum": 0 },
-        "failedCount": { "type": "integer", "minimum": 0 },
+        "minedAt": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "successfulCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "failedCount": {
+          "type": "integer",
+          "minimum": 0
+        },
         "silentlySkippedCount": {
           "type": "integer",
           "minimum": 0,
@@ -386,16 +641,26 @@
           "minimum": 0,
           "description": "Wall-clock time spent on silently-skipped txs in this block. Added 2026-04-22."
         },
-        "buildDurationSeconds": { "type": "number", "minimum": 0 },
+        "buildDurationSeconds": {
+          "type": "number",
+          "minimum": 0
+        },
         "totalPublicGas": {
           "type": "object",
           "additionalProperties": false,
           "properties": {
-            "daGas": { "type": "integer" },
-            "l2Gas": { "type": "integer" }
+            "daGas": {
+              "type": "integer"
+            },
+            "l2Gas": {
+              "type": "integer"
+            }
           }
         },
-        "totalSizeInBytes": { "type": "integer", "minimum": 0 },
+        "totalSizeInBytes": {
+          "type": "integer",
+          "minimum": 0
+        },
         "source": {
           "type": "string",
           "const": "log",
@@ -403,15 +668,29 @@
         }
       }
     },
-
     "event": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["at", "type"],
+      "required": [
+        "at",
+        "type"
+      ],
       "properties": {
-        "at": { "type": "string", "format": "date-time" },
-        "type": { "type": "string", "enum": ["chainPruned", "slotSummary"] },
-        "source": { "type": "string", "const": "log" },
+        "at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "chainPruned",
+            "slotSummary"
+          ]
+        },
+        "source": {
+          "type": "string",
+          "const": "log"
+        },
         "fromBlock": {
           "type": "integer",
           "description": "For chainPruned: the pre-prune tip."
@@ -428,20 +707,40 @@
           "type": "integer",
           "description": "For slotSummary: wall-clock slot in which the checkpoint was built."
         },
-        "checkpointNumber": { "type": "integer" },
-        "sourcePod": { "type": "string" },
+        "checkpointNumber": {
+          "type": "integer"
+        },
+        "sourcePod": {
+          "type": "string"
+        },
         "proposer": {
           "type": "string",
           "description": "Validator/proposer address selected for this slot."
         },
-        "attestorAddress": { "type": "string" },
-        "publisherAddress": { "type": "string" },
-        "blocksBuilt": { "type": "number", "minimum": 0 },
-        "txCount": { "type": "number", "minimum": 0 },
-        "totalMana": { "type": "number", "minimum": 0 },
+        "attestorAddress": {
+          "type": "string"
+        },
+        "publisherAddress": {
+          "type": "string"
+        },
+        "blocksBuilt": {
+          "type": "number",
+          "minimum": 0
+        },
+        "txCount": {
+          "type": "number",
+          "minimum": 0
+        },
+        "totalMana": {
+          "type": "number",
+          "minimum": 0
+        },
         "blockBuildFailures": {
           "type": "array",
-          "items": { "type": "object", "additionalProperties": true }
+          "items": {
+            "type": "object",
+            "additionalProperties": true
+          }
         },
         "checkpointBuildFailure": {
           "type": "object",
@@ -459,11 +758,16 @@
         }
       }
     },
-
     "sequencerStateSlot": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["slotNumber", "startedAt", "endedAt", "totalMs", "states"],
+      "required": [
+        "slotNumber",
+        "startedAt",
+        "endedAt",
+        "totalMs",
+        "states"
+      ],
       "properties": {
         "slotNumber": {
           "type": "integer",
@@ -490,7 +794,10 @@
         },
         "states": {
           "type": "object",
-          "additionalProperties": { "type": "number", "minimum": 0 },
+          "additionalProperties": {
+            "type": "number",
+            "minimum": 0
+          },
           "description": "Map from SequencerState name to total milliseconds spent in that state during this slot."
         }
       }

--- a/spartan/scripts/bench_10tps/bench_scrape.ts
+++ b/spartan/scripts/bench_10tps/bench_scrape.ts
@@ -53,6 +53,7 @@ type Args = {
   targetTps: number;
   workload: string;
   output: string | undefined;
+  inclusionRecords: string | undefined;
   waitForPendingZero: boolean;
   maxPendingWaitSeconds: number;
 };
@@ -78,6 +79,10 @@ function parseArgs(): Args {
       argv.indexOf("--output") === -1
         ? undefined
         : argv[argv.indexOf("--output") + 1],
+    inclusionRecords:
+      argv.indexOf("--inclusion-records") === -1
+        ? undefined
+        : argv[argv.indexOf("--inclusion-records") + 1],
     waitForPendingZero:
       !argv.includes("--no-wait-for-pending-zero") &&
       (argv.includes("--wait-for-pending-zero") ||
@@ -133,6 +138,128 @@ type SeriesEntry = {
   labels: Record<string, string>;
   points: TsPoint[];
 };
+
+// --- Inclusion records (client-observed per-tx timing from n_tps.test.ts) ---
+
+// Subset of TxInclusionData (yarn-project/.../tx_metrics.ts) that we care
+// about. Records are emitted into /tmp/n_tps_timing_data.json under the
+// `inclusionRecords` key, filtered to the high-value group, so this is the
+// authoritative client-observed inclusion-latency dataset for the run.
+type InclusionRecord = {
+  txHash: string;
+  sentAtMs: number;
+  minedAtMs: number;
+  blocknumber: number;
+};
+
+async function loadInclusionRecords(
+  path: string | undefined,
+): Promise<InclusionRecord[]> {
+  if (!path) return [];
+  try {
+    const raw = await readFile(path, "utf8");
+    const parsed = JSON.parse(raw) as {
+      inclusionRecords?: InclusionRecord[];
+    };
+    const records = parsed.inclusionRecords ?? [];
+    log(`Loaded ${records.length} inclusion records`, { path });
+    return records;
+  } catch (err) {
+    log("inclusion records load failed", {
+      path,
+      err: err instanceof Error ? err.message : String(err),
+    });
+    return [];
+  }
+}
+
+// Nearest-rank quantile. Returns null on empty input.
+function quantile(sorted: number[], p: number): number | null {
+  if (sorted.length === 0) return null;
+  const idx = Math.min(sorted.length - 1, Math.floor(p * sorted.length));
+  return sorted[idx];
+}
+
+function deltasMs(records: InclusionRecord[]): number[] {
+  const out: number[] = [];
+  for (const r of records) {
+    if (r.sentAtMs > 0 && r.minedAtMs > 0) {
+      const d = r.minedAtMs - r.sentAtMs;
+      if (d > 0) out.push(d);
+    }
+  }
+  return out;
+}
+
+function inclusionLatencyScalarMs(
+  records: InclusionRecord[],
+  p: number,
+): number | null {
+  const sorted = deltasMs(records).sort((a, b) => a - b);
+  return quantile(sorted, p);
+}
+
+// Bin records by sentAt minute, compute per-bin quantile. Matches the
+// `[1m]` window semantics the old Prom-based tx_mined_delay queries used.
+function inclusionLatencyTimeSeriesPoints(
+  records: InclusionRecord[],
+  startedAtEpoch: number,
+  endedAtEpoch: number,
+  p: number,
+  bucketSec = 60,
+): TsPoint[] {
+  const bins = new Map<number, number[]>();
+  for (const r of records) {
+    if (r.sentAtMs <= 0 || r.minedAtMs <= 0) continue;
+    const sentSec = Math.floor(r.sentAtMs / 1000);
+    if (sentSec < startedAtEpoch || sentSec > endedAtEpoch) continue;
+    const d = r.minedAtMs - r.sentAtMs;
+    if (d <= 0) continue;
+    const bin = Math.floor(sentSec / bucketSec) * bucketSec;
+    const arr = bins.get(bin) ?? [];
+    arr.push(d);
+    bins.set(bin, arr);
+  }
+  const points: TsPoint[] = [];
+  for (const bin of [...bins.keys()].sort((a, b) => a - b)) {
+    const arr = bins.get(bin)!.sort((a, b) => a - b);
+    points.push({ unixEpoch: bin, value: quantile(arr, p) });
+  }
+  return points;
+}
+
+function buildInclusionLatencyTimeSeries(
+  records: InclusionRecord[],
+  startedAtEpoch: number,
+  endedAtEpoch: number,
+  p: number,
+): {
+  metric: string;
+  unit: string;
+  source: string;
+  query: string;
+  stepSeconds: number;
+  series: SeriesEntry[];
+} {
+  return {
+    metric: "n_tps_test.tx_inclusion_time",
+    unit: "ms",
+    source: "client_observed",
+    query: `n_tps.test.ts inclusionRecords (group=tx_inclusion_time), quantile=${p}, 60s bins by sentAtMs`,
+    stepSeconds: 60,
+    series: [
+      {
+        labels: {},
+        points: inclusionLatencyTimeSeriesPoints(
+          records,
+          startedAtEpoch,
+          endedAtEpoch,
+          p,
+        ),
+      },
+    ],
+  };
+}
 
 const parseValue = (v: string | undefined): number | null =>
   v === undefined || v === "NaN" ? null : Number(v);
@@ -1408,6 +1535,7 @@ type SummaryArgs = {
   timeSeries: Record<string, { series: SeriesEntry[] }>;
   blocks: BlockRecord[];
   events: Event[];
+  inclusionRecords: InclusionRecord[];
 };
 
 async function buildSummary(a: SummaryArgs): Promise<Record<string, unknown>> {
@@ -1463,24 +1591,17 @@ async function buildSummary(a: SummaryArgs): Promise<Record<string, unknown>> {
   const oneShotQuantile = (q: number, bucket: string) =>
     `histogram_quantile(${q}, sum by (le)(rate(${bucket}${NS}[${windowSpec}])))`;
 
-  const [
-    inclLatP50,
-    inclLatP95,
-    inclLatP99,
-    buildP50,
-    buildP95,
-    ppTxP50,
-    ppTxP95,
-  ] = await Promise.all([
-    safeInstant(
-      oneShotQuantile(0.5, "aztec_mempool_tx_mined_delay_milliseconds_bucket"),
-    ),
-    safeInstant(
-      oneShotQuantile(0.95, "aztec_mempool_tx_mined_delay_milliseconds_bucket"),
-    ),
-    safeInstant(
-      oneShotQuantile(0.99, "aztec_mempool_tx_mined_delay_milliseconds_bucket"),
-    ),
+  // Inclusion-latency quantiles are now computed from per-tx client-observed
+  // records emitted by n_tps.test.ts (high-value group only). The other
+  // histogram-based scalars below still come from Prometheus.
+  const inclLatP50 = inclusionLatencyScalarMs(a.inclusionRecords, 0.5);
+  const inclLatP95 = inclusionLatencyScalarMs(a.inclusionRecords, 0.95);
+  const inclLatP99 = inclusionLatencyScalarMs(a.inclusionRecords, 0.99);
+  if (a.inclusionRecords.length === 0) {
+    log("No inclusion records loaded; summary.inclusionLatencyP* will be null");
+  }
+
+  const [buildP50, buildP95, ppTxP50, ppTxP95] = await Promise.all([
     safeInstant(
       oneShotQuantile(
         0.5,
@@ -1794,6 +1915,34 @@ async function main(): Promise<void> {
     log("Scraping Prometheus time-series");
     const timeSeries = await scrapeTimeSeries(startedAtEpoch, promEndEpoch);
 
+    log("Loading client-observed inclusion records");
+    const inclusionRecords = await loadInclusionRecords(args.inclusionRecords);
+    // Compute the headline inclusion-latency time series from per-tx records
+    // and inject under the same slugs the dashboard reads. No Prometheus
+    // dependency for these — they reflect the true client → block-visible
+    // wall-clock latency for high-value txs only.
+    (timeSeries as Record<string, unknown>).txMinedDelayP50 =
+      buildInclusionLatencyTimeSeries(
+        inclusionRecords,
+        startedAtEpoch,
+        promEndEpoch,
+        0.5,
+      );
+    (timeSeries as Record<string, unknown>).txMinedDelayP95 =
+      buildInclusionLatencyTimeSeries(
+        inclusionRecords,
+        startedAtEpoch,
+        promEndEpoch,
+        0.95,
+      );
+    (timeSeries as Record<string, unknown>).txMinedDelayP99 =
+      buildInclusionLatencyTimeSeries(
+        inclusionRecords,
+        startedAtEpoch,
+        promEndEpoch,
+        0.99,
+      );
+
     log("Scraping per-block logs from gcloud");
     // Extend the log window by the drain buffer too — some blocks near endedAt
     // arrive in gcloud after the test stops sending.
@@ -1848,6 +1997,7 @@ async function main(): Promise<void> {
       timeSeries: timeSeries as Record<string, { series: SeriesEntry[] }>,
       blocks,
       events,
+      inclusionRecords,
     });
 
     const payload = {

--- a/yarn-project/end-to-end/src/spartan/n_tps.test.ts
+++ b/yarn-project/end-to-end/src/spartan/n_tps.test.ts
@@ -6,6 +6,7 @@ import { SponsoredFeePaymentMethod } from '@aztec/aztec.js/fee';
 import { type AztecNode, createAztecNodeClient } from '@aztec/aztec.js/node';
 import { AccountManager } from '@aztec/aztec.js/wallet';
 import { INITIAL_L2_BLOCK_NUM } from '@aztec/constants';
+import { BlockNumber } from '@aztec/foundation/branded-types';
 import { times, timesParallel } from '@aztec/foundation/collection';
 import { randomBigInt } from '@aztec/foundation/crypto/random';
 import { Fr } from '@aztec/foundation/curves/bn254';
@@ -552,6 +553,34 @@ describe('sustained N TPS test', () => {
     }));
     const startedAt = new Date().toISOString();
 
+    // Block-watcher: stamps wall-clock minedAtMs on each sent tx the first time
+    // its block becomes visible to this client. Runs throughout sending AND the
+    // post-window waitForTx tail so late blocks still get a true client-observed
+    // timestamp. recordMinedTx (in waitForTx) is the slow-path fallback for any
+    // tx the watcher misses.
+    let lastSeenBlock = await aztecNode.getBlockNumber();
+    const blockWatcher = new RunningPromise(
+      async () => {
+        const current = await aztecNode.getBlockNumber();
+        while (lastSeenBlock < current) {
+          const n = BlockNumber.add(lastSeenBlock, 1);
+          const block = await aztecNode.getBlock(n, { includeTransactions: true });
+          lastSeenBlock = n;
+          if (!block) {
+            continue;
+          }
+          metrics.observeBlockForMinedTxs(
+            n,
+            block.body.txEffects.map(t => t.txHash),
+            Date.now(),
+          );
+        }
+      },
+      logger,
+      1000,
+    );
+    blockWatcher.start();
+
     sendTxsAtTps(logger, abortController.signal, lowValueLanes, lowValueTps, lowValueSendTx);
     const sentTxHashes = sendTxsAtTps(logger, abortController.signal, highValueLanes, highValueTps, highValueSendTx);
 
@@ -563,11 +592,6 @@ describe('sustained N TPS test', () => {
       highValueTxs,
       highValueSent: sentTxHashes.length,
     });
-
-    // metadata about the test run for the scraper script
-    const metadataPath = '/tmp/n_tps_timing_data.json';
-    await writeFile(metadataPath, JSON.stringify({ startedAt, endedAt, runId: process.env.BENCH_RUN_ID }));
-    logger.info('Wrote benchmark metadata', { path: metadataPath, startedAt, endedAt });
 
     const results: { success: boolean; txHash: string; error?: any }[] = [];
     const waitForTx = async (txHash: string, txName: string) => {
@@ -606,6 +630,24 @@ describe('sustained N TPS test', () => {
       index += chunk.length;
       logger.debug('Processed tx batch', { processed: index, remaining: sentTxHashes.length });
     }
+
+    await blockWatcher.stop();
+
+    // Metadata + per-tx inclusion records for the bench_scrape script. Records
+    // are filtered to the high-value group, so this is the authoritative
+    // client-observed inclusion-latency dataset for the run.
+    const inclusionRecords = metrics.getInclusionRecords('tx_inclusion_time');
+    const metadataPath = '/tmp/n_tps_timing_data.json';
+    await writeFile(
+      metadataPath,
+      JSON.stringify({ startedAt, endedAt, runId: process.env.BENCH_RUN_ID, inclusionRecords }),
+    );
+    logger.info('Wrote benchmark metadata', {
+      path: metadataPath,
+      startedAt,
+      endedAt,
+      inclusionRecords: inclusionRecords.length,
+    });
 
     // Count successes and failures
     const successCount = results.filter(r => r.success).length;

--- a/yarn-project/end-to-end/src/spartan/tx_metrics.ts
+++ b/yarn-project/end-to-end/src/spartan/tx_metrics.ts
@@ -134,9 +134,12 @@ export class ProvingMetrics {
 
 export type TxInclusionData = {
   txHash: string;
-  sentAt: number;
-  minedAt: number;
-  attestedAt: number;
+  /** Wall-clock at client when the tx was submitted, in ms (Date.now()). */
+  sentAtMs: number;
+  /** Wall-clock at client when the block containing the tx first became visible, in ms (Date.now()). -1 if never observed. */
+  minedAtMs: number;
+  /** Reserved for future attestation-observed-at signal; -1 today. */
+  attestedAtMs: number;
   blocknumber: number;
   priorityFee: number;
   totalFee: number;
@@ -174,9 +177,9 @@ export class TxInclusionMetrics {
 
     this.data.set(txHash, {
       txHash,
-      sentAt: Math.trunc(Date.now() / 1000),
-      minedAt: -1,
-      attestedAt: -1,
+      sentAtMs: Date.now(),
+      minedAtMs: -1,
+      attestedAtMs: -1,
       blocknumber: -1,
       priorityFee: Number(priorityFees.feePerDaGas + priorityFees.feePerL2Gas),
       totalFee: -1,
@@ -184,6 +187,28 @@ export class TxInclusionMetrics {
       group,
     });
     this.groups.add(group);
+  }
+
+  /**
+   * Stamp mined-at metadata for any tracked tx contained in this block, using
+   * `observedAtMs` (caller-supplied wall-clock at the moment they first saw the
+   * block). Idempotent: existing minedAtMs is preserved so the first observer
+   * wins (typically the block-watcher; recordMinedTx is a fallback).
+   */
+  observeBlockForMinedTxs(
+    blockNumber: number,
+    txHashes: ReadonlyArray<{ toString(): string }>,
+    observedAtMs: number,
+  ): void {
+    txHashes.forEach((txHash, position) => {
+      const data = this.data.get(txHash.toString());
+      if (!data || data.minedAtMs !== -1) {
+        return;
+      }
+      data.blocknumber = blockNumber;
+      data.minedAtMs = observedAtMs;
+      data.positionInBlock = position;
+    });
   }
 
   async recordMinedTx(txReceipt: TxReceipt): Promise<void> {
@@ -197,26 +222,43 @@ export class TxInclusionMetrics {
       return;
     }
 
-    if (!this.blocks.has(blockNumber)) {
-      this.blocks.set(blockNumber, this.aztecNode.getBlock(blockNumber, { includeTransactions: true }));
-    }
-
-    const block = await this.blocks.get(blockNumber)!;
-    if (!block) {
-      this.logger?.warn('Failed to load block for mined tx receipt', { txHash: txHash.toString(), blockNumber });
-      return;
-    }
     const data = this.data.get(txHash.toString());
     if (!data) {
       const message = `Missing sent tx record for mined tx ${txHash.toString()}`;
       this.logger?.warn(message, { txHash: txHash.toString(), blockNumber });
       throw new Error(message);
     }
-    data.blocknumber = blockNumber;
-    data.minedAt = Number(block.header.globalVariables.timestamp);
-    data.attestedAt = -1;
     data.totalFee = Number(txReceipt.transactionFee ?? 0n);
-    data.positionInBlock = block.body.txEffects.findIndex(txEffect => txEffect.txHash.equals(txHash));
+
+    // Fallback path for txs the block-watcher missed (e.g. observed only after
+    // the watcher stopped). Stamp with the block's L2 slot timestamp; this is
+    // earlier than the true client-observed time by attestation+propagation
+    // lag, but it's the only deterministic timestamp available post-hoc.
+    if (data.minedAtMs === -1) {
+      if (!this.blocks.has(blockNumber)) {
+        this.blocks.set(blockNumber, this.aztecNode.getBlock(blockNumber, { includeTransactions: true }));
+      }
+      const block = await this.blocks.get(blockNumber)!;
+      if (!block) {
+        this.logger?.warn('Failed to load block for mined tx receipt', { txHash: txHash.toString(), blockNumber });
+        return;
+      }
+      data.blocknumber = blockNumber;
+      data.minedAtMs = Number(block.header.globalVariables.timestamp) * 1000;
+      data.positionInBlock = block.body.txEffects.findIndex(txEffect => txEffect.txHash.equals(txHash));
+    }
+  }
+
+  /** Per-tx inclusion records for a group. Used to serialise out for downstream tooling. */
+  getInclusionRecords(group?: string): TxInclusionData[] {
+    const out: TxInclusionData[] = [];
+    for (const tx of this.data.values()) {
+      if (group !== undefined && tx.group !== group) {
+        continue;
+      }
+      out.push({ ...tx });
+    }
+    return out;
   }
 
   public inclusionTimeInSeconds(group: string): {
@@ -231,19 +273,23 @@ export class TxInclusionMetrics {
     const histogram = createHistogram({});
     let nonPositive = 0;
     for (const tx of this.data.values()) {
-      if (!tx.blocknumber || tx.group !== group || tx.minedAt === -1) {
+      if (!tx.blocknumber || tx.group !== group || tx.minedAtMs === -1) {
         continue;
       }
 
-      // `minedAt` is the block's L2 slot timestamp (seconds) while `sentAt` is the wall-clock
-      // send time. Because the slot timestamp can precede or equal the send time, the delta
-      // can be <= 0, which perf_hooks.createHistogram rejects. Skip those instead of crashing.
-      const delta = tx.minedAt - tx.sentAt;
-      if (delta <= 0) {
+      // Both timestamps are client wall-clock (ms). A negative delta should be
+      // impossible since the watcher stamps minedAtMs strictly after sentAtMs,
+      // but the fallback path (recordMinedTx via L2 slot timestamp) can stamp
+      // earlier than sentAtMs. perf_hooks.createHistogram rejects <=0; skip
+      // those instead of crashing.
+      const deltaMs = tx.minedAtMs - tx.sentAtMs;
+      if (deltaMs <= 0) {
         nonPositive++;
         continue;
       }
-      histogram.record(delta);
+      // Histogram is recorded in seconds (rounded) to match the existing
+      // toGithubActionBenchmarkJSON output unit; per-tx records carry the raw ms.
+      histogram.record(Math.max(1, Math.round(deltaMs / 1000)));
     }
     if (nonPositive > 0) {
       this.logger?.debug(`Dropped ${nonPositive} tx inclusion samples with non-positive delta`, { group });


### PR DESCRIPTION
## Summary

Replaces the Prometheus `aztec_mempool_tx_mined_delay_milliseconds` histogram (which mixes every mempool observer — RPC + validators + full-nodes — and both high- and low-value txs) with a **client-observed measurement scoped to the high-value lane**.

### What changes
- **`n_tps.test.ts`**: block-watcher `RunningPromise` polls `getBlockNumber()` every 1s and stamps wall-clock `minedAtMs` the first time each sent tx's block becomes visible to the test client. Records dumped (high-value group only) into `/tmp/n_tps_timing_data.json` alongside the existing `startedAt`/`endedAt`.
- **`tx_metrics.ts`**: rename `sentAt`/`minedAt`/`attestedAt` → `*Ms` (ms wall-clock); add `observeBlockForMinedTxs` (idempotent, first observer wins) and `getInclusionRecords`. `recordMinedTx` kept as fallback (slot-timestamp × 1000) for any tx the watcher misses.
- **`bench_scrape.ts`**: load records via new `--inclusion-records` flag; compute `summary.inclusionLatencyP{50,95,99}Ms` and the `txMinedDelayP{50,95,99}` time series (60s bins by `sentAtMs`) directly from the per-tx data. The other Prom-based histograms (build duration, public-processor) are untouched.
- **`bench_output.schema.json`**: widens `timeSeries.source` enum to include `"client_observed"`, declares the three `txMinedDelay*` slugs.
- **`bootstrap.sh`**: `HIGH_VALUE_TPS=1`, `LOW_VALUE_TPS=9` (was 10/0) so the high-value scoping is non-trivial; passes `--inclusion-records "$metadata"` to the scraper.

Field names on the run JSON are unchanged, so the dashboard panel in `AztecProtocol/explorations` keeps working — descriptions updated to reflect the new source (PR `spy/inclusion-latency-client-source`).

### Why
- Prom histogram measures *mempool-add → mempool-saw-block* per node. Aggregating across RPC + validators dilutes the headline with the validator's gossip-arrival-based view.
- It also doesn't distinguish high-value from low-value lanes. In the new 1/9 mix, low-value txs run at network min priority and are explicitly allowed to fail fee checks, which would dominate any aggregated quantile.
- Client-observed wall-clock is what a paying client actually experiences end-to-end.

### Caveats
- `minedAtMs` has ~1s jitter from the watcher's poll interval. p50 is typically multiple slots, so this is small relative to the signal.
- `bench_output.schema.json` diff is noisy: the precommit prettier hook expanded inline `{ "$ref": "..." }` entries throughout. Semantic change is ~7 lines at the top of the file.

### Test plan
- [ ] Run bench-10tps end-to-end against a real namespace.
- [ ] Verify `/tmp/n_tps_timing_data.json` contains `inclusionRecords` with non-trivial `minedAtMs - sentAtMs` deltas.
- [ ] Verify run JSON has `timeSeries.txMinedDelayP*` with `source: "client_observed"` and `summary.inclusionLatencyP*Ms` populated.
- [ ] Verify the dashboard panel renders the line chart on the new run.

Supersedes #23465.