### PR TITLE
feat(ipc-codegen): generate spawned TS service packages

### DIFF
--- a/ipc-codegen/README.md
+++ b/ipc-codegen/README.md
@@ -101,6 +101,7 @@ node --experimental-strip-types --experimental-transform-types --no-warnings \
 |---|---|
 | `--server` | Emit server dispatch (matches request name to handler, deserialises, calls handler, serialises response). Pair it with an `ipc::IpcServer` from ipc-runtime. |
 | `--client` | Emit a typed client class/struct with one method per command. Pair it with an `ipc::IpcClient` (C++) or the equivalent Rust/Zig/TS binding. |
+| `--package <dir>` | TS only. Emit a complete package wrapper around the generated async client. The wrapper launches a native service binary, connects over UDS or SHM, and resolves the binary from an override path, environment variable, installed arch package, or local `build/<platform>/` directory. |
 | `--uds` | Rust/Zig only. Copies the `Backend` trait template (and `error.rs` for Rust) into `<out>` so consumers can plug ipc-runtime — or any custom transport — behind the generated client. The flag name is historical: the trait is transport-agnostic. |
 | `--ffi` | Rust/Zig only. Adds the `ffi_backend` template (a thin wrapper exposing the generated client over a C ABI for embedding in other languages). |
 
@@ -125,6 +126,11 @@ node --experimental-strip-types --experimental-transform-types --no-warnings \
 |---|---|
 | `--curve-constants` | TS only. Also emit `curve_constants.ts` with bn254/grumpkin/secp moduli & generators for schemas that need curve constants. |
 | `--skeleton <dir>` | One-shot scaffolding: writes a `<service>_handlers.{ts,rs,zig,cpp}` stub, `main`, and a build file into `<dir>` if they don't already exist. Skipped on subsequent runs. |
+| `--package-name <name>` | TS package mode only. Package name to write into the generated wrapper `package.json`. |
+| `--binary-name <name>` | TS package mode only. Native service binary name to launch. |
+| `--binary-env-var <name>` | TS package mode only. Environment variable that can override the binary path. Defaults to `<BINARY_NAME>_PATH`. |
+| `--package-transports <uds,shm>` | TS package mode only. Comma-separated transports supported by the generated wrapper. |
+| `--ipc-runtime-dependency <spec>` | TS package mode only. Dependency spec for `@aztec/ipc-runtime`, e.g. a release version or local `file:` dependency in examples. |
 
 ## Worked examples
 
@@ -146,6 +152,29 @@ src/generate.ts \
 Produces `api_types.ts`, `async.ts`, `sync.ts`, `curve_constants.ts`. The TS
 client uses `@aztec/ipc-runtime`'s `UdsIpcClient` or `NapiShmSyncClient` for
 transport — no template copy.
+
+### TypeScript spawned-service package
+
+```sh
+src/generate.ts \
+  --schema /path/to/myservice_schema.json \
+  --lang ts \
+  --out /path/to/myservice/src/generated \
+  --client --strip-method-prefix \
+  --prefix MyService \
+  --package /path/to/myservice \
+  --package-name @aztec/myservice \
+  --binary-name myservice \
+  --package-transports uds,shm
+```
+
+Produces the generated TS client under `src/generated/` plus a package shell
+(`package.json`, `tsconfig.json`, `src/index.ts`, `src/platform.ts`, and
+`scripts/prepare_arch_packages.sh`). The package exports a
+`MyServiceService.spawn(...)` helper that launches the native binary and wraps
+the generated async client. `scripts/prepare_arch_packages.sh` turns
+`build/<platform>/<binary>` directories into per-architecture npm packages
+matching the binary resolution path.
 
 ### C++ server + client, under a project sub-include path
 

--- a/ipc-codegen/bootstrap.sh
+++ b/ipc-codegen/bootstrap.sh
@@ -20,6 +20,7 @@ function build {
   (cd echo_example/cpp && ./bootstrap.sh)
   (cd echo_example/rust && ./bootstrap.sh)
   (cd echo_example/ts && ./bootstrap.sh)
+  (cd echo_example/ts_package && ./bootstrap.sh)
   (cd echo_example/zig && ./bootstrap.sh)
 
   # NB: the golden msgpack fixtures under echo_example/schema/golden/ are
@@ -50,6 +51,8 @@ function test_cmds {
   echo "$prefix $script golden rust"
   echo "$prefix $script golden ts"
   echo "$prefix ipc-codegen/echo_example/cpp/build/bin/schema_reflection_test --schema ipc-codegen/echo_example/schema/schema.json"
+  echo "$prefix ipc-codegen/echo_example/ts_package/test.sh uds"
+  echo "$prefix ipc-codegen/echo_example/ts_package/test.sh shm"
 
   # Matrix: one command per (server, client) pair over UDS.
   for server in "${matrix_langs[@]}"; do

--- a/ipc-codegen/echo_example/ts_package/.gitignore
+++ b/ipc-codegen/echo_example/ts_package/.gitignore
@@ -1,0 +1,11 @@
+node_modules/
+dest/
+build/
+packages/
+package-lock.json
+package.json
+tsconfig.json
+src/generated/
+src/index.ts
+src/platform.ts
+scripts/prepare_arch_packages.sh

--- a/ipc-codegen/echo_example/ts_package/README.md
+++ b/ipc-codegen/echo_example/ts_package/README.md
@@ -1,0 +1,31 @@
+# @aztec/echo-ipc
+
+Generated TypeScript IPC package for the Echo service.
+
+```ts
+import { EchoService } from '@aztec/echo-ipc';
+
+const service = await EchoService.spawn({ transport: 'uds' });
+try {
+  const response = await service.bytes({ data: new Uint8Array([1, 2, 3]) });
+} finally {
+  await service.destroy();
+}
+```
+
+The package resolves `echo_server` from `ECHO_SERVER_PATH`,
+an installed arch package, or `build/<platform>/echo_server`.
+
+## Build
+
+```sh
+npm install --omit=optional
+npm run build
+```
+
+To prepare per-architecture binary packages from local `build/<platform>`
+directories:
+
+```sh
+npm run prepare_arch_packages
+```

--- a/ipc-codegen/echo_example/ts_package/bootstrap.sh
+++ b/ipc-codegen/echo_example/ts_package/bootstrap.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+CODEGEN="$(cd "$DIR/../.." && pwd)"
+REPO_ROOT="$(cd "$CODEGEN/.." && pwd)"
+NODE="node --experimental-strip-types --experimental-transform-types --no-warnings"
+
+$NODE "$CODEGEN/src/generate.ts" \
+  --schema "$DIR/../schema/schema.json" \
+  --lang ts \
+  --client \
+  --out "$DIR/src/generated" \
+  --prefix Echo \
+  --strip-method-prefix \
+  --package "$DIR" \
+  --package-name "@aztec/echo-ipc" \
+  --binary-name echo_server \
+  --package-transports uds,shm \
+  --ipc-runtime-dependency "file:../../../ipc-runtime/ts"
+
+(cd "$DIR/../cpp" && ./bootstrap.sh)
+(cd "$REPO_ROOT/ipc-runtime" && ./bootstrap.sh)
+(cd "$REPO_ROOT/ipc-runtime/ts" && yarn install --immutable && yarn build)
+
+platform_dir="$(
+  node -e "const arch = { x64: 'amd64', arm64: 'arm64' }[process.arch] ?? process.arch; const os = { linux: 'linux', darwin: 'macos' }[process.platform] ?? process.platform; console.log(arch + '-' + os);"
+)"
+mkdir -p "$DIR/build/$platform_dir"
+cp "$DIR/../cpp/build/bin/echo_server" "$DIR/build/$platform_dir/echo_server"
+
+rm -rf "$DIR/node_modules"
+(cd "$DIR" && npm install --omit=optional --no-package-lock --quiet)
+(cd "$DIR" && npm run build --silent)
+(cd "$DIR" && npm run prepare_arch_packages --silent)

--- a/ipc-codegen/echo_example/ts_package/src/package_test.ts
+++ b/ipc-codegen/echo_example/ts_package/src/package_test.ts
@@ -1,0 +1,72 @@
+import { EchoService, type EchoTransport } from "./index.js";
+
+const args = process.argv.slice(2);
+const transportArg = args[args.indexOf("--transport") + 1] ?? "uds";
+if (transportArg !== "uds" && transportArg !== "shm") {
+  throw new Error(`Unknown --transport '${transportArg}'`);
+}
+const transport = transportArg as EchoTransport;
+
+function testHash(base: number): Uint8Array {
+  return Uint8Array.from({ length: 32 }, (_v, i) => base + i);
+}
+
+function assertEqual(actual: unknown, expected: unknown, label: string) {
+  const actualJson = JSON.stringify(actual);
+  const expectedJson = JSON.stringify(expected);
+  if (actualJson !== expectedJson) {
+    throw new Error(`${label}: expected ${expectedJson}, got ${actualJson}`);
+  }
+}
+
+function assertBytes(actual: Uint8Array, expected: Uint8Array, label: string) {
+  assertEqual(
+    Buffer.from(actual).toString("hex"),
+    Buffer.from(expected).toString("hex"),
+    label,
+  );
+}
+
+const service = await EchoService.spawn({ transport });
+try {
+  const data = Uint8Array.from([0xde, 0xad, 0xbe, 0xef, 0x42]);
+  const bytes = await service.bytes({ data });
+  assertBytes(bytes.data, data, "bytes.data");
+
+  const fields = await service.fields({
+    a: 42,
+    b: 999999,
+    name: "hello generated package",
+  });
+  assertEqual(fields.a, 42, "fields.a");
+  assertEqual(fields.b, 999999, "fields.b");
+  assertEqual(fields.name, "hello generated package", "fields.name");
+
+  const inner = {
+    values: [Uint8Array.from([1, 2, 3]), Uint8Array.from([4, 5])],
+    flag: true,
+  };
+  const nested = await service.nested({ inner });
+  assertEqual(nested.inner.flag, true, "nested.inner.flag");
+  assertEqual(nested.inner.values.length, 2, "nested.inner.values.length");
+  assertBytes(nested.inner.values[0]!, inner.values[0]!, "nested.inner.values[0]");
+
+  const hash = testHash(0x10);
+  const second = testHash(0x40);
+  const aliases = await service.aliases({
+    treeId: 7,
+    hash,
+    maybeHash: second,
+    hashes: [hash, second],
+  });
+  assertEqual(aliases.treeId, 7, "aliases.treeId");
+  assertBytes(aliases.hash, hash, "aliases.hash");
+  assertBytes(aliases.maybeHash!, second, "aliases.maybeHash");
+  assertEqual(aliases.hashes.length, 2, "aliases.hashes.length");
+
+  await service.shutdown({});
+} finally {
+  await service.destroy();
+}
+
+console.error(`echo ts package: ${transport} OK`);

--- a/ipc-codegen/echo_example/ts_package/test.sh
+++ b/ipc-codegen/echo_example/ts_package/test.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+transport="${1:-uds}"
+
+(cd "$DIR" && npm run test --silent -- --transport "$transport")

--- a/ipc-codegen/src/generate.ts
+++ b/ipc-codegen/src/generate.ts
@@ -15,6 +15,7 @@
  *   --server                 Generate server dispatch
  *   --client                 Generate client
  *   --skeleton <dir>         Generate handler stubs + main (one-time, not regenerated)
+ *   --package <dir>          Generate a TS package shell around a spawned IPC service
  *   --cpp-namespace <ns>     C++ namespace (e.g. my::service)
  *   --cpp-wire-namespace <ns> Wire types sub-namespace (default: wire)
  *   --curve-constants <path> Generate TS curve constants from JSON at <path>
@@ -37,6 +38,10 @@ import { dirname, join, resolve } from "path";
 import { fileURLToPath } from "url";
 import { SchemaVisitor, type CompiledSchema } from "./schema_visitor.ts";
 import { TypeScriptCodegen } from "./typescript_codegen.ts";
+import {
+  defaultBinaryEnvVar,
+  TypeScriptPackageCodegen,
+} from "./typescript_package_codegen.ts";
 import { RustCodegen } from "./rust_codegen.ts";
 import { ZigCodegen } from "./zig_codegen.ts";
 import { CppCodegen } from "./cpp_codegen.ts";
@@ -57,6 +62,12 @@ interface Args {
   server: boolean;
   client: boolean;
   skeleton: string;
+  packageDir: string;
+  packageName: string;
+  binaryName: string;
+  binaryEnvVar: string;
+  packageTransports: string;
+  ipcRuntimeDependency: string;
   cppNamespace: string;
   cppWireNamespace: string;
   cppIncludeDir: string;
@@ -75,6 +86,12 @@ function parseArgs(argv: string[]): Args {
     server: false,
     client: false,
     skeleton: "",
+    packageDir: "",
+    packageName: "",
+    binaryName: "",
+    binaryEnvVar: "",
+    packageTransports: "uds",
+    ipcRuntimeDependency: "@aztec/ipc-runtime",
     cppNamespace: "",
     cppWireNamespace: "wire",
     cppIncludeDir: "",
@@ -106,6 +123,24 @@ function parseArgs(argv: string[]): Args {
         break;
       case "--skeleton":
         args.skeleton = argv[++i];
+        break;
+      case "--package":
+        args.packageDir = argv[++i];
+        break;
+      case "--package-name":
+        args.packageName = argv[++i];
+        break;
+      case "--binary-name":
+        args.binaryName = argv[++i];
+        break;
+      case "--binary-env-var":
+        args.binaryEnvVar = argv[++i];
+        break;
+      case "--package-transports":
+        args.packageTransports = argv[++i];
+        break;
+      case "--ipc-runtime-dependency":
+        args.ipcRuntimeDependency = argv[++i];
         break;
       case "--cpp-namespace":
         args.cppNamespace = argv[++i];
@@ -146,6 +181,10 @@ Optional:
   --server                 Generate server dispatch
   --client                 Generate client
   --skeleton <dir>         Generate handler stubs + main (one-time)
+  --package <dir>          Generate a TS package shell around a spawned IPC service
+  --package-name <name>    TS package name for --package
+  --binary-name <name>     Native service binary name for --package
+  --package-transports <t> Comma-separated transports for --package (uds,shm)
   --prefix <str>           Type prefix (auto-detected if omitted)
   --cpp-namespace <ns>     C++ namespace (e.g. my::ns)
   --cpp-wire-namespace <ns> Wire types sub-namespace (default: wire)
@@ -289,7 +328,7 @@ function generate(args: Args) {
         // No transport template copy — consumers import UdsIpcServer from
         // '@aztec/ipc-runtime' (or hand a compatible byte-handler in).
       }
-      if (args.client) {
+      if (args.client || args.packageDir) {
         writeFile("async.ts", gen.generateAsyncApi(compiled));
         writeFile("sync.ts", gen.generateSyncApi(compiled));
         // No transport template copy — consumers import IpcClient from
@@ -297,6 +336,51 @@ function generate(args: Args) {
       }
       if (args.curveConstants) {
         generateCurveConstants(absOut, resolve(args.curveConstants));
+      }
+      if (args.packageDir) {
+        const packageDir = resolve(args.packageDir);
+        const binaryName =
+          args.binaryName || toSnakeCase(prefix).replace(/_/g, "-");
+        const packageName =
+          args.packageName || `${toSnakeCase(prefix).replace(/_/g, "-")}-ipc`;
+        const packageGen = new TypeScriptPackageCodegen({
+          prefix,
+          packageName,
+          binaryName,
+          binaryEnvVar: args.binaryEnvVar || defaultBinaryEnvVar(binaryName),
+          ipcRuntimeDependency: args.ipcRuntimeDependency,
+          transports: args.packageTransports
+            .split(",")
+            .map((t) => t.trim())
+            .filter(Boolean),
+        });
+        const writePackage = (
+          name: string,
+          content: string,
+          opts?: { executable?: boolean },
+        ) => {
+          const path = join(packageDir, name);
+          mkdirSync(dirname(path), { recursive: true });
+          const tmpPath = `${path}.${process.pid}.tmp`;
+          writeFileSync(tmpPath, content);
+          renameSync(tmpPath, path);
+          if (opts?.executable) {
+            try {
+              execSync(`chmod +x ${path}`);
+            } catch {}
+          }
+          console.log(`  ${path} (package)`);
+        };
+        writePackage("package.json", packageGen.generatePackageJson());
+        writePackage("tsconfig.json", packageGen.generateTsconfig());
+        writePackage("README.md", packageGen.generateReadme());
+        writePackage("src/index.ts", packageGen.generateIndex());
+        writePackage("src/platform.ts", packageGen.generatePlatform());
+        writePackage(
+          "scripts/prepare_arch_packages.sh",
+          packageGen.generatePrepareArchPackagesScript(),
+          { executable: true },
+        );
       }
       // Skeleton (one-time handler stubs + main + build files)
       if (args.skeleton) {

--- a/ipc-codegen/src/typescript_package_codegen.ts
+++ b/ipc-codegen/src/typescript_package_codegen.ts
@@ -1,0 +1,466 @@
+import { toSnakeCase } from "./naming.ts";
+
+export interface TypeScriptPackageOptions {
+  prefix: string;
+  packageName: string;
+  binaryName: string;
+  binaryEnvVar: string;
+  ipcRuntimeDependency: string;
+  transports: string[];
+}
+
+function className(prefix: string): string {
+  return `${prefix}Service`;
+}
+
+function transportType(prefix: string): string {
+  return `${prefix}Transport`;
+}
+
+function optionsType(prefix: string): string {
+  return `${prefix}ServiceOptions`;
+}
+
+function binaryFinderName(prefix: string): string {
+  return `find${prefix}Binary`;
+}
+
+function envName(binaryName: string): string {
+  return `${binaryName.replace(/[^a-zA-Z0-9]+/g, "_").toUpperCase()}_PATH`;
+}
+
+function packageStem(packageName: string): string {
+  return packageName.startsWith("@")
+    ? packageName.split("/")[1]!
+    : packageName;
+}
+
+function archPackageNames(packageName: string): Record<string, string> {
+  return {
+    "linux-x64": `${packageName}-linux-x64`,
+    "darwin-x64": `${packageName}-darwin-x64`,
+    "linux-arm64": `${packageName}-linux-arm64`,
+    "darwin-arm64": `${packageName}-darwin-arm64`,
+  };
+}
+
+export function defaultBinaryEnvVar(binaryName: string): string {
+  return envName(binaryName);
+}
+
+export class TypeScriptPackageCodegen {
+  constructor(private opts: TypeScriptPackageOptions) {}
+
+  generatePackageJson(): string {
+    const optionalDependencies = Object.fromEntries(
+      Object.values(archPackageNames(this.opts.packageName)).map((name) => [
+        name,
+        "0.1.0",
+      ]),
+    );
+    const pkg = {
+      name: this.opts.packageName,
+      version: "0.1.0",
+      type: "module",
+      exports: {
+        ".": {
+          types: "./dest/index.d.ts",
+          default: "./dest/index.js",
+        },
+      },
+      files: ["dest/", "build/", "README.md"],
+      scripts: {
+        clean: "rm -rf dest tsconfig.tsbuildinfo",
+        build: "tsc -p tsconfig.json",
+        test: "tsx src/package_test.ts",
+        prepare_arch_packages: "./scripts/prepare_arch_packages.sh",
+      },
+      dependencies: {
+        "@aztec/ipc-runtime": this.opts.ipcRuntimeDependency,
+        msgpackr: "^1.10.0",
+        tslib: "^2.4.0",
+      },
+      optionalDependencies,
+      devDependencies: {
+        "@types/node": "^22.15.17",
+        tsx: "^4.19.0",
+        typescript: "^5.3.3",
+      },
+    };
+    return JSON.stringify(pkg, null, 2) + "\n";
+  }
+
+  generateTsconfig(): string {
+    return JSON.stringify(
+      {
+        compilerOptions: {
+          target: "ES2022",
+          module: "NodeNext",
+          moduleResolution: "NodeNext",
+          declaration: true,
+          outDir: "dest",
+          rootDir: "src",
+          strict: true,
+          esModuleInterop: true,
+          skipLibCheck: true,
+          forceConsistentCasingInFileNames: true,
+        },
+        include: ["src/**/*.ts"],
+      },
+      null,
+      2,
+    ) + "\n";
+  }
+
+  generateIndex(): string {
+    const prefix = this.opts.prefix;
+    const serviceClass = className(prefix);
+    const serviceOptions = optionsType(prefix);
+    const serviceTransport = transportType(prefix);
+    const findBinary = binaryFinderName(prefix);
+    const supportsShm = this.opts.transports.includes("shm");
+    const transports = this.opts.transports.map((t) => `'${t}'`).join(" | ");
+    const defaultTransport = this.opts.transports.includes("uds")
+      ? "uds"
+      : this.opts.transports[0]!;
+
+    return `import { spawn, type ChildProcess } from 'node:child_process';
+import { existsSync, unlinkSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { threadId } from 'node:worker_threads';
+import {
+  ${supportsShm ? "createNapiShmAsyncClient,\n  " : ""}UdsIpcClient,
+  type IpcClientAsync,
+} from '@aztec/ipc-runtime';
+import { AsyncApi, type IpcErrorFactory } from './generated/async.js';
+import { ${findBinary} } from './platform.js';
+
+export * from './generated/api_types.js';
+export { AsyncApi } from './generated/async.js';
+
+export type ${serviceTransport} = ${transports};
+
+export interface ${serviceOptions} {
+  binaryPath?: string;
+  transport?: ${serviceTransport};
+  logger?: (msg: string) => void;
+  connectTimeoutMs?: number;
+  env?: NodeJS.ProcessEnv;
+  extraArgs?: string[];
+  createError?: IpcErrorFactory;
+${supportsShm ? "  napiPath?: string;\n  clientId?: number;\n" : ""}}
+
+let instanceCounter = 0;
+
+class SpawnedBackend implements IpcClientAsync {
+  private constructor(
+    private child: ChildProcess,
+    private client: IpcClientAsync,
+    private ipcPath: string,
+    private transport: ${serviceTransport},
+    private exitPromise: Promise<void>,
+  ) {}
+
+  static async spawn(options: ${serviceOptions} = {}): Promise<SpawnedBackend> {
+    const binaryPath = ${findBinary}(options.binaryPath);
+    if (!binaryPath) {
+      throw new Error('${this.opts.binaryName} binary not found');
+    }
+
+    const transport = options.transport ?? '${defaultTransport}';
+    const instanceId = '${toSnakeCase(prefix)}-' + process.pid + '-' + threadId + '-' + instanceCounter++;
+    const ipcPath = transport === 'shm'
+      ? instanceId + '.shm'
+      : join(tmpdir(), instanceId + '.sock');
+
+    if (transport === 'uds' && existsSync(ipcPath)) {
+      unlinkSync(ipcPath);
+    }
+
+    const child = spawn(binaryPath, ['--socket', ipcPath, ...(options.extraArgs ?? [])], {
+      stdio: ['ignore', options.logger ? 'pipe' : 'ignore', options.logger ? 'pipe' : 'ignore'],
+      env: { ...process.env, ...(options.env ?? {}) },
+    });
+
+    if (options.logger) {
+      child.stdout?.on('data', (data: Buffer) => options.logger?.('[${this.opts.binaryName} stdout] ' + data.toString().trimEnd()));
+      child.stderr?.on('data', (data: Buffer) => options.logger?.('[${this.opts.binaryName} stderr] ' + data.toString().trimEnd()));
+    }
+
+    const exitPromise = new Promise<void>(resolve => {
+      child.on('exit', () => resolve());
+    });
+
+    const client = await connectClient(child, ipcPath, transport, options);
+    return new SpawnedBackend(child, client, ipcPath, transport, exitPromise);
+  }
+
+  getIpcPath(): string {
+    return this.ipcPath;
+  }
+
+  call(input: Uint8Array): Promise<Uint8Array> {
+    return this.client.call(input);
+  }
+
+  async destroy(): Promise<void> {
+    await this.client.destroy();
+    if (this.child.exitCode === null) {
+      this.child.kill('SIGTERM');
+    }
+    await this.exitPromise;
+    this.child.stdout?.destroy();
+    this.child.stderr?.destroy();
+    this.child.removeAllListeners();
+    cleanupIpcPath(this.ipcPath, this.transport);
+  }
+}
+
+async function connectClient(
+  child: ChildProcess,
+  ipcPath: string,
+  transport: ${serviceTransport},
+  options: ${serviceOptions},
+): Promise<IpcClientAsync> {
+  const timeoutMs = options.connectTimeoutMs ?? 5000;
+  const deadline = Date.now() + timeoutMs;
+  let lastError: unknown;
+
+  while (Date.now() <= deadline) {
+    if (child.exitCode !== null) {
+      throw new Error('${this.opts.binaryName} exited before IPC connection was ready');
+    }
+    try {
+      if (transport === 'uds') {
+        return await UdsIpcClient.connect(ipcPath, { connectTimeoutMs: Math.max(1, deadline - Date.now()) });
+      }
+${supportsShm ? `      if (transport === 'shm') {
+        return createNapiShmAsyncClient(ipcPath.replace(/\\.shm$/, ''), {
+          clientId: options.clientId ?? 0,
+          customAddonPath: options.napiPath,
+        });
+      }
+` : ""}      throw new Error('Unsupported transport: ' + transport);
+    } catch (err) {
+      lastError = err;
+      await new Promise(resolve => setTimeout(resolve, 50));
+    }
+  }
+
+  throw new Error('Timed out connecting to ${this.opts.binaryName}: ' + (lastError instanceof Error ? lastError.message : String(lastError)));
+}
+
+function cleanupIpcPath(ipcPath: string, transport: ${serviceTransport}) {
+  try {
+    if (transport === 'uds' && existsSync(ipcPath)) {
+      unlinkSync(ipcPath);
+    }
+    if (transport === 'shm') {
+      const shmName = ipcPath.replace(/\\.shm$/, '');
+      for (const suffix of ['_request', '_response']) {
+        const shmPath = '/dev/shm/' + shmName + suffix;
+        if (existsSync(shmPath)) {
+          unlinkSync(shmPath);
+        }
+      }
+    }
+  } catch {}
+}
+
+export class ${serviceClass} extends AsyncApi {
+  private constructor(private spawnedBackend: SpawnedBackend, createError?: IpcErrorFactory) {
+    super(spawnedBackend, createError);
+  }
+
+  static async spawn(options: ${serviceOptions} = {}): Promise<${serviceClass}> {
+    const backend = await SpawnedBackend.spawn(options);
+    return new ${serviceClass}(backend, options.createError);
+  }
+
+  getIpcPath(): string {
+    return this.spawnedBackend.getIpcPath();
+  }
+}
+`;
+  }
+
+  generatePlatform(): string {
+    const packageName = this.opts.packageName;
+    const findBinary = binaryFinderName(this.opts.prefix);
+    const envVar = this.opts.binaryEnvVar;
+    const stem = packageStem(packageName);
+    const archPackages = archPackageNames(packageName);
+
+    return `import { createRequire } from 'node:module';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export type Platform = 'x86_64-linux' | 'x86_64-darwin' | 'aarch64-linux' | 'aarch64-darwin';
+
+const PLATFORM_TO_BUILD_DIR: Record<Platform, string> = {
+  'x86_64-linux': 'amd64-linux',
+  'x86_64-darwin': 'amd64-macos',
+  'aarch64-linux': 'arm64-linux',
+  'aarch64-darwin': 'arm64-macos',
+};
+
+const PLATFORM_TO_PACKAGE: Record<Platform, string> = {
+  'x86_64-linux': '${archPackages["linux-x64"]}',
+  'x86_64-darwin': '${archPackages["darwin-x64"]}',
+  'aarch64-linux': '${archPackages["linux-arm64"]}',
+  'aarch64-darwin': '${archPackages["darwin-arm64"]}',
+};
+
+function currentDir(): string {
+  return path.dirname(fileURLToPath(import.meta.url));
+}
+
+function detectPlatform(): Platform | null {
+  if (process.arch === 'x64' && process.platform === 'linux') return 'x86_64-linux';
+  if (process.arch === 'x64' && process.platform === 'darwin') return 'x86_64-darwin';
+  if (process.arch === 'arm64' && process.platform === 'linux') return 'aarch64-linux';
+  if (process.arch === 'arm64' && process.platform === 'darwin') return 'aarch64-darwin';
+  return null;
+}
+
+function findPackageRoot(): string | null {
+  let dir = currentDir();
+  const root = path.parse(dir).root;
+  while (dir !== root) {
+    if (fs.existsSync(path.join(dir, 'package.json'))) {
+      if (fs.existsSync(path.join(dir, 'build')) || fs.existsSync(path.join(dir, 'dest'))) {
+        return dir;
+      }
+    }
+    dir = path.dirname(dir);
+  }
+  return null;
+}
+
+function findArchPackageDir(platform: Platform): string | null {
+  try {
+    const require = createRequire(import.meta.url);
+    return path.dirname(require.resolve(PLATFORM_TO_PACKAGE[platform] + '/package.json'));
+  } catch {
+    return null;
+  }
+}
+
+export function ${findBinary}(customPath?: string): string | null {
+  if (customPath) {
+    return fs.existsSync(customPath) ? path.resolve(customPath) : null;
+  }
+
+  const envPath = process.env.${envVar};
+  if (envPath) {
+    return fs.existsSync(envPath) ? path.resolve(envPath) : null;
+  }
+
+  const platform = detectPlatform();
+  if (!platform) {
+    return null;
+  }
+
+  const archDir = findArchPackageDir(platform);
+  if (archDir) {
+    const candidate = path.join(archDir, '${this.opts.binaryName}');
+    if (fs.existsSync(candidate)) {
+      return candidate;
+    }
+  }
+
+  const packageRoot = findPackageRoot();
+  if (!packageRoot) {
+    return null;
+  }
+
+  const localCandidate = path.join(packageRoot, 'build', PLATFORM_TO_BUILD_DIR[platform], '${this.opts.binaryName}');
+  return fs.existsSync(localCandidate) ? localCandidate : null;
+}
+
+export const ARCH_PACKAGE_STEM = '${stem}';
+`;
+  }
+
+  generatePrepareArchPackagesScript(): string {
+    return `#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+declare -A PLATFORMS=(
+  ["amd64-linux"]="linux-x64 linux x64"
+  ["arm64-linux"]="linux-arm64 linux arm64"
+  ["amd64-macos"]="darwin-x64 darwin x64"
+  ["arm64-macos"]="darwin-arm64 darwin arm64"
+)
+
+version=$(node -p "require('./package.json').version")
+
+for build_dir in "\${!PLATFORMS[@]}"; do
+  read -r suffix os cpu <<< "\${PLATFORMS[$build_dir]}"
+  pkg_name="${this.opts.packageName}-\${suffix}"
+  out_dir="packages/${packageStem(this.opts.packageName)}-\${suffix}"
+
+  if [ ! -d "build/\${build_dir}" ]; then
+    echo "Skipping \${pkg_name}: no build/\${build_dir} directory"
+    continue
+  fi
+
+  rm -rf "\${out_dir}"
+  mkdir -p "\${out_dir}"
+  cp "build/\${build_dir}/${this.opts.binaryName}" "\${out_dir}/${this.opts.binaryName}"
+
+  cat > "\${out_dir}/package.json" <<EOF
+{
+  "name": "\${pkg_name}",
+  "version": "\${version}",
+  "description": "Native binary for ${this.opts.packageName} (\${suffix})",
+  "license": "MIT",
+  "os": ["\${os}"],
+  "cpu": ["\${cpu}"],
+  "files": ["${this.opts.binaryName}"],
+  "preferUnplugged": true
+}
+EOF
+done
+`;
+  }
+
+  generateReadme(): string {
+    return `# ${this.opts.packageName}
+
+Generated TypeScript IPC package for the ${this.opts.prefix} service.
+
+\`\`\`ts
+import { ${className(this.opts.prefix)} } from '${this.opts.packageName}';
+
+const service = await ${className(this.opts.prefix)}.spawn({ transport: 'uds' });
+try {
+  const response = await service.bytes({ data: new Uint8Array([1, 2, 3]) });
+} finally {
+  await service.destroy();
+}
+\`\`\`
+
+The package resolves \`${this.opts.binaryName}\` from \`${this.opts.binaryEnvVar}\`,
+an installed arch package, or \`build/<platform>/${this.opts.binaryName}\`.
+
+## Build
+
+\`\`\`sh
+npm install --omit=optional
+npm run build
+\`\`\`
+
+To prepare per-architecture binary packages from local \`build/<platform>\`
+directories:
+
+\`\`\`sh
+npm run prepare_arch_packages
+\`\`\`
+`;
+  }
+}


### PR DESCRIPTION
## Summary
- add TS package generation mode to ipc-codegen
- generate a service wrapper that launches a native binary and connects via UDS or SHM
- add an echo TS package example that regenerates the package, stages a local arch binary, builds, and smoke-tests both transports

## Why
This gives WSDB/AVM-style services a generated package shape instead of hand-written wrappers in bb.js. The generated package resolves binaries from an override path, env var, installed arch package, or local build directory, which matches the planned per-arch release package direction.

## Validation
- ipc-codegen/echo_example/ts_package/bootstrap.sh
- ipc-codegen/echo_example/ts_package/test.sh uds
- ipc-codegen/echo_example/ts_package/test.sh shm
- git diff --check