### PR TITLE
fix(txe): update TXE oracle interface hash for new AVM oracle methods

### DIFF
--- a/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
@@ -208,9 +208,7 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
       this.aztecNode.getNoteHashMembershipWitness(blockHash, noteHash),
     );
     if (!witness) {
-      throw new Error(
-        `Note hash ${noteHash} not found in the note hash tree at block ${blockHash.toString()}.`,
-      );
+      throw new Error(`Note hash ${noteHash} not found in the note hash tree at block ${blockHash.toString()}.`);
     }
     return witness;
   }

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
@@ -249,7 +249,7 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
       this.aztecNode.getNullifierMembershipWitness(blockHash, nullifier),
     );
     if (!witness) {
-      throw new Error(`Nullifier witness not found for nullifier ${nullifier} at block hash ${blockHash.toString()}.`);
+      throw new Error(`Nullifier membership witness not found at block ${blockHash.toString()}.`);
     }
     return witness;
   }

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
@@ -209,7 +209,7 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
     );
     if (!witness) {
       throw new Error(
-        `Note hash ${noteHash} not found in the note hash tree at anchor block hash ${blockHash.toString()}.`,
+        `Note hash ${noteHash} not found in the note hash tree at block ${blockHash.toString()}.`,
       );
     }
     return witness;

--- a/yarn-project/txe/src/txe_oracle_version.ts
+++ b/yarn-project/txe/src/txe_oracle_version.ts
@@ -6,7 +6,7 @@
  * The Noir counterparts are in `noir-projects/aztec-nr/aztec/src/test/helpers/txe_oracles.nr`.
  */
 export const TXE_ORACLE_VERSION_MAJOR = 1;
-export const TXE_ORACLE_VERSION_MINOR = 0;
+export const TXE_ORACLE_VERSION_MINOR = 1;
 
 /**
  * This hash is computed from the TXE oracle interfaces (IAvmExecutionOracle and ITxeExecutionOracle) and is used to
@@ -14,4 +14,4 @@ export const TXE_ORACLE_VERSION_MINOR = 0;
  *   - TXE_ORACLE_VERSION_MAJOR (and reset MINOR to 0) for breaking changes, or
  *   - TXE_ORACLE_VERSION_MINOR for additive changes (new oracle method added).
  */
-export const TXE_ORACLE_INTERFACE_HASH = 'c5e3567b08790c8181254c0831de6b5af49e221e14d36dded3fc5d8787fba482';
+export const TXE_ORACLE_INTERFACE_HASH = '833b77ccdba925b1ed129028432c7d4b116867fb426cee40f9d6104c5aa31e42';


### PR DESCRIPTION
## Summary

- Update `TXE_ORACLE_INTERFACE_HASH` and bump `TXE_ORACLE_VERSION_MINOR` to account for the five new AVM oracle methods (`returndataSize`, `returndataCopy`, `call`, `staticCall`, `successCopy`) added to `IAvmExecutionOracle` in #23422.