### PR TITLE
chore: improve pod scheduling

### DIFF
--- a/spartan/terraform/deploy-aztec-infra/values/bot-resources-prod.yaml
+++ b/spartan/terraform/deploy-aztec-infra/values/bot-resources-prod.yaml
@@ -2,16 +2,28 @@ bot:
   nodeSelector:
     local-ssd: "false"
     node-type: "network"
-    cores: "2"
-    pool: "spot"
 
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
         nodeSelectorTerms:
           - matchExpressions:
-              - key: cloud.google.com/gke-spot
-                operator: Exists
+              - key: cores
+                operator: NotIn
+                values:
+                  - "32"
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          preference:
+            matchExpressions:
+              - key: cores
+                operator: In
+                values:
+                  - "2"
+              - key: pool
+                operator: In
+                values:
+                  - spot
 
   tolerations:
     - key: "cloud.google.com/gke-spot"

--- a/spartan/terraform/deploy-aztec-infra/values/full-node-resources-prod.yaml
+++ b/spartan/terraform/deploy-aztec-infra/values/full-node-resources-prod.yaml
@@ -1,7 +1,35 @@
 nodeSelector:
   local-ssd: "false"
   node-type: "network"
-  cores: "2"
+
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: cores
+              operator: NotIn
+              values:
+                - "32"
+    preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        preference:
+          matchExpressions:
+            - key: cores
+              operator: In
+              values:
+                - "2"
+            - key: pool
+              operator: In
+              values:
+                - spot
+
+tolerations:
+  - key: "cloud.google.com/gke-spot"
+    operator: "Equal"
+    value: "true"
+    effect: "NoSchedule"
+
 replicaCount: 1
 
 node:

--- a/spartan/terraform/deploy-aztec-infra/values/p2p-bootstrap-resources-dev.yaml
+++ b/spartan/terraform/deploy-aztec-infra/values/p2p-bootstrap-resources-dev.yaml
@@ -1,7 +1,11 @@
+nodeSelector:
+  local-ssd: "false"
+  node-type: "network"
+
 node:
   resources:
     requests:
-      cpu: "0.25"
+      cpu: "0.1"
       memory: "0.5Gi"
     limits:
       cpu: "0.5"

--- a/spartan/terraform/deploy-aztec-infra/values/p2p-bootstrap-resources-prod.yaml
+++ b/spartan/terraform/deploy-aztec-infra/values/p2p-bootstrap-resources-prod.yaml
@@ -5,22 +5,14 @@ nodeSelector:
 node:
   resources:
     requests:
-      cpu: "0.5"
+      cpu: "0.1"
       memory: "0.5Gi"
     limits:
       cpu: "1"
       memory: "1Gi"
 
 persistence:
-  enabled: true
+  enabled: false
 
 statefulSet:
-  enabled: true
-  volumeClaimTemplates:
-    - metadata:
-        name: data
-      spec:
-        accessModes: [ReadWriteOnce]
-        resources:
-          requests:
-            storage: 4Gi
+  enabled: false

--- a/spartan/terraform/deploy-aztec-infra/values/prover-resources-prod.yaml
+++ b/spartan/terraform/deploy-aztec-infra/values/prover-resources-prod.yaml
@@ -11,7 +11,17 @@ node:
   nodeSelector:
     local-ssd: "false"
     node-type: "network"
-    cores: "2"
+
+  affinity:
+    nodeAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          preference:
+            matchExpressions:
+              - key: cores
+                operator: In
+                values:
+                  - "2"
 
   persistence:
     enabled: true
@@ -31,7 +41,17 @@ broker:
   nodeSelector:
     local-ssd: "false"
     node-type: "network"
-    cores: "2"
+
+  affinity:
+    nodeAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          preference:
+            matchExpressions:
+              - key: cores
+                operator: In
+                values:
+                  - "2"
 
   persistence:
     enabled: true

--- a/spartan/terraform/deploy-aztec-infra/values/rpc-resources-prod.yaml
+++ b/spartan/terraform/deploy-aztec-infra/values/rpc-resources-prod.yaml
@@ -1,7 +1,17 @@
 nodeSelector:
   local-ssd: "false"
   node-type: "network"
-  cores: "2"
+
+affinity:
+  nodeAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        preference:
+          matchExpressions:
+            - key: cores
+              operator: In
+              values:
+                - "2"
 
 replicaCount: 1
 

--- a/spartan/terraform/deploy-aztec-infra/values/validator-resources-prod.yaml
+++ b/spartan/terraform/deploy-aztec-infra/values/validator-resources-prod.yaml
@@ -2,7 +2,6 @@ validator:
   nodeSelector:
     local-ssd: "false"
     node-type: "network"
-    cores: "2"
   node:
     resources:
       requests:

--- a/spartan/terraform/deploy-aztec-infra/values/validator-resources-spot.yaml
+++ b/spartan/terraform/deploy-aztec-infra/values/validator-resources-spot.yaml
@@ -2,16 +2,28 @@ validator:
   nodeSelector:
     local-ssd: "false"
     node-type: "network"
-    cores: "2"
-    pool: "spot"
 
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
         nodeSelectorTerms:
           - matchExpressions:
-              - key: cloud.google.com/gke-spot
-                operator: Exists
+              - key: cores
+                operator: NotIn
+                values:
+                  - "32"
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          preference:
+            matchExpressions:
+              - key: cores
+                operator: In
+                values:
+                  - "2"
+              - key: pool
+                operator: In
+                values:
+                  - spot
 
   tolerations:
     - key: "cloud.google.com/gke-spot"


### PR DESCRIPTION
- replace hard requirement to run on 2 core machines with affinity
- replace hard requirement to run on spots with affinity
- run full-nodes on spots
- p2p bootstrap smaller CPU requests.

Fix A-1140 and A-1141