### PR TITLE
refactor(pxe): restore satisfies-typed oracle registries

### DIFF
--- a/yarn-project/pxe/src/contract_function_simulator/oracle/oracle_registry.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/oracle_registry.ts
@@ -81,71 +81,7 @@ export {
   type TypeMapping,
 } from './oracle_type_mappings.js';
 
-type OracleRegistryName =
-  | 'aztec_misc_assertCompatibleOracleVersion'
-  | 'aztec_misc_getRandomField'
-  | 'aztec_misc_log'
-  | 'aztec_utl_getUtilityContext'
-  | 'aztec_utl_getKeyValidationRequest'
-  | 'aztec_utl_getContractInstance'
-  | 'aztec_utl_getNoteHashMembershipWitness'
-  | 'aztec_utl_getBlockHashMembershipWitness'
-  | 'aztec_utl_getNullifierMembershipWitness'
-  | 'aztec_utl_getLowNullifierMembershipWitness'
-  | 'aztec_utl_getPublicDataWitness'
-  | 'aztec_utl_getBlockHeader'
-  | 'aztec_utl_getAuthWitness'
-  | 'aztec_utl_getPublicKeysAndPartialAddress'
-  | 'aztec_utl_doesNullifierExist'
-  | 'aztec_utl_getL1ToL2MembershipWitness'
-  | 'aztec_utl_getFromPublicStorage'
-  | 'aztec_utl_getNotes'
-  | 'aztec_utl_getPendingTaggedLogs'
-  | 'aztec_utl_validateAndStoreEnqueuedNotesAndEvents'
-  | 'aztec_utl_getLogsByTag'
-  | 'aztec_utl_getMessageContextsByTxHash'
-  | 'aztec_utl_getTxEffect'
-  | 'aztec_utl_setCapsule'
-  | 'aztec_utl_getCapsule'
-  | 'aztec_utl_deleteCapsule'
-  | 'aztec_utl_copyCapsule'
-  | 'aztec_utl_decryptAes128'
-  | 'aztec_utl_getSharedSecrets'
-  | 'aztec_utl_setContractSyncCacheInvalid'
-  | 'aztec_utl_emitOffchainEffect'
-  | 'aztec_utl_callUtilityFunction'
-  | 'aztec_utl_pushEphemeral'
-  | 'aztec_utl_popEphemeral'
-  | 'aztec_utl_getEphemeral'
-  | 'aztec_utl_setEphemeral'
-  | 'aztec_utl_getEphemeralLen'
-  | 'aztec_utl_removeEphemeral'
-  | 'aztec_utl_clearEphemeral'
-  | 'aztec_utl_pushTransient'
-  | 'aztec_utl_popTransient'
-  | 'aztec_utl_getTransient'
-  | 'aztec_utl_setTransient'
-  | 'aztec_utl_getTransientLen'
-  | 'aztec_utl_removeTransient'
-  | 'aztec_utl_clearTransient'
-  | 'aztec_prv_setHashPreimage'
-  | 'aztec_prv_getHashPreimage'
-  | 'aztec_prv_notifyCreatedNote'
-  | 'aztec_prv_notifyNullifiedNote'
-  | 'aztec_prv_notifyCreatedNullifier'
-  | 'aztec_prv_isNullifierPending'
-  | 'aztec_prv_notifyCreatedContractClassLog'
-  | 'aztec_prv_callPrivateFunction'
-  | 'aztec_prv_assertValidPublicCalldata'
-  | 'aztec_prv_notifyRevertiblePhaseStart'
-  | 'aztec_prv_isExecutionInRevertiblePhase'
-  | 'aztec_prv_getAppTaggingSecret'
-  | 'aztec_prv_getNextTaggingIndex'
-  | 'aztec_prv_getSenderForTags';
-
-type OracleRegistry = Record<OracleRegistryName, OracleRegistryEntry>;
-
-export const ORACLE_REGISTRY: OracleRegistry = {
+export const ORACLE_REGISTRY = {
   aztec_misc_assertCompatibleOracleVersion: makeEntry({
     params: [
       { name: 'major', type: U32 },
@@ -566,7 +502,7 @@ export const ORACLE_REGISTRY: OracleRegistry = {
   }),
 
   aztec_prv_getSenderForTags: makeEntry({ returnType: OPTION(AZTEC_ADDRESS) }),
-};
+} satisfies Record<string, OracleRegistryEntry>;
 
 // ─── Registry Infrastructure ─────────────────────────────────────────────────
 

--- a/yarn-project/txe/src/oracle/test-resolver/resolver.ts
+++ b/yarn-project/txe/src/oracle/test-resolver/resolver.ts
@@ -33,7 +33,7 @@ export class OracleTestResolver {
 
   constructor(
     private readonly registry: Record<string, OracleRegistryEntry>,
-    private readonly fixtures: Partial<Record<string, OracleTestScenario[]>>,
+    private readonly fixtures: Record<string, OracleTestScenario[]>,
     logger?: Logger,
   ) {
     this.logger = logger ?? createLogger('txe:test-resolver');

--- a/yarn-project/txe/src/oracle/txe_oracle_registry.ts
+++ b/yarn-project/txe/src/oracle/txe_oracle_registry.ts
@@ -146,7 +146,7 @@ const TXE_PRIVATE_EVENTS: TypeMapping<Fr[][]> = {
   },
 };
 
-export const TXE_ORACLE_REGISTRY: Record<string, OracleRegistryEntry> = {
+export const TXE_ORACLE_REGISTRY = {
   ...ORACLE_REGISTRY,
 
   aztec_txe_assertCompatibleOracleVersion: makeEntry({
@@ -368,7 +368,7 @@ export const TXE_ORACLE_REGISTRY: Record<string, OracleRegistryEntry> = {
     params: [{ name: 'address', type: AZTEC_ADDRESS }],
     returnType: CONTRACT_INSTANCE_MEMBER,
   }),
-};
+} satisfies Record<string, OracleRegistryEntry>;
 
 /**
  * Deserializes oracle inputs, calls the handler with typed params, serializes the result, and wraps

--- a/yarn-project/txe/src/oracle/txe_oracle_top_level_context.ts
+++ b/yarn-project/txe/src/oracle/txe_oracle_top_level_context.ts
@@ -174,7 +174,7 @@ export class TXEOracleTopLevelContext implements IMiscOracle, ITxeExecutionOracl
     return (await this.stateMachine.node.getBlockData('latest'))!.header.globalVariables.timestamp;
   }
 
-  async getLastTxEffects(): ReturnType<ITxeExecutionOracle['getLastTxEffects']> {
+  async getLastTxEffects() {
     const latestBlockNumber = await this.stateMachine.archiver.getBlockNumber();
     const block = await this.stateMachine.archiver.getBlock({ number: latestBlockNumber });
 


### PR DESCRIPTION
## Summary

- #23821 (a sequencer-timetable refactor) incidentally rewrote the oracle registry typings: it swapped the `satisfies Record<string, OracleRegistryEntry>` form on `ORACLE_REGISTRY` and `TXE_ORACLE_REGISTRY` for explicit `Record<…>` / hand-maintained named-union annotations, widened the test resolver's `fixtures` parameter to `Partial<…>`, and added an explicit return type on `getLastTxEffects`.
- Those annotations widen every registry entry to the generic `OracleRegistryEntry`, which collapses the derived oracle interfaces (`IMiscOracle` / `IUtilityExecutionOracle` / `IPrivateExecutionOracle`) and the TXE roundtrip-test fixture types (`OracleTestScenario<K>`) down to `any` / `string`, silently dropping the per-oracle type checking that #23840 and the oracle test framework were built to provide.
- This reverts those four type-level edits back to the `satisfies` form, restoring the precise per-entry types. `tsgo` declaration build, `--noEmit`, and lint all pass on `pxe` and `txe`.