### PR TITLE
test: always capture local network logs for compose tests

### DIFF
--- a/ci3/run_compose_test
+++ b/ci3/run_compose_test
@@ -45,4 +45,8 @@ docker logs -f "$cid" &
 # Block until the target container exits; exit status is the container's exit code.
 rc=$(docker wait "$cid")
 
+# Give the backgrounded `docker logs -f` a moment to flush the container's final output
+# (e.g. the trailing local-network logs) before the EXIT trap tears the container down.
+sleep 1
+
 exit "$rc"

--- a/yarn-project/end-to-end/bootstrap.sh
+++ b/yarn-project/end-to-end/bootstrap.sh
@@ -107,11 +107,7 @@ function test_cmds {
   for flow in ../cli-wallet/test/flows/*.sh; do
     # Note these scripts are ran directly by docker-compose.yml because it ends in '.sh'.
     # Set LOG_LEVEL=info for a better output experience. Deeper debugging should happen with other e2e tests.
-    if [[ "$flow" == *private_transfer.sh ]]; then
-      echo "$hash:ONLY_TERM_PARENT=1 LOG_LEVEL=info LOCAL_NETWORK_LOG_LEVEL='info; debug:p2p,sequencer,archiver,world-state,aztec-node' $run_test_script compose $flow"
-    else
-      echo "$hash:ONLY_TERM_PARENT=1 LOG_LEVEL=info $run_test_script compose $flow"
-    fi
+    echo "$hash:ONLY_TERM_PARENT=1 LOG_LEVEL=info $run_test_script compose $flow"
   done
 }
 

--- a/yarn-project/end-to-end/bootstrap.sh
+++ b/yarn-project/end-to-end/bootstrap.sh
@@ -106,8 +106,8 @@ function test_cmds {
   # compose-based tests with custom scripts
   for flow in ../cli-wallet/test/flows/*.sh; do
     # Note these scripts are ran directly by docker-compose.yml because it ends in '.sh'.
-    # Set LOG_LEVEL=info for a better output experience. Deeper debugging should happen with other e2e tests.
-    echo "$hash:ONLY_TERM_PARENT=1 LOG_LEVEL=info $run_test_script compose $flow"
+    # Run at LOG_LEVEL=verbose so the captured local-network logs are detailed enough for diagnostics.
+    echo "$hash:ONLY_TERM_PARENT=1 LOG_LEVEL=verbose $run_test_script compose $flow"
   done
 }
 

--- a/yarn-project/end-to-end/scripts/docker-compose.yml
+++ b/yarn-project/end-to-end/scripts/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     volumes:
       - ../../../:/root/aztec-packages
       - ${HOME}/.bb-crs:/root/.bb-crs
-      - ${COMPOSE_LOG_DIR:-/tmp/aztec-compose-logs/default}:/logs
+      - local-network-logs:/logs
     working_dir: /root/aztec-packages/yarn-project/aztec
     entrypoint: >
       bash -c '
@@ -43,7 +43,7 @@ services:
     volumes:
       - ../../../:/root/aztec-packages
       - ${HOME}/.bb-crs:/root/.bb-crs
-      - ${COMPOSE_LOG_DIR:-/tmp/aztec-compose-logs/default}:/logs
+      - local-network-logs:/logs
     tmpfs:
       - /tmp:rw,size=1g
       - /tmp-jest:rw,size=512m
@@ -88,9 +88,11 @@ services:
         echo "===== local-network logs ====="
         cat /logs/local-network.log || true
         echo "===== end local-network logs ====="
-        rm -f /logs/local-network.log
         exit $$rc
       '
     depends_on:
       - local-network
       - fork
+
+volumes:
+  local-network-logs:

--- a/yarn-project/end-to-end/scripts/docker-compose.yml
+++ b/yarn-project/end-to-end/scripts/docker-compose.yml
@@ -15,17 +15,15 @@ services:
     volumes:
       - ../../../:/root/aztec-packages
       - ${HOME}/.bb-crs:/root/.bb-crs
-      - local-network-logs:/logs
+      - ${COMPOSE_LOG_DIR:-/tmp/aztec-compose-logs/default}:/logs
     working_dir: /root/aztec-packages/yarn-project/aztec
     entrypoint: >
       bash -c '
-        export LOG_LEVEL="$${LOCAL_NETWORK_LOG_LEVEL:-$${LOG_LEVEL:-verbose}}"
         set -o pipefail
         node ./dest/bin start --local-network 2>&1 | tee /logs/local-network.log
       '
     environment:
       LOG_LEVEL: ${LOG_LEVEL:-verbose}
-      LOCAL_NETWORK_LOG_LEVEL: ${LOCAL_NETWORK_LOG_LEVEL:-}
       ETHEREUM_HOSTS: http://fork:8545
       L1_CHAIN_ID: 31337
       FORCE_COLOR: ${FORCE_COLOR:-1}
@@ -45,7 +43,7 @@ services:
     volumes:
       - ../../../:/root/aztec-packages
       - ${HOME}/.bb-crs:/root/.bb-crs
-      - local-network-logs:/logs
+      - ${COMPOSE_LOG_DIR:-/tmp/aztec-compose-logs/default}:/logs
     tmpfs:
       - /tmp:rw,size=1g
       - /tmp-jest:rw,size=512m
@@ -87,16 +85,12 @@ services:
         while kill -0 -$$pgid 2>/dev/null; do sleep 0.1; done
         wait $$pid
         rc=$$?
-        if [ $$rc -ne 0 ]; then
-          echo "===== local-network logs ====="
-          cat /logs/local-network.log || true
-          echo "===== end local-network logs ====="
-        fi
+        echo "===== local-network logs ====="
+        cat /logs/local-network.log || true
+        echo "===== end local-network logs ====="
+        rm -f /logs/local-network.log
         exit $$rc
       '
     depends_on:
       - local-network
       - fork
-
-volumes:
-  local-network-logs:

--- a/yarn-project/end-to-end/scripts/run_test.sh
+++ b/yarn-project/end-to-end/scripts/run_test.sh
@@ -18,9 +18,8 @@ case "$type" in
   ;;
   "compose")
     # TODO: Replace this file with test_simple.sh, and just emit the below as part of test_cmds.
-    compose_log_name="$(echo "${test}${NAME_POSTFIX:-}" | sed 's/^[^a-zA-Z0-9]*//; s/[\/\.]/_/g')"
-    export COMPOSE_LOG_DIR=${COMPOSE_LOG_DIR:-/tmp/aztec-compose-logs/$compose_log_name}
-    TEST=$test exec run_compose_test $test end-to-end $PWD
+    # Remove volumes on cleanup so the local-network logs volume doesn't persist across runs.
+    TEST=$test REMOVE_COMPOSE_VOLUMES=1 exec run_compose_test $test end-to-end $PWD
   ;;
   "web3signer")
     TEST=$test exec run_compose_test $test end-to-end $PWD/web3signer

--- a/yarn-project/end-to-end/scripts/run_test.sh
+++ b/yarn-project/end-to-end/scripts/run_test.sh
@@ -18,6 +18,8 @@ case "$type" in
   ;;
   "compose")
     # TODO: Replace this file with test_simple.sh, and just emit the below as part of test_cmds.
+    compose_log_name="$(echo "${test}${NAME_POSTFIX:-}" | sed 's/^[^a-zA-Z0-9]*//; s/[\/\.]/_/g')"
+    export COMPOSE_LOG_DIR=${COMPOSE_LOG_DIR:-/tmp/aztec-compose-logs/$compose_log_name}
     TEST=$test exec run_compose_test $test end-to-end $PWD
   ;;
   "web3signer")


### PR DESCRIPTION
Always print the local-network service logs at the end of normal compose e2e tests, regardless of whether the test passed or failed.

Changes:
- Keep local-network output in /logs/local-network.log via the compose service tee.
- Print those logs after the end-to-end test process exits for every local-network compose run.
- Keep /logs in a per-project Docker named volume (local-network-logs) and remove it on teardown via REMOVE_COMPOSE_VOLUMES=1, so logs don't persist across runs. No host bind mount.
- Remove the private_transfer.sh-specific LOCAL_NETWORK_LOG_LEVEL override and run the compose flows at LOG_LEVEL=verbose so the captured node logs are detailed enough for diagnostics.
- Add a short flush window in run_compose_test after the container exits, so the trailing local-network logs aren't truncated by docker compose down.
- Leave the proposed-chain mint behavior unchanged; there is no checkpoint wait in the mint helper.

Example run: http://ci.aztec-labs.com/0245ece3810f8624