### PR TITLE
feat: add alerts for internal networks

### DIFF
--- a/spartan/metrics/grafana/alerts/contactpoints.yaml
+++ b/spartan/metrics/grafana/alerts/contactpoints.yaml
@@ -37,6 +37,30 @@ contactPoints:
         disableResolveMessage: false
 
   - orgId: 1
+    name: "Slack #alerts-staging-public by namespace"
+    receivers:
+      - uid: alertsstagingpublicbynamespace
+        type: slack
+        settings:
+          url: $SLACK_WEBHOOK_STAGING_PUBLIC_URL
+          mentionUsers: $SLACK_ALERT_MENTION_USER_IDS
+          text: |-
+            {{ template "aztec.slack.by_namespace" . }}
+        disableResolveMessage: false
+
+  - orgId: 1
+    name: "Slack #alerts-staging-public by network"
+    receivers:
+      - uid: alertsstagingpublicbynetwork
+        type: slack
+        settings:
+          url: $SLACK_WEBHOOK_STAGING_PUBLIC_URL
+          mentionUsers: $SLACK_ALERT_MENTION_USER_IDS
+          text: |-
+            {{ template "aztec.slack.by_network" . }}
+        disableResolveMessage: false
+
+  - orgId: 1
     name: "Slack #alerts-testnet by namespace"
     receivers:
       - uid: alertstestnetbynamespace

--- a/spartan/metrics/grafana/alerts/rules.yaml
+++ b/spartan/metrics/grafana/alerts/rules.yaml
@@ -516,6 +516,90 @@ groups:
           labels:
             <<: *common_labels
           isPaused: false
+        - uid: slashingroundexecuted
+          title: Slashing - round executed
+          condition: C
+          data:
+            - refId: A
+              relativeTimeRange:
+                from: 600
+                to: 0
+              datasourceUid: spartan-metrics-prometheus
+              model:
+                editorMode: code
+                expr: sum by (k8s_namespace_name) (increase(aztec_slasher_round_executed_count{k8s_namespace_name=~"__INTERNAL_NETWORK_NAMESPACES_REGEX__"}[10m]))
+                instant: true
+                intervalMs: 60000
+                legendFormat: __auto
+                maxDataPoints: 43200
+                range: false
+                refId: A
+            - refId: B
+              relativeTimeRange:
+                from: 600
+                to: 0
+              datasourceUid: __expr__
+              model:
+                conditions:
+                    - evaluator:
+                        params: []
+                        type: gt
+                      operator:
+                        type: and
+                      query:
+                        params:
+                            - B
+                      reducer:
+                        params: []
+                        type: last
+                      type: query
+                datasource:
+                    type: __expr__
+                    uid: __expr__
+                expression: A
+                intervalMs: 1000
+                maxDataPoints: 43200
+                reducer: last
+                refId: B
+                type: reduce
+            - refId: C
+              relativeTimeRange:
+                from: 600
+                to: 0
+              datasourceUid: __expr__
+              model:
+                conditions:
+                    - evaluator:
+                        params:
+                            - 0
+                        type: gt
+                      operator:
+                        type: and
+                      query:
+                        params:
+                            - C
+                      reducer:
+                        params: []
+                        type: last
+                      type: query
+                datasource:
+                    type: __expr__
+                    uid: __expr__
+                expression: B
+                intervalMs: 1000
+                maxDataPoints: 43200
+                refId: C
+                type: threshold
+          dashboardUid: ""
+          panelId: 0
+          noDataState: NoData
+          execErrState: Error
+          for: 0s
+          annotations:
+            summary: Slashing round executed in {{ $labels.k8s_namespace_name }}
+          labels:
+            <<: *common_labels
+          isPaused: false
         - uid: def0g11bn64n4a
           title: Chain - reorg
           condition: C
@@ -1183,6 +1267,596 @@ groups:
           for: 0s
           annotations:
             summary: There was an error taking a snapshot in {{ $labels.k8s_namespace_name }}
+          labels:
+            <<: *common_labels
+          isPaused: false
+        - uid: netlowSlotFillRate
+          title: Sequencer - low slot fill rate
+          condition: C
+          data:
+            - refId: A
+              relativeTimeRange:
+                from: 600
+                to: 0
+              datasourceUid: spartan-metrics-prometheus
+              model:
+                editorMode: code
+                expr: (sum by (k8s_namespace_name) (increase(aztec_sequencer_slot_filled_count{k8s_namespace_name=~"__INTERNAL_NETWORK_NAMESPACES_REGEX__"}[10m])) / sum by (k8s_namespace_name) (increase(aztec_sequencer_slot_total_count{k8s_namespace_name=~"__INTERNAL_NETWORK_NAMESPACES_REGEX__"}[10m]))) and on (k8s_namespace_name) (sum by (k8s_namespace_name) (increase(aztec_sequencer_slot_total_count{k8s_namespace_name=~"__INTERNAL_NETWORK_NAMESPACES_REGEX__"}[10m])) >= 5)
+                instant: true
+                intervalMs: 60000
+                legendFormat: __auto
+                maxDataPoints: 43200
+                range: false
+                refId: A
+            - refId: B
+              relativeTimeRange:
+                from: 600
+                to: 0
+              datasourceUid: __expr__
+              model:
+                conditions:
+                    - evaluator:
+                        params: []
+                        type: gt
+                      operator:
+                        type: and
+                      query:
+                        params:
+                            - B
+                      reducer:
+                        params: []
+                        type: last
+                      type: query
+                datasource:
+                    type: __expr__
+                    uid: __expr__
+                expression: A
+                intervalMs: 1000
+                maxDataPoints: 43200
+                reducer: last
+                refId: B
+                type: reduce
+            - refId: C
+              relativeTimeRange:
+                from: 600
+                to: 0
+              datasourceUid: __expr__
+              model:
+                conditions:
+                    - evaluator:
+                        params:
+                            - 0.8
+                        type: lt
+                      operator:
+                        type: and
+                      query:
+                        params:
+                            - C
+                      reducer:
+                        params: []
+                        type: last
+                      type: query
+                datasource:
+                    type: __expr__
+                    uid: __expr__
+                expression: B
+                intervalMs: 1000
+                maxDataPoints: 43200
+                refId: C
+                type: threshold
+          dashboardUid: ""
+          panelId: 0
+          noDataState: NoData
+          execErrState: Error
+          for: 5m
+          annotations:
+            summary: Sequencer slot fill rate is below 80% in {{ $labels.k8s_namespace_name }}
+          labels:
+            <<: *common_labels
+          isPaused: false
+        - uid: netCheckpointFailures
+          title: Sequencer - checkpoint proposal failures
+          condition: C
+          data:
+            - refId: A
+              relativeTimeRange:
+                from: 600
+                to: 0
+              datasourceUid: spartan-metrics-prometheus
+              model:
+                editorMode: code
+                expr: sum by (k8s_namespace_name, aztec_error_type) (increase(aztec_sequencer_checkpoint_proposal_failed_count{k8s_namespace_name=~"__INTERNAL_NETWORK_NAMESPACES_REGEX__"}[10m]))
+                instant: true
+                intervalMs: 60000
+                legendFormat: __auto
+                maxDataPoints: 43200
+                range: false
+                refId: A
+            - refId: B
+              relativeTimeRange:
+                from: 600
+                to: 0
+              datasourceUid: __expr__
+              model:
+                conditions:
+                    - evaluator:
+                        params: []
+                        type: gt
+                      operator:
+                        type: and
+                      query:
+                        params:
+                            - B
+                      reducer:
+                        params: []
+                        type: last
+                      type: query
+                datasource:
+                    type: __expr__
+                    uid: __expr__
+                expression: A
+                intervalMs: 1000
+                maxDataPoints: 43200
+                reducer: last
+                refId: B
+                type: reduce
+            - refId: C
+              relativeTimeRange:
+                from: 600
+                to: 0
+              datasourceUid: __expr__
+              model:
+                conditions:
+                    - evaluator:
+                        params:
+                            - 2
+                        type: gt
+                      operator:
+                        type: and
+                      query:
+                        params:
+                            - C
+                      reducer:
+                        params: []
+                        type: last
+                      type: query
+                datasource:
+                    type: __expr__
+                    uid: __expr__
+                expression: B
+                intervalMs: 1000
+                maxDataPoints: 43200
+                refId: C
+                type: threshold
+          dashboardUid: ""
+          panelId: 0
+          noDataState: NoData
+          execErrState: Error
+          for: 1m
+          annotations:
+            summary: Checkpoint proposal failed in {{ $labels.k8s_namespace_name }}
+            description: Checkpoint proposal failure reason - {{ $labels.aztec_error_type }}.
+          labels:
+            <<: *common_labels
+          isPaused: false
+        - uid: l1TxPublishFailures
+          title: L1 - tx publish failures
+          condition: C
+          data:
+            - refId: A
+              relativeTimeRange:
+                from: 600
+                to: 0
+              datasourceUid: spartan-metrics-prometheus
+              model:
+                editorMode: code
+                expr: sum by (k8s_namespace_name) (increase({__name__=~"aztec_l1_tx_(reverted|cancelled|not_mined)_count",k8s_namespace_name=~"__INTERNAL_NETWORK_NAMESPACES_REGEX__"}[10m]))
+                instant: true
+                intervalMs: 60000
+                legendFormat: __auto
+                maxDataPoints: 43200
+                range: false
+                refId: A
+            - refId: B
+              relativeTimeRange:
+                from: 600
+                to: 0
+              datasourceUid: __expr__
+              model:
+                conditions:
+                    - evaluator:
+                        params: []
+                        type: gt
+                      operator:
+                        type: and
+                      query:
+                        params:
+                            - B
+                      reducer:
+                        params: []
+                        type: last
+                      type: query
+                datasource:
+                    type: __expr__
+                    uid: __expr__
+                expression: A
+                intervalMs: 1000
+                maxDataPoints: 43200
+                reducer: last
+                refId: B
+                type: reduce
+            - refId: C
+              relativeTimeRange:
+                from: 600
+                to: 0
+              datasourceUid: __expr__
+              model:
+                conditions:
+                    - evaluator:
+                        params:
+                            - 2
+                        type: gt
+                      operator:
+                        type: and
+                      query:
+                        params:
+                            - C
+                      reducer:
+                        params: []
+                        type: last
+                      type: query
+                datasource:
+                    type: __expr__
+                    uid: __expr__
+                expression: B
+                intervalMs: 1000
+                maxDataPoints: 43200
+                refId: C
+                type: threshold
+          dashboardUid: ""
+          panelId: 0
+          noDataState: NoData
+          execErrState: Error
+          for: 1m
+          annotations:
+            summary: L1 transaction publishing is failing in {{ $labels.k8s_namespace_name }}
+          labels:
+            <<: *common_labels
+          isPaused: false
+        - uid: p2pSlowGossipValidation
+          title: P2P - slow gossip validation
+          condition: C
+          data:
+            - refId: A
+              relativeTimeRange:
+                from: 600
+                to: 0
+              datasourceUid: spartan-metrics-prometheus
+              model:
+                editorMode: code
+                expr: sum by (k8s_namespace_name) (increase(aztec_p2p_gossip_slow_validation_count{k8s_namespace_name=~"__INTERNAL_NETWORK_NAMESPACES_REGEX__"}[10m]))
+                instant: true
+                intervalMs: 60000
+                legendFormat: __auto
+                maxDataPoints: 43200
+                range: false
+                refId: A
+            - refId: B
+              relativeTimeRange:
+                from: 600
+                to: 0
+              datasourceUid: __expr__
+              model:
+                conditions:
+                    - evaluator:
+                        params: []
+                        type: gt
+                      operator:
+                        type: and
+                      query:
+                        params:
+                            - B
+                      reducer:
+                        params: []
+                        type: last
+                      type: query
+                datasource:
+                    type: __expr__
+                    uid: __expr__
+                expression: A
+                intervalMs: 1000
+                maxDataPoints: 43200
+                reducer: last
+                refId: B
+                type: reduce
+            - refId: C
+              relativeTimeRange:
+                from: 600
+                to: 0
+              datasourceUid: __expr__
+              model:
+                conditions:
+                    - evaluator:
+                        params:
+                            - 0
+                        type: gt
+                      operator:
+                        type: and
+                      query:
+                        params:
+                            - C
+                      reducer:
+                        params: []
+                        type: last
+                      type: query
+                datasource:
+                    type: __expr__
+                    uid: __expr__
+                expression: B
+                intervalMs: 1000
+                maxDataPoints: 43200
+                refId: C
+                type: threshold
+          dashboardUid: ""
+          panelId: 0
+          noDataState: NoData
+          execErrState: Error
+          for: 1m
+          annotations:
+            summary: P2P gossip validation is slow in {{ $labels.k8s_namespace_name }}
+          labels:
+            <<: *common_labels
+          isPaused: false
+        - uid: mempoolTxPoolAnomaly
+          title: Mempool - tx pool rejection spike
+          condition: C
+          data:
+            - refId: A
+              relativeTimeRange:
+                from: 600
+                to: 0
+              datasourceUid: spartan-metrics-prometheus
+              model:
+                editorMode: code
+                expr: sum by (k8s_namespace_name) (increase({__name__=~"aztec_mempool_tx_pool_v2_(rejected_count|evicted_count|ignored_count|missing_on_protect)",k8s_namespace_name=~"__INTERNAL_NETWORK_NAMESPACES_REGEX__"}[10m]))
+                instant: true
+                intervalMs: 60000
+                legendFormat: __auto
+                maxDataPoints: 43200
+                range: false
+                refId: A
+            - refId: B
+              relativeTimeRange:
+                from: 600
+                to: 0
+              datasourceUid: __expr__
+              model:
+                conditions:
+                    - evaluator:
+                        params: []
+                        type: gt
+                      operator:
+                        type: and
+                      query:
+                        params:
+                            - B
+                      reducer:
+                        params: []
+                        type: last
+                      type: query
+                datasource:
+                    type: __expr__
+                    uid: __expr__
+                expression: A
+                intervalMs: 1000
+                maxDataPoints: 43200
+                reducer: last
+                refId: B
+                type: reduce
+            - refId: C
+              relativeTimeRange:
+                from: 600
+                to: 0
+              datasourceUid: __expr__
+              model:
+                conditions:
+                    - evaluator:
+                        params:
+                            - 50
+                        type: gt
+                      operator:
+                        type: and
+                      query:
+                        params:
+                            - C
+                      reducer:
+                        params: []
+                        type: last
+                      type: query
+                datasource:
+                    type: __expr__
+                    uid: __expr__
+                expression: B
+                intervalMs: 1000
+                maxDataPoints: 43200
+                refId: C
+                type: threshold
+          dashboardUid: ""
+          panelId: 0
+          noDataState: NoData
+          execErrState: Error
+          for: 1m
+          annotations:
+            summary: Tx pool rejected, evicted, ignored, or missing tx count is elevated in {{ $labels.k8s_namespace_name }}
+          labels:
+            <<: *common_labels
+          isPaused: false
+        - uid: seqPipelineDiscards
+          title: Sequencer - pipeline discards
+          condition: C
+          data:
+            - refId: A
+              relativeTimeRange:
+                from: 600
+                to: 0
+              datasourceUid: spartan-metrics-prometheus
+              model:
+                editorMode: code
+                expr: sum by (k8s_namespace_name) (increase({__name__=~"aztec_sequencer_pipeline_(discards_count|parent_checkpoint_mismatch_count)",k8s_namespace_name=~"__INTERNAL_NETWORK_NAMESPACES_REGEX__"}[10m]))
+                instant: true
+                intervalMs: 60000
+                legendFormat: __auto
+                maxDataPoints: 43200
+                range: false
+                refId: A
+            - refId: B
+              relativeTimeRange:
+                from: 600
+                to: 0
+              datasourceUid: __expr__
+              model:
+                conditions:
+                    - evaluator:
+                        params: []
+                        type: gt
+                      operator:
+                        type: and
+                      query:
+                        params:
+                            - B
+                      reducer:
+                        params: []
+                        type: last
+                      type: query
+                datasource:
+                    type: __expr__
+                    uid: __expr__
+                expression: A
+                intervalMs: 1000
+                maxDataPoints: 43200
+                reducer: last
+                refId: B
+                type: reduce
+            - refId: C
+              relativeTimeRange:
+                from: 600
+                to: 0
+              datasourceUid: __expr__
+              model:
+                conditions:
+                    - evaluator:
+                        params:
+                            - 2
+                        type: gt
+                      operator:
+                        type: and
+                      query:
+                        params:
+                            - C
+                      reducer:
+                        params: []
+                        type: last
+                      type: query
+                datasource:
+                    type: __expr__
+                    uid: __expr__
+                expression: B
+                intervalMs: 1000
+                maxDataPoints: 43200
+                refId: C
+                type: threshold
+          dashboardUid: ""
+          panelId: 0
+          noDataState: NoData
+          execErrState: Error
+          for: 1m
+          annotations:
+            summary: Sequencer pipeline discarded checkpoint work in {{ $labels.k8s_namespace_name }}
+          labels:
+            <<: *common_labels
+          isPaused: false
+        - uid: validatorAttestationFailures
+          title: Validator - attestation failures
+          condition: C
+          data:
+            - refId: A
+              relativeTimeRange:
+                from: 600
+                to: 0
+              datasourceUid: spartan-metrics-prometheus
+              model:
+                editorMode: code
+                expr: sum by (k8s_namespace_name, aztec_error_type) (increase({__name__=~"aztec_validator_attestation_failed_(bad_proposal|node_issue)_count",k8s_namespace_name=~"__INTERNAL_NETWORK_NAMESPACES_REGEX__",aztec_is_committee_member="true"}[10m]))
+                instant: true
+                intervalMs: 60000
+                legendFormat: __auto
+                maxDataPoints: 43200
+                range: false
+                refId: A
+            - refId: B
+              relativeTimeRange:
+                from: 600
+                to: 0
+              datasourceUid: __expr__
+              model:
+                conditions:
+                    - evaluator:
+                        params: []
+                        type: gt
+                      operator:
+                        type: and
+                      query:
+                        params:
+                            - B
+                      reducer:
+                        params: []
+                        type: last
+                      type: query
+                datasource:
+                    type: __expr__
+                    uid: __expr__
+                expression: A
+                intervalMs: 1000
+                maxDataPoints: 43200
+                reducer: last
+                refId: B
+                type: reduce
+            - refId: C
+              relativeTimeRange:
+                from: 600
+                to: 0
+              datasourceUid: __expr__
+              model:
+                conditions:
+                    - evaluator:
+                        params:
+                            - 0
+                        type: gt
+                      operator:
+                        type: and
+                      query:
+                        params:
+                            - C
+                      reducer:
+                        params: []
+                        type: last
+                      type: query
+                datasource:
+                    type: __expr__
+                    uid: __expr__
+                expression: B
+                intervalMs: 1000
+                maxDataPoints: 43200
+                refId: C
+                type: threshold
+          dashboardUid: ""
+          panelId: 0
+          noDataState: NoData
+          execErrState: Error
+          for: 1m
+          annotations:
+            summary: Validator attestation failures detected in {{ $labels.k8s_namespace_name }}
+            description: Attestation failure reason - {{ $labels.aztec_error_type }}.
           labels:
             <<: *common_labels
           isPaused: false

--- a/spartan/metrics/templates/grafana-alerts.yaml
+++ b/spartan/metrics/templates/grafana-alerts.yaml
@@ -12,7 +12,7 @@ metadata:
     grafana_alert: "1"
 data:
   {{ $filename }}: |-
-{{ $.Files.Get $path | indent 4 }}
+{{ $.Files.Get $path | replace "__INTERNAL_NETWORK_NAMESPACES_REGEX__" $.Values.alerts.internalNetworkNamespacesRegex | indent 4 }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/spartan/metrics/values.yaml
+++ b/spartan/metrics/values.yaml
@@ -1,3 +1,6 @@
+alerts:
+  internalNetworkNamespacesRegex: "next-net|staging-internal|staging-public"
+
 opentelemetry-collector:
   mode: deployment
 
@@ -119,7 +122,7 @@ grafana:
     server:
       domain:
   env:
-    STAGING_REGEX: "^staging$"
+    STAGING_REGEX: "staging-public|staging-internal"
     NEXT_SCENARIO_REGEX: "v[0-9]+-scenario|next-scenario"
     NEXT_NET_REGEX: "next-net"
     TESTNET_NAMESPACES_REGEX: "testnet|v[0-9]+-testnet"

--- a/yarn-project/slasher/src/metrics.ts
+++ b/yarn-project/slasher/src/metrics.ts
@@ -1,0 +1,19 @@
+import {
+  Metrics,
+  type TelemetryClient,
+  type UpDownCounter,
+  createUpDownCounterWithDefault,
+} from '@aztec/telemetry-client';
+
+export class SlasherMetrics {
+  private readonly roundExecuted: UpDownCounter;
+
+  constructor(client: TelemetryClient, name = 'Slasher') {
+    const meter = client.getMeter(name);
+    this.roundExecuted = createUpDownCounterWithDefault(meter, Metrics.SLASHER_ROUND_EXECUTED_COUNT);
+  }
+
+  public recordRoundExecuted(): void {
+    this.roundExecuted.add(1);
+  }
+}

--- a/yarn-project/slasher/src/slasher_client.test.ts
+++ b/yarn-project/slasher/src/slasher_client.test.ts
@@ -9,12 +9,16 @@ import { DateProvider } from '@aztec/foundation/timer';
 import { openTmpStore } from '@aztec/kv-store/lmdb';
 import type { SlasherConfig } from '@aztec/stdlib/interfaces/server';
 import { type Offense, OffenseType, type ProposerSlashAction } from '@aztec/stdlib/slashing';
+import { Metrics } from '@aztec/telemetry-client';
+import { BenchmarkTelemetryClient } from '@aztec/telemetry-client/bench';
 
 import { jest } from '@jest/globals';
 import { type MockProxy, mockDeep } from 'jest-mock-extended';
 import assert from 'node:assert';
+import type { Hex } from 'viem';
 
 import { DefaultSlasherConfig } from './config.js';
+import { SlasherMetrics } from './metrics.js';
 import { SlasherClient, type SlasherSettings } from './slasher_client.js';
 import { SlasherOffensesStore } from './stores/offenses_store.js';
 import { DummyWatcher } from './test/dummy_watcher.js';
@@ -31,6 +35,7 @@ describe('SlasherClient', () => {
   let dateProvider: DateProvider;
   let logger: Logger;
   let mockEpochCache: MockProxy<EpochCache>;
+  let telemetryClient: BenchmarkTelemetryClient;
 
   let committee: EthAddress[];
 
@@ -123,6 +128,7 @@ describe('SlasherClient', () => {
     dummyWatcher = new DummyWatcher();
     dateProvider = new DateProvider();
     logger = createLogger('test');
+    telemetryClient = new BenchmarkTelemetryClient();
     committee = times(settings.targetCommitteeSize, i => EthAddress.fromNumber(i + 1));
 
     // Create mock EpochCache
@@ -179,6 +185,7 @@ describe('SlasherClient', () => {
       dateProvider,
       offensesStore,
       logger,
+      new SlasherMetrics(telemetryClient),
     );
   });
 
@@ -188,6 +195,20 @@ describe('SlasherClient', () => {
   });
 
   describe('getProposerActions', () => {
+    describe('round execution metrics', () => {
+      it('records a metric when a slashing round is executed', async () => {
+        rollup.getSlashEvents.mockResolvedValue([]);
+
+        await slasherClient.handleRoundExecuted(7n, 2n, '0x1');
+
+        const metric = telemetryClient
+          .getMeters()
+          .flatMap(meter => meter.metrics)
+          .find(metric => metric.name === Metrics.SLASHER_ROUND_EXECUTED_COUNT.name);
+        expect(metric?.points.map(point => point.value)).toEqual([0, 1]);
+      });
+    });
+
     describe('vote-offenses', () => {
       it('should return vote-offenses action when offenses are available for the target round', async () => {
         // Round 5 votes on round 3 (offset of 2)
@@ -1093,6 +1114,10 @@ describe('SlasherClient', () => {
 
 // Test helper class that exposes protected methods for testing
 class TestSlasherClient extends SlasherClient {
+  public override handleRoundExecuted(round: bigint, slashCount: bigint, l1BlockHash: Hex): Promise<void> {
+    return super.handleRoundExecuted(round, slashCount, l1BlockHash);
+  }
+
   public override handleNewRound(round: bigint): Promise<void> {
     return super.handleNewRound(round);
   }

--- a/yarn-project/slasher/src/slasher_client.ts
+++ b/yarn-project/slasher/src/slasher_client.ts
@@ -17,9 +17,11 @@ import {
   getOffenseTypeName,
   getSlashConsensusVotesFromOffenses,
 } from '@aztec/stdlib/slashing';
+import { getTelemetryClient } from '@aztec/telemetry-client';
 
 import type { Hex } from 'viem';
 
+import { SlasherMetrics } from './metrics.js';
 import {
   SlashOffensesCollector,
   type SlashOffensesCollectorConfig,
@@ -101,6 +103,7 @@ export class SlasherClient implements ProposerSlashActionProvider, SlasherClient
     private dateProvider: DateProvider,
     private offensesStore: SlasherOffensesStore,
     private log = createLogger('slasher:consensus'),
+    private readonly metrics = new SlasherMetrics(getTelemetryClient()),
   ) {
     this.roundMonitor = new SlashRoundMonitor(settings, dateProvider);
     this.offensesCollector = new SlashOffensesCollector(config, settings, watchers, offensesStore);
@@ -161,6 +164,7 @@ export class SlasherClient implements ProposerSlashActionProvider, SlasherClient
 
   /** Called when we see a RoundExecuted event on the SlashingProposer (just for logging). */
   protected async handleRoundExecuted(round: bigint, slashCount: bigint, l1BlockHash: Hex) {
+    this.metrics.recordRoundExecuted();
     const slashes = await this.rollup.getSlashEvents(l1BlockHash);
     this.log.info(`Slashing round ${round} has been executed with ${slashCount} slashes`, { slashes });
   }

--- a/yarn-project/telemetry-client/src/metrics.ts
+++ b/yarn-project/telemetry-client/src/metrics.ts
@@ -542,6 +542,11 @@ export const SEQUENCER_SLASHING_ATTEMPTS_COUNT: MetricDefinition = {
   description: 'The number of slashing action attempts',
   valueType: ValueType.INT,
 };
+export const SLASHER_ROUND_EXECUTED_COUNT: MetricDefinition = {
+  name: 'aztec.slasher.round.executed_count',
+  description: 'The number of slashing rounds executed',
+  valueType: ValueType.INT,
+};
 export const SEQUENCER_CHECKPOINT_SUCCESS_COUNT: MetricDefinition = {
   name: 'aztec.sequencer.checkpoint.success_count',
   description: 'The number of times checkpoint publishing succeeded',


### PR DESCRIPTION
Fix A-1139

Alert on:
- any slashing round execution
- missed slots
- checkpoint proposal failures
- L1 failures
- slow gossip validation
- spike in tx validation
- attestation validation issues
- parent checkpoint mismatch