### PR TITLE
feat: partially_evaluate — 5-wide WASM SIMD

### DIFF
--- a/barretenberg/cpp/src/barretenberg/commitment_schemes/gemini/gemini_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/commitment_schemes/gemini/gemini_impl.hpp
@@ -150,13 +150,45 @@ std::vector<typename GeminiProver_<Curve>::Polynomial> GeminiProver_<Curve>::com
         // A_l_fold = Aₗ₊₁(X) = (1-uₗ)⋅even(Aₗ)(X) + uₗ⋅odd(Aₗ)(X)
         auto A_l_fold = fold_polynomials[l].data();
 
+        // Kernel shape per output j: A_l_fold[j] = A_l[2j] + u_l * (A_l[2j+1] - A_l[2j]).
+        // Same stride-2 lerp as Sumcheck::partially_evaluate; under WASM SIMD with Bn254Fr,
+        // each thread's slice runs the 5-output SIMD lerp via VectorField::gather + lerp +
+        // store_to, with a scalar tail. Output buffer A_l_fold is distinct from the source
+        // A_l (allocated fresh in fold_polynomials[l]), so no aliasing concerns.
         parallel_for_heuristic(
             num_pairs,
-            [&](size_t j) {
-                // fold(Aₗ)[j] = (1-uₗ)⋅even(Aₗ)[j] + uₗ⋅odd(Aₗ)[j]
-                //            = (1-uₗ)⋅Aₗ[2j]      + uₗ⋅Aₗ[2j+1]
-                //            = Aₗ₊₁[j]
-                A_l_fold[j] = A_l[j << 1] + u_l * (A_l[(j << 1) + 1] - A_l[j << 1]);
+            [&](const ThreadChunk& chunk) {
+                auto chunk_range = chunk.range(num_pairs);
+                if (chunk_range.empty()) {
+                    return;
+                }
+                const size_t lo = *chunk_range.begin();
+                const size_t hi = lo + chunk_range.size();
+                size_t j = lo;
+#if defined(__wasm_simd128__)
+                if constexpr (has_simd_mont_mul_v<typename Fr::Params>) {
+                    using Vec = VectorField<typename Fr::Params>;
+                    const Vec u_vec = Vec::broadcast(u_l);
+                    const size_t pair_groups = (hi - lo) / 5;
+                    for (size_t b = 0; b < pair_groups; ++b) {
+                        const size_t src_base = (lo + b * 5) << 1;
+                        const std::array<size_t, 5> even_idx{
+                            src_base + 0, src_base + 2, src_base + 4, src_base + 6, src_base + 8
+                        };
+                        const std::array<size_t, 5> odd_idx{
+                            src_base + 1, src_base + 3, src_base + 5, src_base + 7, src_base + 9
+                        };
+                        const Vec even = Vec::gather(A_l, even_idx);
+                        const Vec odd = Vec::gather(A_l, odd_idx);
+                        const Vec result = even + (odd - even) * u_vec;
+                        result.store_to(A_l_fold + lo + b * 5);
+                    }
+                    j = lo + pair_groups * 5;
+                }
+#endif
+                for (; j < hi; ++j) {
+                    A_l_fold[j] = A_l[j << 1] + u_l * (A_l[(j << 1) + 1] - A_l[j << 1]);
+                }
             },
             fold_iteration_cost);
         // If odd number of coefficients, the last one has no partner (implicitly 0)

--- a/barretenberg/cpp/src/barretenberg/common/assert.hpp
+++ b/barretenberg/cpp/src/barretenberg/common/assert.hpp
@@ -184,9 +184,40 @@ struct AssertGuard {
 
 // These are used in tests.
 #ifdef BB_NO_EXCEPTIONS
+#ifdef __wasm__
+// WASI gtest does not expose ASSERT_DEATH / EXPECT_DEATH (process-exit semantics aren't
+// available to user code inside the WASM module). Skip the assertion instead — the
+// test still executes the surrounding setup, just stops at the death check. Without
+// this fallback, every TU that includes a death-style assertion fails to compile under
+// WASM, which is why only `ecc_tests` currently builds for `test_cmds_wasm_threads` in
+// bootstrap.sh.
+//
+// The `sizeof((void)(statement), 0)` and `(void)sizeof(matcher)` patterns parse the
+// arguments without evaluating them, so any locals / typedefs referenced inside the
+// death-check expression don't trigger -Wunused warnings at the call site.
+#define ASSERT_THROW_OR_ABORT(statement, matcher)                                                                      \
+    do {                                                                                                               \
+        (void)sizeof((void)(statement), 0);                                                                            \
+        (void)sizeof(matcher);                                                                                         \
+        GTEST_SKIP() << "death tests unavailable on WASI";                                                             \
+    } while (0)
+#define EXPECT_THROW_OR_ABORT(statement, matcher)                                                                      \
+    do {                                                                                                               \
+        (void)sizeof((void)(statement), 0);                                                                            \
+        (void)sizeof(matcher);                                                                                         \
+        GTEST_SKIP() << "death tests unavailable on WASI";                                                             \
+    } while (0)
+#define EXPECT_THROW_WITH_MESSAGE(code, expectedMessage)                                                               \
+    do {                                                                                                               \
+        (void)sizeof((void)(code), 0);                                                                                 \
+        (void)sizeof(expectedMessage);                                                                                 \
+        GTEST_SKIP() << "death tests unavailable on WASI";                                                             \
+    } while (0)
+#else
 #define ASSERT_THROW_OR_ABORT(statement, matcher) ASSERT_DEATH(statement, matcher)
 #define EXPECT_THROW_OR_ABORT(statement, matcher) EXPECT_DEATH(statement, matcher)
 #define EXPECT_THROW_WITH_MESSAGE(code, expectedMessage) EXPECT_DEATH(code, expectedMessage)
+#endif
 #else
 #define ASSERT_THROW_OR_ABORT(statement, matcher) ASSERT_THROW(statement, std::runtime_error)
 #define EXPECT_THROW_OR_ABORT(statement, matcher) EXPECT_THROW(statement, std::runtime_error)

--- a/barretenberg/cpp/src/barretenberg/polynomials/eq_polynomial.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/eq_polynomial.test.cpp
@@ -207,7 +207,7 @@ TEST_F(EqPolyTest, ProverTableMatchesVerifierOnBooleanPoints)
     for (uint64_t ell = 0; ell < (1ULL << d); ++ell) {
         const auto u = bool_vec_from_mask(d, ell);
         const FF got_ver = v.evaluate(u);
-        const FF got_prov = peq.at(ell);
+        const FF got_prov = peq.at(static_cast<size_t>(ell));
         EXPECT_EQ(got_prov, got_ver) << "ell=" << ell;
     }
 }

--- a/barretenberg/cpp/src/barretenberg/sumcheck/sumcheck.hpp
+++ b/barretenberg/cpp/src/barretenberg/sumcheck/sumcheck.hpp
@@ -670,16 +670,25 @@ template <typename Flavor> class SumcheckProver {
      * Kernel shape per output k: dst[k] = src[2k] + r * (src[2k+1] - src[2k]) — a linear
      * interpolation between adjacent source slots. Stride-2 read, contiguous write.
      *
-     * Under WASM SIMD with Bn254Fr, processes 5 outputs per iteration via VectorField:
-     * one width-5 sub + one width-5 mul + one width-5 add replaces 5 scalar Mont-muls (≈5×
-     * Mont-mul saving per group). Even/odd lanes are loaded via `Vec::gather` (per-lane
-     * scalar reads — the Mont-mul savings dominate the gather cost). The result is stored
-     * via the SIMD-shuffle linear-memory `store_to`. Tail and non-WASM/non-Bn254Fr take
-     * the original scalar K=1 path.
+     * Under WASM SIMD with Bn254Fr, the dense interior of each polynomial runs the K=5 path:
+     * one width-5 sub + one width-5 mul + one width-5 add replaces 5 scalar Mont-muls.
+     * Even/odd lanes load via `Vec::gather`; result stores via `store_to`. Tail and
+     * non-WASM/non-Bn254Fr take the original scalar K=1 path.
      *
-     * Aliasing under partially_evaluate_in_place: batch b reads src[10b..10b+9] and writes
-     * dst[5b..5b+4]. For b > 0, write zone [5b..5b+4] ⊂ [0..10b-1] is strictly before the
-     * read zone — no future-read conflict. Within batch 0, both gathers complete before
+     * Virtual-zero prefix handling: barretenberg polynomials are virtual-shifted —
+     * `poly.operator[](i)` returns 0 for `i < poly.start_index()` (the slots before
+     * the backing buffer). The scalar path uses `poly[i]`, which respects this; the
+     * SIMD `Vec::gather` uses raw pointer arithmetic on `poly.data()` and would deref
+     * before the backing buffer if applied at i < start_index. Shiftable polynomials
+     * (start_index = NUM_ZERO_ROWS = 1) appear throughout MegaFlavor round 0, so this
+     * matters. Run a scalar head until `i >= start_index`, SIMD bulk over the dense
+     * region, then scalar tail. Also gate SIMD on `dest.start_index() == 0` since
+     * `store_to` writes contiguously from `dest.data()`; the
+     * PartiallyEvaluatedMultivariates constructor always satisfies this, but be
+     * explicit for safety.
+     *
+     * Aliasing under partially_evaluate_in_place: batch b's read region is strictly
+     * before batch b+1's write region; within batch 0 the gathers complete before
      * any store. Safe.
      */
     static void partially_evaluate(auto& source_polynomials,
@@ -691,37 +700,50 @@ template <typename Flavor> class SumcheckProver {
         parallel_for(source_view.size(), [&](size_t j) {
             BB_BENCH_TRACY_NAME("Sumcheck::partially_evaluate");
             const auto& poly = source_view[j];
+            auto& dest = dest_view[j];
             const size_t limit = poly.end_index();
+            const size_t start = poly.start_index();
             size_t i = 0;
+            // Scalar head: cover the virtual-zero prefix where `poly[i]` would return 0
+            // for i < start. The SIMD gather can't safely read before poly.data().
+            for (; i < start && i < limit; i += 2) {
+                dest.at(i >> 1) = poly[i] + round_challenge * (poly[i + 1] - poly[i]);
+            }
 #if defined(__wasm_simd128__)
             if constexpr (has_simd_mont_mul_v<typename FF::Params>) {
-                using Vec = VectorField<typename FF::Params>;
-                const Vec r_vec = Vec::broadcast(round_challenge);
-                const FF* src_base = poly.data() - poly.start_index();
-                FF* dst_base = dest_view[j].data() - dest_view[j].start_index();
-                const size_t k5_groups = limit / 10; // full 10-source-element groups
-                for (size_t b = 0; b < k5_groups; ++b) {
-                    const size_t src_base_idx = b * 10;
-                    const std::array<size_t, 5> even_idx{
-                        src_base_idx + 0, src_base_idx + 2, src_base_idx + 4, src_base_idx + 6, src_base_idx + 8
-                    };
-                    const std::array<size_t, 5> odd_idx{
-                        src_base_idx + 1, src_base_idx + 3, src_base_idx + 5, src_base_idx + 7, src_base_idx + 9
-                    };
-                    const Vec even = Vec::gather(src_base, even_idx);
-                    const Vec odd = Vec::gather(src_base, odd_idx);
-                    const Vec result = even + (odd - even) * r_vec;
-                    result.store_to(dst_base + b * 5);
+                // After the head, i >= start (or i >= limit). Bulk SIMD is safe iff there
+                // are dense source elements remaining AND the dest is start_index=0
+                // (which `store_to` assumes).
+                if (i < limit && dest.start_index() == 0) {
+                    using Vec = VectorField<typename FF::Params>;
+                    const Vec r_vec = Vec::broadcast(round_challenge);
+                    // poly.data()[i - start] is the dense slot for absolute index i.
+                    const FF* src_dense = poly.data() + (i - start);
+                    FF* dst_dense = dest.data();
+                    const size_t k5_groups = (limit - i) / 10;
+                    for (size_t b = 0; b < k5_groups; ++b) {
+                        const size_t src_off = b * 10;
+                        const std::array<size_t, 5> even_idx{
+                            src_off + 0, src_off + 2, src_off + 4, src_off + 6, src_off + 8
+                        };
+                        const std::array<size_t, 5> odd_idx{
+                            src_off + 1, src_off + 3, src_off + 5, src_off + 7, src_off + 9
+                        };
+                        const Vec even = Vec::gather(src_dense, even_idx);
+                        const Vec odd = Vec::gather(src_dense, odd_idx);
+                        const Vec result = even + (odd - even) * r_vec;
+                        result.store_to(dst_dense + (i >> 1) + b * 5);
+                    }
+                    i += k5_groups * 10;
                 }
-                i = k5_groups * 10; // scalar tail starts at the first untouched source index
             }
 #endif
-            // Scalar K=1 tail (or full pass on native / non-Bn254Fr). When the SIMD path is
-            // disabled, i == 0 and this recovers the original loop exactly.
+            // Scalar tail (also handles the full pass on native / non-Bn254Fr / when the
+            // SIMD block was guarded out).
             for (; i < limit; i += 2) {
-                dest_view[j].at(i >> 1) = poly[i] + round_challenge * (poly[i + 1] - poly[i]);
+                dest.at(i >> 1) = poly[i] + round_challenge * (poly[i + 1] - poly[i]);
             }
-            dest_view[j].shrink_end_index((limit / 2) + (limit % 2));
+            dest.shrink_end_index((limit / 2) + (limit % 2));
         });
     };
 

--- a/barretenberg/cpp/src/barretenberg/sumcheck/sumcheck.hpp
+++ b/barretenberg/cpp/src/barretenberg/sumcheck/sumcheck.hpp
@@ -666,6 +666,21 @@ template <typename Flavor> class SumcheckProver {
      * @brief Evaluate at the round challenge and prepare for next round.
      * @details Reads from source_polynomials and writes to dest_polynomials.
      * See Sumcheck.md for detailed mathematical documentation of the book-keeping table approach.
+     *
+     * Kernel shape per output k: dst[k] = src[2k] + r * (src[2k+1] - src[2k]) — a linear
+     * interpolation between adjacent source slots. Stride-2 read, contiguous write.
+     *
+     * Under WASM SIMD with Bn254Fr, processes 5 outputs per iteration via VectorField:
+     * one width-5 sub + one width-5 mul + one width-5 add replaces 5 scalar Mont-muls (≈5×
+     * Mont-mul saving per group). Even/odd lanes are loaded via `Vec::gather` (per-lane
+     * scalar reads — the Mont-mul savings dominate the gather cost). The result is stored
+     * via the SIMD-shuffle linear-memory `store_to`. Tail and non-WASM/non-Bn254Fr take
+     * the original scalar K=1 path.
+     *
+     * Aliasing under partially_evaluate_in_place: batch b reads src[10b..10b+9] and writes
+     * dst[5b..5b+4]. For b > 0, write zone [5b..5b+4] ⊂ [0..10b-1] is strictly before the
+     * read zone — no future-read conflict. Within batch 0, both gathers complete before
+     * any store. Safe.
      */
     static void partially_evaluate(auto& source_polynomials,
                                    PartiallyEvaluatedMultivariates& dest_polynomials,
@@ -676,8 +691,34 @@ template <typename Flavor> class SumcheckProver {
         parallel_for(source_view.size(), [&](size_t j) {
             BB_BENCH_TRACY_NAME("Sumcheck::partially_evaluate");
             const auto& poly = source_view[j];
-            size_t limit = poly.end_index();
-            for (size_t i = 0; i < limit; i += 2) {
+            const size_t limit = poly.end_index();
+            size_t i = 0;
+#if defined(__wasm_simd128__)
+            if constexpr (has_simd_mont_mul_v<typename FF::Params>) {
+                using Vec = VectorField<typename FF::Params>;
+                const Vec r_vec = Vec::broadcast(round_challenge);
+                const FF* src_base = poly.data() - poly.start_index();
+                FF* dst_base = dest_view[j].data() - dest_view[j].start_index();
+                const size_t k5_groups = limit / 10; // full 10-source-element groups
+                for (size_t b = 0; b < k5_groups; ++b) {
+                    const size_t src_base_idx = b * 10;
+                    const std::array<size_t, 5> even_idx{
+                        src_base_idx + 0, src_base_idx + 2, src_base_idx + 4, src_base_idx + 6, src_base_idx + 8
+                    };
+                    const std::array<size_t, 5> odd_idx{
+                        src_base_idx + 1, src_base_idx + 3, src_base_idx + 5, src_base_idx + 7, src_base_idx + 9
+                    };
+                    const Vec even = Vec::gather(src_base, even_idx);
+                    const Vec odd = Vec::gather(src_base, odd_idx);
+                    const Vec result = even + (odd - even) * r_vec;
+                    result.store_to(dst_base + b * 5);
+                }
+                i = k5_groups * 10; // scalar tail starts at the first untouched source index
+            }
+#endif
+            // Scalar K=1 tail (or full pass on native / non-Bn254Fr). When the SIMD path is
+            // disabled, i == 0 and this recovers the original loop exactly.
+            for (; i < limit; i += 2) {
                 dest_view[j].at(i >> 1) = poly[i] + round_challenge * (poly[i + 1] - poly[i]);
             }
             dest_view[j].shrink_end_index((limit / 2) + (limit % 2));


### PR DESCRIPTION
Stacked on #23353.

## What's in this PR

**(1) Vectorized `Sumcheck::partially_evaluate`** ([sumcheck.hpp:670-718](barretenberg/cpp/src/barretenberg/sumcheck/sumcheck.hpp#L670-L718)). Stride-2 lerp kernel `dst[k] = src[2k] + r * (src[2k+1] - src[2k])`. Under WASM SIMD with Bn254Fr, replace each 5-output group with one width-5 vec-sub + vec-mul + vec-add — ~5 scalar Mont-muls → ~1 vec Mont-mul. Even/odd lanes via `VectorField::gather`, result via SIMD-shuffle `store_to`. Scalar K=1 tail handles remainder.

Aliasing under `partially_evaluate_in_place`: batch b reads `src[10b..10b+9]`, writes `dst[5b..5b+4]`. For b > 0 the write zone strictly precedes the next batch's read zone; within batch 0 both gathers complete before any store.

**(2) Vectorized `Gemini::compute_fold_polynomials`** ([gemini_impl.hpp:143-194](barretenberg/cpp/src/barretenberg/commitment_schemes/gemini/gemini_impl.hpp#L143-L194)). Same lerp shape as (1): `A_l_fold[j] = A_l[2j] + u_l * (A_l[2j+1] - A_l[2j])`. Converts the per-`j` `parallel_for_heuristic` to its `ThreadChunk` variant so each thread runs the same q1s1 SIMD path on its slice. Output buffer is freshly allocated per fold round → no aliasing.

**(3) WASM-build unblock for poly / sumcheck test TUs** ([assert.hpp](barretenberg/cpp/src/barretenberg/common/assert.hpp), [eq_polynomial.test.cpp](barretenberg/cpp/src/barretenberg/polynomials/eq_polynomial.test.cpp)). `ASSERT_THROW_OR_ABORT` / `EXPECT_THROW_OR_ABORT` expand to `ASSERT_DEATH` / `EXPECT_DEATH` under `BB_NO_EXCEPTIONS`, but WASI gtest does not provide death tests. Add a `__wasm__` branch turning them into `GTEST_SKIP`. Plus one `static_cast<size_t>` for a narrowing fatal. Together these make `polynomials_tests` / `sumcheck_tests` compile cleanly on WASM. Today only `ecc_tests` builds for `test_cmds_wasm_threads` in [bootstrap.sh:280-283](barretenberg/cpp/bootstrap.sh#L280-L283).

## Why

Sumcheck is ~20-30% of Chonk prove on WASM; `partially_evaluate` is ~30-50% of sumcheck (the per-round book-keeping loop). Gemini's `compute_fold_polynomials` is the same lerp shape in PCS, called once per proof over the full polynomial.

## Measurement

**`partially_evaluate` (BrowserStack, V8 ARM, 9 trials A/B):**

| Device | N | scalar ms/call | simd ms/call | simd/scalar |
|---|---|---|---|---|
| macOS M2 V8 | 65536 | 2.092 | 0.635 | **0.304 (~3.29×)** |
| macOS M2 V8 | 262144 | 8.369 | 2.566 | **0.307** |
| S25 Ultra V8 | 65536 | 1.591 | 0.552 | **0.347 (~2.88×)** |
| S25 Ultra V8 | 262144 | 6.432 | 2.287 | **0.356** |
| Pixel 9 Pro V8 | 65536 | 3.355 | 0.974 | **0.290 (~3.44×)** |
| Pixel 9 Pro V8 | 262144 | 13.289 | 3.993 | **0.300** |

Bit-identical output verified on every device. CV ≤ 0.018 across all measurements. Gemini fold has the same kernel shape so the same ~3× should carry; e2e measurement pending.

**Estimated e2e:** ~4-10% on V8 from partially_evaluate alone (sumcheck-share × kernel-share × kernel-speedup). Gemini fold is additive on the PCS path.

## Known: WASM `_start` trap blocks runs of `polynomials_tests` / `sumcheck_tests`

Builds clean post commit (3); runs trap at WASI `_start` before any user code. Separate pre-existing runtime issue (likely global-ctor abort tied to the larger lib set those tests link). Outside the scope of this PR.

## Tests

- Native `ultra_honk_tests`: PASS (sumcheck path).
- Native `commitment_schemes_tests`: PASS 90/90 (Gemini path).
- Native `sumcheck_tests::PartialEvaluation*`: PASS.
- WASM `ecc_tests`: unaffected.
- WASM `polynomials_tests` / `sumcheck_tests` / `commitment_schemes_tests`: build clean post commit (3); runs blocked by pre-existing `_start` trap (flagged above).

## JSC

Same primitive (`VectorField<Bn254FrParams>::operator*`) as PR4 — extend the existing JSC gate to cover this path before enabling on Safari.

## Stack

#23202 → #23209 → #23210 → #23353 → **this PR**