### PR TITLE
feat(stdlib): make empty ChonkProof hold an empty array

### DIFF
--- a/yarn-project/stdlib/src/proofs/chonk_proof.test.ts
+++ b/yarn-project/stdlib/src/proofs/chonk_proof.test.ts
@@ -10,9 +10,20 @@ describe('ChonkProof', () => {
     expect(() => new ChonkProof(fields)).toThrow(`Invalid ChonkProof length: ${CHONK_PROOF_LENGTH + 1}`);
   });
 
+  it('empty proof holds an empty fields array', () => {
+    const proof = ChonkProof.empty();
+    expect(proof.fields).toEqual([]);
+  });
+
   it('isEmpty should return true for empty proof', () => {
     const proof = ChonkProof.empty();
     expect(proof.isEmpty()).toBe(true);
+  });
+
+  it('serializes empty proof as a single zero length', () => {
+    const buffer = ChonkProof.empty().toBuffer();
+    expect(buffer).toEqual(numToUInt32BE(0));
+    expect(buffer.length).toBe(4);
   });
 
   it('should serialize and deserialize empty proof', () => {
@@ -99,6 +110,15 @@ describe('ChonkProofWithPublicInputs', () => {
   it('isEmpty should return true for empty proof', () => {
     const proof = ChonkProofWithPublicInputs.empty();
     expect(proof.isEmpty()).toBe(true);
+  });
+
+  it('empty proof round-trips with an empty fields array', () => {
+    const original = ChonkProofWithPublicInputs.empty();
+    expect(original.fieldsWithPublicInputs).toEqual([]);
+
+    const deserialized = ChonkProofWithPublicInputs.fromBuffer(original.toBuffer());
+    expect(deserialized.fieldsWithPublicInputs).toEqual([]);
+    expect(deserialized.isEmpty()).toBe(true);
   });
 
   it('should serialize and deserialize proof with public inputs', () => {

--- a/yarn-project/stdlib/src/proofs/chonk_proof.ts
+++ b/yarn-project/stdlib/src/proofs/chonk_proof.ts
@@ -7,13 +7,16 @@ import { bufferSchemaFor } from '@aztec/foundation/schemas';
 import { BufferReader, numToUInt32BE, serializeToBuffer } from '@aztec/foundation/serialize';
 
 /**
- * Serialization format detection for ChonkProof is size-based:
+ * Serialization format detection for ChonkProof is value-based on the leading uint32:
+ *   - EMPTY:                 [0: uint32]                              → total = 4 bytes
  *   - UNCOMPRESSED (legacy): [field_count=1632: uint32] [fields...]  → total ≈ 52KB (>= 40KB)
  *   - COMPRESSED:            [byte_count: uint32] [compressed_bytes] → total ≈ 35KB (< 40KB)
  *
- * Detection: if the first uint32 equals CHONK_PROOF_LENGTH (1632), it's legacy format
- * (field count). Otherwise, it's compressed format (byte count). The old uncompressed
- * format is never smaller than 40KB; compressed proofs are always smaller than 40KB.
+ * Detection from the first uint32: 0 means an empty proof (no fields); CHONK_PROOF_LENGTH
+ * (1632) means legacy format (field count); any other value is the compressed byte count.
+ * A real compressed proof always has a non-zero byte count, so 0 is an unambiguous sentinel
+ * for the empty case. The old uncompressed format is never smaller than 40KB; compressed
+ * proofs are always smaller than 40KB.
  */
 
 // CHONK: "Client Honk" - An UltraHonk variant with incremental folding and delayed non-native arithmetic.
@@ -32,7 +35,8 @@ export class ChonkProof {
     public fields: Fr[],
     compressedProof?: Buffer,
   ) {
-    if (fields.length !== CHONK_PROOF_LENGTH) {
+    // An empty proof (no fields) is a valid placeholder; see ChonkProof.empty().
+    if (fields.length !== 0 && fields.length !== CHONK_PROOF_LENGTH) {
       throw new Error(`Invalid ChonkProof length: ${fields.length}`);
     }
     this.compressedProof = compressedProof;
@@ -47,7 +51,7 @@ export class ChonkProof {
   }
 
   static empty() {
-    return new ChonkProof(new Array(CHONK_PROOF_LENGTH).fill(Fr.ZERO));
+    return new ChonkProof([]);
   }
 
   static random() {
@@ -77,7 +81,8 @@ export class ChonkProof {
    * Deserialize a ChonkProof from a buffer.
    * Supports both legacy (field elements) and compressed (chonk compression) formats.
    *
-   * Size-based format detection:
+   * Value-based format detection on the leading uint32:
+   *   - First uint32 == 0: empty proof (no fields), total = 4 bytes
    *   - First uint32 == CHONK_PROOF_LENGTH (1632): legacy format, read field elements
    *     Total proof data ≈ 52KB (always >= 40KB)
    *   - Otherwise: compressed format, first uint32 is byte count of compressed data
@@ -86,6 +91,11 @@ export class ChonkProof {
   static fromBuffer(buffer: Buffer | BufferReader): ChonkProof {
     const reader = BufferReader.asReader(buffer);
     const firstUint32 = reader.readNumber();
+
+    if (firstUint32 === 0) {
+      // Empty format: a zero length encodes an empty proof.
+      return ChonkProof.empty();
+    }
 
     if (firstUint32 === CHONK_PROOF_LENGTH) {
       // Legacy format: firstUint32 is the field count (1632)
@@ -138,6 +148,10 @@ export class ChonkProof {
       // Compressed format: [compressed_byte_count: uint32] [compressed_bytes]
       return Buffer.concat([numToUInt32BE(this.compressedProof.length), this.compressedProof]);
     }
+    if (this.fields.length === 0) {
+      // Empty format: a single zero length, no fields.
+      return numToUInt32BE(0);
+    }
     // Legacy format: [field_count=1632: uint32] [fields...]
     return serializeToBuffer(this.fields.length, this.fields);
   }
@@ -156,17 +170,24 @@ export class ChonkProofWithPublicInputs {
     // For recursive verification, use without public inputs via `removePublicInputs()`.
     public fieldsWithPublicInputs: Fr[],
   ) {
-    if (fieldsWithPublicInputs.length < CHONK_PROOF_LENGTH) {
+    // An empty proof (no fields) is a valid placeholder; see ChonkProofWithPublicInputs.empty().
+    if (fieldsWithPublicInputs.length !== 0 && fieldsWithPublicInputs.length < CHONK_PROOF_LENGTH) {
       throw new Error(`Invalid ChonkProofWithPublicInputs length: ${fieldsWithPublicInputs.length}`);
     }
   }
 
   public getPublicInputs() {
+    if (this.fieldsWithPublicInputs.length === 0) {
+      return [];
+    }
     const numPublicInputs = this.fieldsWithPublicInputs.length - CHONK_PROOF_LENGTH;
     return this.fieldsWithPublicInputs.slice(0, numPublicInputs);
   }
 
   public removePublicInputs() {
+    if (this.fieldsWithPublicInputs.length === 0) {
+      return new ChonkProof([], this.compressedProof);
+    }
     const numPublicInputs = this.fieldsWithPublicInputs.length - CHONK_PROOF_LENGTH;
     // Flow compressed proof bytes through so the ChonkProof can serialize efficiently
     return new ChonkProof(this.fieldsWithPublicInputs.slice(numPublicInputs), this.compressedProof);


### PR DESCRIPTION
## Motivation

`ChonkProof.empty()` returned an array of `CHONK_PROOF_LENGTH` (1632) `Fr.ZERO` fields, which serializes to ~52KB. Empty proofs are only ever placeholders (simulated txs, the fuzzer, the txe, p2p testbench, and proof-stripping for tx archival), so carrying 1632 zeros around — and persisting them to the archive — is pure waste. The goal is for an empty proof to actually be empty.

## Approach

`empty()` now holds an empty `Fr[]`, and serialization gains a third format: a leading `uint32` of `0` encodes an empty proof. On read, `0` is recognized as the empty case, `CHONK_PROOF_LENGTH` (1632) stays the legacy field-count format, and any other value remains the compressed byte count. A real compressed proof always has a non-zero byte count, so `0` is an unambiguous sentinel. The constructors accept length `0`, and the public-input helpers guard the empty case so the `length - 1632` math can't go negative.

## Changes

- **stdlib (proofs)**: `ChonkProof`/`ChonkProofWithPublicInputs` `empty()` hold `[]`; constructors allow length `0`; `toBuffer`/`fromBuffer` handle the zero-length format; `getPublicInputs`/`removePublicInputs` guard empty. Empty proofs now round-trip in 4 bytes instead of ~52KB.
- **stdlib (tests)**: Added assertions that empty proofs hold `[]`, serialize to a single zero length, and round-trip for both classes.

All proving/verification paths (rollup `RecursiveProof` construction, the bb verifiers, PXE `removePublicInputs`) only ever receive real proofs from bb with the full field count, so they are unaffected; the only path empty proofs traverse is serialization round-trips (tx archive, tx clone, JSON-RPC).