### PR TITLE
fix: stale detector

### DIFF
--- a/yarn-project/aztec.js/src/deployment/publish_instance.ts
+++ b/yarn-project/aztec.js/src/deployment/publish_instance.ts
@@ -18,7 +18,7 @@ export function publishInstance(wallet: Wallet, instance: ContractInstanceWithAd
     contractClassId,
     instance.initializationHash,
     instance.immutablesHash,
-    publicKeys.toNoirStruct(),
+    publicKeys,
     isUniversalDeploy,
   );
 }

--- a/yarn-project/stdlib/src/abi/utils.ts
+++ b/yarn-project/stdlib/src/abi/utils.ts
@@ -59,10 +59,10 @@ export function isPublicKeysStruct(abiType: AbiType) {
     abiType.kind === 'struct' &&
     abiType.path === 'aztec::protocol_types::public_keys::PublicKeys' &&
     abiType.fields.length === 4 &&
-    abiType.fields[0].name === 'npk_m' &&
+    abiType.fields[0].name === 'npk_m_hash' &&
     abiType.fields[1].name === 'ivpk_m' &&
-    abiType.fields[2].name === 'ovpk_m' &&
-    abiType.fields[3].name === 'tpk_m'
+    abiType.fields[2].name === 'ovpk_m_hash' &&
+    abiType.fields[3].name === 'tpk_m_hash'
   );
 }
 


### PR DESCRIPTION
Updating the detector code as part of the azip-8 pr so we don't have to use `toNoirStruct`