### PR TITLE
test(l1): assert verifier/distributor/booster/slasher references in V5 validate()

### DIFF
--- a/l1-contracts/script/deploy/DeployRollupForUpgradeV5.s.sol
+++ b/l1-contracts/script/deploy/DeployRollupForUpgradeV5.s.sol
@@ -28,7 +28,7 @@ import {EthPerFeeAssetE12, EthValue} from "@aztec/core/libraries/rollup/FeeLib.s
 import {Bps, RewardConfig} from "@aztec/core/libraries/rollup/RewardLib.sol";
 import {Inbox} from "@aztec/core/messagebridge/Inbox.sol";
 import {Outbox} from "@aztec/core/messagebridge/Outbox.sol";
-import {IBooster, RewardBoostConfig} from "@aztec/core/reward-boost/RewardBooster.sol";
+import {IBooster, RewardBooster, RewardBoostConfig} from "@aztec/core/reward-boost/RewardBooster.sol";
 import {Slasher} from "@aztec/core/slashing/Slasher.sol";
 import {SlashingProposer} from "@aztec/core/slashing/SlashingProposer.sol";
 
@@ -487,6 +487,13 @@ contract DeployRollupForUpgradeV5 is Script, StdAssertions {
     assertEq(address(_p.ASSET()), address(IRollup(address(newRollup)).getFeeAsset()), "asset is not the fee asset");
     assertGt(bytes(_p.getURI()).length, 0, "payload uri empty");
 
+    // The v5 rollup binds its distributor immutably, so the distributor's own immutables must
+    // match the chain it serves: a wrong ASSET strands the drained pool (claim transfers ASSET,
+    // not whatever was deposited), a wrong REGISTRY breaks canonical resolution.
+    RewardDistributor newRd = RewardDistributor(address(_p.NEW_REWARD_DISTRIBUTOR()));
+    assertEq(address(newRd.ASSET()), expected.feeAsset, "new distributor asset mismatch");
+    assertEq(address(newRd.REGISTRY()), expected.registry, "new distributor registry mismatch");
+
     assertNotEq(address(_p.ESCAPE_HATCH()), address(0), "escape hatch missing");
     assertEq(_p.ESCAPE_HATCH().getRollup(), address(newRollup), "escape hatch rollup mismatch");
     assertEq(address(newRollup.getEscapeHatch()), address(0), "new rollup hatch slot not empty");
@@ -592,6 +599,16 @@ contract DeployRollupForUpgradeV5 is Script, StdAssertions {
       address(rollupCore.getRewardDistributor()), address(_p.NEW_REWARD_DISTRIBUTOR()), "rollup distributor mismatch"
     );
 
+    // The verifier is the one immutable that must never be a MockVerifier in production. Compare
+    // the deployed code's hash against the mock's compile-time runtime code so a mock is caught on
+    // both the run() path and the re-runnable validate(address) path (where _rollupOutput is unset).
+    IVerifier verifier = rollupCore.getEpochProofVerifier();
+    assertNotEq(address(verifier), address(0), "verifier missing");
+    assertTrue(address(verifier).codehash != keccak256(type(MockVerifier).runtimeCode), "verifier is a MockVerifier");
+    if (address(_rollupOutput.verifier) != address(0)) {
+      assertEq(address(verifier), address(_rollupOutput.verifier), "verifier mismatch");
+    }
+
     assertEq(rollup.getSlotDuration(), ec.slotDuration, "slot duration mismatch");
     assertEq(rollup.getEpochDuration(), ec.epochDuration, "epoch duration mismatch");
     assertEq(rollup.getTargetCommitteeSize(), ec.targetCommitteeSize, "committee size mismatch");
@@ -615,6 +632,7 @@ contract DeployRollupForUpgradeV5 is Script, StdAssertions {
     assertEq(Bps.unwrap(rewardConfig.sequencerBps), ec.sequencerBps, "sequencer bps mismatch");
     assertEq(rewardConfig.checkpointReward, ec.checkpointReward, "checkpoint reward mismatch");
     assertNotEq(address(rewardConfig.booster), address(0), "booster missing");
+    assertEq(address(RewardBooster(address(rewardConfig.booster)).ROLLUP()), address(rollup), "booster rollup mismatch");
     RewardBoostConfig memory boostConfig = IBooster(address(rewardConfig.booster)).getConfig();
     assertEq(boostConfig.increment, ec.rewardBoostConfig.increment, "boost increment mismatch");
     assertEq(boostConfig.maxScore, ec.rewardBoostConfig.maxScore, "boost max score mismatch");
@@ -675,6 +693,14 @@ contract DeployRollupForUpgradeV5 is Script, StdAssertions {
     assertEq(proposer.SLASH_AMOUNT_MEDIUM(), ec.slashAmountMedium, "proposer slash medium mismatch");
     assertEq(proposer.SLASH_AMOUNT_LARGE(), ec.slashAmountLarge, "proposer slash large mismatch");
     assertEq(proposer.COMMITTEE_SIZE(), ec.targetCommitteeSize, "proposer committee size mismatch");
+    assertNotEq(proposer.SLASH_PAYLOAD_IMPLEMENTATION(), address(0), "slash payload implementation missing");
+
+    // A freshly deployed rollup must carry no slasher-migration state: a non-zero legacy or
+    // pending slasher would mean the deploy inherited stale state and could slash unexpectedly.
+    (address legacySlasher,) = IStaking(address(_p.NEW_ROLLUP())).getLegacySlasher();
+    assertEq(legacySlasher, address(0), "unexpected legacy slasher on fresh rollup");
+    (address pendingSlasher,) = IStaking(address(_p.NEW_ROLLUP())).getPendingSlasher();
+    assertEq(pendingSlasher, address(0), "unexpected pending slasher on fresh rollup");
     console.log(unicode"[assert] slasher stack ✓");
   }
 


### PR DESCRIPTION
## Motivation

Stacks on top of #23752. A review of that PR found that `DeployRollupForUpgradeV5.validate()` asserts essentially every **config scalar** of the deployed v5 stack (durations, thresholds, slashing params, reward/boost config, staking-queue config, genesis roots) but leaves several **references to other contracts** and a couple of immutables unchecked. Those gaps are exactly the kind a config-value sweep misses, and one of them is high-severity: nothing confirmed the rollup's epoch-proof verifier, so a `MockVerifier` could be wired in and `validate()` would still pass green.

## Approach

Add the missing assertions to the existing `validate()` sub-functions, where the relevant objects are already in hand. No new validation phase.

- **Verifier (the important one):** in `_validateRollupGetterConfig`, assert `getEpochProofVerifier()` is non-zero and that its `codehash` differs from `keccak256(type(MockVerifier).runtimeCode)`. Comparing against the mock's compile-time runtime code catches a mock on **both** the `run()` path and the re-runnable `validate(address)` path (where `_rollupOutput` is unset), without deploying anything or hardcoding a size threshold. On the `run()` path it additionally asserts equality with the just-deployed verifier.
- **New `RewardDistributor`:** assert its own `ASSET()`/`REGISTRY()` against the per-chain table (a wrong asset would strand the drained pool, since `claim` transfers `ASSET`, not whatever was deposited).
- **`RewardBooster`:** assert its `ROLLUP()` back-reference points at the new rollup.
- **Slasher stack:** assert `SlashingProposer.SLASH_PAYLOAD_IMPLEMENTATION()` is non-zero, and that `getLegacySlasher()`/`getPendingSlasher()` are empty on the freshly deployed rollup (no inherited slasher-migration state).

Deliberately left out: `getBurnAddress`, `getManaLimit`, `getSlasherExecutionDelay`, `getProvingCostPerManaInFeeAsset`, `getGenesisTime`. These are `pure` compile-time constants or values derived from inputs `validate()` already asserts, so checking them would pin the implementation without catching any real misconfiguration.

## Changes

- **l1-contracts (script)**: extend `DeployRollupForUpgradeV5.validate()` with verifier, new-distributor, booster, and slasher reference/immutable assertions; import `RewardBooster`.

These assertions run on the deploy `run()` path and the re-runnable `validate(address)` path; they are not exercised by the stub-based unit/fork tests (whose stubs don't implement these getters), matching where the existing rollup-config assertions live.