### PR TITLE
test: fix web3signer pipelining `e2e_multi_validator_node_key_store.test.ts`

### DIFF
--- a/.test_patterns.yml
+++ b/.test_patterns.yml
@@ -379,20 +379,6 @@ tests:
     owners:
       - *spyros
 
-  # Multi-validator web3signer suite is unstable under proposer pipelining:
-  # two distinct failure modes have been seen in the same "should build blocks
-  # & attest with multiple validator keys" case — Promise.all index-0
-  # waitForTx aborting with "Tx dropped by P2P node"
-  # (ci.aztec-labs.com/9a5fa90aa18f62e7), and the proposer missing the slot's
-  # 5-attestation deadline ("AttestationTimeoutError" / "Block .* not found .*
-  # reorg") on PR #23344 run 26370196367 (ci.aztec-labs.com/b91d3218b5e88ae4).
-  # Error-regex flake matches still let ci3 retry-and-fail both attempts. Skip
-  # outright on merge-train/spartan until proposer pipelining stabilises.
-  - regex: "yarn-project/end-to-end/scripts/run_test.sh web3signer src/composed/web3signer/e2e_multi_validator_node_key_store.test.ts"
-    skip: true
-    owners:
-      - *palla
-
   # http://ci.aztec-labs.com/98d59d04f85223f8
   # Build-cache flake: module not found during Jest startup
   - regex: "src/e2e_sequencer/gov_proposal.parallel.test.ts"

--- a/yarn-project/end-to-end/src/composed/web3signer/e2e_multi_validator_node_key_store.test.ts
+++ b/yarn-project/end-to-end/src/composed/web3signer/e2e_multi_validator_node_key_store.test.ts
@@ -284,21 +284,24 @@ describe('e2e_multi_validator_node', () => {
       deployL1ContractsValues,
       aztecNode,
       sequencer: sequencerClient,
-    } = await setup(1, {
-      ...PIPELINING_SETUP_OPTS,
-      initialValidators,
-      aztecTargetCommitteeSize: COMMITTEE_SIZE,
-      keyStoreDirectory,
-      minTxsPerBlock: 1,
-      maxTxsPerBlock: 1,
-      archiverPollingIntervalMS: 200,
-      sequencerPollingIntervalMS: 200,
-      worldStateBlockCheckIntervalMS: 200,
-      blockCheckIntervalMS: 200,
-      startProverNode: true,
-      aztecEpochDuration: 8,
-      aztecProofSubmissionEpochs: 4,
-    }));
+    } = await setup(
+      1,
+      {
+        ...PIPELINING_SETUP_OPTS,
+        initialValidators,
+        aztecTargetCommitteeSize: COMMITTEE_SIZE,
+        keyStoreDirectory,
+        maxTxsPerBlock: 1,
+        archiverPollingIntervalMS: 200,
+        sequencerPollingIntervalMS: 200,
+        worldStateBlockCheckIntervalMS: 200,
+        blockCheckIntervalMS: 200,
+        startProverNode: true,
+        aztecEpochDuration: 8,
+        aztecProofSubmissionEpochs: 4,
+      },
+      { syncChainTip: 'checkpointed' },
+    ));
 
     sequencer = (sequencerClient! as TestSequencerClient).getSequencer();
     publisherFactory = (sequencer as TestSequencer).publisherFactory;


### PR DESCRIPTION
Fix web3signer e2e `e2e_multi_validator_node_key_store.test.ts` by removing the minTxsPerBlock override so the pipelining preset can publish empty checkpoints while txs arrive. Also anchors the test PXE to the checkpointed chain tip to prevent checkpoint prunes from killing sent txs.