### PR TITLE
fix(cli): transpile pre-existing artifacts on aztec compile

### DIFF
--- a/yarn-project/aztec/src/cli/cmds/compile.test.ts
+++ b/yarn-project/aztec/src/cli/cmds/compile.test.ts
@@ -70,6 +70,15 @@ function runCompile() {
   }
 }
 
+function runNargoCompile() {
+  const nargo = process.env.NARGO ?? 'nargo';
+  try {
+    execFileSync(nargo, ['compile'], { cwd: WORKSPACE, stdio: 'pipe' });
+  } catch (e: any) {
+    throw new Error(`nargo compile failed:\n${e.stderr?.toString() ?? e.message}`);
+  }
+}
+
 function runCodegen() {
   try {
     execFileSync('node', [CLI, 'codegen', 'target', '-o', 'codegen-output', '-f'], {
@@ -80,6 +89,30 @@ function runCodegen() {
     throw new Error(`codegen failed:\n${e.stderr?.toString() ?? e.message}`);
   }
 }
+
+// Regression test for https://github.com/AztecProtocol/aztec-packages/issues/24075: a bare `nargo compile` leaves
+// untranspiled artifacts in target/. `aztec compile` must still postprocess them (transpile + generate VKs).
+describe('aztec compile postprocesses pre-existing untranspiled artifacts', () => {
+  const CONTRACT_ARTIFACT = join(TARGET, 'simple_contract-SimpleContract.json');
+
+  beforeAll(() => {
+    cleanupArtifacts();
+    runNargoCompile();
+  }, 120_000);
+
+  afterAll(() => {
+    cleanupArtifacts();
+  });
+
+  it('transpiles artifacts left untranspiled by a bare nargo compile', () => {
+    const beforeAztecCompile = JSON.parse(readFileSync(CONTRACT_ARTIFACT, 'utf-8'));
+    expect(beforeAztecCompile.transpiled).toBeFalsy();
+
+    runCompile();
+    const afterAztecCompile = JSON.parse(readFileSync(CONTRACT_ARTIFACT, 'utf-8'));
+    expect(afterAztecCompile.transpiled).toBe(true);
+  }, 120_000);
+});
 
 // Validates that aztec compile warns when contract crates contain tests. We want tests to be in a separate `lib` crate.
 describe('aztec compile warns about tests in contract crates', () => {

--- a/yarn-project/aztec/src/cli/cmds/compile.ts
+++ b/yarn-project/aztec/src/cli/cmds/compile.ts
@@ -12,8 +12,8 @@ import { needsRecompile } from './utils/needs_recompile.js';
 import { run } from './utils/spawn.js';
 import { warnIfAztecVersionMismatch } from './utils/warn_if_aztec_version_mismatch.js';
 
-/** Returns paths to contract artifacts in the target directory. */
-async function collectContractArtifacts(): Promise<string[]> {
+/** Returns contract artifacts in the target directory along with whether each has already been postprocessed. */
+async function collectContractArtifacts(): Promise<ContractArtifactInfo[]> {
   let files;
   try {
     files = await readArtifactFiles('target');
@@ -23,7 +23,9 @@ async function collectContractArtifacts(): Promise<string[]> {
     }
     throw err;
   }
-  return files.filter(f => Array.isArray(f.content.functions)).map(f => f.filePath);
+  return files
+    .filter(f => Array.isArray(f.content.functions))
+    .map(f => ({ filePath: f.filePath, transpiled: f.content.transpiled === true }));
 }
 
 /** Stamps the Aztec stack version into the contract artifacts. */
@@ -141,30 +143,34 @@ async function checkNoTestsInContracts(nargo: string, log: LogFn): Promise<void>
 async function compileAztecContract(nargoArgs: string[], log: LogFn): Promise<void> {
   await warnIfAztecVersionMismatch(log);
 
-  if (!(await needsRecompile())) {
-    log('No source changes detected, skipping compilation.');
-    return;
-  }
-
   const nargo = process.env.NARGO ?? 'nargo';
   const bb = process.env.BB ?? findBbBinary() ?? 'bb';
 
-  await run(nargo, ['compile', ...nargoArgs]);
+  const shouldRecompile = await needsRecompile();
+  if (shouldRecompile) {
+    await run(nargo, ['compile', ...nargoArgs]);
 
-  // Ensure contract crates contain no tests (tests belong in the test crate).
-  await checkNoTestsInContracts(nargo, log);
-
-  const artifacts = await collectContractArtifacts();
-
-  if (artifacts.length > 0) {
-    log('Postprocessing contracts...');
-    const bbArgs = artifacts.flatMap(a => ['-i', a]);
-    await run(bb, ['aztec_process', ...bbArgs]);
-
-    await stampAztecVersion(artifacts);
+    // Ensure contract crates contain no tests (tests belong in the test crate).
+    await checkNoTestsInContracts(nargo, log);
   }
 
-  log('Compilation complete!');
+  // Postprocess any untranspiled artifacts: those just produced by nargo above, and any left behind by a bare
+  // `nargo compile` run outside `aztec compile`.
+  const unprocessed = (await collectContractArtifacts()).filter(a => !a.transpiled).map(a => a.filePath);
+
+  if (unprocessed.length > 0) {
+    log('Postprocessing contracts...');
+    const bbArgs = unprocessed.flatMap(a => ['-i', a]);
+    await run(bb, ['aztec_process', ...bbArgs]);
+
+    await stampAztecVersion(unprocessed);
+  }
+
+  if (shouldRecompile || unprocessed.length > 0) {
+    log('Compilation complete!');
+  } else {
+    log('No source changes detected, skipping compilation.');
+  }
 }
 
 export function injectCompileCommand(program: Command, log: LogFn): Command {
@@ -189,4 +195,11 @@ export function injectCompileCommand(program: Command, log: LogFn): Command {
     .action((nargoArgs: string[]) => compileAztecContract(nargoArgs, log));
 
   return program;
+}
+
+interface ContractArtifactInfo {
+  /** Path to the artifact JSON in the target directory. */
+  filePath: string;
+  /** Whether the artifact has already been transpiled and had its verification keys generated. */
+  transpiled: boolean;
 }

--- a/yarn-project/aztec/src/cli/cmds/utils/artifacts.ts
+++ b/yarn-project/aztec/src/cli/cmds/utils/artifacts.ts
@@ -6,6 +6,11 @@ export interface CompiledArtifact {
   file_map: unknown;
   functions: ContractFunction[];
   bytecode?: string;
+  /**
+   * Set to true by the AVM transpiler (invoked via `bb aztec_process`) once the contract has been transpiled and its
+   * verification keys generated. Absent on raw `nargo compile` output, hence optional.
+   */
+  transpiled?: boolean;
 }
 
 export interface ContractFunction {


### PR DESCRIPTION
## Summary

`aztec compile` compared only source mtimes against `target/`, so when artifacts already existed from a bare `nargo compile` it skipped postprocessing — leaving them un-transpiled and without verification keys, which the SDK rejected unless you deleted `target/` first.

Postprocessing now runs for any contract artifact not yet marked `transpiled`, independent of the `nargo compile` cache check. Already-transpiled artifacts are skipped, so caching still holds.

Fixes F-745
Fixes #24075