### PR TITLE
fix(bb): cap max_witness_index during circuit deserialization to prevent OOM-DoS

### DIFF
--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_to_constraint_buf.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_to_constraint_buf.cpp
@@ -71,6 +71,13 @@ uint32_t get_witness_from_function_input(const Acir::FunctionInput& input)
 void update_max_witness_index(const uint32_t witness_idx, AcirFormat& af)
 {
     if (witness_idx != stdlib::IS_CONSTANT) {
+        // Cap witness index to prevent OOM-DoS via crafted circuit opcodes referencing
+        // extremely large indices. Same bound as witness_map_to_witness_vector (2^28).
+        static constexpr uint32_t MAX_WITNESS_INDEX = 1U << 28;
+        BB_ASSERT_LTE(witness_idx,
+                      MAX_WITNESS_INDEX,
+                      "acir_format::update_max_witness_index: witness index exceeds maximum (" +
+                          std::to_string(MAX_WITNESS_INDEX) + "), got " + std::to_string(witness_idx));
         af.max_witness_index = std::max(af.max_witness_index, witness_idx);
     }
 }


### PR DESCRIPTION
## Description

Companion fix to #23545 — while that PR caps the witness *map* index at 2^28 during `witness_map_to_witness_vector`, the circuit deserialization path via `update_max_witness_index` does **not** enforce any upper bound on witness indices parsed from ACIR opcodes.

A crafted circuit binary with opcodes referencing witness index near `UINT32_MAX` would still trigger unbounded allocation when `witness_map_to_witness_vector` later constructs the witness vector using `af.max_witness_index`.

### Changes

Added a bounds check in `update_max_witness_index()` to reject any witness index exceeding `MAX_WITNESS_INDEX` (2^28, ~268M — same constant as #23545). This provides defense-in-depth against OOM-DoS via the circuit deserialization path.

### Motivation

Without this fix, the protection added in #23545 can be bypassed by supplying a valid (small) witness map but a circuit with opcodes that reference absurdly large witness indices. The current code would accept these indices into `af.max_witness_index`, which is later used to size allocations.

### Testing

- Existing tests pass (the constant is 32× the largest realistic circuit)
- Follows the same pattern and threshold as #23545

### Impact

Security hardening — prevents OOM denial-of-service via crafted ACIR circuit input. Should be backported alongside #23545.