### PR TITLE
fix(test): use in-memory file store for TxFileStore tests (A-1211)

### DIFF
--- a/yarn-project/p2p/src/services/tx_file_store/tx_file_store.test.ts
+++ b/yarn-project/p2p/src/services/tx_file_store/tx_file_store.test.ts
@@ -1,13 +1,10 @@
 import { createLogger } from '@aztec/foundation/log';
 import { sleep } from '@aztec/foundation/sleep';
-import { type FileStore, createFileStore } from '@aztec/stdlib/file-store';
+import { InMemoryFileStore } from '@aztec/stdlib/file-store';
 import { Tx, type TxValidator } from '@aztec/stdlib/tx';
 
 import { jest } from '@jest/globals';
-import { mkdtemp, readdir, rm } from 'fs/promises';
 import { type MockProxy, mock } from 'jest-mock-extended';
-import { tmpdir } from 'os';
-import { join } from 'path';
 
 import { InMemoryTxPool } from '../../test-helpers/testbench-utils.js';
 import { FileStoreTxSource } from '../tx_collection/file_store_tx_source.js';
@@ -15,14 +12,15 @@ import type { TxFileStoreConfig } from './config.js';
 import { TxFileStore } from './tx_file_store.js';
 
 describe('TxFileStore', () => {
-  let tmpDir: string;
-  let fileStore: FileStore;
+  let fileStore: InMemoryFileStore;
   let txPool: InMemoryTxPool;
   let config: TxFileStoreConfig;
   let txFileStore: TxFileStore | undefined;
   let mockValidator: MockProxy<TxValidator>;
   const log = createLogger('test:tx_file_store');
   const basePath = 'aztec-1-1-0x1234';
+  const storeNamespace = 'tx-file-store-test';
+  const storeUrl = `mem://${storeNamespace}`;
 
   const makeTx = async () => {
     const tx = Tx.random();
@@ -30,36 +28,23 @@ describe('TxFileStore', () => {
     return tx;
   };
 
-  /** Counts files in the txs subdirectory of the temp directory. */
-  async function countUploadedFiles(): Promise<number> {
-    try {
-      const files = await readdir(join(tmpDir, basePath, 'txs'));
-      return files.length;
-    } catch {
-      return 0;
-    }
+  /** Counts tx files uploaded to the store under basePath. */
+  function countUploadedFiles(): number {
+    return fileStore.listFiles(`${basePath}/txs`).length;
   }
 
-  beforeAll(async () => {
-    tmpDir = await mkdtemp(join(tmpdir(), 'tx-file-store-test-'));
-  });
-
-  beforeEach(async () => {
-    // Clean up any files from previous test
-    try {
-      await rm(join(tmpDir, basePath), { recursive: true, force: true });
-    } catch {
-      // Directory might not exist
-    }
-
-    fileStore = await createFileStore(`file://${tmpDir}`);
+  beforeEach(() => {
+    // Fresh in-memory store per test. Using an in-memory store (rather than a real on-disk file
+    // store) keeps these tests deterministic — they exercise TxFileStore, not file-store I/O.
+    InMemoryFileStore.clear(storeNamespace);
+    fileStore = new InMemoryFileStore(storeNamespace);
     txPool = new InMemoryTxPool();
     mockValidator = mock<TxValidator>();
     mockValidator.validateTx.mockResolvedValue({ result: 'valid' });
 
     config = {
       txFileStoreEnabled: true,
-      txFileStoreUrl: `file://${tmpDir}`,
+      txFileStoreUrl: storeUrl,
       txFileStoreUploadConcurrency: 2,
       txFileStoreMaxQueueSize: 10,
     };
@@ -70,10 +55,6 @@ describe('TxFileStore', () => {
       await txFileStore.stop();
       txFileStore = undefined;
     }
-  });
-
-  afterAll(async () => {
-    await rm(tmpDir, { recursive: true, force: true });
   });
 
   describe('create', () => {
@@ -124,7 +105,7 @@ describe('TxFileStore', () => {
       await txPool.addPendingTxs([tx1]);
       await txFileStore!.flush();
 
-      const countBefore = await countUploadedFiles();
+      const countBefore = countUploadedFiles();
       expect(countBefore).toBe(1);
 
       await txFileStore!.stop();
@@ -278,7 +259,7 @@ describe('TxFileStore', () => {
       await txFileStore!.flush();
 
       expect(spy).toHaveBeenCalledTimes(3);
-      expect(await countUploadedFiles()).toBe(1);
+      expect(countUploadedFiles()).toBe(1);
 
       spy.mockRestore();
     }, 10000);
@@ -307,7 +288,7 @@ describe('TxFileStore', () => {
 
       // tx1 failed after 4 attempts (initial + 3 retries), tx2 succeeded
       expect(spy).toHaveBeenCalledTimes(5);
-      expect(await countUploadedFiles()).toBe(1);
+      expect(countUploadedFiles()).toBe(1);
 
       spy.mockRestore();
     }, 10000);
@@ -319,7 +300,7 @@ describe('TxFileStore', () => {
       await fileStore.save(`${basePath}/txs/${tx.txHash.toString()}.bin`, tx.toBuffer(), { compress: false });
 
       mockValidator.validateTx.mockResolvedValueOnce({ result: 'invalid', reason: ['invalid'] });
-      const source = (await FileStoreTxSource.create(`file://${tmpDir}`, basePath, mockValidator, log))!;
+      const source = (await FileStoreTxSource.create(storeUrl, basePath, mockValidator, log))!;
       const result = await source.getTxsByHash([tx.txHash]);
 
       expect(result.validTxs).toHaveLength(0);
@@ -330,7 +311,7 @@ describe('TxFileStore', () => {
       const tx = await makeTx();
       await fileStore.save(`${basePath}/txs/${tx.txHash.toString()}.bin`, tx.toBuffer(), { compress: false });
 
-      const source = (await FileStoreTxSource.create(`file://${tmpDir}`, basePath, mockValidator, log))!;
+      const source = (await FileStoreTxSource.create(storeUrl, basePath, mockValidator, log))!;
       const result = await source.getTxsByHash([tx.txHash]);
 
       expect(result.validTxs).toHaveLength(1);
@@ -347,7 +328,7 @@ describe('TxFileStore', () => {
         .mockResolvedValueOnce({ result: 'valid' })
         .mockResolvedValueOnce({ result: 'invalid', reason: ['bad'] });
 
-      const source = (await FileStoreTxSource.create(`file://${tmpDir}`, basePath, mockValidator, log))!;
+      const source = (await FileStoreTxSource.create(storeUrl, basePath, mockValidator, log))!;
       const result = await source.getTxsByHash([tx1.txHash, tx2.txHash]);
 
       expect(result.validTxs).toHaveLength(1);
@@ -386,7 +367,7 @@ describe('TxFileStore', () => {
       await txFileStore!.flush();
 
       // Read back via FileStoreTxSource using the same local file store
-      const txSource = await FileStoreTxSource.create(`file://${tmpDir}`, basePath, mockValidator, log);
+      const txSource = await FileStoreTxSource.create(storeUrl, basePath, mockValidator, log);
       expect(txSource).toBeDefined();
 
       const results = await txSource!.getTxsByHash([tx.getTxHash()]);

--- a/yarn-project/stdlib/src/file-store/factory.ts
+++ b/yarn-project/stdlib/src/file-store/factory.ts
@@ -4,6 +4,7 @@ import { GoogleCloudFileStore } from './gcs.js';
 import { HttpFileStore, type HttpFileStoreOptions } from './http.js';
 import type { FileStore, ReadOnlyFileStore } from './interface.js';
 import { LocalFileStore } from './local.js';
+import { InMemoryFileStore } from './memory.js';
 import { S3FileStore } from './s3.js';
 
 const supportedExamples = [
@@ -21,6 +22,12 @@ export async function createFileStore(
 ): Promise<FileStore | undefined> {
   if (config === undefined) {
     return undefined;
+  } else if (config.startsWith('mem://')) {
+    // In-memory store for tests (see InMemoryFileStore). The namespace is everything after the
+    // scheme, so `mem://X` and a later `mem://X` share data, like two file:// stores over one dir.
+    const namespace = config.slice('mem://'.length).replace(/\/+$/, '');
+    logger.info(`Creating in-memory file store at ${namespace}`);
+    return new InMemoryFileStore(namespace);
   } else if (config.startsWith('file://')) {
     const url = new URL(config);
     if (url.host) {

--- a/yarn-project/stdlib/src/file-store/index.ts
+++ b/yarn-project/stdlib/src/file-store/index.ts
@@ -1,3 +1,4 @@
 export * from './interface.js';
 export * from './factory.js';
 export { type HttpFileStoreOptions } from './http.js';
+export { InMemoryFileStore } from './memory.js';

--- a/yarn-project/stdlib/src/file-store/memory.test.ts
+++ b/yarn-project/stdlib/src/file-store/memory.test.ts
@@ -1,0 +1,70 @@
+import { createFileStore, createReadOnlyFileStore } from './factory.js';
+import { InMemoryFileStore } from './memory.js';
+
+describe('InMemoryFileStore', () => {
+  afterEach(() => InMemoryFileStore.clear());
+
+  it('round-trips data read by path and by returned uri', async () => {
+    const store = new InMemoryFileStore('ns');
+    const data = Buffer.from('foobar');
+    const uri = await store.save('dir/test.txt', data);
+
+    expect(uri).toBe('mem://ns/dir/test.txt');
+    expect((await store.read('dir/test.txt')).toString()).toBe('foobar');
+    expect((await store.read(uri)).toString()).toBe('foobar');
+    expect(await store.exists('dir/test.txt')).toBe(true);
+    expect(await store.exists('missing.txt')).toBe(false);
+  });
+
+  it('transparently gunzips content stored compressed', async () => {
+    const store = new InMemoryFileStore('ns');
+    const data = Buffer.from('x'.repeat(1000));
+    await store.save('c.bin', data, { compress: true });
+    expect((await store.read('c.bin')).equals(data)).toBe(true);
+  });
+
+  it('throws when reading a missing file', async () => {
+    const store = new InMemoryFileStore('ns');
+    await expect(store.read('nope.bin')).rejects.toThrow('File not found');
+  });
+
+  it('lists files under a prefix', async () => {
+    const store = new InMemoryFileStore('ns');
+    await store.save('txs/a.bin', Buffer.from('a'));
+    await store.save('txs/b.bin', Buffer.from('b'));
+    await store.save('other/c.bin', Buffer.from('c'));
+
+    expect(store.listFiles('txs').sort()).toEqual(['txs/a.bin', 'txs/b.bin']);
+    expect(store.listFiles()).toHaveLength(3);
+  });
+
+  it('shares data across instances of the same namespace', async () => {
+    const writer = new InMemoryFileStore('shared');
+    await writer.save('f.bin', Buffer.from('hello'));
+
+    // A separate instance over the same namespace sees the write (mirrors two file:// stores over one dir).
+    const reader = new InMemoryFileStore('shared');
+    expect((await reader.read('f.bin')).toString()).toBe('hello');
+
+    // A different namespace does not.
+    const other = new InMemoryFileStore('other');
+    expect(await other.exists('f.bin')).toBe(false);
+  });
+
+  it('clears a single namespace without affecting others', async () => {
+    await new InMemoryFileStore('a').save('f.bin', Buffer.from('a'));
+    await new InMemoryFileStore('b').save('f.bin', Buffer.from('b'));
+
+    InMemoryFileStore.clear('a');
+    expect(await new InMemoryFileStore('a').exists('f.bin')).toBe(false);
+    expect(await new InMemoryFileStore('b').exists('f.bin')).toBe(true);
+  });
+
+  it('is created by the factory for mem:// urls and shares the namespace', async () => {
+    const writer = await createFileStore('mem://factory-ns');
+    await writer.save('f.bin', Buffer.from('viafactory'));
+
+    const reader = await createReadOnlyFileStore('mem://factory-ns');
+    expect((await reader.read('f.bin')).toString()).toBe('viafactory');
+  });
+});

--- a/yarn-project/stdlib/src/file-store/memory.ts
+++ b/yarn-project/stdlib/src/file-store/memory.ts
@@ -1,0 +1,94 @@
+import { writeFile } from 'fs/promises';
+import { promisify } from 'util';
+import { gunzip as gunzipCb, gzip as gzipCb } from 'zlib';
+
+import type { FileStore, FileStoreSaveOptions } from './interface.js';
+
+const gzip = promisify(gzipCb);
+const gunzip = promisify(gunzipCb);
+
+// Backing data is shared per namespace so that a store created for writing and a (read-only) store
+// created later from the same `mem://` URL observe the same files — mirroring how two `file://`
+// stores over the same directory share state on disk. Without this, `FileStoreTxSource`, which
+// builds its own store from the URL, would never see what a test wrote through a different instance.
+const namespaces = new Map<string, Map<string, Buffer>>();
+
+/**
+ * In-memory {@link FileStore}, addressed via `mem://<namespace>/...`. Reads and writes are synchronous
+ * map operations with no disk I/O, so it is deterministic — useful for tests that exercise consumers
+ * of a file store (e.g. the tx file store) rather than the on-disk store itself, where a real
+ * filesystem can introduce timing flakes.
+ */
+export class InMemoryFileStore implements FileStore {
+  private readonly files: Map<string, Buffer>;
+
+  constructor(private readonly namespace: string) {
+    let files = namespaces.get(namespace);
+    if (!files) {
+      files = new Map();
+      namespaces.set(namespace, files);
+    }
+    this.files = files;
+  }
+
+  /** Clears all in-memory file store data, or a single namespace. Intended for test isolation. */
+  static clear(namespace?: string): void {
+    if (namespace === undefined) {
+      namespaces.clear();
+    } else {
+      namespaces.delete(namespace);
+    }
+  }
+
+  public async save(path: string, data: Buffer, opts?: FileStoreSaveOptions): Promise<string> {
+    const toStore = opts?.compress ? await gzip(data) : data;
+    const key = this.key(path);
+    this.files.set(key, Buffer.from(toStore));
+    return `mem://${this.namespace}/${key}`;
+  }
+
+  public async upload(destPath: string, srcPath: string, opts?: FileStoreSaveOptions): Promise<string> {
+    const { readFile } = await import('fs/promises');
+    return this.save(destPath, await readFile(srcPath), opts);
+  }
+
+  public async read(pathOrUrl: string): Promise<Buffer> {
+    const data = this.files.get(this.key(pathOrUrl));
+    if (data === undefined) {
+      throw new Error(`File not found in memory store: ${pathOrUrl}`);
+    }
+    // Match LocalFileStore: transparently gunzip content that was stored compressed.
+    if (data.length >= 2 && data[0] === 0x1f && data[1] === 0x8b) {
+      return await gunzip(data);
+    }
+    return data;
+  }
+
+  public async download(pathOrUrl: string, destPath: string): Promise<void> {
+    await writeFile(destPath, await this.read(pathOrUrl));
+  }
+
+  public exists(pathOrUrl: string): Promise<boolean> {
+    return Promise.resolve(this.files.has(this.key(pathOrUrl)));
+  }
+
+  /** Lists stored file keys, optionally restricted to those under `prefix`. Not part of {@link FileStore}. */
+  public listFiles(prefix = ''): string[] {
+    const keys = [...this.files.keys()];
+    const normalizedPrefix = prefix.replace(/^\/+/, '');
+    return normalizedPrefix ? keys.filter(k => k.startsWith(normalizedPrefix)) : keys;
+  }
+
+  /** Resolves a relative path or a `mem://` URI (as returned by `save`) to the registry key. */
+  private key(pathOrUrl: string): string {
+    const ownPrefix = `mem://${this.namespace}/`;
+    if (pathOrUrl.startsWith(ownPrefix)) {
+      return pathOrUrl.slice(ownPrefix.length);
+    }
+    if (pathOrUrl.startsWith('mem://')) {
+      // A mem:// URI for some namespace: drop the scheme and the leading namespace segment.
+      return pathOrUrl.slice('mem://'.length).replace(/^[^/]*\//, '');
+    }
+    return pathOrUrl.replace(/^\/+/, '');
+  }
+}


### PR DESCRIPTION
## Problem

`TxFileStore › tx download validation › partitions txs based on validator result` (A-1211) is flaky on the constrained CI container. It writes two tx files to a real (tmpfs) file store, then `getTxsByHash` reads them back concurrently. A transient read miss is **silently swallowed** in `FileStoreTxSource.getTxsByHash` (`catch { downloadsFailed.add(1); return undefined; }`) and the tx is dropped, not errored. So only one tx reaches the validator, consumes the first mocked result (`valid`), and nothing is classified invalid — giving `validTxs=1, invalidTxHashes=0` instead of `1/1`. (Verified: a fresh mock per test rules out mock-state leak, so the only explanation is a dropped read; passes locally on an unconstrained box.)

## Fix

These tests exercise `TxFileStore` / tx-collection logic, not the on-disk file store, so back them with an in-memory store and remove the filesystem race entirely.

- **New `InMemoryFileStore`** (`stdlib/src/file-store/memory.ts`), addressed via `mem://<namespace>`:
  - Reads/writes are synchronous `Map` operations — no disk I/O, fully deterministic.
  - Data is **shared per namespace**, so a writer and a read-only store built from the same `mem://` URL observe the same files (as two `file://` stores over one directory would). This matters because `FileStoreTxSource` builds its own store from the URL.
  - Mirrors `LocalFileStore`'s transparent gzip/gunzip (uploads use `compress: true`).
  - `InMemoryFileStore.clear()` for per-test isolation; `listFiles(prefix)` for enumeration.
  - Wired into `createFileStore` / `createReadOnlyFileStore` for the `mem://` scheme. Unit tests in `memory.test.ts` cover round-trip, compression, missing-file, listing, namespace sharing, clear, and factory creation.
- **`tx_file_store.test.ts`** now uses a `mem://` store; `countUploadedFiles` enumerates via `listFiles` instead of `readdir`. No more tmpdir/fs.

Note: this is a test-determinism fix. The silent-swallow behavior in `FileStoreTxSource` is left as-is — dropping a tx from one best-effort source is arguably acceptable (it's re-collected elsewhere); making that path log/distinguish absent-vs-transient is a separate, optional improvement.

## Testing

- Full `tx_file_store.test.ts`: 17/17. Previously-flaky case: 10/10 across repeated runs (in-memory `read` is a synchronous map lookup — no race possible).
- New `memory.test.ts`: 7/7.
- Build, lint clean.

Closes A-1211.
