### PR TITLE
fix(test): reliably find target proposer in sentinel_status_slash (A-1217)

### DIFF
--- a/yarn-project/end-to-end/src/e2e_p2p/sentinel_status_slash.parallel.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/sentinel_status_slash.parallel.test.ts
@@ -18,7 +18,7 @@ import path from 'path';
 import { shouldCollectMetrics } from '../fixtures/fixtures.js';
 import { createNodes } from '../fixtures/setup_p2p_test.js';
 import { P2PNetworkTest } from './p2p_network.js';
-import { awaitCommitteeExists } from './shared.js';
+import { awaitCommitteeExists, findUpcomingProposerSlot } from './shared.js';
 
 /**
  * Exercises the sentinel's six-case proposer-status taxonomy end-to-end by driving each of the
@@ -243,68 +243,36 @@ describe('e2e_p2p_sentinel_status_slash', () => {
     return targetAddress;
   }
 
+  // Land two slots before an upcoming slot in which `targetAddress` is the proposer, so the network
+  // has a slot of real-time to settle before the malicious node (which we control) builds.
+  const MIN_LEAD_SLOTS = 2;
+
   /**
-   * Finds the next slot at which `targetAddress` is the proposer and warps L1 time to the slot
-   * just before it (so the proposer-pipelining build phase for the target's slot lands on the
-   * malicious node immediately, with no need to poll for the slot to come around naturally).
+   * Warps L1 time to {@link MIN_LEAD_SLOTS} slots before an upcoming slot in which `targetAddress` is
+   * the proposer, so the proposer-pipelining build phase for the target's slot lands on the malicious
+   * node with a slot of real-time for the network to settle first.
    *
-   * Probes the NEXT epoch's slots only (further epochs revert with `EpochNotStable`). If the
-   * target isn't selected next epoch, advances one epoch and tries again.
+   * The proposer search is delegated to the shared `findUpcomingProposerSlot`, which scans forward
+   * from {@link MIN_LEAD_SLOTS} ahead — examining both epoch parities so the RANDAO-shuffled 1-of-N
+   * target is reliably found — and guarantees the returned slot is at least {@link MIN_LEAD_SLOTS}
+   * ahead, so the landing warp can never go backwards.
    */
-  async function warpToSlotBeforeTargetProposer(targetAddress: EthAddress): Promise<SlotNumber> {
+  async function warpToSlotBeforeTargetProposer(targetAddress: EthAddress): Promise<void> {
     const epochCache = (nodes[0] as TestAztecNodeService).epochCache;
     const cheatCodes = t.ctx.cheatCodes.rollup;
-    const maxEpochAttempts = 20;
-
-    for (let attempt = 0; attempt < maxEpochAttempts; attempt++) {
-      const currentSlot = Number(await cheatCodes.getSlot());
-      const currentEpoch = Math.floor(currentSlot / AZTEC_EPOCH_DURATION);
-      // Probe every slot of the next epoch. The current epoch is partly elapsed and the second-next
-      // epoch's committee may revert with EpochNotStable, so the next epoch is the only fully
-      // available window. Scan the WHOLE epoch — both slot parities: the proposer is a different
-      // RANDAO-shuffled committee member per slot, so probing only part of the epoch can
-      // systematically never land on the target. (Deriving the start from `currentSlot +
-      // minBufferSlots` previously collapsed this to a single, always-odd slot whenever the buffer
-      // was comparable to AZTEC_EPOCH_DURATION — here both are 2 — leaving the 1-of-N target
-      // effectively unreachable. The pre-warp buffer is unnecessary: landing at `targetSlot - 2`
-      // below already gives the network a full slot of real-time to settle after any warp.)
-      const searchStart = (currentEpoch + 1) * AZTEC_EPOCH_DURATION;
-      const searchEnd = (currentEpoch + 2) * AZTEC_EPOCH_DURATION - 1;
-
-      let targetSlot: number | undefined;
-      for (let s = searchStart; s <= searchEnd; s++) {
-        const proposer = await epochCache.getProposerAttesterAddressInSlot(SlotNumber(s));
-        if (proposer && targetAddress.equals(proposer)) {
-          targetSlot = s;
-          break;
-        }
-      }
-
-      if (targetSlot === undefined) {
-        t.logger.info(`Target not selected as proposer in slots ${searchStart}..${searchEnd}; advancing one epoch`);
-        await cheatCodes.advanceToNextEpoch();
-        continue;
-      }
-
-      // Land 2 slots before the target (clamped so we never warp backwards). The malicious's
-      // sequencer pipelines for slot N during slot N-1, so landing at N-2 gives the network one
-      // full slot (N-1) of real-time to settle after the warp before the malicious starts
-      // building. Use the absolute-slot helper rather than `advanceSlots(N)` so any real-time
-      // elapsed between the slot search above and this call doesn't push us past the intended
-      // landing slot.
-      const landingSlot = SlotNumber(Math.max(targetSlot - 2, currentSlot));
-      t.logger.warn(
-        `Target proposes at slot ${targetSlot}; warping to slot ${landingSlot} (target is 2 slots ahead to let gossipsub stabilise before the malicious broadcasts)`,
-      );
-      if (landingSlot > currentSlot) {
-        await cheatCodes.advanceToSlot(landingSlot);
-      }
-      return SlotNumber(targetSlot);
+    const targetSlot = await findUpcomingProposerSlot({
+      epochCache,
+      cheatCodes,
+      targetProposer: targetAddress,
+      logger: t.logger,
+      minLeadSlots: MIN_LEAD_SLOTS,
+    });
+    // The malicious sequencer pipelines for slot N during N-1, so landing at N - MIN_LEAD_SLOTS leaves
+    // slot N-1 of real-time for the network to settle before it broadcasts.
+    const landingSlot = SlotNumber(targetSlot - MIN_LEAD_SLOTS);
+    if (landingSlot > Number(await cheatCodes.getSlot())) {
+      await cheatCodes.advanceToSlot(landingSlot);
     }
-
-    throw new Error(
-      `Target proposer ${targetAddress} not found with sufficient buffer within ${maxEpochAttempts} epochs`,
-    );
   }
 
   /**

--- a/yarn-project/end-to-end/src/e2e_p2p/sentinel_status_slash.parallel.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/sentinel_status_slash.parallel.test.ts
@@ -255,19 +255,20 @@ describe('e2e_p2p_sentinel_status_slash', () => {
     const epochCache = (nodes[0] as TestAztecNodeService).epochCache;
     const cheatCodes = t.ctx.cheatCodes.rollup;
     const maxEpochAttempts = 20;
-    // Minimum slots between the warp landing (`targetSlot - 1`) and where we currently are.
-    // Without this, the malicious's bad broadcast lands while observers are still transitioning
-    // across the epoch boundary and gossipsub may drop the proposal. Two slots of real-time
-    // is enough for everyone to stabilise.
-    const minBufferSlots = 2;
 
     for (let attempt = 0; attempt < maxEpochAttempts; attempt++) {
       const currentSlot = Number(await cheatCodes.getSlot());
       const currentEpoch = Math.floor(currentSlot / AZTEC_EPOCH_DURATION);
-      // Search the remainder of the current epoch and all of the next epoch (the second-next
-      // epoch's committee may revert with EpochNotStable). Skip slots within `minBufferSlots`
-      // of the current slot — too close to warp into safely.
-      const searchStart = currentSlot + minBufferSlots;
+      // Probe every slot of the next epoch. The current epoch is partly elapsed and the second-next
+      // epoch's committee may revert with EpochNotStable, so the next epoch is the only fully
+      // available window. Scan the WHOLE epoch — both slot parities: the proposer is a different
+      // RANDAO-shuffled committee member per slot, so probing only part of the epoch can
+      // systematically never land on the target. (Deriving the start from `currentSlot +
+      // minBufferSlots` previously collapsed this to a single, always-odd slot whenever the buffer
+      // was comparable to AZTEC_EPOCH_DURATION — here both are 2 — leaving the 1-of-N target
+      // effectively unreachable. The pre-warp buffer is unnecessary: landing at `targetSlot - 2`
+      // below already gives the network a full slot of real-time to settle after any warp.)
+      const searchStart = (currentEpoch + 1) * AZTEC_EPOCH_DURATION;
       const searchEnd = (currentEpoch + 2) * AZTEC_EPOCH_DURATION - 1;
 
       let targetSlot: number | undefined;
@@ -285,12 +286,13 @@ describe('e2e_p2p_sentinel_status_slash', () => {
         continue;
       }
 
-      // Land 2 slots before the target. The malicious's sequencer pipelines for slot N during
-      // slot N-1, so landing at N-2 gives the network one full slot (N-1) of real-time to
-      // settle after the warp before the malicious starts building. Use the absolute-slot
-      // helper rather than `advanceSlots(N)` so any real-time elapsed between the slot search
-      // above and this call doesn't push us past the intended landing slot.
-      const landingSlot = SlotNumber(targetSlot - 2);
+      // Land 2 slots before the target (clamped so we never warp backwards). The malicious's
+      // sequencer pipelines for slot N during slot N-1, so landing at N-2 gives the network one
+      // full slot (N-1) of real-time to settle after the warp before the malicious starts
+      // building. Use the absolute-slot helper rather than `advanceSlots(N)` so any real-time
+      // elapsed between the slot search above and this call doesn't push us past the intended
+      // landing slot.
+      const landingSlot = SlotNumber(Math.max(targetSlot - 2, currentSlot));
       t.logger.warn(
         `Target proposes at slot ${targetSlot}; warping to slot ${landingSlot} (target is 2 slots ahead to let gossipsub stabilise before the malicious broadcasts)`,
       );

--- a/yarn-project/end-to-end/src/e2e_p2p/shared.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/shared.ts
@@ -148,6 +148,65 @@ export async function awaitCommitteeExists({
 }
 
 /**
+ * Scans L2 slots forward from `minLeadSlots` ahead of the current slot, returning the first slot in
+ * which `targetProposer` is the proposer.
+ *
+ * Scanning starts at `currentSlot + minLeadSlots` and only ever moves forward, so every returned slot
+ * is at least `minLeadSlots` ahead — a caller can safely warp to `targetSlot - minLeadSlots` for a
+ * settle buffer without risking a backwards warp. Stepping by a single slot examines both epoch
+ * parities, which matters because the per-slot proposer is a different RANDAO-shuffled committee
+ * member: searching only a fixed offset within each epoch can leave a 1-of-N target unexamined when
+ * the epoch is short. A candidate in an epoch whose committee isn't sampled yet makes the proposer
+ * lookup revert with EpochNotStable; this warps one epoch forward and continues, keeping the
+ * candidate at least `minLeadSlots` ahead of the new current slot. Throws after `maxSlotsToScan`.
+ *
+ * Unlike {@link advanceToEpochBeforeProposer}, this does not stop an epoch early — callers that want
+ * to warp close to the target (rather than stage sequencers an epoch ahead) use this and warp the
+ * final `minLeadSlots` in themselves.
+ */
+export async function findUpcomingProposerSlot({
+  epochCache,
+  cheatCodes,
+  targetProposer,
+  logger,
+  minLeadSlots,
+  maxSlotsToScan = 100,
+}: {
+  epochCache: EpochCacheInterface;
+  cheatCodes: RollupCheatCodes;
+  targetProposer: EthAddress;
+  logger: Logger;
+  minLeadSlots: number;
+  maxSlotsToScan?: number;
+}): Promise<SlotNumber> {
+  let candidate = Number(await cheatCodes.getSlot()) + minLeadSlots;
+
+  for (let scanned = 0; scanned < maxSlotsToScan; scanned++) {
+    let proposer: EthAddress | undefined;
+    try {
+      proposer = await epochCache.getProposerAttesterAddressInSlot(SlotNumber(candidate));
+    } catch (err) {
+      if (!(err instanceof Error) || !err.message.includes('EpochNotStable')) {
+        throw err;
+      }
+      await cheatCodes.advanceToNextEpoch();
+      const newCurrentSlot = Number(await cheatCodes.getSlot());
+      // Keep the lead after the warp: never return a slot we could no longer warp ahead of.
+      candidate = Math.max(candidate, newCurrentSlot + minLeadSlots);
+      continue;
+    }
+
+    if (proposer && proposer.equals(targetProposer)) {
+      logger.warn(`Found target proposer ${targetProposer} at slot ${candidate}`);
+      return SlotNumber(candidate);
+    }
+    candidate++;
+  }
+
+  throw new Error(`Target proposer ${targetProposer} not found within ${maxSlotsToScan} slots`);
+}
+
+/**
  * Advance epochs until we find one where the target proposer is selected for a slot at least
  * `warmupSlots` into the epoch, then stop one epoch before it. This leaves time for the caller to
  * start sequencers before warping to the target epoch, avoiding the race where the target epoch


### PR DESCRIPTION
## Problem

The e2e helper `warpToSlotBeforeTargetProposer` (in `sentinel_status_slash.parallel.test.ts`) intermittently threw `Target proposer ... not found with sufficient buffer within 20 epochs`, surfacing as an `e2e_p2p` flake. It's a deterministic helper bug, not network flakiness.

The search window was derived as `searchStart = currentSlot + minBufferSlots`, `searchEnd = (currentEpoch + 2) * AZTEC_EPOCH_DURATION - 1`. With `AZTEC_EPOCH_DURATION = 2` and `minBufferSlots = 2`, the buffer offset consumes a full epoch, so whenever `currentSlot` is odd the window collapses to a single, always-odd slot. Because the proposer for each slot is a different RANDAO-shuffled committee member, probing only odd slots never examines the even slot of any epoch — where the 1-of-6 target can be the proposer — so the loop exhausts all attempts and throws.

## Log verification

Confirmed against CI run [`cc8c935bb167ed37`](http://ci.aztec-labs.com/cc8c935bb167ed37):

- All 20 attempts probed a 1-slot window, every probed slot odd: `13, 15, 17, … 51`. Zero hit lines.
- The target `0x90f79b…` was on the committee every epoch (RANDAO-shuffled into different positions) and attested at slots 11–12 — reachable, just never at a probed (odd) slot.
- Zero `EpochNotStable` reverts during the scan — the search ran clean, just structurally blind to even slots.

## Fix

Extract the proposer search into a shared `findUpcomingProposerSlot` in `e2e_p2p/shared.ts`, parameterized by `minLeadSlots`, and have the sentinel test use it:

- Scans forward **one slot at a time** from `currentSlot + minLeadSlots`, so it examines **both epoch parities** (fixing the odd-only blindness) and finds the RANDAO-shuffled target wherever it proposes.
- Guarantees the returned slot is **at least `minLeadSlots` ahead**, so the sentinel can warp to `targetSlot - minLeadSlots` for its settle buffer with no risk of a backwards warp — the lead comes from the scan start, not from a per-epoch position constraint.
- Handles `EpochNotStable` by warping one epoch forward and continuing, keeping the lead.

The sentinel helper becomes a thin wrapper: `findUpcomingProposerSlot({ minLeadSlots: 2 })` then `advanceToSlot(targetSlot - 2)`.

Kept **separate** from the existing `advanceToEpochBeforeProposer`, which serves a genuinely different pattern: its four callers stay one epoch before the target to start sequencers, then warp to the epoch boundary, and rely on `warmupSlots` for their warm-up margin (load-bearing — without it their proposals serialize past the slot boundary and are rejected as late). That helper is unchanged, so its callers are unaffected.

## Testing

- Build, format, and lint clean; only `shared.ts` and the sentinel test changed.
- The proposer search now examines both parities and guarantees the lead by construction.
- **Not yet run:** the full e2e (`sentinel_status_slash.parallel.test.ts`, ~20 min, real-time-dependent). The real validation is running it repeatedly to confirm the proposer is found and the suite's other two tests (which share the helper) still pass.

Closes A-1217.
