### PR TITLE
fix: disable apt periodic upgrades on CI hosts

### DIFF
--- a/ci3/bootstrap_ec2
+++ b/ci3/bootstrap_ec2
@@ -244,6 +244,11 @@ host_script=$(
   cat <<EOF
 set -euo pipefail
 
+# This runtime guard should be baked into the build image. Unattended upgrades
+# can restart SSM while CI is running, leaving SSM commands stuck InProgress.
+echo "HOST: disabling apt periodic upgrades..."
+sudo systemctl mask --now apt-daily.timer apt-daily-upgrade.timer apt-daily.service apt-daily-upgrade.service unattended-upgrades.service &>/dev/null || true
+
 sudo sysctl fs.inotify.max_user_watches=1048576 &>/dev/null
 sudo sysctl fs.inotify.max_user_instances=1048576 &>/dev/null
 


### PR DESCRIPTION
## Summary
- disable apt periodic upgrade timers/services at the CI host script entry point
- leave a runtime comment noting this should be baked into the build image

## Why
We saw an SSM-mode CI host where the build completed successfully, but the EC2 instance did not terminate through the normal cleanup path. The host logs showed `/usr/bin/unattended-upgrade` running during the CI job and restarting `amazon-ssm-agent` while the SSM `AWS-RunShellScript` command was still active. After that restart, the command state on the host was under SSM's `document/state/corrupt` path and AWS continued to report the command as `InProgress` with response code `-1`.

That matters because `bootstrap_ec2` waits for `ssm_send_command` to finish; once it exits, the local cleanup trap terminates the instance. If SSM never reports a terminal status, the normal cleanup path is skipped and the instance is left to the fallback shutdown timer/reaper.

This is a runtime guard so new CI hosts stop apt's periodic upgrade machinery before starting the build. The same setting should be baked into the build image so the host never starts with these timers enabled.

## Testing
- `bash -n ci3/bootstrap_ec2`
