### PR TITLE
fix: embedded wallet defaults to proposed

### DIFF
--- a/boxes/boxes/react/src/hooks/useContract.tsx
+++ b/boxes/boxes/react/src/hooks/useContract.tsx
@@ -3,6 +3,7 @@ import { deployerEnv } from '../config';
 
 import { Contract } from '@aztec/aztec.js/contracts';
 import { Fr } from '@aztec/aztec.js/fields';
+import { TxStatus } from '@aztec/aztec.js/tx';
 import { toast } from 'react-toastify';
 
 export function useContract() {
@@ -20,6 +21,8 @@ export function useContract() {
 
     const deploymentPromise = BoxReactContract.deploy(wallet, Fr.random(), defaultAccountAddress).send({
       from: defaultAccountAddress,
+      // PROPOSED (the wallet default) is flaky in boxes CI, so wait for the checkpoint.
+      wait: { waitForStatus: TxStatus.CHECKPOINTED },
     });
 
     const { contract } = await toast.promise(deploymentPromise, {

--- a/boxes/boxes/react/src/hooks/useNumber.tsx
+++ b/boxes/boxes/react/src/hooks/useNumber.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { Contract } from '@aztec/aztec.js/contracts';
+import { TxStatus } from '@aztec/aztec.js/tx';
 import { toast } from 'react-toastify';
 import { deployerEnv } from '../config';
 
@@ -28,7 +29,10 @@ export function useNumber({ contract }: { contract: Contract }) {
       const value = BigInt(el.value);
       const defaultAccountAddress = deployerEnv.getDefaultAccountAddress();
       await toast.promise(
-        contract!.methods.setNumber(value, defaultAccountAddress).send({ from: defaultAccountAddress }),
+        // PROPOSED (the wallet default) is flaky in boxes CI, so wait for the checkpoint.
+        contract!.methods
+          .setNumber(value, defaultAccountAddress)
+          .send({ from: defaultAccountAddress, wait: { waitForStatus: TxStatus.CHECKPOINTED } }),
         {
           pending: 'Setting number...',
           success: `Number set to: ${value}`,

--- a/boxes/boxes/vanilla/app/embedded-wallet.ts
+++ b/boxes/boxes/vanilla/app/embedded-wallet.ts
@@ -6,6 +6,7 @@ import {
 import { SponsoredFeePaymentMethod } from '@aztec/aztec.js/fee';
 import { Fr } from '@aztec/aztec.js/fields';
 import { createLogger } from '@aztec/aztec.js/log';
+import { TxStatus } from '@aztec/aztec.js/tx';
 import { DeployAccountOptions } from '@aztec/aztec.js/wallet';
 import type { AztecNode } from '@aztec/aztec.js/node';
 import {
@@ -143,7 +144,8 @@ export class EmbeddedWallet extends EmbeddedWalletBase {
       },
       skipClassPublication: true,
       skipInstancePublication: true,
-      wait: { timeout: 120 },
+      // PROPOSED (the wallet default) is flaky in boxes CI, so wait for the checkpoint.
+      wait: { timeout: 120, waitForStatus: TxStatus.CHECKPOINTED },
     };
 
     const { receipt } = await deployMethod.send(deployOpts);

--- a/boxes/boxes/vanilla/app/main.ts
+++ b/boxes/boxes/vanilla/app/main.ts
@@ -5,6 +5,7 @@ import {
   getContractInstanceFromInstantiationParams,
 } from '@aztec/aztec.js/contracts';
 import { Fr } from '@aztec/aztec.js/fields';
+import { TxStatus } from '@aztec/aztec.js/tx';
 import type { Wallet } from '@aztec/aztec.js/wallet';
 import { EmbeddedWallet } from './embedded-wallet';
 import { PrivateVotingContract } from '../artifacts/PrivateVoting';
@@ -162,7 +163,11 @@ voteButton.addEventListener('click', async (e) => {
     // Send tx
     await votingContract.methods
       .cast_vote({ id: electionId }, candidate)
-      .send({ from: connectedAccount });
+      // PROPOSED (the wallet default) is flaky in boxes CI, so wait for the checkpoint.
+      .send({
+        from: connectedAccount,
+        wait: { waitForStatus: TxStatus.CHECKPOINTED },
+      });
 
     // Update tally
     displayStatusMessage('Updating vote tally...');
@@ -198,7 +203,10 @@ async function updateVoteTally(wallet: Wallet, from: AztecAddress) {
     )
   );
 
-  const { result: batchResult } = await new BatchCall(wallet, payloads).simulate({ from });
+  const { result: batchResult } = await new BatchCall(
+    wallet,
+    payloads
+  ).simulate({ from });
 
   batchResult.forEach(({ result: value }, i) => {
     results[i + 1] = value;

--- a/boxes/boxes/vanilla/scripts/deploy.ts
+++ b/boxes/boxes/vanilla/scripts/deploy.ts
@@ -8,6 +8,7 @@ import {
 import { SponsoredFeePaymentMethod } from '@aztec/aztec.js/fee';
 import { Fr } from '@aztec/aztec.js/fields';
 import { PublicKeys } from '@aztec/aztec.js/keys';
+import { TxStatus } from '@aztec/aztec.js/tx';
 import { createAztecNodeClient } from '@aztec/aztec.js/node';
 import type { DeployAccountOptions, Wallet } from '@aztec/aztec.js/wallet';
 import { type AztecNode } from '@aztec/aztec.js/node';
@@ -60,7 +61,8 @@ async function createAccount(wallet: EmbeddedWallet) {
     },
     skipClassPublication: true,
     skipInstancePublication: true,
-    wait: { timeout: 120 },
+    // PROPOSED (the wallet default) is flaky in boxes CI, so wait for the checkpoint.
+    wait: { timeout: 120, waitForStatus: TxStatus.CHECKPOINTED },
   };
   await deployMethod.send(deployOpts);
 
@@ -81,7 +83,8 @@ async function deployContract(wallet: Wallet, deployer: AztecAddress) {
         sponsoredPFCContract.address
       ),
     },
-    wait: { timeout: 120 },
+    // PROPOSED (the wallet default) is flaky in CI, so wait for the checkpoint.
+    wait: { timeout: 120, waitForStatus: TxStatus.CHECKPOINTED },
   });
 
   const electionId = new Fr(42);
@@ -93,7 +96,8 @@ async function deployContract(wallet: Wallet, deployer: AztecAddress) {
         sponsoredPFCContract.address
       ),
     },
-    wait: { timeout: 120 },
+    // PROPOSED (the wallet default) is flaky in CI, so wait for the checkpoint.
+    wait: { timeout: 120, waitForStatus: TxStatus.CHECKPOINTED },
   });
 
   return {

--- a/boxes/boxes/vite/src/hooks/useContract.tsx
+++ b/boxes/boxes/vite/src/hooks/useContract.tsx
@@ -3,6 +3,7 @@ import { deployerEnv } from '../config';
 
 import { Contract } from '@aztec/aztec.js/contracts';
 import { Fr } from '@aztec/aztec.js/fields';
+import { TxStatus } from '@aztec/aztec.js/tx';
 import { toast } from 'react-toastify';
 
 export function useContract() {
@@ -20,6 +21,8 @@ export function useContract() {
 
     const deploymentPromise = BoxReactContract.deploy(wallet, Fr.random(), defaultAccountAddress).send({
       from: defaultAccountAddress,
+      // PROPOSED (the wallet default) is flaky in boxes CI, so wait for the checkpoint.
+      wait: { waitForStatus: TxStatus.CHECKPOINTED },
     });
 
     const { contract } = await toast.promise(deploymentPromise, {

--- a/boxes/boxes/vite/src/hooks/useNumber.tsx
+++ b/boxes/boxes/vite/src/hooks/useNumber.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { Contract } from '@aztec/aztec.js/contracts';
+import { TxStatus } from '@aztec/aztec.js/tx';
 import { toast } from 'react-toastify';
 import { deployerEnv } from '../config';
 
@@ -28,7 +29,10 @@ export function useNumber({ contract }: { contract: Contract }) {
       const value = BigInt(el.value);
       const defaultAccountAddress = deployerEnv.getDefaultAccountAddress();
       await toast.promise(
-        contract!.methods.setNumber(value, defaultAccountAddress).send({ from: defaultAccountAddress }),
+        // PROPOSED (the wallet default) is flaky in boxes CI, so wait for the checkpoint.
+        contract!.methods
+          .setNumber(value, defaultAccountAddress)
+          .send({ from: defaultAccountAddress, wait: { waitForStatus: TxStatus.CHECKPOINTED } }),
         {
           pending: 'Setting number...',
           success: `Number set to: ${value}`,

--- a/yarn-project/wallets/src/embedded/embedded_wallet.ts
+++ b/yarn-project/wallets/src/embedded/embedded_wallet.ts
@@ -1,6 +1,12 @@
 import { type Account, NO_FROM } from '@aztec/aztec.js/account';
 import { CallAuthorizationRequest } from '@aztec/aztec.js/authorization';
-import { type InteractionWaitOptions, type SendReturn, type WaitOpts, getGasLimits } from '@aztec/aztec.js/contracts';
+import {
+  type InteractionWaitOptions,
+  NO_WAIT,
+  type SendReturn,
+  type WaitOpts,
+  getGasLimits,
+} from '@aztec/aztec.js/contracts';
 import type {
   Aliased,
   ExecuteUtilityOptions,
@@ -196,20 +202,23 @@ export class EmbeddedWallet extends BaseWallet {
       gasLimits: opts.fee?.gasSettings?.gasLimits ?? estimated.gasLimits,
       teardownGasLimits: opts.fee?.gasSettings?.teardownGasLimits ?? estimated.teardownGasLimits,
     });
-    const waitOpts: WaitOpts = typeof opts.wait === 'object' ? opts.wait : {};
-
-    if (!waitOpts?.waitForStatus) {
-      // Default to PROPOSED so the wait returns as soon as the tx lands in a proposed L2 block,
-      // rather than waiting until the end of the slot for the checkpoint to be published to L1.
-      // This is what makes MBPS (Multiple Blocks Per Slot) actually improve UX: with CHECKPOINTED
-      // we'd block until L1 inclusion regardless of how early in the slot the tx was sequenced.
-      // The tradeoff is a weaker guarantee — a proposed block only becomes canonical once it (or
-      // a later block in the same slot) is checkpointed, so a tx could be re-orged out if the
-      // proposer fails to publish to L1 (which should be rare, since they'd get slashed for it).
-      waitOpts!.waitForStatus = TxStatus.PROPOSED;
+    if (opts.wait !== NO_WAIT) {
+      const waitOpts: WaitOpts = typeof opts.wait === 'object' ? opts.wait : {};
+      if (!waitOpts.waitForStatus) {
+        // Default to PROPOSED so the wait returns as soon as the tx lands in a proposed L2 block,
+        // rather than waiting until the end of the slot for the checkpoint to be published to L1.
+        // This is what makes MBPS (Multiple Blocks Per Slot) actually improve UX: with CHECKPOINTED
+        // we'd block until L1 inclusion regardless of how early in the slot the tx was sequenced.
+        // The tradeoff is a weaker guarantee — a proposed block only becomes canonical once it (or
+        // a later block in the same slot) is checkpointed, so a tx could be re-orged out if the
+        // proposer fails to publish to L1 (which should be rare, since they'd get slashed for it).
+        waitOpts.waitForStatus = TxStatus.PROPOSED;
+      }
+      opts.wait = waitOpts as W;
     }
     return super.sendTx(executionPayload, {
       ...opts,
+      wait: opts.wait,
       fee: { ...opts.fee, gasSettings },
     });
   }

--- a/yarn-project/wallets/src/embedded/embedded_wallet.ts
+++ b/yarn-project/wallets/src/embedded/embedded_wallet.ts
@@ -202,9 +202,13 @@ export class EmbeddedWallet extends BaseWallet {
       gasLimits: opts.fee?.gasSettings?.gasLimits ?? estimated.gasLimits,
       teardownGasLimits: opts.fee?.gasSettings?.teardownGasLimits ?? estimated.teardownGasLimits,
     });
-    if (opts.wait !== NO_WAIT) {
-      const waitOpts: WaitOpts = typeof opts.wait === 'object' ? opts.wait : {};
-      if (!waitOpts.waitForStatus) {
+    // NO_WAIT short-circuits the wait in super.sendTx, so forward it as-is; otherwise build a fresh
+    // wait config (without mutating the caller's opts) defaulting the status to PROPOSED.
+    let wait: InteractionWaitOptions = opts.wait;
+    if (wait !== NO_WAIT) {
+      const callerWaitOpts: WaitOpts = typeof wait === 'object' ? wait : {};
+      wait = {
+        ...callerWaitOpts,
         // Default to PROPOSED so the wait returns as soon as the tx lands in a proposed L2 block,
         // rather than waiting until the end of the slot for the checkpoint to be published to L1.
         // This is what makes MBPS (Multiple Blocks Per Slot) actually improve UX: with CHECKPOINTED
@@ -212,13 +216,12 @@ export class EmbeddedWallet extends BaseWallet {
         // The tradeoff is a weaker guarantee — a proposed block only becomes canonical once it (or
         // a later block in the same slot) is checkpointed, so a tx could be re-orged out if the
         // proposer fails to publish to L1 (which should be rare, since they'd get slashed for it).
-        waitOpts.waitForStatus = TxStatus.PROPOSED;
-      }
-      opts.wait = waitOpts as W;
+        waitForStatus: callerWaitOpts.waitForStatus ?? TxStatus.PROPOSED,
+      };
     }
     return super.sendTx(executionPayload, {
       ...opts,
-      wait: opts.wait,
+      wait: wait as W,
       fee: { ...opts.fee, gasSettings },
     });
   }

--- a/yarn-project/wallets/src/embedded/embedded_wallet.ts
+++ b/yarn-project/wallets/src/embedded/embedded_wallet.ts
@@ -202,8 +202,6 @@ export class EmbeddedWallet extends BaseWallet {
       gasLimits: opts.fee?.gasSettings?.gasLimits ?? estimated.gasLimits,
       teardownGasLimits: opts.fee?.gasSettings?.teardownGasLimits ?? estimated.teardownGasLimits,
     });
-    // NO_WAIT short-circuits the wait in super.sendTx, so forward it as-is; otherwise build a fresh
-    // wait config (without mutating the caller's opts) defaulting the status to PROPOSED.
     let wait: InteractionWaitOptions = opts.wait;
     if (wait !== NO_WAIT) {
       const callerWaitOpts: WaitOpts = typeof wait === 'object' ? wait : {};


### PR DESCRIPTION
This was broken in the default case, because we were relying on mutating `opts.wait` that is usually undefined. 

Hopefully the code is a bit clearer too