### PR TITLE
chore: regenerate yarn.lock for noir beta.22

### DIFF
--- a/yarn-project/yarn.lock
+++ b/yarn-project/yarn.lock
@@ -1619,7 +1619,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@aztec/noir-noir_codegen@portal:../noir/packages/noir_codegen::locator=%40aztec%2Faztec3-packages%40workspace%3A."
   dependencies:
-    "@aztec/noir-types": "npm:1.0.0-beta.21"
+    "@aztec/noir-types": "npm:1.0.0-beta.22"
     glob: "npm:^13.0.6"
     ts-command-line-args: "npm:^2.5.1"
   bin:
@@ -1628,14 +1628,14 @@ __metadata:
   linkType: soft
 
 "@aztec/noir-noir_js@file:../noir/packages/noir_js::locator=%40aztec%2Faztec3-packages%40workspace%3A.":
-  version: 1.0.0-beta.21
-  resolution: "@aztec/noir-noir_js@file:../noir/packages/noir_js#../noir/packages/noir_js::hash=294c27&locator=%40aztec%2Faztec3-packages%40workspace%3A."
+  version: 1.0.0-beta.22
+  resolution: "@aztec/noir-noir_js@file:../noir/packages/noir_js#../noir/packages/noir_js::hash=4f6262&locator=%40aztec%2Faztec3-packages%40workspace%3A."
   dependencies:
-    "@aztec/noir-acvm_js": "npm:1.0.0-beta.21"
-    "@aztec/noir-noirc_abi": "npm:1.0.0-beta.21"
-    "@aztec/noir-types": "npm:1.0.0-beta.21"
+    "@aztec/noir-acvm_js": "npm:1.0.0-beta.22"
+    "@aztec/noir-noirc_abi": "npm:1.0.0-beta.22"
+    "@aztec/noir-types": "npm:1.0.0-beta.22"
     pako: "npm:^2.1.0"
-  checksum: 10/ef758950e67df3711103b159b5b39bbe36cf5028b636f0ecfdd528bb4a849057768a01b6b82bd3084d22df3def1ffd59f3c8ec9394e4b8a6c3a741f0ab304630
+  checksum: 10/df0680ba2a5ebdfa1fec3f63ad5d2f18e96ea57bca55104db8ba31385ae1acdf528f9d02be1d5723880a569da4ff61bc26b7939a8740fb3fd61e3f6c6606d06c
   languageName: node
   linkType: hard
 
@@ -1643,7 +1643,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@aztec/noir-noirc_abi@portal:../noir/packages/noirc_abi::locator=%40aztec%2Faztec3-packages%40workspace%3A."
   dependencies:
-    "@aztec/noir-types": "npm:1.0.0-beta.21"
+    "@aztec/noir-types": "npm:1.0.0-beta.22"
   languageName: node
   linkType: soft
 

--- a/yarn-project/yarn.lock
+++ b/yarn-project/yarn.lock
@@ -1629,13 +1629,13 @@ __metadata:
 
 "@aztec/noir-noir_js@file:../noir/packages/noir_js::locator=%40aztec%2Faztec3-packages%40workspace%3A.":
   version: 1.0.0-beta.22
-  resolution: "@aztec/noir-noir_js@file:../noir/packages/noir_js#../noir/packages/noir_js::hash=4f6262&locator=%40aztec%2Faztec3-packages%40workspace%3A."
+  resolution: "@aztec/noir-noir_js@file:../noir/packages/noir_js#../noir/packages/noir_js::hash=893a3e&locator=%40aztec%2Faztec3-packages%40workspace%3A."
   dependencies:
     "@aztec/noir-acvm_js": "npm:1.0.0-beta.22"
     "@aztec/noir-noirc_abi": "npm:1.0.0-beta.22"
     "@aztec/noir-types": "npm:1.0.0-beta.22"
     pako: "npm:^2.1.0"
-  checksum: 10/df0680ba2a5ebdfa1fec3f63ad5d2f18e96ea57bca55104db8ba31385ae1acdf528f9d02be1d5723880a569da4ff61bc26b7939a8740fb3fd61e3f6c6606d06c
+  checksum: 10/b1c958ddcfc861e7f14d35bd29d654ba985baa7ca57530cdf2c13fae821b67b8a17d0df599f8ed697fc7a08bccde094b4aec145d2f07d0ce18d97d5731f6785f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Regenerate `yarn.lock` to match noir wrapper packages at `beta.22` after the submodule bump in #23870 left the lockfile stale, causing `yarn install --immutable` to fail in CI.