### PR TITLE
fix(test): handle default inbox lag of 2, remove temporary inboxLag=1 pins (A-1250)

### DIFF
--- a/docs/examples/ts/aztecjs_connection/index.ts
+++ b/docs/examples/ts/aztecjs_connection/index.ts
@@ -153,6 +153,13 @@ const { result: balance } = await token.methods
 console.log(`Alice's token balance: ${balance}`);
 // docs:end:simulate_function
 
+// The bridged Fee Juice claim only becomes consumable once the network's inbox lag (2 checkpoints)
+// has elapsed since the L1->L2 message was inserted. The token deploy and mint above produced two
+// blocks; mine one more here so the claim is available when we pay with it below.
+await token.methods
+  .mint_to_public(aliceAddress, 1n)
+  .send({ from: aliceAddress });
+
 // docs:start:bridge_fee_juice_claim
 import { FeeJuicePaymentMethodWithClaim } from "@aztec/aztec.js/fee";
 

--- a/docs/examples/ts/docker-compose.yml
+++ b/docs/examples/ts/docker-compose.yml
@@ -22,10 +22,6 @@ services:
       ETHEREUM_HOSTS: http://fork:8545
       L1_CHAIN_ID: 31337
       FORCE_COLOR: ${FORCE_COLOR:-1}
-      # Pin the inbox lag to 1 for the sandbox. The network default is now 2, but the docs examples
-      # bridge fee juice and consume the L1->L2 message within a single checkpoint; with lag 2 the
-      # message isn't available yet, failing with "No L1 to L2 message found".
-      AZTEC_INBOX_LAG: 1
       ARCHIVER_POLLING_INTERVAL_MS: 500
       P2P_BLOCK_CHECK_INTERVAL_MS: 500
       SEQ_POLLING_INTERVAL_MS: 500

--- a/yarn-project/cli-wallet/test/flows/create_account_pay_native.sh
+++ b/yarn-project/cli-wallet/test/flows/create_account_pay_native.sh
@@ -11,8 +11,11 @@ aztec-wallet bridge-fee-juice 1000000000000000000000 main --mint --no-wait
 
 section "Use a pre-funded test account to send dummy txs to force block creations"
 
+# The bridged claim is only consumable inboxLag (2) checkpoints after the L1->L2 message is inserted,
+# so we force three blocks here (deploy + two increments) before claiming below.
 aztec-wallet import-test-accounts
 aztec-wallet deploy counter_contract@Counter --init initialize --args 0 accounts:test0 -f test0 -a counter
+aztec-wallet send increment -ca counter --args accounts:test0 -f test0
 aztec-wallet send increment -ca counter --args accounts:test0 -f test0
 
 section "Deploy main account claiming the fee juice, use it later"

--- a/yarn-project/cli-wallet/test/flows/shared/create_funded_account.sh
+++ b/yarn-project/cli-wallet/test/flows/shared/create_funded_account.sh
@@ -5,8 +5,11 @@ section "Creating a funded account (alias: $ALIAS)"
 aztec-wallet create-account -a $ALIAS --register-only
 aztec-wallet bridge-fee-juice 1000000000000000000000 $ALIAS --mint --no-wait
 
-# The following produces two blocks, allowing the claim to be used in the next block.
+# The bridged claim is only consumable inboxLag (2) checkpoints after the L1->L2 message is inserted.
+# deploy_token.sh produces two blocks; the extra set_minter below produces a third, so the claim is
+# available by the time we deploy the account with it.
 source $flows/shared/deploy_token.sh tmp-token-$ALIAS $ALIAS
+aztec-wallet send set_minter -ca tmp-token-$ALIAS --args accounts:test0 true -f test0
 
 # Deploying the account, paying the fee via bridging fee juice from L1 using the claim created above.
 aztec-wallet deploy-account $ALIAS --payment method=fee_juice,claim

--- a/yarn-project/cli-wallet/test/flows/shared/deploy_main_account_and_token.sh
+++ b/yarn-project/cli-wallet/test/flows/shared/deploy_main_account_and_token.sh
@@ -7,8 +7,11 @@ aztec-wallet create-account -a $ACCOUNT_ALIAS --register-only
 aztec-wallet bridge-fee-juice 1000000000000000000000 $ACCOUNT_ALIAS --mint --no-wait
 
 # Deploy token contract and set the main account as a minter.
-# The following produces two blocks, allowing the claim to be used in the next block.
+# The bridged claim is only consumable inboxLag (2) checkpoints after the L1->L2 message is inserted.
+# deploy_token.sh produces two blocks; the extra set_minter below produces a third, so the claim is
+# available by the time we deploy the account with it.
 source $flows/shared/deploy_token.sh $TOKEN_ALIAS $ACCOUNT_ALIAS
+aztec-wallet send set_minter -ca $TOKEN_ALIAS --args accounts:test0 true -f test0
 
 # Deploying the account, paying the fee via bridging fee juice from L1 using the claim created above.
 aztec-wallet deploy-account $ACCOUNT_ALIAS --payment method=fee_juice,claim

--- a/yarn-project/cli-wallet/test/flows/shared/deploy_sponsored_fpc_and_token.sh
+++ b/yarn-project/cli-wallet/test/flows/shared/deploy_sponsored_fpc_and_token.sh
@@ -16,8 +16,11 @@ claimAmount=$(retrieve claimAmount)
 claimSecret=$(retrieve claimSecret)
 messageLeafIndex=$(retrieve messageLeafIndex)
 
-# The following produces two blocks, allowing the claim to be used in the next block.
+# The bridged claim is only consumable inboxLag (2) checkpoints after the L1->L2 message is inserted.
+# deploy_token.sh produces two blocks; the extra set_minter below produces a third, so the claim is
+# available by the time we consume it.
 source $flows/shared/deploy_token.sh $TOKEN_ALIAS test1
+aztec-wallet send set_minter -ca $TOKEN_ALIAS --args accounts:test0 true -f test0
 
 # Claim the fee juice by calling the fee juice contract directly. Reference it via the registered
 # protocol-contract alias rather than a hardcoded address, which moves when protocol addresses are renumbered.

--- a/yarn-project/end-to-end/scripts/docker-compose.yml
+++ b/yarn-project/end-to-end/scripts/docker-compose.yml
@@ -27,10 +27,6 @@ services:
       ETHEREUM_HOSTS: http://fork:8545
       L1_CHAIN_ID: 31337
       FORCE_COLOR: ${FORCE_COLOR:-1}
-      # Pin the inbox lag to 1 for the sandbox. The network default is now 2, but the cli-wallet flows
-      # and guide examples bridge fee juice and consume the L1->L2 message within a single checkpoint;
-      # with lag 2 the message isn't available yet, failing with "No L1 to L2 message found".
-      AZTEC_INBOX_LAG: 1
       ARCHIVER_POLLING_INTERVAL_MS: 500
       P2P_BLOCK_CHECK_INTERVAL_MS: 500
       SEQ_POLLING_INTERVAL_MS: 500

--- a/yarn-project/end-to-end/src/e2e_l1_publisher/e2e_l1_publisher.test.ts
+++ b/yarn-project/end-to-end/src/e2e_l1_publisher/e2e_l1_publisher.test.ts
@@ -277,11 +277,25 @@ describe('L1Publisher integration', () => {
         }
         return Promise.resolve(undefined);
       },
-      getBlockData(query: BlockQuery) {
+      async getBlockData(query: BlockQuery) {
         if ('number' in query && Number(query.number) === 0) {
-          return Promise.resolve(genesisBlockData);
+          return genesisBlockData;
         }
-        return Promise.resolve(undefined);
+        // The block stream's reorg-detection walk asks the source for the hash of blocks the world state
+        // already holds (via header.hash()) before extending past them, so serve every block we've built
+        // -- not just genesis. Otherwise syncing past block 1 aborts with "Source has no data for a block
+        // at or below its proposed tip", which blocks proposing a third consecutive checkpoint.
+        const block = 'number' in query ? blocks.find(b => Number(b.number) === Number(query.number)) : undefined;
+        if (!block) {
+          return undefined;
+        }
+        return {
+          header: block.header,
+          archive: block.archive,
+          blockHash: await block.header.hash(),
+          checkpointNumber: CheckpointNumber.fromBlockNumber(block.number),
+          indexWithinCheckpoint: IndexWithinCheckpoint(0),
+        };
       },
       async getCheckpoints(query: CheckpointsQuery) {
         // Test uses 1-block-per-checkpoint, so we find block by checkpoint number

--- a/yarn-project/end-to-end/src/e2e_l1_publisher/e2e_l1_publisher.test.ts
+++ b/yarn-project/end-to-end/src/e2e_l1_publisher/e2e_l1_publisher.test.ts
@@ -107,7 +107,8 @@ const logger = createLogger('integration_l1_publisher');
 
 const config: AztecNodeConfig = { ...getConfigEnvVars(), checkIntervalMs: 100, stallTimeMs: 6_000 };
 
-const numberOfConsecutiveBlocks = 2;
+// Must exceed the inbox lag (network default 2) so at least one checkpoint consumes a real L1->L2 message.
+const numberOfConsecutiveBlocks = 3;
 
 jest.setTimeout(1000000);
 
@@ -492,11 +493,10 @@ describe('L1Publisher integration', () => {
   describe('block building', () => {
     beforeEach(async () => {
       // This suite proposes consecutive checkpoints and models the inbox lag by hand (a checkpoint
-      // consumes the L1->L2 messages sent during the previous checkpoint -- see the shift at the
-      // bottom of buildAndPublishBlock). That bookkeeping assumes a single-checkpoint lag, so pin
-      // inboxLag to 1 rather than inheriting the network default (now 2); with only two consecutive
-      // blocks a lag of 2 would mean no checkpoint ever consumes a real message.
-      await setup({ inboxLag: 1 });
+      // consumes the L1->L2 messages sent inboxLag checkpoints earlier -- see the shift register in
+      // buildAndPublishBlock). It inherits the network default lag and proposes enough checkpoints
+      // that a real message is actually consumed and validated on L1.
+      await setup();
     });
 
     const buildAndPublishBlock = async (numTxs: number, jsonFileNamePrefix: string) => {
@@ -510,8 +510,11 @@ describe('L1Publisher integration', () => {
         '0x1647b194c649f5dd01d7c832f89b0f496043c9150797923ea89e93d5ac619a93',
       );
 
-      let currentL1ToL2Messages: Fr[] = [];
-      let nextL1ToL2Messages: Fr[] = [];
+      // The deployed rollup consumes L1->L2 messages with a lag of `inboxLag` checkpoints: a message
+      // inserted while building checkpoint N is only consumable at checkpoint N + inboxLag. Model that
+      // with a shift register so a real message is genuinely consumed and validated on L1.
+      const inboxLag = getL1ContractsConfigEnvVars().inboxLag;
+      const messagesInFlight: Fr[][] = Array.from({ length: inboxLag }, () => []);
       const blobFieldsPerCheckpoint: Fr[][] = [];
       // The below batched blob is used for testing different epochs with 1..numberOfConsecutiveBlocks blocks on L1.
       // For real usage, always collect ALL epoch blobs first then call .batch().
@@ -522,9 +525,14 @@ describe('L1Publisher integration', () => {
         // and causes a chain prune
         const l1ToL2Content = range(Math.min(16, NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP), 128 * i + 1 + 0x400).map(fr);
 
+        const sentThisCheckpoint: Fr[] = [];
         for (let j = 0; j < l1ToL2Content.length; j++) {
-          nextL1ToL2Messages.push(await sendToL2(l1ToL2Content[j], recipientAddress));
+          sentThisCheckpoint.push(await sendToL2(l1ToL2Content[j], recipientAddress));
         }
+
+        // Consume the messages sent inboxLag checkpoints ago, then enqueue this checkpoint's messages.
+        const currentL1ToL2Messages = messagesInFlight.shift()!;
+        messagesInFlight.push(sentThisCheckpoint);
 
         // Ensure that each transaction has unique (non-intersecting nullifier values)
         const totalNullifiersPerBlock = 4 * MAX_NULLIFIERS_PER_TX;
@@ -648,11 +656,6 @@ describe('L1Publisher integration', () => {
           ],
         });
         expect(ethTx.input).toEqual(expectedData);
-
-        // There is a 1 block lag between before messages get consumed from the inbox
-        currentL1ToL2Messages = nextL1ToL2Messages;
-        // We wipe the messages from previous iteration
-        nextL1ToL2Messages = [];
 
         // Make sure that time have progressed to the next slot!
         await progressTimeBySlot();

--- a/yarn-project/end-to-end/src/guides/up_quick_start.sh
+++ b/yarn-project/end-to-end/src/guides/up_quick_start.sh
@@ -38,6 +38,11 @@ fi
 
 TRANSFER_AMOUNT=42
 
+# Alice's bridged fee-juice claim is only consumable inboxLag (2) checkpoints after the L1->L2 message
+# is inserted. The token deploy and mint above produced two blocks; force one more here (a public mint
+# from test0, which leaves the alice/bob private balances untouched) so the claim is available below.
+aztec-wallet send mint_to_public -ca last --args accounts:test0 1 -f test0
+
 aztec-wallet send transfer_in_private -ca last --args accounts:alice accounts:bob $TRANSFER_AMOUNT 0 -f alice --payment method=fee_juice,claim
 
 # Test end result


### PR DESCRIPTION
## Summary

The network default inbox lag (`AZTEC_INBOX_LAG`) was changed from 1 to 2 (#24127). The stop-gap #24162 pinned `inboxLag` back to 1 in the sandbox compose envs and the `e2e_l1_publisher` block-building suite to unblock CI. This PR removes those pins and updates the affected bridge-then-consume flows to work under the default `inboxLag = 2`.

With `inboxLag = N`, an L1→L2 message inserted while building checkpoint `K` is only consumable starting at checkpoint `K + N`, so every consumer must wait one more checkpoint than before.

## Changes

- Drop `AZTEC_INBOX_LAG: 1` from `yarn-project/end-to-end/scripts/docker-compose.yml` and `docs/examples/ts/docker-compose.yml`.
- cli-wallet flows (`create_funded_account`, `deploy_main_account_and_token`, `deploy_sponsored_fpc_and_token`, `create_account_pay_native`) and the `up_quick_start` guide now produce a third block before consuming the bridged fee-juice claim.
- The `aztecjs_connection` docs example mines one more block before paying with the claim.
- `e2e_l1_publisher` removes `setup({ inboxLag: 1 })`, models the lag with a shift register of depth `inboxLag` (derived from `getL1ContractsConfigEnvVars()`, so it tracks the deployed rollup), and proposes 3 consecutive checkpoints so a real L1→L2 message is consumed and validated on L1.

The deliberate AutomineSequencer `inboxLag: 1` in `fixtures.ts` is left unchanged (automine publishes one block per tx, so single-checkpoint lag is correct there).

## Notes

- Safe for the committed L1 Solidity fixtures: `RollupBase.sol` recomputes `inHash` from the populated inbox, so the sol tests don't depend on the TS shift, and `TestConstants.AZTEC_INBOX_LAG` is already 2.
- Verified locally: end-to-end package typechecks, prettier clean, all changed shell scripts pass `bash -n`. The compose/e2e suites themselves need the CI sandbox image; running via `ci-full`.

Closes A-1250.
