### PR TITLE
chore(ci): Static oracle version check

### DIFF
--- a/yarn-project/pxe/src/bin/check_oracle_version.test.ts
+++ b/yarn-project/pxe/src/bin/check_oracle_version.test.ts
@@ -1,0 +1,55 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import { readNumericGlobal } from './check_oracle_version.js';
+
+describe('readNumericGlobal', () => {
+  let dir: string;
+
+  beforeAll(() => {
+    dir = mkdtempSync(join(tmpdir(), 'oracle-version-'));
+  });
+
+  afterAll(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  const writeFixture = (name: string, contents: string): string => {
+    const path = join(dir, name);
+    writeFileSync(path, contents);
+    return path;
+  };
+
+  it('extracts the value from a Noir global declaration', () => {
+    const path = writeFixture(
+      'version.nr',
+      `pub global ORACLE_VERSION_MAJOR: Field = 28;\npub global ORACLE_VERSION_MINOR: Field = 3;\n`,
+    );
+    expect(readNumericGlobal(path, 'ORACLE_VERSION_MAJOR')).toBe(28);
+    expect(readNumericGlobal(path, 'ORACLE_VERSION_MINOR')).toBe(3);
+  });
+
+  it('extracts the value from a TypeScript const declaration', () => {
+    const path = writeFixture('oracle_version.ts', `export const ORACLE_VERSION_MAJOR = 28;\n`);
+    expect(readNumericGlobal(path, 'ORACLE_VERSION_MAJOR')).toBe(28);
+  });
+
+  it('reads the declaration and ignores later usages of the constant', () => {
+    const path = writeFixture(
+      'usage.nr',
+      `pub global TXE_ORACLE_VERSION_MAJOR: Field = 5;\nfoo(TXE_ORACLE_VERSION_MAJOR, TXE_ORACLE_VERSION_MINOR);\n`,
+    );
+    expect(readNumericGlobal(path, 'TXE_ORACLE_VERSION_MAJOR')).toBe(5);
+  });
+
+  it('does not match a constant whose name extends the requested name', () => {
+    const path = writeFixture('prefixed.nr', `pub global SOME_ORACLE_VERSION_MAJOR: Field = 9;\n`);
+    expect(() => readNumericGlobal(path, 'ORACLE_VERSION_MAJOR')).toThrow(/Could not find numeric global/);
+  });
+
+  it('throws when the global is absent', () => {
+    const path = writeFixture('empty.nr', `pub global SOMETHING_ELSE: Field = 1;\n`);
+    expect(() => readNumericGlobal(path, 'ORACLE_VERSION_MAJOR')).toThrow(/Could not find numeric global/);
+  });
+});

--- a/yarn-project/pxe/src/bin/check_oracle_version.test.ts
+++ b/yarn-project/pxe/src/bin/check_oracle_version.test.ts
@@ -2,7 +2,7 @@ import { mkdtempSync, rmSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 
-import { readNumericGlobal } from './check_oracle_version.js';
+import { readNumericGlobal } from './oracle_version_helpers.js';
 
 describe('readNumericGlobal', () => {
   let dir: string;

--- a/yarn-project/pxe/src/bin/check_oracle_version.ts
+++ b/yarn-project/pxe/src/bin/check_oracle_version.ts
@@ -1,12 +1,10 @@
-/* eslint-disable import-x/no-named-as-default-member */
 import { keccak256String } from '@aztec/foundation/crypto/keccak';
 
-import { readFileSync } from 'fs';
 import { dirname, join } from 'path';
-import ts from 'typescript';
 import { fileURLToPath } from 'url';
 
 import { ORACLE_INTERFACE_HASH, ORACLE_VERSION_MAJOR } from '../oracle_version.js';
+import { getOracleInterfaceSignature, readNumericGlobal } from './oracle_version_helpers.js';
 
 /**
  * Verifies that the Oracle interface matches the expected interface hash.
@@ -84,150 +82,6 @@ function assertContractOracleVersionMajorInSync(): void {
     const details = copies.map(copy => `${copy.label}=${copy.value}`).join(', ');
     throw new Error(`ORACLE_VERSION_MAJOR is out of sync: ${details}. Bump all copies together.`);
   }
-}
-
-/**
- * Extracts method signatures from TypeScript classes or interfaces and returns a deterministic string representation.
- *
- * This is used to detect when an oracle interface changes so that the oracle version can be bumped. It works with both
- * class declarations (e.g. PXE's `Oracle` class) and interface declarations (e.g. TXE's `IAvmExecutionOracle`).
- *
- * @param sourcePath - Absolute path to the TypeScript source file to parse.
- * @param targets - Names of classes or interfaces to extract methods from.
- * @param excludedMembers - Method names to skip (e.g. non-oracle helpers like `constructor`).
- */
-export function getOracleInterfaceSignature(sourcePath: string, targets: string[], excludedMembers: string[]): string {
-  // Read and parse the TypeScript source file
-  const sourceCode = readFileSync(sourcePath, 'utf-8');
-  const sourceFile = ts.createSourceFile(sourcePath, sourceCode, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
-
-  // Extract method signatures from the target classes/interfaces
-  const methodSignatures: string[] = [];
-
-  function visit(node: ts.Node) {
-    // Look for class or interface declarations matching the target names
-    const isTarget =
-      (ts.isClassDeclaration(node) || ts.isInterfaceDeclaration(node)) && targets.includes(node.name?.text ?? '');
-
-    if (isTarget) {
-      // Visit all members of the class/interface
-      node.members.forEach(member => {
-        if (
-          (ts.isMethodDeclaration(member) || ts.isMethodSignature(member)) &&
-          member.name &&
-          ts.isIdentifier(member.name)
-        ) {
-          const methodName = member.name.text;
-
-          // Skip excluded methods
-          if (excludedMembers.includes(methodName)) {
-            return;
-          }
-
-          // Extract parameter signatures
-          const paramSignatures: string[] = [];
-          member.parameters.forEach(param => {
-            const paramName = extractParameterName(param, sourceFile);
-            const paramType = extractTypeString(param.type, sourceFile);
-            paramSignatures.push(`${paramName}: ${paramType}`);
-          });
-
-          // Extract return type
-          const returnType = extractTypeString(member.type, sourceFile);
-
-          // Build full signature: methodName(param1: Type1, param2: Type2): ReturnType
-          const signature = `${methodName}(${paramSignatures.join(', ')}): ${returnType}`;
-          methodSignatures.push(signature);
-        }
-      });
-    }
-
-    ts.forEachChild(node, visit);
-  }
-
-  visit(sourceFile);
-
-  // Sort signatures alphabetically for consistent hashing
-  methodSignatures.sort();
-
-  // Create a hashable representation by concatenating all signatures
-  return methodSignatures.join('');
-}
-
-/**
- * Reads an integer-valued global constant from a Noir or TypeScript source file.
- *
- * Matches both the Noir form (`pub global NAME: Field = N;`) and the TypeScript form (`export const NAME = N;`). This
- * lets us compare a version constant that is hand-duplicated across the TS and Noir layers (which can't import each
- * other) without depending on either compiler. Only the assignment form `NAME = N` matches, so later usages of the
- * constant are ignored regardless of their order in the file.
- *
- * @param sourcePath - Absolute path to the source file to read.
- * @param name - Name of the global constant whose integer value should be extracted.
- * @returns The integer value assigned to the constant.
- * @throws If the constant's declaration is not found in the file.
- */
-export function readNumericGlobal(sourcePath: string, name: string): number {
-  const sourceCode = readFileSync(sourcePath, 'utf-8');
-  const match = sourceCode.match(new RegExp(`\\b${name}\\s*(?::\\s*\\w+\\s*)?=\\s*(\\d+)`));
-  if (!match) {
-    throw new Error(`Could not find numeric global '${name}' in ${sourcePath}.`);
-  }
-  return Number(match[1]);
-}
-
-/**
- * Extracts the parameter name from a parameter node, handling destructured parameters.
- */
-function extractParameterName(param: ts.ParameterDeclaration, sourceFile: ts.SourceFile): string {
-  const name = param.name;
-
-  if (ts.isIdentifier(name)) {
-    return name.text;
-  }
-
-  if (ts.isArrayBindingPattern(name)) {
-    // Handle destructured parameters like [blockNumber]: ACVMField[]
-    // Extract the first element name
-    if (name.elements.length > 0) {
-      const element = name.elements[0];
-      if (ts.isBindingElement(element)) {
-        const elementName = element.name;
-        if (ts.isIdentifier(elementName)) {
-          return elementName.text;
-        }
-        // Nested destructuring - use text representation
-        if (ts.isArrayBindingPattern(elementName) || ts.isObjectBindingPattern(elementName)) {
-          return elementName.getText(sourceFile);
-        }
-      }
-    }
-    // Fallback: return the text representation
-    return name.getText(sourceFile);
-  }
-
-  if (ts.isObjectBindingPattern(name)) {
-    // Handle object destructuring
-    return name.getText(sourceFile);
-  }
-
-  // Fallback for any other case - this should never happen but TypeScript needs it
-  return (name as ts.Node).getText(sourceFile);
-}
-
-/**
- * Extracts the type string from a type node, normalizing whitespace.
- */
-function extractTypeString(typeNode: ts.TypeNode | undefined, sourceFile: ts.SourceFile): string {
-  if (!typeNode) {
-    return 'void';
-  }
-
-  // Get the type text and normalize whitespace
-  let typeText = typeNode.getText(sourceFile);
-  // Normalize whitespace: remove extra spaces, newlines, and tabs
-  typeText = typeText.replace(/\s+/g, ' ').trim();
-  return typeText;
 }
 
 assertOracleInterfaceMatches();

--- a/yarn-project/pxe/src/bin/check_oracle_version.ts
+++ b/yarn-project/pxe/src/bin/check_oracle_version.ts
@@ -50,7 +50,7 @@ function assertOracleInterfaceMatches(): void {
  * Verifies that `ORACLE_VERSION_MAJOR` is identical across all of its hand-maintained copies.
  *
  * The major version is duplicated across the PXE TypeScript constant and two Noir constants (Aztec.nr and the protocol
- * contracts' `aztec_sublib`) because those layers can't import each other. This static check fails fastvat build time,
+ * contracts' `aztec_sublib`) because those layers can't import each other. This static check fails fast at build time,
  * naming each file and its value.
  *
  * Only the major version is checked: the minor version legitimately diverges under the "environment minor >= contract

--- a/yarn-project/pxe/src/bin/check_oracle_version.ts
+++ b/yarn-project/pxe/src/bin/check_oracle_version.ts
@@ -6,7 +6,7 @@ import { dirname, join } from 'path';
 import ts from 'typescript';
 import { fileURLToPath } from 'url';
 
-import { ORACLE_INTERFACE_HASH } from '../oracle_version.js';
+import { ORACLE_INTERFACE_HASH, ORACLE_VERSION_MAJOR } from '../oracle_version.js';
 
 /**
  * Verifies that the Oracle interface matches the expected interface hash.
@@ -43,6 +43,47 @@ function assertOracleInterfaceMatches(): void {
     throw new Error(
       `The Oracle interface has changed. Update ORACLE_INTERFACE_HASH to ${oracleInterfaceHash} in pxe/src/oracle_version.ts and bump the oracle version (ORACLE_VERSION_MAJOR for breaking changes, ORACLE_VERSION_MINOR for oracle additions).`,
     );
+  }
+}
+
+/**
+ * Verifies that `ORACLE_VERSION_MAJOR` is identical across all of its hand-maintained copies.
+ *
+ * The major version is duplicated across the PXE TypeScript constant and two Noir constants (Aztec.nr and the protocol
+ * contracts' `aztec_sublib`) because those layers can't import each other. A mismatch is only caught at runtime today,
+ * deep inside an e2e run, with a cryptic "Incompatible private environment version" error. This static check fails fast
+ * at build time instead, naming each file and its value.
+ *
+ * Only the major version is checked: the minor version legitimately diverges under the "environment minor >= contract
+ * minor" tolerance, so asserting minor equality would false-positive.
+ */
+function assertContractOracleVersionMajorInSync(): void {
+  const currentDir = dirname(fileURLToPath(import.meta.url));
+  // Go up from dest/bin/ or src/bin/ to the package root (pxe/), then up two more to the git root.
+  const packageRoot = dirname(dirname(currentDir));
+  const gitRoot = join(packageRoot, '..', '..');
+
+  const copies = [
+    { label: 'pxe/src/oracle_version.ts', value: ORACLE_VERSION_MAJOR },
+    {
+      label: 'aztec-nr/aztec/src/oracle/version.nr',
+      value: readNumericGlobal(
+        join(gitRoot, 'noir-projects/aztec-nr/aztec/src/oracle/version.nr'),
+        'ORACLE_VERSION_MAJOR',
+      ),
+    },
+    {
+      label: 'aztec_sublib/src/oracle/version.nr',
+      value: readNumericGlobal(
+        join(gitRoot, 'noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/oracle/version.nr'),
+        'ORACLE_VERSION_MAJOR',
+      ),
+    },
+  ];
+
+  if (new Set(copies.map(copy => copy.value)).size > 1) {
+    const details = copies.map(copy => `${copy.label}=${copy.value}`).join(', ');
+    throw new Error(`ORACLE_VERSION_MAJOR is out of sync: ${details}. Bump all copies together.`);
   }
 }
 
@@ -115,6 +156,28 @@ export function getOracleInterfaceSignature(sourcePath: string, targets: string[
 }
 
 /**
+ * Reads an integer-valued global constant from a Noir or TypeScript source file.
+ *
+ * Matches both the Noir form (`pub global NAME: Field = N;`) and the TypeScript form (`export const NAME = N;`). This
+ * lets us compare a version constant that is hand-duplicated across the TS and Noir layers (which can't import each
+ * other) without depending on either compiler. Only the assignment form `NAME = N` matches, so later usages of the
+ * constant are ignored regardless of their order in the file.
+ *
+ * @param sourcePath - Absolute path to the source file to read.
+ * @param name - Name of the global constant whose integer value should be extracted.
+ * @returns The integer value assigned to the constant.
+ * @throws If the constant's declaration is not found in the file.
+ */
+export function readNumericGlobal(sourcePath: string, name: string): number {
+  const sourceCode = readFileSync(sourcePath, 'utf-8');
+  const match = sourceCode.match(new RegExp(`\\b${name}\\s*(?::\\s*\\w+\\s*)?=\\s*(\\d+)`));
+  if (!match) {
+    throw new Error(`Could not find numeric global '${name}' in ${sourcePath}.`);
+  }
+  return Number(match[1]);
+}
+
+/**
  * Extracts the parameter name from a parameter node, handling destructured parameters.
  */
 function extractParameterName(param: ts.ParameterDeclaration, sourceFile: ts.SourceFile): string {
@@ -169,3 +232,4 @@ function extractTypeString(typeNode: ts.TypeNode | undefined, sourceFile: ts.Sou
 }
 
 assertOracleInterfaceMatches();
+assertContractOracleVersionMajorInSync();

--- a/yarn-project/pxe/src/bin/check_oracle_version.ts
+++ b/yarn-project/pxe/src/bin/check_oracle_version.ts
@@ -50,9 +50,8 @@ function assertOracleInterfaceMatches(): void {
  * Verifies that `ORACLE_VERSION_MAJOR` is identical across all of its hand-maintained copies.
  *
  * The major version is duplicated across the PXE TypeScript constant and two Noir constants (Aztec.nr and the protocol
- * contracts' `aztec_sublib`) because those layers can't import each other. A mismatch is only caught at runtime today,
- * deep inside an e2e run, with a cryptic "Incompatible private environment version" error. This static check fails fast
- * at build time instead, naming each file and its value.
+ * contracts' `aztec_sublib`) because those layers can't import each other. This static check fails fastvat build time,
+ * naming each file and its value.
  *
  * Only the major version is checked: the minor version legitimately diverges under the "environment minor >= contract
  * minor" tolerance, so asserting minor equality would false-positive.

--- a/yarn-project/pxe/src/bin/index.ts
+++ b/yarn-project/pxe/src/bin/index.ts
@@ -1,1 +1,1 @@
-export { getOracleInterfaceSignature, readNumericGlobal } from './check_oracle_version.js';
+export { getOracleInterfaceSignature, readNumericGlobal } from './oracle_version_helpers.js';

--- a/yarn-project/pxe/src/bin/index.ts
+++ b/yarn-project/pxe/src/bin/index.ts
@@ -1,1 +1,1 @@
-export { getOracleInterfaceSignature } from './check_oracle_version.js';
+export { getOracleInterfaceSignature, readNumericGlobal } from './check_oracle_version.js';

--- a/yarn-project/pxe/src/bin/oracle_version_helpers.ts
+++ b/yarn-project/pxe/src/bin/oracle_version_helpers.ts
@@ -1,0 +1,121 @@
+/* eslint-disable import-x/no-named-as-default-member */
+import { readFileSync } from 'fs';
+import ts from 'typescript';
+
+/**
+ * Extracts method signatures from TypeScript classes or interfaces and returns a deterministic string representation.
+ *
+ * This is used to detect when an oracle interface changes so that the oracle version can be bumped. It works with both
+ * class declarations (e.g. PXE's `Oracle` class) and interface declarations (e.g. TXE's `IAvmExecutionOracle`).
+ *
+ * @param sourcePath - Absolute path to the TypeScript source file to parse.
+ * @param targets - Names of classes or interfaces to extract methods from.
+ * @param excludedMembers - Method names to skip (e.g. non-oracle helpers like `constructor`).
+ */
+export function getOracleInterfaceSignature(sourcePath: string, targets: string[], excludedMembers: string[]): string {
+  const sourceCode = readFileSync(sourcePath, 'utf-8');
+  const sourceFile = ts.createSourceFile(sourcePath, sourceCode, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
+
+  const methodSignatures: string[] = [];
+
+  function visit(node: ts.Node) {
+    const isTarget =
+      (ts.isClassDeclaration(node) || ts.isInterfaceDeclaration(node)) && targets.includes(node.name?.text ?? '');
+
+    if (isTarget) {
+      node.members.forEach(member => {
+        if (
+          (ts.isMethodDeclaration(member) || ts.isMethodSignature(member)) &&
+          member.name &&
+          ts.isIdentifier(member.name)
+        ) {
+          const methodName = member.name.text;
+
+          if (excludedMembers.includes(methodName)) {
+            return;
+          }
+
+          const paramSignatures: string[] = [];
+          member.parameters.forEach(param => {
+            const paramName = extractParameterName(param, sourceFile);
+            const paramType = extractTypeString(param.type, sourceFile);
+            paramSignatures.push(`${paramName}: ${paramType}`);
+          });
+
+          const returnType = extractTypeString(member.type, sourceFile);
+
+          const signature = `${methodName}(${paramSignatures.join(', ')}): ${returnType}`;
+          methodSignatures.push(signature);
+        }
+      });
+    }
+
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+
+  methodSignatures.sort();
+
+  return methodSignatures.join('');
+}
+
+/**
+ * Reads an integer-valued global constant from a Noir or TypeScript source file.
+ *
+ * Matches both the Noir form (`pub global NAME: Field = N;`) and the TypeScript form (`export const NAME = N;`). This
+ * lets us compare a version constant that is hand-duplicated across the TS and Noir layers (which can't import each
+ * other) without depending on either compiler. Only the assignment form `NAME = N` matches, so later usages of the
+ * constant are ignored regardless of their order in the file.
+ *
+ * @param sourcePath - Absolute path to the source file to read.
+ * @param name - Name of the global constant whose integer value should be extracted.
+ * @returns The integer value assigned to the constant.
+ * @throws If the constant's declaration is not found in the file.
+ */
+export function readNumericGlobal(sourcePath: string, name: string): number {
+  const sourceCode = readFileSync(sourcePath, 'utf-8');
+  const match = sourceCode.match(new RegExp(`\\b${name}\\s*(?::\\s*\\w+\\s*)?=\\s*(\\d+)`));
+  if (!match) {
+    throw new Error(`Could not find numeric global '${name}' in ${sourcePath}.`);
+  }
+  return Number(match[1]);
+}
+
+function extractParameterName(param: ts.ParameterDeclaration, sourceFile: ts.SourceFile): string {
+  const name = param.name;
+
+  if (ts.isIdentifier(name)) {
+    return name.text;
+  }
+
+  if (ts.isArrayBindingPattern(name)) {
+    if (name.elements.length > 0) {
+      const element = name.elements[0];
+      if (ts.isBindingElement(element)) {
+        const elementName = element.name;
+        if (ts.isIdentifier(elementName)) {
+          return elementName.text;
+        }
+        if (ts.isArrayBindingPattern(elementName) || ts.isObjectBindingPattern(elementName)) {
+          return elementName.getText(sourceFile);
+        }
+      }
+    }
+    return name.getText(sourceFile);
+  }
+
+  if (ts.isObjectBindingPattern(name)) {
+    return name.getText(sourceFile);
+  }
+
+  return (name as ts.Node).getText(sourceFile);
+}
+
+function extractTypeString(typeNode: ts.TypeNode | undefined, sourceFile: ts.SourceFile): string {
+  if (!typeNode) {
+    return 'void';
+  }
+
+  return typeNode.getText(sourceFile).replace(/\s+/g, ' ').trim();
+}

--- a/yarn-project/txe/src/bin/check_txe_oracle_version.ts
+++ b/yarn-project/txe/src/bin/check_txe_oracle_version.ts
@@ -1,10 +1,10 @@
 import { keccak256String } from '@aztec/foundation/crypto/keccak';
-import { getOracleInterfaceSignature } from '@aztec/pxe/bin';
+import { getOracleInterfaceSignature, readNumericGlobal } from '@aztec/pxe/bin';
 
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 
-import { TXE_ORACLE_INTERFACE_HASH } from '../txe_oracle_version.js';
+import { TXE_ORACLE_INTERFACE_HASH, TXE_ORACLE_VERSION_MAJOR } from '../txe_oracle_version.js';
 
 /**
  * Verifies that the TXE oracle interfaces match the expected interface hash.
@@ -34,4 +34,37 @@ function assertTxeOracleInterfaceMatches(): void {
   }
 }
 
+/**
+ * Verifies that `TXE_ORACLE_VERSION_MAJOR` is identical across its two hand-maintained copies: the TXE TypeScript
+ * constant and the Aztec.nr Noir test helper constant. These layers can't import each other, so the major version is
+ * duplicated by hand and a mismatch otherwise only surfaces at runtime. This is the TXE counterpart of the contract
+ * oracle version check in `pxe/src/bin/check_oracle_version.ts`; the two version families are tracked separately.
+ *
+ * Only the major version is checked: the minor version legitimately diverges under the "environment minor >= contract
+ * minor" tolerance, so asserting minor equality would false-positive.
+ */
+function assertTxeOracleVersionMajorInSync(): void {
+  const currentDir = dirname(fileURLToPath(import.meta.url));
+  // Go up from dest/bin/ or src/bin/ to the package root (txe/), then up two more to the git root.
+  const packageRoot = dirname(dirname(currentDir));
+  const gitRoot = join(packageRoot, '..', '..');
+
+  const copies = [
+    { label: 'txe/src/txe_oracle_version.ts', value: TXE_ORACLE_VERSION_MAJOR },
+    {
+      label: 'aztec-nr/aztec/src/test/helpers/txe_oracles.nr',
+      value: readNumericGlobal(
+        join(gitRoot, 'noir-projects/aztec-nr/aztec/src/test/helpers/txe_oracles.nr'),
+        'TXE_ORACLE_VERSION_MAJOR',
+      ),
+    },
+  ];
+
+  if (new Set(copies.map(copy => copy.value)).size > 1) {
+    const details = copies.map(copy => `${copy.label}=${copy.value}`).join(', ');
+    throw new Error(`TXE_ORACLE_VERSION_MAJOR is out of sync: ${details}. Bump all copies together.`);
+  }
+}
+
 assertTxeOracleInterfaceMatches();
+assertTxeOracleVersionMajorInSync();


### PR DESCRIPTION
No issue, fixes confusing CI errors I ran into on https://github.com/AztecProtocol/aztec-packages/pull/23796 when the `aztec_sublib` oracle version was not updated http://ci.aztec-labs.com/83a883aee887f12c:
<details><summary>Details</summary>
<p>

```
17:46:29 
17:46:29   ● e2e_blacklist_token_contract transfer public › failure cases › transfer from a blacklisted account
17:46:29 
17:46:29     TypeError: Cannot read properties of undefined (reading 'check')
17:46:29 
17:46:29       22 |
17:46:29       23 |   afterEach(async () => {
17:46:29     > 24 |     await t.tokenSim.check();
17:46:29          |                      ^
17:46:29       25 |   });
17:46:29       26 |
17:46:29       27 |   it('transfer less than balance', async () => {
17:46:29 
17:46:29       at Object.check (e2e_blacklist_token_contract/transfer_public.test.ts:24:22)
17:46:29 
17:46:29   ● e2e_blacklist_token_contract transfer public › failure cases › transfer to a blacklisted account
17:46:29 
17:46:29     Simulation error: Incompatible private environment version: The contract was compiled with an older version of Aztec.nr than your private environment supports. Recompile the contract with a compatible version of Aztec.nr. See https://docs.aztec.network/errors/8 (expected oracle major version 28, got 27)
17:46:29 
17:46:29       at ContractClassRegistry.publish
17:46:29       at MultiCallEntrypoint.entrypoint
17:46:29 
17:46:29     Cause:
17:46:29     Incompatible private environment version: The contract was compiled with an older version of Aztec.nr than your private environment supports. Recompile the contract with a compatible version of Aztec.nr. See https://docs.aztec.network/errors/8 (expected oracle major version 28, got 27)
17:46:29 
17:46:29       85 |         if (major !== ORACLE_VERSION_MAJOR) {
17:46:29       86 |             const hint = major > ORACLE_VERSION_MAJOR ? 'The contract was compiled with a newer version of Aztec.nr than your private environment supports. Upgrade your private environment to a compatible version.' : 'The contract was compiled with an older version of Aztec.nr than your private environment supports. Recompile the contract with a compatible version of Aztec.nr.';
17:46:29     > 87 |             throw new Error(`Incompatible private environment version: ${hint} See https://docs.aztec.network/errors/8 (expected oracle major version ${ORACLE_VERSION_MAJOR}, got ${major})`);
17:46:29          |                   ^
17:46:29       88 |         }
17:46:29       89 |         this.contractOracleVersion = {
17:46:29       90 |             major,
17:46:29 
17:46:29       at PrivateExecutionOracle.assertCompatibleOracleVersion (../../pxe/dest/contract_function_simulator/oracle/utility_execution_oracle.js:87:19)
```

</p>
</details> 

We are told there is an oracle mismatch, but there is nothing to indicate it is in the aztec-nr sublib as I had already updated the actual aztec-nr version constant. The error also only comes about at runtime in an e2e test. We should be able to error out in the pre-existing `check_oracle_version` scripts for pxe/txe. 