### PR TITLE
chore: enable workload identity

### DIFF
--- a/spartan/aztec-bot/values.yaml
+++ b/spartan/aztec-bot/values.yaml
@@ -1,5 +1,6 @@
 global:
-  aztecRollupVersion: "canonical"
+  aztecEnv:
+    ROLLUP_VERSION: "canonical"
   aztecNetwork: ""
   customAztecNetwork:
     enabled: false

--- a/spartan/aztec-node/templates/_pod-template.yaml
+++ b/spartan/aztec-node/templates/_pod-template.yaml
@@ -339,7 +339,7 @@ spec:
         - name: PROVER_ID
           value: {{ .Values.node.coinbase | quote }}
         {{- end }}
-        {{- range $key, $value := .Values.node.env }}
+        {{- range $key, $value := mergeOverwrite (dict) .Values.global.aztecEnv .Values.node.env }}
         - name: {{ $key }}
           value: {{ $value | quote }}
         {{- end }}

--- a/spartan/aztec-node/templates/_pod-template.yaml
+++ b/spartan/aztec-node/templates/_pod-template.yaml
@@ -145,6 +145,20 @@ spec:
         - secretRef:
             name: {{ include "chart.fullname" . }}-env
         {{- end }}
+        {{- range .Values.node.envFrom.configMaps }}
+        - configMapRef:
+            name: {{ tpl .name $ | quote }}
+            {{- if hasKey . "optional" }}
+            optional: {{ .optional }}
+            {{- end }}
+        {{- end }}
+        {{- range .Values.node.envFrom.secrets }}
+        - secretRef:
+            name: {{ tpl .name $ | quote }}
+            {{- if hasKey . "optional" }}
+            optional: {{ .optional }}
+            {{- end }}
+        {{- end }}
       env:
         - name: POD_IP
           valueFrom:

--- a/spartan/aztec-node/templates/extra-objects.yaml
+++ b/spartan/aztec-node/templates/extra-objects.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.extraObjects }}
+---
+{{ tpl (toYaml .) $ }}
+{{- end }}

--- a/spartan/aztec-node/values.yaml
+++ b/spartan/aztec-node/values.yaml
@@ -11,8 +11,8 @@ podManagementPolicy: Parallel
 
 # global config for all Aztec nodes in an instalation
 global:
-  # Which rollup contract we want to follow from the registry
-  aztecRollupVersion: "canonical"
+  # -- Environment variables shared by all Aztec nodes. Overridden by node.env.
+  aztecEnv: {}
   # -- Network name - this is a predefined network - alpha-testnet, devnet
   aztecNetwork: ""
   # -- Custom network - (not recommended) - Only for custom testnet usecases, (must have deployed your own protocol contracts first)

--- a/spartan/aztec-node/values.yaml
+++ b/spartan/aztec-node/values.yaml
@@ -88,6 +88,8 @@ node:
   envFrom:
     configMapEnabled: false
     secretEnabled: false
+    configMaps: []
+    secrets: []
 
   configMap:
     envEnabled: false
@@ -251,3 +253,6 @@ serviceAccount:
   name: ""
   # -- Annotations for the service account
   annotations: {}
+
+# -- Additional Kubernetes objects to render with this chart.
+extraObjects: []

--- a/spartan/aztec-prover-stack/values.yaml
+++ b/spartan/aztec-prover-stack/values.yaml
@@ -1,5 +1,6 @@
 global:
-  aztecRollupVersion: "canonical"
+  aztecEnv:
+    ROLLUP_VERSION: "canonical"
   aztecNetwork: ""
   customAztecNetwork:
     enabled: false

--- a/spartan/aztec-validator/values.yaml
+++ b/spartan/aztec-validator/values.yaml
@@ -1,5 +1,6 @@
 global:
-  aztecRollupVersion: "canonical"
+  aztecEnv:
+    ROLLUP_VERSION: "canonical"
   aztecNetwork: ""
   customAztecNetwork:
     enabled: false

--- a/spartan/terraform/deploy-aztec-infra/values/common.yaml
+++ b/spartan/terraform/deploy-aztec-infra/values/common.yaml
@@ -1,2 +1,3 @@
 global:
-  aztecRollupVersion: "canonical"
+  aztecEnv:
+    ROLLUP_VERSION: "canonical"

--- a/spartan/terraform/gke-cluster/main.tf
+++ b/spartan/terraform/gke-cluster/main.tf
@@ -41,9 +41,10 @@ module "gke_cluster_private" {
 module "gke_cluster_public" {
   source = "./cluster"
 
-  cluster_name    = "aztec-gke-public"
-  project         = var.project
-  region          = var.region
-  zone            = var.zone
-  service_account = google_service_account.gke_sa.email
+  cluster_name             = "aztec-gke-public"
+  project                  = var.project
+  region                   = var.region
+  zone                     = var.zone
+  service_account          = google_service_account.gke_sa.email
+  enable_workload_identity = true
 }


### PR DESCRIPTION
Enables workload identity for Spartan GKE clusters.

Stack: #23997 -> #23998 -> #23999 -> #24000 -> #24001 -> #24002

Fixes: A-1142, A-1134, A-1135, A-1136.