### PR TITLE
feat(archiver): add getL2ToL1MembershipWitness node RPC

### DIFF
--- a/docs/docs-developers/docs/aztec-nr/framework-description/ethereum_aztec_messaging.md
+++ b/docs/docs-developers/docs/aztec-nr/framework-description/ethereum_aztec_messaging.md
@@ -69,7 +69,6 @@ L2 to L1 messages are only available after the epoch proof is submitted to L1. S
 Compute the witness for the L2 to L1 message in TypeScript:
 
 ```ts
-import { computeL2ToL1MembershipWitness } from "@aztec/stdlib/messaging";
 import { computeL2ToL1MessageHash } from "@aztec/stdlib/hash";
 
 const l2ToL1Message = computeL2ToL1MessageHash({
@@ -80,9 +79,8 @@ const l2ToL1Message = computeL2ToL1MessageHash({
   chainId: new Fr(chainId),
 });
 
-const witness = await computeL2ToL1MembershipWitness(
-  aztecNode,
-  txReceipt.blockNumber!,
+const witness = await aztecNode.getL2ToL1MembershipWitness(
+  txReceipt.txHash,
   l2ToL1Message
 );
 

--- a/docs/docs-developers/docs/resources/migration_notes.md
+++ b/docs/docs-developers/docs/resources/migration_notes.md
@@ -1466,23 +1466,22 @@ This change requires no input from your side unless you were testing or relying 
 
 `TxReceipt` now includes an `epochNumber` field that indicates which epoch the transaction was included in.
 
-### [Aztec.js] `computeL2ToL1MembershipWitness` signature changed
+### [Aztec.js] Use `getL2ToL1MembershipWitness` for L2-to-L1 message witnesses
 
-The function signature has changed to resolve the epoch internally from a transaction hash, rather than requiring the caller to pass the epoch number.
+The node now computes L2-to-L1 membership witnesses directly, resolving the epoch and Outbox root internally from the transaction hash. Use `getL2ToL1MembershipWitness` instead of fetching raw epoch messages and computing the witness client-side.
 
 **Migration:**
 
 ```diff
-- const witness = await computeL2ToL1MembershipWitness(aztecNode, epochNumber, messageHash);
-- // epoch was passed in by the caller
-+ const witness = await computeL2ToL1MembershipWitness(aztecNode, messageHash, txHash);
-+ // epoch is now available on the returned witness
+- const messages = await aztecNode.getL2ToL1Messages(epochNumber);
+- // compute the witness client-side from the epoch messages
++ const witness = await aztecNode.getL2ToL1MembershipWitness(txHash, messageHash);
 + const epoch = witness.epochNumber;
 ```
 
-The return type `L2ToL1MembershipWitness` now includes `epochNumber`. An optional `messageIndexInTx` parameter can be passed as the fourth argument to disambiguate when a transaction emits multiple identical L2-to-L1 messages.
+The return type `L2ToL1MembershipWitness` includes `epochNumber`. An optional `messageIndexInTx` parameter can be passed as the third argument to disambiguate when a transaction emits multiple identical L2-to-L1 messages.
 
-**Impact**: All call sites that compute L2-to-L1 membership witnesses must update to the new argument order and extract `epochNumber` from the result instead of passing it in.
+**Impact**: Call sites that compute L2-to-L1 membership witnesses should use the node method and extract `epochNumber` from the result.
 
 ### [Aztec.js] `getPublicEvents` now returns an object instead of an array
 
@@ -2835,31 +2834,17 @@ Note: current node softwares still produce exactly one L2 block per checkpoint, 
 
 ### [L1 Contracts] L2-to-L1 messages are now grouped by epoch.
 
-L2-to-L1 messages are now aggregated and organized per epoch rather than per block. This change affects how you compute membership witnesses for consuming messages on L1. You now need to know the epoch number in which the message was emitted to retrieve and consume the message.
+L2-to-L1 messages are aggregated and organized per epoch rather than per block, but callers should now ask the node to compute the membership witness directly from the emitting transaction hash. The node resolves the epoch and Outbox root internally.
 
 **Note**: This is only an API change. The protocol behavior remains the same - messages can still only be consumed once an epoch is proven as before.
 
 #### What changed
 
-Previously, you might have computed the membership witness without explicitly needing the epoch:
+Previously, callers fetched epoch messages and computed the witness client-side. Now, call `getL2ToL1MembershipWitness` on the node:
 
 ```typescript
-const witness = await computeL2ToL1MembershipWitness(
-  node,
-  l2TxReceipt.blockNumber,
-  l2ToL1Message,
-);
-```
-
-Now, you should provide the epoch number:
-
-```typescript
-const epoch = await rollup.getEpochNumberForCheckpoint(
-  CheckpointNumber.fromBlockNumber(l2TxReceipt.blockNumber),
-);
-const witness = await computeL2ToL1MembershipWitness(
-  node,
-  epoch,
+const witness = await node.getL2ToL1MembershipWitness(
+  l2TxReceipt.txHash,
   l2ToL1Message,
 );
 ```

--- a/docs/docs-developers/docs/tutorials/js_tutorials/aave_bridge.md
+++ b/docs/docs-developers/docs/tutorials/js_tutorials/aave_bridge.md
@@ -369,7 +369,6 @@ import {
   computeL2ToL1MessageHash,
   computeSecretHash,
 } from "@aztec/stdlib/hash";
-import { computeL2ToL1MembershipWitness } from "@aztec/stdlib/messaging";
 import { EmbeddedWallet } from "@aztec/wallets/embedded";
 import { decodeEventLog, pad, toFunctionSelector } from "@aztec/viem";
 import { foundry } from "@aztec/viem/chains";

--- a/docs/docs-developers/docs/tutorials/js_tutorials/token_bridge.md
+++ b/docs/docs-developers/docs/tutorials/js_tutorials/token_bridge.md
@@ -436,7 +436,7 @@ Great! You can expand the L2 contract to add features like NFT transfers. For no
 
 #include_code exit_from_l2 /docs/examples/ts/token_bridge/index.ts typescript
 
-Just like in the L1 → L2 flow, you need to know what to claim on L1. Where in the message tree is the message you want to claim? Use the utility `computeL2ToL1MembershipWitness`, which provides the leaf and the sibling path of the message:
+Just like in the L1 → L2 flow, you need to know what to claim on L1. Where in the message tree is the message you want to claim? Use `node.getL2ToL1MembershipWitness`, which provides the leaf and the sibling path of the message:
 
 #include_code get_withdrawal_witness /docs/examples/ts/token_bridge/index.ts typescript
 

--- a/docs/docs-operate/operators/reference/node-api-reference.md
+++ b/docs/docs-operate/operators/reference/node-api-reference.md
@@ -582,7 +582,31 @@ curl -X POST http://localhost:8080 \
   -d '{"jsonrpc":"2.0","method":"node_getL1ToL2MessageCheckpoint","params":["0x1234..."],"id":1}'
 ```
 
+### node_getL2ToL1MembershipWitness
+
+Returns the L2-to-L1 membership witness for a message emitted by a transaction.
+
+**Parameters**:
+
+1. `txHash` - `TxHash` - The transaction that emitted the L2-to-L1 message.
+2. `message` - `Fr` - The message hash to prove inclusion of.
+3. `messageIndexInTx` - `number` - Optional index of the message within the transaction. Use this when the same message hash appears multiple times in the transaction.
+
+**Returns**: `L2ToL1MembershipWitness | undefined` - The membership witness, or undefined if the transaction is not settled or no covering Outbox root is available yet.
+
+**Example**:
+
+```bash
+curl -X POST http://localhost:8080 \
+  -H "Content-Type: application/json" \
+  -d "{\"jsonrpc\":\"2.0\",\"method\":\"node_getL2ToL1MembershipWitness\",\"params\":[\"0x1234...\",\"0xabcd...\"],\"id\":1}"
+```
+
 ### node_getL2ToL1Messages
+
+:::warning Deprecated
+Use `node_getL2ToL1MembershipWitness` to get an L2-to-L1 message witness directly.
+:::
 
 Returns all the L2 to L1 messages in an epoch.
 

--- a/docs/examples/ts/aave_bridge/index.ts
+++ b/docs/examples/ts/aave_bridge/index.ts
@@ -4,14 +4,12 @@ import { SetPublicAuthwitContractInteraction } from "@aztec/aztec.js/authorizati
 import { Fr } from "@aztec/aztec.js/fields";
 import { createAztecNodeClient, waitForNode } from "@aztec/aztec.js/node";
 import { createExtendedL1Client } from "@aztec/ethereum/client";
-import { OutboxContract } from "@aztec/ethereum/contracts";
 import { deployL1Contract } from "@aztec/ethereum/deploy-l1-contract";
 import { sha256ToField } from "@aztec/foundation/crypto/sha256";
 import {
   computeL2ToL1MessageHash,
   computeSecretHash,
 } from "@aztec/stdlib/hash";
-import { computeL2ToL1MembershipWitness } from "@aztec/stdlib/messaging";
 import { EmbeddedWallet } from "@aztec/wallets/embedded";
 import { decodeEventLog, pad, toFunctionSelector } from "@aztec/viem";
 import { foundry } from "@aztec/viem/chains";
@@ -280,17 +278,8 @@ while (provenBlockNumber < exitBlockNumber) {
 console.log("Block proven!\n");
 
 // Compute the membership witness using the message hash and the L2 tx hash.
-// The Outbox is queried to pick the smallest partial-proof root that covers the tx's checkpoint.
-const outbox = new OutboxContract(
-  l1Client,
-  nodeInfo.l1ContractAddresses.outboxAddress,
-);
-const witness = await computeL2ToL1MembershipWitness(
-  node,
-  outbox,
-  msgLeaf,
-  exitReceipt.txHash,
-);
+// The node picks the smallest partial-proof root that covers the tx's checkpoint.
+const witness = await node.getL2ToL1MembershipWitness(exitReceipt.txHash, msgLeaf);
 const epoch = witness!.epochNumber;
 const numCheckpointsInEpoch = witness!.numCheckpointsInEpoch;
 

--- a/docs/examples/ts/example_swap/index.ts
+++ b/docs/examples/ts/example_swap/index.ts
@@ -5,7 +5,6 @@ import { SetPublicAuthwitContractInteraction } from "@aztec/aztec.js/authorizati
 import { Fr } from "@aztec/aztec.js/fields";
 import { createAztecNodeClient, waitForNode } from "@aztec/aztec.js/node";
 import { createExtendedL1Client } from "@aztec/ethereum/client";
-import { OutboxContract } from "@aztec/ethereum/contracts";
 import { deployL1Contract } from "@aztec/ethereum/deploy-l1-contract";
 import { sha256ToField } from "@aztec/foundation/crypto/sha256";
 import { TokenContract } from "@aztec/noir-contracts.js/Token";
@@ -14,7 +13,6 @@ import {
   computeL2ToL1MessageHash,
   computeSecretHash,
 } from "@aztec/stdlib/hash";
-import { computeL2ToL1MembershipWitness } from "@aztec/stdlib/messaging";
 import { decodeEventLog, encodeFunctionData, pad } from "@aztec/viem";
 import { EmbeddedWallet } from "@aztec/wallets/embedded";
 import { foundry } from "@aztec/viem/chains";
@@ -446,17 +444,8 @@ const exitMsgLeaf = computeL2ToL1MessageHash({
 // docs:end:consume_l1_messages_setup
 
 // docs:start:consume_l1_messages_witnesses
-// The Outbox is queried to pick the smallest partial-proof root that covers each tx's checkpoint.
-const outbox = new OutboxContract(
-  l1Client,
-  nodeInfo.l1ContractAddresses.outboxAddress,
-);
-const exitWitness = await computeL2ToL1MembershipWitness(
-  node,
-  outbox,
-  exitMsgLeaf,
-  swapReceipt.txHash,
-);
+// The node picks the smallest partial-proof root that covers each tx's checkpoint.
+const exitWitness = await node.getL2ToL1MembershipWitness(swapReceipt.txHash, exitMsgLeaf);
 const exitSiblingPath = exitWitness!.siblingPath
   .toBufferArray()
   .map((buf: Buffer) => `0x${buf.toString("hex")}` as `0x${string}`);
@@ -506,12 +495,7 @@ const swapMsgLeaf = computeL2ToL1MessageHash({
   chainId: new Fr(foundry.id),
 });
 
-const swapWitness = await computeL2ToL1MembershipWitness(
-  node,
-  outbox,
-  swapMsgLeaf,
-  swapReceipt.txHash,
-);
+const swapWitness = await node.getL2ToL1MembershipWitness(swapReceipt.txHash, swapMsgLeaf);
 const swapSiblingPath = swapWitness!.siblingPath
   .toBufferArray()
   .map((buf: Buffer) => `0x${buf.toString("hex")}` as `0x${string}`);

--- a/docs/examples/ts/token_bridge/index.ts
+++ b/docs/examples/ts/token_bridge/index.ts
@@ -4,14 +4,12 @@ import { AztecAddress, EthAddress } from "@aztec/aztec.js/addresses";
 import { Fr } from "@aztec/aztec.js/fields";
 import { createAztecNodeClient } from "@aztec/aztec.js/node";
 import { createExtendedL1Client } from "@aztec/ethereum/client";
-import { OutboxContract } from "@aztec/ethereum/contracts";
 import { deployL1Contract } from "@aztec/ethereum/deploy-l1-contract";
 import { sha256ToField } from "@aztec/foundation/crypto/sha256";
 import {
   computeL2ToL1MessageHash,
   computeSecretHash,
 } from "@aztec/stdlib/hash";
-import { computeL2ToL1MembershipWitness } from "@aztec/stdlib/messaging";
 import { EmbeddedWallet } from "@aztec/wallets/embedded";
 import { decodeEventLog, pad } from "@aztec/viem";
 import { foundry } from "@aztec/viem/chains";
@@ -305,17 +303,8 @@ while (provenBlockNumber < exitReceipt.blockNumber!) {
 console.log("Block proven!\n");
 
 // Compute the membership witness using the message hash and the L2 tx hash.
-// The Outbox is queried to pick the smallest partial-proof root that covers the tx's checkpoint.
-const outbox = new OutboxContract(
-  l1Client,
-  nodeInfo.l1ContractAddresses.outboxAddress,
-);
-const witness = await computeL2ToL1MembershipWitness(
-  node,
-  outbox,
-  msgLeaf,
-  exitReceipt.txHash,
-);
+// The node picks the smallest partial-proof root that covers the tx's checkpoint.
+const witness = await node.getL2ToL1MembershipWitness(exitReceipt.txHash, msgLeaf);
 const epoch = witness!.epochNumber;
 const numCheckpointsInEpoch = witness!.numCheckpointsInEpoch;
 console.log(`   Epoch for block ${exitReceipt.blockNumber}: ${epoch}`);

--- a/docs/scripts/node_api_reference_generation/generate_node_api_reference.ts
+++ b/docs/scripts/node_api_reference_generation/generate_node_api_reference.ts
@@ -468,6 +468,7 @@ const METHOD_GROUPS: { heading: string; namespace: string; methods: string[] }[]
     methods: [
       'getL1ToL2MessageMembershipWitness',
       'getL1ToL2MessageCheckpoint',
+      'getL2ToL1MembershipWitness',
       'getL2ToL1Messages',
     ],
   },

--- a/yarn-project/archiver/src/archiver-misc.test.ts
+++ b/yarn-project/archiver/src/archiver-misc.test.ts
@@ -1,7 +1,7 @@
 import type { BlobClientInterface } from '@aztec/blob-client/client';
 import { GENESIS_ARCHIVE_ROOT } from '@aztec/constants';
 import { DefaultL1ContractsConfig } from '@aztec/ethereum/config';
-import type { RollupContract } from '@aztec/ethereum/contracts';
+import type { OutboxContract, RollupContract } from '@aztec/ethereum/contracts';
 import type { ViemPublicClient } from '@aztec/ethereum/types';
 import { BlockNumber, CheckpointNumber, EpochNumber, SlotNumber } from '@aztec/foundation/branded-types';
 import { Buffer32 } from '@aztec/foundation/buffer';
@@ -68,6 +68,7 @@ describe('Archiver misc', () => {
       publicClient,
       publicClient,
       rollupContract,
+      mock<OutboxContract>(),
       {
         rollupAddress: EthAddress.random(),
         registryAddress: EthAddress.random(),

--- a/yarn-project/archiver/src/archiver-store.test.ts
+++ b/yarn-project/archiver/src/archiver-store.test.ts
@@ -1,5 +1,5 @@
 import type { BlobClientInterface } from '@aztec/blob-client/client';
-import { RollupContract } from '@aztec/ethereum/contracts';
+import { type OutboxContract, RollupContract } from '@aztec/ethereum/contracts';
 import type { ViemPublicClient } from '@aztec/ethereum/types';
 import {
   BlockNumber,
@@ -108,6 +108,7 @@ describe('Archiver Store', () => {
       publicClient,
       debugClient,
       rollupContract,
+      mock<OutboxContract>(),
       contractAddresses,
       archiverStore,
       config,

--- a/yarn-project/archiver/src/archiver-sync.test.ts
+++ b/yarn-project/archiver/src/archiver-sync.test.ts
@@ -3,7 +3,12 @@ import { makeRandomBlob } from '@aztec/blob-lib/testing';
 import { GENESIS_ARCHIVE_ROOT } from '@aztec/constants';
 import type { EpochCache, EpochCommitteeInfo } from '@aztec/epoch-cache';
 import { DefaultL1ContractsConfig } from '@aztec/ethereum/config';
-import { BlockTagTooOldError, type InboxContract, type RollupContract } from '@aztec/ethereum/contracts';
+import {
+  BlockTagTooOldError,
+  type InboxContract,
+  type OutboxContract,
+  type RollupContract,
+} from '@aztec/ethereum/contracts';
 import type { ViemPublicClient } from '@aztec/ethereum/types';
 import { BlockNumber, CheckpointNumber, EpochNumber, SlotNumber } from '@aztec/foundation/branded-types';
 import { Buffer32 } from '@aztec/foundation/buffer';
@@ -116,6 +121,7 @@ describe('Archiver Sync', () => {
       publicClient,
       publicClient,
       rollupContract,
+      mock<OutboxContract>(),
       contractAddresses,
       store,
       config,

--- a/yarn-project/archiver/src/archiver.ts
+++ b/yarn-project/archiver/src/archiver.ts
@@ -1,6 +1,6 @@
 import type { BlobClientInterface } from '@aztec/blob-client/client';
 import { EpochCache, PROPOSER_PIPELINING_SLOT_OFFSET } from '@aztec/epoch-cache';
-import { BlockTagTooOldError, RollupContract } from '@aztec/ethereum/contracts';
+import { BlockTagTooOldError, OutboxContract, RollupContract } from '@aztec/ethereum/contracts';
 import type { L1ContractAddresses } from '@aztec/ethereum/l1-contract-addresses';
 import type { ViemPublicClient, ViemPublicDebugClient } from '@aztec/ethereum/types';
 import { BlockNumber, CheckpointNumber, EpochNumber, SlotNumber } from '@aztec/foundation/branded-types';
@@ -30,7 +30,8 @@ import {
   getTimestampForSlot,
   getTimestampRangeForEpoch,
 } from '@aztec/stdlib/epoch-helpers';
-import type { BlockHeader } from '@aztec/stdlib/tx';
+import type { L2ToL1MembershipWitness } from '@aztec/stdlib/messaging';
+import type { BlockHeader, TxHash } from '@aztec/stdlib/tx';
 import { type TelemetryClient, type Traceable, type Tracer, trackSpan } from '@aztec/telemetry-client';
 
 import { type ArchiverConfig, mapArchiverConfig } from './config.js';
@@ -41,6 +42,7 @@ import { ArchiverDataSourceBase } from './modules/data_source_base.js';
 import { ArchiverDataStoreUpdater } from './modules/data_store_updater.js';
 import type { ArchiverInstrumentation } from './modules/instrumentation.js';
 import type { ArchiverL1Synchronizer } from './modules/l1_synchronizer.js';
+import { OutboxTreesResolver } from './modules/outbox_trees_resolver.js';
 import { type ArchiverDataStores, backupArchiverDataStores, getArchiverSynchPoint } from './store/data_stores.js';
 import { L2TipsCache } from './store/l2_tips_cache.js';
 
@@ -85,6 +87,9 @@ export class Archiver extends ArchiverDataSourceBase implements L2BlockSink, Tra
   /** L1 synchronizer that handles fetching checkpoints and messages from L1. */
   private readonly synchronizer: ArchiverL1Synchronizer;
 
+  /** Resolver for L2-to-L1 message membership witnesses, built over this archiver's read view. */
+  private readonly outboxTreesResolver: OutboxTreesResolver;
+
   private initialSyncComplete: boolean = false;
   private initialSyncPromise: PromiseWithResolvers<void>;
 
@@ -106,6 +111,7 @@ export class Archiver extends ArchiverDataSourceBase implements L2BlockSink, Tra
    * @param publicClient - A client for interacting with the Ethereum node.
    * @param debugClient - A client for interacting with the Ethereum node for debug/trace methods.
    * @param rollup - Rollup contract instance.
+   * @param outbox - Outbox contract instance, used to read per-epoch L2-to-L1 message roots.
    * @param inbox - Inbox contract instance.
    * @param l1Addresses - L1 contract addresses (registry, governance proposer, slashing proposer).
    * @param dataStores - Archiver substores for storage & retrieval of blocks, encrypted logs & contract data.
@@ -125,6 +131,7 @@ export class Archiver extends ArchiverDataSourceBase implements L2BlockSink, Tra
     private readonly publicClient: ViemPublicClient,
     private readonly debugClient: ViemPublicDebugClient,
     private readonly rollup: RollupContract,
+    private readonly outbox: OutboxContract,
     private readonly l1Addresses: Pick<
       L1ContractAddresses,
       'rollupAddress' | 'registryAddress' | 'inboxAddress' | 'governanceProposerAddress'
@@ -168,6 +175,15 @@ export class Archiver extends ArchiverDataSourceBase implements L2BlockSink, Tra
       rollupManaLimit: l1Constants.rollupManaLimit,
     });
 
+    // The resolver reads its witness data from this archiver and pins its lazy Outbox-root fetches
+    // to the archiver's synced L1 block. No method on `this` is invoked during construction.
+    this.outboxTreesResolver = new OutboxTreesResolver(
+      this.outbox,
+      this,
+      () => Promise.resolve(this.getL1BlockNumber()),
+      l1Constants.epochDuration,
+    );
+
     // Running promise starts with a small interval inbetween runs, so all iterations needed for the initial sync
     // are done as fast as possible. This then gets updated once the initial sync completes.
     this.runningPromise = new RunningPromise(
@@ -176,6 +192,27 @@ export class Archiver extends ArchiverDataSourceBase implements L2BlockSink, Tra
       this.config.pollingIntervalMs / 10,
       makeLoggingErrorHandler(this.log, NoBlobBodiesFoundError, BlockTagTooOldError),
     );
+  }
+
+  /**
+   * Returns the L2-to-L1 membership witness for `message` emitted by tx `txHash`. The node selects
+   * the smallest partial-proof root on the Outbox that covers the tx's checkpoint and builds the
+   * witness against it.
+   *
+   * The node reads the Outbox roots lazily, pinned to its synced L1 block, so the witness reflects
+   * the node's synced view. Returns `undefined` if the tx isn't yet in a block/epoch or no covering
+   * root has landed on L1 as of the synced block.
+   *
+   * Caveat: roots are cached only for the current synced L1 block and re-fetched once the node
+   * advances, so a reorg is picked up on the next synced-block advance rather than re-validated per
+   * request.
+   */
+  public getL2ToL1MembershipWitness(
+    txHash: TxHash,
+    message: Fr,
+    messageIndexInTx?: number,
+  ): Promise<L2ToL1MembershipWitness | undefined> {
+    return this.outboxTreesResolver.getL2ToL1MembershipWitness(txHash, message, messageIndexInTx);
   }
 
   /** Updates archiver config */

--- a/yarn-project/archiver/src/factory.ts
+++ b/yarn-project/archiver/src/factory.ts
@@ -1,7 +1,7 @@
 import { EpochCache } from '@aztec/epoch-cache';
 import { createEthereumChain } from '@aztec/ethereum/chain';
 import { makeL1HttpTransport } from '@aztec/ethereum/client';
-import { InboxContract, RollupContract } from '@aztec/ethereum/contracts';
+import { InboxContract, OutboxContract, RollupContract } from '@aztec/ethereum/contracts';
 import { pickL1ContractAddresses } from '@aztec/ethereum/l1-contract-addresses';
 import type { ViemPublicDebugClient } from '@aztec/ethereum/types';
 import { BlockNumber } from '@aztec/foundation/branded-types';
@@ -85,6 +85,7 @@ export async function createArchiver(
   // Create L1 contract instances
   const rollup = new RollupContract(publicClient, config.rollupAddress);
   const inbox = new InboxContract(publicClient, config.inboxAddress);
+  const outbox = new OutboxContract(publicClient, config.outboxAddress);
 
   // Fetch L1 constants from rollup contract
   const [
@@ -172,6 +173,7 @@ export async function createArchiver(
     publicClient,
     debugClient,
     rollup,
+    outbox,
     { ...pickL1ContractAddresses(config), slashingProposerAddress },
     archiverStore,
     archiverConfig,

--- a/yarn-project/archiver/src/modules/data_source_base.ts
+++ b/yarn-project/archiver/src/modules/data_source_base.ts
@@ -40,7 +40,7 @@ import {
 } from '@aztec/stdlib/epoch-helpers';
 import type { L2LogsSource } from '@aztec/stdlib/interfaces/server';
 import type { LogResult, PrivateLogsQuery, PublicLogsQuery } from '@aztec/stdlib/logs';
-import type { L1ToL2MessageSource } from '@aztec/stdlib/messaging';
+import type { L1ToL2MessageSource, L2ToL1MembershipWitness } from '@aztec/stdlib/messaging';
 import { AppendOnlyTreeSnapshot } from '@aztec/stdlib/trees';
 import type { BlockHeader, IndexedTxEffect, TxHash } from '@aztec/stdlib/tx';
 import type { UInt64 } from '@aztec/stdlib/types';
@@ -148,6 +148,12 @@ export abstract class ArchiverDataSourceBase
   abstract isEpochComplete(epochNumber: EpochNumber): Promise<boolean>;
 
   abstract syncImmediate(): Promise<void>;
+
+  abstract getL2ToL1MembershipWitness(
+    txHash: TxHash,
+    message: Fr,
+    messageIndexInTx?: number,
+  ): Promise<L2ToL1MembershipWitness | undefined>;
 
   public async isPruneDueAtSlot(slot: SlotNumber): Promise<boolean> {
     if (!this.l1Constants) {

--- a/yarn-project/archiver/src/modules/outbox_trees_resolver.test.ts
+++ b/yarn-project/archiver/src/modules/outbox_trees_resolver.test.ts
@@ -1,0 +1,375 @@
+import { MAX_CHECKPOINTS_PER_EPOCH } from '@aztec/constants';
+import type { OutboxContract } from '@aztec/ethereum/contracts';
+import {
+  BlockNumber,
+  CheckpointNumber,
+  EpochNumber,
+  IndexWithinCheckpoint,
+  SlotNumber,
+} from '@aztec/foundation/branded-types';
+import { sha256Trunc } from '@aztec/foundation/crypto/sha256';
+import { Fr } from '@aztec/foundation/curves/bn254';
+import { type L2ToL1MembershipWitness, computeEpochOutHash } from '@aztec/stdlib/messaging';
+import { TxHash } from '@aztec/stdlib/tx';
+
+import { type MockProxy, mock } from 'jest-mock-extended';
+
+import { type OutboxTreesArchiverView, OutboxTreesResolver } from './outbox_trees_resolver.js';
+
+/** Slots per epoch used to map fixture slot numbers back to epochs via `getEpochAtSlot`. */
+const EPOCH_DURATION = 32;
+
+describe('OutboxTreesResolver lazy roots cache', () => {
+  let outbox: MockProxy<OutboxContract>;
+  let archiver: MockProxy<OutboxTreesArchiverView>;
+  let resolver: OutboxTreesResolver;
+
+  let syncedL1Block: bigint;
+  let getRootsCalls: number;
+
+  const EPOCH = EpochNumber(0);
+
+  beforeEach(() => {
+    outbox = mock<OutboxContract>();
+    archiver = mock<OutboxTreesArchiverView>();
+
+    syncedL1Block = 100n;
+    getRootsCalls = 0;
+
+    outbox.getRoots.mockImplementation(() => {
+      getRootsCalls++;
+      return Promise.resolve(makeZeroRoots());
+    });
+
+    resolver = new OutboxTreesResolver(outbox, archiver, () => Promise.resolve(syncedL1Block), EPOCH_DURATION);
+  });
+
+  // Exercises the private #getRoots path through a witness request whose epoch has no blocks,
+  // forcing #getRoots to run while letting the witness short-circuit afterwards. We assert the cache
+  // side effects (getRoots counter) rather than the witness itself.
+  const fetchRootsViaWitness = async (epoch: EpochNumber) => {
+    const txHash = TxHash.random();
+    archiver.getTxEffect.mockResolvedValue(makeTxEffect(epoch, 1) as never);
+    // The archiver returns no blocks so the helper bails to undefined after #getRoots runs.
+    archiver.getBlocks.mockResolvedValue([] as never);
+    archiver.getBlock.mockResolvedValue(undefined as never);
+    archiver.getCheckpointsData.mockResolvedValue([] as never);
+    await resolver.getL2ToL1MembershipWitness(txHash, Fr.random());
+  };
+
+  it('caches roots within the same synced L1 block', async () => {
+    await fetchRootsViaWitness(EPOCH);
+    await fetchRootsViaWitness(EPOCH);
+    // The second request at the same synced L1 block is served from the in-memory cache.
+    expect(getRootsCalls).toBe(1);
+  });
+
+  it('refetches when the synced L1 block advances', async () => {
+    await fetchRootsViaWitness(EPOCH);
+    expect(getRootsCalls).toBe(1);
+
+    syncedL1Block = 101n;
+    await fetchRootsViaWitness(EPOCH);
+    expect(getRootsCalls).toBe(2);
+  });
+
+  it('pins the getRoots read to the synced L1 block number', async () => {
+    syncedL1Block = 777n;
+    await fetchRootsViaWitness(EPOCH);
+    expect(outbox.getRoots).toHaveBeenCalledWith(EPOCH, { blockNumber: 777n });
+  });
+
+  it('does no L1 reads and returns no witness when the node has not synced an L1 block yet', async () => {
+    const notSyncedResolver = new OutboxTreesResolver(
+      outbox,
+      archiver,
+      () => Promise.resolve(undefined),
+      EPOCH_DURATION,
+    );
+    const txHash = TxHash.random();
+    archiver.getTxEffect.mockResolvedValue(makeTxEffect(EPOCH, 1) as never);
+
+    expect(await notSyncedResolver.getL2ToL1MembershipWitness(txHash, Fr.random())).toBeUndefined();
+    expect(getRootsCalls).toBe(0);
+  });
+
+  it('single-flights concurrent requests for the same epoch into one getRoots call', async () => {
+    const txHash = TxHash.random();
+    archiver.getTxEffect.mockResolvedValue(makeTxEffect(EPOCH, 1) as never);
+    archiver.getBlocks.mockResolvedValue([] as never);
+    archiver.getBlock.mockResolvedValue(undefined as never);
+    archiver.getCheckpointsData.mockResolvedValue([] as never);
+
+    await Promise.all(Array.from({ length: 8 }, () => resolver.getL2ToL1MembershipWitness(txHash, Fr.random())));
+    expect(getRootsCalls).toBe(1);
+  });
+});
+
+describe('OutboxTreesResolver witness building', () => {
+  let outbox: MockProxy<OutboxContract>;
+  let archiver: MockProxy<OutboxTreesArchiverView>;
+  let resolver: OutboxTreesResolver;
+
+  beforeEach(() => {
+    outbox = mock<OutboxContract>();
+    archiver = mock<OutboxTreesArchiverView>();
+    // Witness tests fetch the covering roots once at synced block 0 via the outbox mock.
+    resolver = new OutboxTreesResolver(outbox, archiver, () => Promise.resolve(0n), EPOCH_DURATION);
+  });
+
+  it('returns undefined when the tx is not yet in a block', async () => {
+    archiver.getTxEffect.mockResolvedValue(undefined);
+    expect(await resolver.getL2ToL1MembershipWitness(TxHash.random(), Fr.random())).toBeUndefined();
+  });
+
+  it('builds a correct K=1 witness', async () => {
+    const epoch = EpochNumber(0);
+    const checkpoints: Fr[][][][] = [[[[Fr.random()]]]];
+    const txHash = TxHash.random();
+    const targetMessage = checkpoints[0][0][0][0];
+
+    const fixture = buildFixture(checkpoints, epoch, txHash, 0, 0);
+    wireWitnessFixture(outbox, archiver, fixture);
+
+    const witness = await resolver.getL2ToL1MembershipWitness(txHash, targetMessage);
+    assertWitness(witness, targetMessage, fixture, 1);
+  });
+
+  it('builds a correct K=2 witness for a tx in the second checkpoint', async () => {
+    const epoch = EpochNumber(0);
+    const checkpoints: Fr[][][][] = [[[[Fr.random()]]], [[[Fr.random()]]]];
+    const txHash = TxHash.random();
+    const targetMessage = checkpoints[1][0][0][0];
+
+    const fixture = buildFixture(checkpoints, epoch, txHash, 1, 0);
+    wireWitnessFixture(outbox, archiver, fixture);
+
+    const witness = await resolver.getL2ToL1MembershipWitness(txHash, targetMessage);
+    assertWitness(witness, targetMessage, fixture, 2);
+  });
+
+  it('builds a correct witness for a checkpoint with mixed empty/non-empty txs (block-level compression)', async () => {
+    const epoch = EpochNumber(0);
+    const t1 = [Fr.random(), Fr.random(), Fr.random()];
+    const t3 = [Fr.random()];
+    const checkpoints: Fr[][][][] = [[[[], t1, [], t3]]];
+    const txHash = TxHash.random();
+    const targetMessage = t1[1];
+
+    const fixture = buildFixture(checkpoints, epoch, txHash, 0, 0, 1);
+    wireWitnessFixture(outbox, archiver, fixture);
+
+    const witness = await resolver.getL2ToL1MembershipWitness(txHash, targetMessage, 1);
+    assertWitness(witness, targetMessage, fixture, 1);
+  });
+
+  it('disambiguates duplicate message values via messageIndexInTx', async () => {
+    const epoch = EpochNumber(0);
+    const dup = Fr.random();
+    const checkpoints: Fr[][][][] = [[[[dup, Fr.random(), dup]]]];
+    const txHash = TxHash.random();
+
+    const fixture = buildFixture(checkpoints, epoch, txHash, 0, 0, 0);
+    wireWitnessFixture(outbox, archiver, fixture);
+
+    // Without an index, the duplicate value is ambiguous and the helper throws.
+    await expect(resolver.getL2ToL1MembershipWitness(txHash, dup)).rejects.toThrow();
+
+    const witnessAt0 = await resolver.getL2ToL1MembershipWitness(txHash, dup, 0);
+    const witnessAt2 = await resolver.getL2ToL1MembershipWitness(txHash, dup, 2);
+    assertWitness(witnessAt0, dup, fixture, 1);
+    assertWitness(witnessAt2, dup, fixture, 1);
+    // Distinct positions yield distinct leaf indices.
+    expect(witnessAt0!.leafIndex).not.toBe(witnessAt2!.leafIndex);
+  });
+
+  it('throws when the cached root does not match the locally recomputed root and the synced block is stable', async () => {
+    const epoch = EpochNumber(0);
+    const checkpoints: Fr[][][][] = [[[[Fr.random()]]]];
+    const txHash = TxHash.random();
+    const targetMessage = checkpoints[0][0][0][0];
+
+    const fixture = buildFixture(checkpoints, epoch, txHash, 0, 0);
+    // Wire the archiver data but have the outbox return a deliberately wrong (random) covering root.
+    wireArchiver(archiver, fixture);
+    const roots = makeZeroRoots();
+    roots[0] = Fr.random();
+    outbox.getRoots.mockResolvedValue(roots);
+
+    await expect(resolver.getL2ToL1MembershipWitness(txHash, targetMessage)).rejects.toThrow();
+  });
+
+  it('returns undefined instead of throwing when the synced block moved during a mismatched assembly', async () => {
+    const epoch = EpochNumber(0);
+    const checkpoints: Fr[][][][] = [[[[Fr.random()]]]];
+    const txHash = TxHash.random();
+    const targetMessage = checkpoints[0][0][0][0];
+
+    const fixture = buildFixture(checkpoints, epoch, txHash, 0, 0);
+    wireArchiver(archiver, fixture);
+    const roots = makeZeroRoots();
+    roots[0] = Fr.random(); // wrong root → helper throws a mismatch
+    outbox.getRoots.mockResolvedValue(roots);
+
+    // A synced block that advances between the before/after reads marks the mismatch transient.
+    let syncedCalls = 0;
+    const drifting = new OutboxTreesResolver(
+      outbox,
+      archiver,
+      () => Promise.resolve(BigInt(syncedCalls++)),
+      EPOCH_DURATION,
+    );
+
+    expect(await drifting.getL2ToL1MembershipWitness(txHash, targetMessage)).toBeUndefined();
+  });
+});
+
+// --- Helpers ----------------------------------------------------------------
+
+function makeZeroRoots(): Fr[] {
+  return Array.from({ length: MAX_CHECKPOINTS_PER_EPOCH }, () => Fr.ZERO);
+}
+
+/**
+ * Builds the slice of an `IndexedTxEffect` the resolver reads to assemble a witness. `slotNumber` is
+ * placed inside `epoch` via `EPOCH_DURATION` so `getEpochAtSlot` recovers the intended epoch.
+ */
+function makeTxEffect(epoch: number, blockNumber: number, txIndexInBlock = 1) {
+  return {
+    l2BlockNumber: BlockNumber(blockNumber),
+    txIndexInBlock,
+    slotNumber: SlotNumber(epoch * EPOCH_DURATION),
+  };
+}
+
+/**
+ * Minimal fixture describing an epoch's worth of L2-to-L1 messages plus the metadata needed for
+ * the resolver to assemble a witness for a specific tx. Encodes a single block per checkpoint
+ * (sufficient for the cases exercised here).
+ */
+type Fixture = {
+  epoch: EpochNumber;
+  messagesInEpoch: Fr[][][][];
+  blocks: Array<{
+    number: BlockNumber;
+    checkpointNumber: CheckpointNumber;
+    indexWithinCheckpoint: IndexWithinCheckpoint;
+    header: { globalVariables: { slotNumber: SlotNumber } };
+    body: { txEffects: Array<{ l2ToL1Msgs: Fr[]; txHash: TxHash }> };
+  }>;
+  blockNumber: number;
+  txHash: TxHash;
+  txIndex: number;
+  checkpointIndex: number;
+  blockIndex: number;
+};
+
+function buildFixture(
+  messagesInEpoch: Fr[][][][],
+  epoch: EpochNumber,
+  txHash: TxHash,
+  checkpointIndex: number,
+  blockIndex: number,
+  txIndexInBlock = 0,
+): Fixture {
+  let blockCounter = 1;
+  const blocks: Fixture['blocks'] = [];
+  for (let ci = 0; ci < messagesInEpoch.length; ci++) {
+    const checkpointNumber = CheckpointNumber(ci + 1);
+    for (let bi = 0; bi < messagesInEpoch[ci].length; bi++) {
+      const slotNumber = SlotNumber(ci + 1);
+      const txEffects = messagesInEpoch[ci][bi].map((msgs, ti) => ({
+        l2ToL1Msgs: msgs,
+        txHash: ci === checkpointIndex && bi === blockIndex && ti === txIndexInBlock ? txHash : TxHash.random(),
+      }));
+      blocks.push({
+        number: BlockNumber(blockCounter),
+        checkpointNumber,
+        indexWithinCheckpoint: IndexWithinCheckpoint(bi),
+        header: { globalVariables: { slotNumber } },
+        body: { txEffects },
+      });
+      blockCounter++;
+    }
+  }
+
+  let targetBlockNumber = 1;
+  for (let ci = 0; ci < checkpointIndex; ci++) {
+    targetBlockNumber += messagesInEpoch[ci].length;
+  }
+  targetBlockNumber += blockIndex;
+
+  return {
+    epoch,
+    messagesInEpoch,
+    blocks,
+    blockNumber: targetBlockNumber,
+    txHash,
+    txIndex: txIndexInBlock,
+    checkpointIndex,
+    blockIndex,
+  };
+}
+
+function wireArchiver(archiver: MockProxy<OutboxTreesArchiverView>, fixture: Fixture) {
+  archiver.getBlocks.mockImplementation((() => Promise.resolve(fixture.blocks as never)) as never);
+  archiver.getBlock.mockImplementation((({ number }: { number: BlockNumber }) =>
+    Promise.resolve(fixture.blocks.find(b => b.number === number) ?? undefined)) as never);
+  archiver.getCheckpointsData.mockImplementation((() =>
+    Promise.resolve(
+      Array.from(new Set(fixture.blocks.map(b => b.checkpointNumber))).map(checkpointNumber => ({
+        checkpointNumber,
+      })),
+    )) as never);
+  archiver.getTxEffect.mockImplementation(((txHash: TxHash) => {
+    if (!txHash.equals(fixture.txHash)) {
+      return Promise.resolve(undefined);
+    }
+    // The target block's slot equals its checkpoint index + 1 (see buildFixture).
+    return Promise.resolve({
+      l2BlockNumber: BlockNumber(fixture.blockNumber),
+      txIndexInBlock: fixture.txIndex,
+      slotNumber: SlotNumber(fixture.checkpointIndex + 1),
+    });
+  }) as never);
+}
+
+function wireWitnessFixture(
+  outbox: MockProxy<OutboxContract>,
+  archiver: MockProxy<OutboxTreesArchiverView>,
+  fixture: Fixture,
+) {
+  wireArchiver(archiver, fixture);
+  const roots = makeZeroRoots();
+  const k = fixture.checkpointIndex + 1;
+  roots[k - 1] = computeEpochOutHash(fixture.messagesInEpoch.slice(0, k));
+  outbox.getRoots.mockResolvedValue(roots);
+}
+
+function assertWitness(
+  witness: L2ToL1MembershipWitness | undefined,
+  targetMessage: Fr,
+  fixture: Fixture,
+  expectedNumCheckpointsInEpoch: number,
+) {
+  expect(witness).toBeDefined();
+  expect(witness!.epochNumber).toBe(fixture.epoch);
+  expect(witness!.numCheckpointsInEpoch).toBe(expectedNumCheckpointsInEpoch);
+
+  const reconstructed = reconstructRoot(targetMessage, witness!);
+  expect(reconstructed.equals(witness!.root.toBuffer())).toBe(true);
+}
+
+function reconstructRoot(leaf: Fr, witness: L2ToL1MembershipWitness): Buffer {
+  let subtreeRoot = leaf.toBuffer();
+  let index = witness.leafIndex;
+  const path = witness.siblingPath.toBufferArray();
+  for (let height = 0; height < path.length; height++) {
+    const isRight = (index & 1n) === 1n;
+    subtreeRoot = isRight
+      ? sha256Trunc(Buffer.concat([path[height], subtreeRoot]))
+      : sha256Trunc(Buffer.concat([subtreeRoot, path[height]]));
+    index >>= 1n;
+  }
+  return subtreeRoot;
+}

--- a/yarn-project/archiver/src/modules/outbox_trees_resolver.ts
+++ b/yarn-project/archiver/src/modules/outbox_trees_resolver.ts
@@ -1,0 +1,199 @@
+import type { OutboxContract } from '@aztec/ethereum/contracts';
+import type { BlockNumber, EpochNumber } from '@aztec/foundation/branded-types';
+import { chunkBy } from '@aztec/foundation/collection';
+import type { Fr } from '@aztec/foundation/curves/bn254';
+import { type Logger, createLogger } from '@aztec/foundation/log';
+import type { L2Block } from '@aztec/stdlib/block';
+import type { CheckpointData } from '@aztec/stdlib/checkpoint';
+import { getEpochAtSlot } from '@aztec/stdlib/epoch-helpers';
+import { type L2ToL1MembershipWitness, computeL2ToL1MembershipWitness } from '@aztec/stdlib/messaging';
+import type { IndexedTxEffect, TxHash } from '@aztec/stdlib/tx';
+
+/**
+ * Archiver-side view of the data the resolver needs to assemble a witness. The archiver implements
+ * each of these natively, so no L2 RPC plumbing is required.
+ */
+export interface OutboxTreesArchiverView {
+  getBlocks(query: { epoch: EpochNumber; onlyCheckpointed: true }): Promise<L2Block[]>;
+  getBlock(query: { number: BlockNumber }): Promise<L2Block | undefined>;
+  getCheckpointsData(query: { epoch: EpochNumber }): Promise<CheckpointData[]>;
+  getTxEffect(txHash: TxHash): Promise<IndexedTxEffect | undefined>;
+}
+
+/** A cached per-epoch set of Outbox roots, tagged with the synced L1 block they were read at. */
+type CachedRoots = {
+  /** The `MAX_CHECKPOINTS_PER_EPOCH`-length array of partial-proof roots the L1 Outbox holds for the epoch. */
+  roots: Fr[];
+  /** The node's synced L1 block number at the moment we fetched these roots. */
+  fetchedAtL1Block: bigint;
+};
+
+/**
+ * Holds an in-memory cache of per-epoch Outbox roots used to build L2-to-L1 message membership
+ * witnesses, plus the single-flight registry that dedupes concurrent fetches.
+ *
+ * Roots are fetched lazily on request and cached against the node's synced L1 block: a cached entry
+ * is reused only while the synced L1 block is unchanged, and re-fetched from L1 once the node
+ * advances. The cache is intentionally not persisted — entries are valid for at most one L1 slot, so
+ * there is nothing worth carrying across restarts. The four merkle-tree levels are rebuilt per
+ * request from the archiver's raw L2 data via `computeL2ToL1MembershipWitness`; no trees or
+ * intermediate out-hashes are cached.
+ *
+ * TODO: Re-add permanent caching for sealed-and-L1-finalized epochs so their roots can be frozen
+ * and served without any L1 read once they can no longer change. That logic was dropped here to keep
+ * the cache simple; it would likely want a persisted store again.
+ */
+export class OutboxTreesResolver {
+  /** In-memory cache of per-epoch Outbox roots, keyed by epoch number. */
+  #cache: Map<EpochNumber, CachedRoots> = new Map();
+
+  /** Single-flight registry for in-flight roots fetches, keyed by epoch number. */
+  #pending: Map<EpochNumber, Promise<Fr[] | undefined>> = new Map();
+
+  /** Adapter exposing the slice of the node API that `computeL2ToL1MembershipWitness` requires. */
+  #node: Parameters<typeof computeL2ToL1MembershipWitness>[0];
+
+  constructor(
+    private readonly outbox: OutboxContract,
+    private readonly archiver: OutboxTreesArchiverView,
+    private readonly getSyncedL1BlockNumber: () => Promise<bigint | undefined>,
+    private readonly epochDuration: number,
+    private readonly log: Logger = createLogger('archiver:outbox'),
+  ) {
+    this.#node = this.makeNodeView();
+  }
+
+  /**
+   * Builds the L2-to-L1 membership witness for `message` in tx `txHash`. Returns `undefined` if the
+   * tx isn't yet in a block/epoch, or if the Outbox holds no covering partial-proof root for the
+   * tx's checkpoint as of the node's synced L1 block — callers should retry in that case.
+   */
+  public async getL2ToL1MembershipWitness(
+    txHash: TxHash,
+    message: Fr,
+    messageIndexInTx?: number,
+  ): Promise<L2ToL1MembershipWitness | undefined> {
+    const indexed = await this.archiver.getTxEffect(txHash);
+    if (!indexed) {
+      this.log.trace(`No tx effect for tx, no witness available`, { txHash });
+      return undefined;
+    }
+
+    // Derive the epoch from the tx's slot the same way the node assembles a mined receipt, so the
+    // witness helper sees the same view a `getTxReceipt` caller would.
+    const epochNumber = getEpochAtSlot(indexed.slotNumber, { epochDuration: this.epochDuration });
+    const roots = await this.#getRoots(epochNumber);
+    if (roots === undefined) {
+      return undefined;
+    }
+
+    const receipt = {
+      txHash,
+      epochNumber,
+      blockNumber: indexed.l2BlockNumber,
+      txIndexInBlock: indexed.txIndexInBlock,
+    };
+
+    const syncedBefore = await this.getSyncedL1BlockNumber();
+    try {
+      return await computeL2ToL1MembershipWitness(this.#node, roots, message, receipt, messageIndexInTx);
+    } catch (err) {
+      // The helper throws if the locally-assembled epoch root disagrees with the cached Outbox root.
+      // The cached roots are pinned to the node's synced L1 block, but the helper reads block /
+      // checkpoint data live, so if the archiver advanced mid-assembly the two can momentarily reflect
+      // different heights and produce a transient mismatch. When the synced block moved during
+      // assembly we treat the mismatch as transient and return undefined so the caller can retry; a
+      // mismatch at a stable synced block is a genuine node/L1 disagreement and must surface.
+      const syncedAfter = await this.getSyncedL1BlockNumber();
+      if (syncedBefore !== syncedAfter && err instanceof Error && err.message.includes('does not match Outbox')) {
+        this.log.debug(`Transient outbox root mismatch during sync, returning no witness`, {
+          txHash,
+          epoch: epochNumber,
+        });
+        return undefined;
+      }
+      throw err;
+    }
+  }
+
+  /**
+   * Lazily returns the per-epoch Outbox roots, reusing the cached entry while the node's synced L1
+   * block is unchanged and re-fetching from L1 once it advances. Returns `undefined` if the node has
+   * not established a synced L1 block yet. Concurrent requests for the same epoch share a single
+   * in-flight fetch via {@link #pending}.
+   */
+  #getRoots(epoch: EpochNumber): Promise<Fr[] | undefined> {
+    const inFlight = this.#pending.get(epoch);
+    if (inFlight) {
+      return inFlight;
+    }
+
+    const promise = this.#refreshRoots(epoch).finally(() => {
+      this.#pending.delete(epoch);
+    });
+    this.#pending.set(epoch, promise);
+    return promise;
+  }
+
+  /**
+   * Single-flight body for {@link #getRoots}. Re-reads the cached entry and synced block here —
+   * rather than capturing them before winning the {@link #pending} slot — so a late entrant that
+   * missed the slot cannot overwrite a fresher entry the previous winner just wrote.
+   */
+  async #refreshRoots(epoch: EpochNumber): Promise<Fr[] | undefined> {
+    const synced = await this.getSyncedL1BlockNumber();
+    if (synced === undefined) {
+      // The archiver has no synced L1 block yet, so there is no consistent height to read the Outbox
+      // at. The caller retries once the node has synced.
+      return undefined;
+    }
+
+    const cached = this.#cache.get(epoch);
+    if (cached && cached.fetchedAtL1Block === synced) {
+      return cached.roots;
+    }
+
+    // TODO: Re-add permanent caching for sealed-and-L1-finalized epochs so we can skip the L1 read
+    // entirely once an epoch's roots can no longer change. For now the cache is valid only for the
+    // current synced L1 block and we re-query the Outbox whenever the node advances.
+    const roots = await this.outbox.getRoots(epoch, { blockNumber: synced });
+    this.#cache.set(epoch, { roots, fetchedAtL1Block: synced });
+    this.log.trace(`Fetched outbox roots for epoch ${epoch}`, {
+      epoch,
+      syncedL1Block: synced,
+      nonZeroRoots: roots.filter(r => !r.isZero()).length,
+    });
+    return roots;
+  }
+
+  /**
+   * Returns the L2-to-L1 messages in `epoch`, organized as `checkpoint[] → block[] → tx[] →
+   * message[]`. Mirrors `AztecNodeService.getL2ToL1Messages` so the resolver can run off the
+   * archiver directly without going through the node RPC surface.
+   */
+  async #getL2ToL1Messages(epoch: EpochNumber): Promise<Fr[][][][]> {
+    const blocks = await this.archiver.getBlocks({ epoch, onlyCheckpointed: true });
+    const blocksInCheckpoints = chunkBy(blocks, block => block.header.globalVariables.slotNumber);
+    return blocksInCheckpoints.map(slotBlocks =>
+      slotBlocks.map(block => block.body.txEffects.map(txEffect => txEffect.l2ToL1Msgs)),
+    );
+  }
+
+  /**
+   * Builds the node-shaped adapter handed to `computeL2ToL1MembershipWitness`. The helper invokes
+   * `getL2ToL1Messages` / `getBlock` / `getCheckpointsData`; `getTxReceipt` is part of the helper's
+   * node type but is never invoked because we always pass an already-resolved receipt.
+   */
+  private makeNodeView(): Parameters<typeof computeL2ToL1MembershipWitness>[0] {
+    return {
+      getL2ToL1Messages: (epoch: EpochNumber) => this.#getL2ToL1Messages(epoch),
+      getBlock: ((param: BlockNumber) => this.archiver.getBlock({ number: param })) as Parameters<
+        typeof computeL2ToL1MembershipWitness
+      >[0]['getBlock'],
+      getCheckpointsData: (query: { epoch: EpochNumber }) => this.archiver.getCheckpointsData(query),
+      getTxReceipt: (() => {
+        throw new Error('OutboxTreesResolver always passes a resolved receipt; getTxReceipt must not be called');
+      }) as Parameters<typeof computeL2ToL1MembershipWitness>[0]['getTxReceipt'],
+    };
+  }
+}

--- a/yarn-project/archiver/src/test/mock_l2_block_source.ts
+++ b/yarn-project/archiver/src/test/mock_l2_block_source.ts
@@ -367,6 +367,11 @@ export class MockL2BlockSource implements L2BlockSource, ContractDataSource {
     };
   }
 
+  public getL2ToL1MembershipWitness(): Promise<undefined> {
+    // Mock does not back the L2-to-L1 message witness flow.
+    return Promise.resolve(undefined);
+  }
+
   async getL2Tips(): Promise<L2Tips> {
     const [latest, proven, finalized, checkpointed, proposedCheckpoint] = [
       await this.getBlockNumber(),

--- a/yarn-project/archiver/src/test/noop_l1_archiver.ts
+++ b/yarn-project/archiver/src/test/noop_l1_archiver.ts
@@ -1,5 +1,5 @@
 import type { BlobClientInterface } from '@aztec/blob-client/client';
-import type { RollupContract } from '@aztec/ethereum/contracts';
+import type { OutboxContract, RollupContract } from '@aztec/ethereum/contracts';
 import type { ViemPublicClient, ViemPublicDebugClient } from '@aztec/ethereum/types';
 import { SlotNumber } from '@aztec/foundation/branded-types';
 import { Buffer32 } from '@aztec/foundation/buffer';
@@ -63,6 +63,7 @@ export class NoopL1Archiver extends Archiver {
     const publicClient = mock<ViemPublicClient>();
     const debugClient = mock<ViemPublicDebugClient>();
     const rollup = mock<RollupContract>();
+    const outbox = mock<OutboxContract>();
     const blobClient = mock<BlobClientInterface>();
 
     // Mock methods called during start()
@@ -76,6 +77,7 @@ export class NoopL1Archiver extends Archiver {
       publicClient,
       debugClient,
       rollup,
+      outbox,
       {
         rollupAddress: EthAddress.ZERO,
         registryAddress: EthAddress.ZERO,

--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -111,7 +111,12 @@ import {
 } from '@aztec/stdlib/interfaces/server';
 import type { DebugLogStore, LogResult, PrivateLogsQuery, PublicLogsQuery } from '@aztec/stdlib/logs';
 import { InMemoryDebugLogStore, NullDebugLogStore } from '@aztec/stdlib/logs';
-import { InboxLeaf, type L1ToL2MessageSource, appendL1ToL2MessagesToTree } from '@aztec/stdlib/messaging';
+import {
+  InboxLeaf,
+  type L1ToL2MessageSource,
+  type L2ToL1MembershipWitness,
+  appendL1ToL2MessagesToTree,
+} from '@aztec/stdlib/messaging';
 import type { Offense } from '@aztec/stdlib/slashing';
 import { MIN_EXECUTION_TIME } from '@aztec/stdlib/timetable';
 import type { NullifierLeafPreimage, PublicDataTreeLeafPreimage } from '@aztec/stdlib/trees';
@@ -1449,6 +1454,9 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, AztecNodeDeb
 
   /**
    * Returns all the L2 to L1 messages in an epoch.
+   *
+   * @deprecated Use {@link getL2ToL1MembershipWitness} to get an L2-to-L1 message witness directly.
+   *
    * @param epoch - The epoch at which to get the data.
    * @returns The L2 to L1 messages (empty array if the epoch is not found).
    */
@@ -1458,6 +1466,18 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, AztecNodeDeb
     return blocksInCheckpoints.map(slotBlocks =>
       slotBlocks.map(block => block.body.txEffects.map(txEffect => txEffect.l2ToL1Msgs)),
     );
+  }
+
+  /**
+   * Returns the L2-to-L1 membership witness for a message in `txHash`. Passthrough to the
+   * archiver's locally-cached resolver — see {@link Archiver.getL2ToL1MembershipWitness}.
+   */
+  public getL2ToL1MembershipWitness(
+    txHash: TxHash,
+    message: Fr,
+    messageIndexInTx?: number,
+  ): Promise<L2ToL1MembershipWitness | undefined> {
+    return this.blockSource.getL2ToL1MembershipWitness(txHash, message, messageIndexInTx);
   }
 
   public async getNullifierMembershipWitness(

--- a/yarn-project/end-to-end/src/composed/e2e_token_bridge_tutorial_test.test.ts
+++ b/yarn-project/end-to-end/src/composed/e2e_token_bridge_tutorial_test.test.ts
@@ -7,8 +7,8 @@ import { Fr } from '@aztec/aztec.js/fields';
 import { createLogger } from '@aztec/aztec.js/log';
 import { createAztecNodeClient, waitForNode } from '@aztec/aztec.js/node';
 import { createExtendedL1Client } from '@aztec/ethereum/client';
-import { OutboxContract } from '@aztec/ethereum/contracts';
 import { deployL1Contract } from '@aztec/ethereum/deploy-l1-contract';
+import { retryUntil } from '@aztec/foundation/retry';
 import {
   FeeAssetHandlerAbi,
   FeeAssetHandlerBytecode,
@@ -20,7 +20,6 @@ import {
 import { TokenContract } from '@aztec/noir-contracts.js/Token';
 import { TokenBridgeContract } from '@aztec/noir-contracts.js/TokenBridge';
 import { AuthRegistryArtifact, getStandardAuthRegistry } from '@aztec/standard-contracts/auth-registry';
-import { computeL2ToL1MembershipWitness } from '@aztec/stdlib/messaging';
 import { registerInitialLocalNetworkAccountsInWallet } from '@aztec/wallets/testing';
 
 import { getContract } from 'viem';
@@ -211,11 +210,12 @@ describe('e2e_cross_chain_messaging token_bridge_tutorial_test', () => {
       .simulate({ from: ownerAztecAddress });
     logger.info(`New L2 balance of ${ownerAztecAddress} is ${newL2Balance}`);
 
-    const outboxContract = new OutboxContract(l1Client, l1ContractAddresses.outboxAddress);
-    const result = await computeL2ToL1MembershipWitness(node, outboxContract, l2ToL1Message, l2TxReceipt);
-    if (!result) {
-      throw new Error('L2 to L1 message not found');
-    }
+    const result = await retryUntil(
+      () => node.getL2ToL1MembershipWitness(l2TxReceipt.txHash, l2ToL1Message),
+      'l2 to l1 membership witness',
+      60,
+      1,
+    );
 
     await l1PortalManager.withdrawFunds(
       withdrawAmount,

--- a/yarn-project/end-to-end/src/e2e_cross_chain_messaging/l2_to_l1.test.ts
+++ b/yarn-project/end-to-end/src/e2e_cross_chain_messaging/l2_to_l1.test.ts
@@ -3,16 +3,13 @@ import { BatchCall } from '@aztec/aztec.js/contracts';
 import { Fr } from '@aztec/aztec.js/fields';
 import type { Wallet } from '@aztec/aztec.js/wallet';
 import { OutboxContract, RollupContract, type ViemL2ToL1Msg } from '@aztec/ethereum/contracts';
+import { retryUntil } from '@aztec/foundation/retry';
 import { OutboxAbi } from '@aztec/l1-artifacts';
 import { TestContract } from '@aztec/noir-test-contracts.js/Test';
 import { type Sequencer, type SequencerEvents, SequencerState } from '@aztec/sequencer-client';
 import { computeL2ToL1MessageHash } from '@aztec/stdlib/hash';
 import type { AztecNode, AztecNodeAdmin } from '@aztec/stdlib/interfaces/client';
-import {
-  type L2ToL1MembershipWitness,
-  computeL2ToL1MembershipWitness,
-  getL2ToL1MessageLeafId,
-} from '@aztec/stdlib/messaging';
+import { type L2ToL1MembershipWitness, getL2ToL1MessageLeafId } from '@aztec/stdlib/messaging';
 import { type TxHash, TxStatus } from '@aztec/stdlib/tx';
 
 import { jest } from '@jest/globals';
@@ -350,7 +347,12 @@ describe('e2e_cross_chain_messaging l2_to_l1', () => {
 
   async function expectConsumeMessageToSucceed(msg: ReturnType<typeof makeL2ToL1Message>, l2TxHash: TxHash) {
     const msgLeaf = computeMessageLeaf(msg);
-    const result = (await computeL2ToL1MembershipWitness(aztecNode, outbox, msgLeaf, l2TxHash))!;
+    const result = await retryUntil(
+      () => aztecNode.getL2ToL1MembershipWitness(l2TxHash, msgLeaf),
+      'l2 to l1 membership witness',
+      60,
+      1,
+    );
     const { epochNumber: epoch, numCheckpointsInEpoch, ...witness } = result;
     const leafId = getL2ToL1MessageLeafId(witness);
 

--- a/yarn-project/end-to-end/src/e2e_cross_chain_messaging/token_bridge_private.test.ts
+++ b/yarn-project/end-to-end/src/e2e_cross_chain_messaging/token_bridge_private.test.ts
@@ -2,9 +2,9 @@ import { AztecAddress, EthAddress } from '@aztec/aztec.js/addresses';
 import { Fr } from '@aztec/aztec.js/fields';
 import type { Logger } from '@aztec/aztec.js/log';
 import type { AztecNode } from '@aztec/aztec.js/node';
+import { retryUntil } from '@aztec/foundation/retry';
 import type { TokenContract } from '@aztec/noir-contracts.js/Token';
 import type { TokenBridgeContract } from '@aztec/noir-contracts.js/TokenBridge';
-import { computeL2ToL1MembershipWitness } from '@aztec/stdlib/messaging';
 
 import { jest } from '@jest/globals';
 
@@ -82,12 +82,12 @@ describe('e2e_cross_chain_messaging token_bridge_private', () => {
     // Advance the epoch until the tx is proven since the messages are inserted to the outbox when the epoch is proven.
     await t.advanceToEpochProven(l2TxReceipt);
 
-    const l2ToL1MessageResult = (await computeL2ToL1MembershipWitness(
-      aztecNode,
-      crossChainTestHarness.outboxContract,
-      l2ToL1Message,
-      l2TxReceipt,
-    ))!;
+    const l2ToL1MessageResult = await retryUntil(
+      () => aztecNode.getL2ToL1MembershipWitness(l2TxReceipt.txHash, l2ToL1Message),
+      'l2 to l1 membership witness',
+      60,
+      1,
+    );
 
     // Check balance before and after exit.
     expect(await crossChainTestHarness.getL1BalanceOf(ethAccount)).toBe(l1TokenBalance - bridgeAmount);

--- a/yarn-project/end-to-end/src/e2e_cross_chain_messaging/token_bridge_public.test.ts
+++ b/yarn-project/end-to-end/src/e2e_cross_chain_messaging/token_bridge_public.test.ts
@@ -1,5 +1,5 @@
 import { Fr } from '@aztec/aztec.js/fields';
-import { computeL2ToL1MembershipWitness } from '@aztec/stdlib/messaging';
+import { retryUntil } from '@aztec/foundation/retry';
 
 import { jest } from '@jest/globals';
 
@@ -88,12 +88,12 @@ describe('e2e_cross_chain_messaging token_bridge_public', () => {
     // Advance the epoch until the tx is proven since the messages are inserted to the outbox when the epoch is proven.
     await t.advanceToEpochProven(l2TxReceipt);
 
-    const l2ToL1MessageResult = (await computeL2ToL1MembershipWitness(
-      aztecNode,
-      crossChainTestHarness.outboxContract,
-      l2ToL1Message,
-      l2TxReceipt,
-    ))!;
+    const l2ToL1MessageResult = await retryUntil(
+      () => aztecNode.getL2ToL1MembershipWitness(l2TxReceipt.txHash, l2ToL1Message),
+      'l2 to l1 membership witness',
+      60,
+      1,
+    );
 
     // Check balance before and after exit.
     expect(await crossChainTestHarness.getL1BalanceOf(ethAccount)).toBe(l1TokenBalance - bridgeAmount);

--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_partial_proof_multi_root.test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_partial_proof_multi_root.test.ts
@@ -12,7 +12,12 @@ import { retryUntil } from '@aztec/foundation/retry';
 import { OutboxAbi } from '@aztec/l1-artifacts';
 import { TestContract } from '@aztec/noir-test-contracts.js/Test';
 import { computeL2ToL1MessageHash } from '@aztec/stdlib/hash';
-import { computeEpochOutHash, computeL2ToL1MembershipWitness, getL2ToL1MessageLeafId } from '@aztec/stdlib/messaging';
+import {
+  type L2ToL1MembershipWitness,
+  computeEpochOutHash,
+  computeL2ToL1MembershipWitness,
+  getL2ToL1MessageLeafId,
+} from '@aztec/stdlib/messaging';
 import { type TxReceipt, TxStatus } from '@aztec/stdlib/tx';
 
 import { jest } from '@jest/globals';
@@ -209,9 +214,14 @@ describe('e2e_epochs/epochs_partial_proof_multi_root', () => {
       expect(onChainRoots[i].isZero()).toBe(true);
     }
 
-    // Consume msg2 against the smallest covering root the helper picks (K=2).
+    // Consume msg2 against the smallest covering root the node picks (K=2).
     {
-      const witness = (await computeL2ToL1MembershipWitness(node, outbox, sends[1].leaf, sends[1].receipt))!;
+      const witness = await retryUntil(
+        () => node.getL2ToL1MembershipWitness(sends[1].receipt.txHash, sends[1].leaf),
+        'K=2 membership witness',
+        30,
+        1,
+      );
       expect(witness).toBeDefined();
       expect(witness.epochNumber).toBe(epoch);
       expect(witness.numCheckpointsInEpoch).toBe(2);
@@ -221,9 +231,9 @@ describe('e2e_epochs/epochs_partial_proof_multi_root', () => {
     }
 
     // Negative: msg4 lives in checkpoint at index 3, and the largest covering K we inserted is
-    // K=3 (covers indices 0..2). The helper must return undefined: no covering root yet.
+    // K=3 (covers indices 0..2). The node must return undefined: no covering root yet.
     {
-      const witness = await computeL2ToL1MembershipWitness(node, outbox, sends[3].leaf, sends[3].receipt);
+      const witness = await node.getL2ToL1MembershipWitness(sends[3].receipt.txHash, sends[3].leaf);
       expect(witness).toBeUndefined();
     }
 
@@ -232,15 +242,22 @@ describe('e2e_epochs/epochs_partial_proof_multi_root', () => {
     // (by hiding slot 0 of the on-chain roots from the helper so it walks past it) and verify
     // the second consume reverts due to the shared bitmap.
     {
-      // K=1 path (default helper choice).
-      const witnessK1 = (await computeL2ToL1MembershipWitness(node, outbox, sends[0].leaf, sends[0].receipt))!;
+      // K=1 path (default node choice).
+      const witnessK1 = await retryUntil(
+        () => node.getL2ToL1MembershipWitness(sends[0].receipt.txHash, sends[0].leaf),
+        'K=1 membership witness',
+        30,
+        1,
+      );
       expect(witnessK1.numCheckpointsInEpoch).toBe(1);
       expect(witnessK1.root.toString()).toBe(root1.toString());
       await expectConsumeSucceeds(sends[0].msg, sends[0].leaf, witnessK1, epoch);
 
       // K=2 path: feed the helper a roots array with slot 0 zeroed so it picks the next covering
-      // root (K=2). Both K=1 and K=2 cover checkpoint 0, so this is a legitimate witness, but
-      // the shared bitmap (indexed by stable leafId) must prevent a second consume.
+      // root (K=2). This case can't go through the node RPC (which always picks the smallest
+      // covering root for the cached on-chain state), so we use the helper directly with a
+      // synthetic roots array. Both K=1 and K=2 cover checkpoint 0, so this is a legitimate
+      // witness, but the shared bitmap (indexed by stable leafId) must prevent a second consume.
       const rootsWithoutK1: Fr[] = [Fr.ZERO, ...onChainRoots.slice(1)];
       const witnessK2 = (await computeL2ToL1MembershipWitness(node, rootsWithoutK1, sends[0].leaf, sends[0].receipt))!;
       expect(witnessK2.numCheckpointsInEpoch).toBe(2);
@@ -262,7 +279,12 @@ describe('e2e_epochs/epochs_partial_proof_multi_root', () => {
 
     // Replay protection: consuming msg2 again (now under any covering root) reverts.
     {
-      const witness = (await computeL2ToL1MembershipWitness(node, outbox, sends[1].leaf, sends[1].receipt))!;
+      const witness = await retryUntil(
+        () => node.getL2ToL1MembershipWitness(sends[1].receipt.txHash, sends[1].leaf),
+        'replay membership witness',
+        30,
+        1,
+      );
       await expect(
         outbox.consume(
           sends[1].msg,
@@ -287,7 +309,12 @@ describe('e2e_epochs/epochs_partial_proof_multi_root', () => {
       const root4 = computeEpochOutHash(messagesPerCheckpoint.slice(0, 4));
       await retryUntil(async () => !(await outbox.getRoots(epoch))[3].isZero(), 'K=4 root visible', 10, 0.1);
 
-      const witness = (await computeL2ToL1MembershipWitness(node, outbox, sends[3].leaf, sends[3].receipt))!;
+      const witness = await retryUntil(
+        () => node.getL2ToL1MembershipWitness(sends[3].receipt.txHash, sends[3].leaf),
+        'K=4 membership witness',
+        30,
+        1,
+      );
       expect(witness.numCheckpointsInEpoch).toBe(4);
       expect(witness.root.toString()).toBe(root4.toString());
       await expectConsumeSucceeds(sends[3].msg, sends[3].leaf, witness, epoch);
@@ -301,7 +328,7 @@ describe('e2e_epochs/epochs_partial_proof_multi_root', () => {
   async function expectConsumeSucceeds(
     msg: ViemL2ToL1Msg,
     leaf: Fr,
-    witness: NonNullable<Awaited<ReturnType<typeof computeL2ToL1MembershipWitness>>>,
+    witness: L2ToL1MembershipWitness,
     epoch: EpochNumber,
   ) {
     const txHash = await outbox.consume(

--- a/yarn-project/end-to-end/src/e2e_p2p/add_rollup.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/add_rollup.test.ts
@@ -7,7 +7,7 @@ import { generateClaimSecret } from '@aztec/aztec.js/ethereum';
 import { Fr } from '@aztec/aztec.js/fields';
 import { waitForL1ToL2MessageReady } from '@aztec/aztec.js/messaging';
 import { RollupCheatCodes } from '@aztec/aztec/testing';
-import { FeeAssetHandlerContract, OutboxContract, RegistryContract, RollupContract } from '@aztec/ethereum/contracts';
+import { FeeAssetHandlerContract, RegistryContract, RollupContract } from '@aztec/ethereum/contracts';
 import { deployRollupForUpgrade } from '@aztec/ethereum/deploy-aztec-l1-contracts';
 import { deployL1Contract } from '@aztec/ethereum/deploy-l1-contract';
 import type { L1ContractAddresses } from '@aztec/ethereum/l1-contract-addresses';
@@ -30,7 +30,7 @@ import { protocolContractsHash } from '@aztec/protocol-contracts';
 import { getPXEConfig } from '@aztec/pxe/server';
 import { computeL2ToL1MessageHash } from '@aztec/stdlib/hash';
 import { tryStop } from '@aztec/stdlib/interfaces/server';
-import { computeL2ToL1MembershipWitness, getL2ToL1MessageLeafId } from '@aztec/stdlib/messaging';
+import { getL2ToL1MessageLeafId } from '@aztec/stdlib/messaging';
 import { getGenesisValues } from '@aztec/world-state/testing';
 
 import { jest } from '@jest/globals';
@@ -372,8 +372,12 @@ describe('e2e_p2p_add_rollup', () => {
         await cheatcodes.advanceToEpoch(EpochNumber(minedReceipt.epochNumber + 1));
         await waitForProven(node, l2OutgoingReceipt, { provenTimeout: 300 });
 
-        const outboxContract = new OutboxContract(l1Client, l1ContractAddresses.outboxAddress);
-        const l2ToL1MessageResult = (await computeL2ToL1MembershipWitness(node, outboxContract, leaf, minedReceipt))!;
+        const l2ToL1MessageResult = await retryUntil(
+          () => node.getL2ToL1MembershipWitness(minedReceipt.txHash, leaf),
+          'l2 to l1 membership witness',
+          60,
+          1,
+        );
         const { epochNumber: epoch, numCheckpointsInEpoch, ...l2ToL1MessageWitness } = l2ToL1MessageResult;
         const leafId = getL2ToL1MessageLeafId(l2ToL1MessageWitness);
 

--- a/yarn-project/end-to-end/src/shared/uniswap_l1_l2.ts
+++ b/yarn-project/end-to-end/src/shared/uniswap_l1_l2.ts
@@ -13,10 +13,10 @@ import type { ExtendedViemWalletClient } from '@aztec/ethereum/types';
 import { extractEvent } from '@aztec/ethereum/utils';
 import { EpochNumber } from '@aztec/foundation/branded-types';
 import { sha256ToField } from '@aztec/foundation/crypto/sha256';
+import { retryUntil } from '@aztec/foundation/retry';
 import { InboxAbi, UniswapPortalAbi, UniswapPortalBytecode } from '@aztec/l1-artifacts';
 import { UniswapContract } from '@aztec/noir-contracts.js/Uniswap';
 import { computeL2ToL1MessageHash } from '@aztec/stdlib/hash';
-import { computeL2ToL1MembershipWitness } from '@aztec/stdlib/messaging';
 
 import { jest } from '@jest/globals';
 import { type GetContractReturnType, getContract, parseEther, toFunctionSelector } from 'viem';
@@ -269,11 +269,19 @@ export const uniswapL1L2TestSuite = (
       const daiL1BalanceOfPortalBeforeSwap = await daiCrossChainHarness.getL1BalanceOf(
         daiCrossChainHarness.tokenPortalAddress,
       );
-      // Fetch the outbox roots once and share them between the two witnesses in this epoch.
-      const epochRoots = await wethCrossChainHarness.outboxContract.getRoots(minedReceipt.epochNumber);
-      const swapResult = (await computeL2ToL1MembershipWitness(aztecNode, epochRoots, swapPrivateLeaf, minedReceipt))!;
+      const swapResult = await retryUntil(
+        () => aztecNode.getL2ToL1MembershipWitness(minedReceipt.txHash, swapPrivateLeaf),
+        'swap private l2 to l1 witness',
+        60,
+        1,
+      );
       const { epochNumber: epoch, numCheckpointsInEpoch } = swapResult;
-      const withdrawResult = (await computeL2ToL1MembershipWitness(aztecNode, epochRoots, withdrawLeaf, minedReceipt))!;
+      const withdrawResult = await retryUntil(
+        () => aztecNode.getL2ToL1MembershipWitness(minedReceipt.txHash, withdrawLeaf),
+        'withdraw l2 to l1 witness',
+        60,
+        1,
+      );
 
       const swapPrivateL2MessageIndex = swapResult.leafIndex;
       const swapPrivateSiblingPath = swapResult.siblingPath;
@@ -861,11 +869,19 @@ export const uniswapL1L2TestSuite = (
       await cheatCodes.rollup.advanceToEpoch(EpochNumber(minedReceipt.epochNumber + 1));
       await waitForProven(aztecNode, withdrawReceipt, { provenTimeout: 300 });
 
-      // Fetch the outbox roots once and share them between the two witnesses in this epoch.
-      const epochRoots = await wethCrossChainHarness.outboxContract.getRoots(minedReceipt.epochNumber);
-      const swapResult = (await computeL2ToL1MembershipWitness(aztecNode, epochRoots, swapPrivateLeaf, minedReceipt))!;
+      const swapResult = await retryUntil(
+        () => aztecNode.getL2ToL1MembershipWitness(minedReceipt.txHash, swapPrivateLeaf),
+        'swap private l2 to l1 witness',
+        60,
+        1,
+      );
       const { epochNumber: epoch, numCheckpointsInEpoch } = swapResult;
-      const withdrawResult = (await computeL2ToL1MembershipWitness(aztecNode, epochRoots, withdrawLeaf, minedReceipt))!;
+      const withdrawResult = await retryUntil(
+        () => aztecNode.getL2ToL1MembershipWitness(minedReceipt.txHash, withdrawLeaf),
+        'withdraw l2 to l1 witness',
+        60,
+        1,
+      );
 
       const swapPrivateL2MessageIndex = swapResult.leafIndex;
       const swapPrivateSiblingPath = swapResult.siblingPath;
@@ -1002,11 +1018,19 @@ export const uniswapL1L2TestSuite = (
       await cheatCodes.rollup.advanceToEpoch(EpochNumber(minedReceipt.epochNumber + 1));
       await waitForProven(aztecNode, withdrawReceipt, { provenTimeout: 300 });
 
-      // Fetch the outbox roots once and share them between the two witnesses in this epoch.
-      const epochRoots = await wethCrossChainHarness.outboxContract.getRoots(minedReceipt.epochNumber);
-      const swapResult = (await computeL2ToL1MembershipWitness(aztecNode, epochRoots, swapPublicLeaf, minedReceipt))!;
+      const swapResult = await retryUntil(
+        () => aztecNode.getL2ToL1MembershipWitness(minedReceipt.txHash, swapPublicLeaf),
+        'swap public l2 to l1 witness',
+        60,
+        1,
+      );
       const { epochNumber: epoch, numCheckpointsInEpoch } = swapResult;
-      const withdrawResult = (await computeL2ToL1MembershipWitness(aztecNode, epochRoots, withdrawLeaf, minedReceipt))!;
+      const withdrawResult = await retryUntil(
+        () => aztecNode.getL2ToL1MembershipWitness(minedReceipt.txHash, withdrawLeaf),
+        'withdraw l2 to l1 witness',
+        60,
+        1,
+      );
 
       const swapPublicL2MessageIndex = swapResult.leafIndex;
       const swapPublicSiblingPath = swapResult.siblingPath;

--- a/yarn-project/ethereum/src/contracts/outbox.ts
+++ b/yarn-project/ethereum/src/contracts/outbox.ts
@@ -89,9 +89,13 @@ export class OutboxContract {
    * Returns every root stored for `epoch`. Slot `i` of the returned array holds the root inserted
    * for `numCheckpointsInEpoch = i + 1`, or `Fr.ZERO` if no proof of that depth has been inserted
    * yet. The array length is always `MAX_CHECKPOINTS_PER_EPOCH`.
+   *
+   * @param opts - Optional viem read options. Pass `blockNumber` to pin the read to a specific L1
+   *   block, which is important for callers that want a consistent snapshot across multiple reads
+   *   (e.g. the archiver's outbox-trees resolver, which pins to the node's synced L1 block).
    */
-  public async getRoots(epoch: EpochNumber): Promise<Fr[]> {
-    const raw = await this.outbox.read.getRoots([BigInt(epoch)]);
+  public async getRoots(epoch: EpochNumber, opts?: { blockNumber?: bigint }): Promise<Fr[]> {
+    const raw = await this.outbox.read.getRoots([BigInt(epoch)], opts);
     return raw.map(hex => Fr.fromString(hex));
   }
 

--- a/yarn-project/stdlib/src/block/l2_block_source.ts
+++ b/yarn-project/stdlib/src/block/l2_block_source.ts
@@ -19,6 +19,7 @@ import type { CheckpointData, ProposedCheckpointData, ProposedCheckpointInput } 
 import type { CheckpointInfo } from '../checkpoint/checkpoint_info.js';
 import type { PublishedCheckpoint } from '../checkpoint/published_checkpoint.js';
 import type { L1RollupConstants } from '../epoch-helpers/index.js';
+import type { L2ToL1MembershipWitness } from '../messaging/l2_to_l1_membership.js';
 import { CheckpointHeader } from '../rollup/checkpoint_header.js';
 import type { IndexedTxEffect } from '../tx/indexed_tx_effect.js';
 import type { TxHash } from '../tx/tx_hash.js';
@@ -159,6 +160,23 @@ export interface L2BlockSource {
    * @returns The requested tx effect with block info (or undefined if not found).
    */
   getTxEffect(txHash: TxHash): Promise<IndexedTxEffect | undefined>;
+
+  /**
+   * Returns the L2-to-L1 membership witness for `message` emitted by tx `txHash`, built against the
+   * smallest partial-proof root on the Outbox that covers the tx's checkpoint.
+   *
+   * The Outbox roots are read lazily, pinned to the node's synced L1 block, so the witness reflects
+   * the node's synced view. Returns `undefined` if the tx isn't yet in a block/epoch or no covering
+   * root has landed on L1 as of the synced block.
+   *
+   * Caveat: cached roots that are sealed and L1-finalized are not re-validated. A reorg deeper than
+   * L1 finality could leave the node serving a witness against a no-longer-canonical root.
+   */
+  getL2ToL1MembershipWitness(
+    txHash: TxHash,
+    message: Fr,
+    messageIndexInTx?: number,
+  ): Promise<L2ToL1MembershipWitness | undefined>;
 
   /**
    * Returns the last L2 slot number for which we have all L1 data needed to build the next checkpoint.

--- a/yarn-project/stdlib/src/interfaces/archiver.test.ts
+++ b/yarn-project/stdlib/src/interfaces/archiver.test.ts
@@ -119,6 +119,11 @@ describe('ArchiverApiSchema', () => {
     expect(result!.data).toBeInstanceOf(TxEffect);
   });
 
+  it('getL2ToL1MembershipWitness', async () => {
+    const result = await context.client.getL2ToL1MembershipWitness(TxHash.random(), Fr.random());
+    expect(result).toBeUndefined();
+  });
+
   it('getSyncedL2SlotNumber', async () => {
     const result = await context.client.getSyncedL2SlotNumber();
     expect(result).toBe(SlotNumber(1));
@@ -427,6 +432,9 @@ class MockArchiver implements ArchiverApi {
       txIndexInBlock: randomInt(10),
       slotNumber: SlotNumber(1),
     };
+  }
+  getL2ToL1MembershipWitness(): Promise<undefined> {
+    return Promise.resolve(undefined);
   }
   getSyncedL2SlotNumber(): Promise<SlotNumber> {
     return Promise.resolve(SlotNumber(1));

--- a/yarn-project/stdlib/src/interfaces/archiver.ts
+++ b/yarn-project/stdlib/src/interfaces/archiver.ts
@@ -26,6 +26,7 @@ import { L1RollupConstantsSchema } from '../epoch-helpers/index.js';
 import { LogResultSchema } from '../logs/log_result.js';
 import { PrivateLogsQuerySchema, PublicLogsQuerySchema } from '../logs/logs_query.js';
 import type { L1ToL2MessageSource } from '../messaging/l1_to_l2_message_source.js';
+import { L2ToL1MembershipWitnessSchema } from '../messaging/l2_to_l1_membership.js';
 import { optional, schemas } from '../schemas/schemas.js';
 import { indexedTxSchema } from '../tx/indexed_tx_effect.js';
 import { TxHash } from '../tx/tx_hash.js';
@@ -99,6 +100,13 @@ export const ArchiverApiSchema: ApiSchemaFor<ArchiverApi> = {
   getCheckpointData: z.function({ input: z.tuple([CheckpointQuerySchema]), output: CheckpointDataSchema.optional() }),
   getCheckpointsData: z.function({ input: z.tuple([CheckpointsQuerySchema]), output: z.array(CheckpointDataSchema) }),
   getTxEffect: z.function({ input: z.tuple([TxHash.schema]), output: indexedTxSchema().optional() }),
+  // Reads Outbox roots lazily, pinned to the node's synced L1 block. Caveat: cached roots that are
+  // sealed and L1-finalized are not re-validated, so a reorg deeper than L1 finality could leave the
+  // node serving a witness against a no-longer-canonical root.
+  getL2ToL1MembershipWitness: z.function({
+    input: z.tuple([TxHash.schema, schemas.Fr, optional(schemas.Integer)]),
+    output: L2ToL1MembershipWitnessSchema.optional(),
+  }),
   getSyncedL2SlotNumber: z.function({ input: z.tuple([]), output: schemas.SlotNumber.optional() }),
   getSyncedL2EpochNumber: z.function({ input: z.tuple([]), output: EpochNumberSchema.optional() }),
   getBlocksForSlot: z.function({ input: z.tuple([schemas.SlotNumber]), output: z.array(L2Block.schema) }),

--- a/yarn-project/stdlib/src/interfaces/aztec-node.test.ts
+++ b/yarn-project/stdlib/src/interfaces/aztec-node.test.ts
@@ -134,6 +134,11 @@ describe('AztecNodeApiSchema', () => {
     expect(response[0][0][0][0]).toBeInstanceOf(Fr);
   });
 
+  it('getL2ToL1MembershipWitness', async () => {
+    const response = await context.client.getL2ToL1MembershipWitness(TxHash.random(), Fr.random());
+    expect(response).toBeUndefined();
+  });
+
   it('getBlockHashMembershipWitness', async () => {
     const response = await context.client.getBlockHashMembershipWitness(BlockNumber(1), BlockHash.random());
     expect(response).toBeInstanceOf(MembershipWitness);
@@ -641,6 +646,11 @@ class MockAztecNode implements AztecNode {
         ),
       ),
     );
+  }
+  getL2ToL1MembershipWitness(txHash: TxHash, message: Fr, _messageIndexInTx?: number) {
+    expect(txHash).toBeInstanceOf(TxHash);
+    expect(message).toBeInstanceOf(Fr);
+    return Promise.resolve(undefined);
   }
   getNullifierMembershipWitness(
     referenceBlock: BlockParameter,

--- a/yarn-project/stdlib/src/interfaces/aztec-node.ts
+++ b/yarn-project/stdlib/src/interfaces/aztec-node.ts
@@ -44,6 +44,7 @@ import {
   type PublicLogsQuery,
   PublicLogsQuerySchema,
 } from '../logs/logs_query.js';
+import { type L2ToL1MembershipWitness, L2ToL1MembershipWitnessSchema } from '../messaging/l2_to_l1_membership.js';
 import { type ApiSchemaFor, optional, schemas } from '../schemas/schemas.js';
 import { MerkleTreeId } from '../trees/merkle_tree_id.js';
 import { NullifierMembershipWitness } from '../trees/nullifier_membership_witness.js';
@@ -189,11 +190,37 @@ export interface AztecNode {
 
   /**
    * Returns all the L2 to L1 messages in an epoch.
+   *
+   * @deprecated Use {@link getL2ToL1MembershipWitness} to get an L2-to-L1 message witness directly.
+   *
    * @param epoch - The epoch at which to get the data.
    * @returns A nested array of the L2 to L1 messages in each tx of each block in each checkpoint in the epoch (empty
    * array if the epoch is not found).
    */
   getL2ToL1Messages(epoch: EpochNumber): Promise<Fr[][][][]>;
+
+  /**
+   * Returns the L2-to-L1 membership witness for `message` emitted by tx `txHash`. The node selects
+   * the smallest partial-proof root on the Outbox that covers the tx's checkpoint and builds the
+   * witness against it.
+   *
+   * The node reads the Outbox roots lazily, pinned to its synced L1 block, so the witness reflects
+   * the node's synced view. Returns `undefined` if the tx isn't yet in a block/epoch or no covering
+   * root has landed on L1 as of the synced block.
+   *
+   * Caveat: cached roots that are sealed and L1-finalized are not re-validated. A reorg deeper than
+   * L1 finality could leave the node serving a witness against a no-longer-canonical root.
+   *
+   * @param txHash - The tx whose L2-to-L1 message we want a witness for.
+   * @param message - The message hash to prove inclusion of.
+   * @param messageIndexInTx - Optional index of the message within the tx's L2-to-L1 messages; pass
+   *   this when the same message hash appears multiple times in the tx.
+   */
+  getL2ToL1MembershipWitness(
+    txHash: TxHash,
+    message: Fr,
+    messageIndexInTx?: number,
+  ): Promise<L2ToL1MembershipWitness | undefined>;
 
   /**
    * Returns the block number at a given chain tip, or the latest proposed block number when
@@ -531,6 +558,14 @@ export const AztecNodeApiSchema: ApiSchemaFor<AztecNode> = {
   getL2ToL1Messages: z.function({
     input: z.tuple([EpochNumberSchema]),
     output: z.array(z.array(z.array(z.array(schemas.Fr)))),
+  }),
+
+  // Reads Outbox roots lazily, pinned to the node's synced L1 block. Caveat: cached roots that are
+  // sealed and L1-finalized are not re-validated, so a reorg deeper than L1 finality could leave the
+  // node serving a witness against a no-longer-canonical root.
+  getL2ToL1MembershipWitness: z.function({
+    input: z.tuple([TxHash.schema, schemas.Fr, optional(schemas.Integer)]),
+    output: L2ToL1MembershipWitnessSchema.optional(),
   }),
 
   getBlockNumber: z.function({ input: z.tuple([optional(ChainTipSchema)]), output: BlockNumberSchema }),

--- a/yarn-project/stdlib/src/messaging/l2_to_l1_membership.ts
+++ b/yarn-project/stdlib/src/messaging/l2_to_l1_membership.ts
@@ -1,9 +1,12 @@
 import { MAX_CHECKPOINTS_PER_EPOCH, OUT_HASH_TREE_LEAF_COUNT } from '@aztec/constants';
-import type { EpochNumber } from '@aztec/foundation/branded-types';
+import { type EpochNumber, EpochNumberSchema } from '@aztec/foundation/branded-types';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { SiblingPath, UnbalancedMerkleTreeCalculator, computeUnbalancedShaRoot } from '@aztec/foundation/trees';
 
+import { z } from 'zod';
+
 import type { AztecNode } from '../interfaces/aztec-node.js';
+import { schemas } from '../schemas/schemas.js';
 import { TxHash } from '../tx/tx_hash.js';
 import type { TxReceipt } from '../tx/tx_receipt.js';
 
@@ -122,6 +125,19 @@ export type L2ToL1MembershipWitness = {
   leafIndex: bigint;
   siblingPath: SiblingPath<number>;
 };
+
+/**
+ * Zod schema for {@link L2ToL1MembershipWitness}. The sibling-path length varies with the shape of
+ * the per-epoch tree, so we use the unsized `SiblingPath.schema` here rather than a fixed-height
+ * `schemaFor`.
+ */
+export const L2ToL1MembershipWitnessSchema = z.object({
+  epochNumber: EpochNumberSchema,
+  numCheckpointsInEpoch: schemas.Integer,
+  root: schemas.Fr,
+  leafIndex: schemas.BigInt,
+  siblingPath: SiblingPath.schema,
+}) as unknown as z.ZodType<L2ToL1MembershipWitness>;
 
 /**
  * Computes the L2 to L1 membership witness for a given message in a transaction.

--- a/yarn-project/txe/src/state_machine/archiver.ts
+++ b/yarn-project/txe/src/state_machine/archiver.ts
@@ -111,4 +111,9 @@ export class TXEArchiver extends ArchiverDataSourceBase {
   public syncImmediate(): Promise<void> {
     throw new Error('TXE Archiver does not implement "syncImmediate"');
   }
+
+  public getL2ToL1MembershipWitness(): Promise<undefined> {
+    // TXE doesn't drive the L2-to-L1 message flow through this archiver.
+    return Promise.resolve(undefined);
+  }
 }


### PR DESCRIPTION
## Motivation

Building an L2-to-L1 message membership witness is currently a client-side responsibility: callers hand `computeL2ToL1MembershipWitness` an `OutboxRootsReader` plus a node, and the helper reads the L1 Outbox and rebuilds the full four-level message tree on every call, which involves sending all messages for an entire epoch to the client. This adds a node JSON-RPC method that does the work centrally, behind a cache.

As of this PR, the cache only caches reads to the Outbox and for a single L1 slot, but the intent is to eventually cache the individual L2-to-L1 trees so we don't have to recompute them on every request, as well as permanently cache data for an epoch once it's finalized.

Fixes A-653

## Approach

A new `OutboxTreesResolver` in the archiver resolves witness requests. Roots are fetched lazily on request and re-fetched only when the node's synced L1 block has advanced. The four tree levels are rebuilt per request by delegating to the existing, unchanged `computeL2ToL1MembershipWitness` helper with the cached roots array, so there is no second cache to keep consistent. The resolver is exposed through the archiver (the node's block source) and surfaced as `AztecNode.getL2ToL1MembershipWitness`.

## Changes

- **archiver**: New `OutboxTreesResolver` (lazy roots cache, single-flight de-duplication, witness assembly).
- **stdlib**: Add `getL2ToL1MembershipWitness` to the `AztecNode` / `L2BlockSource` / archiver interfaces and schemas; export `L2ToL1MembershipWitnessSchema`. The `computeL2ToL1MembershipWitness` helper is unchanged.
- **aztec-node**: `AztecNodeService.getL2ToL1MembershipWitness` passthrough to the block source.
- **ethereum**: `OutboxContract.getRoots` gains an optional `{ blockNumber }` read option so reads can be pinned to the node's synced L1 block.
- **end-to-end (tests)**: Migrate `computeL2ToL1MembershipWitness` call sites to the new RPC, wrapped in `retryUntil` for the cache's eventual consistency. The synthetic-roots case in `epochs_partial_proof_multi_root` keeps using the helper directly.
- **archiver (tests)**: New `outbox_trees_resolver.test.ts` covering the lazy cache (refresh-on-advance, seal/finalize permanence, not-synced handling), single-flight, witness correctness across partial-proof depths and block-level compression, and transient-vs-genuine root mismatch handling.