### PR TITLE
feat(prover-node): capture checkpoint-level proving metrics

### DIFF
--- a/spartan/metrics/grafana/dashboards/aztec_provers.json
+++ b/spartan/metrics/grafana/dashboards/aztec_provers.json
@@ -575,44 +575,16 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "AVG epoch proving duration"
+              "options": "AVG checkpoint proving duration"
             },
             "properties": [
               {
                 "id": "unit",
-                "value": "s"
+                "value": "ms"
               },
               {
                 "id": "custom.axisPlacement",
                 "value": "left"
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Txs"
-            },
-            "properties": [
-              {
-                "id": "thresholds",
-                "value": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green",
-                      "value": null
-                    },
-                    {
-                      "color": "super-light-yellow",
-                      "value": 115
-                    },
-                    {
-                      "color": "dark-yellow",
-                      "value": 230
-                    }
-                  ]
-                }
               }
             ]
           }
@@ -646,9 +618,9 @@
             "uid": "${data_source}"
           },
           "editorMode": "code",
-          "expr": "rate(aztec_prover_node_job_duration_seconds_sum{k8s_namespace_name=\"$namespace\"}[$__rate_interval])/rate(aztec_prover_node_job_duration_seconds_count{k8s_namespace_name=\"$namespace\"}[$__rate_interval])",
+          "expr": "rate(aztec_prover_node_checkpoint_proving_duration_milliseconds_sum{k8s_namespace_name=\"$namespace\"}[$__rate_interval])/rate(aztec_prover_node_checkpoint_proving_duration_milliseconds_count{k8s_namespace_name=\"$namespace\"}[$__rate_interval])",
           "instant": false,
-          "legendFormat": "AVG epoch proving duration",
+          "legendFormat": "AVG checkpoint proving duration",
           "range": true,
           "refId": "A"
         },
@@ -658,10 +630,10 @@
             "uid": "${data_source}"
           },
           "editorMode": "builder",
-          "expr": "last_over_time(aztec_prover_node_job_transactions{k8s_namespace_name=\"$namespace\"}[$__rate_interval])\n",
+          "expr": "rate(aztec_prover_node_checkpoint_transactions_sum{k8s_namespace_name=\"$namespace\"}[$__rate_interval])/rate(aztec_prover_node_checkpoint_transactions_count{k8s_namespace_name=\"$namespace\"}[$__rate_interval])",
           "hide": false,
           "instant": false,
-          "legendFormat": "Txs",
+          "legendFormat": "Txs per checkpoint",
           "range": true,
           "refId": "B"
         },
@@ -679,7 +651,7 @@
           "refId": "C"
         }
       ],
-      "title": "Epoch proving",
+      "title": "Checkpoint proving",
       "type": "timeseries"
     },
     {
@@ -835,7 +807,7 @@
               }
             ]
           },
-          "unit": "Ξ"
+          "unit": "\u039e"
         },
         "overrides": []
       },
@@ -1172,7 +1144,7 @@
             "uid": "${prometheusDS}"
           },
           "editorMode": "code",
-          "expr": "sum(increase(aztec_prover_node_execution_duration_milliseconds_bucket{k8s_namespace_name=\"$namespace\"}[$__rate_interval])) by (le)",
+          "expr": "sum(increase(aztec_prover_node_checkpoint_processing_duration_milliseconds_bucket{k8s_namespace_name=\"$namespace\"}[$__rate_interval])) by (le)",
           "format": "heatmap",
           "interval": "",
           "legendFormat": "{{le}}",
@@ -1180,7 +1152,7 @@
           "refId": "A"
         }
       ],
-      "title": "Prover Node Execution Duration (Heatmap)",
+      "title": "Prover Node Checkpoint Processing Duration (Heatmap)",
       "type": "heatmap"
     },
     {
@@ -1574,12 +1546,214 @@
       "type": "timeseries"
     },
     {
+      "datasource": {
+        "default": true,
+        "type": "prometheus",
+        "uid": "${data_source}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 68
+      },
+      "id": 42,
+      "options": {
+        "legend": {
+          "calcs": [
+            "last",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "9.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(aztec_prover_node_active_checkpoints{k8s_namespace_name=\"$namespace\"})",
+          "legendFormat": "Active checkpoints",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Active Checkpoints",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "default": true,
+        "type": "prometheus",
+        "uid": "${data_source}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 68
+      },
+      "id": 43,
+      "options": {
+        "legend": {
+          "calcs": [
+            "last",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "9.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "aztec_prover_node_active_epoch_sessions{k8s_namespace_name=\"$namespace\"}",
+          "legendFormat": "{{aztec_epoch_session_kind}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Active Epoch Sessions by Kind",
+      "type": "timeseries"
+    },
+    {
       "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 68
+        "y": 76
       },
       "id": 16,
       "panels": [],
@@ -1652,7 +1826,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 69
+        "y": 77
       },
       "id": 17,
       "options": {
@@ -1754,7 +1928,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 69
+        "y": 77
       },
       "id": 18,
       "options": {
@@ -1855,7 +2029,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 77
+        "y": 85
       },
       "id": 19,
       "interval": "20m",
@@ -1959,7 +2133,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 77
+        "y": 85
       },
       "id": 20,
       "options": {
@@ -2002,7 +2176,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 85
+        "y": 93
       },
       "id": 21,
       "panels": [],
@@ -2058,7 +2232,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 86
+        "y": 94
       },
       "id": 22,
       "interval": "20m",
@@ -2130,7 +2304,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 86
+        "y": 94
       },
       "id": 23,
       "maxDataPoints": 32,
@@ -2154,7 +2328,7 @@
           "color": "rgba(255,0,255,0.7)"
         },
         "filterValues": {
-          "le": 1e-9
+          "le": 1e-09
         },
         "legend": {
           "show": true
@@ -2259,7 +2433,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 94
+        "y": 102
       },
       "id": 24,
       "options": {
@@ -2301,7 +2475,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 102
+        "y": 110
       },
       "id": 25,
       "panels": [],
@@ -2341,7 +2515,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 103
+        "y": 111
       },
       "id": 26,
       "interval": "1m",
@@ -2411,7 +2585,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 103
+        "y": 111
       },
       "id": 28,
       "options": {
@@ -2513,7 +2687,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 111
+        "y": 119
       },
       "id": 29,
       "interval": "20m",
@@ -2582,7 +2756,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 119
+        "y": 127
       },
       "id": 30,
       "options": {
@@ -2629,7 +2803,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 127
+        "y": 135
       },
       "id": 37,
       "panels": [],
@@ -2691,7 +2865,7 @@
               }
             ]
           },
-          "unit": "Ξ"
+          "unit": "\u039e"
         },
         "overrides": []
       },
@@ -2699,7 +2873,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 128
+        "y": 136
       },
       "id": 38,
       "interval": "5m",
@@ -2798,7 +2972,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 128
+        "y": 136
       },
       "id": 39,
       "interval": "5m",
@@ -2896,7 +3070,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 136
+        "y": 144
       },
       "id": 40,
       "interval": "5m",
@@ -2955,7 +3129,7 @@
               }
             ]
           },
-          "unit": "Ξ"
+          "unit": "\u039e"
         },
         "overrides": []
       },
@@ -2963,7 +3137,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 136
+        "y": 144
       },
       "id": 41,
       "options": {

--- a/yarn-project/prover-node/src/job/checkpoint-prover.ts
+++ b/yarn-project/prover-node/src/job/checkpoint-prover.ts
@@ -277,6 +277,8 @@ export class CheckpointProver {
             checkpointNumber: this.checkpoint.number,
             blockProofCount: result.blockProofOutputs.length,
           });
+          // Spans processing + proving (from executeCheckpoint start, after tx gathering) to proofs ready.
+          this.deps.metrics.recordCheckpointProving(checkpointTimer.ms());
           this.blockProofs.resolve(result.blockProofOutputs);
         },
         err => this.blockProofs.reject(err),
@@ -344,7 +346,8 @@ export class CheckpointProver {
       }
 
       this.completed = true;
-      this.deps.metrics.recordCheckpointProcessing(checkpointTimer.ms());
+      const numTxs = this.checkpoint.blocks.reduce((acc, block) => acc + block.body.txEffects.length, 0);
+      this.deps.metrics.recordCheckpointProcessing(checkpointTimer.ms(), this.checkpoint.blocks.length, numTxs);
       this.deps.log.info(
         `Finished enqueueing block-level proving for checkpoint ${this.checkpoint.number} in ${checkpointTimer.ms()}ms`,
         {

--- a/yarn-project/prover-node/src/job/epoch-session.ts
+++ b/yarn-project/prover-node/src/job/epoch-session.ts
@@ -347,7 +347,7 @@ export class EpochSession implements Traceable {
           { uuid: this.uuid, ...this.spec },
         );
         this.state = 'completed';
-        this.deps.metrics.recordProvingJob(timer.ms(), timer.ms(), checkpointCount, epochSizeBlocks, epochSizeTxs);
+        this.deps.metrics.recordProvingJob(timer.ms(), checkpointCount, epochSizeBlocks, epochSizeTxs);
         return;
       case 'superseded':
         this.log.info(`EpochSession ${this.uuid} superseded by a longer candidate`, {

--- a/yarn-project/prover-node/src/metrics.ts
+++ b/yarn-project/prover-node/src/metrics.ts
@@ -22,7 +22,6 @@ import type { CheckpointStore } from './checkpoint-store.js';
 import type { SessionManager } from './session-manager.js';
 
 export class ProverNodeJobMetrics {
-  proverEpochExecutionDuration: Histogram;
   provingJobDuration: Histogram;
   provingJobCheckpoints: Gauge;
   provingJobBlocks: Gauge;
@@ -31,6 +30,9 @@ export class ProverNodeJobMetrics {
   private blobProcessingDuration: Gauge;
   private blockProcessingDuration: Histogram;
   private checkpointProcessingDuration: Histogram;
+  private checkpointProvingDuration: Histogram;
+  private checkpointBlocks: Histogram;
+  private checkpointTransactions: Histogram;
 
   /** Observable gauges for live state. Registered via `observeState(...)` once the
    *  CheckpointStore and SessionManager are available. */
@@ -44,7 +46,6 @@ export class ProverNodeJobMetrics {
     public readonly tracer: Tracer,
     private logger = createLogger('prover-node:publisher:metrics'),
   ) {
-    this.proverEpochExecutionDuration = this.meter.createHistogram(Metrics.PROVER_NODE_EXECUTION_DURATION);
     this.provingJobDuration = this.meter.createHistogram(Metrics.PROVER_NODE_JOB_DURATION);
     this.provingJobCheckpoints = this.meter.createGauge(Metrics.PROVER_NODE_JOB_CHECKPOINTS);
     this.provingJobBlocks = this.meter.createGauge(Metrics.PROVER_NODE_JOB_BLOCKS);
@@ -53,16 +54,12 @@ export class ProverNodeJobMetrics {
     this.blobProcessingDuration = this.meter.createGauge(Metrics.PROVER_NODE_BLOB_PROCESSING_LAST_DURATION);
     this.blockProcessingDuration = this.meter.createHistogram(Metrics.PROVER_NODE_BLOCK_PROCESSING_DURATION);
     this.checkpointProcessingDuration = this.meter.createHistogram(Metrics.PROVER_NODE_CHECKPOINT_PROCESSING_DURATION);
+    this.checkpointProvingDuration = this.meter.createHistogram(Metrics.PROVER_NODE_CHECKPOINT_PROVING_DURATION);
+    this.checkpointBlocks = this.meter.createHistogram(Metrics.PROVER_NODE_CHECKPOINT_BLOCKS);
+    this.checkpointTransactions = this.meter.createHistogram(Metrics.PROVER_NODE_CHECKPOINT_TRANSACTIONS);
   }
 
-  public recordProvingJob(
-    executionTimeMs: number,
-    totalTimeMs: number,
-    numCheckpoints: number,
-    numBlocks: number,
-    numTxs: number,
-  ) {
-    this.proverEpochExecutionDuration.record(Math.ceil(executionTimeMs));
+  public recordProvingJob(totalTimeMs: number, numCheckpoints: number, numBlocks: number, numTxs: number) {
     this.provingJobDuration.record(totalTimeMs / 1000);
     this.provingJobCheckpoints.record(Math.floor(numCheckpoints));
     this.provingJobBlocks.record(Math.floor(numBlocks));
@@ -77,8 +74,14 @@ export class ProverNodeJobMetrics {
     this.blockProcessingDuration.record(Math.ceil(durationMs));
   }
 
-  public recordCheckpointProcessing(durationMs: number) {
+  public recordCheckpointProcessing(durationMs: number, numBlocks: number, numTxs: number) {
     this.checkpointProcessingDuration.record(Math.ceil(durationMs));
+    this.checkpointBlocks.record(Math.floor(numBlocks));
+    this.checkpointTransactions.record(Math.floor(numTxs));
+  }
+
+  public recordCheckpointProving(durationMs: number) {
+    this.checkpointProvingDuration.record(Math.ceil(durationMs));
   }
 
   /**

--- a/yarn-project/telemetry-client/src/metrics.ts
+++ b/yarn-project/telemetry-client/src/metrics.ts
@@ -1199,12 +1199,6 @@ export const PROVING_AGENT_IDLE: MetricDefinition = {
   valueType: ValueType.DOUBLE,
 };
 
-export const PROVER_NODE_EXECUTION_DURATION: MetricDefinition = {
-  name: 'aztec.prover_node.execution.duration',
-  description: 'Duration of execution of an epoch by the prover',
-  unit: 'ms',
-  valueType: ValueType.INT,
-};
 export const PROVER_NODE_JOB_DURATION: MetricDefinition = {
   name: 'aztec.prover_node.job_duration',
   description: 'Duration of proving job',
@@ -1241,6 +1235,23 @@ export const PROVER_NODE_BLOCK_PROCESSING_DURATION: MetricDefinition = {
 export const PROVER_NODE_CHECKPOINT_PROCESSING_DURATION: MetricDefinition = {
   name: 'aztec.prover_node.checkpoint_processing.duration',
   description: 'Duration of processing a single checkpoint in epoch proving job',
+  unit: 'ms',
+  valueType: ValueType.INT,
+};
+export const PROVER_NODE_CHECKPOINT_BLOCKS: MetricDefinition = {
+  name: 'aztec.prover_node.checkpoint_blocks',
+  description: 'Number of blocks in a proven checkpoint',
+  valueType: ValueType.INT,
+};
+export const PROVER_NODE_CHECKPOINT_TRANSACTIONS: MetricDefinition = {
+  name: 'aztec.prover_node.checkpoint_transactions',
+  description: 'Number of transactions in a proven checkpoint',
+  valueType: ValueType.INT,
+};
+export const PROVER_NODE_CHECKPOINT_PROVING_DURATION: MetricDefinition = {
+  name: 'aztec.prover_node.checkpoint_proving.duration',
+  description:
+    'Duration from the start of checkpoint processing to its block proofs being ready (excludes tx gathering)',
   unit: 'ms',
   valueType: ValueType.INT,
 };


### PR DESCRIPTION
## Summary

Follow-up to the `CheckpointStore` + `SessionManager` redesign (#23552), which left the prover-node metrics covering only per-epoch-session timing. This adds checkpoint-level visibility and removes a metric that no longer carried distinct data.

## Changes

**New per-checkpoint metrics** (`telemetry-client`, `prover-node/src/metrics.ts`, `checkpoint-prover.ts`):
- `aztec.prover_node.checkpoint_blocks` / `aztec.prover_node.checkpoint_transactions` — histograms of per-checkpoint sizing, recorded alongside the existing `checkpoint_processing.duration`.
- `aztec.prover_node.checkpoint_proving.duration` — spans from the start of checkpoint processing (after tx gathering) through block-proofs-ready. Recorded when the sub-tree result resolves. Complements `checkpoint_processing.duration`, which still measures execution/enqueue only.

**Removed `aztec.prover_node.execution.duration`**:
- In the old `EpochProvingJob`, `executionTime` was snapshotted before finalize/publish, so it was genuinely distinct from `job_duration`. In the new `EpochSession` the only timer available spans top-tree proving + publish, and the call site passed `timer.ms()` for *both* arguments — so the two metrics reported identical values. Execution timing now lives at the checkpoint level. `recordProvingJob` drops its redundant `executionTimeMs` argument.

**Dashboard** (`spartan/metrics/grafana/dashboards/aztec_provers.json`):
- Repointed the former "Execution Duration" heatmap to `checkpoint_processing.duration`.
- Turned the "Epoch proving" chart into a checkpoint-centric view: checkpoint proving duration + txs per checkpoint + agents.
- Added "Active Checkpoints" and "Active Epoch Sessions by Kind" panels for the live-state observable gauges introduced in #23552.

## Test plan

- `telemetry-client` and `prover-node` typecheck clean.
- `yarn workspace @aztec/prover-node test src/job/checkpoint-prover.test.ts src/job/epoch-session.test.ts` — 53 tests pass.
- Dashboard JSON validated.

> Note: removing `aztec.prover_node.execution.duration` is a breaking change for any external query/alert on that metric.