### PR TITLE
fix(p2p): re-seed discovery from persisted peer ENRs after restart

### DIFF
--- a/yarn-project/end-to-end/src/e2e_p2p/rediscovery.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/rediscovery.test.ts
@@ -1,7 +1,6 @@
 import type { AztecNodeService } from '@aztec/aztec-node';
 import { waitForTx } from '@aztec/aztec.js/node';
 import { TxHash } from '@aztec/aztec.js/tx';
-import { sleep } from '@aztec/foundation/sleep';
 
 import fs from 'fs';
 import os from 'os';
@@ -67,8 +66,9 @@ describe('e2e_p2p_rediscovery', () => {
       shouldCollectMetrics(),
     );
 
-    // wait a bit for peers to discover each other
-    await sleep(8000);
+    // Wait for the nodes to form a full mesh before tearing down, so each one persists every peer's
+    // ENR to its store. Without this guarantee there would be nothing to rediscover after the restart.
+    await t.waitForP2PMeshConnectivity(nodes, NUM_VALIDATORS, 120);
 
     // We need to `createNodes` before we setup account, because
     // those nodes actually form the committee, and so we cannot build
@@ -78,16 +78,17 @@ describe('e2e_p2p_rediscovery', () => {
     // stop bootstrap node
     await t.bootstrapNode?.stop();
 
-    // create new nodes from datadir
-    const newNodes: AztecNodeService[] = [];
-
-    // stop all nodes
+    // Bring the whole network down before bringing any node back up. This is the real test of
+    // rediscovery: with every node stopped there are no live peers left to dial the restarted nodes,
+    // so they can only rejoin by re-seeding discovery from the peers they persisted to disk.
     for (let i = 0; i < NUM_VALIDATORS; i++) {
-      const node = nodes[i];
-      await node.stop();
+      await nodes[i].stop();
       t.logger.info(`Node ${i} stopped`);
-      await sleep(2500);
+    }
 
+    // recreate all nodes from their data dirs, without a bootstrap node
+    const newNodes: AztecNodeService[] = [];
+    for (let i = 0; i < NUM_VALIDATORS; i++) {
       const newNode = await createNode(
         t.ctx.aztecNodeConfig,
         t.ctx.dateProvider,

--- a/yarn-project/p2p/src/services/discv5/discV5_service.ts
+++ b/yarn-project/p2p/src/services/discv5/discV5_service.ts
@@ -1,5 +1,6 @@
 import { createLogger } from '@aztec/foundation/log';
 import { sleep } from '@aztec/foundation/sleep';
+import type { AztecAsyncKVStore, AztecAsyncMap } from '@aztec/kv-store';
 import { type ComponentsVersions, checkCompressedComponentVersion } from '@aztec/stdlib/versioning';
 import { OtelMetricsAdapter, type TelemetryClient, getTelemetryClient } from '@aztec/telemetry-client';
 
@@ -16,6 +17,11 @@ import { convertToMultiaddr } from '../../util.js';
 import { type PeerDiscoveryService, PeerDiscoveryState } from '../service.js';
 
 const delayBeforeStart = 2000; // 2sec
+
+/** Map name under which discovered peer ENRs are persisted so discovery can be re-seeded after a restart. */
+const PERSISTED_ENRS_MAP_NAME = 'discovered_peer_enrs';
+/** Upper bound on persisted peer ENRs, to keep the store bounded as peers churn. */
+const MAX_PERSISTED_PEER_ENRS = 100;
 
 /**
  * Peer discovery service using Discv5.
@@ -40,6 +46,9 @@ export class DiscV5Service extends EventEmitter implements PeerDiscoveryService 
 
   private currentIp: string | undefined;
 
+  /** Persistent store of discovered peer ENRs, used to re-seed discovery after a restart. */
+  private readonly persistedEnrs?: AztecAsyncMap<string, string>;
+
   private handlers = {
     onMultiaddrUpdated: this.onMultiaddrUpdated.bind(this),
     onDiscovered: this.onDiscovered.bind(this),
@@ -52,9 +61,12 @@ export class DiscV5Service extends EventEmitter implements PeerDiscoveryService 
     private readonly packageVersion: string,
     telemetry: TelemetryClient = getTelemetryClient(),
     private logger = createLogger('p2p:discv5_service'),
+    store?: AztecAsyncKVStore,
     configOverrides: Partial<IDiscv5CreateOptions> = {},
   ) {
     super();
+
+    this.persistedEnrs = store?.openMap(PERSISTED_ENRS_MAP_NAME);
 
     const { p2pIp, p2pPort, p2pBroadcastPort, bootstrapNodes, trustedPeers, privatePeers } = config;
 
@@ -220,6 +232,11 @@ export class DiscV5Service extends EventEmitter implements PeerDiscoveryService 
         this.discv5.addEnr(enr);
       }
     }
+
+    // Re-seed discovery from peers persisted on previous runs. This lets a node rejoin the network
+    // after a restart even when no bootstrap node is reachable: discv5 has no on-disk routing table,
+    // so without this its DHT would start empty and rediscovery would depend on inbound dials alone.
+    await this.reseedFromPersistedEnrs();
   }
 
   public async runRandomNodesQuery(): Promise<void> {
@@ -278,7 +295,75 @@ export class DiscV5Service extends EventEmitter implements PeerDiscoveryService 
     const multiAddrTcp = await enr.getFullMultiaddr('tcp');
     const multiAddrUdp = await enr.getFullMultiaddr('udp');
     this.logger.debug(`Added ENR ${enr.encodeTxt()}`, { multiAddrTcp, multiAddrUdp, nodeId: enr.nodeId });
+    // Persist valid, non-bootnode peers so we can re-seed discovery after a restart. Bootnodes are
+    // excluded because they are supplied via config and re-added on start.
+    if (!this.isOurBootnode(enr) && enr.nodeId !== this.enr.nodeId && this.validateEnr(enr)) {
+      await this.persistEnr(enr);
+    }
     this.onDiscovered(enr);
+  }
+
+  private async persistEnr(enr: ENR): Promise<void> {
+    if (!this.persistedEnrs) {
+      return;
+    }
+    try {
+      await this.persistedEnrs.set(enr.nodeId, enr.encodeTxt());
+      await this.prunePersistedEnrs();
+    } catch (err) {
+      this.logger.warn(`Failed to persist discovered ENR ${enr.nodeId}`, err);
+    }
+  }
+
+  private async prunePersistedEnrs(): Promise<void> {
+    if (!this.persistedEnrs) {
+      return;
+    }
+    let toDelete = (await this.persistedEnrs.sizeAsync()) - MAX_PERSISTED_PEER_ENRS;
+    if (toDelete <= 0) {
+      return;
+    }
+    for await (const key of this.persistedEnrs.keysAsync()) {
+      if (toDelete-- <= 0) {
+        break;
+      }
+      await this.persistedEnrs.delete(key);
+    }
+  }
+
+  private async reseedFromPersistedEnrs(): Promise<void> {
+    if (!this.persistedEnrs) {
+      return;
+    }
+    const stale: string[] = [];
+    let reseeded = 0;
+    for await (const [nodeId, enrTxt] of this.persistedEnrs.entriesAsync()) {
+      let enr: ENR;
+      try {
+        enr = ENR.decodeTxt(enrTxt);
+      } catch (err) {
+        this.logger.debug(`Dropping undecodable persisted ENR ${nodeId}`, err);
+        stale.push(nodeId);
+        continue;
+      }
+      // Drop peers that no longer pass version checks so we don't keep dialing incompatible nodes.
+      if (!this.validateEnr(enr)) {
+        stale.push(nodeId);
+        continue;
+      }
+      try {
+        this.discv5.addEnr(enr);
+        reseeded++;
+      } catch (err) {
+        this.logger.debug(`Error re-seeding persisted ENR ${nodeId}`, err);
+      }
+    }
+    for (const nodeId of stale) {
+      await this.persistedEnrs.delete(nodeId);
+    }
+    if (reseeded > 0) {
+      this.logger.info(`Re-seeded discovery with ${reseeded} persisted peer ENRs`);
+    }
   }
 
   private isOurBootnode(enr: ENR) {

--- a/yarn-project/p2p/src/services/discv5/discV5_service.ts
+++ b/yarn-project/p2p/src/services/discv5/discV5_service.ts
@@ -1,7 +1,7 @@
 import { createLogger } from '@aztec/foundation/log';
 import { sleep } from '@aztec/foundation/sleep';
 import { DateProvider } from '@aztec/foundation/timer';
-import type { AztecAsyncKVStore, AztecAsyncMap } from '@aztec/kv-store';
+import type { AztecAsyncKVStore } from '@aztec/kv-store';
 import { type ComponentsVersions, checkCompressedComponentVersion } from '@aztec/stdlib/versioning';
 import { OtelMetricsAdapter, type TelemetryClient, getTelemetryClient } from '@aztec/telemetry-client';
 
@@ -16,34 +16,12 @@ import { createNodeENR } from '../../enr/generate-enr.js';
 import { AZTEC_ENR_KEY, Discv5Event, PeerEvent } from '../../types/index.js';
 import { convertToMultiaddr } from '../../util.js';
 import { type PeerDiscoveryService, PeerDiscoveryState } from '../service.js';
+import { PersistedEnrStore } from './persisted_enr_store.js';
 
 const delayBeforeStart = 2000; // 2sec
 
-/** Map name under which discovered peer ENRs are persisted so discovery can be re-seeded after a restart. */
-const PERSISTED_ENRS_MAP_NAME = 'discovered_peer_enrs';
 /** Upper bound on persisted peer ENRs, to keep the store bounded as peers churn. */
 const MAX_PERSISTED_PEER_ENRS = 100;
-
-/**
- * A persisted peer entry: the ENR text plus a monotonic sequence number recording when the peer was
- * last seen. The sequence orders the store as a FIFO so eviction drops the oldest-seen peers first.
- */
-interface PersistedEnr {
-  enr: string;
-  seq: number;
-}
-
-function parsePersistedEnr(value: string): PersistedEnr | undefined {
-  try {
-    const parsed = JSON.parse(value);
-    if (typeof parsed?.enr === 'string' && typeof parsed?.seq === 'number') {
-      return parsed;
-    }
-  } catch {
-    // Unparseable entry; caller treats it as stale.
-  }
-  return undefined;
-}
 
 /**
  * Peer discovery service using Discv5.
@@ -71,15 +49,11 @@ export class DiscV5Service extends EventEmitter implements PeerDiscoveryService 
   private currentIp: string | undefined;
 
   /** Persistent store of discovered peer ENRs, used to re-seed discovery after a restart. */
-  private readonly persistedEnrs?: AztecAsyncMap<string, string>;
-  /** The KV store backing {@link persistedEnrs}, retained so writes can run in a transaction. */
-  private readonly persistedEnrStore?: AztecAsyncKVStore;
-  /** Monotonic sequence stamped on each persisted ENR; seeded from the store's max on startup. */
-  private enrSeq = 0;
+  private readonly persistedEnrs?: PersistedEnrStore;
 
   private handlers = {
     onMultiaddrUpdated: this.onMultiaddrUpdated.bind(this),
-    onDiscovered: this.onDiscovered.bind(this),
+    onPeerDiscovered: this.onPeerDiscovered.bind(this),
     onEnrAdded: this.onEnrAdded.bind(this),
   };
 
@@ -95,8 +69,9 @@ export class DiscV5Service extends EventEmitter implements PeerDiscoveryService 
   ) {
     super();
 
-    this.persistedEnrStore = store;
-    this.persistedEnrs = store?.openMap(PERSISTED_ENRS_MAP_NAME);
+    this.persistedEnrs = store
+      ? new PersistedEnrStore(store, MAX_PERSISTED_PEER_ENRS, createLogger(`${this.logger.module}:enr-store`))
+      : undefined;
 
     const { p2pIp, p2pPort, p2pBroadcastPort, bootstrapNodes, trustedPeers, privatePeers } = config;
 
@@ -173,7 +148,7 @@ export class DiscV5Service extends EventEmitter implements PeerDiscoveryService 
       }
     };
 
-    this.discv5.on(Discv5Event.DISCOVERED, this.handlers.onDiscovered);
+    this.discv5.on(Discv5Event.DISCOVERED, this.handlers.onPeerDiscovered);
     this.discv5.on(Discv5Event.ENR_ADDED, this.handlers.onEnrAdded);
     this.discv5.on(Discv5Event.MULTIADDR_UPDATED, this.handlers.onMultiaddrUpdated);
   }
@@ -271,7 +246,22 @@ export class DiscV5Service extends EventEmitter implements PeerDiscoveryService 
     // Re-seed discovery from peers persisted on previous runs. This lets a node rejoin the network
     // after a restart even when no bootstrap node is reachable: discv5 has no on-disk routing table,
     // so without this its DHT would start empty and rediscovery would depend on inbound dials alone.
-    await this.reseedFromPersistedEnrs();
+    if (this.persistedEnrs) {
+      // Drop peers that are now config-provided (re-injected above) or fail version checks.
+      const enrs = await this.persistedEnrs.load(
+        enr => this.validateEnr(enr) && !this.configProvidedNodeIds.has(enr.nodeId),
+      );
+      for (const enr of enrs) {
+        try {
+          this.discv5.addEnr(enr);
+        } catch (err) {
+          this.logger.debug(`Error re-seeding persisted ENR ${enr.nodeId}`, err);
+        }
+      }
+      if (enrs.length > 0) {
+        this.logger.info(`Re-seeded discovery with ${enrs.length} persisted peer ENRs`);
+      }
+    }
   }
 
   public async runRandomNodesQuery(): Promise<void> {
@@ -317,7 +307,7 @@ export class DiscV5Service extends EventEmitter implements PeerDiscoveryService 
     if (this.currentState !== PeerDiscoveryState.RUNNING) {
       return;
     }
-    await this.discv5.off(Discv5Event.DISCOVERED, this.handlers.onDiscovered);
+    await this.discv5.off(Discv5Event.DISCOVERED, this.handlers.onPeerDiscovered);
     await this.discv5.off(Discv5Event.ENR_ADDED, this.handlers.onEnrAdded);
     await this.discv5.off(Discv5Event.MULTIADDR_UPDATED, this.handlers.onMultiaddrUpdated);
 
@@ -330,94 +320,26 @@ export class DiscV5Service extends EventEmitter implements PeerDiscoveryService 
     const multiAddrTcp = await enr.getFullMultiaddr('tcp');
     const multiAddrUdp = await enr.getFullMultiaddr('udp');
     this.logger.debug(`Added ENR ${enr.encodeTxt()}`, { multiAddrTcp, multiAddrUdp, nodeId: enr.nodeId });
-    // Persist organically-discovered peers so we can re-seed discovery after a restart. Config-provided
-    // peers (bootstrap/trusted/private) and our own ENR are excluded — they are re-injected on start.
-    if (!this.configProvidedNodeIds.has(enr.nodeId) && enr.nodeId !== this.enr.nodeId && this.validateEnr(enr)) {
-      await this.persistEnr(enr);
+    // A peer just entered the routing table — persist it so we can re-seed discovery after a restart.
+    if (this.persistedEnrs && this.shouldPersist(enr)) {
+      await this.persistedEnrs.persist(enr);
     }
     this.onDiscovered(enr);
   }
 
-  private async persistEnr(enr: ENR): Promise<void> {
-    const store = this.persistedEnrStore;
-    const map = this.persistedEnrs;
-    if (!store || !map) {
-      return;
+  private async onPeerDiscovered(enr: ENR) {
+    // discv5 updates an existing routing-table entry on an ENR sequence bump without emitting enrAdded,
+    // so DISCOVERED is our only signal that a peer we already track may have changed address. Refresh
+    // the persisted copy (a no-op for peers we don't already store) so we don't keep dialing a stale ENR.
+    if (this.persistedEnrs && this.shouldPersist(enr)) {
+      await this.persistedEnrs.refresh(enr);
     }
-    const nodeId = enr.nodeId;
-    const enrTxt = enr.encodeTxt();
-    try {
-      // Write and evict atomically so concurrent ENR_ADDED events can't race the size check.
-      await store.transactionAsync(async () => {
-        await map.set(nodeId, JSON.stringify({ enr: enrTxt, seq: ++this.enrSeq }));
-        await this.evictOldestEnrs(map);
-      });
-    } catch (err) {
-      this.logger.warn(`Failed to persist discovered ENR ${nodeId}`, err);
-    }
+    this.onDiscovered(enr);
   }
 
-  /** Drops the oldest-seen ENRs (lowest sequence) once the store exceeds its cap. Runs inside a transaction. */
-  private async evictOldestEnrs(map: AztecAsyncMap<string, string>): Promise<void> {
-    const overflow = (await map.sizeAsync()) - MAX_PERSISTED_PEER_ENRS;
-    if (overflow <= 0) {
-      return;
-    }
-    const bySeq: { nodeId: string; seq: number }[] = [];
-    for await (const [nodeId, value] of map.entriesAsync()) {
-      bySeq.push({ nodeId, seq: parsePersistedEnr(value)?.seq ?? 0 });
-    }
-    bySeq.sort((a, b) => a.seq - b.seq);
-    for (let i = 0; i < overflow; i++) {
-      await map.delete(bySeq[i].nodeId);
-    }
-  }
-
-  private async reseedFromPersistedEnrs(): Promise<void> {
-    const store = this.persistedEnrStore;
-    const map = this.persistedEnrs;
-    if (!store || !map) {
-      return;
-    }
-    const stale: string[] = [];
-    let reseeded = 0;
-    let maxSeq = 0;
-    for await (const [nodeId, value] of map.entriesAsync()) {
-      const parsed = parsePersistedEnr(value);
-      let enr: ENR | undefined;
-      if (parsed) {
-        try {
-          enr = ENR.decodeTxt(parsed.enr);
-        } catch (err) {
-          this.logger.debug(`Dropping undecodable persisted ENR ${nodeId}`, err);
-        }
-      }
-      // Drop entries we can't parse/decode, peers that no longer pass version checks, or peers that are
-      // now provided via config (they get re-injected from config, so they don't belong in this store).
-      if (!parsed || !enr || !this.validateEnr(enr) || this.configProvidedNodeIds.has(nodeId)) {
-        stale.push(nodeId);
-        continue;
-      }
-      maxSeq = Math.max(maxSeq, parsed.seq);
-      try {
-        this.discv5.addEnr(enr);
-        reseeded++;
-      } catch (err) {
-        this.logger.debug(`Error re-seeding persisted ENR ${nodeId}`, err);
-      }
-    }
-    // Continue the sequence from the highest persisted value so FIFO order survives restarts.
-    this.enrSeq = maxSeq;
-    if (stale.length > 0) {
-      await store.transactionAsync(async () => {
-        for (const nodeId of stale) {
-          await map.delete(nodeId);
-        }
-      });
-    }
-    if (reseeded > 0) {
-      this.logger.info(`Re-seeded discovery with ${reseeded} persisted peer ENRs`);
-    }
+  /** Whether an ENR belongs in the persisted store: a validated, non-config peer that isn't ourselves. */
+  private shouldPersist(enr: ENR): boolean {
+    return !this.configProvidedNodeIds.has(enr.nodeId) && enr.nodeId !== this.enr.nodeId && this.validateEnr(enr);
   }
 
   private isOurBootnode(enr: ENR) {

--- a/yarn-project/p2p/src/services/discv5/discV5_service.ts
+++ b/yarn-project/p2p/src/services/discv5/discV5_service.ts
@@ -1,5 +1,6 @@
 import { createLogger } from '@aztec/foundation/log';
 import { sleep } from '@aztec/foundation/sleep';
+import { DateProvider } from '@aztec/foundation/timer';
 import type { AztecAsyncKVStore, AztecAsyncMap } from '@aztec/kv-store';
 import { type ComponentsVersions, checkCompressedComponentVersion } from '@aztec/stdlib/versioning';
 import { OtelMetricsAdapter, type TelemetryClient, getTelemetryClient } from '@aztec/telemetry-client';
@@ -62,6 +63,8 @@ export class DiscV5Service extends EventEmitter implements PeerDiscoveryService 
   private bootstrapNodePeerIds: PeerId[] = [];
   public bootstrapNodeEnrs: ENR[] = [];
   private trustedPeerEnrs: ENR[] = [];
+  /** Node IDs of all config-provided peers (bootstrap, trusted, private); these are never persisted. */
+  private readonly configProvidedNodeIds: Set<string>;
 
   private startTime = 0;
 
@@ -88,6 +91,7 @@ export class DiscV5Service extends EventEmitter implements PeerDiscoveryService 
     private logger = createLogger('p2p:discv5_service'),
     store?: AztecAsyncKVStore,
     configOverrides: Partial<IDiscv5CreateOptions> = {},
+    private readonly dateProvider: DateProvider = new DateProvider(),
   ) {
     super();
 
@@ -100,6 +104,11 @@ export class DiscV5Service extends EventEmitter implements PeerDiscoveryService 
     this.bootstrapNodeEnrs = bootstrapNodes.map(x => ENR.decodeTxt(x));
     const privatePeerEnrs = new Set(privatePeers);
     this.trustedPeerEnrs = trustedPeers.filter(x => !privatePeerEnrs.has(x)).map(x => ENR.decodeTxt(x));
+    // Peers supplied via config are re-injected from config on every start, so they must never end up
+    // in the persisted (discovered-peer) store — private peers especially must not be written there.
+    this.configProvidedNodeIds = new Set(
+      [...bootstrapNodes, ...trustedPeers, ...privatePeers].map(x => ENR.decodeTxt(x).nodeId),
+    );
 
     // If no overridden broadcast port is provided, use the p2p port as the broadcast port
     if (!p2pBroadcastPort) {
@@ -206,7 +215,7 @@ export class DiscV5Service extends EventEmitter implements PeerDiscoveryService 
     }
     this.logger.debug('Starting DiscV5');
     await this.discv5.start();
-    this.startTime = Date.now();
+    this.startTime = this.dateProvider.now();
 
     const enrUpdateEnabled = this.config.queryForIp || !this.config.p2pIp;
     this.logger.info(`DiscV5 service started`, {
@@ -272,8 +281,8 @@ export class DiscV5Service extends EventEmitter implements PeerDiscoveryService 
 
     // First, wait some time before starting the peer discovery
     // reference: https://github.com/ChainSafe/lodestar/issues/3423
-    const msSinceStart = Date.now() - this.startTime;
-    if (Date.now() - this.startTime <= delayBeforeStart) {
+    const msSinceStart = this.dateProvider.now() - this.startTime;
+    if (this.dateProvider.now() - this.startTime <= delayBeforeStart) {
       await sleep(delayBeforeStart - msSinceStart);
     }
 
@@ -321,9 +330,9 @@ export class DiscV5Service extends EventEmitter implements PeerDiscoveryService 
     const multiAddrTcp = await enr.getFullMultiaddr('tcp');
     const multiAddrUdp = await enr.getFullMultiaddr('udp');
     this.logger.debug(`Added ENR ${enr.encodeTxt()}`, { multiAddrTcp, multiAddrUdp, nodeId: enr.nodeId });
-    // Persist valid, non-bootnode peers so we can re-seed discovery after a restart. Bootnodes are
-    // excluded because they are supplied via config and re-added on start.
-    if (!this.isOurBootnode(enr) && enr.nodeId !== this.enr.nodeId && this.validateEnr(enr)) {
+    // Persist organically-discovered peers so we can re-seed discovery after a restart. Config-provided
+    // peers (bootstrap/trusted/private) and our own ENR are excluded — they are re-injected on start.
+    if (!this.configProvidedNodeIds.has(enr.nodeId) && enr.nodeId !== this.enr.nodeId && this.validateEnr(enr)) {
       await this.persistEnr(enr);
     }
     this.onDiscovered(enr);
@@ -383,8 +392,9 @@ export class DiscV5Service extends EventEmitter implements PeerDiscoveryService 
           this.logger.debug(`Dropping undecodable persisted ENR ${nodeId}`, err);
         }
       }
-      // Drop entries we can't parse/decode, or peers that no longer pass version checks.
-      if (!parsed || !enr || !this.validateEnr(enr)) {
+      // Drop entries we can't parse/decode, peers that no longer pass version checks, or peers that are
+      // now provided via config (they get re-injected from config, so they don't belong in this store).
+      if (!parsed || !enr || !this.validateEnr(enr) || this.configProvidedNodeIds.has(nodeId)) {
         stale.push(nodeId);
         continue;
       }

--- a/yarn-project/p2p/src/services/discv5/discV5_service.ts
+++ b/yarn-project/p2p/src/services/discv5/discV5_service.ts
@@ -24,6 +24,27 @@ const PERSISTED_ENRS_MAP_NAME = 'discovered_peer_enrs';
 const MAX_PERSISTED_PEER_ENRS = 100;
 
 /**
+ * A persisted peer entry: the ENR text plus a monotonic sequence number recording when the peer was
+ * last seen. The sequence orders the store as a FIFO so eviction drops the oldest-seen peers first.
+ */
+interface PersistedEnr {
+  enr: string;
+  seq: number;
+}
+
+function parsePersistedEnr(value: string): PersistedEnr | undefined {
+  try {
+    const parsed = JSON.parse(value);
+    if (typeof parsed?.enr === 'string' && typeof parsed?.seq === 'number') {
+      return parsed;
+    }
+  } catch {
+    // Unparseable entry; caller treats it as stale.
+  }
+  return undefined;
+}
+
+/**
  * Peer discovery service using Discv5.
  */
 export class DiscV5Service extends EventEmitter implements PeerDiscoveryService {
@@ -48,6 +69,10 @@ export class DiscV5Service extends EventEmitter implements PeerDiscoveryService 
 
   /** Persistent store of discovered peer ENRs, used to re-seed discovery after a restart. */
   private readonly persistedEnrs?: AztecAsyncMap<string, string>;
+  /** The KV store backing {@link persistedEnrs}, retained so writes can run in a transaction. */
+  private readonly persistedEnrStore?: AztecAsyncKVStore;
+  /** Monotonic sequence stamped on each persisted ENR; seeded from the store's max on startup. */
+  private enrSeq = 0;
 
   private handlers = {
     onMultiaddrUpdated: this.onMultiaddrUpdated.bind(this),
@@ -66,6 +91,7 @@ export class DiscV5Service extends EventEmitter implements PeerDiscoveryService 
   ) {
     super();
 
+    this.persistedEnrStore = store;
     this.persistedEnrs = store?.openMap(PERSISTED_ENRS_MAP_NAME);
 
     const { p2pIp, p2pPort, p2pBroadcastPort, bootstrapNodes, trustedPeers, privatePeers } = config;
@@ -304,53 +330,65 @@ export class DiscV5Service extends EventEmitter implements PeerDiscoveryService 
   }
 
   private async persistEnr(enr: ENR): Promise<void> {
-    if (!this.persistedEnrs) {
+    const store = this.persistedEnrStore;
+    const map = this.persistedEnrs;
+    if (!store || !map) {
       return;
     }
+    const nodeId = enr.nodeId;
+    const enrTxt = enr.encodeTxt();
     try {
-      await this.persistedEnrs.set(enr.nodeId, enr.encodeTxt());
-      await this.prunePersistedEnrs();
+      // Write and evict atomically so concurrent ENR_ADDED events can't race the size check.
+      await store.transactionAsync(async () => {
+        await map.set(nodeId, JSON.stringify({ enr: enrTxt, seq: ++this.enrSeq }));
+        await this.evictOldestEnrs(map);
+      });
     } catch (err) {
-      this.logger.warn(`Failed to persist discovered ENR ${enr.nodeId}`, err);
+      this.logger.warn(`Failed to persist discovered ENR ${nodeId}`, err);
     }
   }
 
-  private async prunePersistedEnrs(): Promise<void> {
-    if (!this.persistedEnrs) {
+  /** Drops the oldest-seen ENRs (lowest sequence) once the store exceeds its cap. Runs inside a transaction. */
+  private async evictOldestEnrs(map: AztecAsyncMap<string, string>): Promise<void> {
+    const overflow = (await map.sizeAsync()) - MAX_PERSISTED_PEER_ENRS;
+    if (overflow <= 0) {
       return;
     }
-    let toDelete = (await this.persistedEnrs.sizeAsync()) - MAX_PERSISTED_PEER_ENRS;
-    if (toDelete <= 0) {
-      return;
+    const bySeq: { nodeId: string; seq: number }[] = [];
+    for await (const [nodeId, value] of map.entriesAsync()) {
+      bySeq.push({ nodeId, seq: parsePersistedEnr(value)?.seq ?? 0 });
     }
-    for await (const key of this.persistedEnrs.keysAsync()) {
-      if (toDelete-- <= 0) {
-        break;
-      }
-      await this.persistedEnrs.delete(key);
+    bySeq.sort((a, b) => a.seq - b.seq);
+    for (let i = 0; i < overflow; i++) {
+      await map.delete(bySeq[i].nodeId);
     }
   }
 
   private async reseedFromPersistedEnrs(): Promise<void> {
-    if (!this.persistedEnrs) {
+    const store = this.persistedEnrStore;
+    const map = this.persistedEnrs;
+    if (!store || !map) {
       return;
     }
     const stale: string[] = [];
     let reseeded = 0;
-    for await (const [nodeId, enrTxt] of this.persistedEnrs.entriesAsync()) {
-      let enr: ENR;
-      try {
-        enr = ENR.decodeTxt(enrTxt);
-      } catch (err) {
-        this.logger.debug(`Dropping undecodable persisted ENR ${nodeId}`, err);
+    let maxSeq = 0;
+    for await (const [nodeId, value] of map.entriesAsync()) {
+      const parsed = parsePersistedEnr(value);
+      let enr: ENR | undefined;
+      if (parsed) {
+        try {
+          enr = ENR.decodeTxt(parsed.enr);
+        } catch (err) {
+          this.logger.debug(`Dropping undecodable persisted ENR ${nodeId}`, err);
+        }
+      }
+      // Drop entries we can't parse/decode, or peers that no longer pass version checks.
+      if (!parsed || !enr || !this.validateEnr(enr)) {
         stale.push(nodeId);
         continue;
       }
-      // Drop peers that no longer pass version checks so we don't keep dialing incompatible nodes.
-      if (!this.validateEnr(enr)) {
-        stale.push(nodeId);
-        continue;
-      }
+      maxSeq = Math.max(maxSeq, parsed.seq);
       try {
         this.discv5.addEnr(enr);
         reseeded++;
@@ -358,8 +396,14 @@ export class DiscV5Service extends EventEmitter implements PeerDiscoveryService 
         this.logger.debug(`Error re-seeding persisted ENR ${nodeId}`, err);
       }
     }
-    for (const nodeId of stale) {
-      await this.persistedEnrs.delete(nodeId);
+    // Continue the sequence from the highest persisted value so FIFO order survives restarts.
+    this.enrSeq = maxSeq;
+    if (stale.length > 0) {
+      await store.transactionAsync(async () => {
+        for (const nodeId of stale) {
+          await map.delete(nodeId);
+        }
+      });
     }
     if (reseeded > 0) {
       this.logger.info(`Re-seeded discovery with ${reseeded} persisted peer ENRs`);

--- a/yarn-project/p2p/src/services/discv5/discv5_service.test.ts
+++ b/yarn-project/p2p/src/services/discv5/discv5_service.test.ts
@@ -222,8 +222,6 @@ describe('Discv5Service', () => {
     await stopNodes(node1, node2, node3);
   });
 
-  // Test is flakey, so skipping for now.
-  // TODO: Investigate: #6246
   it('resurrects persisted peers from the store on restart with no bootnode', async () => {
     const peerIdA = await createSecp256k1PeerId();
     const portA = ++basePort;

--- a/yarn-project/p2p/src/services/discv5/discv5_service.test.ts
+++ b/yarn-project/p2p/src/services/discv5/discv5_service.test.ts
@@ -365,6 +365,6 @@ describe('Discv5Service', () => {
       l2QueueSize: 100,
       ...overrides,
     };
-    return new DiscV5Service(peerId, config, testPackageVersion, undefined, undefined, overrides);
+    return new DiscV5Service(peerId, config, testPackageVersion, undefined, undefined, undefined, overrides);
   };
 });

--- a/yarn-project/p2p/src/services/discv5/discv5_service.test.ts
+++ b/yarn-project/p2p/src/services/discv5/discv5_service.test.ts
@@ -15,6 +15,7 @@ import { type BootnodeConfig, DEFAULT_PUBLIC_IP_SERVICES, type P2PConfig, getP2P
 import { AZTEC_ENR_CLIENT_VERSION_KEY } from '../../types/index.js';
 import { PeerDiscoveryState } from '../service.js';
 import { DiscV5Service } from './discV5_service.js';
+import { PersistedEnrStore } from './persisted_enr_store.js';
 
 /**
  * Runs discovery queries on all nodes until the condition is met or timeout expires.
@@ -223,28 +224,73 @@ describe('Discv5Service', () => {
 
   // Test is flakey, so skipping for now.
   // TODO: Investigate: #6246
-  it.skip('should persist peers without bootnode', async () => {
-    const node1 = await createNode();
-    const node2 = await createNode();
-    await node1.start();
-    await node2.start();
+  it('resurrects persisted peers from the store on restart with no bootnode', async () => {
+    const peerIdA = await createSecp256k1PeerId();
+    const portA = ++basePort;
 
-    await runDiscoveryUntil([node1, node2], () => node2.getKadValues().length >= 2);
+    // nodeA is backed by the suite's store (the only KV store in play — the bootnode shares it), so it
+    // persists the peers it discovers. We can recreate it as a fresh instance with the same identity,
+    // port and store to model a process restart. nodeB has no store; it's only a peer for nodeA to find.
+    const makeNodeA = (useBootnode: boolean) =>
+      new DiscV5Service(
+        peerIdA,
+        {
+          ...getP2PDefaultConfig(),
+          ...emptyChainConfig,
+          p2pIp: `127.0.0.1`,
+          listenAddress: `127.0.0.1`,
+          p2pPort: portA,
+          bootstrapNodes: useBootnode ? [bootNode.getENR().encodeTxt()] : [],
+          blockCheckIntervalMS: 50,
+          peerCheckIntervalMS: 50,
+          p2pEnabled: true,
+          l2QueueSize: 100,
+        },
+        testPackageVersion,
+        undefined,
+        undefined,
+        store,
+      );
 
-    await node2.stop();
+    let nodeA = makeNodeA(true);
+    const nodeB = await createNode();
+    await nodeA.start();
+    await nodeB.start();
+
+    // A read-only view of the same store, to assert what nodeA persists.
+    const persistedView = new PersistedEnrStore(store, 1000);
+    const persistedNodeIds = async () => (await persistedView.load(() => true)).map(enr => enr.nodeId);
+
+    // Drive discovery until nodeA has found nodeB and persisted its ENR — exercising the persist hook
+    // for a discovered, non-bootnode peer.
+    await retryUntil(
+      async () => {
+        await Promise.all([nodeA, nodeB].map(n => n.runRandomNodesQuery()));
+        return (await persistedNodeIds()).includes(nodeB.getEnr().nodeId) || undefined;
+      },
+      'nodeB persisted by nodeA',
+      30,
+      0.2,
+    );
+
+    // The bootnode is config-provided, so it must never be persisted.
+    expect(await persistedNodeIds()).not.toContain(bootNode.getENR().nodeId);
+
+    // Tear the live network down so nothing can re-teach nodeA about nodeB.
+    await nodeA.stop();
+    await nodeB.stop();
     await bootNode.stop();
 
-    await node2.start();
+    // Recreate nodeA as a fresh instance on the same store with no bootnode. Its discv5 routing table
+    // starts empty, so the only way it can know nodeB is by resurrecting the persisted ENR on start().
+    nodeA = makeNodeA(false);
+    await nodeA.start();
 
-    await runDiscoveryUntil([node1, node2], () => node2.getKadValues().length >= 1);
+    const resurrected = await Promise.all(nodeA.getKadValues().map(async enr => (await enr.peerId()).toString()));
+    expect(resurrected).toContain(nodeB.getPeerId().toString());
+    expect(resurrected).not.toContain(bootNodePeerId.toString());
 
-    const node2Peers = await Promise.all(node2.getKadValues().map(async peer => (await peer.peerId()).toString()));
-    // NOTE: bootnode seems to still be present in list of peers sometimes, will investigate
-    // expect(node2Peers).toHaveLength(1);
-    expect(node2Peers).toContain(node1.getPeerId().toString());
-
-    await node1.stop();
-    await node2.stop();
+    await nodeA.stop();
   });
 
   it('should use trusted peers for discovery', async () => {

--- a/yarn-project/p2p/src/services/discv5/persisted_enr_store.test.ts
+++ b/yarn-project/p2p/src/services/discv5/persisted_enr_store.test.ts
@@ -1,0 +1,100 @@
+import type { AztecAsyncKVStore } from '@aztec/kv-store';
+import { openTmpStore } from '@aztec/kv-store/lmdb-v2';
+
+import type { PeerId } from '@libp2p/interface';
+import { createSecp256k1PeerId } from '@libp2p/peer-id-factory';
+import { ENR, SignableENR } from '@nethermindeth/enr';
+
+import { PersistedEnrStore } from './persisted_enr_store.js';
+
+describe('PersistedEnrStore', () => {
+  let store: AztecAsyncKVStore;
+
+  beforeEach(async () => {
+    store = await openTmpStore('persisted-enr-store-test');
+  });
+
+  afterEach(async () => {
+    await store.close();
+  });
+
+  // Mints an immutable ENR for the given peer at a specific sequence number. The same peer always
+  // produces the same nodeId regardless of sequence, so this lets us model a peer updating its ENR.
+  const enrForPeer = (peerId: PeerId, seq: bigint): ENR => {
+    const signable = SignableENR.createFromPeerId(peerId);
+    signable.seq = seq;
+    return ENR.decodeTxt(signable.encodeTxt());
+  };
+
+  const nodeIdsOf = (enrs: ENR[]) => new Set(enrs.map(e => e.nodeId));
+
+  it('round-trips persisted ENRs through load', async () => {
+    const enrStore = new PersistedEnrStore(store, 10);
+    const a = enrForPeer(await createSecp256k1PeerId(), 1n);
+    const b = enrForPeer(await createSecp256k1PeerId(), 1n);
+
+    await enrStore.persist(a);
+    await enrStore.persist(b);
+
+    expect(nodeIdsOf(await enrStore.load(() => true))).toEqual(nodeIdsOf([a, b]));
+  });
+
+  it('refreshes a tracked peer to a newer ENR, ignores older ones, and never adds unknown peers', async () => {
+    const enrStore = new PersistedEnrStore(store, 10);
+    const peer = await createSecp256k1PeerId();
+
+    await enrStore.persist(enrForPeer(peer, 1n));
+
+    // A newer ENR (higher sequence) replaces the stored one.
+    await enrStore.refresh(enrForPeer(peer, 3n));
+    let loaded = await enrStore.load(() => true);
+    expect(loaded).toHaveLength(1);
+    expect(loaded[0].seq).toBe(3n);
+
+    // An older ENR is ignored.
+    await enrStore.refresh(enrForPeer(peer, 2n));
+    loaded = await enrStore.load(() => true);
+    expect(loaded[0].seq).toBe(3n);
+
+    // Refreshing a peer we don't already track is a no-op (refresh only updates, never inserts).
+    await enrStore.refresh(enrForPeer(await createSecp256k1PeerId(), 1n));
+    expect(await enrStore.load(() => true)).toHaveLength(1);
+  });
+
+  it('evicts the oldest-seen ENRs first once over capacity', async () => {
+    const enrStore = new PersistedEnrStore(store, 3);
+    const a = enrForPeer(await createSecp256k1PeerId(), 1n);
+    const b = enrForPeer(await createSecp256k1PeerId(), 1n);
+    const c = enrForPeer(await createSecp256k1PeerId(), 1n);
+    const d = enrForPeer(await createSecp256k1PeerId(), 1n);
+    const e = enrForPeer(await createSecp256k1PeerId(), 1n);
+
+    // Fill past the cap: A is the oldest and gets evicted.
+    await enrStore.persist(a);
+    await enrStore.persist(b);
+    await enrStore.persist(c);
+    await enrStore.persist(d);
+    expect(nodeIdsOf(await enrStore.load(() => true))).toEqual(nodeIdsOf([b, c, d]));
+
+    // Re-persisting B marks it most-recently-seen, so the next eviction drops C (now the oldest) not B.
+    await enrStore.persist(b);
+    await enrStore.persist(e);
+    expect(nodeIdsOf(await enrStore.load(() => true))).toEqual(nodeIdsOf([b, d, e]));
+  });
+
+  it('drops rejected and undecodable entries on load', async () => {
+    const enrStore = new PersistedEnrStore(store, 10);
+    const keep = enrForPeer(await createSecp256k1PeerId(), 1n);
+    const reject = enrForPeer(await createSecp256k1PeerId(), 1n);
+
+    await enrStore.persist(keep);
+    await enrStore.persist(reject);
+
+    // The predicate rejects one peer; it should be returned-excluded and removed from the store.
+    const loaded = await enrStore.load(enr => enr.nodeId === keep.nodeId);
+    expect(nodeIdsOf(loaded)).toEqual(nodeIdsOf([keep]));
+
+    // A subsequent accept-all load confirms the rejected entry was deleted, not merely filtered.
+    expect(nodeIdsOf(await enrStore.load(() => true))).toEqual(nodeIdsOf([keep]));
+  });
+});

--- a/yarn-project/p2p/src/services/discv5/persisted_enr_store.test.ts
+++ b/yarn-project/p2p/src/services/discv5/persisted_enr_store.test.ts
@@ -3,6 +3,7 @@ import { openTmpStore } from '@aztec/kv-store/lmdb-v2';
 
 import type { PeerId } from '@libp2p/interface';
 import { createSecp256k1PeerId } from '@libp2p/peer-id-factory';
+import { multiaddr } from '@multiformats/multiaddr';
 import { ENR, SignableENR } from '@nethermindeth/enr';
 
 import { PersistedEnrStore } from './persisted_enr_store.js';
@@ -18,83 +19,118 @@ describe('PersistedEnrStore', () => {
     await store.close();
   });
 
-  // Mints an immutable ENR for the given peer at a specific sequence number. The same peer always
-  // produces the same nodeId regardless of sequence, so this lets us model a peer updating its ENR.
-  const enrForPeer = (peerId: PeerId, seq: bigint): ENR => {
+  // Mints an immutable ENR for the given peer at a specific sequence number and UDP port. The same
+  // peer always produces the same nodeId regardless of sequence/address, so this models a peer that
+  // bumps its ENR (e.g. after changing address).
+  const enrForPeer = (peerId: PeerId, seq: bigint, udpPort: number): ENR => {
     const signable = SignableENR.createFromPeerId(peerId);
+    signable.setLocationMultiaddr(multiaddr(`/ip4/127.0.0.1/udp/${udpPort}`));
     signable.seq = seq;
     return ENR.decodeTxt(signable.encodeTxt());
   };
 
-  const nodeIdsOf = (enrs: ENR[]) => new Set(enrs.map(e => e.nodeId));
+  // Loads the store and indexes the result by nodeId so tests can assert on individual peers' ENRs.
+  const loadByNodeId = async (enrStore: PersistedEnrStore, accept: (enr: ENR) => boolean = () => true) => {
+    const enrs = await enrStore.load(accept);
+    return new Map(enrs.map(enr => [enr.nodeId, enr]));
+  };
 
-  it('round-trips persisted ENRs through load', async () => {
+  // Asserts the store holds exactly `expected`, matching each by full ENR record (txt), sequence and port.
+  const expectStoredExactly = async (enrStore: PersistedEnrStore, expected: ENR[]) => {
+    const loaded = await loadByNodeId(enrStore);
+    expect([...loaded.keys()].sort()).toEqual(expected.map(e => e.nodeId).sort());
+    for (const enr of expected) {
+      const stored = loaded.get(enr.nodeId);
+      expect(stored?.encodeTxt()).toBe(enr.encodeTxt());
+      expect(stored?.seq).toBe(enr.seq);
+      expect(stored?.udp).toBe(enr.udp);
+    }
+  };
+
+  it('round-trips persisted ENRs through load, preserving their full record', async () => {
     const enrStore = new PersistedEnrStore(store, 10);
-    const a = enrForPeer(await createSecp256k1PeerId(), 1n);
-    const b = enrForPeer(await createSecp256k1PeerId(), 1n);
+    const a = enrForPeer(await createSecp256k1PeerId(), 1n, 4001);
+    const b = enrForPeer(await createSecp256k1PeerId(), 1n, 4002);
 
     await enrStore.persist(a);
     await enrStore.persist(b);
 
-    expect(nodeIdsOf(await enrStore.load(() => true))).toEqual(nodeIdsOf([a, b]));
+    await expectStoredExactly(enrStore, [a, b]);
   });
 
-  it('refreshes a tracked peer to a newer ENR, ignores older ones, and never adds unknown peers', async () => {
+  it('refreshes a tracked peer to a newer ENR (new address), ignores older ones, never adds unknown peers', async () => {
     const enrStore = new PersistedEnrStore(store, 10);
     const peer = await createSecp256k1PeerId();
+    const v1 = enrForPeer(peer, 1n, 5001);
+    const v2 = enrForPeer(peer, 2n, 5002);
+    const v3 = enrForPeer(peer, 3n, 5003);
+    const nodeId = v1.nodeId; // v1/v2/v3 share a nodeId (same peer), so any of them works
 
-    await enrStore.persist(enrForPeer(peer, 1n));
+    await enrStore.persist(v1);
+    await expectStoredExactly(enrStore, [v1]);
 
-    // A newer ENR (higher sequence) replaces the stored one.
-    await enrStore.refresh(enrForPeer(peer, 3n));
-    let loaded = await enrStore.load(() => true);
-    expect(loaded).toHaveLength(1);
-    expect(loaded[0].seq).toBe(3n);
+    // A newer ENR (higher sequence, new address) replaces the stored one in full.
+    await enrStore.refresh(v3);
+    let stored = (await loadByNodeId(enrStore)).get(nodeId);
+    expect(stored?.encodeTxt()).toBe(v3.encodeTxt());
+    expect(stored?.seq).toBe(3n);
+    expect(stored?.udp).toBe(5003);
 
-    // An older ENR is ignored.
-    await enrStore.refresh(enrForPeer(peer, 2n));
-    loaded = await enrStore.load(() => true);
-    expect(loaded[0].seq).toBe(3n);
+    // An older ENR is ignored — the stored record and address are unchanged.
+    await enrStore.refresh(v2);
+    stored = (await loadByNodeId(enrStore)).get(nodeId);
+    expect(stored?.encodeTxt()).toBe(v3.encodeTxt());
+    expect(stored?.seq).toBe(3n);
+    expect(stored?.udp).toBe(5003);
 
     // Refreshing a peer we don't already track is a no-op (refresh only updates, never inserts).
-    await enrStore.refresh(enrForPeer(await createSecp256k1PeerId(), 1n));
-    expect(await enrStore.load(() => true)).toHaveLength(1);
+    const unknown = enrForPeer(await createSecp256k1PeerId(), 1n, 5099);
+    await enrStore.refresh(unknown);
+    const loaded = await loadByNodeId(enrStore);
+    expect(loaded.has(unknown.nodeId)).toBe(false);
+    await expectStoredExactly(enrStore, [v3]);
   });
 
-  it('evicts the oldest-seen ENRs first once over capacity', async () => {
+  it('evicts the oldest-seen ENRs first once over capacity, keeping the rest intact', async () => {
     const enrStore = new PersistedEnrStore(store, 3);
-    const a = enrForPeer(await createSecp256k1PeerId(), 1n);
-    const b = enrForPeer(await createSecp256k1PeerId(), 1n);
-    const c = enrForPeer(await createSecp256k1PeerId(), 1n);
-    const d = enrForPeer(await createSecp256k1PeerId(), 1n);
-    const e = enrForPeer(await createSecp256k1PeerId(), 1n);
+    const a = enrForPeer(await createSecp256k1PeerId(), 1n, 6001);
+    const b = enrForPeer(await createSecp256k1PeerId(), 1n, 6002);
+    const c = enrForPeer(await createSecp256k1PeerId(), 1n, 6003);
+    const d = enrForPeer(await createSecp256k1PeerId(), 1n, 6004);
+    const e = enrForPeer(await createSecp256k1PeerId(), 1n, 6005);
 
-    // Fill past the cap: A is the oldest and gets evicted.
+    // Fill past the cap: A is the oldest-seen and gets evicted; B, C, D remain with their records intact.
     await enrStore.persist(a);
     await enrStore.persist(b);
     await enrStore.persist(c);
     await enrStore.persist(d);
-    expect(nodeIdsOf(await enrStore.load(() => true))).toEqual(nodeIdsOf([b, c, d]));
+    let loaded = await loadByNodeId(enrStore);
+    expect(loaded.has(a.nodeId)).toBe(false);
+    await expectStoredExactly(enrStore, [b, c, d]);
 
-    // Re-persisting B marks it most-recently-seen, so the next eviction drops C (now the oldest) not B.
+    // Re-persisting B marks it most-recently-seen, so the next eviction drops C (now the oldest), not B.
     await enrStore.persist(b);
     await enrStore.persist(e);
-    expect(nodeIdsOf(await enrStore.load(() => true))).toEqual(nodeIdsOf([b, d, e]));
+    loaded = await loadByNodeId(enrStore);
+    expect(loaded.has(a.nodeId)).toBe(false);
+    expect(loaded.has(c.nodeId)).toBe(false);
+    await expectStoredExactly(enrStore, [b, d, e]);
   });
 
-  it('drops rejected and undecodable entries on load', async () => {
+  it('drops rejected and undecodable entries on load, keeping the accepted record intact', async () => {
     const enrStore = new PersistedEnrStore(store, 10);
-    const keep = enrForPeer(await createSecp256k1PeerId(), 1n);
-    const reject = enrForPeer(await createSecp256k1PeerId(), 1n);
+    const keep = enrForPeer(await createSecp256k1PeerId(), 1n, 7001);
+    const reject = enrForPeer(await createSecp256k1PeerId(), 1n, 7002);
 
     await enrStore.persist(keep);
     await enrStore.persist(reject);
 
-    // The predicate rejects one peer; it should be returned-excluded and removed from the store.
-    const loaded = await enrStore.load(enr => enr.nodeId === keep.nodeId);
-    expect(nodeIdsOf(loaded)).toEqual(nodeIdsOf([keep]));
+    // The predicate rejects one peer; it is excluded from the result and deleted from the store.
+    const loaded = await loadByNodeId(enrStore, enr => enr.nodeId === keep.nodeId);
+    expect([...loaded.keys()]).toEqual([keep.nodeId]);
+    expect(loaded.get(keep.nodeId)?.encodeTxt()).toBe(keep.encodeTxt());
 
-    // A subsequent accept-all load confirms the rejected entry was deleted, not merely filtered.
-    expect(nodeIdsOf(await enrStore.load(() => true))).toEqual(nodeIdsOf([keep]));
+    // A subsequent accept-all load confirms the rejected entry was deleted, not merely filtered out.
+    await expectStoredExactly(enrStore, [keep]);
   });
 });

--- a/yarn-project/p2p/src/services/discv5/persisted_enr_store.ts
+++ b/yarn-project/p2p/src/services/discv5/persisted_enr_store.ts
@@ -90,8 +90,14 @@ export class PersistedEnrStore {
         if (!existing) {
           return;
         }
-        const storedSeq = this.decodeStoredEnr(existing)?.seq;
-        if (storedSeq !== undefined && enr.seq <= storedSeq) {
+        // Two unrelated sequence numbers are in play:
+        //  - the ENR sequence (`enr.seq` / `storedEnrSeq`) is set by the *peer* and bumped whenever it
+        //    revises its record (e.g. changes address); we compare these to decide whether the incoming
+        //    ENR is genuinely newer and worth keeping.
+        //  - our storage sequence (`this.seq`) is an internal counter used only for FIFO eviction; we
+        //    stamp a fresh one so this entry counts as most-recently-seen.
+        const storedEnrSeq = this.decodeStoredEnr(existing)?.seq;
+        if (storedEnrSeq !== undefined && enr.seq <= storedEnrSeq) {
           return;
         }
         await this.enrs.set(nodeId, JSON.stringify({ enr: enr.encodeTxt(), seq: ++this.seq }));

--- a/yarn-project/p2p/src/services/discv5/persisted_enr_store.ts
+++ b/yarn-project/p2p/src/services/discv5/persisted_enr_store.ts
@@ -1,0 +1,154 @@
+import { type Logger, createLogger } from '@aztec/foundation/log';
+import type { AztecAsyncKVStore, AztecAsyncMap } from '@aztec/kv-store';
+
+import { ENR } from '@nethermindeth/enr';
+
+/** Map name under which discovered peer ENRs are persisted so discovery can be re-seeded after a restart. */
+const PERSISTED_ENRS_MAP_NAME = 'discovered_peer_enrs';
+
+/**
+ * A persisted peer entry: the ENR text plus a monotonic sequence number recording when the peer was
+ * last seen. The sequence orders the store as a FIFO so eviction drops the oldest-seen peers first.
+ */
+interface PersistedEnr {
+  enr: string;
+  seq: number;
+}
+
+function parsePersistedEnr(value: string): PersistedEnr | undefined {
+  try {
+    const parsed = JSON.parse(value);
+    if (typeof parsed?.enr === 'string' && typeof parsed?.seq === 'number') {
+      return parsed;
+    }
+  } catch {
+    // Unparseable entry; caller treats it as stale.
+  }
+  return undefined;
+}
+
+/**
+ * A bounded, transactional store of discovered peer ENRs used to re-seed discovery after a restart.
+ *
+ * Entries are keyed by nodeId (so re-seeing a peer dedups in place) and carry a monotonic sequence so
+ * the store behaves as a FIFO: when it exceeds its cap, the oldest-seen peers are evicted first. All
+ * writes run in a transaction so concurrent discovery events can't race the size check.
+ */
+export class PersistedEnrStore {
+  private readonly enrs: AztecAsyncMap<string, string>;
+  /** Monotonic sequence stamped on each entry; seeded from the store's max in {@link load}. */
+  private seq = 0;
+
+  constructor(
+    private readonly store: AztecAsyncKVStore,
+    private readonly maxEntries: number,
+    private readonly logger: Logger = createLogger('p2p:discv5:enr-store'),
+  ) {
+    this.enrs = store.openMap(PERSISTED_ENRS_MAP_NAME);
+  }
+
+  /** Adds or replaces a peer's ENR, stamping it as most-recently-seen and evicting the oldest if over cap. */
+  public async persist(enr: ENR): Promise<void> {
+    const nodeId = enr.nodeId;
+    const enrTxt = enr.encodeTxt();
+    try {
+      await this.store.transactionAsync(async () => {
+        const seq = ++this.seq;
+        // Reads inside a write transaction see committed state, not our own pending set, so gather the
+        // existing entries first and account for the one we're about to add when deciding what to evict.
+        const others: { nodeId: string; seq: number }[] = [];
+        for await (const [id, value] of this.enrs.entriesAsync()) {
+          if (id !== nodeId) {
+            others.push({ nodeId: id, seq: parsePersistedEnr(value)?.seq ?? 0 });
+          }
+        }
+        const overflow = others.length + 1 - this.maxEntries;
+        if (overflow > 0) {
+          others.sort((a, b) => a.seq - b.seq); // oldest-seen (lowest sequence) first
+          for (let i = 0; i < overflow; i++) {
+            await this.enrs.delete(others[i].nodeId);
+          }
+        }
+        await this.enrs.set(nodeId, JSON.stringify({ enr: enrTxt, seq }));
+      });
+    } catch (err) {
+      this.logger.warn(`Failed to persist discovered ENR ${nodeId}`, err);
+    }
+  }
+
+  /**
+   * Refreshes an already-persisted peer's stored ENR when a newer one (higher ENR sequence) is seen.
+   * A no-op for peers we don't already track — we never add new peers via this path, only update.
+   *
+   * This exists because discv5 updates an existing routing-table entry on an ENR sequence bump without
+   * emitting an `enrAdded` event, so a peer that changes address would otherwise keep its stale ENR
+   * persisted until evicted.
+   */
+  public async refresh(enr: ENR): Promise<void> {
+    const nodeId = enr.nodeId;
+    try {
+      await this.store.transactionAsync(async () => {
+        const existing = await this.enrs.getAsync(nodeId);
+        if (!existing) {
+          return;
+        }
+        const storedSeq = this.decodeStoredEnr(existing)?.seq;
+        if (storedSeq !== undefined && enr.seq <= storedSeq) {
+          return;
+        }
+        await this.enrs.set(nodeId, JSON.stringify({ enr: enr.encodeTxt(), seq: ++this.seq }));
+      });
+    } catch (err) {
+      this.logger.warn(`Failed to refresh persisted ENR ${nodeId}`, err);
+    }
+  }
+
+  /**
+   * Loads all persisted ENRs, decoding each and keeping those the `accept` predicate allows. Entries
+   * that fail to decode or are rejected are removed from the store. The FIFO sequence resumes from the
+   * highest persisted value so eviction order survives restarts.
+   */
+  public async load(accept: (enr: ENR) => boolean): Promise<ENR[]> {
+    const valid: ENR[] = [];
+    const stale: string[] = [];
+    let maxSeq = 0;
+    for await (const [nodeId, value] of this.enrs.entriesAsync()) {
+      const parsed = parsePersistedEnr(value);
+      let enr: ENR | undefined;
+      if (parsed) {
+        try {
+          enr = ENR.decodeTxt(parsed.enr);
+        } catch (err) {
+          this.logger.debug(`Dropping undecodable persisted ENR ${nodeId}`, err);
+        }
+      }
+      if (!parsed || !enr || !accept(enr)) {
+        stale.push(nodeId);
+        continue;
+      }
+      maxSeq = Math.max(maxSeq, parsed.seq);
+      valid.push(enr);
+    }
+    this.seq = maxSeq;
+    if (stale.length > 0) {
+      await this.store.transactionAsync(async () => {
+        for (const nodeId of stale) {
+          await this.enrs.delete(nodeId);
+        }
+      });
+    }
+    return valid;
+  }
+
+  private decodeStoredEnr(value: string): ENR | undefined {
+    const parsed = parsePersistedEnr(value);
+    if (!parsed) {
+      return undefined;
+    }
+    try {
+      return ENR.decodeTxt(parsed.enr);
+    } catch {
+      return undefined;
+    }
+  }
+}

--- a/yarn-project/p2p/src/services/discv5/persisted_enr_store.ts
+++ b/yarn-project/p2p/src/services/discv5/persisted_enr_store.ts
@@ -54,8 +54,6 @@ export class PersistedEnrStore {
     try {
       await this.store.transactionAsync(async () => {
         const seq = ++this.seq;
-        // Reads inside a write transaction see committed state, not our own pending set, so gather the
-        // existing entries first and account for the one we're about to add when deciding what to evict.
         const others: { nodeId: string; seq: number }[] = [];
         for await (const [id, value] of this.enrs.entriesAsync()) {
           if (id !== nodeId) {

--- a/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
+++ b/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
@@ -368,6 +368,7 @@ export class LibP2PService extends WithTracer implements P2PService {
       packageVersion,
       telemetry,
       createLogger(`${logger.module}:discv5_service`, logger.getBindings()),
+      peerStore,
     );
 
     // Seed libp2p's bootstrap discovery with private and trusted peers


### PR DESCRIPTION
## Problem

A node that restarts after its bootstrap nodes are gone cannot rejoin the network on its own, even though it has a list of peers persisted on disk.

discv5 builds its routing table only from **bootstrap** and **trusted** ENRs (`discV5_service.ts` `start()`), and keeps that table **in memory** — it is never persisted. The peer-manager dial queue is fed exclusively by discv5 discovery events, and libp2p auto-dial is disabled (`minConnections: 0`). So after a restart with no reachable bootstrap node, a node's DHT starts empty and the only way it reconnects is via **inbound** dials from peers that still hold its ENR. That is unreliable and fails entirely on a full-network restart.

This is the root cause of the flaky `e2e_p2p_rediscovery` failure (see A-1244): the test only passed because it restarted nodes one at a time, so still-running neighbours dialed the restarted node back. The last nodes to restart often ended up below quorum (`discv5KadPeers: 0`, stuck at 2/3 peers).

## Fix

Persist discovered peer ENRs and re-seed discovery from them on startup:

- **Persist** valid, non-bootnode peer ENRs to the p2p peer store (`onEnrAdded`), keyed by nodeId, bounded to `MAX_PERSISTED_PEER_ENRS` with simple eviction.
- **Re-seed** on `start()`, alongside the existing bootstrap/trusted-ENR seeding: load persisted ENRs and `discv5.addEnr(...)` each (dropping stale/incompatible ones). Re-adding an ENR flows through the existing `onDiscovered` → `DISCOVERED` → `PeerManager` dial path, so no new dial logic is required.

ENRs carry both UDP (discv5) and TCP (libp2p) addresses, so this restores both discovery and dialability without a bootstrap node. The persisted store is the same `peerStore` libp2p already uses; the discovery service just opens its own map on it.

## Test

`e2e_p2p_rediscovery` now exercises the real capability:

- Wait for a full mesh before teardown, so every node has persisted all its peers (replaces a blind `sleep`).
- Stop the bootstrap node and **all** validators, then restart them **all** — a full-network bounce — instead of the rolling stop-one/restart-one loop. With no live peers to dial the nodes back, the mesh can only rebuild by re-seeding from persisted ENRs.

Existing discv5 unit tests pass unchanged. (The pre-existing `should persist peers without bootnode` unit test remains skipped — it can't be made faithful without spawning fresh node processes; the e2e test is the integration coverage.)

Fixes A-1244.