### PR TITLE
fix: drop usage of include and indexof on types that support equals

### DIFF
--- a/yarn-project/archiver/src/test/mock_l2_block_source.ts
+++ b/yarn-project/archiver/src/test/mock_l2_block_source.ts
@@ -367,7 +367,7 @@ export class MockL2BlockSource implements L2BlockSource, ContractDataSource {
       data: txEffect,
       l2BlockNumber: block.number,
       l2BlockHash: await block.hash(),
-      txIndexInBlock: block.body.txEffects.indexOf(txEffect),
+      txIndexInBlock: block.body.txEffects.findIndex(t => t.txHash.equals(txHash)),
     };
   }
 

--- a/yarn-project/end-to-end/src/e2e_synching.test.ts
+++ b/yarn-project/end-to-end/src/e2e_synching.test.ts
@@ -633,7 +633,7 @@ describe('e2e_synching', () => {
           );
           for (let i = 0; i < contracts.length; i++) {
             expect(contractInstances[i]).not.toBeUndefined();
-            expect(contractClassIds.includes(contractInstances[i].currentContractClassId)).toBeTrue;
+            expect(contractClassIds.some(id => id.equals(contractInstances[i].currentContractClassId))).toBeTrue;
           }
 
           expect(await archiver.getTxEffect(txHash)).not.toBeUndefined;
@@ -649,8 +649,8 @@ describe('e2e_synching', () => {
 
           const contractClassIdsAfter = await archiver.getContractClassIds();
 
-          expect(contractClassIdsAfter.includes(contractInstances[0].currentContractClassId)).toBeTrue;
-          expect(contractClassIdsAfter.includes(contractInstances[1].currentContractClassId)).toBeFalse;
+          expect(contractClassIdsAfter.some(id => id.equals(contractInstances[0].currentContractClassId))).toBeTrue;
+          expect(contractClassIdsAfter.some(id => id.equals(contractInstances[1].currentContractClassId))).toBeFalse;
           expect(await archiver.getContract(contracts[0].address)).not.toBeUndefined;
           expect(await archiver.getContract(contracts[1].address)).toBeUndefined;
           expect(await archiver.getContract(contracts[2].address)).toBeUndefined;

--- a/yarn-project/foundation/eslint-rules/no-non-primitive-in-collections.js
+++ b/yarn-project/foundation/eslint-rules/no-non-primitive-in-collections.js
@@ -20,18 +20,23 @@ const BRANDED_PRIMITIVE_TYPES = new Set([
   'IndexWithinCheckpoint',
 ]);
 
+const ARRAY_MEMBERSHIP_METHODS = new Set(['includes', 'indexOf', 'lastIndexOf']);
+
 /** @type {import('eslint').Rule.RuleModule} */
 export default {
   meta: {
     type: 'problem',
     docs: {
-      description: 'Disallow non-primitive types in Set<T> and Map<T, ...> collections',
+      description:
+        'Disallow non-primitive types in Set<T>, Map<T, ...>, and Array.prototype.{includes,indexOf,lastIndexOf} membership checks',
       category: 'Best Practices',
       recommended: true,
     },
     messages: {
       nonPrimitiveInSet: 'Set should only be used with primitive types. Found Set<{{type}}>',
       nonPrimitiveInMapKey: 'Map keys should only be primitive types. Found Map<{{type}}, ...>',
+      nonPrimitiveInArrayMembership:
+        'Array.prototype.{{method}} uses SameValueZero (reference equality for objects) and will silently miss equal-but-distinct class instances. Use .some(x => x.equals(target)) or project to a primitive (e.g. .map(x => x.toString())) first. Element type: {{type}}',
     },
     schema: [],
   },
@@ -229,6 +234,41 @@ export default {
     }
 
     /**
+     * Heuristic: does this type expose an `equals` method? Types that do are opting into value
+     * equality (Fr, AztecAddress, TxHash, ...) — and using SameValueZero membership checks on
+     * arrays of them is almost always a bug. Types without `equals` (callback function types,
+     * AbortController, plain objects) are typically used with reference equality intentionally.
+     */
+    function hasEqualsMethod(tsType) {
+      if (!tsType || !tsType.getProperty) return false;
+      const equalsSymbol = tsType.getProperty('equals');
+      if (!equalsSymbol) return false;
+      const decls = equalsSymbol.getDeclarations?.() ?? [];
+      return decls.some(d => ts.isMethodDeclaration(d) || ts.isMethodSignature(d));
+    }
+
+    /**
+     * Extract the element type of an Array<T> / ReadonlyArray<T> / T[] / readonly T[].
+     * Returns undefined for non-array receivers (e.g. `string`, which also has a `.includes` method).
+     */
+    function getArrayElementType(tsType) {
+      if (!tsType) return undefined;
+
+      if (typeof checker.getElementTypeOfArrayType === 'function') {
+        const elem = checker.getElementTypeOfArrayType(tsType);
+        if (elem) return elem;
+      }
+
+      const symbol = tsType.getSymbol ? tsType.getSymbol() : undefined;
+      const name = symbol?.getName?.();
+      if (name === 'Array' || name === 'ReadonlyArray') {
+        return tsType.typeArguments?.[0] ?? tsType.aliasTypeArguments?.[0];
+      }
+
+      return undefined;
+    }
+
+    /**
      * Get a readable type name from a type node
      */
     function getTypeName(typeNode) {
@@ -314,6 +354,55 @@ export default {
               },
             });
           }
+        }
+      },
+
+      CallExpression(node) {
+        // We need the type checker to know whether the receiver is an array of class instances.
+        // In AST-only fallback mode we can't reliably distinguish `addrs.includes(x)` (bug)
+        // from `["a","b"].includes(x)` (fine), so we skip rather than risk false positives.
+        if (!checker || !parserServices) {
+          return;
+        }
+
+        const callee = node.callee;
+        if (callee.type !== 'MemberExpression' || callee.computed) {
+          return;
+        }
+        if (callee.property.type !== 'Identifier' || !ARRAY_MEMBERSHIP_METHODS.has(callee.property.name)) {
+          return;
+        }
+        if (node.arguments.length === 0) {
+          return;
+        }
+
+        try {
+          const receiverTsNode = parserServices.esTreeNodeToTSNodeMap.get(callee.object);
+          const receiverType = checker.getTypeAtLocation(receiverTsNode);
+          const elementType = getArrayElementType(receiverType);
+          if (!elementType) {
+            // Not an array (e.g. `string.includes`, or an unknown receiver) — leave alone.
+            return;
+          }
+          if (isAllowedTypeWithChecker(elementType)) {
+            return;
+          }
+          // Only flag types that opted into value equality. Arrays of callbacks / DOM types /
+          // plain function types are commonly searched via reference identity on purpose.
+          if (!hasEqualsMethod(elementType)) {
+            return;
+          }
+
+          context.report({
+            node,
+            messageId: 'nonPrimitiveInArrayMembership',
+            data: {
+              method: callee.property.name,
+              type: checker.typeToString(elementType),
+            },
+          });
+        } catch (e) {
+          // Type information unavailable for this node — skip silently.
         }
       },
     };

--- a/yarn-project/foundation/src/trees/indexed_merkle_tree_calculator.test.ts
+++ b/yarn-project/foundation/src/trees/indexed_merkle_tree_calculator.test.ts
@@ -200,13 +200,13 @@ describe('indexed merkle tree root calculator', () => {
     const testValue = values[testIndex];
     const sortedValues = [...values].sort((a, b) => a.cmp(b));
     // ...and find its next value.
-    const nextValue = sortedValues[sortedValues.indexOf(testValue) + 1] || Fr.ZERO;
+    const nextValue = sortedValues[sortedValues.findIndex(v => v.equals(testValue)) + 1] || Fr.ZERO;
 
     // Reconstruct its leaf preimage.
     const testLeafPreimage = new TestLeafPreimage(
       testValue.toField(),
       nextValue.toField(),
-      BigInt(values.indexOf(nextValue) || 0),
+      BigInt(values.findIndex(v => v.equals(nextValue))),
     );
     expect(tree.leafPreimages[testIndex]).toEqual(testLeafPreimage);
 
@@ -243,7 +243,7 @@ describe('indexed merkle tree root calculator', () => {
     const expectedLowLeaf = new TestLeafPreimage(
       previousValue.toField(),
       nextValue.toField(),
-      BigInt(values.indexOf(nextValue)),
+      BigInt(values.findIndex(v => v.equals(nextValue))),
     );
     const lowLeaf = tree.getLowLeaf(testValue.toBigInt());
     const hashedLowLeaf = await hasher.hashInputs(lowLeaf.toHashInputs());

--- a/yarn-project/pxe/src/logs/log_service.ts
+++ b/yarn-project/pxe/src/logs/log_service.ts
@@ -168,8 +168,8 @@ export class LogService {
     }
     const recipientIvsk = await this.keyStore.getMasterIncomingViewingSecretKey(recipient);
 
-    // We implicitly add all PXE accounts as senders, this helps us decrypt tags on notes that we send to ourselves
-    // (recipient = us, sender = us)
+    // We implicitly add all PXE accounts as senders, this helps us find tagged logs with messages that are sent to a
+    // local account (recipient = us, sender = us)
     const allSenders = [...(await this.senderAddressBookStore.getSenders()), ...(await this.keyStore.getAccounts())];
 
     // We deduplicate the senders by adding them to a set and then converting the set back to an array

--- a/yarn-project/pxe/src/pxe.test.ts
+++ b/yarn-project/pxe/src/pxe.test.ts
@@ -119,6 +119,13 @@ describe('PXE', () => {
     await pxe.registerAccount(randomSecretKey, randomPartialAddress);
   });
 
+  it('does not add a keystore account to the sender address book when registered as a sender', async () => {
+    const { address } = await pxe.registerAccount(Fr.random(), Fr.random());
+    await pxe.registerSender(address);
+    const senders = await pxe.getSenders();
+    expect(senders.map(s => s.toString())).not.toContain(address.toString());
+  });
+
   it('successfully adds a contract', async () => {
     const contracts = await Promise.all([randomDeployedContract(), randomDeployedContract()]);
     for (const contract of contracts) {

--- a/yarn-project/pxe/src/pxe.ts
+++ b/yarn-project/pxe/src/pxe.ts
@@ -604,7 +604,7 @@ export class PXE {
   public async registerAccount(secretKey: Fr, partialAddress: PartialAddress): Promise<CompleteAddress> {
     const accounts = await this.keyStore.getAccounts();
     const accountCompleteAddress = await this.keyStore.addAccount(secretKey, partialAddress);
-    if (accounts.includes(accountCompleteAddress.address)) {
+    if (accounts.some(a => a.equals(accountCompleteAddress.address))) {
       this.log.info(`Account:\n "${accountCompleteAddress.address.toString()}"\n already registered.`);
       return accountCompleteAddress;
     } else {
@@ -634,7 +634,7 @@ export class PXE {
     }
 
     const accounts = await this.keyStore.getAccounts();
-    if (accounts.includes(sender)) {
+    if (accounts.some(a => a.equals(sender))) {
       this.log.info(`Sender:\n "${sender.toString()}"\n already registered.`);
       return sender;
     }

--- a/yarn-project/validator-client/src/proposal_handler.ts
+++ b/yarn-project/validator-client/src/proposal_handler.ts
@@ -777,7 +777,7 @@ export class ProposalHandler {
     // If we do not have all of the transactions, then we should fail
     if (txs.length !== txHashes.length) {
       const foundTxHashes = txs.map(tx => tx.getTxHash());
-      const missingTxHashes = txHashes.filter(txHash => !foundTxHashes.includes(txHash));
+      const missingTxHashes = txHashes.filter(txHash => !foundTxHashes.some(h => h.equals(txHash)));
       throw new TransactionsNotAvailableError(missingTxHashes);
     }
 


### PR DESCRIPTION
`includes` and `indexOf` compare values by reference, they don't do deep equality checks. We had three instances of this, two in pxe (not great, not terrible) and one in the validator client (minor, an error message would contain a misdiagnosis), plus a bunch in mocks and tests.

This introduces an eslint rule that catches this: if we do `includes` or `indexOf` on a type that implements the `equals` function, then that's an error. This PR also fixes some instances that are not actually incorrect as they happen to perform the check on values that were created locally, so the reference check matches the deep equality check, but this is brittle and should not be relied upon.