### PR TITLE
feat: batch field inversions in the Solidity Honk verifier

### DIFF
--- a/barretenberg/cpp/src/barretenberg/dsl/acir_proofs/honk_contract.hpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_proofs/honk_contract.hpp
@@ -54,6 +54,8 @@ using {equal as ==} for Fr global;
 
 uint256 constant SUBGROUP_SIZE = 256;
 uint256 constant MODULUS = 21888242871839275222246405745257275088548364400416034343698204186575808495617; // Prime field order
+// SUBGROUP_SIZE⁻¹ mod MODULUS — precomputed so checkEvalsConsistency need not invert the constant 256 on chain.
+Fr constant SUBGROUP_SIZE_INVERSE = Fr.wrap(0x3033ea246e506e898e97f570caffd704cb0bb460313fb720b29e139e5c100001);
 uint256 constant P = MODULUS;
 Fr constant SUBGROUP_GENERATOR = Fr.wrap(0x07b0c561a6148404f086204a9f36ffb0617942546750f230c893619174a57a76);
 Fr constant SUBGROUP_GENERATOR_INVERSE = Fr.wrap(0x204bd3277422fad364751ad938e2b5e6a54cf8c68712848a692c553d0329f5d6);
@@ -117,6 +119,38 @@ library FrLib {
         }
 
         return Fr.wrap(result);
+    }
+
+    /// @notice Invert a batch of field elements with a single modexp via Montgomery's trick.
+    /// @dev results[i] = (∏_{j<i} v[j]) · (∏_j v[j])⁻¹ · (∏_{j>i} v[j]) = v[i]⁻¹.
+    ///      The whole batch costs one modexp instead of one per element. Reverts with
+    ///      InvertOfZero iff any input is zero: the field has no zero divisors, so the
+    ///      total product is zero exactly when some element is zero — observably identical
+    ///      to calling invert() on each element.
+    function batchInvert(Fr[] memory values) internal view returns (Fr[] memory results) {
+        uint256 n = values.length;
+        results = new Fr[](n);
+        if (n == 0) {
+            return results;
+        }
+
+        // Forward pass: results[i] holds the product of all values before index i.
+        Fr acc = ONE;
+        for (uint256 i = 0; i < n; ++i) {
+            results[i] = acc;
+            acc = acc * values[i];
+        }
+
+        // acc is now the product of every element; it is zero iff some element was zero.
+        require(Fr.unwrap(acc) != 0, Errors.InvertOfZero());
+        acc = invert(acc); // the single modexp
+
+        // Backward pass: peel one element off the running inverse product at a time.
+        for (uint256 i = n; i > 0; --i) {
+            uint256 j = i - 1;
+            results[j] = results[j] * acc;
+            acc = acc * values[j];
+        }
     }
 
     function div(Fr numerator, Fr denominator) internal view returns (Fr) {
@@ -1427,6 +1461,9 @@ library CommitmentSchemeLib {
         Fr scalingFactorNeg;
         // Fold_i(r^{2^i}) reconstructed by Verifier
         Fr[] foldPosEvaluations;
+        // All Shplonk/Gemini denominator inverses, computed with a single batch inversion:
+        // [i] = 1/(z - r^{2^i}), [logSize + i] = 1/(z + r^{2^i}), then 1/r and (ZK) 1/(z - g·r).
+        Fr[] shplonkInverses;
     }
 
     // Compute the evaluations Aₗ(r^{2ˡ}) for l = 0, ..., m-1
@@ -1438,14 +1475,27 @@ library CommitmentSchemeLib {
         uint256 logSize
     ) internal view returns (Fr[] memory) {
         Fr[] memory foldPosEvaluations = new Fr[](logSize);
+
+        // Each round divides by (challengePower·(1 - u) + u), which depends only on
+        // (challengePower, u) and not on the running accumulator. Precompute every denominator
+        // and invert them all with a single modexp before folding.
+        Fr[] memory denominators = new Fr[](logSize);
+        for (uint256 i = 0; i < logSize; ++i) {
+            Fr challengePower = geminiEvalChallengePowers[i];
+            Fr u = sumcheckUChallenges[i];
+            denominators[i] = challengePower * (ONE - u) + u;
+        }
+        Fr[] memory invertedDenominators = FrLib.batchInvert(denominators);
+
         for (uint256 i = logSize; i > 0; --i) {
             Fr challengePower = geminiEvalChallengePowers[i - 1];
             Fr u = sumcheckUChallenges[i - 1];
 
-            Fr batchedEvalRoundAcc = ((challengePower * batchedEvalAccumulator * Fr.wrap(2)) - geminiEvaluations[i - 1]
+            Fr batchedEvalRoundAcc =
+            ((challengePower * batchedEvalAccumulator * Fr.wrap(2)) - geminiEvaluations[i - 1]
                     * (challengePower * (ONE - u) - u));
             // Divide by the denominator
-            batchedEvalRoundAcc = batchedEvalRoundAcc * (challengePower * (ONE - u) + u).invert();
+            batchedEvalRoundAcc = batchedEvalRoundAcc * invertedDenominators[i - 1];
 
             batchedEvalAccumulator = batchedEvalRoundAcc;
             foldPosEvaluations[i - 1] = batchedEvalRoundAcc;
@@ -1867,25 +1917,21 @@ abstract contract BaseHonkVerifier is IVerifier {
         ];
         // To compute the next target sum, we evaluate the given univariate at a point u (challenge).
 
-        // Performing Barycentric evaluations
-        // Compute B(x)
+        // Performing Barycentric evaluations.
+        // Compute B(x) = ∏ (x - i) and the per-point denominators DENOM[i]·(x - i) in a single
+        // pass, caching (x - i) which both use, then invert all denominators with one modexp.
         Fr numeratorValue = ONE;
+        Fr[] memory denominators = new Fr[](BATCHED_RELATION_PARTIAL_LENGTH);
         for (uint256 i = 0; i < BATCHED_RELATION_PARTIAL_LENGTH; ++i) {
-            numeratorValue = numeratorValue * (roundChallenge - Fr.wrap(i));
+            Fr challengeMinusI = roundChallenge - Fr.wrap(i);
+            numeratorValue = numeratorValue * challengeMinusI;
+            denominators[i] = BARYCENTRIC_LAGRANGE_DENOMINATORS[i] * challengeMinusI;
         }
 
-        Fr[BATCHED_RELATION_PARTIAL_LENGTH] memory denominatorInverses;
-        for (uint256 i = 0; i < BATCHED_RELATION_PARTIAL_LENGTH; ++i) {
-            Fr inv = BARYCENTRIC_LAGRANGE_DENOMINATORS[i];
-            inv = inv * (roundChallenge - Fr.wrap(i));
-            inv = FrLib.invert(inv);
-            denominatorInverses[i] = inv;
-        }
+        Fr[] memory denominatorInverses = FrLib.batchInvert(denominators);
 
         for (uint256 i = 0; i < BATCHED_RELATION_PARTIAL_LENGTH; ++i) {
-            Fr term = roundUnivariates[i];
-            term = term * denominatorInverses[i];
-            targetSum = targetSum + term;
+            targetSum = targetSum + roundUnivariates[i] * denominatorInverses[i];
         }
 
         // Scale the sum by the value of B(x)
@@ -1906,12 +1952,24 @@ abstract contract BaseHonkVerifier is IVerifier {
         Fr[] memory scalars = new Fr[](NUMBER_UNSHIFTED + $LOG_N + 2);
         Honk.G1Point[] memory commitments = new Honk.G1Point[](NUMBER_UNSHIFTED + $LOG_N + 2);
 
-        mem.posInvertedDenominator = (tp.shplonkZ - powers_of_evaluation_challenge[0]).invert();
-        mem.negInvertedDenominator = (tp.shplonkZ + powers_of_evaluation_challenge[0]).invert();
+        // Batch-invert every Shplonk/Gemini denominator with a single modexp:
+        //   [i]          = z - r^{2^i}   for i in [0, $LOG_N)
+        //   [$LOG_N + i] = z + r^{2^i}   for i in [0, $LOG_N)
+        //   [2*$LOG_N]   = r             (for the 1/r shift factor)
+        mem.shplonkInverses = new Fr[](2 * $LOG_N + 1);
+        for (uint256 i = 0; i < $LOG_N; ++i) {
+            mem.shplonkInverses[i] = tp.shplonkZ - powers_of_evaluation_challenge[i];
+            mem.shplonkInverses[$LOG_N + i] = tp.shplonkZ + powers_of_evaluation_challenge[i];
+        }
+        mem.shplonkInverses[2 * $LOG_N] = tp.geminiR;
+        mem.shplonkInverses = FrLib.batchInvert(mem.shplonkInverses);
+
+        mem.posInvertedDenominator = mem.shplonkInverses[0];
+        mem.negInvertedDenominator = mem.shplonkInverses[$LOG_N];
 
         mem.unshiftedScalar = mem.posInvertedDenominator + (tp.shplonkNu * mem.negInvertedDenominator);
-        mem.shiftedScalar =
-            tp.geminiR.invert() * (mem.posInvertedDenominator - (tp.shplonkNu * mem.negInvertedDenominator));
+        mem.shiftedScalar = mem.shplonkInverses[2 * $LOG_N]
+            * (mem.posInvertedDenominator - (tp.shplonkNu * mem.negInvertedDenominator));
 
         scalars[0] = ONE;
         commitments[0] = proof.shplonkQ;
@@ -2050,9 +2108,9 @@ abstract contract BaseHonkVerifier is IVerifier {
         // Compute Shplonk constant term contributions from Aₗ(± r^{2ˡ}) for l = 1, ..., m-1;
         // Compute scalar multipliers for each fold commitment
         for (uint256 i = 0; i < $LOG_N - 1; ++i) {
-            // Update inverted denominators
-            mem.posInvertedDenominator = (tp.shplonkZ - powers_of_evaluation_challenge[i + 1]).invert();
-            mem.negInvertedDenominator = (tp.shplonkZ + powers_of_evaluation_challenge[i + 1]).invert();
+            // Inverted denominators for r^{2^(i+1)}, precomputed in the batch above
+            mem.posInvertedDenominator = mem.shplonkInverses[i + 1];
+            mem.negInvertedDenominator = mem.shplonkInverses[$LOG_N + i + 1];
 
             // Compute the scalar multipliers for Aₗ(± r^{2ˡ}) and [Aₗ]
             mem.scalingFactorPos = mem.batchingChallenge * mem.posInvertedDenominator;
@@ -2118,7 +2176,14 @@ abstract contract BaseHonkVerifier is IVerifier {
         assembly {
             let free := mload(0x40)
 
-            let count := 0x01
+            // scalars[0] is statically 1, so the first MSM term equals commitments[0] (shplonkQ).
+            // Seed the accumulator with it directly, skipping one ecMul. Its on-curve validity is
+            // still enforced by the first in-loop ecAdd, which rejects off-curve inputs.
+            let first := mload(add(base, 0x20))
+            mstore(free, mload(first))
+            mstore(add(free, 0x20), mload(add(first, 0x20)))
+
+            let count := 0x02
             for {} lt(count, add(limit, 1)) { count := add(count, 1) } {
                 // Get loop offsets
                 let base_base := add(base, mul(count, 0x20))

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_proofs/honk_zk_contract.hpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_proofs/honk_zk_contract.hpp
@@ -54,6 +54,8 @@ using {equal as ==} for Fr global;
 
 uint256 constant SUBGROUP_SIZE = 256;
 uint256 constant MODULUS = 21888242871839275222246405745257275088548364400416034343698204186575808495617; // Prime field order
+// SUBGROUP_SIZE⁻¹ mod MODULUS — precomputed so checkEvalsConsistency need not invert the constant 256 on chain.
+Fr constant SUBGROUP_SIZE_INVERSE = Fr.wrap(0x3033ea246e506e898e97f570caffd704cb0bb460313fb720b29e139e5c100001);
 uint256 constant P = MODULUS;
 Fr constant SUBGROUP_GENERATOR = Fr.wrap(0x07b0c561a6148404f086204a9f36ffb0617942546750f230c893619174a57a76);
 Fr constant SUBGROUP_GENERATOR_INVERSE = Fr.wrap(0x204bd3277422fad364751ad938e2b5e6a54cf8c68712848a692c553d0329f5d6);
@@ -117,6 +119,38 @@ library FrLib {
         }
 
         return Fr.wrap(result);
+    }
+
+    /// @notice Invert a batch of field elements with a single modexp via Montgomery's trick.
+    /// @dev results[i] = (∏_{j<i} v[j]) · (∏_j v[j])⁻¹ · (∏_{j>i} v[j]) = v[i]⁻¹.
+    ///      The whole batch costs one modexp instead of one per element. Reverts with
+    ///      InvertOfZero iff any input is zero: the field has no zero divisors, so the
+    ///      total product is zero exactly when some element is zero — observably identical
+    ///      to calling invert() on each element.
+    function batchInvert(Fr[] memory values) internal view returns (Fr[] memory results) {
+        uint256 n = values.length;
+        results = new Fr[](n);
+        if (n == 0) {
+            return results;
+        }
+
+        // Forward pass: results[i] holds the product of all values before index i.
+        Fr acc = ONE;
+        for (uint256 i = 0; i < n; ++i) {
+            results[i] = acc;
+            acc = acc * values[i];
+        }
+
+        // acc is now the product of every element; it is zero iff some element was zero.
+        require(Fr.unwrap(acc) != 0, Errors.InvertOfZero());
+        acc = invert(acc); // the single modexp
+
+        // Backward pass: peel one element off the running inverse product at a time.
+        for (uint256 i = n; i > 0; --i) {
+            uint256 j = i - 1;
+            results[j] = results[j] * acc;
+            acc = acc * values[j];
+        }
     }
 
     function div(Fr numerator, Fr denominator) internal view returns (Fr) {
@@ -1483,6 +1517,9 @@ library CommitmentSchemeLib {
         Fr scalingFactorNeg;
         // Fold_i(r^{2^i}) reconstructed by Verifier
         Fr[] foldPosEvaluations;
+        // All Shplonk/Gemini denominator inverses, computed with a single batch inversion:
+        // [i] = 1/(z - r^{2^i}), [logSize + i] = 1/(z + r^{2^i}), then 1/r and (ZK) 1/(z - g·r).
+        Fr[] shplonkInverses;
     }
 
     // Compute the evaluations Aₗ(r^{2ˡ}) for l = 0, ..., m-1
@@ -1494,14 +1531,27 @@ library CommitmentSchemeLib {
         uint256 logSize
     ) internal view returns (Fr[] memory) {
         Fr[] memory foldPosEvaluations = new Fr[](logSize);
+
+        // Each round divides by (challengePower·(1 - u) + u), which depends only on
+        // (challengePower, u) and not on the running accumulator. Precompute every denominator
+        // and invert them all with a single modexp before folding.
+        Fr[] memory denominators = new Fr[](logSize);
+        for (uint256 i = 0; i < logSize; ++i) {
+            Fr challengePower = geminiEvalChallengePowers[i];
+            Fr u = sumcheckUChallenges[i];
+            denominators[i] = challengePower * (ONE - u) + u;
+        }
+        Fr[] memory invertedDenominators = FrLib.batchInvert(denominators);
+
         for (uint256 i = logSize; i > 0; --i) {
             Fr challengePower = geminiEvalChallengePowers[i - 1];
             Fr u = sumcheckUChallenges[i - 1];
 
-            Fr batchedEvalRoundAcc = ((challengePower * batchedEvalAccumulator * Fr.wrap(2)) - geminiEvaluations[i - 1]
+            Fr batchedEvalRoundAcc =
+            ((challengePower * batchedEvalAccumulator * Fr.wrap(2)) - geminiEvaluations[i - 1]
                     * (challengePower * (ONE - u) - u));
             // Divide by the denominator
-            batchedEvalRoundAcc = batchedEvalRoundAcc * (challengePower * (ONE - u) + u).invert();
+            batchedEvalRoundAcc = batchedEvalRoundAcc * invertedDenominators[i - 1];
 
             batchedEvalAccumulator = batchedEvalRoundAcc;
             foldPosEvaluations[i - 1] = batchedEvalRoundAcc;
@@ -1794,7 +1844,7 @@ abstract contract BaseZKHonkVerifier is IVerifier {
         Fr lagrangeFirst;
         Fr lagrangeLast;
         Fr rootPower;
-        Fr[SUBGROUP_SIZE] denominators; // this has to disappear
+        Fr[] denominators;
         Fr diff;
     }
 
@@ -1963,17 +2013,18 @@ abstract contract BaseZKHonkVerifier is IVerifier {
 
         // To compute the next target sum, we evaluate the given univariate at a point u (challenge).
 
-        // Performing Barycentric evaluations
-        // Compute B(x)
+        // Performing Barycentric evaluations.
+        // Compute B(x) = ∏ (x - i) and the per-point denominators DENOM[i]·(x - i) in a single
+        // pass, caching (x - i) which both use, then invert all denominators with one modexp.
         Fr numeratorValue = Fr.wrap(1);
+        Fr[] memory denominators = new Fr[](ZK_BATCHED_RELATION_PARTIAL_LENGTH);
         for (uint256 i = 0; i < ZK_BATCHED_RELATION_PARTIAL_LENGTH; ++i) {
-            numeratorValue = numeratorValue * (roundChallenge - Fr.wrap(i));
+            Fr challengeMinusI = roundChallenge - Fr.wrap(i);
+            numeratorValue = numeratorValue * challengeMinusI;
+            denominators[i] = BARYCENTRIC_LAGRANGE_DENOMINATORS[i] * challengeMinusI;
         }
 
-        Fr[ZK_BATCHED_RELATION_PARTIAL_LENGTH] memory denominatorInverses;
-        for (uint256 i = 0; i < ZK_BATCHED_RELATION_PARTIAL_LENGTH; ++i) {
-            denominatorInverses[i] = FrLib.invert(BARYCENTRIC_LAGRANGE_DENOMINATORS[i] * (roundChallenge - Fr.wrap(i)));
-        }
+        Fr[] memory denominatorInverses = FrLib.batchInvert(denominators);
 
         for (uint256 i = 0; i < ZK_BATCHED_RELATION_PARTIAL_LENGTH; ++i) {
             targetSum = targetSum + roundUnivariates[i] * denominatorInverses[i];
@@ -1996,12 +2047,26 @@ abstract contract BaseZKHonkVerifier is IVerifier {
         Fr[] memory scalars = new Fr[]($MSMSize);
         Honk.G1Point[] memory commitments = new Honk.G1Point[]($MSMSize);
 
-        mem.posInvertedDenominator = (tp.shplonkZ - powers_of_evaluation_challenge[0]).invert();
-        mem.negInvertedDenominator = (tp.shplonkZ + powers_of_evaluation_challenge[0]).invert();
+        // Batch-invert every Shplonk/Gemini denominator with a single modexp:
+        //   [i]            = z - r^{2^i}   for i in [0, $LOG_N)
+        //   [$LOG_N + i]   = z + r^{2^i}   for i in [0, $LOG_N)
+        //   [2*$LOG_N]     = r             (for the 1/r shift factor)
+        //   [2*$LOG_N + 1] = z - g·r       (Libra denominator; z - r is reused from index 0)
+        mem.shplonkInverses = new Fr[](2 * $LOG_N + 2);
+        for (uint256 i = 0; i < $LOG_N; ++i) {
+            mem.shplonkInverses[i] = tp.shplonkZ - powers_of_evaluation_challenge[i];
+            mem.shplonkInverses[$LOG_N + i] = tp.shplonkZ + powers_of_evaluation_challenge[i];
+        }
+        mem.shplonkInverses[2 * $LOG_N] = tp.geminiR;
+        mem.shplonkInverses[2 * $LOG_N + 1] = tp.shplonkZ - SUBGROUP_GENERATOR * tp.geminiR;
+        mem.shplonkInverses = FrLib.batchInvert(mem.shplonkInverses);
+
+        mem.posInvertedDenominator = mem.shplonkInverses[0];
+        mem.negInvertedDenominator = mem.shplonkInverses[$LOG_N];
 
         mem.unshiftedScalar = mem.posInvertedDenominator + (tp.shplonkNu * mem.negInvertedDenominator);
-        mem.shiftedScalar =
-            tp.geminiR.invert() * (mem.posInvertedDenominator - (tp.shplonkNu * mem.negInvertedDenominator));
+        mem.shiftedScalar = mem.shplonkInverses[2 * $LOG_N]
+            * (mem.posInvertedDenominator - (tp.shplonkNu * mem.negInvertedDenominator));
 
         scalars[0] = Fr.wrap(1);
         commitments[0] = proof.shplonkQ;
@@ -2151,9 +2216,9 @@ abstract contract BaseZKHonkVerifier is IVerifier {
             bool dummy_round = i >= ($LOG_N - 1);
 
             if (!dummy_round) {
-                // Update inverted denominators
-                mem.posInvertedDenominator = (tp.shplonkZ - powers_of_evaluation_challenge[i + 1]).invert();
-                mem.negInvertedDenominator = (tp.shplonkZ + powers_of_evaluation_challenge[i + 1]).invert();
+                // Inverted denominators for r^{2^(i+1)}, precomputed in the batch above
+                mem.posInvertedDenominator = mem.shplonkInverses[i + 1];
+                mem.negInvertedDenominator = mem.shplonkInverses[$LOG_N + i + 1];
 
                 // Compute the scalar multipliers for Aₗ(± r^{2ˡ}) and [Aₗ]
                 mem.scalingFactorPos = mem.batchingChallenge * mem.posInvertedDenominator;
@@ -2174,9 +2239,10 @@ abstract contract BaseZKHonkVerifier is IVerifier {
 
         boundary += $LOG_N - 1;
 
-        // Finalize the batch opening claim
-        mem.denominators[0] = Fr.wrap(1).div(tp.shplonkZ - tp.geminiR);
-        mem.denominators[1] = Fr.wrap(1).div(tp.shplonkZ - SUBGROUP_GENERATOR * tp.geminiR);
+        // Finalize the batch opening claim. Both Libra denominators were inverted in the batch
+        // above: 1/(z - r) is index 0 (since r^{2^0} = r) and 1/(z - g·r) is index 2*$LOG_N + 1.
+        mem.denominators[0] = mem.shplonkInverses[0];
+        mem.denominators[1] = mem.shplonkInverses[2 * $LOG_N + 1];
         mem.denominators[2] = mem.denominators[0];
         mem.denominators[3] = mem.denominators[0];
 
@@ -2236,7 +2302,14 @@ abstract contract BaseZKHonkVerifier is IVerifier {
         Fr libraEval
     ) internal view returns (bool check) {
         Fr one = Fr.wrap(1);
-        Fr vanishingPolyEval = geminiR.pow(SUBGROUP_SIZE) - one;
+
+        // vanishingPolyEval = r^SUBGROUP_SIZE - 1. SUBGROUP_SIZE is a power of two, so r^SUBGROUP_SIZE
+        // is obtained by repeated squaring rather than a modexp.
+        Fr vanishingPolyEval = geminiR;
+        for (uint256 sq = 1; sq < SUBGROUP_SIZE; sq <<= 1) {
+            vanishingPolyEval = vanishingPolyEval.sqr();
+        }
+        vanishingPolyEval = vanishingPolyEval - one;
         require(vanishingPolyEval != Fr.wrap(0), Errors.GeminiChallengeInSubgroup());
 
         SmallSubgroupIpaIntermediates memory mem;
@@ -2249,16 +2322,24 @@ abstract contract BaseZKHonkVerifier is IVerifier {
             }
         }
 
+        // All SUBGROUP_SIZE denominators g^{-idx}·r - 1 are known up front, so invert them with a
+        // single modexp. They are guaranteed non-zero here: a zero denominator means r = g^idx lies
+        // in the subgroup, which forces r^SUBGROUP_SIZE = 1 and would already have tripped the
+        // GeminiChallengeInSubgroup revert above.
+        mem.denominators = new Fr[](SUBGROUP_SIZE);
         mem.rootPower = one;
-        mem.challengePolyEval = Fr.wrap(0);
         for (uint256 idx = 0; idx < SUBGROUP_SIZE; idx++) {
             mem.denominators[idx] = mem.rootPower * geminiR - one;
-            mem.denominators[idx] = mem.denominators[idx].invert();
-            mem.challengePolyEval = mem.challengePolyEval + mem.challengePolyLagrange[idx] * mem.denominators[idx];
             mem.rootPower = mem.rootPower * SUBGROUP_GENERATOR_INVERSE;
         }
+        mem.denominators = FrLib.batchInvert(mem.denominators);
 
-        Fr numerator = vanishingPolyEval * Fr.wrap(SUBGROUP_SIZE).invert();
+        mem.challengePolyEval = Fr.wrap(0);
+        for (uint256 idx = 0; idx < SUBGROUP_SIZE; idx++) {
+            mem.challengePolyEval = mem.challengePolyEval + mem.challengePolyLagrange[idx] * mem.denominators[idx];
+        }
+
+        Fr numerator = vanishingPolyEval * SUBGROUP_SIZE_INVERSE;
         mem.challengePolyEval = mem.challengePolyEval * numerator;
         mem.lagrangeFirst = mem.denominators[0] * numerator;
         mem.lagrangeLast = mem.denominators[SUBGROUP_SIZE - 1] * numerator;
@@ -2289,7 +2370,14 @@ abstract contract BaseZKHonkVerifier is IVerifier {
         assembly {
             let free := mload(0x40)
 
-            let count := 0x01
+            // scalars[0] is statically 1, so the first MSM term equals commitments[0] (shplonkQ).
+            // Seed the accumulator with it directly, skipping one ecMul. Its on-curve validity is
+            // still enforced by the first in-loop ecAdd, which rejects off-curve inputs.
+            let first := mload(add(base, 0x20))
+            mstore(free, mload(first))
+            mstore(add(free, 0x20), mload(add(first, 0x20)))
+
+            let count := 0x02
             for {} lt(count, add(limit, 1)) { count := add(count, 1) } {
                 // Get loop offsets
                 let base_base := add(base, mul(count, 0x20))

--- a/barretenberg/sol/src/honk/BaseHonkVerifier.sol
+++ b/barretenberg/sol/src/honk/BaseHonkVerifier.sol
@@ -166,27 +166,21 @@ abstract contract BaseHonkVerifier is IVerifier {
         ];
         // To compute the next target sum, we evaluate the given univariate at a point u (challenge).
 
-        // TODO: opt: use same array mem for each iteratioon
-        // Performing Barycentric evaluations
-        // Compute B(x)
+        // Performing Barycentric evaluations.
+        // Compute B(x) = ∏ (x - i) and the per-point denominators DENOM[i]·(x - i) in a single
+        // pass, caching (x - i) which both use, then invert all denominators with one modexp.
         Fr numeratorValue = ONE;
+        Fr[] memory denominators = new Fr[](BATCHED_RELATION_PARTIAL_LENGTH);
         for (uint256 i = 0; i < BATCHED_RELATION_PARTIAL_LENGTH; ++i) {
-            numeratorValue = numeratorValue * (roundChallenge - Fr.wrap(i));
+            Fr challengeMinusI = roundChallenge - Fr.wrap(i);
+            numeratorValue = numeratorValue * challengeMinusI;
+            denominators[i] = BARYCENTRIC_LAGRANGE_DENOMINATORS[i] * challengeMinusI;
         }
 
-        // Calculate domain size $N of inverses -- TODO: montgomery's trick
-        Fr[BATCHED_RELATION_PARTIAL_LENGTH] memory denominatorInverses;
-        for (uint256 i = 0; i < BATCHED_RELATION_PARTIAL_LENGTH; ++i) {
-            Fr inv = BARYCENTRIC_LAGRANGE_DENOMINATORS[i];
-            inv = inv * (roundChallenge - Fr.wrap(i));
-            inv = FrLib.invert(inv);
-            denominatorInverses[i] = inv;
-        }
+        Fr[] memory denominatorInverses = FrLib.batchInvert(denominators);
 
         for (uint256 i = 0; i < BATCHED_RELATION_PARTIAL_LENGTH; ++i) {
-            Fr term = roundUnivariates[i];
-            term = term * denominatorInverses[i];
-            targetSum = targetSum + term;
+            targetSum = targetSum + roundUnivariates[i] * denominatorInverses[i];
         }
 
         // Scale the sum by the value of B(x)
@@ -207,12 +201,24 @@ abstract contract BaseHonkVerifier is IVerifier {
         Fr[] memory scalars = new Fr[](NUMBER_UNSHIFTED + $LOG_N + 2);
         Honk.G1Point[] memory commitments = new Honk.G1Point[](NUMBER_UNSHIFTED + $LOG_N + 2);
 
-        mem.posInvertedDenominator = (tp.shplonkZ - powers_of_evaluation_challenge[0]).invert();
-        mem.negInvertedDenominator = (tp.shplonkZ + powers_of_evaluation_challenge[0]).invert();
+        // Batch-invert every Shplonk/Gemini denominator with a single modexp:
+        //   [i]          = z - r^{2^i}   for i in [0, $LOG_N)
+        //   [$LOG_N + i] = z + r^{2^i}   for i in [0, $LOG_N)
+        //   [2*$LOG_N]   = r             (for the 1/r shift factor)
+        mem.shplonkInverses = new Fr[](2 * $LOG_N + 1);
+        for (uint256 i = 0; i < $LOG_N; ++i) {
+            mem.shplonkInverses[i] = tp.shplonkZ - powers_of_evaluation_challenge[i];
+            mem.shplonkInverses[$LOG_N + i] = tp.shplonkZ + powers_of_evaluation_challenge[i];
+        }
+        mem.shplonkInverses[2 * $LOG_N] = tp.geminiR;
+        mem.shplonkInverses = FrLib.batchInvert(mem.shplonkInverses);
+
+        mem.posInvertedDenominator = mem.shplonkInverses[0];
+        mem.negInvertedDenominator = mem.shplonkInverses[$LOG_N];
 
         mem.unshiftedScalar = mem.posInvertedDenominator + (tp.shplonkNu * mem.negInvertedDenominator);
-        mem.shiftedScalar =
-            tp.geminiR.invert() * (mem.posInvertedDenominator - (tp.shplonkNu * mem.negInvertedDenominator));
+        mem.shiftedScalar = mem.shplonkInverses[2 * $LOG_N]
+            * (mem.posInvertedDenominator - (tp.shplonkNu * mem.negInvertedDenominator));
 
         scalars[0] = ONE;
         commitments[0] = proof.shplonkQ;
@@ -351,9 +357,9 @@ abstract contract BaseHonkVerifier is IVerifier {
         // Compute Shplonk constant term contributions from Aₗ(± r^{2ˡ}) for l = 1, ..., m-1;
         // Compute scalar multipliers for each fold commitment
         for (uint256 i = 0; i < $LOG_N - 1; ++i) {
-            // Update inverted denominators
-            mem.posInvertedDenominator = (tp.shplonkZ - powers_of_evaluation_challenge[i + 1]).invert();
-            mem.negInvertedDenominator = (tp.shplonkZ + powers_of_evaluation_challenge[i + 1]).invert();
+            // Inverted denominators for r^{2^(i+1)}, precomputed in the batch above
+            mem.posInvertedDenominator = mem.shplonkInverses[i + 1];
+            mem.negInvertedDenominator = mem.shplonkInverses[$LOG_N + i + 1];
 
             // Compute the scalar multipliers for Aₗ(± r^{2ˡ}) and [Aₗ]
             mem.scalingFactorPos = mem.batchingChallenge * mem.posInvertedDenominator;
@@ -419,7 +425,14 @@ abstract contract BaseHonkVerifier is IVerifier {
         assembly {
             let free := mload(0x40)
 
-            let count := 0x01
+            // scalars[0] is statically 1, so the first MSM term equals commitments[0] (shplonkQ).
+            // Seed the accumulator with it directly, skipping one ecMul. Its on-curve validity is
+            // still enforced by the first in-loop ecAdd, which rejects off-curve inputs.
+            let first := mload(add(base, 0x20))
+            mstore(free, mload(first))
+            mstore(add(free, 0x20), mload(add(first, 0x20)))
+
+            let count := 0x02
             for {} lt(count, add(limit, 1)) { count := add(count, 1) } {
                 // Get loop offsets
                 let base_base := add(base, mul(count, 0x20))

--- a/barretenberg/sol/src/honk/BaseZKHonkVerifier.sol
+++ b/barretenberg/sol/src/honk/BaseZKHonkVerifier.sol
@@ -4,7 +4,14 @@ pragma solidity >=0.8.27;
 
 import {IVerifier} from "./../interfaces/IVerifier.sol";
 import {CommitmentSchemeLib} from "./CommitmentScheme.sol";
-import {SUBGROUP_GENERATOR, SUBGROUP_GENERATOR_INVERSE, SUBGROUP_SIZE, Fr, FrLib} from "./Fr.sol";
+import {
+    SUBGROUP_GENERATOR,
+    SUBGROUP_GENERATOR_INVERSE,
+    SUBGROUP_SIZE,
+    SUBGROUP_SIZE_INVERSE,
+    Fr,
+    FrLib
+} from "./Fr.sol";
 import {
     Honk,
     NUMBER_OF_ENTITIES,
@@ -41,7 +48,7 @@ abstract contract BaseZKHonkVerifier is IVerifier {
         Fr lagrangeFirst;
         Fr lagrangeLast;
         Fr rootPower;
-        Fr[SUBGROUP_SIZE] denominators; // this has to disappear
+        Fr[] denominators;
         Fr diff;
     }
 
@@ -211,19 +218,18 @@ abstract contract BaseZKHonkVerifier is IVerifier {
 
         // To compute the next target sum, we evaluate the given univariate at a point u (challenge).
 
-        // TODO: opt: use same array mem for each iteratioon
-        // Performing Barycentric evaluations
-        // Compute B(x)
+        // Performing Barycentric evaluations.
+        // Compute B(x) = ∏ (x - i) and the per-point denominators DENOM[i]·(x - i) in a single
+        // pass, caching (x - i) which both use, then invert all denominators with one modexp.
         Fr numeratorValue = Fr.wrap(1);
+        Fr[] memory denominators = new Fr[](ZK_BATCHED_RELATION_PARTIAL_LENGTH);
         for (uint256 i = 0; i < ZK_BATCHED_RELATION_PARTIAL_LENGTH; ++i) {
-            numeratorValue = numeratorValue * (roundChallenge - Fr.wrap(i));
+            Fr challengeMinusI = roundChallenge - Fr.wrap(i);
+            numeratorValue = numeratorValue * challengeMinusI;
+            denominators[i] = BARYCENTRIC_LAGRANGE_DENOMINATORS[i] * challengeMinusI;
         }
 
-        // Calculate domain size $N of inverses -- TODO: montgomery's trick
-        Fr[ZK_BATCHED_RELATION_PARTIAL_LENGTH] memory denominatorInverses;
-        for (uint256 i = 0; i < ZK_BATCHED_RELATION_PARTIAL_LENGTH; ++i) {
-            denominatorInverses[i] = FrLib.invert(BARYCENTRIC_LAGRANGE_DENOMINATORS[i] * (roundChallenge - Fr.wrap(i)));
-        }
+        Fr[] memory denominatorInverses = FrLib.batchInvert(denominators);
 
         for (uint256 i = 0; i < ZK_BATCHED_RELATION_PARTIAL_LENGTH; ++i) {
             targetSum = targetSum + roundUnivariates[i] * denominatorInverses[i];
@@ -246,12 +252,26 @@ abstract contract BaseZKHonkVerifier is IVerifier {
         Fr[] memory scalars = new Fr[]($MSMSize);
         Honk.G1Point[] memory commitments = new Honk.G1Point[]($MSMSize);
 
-        mem.posInvertedDenominator = (tp.shplonkZ - powers_of_evaluation_challenge[0]).invert();
-        mem.negInvertedDenominator = (tp.shplonkZ + powers_of_evaluation_challenge[0]).invert();
+        // Batch-invert every Shplonk/Gemini denominator with a single modexp:
+        //   [i]            = z - r^{2^i}   for i in [0, $LOG_N)
+        //   [$LOG_N + i]   = z + r^{2^i}   for i in [0, $LOG_N)
+        //   [2*$LOG_N]     = r             (for the 1/r shift factor)
+        //   [2*$LOG_N + 1] = z - g·r       (Libra denominator; z - r is reused from index 0)
+        mem.shplonkInverses = new Fr[](2 * $LOG_N + 2);
+        for (uint256 i = 0; i < $LOG_N; ++i) {
+            mem.shplonkInverses[i] = tp.shplonkZ - powers_of_evaluation_challenge[i];
+            mem.shplonkInverses[$LOG_N + i] = tp.shplonkZ + powers_of_evaluation_challenge[i];
+        }
+        mem.shplonkInverses[2 * $LOG_N] = tp.geminiR;
+        mem.shplonkInverses[2 * $LOG_N + 1] = tp.shplonkZ - SUBGROUP_GENERATOR * tp.geminiR;
+        mem.shplonkInverses = FrLib.batchInvert(mem.shplonkInverses);
+
+        mem.posInvertedDenominator = mem.shplonkInverses[0];
+        mem.negInvertedDenominator = mem.shplonkInverses[$LOG_N];
 
         mem.unshiftedScalar = mem.posInvertedDenominator + (tp.shplonkNu * mem.negInvertedDenominator);
-        mem.shiftedScalar =
-            tp.geminiR.invert() * (mem.posInvertedDenominator - (tp.shplonkNu * mem.negInvertedDenominator));
+        mem.shiftedScalar = mem.shplonkInverses[2 * $LOG_N]
+            * (mem.posInvertedDenominator - (tp.shplonkNu * mem.negInvertedDenominator));
 
         scalars[0] = Fr.wrap(1);
         commitments[0] = proof.shplonkQ;
@@ -401,9 +421,9 @@ abstract contract BaseZKHonkVerifier is IVerifier {
             bool dummy_round = i >= ($LOG_N - 1);
 
             if (!dummy_round) {
-                // Update inverted denominators
-                mem.posInvertedDenominator = (tp.shplonkZ - powers_of_evaluation_challenge[i + 1]).invert();
-                mem.negInvertedDenominator = (tp.shplonkZ + powers_of_evaluation_challenge[i + 1]).invert();
+                // Inverted denominators for r^{2^(i+1)}, precomputed in the batch above
+                mem.posInvertedDenominator = mem.shplonkInverses[i + 1];
+                mem.negInvertedDenominator = mem.shplonkInverses[$LOG_N + i + 1];
 
                 // Compute the scalar multipliers for Aₗ(± r^{2ˡ}) and [Aₗ]
                 mem.scalingFactorPos = mem.batchingChallenge * mem.posInvertedDenominator;
@@ -424,9 +444,10 @@ abstract contract BaseZKHonkVerifier is IVerifier {
 
         boundary += $LOG_N - 1;
 
-        // Finalize the batch opening claim
-        mem.denominators[0] = Fr.wrap(1).div(tp.shplonkZ - tp.geminiR);
-        mem.denominators[1] = Fr.wrap(1).div(tp.shplonkZ - SUBGROUP_GENERATOR * tp.geminiR);
+        // Finalize the batch opening claim. Both Libra denominators were inverted in the batch
+        // above: 1/(z - r) is index 0 (since r^{2^0} = r) and 1/(z - g·r) is index 2*$LOG_N + 1.
+        mem.denominators[0] = mem.shplonkInverses[0];
+        mem.denominators[1] = mem.shplonkInverses[2 * $LOG_N + 1];
         mem.denominators[2] = mem.denominators[0];
         mem.denominators[3] = mem.denominators[0];
 
@@ -486,7 +507,14 @@ abstract contract BaseZKHonkVerifier is IVerifier {
         Fr libraEval
     ) internal view returns (bool check) {
         Fr one = Fr.wrap(1);
-        Fr vanishingPolyEval = geminiR.pow(SUBGROUP_SIZE) - one;
+
+        // vanishingPolyEval = r^SUBGROUP_SIZE - 1. SUBGROUP_SIZE is a power of two, so r^SUBGROUP_SIZE
+        // is obtained by repeated squaring rather than a modexp.
+        Fr vanishingPolyEval = geminiR;
+        for (uint256 sq = 1; sq < SUBGROUP_SIZE; sq <<= 1) {
+            vanishingPolyEval = vanishingPolyEval.sqr();
+        }
+        vanishingPolyEval = vanishingPolyEval - one;
         require(vanishingPolyEval != Fr.wrap(0), Errors.GeminiChallengeInSubgroup());
 
         SmallSubgroupIpaIntermediates memory mem;
@@ -499,16 +527,24 @@ abstract contract BaseZKHonkVerifier is IVerifier {
             }
         }
 
+        // All SUBGROUP_SIZE denominators g^{-idx}·r - 1 are known up front, so invert them with a
+        // single modexp. They are guaranteed non-zero here: a zero denominator means r = g^idx lies
+        // in the subgroup, which forces r^SUBGROUP_SIZE = 1 and would already have tripped the
+        // GeminiChallengeInSubgroup revert above.
+        mem.denominators = new Fr[](SUBGROUP_SIZE);
         mem.rootPower = one;
-        mem.challengePolyEval = Fr.wrap(0);
         for (uint256 idx = 0; idx < SUBGROUP_SIZE; idx++) {
             mem.denominators[idx] = mem.rootPower * geminiR - one;
-            mem.denominators[idx] = mem.denominators[idx].invert();
-            mem.challengePolyEval = mem.challengePolyEval + mem.challengePolyLagrange[idx] * mem.denominators[idx];
             mem.rootPower = mem.rootPower * SUBGROUP_GENERATOR_INVERSE;
         }
+        mem.denominators = FrLib.batchInvert(mem.denominators);
 
-        Fr numerator = vanishingPolyEval * Fr.wrap(SUBGROUP_SIZE).invert();
+        mem.challengePolyEval = Fr.wrap(0);
+        for (uint256 idx = 0; idx < SUBGROUP_SIZE; idx++) {
+            mem.challengePolyEval = mem.challengePolyEval + mem.challengePolyLagrange[idx] * mem.denominators[idx];
+        }
+
+        Fr numerator = vanishingPolyEval * SUBGROUP_SIZE_INVERSE;
         mem.challengePolyEval = mem.challengePolyEval * numerator;
         mem.lagrangeFirst = mem.denominators[0] * numerator;
         mem.lagrangeLast = mem.denominators[SUBGROUP_SIZE - 1] * numerator;
@@ -539,7 +575,14 @@ abstract contract BaseZKHonkVerifier is IVerifier {
         assembly {
             let free := mload(0x40)
 
-            let count := 0x01
+            // scalars[0] is statically 1, so the first MSM term equals commitments[0] (shplonkQ).
+            // Seed the accumulator with it directly, skipping one ecMul. Its on-curve validity is
+            // still enforced by the first in-loop ecAdd, which rejects off-curve inputs.
+            let first := mload(add(base, 0x20))
+            mstore(free, mload(first))
+            mstore(add(free, 0x20), mload(add(first, 0x20)))
+
+            let count := 0x02
             for {} lt(count, add(limit, 1)) { count := add(count, 1) } {
                 // Get loop offsets
                 let base_base := add(base, mul(count, 0x20))

--- a/barretenberg/sol/src/honk/CommitmentScheme.sol
+++ b/barretenberg/sol/src/honk/CommitmentScheme.sol
@@ -32,6 +32,9 @@ library CommitmentSchemeLib {
         Fr scalingFactorNeg;
         // Fold_i(r^{2^i}) reconstructed by Verifier
         Fr[] foldPosEvaluations;
+        // All Shplonk/Gemini denominator inverses, computed with a single batch inversion:
+        // [i] = 1/(z - r^{2^i}), [logSize + i] = 1/(z + r^{2^i}), then 1/r and (ZK) 1/(z - g·r).
+        Fr[] shplonkInverses;
     }
 
     // Compute the evaluations Aₗ(r^{2ˡ}) for l = 0, ..., m-1
@@ -43,14 +46,27 @@ library CommitmentSchemeLib {
         uint256 logSize
     ) internal view returns (Fr[] memory) {
         Fr[] memory foldPosEvaluations = new Fr[](logSize);
+
+        // Each round divides by (challengePower·(1 - u) + u), which depends only on
+        // (challengePower, u) and not on the running accumulator. Precompute every denominator
+        // and invert them all with a single modexp before folding.
+        Fr[] memory denominators = new Fr[](logSize);
+        for (uint256 i = 0; i < logSize; ++i) {
+            Fr challengePower = geminiEvalChallengePowers[i];
+            Fr u = sumcheckUChallenges[i];
+            denominators[i] = challengePower * (ONE - u) + u;
+        }
+        Fr[] memory invertedDenominators = FrLib.batchInvert(denominators);
+
         for (uint256 i = logSize; i > 0; --i) {
             Fr challengePower = geminiEvalChallengePowers[i - 1];
             Fr u = sumcheckUChallenges[i - 1];
 
-            Fr batchedEvalRoundAcc = ((challengePower * batchedEvalAccumulator * Fr.wrap(2)) - geminiEvaluations[i - 1]
+            Fr batchedEvalRoundAcc =
+            ((challengePower * batchedEvalAccumulator * Fr.wrap(2)) - geminiEvaluations[i - 1]
                     * (challengePower * (ONE - u) - u));
             // Divide by the denominator
-            batchedEvalRoundAcc = batchedEvalRoundAcc * (challengePower * (ONE - u) + u).invert();
+            batchedEvalRoundAcc = batchedEvalRoundAcc * invertedDenominators[i - 1];
 
             batchedEvalAccumulator = batchedEvalRoundAcc;
             foldPosEvaluations[i - 1] = batchedEvalRoundAcc;

--- a/barretenberg/sol/src/honk/Fr.sol
+++ b/barretenberg/sol/src/honk/Fr.sol
@@ -15,6 +15,8 @@ using {equal as ==} for Fr global;
 
 uint256 constant SUBGROUP_SIZE = 256;
 uint256 constant MODULUS = 21888242871839275222246405745257275088548364400416034343698204186575808495617; // Prime field order
+// SUBGROUP_SIZE⁻¹ mod MODULUS — precomputed so checkEvalsConsistency need not invert the constant 256 on chain.
+Fr constant SUBGROUP_SIZE_INVERSE = Fr.wrap(0x3033ea246e506e898e97f570caffd704cb0bb460313fb720b29e139e5c100001);
 uint256 constant P = MODULUS;
 Fr constant SUBGROUP_GENERATOR = Fr.wrap(0x07b0c561a6148404f086204a9f36ffb0617942546750f230c893619174a57a76);
 Fr constant SUBGROUP_GENERATOR_INVERSE = Fr.wrap(0x204bd3277422fad364751ad938e2b5e6a54cf8c68712848a692c553d0329f5d6);
@@ -80,7 +82,38 @@ library FrLib {
         return Fr.wrap(result);
     }
 
-    // TODO: Montgomery's batch inversion trick
+    /// @notice Invert a batch of field elements with a single modexp via Montgomery's trick.
+    /// @dev results[i] = (∏_{j<i} v[j]) · (∏_j v[j])⁻¹ · (∏_{j>i} v[j]) = v[i]⁻¹.
+    ///      The whole batch costs one modexp instead of one per element. Reverts with
+    ///      InvertOfZero iff any input is zero: the field has no zero divisors, so the
+    ///      total product is zero exactly when some element is zero — observably identical
+    ///      to calling invert() on each element.
+    function batchInvert(Fr[] memory values) internal view returns (Fr[] memory results) {
+        uint256 n = values.length;
+        results = new Fr[](n);
+        if (n == 0) {
+            return results;
+        }
+
+        // Forward pass: results[i] holds the product of all values before index i.
+        Fr acc = ONE;
+        for (uint256 i = 0; i < n; ++i) {
+            results[i] = acc;
+            acc = acc * values[i];
+        }
+
+        // acc is now the product of every element; it is zero iff some element was zero.
+        require(Fr.unwrap(acc) != 0, Errors.InvertOfZero());
+        acc = invert(acc); // the single modexp
+
+        // Backward pass: peel one element off the running inverse product at a time.
+        for (uint256 i = n; i > 0; --i) {
+            uint256 j = i - 1;
+            results[j] = results[j] * acc;
+            acc = acc * values[j];
+        }
+    }
+
     function div(Fr numerator, Fr denominator) internal view returns (Fr) {
         unchecked {
             return numerator * invert(denominator);

--- a/barretenberg/sol/test/FrLib.t.sol
+++ b/barretenberg/sol/test/FrLib.t.sol
@@ -14,6 +14,10 @@ contract FrLibWrapper {
         return FrLib.invert(a);
     }
 
+    function batchInvert(Fr[] memory a) public view returns (Fr[] memory) {
+        return FrLib.batchInvert(a);
+    }
+
     function from(uint256 value) public view returns (Fr) {
         return FrLib.from(value);
     }
@@ -60,5 +64,84 @@ contract FrLibTest is TestBase {
 
         vm.expectRevert(Errors.ValueGeFieldOrder.selector);
         lib.fromBytes32(a);
+    }
+
+    // batchInvert must produce exactly the same results as inverting each element
+    // individually, and each result must be a true multiplicative inverse.
+    function test_batch_invert_matches_single_invert() public {
+        Fr[] memory values = new Fr[](5);
+        values[0] = Fr.wrap(1);
+        values[1] = Fr.wrap(2);
+        values[2] = Fr.wrap(0x1234567890abcdef);
+        values[3] = Fr.wrap(P - 1);
+        values[4] = Fr.wrap(7);
+
+        Fr[] memory batched = lib.batchInvert(values);
+
+        for (uint256 i = 0; i < values.length; i++) {
+            assertEq(Fr.unwrap(batched[i]), Fr.unwrap(lib.invert(values[i])), "batch != single");
+            assertEq(Fr.unwrap(values[i] * batched[i]), 1, "v * inv != 1");
+        }
+    }
+
+    function test_batch_invert_empty() public {
+        Fr[] memory values = new Fr[](0);
+        Fr[] memory batched = lib.batchInvert(values);
+        assertEq(batched.length, 0, "empty in, empty out");
+    }
+
+    function test_batch_invert_single() public {
+        Fr[] memory values = new Fr[](1);
+        values[0] = Fr.wrap(0xdeadbeef);
+        Fr[] memory batched = lib.batchInvert(values);
+        assertEq(batched.length, 1);
+        assertEq(Fr.unwrap(batched[0]), Fr.unwrap(lib.invert(values[0])), "single mismatch");
+        assertEq(Fr.unwrap(values[0] * batched[0]), 1, "v * inv != 1");
+    }
+
+    // A zero anywhere in the batch must revert exactly like invert(0) does.
+    function test_batch_invert_reverts_on_zero_first() public {
+        Fr[] memory values = new Fr[](3);
+        values[0] = Fr.wrap(0);
+        values[1] = Fr.wrap(3);
+        values[2] = Fr.wrap(5);
+        vm.expectRevert(Errors.InvertOfZero.selector);
+        lib.batchInvert(values);
+    }
+
+    function test_batch_invert_reverts_on_zero_middle() public {
+        Fr[] memory values = new Fr[](3);
+        values[0] = Fr.wrap(3);
+        values[1] = Fr.wrap(0);
+        values[2] = Fr.wrap(5);
+        vm.expectRevert(Errors.InvertOfZero.selector);
+        lib.batchInvert(values);
+    }
+
+    function test_batch_invert_reverts_on_zero_last() public {
+        Fr[] memory values = new Fr[](3);
+        values[0] = Fr.wrap(3);
+        values[1] = Fr.wrap(5);
+        values[2] = Fr.wrap(0);
+        vm.expectRevert(Errors.InvertOfZero.selector);
+        lib.batchInvert(values);
+    }
+
+    function testFuzz_batch_invert(uint256 a, uint256 b, uint256 c) public {
+        // Constrain into the field and away from zero (zero is covered by the revert tests).
+        a = bound(a, 1, P - 1);
+        b = bound(b, 1, P - 1);
+        c = bound(c, 1, P - 1);
+
+        Fr[] memory values = new Fr[](3);
+        values[0] = Fr.wrap(a);
+        values[1] = Fr.wrap(b);
+        values[2] = Fr.wrap(c);
+
+        Fr[] memory batched = lib.batchInvert(values);
+        for (uint256 i = 0; i < values.length; i++) {
+            assertEq(Fr.unwrap(batched[i]), Fr.unwrap(lib.invert(values[i])), "fuzz batch != single");
+            assertEq(Fr.unwrap(values[i] * batched[i]), 1, "fuzz v * inv != 1");
+        }
     }
 }

--- a/barretenberg/sol/test/honk/negative/NegativeTestBaseZK.sol
+++ b/barretenberg/sol/test/honk/negative/NegativeTestBaseZK.sol
@@ -278,6 +278,22 @@ abstract contract NegativeTestBaseZK is TestBase {
         verifier.verify{gas: 15_000_000}(proof, cachedPublicInputs);
     }
 
+    /// @notice An off-curve shplonkQ still rejects the proof despite seeding the MSM accumulator.
+    /// @dev shplonkQ is the first batchMul term and its scalar is statically 1, so it seeds the
+    ///      accumulator without an ecMul. Its on-curve validity is still enforced by the first
+    ///      in-loop ecAdd: feeding the off-curve point (1, 1) makes the bn256 precompile fail and
+    ///      consume all forwarded gas, so the call reverts without data (mirroring the non-ZK
+    ///      test_OffCurve_ShplonkQ). shplonkQ occupies bytes [len-128, len-64) (kzgQuotient is last).
+    function test_OffCurve_ShplonkQ() public virtual {
+        bytes memory proof = copyProof();
+
+        // (1, 1) is < Q on both coordinates but not on the curve (1 != 1 + 3).
+        setG1Point(proof, proof.length - 128, 1, 1);
+
+        vm.expectRevert(bytes(""));
+        verifier.verify{gas: 15_000_000}(proof, cachedPublicInputs);
+    }
+
     /*//////////////////////////////////////////////////////////////
                     SHPLEMINI / PAIRING FAILURES
     //////////////////////////////////////////////////////////////*/


### PR DESCRIPTION
Replaces clusters of individual `.invert()` calls (each hitting the MODEXP precompile) with Montgomery batch inversion—one MODEXP per batch, with linear `mulmod` operations for the remaining work. Includes several additional optimizations in the same code paths.

## Changes

### `FrLib.batchInvert()`

Introduces a new library function implementing the standard prefix-product batch inversion technique.

- Uses a single MODEXP call to invert an entire array.
- Reverts with `InvertOfZero` if any element is zero, matching the behavior of individual `.invert()` calls.

### Sumcheck barycentric evaluation

Each round now:

- Collects all denominators and batch-inverts them once.
- Computes `(roundChallenge - i)` a single time per iteration and reuses it for both the numerator product and denominator.

### Gemini folding

- All `logSize` denominators are precomputed and batch-inverted before entering the fold loop.
- Denominators are independent of the running accumulator, making them suitable for batching.

### Shplonk denominators

- Collects all denominators upfront:
  - `2 * LOG_N + 1` values in non-ZK mode.
  - `2 * LOG_N + 2` values in ZK mode (including the Libra denominator).
- Performs a single batch inversion instead of individual inversions during scalar construction.

### ZK-specific optimizations

Additional improvements for the ZK verifier:

- Replaces `256⁻¹ mod p` with a precomputed constant.
- Computes `geminiR^256` using 8 squarings instead of `pow()`.
- Batch-inverts all 256 `checkEvalsConsistency` denominators.

These changes account for most of the observed ZK gas reduction.

### MSM seeding

Since `shplonkQ` always has scalar `1`:

- The assembly MSM loop now seeds the accumulator directly.
- Avoids an unnecessary `ecMul`.
- On-curve validation remains enforced by the first `ecAdd` in the loop.

## Results

Median `verify()` gas usage via `forge test --gas-report`:

| Verifier | log_n | Baseline | Optimized | Δ | % |
|----------|--------|----------:|----------:|----------:|----------:|
| Add2Honk | 5 | 877,987 | 829,127 | −48,860 | −5.6% |
| Add2HonkZK | 5 | 1,785,462 | 1,458,842 | −326,620 | −18.3% |
| BlakeHonk | 15 | 1,411,841 | 1,267,685 | −144,156 | −10.2% |
| BlakeHonkZK | 15 | 2,400,105 | 1,965,564 | −434,541 | −18.1% |
| EcdsaHonk | 16 | 1,468,213 | 1,314,333 | −153,880 | −10.5% |
| EcdsaHonkZK | 16 | 2,464,484 | 2,018,976 | −445,508 | −18.1% |
| RecursiveHonk | 20 | 1,692,908 | 1,499,709 | −193,199 | −11.4% |
| RecursiveHonkZK | 20 | 2,721,626 | 2,231,521 | −490,105 | −18.0% |
| BlakeOpt / BlakeOptZK | — | 570,264 / 686,231 | identical | 0 | 0% |

### Summary

- **Non-ZK:** ~10% gas reduction, increasing with `log_n`.
- **ZK:** ~18% gas reduction across all circuit sizes, driven primarily by batching the `checkEvalsConsistency` denominators (256 MODEXP calls → 1).
- The hand-optimized assembly verifier is unchanged.

## Tests

- Added unit and fuzz tests for `batchInvert` in `FrLib.t.sol`.
- Added `test_OffCurve_ShplonkQ` to verify that MSM seeding does not weaken off-curve validation for `shplonkQ`.
- Mirrored all changes into `honk_contract.hpp` and `honk_zk_contract.hpp` via `copy_to_cpp.sh`.