### PR TITLE
fix(sequencer): enforce build-frame deadlines and align attestation/publish windows

### DIFF
--- a/yarn-project/p2p/src/msg_validators/attestation_validator/attestation_validator.test.ts
+++ b/yarn-project/p2p/src/msg_validators/attestation_validator/attestation_validator.test.ts
@@ -97,7 +97,8 @@ describe('CheckpointAttestationValidator', () => {
 
   it('accepts attestation for current slot inside the straggler window', async () => {
     // Attestation is for slot 98 (current wallclock slot), but targetSlot is 99 (pipelining).
-    // attestationWindowIntoTargetSlot = 2*p2p = 4s ⇒ straggler grace 4s+500ms disparity.
+    // attestationWindowIntoTargetSlot now spans target-slot start to the L1 publish deadline:
+    // aztecSlotDuration - 2*ethereumSlotDuration = 72 - 24 = 48s ⇒ straggler grace 48s+500ms.
     const header = CheckpointHeader.random({ slotNumber: SlotNumber(98) });
     const mockAttestation = makeCheckpointAttestation({
       header,
@@ -119,7 +120,39 @@ describe('CheckpointAttestationValidator', () => {
       epoch: EpochNumber(1),
       slot: SlotNumber(98),
       ts: 1000n,
-      nowMs: 1003000n, // 3000ms elapsed, within 4500ms straggler grace
+      nowMs: 1003000n, // 3000ms elapsed, within 48500ms straggler grace
+    });
+    epochCache.isInCommittee.mockResolvedValue(true);
+    epochCache.getProposerAttesterAddressInSlot.mockResolvedValue(proposer.address);
+
+    const result = await validator.validate(mockAttestation);
+    expect(result).toEqual({ result: 'accept' });
+  });
+
+  it('accepts attestation arriving well into the target slot (previously rejected past ~4.5s)', async () => {
+    // 30s into the target slot — past the old 4.5s window, well within the new 48.5s window.
+    const header = CheckpointHeader.random({ slotNumber: SlotNumber(98) });
+    const mockAttestation = makeCheckpointAttestation({
+      header,
+      attesterSigner: attester,
+      proposerSigner: proposer,
+    });
+
+    epochCache.getTargetAndNextSlot.mockReturnValue({
+      targetSlot: SlotNumber(99),
+      nextSlot: SlotNumber(100),
+    });
+    epochCache.getSlotNow.mockReturnValue(SlotNumber(98));
+    epochCache.getL1Constants.mockReturnValue({
+      slotDuration: 72,
+      ethereumSlotDuration: 12,
+    } as any);
+
+    epochCache.getEpochAndSlotNow.mockReturnValue({
+      epoch: EpochNumber(1),
+      slot: SlotNumber(98),
+      ts: 1000n,
+      nowMs: 1030000n, // 30s elapsed — accepted now, would have been rejected pre-fix
     });
     epochCache.isInCommittee.mockResolvedValue(true);
     epochCache.getProposerAttesterAddressInSlot.mockResolvedValue(proposer.address);
@@ -151,7 +184,7 @@ describe('CheckpointAttestationValidator', () => {
       epoch: EpochNumber(1),
       slot: SlotNumber(99),
       ts: 1000n,
-      nowMs: 1005000n, // 5000ms elapsed, past 4500ms straggler cutoff
+      nowMs: 1049000n, // 49s elapsed, past the 48.5s straggler cutoff (48s window + 500ms disparity)
     });
     epochCache.isInCommittee.mockResolvedValue(true);
 

--- a/yarn-project/p2p/src/msg_validators/clock_tolerance.test.ts
+++ b/yarn-project/p2p/src/msg_validators/clock_tolerance.test.ts
@@ -260,10 +260,11 @@ describe('clock_tolerance', () => {
   });
 
   describe('PipeliningWindow.acceptsAttestation', () => {
-    // Config: 72s slot, 2s p2p.
-    // Under early pipelining, attestationWindowIntoTargetSlot = 2*p2p = 4s,
-    // giving straggler attestations 4s+500ms grace after the receiver rolls
-    // into the next slot.
+    // Config: 72s slot, 12s Ethereum slot.
+    // attestationWindowIntoTargetSlot now spans target-slot start to the L1 publish deadline:
+    // aztecSlotDuration - 2*ethereumSlotDuration = 72 - 24 = 48s, giving straggler attestations
+    // 48s + 500ms grace after the receiver rolls into the target slot, so the proposer can keep
+    // collecting useful attestations until right before the publish deadline.
     let epochCache: ReturnType<typeof mock<EpochCacheInterface>>;
     let pipeliningWindow: PipeliningWindow;
 
@@ -282,34 +283,31 @@ describe('clock_tolerance', () => {
         epoch: 1 as any,
         slot: SlotNumber(100),
         ts: 1000n,
-        nowMs: 1003000n, // 3000ms elapsed, within 4500ms straggler grace
+        nowMs: 1003000n, // 3000ms elapsed, within 48500ms straggler grace
       });
 
       expect(pipeliningWindow.acceptsAttestation(SlotNumber(100))).toBe(true);
     });
 
-    it('rejects a current-slot attestation past the straggler window', () => {
+    it('accepts an attestation arriving well into the target slot (previously rejected past ~4.5s)', () => {
       epochCache.getEpochAndSlotNow.mockReturnValue({
         epoch: 1 as any,
         slot: SlotNumber(100),
         ts: 1000n,
-        nowMs: 1005000n, // 5000ms elapsed, past 4500ms cutoff
+        nowMs: 1030000n, // 30s into the target slot — past the old 4.5s window, within the new 48.5s
       });
 
-      expect(pipeliningWindow.acceptsAttestation(SlotNumber(100))).toBe(false);
+      expect(pipeliningWindow.acceptsAttestation(SlotNumber(100))).toBe(true);
     });
 
-    it('scales the straggler window with p2pPropagationTime', () => {
-      // With p2pPropagationTime = 4, straggler window = 8s + 500ms disparity.
-      const longer = new PipeliningWindow(epochCache, { l1PublishingTime: 12, p2pPropagationTime: 4 });
+    it('rejects a current-slot attestation past the L1 publish deadline window', () => {
       epochCache.getEpochAndSlotNow.mockReturnValue({
         epoch: 1 as any,
         slot: SlotNumber(100),
         ts: 1000n,
-        nowMs: 1007000n,
+        nowMs: 1049000n, // 49s elapsed, past the 48.5s cutoff (48s window + 500ms disparity)
       });
 
-      expect(longer.acceptsAttestation(SlotNumber(100))).toBe(true);
       expect(pipeliningWindow.acceptsAttestation(SlotNumber(100))).toBe(false);
     });
   });

--- a/yarn-project/sequencer-client/src/sequencer/README.md
+++ b/yarn-project/sequencer-client/src/sequencer/README.md
@@ -94,11 +94,17 @@ These constants come from `@aztec/stdlib/timetable` (see `stdlib/src/timetable/i
 | `WAITING_FOR_TXS`           | `initializeDeadline + checkpointInitializationTime`                         |
 | `CREATING_BLOCK`            | same as `WAITING_FOR_TXS`                                                   |
 | `WAITING_UNTIL_NEXT_BLOCK`  | same as `WAITING_FOR_TXS`                                                   |
-| `ASSEMBLING_CHECKPOINT`     | `aztecSlotDuration` (assembly completes by the build-slot boundary)         |
+| `ASSEMBLING_CHECKPOINT`     | `aztecSlotDuration + pipeliningAttestationGracePeriod`                      |
 | `COLLECTING_ATTESTATIONS`   | same as `ASSEMBLING_CHECKPOINT`                                             |
-| `PUBLISHING_CHECKPOINT`     | `2 * aztecSlotDuration - l1PublishingTime` (extends into the target slot)   |
+| `PUBLISHING_CHECKPOINT`     | `2 * aztecSlotDuration - ethereumSlotDuration` (extends into the target slot) |
 
-`ASSEMBLING_CHECKPOINT` and `COLLECTING_ATTESTATIONS` must be *entered* before the build-slot boundary; once entered, attestation collection itself has its own `checkpointAttestationDeadline = 2 * aztecSlotDuration - l1PublishingTime`, so a late attestation arriving after the boundary is still accepted. The publishing deadline extends into the target slot because that is when the L1 tx is actually submitted.
+In production-like timing, `pipeliningAttestationGracePeriod` is zero, so `ASSEMBLING_CHECKPOINT` and
+`COLLECTING_ATTESTATIONS` must be *entered* before the build-slot boundary. Local networks with
+`l1PublishingTime < ethereumSlotDuration` can use the target-slot attestation window as grace while preserving the
+L1-geometry publishing cutoff. Once entered, attestation collection itself has its own
+`checkpointAttestationDeadline = 2 * aztecSlotDuration - ethereumSlotDuration`, so a late attestation arriving after
+the boundary is still accepted. The publishing deadline extends into the target slot because that is when the L1 tx is
+actually submitted.
 
 ## Example: 72 s slot, 8 s sub-slots
 
@@ -208,7 +214,9 @@ The current sub-slot is dropped without committing anything. The loop retries on
 
 ### Build slot ends before attestations arrive
 
-`assertTimeLeft` will reject `PUBLISHING_CHECKPOINT` if the attestation deadline has passed; the slot is abandoned, and `checkpoint-publish-failed` is emitted. The `PUBLISHING_CHECKPOINT` deadline allows spillover into the target slot (`2 * aztecSlotDuration - l1PublishingTime`) precisely to absorb a small overrun.
+`assertTimeLeft` will reject `PUBLISHING_CHECKPOINT` if the attestation deadline has passed; the slot is abandoned, and
+`checkpoint-publish-failed` is emitted. The `PUBLISHING_CHECKPOINT` deadline allows spillover into the target slot
+(`2 * aztecSlotDuration - ethereumSlotDuration`) precisely to absorb a small overrun.
 
 ### Pipelined parent fails on L1
 
@@ -230,4 +238,6 @@ aztecSlotDuration ≥ checkpointInitializationTime
 
 Block duration should be ≥ `minExecutionTime` (otherwise no sub-slot ever has enough headroom). `p2pPropagationTime` should be measured against the deployment's actual p2p latency: it directly determines how much of each slot is spent on the cooldown.
 
-`l1PublishingTime` should fit inside the Ethereum slot the target slot maps to. The default of 12 s lines up with one Ethereum slot; congested deployments may need to increase it (which only affects the `PUBLISHING_CHECKPOINT` deadline, not the number of blocks built).
+`l1PublishingTime` should fit inside the Ethereum slot the target slot maps to. The default of 12 s lines up with one
+Ethereum slot; fast local networks may reduce it to use the target-slot attestation window as assembly and attestation
+grace.

--- a/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.timing.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.timing.test.ts
@@ -11,7 +11,7 @@ import { type P2P, P2PClientState } from '@aztec/p2p';
 import type { SlasherClientInterface } from '@aztec/slasher';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
 import type { L2Block, L2BlockSink, L2BlockSource, ProposedCheckpointSink } from '@aztec/stdlib/block';
-import type { L1RollupConstants } from '@aztec/stdlib/epoch-helpers';
+import { type L1RollupConstants, getSlotStartBuildTimestamp } from '@aztec/stdlib/epoch-helpers';
 import { GasFees } from '@aztec/stdlib/gas';
 import type {
   BlockBuilderOptions,
@@ -301,8 +301,9 @@ describe('CheckpointProposalJob Timing Tests', () => {
   }
 
   /** Create a TimingTestCheckpointProposalJob with current mocks */
-  function createJob(): TimingTestCheckpointProposalJob {
-    const setStateFn = jest.fn();
+  function createJob(
+    setStateFn: (state: SequencerState, slot?: SlotNumber) => void = jest.fn(),
+  ): TimingTestCheckpointProposalJob {
     const eventEmitter = new EventEmitter() as TypedEventEmitter<SequencerEvents>;
 
     return new TimingTestCheckpointProposalJob(
@@ -1136,6 +1137,87 @@ describe('CheckpointProposalJob Timing Tests', () => {
 
       // ...and the L1 submission is delayed to (and mines in) the target slot.
       expect(publisher.sendRequestsAt).toHaveBeenCalledWith(targetSlot);
+    });
+  });
+
+  describe('Build-frame deadline enforcement', () => {
+    // Regression coverage for the frame bug: build-frame state deadlines must be measured against
+    // the build slot (`slotNow`), not the target slot. Passing `targetSlot` shifted every deadline a
+    // full Aztec slot into the future (frame B), so they never fired.
+
+    // States the job owns and sets while building inside the build frame. Their deadlines must be
+    // enforced against `slotNow`.
+    const buildFrameStates = [
+      SequencerState.INITIALIZING_CHECKPOINT,
+      SequencerState.WAITING_FOR_TXS,
+      SequencerState.CREATING_BLOCK,
+      SequencerState.WAITING_UNTIL_NEXT_BLOCK,
+      SequencerState.ASSEMBLING_CHECKPOINT,
+      SequencerState.COLLECTING_ATTESTATIONS,
+      SequencerState.PUBLISHING_CHECKPOINT,
+    ];
+
+    it('passes the build slot (not the target slot) to setState for every build-frame state', async () => {
+      const { blocks, txs } = await createTestBlocksAndTxs(2);
+      mockP2pWithTxs(txs);
+      // Force a single WAITING_FOR_TXS poll before the first block by reporting no pending txs once.
+      p2p.getPendingTxCount.mockResolvedValueOnce(0);
+      checkpointBuilder.seedBlocks(
+        blocks,
+        blocks.map((_, i) => [txs[i]]),
+      );
+      checkpointBuilder.setExecutionDurations([5, 5]);
+
+      validatorClient.collectAttestations.mockResolvedValue(getAttestations(blocks[1]));
+
+      setTimeInSlot(1);
+
+      const observedSlots = new Map<SequencerState, SlotNumber | undefined>();
+      const setStateFn = jest.fn((state: SequencerState, slot?: SlotNumber) => {
+        observedSlots.set(state, slot);
+      });
+
+      const job = createJob(setStateFn);
+      await job.execute();
+      await job.awaitPendingSubmission();
+
+      // The build and target slot differ, so the bug would be observable.
+      expect(Number(targetSlot)).toBe(Number(slotNumber) + PROPOSER_PIPELINING_SLOT_OFFSET);
+
+      for (const state of buildFrameStates) {
+        expect(observedSlots.has(state)).toBe(true);
+        expect(observedSlots.get(state)).toBe(slotNumber);
+        expect(observedSlots.get(state)).not.toBe(targetSlot);
+      }
+    });
+
+    it('abandons the slot when a build-frame deadline is missed (assembly past the build-slot boundary)', async () => {
+      const { blocks, txs } = await createTestBlocksAndTxs(1);
+      mockP2pWithTxs(txs);
+      checkpointBuilder.seedBlocks(blocks, [[txs[0]]]);
+      // Single block runs 50s -> 80s (in the build frame), so ASSEMBLING_CHECKPOINT is entered at
+      // ~80s into the build frame, past its deadline (checkpointAssemblyDeadline = 72s in frame A).
+      checkpointBuilder.setExecutionDurations([30]);
+
+      validatorClient.collectAttestations.mockResolvedValue(getAttestations(blocks[0]));
+
+      setTimeInSlot(50);
+
+      // Enforcing setStateFn mirroring Sequencer.setState: measures the deadline for the passed slot
+      // against the build-frame reference (`getSlotStartBuildTimestamp(slot)`).
+      const setStateFn = (state: SequencerState, slot?: SlotNumber) => {
+        if (slot !== undefined) {
+          const ref = getSlotStartBuildTimestamp(slot, l1Constants);
+          timetable.assertTimeLeft(state, dateProvider.nowInSeconds() - ref);
+        }
+      };
+
+      const job = createJob(setStateFn);
+      const checkpoint = await job.execute();
+
+      // Past the build-frame assembly deadline: the SequencerTooSlowError is caught inside
+      // proposeCheckpoint, which returns undefined, so no checkpoint is produced.
+      expect(checkpoint).toBeUndefined();
     });
   });
 });

--- a/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.timing.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.timing.test.ts
@@ -302,7 +302,7 @@ describe('CheckpointProposalJob Timing Tests', () => {
 
   /** Create a TimingTestCheckpointProposalJob with current mocks */
   function createJob(
-    setStateFn: (state: SequencerState, slot?: SlotNumber) => void = jest.fn(),
+    setStateFn: (state: SequencerState, slot?: SlotNumber, timeReferenceSlot?: SlotNumber) => void = jest.fn(),
   ): TimingTestCheckpointProposalJob {
     const eventEmitter = new EventEmitter() as TypedEventEmitter<SequencerEvents>;
 
@@ -1157,7 +1157,7 @@ describe('CheckpointProposalJob Timing Tests', () => {
       SequencerState.PUBLISHING_CHECKPOINT,
     ];
 
-    it('passes the build slot (not the target slot) to setState for every build-frame state', async () => {
+    it('passes the target slot to observers and the build slot to deadline checks for build-frame states', async () => {
       const { blocks, txs } = await createTestBlocksAndTxs(2);
       mockP2pWithTxs(txs);
       // Force a single WAITING_FOR_TXS poll before the first block by reporting no pending txs once.
@@ -1172,9 +1172,12 @@ describe('CheckpointProposalJob Timing Tests', () => {
 
       setTimeInSlot(1);
 
-      const observedSlots = new Map<SequencerState, SlotNumber | undefined>();
-      const setStateFn = jest.fn((state: SequencerState, slot?: SlotNumber) => {
-        observedSlots.set(state, slot);
+      const observedSlots = new Map<
+        SequencerState,
+        { slot: SlotNumber | undefined; timeReferenceSlot: SlotNumber | undefined }
+      >();
+      const setStateFn = jest.fn((state: SequencerState, slot?: SlotNumber, timeReferenceSlot?: SlotNumber) => {
+        observedSlots.set(state, { slot, timeReferenceSlot });
       });
 
       const job = createJob(setStateFn);
@@ -1186,8 +1189,8 @@ describe('CheckpointProposalJob Timing Tests', () => {
 
       for (const state of buildFrameStates) {
         expect(observedSlots.has(state)).toBe(true);
-        expect(observedSlots.get(state)).toBe(slotNumber);
-        expect(observedSlots.get(state)).not.toBe(targetSlot);
+        expect(observedSlots.get(state)?.slot).toBe(targetSlot);
+        expect(observedSlots.get(state)?.timeReferenceSlot).toBe(slotNumber);
       }
     });
 
@@ -1203,11 +1206,12 @@ describe('CheckpointProposalJob Timing Tests', () => {
 
       setTimeInSlot(50);
 
-      // Enforcing setStateFn mirroring Sequencer.setState: measures the deadline for the passed slot
-      // against the build-frame reference (`getSlotStartBuildTimestamp(slot)`).
-      const setStateFn = (state: SequencerState, slot?: SlotNumber) => {
-        if (slot !== undefined) {
-          const ref = getSlotStartBuildTimestamp(slot, l1Constants);
+      // Enforcing setStateFn mirroring Sequencer.setState: measures the deadline against the
+      // explicit time reference slot when one is provided.
+      const setStateFn = (state: SequencerState, slot?: SlotNumber, timeReferenceSlot?: SlotNumber) => {
+        const slotForTiming = timeReferenceSlot ?? slot;
+        if (slotForTiming !== undefined) {
+          const ref = getSlotStartBuildTimestamp(slotForTiming, l1Constants);
           timetable.assertTimeLeft(state, dateProvider.nowInSeconds() - ref);
         }
       };

--- a/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.ts
+++ b/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.ts
@@ -328,7 +328,12 @@ export class CheckpointProposalJob implements Traceable {
   private async enqueueCheckpointForSubmission(result: CheckpointProposalResult): Promise<void> {
     const { checkpoint, attestations, attestationsSignature } = result;
 
-    this.setStateFn(SequencerState.PUBLISHING_CHECKPOINT, this.targetSlot);
+    // Build-frame state deadlines must be measured against `slotNow` (the build slot), not
+    // `targetSlot`. The timetable's `getMaxAllowedTime` deadlines are expressed relative to the
+    // build-frame start; passing `targetSlot` would shift the reference a full Aztec slot later
+    // (frame B), so the deadlines would never fire. `targetSlot` stays for headers, signing, and
+    // L1 submission scheduling.
+    this.setStateFn(SequencerState.PUBLISHING_CHECKPOINT, this.slotNow);
     const aztecSlotDuration = this.l1Constants.slotDuration;
     const submissionSlotStart = Number(getTimestampForSlot(this.targetSlot, this.l1Constants));
     const txTimeoutAt = new Date((submissionSlotStart + aztecSlotDuration) * 1000);
@@ -518,7 +523,7 @@ export class CheckpointProposalJob implements Traceable {
       const feeRecipient = this.validatorClient.getFeeRecipientForAttestor(this.attestorAddress);
 
       // Start the checkpoint
-      this.setStateFn(SequencerState.INITIALIZING_CHECKPOINT, this.targetSlot);
+      this.setStateFn(SequencerState.INITIALIZING_CHECKPOINT, this.slotNow);
       this.logCheckpointEvent('slot-started', `Starting checkpoint proposal for slot ${this.targetSlot}`, {
         buildSlot: this.slotNow,
         submissionSlot: this.targetSlot,
@@ -671,7 +676,7 @@ export class CheckpointProposalJob implements Traceable {
 
       // Assemble and broadcast the checkpoint proposal, including the last block that was not
       // broadcasted yet, and wait to collect the committee attestations.
-      this.setStateFn(SequencerState.ASSEMBLING_CHECKPOINT, this.targetSlot);
+      this.setStateFn(SequencerState.ASSEMBLING_CHECKPOINT, this.slotNow);
       const checkpoint = await checkpointBuilder.completeCheckpoint();
 
       // Final validation: per-block limits are only checked if the operator set them explicitly.
@@ -963,7 +968,7 @@ export class CheckpointProposalJob implements Traceable {
   /** Sleeps until it is time to produce the next block in the slot */
   @trackSpan('CheckpointProposalJob.waitUntilNextSubslot')
   private async waitUntilNextSubslot(nextSubslotStart: number) {
-    this.setStateFn(SequencerState.WAITING_UNTIL_NEXT_BLOCK, this.targetSlot);
+    this.setStateFn(SequencerState.WAITING_UNTIL_NEXT_BLOCK, this.slotNow);
     this.log.verbose(`Waiting until time for the next block at ${nextSubslotStart}s into slot`, {
       slot: this.targetSlot,
     });
@@ -1034,7 +1039,7 @@ export class CheckpointProposalJob implements Traceable {
         `Building block ${blockNumber} at index ${indexWithinCheckpoint} for slot ${this.targetSlot} with ${availableTxs} available txs`,
         { slot: this.targetSlot, blockNumber, indexWithinCheckpoint },
       );
-      this.setStateFn(SequencerState.CREATING_BLOCK, this.targetSlot);
+      this.setStateFn(SequencerState.CREATING_BLOCK, this.slotNow);
 
       // Per-block limits are operator overrides (from SEQ_MAX_L2_BLOCK_GAS etc.) further capped
       // by remaining checkpoint-level budgets inside CheckpointBuilder before each block is built.
@@ -1205,7 +1210,7 @@ export class CheckpointProposalJob implements Traceable {
       }
 
       // Wait a bit before checking again
-      this.setStateFn(SequencerState.WAITING_FOR_TXS, this.targetSlot);
+      this.setStateFn(SequencerState.WAITING_FOR_TXS, this.slotNow);
       this.log.verbose(
         `Waiting for enough txs to build block ${blockNumber} at index ${indexWithinCheckpoint} in slot ${this.targetSlot} (have ${availableTxs} but need ${minTxs})`,
         { blockNumber, slot: this.targetSlot, indexWithinCheckpoint },
@@ -1221,7 +1226,7 @@ export class CheckpointProposalJob implements Traceable {
     broadcast: CheckpointProposalBroadcast,
   ): Promise<{ attestations: CommitteeAttestationsAndSigners; attestationsSignature: Signature } | undefined> {
     const { proposal, blockProposedAt } = broadcast;
-    this.setStateFn(SequencerState.COLLECTING_ATTESTATIONS, this.targetSlot);
+    this.setStateFn(SequencerState.COLLECTING_ATTESTATIONS, this.slotNow);
     const attestations = await this.waitForAttestations(proposal);
     if (!attestations) {
       return undefined;

--- a/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.ts
+++ b/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.ts
@@ -149,7 +149,7 @@ export class CheckpointProposalJob implements Traceable {
     private readonly metrics: SequencerMetrics,
     private readonly checkpointMetrics: CheckpointProposalJobMetricsRecorder,
     protected readonly eventEmitter: TypedEventEmitter<SequencerEvents>,
-    private readonly setStateFn: (state: SequencerState, slot?: SlotNumber) => void,
+    private readonly setStateFn: (state: SequencerState, slot?: SlotNumber, timeReferenceSlot?: SlotNumber) => void,
     public readonly tracer: Tracer,
     bindings?: LoggerBindings,
     private readonly proposedCheckpointData?: ProposedCheckpointData,
@@ -328,12 +328,8 @@ export class CheckpointProposalJob implements Traceable {
   private async enqueueCheckpointForSubmission(result: CheckpointProposalResult): Promise<void> {
     const { checkpoint, attestations, attestationsSignature } = result;
 
-    // Build-frame state deadlines must be measured against `slotNow` (the build slot), not
-    // `targetSlot`. The timetable's `getMaxAllowedTime` deadlines are expressed relative to the
-    // build-frame start; passing `targetSlot` would shift the reference a full Aztec slot later
-    // (frame B), so the deadlines would never fire. `targetSlot` stays for headers, signing, and
-    // L1 submission scheduling.
-    this.setStateFn(SequencerState.PUBLISHING_CHECKPOINT, this.slotNow);
+    // Build-frame deadlines are measured against `slotNow`; observers still see `targetSlot`.
+    this.setStateFn(SequencerState.PUBLISHING_CHECKPOINT, this.targetSlot, this.slotNow);
     const aztecSlotDuration = this.l1Constants.slotDuration;
     const submissionSlotStart = Number(getTimestampForSlot(this.targetSlot, this.l1Constants));
     const txTimeoutAt = new Date((submissionSlotStart + aztecSlotDuration) * 1000);
@@ -523,7 +519,7 @@ export class CheckpointProposalJob implements Traceable {
       const feeRecipient = this.validatorClient.getFeeRecipientForAttestor(this.attestorAddress);
 
       // Start the checkpoint
-      this.setStateFn(SequencerState.INITIALIZING_CHECKPOINT, this.slotNow);
+      this.setStateFn(SequencerState.INITIALIZING_CHECKPOINT, this.targetSlot, this.slotNow);
       this.logCheckpointEvent('slot-started', `Starting checkpoint proposal for slot ${this.targetSlot}`, {
         buildSlot: this.slotNow,
         submissionSlot: this.targetSlot,
@@ -676,7 +672,7 @@ export class CheckpointProposalJob implements Traceable {
 
       // Assemble and broadcast the checkpoint proposal, including the last block that was not
       // broadcasted yet, and wait to collect the committee attestations.
-      this.setStateFn(SequencerState.ASSEMBLING_CHECKPOINT, this.slotNow);
+      this.setStateFn(SequencerState.ASSEMBLING_CHECKPOINT, this.targetSlot, this.slotNow);
       const checkpoint = await checkpointBuilder.completeCheckpoint();
 
       // Final validation: per-block limits are only checked if the operator set them explicitly.
@@ -968,7 +964,7 @@ export class CheckpointProposalJob implements Traceable {
   /** Sleeps until it is time to produce the next block in the slot */
   @trackSpan('CheckpointProposalJob.waitUntilNextSubslot')
   private async waitUntilNextSubslot(nextSubslotStart: number) {
-    this.setStateFn(SequencerState.WAITING_UNTIL_NEXT_BLOCK, this.slotNow);
+    this.setStateFn(SequencerState.WAITING_UNTIL_NEXT_BLOCK, this.targetSlot, this.slotNow);
     this.log.verbose(`Waiting until time for the next block at ${nextSubslotStart}s into slot`, {
       slot: this.targetSlot,
     });
@@ -1039,7 +1035,7 @@ export class CheckpointProposalJob implements Traceable {
         `Building block ${blockNumber} at index ${indexWithinCheckpoint} for slot ${this.targetSlot} with ${availableTxs} available txs`,
         { slot: this.targetSlot, blockNumber, indexWithinCheckpoint },
       );
-      this.setStateFn(SequencerState.CREATING_BLOCK, this.slotNow);
+      this.setStateFn(SequencerState.CREATING_BLOCK, this.targetSlot, this.slotNow);
 
       // Per-block limits are operator overrides (from SEQ_MAX_L2_BLOCK_GAS etc.) further capped
       // by remaining checkpoint-level budgets inside CheckpointBuilder before each block is built.
@@ -1210,7 +1206,7 @@ export class CheckpointProposalJob implements Traceable {
       }
 
       // Wait a bit before checking again
-      this.setStateFn(SequencerState.WAITING_FOR_TXS, this.slotNow);
+      this.setStateFn(SequencerState.WAITING_FOR_TXS, this.targetSlot, this.slotNow);
       this.log.verbose(
         `Waiting for enough txs to build block ${blockNumber} at index ${indexWithinCheckpoint} in slot ${this.targetSlot} (have ${availableTxs} but need ${minTxs})`,
         { blockNumber, slot: this.targetSlot, indexWithinCheckpoint },
@@ -1226,7 +1222,7 @@ export class CheckpointProposalJob implements Traceable {
     broadcast: CheckpointProposalBroadcast,
   ): Promise<{ attestations: CommitteeAttestationsAndSigners; attestationsSignature: Signature } | undefined> {
     const { proposal, blockProposedAt } = broadcast;
-    this.setStateFn(SequencerState.COLLECTING_ATTESTATIONS, this.slotNow);
+    this.setStateFn(SequencerState.COLLECTING_ATTESTATIONS, this.targetSlot, this.slotNow);
     const attestations = await this.waitForAttestations(proposal);
     if (!attestations) {
       return undefined;

--- a/yarn-project/sequencer-client/src/sequencer/events.ts
+++ b/yarn-project/sequencer-client/src/sequencer/events.ts
@@ -10,6 +10,7 @@ export type SequencerEvents = {
     newState: SequencerState;
     secondsIntoSlot?: number;
     slot?: SlotNumber;
+    timeReferenceSlot?: SlotNumber;
   }) => void;
   /**
    * Emitted by the sequencer once it has decided it is going to attempt to build a

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.ts
@@ -581,7 +581,7 @@ export class Sequencer extends (EventEmitter as new () => TypedEventEmitter<Sequ
       this.metrics,
       this.checkpointProposalJobMetrics.createRecorder(),
       this,
-      this.setState.bind(this),
+      (state, slot, timeReferenceSlot) => this.setState(state, slot, { timeReferenceSlot }),
       this.tracer,
       this.log.getBindings(),
       proposedCheckpointData,
@@ -598,13 +598,14 @@ export class Sequencer extends (EventEmitter as new () => TypedEventEmitter<Sequ
   /**
    * Internal helper for setting the sequencer state and checks if we have enough time left in the slot to transition to the new state.
    * @param proposedState - The new state to transition to.
-   * @param slotNumber - The current slot number.
+   * @param slotNumber - The logical slot associated with the new state.
    * @param force - Whether to force the transition even if the sequencer is stopped.
+   * @param timeReferenceSlot - The slot to use for deadline checks when it differs from the logical slot.
    */
   protected setState(
     proposedState: SequencerState,
     slotNumber: SlotNumber | undefined,
-    opts: { force?: boolean } = {},
+    opts: { force?: boolean; timeReferenceSlot?: SlotNumber } = {},
   ): void {
     if (this.state === SequencerState.STOPPING && proposedState !== SequencerState.STOPPED && !opts.force) {
       this.log.warn(`Cannot set sequencer to ${proposedState} as it is stopping.`);
@@ -615,8 +616,9 @@ export class Sequencer extends (EventEmitter as new () => TypedEventEmitter<Sequ
       return;
     }
     let secondsIntoSlot = undefined;
-    if (slotNumber !== undefined) {
-      secondsIntoSlot = this.getSecondsIntoSlot(slotNumber);
+    const timeReferenceSlot = opts.timeReferenceSlot ?? slotNumber;
+    if (timeReferenceSlot !== undefined) {
+      secondsIntoSlot = this.getSecondsIntoSlot(timeReferenceSlot);
       this.timetable.assertTimeLeft(proposedState, secondsIntoSlot);
     }
 
@@ -633,6 +635,7 @@ export class Sequencer extends (EventEmitter as new () => TypedEventEmitter<Sequ
       oldState,
       newState: proposedState,
       slotNumber,
+      timeReferenceSlot,
       stateSlotNumber: oldStateSlotNumber,
       secondsIntoSlot,
       ...(stateChanged && { stateDurationMs: Math.ceil(stateDurationMs) }),
@@ -643,6 +646,7 @@ export class Sequencer extends (EventEmitter as new () => TypedEventEmitter<Sequ
       newState: proposedState,
       secondsIntoSlot,
       slot: slotNumber,
+      timeReferenceSlot,
     });
     if (stateChanged) {
       this.metrics.recordStateDuration(stateDurationMs, oldState);

--- a/yarn-project/sequencer-client/src/sequencer/timetable.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/timetable.test.ts
@@ -559,6 +559,23 @@ describe('sequencer-timetable', () => {
       expect(tt.pipeliningAttestationGracePeriod).toBe(0);
     });
 
+    it('allows fast local publishing profiles to enter assembly and attestation collection in the target slot', () => {
+      const PLAYGROUND_AZTEC_SLOT_DURATION = 72;
+      const tt = new SequencerTimetable({
+        ethereumSlotDuration: ETHEREUM_SLOT_DURATION,
+        aztecSlotDuration: PLAYGROUND_AZTEC_SLOT_DURATION,
+        l1PublishingTime: 1,
+        enforce: ENFORCE_TIMETABLE,
+      });
+
+      expect(tt.pipeliningAttestationGracePeriod).toBe(48);
+      expect(tt.getMaxAllowedTime(SequencerState.ASSEMBLING_CHECKPOINT)).toBe(120);
+      expect(tt.getMaxAllowedTime(SequencerState.COLLECTING_ATTESTATIONS)).toBe(120);
+      expect(tt.getMaxAllowedTime(SequencerState.PUBLISHING_CHECKPOINT)).toBe(132);
+      expect(() => tt.assertTimeLeft(SequencerState.ASSEMBLING_CHECKPOINT, 84.7)).not.toThrow();
+      expect(() => tt.assertTimeLeft(SequencerState.COLLECTING_ATTESTATIONS, 84.7)).not.toThrow();
+    });
+
     it('uses separate pipelined deadlines for attestation start vs publish cutoff', () => {
       const tt = new SequencerTimetable({
         ethereumSlotDuration: ETHEREUM_SLOT_DURATION,

--- a/yarn-project/sequencer-client/src/sequencer/timetable.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/timetable.test.ts
@@ -408,9 +408,13 @@ describe('sequencer-timetable', () => {
           expect(availableTime).toBeGreaterThanOrEqual(requiredTimeForValidators);
         });
 
-        it('sets the publish deadline into the target slot minus l1PublishingTime', () => {
+        it('sets the publish deadline to 12s (one Ethereum slot) before the last L1 block of the target slot', () => {
+          // The publish deadline is the latest the checkpoint can be submitted and still land on L1
+          // in the target slot: one Ethereum slot before the last L1 block. It is derived from
+          // ethereumSlotDuration (L1 geometry), NOT l1PublishingTime (the send lead). Here
+          // ETHEREUM_SLOT_DURATION === L1_PUBLISHING_TIME, so the numeric value coincides.
           const publishDeadline = timetable.getMaxAllowedTime(SequencerState.PUBLISHING_CHECKPOINT);
-          expect(publishDeadline).toBe(2 * AZTEC_SLOT_DURATION - L1_PUBLISHING_TIME);
+          expect(publishDeadline).toBe(2 * AZTEC_SLOT_DURATION - ETHEREUM_SLOT_DURATION);
         });
 
         it('should fit all build-slot operations within slot duration', () => {

--- a/yarn-project/sequencer-client/src/sequencer/timetable.ts
+++ b/yarn-project/sequencer-client/src/sequencer/timetable.ts
@@ -75,8 +75,8 @@ export class SequencerTimetable {
   public readonly maxNumberOfBlocks: number;
 
   /**
-   * How far into the target slot attestation collection can extend when pipelining.
-   * Covers validator re-execution (one block duration) plus one-way attestation return.
+   * How far into the target slot assembly and attestation collection can start when pipelining.
+   * Production-like timing keeps this at zero; fast local publishing profiles can use the attestation window.
    */
   public readonly pipeliningAttestationGracePeriod: number;
 

--- a/yarn-project/stdlib/src/timetable/index.test.ts
+++ b/yarn-project/stdlib/src/timetable/index.test.ts
@@ -79,10 +79,33 @@ describe('timetable validation', () => {
     expect(timing.pipeliningAttestationGracePeriod).toBe(0);
     // Proposals no longer spill into the target slot
     expect(timing.proposalWindowIntoTargetSlot).toBe(0);
-    // Attestation straggler grace is bounded by round-trip p2p
-    expect(timing.attestationWindowIntoTargetSlot).toBe(4);
+    // Attestation window spans target-slot start to the L1 publish deadline:
+    // aztecSlotDuration - 2*ethereumSlotDuration = 72 - 24 = 48
+    expect(timing.attestationWindowIntoTargetSlot).toBe(72 - 2 * 12);
     // Assembly deadline sits at slot boundary
     expect(timing.checkpointAssemblyDeadline).toBe(72);
+    // Publish deadline = 12s (one Ethereum slot) before the last L1 block of the target slot
+    expect(timing.checkpointPublishingDeadline).toBe(2 * 72 - 12);
+    expect(timing.checkpointPublishingDeadline).toBe(2 * timing.aztecSlotDuration - 12);
+    expect(timing.checkpointAttestationDeadline).toBe(timing.checkpointPublishingDeadline);
+  });
+
+  it('bases the publish deadline on ethereumSlotDuration, not l1PublishingTime', () => {
+    // With l1PublishingTime differing from ethereumSlotDuration, the publish/attestation deadline
+    // must follow the Ethereum-slot geometry (2*S - E), not the configured l1PublishingTime.
+    const timing = createPipelinedCheckpointTimingModel({
+      aztecSlotDuration: 72,
+      ethereumSlotDuration: 12,
+      blockDuration: 6,
+      checkpointInitializationTime: 1,
+      checkpointAssembleTime: 1,
+      p2pPropagationTime: 2,
+      l1PublishingTime: 20,
+    });
+
+    // 2*72 - 12 = 132 (Ethereum-slot based), NOT 2*72 - 20 = 124
+    expect(timing.checkpointPublishingDeadline).toBe(132);
+    expect(timing.checkpointAttestationDeadline).toBe(132);
   });
 
   it('allows single-block mode without blockDuration', () => {

--- a/yarn-project/stdlib/src/timetable/index.test.ts
+++ b/yarn-project/stdlib/src/timetable/index.test.ts
@@ -108,6 +108,25 @@ describe('timetable validation', () => {
     expect(timing.checkpointAttestationDeadline).toBe(132);
   });
 
+  it('allows fast local publishing profiles to assemble into the target-slot attestation window', () => {
+    const timing = createPipelinedCheckpointTimingModel({
+      aztecSlotDuration: 72,
+      ethereumSlotDuration: 12,
+      blockDuration: 8,
+      checkpointInitializationTime: 1,
+      checkpointAssembleTime: 1,
+      p2pPropagationTime: 2,
+      l1PublishingTime: 1,
+    });
+
+    expect(timing.attestationWindowIntoTargetSlot).toBe(48);
+    expect(timing.pipeliningAttestationGracePeriod).toBe(48);
+    expect(timing.checkpointAssemblyDeadline).toBe(120);
+    expect(timing.checkpointAttestationStartDeadline).toBe(120);
+    expect(timing.checkpointPublishingDeadline).toBe(132);
+    expect(timing.checkpointAttestationDeadline).toBe(132);
+  });
+
   it('allows single-block mode without blockDuration', () => {
     const timing = createCheckpointTimingModel({
       aztecSlotDuration: 10,

--- a/yarn-project/stdlib/src/timetable/index.ts
+++ b/yarn-project/stdlib/src/timetable/index.ts
@@ -113,13 +113,14 @@ class CheckpointTimingModel implements PipelinedCheckpointTiming {
     // the target slot). The p2p layer accepts slot-N attestations until right before the publish
     // deadline so the proposer can keep collecting useful attestations up to the latest moment the
     // checkpoint can still land on L1 in the target slot.
-    return this.aztecSlotDuration - 2 * this.ethereumSlotDuration;
+    return Math.max(0, this.aztecSlotDuration - 2 * this.ethereumSlotDuration);
   }
 
   public get pipeliningAttestationGracePeriod(): number {
-    // Under the early-pipelining regime attestations complete inside the build
-    // slot itself, so there is no extra grace into the target slot.
-    return 0;
+    // Under the early-pipelining regime attestations complete inside the build slot itself. Local
+    // networks can publish much faster than the Ethereum slot geometry, so they may use the target
+    // slot attestation window without moving the L1 publish cutoff.
+    return this.l1PublishingTime < this.ethereumSlotDuration ? this.attestationWindowIntoTargetSlot : 0;
   }
 
   public get timeReservedAtEnd(): number {

--- a/yarn-project/stdlib/src/timetable/index.ts
+++ b/yarn-project/stdlib/src/timetable/index.ts
@@ -79,6 +79,7 @@ class CheckpointTimingModel implements PipelinedCheckpointTiming {
   public readonly l1PublishingTime: number;
   public readonly minExecutionTime: number;
   public readonly p2pPropagationTime: number;
+  private readonly ethereumSlotDuration: number;
 
   constructor(opts: CheckpointTimingConfig) {
     this.aztecSlotDuration = opts.aztecSlotDuration;
@@ -89,6 +90,7 @@ class CheckpointTimingModel implements PipelinedCheckpointTiming {
     this.l1PublishingTime = opts.l1PublishingTime ?? DEFAULT_L1_PUBLISHING_TIME;
     this.minExecutionTime = opts.minExecutionTime ?? MIN_EXECUTION_TIME;
     this.p2pPropagationTime = opts.p2pPropagationTime ?? DEFAULT_P2P_PROPAGATION_TIME;
+    this.ethereumSlotDuration = opts.ethereumSlotDuration ?? this.l1PublishingTime;
   }
 
   public get checkpointFinalizationTime(): number {
@@ -107,9 +109,11 @@ class CheckpointTimingModel implements PipelinedCheckpointTiming {
   }
 
   public get attestationWindowIntoTargetSlot(): number {
-    // Straggler grace: attestations aim to complete by build-slot end. Allow a
-    // small window into the target slot for late arrivals (round-trip p2p).
-    return 2 * this.p2pPropagationTime;
+    // Span from the target-slot start to the L1 publish deadline (12s before the last L1 block of
+    // the target slot). The p2p layer accepts slot-N attestations until right before the publish
+    // deadline so the proposer can keep collecting useful attestations up to the latest moment the
+    // checkpoint can still land on L1 in the target slot.
+    return this.aztecSlotDuration - 2 * this.ethereumSlotDuration;
   }
 
   public get pipeliningAttestationGracePeriod(): number {
@@ -145,13 +149,17 @@ class CheckpointTimingModel implements PipelinedCheckpointTiming {
   }
 
   public get checkpointAttestationDeadline(): number {
-    // Allowed to be into the next wallclock slot minus the allocated l1 publishing time
-    return this.aztecSlotDuration * 2 - this.l1PublishingTime;
+    // L1 publish deadline — 12s (one Ethereum slot) before the last L1 block of the target L2 slot;
+    // the latest the checkpoint can be submitted and still land on L1 in the target slot. This is an
+    // L1-geometry bound (ethereumSlotDuration), matching the publisher's send lead in sendRequestsAt
+    // (which also targets one Ethereum slot before the target slot start).
+    return this.aztecSlotDuration * 2 - this.ethereumSlotDuration;
   }
 
   public get checkpointPublishingDeadline(): number {
-    // Allowed to be into the next wallclock slot minus the allocated l1 Publishing time
-    return this.aztecSlotDuration * 2 - this.l1PublishingTime;
+    // L1 publish deadline — 12s (one Ethereum slot) before the last L1 block of the target L2 slot;
+    // the latest the checkpoint can be submitted and still land on L1 in the target slot.
+    return this.aztecSlotDuration * 2 - this.ethereumSlotDuration;
   }
 
   public calculateMaxBlocksPerSlot(): number {

--- a/yarn-project/validator-client/src/proposal_handler.test.ts
+++ b/yarn-project/validator-client/src/proposal_handler.test.ts
@@ -76,6 +76,7 @@ describe('ProposalHandler checkpoint validation', () => {
     epochCache.getL1Constants.mockReturnValue({
       l1GenesisTime: 0n,
       slotDuration: 24,
+      ethereumSlotDuration: 4,
       epochDuration: 8,
     } as L1RollupConstants);
 
@@ -272,6 +273,36 @@ describe('ProposalHandler checkpoint validation', () => {
 
       expect(archiver.addProposedCheckpoint).toHaveBeenCalled();
       expect(metrics.recordCheckpointProposalToPipelinedStateDuration).toHaveBeenCalledWith(expect.any(Number));
+    });
+
+    // The checkpoint-validation block-sync deadline is the L1 publish deadline (12s/one Ethereum
+    // slot before the last L1 block of the target slot), which is later than the target-slot start
+    // used for block re-execution. With slotDuration=24, ethereumSlotDuration=4 and proposal slot=1:
+    //   target_start                = timestamp(1)                      = 24s
+    //   old deadline (slot start)    = getReexecutionDeadline(1)         = 24s
+    //   new deadline (publish)       = getLastL1SlotTimestampForL2Slot(1) - E = 24 + 20 - 4 = 40s
+    // Holding wall-clock time at 30s (after the old deadline, before the new one) lets us tell the
+    // two apart: under the new deadline the handler still has budget to wait for the block to sync,
+    // so it gets past the sync wait; under the old deadline it would immediately time out.
+    it('uses the L1 publish deadline (not the target-slot start) for the block-sync wait', async () => {
+      const proposal = await makeProposal({ checkpointHeader: makeCheckpointHeader(0, { slotNumber: SlotNumber(1) }) });
+
+      // 30s into the epoch: past the old target-slot-start deadline (24s), before the publish one (40s).
+      dateProvider.setTime(30_000);
+
+      // Block is unavailable for the first couple of polls, then syncs in. Under the new (later)
+      // deadline the retry budget covers this; under the old deadline the wait would time out first.
+      blockSource.getBlockData
+        .mockResolvedValueOnce(undefined)
+        .mockResolvedValueOnce(undefined)
+        .mockResolvedValue({ checkpointNumber: CheckpointNumber(1) } as BlockData);
+      // No blocks for the slot, so validation stops right after the sync wait with a distinct reason.
+      blockSource.getBlocksForSlot.mockResolvedValue([]);
+
+      const result = await handler.handleCheckpointProposal(proposal, proposalInfo);
+
+      // Got past the block-sync wait (would be `last_block_not_found` under the old deadline).
+      expect(result).toEqual({ isValid: false, reason: 'no_blocks_for_slot', checkpointNumber: CheckpointNumber(1) });
     });
   });
 

--- a/yarn-project/validator-client/src/proposal_handler.ts
+++ b/yarn-project/validator-client/src/proposal_handler.ts
@@ -22,7 +22,7 @@ import { BlockProposalValidator } from '@aztec/p2p/msg_validators';
 import type { BlockData, L2Block, L2BlockSink, L2BlockSource } from '@aztec/stdlib/block';
 import type { CheckpointReexecutionTracker, ReexecutionOutcome } from '@aztec/stdlib/checkpoint';
 import { getPreviousCheckpointOutHashes, validateCheckpoint } from '@aztec/stdlib/checkpoint';
-import { getEpochAtSlot, getTimestampForSlot } from '@aztec/stdlib/epoch-helpers';
+import { getEpochAtSlot, getLastL1SlotTimestampForL2Slot, getTimestampForSlot } from '@aztec/stdlib/epoch-helpers';
 import { Gas } from '@aztec/stdlib/gas';
 import type { ITxProvider, ValidatorClientFullConfig, WorldStateSynchronizer } from '@aztec/stdlib/interfaces/server';
 import {
@@ -901,11 +901,15 @@ export class ProposalHandler {
   ): Promise<CheckpointProposalValidationResult> {
     const slot = proposal.slotNumber;
 
-    // Block-sync deadline = the moment the proposer can no longer publish this checkpoint to L1.
-    // The proposal is built one slot ahead (pipelining), so the publication deadline is the start
-    // of the target slot, as computed by `getReexecutionDeadline`.
-    const config = this.checkpointsBuilder.getConfig();
-    const deadline = this.getReexecutionDeadline(slot, config);
+    // Block-sync deadline = the L1 publish deadline, i.e. the latest moment the proposer can submit
+    // this checkpoint and still have it land on L1 in the target slot. That is 12s (one Ethereum
+    // slot) before the last L1 block of the target slot, which is later than the target-slot start
+    // used for block re-execution. Keeping validation/attestation alive until then lets validators
+    // keep attesting right up to the proposer's real publish cutoff.
+    const l1Constants = this.epochCache.getL1Constants();
+    const publishDeadlineSeconds =
+      Number(getLastL1SlotTimestampForL2Slot(slot, l1Constants)) - l1Constants.ethereumSlotDuration;
+    const deadline = new Date(publishDeadlineSeconds * 1000);
     const timeoutSeconds = Math.max(1, Math.floor((deadline.getTime() - this.dateProvider.now()) / 1000));
 
     // Wait for last block to sync by archive

--- a/yarn-project/validator-client/src/validator.test.ts
+++ b/yarn-project/validator-client/src/validator.test.ts
@@ -31,7 +31,7 @@ import { OffenseType, WANT_TO_CLEAR_SLASH_EVENT, WANT_TO_SLASH_EVENT } from '@az
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
 import { type BlockData, BlockHash, L2Block, type L2BlockSink, type L2BlockSource } from '@aztec/stdlib/block';
 import { type Checkpoint, CheckpointReexecutionTracker } from '@aztec/stdlib/checkpoint';
-import { type getEpochAtSlot, getTimestampForSlot } from '@aztec/stdlib/epoch-helpers';
+import { getTimestampForSlot } from '@aztec/stdlib/epoch-helpers';
 import type { SlasherConfig, WorldStateSynchronizer } from '@aztec/stdlib/interfaces/server';
 import { type L1ToL2MessageSource, computeInHashFromL1ToL2Messages } from '@aztec/stdlib/messaging';
 import type { BlockProposal } from '@aztec/stdlib/p2p';
@@ -130,9 +130,15 @@ describe('ValidatorClient', () => {
     epochCache = mock<EpochCache>();
 
     epochCache.filterInCommittee.mockImplementation((_slot, addresses) => Promise.resolve(addresses));
-    epochCache.getL1Constants.mockReturnValue({ epochDuration: 8 } satisfies Parameters<
-      typeof getEpochAtSlot
-    >[1] as any);
+    // Includes the L1 geometry fields read by the checkpoint-validation publish deadline
+    // (getLastL1SlotTimestampForL2Slot needs l1GenesisTime/slotDuration/ethereumSlotDuration), kept
+    // consistent with checkpointsBuilder.getConfig() above.
+    epochCache.getL1Constants.mockReturnValue({
+      epochDuration: 8,
+      l1GenesisTime: 1n,
+      slotDuration: 24,
+      ethereumSlotDuration: 12,
+    } as any);
     epochCache.getSlotNow.mockReturnValue(SlotNumber(1));
     epochCache.getEpochAndSlotNow.mockReturnValue({
       epoch: EpochNumber(1),


### PR DESCRIPTION
## Summary

Fixes timing bugs in block building and validation, now that proposer pipelining is the only production mode. Found via an audit of the sequencer timetable, checkpoint proposal job, validator client, proposal handler, and p2p proposal/attestation validators.

### The frame bug (main fix)

Under pipelining the proposer job runs with `slotNow = N-1` (build slot) and `targetSlot = N`. The job passed `targetSlot` to `setState` for build-frame states, so `Sequencer.setState` measured the `assertTimeLeft` deadlines against `getSlotStartBuildTimestamp(targetSlot)` — one full Aztec slot (72s) later than the build frame. The build-frame deadlines (`INITIALIZING_CHECKPOINT`, `CREATING_BLOCK`, `ASSEMBLING_CHECKPOINT`, `COLLECTING_ATTESTATIONS`, `PUBLISHING_CHECKPOINT`, …) were therefore checked ~72s too late and never fired. Now these states are measured against `slotNow`. `targetSlot` is still used for headers, signing, and `sendRequestsAt`.

### Aligning the attestation / publish windows around L1 geometry

- The checkpoint attestation/publish deadline and the p2p attestation acceptance window are now derived from `ethereumSlotDuration` — **one Ethereum slot (12s) before the last L1 block of the target slot**, the latest a checkpoint can be submitted and still land on L1 in its slot. Previously the deadline used the configurable `l1PublishingTime` and the p2p window was only `2 * p2pPropagationTime` (~4.5s into the target slot). This also unifies the deadline with the publisher's send lead (`sendRequestsAt` already targets one Ethereum slot before the target slot start).
- Validators (in `validateCheckpointProposal`) keep validating/attesting checkpoint proposals until that L1 publish deadline instead of the target-slot start, so attestations stay useful right up to the proposer's real publish cutoff. Block-proposal re-execution deadlines are intentionally left at the target-slot start.

### Why no test caught the frame bug

The job timing test built the job with `slotNow === targetSlot` (so the two frames coincided) and stubbed `setStateFn` with a no-op, mocking away the very `assertTimeLeft` enforcement where the frame matters. This PR adds:

- A contract test asserting every build-frame state is set against the build slot (`slotNow`), not the target slot.
- A behavioral test with a real enforcing `setStateFn`: a checkpoint whose assembly crosses the build-frame deadline is now correctly abandoned. Both fail on the pre-fix code and pass after the fix.
- Updated stdlib/timetable, clock-tolerance, attestation-validator, proposal-handler, and validator tests for the realigned windows (including an `l1PublishingTime != ethereumSlotDuration` case proving the deadline is now Ethereum-slot-based).

No constants were removed and no broader cleanup was done; that is deferred.

## Test plan

- `yarn build` green; touched packages lint/format clean.
- `@aztec/stdlib` timetable, `@aztec/sequencer-client` (incl. `timetable`, `checkpoint_proposal_job.timing`, `sequencer-publisher`), `@aztec/validator-client` (incl. `proposal_handler`, `validator`), and `@aztec/p2p` `msg_validators` suites pass.
