### PR TITLE
chore(v4): add release-image fix to v4.3.1 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 * **prover:** wait for previous epoch to be proven ([#23457](https://github.com/AztecProtocol/aztec-packages/issues/23457)) ([fd89d46](https://github.com/AztecProtocol/aztec-packages/commit/fd89d46305022a4b6c3b0bb9faa5fb57980aca59))
 * **stdlib:** guard tip-store finalize against deleting live tips (backport [#23295](https://github.com/AztecProtocol/aztec-packages/issues/23295)) ([#23505](https://github.com/AztecProtocol/aztec-packages/issues/23505)) ([bdc777b](https://github.com/AztecProtocol/aztec-packages/commit/bdc777bb778c6942dcc5c13eb84e86c619170002))
+* **release-image:** re-stamp aztec_version into released noir-contracts artifacts so released JSONs no longer carry `"dev"` (backport [#23470](https://github.com/AztecProtocol/aztec-packages/issues/23470)) ([#23851](https://github.com/AztecProtocol/aztec-packages/issues/23851)) ([7d80b2d](https://github.com/AztecProtocol/aztec-packages/commit/7d80b2dabe))
 
 
 ## [4.3.0](https://github.com/AztecProtocol/aztec-packages/compare/v4.2.1...v4.3.0) (2026-05-19)


### PR DESCRIPTION
## Summary

Adds the third bug fix that landed on `v4` (via backport PR #23851 of #23470) to the existing `## [4.3.1]` `CHANGELOG.md` entry so the section reflects what v4.3.1 actually ships.

Single-line change in `CHANGELOG.md` only — no version-file or manifest changes. Manifest stays at 4.3.1.

## What v4.3.1 contains after this lands

- `prover: wait for previous epoch to be proven` (#23457)
- `stdlib: guard tip-store finalize against deleting live tips` (backport of #23295, via #23505)
- `release-image: re-stamp aztec_version into released noir-contracts artifacts` (backport of #23470, via #23851) — **new entry, fixes the v4.3.1 ci-compat-e2e failure**

## After merging

Force-move the `v4.3.1` tag to the merge commit of this PR (safe — nothing has been published as 4.3.1 yet: npm has only 4.3.0, Docker Hub returns 404 for `aztec:4.3.1`, GitHub Release for v4.3.1 doesn't exist).

## Test plan

- [ ] Visual check that the `## [4.3.1]` section in `CHANGELOG.md` lists all three fixes