### PR TITLE
fix: cap CI devbox hostname

### DIFF
--- a/ci3/bootstrap_ec2
+++ b/ci3/bootstrap_ec2
@@ -83,6 +83,7 @@ else
 fi
 
 [ -n "${INSTANCE_POSTFIX:-}" ] && instance_name+="_$INSTANCE_POSTFIX"
+docker_hostname=$(echo -n "$instance_name" | tr '_' '-' | cut -c 1-63)
 
 if [ "$use_ssh" -eq 1 ]; then
   echo_header "request build instance (SSH)"
@@ -298,7 +299,7 @@ start_build() {
 
   docker run --privileged --rm \${docker_args:-} \
     --name aztec_build \
-    --hostname $instance_name \
+    --hostname $docker_hostname \
     -v bootstrap_ci_local_docker:/var/lib/docker \
     -v bootstrap_ci_repo:/home/aztec-dev/aztec-packages \
     -v \$HOME/.ssh:/home/aztec-dev/.ssh:ro \


### PR DESCRIPTION
Running ci.sh grind was failing with `sethostname: invalid argument`. Codex attributed the failure to a long branch name, causing a long instance name, which was too long for `sethostname`. Confirmed that switching to a shorter branch name fixed the issue.

```
--- request build instance (SSH) ---
Requesting m6a.48xlarge spot instance (name: spl_fix-web3signer-pipelining-test_amd64_grind-test-cdfb13e6637062de) (type: m6a.48xlarge) (ami: ami-067627aa971a1dcbb) (bid: 8.3136)...
Waiting for instance id for spot request: sir-dvtzjepj...
Timeout waiting for spot request.
Requesting m6a.48xlarge on-demand instance (name: spl_fix-web3signer-pipelining-test_amd64_grind-test-cdfb13e6637062de) (type: m6a.48xlarge) (ami: ami-067627aa971a1dcbb) (bid: 8.3136)...
Instance id: i-0fd2be01d28ec47e5
Waiting for SSH at 13.58.96.227...
--- connect via SSH ---
Stdout is not a tty, running in background...
Host processes pinned to OS CPUs: 88-95,184-191
HOST: fetching EC2 metadata token...
HOST: metadata token acquired.
HOST: decoding credentials...
HOST: starting devbox container...
HOST: devbox container launched (pid=10513). Monitoring for spot termination...
HOST: preparing devbox (uid/gid, docker run)...
docker: Error response from daemon: failed to create task for container: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: error during container init: sethostname: invalid argument
```