### PR TITLE
chore: improve noir contract test tooling

### DIFF
--- a/noir-projects/noir-contracts/bootstrap.sh
+++ b/noir-projects/noir-contracts/bootstrap.sh
@@ -195,18 +195,23 @@ function test_cmds {
   fi
 }
 
-function test {
-  # Starting txe servers with incrementing port numbers.
-  # Base port is below the Linux ephemeral range (32768-60999) to avoid conflicts.
-  local txe_base_port=14730
-  export NUM_TXES=1
+function start_txes {
+  local txe_base_port=$1
+  local num_txes=$2
   trap 'kill $(jobs -p) &>/dev/null || true' EXIT
-  for i in $(seq 0 $((NUM_TXES-1))); do
+
+  for i in $(seq 0 $((num_txes-1))); do
     check_port $((txe_base_port + i)) || echo "WARNING: port $((txe_base_port + i)) is in use, TXE $i may fail to start"
     (cd $root/yarn-project/txe && UV_THREADPOOL_SIZE=8 LOG_LEVEL=silent TXE_PORT=$((txe_base_port + i)) yarn start) >/dev/null &
   done
+}
+
+function wait_for_txes {
+  local txe_base_port=$1
+  local num_txes=$2
+
   echo "Waiting for TXE's to start..."
-  for i in $(seq 0 $((NUM_TXES-1))); do
+  for i in $(seq 0 $((num_txes-1))); do
       local j=0
       local port=$((txe_base_port + i))
       while ! nc -z 127.0.0.1 $port &>/dev/null; do
@@ -219,9 +224,57 @@ function test {
         j=$((j+1))
       done
   done
+}
+
+function start_focused_txe {
+  local txe_base_port=$1
+  export NUM_TXES=1
+  start_txes "$txe_base_port" "$NUM_TXES"
+  wait_for_txes "$txe_base_port" "$NUM_TXES"
+  export NARGO_FOREIGN_CALL_TIMEOUT=300000
+}
+
+function test {
+  # Starting txe servers with incrementing port numbers.
+  # Base port is below the Linux ephemeral range (32768-60999) to avoid conflicts.
+  local txe_base_port=14730
+  export NUM_TXES=1
+  start_txes "$txe_base_port" "$NUM_TXES"
+  wait_for_txes "$txe_base_port" "$NUM_TXES"
 
   export NARGO_FOREIGN_CALL_TIMEOUT=300000
   test_cmds | filter_test_cmds | parallelize
+}
+
+function test-package {
+  if [ "$#" -ne 1 ]; then
+    echo_stderr "Usage: ./bootstrap.sh test-package <package>"
+    return 1
+  fi
+
+  local package=$1
+  local txe_base_port=14730
+  start_focused_txe "$txe_base_port"
+
+  $NARGO test \
+    --silence-warnings \
+    --skip-brillig-constraints-check \
+    --oracle-resolver "http://127.0.0.1:$txe_base_port" \
+    --package "$package"
+}
+
+function test-one {
+  if [ "$#" -ne 2 ]; then
+    echo_stderr "Usage: ./bootstrap.sh test-one <package> <exact_test_name>"
+    return 1
+  fi
+
+  local package=$1
+  local test_name=$2
+  local txe_base_port=14730
+  start_focused_txe "$txe_base_port"
+
+  $root/noir-projects/scripts/run_test.sh noir-contracts "$package" "$test_name" "$txe_base_port"
 }
 
 function format {

--- a/noir-projects/noir-contracts/bootstrap.sh
+++ b/noir-projects/noir-contracts/bootstrap.sh
@@ -31,6 +31,8 @@ export BB=${BB:-../../barretenberg/cpp/build/bin/bb}
 export NARGO=${NARGO:-../../noir/noir-repo/target/release/nargo}
 export BB_HASH=${BB_HASH:-$(../../barretenberg/cpp/bootstrap.sh hash)}
 export NOIR_HASH=${NOIR_HASH:-$(../../noir/bootstrap.sh hash)}
+# Below the Linux ephemeral range (32768-60999) to reduce accidental port conflicts.
+DEFAULT_TXE_PORT=14730
 
 # Set common flags for parallel.
 export PARALLEL_FLAGS="-j${PARALLELISM:-16} --halt now,fail=1 --memsuspend $(memsuspend_limit)"
@@ -167,6 +169,7 @@ function build {
 }
 
 function test_cmds {
+  local txe_port=${1:-$DEFAULT_TXE_PORT}
   local folder_name
   if [ -n "${DOCS_WORKING_DIR:-}" ]; then
     folder_name="examples"
@@ -179,71 +182,44 @@ function test_cmds {
 
   # Fairies want to run these tests on every PR
   if [ "${TARGET_BRANCH:-}" = "merge-train/fairies" ]; then
-    i=0
     $NARGO test --list-tests --silence-warnings | sort | while read -r package test; do
-      port=$((14730 + (i++ % ${NUM_TXES:-1})))
-      echo "disabled-cache noir-projects/scripts/run_test.sh noir-contracts $package $test $port"
+      echo "disabled-cache noir-projects/scripts/run_test.sh noir-contracts $package $test $txe_port"
     done
   else
     local -A cache
-    i=0
     $NARGO test --list-tests --silence-warnings | sort | while read -r package test; do
-      port=$((14730 + (i++ % ${NUM_TXES:-1})))
       [ -z "${cache[$package]:-}" ] && cache[$package]=$(get_contract_hash $package $folder_name)
-      echo "${cache[$package]} noir-projects/scripts/run_test.sh noir-contracts $package $test $port"
+      echo "${cache[$package]} noir-projects/scripts/run_test.sh noir-contracts $package $test $txe_port"
     done
   fi
 }
 
-function start_txes {
-  local txe_base_port=$1
-  local num_txes=$2
+function start_txe {
+  local txe_port=$1
   trap 'kill $(jobs -p) &>/dev/null || true' EXIT
 
-  for i in $(seq 0 $((num_txes-1))); do
-    check_port $((txe_base_port + i)) || echo "WARNING: port $((txe_base_port + i)) is in use, TXE $i may fail to start"
-    (cd $root/yarn-project/txe && UV_THREADPOOL_SIZE=8 LOG_LEVEL=silent TXE_PORT=$((txe_base_port + i)) yarn start) >/dev/null &
+  check_port "$txe_port" || echo "WARNING: port $txe_port is in use, TXE may fail to start"
+  (cd $root/yarn-project/txe && UV_THREADPOOL_SIZE=8 LOG_LEVEL=silent TXE_PORT=$txe_port yarn start) >/dev/null &
+
+  echo "Waiting for TXE to start..."
+  local j=0
+  while ! nc -z 127.0.0.1 "$txe_port" &>/dev/null; do
+    if [ $j == 60 ]; then
+      echo "TXE failed to start on port $txe_port after 60s." >&2
+      check_port "$txe_port"
+      exit 1
+    fi
+    sleep 1
+    j=$((j+1))
   done
-}
 
-function wait_for_txes {
-  local txe_base_port=$1
-  local num_txes=$2
-
-  echo "Waiting for TXE's to start..."
-  for i in $(seq 0 $((num_txes-1))); do
-      local j=0
-      local port=$((txe_base_port + i))
-      while ! nc -z 127.0.0.1 $port &>/dev/null; do
-        if [ $j == 60 ]; then
-          echo "TXE $i failed to start on port $port after 60s." >&2
-          check_port $port
-          exit 1
-        fi
-        sleep 1
-        j=$((j+1))
-      done
-  done
-}
-
-function start_focused_txe {
-  local txe_base_port=$1
-  export NUM_TXES=1
-  start_txes "$txe_base_port" "$NUM_TXES"
-  wait_for_txes "$txe_base_port" "$NUM_TXES"
   export NARGO_FOREIGN_CALL_TIMEOUT=300000
 }
 
 function test {
-  # Starting txe servers with incrementing port numbers.
-  # Base port is below the Linux ephemeral range (32768-60999) to avoid conflicts.
-  local txe_base_port=14730
-  export NUM_TXES=1
-  start_txes "$txe_base_port" "$NUM_TXES"
-  wait_for_txes "$txe_base_port" "$NUM_TXES"
-
-  export NARGO_FOREIGN_CALL_TIMEOUT=300000
-  test_cmds | filter_test_cmds | parallelize
+  local txe_port=$DEFAULT_TXE_PORT
+  start_txe "$txe_port"
+  test_cmds "$txe_port" | filter_test_cmds | parallelize
 }
 
 function test-package {
@@ -253,13 +229,13 @@ function test-package {
   fi
 
   local package=$1
-  local txe_base_port=14730
-  start_focused_txe "$txe_base_port"
+  local txe_port=$DEFAULT_TXE_PORT
+  start_txe "$txe_port"
 
   $NARGO test \
     --silence-warnings \
     --skip-brillig-constraints-check \
-    --oracle-resolver "http://127.0.0.1:$txe_base_port" \
+    --oracle-resolver "http://127.0.0.1:$txe_port" \
     --package "$package"
 }
 
@@ -271,10 +247,10 @@ function test-one {
 
   local package=$1
   local test_name=$2
-  local txe_base_port=14730
-  start_focused_txe "$txe_base_port"
+  local txe_port=$DEFAULT_TXE_PORT
+  start_txe "$txe_port"
 
-  $root/noir-projects/scripts/run_test.sh noir-contracts "$package" "$test_name" "$txe_base_port"
+  $root/noir-projects/scripts/run_test.sh noir-contracts "$package" "$test_name" "$txe_port"
 }
 
 function format {

--- a/yarn-project/stdlib/scripts/copy-contracts.sh
+++ b/yarn-project/stdlib/scripts/copy-contracts.sh
@@ -12,7 +12,16 @@ cp "../../noir-projects/noir-contracts/target/token_contract-Token.json" ./fixtu
 # These allow TypeScript to skip expensive hash computations and also serve as cross-validation
 # that the C++ and TypeScript implementations are equivalent.
 bb=$(../../barretenberg/cpp/scripts/find-bb)
+if [ ! -x "$bb" ]; then
+  echo "Missing Barretenberg binary: $bb" >&2
+  if [ "$(basename "$bb")" = "bb-avm" ]; then
+    echo "bb-avm is required to post-process contract fixtures." >&2
+    echo "Rebuild Barretenberg with AVM enabled." >&2
+    echo "If using bootstrap, ensure AVM is not set to 0: AVM=1 ./bootstrap.sh build_native" >&2
+  fi
+  exit 1
+fi
 for fixture in ./fixtures/Benchmarking.test.json ./fixtures/Test.test.json ./fixtures/Token.test.json; do
   echo "Post-processing $fixture..."
-  $bb aztec_process -i "$fixture" -o "$fixture"
+  "$bb" aztec_process -i "$fixture" -o "$fixture"
 done


### PR DESCRIPTION
Adds focused test helpers and clearer missing bb-avm error. 

I ran into a missing `bb-avm` in my local build and there nothing to tell me that it was missing until deeper down the stack.

Whenever I added new tests I also found myself running TXE and calling out to nargo manually rather than ever using the bootstrap scripts. I added two test commands which will start a single TXE and run a single contract package or a single test through the bootstrap script. 