### PR TITLE
fix: anchor Grumpkin SRS to pinned chunk hashes on load

### DIFF
--- a/barretenberg/cpp/src/barretenberg/bbapi/bbapi_srs.cpp
+++ b/barretenberg/cpp/src/barretenberg/bbapi/bbapi_srs.cpp
@@ -9,6 +9,8 @@
 #include "barretenberg/ecc/curves/bn254/g2.hpp"
 #include "barretenberg/ecc/curves/grumpkin/grumpkin.hpp"
 #include "barretenberg/numeric/uint256/uint256.hpp"
+#include "barretenberg/srs/factories/get_grumpkin_crs.hpp"
+#include "barretenberg/srs/factories/grumpkin_crs_data.hpp"
 #include "barretenberg/srs/global_crs.hpp"
 
 namespace bb::bbapi {
@@ -74,6 +76,11 @@ SrsInitGrumpkinSrs::Response SrsInitGrumpkinSrs::execute(BB_UNUSED BBApiRequest&
         throw_or_abort("SrsInitGrumpkinSrs: points_buf too small (" + std::to_string(points_buf.size()) +
                        " bytes) for num_points=" + std::to_string(num_points) + " (need " +
                        std::to_string(required_size) + ")");
+    }
+
+    // Anchor whole chunks of the WASM-ingress buffer (bb.js fetches 2^16 points = one chunk).
+    if (points_buf.size() >= bb::srs::GRUMPKIN_G1_CHUNK_SIZE_BYTES) {
+        verify_grumpkin_crs_integrity(std::span<const uint8_t>(points_buf.data(), points_buf.size()));
     }
 
     // Parse Grumpkin affine elements from buffer

--- a/barretenberg/cpp/src/barretenberg/ecc/groups/affine_element.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/groups/affine_element.test.cpp
@@ -208,6 +208,30 @@ template <typename G1> class TestAffineElement : public testing::Test {
         EXPECT_NE(P < Q, Q < P);
     }
 
+    // Regression test: from_compressed must reject non-canonical encodings (x_coordinate >= modulus).
+    // Without the range check, Fq(x) silently reduces mod p, so distinct compressed bytestrings whose
+    // x values differ by a multiple of p would decompress to the same point (encoding malleability).
+    static void test_point_compression_non_canonical_x()
+    {
+        using Fq = typename G1::Fq;
+        // x1 = 1 and x2 = 1 + p both fit in 255 bits because p_BN254 < 2^254 and p_Grumpkin < 2^254.
+        // They are distinct as 255-bit integers but equal mod p.
+        uint256_t x1 = uint256_t(1);
+        uint256_t x2 = uint256_t(1) + Fq::modulus;
+        ASSERT_NE(x1, x2);
+        ASSERT_LT(x2, uint256_t(1) << 255);
+
+        affine_element pt1 = affine_element::from_compressed(x1);
+        affine_element pt2 = affine_element::from_compressed(x2);
+
+        // Canonical input (x = 1) decompresses to a valid point on these curves.
+        EXPECT_TRUE(pt1.on_curve());
+        // Non-canonical input must return the (0, 0) sentinel rather than the same point as x1.
+        EXPECT_EQ(pt2.x, Fq::zero());
+        EXPECT_EQ(pt2.y, Fq::zero());
+        EXPECT_NE(pt1, pt2);
+    }
+
     // Verify that from_compressed with an x that has no y on the curve returns the (0,0) sentinel.
     static void test_point_compression_invalid_x()
     {
@@ -495,6 +519,16 @@ TYPED_TEST(TestAffineElement, PointCompressionInvalidX)
         GTEST_SKIP(); // from_compressed is not used on large-modulus curves
     } else {
         TestFixture::test_point_compression_invalid_x();
+    }
+}
+
+// Regression test: from_compressed must reject non-canonical x >= modulus.
+TYPED_TEST(TestAffineElement, PointCompressionNonCanonicalX)
+{
+    if constexpr (TypeParam::Fq::modulus.data[3] >= MODULUS_TOP_LIMB_LARGE_THRESHOLD) {
+        GTEST_SKIP(); // from_compressed is not used on large-modulus curves
+    } else {
+        TestFixture::test_point_compression_non_canonical_x();
     }
 }
 

--- a/barretenberg/cpp/src/barretenberg/ecc/groups/affine_element_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/groups/affine_element_impl.hpp
@@ -24,6 +24,13 @@ constexpr affine_element<Fq, Fr, T> affine_element<Fq, Fr, T>::from_compressed(c
     x_coordinate.data[3] = x_coordinate.data[3] & (~UINT256_TOP_LIMB_MSB);
     bool y_bit = compressed.get_bit(255);
 
+    // Reject non-canonical encodings: the lower 255 bits encode x. If x_coordinate >= Fq::modulus,
+    // Fq(x_coordinate) silently reduces mod p, so two distinct compressed bytestrings differing by
+    // a multiple of p would decompress to the same point (encoding malleability).
+    if (x_coordinate >= Fq::modulus) {
+        return affine_element(Fq::zero(), Fq::zero());
+    }
+
     Fq x = Fq(x_coordinate);
     Fq y2 = (x.sqr() * x + T::b);
     if constexpr (T::has_a) {

--- a/barretenberg/cpp/src/barretenberg/srs/factories/crs_factory.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/srs/factories/crs_factory.test.cpp
@@ -6,6 +6,9 @@
 #include "barretenberg/srs/factories/bn254_crs_data.hpp"
 #include "barretenberg/srs/factories/bn254_g1_chunk_hashes.hpp"
 #include "barretenberg/srs/factories/get_bn254_crs.hpp"
+#include "barretenberg/srs/factories/get_grumpkin_crs.hpp"
+#include "barretenberg/srs/factories/grumpkin_crs_data.hpp"
+#include "barretenberg/srs/factories/grumpkin_srs_gen.hpp"
 #include "barretenberg/srs/factories/mem_bn254_crs_factory.hpp"
 #include "barretenberg/srs/factories/mem_grumpkin_crs_factory.hpp"
 #include "barretenberg/srs/factories/native_crs_factory.hpp"
@@ -99,6 +102,47 @@ TEST(CrsFactory, grumpkin)
     // Tiny download check to test the 'net CRS' path
     ASSERT_ANY_THROW(check_grumpkin_consistency(temp_crs_path, 1, /*allow_download=*/false));
     check_grumpkin_consistency(temp_crs_path, 1, /*allow_download=*/true);
+}
+
+// Gates that bootstrap.sh produced the canonical file: every chunk matches GRUMPKIN_G1_CHUNK_HASHES.
+TEST(CrsFactory, GrumpkinG1OnDiskMatchesChunkHashes)
+{
+    auto data = bb::read_file(bb::srs::bb_crs_path() / "grumpkin_g1.flat.dat", bb::srs::GRUMPKIN_G1_SIZE_BYTES);
+    ASSERT_EQ(data.size(), bb::srs::GRUMPKIN_G1_SIZE_BYTES);
+    bb::verify_grumpkin_crs_integrity(std::span<const uint8_t>(data.data(), data.size()));
+}
+
+// Gates that the generator output still matches GRUMPKIN_G1_CHUNK_HASHES (i.e. the seed-derived SRS
+// hasn't drifted). Fails if the SRS is regenerated, in which case update the chunk hashes.
+TEST(CrsFactory, GrumpkinG1GeneratorMatchesChunkHashes)
+{
+    auto points = bb::srs::generate_grumpkin_srs(bb::srs::GRUMPKIN_G1_NUM_POINTS);
+    auto bytes = to_buffer(points);
+    ASSERT_EQ(bytes.size(), bb::srs::GRUMPKIN_G1_SIZE_BYTES);
+    bb::verify_grumpkin_crs_integrity(std::span<const uint8_t>(bytes.data(), bytes.size()));
+}
+
+// Plant a one-chunk cache of `[1·G, 2·G, …]` (known pairwise discrete logs → IPA binding break).
+// The on-curve check accepts it; the chunk-hash anchor rejects it.
+TEST(CrsFactory, GrumpkinCacheTamperingRejected)
+{
+    using AffineEl = bb::curve::Grumpkin::AffineElement;
+
+    const fs::path cache_path = "barretenberg_srs_test_crs_grumpkin_tamper";
+    fs::remove_all(cache_path);
+    fs::create_directories(cache_path);
+
+    std::vector<AffineEl> tampered(bb::srs::GRUMPKIN_G1_CHUNK_SIZE_POINTS);
+    AffineEl G = AffineEl::one();
+    for (size_t i = 0; i < tampered.size(); ++i) {
+        bb::curve::Grumpkin::ScalarField scalar(i + 1);
+        tampered[i] = AffineEl(bb::curve::Grumpkin::Element(G) * scalar);
+    }
+    bb::write_file(cache_path / "grumpkin_g1.flat.dat", to_buffer(tampered));
+
+    ASSERT_ANY_THROW(bb::get_grumpkin_g1_data(cache_path, /*num_points=*/8, /*allow_download=*/false));
+
+    fs::remove_all(cache_path);
 }
 
 // TODO: Re-enable once g1_compressed.dat is deployed to S3 fallback

--- a/barretenberg/cpp/src/barretenberg/srs/factories/get_grumpkin_crs.cpp
+++ b/barretenberg/cpp/src/barretenberg/srs/factories/get_grumpkin_crs.cpp
@@ -3,10 +3,24 @@
 #include "barretenberg/common/flock.hpp"
 #include "barretenberg/common/throw_or_abort.hpp"
 #include "barretenberg/common/try_catch_shim.hpp"
+#include "barretenberg/crypto/sha256/sha256.hpp"
 #include "barretenberg/ecc/curves/grumpkin/grumpkin.hpp"
+#include "grumpkin_crs_data.hpp"
 #include "grumpkin_srs_gen.hpp"
 
 namespace bb {
+
+void verify_grumpkin_crs_integrity(std::span<const uint8_t> data)
+{
+    size_t full_chunks = std::min(data.size() / bb::srs::GRUMPKIN_G1_CHUNK_SIZE_BYTES, bb::srs::GRUMPKIN_G1_NUM_CHUNKS);
+    for (size_t c = 0; c < full_chunks; ++c) {
+        auto chunk = data.subspan(c * bb::srs::GRUMPKIN_G1_CHUNK_SIZE_BYTES, bb::srs::GRUMPKIN_G1_CHUNK_SIZE_BYTES);
+        if (bb::crypto::sha256(chunk) != bb::srs::GRUMPKIN_G1_CHUNK_HASHES[c]) {
+            throw_or_abort("grumpkin g1 SHA-256 mismatch at chunk " + std::to_string(c));
+        }
+    }
+}
+
 std::vector<curve::Grumpkin::AffineElement> get_grumpkin_g1_data(const std::filesystem::path& path,
                                                                  size_t num_points,
                                                                  bool allow_download)
@@ -22,6 +36,24 @@ std::vector<curve::Grumpkin::AffineElement> get_grumpkin_g1_data(const std::file
 
     if (g1_downloaded_points >= num_points) {
         vinfo("using cached grumpkin crs with num points ", g1_downloaded_points, " at: ", g1_path);
+
+        // Read up to the chunk boundary covering num_points and anchor those chunks against the
+        // pinned hashes. Sub-chunk requests (only cold-generated small caches) can't form a whole
+        // chunk and fall back to the on-curve smoke check below.
+        size_t chunks_needed =
+            (num_points + bb::srs::GRUMPKIN_G1_CHUNK_SIZE_POINTS - 1) / bb::srs::GRUMPKIN_G1_CHUNK_SIZE_POINTS;
+        size_t verify_points = chunks_needed * bb::srs::GRUMPKIN_G1_CHUNK_SIZE_POINTS;
+        if (chunks_needed <= bb::srs::GRUMPKIN_G1_NUM_CHUNKS && verify_points <= g1_downloaded_points) {
+            auto data = read_file(g1_path, verify_points * sizeof(curve::Grumpkin::AffineElement));
+            verify_grumpkin_crs_integrity(std::span<const uint8_t>(data.data(), data.size()));
+            std::vector<curve::Grumpkin::AffineElement> points(num_points);
+            for (uint32_t i = 0; i < num_points; ++i) {
+                points[i] =
+                    from_buffer<curve::Grumpkin::AffineElement>(data, i * sizeof(curve::Grumpkin::AffineElement));
+            }
+            return points;
+        }
+
         auto data = read_file(g1_path, num_points * sizeof(curve::Grumpkin::AffineElement));
         std::vector<curve::Grumpkin::AffineElement> points(num_points);
         for (uint32_t i = 0; i < num_points; ++i) {

--- a/barretenberg/cpp/src/barretenberg/srs/factories/get_grumpkin_crs.hpp
+++ b/barretenberg/cpp/src/barretenberg/srs/factories/get_grumpkin_crs.hpp
@@ -4,6 +4,7 @@
 #include <filesystem>
 #include <fstream>
 #include <ios>
+#include <span>
 
 namespace bb {
 
@@ -11,4 +12,12 @@ std::vector<curve::Grumpkin::AffineElement> get_grumpkin_g1_data(const std::file
                                                                  size_t num_points,
                                                                  bool allow_download = true);
 
-}
+/**
+ * @brief Verify every whole chunk present in `data` against the pinned Grumpkin chunk hashes.
+ * @details Verifies `min(data.size() / GRUMPKIN_G1_CHUNK_SIZE_BYTES, GRUMPKIN_G1_NUM_CHUNKS)`
+ * chunks and throws on any mismatch. A trailing partial chunk is not verifiable and is ignored,
+ * so callers wanting a given prefix anchored must pass data covering whole chunks.
+ */
+void verify_grumpkin_crs_integrity(std::span<const uint8_t> data);
+
+} // namespace bb

--- a/barretenberg/cpp/src/barretenberg/srs/factories/grumpkin_crs_data.hpp
+++ b/barretenberg/cpp/src/barretenberg/srs/factories/grumpkin_crs_data.hpp
@@ -1,0 +1,51 @@
+#pragma once
+#include "barretenberg/ecc/curves/grumpkin/grumpkin.hpp"
+#include <array>
+#include <cstddef>
+#include <cstdint>
+
+namespace bb::srs {
+
+/**
+ * @brief Canonical number of points in the Aztec Grumpkin SRS published at
+ * `https://crs.aztec-cdn.foundation/grumpkin_g1.dat`.
+ *
+ * @details Sized for ECCVM proving (`CONST_ECCVM_LOG_N = 15`, 2^15 IPA opening rounds) with one
+ * doubling of headroom. This is the size that `barretenberg/crs/bootstrap.sh` downloads.
+ */
+inline constexpr size_t GRUMPKIN_G1_NUM_POINTS = 1ULL << 18;
+
+/**
+ * @brief Canonical byte length of the Aztec Grumpkin SRS file.
+ *
+ * @details Each affine point is 64 bytes (Fq.x ‖ Fq.y, big-endian). 2^18 × 64 = 16 MiB.
+ */
+inline constexpr size_t GRUMPKIN_G1_SIZE_BYTES = GRUMPKIN_G1_NUM_POINTS * sizeof(curve::Grumpkin::AffineElement);
+
+/**
+ * @brief Per-chunk SHA-256 anchors for the transparent Grumpkin SRS.
+ *
+ * @details Callers request a prefix of the SRS (bb.js fetches 2^16, the native prover requests its
+ * dyadic ECCVM size, bootstrap downloads all 2^18), so anchoring must work on prefixes.
+ * `GRUMPKIN_G1_CHUNK_HASHES[c]` is the SHA-256 of chunk `c` (`GRUMPKIN_G1_CHUNK_SIZE_POINTS`
+ * points), letting any prefix covering whole chunks be verified. The SRS is deterministic
+ * (`generate_grumpkin_srs`), so `GrumpkinG1GeneratorMatchesChunkHashes` pins these against the
+ * generator; update them in lockstep with re-uploading the file to both CRS hosts.
+ */
+inline constexpr size_t GRUMPKIN_G1_NUM_CHUNKS = 4;
+inline constexpr size_t GRUMPKIN_G1_CHUNK_SIZE_POINTS = GRUMPKIN_G1_NUM_POINTS / GRUMPKIN_G1_NUM_CHUNKS;
+inline constexpr size_t GRUMPKIN_G1_CHUNK_SIZE_BYTES =
+    GRUMPKIN_G1_CHUNK_SIZE_POINTS * sizeof(curve::Grumpkin::AffineElement);
+
+inline constexpr std::array<std::array<uint8_t, 32>, GRUMPKIN_G1_NUM_CHUNKS> GRUMPKIN_G1_CHUNK_HASHES = { {
+    { 0x64, 0x23, 0x6c, 0x94, 0x55, 0xe7, 0x5a, 0xee, 0xa7, 0x7a, 0x94, 0x58, 0x7e, 0xa6, 0x07, 0xee,
+      0xd2, 0xe9, 0x78, 0xd2, 0x60, 0x9a, 0x42, 0x1d, 0x66, 0xbf, 0x10, 0xbb, 0x96, 0x98, 0xb8, 0xfd },
+    { 0xf4, 0xac, 0xd7, 0x8e, 0x41, 0x5e, 0x4d, 0xb2, 0x1f, 0xb2, 0x37, 0x88, 0x8c, 0x23, 0x10, 0x5f,
+      0x49, 0x19, 0xd3, 0x0e, 0x18, 0x22, 0x6f, 0xaa, 0x47, 0x0a, 0x11, 0xae, 0xc6, 0x9e, 0x49, 0xbb },
+    { 0xd0, 0x0e, 0x44, 0x59, 0xfc, 0xaf, 0xf4, 0xdb, 0xb7, 0xa1, 0xe6, 0xc9, 0x37, 0xd4, 0x84, 0x66,
+      0xa4, 0x4e, 0x00, 0x93, 0x8e, 0xf1, 0x7d, 0x56, 0xf9, 0xa6, 0xde, 0xbb, 0x0f, 0x63, 0x50, 0x9d },
+    { 0xfd, 0xb5, 0x55, 0x46, 0x52, 0xa0, 0x2c, 0xb0, 0x5c, 0x69, 0x31, 0xb9, 0x69, 0xce, 0xcc, 0xfa,
+      0xea, 0x4d, 0x38, 0xe7, 0x49, 0x79, 0x17, 0x9d, 0x1c, 0xf0, 0xcf, 0x4b, 0xe2, 0xa8, 0xf8, 0x9d },
+} };
+
+} // namespace bb::srs

--- a/barretenberg/cpp/src/barretenberg/srs/factories/mem_grumpkin_crs_factory.cpp
+++ b/barretenberg/cpp/src/barretenberg/srs/factories/mem_grumpkin_crs_factory.cpp
@@ -18,7 +18,11 @@ class MemGrumpkinCrs : public Crs<Grumpkin> {
 
     MemGrumpkinCrs(std::vector<Grumpkin::AffineElement> points)
         : monomials_(std::move(points))
-    {}
+    {
+        if (monomials_.empty() || !monomials_[0].on_curve()) {
+            throw_or_abort("MemGrumpkinCrs: first point is not on the Grumpkin curve");
+        }
+    }
 
     ~MemGrumpkinCrs() override = default;
     std::span<Grumpkin::AffineElement> get_monomial_points() override { return monomials_; }

--- a/barretenberg/crs/bootstrap.sh
+++ b/barretenberg/crs/bootstrap.sh
@@ -98,8 +98,7 @@ function build {
     download_with_fallback "$g2" "g2.dat"
   fi
 
-  # TODO: This grumpkin CRS in S3 still has the 28 byte header on it. Remove.
-  # And if we ever need more than transcript00.dat, concatenate to single file like we did with bn254 above.
+  # The Grumpkin SRS is a 16 MiB file (2^18 affine points × 64 bytes/point, big-endian x ‖ y).
   crs_size=$((2**18))
   crs_size_bytes=$((crs_size*64))
   gg1=$crs_path/grumpkin_g1.flat.dat


### PR DESCRIPTION
The Grumpkin IPA SRS is meant to be reproducible from a fixed seed, but nothing checked the bytes we actually load against it — the loader only did an on-curve check on the first point, and the WASM ingress did nothing. A tampered CDN download or `~/.bb-crs` cache file could swap in points with known discrete logs and quietly break IPA binding.

This pins per-chunk SHA-256 hashes of the canonical SRS and verifies whatever prefix gets loaded: the native cache path, the WASM ingress from bb.js, and the generator/on-disk tests. Per-chunk rather than one whole-file digest because callers load prefixes — bb.js fetches 2^16 points, the native prover its dyadic ECCVM size, and only bootstrap pulls all 2^18.

Stacked on #22908: the generator-reproducibility test only passes with that branch's canonical `from_compressed` fix, so this targets it as the base.