### PR TITLE
test(e2e): wait warmup slots in slashing tests

### DIFF
--- a/yarn-project/end-to-end/src/e2e_p2p/duplicate_attestation_slash.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/duplicate_attestation_slash.test.ts
@@ -224,7 +224,7 @@ describe('e2e_p2p_duplicate_attestation_slash', () => {
     // Find an epoch where the malicious proposer is selected, stopping one epoch before
     // so we have time to start sequencers before the target epoch arrives
     const epochCache = (honestNode1 as TestAztecNodeService).epochCache;
-    const { targetEpoch } = await advanceToEpochBeforeProposer({
+    const { targetEpoch, targetSlot } = await advanceToEpochBeforeProposer({
       epochCache,
       cheatCodes: t.ctx.cheatCodes.rollup,
       targetProposer: maliciousProposerAddress,
@@ -235,9 +235,14 @@ describe('e2e_p2p_duplicate_attestation_slash', () => {
     t.logger.warn('Starting all sequencers');
     await Promise.all(nodes.map(n => n.getSequencer()!.start()));
 
-    // Now warp to the target epoch — sequencers are already running
-    t.logger.warn(`Advancing to target epoch ${targetEpoch}`);
-    await t.ctx.cheatCodes.rollup.advanceToEpoch(targetEpoch);
+    // Now warp to one slot before the target epoch — sequencers are already running. The helper
+    // picks a target slot at least one slot into the epoch, so warping here (rather than to the
+    // epoch start) leaves the freshly-started sequencers a full warm-up slot before the pipelined
+    // build for the malicious slot begins. Without that margin the duplicate proposals serialize
+    // past the slot boundary and receivers reject them as late, so the malicious nodes never get to
+    // attest to both and no duplicate attestation is produced.
+    t.logger.warn(`Advancing to one slot before target epoch ${targetEpoch} (target slot ${targetSlot})`);
+    await t.ctx.cheatCodes.rollup.advanceToEpoch(targetEpoch, { offset: -AZTEC_SLOT_DURATION });
 
     // Wait for offenses to be detected
     // We expect BOTH duplicate proposal AND duplicate attestation offenses

--- a/yarn-project/end-to-end/src/e2e_p2p/duplicate_proposal_slash.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/duplicate_proposal_slash.test.ts
@@ -212,7 +212,7 @@ describe('e2e_p2p_duplicate_proposal_slash', () => {
     // Find an epoch where the malicious proposer is selected, stopping one epoch before
     // so we have time to start sequencers before the target epoch arrives
     const epochCache = (honestNode1 as TestAztecNodeService).epochCache;
-    const { targetEpoch } = await advanceToEpochBeforeProposer({
+    const { targetEpoch, targetSlot } = await advanceToEpochBeforeProposer({
       epochCache,
       cheatCodes: t.ctx.cheatCodes.rollup,
       targetProposer: maliciousValidatorAddress,
@@ -224,11 +224,12 @@ describe('e2e_p2p_duplicate_proposal_slash', () => {
     await Promise.all(nodes.map(n => n.getSequencer()!.start()));
 
     // Now warp to one slot before the target epoch — sequencers are already running.
-    // Under proposer pipelining, the malicious proposers begin building for the first
-    // slot of the target epoch one slot earlier; warping to the start of the epoch
-    // would force both AVM-heavy duplicate proposals to serialize past the slot
-    // boundary, after which honest receivers reject them as late.
-    t.logger.warn(`Advancing to one slot before target epoch ${targetEpoch}`);
+    // Under proposer pipelining, the malicious proposers begin building for their slot one slot
+    // earlier; warping to the start of the epoch would force both AVM-heavy duplicate proposals to
+    // serialize past the slot boundary, after which honest receivers reject them as late. The helper
+    // picks a target slot at least one slot into the epoch, so warping here leaves a full warm-up
+    // slot before the build begins rather than starting it at the exact instant of the warp.
+    t.logger.warn(`Advancing to one slot before target epoch ${targetEpoch} (target slot ${targetSlot})`);
     await t.ctx.cheatCodes.rollup.advanceToEpoch(targetEpoch, { offset: -AZTEC_SLOT_DURATION });
 
     // Wait for offense to be detected. Under proposer pipelining, checkpoint proposals are broadcast

--- a/yarn-project/end-to-end/src/e2e_p2p/shared.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/shared.ts
@@ -148,12 +148,21 @@ export async function awaitCommitteeExists({
 }
 
 /**
- * Advance epochs until we find one where the target proposer is selected for at least one slot,
- * then stop one epoch before it. This leaves time for the caller to start sequencers before
- * warping to the target epoch, avoiding the race where the target epoch passes before sequencers
- * are ready.
+ * Advance epochs until we find one where the target proposer is selected for a slot at least
+ * `warmupSlots` into the epoch, then stop one epoch before it. This leaves time for the caller to
+ * start sequencers before warping to the target epoch, avoiding the race where the target epoch
+ * passes before sequencers are ready.
  *
- * Returns the target epoch number so the caller can warp to it after starting sequencers.
+ * The first `warmupSlots` slots of the epoch are skipped on purpose. Callers warp to one slot
+ * before the target epoch and, under proposer pipelining, the proposer begins building one slot
+ * before its proposal slot. If the proposer were in the first slot of the epoch, that build would
+ * begin at the exact instant of the warp, leaving the freshly-started sequencer no warm-up margin;
+ * it then serializes its (often AVM-heavy) proposal past the slot boundary and honest receivers
+ * reject it as late. Picking a slot at least `warmupSlots` into the epoch guarantees that many full
+ * slots of wall-clock between the warp and the start of the proposer's build.
+ *
+ * Returns the target epoch and the concrete target slot so the caller can warp to it after starting
+ * sequencers.
  */
 export async function advanceToEpochBeforeProposer({
   epochCache,
@@ -161,13 +170,15 @@ export async function advanceToEpochBeforeProposer({
   targetProposer,
   logger,
   maxAttempts = 20,
+  warmupSlots = 1,
 }: {
   epochCache: EpochCacheInterface;
   cheatCodes: RollupCheatCodes;
   targetProposer: EthAddress;
   logger: Logger;
   maxAttempts?: number;
-}): Promise<{ targetEpoch: EpochNumber }> {
+  warmupSlots?: number;
+}): Promise<{ targetEpoch: EpochNumber; targetSlot: SlotNumber }> {
   const { epochDuration } = await cheatCodes.getConfig();
 
   for (let attempt = 0; attempt < maxAttempts; attempt++) {
@@ -175,8 +186,11 @@ export async function advanceToEpochBeforeProposer({
     // Check the NEXT epoch's slots so we stay one epoch before the target,
     // giving the caller time to start sequencers before the target epoch arrives.
     const nextEpoch = Number(currentEpoch) + 1;
-    const startSlot = nextEpoch * Number(epochDuration);
-    const endSlot = startSlot + Number(epochDuration);
+    const epochStartSlot = nextEpoch * Number(epochDuration);
+    // Skip the first `warmupSlots` slots so the caller keeps a warm-up margin after warping to one
+    // slot before the epoch (see the doc comment above).
+    const startSlot = epochStartSlot + warmupSlots;
+    const endSlot = epochStartSlot + Number(epochDuration);
 
     logger.info(
       `Checking next epoch ${nextEpoch} (slots ${startSlot}-${endSlot - 1}) for proposer ${targetProposer} (current epoch: ${currentEpoch})`,
@@ -188,7 +202,7 @@ export async function advanceToEpochBeforeProposer({
         logger.warn(
           `Found target proposer ${targetProposer} in slot ${s} of epoch ${nextEpoch}. Staying at epoch ${currentEpoch} to allow sequencer startup.`,
         );
-        return { targetEpoch: EpochNumber(nextEpoch) };
+        return { targetEpoch: EpochNumber(nextEpoch), targetSlot: SlotNumber(s) };
       }
     }
 


### PR DESCRIPTION
Attempt at deflaking slashing tests by keeping some warmup slots. Codex analysis below.

## Cause

The duplicate proposal slash test was timing-fragile after proposer pipelining. In the failed CI run, the malicious shared-key validators were selected for the first slot of the target epoch immediately after the test started sequencers and warped time forward.

Because pipelining builds a proposal one slot ahead, selecting the first slot meant the malicious nodes had to start building at the exact warp boundary. They started late in the build sub-slot, serialized the duplicate proposals after the receiver nodes had already advanced to the next slot, and the receivers rejected the gossip as late (`invalid slot number`) before duplicate-proposal detection could run.

Failed run: [`36837b7edc543e70`](https://ci.aztec-labs.com/36837b7edc543e70)

## Analysis

The failed run never produced a `DUPLICATE_PROPOSAL` offense. It only produced a `DUPLICATE_ATTESTATION` offense, then timed out waiting for the expected proposal offense.

Timeline from the failed run:

- malicious validators were selected for slot 10
- both started building late in sub-slot 3
- both broadcast checkpoint proposals for slot 10
- receivers had already advanced to slot 11 and rejected slot 10 proposals as stale
- the generic offense wait was satisfied by a duplicate attestation
- the final `DUPLICATE_PROPOSAL` assertion timed out

A passing run selected a later proposer slot instead. That gave the sequencers a full warmup slot after the warp, both malicious nodes built early enough, standalone duplicate proposals were broadcast in time, and `DUPLICATE_PROPOSAL` was detected.

## Fix Rationale

Update `advanceToEpochBeforeProposer` to skip the first `warmupSlots` slots of the target epoch and return the concrete `targetSlot`. The duplicate proposal and duplicate attestation tests still warp to one slot before the target epoch, but now the selected malicious proposer slot is at least one slot into that epoch.

That gives freshly-started sequencers one full slot of wall-clock warmup before the pipelined build for the malicious slot begins, avoiding the startup/warp boundary race where duplicate proposals are emitted too late and rejected before slash detection.
