### PR TITLE
fix(p2p): stop checkpoint-replay storm when pruning to an uncheckpointed block

### DIFF
--- a/yarn-project/stdlib/src/block/l2_block_stream/l2_block_stream.test.ts
+++ b/yarn-project/stdlib/src/block/l2_block_stream/l2_block_stream.test.ts
@@ -396,6 +396,32 @@ describe('L2BlockStream', () => {
         { type: 'chain-pruned', block: makeBlockId(25), checkpoint: makeCheckpointId(25) },
       ]);
     });
+
+    // Regression test for the checkpoint-replay storm: pruning to an uncheckpointed block ahead of
+    // the checkpointed tip must not reset the checkpointed cursor, otherwise the next work() replays
+    // every checkpoint from 1 to the source tip.
+    it('does not replay checkpoints after pruning to an uncheckpointed block ahead of the checkpointed tip', async () => {
+      // Sync blocks 1-7: blocks 1-5 are checkpointed (checkpoints 1-5), blocks 6-7 uncheckpointed.
+      setRemoteTips(7, 5);
+      await blockStream.work();
+      const checkpointEventsOnSync = handler.events.filter(e => e.type === 'chain-checkpointed');
+      expect(checkpointEventsOnSync).toHaveLength(5);
+      handler.clearEvents();
+
+      // Source drops its proposed tip to block 6 (uncheckpointed, still ahead of checkpointed=5).
+      // The stream prunes the local proposed tip from 7 back to 6.
+      setRemoteTips(6, 5);
+      await blockStream.work();
+      expect(handler.events).toEqual([
+        { type: 'chain-pruned', block: makeBlockId(6), checkpoint: makeCheckpointId(5) },
+      ]);
+      handler.clearEvents();
+
+      // The next sync must NOT re-emit any chain-checkpointed events: the checkpointed cursor was
+      // left at block 5 / checkpoint 5, so there is nothing to replay.
+      await blockStream.work();
+      expect(handler.events.filter(e => e.type === 'chain-checkpointed')).toEqual([]);
+    });
   });
 
   describe('multiple blocks per checkpoint', () => {

--- a/yarn-project/stdlib/src/block/l2_block_stream/l2_tips_store_base.ts
+++ b/yarn-project/stdlib/src/block/l2_block_stream/l2_tips_store_base.ts
@@ -186,12 +186,16 @@ export abstract class L2TipsStoreBase implements L2BlockStreamEventHandler, L2Bl
       return;
     }
     await this.runInTransaction(async () => {
+      // A prune is a rollback: the proposed tip moves to the prune target unconditionally, but
+      // checkpoint-bearing cursors may only move backward. Forward-advancing them onto an
+      // uncheckpointed block leaves them on a block with no checkpoint mapping, which getCheckpointId
+      // would otherwise resolve to checkpoint zero and drive a replay storm.
       await this.saveTag('proposed', event.block);
-      await this.saveTag('checkpointed', event.block);
-      await this.saveTag('proposedCheckpoint', event.block);
-      const storeProven = await this.getBlockId('proven');
-      if (storeProven.number > event.block.number) {
-        await this.saveTag('proven', event.block);
+      for (const tag of ['checkpointed', 'proposedCheckpoint', 'proven'] as const) {
+        const current = await this.getTip(tag);
+        if (current !== undefined && current > event.block.number) {
+          await this.saveTag(tag, event.block);
+        }
       }
     });
   }

--- a/yarn-project/stdlib/src/block/test/l2_tips_store_test_suite.ts
+++ b/yarn-project/stdlib/src/block/test/l2_tips_store_test_suite.ts
@@ -541,4 +541,26 @@ export function testL2TipsStore(makeTipsStore: () => Promise<L2TipsStore>) {
     // No checkpoint for block 3 since it wasn't checkpointed
     expect(tips.proven.checkpoint.number).toEqual(CheckpointNumber.ZERO);
   });
+
+  it('keeps the checkpointed tip when pruning to an uncheckpointed block ahead of it', async () => {
+    const blocks1to5 = await Promise.all(times(5, i => makeBlock(i + 1)));
+    await tipsStore.handleBlockStreamEvent({ type: 'blocks-added', blocks: blocks1to5 });
+    const checkpoint1 = await makeCheckpoint(1, blocks1to5);
+    await tipsStore.handleBlockStreamEvent(await makeCheckpointedEvent(checkpoint1)); // checkpointed = block 5 / ckpt 1
+
+    const blocks6to7 = await Promise.all(times(2, i => makeBlock(i + 6)));
+    await tipsStore.handleBlockStreamEvent({ type: 'blocks-added', blocks: blocks6to7 }); // proposed = 7
+
+    // Prune to block 6: an uncheckpointed block AHEAD of the checkpointed tip (block 5).
+    await tipsStore.handleBlockStreamEvent({
+      type: 'chain-pruned',
+      block: makeBlockId(6),
+      checkpoint: makeCheckpointIdForBlock(5),
+    });
+
+    const tips = await tipsStore.getL2Tips();
+    expect(tips.proposed).toEqual(makeTip(6));
+    expect(tips.checkpointed.block).toEqual(makeTip(5));
+    expect(tips.checkpointed.checkpoint.number).toEqual(CheckpointNumber(1)); // must NOT be zero
+  });
 }


### PR DESCRIPTION
## Motivation

On a staging HA validator, an archiver orphan prune triggered a storm of thousands of duplicate `chain-checkpointed` events out of p2p's `L2BlockStream`.

The local tips store keeps a block number per cursor and derives the checkpoint number from a `block -> checkpoint` map that is only populated for the last block of each confirmed checkpoint. `handleChainPruned` moved the `checkpointed` and `proposedCheckpoint` cursors to the prune target unconditionally. That target is the new tip of the *proposed* chain and can be an uncheckpointed block with no mapping (in the incident, a block belonging to a not-yet-confirmed checkpoint, sitting ahead of the checkpointed tip). `getCheckpointId` then resolved that cursor to checkpoint zero, the stream computed `nextCheckpointToEmit = 0 + 1 = 1`, and it replayed every checkpoint from 1 up to the source tip.

## Approach

A prune is a rollback, so checkpoint-bearing cursors may only move *backward*. `handleChainPruned` now sets `proposed` unconditionally and clamps `checkpointed`/`proposedCheckpoint`/`proven` to the prune target only when they are ahead of it (generalizing the guard `proven` already had). In the incident the checkpointed cursor is left untouched and keeps resolving to its real checkpoint, so there is nothing to replay.

Surfacing a missing mapping *loudly* (rather than silently reporting checkpoint zero) is intentionally deferred to a stacked follow-up: doing it safely requires per-tip checkpoint ids so the store can fail loudly on genuine corruption without bricking legitimate skipped-history prunes (which would otherwise throw on the next `getL2Tips`). This PR is the minimal, behavior-preserving fix for the storm.

## Changes

- **stdlib**: `handleChainPruned` clamps checkpoint-bearing cursors backward only instead of forcing them onto the (possibly uncheckpointed) prune target.
- **stdlib (tests)**: store-level regression that a prune to an uncheckpointed block ahead of the checkpointed tip leaves the cursor intact and resolving to its real checkpoint; stream-level regression asserting no `chain-checkpointed` replay after such a prune.

Fixes A-1167