### PR TITLE
fix(ci3): GITHUB_REPOSITORY unbound when running ci.sh locally (v5-next)

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -55,8 +55,8 @@ function print_usage {
 
 # Keep this in sync with bootstrap_ec2's instance_name scheme (repo-scoped) so the
 # shell/kill/get-ip helpers find instances launched by a CI run for this repo.
-repo=${GITHUB_REPOSITORY##*/}
-repo=${repo:-aztec-packages}
+repo=${GITHUB_REPOSITORY:-aztec-packages}
+repo=${repo##*/}
 instance_name=${INSTANCE_NAME:-${repo}_$(echo -n "$BRANCH" | tr -c 'a-zA-Z0-9-' '_')_${arch}}
 [ -n "${INSTANCE_POSTFIX:-}" ] && instance_name+="_$INSTANCE_POSTFIX"
 

--- a/ci3/bootstrap_ec2
+++ b/ci3/bootstrap_ec2
@@ -71,8 +71,8 @@ fi
 # the same tag/ref concurrently under the same role, and must not reap each
 # other's instances. The key stays stable across re-runs within a repo, so the
 # orphan cleanup still works.
-repo=${GITHUB_REPOSITORY##*/}
-repo=${repo:-aztec-packages}
+repo=${GITHUB_REPOSITORY:-aztec-packages}
+repo=${repo##*/}
 if [[ "$REF_NAME" =~ ^gh-readonly-queue/.*(pr-[0-9]+) ]]; then
   instance_name="${repo}_${BASH_REMATCH[1]}_$arch"
 else


### PR DESCRIPTION
Port of the unbound-variable fix (see AztecProtocol/aztec-packages#24059).

The repo-scoped instance name added `repo=${GITHUB_REPOSITORY##*/}` then `repo=${repo:-aztec-packages}`. Under `set -u` (set by `ci3/source`), `##*/` on an unset `GITHUB_REPOSITORY` aborts before the default applies, so any local `./ci.sh <cmd>` fails with `GITHUB_REPOSITORY: unbound variable`. CI always has it set, so it passed there.

Fix: default first, then strip — `repo=${GITHUB_REPOSITORY:-aztec-packages}; repo=${repo##*/}` — in `ci.sh` and `ci3/bootstrap_ec2`. Instance-name scheme unchanged.