### PR TITLE
chore(bb-prover): wire BB_DEBUG_OUTPUT_DIR through AvmProvingTester

### DIFF
--- a/yarn-project/bb-prover/src/avm_proving_tests/avm_proving_tester.ts
+++ b/yarn-project/bb-prover/src/avm_proving_tests/avm_proving_tester.ts
@@ -1,4 +1,5 @@
 import type { AvmStat } from '@aztec/bb.js';
+import { createLogger } from '@aztec/foundation/log';
 import { Timer } from '@aztec/foundation/timer';
 import {
   PublicTxSimulationTester,
@@ -32,7 +33,10 @@ const provingConfig: PublicSimulatorConfig = PublicSimulatorConfig.from({
 });
 
 export class AvmProvingTester extends PublicTxSimulationTester {
-  private readonly bbJsFactory = new BBJsFactory(BB_PATH);
+  private readonly bbJsFactory = new BBJsFactory(BB_PATH, {
+    debugDir: process.env.BB_DEBUG_OUTPUT_DIR,
+    logger: createLogger('bb-prover:avm-proving-tester'),
+  });
 
   constructor(
     private checkCircuitOnly: boolean,


### PR DESCRIPTION
Pass debugDir and a logger to BBJsFactory so that running the AVM proving tests with BB_DEBUG_OUTPUT_DIR set actually dumps avm_inputs.bin and the equivalent bb-avm CLI command to disk (via DebugBBJsInstance). Without this the env var was silently ignored by these tests.