### PR TITLE
fix(bb): cap WitnessMap index to prevent OOM-DoS in ACIR deserialization

### DIFF
--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_to_constraint_buf.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_to_constraint_buf.cpp
@@ -27,7 +27,8 @@ namespace acir_format {
 
 using namespace bb;
 
-/// ========= HELPERS ========= ///
+// Cap on `WitnessMap` indices: bounds the gap-fill allocation in `witness_map_to_witness_vector`.
+static constexpr uint32_t MAX_WITNESS_INDEX = 1U << 28;
 
 template <class... Ts> struct overloaded : Ts... {
     using Ts::operator()...;
@@ -430,6 +431,15 @@ WitnessVector witness_map_to_witness_vector(Witnesses::WitnessMap const& witness
 {
     // Note that the WitnessMap is in increasing order of witness indices because the comparator for the Acir::Witness
     // is defined in terms of the witness index.
+
+    if (!witness_map.value.empty()) {
+        const uint32_t max_index = witness_map.value.rbegin()->first.value;
+        if (max_index > MAX_WITNESS_INDEX) {
+            throw_or_abort("acir_format::witness_map_to_witness_vector: witness index " +
+                           std::to_string(max_index) + " exceeds the maximum allowed (" +
+                           std::to_string(MAX_WITNESS_INDEX) + ").");
+        }
+    }
 
     WitnessVector witness_vector;
     for (size_t index = 0; const auto& e : witness_map.value) {

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/witness_map_dos.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/witness_map_dos.test.cpp
@@ -1,0 +1,58 @@
+// Regression tests for the witness-index cap in `witness_map_to_witness_vector`.
+// Without it, a crafted `WitnessMap{{Witness{UINT32_MAX}, ...}}` forces ~2^32 `fr`
+// allocations (~137 GB) via the gap-fill loop.
+
+#include <gtest/gtest.h>
+#include <vector>
+
+#include "acir_to_constraint_buf.hpp"
+#include "barretenberg/common/assert.hpp"
+#include "barretenberg/ecc/curves/bn254/fr.hpp"
+#include "serde/witness_stack.hpp"
+
+using namespace acir_format;
+
+class WitnessMapDoSTest : public ::testing::Test {};
+
+static std::vector<uint8_t> encoded_zero_fr()
+{
+    std::vector<uint8_t> buf(32, 0);
+    return buf;
+}
+
+TEST_F(WitnessMapDoSTest, RejectsUint32MaxWitnessIndex)
+{
+    Witnesses::WitnessMap witness_map;
+    witness_map.value.emplace(Witnesses::Witness{ UINT32_MAX }, encoded_zero_fr());
+
+    EXPECT_THROW_WITH_MESSAGE(witness_map_to_witness_vector(witness_map), "exceeds the maximum allowed");
+}
+
+TEST_F(WitnessMapDoSTest, RejectsIndexJustOverCap)
+{
+    // Mirrors the file-local constant in acir_to_constraint_buf.cpp; keep in sync.
+    constexpr uint32_t MAX_WITNESS_INDEX = 1U << 28;
+
+    Witnesses::WitnessMap witness_map;
+    witness_map.value.emplace(Witnesses::Witness{ MAX_WITNESS_INDEX + 1U }, encoded_zero_fr());
+
+    EXPECT_THROW_WITH_MESSAGE(witness_map_to_witness_vector(witness_map), "exceeds the maximum allowed");
+}
+
+TEST_F(WitnessMapDoSTest, AcceptsRealisticIndex)
+{
+    Witnesses::WitnessMap witness_map;
+    witness_map.value.emplace(Witnesses::Witness{ 0U }, encoded_zero_fr());
+    witness_map.value.emplace(Witnesses::Witness{ 5U }, encoded_zero_fr());
+    witness_map.value.emplace(Witnesses::Witness{ 1023U }, encoded_zero_fr());
+
+    auto witness_vector = witness_map_to_witness_vector(witness_map);
+    EXPECT_EQ(witness_vector.size(), 1024U);
+}
+
+TEST_F(WitnessMapDoSTest, AcceptsEmptyMap)
+{
+    Witnesses::WitnessMap witness_map;
+    auto witness_vector = witness_map_to_witness_vector(witness_map);
+    EXPECT_EQ(witness_vector.size(), 0U);
+}


### PR DESCRIPTION
Crafted msgpack with a single witness entry at index 0xFFFFFFFF makes `witness_map_to_witness_vector` allocate ~137 GB filling the gap. Caps the max witness index at 2^28 (~32× the largest realistic circuit) and rejects oversized maps with throw_or_abort.  

Reachable via ChonkAccumulate / CircuitProve on bbapi, anything that hosts bb for an external witness buffer (sequencer, prover node, PXE service) gets one-shot OOM'd today.  

Test in witness_map_dos.test.cpp covers the exploit, the boundary, the empty case, and confirms the gap-fill still works for legitimate sparse maps.