### PR TITLE
test: default TestWallet to proposed

### DIFF
--- a/yarn-project/end-to-end/src/composed/web3signer/e2e_multi_validator_node_key_store.test.ts
+++ b/yarn-project/end-to-end/src/composed/web3signer/e2e_multi_validator_node_key_store.test.ts
@@ -17,7 +17,7 @@ import { StatefulTestContractArtifact } from '@aztec/noir-test-contracts.js/Stat
 import type { Sequencer, SequencerClient, SequencerPublisherFactory } from '@aztec/sequencer-client';
 import type { TestSequencer, TestSequencerClient } from '@aztec/sequencer-client/test';
 import type { BlockProposalOptions } from '@aztec/stdlib/p2p';
-import type { BlockHeader, Tx } from '@aztec/stdlib/tx';
+import { type BlockHeader, type Tx, TxStatus } from '@aztec/stdlib/tx';
 import { NodeKeystoreAdapter, ValidatorClient } from '@aztec/validator-client';
 
 import { jest } from '@jest/globals';
@@ -287,6 +287,7 @@ describe('e2e_multi_validator_node', () => {
     } = await setup(
       1,
       {
+        defaultWaitStatus: TxStatus.CHECKPOINTED,
         ...PIPELINING_SETUP_OPTS,
         initialValidators,
         aztecTargetCommitteeSize: COMMITTEE_SIZE,

--- a/yarn-project/end-to-end/src/e2e_amm.test.ts
+++ b/yarn-project/end-to-end/src/e2e_amm.test.ts
@@ -3,6 +3,7 @@ import { Fr } from '@aztec/aztec.js/fields';
 import type { Logger } from '@aztec/aztec.js/log';
 import { AMMContract } from '@aztec/noir-contracts.js/AMM';
 import type { TokenContract } from '@aztec/noir-contracts.js/Token';
+import { TxStatus } from '@aztec/stdlib/tx';
 
 import { jest } from '@jest/globals';
 
@@ -51,7 +52,11 @@ describe('AMM', () => {
       wallet,
       accounts: [adminAddress, liquidityProviderAddress, otherLiquidityProviderAddress, swapperAddress],
       logger,
-    } = await setup(4, { ...AUTOMINE_E2E_OPTS }, { syncChainTip: 'checkpointed' }));
+    } = await setup(
+      4,
+      { defaultWaitStatus: TxStatus.CHECKPOINTED, ...AUTOMINE_E2E_OPTS },
+      { syncChainTip: 'checkpointed' },
+    ));
 
     ({ contract: token0 } = await deployToken(wallet, adminAddress, 0n, logger));
     ({ contract: token1 } = await deployToken(wallet, adminAddress, 0n, logger));

--- a/yarn-project/end-to-end/src/e2e_blacklist_token_contract/blacklist_token_contract_test.ts
+++ b/yarn-project/end-to-end/src/e2e_blacklist_token_contract/blacklist_token_contract_test.ts
@@ -11,6 +11,7 @@ import { GenericProxyContract } from '@aztec/noir-test-contracts.js/GenericProxy
 import { InvalidAccountContract } from '@aztec/noir-test-contracts.js/InvalidAccount';
 import type { SequencerClient } from '@aztec/sequencer-client';
 import type { AztecNodeDebug } from '@aztec/stdlib/interfaces/client';
+import { TxStatus } from '@aztec/stdlib/tx';
 
 import { jest } from '@jest/globals';
 
@@ -158,6 +159,8 @@ export class BlacklistTokenContractTest {
   async setup(opts: Partial<SetupOptions> = {}) {
     this.logger.info('Setting up fresh context');
     this.context = await setup(0, {
+      // Finality-sensitive suite: default to CHECKPOINTED before any setup-phase send.
+      defaultWaitStatus: TxStatus.CHECKPOINTED,
       ...opts,
       fundSponsoredFPC: true,
       skipAccountDeployment: true,

--- a/yarn-project/end-to-end/src/e2e_block_building.test.ts
+++ b/yarn-project/end-to-end/src/e2e_block_building.test.ts
@@ -63,6 +63,7 @@ describe('e2e_block_building', () => {
         accounts: [ownerAddress, minterAddress],
         sequencer: sequencerClient,
       } = await setup(2, {
+        defaultWaitStatus: TxStatus.CHECKPOINTED,
         ...PIPELINING_SETUP_OPTS,
         archiverPollingIntervalMS: 200,
         sequencerPollingIntervalMS: 200,
@@ -307,7 +308,7 @@ describe('e2e_block_building', () => {
         logger,
         wallet,
         accounts: [ownerAddress],
-      } = await setup(1, { ...PIPELINING_SETUP_OPTS }));
+      } = await setup(1, { defaultWaitStatus: TxStatus.CHECKPOINTED, ...PIPELINING_SETUP_OPTS }));
       ({ contract } = await TestContract.deploy(wallet).send({ from: ownerAddress }));
       logger.info(`Test contract deployed at ${contract.address}`);
     });
@@ -433,7 +434,7 @@ describe('e2e_block_building', () => {
         logger,
         wallet,
         accounts: [ownerAddress],
-      } = await setup(1, { ...PIPELINING_SETUP_OPTS }));
+      } = await setup(1, { defaultWaitStatus: TxStatus.CHECKPOINTED, ...PIPELINING_SETUP_OPTS }));
 
       logger.info(`Deploying test contract`);
       ({ contract: testContract } = await TestContract.deploy(wallet).send({ from: ownerAddress }));
@@ -502,6 +503,7 @@ describe('e2e_block_building', () => {
     // Regression for https://github.com/AztecProtocol/aztec-packages/issues/7918
     it('publishes two empty blocks', async () => {
       ({ teardown, wallet, logger, aztecNode } = await setup(0, {
+        defaultWaitStatus: TxStatus.CHECKPOINTED,
         ...PIPELINING_SETUP_OPTS,
         minTxsPerBlock: 0,
         buildCheckpointIfEmpty: true,
@@ -514,7 +516,12 @@ describe('e2e_block_building', () => {
 
     // Regression for https://github.com/AztecProtocol/aztec-packages/issues/7537
     it('sends a tx on the first block', async () => {
-      const context = await setup(0, { ...PIPELINING_SETUP_OPTS, minTxsPerBlock: 0, numberOfInitialFundedAccounts: 1 });
+      const context = await setup(0, {
+        defaultWaitStatus: TxStatus.CHECKPOINTED,
+        ...PIPELINING_SETUP_OPTS,
+        minTxsPerBlock: 0,
+        numberOfInitialFundedAccounts: 1,
+      });
       ({ teardown, logger, aztecNode, wallet } = context);
       await sleep(1000);
 
@@ -535,7 +542,7 @@ describe('e2e_block_building', () => {
         wallet,
         aztecNodeAdmin,
         accounts: [ownerAddress],
-      } = await setup(1, { ...PIPELINING_SETUP_OPTS, minTxsPerBlock: 1 }));
+      } = await setup(1, { defaultWaitStatus: TxStatus.CHECKPOINTED, ...PIPELINING_SETUP_OPTS, minTxsPerBlock: 1 }));
 
       logger.info('Deploying token contract');
       const { contract: token } = await TokenContract.deploy(wallet, ownerAddress, 'TokenName', 'TokenSymbol', 18).send(
@@ -563,7 +570,12 @@ describe('e2e_block_building', () => {
     // which translates in an incorrect end state for world state. We can easily detect this by checking whether the nullifier
     // tree next available leaf index is a multiple of 64.
     it('clears up all nullifiers if tx processing fails', async () => {
-      const context = await setup(1, { ...PIPELINING_SETUP_OPTS, minTxsPerBlock: 1, numberOfInitialFundedAccounts: 1 });
+      const context = await setup(1, {
+        defaultWaitStatus: TxStatus.CHECKPOINTED,
+        ...PIPELINING_SETUP_OPTS,
+        minTxsPerBlock: 1,
+        numberOfInitialFundedAccounts: 1,
+      });
       ({
         teardown,
         logger,
@@ -631,7 +643,7 @@ describe('e2e_block_building', () => {
         cheatCodes,
         watcher,
         accounts: [ownerAddress],
-      } = await setup(1, { ...PIPELINING_SETUP_OPTS, minTxsPerBlock: 1 }));
+      } = await setup(1, { defaultWaitStatus: TxStatus.CHECKPOINTED, ...PIPELINING_SETUP_OPTS, minTxsPerBlock: 1 }));
 
       ({ contract } = await StatefulTestContract.deploy(wallet, ownerAddress, 1).send({ from: ownerAddress }));
       initialBlockNumber = await aztecNode.getBlockNumber();

--- a/yarn-project/end-to-end/src/e2e_cross_chain_messaging/cross_chain_messaging_test.ts
+++ b/yarn-project/end-to-end/src/e2e_cross_chain_messaging/cross_chain_messaging_test.ts
@@ -21,6 +21,7 @@ import { TokenContract } from '@aztec/noir-contracts.js/Token';
 import { TokenBridgeContract } from '@aztec/noir-contracts.js/TokenBridge';
 import type { PXEConfig } from '@aztec/pxe/server';
 import type { AztecNodeAdmin } from '@aztec/stdlib/interfaces/client';
+import { TxStatus } from '@aztec/stdlib/tx';
 
 import { MNEMONIC } from '../fixtures/fixtures.js';
 import {
@@ -97,6 +98,8 @@ export class CrossChainMessagingTest {
     this.context = await setup(
       0,
       {
+        // Finality-sensitive suite: default to CHECKPOINTED before any setup-phase send.
+        defaultWaitStatus: TxStatus.CHECKPOINTED,
         ...this.setupOptions,
         ...opts,
         fundSponsoredFPC: true,

--- a/yarn-project/end-to-end/src/e2e_deploy_contract/deploy_test.ts
+++ b/yarn-project/end-to-end/src/e2e_deploy_contract/deploy_test.ts
@@ -8,6 +8,7 @@ import type { AztecNode } from '@aztec/aztec.js/node';
 import type { Wallet } from '@aztec/aztec.js/wallet';
 import type { StatefulTestContract } from '@aztec/noir-test-contracts.js/StatefulTest';
 import type { AztecNodeAdmin } from '@aztec/stdlib/interfaces/client';
+import { TxStatus } from '@aztec/stdlib/tx';
 
 import { type EndToEndContext, type SetupOptions, deployAccounts, setup, teardown } from '../fixtures/setup.js';
 import type { TestWallet } from '../test-wallet/test_wallet.js';
@@ -27,6 +28,8 @@ export class DeployTest {
   async setup(opts: Partial<SetupOptions> = {}) {
     this.logger.info('Setting up test environment');
     this.context = await setup(0, {
+      // Finality-sensitive suite: default to CHECKPOINTED before any setup-phase send.
+      defaultWaitStatus: TxStatus.CHECKPOINTED,
       ...opts,
       fundSponsoredFPC: true,
       skipAccountDeployment: true,

--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_test.ts
@@ -30,6 +30,7 @@ import { type SequencerClient, type SequencerEvents, SequencerState } from '@azt
 import { type BlockParameter, EthAddress } from '@aztec/stdlib/block';
 import { type L1RollupConstants, getProofSubmissionDeadlineTimestamp } from '@aztec/stdlib/epoch-helpers';
 import { tryStop } from '@aztec/stdlib/interfaces/server';
+import { TxStatus } from '@aztec/stdlib/tx';
 import type { SlashingProtectionDatabase } from '@aztec/validator-ha-signer/types';
 
 import { join } from 'path';
@@ -150,6 +151,8 @@ export class EpochsTestContext {
     const context = await setup(
       useHardcodedAccount ? 0 : (opts.numberOfAccounts ?? 0),
       {
+        // Finality-sensitive suite: default to CHECKPOINTED before any setup-phase send.
+        defaultWaitStatus: TxStatus.CHECKPOINTED,
         automineL1Setup: true,
         checkIntervalMs: 50,
         archiverPollingIntervalMS: ARCHIVER_POLL_INTERVAL,

--- a/yarn-project/end-to-end/src/e2e_fees/fees_test.ts
+++ b/yarn-project/end-to-end/src/e2e_fees/fees_test.ts
@@ -20,6 +20,7 @@ import { ProtocolContractAddress } from '@aztec/protocol-contracts';
 import { getCanonicalFeeJuice } from '@aztec/protocol-contracts/fee-juice';
 import { GasSettings } from '@aztec/stdlib/gas';
 import type { AztecNodeAdmin } from '@aztec/stdlib/interfaces/client';
+import { TxStatus } from '@aztec/stdlib/tx';
 
 import { getContract } from 'viem';
 
@@ -110,6 +111,8 @@ export class FeesTest {
     // Token allowlist entries are test-only: FPC-based fee payment with custom tokens won't work on mainnet alpha.
     const tokenAllowList = await getTokenAllowedSetupFunctions();
     this.context = await setup(0, {
+      // Finality-sensitive suite: default to CHECKPOINTED before any setup-phase send.
+      defaultWaitStatus: TxStatus.CHECKPOINTED,
       startProverNode: true,
       ...this.setupOptions,
       ...opts,

--- a/yarn-project/end-to-end/src/e2e_multi_eoa.test.ts
+++ b/yarn-project/end-to-end/src/e2e_multi_eoa.test.ts
@@ -14,6 +14,7 @@ import { StatefulTestContract } from '@aztec/noir-test-contracts.js/StatefulTest
 import type { SequencerClient } from '@aztec/sequencer-client';
 import type { TestSequencerClient } from '@aztec/sequencer-client/test';
 import type { AztecNode, AztecNodeAdmin } from '@aztec/stdlib/interfaces/client';
+import { TxStatus } from '@aztec/stdlib/tx';
 
 import { jest } from '@jest/globals';
 import 'jest-extended';
@@ -78,6 +79,7 @@ describe('e2e_multi_eoa', () => {
       } = await setup(
         2,
         {
+          defaultWaitStatus: TxStatus.CHECKPOINTED,
           ...PIPELINING_SETUP_OPTS,
           archiverPollingIntervalMS: 200,
           sequencerPollingIntervalMS: 200,

--- a/yarn-project/end-to-end/src/e2e_multi_validator/e2e_multi_validator_node.test.ts
+++ b/yarn-project/end-to-end/src/e2e_multi_validator/e2e_multi_validator_node.test.ts
@@ -79,6 +79,7 @@ describe('e2e_multi_validator_node', () => {
       await setup(
         1,
         {
+          defaultWaitStatus: TxStatus.CHECKPOINTED,
           ...PIPELINING_SETUP_OPTS,
           initialValidators,
           aztecTargetCommitteeSize: COMMITTEE_SIZE,

--- a/yarn-project/end-to-end/src/e2e_nested_contract/nested_contract_test.ts
+++ b/yarn-project/end-to-end/src/e2e_nested_contract/nested_contract_test.ts
@@ -4,6 +4,7 @@ import type { AztecNode } from '@aztec/aztec.js/node';
 import type { Wallet } from '@aztec/aztec.js/wallet';
 import { ChildContract } from '@aztec/noir-test-contracts.js/Child';
 import { ParentContract } from '@aztec/noir-test-contracts.js/Parent';
+import { TxStatus } from '@aztec/stdlib/tx';
 
 import {
   type EndToEndContext,
@@ -54,6 +55,8 @@ export class NestedContractTest {
   async setup(opts: Partial<SetupOptions> = {}) {
     this.logger.info('Setting up fresh subsystems');
     this.context = await setup(0, {
+      // Finality-sensitive suite: default to CHECKPOINTED before any setup-phase send.
+      defaultWaitStatus: TxStatus.CHECKPOINTED,
       ...opts,
       fundSponsoredFPC: true,
       skipAccountDeployment: true,

--- a/yarn-project/end-to-end/src/e2e_offchain_payment.test.ts
+++ b/yarn-project/end-to-end/src/e2e_offchain_payment.test.ts
@@ -5,6 +5,7 @@ import { extractOffchainOutput } from '@aztec/aztec.js/contracts';
 import type { AztecNode } from '@aztec/aztec.js/node';
 import { retryUntil } from '@aztec/foundation/retry';
 import { OffchainPaymentContract } from '@aztec/noir-test-contracts.js/OffchainPayment';
+import { TxStatus } from '@aztec/stdlib/tx';
 
 import { jest } from '@jest/globals';
 
@@ -28,6 +29,8 @@ describe('e2e_offchain_payment', () => {
 
   beforeAll(async () => {
     ({ teardown, wallet, accounts, aztecNode, aztecNodeService } = await setup(2, {
+      // Finality-sensitive: default to CHECKPOINTED before any setup-phase send.
+      defaultWaitStatus: TxStatus.CHECKPOINTED,
       ...AUTOMINE_E2E_OPTS,
       anvilSlotsInAnEpoch: 32,
     }));

--- a/yarn-project/end-to-end/src/e2e_p2p/add_rollup.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/add_rollup.test.ts
@@ -31,6 +31,7 @@ import { getPXEConfig } from '@aztec/pxe/server';
 import { computeL2ToL1MessageHash } from '@aztec/stdlib/hash';
 import { tryStop } from '@aztec/stdlib/interfaces/server';
 import { getL2ToL1MessageLeafId } from '@aztec/stdlib/messaging';
+import { TxStatus } from '@aztec/stdlib/tx';
 import { getGenesisValues } from '@aztec/world-state/testing';
 
 import { jest } from '@jest/globals';
@@ -291,6 +292,7 @@ describe('e2e_p2p_add_rollup', () => {
         { ...getPXEConfig(), proverEnabled: false, syncChainTip: 'checkpointed' },
         { loggerActorLabel: 'pxe-bridge' },
       );
+      wallet.setDefaultWaitStatus(TxStatus.CHECKPOINTED);
       const aliceAccountManager = await wallet.createSchnorrAccount(aliceAccount.secret, aliceAccount.salt);
       const aliceDeploymethod = await aliceAccountManager.getDeployMethod();
       await aliceDeploymethod.send({

--- a/yarn-project/end-to-end/src/e2e_sequencer/gov_proposal.parallel.test.ts
+++ b/yarn-project/end-to-end/src/e2e_sequencer/gov_proposal.parallel.test.ts
@@ -24,6 +24,7 @@ import { NewGovernanceProposerPayloadBytecode } from '@aztec/l1-artifacts/NewGov
 import { TestContract } from '@aztec/noir-test-contracts.js/Test';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
 import type { AztecNode, AztecNodeAdmin } from '@aztec/stdlib/interfaces/client';
+import { TxStatus } from '@aztec/stdlib/tx';
 
 import { jest } from '@jest/globals';
 import { privateKeyToAccount } from 'viem/accounts';
@@ -67,6 +68,7 @@ describe('e2e_gov_proposal', () => {
 
     let accounts: AztecAddress[] = [];
     const context = await setup(1, {
+      defaultWaitStatus: TxStatus.CHECKPOINTED,
       ...PIPELINING_SETUP_OPTS,
       anvilAccounts: 100,
       aztecTargetCommitteeSize: COMMITTEE_SIZE,

--- a/yarn-project/end-to-end/src/e2e_token_contract/token_contract_test.ts
+++ b/yarn-project/end-to-end/src/e2e_token_contract/token_contract_test.ts
@@ -4,6 +4,7 @@ import type { AztecNode } from '@aztec/aztec.js/node';
 import { TokenContract } from '@aztec/noir-contracts.js/Token';
 import { GenericProxyContract } from '@aztec/noir-test-contracts.js/GenericProxy';
 import { InvalidAccountContract } from '@aztec/noir-test-contracts.js/InvalidAccount';
+import { TxStatus } from '@aztec/stdlib/tx';
 
 import { jest } from '@jest/globals';
 
@@ -126,6 +127,8 @@ export class TokenContractTest {
 
   async setup(opts: Partial<SetupOptions> = {}) {
     this.context = await setup(0, {
+      // Finality-sensitive suite: default to CHECKPOINTED before any setup-phase send.
+      defaultWaitStatus: TxStatus.CHECKPOINTED,
       ...opts,
       metricsPort: this.metricsPort,
       fundSponsoredFPC: true,

--- a/yarn-project/end-to-end/src/fixtures/e2e_prover_test.ts
+++ b/yarn-project/end-to-end/src/fixtures/e2e_prover_test.ts
@@ -13,6 +13,7 @@ import { FeeAssetHandlerAbi } from '@aztec/l1-artifacts';
 import { TokenContract } from '@aztec/noir-contracts.js/Token';
 import type { ContractInstanceWithAddress } from '@aztec/stdlib/contract';
 import type { AztecNodeAdmin } from '@aztec/stdlib/interfaces/client';
+import { TxStatus } from '@aztec/stdlib/tx';
 import { getGenesisValues } from '@aztec/world-state/testing';
 
 import { type Hex, getContract } from 'viem';
@@ -128,6 +129,8 @@ export class FullProverTest {
   async setup(opts: Partial<SetupOptions> = {}) {
     this.logger.info('Setting up subsystems from fresh');
     this.context = await setup(0, {
+      // Finality-sensitive suite: default to CHECKPOINTED before any setup-phase send.
+      defaultWaitStatus: TxStatus.CHECKPOINTED,
       ...opts,
       startProverNode: true,
       coinbase: this.coinbase,

--- a/yarn-project/end-to-end/src/fixtures/setup.ts
+++ b/yarn-project/end-to-end/src/fixtures/setup.ts
@@ -58,6 +58,7 @@ import { type ContractInstanceWithAddress, getContractInstanceFromInstantiationP
 import type { AztecNodeAdmin, AztecNodeDebug } from '@aztec/stdlib/interfaces/client';
 import { tryStop } from '@aztec/stdlib/interfaces/server';
 import type { PublicDataTreeLeaf } from '@aztec/stdlib/trees';
+import { TxStatus } from '@aztec/stdlib/tx';
 import type { GenesisData } from '@aztec/stdlib/world-state';
 import {
   type TelemetryClient,
@@ -169,6 +170,8 @@ export type SetupOptions = {
   numberOfInitialFundedAccounts?: number;
   /** Data of the initial funded accounts */
   initialFundedAccounts?: InitialAccountData[];
+  /** Inclusion status the test wallet's sends default to (PROPOSED if unset). Applied before any setup-phase send. */
+  defaultWaitStatus?: TxStatus;
   /** An initial set of validators */
   initialValidators?: (Operator & { privateKey: `0x${string}` })[];
   /** Anvil Start time */
@@ -626,6 +629,10 @@ export async function setup(
 
     if (opts.walletMinFeePadding !== undefined) {
       wallet.setMinFeePadding(opts.walletMinFeePadding);
+    }
+
+    if (opts.defaultWaitStatus !== undefined) {
+      wallet.setDefaultWaitStatus(opts.defaultWaitStatus);
     }
 
     const cheatCodes = await CheatCodes.create(

--- a/yarn-project/end-to-end/src/test-wallet/test_wallet.ts
+++ b/yarn-project/end-to-end/src/test-wallet/test_wallet.ts
@@ -13,6 +13,7 @@ import {
   isContractFunctionInteractionCallIntent,
   lookupValidity,
 } from '@aztec/aztec.js/authorization';
+import { type InteractionWaitOptions, NO_WAIT, type SendReturn, type WaitOpts } from '@aztec/aztec.js/contracts';
 import type { AztecNode } from '@aztec/aztec.js/node';
 import { AccountManager, type SendOptions } from '@aztec/aztec.js/wallet';
 import { TxSimulationResultWithAppOffset } from '@aztec/aztec.js/wallet';
@@ -36,7 +37,7 @@ import {
   type TxHash,
   type TxReceipt,
 } from '@aztec/stdlib/tx';
-import { ExecutionPayload, mergeExecutionPayloads } from '@aztec/stdlib/tx';
+import { ExecutionPayload, TxStatus, mergeExecutionPayloads } from '@aztec/stdlib/tx';
 import { BaseWallet, type SimulateViaEntrypointOptions } from '@aztec/wallet-sdk/base-wallet';
 import type { AccountType } from '@aztec/wallets/embedded';
 
@@ -81,6 +82,38 @@ export class TestWallet extends BaseWallet {
     const wallet = new TestWallet(pxe, nodeRef);
     await wallet.initStubClasses();
     return wallet;
+  }
+
+  // Inclusion status that sends default to when the caller does not specify one. Defaults to PROPOSED
+  // (matching the production EmbeddedWallet); tests that read checkpoint/L1-settled state can opt back
+  // to CHECKPOINTED via setDefaultWaitStatus.
+  private defaultWaitStatus: TxStatus = TxStatus.PROPOSED;
+
+  /**
+   * Sets the inclusion status that sends wait for when the caller does not pass an explicit
+   * waitForStatus. Tests asserting on checkpoint- or L1-settled state should set this to CHECKPOINTED.
+   */
+  public setDefaultWaitStatus(status: TxStatus): void {
+    this.defaultWaitStatus = status;
+  }
+
+  /**
+   * Defaults the wait status to {@link defaultWaitStatus} (PROPOSED unless overridden) rather than the
+   * base wallet's CHECKPOINTED. Tests only need a tx to land in a proposed L2 block; waiting for the
+   * checkpoint to be sealed to L1 couples every send to checkpoint-sealing latency.
+   */
+  public override sendTx<W extends InteractionWaitOptions = undefined>(
+    executionPayload: ExecutionPayload,
+    opts: SendOptions<W>,
+  ): Promise<SendReturn<W>> {
+    if (opts.wait === NO_WAIT) {
+      return super.sendTx(executionPayload, opts);
+    }
+    const waitOpts: WaitOpts = typeof opts.wait === 'object' ? opts.wait : {};
+    if (!waitOpts.waitForStatus) {
+      waitOpts.waitForStatus = this.defaultWaitStatus;
+    }
+    return super.sendTx(executionPayload, { ...opts, wait: waitOpts as W });
   }
 
   /**


### PR DESCRIPTION
## Summary
- Recreates the #23857 TestWallet wait-status change on a fresh branch from `merge-train/spartan`.
- Defaults `TestWallet` sends to `PROPOSED`, with `setup()` and finality-sensitive suites opting back into `CHECKPOINTED`.
- Keeps the direct `TestWallet.create(...)` case using the setter where there is no `setup()` call to configure.

## Test plan
- `git diff --cached --check`
- `NODE_OPTIONS=--max-old-space-size=8192 yarn lint end-to-end`

Supersedes #23857.