### PR TITLE
fix(ethereum): skip unfunded publishers in selection

### DIFF
--- a/yarn-project/ethereum/src/publisher_manager.test.ts
+++ b/yarn-project/ethereum/src/publisher_manager.test.ts
@@ -126,6 +126,30 @@ describe('PublisherManager', () => {
       expect(result).toBe(mockPublishers[2]); // undefined (0n) is lowest
     });
 
+    it('should not select a publisher with zero balance', async () => {
+      // Publisher 1 is IDLE (best state) but unfunded; a funded publisher should win instead.
+      mockPublishers[0].state = TxUtilsState.MINED;
+      mockPublishers[0].balance = 1000n;
+
+      mockPublishers[1].state = TxUtilsState.IDLE;
+      mockPublishers[1].balance = 0n;
+
+      mockPublishers[2].state = TxUtilsState.MINED;
+      mockPublishers[2].balance = 1000n;
+
+      const result = await publisherManager.getAvailablePublisher();
+
+      expect(result).not.toBe(mockPublishers[1]);
+    });
+
+    it('falls back to zero-balance publishers when none are funded', async () => {
+      mockPublishers.forEach(p => (p.balance = 0n));
+
+      const result = await publisherManager.getAvailablePublisher();
+
+      expect(result).toBeDefined();
+    });
+
     it('should apply filter correctly', async () => {
       mockPublishers[0].state = TxUtilsState.IDLE;
       mockPublishers[1].state = TxUtilsState.MINED;

--- a/yarn-project/ethereum/src/publisher_manager.ts
+++ b/yarn-project/ethereum/src/publisher_manager.ts
@@ -133,8 +133,17 @@ export class PublisherManager<UtilsType extends L1TxUtils = L1TxUtils> {
       }),
     );
 
+    // Discount unfunded publishers: a publisher with no ETH cannot send a tx, so it must never win
+    // selection regardless of how favourable its state or last-used time is. Fall back to the full
+    // set only if every candidate is unfunded, so behaviour is no worse than before.
+    let fundedPublishers = publishersWithBalance.filter(p => p.balance > 0n);
+    if (fundedPublishers.length === 0) {
+      this.log.warn(`All candidate publishers have zero balance; selecting from unfunded publishers.`);
+      fundedPublishers = publishersWithBalance;
+    }
+
     // Sort based on state, then balance, then time since last use
-    const sortedPublishers = publishersWithBalance.sort((a, b) => {
+    const sortedPublishers = fundedPublishers.sort((a, b) => {
       const stateComparison = sortOrder.indexOf(a.publisher.state) - sortOrder.indexOf(b.publisher.state);
       if (stateComparison !== 0) {
         return stateComparison;


### PR DESCRIPTION
## Problem

The `PublisherManager` selects a publisher by sorting candidates on state → balance → least-recently-used. Balance is only a tiebreaker *after* state, so a publisher with **zero ETH** could still be chosen if its state (e.g. `IDLE`) or last-used time ranked it higher even though it cannot send a transaction.

This bit a prover configured with two publisher accounts (A and B) where only A was funded. A submitted the first epoch's proof; for the second epoch the manager picked B (better state / LRU), which had no funds and could not publish.

## Fix

In `getAvailablePublisher`, filter out zero-balance publishers after fetching balances and before sorting. The core prioritization (state → balance → LRU) is unchanged — unfunded publishers simply never enter the sort. If *every* candidate is unfunded, it falls back to the full set and logs a warning, so behavior is no worse than before in the degenerate case.

## Testing

Added two unit tests to `publisher_manager.test.ts`:
- an unfunded publisher in the best (`IDLE`) state is not selected over funded candidates
- selection still returns a publisher when all candidates are unfunded (fallback)

Full suite (22 tests) passes.