### PR TITLE
fix(pxe): prevent contract sync deadlock on nested syncs

### DIFF
--- a/yarn-project/pxe/src/contract_sync/contract_sync_service.test.ts
+++ b/yarn-project/pxe/src/contract_sync/contract_sync_service.test.ts
@@ -1,5 +1,6 @@
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { createLogger } from '@aztec/foundation/log';
+import { executeTimeout } from '@aztec/foundation/timer';
 import { FunctionCall, FunctionSelector, FunctionType } from '@aztec/stdlib/abi';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
 import type { ContractInstanceWithAddress } from '@aztec/stdlib/contract';
@@ -11,7 +12,7 @@ import { mock } from 'jest-mock-extended';
 
 import type { ContractStore } from '../storage/contract_store/contract_store.js';
 import type { NoteStore } from '../storage/note_store/note_store.js';
-import { ContractSyncService } from './contract_sync_service.js';
+import { ContractSyncService, MAX_CONCURRENT_SCOPE_SYNCS } from './contract_sync_service.js';
 
 describe('ContractSyncService', () => {
   let aztecNode: ReturnType<typeof mock<AztecNode>>;
@@ -135,6 +136,78 @@ describe('ContractSyncService', () => {
       ]);
       await Promise.all([p1, p2]);
       expectSyncedScopes([scopeA], [scopeB]);
+    });
+
+    // Regression test for the nested-sync deadlock. Each outer sync holds a slot while its sync_state triggers a
+    // nested sync (a cross-contract utility call) that needs a slot of its own. With a single shared limiter, the
+    // MAX_CONCURRENT_SCOPE_SYNCS outer syncs would hold every slot while awaiting nested syncs that can never
+    // acquire one. Per-call limiters give the nested syncs their own slots, so the batch completes.
+    it('does not deadlock when concurrent syncs each trigger a nested sync', async () => {
+      const outerContracts = Array.from({ length: MAX_CONCURRENT_SCOPE_SYNCS }, (_, i) =>
+        AztecAddress.fromBigInt(1000n + BigInt(i)),
+      );
+      const nestedContracts = Array.from({ length: MAX_CONCURRENT_SCOPE_SYNCS }, (_, i) =>
+        AztecAddress.fromBigInt(2000n + BigInt(i)),
+      );
+      const nestedByOuter = new Map(outerContracts.map((outer, i) => [outer.toString(), nestedContracts[i]]));
+
+      utilityExecutor.mockImplementation(async (call, scopes) => {
+        const nested = nestedByOuter.get(call.to.toString());
+        if (nested) {
+          await service.ensureContractSynced(nested, null, utilityExecutor, anchorBlockHeader, jobId, scopes);
+        }
+      });
+
+      const syncAll = Promise.all(
+        outerContracts.map(outer =>
+          service.ensureContractSynced(outer, null, utilityExecutor, anchorBlockHeader, jobId, [scopeA]),
+        ),
+      );
+
+      await executeTimeout(() => syncAll, 2000, 'nested sync deadlock');
+    });
+
+    it('bounds the number of concurrently syncing scopes within a single call', async () => {
+      const scopes = Array.from({ length: MAX_CONCURRENT_SCOPE_SYNCS + 3 }, (_, i) =>
+        AztecAddress.fromBigInt(500n + BigInt(i)),
+      );
+
+      let inFlight = 0;
+      let peak = 0;
+      const releases: Array<() => void> = [];
+      utilityExecutor.mockImplementation(() => {
+        inFlight++;
+        peak = Math.max(peak, inFlight);
+        return new Promise<void>(resolve =>
+          releases.push(() => {
+            inFlight--;
+            resolve();
+          }),
+        );
+      });
+
+      const syncAll = service.ensureContractSynced(
+        contractAddress,
+        null,
+        utilityExecutor,
+        anchorBlockHeader,
+        jobId,
+        scopes,
+      );
+
+      // The first wave saturates the limiter; the remaining scopes must queue rather than run.
+      await tick();
+      expect(inFlight).toBe(MAX_CONCURRENT_SCOPE_SYNCS);
+
+      // Releasing one in-flight sync admits exactly one queued scope, so the cap is never exceeded.
+      while (releases.length > 0) {
+        releases.shift()!();
+        await tick();
+      }
+
+      await syncAll;
+      expect(peak).toBe(MAX_CONCURRENT_SCOPE_SYNCS);
+      expect(utilityExecutor).toHaveBeenCalledTimes(scopes.length);
     });
 
     it('re-syncs if first sync fails', async () => {
@@ -400,4 +473,7 @@ describe('ContractSyncService', () => {
   };
 
   const expectNoSync = () => expect(utilityExecutor).not.toHaveBeenCalled();
+
+  /** Yields to the macrotask queue, draining all pending microtasks (semaphore acquires/releases) in between. */
+  const tick = () => new Promise<void>(resolve => setImmediate(resolve));
 });

--- a/yarn-project/pxe/src/contract_sync/contract_sync_service.ts
+++ b/yarn-project/pxe/src/contract_sync/contract_sync_service.ts
@@ -12,8 +12,11 @@ import type { ContractStore } from '../storage/contract_store/contract_store.js'
 import type { NoteStore } from '../storage/note_store/note_store.js';
 import { syncScope, verifyCurrentClassId } from './helpers.js';
 
-/** Maximum number of scope syncs running concurrently across the PXE. */
-const MAX_CONCURRENT_SCOPE_SYNCS = 5;
+/**
+ * Maximum number of scope syncs running concurrently within a single sync call. Sized to trade off parallelism
+ * on non-ACIR work (node RPC, note store reads) against memory pressure from concurrent circuit execution.
+ */
+export const MAX_CONCURRENT_SCOPE_SYNCS = 5;
 
 /**
  * Service for syncing the private state of contracts and verifying that the PXE holds the current class artifact.
@@ -32,11 +35,6 @@ export class ContractSyncService implements StagedStore {
   // Tracks class ID verification per contract. Keyed by contract address only (no scope), since
   // class ID verification is scope-independent. Cleared on wipe/discard.
   private classIdVerificationCache: Map<string, Promise<void>> = new Map();
-
-  // Bounds the number of scope syncs running concurrently. Scopes beyond this limit queue here. Sized to trade off
-  // parallelism on non-ACIR work (node RPC, note store reads) against memory pressure from concurrent circuit
-  // execution.
-  #syncSlot = new Semaphore(MAX_CONCURRENT_SCOPE_SYNCS);
 
   constructor(
     private aztecNode: AztecNode,
@@ -119,9 +117,17 @@ export class ContractSyncService implements StagedStore {
     const verifyPromise = this.#verifyClassId(contractAddress, anchorBlockHeader);
     const syncNullifiersPromise = this.#syncNoteNullifiers(contractAddress, anchorBlockHeader, jobId, scopesToSync);
 
+    // We build a new semaphore for each sync call, so it rate-limits the scopes within that single call. We do
+    // this so that if these scope syncs trigger nested syncs, the nested ones can execute without causing a deadlock.
+    const syncSlot = new Semaphore(MAX_CONCURRENT_SCOPE_SYNCS);
+
     for (const scope of scopesToSync) {
       const key = toKey(contractAddress, scope);
-      const promise = Promise.all([verifyPromise, syncNullifiersPromise, this.#runBounded(() => syncScopeFn(scope))])
+      const promise = Promise.all([
+        verifyPromise,
+        syncNullifiersPromise,
+        runBounded(syncSlot, () => syncScopeFn(scope)),
+      ])
         .then(() => {})
         .catch(err => {
           this.syncedContracts.delete(key);
@@ -165,16 +171,6 @@ export class ContractSyncService implements StagedStore {
     await noteService.syncNoteNullifiers(contractAddress, scopes);
   }
 
-  /** Runs fn while holding a slot in #syncSlot, bounding total concurrent scope syncs. */
-  async #runBounded<T>(fn: () => Promise<T>): Promise<T> {
-    await this.#syncSlot.acquire();
-    try {
-      return await fn();
-    } finally {
-      this.#syncSlot.release();
-    }
-  }
-
   /** Collects all relevant scope promises (including in-flight ones from concurrent calls) and awaits them. */
   async #awaitSync(contractAddress: AztecAddress, scopes: AztecAddress[]): Promise<void> {
     const promises = scopes
@@ -186,4 +182,14 @@ export class ContractSyncService implements StagedStore {
 
 function toKey(contract: AztecAddress, scope: AztecAddress) {
   return `${contract.toString()}:${scope.toString()}`;
+}
+
+/** Runs fn while holding a slot in the given semaphore, bounding concurrent scope syncs within a single call. */
+async function runBounded<T>(syncSlot: Semaphore, fn: () => Promise<T>): Promise<T> {
+  await syncSlot.acquire();
+  try {
+    return await fn();
+  } finally {
+    syncSlot.release();
+  }
 }


### PR DESCRIPTION
## Why

The contract sync service uses a semaphore to limit how many scope syncs run concurrently. The problem: a scope sync can trigger a nested sync (a cross-contract utility call from `sync_state`) that needs a slot of its own. So when 5 syncs each hold a slot and each waits on a nested sync, no slots are left for those nested syncs, and everything deadlocks. And because the semaphore was shared across the whole PXE, unrelated transactions could fill it and trigger the same deadlock.

## Fix

Give each sync call its own semaphore, rate-limiting only the scopes within that single call. Those scopes don't depend on each other, so bounding them can't deadlock. A nested sync builds its own limiter, so it always has a slot and can make progress. We still cap resource usage when a single call has many scopes.
