### PR TITLE
feat(aztec-nr): encrypt handshake log for indistinguishability

### DIFF
--- a/noir-projects/noir-contracts/contracts/message_discovery/handshake_registry_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/message_discovery/handshake_registry_contract/src/main.nr
@@ -23,7 +23,10 @@ pub contract HandshakeRegistry {
     use aztec::{
         keys::{ecdh_shared_secret::derive_ecdh_shared_secret, ephemeral::generate_positive_ephemeral_key_pair},
         macros::{functions::external, storage::storage},
-        messages::message_delivery::MessageDelivery,
+        messages::{
+            encryption::{aes128::AES128, message_encryption::MessageEncryption},
+            message_delivery::MessageDelivery,
+        },
         oracle::notes::set_sender_for_tags,
         protocol::{
             address::AztecAddress, constants::DOM_SEP__NON_INTERACTIVE_HANDSHAKE_LOG_TAG, hash::compute_log_tag,
@@ -46,7 +49,7 @@ pub contract HandshakeRegistry {
     /// `S = eph_sk * recipient_address_point`, and produces three effects:
     ///
     /// 1. Inserts or replaces a [`HandshakeNote`] owned by `sender`, holding the raw point `S`.
-    /// 2. Emits a 1-field private log under a recipient-keyed tag with payload `[eph_pk.x]`. The recipient
+    /// 2. Emits an encrypted private log under a recipient-keyed tag with payload `[eph_pk.x]`. The recipient
     ///    discovers handshakes addressed to them by scanning their tag and recovers `S` from `eph_pk` via their own
     ///    ECDH (`recipient_isk * eph_pk`). `eph_pk.y` is fixed positive by the
     ///    [`generate_positive_ephemeral_key_pair`] convention, so only `eph_pk.x` is transmitted.
@@ -70,7 +73,7 @@ pub contract HandshakeRegistry {
         // is safe to set from a constrained context.
         unsafe { set_sender_for_tags(sender) };
         // Delivery is `ONCHAIN_UNCONSTRAINED`. The recipient is not involved in this note's delivery. They
-        // discover the handshake via the recipient-keyed log emitted below, not via the sender's note.
+        // discover the handshake via the encrypted log emitted below, not via the sender's note.
         // We use onchain unconstrained delivery rather than `OFFCHAIN` so the note is
         // discoverable via normal PXE sync.
         self.storage.handshakes.at(recipient).at(sender).initialize_or_replace(|_| note).deliver(
@@ -82,8 +85,8 @@ pub contract HandshakeRegistry {
             DOM_SEP__NON_INTERACTIVE_HANDSHAKE_LOG_TAG,
         );
 
-        // TODO(F-653): Encrypt `eph_pk.x` to keep the log private
-        self.context.emit_private_log_unsafe(log_tag, BoundedVec::from_array([eph_pk.x]));
+        let ciphertext = AES128::encrypt([eph_pk.x], recipient, self.context.this_address());
+        self.context.emit_private_log_unsafe(log_tag, BoundedVec::from_array(ciphertext));
 
         note.siloed_for(self.msg_sender())
     }

--- a/noir-projects/noir-contracts/contracts/message_discovery/handshake_registry_contract/src/test.nr
+++ b/noir-projects/noir-contracts/contracts/message_discovery/handshake_registry_contract/src/test.nr
@@ -3,7 +3,7 @@ use crate::HandshakeRegistry;
 use aztec::{
     protocol::{
         address::AztecAddress,
-        constants::DOM_SEP__NON_INTERACTIVE_HANDSHAKE_LOG_TAG,
+        constants::{DOM_SEP__NON_INTERACTIVE_HANDSHAKE_LOG_TAG, PRIVATE_LOG_SIZE_IN_FIELDS},
         hash::{compute_log_tag, compute_siloed_private_log_first_field},
         traits::{FromField, ToField},
     },
@@ -66,9 +66,9 @@ unconstrained fn handshake_to_invalid_recipient_panics() {
 }
 
 // The handshake tag depends only on the recipient, so multiple senders posting to
-// the same recipient land under log tag.
+// the same recipient land under the same log tag.
 #[test]
-unconstrained fn two_senders_to_same_recipient_share_tag_with_distinct_payloads() {
+unconstrained fn two_senders_to_same_recipient_share_tag() {
     let (env, registry_address, sender, other_sender, recipient) = setup();
     let registry = HandshakeRegistry::at(registry_address);
 
@@ -86,22 +86,18 @@ unconstrained fn two_senders_to_same_recipient_share_tag_with_distinct_payloads(
     );
     let expected_siloed_tag = compute_siloed_private_log_first_field(registry_address, raw_tag);
 
-    // Each announcement log carries [siloed tag, eph_pk.x] = 2 fields.
-    assert_eq(logs_first.get(1).len(), 2);
-    assert_eq(logs_second.get(1).len(), 2);
+    // The handshake announcement log (index 1) is encrypted and uniformly sized.
+    assert_eq(logs_first.get(1).len(), PRIVATE_LOG_SIZE_IN_FIELDS);
+    assert_eq(logs_second.get(1).len(), PRIVATE_LOG_SIZE_IN_FIELDS);
     assert_eq(logs_first.get(1).get(0), expected_siloed_tag);
     assert_eq(logs_second.get(1).get(0), expected_siloed_tag);
 
-    let eph_pk_x_0 = logs_first.get(1).get(1);
-    let eph_pk_x_1 = logs_second.get(1).get(1);
-    assert(eph_pk_x_0 != 0, "eph_pk.x should be non-zero");
-    assert(eph_pk_x_1 != 0, "eph_pk.x should be non-zero");
-    assert(eph_pk_x_0 != eph_pk_x_1, "ephemeral keys should differ in handshakes from different senders");
+    // Different ephemeral keys produce different ciphertexts even under the same tag.
+    assert(logs_first.get(1).get(1) != logs_second.get(1).get(1), "ciphertexts should differ across senders");
 }
 
 // Re-handshaking for the same `(sender, recipient)` replaces the prior current handshake and produces
-// distinct `S` (hence distinct app-siloed secrets when siloed against the same caller). Each call emits a
-// distinct ephemeral key in its log.
+// distinct `S` (hence distinct app-siloed secrets when siloed against the same caller).
 #[test]
 unconstrained fn rehandshake_replaces_previous_secret_and_returns_latest() {
     let (env, registry_address, sender, _, recipient) = setup();
@@ -120,13 +116,15 @@ unconstrained fn rehandshake_replaces_previous_secret_and_returns_latest() {
         DOM_SEP__NON_INTERACTIVE_HANDSHAKE_LOG_TAG,
     );
     let expected_siloed_tag = compute_siloed_private_log_first_field(registry_address, raw_tag);
+
+    // Both handshake announcement logs are encrypted, uniformly sized, and share the same tag.
+    assert_eq(logs_first.get(1).len(), PRIVATE_LOG_SIZE_IN_FIELDS);
+    assert_eq(logs_second.get(1).len(), PRIVATE_LOG_SIZE_IN_FIELDS);
     assert_eq(logs_first.get(1).get(0), expected_siloed_tag);
     assert_eq(logs_second.get(1).get(0), expected_siloed_tag);
 
-    assert(
-        logs_first.get(1).get(1) != logs_second.get(1).get(1),
-        "ephemeral keys should differ across repeated handshakes",
-    );
+    // Different ephemeral keys produce different ciphertexts even under the same tag.
+    assert(logs_first.get(1).get(1) != logs_second.get(1).get(1), "ciphertexts should differ across handshakes");
 
     // Same caller and same `(sender, recipient)`, but two distinct raw `S` produce two distinct silos
     assert(secret_first != secret_second, "successive handshakes should produce distinct app-siloed secrets");


### PR DESCRIPTION
## Summary

- AES128-encrypts the handshake announcement log payload (`eph_pk.x`) so it produces a uniform 16-field log, matching all other private messages. Previously the handshake emitted a 2-field log (tag + raw `eph_pk.x`), letting an observer identify handshake transactions by log size.
- The existing recipient-keyed handshake tag (`DOM_SEP__NON_INTERACTIVE_HANDSHAKE_LOG_TAG`) is preserved — only the payload is encrypted.
- Updates test assertions to check for `PRIVATE_LOG_SIZE_IN_FIELDS` and compares ciphertexts instead of raw ephemeral key values.

Fixes F-653