### PR TITLE
fix: allow prover mode autodetection

### DIFF
--- a/yarn-project/wallets/src/embedded/entrypoints/browser.ts
+++ b/yarn-project/wallets/src/embedded/entrypoints/browser.ts
@@ -35,7 +35,7 @@ export class BrowserEmbeddedWallet extends EmbeddedWallet {
     const mergedCreationOverrides: PXECreationOptions = { ...options.pxeOptions, ...pxeCreationFromPxe };
 
     const pxeConfig: PXEConfig = Object.assign(getPXEConfig(), {
-      proverEnabled: mergedConfigOverrides.proverEnabled ?? false,
+      proverEnabled: mergedConfigOverrides.proverEnabled,
       dataDirectory: `pxe_data_${l1Contracts.rollupAddress}`,
       autoSync: false,
       ...mergedConfigOverrides,

--- a/yarn-project/wallets/src/embedded/entrypoints/node.ts
+++ b/yarn-project/wallets/src/embedded/entrypoints/node.ts
@@ -36,7 +36,7 @@ export class NodeEmbeddedWallet extends EmbeddedWallet {
     const mergedCreationOverrides: PXECreationOptions = { ...options.pxeOptions, ...pxeCreationFromPxe };
 
     const pxeConfig: PXEConfig = Object.assign(getPXEConfig(), {
-      proverEnabled: mergedConfigOverrides.proverEnabled ?? false,
+      proverEnabled: mergedConfigOverrides.proverEnabled,
       dataDirectory: `pxe_data_${l1Contracts.rollupAddress}`,
       autoSync: false,
       ...mergedConfigOverrides,


### PR DESCRIPTION
PXE has logic to detect whether generating proofs is necessary depending on the node it's connected to (via `node.getNodeInfo()`). `EmbeddedWallet` was overriding its own default, preventing the autodetection.