### PR TITLE
feat(pxe): add constrained-secret search discipline to syncTaggedPrivateLogs

### DIFF
--- a/yarn-project/pxe/src/tagging/recipient_sync/sync_tagged_private_logs.test.ts
+++ b/yarn-project/pxe/src/tagging/recipient_sync/sync_tagged_private_logs.test.ts
@@ -43,6 +43,18 @@ describe('syncTaggedPrivateLogs', () => {
     return query.tags.map((entry: TagQuery<SiloedTag>) => (entry instanceof SiloedTag ? entry : entry.tag));
   }
 
+  function mockNodeWithLogs(logTags: SiloedTag[], blockNumber: number, blockTimestamp: bigint) {
+    aztecNode.getPrivateLogsByTags.mockImplementation((query: PrivateLogsQuery) => {
+      const tags = extractTags(query);
+      return Promise.resolve(
+        tags.map((t: SiloedTag) => {
+          const match = logTags.find(tag => tag.equals(t));
+          return match ? [makeLog(blockNumber, blockTimestamp, match.value)] : [];
+        }),
+      );
+    });
+  }
+
   beforeEach(async () => {
     aztecNode.getPrivateLogsByTags.mockReset();
     taggingStore = new RecipientTaggingStore(await openTmpStore('test'));
@@ -56,7 +68,7 @@ describe('syncTaggedPrivateLogs', () => {
   });
 
   it('returns empty array when no logs found for any secret', async () => {
-    const secrets = await makeSecrets(3);
+    const secrets = await makeSecrets(3, AppTaggingSecretKind.UNCONSTRAINED);
     aztecNode.getPrivateLogsByTags.mockImplementation((query: PrivateLogsQuery) => {
       const tags = extractTags(query);
       return Promise.resolve(tags.map(() => []));
@@ -75,7 +87,7 @@ describe('syncTaggedPrivateLogs', () => {
   });
 
   it('batches tags from multiple secrets into a single RPC call', async () => {
-    const secrets = await makeSecrets(3);
+    const secrets = await makeSecrets(3, AppTaggingSecretKind.UNCONSTRAINED);
     const finalizedBlockNumber = BlockNumber(10);
 
     aztecNode.getPrivateLogsByTags.mockImplementation((query: PrivateLogsQuery) => {
@@ -89,7 +101,7 @@ describe('syncTaggedPrivateLogs', () => {
   });
 
   it('syncs logs and updates store independently per secret', async () => {
-    const secrets = await makeSecrets(3);
+    const secrets = await makeSecrets(3, AppTaggingSecretKind.UNCONSTRAINED);
     const finalizedBlockNumber = BlockNumber(10);
     const logBlockTimestamp = CURRENT_TIMESTAMP - BigInt(MAX_TX_LIFETIME) - 1000n;
 
@@ -98,19 +110,7 @@ describe('syncTaggedPrivateLogs', () => {
     const log1Tag = await computeSiloedTagForIndex(secrets[0], log1Index);
     const log2Tag = await computeSiloedTagForIndex(secrets[1], log2Index);
 
-    aztecNode.getPrivateLogsByTags.mockImplementation((query: PrivateLogsQuery) => {
-      const tags = extractTags(query);
-      return Promise.resolve(
-        tags.map((t: SiloedTag) => {
-          if (t.equals(log1Tag)) {
-            return [makeLog(Number(finalizedBlockNumber), logBlockTimestamp, log1Tag.value)];
-          } else if (t.equals(log2Tag)) {
-            return [makeLog(Number(finalizedBlockNumber), logBlockTimestamp, log2Tag.value)];
-          }
-          return [];
-        }),
-      );
-    });
+    mockNodeWithLogs([log1Tag, log2Tag], Number(finalizedBlockNumber), logBlockTimestamp);
 
     const logs = await syncTaggedPrivateLogs(
       secrets,
@@ -132,21 +132,14 @@ describe('syncTaggedPrivateLogs', () => {
   });
 
   it('does not advance aged index for recent logs', async () => {
-    const [secret] = await makeSecrets(1);
+    const [secret] = await makeSecrets(1, AppTaggingSecretKind.UNCONSTRAINED);
     const finalizedBlockNumber = BlockNumber(10);
     const logBlockTimestamp = CURRENT_TIMESTAMP - 5000n; // not aged
 
     const logIndex = 5;
     const logTag = await computeSiloedTagForIndex(secret, logIndex);
 
-    aztecNode.getPrivateLogsByTags.mockImplementation((query: PrivateLogsQuery) => {
-      const tags = extractTags(query);
-      return Promise.resolve(
-        tags.map((t: SiloedTag) =>
-          t.equals(logTag) ? [makeLog(Number(finalizedBlockNumber), logBlockTimestamp, logTag.value)] : [],
-        ),
-      );
-    });
+    mockNodeWithLogs([logTag], Number(finalizedBlockNumber), logBlockTimestamp);
 
     await syncTaggedPrivateLogs([secret], aztecNode, taggingStore, ANCHOR_BLOCK_HEADER, finalizedBlockNumber, JOB_ID);
 
@@ -155,7 +148,7 @@ describe('syncTaggedPrivateLogs', () => {
   });
 
   it('updates store correctly when multiple iterations are needed', async () => {
-    const [secret] = await makeSecrets(1);
+    const [secret] = await makeSecrets(1, AppTaggingSecretKind.UNCONSTRAINED);
     const finalizedBlockNumber = BlockNumber(10);
     const agedBlockTimestamp = CURRENT_TIMESTAMP - BigInt(MAX_TX_LIFETIME) - 1000n;
 
@@ -168,19 +161,7 @@ describe('syncTaggedPrivateLogs', () => {
     const newWindowIndex = lastIndexInInitialWindow + 3;
     const log2Tag = await computeSiloedTagForIndex(secret, newWindowIndex);
 
-    aztecNode.getPrivateLogsByTags.mockImplementation((query: PrivateLogsQuery) => {
-      const tags = extractTags(query);
-      return Promise.resolve(
-        tags.map((t: SiloedTag) => {
-          if (t.equals(log1Tag)) {
-            return [makeLog(Number(finalizedBlockNumber), agedBlockTimestamp, log1Tag.value)];
-          } else if (t.equals(log2Tag)) {
-            return [makeLog(Number(finalizedBlockNumber), agedBlockTimestamp, log2Tag.value)];
-          }
-          return [];
-        }),
-      );
-    });
+    mockNodeWithLogs([log1Tag, log2Tag], Number(finalizedBlockNumber), agedBlockTimestamp);
 
     const logs = await syncTaggedPrivateLogs(
       [secret],
@@ -197,7 +178,7 @@ describe('syncTaggedPrivateLogs', () => {
   });
 
   it('respects pre-existing store indexes', async () => {
-    const [secret] = await makeSecrets(1);
+    const [secret] = await makeSecrets(1, AppTaggingSecretKind.UNCONSTRAINED);
     const finalizedBlockNumber = BlockNumber(10);
 
     const existingAgedIndex = 5;
@@ -226,7 +207,7 @@ describe('syncTaggedPrivateLogs', () => {
   });
 
   it('handles multiple logs at the same tag index', async () => {
-    const [secret] = await makeSecrets(1);
+    const [secret] = await makeSecrets(1, AppTaggingSecretKind.UNCONSTRAINED);
     const finalizedBlockNumber = BlockNumber(10);
     const logBlockTimestamp = CURRENT_TIMESTAMP - BigInt(MAX_TX_LIFETIME) - 1000n;
 
@@ -260,8 +241,159 @@ describe('syncTaggedPrivateLogs', () => {
     expect(logs).toHaveLength(2);
   });
 
+  describe('constrained secrets', () => {
+    it('stops at first gap and does not track aged index', async () => {
+      const [secret] = await makeSecrets(1, AppTaggingSecretKind.CONSTRAINED);
+      const finalizedBlockNumber = BlockNumber(10);
+      const logBlockTimestamp = CURRENT_TIMESTAMP - BigInt(MAX_TX_LIFETIME) - 1000n;
+
+      const logTags = await Promise.all([0, 1, 2].map(i => computeSiloedTagForIndex(secret, i)));
+      mockNodeWithLogs(logTags, Number(finalizedBlockNumber), logBlockTimestamp);
+
+      const logs = await syncTaggedPrivateLogs(
+        [secret],
+        aztecNode,
+        taggingStore,
+        ANCHOR_BLOCK_HEADER,
+        finalizedBlockNumber,
+        JOB_ID,
+      );
+
+      expect(logs).toHaveLength(3);
+      expect(await taggingStore.getHighestFinalizedIndex(secret, JOB_ID)).toBe(2);
+      expect(await taggingStore.getHighestAgedIndex(secret, JOB_ID)).toBeUndefined();
+    });
+
+    it('continues when all indexes in the batch have logs', async () => {
+      const [secret] = await makeSecrets(1, AppTaggingSecretKind.CONSTRAINED);
+      const finalizedBlockNumber = BlockNumber(10);
+      const logBlockTimestamp = CURRENT_TIMESTAMP - BigInt(MAX_TX_LIFETIME) - 1000n;
+
+      const totalLogs = UNFINALIZED_TAGGING_INDEXES_WINDOW_LEN + 2;
+      const logTags = await Promise.all(
+        Array.from({ length: totalLogs }, (_, i) => computeSiloedTagForIndex(secret, i)),
+      );
+
+      mockNodeWithLogs(logTags, Number(finalizedBlockNumber), logBlockTimestamp);
+
+      const logs = await syncTaggedPrivateLogs(
+        [secret],
+        aztecNode,
+        taggingStore,
+        ANCHOR_BLOCK_HEADER,
+        finalizedBlockNumber,
+        JOB_ID,
+      );
+
+      expect(logs).toHaveLength(totalLogs);
+      expect(aztecNode.getPrivateLogsByTags).toHaveBeenCalledTimes(2);
+    });
+
+    it('persists cursor only up to finalized block', async () => {
+      const [secret] = await makeSecrets(1, AppTaggingSecretKind.CONSTRAINED);
+      const finalizedBlockNumber = BlockNumber(5);
+      const oldTimestamp = CURRENT_TIMESTAMP - BigInt(MAX_TX_LIFETIME) - 1000n;
+      const recentTimestamp = CURRENT_TIMESTAMP - 5000n;
+
+      const finalizedTags = await Promise.all([0, 1, 2, 3].map(i => computeSiloedTagForIndex(secret, i)));
+      const unfinalizedTags = await Promise.all([4, 5].map(i => computeSiloedTagForIndex(secret, i)));
+
+      aztecNode.getPrivateLogsByTags.mockImplementation((query: PrivateLogsQuery) => {
+        const tags = extractTags(query);
+        return Promise.resolve(
+          tags.map((t: SiloedTag) => {
+            if (finalizedTags.find(tag => tag.equals(t))) {
+              return [makeLog(Number(finalizedBlockNumber), oldTimestamp, t.value)];
+            }
+            if (unfinalizedTags.find(tag => tag.equals(t))) {
+              return [makeLog(8, recentTimestamp, t.value)];
+            }
+            return [];
+          }),
+        );
+      });
+
+      const logs = await syncTaggedPrivateLogs(
+        [secret],
+        aztecNode,
+        taggingStore,
+        ANCHOR_BLOCK_HEADER,
+        finalizedBlockNumber,
+        JOB_ID,
+      );
+
+      expect(logs).toHaveLength(6);
+      expect(await taggingStore.getHighestFinalizedIndex(secret, JOB_ID)).toBe(3);
+      expect(aztecNode.getPrivateLogsByTags).toHaveBeenCalledTimes(1);
+    });
+
+    it('respects pre-existing finalized index', async () => {
+      const [secret] = await makeSecrets(1, AppTaggingSecretKind.CONSTRAINED);
+      const existingFinalizedIndex = 5;
+      await taggingStore.updateHighestFinalizedIndex(secret, existingFinalizedIndex, JOB_ID);
+
+      aztecNode.getPrivateLogsByTags.mockImplementation((query: PrivateLogsQuery) =>
+        Promise.resolve(query.tags.map(() => [])),
+      );
+
+      await syncTaggedPrivateLogs([secret], aztecNode, taggingStore, ANCHOR_BLOCK_HEADER, BlockNumber(10), JOB_ID);
+
+      const calledTags = extractTags(aztecNode.getPrivateLogsByTags.mock.calls[0][0]);
+
+      const expectedStart = existingFinalizedIndex + 1;
+      const expectedEnd = existingFinalizedIndex + UNFINALIZED_TAGGING_INDEXES_WINDOW_LEN;
+      const expectedTags = await Promise.all(
+        Array.from({ length: expectedEnd - expectedStart + 1 }, (_, i) =>
+          computeSiloedTagForIndex(secret, expectedStart + i),
+        ),
+      );
+
+      expect(calledTags).toEqual(expectedTags);
+    });
+  });
+
+  describe('mixed constrained and unconstrained secrets', () => {
+    it('batches both kinds into a single RPC call with different stop conditions', async () => {
+      const [constrainedSecret] = await makeSecrets(1, AppTaggingSecretKind.CONSTRAINED);
+      const [unconstrainedSecret] = await makeSecrets(1, AppTaggingSecretKind.UNCONSTRAINED);
+      const finalizedBlockNumber = BlockNumber(10);
+      const logBlockTimestamp = CURRENT_TIMESTAMP - BigInt(MAX_TX_LIFETIME) - 1000n;
+
+      const constrainedLogTags = await Promise.all([0, 1].map(i => computeSiloedTagForIndex(constrainedSecret, i)));
+      const unconstrainedLogTags = await Promise.all([0, 5].map(i => computeSiloedTagForIndex(unconstrainedSecret, i)));
+
+      aztecNode.getPrivateLogsByTags.mockImplementation((query: PrivateLogsQuery) => {
+        const tags = extractTags(query);
+        return Promise.resolve(
+          tags.map((t: SiloedTag) => {
+            const cMatch = constrainedLogTags.find(tag => tag.equals(t));
+            const uMatch = unconstrainedLogTags.find(tag => tag.equals(t));
+            if (cMatch || uMatch) {
+              return [makeLog(Number(finalizedBlockNumber), logBlockTimestamp, t.value)];
+            }
+            return [];
+          }),
+        );
+      });
+
+      const logs = await syncTaggedPrivateLogs(
+        [constrainedSecret, unconstrainedSecret],
+        aztecNode,
+        taggingStore,
+        ANCHOR_BLOCK_HEADER,
+        finalizedBlockNumber,
+        JOB_ID,
+      );
+
+      expect(logs).toHaveLength(4);
+      expect(await taggingStore.getHighestFinalizedIndex(constrainedSecret, JOB_ID)).toBe(1);
+      expect(await taggingStore.getHighestAgedIndex(constrainedSecret, JOB_ID)).toBeUndefined();
+      expect(await taggingStore.getHighestFinalizedIndex(unconstrainedSecret, JOB_ID)).toBe(5);
+    });
+  });
+
   it('caps the node query at anchorBlockNumber + 1 (toBlock exclusive)', async () => {
-    const [secret] = await makeSecrets(1);
+    const [secret] = await makeSecrets(1, AppTaggingSecretKind.UNCONSTRAINED);
     const anchorBlock = BlockNumber(10);
     const header = BlockHeader.random({ blockNumber: anchorBlock, timestamp: CURRENT_TIMESTAMP });
     const finalizedBlockNumber = BlockNumber(10);
@@ -296,6 +428,6 @@ describe('syncTaggedPrivateLogs', () => {
   });
 });
 
-function makeSecrets(count: number): Promise<AppTaggingSecret[]> {
-  return Promise.all(Array.from({ length: count }, () => randomAppTaggingSecret(AppTaggingSecretKind.UNCONSTRAINED)));
+function makeSecrets(count: number, kind: AppTaggingSecretKind): Promise<AppTaggingSecret[]> {
+  return Promise.all(Array.from({ length: count }, () => randomAppTaggingSecret(kind)));
 }

--- a/yarn-project/pxe/src/tagging/recipient_sync/sync_tagged_private_logs.ts
+++ b/yarn-project/pxe/src/tagging/recipient_sync/sync_tagged_private_logs.ts
@@ -139,16 +139,13 @@ function getIndexRangesForSecrets(
 ): Promise<PendingSecret[]> {
   return Promise.all(
     secrets.map(async secret => {
-      const isConstrained = secret.kind === AppTaggingSecretKind.CONSTRAINED;
       const currentHighestFinalizedIndex = await taggingStore.getHighestFinalizedIndex(secret, jobId);
 
-      let start: number;
-      if (isConstrained) {
-        start = currentHighestFinalizedIndex === undefined ? 0 : currentHighestFinalizedIndex + 1;
-      } else {
-        const currentHighestAgedIndex = await taggingStore.getHighestAgedIndex(secret, jobId);
-        start = currentHighestAgedIndex === undefined ? 0 : currentHighestAgedIndex + 1;
-      }
+      const highestIndexBeforeStart =
+        secret.kind === AppTaggingSecretKind.CONSTRAINED
+          ? currentHighestFinalizedIndex
+          : await taggingStore.getHighestAgedIndex(secret, jobId);
+      const start = highestIndexBeforeStart === undefined ? 0 : highestIndexBeforeStart + 1;
 
       const end = (currentHighestFinalizedIndex ?? 0) + UNFINALIZED_TAGGING_INDEXES_WINDOW_LEN + 1;
 
@@ -221,32 +218,29 @@ async function processConstrainedResults(
   // Find where the contiguous run of indexes ends. Constrained delivery guarantees there are no logs after the
   // first gap, so all logs in the batch are within this prefix.
   const indexesWithLogs = new Set(logsWithIndexes.map(l => l.taggingIndex));
-  let contiguousEnd = pending.start;
-  while (contiguousEnd < pending.end && indexesWithLogs.has(contiguousEnd)) {
-    contiguousEnd++;
+  let firstMissingIndex = pending.start;
+  while (firstMissingIndex < pending.end && indexesWithLogs.has(firstMissingIndex)) {
+    firstMissingIndex++;
   }
 
+  // Finalize any logs before the gap. The nullifier for a constrained-delivery log is emitted in the same
+  // transaction, guaranteeing the log cannot disappear once included, so we persist the highest finalized
+  // index even when a gap stops the scan. This lets the next sync round skip already-finalized indexes.
   const { highestFinalizedIndex } = findHighestIndexes(logsWithIndexes, currentTimestamp, finalizedBlockNumber);
 
   if (highestFinalizedIndex !== undefined) {
     await taggingStore.updateHighestFinalizedIndex(pending.secret, highestFinalizedIndex, jobId);
+
+    if (firstMissingIndex >= pending.end) {
+      return {
+        secret: pending.secret,
+        start: pending.end,
+        end: highestFinalizedIndex + UNFINALIZED_TAGGING_INDEXES_WINDOW_LEN + 1,
+      };
+    }
   }
 
-  // Gap found — the contiguous sequence has ended, no further logs to scan.
-  if (contiguousEnd < pending.end) {
-    return undefined;
-  }
-
-  // All queried indexes had logs. Advance the window only if the finalized index moved.
-  if (highestFinalizedIndex === undefined) {
-    return undefined;
-  }
-
-  return {
-    secret: pending.secret,
-    start: pending.end,
-    end: highestFinalizedIndex + UNFINALIZED_TAGGING_INDEXES_WINDOW_LEN + 1,
-  };
+  return undefined;
 }
 
 /**

--- a/yarn-project/pxe/src/tagging/recipient_sync/sync_tagged_private_logs.ts
+++ b/yarn-project/pxe/src/tagging/recipient_sync/sync_tagged_private_logs.ts
@@ -3,7 +3,7 @@ import { isDefined } from '@aztec/foundation/types';
 import type { BlockHash } from '@aztec/stdlib/block';
 import type { AztecNode } from '@aztec/stdlib/interfaces/client';
 import type { AppTaggingSecret, LogResult } from '@aztec/stdlib/logs';
-import { SiloedTag } from '@aztec/stdlib/logs';
+import { AppTaggingSecretKind, SiloedTag } from '@aztec/stdlib/logs';
 import type { BlockHeader } from '@aztec/stdlib/tx';
 
 import type { RecipientTaggingStore } from '../../storage/tagging_store/recipient_tagging_store.js';
@@ -13,11 +13,12 @@ import { findHighestIndexes } from './utils/find_highest_indexes.js';
 
 /**
  * Fetches and syncs tagged private logs for multiple sender-recipient pairs, batching tag queries across all secrets
- * into shared RPC calls.
+ * into shared RPC calls. Handles both constrained and unconstrained secrets, which differ in their scan strategy
+ * but share the same batching infrastructure.
  *
- * # Explanation of how the algorithm works
+ * # Unconstrained secrets
  *
- * For each secret we sync logs that correspond to the tagging index range
+ * For each unconstrained secret we sync logs that correspond to the tagging index range
  * (highestAgedIndex, highestFinalizedIndex + WINDOW_LEN]
  *
  * highestAgedIndex is the highest index that was used in a tx that is included in a block at least
@@ -54,11 +55,23 @@ import { findHighestIndexes } from './utils/find_highest_indexes.js';
  * the highest finalized index. If that index was already used, they will throw an error. For this reason we
  * don't have to look further than `highestFinalizedIndex + WINDOW_LEN`.
  *
- * ## Batching across secrets
+ * # Constrained secrets
  *
- * Instead of running one RPC call per secret, we merge tags from all pending secrets into a single flat array,
- * make one batched `getAllPrivateLogsByTags` call (which internally chunks at MAX_RPC_LEN), then split results
- * back per secret using tracked offsets. Only secrets whose window advanced are kept for the next iteration.
+ * Constrained delivery enforces a contiguous index sequence (each send proves the predecessor's nullifier,
+ * chaining back to the handshake), so there is only one sender and indexes are sequential. This means:
+ * - The lower bound is `highestFinalizedIndex + 1`. The `highestAgedIndex` mechanism is unnecessary because
+ *   the nullifier chain prevents out-of-order index usage: no device can fill in a lower index after a higher
+ *   one is already on-chain.
+ * - The scan stops at the first gap in the index sequence. If all indexes in the batch have logs, the window
+ *   advances. If a gap is found, the sequence has ended and no further logs exist.
+ * - The upper bound is the same as unconstrained: `highestFinalizedIndex + WINDOW_LEN`.
+ *
+ * # Batching across secrets
+ *
+ * Instead of running one RPC call per secret, we merge tags from all pending secrets (both constrained and
+ * unconstrained) into a single flat array, make one batched `getAllPrivateLogsByTags` call (which internally
+ * chunks at MAX_RPC_LEN), then split results back per secret using tracked offsets. Only secrets whose window
+ * advanced are kept for the next iteration.
  */
 export async function syncTaggedPrivateLogs(
   secrets: AppTaggingSecret[],
@@ -96,7 +109,12 @@ export async function syncTaggedPrivateLogs(
 
         // Persist new indexes. If the finalized index moved forward, the window advances
         // and we need another round for this secret.
-        return await updateIndexesAndAdvanceWindow(
+        const processForKind =
+          pendingSecret.secret.kind === AppTaggingSecretKind.CONSTRAINED
+            ? processConstrainedResults
+            : processUnconstrainedResults;
+
+        return await processForKind(
           pendingSecret,
           logsFoundWithSecret,
           taggingStore,
@@ -121,12 +139,17 @@ function getIndexRangesForSecrets(
 ): Promise<PendingSecret[]> {
   return Promise.all(
     secrets.map(async secret => {
-      const [currentHighestAgedIndex, currentHighestFinalizedIndex] = await Promise.all([
-        taggingStore.getHighestAgedIndex(secret, jobId),
-        taggingStore.getHighestFinalizedIndex(secret, jobId),
-      ]);
+      const isConstrained = secret.kind === AppTaggingSecretKind.CONSTRAINED;
+      const currentHighestFinalizedIndex = await taggingStore.getHighestFinalizedIndex(secret, jobId);
 
-      const start = currentHighestAgedIndex === undefined ? 0 : currentHighestAgedIndex + 1;
+      let start: number;
+      if (isConstrained) {
+        start = currentHighestFinalizedIndex === undefined ? 0 : currentHighestFinalizedIndex + 1;
+      } else {
+        const currentHighestAgedIndex = await taggingStore.getHighestAgedIndex(secret, jobId);
+        start = currentHighestAgedIndex === undefined ? 0 : currentHighestAgedIndex + 1;
+      }
+
       const end = (currentHighestFinalizedIndex ?? 0) + UNFINALIZED_TAGGING_INDEXES_WINDOW_LEN + 1;
 
       return { secret, start, end };
@@ -183,10 +206,54 @@ async function fetchLogsForSecrets(
 }
 
 /**
- * Processes a single secret's fetched logs: updates stored indexes and returns a new PendingSecret
+ * Processes fetched logs for a constrained secret. Constrained delivery guarantees contiguous index sequences,
+ * so we scan from the start of the queried range and stop at the first missing index. Only `highestFinalizedIndex`
+ * is tracked (no aged index).
+ */
+async function processConstrainedResults(
+  pending: PendingSecret,
+  logsWithIndexes: LogWithIndex[],
+  taggingStore: RecipientTaggingStore,
+  currentTimestamp: bigint,
+  finalizedBlockNumber: BlockNumber,
+  jobId: string,
+): Promise<PendingSecret | undefined> {
+  // Find where the contiguous run of indexes ends. Constrained delivery guarantees there are no logs after the
+  // first gap, so all logs in the batch are within this prefix.
+  const indexesWithLogs = new Set(logsWithIndexes.map(l => l.taggingIndex));
+  let contiguousEnd = pending.start;
+  while (contiguousEnd < pending.end && indexesWithLogs.has(contiguousEnd)) {
+    contiguousEnd++;
+  }
+
+  const { highestFinalizedIndex } = findHighestIndexes(logsWithIndexes, currentTimestamp, finalizedBlockNumber);
+
+  if (highestFinalizedIndex !== undefined) {
+    await taggingStore.updateHighestFinalizedIndex(pending.secret, highestFinalizedIndex, jobId);
+  }
+
+  // Gap found — the contiguous sequence has ended, no further logs to scan.
+  if (contiguousEnd < pending.end) {
+    return undefined;
+  }
+
+  // All queried indexes had logs. Advance the window only if the finalized index moved.
+  if (highestFinalizedIndex === undefined) {
+    return undefined;
+  }
+
+  return {
+    secret: pending.secret,
+    start: pending.end,
+    end: highestFinalizedIndex + UNFINALIZED_TAGGING_INDEXES_WINDOW_LEN + 1,
+  };
+}
+
+/**
+ * Processes a single unconstrained secret's fetched logs: updates stored indexes and returns a new PendingSecret
  * if the window needs to advance, or undefined if this secret is done.
  */
-async function updateIndexesAndAdvanceWindow(
+async function processUnconstrainedResults(
   pending: PendingSecret,
   logsWithIndexes: LogWithIndex[],
   taggingStore: RecipientTaggingStore,


### PR DESCRIPTION
## Summary

- `syncTaggedPrivateLogs` previously applied the same windowed scan to all secrets regardless of kind. The windowed scan tolerates gaps and tracks `highestAgedIndex` to handle multiple devices independently picking indexes, which is the right behavior for unconstrained delivery but unnecessarily conservative for constrained delivery.
- Constrained delivery enforces a contiguous index sequence through the nullifier chain (each send proves the predecessor), so the recipient can use a simpler scan: start at `highestFinalizedIndex + 1`, stop at the first missing index. No aged index tracking needed since out-of-order index usage is impossible.
- Both kinds still share the same RPC batch. The dispatch is a single ternary in the main loop that selects between `processConstrainedResults` and `processUnconstrainedResults`, which share the same signature.

Fixes F-703