### PR TITLE
refactor: alias PublicKey to Point, drop hash methods

### DIFF
--- a/yarn-project/CLAUDE.md
+++ b/yarn-project/CLAUDE.md
@@ -131,7 +131,7 @@ LOG_LEVEL='info; debug:sequencer,archiver' yarn workspace @aztec/<package-name> 
 
 ### Style
 
-- **Line width**: 120 characters (`printWidth: 120` in `.prettierrc.json`). Wrap comments and code at 120, not 80.
+- **Line width**: 120 characters (`printWidth: 120` in `.prettierrc.json`). Wrap **everything** at 120 — code, inline comments, and JSDoc/block comments alike. Do not wrap at 80, 90, or 100 out of habit. Prettier does not reflow comment bodies, so an under-wrapped JSDoc paragraph will sit at ~90 chars forever unless you wrote it at 120 to begin with.
 
 ### Format
 

--- a/yarn-project/foundation/src/curves/grumpkin/point.ts
+++ b/yarn-project/foundation/src/curves/grumpkin/point.ts
@@ -1,5 +1,4 @@
 import { toBigIntBE } from '../../bigint-buffer/index.js';
-import { poseidon2Hash } from '../../crypto/poseidon/index.js';
 import { randomBoolean } from '../../crypto/random/index.js';
 import { hexSchemaFor } from '../../schemas/utils.js';
 import { BufferReader, FieldReader, serializeToBuffer } from '../../serialize/index.js';
@@ -275,10 +274,6 @@ export class Point {
 
   isZero() {
     return this.x.isZero() && this.y.isZero();
-  }
-
-  hash() {
-    return poseidon2Hash(this.toFields());
   }
 
   /**

--- a/yarn-project/stdlib/src/keys/public_key.ts
+++ b/yarn-project/stdlib/src/keys/public_key.ts
@@ -3,25 +3,26 @@ import { poseidon2HashWithSeparator } from '@aztec/foundation/crypto/poseidon';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { Point } from '@aztec/foundation/curves/grumpkin';
 
-// TODO(MW): Still using hashPublicKey() rather than key.hash() because ts constructs a Point
-// from inherited static methods e.g.
-//  const npkM = await PublicKey.random(); <-- npkM is actually a Point...
-// ... so npkM.hash() uses Point.hash(). This is a massive footgun and breaks address derivation.
-// Can either:
-//   - redefine all of the static Point methods below as overrides to return PublicKeys
-//   - continue to use hashPublicKey() explicitly
+/**
+ * Hashes a public key.
+ *
+ * Mirrors Noir's `hash_public_key` in `noir-protocol-circuits/crates/types/src/public_keys.nr`:
+ * `Poseidon2(DOM_SEP__SINGLE_PUBLIC_KEY_HASH, [pk.x, pk.y])`.
+ *
+ * This is distinct from Noir's generic `Hash` impl for `EmbeddedCurvePoint` (`noir_stdlib/src/embedded_curve_ops.nr`),
+ * which simply absorbs `x` then `y` into a `Hasher` state with no domain separator. That generic impl is unsuitable
+ * for hashing keys at the protocol boundary, where the domain separator is required to prevent collisions with hashes
+ * of other Grumpkin points (e.g. note commitments, nullifiers).
+ */
 export function hashPublicKey(pk: PublicKey): Promise<Fr> {
   return poseidon2HashWithSeparator([pk.x, pk.y], DomainSeparator.SINGLE_PUBLIC_KEY_HASH);
 }
 
-/** Represents a user public key. */
-export class PublicKey extends Point {
-  /**
-   * Hashes a public key under the canonical single-public-key domain separator.
-   *
-   * `Poseidon2(DOM_SEP__SINGLE_PUBLIC_KEY_HASH, [pk.x, pk.y])`.
-   */
-  override hash(): Promise<Fr> {
-    return hashPublicKey(this);
-  }
-}
+/**
+ * Represents a user public key.
+ *
+ * Structurally identical to a Grumpkin `Point`; exposed as a distinct name so call sites read as "public key" where
+ * that's the domain meaning.
+ */
+export type PublicKey = Point;
+export const PublicKey = Point;


### PR DESCRIPTION
## Summary
- Drops `hash()` from `Point` (foundation) and replaces the `PublicKey` subclass with a type+value alias for `Point`. The two are now interchangeable, fixing a swath of TS errors where `Point` was passed to call sites that expected `PublicKey`.
- The subclassing footgun is gone: inherited static factories (`Point.random()`, `Point.fromFields()`, etc.) no longer return objects that silently lack the protocol's key-hash method. Hashing goes through `hashPublicKey()` only, which mirrors Noir's `hash_public_key` (`Poseidon2(DOM_SEP__SINGLE_PUBLIC_KEY_HASH, [x, y])`) — distinct from Noir's generic `EmbeddedCurvePoint::hash`.
- Strengthens the line-width rule in `yarn-project/CLAUDE.md` to explicitly cover JSDoc/block comments at 120 chars.

## Test plan
- `yarn build` from `yarn-project/` — passes (all 35 prior TS errors resolved).