### PR TITLE
fix(test): wire proper L1 contracts config

### DIFF
--- a/yarn-project/archiver/src/factory.ts
+++ b/yarn-project/archiver/src/factory.ts
@@ -89,6 +89,8 @@ export async function createArchiver(
     l1StartBlock,
     l1GenesisTime,
     proofSubmissionEpochs,
+    epochDuration,
+    slotDuration,
     genesisArchiveRoot,
     slashingProposerAddress,
     targetCommitteeSize,
@@ -97,6 +99,8 @@ export async function createArchiver(
     rollup.getL1StartBlock(),
     rollup.getL1GenesisTime(),
     rollup.getProofSubmissionEpochs(),
+    rollup.getEpochDuration(),
+    rollup.getSlotDuration(),
     rollup.getGenesisArchiveTreeRoot(),
     rollup.getSlashingProposerAddress(),
     rollup.getTargetCommitteeSize(),
@@ -107,7 +111,7 @@ export async function createArchiver(
     .getBlock({ blockNumber: l1StartBlock, includeTransactions: false })
     .then(block => Buffer32.fromString(block.hash));
 
-  const { aztecEpochDuration: epochDuration, aztecSlotDuration: slotDuration, ethereumSlotDuration } = config;
+  const { ethereumSlotDuration } = config;
 
   const l1Constants = {
     l1StartBlockHash,

--- a/yarn-project/aztec/src/local-network/local-network.ts
+++ b/yarn-project/aztec/src/local-network/local-network.ts
@@ -8,7 +8,7 @@ import { type BlobClientInterface, createBlobClient } from '@aztec/blob-client/c
 import { GENESIS_ARCHIVE_ROOT } from '@aztec/constants';
 import { createEthereumChain } from '@aztec/ethereum/chain';
 import { waitForPublicClient } from '@aztec/ethereum/client';
-import { getL1ContractsConfigEnvVars } from '@aztec/ethereum/config';
+import { type L1ContractsConfig, getL1ContractsConfigEnvVars, l1ContractsConfigMappings } from '@aztec/ethereum/config';
 import { NULL_KEY } from '@aztec/ethereum/constants';
 import { deployAztecL1Contracts } from '@aztec/ethereum/deploy-aztec-l1-contracts';
 import type { L1ContractAddresses } from '@aztec/ethereum/l1-contract-addresses';
@@ -63,18 +63,27 @@ export async function deployContractsToL1(
 ): Promise<L1ContractAddresses> {
   await waitForPublicClient(aztecNodeConfig);
 
-  const l1Contracts = await deployAztecL1Contracts(aztecNodeConfig.l1RpcUrls[0], privateKey, foundry.id, {
+  const l1ContractsConfig = {
     ...getL1ContractsConfigEnvVars(), // TODO: We should not need to be loading config from env again, caller should handle this
     ...aztecNodeConfig,
+    aztecTargetCommitteeSize: 0, // no committee in local network
+    slasherEnabled: false, // no slashing in local network
+  };
+
+  const l1Contracts = await deployAztecL1Contracts(aztecNodeConfig.l1RpcUrls[0], privateKey, foundry.id, {
+    ...l1ContractsConfig,
     vkTreeRoot: getVKTreeRoot(),
     protocolContractsHash,
     genesisArchiveRoot: opts.genesisArchiveRoot ?? new Fr(GENESIS_ARCHIVE_ROOT),
     feeJuicePortalInitialBalance: opts.feeJuicePortalInitialBalance,
-    aztecTargetCommitteeSize: 0, // no committee in local network
-    slasherEnabled: false, // no slashing in local network
     realVerifier: false,
   });
 
+  const l1ConfigEntries = Object.keys(l1ContractsConfigMappings).map(key => [
+    key,
+    l1ContractsConfig[key as keyof L1ContractsConfig],
+  ]);
+  Object.assign(aztecNodeConfig, Object.fromEntries(l1ConfigEntries));
   Object.assign(aztecNodeConfig, l1Contracts.l1ContractAddresses);
   aztecNodeConfig.rollupVersion = l1Contracts.rollupVersion;
 

--- a/yarn-project/end-to-end/src/fixtures/setup.ts
+++ b/yarn-project/end-to-end/src/fixtures/setup.ts
@@ -21,7 +21,7 @@ import { AnvilTestWatcher, type AnvilTestWatcherOpts, CheatCodes } from '@aztec/
 import { SPONSORED_FPC_SALT } from '@aztec/constants';
 import { isAnvilTestChain } from '@aztec/ethereum/chain';
 import { createExtendedL1Client } from '@aztec/ethereum/client';
-import { getL1ContractsConfigEnvVars } from '@aztec/ethereum/config';
+import { type L1ContractsConfig, getL1ContractsConfigEnvVars, l1ContractsConfigMappings } from '@aztec/ethereum/config';
 import { NULL_KEY } from '@aztec/ethereum/constants';
 import { deployMulticall3 } from '@aztec/ethereum/contracts';
 import {
@@ -440,14 +440,18 @@ export async function setup(
     // This is necessary because deployMulticall3 sends multiple transactions and viem may cache a stale nonce
     await l1Client.getTransactionCount({ address: l1Client.account.address });
 
+    const l1ContractsConfig = {
+      ...getL1ContractsConfigEnvVars(),
+      ...opts,
+      ...opts.l1ContractsArgs,
+    };
+
     const deployL1ContractsValues: DeployAztecL1ContractsReturnType = await deployAztecL1Contracts(
       config.l1RpcUrls[0],
       publisherPrivKeyHex!,
       chain.id,
       {
-        ...getL1ContractsConfigEnvVars(),
-        ...opts,
-        ...opts.l1ContractsArgs,
+        ...l1ContractsConfig,
         vkTreeRoot: getVKTreeRoot(),
         protocolContractsHash,
         genesisArchiveRoot,
@@ -457,6 +461,11 @@ export async function setup(
       },
     );
 
+    const l1ConfigEntries = Object.keys(l1ContractsConfigMappings).map(key => [
+      key,
+      l1ContractsConfig[key as keyof L1ContractsConfig],
+    ]);
+    Object.assign(config, Object.fromEntries(l1ConfigEntries));
     Object.assign(config, deployL1ContractsValues.l1ContractAddresses);
     config.rollupVersion = deployL1ContractsValues.rollupVersion;
 


### PR DESCRIPTION
It seems some services were getting stale L1 contracts config. For instance, the archiver of the first node was getting the default epoch duration as opposed to the one defined on the test, breaking checks.