### PR TITLE
test(e2e): wait for checkpoint before sentinel assertions in `e2e_p2p_multiple_validators_sentinel`

### DIFF
--- a/yarn-project/end-to-end/src/e2e_p2p/multiple_validators_sentinel.parallel.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/multiple_validators_sentinel.parallel.test.ts
@@ -104,20 +104,32 @@ describe('e2e_p2p_multiple_validators_sentinel', () => {
     }
   });
 
-  it('collects attestations for all validators on a node', async () => {
-    // Ensure all nodes see each other, especially the sentinel, before starting slot counting
-    await t.waitForP2PMeshConnectivity([...nodes, sentinel]);
-
-    // Wait until validator nodes have advanced past their first proposed slot so that the
-    // pipelining warm-up period (where some attestations may be missed) is behind us.
+  const waitForPostWarmupCheckpoint = async (action: string): Promise<void> => {
     await t.monitor.run();
     const warmupSlot = Number(t.monitor.l2SlotNumber) + 1;
-    t.logger.info(`Waiting for warmup slot ${warmupSlot} before establishing initial slot`);
+    t.logger.info(`Waiting for warmup slot ${warmupSlot} before ${action}`);
     await retryUntil(
       async () => (await t.monitor.run()).l2SlotNumber >= warmupSlot,
       'warmup slot',
       AZTEC_SLOT_DURATION * 3,
     );
+
+    const warmupCheckpoint = t.monitor.checkpointNumber;
+    t.logger.info(`Waiting for checkpoint after warmup before ${action}`, { warmupCheckpoint });
+    await retryUntil(
+      async () => (await t.monitor.run()).checkpointNumber > warmupCheckpoint,
+      'post-warmup checkpoint',
+      AZTEC_SLOT_DURATION * (SLOT_COUNT + 1) * 3,
+    );
+  };
+
+  it('collects attestations for all validators on a node', async () => {
+    // Ensure all nodes see each other, especially the sentinel, before starting slot counting
+    await t.waitForP2PMeshConnectivity([...nodes, sentinel]);
+
+    // Wait until validator nodes have advanced past their first proposed slot and landed a checkpoint so that the
+    // pipelining warm-up period (where some attestations may be missed) is behind us.
+    await waitForPostWarmupCheckpoint('establishing initial slot');
 
     const { checkpointNumber: initialBlock, l2SlotNumber: initialSlot } = t.monitor;
 
@@ -155,6 +167,8 @@ describe('e2e_p2p_multiple_validators_sentinel', () => {
   it('collects attestations for validators in proposer node when block is not published', async () => {
     // Ensure all nodes see each other, especially the sentinel
     await t.waitForP2PMeshConnectivity([...nodes, sentinel]);
+
+    await waitForPostWarmupCheckpoint('stopping a validator node and establishing initial slot');
 
     // Stop the second node, this means the first node won't be able to propose since won't achieve quorum
     await tryStop(nodes[1]);


### PR DESCRIPTION
## Summary

- Stabilizes the multiple-validator sentinel e2e by waiting for a post-warmup checkpoint before recording the assertion window.
- Reuses the same warm-up helper in the second test so isolated runs avoid the same fresh-network startup noise before stopping a validator.

## Failed run

Failed CI run: http://ci.aztec-labs.com/07fb31bc0706159f

The failing test was `e2e_p2p_multiple_validators_sentinel > collects attestations for all validators on a node`. The test expected no `attestation-missed` entries, but the assertion window started while the network was still in the first pipelined slots after startup. In the failed run, slot 8 was built on a pending, not-yet-checkpointed parent, so some remote validators could not validate/attest in time and the sentinel recorded a missed attestation.

## Fix

The test now waits for one warm-up slot and then waits for the observed checkpoint number to advance before capturing `initialSlot`. That keeps startup pipelining behavior out of the strict sentinel assertion window while preserving the test's actual coverage: once the network is past warm-up, every validator should be observed attesting or proposing as expected.

## Verification

- `yarn format end-to-end`
- `yarn build`
- `yarn workspace @aztec/end-to-end test:e2e e2e_p2p/multiple_validators_sentinel.parallel.test.ts -t 'collects attestations for all validators on a node'`