### PR TITLE
feat: add readiness gate

### DIFF
--- a/spartan/aztec-bot/values.yaml
+++ b/spartan/aztec-bot/values.yaml
@@ -96,6 +96,8 @@ bot:
 
     startCmd:
       - --bot
+    readinessProbe:
+      enabled: false
 
     hostNetwork: false
 

--- a/spartan/aztec-node/README.md
+++ b/spartan/aztec-node/README.md
@@ -159,6 +159,14 @@ service:
 | node.nodeJsOptions | ["--no-warnings", "--max-old-space-size=4096"] | Node.js options |
 | node.startupProbe.periodSeconds | 30 | Period seconds for startup probe |
 | node.startupProbe.failureThreshold | 3 | Failure threshold for startup probe |
+| node.readinessProbe.enabled | true | Enable readiness probe rendering |
+| node.readinessProbe.exec | sync status check | Exec readiness probe config |
+| node.readinessProbe.httpGet | null | HTTP readiness probe config |
+| node.readinessProbe.periodSeconds | 15 | Period seconds for readiness probe |
+| node.readinessProbe.timeoutSeconds | 2 | Timeout seconds for readiness probe |
+| node.readinessProbe.initialDelaySeconds | 0 | Initial delay before readiness probes |
+| node.readinessProbe.failureThreshold | 1 | Failure threshold for readiness probe |
+| node.readinessProbe.successThreshold | 1 | Success threshold for readiness probe |
 | persistence.enabled | false | Enable persistence (uses emptyDir when disabled) |
 | persistence.existingClaim | null | Use an existing PVC |
 | persistence.accessModes | ["ReadWriteOnce"] | Access modes for persistence |

--- a/spartan/aztec-node/templates/_pod-template.yaml
+++ b/spartan/aztec-node/templates/_pod-template.yaml
@@ -119,6 +119,21 @@ spec:
         timeoutSeconds: {{ .Values.node.startupProbe.timeoutSeconds }}
         initialDelaySeconds: {{ .Values.node.startupProbe.initialDelaySeconds }}
         failureThreshold: {{ .Values.node.startupProbe.failureThreshold }}
+      {{- if .Values.node.readinessProbe.enabled }}
+      readinessProbe:
+        {{- if .Values.node.readinessProbe.exec }}
+        exec:
+{{ toYaml .Values.node.readinessProbe.exec | indent 10 }}
+        {{- else if .Values.node.readinessProbe.httpGet }}
+        httpGet:
+{{ toYaml .Values.node.readinessProbe.httpGet | indent 10 }}
+        {{- end }}
+        periodSeconds: {{ .Values.node.readinessProbe.periodSeconds }}
+        timeoutSeconds: {{ .Values.node.readinessProbe.timeoutSeconds }}
+        initialDelaySeconds: {{ .Values.node.readinessProbe.initialDelaySeconds }}
+        failureThreshold: {{ .Values.node.readinessProbe.failureThreshold }}
+        successThreshold: {{ .Values.node.readinessProbe.successThreshold }}
+      {{- end }}
       volumeMounts:
         - name: shared
           mountPath: /shared

--- a/spartan/aztec-node/values.yaml
+++ b/spartan/aztec-node/values.yaml
@@ -138,6 +138,21 @@ node:
     # 20 minutes default but this might not be enough if the node has to download a lot of blocks.
     failureThreshold: 40
 
+  readinessProbe:
+    enabled: true
+    exec:
+      command:
+        - /bin/sh
+        - -ec
+        - |
+          curl -sf -H 'content-type: application/json' --data '{"jsonrpc":"2.0","id":1,"method":"node_getWorldStateSyncStatus","params":[]}' "http://127.0.0.1:${AZTEC_PORT:-8080}" | jq -e '.result.treesAreSynched == true' > /dev/null
+    httpGet: null
+    periodSeconds: 15
+    timeoutSeconds: 2
+    initialDelaySeconds: 0
+    failureThreshold: 1
+    successThreshold: 1
+
   resources: {}
 
   proverRealProofs: true

--- a/spartan/aztec-prover-stack/values.yaml
+++ b/spartan/aztec-prover-stack/values.yaml
@@ -69,6 +69,8 @@ broker:
       RPC_MAX_BODY_SIZE: "50mb"
     startCmd:
       - --prover-broker
+    readinessProbe:
+      enabled: false
 
   hostNetwork: false
 
@@ -111,6 +113,8 @@ agent:
       source /scripts/wait-for-broker.sh
     startCmd:
       - --prover-agent
+    readinessProbe:
+      enabled: false
 
   service:
     p2p:

--- a/spartan/terraform/deploy-aztec-infra/values/p2p-bootstrap.yaml
+++ b/spartan/terraform/deploy-aztec-infra/values/p2p-bootstrap.yaml
@@ -12,6 +12,8 @@ node:
 
   startCmd:
     - --p2p-bootstrap
+  readinessProbe:
+    enabled: false
 
 service:
   p2p:

--- a/spartan/terraform/deploy-rpc/modules/rpc/main.tf
+++ b/spartan/terraform/deploy-rpc/modules/rpc/main.tf
@@ -228,6 +228,35 @@ resource "kubernetes_manifest" "hpa" {
       }
       minReplicas = 1
       maxReplicas = 4
+      behavior = {
+        scaleUp = {
+          stabilizationWindowSeconds = 600
+          selectPolicy               = "Max"
+          policies = [
+            {
+              type          = "Pods"
+              value         = 4
+              periodSeconds = 15
+            },
+            {
+              type          = "Percent"
+              value         = 100
+              periodSeconds = 15
+            }
+          ]
+        }
+        scaleDown = {
+          stabilizationWindowSeconds = 300
+          selectPolicy               = "Max"
+          policies = [
+            {
+              type          = "Percent"
+              value         = 100
+              periodSeconds = 15
+            }
+          ]
+        }
+      }
       metrics = [
         {
           type = "Resource"


### PR DESCRIPTION
Adds RPC readiness gating for Spartan deployments.

Stack: #23997 -> #23998 -> #23999 -> #24000 -> #24001 -> #24002

Fixes: A-1142, A-1134, A-1135, A-1136.