### PR TITLE
fix(e2e): poll for high-value inclusion in n_tps bench

### DIFF
--- a/yarn-project/end-to-end/src/spartan/n_tps.test.ts
+++ b/yarn-project/end-to-end/src/spartan/n_tps.test.ts
@@ -3,7 +3,7 @@ import { NO_FROM } from '@aztec/aztec.js/account';
 import type { AztecAddress } from '@aztec/aztec.js/addresses';
 import { NO_WAIT, toSendOptions } from '@aztec/aztec.js/contracts';
 import { SponsoredFeePaymentMethod } from '@aztec/aztec.js/fee';
-import { type AztecNode, createAztecNodeClient } from '@aztec/aztec.js/node';
+import { type AztecNode, createAztecNodeClient, waitForTx } from '@aztec/aztec.js/node';
 import { AccountManager } from '@aztec/aztec.js/wallet';
 import { INITIAL_L2_BLOCK_NUM } from '@aztec/constants';
 import { BlockNumber } from '@aztec/foundation/branded-types';
@@ -18,7 +18,7 @@ import { BenchmarkingContract } from '@aztec/noir-test-contracts.js/Benchmarking
 import { type Gas, GasFees, GasSettings } from '@aztec/stdlib/gas';
 import { deriveSigningKey } from '@aztec/stdlib/keys';
 import { TopicType } from '@aztec/stdlib/p2p';
-import { Tx, TxHash } from '@aztec/stdlib/tx';
+import { Tx, TxHash, TxStatus } from '@aztec/stdlib/tx';
 
 import { jest } from '@jest/globals';
 import { mkdir, writeFile } from 'fs/promises';
@@ -600,8 +600,8 @@ describe('sustained N TPS test', () => {
 
     // Block-watcher: stamps wall-clock minedAtMs on each sent tx the first time
     // its block becomes visible to this client. Runs throughout sending AND the
-    // post-window waitForTx tail so late blocks still get a true client-observed
-    // timestamp. recordMinedTx (in waitForTx) is the slow-path fallback for any
+    // post-window inclusion wait so late blocks still get a true client-observed
+    // timestamp. recordMinedTx (in waitForHighValueTx) is the slow-path fallback for any
     // tx the watcher misses.
     let lastSeenBlock = await aztecNode.getBlockNumber();
     const blockWatcher = new RunningPromise(
@@ -639,26 +639,31 @@ describe('sustained N TPS test', () => {
     });
 
     const results: { success: boolean; txHash: string; error?: any }[] = [];
-    const waitForTx = async (txHash: string, txName: string) => {
+    const highValueInclusionWaitTimeoutSeconds = 300;
+    const waitForHighValueTx = async (txHash: string, txName: string) => {
       try {
-        const receipt = await aztecNode.getTxReceipt(TxHash.fromString(txHash));
-        if (receipt.blockNumber) {
-          logger.info(`${txName} included in block ${receipt.blockNumber}`);
-          logger.debug(`${txName} receipt details`, {
-            txHash: receipt.txHash.toString(),
-            status: receipt.status,
-            blockNumber: receipt.blockNumber,
-            transactionFee: receipt.transactionFee?.toString(),
-          });
-          await metrics.recordMinedTx(receipt);
-        } else {
-          throw new Error('Invalid txReceipt: ' + JSON.stringify(receipt));
-        }
+        const receipt = await waitForTx(aztecNode, TxHash.fromString(txHash), {
+          timeout: highValueInclusionWaitTimeoutSeconds,
+          waitForStatus: TxStatus.PROPOSED,
+        });
+        logger.info(`${txName} included in block ${receipt.blockNumber}`, {
+          txName,
+          blockNumber: receipt.blockNumber,
+        });
+        logger.debug(`${txName} receipt details`, {
+          txHash: receipt.txHash.toString(),
+          status: receipt.status,
+          blockNumber: receipt.blockNumber,
+          transactionFee: receipt.transactionFee?.toString(),
+        });
+        await metrics.recordMinedTx(receipt);
         results.push({ success: true, txHash });
       } catch (error) {
         const receipt = await aztecNode.getTxReceipt(TxHash.fromString(txHash)).catch(() => undefined);
-        logger.error(`${txName} was not included: ${error}`, {
+        logger.error(`${txName} was not included`, {
+          txName,
           txHash,
+          err: error,
           receiptStatus: receipt?.status,
           receiptBlockNumber: receipt?.blockNumber,
           receiptError: receipt?.error,
@@ -672,7 +677,7 @@ describe('sustained N TPS test', () => {
     logger.info('Waiting for high-value txs to be mined', { totalSent: totalHighValueSent });
     while (sentTxHashes.length > 0) {
       const chunk = sentTxHashes.splice(0, 10);
-      await Promise.all(chunk.map((txHash, idx) => waitForTx(txHash, `highValueTx_${idx + 1 + index}`)));
+      await Promise.all(chunk.map((txHash, idx) => waitForHighValueTx(txHash, `highValueTx_${idx + 1 + index}`)));
       index += chunk.length;
       logger.debug('Processed tx batch', { processed: index, remaining: sentTxHashes.length });
     }


### PR DESCRIPTION
## Summary

- After the sustained send window, high-value txs in `n_tps.test.ts` now use `@aztec/aztec.js/node` `waitForTx` (poll until `PROPOSED`, 300s timeout) instead of a single `getTxReceipt`.
- Fixes nightly Spartan benchmark failure on `low_0_1_high_0_1` where 11/60 txs were still `pending` when checked immediately after the 600s window (max observed inclusion ~147s).

## Context

CI: https://github.com/AztecProtocol/aztec-packages/actions/runs/26941178198/job/79486417752  
Log: http://ci.aztec-labs.com/8c0a81ecdea3d20f
