### PR TITLE
test(e2e): invalidate and republish checkpoint on the same slot

### DIFF
--- a/yarn-project/archiver/src/index.ts
+++ b/yarn-project/archiver/src/index.ts
@@ -27,3 +27,4 @@ export { L2TipsCache } from './store/l2_tips_cache.js';
 
 export { retrieveL2ProofVerifiedEvents } from './l1/data_retrieval.js';
 export { CalldataRetriever } from './l1/calldata_retriever.js';
+export { validateCheckpointAttestations } from './modules/validation.js';

--- a/yarn-project/archiver/src/modules/validation.ts
+++ b/yarn-project/archiver/src/modules/validation.ts
@@ -19,7 +19,7 @@ export type { ValidateCheckpointResult };
  * Returns info for each attestation, preserving array indices.
  */
 export function getAttestationInfoFromPublishedCheckpoint(
-  { checkpoint, attestations }: PublishedCheckpoint,
+  { checkpoint, attestations }: Pick<PublishedCheckpoint, 'checkpoint' | 'attestations'>,
   signatureContext: CoordinationSignatureContext,
 ): AttestationInfo[] {
   const payload = ConsensusPayload.fromCheckpoint(checkpoint, signatureContext);
@@ -31,7 +31,7 @@ export function getAttestationInfoFromPublishedCheckpoint(
  * Returns true if the attestations are valid and sufficient, false otherwise.
  */
 export async function validateCheckpointAttestations(
-  publishedCheckpoint: PublishedCheckpoint,
+  publishedCheckpoint: Pick<PublishedCheckpoint, 'checkpoint' | 'attestations'>,
   epochCache: EpochCache,
   constants: Pick<L1RollupConstants, 'epochDuration'>,
   signatureContext: CoordinationSignatureContext,

--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_invalidate_block.parallel.test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_invalidate_block.parallel.test.ts
@@ -53,6 +53,11 @@ describe('e2e_epochs/epochs_invalidate_block', () => {
   let testContract: TestContract;
   let from: AztecAddress;
 
+  // L1/L2 slot timing. Defaults to ~4 L1 blocks per slot; a nested describe overrides this to widen
+  // the ratio for the malicious-republish test, which has to fit two L1 sends inside a single slot.
+  let ethereumSlotDuration = 8;
+  let aztecSlotDuration = 32;
+
   beforeEach(async () => {
     validators = times(VALIDATOR_COUNT, i => {
       const privateKey = bufferToHex(getPrivateKeyFromIndex(i + 3)!);
@@ -63,10 +68,10 @@ describe('e2e_epochs/epochs_invalidate_block', () => {
     // Setup context with the given set of validators, mocked gossip sub network, and no anvil test watcher.
     // Uses multiple-blocks-per-slot timing configuration.
     test = await EpochsTestContext.setup({
-      ethereumSlotDuration: 8,
-      aztecSlotDuration: 32,
+      ethereumSlotDuration,
+      aztecSlotDuration,
       blockDurationMs: 6000,
-      l1PublishingTime: 8,
+      l1PublishingTime: ethereumSlotDuration,
       enforceTimeTable: true,
       numberOfAccounts: 0,
       initialValidators: validators,
@@ -130,6 +135,32 @@ describe('e2e_epochs/epochs_invalidate_block', () => {
     ]);
   }
 
+  type CheckpointProposedEvent = Awaited<ReturnType<RollupContract['getCheckpointProposedEvents']>>[number];
+
+  async function getCheckpointAttestationCount(
+    event: CheckpointProposedEvent,
+    checkpointNumber: CheckpointNumber,
+  ): Promise<number> {
+    const calldataRetriever = new CalldataRetriever(
+      l1Client as unknown as ViemPublicClient,
+      l1Client as unknown as ViemPublicDebugClient,
+      VALIDATOR_COUNT,
+      undefined,
+      createLogger('e2e:epochs_invalidate_block:calldata'),
+      EthAddress.fromString(rollupContract.address),
+    );
+    const { attestations } = await calldataRetriever.getCheckpointFromRollupTx(
+      event.l1TransactionHash,
+      event.args.versionedBlobHashes,
+      checkpointNumber,
+      {
+        attestationsHash: event.args.attestationsHash.toString(),
+        payloadDigest: event.args.payloadDigest.toString(),
+      },
+    );
+    return attestations.filter(a => !a.signature.isEmpty()).length;
+  }
+
   /**
    * Asserts that the given checkpoint, as posted on L1, has fewer valid attestations than quorum.
    * Useful to catch config-timing races where malicious config does not take effect before the proposer
@@ -140,24 +171,7 @@ describe('e2e_epochs/epochs_invalidate_block', () => {
     const event = proposedEvents.find(e => e.args.checkpointNumber === checkpointNumber);
     expect(event).toBeDefined();
 
-    const calldataRetriever = new CalldataRetriever(
-      l1Client as unknown as ViemPublicClient,
-      l1Client as unknown as ViemPublicDebugClient,
-      VALIDATOR_COUNT,
-      undefined,
-      createLogger('e2e:epochs_invalidate_block:calldata'),
-      EthAddress.fromString(rollupContract.address),
-    );
-    const { attestations } = await calldataRetriever.getCheckpointFromRollupTx(
-      event!.l1TransactionHash,
-      event!.args.versionedBlobHashes,
-      checkpointNumber,
-      {
-        attestationsHash: event!.args.attestationsHash.toString(),
-        payloadDigest: event!.args.payloadDigest.toString(),
-      },
-    );
-    const validCount = attestations.filter(a => !a.signature.isEmpty()).length;
+    const validCount = await getCheckpointAttestationCount(event!, checkpointNumber);
     const quorum = computeQuorum(VALIDATOR_COUNT);
     logger.warn(`Checkpoint ${checkpointNumber} has ${validCount}/${VALIDATOR_COUNT} attestations (quorum=${quorum})`);
     expect(validCount).toBeLessThan(quorum);
@@ -813,6 +827,138 @@ describe('e2e_epochs/epochs_invalidate_block', () => {
     await runInvalidationTest({
       attackConfig: { shuffleAttestationOrdering: true },
       disableConfig: { shuffleAttestationOrdering: false },
+    });
+  });
+
+  describe('malicious proposer self-corrects an invalid checkpoint via multicall', () => {
+    beforeAll(() => {
+      // Wider L2 slot (12 L1 blocks per slot) so the proposer can fit two L1 sends in a single slot:
+      // the self-only (invalid) publish, then the invalidation + valid republish.
+      ethereumSlotDuration = 4;
+      aztecSlotDuration = 48;
+    });
+
+    afterAll(() => {
+      ethereumSlotDuration = 8;
+      aztecSlotDuration = 32;
+    });
+
+    // A malicious proposer collects all attestations for a valid checkpoint, but instead of publishing
+    // it directly: posts the checkpoint to L1 with only its own (insufficient) attestation, invalidates
+    // its own checkpoint, and re-posts it with the valid attestations. We verify the chain still makes
+    // progress and that the insufficient-attestations offense is still recorded against the proposer.
+    it('republishes its own checkpoint with valid attestations after an invalid publish', async () => {
+      const sequencers = nodes.map(node => node.getSequencer()!);
+      sequencers.forEach(s =>
+        s.updateConfig({
+          secondsBeforeInvalidatingBlockAsNonCommitteeMember: Number.MAX_SAFE_INTEGER,
+          minTxsPerBlock: 0,
+        }),
+      );
+      await Promise.all(sequencers.map(s => s.start()));
+
+      const initialCheckpointNumber = (await nodes[0].getChainTips()).checkpointed.checkpoint.number;
+      await test.waitUntilCheckpointNumber(
+        CheckpointNumber(initialCheckpointNumber + 1),
+        test.L2_SLOT_DURATION_IN_S * 4,
+      );
+
+      await test.monitor.waitUntilNextL2Slot();
+      const { l2SlotNumber: currentSlot } = await test.monitor.run();
+      const badSlot = SlotNumber.add(currentSlot, 3);
+      const proposer = await test.epochCache.getProposerAttesterAddressInSlot(badSlot);
+      if (!proposer) {
+        throw new Error(`Could not resolve proposer for slot ${badSlot}`);
+      }
+
+      const proposerNodeIndex = nodes.findIndex(node =>
+        node.getSequencer()!.validatorAddresses!.some(address => address.equals(proposer)),
+      );
+      if (proposerNodeIndex === -1) {
+        throw new Error(`Could not find node for proposer ${proposer}`);
+      }
+      const observerIndex = (proposerNodeIndex + 1) % nodes.length;
+
+      await nodes[proposerNodeIndex].setConfig({
+        testRepublishInvalidCheckpoint: true,
+        skipInvalidateBlockAsProposer: true,
+        minTxsPerBlock: 0,
+      });
+
+      const fromL1Block = await l1Client.getBlockNumber();
+      const invalidationPromise = awaitCheckpointInvalidationEvent();
+      const badCheckpointPromise = promiseWithResolvers<CheckpointNumber>();
+      test.monitor.on('checkpoint', ({ checkpointNumber, l2SlotNumber }) => {
+        if (l2SlotNumber === badSlot) {
+          badCheckpointPromise.resolve(checkpointNumber);
+        }
+      });
+
+      await timesAsync(4, i => testContract.methods.emit_nullifier(BigInt(i + 1)).send({ from, wait: NO_WAIT }));
+
+      const badCheckpointNumber = await executeTimeout(
+        () => badCheckpointPromise.promise,
+        test.L2_SLOT_DURATION_IN_S * 8 * 1000,
+        `Waiting for checkpoint at slot ${badSlot}`,
+      );
+      await assertCheckpointInsufficientAttestations(badCheckpointNumber);
+
+      const { checkpointNumber: invalidatedCheckpointNumber, event: invalidationEvent } = await invalidationPromise;
+      expect(invalidatedCheckpointNumber).toEqual(badCheckpointNumber);
+
+      // The proposer publishes the checkpoint twice: once with self-only (invalid) attestations and
+      // again with the valid set, with its own invalidation bundled in between.
+      const proposedForBadCheckpoint = await retryUntil(
+        async () => {
+          const proposed = (
+            await rollupContract.getCheckpointProposedEvents(fromL1Block, await l1Client.getBlockNumber())
+          ).filter(e => e.args.checkpointNumber === badCheckpointNumber);
+          return proposed.length >= 2 ? proposed : undefined;
+        },
+        'two CheckpointProposed events for the bad checkpoint',
+        test.L2_SLOT_DURATION_IN_S * 4,
+        0.5,
+      );
+
+      const firstProposal = proposedForBadCheckpoint[0];
+      const lastProposal = proposedForBadCheckpoint[proposedForBadCheckpoint.length - 1];
+      // All proposals are for the same checkpoint archive, and the invalidation lands between them.
+      expect(new Set(proposedForBadCheckpoint.map(e => e.args.archive.toString())).size).toBe(1);
+      expect(invalidationEvent.blockNumber!).toBeGreaterThanOrEqual(firstProposal.l1BlockNumber);
+      expect(lastProposal.l1BlockNumber).toBeGreaterThanOrEqual(invalidationEvent.blockNumber!);
+      // The final, republished checkpoint carries a full quorum of valid attestations.
+      expect(await getCheckpointAttestationCount(lastProposal, badCheckpointNumber)).toBeGreaterThanOrEqual(
+        computeQuorum(VALIDATOR_COUNT),
+      );
+
+      await nodes[proposerNodeIndex].setConfig({
+        testRepublishInvalidCheckpoint: false,
+        skipInvalidateBlockAsProposer: false,
+      });
+
+      await retryUntil(
+        async () => {
+          const checkpoints = (await Promise.all(nodes.map(node => node.getChainTips()))).map(
+            tips => tips.checkpointed.checkpoint.number,
+          );
+          logger.info(`Node checkpointed tips: ${checkpoints.join(', ')}`);
+          return checkpoints.every(checkpoint => checkpoint > badCheckpointNumber);
+        },
+        'all nodes advance past the republished checkpoint',
+        test.L2_SLOT_DURATION_IN_S * 8,
+        0.5,
+      );
+
+      const offenses = await nodes[observerIndex].getSlashOffenses('all');
+      const insufficient = offenses.find(
+        offense =>
+          offense.offenseType === OffenseType.PROPOSED_INSUFFICIENT_ATTESTATIONS &&
+          offense.epochOrSlot === BigInt(badSlot),
+      );
+      expect(insufficient).toBeDefined();
+      expect(insufficient!.validator.equals(proposer)).toBeTrue();
+
+      logger.warn(`Test succeeded '${expect.getState().currentTestName}'`);
     });
   });
 });

--- a/yarn-project/sequencer-client/src/config.ts
+++ b/yarn-project/sequencer-client/src/config.ts
@@ -51,6 +51,7 @@ export const DefaultSequencerConfig = {
   skipCollectingAttestations: false,
   skipInvalidateBlockAsProposer: false,
   skipWaitForValidParentCheckpointOnL1: false,
+  testRepublishInvalidCheckpoint: false,
   broadcastInvalidBlockProposal: false,
   broadcastInvalidCheckpointProposalOnly: false,
   injectFakeAttestation: false,
@@ -191,6 +192,11 @@ export const sequencerConfigMappings: ConfigMappingsType<SequencerConfig> = {
       'Bypass the parent checkpoint validity check before submitting a pipelined checkpoint, ' +
       'allowing the proposer to publish even when the parent landed on L1 with invalid attestations (for testing only)',
     ...booleanConfigHelper(DefaultSequencerConfig.skipWaitForValidParentCheckpointOnL1),
+  },
+  testRepublishInvalidCheckpoint: {
+    description:
+      'Publish a checkpoint with only the self-attestation, then invalidate and repropose it with valid attestations (for testing only)',
+    ...booleanConfigHelper(DefaultSequencerConfig.testRepublishInvalidCheckpoint),
   },
   broadcastInvalidBlockProposal: {
     description: 'Broadcast invalid block proposals with corrupted state (for testing only)',

--- a/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.ts
+++ b/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.ts
@@ -1,3 +1,4 @@
+import { validateCheckpointAttestations } from '@aztec/archiver';
 import type { EpochCache } from '@aztec/epoch-cache';
 import type { SimulationOverridesPlan } from '@aztec/ethereum/contracts';
 import {
@@ -66,7 +67,11 @@ import { CheckpointBuilder, type FullNodeCheckpointsBuilder, type ValidatorClien
 import { DutyAlreadySignedError, SlashingProtectionError } from '@aztec/validator-ha-signer/errors';
 
 import type { GlobalVariableBuilder } from '../global_variable_builder/global_builder.js';
-import type { InvalidateCheckpointRequest, SequencerPublisher } from '../publisher/sequencer-publisher.js';
+import type {
+  InvalidateCheckpointRequest,
+  SendRequestsResult,
+  SequencerPublisher,
+} from '../publisher/sequencer-publisher.js';
 import { buildCheckpointSimulationOverridesPlan } from './chain_state_overrides.js';
 import type { CheckpointProposalJobMetricsRecorder } from './checkpoint_proposal_job_metrics.js';
 import { CheckpointVoter } from './checkpoint_voter.js';
@@ -93,6 +98,8 @@ type CheckpointProposalResult = {
   attestations: CommitteeAttestationsAndSigners;
   attestationsSignature: Signature;
 };
+
+type SignedAttestations = Omit<CheckpointProposalResult, 'checkpoint'>;
 
 /**
  * Handles the execution of a checkpoint proposal after the initial preparation phase.
@@ -254,24 +261,32 @@ export class CheckpointProposalJob implements Traceable {
 
       // Wait for the previous checkpoint to land on L1 before submitting, so we can check it
       // matches the proposed checkpoint we used as parent, and has valid attestations.
-      if (signedAttestations && (await this.waitForValidParentCheckpointOnL1())) {
-        await this.enqueueCheckpointForSubmission({ checkpoint, ...signedAttestations });
-      }
+      const canSubmitCheckpoint = signedAttestations ? await this.waitForValidParentCheckpointOnL1() : false;
 
-      // If we failed to collect attestations, at least check if we need to issue an invalidation
-      if (!signedAttestations && (await this.waitForSyncedL2SlotNumber(this.slotNow))) {
-        const validationStatus = await this.l2BlockSource.getPendingChainValidationStatus();
-        if (!validationStatus.valid) {
-          this.log.warn(
-            `Checkpoint ${validationStatus.checkpoint.checkpointNumber} has invalid attestations, enqueuing invalidation in spite of attestation collection failure`,
-            { checkpoint: validationStatus.checkpoint, reason: validationStatus.reason },
-          );
-          await this.enqueueInvalidation(validationStatus);
+      let l1Response: SendRequestsResult | undefined;
+      if (signedAttestations && canSubmitCheckpoint && this.config.testRepublishInvalidCheckpoint) {
+        // Test-only: publish self-only (invalid) attestations, then invalidate and republish the valid set.
+        l1Response = await this.republishOwnCheckpointWithValidAttestations(broadcast, signedAttestations);
+      } else {
+        if (signedAttestations && canSubmitCheckpoint) {
+          await this.enqueueCheckpointForSubmission({ checkpoint, ...signedAttestations });
         }
-      }
 
-      // Send whatever was enqueued: votes + (propose | invalidation | nothing).
-      const l1Response = await this.publisher.sendRequestsAt(this.targetSlot);
+        // If we failed to collect attestations, at least check if we need to issue an invalidation
+        if (!signedAttestations && (await this.waitForSyncedL2SlotNumber(this.slotNow))) {
+          const validationStatus = await this.l2BlockSource.getPendingChainValidationStatus();
+          if (!validationStatus.valid) {
+            this.log.warn(
+              `Checkpoint ${validationStatus.checkpoint.checkpointNumber} has invalid attestations, enqueuing invalidation in spite of attestation collection failure`,
+              { checkpoint: validationStatus.checkpoint, reason: validationStatus.reason },
+            );
+            await this.enqueueInvalidation(validationStatus);
+          }
+        }
+
+        // Send whatever was enqueued: votes + (propose | invalidation | nothing).
+        l1Response = await this.publisher.sendRequestsAt(this.targetSlot);
+      }
       const proposedAction = l1Response?.successfulActions.find(a => a === 'propose');
       if (proposedAction) {
         this.logCheckpointEvent('published', `Checkpoint published for slot ${this.targetSlot}`, {
@@ -350,6 +365,98 @@ export class CheckpointProposalJob implements Traceable {
     await this.publisher.enqueueProposeCheckpoint(checkpoint, attestations, attestationsSignature, {
       txTimeoutAt,
     });
+  }
+
+  /**
+   * Builds an attestation set carrying only the proposer's own signature, derived from the already
+   * collected valid set so we don't re-attest (which would hit slashing protection and drop the
+   * proposer's own attestation). Keeps the proposer's signature in place and demotes every other
+   * committee member to address-only, yielding fewer than quorum signatures (insufficient → invalid).
+   */
+  private async getSelfOnlySignedAttestations(validAttestations: SignedAttestations): Promise<SignedAttestations> {
+    const signer = this.proposer ?? this.publisher.getSenderAddress();
+    const selfOnlyAttestations = validAttestations.attestations.attestations.map(a =>
+      a.address.equals(signer) ? a : CommitteeAttestation.fromAddress(a.address),
+    );
+    const attestations = new CommitteeAttestationsAndSigners(selfOnlyAttestations, this.getSignatureContext());
+
+    // Sign without HA slashing protection: the slot's protected attestations-and-signers signature
+    // is already taken by the valid set we collected, and the protected path would reject a second,
+    // differing payload for the same slot. This self-only set is a throwaway for the invalid publish.
+    const attestationsSignature = await this.validatorClient.signAttestationsAndSignersWithoutProtection(
+      attestations,
+      signer,
+    );
+    return { attestations, attestationsSignature };
+  }
+
+  /**
+   * Test-only: reproduces a malicious proposer that publishes an invalid checkpoint and then
+   * self-corrects within the same slot. Publishes the checkpoint carrying only the proposer's own
+   * attestation (below quorum → invalid), then bundles an invalidation of that checkpoint together
+   * with a republish carrying the full valid attestation set into a single L1 multicall. Returns the
+   * L1 response of the last send attempted, or undefined if it was interrupted.
+   */
+  private async republishOwnCheckpointWithValidAttestations(
+    broadcast: CheckpointProposalBroadcast,
+    validAttestations: SignedAttestations,
+  ): Promise<SendRequestsResult | undefined> {
+    const { checkpoint } = broadcast;
+    const submissionSlotStart = Number(getTimestampForSlot(this.targetSlot, this.l1Constants));
+    const txTimeoutAt = new Date((submissionSlotStart + this.l1Constants.slotDuration) * 1000);
+    const logCtx = { slot: this.targetSlot, checkpointNumber: this.checkpointNumber };
+
+    // Publish the checkpoint with only our own attestation, so it lands on L1 below quorum (invalid).
+    const { attestations, attestationsSignature } = await this.getSelfOnlySignedAttestations(validAttestations);
+    this.setStateFn(SequencerState.PUBLISHING_CHECKPOINT, this.targetSlot);
+    await this.publisher.enqueueProposeCheckpoint(checkpoint, attestations, attestationsSignature, { txTimeoutAt });
+    this.log.warn(
+      `Publishing checkpoint ${this.checkpointNumber} with self-only attestations before republishing`,
+      logCtx,
+    );
+    const firstResponse = await this.publisher.sendRequestsAt(this.targetSlot);
+    if (!firstResponse?.successfulActions.includes('propose')) {
+      this.log.warn(`Self-only checkpoint publish did not land, aborting republish`, {
+        ...logCtx,
+        successfulActions: firstResponse?.successfulActions,
+        failedActions: firstResponse?.failedActions,
+      });
+      return firstResponse;
+    }
+
+    // Validate the self-only set we just posted directly, instead of waiting for the archiver to sync
+    // and flag the checkpoint invalid. The archiver only resolves that at the slot boundary, which is
+    // too late to invalidate and republish within the same slot.
+    const validationStatus = await validateCheckpointAttestations(
+      { checkpoint, attestations: attestations.attestations },
+      this.epochCache,
+      this.l1Constants,
+      this.getSignatureContext(),
+      this.log,
+    );
+    if (validationStatus.valid) {
+      this.log.warn(`Self-only checkpoint ${this.checkpointNumber} unexpectedly validated, skipping republish`, logCtx);
+      return firstResponse;
+    }
+
+    // Invalidate our own checkpoint and republish it with the valid attestation set, bundled in one L1 tx.
+    const invalidateRequest = await this.publisher.simulateInvalidateCheckpoint(validationStatus);
+    if (!invalidateRequest) {
+      this.log.warn(`Invalidation simulation returned undefined, skipping republish`, logCtx);
+      return firstResponse;
+    }
+    this.publisher.enqueueInvalidateCheckpoint(invalidateRequest, { txTimeoutAt });
+    await this.publisher.enqueueProposeCheckpoint(
+      checkpoint,
+      validAttestations.attestations,
+      validAttestations.attestationsSignature,
+      { txTimeoutAt },
+    );
+    this.log.warn(`Invalidating and republishing checkpoint ${this.checkpointNumber} with valid attestations`, {
+      ...logCtx,
+      reason: validationStatus.reason,
+    });
+    return this.publisher.sendRequests(this.targetSlot);
   }
 
   /**

--- a/yarn-project/stdlib/src/interfaces/configs.ts
+++ b/yarn-project/stdlib/src/interfaces/configs.ts
@@ -67,6 +67,8 @@ export interface SequencerConfig {
    * the proposer to publish even when the parent landed on L1 with invalid attestations (for testing only).
    */
   skipWaitForValidParentCheckpointOnL1?: boolean;
+  /** Publish a checkpoint with only the self-attestation, then invalidate and repropose it with valid attestations. */
+  testRepublishInvalidCheckpoint?: boolean;
   /** Broadcast invalid block proposals with corrupted state (for testing only) */
   broadcastInvalidBlockProposal?: boolean;
   /** Broadcast an invalid block proposal only at this indexWithinCheckpoint (for testing only) */
@@ -140,6 +142,7 @@ export const SequencerConfigSchema = zodFor<SequencerConfig>()(
     skipCollectingAttestations: z.boolean().optional(),
     skipInvalidateBlockAsProposer: z.boolean().optional(),
     skipWaitForValidParentCheckpointOnL1: z.boolean().optional(),
+    testRepublishInvalidCheckpoint: z.boolean().optional(),
     secondsBeforeInvalidatingBlockAsCommitteeMember: z.number(),
     secondsBeforeInvalidatingBlockAsNonCommitteeMember: z.number(),
     broadcastInvalidBlockProposal: z.boolean().optional(),

--- a/yarn-project/validator-client/src/duties/validation_service.ts
+++ b/yarn-project/validator-client/src/duties/validation_service.ts
@@ -221,4 +221,19 @@ export class ValidationService {
     const typedData = getCoordinationSignatureTypedData(attestationsAndSigners);
     return this.keyStore.signTypedDataWithAddress(proposer, typedData, context);
   }
+
+  /**
+   * Signs an attestations-and-signers payload bypassing HA slashing protection. This allows
+   * producing more than one such signature for the same slot, which the protected path forbids.
+   * For testing only: used by the malicious-republish path to sign a throwaway self-only set in
+   * addition to the slot's real (protected) attestation set.
+   */
+  signAttestationsAndSignersWithoutProtection(
+    attestationsAndSigners: CommitteeAttestationsAndSigners,
+    proposer: EthAddress,
+  ): Promise<Signature> {
+    const context: SigningContext = { dutyType: DutyType.AUTH_REQUEST };
+    const typedData = getCoordinationSignatureTypedData(attestationsAndSigners);
+    return this.keyStore.signTypedDataWithAddress(proposer, typedData, context);
+  }
 }

--- a/yarn-project/validator-client/src/validator.ts
+++ b/yarn-project/validator-client/src/validator.ts
@@ -1004,6 +1004,18 @@ export class ValidatorClient extends (EventEmitter as new () => WatcherEmitter) 
     );
   }
 
+  /**
+   * Signs an attestations-and-signers payload bypassing HA slashing protection (for testing only).
+   * Used by the malicious-republish path to sign a throwaway self-only set alongside the slot's
+   * real attestation set, which the protected path would otherwise reject as a double-sign.
+   */
+  async signAttestationsAndSignersWithoutProtection(
+    attestationsAndSigners: CommitteeAttestationsAndSigners,
+    proposer: EthAddress,
+  ): Promise<Signature> {
+    return await this.validationService.signAttestationsAndSignersWithoutProtection(attestationsAndSigners, proposer);
+  }
+
   async collectOwnAttestations(
     proposal: CheckpointProposal,
     checkpointNumber: CheckpointNumber,


### PR DESCRIPTION
New test for a scenario where a malicious proposer:
- Collects all attestations for a valid checkpoint proposal
- Posts the checkpoint to L1 with invalid attestations
- Invalidates its own checkpoint
- Re-posts it with the valid attestations