### PR TITLE
fix: bb format.sh re-staging inside worktrees

### DIFF
--- a/barretenberg/cpp/format.sh
+++ b/barretenberg/cpp/format.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+
+# we have to unset this env var set by git hooks so that the relative paths below work correctly when used inside worktrees
+unset GIT_DIR
+
 function format_files {
   if [ -n "$1" ]; then
     echo "$1" | parallel -j+0 'clang-format-20 -i {} && sed -i.bak "s/\r$//" {} && rm {}.bak'


### PR DESCRIPTION
## Problem

`.git/hooks/pre-commit` runs `barretenberg/cpp/format.sh staged`, which lists staged C++ files with `git diff-index --relative --cached` and re-`git add`s them after clang-format. Git sets `GIT_DIR` to an absolute path when invoking hooks; inside a worktree that makes `--relative` resolve against the wrong root, so the re-add runs `git add` on a path that is in the index but does not exist at the expected location — which stages a *deletion*. Committing inside a worktree therefore silently drops staged `.cpp`/`.hpp` files from the tree. Hit in practice when a merge that touched 34 barretenberg C++ files committed them away.

## Fix

`unset GIT_DIR` near the top of `format.sh`, so the relative paths resolve against the worktree root. Same bug and one-liner fix as #22557 (`yarn-project/precommit.sh`) and #23628 (`noir-projects/precommit.sh`); `format.sh` is the last pre-commit hook script that still had it.