### PR TITLE
feat(standard-contracts): show expected-vs-actual diff in drift error

### DIFF
--- a/yarn-project/standard-contracts/src/drift.ts
+++ b/yarn-project/standard-contracts/src/drift.ts
@@ -184,18 +184,103 @@ export async function readIfExists(filePath: string): Promise<string | null> {
   }
 }
 
+/** Result of a {@link writeIfChanged} call: whether the file changed, and its prior bytes. */
+export type WriteResult = { changed: boolean; previous: string | null };
+
 /**
  * Compares `content` against the bytes currently at `filePath`. If they differ (including the file
- * not existing), writes the new content and returns `true`. If they match, leaves the file
- * untouched and returns `false`. Skipping the write when the content is identical avoids mtime
- * churn that would otherwise re-trigger downstream build steps on every generator run.
+ * not existing), writes the new content and returns `{ changed: true }`. If they match, leaves the
+ * file untouched and returns `{ changed: false }`. Skipping the write when the content is identical
+ * avoids mtime churn that would otherwise re-trigger downstream build steps on every generator run.
+ *
+ * The file's prior content is returned as `previous` (`null` if it didn't exist) so callers can
+ * render a diff of what changed without re-reading the now-overwritten file.
  */
-export async function writeIfChanged(filePath: string, content: string): Promise<boolean> {
+export async function writeIfChanged(filePath: string, content: string): Promise<WriteResult> {
   const existing = await readIfExists(filePath);
   if (existing === content) {
-    return false;
+    return { changed: false, previous: existing };
   }
   await fs.mkdir(path.dirname(filePath), { recursive: true });
   await fs.writeFile(filePath, content);
-  return true;
+  return { changed: true, previous: existing };
+}
+
+/**
+ * Line-level longest-common-subsequence diff. Returns one tagged entry per line: `' '` for an
+ * unchanged line, `'-'` for a line only in `a`, `'+'` for a line only in `b`. The generated files
+ * are small (tens of lines), so the O(n*m) table is not a concern.
+ */
+function lcsLineDiff(a: string[], b: string[]): { tag: ' ' | '-' | '+'; line: string }[] {
+  const n = a.length;
+  const m = b.length;
+  const dp: number[][] = Array.from({ length: n + 1 }, () => new Array<number>(m + 1).fill(0));
+  for (let i = n - 1; i >= 0; i--) {
+    for (let j = m - 1; j >= 0; j--) {
+      dp[i][j] = a[i] === b[j] ? dp[i + 1][j + 1] + 1 : Math.max(dp[i + 1][j], dp[i][j + 1]);
+    }
+  }
+  const out: { tag: ' ' | '-' | '+'; line: string }[] = [];
+  let i = 0;
+  let j = 0;
+  while (i < n && j < m) {
+    if (a[i] === b[j]) {
+      out.push({ tag: ' ', line: a[i++] });
+      j++;
+    } else if (dp[i + 1][j] >= dp[i][j + 1]) {
+      out.push({ tag: '-', line: a[i++] });
+    } else {
+      out.push({ tag: '+', line: b[j++] });
+    }
+  }
+  while (i < n) {
+    out.push({ tag: '-', line: a[i++] });
+  }
+  while (j < m) {
+    out.push({ tag: '+', line: b[j++] });
+  }
+  return out;
+}
+
+/**
+ * Renders a compact unified-style diff between the file currently on disk (`actual` — the committed
+ * bytes) and the freshly-derived bytes (`expected`). Runs of unchanged lines beyond `context` are
+ * collapsed to a `...` marker so only the changed addresses/hashes (and a little surrounding
+ * context) are shown. Surfaced in the generator's drift error so a developer — or anyone reading a
+ * CI log — can read the new values straight off the `+` lines without rebuilding locally.
+ */
+export function renderDriftDiff(filePath: string, actual: string | null, expected: string, context = 3): string {
+  // Drop the empty trailing segment that a terminal newline yields so the diff doesn't end on a
+  // meaningless blank context line; intentional blank lines mid-file are preserved.
+  const splitLines = (s: string) => {
+    const ls = s.split('\n');
+    if (ls.length > 0 && ls[ls.length - 1] === '') {
+      ls.pop();
+    }
+    return ls;
+  };
+  const diff = lcsLineDiff(splitLines(actual ?? ''), splitLines(expected));
+  const visible = new Array<boolean>(diff.length).fill(false);
+  diff.forEach((entry, idx) => {
+    if (entry.tag !== ' ') {
+      const lo = Math.max(0, idx - context);
+      const hi = Math.min(diff.length - 1, idx + context);
+      for (let k = lo; k <= hi; k++) {
+        visible[k] = true;
+      }
+    }
+  });
+  const actualLabel = actual === null ? '(actual: file did not exist)' : '(actual / committed on disk)';
+  const lines = [`--- ${filePath}  ${actualLabel}`, `+++ ${filePath}  (expected / freshly derived)`];
+  let collapsed = false;
+  for (let idx = 0; idx < diff.length; idx++) {
+    if (visible[idx]) {
+      lines.push(`${diff[idx].tag} ${diff[idx].line}`);
+      collapsed = false;
+    } else if (!collapsed) {
+      lines.push('  ...');
+      collapsed = true;
+    }
+  }
+  return lines.join('\n');
 }

--- a/yarn-project/standard-contracts/src/drift.ts
+++ b/yarn-project/standard-contracts/src/drift.ts
@@ -184,103 +184,18 @@ export async function readIfExists(filePath: string): Promise<string | null> {
   }
 }
 
-/** Result of a {@link writeIfChanged} call: whether the file changed, and its prior bytes. */
-export type WriteResult = { changed: boolean; previous: string | null };
-
 /**
  * Compares `content` against the bytes currently at `filePath`. If they differ (including the file
- * not existing), writes the new content and returns `{ changed: true }`. If they match, leaves the
- * file untouched and returns `{ changed: false }`. Skipping the write when the content is identical
- * avoids mtime churn that would otherwise re-trigger downstream build steps on every generator run.
- *
- * The file's prior content is returned as `previous` (`null` if it didn't exist) so callers can
- * render a diff of what changed without re-reading the now-overwritten file.
+ * not existing), writes the new content and returns `true`. If they match, leaves the file
+ * untouched and returns `false`. Skipping the write when the content is identical avoids mtime
+ * churn that would otherwise re-trigger downstream build steps on every generator run.
  */
-export async function writeIfChanged(filePath: string, content: string): Promise<WriteResult> {
+export async function writeIfChanged(filePath: string, content: string): Promise<boolean> {
   const existing = await readIfExists(filePath);
   if (existing === content) {
-    return { changed: false, previous: existing };
+    return false;
   }
   await fs.mkdir(path.dirname(filePath), { recursive: true });
   await fs.writeFile(filePath, content);
-  return { changed: true, previous: existing };
-}
-
-/**
- * Line-level longest-common-subsequence diff. Returns one tagged entry per line: `' '` for an
- * unchanged line, `'-'` for a line only in `a`, `'+'` for a line only in `b`. The generated files
- * are small (tens of lines), so the O(n*m) table is not a concern.
- */
-function lcsLineDiff(a: string[], b: string[]): { tag: ' ' | '-' | '+'; line: string }[] {
-  const n = a.length;
-  const m = b.length;
-  const dp: number[][] = Array.from({ length: n + 1 }, () => new Array<number>(m + 1).fill(0));
-  for (let i = n - 1; i >= 0; i--) {
-    for (let j = m - 1; j >= 0; j--) {
-      dp[i][j] = a[i] === b[j] ? dp[i + 1][j + 1] + 1 : Math.max(dp[i + 1][j], dp[i][j + 1]);
-    }
-  }
-  const out: { tag: ' ' | '-' | '+'; line: string }[] = [];
-  let i = 0;
-  let j = 0;
-  while (i < n && j < m) {
-    if (a[i] === b[j]) {
-      out.push({ tag: ' ', line: a[i++] });
-      j++;
-    } else if (dp[i + 1][j] >= dp[i][j + 1]) {
-      out.push({ tag: '-', line: a[i++] });
-    } else {
-      out.push({ tag: '+', line: b[j++] });
-    }
-  }
-  while (i < n) {
-    out.push({ tag: '-', line: a[i++] });
-  }
-  while (j < m) {
-    out.push({ tag: '+', line: b[j++] });
-  }
-  return out;
-}
-
-/**
- * Renders a compact unified-style diff between the file currently on disk (`actual` — the committed
- * bytes) and the freshly-derived bytes (`expected`). Runs of unchanged lines beyond `context` are
- * collapsed to a `...` marker so only the changed addresses/hashes (and a little surrounding
- * context) are shown. Surfaced in the generator's drift error so a developer — or anyone reading a
- * CI log — can read the new values straight off the `+` lines without rebuilding locally.
- */
-export function renderDriftDiff(filePath: string, actual: string | null, expected: string, context = 3): string {
-  // Drop the empty trailing segment that a terminal newline yields so the diff doesn't end on a
-  // meaningless blank context line; intentional blank lines mid-file are preserved.
-  const splitLines = (s: string) => {
-    const ls = s.split('\n');
-    if (ls.length > 0 && ls[ls.length - 1] === '') {
-      ls.pop();
-    }
-    return ls;
-  };
-  const diff = lcsLineDiff(splitLines(actual ?? ''), splitLines(expected));
-  const visible = new Array<boolean>(diff.length).fill(false);
-  diff.forEach((entry, idx) => {
-    if (entry.tag !== ' ') {
-      const lo = Math.max(0, idx - context);
-      const hi = Math.min(diff.length - 1, idx + context);
-      for (let k = lo; k <= hi; k++) {
-        visible[k] = true;
-      }
-    }
-  });
-  const actualLabel = actual === null ? '(actual: file did not exist)' : '(actual / committed on disk)';
-  const lines = [`--- ${filePath}  ${actualLabel}`, `+++ ${filePath}  (expected / freshly derived)`];
-  let collapsed = false;
-  for (let idx = 0; idx < diff.length; idx++) {
-    if (visible[idx]) {
-      lines.push(`${diff[idx].tag} ${diff[idx].line}`);
-      collapsed = false;
-    } else if (!collapsed) {
-      lines.push('  ...');
-      collapsed = true;
-    }
-  }
-  return lines.join('\n');
+  return true;
 }

--- a/yarn-project/standard-contracts/src/scripts/generate_data.ts
+++ b/yarn-project/standard-contracts/src/scripts/generate_data.ts
@@ -22,7 +22,7 @@ import {
   loadArtifact,
   standardContracts,
 } from '../contract_data.js';
-import { renderAllTargets, renderDriftDiff, writeIfChanged } from '../drift.js';
+import { renderAllTargets, writeIfChanged } from '../drift.js';
 
 const log = createConsoleLogger('autogenerate');
 
@@ -58,6 +58,79 @@ async function generateDeclarationFile(destName: string) {
   await fs.writeFile(path.join(STANDARD_ARTIFACTS_DEST_DIR, `${destName}.d.json.ts`), content);
 }
 
+/** The committed derived values for one contract, read back from the generated data module. */
+type CommittedValues = {
+  address: string;
+  classId: string;
+  artifactHash: string;
+  privateFunctionsRoot: string;
+  publicBytecodeCommitment: string;
+  initializationHash: string;
+  privateFunctionsCount: number;
+};
+
+/**
+ * Reads the currently-committed derived values out of the generated `standard_contract_data.ts`
+ * module so the drift report can show old → new. Returns `undefined` if the module doesn't exist
+ * yet (first-ever generation).
+ */
+async function loadCommittedValues(): Promise<Record<string, CommittedValues> | undefined> {
+  let mod: typeof import('../standard_contract_data.js');
+  try {
+    mod = await import('../standard_contract_data.js');
+  } catch {
+    return undefined;
+  }
+  const out: Record<string, CommittedValues> = {};
+  for (const name of Object.keys(mod.StandardContractAddress) as (keyof typeof mod.StandardContractAddress)[]) {
+    const preimage = mod.StandardContractClassIdPreimage[name];
+    out[name] = {
+      address: mod.StandardContractAddress[name].toString(),
+      classId: mod.StandardContractClassId[name].toString(),
+      artifactHash: preimage.artifactHash.toString(),
+      privateFunctionsRoot: preimage.privateFunctionsRoot.toString(),
+      publicBytecodeCommitment: preimage.publicBytecodeCommitment.toString(),
+      initializationHash: mod.StandardContractInitializationHash[name].toString(),
+      privateFunctionsCount: mod.StandardContractPrivateFunctions[name].length,
+    };
+  }
+  return out;
+}
+
+/**
+ * Lists which derived consts changed, comparing the freshly-derived values against the committed
+ * snapshot — one indented line per changed field.
+ */
+function describeChanges(
+  names: string[],
+  derived: ContractData[],
+  committed: Record<string, CommittedValues> | undefined,
+): string {
+  const lines: string[] = [];
+  names.forEach((name, i) => {
+    const d = derived[i];
+    const prev = committed?.[name];
+    if (!prev) {
+      lines.push(`  ${name}: newly added (no prior committed values)`);
+      return;
+    }
+    const cmp = (field: string, oldV: string, newV: string) => {
+      if (oldV !== newV) {
+        lines.push(`  ${name}.${field}: ${oldV} → ${newV}`);
+      }
+    };
+    cmp('address', prev.address, d.address.toString());
+    cmp('classId', prev.classId, d.classId.toString());
+    cmp('artifactHash', prev.artifactHash, d.artifactHash.toString());
+    cmp('privateFunctionsRoot', prev.privateFunctionsRoot, d.privateFunctionsRoot.toString());
+    cmp('publicBytecodeCommitment', prev.publicBytecodeCommitment, d.publicBytecodeCommitment.toString());
+    cmp('initializationHash', prev.initializationHash, d.initializationHash.toString());
+    cmp('privateFunctions count', String(prev.privateFunctionsCount), String(d.privateFunctions.length));
+  });
+  // Possible if only the generated-file formatting changed (e.g. a codegen tweak) with no value delta.
+  return lines.length > 0 ? lines.join('\n') : '  (no derived value changed — only generated-file formatting)';
+}
+
 async function main() {
   await clearDestDir();
 
@@ -69,21 +142,23 @@ async function main() {
     contractDataList.push(await computeContractData(artifact));
   }
 
+  // Snapshot the committed values before we overwrite the data file, so the drift report can show
+  // exactly which consts changed (old → new) rather than a raw text diff.
+  const committed = await loadCommittedValues();
+
   const targets = await renderAllTargets(names, contractDataList);
-  const driftedFiles: { path: string; diff: string }[] = [];
+  const driftedFiles: string[] = [];
   for (const { path: filePath, content } of targets) {
-    const { changed, previous } = await writeIfChanged(filePath, content);
-    if (changed) {
-      driftedFiles.push({ path: filePath, diff: renderDriftDiff(filePath, previous, content) });
+    if (await writeIfChanged(filePath, content)) {
+      driftedFiles.push(filePath);
     }
   }
 
   if (driftedFiles.length > 0) {
-    const list = driftedFiles.map(f => `  - ${f.path}`).join('\n');
-    const diffs = driftedFiles.map(f => f.diff).join('\n\n');
+    const list = driftedFiles.map(f => `  - ${f}`).join('\n');
     throw new Error(
       `Standard contract addresses have changed. The following generated files were out of date and have been rewritten in-place with the freshly-derived values:\n${list}\n\n` +
-        `What changed (− actual / committed, + expected / freshly derived):\n\n${diffs}\n\n` +
+        `Changed values (old → new):\n${describeChanges(names, contractDataList, committed)}\n\n` +
         `These are derived values — don't hand-edit them. Drift means an upstream change (a modified standard contract, its initialization parameters, or the bb/noir compiler) altered what they derive to.\n\n` +
         `Any noir-contract that imports the stale addresses (via aztec-nr or aztec_sublib) now has stale bytecode and must be rebuilt.\n\n` +
         `To recover, the simplest option is to re-run \`./bootstrap.sh\` from the repo root: the second pass picks up the now-correct values.\n\n` +

--- a/yarn-project/standard-contracts/src/scripts/generate_data.ts
+++ b/yarn-project/standard-contracts/src/scripts/generate_data.ts
@@ -84,6 +84,7 @@ async function main() {
     throw new Error(
       `Standard contract addresses have changed. The following generated files were out of date and have been rewritten in-place with the freshly-derived values:\n${list}\n\n` +
         `What changed (− actual / committed, + expected / freshly derived):\n\n${diffs}\n\n` +
+        `These are derived values — don't hand-edit them. Drift means an upstream change (a modified standard contract, its initialization parameters, or the bb/noir compiler) altered what they derive to.\n\n` +
         `Any noir-contract that imports the stale addresses (via aztec-nr or aztec_sublib) now has stale bytecode and must be rebuilt.\n\n` +
         `To recover, the simplest option is to re-run \`./bootstrap.sh\` from the repo root: the second pass picks up the now-correct values.\n\n` +
         `For a faster targeted recovery without rebuilding everything, run from the repo root:\n` +

--- a/yarn-project/standard-contracts/src/scripts/generate_data.ts
+++ b/yarn-project/standard-contracts/src/scripts/generate_data.ts
@@ -159,7 +159,6 @@ async function main() {
     throw new Error(
       `Standard contract addresses have changed. The following generated files were out of date and have been rewritten in-place with the freshly-derived values:\n${list}\n\n` +
         `Changed values (old → new):\n${describeChanges(names, contractDataList, committed)}\n\n` +
-        `These are derived values — don't hand-edit them. Drift means an upstream change (a modified standard contract, its initialization parameters, or the bb/noir compiler) altered what they derive to.\n\n` +
         `Any noir-contract that imports the stale addresses (via aztec-nr or aztec_sublib) now has stale bytecode and must be rebuilt.\n\n` +
         `To recover, the simplest option is to re-run \`./bootstrap.sh\` from the repo root: the second pass picks up the now-correct values.\n\n` +
         `For a faster targeted recovery without rebuilding everything, run from the repo root:\n` +

--- a/yarn-project/standard-contracts/src/scripts/generate_data.ts
+++ b/yarn-project/standard-contracts/src/scripts/generate_data.ts
@@ -22,7 +22,7 @@ import {
   loadArtifact,
   standardContracts,
 } from '../contract_data.js';
-import { renderAllTargets, writeIfChanged } from '../drift.js';
+import { renderAllTargets, renderDriftDiff, writeIfChanged } from '../drift.js';
 
 const log = createConsoleLogger('autogenerate');
 
@@ -70,17 +70,20 @@ async function main() {
   }
 
   const targets = await renderAllTargets(names, contractDataList);
-  const driftedFiles: string[] = [];
+  const driftedFiles: { path: string; diff: string }[] = [];
   for (const { path: filePath, content } of targets) {
-    if (await writeIfChanged(filePath, content)) {
-      driftedFiles.push(filePath);
+    const { changed, previous } = await writeIfChanged(filePath, content);
+    if (changed) {
+      driftedFiles.push({ path: filePath, diff: renderDriftDiff(filePath, previous, content) });
     }
   }
 
   if (driftedFiles.length > 0) {
-    const list = driftedFiles.map(f => `  - ${f}`).join('\n');
+    const list = driftedFiles.map(f => `  - ${f.path}`).join('\n');
+    const diffs = driftedFiles.map(f => f.diff).join('\n\n');
     throw new Error(
       `Standard contract addresses have changed. The following generated files were out of date and have been rewritten in-place with the freshly-derived values:\n${list}\n\n` +
+        `What changed (− actual / committed, + expected / freshly derived):\n\n${diffs}\n\n` +
         `Any noir-contract that imports the stale addresses (via aztec-nr or aztec_sublib) now has stale bytecode and must be rebuilt.\n\n` +
         `To recover, the simplest option is to re-run \`./bootstrap.sh\` from the repo root: the second pass picks up the now-correct values.\n\n` +
         `For a faster targeted recovery without rebuilding everything, run from the repo root:\n` +

--- a/yarn-project/standard-contracts/src/standard_contract_data.test.ts
+++ b/yarn-project/standard-contracts/src/standard_contract_data.test.ts
@@ -91,44 +91,31 @@ describe('standard_contract_data drift', () => {
     }
   });
 
-  describe('committed file content', () => {
-    // Render every target once and assert per-target so an individual stale file (e.g. only one of
-    // the two `standard_addresses.nr` twins drifted) shows up as its own failure rather than being
-    // hidden behind another.
-    let targets: { path: string; content: string }[];
+  // The per-field block above already covers every TS-side value, so we don't re-check the rendered
+  // `standard_contract_data.ts` here. The Noir `standard_addresses.nr` twins are not covered there
+  // (the per-field block reads only the TS exports), so verify those circuit-facing address files
+  // match what the generator would render right now.
+  it('committed standard_addresses.nr twins match re-rendered output', async () => {
+    if (!(await allArtifactsExist())) {
+      throw new Error(
+        `One or more standard-contract artifacts are missing under ${NOIR_ARTIFACTS_SRC_PATH}. ` +
+          `Run \`./bootstrap.sh\` from the repo root to build noir-contracts first.`,
+      );
+    }
 
-    beforeAll(async () => {
-      if (!(await allArtifactsExist())) {
-        throw new Error(
-          `One or more standard-contract artifacts are missing under ${NOIR_ARTIFACTS_SRC_PATH}. ` +
-            `Run \`./bootstrap.sh\` from the repo root to build noir-contracts first.`,
-        );
-      }
+    const names = standardContracts.map(c => c.name);
+    const contractDataList: ContractData[] = [];
+    for (const { src } of standardContracts) {
+      contractDataList.push(await computeContractData(await loadArtifact(src)));
+    }
+    const targets = await renderAllTargets(names, contractDataList);
 
-      const names = standardContracts.map(c => c.name);
-      const contractDataList: ContractData[] = [];
-      for (const { src } of standardContracts) {
-        contractDataList.push(await computeContractData(await loadArtifact(src)));
-      }
-      targets = await renderAllTargets(names, contractDataList);
-    });
-
-    it('committed standard_contract_data.ts matches re-rendered output', async () => {
-      const tsTarget = targets.find(t => t.path.endsWith('standard_contract_data.ts'));
-      expect(tsTarget).toBeDefined();
-      const committed = await readIfExists(tsTarget!.path);
+    const noirTargets = targets.filter(t => t.path.endsWith('.nr'));
+    expect(noirTargets.length).toBeGreaterThan(0);
+    for (const target of noirTargets) {
+      const committed = await readIfExists(target.path);
       expect(committed).not.toBeNull();
-      expect(committed).toEqual(tsTarget!.content);
-    });
-
-    it('committed standard_addresses.nr twins match re-rendered output', async () => {
-      const noirTargets = targets.filter(t => t.path.endsWith('.nr'));
-      expect(noirTargets.length).toBeGreaterThan(0);
-      for (const target of noirTargets) {
-        const committed = await readIfExists(target.path);
-        expect(committed).not.toBeNull();
-        expect(committed).toEqual(target.content);
-      }
-    });
+      expect(committed).toEqual(target.content);
+    }
   });
 });

--- a/yarn-project/standard-contracts/src/standard_contract_data.test.ts
+++ b/yarn-project/standard-contracts/src/standard_contract_data.test.ts
@@ -45,7 +45,7 @@ async function allArtifactsExist(): Promise<boolean> {
 describe('standard_contract_data drift', () => {
   describe('per-field derivation', () => {
     for (const { name, src } of standardContracts) {
-      it(`${name}: derived address and class data match committed values`, async () => {
+      it(`${name}: all derived fields match committed values`, async () => {
         if (!(await artifactExists(src))) {
           throw new Error(
             `Artifact \`${src}.json\` not found under ${NOIR_ARTIFACTS_SRC_PATH}. ` +
@@ -53,36 +53,40 @@ describe('standard_contract_data drift', () => {
           );
         }
 
-        const artifact = await loadArtifact(src);
-        const derived = await computeContractData(artifact);
+        const derived = await computeContractData(await loadArtifact(src));
+        const preimage = StandardContractClassIdPreimage[name as keyof typeof StandardContractClassIdPreimage];
 
-        const committedAddress = StandardContractAddress[name as keyof typeof StandardContractAddress];
-        const committedClassId = StandardContractClassId[name as keyof typeof StandardContractClassId];
-        const committedClassIdPreimage =
-          StandardContractClassIdPreimage[name as keyof typeof StandardContractClassIdPreimage];
-        const committedInitializationHash =
-          StandardContractInitializationHash[name as keyof typeof StandardContractInitializationHash];
-        const committedPrivateFunctions =
-          StandardContractPrivateFunctions[name as keyof typeof StandardContractPrivateFunctions];
+        // Assemble every derived field and its committed counterpart into matching objects so a
+        // single `toEqual` reports all differing fields at once as a standard expected/received diff.
+        const derivedValues = {
+          address: derived.address.toString(),
+          classId: derived.classId.toString(),
+          artifactHash: derived.artifactHash.toString(),
+          privateFunctionsRoot: derived.privateFunctionsRoot.toString(),
+          publicBytecodeCommitment: derived.publicBytecodeCommitment.toString(),
+          initializationHash: derived.initializationHash.toString(),
+          privateFunctions: derived.privateFunctions.map(fn => ({
+            selector: fn.selector.toField().toString(),
+            vkHash: fn.vkHash.toString(),
+          })),
+        };
+        const committedValues = {
+          address: StandardContractAddress[name as keyof typeof StandardContractAddress].toString(),
+          classId: StandardContractClassId[name as keyof typeof StandardContractClassId].toString(),
+          artifactHash: preimage.artifactHash.toString(),
+          privateFunctionsRoot: preimage.privateFunctionsRoot.toString(),
+          publicBytecodeCommitment: preimage.publicBytecodeCommitment.toString(),
+          initializationHash:
+            StandardContractInitializationHash[name as keyof typeof StandardContractInitializationHash].toString(),
+          privateFunctions: StandardContractPrivateFunctions[name as keyof typeof StandardContractPrivateFunctions].map(
+            fn => ({
+              selector: fn.selector.toField().toString(),
+              vkHash: fn.vkHash.toString(),
+            }),
+          ),
+        };
 
-        expect(derived.address.toString()).toEqual(committedAddress.toString());
-        expect(derived.classId.toString()).toEqual(committedClassId.toString());
-        expect(derived.artifactHash.toString()).toEqual(committedClassIdPreimage.artifactHash.toString());
-        expect(derived.privateFunctionsRoot.toString()).toEqual(
-          committedClassIdPreimage.privateFunctionsRoot.toString(),
-        );
-        expect(derived.publicBytecodeCommitment.toString()).toEqual(
-          committedClassIdPreimage.publicBytecodeCommitment.toString(),
-        );
-        expect(derived.initializationHash.toString()).toEqual(committedInitializationHash.toString());
-
-        expect(derived.privateFunctions.length).toEqual(committedPrivateFunctions.length);
-        for (let i = 0; i < derived.privateFunctions.length; i++) {
-          expect(derived.privateFunctions[i].selector.toField().toString()).toEqual(
-            committedPrivateFunctions[i].selector.toField().toString(),
-          );
-          expect(derived.privateFunctions[i].vkHash.toString()).toEqual(committedPrivateFunctions[i].vkHash.toString());
-        }
+        expect(derivedValues).toEqual(committedValues);
       });
     }
   });


### PR DESCRIPTION
When a standard contract's derived address/class data drifts, the build now reports exactly which consts changed (old → new), so you can read the new values without rebuilding locally.

### Build-time generator error (`generate_data.ts`)
```
Standard contract addresses have changed. The following generated files were out of date and have been rewritten in-place with the freshly-derived values:
  - ./src/standard_contract_data.ts
  - ../../noir-projects/aztec-nr/aztec/src/standard_addresses.nr
  - ../../noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/standard_addresses.nr

Changed values (old → new):
  PublicChecks.address: 0x05d900a6ed1b4ad3ff52cbe5f98d9b291b0f35c6dd5c41b1642659344d234bfe → 0x157adf2a48199ba8f417358aa8d728c00ceb83923425694d7c738291b4fc8902
  PublicChecks.classId: 0x022bbd3c085d6a09ec500110852441419c7b1e6dc21a8d459233b72a84d03a1f → 0x11a1123d541845258225c31b116f5d0ebb2d83a020ac173096ea7eb2ece483e9
  PublicChecks.publicBytecodeCommitment: 0x013c4f854a5c87c9daf86c5f9bc07a42c2a061f1d924a5b3564ec7edc8e18cb7 → 0x185edf0f22857537a30a03eeb76f56b2c5b1cd49495294391d74f88ac6528e6b

  ...stale-bytecode note + recovery steps...
```

### Backup jest test
One `expect().toEqual()` per contract (every field, every contract surfaces — not just the first), plus a `.nr` twins check.
```
● standard_contract_data drift › per-field derivation › AuthRegistry: all derived fields match committed values
    - Expected  - 1
    + Received  + 1
      Object {
    -   "address": "0x01de9d215d1845808cf388d3a88f9066af1e73ec280e979c3b1aec8ba6b149ea",
    +   "address": "0x1ad6c58d49414977725dbde2f5052708ca67548730d98adee2d3833c91348a24",
        "artifactHash": "0x0dd24a86cce5ff4ef33ca14f16359c5a154ce3f1ed91a9570dd5343569f5386f",
        "classId": "0x2cfbdd0ce7cc31b5cc5f4eb8f680e0e245882b2208bd67828e41a8bd24a19292",
        ...
      }

● standard_contract_data drift › committed standard_addresses.nr twins match re-rendered output
    - Expected  - 2
    + Received  + 2
      pub global STANDARD_AUTH_REGISTRY_ADDRESS: AztecAddress = AztecAddress::from_field(
    -     0x1ad6c58d49414977725dbde2f5052708ca67548730d98adee2d3833c91348a24,
    +     0x01de9d215d1845808cf388d3a88f9066af1e73ec280e979c3b1aec8ba6b149ea,
      );
```