### PR TITLE
fix(ci3): GITHUB_REPOSITORY unbound when running ci.sh locally

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -55,8 +55,8 @@ function print_usage {
 
 # Keep this in sync with bootstrap_ec2's instance_name scheme (repo-scoped) so the
 # shell/kill/get-ip helpers find instances launched by a CI run for this repo.
-repo=${GITHUB_REPOSITORY##*/}
-repo=${repo:-aztec-packages}
+repo=${GITHUB_REPOSITORY:-aztec-packages}
+repo=${repo##*/}
 instance_name=${INSTANCE_NAME:-${repo}_$(echo -n "$BRANCH" | tr -c 'a-zA-Z0-9-' '_')_${arch}}
 [ -n "${INSTANCE_POSTFIX:-}" ] && instance_name+="_$INSTANCE_POSTFIX"
 

--- a/ci3/bootstrap_ec2
+++ b/ci3/bootstrap_ec2
@@ -71,8 +71,8 @@ fi
 # the same tag/ref concurrently under the same role, and must not reap each
 # other's instances. The key stays stable across re-runs within a repo, so the
 # orphan cleanup still works.
-repo=${GITHUB_REPOSITORY##*/}
-repo=${repo:-aztec-packages}
+repo=${GITHUB_REPOSITORY:-aztec-packages}
+repo=${repo##*/}
 if [[ "$REF_NAME" =~ ^gh-readonly-queue/.*(pr-[0-9]+) ]]; then
   instance_name="${repo}_${BASH_REMATCH[1]}_$arch"
 else


### PR DESCRIPTION
## Regression

The cross-repo instance-name fix (#23987) added to `ci.sh` and `ci3/bootstrap_ec2`:

```sh
repo=${GITHUB_REPOSITORY##*/}
repo=${repo:-aztec-packages}
```

Under `set -u` (set by `ci3/source`), the `##*/` expansion on an **unset** `GITHUB_REPOSITORY` aborts *before* the `:-aztec-packages` default on the next line can apply. So any local invocation fails immediately:

```
$ ./ci.sh bench
./ci.sh: line 58: GITHUB_REPOSITORY: unbound variable
```

It only bit locally — CI always has `GITHUB_REPOSITORY` set, so it passed there.

## Fix

Default first, then strip:

```sh
repo=${GITHUB_REPOSITORY:-aztec-packages}
repo=${repo##*/}
```

Applied in both `ci.sh` and `ci3/bootstrap_ec2`. Verified under `set -u` with the var unset: resolves to `aztec-packages` (and `AztecProtocol/aztec-packages` → `aztec-packages` when set), so the instance-name scheme is unchanged.