### PR TITLE
test(e2e): l2-to-l1 mbps and anchor to checkpointed chain

### DIFF
--- a/yarn-project/end-to-end/src/e2e_cross_chain_messaging/l2_to_l1.test.ts
+++ b/yarn-project/end-to-end/src/e2e_cross_chain_messaging/l2_to_l1.test.ts
@@ -13,7 +13,7 @@ import {
   computeL2ToL1MembershipWitness,
   getL2ToL1MessageLeafId,
 } from '@aztec/stdlib/messaging';
-import type { TxHash } from '@aztec/stdlib/tx';
+import { type TxHash, TxStatus } from '@aztec/stdlib/tx';
 
 import { jest } from '@jest/globals';
 import { type Hex, decodeEventLog } from 'viem';
@@ -67,7 +67,7 @@ describe('e2e_cross_chain_messaging l2_to_l1', () => {
   let contract: TestContract;
 
   beforeAll(async () => {
-    await t.setup({ ...PIPELINING_SETUP_OPTS });
+    await t.setup({ ...PIPELINING_SETUP_OPTS }, { syncChainTip: 'checkpointed' });
 
     ({ crossChainTestHarness, aztecNode, aztecNodeAdmin, wallet, user1Address, rollup, outbox } = t);
 
@@ -75,7 +75,10 @@ describe('e2e_cross_chain_messaging l2_to_l1', () => {
 
     version = BigInt(await rollup.getVersion());
 
-    ({ contract } = await TestContract.deploy(wallet).send({ from: user1Address }));
+    ({ contract } = await TestContract.deploy(wallet).send({
+      from: user1Address,
+      wait: { waitForStatus: TxStatus.CHECKPOINTED },
+    }));
   });
 
   afterAll(async () => {
@@ -250,7 +253,64 @@ describe('e2e_cross_chain_messaging l2_to_l1', () => {
     }
   });
 
-  // TODO(#17027): Add tests for multiple blocks per checkpoint.
+  // Two txs, each emitting one L2-to-L1 message, packed into separate blocks of a single checkpoint.
+  // This exercises the checkpoint level of the L2-to-L1 message tree (the block out hashes within a
+  // checkpoint), which the single-block-per-checkpoint cases above never reach. See #17027.
+  it('2 txs each with a message, in different blocks of the same checkpoint', async () => {
+    const recipient = msgSender;
+    const contents = [Fr.random(), Fr.random()];
+    const messages = contents.map(content => makeL2ToL1Message(recipient, content));
+
+    // Enable multiple-blocks-per-checkpoint: enforce the timetable so the sequencer splits the slot
+    // into per-block sub-slots, cap each block at a single tx, and require (and accept at most) two
+    // blocks before publishing the checkpoint. With the two txs below this yields one checkpoint
+    // holding two single-tx blocks.
+    await aztecNodeAdmin.setConfig({
+      enforceTimeTable: true,
+      blockDurationMs: 2000,
+      minTxsPerBlock: 1,
+      maxTxsPerBlock: 1,
+      minBlocksForCheckpoint: 2,
+      maxBlocksPerCheckpoint: 2,
+    });
+    await waitForSequencerIdle(t.context.sequencer!.getSequencer());
+
+    // Send the 2 txs. minBlocksForCheckpoint=2 keeps the sequencer from publishing until both have
+    // been packed (one per block), so they always end up in the same checkpoint.
+    const [{ receipt: receipt0 }, { receipt: receipt1 }] = await Promise.all([
+      contract.methods
+        .create_l2_to_l1_message_arbitrary_recipient_private(contents[0], recipient)
+        .send({ from: user1Address }),
+      contract.methods
+        .create_l2_to_l1_message_arbitrary_recipient_private(contents[1], recipient)
+        .send({ from: user1Address }),
+    ]);
+
+    // The 2 txs must land in different blocks...
+    expect(receipt0.blockNumber).not.toEqual(receipt1.blockNumber);
+
+    // ...that belong to the same checkpoint, at consecutive positions within it.
+    const block0 = (await aztecNode.getBlock(receipt0.blockNumber!, { includeTransactions: true }))!;
+    const block1 = (await aztecNode.getBlock(receipt1.blockNumber!, { includeTransactions: true }))!;
+    expect(block0.checkpointNumber).toEqual(block1.checkpointNumber);
+    expect([block0.indexWithinCheckpoint, block1.indexWithinCheckpoint].sort((a, b) => a - b)).toEqual([0, 1]);
+
+    // Each block carries exactly its own message.
+    expect(block0.body.txEffects.flatMap(txEffect => txEffect.l2ToL1Msgs)).toStrictEqual([
+      computeMessageLeaf(messages[0]),
+    ]);
+    expect(block1.body.txEffects.flatMap(txEffect => txEffect.l2ToL1Msgs)).toStrictEqual([
+      computeMessageLeaf(messages[1]),
+    ]);
+
+    // Advance the epoch until proven, since the messages are inserted to the outbox when the epoch is proven.
+    await t.advanceToEpochProven(receipt1);
+
+    // Consume both messages. The membership witnesses now span the checkpoint's block subtree, not just
+    // a single block.
+    await expectConsumeMessageToSucceed(messages[0], receipt0.txHash);
+    await expectConsumeMessageToSucceed(messages[1], receipt1.txHash);
+  });
 
   function makeL2ToL1Message(recipient: EthAddress, content: Fr = Fr.ZERO): ViemL2ToL1Msg {
     return {


### PR DESCRIPTION
Adds a missing e2e test to the l2-to-l1 suite to test that two blocks with outgoing messages in the same checkpoint are processed correctly.

Also guards against setup flakes by anchoring the pxe to the checkpointed chain (see [this flaked run](http://ci.aztec-labs.com/448641256e72540b))