### PR TITLE
chore: remove obsolete no_predicates wrappers (#7729)

### DIFF
--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/main.nr
@@ -17,7 +17,6 @@ pub contract Token {
 
     use aztec::{
         authwit::auth::compute_authwit_nullifier,
-        context::{PrivateCall, PrivateContext},
         macros::{
             events::event,
             functions::{authorize_once, external, initializer, internal, only_self, view},
@@ -247,20 +246,8 @@ pub contract Token {
             // try_sub failed to nullify enough notes to reach the target amount, so we compute the amount remaining
             // and try again.
             let remaining = amount - subtracted;
-            compute_recurse_subtract_balance_call(*context, account, remaining).call(context)
+            Token::at(context.this_address())._recurse_subtract_balance(account, remaining).call(context)
         }
-    }
-
-    // TODO(#7729): apply no_predicates to the contract interface method directly instead of having to use a wrapper
-    // like we do here.
-    #[no_predicates]
-    #[contract_library_method]
-    fn compute_recurse_subtract_balance_call(
-        context: PrivateContext,
-        account: AztecAddress,
-        remaining: u128,
-    ) -> PrivateCall<25, 2, u128> {
-        Token::at(context.this_address())._recurse_subtract_balance(account, remaining)
     }
 
     #[only_self]

--- a/noir-projects/noir-contracts/contracts/test/storage_proof_test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/storage_proof_test_contract/src/main.nr
@@ -12,7 +12,6 @@ contract StorageProofTest {
         utils::to_nibbles,
     };
     use aztec::{
-        context::calls::PrivateCall,
         macros::functions::{external, internal, only_self, view},
         oracle::capsules,
         protocol::{
@@ -90,15 +89,15 @@ contract StorageProofTest {
 
         let storage_trie_key = keccak256(slot_key, 32);
 
-        let (slot_leaf_hash, slot_nibble_index) = call_verify_storage_proof_path_recursively(
-            self.address,
-            0,
-            hinted_storage_proof_length,
-            0,
-            hinted_account.storage_hash,
-            to_nibbles(storage_trie_key),
-            storage_proof_capsule_key,
-        )
+        let (slot_leaf_hash, slot_nibble_index) = StorageProofTest::at(self.address)
+            .verify_storage_proof_path_recursively(
+                0,
+                hinted_storage_proof_length,
+                0,
+                hinted_account.storage_hash,
+                to_nibbles(storage_trie_key),
+                storage_proof_capsule_key,
+            )
             .call(self.context);
 
         assert_eq(slot_leaf_hash, compute_slot_hash(slot_contents, slot_nibble_index, storage_trie_key));
@@ -146,40 +145,17 @@ contract StorageProofTest {
         if new_num_processed_nodes == num_total_nodes {
             (child_hash, end_nibble_index)
         } else {
-            call_verify_storage_proof_path_recursively(
-                self.address,
-                new_num_processed_nodes,
-                num_total_nodes,
-                end_nibble_index,
-                child_hash,
-                storage_trie_key_nibbles,
-                storage_proof_capsule_key,
-            )
+            StorageProofTest::at(self.address)
+                .verify_storage_proof_path_recursively(
+                    new_num_processed_nodes,
+                    num_total_nodes,
+                    end_nibble_index,
+                    child_hash,
+                    storage_trie_key_nibbles,
+                    storage_proof_capsule_key,
+                )
                 .call(self.context)
         }
-    }
-
-    // TODO(#7729): apply no_predicates to the contract interface method directly instead of having to use a wrapper
-    // like we do here.
-    #[no_predicates]
-    #[contract_library_method]
-    fn call_verify_storage_proof_path_recursively(
-        this_address: AztecAddress,
-        num_processed_nodes: u32,
-        num_total_nodes: u32,
-        start_nibble_index: u32,
-        parent_hash: [u64; 4],
-        storage_trie_key_nibbles: [u8; 64],
-        storage_proof_capsule_key: Field,
-    ) -> PrivateCall<37, 72, ([u64; 4], u32)> {
-        StorageProofTest::at(this_address).verify_storage_proof_path_recursively(
-            num_processed_nodes,
-            num_total_nodes,
-            start_nibble_index,
-            parent_hash,
-            storage_trie_key_nibbles,
-            storage_proof_capsule_key,
-        )
     }
 
     #[contract_library_method]


### PR DESCRIPTION
## Summary

Issue #7729 (closed) left behind two `TODO(#7729)` wrappers that used `#[no_predicates]` + `#[contract_library_method]` to compute recursive contract interface calls outside of conditional branches:

- `compute_recurse_subtract_balance_call` in the token contract
- `call_verify_storage_proof_path_recursively` in the storage proof test contract

This PR removes both wrappers and calls the contract interface methods directly at the call sites (including inside the recursive `if/else` branches the wrappers were originally guarding).

## Verification

Compiled each contract with and without the wrappers (`nargo compile --inliner-aggressiveness 0`, matching `bootstrap.sh`) and measured the affected functions with `bb gates --scheme chonk`:

| Function | With wrapper | Without wrapper |
|---|---|---|
| `Token::transfer` | 5,602 opcodes / 19,766 circuit size | identical |
| `Token::_recurse_subtract_balance` | 13,175 / 35,020 | identical |
| `StorageProofTest::storage_proof` | 18,130 / 92,641 | identical |
| `StorageProofTest::verify_storage_proof_path_recursively` | 55,575 / 383,444 | identical |

The extracted function ACIR is byte-identical (matching md5) across the two builds in all four cases, so the manual optimization no longer has any effect and the compiler handles this on its own.

These were the last two `#[no_predicates]` usages referencing #7729 in `noir-contracts`.