### PR TITLE
chore: Fix old snapshots, nargo fmt

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/macros/aztec.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/aztec.nr
@@ -157,8 +157,11 @@ pub comptime fn aztec(m: Module, args: [AztecConfig]) -> Quoted {
         Option::none()
     };
 
-    let sync_state_fn_and_abi_export =
-        generate_sync_state(process_custom_message_option, offchain_inbox_sync_option, custom_sync_handler);
+    let sync_state_fn_and_abi_export = generate_sync_state(
+        process_custom_message_option,
+        offchain_inbox_sync_option,
+        custom_sync_handler,
+    );
 
     if m.functions().any(|f| f.name() == quote { offchain_receive }) {
         panic(

--- a/noir-projects/aztec-nr/aztec/src/messages/discovery/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/discovery/mod.nr
@@ -112,13 +112,12 @@ pub type CustomMessageHandler = unconstrained fn(
 /// this handler instead of [`do_sync_state`]. It receives all of the same parameters, so it can run custom logic
 /// (e.g. fetching and decrypting custom logs) before, after, or instead of calling [`do_sync_state`].
 pub type CustomSyncHandler = unconstrained fn(
-    /* contract_address */ AztecAddress,
-    /* compute_note_hash */ ComputeNoteHash,
-    /* compute_note_nullifier */ ComputeNoteNullifier,
-    /* process_custom_message */ Option<CustomMessageHandler>,
-    /* offchain_inbox_sync */ Option<OffchainInboxSync>,
-    /* scope */ AztecAddress,
-);
+/* contract_address */AztecAddress,
+/* compute_note_hash */ ComputeNoteHash,
+/* compute_note_nullifier */ ComputeNoteNullifier,
+/* process_custom_message */ Option<CustomMessageHandler>,
+/* offchain_inbox_sync */ Option<OffchainInboxSync>,
+/* scope */ AztecAddress);
 
 /// Synchronizes the contract's private state with the network.
 ///

--- a/noir-projects/aztec-nr/aztec/src/messages/discovery/partial_notes.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/discovery/partial_notes.nr
@@ -108,10 +108,7 @@ pub(crate) unconstrained fn fetch_and_process_partial_note_completion_logs(
             // searching for this tagged log when performing message discovery in the future until we either find it or
             // the entry is somehow removed from the array.
         } else {
-            assert(
-                num_logs == 1,
-                f"Expected at most 1 completion log per partial note, got {num_logs}",
-            );
+            assert(num_logs == 1, f"Expected at most 1 completion log per partial note, got {num_logs}");
 
             aztecnr_debug_log_format!("Completion log found for partial note with tag {}")([
                 pending_partial_note.note_completion_log_tag,

--- a/noir-projects/aztec-nr/aztec/src/messages/processing/log_retrieval_request.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/processing/log_retrieval_request.nr
@@ -6,8 +6,7 @@ pub(crate) struct LogSourceEnum {
     pub PUBLIC_AND_PRIVATE: Field,
 }
 
-pub(crate) global LogSource: LogSourceEnum =
-    LogSourceEnum { PRIVATE: 0, PUBLIC: 1, PUBLIC_AND_PRIVATE: 2 };
+pub(crate) global LogSource: LogSourceEnum = LogSourceEnum { PRIVATE: 0, PUBLIC: 1, PUBLIC_AND_PRIVATE: 2 };
 
 /// A request for the `bulk_retrieve_logs` oracle to fetch all logs matching a tag.
 #[derive(Serialize)]

--- a/noir-projects/aztec-nr/aztec/src/messages/processing/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/processing/mod.nr
@@ -19,10 +19,7 @@ use crate::{
         discovery::partial_notes::DeliveredPendingPartialNote,
         encoding::MESSAGE_CIPHERTEXT_LEN,
         logs::{event::MAX_EVENT_SERIALIZED_LEN, note::MAX_NOTE_PACKED_LEN},
-        processing::{
-            log_retrieval_request::LogRetrievalRequest,
-            log_retrieval_response::LogRetrievalResponse,
-        },
+        processing::{log_retrieval_request::LogRetrievalRequest, log_retrieval_response::LogRetrievalResponse},
     },
     oracle::message_processing,
 };

--- a/noir-projects/aztec-nr/aztec/src/oracle/message_processing.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/message_processing.nr
@@ -1,8 +1,8 @@
 use crate::ephemeral::EphemeralArray;
 use crate::messages::processing::{
-    event_validation_request::EventValidationRequest,
-    log_retrieval_request::LogRetrievalRequest, log_retrieval_response::LogRetrievalResponse, MessageContext,
-    NoteValidationRequest, pending_tagged_log::PendingTaggedLog,
+    event_validation_request::EventValidationRequest, log_retrieval_request::LogRetrievalRequest,
+    log_retrieval_response::LogRetrievalResponse, MessageContext, NoteValidationRequest,
+    pending_tagged_log::PendingTaggedLog,
 };
 use crate::protocol::address::AztecAddress;
 use crate::protocol::blob_data::TxEffect;

--- a/noir-projects/noir-contracts/contracts/test/custom_sync_state_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/custom_sync_state_contract/src/main.nr
@@ -2,24 +2,21 @@
 // sync_state is called and then forwards to do_sync_state.
 mod test;
 
+use ::aztec::macros::aztec;
 use ::aztec::{
-    messages::discovery::{
-        ComputeNoteHash, ComputeNoteNullifier, CustomMessageHandler, do_sync_state,
+    messages::{
+        discovery::{ComputeNoteHash, ComputeNoteNullifier, CustomMessageHandler, do_sync_state},
+        processing::offchain::OffchainInboxSync,
     },
-    messages::processing::offchain::OffchainInboxSync,
     oracle::capsules,
     protocol::{address::AztecAddress, hash::sha256_to_field},
 };
-use ::aztec::macros::aztec;
 
 global SYNC_COUNTER_SLOT: Field = sha256_to_field("SYNC_COUNTER".as_bytes());
 
 #[aztec(::aztec::macros::AztecConfig::new().custom_sync_state(crate::my_custom_sync))]
 contract CustomSyncState {
-    use aztec::macros::{
-        functions::{external, initializer},
-        storage::storage,
-    };
+    use aztec::macros::{functions::{external, initializer}, storage::storage};
     use aztec::messages::message_delivery::MessageDelivery;
     use aztec::protocol::address::AztecAddress;
     use aztec::state_vars::{Owned, PrivateImmutable};
@@ -34,9 +31,7 @@ contract CustomSyncState {
     #[initializer]
     fn constructor(owner: AztecAddress, value: Field) {
         let note = FieldNote { value };
-        self.storage.value.at(owner).initialize(note).deliver(
-            MessageDelivery.ONCHAIN_UNCONSTRAINED,
-        );
+        self.storage.value.at(owner).initialize(note).deliver(MessageDelivery.ONCHAIN_UNCONSTRAINED);
     }
 
     #[external("utility")]
@@ -55,8 +50,7 @@ unconstrained fn my_custom_sync(
     offchain_inbox_sync: Option<OffchainInboxSync>,
     scope: AztecAddress,
 ) {
-    let current: Option<Field> =
-        capsules::load(contract_address, crate::SYNC_COUNTER_SLOT, scope);
+    let current: Option<Field> = capsules::load(contract_address, crate::SYNC_COUNTER_SLOT, scope);
     let new_count = current.map(|c| c + 1).unwrap_or(1);
     capsules::store(contract_address, crate::SYNC_COUNTER_SLOT, new_count, scope);
     do_sync_state(

--- a/noir-projects/noir-contracts/contracts/test/custom_sync_state_contract/src/test.nr
+++ b/noir-projects/noir-contracts/contracts/test/custom_sync_state_contract/src/test.nr
@@ -29,14 +29,9 @@ unconstrained fn test_custom_sync_hook_is_called() {
     assert_eq(result, value);
 }
 
-unconstrained fn get_sync_count(
-    env: TestEnvironment,
-    contract_address: AztecAddress,
-    scope: AztecAddress,
-) -> Field {
+unconstrained fn get_sync_count(env: TestEnvironment, contract_address: AztecAddress, scope: AztecAddress) -> Field {
     env.utility_context_at(contract_address, |_| {
-        let count: Option<Field> =
-            capsules::load(contract_address, crate::SYNC_COUNTER_SLOT, scope);
+        let count: Option<Field> = capsules::load(contract_address, crate::SYNC_COUNTER_SLOT, scope);
         count.unwrap_or(0)
     })
 }

--- a/yarn-project/foundation/src/curves/bls12/point.test.ts
+++ b/yarn-project/foundation/src/curves/bls12/point.test.ts
@@ -165,7 +165,7 @@ describe('BLS12Point', () => {
 
     // Run with AZTEC_GENERATE_TEST_DATA=1 to update noir test data
     updateInlineTestData(
-      'noir-projects/noir-protocol-circuits/crates/blob/src/blob_batching_public_inputs.nr',
+      'noir-projects/noir-protocol-circuits/crates/blob/src/utils/compress_to_blob_commitment.nr',
       'expected_compressed_point_greater',
       byteArrayString,
     );
@@ -188,7 +188,7 @@ describe('BLS12Point', () => {
 
     // Run with AZTEC_GENERATE_TEST_DATA=1 to update noir test data
     updateInlineTestData(
-      'noir-projects/noir-protocol-circuits/crates/blob/src/blob_batching_public_inputs.nr',
+      'noir-projects/noir-protocol-circuits/crates/blob/src/utils/compress_to_blob_commitment.nr',
       'expected_compressed_point_not_greater',
       byteArrayString,
     );

--- a/yarn-project/foundation/src/curves/grumpkin/point.test.ts
+++ b/yarn-project/foundation/src/curves/grumpkin/point.test.ts
@@ -1,5 +1,4 @@
 import { jsonParseWithSchema, jsonStringify } from '../../json-rpc/convert.js';
-import { updateInlineTestData } from '../../testing/files/index.js';
 import { Fr } from '../bn254/field.js';
 import { Point } from './point.js';
 
@@ -46,46 +45,6 @@ describe('Point', () => {
     const p2 = await Point.fromCompressedBuffer(p.toCompressedBuffer());
 
     expect(p.equals(p2)).toBeTruthy();
-  });
-
-  it('compressed point with + sign matches Noir', () => {
-    const p = new Point(
-      new Fr(0x1af41f5de96446dc3776a1eb2d98bb956b7acd9979a67854bec6fa7c2973bd73n),
-      new Fr(0x07fc22c7f2c7057571f137fe46ea9c95114282bc95d37d71ec4bfb88de457d4an),
-    );
-    expect(p.toXAndSign()[1]).toBe(true);
-
-    const compressed = p.toCompressedBuffer().toString('hex');
-    expect(compressed).toMatchInlineSnapshot(`"9af41f5de96446dc3776a1eb2d98bb956b7acd9979a67854bec6fa7c2973bd73"`);
-
-    const byteArrayString = `[${compressed.match(/.{1,2}/g)!.map(byte => parseInt(byte, 16))}]`;
-
-    // Run with AZTEC_GENERATE_TEST_DATA=1 to update noir test data
-    updateInlineTestData(
-      'noir-projects/aztec-nr/aztec/src/utils/point.nr',
-      'expected_compressed_point_positive_sign',
-      byteArrayString,
-    );
-  });
-
-  it('compressed point with - sign matches Noir', () => {
-    const p = new Point(
-      new Fr(0x247371652e55dd74c9af8dbe9fb44931ba29a9229994384bd7077796c14ee2b5n),
-      new Fr(0x26441aec112e1ae4cee374f42556932001507ad46e255ffb27369c7e3766e5c0n),
-    );
-    expect(p.toXAndSign()[1]).toBe(false);
-
-    const compressed = p.toCompressedBuffer().toString('hex');
-    expect(compressed).toMatchInlineSnapshot(`"247371652e55dd74c9af8dbe9fb44931ba29a9229994384bd7077796c14ee2b5"`);
-
-    const byteArrayString = `[${compressed.match(/.{1,2}/g)!.map(byte => parseInt(byte, 16))}]`;
-
-    // Run with AZTEC_GENERATE_TEST_DATA=1 to update noir test data
-    updateInlineTestData(
-      'noir-projects/aztec-nr/aztec/src/utils/point.nr',
-      'expected_compressed_point_negative_sign',
-      byteArrayString,
-    );
   });
 
   it('serializes from and to JSON', async () => {


### PR DESCRIPTION
### Summary

Hopefully not just me - had some build failures due to unformatted `nr` code, so ran `nargo fmt`.

Also found that the `point` tests used old fixtures which either don't exist or have been moved.

Happy to target a train if that's better!
