### PR TITLE
fix: interrupt checkpoint job on sequencer stop

### DIFF
--- a/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.test.ts
@@ -1696,6 +1696,34 @@ describe('CheckpointProposalJob', () => {
       expect(validatorClient.collectAttestations).toHaveBeenCalled();
     });
 
+    it('interrupts a pending L1 submission waiting for archiver sync', async () => {
+      const { txs, block } = await setupTxsAndBlock(p2p, globalVariables, 1, chainId);
+      checkpointBuilder.seedBlocks([block], [txs]);
+      validatorClient.collectAttestations.mockResolvedValue(getAttestations(block));
+      l2BlockSource.getSyncedL2SlotNumber.mockResolvedValue(undefined);
+
+      const checkpoint = await job.execute();
+      expect(checkpoint).toBeDefined();
+
+      const pendingSubmission = job.awaitPendingSubmission().then(() => 'stopped' as const);
+      job.interrupt();
+
+      let timeout: NodeJS.Timeout | undefined;
+      try {
+        const result = await Promise.race([
+          pendingSubmission,
+          new Promise<'timed-out'>(resolve => {
+            timeout = setTimeout(() => resolve('timed-out'), 1000);
+          }),
+        ]);
+        expect(result).toBe('stopped');
+      } finally {
+        if (timeout) {
+          clearTimeout(timeout);
+        }
+      }
+    });
+
     it('aborts checkpoint when syncing proposed block to archiver fails', async () => {
       const { txs, block } = await setupTxsAndBlock(p2p, globalVariables, 1, chainId);
       checkpointBuilder.seedBlocks([block], [txs]);

--- a/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.ts
+++ b/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.ts
@@ -14,12 +14,12 @@ import {
   generateUnrecoverableSignature,
 } from '@aztec/foundation/crypto/secp256k1-signer';
 import { Fr } from '@aztec/foundation/curves/bn254';
+import { TimeoutError } from '@aztec/foundation/error';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { Signature } from '@aztec/foundation/eth-signature';
 import { filter } from '@aztec/foundation/iterator';
 import { type Logger, type LoggerBindings, createLogger } from '@aztec/foundation/log';
-import { retryUntil } from '@aztec/foundation/retry';
-import { sleep, sleepUntil } from '@aztec/foundation/sleep';
+import { InterruptibleSleep } from '@aztec/foundation/sleep';
 import { type DateProvider, Timer } from '@aztec/foundation/timer';
 import { type TypedEventEmitter, isErrorClass, unfreeze } from '@aztec/foundation/types';
 import type { P2P } from '@aztec/p2p';
@@ -79,6 +79,7 @@ import { SequencerState } from './utils.js';
 
 /** How much time to sleep while waiting for min transactions to accumulate for a block */
 const TXS_POLLING_MS = 500;
+const ARCHIVER_SYNC_POLLING_MS = 200;
 
 /** Result from proposeCheckpoint when a checkpoint was successfully built and broadcast. */
 type CheckpointProposalBroadcast = {
@@ -106,6 +107,8 @@ export class CheckpointProposalJob implements Traceable {
 
   /** Tracks the fire-and-forget L1 submission promise so it can be awaited during shutdown. */
   private pendingL1Submission: Promise<void> | undefined;
+  private readonly interruptibleSleep = new InterruptibleSleep();
+  private interrupted = false;
 
   /**
    * Chain state overrides built once per slot in proposeCheckpoint after the checkpoint is
@@ -166,8 +169,27 @@ export class CheckpointProposalJob implements Traceable {
 
   /** Awaits the pending L1 submission if one is in progress. Call during shutdown. */
   public async awaitPendingSubmission(): Promise<void> {
+    const pendingL1Submission = this.pendingL1Submission;
+    if (!pendingL1Submission) {
+      return;
+    }
     this.log.info('Awaiting pending L1 payload submission');
-    await this.pendingL1Submission;
+    await pendingL1Submission;
+    if (this.pendingL1Submission === pendingL1Submission) {
+      this.pendingL1Submission = undefined;
+    }
+  }
+
+  /** Interrupts job-owned waits so shutdown can finish. */
+  public interrupt(): void {
+    this.interrupted = true;
+    this.interruptibleSleep.interrupt();
+  }
+
+  private throwIfInterrupted(): void {
+    if (this.interrupted) {
+      throw new SequencerInterruptedError();
+    }
   }
 
   private logCheckpointEvent(eventName: string, message: string, fields: Record<string, unknown>): void {
@@ -365,16 +387,22 @@ export class CheckpointProposalJob implements Traceable {
     const timeoutSeconds = Math.max(0.1, (targetSlotEndMs + syncDelayTolerance - this.dateProvider.now()) / 1000);
 
     try {
-      return await retryUntil(
-        async () => {
-          const syncedSlot = await this.l2BlockSource.getSyncedL2SlotNumber();
-          return syncedSlot !== undefined && syncedSlot >= waitForSlot;
-        },
-        `archiver sync past slot ${waitForSlot}`,
-        timeoutSeconds,
-        0.2,
-      );
-    } catch {
+      const timer = new Timer();
+      while (true) {
+        this.throwIfInterrupted();
+        const syncedSlot = await this.l2BlockSource.getSyncedL2SlotNumber();
+        if (syncedSlot !== undefined && syncedSlot >= waitForSlot) {
+          return true;
+        }
+        if (timeoutSeconds && timer.s() > timeoutSeconds) {
+          throw new TimeoutError(`Timeout awaiting archiver sync past slot ${waitForSlot}`);
+        }
+        await this.interruptibleSleep.sleep(ARCHIVER_SYNC_POLLING_MS);
+      }
+    } catch (err) {
+      if (err instanceof SequencerInterruptedError) {
+        throw err;
+      }
       this.log.warn(
         `Archiver did not sync L1 past slot ${waitForSlot} before slot ${this.targetSlot} expired, discarding pipelined work`,
         { checkpointNumber: this.checkpointNumber },
@@ -1577,12 +1605,19 @@ export class CheckpointProposalJob implements Traceable {
   protected async waitUntilTimeInSlot(targetSecondsIntoSlot: number): Promise<void> {
     const slotStartTimestamp = this.getSlotStartBuildTimestamp();
     const targetTimestamp = slotStartTimestamp + targetSecondsIntoSlot;
-    await sleepUntil(new Date(targetTimestamp * 1000), this.dateProvider.nowAsDate());
+    this.throwIfInterrupted();
+    const delayMs = targetTimestamp * 1000 - this.dateProvider.nowAsDate().getTime();
+    if (delayMs > 0) {
+      await this.interruptibleSleep.sleep(delayMs);
+    }
+    this.throwIfInterrupted();
   }
 
   /** Waits the polling interval for transactions. Extracted for test overriding. */
   protected async waitForTxsPollingInterval(): Promise<void> {
-    await sleep(TXS_POLLING_MS);
+    this.throwIfInterrupted();
+    await this.interruptibleSleep.sleep(TXS_POLLING_MS);
+    this.throwIfInterrupted();
   }
 
   private getSlotStartBuildTimestamp(): number {

--- a/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.ts
+++ b/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.ts
@@ -14,7 +14,7 @@ import {
   generateUnrecoverableSignature,
 } from '@aztec/foundation/crypto/secp256k1-signer';
 import { Fr } from '@aztec/foundation/curves/bn254';
-import { TimeoutError } from '@aztec/foundation/error';
+import { InterruptError, TimeoutError } from '@aztec/foundation/error';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { Signature } from '@aztec/foundation/eth-signature';
 import { filter } from '@aztec/foundation/iterator';
@@ -176,18 +176,23 @@ export class CheckpointProposalJob implements Traceable {
   /** Interrupts job-owned waits so shutdown can finish. */
   public interrupt(): void {
     this.interrupted = true;
-    this.interruptibleSleep.interrupt();
+    this.interruptibleSleep.interrupt(true);
   }
 
-  private async sleepInterruptibly(ms: number): Promise<void> {
+  private async awaitInterruptibleSleep(ms: number): Promise<void> {
     if (this.interrupted) {
       throw new SequencerInterruptedError();
     }
-    if (ms > 0) {
+    if (ms <= 0) {
+      return;
+    }
+    try {
       await this.interruptibleSleep.sleep(ms);
-    }
-    if (this.interrupted) {
-      throw new SequencerInterruptedError();
+    } catch (err) {
+      if (err instanceof InterruptError) {
+        throw new SequencerInterruptedError();
+      }
+      throw err;
     }
   }
 
@@ -395,7 +400,7 @@ export class CheckpointProposalJob implements Traceable {
         if (timeoutSeconds && timer.s() > timeoutSeconds) {
           throw new TimeoutError(`Timeout awaiting archiver sync past slot ${waitForSlot}`);
         }
-        await this.sleepInterruptibly(ARCHIVER_SYNC_POLLING_MS);
+        await this.awaitInterruptibleSleep(ARCHIVER_SYNC_POLLING_MS);
       }
     } catch (err) {
       if (err instanceof SequencerInterruptedError) {
@@ -1604,12 +1609,12 @@ export class CheckpointProposalJob implements Traceable {
     const slotStartTimestamp = this.getSlotStartBuildTimestamp();
     const targetTimestamp = slotStartTimestamp + targetSecondsIntoSlot;
     const delayMs = targetTimestamp * 1000 - this.dateProvider.nowAsDate().getTime();
-    await this.sleepInterruptibly(delayMs);
+    await this.awaitInterruptibleSleep(delayMs);
   }
 
   /** Pause between mempool polls in waitForMinTxs. Extracted for test overriding. */
   protected async waitForTxsPollingInterval(): Promise<void> {
-    await this.sleepInterruptibly(TXS_POLLING_MS);
+    await this.awaitInterruptibleSleep(TXS_POLLING_MS);
   }
 
   private getSlotStartBuildTimestamp(): number {

--- a/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.ts
+++ b/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.ts
@@ -1613,8 +1613,10 @@ export class CheckpointProposalJob implements Traceable {
     this.throwIfInterrupted();
   }
 
-  /** Waits the polling interval for transactions. Extracted for test overriding. */
+  /** Pause between mempool polls in waitForMinTxs. Extracted for test overriding. */
   protected async waitForTxsPollingInterval(): Promise<void> {
+    // using throwIfInterrupted twice: Sequencer.stop() sets interrupted and wakes InterruptibleSleep, but sleep
+    // returns normally. Before sleep: bail if stop already happened. After sleep: bail if stop happened during sleep.
     this.throwIfInterrupted();
     await this.interruptibleSleep.sleep(TXS_POLLING_MS);
     this.throwIfInterrupted();

--- a/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.ts
+++ b/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.ts
@@ -169,15 +169,8 @@ export class CheckpointProposalJob implements Traceable {
 
   /** Awaits the pending L1 submission if one is in progress. Call during shutdown. */
   public async awaitPendingSubmission(): Promise<void> {
-    const pendingL1Submission = this.pendingL1Submission;
-    if (!pendingL1Submission) {
-      return;
-    }
     this.log.info('Awaiting pending L1 payload submission');
-    await pendingL1Submission;
-    if (this.pendingL1Submission === pendingL1Submission) {
-      this.pendingL1Submission = undefined;
-    }
+    await this.pendingL1Submission;
   }
 
   /** Interrupts job-owned waits so shutdown can finish. */
@@ -186,7 +179,13 @@ export class CheckpointProposalJob implements Traceable {
     this.interruptibleSleep.interrupt();
   }
 
-  private throwIfInterrupted(): void {
+  private async sleepInterruptibly(ms: number): Promise<void> {
+    if (this.interrupted) {
+      throw new SequencerInterruptedError();
+    }
+    if (ms > 0) {
+      await this.interruptibleSleep.sleep(ms);
+    }
     if (this.interrupted) {
       throw new SequencerInterruptedError();
     }
@@ -389,7 +388,6 @@ export class CheckpointProposalJob implements Traceable {
     try {
       const timer = new Timer();
       while (true) {
-        this.throwIfInterrupted();
         const syncedSlot = await this.l2BlockSource.getSyncedL2SlotNumber();
         if (syncedSlot !== undefined && syncedSlot >= waitForSlot) {
           return true;
@@ -397,7 +395,7 @@ export class CheckpointProposalJob implements Traceable {
         if (timeoutSeconds && timer.s() > timeoutSeconds) {
           throw new TimeoutError(`Timeout awaiting archiver sync past slot ${waitForSlot}`);
         }
-        await this.interruptibleSleep.sleep(ARCHIVER_SYNC_POLLING_MS);
+        await this.sleepInterruptibly(ARCHIVER_SYNC_POLLING_MS);
       }
     } catch (err) {
       if (err instanceof SequencerInterruptedError) {
@@ -1605,21 +1603,13 @@ export class CheckpointProposalJob implements Traceable {
   protected async waitUntilTimeInSlot(targetSecondsIntoSlot: number): Promise<void> {
     const slotStartTimestamp = this.getSlotStartBuildTimestamp();
     const targetTimestamp = slotStartTimestamp + targetSecondsIntoSlot;
-    this.throwIfInterrupted();
     const delayMs = targetTimestamp * 1000 - this.dateProvider.nowAsDate().getTime();
-    if (delayMs > 0) {
-      await this.interruptibleSleep.sleep(delayMs);
-    }
-    this.throwIfInterrupted();
+    await this.sleepInterruptibly(delayMs);
   }
 
   /** Pause between mempool polls in waitForMinTxs. Extracted for test overriding. */
   protected async waitForTxsPollingInterval(): Promise<void> {
-    // using throwIfInterrupted twice: Sequencer.stop() sets interrupted and wakes InterruptibleSleep, but sleep
-    // returns normally. Before sleep: bail if stop already happened. After sleep: bail if stop happened during sleep.
-    this.throwIfInterrupted();
-    await this.interruptibleSleep.sleep(TXS_POLLING_MS);
-    this.throwIfInterrupted();
+    await this.sleepInterruptibly(TXS_POLLING_MS);
   }
 
   private getSlotStartBuildTimestamp(): number {

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.ts
@@ -186,6 +186,7 @@ export class Sequencer extends (EventEmitter as new () => TypedEventEmitter<Sequ
   public async stop(): Promise<void> {
     this.log.info(`Stopping sequencer`);
     this.setState(SequencerState.STOPPING, undefined, { force: true });
+    this.lastCheckpointProposalJob?.interrupt();
     await this.publisherFactory.stopAll();
     await this.runningPromise?.stop();
     await this.lastCheckpointProposalJob?.awaitPendingSubmission();


### PR DESCRIPTION
## Summary

- Interrupt the active `CheckpointProposalJob` when the sequencer stops so background L1 submission work does not keep nodes alive after HA e2e teardown.
- Replace non-cancellable archiver-sync / slot / tx polling sleeps with `InterruptibleSleep` and clear the pending submission promise after await.
- Add a unit test that reproduces a hung archiver-sync wait and verifies interrupt completes shutdown promptly.

Relates to CI hang on `e2e_ha_full.test.ts` ([run 27030329241](https://github.com/AztecProtocol/aztec-packages/actions/runs/27030329241/job/79780770193), [log](http://ci.aztec-labs.com/55965f47a9f82b04)): suite passed, then Jest failed to exit with active handles while `HA-4` kept logging after abandoned node stop.
