### PR TITLE
fix(sequencer): atomically query current and target slots

### DIFF
--- a/yarn-project/sequencer-client/src/client/sequencer-client.ts
+++ b/yarn-project/sequencer-client/src/client/sequencer-client.ts
@@ -145,7 +145,13 @@ export class SequencerClient {
 
     const { maxL2BlockGas, maxDABlockGas, maxTxsPerBlock } = capPerBlockLimits(config, rollupManaLimit, log);
 
-    const l1Constants = { l1GenesisTime, slotDuration: Number(slotDuration), ethereumSlotDuration, rollupManaLimit };
+    const l1Constants = {
+      l1GenesisTime,
+      slotDuration: Number(slotDuration),
+      ethereumSlotDuration,
+      rollupManaLimit,
+      epochDuration: config.aztecEpochDuration,
+    };
 
     const sequencer = new Sequencer(
       publisherFactory,

--- a/yarn-project/sequencer-client/src/sequencer/checkpoint_voter.ha.integration.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/checkpoint_voter.ha.integration.test.ts
@@ -62,6 +62,7 @@ describe('CheckpointVoter HA Integration', () => {
     l1GenesisTime: 1n,
     slotDuration: 24,
     ethereumSlotDuration: DefaultL1ContractsConfig.ethereumSlotDuration,
+    epochDuration: DefaultL1ContractsConfig.aztecEpochDuration,
     rollupManaLimit: Number.MAX_SAFE_INTEGER,
   };
 

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.test.ts
@@ -84,13 +84,14 @@ describe('sequencer', () => {
   let globalVariables: GlobalVariables;
   let l1Constants: Pick<
     L1RollupConstants,
-    'l1GenesisTime' | 'slotDuration' | 'ethereumSlotDuration' | 'rollupManaLimit'
+    'l1GenesisTime' | 'slotDuration' | 'ethereumSlotDuration' | 'rollupManaLimit' | 'epochDuration'
   >;
 
   let sequencer: TestSequencer;
 
   const slotDuration = 8;
   const ethereumSlotDuration = 4;
+  const epochDuration = 16;
 
   const chainId = new Fr(12345);
   const version = Fr.ZERO;
@@ -187,7 +188,13 @@ describe('sequencer', () => {
     );
 
     const l1GenesisTime = BigInt(Math.floor(Date.now() / 1000));
-    l1Constants = { l1GenesisTime, slotDuration, ethereumSlotDuration, rollupManaLimit: Number.MAX_SAFE_INTEGER };
+    l1Constants = {
+      l1GenesisTime,
+      slotDuration,
+      ethereumSlotDuration,
+      epochDuration,
+      rollupManaLimit: Number.MAX_SAFE_INTEGER,
+    };
 
     epochCache = mockDeep<EpochCache>();
     epochCache.isEscapeHatchOpen.mockResolvedValue(false);
@@ -1061,6 +1068,34 @@ describe('sequencer', () => {
       sequencer.skipExecute = false;
     });
 
+    it('derives the pipelined target slot from the same next-L1-slot snapshot', async () => {
+      await setupSingleTxBlock();
+
+      epochCache.getEpochAndSlotInNextL1Slot.mockReturnValue({
+        epoch: EpochNumber(1),
+        slot: SlotNumber(6),
+        ts: 1780066804n,
+        nowSeconds: 1780066811n,
+      });
+      epochCache.getTargetEpochAndSlotInNextL1Slot.mockReturnValue({
+        epoch: EpochNumber(1),
+        slot: SlotNumber(8),
+        ts: 1780066816n,
+        nowSeconds: 1780066812n,
+      });
+      publisher.canProposeAt.mockResolvedValue({
+        slot: SlotNumber(7),
+        checkpointNumber: CheckpointNumber.fromBlockNumber(newBlockNumber),
+        timeOfNextL1Slot: 1780066816n,
+      });
+
+      await sequencer.work();
+
+      expect(epochCache.getTargetEpochAndSlotInNextL1Slot).not.toHaveBeenCalled();
+      expect(epochCache.getProposerAttesterAddressInSlot).toHaveBeenCalledWith(SlotNumber(7));
+      expect(p2p.prepareForSlot).toHaveBeenCalledWith(SlotNumber(7));
+    });
+
     it('skips L1 check when proposed checkpoint exists', async () => {
       await setupSingleTxBlock();
 
@@ -1466,8 +1501,7 @@ class TestSequencer extends Sequencer {
     this.setState(SequencerState.IDLE, undefined, { force: true });
     if (this.skipExecute) {
       this.setState(SequencerState.SYNCHRONIZING, undefined);
-      const { slot, ts, nowSeconds, epoch } = this.epochCache.getEpochAndSlotInNextL1Slot();
-      const { slot: targetSlot, epoch: targetEpoch } = this.epochCache.getTargetEpochAndSlotInNextL1Slot();
+      const { slot, targetSlot, epoch, targetEpoch, ts, nowSeconds } = this.getSlotContextInNextL1Slot();
       await this.prepareCheckpointProposal(slot, targetSlot, epoch, targetEpoch, ts, nowSeconds);
       return;
     }

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.ts
@@ -1,5 +1,5 @@
 import { getKzg } from '@aztec/blob-lib';
-import type { EpochCache } from '@aztec/epoch-cache';
+import { type EpochCache, PROPOSER_PIPELINING_SLOT_OFFSET } from '@aztec/epoch-cache';
 import { NoCommitteeError, type RollupContract } from '@aztec/ethereum/contracts';
 import { BlockNumber, CheckpointNumber, EpochNumber, SlotNumber } from '@aztec/foundation/branded-types';
 import { merge, omit, pick } from '@aztec/foundation/collection';
@@ -14,7 +14,7 @@ import type { SlasherClientInterface } from '@aztec/slasher';
 import type { BlockData, L2BlockSink, L2BlockSource, ValidateCheckpointResult } from '@aztec/stdlib/block';
 import type { Checkpoint, ProposedCheckpointData } from '@aztec/stdlib/checkpoint';
 import type { ChainConfig } from '@aztec/stdlib/config';
-import { getSlotStartBuildTimestamp } from '@aztec/stdlib/epoch-helpers';
+import { getEpochAtSlot, getSlotStartBuildTimestamp } from '@aztec/stdlib/epoch-helpers';
 import {
   type ResolvedSequencerConfig,
   type SequencerConfig,
@@ -45,6 +45,16 @@ import type { SequencerRollupConstants } from './types.js';
 import { SequencerState } from './utils.js';
 
 export { SequencerState };
+
+/** Slot snapshot used to prepare a checkpoint proposal. */
+type SequencerSlotContext = {
+  slot: SlotNumber;
+  targetSlot: SlotNumber;
+  epoch: EpochNumber;
+  targetEpoch: EpochNumber;
+  ts: bigint;
+  nowSeconds: bigint;
+};
 
 /**
  * Sequencer client
@@ -214,8 +224,7 @@ export class Sequencer extends (EventEmitter as new () => TypedEventEmitter<Sequ
   @trackSpan('Sequencer.work')
   protected async work() {
     this.setState(SequencerState.SYNCHRONIZING, undefined);
-    const { slot, ts, nowSeconds, epoch } = this.epochCache.getEpochAndSlotInNextL1Slot();
-    const { slot: targetSlot, epoch: targetEpoch } = this.epochCache.getTargetEpochAndSlotInNextL1Slot();
+    const { slot, targetSlot, epoch, targetEpoch, ts, nowSeconds } = this.getSlotContextInNextL1Slot();
 
     // Check if we are synced and it's our slot, grab a publisher, check previous block invalidation, etc
     const checkpointProposalJob = await this.prepareCheckpointProposal(
@@ -251,6 +260,15 @@ export class Sequencer extends (EventEmitter as new () => TypedEventEmitter<Sequ
     }
 
     return checkpoint;
+  }
+
+  /** Returns slot and target slot from a single clock snapshot. */
+  protected getSlotContextInNextL1Slot(): SequencerSlotContext {
+    const { slot, ts, nowSeconds, epoch } = this.epochCache.getEpochAndSlotInNextL1Slot();
+    const targetSlot = SlotNumber(
+      slot + (this.epochCache.isProposerPipeliningEnabled() ? PROPOSER_PIPELINING_SLOT_OFFSET : 0),
+    );
+    return { slot, targetSlot, epoch, targetEpoch: getEpochAtSlot(targetSlot, this.l1Constants), ts, nowSeconds };
   }
 
   /**

--- a/yarn-project/sequencer-client/src/sequencer/types.ts
+++ b/yarn-project/sequencer-client/src/sequencer/types.ts
@@ -2,5 +2,5 @@ import type { L1RollupConstants } from '@aztec/stdlib/epoch-helpers';
 
 export type SequencerRollupConstants = Pick<
   L1RollupConstants,
-  'ethereumSlotDuration' | 'l1GenesisTime' | 'slotDuration' | 'rollupManaLimit'
+  'ethereumSlotDuration' | 'l1GenesisTime' | 'slotDuration' | 'rollupManaLimit' | 'epochDuration'
 >;


### PR DESCRIPTION
We were hitting flakes caused by a checkpoint proposal job building for slot N+2 during slot N. Example from [this failed run](http://ci.aztec-labs.com/02e1d4a8c9c9d0c9):

```
  417:15:00:04 [15:00:04.669] INFO sequencer node-0
  Preparing checkpoint proposal 7 for target slot 8 during wall-clock slot 6
  {
    "nowSeconds":"1780066811",
    "syncedToL2Slot":6,
    "slot":6,
    "targetSlot":8,
    "slotTs":"1780066804",
    "checkpointNumber":7,
    "hasProposedCheckpoint":true,
    "proposedCheckpointNumber":6,
    "checkpointedCheckpointNumber":5,
    "pipeliningEnabled":true
  }
```

This could be explained by the two non-atomic calls for getting the current and target slot in the sequencer, which could return N and N+2 if they happened at a slot boundary. This PR changes it so we issue a single call and just derive the target slot from the current one based on pipelining offset.