### PR TITLE
test(e2e): wait for L1 txs to be mined in token bridge tutorial test

### DIFF
--- a/yarn-project/end-to-end/src/composed/e2e_token_bridge_tutorial_test.test.ts
+++ b/yarn-project/end-to-end/src/composed/e2e_token_bridge_tutorial_test.test.ts
@@ -71,7 +71,9 @@ async function addMinter(l1TokenContract: EthAddress, l1TokenHandler: EthAddress
     abi: TestERC20Abi,
     client: l1Client,
   });
-  await contract.write.addMinter([l1TokenHandler.toString()]);
+  await l1Client.waitForTransactionReceipt({
+    hash: await contract.write.addMinter([l1TokenHandler.toString()]),
+  });
 }
 
 // To run these tests against a local network:
@@ -138,10 +140,16 @@ describe('e2e_cross_chain_messaging token_bridge_tutorial_test', () => {
     await l2TokenContract.methods.set_minter(l2BridgeContract.address, true).send({ from: ownerAztecAddress });
 
     // Initialize L1 portal contract
-    await l1Portal.write.initialize(
-      [l1ContractAddresses.registryAddress.toString(), l1TokenContract.toString(), l2BridgeContract.address.toString()],
-      {},
-    );
+    await l1Client.waitForTransactionReceipt({
+      hash: await l1Portal.write.initialize(
+        [
+          l1ContractAddresses.registryAddress.toString(),
+          l1TokenContract.toString(),
+          l2BridgeContract.address.toString(),
+        ],
+        {},
+      ),
+    });
     logger.info('L1 portal contract initialized');
 
     const l1PortalManager = new L1TokenPortalManager(


### PR DESCRIPTION
Fixes a race in `e2e_token_bridge_tutorial_test` where L1 setup transactions were submitted but not awaited before dependent bridge calls.

- Waits for the `TestERC20.addMinter` transaction receipt before minting through the handler.
- Waits for the `TokenPortal.initialize` transaction receipt before simulating `depositToAztecPublic`.
- Prevents intermittent `SafeERC20FailedOperation(address token) (0x0)` when the portal deposit simulation runs before `underlying` is initialized.

See http://ci.aztec-labs.com/e100f59864b9c18c for sample failed run.
