### PR TITLE
fix(ci): nightly 10 TPS bench GCP auth and checkout

### DIFF
--- a/.github/workflows/deploy-network.yml
+++ b/.github/workflows/deploy-network.yml
@@ -111,7 +111,9 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           ref: ${{ steps.checkout-ref.outputs.ref }}
-          fetch-depth: 1
+          # Full history so recursive submodules can checkout pinned commits (not only branch tips).
+          fetch-depth: 0
+          lfs: true
           persist-credentials: false
           submodules: recursive # Initialize git submodules for l1-contracts dependencies
 

--- a/.github/workflows/nightly-bench-10tps.yml
+++ b/.github/workflows/nightly-bench-10tps.yml
@@ -114,7 +114,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
-          ref: next
+          ref: ${{ github.sha }}
 
       - name: Run 10 TPS benchmark
         timeout-minutes: 240

--- a/.github/workflows/nightly-bench-10tps.yml
+++ b/.github/workflows/nightly-bench-10tps.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
-          ref: next
+          ref: ${{ github.sha }}
 
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f
@@ -91,12 +91,6 @@ jobs:
         uses: google-github-actions/setup-gcloud@6189d56e4096ee891640bb02ac264be376592d6a
         with:
           install_components: gke-gcloud-auth-plugin
-
-      - name: Setup Terraform
-        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e
-        with:
-          terraform_version: "1.7.5"
-          terraform_wrapper: false
 
       - name: Wait for first L2 block
         env:

--- a/.github/workflows/nightly-bench-10tps.yml
+++ b/.github/workflows/nightly-bench-10tps.yml
@@ -92,6 +92,12 @@ jobs:
         with:
           install_components: gke-gcloud-auth-plugin
 
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e
+        with:
+          terraform_version: "1.7.5"
+          terraform_wrapper: false
+
       - name: Wait for first L2 block
         env:
           GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}

--- a/.github/workflows/weekly-proving-bench.yml
+++ b/.github/workflows/weekly-proving-bench.yml
@@ -83,6 +83,12 @@ jobs:
         with:
           install_components: gke-gcloud-auth-plugin
 
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e
+        with:
+          terraform_version: "1.7.5"
+          terraform_wrapper: false
+
       - name: Wait for first L2 block
         env:
           GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}

--- a/.github/workflows/weekly-proving-bench.yml
+++ b/.github/workflows/weekly-proving-bench.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
-          ref: next
+          ref: ${{ github.sha }}
 
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f
@@ -82,12 +82,6 @@ jobs:
         uses: google-github-actions/setup-gcloud@6189d56e4096ee891640bb02ac264be376592d6a
         with:
           install_components: gke-gcloud-auth-plugin
-
-      - name: Setup Terraform
-        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e
-        with:
-          terraform_version: "1.7.5"
-          terraform_wrapper: false
 
       - name: Wait for first L2 block
         env:

--- a/spartan/scripts/install_deps.sh
+++ b/spartan/scripts/install_deps.sh
@@ -134,6 +134,19 @@ if ! command -v cast &> /dev/null; then
   sudo chmod +x /usr/local/bin/cast
 fi
 
+TERRAFORM_VERSION="1.7.5"
+if ! command -v terraform &> /dev/null; then
+  log "Installing terraform ${TERRAFORM_VERSION}..."
+  tf_os="$(os)"
+  if [ "$tf_os" = "macos" ]; then
+    tf_os="darwin"
+  fi
+  curl -fsSL "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_${tf_os}_$(arch).zip" -o terraform.zip
+  unzip -qo terraform.zip
+  sudo mv terraform /usr/local/bin/terraform
+  rm terraform.zip
+fi
+
 require_cmd git
 require_cmd kubectl
 require_cmd terraform

--- a/spartan/scripts/setup_gcp_secrets.sh
+++ b/spartan/scripts/setup_gcp_secrets.sh
@@ -7,85 +7,10 @@ set -euo pipefail
 
 ENV_FILE="$1"
 
-log_info() { echo "[setup_gcp_secrets] $*" >&2; }
-log_err() { echo "[setup_gcp_secrets] ERROR: $*" >&2; }
-
 if [[ ! -f "$ENV_FILE" ]]; then
-    log_err "Environment file not found: $ENV_FILE"
+    echo "Environment file not found: $ENV_FILE" >&2
     exit 1
 fi
-
-if ! command -v gcloud &>/dev/null; then
-    log_err "gcloud not found on PATH"
-    exit 1
-fi
-
-if ! command -v jq &>/dev/null; then
-    log_err "jq not found on PATH (needed to inspect credentials)"
-    exit 1
-fi
-
-function diagnose_gcloud_auth {
-    log_info "CI=${CI:-0} GCP_PROJECT_ID=${GCP_PROJECT_ID:-<unset>} CLUSTER=${CLUSTER:-<unset>}"
-
-    if [[ -z "${GCP_PROJECT_ID:-}" ]]; then
-        log_err "GCP_PROJECT_ID is not set; gcloud secret access requires --project"
-        return 1
-    fi
-
-    if [[ -n "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]]; then
-        log_info "GOOGLE_APPLICATION_CREDENTIALS=${GOOGLE_APPLICATION_CREDENTIALS}"
-        if [[ ! -f "${GOOGLE_APPLICATION_CREDENTIALS}" ]]; then
-            log_err "Credentials file does not exist: ${GOOGLE_APPLICATION_CREDENTIALS}"
-            return 1
-        fi
-        local cred_type cred_email cred_project
-        cred_type=$(jq -r '.type // "unknown"' "${GOOGLE_APPLICATION_CREDENTIALS}")
-        cred_email=$(jq -r '.client_email // .client_id // "n/a"' "${GOOGLE_APPLICATION_CREDENTIALS}")
-        cred_project=$(jq -r '.project_id // "n/a"' "${GOOGLE_APPLICATION_CREDENTIALS}")
-        log_info "Credential file type=${cred_type} identity=${cred_email} file_project_id=${cred_project}"
-        if [[ "$cred_project" != "n/a" && "$cred_project" != "$GCP_PROJECT_ID" ]]; then
-            log_info "Note: file project_id (${cred_project}) differs from GCP_PROJECT_ID (${GCP_PROJECT_ID})"
-        fi
-    else
-        log_info "GOOGLE_APPLICATION_CREDENTIALS is not set"
-    fi
-
-    log_info "Active gcloud accounts:"
-    gcloud auth list 2>&1 | sed 's/^/[setup_gcp_secrets]   /' >&2 || true
-
-    if [[ "${CI:-0}" == "1" && -n "${GOOGLE_APPLICATION_CREDENTIALS:-}" && -f "${GOOGLE_APPLICATION_CREDENTIALS}" ]]; then
-        log_info "CI=1: activating service account from GOOGLE_APPLICATION_CREDENTIALS"
-        if ! gcloud auth activate-service-account --key-file="${GOOGLE_APPLICATION_CREDENTIALS}" 2>&1 | sed 's/^/[setup_gcp_secrets]   /' >&2; then
-            log_err "gcloud auth activate-service-account failed"
-            return 1
-        fi
-        gcloud config set project "$GCP_PROJECT_ID" >/dev/null
-    fi
-
-    local token_err
-    token_err=$(mktemp)
-    if ! gcloud auth print-access-token >/dev/null 2>"$token_err"; then
-        log_err "Could not obtain a valid access token (expired or missing credentials?)"
-        sed 's/^/[setup_gcp_secrets]   /' "$token_err" >&2
-        rm -f "$token_err"
-        return 1
-    fi
-    rm -f "$token_err"
-    log_info "Access token obtained successfully for project ${GCP_PROJECT_ID}"
-
-    local describe_err
-    describe_err=$(mktemp)
-    if ! gcloud secrets describe otel-collector-url --project="$GCP_PROJECT_ID" >/dev/null 2>"$describe_err"; then
-        log_info "Preflight: cannot describe secret otel-collector-url (may still fail on access):"
-        sed 's/^/[setup_gcp_secrets]   /' "$describe_err" >&2
-    else
-        log_info "Preflight: secret otel-collector-url exists in project ${GCP_PROJECT_ID}"
-    fi
-    rm -f "$describe_err"
-}
-
-diagnose_gcloud_auth || exit 1
 
 # Read the network name from the env file
 NETWORK=${NETWORK:-}
@@ -107,20 +32,11 @@ trap "rm -rf '$SECRETS_TMP_DIR'" EXIT
 get_secret() {
     local secret_name="$1"
     local temp_file="$SECRETS_TMP_DIR/${secret_name}.secret"
-    local gcloud_err
-    gcloud_err=$(mktemp)
 
-    if ! gcloud secrets versions access latest \
-        --secret="$secret_name" \
-        --project="$GCP_PROJECT_ID" \
-        --out-file="$temp_file" 2>"$gcloud_err"; then
-        log_err "Failed to read secret: ${secret_name} (project=${GCP_PROJECT_ID})"
-        log_err "gcloud secrets versions access stderr:"
-        sed 's/^/[setup_gcp_secrets]   /' "$gcloud_err" >&2
-        rm -f "$gcloud_err"
+    gcloud secrets versions access latest --secret="$secret_name" --project="$GCP_PROJECT_ID" --out-file="$temp_file" 2>/dev/null || {
+        echo "Failed to read secret: $secret_name" >&2
         exit 1
-    fi
-    rm -f "$gcloud_err"
+    }
 
     echo "$temp_file"
 }

--- a/spartan/scripts/setup_gcp_secrets.sh
+++ b/spartan/scripts/setup_gcp_secrets.sh
@@ -7,10 +7,85 @@ set -euo pipefail
 
 ENV_FILE="$1"
 
+log_info() { echo "[setup_gcp_secrets] $*" >&2; }
+log_err() { echo "[setup_gcp_secrets] ERROR: $*" >&2; }
+
 if [[ ! -f "$ENV_FILE" ]]; then
-    echo "Environment file not found: $ENV_FILE" >&2
+    log_err "Environment file not found: $ENV_FILE"
     exit 1
 fi
+
+if ! command -v gcloud &>/dev/null; then
+    log_err "gcloud not found on PATH"
+    exit 1
+fi
+
+if ! command -v jq &>/dev/null; then
+    log_err "jq not found on PATH (needed to inspect credentials)"
+    exit 1
+fi
+
+function diagnose_gcloud_auth {
+    log_info "CI=${CI:-0} GCP_PROJECT_ID=${GCP_PROJECT_ID:-<unset>} CLUSTER=${CLUSTER:-<unset>}"
+
+    if [[ -z "${GCP_PROJECT_ID:-}" ]]; then
+        log_err "GCP_PROJECT_ID is not set; gcloud secret access requires --project"
+        return 1
+    fi
+
+    if [[ -n "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]]; then
+        log_info "GOOGLE_APPLICATION_CREDENTIALS=${GOOGLE_APPLICATION_CREDENTIALS}"
+        if [[ ! -f "${GOOGLE_APPLICATION_CREDENTIALS}" ]]; then
+            log_err "Credentials file does not exist: ${GOOGLE_APPLICATION_CREDENTIALS}"
+            return 1
+        fi
+        local cred_type cred_email cred_project
+        cred_type=$(jq -r '.type // "unknown"' "${GOOGLE_APPLICATION_CREDENTIALS}")
+        cred_email=$(jq -r '.client_email // .client_id // "n/a"' "${GOOGLE_APPLICATION_CREDENTIALS}")
+        cred_project=$(jq -r '.project_id // "n/a"' "${GOOGLE_APPLICATION_CREDENTIALS}")
+        log_info "Credential file type=${cred_type} identity=${cred_email} file_project_id=${cred_project}"
+        if [[ "$cred_project" != "n/a" && "$cred_project" != "$GCP_PROJECT_ID" ]]; then
+            log_info "Note: file project_id (${cred_project}) differs from GCP_PROJECT_ID (${GCP_PROJECT_ID})"
+        fi
+    else
+        log_info "GOOGLE_APPLICATION_CREDENTIALS is not set"
+    fi
+
+    log_info "Active gcloud accounts:"
+    gcloud auth list 2>&1 | sed 's/^/[setup_gcp_secrets]   /' >&2 || true
+
+    if [[ "${CI:-0}" == "1" && -n "${GOOGLE_APPLICATION_CREDENTIALS:-}" && -f "${GOOGLE_APPLICATION_CREDENTIALS}" ]]; then
+        log_info "CI=1: activating service account from GOOGLE_APPLICATION_CREDENTIALS"
+        if ! gcloud auth activate-service-account --key-file="${GOOGLE_APPLICATION_CREDENTIALS}" 2>&1 | sed 's/^/[setup_gcp_secrets]   /' >&2; then
+            log_err "gcloud auth activate-service-account failed"
+            return 1
+        fi
+        gcloud config set project "$GCP_PROJECT_ID" >/dev/null
+    fi
+
+    local token_err
+    token_err=$(mktemp)
+    if ! gcloud auth print-access-token >/dev/null 2>"$token_err"; then
+        log_err "Could not obtain a valid access token (expired or missing credentials?)"
+        sed 's/^/[setup_gcp_secrets]   /' "$token_err" >&2
+        rm -f "$token_err"
+        return 1
+    fi
+    rm -f "$token_err"
+    log_info "Access token obtained successfully for project ${GCP_PROJECT_ID}"
+
+    local describe_err
+    describe_err=$(mktemp)
+    if ! gcloud secrets describe otel-collector-url --project="$GCP_PROJECT_ID" >/dev/null 2>"$describe_err"; then
+        log_info "Preflight: cannot describe secret otel-collector-url (may still fail on access):"
+        sed 's/^/[setup_gcp_secrets]   /' "$describe_err" >&2
+    else
+        log_info "Preflight: secret otel-collector-url exists in project ${GCP_PROJECT_ID}"
+    fi
+    rm -f "$describe_err"
+}
+
+diagnose_gcloud_auth || exit 1
 
 # Read the network name from the env file
 NETWORK=${NETWORK:-}
@@ -32,11 +107,20 @@ trap "rm -rf '$SECRETS_TMP_DIR'" EXIT
 get_secret() {
     local secret_name="$1"
     local temp_file="$SECRETS_TMP_DIR/${secret_name}.secret"
+    local gcloud_err
+    gcloud_err=$(mktemp)
 
-    gcloud secrets versions access latest --secret="$secret_name" --project="$GCP_PROJECT_ID" --out-file="$temp_file" 2>/dev/null || {
-        echo "Failed to read secret: $secret_name" >&2
+    if ! gcloud secrets versions access latest \
+        --secret="$secret_name" \
+        --project="$GCP_PROJECT_ID" \
+        --out-file="$temp_file" 2>"$gcloud_err"; then
+        log_err "Failed to read secret: ${secret_name} (project=${GCP_PROJECT_ID})"
+        log_err "gcloud secrets versions access stderr:"
+        sed 's/^/[setup_gcp_secrets]   /' "$gcloud_err" >&2
+        rm -f "$gcloud_err"
         exit 1
-    }
+    fi
+    rm -f "$gcloud_err"
 
     echo "$temp_file"
 }

--- a/spartan/scripts/source_network_env.sh
+++ b/spartan/scripts/source_network_env.sh
@@ -24,6 +24,15 @@ function source_network_env {
       if grep -q "REPLACE_WITH_GCP_SECRET" "$env_file" && command -v gcloud &> /dev/null; then
         echo "Environment file contains GCP secret placeholders. Processing secrets..."
 
+        # Activate GCP credentials before Secret Manager reads (same order as network_deploy.sh).
+        if declare -f gcp_auth >/dev/null 2>&1; then
+          gcp_auth
+        else
+          # shellcheck source=scripts/gcp_auth.sh
+          source "$spartan/scripts/gcp_auth.sh"
+          gcp_auth
+        fi
+
         # Process GCP secrets
         source $spartan/scripts/setup_gcp_secrets.sh "$env_file"
 


### PR DESCRIPTION
## Summary

- Run `gcp_auth` before `setup_gcp_secrets` in `source_network_env` so EC2 benchmark jobs can read Secret Manager (e.g. `otel-collector-url`).
- Improve `setup_gcp_secrets.sh` diagnostics and activate the CI service account before secret fetches.
- Install Terraform on Linux in `install_deps.sh`; add `setup-terraform` on nightly wait jobs.
- Fix `deploy-network` checkout for pinned submodules (`fetch-depth: 0`, `lfs: true`).
- Checkout `github.sha` on the benchmark job so workflow_dispatch from a feature branch runs that branch on EC2 (not `next`).

Validated manually via Nightly Bench 10 TPS workflow_dispatch on this branch (run succeeded).

## Test plan

- [x] Nightly Bench 10 TPS workflow_dispatch from `spy/10tps-bench-terraform` (deploy, wait, benchmark)