### PR TITLE
fix: pin getAttesters reads to a single L1 block (A-819)

### DIFF
--- a/yarn-project/ethereum/src/contracts/gse.ts
+++ b/yarn-project/ethereum/src/contracts/gse.ts
@@ -47,11 +47,16 @@ export class GSEContract {
     return EthAddress.fromString(await this.gse.read.getGovernance());
   }
 
-  getAttestersFromIndicesAtTime(instance: Hex | EthAddress, ts: bigint, indices: bigint[]) {
+  getAttestersFromIndicesAtTime(
+    instance: Hex | EthAddress,
+    ts: bigint,
+    indices: bigint[],
+    options?: { blockNumber?: bigint },
+  ) {
     if (instance instanceof EthAddress) {
       instance = instance.toString();
     }
-    return this.gse.read.getAttestersFromIndicesAtTime([instance, ts, indices]);
+    return this.gse.read.getAttestersFromIndicesAtTime([instance, ts, indices], options);
   }
 
   public async getRegistrationDigest(publicKey: ProjPointType<bigint>): Promise<ProjPointType<bigint>> {

--- a/yarn-project/ethereum/src/contracts/rollup.ts
+++ b/yarn-project/ethereum/src/contracts/rollup.ts
@@ -554,8 +554,9 @@ export class RollupContract {
     return EthAddress.fromString(await this.rollup.read.owner());
   }
 
-  async getActiveAttesterCount(): Promise<number> {
-    return Number(await this.rollup.read.getActiveAttesterCount());
+  async getActiveAttesterCount(options?: { blockNumber?: bigint }): Promise<number> {
+    await checkBlockTag(options?.blockNumber, this.client);
+    return Number(await this.rollup.read.getActiveAttesterCount(options));
   }
 
   public async getSlashingProposerAddress() {
@@ -1190,13 +1191,20 @@ export class RollupContract {
   }
 
   async getAttesters(timestamp?: bigint): Promise<EthAddress[]> {
-    const attesterSize = await this.getActiveAttesterCount();
+    // Pin every read to a single L1 block so the attester count and the chunked index reads
+    // observe a consistent set. Without this, the count and each chunk default to `latest` and
+    // can straddle a block boundary (or reorg), yielding an inconsistent or truncated set.
+    const block = await this.client.getBlock();
+    const blockNumber = block.number ?? undefined;
+    const ts = timestamp ?? block.timestamp;
+    const attesterSize = await this.getActiveAttesterCount({ blockNumber });
     const gse = new GSEContract(this.client, await this.getGSE());
-    const ts = timestamp ?? (await this.client.getBlock()).timestamp;
     const indices = Array.from({ length: attesterSize }, (_, i) => BigInt(i));
     const chunks = chunk(indices, 1000);
 
-    const results = await Promise.all(chunks.map(chunk => gse.getAttestersFromIndicesAtTime(this.address, ts, chunk)));
+    const results = await Promise.all(
+      chunks.map(chunk => gse.getAttestersFromIndicesAtTime(this.address, ts, chunk, { blockNumber })),
+    );
     return results.flat().map(addr => EthAddress.fromString(addr));
   }
 


### PR DESCRIPTION
Fixes A-819 (Audit #164).

## Problem

`RollupContract.getAttesters` (`yarn-project/ethereum/src/contracts/rollup.ts`) made several sequential RPC reads with no pinned block:

- `getActiveAttesterCount()` (read at `latest`)
- N chunked `getAttestersFromIndicesAtTime(...)` reads, one per 1000 indices (each read at `latest`)

The `ts` timestamp argument was already captured once and reused consistently across chunks, so the literal "stale timestamp across chunks" framing of the title doesn't occur. The real defect is that the **reads are not pinned to a single L1 block**: across a block boundary or reorg, the count and the individual chunk reads can observe different attester sets, yielding an inconsistent or truncated result. This only bites for attester sets larger than the 1000-entry chunk size, read precisely across a set-changing block — hence low impact, but real.

## Fix

Fetch the current block once in `getAttesters`, then thread its `number` as a `blockNumber` option through `getActiveAttesterCount` and every chunked `getAttestersFromIndicesAtTime` read so they all evaluate against the same L1 block. This follows the existing `checkBlockTag(options?.blockNumber, ...)` pattern already used by many reads in `rollup.ts` (e.g. `getCheckpointNumber`, `status`, `canPruneAtTime`).

- `getActiveAttesterCount` and `GSEContract.getAttestersFromIndicesAtTime` now accept an optional `{ blockNumber }`.

## Testing

Verified the full TypeScript build passes. No automated test added: reproducing the block-drift race deterministically would require anvil plus a hook to advance an L1 block between the count read and the chunk reads (or deep viem-client mocking), which isn't justified for this low-impact, pattern-following change. The block-pinning behavior mirrors other pinned reads in the same file.