### PR TITLE
refactor(ci): unify release back into a single ci-release command

### DIFF
--- a/.github/workflows/auto-close-issues.yml
+++ b/.github/workflows/auto-close-issues.yml
@@ -14,7 +14,7 @@ jobs:
       pull-requests: read
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           # Conservative depth that avoids historical large files while covering typical merge scenarios
           fetch-depth: 200

--- a/.github/workflows/auto-rebase-pr.yml
+++ b/.github/workflows/auto-rebase-pr.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           fetch-depth: 0
           token: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}

--- a/.github/workflows/avm-circuit-inputs.yml
+++ b/.github/workflows/avm-circuit-inputs.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           persist-credentials: false
 
@@ -69,7 +69,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           persist-credentials: false
 

--- a/.github/workflows/aztec-cli-acceptance-test.yml
+++ b/.github/workflows/aztec-cli-acceptance-test.yml
@@ -32,7 +32,7 @@ jobs:
       VERSION: ${{ github.event.inputs.version || github.event.workflow_run.head_branch }}
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
@@ -57,7 +57,7 @@ jobs:
       VERSION: ${{ github.event.inputs.version || github.event.workflow_run.head_branch }}
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           fetch-depth: 0
           token: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}

--- a/.github/workflows/barretenberg-nightly-debug-build.yml
+++ b/.github/workflows/barretenberg-nightly-debug-build.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           ref: next
 

--- a/.github/workflows/ci3-dashboard-deploy.yml
+++ b/.github/workflows/ci3-dashboard-deploy.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           persist-credentials: false
 

--- a/.github/workflows/ci3-external.yml
+++ b/.github/workflows/ci3-external.yml
@@ -27,7 +27,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           # The commit to checkout.  We want our actual commit, and not the result of merging the PR to the target.
           ref: ${{ github.event.pull_request.head.sha || github.sha }}

--- a/.github/workflows/ci3.yml
+++ b/.github/workflows/ci3.yml
@@ -54,14 +54,22 @@ jobs:
           GH_TOKEN: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
         run: gh pr edit ${{ github.event.pull_request.number }} --remove-label ci-wakeup-pr-after-merge --repo ${{ github.repository }} || true
 
+      # Do NOT bump actions/checkout to v6 here. v6 ("persist creds to a separate file", #2286)
+      # stores the persisted github.token in a temp credentials file pulled in via includeIf, which
+      # `git config --unset-all http....extraheader` cannot clear. Our runner-side pushes (ci3.sh
+      # release-pr tag, ci3_success.sh squash-and-merge) rely on swapping that header for a bot-PAT
+      # remote, so under v6 they push as github-actions[bot] (contents: read) and 403. v5.0.1 is still
+      # node24 but keeps the credential as a removable local extraheader.
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           # The commit to checkout. We want our actual commit, and not the result of merging the PR to the target.
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           # Fetch PR commits depth (we'll deepen by 1 in squash script if needed)
           fetch-depth: ${{ github.event.pull_request.commits || 1 }}
-          persist-credentials: true   # Required for bootstrap_ec2's git fetch
+          # Persisted for authenticated reads (e.g. the aztec-packages-private mirror); pushes swap in
+          # a bot-PAT remote at each push site.
+          persist-credentials: true
 
       - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@v4
@@ -217,7 +225,7 @@ jobs:
         run: gh pr edit ${{ github.event.pull_request.number }} --remove-label ci-network-scenario --repo ${{ github.repository }} || true
 
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
@@ -340,7 +348,7 @@ jobs:
         run: gh pr edit ${{ github.event.pull_request.number }} --remove-label ci-network-bench --repo ${{ github.repository }} || true
 
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
@@ -422,7 +430,7 @@ jobs:
         run: gh pr edit ${{ github.event.pull_request.number }} --remove-label ci-network-kind --repo ${{ github.repository }}
 
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 

--- a/.github/workflows/ci3.yml
+++ b/.github/workflows/ci3.yml
@@ -199,11 +199,10 @@ jobs:
       matrix:
         test_set: ["1", "2"]
     # We run on current nightly tags only, or when the ci-network-scenario label is present in a PR.
-    needs: [ci, validate-nightly-tag, ci-release-publish]
+    needs: [ci, validate-nightly-tag]
     if: |
       always()
       && (needs.ci.result == 'success' || needs.ci.result == 'skipped')
-      && (needs.ci-release-publish.result == 'success' || needs.ci-release-publish.result == 'skipped')
       && github.event.pull_request.head.repo.fork != true
       && github.event.pull_request.draft == false
       && (
@@ -449,99 +448,3 @@ jobs:
           AWS_SHUTDOWN_TIME: 180
         run: |
           ./.github/ci3.sh network-tests-kind
-
-  # Backwards compatibility e2e tests.
-  # Runs e2e tests with contract artifacts from every prior stable release to validate
-  # that new client code works with old contract artifacts ("new pxe / old contracts").
-  # Blocking for stable/RC releases: ci-release-publish requires this job to pass before
-  # publishing. Observational for nightlies: runs, but continue-on-error keeps the workflow
-  # green and ci-release-publish's condition publishes nightlies regardless of the result.
-  # Escape hatch: ci-skip-compat-e2e label makes failures non-blocking on release PRs.
-  ci-compat-e2e:
-    runs-on: ubuntu-latest
-    needs: [ci]
-    if: |
-      always()
-      && (needs.ci.result == 'success' || needs.ci.result == 'skipped')
-      && github.event.pull_request.head.repo.fork != true
-      && github.event.pull_request.draft == false
-      && (
-        (startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-commit.'))
-        || contains(github.event.pull_request.labels.*.name, 'ci-compat-e2e')
-        || contains(github.event.pull_request.labels.*.name, 'ci-release-pr')
-      )
-    # Non-blocking for nightlies and when ci-skip-compat-e2e escape hatch is applied.
-    continue-on-error: ${{ contains(github.ref_name, '-nightly.') || contains(github.event.pull_request.labels.*.name, 'ci-skip-compat-e2e') }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-
-      - name: Run Backwards Compatibility E2E Tests
-        timeout-minutes: 60
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          GITHUB_TOKEN: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
-          BUILD_INSTANCE_SSH_KEY: ${{ secrets.BUILD_INSTANCE_SSH_KEY }}
-          GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
-          DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-          CI3_INSTANCE_PROFILE_NAME: ${{ secrets.CI3_INSTANCE_PROFILE_NAME }}
-          CI3_SECURITY_GROUP_ID: ${{ secrets.CI3_SECURITY_GROUP_ID }}
-          RUN_ID: ${{ github.run_id }}
-          AWS_SHUTDOWN_TIME: 60
-        run: ./.github/ci3.sh compat-e2e
-
-  # Publishes the release (npm, Docker, GitHub release, aztec-up scripts, etc.).
-  # Gated on ci-compat-e2e: a compat regression blocks stable/RC publishing. Nightlies
-  # publish regardless — compat-e2e runs there observationally. Dev `-commit.` tags from
-  # the ci-release-pr flow never reach this job (they are not real releases).
-  ci-release-publish:
-    runs-on: ubuntu-latest
-    environment: master
-    permissions:
-      id-token: write
-      contents: read
-    needs: [ci, ci-compat-e2e]
-    if: |
-      startsWith(github.ref, 'refs/tags/v')
-      && !contains(github.ref_name, '-commit.')
-      && needs.ci.result == 'success'
-      && (
-        contains(github.ref_name, '-nightly.')
-        || needs.ci-compat-e2e.result == 'success'
-      )
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          ref: ${{ github.sha }}
-
-      - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
-          aws-region: us-east-2
-          role-session-name: ci3-release-publish-${{ github.run_id }}
-          role-duration-seconds: 21600
-
-      - name: Run Release Publish
-        env:
-          GITHUB_TOKEN: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
-          BUILD_INSTANCE_SSH_KEY: ${{ secrets.BUILD_INSTANCE_SSH_KEY }}
-          GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
-          GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
-          DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
-          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-          CI3_INSTANCE_PROFILE_NAME: ${{ secrets.CI3_INSTANCE_PROFILE_NAME }}
-          CI3_SECURITY_GROUP_ID: ${{ secrets.CI3_SECURITY_GROUP_ID }}
-          RUN_ID: ${{ github.run_id }}
-        run: ./.github/ci3.sh release-publish

--- a/.github/workflows/ci3.yml
+++ b/.github/workflows/ci3.yml
@@ -122,6 +122,8 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           GITHUB_REF_NAME: ${{ github.ref_name }}
           GITHUB_ACTOR: ${{ github.actor }}
+          # Forwarded to EC2 so release_compat_e2e's nightly-failure Slack alert can build a real run URL.
+          RUN_ID: ${{ github.run_id }}
           CI3_INSTANCE_PROFILE_NAME: ${{ secrets.CI3_INSTANCE_PROFILE_NAME }}
           CI3_SECURITY_GROUP_ID: ${{ secrets.CI3_SECURITY_GROUP_ID }}
           AWS_OIDC_ROLE_ARN: ${{ secrets.AWS_OIDC_ROLE_ARN }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -50,7 +50,7 @@ jobs:
         # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
     - name: Checkout repository
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/create-devnet.yml
+++ b/.github/workflows/create-devnet.yml
@@ -26,7 +26,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout at nightly tag
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           ref: ${{ inputs.nightly_tag }}
           token: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}

--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -21,7 +21,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           ref: ${{ github.event.inputs.source_commit }}
           token: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}

--- a/.github/workflows/create-rollup-upgrade-payload.yml
+++ b/.github/workflows/create-rollup-upgrade-payload.yml
@@ -33,7 +33,7 @@ jobs:
       GOOGLE_APPLICATION_CREDENTIALS: /tmp/gcp-key.json
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           ref: ${{ inputs.ref || github.sha }}
           persist-credentials: false

--- a/.github/workflows/deploy-irm.yml
+++ b/.github/workflows/deploy-irm.yml
@@ -74,7 +74,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           ref: ${{ github.ref }}
           persist-credentials: false

--- a/.github/workflows/deploy-network.yml
+++ b/.github/workflows/deploy-network.yml
@@ -108,7 +108,7 @@ jobs:
           fi
 
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           ref: ${{ steps.checkout-ref.outputs.ref }}
           # Full history so recursive submodules can checkout pinned commits (not only branch tips).

--- a/.github/workflows/deploy-next-net.yml
+++ b/.github/workflows/deploy-next-net.yml
@@ -26,7 +26,7 @@ jobs:
       semver: ${{ steps.determine_tag.outputs.SEMVER }}
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Determine image tag
         id: determine_tag

--- a/.github/workflows/deploy-staging-public.yml
+++ b/.github/workflows/deploy-staging-public.yml
@@ -26,7 +26,7 @@ jobs:
       semver: ${{ steps.resolve.outputs.semver }}
     steps:
       - name: Checkout v4-next
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           ref: v4-next
           token: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
@@ -61,7 +61,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           fetch-depth: 1
 

--- a/.github/workflows/devnet-deploys.yml
+++ b/.github/workflows/devnet-deploys.yml
@@ -26,7 +26,7 @@ jobs:
       patch: ${{ steps.create-tag.outputs.patch }}
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           token: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
           fetch-depth: 0
@@ -58,7 +58,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           fetch-depth: 1
 

--- a/.github/workflows/docs-typesense.yml
+++ b/.github/workflows/docs-typesense.yml
@@ -22,7 +22,7 @@ jobs:
       NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           fetch-depth: 0
 

--- a/.github/workflows/ensure-funded-environment.yml
+++ b/.github/workflows/ensure-funded-environment.yml
@@ -61,7 +61,7 @@ jobs:
       GOOGLE_APPLICATION_CREDENTIALS: /tmp/gcp-key.json
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           ref: ${{ github.ref }}
           fetch-depth: 1

--- a/.github/workflows/ensure-funded-environments.yml
+++ b/.github/workflows/ensure-funded-environments.yml
@@ -31,7 +31,7 @@ jobs:
       matrix: ${{ steps.build-matrix.outputs.matrix }}
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           fetch-depth: 1
 

--- a/.github/workflows/fund-sepolia-accounts.yml
+++ b/.github/workflows/fund-sepolia-accounts.yml
@@ -59,7 +59,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           ref: ${{ inputs.ref || github.ref || 'next' }}
 

--- a/.github/workflows/fuzzing-docker-avm-build-private.yml
+++ b/.github/workflows/fuzzing-docker-avm-build-private.yml
@@ -20,7 +20,7 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Free up disk space on runner
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be

--- a/.github/workflows/fuzzing-docker-avm-build.yml
+++ b/.github/workflows/fuzzing-docker-avm-build.yml
@@ -19,7 +19,7 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Free up disk space on runner
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be

--- a/.github/workflows/fuzzing-docker-build-private.yml
+++ b/.github/workflows/fuzzing-docker-build-private.yml
@@ -20,7 +20,7 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Free up disk space on runner
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be

--- a/.github/workflows/fuzzing-docker-build.yml
+++ b/.github/workflows/fuzzing-docker-build.yml
@@ -19,7 +19,7 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Free up disk space on runner
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be

--- a/.github/workflows/merge-queue-dequeue-notify.yml
+++ b/.github/workflows/merge-queue-dequeue-notify.yml
@@ -11,7 +11,7 @@ jobs:
     if: github.event.action == 'dequeued' && startsWith(github.event.pull_request.head.ref, 'merge-train/') && github.event.pull_request.merged != true
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
@@ -29,7 +29,7 @@ jobs:
     if: github.event.action == 'closed' && github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'merge-train/')
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           ref: ${{ github.event.pull_request.base.ref }}
 

--- a/.github/workflows/merge-train-auto-merge.yml
+++ b/.github/workflows/merge-train-auto-merge.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/merge-train-create-pr.yml
+++ b/.github/workflows/merge-train-create-pr.yml
@@ -13,7 +13,7 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           fetch-depth: 0
 

--- a/.github/workflows/merge-train-next-to-branches.yml
+++ b/.github/workflows/merge-train-next-to-branches.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           fetch-depth: 0
           token: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}

--- a/.github/workflows/merge-train-recreate.yml
+++ b/.github/workflows/merge-train-recreate.yml
@@ -13,7 +13,7 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           fetch-depth: 0
           token: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}

--- a/.github/workflows/merge-train-stale-check.yml
+++ b/.github/workflows/merge-train-stale-check.yml
@@ -14,7 +14,7 @@ jobs:
       contents: read
       pull-requests: read
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
       - name: Run stale check
         env:
           GH_TOKEN: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}

--- a/.github/workflows/merge-train-update-pr-body.yml
+++ b/.github/workflows/merge-train-update-pr-body.yml
@@ -13,7 +13,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           fetch-depth: 0
           token: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}

--- a/.github/workflows/metrics-deploy.yml
+++ b/.github/workflows/metrics-deploy.yml
@@ -108,7 +108,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           ref: ${{ inputs.ref }}
 

--- a/.github/workflows/mirror-repos.yml
+++ b/.github/workflows/mirror-repos.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           ref: next
           fetch-depth: 0

--- a/.github/workflows/network-healthcheck.yml
+++ b/.github/workflows/network-healthcheck.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Run healthcheck
         env:

--- a/.github/workflows/nightly-bench-10tps.yml
+++ b/.github/workflows/nightly-bench-10tps.yml
@@ -31,7 +31,7 @@ jobs:
       source_ref: ${{ steps.docker-image.outputs.source_ref }}
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           ref: next
 
@@ -109,7 +109,7 @@ jobs:
     timeout-minutes: 120
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           ref: ${{ needs.select-image.outputs.source_ref }}
 
@@ -137,7 +137,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           ref: ${{ needs.select-image.outputs.source_ref }}
 
@@ -168,7 +168,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           ref: ${{ needs.select-image.outputs.source_ref }}
 
@@ -194,7 +194,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           ref: ${{ needs.select-image.outputs.source_ref }}
 

--- a/.github/workflows/nightly-release-tag-v4-next.yml
+++ b/.github/workflows/nightly-release-tag-v4-next.yml
@@ -15,7 +15,7 @@ jobs:
   nightly-release-tag-v4-next:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           ref: v4-next
           token: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}

--- a/.github/workflows/nightly-release-tag.yml
+++ b/.github/workflows/nightly-release-tag.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Check out the repository so we can read files and create tags.
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           token: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
 

--- a/.github/workflows/nightly-spartan-bench.yml
+++ b/.github/workflows/nightly-spartan-bench.yml
@@ -23,7 +23,7 @@ jobs:
       source_ref: ${{ steps.nightly-tag.outputs.source_ref }}
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           ref: next
 
@@ -85,7 +85,7 @@ jobs:
     timeout-minutes: 120
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           ref: ${{ needs.select-image.outputs.source_ref }}
 
@@ -114,7 +114,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           ref: ${{ needs.select-image.outputs.source_ref }}
 
@@ -173,7 +173,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           ref: ${{ needs.select-image.outputs.source_ref }}
 
@@ -199,7 +199,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           ref: ${{ needs.select-image.outputs.source_ref }}
 
@@ -237,7 +237,7 @@ jobs:
     timeout-minutes: 120
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           ref: ${{ needs.select-image.outputs.source_ref }}
 
@@ -266,7 +266,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           ref: ${{ needs.select-image.outputs.source_ref }}
 
@@ -323,7 +323,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           ref: ${{ needs.select-image.outputs.source_ref }}
 
@@ -349,7 +349,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           ref: ${{ needs.select-image.outputs.source_ref }}
 
@@ -387,7 +387,7 @@ jobs:
     timeout-minutes: 120
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           ref: ${{ needs.select-image.outputs.source_ref }}
 
@@ -416,7 +416,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           ref: ${{ needs.select-image.outputs.source_ref }}
 
@@ -474,7 +474,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           ref: ${{ needs.select-image.outputs.source_ref }}
 
@@ -500,7 +500,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           ref: ${{ needs.select-image.outputs.source_ref }}
 

--- a/.github/workflows/private-fork-release.yml
+++ b/.github/workflows/private-fork-release.yml
@@ -21,7 +21,7 @@ jobs:
     environment: master
     steps:
       - name: Checkout source
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           repository: AztecProtocol/aztec-packages-private
           ref: ${{ inputs.commit }}

--- a/.github/workflows/publish-misc-pages.yml
+++ b/.github/workflows/publish-misc-pages.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Checkout benchmark-page-data repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           repository: AztecProtocol/benchmark-page-data
           token: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}

--- a/.github/workflows/pull-noir.yml
+++ b/.github/workflows/pull-noir.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout with submodules
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           token: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
           submodules: true

--- a/.github/workflows/pull-request-title.yml
+++ b/.github/workflows/pull-request-title.yml
@@ -40,7 +40,7 @@ jobs:
     if: github.event_name == 'pull_request'
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           sparse-checkout: .github/pull_request_template.md
           sparse-checkout-cone-mode: false

--- a/.github/workflows/redo-typo-pr.yml
+++ b/.github/workflows/redo-typo-pr.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
       with:
         token: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
 

--- a/.github/workflows/release-canary-pr-update.yml
+++ b/.github/workflows/release-canary-pr-update.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           fetch-depth: 0
           token: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}

--- a/.github/workflows/socket-fix.yml
+++ b/.github/workflows/socket-fix.yml
@@ -36,7 +36,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           ref: next
           token: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}

--- a/.github/workflows/test-network-scenarios.yml
+++ b/.github/workflows/test-network-scenarios.yml
@@ -38,7 +38,7 @@ jobs:
         test_set: ${{ fromJSON(inputs.test_set == '' && '["1","2"]' || format('["{0}"]', inputs.test_set)) }}
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Run Network Scenarios
         timeout-minutes: 350

--- a/.github/workflows/weekly-proving-bench.yml
+++ b/.github/workflows/weekly-proving-bench.yml
@@ -23,7 +23,7 @@ jobs:
       source_ref: ${{ steps.nightly-tag.outputs.source_ref }}
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           ref: next
 
@@ -83,7 +83,7 @@ jobs:
     timeout-minutes: 120
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           ref: ${{ needs.select-image.outputs.source_ref }}
 
@@ -111,7 +111,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           ref: ${{ needs.select-image.outputs.source_ref }}
 
@@ -168,7 +168,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           ref: ${{ needs.select-image.outputs.source_ref }}
 
@@ -194,7 +194,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           ref: ${{ needs.select-image.outputs.source_ref }}
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -962,7 +962,7 @@ case "$cmd" in
     if [[ "$(semver prerelease $REF_NAME)" == private* ]]; then
       echo_header "Private fork release: $REF_NAME"
       echo "Creating GitHub release from public repo context (COMMIT_HASH=$COMMIT_HASH)..."
-      release_github
+      release_bb_github
       echo "Fetching private source from aztec-packages-private..."
       git remote add private "https://x-access-token:${GITHUB_TOKEN}@github.com/AztecProtocol/aztec-packages-private.git"
       git fetch --depth 1 private "refs/tags/$REF_NAME"

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -623,7 +623,8 @@ function release_compat_e2e {
 
   # Build and run the compat test commands in an isolated subshell so the bespoke test settings
   # (no test cache, no fast-fail short-circuit) don't leak into the release build/publish that follows.
-  # set -e is explicit here because this function runs under `||` in ci-release, which suspends it.
+  # set -e re-enables errexit inside this subshell: the caller invokes release_compat_e2e with errexit
+  # disabled (to capture its exit code), so without this a failed build/install would be masked.
   (
     set -e
     export USE_TEST_CACHE=0
@@ -946,8 +947,13 @@ case "$cmd" in
 
     # Backwards-compatibility e2e checks. A failure blocks stable/RC releases, but only warns on
     # nightlies (where compat coverage is observational) so the nightly publish still proceeds.
+    # Toggle errexit explicitly rather than `release_compat_e2e || compat_rc=$?`: calling under `||`
+    # suspends errexit for the whole function (and its subshell), masking build/setup failures there.
     compat_rc=0
-    release_compat_e2e || compat_rc=$?
+    set +e
+    release_compat_e2e
+    compat_rc=$?
+    set -e
     if [ "$compat_rc" -ne 0 ]; then
       if [[ "${REF_NAME:-}" == *-nightly.* ]]; then
         run_url="https://github.com/${GITHUB_REPOSITORY:-AztecProtocol/aztec-packages}/actions/runs/${RUN_ID:-unknown}"

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -547,6 +547,95 @@ function release_dryrun {
   DRY_RUN=1 release
 }
 
+function release_compat_e2e {
+  # Runs e2e tests with contract artifacts from every prior stable release since 4.2.0 (the version
+  # where we committed to backwards compatibility). Validates that old contract artifacts work on the
+  # current release. Blocking for stable/RC releases; observational (non-blocking) for nightlies.
+  # Set SKIP_COMPAT_E2E=1 to bypass (escape hatch via the ci-skip-compat-e2e label).
+  if [ "${SKIP_COMPAT_E2E:-0}" = "1" ]; then
+    echo "SKIP_COMPAT_E2E=1, skipping backwards compatibility e2e tests."
+    return 0
+  fi
+
+  # Compat e2e only runs on amd64 — the arm64 release job just builds and publishes release-image.
+  if [ "$(arch)" == arm64 ]; then
+    echo "Skipping backwards compatibility e2e tests on arm64 (amd64 only)."
+    return 0
+  fi
+
+  # TODO: bump when v5 commits to backwards-compatible contract artifacts.
+  #   compat_major:       major version that has compat guarantees today.
+  #   compat_min_version: earliest stable tag of that major to test against
+  #                       (artifacts before this are incompatible due to oracle interface changes).
+  local compat_major="4"
+  local compat_min_version="4.2.0"
+
+  local current_version major
+  current_version=$(jq -r '."."' .release-please-manifest.json)
+  major=$(semver major "$current_version")
+  if [ "$major" != "$compat_major" ]; then
+    echo "Compat e2e tests only apply to v${compat_major}. Current major: v${major}. Skipping."
+    return 0
+  fi
+
+  # Fetch tags (EC2 clone may not have them). Fail loud: a silent fetch failure plus an empty
+  # tag list would publish a real release with zero compat coverage.
+  if ! git fetch origin 'refs/tags/v*:refs/tags/v*'; then
+    echo "ERROR: failed to fetch release tags." >&2
+    return 1
+  fi
+
+  # Discover stable tags for this major version (no prerelease suffixes).
+  local versions=()
+  local tag ver
+  while IFS= read -r tag; do
+    ver=${tag#v}
+    # Include only versions >= compat_min_version (sort -V puts smaller first).
+    if [ "$(printf '%s\n%s' "$compat_min_version" "$ver" | sort -V | head -1)" = "$compat_min_version" ]; then
+      versions+=("$ver")
+    fi
+  done < <(git tag -l "v${major}.*" | grep -E "^v[0-9]+\.[0-9]+\.[0-9]+$" | sort -V)
+
+  # Exclude the current tag when running on a release tag push.
+  if [[ "${REF_NAME:-}" =~ ^v?([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
+    local current_tag="${BASH_REMATCH[1]}"
+    local filtered=()
+    local v
+    for v in "${versions[@]}"; do
+      [ "$v" != "$current_tag" ] && filtered+=("$v")
+    done
+    versions=("${filtered[@]}")
+  fi
+
+  if [ ${#versions[@]} -eq 0 ]; then
+    echo "No prior stable versions found for v${major}.x (>= $compat_min_version). Skipping compat tests."
+    return 0
+  fi
+
+  echo_header "Backwards compatibility e2e tests"
+  echo "Testing against ${#versions[@]} prior stable version(s): ${versions[*]}"
+
+  # Pre-populate the legacy contract cache on the host. Test containers run with --net=none, so the
+  # jest resolver's on-demand npm install would fail with EAI_AGAIN. Install here where we have network.
+  for ver in "${versions[@]}"; do
+    node yarn-project/end-to-end/src/install_legacy_contracts.cjs "$ver"
+  done
+
+  # Build and run the compat test commands in an isolated subshell so the bespoke test settings
+  # (no test cache, no fast-fail short-circuit) don't leak into the release build/publish that follows.
+  # set -e is explicit here because this function runs under `||` in ci-release, which suspends it.
+  (
+    set -e
+    export USE_TEST_CACHE=0
+    export CI_FULL=0
+    export NO_FAIL_FAST=1
+    build
+    for ver in "${versions[@]}"; do
+      yarn-project/end-to-end/bootstrap.sh compat_test_cmds "$ver"
+    done | filter_test_cmds | parallelize
+  )
+}
+
 ### SELF TESTING #######################################################################################################
 function test_bootstrap_linux {
   local name=linux-bootstrap-test-ubuntu
@@ -846,22 +935,30 @@ case "$cmd" in
   # RELEASES #
   ############
   "ci-release")
-    # Verification build for a release tag. Does NOT publish — publishing happens in
-    # ci-release-publish, gated on ci-compat-e2e so a compat regression blocks the release.
+    # Single command that tests and publishes a release. Runs the backwards-compatibility e2e
+    # checks (blocking for stable/RC, observational for nightlies), then builds and publishes.
+    # DRY_RUN=1 exercises the whole flow without publishing — this is how releases are tested in CI.
     export CI=1
     export USE_TEST_CACHE=1
     if ! semver check $REF_NAME; then
       exit 1
     fi
-    build
-    ;;
-  "ci-release-publish")
-    # Actual publish step. `build` cache-hits against ci-release's build of the same commit.
-    export CI=1
-    export USE_TEST_CACHE=1
-    if ! semver check $REF_NAME; then
-      exit 1
+
+    # Backwards-compatibility e2e checks. A failure blocks stable/RC releases, but only warns on
+    # nightlies (where compat coverage is observational) so the nightly publish still proceeds.
+    compat_rc=0
+    release_compat_e2e || compat_rc=$?
+    if [ "$compat_rc" -ne 0 ]; then
+      if [[ "${REF_NAME:-}" == *-nightly.* ]]; then
+        run_url="https://github.com/${GITHUB_REPOSITORY:-AztecProtocol/aztec-packages}/actions/runs/${RUN_ID:-unknown}"
+        "$ci3/slack_notify" "Backwards compatibility e2e tests FAILED on nightly tag <${run_url}|${REF_NAME}>" "#team-fairies" || true
+        echo "Compat e2e failed on nightly tag — continuing (non-blocking)."
+      else
+        echo "ERROR: backwards compatibility e2e tests failed — blocking release." >&2
+        exit 1
+      fi
     fi
+
     if [[ "$(semver prerelease $REF_NAME)" == private* ]]; then
       echo_header "Private fork release: $REF_NAME"
       echo "Creating GitHub release from public repo context (COMMIT_HASH=$COMMIT_HASH)..."
@@ -936,82 +1033,6 @@ case "$cmd" in
     build
     yarn-project/end-to-end/bootstrap.sh avm_check_circuit
     ;;
-  #############################################
-  # BACKWARDS COMPATIBILITY E2E TESTS         #
-  #############################################
-  "ci-compat-e2e")
-    # Runs e2e tests with contract artifacts from every prior stable release since 4.2.0 (version where we committed to
-    # backwards compatibility). This Validates that old contract artifacts work on current release.
-    export CI=1
-    export USE_TEST_CACHE=0
-    export CI_FULL=0
-    export NO_FAIL_FAST=1
-
-    build
-
-    # TODO: bump when v5 commits to backwards-compatible contract artifacts.
-    #   compat_major:       major version that has compat guarantees today.
-    #   compat_min_version: earliest stable tag of that major to test against
-    #                       (artifacts before this are incompatible due to oracle interface changes).
-    compat_major="4"
-    compat_min_version="4.2.0"
-
-    # Get current major version.
-    current_version=$(jq -r '."."' .release-please-manifest.json)
-    major=$(semver major "$current_version")
-    if [ "$major" != "$compat_major" ]; then
-      echo "Compat e2e tests only apply to v${compat_major}. Current major: v${major}. Skipping."
-      exit 0
-    fi
-    min_version="$compat_min_version"
-
-    # Fetch tags (EC2 clone may not have them). Fail loud: a silent fetch failure plus an empty
-    # tag list would publish a real release with zero compat coverage.
-    if ! git fetch origin 'refs/tags/v*:refs/tags/v*'; then
-      echo "ERROR: failed to fetch release tags." >&2
-      exit 1
-    fi
-
-    # Discover stable tags for this major version (no prerelease suffixes).
-    versions=()
-    while IFS= read -r tag; do
-      ver=${tag#v}
-      # Include only versions >= min_version (sort -V puts smaller first).
-      if [ "$(printf '%s\n%s' "$min_version" "$ver" | sort -V | head -1)" = "$min_version" ]; then
-        versions+=("$ver")
-      fi
-    done < <(git tag -l "v${major}.*" | grep -E "^v[0-9]+\.[0-9]+\.[0-9]+$" | sort -V)
-
-    # Exclude the current tag when running on a release tag push.
-    if [[ "${REF_NAME:-}" =~ ^v([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
-      current_tag="${BASH_REMATCH[1]}"
-      filtered=()
-      for v in "${versions[@]}"; do
-        [ "$v" != "$current_tag" ] && filtered+=("$v")
-      done
-      versions=("${filtered[@]}")
-    fi
-
-    if [ ${#versions[@]} -eq 0 ]; then
-      echo "No prior stable versions found for v${major}.x (>= $min_version). Skipping compat tests."
-      exit 0
-    fi
-
-    echo_header "Backwards compatibility e2e tests"
-    echo "Testing against ${#versions[@]} prior stable version(s): ${versions[*]}"
-
-    # Pre-populate the legacy contract cache on the host. Test containers run with --net=none, so the
-    # jest resolver's on-demand npm install would fail with EAI_AGAIN. Install here where we have network.
-    for ver in "${versions[@]}"; do
-      node yarn-project/end-to-end/src/install_legacy_contracts.cjs "$ver"
-    done
-
-    # Generate compat test commands for all versions and run them in parallel.
-    for ver in "${versions[@]}"; do
-      yarn-project/end-to-end/bootstrap.sh compat_test_cmds "$ver"
-    done | filter_test_cmds | parallelize
-    ;;
-
   ##########################################
   # ROLLUP UPGRADE DEPLOYMENT              #
   ##########################################

--- a/ci.sh
+++ b/ci.sh
@@ -36,7 +36,6 @@ function print_usage {
   echo_cmd "network-teardown"      "Spin up an EC2 instance to teardown a network deployment."
   echo_cmd "network-tests-kind"    "Spin up an EC2 instance to run a KIND-based spartan test."
   echo_cmd "deploy-rollup-upgrade" "Spin up an EC2 instance to deploy a rollup upgrade."
-  echo_cmd "compat-e2e"            "Spin up an EC2 instance and run backwards compat e2e tests."
   echo_cmd "chonk-input-update"    "Spin up an EC2 instance to update pinned Chonk IVC inputs and push the diff."
   echo_cmd "release"               "Spin up an EC2 instance and run bootstrap release."
   echo_cmd "shell-new"             "Spin up an EC2 instance, clone the repo, and drop into a shell."
@@ -321,49 +320,19 @@ case "$cmd" in
     bootstrap_ec2 "./bootstrap.sh ci-deploy-rollup-upgrade $*"
     ;;
 
-  ##############################
-  # BACKWARDS COMPATIBILITY   #
-  ##############################
-  compat-e2e)
-    # Spin up an EC2 instance and run backwards compatibility e2e tests
-    # against contract artifacts from prior stable releases.
-    export CI_DASHBOARD="releases"
-    export JOB_ID="x-compat-e2e"
-    export AWS_SHUTDOWN_TIME=60
-    rc=0
-    bootstrap_ec2 "./bootstrap.sh ci-compat-e2e" || rc=$?
-    # On nightly tags compat-e2e is non-blocking (continue-on-error in ci3.yml), so
-    # failures otherwise go unnoticed. Notify #team-fairies so they get picked up.
-    if [ "$rc" -ne 0 ] && [[ "${REF_NAME:-}" == *-nightly.* ]]; then
-      run_url="https://github.com/${GITHUB_REPOSITORY:-AztecProtocol/aztec-packages}/actions/runs/${GITHUB_RUN_ID:-unknown}"
-      "$ci3/slack_notify" "Backwards compatibility e2e tests FAILED on nightly tag <${run_url}|${REF_NAME}>" "#team-fairies"
-    fi
-    exit "$rc"
-    ;;
-
   ############
   # RELEASES #
   ############
   release)
-    # Spin up ec2 instance and run the release-tag verification build (no publish).
+    # Spin up ec2 instances (amd64 + arm64) and run the full release flow: backwards-compat e2e
+    # checks, build, and publish. Set DRY_RUN=1 to exercise the whole flow without publishing.
     export CI_DASHBOARD="releases"
+    # Roomier instance lifetime than a standard run: the amd64 job builds, runs the backwards-compat
+    # e2e suite, and then publishes, which together exceed the default 75 min shutdown.
+    export AWS_SHUTDOWN_TIME=${AWS_SHUTDOWN_TIME:-180}
     multi_job_run \
       'x-release amd64 ci-release' \
       'a-release arm64 ci-release'
-    ;;
-  release-publish)
-    # Spin up ec2 instance and run the actual publish flow. Gated in ci3.yml on ci + ci-compat-e2e.
-    export CI_DASHBOARD="releases"
-    export DENOISE=1
-    export DENOISE_WIDTH=32
-    run() {
-      PARENT_LOG_ID=$RUN_ID JOB_ID=$1 INSTANCE_POSTFIX=$1 ARCH=$2 exec denoise "bootstrap_ec2 './bootstrap.sh ci-release-publish'"
-    }
-    export -f run
-
-    parallel --termseq 'TERM,10000' --tagstring '{= $_=~s/run (\w+).*/$1/; =}' --line-buffered --halt now,fail=1 ::: \
-      'run x-release-publish amd64' \
-      'run a-release-publish arm64' | DUP=1 cache_log "Release Publish CI run" $RUN_ID
     ;;
 
   ##################


### PR DESCRIPTION
## What

1. Reunifies the release flow into a single `ci-release` command (undoes the `ci-release` / `ci-release-publish` split from #22930). This had introduced several bugs and caused the command to span multiple machines.
2. Fixes runner-side `git push` auth, broken by the checkout-v6 repin.
