### PR TITLE
fix: init bb.js sync singleton before subsystems start in createAndSync

### DIFF
--- a/yarn-project/aztec-node/package.json
+++ b/yarn-project/aztec-node/package.json
@@ -67,6 +67,7 @@
   "dependencies": {
     "@aztec/archiver": "workspace:^",
     "@aztec/bb-prover": "workspace:^",
+    "@aztec/bb.js": "portal:../../barretenberg/ts",
     "@aztec/blob-client": "workspace:^",
     "@aztec/blob-lib": "workspace:^",
     "@aztec/constants": "workspace:^",

--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -527,6 +527,11 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, AztecNodeDeb
   ): Promise<AztecNodeService> {
     const config = { ...inputConfig }; // Copy the config so we dont mutate the input object
     const log = deps.logger ?? createLogger('node');
+
+    // Initialise the bb.js sync WASM singleton here, before any subsystem runs.
+    const { BarretenbergSync } = await import('@aztec/bb.js');
+    await BarretenbergSync.initSingleton();
+
     const packageVersion = getPackageVersion();
     const telemetry = deps.telemetry ?? getTelemetryClient();
     const dateProvider = deps.dateProvider ?? new DateProvider();

--- a/yarn-project/yarn.lock
+++ b/yarn-project/yarn.lock
@@ -754,6 +754,7 @@ __metadata:
   dependencies:
     "@aztec/archiver": "workspace:^"
     "@aztec/bb-prover": "workspace:^"
+    "@aztec/bb.js": "portal:../../barretenberg/ts"
     "@aztec/blob-client": "workspace:^"
     "@aztec/blob-lib": "workspace:^"
     "@aztec/constants": "workspace:^"


### PR DESCRIPTION
## Problem

A prover node in production crashed an epoch proving job:

```
Error in EpochSession 9598f7a8-...: Error: Sub-tree for checkpoint 1 failed: Error: First call BarretenbergSync.initSingleton() on @aztec/bb.js module.
    at TopTreeProvingState.rejectionCallback (.../prover-client/dest/orchestrator/top-tree-orchestrator.js:68:210)
```

The error comes from `BarretenbergSync.getSingleton()` throwing when the WASM singleton has not been initialised. Epoch proving deserializes compressed Chonk proofs via `ChonkProof.fromBuffer` → `ChonkProof.fromCompressedBytes` → `getSingleton()`.

The prover node starts monitoring epochs as soon as it is created inside `AztecNodeService.createAndSync`. The only init on the start path (`aztec_start_action.ts`) runs later and is guarded on `services.aztec`, so an `EpochSession` can reach the decompress path before the singleton is initialised — the race that crashed the job in production.

## Fix

Initialise the singleton at the top of `createAndSync`, before any subsystem runs. This covers the prover node, validator, sequencer, and every other `createAndSync` caller (including e2e tests).

The existing `initSingleton()` call in `aztec_start_action` is left in place — `initSingleton` is idempotent (the singleton promise is cached), so it remains a harmless guard for the RPC schema-parsing path.

Fixes A-1243.