### PR TITLE
chore(l1-contracts): refresh gas benchmark snapshots

### DIFF
--- a/l1-contracts/gas_benchmark.md
+++ b/l1-contracts/gas_benchmark.md
@@ -12,24 +12,24 @@
 
 ## No Validators
 
-| Function             | Avg Gas | Max Gas | Calldata Size | Calldata Gas |
-|----------------------|---------|---------|---------------|--------------|
-| propose              | 195,988 | 222,201 |           932 |       14,912 |
-| submitEpochRootProof | 697,655 | 743,529 |         2,820 |       45,120 |
-| setupEpoch           |  31,998 | 113,793 |             - |            - |
+| Function             |   Avg Gas |   Max Gas | Calldata Size | Calldata Gas |
+|----------------------|-----------|-----------|---------------|--------------|
+| propose              |   196,245 |   222,459 |           964 |       15,424 |
+| submitEpochRootProof | 1,000,225 | 1,038,384 |        14,084 |      225,344 |
+| setupEpoch           |    32,042 |   113,837 |             - |            - |
 
-**Avg Gas Cost per Second**: 3,341.5 gas/second
+**Avg Gas Cost per Second**: 3,607.8 gas/second
 *Epoch duration*: 0h 38m 24s
 
 ## Validators
 
-| Function             | Avg Gas | Max Gas | Calldata Size | Calldata Gas |
-|----------------------|---------|---------|---------------|--------------|
-| propose              | 324,449 | 351,604 |         4,452 |       71,232 |
-| submitEpochRootProof | 896,101 | 941,944 |         5,316 |       85,056 |
-| aggregate3           | 373,118 | 386,457 |             - |            - |
-| setupEpoch           |  46,459 | 547,626 |             - |            - |
+| Function             |   Avg Gas |   Max Gas | Calldata Size | Calldata Gas |
+|----------------------|-----------|-----------|---------------|--------------|
+| propose              |   324,630 |   351,829 |         4,484 |       71,744 |
+| submitEpochRootProof | 1,581,276 | 1,678,797 |        16,580 |      265,280 |
+| aggregate3           |   373,249 |   386,660 |             - |            - |
+| setupEpoch           |    46,504 |   547,670 |             - |            - |
 
-**Avg Gas Cost per Second**: 5,304.3 gas/second
+**Avg Gas Cost per Second**: 5,901.6 gas/second
 *Epoch duration*: 0h 38m 24s
 

--- a/l1-contracts/gas_benchmark_results.json
+++ b/l1-contracts/gas_benchmark_results.json
@@ -2,62 +2,62 @@
   "no_validators": {
     "propose": {
       "calls": 150,
-      "min": 182373,
-      "mean": 195988,
-      "median": 191762,
-      "max": 222201,
-      "calldata_size": 932,
-      "calldata_gas": 14912
+      "min": 182631,
+      "mean": 196245,
+      "median": 192020,
+      "max": 222459,
+      "calldata_size": 964,
+      "calldata_gas": 15424
     },
     "setupEpoch": {
       "calls": 150,
-      "min": 29264,
-      "mean": 31998,
-      "median": 29264,
-      "max": 113793
+      "min": 29309,
+      "mean": 32042,
+      "median": 29309,
+      "max": 113837
     },
     "submitEpochRootProof": {
       "calls": 4,
-      "min": 676491,
-      "mean": 697655,
-      "median": 685300,
-      "max": 743529,
-      "calldata_size": 2820,
-      "calldata_gas": 45120
+      "min": 981633,
+      "mean": 1000225,
+      "median": 990442,
+      "max": 1038384,
+      "calldata_size": 14084,
+      "calldata_gas": 225344
     }
   },
   "validators": {
     "propose": {
       "calls": 150,
-      "min": 302105,
-      "mean": 324449,
-      "median": 323910,
-      "max": 351604,
-      "calldata_size": 4452,
-      "calldata_gas": 71232
+      "min": 302282,
+      "mean": 324630,
+      "median": 324123,
+      "max": 351829,
+      "calldata_size": 4484,
+      "calldata_gas": 71744
     },
     "setupEpoch": {
       "calls": 150,
-      "min": 29264,
-      "mean": 46459,
-      "median": 29264,
-      "max": 547626
+      "min": 29309,
+      "mean": 46504,
+      "median": 29309,
+      "max": 547670
     },
     "submitEpochRootProof": {
       "calls": 4,
-      "min": 874924,
-      "mean": 896101,
-      "median": 883769,
-      "max": 941944,
-      "calldata_size": 5316,
-      "calldata_gas": 85056
+      "min": 1469608,
+      "mean": 1581276,
+      "median": 1588350,
+      "max": 1678797,
+      "calldata_size": 16580,
+      "calldata_gas": 265280
     },
     "aggregate3": {
       "calls": 55,
-      "min": 362015,
-      "mean": 373118,
-      "median": 372828,
-      "max": 386457
+      "min": 362121,
+      "mean": 373249,
+      "median": 373006,
+      "max": 386660
     }
   }
 }


### PR DESCRIPTION
## Motivation

The committed L1 gas snapshots (`gas_benchmark.md` / `gas_benchmark_results.json`) still showed pre-change numbers. The unsound-verifier fix in the base PR (#24190) materially changes `submitEpochRootProof` gas, so the snapshots were stale and the benchmark dashboard would alert on the regression without a refreshed baseline in the tree.

## Approach

Re-ran `./bootstrap.sh gas_benchmark` and committed the regenerated snapshots. No source changes.

The deltas reflect the base PR: `submitEpochRootProof` now carries the full `ProposedHeader[]` as calldata (including the new `accumulatedFees` word) and rehashes each header on-chain in `verifyHeaders`, so its cost rises with checkpoints-per-epoch (32 in the benchmark, the max).

Measured changes:
- **No validators** — `submitEpochRootProof` 697,655 → 1,000,225 avg (+43%); `propose` 195,988 → 196,245 (+0.1%).
- **100 validators (48-member committee)** — `submitEpochRootProof` 896,101 → 1,581,276 avg (+76%); `propose` 324,449 → 324,630.

`propose` only gains the one `accumulatedFees` calldata word (+32 bytes).

## Changes

- **l1-contracts**: regenerated `gas_benchmark.md` and `gas_benchmark_results.json`.

Based on #24190.