### PR TITLE
test(e2e): stabilize invalidation slots in `proposer invalidates multiple checkpoints`

### DIFF
--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_invalidate_block.parallel.test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_invalidate_block.parallel.test.ts
@@ -390,17 +390,46 @@ describe('e2e_epochs/epochs_invalidate_block', () => {
     const { l2SlotNumber: currentSlot } = await test.monitor.run();
     logger.warn(`First checkpoint mined, current slot is ${currentSlot}`);
 
-    // Pick the next two slots with a 2-slot gap to account for pipelining plus a margin
-    const badSlot1 = SlotNumber.add(currentSlot, 3);
-    const badSlot2 = SlotNumber.add(currentSlot, 4);
+    // The bad config is applied while sequencers are already running; skip pairs where the prior pipelined
+    // target slot could snapshot that config before the intended bad slots.
+    let badSlot1: SlotNumber | undefined;
+    let badSlot2: SlotNumber | undefined;
+    let badProposers: EthAddress[] = [];
+    const firstCandidateSlot = Number(currentSlot) + 3;
+    const maxBadSlotSearchAttempts = 20;
+    for (let attempt = 0; attempt < maxBadSlotSearchAttempts && badSlot1 === undefined; attempt++) {
+      const candidateSlot1 = SlotNumber(firstCandidateSlot + attempt);
+      const candidateSlot2 = SlotNumber.add(candidateSlot1, 1);
+      const priorPipelinedTargetSlot = SlotNumber.add(candidateSlot1, -1);
+      const [priorProposer, p1, p2] = await Promise.all([
+        test.epochCache.getProposerAttesterAddressInSlot(priorPipelinedTargetSlot),
+        test.epochCache.getProposerAttesterAddressInSlot(candidateSlot1),
+        test.epochCache.getProposerAttesterAddressInSlot(candidateSlot2),
+      ]);
+
+      logger.warn(`Checking bad checkpoint slots ${candidateSlot1} and ${candidateSlot2}`, {
+        priorPipelinedTargetSlot,
+        priorProposer: priorProposer?.toString(),
+        p1: p1?.toString(),
+        p2: p2?.toString(),
+      });
+
+      if (p1 && p2 && !priorProposer?.equals(p1) && !priorProposer?.equals(p2)) {
+        badSlot1 = candidateSlot1;
+        badSlot2 = candidateSlot2;
+        badProposers = [p1, p2];
+      }
+    }
+    if (badSlot1 === undefined || badSlot2 === undefined) {
+      throw new Error(`Could not find bad checkpoint slots after ${maxBadSlotSearchAttempts} attempts`);
+    }
     const badSlots = [badSlot1, badSlot2];
-    const badProposers = await Promise.all(badSlots.map(s => test.epochCache.getProposerAttesterAddressInSlot(s)));
 
     const badNodes = [];
     for (let badProposerIndex = 0; badProposerIndex < badProposers.length; badProposerIndex++) {
       const badProposer = badProposers[badProposerIndex];
       logger.warn(`Disabling invalidation checks and attestation gathering for proposer ${badProposer}`);
-      const nodeIndex = nodes.findIndex(n => n.getSequencer()!.validatorAddresses!.some(a => a.equals(badProposer!)));
+      const nodeIndex = nodes.findIndex(n => n.getSequencer()!.validatorAddresses!.some(a => a.equals(badProposer)));
       if (nodeIndex === -1) {
         throw new Error(`Could not find node for proposer ${badProposer}`);
       }


### PR DESCRIPTION
Summary:
- Scan for consecutive bad checkpoint slots whose prior pipelined target slot is not owned by either intended bad proposer.
- Keep the malicious-config injection tied to the selected bad proposers and remove the now-unnecessary non-null assertion.
- Add an inline comment documenting why the prior pipelined target slot matters.

Why:
The test applies malicious checkpoint config while sequencers are already running. With proposer pipelining, the previous target slot can snapshot that config before the intended bad slots are built. If that prior proposer is one of the intended bad proposers, the test may spend the malicious config on the wrong checkpoint and stop validating the intended two-checkpoint invalidation path. This mirrors the slot-selection issue fixed for the invalid proposal slashing test, but applies it to the consecutive checkpoint invalidation scenario.

Testing:
- yarn format end-to-end
- yarn build
- LOG_LEVEL="info; debug:sequencer,publisher,validator" yarn workspace @aztec/end-to-end test:e2e e2e_epochs/epochs_invalidate_block.parallel.test.ts -t "proposer invalidates multiple checkpoints"