### PR TITLE
test(e2e): stabilize invalid proposal slashing target slot in `attested_invalid_proposal`

### DIFF
--- a/yarn-project/end-to-end/src/e2e_slashing/attested_invalid_proposal.test.ts
+++ b/yarn-project/end-to-end/src/e2e_slashing/attested_invalid_proposal.test.ts
@@ -135,15 +135,18 @@ async function advanceToEpochBeforePipelinedTargetSlot({
     const currentEpoch = await cheatCodes.getEpoch();
     const nextEpoch = Number(currentEpoch) + 1;
     const firstSlotOfNextEpoch = nextEpoch * Number(epochDuration);
+    // The prior pipelined target can start first after the epoch warp and consume the bad proposer config.
+    const priorPipelinedTargetSlot = SlotNumber(firstSlotOfNextEpoch);
     const pipelinedTargetSlot = SlotNumber(firstSlotOfNextEpoch + 1);
+    const priorProposer = await epochCache.getProposerAttesterAddressInSlot(priorPipelinedTargetSlot);
     const proposer = await epochCache.getProposerAttesterAddressInSlot(pipelinedTargetSlot);
 
     logger.info(
       `Checking pipelined target slot ${pipelinedTargetSlot} in epoch ${nextEpoch} for proposer ${targetProposer}`,
-      { proposer: proposer?.toString() },
+      { proposer: proposer?.toString(), priorPipelinedTargetSlot, priorProposer: priorProposer?.toString() },
     );
 
-    if (proposer?.equals(targetProposer)) {
+    if (proposer?.equals(targetProposer) && !priorProposer?.equals(targetProposer)) {
       return { targetEpoch: EpochNumber(nextEpoch), targetSlot: pipelinedTargetSlot };
     }
 


### PR DESCRIPTION
## Summary
- skip target slots in attested invalid proposal slashing when the previous pipelined target slot has the same bad proposer
- log the previous pipelined target proposer while selecting the test slot

## Why
CI run http://ci.aztec-labs.com/bf99262466eae1dd selected slot 21 for the invalid checkpoint scenario, but the same bad proposer could first run a prior pipelined slot and build only a partial checkpoint. That left the test waiting for block-proposed events on the intended slot that never arrived. Requiring the previous pipelined target slot to have a different proposer keeps the malicious config from being consumed by the wrong slot after the epoch warp.

## Testing
- yarn format end-to-end
- yarn build
- LOG_LEVEL='info; debug:sequencer,publisher,validator' yarn workspace @aztec/end-to-end test:e2e e2e_slashing/attested_invalid_proposal.test.ts