### PR TITLE
fix(e2e): await async selector() in e2e_nested_utility_calls

### DIFF
--- a/yarn-project/end-to-end/src/e2e_nested_utility_calls.test.ts
+++ b/yarn-project/end-to-end/src/e2e_nested_utility_calls.test.ts
@@ -107,7 +107,7 @@ describe('authorizeUtilityCall hook', () => {
     expect(lastRequest).toMatchObject({
       caller: contractA.address,
       target: contractB.address,
-      functionSelector: contractB.methods.pow_utility.selector(),
+      functionSelector: await contractB.methods.pow_utility.selector(),
       functionName: 'pow_utility',
       callerContext: 'utility',
     });
@@ -122,7 +122,7 @@ describe('authorizeUtilityCall hook', () => {
     expect(lastRequest).toMatchObject({
       caller: contractA.address,
       target: contractB.address,
-      functionSelector: contractB.methods.pow_utility.selector(),
+      functionSelector: await contractB.methods.pow_utility.selector(),
       functionName: 'pow_utility',
       callerContext: 'utility',
     });
@@ -135,7 +135,7 @@ describe('authorizeUtilityCall hook', () => {
     expect(lastRequest).toMatchObject({
       caller: contractA.address,
       target: contractB.address,
-      functionSelector: contractB.methods.pow_utility.selector(),
+      functionSelector: await contractB.methods.pow_utility.selector(),
       functionName: 'pow_utility',
       callerContext: 'private',
     });
@@ -150,7 +150,7 @@ describe('authorizeUtilityCall hook', () => {
     expect(lastRequest).toMatchObject({
       caller: contractA.address,
       target: contractB.address,
-      functionSelector: contractB.methods.pow_utility.selector(),
+      functionSelector: await contractB.methods.pow_utility.selector(),
       functionName: 'pow_utility',
       callerContext: 'private',
     });


### PR DESCRIPTION
## Root cause

The 4 `toMatchObject` assertions in the `authorizeUtilityCall hook` block of `e2e_nested_utility_calls.test.ts` compared `lastRequest.functionSelector` against `contractB.methods.pow_utility.selector()`. That method is **async** — it returns `Promise<FunctionSelector>` via `FunctionSelector.fromNameAndParameters(...)`, which became async in #23007.

Because the expected value was an **un-awaited Promise**, and a Promise has no own enumerable properties, `toMatchObject` treated `functionSelector` as a vacuously-satisfied empty object and never compared the actual selector. The assertions silently passed regardless of the real value — the selector check was a no-op since #23007.

Note: this is a *latent / vacuous-assertion* defect, not a deterministic hard failure. The 4 subtests were passing (10/10) both before and after the change; the value of the fix is that the assertions now actually verify the selector.

## Fix

Add `await` to the 4 assertions:

```ts
functionSelector: await contractB.methods.pow_utility.selector(),
```

One line each, no other changes.

## Verification

Ran `yarn-project/end-to-end/scripts/run_test.sh simple src/e2e_nested_utility_calls.test.ts` (node 24.12.0, full bootstrap):

- **Before fix (un-awaited):** 10/10 passed — but the selector assertion was vacuous.
- **After fix (awaited):** 10/10 passed.
- **Negative control:** temporarily swapping in a deliberately wrong selector (`set_pow_args`) on the awaited assertion makes that subtest fail (1 failed / 9 passed), proving the awaited assertion is now genuinely meaningful. Reverted before commit.