### PR TITLE
fix(p2p): fall back to archiver in BLOCK_TXS response validation

### DIFF
--- a/yarn-project/end-to-end/src/e2e_p2p/late_prover_tx_collection.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/late_prover_tx_collection.test.ts
@@ -1,0 +1,165 @@
+import type { AztecNodeService } from '@aztec/aztec-node';
+import { waitForTx } from '@aztec/aztec.js/node';
+import { BlockNumber } from '@aztec/foundation/branded-types';
+import { retryUntil } from '@aztec/foundation/retry';
+import { tryStop } from '@aztec/stdlib/interfaces/server';
+import type { Tx } from '@aztec/stdlib/tx';
+
+import { jest } from '@jest/globals';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { shouldCollectMetrics } from '../fixtures/fixtures.js';
+import { ATTESTER_PRIVATE_KEYS_START_INDEX, createNodes, createProverNode } from '../fixtures/setup_p2p_test.js';
+import { P2PNetworkTest, SHORTENED_BLOCK_TIME_CONFIG_NO_PRUNES, WAIT_FOR_TX_TIMEOUT } from './p2p_network.js';
+import { submitTransactions } from './shared.js';
+
+// A prover joins the mesh after a block has been mined and its proposal/tx gossip already happened,
+// so it knows the block from its archiver (via L1 sync) but has no proposal locally and is missing
+// the block's txs. It must fetch them from its (dumb) peers over reqresp BLOCK_TXS — the same path
+// ProverNode.gatherTxs takes when preparing an epoch proof — and the test asserts the prover ends up
+// holding all of the block's txs.
+
+const NUM_VALIDATORS = 4;
+const NUM_TXS = 2;
+const BOOT_NODE_UDP_PORT = process.env.BOOT_NODE_UDP_PORT ? parseInt(process.env.BOOT_NODE_UDP_PORT) : 4900;
+const AZTEC_SLOT_DURATION = 12;
+const AZTEC_EPOCH_DURATION = 4;
+
+const DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'late-prover-'));
+
+jest.setTimeout(1000 * 60 * 10);
+
+describe('e2e_p2p_late_prover_tx_collection', () => {
+  let t: P2PNetworkTest;
+  let nodes: AztecNodeService[] = [];
+  let proverNode: AztecNodeService | undefined;
+
+  beforeEach(async () => {
+    t = await P2PNetworkTest.create({
+      testName: 'e2e_p2p_late_prover_tx_collection',
+      numberOfNodes: 0,
+      numberOfValidators: NUM_VALIDATORS,
+      basePort: BOOT_NODE_UDP_PORT,
+      metricsPort: shouldCollectMetrics(),
+      startProverNode: false, // we start our own prover, late, after a block is mined
+      initialConfig: {
+        ...SHORTENED_BLOCK_TIME_CONFIG_NO_PRUNES,
+        aztecSlotDuration: AZTEC_SLOT_DURATION,
+        aztecEpochDuration: AZTEC_EPOCH_DURATION,
+        listenAddress: '127.0.0.1',
+        enableProposerPipelining: true,
+        // Only build blocks that actually carry txs, so the chain idles after our block is mined and
+        // the late prover is never auto-triggered to collect for a different block.
+        minTxsPerBlock: 1,
+        inboxLag: 2,
+      },
+    });
+
+    await t.setup();
+    await t.applyBaseSetup();
+  });
+
+  afterEach(async () => {
+    await tryStop(proverNode);
+    await t.stopNodes(nodes);
+    await t.teardown();
+    for (let i = 0; i < NUM_VALIDATORS; i++) {
+      fs.rmSync(`${DATA_DIR}-${i}`, { recursive: true, force: true, maxRetries: 3 });
+    }
+    fs.rmSync(`${DATA_DIR}-late-prover`, { recursive: true, force: true, maxRetries: 3 });
+  });
+
+  it("lets a late-joining prover collect a mined block's txs from dumb peers when it has no local proposal", async () => {
+    if (!t.bootstrapNodeEnr) {
+      throw new Error('Bootstrap node ENR is not available');
+    }
+
+    // 1. Stand up the validator network and let it form the mesh.
+    t.logger.info('Creating validator nodes');
+    nodes = await createNodes(
+      t.ctx.aztecNodeConfig,
+      t.ctx.dateProvider,
+      t.bootstrapNodeEnr,
+      NUM_VALIDATORS,
+      BOOT_NODE_UDP_PORT,
+      t.genesis,
+      DATA_DIR,
+      shouldCollectMetrics(),
+    );
+    await t.waitForP2PMeshConnectivity(nodes, NUM_VALIDATORS);
+    await t.setupAccount();
+
+    // 2. Submit txs and wait for them to be mined into a block. The validators end up holding the
+    //    proposal, the mined block, and the txs in their pools — everything the prover will be missing.
+    t.logger.info('Submitting transactions and waiting for them to be mined');
+    const txHashes = await submitTransactions(t.logger, nodes[0], NUM_TXS, t.fundedAccount);
+    await Promise.all(txHashes.map(h => waitForTx(nodes[0], h, { timeout: WAIT_FOR_TX_TIMEOUT })));
+
+    const receipt = await nodes[0].getTxReceipt(txHashes[0]);
+    const minedBlockNumber = BlockNumber(receipt.blockNumber!);
+    const minedBlock = await nodes[0].getBlockSource().getBlock({ number: minedBlockNumber });
+    if (!minedBlock) {
+      throw new Error(`Mined block ${minedBlockNumber} not found on validator`);
+    }
+    const blockTxHashes = minedBlock.body.txEffects.map(e => e.txHash);
+    t.logger.info(`Block ${minedBlockNumber} mined with ${blockTxHashes.length} txs`);
+
+    // 3. Start the prover LATE: after the block was mined and its proposal/tx gossip already happened.
+    //    It learns the mined block via L1/archiver sync, but never received the proposal or the txs.
+    t.logger.info('Creating late-joining prover node');
+    ({ proverNode } = await createProverNode(
+      t.ctx.aztecNodeConfig,
+      BOOT_NODE_UDP_PORT + NUM_VALIDATORS + 1,
+      t.bootstrapNodeEnr,
+      ATTESTER_PRIVATE_KEYS_START_INDEX + NUM_VALIDATORS + 1,
+      { dateProvider: t.ctx.dateProvider },
+      t.genesis,
+      `${DATA_DIR}-late-prover`,
+      shouldCollectMetrics(),
+    ));
+
+    // The prover syncs the mined block from L1 (no peers required), so wait for both the archive sync
+    // and for it to actually peer with the network before driving reqresp collection.
+    await retryUntil(
+      async () => (await proverNode!.getBlockNumber()) >= minedBlockNumber,
+      'prover to sync the mined block via L1',
+      60,
+      1,
+    );
+    await retryUntil(
+      async () => (await proverNode!.getP2P().getPeers()).length >= 2,
+      'prover to connect to peers',
+      60,
+      1,
+    );
+
+    // Sanity check: the prover does not have the block's txs (it joined after they were gossiped, and
+    // gossip is not replayed to late joiners). The archiver only carries tx effects, not full txs.
+    const txsBeforeCollection = await proverNode.getTxsByHash(blockTxHashes);
+    expect(txsBeforeCollection.length).toBe(0);
+
+    // 4. Drive the exact collection ProverNode.gatherTxs performs to prove the block: fetch the missing
+    //    txs over reqresp BLOCK_TXS from dumb peers, running the prover's real response validation
+    //    against its own (empty) attestation pool and its archiver.
+    //
+    //    Deadline must be computed against the same DateProvider the prover uses (advanced by the
+    //    harness's cheatCodes). Using Date.now() would land in the past from the prover's view of time,
+    //    and collectFastFor would short-circuit with timeout <= 0.
+    const txCollection = (proverNode as unknown as { p2pClient: { txCollection: TxCollectionLike } }).p2pClient
+      .txCollection;
+    const collected = await txCollection.collectFastForBlock(minedBlock, blockTxHashes, {
+      deadline: new Date(t.ctx.dateProvider.now() + AZTEC_SLOT_DURATION * 1000 * 4),
+    });
+
+    const collectedHashes = collected.map(tx => tx.getTxHash().toString()).sort();
+    const expectedHashes = blockTxHashes.map(h => h.toString()).sort();
+    expect(collectedHashes).toEqual(expectedHashes);
+  });
+});
+
+/** Minimal shape of the (otherwise private) TxCollection we reach into for this test. */
+interface TxCollectionLike {
+  collectFastForBlock(block: unknown, txHashes: unknown[], opts: { deadline: Date }): Promise<Tx[]>;
+}

--- a/yarn-project/p2p/src/services/libp2p/libp2p_service.test.ts
+++ b/yarn-project/p2p/src/services/libp2p/libp2p_service.test.ts
@@ -5,7 +5,7 @@ import { Secp256k1Signer } from '@aztec/foundation/crypto/secp256k1-signer';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { type Logger, createLogger } from '@aztec/foundation/log';
 import { openTmpStore } from '@aztec/kv-store/lmdb';
-import type { L2BlockSource } from '@aztec/stdlib/block';
+import type { L2Block, L2BlockSource } from '@aztec/stdlib/block';
 import type { ContractDataSource } from '@aztec/stdlib/contract';
 import { GasFees } from '@aztec/stdlib/gas';
 import type { ClientProtocolCircuitVerifier } from '@aztec/stdlib/interfaces/server';
@@ -328,6 +328,13 @@ describe('LibP2PService', () => {
       return new BlockTxsResponse(archiveRoot, txs as TxArray, BitVector.init(length, indices));
     }
 
+    /** Builds a minimal archived block whose txEffects carry the given tx hashes, for archiver-fallback tests. */
+    function makeArchivedBlock(txHashes: string[]): L2Block {
+      return {
+        body: { txEffects: txHashes.map(h => ({ txHash: { toString: () => h } })) },
+      } as unknown as L2Block;
+    }
+
     /** Sets up the mempools with a mock attestation pool that returns a proposal with given tx hashes. */
     function setProposalTxHashes(svc: TestLibP2PService, txHashes: string[]): void {
       // Create a partial mock of the attestation pool that only implements getBlockProposalByArchive.
@@ -483,21 +490,44 @@ describe('LibP2PService', () => {
       expect(mockPeerManager.penalizePeer).toHaveBeenCalledWith(mockPeerId, PeerErrorSeverity.LowToleranceError);
     });
 
-    it('should reject without penalizing when proposal is missing', async () => {
+    it('should reject without penalizing when the block is unknown (no proposal and not in the archiver)', async () => {
       const hash = Fr.random();
       // Simple valid shape that should pass pre-checks
       const request = makeRequest(hash, 3, [0, 2]);
       const response = makeResponse(hash, 3, [0, 2], ['0xgood0']);
 
-      // No proposal available - mock attestationPool to return undefined
+      // Neither the attestation pool nor the archiver knows this block, so we cannot verify the
+      // membership/order of the returned txs. This is not a peer fault, so no penalty is applied.
       const mockAttestationPool: MockAttestationPoolForTests = {
         getBlockProposalByArchive: (_: string) => Promise.resolve(undefined),
       };
       service.setAttestationPool(mockAttestationPool);
+      mockArchiver.getBlock.mockResolvedValue(undefined);
 
       const ok = await service.validateRequestedBlockTxsConsistency(request, response, mockPeerId);
       expect(ok).toBe(false);
       expect(mockPeerManager.penalizePeer).not.toHaveBeenCalled();
+    });
+
+    // Regression test for the tx-collection ban-storm: a prover (or any node) collecting txs to
+    // prove an already-mined block has no block proposal in its attestation pool, but it does know
+    // the block via the archiver. The validator must fall back to the archiver (as the responder
+    // handler does) so it can accept valid responses instead of rejecting every one and storming peers.
+    it('should accept when the proposal is missing but the block is known via the archiver', async () => {
+      const hash = Fr.random();
+      const request = makeRequest(hash, 5, [0, 2, 4]);
+      const response = makeResponse(hash, 5, [0, 2, 4], ['0xgood0', '0xgood2', '0xgood4']);
+
+      // No proposal (the prover never received it), but the mined block is in the archiver.
+      service.setAttestationPool({ getBlockProposalByArchive: (_: string) => Promise.resolve(undefined) });
+      mockArchiver.getBlock.mockResolvedValue(
+        makeArchivedBlock(['0xgood0', '0xother1', '0xgood2', '0xother3', '0xgood4']),
+      );
+
+      const ok = await service.validateRequestedBlockTxsConsistency(request, response, mockPeerId);
+      expect(ok).toBe(true);
+      expect(mockPeerManager.penalizePeer).not.toHaveBeenCalled();
+      expect(mockArchiver.getBlock).toHaveBeenCalledWith({ archive: hash });
     });
   });
 

--- a/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
+++ b/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
@@ -1560,18 +1560,26 @@ export class LibP2PService extends WithTracer implements P2PService {
         );
       }
 
-      // Given proposal (should have locally), ensure returned txs are valid subset and match request indices
+      // To verify membership/order of the returned txs we need the canonical tx hash list for the
+      // block. Prefer the block proposal (held while a block is in flight), but fall back to the
+      // archiver for blocks we only know as mined — e.g. a prover collecting txs to prove a block it
+      // never received a proposal for. This mirrors the responder side (reqRespBlockTxsHandler),
+      // which serves from proposal-or-archiver.
       const proposal = await this.mempools.attestationPool.getBlockProposalByArchive(request.archiveRoot.toString());
-      if (proposal) {
+      const blockTxHashes =
+        proposal?.txHashes ??
+        (await this.archiver.getBlock({ archive: request.archiveRoot }))?.body.txEffects.map(e => e.txHash);
+
+      if (blockTxHashes) {
         // Build intersected indices
         const intersectIdx = request.txIndices.getTrueIndices().filter(i => response.txIndices.isSet(i));
 
         // Enforce subset membership and preserve increasing order by index.
-        const hashToIndexInProposal = new Map<string, number>(
-          proposal.txHashes.map((h, i) => [h.toString(), i] as [string, number]),
+        const hashToIndexInBlock = new Map<string, number>(
+          blockTxHashes.map((h, i) => [h.toString(), i] as [string, number]),
         );
         const allowedIndexSet = new Set(intersectIdx);
-        const indices = returnedHashes.map(h => hashToIndexInProposal.get(h));
+        const indices = returnedHashes.map(h => hashToIndexInBlock.get(h));
         const allAllowed = indices.every(idx => idx !== undefined && allowedIndexSet.has(idx));
         const strictlyIncreasing = indices.every((idx, i) => (i === 0 ? idx !== undefined : idx! > indices[i - 1]!));
         if (!allAllowed || !strictlyIncreasing) {
@@ -1579,9 +1587,10 @@ export class LibP2PService extends WithTracer implements P2PService {
           throw new ValidationError('Returned txs do not match expected subset/order for requested indices');
         }
       } else {
-        // No local proposal, cannot check the membership/order of the returned txs
+        // Neither a local proposal nor an archived block: we cannot verify membership/order of the
+        // returned txs. This is a local-state gap, not a peer fault, so we do not penalize.
         this.logger.warn(
-          `Block proposal not found for archive root ${request.archiveRoot.toString()}; cannot validate membership/order of returned txs`,
+          `Block ${request.archiveRoot.toString()} not found in attestation pool or archiver; cannot validate membership/order of returned txs`,
         );
         return false;
       }


### PR DESCRIPTION
## Summary

`Libp2pService.validateRequestedBlockTxsConsistency` rejects every BLOCK_TXS reqresp response for any block whose proposal is not in the local attestation pool. The responder handler already falls back to the archiver in this case, the validator did not. So any node that doesn't have the proposal locally — but does know the block from the archiver — cannot collect its missing txs, and instead storms its peers until it is rate-limited and disconnected.

This PR teaches the validator the same proposal-or-archiver fallback the handler already uses, breaking the storm at its source.

## The defect: validator/handler asymmetry

To verify that a peer's BLOCK_TXS response matches the block, the validator needs the canonical tx-hash list for the block. Until this PR it consulted only the attestation pool:

```ts
// yarn-project/p2p/src/services/libp2p/libp2p_service.ts (pre-fix)
const proposal = await this.mempools.attestationPool.getBlockProposalByArchive(...);
if (proposal) { /* check membership/order */ } else { return false; }
```

The responder handler (`p2p/src/services/reqresp/protocols/block_txs/block_txs_handler.ts:40-45`) already serves from either source:

```ts
let txHashes = (await attestationPool.getBlockProposalByArchive(...))?.txHashes;
if (!txHashes) {
  txHashes = (await archiver.getBlock({ archive: request.archiveRoot }))?.body.txEffects.map(e => e.txHash);
}
```

So peers can produce valid responses for blocks that are only known via the archiver, but the validator at the other end rejects them.

## When this fires

Any p2p-enabled node subscribes to `block_proposal` gossip (`libp2p_service.ts:575`) and stores received proposals into its attestation pool (`validateAndStoreBlockProposal` at `libp2p_service.ts:1236`, calling `tryAddBlockProposal` at line 1252). Neither subscription nor storage is gated by `disableValidator` — that flag only controls the validator-client (attestation signing). So in the steady state, a node that was online when a proposal was gossiped does have it locally.

The validator's lookup fails whenever the node lacks the proposal in its local attestation pool, yet still needs to collect the block's txs over reqresp. The real-world triggers we've seen and can describe:

- **A node joins the mesh late** and misses the proposal gossip for blocks that  were proposed before it arrived. This was originally noticed during an e2e run where mesh formation was slower than usual, and it's the scenario the e2e test in this PR reproduces.
- A prover-node calling `ProverNode.gatherTxs` (`prover-node/src/prover-node.ts:330`) → `TxProvider.getTxsForBlock` → `TxCollection.collectFastFor({type:'block', ...})` → `BatchTxRequester` for any block whose proposal it doesn't happen to hold: prover restart, gossip drop, mesh churn during the epoch, etc.

In every case the prover (or any node) has the mined block in its archiver but no proposal in its attestation pool. Until this PR the validator only consulted the attestation pool, so every otherwise-valid response was rejected.

## The self-inflicted ban-storm

In `BatchTxRequester` (`p2p/src/services/reqresp/batch-tx-requester/batch_tx_requester.ts`):

```ts
// line 432-438: every response gets rejected because validation has no way to validate it
const isValid = await this.p2pService.validateRequestedBlockTxsConsistency(...);
if (!isValid) {
  this.handleFailResponseFromPeer(peerId, ReqRespStatus.INTERNAL_ERROR);
  return;
}

// line 461-481: INTERNAL_ERROR correctly does not penalize the peer, but
// also does not back off — the dumb worker loop just rotates to the next peer:
if (responseStatus === ReqRespStatus.NOT_FOUND || responseStatus === ReqRespStatus.INTERNAL_ERROR) {
  this.peers.markPeerDumb(peerId);
  this.txsMetadata.clearPeerData(peerId);
  return;
}
```

The dumb worker loop (`batch_tx_requester.ts:261-304`) has no inter-iteration sleep and ten parallel workers (`dumbParallelWorkerCount: 10`) round-robin the peers. Per-peer in-flight de-duplication caps it at one request in flight per peer, but the steady-state hit-rate per peer easily exceeds the responder's per-peer GCRA cap.

The penalty arrives from the **responder** side, on the requester:

```ts
// rate_limiter.ts:214-225
if (rateLimitStatus === RateLimitStatus.DeniedPeer) {
  this.peerScoring.penalizePeer(peerId, PeerErrorSeverity.HighToleranceError);
}
```

```
BLOCK_TXS per-peer cap : 10 req / 1000 ms   (rate_limits.ts:55-65)
HighToleranceError     : -2 score points    (peer_scoring.ts:34-36)
disconnect threshold   : -50                (peer_scoring.ts:57)
ban threshold          : -100               (peer_scoring.ts:56)
```

With ~1 GCRA denial per second per peer, the prover loses 2 points/sec at each responder. The first responder hits **-50 in ~25 s** and goodbyes the prover via `peer_manager.ts:601-603 pruneUnhealthyPeers` (`GoodByeReason.LOW_SCORE`); **-100 in ~50 s** would ban.

## Fix

A four-line change in `yarn-project/p2p/src/services/libp2p/libp2p_service.ts`: fall back to the archiver after the attestation-pool lookup, mirroring the responder handler. If neither source has the block we still return `false`without penalising the peer (it really is unverifiable locally).

```ts
const proposal = await this.mempools.attestationPool.getBlockProposalByArchive(...);
const blockTxHashes =
  proposal?.txHashes ??
  (await this.archiver.getBlock({ archive: request.archiveRoot }))?.body.txEffects.map(e => e.txHash);

if (blockTxHashes) { /* existing membership/order check, against blockTxHashes */ }
else               { /* unchanged: log warn, return false, no penalty */ }
```

The validator's other checks (archive-root match, bitvector length, no dupes, size bounds, subset-membership, ordering) are unchanged.

## Tests

**Unit anchor** — `p2p/src/services/libp2p/libp2p_service.test.ts`

- New test: *"should accept when the proposal is missing but the block is known via the archiver"* — verified red before the fix (`Expected: true, Received: false`) and green after.
- Existing test renamed and tightened to *"should reject without penalising when the block is unknown (no proposal and not in the archiver)"* — covers the still-correct rejection path.
- All 46 tests in the file pass.

**End-to-end** — `end-to-end/src/e2e_p2p/late_prover_tx_collection.test.ts`

Validators form a mesh and mine a block carrying real txs; a prover joins **after** the block is mined, so it has the block in its archiver but never received the proposal or txs over gossip. The test then drives the exact production path the prover would take to gather txs for proving:

```ts
const txCollection = (proverNode as ...).p2pClient.txCollection;
const collected = await txCollection.collectFastForBlock(minedBlock, blockTxHashes, { deadline });
expect(collected.map(t => t.getTxHash().toString()).sort())
  .toEqual(blockTxHashes.map(h => h.toString()).sort());
```

- Red on the unfixed source: `collected.length === 0` (validation rejects every response, dumb loop runs until the deadline), assertion fails.
- Green with the fix: all of `block.body.txEffects`'s txs are collected.
