### PR TITLE
fix(archiver): skip descendants of invalid-attestations checkpoints

### DIFF
--- a/yarn-project/archiver/src/archiver-sync.test.ts
+++ b/yarn-project/archiver/src/archiver-sync.test.ts
@@ -689,6 +689,13 @@ describe('Archiver Sync', () => {
       const invalidCheckpointDetectedSpy = jest.fn();
       archiver.events.on(L2BlockSourceEvents.InvalidAttestationsCheckpointDetected, invalidCheckpointDetectedSpy);
 
+      // And another spy for DescendentOfInvalidAttestationsCheckpointDetected, which fires only for a
+      // checkpoint with VALID attestations that builds on a rejected ancestor. CP3 here has invalid
+      // attestations of its own, so it is caught by the attestation check first and should never
+      // reach the descendant path — this spy must not fire in this test.
+      const descendantOfInvalidSpy = jest.fn();
+      archiver.events.on(L2BlockSourceEvents.DescendentOfInvalidAttestationsCheckpointDetected, descendantOfInvalidSpy);
+
       // Add valid checkpoint 1 with correct attestations
       const { checkpoint: cp1 } = await fake.addCheckpoint(CheckpointNumber(1), {
         l1BlockNumber: 70n,
@@ -780,20 +787,23 @@ describe('Archiver Sync', () => {
       expect(validationStatus.checkpoint.checkpointNumber).toEqual(2);
       expect(validationStatus.checkpoint.archive.toString()).toEqual(badCp2b.archive.root.toString());
 
-      // Check that event was also emitted for bad CP3
+      // CP3 has invalid attestations of its own, so it is caught by the attestation check (which
+      // runs before the descendant-of-invalid check) and surfaced as an
+      // InvalidAttestationsCheckpointDetected event — NOT a descendant event — even though it also
+      // builds on the rejected bad CP2b.
+      expect(descendantOfInvalidSpy).not.toHaveBeenCalled();
+
+      // Should have been called 3 times for invalid attestations: bad CP2, bad CP2b, bad CP3
+      expect(invalidCheckpointDetectedSpy).toHaveBeenCalledTimes(3);
       expect(invalidCheckpointDetectedSpy).toHaveBeenCalledWith(
         expect.objectContaining({
           type: L2BlockSourceEvents.InvalidAttestationsCheckpointDetected,
           validationResult: expect.objectContaining({
             valid: false,
-            reason: 'invalid-attestation',
             checkpoint: expect.objectContaining({ checkpointNumber: 3 }),
           }),
         }),
       );
-
-      // Should have been called 3 times: bad CP2, bad CP2b, bad CP3
-      expect(invalidCheckpointDetectedSpy).toHaveBeenCalledTimes(3);
 
       // Now recover: remove bad checkpoints and add good CP2 and CP3 with valid attestations
       // Good checkpoints have messages that the archiver will validate
@@ -830,6 +840,76 @@ describe('Archiver Sync', () => {
 
       // With a valid pending chain validation status
       expect(await archiver.getPendingChainValidationStatus()).toEqual(expect.objectContaining({ valid: true }));
+    }, 15_000);
+
+    it('skips a valid-attestations checkpoint that builds on a rejected ancestor', async () => {
+      // Regression for the archiver "non-consecutive checkpoint" retry loop: when a checkpoint
+      // with insufficient/invalid attestations is followed by a valid-attestations descendant,
+      // addCheckpoints used to throw InitialCheckpointNumberNotSequentialError and loop on the
+      // catch handler's L1-sync-point rollback. Now the descendant is detected, skipped, and
+      // surfaced via DescendentOfInvalidAttestationsCheckpointDetected.
+      expect(await archiver.getCheckpointNumber()).toEqual(CheckpointNumber(0));
+
+      fake.setTargetCommitteeSize(3);
+      const signers = times(3, Secp256k1Signer.random);
+      const committee = signers.map(s => s.address);
+      epochCache.getCommitteeForEpoch.mockResolvedValue({ committee, seed: 0n } as EpochCommitteeInfo);
+
+      const descendantOfInvalidSpy = jest.fn();
+      archiver.events.on(L2BlockSourceEvents.DescendentOfInvalidAttestationsCheckpointDetected, descendantOfInvalidSpy);
+
+      // Valid CP1
+      const { checkpoint: cp1 } = await fake.addCheckpoint(CheckpointNumber(1), {
+        l1BlockNumber: 70n,
+        messagesL1BlockNumber: 50n,
+        numL1ToL2Messages: 3,
+        signers,
+      });
+      const cp1Archive = cp1.blocks.at(-1)!.archive;
+
+      // Bad CP2 (insufficient attestations — random signers not in committee)
+      const badSigners = times(3, Secp256k1Signer.random);
+      const { checkpoint: badCp2 } = await fake.addCheckpoint(CheckpointNumber(2), {
+        l1BlockNumber: 80n,
+        numL1ToL2Messages: 0,
+        signers: badSigners,
+        previousArchive: cp1Archive,
+      });
+
+      // Valid-attestations CP3 chained from bad CP2: this is the case that used to wedge the
+      // synchronizer.
+      const { checkpoint: validCp3 } = await fake.addCheckpoint(CheckpointNumber(3), {
+        l1BlockNumber: 82n,
+        numL1ToL2Messages: 0,
+        signers,
+        previousArchive: badCp2.blocks.at(-1)!.archive,
+      });
+
+      fake.setL1BlockNumber(85n);
+      await archiver.syncImmediate();
+
+      // Archiver should have stayed at CP1 (skipped both CP2 and CP3) without throwing.
+      expect(await archiver.getCheckpointNumber()).toEqual(CheckpointNumber(1));
+
+      // The descendant event should have fired for CP3 with the bad CP2 ancestor.
+      expect(descendantOfInvalidSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: L2BlockSourceEvents.DescendentOfInvalidAttestationsCheckpointDetected,
+          checkpoint: expect.objectContaining({
+            checkpointNumber: 3,
+            archive: validCp3.archive.root,
+          }),
+          ancestorArchiveRoot: badCp2.archive.root,
+          ancestorCheckpointNumber: 2,
+        }),
+      );
+      expect(descendantOfInvalidSpy).toHaveBeenCalledTimes(1);
+
+      // The rejected entries should persist in the store, keyed by their own archive roots.
+      const rejectedBad = await archiverStore.blocks.getRejectedCheckpointByArchiveRoot(badCp2.archive.root);
+      const rejectedValid = await archiverStore.blocks.getRejectedCheckpointByArchiveRoot(validCp3.archive.root);
+      expect(rejectedBad).toBeDefined();
+      expect(rejectedValid).toBeDefined();
     }, 15_000);
   });
 

--- a/yarn-project/archiver/src/errors.ts
+++ b/yarn-project/archiver/src/errors.ts
@@ -31,13 +31,13 @@ export class InitialCheckpointNumberNotSequentialError extends Error {
 
 export class CheckpointNumberNotSequentialError extends Error {
   constructor(
-    newCheckpointNumber: CheckpointNumber,
-    previous: CheckpointNumber | undefined,
+    public readonly newCheckpointNumber: CheckpointNumber,
+    public readonly previousCheckpointNumber: CheckpointNumber | undefined,
     source?: 'proposed' | 'confirmed',
   ) {
     const qualifier = source ? `${source} ` : '';
     super(
-      `Cannot insert new checkpoint ${newCheckpointNumber} given previous ${qualifier}checkpoint number is ${previous ?? 'undefined'}`,
+      `Cannot insert new checkpoint ${newCheckpointNumber} given previous ${qualifier}checkpoint number is ${previousCheckpointNumber ?? 'undefined'}`,
     );
     this.name = 'CheckpointNumberNotSequentialError';
   }

--- a/yarn-project/archiver/src/modules/l1_synchronizer.ts
+++ b/yarn-project/archiver/src/modules/l1_synchronizer.ts
@@ -17,7 +17,7 @@ import { count } from '@aztec/foundation/string';
 import { DateProvider, Timer, elapsed } from '@aztec/foundation/timer';
 import { isDefined, isErrorClass } from '@aztec/foundation/types';
 import { type ArchiverEmitter, L2BlockSourceEvents, type ValidateCheckpointResult } from '@aztec/stdlib/block';
-import { Checkpoint, PublishedCheckpoint } from '@aztec/stdlib/checkpoint';
+import { Checkpoint, type CheckpointData, PublishedCheckpoint } from '@aztec/stdlib/checkpoint';
 import { type L1RollupConstants, getEpochAtSlot, getSlotAtNextL1Block } from '@aztec/stdlib/epoch-helpers';
 import { computeInHashFromL1ToL2Messages } from '@aztec/stdlib/messaging';
 import type { CoordinationSignatureContext } from '@aztec/stdlib/p2p';
@@ -32,6 +32,7 @@ import {
   retrieveL1ToL2Messages,
   retrievedToPublishedCheckpoint,
 } from '../l1/data_retrieval.js';
+import type { RejectedCheckpoint } from '../store/block_store.js';
 import { type ArchiverDataStores, getArchiverSynchPoint } from '../store/data_stores.js';
 import type { L2TipsCache } from '../store/l2_tips_cache.js';
 import { MessageStoreError } from '../store/message_store.js';
@@ -46,13 +47,15 @@ type RollupStatus = {
   pendingCheckpointNumber: CheckpointNumber;
   pendingArchive: string;
   validationResult: ValidateCheckpointResult | undefined;
+  /** Last valid checkpoint observed on L1 and synced on this iteration */
   lastRetrievedCheckpoint?: PublishedCheckpoint;
-  lastL1BlockWithCheckpoint?: bigint;
+  /** Last checkpoint observed on L1 across both valid and rejected entries on this iteration */
+  lastSeenCheckpoint?: PublishedCheckpoint;
 };
 
 /**
  * Handles L1 synchronization for the archiver.
- * Responsible for fetching checkpoints, L1→L2 messages, and handling L1 reorgs.
+ * Responsible for fetching checkpoints, L1 to L2 messages, and handling L1 reorgs.
  */
 export class ArchiverL1Synchronizer implements Traceable {
   private l1BlockNumber: bigint | undefined;
@@ -202,18 +205,10 @@ export class ArchiverL1Synchronizer implements Traceable {
         currentL1Timestamp,
       );
 
-      // If the last checkpoint we processed had an invalid attestation, we manually advance the L1 syncpoint
-      // past it, since otherwise we'll keep downloading it and reprocessing it on every iteration until
-      // we get a valid checkpoint to advance the syncpoint.
-      if (!rollupStatus.validationResult?.valid && rollupStatus.lastL1BlockWithCheckpoint !== undefined) {
-        await this.stores.blocks.setSynchedL1BlockNumber(rollupStatus.lastL1BlockWithCheckpoint);
-      }
-
       // And lastly we check if we are missing any checkpoints behind us due to a possible L1 reorg.
       // We only do this if rollup cant prune on the next submission. Otherwise we will end up
-      // re-syncing the checkpoints we have just unwound above. We also dont do this if the last checkpoint is invalid,
-      // since the archiver will rightfully refuse to sync up to it.
-      if (!rollupCanPrune && rollupStatus.validationResult?.valid) {
+      // re-syncing the checkpoints we have just unwound above.
+      if (!rollupCanPrune) {
         await this.checkForNewCheckpointsBeforeL1SyncPoint(rollupStatus, blocksSynchedTo, currentL1BlockNumber);
       }
 
@@ -796,7 +791,7 @@ export class ArchiverL1Synchronizer implements Traceable {
     let searchStartBlock: bigint = blocksSynchedTo;
     let searchEndBlock: bigint = blocksSynchedTo;
     let lastRetrievedCheckpoint: PublishedCheckpoint | undefined;
-    let lastL1BlockWithCheckpoint: bigint | undefined = undefined;
+    let lastSeenCheckpoint: PublishedCheckpoint | undefined;
 
     do {
       [searchStartBlock, searchEndBlock] = this.nextRange(searchEndBlock, currentL1BlockNumber);
@@ -865,6 +860,9 @@ export class ArchiverL1Synchronizer implements Traceable {
 
       // Now loop through all checkpoints and validate their attestations
       for (const published of publishedCheckpoints) {
+        // Check the attestations uploaded by the publisher to L1 are correct
+        // Rollup contract does not validate attestations to save on gas, so this
+        // falls on the nodes to verify offchain and skip those checkpoints.
         const validationResult = this.config.skipValidateCheckpointAttestations
           ? { valid: true as const }
           : await validateCheckpointAttestations(
@@ -875,17 +873,29 @@ export class ArchiverL1Synchronizer implements Traceable {
               this.log,
             );
 
-        // Only update the validation result if it has changed, so we can keep track of the first invalid checkpoint
+        // Also skip the checkpoint if it builds on a previously-rejected ancestor. Without
+        // this, addCheckpoints would throw InitialCheckpointNumberNotSequentialError when the
+        // ancestor was skipped earlier (e.g. due to invalid attestations), the catch handler
+        // would roll back the L1 sync point, and the next iteration would re-fetch and re-throw.
+        const rejectedAncestor = await this.stores.blocks.getRejectedCheckpointByArchiveRoot(
+          published.checkpoint.header.lastArchiveRoot,
+        );
+
+        // Update the validation result if it has changed, so we can keep track of the first invalid checkpoint
         // in case there is a sequence of more than one invalid checkpoint, as we need to invalidate the first one.
         // There is an exception though: if a checkpoint is invalidated and replaced with another invalid checkpoint,
         // we need to update the validation result, since we need to be able to invalidate the new one.
         // See test 'chain progresses if an invalid checkpoint is invalidated with an invalid one' for more info.
-        if (
-          rollupStatus.validationResult?.valid !== validationResult.valid ||
-          (!rollupStatus.validationResult.valid &&
-            !validationResult.valid &&
-            rollupStatus.validationResult.checkpoint.checkpointNumber === validationResult.checkpoint.checkpointNumber)
-        ) {
+        // Do not update the validation result if there is a rejected ancestor, since in that case we want to keep the
+        // original invalidation, as the new checkpoint is extending from a previous invalid one.
+        const validStatusChanged = rollupStatus.validationResult?.valid !== validationResult.valid;
+        const invalidStatusWithSameCheckpointNumber =
+          !validationResult.valid &&
+          rollupStatus.validationResult &&
+          !rollupStatus.validationResult.valid &&
+          rollupStatus.validationResult.checkpoint.checkpointNumber === validationResult.checkpoint.checkpointNumber;
+
+        if (!rejectedAncestor && (validStatusChanged || invalidStatusWithSameCheckpointNumber)) {
           rollupStatus.validationResult = validationResult;
         }
 
@@ -902,9 +912,55 @@ export class ArchiverL1Synchronizer implements Traceable {
             validationResult,
           });
 
-          // We keep consuming checkpoints if we find an invalid one, since we do not listen for CheckpointInvalidated events
-          // We just pretend the invalid ones are not there and keep consuming the next checkpoints
-          // Note that this breaks if the committee ever attests to a descendant of an invalid checkpoint
+          // Persist a rejected-ancestor entry so any later checkpoint that builds on this one
+          // is detected and skipped (rather than tripping the addCheckpoints consecutive-number
+          // check and causing the sync point to roll back in a loop).
+          await this.stores.blocks.addRejectedCheckpoint({
+            checkpointNumber: published.checkpoint.number,
+            archiveRoot: published.checkpoint.archive.root,
+            parentArchiveRoot: published.checkpoint.header.lastArchiveRoot,
+            slotNumber: published.checkpoint.header.slotNumber,
+            l1: published.l1,
+            reason: 'invalid-attestations' as const,
+          });
+
+          continue;
+        }
+
+        if (rejectedAncestor) {
+          const descendantInfo = published.checkpoint.toCheckpointInfo();
+          this.log.warn(
+            `Skipping checkpoint ${published.checkpoint.number} as it is a descendant of ` +
+              `rejected checkpoint ${rejectedAncestor.checkpointNumber} (${rejectedAncestor.reason})`,
+            {
+              checkpointNumber: published.checkpoint.number,
+              checkpointHash: published.checkpoint.hash(),
+              l1BlockNumber: published.l1.blockNumber,
+              l1BlockHash: published.l1.blockHash,
+              ancestorCheckpointNumber: rejectedAncestor.checkpointNumber,
+              ancestorArchiveRoot: rejectedAncestor.archiveRoot.toString(),
+              ancestorReason: rejectedAncestor.reason,
+            },
+          );
+
+          this.events.emit(L2BlockSourceEvents.DescendentOfInvalidAttestationsCheckpointDetected, {
+            type: L2BlockSourceEvents.DescendentOfInvalidAttestationsCheckpointDetected,
+            checkpoint: descendantInfo,
+            ancestorArchiveRoot: rejectedAncestor.archiveRoot,
+            ancestorCheckpointNumber: rejectedAncestor.checkpointNumber,
+          });
+
+          // Persist this chainpoint as rejected as well, so we can construct a chain of
+          // skipped checkpoints starting from the first one with invalid attestations.
+          await this.stores.blocks.addRejectedCheckpoint({
+            checkpointNumber: published.checkpoint.number,
+            archiveRoot: published.checkpoint.archive.root,
+            parentArchiveRoot: published.checkpoint.header.lastArchiveRoot,
+            slotNumber: published.checkpoint.header.slotNumber,
+            l1: published.l1,
+            reason: 'descends-from-invalid-attestations' as const,
+          });
+
           continue;
         }
 
@@ -1005,12 +1061,21 @@ export class ArchiverL1Synchronizer implements Traceable {
           const previousCheckpoint = previousCheckpointNumber
             ? await this.stores.blocks.getCheckpointData(CheckpointNumber(previousCheckpointNumber))
             : undefined;
-          const updatedL1SyncPoint = previousCheckpoint?.l1.blockNumber ?? this.l1Constants.l1StartBlock;
+          const lastFinalizedCheckpoint = await this.stores.blocks.getCheckpointData(
+            await this.stores.blocks.getFinalizedCheckpointNumber(),
+          );
+          const updatedL1SyncPoint =
+            previousCheckpoint?.l1.blockNumber ??
+            lastFinalizedCheckpoint?.l1.blockNumber ??
+            this.l1Constants.l1StartBlock;
           await this.stores.blocks.setSynchedL1BlockNumber(updatedL1SyncPoint);
           this.log.warn(
             `Attempting to insert checkpoint ${newCheckpointNumber} with previous block ${previousCheckpointNumber}. Rolling back L1 sync point to ${updatedL1SyncPoint} to try and fetch the missing blocks.`,
             {
               previousCheckpointNumber,
+              previousCheckpoint: previousCheckpoint?.header.toInspect(),
+              lastFinalizedCheckpoint: lastFinalizedCheckpoint?.header.toInspect(),
+              l1StartBlock: this.l1Constants.l1StartBlock,
               newCheckpointNumber,
               updatedL1SyncPoint,
             },
@@ -1031,13 +1096,13 @@ export class ArchiverL1Synchronizer implements Traceable {
         });
       }
       lastRetrievedCheckpoint = validCheckpoints.at(-1) ?? lastRetrievedCheckpoint;
-      lastL1BlockWithCheckpoint = calldataCheckpoints.at(-1)?.l1.blockNumber ?? lastL1BlockWithCheckpoint;
+      lastSeenCheckpoint = publishedCheckpoints.at(-1) ?? lastSeenCheckpoint;
     } while (searchEndBlock < currentL1BlockNumber);
 
     // Important that we update AFTER inserting the blocks.
     await updateProvenCheckpoint();
 
-    return { ...rollupStatus, lastRetrievedCheckpoint, lastL1BlockWithCheckpoint };
+    return { ...rollupStatus, lastRetrievedCheckpoint, lastSeenCheckpoint };
   }
 
   /**
@@ -1137,35 +1202,38 @@ export class ArchiverL1Synchronizer implements Traceable {
     blocksSynchedTo: bigint,
     currentL1BlockNumber: bigint,
   ): Promise<void> {
-    const { lastRetrievedCheckpoint, pendingCheckpointNumber } = status;
-    // Compare the last checkpoint we have (either retrieved in this round or loaded from store) with what the
-    // rollup contract told us was the latest one (pinned at the currentL1BlockNumber).
+    const { lastSeenCheckpoint, pendingCheckpointNumber } = status;
+    // Compare the last checkpoint (valid or not) we have (either retrieved in this round or loaded from store)
+    // with what the rollup contract told us was the latest one (pinned at the currentL1BlockNumber).
     const latestLocalCheckpointNumber =
-      lastRetrievedCheckpoint?.checkpoint.number ?? (await this.stores.blocks.getLatestCheckpointNumber());
+      lastSeenCheckpoint?.checkpoint.number ??
+      CheckpointNumber.max(
+        await this.stores.blocks.getLatestCheckpointNumber(),
+        await this.stores.blocks.getLatestRejectedCheckpointNumber(),
+      ) ??
+      CheckpointNumber.ZERO;
+
     if (latestLocalCheckpointNumber < pendingCheckpointNumber) {
       // Here we have consumed all logs until the `currentL1Block` we pinned at the beginning of the archiver loop,
       // but still haven't reached the pending checkpoint according to the call to the rollup contract.
       // We suspect an L1 reorg that added checkpoints *behind* us. If that is the case, it must have happened between
       // the last checkpoint we saw and the current one, so we reset the last synched L1 block number. In the edge case
       // we don't have one, we go back 2 L1 epochs, which is the deepest possible reorg (assuming Casper is working).
-      let latestLocalCheckpointArchive: string | undefined = undefined;
-      let targetL1BlockNumber = maxBigint(currentL1BlockNumber - 64n, 0n);
-      if (lastRetrievedCheckpoint) {
-        latestLocalCheckpointArchive = lastRetrievedCheckpoint.checkpoint.archive.root.toString();
-        targetL1BlockNumber = lastRetrievedCheckpoint.l1.blockNumber;
-      } else if (latestLocalCheckpointNumber > 0) {
-        const checkpoint = await this.stores.blocks
-          .getRangeOfCheckpoints(latestLocalCheckpointNumber, 1)
-          .then(([c]) => c);
-        latestLocalCheckpointArchive = checkpoint.archive.root.toString();
-        targetL1BlockNumber = checkpoint.l1.blockNumber;
-      }
+      const latestLocalCheckpoint: PublishedCheckpoint | CheckpointData | RejectedCheckpoint | undefined =
+        lastSeenCheckpoint ??
+        (await this.stores.blocks.getCheckpointData(latestLocalCheckpointNumber)) ??
+        (await this.stores.blocks.getRejectedCheckpointByNumber(latestLocalCheckpointNumber));
+
+      const targetL1BlockNumber =
+        latestLocalCheckpoint?.l1.blockNumber ??
+        maxBigint(currentL1BlockNumber - 64n, this.l1Constants.l1StartBlock, 0n);
+
       this.log.warn(
         `Failed to reach checkpoint ${pendingCheckpointNumber} at ${currentL1BlockNumber} (latest is ${latestLocalCheckpointNumber}). ` +
           `Rolling back last synched L1 block number to ${targetL1BlockNumber}.`,
         {
           latestLocalCheckpointNumber,
-          latestLocalCheckpointArchive,
+          latestLocalCheckpointL1: latestLocalCheckpoint?.l1,
           blocksSynchedTo,
           currentL1BlockNumber,
           ...status,

--- a/yarn-project/archiver/src/store/block_store.test.ts
+++ b/yarn-project/archiver/src/store/block_store.test.ts
@@ -2833,4 +2833,87 @@ describe('BlockStore', () => {
       expect(await blockStore.getBlock({ number: BlockNumber(2) })).toBeUndefined();
     });
   });
+
+  describe('rejected checkpoints', () => {
+    const makeEntry = (overrides: { archiveRoot?: Fr; l1BlockNumber?: number; checkpointNumber?: number } = {}) => ({
+      checkpointNumber: CheckpointNumber(overrides.checkpointNumber ?? 1),
+      archiveRoot: overrides.archiveRoot ?? Fr.random(),
+      parentArchiveRoot: Fr.random(),
+      slotNumber: SlotNumber(1),
+      l1: makeL1PublishedData(overrides.l1BlockNumber ?? 100),
+      reason: 'invalid-attestations' as const,
+    });
+
+    it('returns an empty result when no rejected checkpoints have been recorded', async () => {
+      expect(await blockStore.getRejectedCheckpointByArchiveRoot(Fr.random())).toBeUndefined();
+      expect(await blockStore.getLatestRejectedCheckpointNumber()).toEqual(
+        CheckpointNumber(INITIAL_CHECKPOINT_NUMBER - 1),
+      );
+    });
+
+    it('round-trips an added rejected entry', async () => {
+      const entry = makeEntry();
+      await blockStore.addRejectedCheckpoint(entry);
+
+      const stored = await blockStore.getRejectedCheckpointByArchiveRoot(entry.archiveRoot);
+      expect(stored).toBeDefined();
+      expect(stored!.checkpointNumber).toEqual(entry.checkpointNumber);
+      expect(stored!.archiveRoot.toString()).toEqual(entry.archiveRoot.toString());
+      expect(stored!.parentArchiveRoot.toString()).toEqual(entry.parentArchiveRoot.toString());
+      expect(stored!.slotNumber).toEqual(entry.slotNumber);
+      expect(stored!.l1.blockNumber).toEqual(entry.l1.blockNumber);
+      expect(stored!.l1.blockHash).toEqual(entry.l1.blockHash);
+      expect(stored!.reason).toEqual(entry.reason);
+    });
+
+    it('updates an existing entry when re-added with the same archive root', async () => {
+      const archiveRoot = Fr.random();
+      await blockStore.addRejectedCheckpoint(makeEntry({ archiveRoot, l1BlockNumber: 100 }));
+      await blockStore.addRejectedCheckpoint(makeEntry({ archiveRoot, l1BlockNumber: 110 }));
+
+      const stored = await blockStore.getRejectedCheckpointByArchiveRoot(archiveRoot);
+      expect(stored).toBeDefined();
+      expect(stored!.l1.blockNumber).toEqual(110n);
+    });
+
+    it('preserves the descends-from-invalid-attestations reason', async () => {
+      const entry = {
+        ...makeEntry(),
+        reason: 'descends-from-invalid-attestations' as const,
+      };
+      await blockStore.addRejectedCheckpoint(entry);
+      const stored = await blockStore.getRejectedCheckpointByArchiveRoot(entry.archiveRoot);
+      expect(stored!.reason).toEqual('descends-from-invalid-attestations');
+    });
+
+    it('returns the latest rejected checkpoint number across all entries', async () => {
+      await blockStore.addRejectedCheckpoint(makeEntry({ checkpointNumber: 1 }));
+      await blockStore.addRejectedCheckpoint(makeEntry({ checkpointNumber: 5 }));
+      await blockStore.addRejectedCheckpoint(makeEntry({ checkpointNumber: 3 }));
+
+      expect(await blockStore.getLatestRejectedCheckpointNumber()).toEqual(CheckpointNumber(5));
+    });
+
+    it('looks up a rejected entry by checkpoint number', async () => {
+      const entry = makeEntry({ checkpointNumber: 7 });
+      await blockStore.addRejectedCheckpoint(entry);
+
+      const stored = await blockStore.getRejectedCheckpointByNumber(CheckpointNumber(7));
+      expect(stored?.archiveRoot.toString()).toEqual(entry.archiveRoot.toString());
+      expect(await blockStore.getRejectedCheckpointByNumber(CheckpointNumber(8))).toBeUndefined();
+    });
+
+    it('removes a rejected entry by archive root', async () => {
+      const entry = makeEntry({ checkpointNumber: 4 });
+      await blockStore.addRejectedCheckpoint(entry);
+      expect(await blockStore.getRejectedCheckpointByArchiveRoot(entry.archiveRoot)).toBeDefined();
+
+      await blockStore.removeRejectedCheckpointByArchiveRoot(entry.archiveRoot);
+      expect(await blockStore.getRejectedCheckpointByArchiveRoot(entry.archiveRoot)).toBeUndefined();
+      expect(await blockStore.getRejectedCheckpointByNumber(CheckpointNumber(4))).toBeUndefined();
+      expect(await blockStore.getLatestRejectedCheckpointNumber()).toEqual(
+        CheckpointNumber(INITIAL_CHECKPOINT_NUMBER - 1),
+      );
+    });
+  });
 });

--- a/yarn-project/archiver/src/store/block_store.ts
+++ b/yarn-project/archiver/src/store/block_store.ts
@@ -73,6 +73,41 @@ type BlockStorage = {
   indexWithinCheckpoint: number;
 };
 
+/** Reason a checkpoint was rejected during sync. */
+export type RejectedCheckpointReason = 'invalid-attestations' | 'descends-from-invalid-attestations';
+
+/**
+ * A checkpoint observed on L1 that the archiver decided not to ingest, recorded so that
+ * any descendant that builds on top of it can also be skipped (rather than throwing
+ * `InitialCheckpointNumberNotSequentialError` and looping). An entry is dropped via
+ * {@link BlockStore.removeRejectedCheckpointByArchiveRoot} once a checkpoint with the same
+ * archive root is later ingested as valid (e.g. it gathered enough attestations), which
+ * re-enables its descendants.
+ */
+export type RejectedCheckpoint = {
+  /** Checkpoint number this entry represents. */
+  checkpointNumber: CheckpointNumber;
+  /** Archive root produced by this rejected checkpoint (matched against descendants' `lastArchiveRoot`). */
+  archiveRoot: Fr;
+  /** `lastArchiveRoot` from this checkpoint's header (the ancestor it built on). */
+  parentArchiveRoot: Fr;
+  /** Slot number of the rejected checkpoint. */
+  slotNumber: SlotNumber;
+  /** L1 publication data for the rejected checkpoint (block number, hash, timestamp). */
+  l1: L1PublishedData;
+  /** Why the entry was recorded. */
+  reason: RejectedCheckpointReason;
+};
+
+type RejectedCheckpointStorage = {
+  checkpointNumber: number;
+  archiveRoot: Buffer;
+  parentArchiveRoot: Buffer;
+  slotNumber: number;
+  l1: Buffer;
+  reason: RejectedCheckpointReason;
+};
+
 /** Checkpoint Storage shared between Checkpoints + Proposed Checkpoints */
 type CommonCheckpointStorage = {
   header: Buffer;
@@ -153,6 +188,12 @@ export class BlockStore {
   /** Index mapping block archive to block number */
   #blockArchiveIndex: AztecAsyncMap<string, number>;
 
+  /** Map rejected checkpoints (due to invalid attestations) by archive root */
+  #rejectedCheckpoints: AztecAsyncMap<string, RejectedCheckpointStorage>;
+
+  /** Index mapping a rejected checkpoint's number to its archive root, so the latest can be read in reverse order */
+  #rejectedCheckpointsByNumber: AztecAsyncMap<number, string>;
+
   #log = createLogger('archiver:block_store');
 
   constructor(private db: AztecAsyncKVStore) {
@@ -169,6 +210,8 @@ export class BlockStore {
     this.#checkpoints = db.openMap('archiver_checkpoints');
     this.#slotToCheckpoint = db.openMap('archiver_slot_to_checkpoint');
     this.#proposedCheckpoints = db.openMap('archiver_proposed_checkpoints');
+    this.#rejectedCheckpoints = db.openMap('archiver_rejected_checkpoints');
+    this.#rejectedCheckpointsByNumber = db.openMap('archiver_rejected_checkpoints_by_number');
   }
 
   /**
@@ -340,9 +383,13 @@ export class BlockStore {
 
         // Remove proposed checkpoint if it exists, since L1 is authoritative
         await this.#proposedCheckpoints.delete(checkpoint.checkpoint.number);
+
+        // Drop any rejected entry for this archive root: a checkpoint that was previously rejected
+        // (e.g. invalid attestations) is now being ingested as valid, so its descendants are allowed.
+        await this.removeRejectedCheckpointByArchiveRoot(checkpoint.checkpoint.archive.root);
       }
 
-      await this.#lastSynchedL1Block.set(checkpoints[checkpoints.length - 1].l1.blockNumber);
+      await this.advanceSynchedL1BlockNumber(checkpoints[checkpoints.length - 1].l1.blockNumber);
       return true;
     });
   }
@@ -387,7 +434,7 @@ export class BlockStore {
         feeAssetPriceModifier: incoming.checkpoint.feeAssetPriceModifier.toString(),
       });
       // Update the sync point to reflect the new L1 block
-      await this.#lastSynchedL1Block.set(incoming.l1.blockNumber);
+      await this.advanceSynchedL1BlockNumber(incoming.l1.blockNumber);
     }
     return checkpoints.slice(i);
   }
@@ -776,8 +823,12 @@ export class BlockStore {
       // Remove only this pending entry — remaining entries N+1, N+2, ... stay valid
       await this.#proposedCheckpoints.delete(proposed.checkpointNumber);
 
+      // Drop any rejected entry for this archive root: a checkpoint that was previously rejected
+      // (e.g. invalid attestations) is now being promoted as valid, so its descendants are allowed.
+      await this.removeRejectedCheckpointByArchiveRoot(proposed.archive.root);
+
       // Update the last synced L1 block
-      await this.#lastSynchedL1Block.set(l1.blockNumber);
+      await this.advanceSynchedL1BlockNumber(l1.blockNumber);
     });
   }
 
@@ -1426,5 +1477,81 @@ export class BlockStore {
     } else {
       await this.#pendingChainValidationStatus.delete();
     }
+  }
+
+  /** Records a rejected-checkpoint entry, keyed by its own archive root. */
+  async addRejectedCheckpoint(entry: RejectedCheckpoint): Promise<void> {
+    const archiveRootHex = entry.archiveRoot.toString();
+    await this.#rejectedCheckpoints.set(archiveRootHex, {
+      checkpointNumber: entry.checkpointNumber,
+      archiveRoot: entry.archiveRoot.toBuffer(),
+      parentArchiveRoot: entry.parentArchiveRoot.toBuffer(),
+      slotNumber: entry.slotNumber,
+      l1: entry.l1.toBuffer(),
+      reason: entry.reason,
+    });
+    await this.#rejectedCheckpointsByNumber.set(entry.checkpointNumber, archiveRootHex);
+    await this.advanceSynchedL1BlockNumber(entry.l1.blockNumber);
+  }
+
+  /** Returns the rejected-checkpoint entry with the given archive root, or undefined if not present. */
+  async getRejectedCheckpointByArchiveRoot(archiveRoot: Fr): Promise<RejectedCheckpoint | undefined> {
+    const stored = await this.#rejectedCheckpoints.getAsync(archiveRoot.toString());
+    return stored ? this.rejectedCheckpointFromStorage(stored) : undefined;
+  }
+
+  /** Returns the rejected-checkpoint entry recorded for the given checkpoint number, or undefined if none. */
+  async getRejectedCheckpointByNumber(checkpointNumber: CheckpointNumber): Promise<RejectedCheckpoint | undefined> {
+    const archiveRootHex = await this.#rejectedCheckpointsByNumber.getAsync(checkpointNumber);
+    if (archiveRootHex === undefined) {
+      return undefined;
+    }
+    const stored = await this.#rejectedCheckpoints.getAsync(archiveRootHex);
+    return stored ? this.rejectedCheckpointFromStorage(stored) : undefined;
+  }
+
+  /** Returns the highest checkpoint number recorded across all rejected entries, or `INITIAL_CHECKPOINT_NUMBER - 1` if none. */
+  async getLatestRejectedCheckpointNumber(): Promise<CheckpointNumber> {
+    const [latest] = await toArray(this.#rejectedCheckpointsByNumber.keysAsync({ reverse: true, limit: 1 }));
+    return CheckpointNumber(latest ?? INITIAL_CHECKPOINT_NUMBER - 1);
+  }
+
+  /** Removes a rejected-checkpoint entry by its archive root (used when an entry no longer matches L1). */
+  async removeRejectedCheckpointByArchiveRoot(archiveRoot: Fr): Promise<void> {
+    const archiveRootHex = archiveRoot.toString();
+    const stored = await this.#rejectedCheckpoints.getAsync(archiveRootHex);
+    await this.#rejectedCheckpoints.delete(archiveRootHex);
+    if (stored) {
+      // Only clear the by-number index if it still points at this archive root, so a distinct
+      // entry that shares the checkpoint number (e.g. an L1 reorg replacement) is not dropped.
+      const indexed = await this.#rejectedCheckpointsByNumber.getAsync(stored.checkpointNumber);
+      if (indexed === archiveRootHex) {
+        await this.#rejectedCheckpointsByNumber.delete(stored.checkpointNumber);
+      }
+    }
+  }
+
+  /**
+   * Advances the stored last-synched L1 block number to `l1BlockNumber` only if it is strictly
+   * greater than the current value. Use this whenever ingesting checkpoint-shaped data so the
+   * sync pointer never walks backwards on out-of-order writes (e.g. an invalid checkpoint
+   * advance followed by a valid-checkpoint commit landing at an earlier L1 block).
+   */
+  private async advanceSynchedL1BlockNumber(l1BlockNumber: bigint): Promise<void> {
+    const current = await this.#lastSynchedL1Block.getAsync();
+    if (current === undefined || l1BlockNumber > current) {
+      await this.#lastSynchedL1Block.set(l1BlockNumber);
+    }
+  }
+
+  private rejectedCheckpointFromStorage(stored: RejectedCheckpointStorage): RejectedCheckpoint {
+    return {
+      checkpointNumber: CheckpointNumber(stored.checkpointNumber),
+      archiveRoot: Fr.fromBuffer(stored.archiveRoot),
+      parentArchiveRoot: Fr.fromBuffer(stored.parentArchiveRoot),
+      slotNumber: SlotNumber(stored.slotNumber),
+      l1: L1PublishedData.fromBuffer(stored.l1),
+      reason: stored.reason,
+    };
   }
 }

--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -779,7 +779,7 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, AztecNodeDeb
           config.slashProposeInvalidAttestationsPenalty > 0n ||
           config.slashProposeDescendantOfCheckpointWithInvalidAttestationsPenalty > 0n
         ) {
-          attestationsBlockWatcher = new AttestationsBlockWatcher(archiver, epochCache, config);
+          attestationsBlockWatcher = new AttestationsBlockWatcher(archiver, epochCache, config, log.getBindings());
           watchers.push(attestationsBlockWatcher);
         }
       }

--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_invalidate_block.parallel.test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_invalidate_block.parallel.test.ts
@@ -1,4 +1,4 @@
-import { CalldataRetriever } from '@aztec/archiver';
+import { type Archiver, CalldataRetriever } from '@aztec/archiver';
 import type { AztecNodeService } from '@aztec/aztec-node';
 import type { AztecAddress } from '@aztec/aztec.js/addresses';
 import { NO_WAIT } from '@aztec/aztec.js/contracts';
@@ -16,6 +16,7 @@ import { EthAddress } from '@aztec/foundation/eth-address';
 import { createLogger } from '@aztec/foundation/log';
 import { promiseWithResolvers } from '@aztec/foundation/promise';
 import { retryUntil } from '@aztec/foundation/retry';
+import { sleep } from '@aztec/foundation/sleep';
 import { bufferToHex } from '@aztec/foundation/string';
 import { timeoutPromise } from '@aztec/foundation/timer';
 import type { TestContract } from '@aztec/noir-test-contracts.js/Test';
@@ -470,6 +471,219 @@ describe('e2e_epochs/epochs_invalidate_block', () => {
     await test.waitUntilCheckpointNumber(nextCheckpointNumber, test.L2_SLOT_DURATION_IN_S * 16);
 
     logger.warn(`Test succeeded '${expect.getState().currentTestName}'`);
+  });
+
+  // Reproduction for the archiver "non-consecutive checkpoint" loop bug:
+  // P1 publishes a checkpoint with insufficient attestations (archiver skips it via `continue` at
+  // l1_synchronizer.ts:908); the next proposer P2 publishes a *valid* descendant without first
+  // invalidating P1. When the archiver tries to insert P2 the consecutiveness check throws
+  // `InitialCheckpointNumberNotSequentialError`, the L1 sync point is rolled back, and the next
+  // poll re-fetches the same range and re-throws — a deterministic loop bounded only by the
+  // polling interval. Today no fixture path reaches this state because every proposer either
+  // bails out of publishing or bundles an invalidation; this test wires up the new
+  // `skipWaitForValidParentCheckpointOnL1` flag together with `skipInvalidateBlockAsProposer`
+  // on P2 to force the fault.
+  it('archiver gets stuck when next proposer extends an invalid-attestations checkpoint', async () => {
+    const sequencers = nodes.map(node => node.getSequencer()!);
+
+    // The committee invalidation fallback is already disabled by the fixture-level
+    // `secondsBeforeInvalidatingBlockAsCommitteeMember`. We also need to disable the non-committee
+    // fallback (`considerInvalidatingCheckpoint` at sequencer.ts:950, called from L345) on every
+    // node, otherwise any sequencer whose pending chain is invalid will eventually invalidate P1
+    // and break the loop we're trying to reproduce.
+    sequencers.forEach(s =>
+      s.updateConfig({
+        secondsBeforeInvalidatingBlockAsNonCommitteeMember: Number.MAX_SAFE_INTEGER,
+        minTxsPerBlock: 0,
+      }),
+    );
+    await Promise.all(sequencers.map(s => s.start()));
+    logger.warn(`Started all sequencers, waiting for first checkpoint before applying malicious config`);
+
+    // Wait for at least one good checkpoint to be mined so any in-progress slot has completed.
+    const initialCheckpointNumber = (await nodes[0].getChainTips()).checkpointed.checkpoint.number;
+    await test.waitUntilCheckpointNumber(CheckpointNumber(initialCheckpointNumber + 1), test.L2_SLOT_DURATION_IN_S * 4);
+
+    // Align to the start of an L2 slot, then pick two slots with a 3-slot gap so the malicious
+    // config has time to land on each proposer's job snapshot under pipelining, and P1's proposal
+    // has time to propagate to P2 before P2 starts pipelined building.
+    await test.monitor.waitUntilNextL2Slot();
+    const { l2SlotNumber: currentSlot } = await test.monitor.run();
+    logger.warn(`First checkpoint mined, current slot is ${currentSlot}`);
+
+    let badSlot1 = SlotNumber.add(currentSlot, 3);
+    let badSlot2 = SlotNumber.add(currentSlot, 4);
+    let p1Proposer = await test.epochCache.getProposerAttesterAddressInSlot(badSlot1);
+    let p2Proposer = await test.epochCache.getProposerAttesterAddressInSlot(badSlot2);
+
+    // Ensure the two slots belong to different proposers; retry by walking forward one slot at
+    // a time. With committee size 6 and random shuffling this should usually succeed first try.
+    let attempts = 0;
+    while (p1Proposer && p2Proposer && p1Proposer.equals(p2Proposer)) {
+      attempts += 1;
+      if (attempts > 6) {
+        throw new Error(`Could not find two consecutive slots with different proposers`);
+      }
+      badSlot1 = SlotNumber.add(badSlot1, 1);
+      badSlot2 = SlotNumber.add(badSlot2, 1);
+      p1Proposer = await test.epochCache.getProposerAttesterAddressInSlot(badSlot1);
+      p2Proposer = await test.epochCache.getProposerAttesterAddressInSlot(badSlot2);
+    }
+    if (!p1Proposer || !p2Proposer) {
+      throw new Error(`Could not resolve proposers for slots ${badSlot1} and ${badSlot2}`);
+    }
+
+    const p1NodeIndex = nodes.findIndex(n => n.getSequencer()!.validatorAddresses!.some(a => a.equals(p1Proposer!)));
+    const p2NodeIndex = nodes.findIndex(n => n.getSequencer()!.validatorAddresses!.some(a => a.equals(p2Proposer!)));
+    if (p1NodeIndex === -1 || p2NodeIndex === -1) {
+      throw new Error(`Could not find nodes for proposers P1=${p1Proposer} P2=${p2Proposer}`);
+    }
+    const p1Node = nodes[p1NodeIndex];
+    const p2Node = nodes[p2NodeIndex];
+    logger.warn(`Applying malicious configs`, {
+      p1NodeIndex,
+      p1Proposer: p1Proposer.toString(),
+      badSlot1,
+      p2NodeIndex,
+      p2Proposer: p2Proposer.toString(),
+      badSlot2,
+    });
+
+    // P1 publishes its checkpoint with only its own self-attestation (insufficient) and skips
+    // any invalidation of earlier checkpoints.
+    await p1Node.setConfig({
+      skipCollectingAttestations: true,
+      skipInvalidateBlockAsProposer: true,
+      minTxsPerBlock: 0,
+    });
+
+    // P2 collects attestations normally so its checkpoint lands valid, but bypasses the
+    // parent-validity gate (the new flag) and the L270 invalidation enqueue (the existing flag).
+    // `skipInvalidateBlockAsProposer` short-circuits `enqueueInvalidation` at L479-482, which
+    // covers both the call site at L270 and the in-method one at L422 that fires when the parent
+    // is detected as invalid inside `waitForValidParentCheckpointOnL1` (although that path is
+    // now unreachable because the new flag returns early at the top of the method).
+    await p2Node.setConfig({
+      skipWaitForValidParentCheckpointOnL1: true,
+      skipInvalidateBlockAsProposer: true,
+      minTxsPerBlock: 0,
+    });
+
+    // Install a log-capture spy on node[0]'s archiver l1_synchronizer logger. The warn message
+    // at l1_synchronizer.ts:1010-1011 ("Rolling back L1 sync point") is unique to the
+    // `InitialCheckpointNumberNotSequentialError` retry path, so its repetition is the loop
+    // signature we want to assert on.
+    const observerArchiver = nodes[0].getBlockSource() as Archiver;
+
+    const synchronizerLog = (observerArchiver as any).synchronizer.log;
+    const synchronizerWarnSpy = jest.spyOn(synchronizerLog, 'warn');
+
+    try {
+      // Send a couple of txs so there's content for both checkpoints.
+      logger.warn('Sending transactions to fill the bad checkpoints');
+      await timesAsync(4, i => testContract.methods.emit_nullifier(BigInt(i + 1)).send({ from, wait: NO_WAIT }));
+
+      // Watch for both CheckpointProposed events at the targeted slots.
+      const p1CheckpointPromise = promiseWithResolvers<CheckpointNumber>();
+      const p2CheckpointPromise = promiseWithResolvers<CheckpointNumber>();
+      test.monitor.on('checkpoint', ({ checkpointNumber, l2SlotNumber }) => {
+        if (l2SlotNumber === badSlot1) {
+          p1CheckpointPromise.resolve(checkpointNumber);
+        }
+        if (l2SlotNumber === badSlot2) {
+          p2CheckpointPromise.resolve(checkpointNumber);
+        }
+      });
+
+      logger.warn(`Waiting for two checkpoints to be mined on slots ${badSlot1} and ${badSlot2}`);
+      const [p1Checkpoint, p2Checkpoint] = await Promise.race([
+        Promise.all([p1CheckpointPromise.promise, p2CheckpointPromise.promise]),
+        timeoutPromise(test.L2_SLOT_DURATION_IN_S * 8 * 1000, 'Waiting for both checkpoints').then(
+          () => [CheckpointNumber(0), CheckpointNumber(0)] as const,
+        ),
+      ]);
+      logger.warn(`Observed checkpoints`, { p1Checkpoint, p2Checkpoint, badSlot1, badSlot2 });
+      expect(p2Checkpoint).toEqual(CheckpointNumber(p1Checkpoint + 1));
+
+      // P1 must have landed with insufficient attestations (the trigger for the archiver skip).
+      await assertCheckpointInsufficientAttestations(p1Checkpoint);
+
+      // Read both events from L1, confirm P2's header actually extends P1's. Without this the
+      // archiver's consecutiveness check wouldn't fire and the test could silently pass without
+      // having engineered the fault.
+      const proposedEvents = await rollupContract.getCheckpointProposedEvents(1n, await l1Client.getBlockNumber());
+      const p1Event = proposedEvents.find(e => e.args.checkpointNumber === p1Checkpoint);
+      const p2Event = proposedEvents.find(e => e.args.checkpointNumber === p2Checkpoint);
+      expect(p1Event).toBeDefined();
+      expect(p2Event).toBeDefined();
+      expect(p1Event!.l1BlockNumber).toBeLessThan(p2Event!.l1BlockNumber);
+
+      const calldataRetriever = new CalldataRetriever(
+        l1Client as unknown as ViemPublicClient,
+        l1Client as unknown as ViemPublicDebugClient,
+        VALIDATOR_COUNT,
+        undefined,
+        createLogger('e2e:epochs_invalidate_block:stuck-archiver:calldata'),
+        EthAddress.fromString(rollupContract.address),
+      );
+      const p1Data = await calldataRetriever.getCheckpointFromRollupTx(
+        p1Event!.l1TransactionHash,
+        p1Event!.args.versionedBlobHashes,
+        p1Checkpoint,
+        {
+          attestationsHash: p1Event!.args.attestationsHash.toString(),
+          payloadDigest: p1Event!.args.payloadDigest.toString(),
+        },
+      );
+      const p2Data = await calldataRetriever.getCheckpointFromRollupTx(
+        p2Event!.l1TransactionHash,
+        p2Event!.args.versionedBlobHashes,
+        p2Checkpoint,
+        {
+          attestationsHash: p2Event!.args.attestationsHash.toString(),
+          payloadDigest: p2Event!.args.payloadDigest.toString(),
+        },
+      );
+      // P2 builds on P1: its lastArchiveRoot is the archive root produced by P1.
+      expect(p2Data.header.lastArchiveRoot.toString()).toEqual(p1Data.archiveRoot.toString());
+
+      // Both checkpoints have landed and P2 extends P1. Wait a few slots and confirm the
+      // archiver is stuck in the rollback retry loop. The polling interval is 200ms (set in
+      // beforeEach), so within 6 * 32s we expect well over 3 retries.
+      const waitMs = test.L2_SLOT_DURATION_IN_S * 6 * 1000;
+      logger.warn(`Waiting ${waitMs}ms for the archiver retry loop to repeat`);
+      await sleep(waitMs);
+
+      // Primary signal: repeated rollback warns from the synchronizer.
+      const rollbackWarnCalls = synchronizerWarnSpy.mock.calls.filter(
+        (call: any[]) => typeof call[0] === 'string' && call[0].includes('Rolling back L1 sync point'),
+      );
+      logger.warn(`Observed ${rollbackWarnCalls.length} "Rolling back L1 sync point" warnings on node[0]`);
+      expect(rollbackWarnCalls.length).toBeGreaterThanOrEqual(3);
+
+      // Belt-and-suspenders: node[0] must not have advanced past P1 — if it had, the loop would
+      // have resolved itself somehow and our log capture is suspect.
+      const observedTips = await nodes[0].getChainTips();
+      logger.warn(`Observer node tips`, {
+        checkpointedBlock: observedTips.checkpointed.block.number,
+        checkpointedCheckpoint: observedTips.checkpointed.checkpoint.number,
+        proposedBlock: observedTips.proposed.number,
+      });
+      expect(observedTips.checkpointed.checkpoint.number).toBeLessThan(p2Checkpoint);
+
+      logger.warn(`Test succeeded '${expect.getState().currentTestName}'`);
+    } finally {
+      // Best-effort cleanup so the afterEach teardown doesn't hang on a stuck archiver. We do
+      // not require the chain to recover — the bug means it can't until a fix lands.
+      await Promise.all([
+        p1Node
+          .setConfig({ skipCollectingAttestations: false, skipInvalidateBlockAsProposer: false })
+          .catch(() => undefined),
+        p2Node
+          .setConfig({ skipWaitForValidParentCheckpointOnL1: false, skipInvalidateBlockAsProposer: false })
+          .catch(() => undefined),
+      ]);
+    }
   });
 
   // All tests but this one disable invalidation by committee. This test disables invalidation by proposer and

--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_invalidate_block.parallel.test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_invalidate_block.parallel.test.ts
@@ -8,6 +8,7 @@ import { waitForTx } from '@aztec/aztec.js/node';
 import { RollupContract } from '@aztec/ethereum/contracts';
 import type { Operator } from '@aztec/ethereum/deploy-aztec-l1-contracts';
 import type { ExtendedViemWalletClient, ViemPublicClient, ViemPublicDebugClient } from '@aztec/ethereum/types';
+import { range } from '@aztec/foundation/array';
 import { asyncMap } from '@aztec/foundation/async-map';
 import { CheckpointNumber, SlotNumber } from '@aztec/foundation/branded-types';
 import { times, timesAsync } from '@aztec/foundation/collection';
@@ -16,11 +17,11 @@ import { EthAddress } from '@aztec/foundation/eth-address';
 import { createLogger } from '@aztec/foundation/log';
 import { promiseWithResolvers } from '@aztec/foundation/promise';
 import { retryUntil } from '@aztec/foundation/retry';
-import { sleep } from '@aztec/foundation/sleep';
 import { bufferToHex } from '@aztec/foundation/string';
-import { timeoutPromise } from '@aztec/foundation/timer';
+import { executeTimeout, timeoutPromise } from '@aztec/foundation/timer';
 import type { TestContract } from '@aztec/noir-test-contracts.js/Test';
 import { OffenseType } from '@aztec/slasher';
+import { L2BlockSourceEvents } from '@aztec/stdlib/block';
 import { computeQuorum, getTimestampForSlot } from '@aztec/stdlib/epoch-helpers';
 
 import { jest } from '@jest/globals';
@@ -473,17 +474,14 @@ describe('e2e_epochs/epochs_invalidate_block', () => {
     logger.warn(`Test succeeded '${expect.getState().currentTestName}'`);
   });
 
-  // Reproduction for the archiver "non-consecutive checkpoint" loop bug:
-  // P1 publishes a checkpoint with insufficient attestations (archiver skips it via `continue` at
-  // l1_synchronizer.ts:908); the next proposer P2 publishes a *valid* descendant without first
-  // invalidating P1. When the archiver tries to insert P2 the consecutiveness check throws
-  // `InitialCheckpointNumberNotSequentialError`, the L1 sync point is rolled back, and the next
-  // poll re-fetches the same range and re-throws — a deterministic loop bounded only by the
-  // polling interval. Today no fixture path reaches this state because every proposer either
-  // bails out of publishing or bundles an invalidation; this test wires up the new
-  // `skipWaitForValidParentCheckpointOnL1` flag together with `skipInvalidateBlockAsProposer`
-  // on P2 to force the fault.
-  it('archiver gets stuck when next proposer extends an invalid-attestations checkpoint', async () => {
+  // P1 publishes a checkpoint with insufficient attestations; the next proposer P2 publishes a
+  // valid descendant without first invalidating P1. Before the fix, the archiver tripped its
+  // `InitialCheckpointNumberNotSequentialError` consecutive-number guard, rolled back the L1
+  // sync point, and looped indefinitely. The fix records P1 as a rejected ancestor and skips P2
+  // (its valid descendant) outright, emitting `DescendentOfInvalidAttestationsCheckpointDetected`
+  // so the slasher can target P2's proposer. This test verifies the chain advances past P2 and
+  // that both proposers end up flagged for slashing.
+  it('archiver skips a descendant of an invalid-attestations checkpoint', async () => {
     const sequencers = nodes.map(node => node.getSequencer()!);
 
     // The committee invalidation fallback is already disabled by the fixture-level
@@ -558,132 +556,111 @@ describe('e2e_epochs/epochs_invalidate_block', () => {
     });
 
     // P2 collects attestations normally so its checkpoint lands valid, but bypasses the
-    // parent-validity gate (the new flag) and the L270 invalidation enqueue (the existing flag).
-    // `skipInvalidateBlockAsProposer` short-circuits `enqueueInvalidation` at L479-482, which
-    // covers both the call site at L270 and the in-method one at L422 that fires when the parent
-    // is detected as invalid inside `waitForValidParentCheckpointOnL1` (although that path is
-    // now unreachable because the new flag returns early at the top of the method).
+    // parent-validity gate, so it ends up pushing a valid checkpoint with valid attestations
+    // that descends from the invalid P1, which is the scenario we want to test.
     await p2Node.setConfig({
       skipWaitForValidParentCheckpointOnL1: true,
       skipInvalidateBlockAsProposer: true,
       minTxsPerBlock: 0,
     });
 
-    // Install a log-capture spy on node[0]'s archiver l1_synchronizer logger. The warn message
-    // at l1_synchronizer.ts:1010-1011 ("Rolling back L1 sync point") is unique to the
-    // `InitialCheckpointNumberNotSequentialError` retry path, so its repetition is the loop
-    // signature we want to assert on.
-    const observerArchiver = nodes[0].getBlockSource() as Archiver;
-
-    const synchronizerLog = (observerArchiver as any).synchronizer.log;
-    const synchronizerWarnSpy = jest.spyOn(synchronizerLog, 'warn');
-
-    try {
-      // Send a couple of txs so there's content for both checkpoints.
-      logger.warn('Sending transactions to fill the bad checkpoints');
-      await timesAsync(4, i => testContract.methods.emit_nullifier(BigInt(i + 1)).send({ from, wait: NO_WAIT }));
-
-      // Watch for both CheckpointProposed events at the targeted slots.
-      const p1CheckpointPromise = promiseWithResolvers<CheckpointNumber>();
-      const p2CheckpointPromise = promiseWithResolvers<CheckpointNumber>();
-      test.monitor.on('checkpoint', ({ checkpointNumber, l2SlotNumber }) => {
-        if (l2SlotNumber === badSlot1) {
-          p1CheckpointPromise.resolve(checkpointNumber);
-        }
-        if (l2SlotNumber === badSlot2) {
-          p2CheckpointPromise.resolve(checkpointNumber);
-        }
+    // Subscribe to the new archiver event so we can assert P2 was surfaced through it.
+    const observerIndex = range(nodes.length).find(i => i !== p1NodeIndex && i !== p2NodeIndex)!;
+    const observerArchiver = nodes[observerIndex].getBlockSource() as Archiver;
+    const descendantEvents: { checkpointNumber: CheckpointNumber; ancestorCheckpointNumber: CheckpointNumber }[] = [];
+    const onDescendant = (event: {
+      checkpoint: { checkpointNumber: CheckpointNumber };
+      ancestorCheckpointNumber: CheckpointNumber;
+    }) => {
+      descendantEvents.push({
+        checkpointNumber: event.checkpoint.checkpointNumber,
+        ancestorCheckpointNumber: event.ancestorCheckpointNumber,
       });
+    };
 
-      logger.warn(`Waiting for two checkpoints to be mined on slots ${badSlot1} and ${badSlot2}`);
-      const [p1Checkpoint, p2Checkpoint] = await Promise.race([
-        Promise.all([p1CheckpointPromise.promise, p2CheckpointPromise.promise]),
-        timeoutPromise(test.L2_SLOT_DURATION_IN_S * 8 * 1000, 'Waiting for both checkpoints').then(
-          () => [CheckpointNumber(0), CheckpointNumber(0)] as const,
-        ),
-      ]);
-      logger.warn(`Observed checkpoints`, { p1Checkpoint, p2Checkpoint, badSlot1, badSlot2 });
-      expect(p2Checkpoint).toEqual(CheckpointNumber(p1Checkpoint + 1));
+    observerArchiver.events.on(L2BlockSourceEvents.DescendentOfInvalidAttestationsCheckpointDetected, onDescendant);
 
-      // P1 must have landed with insufficient attestations (the trigger for the archiver skip).
-      await assertCheckpointInsufficientAttestations(p1Checkpoint);
+    // Send a couple of txs so there's content for both checkpoints.
+    logger.warn('Sending transactions to fill the bad checkpoints');
+    await Promise.all(times(4, i => testContract.methods.emit_nullifier(BigInt(i + 1)).send({ from, wait: NO_WAIT })));
 
-      // Read both events from L1, confirm P2's header actually extends P1's. Without this the
-      // archiver's consecutiveness check wouldn't fire and the test could silently pass without
-      // having engineered the fault.
-      const proposedEvents = await rollupContract.getCheckpointProposedEvents(1n, await l1Client.getBlockNumber());
-      const p1Event = proposedEvents.find(e => e.args.checkpointNumber === p1Checkpoint);
-      const p2Event = proposedEvents.find(e => e.args.checkpointNumber === p2Checkpoint);
-      expect(p1Event).toBeDefined();
-      expect(p2Event).toBeDefined();
-      expect(p1Event!.l1BlockNumber).toBeLessThan(p2Event!.l1BlockNumber);
+    // Watch for both CheckpointProposed events at the targeted slots.
+    const p1CheckpointPromise = promiseWithResolvers<CheckpointNumber>();
+    const p2CheckpointPromise = promiseWithResolvers<CheckpointNumber>();
+    test.monitor.on('checkpoint', ({ checkpointNumber, l2SlotNumber }) => {
+      if (l2SlotNumber === badSlot1) {
+        p1CheckpointPromise.resolve(checkpointNumber);
+      }
+      if (l2SlotNumber === badSlot2) {
+        p2CheckpointPromise.resolve(checkpointNumber);
+      }
+    });
 
-      const calldataRetriever = new CalldataRetriever(
-        l1Client as unknown as ViemPublicClient,
-        l1Client as unknown as ViemPublicDebugClient,
-        VALIDATOR_COUNT,
-        undefined,
-        createLogger('e2e:epochs_invalidate_block:stuck-archiver:calldata'),
-        EthAddress.fromString(rollupContract.address),
-      );
-      const p1Data = await calldataRetriever.getCheckpointFromRollupTx(
-        p1Event!.l1TransactionHash,
-        p1Event!.args.versionedBlobHashes,
-        p1Checkpoint,
-        {
-          attestationsHash: p1Event!.args.attestationsHash.toString(),
-          payloadDigest: p1Event!.args.payloadDigest.toString(),
-        },
-      );
-      const p2Data = await calldataRetriever.getCheckpointFromRollupTx(
-        p2Event!.l1TransactionHash,
-        p2Event!.args.versionedBlobHashes,
-        p2Checkpoint,
-        {
-          attestationsHash: p2Event!.args.attestationsHash.toString(),
-          payloadDigest: p2Event!.args.payloadDigest.toString(),
-        },
-      );
-      // P2 builds on P1: its lastArchiveRoot is the archive root produced by P1.
-      expect(p2Data.header.lastArchiveRoot.toString()).toEqual(p1Data.archiveRoot.toString());
+    logger.warn(`Waiting for two checkpoints to be mined on slots ${badSlot1} and ${badSlot2}`);
+    const [p1Checkpoint, p2Checkpoint] = await executeTimeout(
+      () => Promise.all([p1CheckpointPromise.promise, p2CheckpointPromise.promise]),
+      test.L2_SLOT_DURATION_IN_S * 8 * 1000,
+      'Waiting for both checkpoints',
+    );
+    logger.warn(`Observed checkpoints`, { p1Checkpoint, p2Checkpoint, badSlot1, badSlot2 });
+    expect(p2Checkpoint).toEqual(CheckpointNumber(p1Checkpoint + 1));
 
-      // Both checkpoints have landed and P2 extends P1. Wait a few slots and confirm the
-      // archiver is stuck in the rollback retry loop. The polling interval is 200ms (set in
-      // beforeEach), so within 6 * 32s we expect well over 3 retries.
-      const waitMs = test.L2_SLOT_DURATION_IN_S * 6 * 1000;
-      logger.warn(`Waiting ${waitMs}ms for the archiver retry loop to repeat`);
-      await sleep(waitMs);
+    // P1 must have landed with insufficient attestations (the trigger for the archiver skip).
+    await assertCheckpointInsufficientAttestations(p1Checkpoint);
 
-      // Primary signal: repeated rollback warns from the synchronizer.
-      const rollbackWarnCalls = synchronizerWarnSpy.mock.calls.filter(
-        (call: any[]) => typeof call[0] === 'string' && call[0].includes('Rolling back L1 sync point'),
-      );
-      logger.warn(`Observed ${rollbackWarnCalls.length} "Rolling back L1 sync point" warnings on node[0]`);
-      expect(rollbackWarnCalls.length).toBeGreaterThanOrEqual(3);
+    // Restore P2 to a healthy config so a later proposer (or P2 in a future slot) can resume
+    // the chain by invalidating P1 and posting fresh checkpoints.
+    await p2Node.setConfig({ skipWaitForValidParentCheckpointOnL1: false, skipInvalidateBlockAsProposer: false });
 
-      // Belt-and-suspenders: node[0] must not have advanced past P1 — if it had, the loop would
-      // have resolved itself somehow and our log capture is suspect.
-      const observedTips = await nodes[0].getChainTips();
-      logger.warn(`Observer node tips`, {
-        checkpointedBlock: observedTips.checkpointed.block.number,
-        checkpointedCheckpoint: observedTips.checkpointed.checkpoint.number,
-        proposedBlock: observedTips.proposed.number,
-      });
-      expect(observedTips.checkpointed.checkpoint.number).toBeLessThan(p2Checkpoint);
+    // The archiver should no longer stall: wait for the chain to advance past P2 within a
+    // handful of slots. Note we wait on local checkpoint progress here (i.e. for the chain to
+    // get unstuck), not specifically on observing P2 in the checkpointed tip — P1 and P2 will
+    // both be skipped, the chain will be invalidated, and progress comes from later slots.
+    const targetCheckpoint = CheckpointNumber(p2Checkpoint + 1);
+    logger.warn(`Waiting for node ${observerIndex} to advance past checkpoint ${p2Checkpoint}`);
+    await retryUntil(
+      async () => {
+        const tips = await nodes[observerIndex].getChainTips();
+        return tips.checkpointed.checkpoint.number >= targetCheckpoint;
+      },
+      'archiver advances past P2',
+      test.L2_SLOT_DURATION_IN_S * 8,
+      0.5,
+    );
 
-      logger.warn(`Test succeeded '${expect.getState().currentTestName}'`);
-    } finally {
-      // Best-effort cleanup so the afterEach teardown doesn't hang on a stuck archiver. We do
-      // not require the chain to recover — the bug means it can't until a fix lands.
-      await Promise.all([
-        p1Node
-          .setConfig({ skipCollectingAttestations: false, skipInvalidateBlockAsProposer: false })
-          .catch(() => undefined),
-        p2Node
-          .setConfig({ skipWaitForValidParentCheckpointOnL1: false, skipInvalidateBlockAsProposer: false })
-          .catch(() => undefined),
-      ]);
-    }
+    // Confirm the descendant-of-invalid event fired for P2 at least once.
+    logger.warn(`Observed ${descendantEvents.length} DescendentOfInvalidAttestationsCheckpointDetected events`);
+    expect(descendantEvents.some(e => e.checkpointNumber === p2Checkpoint)).toBe(true);
+
+    // Both proposers should be flagged for slashing: P1 under PROPOSED_INSUFFICIENT_ATTESTATIONS
+    // and P2 under PROPOSED_DESCENDANT_OF_CHECKPOINT_WITH_INVALID_ATTESTATIONS.
+    const offenses = await nodes[observerIndex].getSlashOffenses('all');
+    logger.warn(`Collected ${offenses.length} offenses`, {
+      offenses: offenses.map(o => ({
+        offenseType: o.offenseType,
+        validator: o.validator.toString(),
+        slot: o.epochOrSlot,
+      })),
+    });
+    const insufficient = offenses.find(
+      o => o.offenseType === OffenseType.PROPOSED_INSUFFICIENT_ATTESTATIONS && o.epochOrSlot === BigInt(badSlot1),
+    );
+    expect(insufficient).toBeDefined();
+    expect(insufficient!.validator.equals(p1Proposer!)).toBeTrue();
+
+    const descendant = offenses.find(
+      o =>
+        o.offenseType === OffenseType.PROPOSED_DESCENDANT_OF_CHECKPOINT_WITH_INVALID_ATTESTATIONS &&
+        o.epochOrSlot === BigInt(badSlot2),
+    );
+    expect(descendant).toBeDefined();
+    expect(descendant!.validator.equals(p2Proposer!)).toBeTrue();
+
+    logger.warn(`Test succeeded '${expect.getState().currentTestName}'`);
+    observerArchiver.events.removeListener(
+      L2BlockSourceEvents.DescendentOfInvalidAttestationsCheckpointDetected,
+      onDescendant,
+    );
   });
 
   // All tests but this one disable invalidation by committee. This test disables invalidation by proposer and

--- a/yarn-project/foundation/src/branded-types/checkpoint_number.ts
+++ b/yarn-project/foundation/src/branded-types/checkpoint_number.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 
+import { isDefined } from '../types/index.js';
 import type { BlockNumber } from './block_number.js';
 import type { Branded } from './types.js';
 
@@ -88,6 +89,15 @@ CheckpointNumber.isValid = function (value: unknown): value is CheckpointNumber 
 /** Increments a CheckpointNumber by a given value. */
 CheckpointNumber.add = function (n: CheckpointNumber, increment: number): CheckpointNumber {
   return CheckpointNumber(n + increment);
+};
+
+/** Computes max of a set of checkpoint numbers, ignoring undefined values. */
+CheckpointNumber.max = function (...values: (CheckpointNumber | undefined)[]): CheckpointNumber | undefined {
+  const filtered = values.filter(isDefined);
+  if (filtered.length === 0) {
+    return undefined;
+  }
+  return CheckpointNumber(Math.max(...filtered));
 };
 
 /** The zero checkpoint value. */

--- a/yarn-project/sequencer-client/src/config.ts
+++ b/yarn-project/sequencer-client/src/config.ts
@@ -52,6 +52,7 @@ export const DefaultSequencerConfig = {
   secondsBeforeInvalidatingBlockAsNonCommitteeMember: 432, // 36 L1 blocks
   skipCollectingAttestations: false,
   skipInvalidateBlockAsProposer: false,
+  skipWaitForValidParentCheckpointOnL1: false,
   broadcastInvalidBlockProposal: false,
   broadcastInvalidCheckpointProposalOnly: false,
   injectFakeAttestation: false,
@@ -187,6 +188,12 @@ export const sequencerConfigMappings: ConfigMappingsType<SequencerConfig> = {
   skipInvalidateBlockAsProposer: {
     description: 'Do not invalidate the previous block if invalid when we are the proposer (for testing only)',
     ...booleanConfigHelper(DefaultSequencerConfig.skipInvalidateBlockAsProposer),
+  },
+  skipWaitForValidParentCheckpointOnL1: {
+    description:
+      'Bypass the parent checkpoint validity check before submitting a pipelined checkpoint, ' +
+      'allowing the proposer to publish even when the parent landed on L1 with invalid attestations (for testing only)',
+    ...booleanConfigHelper(DefaultSequencerConfig.skipWaitForValidParentCheckpointOnL1),
   },
   broadcastInvalidBlockProposal: {
     description: 'Broadcast invalid block proposals with corrupted state (for testing only)',

--- a/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.ts
+++ b/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.ts
@@ -396,6 +396,13 @@ export class CheckpointProposalJob implements Traceable {
    * If the parent has invalid attestations, enqueues an invalidation. Returns whether to proceed with the proposal.
    */
   protected async waitForValidParentCheckpointOnL1(): Promise<boolean> {
+    if (this.config.skipWaitForValidParentCheckpointOnL1) {
+      this.log.warn(`Skipping waitForValidParentCheckpointOnL1 due to test configuration`, {
+        checkpointNumber: this.checkpointNumber,
+      });
+      return true;
+    }
+
     const parentCheckpointNumber = CheckpointNumber(this.checkpointNumber - 1);
 
     // Wait until archiver has synced L1 past the parent's slot (slotNow)

--- a/yarn-project/slasher/src/watchers/attestations_block_watcher.test.ts
+++ b/yarn-project/slasher/src/watchers/attestations_block_watcher.test.ts
@@ -1,13 +1,15 @@
-import type { EpochCache } from '@aztec/epoch-cache';
+import type { EpochCache, EpochCommitteeInfo } from '@aztec/epoch-cache';
 import { CheckpointNumber, EpochNumber, SlotNumber } from '@aztec/foundation/branded-types';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import type {
+  DescendentOfInvalidAttestationsCheckpointEvent,
   InvalidCheckpointDetectedEvent,
   L2BlockSourceEventEmitter,
   ValidateCheckpointNegativeResult,
 } from '@aztec/stdlib/block';
 import type { CheckpointInfo } from '@aztec/stdlib/checkpoint';
+import type { L1RollupConstants } from '@aztec/stdlib/epoch-helpers';
 import { OffenseType } from '@aztec/stdlib/slashing';
 
 import { jest } from '@jest/globals';
@@ -45,8 +47,15 @@ describe('AttestationsBlockWatcher', () => {
     proposer = EthAddress.fromString('0x0000000000000000000000000000000000000abc');
     committee = [proposer, EthAddress.fromString('0x0000000000000000000000000000000000000def')];
 
-    // Default mock return value
+    // Default mock return values
     epochCache.getProposerFromEpochCommittee.mockReturnValue(proposer);
+    epochCache.getL1Constants.mockReturnValue({ epochDuration: 32 } as L1RollupConstants);
+    epochCache.getCommitteeForEpoch.mockResolvedValue({
+      committee,
+      seed: 0n,
+      epoch: EpochNumber(0),
+      isEscapeHatchOpen: false,
+    } as EpochCommitteeInfo);
   });
 
   it('should emit WANT_TO_SLASH_EVENT for proposer when invalid checkpoint detected due to insufficient attestations', () => {
@@ -110,36 +119,19 @@ describe('AttestationsBlockWatcher', () => {
     expect(handler).toHaveBeenCalledTimes(1);
   });
 
-  it('should emit WANT_TO_SLASH_EVENT for attestors when checkpoint built on invalid parent', () => {
-    // First, handle an invalid checkpoint using the pre-configured data
-    const invalidCheckpointValidationResult: ValidateCheckpointNegativeResult = {
-      valid: false,
-      reason: 'insufficient-attestations',
-      checkpoint: checkpointInfo,
-      committee,
-      epoch: EpochNumber(1),
-      seed: 0n,
-      attestors: [],
-      attestations: [],
-    };
-
-    const invalidCheckpointEvent: InvalidCheckpointDetectedEvent = {
-      type: 'invalidCheckpointDetected',
-      validationResult: invalidCheckpointValidationResult,
-    };
-
-    watcher.handleInvalidCheckpoint(invalidCheckpointEvent);
-
-    // Now handle a checkpoint that builds on the invalid checkpoint
+  it('emits both an invalid-attestations slash and a descendant slash for a checkpoint that has invalid attestations and builds on an invalid ancestor', async () => {
+    // A checkpoint that both has invalid attestations of its own and extends a previously-rejected
+    // ancestor produces two offenses. The archiver reports each via its own event, so the watcher sees
+    // an invalidCheckpointDetected (own attestations) and a descendentOfInvalidAttestationsCheckpointDetected
+    // (extends a rejected ancestor) for the same checkpoint.
     const childCheckpointInfo: CheckpointInfo = {
       archive: Fr.random(),
-      lastArchive: checkpointInfo.archive, // Parent archive
+      lastArchive: checkpointInfo.archive, // Parent archive (the rejected ancestor)
       slotNumber: SlotNumber(2),
       checkpointNumber: CheckpointNumber(2),
       timestamp: BigInt(Math.floor(Date.now() / 1000)),
     };
     const proposer2 = EthAddress.fromString('0x0000000000000000000000000000000000000def');
-
     epochCache.getProposerFromEpochCommittee.mockReturnValue(proposer2);
 
     const attestor1 = EthAddress.fromString('0x0000000000000000000000000000000000000111');
@@ -156,13 +148,11 @@ describe('AttestationsBlockWatcher', () => {
       attestations: [],
     };
 
-    const childEvent: InvalidCheckpointDetectedEvent = {
+    // First event: slash the proposer for the invalid attestations on its own checkpoint.
+    watcher.handleInvalidCheckpoint({
       type: 'invalidCheckpointDetected',
       validationResult: childValidationResult,
-    };
-
-    handler.mockClear();
-    watcher.handleInvalidCheckpoint(childEvent);
+    });
 
     expect(handler).toHaveBeenCalledWith([
       {
@@ -173,25 +163,28 @@ describe('AttestationsBlockWatcher', () => {
       } satisfies WantToSlashArgs,
     ]);
 
+    // Second event: slash the same proposer for building on the rejected ancestor.
+    await watcher.handleDescendantOfInvalid({
+      type: 'descendentOfInvalidAttestationsCheckpointDetected',
+      checkpoint: childCheckpointInfo,
+      ancestorArchiveRoot: checkpointInfo.archive,
+      ancestorCheckpointNumber: checkpointInfo.checkpointNumber,
+    });
+
     expect(handler).toHaveBeenCalledWith([
       {
-        validator: attestor1,
+        validator: proposer2,
         amount: config.slashProposeDescendantOfCheckpointWithInvalidAttestationsPenalty,
         offenseType: OffenseType.PROPOSED_DESCENDANT_OF_CHECKPOINT_WITH_INVALID_ATTESTATIONS,
         epochOrSlot: 2n,
-      },
-      {
-        validator: attestor2,
-        amount: config.slashProposeDescendantOfCheckpointWithInvalidAttestationsPenalty,
-        offenseType: OffenseType.PROPOSED_DESCENDANT_OF_CHECKPOINT_WITH_INVALID_ATTESTATIONS,
-        epochOrSlot: 2n,
-      },
-    ] satisfies WantToSlashArgs[]);
+      } satisfies WantToSlashArgs,
+    ]);
     expect(handler).toHaveBeenCalledTimes(2);
   });
 
-  it('should not process the same invalid checkpoint twice', () => {
-    const validationResult: ValidateCheckpointNegativeResult = {
+  it('emits WANT_TO_SLASH_EVENT for proposer when a valid-attestations descendant of an invalid checkpoint is detected', async () => {
+    // Seed the watcher with one invalid ancestor so the descendant event hits the cache.
+    const invalidValidationResult: ValidateCheckpointNegativeResult = {
       valid: false,
       reason: 'insufficient-attestations',
       checkpoint: checkpointInfo,
@@ -201,18 +194,118 @@ describe('AttestationsBlockWatcher', () => {
       attestors: [],
       attestations: [],
     };
-
-    const event: InvalidCheckpointDetectedEvent = {
+    watcher.handleInvalidCheckpoint({
       type: 'invalidCheckpointDetected',
-      validationResult,
+      validationResult: invalidValidationResult,
+    });
+
+    handler.mockClear();
+
+    const descendantCheckpointInfo: CheckpointInfo = {
+      archive: Fr.random(),
+      lastArchive: checkpointInfo.archive,
+      slotNumber: SlotNumber(2),
+      checkpointNumber: CheckpointNumber(2),
+      timestamp: BigInt(Math.floor(Date.now() / 1000)),
+    };
+    const descendantProposer = EthAddress.fromString('0x0000000000000000000000000000000000000def');
+    epochCache.getProposerFromEpochCommittee.mockReturnValue(descendantProposer);
+
+    const event: DescendentOfInvalidAttestationsCheckpointEvent = {
+      type: 'descendentOfInvalidAttestationsCheckpointDetected',
+      checkpoint: descendantCheckpointInfo,
+      ancestorArchiveRoot: checkpointInfo.archive,
+      ancestorCheckpointNumber: checkpointInfo.checkpointNumber,
     };
 
-    // Handle the same event twice
-    watcher.handleInvalidCheckpoint(event);
-    watcher.handleInvalidCheckpoint(event);
+    await watcher.handleDescendantOfInvalid(event);
 
-    // Should only emit once (duplicate was skipped)
+    expect(handler).toHaveBeenCalledWith([
+      {
+        validator: descendantProposer,
+        amount: config.slashProposeDescendantOfCheckpointWithInvalidAttestationsPenalty,
+        offenseType: OffenseType.PROPOSED_DESCENDANT_OF_CHECKPOINT_WITH_INVALID_ATTESTATIONS,
+        epochOrSlot: 2n,
+      } satisfies WantToSlashArgs,
+    ]);
     expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it('slashes a further descendant that both has invalid attestations and extends another descendant', async () => {
+    // The archiver tracks the rejected chain and reports each descendant via its own event. A further
+    // descendant (D2) that both has its own invalid attestations and extends an earlier descendant (D1)
+    // is reported through two events; the watcher slashes its proposer for each offense independently.
+    const d2: CheckpointInfo = {
+      archive: Fr.random(),
+      lastArchive: Fr.random(),
+      slotNumber: SlotNumber(3),
+      checkpointNumber: CheckpointNumber(3),
+      timestamp: BigInt(Math.floor(Date.now() / 1000)),
+    };
+    const d2Proposer = EthAddress.fromString('0x0000000000000000000000000000000000000bbb');
+    epochCache.getProposerFromEpochCommittee.mockReturnValue(d2Proposer);
+
+    // D2 has invalid attestations of its own.
+    watcher.handleInvalidCheckpoint({
+      type: 'invalidCheckpointDetected',
+      validationResult: {
+        valid: false,
+        reason: 'insufficient-attestations',
+        checkpoint: d2,
+        committee,
+        epoch: EpochNumber(1),
+        seed: 0n,
+        attestors: [],
+        attestations: [],
+      },
+    });
+
+    expect(handler).toHaveBeenCalledWith([
+      {
+        validator: d2Proposer,
+        amount: config.slashProposeInvalidAttestationsPenalty,
+        offenseType: OffenseType.PROPOSED_INSUFFICIENT_ATTESTATIONS,
+        epochOrSlot: 3n,
+      } satisfies WantToSlashArgs,
+    ]);
+
+    // D2 also extends an earlier descendant of an invalid checkpoint.
+    await watcher.handleDescendantOfInvalid({
+      type: 'descendentOfInvalidAttestationsCheckpointDetected',
+      checkpoint: d2,
+      ancestorArchiveRoot: Fr.random(),
+      ancestorCheckpointNumber: CheckpointNumber(1),
+    });
+
+    expect(handler).toHaveBeenCalledWith([
+      {
+        validator: d2Proposer,
+        amount: config.slashProposeDescendantOfCheckpointWithInvalidAttestationsPenalty,
+        offenseType: OffenseType.PROPOSED_DESCENDANT_OF_CHECKPOINT_WITH_INVALID_ATTESTATIONS,
+        epochOrSlot: 3n,
+      } satisfies WantToSlashArgs,
+    ]);
+    expect(handler).toHaveBeenCalledTimes(2);
+  });
+
+  it('handles descendant-of-invalid event when no proposer is found', async () => {
+    epochCache.getProposerFromEpochCommittee.mockReturnValue(undefined);
+
+    const descendant: CheckpointInfo = {
+      archive: Fr.random(),
+      lastArchive: Fr.random(),
+      slotNumber: SlotNumber(2),
+      checkpointNumber: CheckpointNumber(2),
+      timestamp: BigInt(Math.floor(Date.now() / 1000)),
+    };
+    await watcher.handleDescendantOfInvalid({
+      type: 'descendentOfInvalidAttestationsCheckpointDetected',
+      checkpoint: descendant,
+      ancestorArchiveRoot: Fr.random(),
+      ancestorCheckpointNumber: CheckpointNumber(1),
+    });
+
+    expect(handler).not.toHaveBeenCalled();
   });
 
   it('should handle case when no proposer is found', () => {

--- a/yarn-project/slasher/src/watchers/attestations_block_watcher.ts
+++ b/yarn-project/slasher/src/watchers/attestations_block_watcher.ts
@@ -1,14 +1,15 @@
 import { EpochCache } from '@aztec/epoch-cache';
-import { SlotNumber } from '@aztec/foundation/branded-types';
+import { EpochNumber } from '@aztec/foundation/branded-types';
 import { merge, pick } from '@aztec/foundation/collection';
-import { FifoSet } from '@aztec/foundation/fifo-set';
-import { type Logger, createLogger } from '@aztec/foundation/log';
+import { type Logger, type LoggerBindings, createLogger } from '@aztec/foundation/log';
 import {
+  type DescendentOfInvalidAttestationsCheckpointEvent,
   type InvalidCheckpointDetectedEvent,
   type L2BlockSourceEventEmitter,
   L2BlockSourceEvents,
   type ValidateCheckpointNegativeResult,
 } from '@aztec/stdlib/block';
+import { getEpochAtSlot } from '@aztec/stdlib/epoch-helpers';
 import { OffenseType } from '@aztec/stdlib/slashing';
 
 import EventEmitter from 'node:events';
@@ -20,22 +21,28 @@ const AttestationsBlockWatcherConfigKeys = [
   'slashProposeDescendantOfCheckpointWithInvalidAttestationsPenalty',
   'slashProposeInvalidAttestationsPenalty',
 ] as const;
-const MAX_INVALID_CHECKPOINTS = 100;
 
 type AttestationsBlockWatcherConfig = Pick<SlasherConfig, (typeof AttestationsBlockWatcherConfigKeys)[number]>;
 
 /**
- * This watcher is responsible for detecting invalid blocks and creating slashing arguments for offenders.
- * An invalid block is one that doesn't have enough attestations or has incorrect attestations.
- * The proposer of an invalid block should be slashed.
- * If there's another block consecutive to the invalid one, its proposer and attestors should also be slashed.
+ * Watches the archiver for checkpoints whose publication is itself a slashable offense.
+ *
+ * Two cases are handled, both targeting the proposer of the offending checkpoint:
+ *
+ * - Invalid-attestations checkpoint: the proposer published a checkpoint to L1 whose
+ *   attestations are either insufficient (below quorum) or incorrect (signature from a
+ *   non-committee member, malformed signature, etc.). Slashed via
+ *   {@link OffenseType.PROPOSED_INSUFFICIENT_ATTESTATIONS} or
+ *   {@link OffenseType.PROPOSED_INCORRECT_ATTESTATIONS}.
+ *
+ * - Descendant of an invalid checkpoint: the proposer published a checkpoint that extends a
+ *   previously-rejected one. The descendant may itself have valid attestations, but it is still
+ *   unusable. Triggered by the archiver's  `CheckpointBuiltOnInvalidAncestorDetected` event
+ *   when the descendant has valid attestations (skipped before ingestion). Slashes the descendant's
+ *   proposer via {@link OffenseType.PROPOSED_DESCENDANT_OF_CHECKPOINT_WITH_INVALID_ATTESTATIONS}.
  */
 export class AttestationsBlockWatcher extends (EventEmitter as new () => WatcherEmitter) implements Watcher {
-  private log: Logger = createLogger('attestations-block-watcher');
-
-  // Recently seen invalid archive roots.
-  private invalidArchiveRoots = FifoSet.withLimit<string>(MAX_INVALID_CHECKPOINTS);
-
+  private log: Logger;
   private config: AttestationsBlockWatcherConfig;
 
   private boundHandleInvalidCheckpoint = (event: InvalidCheckpointDetectedEvent) => {
@@ -49,12 +56,23 @@ export class AttestationsBlockWatcher extends (EventEmitter as new () => Watcher
     }
   };
 
+  private boundHandleDescendantOfInvalid = (event: DescendentOfInvalidAttestationsCheckpointEvent) => {
+    this.handleDescendantOfInvalid(event).catch(err => {
+      this.log.error('Error handling descendant of invalid checkpoint', err, {
+        checkpointNumber: event.checkpoint.checkpointNumber,
+        ancestorCheckpointNumber: event.ancestorCheckpointNumber,
+      });
+    });
+  };
+
   constructor(
     private l2BlockSource: L2BlockSourceEventEmitter,
     private epochCache: EpochCache,
     config: AttestationsBlockWatcherConfig,
+    bindings?: LoggerBindings,
   ) {
     super();
+    this.log = createLogger('slasher:attestations-block-watcher', bindings);
     this.config = pick(config, ...AttestationsBlockWatcherConfigKeys);
     this.log.info('AttestationsBlockWatcher initialized');
   }
@@ -69,6 +87,10 @@ export class AttestationsBlockWatcher extends (EventEmitter as new () => Watcher
       L2BlockSourceEvents.InvalidAttestationsCheckpointDetected,
       this.boundHandleInvalidCheckpoint,
     );
+    this.l2BlockSource.events.on(
+      L2BlockSourceEvents.DescendentOfInvalidAttestationsCheckpointDetected,
+      this.boundHandleDescendantOfInvalid,
+    );
     return Promise.resolve();
   }
 
@@ -77,71 +99,25 @@ export class AttestationsBlockWatcher extends (EventEmitter as new () => Watcher
       L2BlockSourceEvents.InvalidAttestationsCheckpointDetected,
       this.boundHandleInvalidCheckpoint,
     );
+    this.l2BlockSource.events.removeListener(
+      L2BlockSourceEvents.DescendentOfInvalidAttestationsCheckpointDetected,
+      this.boundHandleDescendantOfInvalid,
+    );
     return Promise.resolve();
   }
 
   /** Event handler for invalid checkpoints as reported by the archiver. Public for testing purposes. */
   public handleInvalidCheckpoint(event: InvalidCheckpointDetectedEvent): void {
     const { validationResult } = event;
-    const checkpoint = validationResult.checkpoint;
-
-    // Check if we already have processed this checkpoint, archiver may emit the same event multiple times
-    if (this.invalidArchiveRoots.has(checkpoint.archive.toString())) {
-      this.log.trace(`Already processed invalid checkpoint ${checkpoint.checkpointNumber}`);
-      return;
-    }
+    const { reason, checkpoint } = validationResult;
 
     this.log.verbose(`Detected invalid checkpoint ${checkpoint.checkpointNumber}`, {
       ...checkpoint,
       reason: validationResult.valid === false ? validationResult.reason : 'unknown',
     });
 
-    this.invalidArchiveRoots.add(checkpoint.archive.toString());
-
-    // Slash the proposer of the invalid checkpoint
-    this.slashProposer(event.validationResult);
-
-    // Check if the parent of this checkpoint is invalid as well, if so, we will slash its attestors as well
-    this.slashAttestorsOnAncestorInvalid(event.validationResult);
-  }
-
-  private slashAttestorsOnAncestorInvalid(validationResult: ValidateCheckpointNegativeResult) {
-    const checkpoint = validationResult.checkpoint;
-
-    const parentArchive = checkpoint.lastArchive.toString();
-    if (this.invalidArchiveRoots.has(parentArchive)) {
-      const attestors = validationResult.attestors;
-      this.log.info(
-        `Want to slash attestors of checkpoint ${checkpoint.checkpointNumber} built on invalid checkpoint`,
-        {
-          ...checkpoint,
-          ...attestors,
-          parentArchive,
-        },
-      );
-
-      this.emit(
-        WANT_TO_SLASH_EVENT,
-        attestors.map(attestor => ({
-          validator: attestor,
-          amount: this.config.slashProposeDescendantOfCheckpointWithInvalidAttestationsPenalty,
-          offenseType: OffenseType.PROPOSED_DESCENDANT_OF_CHECKPOINT_WITH_INVALID_ATTESTATIONS,
-          epochOrSlot: BigInt(SlotNumber(checkpoint.slotNumber)),
-        })),
-      );
-    }
-  }
-
-  private slashProposer(validationResult: ValidateCheckpointNegativeResult) {
-    const { reason, checkpoint } = validationResult;
-    const checkpointNumber = checkpoint.checkpointNumber;
-    const slot = checkpoint.slotNumber;
-    const epochCommitteeInfo = {
-      committee: validationResult.committee,
-      seed: validationResult.seed,
-      epoch: validationResult.epoch,
-      isEscapeHatchOpen: false,
-    };
+    const { checkpointNumber, slotNumber: slot } = checkpoint;
+    const epochCommitteeInfo = { ...validationResult, isEscapeHatchOpen: false };
     const proposer = this.epochCache.getProposerFromEpochCommittee(epochCommitteeInfo, slot);
 
     if (!proposer) {
@@ -162,6 +138,40 @@ export class AttestationsBlockWatcher extends (EventEmitter as new () => Watcher
       ...checkpoint,
       ...args,
     });
+
+    this.emit(WANT_TO_SLASH_EVENT, [args]);
+  }
+
+  /**
+   * Event handler for valid-attestations checkpoints that build on a previously-rejected ancestor.
+   * The archiver emits this when ingesting the descendant, and we slash its proposer.
+   */
+  public async handleDescendantOfInvalid(event: DescendentOfInvalidAttestationsCheckpointEvent): Promise<void> {
+    const { checkpoint, ancestorCheckpointNumber, ancestorArchiveRoot } = event;
+
+    const slot = checkpoint.slotNumber;
+    const epoch = EpochNumber(getEpochAtSlot(slot, this.epochCache.getL1Constants()));
+    const epochCommitteeInfo = await this.epochCache.getCommitteeForEpoch(epoch);
+    const proposer = this.epochCache.getProposerFromEpochCommittee({ ...epochCommitteeInfo, epoch }, slot);
+
+    if (!proposer) {
+      this.log.warn(
+        `No proposer found for invalid descendant checkpoint ${checkpoint.checkpointNumber} at slot ${slot}`,
+      );
+      return;
+    }
+
+    const args: WantToSlashArgs = {
+      validator: proposer,
+      amount: this.config.slashProposeDescendantOfCheckpointWithInvalidAttestationsPenalty,
+      offenseType: OffenseType.PROPOSED_DESCENDANT_OF_CHECKPOINT_WITH_INVALID_ATTESTATIONS,
+      epochOrSlot: BigInt(slot),
+    };
+
+    this.log.info(
+      `Want to slash proposer of checkpoint ${checkpoint.checkpointNumber} built on invalid checkpoint ${ancestorCheckpointNumber}`,
+      { ...checkpoint, ancestorArchiveRoot: ancestorArchiveRoot.toString(), ...args },
+    );
 
     this.emit(WANT_TO_SLASH_EVENT, [args]);
   }

--- a/yarn-project/stdlib/src/block/l2_block_source.ts
+++ b/yarn-project/stdlib/src/block/l2_block_source.ts
@@ -16,6 +16,7 @@ import type { TypedEventEmitter } from '@aztec/foundation/types';
 import { z } from 'zod';
 
 import type { CheckpointData, ProposedCheckpointData } from '../checkpoint/checkpoint_data.js';
+import type { CheckpointInfo } from '../checkpoint/checkpoint_info.js';
 import type { PublishedCheckpoint } from '../checkpoint/published_checkpoint.js';
 import type { L1RollupConstants } from '../epoch-helpers/index.js';
 import { CheckpointHeader } from '../rollup/checkpoint_header.js';
@@ -294,6 +295,9 @@ export type ArchiverEmitter = TypedEventEmitter<{
   [L2BlockSourceEvents.InvalidAttestationsCheckpointDetected]: (args: InvalidCheckpointDetectedEvent) => void;
   [L2BlockSourceEvents.L2BlocksCheckpointed]: (args: L2CheckpointEvent) => void;
   [L2BlockSourceEvents.CheckpointEquivocationDetected]: (args: CheckpointEquivocationDetectedEvent) => void;
+  [L2BlockSourceEvents.DescendentOfInvalidAttestationsCheckpointDetected]: (
+    args: DescendentOfInvalidAttestationsCheckpointEvent,
+  ) => void;
 }>;
 export interface L2BlockSourceEventEmitter extends L2BlockSource {
   events: ArchiverEmitter;
@@ -376,6 +380,7 @@ export enum L2BlockSourceEvents {
   L2BlocksCheckpointed = 'l2BlocksCheckpointed',
   InvalidAttestationsCheckpointDetected = 'invalidCheckpointDetected',
   CheckpointEquivocationDetected = 'checkpointEquivocationDetected',
+  DescendentOfInvalidAttestationsCheckpointDetected = 'descendentOfInvalidAttestationsCheckpointDetected',
 }
 
 export type L2BlockProvenEvent = {
@@ -417,4 +422,20 @@ export type CheckpointEquivocationDetectedEvent = {
   checkpointNumber: CheckpointNumber;
   l1ArchiveRoot: Fr;
   proposedArchiveRoot: Fr;
+};
+
+/**
+ * Emitted when the archiver observes a checkpoint that builds on a previously-rejected
+ * ancestor (typically one with insufficient/invalid attestations). The descendant itself may
+ * have valid attestations, but it cannot be ingested because the chain it extends was
+ * skipped. The slasher uses this to slash the proposer of the descendant.
+ */
+export type DescendentOfInvalidAttestationsCheckpointEvent = {
+  type: 'descendentOfInvalidAttestationsCheckpointDetected';
+  /** The descendant checkpoint being rejected. */
+  checkpoint: CheckpointInfo;
+  /** Archive root of the rejected ancestor this descendant builds on. */
+  ancestorArchiveRoot: Fr;
+  /** Checkpoint number of the rejected ancestor. */
+  ancestorCheckpointNumber: CheckpointNumber;
 };

--- a/yarn-project/stdlib/src/interfaces/configs.ts
+++ b/yarn-project/stdlib/src/interfaces/configs.ts
@@ -62,6 +62,11 @@ export interface SequencerConfig {
   skipCollectingAttestations?: boolean;
   /** Do not invalidate the previous block if invalid when we are the proposer (for testing only) */
   skipInvalidateBlockAsProposer?: boolean;
+  /**
+   * Bypass the parent checkpoint validity check before submitting a pipelined checkpoint, allowing
+   * the proposer to publish even when the parent landed on L1 with invalid attestations (for testing only).
+   */
+  skipWaitForValidParentCheckpointOnL1?: boolean;
   /** Broadcast invalid block proposals with corrupted state (for testing only) */
   broadcastInvalidBlockProposal?: boolean;
   /** Broadcast an invalid block proposal only at this indexWithinCheckpoint (for testing only) */
@@ -126,6 +131,7 @@ export const SequencerConfigSchema = zodFor<SequencerConfig>()(
     attestationPropagationTime: z.number().optional(),
     skipCollectingAttestations: z.boolean().optional(),
     skipInvalidateBlockAsProposer: z.boolean().optional(),
+    skipWaitForValidParentCheckpointOnL1: z.boolean().optional(),
     secondsBeforeInvalidatingBlockAsCommitteeMember: z.number(),
     secondsBeforeInvalidatingBlockAsNonCommitteeMember: z.number(),
     broadcastInvalidBlockProposal: z.boolean().optional(),


### PR DESCRIPTION
## Motivation

`archiver/src/modules/l1_synchronizer.ts` skipped checkpoints with insufficient/invalid attestations under the assumption that the next proposer would invalidate them before publishing. When that assumption was violated — i.e., proposer P2 published a valid-attestations checkpoint that extended P1's invalid one — the archiver hit `InitialCheckpointNumberNotSequentialError` in `block_store.addCheckpoints`, the catch handler rolled back the L1 sync point, and the next poll re-fetched the same range and re-threw. The archiver looped indefinitely. The protocol already defines `OffenseType.PROPOSED_DESCENDANT_OF_CHECKPOINT_WITH_INVALID_ATTESTATIONS` for exactly this case but the slasher couldn't see valid-attestations descendants because the archiver threw before emitting any event.

### Human Note

This is particularly relevant under pipelining. Attestors now attest to a checkpoint _before_ the previous one is pushed to L1, so they can be inadvertently attesting to a checkpoint built on top of one that became invalid as it was published to the rollup the contract with wrong attestations. So an honest attestor could get slashed if the proposer was malicious.

## Approach

In the synchronizer, persist rejected ancestors in the block store keyed by archive root. On each new checkpoint, before attestation validation, compare its `header.lastArchiveRoot` against the persisted set — if it matches, skip the checkpoint as a descendant of an invalid ancestor and emit a new `L2BlockSourceEvents.CheckpointBuiltOnInvalidAncestorDetected` event with enough metadata to resolve the proposer. The slasher's `AttestationsBlockWatcher` is fixed to slash the proposer (not the attestors) under the new event.

Fixes A-1072