### PR TITLE
fix: released contract artifact aztec version (forward port of #23470)

### DIFF
--- a/ci3/release_prep_package_json
+++ b/ci3/release_prep_package_json
@@ -22,3 +22,13 @@ for deps in dependencies devDependencies peerDependencies; do
     mv tmp.json package.json
   done
 done
+
+# Stamp aztec_version into any published noir contract artifacts in artifacts/*.json. The build-time stamp in
+# noir-projects/noir-contracts/bootstrap.sh writes "dev"; $version here is the authoritative release version about to
+# be written to package.json. We cannot stamp real version in bootstrap because there we don't have access to it.
+if [ -d artifacts ]; then
+  for f in artifacts/*.json; do
+    [ -e "$f" ] || continue
+    jq --arg v "$version" '.aztec_version = $v' "$f" >$tmp && mv $tmp "$f"
+  done
+fi

--- a/noir-projects/noir-contracts/bootstrap.sh
+++ b/noir-projects/noir-contracts/bootstrap.sh
@@ -93,20 +93,17 @@ function get_contract_path {
 }
 export -f get_contract_path
 
-# Stamps the aztec version into a contract artifact JSON in place. Mirrors stampAztecVersion in
-# yarn-project/aztec/src/cli/cmds/compile.ts so monorepo-built artifacts match those produced by `aztec compile`.
-# On release builds (REF_NAME is valid semver) the tag without the leading "v" is used; otherwise "dev".
-function stamp_aztec_version {
+# Stamps "dev" (DEV_VERSION) as the artifact's aztec_version - that is the expected version of a locally checked out
+# monorepo. The real release version is applied at publish time by whichever path owns it:
+# ci3/release_prep_package_json for npm packages, release-image/Dockerfile for the docker image.
+function stamp_dev_aztec_version {
   local json_path=$1
-  # "dev" here corresponds to DEV_VERSION in yarn-project/stdlib/src/update-checker/dev_version.ts.
-  local version="dev"
-  semver check "$REF_NAME" 2>/dev/null && version="${REF_NAME#v}"
   local tmp=$(mktemp)
-  jq --arg v "$version" '.aztec_version = $v' "$json_path" > "$tmp"
+  jq '.aztec_version = "dev"' "$json_path" > "$tmp"
   cat "$tmp" > "$json_path"
   rm "$tmp"
 }
-export -f stamp_aztec_version
+export -f stamp_dev_aztec_version
 
 # This compiles a noir contract, transpiles public functions, strips internal prefixes,
 # and generates verification keys for private functions via 'bb aztec_process'.
@@ -128,9 +125,9 @@ function compile {
     $BB aztec_process -i $json_path
     cache_upload contract-$contract_hash.tar.gz $json_path
   fi
-  # Stamp the current version after the cache block so the field always matches the build's version, whether
-  # the artifact came from a fresh compile or a cache hit.
-  stamp_aztec_version "$json_path"
+  # Stamp the version after the cache block so the field is always present, whether the artifact came from a fresh
+  # compile or a cache hit.
+  stamp_dev_aztec_version "$json_path"
 }
 export -f compile
 

--- a/release-image/Dockerfile
+++ b/release-image/Dockerfile
@@ -19,4 +19,16 @@ WORKDIR "/usr/src/yarn-project"
 ARG VERSION
 RUN echo '{".": "'$VERSION'"}' > /usr/src/.release-please-manifest.json
 
+# Stamp aztec_version into the shipped contract artifacts. The build-time stamp in
+# noir-projects/noir-contracts/bootstrap.sh writes "dev" unconditionally; $VERSION here is the authoritative release
+# version for this image.
+RUN for dir in \
+        /usr/src/yarn-project/accounts/artifacts \
+        /usr/src/yarn-project/noir-contracts.js/artifacts \
+        /usr/src/yarn-project/noir-test-contracts.js/artifacts; do \
+      for f in "$dir"/*.json; do \
+        jq --arg v "$VERSION" '.aztec_version = $v' "$f" > /tmp/a.json && mv /tmp/a.json "$f"; \
+      done; \
+    done
+
 ENTRYPOINT ["node", "--no-warnings", "/usr/src/yarn-project/aztec/dest/bin/index.js"]


### PR DESCRIPTION
Forward-port of #23470 (originally merged to `backport-to-v4-next-staging` for the v4 release line).

> [!IMPORTANT]
> Do not merge until we get a green v4 nightly release.

## Summary

The v4.3.0 release shipped contract artifact JSONs with `aztec_version: "dev"` baked in, which caused ci-compat-e2e to fail because the artifact version did not match the expected tested version. The root cause is that `REF_NAME` is not reliably populated when the release artifacts are built, so `stamp_aztec_version` in `noir-projects/noir-contracts/bootstrap.sh` was falling back to `"dev"`.

The fix re-stamps the version at the point in the release process where the actual version is known:

- `ci3/release_prep_package_json` now stamps `aztec_version` into `artifacts/*.json` at npm-publish time using the authoritative `$version` arg.
- `release-image/Dockerfile` now re-stamps `aztec_version` into all shipped contract artifacts (accounts, noir-contracts.js, noir-test-contracts.js) using `$VERSION` at image build time.
- `noir-projects/noir-contracts/bootstrap.sh` is simplified to always stamp `"dev"` (renamed to `stamp_dev_aztec_version`) — the real version is now applied at publish time by whichever path owns it.

The `stamp_dev_aztec_version` helper preserves the `cat`/`rm` pattern from #23174 so artifact file permissions aren't clobbered.

The `assertContractArtifactsVersion()` bypass from the original PR is omitted here because v5 doesn't have the bad v4.3.0 artifact in its compat matrix.

## Verification (from the original PR)

- **npm release**: `DRY_RUN=1 ../../ci3/deploy_npm latest 5.1.0-test` produced artifacts with `aztec_version: "5.1.0-test"`.
- **docker release**: built the docker image and inspected the contract artifacts inside — `aztec_version` matches `$VERSION`.