### PR TITLE
test(e2e): restore both malicious nodes to honest in `invalidate_block`

### DIFF
--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_invalidate_block.parallel.test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_invalidate_block.parallel.test.ts
@@ -661,9 +661,12 @@ describe('e2e_epochs/epochs_invalidate_block', () => {
     // P1 must have landed with insufficient attestations (the trigger for the archiver skip).
     await assertCheckpointInsufficientAttestations(p1Checkpoint);
 
-    // Restore P2 to a healthy config so a later proposer (or P2 in a future slot) can resume
-    // the chain by invalidating P1 and posting fresh checkpoints.
-    await p2Node.setConfig({ skipWaitForValidParentCheckpointOnL1: false, skipInvalidateBlockAsProposer: false });
+    // Restore the bad proposers to a healthy config so later slots can resume the chain by
+    // invalidating P1 and posting fresh checkpoints.
+    await Promise.all([
+      p1Node.setConfig({ skipCollectingAttestations: false, skipInvalidateBlockAsProposer: false }),
+      p2Node.setConfig({ skipWaitForValidParentCheckpointOnL1: false, skipInvalidateBlockAsProposer: false }),
+    ]);
 
     // The archiver should no longer stall: wait for the chain to advance past P2 within a
     // handful of slots. Note we wait on local checkpoint progress here (i.e. for the chain to


### PR DESCRIPTION
Fixes flake in epochs_invalidate_block test "archiver skips a descendant of an invalid-attestations checkpoint" when one of the malicious nodes was picked as proposer when we expected the chain to advance successfully. Codex analysis below.

**Test Summary**
`archiver skips a descendant of an invalid-attestations checkpoint` verifies that when P1 posts a checkpoint with insufficient attestations and P2 posts a valid-attestation descendant, archivers reject both, emit `DescendentOfInvalidAttestationsCheckpointDetected`, and the chain later recovers past P2.

**Failed Run Error**
CI `a4dc267449e28279` timed out at:
`TimeoutError: Timeout awaiting archiver advances past P2`

**Failed vs Successful Divergence**
Both runs correctly skipped P1 and P2. The divergence came afterward: in the failed run, P1 stayed malicious and got scheduled again, publishing more invalid checkpoints before the observer reached checkpoint `3`. In the passing run, healthy proposers recovered the chain first.

**Timeline**
Failed:
- `20:55:51`: P2 skipped as descendant of rejected checkpoint 1.
- `20:57:27`: P1 publishes another invalid checkpoint 1.
- `20:59:03`: another checkpoint 2 is skipped for insufficient attestations.
- `21:00:31`: timeout waiting for checkpointed tip `>= p2Checkpoint + 1`.

Successful:
- `20:43:25`: P2 skipped as descendant of rejected checkpoint 1.
- `20:45:01`: replacement checkpoint 1 downloaded.
- `20:45:33`: checkpoint 2 downloaded.
- `20:46:05`: checkpoint 3 downloaded; test succeeds.

**Hypothesis**
High confidence: the test restored only P2 after confirming P1’s bad checkpoint, leaving P1’s `skipCollectingAttestations` and `skipInvalidateBlockAsProposer` config active. If P1 is scheduled again during recovery, the test waits on an accidental scheduling race rather than the archiver behavior.

**Evidence**
- Logs: failed run shows P1 republishing invalid checkpoints after the intended P1/P2 scenario; passing run reaches checkpoints 1, 2, and 3 before P1 can interfere.
- Source: the test intended only P1/P2 to be malicious, then recovery is checked in [epochs_invalidate_block.parallel.test.ts](/home/santiago/Projects/aztec-2/yarn-project/end-to-end/src/e2e_epochs/epochs_invalidate_block.parallel.test.ts:661). Archiver rejected-ancestor behavior is in [l1_synchronizer.ts](/home/santiago/Projects/aztec-2/yarn-project/archiver/src/modules/l1_synchronizer.ts:879).
- Skeptic check: confirmed the fix does not weaken the test; keeping P1 malicious after the assertion only tests proposer-schedule luck.

**Proposed Fix**
Updated [epochs_invalidate_block.parallel.test.ts](/home/santiago/Projects/aztec-2/yarn-project/end-to-end/src/e2e_epochs/epochs_invalidate_block.parallel.test.ts:667) to restore both bad proposers before waiting for chain progress:

- P1: `skipCollectingAttestations: false`, `skipInvalidateBlockAsProposer: false`
- P2: `skipWaitForValidParentCheckpointOnL1: false`, `skipInvalidateBlockAsProposer: false`

**Verification**
Passed:

```bash
LOG_LEVEL='info; debug:sequencer,archiver,publisher,validator' ANVIL_PORT=8564 yarn workspace @aztec/end-to-end test:e2e e2e_epochs/epochs_invalidate_block.parallel.test.ts -t 'archiver skips a descendant of an invalid-attestations checkpoint'
```

Result: `1 passed, 8 skipped`.