### PR TITLE
feat(ci): private-nightly docker release series + next-net source

### DIFF
--- a/.github/workflows/ci3.yml
+++ b/.github/workflows/ci3.yml
@@ -178,7 +178,10 @@ jobs:
   # Prevents stale or replayed nightly tags from triggering scenario tests.
   validate-nightly-tag:
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v') && contains(github.ref_name, '-nightly.')
+    # `-private-nightly.` contains `-nightly.` as a substring — exclude it so the private docker-only
+    # nightly series does not spin up the network-scenario matrices (ci-network-scenario gates on this
+    # job's is_current output).
+    if: startsWith(github.ref, 'refs/tags/v') && contains(github.ref_name, '-nightly.') && !contains(github.ref_name, '-private-nightly.')
     outputs:
       is_current: ${{ steps.check.outputs.is_current }}
     steps:

--- a/.github/workflows/deploy-next-net.yml
+++ b/.github/workflows/deploy-next-net.yml
@@ -30,6 +30,8 @@ jobs:
 
       - name: Determine image tag
         id: determine_tag
+        env:
+          GH_TOKEN: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
         run: |
           if [[ -n "${{ inputs.image_tag }}" ]]; then
             # Manual trigger with specified tag
@@ -39,12 +41,14 @@ jobs:
             # Extract semver (remove -amd64 suffix if present)
             SEMVER=$(echo "$TAG" | sed 's/-amd64$//')
           else
-            # Scheduled nightly run - get latest nightly tag
-            current_version=$(jq -r '."."' .release-please-manifest.json)
-            echo "Current version: $current_version"
+            # Scheduled run - deploy the latest PRIVATE nightly (the embargoed v5 line that next-net
+            # tracks). Version comes from aztec-packages-private/v5-next, not the public manifest.
+            current_version=$(gh api "repos/AztecProtocol/aztec-packages-private/contents/.release-please-manifest.json?ref=v5-next" \
+                                --jq '.content' | base64 -d | jq -r '."."')
+            echo "Private v5-next version: $current_version"
 
-            # Format the tag as: <current_version>-nightly.<YYYYMMDD>-amd64
-            nightly_semver="${current_version}-nightly.$(date -u +%Y%m%d)"
+            # Format the tag as: <current_version>-private-nightly.<YYYYMMDD>-amd64
+            nightly_semver="${current_version}-private-nightly.$(date -u +%Y%m%d)"
             nightly_tag="${nightly_semver}-amd64"
 
             # Check if the tag exists on docker hub
@@ -52,7 +56,7 @@ jobs:
             if [[ "$TAGS" != *"not found"* ]]; then
               TAG="$nightly_tag"
               SEMVER="$nightly_semver"
-              echo "Using nightly tag: $TAG"
+              echo "Using private nightly tag: $TAG"
             else
               echo "Error: Tag $nightly_tag not published to docker hub"
               exit 1

--- a/.github/workflows/nightly-release-tag-private.yml
+++ b/.github/workflows/nightly-release-tag-private.yml
@@ -1,0 +1,59 @@
+name: Nightly Release Tag (private)
+# Private nightly series, sourced from aztec-packages-private/v5-next (the embargoed v5 line).
+# Tags v{version}-private-nightly.<date> in BOTH repos: the private tag is the build source, the
+# public tag is the trigger (its push fires ci3.yml -> ci-release, which detects the private-nightly
+# prerelease, fetches the private tag, and publishes the aztec docker image only). next-net deploys
+# consume the resulting image.
+on:
+  schedule:
+    # 1:00 AM UTC — ahead of the 4:00 AM next-net deploy so the image is ready.
+    - cron: "0 1 * * *"
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+
+concurrency:
+  group: ${{ github.workflow }}
+
+jobs:
+  private-nightly-tag:
+    runs-on: ubuntu-latest
+    # Only run in the canonical public repo. In the private mirror, origin is private, so the
+    # public-trigger push below would misfire.
+    if: github.repository == 'AztecProtocol/aztec-packages'
+    env:
+      PRIVATE_REPO: AztecProtocol/aztec-packages-private
+      PRIVATE_BRANCH: v5-next
+    steps:
+      - name: Tag private v5-next (build source)
+        env:
+          GH_TOKEN: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          sha=$(gh api "repos/${PRIVATE_REPO}/branches/${PRIVATE_BRANCH}" --jq '.commit.sha')
+          ver=$(gh api "repos/${PRIVATE_REPO}/contents/.release-please-manifest.json?ref=${PRIVATE_BRANCH}" \
+                  --jq '.content' | base64 -d | jq -r '."."')
+          tag="v${ver}-private-nightly.$(date -u +%Y%m%d)"
+          echo "Private nightly tag: $tag  (source ${PRIVATE_REPO}@${sha})"
+          echo "RELEASE_TAG=$tag" >> "$GITHUB_ENV"
+          gh api --method POST "repos/${PRIVATE_REPO}/git/refs" \
+            -f "ref=refs/tags/${tag}" -f "sha=${sha}" --jq '.ref' \
+            || echo "Private tag ${tag} already exists, continuing."
+
+      - name: Checkout public next
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          ref: next
+          token: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
+
+      - name: Push public trigger tag
+        run: |
+          set -euo pipefail
+          git config user.email "tech@aztecprotocol.com"
+          git config user.name "AztecBot"
+          # Push with the bot PAT so the tag push triggers ci3.yml (GITHUB_TOKEN pushes do not).
+          # ci-release runs from this public commit but builds the fetched private worktree.
+          git tag -a "${RELEASE_TAG}" -m "${RELEASE_TAG}"
+          git push origin "${RELEASE_TAG}"
+          echo "Pushed ${RELEASE_TAG}; ci-release will build the private source and publish the docker image."

--- a/.github/workflows/nightly-release-tag-private.yml
+++ b/.github/workflows/nightly-release-tag-private.yml
@@ -6,7 +6,7 @@ name: Nightly Release Tag (private)
 # consume the resulting image.
 on:
   schedule:
-    # 1:00 AM UTC — ahead of the 4:00 AM next-net deploy so the image is ready.
+    # 1:00 AM UTC — well ahead of the next-net scheduled deploy so the image is ready.
     - cron: "0 1 * * *"
   workflow_dispatch: {}
 
@@ -36,10 +36,19 @@ jobs:
                   --jq '.content' | base64 -d | jq -r '."."')
           tag="v${ver}-private-nightly.$(date -u +%Y%m%d)"
           echo "Private nightly tag: $tag  (source ${PRIVATE_REPO}@${sha})"
+          # Create the build-source tag. A same-day re-run (tag already present) is fine; any other
+          # failure must abort here in the cheap tagger rather than push a public trigger for a source
+          # tag that doesn't exist. RELEASE_TAG is set only after the source tag is confirmed.
+          if gh api --method POST "repos/${PRIVATE_REPO}/git/refs" \
+               -f "ref=refs/tags/${tag}" -f "sha=${sha}" --jq '.ref'; then
+            echo "Created ${tag}."
+          elif gh api "repos/${PRIVATE_REPO}/git/ref/tags/${tag}" --jq '.ref' >/dev/null 2>&1; then
+            echo "Private tag ${tag} already exists, continuing."
+          else
+            echo "ERROR: failed to create private tag ${tag}." >&2
+            exit 1
+          fi
           echo "RELEASE_TAG=$tag" >> "$GITHUB_ENV"
-          gh api --method POST "repos/${PRIVATE_REPO}/git/refs" \
-            -f "ref=refs/tags/${tag}" -f "sha=${sha}" --jq '.ref' \
-            || echo "Private tag ${tag} already exists, continuing."
 
       - name: Checkout public next
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
@@ -55,5 +64,9 @@ jobs:
           # Push with the bot PAT so the tag push triggers ci3.yml (GITHUB_TOKEN pushes do not).
           # ci-release runs from this public commit but builds the fetched private worktree.
           git tag -a "${RELEASE_TAG}" -m "${RELEASE_TAG}"
-          git push origin "${RELEASE_TAG}"
-          echo "Pushed ${RELEASE_TAG}; ci-release will build the private source and publish the docker image."
+          # Idempotent: a same-day re-run finds the tag already pushed (and ci-release already fired).
+          if git push origin "${RELEASE_TAG}"; then
+            echo "Pushed ${RELEASE_TAG}; ci-release will build the private source and publish the docker image."
+          else
+            echo "Public tag ${RELEASE_TAG} already present; ci-release already triggered."
+          fi

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -637,6 +637,22 @@ function release_compat_e2e {
   )
 }
 
+function checkout_private_worktree {
+  # Fetch the private fork source at $REF_NAME and cd into a worktree built from it. The same tag
+  # must exist in aztec-packages-private. Used by the private-fork and private-nightly release paths.
+  echo "Fetching private source from aztec-packages-private for $REF_NAME..."
+  git remote add private "https://x-access-token:${GITHUB_TOKEN}@github.com/AztecProtocol/aztec-packages-private.git"
+  git fetch --depth 1 private "refs/tags/$REF_NAME"
+  git worktree add aztec-private FETCH_HEAD
+  cd aztec-private
+  echo "Initializing submodules in private worktree..."
+  git submodule update --init --recursive
+  echo "Private worktree ready at $(pwd) (HEAD=$(git rev-parse --short HEAD)). Cache uploads disabled."
+  export NO_CACHE_UPLOAD=1
+  # Unset so child bootstrap.sh re-derives these from the worktree.
+  unset COMMIT_HASH root
+}
+
 ### SELF TESTING #######################################################################################################
 function test_bootstrap_linux {
   local name=linux-bootstrap-test-ubuntu
@@ -945,6 +961,17 @@ case "$cmd" in
       exit 1
     fi
 
+    # Private nightly series (docker images only). A `*-private-nightly.<date>` tag builds from the
+    # private fork and publishes just the aztec docker image — no npm/cargo/github release, no compat
+    # gate. next-net deploys consume these. Checked before the generic private* path below.
+    if [[ "$(semver prerelease $REF_NAME)" == private-nightly* ]]; then
+      echo_header "Private nightly (docker images only): $REF_NAME"
+      checkout_private_worktree
+      ./bootstrap.sh build release
+      release-image/bootstrap.sh release
+      exit 0
+    fi
+
     # Backwards-compatibility e2e checks. A failure blocks stable/RC releases, but only warns on
     # nightlies (where compat coverage is observational) so the nightly publish still proceeds.
     # Toggle errexit explicitly rather than `release_compat_e2e || compat_rc=$?`: calling under `||`
@@ -969,17 +996,7 @@ case "$cmd" in
       echo_header "Private fork release: $REF_NAME"
       echo "Creating GitHub release from public repo context (COMMIT_HASH=$COMMIT_HASH)..."
       release_bb_github
-      echo "Fetching private source from aztec-packages-private..."
-      git remote add private "https://x-access-token:${GITHUB_TOKEN}@github.com/AztecProtocol/aztec-packages-private.git"
-      git fetch --depth 1 private "refs/tags/$REF_NAME"
-      git worktree add aztec-private FETCH_HEAD
-      cd aztec-private
-      echo "Initializing submodules in private worktree..."
-      git submodule update --init --recursive
-      echo "Private worktree ready at $(pwd) (HEAD=$(git rev-parse --short HEAD)). Cache uploads disabled."
-      export NO_CACHE_UPLOAD=1
-      # Unset so child bootstrap.sh re-derives these from the worktree.
-      unset COMMIT_HASH root
+      checkout_private_worktree
     fi
     ./bootstrap.sh build release
     ./bootstrap.sh release

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -965,6 +965,12 @@ case "$cmd" in
     # private fork and publishes just the aztec docker image — no npm/cargo/github release, no compat
     # gate. next-net deploys consume these. Checked before the generic private* path below.
     if [[ "$(semver prerelease $REF_NAME)" == private-nightly* ]]; then
+      # Only build in the public repo. The tagger creates the build-source tag in the private repo
+      # too; if that fires ci-release in the private mirror it would self-fetch and race the image.
+      if [[ "${GITHUB_REPOSITORY:-}" == "AztecProtocol/aztec-packages-private" ]]; then
+        echo "Skipping private-nightly build in the private mirror (handled by the public repo)."
+        exit 0
+      fi
       echo_header "Private nightly (docker images only): $REF_NAME"
       checkout_private_worktree
       ./bootstrap.sh build release


### PR DESCRIPTION
Stacked on #23780 (ci-release unification). Sets up a **private nightly** release series sourced from the embargoed v5 line, publishing the **docker image only**, which **next-net** then deploys.

## Pieces
- **`bootstrap.sh`** — `ci-release` gains a `*-private-nightly.<date>` path (checked before the generic `private*`): fetch the matching tag from `aztec-packages-private`, build it, publish **only** the `release-image` docker image — no npm/cargo/github, no compat gate. Existing private-fork checkout refactored into `checkout_private_worktree`, shared by both private paths.
- **`.github/workflows/nightly-release-tag-private.yml`** (new) — scheduled 1 AM UTC: reads `private/v5-next`'s version → tags `v{version}-private-nightly.<date>` in the private repo (build source) and pushes the same tag to public `next` (the trigger). Guarded to the public repo so the private mirror can't misfire.
- **`.github/workflows/deploy-next-net.yml`** — scheduled deploy resolves `aztecprotocol/aztec:<priv-version>-private-nightly.<date>-amd64` from `private/v5-next` (separate commit, easy to gate).

## Flow
```
01:00  tag v5-next (private, API) + push same tag to public next (PAT) → ci-release builds private worktree → pushes aztecprotocol/aztec:5.0.0-private-nightly.<date>{,-amd64,-arm64}
04:00  deploy-next-net resolves …-private-nightly.<date>-amd64 → deploys next-net
```

## ⚠️ Must land in this order
The public trigger tag runs `ci-release` **from public `next`**, so the `private-nightly` path must already be merged there — **otherwise a `…-private-nightly` tag falls into the generic `private*` path and does a FULL release**, not docker-only. So: merge #23780 → merge this → then enable the tagger.

## Notes
- **next-net behavior change**: it will track the **private v5 line**, not public v6. Intended per "next-net deploys the next deployment", but flagging.
- Private side: `private/v5-next` branch is created (from `private:next`, v5.0.0). No private-repo code change is needed — orchestration is public.