### PR TITLE
feat(prover-node)!: wire prover JSON-RPC API to the admin endpoint

### DIFF
--- a/docs/docs-developers/docs/resources/migration_notes.md
+++ b/docs/docs-developers/docs/resources/migration_notes.md
@@ -9,6 +9,19 @@ Aztec is in active development. Each version may introduce breaking changes that
 
 ## TBD
 
+### [Prover Node JSON-RPC] Prover API moved to the admin endpoint; `getL2Tips`/`getWorldStateSyncStatus` removed
+
+The prover node's JSON-RPC methods (`prover_*`) have moved off the public node RPC server and onto the admin RPC server. They now require the admin API key and are served on the admin port (8880) instead of the public port (8080).
+
+In addition, `prover_getL2Tips` and `prover_getWorldStateSyncStatus` have been removed from the prover API. They duplicated data already served by the node: use `aztec_getChainTips` (same shape as the old `getL2Tips`) and `aztec_getWorldStateSyncStatus` instead.
+
+If you call the prover RPC directly (e.g. via `curl`), point at the admin endpoint with the API key and use the remaining methods:
+
+- `prover_startProof` — schedule proving for an epoch
+- `prover_getJobs` — list proving jobs
+
+A client factory `createProverNodeAdminClient(url, versions?, fetch?, apiKey?)` is now exported from `@aztec/stdlib/interfaces/server`, and the CLI exposes `aztec prover start-proof --epoch <n> --admin-url <url> --api-key <key>` and `aztec prover get-jobs` (the API key defaults to `AZTEC_ADMIN_API_KEY`).
+
 ### [Aztec.nr] `ContractInstance.contract_class_id` renamed to `original_contract_class_id`
 
 The `contract_class_id` field of the `ContractInstance` struct (returned by `get_contract_instance`) has been renamed to `original_contract_class_id`. The struct is the contract's *address preimage*, so this field is the class id the contract was deployed with: for contracts whose class was later updated via the `ContractInstanceRegistry`, it is NOT the class currently executing. The rename makes that explicit.

--- a/yarn-project/aztec/src/bin/index.ts
+++ b/yarn-project/aztec/src/bin/index.ts
@@ -18,6 +18,7 @@ import { Command } from 'commander';
 import { injectCompileCommand } from '../cli/cmds/compile.js';
 import { injectMigrateCommand } from '../cli/cmds/migrate_ha_db.js';
 import { injectProfileCommand } from '../cli/cmds/profile.js';
+import { injectProverCommand } from '../cli/cmds/prover.js';
 import { injectAztecCommands } from '../cli/index.js';
 
 const NETWORK_FLAG = 'network';
@@ -61,6 +62,7 @@ async function main() {
   program = injectCompileCommand(program, userLog);
   program = injectProfileCommand(program, userLog);
   program = injectMigrateCommand(program, userLog);
+  program = injectProverCommand(program, userLog);
 
   await program.parseAsync(process.argv);
 }

--- a/yarn-project/aztec/src/cli/cmds/prover.ts
+++ b/yarn-project/aztec/src/cli/cmds/prover.ts
@@ -1,0 +1,42 @@
+import { jsonStringify } from '@aztec/foundation/json-rpc';
+import type { LogFn } from '@aztec/foundation/log';
+import { createProverNodeAdminClient } from '@aztec/stdlib/interfaces/server';
+
+import { type Command, InvalidArgumentError } from 'commander';
+
+function parseEpoch(value: string): number {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    throw new InvalidArgumentError('Epoch must be a non-negative integer.');
+  }
+  return parsed;
+}
+
+export function injectProverCommand(program: Command, log: LogFn): Command {
+  const proverCommand = program.command('prover').description('Operate a prover node via its admin JSON-RPC endpoint');
+
+  proverCommand
+    .command('start-proof')
+    .description('Schedules proving for the given epoch')
+    .requiredOption('--epoch <n>', 'Epoch number to prove', parseEpoch)
+    .requiredOption('--admin-url <url>', 'URL of the prover node admin JSON-RPC endpoint')
+    .option('--api-key <key>', 'Admin API key', process.env.AZTEC_ADMIN_API_KEY)
+    .action(async options => {
+      const client = createProverNodeAdminClient(options.adminUrl, {}, undefined, options.apiKey);
+      const jobId = await client.startProof(options.epoch);
+      log(`Started proving job ${jobId} for epoch ${options.epoch}`);
+    });
+
+  proverCommand
+    .command('get-jobs')
+    .description('Lists the prover node proving jobs')
+    .requiredOption('--admin-url <url>', 'URL of the prover node admin JSON-RPC endpoint')
+    .option('--api-key <key>', 'Admin API key', process.env.AZTEC_ADMIN_API_KEY)
+    .action(async options => {
+      const client = createProverNodeAdminClient(options.adminUrl, {}, undefined, options.apiKey);
+      const jobs = await client.getJobs();
+      log(jsonStringify(jobs, true));
+    });
+
+  return program;
+}

--- a/yarn-project/aztec/src/cli/cmds/start_node.ts
+++ b/yarn-project/aztec/src/cli/cmds/start_node.ts
@@ -165,7 +165,7 @@ export async function startNode(
   // Register prover-node services if the prover node subsystem is running
   const proverNode = node.getProverNode();
   if (proverNode) {
-    services.prover = [proverNode, ProverNodeApiSchema];
+    adminServices.prover = [proverNode, ProverNodeApiSchema];
     if (!nodeConfig.proverBrokerUrl) {
       services.provingJobSource = [proverNode.getProver().getProvingJobSource(), ProvingJobConsumerSchema];
     }

--- a/yarn-project/prover-node/src/prover-node.ts
+++ b/yarn-project/prover-node/src/prover-node.ts
@@ -30,7 +30,6 @@ import {
   type ITxProvider,
   type ProverNodeApi,
   type Service,
-  type WorldStateSyncStatus,
   type WorldStateSynchronizer,
   tryStop,
 } from '@aztec/stdlib/interfaces/server';
@@ -209,17 +208,6 @@ export class ProverNode implements L2BlockStreamEventHandler, ProverNodeApi, Tra
       throw new Error('SessionManager not yet constructed — start() must be called first.');
     }
     return this.sessionManager;
-  }
-
-  /** Returns world state status. */
-  public async getWorldStateSyncStatus(): Promise<WorldStateSyncStatus> {
-    const { syncSummary } = await this.worldState.status();
-    return syncSummary;
-  }
-
-  /** Returns archiver status. */
-  public getL2Tips() {
-    return this.l2BlockSource.getL2Tips();
   }
 
   /** Returns the underlying prover instance. */

--- a/yarn-project/stdlib/src/interfaces/prover-node.test.ts
+++ b/yarn-project/stdlib/src/interfaces/prover-node.test.ts
@@ -1,9 +1,7 @@
-import { BlockNumber, CheckpointNumber } from '@aztec/foundation/branded-types';
+import { BlockNumber } from '@aztec/foundation/branded-types';
 import { type JsonRpcTestContext, createJsonRpcTestSetup } from '@aztec/foundation/json-rpc/test';
 
-import type { L2Tips } from '../block/l2_block_source.js';
 import { type EpochProvingJobState, type ProverNodeApi, ProverNodeApiSchema } from './prover-node.js';
-import type { WorldStateSyncStatus } from './world_state.js';
 
 describe('ProvingNodeApiSchema', () => {
   let handler: MockProverNode;
@@ -35,51 +33,9 @@ describe('ProvingNodeApiSchema', () => {
   it('startProof', async () => {
     await context.client.startProof(BlockNumber(1));
   });
-
-  it('getL2Tips', async () => {
-    const result = await context.client.getL2Tips();
-    const expectedTipId = {
-      block: { number: 1, hash: `0x01` },
-      checkpoint: { number: 1, hash: `0x01` },
-    };
-    expect(result).toEqual({
-      proposed: { number: 1, hash: `0x01` },
-      checkpointed: expectedTipId,
-      proven: expectedTipId,
-      finalized: expectedTipId,
-    });
-  });
-
-  it('getWorldStateSyncStatus', async () => {
-    const response = await context.client.getWorldStateSyncStatus();
-    expect(response).toEqual(await handler.getWorldStateSyncStatus());
-  });
 });
 
 class MockProverNode implements ProverNodeApi {
-  getWorldStateSyncStatus(): Promise<WorldStateSyncStatus> {
-    return Promise.resolve({
-      finalizedBlockNumber: BlockNumber(1),
-      latestBlockHash: '0x',
-      latestBlockNumber: BlockNumber(1),
-      oldestHistoricBlockNumber: BlockNumber(1),
-      treesAreSynched: true,
-    });
-  }
-
-  getL2Tips(): Promise<L2Tips> {
-    const tipId = {
-      block: { number: BlockNumber(1), hash: `0x01` },
-      checkpoint: { number: CheckpointNumber(1), hash: `0x01` },
-    };
-    return Promise.resolve({
-      proposed: { number: BlockNumber(1), hash: `0x01` },
-      checkpointed: tipId,
-      proven: tipId,
-      finalized: tipId,
-    });
-  }
-
   getJobs(): Promise<{ uuid: string; status: EpochProvingJobState; epochNumber: number }[]> {
     return Promise.resolve([
       { uuid: 'uuid1', status: 'initialized', epochNumber: 10 },

--- a/yarn-project/stdlib/src/interfaces/prover-node.ts
+++ b/yarn-project/stdlib/src/interfaces/prover-node.ts
@@ -1,8 +1,9 @@
+import { createSafeJsonRpcClient, defaultFetch } from '@aztec/foundation/json-rpc/client';
+
 import { z } from 'zod';
 
-import { type L2Tips, L2TipsSchema } from '../block/l2_block_source.js';
 import { type ApiSchemaFor, schemas } from '../schemas/index.js';
-import { type WorldStateSyncStatus, WorldStateSyncStatusSchema } from './world_state.js';
+import { type ComponentsVersions, getVersioningResponseHandler } from '../versioning/index.js';
 
 const EpochProvingJobState = [
   'initialized',
@@ -30,7 +31,7 @@ export const EpochProvingJobTerminalState: EpochProvingJobState[] = [
 
 export type EpochProvingJobTerminalState = (typeof EpochProvingJobTerminalState)[number];
 
-/** JSON RPC public interface to a prover node. */
+/** JSON RPC admin interface to a prover node. */
 export interface ProverNodeApi {
   getJobs(): Promise<{ uuid: string; status: EpochProvingJobState; epochNumber: number }[]>;
 
@@ -40,10 +41,6 @@ export interface ProverNodeApi {
    * track the returned job's progress.
    */
   startProof(epochNumber: number): Promise<string>;
-
-  getL2Tips(): Promise<L2Tips>;
-
-  getWorldStateSyncStatus(): Promise<WorldStateSyncStatus>;
 }
 
 /** Schemas for prover node API functions. */
@@ -54,8 +51,18 @@ export const ProverNodeApiSchema: ApiSchemaFor<ProverNodeApi> = {
   }),
 
   startProof: z.function({ input: z.tuple([schemas.Integer]), output: z.string() }),
-
-  getL2Tips: z.function({ input: z.tuple([]), output: L2TipsSchema }),
-
-  getWorldStateSyncStatus: z.function({ input: z.tuple([]), output: WorldStateSyncStatusSchema }),
 };
+
+export function createProverNodeAdminClient(
+  url: string,
+  versions: Partial<ComponentsVersions> = {},
+  fetch = defaultFetch,
+  apiKey?: string,
+): ProverNodeApi {
+  return createSafeJsonRpcClient<ProverNodeApi>(url, ProverNodeApiSchema, {
+    namespaceMethods: 'prover',
+    fetch,
+    onResponse: getVersioningResponseHandler(versions),
+    ...(apiKey ? { extraHeaders: { 'x-api-key': apiKey } } : {}),
+  });
+}


### PR DESCRIPTION
## Motivation

The prover node's JSON-RPC API was registered on the **public** RPC server, so operator-only actions — notably `startProof` — were callable without authentication. The API also carried `getL2Tips` and `getWorldStateSyncStatus`, which duplicate data the aztec node already serves. A-1078 asks to wire these methods to the admin API.

## Approach

- Register the prover API under `adminServices` (admin port, behind the admin API-key middleware) instead of the public `services` map.
- Drop the redundant `getL2Tips`/`getWorldStateSyncStatus` from the prover API — the node already exposes `getChainTips` (same shape) and `getWorldStateSyncStatus`.
- Add a `createProverNodeAdminClient` factory (namespaced under `prover`) and an `aztec prover` CLI command (`start-proof`, `get-jobs`) for operator access.

The prover node always runs as a subsystem of an aztec node whose admin server is already mounted, so no new server plumbing is needed — only the namespace registration moves. The proving job source stays on the public server, since prover agents pull jobs from it.

## API changes

- Prover JSON-RPC methods (`prover_*`) move from the public port to the admin port and now require the admin API key.
- `prover_getL2Tips` and `prover_getWorldStateSyncStatus` are removed — use `aztec_getChainTips` / `aztec_getWorldStateSyncStatus` instead.
- New `createProverNodeAdminClient` exported from `@aztec/stdlib/interfaces/server`.
- New CLI: `aztec prover start-proof --epoch <n> --admin-url <url> --api-key <key>` and `aztec prover get-jobs` (API key defaults to `AZTEC_ADMIN_API_KEY`).

## Changes

- **stdlib**: trim `ProverNodeApi`/`ProverNodeApiSchema`; add `createProverNodeAdminClient`.
- **prover-node**: remove the two redundant method implementations.
- **aztec (cli)**: register the prover API under `adminServices`; add the `prover` CLI command group.
- **stdlib (tests)**: drop the removed-method schema round-trip tests and mocks.
- **docs**: migration note documenting the public→admin move and method removals.

Fixes A-1078