### PR TITLE
test(ci): mark e2e_epochs/epochs_mbps_redistribution as flaky

### DIFF
--- a/.test_patterns.yml
+++ b/.test_patterns.yml
@@ -275,6 +275,13 @@ tests:
     owners:
       - *sean
 
+  # Asserts all late txs land in the checkpoint's last block, but the proposer seals the last block as
+  # soon as one tx is available and snapshots the mempool, so late txs still propagating over gossip
+  # spill into the next checkpoint. Flaky until the sequencer waits for the last block's tx window.
+  - regex: "src/e2e_epochs/epochs_mbps_redistribution.test.ts"
+    owners:
+      - *phil
+
   # Blanket flake patterns for unstable p2p, epoch, and l1 tx utils tests
   # This is a temporary measure while team bandwidth is constrained
   # Replaced many specific patterns - see https://github.com/AztecProtocol/aztec-packages/pull/17962 for historical context


### PR DESCRIPTION
## What

Adds `src/e2e_epochs/epochs_mbps_redistribution.test.ts` to `.test_patterns.yml` as a flaky test so its failures alert owners rather than blocking the merge queue.

## Why

`epochs_mbps_redistribution` ("redistributes checkpoint budget so late txs fit in the last block") dequeued #24053 from the merge queue by failing both its initial run and its retry. It is not a redistribution regression — it is a timing race in the sequencer:

- The proposer's last block releases as soon as `availableTxs >= 1` (`waitForMinTxs`) and then `iterateEligiblePendingTxs` freezes the tx set in a single mempool snapshot (`p2p/src/client/p2p_client.ts`).
- The four late txs are submitted concurrently and propagate over gossip one at a time, while the proposer polls every 500ms.
- Whichever subset is present at the releasing poll is what the last block gets; the rest spill into the next checkpoint, so `new Set(lateBlockNumbers).size` is occasionally 2 instead of 1.

The existing blanket entry `src/e2e_epochs/.*\.test\.ts` only tolerates this within the `e2e-p2p-epoch-flakes` group budget (`flake_error_threshold: 5`), which is why a hard failure still got through. This adds a dedicated, ungrouped entry so the specific test is always treated as a flake.

## Follow-up

This is the stop-gap. The real fix (separate PR) makes the final block of a checkpoint collect txs until its build deadline instead of sealing on the first available tx, which removes the race deterministically. Once that lands, this entry should be removed.