### PR TITLE
fix: guard formatViemError structuredClone against non-cloneable errors (A-818)

### DIFF
--- a/yarn-project/ethereum/src/utils.test.ts
+++ b/yarn-project/ethereum/src/utils.test.ts
@@ -1,6 +1,6 @@
 import type { Abi } from 'viem';
 
-import { mergeAbis } from './utils.js';
+import { FormattedViemError, formatViemError, mergeAbis } from './utils.js';
 
 describe('mergeAbis', () => {
   it('dedupes identical function items', () => {
@@ -57,5 +57,21 @@ describe('mergeAbis', () => {
     const merged = mergeAbis([[eventIndexed], [eventNonIndexed]]);
 
     expect(merged).toHaveLength(2);
+  });
+});
+
+describe('formatViemError', () => {
+  it('formats an error whose cause carries non-cloneable function-valued context', () => {
+    // viem RPC errors routinely attach plain-object context holding functions (e.g. transport
+    // request methods). structuredClone throws DataCloneError on these, so formatViemError must
+    // not let the clone failure mask the underlying error.
+    const error = new Error('rpc request failed');
+    (error as any).cause = { code: -32000, request: { send: () => undefined } };
+
+    const formatted = formatViemError(error);
+
+    expect(formatted).toBeInstanceOf(FormattedViemError);
+    expect(formatted.message).toContain('rpc request failed');
+    expect(formatted.cause).toBe(error);
   });
 });

--- a/yarn-project/ethereum/src/utils.ts
+++ b/yarn-project/ethereum/src/utils.ts
@@ -235,18 +235,18 @@ export function formatViemError(error: any, abi: Abi = ErrorsAbi): FormattedViem
     // If decoding fails, we fall back to the original formatting
   }
 
-  // Strip ABI from the error object before formatting
+  // Strip ABI from the error object before formatting. We clone first to avoid mutating the
+  // caller's error, but structuredClone throws DataCloneError on values it cannot clone (e.g.
+  // viem RPC errors carrying function-valued request context). If cloning fails, fall back to
+  // formatting the original error untouched rather than letting the clone failure mask it.
   if (error && typeof error === 'object') {
-    // Create a clone to avoid modifying the original
-    const errorClone = structuredClone(error);
-
-    // Helper function to recursively remove ABI properties
-
-    // Strip ABIs from the clone
-    stripAbis(errorClone);
-
-    // Use the cleaned clone for further processing
-    error = errorClone;
+    try {
+      const errorClone = structuredClone(error);
+      stripAbis(errorClone);
+      error = errorClone;
+    } catch {
+      // Leave `error` as the original; we skip stripAbis to avoid mutating the caller's object.
+    }
   }
 
   // If it's a regular Error instance, return it with its message


### PR DESCRIPTION
Fixes A-818 (Audit #163).

## Problem

`formatViemError` (`yarn-project/ethereum/src/utils.ts`) called `structuredClone(error)` unguarded, before the `instanceof Error` formatting fallback. `structuredClone` throws `DataCloneError` on values it cannot clone — and viem RPC/contract errors routinely attach plain-object context holding functions (e.g. transport request methods). When that happened, the formatter itself threw, and since several call sites do `throw formatViemError(...)` (`rollup.ts`, `l1_tx_utils.ts`), the original L1 revert/RPC error was replaced by a `DataCloneError` and lost — degrading operator diagnostics.

## Fix

Wrap the clone (and the `stripAbis` call that depends on it) in a `try/catch`. On clone failure, fall back to formatting the original error untouched (skipping `stripAbis` so we don't mutate the caller's object). The `cause` still carries the original error in all paths.

## Test

Added a `formatViemError` test in `utils.test.ts` covering an error whose `cause` holds a function-valued `request` field. It throws `DataCloneError` without the fix and returns a `FormattedViemError` (preserving the message and `cause`) with it.