### PR TITLE
fix: client flows benchmarks

### DIFF
--- a/yarn-project/end-to-end/src/bench/client_flows/account_deployments.test.ts
+++ b/yarn-project/end-to-end/src/bench/client_flows/account_deployments.test.ts
@@ -2,7 +2,6 @@ import { EcdsaRAccountContractArtifact } from '@aztec/accounts/ecdsa';
 import { SchnorrAccountContractArtifact } from '@aztec/accounts/schnorr';
 import { NO_FROM } from '@aztec/aztec.js/account';
 import { AztecAddress } from '@aztec/aztec.js/addresses';
-import { BatchCall } from '@aztec/aztec.js/contracts';
 import { publishContractClass } from '@aztec/aztec.js/deployment';
 import type { DeployAccountOptions, Wallet } from '@aztec/aztec.js/wallet';
 import { SponsoredFPCContract } from '@aztec/noir-contracts.js/SponsoredFPC';
@@ -40,7 +39,7 @@ describe('Deployment benchmark', () => {
       await publishContractClass(adminWallet, SchnorrAccountContractArtifact),
       await publishContractClass(adminWallet, EcdsaRAccountContractArtifact),
     ];
-    for (let interaction of interactions) {
+    for (const interaction of interactions) {
       await interaction.send({ from: adminAddress });
     }
   });

--- a/yarn-project/end-to-end/src/bench/client_flows/account_deployments.test.ts
+++ b/yarn-project/end-to-end/src/bench/client_flows/account_deployments.test.ts
@@ -33,14 +33,16 @@ describe('Deployment benchmark', () => {
     await t.setup();
     await t.applyDeploySponsoredFPC();
     ({ adminWallet, adminAddress, userWallet, sponsoredFPCInstance } = t);
-    // Ensure the ECDSAR1 contract is already registered, to avoid benchmarking an extra call to the ContractClassRegistry
+    // Ensure both account contract classes are already deployed, to avoid benchmarking an extra call to the ContractClassRegistry
     // The typical interaction would be for a user to deploy an account contract that is already registered in the
     // network.
-    const publishContractClassInteractions = new BatchCall(adminWallet, [
-      await publishContractClass(adminWallet, EcdsaRAccountContractArtifact),
+    const interactions = [
       await publishContractClass(adminWallet, SchnorrAccountContractArtifact),
-    ]);
-    await publishContractClassInteractions.send({ from: adminAddress });
+      await publishContractClass(adminWallet, EcdsaRAccountContractArtifact),
+    ];
+    for (let interaction of interactions) {
+      await interaction.send({ from: adminAddress });
+    }
   });
 
   afterAll(async () => {

--- a/yarn-project/end-to-end/src/bench/client_flows/account_deployments.test.ts
+++ b/yarn-project/end-to-end/src/bench/client_flows/account_deployments.test.ts
@@ -33,7 +33,7 @@ describe('Deployment benchmark', () => {
     await t.setup();
     await t.applyDeploySponsoredFPC();
     ({ adminWallet, adminAddress, userWallet, sponsoredFPCInstance } = t);
-    // Ensure both account contract classes are already deployed, to avoid benchmarking an extra call to the ContractClassRegistry
+    // Ensure both account contract classes are already registered, to avoid benchmarking an extra call to the ContractClassRegistry
     // The typical interaction would be for a user to deploy an account contract that is already registered in the
     // network.
     const interactions = [


### PR DESCRIPTION
Cannot register two contract classes in a single tx!
