### PR TITLE
chore: add tmp folder in yarn-project

### DIFF
--- a/yarn-project/.gitignore
+++ b/yarn-project/.gitignore
@@ -61,6 +61,7 @@ cli-wallet/test/data
 cli/src/config/generated
 ethereum/src/generated
 slasher/src/generated
+tmp/
 
 .claude/settings.local.json
 .yarn/*


### PR DESCRIPTION
So we can dump in there tmp files like plans, analysis, etc.
