### PR TITLE
fix(pxe): enforce full field consumption at oracle boundaries

### DIFF
--- a/yarn-project/pxe/src/contract_function_simulator/oracle/oracle_registry.test.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/oracle_registry.test.ts
@@ -1,7 +1,11 @@
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { FieldReader } from '@aztec/foundation/serialize';
+import { AztecAddress } from '@aztec/stdlib/aztec-address';
+import { Tag } from '@aztec/stdlib/logs';
 
-import { BYTE, type TypeMapping, U32 } from './oracle_registry.js';
+import { EphemeralArrayService } from '../ephemeral_array_service.js';
+import { LogRetrievalRequest } from '../noir-structs/log_retrieval_request.js';
+import { BYTE, EPHEMERAL_ARRAY, FIELD, LOG_RETRIEVAL_REQUEST, type TypeMapping, U32 } from './oracle_registry.js';
 
 function deserialize<T>(mapping: TypeMapping<T>, value: Fr): T {
   const reader = new FieldReader([value]);
@@ -36,4 +40,35 @@ describe('oracle_registry type mappings', () => {
       expect(() => deserialize(BYTE, new Fr(256))).toThrow('BYTE overflow');
     });
   });
+
+  describe('EPHEMERAL_ARRAY', () => {
+    it('deserializes well-formed rows', () => {
+      const a = Fr.random();
+      const b = Fr.random();
+      expect(readEphemeralArray(FIELD, [[a], [b]])).toEqual([a, b]);
+    });
+
+    it('rejects a row with too few fields', () => {
+      expect(() => readEphemeralArray(FIELD, [[]])).toThrow('Not enough fields to be consumed.');
+    });
+
+    it('rejects a row with trailing fields', () => {
+      expect(() => readEphemeralArray(FIELD, [[Fr.random(), Fr.random()]])).toThrow('unexpected trailing field(s)');
+    });
+
+    it('rejects a multi-field row with trailing fields', async () => {
+      const row = new LogRetrievalRequest(await AztecAddress.random(), new Tag(Fr.random())).toFields();
+      expect(() => readEphemeralArray(LOG_RETRIEVAL_REQUEST, [[...row, Fr.random()]])).toThrow(
+        'unexpected trailing field(s)',
+      );
+    });
+  });
 });
+
+/** Reads an input-mode EphemeralArray backed by `rows`, the way the registry does when deserializing an oracle param. */
+function readEphemeralArray<T>(element: TypeMapping<T>, rows: Fr[][]): T[] {
+  const service = new EphemeralArrayService();
+  const slot = service.newArray(rows);
+  const array = EPHEMERAL_ARRAY(element).deserialization!.fn([new FieldReader([slot])]);
+  return array.readAll(service);
+}

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/oracle_registry.test.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/oracle_registry.test.ts
@@ -5,7 +5,15 @@ import { Tag } from '@aztec/stdlib/logs';
 
 import { EphemeralArrayService } from '../ephemeral_array_service.js';
 import { LogRetrievalRequest } from '../noir-structs/log_retrieval_request.js';
-import { BYTE, EPHEMERAL_ARRAY, FIELD, LOG_RETRIEVAL_REQUEST, type TypeMapping, U32 } from './oracle_registry.js';
+import {
+  BOUNDED_VEC,
+  BYTE,
+  EPHEMERAL_ARRAY,
+  FIELD,
+  LOG_RETRIEVAL_REQUEST,
+  type TypeMapping,
+  U32,
+} from './oracle_registry.js';
 
 function deserialize<T>(mapping: TypeMapping<T>, value: Fr): T {
   const reader = new FieldReader([value]);
@@ -41,6 +49,29 @@ describe('oracle_registry type mappings', () => {
     });
   });
 
+  describe('BOUNDED_VEC', () => {
+    it('deserializes when capacity equals length', () => {
+      const a = Fr.random();
+      const b = Fr.random();
+      const bv = deserializeBoundedVec(FIELD, [a, b], 2);
+      expect(bv.data).toEqual([a, b]);
+      expect(bv.maxLength).toBe(2);
+    });
+
+    it('deserializes when capacity exceeds length', () => {
+      const a = Fr.random();
+      const bv = deserializeBoundedVec(FIELD, [a], 4);
+      expect(bv.data).toEqual([a]);
+      expect(bv.maxLength).toBe(4);
+    });
+
+    it('deserializes an empty vec with nonzero capacity', () => {
+      const bv = deserializeBoundedVec(FIELD, [], 3);
+      expect(bv.data).toEqual([]);
+      expect(bv.maxLength).toBe(3);
+    });
+  });
+
   describe('EPHEMERAL_ARRAY', () => {
     it('deserializes well-formed rows', () => {
       const a = Fr.random();
@@ -64,6 +95,14 @@ describe('oracle_registry type mappings', () => {
     });
   });
 });
+
+/** Deserializes a BoundedVec from `data` (padded to `capacity` with Fr.ZERO) and a length field. */
+function deserializeBoundedVec<T>(element: TypeMapping<T>, data: Fr[], capacity: number) {
+  const padded = [...data, ...Array(capacity - data.length).fill(Fr.ZERO)];
+  const storageReader = new FieldReader(padded);
+  const lengthReader = new FieldReader([new Fr(data.length)]);
+  return BOUNDED_VEC(element).deserialization!.fn([storageReader, lengthReader]);
+}
 
 /** Reads an input-mode EphemeralArray backed by `rows`, the way the registry does when deserializing an oracle param. */
 function readEphemeralArray<T>(element: TypeMapping<T>, rows: Fr[][]): T[] {

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/oracle_registry.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/oracle_registry.ts
@@ -833,7 +833,7 @@ function ARRAY<T>(element: TypeMapping<T>): TypeMapping<T[]> {
  * slot 1: Fr(2)                                  // actual length
  * ```
  */
-function BOUNDED_VEC<T>(element: TypeMapping<T>): TypeMapping<BoundedVec<T>> {
+export function BOUNDED_VEC<T>(element: TypeMapping<T>): TypeMapping<BoundedVec<T>> {
   return {
     serialization: element.serialization
       ? {
@@ -936,8 +936,8 @@ function BUFFER(bitSize: number): TypeMapping<Buffer> {
 }
 
 export function EPHEMERAL_ARRAY<T>(element: TypeMapping<T>): TypeMapping<EphemeralArray<T>> {
-  // Each row is read from its own reader and must be consumed fully; trailing fields mean malformed input. We wrap
-  // `element` to assert that after deserializing each row.
+  // An EphemeralArray param is a single slot; the per-param assert covers that slot but never sees the
+  // per-row readers materialized in readAll(). Assert full consumption per row here.
   const rowElement: TypeMapping<T> | undefined = element.deserialization
     ? {
         deserialization: {

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/oracle_registry.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/oracle_registry.ts
@@ -773,8 +773,11 @@ function makeEntry<const TParams extends RegistryParam[] = [], TReturnValue = vo
           .slice(offset, offset + slotCount)
           .map(slot => new FieldReader(slot.map(hex => Fr.fromString(hex))));
         offset += slotCount;
-        // Delegate to the TypeMapping's deserializer and tag the result with the param name.
-        return { name: param.name, value: param.type.deserialization.fn(readers) };
+        // Delegate to the TypeMapping's deserializer, assert the param's slots are fully consumed, and tag the
+        // result with the param name.
+        const value = param.type.deserialization.fn(readers);
+        assertReadersConsumed(readers);
+        return { name: param.name, value };
       }) as unknown as InferDeserializedParams<TParams>;
     },
     serializeReturn(result: TReturnValue): OutputSlot[] {
@@ -852,6 +855,9 @@ function BOUNDED_VEC<T>(element: TypeMapping<T>): TypeMapping<BoundedVec<T>> {
             for (let i = 0; i < length; i++) {
               elements.push(element.deserialization!.fn([storageReader]));
             }
+            // Drain the trailing zero-padding (maxLength - length unused element slots) so the storage reader is
+            // fully consumed.
+            storageReader.skip(storageReader.remainingFields());
             return BoundedVec.from<T>({ data: elements, maxLength });
           },
           slots: 2,
@@ -898,11 +904,14 @@ export function OPTION<T>(inner: TypeMapping<T>): TypeMapping<Option<T>> {
       : undefined,
     deserialization: inner.deserialization
       ? {
-          fn: readers => {
-            if (readers[0].readField().isZero()) {
+          fn: ([discriminant, ...innerReaders]) => {
+            if (discriminant.readField().isZero()) {
+              // None still carries zero-filled inner slots on the wire; drain them so the inner readers are fully
+              // consumed.
+              innerReaders.forEach(reader => reader.skip(reader.remainingFields()));
               return Option.none<T>(undefined as unknown as T);
             }
-            return Option.some(inner.deserialization!.fn(readers.slice(1)));
+            return Option.some(inner.deserialization!.fn(innerReaders));
           },
           slots: inner.deserialization.slots + 1,
         }
@@ -927,12 +936,26 @@ function BUFFER(bitSize: number): TypeMapping<Buffer> {
 }
 
 export function EPHEMERAL_ARRAY<T>(element: TypeMapping<T>): TypeMapping<EphemeralArray<T>> {
+  // Each row is read from its own reader and must be consumed fully; trailing fields mean malformed input. We wrap
+  // `element` to assert that after deserializing each row.
+  const rowElement: TypeMapping<T> | undefined = element.deserialization
+    ? {
+        deserialization: {
+          fn: readers => {
+            const value = element.deserialization!.fn(readers);
+            assertReadersConsumed(readers);
+            return value;
+          },
+          slots: element.deserialization.slots,
+        },
+      }
+    : undefined;
   return {
     serialization: element.serialization
       ? { fn: ea => [ea.materializeSlot(v => element.serialization!.fn(v).flat() as Fr[])] }
       : undefined,
-    deserialization: element.deserialization
-      ? { fn: ([reader]) => EphemeralArray.fromSlot(reader.readField(), element), slots: 1 }
+    deserialization: rowElement
+      ? { fn: ([reader]) => EphemeralArray.fromSlot(reader.readField(), rowElement), slots: 1 }
       : undefined,
   };
 }
@@ -969,3 +992,16 @@ type InferDeserializedParams<T extends RegistryParam[]> = {
 };
 
 type MaybePromise<T> = T | Promise<T>;
+
+/**
+ * Asserts that every reader was fully consumed by a deserialization, throwing on leftover fields.
+ */
+function assertReadersConsumed(readers: FieldReader[]): void {
+  readers.forEach((reader, slot) => {
+    if (!reader.isFinished()) {
+      throw new Error(
+        `Malformed oracle input: ${reader.remainingFields()} unexpected trailing field(s) in slot ${slot}`,
+      );
+    }
+  });
+}


### PR DESCRIPTION
## Problem

The `EphemeralArray<T>` refactor in #23649 moved deserialization into the oracle registry but dropped the per-row field-consumption check. Extra trailing fields in an ephemeral-array row, and in oracle parameter slots generally, were silently ignored. A malformed oracle input that should be rejected deserialized as if it were well-formed, weakening the oracle ABI.

## Fix

Adds `assertReadersConsumed` and calls it at the two boundaries where each `FieldReader` wraps exactly one logical value: oracle parameter slots (in `makeEntry`) and ephemeral-array rows (via a wrapped element in `EPHEMERAL_ARRAY`). Trailing fields there now throw. Streaming combinators that deliberately under-consume a shared reader keep working: `BOUNDED_VEC` and `OPTION` drain their trailing zero-padding so the boundary check sees a fully-consumed reader.