### PR TITLE
fix(test): pin AZTEC_INBOX_LAG=1 in sandbox compose envs

### DIFF
--- a/docs/examples/ts/docker-compose.yml
+++ b/docs/examples/ts/docker-compose.yml
@@ -22,6 +22,10 @@ services:
       ETHEREUM_HOSTS: http://fork:8545
       L1_CHAIN_ID: 31337
       FORCE_COLOR: ${FORCE_COLOR:-1}
+      # Pin the inbox lag to 1 for the sandbox. The network default is now 2, but the docs examples
+      # bridge fee juice and consume the L1->L2 message within a single checkpoint; with lag 2 the
+      # message isn't available yet, failing with "No L1 to L2 message found".
+      AZTEC_INBOX_LAG: 1
       ARCHIVER_POLLING_INTERVAL_MS: 500
       P2P_BLOCK_CHECK_INTERVAL_MS: 500
       SEQ_POLLING_INTERVAL_MS: 500

--- a/yarn-project/end-to-end/scripts/docker-compose.yml
+++ b/yarn-project/end-to-end/scripts/docker-compose.yml
@@ -27,6 +27,10 @@ services:
       ETHEREUM_HOSTS: http://fork:8545
       L1_CHAIN_ID: 31337
       FORCE_COLOR: ${FORCE_COLOR:-1}
+      # Pin the inbox lag to 1 for the sandbox. The network default is now 2, but the cli-wallet flows
+      # and guide examples bridge fee juice and consume the L1->L2 message within a single checkpoint;
+      # with lag 2 the message isn't available yet, failing with "No L1 to L2 message found".
+      AZTEC_INBOX_LAG: 1
       ARCHIVER_POLLING_INTERVAL_MS: 500
       P2P_BLOCK_CHECK_INTERVAL_MS: 500
       SEQ_POLLING_INTERVAL_MS: 500

--- a/yarn-project/end-to-end/src/e2e_l1_publisher/e2e_l1_publisher.test.ts
+++ b/yarn-project/end-to-end/src/e2e_l1_publisher/e2e_l1_publisher.test.ts
@@ -491,7 +491,12 @@ describe('L1Publisher integration', () => {
 
   describe('block building', () => {
     beforeEach(async () => {
-      await setup();
+      // This suite proposes consecutive checkpoints and models the inbox lag by hand (a checkpoint
+      // consumes the L1->L2 messages sent during the previous checkpoint -- see the shift at the
+      // bottom of buildAndPublishBlock). That bookkeeping assumes a single-checkpoint lag, so pin
+      // inboxLag to 1 rather than inheriting the network default (now 2); with only two consecutive
+      // blocks a lag of 2 would mean no checkpoint ever consumes a real message.
+      await setup({ inboxLag: 1 });
     });
 
     const buildAndPublishBlock = async (numTxs: number, jsonFileNamePrefix: string) => {


### PR DESCRIPTION
## Problem

The network default inbox lag was changed from 1 to 2 (on `merge-train/spartan-v5`). That regressed every test environment that bridges fee juice and consumes the resulting L1→L2 message within a single checkpoint — with lag 2 the message isn't consumable yet, so they fail with `No L1 to L2 message found` (or, for `e2e_l1_publisher`, no checkpoint ever consumes a real message):

- `cli-wallet/test/flows/*` — create_account_pay_native, private_transfer, profile, public_authwit_transfer, shield_and_transfer, sponsored_create_account_and_mint
- `docs/examples/bootstrap.sh execute`
- `guides/up_quick_start.test.ts`
- `e2e_l1_publisher` block-building suite

## Fix

Pin the inbox lag to 1 for these test environments:

- **Sandbox compose suites** (cli-wallet flows, docs examples, up_quick_start): set `AZTEC_INBOX_LAG: 1` on the `local-network` service in both compose files — `yarn-project/end-to-end/scripts/docker-compose.yml` and `docs/examples/ts/docker-compose.yml`. These run the node via `node ./dest/bin start --local-network`, so they don't go through the TS `setup()` helper; `AZTEC_INBOX_LAG` (`ethereum/src/config.ts`) feeds both the L1 deploy and the node config.
- **`e2e_l1_publisher` block-building suite**: `setup({ inboxLag: 1 })`, since that suite models the single-checkpoint inbox lag by hand.

Together these cover the inboxLag-2 fallout across the affected test environments.

Note: the `e2e_l1_publisher` change here is the same fix as #24158; this PR consolidates it with the sandbox compose-env pins. If this lands, #24158 can be closed (or vice-versa). The unrelated `e2e_p2p/rediscovery` P2P flake is not addressed here.

## Testing

- Compose files validated (YAML parses; `AZTEC_INBOX_LAG=1` confirmed under `local-network.environment`).
- `setup({ inboxLag: 1 })` typechecks (`SetupOptions & Partial<AztecNodeConfig>`).
- **Not yet run locally:** the suites themselves (require the CI docker image / sandbox). Labeled `ci-full` to exercise the full suite.
