### PR TITLE
fix(bb): Reuse hiding vk from msgpack in pinned inputs test

### DIFF
--- a/barretenberg/cpp/scripts/chonk-inputs.hash
+++ b/barretenberg/cpp/scripts/chonk-inputs.hash
@@ -1,1 +1,1 @@
-209dde8e69a27c9f
+eb87ac784cd6fd7e

--- a/barretenberg/cpp/src/barretenberg/bbapi/bbapi_chonk_pinned_inputs.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/bbapi/bbapi_chonk_pinned_inputs.test.cpp
@@ -83,6 +83,7 @@ class ChonkPinnedIvcInputsTest : public ::testing::Test {
         ASSERT_FALSE(raw_steps.empty()) << "no execution steps in " << inputs_path;
 
         const auto hiding_bytecode = raw_steps.back().bytecode;
+        const auto hiding_vk = raw_steps.back().vk;
 
         bb::bbapi::BBApiRequest request;
         request.vk_policy = bb::bbapi::VkPolicy::DEFAULT;
@@ -99,12 +100,9 @@ class ChonkPinnedIvcInputsTest : public ::testing::Test {
         }
 
         auto prove_response = bb::bbapi::ChonkProve{}.execute(request);
-        auto vk_response =
-            bb::bbapi::ChonkComputeVk{ .circuit = { .bytecode = hiding_bytecode }, .use_zk_flavor = true }.execute();
 
         auto verify_response =
-            bb::bbapi::ChonkVerify{ .proof = std::move(prove_response.proof), .vk = std::move(vk_response.bytes) }
-                .execute();
+            bb::bbapi::ChonkVerify{ .proof = std::move(prove_response.proof), .vk = hiding_vk }.execute();
         EXPECT_TRUE(verify_response.valid) << "ChonkVerify rejected " << flow_dir.filename();
     }
 };


### PR DESCRIPTION
Fix the nightly debug by changing the pinned inputs ivc test so that for verification it uses the hiding vk supplied in the msgpack instead of reconstructing it.