### PR TITLE
chore(backport-to-v4): fix: released contract artifact aztec version (#23470)

### DIFF
--- a/ci3/release_prep_package_json
+++ b/ci3/release_prep_package_json
@@ -22,3 +22,13 @@ for deps in dependencies devDependencies peerDependencies; do
     mv tmp.json package.json
   done
 done
+
+# Stamp aztec_version into any published noir contract artifacts in artifacts/*.json. The build-time stamp in
+# noir-projects/noir-contracts/bootstrap.sh writes "dev"; $version here is the authoritative release version about to
+# be written to package.json. We cannot stamp real version in bootstrap because there we don't have access to it.
+if [ -d artifacts ]; then
+  for f in artifacts/*.json; do
+    [ -e "$f" ] || continue
+    jq --arg v "$version" '.aztec_version = $v' "$f" >$tmp && mv $tmp "$f"
+  done
+fi

--- a/noir-projects/noir-contracts/bootstrap.sh
+++ b/noir-projects/noir-contracts/bootstrap.sh
@@ -93,19 +93,16 @@ function get_contract_path {
 }
 export -f get_contract_path
 
-# Stamps the aztec version into a contract artifact JSON in place. Mirrors stampAztecVersion in
-# yarn-project/aztec/src/cli/cmds/compile.ts so monorepo-built artifacts match those produced by `aztec compile`.
-# On release builds (REF_NAME is valid semver) the tag without the leading "v" is used; otherwise "dev".
-function stamp_aztec_version {
+# Stamps "dev" (DEV_VERSION) as the artifact's aztec_version - that is the expected version of a locally checked out
+# monorepo. The real release version is applied at publish time by whichever path owns it:
+# ci3/release_prep_package_json for npm packages, release-image/Dockerfile for the docker image.
+function stamp_dev_aztec_version {
   local json_path=$1
-  # "dev" here corresponds to DEV_VERSION in yarn-project/stdlib/src/update-checker/dev_version.ts.
-  local version="dev"
-  semver check "$REF_NAME" 2>/dev/null && version="${REF_NAME#v}"
   local tmp=$(mktemp)
-  jq --arg v "$version" '.aztec_version = $v' "$json_path" > "$tmp"
+  jq '.aztec_version = "dev"' "$json_path" > "$tmp"
   mv "$tmp" "$json_path"
 }
-export -f stamp_aztec_version
+export -f stamp_dev_aztec_version
 
 # This compiles a noir contract, transpiles public functions, strips internal prefixes,
 # and generates verification keys for private functions via 'bb aztec_process'.
@@ -127,9 +124,9 @@ function compile {
     $BB aztec_process -i $json_path
     cache_upload contract-$contract_hash.tar.gz $json_path
   fi
-  # Stamp the current version after the cache block so the field always matches the build's version, whether
-  # the artifact came from a fresh compile or a cache hit.
-  stamp_aztec_version "$json_path"
+  # Stamp the version after the cache block so the field is always present, whether the artifact came from a fresh
+  # compile or a cache hit.
+  stamp_dev_aztec_version "$json_path"
 }
 export -f compile
 

--- a/release-image/Dockerfile
+++ b/release-image/Dockerfile
@@ -22,4 +22,16 @@ RUN echo '{".": "'$VERSION'"}' > /usr/src/.release-please-manifest.json
 RUN jq --arg v "$VERSION" '.version = $v' /usr/src/yarn-project/stdlib/package.json > /tmp/p.json \
     && mv /tmp/p.json /usr/src/yarn-project/stdlib/package.json
 
+# Stamp aztec_version into the shipped contract artifacts. The build-time stamp in
+# noir-projects/noir-contracts/bootstrap.sh writes "dev" unconditionally; $VERSION here is the authoritative release
+# version for this image.
+RUN for dir in \
+        /usr/src/yarn-project/accounts/artifacts \
+        /usr/src/yarn-project/noir-contracts.js/artifacts \
+        /usr/src/yarn-project/noir-test-contracts.js/artifacts; do \
+      for f in "$dir"/*.json; do \
+        jq --arg v "$VERSION" '.aztec_version = $v' "$f" > /tmp/a.json && mv /tmp/a.json "$f"; \
+      done; \
+    done
+
 ENTRYPOINT ["node", "--no-warnings", "/usr/src/yarn-project/aztec/dest/bin/index.js"]

--- a/yarn-project/end-to-end/src/fixtures/setup.ts
+++ b/yarn-project/end-to-end/src/fixtures/setup.ts
@@ -54,6 +54,7 @@ import { type ContractInstanceWithAddress, getContractInstanceFromInstantiationP
 import type { AztecNodeAdmin, AztecNodeDebug } from '@aztec/stdlib/interfaces/client';
 import { tryStop } from '@aztec/stdlib/interfaces/server';
 import type { PublicDataTreeLeaf } from '@aztec/stdlib/trees';
+import { DEV_VERSION } from '@aztec/stdlib/update-checker';
 import {
   type TelemetryClient,
   type TelemetryClientConfig,
@@ -280,6 +281,14 @@ function assertContractArtifactsVersion() {
   if (aztecVersion === ARTIFACT_VERSION_BEFORE_INJECTION) {
     createLogger('e2e:setup').info(
       `Skipping artifact version check: artifact predates version injection (CONTRACT_ARTIFACTS_VERSION=${expected})`,
+    );
+    return;
+  }
+  // TODO(F-557): Remove once v4.3.0 drops off the compat matrix. The v4.3.0 npm release shipped with
+  // aztec_version: "dev" baked into the artifact JSONs because of a bug.
+  if (expected === '4.3.0' && aztecVersion === DEV_VERSION) {
+    createLogger('e2e:setup').warn(
+      `Skipping artifact version check: v4.3.0 artifacts shipped with aztec_version="dev"`,
     );
     return;
   }


### PR DESCRIPTION
## Summary

Backport of [#23470](https://github.com/AztecProtocol/aztec-packages/pull/23470) (by @benesjan) from `v4-next` to `v4`.

This is needed to unblock the v4.3.1 release. The v4.3.0 release shipped contract artifact JSONs with `aztec_version: "dev"` baked in (because `REF_NAME` wasn't correctly populated during release-image build), which causes `ci-compat-e2e` on v4 to fail with `Artifact version mismatch: expected 4.3.0 but got dev`. The same failure was blocking v4.3.1 publish.

The fix re-stamps the version into the artifact later in the release process where the actual version is reliably available.

## Cherry-pick details

- Original commit on `v4-next`: `a2d104a1b4` (merge commit of #23470)
- Cherry-picked with `-m 1` (parent 1 = v4-next mainline) — applied cleanly with no conflicts.
- Files touched (4):
  - `ci3/release_prep_package_json` (+10)
  - `noir-projects/noir-contracts/bootstrap.sh` (+11 / -10)
  - `release-image/Dockerfile` (+12)
  - `yarn-project/end-to-end/src/fixtures/setup.ts` (+9)
- Diff stats match the v4-next commit exactly (40+/12-).

## After merging

1. Update the `v4.3.1` CHANGELOG entry on v4 to include this fix.
2. Force-move the `v4.3.1` git tag to the new v4 HEAD (safe — nothing has been published as 4.3.1 yet: npm has only 4.3.0, Docker Hub returns 404 for `aztec:4.3.1`, GitHub Release for v4.3.1 doesn't exist).
3. Re-trigger v4 CI — compat should now pass, `ci-release-publish` should run for real.

## Test plan

- [ ] CI green (specifically `ci-compat-e2e`)
- [ ] Verify a built artifact JSON contains the actual release version, not `"dev"`