### PR TITLE
test(spartan): wait for proposed instead of checkpointed in performTransfers

### DIFF
--- a/yarn-project/end-to-end/src/spartan/setup_test_wallets.ts
+++ b/yarn-project/end-to-end/src/spartan/setup_test_wallets.ts
@@ -16,6 +16,7 @@ import { makeBackoff, retry, retryUntil } from '@aztec/foundation/retry';
 import { TokenContract } from '@aztec/noir-contracts.js/Token';
 import { Gas } from '@aztec/stdlib/gas';
 import type { AztecNodeAdmin } from '@aztec/stdlib/interfaces/client';
+import { TxStatus } from '@aztec/stdlib/tx';
 import { getGasLimits } from '@aztec/wallet-sdk/base-wallet';
 import { registerInitialLocalNetworkAccountsInWallet } from '@aztec/wallets/testing';
 
@@ -429,7 +430,9 @@ export async function performTransfers({
 
     const provenTxs = await Promise.all(txs);
 
-    await Promise.all(provenTxs.map(t => t.send({ wait: { timeout: 600 } })));
+    // Wait only for the txs to be proposed, not checkpointed. This is enough to keep the chain
+    // loaded for the reorg scenario, and avoids each round blocking on the (slower) checkpoint lag.
+    await Promise.all(provenTxs.map(t => t.send({ wait: { timeout: 600, waitForStatus: TxStatus.PROPOSED } })));
 
     logger.info(`Completed round ${i + 1} / ${rounds}`);
   }


### PR DESCRIPTION
Backport of #23853 for the v5 Spartan train.

Linear: https://linear.app/aztec-labs/issue/A-1233/nightly-scenario-reorg-test-times-out-post-disruption-recovery-too

This keeps the reorg scenario transfer loop from waiting for each round to reach CHECKPOINTED before submitting the next round; PROPOSED is enough to keep the chain loaded.

Testing: `git diff --check` passed. `yarn build` was not run because the temporary worktree does not have Yarn node_modules state installed.