### PR TITLE
test(ws): await close promise in native world state test

### DIFF
--- a/yarn-project/world-state/src/native/native_world_state.test.ts
+++ b/yarn-project/world-state/src/native/native_world_state.test.ts
@@ -961,6 +961,9 @@ describe('NativeWorldState', () => {
       await expect(delayedFork.getSiblingPath(MerkleTreeId.NULLIFIER_TREE, 0n)).rejects.toThrow('Fork not found');
 
       await sleep(closeDelayMs * 3);
+      const closePromise = (delayedFork as any).closePromise;
+      expect(closePromise).toBeDefined();
+      await closePromise;
 
       expect(warnSpy).not.toHaveBeenCalled();
       expect((ws as any).instance.queues.has(forkId)).toBe(false);


### PR DESCRIPTION
Tackles flake at [this run](http://ci.aztec-labs.com/f68773618307b3a1) by awaiting the close promise on the fork.

```
22:00:44   ● NativeWorldState › Pending and Proven chain › does not fail when a delayed-close fork is destroyed by a reorg before its close fires
22:00:44
22:00:44     expect(received).toBe(expected) // Object.is equality
22:00:44
22:00:44     Expected: false
22:00:44     Received: true
22:00:44
22:00:44       964 |
22:00:44       965 |       expect(warnSpy).not.toHaveBeenCalled();
22:00:44     > 966 |       expect((ws as any).instance.queues.has(forkId)).toBe(false);
22:00:44           |                                                       ^
22:00:44       967 |     });
22:00:44       968 |   });
22:00:44       969 |
22:00:44
22:00:44       at Object.toBe (native/native_world_state.test.ts:966:55)
```