### PR TITLE
ci: notify private mirror to sync on push (replaces its 15-min poll)

### DIFF
--- a/.github/workflows/notify-private-sync.yml
+++ b/.github/workflows/notify-private-sync.yml
@@ -1,0 +1,28 @@
+# Notify the private mirror (AztecProtocol/aztec-packages-private) to sync this branch.
+#
+# Replaces the private repo's 15-minute polling: on every push to next/v5-next we dispatch its
+# sync-upstream-<branch>.yml via AztecBot. This ONLY dispatches a workflow in the private repo — it
+# never checks out, reads, or pushes any private content, so no private commits can leak into public.
+name: Notify Private Sync
+
+on:
+  push:
+    branches: [next, v5-next]
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "Branch to sync (next or v5-next)"
+        required: true
+        default: next
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch sync in the private repo
+        env:
+          GH_TOKEN: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
+          BRANCH: ${{ github.event.inputs.branch || github.ref_name }}
+        run: |
+          gh workflow run "sync-upstream-${BRANCH}.yml" \
+            --repo AztecProtocol/aztec-packages-private --ref next


### PR DESCRIPTION
## What

Adds a tiny workflow that, on every push to `next`/`v5-next`, dispatches the private mirror's (`AztecProtocol/aztec-packages-private`) `sync-upstream-<branch>.yml` via AztecBot — so the mirror is **notified** of public changes instead of **polling** every 15 minutes (companion PR there drops the cron).

## Safety

This workflow **only dispatches** a workflow in the private repo. It does **not** checkout, read, or push any private content — there is no path for private commits to enter this public repo. Auth is the existing `AZTEC_BOT_GITHUB_TOKEN` secret.

Minimal: one new file, one `gh workflow run` call.