### PR TITLE
fix: protect HA validator Postgres from cluster scale-down

### DIFF
--- a/spartan/aztec-postgres/templates/pdb.yaml
+++ b/spartan/aztec-postgres/templates/pdb.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "aztec-postgres.fullname" . }}
+  labels:
+    {{- include "aztec-postgres.labels" . | nindent 4 }}
+spec:
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ .Chart.Name }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/spartan/aztec-postgres/templates/statefulset.yaml
+++ b/spartan/aztec-postgres/templates/statefulset.yaml
@@ -17,6 +17,10 @@ spec:
         app.kubernetes.io/name: {{ .Chart.Name }}
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/component: {{ .Values.component | default .Chart.Name }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/spartan/aztec-postgres/values.yaml
+++ b/spartan/aztec-postgres/values.yaml
@@ -30,3 +30,11 @@ service:
   port: 5432
 
 nodeSelector: {}
+
+# Block cluster-autoscaler scale-down evictions (single-replica HA signing DB).
+podAnnotations:
+  cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
+
+podDisruptionBudget:
+  enabled: true
+  minAvailable: 1


### PR DESCRIPTION
## Summary
- Annotate validator HA Postgres pods with `cluster-autoscaler.kubernetes.io/safe-to-evict: "false"` so GKE does not evict them during node scale-down.
- Add a PodDisruptionBudget (`minAvailable: 1`) matching the `aztec-node` chart pattern for voluntary disruptions.

Motivation: CI `validator_nuke_and_suppression.test.ts` missed slot 445 when autoscaler scale-down deleted `v5-scenario-2-validator-ha-db-postgres-0`, leaving validators with `ECONNREFUSED` on the DB service for ~53s.