### PR TITLE
chore(ci): notify slack on benchmark success

### DIFF
--- a/.github/workflows/nightly-bench-10tps.yml
+++ b/.github/workflows/nightly-bench-10tps.yml
@@ -187,8 +187,8 @@ jobs:
           NO_SPOT: 1
         run: ./.github/ci3.sh network-teardown bench-10tps bench-10tps
 
-  notify-failure:
-    if: ${{ always() && failure() && github.event_name != 'workflow_dispatch' && (github.event_name != 'schedule' || github.repository == 'AztecProtocol/aztec-packages') }}
+  notify:
+    if: (success() || failure()) && github.event_name != 'workflow_dispatch' && (github.event_name != 'schedule' || github.repository == 'AztecProtocol/aztec-packages')
     needs:
       - select-image
       - deploy-bench-10tps-network
@@ -202,7 +202,20 @@ jobs:
         with:
           ref: ${{ needs.select-image.outputs.source_ref }}
 
-      - name: Notify Slack on failure
+      - name: Notify Slack on success
+        if: success()
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+        run: |
+          export CI=1
+          IMAGE="${{ needs.select-image.outputs.image_label || 'unknown' }}"
+          RUN_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          ./ci3/slack_notify \
+            "Nightly 10 TPS benchmark PASSED (image ${IMAGE}) :white_check_mark: <${RUN_URL}|View Run>" \
+            "#alerts-next-scenario"
+
+      - name: Notify Slack and dispatch ClaudeBox on failure
+        if: failure()
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}

--- a/.github/workflows/nightly-spartan-bench.yml
+++ b/.github/workflows/nightly-spartan-bench.yml
@@ -192,8 +192,8 @@ jobs:
           NO_SPOT: 1
         run: ./.github/ci3.sh network-teardown tps-scenario nightly-bench
 
-  notify-bench-failure:
-    if: ${{ always() && failure() && github.event_name != 'workflow_dispatch' && (github.event_name != 'schedule' || github.repository == 'AztecProtocol/aztec-packages') }}
+  notify-bench:
+    if: (success() || failure()) && github.event_name != 'workflow_dispatch' && (github.event_name != 'schedule' || github.repository == 'AztecProtocol/aztec-packages')
     needs:
       - select-image
       - deploy-bench-network
@@ -207,7 +207,20 @@ jobs:
         with:
           ref: ${{ needs.select-image.outputs.source_ref }}
 
+      - name: Notify Slack on success
+        if: success()
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+        run: |
+          export CI=1
+          TAG="${{ needs.select-image.outputs.nightly_tag || 'unknown' }}"
+          RUN_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          ./ci3/slack_notify \
+            "Nightly Spartan TPS benchmarks PASSED (nightly tag ${TAG}) :white_check_mark: <${RUN_URL}|View Run>" \
+            "#alerts-next-scenario"
+
       - name: Notify Slack and dispatch ClaudeBox on failure
+        if: failure()
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
@@ -346,8 +359,8 @@ jobs:
           NO_SPOT: 1
         run: ./.github/ci3.sh network-teardown prove-n-tps-fake prove-n-tps-fake
 
-  notify-proving-failure:
-    if: ${{ always() && failure() && github.event_name != 'workflow_dispatch' && (github.event_name != 'schedule' || github.repository == 'AztecProtocol/aztec-packages') }}
+  notify-proving:
+    if: (success() || failure()) && github.event_name != 'workflow_dispatch' && (github.event_name != 'schedule' || github.repository == 'AztecProtocol/aztec-packages')
     needs:
       - select-image
       - deploy-proving-network
@@ -361,7 +374,20 @@ jobs:
         with:
           ref: ${{ needs.select-image.outputs.source_ref }}
 
+      - name: Notify Slack on success
+        if: success()
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+        run: |
+          export CI=1
+          TAG="${{ needs.select-image.outputs.nightly_tag || 'unknown' }}"
+          RUN_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          ./ci3/slack_notify \
+            "Nightly proving benchmarks passed (nightly tag ${TAG}) :white_check_mark: <${RUN_URL}|View Run>" \
+            "#alerts-next-scenario"
+
       - name: Notify Slack and dispatch ClaudeBox on failure
+        if: failure()
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
@@ -500,8 +526,8 @@ jobs:
           NO_SPOT: 1
         run: ./.github/ci3.sh network-teardown block-capacity nightly-block-capacity
 
-  notify-block-capacity-failure:
-    if: ${{ always() && failure() && github.event_name != 'workflow_dispatch' && (github.event_name != 'schedule' || github.repository == 'AztecProtocol/aztec-packages') }}
+  notify-block-capacity:
+    if: (success() || failure()) && github.event_name != 'workflow_dispatch' && (github.event_name != 'schedule' || github.repository == 'AztecProtocol/aztec-packages')
     needs:
       - select-image
       - deploy-block-capacity-network
@@ -515,7 +541,20 @@ jobs:
         with:
           ref: ${{ needs.select-image.outputs.source_ref }}
 
+      - name: Notify Slack on success
+        if: success()
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+        run: |
+          export CI=1
+          TAG="${{ needs.select-image.outputs.nightly_tag || 'unknown' }}"
+          RUN_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          ./ci3/slack_notify \
+            "Nightly block capacity benchmarks passed (nightly tag ${TAG}) :white_check_mark: <${RUN_URL}|View Run>" \
+            "#alerts-next-scenario"
+
       - name: Notify Slack and dispatch ClaudeBox on failure
+        if: failure()
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}

--- a/.github/workflows/weekly-proving-bench.yml
+++ b/.github/workflows/weekly-proving-bench.yml
@@ -188,8 +188,8 @@ jobs:
           NO_SPOT: 1
         run: ./.github/ci3.sh network-teardown prove-n-tps-real prove-n-tps-real
 
-  notify-failure:
-    if: ${{ always() && failure() && github.event_name != 'workflow_dispatch' && (github.event_name != 'schedule' || github.repository == 'AztecProtocol/aztec-packages') }}
+  notify:
+    if: (success() || failure()) && github.event_name != 'workflow_dispatch' && (github.event_name != 'schedule' || github.repository == 'AztecProtocol/aztec-packages')
     needs:
       - select-image
       - deploy-real-proving-network
@@ -203,7 +203,20 @@ jobs:
         with:
           ref: ${{ needs.select-image.outputs.source_ref }}
 
+      - name: Notify Slack on success
+        if: success()
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+        run: |
+          export CI=1
+          TAG="${{ needs.select-image.outputs.nightly_tag || 'unknown' }}"
+          RUN_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          ./ci3/slack_notify \
+            "Weekly real proving benchmark passed (nightly tag ${TAG}) :white_check_mark: <${RUN_URL}|View Run>" \
+            "#alerts-next-scenario"
+
       - name: Notify Slack and dispatch ClaudeBox on failure
+        if: failure()
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}


### PR DESCRIPTION
Fixes [A-1149](https://linear.app/aztec-labs/issue/A-1149/have-all-benchmarks-report-to-slack-on-success-or-failure)