### PR TITLE
fix: init bb sync before node rpc

### DIFF
--- a/yarn-project/aztec/src/cli/aztec_start_action.ts
+++ b/yarn-project/aztec/src/cli/aztec_start_action.ts
@@ -95,9 +95,9 @@ export async function aztecStart(options: any, userLog: LogFn, debugLogger: Logg
   // Start the main JSON-RPC server
   if (Object.entries(services).length > 0) {
     if (services.node) {
-      const { BackendType, BarretenbergSync } = await import('@aztec/bb.js');
+      const { BarretenbergSync } = await import('@aztec/bb.js');
       // JSON-RPC schema parsing may decompress compressed Chonk proofs before the node handler runs.
-      await BarretenbergSync.initSingleton({ backend: BackendType.Wasm });
+      await BarretenbergSync.initSingleton();
     }
 
     const rpcServer = createNamespacedSafeJsonRpcServer(services, {

--- a/yarn-project/aztec/src/cli/aztec_start_action.ts
+++ b/yarn-project/aztec/src/cli/aztec_start_action.ts
@@ -94,6 +94,12 @@ export async function aztecStart(options: any, userLog: LogFn, debugLogger: Logg
 
   // Start the main JSON-RPC server
   if (Object.entries(services).length > 0) {
+    if (services.node) {
+      const { BackendType, BarretenbergSync } = await import('@aztec/bb.js');
+      // JSON-RPC schema parsing may decompress compressed Chonk proofs before the node handler runs.
+      await BarretenbergSync.initSingleton({ backend: BackendType.Wasm });
+    }
+
     const rpcServer = createNamespacedSafeJsonRpcServer(services, {
       diagnostic: getOtelJsonRpcDiagnosticsMiddleware(),
       http200OnError: false,

--- a/yarn-project/end-to-end/src/test-wallet/worker_wallet.ts
+++ b/yarn-project/end-to-end/src/test-wallet/worker_wallet.ts
@@ -71,7 +71,7 @@ export class WorkerWallet implements Wallet {
       env: {
         ...parentEnv,
         ...(process.stderr.isTTY || process.env.FORCE_COLOR ? { FORCE_COLOR: '1' } : {}),
-        LOG_LEVEL: process.env.WORKER_LOG_LEVEL ?? 'warn',
+        LOG_LEVEL: process.env.WORKER_LOG_LEVEL ?? 'info',
       },
     });
 


### PR DESCRIPTION
Initialize `BarretenbergSync` before exposing the node JSON-RPC server so compressed Chonk proofs can be decoded during request validation.
This covers the actual failing path [here](http://ci.aztec-labs.com/7805729346535f4a): JSON-RPC receives `node_sendTx`, `AztecNodeApiSchema.sendTx` parses params through `Tx.schema`, and `ChonkProof.fromCompressedBytes()` calls `BarretenbergSync.getSingleton()` before the node handler runs.
