### PR TITLE
fix: ingest L1 checkpoints up to the blob block capacity (A-1156)

### DIFF
--- a/yarn-project/archiver/src/modules/data_store_updater.ts
+++ b/yarn-project/archiver/src/modules/data_store_updater.ts
@@ -18,6 +18,7 @@ import {
   computeContractAddressFromInstance,
   computeContractClassId,
 } from '@aztec/stdlib/contract';
+import { MAX_CAPACITY_BLOCKS_PER_CHECKPOINT } from '@aztec/stdlib/deserialization';
 import type { ContractClassLog, PrivateLog, PublicLog } from '@aztec/stdlib/logs';
 import type { UInt64 } from '@aztec/stdlib/types';
 
@@ -103,11 +104,19 @@ export class ArchiverDataStoreUpdater {
     },
     evictProposedFrom?: CheckpointNumber,
   ): Promise<ReconcileCheckpointsResult> {
+    // Checkpoints here are already accepted by L1, so tolerate up to the physical blob-capacity
+    // ceiling rather than the conservative attestable limit used when building/attesting.
     for (const checkpoint of checkpoints) {
-      validateCheckpoint(checkpoint.checkpoint, { rollupManaLimit: this.opts?.rollupManaLimit });
+      validateCheckpoint(checkpoint.checkpoint, {
+        rollupManaLimit: this.opts?.rollupManaLimit,
+        maxBlocksPerCheckpoint: MAX_CAPACITY_BLOCKS_PER_CHECKPOINT,
+      });
     }
     if (promoteProposed) {
-      validateCheckpoint(promoteProposed.checkpoint.checkpoint, { rollupManaLimit: this.opts?.rollupManaLimit });
+      validateCheckpoint(promoteProposed.checkpoint.checkpoint, {
+        rollupManaLimit: this.opts?.rollupManaLimit,
+        maxBlocksPerCheckpoint: MAX_CAPACITY_BLOCKS_PER_CHECKPOINT,
+      });
     }
 
     const result = await this.stores.db.transactionAsync(async () => {

--- a/yarn-project/p2p/src/msg_validators/proposal_validator/checkpoint_proposal_validator.ts
+++ b/yarn-project/p2p/src/msg_validators/proposal_validator/checkpoint_proposal_validator.ts
@@ -35,6 +35,12 @@ export class CheckpointProposalValidator implements P2PValidator<CheckpointPropo
 
     const blockProposal = proposal.getBlockProposal();
     if (blockProposal) {
+      // The terminal block is carried inside the checkpoint proposal rather than gossiped as a
+      // standalone block proposal, so apply the per-checkpoint block ceiling to it here too.
+      const indexResult = this.proposalValidator.validateBlockIndexWithinCheckpoint(blockProposal);
+      if (indexResult.result !== 'accept') {
+        return indexResult;
+      }
       return this.proposalValidator.validateTxs(blockProposal);
     }
 

--- a/yarn-project/p2p/src/msg_validators/proposal_validator/proposal_validator.test.ts
+++ b/yarn-project/p2p/src/msg_validators/proposal_validator/proposal_validator.test.ts
@@ -3,6 +3,7 @@ import { NoCommitteeError } from '@aztec/ethereum/contracts';
 import { EpochNumber, IndexWithinCheckpoint, SlotNumber } from '@aztec/foundation/branded-types';
 import { Secp256k1Signer } from '@aztec/foundation/crypto/secp256k1-signer';
 import { EthAddress } from '@aztec/foundation/eth-address';
+import { MAX_ATTESTABLE_BLOCKS_PER_CHECKPOINT } from '@aztec/stdlib/deserialization';
 import { PeerErrorSeverity } from '@aztec/stdlib/p2p';
 import {
   TEST_COORDINATION_SIGNATURE_CONTEXT,
@@ -598,6 +599,46 @@ describe('ProposalValidator', () => {
       const proposal = await makeBlockProposal({
         blockHeader: makeBlockHeader(0, { slotNumber: currentSlot }),
         indexWithinCheckpoint: IndexWithinCheckpoint(4),
+        signer,
+      });
+      const result = await validator.validate(proposal);
+      expect(result).toEqual({ result: 'accept' });
+    });
+  });
+
+  describe('maxBlocksPerCheckpoint hard ceiling', () => {
+    const signer = Secp256k1Signer.random();
+
+    beforeEach(() => {
+      // No maxBlocksPerCheckpoint configured: the hard MAX_ATTESTABLE_BLOCKS_PER_CHECKPOINT ceiling must still apply.
+      validator = new ProposalValidator(
+        epochCache,
+        makeTimetable(),
+        {
+          txsPermitted: true,
+          signatureContext: TEST_COORDINATION_SIGNATURE_CONTEXT,
+          clockDisparityMs: TEST_CLOCK_DISPARITY_MS,
+        },
+        'test',
+      );
+      epochCache.getProposerAttesterAddressInSlot.mockResolvedValue(signer.address);
+    });
+
+    it('rejects the block past the attestable limit even when maxBlocksPerCheckpoint is unset', async () => {
+      // indexWithinCheckpoint is 0-based, so index 72 is the 73rd block.
+      const proposal = await makeBlockProposal({
+        blockHeader: makeBlockHeader(0, { slotNumber: currentSlot }),
+        indexWithinCheckpoint: IndexWithinCheckpoint(MAX_ATTESTABLE_BLOCKS_PER_CHECKPOINT),
+        signer,
+      });
+      const result = await validator.validate(proposal);
+      expect(result).toEqual({ result: 'reject', severity: PeerErrorSeverity.MidToleranceError });
+    });
+
+    it('accepts the last block within the attestable limit', async () => {
+      const proposal = await makeBlockProposal({
+        blockHeader: makeBlockHeader(0, { slotNumber: currentSlot }),
+        indexWithinCheckpoint: IndexWithinCheckpoint(MAX_ATTESTABLE_BLOCKS_PER_CHECKPOINT - 1),
         signer,
       });
       const result = await validator.validate(proposal);

--- a/yarn-project/p2p/src/msg_validators/proposal_validator/proposal_validator.test.ts
+++ b/yarn-project/p2p/src/msg_validators/proposal_validator/proposal_validator.test.ts
@@ -18,6 +18,7 @@ import { TxHash } from '@aztec/stdlib/tx';
 import { jest } from '@jest/globals';
 import { type MockProxy, mock } from 'jest-mock-extended';
 
+import { CheckpointProposalValidator } from './checkpoint_proposal_validator.js';
 import { ProposalValidator } from './proposal_validator.js';
 
 /** Clock-disparity tolerance (ms) the validators are configured with in these tests. */
@@ -642,6 +643,50 @@ describe('ProposalValidator', () => {
         signer,
       });
       const result = await validator.validate(proposal);
+      expect(result).toEqual({ result: 'accept' });
+    });
+  });
+
+  describe('checkpoint proposal embedded last-block ceiling', () => {
+    const signer = Secp256k1Signer.random();
+    let checkpointValidator: CheckpointProposalValidator;
+
+    beforeEach(() => {
+      // No maxBlocksPerCheckpoint configured: the hard ceiling must still apply to the terminal block
+      // carried inside the checkpoint proposal (it is not gossiped as a standalone block proposal).
+      checkpointValidator = new CheckpointProposalValidator(epochCache, makeTimetable(), {
+        txsPermitted: true,
+        signatureContext: TEST_COORDINATION_SIGNATURE_CONTEXT,
+        clockDisparityMs: TEST_CLOCK_DISPARITY_MS,
+      });
+      epochCache.getProposerAttesterAddressInSlot.mockResolvedValue(signer.address);
+    });
+
+    it('rejects when the embedded last block is past the attestable limit', async () => {
+      const proposal = await makeCheckpointProposal({
+        checkpointHeader: makeCheckpointHeader(0, { slotNumber: currentSlot }),
+        signer,
+        lastBlock: {
+          blockHeader: makeBlockHeader(0, { slotNumber: currentSlot }),
+          indexWithinCheckpoint: IndexWithinCheckpoint(MAX_ATTESTABLE_BLOCKS_PER_CHECKPOINT),
+          txHashes: [],
+        },
+      });
+      const result = await checkpointValidator.validate(proposal);
+      expect(result).toEqual({ result: 'reject', severity: PeerErrorSeverity.MidToleranceError });
+    });
+
+    it('accepts when the embedded last block is within the attestable limit', async () => {
+      const proposal = await makeCheckpointProposal({
+        checkpointHeader: makeCheckpointHeader(0, { slotNumber: currentSlot }),
+        signer,
+        lastBlock: {
+          blockHeader: makeBlockHeader(0, { slotNumber: currentSlot }),
+          indexWithinCheckpoint: IndexWithinCheckpoint(MAX_ATTESTABLE_BLOCKS_PER_CHECKPOINT - 1),
+          txHashes: [],
+        },
+      });
+      const result = await checkpointValidator.validate(proposal);
       expect(result).toEqual({ result: 'accept' });
     });
   });

--- a/yarn-project/p2p/src/msg_validators/proposal_validator/proposal_validator.ts
+++ b/yarn-project/p2p/src/msg_validators/proposal_validator/proposal_validator.ts
@@ -1,6 +1,7 @@
 import type { EpochCacheInterface } from '@aztec/epoch-cache';
 import { NoCommitteeError } from '@aztec/ethereum/contracts';
 import { type Logger, createLogger } from '@aztec/foundation/log';
+import { MAX_ATTESTABLE_BLOCKS_PER_CHECKPOINT } from '@aztec/stdlib/deserialization';
 import {
   type BlockProposal,
   type CheckpointProposalCore,
@@ -106,15 +107,22 @@ export class ProposalValidator {
         return { result: 'reject', severity: PeerErrorSeverity.MidToleranceError };
       }
 
-      if (
-        this.maxBlocksPerCheckpoint !== undefined &&
-        'indexWithinCheckpoint' in proposal &&
-        proposal.indexWithinCheckpoint >= this.maxBlocksPerCheckpoint
-      ) {
-        this.logger.warn(
-          `Penalizing peer for proposal with indexWithinCheckpoint ${proposal.indexWithinCheckpoint} >= max ${this.maxBlocksPerCheckpoint}`,
+      // A block proposal whose index lands beyond the checkpoint block limit can never be part of a
+      // checkpoint we would attest to, so reject it immediately at ingress.
+      // MAX_ATTESTABLE_BLOCKS_PER_CHECKPOINT is a hard ceiling applied even when maxBlocksPerCheckpoint
+      // is unset; a lower configured value tightens it further. (indexWithinCheckpoint is 0-based, so a
+      // ceiling of 72 rejects the 73rd block.)
+      if ('indexWithinCheckpoint' in proposal) {
+        const maxBlocksPerCheckpoint = Math.min(
+          this.maxBlocksPerCheckpoint ?? MAX_ATTESTABLE_BLOCKS_PER_CHECKPOINT,
+          MAX_ATTESTABLE_BLOCKS_PER_CHECKPOINT,
         );
-        return { result: 'reject', severity: PeerErrorSeverity.MidToleranceError };
+        if (proposal.indexWithinCheckpoint >= maxBlocksPerCheckpoint) {
+          this.logger.warn(
+            `Penalizing peer for proposal with indexWithinCheckpoint ${proposal.indexWithinCheckpoint} >= max ${maxBlocksPerCheckpoint}`,
+          );
+          return { result: 'reject', severity: PeerErrorSeverity.MidToleranceError };
+        }
       }
 
       return { result: 'accept' };

--- a/yarn-project/p2p/src/msg_validators/proposal_validator/proposal_validator.ts
+++ b/yarn-project/p2p/src/msg_validators/proposal_validator/proposal_validator.ts
@@ -109,19 +109,10 @@ export class ProposalValidator {
 
       // A block proposal whose index lands beyond the checkpoint block limit can never be part of a
       // checkpoint we would attest to, so reject it immediately at ingress.
-      // MAX_ATTESTABLE_BLOCKS_PER_CHECKPOINT is a hard ceiling applied even when maxBlocksPerCheckpoint
-      // is unset; a lower configured value tightens it further. (indexWithinCheckpoint is 0-based, so a
-      // ceiling of 72 rejects the 73rd block.)
       if ('indexWithinCheckpoint' in proposal) {
-        const maxBlocksPerCheckpoint = Math.min(
-          this.maxBlocksPerCheckpoint ?? MAX_ATTESTABLE_BLOCKS_PER_CHECKPOINT,
-          MAX_ATTESTABLE_BLOCKS_PER_CHECKPOINT,
-        );
-        if (proposal.indexWithinCheckpoint >= maxBlocksPerCheckpoint) {
-          this.logger.warn(
-            `Penalizing peer for proposal with indexWithinCheckpoint ${proposal.indexWithinCheckpoint} >= max ${maxBlocksPerCheckpoint}`,
-          );
-          return { result: 'reject', severity: PeerErrorSeverity.MidToleranceError };
+        const indexResult = this.validateBlockIndexWithinCheckpoint(proposal);
+        if (indexResult.result !== 'accept') {
+          return indexResult;
         }
       }
 
@@ -132,6 +123,27 @@ export class ProposalValidator {
       }
       throw e;
     }
+  }
+
+  /**
+   * Rejects a block proposal whose index within its checkpoint lands at or beyond the per-checkpoint
+   * block limit. `MAX_ATTESTABLE_BLOCKS_PER_CHECKPOINT` is a hard ceiling applied even when
+   * `maxBlocksPerCheckpoint` is unset; a lower configured value tightens it further.
+   * `indexWithinCheckpoint` is 0-based, so a ceiling of 72 rejects the 73rd block. Applies to standalone
+   * block proposals and to the terminal block embedded in a checkpoint proposal.
+   */
+  public validateBlockIndexWithinCheckpoint(proposal: BlockProposal): ValidationResult {
+    const maxBlocksPerCheckpoint = Math.min(
+      this.maxBlocksPerCheckpoint ?? MAX_ATTESTABLE_BLOCKS_PER_CHECKPOINT,
+      MAX_ATTESTABLE_BLOCKS_PER_CHECKPOINT,
+    );
+    if (proposal.indexWithinCheckpoint >= maxBlocksPerCheckpoint) {
+      this.logger.warn(
+        `Penalizing peer for proposal with indexWithinCheckpoint ${proposal.indexWithinCheckpoint} >= max ${maxBlocksPerCheckpoint}`,
+      );
+      return { result: 'reject', severity: PeerErrorSeverity.MidToleranceError };
+    }
+    return { result: 'accept' };
   }
 
   /** Validates transaction-related fields of a block proposal. */

--- a/yarn-project/stdlib/src/checkpoint/checkpoint.test.ts
+++ b/yarn-project/stdlib/src/checkpoint/checkpoint.test.ts
@@ -1,0 +1,18 @@
+import { CheckpointNumber } from '@aztec/foundation/branded-types';
+
+import { MAX_ATTESTABLE_BLOCKS_PER_CHECKPOINT } from '../deserialization/index.js';
+import { Checkpoint } from './checkpoint.js';
+
+describe('Checkpoint serialization', () => {
+  it('round-trips a checkpoint with more blocks than the attestable limit', async () => {
+    // Checkpoints synced from L1 can exceed the attestable limit, so deserialization must accept them
+    // up to the blob-capacity ceiling rather than truncating or throwing at the attestable limit.
+    const numBlocks = MAX_ATTESTABLE_BLOCKS_PER_CHECKPOINT + 1;
+    const checkpoint = await Checkpoint.random(CheckpointNumber(1), { numBlocks });
+
+    const roundTripped = Checkpoint.fromBuffer(checkpoint.toBuffer());
+
+    expect(roundTripped.blocks.length).toBe(numBlocks);
+    expect(roundTripped.toBuffer()).toEqual(checkpoint.toBuffer());
+  });
+});

--- a/yarn-project/stdlib/src/checkpoint/checkpoint.ts
+++ b/yarn-project/stdlib/src/checkpoint/checkpoint.ts
@@ -14,7 +14,7 @@ import type { FieldsOf } from '@aztec/foundation/types';
 import { z } from 'zod';
 
 import { L2Block } from '../block/l2_block.js';
-import { MAX_BLOCKS_PER_CHECKPOINT } from '../deserialization/index.js';
+import { MAX_CAPACITY_BLOCKS_PER_CHECKPOINT } from '../deserialization/index.js';
 import { computeCheckpointOutHash } from '../messaging/out_hash.js';
 import { CheckpointHeader } from '../rollup/checkpoint_header.js';
 import { schemas } from '../schemas/schemas.js';
@@ -68,7 +68,7 @@ export class Checkpoint {
     const reader = BufferReader.asReader(buf);
     const archive = reader.readObject(AppendOnlyTreeSnapshot);
     const header = reader.readObject(CheckpointHeader);
-    const blocks = reader.readVector(L2Block, MAX_BLOCKS_PER_CHECKPOINT);
+    const blocks = reader.readVector(L2Block, MAX_CAPACITY_BLOCKS_PER_CHECKPOINT);
     const number = CheckpointNumber(reader.readNumber());
     const feeAssetPriceModifier = reader.readInt256();
     return new Checkpoint(archive, header, blocks, number, feeAssetPriceModifier);

--- a/yarn-project/stdlib/src/checkpoint/validate.test.ts
+++ b/yarn-project/stdlib/src/checkpoint/validate.test.ts
@@ -6,6 +6,7 @@ import { EthAddress } from '@aztec/foundation/eth-address';
 import { jest } from '@jest/globals';
 
 import { AztecAddress } from '../aztec-address/index.js';
+import { MAX_ATTESTABLE_BLOCKS_PER_CHECKPOINT, MAX_CAPACITY_BLOCKS_PER_CHECKPOINT } from '../deserialization/index.js';
 import { GasFees } from '../gas/index.js';
 import { AppendOnlyTreeSnapshot } from '../trees/append_only_tree_snapshot.js';
 import { BlockHeader } from '../tx/block_header.js';
@@ -70,18 +71,40 @@ describe('validateCheckpointStructure', () => {
     expect(() => validateCheckpointStructure(checkpoint)).toThrow('Checkpoint has no blocks');
   });
 
-  it('throws when block count exceeds MAX_BLOCKS_PER_CHECKPOINT', async () => {
-    // Build 73 blocks (MAX_BLOCKS_PER_CHECKPOINT = 72)
+  it('throws when block count exceeds the attestable limit (the default)', async () => {
+    // Build MAX_ATTESTABLE_BLOCKS_PER_CHECKPOINT + 1 (= 73) blocks; the default limit is the attestable one.
     const checkpoint = await makeValidCheckpoint(1);
-    // Reuse the single block to fill up 73 slots (structure checks happen before archive chaining in loop)
+    // Reuse the single block to fill up the slots (the count check happens before archive chaining in loop)
     const block = checkpoint.blocks[0];
-    checkpoint.blocks = Array.from({ length: 73 }, (_, i) => {
+    checkpoint.blocks = Array.from({ length: MAX_ATTESTABLE_BLOCKS_PER_CHECKPOINT + 1 }, (_, i) => {
       const cloned = Object.create(Object.getPrototypeOf(block), Object.getOwnPropertyDescriptors(block));
       cloned.indexWithinCheckpoint = IndexWithinCheckpoint(i);
       return cloned;
     });
     expect(() => validateCheckpointStructure(checkpoint)).toThrow(CheckpointValidationError);
-    expect(() => validateCheckpointStructure(checkpoint)).toThrow(/exceeding limit of 72/);
+    expect(() => validateCheckpointStructure(checkpoint)).toThrow(
+      new RegExp(`exceeding limit of ${MAX_ATTESTABLE_BLOCKS_PER_CHECKPOINT}`),
+    );
+  });
+
+  it('accepts more than the attestable limit when given the capacity ceiling (L1-ingest path)', async () => {
+    const checkpoint = await makeValidCheckpoint(MAX_ATTESTABLE_BLOCKS_PER_CHECKPOINT + 1);
+    // The default (attestable) limit rejects it...
+    expect(() => validateCheckpointStructure(checkpoint)).toThrow(
+      new RegExp(`exceeding limit of ${MAX_ATTESTABLE_BLOCKS_PER_CHECKPOINT}`),
+    );
+    // ...but the capacity ceiling used when ingesting L1 checkpoints accepts it.
+    expect(() =>
+      validateCheckpointStructure(checkpoint, { maxBlocksPerCheckpoint: MAX_CAPACITY_BLOCKS_PER_CHECKPOINT }),
+    ).not.toThrow();
+  });
+
+  it('respects an explicit maxBlocksPerCheckpoint', async () => {
+    const checkpoint = await makeValidCheckpoint(3);
+    expect(() => validateCheckpointStructure(checkpoint, { maxBlocksPerCheckpoint: 2 })).toThrow(
+      /exceeding limit of 2/,
+    );
+    expect(() => validateCheckpointStructure(checkpoint, { maxBlocksPerCheckpoint: 5 })).not.toThrow();
   });
 
   it('throws when indexWithinCheckpoint is wrong', async () => {

--- a/yarn-project/stdlib/src/checkpoint/validate.ts
+++ b/yarn-project/stdlib/src/checkpoint/validate.ts
@@ -2,7 +2,7 @@ import { BLOBS_PER_CHECKPOINT, FIELDS_PER_BLOB, MAX_PROCESSABLE_DA_GAS_PER_CHECK
 import type { CheckpointNumber, SlotNumber } from '@aztec/foundation/branded-types';
 import { sum } from '@aztec/foundation/collection';
 
-import { MAX_BLOCKS_PER_CHECKPOINT } from '../deserialization/index.js';
+import { MAX_ATTESTABLE_BLOCKS_PER_CHECKPOINT } from '../deserialization/index.js';
 import type { Checkpoint } from './checkpoint.js';
 
 export class CheckpointValidationError extends Error {
@@ -32,9 +32,15 @@ export function validateCheckpoint(
     maxDABlockGas?: number;
     maxTxsPerCheckpoint?: number;
     maxTxsPerBlock?: number;
+    /**
+     * Max blocks per checkpoint. Defaults to {@link MAX_ATTESTABLE_BLOCKS_PER_CHECKPOINT}; the L1-sync
+     * ingest path passes `MAX_CAPACITY_BLOCKS_PER_CHECKPOINT` to tolerate larger checkpoints already
+     * accepted by L1.
+     */
+    maxBlocksPerCheckpoint?: number;
   },
 ): void {
-  validateCheckpointStructure(checkpoint);
+  validateCheckpointStructure(checkpoint, { maxBlocksPerCheckpoint: opts.maxBlocksPerCheckpoint });
   validateCheckpointLimits(checkpoint, opts);
   validateCheckpointBlocksLimits(checkpoint, opts);
 }
@@ -42,7 +48,7 @@ export function validateCheckpoint(
 /**
  * Validates structural integrity of a checkpoint.
  * - Non-empty block list
- * - Block count within MAX_BLOCKS_PER_CHECKPOINT
+ * - Block count within `maxBlocksPerCheckpoint` (default {@link MAX_ATTESTABLE_BLOCKS_PER_CHECKPOINT})
  * - Checkpoint slot matches the first block's slot
  * - Checkpoint lastArchiveRoot matches the first block's lastArchive root
  * - Sequential block numbers without gaps
@@ -51,16 +57,20 @@ export function validateCheckpoint(
  * - Consistent slot number across all blocks
  * - Global variables (slot, timestamp, coinbase, feeRecipient, gasFees) match checkpoint header for each block
  */
-export function validateCheckpointStructure(checkpoint: Checkpoint): void {
+export function validateCheckpointStructure(
+  checkpoint: Checkpoint,
+  opts: { maxBlocksPerCheckpoint?: number } = {},
+): void {
+  const { maxBlocksPerCheckpoint = MAX_ATTESTABLE_BLOCKS_PER_CHECKPOINT } = opts;
   const { blocks, number, slot } = checkpoint;
 
   if (blocks.length === 0) {
     throw new CheckpointValidationError('Checkpoint has no blocks', number, slot);
   }
 
-  if (blocks.length > MAX_BLOCKS_PER_CHECKPOINT) {
+  if (blocks.length > maxBlocksPerCheckpoint) {
     throw new CheckpointValidationError(
-      `Checkpoint has ${blocks.length} blocks, exceeding limit of ${MAX_BLOCKS_PER_CHECKPOINT}`,
+      `Checkpoint has ${blocks.length} blocks, exceeding limit of ${maxBlocksPerCheckpoint}`,
       number,
       slot,
     );

--- a/yarn-project/stdlib/src/deserialization/deserialization.test.ts
+++ b/yarn-project/stdlib/src/deserialization/deserialization.test.ts
@@ -1,0 +1,48 @@
+import {
+  NUM_BLOCK_END_BLOB_FIELDS,
+  NUM_CHECKPOINT_END_MARKER_FIELDS,
+  NUM_FIRST_BLOCK_END_BLOB_FIELDS,
+  getNumTxBlobFields,
+} from '@aztec/blob-lib/encoding';
+import { BLOBS_PER_CHECKPOINT, FIELDS_PER_BLOB } from '@aztec/constants';
+
+import { MAX_CAPACITY_BLOCKS_PER_CHECKPOINT } from './index.js';
+
+describe('MAX_CAPACITY_BLOCKS_PER_CHECKPOINT', () => {
+  // Smallest blob footprint of a single tx: start marker + tx hash + fee + 1 mandatory nullifier.
+  // Derived from getNumTxBlobFields so it tracks the tx encoding automatically.
+  const MIN_TX_BLOB_FIELDS = getNumTxBlobFields({
+    numNoteHashes: 0,
+    numNullifiers: 1,
+    numL2ToL1Msgs: 0,
+    numPublicDataWrites: 0,
+    numPrivateLogs: 0,
+    privateLogsLength: 0,
+    publicLogsLength: 0,
+    contractClassLogLength: 0,
+  });
+
+  // Largest checkpoint that fits in the blob budget with the most compact construction:
+  // one (possibly empty) first block + (N - 1) single-nullifier blocks + a checkpoint-end marker.
+  // This is the real ceiling the proving system / L1 enforce — there is no explicit block-count cap.
+  const blobBudget = BLOBS_PER_CHECKPOINT * FIELDS_PER_BLOB;
+  const maxBlocksThatFitInBlobs =
+    1 +
+    Math.floor(
+      (blobBudget - NUM_CHECKPOINT_END_MARKER_FIELDS - NUM_FIRST_BLOCK_END_BLOB_FIELDS) /
+        (NUM_BLOCK_END_BLOB_FIELDS + MIN_TX_BLOB_FIELDS),
+    );
+
+  it('is not stricter than the blob-capacity ceiling enforced by the circuits/L1', () => {
+    // If the node bound were below what blobs can carry, a structurally-valid checkpoint that L1
+    // accepts (and can be proven) would be rejected on ingest and permanently wedge the archiver.
+    expect(MAX_CAPACITY_BLOCKS_PER_CHECKPOINT).toBeGreaterThanOrEqual(maxBlocksThatFitInBlobs);
+  });
+
+  it('matches the documented ceiling for the current blob constants', () => {
+    // Pins the arithmetic so a change to BLOBS_PER_CHECKPOINT / FIELDS_PER_BLOB / block-field counts
+    // is noticed and the constant + its comment get revisited.
+    expect(maxBlocksThatFitInBlobs).toBe(2457);
+    expect(MAX_CAPACITY_BLOCKS_PER_CHECKPOINT).toBe(2457);
+  });
+});

--- a/yarn-project/stdlib/src/deserialization/index.ts
+++ b/yarn-project/stdlib/src/deserialization/index.ts
@@ -11,8 +11,38 @@ export const MAX_TXS_PER_BLOCK = 2 ** 16;
 /** Max committee size - theoretical max from bitmap design (256 bytes × 8 bits) */
 export const MAX_COMMITTEE_SIZE = 2048;
 
-/** Max blocks per checkpoint */
-export const MAX_BLOCKS_PER_CHECKPOINT = 72;
+/**
+ * Physical maximum number of L2 blocks a single checkpoint can hold.
+ *
+ * This MUST be >= the number of blocks the proving system can actually carry. If it were lower, a
+ * structurally-valid checkpoint that L1 accepts and that can be proven would be rejected on ingest
+ * (`validateCheckpoint`) and wedge the archiver. The circuits and L1 impose no explicit per-checkpoint
+ * block count; the real ceiling is the blob-field budget:
+ *
+ *   budget = BLOBS_PER_CHECKPOINT * FIELDS_PER_BLOB = 6 * 4096 = 24,576 fields
+ *
+ *   per-block minimal blob footprint:
+ *     first block  (may be empty)   = 7 fields   (NUM_FIRST_BLOCK_END_BLOB_FIELDS)
+ *     every other  (needs >= 1 tx)  = 6 + 4 = 10 fields
+ *                                     (NUM_BLOCK_END_BLOB_FIELDS + a 4-field minimal tx:
+ *                                      tx start marker + tx hash + fee + 1 mandatory nullifier)
+ *     + 1 checkpoint-end marker      (NUM_CHECKPOINT_END_MARKER_FIELDS)
+ *
+ *   max N:  7 + 10*(N - 1) + 1 <= 24,576  =>  10*(N - 1) <= 24,568  =>  N <= 2,457
+ *
+ * Only the first block may be empty; all other blocks require >= 1 tx (the circuits have no empty-tx
+ * variant for non-first blocks). 2457 is exactly this ceiling: any checkpoint above the blob budget
+ * cannot be encoded, so it can never be posted to L1. Invariant checked by the unit test in
+ * deserialization.test.ts. Used for deserialization and when ingesting checkpoints already on L1.
+ */
+export const MAX_CAPACITY_BLOCKS_PER_CHECKPOINT = 2457;
+
+/**
+ * Max blocks per checkpoint we are willing to build or attest to (conservative client policy, and the
+ * default block-count limit for `validateCheckpoint`). Distinct from {@link MAX_CAPACITY_BLOCKS_PER_CHECKPOINT},
+ * which is the higher ceiling we tolerate when deserializing checkpoints already accepted by L1.
+ */
+export const MAX_ATTESTABLE_BLOCKS_PER_CHECKPOINT = 72;
 
 /** Max tx effects per body (based on blob capacity per checkpoint) */
 export const MAX_TX_EFFECTS_PER_BODY = BLOBS_PER_CHECKPOINT * FIELDS_PER_BLOB;


### PR DESCRIPTION
## Motivation

A single constant, `MAX_BLOCKS_PER_CHECKPOINT = 72`, was doing two unrelated jobs: it bounded checkpoint **deserialization** (`Checkpoint.fromBuffer`) and **L1-sync ingest** validation, *and* it served as the build/attest policy limit.

The protocol and L1 impose no per-checkpoint block-count cap — the real ceiling is the blob-field budget (`BLOBS_PER_CHECKPOINT * FIELDS_PER_BLOB = 24,576` fields, ~2457 minimally-sized blocks). So a checkpoint that L1 accepts with more than 72 small blocks could not be deserialized or validated on ingest: the archiver throws, never advances past that L1 block, and wedges permanently — a liveness failure for any node that hits such a checkpoint.

## Approach

Split the conflated constant into two, each with one job:

- `MAX_CAPACITY_BLOCKS_PER_CHECKPOINT = 2457` — the exact blob-capacity ceiling. Used for deserialization and when ingesting checkpoints already accepted by L1.
- `MAX_ATTESTABLE_BLOCKS_PER_CHECKPOINT = 72` — the conservative policy for what we build or attest to, and the **default** block-count limit for `validateCheckpoint`.

`validateCheckpoint` / `validateCheckpointStructure` gain a `maxBlocksPerCheckpoint?` option that defaults to the attestable limit (fail-closed). The L1-sync ingest path explicitly opts into the capacity ceiling; build and proposal-validation use the default and set nothing.

The p2p block-proposal validator now enforces the attestable ceiling as a hard, always-on bound (a lower configured `maxBlocksPerCheckpoint` still tightens it). `indexWithinCheckpoint` is 0-based, so a proposal for the 73rd block (index 72) is rejected at gossip ingress with a peer penalty — previously the check was skipped entirely when the config was unset.

The 2457 value is the exact blob ceiling, pinned by a unit test that re-derives it from the blob constants so any change to those forces a re-derivation.

## API changes

- `stdlib` (`@aztec/stdlib/deserialization`): removed `MAX_BLOCKS_PER_CHECKPOINT`; added `MAX_CAPACITY_BLOCKS_PER_CHECKPOINT` and `MAX_ATTESTABLE_BLOCKS_PER_CHECKPOINT`.
- `validateCheckpoint` and `validateCheckpointStructure` accept an optional `maxBlocksPerCheckpoint` (defaults to the attestable limit).

## Changes

- **stdlib**: split the constant; `Checkpoint.fromBuffer` deserializes up to the capacity ceiling; `validateCheckpoint`/`validateCheckpointStructure` parameterize the block-count limit, defaulting to the attestable limit.
- **archiver**: the L1-sync ingest path (`data_store_updater`) validates checkpoints against the capacity ceiling.
- **p2p**: the proposal validator enforces the attestable ceiling on block proposals unconditionally at gossip ingress.
- **stdlib (tests)**: new constant-invariant test pinning 2457 to the blob budget; new >72-block serialization round-trip; `validate` tests for default-rejects / capacity-accepts / explicit-limit.
- **p2p (tests)**: 73rd-block rejection holds even when `maxBlocksPerCheckpoint` is unset.

Fixes A-1156