### PR TITLE
chore(foundation): faster toBufferBE via zero fast-path

### DIFF
--- a/yarn-project/foundation/src/bigint-buffer/bigint-buffer.test.ts
+++ b/yarn-project/foundation/src/bigint-buffer/bigint-buffer.test.ts
@@ -1,6 +1,25 @@
-import { fromHex, toHex } from './index.js';
+import { fromHex, toBufferBE, toHex } from './index.js';
 
 describe('bigint-buffer', () => {
+  describe('toBufferBE', () => {
+    it('serializes zero to a zeroed buffer of the requested width', () => {
+      expect(toBufferBE(0n, 32)).toEqual(Buffer.alloc(32));
+    });
+
+    it('big-endian pads small values on the left', () => {
+      expect(toBufferBE(1n, 4)).toEqual(Buffer.from([0, 0, 0, 1]));
+      expect(toBufferBE(0x0102n, 4)).toEqual(Buffer.from([0, 0, 1, 2]));
+    });
+
+    it('serializes a value that exactly fills the width', () => {
+      expect(toBufferBE(0xdeadbeefn, 4)).toEqual(Buffer.from('deadbeef', 'hex'));
+    });
+
+    it('throws on negative values', () => {
+      expect(() => toBufferBE(-1n, 32)).toThrow('negative');
+    });
+  });
+
   describe('toHex', () => {
     it('does not pad even length', () => {
       expect(toHex(16n)).toEqual('0x10');

--- a/yarn-project/foundation/src/bigint-buffer/index.ts
+++ b/yarn-project/foundation/src/bigint-buffer/index.ts
@@ -49,8 +49,13 @@ export function toBufferLE(num: bigint, width: number): Buffer {
  * @returns A big-endian buffer representation of num.
  */
 export function toBufferBE(num: bigint, width: number): Buffer {
-  if (num < BigInt(0)) {
+  if (num < 0n) {
     throw new Error(`Cannot convert negative bigint ${num.toString()} to buffer with toBufferBE.`);
+  }
+  // The values serialized in the hot paths are overwhelmingly zero (field elements are mostly
+  // zero-padding in protocol structs), and the hex round-trip is wasteful for them.
+  if (num === 0n) {
+    return Buffer.alloc(width);
   }
   const hex = num.toString(16);
   const buffer = Buffer.from(hex.padStart(width * 2, '0').slice(0, width * 2), 'hex');


### PR DESCRIPTION
## Summary

Adds a zero fast-path to `toBufferBE`, the bigint→big-endian-buffer conversion underlying `Fr.toBuffer()`. Field elements serialized in protocol structs are overwhelmingly zero (kernel public inputs are mostly fixed-size zero-padding), so short-circuiting the zero case avoids a wasteful `bigint → hex string → Buffer.from(hex)` round-trip.

```ts
if (num === 0n) {
  return Buffer.alloc(width);
}
```

## Why

Profiling `Tx.toBuffer()` showed it spends ~6.7ms almost entirely in per-field `Fr.toBuffer()` across ~3900 fields, and **96% of those fields are zero**. The scalar conversion is already near-optimal otherwise — a 64-bit-words variant (`writeBigUInt64BE`×4) is actually *slower* on real (non-zero) field elements because V8's bigint shifts allocate.

Micro-benchmark of `toBufferBE` variants (width=32, correctness-checked against current):

| variant | 96%-zero (real) | all-random (worst case) |
|---|---|---|
| current | 452 ns | 382 ns |
| 64-bit words | 215 ns | 503 ns (slower) |
| **zero fast-path** | **55 ns** | 387 ns (free) |

The fast-path is ~8× on the real workload and costs one `=== 0n` compare on the worst case.

## Impact

End-to-end on `mockTx(42)`:

| | before | after |
|---|---|---|
| `tx.toBuffer()` total | 6.66 ms | 4.20 ms (−37%) |
| `data.toBuffer()` | 4.34 ms | 2.25 ms (−48%) |

`data.toBuffer()` (the kernel public inputs) is the production-relevant figure: the mock serializes an uncompressed proof, whereas real txs carry a compressed proof that serializes as a single blob. The benefit applies to every `Fr.toBuffer()` / serialization path in the monorepo, not just txs.

The remaining cost is structural — a Buffer is allocated per field and then `Buffer.concat`'d across thousands of them. Eliminating that needs a single-preallocated-buffer serializer; this change is the safe, broadly-beneficial first step.

## Testing

`toBufferBE` previously had no direct unit tests; added coverage for the zero path, big-endian left-padding, exact-width values, and the negative-input throw. The conversion is otherwise byte-identical to before.
