### PR TITLE
fix(p2p)!: revamp BLOCK_TXS validations

### DIFF
--- a/yarn-project/p2p/src/client/test/p2p_client.integration_block_txs.test.ts
+++ b/yarn-project/p2p/src/client/test/p2p_client.integration_block_txs.test.ts
@@ -182,7 +182,7 @@ describe('p2p client integration block txs protocol ', () => {
 
     expect(response.status).toBe(ReqRespStatus.SUCCESS);
     const blockTxsResponse = BlockTxsResponse.fromBuffer(response.data);
-    expect(blockTxsResponse.archiveRoot.equals(archiveRoot)).toBe(true);
+    expect(blockTxsResponse.peerHasBlock()).toBe(true);
     expect(blockTxsResponse.txs.length).toBe(requestedIndices.length);
     expect(blockTxsResponse.txIndices.getTrueIndices()).toEqual([0, 1, 2, 3, 4]);
 
@@ -218,7 +218,7 @@ describe('p2p client integration block txs protocol ', () => {
 
     expect(response.status).toBe(ReqRespStatus.SUCCESS);
     const blockTxsResponse = BlockTxsResponse.fromBuffer(response.data);
-    expect(blockTxsResponse.archiveRoot.equals(archiveRoot)).toBe(true);
+    expect(blockTxsResponse.peerHasBlock()).toBe(true);
     expect(blockTxsResponse.txs.length).toBe(2); // Only txs at indices 0 and 2 are returned
     expect(blockTxsResponse.txIndices.getTrueIndices()).toEqual([0, 2, 3]);
 
@@ -242,7 +242,7 @@ describe('p2p client integration block txs protocol ', () => {
 
     expect(response.status).toBe(ReqRespStatus.SUCCESS);
     const blockTxsResponse = BlockTxsResponse.fromBuffer(response.data);
-    expect(blockTxsResponse.archiveRoot.equals(archiveRoot)).toBe(true);
+    expect(blockTxsResponse.peerHasBlock()).toBe(true);
     expect(blockTxsResponse.txs.length).toBe(0);
     expect(blockTxsResponse.txIndices.getTrueIndices()).toEqual([]);
   });
@@ -267,7 +267,7 @@ describe('p2p client integration block txs protocol ', () => {
 
     expect(response.status).toBe(ReqRespStatus.SUCCESS);
     const blockTxsResponse = BlockTxsResponse.fromBuffer(response.data);
-    expect(blockTxsResponse.archiveRoot.equals(archiveRoot)).toBe(true);
+    expect(blockTxsResponse.peerHasBlock()).toBe(true);
     expect(blockTxsResponse.txs.length).toBe(requestedIndices.length);
     expect(blockTxsResponse.txIndices.getTrueIndices()).toEqual([0, 1, 2, 3, 4]);
 
@@ -304,7 +304,7 @@ describe('p2p client integration block txs protocol ', () => {
 
     expect(response.status).toBe(ReqRespStatus.SUCCESS);
     const blockTxsResponse = BlockTxsResponse.fromBuffer(response.data);
-    expect(blockTxsResponse.archiveRoot.equals(archiveRoot)).toBe(true);
+    expect(blockTxsResponse.peerHasBlock()).toBe(true);
     expect(blockTxsResponse.txs.length).toBe(2); // Only 2 txs returned
     expect(blockTxsResponse.txIndices.getTrueIndices()).toEqual([1, 3]); // Only indices 1 and 3 available
 
@@ -344,8 +344,8 @@ describe('p2p client integration block txs protocol ', () => {
     expect(response.status).toBe(ReqRespStatus.SUCCESS);
     const blockTxsResponse = BlockTxsResponse.fromBuffer(response.data);
 
-    // When peer doesn't have proposal but has txs, it returns Fr.ZERO as archive root
-    expect(blockTxsResponse.archiveRoot.equals(Fr.ZERO)).toBe(true);
+    // When the peer doesn't have the proposal but has txs, it signals so with an empty bitvector.
+    expect(blockTxsResponse.peerHasBlock()).toBe(false);
     expect(blockTxsResponse.txs.length).toBe(2); // Only 2 txs available
     expect(blockTxsResponse.txIndices.getLength()).toBe(0); // Empty BitVector when no proposal
 
@@ -374,7 +374,7 @@ describe('p2p client integration block txs protocol ', () => {
     expect(response.status).toBe(ReqRespStatus.SUCCESS);
     const blockTxsResponse = BlockTxsResponse.fromBuffer(response.data);
 
-    expect(blockTxsResponse.archiveRoot.equals(Fr.ZERO)).toBe(true);
+    expect(blockTxsResponse.peerHasBlock()).toBe(false);
     expect(blockTxsResponse.txs.length).toBe(1); // Only 1 tx available
     expect(blockTxsResponse.txIndices.getLength()).toBe(0);
 
@@ -396,7 +396,7 @@ describe('p2p client integration block txs protocol ', () => {
     expect(response.status).toBe(ReqRespStatus.SUCCESS);
     const blockTxsResponse = BlockTxsResponse.fromBuffer(response.data);
 
-    expect(blockTxsResponse.archiveRoot.equals(Fr.ZERO)).toBe(true);
+    expect(blockTxsResponse.peerHasBlock()).toBe(false);
     expect(blockTxsResponse.txs.length).toBe(0); // No txs available
     expect(blockTxsResponse.txIndices.getLength()).toBe(0);
   });
@@ -419,11 +419,12 @@ describe('p2p client integration block txs protocol ', () => {
     expect(response.status).toBe(ReqRespStatus.NOT_FOUND);
   });
 
-  // When the responder takes the Fr.zero branch (no proposal/archived block locally, but matched
-  // the requested hashes against its tx pool) it is acting correctly per block_txs_handler.ts:54-58.
-  // Drive the response back through the requester's real validation and confirm it does NOT apply
-  // a peer penalty — Fr.zero is a documented "I don't have the block" signal, not misbehavior.
-  it('requester does not penalize peer that returns Fr.zero (peer lacks proposal but matched by hash)', async () => {
+  // When the responder takes the "no proposal/archived block locally, but matched the requested
+  // hashes against its tx pool" branch it is acting correctly per block_txs_handler.ts:54-58, and
+  // signals so with an empty bitvector. Drive the response back through the requester's real
+  // validation and confirm it does NOT apply a peer penalty — this is an "I don't have the block"
+  // signal, not misbehavior.
+  it('requester does not penalize peer that lacks the proposal but matched txs by hash', async () => {
     attestationPool.getBlockProposalByArchive.mockResolvedValue(undefined);
     const hashToTx = new Map(txs.map((tx, i) => [txHashes[i].toString(), tx]));
     txPool.getTxsByHash.mockImplementation((hashes: TxHash[]) =>
@@ -435,7 +436,7 @@ describe('p2p client integration block txs protocol ', () => {
     const penalizeSpy = jest.spyOn(peerManager, 'penalizePeer');
 
     // Build and send a real reqresp BLOCK_TXS request over libp2p (includeFullTxHashes=true so
-    // the responder hits the Fr.zero branch instead of NOT_FOUND).
+    // the responder hits the "matched by hash" branch instead of NOT_FOUND).
     const requestedHashes = [txHashes[1], txHashes[3]];
     const sourceProposal = await createBlockProposal(blockNumber, Fr.random(), txHashes);
     const request = BlockTxsRequest.fromTxsSourceAndMissingTxs(sourceProposal, requestedHashes, true)!;
@@ -447,7 +448,7 @@ describe('p2p client integration block txs protocol ', () => {
 
     expect(response.status).toBe(ReqRespStatus.SUCCESS);
     const decoded = BlockTxsResponse.fromBuffer(response.data);
-    expect(decoded.archiveRoot.equals(Fr.ZERO)).toBe(true);
+    expect(decoded.peerHasBlock()).toBe(false);
 
     // Run the response through client1's real validation — this is what BatchTxRequester does in
     // production. The peer must not be penalized.

--- a/yarn-project/p2p/src/services/libp2p/libp2p_service.test.ts
+++ b/yarn-project/p2p/src/services/libp2p/libp2p_service.test.ts
@@ -317,15 +317,16 @@ describe('LibP2PService', () => {
   });
 
   describe('validateRequestedBlockTxsConsistency', () => {
-    function makeRequest(archiveRoot: Fr, length: number, indices: number[]): BlockTxsRequest {
-      return new BlockTxsRequest(archiveRoot, new TxHashArray(), BitVector.init(length, indices));
+    function makeRequest(archiveRoot: Fr, length: number, indices: number[], txHashes: string[] = []): BlockTxsRequest {
+      const hashes = txHashes.map(h => ({ toString: () => h })) as unknown as TxHashArray;
+      return new BlockTxsRequest(archiveRoot, hashes, BitVector.init(length, indices));
     }
 
-    function makeResponse(archiveRoot: Fr, length: number, indices: number[], txHashes: string[]): BlockTxsResponse {
+    function makeResponse(length: number, indices: number[], txHashes: string[]): BlockTxsResponse {
       const txs = txHashes.map(h => ({
         getTxHash: () => ({ toString: () => h }),
       })) as MockTx[];
-      return new BlockTxsResponse(archiveRoot, txs as TxArray, BitVector.init(length, indices));
+      return new BlockTxsResponse(txs as TxArray, BitVector.init(length, indices));
     }
 
     /** Builds a minimal archived block whose txEffects carry the given tx hashes, for archiver-fallback tests. */
@@ -348,52 +349,20 @@ describe('LibP2PService', () => {
       svc.setAttestationPool(mockAttestationPool);
     }
 
-    it('should penalize and reject on archive root mismatch', async () => {
-      const reqHash = Fr.random();
-      const otherHash = Fr.random();
-      const request = makeRequest(reqHash, 5, [0, 2]);
-      const response = makeResponse(otherHash, 5, [0, 2], []);
-
-      const ok = await service.validateRequestedBlockTxsConsistency(request, response, mockPeerId);
-      expect(ok).toBe(false);
-      expect(mockPeerManager.penalizePeer).toHaveBeenCalledWith(mockPeerId, PeerErrorSeverity.MidToleranceError);
-    });
-
-    it('should penalize and reject on bitvector length mismatch', async () => {
-      const hash = Fr.random();
-      const request = makeRequest(hash, 5, [0, 2]);
-      const response = makeResponse(hash, 4, [0, 2], []);
-
-      const ok = await service.validateRequestedBlockTxsConsistency(request, response, mockPeerId);
-      expect(ok).toBe(false);
-      expect(mockPeerManager.penalizePeer).toHaveBeenCalledWith(mockPeerId, PeerErrorSeverity.MidToleranceError);
-    });
-
     it('should penalize and reject on duplicate txs', async () => {
       const hash = Fr.random();
       const request = makeRequest(hash, 5, [0, 2, 3]);
-      const response = makeResponse(hash, 5, [0, 2, 3], ['0xaaa', '0xaaa']); // duplicate
+      const response = makeResponse(5, [0, 2, 3], ['0xaaa', '0xaaa']); // duplicate
 
       const ok = await service.validateRequestedBlockTxsConsistency(request, response, mockPeerId);
       expect(ok).toBe(false);
       expect(mockPeerManager.penalizePeer).toHaveBeenCalledWith(mockPeerId, PeerErrorSeverity.MidToleranceError);
     });
 
-    it('should penalize and reject when returned txs exceed requested intersect available', async () => {
+    it('should penalize and reject when a returned tx is not part of the block', async () => {
       const hash = Fr.random();
-      // requested indices [0,2], available [0] -> maxReturnable 1, but return 2
-      const request = makeRequest(hash, 3, [0, 2]);
-      const response = makeResponse(hash, 3, [0], ['0x1', '0x2']);
-
-      const ok = await service.validateRequestedBlockTxsConsistency(request, response, mockPeerId);
-      expect(ok).toBe(false);
-      expect(mockPeerManager.penalizePeer).toHaveBeenCalledWith(mockPeerId, PeerErrorSeverity.MidToleranceError);
-    });
-
-    it('should penalize and reject when proposal exists and a tx is not part of requested indices of proposal', async () => {
-      const hash = Fr.random();
-      const request = makeRequest(hash, 5, [0, 2, 4]); // requested 0,2,4
-      const response = makeResponse(hash, 5, [0, 2, 4], ['0xgood0', '0xbad']); // one bad
+      const request = makeRequest(hash, 5, [0, 2, 4]);
+      const response = makeResponse(5, [0, 2, 4], ['0xgood0', '0xbad']); // 0xbad is not in the block
 
       setProposalTxHashes(service, ['0xgood0', '0xgood2', '0xgood4', '0xother', '0xother2']);
 
@@ -402,36 +371,23 @@ describe('LibP2PService', () => {
       expect(mockPeerManager.penalizePeer).toHaveBeenCalledWith(mockPeerId, PeerErrorSeverity.LowToleranceError);
     });
 
-    it('should penalize and reject when proposal exists and a tx is from an unrequested index', async () => {
+    it('should penalize and reject on bitvector length mismatch when the peer has the block', async () => {
       const hash = Fr.random();
-      // Requested indices [0,2,4]; response advertises availability for [0,2,4]
-      const request = makeRequest(hash, 5, [0]);
-      // Return a tx that exists in the proposal but at an unrequested index (1)
-      const response = makeResponse(hash, 5, [0], ['0xother1']);
+      const request = makeRequest(hash, 5, [0, 2]);
+      // Peer claims to have the block (non-empty bitvector) but its length disagrees with the block size.
+      const response = makeResponse(4, [0, 2], []);
 
-      setProposalTxHashes(service, ['0xgood0', '0xother1', '0xgood2', '0xother3', '0xgood4']);
+      setProposalTxHashes(service, ['0xgood0', '0xgood1', '0xgood2', '0xgood3', '0xgood4']);
 
       const ok = await service.validateRequestedBlockTxsConsistency(request, response, mockPeerId);
       expect(ok).toBe(false);
-      expect(mockPeerManager.penalizePeer).toHaveBeenCalledWith(mockPeerId, PeerErrorSeverity.LowToleranceError);
+      expect(mockPeerManager.penalizePeer).toHaveBeenCalledWith(mockPeerId, PeerErrorSeverity.MidToleranceError);
     });
 
-    it('should accept when shapes match, count matches, and order matches proposal/requested indices', async () => {
+    it('should accept when all returned txs belong to the block and the bitvector length matches', async () => {
       const hash = Fr.random();
-      const request = makeRequest(hash, 5, [0, 2, 4]); // requested 0,2,4
-      const response = makeResponse(hash, 5, [0, 2, 4], ['0xgood0', '0xgood2', '0xgood4']); // all and in order
-
-      setProposalTxHashes(service, ['0xgood0', '0xother1', '0xgood2', '0xother3', '0xgood4']);
-
-      const ok = await service.validateRequestedBlockTxsConsistency(request, response, mockPeerId);
-      expect(ok).toBe(true);
-    });
-
-    it('should accept partial subset when proposal exists and order matches requested indices', async () => {
-      const hash = Fr.random();
-      // Request indices [0,2,4] but only return a subset [0,4]
       const request = makeRequest(hash, 5, [0, 2, 4]);
-      const response = makeResponse(hash, 5, [0, 2, 4], ['0xgood0', '0xgood4']); // partial, ordered 0 < 4
+      const response = makeResponse(5, [0, 2, 4], ['0xgood0', '0xgood2', '0xgood4']);
 
       setProposalTxHashes(service, ['0xgood0', '0xother1', '0xgood2', '0xother3', '0xgood4']);
 
@@ -440,11 +396,54 @@ describe('LibP2PService', () => {
       expect(mockPeerManager.penalizePeer).not.toHaveBeenCalled();
     });
 
-    it('should accept when requested intersect available is non-empty but zero txs are returned', async () => {
+    it('should accept a partial subset when the peer advertises only the txs it returns', async () => {
       const hash = Fr.random();
-      // requested [0,2], available [0,2] -> intersection size 2, but return 0 txs
+      // We request [0, 2, 4] but the peer only has (and advertises) [0, 4], returning those two.
+      const request = makeRequest(hash, 5, [0, 2, 4]);
+      const response = makeResponse(5, [0, 4], ['0xgood0', '0xgood4']);
+
+      setProposalTxHashes(service, ['0xgood0', '0xother1', '0xgood2', '0xother3', '0xgood4']);
+
+      const ok = await service.validateRequestedBlockTxsConsistency(request, response, mockPeerId);
+      expect(ok).toBe(true);
+      expect(mockPeerManager.penalizePeer).not.toHaveBeenCalled();
+    });
+
+    it('should accept when the peer returns only the requested txs it has, with more bits set than txs', async () => {
+      const hash = Fr.random();
+      // Block has txs a,b,c,d,e (indices 0..4). We ask for a,b,c ([0,1,2]); the peer has c,d,e
+      // (bitvector [2,3,4]). The only requested-and-available tx is c, so the response carries a
+      // single tx but advertises three available indices.
+      const request = makeRequest(hash, 5, [0, 1, 2]);
+      const response = makeResponse(5, [2, 3, 4], ['0xc']);
+
+      setProposalTxHashes(service, ['0xa', '0xb', '0xc', '0xd', '0xe']);
+
+      const ok = await service.validateRequestedBlockTxsConsistency(request, response, mockPeerId);
+      expect(ok).toBe(true);
+      expect(mockPeerManager.penalizePeer).not.toHaveBeenCalled();
+    });
+
+    it('should accept txs requested by explicit hash even when they are not part of the block', async () => {
+      const hash = Fr.random();
+      // Block has a,b,c (indices 0,1,2). We request b via indices ([1]) and d via an explicit tx
+      // hash (d is not part of the block). The peer returns b and d, advertising index 1 for b.
+      const request = makeRequest(hash, 3, [1], ['0xd']);
+      const response = makeResponse(3, [1], ['0xb', '0xd']);
+
+      setProposalTxHashes(service, ['0xa', '0xb', '0xc']);
+
+      const ok = await service.validateRequestedBlockTxsConsistency(request, response, mockPeerId);
+      expect(ok).toBe(true);
+      expect(mockPeerManager.penalizePeer).not.toHaveBeenCalled();
+    });
+
+    it('should accept zero txs when the peer has the block but none of the requested indices', async () => {
+      const hash = Fr.random();
+      // We request [0, 2], but the peer only advertises availability for [1, 3] (txs we did not ask
+      // for). The intersection of requested-and-available is empty, so returning zero txs is fine.
       const request = makeRequest(hash, 5, [0, 2]);
-      const response = makeResponse(hash, 5, [0, 2], []); // empty response.txs
+      const response = makeResponse(5, [1, 3], []);
 
       setProposalTxHashes(service, ['0xgood0', '0xother1', '0xgood2', '0xother3', '0xother4']);
 
@@ -453,37 +452,14 @@ describe('LibP2PService', () => {
       expect(mockPeerManager.penalizePeer).not.toHaveBeenCalled();
     });
 
-    it('penalizes and rejects when requested intersect available is empty but response returns txs', async () => {
+    it('should penalize and reject when the peer advertises a requested tx but does not return it', async () => {
       const hash = Fr.random();
-      // requested [1], available [] -> intersection 0, but non-empty txs returned
-      const request = makeRequest(hash, 3, [1]);
-      const response = makeResponse(hash, 3, [], ['0xsome']);
+      // We request [0, 2] and the peer claims to have both (bitvector [0, 2]), but only returns the
+      // tx at index 0 — withholding the one at index 2 it advertised.
+      const request = makeRequest(hash, 3, [0, 2]);
+      const response = makeResponse(3, [0, 2], ['0xgood0']);
 
-      const ok = await service.validateRequestedBlockTxsConsistency(request, response, mockPeerId);
-      expect(ok).toBe(false);
-      expect(mockPeerManager.penalizePeer).toHaveBeenCalledWith(mockPeerId, PeerErrorSeverity.MidToleranceError);
-    });
-
-    it('should penalize and reject when order does not match proposal/requested indices', async () => {
-      const hash = Fr.random();
-      const request = makeRequest(hash, 5, [0, 2, 4]); // requested 0,2,4
-      // Out of order relative to indices [0,2,4]
-      const response = makeResponse(hash, 5, [0, 2, 4], ['0xgood4', '0xgood0', '0xgood2']);
-
-      setProposalTxHashes(service, ['0xgood0', '0xother1', '0xgood2', '0xother3', '0xgood4']);
-
-      const ok = await service.validateRequestedBlockTxsConsistency(request, response, mockPeerId);
-      expect(ok).toBe(false);
-      expect(mockPeerManager.penalizePeer).toHaveBeenCalledWith(mockPeerId, PeerErrorSeverity.LowToleranceError);
-    });
-
-    it('should penalize and reject when partial subset is unordered relative to requested indices', async () => {
-      const hash = Fr.random();
-      const request = makeRequest(hash, 5, [0, 2, 4]); // requested 0,2,4
-      // Return only a subset but swap order (4 before 0)
-      const response = makeResponse(hash, 5, [0, 2, 4], ['0xgood4', '0xgood0']);
-
-      setProposalTxHashes(service, ['0xgood0', '0xother1', '0xgood2', '0xother3', '0xgood4']);
+      setProposalTxHashes(service, ['0xgood0', '0xother1', '0xgood2']);
 
       const ok = await service.validateRequestedBlockTxsConsistency(request, response, mockPeerId);
       expect(ok).toBe(false);
@@ -494,10 +470,10 @@ describe('LibP2PService', () => {
       const hash = Fr.random();
       // Simple valid shape that should pass pre-checks
       const request = makeRequest(hash, 3, [0, 2]);
-      const response = makeResponse(hash, 3, [0, 2], ['0xgood0']);
+      const response = makeResponse(3, [0, 2], ['0xgood0']);
 
       // Neither the attestation pool nor the archiver knows this block, so we cannot verify the
-      // membership/order of the returned txs. This is not a peer fault, so no penalty is applied.
+      // membership of the returned txs. This is not a peer fault, so no penalty is applied.
       const mockAttestationPool: MockAttestationPoolForTests = {
         getBlockProposalByArchive: (_: string) => Promise.resolve(undefined),
       };
@@ -516,7 +492,7 @@ describe('LibP2PService', () => {
     it('should accept when the proposal is missing but the block is known via the archiver', async () => {
       const hash = Fr.random();
       const request = makeRequest(hash, 5, [0, 2, 4]);
-      const response = makeResponse(hash, 5, [0, 2, 4], ['0xgood0', '0xgood2', '0xgood4']);
+      const response = makeResponse(5, [0, 2, 4], ['0xgood0', '0xgood2', '0xgood4']);
 
       // No proposal (the prover never received it), but the mined block is in the archiver.
       service.setAttestationPool({ getBlockProposalByArchive: (_: string) => Promise.resolve(undefined) });
@@ -530,19 +506,34 @@ describe('LibP2PService', () => {
       expect(mockArchiver.getBlock).toHaveBeenCalledWith({ archive: hash });
     });
 
-    // The reqresp BLOCK_TXS responder (block_txs_handler.ts:54-58) returns archiveRoot=Fr.ZERO
-    // when it doesn't have the block in either the attestation pool or the archiver, but the
-    // request carried full tx hashes — it matches them against its pool and ships whatever it
-    // finds. This is a documented "I don't have the block" signal, not misbehavior, so the
-    // requester must not penalize the peer for it.
-    it('should not penalize a peer that signals lacking the block with Fr.ZERO archive root', async () => {
+    // Regression test for the former bug: a peer that lacks the block answers with an empty bitvector
+    // (the "I don't have the block" signal from block_txs_handler.ts) but still ships the txs it matched
+    // by hash. The old validator rejected any such response, discarding perfectly good txs. The fix
+    // must accept the response (so the txs are used) while leaving the dumb-marking to the requester.
+    it('should accept (and use) txs from a peer that signals it lacks the block via an empty bitvector', async () => {
       const hash = Fr.random();
       const request = makeRequest(hash, 3, [0, 2]);
-      const response = makeResponse(Fr.ZERO, 0, [], ['0xfound0', '0xfound2']);
+      // Empty bitvector -> peerHasBlock() is false, but the returned txs are valid block txs.
+      const response = makeResponse(0, [], ['0xfound0', '0xfound2']);
 
-      await service.validateRequestedBlockTxsConsistency(request, response, mockPeerId);
+      // We know the block locally, so we can still validate that the returned txs belong to it.
+      setProposalTxHashes(service, ['0xfound0', '0xother1', '0xfound2']);
 
+      const ok = await service.validateRequestedBlockTxsConsistency(request, response, mockPeerId);
+      expect(ok).toBe(true);
       expect(mockPeerManager.penalizePeer).not.toHaveBeenCalled();
+    });
+
+    it('should still penalize a block-lacking peer (empty bitvector) that returns a tx not in the block', async () => {
+      const hash = Fr.random();
+      const request = makeRequest(hash, 3, [0, 2]);
+      const response = makeResponse(0, [], ['0xfound0', '0xbad']); // 0xbad is not part of the block
+
+      setProposalTxHashes(service, ['0xfound0', '0xother1', '0xfound2']);
+
+      const ok = await service.validateRequestedBlockTxsConsistency(request, response, mockPeerId);
+      expect(ok).toBe(false);
+      expect(mockPeerManager.penalizePeer).toHaveBeenCalledWith(mockPeerId, PeerErrorSeverity.LowToleranceError);
     });
   });
 

--- a/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
+++ b/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
@@ -1540,81 +1540,65 @@ export class LibP2PService extends WithTracer implements P2PService {
     peerId: PeerId,
   ): Promise<boolean> {
     try {
-      // A response with archiveRoot=Fr.zero is the documented "I don't have the block" signal from
-      // reqRespBlockTxsHandler (block_txs_handler.ts:54-58): the peer lacked the block in its
-      // attestation pool and archiver, but matched the requested hashes against its tx pool and
-      // shipped what it found. This is legitimate behaviour, not misbehaviour — we just can't verify
-      // membership/order without the block, so we drop the response without penalising the peer.
-      if (response.archiveRoot.isZero()) {
-        this.logger.debug(`Peer ${peerId.toString()} signalled missing block with Fr.zero archive root`);
-        return false;
-      }
-
-      if (!response.archiveRoot.equals(request.archiveRoot)) {
-        this.peerManager.penalizePeer(peerId, PeerErrorSeverity.MidToleranceError);
-        throw new ValidationError(
-          `Received block txs for unexpected archive root: expected ${request.archiveRoot.toString()}, got ${response.archiveRoot.toString()}`,
-        );
-      }
-
-      if (response.txIndices.getLength() !== request.txIndices.getLength()) {
-        this.peerManager.penalizePeer(peerId, PeerErrorSeverity.MidToleranceError);
-        throw new ValidationError(
-          `Received block txs with mismatched bitvector length: expected ${request.txIndices.getLength()}, got ${response.txIndices.getLength()}`,
-        );
-      }
-
-      // Check no duplicates and not exceeding returnable count
-      const requestedIndices = new Set(request.txIndices.getTrueIndices());
-      const availableIndices = new Set(response.txIndices.getTrueIndices());
-      const maxReturnable = [...requestedIndices].filter(i => availableIndices.has(i)).length;
-
-      const returnedHashes = await Promise.all(response.txs.map(tx => tx.getTxHash().toString()));
+      // Check for duplicates txs (or hashes) in the response.
+      const returnedHashes = response.txs.map(tx => tx.getTxHash().toString());
       const uniqueReturned = new Set(returnedHashes.map(h => h.toString()));
       if (uniqueReturned.size !== returnedHashes.length) {
         this.peerManager.penalizePeer(peerId, PeerErrorSeverity.MidToleranceError);
         throw new ValidationError(`Received duplicate txs in block txs response`);
       }
-      if (response.txs.length > maxReturnable) {
-        this.peerManager.penalizePeer(peerId, PeerErrorSeverity.MidToleranceError);
-        throw new ValidationError(
-          `Received more txs (${response.txs.length}) than requested-and-available (${maxReturnable})`,
-        );
-      }
 
-      // To verify membership/order of the returned txs we need the canonical tx hash list for the
-      // block. Prefer the block proposal (held while a block is in flight), but fall back to the
-      // archiver for blocks we only know as mined — e.g. a prover collecting txs to prove a block it
-      // never received a proposal for. This mirrors the responder side (reqRespBlockTxsHandler),
-      // which serves from proposal-or-archiver.
+      // We get the block tx hashes from the proposal or the archiver.
       const proposal = await this.mempools.attestationPool.getBlockProposalByArchive(request.archiveRoot.toString());
       const blockTxHashes =
         proposal?.txHashes ??
         (await this.archiver.getBlock({ archive: request.archiveRoot }))?.body.txEffects.map(e => e.txHash);
 
-      if (blockTxHashes) {
-        // Build intersected indices
-        const intersectIdx = request.txIndices.getTrueIndices().filter(i => response.txIndices.isSet(i));
-
-        // Enforce subset membership and preserve increasing order by index.
-        const hashToIndexInBlock = new Map<string, number>(
-          blockTxHashes.map((h, i) => [h.toString(), i] as [string, number]),
-        );
-        const allowedIndexSet = new Set(intersectIdx);
-        const indices = returnedHashes.map(h => hashToIndexInBlock.get(h));
-        const allAllowed = indices.every(idx => idx !== undefined && allowedIndexSet.has(idx));
-        const strictlyIncreasing = indices.every((idx, i) => (i === 0 ? idx !== undefined : idx! > indices[i - 1]!));
-        if (!allAllowed || !strictlyIncreasing) {
-          this.peerManager.penalizePeer(peerId, PeerErrorSeverity.LowToleranceError);
-          throw new ValidationError('Returned txs do not match expected subset/order for requested indices');
-        }
-      } else {
+      // If we don't have the block, we can't verify membership/order of the returned txs.
+      if (!blockTxHashes) {
+        // This shouldn't happen, since we asked for the block (proposal).
         // Neither a local proposal nor an archived block: we cannot verify membership/order of the
         // returned txs. This is a local-state gap, not a peer fault, so we do not penalize.
         this.logger.warn(
           `Block ${request.archiveRoot.toString()} not found in attestation pool or archiver; cannot validate membership/order of returned txs`,
         );
+        // NOTE: We mark the response as invalid, given the limitations of a true/false return value.
         return false;
+      }
+
+      // Verify that the returned tx hashes are a subset of (block tx hashes) U (requested tx hashes).
+      const uniqueRequestedHashes = new Set([
+        ...blockTxHashes.map(h => h.toString()),
+        ...request.txHashes.map(h => h.toString()),
+      ]);
+      if (!returnedHashes.every(h => uniqueRequestedHashes.has(h))) {
+        this.peerManager.penalizePeer(peerId, PeerErrorSeverity.LowToleranceError);
+        throw new ValidationError('Returned txs do not match expected subset of requested tx hashes');
+      }
+
+      // Tx indices information is optional, but if present, we need to verify a few things.
+      if (!response.peerHasBlock()) {
+        this.logger.debug(`Peer ${peerId.toString()} signalled missing block`);
+        return true;
+      }
+
+      // If the response has a non-empty bitvector, it needs to be consistent with the number of txs in the block.
+      if (response.txIndices.getLength() !== blockTxHashes.length) {
+        this.peerManager.penalizePeer(peerId, PeerErrorSeverity.MidToleranceError);
+        throw new ValidationError(
+          `Received block txs with mismatched bitvector length: expected ${blockTxHashes.length}, got ${response.txIndices.getLength()}`,
+        );
+      }
+
+      // For every index we requested that the peer claims to have (per its bitvector), the
+      // corresponding tx must be present in the response. A peer advertising availability but
+      // withholding the tx is inconsistent.
+      const returnedHashSet = new Set(returnedHashes);
+      const expectedIndices = request.txIndices.getTrueIndices().filter(i => response.txIndices.isSet(i));
+      const missingExpected = expectedIndices.some(i => !returnedHashSet.has(blockTxHashes[i].toString()));
+      if (missingExpected) {
+        this.peerManager.penalizePeer(peerId, PeerErrorSeverity.LowToleranceError);
+        throw new ValidationError('Peer advertised requested txs via indices but did not return them');
       }
 
       return true;

--- a/yarn-project/p2p/src/services/reqresp/batch-tx-requester/batch_tx_requester.test.ts
+++ b/yarn-project/p2p/src/services/reqresp/batch-tx-requester/batch_tx_requester.test.ts
@@ -263,7 +263,6 @@ describe('BatchTxRequester', () => {
         const availableTxs = availableTxHashes.map(h => makeTx(h));
 
         const response = new BlockTxsResponse(
-          blockProposal.archive,
           new TxArray(...availableTxs),
           BitVector.init(blockProposal.txHashes.length, peerHasIndices),
         );
@@ -625,7 +624,6 @@ describe('BatchTxRequester', () => {
 
         const someTxs = missing.slice(0, missing.length / 2).map(h => makeTx(h));
         const response = new BlockTxsResponse(
-          blockProposal.archive,
           new TxArray(...someTxs),
           BitVector.init(blockProposal.txHashes.length, []),
         );
@@ -714,7 +712,6 @@ describe('BatchTxRequester', () => {
         // peer1: always succeeds
         if (peerStr === peers[1].toString()) {
           const response = new BlockTxsResponse(
-            blockProposal.archive,
             new TxArray(...availableTxs),
             BitVector.init(blockProposal.txHashes.length, availableIndices),
           );
@@ -733,7 +730,6 @@ describe('BatchTxRequester', () => {
             };
           }
           const response = new BlockTxsResponse(
-            blockProposal.archive,
             new TxArray(...availableTxs),
             BitVector.init(blockProposal.txHashes.length, availableIndices),
           );
@@ -877,7 +873,6 @@ describe('BatchTxRequester', () => {
         const availableTxs = availableTxHashes.map(h => makeTx(h));
 
         const response = new BlockTxsResponse(
-          blockProposal.archive,
           new TxArray(...availableTxs),
           BitVector.init(blockProposal.txHashes.length, peerHasIndices),
         );
@@ -1067,7 +1062,6 @@ describe('BatchTxRequester', () => {
         const availableTxs = availableTxHashes.map(h => makeTx(h));
 
         const response = new BlockTxsResponse(
-          blockProposal.archive,
           new TxArray(...availableTxs),
           BitVector.init(blockProposal.txHashes.length, peerHasIndices),
         );
@@ -1582,7 +1576,6 @@ describe('BatchTxRequester', () => {
         const availableTxs = availableTxHashes.map(h => makeTx(h));
 
         const response = new BlockTxsResponse(
-          blockProposal.archive,
           new TxArray(...availableTxs),
           BitVector.init(blockProposal.txHashes.length, peerHasIndices),
         );
@@ -1767,11 +1760,7 @@ describe('BatchTxRequester', () => {
 
             return {
               status: ReqRespStatus.SUCCESS,
-              data: new BlockTxsResponse(
-                blockProposal.archive,
-                new TxArray(...availableTxs),
-                BitVector.init(txCount, allIndices),
-              ).toBuffer(),
+              data: new BlockTxsResponse(new TxArray(...availableTxs), BitVector.init(txCount, allIndices)).toBuffer(),
             };
           }
           // Subsequent smart requests return NOT_FOUND (pruned proposal, no full hashes in request)
@@ -1786,11 +1775,7 @@ describe('BatchTxRequester', () => {
 
         return {
           status: ReqRespStatus.SUCCESS,
-          data: new BlockTxsResponse(
-            blockProposal.archive,
-            new TxArray(...availableTxs),
-            BitVector.init(txCount, allIndices),
-          ).toBuffer(),
+          data: new BlockTxsResponse(new TxArray(...availableTxs), BitVector.init(txCount, allIndices)).toBuffer(),
         };
       });
 
@@ -1822,7 +1807,7 @@ describe('BatchTxRequester', () => {
       expect(peer0Penalties).toHaveLength(0);
     });
 
-    it('should demote a smart peer when it responds with invalid block data', async () => {
+    it('should demote a smart peer to dumb (without penalising) when it stops advertising the block', async () => {
       const txCount = 2 * TX_BATCH_SIZE;
       const deadline = 5_000;
       const missing = Array.from({ length: txCount }, () => TxHash.random());
@@ -1858,18 +1843,15 @@ describe('BatchTxRequester', () => {
 
             return {
               status: ReqRespStatus.SUCCESS,
-              data: new BlockTxsResponse(
-                blockProposal.archive,
-                new TxArray(...availableTxs),
-                BitVector.init(txCount, allIndices),
-              ).toBuffer(),
+              data: new BlockTxsResponse(new TxArray(...availableTxs), BitVector.init(txCount, allIndices)).toBuffer(),
             };
           }
 
-          // Subsequent smart requests: invalid block response (pruned proposal fallback)
+          // Subsequent smart requests: a zero-length bitvector signals the peer no longer has the
+          // block (a full-length all-zeros vector would instead mean "has the block, but no txs").
           return {
             status: ReqRespStatus.SUCCESS,
-            data: new BlockTxsResponse(Fr.zero(), new TxArray(), BitVector.init(txCount, [])).toBuffer(),
+            data: new BlockTxsResponse(new TxArray(), BitVector.init(0, [])).toBuffer(),
           };
         }
 
@@ -1881,11 +1863,7 @@ describe('BatchTxRequester', () => {
 
         return {
           status: ReqRespStatus.SUCCESS,
-          data: new BlockTxsResponse(
-            blockProposal.archive,
-            new TxArray(...availableTxs),
-            BitVector.init(txCount, allIndices),
-          ).toBuffer(),
+          data: new BlockTxsResponse(new TxArray(...availableTxs), BitVector.init(txCount, allIndices)).toBuffer(),
         };
       });
 
@@ -1908,108 +1886,13 @@ describe('BatchTxRequester', () => {
       const results = await BatchTxRequester.collectAllTxs(requester.run());
       expect(results).toHaveLength(txCount);
 
-      // Verify peer0 was first promoted to smart, then demoted on invalid block response (Fr.zero)
+      // Verify peer0 was first promoted to smart, then demoted once it stopped advertising the block
       expect(peerCollection.smartPeersMarked).toContain(peers[0].toString());
       expect(peerCollection.peersMarkedDumb).toContain(peers[0].toString());
 
-      // Fr.zero is a legitimate pruned-proposal response — peer should NOT be penalised
+      // A peer that lacks the block is in a legitimate state — it should NOT be penalised
       const peer0Penalties = peerCollection.peersPenalised.filter(e => e.peerId === peers[0].toString());
       expect(peer0Penalties).toHaveLength(0);
-    });
-
-    it('should penalise a smart peer that responds with a non-zero archive root mismatch', async () => {
-      const txCount = 2 * TX_BATCH_SIZE;
-      const deadline = 5_000;
-      const missing = Array.from({ length: txCount }, () => TxHash.random());
-
-      blockProposal = await makeBlockProposal({
-        signer: Secp256k1Signer.random(),
-        blockHeader: makeBlockHeader(1, { blockNumber: BlockNumber(1) }),
-        archiveRoot: Fr.random(),
-        txHashes: missing,
-      });
-
-      const peers = await Promise.all([createSecp256k1PeerId(), createSecp256k1PeerId()]);
-      connectionSampler.getPeerListSortedByConnectionCountAsc.mockReturnValue(peers);
-
-      const peerCollection = new TestPeerCollection(
-        new PeerCollection(connectionSampler, undefined, new DateProvider()),
-      );
-
-      const allIndices = Array.from({ length: txCount }, (_, i) => i);
-
-      let peer0RequestCount = 0;
-      reqResp.sendRequestToPeer.mockImplementation(async (peerId: any, _sub: any, data: any) => {
-        const peerStr = peerId.toString();
-
-        if (peerStr === peers[0].toString()) {
-          peer0RequestCount++;
-
-          if (peer0RequestCount === 1) {
-            // First dumb request: valid response claiming all txs → promoted to smart
-            const request = BlockTxsRequest.fromBuffer(data);
-            const requestedIndices = request.txIndices.getTrueIndices();
-            const availableTxs = requestedIndices.map(idx => makeTx(blockProposal.txHashes[idx]));
-
-            return {
-              status: ReqRespStatus.SUCCESS,
-              data: new BlockTxsResponse(
-                blockProposal.archive,
-                new TxArray(...availableTxs),
-                BitVector.init(txCount, allIndices),
-              ).toBuffer(),
-            };
-          }
-
-          // Subsequent smart requests: non-zero archive root mismatch (malicious response)
-          return {
-            status: ReqRespStatus.SUCCESS,
-            data: new BlockTxsResponse(Fr.random(), new TxArray(), BitVector.init(txCount, [])).toBuffer(),
-          };
-        }
-
-        // peer1 always succeeds with a delay
-        await sleep(50);
-        const request = BlockTxsRequest.fromBuffer(data);
-        const requestedIndices = request.txIndices.getTrueIndices();
-        const availableTxs = requestedIndices.map(idx => makeTx(blockProposal.txHashes[idx]));
-
-        return {
-          status: ReqRespStatus.SUCCESS,
-          data: new BlockTxsResponse(
-            blockProposal.archive,
-            new TxArray(...availableTxs),
-            BitVector.init(txCount, allIndices),
-          ).toBuffer(),
-        };
-      });
-
-      const tracker = RequestTracker.create(missing, new Date(Date.now() + deadline));
-      const requester = new BatchTxRequester(
-        tracker,
-        blockProposal,
-        undefined,
-        mockP2PService,
-        logger,
-        new DateProvider(),
-        {
-          smartParallelWorkerCount: 1,
-          dumbParallelWorkerCount: 1,
-          peerCollection,
-          txValidator,
-        },
-      );
-
-      const results = await BatchTxRequester.collectAllTxs(requester.run());
-      expect(results).toHaveLength(txCount);
-
-      // Verify peer0 was promoted then demoted
-      expect(peerCollection.smartPeersMarked).toContain(peers[0].toString());
-      expect(peerCollection.peersMarkedDumb).toContain(peers[0].toString());
-
-      // Non-zero archive root mismatch is malicious — peer must be penalised
-      const peer0Penalties = peerCollection.peersPenalised.filter(e => e.peerId === peers[0].toString());
-      expect(peer0Penalties.length).toBeGreaterThan(0);
     });
   });
 
@@ -2050,7 +1933,6 @@ describe('BatchTxRequester', () => {
         return Promise.resolve({
           status: ReqRespStatus.SUCCESS,
           data: new BlockTxsResponse(
-            blockProposal.archive,
             new TxArray(...availableTxs),
             BitVector.init(txCount, requestedIndices),
           ).toBuffer(),
@@ -2086,6 +1968,71 @@ describe('BatchTxRequester', () => {
       // …but NOT penalised — failed consistency yields INTERNAL_ERROR, not a penalty cause.
       const peer0Penalties = peerCollection.peersPenalised.filter(e => e.peerId === peers[0].toString());
       expect(peer0Penalties).toHaveLength(0);
+    });
+
+    // Regression test for the former bug: a peer that signals it lacks the block (empty bitvector)
+    // but still ships the txs it matched by hash used to have its whole response discarded. The
+    // requester must instead USE those txs and merely mark the peer dumb (it can't serve index-based
+    // smart requests), without penalising it.
+    it('uses the txs from a peer that lacks the block (empty bitvector) and marks it dumb', async () => {
+      const txCount = TX_BATCH_SIZE;
+      const deadline = 5_000;
+      const missing = Array.from({ length: txCount }, () => TxHash.random());
+
+      blockProposal = await makeBlockProposal({
+        signer: Secp256k1Signer.random(),
+        blockHeader: makeBlockHeader(1, { blockNumber: BlockNumber(1) }),
+        archiveRoot: Fr.random(),
+        txHashes: missing,
+      });
+
+      const peers = await Promise.all([createSecp256k1PeerId()]);
+      connectionSampler.getPeerListSortedByConnectionCountAsc.mockReturnValue(peers);
+
+      const peerCollection = new TestPeerCollection(
+        new PeerCollection(connectionSampler, undefined, new DateProvider()),
+      );
+
+      // The validator accepts the response: a valid subset of block txs is fine even when the peer
+      // signals it lacks the block.
+      mockP2PService.validateRequestedBlockTxsConsistency.mockResolvedValue(true);
+
+      // The peer ships the requested txs but with an EMPTY bitvector -> peerHasBlock() === false.
+      reqResp.sendRequestToPeer.mockImplementation((_peerId: any, _sub: any, data: any) => {
+        const request = BlockTxsRequest.fromBuffer(data);
+        const requestedIndices = request.txIndices.getTrueIndices();
+        const availableTxs = requestedIndices.map(idx => makeTx(blockProposal.txHashes[idx]));
+
+        return Promise.resolve({
+          status: ReqRespStatus.SUCCESS,
+          data: new BlockTxsResponse(new TxArray(...availableTxs), BitVector.init(0, [])).toBuffer(),
+        });
+      });
+
+      const requester = new BatchTxRequester(
+        RequestTracker.create(missing, new Date(Date.now() + deadline)),
+        blockProposal,
+        undefined,
+        mockP2PService,
+        logger,
+        new DateProvider(),
+        {
+          smartParallelWorkerCount: 1,
+          dumbParallelWorkerCount: 1,
+          peerCollection,
+          txValidator,
+        },
+      );
+
+      const results = await BatchTxRequester.collectAllTxs(requester.run());
+
+      // The core of the regression: the txs were USED (delivered), not discarded.
+      expect(results).toHaveLength(txCount);
+
+      // The peer is marked dumb (it can't serve smart, index-based requests) but is NOT penalised.
+      expect(peerCollection.peersMarkedDumb).toContain(peers[0].toString());
+      const peerPenalties = peerCollection.peersPenalised.filter(e => e.peerId === peers[0].toString());
+      expect(peerPenalties).toHaveLength(0);
     });
   });
 });
@@ -2382,7 +2329,6 @@ const createRequestLogger = (
     const availableTxs = availableTxHashes.map(h => makeTx(h));
 
     const response = new BlockTxsResponse(
-      blockProposal.archive,
       new TxArray(...availableTxs),
       BitVector.init(blockProposal.txHashes.length, peerHasIndices),
     );

--- a/yarn-project/p2p/src/services/reqresp/batch-tx-requester/batch_tx_requester.ts
+++ b/yarn-project/p2p/src/services/reqresp/batch-tx-requester/batch_tx_requester.ts
@@ -564,9 +564,10 @@ export class BatchTxRequester {
       return;
     }
 
-    const hasArchiveRootMismatch = this.blockTxsSource.archive.toString() !== response.archiveRoot.toString();
-    if (hasArchiveRootMismatch) {
-      this.handleArchiveRootMismatch(peerId, response);
+    // If the peer doesn't have the block, we mark them as dumb.
+    if (!response.peerHasBlock()) {
+      this.peers.markPeerDumb(peerId);
+      this.txsMetadata.clearPeerData(peerId);
       return;
     }
 
@@ -582,21 +583,6 @@ export class BatchTxRequester {
 
     // Unblock smart workers
     this.smartRequesterSemaphore.release();
-  }
-
-  /**
-   * Handles an archive root mismatch between local state and peer response.
-   *
-   * - Response archive is Fr.ZERO (peer pruned proposal, legitimate): marks peer dumb.
-   * - Non-zero archive mismatch (malicious response): penalises + marks dumb.
-   */
-  private handleArchiveRootMismatch(peerId: PeerId, response: BlockTxsResponse): void {
-    if (!response.archiveRoot.isZero()) {
-      this.peers.penalisePeer(peerId, PeerErrorSeverity.LowToleranceError);
-    }
-
-    this.peers.markPeerDumb(peerId);
-    this.txsMetadata.clearPeerData(peerId);
   }
 
   private peerHasSomeTxsWeAreMissing(_peerId: PeerId, response: BlockTxsResponse): boolean {

--- a/yarn-project/p2p/src/services/reqresp/protocols/block_txs/block_txs.test.ts
+++ b/yarn-project/p2p/src/services/reqresp/protocols/block_txs/block_txs.test.ts
@@ -142,18 +142,17 @@ describe('BlockTxRequest', () => {
 
 describe('BlockTxResponse', () => {
   it('should serialize and deserialize correctly', async () => {
-    const archiveRoot = Fr.random();
     const txs = new TxArray(await mockTx(), await mockTx(), await mockTx());
     const txIndices = BitVector.init(8, [0, 2, 5]);
 
-    const original = new BlockTxsResponse(archiveRoot, txs, txIndices);
+    const original = new BlockTxsResponse(txs, txIndices);
     const buffer = original.toBuffer();
     const deserialized = BlockTxsResponse.fromBuffer(buffer);
 
-    expect(deserialized.archiveRoot).toEqual(original.archiveRoot);
     expect(deserialized.txs.length).toBe(original.txs.length);
     expect(deserialized.txIndices.getLength()).toBe(original.txIndices.getLength());
     expect(deserialized.txIndices.getTrueIndices()).toEqual(original.txIndices.getTrueIndices());
+    expect(deserialized.peerHasBlock()).toBe(true);
 
     // Make sure we calculate transaction hashes before comparison
     await Promise.all([...original.txs.map(tx => tx.getTxHash()), ...deserialized.txs.map(tx => tx.getTxHash())]);
@@ -163,17 +162,24 @@ describe('BlockTxResponse', () => {
   });
 
   it('should handle empty response', () => {
-    const archiveRoot = Fr.random();
     const txs = new TxArray(); // No transactions
     const txIndices = BitVector.init(10, []); // No indices
 
-    const original = new BlockTxsResponse(archiveRoot, txs, txIndices);
+    const original = new BlockTxsResponse(txs, txIndices);
     const buffer = original.toBuffer();
     const deserialized = BlockTxsResponse.fromBuffer(buffer);
 
-    expect(deserialized.archiveRoot).toEqual(archiveRoot);
     expect(deserialized.txs.length).toBe(0);
     expect(deserialized.txIndices.getTrueIndices()).toEqual([]);
+    // A non-empty bitvector (length 10) still signals the peer has the block, just none of these txs.
+    expect(deserialized.peerHasBlock()).toBe(true);
+  });
+
+  it('peerHasBlock is false when the bitvector is empty', () => {
+    // This is the "I don't have the block but matched your hashes" signal from the responder.
+    const response = new BlockTxsResponse(new TxArray(), BitVector.init(0, []));
+    expect(response.peerHasBlock()).toBe(false);
+    expect(BlockTxsResponse.empty().peerHasBlock()).toBe(false);
   });
 });
 

--- a/yarn-project/p2p/src/services/reqresp/protocols/block_txs/block_txs_handler.test.ts
+++ b/yarn-project/p2p/src/services/reqresp/protocols/block_txs/block_txs_handler.test.ts
@@ -71,7 +71,8 @@ describe('reqRespBlockTxsHandler', () => {
       const response = await callHandler(request);
 
       expect(response.txs.length).toBe(2);
-      expect(response.archiveRoot).toEqual(Fr.zero());
+      // An empty bitvector signals the peer did not have the block (only matched the requested hashes).
+      expect(response.peerHasBlock()).toBe(false);
     });
 
     it('returns empty when txs not in pool', async () => {
@@ -98,7 +99,8 @@ describe('reqRespBlockTxsHandler', () => {
       const request = new BlockTxsRequest(proposal.archive, new TxHashArray(), BitVector.init(3, [0, 1, 2]));
       const response = await callHandler(request);
 
-      expect(response.archiveRoot).toEqual(proposal.archive);
+      // A non-empty bitvector signals the peer has the block.
+      expect(response.peerHasBlock()).toBe(true);
       expect(response.txs.length).toBe(3);
       expect(response.txIndices.getTrueIndices()).toEqual([0, 1, 2]);
     });
@@ -146,7 +148,7 @@ describe('reqRespBlockTxsHandler', () => {
       const request = new BlockTxsRequest(block.archive.root, new TxHashArray(), BitVector.init(3, [0, 1, 2]));
       const response = await callHandler(request);
 
-      expect(response.archiveRoot).toEqual(block.archive.root);
+      expect(response.peerHasBlock()).toBe(true);
       expect(response.txs.length).toBe(3);
       expect(response.txIndices.getTrueIndices()).toEqual([0, 1, 2]);
 

--- a/yarn-project/p2p/src/services/reqresp/protocols/block_txs/block_txs_handler.ts
+++ b/yarn-project/p2p/src/services/reqresp/protocols/block_txs/block_txs_handler.ts
@@ -1,4 +1,3 @@
-import { Fr } from '@aztec/foundation/curves/bn254';
 import type { L2BlockSource } from '@aztec/stdlib/block';
 import { TxArray } from '@aztec/stdlib/tx';
 
@@ -53,7 +52,7 @@ export function reqRespBlockTxsHandler(
     // But peer has sent requested tx hashes, so we can send them the transactions
     if (!txHashes && requestedTxsHashes !== undefined) {
       const responseTxs = (await txPool.getTxsByHash(requestedTxsHashes)).filter(tx => !!tx);
-      const response = new BlockTxsResponse(Fr.zero(), new TxArray(...responseTxs), BitVector.init(0, []));
+      const response = new BlockTxsResponse(new TxArray(...responseTxs), BitVector.init(0, []));
       return response.toBuffer();
     }
 
@@ -71,7 +70,7 @@ export function reqRespBlockTxsHandler(
     requestedTxsHashes = txHashes.filter((_, idx) => requestedIndices.has(idx));
 
     const responseTxs = (await txPool.getTxsByHash(requestedTxsHashes)).filter(tx => !!tx);
-    const response = new BlockTxsResponse(request.archiveRoot, new TxArray(...responseTxs), responseBitVector);
+    const response = new BlockTxsResponse(new TxArray(...responseTxs), responseBitVector);
 
     return response.toBuffer();
   };

--- a/yarn-project/p2p/src/services/reqresp/protocols/block_txs/block_txs_reqresp.ts
+++ b/yarn-project/p2p/src/services/reqresp/protocols/block_txs/block_txs_reqresp.ts
@@ -16,14 +16,14 @@ export interface BlockTxsSource {
  */
 export class BlockTxsRequest {
   constructor(
-    // Archive root after the proposed block is applied (proposal identifier)
+    // Archive root after the proposed block is applied (proposal identifier).
     readonly archiveRoot: Fr,
-    // Hashes of txs we are requesting
+    // Hashes of txs we are requesting (optional). Used as a fallback if the peer doesn't have the block.
+    // Note: if a hash here is NOT part of the block (proposal), the peer can decide to return it or not.
     readonly txHashes: TxHashArray,
-    // BitVector indicating which txs from the proposal we are requesting
-    // 1 means we want the tx, 0 means we don't
-    // If we know peer has the Block Proposal then we can use this BitVector
-    // Otherwise we can use this optimization
+    // BitVector indicating which txs from the block (proposal) we are requesting
+    // 1 means we want the tx, 0 means we don't.
+    // This will only return txs in the response if the peer has the block (proposal).
     readonly txIndices: BitVector,
   ) {}
 
@@ -91,12 +91,20 @@ export class BlockTxsRequest {
  */
 export class BlockTxsResponse {
   constructor(
-    readonly archiveRoot: Fr,
-    readonly txs: TxArray, // List of transactions we requested and peer has
+    // List of transactions we requested and peer has
+    readonly txs: TxArray,
     // BitVector indicating which txs from the proposal are available at the peer
     // 1 means the tx is available, 0 means it is not
     readonly txIndices: BitVector,
   ) {}
+
+  /**
+   * Whether the response indicates that the peer has the block.
+   * @returns True if the peer has the block, false otherwise.
+   */
+  peerHasBlock(): boolean {
+    return this.txIndices.getLength() > 0;
+  }
 
   /**
    * Deserializes the BlockTxResponse object from a Buffer
@@ -105,25 +113,22 @@ export class BlockTxsResponse {
    */
   static fromBuffer(buffer: Buffer | BufferReader): BlockTxsResponse {
     const reader = BufferReader.asReader(buffer);
-    const archiveRoot = Fr.fromBuffer(reader);
     const txs = TxArray.fromBuffer(reader);
     const txIndices = BitVector.fromBuffer(reader);
 
-    return new BlockTxsResponse(archiveRoot, txs, txIndices);
+    return new BlockTxsResponse(txs, txIndices);
   }
 
   /**
    * Serializes the BlockTxResponse object into a Buffer
-   * @dev: In current implementation, txIndices is serialized as Buffer of unknown length,
-   * thus we serialize it last
    * @returns Buffer representation of the BlockTxResponse object
    */
   toBuffer(): Buffer {
-    return serializeToBuffer([this.archiveRoot, this.txs.toBuffer(), this.txIndices.toBuffer()]);
+    return serializeToBuffer([this.txs.toBuffer(), this.txIndices.toBuffer()]);
   }
 
   static empty(): BlockTxsResponse {
-    return new BlockTxsResponse(Fr.ZERO, new TxArray(), BitVector.init(0, []));
+    return new BlockTxsResponse(new TxArray(), BitVector.init(0, []));
   }
 }
 


### PR DESCRIPTION
## Summary

`BLOCK_TXS` request/response validation had a bug that caused us to **discard perfectly good transactions**.

When a peer doesn't have the block (proposal pruned, or never received) but the request carried the full tx hashes, the responder (`reqRespBlockTxsHandler`) still matches those hashes against its own tx pool and ships whatever it finds — it just can't produce an availability bitvector for a block it doesn't know about. This is a legitimate "I don't have the block, but here are the txs you asked for by hash" response, not misbehaviour.

Previously this case was signalled by setting `archiveRoot = Fr.ZERO` on the response, and `validateRequestedBlockTxsConsistency` treated any response that didn't echo the requested archive root (including the zero case) as a hard failure: it returned `false`, which routed the response through the `INTERNAL_ERROR` path and discarded the returned txs entirely. The intended behaviour is the opposite — we want to **use** the txs the peer returned and merely mark the peer as "dumb" (it can't serve index-based smart requests), without penalising it.

## Changes

**Drop `archiveRoot` from `BlockTxsResponse`.**
- The archive root on the response only ever served as an out-of-band "I have / don't have the block" flag (and a redundant echo of the request).
- Checking if the response matches the request doesn't make sense. A cheating peer can always return the same archive root as the request, but otherwise malform the rest of the response.
- It is replaced by a `peerHasBlock()` helper that derives the same signal from the availability bitvector: an empty bitvector (length 0) means the peer doesn't have the block. The responder no longer special-cases the archive root.

**Rework `validateRequestedBlockTxsConsistency`.** Validation now:
- rejects + penalises (mid) duplicate txs in the response;
- resolves the block tx hashes from the proposal or the archiver — if neither is available we can't verify membership, so we reject without penalising (local-state gap, not a peer fault);
- rejects + penalises (low) any returned tx that is neither part of the block nor one we explicitly requested by hash — i.e. the returned set must be a subset of `block tx hashes ∪ request.txHashes` (a tx requested by hash may legitimately not belong to the block being validated);
- accepts (returns `true`) when the peer signals it lacks the block (`!peerHasBlock()`) — the returned txs are still valid and usable, which is the core of the fix;
- rejects + penalises (mid) a bitvector whose length disagrees with the block size;
- rejects + penalises (low) a peer that advertises a requested tx via its bitvector but withholds it from the response.

The previous order / strictly-increasing and `maxReturnable` checks are removed; membership plus the advertise-vs-deliver check cover the cases that matter.

**Move dumb-marking into the smart/dumb decision.** `BatchTxRequester` no longer inspects archive roots. `decideIfPeerIsSmart` marks a peer dumb (and clears its per-peer data, without penalty) whenever the response signals it lacks the block (`!peerHasBlock()`); penalisation for genuinely inconsistent responses is left to the validator. The old `handleArchiveRootMismatch` helper is removed.

## Tests

- Updated the serialization, handler, validation, requester and integration tests to the `peerHasBlock()` model.
- Added a regression test at the validator level — a peer that signals it lacks the block via an empty bitvector but returns valid txs is now accepted instead of discarded.
- Added a regression test at the requester level — those txs are delivered (used) and the peer is marked dumb without penalty.
- Added coverage for the partial-availability case (peer returns fewer txs than bits set: we request a,b,c, peer has c,d,e, so only c comes back with three bits set) and for the by-hash case (a tx requested via `request.txHashes` that is not part of the block is accepted).

The regression tests fail against the former behaviour.
