### PR TITLE
fix(foundation): reject malformed hex buffer strings

### DIFF
--- a/yarn-project/foundation/src/eth-signature/eth_signature.ts
+++ b/yarn-project/foundation/src/eth-signature/eth_signature.ts
@@ -62,7 +62,7 @@ export class Signature {
    * default serialization of u32
    */
   static fromString(sig: `0x${string}`): Signature {
-    const buf = hexToBuffer(sig);
+    const buf = hexToBuffer(sig.slice(0, 2 + 64 * 2));
     const reader = BufferReader.asReader(buf);
     const r = reader.readObject(Buffer32);
     const s = reader.readObject(Buffer32);

--- a/yarn-project/foundation/src/schemas/schemas.test.ts
+++ b/yarn-project/foundation/src/schemas/schemas.test.ts
@@ -11,6 +11,18 @@ describe('schemas', () => {
     });
   });
 
+  describe('BufferHex', () => {
+    it('rejects odd-length hex strings instead of truncating the last nibble', () => {
+      expect(schemas.BufferHex.safeParse('0xabc').success).toBe(false);
+    });
+  });
+
+  describe('Fr', () => {
+    it('continues to parse odd-length numeric hex strings', () => {
+      expect(schemas.Fr.parse('0x1').toBigInt()).toBe(1n);
+    });
+  });
+
   describe('Boolean', () => {
     it('accepts a boolean value', () => {
       expect(schemas.Boolean.parse(true)).toEqual(true);

--- a/yarn-project/foundation/src/schemas/schemas.ts
+++ b/yarn-project/foundation/src/schemas/schemas.ts
@@ -7,7 +7,7 @@ import { SecretValue } from '../config/secret_value.js';
 import { Fq, Fr } from '../curves/bn254/field.js';
 import { Point } from '../curves/grumpkin/point.js';
 import { EthAddress } from '../eth-address/index.js';
-import { isHex, withHexPrefix, withoutHexPrefix } from '../string/index.js';
+import { hexToBuffer, isHex, isHexBufferString, withHexPrefix, withoutHexPrefix } from '../string/index.js';
 import { bufferSchema, hexSchema } from './utils.js';
 
 export const schemas = {
@@ -76,8 +76,8 @@ export const schemas = {
   BufferHex: z
     .string()
     .refine(isHex, 'Not a valid hex string')
-    .transform(withoutHexPrefix)
-    .transform(data => Buffer.from(data, 'hex')),
+    .refine(isHexBufferString, 'Hex string must have an even number of characters')
+    .transform(hexToBuffer),
 
   /** Hex string with an optional 0x prefix which gets removed as part of the parsing. */
   HexString: hexSchema,

--- a/yarn-project/foundation/src/schemas/utils.ts
+++ b/yarn-project/foundation/src/schemas/utils.ts
@@ -1,7 +1,7 @@
 import { type ZodObject, type ZodRawShape, type ZodType, type ZodTypeAny, z } from 'zod';
 
 import { pick } from '../collection/object.js';
-import { isHex, withoutHexPrefix } from '../string/index.js';
+import { hexToBuffer, isHex, isHexBufferString, withoutHexPrefix } from '../string/index.js';
 import type { ZodFor } from './types.js';
 
 export const hexSchema = z.string().refine(isHex, 'Not a valid hex string').transform(withoutHexPrefix);
@@ -60,7 +60,10 @@ export function hexSchemaFor<TClass extends { fromString(str: string): any } | {
   const hexSchema = stringSchema.refine(isHex, 'Not a valid hex string');
   return 'fromString' in klazz
     ? hexSchema.transform(klazz.fromString.bind(klazz))
-    : hexSchema.transform(str => Buffer.from(withoutHexPrefix(str), 'hex')).transform(klazz.fromBuffer.bind(klazz));
+    : hexSchema
+        .refine(isHexBufferString, 'Hex string must have an even number of characters')
+        .transform(hexToBuffer)
+        .transform(klazz.fromBuffer.bind(klazz));
 }
 
 /**

--- a/yarn-project/foundation/src/string/index.test.ts
+++ b/yarn-project/foundation/src/string/index.test.ts
@@ -1,4 +1,4 @@
-import { urlJoin, withHexPrefix, withoutHexPrefix } from './index.js';
+import { hexToBuffer, urlJoin, withHexPrefix, withoutHexPrefix } from './index.js';
 
 describe('string', () => {
   describe('urlJoin', () => {
@@ -38,6 +38,21 @@ describe('string', () => {
 
     it('leaves string unchanged without prefix', () => {
       expect(withoutHexPrefix('deadbeef')).toBe('deadbeef');
+    });
+  });
+
+  describe('hexToBuffer', () => {
+    it('parses hex strings with or without a prefix', () => {
+      expect(hexToBuffer('0xdeadbeef')).toEqual(Buffer.from('deadbeef', 'hex'));
+      expect(hexToBuffer('deadbeef')).toEqual(Buffer.from('deadbeef', 'hex'));
+    });
+
+    it('rejects odd-length hex strings', () => {
+      expect(() => hexToBuffer('0xabc')).toThrow('Invalid hex string length');
+    });
+
+    it('rejects non-hex strings', () => {
+      expect(() => hexToBuffer('0xzz')).toThrow('Invalid hex string');
     });
   });
 });

--- a/yarn-project/foundation/src/string/index.ts
+++ b/yarn-project/foundation/src/string/index.ts
@@ -17,7 +17,17 @@ export function isHex(str: string): boolean {
   return /^(0x)?[0-9a-fA-F]*$/.test(str);
 }
 
+export function isHexBufferString(str: string): boolean {
+  return isHex(str) && withoutHexPrefix(str).length % 2 === 0;
+}
+
 export function hexToBuffer(str: string): Buffer {
+  if (!isHex(str)) {
+    throw new Error(`Invalid hex string: ${str}`);
+  }
+  if (!isHexBufferString(str)) {
+    throw new Error(`Invalid hex string length: ${str}`);
+  }
   return Buffer.from(withoutHexPrefix(str), 'hex');
 }
 


### PR DESCRIPTION
- Validate hex strings before decoding them into Buffers so odd-length inputs are rejected instead of being silently truncated by `Buffer.from(..., 'hex')`.
- Reuse the stricter byte-oriented validation in `schemas.BufferHex` and the `hexSchemaFor(...fromBuffer)` path.
- Keep numeric field schemas accepting odd-length hex values such as `0x1`.
- Update signature parsing so `r` and `s` are decoded explicitly without relying on the trailing `v` nibble being ignored.


Node.js does not reject odd-length hex strings when decoding with `Buffer.from(value, 'hex')`; it silently drops the trailing nibble. For byte-oriented inputs this can turn malformed serialized data into a different valid byte sequence, which makes invalid RPC/schema inputs harder to detect.

This change makes buffer decoding fail fast for malformed hex while preserving numeric hex parsing for field values such as `0x1`.


