### PR TITLE
feat!: proofless tx lookup in getTxByHash and getTxsByHash

### DIFF
--- a/docs/docs-developers/docs/resources/migration_notes.md
+++ b/docs/docs-developers/docs/resources/migration_notes.md
@@ -959,15 +959,18 @@ The empire slashing model has been removed. Only the tally-based slashing model 
 
 ## Unreleased (v5)
 
-### [Aztec Node] `getTxByHash` and `getTxsByHash` no longer return tx proofs by default
+### [Aztec Node] `getTxByHash`, `getTxsByHash` and `getPendingTxs` no longer return tx proofs by default
 
-`AztecNode.getTxByHash` and `AztecNode.getTxsByHash` now take an optional `GetTxByHashOptions` argument with an `includeProof` flag. The proof is stripped from returned txs unless `includeProof: true` is passed, cutting roughly 35-52KB per tx over the wire. This matches the `includeProof` semantics of `GetTxReceiptOptions` in `getTxReceipt`.
+`AztecNode.getTxByHash`, `AztecNode.getTxsByHash` and `AztecNode.getPendingTxs` (also exposed on the P2P API) now take an optional `GetTxByHashOptions` argument with an `includeProof` flag. The proof is stripped from returned txs unless `includeProof: true` is passed, cutting roughly 35-52KB per tx over the wire. This matches the `includeProof` semantics of `GetTxReceiptOptions` in `getTxReceipt`.
 
 **Migration:**
 
 ```diff
 - const tx = await node.getTxByHash(txHash);
 + const tx = await node.getTxByHash(txHash, { includeProof: true });
+
+- const txs = await node.getPendingTxs(limit, after);
++ const txs = await node.getPendingTxs(limit, after, { includeProof: true });
 ```
 
 **Impact**: Callers that read the proof off returned txs (eg to re-broadcast or validate them) must now pass `{ includeProof: true }` explicitly; by default the returned txs carry an empty proof.

--- a/docs/docs-developers/docs/resources/migration_notes.md
+++ b/docs/docs-developers/docs/resources/migration_notes.md
@@ -961,7 +961,7 @@ The empire slashing model has been removed. Only the tally-based slashing model 
 
 ### [Aztec Node] `getTxByHash`, `getTxsByHash` and `getPendingTxs` no longer return tx proofs by default
 
-`AztecNode.getTxByHash`, `AztecNode.getTxsByHash` and `AztecNode.getPendingTxs` (also exposed on the P2P API) now take an optional `GetTxByHashOptions` argument with an `includeProof` flag. The proof is stripped from returned txs unless `includeProof: true` is passed, cutting roughly 35-52KB per tx over the wire. This matches the `includeProof` semantics of `GetTxReceiptOptions` in `getTxReceipt`.
+`AztecNode.getTxByHash`, `AztecNode.getTxsByHash` and `AztecNode.getPendingTxs` (also exposed on the P2P API) now take an optional `GetTxByHashOptions` argument with an `includeProof` flag. The proof is stripped from returned txs unless `includeProof: true` is passed, cutting roughly 35-52KB per tx over the wire.
 
 **Migration:**
 

--- a/docs/docs-developers/docs/resources/migration_notes.md
+++ b/docs/docs-developers/docs/resources/migration_notes.md
@@ -959,6 +959,19 @@ The empire slashing model has been removed. Only the tally-based slashing model 
 
 ## Unreleased (v5)
 
+### [Aztec Node] `getTxByHash` and `getTxsByHash` no longer return tx proofs by default
+
+`AztecNode.getTxByHash` and `AztecNode.getTxsByHash` now take an optional `GetTxByHashOptions` argument with an `includeProof` flag. The proof is stripped from returned txs unless `includeProof: true` is passed, cutting roughly 35-52KB per tx over the wire. This matches the `includeProof` semantics of `GetTxReceiptOptions` in `getTxReceipt`.
+
+**Migration:**
+
+```diff
+- const tx = await node.getTxByHash(txHash);
++ const tx = await node.getTxByHash(txHash, { includeProof: true });
+```
+
+**Impact**: Callers that read the proof off returned txs (eg to re-broadcast or validate them) must now pass `{ includeProof: true }` explicitly; by default the returned txs carry an empty proof.
+
 ### [aztec.js] `DeployMethod.send()` always returns `{ contract, receipt, instance }`
 
 The `returnReceipt` option in deploy wait options has been removed. `DeployMethod.send()` now always returns an object with `contract`, `receipt`, and `instance` at the top level, provided the user waits for the transaction to be included.

--- a/yarn-project/aztec-node/src/aztec-node/server.test.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.test.ts
@@ -1639,7 +1639,9 @@ describe('aztec node', () => {
       p2p.getTxStatus.mockResolvedValue('pending');
       l2BlockSource.getTxEffect.mockResolvedValue(undefined);
       const pendingTx = await mockTx();
-      p2p.getTxByHashFromPool.mockResolvedValue(pendingTx);
+      p2p.getTxByHashFromPool.mockImplementation((_h, opts) =>
+        Promise.resolve(opts?.includeProof === false ? pendingTx.withoutProof() : pendingTx),
+      );
 
       const receipt = await node.getTxReceipt(txHash, { includePendingTx: true });
       expect(receipt).toBeInstanceOf(PendingTxReceipt);
@@ -1648,6 +1650,24 @@ describe('aztec node', () => {
       }
       expect(receipt.tx).toBeDefined();
       expect(receipt.tx!.chonkProof).toEqual(pendingTx.withoutProof().chonkProof);
+    });
+
+    it('attaches the pending tx with its proof when includePendingTx and includeProof are set', async () => {
+      const txHash = TxHash.random();
+      p2p.getTxStatus.mockResolvedValue('pending');
+      l2BlockSource.getTxEffect.mockResolvedValue(undefined);
+      const pendingTx = await mockTx();
+      p2p.getTxByHashFromPool.mockImplementation((_h, opts) =>
+        Promise.resolve(opts?.includeProof === false ? pendingTx.withoutProof() : pendingTx),
+      );
+
+      const receipt = await node.getTxReceipt(txHash, { includePendingTx: true, includeProof: true });
+      expect(receipt).toBeInstanceOf(PendingTxReceipt);
+      if (!receipt.isPending()) {
+        throw new Error('expected a pending receipt');
+      }
+      expect(receipt.tx).toBeDefined();
+      expect(receipt.tx!.chonkProof).toEqual(pendingTx.chonkProof);
     });
 
     it('returns a dropped receipt when the tx is unknown to the pool and not mined', async () => {

--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -1306,8 +1306,8 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, AztecNodeDeb
    * @param after - The last known pending tx. Used for pagination
    * @returns - The pending txs.
    */
-  public getPendingTxs(limit?: number, after?: TxHash): Promise<Tx[]> {
-    return this.p2pClient!.getPendingTxs(limit, after);
+  public getPendingTxs(limit?: number, after?: TxHash, options?: GetTxByHashOptions): Promise<Tx[]> {
+    return this.p2pClient!.getPendingTxs(limit, after, options);
   }
 
   public getPendingTxCount(): Promise<number> {

--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -1115,7 +1115,7 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, AztecNodeDeb
   }
 
   public async getMaxPriorityFees(): Promise<GasFees> {
-    for await (const tx of this.p2pClient.iteratePendingTxs()) {
+    for await (const tx of this.p2pClient.iteratePendingTxs({ includeProof: false })) {
       return tx.getGasSettings().maxPriorityFeesPerGas;
     }
 

--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -1217,8 +1217,7 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, AztecNodeDeb
       if (options?.includePendingTx) {
         // The tx may have left the pool since we checked its status (mined or dropped); in that case we
         // leave `tx` unset and still return a pending receipt.
-        const pendingTx = await this.p2pClient.getTxByHashFromPool(txHash);
-        tx = pendingTx && !options.includeProof ? pendingTx.withoutProof() : pendingTx;
+        tx = await this.p2pClient.getTxByHashFromPool(txHash, { includeProof: !!options.includeProof });
       }
       receipt = new PendingTxReceipt(txHash, tx);
     } else {

--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -1333,7 +1333,8 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, AztecNodeDeb
    * @returns - The txs if it exists.
    */
   public async getTxsByHash(txHashes: TxHash[], options?: GetTxByHashOptions): Promise<Tx[]> {
-    return compactArray(await Promise.all(txHashes.map(txHash => this.getTxByHash(txHash, options))));
+    const txs = await this.p2pClient!.getTxsByHashFromPool(txHashes, { includeProof: !!options?.includeProof });
+    return compactArray(txs);
   }
 
   public async findLeavesIndexes(

--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -98,6 +98,7 @@ import type {
   CheckpointIncludeOptions,
   CheckpointParameter,
   CheckpointResponse,
+  GetTxByHashOptions,
 } from '@aztec/stdlib/interfaces/client';
 import { AztecNodeAdminConfigSchema } from '@aztec/stdlib/interfaces/client';
 import {
@@ -1314,21 +1315,25 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, AztecNodeDeb
   }
 
   /**
-   * Method to retrieve a single tx from the mempool or unfinalized chain.
+   * Method to retrieve a single tx from the mempool or unfinalized chain. The tx's proof is only loaded and returned
+   * when `includeProof` is set.
    * @param txHash - The transaction hash to return.
+   * @param options - Options for the returned tx (eg whether to include its proof).
    * @returns - The tx if it exists.
    */
-  public getTxByHash(txHash: TxHash): Promise<Tx | undefined> {
-    return Promise.resolve(this.p2pClient!.getTxByHashFromPool(txHash));
+  public getTxByHash(txHash: TxHash, options?: GetTxByHashOptions): Promise<Tx | undefined> {
+    return this.p2pClient!.getTxByHashFromPool(txHash, { includeProof: !!options?.includeProof });
   }
 
   /**
-   * Method to retrieve txs from the mempool or unfinalized chain.
+   * Method to retrieve txs from the mempool or unfinalized chain. The txs' proofs are only loaded and returned when
+   * `includeProof` is set.
    * @param txHash - The transaction hash to return.
+   * @param options - Options for the returned txs (eg whether to include their proofs).
    * @returns - The txs if it exists.
    */
-  public async getTxsByHash(txHashes: TxHash[]): Promise<Tx[]> {
-    return compactArray(await Promise.all(txHashes.map(txHash => this.getTxByHash(txHash))));
+  public async getTxsByHash(txHashes: TxHash[], options?: GetTxByHashOptions): Promise<Tx[]> {
+    return compactArray(await Promise.all(txHashes.map(txHash => this.getTxByHash(txHash, options))));
   }
 
   public async findLeavesIndexes(

--- a/yarn-project/p2p/src/client/factory.ts
+++ b/yarn-project/p2p/src/client/factory.ts
@@ -75,7 +75,8 @@ export async function createP2PClient(
   }
 
   const bindings = logger.getBindings();
-  const store = deps.store ?? (await createStore(P2P_STORE_NAME, 2, config, bindings));
+  // Schema version 3: tx proofs are stored in a separate map from the tx data (see TxPoolV2Impl).
+  const store = deps.store ?? (await createStore(P2P_STORE_NAME, 3, config, bindings));
   const archive = await createStore(P2P_ARCHIVE_STORE_NAME, 1, config, bindings);
   const peerStore = await createStore(P2P_PEER_STORE_NAME, 1, config, bindings);
   const attestationStore = await createStore(P2P_ATTESTATION_STORE_NAME, 2, config, bindings);

--- a/yarn-project/p2p/src/client/interface.ts
+++ b/yarn-project/p2p/src/client/interface.ts
@@ -124,16 +124,18 @@ export type P2P = P2PClient & {
   /**
    * Returns a transaction in the transaction pool by its hash.
    * @param txHash  - Hash of tx to return.
+   * @param opts - Set `includeProof: false` to skip loading the tx proof from the DB.
    * @returns A single tx or undefined.
    */
-  getTxByHashFromPool(txHash: TxHash): Promise<Tx | undefined>;
+  getTxByHashFromPool(txHash: TxHash, opts?: { includeProof?: boolean }): Promise<Tx | undefined>;
 
   /**
    * Returns transactions in the transaction pool by hash.
    * @param txHashes  - Hashes of txs to return.
+   * @param opts - Set `includeProof: false` to skip loading tx proofs from the DB.
    * @returns An array of txs or undefined.
    */
-  getTxsByHashFromPool(txHashes: TxHash[]): Promise<(Tx | undefined)[]>;
+  getTxsByHashFromPool(txHashes: TxHash[], opts?: { includeProof?: boolean }): Promise<(Tx | undefined)[]>;
 
   /**
    * Checks if transactions exist in the pool

--- a/yarn-project/p2p/src/client/interface.ts
+++ b/yarn-project/p2p/src/client/interface.ts
@@ -158,11 +158,17 @@ export type P2P = P2PClient & {
    */
   getTxStatus(txHash: TxHash): Promise<'pending' | 'mined' | 'deleted' | undefined>;
 
-  /** Returns an iterator over pending txs on the mempool. */
-  iteratePendingTxs(): AsyncIterableIterator<Tx>;
+  /**
+   * Returns an iterator over pending txs on the mempool.
+   * Set `includeProof: false` to skip loading tx proofs from the DB.
+   */
+  iteratePendingTxs(opts?: { includeProof?: boolean }): AsyncIterableIterator<Tx>;
 
-  /** Returns an iterator over pending txs that have been in the pool long enough to be eligible for block building. */
-  iterateEligiblePendingTxs(): AsyncIterableIterator<Tx>;
+  /**
+   * Returns an iterator over pending txs that have been in the pool long enough to be eligible for block building.
+   * Set `includeProof: false` to skip loading tx proofs from the DB.
+   */
+  iterateEligiblePendingTxs(opts?: { includeProof?: boolean }): AsyncIterableIterator<Tx>;
 
   /** Returns the number of pending txs in the mempool. */
   getPendingTxCount(): Promise<number>;

--- a/yarn-project/p2p/src/client/p2p_client.ts
+++ b/yarn-project/p2p/src/client/p2p_client.ts
@@ -25,7 +25,7 @@ import {
 } from '@aztec/stdlib/block';
 import type { ContractDataSource } from '@aztec/stdlib/contract';
 import { getTimestampForSlot } from '@aztec/stdlib/epoch-helpers';
-import { type PeerInfo, tryStop } from '@aztec/stdlib/interfaces/server';
+import { type GetTxByHashOptions, type PeerInfo, tryStop } from '@aztec/stdlib/interfaces/server';
 import { type BlockProposal, CheckpointAttestation, type CheckpointProposal, type TopicType } from '@aztec/stdlib/p2p';
 import type { BlockHeader, Tx, TxHash } from '@aztec/stdlib/tx';
 import { Attributes, type TelemetryClient, WithTracer, getTelemetryClient, trackSpan } from '@aztec/telemetry-client';
@@ -432,7 +432,7 @@ export class P2PClient extends WithTracer implements P2P {
     this.p2pService.registerCheckpointAttestationCallback(callback);
   }
 
-  public async getPendingTxs(limit?: number, after?: TxHash): Promise<Tx[]> {
+  public async getPendingTxs(limit?: number, after?: TxHash, options?: GetTxByHashOptions): Promise<Tx[]> {
     if (limit !== undefined && limit <= 0) {
       throw new TypeError('limit must be greater than 0');
     }
@@ -451,7 +451,9 @@ export class P2PClient extends WithTracer implements P2P {
     const endIndex = limit !== undefined ? startIndex + limit : undefined;
     txHashes = txHashes.slice(startIndex, endIndex);
 
-    const maybeTxs = await Promise.all(txHashes.map(txHash => this.txPool.getTxByHash(txHash)));
+    // This is a public-facing API (exposed via both the node and the p2p RPC), so proofs are opt-in.
+    const includeProof = !!options?.includeProof;
+    const maybeTxs = await Promise.all(txHashes.map(txHash => this.txPool.getTxByHash(txHash, { includeProof })));
     return maybeTxs.filter((tx): tx is Tx => !!tx);
   }
 

--- a/yarn-project/p2p/src/client/p2p_client.ts
+++ b/yarn-project/p2p/src/client/p2p_client.ts
@@ -459,18 +459,18 @@ export class P2PClient extends WithTracer implements P2P {
     return this.txPool.getPendingTxCount();
   }
 
-  public async *iteratePendingTxs(): AsyncIterableIterator<Tx> {
+  public async *iteratePendingTxs(opts?: { includeProof?: boolean }): AsyncIterableIterator<Tx> {
     for (const txHash of await this.txPool.getPendingTxHashes()) {
-      const tx = await this.txPool.getTxByHash(txHash);
+      const tx = await this.txPool.getTxByHash(txHash, opts);
       if (tx) {
         yield tx;
       }
     }
   }
 
-  public async *iterateEligiblePendingTxs(): AsyncIterableIterator<Tx> {
+  public async *iterateEligiblePendingTxs(opts?: { includeProof?: boolean }): AsyncIterableIterator<Tx> {
     for (const txHash of await this.txPool.getEligiblePendingTxHashes()) {
-      const tx = await this.txPool.getTxByHash(txHash);
+      const tx = await this.txPool.getTxByHash(txHash, opts);
       if (tx) {
         yield tx;
       }

--- a/yarn-project/p2p/src/client/p2p_client.ts
+++ b/yarn-project/p2p/src/client/p2p_client.ts
@@ -480,19 +480,21 @@ export class P2PClient extends WithTracer implements P2P {
   /**
    * Returns a transaction in the transaction pool by its hash.
    * @param txHash - Hash of the transaction to look for in the pool.
+   * @param opts - Set `includeProof: false` to skip loading the tx proof from the DB.
    * @returns A single tx or undefined.
    */
-  getTxByHashFromPool(txHash: TxHash): Promise<Tx | undefined> {
-    return this.txPool.getTxByHash(txHash);
+  getTxByHashFromPool(txHash: TxHash, opts?: { includeProof?: boolean }): Promise<Tx | undefined> {
+    return this.txPool.getTxByHash(txHash, opts);
   }
 
   /**
    * Returns transactions in the transaction pool by hash.
    * @param txHashes - Hashes of the transactions to look for.
+   * @param opts - Set `includeProof: false` to skip loading tx proofs from the DB.
    * @returns The txs found, in the same order as the requested hashes. If a tx is not found, it will be undefined.
    */
-  getTxsByHashFromPool(txHashes: TxHash[]): Promise<(Tx | undefined)[]> {
-    return this.txPool.getTxsByHash(txHashes);
+  getTxsByHashFromPool(txHashes: TxHash[], opts?: { includeProof?: boolean }): Promise<(Tx | undefined)[]> {
+    return this.txPool.getTxsByHash(txHashes, opts);
   }
 
   hasTxsInPool(txHashes: TxHash[]): Promise<boolean[]> {

--- a/yarn-project/p2p/src/mem_pools/tx_pool_v2/deleted_pool.test.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool_v2/deleted_pool.test.ts
@@ -13,7 +13,7 @@ describe('DeletedPool', () => {
   beforeEach(async () => {
     store = await openTmpStore('deleted-pool-test');
     txsDB = store.openMap('txs');
-    pool = new DeletedPool(store, txsDB, createLogger('test'));
+    pool = new DeletedPool(store, txHash => txsDB.delete(txHash), createLogger('test'));
     await pool.hydrateFromDatabase();
   });
 
@@ -111,7 +111,7 @@ describe('DeletedPool', () => {
       // Clear tx1 (re-mined higher), keep tx2
       await pool.clearIfMinedHigher('tx1', BlockNumber(12));
 
-      const pool2 = new DeletedPool(store, txsDB, createLogger('test2'));
+      const pool2 = new DeletedPool(store, txHash => txsDB.delete(txHash), createLogger('test2'));
       await pool2.hydrateFromDatabase();
 
       expect(pool2.isFromPrunedBlock('tx1')).toBe(false);
@@ -306,7 +306,7 @@ describe('DeletedPool', () => {
       ]);
 
       // Create a new pool instance with the same store
-      const pool2 = new DeletedPool(store, txsDB, createLogger('test2'));
+      const pool2 = new DeletedPool(store, txHash => txsDB.delete(txHash), createLogger('test2'));
       await pool2.hydrateFromDatabase();
 
       expect(pool2.isFromPrunedBlock('tx1')).toBe(true);
@@ -328,7 +328,7 @@ describe('DeletedPool', () => {
       await pool.finalizeBlock(BlockNumber(5));
 
       // Create a new pool instance with the same store
-      const pool2 = new DeletedPool(store, txsDB, createLogger('test2'));
+      const pool2 = new DeletedPool(store, txHash => txsDB.delete(txHash), createLogger('test2'));
       await pool2.hydrateFromDatabase();
 
       expect(pool2.isFromPrunedBlock('tx1')).toBe(false);
@@ -351,7 +351,7 @@ describe('DeletedPool', () => {
       expect(pool.isSoftDeleted('tx2')).toBe(false);
 
       // Create a new pool instance with the same store (simulates restart)
-      const pool2 = new DeletedPool(store, txsDB, createLogger('test2'));
+      const pool2 = new DeletedPool(store, txHash => txsDB.delete(txHash), createLogger('test2'));
       await pool2.hydrateFromDatabase();
 
       // Soft-deleted state should be preserved
@@ -487,7 +487,7 @@ describe('DeletedPool', () => {
       expect(await txsDB.getAsync('tx2')).toBeDefined();
 
       // Simulate restart
-      const pool2 = new DeletedPool(store, txsDB, createLogger('test2'));
+      const pool2 = new DeletedPool(store, txHash => txsDB.delete(txHash), createLogger('test2'));
       await pool2.hydrateFromDatabase();
 
       // Both should be hard-deleted after hydration
@@ -507,7 +507,7 @@ describe('DeletedPool', () => {
       await pool.deleteTx('tx2');
 
       // Simulate restart
-      const pool2 = new DeletedPool(store, txsDB, createLogger('test2'));
+      const pool2 = new DeletedPool(store, txHash => txsDB.delete(txHash), createLogger('test2'));
       await pool2.hydrateFromDatabase();
 
       // tx1 (prune-soft-deleted) should still be in DB

--- a/yarn-project/p2p/src/mem_pools/tx_pool_v2/deleted_pool.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool_v2/deleted_pool.ts
@@ -52,8 +52,8 @@ export class DeletedPool {
   /** Persisted map: txHash -> DeletedTxState (serialized) - for prune-based soft deletions */
   #deletedTxsDB: AztecAsyncMap<string, Buffer>;
 
-  /** Reference to the main txs database for hard deletion */
-  #txsDB: AztecAsyncMap<string, Buffer>;
+  /** Hard-deletes a tx's stored data (tx blob and proof) from the pool's stores. */
+  #deleteTxData: (txHash: string) => Promise<void>;
 
   /** In-memory state for transactions from pruned blocks */
   #state: Map<string, DeletedTxState> = new Map();
@@ -69,10 +69,10 @@ export class DeletedPool {
 
   #log: Logger;
 
-  constructor(store: AztecAsyncKVStore, txsDB: AztecAsyncMap<string, Buffer>, log: Logger) {
+  constructor(store: AztecAsyncKVStore, deleteTxData: (txHash: string) => Promise<void>, log: Logger) {
     this.#deletedTxsDB = store.openMap('deleted_txs');
     this.#slotDeletedDB = store.openSet('slot_deleted_txs');
-    this.#txsDB = txsDB;
+    this.#deleteTxData = deleteTxData;
     this.#log = log;
   }
 
@@ -100,7 +100,7 @@ export class DeletedPool {
     // Slot-deleted txs are stale after restart - hard-delete them all
     let slotDeletedCount = 0;
     for await (const txHash of this.#slotDeletedDB.entriesAsync()) {
-      await this.#txsDB.delete(txHash);
+      await this.#deleteTxData(txHash);
       await this.#slotDeletedDB.delete(txHash);
       slotDeletedCount++;
     }
@@ -234,7 +234,7 @@ export class DeletedPool {
     for (const txHash of toHardDelete) {
       this.#state.delete(txHash);
       await this.#deletedTxsDB.delete(txHash);
-      await this.#txsDB.delete(txHash);
+      await this.#deleteTxData(txHash);
     }
 
     this.#log.debug(`Finalized ${toHardDelete.length} txs from pruned blocks at block ${finalizedBlockNumber}`, {
@@ -266,7 +266,7 @@ export class DeletedPool {
     for (const txHash of toHardDelete) {
       this.#slotDeletedTxs.delete(txHash);
       await this.#slotDeletedDB.delete(txHash);
-      await this.#txsDB.delete(txHash);
+      await this.#deleteTxData(txHash);
     }
 
     this.#log.debug(

--- a/yarn-project/p2p/src/mem_pools/tx_pool_v2/interfaces.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool_v2/interfaces.ts
@@ -192,11 +192,11 @@ export interface TxPoolV2 extends TypedEventEmitter<TxPoolV2Events> {
    */
   handleFinalizedBlock(block: BlockHeader): Promise<void>;
 
-  /** Gets a transaction by its hash */
-  getTxByHash(txHash: TxHash): Promise<Tx | undefined>;
+  /** Gets a transaction by its hash. Set `includeProof: false` to skip loading the proof from the DB. */
+  getTxByHash(txHash: TxHash, opts?: { includeProof?: boolean }): Promise<Tx | undefined>;
 
-  /** Gets multiple transactions by their hashes */
-  getTxsByHash(txHashes: TxHash[]): Promise<(Tx | undefined)[]>;
+  /** Gets multiple transactions by their hashes. Set `includeProof: false` to skip loading proofs from the DB. */
+  getTxsByHash(txHashes: TxHash[], opts?: { includeProof?: boolean }): Promise<(Tx | undefined)[]>;
 
   /** Checks if transactions exist in the pool */
   hasTxs(txHashes: TxHash[]): Promise<boolean[]>;

--- a/yarn-project/p2p/src/mem_pools/tx_pool_v2/tx_pool_v2.test.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool_v2/tx_pool_v2.test.ts
@@ -9,6 +9,7 @@ import { BlockNumber, CheckpointNumber, IndexWithinCheckpoint, SlotNumber } from
 import { timesAsync } from '@aztec/foundation/collection';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { DateProvider } from '@aztec/foundation/timer';
+import type { AztecAsyncMap } from '@aztec/kv-store';
 import { openTmpStore } from '@aztec/kv-store/lmdb-v2';
 import { RevertCode } from '@aztec/stdlib/avm';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
@@ -22,7 +23,7 @@ import {
   PublicDataTreeLeaf,
   PublicDataTreeLeafPreimage,
 } from '@aztec/stdlib/trees';
-import { BlockHeader, GlobalVariables, type Tx, TxEffect, TxHash, type TxValidator } from '@aztec/stdlib/tx';
+import { BlockHeader, GlobalVariables, Tx, TxEffect, TxHash, type TxValidator } from '@aztec/stdlib/tx';
 
 import { type MockProxy, mock } from 'jest-mock-extended';
 
@@ -517,6 +518,62 @@ describe('TxPoolV2', () => {
       expect(result.rejected).toHaveLength(0);
       expect(await pool.getPendingTxCount()).toBe(2);
       expectAddedTxs(tx1, tx2); // Only callbacks for the accepted txs
+    });
+  });
+
+  describe('proof storage', () => {
+    it('returns the full tx including its proof by default', async () => {
+      const tx = await mockTx(1);
+      await pool.addPendingTxs([tx]);
+
+      const retrieved = await pool.getTxByHash(tx.getTxHash());
+      expect(retrieved).toBeDefined();
+      expect(retrieved!.chonkProof.isEmpty()).toBe(false);
+      expect(retrieved!.toBuffer().equals(tx.toBuffer())).toBe(true);
+    });
+
+    it('returns the tx without its proof when includeProof is false', async () => {
+      const tx = await mockTx(1);
+      await pool.addPendingTxs([tx]);
+
+      const retrieved = await pool.getTxByHash(tx.getTxHash(), { includeProof: false });
+      expect(retrieved).toBeDefined();
+      expect(retrieved!.chonkProof.isEmpty()).toBe(true);
+      expect(retrieved!.toBuffer().equals(tx.withoutProof().toBuffer())).toBe(true);
+    });
+
+    it('threads includeProof through getTxsByHash', async () => {
+      const tx1 = await mockTx(1);
+      const tx2 = await mockTx(2);
+      await pool.addPendingTxs([tx1, tx2]);
+      const hashes = [tx1.getTxHash(), tx2.getTxHash()];
+
+      const withProofs = await pool.getTxsByHash(hashes);
+      expect(withProofs.map(tx => tx!.chonkProof.isEmpty())).toEqual([false, false]);
+
+      const withoutProofs = await pool.getTxsByHash(hashes, { includeProof: false });
+      expect(withoutProofs.map(tx => tx!.chonkProof.isEmpty())).toEqual([true, true]);
+    });
+
+    it('stores the proof separately from the tx data and deletes both on hard delete', async () => {
+      const tx = await mockTx(1);
+      await pool.addPendingTxs([tx]);
+      const txHashStr = tx.getTxHash().toString();
+
+      const txsDB: AztecAsyncMap<string, Buffer> = store.openMap('txs');
+      const proofsDB: AztecAsyncMap<string, Buffer> = store.openMap('tx_proofs');
+
+      const storedTx = await txsDB.getAsync(txHashStr);
+      expect(Tx.fromBuffer(storedTx!).chonkProof.isEmpty()).toBe(true);
+      expect(await proofsDB.getAsync(txHashStr)).toBeDefined();
+
+      // Slot-soft-delete the tx, then advance two slots to trigger hard deletion.
+      await pool.handleFailedExecution([tx.getTxHash()]);
+      await pool.prepareForSlot(SlotNumber(1));
+      await pool.prepareForSlot(SlotNumber(2));
+
+      expect(await txsDB.getAsync(txHashStr)).toBeUndefined();
+      expect(await proofsDB.getAsync(txHashStr)).toBeUndefined();
     });
   });
 
@@ -1363,6 +1420,17 @@ describe('TxPoolV2', () => {
         // hasTxs should return true (in indices, not just soft-deleted)
         const [hasTx] = await poolWithValidator.hasTxs([tx.getTxHash()]);
         expect(hasTx).toBe(true);
+      });
+
+      it('resurrecting a soft-deleted tx preserves its stored proof', async () => {
+        const tx = await mockTx(1);
+        await softDeleteTx(tx);
+
+        await poolWithValidator.protectTxs([tx.getTxHash()], slot2Header);
+
+        const retrieved = await poolWithValidator.getTxByHash(tx.getTxHash());
+        expect(retrieved!.chonkProof.isEmpty()).toBe(false);
+        expect(retrieved!.toBuffer().equals(tx.toBuffer())).toBe(true);
       });
 
       it('resurrected tx is unprotected on the next slot', async () => {

--- a/yarn-project/p2p/src/mem_pools/tx_pool_v2/tx_pool_v2.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool_v2/tx_pool_v2.ts
@@ -124,12 +124,12 @@ export class AztecKVTxPoolV2 extends (EventEmitter as new () => TypedEventEmitte
 
   // === Queries ===
 
-  getTxByHash(txHash: TxHash): Promise<Tx | undefined> {
-    return this.#queue.put(() => this.#impl.getTxByHash(txHash));
+  getTxByHash(txHash: TxHash, opts?: { includeProof?: boolean }): Promise<Tx | undefined> {
+    return this.#queue.put(() => this.#impl.getTxByHash(txHash, opts));
   }
 
-  getTxsByHash(txHashes: TxHash[]): Promise<(Tx | undefined)[]> {
-    return this.#queue.put(() => this.#impl.getTxsByHash(txHashes));
+  getTxsByHash(txHashes: TxHash[], opts?: { includeProof?: boolean }): Promise<(Tx | undefined)[]> {
+    return this.#queue.put(() => this.#impl.getTxsByHash(txHashes, opts));
   }
 
   hasTxs(txHashes: TxHash[]): Promise<boolean[]> {

--- a/yarn-project/p2p/src/mem_pools/tx_pool_v2/tx_pool_v2_impl.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool_v2/tx_pool_v2_impl.ts
@@ -736,8 +736,16 @@ export class TxPoolV2Impl {
 
   /** Reattaches the separately-stored proof to a tx loaded from #txsDB. */
   async #attachProof(tx: Tx): Promise<Tx> {
-    const proofBuffer = await this.#proofsDB.getAsync(tx.getTxHash().toString());
-    return proofBuffer ? tx.withProof(ChonkProof.fromBuffer(proofBuffer)) : tx;
+    const txHash = tx.getTxHash().toString();
+    const proofBuffer = await this.#proofsDB.getAsync(txHash);
+    if (!proofBuffer) {
+      // #addTx always writes a proof entry (an empty proof serializes to a 4-byte sentinel), so a missing entry
+      // means the blob/proof invariant is broken. Return the proofless tx but flag it, since a consumer that needs
+      // the proof (eg serving peers) would otherwise fail far away from the root cause.
+      this.#log.warn(`Missing stored proof for tx ${txHash}`, { txHash });
+      return tx;
+    }
+    return tx.withProof(ChonkProof.fromBuffer(proofBuffer));
   }
 
   hasTxs(txHashes: TxHash[]): boolean[] {

--- a/yarn-project/p2p/src/mem_pools/tx_pool_v2/tx_pool_v2_impl.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool_v2/tx_pool_v2_impl.ts
@@ -8,6 +8,7 @@ import { computeFeePayerBalanceStorageSlot } from '@aztec/protocol-contracts/fee
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
 import type { L2Block, L2BlockId, L2BlockSource } from '@aztec/stdlib/block';
 import type { WorldStateSynchronizer } from '@aztec/stdlib/interfaces/server';
+import { ChonkProof } from '@aztec/stdlib/proofs';
 import { DatabasePublicStateSource } from '@aztec/stdlib/trees';
 import { BlockHeader, Tx, TxHash, type TxValidator } from '@aztec/stdlib/tx';
 import type { TelemetryClient } from '@aztec/telemetry-client';
@@ -65,7 +66,10 @@ export interface TxPoolV2Callbacks {
 export class TxPoolV2Impl {
   // === Persistence ===
   #store: AztecAsyncKVStore;
+  /** Tx data without its proof. Proofs live in #proofsDB so a tx can be read without loading its proof. */
   #txsDB: AztecAsyncMap<string, Buffer>;
+  /** Tx proofs, keyed by tx hash. Written and deleted in lockstep with #txsDB. */
+  #proofsDB: AztecAsyncMap<string, Buffer>;
 
   // === Dependencies ===
   #l2BlockSource: L2BlockSource;
@@ -99,6 +103,7 @@ export class TxPoolV2Impl {
   ) {
     this.#store = store;
     this.#txsDB = store.openMap('txs');
+    this.#proofsDB = store.openMap('tx_proofs');
 
     this.#l2BlockSource = deps.l2BlockSource;
     this.#worldStateSynchronizer = deps.worldStateSynchronizer;
@@ -108,7 +113,7 @@ export class TxPoolV2Impl {
     this.#config = { ...DEFAULT_TX_POOL_V2_CONFIG, ...config };
     this.#evictedTxHashes = FifoSet.withLimit<string>(this.#config.evictedTxCacheSize);
     this.#archive = new TxArchive(archiveStore, this.#config.archivedTxLimit, log);
-    this.#deletedPool = new DeletedPool(store, this.#txsDB, log);
+    this.#deletedPool = new DeletedPool(store, txHashStr => this.#deleteTxData(txHashStr), log);
     this.#dateProvider = dateProvider;
     this.#instrumentation = new TxPoolV2Instrumentation(telemetry, () => this.#indices.getTotalMetadataBytes());
     this.#log = log;
@@ -216,7 +221,7 @@ export class TxPoolV2Impl {
     }
     await this.#store.transactionAsync(async () => {
       for (const txHashStr of toDelete) {
-        await this.#txsDB.delete(txHashStr);
+        await this.#deleteTxData(txHashStr);
       }
     });
     this.#log.info(`Deleted ${toDelete.length} invalid/rejected transactions on startup`, { txHashes: toDelete });
@@ -462,10 +467,11 @@ export class TxPoolV2Impl {
           // Update protection for existing tx
           this.#indices.updateProtection(txHashStr, slotNumber);
         } else if (this.#deletedPool.isSoftDeleted(txHashStr)) {
-          // Resurrect soft-deleted tx as protected
+          // Resurrect soft-deleted tx as protected. Load the proof too: #addTx rewrites both entries, so re-adding
+          // a proofless tx would wipe the stored proof.
           const buffer = await this.#txsDB.getAsync(txHashStr);
           if (buffer) {
-            const tx = Tx.fromBuffer(buffer);
+            const tx = await this.#attachProof(Tx.fromBuffer(buffer));
             await this.#addTx(tx, { protected: slotNumber });
             softDeletedHits++;
           } else {
@@ -711,18 +717,27 @@ export class TxPoolV2Impl {
 
   // === Query Methods ===
 
-  async getTxByHash(txHash: TxHash): Promise<Tx | undefined> {
+  async getTxByHash(txHash: TxHash, opts: { includeProof?: boolean } = {}): Promise<Tx | undefined> {
     const buffer = await this.#txsDB.getAsync(txHash.toString());
-    return buffer ? Tx.fromBuffer(buffer) : undefined;
+    if (!buffer) {
+      return undefined;
+    }
+    const tx = Tx.fromBuffer(buffer);
+    return opts.includeProof === false ? tx : this.#attachProof(tx);
   }
 
-  async getTxsByHash(txHashes: TxHash[]): Promise<(Tx | undefined)[]> {
+  async getTxsByHash(txHashes: TxHash[], opts: { includeProof?: boolean } = {}): Promise<(Tx | undefined)[]> {
     const results: (Tx | undefined)[] = [];
     for (const h of txHashes) {
-      const buffer = await this.#txsDB.getAsync(h.toString());
-      results.push(buffer ? Tx.fromBuffer(buffer) : undefined);
+      results.push(await this.getTxByHash(h, opts));
     }
     return results;
+  }
+
+  /** Reattaches the separately-stored proof to a tx loaded from #txsDB. */
+  async #attachProof(tx: Tx): Promise<Tx> {
+    const proofBuffer = await this.#proofsDB.getAsync(tx.getTxHash().toString());
+    return proofBuffer ? tx.withProof(ChonkProof.fromBuffer(proofBuffer)) : tx;
   }
 
   hasTxs(txHashes: TxHash[]): boolean[] {
@@ -851,7 +866,8 @@ export class TxPoolV2Impl {
     const meta = precomputedMeta ?? (await buildTxMetaData(tx));
     meta.receivedAt = this.#dateProvider.now();
 
-    await this.#txsDB.set(txHashStr, tx.toBuffer());
+    await this.#txsDB.set(txHashStr, tx.withoutProof().toBuffer());
+    await this.#proofsDB.set(txHashStr, tx.chonkProof.toBuffer());
     await this.#deletedPool.clearSoftDeleted(txHashStr);
     this.#callbacks.onTxsAdded([tx], opts);
 
@@ -888,6 +904,12 @@ export class TxPoolV2Impl {
     this.#indices.remove(txHashStr);
     this.#callbacks.onTxsRemoved([txHashStr]);
     await this.#deletedPool.deleteTx(txHashStr);
+  }
+
+  /** Hard-deletes a tx's stored data (tx blob and proof) from the DB. */
+  async #deleteTxData(txHashStr: string): Promise<void> {
+    await this.#txsDB.delete(txHashStr);
+    await this.#proofsDB.delete(txHashStr);
   }
 
   /** Deletes a batch of transactions, emitting callbacks individually for each. */

--- a/yarn-project/p2p/src/mem_pools/tx_pool_v2/tx_pool_v2_impl.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool_v2/tx_pool_v2_impl.ts
@@ -8,7 +8,6 @@ import { computeFeePayerBalanceStorageSlot } from '@aztec/protocol-contracts/fee
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
 import type { L2Block, L2BlockId, L2BlockSource } from '@aztec/stdlib/block';
 import type { WorldStateSynchronizer } from '@aztec/stdlib/interfaces/server';
-import { ChonkProof } from '@aztec/stdlib/proofs';
 import { DatabasePublicStateSource } from '@aztec/stdlib/trees';
 import { BlockHeader, Tx, TxHash, type TxValidator } from '@aztec/stdlib/tx';
 import type { TelemetryClient } from '@aztec/telemetry-client';
@@ -471,7 +470,7 @@ export class TxPoolV2Impl {
           // a proofless tx would wipe the stored proof.
           const buffer = await this.#txsDB.getAsync(txHashStr);
           if (buffer) {
-            const tx = await this.#attachProof(Tx.fromBuffer(buffer));
+            const tx = await this.#loadTxWithProof(txHashStr, buffer);
             await this.#addTx(tx, { protected: slotNumber });
             softDeletedHits++;
           } else {
@@ -718,12 +717,12 @@ export class TxPoolV2Impl {
   // === Query Methods ===
 
   async getTxByHash(txHash: TxHash, opts: { includeProof?: boolean } = {}): Promise<Tx | undefined> {
-    const buffer = await this.#txsDB.getAsync(txHash.toString());
+    const txHashStr = txHash.toString();
+    const buffer = await this.#txsDB.getAsync(txHashStr);
     if (!buffer) {
       return undefined;
     }
-    const tx = Tx.fromBuffer(buffer);
-    return opts.includeProof === false ? tx : this.#attachProof(tx);
+    return opts.includeProof === false ? Tx.fromBuffer(buffer) : this.#loadTxWithProof(txHashStr, buffer);
   }
 
   async getTxsByHash(txHashes: TxHash[], opts: { includeProof?: boolean } = {}): Promise<(Tx | undefined)[]> {
@@ -734,18 +733,17 @@ export class TxPoolV2Impl {
     return results;
   }
 
-  /** Reattaches the separately-stored proof to a tx loaded from #txsDB. */
-  async #attachProof(tx: Tx): Promise<Tx> {
-    const txHash = tx.getTxHash().toString();
-    const proofBuffer = await this.#proofsDB.getAsync(txHash);
+  /** Deserializes a tx blob loaded from #txsDB together with its separately-stored proof. */
+  async #loadTxWithProof(txHashStr: string, buffer: Buffer): Promise<Tx> {
+    const proofBuffer = await this.#proofsDB.getAsync(txHashStr);
     if (!proofBuffer) {
       // #addTx always writes a proof entry (an empty proof serializes to a 4-byte sentinel), so a missing entry
       // means the blob/proof invariant is broken. Return the proofless tx but flag it, since a consumer that needs
       // the proof (eg serving peers) would otherwise fail far away from the root cause.
-      this.#log.warn(`Missing stored proof for tx ${txHash}`, { txHash });
-      return tx;
+      this.#log.warn(`Missing stored proof for tx ${txHashStr}`, { txHash: txHashStr });
+      return Tx.fromBuffer(buffer);
     }
-    return tx.withProof(ChonkProof.fromBuffer(proofBuffer));
+    return Tx.fromBuffers(buffer, proofBuffer);
   }
 
   hasTxs(txHashes: TxHash[]): boolean[] {

--- a/yarn-project/p2p/src/services/tx_collection/tx_source.test.ts
+++ b/yarn-project/p2p/src/services/tx_collection/tx_source.test.ts
@@ -32,6 +32,8 @@ describe('NodeRpcTxSource', () => {
 
     expect(result.validTxs).toHaveLength(2);
     expect(result.invalidTxHashes).toHaveLength(0);
+    // Collected txs feed block validation and proving, so the source must explicitly request proofs.
+    expect(mockClient.getTxsByHash).toHaveBeenCalledWith([tx1.getTxHash(), tx2.getTxHash()], { includeProof: true });
   });
 
   it('returns invalid tx hashes when validator rejects', async () => {

--- a/yarn-project/p2p/src/services/tx_collection/tx_source.ts
+++ b/yarn-project/p2p/src/services/tx_collection/tx_source.ts
@@ -30,7 +30,8 @@ export class NodeRpcTxSource implements TxSource {
   }
 
   public async getTxsByHash(txHashes: TxHash[]): Promise<TxSourceCollectionResult> {
-    return this.verifyTxs(await this.client.getTxsByHash(txHashes));
+    // Collected txs feed block validation and proving, so we need their proofs.
+    return this.verifyTxs(await this.client.getTxsByHash(txHashes, { includeProof: true }));
   }
 
   private async verifyTxs(txs: Tx[]): Promise<TxSourceCollectionResult> {

--- a/yarn-project/sequencer-client/src/sequencer/automine/automine_sequencer.ts
+++ b/yarn-project/sequencer-client/src/sequencer/automine/automine_sequencer.ts
@@ -377,7 +377,8 @@ export class AutomineSequencer {
       this.log.getBindings(),
     );
 
-    const pendingTxs = this.deps.p2pClient.iterateEligiblePendingTxs();
+    // Block building only executes txs, and automine publishes straight to L1, so the proofs are never needed.
+    const pendingTxs = this.deps.p2pClient.iterateEligiblePendingTxs({ includeProof: false });
 
     const buildResult = await this.tryBuildBlock(
       checkpointBuilder,

--- a/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.ts
+++ b/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.ts
@@ -1026,8 +1026,10 @@ export class CheckpointProposalJob implements Traceable {
 
       // Create iterator to pending txs. We filter out txs already included in previous blocks in the checkpoint
       // just in case p2p failed to sync the provisional block and didn't get to remove those txs from the mempool yet.
+      // Block building only executes txs, so we skip loading their proofs unless these same tx objects get attached
+      // to the broadcasted proposals via publishTxsWithProposals.
       const pendingTxs = filter(
-        this.p2pClient.iterateEligiblePendingTxs(),
+        this.p2pClient.iterateEligiblePendingTxs({ includeProof: !!this.config.publishTxsWithProposals }),
         tx => !txHashesAlreadyIncluded.has(tx.txHash.toString()),
       );
 

--- a/yarn-project/stdlib/src/interfaces/aztec-node.test.ts
+++ b/yarn-project/stdlib/src/interfaces/aztec-node.test.ts
@@ -324,6 +324,10 @@ describe('AztecNodeApiSchema', () => {
   it('getPendingTxs', async () => {
     const response = await context.client.getPendingTxs();
     expect(response).toEqual([expect.any(Tx)]);
+    expect(response[0].chonkProof.isEmpty()).toBe(true);
+
+    const responseWithProof = await context.client.getPendingTxs(undefined, undefined, { includeProof: true });
+    expect(responseWithProof[0].chonkProof.isEmpty()).toBe(false);
   });
 
   it('getPendingTxCount', async () => {
@@ -792,8 +796,9 @@ class MockAztecNode implements AztecNode {
       slotNumber: SlotNumber(1),
     };
   }
-  getPendingTxs(): Promise<Tx[]> {
-    return Promise.resolve([Tx.random()]);
+  getPendingTxs(_limit?: number, _after?: TxHash, options?: GetTxByHashOptions): Promise<Tx[]> {
+    const tx = Tx.random({ randomProof: true });
+    return Promise.resolve([options?.includeProof ? tx : tx.withoutProof()]);
   }
   getPendingTxCount(): Promise<number> {
     return Promise.resolve(BlockNumber(1));

--- a/yarn-project/stdlib/src/interfaces/aztec-node.test.ts
+++ b/yarn-project/stdlib/src/interfaces/aztec-node.test.ts
@@ -54,7 +54,7 @@ import type { TxValidationResult } from '../tx/validator/tx_validator.js';
 import type { SingleValidatorStats, ValidatorsStats } from '../validators/types.js';
 import type { AllowedElement } from './allowed_element.js';
 import { MAX_RPC_LEN } from './api_limit.js';
-import { type AztecNode, AztecNodeApiSchema } from './aztec-node.js';
+import { type AztecNode, AztecNodeApiSchema, type GetTxByHashOptions } from './aztec-node.js';
 import type { BlockIncludeOptions, BlockResponse, BlocksIncludeOptions } from './block_response.js';
 import type { ChainTip, ChainTips } from './chain_tips.js';
 import type { CheckpointParameter } from './checkpoint_parameter.js';
@@ -334,11 +334,21 @@ describe('AztecNodeApiSchema', () => {
   it('getTxByHash', async () => {
     const response = await context.client.getTxByHash(TxHash.random());
     expect(response).toBeInstanceOf(Tx);
+    expect(response!.chonkProof.isEmpty()).toBe(true);
+
+    const responseWithProof = await context.client.getTxByHash(TxHash.random(), { includeProof: true });
+    expect(responseWithProof).toBeInstanceOf(Tx);
+    expect(responseWithProof!.chonkProof.isEmpty()).toBe(false);
   });
 
   it('getTxsByHash', async () => {
     const response = await context.client.getTxsByHash([TxHash.random()]);
     expect(response[0]).toBeInstanceOf(Tx);
+    expect(response[0].chonkProof.isEmpty()).toBe(true);
+
+    const responseWithProof = await context.client.getTxsByHash([TxHash.random()], { includeProof: true });
+    expect(responseWithProof[0]).toBeInstanceOf(Tx);
+    expect(responseWithProof[0].chonkProof.isEmpty()).toBe(false);
   });
 
   it('getPublicStorageAt', async () => {
@@ -788,13 +798,15 @@ class MockAztecNode implements AztecNode {
   getPendingTxCount(): Promise<number> {
     return Promise.resolve(BlockNumber(1));
   }
-  getTxByHash(txHash: TxHash): Promise<Tx | undefined> {
+  getTxByHash(txHash: TxHash, options?: GetTxByHashOptions): Promise<Tx | undefined> {
     expect(txHash).toBeInstanceOf(TxHash);
-    return Promise.resolve(Tx.random());
+    const tx = Tx.random({ randomProof: true });
+    return Promise.resolve(options?.includeProof ? tx : tx.withoutProof());
   }
-  getTxsByHash(txHashes: TxHash[]): Promise<Tx[]> {
+  getTxsByHash(txHashes: TxHash[], options?: GetTxByHashOptions): Promise<Tx[]> {
     expect(txHashes[0]).toBeInstanceOf(TxHash);
-    return Promise.resolve([Tx.random()]);
+    const tx = Tx.random({ randomProof: true });
+    return Promise.resolve([options?.includeProof ? tx : tx.withoutProof()]);
   }
   getPublicStorageAt(block: BlockParameter, contract: AztecAddress, slot: Fr): Promise<Fr> {
     expect(

--- a/yarn-project/stdlib/src/interfaces/aztec-node.ts
+++ b/yarn-project/stdlib/src/interfaces/aztec-node.ts
@@ -45,7 +45,7 @@ import {
   PublicLogsQuerySchema,
 } from '../logs/logs_query.js';
 import { type L2ToL1MembershipWitness, L2ToL1MembershipWitnessSchema } from '../messaging/l2_to_l1_membership.js';
-import { type ApiSchemaFor, optional, schemas } from '../schemas/schemas.js';
+import { type ApiSchemaFor, type ZodFor, optional, schemas } from '../schemas/schemas.js';
 import { MerkleTreeId } from '../trees/merkle_tree_id.js';
 import { NullifierMembershipWitness } from '../trees/nullifier_membership_witness.js';
 import { PublicDataWitness } from '../trees/public_data_witness.js';
@@ -85,6 +85,17 @@ import {
   CheckpointResponseSchema,
 } from './checkpoint_response.js';
 import { type WorldStateSyncStatus, WorldStateSyncStatusSchema } from './world_state.js';
+
+/** Options for retrieving txs via {@link AztecNode.getTxByHash} and {@link AztecNode.getTxsByHash}. */
+export type GetTxByHashOptions = {
+  /** Keep the proof on the returned tx; stripped by default. */
+  includeProof?: boolean;
+};
+
+/** Zod schema for {@link GetTxByHashOptions}. */
+const GetTxByHashOptionsSchema: ZodFor<GetTxByHashOptions> = z.object({
+  includeProof: z.boolean().optional(),
+});
 
 /**
  * The aztec node.
@@ -428,18 +439,20 @@ export interface AztecNode {
   getPendingTxCount(): Promise<number>;
 
   /**
-   * Method to retrieve a single pending tx.
+   * Method to retrieve a single pending tx. The tx's proof is stripped unless `includeProof` is set.
    * @param txHash - The transaction hash to return.
+   * @param options - Options for the returned tx (eg whether to include its proof).
    * @returns The pending tx if it exists.
    */
-  getTxByHash(txHash: TxHash): Promise<Tx | undefined>;
+  getTxByHash(txHash: TxHash, options?: GetTxByHashOptions): Promise<Tx | undefined>;
 
   /**
-   * Method to retrieve multiple pending txs.
+   * Method to retrieve multiple pending txs. The txs' proofs are stripped unless `includeProof` is set.
    * @param txHash - The transaction hashes to return.
+   * @param options - Options for the returned txs (eg whether to include their proofs).
    * @returns The pending txs if exist.
    */
-  getTxsByHash(txHashes: TxHash[]): Promise<Tx[]>;
+  getTxsByHash(txHashes: TxHash[], options?: GetTxByHashOptions): Promise<Tx[]>;
 
   /**
    * Gets the storage value at the given contract storage slot.
@@ -663,10 +676,13 @@ export const AztecNodeApiSchema: ApiSchemaFor<AztecNode> = {
 
   getPendingTxCount: z.function({ input: z.tuple([]), output: z.number() }),
 
-  getTxByHash: z.function({ input: z.tuple([TxHash.schema]), output: Tx.schema.optional() }),
+  getTxByHash: z.function({
+    input: z.tuple([TxHash.schema, optional(GetTxByHashOptionsSchema)]),
+    output: Tx.schema.optional(),
+  }),
 
   getTxsByHash: z.function({
-    input: z.tuple([z.array(TxHash.schema).max(MAX_RPC_TXS_LEN)]),
+    input: z.tuple([z.array(TxHash.schema).max(MAX_RPC_TXS_LEN), optional(GetTxByHashOptionsSchema)]),
     output: z.array(Tx.schema),
   }),
 

--- a/yarn-project/stdlib/src/interfaces/aztec-node.ts
+++ b/yarn-project/stdlib/src/interfaces/aztec-node.ts
@@ -93,7 +93,7 @@ export type GetTxByHashOptions = {
 };
 
 /** Zod schema for {@link GetTxByHashOptions}. */
-const GetTxByHashOptionsSchema: ZodFor<GetTxByHashOptions> = z.object({
+export const GetTxByHashOptionsSchema: ZodFor<GetTxByHashOptions> = z.object({
   includeProof: z.boolean().optional(),
 });
 
@@ -427,10 +427,13 @@ export interface AztecNode {
   getTxEffect(txHash: TxHash): Promise<IndexedTxEffect | undefined>;
 
   /**
-   * Method to retrieve pending txs.
+   * Method to retrieve pending txs. The txs' proofs are stripped unless `includeProof` is set.
+   * @param limit - The number of items to return.
+   * @param after - The last known pending tx. Used for pagination.
+   * @param options - Options for the returned txs (eg whether to include their proofs).
    * @returns The pending txs.
    */
-  getPendingTxs(limit?: number, after?: TxHash): Promise<Tx[]>;
+  getPendingTxs(limit?: number, after?: TxHash, options?: GetTxByHashOptions): Promise<Tx[]>;
 
   /**
    * Retrieves the number of pending txs
@@ -670,6 +673,7 @@ export const AztecNodeApiSchema: ApiSchemaFor<AztecNode> = {
     input: z.tuple([
       optional(z.number().gte(1).lte(MAX_RPC_TXS_LEN).default(MAX_RPC_TXS_LEN)),
       optional(TxHash.schema),
+      optional(GetTxByHashOptionsSchema),
     ]),
     output: z.array(Tx.schema),
   }),

--- a/yarn-project/stdlib/src/interfaces/p2p.test.ts
+++ b/yarn-project/stdlib/src/interfaces/p2p.test.ts
@@ -3,6 +3,8 @@ import { type JsonRpcTestContext, createJsonRpcTestSetup } from '@aztec/foundati
 
 import { CheckpointAttestation } from '../p2p/checkpoint_attestation.js';
 import { Tx } from '../tx/tx.js';
+import type { TxHash } from '../tx/tx_hash.js';
+import type { GetTxByHashOptions } from './aztec-node.js';
 import { type P2PApi, P2PApiSchema, type PeerInfo } from './p2p.js';
 
 describe('P2PApiSchema', () => {
@@ -38,6 +40,11 @@ describe('P2PApiSchema', () => {
   it('getPendingTxs', async () => {
     const txs = await context.client.getPendingTxs();
     expect(txs[0]).toBeInstanceOf(Tx);
+    expect(txs[0].chonkProof.isEmpty()).toBe(true);
+
+    const txsWithProof = await context.client.getPendingTxs(undefined, undefined, { includeProof: true });
+    expect(txsWithProof[0]).toBeInstanceOf(Tx);
+    expect(txsWithProof[0].chonkProof.isEmpty()).toBe(false);
   });
 
   it('getPendingTxCount', async () => {
@@ -77,8 +84,9 @@ class MockP2P implements P2PApi {
     return Promise.resolve([CheckpointAttestation.empty()]);
   }
 
-  getPendingTxs(): Promise<Tx[]> {
-    return Promise.resolve([Tx.random()]);
+  getPendingTxs(_limit?: number, _after?: TxHash, options?: GetTxByHashOptions): Promise<Tx[]> {
+    const tx = Tx.random({ randomProof: true });
+    return Promise.resolve([options?.includeProof ? tx : tx.withoutProof()]);
   }
 
   getPendingTxCount(): Promise<number> {

--- a/yarn-project/stdlib/src/interfaces/p2p.ts
+++ b/yarn-project/stdlib/src/interfaces/p2p.ts
@@ -9,6 +9,7 @@ import { type ApiSchemaFor, optional, schemas } from '../schemas/index.js';
 import { Tx } from '../tx/tx.js';
 import { TxHash } from '../tx/tx_hash.js';
 import { MAX_RPC_TXS_LEN } from './api_limit.js';
+import { type GetTxByHashOptions, GetTxByHashOptionsSchema } from './aztec-node.js';
 
 export type PeerInfo =
   | { status: 'connected'; score: number; id: string }
@@ -30,12 +31,14 @@ const PeerInfoSchema = z.discriminatedUnion('status', [
 /** Exposed API to the P2P module. */
 export interface P2PApi {
   /**
-   * Returns all pending transactions in the transaction pool.
+   * Returns all pending transactions in the transaction pool. The txs' proofs are stripped unless
+   * `includeProof` is set.
    * @param limit - The number of items to returns
    * @param after - The last known pending tx. Used for pagination
+   * @param options - Options for the returned txs (eg whether to include their proofs).
    * @returns An array of Txs.
    */
-  getPendingTxs(limit?: number, after?: TxHash): Promise<Tx[]>;
+  getPendingTxs(limit?: number, after?: TxHash, options?: GetTxByHashOptions): Promise<Tx[]>;
 
   /** Returns the number of pending txs in the p2p tx pool. */
   getPendingTxCount(): Promise<number>;
@@ -89,6 +92,7 @@ export const P2PApiSchema: ApiSchemaFor<P2PApi> = {
     input: z.tuple([
       optional(z.number().gte(1).lte(MAX_RPC_TXS_LEN).default(MAX_RPC_TXS_LEN)),
       optional(TxHash.schema),
+      optional(GetTxByHashOptionsSchema),
     ]),
     output: z.array(Tx.schema),
   }),

--- a/yarn-project/stdlib/src/tx/tx.test.ts
+++ b/yarn-project/stdlib/src/tx/tx.test.ts
@@ -20,6 +20,13 @@ describe('Tx', () => {
     expect(Tx.fromBuffer(buf)).toEqual(tx);
   });
 
+  it('convert to and from separate tx and proof buffers', async () => {
+    const tx = await mockTx();
+    const restored = Tx.fromBuffers(tx.withoutProof().toBuffer(), tx.chonkProof.toBuffer());
+    expect(restored).toEqual(tx);
+    expect(restored.chonkProof.isEmpty()).toBe(false);
+  });
+
   it('convert to and from json', async () => {
     const tx = await mockTx();
     const json = jsonStringify(tx);

--- a/yarn-project/stdlib/src/tx/tx.ts
+++ b/yarn-project/stdlib/src/tx/tx.ts
@@ -316,6 +316,15 @@ export class Tx extends Gossipable {
   }
 
   /**
+   * Returns a copy of this tx with the given proof attached. Inverse of {@link Tx.withoutProof}, used to reattach a
+   * proof that is stored separately from the rest of the tx.
+   * @returns A new tx carrying the given proof.
+   */
+  withProof(proof: ChonkProof): Tx {
+    return new Tx(this.txHash, this.data, proof, this.contractClassLogFields, this.publicFunctionCalldata);
+  }
+
+  /**
    * Creates a random tx.
    * @param randomProof - Whether to create a random proof - this will be random bytes of the full size.
    * @returns A random tx.

--- a/yarn-project/stdlib/src/tx/tx.ts
+++ b/yarn-project/stdlib/src/tx/tx.ts
@@ -136,6 +136,23 @@ export class Tx extends Gossipable {
   }
 
   /**
+   * Deserializes a Tx from separately-stored tx and proof buffers. The tx buffer is expected to carry an empty
+   * proof placeholder (as produced by `withoutProof().toBuffer()`), which is skipped in favor of the given proof.
+   * @param txBuffer - Serialized tx with an empty proof placeholder.
+   * @param proofBuffer - Serialized proof to attach.
+   * @returns An instance of Tx carrying the given proof.
+   */
+  static fromBuffers(txBuffer: Buffer | BufferReader, proofBuffer: Buffer | BufferReader): Tx {
+    const reader = BufferReader.asReader(txBuffer);
+    const txHash = reader.readObject(TxHash);
+    const data = reader.readObject(PrivateKernelTailCircuitPublicInputs);
+    reader.readObject(ChonkProof);
+    const contractClassLogFields = reader.readVectorUint8Prefix(ContractClassLogFields);
+    const publicFunctionCalldata = reader.readVectorUint8Prefix(HashedValues);
+    return new Tx(txHash, data, ChonkProof.fromBuffer(proofBuffer), contractClassLogFields, publicFunctionCalldata);
+  }
+
+  /**
    * Serializes the Tx object into a Buffer.
    * @returns Buffer representation of the Tx object.
    */
@@ -313,15 +330,6 @@ export class Tx extends Gossipable {
    */
   withoutProof(): Tx {
     return new Tx(this.txHash, this.data, ChonkProof.empty(), this.contractClassLogFields, this.publicFunctionCalldata);
-  }
-
-  /**
-   * Returns a copy of this tx with the given proof attached. Inverse of {@link Tx.withoutProof}, used to reattach a
-   * proof that is stored separately from the rest of the tx.
-   * @returns A new tx carrying the given proof.
-   */
-  withProof(proof: ChonkProof): Tx {
-    return new Tx(this.txHash, this.data, proof, this.contractClassLogFields, this.publicFunctionCalldata);
   }
 
   /**

--- a/yarn-project/yarn.lock
+++ b/yarn-project/yarn.lock
@@ -1619,7 +1619,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@aztec/noir-noir_codegen@portal:../noir/packages/noir_codegen::locator=%40aztec%2Faztec3-packages%40workspace%3A."
   dependencies:
-    "@aztec/noir-types": "npm:1.0.0-beta.21"
+    "@aztec/noir-types": "npm:1.0.0-beta.22"
     glob: "npm:^13.0.6"
     ts-command-line-args: "npm:^2.5.1"
   bin:
@@ -1628,14 +1628,14 @@ __metadata:
   linkType: soft
 
 "@aztec/noir-noir_js@file:../noir/packages/noir_js::locator=%40aztec%2Faztec3-packages%40workspace%3A.":
-  version: 1.0.0-beta.21
-  resolution: "@aztec/noir-noir_js@file:../noir/packages/noir_js#../noir/packages/noir_js::hash=294c27&locator=%40aztec%2Faztec3-packages%40workspace%3A."
+  version: 1.0.0-beta.22
+  resolution: "@aztec/noir-noir_js@file:../noir/packages/noir_js#../noir/packages/noir_js::hash=893a3e&locator=%40aztec%2Faztec3-packages%40workspace%3A."
   dependencies:
-    "@aztec/noir-acvm_js": "npm:1.0.0-beta.21"
-    "@aztec/noir-noirc_abi": "npm:1.0.0-beta.21"
-    "@aztec/noir-types": "npm:1.0.0-beta.21"
+    "@aztec/noir-acvm_js": "npm:1.0.0-beta.22"
+    "@aztec/noir-noirc_abi": "npm:1.0.0-beta.22"
+    "@aztec/noir-types": "npm:1.0.0-beta.22"
     pako: "npm:^2.1.0"
-  checksum: 10/ef758950e67df3711103b159b5b39bbe36cf5028b636f0ecfdd528bb4a849057768a01b6b82bd3084d22df3def1ffd59f3c8ec9394e4b8a6c3a741f0ab304630
+  checksum: 10/b1c958ddcfc861e7f14d35bd29d654ba985baa7ca57530cdf2c13fae821b67b8a17d0df599f8ed697fc7a08bccde094b4aec145d2f07d0ce18d97d5731f6785f
   languageName: node
   linkType: hard
 
@@ -1643,7 +1643,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@aztec/noir-noirc_abi@portal:../noir/packages/noirc_abi::locator=%40aztec%2Faztec3-packages%40workspace%3A."
   dependencies:
-    "@aztec/noir-types": "npm:1.0.0-beta.21"
+    "@aztec/noir-types": "npm:1.0.0-beta.22"
   languageName: node
   linkType: soft
 


### PR DESCRIPTION
## Motivation

`AztecNode.getTxByHash`, `getTxsByHash` and `getPendingTxs` always shipped the full chonk proof (~35-52KB per tx), which most callers (explorers, wallets polling pending txs) never use. This change makes proofs opt-in to cut wire transfer. Supersedes #23634, which stripped the proof only after loading the full tx from the DB.

## Approach

The tx pool stores proofs in a separate KV map from the tx data, so a proofless lookup never loads the proof from storage at all (the previous attempt loaded and discarded it). The node API getters take an optional `GetTxByHashOptions` with an `includeProof` flag that defaults to false and is threaded down through the p2p client to the pool; pool-internal callers default to full txs since reqresp serving and tx collection need proofs. Internal reads that never need proofs (block-building iterators, fee queries) explicitly skip them. The p2p store schema version is bumped to 3 to drop old single-blob pools (the mempool repopulates via gossip).

## Changes

- **stdlib**: `GetTxByHashOptions` type + schema on `getTxByHash`/`getTxsByHash`/`getPendingTxs` (node and p2p APIs), a `Tx.withoutProof` helper, and a `Tx.fromBuffers` factory that deserializes a tx and its separately-stored proof in one pass.
- **p2p**: `TxPoolV2Impl` splits tx data and proof into separate maps (`txs` / `tx_proofs`), written and deleted in lockstep; `getTxByHash`/`getTxsByHash` take `includeProof` (pool default: include); a missing proof entry logs a structured warning since it breaks the blob/proof invariant; soft-delete resurrection reattaches the proof before rewriting; store schema version bumped to 3.
- **p2p (tx collection)**: the node RPC tx source requests txs with `includeProof: true` since collected txs feed block validation and proving.
- **sequencer-client**: block-building iterators skip proofs — conditionally in the checkpoint proposal job (`publishTxsWithProposals` attaches the same tx objects to gossiped proposals) and always in automine. Block-building validators exclude the proof validator, so this is safe.
- **aztec-node**: getters forward the flag (public default: exclude); `getTxsByHash` uses the batched pool lookup; `getMaxPriorityFees` reads proofless; the `getTxReceipt` pending path passes the flag to the pool instead of loading the full tx and stripping after the fact.
- **tests**: pool proof-storage suite (default round-trip, proofless reads, separate keys, hard-delete cleanup, resurrection preserves proof), node and p2p API schema round-trips, receipt pending-tx assertions, `Tx.fromBuffers` round-trip.
- **docs**: migration note under v5 for the new proofless defaults.

Fixes A-1113

