### PR TITLE
docs: update Google site verification file

### DIFF
--- a/docs/static/google699cae1d0c589fd1.html
+++ b/docs/static/google699cae1d0c589fd1.html
@@ -1,0 +1,1 @@
+google-site-verification: google699cae1d0c589fd1.html

--- a/docs/static/googleaca86f9522be80bf.html
+++ b/docs/static/googleaca86f9522be80bf.html
@@ -1,1 +1,0 @@
-google-site-verification: googleaca86f9522be80bf.html


### PR DESCRIPTION
Replaces the Google Search Console site-verification file in `docs/static/` with the new token.

- Remove `googleaca86f9522be80bf.html`
- Add `google699cae1d0c589fd1.html`

The filename is itself the verification token, so the old file is removed rather than edited in place.