### PR TITLE
fix(testnet): scale per-offense slash penalties so slashing can trigger

### DIFF
--- a/spartan/environments/testnet.env
+++ b/spartan/environments/testnet.env
@@ -32,6 +32,19 @@ AZTEC_PROVING_COST_PER_MANA=12500000
 AZTEC_SLASH_AMOUNT_SMALL=100000e18
 AZTEC_SLASH_AMOUNT_MEDIUM=250000e18
 AZTEC_SLASH_AMOUNT_LARGE=250000e18
+# Per-offense penalties must be on the same scale as the onchain slash amounts above. The slasher sums an
+# offender's penalties for an epoch and maps the total to 1/2/3 slash units by comparing against
+# [SMALL, MEDIUM, LARGE]; a total below SMALL maps to 0 units and is never voted on. The generated defaults
+# (10e18) are ~10,000x below SMALL (100000e18), so without these overrides every offense rounds down to 0
+# units and slashing can never trigger on testnet. Liveness faults map to SMALL (1 unit); provable validity
+# and data-availability faults map to LARGE (3 units).
+SLASH_INACTIVITY_PENALTY=100000e18
+SLASH_UNKNOWN_PENALTY=100000e18
+SLASH_DATA_WITHHOLDING_PENALTY=250000e18
+SLASH_INVALID_BLOCK_PENALTY=250000e18
+SLASH_PROPOSE_INVALID_ATTESTATIONS_PENALTY=250000e18
+SLASH_PROPOSE_DESCENDANT_OF_CHECKPOINT_WITH_INVALID_ATTESTATIONS_PENALTY=250000e18
+SLASH_ATTEST_INVALID_CHECKPOINT_PROPOSAL_PENALTY=250000e18
 AZTEC_ACTIVATION_THRESHOLD=200000e18
 AZTEC_EJECTION_THRESHOLD=100000e18
 AZTEC_GOVERNANCE_PROPOSER_ROUND_SIZE=100


### PR DESCRIPTION
## Problem

The testnet config shipped with `v5.0.0-rc.1` cannot ever slash a validator.

`spartan/environments/testnet.env` raises the onchain slash amounts to be meaningful relative to the 200,000e18 activation threshold:

```
AZTEC_SLASH_AMOUNT_SMALL=100000e18
AZTEC_SLASH_AMOUNT_MEDIUM=250000e18
AZTEC_SLASH_AMOUNT_LARGE=250000e18
```

…but it does **not** override the per-offense penalties, so they keep the generated defaults from `network-defaults.yml` (`~10e18`).

How slashing decides what to vote (`yarn-project/stdlib/src/slashing/votes.ts`):

1. The slasher sums an offender's penalties for an epoch.
2. `getSlashUnitsForAmount` maps that total to **0/1/2/3 units** by comparing against the onchain `[SMALL, MEDIUM, LARGE]` amounts (read from the `SlashingProposer` contract).
3. A total below `SMALL` → **0 units** → no vote is cast → quorum is never reached → `executeRound` produces no `SlashAction`.

With penalties at `10e18` and `SMALL` at `100000e18`, every offense is ~10,000× too small to reach even 1 unit. A slashing round spans only 2 epochs, so realistic accumulation (~1–2 offenses) never gets close. Result: the sentinel correctly detects offenses, but **no validator is ever slashed**. The collector even logs `Offense amount … is below minimum slashing amount …` on every offense (`slash_offenses_collector.ts:100`).

## Fix

Override the active per-offense penalties in `testnet.env` onto the same scale as the onchain amounts:

| Offense | Penalty | Units | Effect |
|---|---|---|---|
| Inactivity (liveness) | 100000e18 | SMALL (1) | slash 100k |
| Unknown (catch-all) | 100000e18 | SMALL (1) | slash 100k |
| Data withholding | 250000e18 | LARGE (3) | full confiscation |
| Invalid block | 250000e18 | LARGE (3) | full confiscation |
| Propose invalid attestations | 250000e18 | LARGE (3) | full confiscation |
| Propose descendant w/ invalid attestations | 250000e18 | LARGE (3) | full confiscation |
| Attest invalid checkpoint proposal | 250000e18 | LARGE (3) | full confiscation |

The intentionally-disabled offenses (duplicate proposal/attestation, invalid checkpoint proposal — `0` in the defaults) are left untouched.

This is the only fix deployable to the **live** testnet without redeploying L1 contracts: `AZTEC_SLASH_AMOUNT_*` are `SlashingProposer` immutables fixed at genesis, whereas `SLASH_*_PENALTY` is node-side config read at runtime and reaches pods via `deploy_network.sh` → helm → pod env.

## Notes / follow-ups (not in this PR)

- Because `AZTEC_LOCAL_EJECTION_THRESHOLD=199000e18`, **any** slash on a 200k stake fully ejects the validator (`StakingLib.slash`): `200k − 100k = 100k < 199k`. SMALL burns 100k and returns 100k via exit; LARGE (capped at the 200k balance) burns the whole stake. There is no "small penalty, keep validating" path on testnet — that's a separate tuning decision.
- `SLASH_INACTIVITY_CONSECUTIVE_EPOCH_THRESHOLD` defaults to `1`, so a single inactive epoch now ejects. If that's too aggressive for testnet, raise the threshold.