### PR TITLE
docs: add testnet faucet link to getting-started guide

### DIFF
--- a/docs/developer_versioned_docs/version-v4.3.0/getting_started_on_testnet.md
+++ b/docs/developer_versioned_docs/version-v4.3.0/getting_started_on_testnet.md
@@ -196,13 +196,15 @@ After registration, you can interact with it using `aztec-wallet send` and `azte
 
 The Sponsored FPC is convenient for getting started, but you can also pay fees directly by bridging Fee Juice from Ethereum Sepolia. See [Paying Fees](./docs/aztec-js/how_to_pay_fees.md#bridge-fee-juice-from-l1) for details on bridging and other fee payment methods.
 
-## Getting testnet tokens
+## Getting Fee Juice from the faucet
 
-If you want to pay fees directly rather than using the Sponsored FPC, you can request testnet tokens from the faucet:
+If you want to pay fees directly instead of using the Sponsored FPC, you can request **Fee Juice** from the testnet faucet:
 
-- [Aztec Testnet Faucet](https://aztec-faucet.nethermind.io/) - request testnet tokens for your account
+- [Aztec Fee Juice Faucet](https://aztec-faucet.nethermind.io/) - dispenses testnet Fee Juice to your account
 
-Bridging Fee Juice from Ethereum also requires Sepolia ETH to cover the L1 transaction, which you can obtain from any public Sepolia faucet.
+:::note Fee Juice is not the AZTEC token
+This faucet dispenses **Fee Juice**, the asset used to pay transaction fees (gas) on Aztec. Fee Juice lives on Aztec (L2) and is only used to pay fees. It is **not** the AZTEC token, which is a separate asset that lives on Ethereum (L1). This faucet does not dispense AZTEC tokens.
+:::
 
 ## Testnet information
 

--- a/docs/developer_versioned_docs/version-v4.3.0/getting_started_on_testnet.md
+++ b/docs/developer_versioned_docs/version-v4.3.0/getting_started_on_testnet.md
@@ -196,6 +196,14 @@ After registration, you can interact with it using `aztec-wallet send` and `azte
 
 The Sponsored FPC is convenient for getting started, but you can also pay fees directly by bridging Fee Juice from Ethereum Sepolia. See [Paying Fees](./docs/aztec-js/how_to_pay_fees.md#bridge-fee-juice-from-l1) for details on bridging and other fee payment methods.
 
+## Getting testnet tokens
+
+If you want to pay fees directly rather than using the Sponsored FPC, you can request testnet tokens from the faucet:
+
+- [Aztec Testnet Faucet](https://aztec-faucet.nethermind.io/) - request testnet tokens for your account
+
+Bridging Fee Juice from Ethereum also requires Sepolia ETH to cover the L1 transaction, which you can obtain from any public Sepolia faucet.
+
 ## Testnet information
 
 For complete testnet technical details including contract addresses and network configuration, see the [Networks page](/networks#testnet).

--- a/docs/docs-developers/getting_started_on_testnet.md
+++ b/docs/docs-developers/getting_started_on_testnet.md
@@ -196,13 +196,15 @@ After registration, you can interact with it using `aztec-wallet send` and `azte
 
 The Sponsored FPC is convenient for getting started, but you can also pay fees directly by bridging Fee Juice from Ethereum Sepolia. See [Paying Fees](./docs/aztec-js/how_to_pay_fees.md#bridge-fee-juice-from-l1) for details on bridging and other fee payment methods.
 
-## Getting testnet tokens
+## Getting Fee Juice from the faucet
 
-If you want to pay fees directly rather than using the Sponsored FPC, you can request testnet tokens from the faucet:
+If you want to pay fees directly instead of using the Sponsored FPC, you can request **Fee Juice** from the testnet faucet:
 
-- [Aztec Testnet Faucet](https://aztec-faucet.nethermind.io/) - request testnet tokens for your account
+- [Aztec Fee Juice Faucet](https://aztec-faucet.nethermind.io/) - dispenses testnet Fee Juice to your account
 
-Bridging Fee Juice from Ethereum also requires Sepolia ETH to cover the L1 transaction, which you can obtain from any public Sepolia faucet.
+:::note Fee Juice is not the AZTEC token
+This faucet dispenses **Fee Juice**, the asset used to pay transaction fees (gas) on Aztec. Fee Juice lives on Aztec (L2) and is only used to pay fees. It is **not** the AZTEC token, which is a separate asset that lives on Ethereum (L1). This faucet does not dispense AZTEC tokens.
+:::
 
 ## Testnet information
 

--- a/docs/docs-developers/getting_started_on_testnet.md
+++ b/docs/docs-developers/getting_started_on_testnet.md
@@ -196,6 +196,14 @@ After registration, you can interact with it using `aztec-wallet send` and `azte
 
 The Sponsored FPC is convenient for getting started, but you can also pay fees directly by bridging Fee Juice from Ethereum Sepolia. See [Paying Fees](./docs/aztec-js/how_to_pay_fees.md#bridge-fee-juice-from-l1) for details on bridging and other fee payment methods.
 
+## Getting testnet tokens
+
+If you want to pay fees directly rather than using the Sponsored FPC, you can request testnet tokens from the faucet:
+
+- [Aztec Testnet Faucet](https://aztec-faucet.nethermind.io/) - request testnet tokens for your account
+
+Bridging Fee Juice from Ethereum also requires Sepolia ETH to cover the L1 transaction, which you can obtain from any public Sepolia faucet.
+
 ## Testnet information
 
 For complete testnet technical details including contract addresses and network configuration, see the [Networks page](/networks#testnet).


### PR DESCRIPTION
## Summary

Adds a short **Getting Fee Juice from the faucet** section to the testnet getting-started guide, in both the source page and the versioned snapshot.

## Why

The Aztec docs assistant ("Honk AI") repeatedly sees users ask where to get the testnet faucet / how to fund a testnet wallet, but **no faucet URL exists anywhere in the docs** — the assistant can only say it doesn't have the link. This closes that gap at the source.

## Change

The same new section in **both** copies of `getting_started_on_testnet.md`, placed next to the existing Sponsored FPC / Fee Juice guidance:

- `docs/docs-developers/getting_started_on_testnet.md` — the authored source page
- `docs/developer_versioned_docs/version-v4.3.0/getting_started_on_testnet.md` — the versioned snapshot the site serves (and that the docs assistant ingests), so the link reaches readers without waiting on a re-version

Content:
- Links the Aztec Fee Juice Faucet (`https://aztec-faucet.nethermind.io/`)
- Includes a `:::note` clarifying that the faucet dispenses **Fee Juice** (the L2 asset used to pay transaction fees on Aztec), **not** the AZTEC token (a separate asset on Ethereum L1) — so users don't expect AZTEC tokens from it

## Note for reviewers

Please confirm `https://aztec-faucet.nethermind.io/` is the **canonical/endorsed** Fee Juice faucet before merging — it was sourced from the community [awesome-aztec](https://github.com/AztecProtocol/awesome-aztec) list, not an existing official doc. Swap the URL if there's a more authoritative one.

Opened as a **draft** pending that confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)