### PR TITLE
feat(ci3): give single-instance PR runs a parent dashboard log

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -112,27 +112,30 @@ case "$cmd" in
     ;;
   fast|docs|barretenberg|barretenberg-full)
     export CI_DASHBOARD="prs"
-    export JOB_ID="x-$cmd"
-    bootstrap_ec2 "./bootstrap.sh ci-$cmd"
+    # Route through multi_job_run (even for a single instance) so the runner-side
+    # orchestration — including the spot/instance request — is captured into a
+    # parent dashboard log, matching merge-queue. The job id stays "x-$cmd" so the
+    # GitHub status check name is unchanged.
+    multi_job_run "x-$cmd amd64 ci-$cmd"
     ;;
   socket-fix)
     export CI_DASHBOARD="prs"
     export JOB_ID="x-socket-fix"
     export INSTANCE_POSTFIX="socket-fix"
     export CPUS=16
-    bootstrap_ec2 "./bootstrap.sh ci-socket-fix $*"
+    # Capture the runner-side output (incl. instance request) to a parent dashboard
+    # log. No denoise here: this is an interactive debug mode where raw output matters.
+    PARENT_LOG_ID=$RUN_ID bootstrap_ec2 "./bootstrap.sh ci-socket-fix $*" 2>&1 | DUP=1 cache_log "CI run" $RUN_ID
     ;;
   full|full-no-test-cache)
     export CI_DASHBOARD="prs"
-    export JOB_ID="x-$cmd"
     export AWS_SHUTDOWN_TIME=75
-    bootstrap_ec2 "./bootstrap.sh ci-$cmd"
+    multi_job_run "x-$cmd amd64 ci-$cmd"
     ;;
   chonk-input-update)
     export CI_DASHBOARD="prs"
-    export JOB_ID="x-$cmd"
     export AWS_SHUTDOWN_TIME=90
-    bootstrap_ec2 "./bootstrap.sh ci-chonk-input-update"
+    multi_job_run "x-$cmd amd64 ci-chonk-input-update"
     ;;
   barretenberg-debug)
     export CI_DASHBOARD="nightly"


### PR DESCRIPTION
## Problem

Merge-queue runs show a top-level "parent log" on the CI dashboard that includes the **spot/instance request** (which instance type was created, spot vs on-demand). Standard PR runs don't — to see what instance a PR run got, you have to leave the dashboard and dig into the GitHub Actions console.

## Cause

The runner-side orchestration output (the `Requesting spot fleet…` line from `aws_request_instance_type`) is printed on the GA runner, *before* the remote build streams to its per-instance `CI_LOG_ID` log. Where that runner-side output lands depends on the path in `ci.sh`:

- **Merge-queue** goes through `multi_job_run`, which pipes everything into a parent dashboard log: `parallel … 'run …' | DUP=1 cache_log "CI run" $RUN_ID`. Each `run()` wraps `bootstrap_ec2` with `PARENT_LOG_ID=$RUN_ID`, so the instance request lands in the parent log and the build log links underneath it.
- **PR modes** called `bootstrap_ec2` directly — no `cache_log`, no parent log — so the instance request only reached the GA console.

## Change

Route the PR-facing single-instance modes through the same `multi_job_run` path (with a single job), so they get an identical `"CI run" $RUN_ID` parent log with the instance request visible and the build log linked beneath it:

- `fast` / `docs` / `barretenberg` / `barretenberg-full`
- `full` / `full-no-test-cache`
- `chonk-input-update`

The job id is kept as `x-$cmd`, so the `ci/<job>` GitHub commit-status name is **unchanged** (no impact on required checks). `socket-fix` (which takes extra args and is an interactive debug mode) keeps its raw, un-denoised output but now pipes through `cache_log` so it also gets a parent log.

## Behavior notes

- PR-run GA console output is now denoised (condensed progress) for the converted modes, matching merge-queue; the full log lives in the dashboard parent log.
- Instances for these modes now carry an `INSTANCE_POSTFIX` equal to the job id (e.g. `x-fast`), so the EC2 `Name` tag becomes `<ref>_amd64_x-fast`. Same-mode re-runs still dedupe correctly.

## Validation

This is a structural reuse of the already-proven merge-queue path (`multi_job_run`), and `bash -n ci.sh` passes. It can't be exercised locally (needs the GA + AWS orchestration), but **this PR's own CI run is the test**: the `fast` job should now produce a `CI run` parent log on the dashboard showing the instance request, reachable without opening GitHub Actions.