### PR TITLE
fix: noir precommit re-staging inside worktrees

### DIFF
--- a/noir-projects/precommit.sh
+++ b/noir-projects/precommit.sh
@@ -4,6 +4,9 @@
 # Nothing should cause a failure, because that would annoy everyone if all they're trying to do is commit.
 set -euo pipefail
 
+# we have to unset this env var set by git hooks so that this relative paths work correctly when used inside worktrees
+unset GIT_DIR
+
 cd $(dirname $0)
 
 export FORCE_COLOR=true


### PR DESCRIPTION
Same bug and fix as #22557 — that PR patched `yarn-project/precommit.sh` but didn't touch `noir-projects/precommit.sh`, which has the same `cd $(dirname $0)` + later `git rev-parse --show-toplevel` pattern.

Inside a worktree, git sets `GIT_DIR` absolutely when invoking hooks; after the `cd`, `--show-toplevel` returns the `noir-projects/` subdir instead of the worktree root. The re-staging step then runs `git add` on paths that don't exist on disk, and `git add` on a missing path that's in the index stages a deletion — so committing `.nr` files inside a worktree silently dropped them from the tree.

Same one-liner fix: `unset GIT_DIR` near the top.