### PR TITLE
feat(aztec-nr)!: rename push_nullifier to push_nullifier_unsafe

### DIFF
--- a/docs/docs-developers/docs/aztec-nr/standards/aip-721.md
+++ b/docs/docs-developers/docs/aztec-nr/standards/aip-721.md
@@ -49,7 +49,7 @@ impl NFTNote {
         // ... creates encrypted log and validity commitment
         let partial_note = PartialNFTNote { commitment };
         let validity_commitment = partial_note.compute_validity_commitment(completer);
-        context.push_nullifier(validity_commitment);
+        context.push_nullifier_unsafe(validity_commitment);
         partial_note
     }
 }

--- a/docs/docs-developers/docs/foundational-topics/advanced/authwit.md
+++ b/docs/docs-developers/docs/foundational-topics/advanced/authwit.md
@@ -144,7 +144,7 @@ You can cancel an authwit before it's used by emitting its nullifier directly. T
 fn cancel_authwit(inner_hash: Field) {
     let on_behalf_of = self.msg_sender();
     let nullifier = compute_authwit_nullifier(on_behalf_of, inner_hash);
-    self.context.push_nullifier(nullifier);
+    self.context.push_nullifier_unsafe(nullifier);
 }
 ```
 

--- a/docs/docs-developers/docs/resources/migration_notes.md
+++ b/docs/docs-developers/docs/resources/migration_notes.md
@@ -20,8 +20,7 @@ make it clear that they are low-level functions that require careful domain sepa
 + context.push_nullifier_unsafe(nullifier);
 ```
 
-Prefer higher-level abstractions like [`SingleUseClaim`](../aztec-nr/storage/single-use-claim.md) or
-[`destroy_note`](../aztec-nr/storage/notes/lifecycle.md) which handle domain separation automatically.
+Prefer higher-level abstractions like `SingleUseClaim` or `destroy_note` which handle domain separation automatically.
 
 ### [Aztec.nr] `LogRetrievalRequest` now includes `source`, `from_block`, and `to_block` fields
 

--- a/docs/docs-developers/docs/resources/migration_notes.md
+++ b/docs/docs-developers/docs/resources/migration_notes.md
@@ -9,6 +9,20 @@ Aztec is in active development. Each version may introduce breaking changes that
 
 ## TBD
 
+### [Aztec.nr] `push_nullifier` renamed to `push_nullifier_unsafe`
+
+`PrivateContext::push_nullifier` and `PublicContext::push_nullifier` have been renamed to `push_nullifier_unsafe` to
+make it clear that they are low-level functions that require careful domain separation. This is consistent with the
+`_unsafe` suffix already used by `emit_private_log_unsafe`, `emit_raw_note_log_unsafe`, and `emit_public_log_unsafe`.
+
+```diff
+- context.push_nullifier(nullifier);
++ context.push_nullifier_unsafe(nullifier);
+```
+
+Prefer higher-level abstractions like [`SingleUseClaim`](../aztec-nr/storage/single-use-claim.md) or
+[`destroy_note`](../aztec-nr/storage/notes/lifecycle.md) which handle domain separation automatically.
+
 ### [Aztec.nr] `LogRetrievalRequest` now includes `source`, `from_block`, and `to_block` fields
 
 `LogRetrievalRequest` has been extended with three new fields to support filtering logs by source and block range. The `get_logs_by_tag` oracle now also returns all matching logs per tag instead of only the first match.

--- a/noir-projects/aztec-nr/aztec/src/authwit/account.nr
+++ b/noir-projects/aztec-nr/aztec/src/authwit/account.nr
@@ -74,7 +74,7 @@ impl AccountActions<&mut PrivateContext> {
 
         if cancellable {
             let tx_nullifier = poseidon2_hash_with_separator([app_payload.tx_nonce], DOM_SEP__TX_NULLIFIER);
-            self.context.push_nullifier(tx_nullifier);
+            self.context.push_nullifier_unsafe(tx_nullifier);
         }
     }
 

--- a/noir-projects/aztec-nr/aztec/src/authwit/auth.nr
+++ b/noir-projects/aztec-nr/aztec/src/authwit/auth.nr
@@ -282,7 +282,7 @@ pub fn assert_inner_hash_valid_authwit(context: &mut PrivateContext, on_behalf_o
     // already be handled in the verification, so we just need something to nullify, that allows the same inner_hash
     // for multiple actors.
     let nullifier = compute_authwit_nullifier(on_behalf_of, inner_hash);
-    context.push_nullifier(nullifier);
+    context.push_nullifier_unsafe(nullifier);
 }
 
 /// Assert that `on_behalf_of` has authorized the current call in the authentication registry

--- a/noir-projects/aztec-nr/aztec/src/context/private_context.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/private_context.nr
@@ -366,16 +366,17 @@ impl PrivateContext {
     /// The raw `nullifier` is not what is inserted into the Aztec state tree: it will be first siloed by contract
     /// address via [`crate::protocol::hash::compute_siloed_nullifier`] in order to prevent accidental or malicious
     /// interference of nullifiers from different contracts.
-    pub fn push_nullifier(&mut self, nullifier: Field) {
+    pub fn push_nullifier_unsafe(&mut self, nullifier: Field) {
         notify_created_nullifier(nullifier);
         self.nullifiers.push(Nullifier { value: nullifier, note_hash: 0 }.count(self.next_counter()));
     }
 
     /// Creates a new [nullifier](crate::nullifier) associated with a note.
     ///
-    /// This is a variant of [`PrivateContext::push_nullifier`] that is used for note nullifiers, i.e. nullifiers that
-    /// correspond to a note. If a note and its nullifier are created in the same transaction, then the private kernels
-    /// will 'squash' these values, deleting them both as if they never existed and reducing transaction fees.
+    /// This is a variant of [`PrivateContext::push_nullifier_unsafe`] that is used for note nullifiers, i.e.
+    /// nullifiers that correspond to a note. If a note and its nullifier are created in the same transaction, then
+    /// the private kernels will 'squash' these values, deleting them both as if they never existed and reducing
+    /// transaction fees.
     ///
     /// The `nullification_note_hash` must be the result of calling
     /// [`crate::note::utils::compute_confirmed_note_hash_for_nullification`] for pending notes, and `0` for settled
@@ -386,10 +387,10 @@ impl PrivateContext {
     /// This is a low-level function that must be used with great care to avoid subtle corruption of contract state.
     /// Instead of calling this function, consider using the higher-level [`crate::note::lifecycle::destroy_note`].
     ///
-    /// The precautions listed for [`PrivateContext::push_nullifier`] apply here as well, and callers should
+    /// The precautions listed for [`PrivateContext::push_nullifier_unsafe`] apply here as well, and callers should
     /// additionally ensure `nullification_note_hash` corresponds to a note emitted by this contract, with its hash
     /// computed in the same transaction execution phase as the call to this function. Finally, only this function
-    /// should be used for note nullifiers, never [`PrivateContext::push_nullifier`].
+    /// should be used for note nullifiers, never [`PrivateContext::push_nullifier_unsafe`].
     ///
     /// Failure to do these things can result in unprovable contexts, accidental deletion of notes, or double-spend
     /// attacks.
@@ -858,7 +859,7 @@ impl PrivateContext {
         );
 
         // Push nullifier (and the "commitment" corresponding to this can be "empty")
-        self.push_nullifier(nullifier)
+        self.push_nullifier_unsafe(nullifier)
     }
 
     /// Emits a private log (an array of Fields) that will be published to an Ethereum blob.

--- a/noir-projects/aztec-nr/aztec/src/context/public_context.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/public_context.nr
@@ -253,7 +253,7 @@ impl PublicContext {
         assert(!self.nullifier_exists_unsafe(nullifier, self.this_address()), "L1-to-L2 message is already nullified");
         assert(self.l1_to_l2_msg_exists(message_hash, leaf_index), "Tried to consume nonexistent L1-to-L2 message");
 
-        self.push_nullifier(nullifier);
+        self.push_nullifier_unsafe(nullifier);
     }
 
     /// Sends an "L2 -> L1 message" from this function (Aztec, L2) to a smart contract on Ethereum (L1). L1 contracts
@@ -406,7 +406,7 @@ impl PublicContext {
     /// The raw `nullifier` is not what is inserted into the Aztec state tree: it will be first siloed by contract
     /// address via [`crate::protocol::hash::compute_siloed_nullifier`] in order to prevent accidental or malicious
     /// interference of nullifiers from different contracts.
-    pub fn push_nullifier(_self: Self, nullifier: Field) {
+    pub fn push_nullifier_unsafe(_self: Self, nullifier: Field) {
         // Safety: AVM opcodes are constrained by the AVM itself
         unsafe { avm::emit_nullifier(nullifier) };
     }

--- a/noir-projects/aztec-nr/aztec/src/event/event_emission.nr
+++ b/noir-projects/aztec-nr/aztec/src/event/event_emission.nr
@@ -29,7 +29,7 @@ where
     // The event commitment is emitted as a nullifier instead of as a note because these are simpler: nullifiers cannot
     // be squashed, making kernel processing simpler, and they have no nonce that recipients need to discover.
     let commitment = compute_private_event_commitment(event, randomness);
-    context.push_nullifier(commitment);
+    context.push_nullifier_unsafe(commitment);
 
     EventMessage::new(NewEvent { event, randomness }, context)
 }

--- a/noir-projects/aztec-nr/aztec/src/history/nullifier.nr
+++ b/noir-projects/aztec-nr/aztec/src/history/nullifier.nr
@@ -15,8 +15,9 @@ mod test;
 /// Asserts that a nullifier existed by the time a block was mined.
 ///
 /// This function takes a _siloed_ nullifier, i.e. the value that is actually stored in the tree. Use
-/// [`crate::protocol::hash::compute_siloed_nullifier`] to convert an inner nullifier (what
-/// [`PrivateContext::push_nullifier`](crate::context::PrivateContext::push_nullifier) takes) into a siloed one.
+/// [`crate::protocol::hash::compute_siloed_nullifier`] to convert an inner nullifier
+/// (what [`PrivateContext::push_nullifier_unsafe`](crate::context::PrivateContext::push_nullifier_unsafe)
+/// takes) into a siloed one.
 ///
 /// Note that this does not mean that the nullifier was created **at** `block_header`, only that it was present in the
 /// tree once all transactions from `block_header` were executed.
@@ -56,8 +57,9 @@ pub fn assert_nullifier_existed_by(block_header: BlockHeader, siloed_nullifier: 
 /// Asserts that a nullifier did not exist by the time a block was mined.
 ///
 /// This function takes a _siloed_ nullifier, i.e. the value that is actually stored in the tree. Use
-/// [`crate::protocol::hash::compute_siloed_nullifier`] to convert an inner nullifier (what
-/// [`PrivateContext::push_nullifier`](crate::context::PrivateContext::push_nullifier) takes) into a siloed one.
+/// [`crate::protocol::hash::compute_siloed_nullifier`] to convert an inner nullifier
+/// (what [`PrivateContext::push_nullifier_unsafe`](crate::context::PrivateContext::push_nullifier_unsafe)
+/// takes) into a siloed one.
 ///
 /// In order to prove that a nullifier **did** exist by `block_header`, use [`assert_nullifier_existed_by`].
 ///
@@ -69,8 +71,8 @@ pub fn assert_nullifier_existed_by(block_header: BlockHeader, siloed_nullifier: 
 ///
 /// If you **must** prove that a nullifier does not exist by the time a transaction is executed, there only two ways to
 /// do this: by actually emitting the nullifier via
-/// [`PrivateContext::push_nullifier`](crate::context::PrivateContext::push_nullifier) (which can of course can be done
-/// once), or by calling a public contract function that calls
+/// [`PrivateContext::push_nullifier_unsafe`](crate::context::PrivateContext::push_nullifier_unsafe)
+/// (which can of course only be done once), or by calling a public contract function that calls
 /// [`PublicContext::nullifier_exists_unsafe`](crate::context::PublicContext::nullifier_exists_unsafe) (which leaks
 /// that this nullifier is being checked):
 ///

--- a/noir-projects/aztec-nr/aztec/src/macros/functions/initialization_utils.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/functions/initialization_utils.nr
@@ -54,14 +54,14 @@ global EMIT_PUBLIC_INIT_NULLIFIER_SELECTOR: FunctionSelector = comptime {
 /// emitting the public nullifier without the private one). The macro-generated code handles this automatically.
 pub fn mark_as_initialized_public(context: PublicContext) {
     let init_nullifier = compute_public_initialization_nullifier(context.this_address());
-    context.push_nullifier(init_nullifier);
+    context.push_nullifier_unsafe(init_nullifier);
 }
 
 fn mark_as_initialized_private(context: &mut PrivateContext) {
     let address = (*context).this_address();
     let instance = get_contract_instance(address);
     let init_nullifier = compute_private_initialization_nullifier(address, instance.initialization_hash);
-    context.push_nullifier(init_nullifier);
+    context.push_nullifier_unsafe(init_nullifier);
 }
 
 /// Emits the private initialization nullifier and, if relevant, enqueues the emission of the public one.
@@ -88,7 +88,7 @@ pub fn mark_as_initialized_from_public_initializer(context: PublicContext) {
     // currently executing, which by definition must have been deployed.
     let init_hash = get_contract_instance_initialization_hash_avm(address).unwrap();
     let private_nullifier = compute_private_initialization_nullifier(address, init_hash);
-    context.push_nullifier(private_nullifier);
+    context.push_nullifier_unsafe(private_nullifier);
     mark_as_initialized_public(context);
 }
 

--- a/noir-projects/aztec-nr/aztec/src/nullifier/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/nullifier/mod.nr
@@ -31,8 +31,8 @@
 //!
 //! ## Nullifier Creation
 //!
-//! The low-level mechanisms to create new nullifiers are [`crate::context::PrivateContext::push_nullifier`] and
-//! [`crate::context::PublicContext::push_nullifier`], but these require care and can be hard to use correctly.
+//! The low-level mechanisms to create new nullifiers are [`crate::context::PrivateContext::push_nullifier_unsafe`] and
+//! [`crate::context::PublicContext::push_nullifier_unsafe`], but these require care and can be hard to use correctly.
 //! Higher-level abstractions exist which safely create nullifiers, such as [`crate::note::lifecycle::destroy_note`]
 //! and
 //! [`crate::state_vars::SingleUseClaim`].

--- a/noir-projects/aztec-nr/aztec/src/state_vars/private_immutable.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/private_immutable.nr
@@ -104,7 +104,7 @@ impl<Note> PrivateImmutable<Note, &mut PrivateContext> {
         // We emit an initialization nullifier to indicate that the struct is initialized. This also prevents the value
         // from being initialized again as a nullifier can be included only once.
         let nullifier = self.get_initialization_nullifier();
-        self.context.push_nullifier(nullifier);
+        self.context.push_nullifier_unsafe(nullifier);
 
         create_note(self.context, self.owner, self.storage_slot, note)
     }

--- a/noir-projects/aztec-nr/aztec/src/state_vars/private_mutable.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/private_mutable.nr
@@ -145,7 +145,7 @@ where
     {
         // Nullify the storage slot.
         let nullifier = self.get_initialization_nullifier();
-        self.context.push_nullifier(nullifier);
+        self.context.push_nullifier_unsafe(nullifier);
 
         create_note(self.context, self.owner, self.storage_slot, note)
     }

--- a/noir-projects/aztec-nr/aztec/src/state_vars/public_immutable.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/public_immutable.nr
@@ -154,7 +154,7 @@ impl<T> PublicImmutable<T, PublicContext> {
         // We emit an initialization nullifier to indicate that the struct is initialized. This also prevents the value
         // from being initialized again as each nullifier can be emitted only once.
         let nullifier = self.compute_initialization_inner_nullifier();
-        self.context.push_nullifier(nullifier);
+        self.context.push_nullifier_unsafe(nullifier);
 
         self.context.storage_write(self.storage_slot, WithHash::new(value));
     }

--- a/noir-projects/aztec-nr/aztec/src/state_vars/single_private_immutable.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/single_private_immutable.nr
@@ -103,7 +103,7 @@ impl<Note> SinglePrivateImmutable<Note, &mut PrivateContext> {
         Note: NoteType + NoteHash + Packable,
     {
         let nullifier = self.get_initialization_nullifier();
-        self.context.push_nullifier(nullifier);
+        self.context.push_nullifier_unsafe(nullifier);
 
         // The note owner is set to the contract's address. Strictly speaking, specifying a note owner is not required
         // here, as this note is never intended to be nullified. However, we must provide an owner because Aztec.nr

--- a/noir-projects/aztec-nr/aztec/src/state_vars/single_private_mutable.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/single_private_mutable.nr
@@ -139,7 +139,7 @@ where
     {
         // Nullify the storage slot.
         let nullifier = self.get_initialization_nullifier();
-        self.context.push_nullifier(nullifier);
+        self.context.push_nullifier_unsafe(nullifier);
 
         create_note(self.context, owner, self.storage_slot, note)
     }

--- a/noir-projects/aztec-nr/aztec/src/state_vars/single_use_claim.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/single_use_claim.nr
@@ -105,7 +105,7 @@ impl SingleUseClaim<&mut PrivateContext> {
     /// storage slot of the underlying state variable.
     pub fn claim(self) {
         let owner_nhk_app = self.context.request_nhk_app(get_public_keys(self.owner).npk_m.hash());
-        self.context.push_nullifier(self.compute_nullifier(owner_nhk_app));
+        self.context.push_nullifier_unsafe(self.compute_nullifier(owner_nhk_app));
     }
 
     /// Asserts that the owner has already claimed this single use claim (i.e. that [`SingleUseClaim::claim`] has been

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment/test/private_context.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment/test/private_context.nr
@@ -145,8 +145,8 @@ unconstrained fn rejects_duplicate_transient_nullifiers() {
     let env = TestEnvironment::new();
 
     env.private_context(|context| {
-        context.push_nullifier(1);
-        context.push_nullifier(1);
+        context.push_nullifier_unsafe(1);
+        context.push_nullifier_unsafe(1);
     });
 }
 
@@ -154,9 +154,9 @@ unconstrained fn rejects_duplicate_transient_nullifiers() {
 unconstrained fn rejects_duplicate_settled_nullifiers() {
     let env = TestEnvironment::new();
 
-    env.private_context(|context| { context.push_nullifier(1); });
+    env.private_context(|context| { context.push_nullifier_unsafe(1); });
 
-    env.private_context(|context| { context.push_nullifier(1); });
+    env.private_context(|context| { context.push_nullifier_unsafe(1); });
 }
 
 #[test]
@@ -207,7 +207,7 @@ unconstrained fn check_nullifier_exists_nonexistent() {
 unconstrained fn check_nullifier_exists_settled() {
     let env = TestEnvironment::new();
 
-    env.private_context(|context| { context.push_nullifier(1); });
+    env.private_context(|context| { context.push_nullifier_unsafe(1); });
 
     env.private_context(|_| { assert(check_nullifier_exists(1)); });
 }
@@ -217,7 +217,7 @@ unconstrained fn check_nullifier_exists_pending() {
     let env = TestEnvironment::new();
 
     env.private_context(|context| {
-        context.push_nullifier(1);
+        context.push_nullifier_unsafe(1);
         assert(check_nullifier_exists(1));
     });
 }

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment/test/public_context.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment/test/public_context.nr
@@ -119,7 +119,7 @@ unconstrained fn read_public_nullifier_same_context() {
     let env = TestEnvironment::new();
 
     env.public_context(|context| {
-        context.push_nullifier(nullifier);
+        context.push_nullifier_unsafe(nullifier);
         assert(context.nullifier_exists_unsafe(nullifier, context.this_address()));
     });
 }
@@ -128,7 +128,7 @@ unconstrained fn read_public_nullifier_same_context() {
 unconstrained fn read_public_nullifier_other_context() {
     let env = TestEnvironment::new();
 
-    env.public_context(|context| { context.push_nullifier(nullifier); });
+    env.public_context(|context| { context.push_nullifier_unsafe(nullifier); });
 
     env.public_context(|context| { assert(context.nullifier_exists_unsafe(nullifier, context.this_address())); });
 }
@@ -137,7 +137,7 @@ unconstrained fn read_public_nullifier_other_context() {
 unconstrained fn read_private_nullifier() {
     let env = TestEnvironment::new();
 
-    env.private_context(|context| { context.push_nullifier(nullifier); });
+    env.private_context(|context| { context.push_nullifier_unsafe(nullifier); });
 
     env.public_context(|context| { assert(context.nullifier_exists_unsafe(nullifier, context.this_address())); });
 }
@@ -147,8 +147,8 @@ unconstrained fn rejects_duplicate_transient_nullifiers() {
     let env = TestEnvironment::new();
 
     env.public_context(|context| {
-        context.push_nullifier(1);
-        context.push_nullifier(1);
+        context.push_nullifier_unsafe(1);
+        context.push_nullifier_unsafe(1);
     });
 }
 
@@ -156,9 +156,9 @@ unconstrained fn rejects_duplicate_transient_nullifiers() {
 unconstrained fn rejects_duplicate_settled_nullifiers() {
     let env = TestEnvironment::new();
 
-    env.public_context(|context| { context.push_nullifier(1); });
+    env.public_context(|context| { context.push_nullifier_unsafe(1); });
 
-    env.public_context(|context| { context.push_nullifier(1); });
+    env.public_context(|context| { context.push_nullifier_unsafe(1); });
 }
 
 #[test(should_fail_with = "Contract calls are forbidden")]

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment/test/utility_context.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment/test/utility_context.nr
@@ -75,7 +75,7 @@ unconstrained fn check_nullifier_exists_nonexistent() {
 unconstrained fn check_nullifier_exists_settled() {
     let env = TestEnvironment::new();
 
-    env.private_context(|context| { context.push_nullifier(1); });
+    env.private_context(|context| { context.push_nullifier_unsafe(1); });
 
     env.utility_context(|_| { assert(check_nullifier_exists(1)); });
 }

--- a/noir-projects/aztec-nr/uint-note/src/uint_note.nr
+++ b/noir-projects/aztec-nr/uint-note/src/uint_note.nr
@@ -135,7 +135,7 @@ impl UintNote {
         // nullifier tree since it uses its own separator, making collisions with actual note nullifiers practically
         // impossible.
         let validity_commitment = partial_note.compute_validity_commitment(completer);
-        context.push_nullifier(validity_commitment);
+        context.push_nullifier_unsafe(validity_commitment);
 
         partial_note
     }

--- a/noir-projects/noir-contracts/contracts/account/simulated_ecdsa_account_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/account/simulated_ecdsa_account_contract/src/main.nr
@@ -38,10 +38,10 @@ pub contract SimulatedEcdsaAccount {
         let seed = unsafe { random() };
 
         // Emit the initialization nullifier for the contract itself.
-        self.context.push_nullifier(seed);
+        self.context.push_nullifier_unsafe(seed);
 
         // Emit the initialization nullifier for the signing_public_key SinglePrivateImmutable.
-        self.context.push_nullifier(seed + 1);
+        self.context.push_nullifier_unsafe(seed + 1);
 
         // Emit the note hash for the signing key note.
         self.context.push_note_hash(seed + 2);

--- a/noir-projects/noir-contracts/contracts/account/simulated_schnorr_account_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/account/simulated_schnorr_account_contract/src/main.nr
@@ -40,10 +40,10 @@ pub contract SimulatedSchnorrAccount {
         let seed = unsafe { random() };
 
         // Emit the initialization nullifier for the contract itself.
-        self.context.push_nullifier(seed);
+        self.context.push_nullifier_unsafe(seed);
 
         // Emit the initialization nullifier for the signing_public_key SinglePrivateImmutable.
-        self.context.push_nullifier(seed + 1);
+        self.context.push_nullifier_unsafe(seed + 1);
 
         // Emit the note hash for the signing key note.
         self.context.push_note_hash(seed + 2);

--- a/noir-projects/noir-contracts/contracts/app/nft_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/nft_contract/src/main.nr
@@ -204,7 +204,7 @@ pub contract NFT {
     fn cancel_authwit(inner_hash: Field) {
         let on_behalf_of = self.msg_sender();
         let nullifier = compute_authwit_nullifier(on_behalf_of, inner_hash);
-        self.context.push_nullifier(nullifier);
+        self.context.push_nullifier_unsafe(nullifier);
     }
 
     #[authorize_once("from", "authwit_nonce")]

--- a/noir-projects/noir-contracts/contracts/app/nft_contract/src/types/nft_note.nr
+++ b/noir-projects/noir-contracts/contracts/app/nft_contract/src/types/nft_note.nr
@@ -131,7 +131,7 @@ impl NFTNote {
         // the nullifier tree since it uses its own separator, making collisions with actual note nullifiers
         // practically impossible.
         let validity_commitment = partial_note.compute_validity_commitment(completer);
-        context.push_nullifier(validity_commitment);
+        context.push_nullifier_unsafe(validity_commitment);
 
         partial_note
     }

--- a/noir-projects/noir-contracts/contracts/app/orderbook_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/orderbook_contract/src/main.nr
@@ -141,7 +141,7 @@ pub contract Orderbook {
         // a nullifier is cheaper (1 Field in DA instead of multiple Fields for the order).
         // TODO(F-399): pushing a raw nullifier with no domain separator like we do here is unsafe: we should instead
         // use something like a singleton `SingleUseClaim`.
-        self.context.push_nullifier(order_id);
+        self.context.push_nullifier_unsafe(order_id);
 
         // Enqueue the fulfillment to finalize both partial notes
         self.enqueue_self._fulfill_order(order_id, taker_partial_note, bid_token, order.bid_amount);

--- a/noir-projects/noir-contracts/contracts/app/simple_token_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/simple_token_contract/src/main.nr
@@ -247,7 +247,7 @@ pub contract SimpleToken {
     fn cancel_authwit(inner_hash: Field) {
         let on_behalf_of = self.msg_sender();
         let nullifier = compute_authwit_nullifier(on_behalf_of, inner_hash);
-        self.context.push_nullifier(nullifier);
+        self.context.push_nullifier_unsafe(nullifier);
     }
 
     #[internal("private")]

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/main.nr
@@ -276,7 +276,7 @@ pub contract Token {
     fn cancel_authwit(inner_hash: Field) {
         let on_behalf_of = self.msg_sender();
         let nullifier = compute_authwit_nullifier(on_behalf_of, inner_hash);
-        self.context.push_nullifier(nullifier);
+        self.context.push_nullifier_unsafe(nullifier);
     }
     // docs:end:cancel_authwit
 

--- a/noir-projects/noir-contracts/contracts/test/avm_test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/avm_test_contract/src/main.nr
@@ -610,7 +610,7 @@ pub contract AvmTest {
 
     #[contract_library_method]
     fn _new_nullifier(context: PublicContext, nullifier: Field) {
-        context.push_nullifier(nullifier);
+        context.push_nullifier_unsafe(nullifier);
     }
 
     #[external("public")]
@@ -630,7 +630,7 @@ pub contract AvmTest {
     #[external("public")]
     fn n_new_nullifiers(num: u32) {
         for i in 0..num {
-            self.context.push_nullifier(i as Field);
+            self.context.push_nullifier_unsafe(i as Field);
         }
     }
 
@@ -672,7 +672,7 @@ pub contract AvmTest {
     // Use the standard context interface to emit a new nullifier
     #[external("public")]
     fn emit_nullifier_and_check(nullifier: Field) {
-        self.context.push_nullifier(nullifier);
+        self.context.push_nullifier_unsafe(nullifier);
         let exists = self.context.nullifier_exists_unsafe(nullifier, self.address);
         assert(exists, "Nullifier was just created, but its existence wasn't detected!");
     }
@@ -680,9 +680,9 @@ pub contract AvmTest {
     // Create the same nullifier twice (shouldn't work!)
     #[external("public")]
     fn nullifier_collision(nullifier: Field) {
-        self.context.push_nullifier(nullifier);
+        self.context.push_nullifier_unsafe(nullifier);
         // Can't do this twice!
-        self.context.push_nullifier(nullifier);
+        self.context.push_nullifier_unsafe(nullifier);
     }
 
     #[external("public")]
@@ -780,13 +780,13 @@ pub contract AvmTest {
 
     #[external("public")]
     fn create_same_nullifier_in_nested_call(nestedAddress: AztecAddress, nullifier: Field) {
-        self.context.push_nullifier(nullifier);
+        self.context.push_nullifier_unsafe(nullifier);
         self.call(AvmTest::at(nestedAddress).new_nullifier(nullifier));
     }
 
     #[external("public")]
     fn create_different_nullifier_in_nested_call(nestedAddress: AztecAddress, nullifier: Field) {
-        self.context.push_nullifier(nullifier);
+        self.context.push_nullifier_unsafe(nullifier);
         self.call(AvmTest::at(nestedAddress).new_nullifier(nullifier + 1));
     }
 

--- a/noir-projects/noir-contracts/contracts/test/benchmarking_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/benchmarking_contract/src/main.nr
@@ -78,7 +78,7 @@ pub contract Benchmarking {
         // Safety: Benchmarking code
         let random_seed = unsafe { random() };
         for i in 0..MAX_NULLIFIERS_PER_CALL {
-            self.context.push_nullifier(random_seed + (i as Field));
+            self.context.push_nullifier_unsafe(random_seed + (i as Field));
         }
     }
 

--- a/noir-projects/noir-contracts/contracts/test/custom_message_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/custom_message_contract/src/main.nr
@@ -147,7 +147,7 @@ contract CustomMessage {
 
         // Emit commitment as nullifier computed from FULL event (same as standard events)
         let commitment = compute_private_event_commitment(event, randomness);
-        self.context.push_nullifier(commitment);
+        self.context.push_nullifier_unsafe(commitment);
 
         let event_type_id = MultiLogEvent::get_event_type_id().to_field();
 

--- a/noir-projects/noir-contracts/contracts/test/private_init_test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/private_init_test_contract/src/main.nr
@@ -37,7 +37,7 @@ pub contract PrivateInitTest {
     #[external("private")]
     #[noinitcheck]
     fn private_no_init_check_emit_nullifier(nullifier: Field) {
-        self.context.push_nullifier(nullifier);
+        self.context.push_nullifier_unsafe(nullifier);
     }
 
     #[external("utility")]

--- a/noir-projects/noir-contracts/contracts/test/spam_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/spam_contract/src/main.nr
@@ -31,7 +31,7 @@ pub contract Spam {
 
         for i in 0..MAX_NULLIFIERS_PER_CALL {
             if (i < nullifier_count) {
-                self.context.push_nullifier(compute_note_nullifier(nullifier_seed, [i as Field]));
+                self.context.push_nullifier_unsafe(compute_note_nullifier(nullifier_seed, [i as Field]));
             }
         }
 

--- a/noir-projects/noir-contracts/contracts/test/test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/test_contract/src/main.nr
@@ -287,13 +287,13 @@ pub contract Test {
 
     #[external("public")]
     fn emit_nullifier_public(nullifier: Field) {
-        self.context.push_nullifier(nullifier);
+        self.context.push_nullifier_unsafe(nullifier);
     }
 
     #[external("private")]
     #[noinitcheck]
     fn emit_nullifier(nullifier: Field) {
-        self.context.push_nullifier(nullifier);
+        self.context.push_nullifier_unsafe(nullifier);
     }
 
     // For testing non-note encrypted logs

--- a/noir-projects/protocol-fuzzer/contracts/side_effect_contract/src/main.nr
+++ b/noir-projects/protocol-fuzzer/contracts/side_effect_contract/src/main.nr
@@ -165,7 +165,7 @@ pub contract SideEffect {
     #[external("private")]
     #[noinitcheck]
     fn emit_nullifier(nullifier: Field) {
-        self.context.push_nullifier(nullifier);
+        self.context.push_nullifier_unsafe(nullifier);
     }
 
     #[external("private")]


### PR DESCRIPTION
## Summary

- Rename `push_nullifier` to `push_nullifier_unsafe` on both `PrivateContext` and `PublicContext` to match the existing `_unsafe` suffix convention used by `emit_private_log_unsafe`, `emit_raw_note_log_unsafe`, and `emit_public_log_unsafe`. This makes it clear that callers must handle domain separation themselves.
- Update all call sites across aztec-nr internals, app/test/account contracts, and protocol-fuzzer.
- Update doc comments, doc links, developer docs, and add a migration note.