### PR TITLE
fix: set default inbox lag to 2

### DIFF
--- a/spartan/environments/network-defaults.yml
+++ b/spartan/environments/network-defaults.yml
@@ -66,7 +66,7 @@ l1-contracts: &l1-contracts-defaults
   # Proof & Block Configuration
   #---------------------------------------------------------------------------
   # Checkpoints to lag in inbox (prevents sequencer DOS attacks).
-  AZTEC_INBOX_LAG: 1
+  AZTEC_INBOX_LAG: 2
   # Epochs after end that proofs are still accepted.
   AZTEC_PROOF_SUBMISSION_EPOCHS: 1
   # Target mana consumption per block.


### PR DESCRIPTION
## Summary
- set the baked-in AZTEC_INBOX_LAG default to 2 in network-defaults.yml
- leave generated outputs unchanged; they will be regenerated by the normal generation flow

## Testing
- not run; YAML default only