### PR TITLE
fix: simulate proposals inside target slot

### DIFF
--- a/yarn-project/sequencer-client/src/publisher/sequencer-bundle-simulator.ts
+++ b/yarn-project/sequencer-client/src/publisher/sequencer-bundle-simulator.ts
@@ -4,7 +4,7 @@ import { type L1TxUtils, MAX_L1_TX_LIMIT } from '@aztec/ethereum/l1-tx-utils';
 import { formatViemError } from '@aztec/ethereum/utils';
 import type { SlotNumber } from '@aztec/foundation/branded-types';
 import { type Logger, createLogger } from '@aztec/foundation/log';
-import { getTimestampForSlot } from '@aztec/stdlib/epoch-helpers';
+import { getLastL1SlotTimestampForL2Slot } from '@aztec/stdlib/epoch-helpers';
 
 import type { Hex, StateOverride } from 'viem';
 
@@ -64,7 +64,7 @@ export class SequencerBundleSimulator {
   }
 
   /**
-   * Simulates the given bundle at the target slot's start timestamp and filters out entries
+   * Simulates the given bundle near the end of the target slot and filters out entries
    * that revert.
    *
    * - If all entries pass on the first pass, returns `success` with the gasLimit.
@@ -75,14 +75,15 @@ export class SequencerBundleSimulator {
    * - If eth_simulateV1 is unavailable, returns `fallback`. The caller is expected to send the
    *   bundle as-is with a safe gas limit.
    *
-   * The simulation `block.timestamp` is always the target L2 slot's start timestamp, since
-   * propose's `validateHeader` and EIP-712 signature checks both derive a slot from
-   * `block.timestamp` and compare against the slot the validator signed for.
+   * The simulation `block.timestamp` is the last L1 slot timestamp inside the target L2 slot.
+   * This still maps to the target L2 slot for propose's `validateHeader` and EIP-712 signature
+   * checks, while avoiding eth_simulateV1 rejecting a child block whose timestamp is not strictly
+   * greater than the current L1 head.
    *
    * Known limitation: on networks where L1 is mining behind cadence (missed L1 slots, anvil with
    * overridden timestamps), the actual `block.timestamp` at send time can land in the prior L2
    * slot. In that case `propose` would revert silently inside the multicall. The simulator does
-   * not detect this case because it simulates AT the target timestamp — the prior implementation
+   * not detect this case because it simulates inside the target slot — the prior implementation
    * used `min(predictedNextL1Ts, targetTimestamp)` to surface this failure mode at simulate time.
    */
   public async simulate(validRequests: RequestWithExpiry[], targetSlot: SlotNumber): Promise<BundleSimulateResult> {
@@ -94,7 +95,7 @@ export class SequencerBundleSimulator {
     const l1TxUtils = this.deps.getL1TxUtils();
 
     const proposeRequest = validRequests.find(r => r.action === 'propose');
-    const simulateTimestamp = getTimestampForSlot(targetSlot, this.deps.epochCache.getL1Constants());
+    const simulateTimestamp = getLastL1SlotTimestampForL2Slot(targetSlot, this.deps.epochCache.getL1Constants());
     const firstPassOverrides = await this.buildStateOverrides(!!proposeRequest);
 
     const firstPass = await this.simulateAndDecode(l1TxUtils, validRequests, simulateTimestamp, firstPassOverrides);

--- a/yarn-project/sequencer-client/src/publisher/sequencer-publisher.test.ts
+++ b/yarn-project/sequencer-client/src/publisher/sequencer-publisher.test.ts
@@ -68,6 +68,7 @@ describe('SequencerPublisher', () => {
   let rollup: MockProxy<RollupContract>;
   let slashingProposerContract: MockProxy<SlashingProposerContract>;
   let governanceProposerContract: MockProxy<GovernanceProposerContract>;
+  let epochCache: MockProxy<EpochCache>;
   let l1TxUtils: MockProxy<L1TxUtils>;
   let l1Metrics: MockProxy<SequencerPublisherMetrics>;
   let forwardSpy: jest.SpiedFunction<typeof Multicall3.forward>;
@@ -137,7 +138,7 @@ describe('SequencerPublisher', () => {
 
     governanceProposerContract = mock<GovernanceProposerContract>();
 
-    const epochCache = mock<EpochCache>();
+    epochCache = mock<EpochCache>();
     epochCache.getEpochAndSlotNow.mockReturnValue({ epoch: EpochNumber(1), slot: SlotNumber(2), ts: 3n, nowMs: 3000n });
     epochCache.getL1Constants.mockReturnValue(EmptyL1RollupConstants);
     epochCache.getSlotNow.mockReturnValue(SlotNumber(2));
@@ -523,6 +524,42 @@ describe('SequencerPublisher', () => {
     expect(result).toEqual(undefined);
     expect(forwardSpy).not.toHaveBeenCalled();
     expect(l1TxUtils.simulate).toHaveBeenCalledTimes(1);
+  });
+
+  it('simulates block header validation at the last L1 timestamp within the L2 slot', async () => {
+    epochCache.getL1Constants.mockReturnValue({
+      ...EmptyL1RollupConstants,
+      l1GenesisTime: 1000n,
+      slotDuration: 72,
+      ethereumSlotDuration: 12,
+    });
+
+    await publisher.validateBlockHeader(CheckpointHeader.random({ slotNumber: SlotNumber(5) }));
+
+    expect(l1TxUtils.simulate.mock.calls[0][1]).toEqual({ time: 1420n });
+  });
+
+  it('simulates request bundles at the last L1 timestamp within the target L2 slot', async () => {
+    epochCache.getL1Constants.mockReturnValue({
+      ...EmptyL1RollupConstants,
+      l1GenesisTime: 1000n,
+      slotDuration: 72,
+      ethereumSlotDuration: 12,
+    });
+    publisher.addRequest({
+      action: 'invalidate-by-invalid-attestation',
+      request: { to: mockRollupAddress, data: '0xdeadbeef' },
+      lastValidL2Slot: SlotNumber(5),
+      checkSuccess: () => true,
+    });
+    forwardSpy.mockResolvedValue({ receipt: proposeTxReceipt, stats: undefined, multicallData: '0x' });
+
+    await publisher.sendRequests(SlotNumber(5));
+
+    expect(l1TxUtils.simulate.mock.calls[0][1]).toEqual({
+      time: 1420n,
+      gasLimit: MAX_L1_TX_LIMIT * 2n,
+    });
   });
 
   describe('bundleSimulate second-pass re-decode', () => {

--- a/yarn-project/sequencer-client/src/publisher/sequencer-publisher.test.ts
+++ b/yarn-project/sequencer-client/src/publisher/sequencer-publisher.test.ts
@@ -526,17 +526,24 @@ describe('SequencerPublisher', () => {
     expect(l1TxUtils.simulate).toHaveBeenCalledTimes(1);
   });
 
-  it('simulates block header validation at the last L1 timestamp within the L2 slot', async () => {
+  it('validates block headers when L1 head is already at the L2 slot boundary', async () => {
     epochCache.getL1Constants.mockReturnValue({
       ...EmptyL1RollupConstants,
       l1GenesisTime: 1000n,
       slotDuration: 72,
       ethereumSlotDuration: 12,
     });
+    const slotStartTimestamp = 1360n;
+    (l1TxUtils as any).simulate.mockImplementationOnce((_call: unknown, blockOverrides: { time?: bigint }) => {
+      if ((blockOverrides.time ?? 0n) <= slotStartTimestamp) {
+        throw new Error(`simulated block timestamp must be greater than parent timestamp`);
+      }
+      return Promise.resolve({ gasUsed: 1_000_000n, result: '0x' });
+    });
 
-    await publisher.validateBlockHeader(CheckpointHeader.random({ slotNumber: SlotNumber(5) }));
-
-    expect(l1TxUtils.simulate.mock.calls[0][1]).toEqual({ time: 1420n });
+    await expect(
+      publisher.validateBlockHeader(CheckpointHeader.random({ slotNumber: SlotNumber(5) })),
+    ).resolves.toBeUndefined();
   });
 
   it('simulates request bundles at the last L1 timestamp within the target L2 slot', async () => {

--- a/yarn-project/sequencer-client/src/publisher/sequencer-publisher.ts
+++ b/yarn-project/sequencer-client/src/publisher/sequencer-publisher.ts
@@ -45,7 +45,11 @@ import { EmpireBaseAbi, ErrorsAbi, RollupAbi, SlashingProposerAbi } from '@aztec
 import { type ProposerSlashAction, encodeSlashConsensusVotes } from '@aztec/slasher';
 import { CommitteeAttestationsAndSigners, type ValidateCheckpointResult } from '@aztec/stdlib/block';
 import type { Checkpoint } from '@aztec/stdlib/checkpoint';
-import { getNextL1SlotTimestamp, getTimestampForSlot } from '@aztec/stdlib/epoch-helpers';
+import {
+  getLastL1SlotTimestampForL2Slot,
+  getNextL1SlotTimestamp,
+  getTimestampForSlot,
+} from '@aztec/stdlib/epoch-helpers';
 import type { CheckpointHeader } from '@aztec/stdlib/rollup';
 import type { L1PublishCheckpointStats } from '@aztec/stdlib/stats';
 import { type TelemetryClient, type Tracer, getTelemetryClient, trackSpan } from '@aztec/telemetry-client';
@@ -727,7 +731,7 @@ export class SequencerPublisher {
     ] as const;
 
     const l1Constants = this.epochCache.getL1Constants();
-    const ts = getTimestampForSlot(header.slotNumber, l1Constants);
+    const ts = getLastL1SlotTimestampForL2Slot(header.slotNumber, l1Constants);
     const stateOverrides = await buildSimulationOverridesStateOverride(this.rollupContract, simulationOverridesPlan);
     let balance = 0n;
     if (this.config.fishermanMode) {


### PR DESCRIPTION
## Summary
- Use the last L1 slot timestamp inside the target L2 slot for proposal/header simulations.
- Keep bundle simulation and pre-broadcast header validation on the same timestamp rule to avoid `eth_simulateV1` timestamp-order failures.
- Add regression coverage for both simulation paths.