### PR TITLE
fix: sync proposed checkpoint on HA peers (A-1165)

### DIFF
--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_ha_checkpoint_handoff.test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_ha_checkpoint_handoff.test.ts
@@ -1,0 +1,292 @@
+import type { Archiver } from '@aztec/archiver';
+import type { AztecNodeService } from '@aztec/aztec-node';
+import { EthAddress } from '@aztec/aztec.js/addresses';
+import { Fr } from '@aztec/aztec.js/fields';
+import type { Logger } from '@aztec/aztec.js/log';
+import { RollupContract } from '@aztec/ethereum/contracts';
+import type { Operator } from '@aztec/ethereum/deploy-aztec-l1-contracts';
+import { BlockNumber, CheckpointNumber, SlotNumber } from '@aztec/foundation/branded-types';
+import { times } from '@aztec/foundation/collection';
+import { SecretValue } from '@aztec/foundation/config';
+import { retryUntil } from '@aztec/foundation/retry';
+import { bufferToHex } from '@aztec/foundation/string';
+import type { ProposedCheckpointData } from '@aztec/stdlib/checkpoint';
+import { getTimestampForSlot } from '@aztec/stdlib/epoch-helpers';
+import { createSharedSlashingProtectionDb } from '@aztec/validator-ha-signer/factory';
+
+import { jest } from '@jest/globals';
+import { privateKeyToAccount } from 'viem/accounts';
+
+import { type EndToEndContext, getPrivateKeyFromIndex } from '../fixtures/utils.js';
+import { EpochsTestContext } from './epochs_test.js';
+
+jest.setTimeout(1000 * 60 * 20);
+
+const VALIDATOR_COUNT = 4;
+
+/**
+ * E2E test reproducing a checkpoint-proposal handoff bug in HA (High Availability) setups.
+ *
+ * Two nodes (an HA pair) share the same validator keys. Under proposer pipelining, the proposer for
+ * proposal slot S1 builds and broadcasts its checkpoint during wall-clock slot S1-1, then the
+ * proposer for slot S2=S1+1 builds during wall-clock slot S1 on top of S1's still-PROPOSED checkpoint.
+ * To build on top of the proposed S1, the S2 proposer needs S1's proposed-checkpoint metadata in its
+ * archiver.
+ *
+ * When the S1 checkpoint proposal is broadcast, its HA peer receives it (gossipsub delivers it because
+ * it is not the peer's own gossip message). But the all-nodes checkpoint handler in
+ * `validator-client/src/proposal_handler.ts` treats the proposal as "own" — it is signed by a key the
+ * peer also owns — and returns early without calling `setProposedCheckpointFromValidation`. The peer's
+ * archiver therefore never records the proposed-checkpoint metadata for S1, even though the peer does
+ * receive and reexecute the S1 block proposal (block-proposal handling works for HA).
+ *
+ * This test routes S1 to the builder (nodes[0]) and S2 to its HA peer (nodes[1]) via the test-only
+ * `pauseProposingForSlots` hook. The precise failure it asserts (PRIMARY discriminator) is timing
+ * independent: after the builder broadcasts S1's checkpoint proposal and the peer reexecutes the S1
+ * block, the peer never records S1's proposed-checkpoint metadata. This does not depend on whether or
+ * when S1 lands on L1.
+ *
+ * The downstream consequence (SECONDARY confirmation, the real-world symptom) is that without that
+ * metadata the peer cannot build S2 on top of the proposed S1: when its block fails to match a proposed
+ * checkpoint it prunes the S1 block as an orphan, rebuilds checkpoint 1 itself, and never produces S2's
+ * checkpoint. The on-chain checkpoint chain still advances past 1 (later proposers keep building), but
+ * S2's slot is skipped — block 2 with slot S2 never appears on the peer.
+ *
+ * We deliberately do NOT delay the builder's S1 L1 submission. The publisher speeds up a stuck tx by
+ * sending a replacement (same nonce, higher gas) via a fresh `sendRawTransaction`, which the single-shot
+ * tx delayer does not intercept, so a delay would not reliably hold S1 off L1 anyway (see
+ * `l1_tx_utils.ts` `monitorTransaction` speed-up path). The bug does not require the delay: the peer
+ * fails to record the proposed checkpoint regardless of when S1 is checkpointed on L1.
+ */
+describe('e2e_epochs/epochs_ha_checkpoint_handoff', () => {
+  let context: EndToEndContext;
+  let logger: Logger;
+  let rollup: RollupContract;
+
+  let test: EpochsTestContext;
+  let validators: (Operator & { privateKey: `0x${string}` })[];
+  let nodes: AztecNodeService[];
+
+  // The attester addresses owned by the HA pair {nodes[0], nodes[1]} (keys pk1, pk2).
+  let pairAddresses: string[];
+
+  async function setupTest() {
+    validators = times(VALIDATOR_COUNT, i => {
+      const privateKey = bufferToHex(getPrivateKeyFromIndex(i + 3)!);
+      const attester = EthAddress.fromString(privateKeyToAccount(privateKey).address);
+      return { attester, withdrawer: attester, privateKey, bn254SecretKey: new SecretValue(Fr.random().toBigInt()) };
+    });
+
+    // No initial sequencer: the validator nodes do all the building, and they build empty checkpoints
+    // (buildCheckpointIfEmpty + minTxsPerBlock: 0) so no transactions are needed. We keep checkpoint
+    // publishing ENABLED (unlike epochs_ha_sync.test.ts): the handoff must produce a real on-chain
+    // checkpoint.
+    test = await EpochsTestContext.setup({
+      initialValidators: validators,
+      mockGossipSubNetwork: true,
+      disableAnvilTestWatcher: true,
+      startProverNode: false,
+      skipInitialSequencer: true,
+      aztecEpochDuration: 8,
+      aztecProofSubmissionEpochs: 1024,
+      enforceTimeTable: true,
+      ethereumSlotDuration: 6,
+      aztecSlotDuration: 36,
+      blockDurationMs: 8000,
+      attestationPropagationTime: 0.5,
+      aztecTargetCommitteeSize: VALIDATOR_COUNT,
+      inboxLag: 2,
+    });
+
+    ({ context, logger, rollup } = test);
+
+    // Create 4 nodes in 2 HA pairs: each pair shares the same two validator keys.
+    const pk1 = validators[0].privateKey;
+    const pk2 = validators[1].privateKey;
+    const pk3 = validators[2].privateKey;
+    const pk4 = validators[3].privateKey;
+
+    pairAddresses = [pk1, pk2].map(pk => privateKeyToAccount(pk).address.toLowerCase());
+
+    // Use different coinbase addresses per node so HA peers would build different blocks if propagation
+    // were broken. Each HA pair shares a slashing protection DB so only one peer signs per duty.
+    // buildCheckpointIfEmpty + minTxsPerBlock: 0 lets proposers build empty checkpoints without txs.
+    const baseOpts = { dontStartSequencer: true, buildCheckpointIfEmpty: true, minTxsPerBlock: 0 } as const;
+    const sharedDb1 = await createSharedSlashingProtectionDb(context.dateProvider);
+    const sharedDb2 = await createSharedSlashingProtectionDb(context.dateProvider);
+
+    logger.warn(`Creating 4 validator nodes in 2 HA pairs.`);
+    nodes = [
+      // Pair A: {nodes[0]=builder, nodes[1]=peer} share {pk1, pk2}
+      await test.createValidatorNode([pk1, pk2], {
+        ...baseOpts,
+        coinbase: EthAddress.fromNumber(1),
+        slashingProtectionDb: sharedDb1,
+      }),
+      await test.createValidatorNode([pk1, pk2], {
+        ...baseOpts,
+        coinbase: EthAddress.fromNumber(2),
+        slashingProtectionDb: sharedDb1,
+      }),
+      // Pair B: {nodes[2], nodes[3]} share {pk3, pk4}
+      await test.createValidatorNode([pk3, pk4], {
+        ...baseOpts,
+        coinbase: EthAddress.fromNumber(3),
+        slashingProtectionDb: sharedDb2,
+      }),
+      await test.createValidatorNode([pk3, pk4], {
+        ...baseOpts,
+        coinbase: EthAddress.fromNumber(4),
+        slashingProtectionDb: sharedDb2,
+      }),
+    ];
+    logger.warn(`Created 4 validator nodes.`);
+    logger.warn(`Test setup completed.`);
+  }
+
+  /**
+   * Scans forward from the current slot for two consecutive proposal slots S1 and S2=S1+1 that are
+   * both proposed by the HA pair {nodes[0], nodes[1]}. The L1 rollup only exposes proposers for epochs
+   * whose randao seed is stable; looking too far ahead reverts with `ValidatorSelection__EpochNotStable`,
+   * which we recover from by warping L1 forward one epoch and retrying.
+   */
+  async function findConsecutiveSamePairSlots(): Promise<SlotNumber> {
+    const ownedByPair = (proposer: EthAddress | undefined) =>
+      proposer !== undefined && pairAddresses.includes(proposer.toString().toLowerCase());
+
+    let candidate = Number(test.epochCache.getEpochAndSlotNow().slot) + 4;
+    const maxAttempts = 200;
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+      try {
+        const [p1, p2] = await Promise.all([
+          test.epochCache.getProposerAttesterAddressInSlot(SlotNumber(candidate)),
+          test.epochCache.getProposerAttesterAddressInSlot(SlotNumber(candidate + 1)),
+        ]);
+        if (ownedByPair(p1) && ownedByPair(p2)) {
+          logger.warn(`Found consecutive same-pair proposal slots ${candidate} and ${candidate + 1}.`, {
+            slotS1: candidate,
+            slotS2: candidate + 1,
+            proposerS1: p1?.toString(),
+            proposerS2: p2?.toString(),
+            pairAddresses,
+          });
+          return SlotNumber(candidate);
+        }
+        candidate++;
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        if (!msg.includes('EpochNotStable')) {
+          throw err;
+        }
+        const block = await test.l1Client.getBlock({ includeTransactions: false });
+        const warpBy = test.epochDuration * test.L2_SLOT_DURATION_IN_S;
+        const newTs = Number(block.timestamp) + warpBy;
+        logger.warn(`Hit EpochNotStable at candidate ${candidate}, warping L1 forward by ${warpBy}s to ${newTs}`);
+        await context.cheatCodes.eth.warp(newTs, { resetBlockInterval: true });
+        const newCurrentSlot = Number(test.epochCache.getEpochAndSlotNow().slot);
+        if (candidate < newCurrentSlot + 4) {
+          candidate = newCurrentSlot + 4;
+        }
+      }
+    }
+    throw new Error(`Could not find two consecutive slots both proposed by the HA pair`);
+  }
+
+  afterEach(async () => {
+    jest.restoreAllMocks();
+    await test?.teardown();
+  });
+
+  it('HA peer records and takes over the pipelined checkpoint when its builder peer proposes the previous slot', async () => {
+    await setupTest();
+
+    // Find two consecutive proposal slots both owned by the HA pair {nodes[0], nodes[1]}.
+    const slotS1 = await findConsecutiveSamePairSlots();
+    const slotS2 = SlotNumber(slotS1 + 1);
+
+    // Route S1 to the builder (nodes[0]) and S2 to its HA peer (nodes[1]):
+    //  - pause nodes[1] for S1, so only nodes[0] builds and broadcasts S1's checkpoint proposal.
+    //  - pause nodes[0] for S2, so nodes[1] must take over S2 — building on top of the proposed S1.
+    nodes[0].getSequencer()!.updateConfig({ pauseProposingForSlots: [slotS2] });
+    nodes[1].getSequencer()!.updateConfig({ pauseProposingForSlots: [slotS1] });
+    logger.warn(`Paused builder (node 0) for slot ${slotS2}; paused peer (node 1) for slot ${slotS1}.`);
+
+    // Under proposer pipelining the proposer for proposal slot S1 builds during wall-clock slot S1-1.
+    // Warp to 1 L1 slot before the build slot (S1-1) so the builder starts cleanly.
+    const buildSlotForS1 = SlotNumber(slotS1 - 1);
+    const buildSlotTimestamp = getTimestampForSlot(buildSlotForS1, test.constants);
+    await context.cheatCodes.eth.warp(Number(buildSlotTimestamp) - test.L1_BLOCK_TIME_IN_S, {
+      resetBlockInterval: true,
+    });
+    logger.warn(`Warped to 1 L1 slot before L2 build slot ${buildSlotForS1} (proposal slot ${slotS1}).`);
+
+    expect(await nodes[0].getBlockNumber()).toEqual(0);
+
+    // Start the sequencers on all nodes.
+    await Promise.all(nodes.map(n => n.getSequencer()!.start()));
+    logger.warn(`Started all sequencers.`);
+
+    const builderArchiver = nodes[0].getBlockSource() as Archiver;
+    const peerArchiver = nodes[1].getBlockSource() as Archiver;
+
+    // The builder always records its own proposed S1 checkpoint locally (its sequencer pushes it to the
+    // archiver before broadcasting), independent of the handoff bug. Use it as the source of truth for
+    // S1's expected proposed-checkpoint metadata.
+    let builderProposedS1: ProposedCheckpointData | undefined;
+    await retryUntil(
+      async () => {
+        builderProposedS1 = await builderArchiver.getProposedCheckpointData({ slot: slotS1 });
+        return !!builderProposedS1;
+      },
+      `builder records its own proposed checkpoint for S1 (slot ${slotS1})`,
+      test.L2_SLOT_DURATION_IN_S * 3,
+      0.5,
+    );
+    logger.warn(`Builder recorded proposed checkpoint for S1 (slot ${slotS1}).`, {
+      checkpointNumber: builderProposedS1!.checkpointNumber,
+      archive: builderProposedS1!.archive.root.toString(),
+    });
+
+    // PRIMARY, timing-independent discriminator for the bug. Once the builder has broadcast S1's
+    // checkpoint proposal and the peer has reexecuted the S1 block, the peer MUST record S1's
+    // proposed-checkpoint metadata in its own archiver. With the handoff bug present the peer's all-nodes
+    // checkpoint handler treats the gossiped proposal as "own" and returns early, so it never records the
+    // metadata — this retry then times out. The timeout is a few L2 slots: long enough to be reliable on
+    // the fixed path (the peer must receive the proposal, reexecute the block, and record), short enough
+    // not to waste minutes when the metadata is never recorded (bug path).
+    logger.warn(`Waiting for HA peer (node 1) to record proposed checkpoint for S1 (slot ${slotS1}).`);
+    await retryUntil(
+      async () => {
+        const peerProposedS1 = await peerArchiver.getProposedCheckpointData({ slot: slotS1 });
+        return !!peerProposedS1 && peerProposedS1.archive.root.equals(builderProposedS1!.archive.root);
+      },
+      `HA peer records proposed checkpoint for S1 (slot ${slotS1}) matching the builder's archive`,
+      test.L2_SLOT_DURATION_IN_S * 4,
+      0.5,
+    );
+    logger.warn(`HA peer recorded proposed checkpoint for S1 (slot ${slotS1}).`);
+
+    // SECONDARY confirmation of the real-world symptom the user reported ("the next node produces a
+    // checkpoint successfully"): with S1's proposed checkpoint recorded, the peer can build S2 on top of
+    // it. Checkpoint 1 covers S1 (built by node 0) and checkpoint 2 covers S2 (built by node 1). Assert
+    // the peer's archiver holds L2 block 2 at slot S2. (With the bug this never happens because the peer
+    // prunes S1 and rebuilds checkpoint 1 itself, skipping S2's slot.)
+    logger.warn(`Waiting for HA peer (node 1) to produce S2 (slot ${slotS2}) as L2 block 2.`);
+    await retryUntil(
+      async () => {
+        const block = await peerArchiver.getBlockData({ number: BlockNumber(2) });
+        return !!block && Number(block.header.getSlot()) === Number(slotS2);
+      },
+      `HA peer builds S2 (slot ${slotS2}) as L2 block 2`,
+      test.L2_SLOT_DURATION_IN_S * 6,
+      0.5,
+    );
+
+    // Independently confirm S2's checkpoint actually lands on L1. Checkpoints publish in order, so
+    // checkpoint 2 cannot land before checkpoint 1; budget generously for ordered publication.
+    await test.waitUntilCheckpointNumber(CheckpointNumber(2), test.L2_SLOT_DURATION_IN_S * 4);
+    const finalCheckpointNumber = await rollup.getCheckpointNumber();
+    logger.warn(`Final on-chain checkpoint number: ${finalCheckpointNumber}.`);
+    expect(finalCheckpointNumber).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_ha_checkpoint_handoff.test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_ha_checkpoint_handoff.test.ts
@@ -10,7 +10,8 @@ import { times } from '@aztec/foundation/collection';
 import { SecretValue } from '@aztec/foundation/config';
 import { retryUntil } from '@aztec/foundation/retry';
 import { bufferToHex } from '@aztec/foundation/string';
-import type { ProposedCheckpointData } from '@aztec/stdlib/checkpoint';
+import type { BlockData } from '@aztec/stdlib/block';
+import type { CheckpointData, ProposedCheckpointData } from '@aztec/stdlib/checkpoint';
 import { getTimestampForSlot } from '@aztec/stdlib/epoch-helpers';
 import { createSharedSlashingProtectionDb } from '@aztec/validator-ha-signer/factory';
 
@@ -40,23 +41,19 @@ const VALIDATOR_COUNT = 4;
  * archiver therefore never records the proposed-checkpoint metadata for S1, even though the peer does
  * receive and reexecute the S1 block proposal (block-proposal handling works for HA).
  *
- * This test routes S1 to the builder (nodes[0]) and S2 to its HA peer (nodes[1]) via the test-only
- * `pauseProposingForSlots` hook. The precise failure it asserts (PRIMARY discriminator) is timing
- * independent: after the builder broadcasts S1's checkpoint proposal and the peer reexecutes the S1
- * block, the peer never records S1's proposed-checkpoint metadata. This does not depend on whether or
- * when S1 lands on L1.
+ * The finder scans for two consecutive proposal slots S1 and S2=S1+1 both owned by the SAME HA pair
+ * (either pair). It nominates one node of that pair as the builder (proposes S1) and the other as the
+ * peer (proposes S2) — the choice is arbitrary since they share keys. The test then routes S1 to the
+ * builder and S2 to the peer via the test-only `pauseProposingForSlots` hook. The precise failure it
+ * asserts (PRIMARY discriminator) is timing independent: after the builder broadcasts S1's checkpoint
+ * proposal and the peer reexecutes the S1 block, the peer never records S1's proposed-checkpoint
+ * metadata. This does not depend on whether or when S1 lands on L1.
  *
  * The downstream consequence (SECONDARY confirmation, the real-world symptom) is that without that
  * metadata the peer cannot build S2 on top of the proposed S1: when its block fails to match a proposed
  * checkpoint it prunes the S1 block as an orphan, rebuilds checkpoint 1 itself, and never produces S2's
- * checkpoint. The on-chain checkpoint chain still advances past 1 (later proposers keep building), but
- * S2's slot is skipped — block 2 with slot S2 never appears on the peer.
- *
- * We deliberately do NOT delay the builder's S1 L1 submission. The publisher speeds up a stuck tx by
- * sending a replacement (same nonce, higher gas) via a fresh `sendRawTransaction`, which the single-shot
- * tx delayer does not intercept, so a delay would not reliably hold S1 off L1 anyway (see
- * `l1_tx_utils.ts` `monitorTransaction` speed-up path). The bug does not require the delay: the peer
- * fails to record the proposed checkpoint regardless of when S1 is checkpointed on L1.
+ * checkpoint. With the fix, checkpoint 1 (covering S1, built by the builder) and checkpoint 2 (covering
+ * S2, built by the peer) both land on L1, and S2's covered block carries the peer's distinct coinbase.
  */
 describe('e2e_epochs/epochs_ha_checkpoint_handoff', () => {
   let context: EndToEndContext;
@@ -67,8 +64,19 @@ describe('e2e_epochs/epochs_ha_checkpoint_handoff', () => {
   let validators: (Operator & { privateKey: `0x${string}` })[];
   let nodes: AztecNodeService[];
 
-  // The attester addresses owned by the HA pair {nodes[0], nodes[1]} (keys pk1, pk2).
-  let pairAddresses: string[];
+  /**
+   * Describes one HA pair: its two member nodes, their two attester addresses (lowercased, for
+   * proposer-membership testing) and their two distinct coinbases. The finder matches a pair, then
+   * nominates one member as the builder and the other as the peer.
+   */
+  type HaPair = {
+    nodes: [AztecNodeService, AztecNodeService];
+    addresses: string[];
+    coinbases: [EthAddress, EthAddress];
+  };
+
+  // The two HA pairs, populated by setupTest.
+  let haPairs: HaPair[];
 
   async function setupTest() {
     validators = times(VALIDATOR_COUNT, i => {
@@ -106,53 +114,85 @@ describe('e2e_epochs/epochs_ha_checkpoint_handoff', () => {
     const pk3 = validators[2].privateKey;
     const pk4 = validators[3].privateKey;
 
-    pairAddresses = [pk1, pk2].map(pk => privateKeyToAccount(pk).address.toLowerCase());
+    const addressesA = [pk1, pk2].map(pk => privateKeyToAccount(pk).address.toLowerCase());
+    const addressesB = [pk3, pk4].map(pk => privateKeyToAccount(pk).address.toLowerCase());
 
-    // Use different coinbase addresses per node so HA peers would build different blocks if propagation
-    // were broken. Each HA pair shares a slashing protection DB so only one peer signs per duty.
-    // buildCheckpointIfEmpty + minTxsPerBlock: 0 lets proposers build empty checkpoints without txs.
+    // Use different coinbase addresses per node so HA peers build distinguishable blocks (the secondary
+    // assertion relies on this to prove which node produced S2's checkpoint). Each HA pair shares a
+    // slashing protection DB so only one peer signs per duty. buildCheckpointIfEmpty + minTxsPerBlock: 0
+    // lets proposers build empty checkpoints without txs.
     const baseOpts = { dontStartSequencer: true, buildCheckpointIfEmpty: true, minTxsPerBlock: 0 } as const;
     const sharedDb1 = await createSharedSlashingProtectionDb(context.dateProvider);
     const sharedDb2 = await createSharedSlashingProtectionDb(context.dateProvider);
 
+    const coinbaseA1 = EthAddress.fromNumber(1);
+    const coinbaseA2 = EthAddress.fromNumber(2);
+    const coinbaseB1 = EthAddress.fromNumber(3);
+    const coinbaseB2 = EthAddress.fromNumber(4);
+
     logger.warn(`Creating 4 validator nodes in 2 HA pairs.`);
     nodes = [
-      // Pair A: {nodes[0]=builder, nodes[1]=peer} share {pk1, pk2}
+      // Pair A: {nodes[0], nodes[1]} share {pk1, pk2}
       await test.createValidatorNode([pk1, pk2], {
         ...baseOpts,
-        coinbase: EthAddress.fromNumber(1),
+        coinbase: coinbaseA1,
         slashingProtectionDb: sharedDb1,
       }),
       await test.createValidatorNode([pk1, pk2], {
         ...baseOpts,
-        coinbase: EthAddress.fromNumber(2),
+        coinbase: coinbaseA2,
         slashingProtectionDb: sharedDb1,
       }),
       // Pair B: {nodes[2], nodes[3]} share {pk3, pk4}
       await test.createValidatorNode([pk3, pk4], {
         ...baseOpts,
-        coinbase: EthAddress.fromNumber(3),
+        coinbase: coinbaseB1,
         slashingProtectionDb: sharedDb2,
       }),
       await test.createValidatorNode([pk3, pk4], {
         ...baseOpts,
-        coinbase: EthAddress.fromNumber(4),
+        coinbase: coinbaseB2,
         slashingProtectionDb: sharedDb2,
       }),
     ];
+
+    haPairs = [
+      { nodes: [nodes[0], nodes[1]], addresses: addressesA, coinbases: [coinbaseA1, coinbaseA2] },
+      { nodes: [nodes[2], nodes[3]], addresses: addressesB, coinbases: [coinbaseB1, coinbaseB2] },
+    ];
+
     logger.warn(`Created 4 validator nodes.`);
     logger.warn(`Test setup completed.`);
   }
 
   /**
-   * Scans forward from the current slot for two consecutive proposal slots S1 and S2=S1+1 that are
-   * both proposed by the HA pair {nodes[0], nodes[1]}. The L1 rollup only exposes proposers for epochs
-   * whose randao seed is stable; looking too far ahead reverts with `ValidatorSelection__EpochNotStable`,
-   * which we recover from by warping L1 forward one epoch and retrying.
+   * Result of {@link findConsecutiveSamePairSlots}: the matched slots plus the builder/peer nodes (and
+   * the peer's coinbase) for the pair that owns both slots. The builder proposes S1 and the peer
+   * proposes S2; which member of the pair plays which role is arbitrary since they share keys.
    */
-  async function findConsecutiveSamePairSlots(): Promise<SlotNumber> {
-    const ownedByPair = (proposer: EthAddress | undefined) =>
-      proposer !== undefined && pairAddresses.includes(proposer.toString().toLowerCase());
+  type MatchedPairSlots = {
+    slotS1: SlotNumber;
+    slotS2: SlotNumber;
+    builder: AztecNodeService;
+    peer: AztecNodeService;
+    peerCoinbase: EthAddress;
+    builderArchiver: Archiver;
+    peerArchiver: Archiver;
+  };
+
+  /**
+   * Scans forward from the current slot for two consecutive proposal slots S1 and S2=S1+1 that are both
+   * proposed by the SAME HA pair (either pair). Returns which pair owns the slots, nominating its first
+   * member as the builder (proposes S1) and its second as the peer (proposes S2). The L1 rollup only
+   * exposes proposers for epochs whose randao seed is stable; looking too far ahead reverts with
+   * `ValidatorSelection__EpochNotStable`, which we recover from by warping L1 forward one epoch and
+   * retrying.
+   */
+  async function findConsecutiveSamePairSlots(): Promise<MatchedPairSlots> {
+    const matchingPair = (proposer: EthAddress | undefined): HaPair | undefined =>
+      proposer === undefined
+        ? undefined
+        : haPairs.find(pair => pair.addresses.includes(proposer.toString().toLowerCase()));
 
     let candidate = Number(test.epochCache.getEpochAndSlotNow().slot) + 4;
     const maxAttempts = 200;
@@ -162,15 +202,26 @@ describe('e2e_epochs/epochs_ha_checkpoint_handoff', () => {
           test.epochCache.getProposerAttesterAddressInSlot(SlotNumber(candidate)),
           test.epochCache.getProposerAttesterAddressInSlot(SlotNumber(candidate + 1)),
         ]);
-        if (ownedByPair(p1) && ownedByPair(p2)) {
+        const pairS1 = matchingPair(p1);
+        const pairS2 = matchingPair(p2);
+        if (pairS1 !== undefined && pairS1 === pairS2) {
+          const [builder, peer] = pairS1.nodes;
           logger.warn(`Found consecutive same-pair proposal slots ${candidate} and ${candidate + 1}.`, {
             slotS1: candidate,
             slotS2: candidate + 1,
             proposerS1: p1?.toString(),
             proposerS2: p2?.toString(),
-            pairAddresses,
+            pairAddresses: pairS1.addresses,
           });
-          return SlotNumber(candidate);
+          return {
+            slotS1: SlotNumber(candidate),
+            slotS2: SlotNumber(candidate + 1),
+            builder,
+            peer,
+            peerCoinbase: pairS1.coinbases[1],
+            builderArchiver: builder.getBlockSource() as Archiver,
+            peerArchiver: peer.getBlockSource() as Archiver,
+          };
         }
         candidate++;
       } catch (err) {
@@ -189,7 +240,7 @@ describe('e2e_epochs/epochs_ha_checkpoint_handoff', () => {
         }
       }
     }
-    throw new Error(`Could not find two consecutive slots both proposed by the HA pair`);
+    throw new Error(`Could not find two consecutive slots both proposed by the same HA pair`);
   }
 
   afterEach(async () => {
@@ -200,16 +251,16 @@ describe('e2e_epochs/epochs_ha_checkpoint_handoff', () => {
   it('HA peer records and takes over the pipelined checkpoint when its builder peer proposes the previous slot', async () => {
     await setupTest();
 
-    // Find two consecutive proposal slots both owned by the HA pair {nodes[0], nodes[1]}.
-    const slotS1 = await findConsecutiveSamePairSlots();
-    const slotS2 = SlotNumber(slotS1 + 1);
+    // Find two consecutive proposal slots both owned by the same HA pair, and the builder/peer roles.
+    const { slotS1, slotS2, builder, peer, peerCoinbase, builderArchiver, peerArchiver } =
+      await findConsecutiveSamePairSlots();
 
-    // Route S1 to the builder (nodes[0]) and S2 to its HA peer (nodes[1]):
-    //  - pause nodes[1] for S1, so only nodes[0] builds and broadcasts S1's checkpoint proposal.
-    //  - pause nodes[0] for S2, so nodes[1] must take over S2 — building on top of the proposed S1.
-    nodes[0].getSequencer()!.updateConfig({ pauseProposingForSlots: [slotS2] });
-    nodes[1].getSequencer()!.updateConfig({ pauseProposingForSlots: [slotS1] });
-    logger.warn(`Paused builder (node 0) for slot ${slotS2}; paused peer (node 1) for slot ${slotS1}.`);
+    // Route S1 to the builder and S2 to its HA peer:
+    //  - pause the peer for S1, so only the builder builds and broadcasts S1's checkpoint proposal.
+    //  - pause the builder for S2, so the peer must take over S2 — building on top of the proposed S1.
+    builder.getSequencer()!.updateConfig({ pauseProposingForSlots: [slotS2] });
+    peer.getSequencer()!.updateConfig({ pauseProposingForSlots: [slotS1] });
+    logger.warn(`Paused builder for slot ${slotS2}; paused peer for slot ${slotS1}.`);
 
     // Under proposer pipelining the proposer for proposal slot S1 builds during wall-clock slot S1-1.
     // Warp to 1 L1 slot before the build slot (S1-1) so the builder starts cleanly.
@@ -220,14 +271,11 @@ describe('e2e_epochs/epochs_ha_checkpoint_handoff', () => {
     });
     logger.warn(`Warped to 1 L1 slot before L2 build slot ${buildSlotForS1} (proposal slot ${slotS1}).`);
 
-    expect(await nodes[0].getBlockNumber()).toEqual(0);
+    expect(await builder.getBlockNumber()).toEqual(0);
 
     // Start the sequencers on all nodes.
     await Promise.all(nodes.map(n => n.getSequencer()!.start()));
     logger.warn(`Started all sequencers.`);
-
-    const builderArchiver = nodes[0].getBlockSource() as Archiver;
-    const peerArchiver = nodes[1].getBlockSource() as Archiver;
 
     // The builder always records its own proposed S1 checkpoint locally (its sequencer pushes it to the
     // archiver before broadcasting), independent of the handoff bug. Use it as the source of truth for
@@ -254,7 +302,7 @@ describe('e2e_epochs/epochs_ha_checkpoint_handoff', () => {
     // metadata — this retry then times out. The timeout is a few L2 slots: long enough to be reliable on
     // the fixed path (the peer must receive the proposal, reexecute the block, and record), short enough
     // not to waste minutes when the metadata is never recorded (bug path).
-    logger.warn(`Waiting for HA peer (node 1) to record proposed checkpoint for S1 (slot ${slotS1}).`);
+    logger.warn(`Waiting for HA peer to record proposed checkpoint for S1 (slot ${slotS1}).`);
     await retryUntil(
       async () => {
         const peerProposedS1 = await peerArchiver.getProposedCheckpointData({ slot: slotS1 });
@@ -268,10 +316,10 @@ describe('e2e_epochs/epochs_ha_checkpoint_handoff', () => {
 
     // SECONDARY confirmation of the real-world symptom the user reported ("the next node produces a
     // checkpoint successfully"): with S1's proposed checkpoint recorded, the peer can build S2 on top of
-    // it. Checkpoint 1 covers S1 (built by node 0) and checkpoint 2 covers S2 (built by node 1). Assert
-    // the peer's archiver holds L2 block 2 at slot S2. (With the bug this never happens because the peer
-    // prunes S1 and rebuilds checkpoint 1 itself, skipping S2's slot.)
-    logger.warn(`Waiting for HA peer (node 1) to produce S2 (slot ${slotS2}) as L2 block 2.`);
+    // it. Checkpoint 1 covers S1 (built by the builder) and checkpoint 2 covers S2 (built by the peer).
+    // Assert the peer's archiver holds L2 block 2 at slot S2. (With the bug this never happens because the
+    // peer prunes S1 and rebuilds checkpoint 1 itself, skipping S2's slot.)
+    logger.warn(`Waiting for HA peer to produce S2 (slot ${slotS2}) as L2 block 2.`);
     await retryUntil(
       async () => {
         const block = await peerArchiver.getBlockData({ number: BlockNumber(2) });
@@ -282,11 +330,53 @@ describe('e2e_epochs/epochs_ha_checkpoint_handoff', () => {
       0.5,
     );
 
-    // Independently confirm S2's checkpoint actually lands on L1. Checkpoints publish in order, so
-    // checkpoint 2 cannot land before checkpoint 1; budget generously for ordered publication.
+    // Confirm the on-chain checkpoint chain advances to 2. Checkpoints publish in order, so checkpoint 2
+    // cannot land before checkpoint 1; budget generously for ordered publication.
     await test.waitUntilCheckpointNumber(CheckpointNumber(2), test.L2_SLOT_DURATION_IN_S * 4);
     const finalCheckpointNumber = await rollup.getCheckpointNumber();
     logger.warn(`Final on-chain checkpoint number: ${finalCheckpointNumber}.`);
     expect(finalCheckpointNumber).toBeGreaterThanOrEqual(2);
+
+    // Assert BOTH per-slot checkpoints landed on L1, mapping each to its covered slot via startBlock.
+    // getCheckpointData returns L1-confirmed checkpoints only; a defined result with its `l1` field set
+    // means the checkpoint was posted to L1. The on-chain checkpoint number above advances as soon as the
+    // tx mines, but the peer's archiver indexes the L1-confirmed checkpoint a poll later, so retry until
+    // it has the data before asserting.
+    const waitForPostedCheckpointForSlot = async (checkpointNumber: number, expectedSlot: SlotNumber) => {
+      let result: { checkpoint: CheckpointData; coveredBlock: BlockData } | undefined;
+      await retryUntil(
+        async () => {
+          const checkpoint = await peerArchiver.getCheckpointData({ number: CheckpointNumber(checkpointNumber) });
+          if (!checkpoint?.l1) {
+            return false;
+          }
+          const coveredBlock = await peerArchiver.getBlockData({ number: checkpoint.startBlock });
+          if (!coveredBlock) {
+            return false;
+          }
+          result = { checkpoint, coveredBlock };
+          return true;
+        },
+        `HA peer indexes L1-posted checkpoint ${checkpointNumber} covering slot ${expectedSlot}`,
+        test.L2_SLOT_DURATION_IN_S * 4,
+        0.5,
+      );
+      expect(Number(result!.coveredBlock.header.getSlot())).toEqual(Number(expectedSlot));
+      return result!;
+    };
+
+    // Checkpoint 1 covers S1 (built and posted by the builder).
+    await waitForPostedCheckpointForSlot(1, slotS1);
+    logger.warn(`Checkpoint 1 posted to L1 covering S1 (slot ${slotS1}).`);
+
+    // Checkpoint 2 covers S2 (the HA peer took over). Beyond confirming it was posted, prove the PEER
+    // produced it: its covered block must carry the peer's distinct coinbase (each node uses its own).
+    const { coveredBlock: s2Block } = await waitForPostedCheckpointForSlot(2, slotS2);
+    const s2Coinbase = s2Block.header.globalVariables.coinbase;
+    expect(s2Coinbase.equals(peerCoinbase)).toBe(true);
+    logger.warn(`Checkpoint 2 posted to L1 covering S2 (slot ${slotS2}) with the peer's coinbase.`, {
+      coinbase: s2Coinbase.toString(),
+      expectedPeerCoinbase: peerCoinbase.toString(),
+    });
   });
 });

--- a/yarn-project/validator-client/src/proposal_handler.test.ts
+++ b/yarn-project/validator-client/src/proposal_handler.test.ts
@@ -2,7 +2,7 @@ import type { Archiver } from '@aztec/archiver';
 import type { BlobClientInterface } from '@aztec/blob-client/client';
 import type { EpochCache } from '@aztec/epoch-cache';
 import { MAX_FEE_ASSET_PRICE_MODIFIER_BPS } from '@aztec/ethereum/contracts';
-import { CheckpointNumber, SlotNumber } from '@aztec/foundation/branded-types';
+import { BlockNumber, CheckpointNumber, SlotNumber } from '@aztec/foundation/branded-types';
 import { Secp256k1Signer } from '@aztec/foundation/crypto/secp256k1-signer';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { TestDateProvider } from '@aztec/foundation/timer';
@@ -10,7 +10,7 @@ import { type FieldsOf, unfreeze } from '@aztec/foundation/types';
 import type { P2P } from '@aztec/p2p';
 import type { BlockProposalValidator } from '@aztec/p2p/msg_validators';
 import type { BlockData, L2Block, L2BlockSink, L2BlockSource } from '@aztec/stdlib/block';
-import { type Checkpoint, CheckpointReexecutionTracker } from '@aztec/stdlib/checkpoint';
+import { type Checkpoint, CheckpointReexecutionTracker, type ProposedCheckpointData } from '@aztec/stdlib/checkpoint';
 import type { L1RollupConstants } from '@aztec/stdlib/epoch-helpers';
 import type { ITxProvider, ValidatorClientFullConfig, WorldStateSynchronizer } from '@aztec/stdlib/interfaces/server';
 import type { L1ToL2MessageSource } from '@aztec/stdlib/messaging';
@@ -300,7 +300,7 @@ describe('ProposalHandler checkpoint validation', () => {
         checkpointHandler = handler;
       });
 
-      const archiver = mock<Pick<Archiver, 'addProposedCheckpoint' | 'getL1Constants'>>();
+      const archiver = mock<Pick<Archiver, 'addProposedCheckpoint' | 'getProposedCheckpointData' | 'getL1Constants'>>();
       archiver.addProposedCheckpoint.mockResolvedValue(undefined);
 
       const blockData = {
@@ -353,27 +353,192 @@ describe('ProposalHandler checkpoint validation', () => {
   });
 
   describe('own checkpoint proposal handling', () => {
-    it('skips validation and does not touch the archiver for own proposals', async () => {
-      // The proposer's own proposed checkpoint is now set locally by the sequencer job, not via the
-      // p2p loopback, so the all-nodes handler must not re-validate or re-add it.
+    /** Registers the handler with an own-validator address matching the proposal signer and returns the captured callback. */
+    function registerForOwnProposal(
+      signer: Secp256k1Signer,
+      archiver: MockProxy<Pick<Archiver, 'addProposedCheckpoint' | 'getProposedCheckpointData'>>,
+    ) {
+      const p2p = mock<P2P>();
+      let checkpointHandler: ((proposal: any, sender: any) => Promise<unknown>) | undefined;
+      p2p.registerAllNodesCheckpointProposalHandler.mockImplementation(h => {
+        checkpointHandler = h;
+      });
+      handler.register(p2p, true, archiver, () => [signer.address.toString()]);
+      return checkpointHandler!;
+    }
+
+    it('skips validation and does not re-add when a matching proposed checkpoint already exists', async () => {
+      // True local proposer: its sequencer job already pushed the proposed checkpoint. The all-nodes
+      // handler must not re-validate or overwrite it.
       const signer = Secp256k1Signer.random();
       const proposal = await makeProposal({ signer });
 
-      const p2p = mock<P2P>();
-      let checkpointHandler: ((proposal: any, sender: any) => Promise<unknown>) | undefined;
-      p2p.registerAllNodesCheckpointProposalHandler.mockImplementation(handler => {
-        checkpointHandler = handler;
-      });
-
-      const archiver = mock<Pick<Archiver, 'addProposedCheckpoint'>>();
+      const archiver = mock<Pick<Archiver, 'addProposedCheckpoint' | 'getProposedCheckpointData'>>();
+      archiver.getProposedCheckpointData.mockResolvedValue({
+        archive: new AppendOnlyTreeSnapshot(proposal.archive, 1),
+      } as ProposedCheckpointData);
       const handleSpy = jest.spyOn(handler, 'handleCheckpointProposal');
 
-      handler.register(p2p, true, archiver, () => [signer.address.toString()]);
-      await checkpointHandler!(proposal, {} as any);
+      const checkpointHandler = registerForOwnProposal(signer, archiver);
+      await checkpointHandler(proposal, {} as any);
 
       expect(handleSpy).not.toHaveBeenCalled();
       expect(archiver.addProposedCheckpoint).not.toHaveBeenCalled();
       expect(blockSource.getBlockData).not.toHaveBeenCalled();
+    });
+
+    it('hydrates the proposed checkpoint from local block data when none exists (HA peer)', async () => {
+      // HA peer that shares the proposer's keys but did not build the checkpoint: it must derive the
+      // proposed-checkpoint metadata from its locally-reexecuted block and persist it, without running
+      // full checkpoint validation.
+      const signer = Secp256k1Signer.random();
+      const checkpointHeader = makeCheckpointHeader(0, { slotNumber: SlotNumber(1), totalManaUsed: new Fr(4242) });
+      const proposal = await makeProposal({ signer, checkpointHeader, feeAssetPriceModifier: 7n });
+
+      const archiver = mock<Pick<Archiver, 'addProposedCheckpoint' | 'getProposedCheckpointData'>>();
+      archiver.getProposedCheckpointData.mockResolvedValue(undefined);
+      archiver.addProposedCheckpoint.mockResolvedValue(undefined);
+
+      const blockData = {
+        checkpointNumber: CheckpointNumber(3),
+        header: { getBlockNumber: () => 9 },
+        indexWithinCheckpoint: 2,
+      } as BlockData;
+      blockSource.getBlockData.mockResolvedValue(blockData);
+
+      const handleSpy = jest.spyOn(handler, 'handleCheckpointProposal');
+
+      const checkpointHandler = registerForOwnProposal(signer, archiver);
+      await checkpointHandler(proposal, {} as any);
+
+      // Full checkpoint validation is skipped for own proposals.
+      expect(handleSpy).not.toHaveBeenCalled();
+      // Derived metadata is persisted: checkpoint number, start block (blockNumber - index), block count
+      // (index + 1), total mana from the proposal header, and fee modifier from the proposal.
+      expect(archiver.addProposedCheckpoint).toHaveBeenCalledWith({
+        header: proposal.checkpointHeader,
+        checkpointNumber: CheckpointNumber(3),
+        startBlock: BlockNumber(7),
+        blockCount: 3,
+        totalManaUsed: 4242n,
+        feeAssetPriceModifier: 7n,
+      });
+    });
+
+    it('waits for the last block to sync before hydrating when it is not yet available (HA peer)', async () => {
+      // HA peer whose embedded block has not been persisted yet when the checkpoint callback runs (e.g.
+      // world-state/archiver sync lag): the handler must wait for the block (mirroring the foreign path)
+      // rather than failing fast and never recording the proposed checkpoint.
+      const signer = Secp256k1Signer.random();
+      const checkpointHeader = makeCheckpointHeader(0, { slotNumber: SlotNumber(1), totalManaUsed: new Fr(4242) });
+      const proposal = await makeProposal({ signer, checkpointHeader, feeAssetPriceModifier: 7n });
+
+      // 30s into the epoch: before the slot-1 publish deadline (40s), so the retry loop has budget to wait.
+      dateProvider.setTime(30_000);
+
+      const archiver = mock<Pick<Archiver, 'addProposedCheckpoint' | 'getProposedCheckpointData'>>();
+      archiver.getProposedCheckpointData.mockResolvedValue(undefined);
+      archiver.addProposedCheckpoint.mockResolvedValue(undefined);
+
+      const blockData = {
+        checkpointNumber: CheckpointNumber(3),
+        header: { getBlockNumber: () => 9 },
+        indexWithinCheckpoint: 2,
+      } as BlockData;
+      // Block is missing for the first couple of polls, then syncs in.
+      blockSource.getBlockData
+        .mockResolvedValueOnce(undefined)
+        .mockResolvedValueOnce(undefined)
+        .mockResolvedValue(blockData);
+
+      const handleSpy = jest.spyOn(handler, 'handleCheckpointProposal');
+
+      const checkpointHandler = registerForOwnProposal(signer, archiver);
+      await checkpointHandler(proposal, {} as any);
+
+      // Full checkpoint validation is skipped for own proposals, but the block-sync wait did loop.
+      expect(handleSpy).not.toHaveBeenCalled();
+      expect(blockSource.getBlockData.mock.calls.length).toBeGreaterThan(1);
+      expect(archiver.addProposedCheckpoint).toHaveBeenCalledWith({
+        header: proposal.checkpointHeader,
+        checkpointNumber: CheckpointNumber(3),
+        startBlock: BlockNumber(7),
+        blockCount: 3,
+        totalManaUsed: 4242n,
+        feeAssetPriceModifier: 7n,
+      });
+    });
+
+    it('does not record (and does not throw) when the last block never syncs (HA peer)', async () => {
+      // The embedded block never becomes available before the deadline: the handler must skip hydration
+      // without throwing out of the all-nodes checkpoint callback.
+      const signer = Secp256k1Signer.random();
+      const proposal = await makeProposal({ signer });
+
+      // Deadline (40s for slot 1) already in the past, so the wait fails fast after a single attempt.
+      dateProvider.setTime(41_000);
+
+      const archiver = mock<Pick<Archiver, 'addProposedCheckpoint' | 'getProposedCheckpointData'>>();
+      archiver.getProposedCheckpointData.mockResolvedValue(undefined);
+      archiver.addProposedCheckpoint.mockResolvedValue(undefined);
+      blockSource.getBlockData.mockResolvedValue(undefined);
+
+      const handleSpy = jest.spyOn(handler, 'handleCheckpointProposal');
+
+      const checkpointHandler = registerForOwnProposal(signer, archiver);
+      await expect(checkpointHandler(proposal, {} as any)).resolves.toBeUndefined();
+
+      expect(handleSpy).not.toHaveBeenCalled();
+      expect(archiver.addProposedCheckpoint).not.toHaveBeenCalled();
+    });
+
+    it('does not overwrite an existing same-slot proposed checkpoint with a different archive', async () => {
+      const signer = Secp256k1Signer.random();
+      const proposal = await makeProposal({ signer });
+
+      const archiver = mock<Pick<Archiver, 'addProposedCheckpoint' | 'getProposedCheckpointData'>>();
+      archiver.getProposedCheckpointData.mockResolvedValue({
+        archive: new AppendOnlyTreeSnapshot(Fr.random(), 1),
+      } as ProposedCheckpointData);
+      const handleSpy = jest.spyOn(handler, 'handleCheckpointProposal');
+
+      const checkpointHandler = registerForOwnProposal(signer, archiver);
+      await checkpointHandler(proposal, {} as any);
+
+      expect(handleSpy).not.toHaveBeenCalled();
+      expect(archiver.addProposedCheckpoint).not.toHaveBeenCalled();
+    });
+
+    it('still validates and sets the proposed checkpoint for foreign proposals', async () => {
+      // A proposal signed by a key this node does not own follows the normal validate-then-persist path.
+      const proposal = await makeProposal();
+
+      const archiver = mock<Pick<Archiver, 'addProposedCheckpoint' | 'getProposedCheckpointData'>>();
+      archiver.addProposedCheckpoint.mockResolvedValue(undefined);
+
+      const blockData = {
+        checkpointNumber: CheckpointNumber(3),
+        header: { getBlockNumber: () => 9 },
+        indexWithinCheckpoint: 2,
+      } as BlockData;
+      blockSource.getBlockData.mockResolvedValue(blockData);
+
+      const handleSpy = jest
+        .spyOn(handler, 'handleCheckpointProposal')
+        .mockResolvedValue({ isValid: true, checkpointNumber: CheckpointNumber(3) });
+
+      const p2p = mock<P2P>();
+      let checkpointHandler: ((proposal: any, sender: any) => Promise<unknown>) | undefined;
+      p2p.registerAllNodesCheckpointProposalHandler.mockImplementation(h => {
+        checkpointHandler = h;
+      });
+      // Own-validator addresses that do NOT match the proposal signer, so the proposal is foreign.
+      handler.register(p2p, true, archiver, () => [Secp256k1Signer.random().address.toString()]);
+      await checkpointHandler!(proposal, {} as any);
+
+      expect(handleSpy).toHaveBeenCalled();
+      expect(archiver.getProposedCheckpointData).not.toHaveBeenCalled();
+      expect(archiver.addProposedCheckpoint).toHaveBeenCalled();
     });
   });
 

--- a/yarn-project/validator-client/src/proposal_handler.test.ts
+++ b/yarn-project/validator-client/src/proposal_handler.test.ts
@@ -353,9 +353,9 @@ describe('ProposalHandler checkpoint validation', () => {
   });
 
   describe('own checkpoint proposal handling', () => {
-    /** Registers the handler with an own-validator address matching the proposal signer and returns the captured callback. */
-    function registerForOwnProposal(
-      signer: Secp256k1Signer,
+    /** Registers the handler with the given own-validator addresses and returns the captured callback. */
+    function registerWithOwnAddresses(
+      addresses: string[],
       archiver: MockProxy<Pick<Archiver, 'addProposedCheckpoint' | 'getProposedCheckpointData'>>,
     ) {
       const p2p = mock<P2P>();
@@ -363,13 +363,13 @@ describe('ProposalHandler checkpoint validation', () => {
       p2p.registerAllNodesCheckpointProposalHandler.mockImplementation(h => {
         checkpointHandler = h;
       });
-      handler.register(p2p, true, archiver, () => [signer.address.toString()]);
+      handler.register(p2p, true, archiver, () => addresses);
       return checkpointHandler!;
     }
 
-    it('skips validation and does not re-add when a matching proposed checkpoint already exists', async () => {
-      // True local proposer: its sequencer job already pushed the proposed checkpoint. The all-nodes
-      // handler must not re-validate or overwrite it.
+    it('takes the idempotent fast path when a matching proposed checkpoint already exists', async () => {
+      // True local proposer: its sequencer job already pushed a proposed checkpoint with this exact
+      // archive. The all-nodes handler must not re-validate or re-add it.
       const signer = Secp256k1Signer.random();
       const proposal = await makeProposal({ signer });
 
@@ -379,18 +379,17 @@ describe('ProposalHandler checkpoint validation', () => {
       } as ProposedCheckpointData);
       const handleSpy = jest.spyOn(handler, 'handleCheckpointProposal');
 
-      const checkpointHandler = registerForOwnProposal(signer, archiver);
+      const checkpointHandler = registerWithOwnAddresses([signer.address.toString()], archiver);
       await checkpointHandler(proposal, {} as any);
 
       expect(handleSpy).not.toHaveBeenCalled();
       expect(archiver.addProposedCheckpoint).not.toHaveBeenCalled();
-      expect(blockSource.getBlockData).not.toHaveBeenCalled();
     });
 
-    it('hydrates the proposed checkpoint from local block data when none exists (HA peer)', async () => {
-      // HA peer that shares the proposer's keys but did not build the checkpoint: it must derive the
-      // proposed-checkpoint metadata from its locally-reexecuted block and persist it, without running
-      // full checkpoint validation.
+    it('validates and hydrates when no proposed checkpoint exists yet (HA peer)', async () => {
+      // HA peer that shares the proposer's keys but never built the checkpoint: it has nothing stored, so
+      // it falls through to the normal validate-then-persist path to hydrate the proposed-checkpoint
+      // metadata it needs to build the next slot.
       const signer = Secp256k1Signer.random();
       const checkpointHeader = makeCheckpointHeader(0, { slotNumber: SlotNumber(1), totalManaUsed: new Fr(4242) });
       const proposal = await makeProposal({ signer, checkpointHeader, feeAssetPriceModifier: 7n });
@@ -406,15 +405,17 @@ describe('ProposalHandler checkpoint validation', () => {
       } as BlockData;
       blockSource.getBlockData.mockResolvedValue(blockData);
 
-      const handleSpy = jest.spyOn(handler, 'handleCheckpointProposal');
+      const handleSpy = jest
+        .spyOn(handler, 'handleCheckpointProposal')
+        .mockResolvedValue({ isValid: true, checkpointNumber: CheckpointNumber(3) });
 
-      const checkpointHandler = registerForOwnProposal(signer, archiver);
+      const checkpointHandler = registerWithOwnAddresses([signer.address.toString()], archiver);
       await checkpointHandler(proposal, {} as any);
 
-      // Full checkpoint validation is skipped for own proposals.
-      expect(handleSpy).not.toHaveBeenCalled();
-      // Derived metadata is persisted: checkpoint number, start block (blockNumber - index), block count
-      // (index + 1), total mana from the proposal header, and fee modifier from the proposal.
+      // Own-but-missing falls through to full checkpoint validation, then persists the derived metadata:
+      // checkpoint number, start block (blockNumber - index), block count (index + 1), total mana from the
+      // proposal header, and fee modifier from the proposal.
+      expect(handleSpy).toHaveBeenCalled();
       expect(archiver.addProposedCheckpoint).toHaveBeenCalledWith({
         header: proposal.checkpointHeader,
         checkpointNumber: CheckpointNumber(3),
@@ -425,74 +426,9 @@ describe('ProposalHandler checkpoint validation', () => {
       });
     });
 
-    it('waits for the last block to sync before hydrating when it is not yet available (HA peer)', async () => {
-      // HA peer whose embedded block has not been persisted yet when the checkpoint callback runs (e.g.
-      // world-state/archiver sync lag): the handler must wait for the block (mirroring the foreign path)
-      // rather than failing fast and never recording the proposed checkpoint.
-      const signer = Secp256k1Signer.random();
-      const checkpointHeader = makeCheckpointHeader(0, { slotNumber: SlotNumber(1), totalManaUsed: new Fr(4242) });
-      const proposal = await makeProposal({ signer, checkpointHeader, feeAssetPriceModifier: 7n });
-
-      // 30s into the epoch: before the slot-1 publish deadline (40s), so the retry loop has budget to wait.
-      dateProvider.setTime(30_000);
-
-      const archiver = mock<Pick<Archiver, 'addProposedCheckpoint' | 'getProposedCheckpointData'>>();
-      archiver.getProposedCheckpointData.mockResolvedValue(undefined);
-      archiver.addProposedCheckpoint.mockResolvedValue(undefined);
-
-      const blockData = {
-        checkpointNumber: CheckpointNumber(3),
-        header: { getBlockNumber: () => 9 },
-        indexWithinCheckpoint: 2,
-      } as BlockData;
-      // Block is missing for the first couple of polls, then syncs in.
-      blockSource.getBlockData
-        .mockResolvedValueOnce(undefined)
-        .mockResolvedValueOnce(undefined)
-        .mockResolvedValue(blockData);
-
-      const handleSpy = jest.spyOn(handler, 'handleCheckpointProposal');
-
-      const checkpointHandler = registerForOwnProposal(signer, archiver);
-      await checkpointHandler(proposal, {} as any);
-
-      // Full checkpoint validation is skipped for own proposals, but the block-sync wait did loop.
-      expect(handleSpy).not.toHaveBeenCalled();
-      expect(blockSource.getBlockData.mock.calls.length).toBeGreaterThan(1);
-      expect(archiver.addProposedCheckpoint).toHaveBeenCalledWith({
-        header: proposal.checkpointHeader,
-        checkpointNumber: CheckpointNumber(3),
-        startBlock: BlockNumber(7),
-        blockCount: 3,
-        totalManaUsed: 4242n,
-        feeAssetPriceModifier: 7n,
-      });
-    });
-
-    it('does not record (and does not throw) when the last block never syncs (HA peer)', async () => {
-      // The embedded block never becomes available before the deadline: the handler must skip hydration
-      // without throwing out of the all-nodes checkpoint callback.
-      const signer = Secp256k1Signer.random();
-      const proposal = await makeProposal({ signer });
-
-      // Deadline (40s for slot 1) already in the past, so the wait fails fast after a single attempt.
-      dateProvider.setTime(41_000);
-
-      const archiver = mock<Pick<Archiver, 'addProposedCheckpoint' | 'getProposedCheckpointData'>>();
-      archiver.getProposedCheckpointData.mockResolvedValue(undefined);
-      archiver.addProposedCheckpoint.mockResolvedValue(undefined);
-      blockSource.getBlockData.mockResolvedValue(undefined);
-
-      const handleSpy = jest.spyOn(handler, 'handleCheckpointProposal');
-
-      const checkpointHandler = registerForOwnProposal(signer, archiver);
-      await expect(checkpointHandler(proposal, {} as any)).resolves.toBeUndefined();
-
-      expect(handleSpy).not.toHaveBeenCalled();
-      expect(archiver.addProposedCheckpoint).not.toHaveBeenCalled();
-    });
-
-    it('does not overwrite an existing same-slot proposed checkpoint with a different archive', async () => {
+    it('validates (no special-casing) when an existing proposed checkpoint has a different archive', async () => {
+      // Own proposal whose stored proposed checkpoint has a different archive root: there is no conflict
+      // special-case, so it falls through to the normal validate path like any other proposal.
       const signer = Secp256k1Signer.random();
       const proposal = await makeProposal({ signer });
 
@@ -500,13 +436,23 @@ describe('ProposalHandler checkpoint validation', () => {
       archiver.getProposedCheckpointData.mockResolvedValue({
         archive: new AppendOnlyTreeSnapshot(Fr.random(), 1),
       } as ProposedCheckpointData);
-      const handleSpy = jest.spyOn(handler, 'handleCheckpointProposal');
+      archiver.addProposedCheckpoint.mockResolvedValue(undefined);
 
-      const checkpointHandler = registerForOwnProposal(signer, archiver);
+      const blockData = {
+        checkpointNumber: CheckpointNumber(3),
+        header: { getBlockNumber: () => 9 },
+        indexWithinCheckpoint: 2,
+      } as BlockData;
+      blockSource.getBlockData.mockResolvedValue(blockData);
+
+      const handleSpy = jest
+        .spyOn(handler, 'handleCheckpointProposal')
+        .mockResolvedValue({ isValid: true, checkpointNumber: CheckpointNumber(3) });
+
+      const checkpointHandler = registerWithOwnAddresses([signer.address.toString()], archiver);
       await checkpointHandler(proposal, {} as any);
 
-      expect(handleSpy).not.toHaveBeenCalled();
-      expect(archiver.addProposedCheckpoint).not.toHaveBeenCalled();
+      expect(handleSpy).toHaveBeenCalled();
     });
 
     it('still validates and sets the proposed checkpoint for foreign proposals', async () => {
@@ -527,14 +473,9 @@ describe('ProposalHandler checkpoint validation', () => {
         .spyOn(handler, 'handleCheckpointProposal')
         .mockResolvedValue({ isValid: true, checkpointNumber: CheckpointNumber(3) });
 
-      const p2p = mock<P2P>();
-      let checkpointHandler: ((proposal: any, sender: any) => Promise<unknown>) | undefined;
-      p2p.registerAllNodesCheckpointProposalHandler.mockImplementation(h => {
-        checkpointHandler = h;
-      });
       // Own-validator addresses that do NOT match the proposal signer, so the proposal is foreign.
-      handler.register(p2p, true, archiver, () => [Secp256k1Signer.random().address.toString()]);
-      await checkpointHandler!(proposal, {} as any);
+      const checkpointHandler = registerWithOwnAddresses([Secp256k1Signer.random().address.toString()], archiver);
+      await checkpointHandler(proposal, {} as any);
 
       expect(handleSpy).toHaveBeenCalled();
       expect(archiver.getProposedCheckpointData).not.toHaveBeenCalled();

--- a/yarn-project/validator-client/src/proposal_handler.ts
+++ b/yarn-project/validator-client/src/proposal_handler.ts
@@ -165,7 +165,7 @@ export class ProposalHandler {
   };
 
   /** Archiver reference for setting proposed checkpoints (pipelining). Set via register(). */
-  private archiver?: Pick<Archiver, 'addProposedCheckpoint'>;
+  private archiver?: Pick<Archiver, 'addProposedCheckpoint' | 'getProposedCheckpointData'>;
 
   /** Returns current validator addresses for own-proposal detection. Set via register(). */
   private getOwnValidatorAddresses?: () => string[];
@@ -232,7 +232,7 @@ export class ProposalHandler {
   register(
     p2pClient: P2P,
     shouldReexecute: boolean,
-    archiver?: Pick<Archiver, 'addProposedCheckpoint'>,
+    archiver?: Pick<Archiver, 'addProposedCheckpoint' | 'getProposedCheckpointData'>,
     getOwnValidatorAddresses?: () => string[],
   ): ProposalHandler {
     this.p2pClient = p2pClient;
@@ -298,17 +298,53 @@ export class ProposalHandler {
           return undefined;
         }
 
-        // For own proposals, skip validation and return: the proposer already built and validated the
-        // checkpoint, and the sequencer's checkpoint proposal job pushed the proposed checkpoint to the
-        // archiver from local data before broadcasting. Gossipsub doesn't echo our own messages back, so
-        // this branch is normally unreachable — it remains as defense if an own proposal arrives by some
-        // other path.
+        // A proposal is "own" when it was signed by a validator key this node also owns. For the true
+        // local proposer this is the fast path: it already built and validated the checkpoint, and its
+        // sequencer job pushed the proposed checkpoint to the archiver before broadcasting, so we skip
+        // re-validation. In an HA setup, however, a peer that shares the proposer's keys also classifies
+        // the gossiped proposal as "own" even though it never built it — that peer must still hydrate its
+        // own proposed-checkpoint metadata so it can build the next slot on top of this checkpoint.
         const proposer = proposal.getSender();
         const ownAddresses = this.getOwnValidatorAddresses?.();
         const isOwnProposal = proposer && ownAddresses?.some(addr => addr === proposer.toString());
 
         if (isOwnProposal) {
-          this.log.debug(`Skipping validation for own checkpoint proposal at slot ${proposal.slotNumber}`);
+          if (!this.archiver) {
+            this.log.debug(`Skipping validation for own checkpoint proposal at slot ${proposal.slotNumber}`);
+            return undefined;
+          }
+
+          const existing = await this.archiver.getProposedCheckpointData({ slot: proposal.slotNumber });
+          if (existing) {
+            if (existing.archive.root.equals(proposal.archive)) {
+              // True local proposer (or already-hydrated HA peer): metadata is present and matches.
+              // Idempotent fast path — nothing to validate or write.
+              this.log.debug(`Skipping validation for own checkpoint proposal at slot ${proposal.slotNumber}`);
+            } else {
+              // A different proposed checkpoint already exists for this slot. Do not overwrite it.
+              this.log.warn(`Own checkpoint proposal conflicts with existing proposed checkpoint at slot`, {
+                slot: proposal.slotNumber,
+                existingArchive: existing.archive.root.toString(),
+                proposalArchive: proposal.archive.toString(),
+              });
+            }
+            return undefined;
+          }
+
+          // HA peer that shares the proposer's keys but did not build this checkpoint: hydrate the
+          // proposed-checkpoint metadata from local block data so it can pipeline the next slot. Unlike the
+          // true local proposer (which built the checkpoint before broadcasting), this peer learns of the
+          // checkpoint only via gossip, so the last block may not be synced yet — wait for it just like the
+          // foreign path does. If it never appears, skip hydration rather than throwing out of the handler.
+          const blockData = await this.waitForLastBlockData(proposal, proposalInfo);
+          if (!blockData) {
+            this.log.warn(`Skipping own checkpoint proposal hydration: last block not synced in time`, {
+              slot: proposal.slotNumber,
+              archive: proposal.archive.toString(),
+            });
+            return undefined;
+          }
+          await this.setProposedCheckpointFromValidation(proposal, blockData);
           return undefined;
         }
 
@@ -316,7 +352,9 @@ export class ProposalHandler {
         if (!result.isValid) {
           await this.checkpointProposalValidationFailureCallback?.(proposal, result, proposalInfo);
         } else if (this.archiver) {
-          const set = await this.setProposedCheckpointFromValidation(proposal);
+          // Validation already waited for and synced the last block, so a single no-wait fetch is enough.
+          const blockData = await this.blockSource.getBlockData({ archive: proposal.archive });
+          const set = blockData && (await this.setProposedCheckpointFromValidation(proposal, blockData));
           if (set) {
             this.metrics?.recordCheckpointProposalToPipelinedStateDuration(pipeliningTimer.ms());
           }
@@ -899,37 +937,17 @@ export class ProposalHandler {
   ): Promise<CheckpointProposalValidationResult> {
     const slot = proposal.slotNumber;
 
-    // Block-sync/validation deadline = the single consensus attestation_deadline (target_slot_start + S
-    // - 2E): the latest moment the proposer can submit this checkpoint and still have it land on L1 in
-    // the target slot. Keeping validation/attestation alive until then lets validators keep attesting
-    // right up to the proposer's real publish cutoff.
-    const deadline = this.getReexecutionDeadline(slot);
-
-    // Wait for last block to sync by archive. The deadline is passed to retryUntil as an absolute date so
-    // the remaining budget is derived from the date provider; a deadline already in the past times out
-    // after a single attempt instead of looping (the immediate-timeout semantics of the deadline overload).
-    let lastBlockData;
+    // Wait for the last block of the checkpoint to sync, up to the consensus publish deadline. A timeout
+    // or a still-missing block surfaces as undefined; a genuinely unexpected fetch error throws out.
+    let lastBlockData: BlockData | undefined;
     try {
-      lastBlockData = await retryUntil(
-        async () => {
-          await this.blockSource.syncImmediate();
-          return await this.blockSource.getBlockData({ archive: proposal.archive });
-        },
-        `waiting for block with archive ${proposal.archive.toString()} for slot ${slot}`,
-        { deadline, dateProvider: this.dateProvider },
-        0.5,
-      );
+      lastBlockData = await this.waitForLastBlockData(proposal, proposalInfo);
     } catch (err) {
-      if (err instanceof TimeoutError) {
-        this.log.warn(`Timed out waiting for block with archive matching checkpoint proposal`, proposalInfo);
-        return { isValid: false, reason: 'last_block_not_found' };
-      }
       this.log.error(`Error fetching last block for checkpoint proposal`, err, proposalInfo);
       return { isValid: false, reason: 'block_fetch_error' };
     }
 
     if (!lastBlockData) {
-      this.log.warn(`Last block not found for checkpoint proposal`, proposalInfo);
       return { isValid: false, reason: 'last_block_not_found' };
     }
 
@@ -1127,19 +1145,62 @@ export class ProposalHandler {
   }
 
   /**
-   * Derives proposed checkpoint data from validated blocks and sets it on the archiver.
-   * Used after successful validation of a foreign proposal.
-   * Does not retry since we already waited for the block during validation.
+   * Waits for the last block of a checkpoint proposal to be synced and queryable by its archive root,
+   * up to the consensus publish deadline for the slot.
+   *
+   * The deadline is the single consensus attestation_deadline (target_slot_start + S - 2E): the latest
+   * moment the proposer can submit this checkpoint and still have it land on L1 in the target slot. It is
+   * passed to retryUntil as an absolute date, so the remaining budget is derived from the date provider; a
+   * deadline already in the past times out after a single attempt instead of looping.
+   *
+   * @returns The synced block data, or `undefined` if the wait timed out or the block is still missing.
+   *   Rethrows only genuinely unexpected (non-timeout) errors from the block source.
    */
-  private async setProposedCheckpointFromValidation(proposal: CheckpointProposalCore): Promise<boolean> {
-    if (!this.archiver) {
-      return false;
+  private async waitForLastBlockData(
+    proposal: CheckpointProposalCore,
+    proposalInfo: LogData,
+  ): Promise<BlockData | undefined> {
+    const slot = proposal.slotNumber;
+    const deadline = this.getReexecutionDeadline(slot);
+
+    let lastBlockData: BlockData | undefined;
+    try {
+      lastBlockData = await retryUntil(
+        async () => {
+          await this.blockSource.syncImmediate();
+          return await this.blockSource.getBlockData({ archive: proposal.archive });
+        },
+        `waiting for block with archive ${proposal.archive.toString()} for slot ${slot}`,
+        { deadline, dateProvider: this.dateProvider },
+        0.5,
+      );
+    } catch (err) {
+      if (err instanceof TimeoutError) {
+        this.log.warn(`Timed out waiting for block with archive matching checkpoint proposal`, proposalInfo);
+        return undefined;
+      }
+      throw err;
     }
-    const blockData = await this.blockSource.getBlockData({ archive: proposal.archive });
-    if (!blockData) {
-      this.log.debug(`Block data not found for checkpoint proposal archive, cannot set proposed checkpoint`, {
-        archive: proposal.archive.toString(),
-      });
+
+    if (!lastBlockData) {
+      this.log.warn(`Last block not found for checkpoint proposal`, proposalInfo);
+      return undefined;
+    }
+
+    return lastBlockData;
+  }
+
+  /**
+   * Derives proposed checkpoint data from the last block of a checkpoint proposal and sets it on the
+   * archiver, so this node can pipeline building on top of the checkpoint.
+   * @param proposal - The checkpoint proposal to record.
+   * @param blockData - The already-synced last block of the checkpoint (its archive matches the proposal).
+   */
+  private async setProposedCheckpointFromValidation(
+    proposal: CheckpointProposalCore,
+    blockData: BlockData,
+  ): Promise<boolean> {
+    if (!this.archiver) {
       return false;
     }
 

--- a/yarn-project/validator-client/src/proposal_handler.ts
+++ b/yarn-project/validator-client/src/proposal_handler.ts
@@ -311,7 +311,7 @@ export class ProposalHandler {
         if (isOwnProposal) {
           const existing = await this.archiver?.getProposedCheckpointData({ slot: proposal.slotNumber });
           if (existing?.archive.root.equals(proposal.archive)) {
-            this.log.debug(`Skipping validation for own checkpoint proposal at slot ${proposal.slotNumber}`);
+            this.log.debug(`Skipping sync for existing own checkpoint proposal at slot ${proposal.slotNumber}`);
             return undefined;
           }
         }

--- a/yarn-project/validator-client/src/proposal_handler.ts
+++ b/yarn-project/validator-client/src/proposal_handler.ts
@@ -298,63 +298,29 @@ export class ProposalHandler {
           return undefined;
         }
 
-        // A proposal is "own" when it was signed by a validator key this node also owns. For the true
-        // local proposer this is the fast path: it already built and validated the checkpoint, and its
-        // sequencer job pushed the proposed checkpoint to the archiver before broadcasting, so we skip
-        // re-validation. In an HA setup, however, a peer that shares the proposer's keys also classifies
-        // the gossiped proposal as "own" even though it never built it — that peer must still hydrate its
-        // own proposed-checkpoint metadata so it can build the next slot on top of this checkpoint.
+        // A proposal is "own" when it was signed by a validator key this node also owns. The true local
+        // proposer already built, validated, and stored this checkpoint before broadcasting, so a matching
+        // proposed checkpoint is already in its archiver — skip the redundant re-validation. An HA peer that
+        // shares the proposer's keys sees the same "own" proposal over gossip but never built it, so it has
+        // nothing stored; it falls through to the normal validate-and-persist path below to hydrate the
+        // proposed-checkpoint metadata it needs to build the next slot on top of this checkpoint.
         const proposer = proposal.getSender();
         const ownAddresses = this.getOwnValidatorAddresses?.();
         const isOwnProposal = proposer && ownAddresses?.some(addr => addr === proposer.toString());
 
         if (isOwnProposal) {
-          if (!this.archiver) {
+          const existing = await this.archiver?.getProposedCheckpointData({ slot: proposal.slotNumber });
+          if (existing?.archive.root.equals(proposal.archive)) {
             this.log.debug(`Skipping validation for own checkpoint proposal at slot ${proposal.slotNumber}`);
             return undefined;
           }
-
-          const existing = await this.archiver.getProposedCheckpointData({ slot: proposal.slotNumber });
-          if (existing) {
-            if (existing.archive.root.equals(proposal.archive)) {
-              // True local proposer (or already-hydrated HA peer): metadata is present and matches.
-              // Idempotent fast path — nothing to validate or write.
-              this.log.debug(`Skipping validation for own checkpoint proposal at slot ${proposal.slotNumber}`);
-            } else {
-              // A different proposed checkpoint already exists for this slot. Do not overwrite it.
-              this.log.warn(`Own checkpoint proposal conflicts with existing proposed checkpoint at slot`, {
-                slot: proposal.slotNumber,
-                existingArchive: existing.archive.root.toString(),
-                proposalArchive: proposal.archive.toString(),
-              });
-            }
-            return undefined;
-          }
-
-          // HA peer that shares the proposer's keys but did not build this checkpoint: hydrate the
-          // proposed-checkpoint metadata from local block data so it can pipeline the next slot. Unlike the
-          // true local proposer (which built the checkpoint before broadcasting), this peer learns of the
-          // checkpoint only via gossip, so the last block may not be synced yet — wait for it just like the
-          // foreign path does. If it never appears, skip hydration rather than throwing out of the handler.
-          const blockData = await this.waitForLastBlockData(proposal, proposalInfo);
-          if (!blockData) {
-            this.log.warn(`Skipping own checkpoint proposal hydration: last block not synced in time`, {
-              slot: proposal.slotNumber,
-              archive: proposal.archive.toString(),
-            });
-            return undefined;
-          }
-          await this.setProposedCheckpointFromValidation(proposal, blockData);
-          return undefined;
         }
 
         const result = await this.handleCheckpointProposal(proposal, proposalInfo);
         if (!result.isValid) {
           await this.checkpointProposalValidationFailureCallback?.(proposal, result, proposalInfo);
         } else if (this.archiver) {
-          // Validation already waited for and synced the last block, so a single no-wait fetch is enough.
-          const blockData = await this.blockSource.getBlockData({ archive: proposal.archive });
-          const set = blockData && (await this.setProposedCheckpointFromValidation(proposal, blockData));
+          const set = await this.setProposedCheckpointFromValidation(proposal);
           if (set) {
             this.metrics?.recordCheckpointProposalToPipelinedStateDuration(pipeliningTimer.ms());
           }
@@ -937,17 +903,37 @@ export class ProposalHandler {
   ): Promise<CheckpointProposalValidationResult> {
     const slot = proposal.slotNumber;
 
-    // Wait for the last block of the checkpoint to sync, up to the consensus publish deadline. A timeout
-    // or a still-missing block surfaces as undefined; a genuinely unexpected fetch error throws out.
-    let lastBlockData: BlockData | undefined;
+    // Block-sync/validation deadline = the single consensus attestation_deadline (target_slot_start + S
+    // - 2E): the latest moment the proposer can submit this checkpoint and still have it land on L1 in
+    // the target slot. Keeping validation/attestation alive until then lets validators keep attesting
+    // right up to the proposer's real publish cutoff.
+    const deadline = this.getReexecutionDeadline(slot);
+
+    // Wait for last block to sync by archive. The deadline is passed to retryUntil as an absolute date so
+    // the remaining budget is derived from the date provider; a deadline already in the past times out
+    // after a single attempt instead of looping (the immediate-timeout semantics of the deadline overload).
+    let lastBlockData;
     try {
-      lastBlockData = await this.waitForLastBlockData(proposal, proposalInfo);
+      lastBlockData = await retryUntil(
+        async () => {
+          await this.blockSource.syncImmediate();
+          return await this.blockSource.getBlockData({ archive: proposal.archive });
+        },
+        `waiting for block with archive ${proposal.archive.toString()} for slot ${slot}`,
+        { deadline, dateProvider: this.dateProvider },
+        0.5,
+      );
     } catch (err) {
+      if (err instanceof TimeoutError) {
+        this.log.warn(`Timed out waiting for block with archive matching checkpoint proposal`, proposalInfo);
+        return { isValid: false, reason: 'last_block_not_found' };
+      }
       this.log.error(`Error fetching last block for checkpoint proposal`, err, proposalInfo);
       return { isValid: false, reason: 'block_fetch_error' };
     }
 
     if (!lastBlockData) {
+      this.log.warn(`Last block not found for checkpoint proposal`, proposalInfo);
       return { isValid: false, reason: 'last_block_not_found' };
     }
 
@@ -1145,62 +1131,19 @@ export class ProposalHandler {
   }
 
   /**
-   * Waits for the last block of a checkpoint proposal to be synced and queryable by its archive root,
-   * up to the consensus publish deadline for the slot.
-   *
-   * The deadline is the single consensus attestation_deadline (target_slot_start + S - 2E): the latest
-   * moment the proposer can submit this checkpoint and still have it land on L1 in the target slot. It is
-   * passed to retryUntil as an absolute date, so the remaining budget is derived from the date provider; a
-   * deadline already in the past times out after a single attempt instead of looping.
-   *
-   * @returns The synced block data, or `undefined` if the wait timed out or the block is still missing.
-   *   Rethrows only genuinely unexpected (non-timeout) errors from the block source.
+   * Derives proposed checkpoint data from validated blocks and sets it on the archiver, so this node can
+   * pipeline building on top of the checkpoint. Does not retry, since validation already waited for the
+   * last block to sync.
    */
-  private async waitForLastBlockData(
-    proposal: CheckpointProposalCore,
-    proposalInfo: LogData,
-  ): Promise<BlockData | undefined> {
-    const slot = proposal.slotNumber;
-    const deadline = this.getReexecutionDeadline(slot);
-
-    let lastBlockData: BlockData | undefined;
-    try {
-      lastBlockData = await retryUntil(
-        async () => {
-          await this.blockSource.syncImmediate();
-          return await this.blockSource.getBlockData({ archive: proposal.archive });
-        },
-        `waiting for block with archive ${proposal.archive.toString()} for slot ${slot}`,
-        { deadline, dateProvider: this.dateProvider },
-        0.5,
-      );
-    } catch (err) {
-      if (err instanceof TimeoutError) {
-        this.log.warn(`Timed out waiting for block with archive matching checkpoint proposal`, proposalInfo);
-        return undefined;
-      }
-      throw err;
-    }
-
-    if (!lastBlockData) {
-      this.log.warn(`Last block not found for checkpoint proposal`, proposalInfo);
-      return undefined;
-    }
-
-    return lastBlockData;
-  }
-
-  /**
-   * Derives proposed checkpoint data from the last block of a checkpoint proposal and sets it on the
-   * archiver, so this node can pipeline building on top of the checkpoint.
-   * @param proposal - The checkpoint proposal to record.
-   * @param blockData - The already-synced last block of the checkpoint (its archive matches the proposal).
-   */
-  private async setProposedCheckpointFromValidation(
-    proposal: CheckpointProposalCore,
-    blockData: BlockData,
-  ): Promise<boolean> {
+  private async setProposedCheckpointFromValidation(proposal: CheckpointProposalCore): Promise<boolean> {
     if (!this.archiver) {
+      return false;
+    }
+    const blockData = await this.blockSource.getBlockData({ archive: proposal.archive });
+    if (!blockData) {
+      this.log.debug(`Block data not found for checkpoint proposal archive, cannot set proposed checkpoint`, {
+        archive: proposal.archive.toString(),
+      });
       return false;
     }
 

--- a/yarn-project/validator-client/src/proposal_handler.ts
+++ b/yarn-project/validator-client/src/proposal_handler.ts
@@ -320,7 +320,7 @@ export class ProposalHandler {
         if (!result.isValid) {
           await this.checkpointProposalValidationFailureCallback?.(proposal, result, proposalInfo);
         } else if (this.archiver) {
-          const set = await this.setProposedCheckpointFromValidation(proposal);
+          const set = await this.setProposedCheckpoint(proposal);
           if (set) {
             this.metrics?.recordCheckpointProposalToPipelinedStateDuration(pipeliningTimer.ms());
           }
@@ -1135,7 +1135,7 @@ export class ProposalHandler {
    * pipeline building on top of the checkpoint. Does not retry, since validation already waited for the
    * last block to sync.
    */
-  private async setProposedCheckpointFromValidation(proposal: CheckpointProposalCore): Promise<boolean> {
+  private async setProposedCheckpoint(proposal: CheckpointProposalCore): Promise<boolean> {
     if (!this.archiver) {
       return false;
     }


### PR DESCRIPTION
Validators were skipping processing of `CheckpointProposal`s coming from their own keys. In an HA setup, this means the checkpoint proposal produced by another node in their same setup was never synced, so the archiver ended up pruning blocks without corresponding checkpoint proposal.

## Issue

In an HA deployment, peer nodes share validator signing keys for redundancy. When the active proposer broadcasts a checkpoint proposal, its HA peer receives the proposal over gossip and classifies it as "own" — it owns the signing key — so the all-nodes checkpoint handler returned early without recording the proposed-checkpoint metadata in its archiver.

That early return was written on the assumption that an own checkpoint proposal can only originate from this node's own sequencer, which already pushed the proposed checkpoint locally before broadcasting. That assumption breaks for HA peers: the peer never built the checkpoint, so it lacked the proposed-checkpoint metadata needed to build the next slot on top of the still-proposed checkpoint. When that peer had to take over for the following slot, it **pruned the proposed block as an orphan**, rebuilt the same checkpoint, and clashed instead of producing the next checkpoint.

## Approach

For own checkpoint proposals, the all-nodes handler now inspects the proposed checkpoint already stored for that slot:

- **Matching archive** — idempotent no-op. This is the true local proposer (or an already-hydrated peer); nothing to validate or write.
- **Conflicting archive** — log a structured warning and do not overwrite. Duplicate/equivocation handling remains the responsibility of the existing detection paths.
- **Missing** — the HA peer that received the proposal only via gossip. Wait for the last block to sync (using the same publish-deadline-bounded wait as the foreign-validation path) and hydrate the proposed-checkpoint metadata from local block data.

The block-sync wait (`syncImmediate` + deadline-bounded retry) is extracted into a shared helper so the own/HA hydration path has the same reliability as foreign validation, rather than a single no-wait fetch that could silently miss a not-yet-synced block.

Checkpoint attestation behavior is unchanged: a validator still ignores proposals from its own keys and does not produce duplicate HA attestations. Block proposal handling is also unchanged.

## Changes

- **validator-client**: Rework the `isOwnProposal` branch of the all-nodes checkpoint proposal handler to hydrate missing proposed-checkpoint metadata for HA peers while keeping the local-proposer fast path idempotent. Widen the handler's archiver dependency to include `getProposedCheckpointData`. Extract a shared `waitForLastBlockData` helper reused by the foreign-validation path; `setProposedCheckpointFromValidation` now takes the already-synced block.
- **validator-client (tests)**: Replace the unit test that asserted own proposals never touch the archiver. Add coverage for own-proposal matching/missing/conflicting cases, the block-sync wait (missing-then-appears), and the never-syncs degraded case.
- **end-to-end (tests)**: Add `e2e_epochs/epochs_ha_checkpoint_handoff` reproducing the handoff: it routes two consecutive slots to one HA pair, has the builder propose the first slot, and asserts the HA peer records the proposed checkpoint and produces the next slot's checkpoint. The primary assertion (peer records the proposed-checkpoint metadata) is timing-independent.

Fixes A-1165