### PR TITLE
refactor(kv-store): use structured context in log messages

### DIFF
--- a/yarn-project/kv-store/src/indexeddb/store.ts
+++ b/yarn-project/kv-store/src/indexeddb/store.ts
@@ -78,7 +78,7 @@ export class AztecIndexedDBStore implements AztecAsyncKVStore {
    */
   static async open(log: Logger, name?: string, ephemeral: boolean = false): Promise<AztecIndexedDBStore> {
     name = name && !ephemeral ? name : globalThis.crypto.getRandomValues(new Uint8Array(16)).join('');
-    log.debug(`Opening IndexedDB ${ephemeral ? 'temp ' : ''}database with name ${name}`);
+    log.debug('Opening IndexedDB database', { ephemeral, name });
     const rootDB = await openDB<AztecIDBSchema>(name, 1, {
       upgrade(db) {
         const objectStore = db.createObjectStore('data', { keyPath: 'slot' });

--- a/yarn-project/kv-store/src/lmdb-v2/factory.ts
+++ b/yarn-project/kv-store/src/lmdb-v2/factory.ts
@@ -46,9 +46,7 @@ export async function createStore(
       schemaVersionMismatchPolicy: options.schemaVersionMismatchPolicy,
     });
 
-    log.info(
-      `Creating ${name} data store at directory ${subDir} with map size ${config.dataStoreMapSizeKb} KB (LMDB v2)`,
-    );
+    log.info('Creating LMDB v2 data store', { name, dataDir: subDir, dbMapSizeKb: config.dataStoreMapSizeKb });
     [store] = await versionManager.open();
   } else {
     store = await openTmpStore(name, true, config.dataStoreMapSizeKb, MAX_READERS, bindings);
@@ -71,19 +69,19 @@ export async function openTmpStore(
 ): Promise<AztecLMDBStoreV2> {
   const log = createLogger('kv-store:lmdb-v2:' + name, bindings);
   const dataDir = await mkdtemp(join(tmpdir(), name + '-'));
-  log.debug(`Created temporary data store at: ${dataDir} with size: ${dbMapSizeKb} KB (LMDB v2)`);
+  log.debug('Created temporary LMDB v2 data store', { dataDir, dbMapSizeKb });
 
   // pass a cleanup callback because process.on('beforeExit', cleanup) does not work under Jest
   const cleanup = async () => {
     if (cleanupTmpDir) {
       try {
         await rm(dataDir, { recursive: true, force: true, maxRetries: 3 });
-        log.debug(`Deleted temporary data store: ${dataDir}`);
+        log.debug('Deleted temporary LMDB v2 data store', { dataDir });
       } catch (err) {
-        log.warn(`Failed to delete temporary data directory (LMDB v2) ${dataDir}: ${err}`);
+        log.warn('Failed to delete temporary LMDB v2 data directory', { dataDir, err });
       }
     } else {
-      log.debug(`Leaving temporary data store: ${dataDir}`);
+      log.debug('Leaving temporary LMDB v2 data store', { dataDir });
     }
   };
 
@@ -104,14 +102,14 @@ export async function openEphemeralStore(
 ): Promise<AztecLMDBStoreV2> {
   const log = createLogger('kv-store:lmdb-v2:' + name, bindings);
   const dataDir = await mkdtemp(join(tmpdir(), name + '-'));
-  log.debug(`Created ephemeral data store at: ${dataDir} with size: ${dbMapSizeKb} KB (LMDB v2)`);
+  log.debug('Created ephemeral LMDB v2 data store', { dataDir, dbMapSizeKb });
 
   const cleanup = async () => {
     try {
       await rm(dataDir, { recursive: true, force: true, maxRetries: 3 });
-      log.debug(`Deleted ephemeral data store: ${dataDir}`);
+      log.debug('Deleted ephemeral LMDB v2 data store', { dataDir });
     } catch (err) {
-      log.warn(`Failed to delete ephemeral data directory (LMDB v2) ${dataDir}: ${err}`);
+      log.warn('Failed to delete ephemeral LMDB v2 data directory', { dataDir, err });
     }
   };
 
@@ -125,7 +123,7 @@ export async function openStoreAt(
   bindings?: LoggerBindings,
 ): Promise<AztecLMDBStoreV2> {
   const log = createLogger('kv-store:lmdb-v2', bindings);
-  log.debug(`Opening data store at: ${dataDir} with size: ${dbMapSizeKb} KB (LMDB v2)`);
+  log.debug('Opening LMDB v2 data store', { dataDir, dbMapSizeKb });
   return await AztecLMDBStoreV2.new(dataDir, dbMapSizeKb, maxReaders, undefined, bindings);
 }
 
@@ -145,14 +143,14 @@ export async function cloneEphemeralStoreFrom(
   const log = createLogger('kv-store:lmdb-v2:' + name, bindings);
   const dataDir = await mkdtemp(join(tmpdir(), name + '-'));
   await copyFile(srcDataMdbPath, join(dataDir, 'data.mdb'));
-  log.debug(`Cloned ephemeral data store at: ${dataDir} from ${srcDataMdbPath} (LMDB v2)`);
+  log.debug('Cloned ephemeral LMDB v2 data store', { dataDir, srcDataMdbPath });
 
   const cleanup = async () => {
     try {
       await rm(dataDir, { recursive: true, force: true, maxRetries: 3 });
-      log.debug(`Deleted ephemeral data store: ${dataDir}`);
+      log.debug('Deleted ephemeral LMDB v2 data store', { dataDir });
     } catch (err) {
-      log.warn(`Failed to delete ephemeral data directory (LMDB v2) ${dataDir}: ${err}`);
+      log.warn('Failed to delete ephemeral LMDB v2 data directory', { dataDir, err });
     }
   };
 
@@ -168,7 +166,7 @@ export async function openVersionedStoreAt(
   bindings?: LoggerBindings,
 ): Promise<AztecLMDBStoreV2> {
   const log = createLogger('kv-store:lmdb-v2', bindings);
-  log.debug(`Opening data store at: ${dataDirectory} with size: ${dbMapSizeKb} KB (LMDB v2)`);
+  log.debug('Opening versioned LMDB v2 data store', { dataDirectory, dbMapSizeKb });
   const [store] = await new DatabaseVersionManager({
     schemaVersion,
     rollupAddress,

--- a/yarn-project/kv-store/src/lmdb-v2/store.ts
+++ b/yarn-project/kv-store/src/lmdb-v2/store.ts
@@ -45,7 +45,7 @@ export class AztecLMDBStoreV2 implements AztecAsyncKVStore, LMDBMessageChannel {
     private cleanup?: () => Promise<void>,
     ephemeral: boolean = false,
   ) {
-    this.log.info(`Starting data store with maxReaders ${maxReaders}`);
+    this.log.info('Starting LMDB v2 data store', { maxReaders });
     this.channel = new MsgpackChannel(new NativeLMDBStore(dataDir, mapSize, maxReaders, ephemeral));
     // leave one reader to always be available for regular, atomic, reads
     this.availableCursors = new Semaphore(maxReaders - 1);
@@ -151,7 +151,7 @@ export class AztecLMDBStoreV2 implements AztecAsyncKVStore, LMDBMessageChannel {
         await tx.commit();
         return res;
       } catch (err) {
-        this.log.error(`Failed to commit transaction`, err);
+        this.log.error('Failed to commit transaction', err);
         throw err;
       } finally {
         tx.close();
@@ -166,7 +166,7 @@ export class AztecLMDBStoreV2 implements AztecAsyncKVStore, LMDBMessageChannel {
   async delete(): Promise<void> {
     await this.close();
     await rm(this.dataDir, { recursive: true, force: true, maxRetries: 3 });
-    this.log.verbose(`Deleted database files at ${this.dataDir}`);
+    this.log.verbose('Deleted LMDB v2 database files', { dataDir: this.dataDir });
     await this.cleanup?.();
   }
 

--- a/yarn-project/kv-store/src/lmdb/store.ts
+++ b/yarn-project/kv-store/src/lmdb/store.ts
@@ -74,7 +74,7 @@ export class AztecLmdbStore implements AztecKVStore, AztecAsyncKVStore {
     const dbPath = path ?? join(tmpdir(), randomBytes(8).toString('hex'));
     mkdirSync(dbPath, { recursive: true });
     const mapSize = 1024 * mapSizeKb;
-    log.debug(`Opening LMDB database at ${path || 'temporary location'} with map size ${mapSize}`);
+    log.debug('Opening LMDB database', { path: path ?? 'temporary location', mapSize });
     const rootDb = open({ path: dbPath, noSync: ephemeral, mapSize });
     return new AztecLmdbStore(rootDb, ephemeral, dbPath);
   }
@@ -183,7 +183,7 @@ export class AztecLmdbStore implements AztecKVStore, AztecAsyncKVStore {
     await this.close();
     if (this.path) {
       await fs.rm(this.path, { recursive: true, force: true, maxRetries: 3 });
-      this.#log.verbose(`Deleted database files at ${this.path}`);
+      this.#log.verbose('Deleted LMDB database files', { path: this.path });
     }
   }
 

--- a/yarn-project/kv-store/src/sqlite-opfs/store.ts
+++ b/yarn-project/kv-store/src/sqlite-opfs/store.ts
@@ -50,14 +50,14 @@ export class AztecSQLiteOPFSStore implements AztecAsyncKVStore {
       const { id } = ev.data;
       const handler = this.#pending.get(id);
       if (!handler) {
-        this.#log.warn(`SQLite worker: no pending handler for id ${id}`);
+        this.#log.warn('SQLite worker has no pending handler', { id });
         return;
       }
       this.#pending.delete(id);
       handler.resolve(ev.data);
     };
     this.#worker.onerror = ev => {
-      this.#log.error(`SQLite worker crashed: ${ev.message}`);
+      this.#log.error('SQLite worker crashed', undefined, { message: ev.message });
       this.#rejectPending(`SQLite worker crashed: ${ev.message}`);
     };
     this.#txQueue.start();
@@ -99,9 +99,7 @@ export class AztecSQLiteOPFSStore implements AztecAsyncKVStore {
       );
     }
     const dbName = name && !ephemeral ? name : `tmp-${globalThis.crypto.getRandomValues(new Uint8Array(8)).join('')}`;
-    log.debug(
-      `Opening SQLite-OPFS ${ephemeral ? 'ephemeral ' : ''}${encryptionKey ? 'encrypted ' : ''}database ${dbName}`,
-    );
+    log.debug('Opening SQLite-OPFS database', { ephemeral, encrypted: encryptionKey !== undefined, dbName });
     const worker = new Worker(new URL('./worker.js', import.meta.url), { type: 'module' });
     const store = new AztecSQLiteOPFSStore(worker, dbName, log, ephemeral);
     // Transfer (not clone) the key buffer to the worker so we don't leave a
@@ -161,7 +159,7 @@ export class AztecSQLiteOPFSStore implements AztecAsyncKVStore {
         return result;
       } catch (err) {
         await this.#sendRequest({ type: 'rollback', id: this.#allocId() }).catch(rollbackErr =>
-          this.#log.warn(`SQLite ROLLBACK failed: ${rollbackErr instanceof Error ? rollbackErr.message : rollbackErr}`),
+          this.#log.warn('SQLite ROLLBACK failed', { err: rollbackErr }),
         );
         throw err;
       } finally {
@@ -181,7 +179,7 @@ export class AztecSQLiteOPFSStore implements AztecAsyncKVStore {
     this.#closed = true;
     await this.#txQueue.end();
     await this.#sendRequest({ type: 'deleteDb', id: this.#allocId(), dbName: this.#name }).catch(err =>
-      this.#log.warn(`SQLite deleteDb failed: ${err instanceof Error ? err.message : err}`),
+      this.#log.warn('SQLite deleteDb failed', { err }),
     );
     this.#worker.terminate();
     this.#rejectPending('SQLite store deleted');


### PR DESCRIPTION
## Summary

Partially addresses #13035 by migrating `@aztec/kv-store` log messages away from string interpolation and into structured log context.

This keeps the change scoped to one package so it is easier to review, while following the logging guidance in `yarn-project/CLAUDE.md`.

## Changes

- Move dynamic values such as database names, data directories, map sizes, reader counts, and errors into log context objects.
- Keep log message strings static for easier filtering.
- Limit the migration to `kv-store` as an incremental step toward #13035.

## Testing

- `git diff --check`
- Confirmed no template-string log calls remain under `yarn-project/kv-store/src`.

Unable to run `yarn format kv-store`, build, or tests in this checkout because dependencies are not installed and `yarn install --immutable` fails due to a missing `../noir/packages/acvm_js` portal manifest.