### PR TITLE
chore(p2p): use sync hash for tx validation hashing

### DIFF
--- a/yarn-project/p2p/src/msg_validators/tx_validator/tx_validation_cache.test.ts
+++ b/yarn-project/p2p/src/msg_validators/tx_validator/tx_validation_cache.test.ts
@@ -18,39 +18,38 @@ describe('TxValidationCache', () => {
     tx = await mockTx(1);
   });
 
-  // The cache key is derived asynchronously, so a call's promise is only registered after its key
-  // resolves. This waits until a call has been registered before issuing a follow-up, making the
-  // coalescing assertions deterministic rather than dependent on the order in which key digests resolve.
+  // A call's promise is only registered after getOrValidate computes its key and calls set. This waits
+  // until a call has been registered before issuing a follow-up, making coalescing assertions deterministic.
   const waitUntilCached = async (validatorSymbol: symbol, forTx: Tx) => {
-    const key = await cache.key(validatorSymbol, forTx);
+    const key = cache.key(validatorSymbol, forTx);
     while (cache.get(key) === undefined) {
       await sleep(1);
     }
   };
 
   describe('get / set', () => {
-    it('returns undefined on a cache miss', async () => {
-      expect(cache.get(await cache.key(validatorA, tx))).toBeUndefined();
+    it('returns undefined on a cache miss', () => {
+      expect(cache.get(cache.key(validatorA, tx))).toBeUndefined();
     });
 
     it('returns the stored promise on a cache hit', async () => {
       const result: TxValidationResult = { result: 'valid' };
-      cache.set(await cache.key(validatorA, tx), Promise.resolve(result));
+      cache.set(cache.key(validatorA, tx), Promise.resolve(result));
 
-      await expect(cache.get(await cache.key(validatorA, tx))).resolves.toEqual(result);
+      await expect(cache.get(cache.key(validatorA, tx))).resolves.toEqual(result);
     });
 
-    it('does not share entries across different validator symbols', async () => {
-      cache.set(await cache.key(validatorA, tx), Promise.resolve({ result: 'valid' }));
+    it('does not share entries across different validator symbols', () => {
+      cache.set(cache.key(validatorA, tx), Promise.resolve({ result: 'valid' }));
 
-      expect(cache.get(await cache.key(validatorB, tx))).toBeUndefined();
+      expect(cache.get(cache.key(validatorB, tx))).toBeUndefined();
     });
 
     it('does not share entries across different txs', async () => {
       const otherTx = await mockTx(2);
-      cache.set(await cache.key(validatorA, tx), Promise.resolve({ result: 'valid' }));
+      cache.set(cache.key(validatorA, tx), Promise.resolve({ result: 'valid' }));
 
-      expect(cache.get(await cache.key(validatorA, otherTx))).toBeUndefined();
+      expect(cache.get(cache.key(validatorA, otherTx))).toBeUndefined();
     });
   });
 
@@ -62,14 +61,14 @@ describe('TxValidationCache', () => {
       const tx3 = await mockTx(12);
       const result: TxValidationResult = { result: 'valid' };
 
-      smallCache.set(await smallCache.key(validatorA, tx1), Promise.resolve(result));
-      smallCache.set(await smallCache.key(validatorA, tx2), Promise.resolve(result));
+      smallCache.set(smallCache.key(validatorA, tx1), Promise.resolve(result));
+      smallCache.set(smallCache.key(validatorA, tx2), Promise.resolve(result));
       // tx1 is now the LRU entry; adding tx3 should evict it
-      smallCache.set(await smallCache.key(validatorA, tx3), Promise.resolve(result));
+      smallCache.set(smallCache.key(validatorA, tx3), Promise.resolve(result));
 
-      expect(smallCache.get(await smallCache.key(validatorA, tx1))).toBeUndefined();
-      expect(smallCache.get(await smallCache.key(validatorA, tx2))).toBeDefined();
-      expect(smallCache.get(await smallCache.key(validatorA, tx3))).toBeDefined();
+      expect(smallCache.get(smallCache.key(validatorA, tx1))).toBeUndefined();
+      expect(smallCache.get(smallCache.key(validatorA, tx2))).toBeDefined();
+      expect(smallCache.get(smallCache.key(validatorA, tx3))).toBeDefined();
     });
 
     it('refreshes recency on get so that accessed entries are not evicted first', async () => {
@@ -79,15 +78,15 @@ describe('TxValidationCache', () => {
       const tx3 = await mockTx(22);
       const result: TxValidationResult = { result: 'valid' };
 
-      smallCache.set(await smallCache.key(validatorA, tx1), Promise.resolve(result));
-      smallCache.set(await smallCache.key(validatorA, tx2), Promise.resolve(result));
+      smallCache.set(smallCache.key(validatorA, tx1), Promise.resolve(result));
+      smallCache.set(smallCache.key(validatorA, tx2), Promise.resolve(result));
       // Access tx1 so tx2 becomes the LRU entry
-      void smallCache.get(await smallCache.key(validatorA, tx1));
-      smallCache.set(await smallCache.key(validatorA, tx3), Promise.resolve(result));
+      void smallCache.get(smallCache.key(validatorA, tx1));
+      smallCache.set(smallCache.key(validatorA, tx3), Promise.resolve(result));
 
-      expect(smallCache.get(await smallCache.key(validatorA, tx1))).toBeDefined();
-      expect(smallCache.get(await smallCache.key(validatorA, tx2))).toBeUndefined();
-      expect(smallCache.get(await smallCache.key(validatorA, tx3))).toBeDefined();
+      expect(smallCache.get(smallCache.key(validatorA, tx1))).toBeDefined();
+      expect(smallCache.get(smallCache.key(validatorA, tx2))).toBeUndefined();
+      expect(smallCache.get(smallCache.key(validatorA, tx3))).toBeDefined();
     });
 
     it('throws when constructed with maxSize < 1', () => {

--- a/yarn-project/p2p/src/msg_validators/tx_validator/tx_validation_cache.ts
+++ b/yarn-project/p2p/src/msg_validators/tx_validator/tx_validation_cache.ts
@@ -2,7 +2,7 @@ import { LruMap } from '@aztec/foundation/collection';
 import { type Logger, createLogger } from '@aztec/foundation/log';
 import type { Tx, TxValidationResult } from '@aztec/stdlib/tx';
 
-import { webcrypto } from 'node:crypto';
+import { createHash } from 'node:crypto';
 
 /**
  * Minimal interface consumed by {@link CachedTxValidator}.
@@ -50,12 +50,11 @@ export class TxValidationCache implements ITxValidationCache {
    *
    * Note: the key should NOT use the tx.hash because it can't be trusted at this point.
    */
-  public async key(validatorSymbol: symbol, tx: Tx): Promise<string> {
-    // Hashing the whole tx takes a few milliseconds. So if we have already hashed
-    // this particular object, we avoid rehashing it.
+  public key(validatorSymbol: symbol, tx: Tx): string {
+    // Serializing the tx dominates cost (~5 ms). If we have already hashed this object, skip toBuffer + hash.
     let hash = this.txHashesCache.get(tx);
     if (hash === undefined) {
-      hash = Buffer.from(await webcrypto.subtle.digest('SHA-256', tx.toBuffer())).toString('hex');
+      hash = createHash('sha256').update(tx.toBuffer()).digest('hex');
       this.txHashesCache.set(tx, hash);
     }
     return `${Symbol.keyFor(validatorSymbol) ?? validatorSymbol.toString()}:${hash}`;
@@ -80,12 +79,12 @@ export class TxValidationCache implements ITxValidationCache {
    * Returns the cached promise if present, otherwise calls `validate`, stores its promise
    * immediately (before awaiting), and returns it.
    */
-  public async getOrValidate(
+  public getOrValidate(
     validatorSymbol: symbol,
     tx: Tx,
     validate: () => Promise<TxValidationResult>,
   ): Promise<TxValidationResult> {
-    const key = await this.key(validatorSymbol, tx);
+    const key = this.key(validatorSymbol, tx);
     const cached = this.get(key);
     if (cached !== undefined) {
       this.#log.debug('Returning cached tx validation result', {

--- a/yarn-project/stdlib/src/tx/tx_bench.test.ts
+++ b/yarn-project/stdlib/src/tx/tx_bench.test.ts
@@ -1,6 +1,6 @@
 import { Timer } from '@aztec/foundation/timer';
 
-import { webcrypto } from 'node:crypto';
+import { createHash } from 'node:crypto';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { type RecordableHistogram, createHistogram } from 'perf_hooks';
@@ -77,7 +77,7 @@ describe('Tx', () => {
     const tx = await mockTxForRollup(42);
     for (let i = 0; i < RUNS; i++) {
       const timer = new Timer();
-      await webcrypto.subtle.digest('SHA-256', tx.toBuffer());
+      createHash('sha256').update(tx.toBuffer()).digest();
       privateSha256Histogram.record(Math.max(1, Math.ceil(timer.ms())));
     }
   });
@@ -86,7 +86,7 @@ describe('Tx', () => {
     const tx = await mockTx(42);
     for (let i = 0; i < RUNS; i++) {
       const timer = new Timer();
-      await webcrypto.subtle.digest('SHA-256', tx.toBuffer());
+      createHash('sha256').update(tx.toBuffer()).digest();
       publicSha256Histogram.record(Math.max(1, Math.ceil(timer.ms())));
     }
   });


### PR DESCRIPTION
Use `createHash` which is used in other parts of the code.
No awaits. This also fixes a potential race condition if you `getOrValidate` concurrently.

Seems to even be slightly faster due to no microtask scheduling.

| Metric | Before (subtle) | After (createHash) | Δ (avg) |
|--------|-----------------|---------------------|---------|
| **PRV-SHA256** | 3.39 ms | 3.13 ms | ~8% faster |
| **PUB-SHA256** | 5.27 ms | 5.00 ms | ~5% faster |
| PRV getTxHash | 9.39 ms | 8.24 ms | (unchanged path; run noise) |
| PUB getTxHash | 18.53 ms | 17.55 ms | (unchanged path; run noise) |