### PR TITLE
fix(p2p): do not penalize peers that signal a missing block with Fr.ZERO

### DIFF
--- a/yarn-project/p2p/src/client/test/p2p_client.integration_block_txs.test.ts
+++ b/yarn-project/p2p/src/client/test/p2p_client.integration_block_txs.test.ts
@@ -7,7 +7,7 @@ import { type Logger, createLogger } from '@aztec/foundation/log';
 import { sleep } from '@aztec/foundation/sleep';
 import { emptyChainConfig } from '@aztec/stdlib/config';
 import type { WorldStateSynchronizer } from '@aztec/stdlib/interfaces/server';
-import { BlockProposal } from '@aztec/stdlib/p2p';
+import { BlockProposal, PeerErrorSeverity } from '@aztec/stdlib/p2p';
 import { makeBlockHeader, makeBlockProposal } from '@aztec/stdlib/testing';
 import { Tx, TxHash, TxHashArray } from '@aztec/stdlib/tx';
 
@@ -417,5 +417,47 @@ describe('p2p client integration block txs protocol ', () => {
 
     // Should get NOT_FOUND because without full tx hashes, handler can't return txs without proposal
     expect(response.status).toBe(ReqRespStatus.NOT_FOUND);
+  });
+
+  // When the responder takes the Fr.zero branch (no proposal/archived block locally, but matched
+  // the requested hashes against its tx pool) it is acting correctly per block_txs_handler.ts:54-58.
+  // Drive the response back through the requester's real validation and confirm it does NOT apply
+  // a peer penalty — Fr.zero is a documented "I don't have the block" signal, not misbehavior.
+  it('requester does not penalize peer that returns Fr.zero (peer lacks proposal but matched by hash)', async () => {
+    attestationPool.getBlockProposalByArchive.mockResolvedValue(undefined);
+    const hashToTx = new Map(txs.map((tx, i) => [txHashes[i].toString(), tx]));
+    txPool.getTxsByHash.mockImplementation((hashes: TxHash[]) =>
+      Promise.resolve(hashes.map(h => hashToTx.get(h.toString())!)),
+    );
+
+    const [client1, client2] = clients as any;
+    const peerManager = client1.p2pService.peerManager;
+    const penalizeSpy = jest.spyOn(peerManager, 'penalizePeer');
+
+    // Build and send a real reqresp BLOCK_TXS request over libp2p (includeFullTxHashes=true so
+    // the responder hits the Fr.zero branch instead of NOT_FOUND).
+    const requestedHashes = [txHashes[1], txHashes[3]];
+    const sourceProposal = await createBlockProposal(blockNumber, Fr.random(), txHashes);
+    const request = BlockTxsRequest.fromTxsSourceAndMissingTxs(sourceProposal, requestedHashes, true)!;
+    const response = await client1.p2pService.reqresp.sendRequestToPeer(
+      client2.p2pService.node.peerId,
+      ReqRespSubProtocol.BLOCK_TXS,
+      request.toBuffer(),
+    );
+
+    expect(response.status).toBe(ReqRespStatus.SUCCESS);
+    const decoded = BlockTxsResponse.fromBuffer(response.data);
+    expect(decoded.archiveRoot.equals(Fr.ZERO)).toBe(true);
+
+    // Run the response through client1's real validation — this is what BatchTxRequester does in
+    // production. The peer must not be penalized.
+    await (client1.p2pService as any).validateRequestedBlockTxsConsistency(
+      request,
+      decoded,
+      client2.p2pService.node.peerId,
+    );
+
+    expect(penalizeSpy).not.toHaveBeenCalledWith(expect.anything(), PeerErrorSeverity.MidToleranceError);
+    expect(penalizeSpy).not.toHaveBeenCalledWith(expect.anything(), PeerErrorSeverity.LowToleranceError);
   });
 });

--- a/yarn-project/p2p/src/services/libp2p/libp2p_service.test.ts
+++ b/yarn-project/p2p/src/services/libp2p/libp2p_service.test.ts
@@ -529,6 +529,21 @@ describe('LibP2PService', () => {
       expect(mockPeerManager.penalizePeer).not.toHaveBeenCalled();
       expect(mockArchiver.getBlock).toHaveBeenCalledWith({ archive: hash });
     });
+
+    // The reqresp BLOCK_TXS responder (block_txs_handler.ts:54-58) returns archiveRoot=Fr.ZERO
+    // when it doesn't have the block in either the attestation pool or the archiver, but the
+    // request carried full tx hashes — it matches them against its pool and ships whatever it
+    // finds. This is a documented "I don't have the block" signal, not misbehavior, so the
+    // requester must not penalize the peer for it.
+    it('should not penalize a peer that signals lacking the block with Fr.ZERO archive root', async () => {
+      const hash = Fr.random();
+      const request = makeRequest(hash, 3, [0, 2]);
+      const response = makeResponse(Fr.ZERO, 0, [], ['0xfound0', '0xfound2']);
+
+      await service.validateRequestedBlockTxsConsistency(request, response, mockPeerId);
+
+      expect(mockPeerManager.penalizePeer).not.toHaveBeenCalled();
+    });
   });
 
   describe('processBlockFromPeer', () => {

--- a/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
+++ b/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
@@ -1528,6 +1528,16 @@ export class LibP2PService extends WithTracer implements P2PService {
     peerId: PeerId,
   ): Promise<boolean> {
     try {
+      // A response with archiveRoot=Fr.zero is the documented "I don't have the block" signal from
+      // reqRespBlockTxsHandler (block_txs_handler.ts:54-58): the peer lacked the block in its
+      // attestation pool and archiver, but matched the requested hashes against its tx pool and
+      // shipped what it found. This is legitimate behaviour, not misbehaviour — we just can't verify
+      // membership/order without the block, so we drop the response without penalising the peer.
+      if (response.archiveRoot.isZero()) {
+        this.logger.debug(`Peer ${peerId.toString()} signalled missing block with Fr.zero archive root`);
+        return false;
+      }
+
       if (!response.archiveRoot.equals(request.archiveRoot)) {
         this.peerManager.penalizePeer(peerId, PeerErrorSeverity.MidToleranceError);
         throw new ValidationError(


### PR DESCRIPTION
**Stacked on:** `[mr/fix-block-txs-validation-archiver-fallback](https://github.com/AztecProtocol/aztec-packages/pull/23624)` (the archiver-fallback PR).

---

## Summary

A peer that legitimately can't find the requested block in its attestation pool or archiver, but matches the requested hashes against its tx pool and sends those txs back, signals "I don't have the block" by setting `archiveRoot = Fr.ZERO` in the response (`block_txs_handler.ts:54-58`). The requester's validation currently treats that response the same as a malicious archive-root mismatch and applies a `MidToleranceError` peer penalty. After enough such responses from the same helpful peer, that peer is disconnected by the requester for behaviour the protocol explicitly documents as legitimate.

This PR makes the validator recognise `Fr.ZERO` as the "I don't have the block" signal and stop penalising peers for it.

## What's broken

### Responder side (correct, intentional)

`block_txs_handler.ts:54-58` — when the responder lacks the block (no proposal, no archived block) but the request carried full tx hashes, it tries to serve from its pool by hash and signals the "I don't know the block" condition with `archiveRoot = Fr.zero()`:

```ts
if (!txHashes && requestedTxsHashes !== undefined) {
  const responseTxs = (await txPool.getTxsByHash(requestedTxsHashes)).filter(tx => !!tx);
  const response = new BlockTxsResponse(Fr.zero(), new TxArray(...responseTxs), BitVector.init(0, []));
  return response.toBuffer();
}
```

### Requester side (broken)

The validator at `libp2p_service.ts:1525-1530` penalizes any archive-root mismatch with `MidToleranceError` (-10 score points) and throws — *including* `Fr.zero`:

```ts
if (!response.archiveRoot.equals(request.archiveRoot)) {
  this.peerManager.penalizePeer(peerId, PeerErrorSeverity.MidToleranceError);
  throw new ValidationError(...);
}
```

After 5 such responses from the same helpful peer, that peer is at -50 in the requester's score book → disconnected by `pruneUnhealthyPeers` (`peer_manager.ts:601-603`).

### Receiver-side code already documented the correct intent

The wrongful penalty contradicts what the receiver-side code explicitly says should happen. `batch_tx_requester.ts:586-600` has `handleArchiveRootMismatch`, whose docstring spells out exactly the semantic we're restoring:

```ts
/**
 * Handles an archive root mismatch between local state and peer response.
 *
 * - Response archive is Fr.ZERO (peer pruned proposal, legitimate): marks peer dumb.
 * - Non-zero archive mismatch (malicious response): penalises + marks dumb.
 */
private handleArchiveRootMismatch(peerId: PeerId, response: BlockTxsResponse): void {
  if (!response.archiveRoot.isZero()) {
    this.peers.penalisePeer(peerId, PeerErrorSeverity.LowToleranceError);
  }
  this.peers.markPeerDumb(peerId);
  this.txsMetadata.clearPeerData(peerId);
}
```

But this function is only reached from `decideIfPeerIsSmart` → `handleSuccessResponseFromPeer`, which only runs when validation returns `true`. The validator's first check (archive-root equality) rejects every archive-mismatched response — including `Fr.zero` — so `handleArchiveRootMismatch` is never actually invoked. The "Fr.zero is legitimate" exemption it encodes has been unreachable since the validator's archive-root check was added.

The flow today:

```
   reqresp response
        │
        ▼
   validateRequestedBlockTxsConsistency
   ├─ Fr.zero       → reject + Mid penalty (BUG, contradicts the docstring above)
   ├─ non-zero ≠    → reject + Mid penalty
   └─ matches archive root ──► handleSuccessResponseFromPeer
                                  └─ decideIfPeerIsSmart
                                       └─ hasArchiveRootMismatch?
                                            always false (validator filtered them all out)
                                            ──► handleArchiveRootMismatch   ◄── DEAD CODE
```

So the receiver side already knew Fr.zero should not be penalised; the decision was just being made at the wrong layer. This PR moves it to the validator, where it can actually fire. `handleArchiveRootMismatch` itself remains dead code (separate cleanup candidate, not in this PR).

## Fix

Special-case `response.archiveRoot.isZero()` at the top of `validateRequestedBlockTxsConsistency` so the archive-root mismatch path is bypassed for `Fr.zero` responses. We still return `false` (the txs are dropped because we can't verify membership/order without the block) but no peer penalty is applied — matching the intent of the `Fr.zero` exemption in `batch_tx_requester.ts:593-600`.

```ts
// libp2p_service.ts (inside validateRequestedBlockTxsConsistency)
if (response.archiveRoot.isZero()) {
  this.logger.debug(`Peer ${peerId.toString()} signalled missing block with Fr.zero archive root`);
  return false;
}

if (!response.archiveRoot.equals(request.archiveRoot)) {
  this.peerManager.penalizePeer(peerId, PeerErrorSeverity.MidToleranceError);
  ...
}
```

The validator's other checks are unchanged. The early return prevents the bitvector-length and `maxReturnable` checks downstream from firing on a zero-length bitvector response, which would otherwise also wrongly penalise the peer.

## Tests

**Unit** — `p2p/src/services/libp2p/libp2p_service.test.ts`

A new test in the `validateRequestedBlockTxsConsistency` describe block: *"should not penalize a peer that signals lacking the block with Fr.ZERO archive root"*. Constructs a response with `archiveRoot = Fr.ZERO` and asserts that `peerManager.penalizePeer` is not called. Verified red before the fix, green after.

**Integration** — `p2p/src/client/test/p2p_client.integration_block_txs.test.ts`

A new test in the `p2p client integration block txs protocol` describe block: *"requester does not penalize peer that returns Fr.zero (peer lacks proposal but matched by hash)"*. Drives a real reqresp BLOCK_TXS request over libp2p between two clients, lets the responder hit the `Fr.zero` branch in `block_txs_handler`, then runs the response through the requester's real `validateRequestedBlockTxsConsistency` and asserts the requester's `peerManager.penalizePeer` is not called with `MidToleranceError` or `LowToleranceError`. Verified red before the fix, green after.
