### PR TITLE
fix(ci3): fetch merge-queue base ref on EC2 for docs gate

### DIFF
--- a/ci3/bootstrap_ec2
+++ b/ci3/bootstrap_ec2
@@ -183,6 +183,9 @@ container_script=$(
   git fetch --depth 1 origin $current_commit
   git checkout FETCH_HEAD
   git checkout -b \$REF_NAME
+  if [ -n "\${TARGET_BRANCH:-}" ]; then
+    git fetch --depth 1 origin "\${TARGET_BRANCH}:refs/remotes/origin/\${TARGET_BRANCH}"
+  fi
   source ci3/source
   ci_log_id=\$CI_LOG_ID
   log_ci_run \$ci_log_id


### PR DESCRIPTION
## Summary

- After the shallow EC2 checkout of the test commit, also fetch `TARGET_BRANCH` (e.g. `next` on merge queue) as `origin/<base>`.
- Fixes merge-queue-heavy failures where `docs/bootstrap.sh` orphan-url check exits with `cannot resolve base branch origin/next` (e.g. PR #23856 dequeue, log [f3da16a873df6e9b](http://ci.aztec-labs.com/f3da16a873df6e9b)).
