### PR TITLE
fix(validator): make block-number guard reorg-aware (A-1218)

### DIFF
--- a/yarn-project/validator-client/src/proposal_handler.test.ts
+++ b/yarn-project/validator-client/src/proposal_handler.test.ts
@@ -1,5 +1,6 @@
 import type { Archiver } from '@aztec/archiver';
 import type { BlobClientInterface } from '@aztec/blob-client/client';
+import { INITIAL_L2_BLOCK_NUM } from '@aztec/constants';
 import type { EpochCache } from '@aztec/epoch-cache';
 import { MAX_FEE_ASSET_PRICE_MODIFIER_BPS } from '@aztec/ethereum/contracts';
 import { BlockNumber, CheckpointNumber, SlotNumber } from '@aztec/foundation/branded-types';
@@ -19,6 +20,7 @@ import { CheckpointHeader } from '@aztec/stdlib/rollup';
 import {
   TEST_COORDINATION_SIGNATURE_CONTEXT,
   makeBlockHeader,
+  makeBlockProposal,
   makeCheckpointHeader,
   makeCheckpointProposal,
 } from '@aztec/stdlib/testing';
@@ -637,6 +639,95 @@ describe('ProposalHandler checkpoint validation', () => {
       const proposal = await makeProposal({ archiveRoot, checkpointHeader: makeHeader() });
       await handler.handleCheckpointProposal(proposal, proposalInfo);
       expect(mockDispose).toHaveBeenCalled();
+    });
+  });
+
+  // Regression for A-1218: during a reorg the archiver can still hold a stale block at the proposal's
+  // number (a different archive, about to be pruned) while the proposal carries the rebuilt replacement.
+  // The block-number guard used to key on number only and permanently drop the rebuilt proposal, so the
+  // node never re-acquired the block and missed the later checkpoint attestation. The guard must reject
+  // only genuine duplicates (same archive) and otherwise wait for the local prune.
+  describe('handleBlockProposal block-number guard (reorg-aware)', () => {
+    /**
+     * Builds a proposal whose parent resolves to genesis (so blockNumber = INITIAL_L2_BLOCK_NUM) and a
+     * handler wired to accept it up to the block-number guard.
+     */
+    async function setupGenesisProposal(proposalArchive: Fr) {
+      const proposal = await makeBlockProposal({
+        blockHeader: makeBlockHeader(1, { slotNumber: SlotNumber(1) }),
+        archiveRoot: proposalArchive,
+      });
+
+      // Parent archive == genesis archive → genesis path → blockNumber = INITIAL_L2_BLOCK_NUM.
+      blockSource.getGenesisValues.mockResolvedValue({
+        genesisArchiveRoot: proposal.blockHeader.lastArchive.root,
+      } as any);
+
+      const blockProposalValidator = mock<BlockProposalValidator>();
+      blockProposalValidator.validate.mockResolvedValue({ result: 'accept' } as any);
+
+      const txProvider = mock<ITxProvider>();
+      txProvider.getTxsForBlockProposal.mockResolvedValue({ txs: [], missingTxs: [] } as any);
+
+      const blockHandler = new ProposalHandler(
+        checkpointsBuilder,
+        mock<WorldStateSynchronizer>(),
+        blockSource,
+        l1ToL2MessageSource,
+        txProvider,
+        blockProposalValidator,
+        epochCache,
+        consensusTimetable,
+        config,
+        mock<BlobClientInterface>(),
+        new CheckpointReexecutionTracker(),
+        metrics,
+        dateProvider,
+      );
+      return { proposal, blockHandler };
+    }
+
+    /** Block-data stub at the target number with the given archive root. */
+    const blockAt = (archiveRoot: Fr) => ({ archive: new AppendOnlyTreeSnapshot(archiveRoot, 1) }) as BlockData;
+
+    it('rejects a genuine duplicate (existing block has the same archive)', async () => {
+      const archive = Fr.random();
+      const { proposal, blockHandler } = await setupGenesisProposal(archive);
+      blockSource.getBlockData.mockResolvedValue(blockAt(archive));
+
+      const result = await blockHandler.handleBlockProposal(proposal, {} as any, false);
+      expect(result).toEqual({
+        isValid: false,
+        blockNumber: BlockNumber(INITIAL_L2_BLOCK_NUM),
+        reason: 'block_number_already_exists',
+      });
+    });
+
+    it('processes a rebuilt proposal once the stale fork at this number is pruned', async () => {
+      const { proposal, blockHandler } = await setupGenesisProposal(Fr.random());
+      // Well before the slot-1 attestation deadline (40s), so the prune wait has budget to retry.
+      dateProvider.setTime(1_000);
+      // Stale block (different archive) on the first read, then pruned (undefined) on the retry.
+      blockSource.getBlockData.mockResolvedValueOnce(blockAt(Fr.random())).mockResolvedValue(undefined);
+
+      const result = await blockHandler.handleBlockProposal(proposal, {} as any, false);
+      expect(result).toEqual({ isValid: true, blockNumber: BlockNumber(INITIAL_L2_BLOCK_NUM) });
+      expect(blockSource.syncImmediate).toHaveBeenCalled();
+    });
+
+    it('falls back to block_number_already_exists when the stale fork is not pruned before the deadline', async () => {
+      const { proposal, blockHandler } = await setupGenesisProposal(Fr.random());
+      // A different block keeps occupying this number and never gets pruned.
+      blockSource.getBlockData.mockResolvedValue(blockAt(Fr.random()));
+      // attestation_deadline(slot=1) = 40s; hold wall-clock past it so the wait fails fast.
+      dateProvider.setTime(41_000);
+
+      const result = await blockHandler.handleBlockProposal(proposal, {} as any, false);
+      expect(result).toEqual({
+        isValid: false,
+        blockNumber: BlockNumber(INITIAL_L2_BLOCK_NUM),
+        reason: 'block_number_already_exists',
+      });
     });
   });
 });

--- a/yarn-project/validator-client/src/proposal_handler.ts
+++ b/yarn-project/validator-client/src/proposal_handler.ts
@@ -598,17 +598,21 @@ export class ProposalHandler {
     });
 
     try {
-      await retryUntil(
+      const { block } = await retryUntil(
         async () => {
           await this.blockSource.syncImmediate();
           const block = await this.blockSource.getBlockData({ number: blockNumber });
-          return block === undefined;
+          // Resolve once the existing block is gone (pruned) or has been replaced by one matching the
+          // proposal — the same condition as the early return above. A matching block is returned so the
+          // caller still treats it as a genuine duplicate; an `undefined` (pruned) block lets the proposal
+          // be processed. Wrap in an object so the `undefined` case is still a truthy retry result.
+          return block === undefined || block.archive.root.equals(proposalArchive) ? { block } : undefined;
         },
         `prune of stale block ${blockNumber}`,
         { deadline, dateProvider: this.dateProvider },
         0.5,
       );
-      return undefined;
+      return block;
     } catch (err) {
       if (err instanceof TimeoutError) {
         this.log.warn(`Timed out waiting for stale block ${blockNumber} to be pruned`, { blockNumber });

--- a/yarn-project/validator-client/src/proposal_handler.ts
+++ b/yarn-project/validator-client/src/proposal_handler.ts
@@ -410,8 +410,12 @@ export class ProposalHandler {
         : BlockNumber(parentBlock.header.getBlockNumber() + 1);
     proposalInfo.blockNumber = blockNumber;
 
-    // Check that this block number does not exist already
-    const existingBlock = await this.blockSource.getBlockData({ number: blockNumber });
+    // Check that this block number does not exist already. During a reorg the archiver can still hold a
+    // stale block at this number (a different archive, about to be pruned) while the proposal carries the
+    // rebuilt replacement; resolveExistingBlockAtNumber waits for the local prune in that case so the
+    // rebuilt block is processed in time to attest, rather than being permanently dropped on a bare
+    // number collision.
+    const existingBlock = await this.resolveExistingBlockAtNumber(blockNumber, proposal.archive, slotNumber);
     if (existingBlock) {
       this.log.warn(`Block number ${blockNumber} already exists, skipping processing`, proposalInfo);
       return { isValid: false, blockNumber, reason: 'block_number_already_exists' };
@@ -558,6 +562,61 @@ export class ProposalHandler {
         this.log.error('Error getting parent block by archive root', err, { parentArchive });
       }
       return undefined;
+    }
+  }
+
+  /**
+   * Resolves whether a block genuinely already exists at `blockNumber`. Returns the existing block only if
+   * it is a true duplicate of the proposal (matching archive). During a reorg the archiver can still hold a
+   * stale fork at this number (different archive) that is about to be pruned; in that case this forces L1
+   * sync and waits, bounded by the attestation deadline, for the prune to land, then returns `undefined` so
+   * the rebuilt block proposal can be processed in time to attest. If the prune does not complete before the
+   * deadline it returns the stale block, so the caller falls back to the safe `block_number_already_exists`
+   * rejection.
+   */
+  private async resolveExistingBlockAtNumber(
+    blockNumber: BlockNumber,
+    proposalArchive: Fr,
+    slotNumber: SlotNumber,
+  ): Promise<BlockData | undefined> {
+    const existingBlock = await this.blockSource.getBlockData({ number: blockNumber });
+    if (!existingBlock || existingBlock.archive.root.equals(proposalArchive)) {
+      return existingBlock;
+    }
+
+    // A different block already occupies this number: it is a stale fork being pruned during a reorg, not a
+    // genuine duplicate. Wait for the local prune rather than permanently rejecting the rebuilt proposal.
+    const deadline = this.getReexecutionDeadline(slotNumber);
+    if (deadline.getTime() - this.dateProvider.now() <= 0) {
+      return existingBlock;
+    }
+
+    this.log.warn(`Block number ${blockNumber} held by a stale fork, awaiting prune before processing proposal`, {
+      blockNumber,
+      existingArchive: existingBlock.archive.root.toString(),
+      proposalArchive: proposalArchive.toString(),
+    });
+
+    try {
+      const { block } = await retryUntil(
+        async () => {
+          await this.blockSource.syncImmediate();
+          const block = await this.blockSource.getBlockData({ number: blockNumber });
+          // Resolve once the stale fork is gone (pruned) or has been replaced by the rebuilt block. Wrap in
+          // an object so an `undefined` (pruned) block is still a truthy result that ends the retry loop.
+          return block === undefined || block.archive.root.equals(proposalArchive) ? { block } : undefined;
+        },
+        `prune of stale block ${blockNumber}`,
+        { deadline, dateProvider: this.dateProvider },
+        0.5,
+      );
+      return block;
+    } catch (err) {
+      if (err instanceof TimeoutError) {
+        this.log.warn(`Timed out waiting for stale block ${blockNumber} to be pruned`, { blockNumber });
+        return existingBlock;
+      }
+      throw err;
     }
   }
 

--- a/yarn-project/validator-client/src/proposal_handler.ts
+++ b/yarn-project/validator-client/src/proposal_handler.ts
@@ -569,7 +569,7 @@ export class ProposalHandler {
    * Resolves whether a block genuinely already exists at `blockNumber`. Returns the existing block only if
    * it is a true duplicate of the proposal (matching archive). During a reorg the archiver can still hold a
    * stale fork at this number (different archive) that is about to be pruned; in that case this forces L1
-   * sync and waits, bounded by the attestation deadline, for the prune to land, then returns `undefined` so
+   * sync and waits, bounded by the re-execution deadline, for the prune to land, then returns `undefined` so
    * the rebuilt block proposal can be processed in time to attest. If the prune does not complete before the
    * deadline it returns the stale block, so the caller falls back to the safe `block_number_already_exists`
    * rejection.
@@ -584,33 +584,31 @@ export class ProposalHandler {
       return existingBlock;
     }
 
-    // A different block already occupies this number: it is a stale fork being pruned during a reorg, not a
-    // genuine duplicate. Wait for the local prune rather than permanently rejecting the rebuilt proposal.
+    // A different block already occupies this number: it may be a stale fork being pruned during a reorg, not a
+    // genuine duplicate. Wait for the local prune rather than permanently rejecting the proposal.
     const deadline = this.getReexecutionDeadline(slotNumber);
     if (deadline.getTime() - this.dateProvider.now() <= 0) {
       return existingBlock;
     }
 
-    this.log.warn(`Block number ${blockNumber} held by a stale fork, awaiting prune before processing proposal`, {
+    this.log.warn(`Block number ${blockNumber} already exists, awaiting potential prune`, {
       blockNumber,
       existingArchive: existingBlock.archive.root.toString(),
       proposalArchive: proposalArchive.toString(),
     });
 
     try {
-      const { block } = await retryUntil(
+      await retryUntil(
         async () => {
           await this.blockSource.syncImmediate();
           const block = await this.blockSource.getBlockData({ number: blockNumber });
-          // Resolve once the stale fork is gone (pruned) or has been replaced by the rebuilt block. Wrap in
-          // an object so an `undefined` (pruned) block is still a truthy result that ends the retry loop.
-          return block === undefined || block.archive.root.equals(proposalArchive) ? { block } : undefined;
+          return block === undefined;
         },
         `prune of stale block ${blockNumber}`,
         { deadline, dateProvider: this.dateProvider },
         0.5,
       );
-      return block;
+      return undefined;
     } catch (err) {
       if (err instanceof TimeoutError) {
         this.log.warn(`Timed out waiting for stale block ${blockNumber} to be pruned`, { blockNumber });

--- a/yarn-project/validator-client/src/validator.test.ts
+++ b/yarn-project/validator-client/src/validator.test.ts
@@ -928,9 +928,14 @@ describe('ValidatorClient', () => {
     });
 
     it('should not validate proposal if the proposed block number is taken', async () => {
-      // Parent block lookup (by archive) returns valid data; existence check (by number) also returns data → block taken.
+      // Parent block lookup (by archive) returns valid data; existence check (by number) returns a block
+      // with the same archive as the proposal → a genuine duplicate, so the number is taken.
       blockSource.getBlockData.mockImplementation(query =>
-        Promise.resolve('number' in query ? ({ header: {} as BlockHeader } as any) : parentBlockData),
+        Promise.resolve(
+          'number' in query
+            ? ({ header: {} as BlockHeader, archive: { root: proposal.archive } } as any)
+            : parentBlockData,
+        ),
       );
       const isValid = await validatorClient.validateBlockProposal(proposal, sender);
       expect(isValid).toBe(false);


### PR DESCRIPTION
## Problem

A validator can permanently miss an attestation during an L2 reorg because of a prune-vs-proposal race in the block-proposal handler. When a stale block N is being pruned and the rebuilt block N proposal arrives in the small window *before this node has applied the prune*, the handler rejected it with `block_number_already_exists` and never re-processed it. The rebuilt block then never landed locally, so the later checkpoint proposal validation polled for it by archive until the attestation deadline and gave up with `last_block_not_found` — no attestation.

The guard at `proposal_handler.ts` keyed on block *number only*: it looked up `getBlockData({ number })` and rejected if any block existed at that number, without comparing the existing block's archive to the proposal.

## Log verification

Confirmed against CI run [`3a45cda231c3747c`](http://ci.aztec-labs.com/3a45cda231c3747c) (failing test `e2e_p2p_multiple_validators_sentinel › collects attestations for all validators on a node`):

- `22:19:05.442` — validator-2 logged `Block number 3 already exists, skipping processing` → `block_number_already_exists` for the rebuilt slot-11 block 3 (archive `0x1cfa1dec…`).
- validator-2 was lagging: peers pruned at `.299–.399`, validator-2 not until `.600` (~158ms after rejecting), so it still held stale block 3 at rejection time.
- `22:20:08.684` — checkpoint validation timed out with `last_block_not_found` on the same archive → missed attestation.
- The slot-11 block never landed on L1 and was permanently lost on validator-2, so an L1-sync-only recovery could never have recovered it — the block must be taken from the proposal in hand.

## Fix

`resolveExistingBlockAtNumber` now compares the existing block's archive to the proposal:

- **Same archive** → genuine duplicate, still skipped (unchanged behaviour).
- **Different archive** → a different, un-checkpointed block occupies this number (e.g. a stale fork being pruned during a reorg). Force L1 sync and wait, bounded by the re-execution deadline, for the local prune to land, then return `undefined` so the proposal is processed from the proposal already in hand and is available to attest.
- **Prune doesn't land before the deadline** → fall back to the safe `block_number_already_exists` rejection.

## Tests

Three new deterministic unit cases in `proposal_handler.test.ts`:

- rejects a genuine duplicate (same archive)
- processes a rebuilt proposal once the stale fork is pruned (regression — fails against the old number-only guard, passes with the fix)
- falls back to `block_number_already_exists` when the stale fork is not pruned before the deadline

Full file 29/29 passing; format, lint, and full TypeScript build clean.

Closes A-1218.
