### PR TITLE
feat: add version RPC deployments

### DIFF
--- a/.github/workflows/deploy-rpc.yml
+++ b/.github/workflows/deploy-rpc.yml
@@ -1,0 +1,238 @@
+name: Deploy RPC
+
+on:
+  workflow_call:
+    inputs:
+      rpc_environment:
+        description: "RPC environment to deploy: testnet or mainnet."
+        required: true
+        type: string
+      v4_aztec_docker_image:
+        description: "Full Aztec Docker image for the v4 RPC, for example aztecprotocol/aztec:4.3.1."
+        required: true
+        type: string
+      canonical_aztec_docker_image:
+        description: "Full Aztec Docker image for canonical RPC. Accepted now, used when the canonical RPC block is enabled."
+        required: false
+        type: string
+        default: ""
+      ref:
+        description: "Git ref to checkout. Defaults to the caller ref."
+        required: false
+        type: string
+      gcp_project_id:
+        description: "GCP project id for the RPC deployment."
+        required: false
+        type: string
+        default: "testnet-440309"
+      gcp_region:
+        description: "GCP region passed to Terraform."
+        required: false
+        type: string
+        default: "us-west1"
+      cluster:
+        description: "GKE cluster name."
+        required: false
+        type: string
+        default: "aztec-gke-public"
+      cluster_location:
+        description: "GKE cluster location used by gcloud."
+        required: false
+        type: string
+        default: "us-west1-a"
+      k8s_cluster_context:
+        description: "Kubernetes context override. Defaults to gke_<project>_<location>_<cluster>."
+        required: false
+        type: string
+        default: ""
+      respect_tf_lock:
+        description: "Whether Terraform should respect state locking."
+        required: false
+        type: boolean
+        default: true
+    secrets:
+      GCP_SA_KEY:
+        description: "GCP service account key for Terraform, GCS state, and GKE access."
+        required: true
+  workflow_dispatch:
+    inputs:
+      rpc_environment:
+        description: "RPC environment to deploy."
+        required: true
+        type: choice
+        options:
+          - testnet
+          - mainnet
+      v4_aztec_docker_image:
+        description: "Full Aztec Docker image for the v4 RPC, for example aztecprotocol/aztec:4.3.1."
+        required: true
+        type: string
+      canonical_aztec_docker_image:
+        description: "Full Aztec Docker image for canonical RPC. Accepted now, used when the canonical RPC block is enabled."
+        required: false
+        type: string
+      ref:
+        description: "Git ref to checkout. Leave empty to use the current ref."
+        required: false
+        type: string
+      gcp_project_id:
+        description: "GCP project id for the RPC deployment."
+        required: false
+        type: string
+        default: "testnet-440309"
+      gcp_region:
+        description: "GCP region passed to Terraform."
+        required: false
+        type: string
+        default: "us-west1"
+      cluster:
+        description: "GKE cluster name."
+        required: false
+        type: string
+        default: "aztec-gke-public"
+      cluster_location:
+        description: "GKE cluster location used by gcloud."
+        required: false
+        type: string
+        default: "us-west1-a"
+      k8s_cluster_context:
+        description: "Kubernetes context override. Defaults to gke_<project>_<location>_<cluster>."
+        required: false
+        type: string
+      respect_tf_lock:
+        description: "Whether Terraform should respect state locking."
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-rpc-${{ inputs.rpc_environment }}
+  cancel-in-progress: false
+
+jobs:
+  deploy-rpc:
+    runs-on: ubuntu-latest
+    env:
+      GCP_PROJECT_ID: ${{ inputs.gcp_project_id }}
+      GCP_REGION: ${{ inputs.gcp_region }}
+      CLUSTER_NAME: ${{ inputs.cluster }}
+      CLUSTER_LOCATION: ${{ inputs.cluster_location }}
+    steps:
+      - name: Determine checkout ref
+        id: checkout-ref
+        env:
+          REQUESTED_REF: ${{ inputs.ref }}
+        run: |
+          if [[ -n "$REQUESTED_REF" ]]; then
+            echo "ref=$REQUESTED_REF" >> "$GITHUB_OUTPUT"
+          else
+            echo "ref=${{ github.ref }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          ref: ${{ steps.checkout-ref.outputs.ref }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Resolve deployment inputs
+        env:
+          RPC_ENVIRONMENT: ${{ inputs.rpc_environment }}
+          V4_AZTEC_DOCKER_IMAGE: ${{ inputs.v4_aztec_docker_image }}
+          CANONICAL_AZTEC_DOCKER_IMAGE: ${{ inputs.canonical_aztec_docker_image }}
+          K8S_CLUSTER_CONTEXT: ${{ inputs.k8s_cluster_context }}
+        run: |
+          if [[ "$RPC_ENVIRONMENT" != "testnet" && "$RPC_ENVIRONMENT" != "mainnet" ]]; then
+            echo "Error: rpc_environment must be testnet or mainnet, got '$RPC_ENVIRONMENT'"
+            exit 1
+          fi
+
+          if [[ ! "$V4_AZTEC_DOCKER_IMAGE" =~ ^.+:.+$ ]]; then
+            echo "Error: v4_aztec_docker_image must be in repository:tag form"
+            exit 1
+          fi
+
+          if [[ -n "$CANONICAL_AZTEC_DOCKER_IMAGE" && ! "$CANONICAL_AZTEC_DOCKER_IMAGE" =~ ^.+:.+$ ]]; then
+            echo "Error: canonical_aztec_docker_image must be empty or in repository:tag form"
+            exit 1
+          fi
+
+          resolved_context="$K8S_CLUSTER_CONTEXT"
+          if [[ -z "$resolved_context" ]]; then
+            resolved_context="gke_${GCP_PROJECT_ID}_${CLUSTER_LOCATION}_${CLUSTER_NAME}"
+          fi
+
+          namespace="${RPC_ENVIRONMENT}-rpc"
+          terraform_dir="spartan/terraform/deploy-rpc/environments/${RPC_ENVIRONMENT}"
+          state_path="${CLUSTER_NAME}/${namespace}/deploy-rpc"
+
+          if [[ ! -d "$terraform_dir" ]]; then
+            echo "Error: Terraform environment not found: $terraform_dir"
+            exit 1
+          fi
+
+          {
+            echo "RPC_ENVIRONMENT=$RPC_ENVIRONMENT"
+            echo "NAMESPACE=$namespace"
+            echo "TERRAFORM_DIR=$terraform_dir"
+            echo "STATE_PATH=$state_path"
+            echo "K8S_CLUSTER_CONTEXT=$resolved_context"
+            echo "TF_VAR_GCP_PROJECT_ID=$GCP_PROJECT_ID"
+            echo "TF_VAR_GCP_REGION=$GCP_REGION"
+            echo "TF_VAR_K8S_CLUSTER_CONTEXT=$resolved_context"
+            echo "TF_VAR_V4_AZTEC_DOCKER_IMAGE=$V4_AZTEC_DOCKER_IMAGE"
+            echo "TF_VAR_CANONICAL_AZTEC_DOCKER_IMAGE=$CANONICAL_AZTEC_DOCKER_IMAGE"
+          } >> "$GITHUB_ENV"
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
+        with:
+          install_components: gke-gcloud-auth-plugin
+
+      - name: Configure kubectl
+        run: |
+          gcloud container clusters get-credentials "$CLUSTER_NAME" \
+            --region "$CLUSTER_LOCATION" \
+            --project "$GCP_PROJECT_ID"
+          kubectl config use-context "$K8S_CLUSTER_CONTEXT"
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
+        with:
+          terraform_version: "1.7.5"
+          terraform_wrapper: false
+
+      - name: Configure Terraform backend
+        run: spartan/scripts/override_terraform_backend.sh "$TERRAFORM_DIR" "$CLUSTER_NAME" "$STATE_PATH"
+
+      - name: Terraform Init
+        run: terraform -chdir="$TERRAFORM_DIR" init -reconfigure
+
+      - name: Terraform Plan
+        run: terraform -chdir="$TERRAFORM_DIR" plan -out=tfplan -lock=${{ inputs.respect_tf_lock }}
+
+      - name: Terraform Apply
+        run: terraform -chdir="$TERRAFORM_DIR" apply -auto-approve -lock=${{ inputs.respect_tf_lock }} tfplan
+
+      - name: Write summary
+        if: always()
+        run: |
+          {
+            echo "## RPC deployment"
+            echo
+            echo "| Field | Value |"
+            echo "|---|---|"
+            echo "| Environment | \`${RPC_ENVIRONMENT:-${{ inputs.rpc_environment }}}\` |"
+            echo "| Namespace | \`${NAMESPACE:-unknown}\` |"
+            echo "| v4 image | \`${TF_VAR_V4_AZTEC_DOCKER_IMAGE:-unknown}\` |"
+            echo "| Terraform state | \`${STATE_PATH:-unknown}\` |"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/spartan/terraform/deploy-rpc/README.md
+++ b/spartan/terraform/deploy-rpc/README.md
@@ -1,0 +1,21 @@
+# RPC Deployment
+
+Terraform for standalone public RPC deployments.
+
+Shared modules:
+
+- `modules/environment`: this module defines an environment. Creates RPC and API Gateway
+- `modules/rpc`: Aztec RPC deployment
+- `../modules/rpc-gateway`: Kong API Gateway
+
+Environments. This is what you want to `terraform apply`
+- `environments/testnet`: testnet RPC
+- `environments/mainnet`: mainnet RPC following canonical & v4
+
+Set the Aztec images in each environment with `V4_AZTEC_DOCKER_IMAGE` and `CANONICAL_AZTEC_DOCKER_IMAGE`. The canonical RPC block is currently commented out, but it already references the canonical image variable for when that route is enabled. Each RPC entry passes its image directly to the node module.
+
+GitHub Actions can deploy these environments through `.github/workflows/deploy-rpc.yml`. Call it with `rpc_environment` set to `testnet` or `mainnet`, and `v4_aztec_docker_image` set to the image to deploy.
+
+RPC node environment is configured through each RPC entry's single `env` map. Common values such as `NETWORK`, `L1_CHAIN_ID`, and `RPC_MAX_BODY_SIZE` live in the environment-level `local.env`; rollup-specific values such as `ROLLUP_VERSION` are merged per RPC.
+
+API key consumers are Terraform inputs, but API key values are not. For each `CONSUMERS` entry, provide `gcp_secret_manager_secret_name`. Set `ALLOW_ANONYMOUS = true` on the environment module to allow anonymous usage, with `ANONYMOUS_RATE_LIMIT_MINUTE` controlling rate limit.

--- a/spartan/terraform/deploy-rpc/environments/mainnet/main.tf
+++ b/spartan/terraform/deploy-rpc/environments/mainnet/main.tf
@@ -1,0 +1,90 @@
+terraform {
+  backend "gcs" {
+    bucket = "aztec-terraform"
+    prefix = "aztec-gke-public/mainnet-rpc/deploy-rpc/terraform.tfstate"
+  }
+
+  required_providers {
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 3.1.2"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 3.1.0"
+    }
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "kubernetes" {
+  alias          = "gke-cluster"
+  config_path    = "~/.kube/config"
+  config_context = var.K8S_CLUSTER_CONTEXT
+}
+
+provider "helm" {
+  alias = "gke-cluster"
+  kubernetes = {
+    config_path    = "~/.kube/config"
+    config_context = var.K8S_CLUSTER_CONTEXT
+  }
+}
+
+provider "google" {
+  project = var.GCP_PROJECT_ID
+  region  = var.GCP_REGION
+}
+
+locals {
+  l1_secret_names = {
+    l1_rpc_secret_name                            = "mainnet-rpc-urls"
+    l1_consensus_host_urls_secret_name            = "mainnet-consensus-host-urls"
+    l1_consensus_host_api_keys_secret_name        = "mainnet-consensus-host-api-keys"
+    l1_consensus_host_api_key_headers_secret_name = "mainnet-consensus-host-api-key-headers"
+  }
+
+  env = {
+    NETWORK           = "mainnet"
+    L1_CHAIN_ID       = "1"
+    RPC_MAX_BODY_SIZE = "10mb"
+  }
+
+  rpcs = {
+    # TODO enable canonical RPC once canonical routes are ready
+    # canonical = merge(local.l1_secret_names, {
+    #   aztec_docker_image = var.CANONICAL_AZTEC_DOCKER_IMAGE
+    #   hosts              = ["mainnet-new.rpc.aztec-labs.com"]
+    #   storage_size       = "8Gi"
+    #   env = merge(local.env, {
+    #     ROLLUP_VERSION = ""
+    #   })
+    # })
+    v4 = merge(local.l1_secret_names, {
+      aztec_docker_image = var.V4_AZTEC_DOCKER_IMAGE
+      hosts              = ["v4.mainnet.rpc.aztec-labs.com"]
+      storage_size       = "8Gi"
+      env = merge(local.env, {
+        ROLLUP_VERSION = "2934756905"
+      })
+    })
+  }
+}
+
+module "environment" {
+  source = "../../modules/environment"
+
+  providers = {
+    helm       = helm.gke-cluster
+    kubernetes = kubernetes.gke-cluster
+    google     = google
+  }
+
+  NAMESPACE       = "mainnet-rpc"
+  RELEASE_PREFIX  = "mainnet"
+  RPCS            = local.rpcs
+  ALLOW_ANONYMOUS = false
+}

--- a/spartan/terraform/deploy-rpc/environments/mainnet/outputs.tf
+++ b/spartan/terraform/deploy-rpc/environments/mainnet/outputs.tf
@@ -1,0 +1,29 @@
+output "rpc_services" {
+  description = "RPC Service names and ports keyed by alias."
+  value       = module.environment.rpc_services
+}
+
+output "kong_routes" {
+  description = "Kong route names keyed by alias."
+  value       = module.environment.kong_routes
+}
+
+output "kong_sticky_session_policy_name" {
+  description = "Kong sticky session policy name, or null when disabled."
+  value       = module.environment.kong_sticky_session_policy_name
+}
+
+output "kong_metrics_service" {
+  description = "Kong metrics Service details for Prometheus scraping."
+  value       = module.environment.kong_metrics_service
+}
+
+output "frontend_load_balancer_ip" {
+  description = "Global static IP assigned to the public GKE frontend Ingress."
+  value       = module.environment.frontend_load_balancer_ip
+}
+
+output "gcp_managed_certificate_name" {
+  description = "GKE ManagedCertificate resource name for RPC hosts."
+  value       = module.environment.gcp_managed_certificate_name
+}

--- a/spartan/terraform/deploy-rpc/environments/mainnet/variables.tf
+++ b/spartan/terraform/deploy-rpc/environments/mainnet/variables.tf
@@ -1,0 +1,28 @@
+variable "GCP_PROJECT_ID" {
+  description = "GCP project id for regional RPC infrastructure."
+  type        = string
+  default     = "testnet-440309"
+}
+
+variable "GCP_REGION" {
+  description = "GCP region for regional RPC infrastructure."
+  type        = string
+  default     = "us-west1"
+}
+
+variable "K8S_CLUSTER_CONTEXT" {
+  description = "Kubernetes context for the GKE cluster."
+  type        = string
+  nullable    = false
+}
+
+variable "V4_AZTEC_DOCKER_IMAGE" {
+  description = "Aztec Docker image to deploy for the v4 RPC."
+  type        = string
+}
+
+variable "CANONICAL_AZTEC_DOCKER_IMAGE" {
+  description = "Aztec Docker image to deploy for the canonical RPC once that route is enabled."
+  type        = string
+  default     = ""
+}

--- a/spartan/terraform/deploy-rpc/environments/testnet/main.tf
+++ b/spartan/terraform/deploy-rpc/environments/testnet/main.tf
@@ -1,0 +1,90 @@
+terraform {
+  backend "gcs" {
+    bucket = "aztec-terraform"
+    prefix = "aztec-gke-public/testnet-rpc/deploy-rpc/terraform.tfstate"
+  }
+
+  required_providers {
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 3.1.2"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 3.1.0"
+    }
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "kubernetes" {
+  alias          = "gke-cluster"
+  config_path    = "~/.kube/config"
+  config_context = var.K8S_CLUSTER_CONTEXT
+}
+
+provider "helm" {
+  alias = "gke-cluster"
+  kubernetes = {
+    config_path    = "~/.kube/config"
+    config_context = var.K8S_CLUSTER_CONTEXT
+  }
+}
+
+provider "google" {
+  project = var.GCP_PROJECT_ID
+  region  = var.GCP_REGION
+}
+
+locals {
+  l1_secret_names = {
+    l1_rpc_secret_name                            = "sepolia-rpc-urls"
+    l1_consensus_host_urls_secret_name            = "sepolia-consensus-host-urls"
+    l1_consensus_host_api_keys_secret_name        = "sepolia-consensus-host-api-keys"
+    l1_consensus_host_api_key_headers_secret_name = "sepolia-consensus-host-api-key-headers"
+  }
+
+  env = {
+    NETWORK           = "testnet"
+    L1_CHAIN_ID       = "11155111"
+    RPC_MAX_BODY_SIZE = "10mb"
+  }
+
+  rpcs = {
+    # TODO enable canonical RPC once testnet upgrades
+    # canonical = merge(local.l1_secret_names, {
+    #   aztec_docker_image = var.CANONICAL_AZTEC_DOCKER_IMAGE
+    #   hosts              = ["testnet-new.rpc.aztec-labs.com"]
+    #   storage_size       = "8Gi"
+    #   env = merge(local.env, {
+    #     ROLLUP_VERSION = ""
+    #   })
+    # })
+    v4 = merge(local.l1_secret_names, {
+      aztec_docker_image = var.V4_AZTEC_DOCKER_IMAGE
+      hosts              = ["v4.testnet.rpc.aztec-labs.com"]
+      storage_size       = "8Gi"
+      env = merge(local.env, {
+        ROLLUP_VERSION = "4127419662"
+      })
+    })
+  }
+}
+
+module "environment" {
+  source = "../../modules/environment"
+
+  providers = {
+    helm       = helm.gke-cluster
+    kubernetes = kubernetes.gke-cluster
+    google     = google
+  }
+
+  NAMESPACE       = "testnet-rpc"
+  RELEASE_PREFIX  = "testnet"
+  RPCS            = local.rpcs
+  ALLOW_ANONYMOUS = true
+}

--- a/spartan/terraform/deploy-rpc/environments/testnet/outputs.tf
+++ b/spartan/terraform/deploy-rpc/environments/testnet/outputs.tf
@@ -1,0 +1,29 @@
+output "rpc_services" {
+  description = "RPC Service names and ports keyed by alias."
+  value       = module.environment.rpc_services
+}
+
+output "kong_routes" {
+  description = "Kong route names keyed by alias."
+  value       = module.environment.kong_routes
+}
+
+output "kong_sticky_session_policy_name" {
+  description = "Kong sticky session policy name, or null when disabled."
+  value       = module.environment.kong_sticky_session_policy_name
+}
+
+output "kong_metrics_service" {
+  description = "Kong metrics Service details for Prometheus scraping."
+  value       = module.environment.kong_metrics_service
+}
+
+output "frontend_load_balancer_ip" {
+  description = "Global static IP assigned to the public GKE frontend Ingress."
+  value       = module.environment.frontend_load_balancer_ip
+}
+
+output "gcp_managed_certificate_name" {
+  description = "GKE ManagedCertificate resource name for RPC hosts."
+  value       = module.environment.gcp_managed_certificate_name
+}

--- a/spartan/terraform/deploy-rpc/environments/testnet/variables.tf
+++ b/spartan/terraform/deploy-rpc/environments/testnet/variables.tf
@@ -1,0 +1,28 @@
+variable "GCP_PROJECT_ID" {
+  description = "GCP project id for regional RPC infrastructure."
+  type        = string
+  default     = "testnet-440309"
+}
+
+variable "GCP_REGION" {
+  description = "GCP region for regional RPC infrastructure."
+  type        = string
+  default     = "us-west1"
+}
+
+variable "K8S_CLUSTER_CONTEXT" {
+  description = "Kubernetes context for the GKE cluster."
+  type        = string
+  default     = "gke_testnet-440309_us-west1-a_aztec-gke-public"
+}
+
+variable "V4_AZTEC_DOCKER_IMAGE" {
+  description = "Aztec Docker image to deploy for the v4 RPC."
+  type        = string
+}
+
+variable "CANONICAL_AZTEC_DOCKER_IMAGE" {
+  description = "Aztec Docker image to deploy for the canonical RPC once that route is enabled."
+  type        = string
+  default     = ""
+}

--- a/spartan/terraform/deploy-rpc/modules/environment/main.tf
+++ b/spartan/terraform/deploy-rpc/modules/environment/main.tf
@@ -1,0 +1,89 @@
+terraform {
+  required_providers {
+    helm = {
+      source = "hashicorp/helm"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+    google = {
+      source = "hashicorp/google"
+    }
+  }
+}
+
+locals {
+  # route requests from the same client to the same RPC node in order to have a consisten view of the chain
+  sticky_policy_name = "${var.RELEASE_PREFIX}-rpc-sticky-sessions"
+
+  routed_rpcs = {
+    for name, rpc in var.RPCS : name => rpc
+    if length(rpc.hosts) > 0
+  }
+
+  rpc_routes = {
+    for name, rpc in local.routed_rpcs : name => {
+      hosts                       = rpc.hosts
+      route_namespace             = var.NAMESPACE
+      upstream_service_name       = module.rpc[name].service_name
+      upstream_service_port       = module.rpc[name].service_port
+      auth_mode                   = var.ALLOW_ANONYMOUS ? "keyed_with_anonymous" : "keyed_only"
+      anonymous_rate_limit_minute = var.ANONYMOUS_RATE_LIMIT_MINUTE
+    }
+  }
+
+}
+
+resource "kubernetes_namespace_v1" "rpc" {
+  metadata {
+    name = var.NAMESPACE
+  }
+}
+
+module "rpc" {
+  for_each = var.RPCS
+
+  source = "../rpc"
+
+  providers = {
+    helm       = helm
+    kubernetes = kubernetes
+  }
+
+  NAMESPACE      = var.NAMESPACE
+  RELEASE_NAME   = "${var.RELEASE_PREFIX}-rpc-${each.key}"
+  RELEASE_PREFIX = var.RELEASE_PREFIX
+
+  AZTEC_DOCKER_IMAGE                            = each.value.aztec_docker_image
+  ENV                                           = each.value.env
+  L1_RPC_SECRET_NAME                            = each.value.l1_rpc_secret_name
+  L1_CONSENSUS_HOST_URLS_SECRET_NAME            = each.value.l1_consensus_host_urls_secret_name
+  L1_CONSENSUS_HOST_API_KEYS_SECRET_NAME        = each.value.l1_consensus_host_api_keys_secret_name
+  L1_CONSENSUS_HOST_API_KEY_HEADERS_SECRET_NAME = each.value.l1_consensus_host_api_key_headers_secret_name
+  STORAGE_SIZE                                  = each.value.storage_size
+  OTEL_COLLECTOR_ENDPOINT_GCP_SECRET_NAME       = var.OTEL_COLLECTOR_ENDPOINT_GCP_SECRET_NAME
+
+  depends_on = [kubernetes_namespace_v1.rpc]
+}
+
+module "rpc_gateway" {
+  source = "../../../modules/rpc-gateway"
+
+  providers = {
+    helm       = helm
+    kubernetes = kubernetes
+    google     = google
+  }
+
+  RELEASE_PREFIX     = var.RELEASE_PREFIX
+  CONSUMER_NAMESPACE = var.NAMESPACE
+
+  STICKY_SESSIONS_ENABLED    = true
+  STICKY_SESSION_POLICY_NAME = local.sticky_policy_name
+
+  ROUTES                            = local.rpc_routes
+  CONSUMERS                         = var.CONSUMERS
+  KONG_OTEL_METRICS_GCP_SECRET_NAME = var.OTEL_COLLECTOR_ENDPOINT_GCP_SECRET_NAME
+
+  depends_on = [module.rpc]
+}

--- a/spartan/terraform/deploy-rpc/modules/environment/outputs.tf
+++ b/spartan/terraform/deploy-rpc/modules/environment/outputs.tf
@@ -1,0 +1,42 @@
+output "rpc_services" {
+  description = "RPC Service names and ports keyed by alias."
+  value = {
+    for name, rpc in module.rpc : name => {
+      namespace = rpc.namespace
+      service   = rpc.service_name
+      port      = rpc.service_port
+      hpa       = rpc.hpa_name
+    }
+  }
+}
+
+output "kong_routes" {
+  description = "Kong route names keyed by alias."
+  value       = module.rpc_gateway.route_names
+}
+
+output "kong_sticky_session_policy_name" {
+  description = "Kong sticky session policy name."
+  value       = module.rpc_gateway.sticky_session_policy_name
+}
+
+output "kong_metrics_service" {
+  description = "Kong metrics Service details for Prometheus scraping."
+  value = {
+    namespace      = module.rpc_gateway.metrics_service_namespace
+    service        = module.rpc_gateway.metrics_service_name
+    port           = module.rpc_gateway.metrics_service_port
+    ingress        = module.rpc_gateway.metrics_service_load_balancer_ingress
+    otel_collector = module.rpc_gateway.otel_collector_deployment_name
+  }
+}
+
+output "frontend_load_balancer_ip" {
+  description = "Global static IP assigned to the public GKE frontend Ingress."
+  value       = module.rpc_gateway.frontend_load_balancer_ip
+}
+
+output "gcp_managed_certificate_name" {
+  description = "GKE ManagedCertificate resource name for RPC hosts."
+  value       = module.rpc_gateway.gcp_managed_certificate_name
+}

--- a/spartan/terraform/deploy-rpc/modules/environment/variables.tf
+++ b/spartan/terraform/deploy-rpc/modules/environment/variables.tf
@@ -1,0 +1,51 @@
+variable "NAMESPACE" {
+  description = "Namespace for RPC workloads and Kong routes."
+  type        = string
+}
+
+variable "RELEASE_PREFIX" {
+  description = "Prefix for generated release and Kubernetes resource names."
+  type        = string
+}
+
+variable "RPCS" {
+  description = "RPC instances keyed by public route alias."
+  type = map(object({
+    aztec_docker_image                            = string
+    l1_rpc_secret_name                            = string
+    l1_consensus_host_urls_secret_name            = string
+    l1_consensus_host_api_keys_secret_name        = string
+    l1_consensus_host_api_key_headers_secret_name = string
+    hosts                                         = list(string)
+    storage_size                                  = string
+    env                                           = map(string)
+  }))
+}
+
+variable "ALLOW_ANONYMOUS" {
+  description = "Whether the RPC gateway allows requests without a valid API key. Missing and invalid keys both use the anonymous consumer."
+  type        = bool
+  default     = false
+}
+
+variable "ANONYMOUS_RATE_LIMIT_MINUTE" {
+  description = "Per-client-IP anonymous request limit per minute when ALLOW_ANONYMOUS=true. Kong local policy makes this per Kong pod."
+  type        = number
+  default     = 300
+}
+
+variable "OTEL_COLLECTOR_ENDPOINT_GCP_SECRET_NAME" {
+  description = "GCP Secret Manager secret containing the OpenTelemetry collector base URL."
+  type        = string
+  default     = "otel-collector-url"
+}
+
+variable "CONSUMERS" {
+  description = "Kong consumers keyed by team name. Configured consumers can use every keyed RPC route in the environment."
+  type = map(object({
+    username                       = string
+    gcp_secret_manager_secret_name = string
+    rate_limit_minute              = number
+  }))
+  default = {}
+}

--- a/spartan/terraform/deploy-rpc/modules/rpc/main.tf
+++ b/spartan/terraform/deploy-rpc/modules/rpc/main.tf
@@ -1,0 +1,247 @@
+terraform {
+  required_providers {
+    helm = {
+      source = "hashicorp/helm"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
+}
+
+locals {
+  aztec_image_parts      = split(":", var.AZTEC_DOCKER_IMAGE)
+  aztec_image_repository = join(":", slice(local.aztec_image_parts, 0, length(local.aztec_image_parts) - 1))
+  aztec_image_tag        = local.aztec_image_parts[length(local.aztec_image_parts) - 1]
+
+  workload_name      = "${var.RELEASE_NAME}-aztec-node"
+  l1_secret_name     = "${var.RELEASE_NAME}-l1"
+  otel_secret_name   = "${var.RELEASE_NAME}-otel"
+  sticky_policy_name = "${var.RELEASE_PREFIX}-rpc-sticky-sessions"
+}
+
+resource "helm_release" "rpc" {
+  name             = var.RELEASE_NAME
+  chart            = "${path.module}/../../../../aztec-node"
+  namespace        = var.NAMESPACE
+  create_namespace = false
+  upgrade_install  = true
+  force_update     = true
+  recreate_pods    = true
+  reuse_values     = false
+  timeout          = 600
+  wait             = true
+  wait_for_jobs    = true
+  take_ownership   = true
+
+  values = [
+    file("${path.module}/values/prod.yaml"),
+    file("${path.module}/values/prod-res.yaml"),
+    yamlencode({
+      fullnameOverride = local.workload_name
+      replicaCount     = 1
+      extraObjects = concat(
+        [
+          {
+            apiVersion = "external-secrets.io/v1"
+            kind       = "ExternalSecret"
+            metadata = {
+              name      = local.l1_secret_name
+              namespace = var.NAMESPACE
+            }
+            spec = {
+              refreshInterval = "1m"
+              secretStoreRef = {
+                name = "gcp-secret-store"
+                kind = "ClusterSecretStore"
+              }
+              target = {
+                name           = local.l1_secret_name
+                creationPolicy = "Owner"
+                template = {
+                  engineVersion = "v2"
+                  type          = "Opaque"
+                  data = {
+                    ETHEREUM_HOSTS                    = "{{`{{ .ethereumHostsJson | fromJson | join \",\" }}`}}"
+                    L1_CONSENSUS_HOST_URLS            = "{{`{{ .consensusHostUrlsJson | fromJson | join \",\" }}`}}"
+                    L1_CONSENSUS_HOST_API_KEYS        = "{{`{{ .consensusHostApiKeysJson | fromJson | join \",\" }}`}}"
+                    L1_CONSENSUS_HOST_API_KEY_HEADERS = "{{`{{ .consensusHostApiKeyHeadersJson | fromJson | join \",\" }}`}}"
+                  }
+                }
+              }
+              data = [
+                {
+                  secretKey = "ethereumHostsJson"
+                  remoteRef = {
+                    key = var.L1_RPC_SECRET_NAME
+                  }
+                },
+                {
+                  secretKey = "consensusHostUrlsJson"
+                  remoteRef = {
+                    key = var.L1_CONSENSUS_HOST_URLS_SECRET_NAME
+                  }
+                },
+                {
+                  secretKey = "consensusHostApiKeysJson"
+                  remoteRef = {
+                    key = var.L1_CONSENSUS_HOST_API_KEYS_SECRET_NAME
+                  }
+                },
+                {
+                  secretKey = "consensusHostApiKeyHeadersJson"
+                  remoteRef = {
+                    key = var.L1_CONSENSUS_HOST_API_KEY_HEADERS_SECRET_NAME
+                  }
+                }
+              ]
+            }
+          }
+        ],
+        var.OTEL_COLLECTOR_ENDPOINT_GCP_SECRET_NAME != "" ? [
+          {
+            apiVersion = "external-secrets.io/v1"
+            kind       = "ExternalSecret"
+            metadata = {
+              name      = local.otel_secret_name
+              namespace = var.NAMESPACE
+            }
+            spec = {
+              refreshInterval = "1m"
+              secretStoreRef = {
+                name = "gcp-secret-store"
+                kind = "ClusterSecretStore"
+              }
+              target = {
+                name           = local.otel_secret_name
+                creationPolicy = "Owner"
+                template = {
+                  engineVersion = "v2"
+                  type          = "Opaque"
+                  data = {
+                    OTEL_EXPORTER_OTLP_METRICS_ENDPOINT = "{{`{{ .otelCollectorEndpoint | trimSuffix \"/\" }}`}}/v1/metrics"
+                    OTEL_EXPORTER_OTLP_TRACES_ENDPOINT  = "{{`{{ .otelCollectorEndpoint | trimSuffix \"/\" }}`}}/v1/traces"
+                  }
+                }
+              }
+              data = [
+                {
+                  secretKey = "otelCollectorEndpoint"
+                  remoteRef = {
+                    key = var.OTEL_COLLECTOR_ENDPOINT_GCP_SECRET_NAME
+                  }
+                }
+              ]
+            }
+          }
+        ] : []
+      )
+
+      global = {
+        aztecImage = {
+          repository = local.aztec_image_repository
+          tag        = local.aztec_image_tag
+          pullPolicy = "Always"
+        }
+        aztecEnv              = var.ENV
+        useGcloudLogging      = true
+        otelCollectorEndpoint = ""
+      }
+
+      node = {
+        logLevel = "info"
+        env = {
+          OTEL_SERVICE_NAME = var.RELEASE_NAME
+        }
+        envFrom = {
+          secrets = concat(
+            [{ name = local.l1_secret_name }],
+            var.OTEL_COLLECTOR_ENDPOINT_GCP_SECRET_NAME != "" ? [{ name = local.otel_secret_name }] : []
+          )
+        }
+        proverRealProofs = true
+        updateStrategy = {
+          type = "RollingUpdate"
+        }
+      }
+
+      persistence = {
+        enabled = true
+      }
+
+      statefulSet = {
+        enabled = true
+        volumeClaimTemplates = [
+          {
+            metadata = {
+              name = "data"
+            }
+            spec = {
+              accessModes = ["ReadWriteOnce"]
+              resources = {
+                requests = {
+                  storage = var.STORAGE_SIZE
+                }
+              }
+            }
+          }
+        ]
+      }
+
+      service = {
+        rpc = {
+          enabled = true
+          port    = 8080
+          type    = "ClusterIP"
+          annotations = {
+            "konghq.com/upstream-policy" = local.sticky_policy_name
+          }
+        }
+        admin = {
+          enabled = false
+        }
+        p2p = {
+          enabled         = true
+          nodePortEnabled = false
+          publicIP        = true
+          port            = 40400
+          announcePort    = 40400
+        }
+      }
+    })
+  ]
+}
+
+resource "kubernetes_manifest" "hpa" {
+  manifest = {
+    apiVersion = "autoscaling/v2"
+    kind       = "HorizontalPodAutoscaler"
+    metadata = {
+      name      = "${local.workload_name}-hpa"
+      namespace = var.NAMESPACE
+    }
+    spec = {
+      scaleTargetRef = {
+        apiVersion = "apps/v1"
+        kind       = "StatefulSet"
+        name       = local.workload_name
+      }
+      minReplicas = 1
+      maxReplicas = 4
+      metrics = [
+        {
+          type = "Resource"
+          resource = {
+            name = "cpu"
+            target = {
+              type               = "Utilization"
+              averageUtilization = 70
+            }
+          }
+        }
+      ]
+    }
+  }
+
+  depends_on = [helm_release.rpc]
+}

--- a/spartan/terraform/deploy-rpc/modules/rpc/outputs.tf
+++ b/spartan/terraform/deploy-rpc/modules/rpc/outputs.tf
@@ -1,0 +1,34 @@
+output "release_name" {
+  description = "Helm release name."
+  value       = helm_release.rpc.name
+}
+
+output "workload_name" {
+  description = "Kubernetes StatefulSet name."
+  value       = local.workload_name
+}
+
+output "service_name" {
+  description = "RPC Kubernetes Service name."
+  value       = local.workload_name
+}
+
+output "service_port" {
+  description = "RPC Kubernetes Service port."
+  value       = 8080
+}
+
+output "namespace" {
+  description = "Kubernetes namespace containing the RPC workload."
+  value       = var.NAMESPACE
+}
+
+output "l1_secret_name" {
+  description = "Kubernetes Secret name populated by ExternalSecrets for L1 env vars."
+  value       = local.l1_secret_name
+}
+
+output "hpa_name" {
+  description = "HorizontalPodAutoscaler name."
+  value       = kubernetes_manifest.hpa.manifest.metadata.name
+}

--- a/spartan/terraform/deploy-rpc/modules/rpc/values/prod-res.yaml
+++ b/spartan/terraform/deploy-rpc/modules/rpc/values/prod-res.yaml
@@ -1,0 +1,23 @@
+nodeSelector:
+  local-ssd: "false"
+  node-type: "network"
+
+affinity:
+  nodeAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        preference:
+          matchExpressions:
+            - key: cores
+              operator: In
+              values:
+                - "2"
+
+node:
+  resources:
+    requests:
+      cpu: "0.5"
+      memory: "2Gi"
+    limits:
+      cpu: "1.9"
+      memory: "6Gi"

--- a/spartan/terraform/deploy-rpc/modules/rpc/values/prod.yaml
+++ b/spartan/terraform/deploy-rpc/modules/rpc/values/prod.yaml
@@ -1,0 +1,33 @@
+nodeType: "rpc-node"
+
+node:
+  preStartScript: |
+    if [ -n "${BOOT_NODE_HOST:-}" ]; then
+      until curl --silent --head --fail "${BOOT_NODE_HOST}/status" > /dev/null; do
+        echo "Waiting for boot node..."
+        sleep 1
+      done
+      echo "Boot node is ready!"
+
+      export BOOTSTRAP_NODES=$(curl -X POST -H "content-type: application/json" --data '{"method": "bootstrap_getEncodedEnr"}' $BOOT_NODE_HOST | jq -r .result)
+    fi
+  startCmd:
+    - --node
+
+persistence:
+  enabled: true
+
+statefulSet:
+  enabled: true
+
+service:
+  rpc:
+    enabled: true
+    type: ClusterIP
+  p2p:
+    enabled: true
+    nodePortEnabled: false
+  admin:
+    enabled: false
+  headless:
+    enabled: false

--- a/spartan/terraform/deploy-rpc/modules/rpc/variables.tf
+++ b/spartan/terraform/deploy-rpc/modules/rpc/variables.tf
@@ -1,0 +1,60 @@
+variable "NAMESPACE" {
+  description = "Kubernetes namespace to deploy the RPC workload into."
+  type        = string
+}
+
+variable "RELEASE_NAME" {
+  description = "Helm release name for this RPC instance."
+  type        = string
+}
+
+variable "RELEASE_PREFIX" {
+  description = "Prefix used for generated RPC gateway resources."
+  type        = string
+}
+
+variable "AZTEC_DOCKER_IMAGE" {
+  description = "Aztec Docker image in repository:tag form."
+  type        = string
+
+  validation {
+    condition     = can(regex("^.+:.+$", var.AZTEC_DOCKER_IMAGE))
+    error_message = "AZTEC_DOCKER_IMAGE must be in repository:tag form, for example aztecprotocol/aztec:latest."
+  }
+}
+
+variable "ENV" {
+  description = "Environment variables for the RPC node."
+  type        = map(string)
+}
+
+variable "L1_RPC_SECRET_NAME" {
+  description = "GCP Secret Manager secret containing the JSON array of L1 execution RPC URLs."
+  type        = string
+}
+
+variable "L1_CONSENSUS_HOST_URLS_SECRET_NAME" {
+  description = "GCP Secret Manager secret containing the JSON array of L1 consensus host URLs."
+  type        = string
+}
+
+variable "L1_CONSENSUS_HOST_API_KEYS_SECRET_NAME" {
+  description = "GCP Secret Manager secret containing the JSON array of L1 consensus host API keys."
+  type        = string
+}
+
+variable "L1_CONSENSUS_HOST_API_KEY_HEADERS_SECRET_NAME" {
+  description = "GCP Secret Manager secret containing the JSON array of L1 consensus host API key headers."
+  type        = string
+}
+
+variable "STORAGE_SIZE" {
+  description = "Persistent volume size per RPC pod."
+  type        = string
+}
+
+variable "OTEL_COLLECTOR_ENDPOINT_GCP_SECRET_NAME" {
+  description = "GCP Secret Manager secret containing the OpenTelemetry collector base URL."
+  type        = string
+  default     = "otel-collector-url"
+}


### PR DESCRIPTION
Adds versioned RPC Terraform deployment wiring.

Stack: #23997 -> #23998 -> #23999 -> #24000 -> #24001 -> #24002

Fixes: A-1142, A-1134, A-1135, A-1136.