### PR TITLE
feat(archiver): decode robustness against out-of-range checkpoint header/archive fields

### DIFF
--- a/yarn-project/archiver/src/archiver-sync.test.ts
+++ b/yarn-project/archiver/src/archiver-sync.test.ts
@@ -921,8 +921,8 @@ describe('Archiver Sync', () => {
       expect(rejectedValid).toBeDefined();
     }, 15_000);
 
-    it('skips a checkpoint whose propose calldata carries an out-of-range header field without stalling (A-1254)', async () => {
-      // Regression for A-1254: a malicious proposer posts a checkpoint whose header carries a uint256 field
+    it('skips a checkpoint whose propose calldata carries an out-of-range header field without stalling', async () => {
+      // Regression: a malicious proposer posts a checkpoint whose header carries a uint256 field
       // above the BN254 modulus. The honest archiver must decode the raw header without throwing, recognize
       // the corrupted header via failed attestation recovery, skip the checkpoint, and keep advancing — not
       // brick its L1 sync point.

--- a/yarn-project/archiver/src/archiver-sync.test.ts
+++ b/yarn-project/archiver/src/archiver-sync.test.ts
@@ -906,9 +906,9 @@ describe('Archiver Sync', () => {
           type: L2BlockSourceEvents.DescendentOfInvalidAttestationsCheckpointDetected,
           checkpoint: expect.objectContaining({
             checkpointNumber: 3,
-            archive: validCp3.archive.root,
+            archive: Buffer32.fromField(validCp3.archive.root),
           }),
-          ancestorArchiveRoot: badCp2.archive.root,
+          ancestorArchiveRoot: Buffer32.fromField(badCp2.archive.root),
           ancestorCheckpointNumber: 2,
         }),
       );

--- a/yarn-project/archiver/src/archiver-sync.test.ts
+++ b/yarn-project/archiver/src/archiver-sync.test.ts
@@ -974,6 +974,59 @@ describe('Archiver Sync', () => {
       expect(syncedL1).toBeDefined();
       expect(syncedL1!).toBeGreaterThanOrEqual(80n);
     }, 15_000);
+
+    it('skips a checkpoint whose propose calldata carries an out-of-range lastArchiveRoot without stalling', async () => {
+      // Regression: a checkpoint that builds on a prior out-of-range archive root carries a `lastArchiveRoot`
+      // above the BN254 modulus. The synchronizer decodes every retrieved checkpoint's raw header eagerly,
+      // before attestation validation; it must carry that field as raw bytes rather than converting to Fr,
+      // which would throw and permanently stall the L1 sync point.
+      expect(await archiver.getCheckpointNumber()).toEqual(CheckpointNumber(0));
+
+      fake.setTargetCommitteeSize(3);
+      const signers = times(3, Secp256k1Signer.random);
+      const committee = signers.map(s => s.address);
+      epochCache.getCommitteeForEpoch.mockResolvedValue({ committee, seed: 0n } as EpochCommitteeInfo);
+
+      const invalidCheckpointDetectedSpy = jest.fn();
+      archiver.events.on(L2BlockSourceEvents.InvalidAttestationsCheckpointDetected, invalidCheckpointDetectedSpy);
+
+      // Valid CP1.
+      const { checkpoint: cp1 } = await fake.addCheckpoint(CheckpointNumber(1), {
+        l1BlockNumber: 70n,
+        messagesL1BlockNumber: 50n,
+        numL1ToL2Messages: 3,
+        signers,
+      });
+      const cp1Archive = cp1.blocks.at(-1)!.archive;
+
+      // Malicious CP2: honest signers attest the clean header, but the broadcast calldata carries a
+      // lastArchiveRoot above the field modulus. The eager raw-header decode must not throw on it.
+      const { checkpoint: maliciousCp2 } = await fake.addCheckpoint(CheckpointNumber(2), {
+        l1BlockNumber: 80n,
+        numL1ToL2Messages: 0,
+        signers,
+        previousArchive: cp1Archive,
+        injectOutOfRangeLastArchiveRoot: 2n ** 256n - 1n,
+      });
+
+      fake.setL1BlockNumber(85n);
+
+      // The sync must complete without throwing despite the out-of-range lastArchiveRoot.
+      await expect(archiver.syncImmediate()).resolves.not.toThrow();
+
+      // The archiver synced CP1 and skipped the malicious CP2 rather than bricking.
+      expect(await archiver.getCheckpointNumber()).toEqual(CheckpointNumber(1));
+      expect(invalidCheckpointDetectedSpy).toHaveBeenCalled();
+
+      // The malicious checkpoint is recorded as rejected (keyed by its in-range archive root).
+      const rejected = await archiverStore.blocks.getRejectedCheckpointByArchiveRoot(maliciousCp2.archive.root);
+      expect(rejected).toBeDefined();
+
+      // The L1 sync point advanced past the malicious checkpoint's L1 block, proving it did not stall.
+      const syncedL1 = await archiverStore.blocks.getSynchedL1BlockNumber();
+      expect(syncedL1).toBeDefined();
+      expect(syncedL1!).toBeGreaterThanOrEqual(80n);
+    }, 15_000);
   });
 
   describe('reorg handling', () => {

--- a/yarn-project/archiver/src/archiver-sync.test.ts
+++ b/yarn-project/archiver/src/archiver-sync.test.ts
@@ -920,6 +920,60 @@ describe('Archiver Sync', () => {
       expect(rejectedBad).toBeDefined();
       expect(rejectedValid).toBeDefined();
     }, 15_000);
+
+    it('skips a checkpoint whose propose calldata carries an out-of-range header field without stalling (A-1254)', async () => {
+      // Regression for A-1254: a malicious proposer posts a checkpoint whose header carries a uint256 field
+      // above the BN254 modulus. The honest archiver must decode the raw header without throwing, recognize
+      // the corrupted header via failed attestation recovery, skip the checkpoint, and keep advancing — not
+      // brick its L1 sync point.
+      expect(await archiver.getCheckpointNumber()).toEqual(CheckpointNumber(0));
+
+      fake.setTargetCommitteeSize(3);
+      const signers = times(3, Secp256k1Signer.random);
+      const committee = signers.map(s => s.address);
+      epochCache.getCommitteeForEpoch.mockResolvedValue({ committee, seed: 0n } as EpochCommitteeInfo);
+
+      const invalidCheckpointDetectedSpy = jest.fn();
+      archiver.events.on(L2BlockSourceEvents.InvalidAttestationsCheckpointDetected, invalidCheckpointDetectedSpy);
+
+      // Valid CP1.
+      const { checkpoint: cp1 } = await fake.addCheckpoint(CheckpointNumber(1), {
+        l1BlockNumber: 70n,
+        messagesL1BlockNumber: 50n,
+        numL1ToL2Messages: 3,
+        signers,
+      });
+      const cp1Archive = cp1.blocks.at(-1)!.archive;
+
+      // Malicious CP2: honest signers attest the clean header, but the broadcast calldata carries an
+      // accumulatedFees field above the field modulus. Honest attestations no longer recover against the
+      // corrupted header, so it is rejected for insufficient/invalid attestations.
+      const { checkpoint: maliciousCp2 } = await fake.addCheckpoint(CheckpointNumber(2), {
+        l1BlockNumber: 80n,
+        numL1ToL2Messages: 0,
+        signers,
+        previousArchive: cp1Archive,
+        injectOutOfRangeAccumulatedFees: 2n ** 256n - 1n,
+      });
+
+      fake.setL1BlockNumber(85n);
+
+      // The sync must complete without throwing despite the out-of-range field.
+      await expect(archiver.syncImmediate()).resolves.not.toThrow();
+
+      // The archiver synced CP1 and skipped the malicious CP2 rather than bricking.
+      expect(await archiver.getCheckpointNumber()).toEqual(CheckpointNumber(1));
+      expect(invalidCheckpointDetectedSpy).toHaveBeenCalled();
+
+      // The malicious checkpoint is recorded as rejected (keyed by its in-range archive root).
+      const rejected = await archiverStore.blocks.getRejectedCheckpointByArchiveRoot(maliciousCp2.archive.root);
+      expect(rejected).toBeDefined();
+
+      // The L1 sync point advanced past the malicious checkpoint's L1 block, proving it did not stall.
+      const syncedL1 = await archiverStore.blocks.getSynchedL1BlockNumber();
+      expect(syncedL1).toBeDefined();
+      expect(syncedL1!).toBeGreaterThanOrEqual(80n);
+    }, 15_000);
   });
 
   describe('reorg handling', () => {

--- a/yarn-project/archiver/src/l1/calldata_retriever.test.ts
+++ b/yarn-project/archiver/src/l1/calldata_retriever.test.ts
@@ -11,9 +11,13 @@ import { type Logger, createLogger } from '@aztec/foundation/log';
 import { withHexPrefix } from '@aztec/foundation/string';
 import { RollupAbi } from '@aztec/l1-artifacts';
 import { Signature } from '@aztec/stdlib/block';
-import { GasFees } from '@aztec/stdlib/gas';
-import { ConsensusPayload, getHashedSignaturePayloadTypedData } from '@aztec/stdlib/p2p';
-import { CheckpointHeader } from '@aztec/stdlib/rollup';
+import { computeCheckpointPayloadDigest } from '@aztec/stdlib/checkpoint';
+import {
+  CheckpointHeader,
+  l1CheckpointHeaderHash,
+  toCheckpointHeader,
+  toL1CheckpointHeader,
+} from '@aztec/stdlib/rollup';
 
 import { jest } from '@jest/globals';
 import { type MockProxy, mock } from 'jest-mock-extended';
@@ -106,7 +110,7 @@ describe('CalldataRetriever', () => {
   });
 
   function makeViemHeader(): ViemHeader {
-    return CheckpointHeader.random().toViem();
+    return toL1CheckpointHeader(CheckpointHeader.random());
   }
 
   function makeViemCommitteeAttestations(): ViemCommitteeAttestations {
@@ -187,8 +191,8 @@ describe('CalldataRetriever', () => {
       const result = await retriever.getCheckpointFromRollupTx(txHash, [], checkpointNumber, hashes);
 
       expect(result.checkpointNumber).toBe(checkpointNumber);
-      expect(result.header).toBeInstanceOf(CheckpointHeader);
-      expect(result.archiveRoot).toBeInstanceOf(Fr);
+      expect(toCheckpointHeader(result.header)).toBeInstanceOf(CheckpointHeader);
+      expect(result.archiveRoot).toBeInstanceOf(Buffer32);
       expect(Array.isArray(result.attestations)).toBe(true);
       expect(result.blockHash).toBe(tx.blockHash);
       expect(instrumentation.recordBlockProposalTxTarget).toHaveBeenCalledWith(MULTI_CALL_3_ADDRESS, false);
@@ -211,7 +215,7 @@ describe('CalldataRetriever', () => {
       const result = await retriever.getCheckpointFromRollupTx(txHash, [], checkpointNumber, hashes);
 
       expect(result.checkpointNumber).toBe(checkpointNumber);
-      expect(result.header).toBeInstanceOf(CheckpointHeader);
+      expect(toCheckpointHeader(result.header)).toBeInstanceOf(CheckpointHeader);
       expect(instrumentation.recordBlockProposalTxTarget).toHaveBeenCalledWith(rollupAddress.toString(), false);
     });
 
@@ -329,7 +333,7 @@ describe('CalldataRetriever', () => {
       });
 
       expect(result.checkpointNumber).toBe(checkpointNumber);
-      expect(result.header).toBeInstanceOf(CheckpointHeader);
+      expect(toCheckpointHeader(result.header)).toBeInstanceOf(CheckpointHeader);
     });
 
     it('should throw when attestationsHash does not match', async () => {
@@ -379,14 +383,14 @@ describe('CalldataRetriever', () => {
       const tx = makeMulticall3Transaction([{ target: rollupAddress.toString(), callData: proposeCalldata }]);
       publicClient.getTransaction.mockResolvedValue(tx);
 
-      // Compute the expected payloadDigest using the same EIP-712 typed data hash
+      // Compute the expected payloadDigest using the same raw EIP-712 typed data hash
       // that CalldataRetriever.computePayloadDigest uses under the hood.
-      const checkpointHeader = CheckpointHeader.fromViem(header);
-      const consensusPayload = new ConsensusPayload(checkpointHeader, archiveRoot, feeAssetPriceModifier, {
-        chainId: 1,
-        rollupAddress,
-      });
-      const expectedPayloadDigest = getHashedSignaturePayloadTypedData(consensusPayload).toString() as Hex;
+      const expectedPayloadDigest = computeCheckpointPayloadDigest({
+        headerHash: l1CheckpointHeaderHash(header),
+        archiveRoot,
+        feeAssetPriceModifier,
+        signatureContext: { chainId: 1, rollupAddress },
+      }).toString() as Hex;
 
       // Mock only attestationsHash computation; use real payloadDigest
       jest
@@ -399,7 +403,7 @@ describe('CalldataRetriever', () => {
       });
 
       expect(result.checkpointNumber).toBe(checkpointNumber);
-      expect(result.header).toBeInstanceOf(CheckpointHeader);
+      expect(toCheckpointHeader(result.header)).toBeInstanceOf(CheckpointHeader);
     });
 
     it('should throw when payloadDigest does not match', async () => {
@@ -431,8 +435,8 @@ describe('CalldataRetriever', () => {
       const result = retriever.tryDecodeMulticall3(tx, hashes, checkpointNumber, blockHash as Hex);
 
       expect(result).toBeDefined();
-      expect(result!.header).toBeInstanceOf(CheckpointHeader);
-      expect(result!.archiveRoot).toBeInstanceOf(Fr);
+      expect(toCheckpointHeader(result!.header)).toBeInstanceOf(CheckpointHeader);
+      expect(result!.archiveRoot).toBeInstanceOf(Buffer32);
       expect(result!.checkpointNumber).toBe(checkpointNumber);
     });
 
@@ -452,7 +456,7 @@ describe('CalldataRetriever', () => {
       const result = retriever.tryDecodeMulticall3(tx, hashes, checkpointNumber, blockHash as Hex);
 
       expect(result).toBeDefined();
-      expect(result!.header).toBeInstanceOf(CheckpointHeader);
+      expect(toCheckpointHeader(result!.header)).toBeInstanceOf(CheckpointHeader);
     });
 
     it('should decode multicall3 with unknown calls when propose is hash-verified', () => {
@@ -467,7 +471,7 @@ describe('CalldataRetriever', () => {
 
       const result = retriever.tryDecodeMulticall3(tx, hashes, checkpointNumber, blockHash as Hex);
       expect(result).toBeDefined();
-      expect(result!.header).toBeInstanceOf(CheckpointHeader);
+      expect(toCheckpointHeader(result!.header)).toBeInstanceOf(CheckpointHeader);
     });
 
     it('should return first when multiple propose candidates all verify (with warning)', () => {
@@ -483,7 +487,7 @@ describe('CalldataRetriever', () => {
       const warnSpy = jest.spyOn(logger, 'warn');
       const result = retriever.tryDecodeMulticall3(tx, hashes, checkpointNumber, blockHash as Hex);
       expect(result).toBeDefined();
-      expect(result!.header).toBeInstanceOf(CheckpointHeader);
+      expect(toCheckpointHeader(result!.header)).toBeInstanceOf(CheckpointHeader);
       expect(warnSpy).toHaveBeenCalledWith(
         expect.stringContaining('Multiple propose candidates verified'),
         expect.any(Object),
@@ -502,8 +506,8 @@ describe('CalldataRetriever', () => {
         if (calldata === proposeCalldata1) {
           return {
             checkpointNumber,
-            archiveRoot: Fr.random(),
-            header: CheckpointHeader.random(),
+            archiveRoot: Buffer32.fromField(Fr.random()),
+            header: toL1CheckpointHeader(CheckpointHeader.random()),
             attestations: [],
             blockHash,
             feeAssetPriceModifier: 0n,
@@ -654,8 +658,8 @@ describe('CalldataRetriever', () => {
       const result = retriever.tryDecodeDirectPropose(tx, hashes, checkpointNumber, blockHash as Hex);
 
       expect(result).toBeDefined();
-      expect(result!.header).toBeInstanceOf(CheckpointHeader);
-      expect(result!.archiveRoot).toBeInstanceOf(Fr);
+      expect(toCheckpointHeader(result!.header)).toBeInstanceOf(CheckpointHeader);
+      expect(result!.archiveRoot).toBeInstanceOf(Buffer32);
       expect(result!.checkpointNumber).toBe(checkpointNumber);
     });
 
@@ -1148,8 +1152,8 @@ describe('CalldataRetriever', () => {
 
       expect(result).toBeDefined();
       expect(result!.checkpointNumber).toBe(checkpointNumber);
-      expect(result!.header).toBeInstanceOf(CheckpointHeader);
-      expect(result!.archiveRoot).toBeInstanceOf(Fr);
+      expect(toCheckpointHeader(result!.header)).toBeInstanceOf(CheckpointHeader);
+      expect(result!.archiveRoot).toBeInstanceOf(Buffer32);
       expect(Array.isArray(result!.attestations)).toBe(true);
       expect(result!.blockHash).toBe(blockHash);
     });
@@ -1239,14 +1243,14 @@ describe('CalldataRetriever', () => {
 
       expect(result).toBeDefined();
       expect(result.checkpointNumber).toBe(checkpointNumber);
-      expect(result.header).toBeInstanceOf(CheckpointHeader);
-      expect(result.archiveRoot).toBeInstanceOf(Fr);
+      expect(toCheckpointHeader(result.header)).toBeInstanceOf(CheckpointHeader);
+      expect(result.archiveRoot).toBeInstanceOf(Buffer32);
       expect(Array.isArray(result.attestations)).toBe(true);
       expect(result.blockHash).toBe(tx.blockHash);
 
       // Verify all components are properly decoded
-      expect(result.header.inHash).toBeInstanceOf(Fr);
-      expect(result.header.gasFees).toBeInstanceOf(GasFees);
+      expect(typeof result.header.inHash).toBe('string');
+      expect(typeof result.header.gasFees.feePerDaGas).toBe('bigint');
 
       // Verify instrumentation was called
       expect(instrumentation.recordBlockProposalTxTarget).toHaveBeenCalledWith(MULTI_CALL_3_ADDRESS, false);
@@ -1313,14 +1317,14 @@ describe('CalldataRetriever', () => {
 
       expect(result).toBeDefined();
       expect(result.checkpointNumber).toBe(checkpointNumber);
-      expect(result.header).toBeInstanceOf(CheckpointHeader);
-      expect(result.archiveRoot).toBeInstanceOf(Fr);
+      expect(toCheckpointHeader(result.header)).toBeInstanceOf(CheckpointHeader);
+      expect(result.archiveRoot).toBeInstanceOf(Buffer32);
       expect(Array.isArray(result.attestations)).toBe(true);
       expect(result.blockHash).toBe(blockHash);
 
       // Verify all components are properly decoded
-      expect(result.header.inHash).toBeInstanceOf(Fr);
-      expect(result.header.gasFees).toBeInstanceOf(GasFees);
+      expect(typeof result.header.inHash).toBe('string');
+      expect(typeof result.header.gasFees.feePerDaGas).toBe('bigint');
 
       // Verify proxy implementation was checked
       expect(publicClient.getStorageAt).toHaveBeenCalled();
@@ -1347,8 +1351,8 @@ describe('CalldataRetriever', () => {
       const result = await retriever.getCheckpointFromRollupTx(txHash, [], checkpointNumber, hashes);
 
       expect(result.checkpointNumber).toBe(checkpointNumber);
-      expect(result.header).toBeInstanceOf(CheckpointHeader);
-      expect(result.archiveRoot).toBeInstanceOf(Fr);
+      expect(toCheckpointHeader(result.header)).toBeInstanceOf(CheckpointHeader);
+      expect(result.archiveRoot).toBeInstanceOf(Buffer32);
       expect(instrumentation.recordBlockProposalTxTarget).toHaveBeenCalledWith(MULTI_CALL_3_ADDRESS, false);
     });
 
@@ -1423,7 +1427,7 @@ describe('CalldataRetriever', () => {
       const result = await retriever.getCheckpointFromRollupTx(txHash, [], checkpointNumber, hashes);
 
       expect(result.checkpointNumber).toBe(checkpointNumber);
-      expect(result.header).toBeInstanceOf(CheckpointHeader);
+      expect(toCheckpointHeader(result.header)).toBeInstanceOf(CheckpointHeader);
       expect(instrumentation.recordBlockProposalTxTarget).toHaveBeenCalledWith(SPIRE_PROPOSER_ADDRESS, false);
     });
 

--- a/yarn-project/archiver/src/l1/calldata_retriever.test.ts
+++ b/yarn-project/archiver/src/l1/calldata_retriever.test.ts
@@ -359,7 +359,7 @@ describe('CalldataRetriever', () => {
     it('should validate payloadDigest', async () => {
       const header = makeViemHeader();
       const attestations = makeViemCommitteeAttestations();
-      const archiveRoot = Fr.random();
+      const archiveRoot = Buffer32.fromField(Fr.random());
       const archive = archiveRoot.toString() as Hex;
       const feeAssetPriceModifier = BigInt(-1);
 

--- a/yarn-project/archiver/src/l1/calldata_retriever.ts
+++ b/yarn-project/archiver/src/l1/calldata_retriever.ts
@@ -1,14 +1,14 @@
 import { MULTI_CALL_3_ADDRESS, type ViemCommitteeAttestations, type ViemHeader } from '@aztec/ethereum/contracts';
 import type { ViemPublicClient, ViemPublicDebugClient } from '@aztec/ethereum/types';
 import { CheckpointNumber } from '@aztec/foundation/branded-types';
+import { Buffer32 } from '@aztec/foundation/buffer';
 import { LruSet } from '@aztec/foundation/collection';
-import { Fr } from '@aztec/foundation/curves/bn254';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import type { Logger } from '@aztec/foundation/log';
 import { RollupAbi } from '@aztec/l1-artifacts';
 import { CommitteeAttestation } from '@aztec/stdlib/block';
 import { computeCheckpointPayloadDigest } from '@aztec/stdlib/checkpoint';
-import { CheckpointHeader } from '@aztec/stdlib/rollup';
+import { type L1CheckpointHeader, l1CheckpointHeaderHash } from '@aztec/stdlib/rollup';
 
 import {
   type AbiParameter,
@@ -28,11 +28,16 @@ import { getCallsFromSpireProposer } from './spire_proposer.js';
 import { getSuccessfulCallsFromTrace } from './trace_tx.js';
 import type { CallInfo } from './types.js';
 
-/** Decoded checkpoint data from a propose calldata. */
+/**
+ * Decoded checkpoint data from a propose calldata. The header and archive root are kept in their raw,
+ * unvalidated form (a structurally-viem `L1CheckpointHeader` and `Buffer32`) so that a malicious
+ * out-of-range field cannot make decoding throw. The caller (the L1 synchronizer) decides validity and
+ * performs the conversion to `CheckpointHeader`/`Fr` at the ingestion boundary (see A-1254).
+ */
 type CheckpointData = {
   checkpointNumber: CheckpointNumber;
-  archiveRoot: Fr;
-  header: CheckpointHeader;
+  archiveRoot: Buffer32;
+  header: L1CheckpointHeader;
   attestations: CommitteeAttestation[];
   blockHash: string;
   feeAssetPriceModifier: bigint;
@@ -426,9 +431,11 @@ export class CalldataRetriever {
         return undefined;
       }
 
-      // Verify payloadDigest
-      const header = CheckpointHeader.fromViem(decodedArgs.header);
-      const archiveRoot = new Fr(Buffer.from(hexToBytes(decodedArgs.archive)));
+      // Keep the header and archive root raw. We compute the payload digest from the raw header hash and raw
+      // archive bytes (both always in range, even when a field is not), so we can still positively identify the
+      // correct propose candidate for a malicious header without ever converting it into a CheckpointHeader/Fr.
+      const header: L1CheckpointHeader = decodedArgs.header;
+      const archiveRoot = Buffer32.fromString(decodedArgs.archive);
       const feeAssetPriceModifier = decodedArgs.oracleInput.feeAssetPriceModifier;
       const computedPayloadDigest = this.computePayloadDigest(header, archiveRoot, feeAssetPriceModifier);
       if (
@@ -471,10 +478,10 @@ export class CalldataRetriever {
     return keccak256(encodeAbiParameters([this.getCommitteeAttestationsStructDef()], [packedAttestations]));
   }
 
-  /** Computes the keccak256 payload digest from the checkpoint header, archive root, and fee asset price modifier. */
-  private computePayloadDigest(header: CheckpointHeader, archiveRoot: Fr, feeAssetPriceModifier: bigint): Hex {
+  /** Computes the keccak256 payload digest from the raw checkpoint header, archive root, and fee asset price modifier. */
+  private computePayloadDigest(header: L1CheckpointHeader, archiveRoot: Buffer32, feeAssetPriceModifier: bigint): Hex {
     return computeCheckpointPayloadDigest({
-      header,
+      headerHash: l1CheckpointHeaderHash(header),
       archiveRoot,
       feeAssetPriceModifier,
       signatureContext: this.getSignatureContext(),

--- a/yarn-project/archiver/src/l1/calldata_retriever.ts
+++ b/yarn-project/archiver/src/l1/calldata_retriever.ts
@@ -32,7 +32,7 @@ import type { CallInfo } from './types.js';
  * Decoded checkpoint data from a propose calldata. The header and archive root are kept in their raw,
  * unvalidated form (a structurally-viem `L1CheckpointHeader` and `Buffer32`) so that a malicious
  * out-of-range field cannot make decoding throw. The caller (the L1 synchronizer) decides validity and
- * performs the conversion to `CheckpointHeader`/`Fr` at the ingestion boundary (see A-1254).
+ * performs the conversion to `CheckpointHeader`/`Fr` at the ingestion boundary.
  */
 type CheckpointData = {
   checkpointNumber: CheckpointNumber;

--- a/yarn-project/archiver/src/l1/data_retrieval.test.ts
+++ b/yarn-project/archiver/src/l1/data_retrieval.test.ts
@@ -1,9 +1,10 @@
 import { type BlockBlobData, type CheckpointBlobData, makeBlockEndBlobData } from '@aztec/blob-lib/encoding';
 import { BlockNumber, CheckpointNumber } from '@aztec/foundation/branded-types';
+import { Buffer32 } from '@aztec/foundation/buffer';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { Body, CommitteeAttestation } from '@aztec/stdlib/block';
 import { L1PublishedData } from '@aztec/stdlib/checkpoint';
-import { CheckpointHeader } from '@aztec/stdlib/rollup';
+import { CheckpointHeader, toL1CheckpointHeader } from '@aztec/stdlib/rollup';
 
 import { type RetrievedCheckpoint, retrievedToPublishedCheckpoint } from './data_retrieval.js';
 
@@ -28,13 +29,13 @@ describe('data_retrieval', () => {
         checkpointEndMarker: { numBlobFields },
       };
 
-      const archiveRoot = Fr.random();
+      const archiveRoot = Buffer32.fromField(Fr.random());
 
       const retrievedCheckpoint: RetrievedCheckpoint = {
         checkpointNumber: CheckpointNumber(1),
         archiveRoot,
         feeAssetPriceModifier: 0n,
-        header: CheckpointHeader.random(),
+        header: toL1CheckpointHeader(CheckpointHeader.random()),
         checkpointBlobData,
         l1: new L1PublishedData(1n, 1000n, '0x1234'),
         chainId: new Fr(1),
@@ -90,13 +91,13 @@ describe('data_retrieval', () => {
         checkpointEndMarker: { numBlobFields: 50 },
       };
 
-      const archiveRoot = Fr.random();
+      const archiveRoot = Buffer32.fromField(Fr.random());
 
       const retrievedCheckpoint: RetrievedCheckpoint = {
         checkpointNumber: CheckpointNumber(1),
         archiveRoot,
         feeAssetPriceModifier: 0n,
-        header: CheckpointHeader.random(),
+        header: toL1CheckpointHeader(CheckpointHeader.random()),
         checkpointBlobData,
         l1: new L1PublishedData(1n, 1000n, '0x1234'),
         chainId: new Fr(1),

--- a/yarn-project/archiver/src/l1/data_retrieval.ts
+++ b/yarn-project/archiver/src/l1/data_retrieval.ts
@@ -40,7 +40,7 @@ import { CalldataRetriever } from './calldata_retriever.js';
 type RetrievedCheckpointBase = {
   checkpointNumber: CheckpointNumber;
   // Raw archive root and header from L1 calldata. They may carry out-of-range field values and are only
-  // converted to Fr/CheckpointHeader at the ingestion boundary, after attestation validation (see A-1254).
+  // converted to Fr/CheckpointHeader at the ingestion boundary, after attestation validation.
   archiveRoot: Buffer32;
   feeAssetPriceModifier: bigint;
   header: L1CheckpointHeader;
@@ -74,8 +74,8 @@ export async function retrievedToPublishedCheckpoint({
 }: RetrievedCheckpoint): Promise<PublishedCheckpoint> {
   // Ingestion boundary: convert the raw header/archive root into validated Fr-valued domain types. The
   // synchronizer only builds a published checkpoint for entries whose attestations validated, so reaching
-  // an out-of-range field here is the catastrophic "a quorum signed an out-of-range header" case (A-1254
-  // Fix 2 makes it unreachable on a patched chain); toCheckpointHeader/Fr surface it loudly by throwing.
+  // an out-of-range field here is the catastrophic "a quorum signed an out-of-range header" case (the L1
+  // range checks make it unreachable on a patched chain); toCheckpointHeader/Fr surface it loudly by throwing.
   const checkpointHeader = toCheckpointHeader(rawCheckpointHeader);
   const archiveRoot = Fr.fromString(rawArchiveRoot.toString());
   const { blocks: blocksBlobData } = checkpointBlobData;

--- a/yarn-project/archiver/src/l1/data_retrieval.ts
+++ b/yarn-project/archiver/src/l1/data_retrieval.ts
@@ -17,6 +17,7 @@ import type {
 import type { ViemPublicClient, ViemPublicDebugClient } from '@aztec/ethereum/types';
 import { asyncPool } from '@aztec/foundation/async-pool';
 import { CheckpointNumber, IndexWithinCheckpoint } from '@aztec/foundation/branded-types';
+import { Buffer32 } from '@aztec/foundation/buffer';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { type Logger, createLogger } from '@aztec/foundation/log';
@@ -24,7 +25,7 @@ import { RollupAbi } from '@aztec/l1-artifacts';
 import { Body, CommitteeAttestation, L2Block } from '@aztec/stdlib/block';
 import { Checkpoint, L1PublishedData, PublishedCheckpoint } from '@aztec/stdlib/checkpoint';
 import { Proof } from '@aztec/stdlib/proofs';
-import { CheckpointHeader } from '@aztec/stdlib/rollup';
+import { type L1CheckpointHeader, toCheckpointHeader } from '@aztec/stdlib/rollup';
 import { AppendOnlyTreeSnapshot } from '@aztec/stdlib/trees';
 import { BlockHeader, GlobalVariables, PartialStateReference, StateReference } from '@aztec/stdlib/tx';
 
@@ -38,9 +39,11 @@ import { CalldataRetriever } from './calldata_retriever.js';
 
 type RetrievedCheckpointBase = {
   checkpointNumber: CheckpointNumber;
-  archiveRoot: Fr;
+  // Raw archive root and header from L1 calldata. They may carry out-of-range field values and are only
+  // converted to Fr/CheckpointHeader at the ingestion boundary, after attestation validation (see A-1254).
+  archiveRoot: Buffer32;
   feeAssetPriceModifier: bigint;
-  header: CheckpointHeader;
+  header: L1CheckpointHeader;
   l1: L1PublishedData;
   chainId: Fr;
   version: Fr;
@@ -60,15 +63,21 @@ export type RetrievedCheckpointFromCalldata = RetrievedCheckpointBase & {
 
 export async function retrievedToPublishedCheckpoint({
   checkpointNumber,
-  archiveRoot,
+  archiveRoot: rawArchiveRoot,
   feeAssetPriceModifier,
-  header: checkpointHeader,
+  header: rawCheckpointHeader,
   checkpointBlobData,
   l1,
   chainId,
   version,
   attestations,
 }: RetrievedCheckpoint): Promise<PublishedCheckpoint> {
+  // Ingestion boundary: convert the raw header/archive root into validated Fr-valued domain types. The
+  // synchronizer only builds a published checkpoint for entries whose attestations validated, so reaching
+  // an out-of-range field here is the catastrophic "a quorum signed an out-of-range header" case (A-1254
+  // Fix 2 makes it unreachable on a patched chain); toCheckpointHeader/Fr surface it loudly by throwing.
+  const checkpointHeader = toCheckpointHeader(rawCheckpointHeader);
+  const archiveRoot = Fr.fromString(rawArchiveRoot.toString());
   const { blocks: blocksBlobData } = checkpointBlobData;
 
   // The lastArchiveRoot of a block is the new archive for the previous block.

--- a/yarn-project/archiver/src/modules/l1_synchronizer.ts
+++ b/yarn-project/archiver/src/modules/l1_synchronizer.ts
@@ -28,7 +28,6 @@ import {
   type CheckpointInfo,
   L1PublishedData,
   PublishedCheckpoint,
-  archiveFromBuffer,
 } from '@aztec/stdlib/checkpoint';
 import { type L1RollupConstants, getEpochAtSlot, getSlotAtNextL1Block } from '@aztec/stdlib/epoch-helpers';
 import { computeInHashFromL1ToL2Messages } from '@aztec/stdlib/messaging';
@@ -50,7 +49,7 @@ import {
   retrieveL1ToL2Messages,
   retrievedToPublishedCheckpoint,
 } from '../l1/data_retrieval.js';
-import type { RejectedCheckpoint } from '../store/block_store.js';
+import type { RejectedCheckpoint, RejectedCheckpointReason } from '../store/block_store.js';
 import { type ArchiverDataStores, getArchiverSynchPoint } from '../store/data_stores.js';
 import type { L2TipsCache } from '../store/l2_tips_cache.js';
 import { MessageStoreError } from '../store/message_store.js';
@@ -72,19 +71,17 @@ function archiveRootsEqual(a: Fr | Buffer32, b: Fr | Buffer32): boolean {
 type RawCheckpointEntry = {
   checkpointNumber: CheckpointNumber;
   header: L1CheckpointHeader;
-  /** Raw archive root, used for digest/validation; may be out of range. */
+  /** Raw archive root bytes (may be out of range). Used for digest/validation, persisted records, and events. */
   archiveRoot: Buffer32;
-  /** Archive root normalized to Fr when in range, used for persisted records and emitted events. */
-  normalizedArchiveRoot: Fr | Buffer32;
   feeAssetPriceModifier: bigint;
   attestations: CommitteeAttestation[];
   l1: L1PublishedData;
   /**
-   * `lastArchiveRoot` of this checkpoint, used for rejected-ancestor lookups. Carried as `Fr | Buffer32`
+   * Raw `lastArchiveRoot` bytes of this checkpoint, used for rejected-ancestor lookups. May be out of range
    * because a checkpoint can build on an out-of-range archive root (it equals the prior checkpoint's stored
-   * archive), so converting it eagerly would throw and stall the L1 sync point.
+   * archive), so it is never eagerly converted to `Fr` (which would throw and stall the L1 sync point).
    */
-  lastArchiveRoot: Fr | Buffer32;
+  lastArchiveRoot: Buffer32;
   slotNumber: SlotNumber;
 } & (
   | { kind: 'calldata'; calldata: RetrievedCheckpointFromCalldata }
@@ -898,11 +895,10 @@ export class ArchiverL1Synchronizer implements Traceable {
               checkpointNumber: checkpointToPromote.checkpoint.number,
               header: toL1CheckpointHeader(checkpointToPromote.checkpoint.header),
               archiveRoot: Buffer32.fromField(checkpointToPromote.checkpoint.archive.root),
-              normalizedArchiveRoot: checkpointToPromote.checkpoint.archive.root,
               feeAssetPriceModifier: checkpointToPromote.checkpoint.feeAssetPriceModifier,
               attestations: checkpointToPromote.attestations,
               l1: checkpointToPromote.l1,
-              lastArchiveRoot: checkpointToPromote.checkpoint.header.lastArchiveRoot,
+              lastArchiveRoot: Buffer32.fromField(checkpointToPromote.checkpoint.header.lastArchiveRoot),
               slotNumber: checkpointToPromote.checkpoint.header.slotNumber,
               promoted: checkpointToPromote,
             },
@@ -915,7 +911,6 @@ export class ArchiverL1Synchronizer implements Traceable {
         checkpointNumber: checkpoint.checkpointNumber,
         header: checkpoint.header,
         archiveRoot: checkpoint.archiveRoot,
-        normalizedArchiveRoot: archiveFromBuffer(checkpoint.archiveRoot.toBuffer()),
         feeAssetPriceModifier: checkpoint.feeAssetPriceModifier,
         attestations: checkpoint.attestations,
         l1: checkpoint.l1,
@@ -937,6 +932,16 @@ export class ArchiverL1Synchronizer implements Traceable {
           feeAssetPriceModifier: raw.feeAssetPriceModifier,
           attestations: raw.attestations,
         };
+
+        // Both rejection paths below persist the same record; only the reason differs.
+        const toRejectedCheckpoint = (reason: RejectedCheckpointReason): RejectedCheckpoint => ({
+          checkpointNumber: raw.checkpointNumber,
+          archiveRoot: raw.archiveRoot,
+          parentArchiveRoot: raw.lastArchiveRoot,
+          slotNumber: raw.slotNumber,
+          l1: raw.l1,
+          reason,
+        });
 
         // Check the attestations uploaded by the publisher to L1 are correct
         // Rollup contract does not validate attestations to save on gas, so this
@@ -991,21 +996,14 @@ export class ArchiverL1Synchronizer implements Traceable {
           // Persist a rejected-ancestor entry so any later checkpoint that builds on this one
           // is detected and skipped (rather than tripping the addCheckpoints consecutive-number
           // check and causing the sync point to roll back in a loop).
-          await this.stores.blocks.addRejectedCheckpoint({
-            checkpointNumber: raw.checkpointNumber,
-            archiveRoot: raw.normalizedArchiveRoot,
-            parentArchiveRoot: raw.lastArchiveRoot,
-            slotNumber: raw.slotNumber,
-            l1: raw.l1,
-            reason: 'invalid-attestations' as const,
-          });
+          await this.stores.blocks.addRejectedCheckpoint(toRejectedCheckpoint('invalid-attestations'));
 
           continue;
         }
 
         if (rejectedAncestor) {
           const descendantInfo: CheckpointInfo = {
-            archive: raw.normalizedArchiveRoot,
+            archive: raw.archiveRoot,
             lastArchive: raw.lastArchiveRoot,
             slotNumber: raw.slotNumber,
             checkpointNumber: raw.checkpointNumber,
@@ -1033,14 +1031,7 @@ export class ArchiverL1Synchronizer implements Traceable {
 
           // Persist this chainpoint as rejected as well, so we can construct a chain of
           // skipped checkpoints starting from the first one with invalid attestations.
-          await this.stores.blocks.addRejectedCheckpoint({
-            checkpointNumber: raw.checkpointNumber,
-            archiveRoot: raw.normalizedArchiveRoot,
-            parentArchiveRoot: raw.lastArchiveRoot,
-            slotNumber: raw.slotNumber,
-            l1: raw.l1,
-            reason: 'descends-from-invalid-attestations' as const,
-          });
+          await this.stores.blocks.addRejectedCheckpoint(toRejectedCheckpoint('descends-from-invalid-attestations'));
 
           continue;
         }
@@ -1246,9 +1237,7 @@ export class ArchiverL1Synchronizer implements Traceable {
     // The calldata header is raw (L1CheckpointHeader) and may be out of range; compare by header hash and
     // archive root bytes rather than converting it into a CheckpointHeader (which could throw).
     if (
-      !l1CheckpointHeaderHash(toL1CheckpointHeader(proposed.header)).equals(
-        l1CheckpointHeaderHash(calldataCheckpoint.header),
-      ) ||
+      !proposed.header.hash().equals(l1CheckpointHeaderHash(calldataCheckpoint.header)) ||
       !archiveRootsEqual(proposed.archive.root, calldataCheckpoint.archiveRoot)
     ) {
       this.log.warn(

--- a/yarn-project/archiver/src/modules/l1_synchronizer.ts
+++ b/yarn-project/archiver/src/modules/l1_synchronizer.ts
@@ -6,7 +6,7 @@ import { getFinalizedL1Block } from '@aztec/ethereum/queries';
 import type { ViemPublicClient, ViemPublicDebugClient } from '@aztec/ethereum/types';
 import { asyncPool } from '@aztec/foundation/async-pool';
 import { maxBigint } from '@aztec/foundation/bigint';
-import { BlockNumber, CheckpointNumber, EpochNumber } from '@aztec/foundation/branded-types';
+import { BlockNumber, CheckpointNumber, EpochNumber, SlotNumber } from '@aztec/foundation/branded-types';
 import { Buffer16, Buffer32 } from '@aztec/foundation/buffer';
 import { compactArray, partition, pick } from '@aztec/foundation/collection';
 import { Fr } from '@aztec/foundation/curves/bn254';
@@ -16,11 +16,29 @@ import { retryTimes } from '@aztec/foundation/retry';
 import { count } from '@aztec/foundation/string';
 import { DateProvider, Timer, elapsed } from '@aztec/foundation/timer';
 import { isDefined, isErrorClass } from '@aztec/foundation/types';
-import { type ArchiverEmitter, L2BlockSourceEvents, type ValidateCheckpointResult } from '@aztec/stdlib/block';
-import { Checkpoint, type CheckpointData, PublishedCheckpoint } from '@aztec/stdlib/checkpoint';
+import {
+  type ArchiverEmitter,
+  type CommitteeAttestation,
+  L2BlockSourceEvents,
+  type ValidateCheckpointResult,
+} from '@aztec/stdlib/block';
+import {
+  Checkpoint,
+  type CheckpointData,
+  type CheckpointInfo,
+  L1PublishedData,
+  PublishedCheckpoint,
+  archiveFromBuffer,
+} from '@aztec/stdlib/checkpoint';
 import { type L1RollupConstants, getEpochAtSlot, getSlotAtNextL1Block } from '@aztec/stdlib/epoch-helpers';
 import { computeInHashFromL1ToL2Messages } from '@aztec/stdlib/messaging';
 import type { CoordinationSignatureContext } from '@aztec/stdlib/p2p';
+import {
+  type L1CheckpointHeader,
+  OutOfRangeFieldError,
+  l1CheckpointHeaderHash,
+  toL1CheckpointHeader,
+} from '@aztec/stdlib/rollup';
 import { type Traceable, type Tracer, execInSpan, trackSpan } from '@aztec/telemetry-client';
 
 import { InitialCheckpointNumberNotSequentialError } from '../errors.js';
@@ -39,7 +57,35 @@ import { MessageStoreError } from '../store/message_store.js';
 import type { InboxMessage } from '../structs/inbox_message.js';
 import { ArchiverDataStoreUpdater } from './data_store_updater.js';
 import type { ArchiverInstrumentation } from './instrumentation.js';
-import { validateCheckpointAttestations } from './validation.js';
+import { type CheckpointForValidation, validateCheckpointAttestations } from './validation.js';
+
+/** Byte-level equality of two archive roots, regardless of whether each is carried as an Fr or raw Buffer32. */
+function archiveRootsEqual(a: Fr | Buffer32, b: Fr | Buffer32): boolean {
+  return a.toString() === b.toString();
+}
+
+/**
+ * A checkpoint observed on L1 in its raw form, used to validate attestations and classify the checkpoint as
+ * valid/invalid/descendant-of-rejected before any blob fetch or Fr/CheckpointHeader conversion. Either a freshly
+ * retrieved calldata checkpoint or one promoted from local proposed data (already in range).
+ */
+type RawCheckpointEntry = {
+  checkpointNumber: CheckpointNumber;
+  header: L1CheckpointHeader;
+  /** Raw archive root, used for digest/validation; may be out of range. */
+  archiveRoot: Buffer32;
+  /** Archive root normalized to Fr when in range, used for persisted records and emitted events. */
+  normalizedArchiveRoot: Fr | Buffer32;
+  feeAssetPriceModifier: bigint;
+  attestations: CommitteeAttestation[];
+  l1: L1PublishedData;
+  /** `lastArchiveRoot` of this checkpoint (always in range), as Fr, for rejected-ancestor lookups. */
+  lastArchiveRoot: Fr;
+  slotNumber: SlotNumber;
+} & (
+  | { kind: 'calldata'; calldata: RetrievedCheckpointFromCalldata }
+  | { kind: 'promoted'; promoted: PublishedCheckpoint }
+);
 
 type RollupStatus = {
   provenCheckpointNumber: CheckpointNumber;
@@ -678,7 +724,7 @@ export class ArchiverL1Synchronizer implements Traceable {
 
       if (
         localCheckpointForDestinationProvenCheckpointNumber &&
-        provenArchive.equals(localCheckpointForDestinationProvenCheckpointNumber.archive.root)
+        archiveRootsEqual(provenArchive, localCheckpointForDestinationProvenCheckpointNumber.archive.root)
       ) {
         const localProvenCheckpointNumber = await this.stores.blocks.getProvenCheckpointNumber();
         if (localProvenCheckpointNumber !== provenCheckpointNumber) {
@@ -740,7 +786,8 @@ export class ArchiverL1Synchronizer implements Traceable {
         return rollupStatus;
       }
 
-      const localPendingCheckpointInChain = archiveForLocalPendingCheckpointNumber.equals(
+      const localPendingCheckpointInChain = archiveRootsEqual(
+        archiveForLocalPendingCheckpointNumber,
         localPendingCheckpoint.archive.root,
       );
       if (!localPendingCheckpointInChain) {
@@ -768,7 +815,7 @@ export class ArchiverL1Synchronizer implements Traceable {
               archiveLocal: candidateCheckpoint.archive.root.toString(),
             },
           );
-          if (archiveAtContract.equals(candidateCheckpoint.archive.root)) {
+          if (archiveRootsEqual(archiveAtContract, candidateCheckpoint.archive.root)) {
             break;
           }
           tipAfterUnwind--;
@@ -835,37 +882,65 @@ export class ArchiverL1Synchronizer implements Traceable {
       const evictProposedFrom =
         promoteResult && 'diverged' in promoteResult ? promoteResult.fromCheckpointNumber : undefined;
 
-      // Then fetch blobs in parallel and build the full published checkpoints
-      const toFetchBlobs = checkpointToPromote ? calldataCheckpoints.slice(0, -1) : calldataCheckpoints;
-      const blobFetched = await asyncPool(10, toFetchBlobs, async checkpoint =>
-        retrievedToPublishedCheckpoint({
-          ...checkpoint,
-          checkpointBlobData: await getCheckpointBlobDataFromBlobs(
-            this.blobClient,
-            checkpoint.l1.blockHash,
-            checkpoint.blobHashes,
-            checkpoint.checkpointNumber,
-            this.log,
-            !initialSyncComplete,
-            checkpoint.parentBeaconBlockRoot,
-            checkpoint.l1.timestamp,
-          ),
-        }),
-      );
+      // Build the per-checkpoint raw view used for attestation validation. We validate BEFORE building the
+      // PublishedCheckpoint (which requires blob fetch and Fr/CheckpointHeader conversion), so a malicious
+      // out-of-range header/archive is rejected via the normal insufficient/invalid-attestations path
+      // instead of throwing during decode and stalling the L1 sync point (A-1254). The promoted checkpoint
+      // (built from local, in-range proposed data) is folded in via its raw form.
+      const promotedRaw: RawCheckpointEntry[] = checkpointToPromote
+        ? [
+            {
+              kind: 'promoted',
+              checkpointNumber: checkpointToPromote.checkpoint.number,
+              header: toL1CheckpointHeader(checkpointToPromote.checkpoint.header),
+              archiveRoot: Buffer32.fromField(checkpointToPromote.checkpoint.archive.root),
+              normalizedArchiveRoot: checkpointToPromote.checkpoint.archive.root,
+              feeAssetPriceModifier: checkpointToPromote.checkpoint.feeAssetPriceModifier,
+              attestations: checkpointToPromote.attestations,
+              l1: checkpointToPromote.l1,
+              lastArchiveRoot: checkpointToPromote.checkpoint.header.lastArchiveRoot,
+              slotNumber: checkpointToPromote.checkpoint.header.slotNumber,
+              promoted: checkpointToPromote,
+            },
+          ]
+        : [];
+      const calldataRaw: RawCheckpointEntry[] = (
+        checkpointToPromote ? calldataCheckpoints.slice(0, -1) : calldataCheckpoints
+      ).map(checkpoint => ({
+        kind: 'calldata',
+        checkpointNumber: checkpoint.checkpointNumber,
+        header: checkpoint.header,
+        archiveRoot: checkpoint.archiveRoot,
+        normalizedArchiveRoot: archiveFromBuffer(checkpoint.archiveRoot.toBuffer()),
+        feeAssetPriceModifier: checkpoint.feeAssetPriceModifier,
+        attestations: checkpoint.attestations,
+        l1: checkpoint.l1,
+        lastArchiveRoot: Fr.fromString(checkpoint.header.lastArchiveRoot),
+        slotNumber: SlotNumber.fromBigInt(checkpoint.header.slotNumber),
+        calldata: checkpoint,
+      }));
+      // Calldata checkpoints come first (in their L1 order), then the promoted one (the latest tip).
+      const rawCheckpoints: RawCheckpointEntry[] = [...calldataRaw, ...promotedRaw];
 
-      // And add the promoted checkpoint to the list of all checkpoints
-      const publishedCheckpoints = checkpointToPromote ? [...blobFetched, checkpointToPromote] : blobFetched;
       const validCheckpoints: PublishedCheckpoint[] = [];
 
-      // Now loop through all checkpoints and validate their attestations
-      for (const published of publishedCheckpoints) {
+      // Validate attestations and classify each checkpoint before any blob fetch / Fr conversion.
+      for (const raw of rawCheckpoints) {
+        const validationInput: CheckpointForValidation = {
+          checkpointNumber: raw.checkpointNumber,
+          header: raw.header,
+          archiveRoot: raw.archiveRoot,
+          feeAssetPriceModifier: raw.feeAssetPriceModifier,
+          attestations: raw.attestations,
+        };
+
         // Check the attestations uploaded by the publisher to L1 are correct
         // Rollup contract does not validate attestations to save on gas, so this
         // falls on the nodes to verify offchain and skip those checkpoints.
         const validationResult = this.config.skipValidateCheckpointAttestations
           ? { valid: true as const }
           : await validateCheckpointAttestations(
-              published,
+              validationInput,
               this.epochCache,
               this.l1Constants,
               this.getSignatureContext(),
@@ -876,9 +951,7 @@ export class ArchiverL1Synchronizer implements Traceable {
         // this, addCheckpoints would throw InitialCheckpointNumberNotSequentialError when the
         // ancestor was skipped earlier (e.g. due to invalid attestations), the catch handler
         // would roll back the L1 sync point, and the next iteration would re-fetch and re-throw.
-        const rejectedAncestor = await this.stores.blocks.getRejectedCheckpointByArchiveRoot(
-          published.checkpoint.header.lastArchiveRoot,
-        );
+        const rejectedAncestor = await this.stores.blocks.getRejectedCheckpointByArchiveRoot(raw.lastArchiveRoot);
 
         // Update the validation result if it has changed, so we can keep track of the first invalid checkpoint
         // in case there is a sequence of more than one invalid checkpoint, as we need to invalidate the first one.
@@ -899,9 +972,9 @@ export class ArchiverL1Synchronizer implements Traceable {
         }
 
         if (!validationResult.valid) {
-          this.log.warn(`Skipping checkpoint ${published.checkpoint.number} due to invalid attestations`, {
-            checkpointHash: published.checkpoint.hash(),
-            l1BlockNumber: published.l1.blockNumber,
+          this.log.warn(`Skipping checkpoint ${raw.checkpointNumber} due to invalid attestations`, {
+            checkpointNumber: raw.checkpointNumber,
+            l1BlockNumber: raw.l1.blockNumber,
             ...pick(validationResult, 'reason'),
           });
 
@@ -915,11 +988,11 @@ export class ArchiverL1Synchronizer implements Traceable {
           // is detected and skipped (rather than tripping the addCheckpoints consecutive-number
           // check and causing the sync point to roll back in a loop).
           await this.stores.blocks.addRejectedCheckpoint({
-            checkpointNumber: published.checkpoint.number,
-            archiveRoot: published.checkpoint.archive.root,
-            parentArchiveRoot: published.checkpoint.header.lastArchiveRoot,
-            slotNumber: published.checkpoint.header.slotNumber,
-            l1: published.l1,
+            checkpointNumber: raw.checkpointNumber,
+            archiveRoot: raw.normalizedArchiveRoot,
+            parentArchiveRoot: raw.lastArchiveRoot,
+            slotNumber: raw.slotNumber,
+            l1: raw.l1,
             reason: 'invalid-attestations' as const,
           });
 
@@ -927,15 +1000,20 @@ export class ArchiverL1Synchronizer implements Traceable {
         }
 
         if (rejectedAncestor) {
-          const descendantInfo = published.checkpoint.toCheckpointInfo();
+          const descendantInfo: CheckpointInfo = {
+            archive: raw.normalizedArchiveRoot,
+            lastArchive: raw.lastArchiveRoot,
+            slotNumber: raw.slotNumber,
+            checkpointNumber: raw.checkpointNumber,
+            timestamp: raw.header.timestamp,
+          };
           this.log.warn(
-            `Skipping checkpoint ${published.checkpoint.number} as it is a descendant of ` +
+            `Skipping checkpoint ${raw.checkpointNumber} as it is a descendant of ` +
               `rejected checkpoint ${rejectedAncestor.checkpointNumber} (${rejectedAncestor.reason})`,
             {
-              checkpointNumber: published.checkpoint.number,
-              checkpointHash: published.checkpoint.hash(),
-              l1BlockNumber: published.l1.blockNumber,
-              l1BlockHash: published.l1.blockHash,
+              checkpointNumber: raw.checkpointNumber,
+              l1BlockNumber: raw.l1.blockNumber,
+              l1BlockHash: raw.l1.blockHash,
               ancestorCheckpointNumber: rejectedAncestor.checkpointNumber,
               ancestorArchiveRoot: rejectedAncestor.archiveRoot.toString(),
               ancestorReason: rejectedAncestor.reason,
@@ -952,15 +1030,48 @@ export class ArchiverL1Synchronizer implements Traceable {
           // Persist this chainpoint as rejected as well, so we can construct a chain of
           // skipped checkpoints starting from the first one with invalid attestations.
           await this.stores.blocks.addRejectedCheckpoint({
-            checkpointNumber: published.checkpoint.number,
-            archiveRoot: published.checkpoint.archive.root,
-            parentArchiveRoot: published.checkpoint.header.lastArchiveRoot,
-            slotNumber: published.checkpoint.header.slotNumber,
-            l1: published.l1,
+            checkpointNumber: raw.checkpointNumber,
+            archiveRoot: raw.normalizedArchiveRoot,
+            parentArchiveRoot: raw.lastArchiveRoot,
+            slotNumber: raw.slotNumber,
+            l1: raw.l1,
             reason: 'descends-from-invalid-attestations' as const,
           });
 
           continue;
+        }
+
+        // Build the full PublishedCheckpoint for a checkpoint that passed validation. This is the ingestion
+        // boundary where the raw header/archive root are converted to CheckpointHeader/Fr. Because attestations
+        // validated, an out-of-range field here means a committee quorum signed an out-of-range header — a
+        // catastrophic, Fix-2-unreachable state we deliberately surface (fail loud) rather than recover from.
+        let published: PublishedCheckpoint;
+        try {
+          published =
+            raw.kind === 'promoted'
+              ? raw.promoted
+              : await retrievedToPublishedCheckpoint({
+                  ...raw.calldata,
+                  checkpointBlobData: await getCheckpointBlobDataFromBlobs(
+                    this.blobClient,
+                    raw.calldata.l1.blockHash,
+                    raw.calldata.blobHashes,
+                    raw.calldata.checkpointNumber,
+                    this.log,
+                    !initialSyncComplete,
+                    raw.calldata.parentBeaconBlockRoot,
+                    raw.calldata.l1.timestamp,
+                  ),
+                });
+        } catch (err) {
+          if (isErrorClass(err, OutOfRangeFieldError)) {
+            this.log.fatal(
+              `Checkpoint ${raw.checkpointNumber} carries out-of-range header/archive fields yet its attestations ` +
+                `validated. A committee quorum signed an out-of-range header — refusing to ingest.`,
+              { checkpointNumber: raw.checkpointNumber, fields: err.fields, l1BlockNumber: raw.l1.blockNumber },
+            );
+          }
+          throw err;
         }
 
         // Check the inHash of the checkpoint against the l1->l2 messages.
@@ -1095,7 +1206,10 @@ export class ArchiverL1Synchronizer implements Traceable {
         });
       }
       lastRetrievedCheckpoint = validCheckpoints.at(-1) ?? lastRetrievedCheckpoint;
-      lastSeenCheckpoint = publishedCheckpoints.at(-1) ?? lastSeenCheckpoint;
+      // Invalid checkpoints are no longer built into PublishedCheckpoints; they are persisted as rejected
+      // entries, so the reorg fallback in checkForNewCheckpointsBeforeL1SyncPoint recovers their L1 block via
+      // getLatestRejectedCheckpointNumber / getRejectedCheckpointByNumber.
+      lastSeenCheckpoint = validCheckpoints.at(-1) ?? lastSeenCheckpoint;
     } while (searchEndBlock < currentL1BlockNumber);
 
     // Important that we update AFTER inserting the blocks.
@@ -1125,9 +1239,13 @@ export class ArchiverL1Synchronizer implements Traceable {
       return undefined;
     }
 
+    // The calldata header is raw (L1CheckpointHeader) and may be out of range; compare by header hash and
+    // archive root bytes rather than converting it into a CheckpointHeader (which could throw).
     if (
-      !proposed.header.equals(calldataCheckpoint.header) ||
-      !proposed.archive.root.equals(calldataCheckpoint.archiveRoot)
+      !l1CheckpointHeaderHash(toL1CheckpointHeader(proposed.header)).equals(
+        l1CheckpointHeaderHash(calldataCheckpoint.header),
+      ) ||
+      !archiveRootsEqual(proposed.archive.root, calldataCheckpoint.archiveRoot)
     ) {
       this.log.warn(
         `Local proposed checkpoint ${proposed.checkpointNumber} does not match checkpoint retrieved from L1, overriding with L1 data`,
@@ -1136,7 +1254,7 @@ export class ArchiverL1Synchronizer implements Traceable {
           proposedHeader: proposed.header.toInspect(),
           proposedArchiveRoot: proposed.archive.root.toString(),
           calldataCheckpointNumber: calldataCheckpoint.checkpointNumber,
-          calldataHeader: calldataCheckpoint.header.toInspect(),
+          calldataHeader: calldataCheckpoint.header,
           calldataArchiveRoot: calldataCheckpoint.archiveRoot.toString(),
         },
       );
@@ -1144,10 +1262,10 @@ export class ArchiverL1Synchronizer implements Traceable {
       // slot proposer; emit a divergence event so the slasher can attribute equivocation.
       // Only emit when the slots match — uncheckpointed entries are pruned above so this
       // should always hold, but guard defensively to avoid mis-attributing a slash.
-      if (proposed.header.slotNumber === calldataCheckpoint.header.slotNumber) {
+      if (BigInt(proposed.header.slotNumber) === calldataCheckpoint.header.slotNumber) {
         this.events.emit(L2BlockSourceEvents.CheckpointEquivocationDetected, {
           type: L2BlockSourceEvents.CheckpointEquivocationDetected,
-          slotNumber: calldataCheckpoint.header.slotNumber,
+          slotNumber: SlotNumber.fromBigInt(calldataCheckpoint.header.slotNumber),
           checkpointNumber: calldataCheckpoint.checkpointNumber,
           l1ArchiveRoot: calldataCheckpoint.archiveRoot,
           proposedArchiveRoot: proposed.archive.root,
@@ -1204,13 +1322,15 @@ export class ArchiverL1Synchronizer implements Traceable {
     const { lastSeenCheckpoint, pendingCheckpointNumber } = status;
     // Compare the last checkpoint (valid or not) we have (either retrieved in this round or loaded from store)
     // with what the rollup contract told us was the latest one (pinned at the currentL1BlockNumber).
+    // Invalid checkpoints are persisted as rejected entries (not as PublishedCheckpoints), so the latest
+    // rejected number must always be folded in — otherwise a freshly-rejected tip would be treated as
+    // "behind L1" and trigger a spurious sync-point rollback.
     const latestLocalCheckpointNumber =
-      lastSeenCheckpoint?.checkpoint.number ??
       CheckpointNumber.max(
+        lastSeenCheckpoint?.checkpoint.number ?? CheckpointNumber.ZERO,
         await this.stores.blocks.getLatestCheckpointNumber(),
         await this.stores.blocks.getLatestRejectedCheckpointNumber(),
-      ) ??
-      CheckpointNumber.ZERO;
+      ) ?? CheckpointNumber.ZERO;
 
     if (latestLocalCheckpointNumber < pendingCheckpointNumber) {
       // Here we have consumed all logs until the `currentL1Block` we pinned at the beginning of the archiver loop,

--- a/yarn-project/archiver/src/modules/l1_synchronizer.ts
+++ b/yarn-project/archiver/src/modules/l1_synchronizer.ts
@@ -79,8 +79,12 @@ type RawCheckpointEntry = {
   feeAssetPriceModifier: bigint;
   attestations: CommitteeAttestation[];
   l1: L1PublishedData;
-  /** `lastArchiveRoot` of this checkpoint (always in range), as Fr, for rejected-ancestor lookups. */
-  lastArchiveRoot: Fr;
+  /**
+   * `lastArchiveRoot` of this checkpoint, used for rejected-ancestor lookups. Carried as `Fr | Buffer32`
+   * because a checkpoint can build on an out-of-range archive root (it equals the prior checkpoint's stored
+   * archive), so converting it eagerly would throw and stall the L1 sync point.
+   */
+  lastArchiveRoot: Fr | Buffer32;
   slotNumber: SlotNumber;
 } & (
   | { kind: 'calldata'; calldata: RetrievedCheckpointFromCalldata }
@@ -915,7 +919,7 @@ export class ArchiverL1Synchronizer implements Traceable {
         feeAssetPriceModifier: checkpoint.feeAssetPriceModifier,
         attestations: checkpoint.attestations,
         l1: checkpoint.l1,
-        lastArchiveRoot: Fr.fromString(checkpoint.header.lastArchiveRoot),
+        lastArchiveRoot: Buffer32.fromString(checkpoint.header.lastArchiveRoot),
         slotNumber: SlotNumber.fromBigInt(checkpoint.header.slotNumber),
         calldata: checkpoint,
       }));

--- a/yarn-project/archiver/src/modules/l1_synchronizer.ts
+++ b/yarn-project/archiver/src/modules/l1_synchronizer.ts
@@ -885,7 +885,7 @@ export class ArchiverL1Synchronizer implements Traceable {
       // Build the per-checkpoint raw view used for attestation validation. We validate BEFORE building the
       // PublishedCheckpoint (which requires blob fetch and Fr/CheckpointHeader conversion), so a malicious
       // out-of-range header/archive is rejected via the normal insufficient/invalid-attestations path
-      // instead of throwing during decode and stalling the L1 sync point (A-1254). The promoted checkpoint
+      // instead of throwing during decode and stalling the L1 sync point. The promoted checkpoint
       // (built from local, in-range proposed data) is folded in via its raw form.
       const promotedRaw: RawCheckpointEntry[] = checkpointToPromote
         ? [

--- a/yarn-project/archiver/src/modules/validation.test.ts
+++ b/yarn-project/archiver/src/modules/validation.test.ts
@@ -6,14 +6,30 @@ import { Secp256k1Signer, flipSignature } from '@aztec/foundation/crypto/secp256
 import { Signature } from '@aztec/foundation/eth-signature';
 import { type Logger, createLogger } from '@aztec/foundation/log';
 import { CommitteeAttestation, EthAddress } from '@aztec/stdlib/block';
-import { Checkpoint } from '@aztec/stdlib/checkpoint';
+import { Checkpoint, type PublishedCheckpoint } from '@aztec/stdlib/checkpoint';
+import { toL1CheckpointHeader } from '@aztec/stdlib/rollup';
 import { TEST_COORDINATION_SIGNATURE_CONTEXT } from '@aztec/stdlib/testing';
 
 import { type MockProxy, mock } from 'jest-mock-extended';
 import assert from 'node:assert';
 
 import { makeSignedPublishedCheckpoint } from '../test/mock_structs.js';
-import { getAttestationInfoFromPublishedCheckpoint, validateCheckpointAttestations } from './validation.js';
+import {
+  type CheckpointForValidation,
+  getAttestationInfoFromCheckpoint,
+  validateCheckpointAttestations,
+} from './validation.js';
+
+/** Converts a published checkpoint into the raw shape consumed by validateCheckpointAttestations. */
+function toValidationInput(published: PublishedCheckpoint): CheckpointForValidation {
+  return {
+    checkpointNumber: published.checkpoint.number,
+    header: toL1CheckpointHeader(published.checkpoint.header),
+    archiveRoot: Buffer32.fromField(published.checkpoint.archive.root),
+    feeAssetPriceModifier: published.checkpoint.feeAssetPriceModifier,
+    attestations: published.attestations,
+  };
+}
 
 describe('validateCheckpointAttestations', () => {
   let epochCache: MockProxy<EpochCache>;
@@ -60,7 +76,7 @@ describe('validateCheckpointAttestations', () => {
     it('validates a checkpoint if no committee is found', async () => {
       const checkpoint = await makeCheckpoint([], []);
       const result = await validateCheckpointAttestations(
-        checkpoint,
+        toValidationInput(checkpoint),
         epochCache,
         constants,
         TEST_COORDINATION_SIGNATURE_CONTEXT,
@@ -74,7 +90,7 @@ describe('validateCheckpointAttestations', () => {
     it('validates a checkpoint with no attestations if no committee is found', async () => {
       const checkpoint = await makeCheckpoint(signers, committee);
       const result = await validateCheckpointAttestations(
-        checkpoint,
+        toValidationInput(checkpoint),
         epochCache,
         constants,
         TEST_COORDINATION_SIGNATURE_CONTEXT,
@@ -90,7 +106,7 @@ describe('validateCheckpointAttestations', () => {
       epochCache.isEscapeHatchOpen.mockResolvedValue(true);
       const checkpoint = await makeCheckpoint(signers, committee);
       const result = await validateCheckpointAttestations(
-        checkpoint,
+        toValidationInput(checkpoint),
         epochCache,
         constants,
         TEST_COORDINATION_SIGNATURE_CONTEXT,
@@ -109,14 +125,14 @@ describe('validateCheckpointAttestations', () => {
     it('uses feeAssetPriceModifier when recovering attestors', async () => {
       const checkpoint = await makeCheckpoint(signers.slice(0, 4), committee, 1, 1n);
 
-      const attestationInfos = getAttestationInfoFromPublishedCheckpoint(
-        checkpoint,
+      const attestationInfos = getAttestationInfoFromCheckpoint(
+        toValidationInput(checkpoint),
         TEST_COORDINATION_SIGNATURE_CONTEXT,
       );
       expect(attestationInfos.filter(a => a.status === 'recovered-from-signature').length).toBe(4);
 
       const result = await validateCheckpointAttestations(
-        checkpoint,
+        toValidationInput(checkpoint),
         epochCache,
         constants,
         TEST_COORDINATION_SIGNATURE_CONTEXT,
@@ -128,7 +144,7 @@ describe('validateCheckpointAttestations', () => {
     it('requests committee for the correct epoch', async () => {
       const checkpoint = await makeCheckpoint(signers, committee, 28);
       await validateCheckpointAttestations(
-        checkpoint,
+        toValidationInput(checkpoint),
         epochCache,
         constants,
         TEST_COORDINATION_SIGNATURE_CONTEXT,
@@ -141,7 +157,7 @@ describe('validateCheckpointAttestations', () => {
       const badSigner = Secp256k1Signer.random();
       const checkpoint = await makeCheckpoint([...signers, badSigner], [...committee, badSigner.address]);
       const result = await validateCheckpointAttestations(
-        checkpoint,
+        toValidationInput(checkpoint),
         epochCache,
         constants,
         TEST_COORDINATION_SIGNATURE_CONTEXT,
@@ -159,7 +175,7 @@ describe('validateCheckpointAttestations', () => {
       const checkpoint = await makeCheckpoint(signers.slice(0, 4), committee);
       checkpoint.attestations[1] = new CommitteeAttestation(EthAddress.ZERO, Signature.empty());
       const result = await validateCheckpointAttestations(
-        checkpoint,
+        toValidationInput(checkpoint),
         epochCache,
         constants,
         TEST_COORDINATION_SIGNATURE_CONTEXT,
@@ -187,11 +203,14 @@ describe('validateCheckpointAttestations', () => {
       checkpoint.attestations[0] = new CommitteeAttestation(EthAddress.ZERO, invalidSig);
 
       // Verify that the invalid signature is detected
-      const attestations = getAttestationInfoFromPublishedCheckpoint(checkpoint, TEST_COORDINATION_SIGNATURE_CONTEXT);
+      const attestations = getAttestationInfoFromCheckpoint(
+        toValidationInput(checkpoint),
+        TEST_COORDINATION_SIGNATURE_CONTEXT,
+      );
       expect(attestations[0].status).toBe('invalid-signature');
 
       const result = await validateCheckpointAttestations(
-        checkpoint,
+        toValidationInput(checkpoint),
         epochCache,
         constants,
         TEST_COORDINATION_SIGNATURE_CONTEXT,
@@ -214,11 +233,14 @@ describe('validateCheckpointAttestations', () => {
       checkpoint.attestations[2] = new CommitteeAttestation(original.address, flipped);
 
       // Verify the flipped signature is detected as invalid
-      const attestations = getAttestationInfoFromPublishedCheckpoint(checkpoint, TEST_COORDINATION_SIGNATURE_CONTEXT);
+      const attestations = getAttestationInfoFromCheckpoint(
+        toValidationInput(checkpoint),
+        TEST_COORDINATION_SIGNATURE_CONTEXT,
+      );
       expect(attestations[2].status).toBe('invalid-signature');
 
       const result = await validateCheckpointAttestations(
-        checkpoint,
+        toValidationInput(checkpoint),
         epochCache,
         constants,
         TEST_COORDINATION_SIGNATURE_CONTEXT,
@@ -244,7 +266,7 @@ describe('validateCheckpointAttestations', () => {
       // Index 2 is a valid attestation from signers[2]
 
       const result = await validateCheckpointAttestations(
-        checkpoint,
+        toValidationInput(checkpoint),
         epochCache,
         constants,
         TEST_COORDINATION_SIGNATURE_CONTEXT,
@@ -258,7 +280,7 @@ describe('validateCheckpointAttestations', () => {
     it('returns false if insufficient attestations', async () => {
       const checkpoint = await makeCheckpoint(signers.slice(0, 2), committee);
       const result = await validateCheckpointAttestations(
-        checkpoint,
+        toValidationInput(checkpoint),
         epochCache,
         constants,
         TEST_COORDINATION_SIGNATURE_CONTEXT,
@@ -274,7 +296,7 @@ describe('validateCheckpointAttestations', () => {
     it('returns true if all attestations are valid and sufficient', async () => {
       const checkpoint = await makeCheckpoint(signers.slice(0, 4), committee);
       const result = await validateCheckpointAttestations(
-        checkpoint,
+        toValidationInput(checkpoint),
         epochCache,
         constants,
         TEST_COORDINATION_SIGNATURE_CONTEXT,
@@ -294,7 +316,7 @@ describe('validateCheckpointAttestations', () => {
       checkpoint.attestations[2] = temp;
 
       const result = await validateCheckpointAttestations(
-        checkpoint,
+        toValidationInput(checkpoint),
         epochCache,
         constants,
         TEST_COORDINATION_SIGNATURE_CONTEXT,
@@ -313,7 +335,7 @@ describe('validateCheckpointAttestations', () => {
       epochCache.isEscapeHatchOpen.mockResolvedValue(true);
       const checkpoint = await makeCheckpoint(signers, committee);
       const result = await validateCheckpointAttestations(
-        checkpoint,
+        toValidationInput(checkpoint),
         epochCache,
         constants,
         TEST_COORDINATION_SIGNATURE_CONTEXT,

--- a/yarn-project/archiver/src/modules/validation.ts
+++ b/yarn-project/archiver/src/modules/validation.ts
@@ -1,8 +1,7 @@
 import type { EpochCache } from '@aztec/epoch-cache';
 import { CheckpointNumber, EpochNumber, SlotNumber } from '@aztec/foundation/branded-types';
-import type { Buffer32 } from '@aztec/foundation/buffer';
+import { Buffer32 } from '@aztec/foundation/buffer';
 import { compactArray } from '@aztec/foundation/collection';
-import { Fr } from '@aztec/foundation/curves/bn254';
 import type { Logger } from '@aztec/foundation/log';
 import {
   type AttestationInfo,
@@ -32,23 +31,15 @@ export type CheckpointForValidation = {
   attestations: CommitteeAttestation[];
 };
 
-/** Builds the CheckpointInfo identifying a (possibly out-of-range) raw checkpoint. */
+/** Builds the CheckpointInfo identifying a (possibly out-of-range) raw checkpoint. Archive roots stay as raw bytes. */
 function toCheckpointInfo(checkpoint: CheckpointForValidation, header: L1CheckpointHeader): CheckpointInfo {
   return {
     archive: checkpoint.archiveRoot,
-    lastArchive: lastArchiveRootToFr(header.lastArchiveRoot),
+    lastArchive: Buffer32.fromString(header.lastArchiveRoot),
     slotNumber: SlotNumber.fromBigInt(header.slotNumber),
     checkpointNumber: checkpoint.checkpointNumber,
     timestamp: header.timestamp,
   };
-}
-
-/**
- * Returns the `lastArchiveRoot` as an `Fr`. `lastArchiveRoot` is forced equal to the on-chain tip archive,
- * which is always field-reduced once it has been stored, so this is in range in practice; we reduce defensively.
- */
-function lastArchiveRootToFr(lastArchiveRoot: `0x${string}`): Fr {
-  return Fr.fromBufferReduce(Buffer.from(lastArchiveRoot.slice(2).padStart(64, '0'), 'hex'));
 }
 
 /**

--- a/yarn-project/archiver/src/modules/validation.ts
+++ b/yarn-project/archiver/src/modules/validation.ts
@@ -1,29 +1,71 @@
 import type { EpochCache } from '@aztec/epoch-cache';
-import { EpochNumber } from '@aztec/foundation/branded-types';
+import { CheckpointNumber, EpochNumber, SlotNumber } from '@aztec/foundation/branded-types';
+import type { Buffer32 } from '@aztec/foundation/buffer';
 import { compactArray } from '@aztec/foundation/collection';
+import { Fr } from '@aztec/foundation/curves/bn254';
 import type { Logger } from '@aztec/foundation/log';
 import {
   type AttestationInfo,
+  type CommitteeAttestation,
   type ValidateCheckpointNegativeResult,
   type ValidateCheckpointResult,
-  getAttestationInfoFromPayload,
+  getAttestationInfoFromDigest,
 } from '@aztec/stdlib/block';
-import type { PublishedCheckpoint } from '@aztec/stdlib/checkpoint';
+import { type CheckpointInfo, computeCheckpointPayloadDigest } from '@aztec/stdlib/checkpoint';
 import { type L1RollupConstants, computeQuorum, getEpochAtSlot } from '@aztec/stdlib/epoch-helpers';
-import { ConsensusPayload, type CoordinationSignatureContext } from '@aztec/stdlib/p2p';
+import type { CoordinationSignatureContext } from '@aztec/stdlib/p2p';
+import { type L1CheckpointHeader, l1CheckpointHeaderHash } from '@aztec/stdlib/rollup';
 
 export type { ValidateCheckpointResult };
 
 /**
- * Extracts attestation information from a published checkpoint.
- * Returns info for each attestation, preserving array indices.
+ * Raw checkpoint data needed to validate attestations. The header and archive root are kept in their raw,
+ * possibly out-of-range form (an `L1CheckpointHeader` and `Buffer32`) so that a malicious out-of-range
+ * field cannot make validation throw — its consensus digest is derived purely from the raw header hash and
+ * raw archive bytes, both of which are always in range (see A-1254).
  */
-export function getAttestationInfoFromPublishedCheckpoint(
-  { checkpoint, attestations }: PublishedCheckpoint,
+export type CheckpointForValidation = {
+  checkpointNumber: CheckpointNumber;
+  header: L1CheckpointHeader;
+  archiveRoot: Buffer32;
+  feeAssetPriceModifier: bigint;
+  attestations: CommitteeAttestation[];
+};
+
+/** Builds the CheckpointInfo identifying a (possibly out-of-range) raw checkpoint. */
+function toCheckpointInfo(checkpoint: CheckpointForValidation, header: L1CheckpointHeader): CheckpointInfo {
+  return {
+    archive: checkpoint.archiveRoot,
+    lastArchive: lastArchiveRootToFr(header.lastArchiveRoot),
+    slotNumber: SlotNumber.fromBigInt(header.slotNumber),
+    checkpointNumber: checkpoint.checkpointNumber,
+    timestamp: header.timestamp,
+  };
+}
+
+/**
+ * Returns the `lastArchiveRoot` as an `Fr`. `lastArchiveRoot` is forced equal to the on-chain tip archive,
+ * which is always field-reduced once it has been stored, so this is in range in practice; we reduce defensively.
+ */
+function lastArchiveRootToFr(lastArchiveRoot: `0x${string}`): Fr {
+  return Fr.fromBufferReduce(Buffer.from(lastArchiveRoot.slice(2).padStart(64, '0'), 'hex'));
+}
+
+/**
+ * Extracts attestation information from a raw checkpoint, recovering signers against the consensus digest
+ * built from the raw header hash and raw archive root.
+ */
+export function getAttestationInfoFromCheckpoint(
+  checkpoint: CheckpointForValidation,
   signatureContext: CoordinationSignatureContext,
 ): AttestationInfo[] {
-  const payload = ConsensusPayload.fromCheckpoint(checkpoint, signatureContext);
-  return getAttestationInfoFromPayload(payload, attestations);
+  const hashedPayload = computeCheckpointPayloadDigest({
+    headerHash: l1CheckpointHeaderHash(checkpoint.header),
+    archiveRoot: checkpoint.archiveRoot,
+    feeAssetPriceModifier: checkpoint.feeAssetPriceModifier,
+    signatureContext,
+  });
+  return getAttestationInfoFromDigest(hashedPayload, checkpoint.attestations);
 }
 
 /**
@@ -31,28 +73,31 @@ export function getAttestationInfoFromPublishedCheckpoint(
  * Returns true if the attestations are valid and sufficient, false otherwise.
  */
 export async function validateCheckpointAttestations(
-  publishedCheckpoint: PublishedCheckpoint,
+  checkpoint: CheckpointForValidation,
   epochCache: EpochCache,
   constants: Pick<L1RollupConstants, 'epochDuration'>,
   signatureContext: CoordinationSignatureContext,
   logger?: Logger,
 ): Promise<ValidateCheckpointResult> {
-  const attestorInfos = getAttestationInfoFromPublishedCheckpoint(publishedCheckpoint, signatureContext);
+  const { header, attestations } = checkpoint;
+  const attestorInfos = getAttestationInfoFromCheckpoint(checkpoint, signatureContext);
   const attestors = compactArray(attestorInfos.map(info => ('address' in info ? info.address : undefined)));
-  const { checkpoint, attestations } = publishedCheckpoint;
-  const headerHash = checkpoint.header.hash();
-  const archiveRoot = checkpoint.archive.root.toString();
-  const slot = checkpoint.header.slotNumber;
+  const headerHash = l1CheckpointHeaderHash(header);
+  const archiveRoot = checkpoint.archiveRoot.toString();
+  const slot = SlotNumber.fromBigInt(header.slotNumber);
   const epoch: EpochNumber = getEpochAtSlot(slot, constants);
   const { committee, seed } = await epochCache.getCommitteeForEpoch(epoch);
-  const logData = { checkpointNumber: checkpoint.number, slot, epoch, headerHash, archiveRoot };
+  const logData = { checkpointNumber: checkpoint.checkpointNumber, slot, epoch, headerHash, archiveRoot };
 
-  logger?.debug(`Validating attestations for checkpoint ${checkpoint.number} at slot ${slot} in epoch ${epoch}`, {
-    committee: (committee ?? []).map(member => member.toString()),
-    recoveredAttestors: attestorInfos,
-    postedAttestations: attestations.map(a => (a.address.isZero() ? a.signature : a.address).toString()),
-    ...logData,
-  });
+  logger?.debug(
+    `Validating attestations for checkpoint ${checkpoint.checkpointNumber} at slot ${slot} in epoch ${epoch}`,
+    {
+      committee: (committee ?? []).map(member => member.toString()),
+      recoveredAttestors: attestorInfos,
+      postedAttestations: attestations.map(a => (a.address.isZero() ? a.signature : a.address).toString()),
+      ...logData,
+    },
+  );
 
   if (!committee || committee.length === 0) {
     logger?.warn(
@@ -72,7 +117,7 @@ export async function validateCheckpointAttestations(
   const failedValidationResult = <TReason extends ValidateCheckpointNegativeResult['reason']>(reason: TReason) => ({
     valid: false as const,
     reason,
-    checkpoint: checkpoint.toCheckpointInfo(),
+    checkpoint: toCheckpointInfo(checkpoint, header),
     committee,
     seed,
     epoch,
@@ -123,7 +168,7 @@ export async function validateCheckpointAttestations(
   }
 
   logger?.debug(
-    `Checkpoint attestations validated successfully for checkpoint ${checkpoint.number} at slot ${slot}`,
+    `Checkpoint attestations validated successfully for checkpoint ${checkpoint.checkpointNumber} at slot ${slot}`,
     logData,
   );
   return { valid: true };

--- a/yarn-project/archiver/src/modules/validation.ts
+++ b/yarn-project/archiver/src/modules/validation.ts
@@ -22,7 +22,7 @@ export type { ValidateCheckpointResult };
  * Raw checkpoint data needed to validate attestations. The header and archive root are kept in their raw,
  * possibly out-of-range form (an `L1CheckpointHeader` and `Buffer32`) so that a malicious out-of-range
  * field cannot make validation throw — its consensus digest is derived purely from the raw header hash and
- * raw archive bytes, both of which are always in range (see A-1254).
+ * raw archive bytes, both of which are always in range.
  */
 export type CheckpointForValidation = {
   checkpointNumber: CheckpointNumber;

--- a/yarn-project/archiver/src/store/block_store.test.ts
+++ b/yarn-project/archiver/src/store/block_store.test.ts
@@ -6,6 +6,7 @@ import {
   IndexWithinCheckpoint,
   SlotNumber,
 } from '@aztec/foundation/branded-types';
+import { Buffer32 } from '@aztec/foundation/buffer';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { sleep } from '@aztec/foundation/sleep';
 import { openTmpStore } from '@aztec/kv-store/lmdb-v2';
@@ -2898,10 +2899,12 @@ describe('BlockStore', () => {
   });
 
   describe('rejected checkpoints', () => {
-    const makeEntry = (overrides: { archiveRoot?: Fr; l1BlockNumber?: number; checkpointNumber?: number } = {}) => ({
+    const makeEntry = (
+      overrides: { archiveRoot?: Buffer32; l1BlockNumber?: number; checkpointNumber?: number } = {},
+    ) => ({
       checkpointNumber: CheckpointNumber(overrides.checkpointNumber ?? 1),
-      archiveRoot: overrides.archiveRoot ?? Fr.random(),
-      parentArchiveRoot: Fr.random(),
+      archiveRoot: overrides.archiveRoot ?? Buffer32.fromField(Fr.random()),
+      parentArchiveRoot: Buffer32.fromField(Fr.random()),
       slotNumber: SlotNumber(1),
       l1: makeL1PublishedData(overrides.l1BlockNumber ?? 100),
       reason: 'invalid-attestations' as const,
@@ -2930,7 +2933,7 @@ describe('BlockStore', () => {
     });
 
     it('updates an existing entry when re-added with the same archive root', async () => {
-      const archiveRoot = Fr.random();
+      const archiveRoot = Buffer32.fromField(Fr.random());
       await blockStore.addRejectedCheckpoint(makeEntry({ archiveRoot, l1BlockNumber: 100 }));
       await blockStore.addRejectedCheckpoint(makeEntry({ archiveRoot, l1BlockNumber: 110 }));
 

--- a/yarn-project/archiver/src/store/block_store.ts
+++ b/yarn-project/archiver/src/store/block_store.ts
@@ -1,5 +1,6 @@
 import { INITIAL_CHECKPOINT_NUMBER, INITIAL_L2_BLOCK_NUM } from '@aztec/constants';
 import { BlockNumber, CheckpointNumber, IndexWithinCheckpoint, SlotNumber } from '@aztec/foundation/branded-types';
+import { Buffer32 } from '@aztec/foundation/buffer';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { toArray } from '@aztec/foundation/iterable';
 import { createLogger } from '@aztec/foundation/log';
@@ -84,8 +85,11 @@ export type RejectedCheckpointReason = 'invalid-attestations' | 'descends-from-i
 export type RejectedCheckpoint = {
   /** Checkpoint number this entry represents. */
   checkpointNumber: CheckpointNumber;
-  /** Archive root produced by this rejected checkpoint (matched against descendants' `lastArchiveRoot`). */
-  archiveRoot: Fr;
+  /**
+   * Archive root produced by this rejected checkpoint (matched against descendants' `lastArchiveRoot`).
+   * `Fr | Buffer32` so a checkpoint rejected for an out-of-range archive root is still recordable (A-1254).
+   */
+  archiveRoot: Fr | Buffer32;
   /** `lastArchiveRoot` from this checkpoint's header (the ancestor it built on). */
   parentArchiveRoot: Fr;
   /** Slot number of the rejected checkpoint. */
@@ -1463,7 +1467,7 @@ export class BlockStore {
   }
 
   /** Returns the rejected-checkpoint entry with the given archive root, or undefined if not present. */
-  async getRejectedCheckpointByArchiveRoot(archiveRoot: Fr): Promise<RejectedCheckpoint | undefined> {
+  async getRejectedCheckpointByArchiveRoot(archiveRoot: Fr | Buffer32): Promise<RejectedCheckpoint | undefined> {
     const stored = await this.#rejectedCheckpoints.getAsync(archiveRoot.toString());
     return stored ? this.rejectedCheckpointFromStorage(stored) : undefined;
   }
@@ -1485,7 +1489,7 @@ export class BlockStore {
   }
 
   /** Removes a rejected-checkpoint entry by its archive root (used when an entry no longer matches L1). */
-  async removeRejectedCheckpointByArchiveRoot(archiveRoot: Fr): Promise<void> {
+  async removeRejectedCheckpointByArchiveRoot(archiveRoot: Fr | Buffer32): Promise<void> {
     const archiveRootHex = archiveRoot.toString();
     const stored = await this.#rejectedCheckpoints.getAsync(archiveRootHex);
     await this.#rejectedCheckpoints.delete(archiveRootHex);
@@ -1515,7 +1519,11 @@ export class BlockStore {
   private rejectedCheckpointFromStorage(stored: RejectedCheckpointStorage): RejectedCheckpoint {
     return {
       checkpointNumber: CheckpointNumber(stored.checkpointNumber),
-      archiveRoot: Fr.fromBuffer(stored.archiveRoot),
+      // The archive root may be out of the BN254 field; keep it as Buffer32 in that case rather than throwing.
+      archiveRoot:
+        BigInt(`0x${stored.archiveRoot.toString('hex')}`) < Fr.MODULUS
+          ? Fr.fromBuffer(stored.archiveRoot)
+          : Buffer32.fromBuffer(stored.archiveRoot),
       parentArchiveRoot: Fr.fromBuffer(stored.parentArchiveRoot),
       slotNumber: SlotNumber(stored.slotNumber),
       l1: L1PublishedData.fromBuffer(stored.l1),

--- a/yarn-project/archiver/src/store/block_store.ts
+++ b/yarn-project/archiver/src/store/block_store.ts
@@ -90,8 +90,11 @@ export type RejectedCheckpoint = {
    * `Fr | Buffer32` so a checkpoint rejected for an out-of-range archive root is still recordable.
    */
   archiveRoot: Fr | Buffer32;
-  /** `lastArchiveRoot` from this checkpoint's header (the ancestor it built on). */
-  parentArchiveRoot: Fr;
+  /**
+   * `lastArchiveRoot` from this checkpoint's header (the ancestor it built on). `Fr | Buffer32` because a
+   * rejected checkpoint can build on an out-of-range archive root.
+   */
+  parentArchiveRoot: Fr | Buffer32;
   /** Slot number of the rejected checkpoint. */
   slotNumber: SlotNumber;
   /** L1 publication data for the rejected checkpoint (block number, hash, timestamp). */
@@ -1524,7 +1527,11 @@ export class BlockStore {
         BigInt(`0x${stored.archiveRoot.toString('hex')}`) < Fr.MODULUS
           ? Fr.fromBuffer(stored.archiveRoot)
           : Buffer32.fromBuffer(stored.archiveRoot),
-      parentArchiveRoot: Fr.fromBuffer(stored.parentArchiveRoot),
+      // The parent archive root may also be out of the BN254 field; keep it as Buffer32 in that case.
+      parentArchiveRoot:
+        BigInt(`0x${stored.parentArchiveRoot.toString('hex')}`) < Fr.MODULUS
+          ? Fr.fromBuffer(stored.parentArchiveRoot)
+          : Buffer32.fromBuffer(stored.parentArchiveRoot),
       slotNumber: SlotNumber(stored.slotNumber),
       l1: L1PublishedData.fromBuffer(stored.l1),
       reason: stored.reason,

--- a/yarn-project/archiver/src/store/block_store.ts
+++ b/yarn-project/archiver/src/store/block_store.ts
@@ -87,7 +87,7 @@ export type RejectedCheckpoint = {
   checkpointNumber: CheckpointNumber;
   /**
    * Archive root produced by this rejected checkpoint (matched against descendants' `lastArchiveRoot`).
-   * `Fr | Buffer32` so a checkpoint rejected for an out-of-range archive root is still recordable (A-1254).
+   * `Fr | Buffer32` so a checkpoint rejected for an out-of-range archive root is still recordable.
    */
   archiveRoot: Fr | Buffer32;
   /** `lastArchiveRoot` from this checkpoint's header (the ancestor it built on). */

--- a/yarn-project/archiver/src/store/block_store.ts
+++ b/yarn-project/archiver/src/store/block_store.ts
@@ -86,15 +86,12 @@ export type RejectedCheckpoint = {
   /** Checkpoint number this entry represents. */
   checkpointNumber: CheckpointNumber;
   /**
-   * Archive root produced by this rejected checkpoint (matched against descendants' `lastArchiveRoot`).
-   * `Fr | Buffer32` so a checkpoint rejected for an out-of-range archive root is still recordable.
+   * Archive root produced by this rejected checkpoint (matched against descendants' `lastArchiveRoot`), as raw
+   * bytes — a checkpoint rejected for an out-of-range archive root has a root that does not fit in `Fr`.
    */
-  archiveRoot: Fr | Buffer32;
-  /**
-   * `lastArchiveRoot` from this checkpoint's header (the ancestor it built on). `Fr | Buffer32` because a
-   * rejected checkpoint can build on an out-of-range archive root.
-   */
-  parentArchiveRoot: Fr | Buffer32;
+  archiveRoot: Buffer32;
+  /** `lastArchiveRoot` from this checkpoint's header (the ancestor it built on), as raw bytes (may be out of range). */
+  parentArchiveRoot: Buffer32;
   /** Slot number of the rejected checkpoint. */
   slotNumber: SlotNumber;
   /** L1 publication data for the rejected checkpoint (block number, hash, timestamp). */
@@ -1522,16 +1519,9 @@ export class BlockStore {
   private rejectedCheckpointFromStorage(stored: RejectedCheckpointStorage): RejectedCheckpoint {
     return {
       checkpointNumber: CheckpointNumber(stored.checkpointNumber),
-      // The archive root may be out of the BN254 field; keep it as Buffer32 in that case rather than throwing.
-      archiveRoot:
-        BigInt(`0x${stored.archiveRoot.toString('hex')}`) < Fr.MODULUS
-          ? Fr.fromBuffer(stored.archiveRoot)
-          : Buffer32.fromBuffer(stored.archiveRoot),
-      // The parent archive root may also be out of the BN254 field; keep it as Buffer32 in that case.
-      parentArchiveRoot:
-        BigInt(`0x${stored.parentArchiveRoot.toString('hex')}`) < Fr.MODULUS
-          ? Fr.fromBuffer(stored.parentArchiveRoot)
-          : Buffer32.fromBuffer(stored.parentArchiveRoot),
+      // Archive roots are stored as raw bytes and may be out of the BN254 field; keep them as Buffer32.
+      archiveRoot: Buffer32.fromBuffer(stored.archiveRoot),
+      parentArchiveRoot: Buffer32.fromBuffer(stored.parentArchiveRoot),
       slotNumber: SlotNumber(stored.slotNumber),
       l1: L1PublishedData.fromBuffer(stored.l1),
       reason: stored.reason,

--- a/yarn-project/archiver/src/test/fake_l1_state.ts
+++ b/yarn-project/archiver/src/test/fake_l1_state.ts
@@ -83,6 +83,12 @@ type AddCheckpointOptions = {
    * header without throwing and rejects it via insufficient/invalid attestations.
    */
   injectOutOfRangeAccumulatedFees?: bigint;
+  /**
+   * If set, the propose calldata carries a header whose `lastArchiveRoot` is the given out-of-range value
+   * (e.g. `2n ** 256n - 1n`), simulating a checkpoint built on a prior out-of-range archive root. Exercises the
+   * synchronizer's eager raw-header decode path, which must carry the field as raw bytes rather than throw.
+   */
+  injectOutOfRangeLastArchiveRoot?: bigint;
 };
 
 /** Result from adding a checkpoint. */
@@ -224,6 +230,7 @@ export class FakeL1State {
       checkpoint,
       signers,
       options.injectOutOfRangeAccumulatedFees,
+      options.injectOutOfRangeLastArchiveRoot,
     );
     const blobHashes = await this.makeVersionedBlobHashes(checkpoint);
     const blobs = await this.makeBlobsFromCheckpoint(checkpoint);
@@ -671,6 +678,7 @@ export class FakeL1State {
     checkpoint: Checkpoint,
     signers: Secp256k1Signer[],
     injectOutOfRangeAccumulatedFees?: bigint,
+    injectOutOfRangeLastArchiveRoot?: bigint,
   ): Promise<{ tx: Transaction; attestationsHash: Buffer32; payloadDigest: Buffer32 }> {
     const signatureContext = this.getSignatureContext();
     const consensusPayload = ConsensusPayload.fromCheckpoint(checkpoint, signatureContext);
@@ -684,6 +692,11 @@ export class FakeL1State {
       // Mirror the malicious-proposer injection: the broadcast calldata carries an out-of-range header field
       // while the clean checkpoint, archive root, and attestations are untouched.
       header.accumulatedFees = injectOutOfRangeAccumulatedFees;
+    }
+    if (injectOutOfRangeLastArchiveRoot !== undefined) {
+      // Same idea for the parent archive root: the raw calldata header carries an out-of-range `lastArchiveRoot`
+      // (the clean checkpoint and attestations are untouched), which the synchronizer must decode without throwing.
+      header.lastArchiveRoot = toHex(injectOutOfRangeLastArchiveRoot, { size: 32 });
     }
     const blobInput = getPrefixedEthBlobCommitments(await getBlobsPerL1Block(checkpoint.toBlobFields()));
     const archive = toHex(checkpoint.archive.root.toBuffer());

--- a/yarn-project/archiver/src/test/fake_l1_state.ts
+++ b/yarn-project/archiver/src/test/fake_l1_state.ts
@@ -12,10 +12,11 @@ import { EthAddress } from '@aztec/foundation/eth-address';
 import { createLogger } from '@aztec/foundation/log';
 import { RollupAbi } from '@aztec/l1-artifacts';
 import { CommitteeAttestation, CommitteeAttestationsAndSigners, L2Block } from '@aztec/stdlib/block';
-import { Checkpoint } from '@aztec/stdlib/checkpoint';
+import { Checkpoint, computeCheckpointPayloadDigest } from '@aztec/stdlib/checkpoint';
 import { getSlotAtTimestamp } from '@aztec/stdlib/epoch-helpers';
 import { InboxLeaf } from '@aztec/stdlib/messaging';
 import { ConsensusPayload, getHashedSignaturePayloadTypedData } from '@aztec/stdlib/p2p';
+import { l1CheckpointHeaderHash, toL1CheckpointHeader } from '@aztec/stdlib/rollup';
 import { mockCheckpointAndMessages } from '@aztec/stdlib/testing';
 import { AppendOnlyTreeSnapshot } from '@aztec/stdlib/trees';
 
@@ -75,6 +76,13 @@ type AddCheckpointOptions = {
   numL1ToL2Messages?: number;
   /** L1 block number where messages were sent. Default: l1BlockNumber - 3 */
   messagesL1BlockNumber?: bigint;
+  /**
+   * If set, the propose calldata carries a header whose `accumulatedFees` is the given out-of-range value
+   * (e.g. `2n ** 256n - 1n`), simulating the A-1254 malicious-proposer attack. The clean checkpoint, its
+   * stored archive root, and the attestation signatures are unchanged, so an honest archiver decodes the raw
+   * header without throwing and rejects it via insufficient/invalid attestations.
+   */
+  injectOutOfRangeAccumulatedFees?: bigint;
 };
 
 /** Result from adding a checkpoint. */
@@ -212,7 +220,11 @@ export class FakeL1State {
     this.addMessages(checkpointNumber, messagesL1BlockNumber, messages);
 
     // Create the transaction, blobs, and event hashes
-    const { tx, attestationsHash, payloadDigest } = await this.makeRollupTx(checkpoint, signers);
+    const { tx, attestationsHash, payloadDigest } = await this.makeRollupTx(
+      checkpoint,
+      signers,
+      options.injectOutOfRangeAccumulatedFees,
+    );
     const blobHashes = await this.makeVersionedBlobHashes(checkpoint);
     const blobs = await this.makeBlobsFromCheckpoint(checkpoint);
 
@@ -397,8 +409,8 @@ export class FakeL1State {
   getRollupStatus(): {
     provenCheckpointNumber: CheckpointNumber;
     pendingCheckpointNumber: CheckpointNumber;
-    provenArchive: Fr;
-    pendingArchive: Fr;
+    provenArchive: Buffer32;
+    pendingArchive: Buffer32;
   } {
     return {
       provenCheckpointNumber: this.provenCheckpointNumber,
@@ -571,9 +583,9 @@ export class FakeL1State {
       .reduce((max, cpData) => (cpData.checkpointNumber > max ? cpData.checkpointNumber : max), CheckpointNumber(0));
   }
 
-  private getArchiveAt(checkpointNumber: CheckpointNumber): Fr {
+  private getArchiveAt(checkpointNumber: CheckpointNumber): Buffer32 {
     if (checkpointNumber === 0) {
-      return this.config.genesisArchiveRoot;
+      return Buffer32.fromField(this.config.genesisArchiveRoot);
     }
     // Find the latest non-pruned entry for this checkpoint number
     const entries = this.checkpoints.filter(cpData => cpData.checkpointNumber === checkpointNumber);
@@ -583,7 +595,7 @@ export class FakeL1State {
       // For pruned or missing checkpoints, return the previous non-pruned checkpoint's archive
       return this.getArchiveAt(CheckpointNumber(checkpointNumber - 1));
     }
-    return latestEntry.checkpoint.archive.root;
+    return Buffer32.fromField(latestEntry.checkpoint.archive.root);
   }
 
   private getNextBlockNumber(checkpointNumber: CheckpointNumber): BlockNumber {
@@ -603,7 +615,7 @@ export class FakeL1State {
         l1TransactionHash: cpData.tx.hash as `0x${string}`,
         args: {
           checkpointNumber: cpData.checkpointNumber,
-          archive: cpData.checkpoint.archive.root,
+          archive: Buffer32.fromField(cpData.checkpoint.archive.root),
           versionedBlobHashes: cpData.blobHashes.map(h => Buffer.from(h.slice(2), 'hex')),
           attestationsHash: cpData.attestationsHash,
           payloadDigest: cpData.payloadDigest,
@@ -658,6 +670,7 @@ export class FakeL1State {
   private async makeRollupTx(
     checkpoint: Checkpoint,
     signers: Secp256k1Signer[],
+    injectOutOfRangeAccumulatedFees?: bigint,
   ): Promise<{ tx: Transaction; attestationsHash: Buffer32; payloadDigest: Buffer32 }> {
     const signatureContext = this.getSignatureContext();
     const consensusPayload = ConsensusPayload.fromCheckpoint(checkpoint, signatureContext);
@@ -666,7 +679,12 @@ export class FakeL1State {
       .map(signer => CommitteeAttestation.fromSignature(signer.sign(attestationDigest)))
       .map(committeeAttestation => committeeAttestation.toViem());
 
-    const header = checkpoint.header.toViem();
+    const header = toL1CheckpointHeader(checkpoint.header);
+    if (injectOutOfRangeAccumulatedFees !== undefined) {
+      // Mirror the malicious-proposer injection: the broadcast calldata carries an out-of-range header field
+      // while the clean checkpoint, archive root, and attestations are untouched.
+      header.accumulatedFees = injectOutOfRangeAccumulatedFees;
+    }
     const blobInput = getPrefixedEthBlobCommitments(await getBlobsPerL1Block(checkpoint.toBlobFields()));
     const archive = toHex(checkpoint.archive.root.toBuffer());
     const attestationsAndSigners = new CommitteeAttestationsAndSigners(
@@ -719,8 +737,14 @@ export class FakeL1State {
       keccak256(encodeAbiParameters([this.getCommitteeAttestationsStructDef()], [packedAttestations])),
     );
 
-    // Compute payloadDigest (same logic as CalldataRetriever)
-    const payloadDigest = getHashedSignaturePayloadTypedData(consensusPayload);
+    // Compute payloadDigest from the (possibly out-of-range) calldata header, matching what the on-chain
+    // CheckpointProposed event would emit for the broadcast header — this is what the archiver verifies against.
+    const payloadDigest = computeCheckpointPayloadDigest({
+      headerHash: l1CheckpointHeaderHash(header),
+      archiveRoot: Buffer32.fromString(archive),
+      feeAssetPriceModifier: 0n,
+      signatureContext,
+    });
 
     const tx = {
       input: multiCallInput,

--- a/yarn-project/archiver/src/test/fake_l1_state.ts
+++ b/yarn-project/archiver/src/test/fake_l1_state.ts
@@ -78,7 +78,7 @@ type AddCheckpointOptions = {
   messagesL1BlockNumber?: bigint;
   /**
    * If set, the propose calldata carries a header whose `accumulatedFees` is the given out-of-range value
-   * (e.g. `2n ** 256n - 1n`), simulating the A-1254 malicious-proposer attack. The clean checkpoint, its
+   * (e.g. `2n ** 256n - 1n`), simulating the out-of-range-header malicious-proposer attack. The clean checkpoint, its
    * stored archive root, and the attestation signatures are unchanged, so an honest archiver decodes the raw
    * header without throwing and rejects it via insufficient/invalid attestations.
    */

--- a/yarn-project/aztec-node/src/aztec-node/node_public_calls_simulator.test.ts
+++ b/yarn-project/aztec-node/src/aztec-node/node_public_calls_simulator.test.ts
@@ -8,6 +8,7 @@ import {
   IndexWithinCheckpoint,
   SlotNumber,
 } from '@aztec/foundation/branded-types';
+import { Buffer32 } from '@aztec/foundation/buffer';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { unfreeze } from '@aztec/foundation/types';
@@ -441,8 +442,8 @@ function makeInvalidStatus(firstInvalid: CheckpointNumber): ValidateCheckpointRe
   return {
     valid: false,
     checkpoint: {
-      archive: Fr.random(),
-      lastArchive: Fr.random(),
+      archive: Buffer32.fromField(Fr.random()),
+      lastArchive: Buffer32.fromField(Fr.random()),
       slotNumber: SlotNumber(10),
       checkpointNumber: firstInvalid,
       timestamp: 0n,

--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_out_of_range_header.test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_out_of_range_header.test.ts
@@ -52,6 +52,12 @@ const VALIDATOR_COUNT = 4;
  * sequencer runs first, lands and corrupts checkpoint 1, and is then stopped before the honest sequencers
  * start. The honest validators recover via the L1-sync invalidation path, which reads the corrupted tip
  * only through the hardened `status()`/`archiveAt()` reads.
+ *
+ * The corruption is deliberately delayed until the honest archivers have ingested checkpoint 1 with its
+ * real in-range archive root and flagged it as under-attested (step 3b). A node only learns the pending
+ * tip is under-attested by ingesting the checkpoint and running attestation validation; once the stored
+ * archive root is corrupted, the archiver drops the checkpoint on an archive-root mismatch before
+ * validating it, so a node that has not yet ingested checkpoint 1 could never detect the under-attestation.
  */
 describe('e2e_epochs/epochs_out_of_range_header', () => {
   let context: EndToEndContext;
@@ -206,6 +212,31 @@ describe('e2e_epochs/epochs_out_of_range_header', () => {
     await test.waitUntilCheckpointNumber(corruptCheckpoint, test.L2_SLOT_DURATION_IN_S * 6);
     expect(await rollupContract.getCheckpointNumber()).toBeGreaterThanOrEqual(corruptCheckpoint);
     logger.warn(`Checkpoint ${corruptCheckpoint} landed on L1.`);
+
+    // 3b. Wait for the honest validators' archivers to ingest checkpoint 1 with its real (in-range) archive root
+    // and flag the pending chain as under-attested, BEFORE we corrupt the stored slot in step 4. This is the
+    // recovery precondition: a node only learns the pending tip is under-attested when its archiver successfully
+    // ingests the checkpoint (its calldata archive matches the stored archive) and runs attestation validation;
+    // it can then invalidate it via the L1-sync path. Once the stored slot is corrupted, the archiver drops
+    // checkpoint 1 on an archive-root mismatch (calldata real root != corrupted stored root) before validating it,
+    // so a node that has not yet ingested it can never detect the under-attestation. waitUntilCheckpointNumber
+    // above only reads the on-chain checkpoint number directly from L1, not any node's archiver, so without this
+    // gate the corruption races the archivers' poll loop and the honest nodes intermittently never invalidate.
+    await retryUntil(
+      async () => {
+        const statuses = await Promise.all(honestNodes.map(n => n.getBlockSource().getPendingChainValidationStatus()));
+        const detected = statuses.filter(s => !s.valid && s.reason === 'insufficient-attestations').length;
+        logger.info(`Honest archivers that flagged checkpoint ${corruptCheckpoint} as under-attested`, {
+          detected,
+          total: honestNodes.length,
+        });
+        return detected === honestNodes.length;
+      },
+      'honest archivers ingest checkpoint 1 and flag it as under-attested before corruption',
+      test.L2_SLOT_DURATION_IN_S * 4,
+      0.5,
+    );
+    logger.warn(`Honest archivers ingested checkpoint ${corruptCheckpoint} and flagged it as under-attested.`);
 
     // 4. Corrupt the stored archive root of checkpoint 1 to an out-of-range value. We do this AFTER it has
     // landed so `propose` (which now reverts on out-of-range fields, PR #24199) has already written the real

--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_out_of_range_header.test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_out_of_range_header.test.ts
@@ -1,0 +1,189 @@
+import type { Archiver } from '@aztec/archiver';
+import type { AztecNodeService } from '@aztec/aztec-node';
+import type { Logger } from '@aztec/aztec.js/log';
+import { RollupContract } from '@aztec/ethereum/contracts';
+import type { ExtendedViemWalletClient } from '@aztec/ethereum/types';
+import { CheckpointNumber } from '@aztec/foundation/branded-types';
+import { retryUntil } from '@aztec/foundation/retry';
+import { sleep } from '@aztec/foundation/sleep';
+import type { SequencerClient } from '@aztec/sequencer-client';
+
+import { jest } from '@jest/globals';
+
+import type { EndToEndContext } from '../fixtures/utils.js';
+import { EpochsTestContext } from './epochs_test.js';
+
+jest.setTimeout(1000 * 60 * 10);
+
+// Reproduces A-1254: a malicious proposer posts a checkpoint whose header carries a uint256 field value above the
+// BN254 scalar field modulus. Honest archivers cannot convert that field back into an Fr while decoding the propose
+// calldata, so their L1 sync throws and never advances past the L1 block where the malicious checkpoint landed,
+// permanently bricking the node.
+//
+// The rollup is deployed with a target committee size of 0 (the default epochs setup with no validators), so
+// ValidatorSelectionLib.verifyProposer skips signature validation on L1. That lets the corrupted header land on L1
+// without forging the proposer signature, while still exercising the exact archiver decode path the issue is about.
+describe('e2e_epochs/epochs_out_of_range_header', () => {
+  let context: EndToEndContext;
+  let logger: Logger;
+  let l1Client: ExtendedViemWalletClient;
+  let rollupContract: RollupContract;
+
+  let test: EpochsTestContext;
+  let maliciousSequencer: SequencerClient;
+  let observerNode: AztecNodeService;
+  let observerArchiver: Archiver;
+
+  beforeEach(async () => {
+    // No validators -> target committee size 0 -> single context sequencer proposes every slot and L1 skips
+    // signature checks. minTxsPerBlock 0 (default) so empty checkpoints build without any txs.
+    test = await EpochsTestContext.setup({
+      numberOfAccounts: 0,
+      aztecProofSubmissionEpochs: 1024,
+      aztecSlotDurationInL1Slots: 3,
+      ethereumSlotDuration: 12,
+      blockDurationMs: 6000,
+      startProverNode: false,
+      minTxsPerBlock: 0,
+    });
+
+    ({ context, logger, l1Client } = test);
+    rollupContract = new RollupContract(l1Client, test.rollup.address);
+    maliciousSequencer = context.sequencer!;
+
+    // Honest observer node: a plain archiver-only node syncing L1, no validator.
+    observerNode = await test.createNonValidatorNode();
+    observerArchiver = observerNode.getBlockSource() as Archiver;
+
+    logger.warn(`Test setup completed.`);
+  });
+
+  afterEach(async () => {
+    jest.restoreAllMocks();
+    await test.teardown();
+  });
+
+  it('honest archiver stalls when a malicious proposer posts an out-of-range checkpoint header', async () => {
+    // 1. Let the chain advance a couple of checkpoints normally and let the observer catch up to them.
+    const goodCheckpointTarget = CheckpointNumber(2);
+    logger.warn(`Phase 1: waiting for ${goodCheckpointTarget} good checkpoints to be mined`);
+    await test.monitor.waitUntilCheckpoint(goodCheckpointTarget);
+
+    logger.warn(`Phase 1: waiting for observer node to sync the good checkpoints`);
+    await retryUntil(
+      async () => {
+        const tips = await observerNode.getChainTips();
+        logger.info(`Observer checkpointed checkpoint=${tips.checkpointed.checkpoint.number}`);
+        return tips.checkpointed.checkpoint.number >= goodCheckpointTarget;
+      },
+      'observer syncs good checkpoints',
+      test.L2_SLOT_DURATION_IN_S * 8,
+      0.5,
+    );
+
+    const preAttackBlockNumber = await observerNode.getBlockNumber();
+    const preAttackL1BlockNumber = observerArchiver.getL1BlockNumber();
+    const preAttackCheckpointNumber = await test.rollup.getCheckpointNumber();
+    logger.warn(`Phase 1 complete: observer synced before attack`, {
+      preAttackBlockNumber,
+      preAttackL1BlockNumber: preAttackL1BlockNumber?.toString(),
+      preAttackCheckpointNumber,
+    });
+
+    // 2. Enable the malicious injection on the proposer. Under proposer pipelining the checkpoint that is built
+    // in the next slot may already have snapshotted the previous (good) config, so the first one or two checkpoints
+    // after this call can still be valid; the injection takes effect once a freshly-built checkpoint is published.
+    logger.warn(`Phase 2: enabling injectOutOfRangeCheckpointHeader on the proposer`);
+    maliciousSequencer.updateConfig({ injectOutOfRangeCheckpointHeader: true, skipCollectingAttestations: true });
+
+    // 3. Wait until the honest observer's archiver bricks: its synced L1 block stops advancing while the L1 chain
+    // (and the rollup's on-chain checkpoint number) keep climbing. The brick is the archiver throwing on the
+    // out-of-range header during decode and never advancing its L1 sync point past the malicious checkpoint.
+    logger.warn(`Phase 3: waiting for the honest observer's archiver to stall`);
+    let stalledSyncedL1 = preAttackL1BlockNumber ?? 0n;
+    let stalledCheckpointNumber = Number(preAttackCheckpointNumber);
+    await retryUntil(
+      async () => {
+        const syncedL1 = observerArchiver.getL1BlockNumber() ?? 0n;
+        const onChainCheckpointNumber = await test.rollup.getCheckpointNumber();
+        stalledSyncedL1 = syncedL1;
+        stalledCheckpointNumber = Number((await observerNode.getChainTips()).checkpointed.checkpoint.number);
+        logger.info(`Phase 3 observer state`, {
+          syncedL1: syncedL1.toString(),
+          observerCheckpointNumber: stalledCheckpointNumber,
+          onChainCheckpointNumber,
+          l1Head: test.monitor.l1BlockNumber,
+        });
+        // Bricked once the rollup has at least one checkpoint the observer never managed to checkpoint. The malicious
+        // checkpoint also bricks the proposer's own archiver, so on-chain progress halts exactly one checkpoint ahead
+        // of the observer; we therefore only require a single-checkpoint gap rather than several.
+        return onChainCheckpointNumber > stalledCheckpointNumber;
+      },
+      'observer archiver falls behind on-chain checkpoints',
+      test.L2_SLOT_DURATION_IN_S * 12,
+      0.5,
+    );
+
+    // The malicious checkpoint is the first one the observer never synced: one past its stalled checkpoint number.
+    const maliciousCheckpointNumber = CheckpointNumber(stalledCheckpointNumber + 1);
+    const proposedEvents = await rollupContract.getCheckpointProposedEvents(1n, await l1Client.getBlockNumber());
+    const maliciousEvent = proposedEvents.find(e => e.args.checkpointNumber === maliciousCheckpointNumber);
+    // Confirm the malicious checkpoint actually mined on L1 (the brick comes from decode, not a reverted propose).
+    expect(maliciousEvent).toBeDefined();
+    const maliciousL1BlockNumber = Number(maliciousEvent!.l1BlockNumber);
+    logger.warn(`Phase 3: identified malicious checkpoint mined on L1`, {
+      maliciousCheckpointNumber,
+      maliciousL1BlockNumber,
+      l1TransactionHash: maliciousEvent!.l1TransactionHash,
+      observerStalledAtCheckpoint: stalledCheckpointNumber,
+      observerStalledAtSyncedL1: stalledSyncedL1.toString(),
+    });
+
+    // 4. Let the L1 chain advance well past the malicious checkpoint, then confirm the honest observer stays stuck:
+    // its synced L1 block does not advance past the malicious checkpoint's L1 block and it never checkpoints it.
+    const l1Target = BigInt(maliciousL1BlockNumber) + BigInt(8);
+    logger.warn(
+      `Phase 4: waiting for L1 to advance to block ${l1Target} (past malicious block ${maliciousL1BlockNumber})`,
+    );
+    await test.monitor.waitUntilL1Block(l1Target);
+
+    const observeMs = test.L2_SLOT_DURATION_IN_S * 6 * 1000;
+    logger.warn(`Phase 4: observing honest archiver for ${observeMs}ms to confirm it cannot advance past the brick`);
+    const deadline = Date.now() + observeMs;
+    let maxObservedSyncedL1 = 0n;
+    let maxObservedCheckpointNumber = 0;
+    while (Date.now() < deadline) {
+      const syncedL1 = observerArchiver.getL1BlockNumber() ?? 0n;
+      const checkpointNumber = Number((await observerNode.getChainTips()).checkpointed.checkpoint.number);
+      if (syncedL1 > maxObservedSyncedL1) {
+        maxObservedSyncedL1 = syncedL1;
+      }
+      maxObservedCheckpointNumber = Math.max(maxObservedCheckpointNumber, checkpointNumber);
+      logger.info(`Observer archiver state during brick window`, {
+        syncedL1: syncedL1.toString(),
+        checkpointNumber,
+        maliciousL1BlockNumber,
+        maliciousCheckpointNumber,
+        l1Head: test.monitor.l1BlockNumber,
+      });
+      await sleep(1000);
+    }
+
+    logger.warn(`Phase 4 results`, {
+      maxObservedSyncedL1: maxObservedSyncedL1.toString(),
+      maxObservedCheckpointNumber,
+      maliciousL1BlockNumber,
+      maliciousCheckpointNumber,
+      currentL1BlockNumber: test.monitor.l1BlockNumber,
+    });
+
+    // The L1 chain has advanced well past the malicious checkpoint's L1 block, but the honest archiver is stuck.
+    expect(test.monitor.l1BlockNumber).toBeGreaterThan(maliciousL1BlockNumber);
+    // The honest archiver's L1 sync point never reached the malicious checkpoint's L1 block: it is bricked.
+    expect(Number(maxObservedSyncedL1)).toBeLessThan(maliciousL1BlockNumber);
+    // And it never checkpointed the malicious checkpoint either.
+    expect(maxObservedCheckpointNumber).toBeLessThan(maliciousCheckpointNumber);
+
+    logger.warn(`Test succeeded '${expect.getState().currentTestName}'`);
+  });
+});

--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_out_of_range_header.test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_out_of_range_header.test.ts
@@ -4,25 +4,27 @@ import type { Logger } from '@aztec/aztec.js/log';
 import { RollupContract } from '@aztec/ethereum/contracts';
 import type { ExtendedViemWalletClient } from '@aztec/ethereum/types';
 import { CheckpointNumber } from '@aztec/foundation/branded-types';
+import { EthAddress } from '@aztec/foundation/eth-address';
 import { retryUntil } from '@aztec/foundation/retry';
-import { sleep } from '@aztec/foundation/sleep';
-import type { SequencerClient } from '@aztec/sequencer-client';
 
 import { jest } from '@jest/globals';
+import { encodeAbiParameters, hexToBigInt, keccak256 } from 'viem';
 
 import type { EndToEndContext } from '../fixtures/utils.js';
 import { EpochsTestContext } from './epochs_test.js';
 
 jest.setTimeout(1000 * 60 * 10);
 
-// Reproduces A-1254: a malicious proposer posts a checkpoint whose header carries a uint256 field value above the
-// BN254 scalar field modulus. Honest archivers cannot convert that field back into an Fr while decoding the propose
-// calldata, so their L1 sync throws and never advances past the L1 block where the malicious checkpoint landed,
-// permanently bricking the node.
+// A-1254 defense-in-depth regression. Fix (2) (L1 range checks, PR #24199) prevents a malicious proposer from
+// ever landing an out-of-range archive root on a patched chain, so we cannot land one via a normal `propose`.
+// To keep exercising the archiver-side Fix (1) defenses on a value that bypasses the contract (e.g. a pre-upgrade
+// chain or a future-added field), this test uses an anvil `setStorageAt` cheat code to overwrite a checkpoint's
+// archive root in the rollup's L1 storage with a value above the BN254 field modulus.
 //
-// The rollup is deployed with a target committee size of 0 (the default epochs setup with no validators), so
-// ValidatorSelectionLib.verifyProposer skips signature validation on L1. That lets the corrupted header land on L1
-// without forging the proposer signature, while still exercising the exact archiver decode path the issue is about.
+// Before Fix (1), the archiver eagerly converted the archive root read from L1 (in `status()` / `archiveAt()` /
+// the CheckpointProposed event) into an `Fr`, which throws for an out-of-range value; the throw was uncaught and
+// the node's L1 sync point stalled permanently. After Fix (1) those reads carry raw `Buffer32` bytes, the
+// corrupted checkpoint is skipped on an archive-root mismatch, and the node keeps syncing.
 describe('e2e_epochs/epochs_out_of_range_header', () => {
   let context: EndToEndContext;
   let logger: Logger;
@@ -30,13 +32,10 @@ describe('e2e_epochs/epochs_out_of_range_header', () => {
   let rollupContract: RollupContract;
 
   let test: EpochsTestContext;
-  let maliciousSequencer: SequencerClient;
   let observerNode: AztecNodeService;
   let observerArchiver: Archiver;
 
   beforeEach(async () => {
-    // No validators -> target committee size 0 -> single context sequencer proposes every slot and L1 skips
-    // signature checks. minTxsPerBlock 0 (default) so empty checkpoints build without any txs.
     test = await EpochsTestContext.setup({
       numberOfAccounts: 0,
       aztecProofSubmissionEpochs: 1024,
@@ -49,7 +48,6 @@ describe('e2e_epochs/epochs_out_of_range_header', () => {
 
     ({ context, logger, l1Client } = test);
     rollupContract = new RollupContract(l1Client, test.rollup.address);
-    maliciousSequencer = context.sequencer!;
 
     // Honest observer node: a plain archiver-only node syncing L1, no validator.
     observerNode = await test.createNonValidatorNode();
@@ -63,8 +61,23 @@ describe('e2e_epochs/epochs_out_of_range_header', () => {
     await test.teardown();
   });
 
-  it('honest archiver stalls when a malicious proposer posts an out-of-range checkpoint header', async () => {
-    // 1. Let the chain advance a couple of checkpoints normally and let the observer catch up to them.
+  /** Computes the L1 storage slot of `rollupStore.archives[checkpointNumber]`. Mirrors makeArchiveOverride. */
+  function archivesStorageSlot(checkpointNumber: CheckpointNumber): bigint {
+    const archivesMappingBase = hexToBigInt(RollupContract.stfStorageSlot) + 1n;
+    return hexToBigInt(
+      keccak256(
+        encodeAbiParameters(
+          [{ type: 'uint256' }, { type: 'uint256' }],
+          [BigInt(checkpointNumber), archivesMappingBase],
+        ),
+      ),
+    );
+  }
+
+  it('honest archiver survives an out-of-range archive root injected into L1 storage and keeps syncing', async () => {
+    const OUT_OF_RANGE = 2n ** 256n - 1n;
+
+    // 1. Let the chain advance a couple of checkpoints and let the observer catch up.
     const goodCheckpointTarget = CheckpointNumber(2);
     logger.warn(`Phase 1: waiting for ${goodCheckpointTarget} good checkpoints to be mined`);
     await test.monitor.waitUntilCheckpoint(goodCheckpointTarget);
@@ -81,108 +94,47 @@ describe('e2e_epochs/epochs_out_of_range_header', () => {
       0.5,
     );
 
-    const preAttackBlockNumber = await observerNode.getBlockNumber();
-    const preAttackL1BlockNumber = observerArchiver.getL1BlockNumber();
-    const preAttackCheckpointNumber = await test.rollup.getCheckpointNumber();
-    logger.warn(`Phase 1 complete: observer synced before attack`, {
-      preAttackBlockNumber,
-      preAttackL1BlockNumber: preAttackL1BlockNumber?.toString(),
-      preAttackCheckpointNumber,
+    const syncedBeforeInjection = await observerNode.getBlockNumber();
+    logger.warn(`Phase 1 complete: observer synced up to L2 block ${syncedBeforeInjection}`);
+
+    // 2. Overwrite the next checkpoint's archive root in L1 storage with an out-of-range value, so the observer
+    // reads a value >= P from `status()` / `archiveAt()` while syncing it. On a real chain Fix (2) makes this
+    // unreachable; we force it here to prove Fix (1) survives a bad value that bypasses the contract.
+    const injectAt = CheckpointNumber((await test.rollup.getCheckpointNumber()) + 1);
+    const slot = archivesStorageSlot(injectAt);
+    logger.warn(`Phase 2: corrupting archives[${injectAt}] to an out-of-range value via setStorageAt`, {
+      slot: `0x${slot.toString(16)}`,
     });
+    await context.cheatCodes.eth.store(EthAddress.fromString(test.rollup.address), slot, OUT_OF_RANGE);
 
-    // 2. Enable the malicious injection on the proposer. Under proposer pipelining the checkpoint that is built
-    // in the next slot may already have snapshotted the previous (good) config, so the first one or two checkpoints
-    // after this call can still be valid; the injection takes effect once a freshly-built checkpoint is published.
-    logger.warn(`Phase 2: enabling injectOutOfRangeCheckpointHeader on the proposer`);
-    maliciousSequencer.updateConfig({ injectOutOfRangeCheckpointHeader: true, skipCollectingAttestations: true });
+    // The archiver wrapper must read the corrupted value as raw bytes without throwing (pre-fix this threw).
+    const corruptedArchive = await rollupContract.archiveAt(injectAt);
+    expect(corruptedArchive.toString()).toEqual(`0x${OUT_OF_RANGE.toString(16)}`);
+    const status = await rollupContract.status(injectAt);
+    expect(status).toBeDefined();
 
-    // 3. Wait until the honest observer's archiver bricks: its synced L1 block stops advancing while the L1 chain
-    // (and the rollup's on-chain checkpoint number) keep climbing. The brick is the archiver throwing on the
-    // out-of-range header during decode and never advancing its L1 sync point past the malicious checkpoint.
-    logger.warn(`Phase 3: waiting for the honest observer's archiver to stall`);
-    let stalledSyncedL1 = preAttackL1BlockNumber ?? 0n;
-    let stalledCheckpointNumber = Number(preAttackCheckpointNumber);
+    // 3. The honest observer must keep syncing and not brick: its L1 sync point keeps advancing and it keeps
+    // checkpointing the good checkpoints the chain continues to produce.
+    const recoveryTarget = CheckpointNumber(Number(injectAt) + 2);
+    logger.warn(`Phase 3: confirming the observer keeps syncing past the corruption (to checkpoint ${recoveryTarget})`);
+    await test.monitor.waitUntilCheckpoint(recoveryTarget);
+
     await retryUntil(
       async () => {
         const syncedL1 = observerArchiver.getL1BlockNumber() ?? 0n;
-        const onChainCheckpointNumber = await test.rollup.getCheckpointNumber();
-        stalledSyncedL1 = syncedL1;
-        stalledCheckpointNumber = Number((await observerNode.getChainTips()).checkpointed.checkpoint.number);
+        const checkpointed = (await observerNode.getChainTips()).checkpointed.checkpoint.number;
         logger.info(`Phase 3 observer state`, {
           syncedL1: syncedL1.toString(),
-          observerCheckpointNumber: stalledCheckpointNumber,
-          onChainCheckpointNumber,
+          observerCheckpointNumber: checkpointed,
           l1Head: test.monitor.l1BlockNumber,
         });
-        // Bricked once the rollup has at least one checkpoint the observer never managed to checkpoint. The malicious
-        // checkpoint also bricks the proposer's own archiver, so on-chain progress halts exactly one checkpoint ahead
-        // of the observer; we therefore only require a single-checkpoint gap rather than several.
-        return onChainCheckpointNumber > stalledCheckpointNumber;
+        // Fix(1) success: the observer's L1 sync point advanced past where the corrupted checkpoint was injected.
+        return syncedL1 > 0n && (await observerNode.getBlockNumber()) > syncedBeforeInjection;
       },
-      'observer archiver falls behind on-chain checkpoints',
-      test.L2_SLOT_DURATION_IN_S * 12,
+      'observer keeps syncing past the out-of-range archive root',
+      test.L2_SLOT_DURATION_IN_S * 16,
       0.5,
     );
-
-    // The malicious checkpoint is the first one the observer never synced: one past its stalled checkpoint number.
-    const maliciousCheckpointNumber = CheckpointNumber(stalledCheckpointNumber + 1);
-    const proposedEvents = await rollupContract.getCheckpointProposedEvents(1n, await l1Client.getBlockNumber());
-    const maliciousEvent = proposedEvents.find(e => e.args.checkpointNumber === maliciousCheckpointNumber);
-    // Confirm the malicious checkpoint actually mined on L1 (the brick comes from decode, not a reverted propose).
-    expect(maliciousEvent).toBeDefined();
-    const maliciousL1BlockNumber = Number(maliciousEvent!.l1BlockNumber);
-    logger.warn(`Phase 3: identified malicious checkpoint mined on L1`, {
-      maliciousCheckpointNumber,
-      maliciousL1BlockNumber,
-      l1TransactionHash: maliciousEvent!.l1TransactionHash,
-      observerStalledAtCheckpoint: stalledCheckpointNumber,
-      observerStalledAtSyncedL1: stalledSyncedL1.toString(),
-    });
-
-    // 4. Let the L1 chain advance well past the malicious checkpoint, then confirm the honest observer stays stuck:
-    // its synced L1 block does not advance past the malicious checkpoint's L1 block and it never checkpoints it.
-    const l1Target = BigInt(maliciousL1BlockNumber) + BigInt(8);
-    logger.warn(
-      `Phase 4: waiting for L1 to advance to block ${l1Target} (past malicious block ${maliciousL1BlockNumber})`,
-    );
-    await test.monitor.waitUntilL1Block(l1Target);
-
-    const observeMs = test.L2_SLOT_DURATION_IN_S * 6 * 1000;
-    logger.warn(`Phase 4: observing honest archiver for ${observeMs}ms to confirm it cannot advance past the brick`);
-    const deadline = Date.now() + observeMs;
-    let maxObservedSyncedL1 = 0n;
-    let maxObservedCheckpointNumber = 0;
-    while (Date.now() < deadline) {
-      const syncedL1 = observerArchiver.getL1BlockNumber() ?? 0n;
-      const checkpointNumber = Number((await observerNode.getChainTips()).checkpointed.checkpoint.number);
-      if (syncedL1 > maxObservedSyncedL1) {
-        maxObservedSyncedL1 = syncedL1;
-      }
-      maxObservedCheckpointNumber = Math.max(maxObservedCheckpointNumber, checkpointNumber);
-      logger.info(`Observer archiver state during brick window`, {
-        syncedL1: syncedL1.toString(),
-        checkpointNumber,
-        maliciousL1BlockNumber,
-        maliciousCheckpointNumber,
-        l1Head: test.monitor.l1BlockNumber,
-      });
-      await sleep(1000);
-    }
-
-    logger.warn(`Phase 4 results`, {
-      maxObservedSyncedL1: maxObservedSyncedL1.toString(),
-      maxObservedCheckpointNumber,
-      maliciousL1BlockNumber,
-      maliciousCheckpointNumber,
-      currentL1BlockNumber: test.monitor.l1BlockNumber,
-    });
-
-    // The L1 chain has advanced well past the malicious checkpoint's L1 block, but the honest archiver is stuck.
-    expect(test.monitor.l1BlockNumber).toBeGreaterThan(maliciousL1BlockNumber);
-    // The honest archiver's L1 sync point never reached the malicious checkpoint's L1 block: it is bricked.
-    expect(Number(maxObservedSyncedL1)).toBeLessThan(maliciousL1BlockNumber);
-    // And it never checkpointed the malicious checkpoint either.
-    expect(maxObservedCheckpointNumber).toBeLessThan(maliciousCheckpointNumber);
 
     logger.warn(`Test succeeded '${expect.getState().currentTestName}'`);
   });

--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_out_of_range_header.test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_out_of_range_header.test.ts
@@ -1,30 +1,58 @@
 import type { Archiver } from '@aztec/archiver';
 import type { AztecNodeService } from '@aztec/aztec-node';
+import { EthAddress } from '@aztec/aztec.js/addresses';
+import { Fr } from '@aztec/aztec.js/fields';
 import type { Logger } from '@aztec/aztec.js/log';
 import { RollupContract } from '@aztec/ethereum/contracts';
+import type { Operator } from '@aztec/ethereum/deploy-aztec-l1-contracts';
 import type { ExtendedViemWalletClient } from '@aztec/ethereum/types';
-import { CheckpointNumber } from '@aztec/foundation/branded-types';
-import { EthAddress } from '@aztec/foundation/eth-address';
+import { CheckpointNumber, SlotNumber } from '@aztec/foundation/branded-types';
+import { times } from '@aztec/foundation/collection';
+import { SecretValue } from '@aztec/foundation/config';
 import { retryUntil } from '@aztec/foundation/retry';
+import { bufferToHex } from '@aztec/foundation/string';
+import { getTimestampForSlot } from '@aztec/stdlib/epoch-helpers';
 
 import { jest } from '@jest/globals';
 import { encodeAbiParameters, hexToBigInt, keccak256 } from 'viem';
+import { privateKeyToAccount } from 'viem/accounts';
 
-import type { EndToEndContext } from '../fixtures/utils.js';
+import { type EndToEndContext, getPrivateKeyFromIndex } from '../fixtures/utils.js';
 import { EpochsTestContext } from './epochs_test.js';
 
-jest.setTimeout(1000 * 60 * 10);
+jest.setTimeout(1000 * 60 * 15);
 
-// A-1254 defense-in-depth regression. Fix (2) (L1 range checks, PR #24199) prevents a malicious proposer from
-// ever landing an out-of-range archive root on a patched chain, so we cannot land one via a normal `propose`.
-// To keep exercising the archiver-side Fix (1) defenses on a value that bypasses the contract (e.g. a pre-upgrade
-// chain or a future-added field), this test uses an anvil `setStorageAt` cheat code to overwrite a checkpoint's
-// archive root in the rollup's L1 storage with a value above the BN254 field modulus.
-//
-// Before Fix (1), the archiver eagerly converted the archive root read from L1 (in `status()` / `archiveAt()` /
-// the CheckpointProposed event) into an `Fr`, which throws for an out-of-range value; the throw was uncaught and
-// the node's L1 sync point stalled permanently. After Fix (1) those reads carry raw `Buffer32` bytes, the
-// corrupted checkpoint is skipped on an archive-root mismatch, and the node keeps syncing.
+const VALIDATOR_COUNT = 4;
+
+/**
+ * E2E recovery test for the archiver hardening against out-of-range checkpoint-header/archive fields.
+ *
+ * A misbehaving proposer lands the first checkpoint with only its own signature (insufficient
+ * attestations). Its stored archive root is then corrupted to a value above the BN254 field modulus
+ * via an anvil `setStorageAt` cheat code. The honest validators and an archiver-only observer node then
+ * must (a) keep reading the out-of-range pending tip via `status()` / `archiveAt()` without bricking
+ * their L1 sync, (b) invalidate the under-attested checkpoint, and (c) build past it.
+ *
+ * Why the corruption is injected via storage rather than through `propose`: the L1 `propose` path now
+ * reverts on out-of-range field elements (PR #24199, already in the base branch), so an out-of-range
+ * value can no longer arrive through a normal proposal. We therefore corrupt the stored archive root
+ * AFTER the checkpoint lands — its calldata/event archive carries the real in-range value, while the
+ * stored slot is corrupted. `status()` / `archiveAt()` read the corrupted slot, which is exactly the
+ * pre-fix brick path. This models a pre-upgrade chain or a future-added field, the only realistic
+ * vector once the L1 range checks exist.
+ *
+ * Before the archiver fix, the archive root read from L1 (via `status()` / `archiveAt()`) was eagerly
+ * converted to an `Fr`, which throws for an out-of-range value; the throw was uncaught and the node's
+ * L1 sync point stalled permanently, so it could never compute that the pending tip was under-attested
+ * and never invalidate it. After the fix those reads carry raw `Buffer32` bytes, the node keeps syncing,
+ * sees the insufficient attestations, and invalidates — letting honest proposers build past the bad tip.
+ *
+ * The honest validator nodes are created up front against the clean chain (so their tx-pool hydration
+ * reads an in-range pending tip) but their sequencers stay stopped: only the misbehaving proposer's
+ * sequencer runs first, lands and corrupts checkpoint 1, and is then stopped before the honest sequencers
+ * start. The honest validators recover via the L1-sync invalidation path, which reads the corrupted tip
+ * only through the hardened `status()`/`archiveAt()` reads.
+ */
 describe('e2e_epochs/epochs_out_of_range_header', () => {
   let context: EndToEndContext;
   let logger: Logger;
@@ -32,25 +60,60 @@ describe('e2e_epochs/epochs_out_of_range_header', () => {
   let rollupContract: RollupContract;
 
   let test: EpochsTestContext;
+  let validators: (Operator & { privateKey: `0x${string}` })[];
+  let nodes: AztecNodeService[];
   let observerNode: AztecNodeService;
   let observerArchiver: Archiver;
 
   beforeEach(async () => {
+    // Four validators so that, after one misbehaves and is stopped, the remaining three honest validators
+    // still reach the >2/3 attestation quorum (3 of 4). aztecTargetCommitteeSize is derived from
+    // initialValidators.length by the harness, so the committee is exactly these four.
+    validators = times(VALIDATOR_COUNT, i => {
+      const privateKey = bufferToHex(getPrivateKeyFromIndex(i + 3)!);
+      const attester = EthAddress.fromString(privateKeyToAccount(privateKey).address);
+      return { attester, withdrawer: attester, privateKey, bn254SecretKey: new SecretValue(Fr.random().toBigInt()) };
+    });
+
     test = await EpochsTestContext.setup({
       numberOfAccounts: 0,
-      aztecProofSubmissionEpochs: 1024,
-      aztecSlotDurationInL1Slots: 3,
-      ethereumSlotDuration: 12,
-      blockDurationMs: 6000,
+      initialValidators: validators,
+      mockGossipSubNetwork: true,
       startProverNode: false,
+      skipInitialSequencer: true,
+      buildCheckpointIfEmpty: true,
       minTxsPerBlock: 0,
+      aztecEpochDuration: 8,
+      aztecProofSubmissionEpochs: 1024,
+      ethereumSlotDuration: 6,
+      aztecSlotDuration: 36,
+      blockDurationMs: 8000,
+      attestationPropagationTime: 0.5,
+      inboxLag: 2,
+      // Invalidate promptly as a committee member once the pending tip is seen to be under-attested,
+      // so recovery does not depend on the long production defaults.
+      secondsBeforeInvalidatingBlockAsCommitteeMember: 1,
     });
 
     ({ context, logger, l1Client } = test);
     rollupContract = new RollupContract(l1Client, test.rollup.address);
 
-    // Honest observer node: a plain archiver-only node syncing L1, no validator.
-    observerNode = await test.createNonValidatorNode();
+    // Create all four validator nodes up front, against the clean genesis chain, but keep their sequencers
+    // stopped. Creating them now (before any checkpoint, so their tx-pool hydration reads the in-range
+    // genesis pending tip) avoids an unrelated startup-time decode of the pending archive root; the
+    // recovery we are testing happens through the incremental L1-sync path, not node creation.
+    nodes = await Promise.all(
+      validators.map((v, i) =>
+        test.createValidatorNode([v.privateKey], {
+          dontStartSequencer: true,
+          buildCheckpointIfEmpty: true,
+          minTxsPerBlock: 0,
+          coinbase: EthAddress.fromNumber(i + 1),
+        }),
+      ),
+    );
+
+    observerNode = await test.createNonValidatorNode({ buildCheckpointIfEmpty: true, minTxsPerBlock: 0 });
     observerArchiver = observerNode.getBlockSource() as Archiver;
 
     logger.warn(`Test setup completed.`);
@@ -58,7 +121,7 @@ describe('e2e_epochs/epochs_out_of_range_header', () => {
 
   afterEach(async () => {
     jest.restoreAllMocks();
-    await test.teardown();
+    await test?.teardown();
   });
 
   /** Computes the L1 storage slot of `rollupStore.archives[checkpointNumber]`. Mirrors makeArchiveOverride. */
@@ -74,65 +137,147 @@ describe('e2e_epochs/epochs_out_of_range_header', () => {
     );
   }
 
-  it('honest archiver survives an out-of-range archive root injected into L1 storage and keeps syncing', async () => {
+  /**
+   * Scans forward from the current slot for the first upcoming proposal slot owned by one of our
+   * validators, returning that slot and the index of the validator that proposes it. The L1 rollup only
+   * exposes proposers for epochs whose randao seed is stable; looking too far ahead reverts with
+   * `ValidatorSelection__EpochNotStable`, which we recover from by warping L1 forward one epoch.
+   */
+  async function findFirstProposalSlot(): Promise<{ slot: SlotNumber; validatorIndex: number }> {
+    const addresses = validators.map(v => v.attester.toString().toLowerCase());
+    let candidate = Number(test.epochCache.getEpochAndSlotNow().slot) + 4;
+    for (let attempt = 0; attempt < 200; attempt++) {
+      try {
+        const proposer = await test.epochCache.getProposerAttesterAddressInSlot(SlotNumber(candidate));
+        const validatorIndex = proposer ? addresses.indexOf(proposer.toString().toLowerCase()) : -1;
+        if (validatorIndex >= 0) {
+          logger.warn(`First upcoming proposal slot ${candidate} owned by validator ${validatorIndex}.`, {
+            slot: candidate,
+            proposer: proposer!.toString(),
+          });
+          return { slot: SlotNumber(candidate), validatorIndex };
+        }
+        candidate++;
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        if (!msg.includes('EpochNotStable')) {
+          throw err;
+        }
+        const block = await test.l1Client.getBlock({ includeTransactions: false });
+        const warpBy = test.epochDuration * test.L2_SLOT_DURATION_IN_S;
+        const newTs = Number(block.timestamp) + warpBy;
+        logger.warn(`Hit EpochNotStable at candidate ${candidate}, warping L1 forward by ${warpBy}s to ${newTs}`);
+        await context.cheatCodes.eth.warp(newTs, { resetBlockInterval: true });
+        const newCurrentSlot = Number(test.epochCache.getEpochAndSlotNow().slot);
+        if (candidate < newCurrentSlot + 4) {
+          candidate = newCurrentSlot + 4;
+        }
+      }
+    }
+    throw new Error(`Could not find an upcoming proposal slot owned by one of our validators`);
+  }
+
+  it('honest validators invalidate an under-attested checkpoint with a corrupted archive root and build past it', async () => {
     const OUT_OF_RANGE = 2n ** 256n - 1n;
 
-    // 1. Let the chain advance a couple of checkpoints and let the observer catch up.
-    const goodCheckpointTarget = CheckpointNumber(2);
-    logger.warn(`Phase 1: waiting for ${goodCheckpointTarget} good checkpoints to be mined`);
-    await test.monitor.waitUntilCheckpoint(goodCheckpointTarget);
+    // 1. Find the first upcoming proposal slot owned by one of our validators. That validator is the lone
+    // misbehaving proposer of checkpoint 1; the other three are the honest validators.
+    const { slot: firstSlot, validatorIndex: badIndex } = await findFirstProposalSlot();
+    const badNode = nodes[badIndex];
+    const honestNodes = nodes.filter((_, i) => i !== badIndex);
 
-    logger.warn(`Phase 1: waiting for observer node to sync the good checkpoints`);
-    await retryUntil(
-      async () => {
-        const tips = await observerNode.getChainTips();
-        logger.info(`Observer checkpointed checkpoint=${tips.checkpointed.checkpoint.number}`);
-        return tips.checkpointed.checkpoint.number >= goodCheckpointTarget;
-      },
-      'observer syncs good checkpoints',
-      test.L2_SLOT_DURATION_IN_S * 8,
-      0.5,
-    );
+    // 2. Start ONLY the misbehaving validator's sequencer, with skipCollectingAttestations so it proposes
+    // with just its own signature (1 of 4 → below the 3-of-4 quorum). Under proposer pipelining the
+    // proposer for proposal slot S builds during wall-clock slot S-1, so warp to one L1 slot before S-1.
+    badNode.getSequencer()!.updateConfig({ skipCollectingAttestations: true });
 
-    const syncedBeforeInjection = await observerNode.getBlockNumber();
-    logger.warn(`Phase 1 complete: observer synced up to L2 block ${syncedBeforeInjection}`);
+    const buildSlot = SlotNumber(firstSlot - 1);
+    const buildSlotTimestamp = getTimestampForSlot(buildSlot, test.constants);
+    await context.cheatCodes.eth.warp(Number(buildSlotTimestamp) - test.L1_BLOCK_TIME_IN_S, {
+      resetBlockInterval: true,
+    });
+    logger.warn(`Warped to 1 L1 slot before build slot ${buildSlot} (proposal slot ${firstSlot}).`);
 
-    // 2. Overwrite the next checkpoint's archive root in L1 storage with an out-of-range value, so the observer
-    // reads a value >= P from `status()` / `archiveAt()` while syncing it. On a real chain Fix (2) makes this
-    // unreachable; we force it here to prove Fix (1) survives a bad value that bypasses the contract.
-    const injectAt = CheckpointNumber((await test.rollup.getCheckpointNumber()) + 1);
-    const slot = archivesStorageSlot(injectAt);
-    logger.warn(`Phase 2: corrupting archives[${injectAt}] to an out-of-range value via setStorageAt`, {
+    logger.warn(`Starting lone misbehaving validator ${badIndex} (skipCollectingAttestations).`);
+    await badNode.getSequencer()!.start();
+
+    // 3. Wait for the under-attested checkpoint 1 to land on L1.
+    const corruptCheckpoint = CheckpointNumber(1);
+    await test.waitUntilCheckpointNumber(corruptCheckpoint, test.L2_SLOT_DURATION_IN_S * 6);
+    expect(await rollupContract.getCheckpointNumber()).toBeGreaterThanOrEqual(corruptCheckpoint);
+    logger.warn(`Checkpoint ${corruptCheckpoint} landed on L1.`);
+
+    // 4. Corrupt the stored archive root of checkpoint 1 to an out-of-range value. We do this AFTER it has
+    // landed so `propose` (which now reverts on out-of-range fields, PR #24199) has already written the real
+    // in-range value to the slot and will not overwrite it again. The checkpoint's calldata/event archive
+    // therefore stays in range; only the stored slot is corrupted, which is what status()/archiveAt() read.
+    const slot = archivesStorageSlot(corruptCheckpoint);
+    logger.warn(`Corrupting archives[${corruptCheckpoint}] to an out-of-range value via setStorageAt`, {
       slot: `0x${slot.toString(16)}`,
     });
     await context.cheatCodes.eth.store(EthAddress.fromString(test.rollup.address), slot, OUT_OF_RANGE);
 
-    // The archiver wrapper must read the corrupted value as raw bytes without throwing (pre-fix this threw).
-    const corruptedArchive = await rollupContract.archiveAt(injectAt);
+    // Sanity: the rollup wrapper reads the corrupted value as raw Buffer32 bytes without throwing (pre-fix
+    // this conversion to Fr threw and bricked the read).
+    const corruptedArchive = await rollupContract.archiveAt(corruptCheckpoint);
     expect(corruptedArchive.toString()).toEqual(`0x${OUT_OF_RANGE.toString(16)}`);
-    const status = await rollupContract.status(injectAt);
-    expect(status).toBeDefined();
+    const status = await rollupContract.status(corruptCheckpoint);
+    expect(status.pendingArchive.toString()).toEqual(`0x${OUT_OF_RANGE.toString(16)}`);
 
-    // 3. The honest observer must keep syncing and not brick: its L1 sync point keeps advancing and it keeps
-    // checkpointing the good checkpoints the chain continues to produce.
-    const recoveryTarget = CheckpointNumber(Number(injectAt) + 2);
-    logger.warn(`Phase 3: confirming the observer keeps syncing past the corruption (to checkpoint ${recoveryTarget})`);
-    await test.monitor.waitUntilCheckpoint(recoveryTarget);
+    // 5. Stop the misbehaving validator's sequencer so it no longer proposes; its key remains in the committee.
+    logger.warn(`Stopping the misbehaving validator's sequencer.`);
+    await badNode.getSequencer()!.stop();
 
+    // 6. Start the three honest validators' sequencers. They were created against the clean chain, so
+    // starting them now exercises the L1-sync invalidation path against the corrupted pending tip.
+    logger.warn(`Starting the three honest validators' sequencers.`);
+    await Promise.all(honestNodes.map(n => n.getSequencer()!.start()));
+
+    // 7a. The observer must not brick reading the out-of-range pending tip: its L1 sync point keeps advancing.
+    const observerL1Before = observerArchiver.getL1BlockNumber() ?? 0n;
+    await retryUntil(
+      () => {
+        const syncedL1 = observerArchiver.getL1BlockNumber() ?? 0n;
+        logger.info(`Observer L1 sync point`, { syncedL1: syncedL1.toString(), before: observerL1Before.toString() });
+        return syncedL1 > observerL1Before;
+      },
+      'observer keeps syncing L1 past the out-of-range archive root',
+      test.L2_SLOT_DURATION_IN_S * 8,
+      0.5,
+    );
+    logger.warn(`Observer L1 sync advanced past the corrupted pending tip.`);
+
+    // 7b. The under-attested checkpoint 1 gets invalidated: the on-chain pending checkpoint number rolls back
+    // below 1 (to 0). Invalidation is what proves the honest nodes successfully read the corrupted pending
+    // tip, computed insufficient attestations, and acted on it.
     await retryUntil(
       async () => {
-        const syncedL1 = observerArchiver.getL1BlockNumber() ?? 0n;
-        const checkpointed = (await observerNode.getChainTips()).checkpointed.checkpoint.number;
-        logger.info(`Phase 3 observer state`, {
-          syncedL1: syncedL1.toString(),
-          observerCheckpointNumber: checkpointed,
-          l1Head: test.monitor.l1BlockNumber,
-        });
-        // Fix(1) success: the observer's L1 sync point advanced past where the corrupted checkpoint was injected.
-        return syncedL1 > 0n && (await observerNode.getBlockNumber()) > syncedBeforeInjection;
+        const pending = await rollupContract.getCheckpointNumber();
+        logger.info(`On-chain pending checkpoint number`, { pending });
+        return pending < corruptCheckpoint;
       },
-      'observer keeps syncing past the out-of-range archive root',
-      test.L2_SLOT_DURATION_IN_S * 16,
+      'under-attested checkpoint 1 is invalidated (pending checkpoint rolls back)',
+      test.L2_SLOT_DURATION_IN_S * 10,
+      0.5,
+    );
+    logger.warn(`Under-attested checkpoint 1 was invalidated.`);
+
+    // 7c. The chain heals: honest proposers build a fresh, properly-attested checkpoint past the bad one, so
+    // the on-chain checkpoint number climbs back to 2 (a clean rebuild of 1 plus a new 2).
+    const healTarget = CheckpointNumber(2);
+    await test.waitUntilCheckpointNumber(healTarget, test.L2_SLOT_DURATION_IN_S * 12);
+    expect(await rollupContract.getCheckpointNumber()).toBeGreaterThanOrEqual(healTarget);
+    logger.warn(`Chain healed: produced checkpoint ${healTarget} past the invalidated checkpoint.`);
+
+    // And the observer indexes the healed chain too, confirming honest sync survived and caught up.
+    await retryUntil(
+      async () => {
+        const checkpointed = (await observerNode.getChainTips()).checkpointed.checkpoint.number;
+        logger.info(`Observer checkpointed checkpoint`, { checkpointed });
+        return checkpointed >= healTarget;
+      },
+      `observer syncs the healed chain up to checkpoint ${healTarget}`,
+      test.L2_SLOT_DURATION_IN_S * 8,
       0.5,
     );
 

--- a/yarn-project/end-to-end/src/e2e_l1_publisher/e2e_l1_publisher.test.ts
+++ b/yarn-project/end-to-end/src/e2e_l1_publisher/e2e_l1_publisher.test.ts
@@ -80,7 +80,7 @@ import {
   getHashedSignaturePayloadTypedData,
   orderAttestations,
 } from '@aztec/stdlib/p2p';
-import { CheckpointHeader } from '@aztec/stdlib/rollup';
+import { CheckpointHeader, toL1CheckpointHeader } from '@aztec/stdlib/rollup';
 import { fr, mockProcessedTx } from '@aztec/stdlib/testing';
 import { AppendOnlyTreeSnapshot } from '@aztec/stdlib/trees';
 import type { BlockHeader, CheckpointGlobalVariables, ProcessedTx } from '@aztec/stdlib/tx';
@@ -644,7 +644,7 @@ describe('L1Publisher integration', () => {
           functionName: 'propose',
           args: [
             {
-              header: checkpoint.header.toViem(),
+              header: toL1CheckpointHeader(checkpoint.header),
               archive: `0x${block.archive.root.toBuffer().toString('hex')}`,
               oracleInput: {
                 feeAssetPriceModifier: 0n,

--- a/yarn-project/ethereum/src/contracts/rollup.test.ts
+++ b/yarn-project/ethereum/src/contracts/rollup.test.ts
@@ -8,7 +8,7 @@ import { DateProvider } from '@aztec/foundation/timer';
 import { RollupAbi } from '@aztec/l1-artifacts/RollupAbi';
 
 import { jest } from '@jest/globals';
-import { type Abi, RpcRequestError, encodeErrorResult } from 'viem';
+import { type Abi, RpcRequestError, encodeAbiParameters, encodeErrorResult, hexToBigInt, keccak256 } from 'viem';
 import { foundry } from 'viem/chains';
 
 import { DefaultL1ContractsConfig } from '../config.js';
@@ -601,6 +601,36 @@ describe('Rollup', () => {
 
       const checkpoint = await rollup.getCheckpoint(CheckpointNumber(0));
       expect(BigInt(checkpoint.slotNumber)).toBe(testSlotNumber);
+    });
+  });
+
+  describe('getCheckpoint with out-of-range archive', () => {
+    /** Computes the storage slot for `archives[checkpointNumber]` (mapping base is stfStorageSlot + 1). */
+    function archiveStorageSlot(checkpointNumber: bigint): bigint {
+      const archivesMappingBase = hexToBigInt(RollupContract.stfStorageSlot) + 1n;
+      return hexToBigInt(
+        keccak256(
+          encodeAbiParameters([{ type: 'uint256' }, { type: 'uint256' }], [checkpointNumber, archivesMappingBase]),
+        ),
+      );
+    }
+
+    it('does not throw when the stored archive root is outside the BN254 field', async () => {
+      // A malicious proposer can land a checkpoint whose archive root is >= the BN254 modulus. An honest node
+      // reading it on a sync/startup path (e.g. the tx-pool fee provider booting against the pending tip) must
+      // not brick. The archive is therefore carried as raw bytes; converting to Fr would throw here.
+      await cheatCodes.store(
+        EthAddress.fromString(rollupAddress),
+        RollupContract.chainTipsStorageSlot,
+        RollupContract.packChainTips(0n, 0n),
+      );
+
+      // 2^256 - 1: maximal bytes32, far above the BN254 modulus, so Fr.fromString would reject it.
+      const outOfRange = (1n << 256n) - 1n;
+      await cheatCodes.store(EthAddress.fromString(rollupAddress), archiveStorageSlot(0n), outOfRange);
+
+      const checkpoint = await rollup.getCheckpoint(CheckpointNumber(0));
+      expect(checkpoint.archive).toEqual(Buffer32.fromBigInt(outOfRange));
     });
   });
 });

--- a/yarn-project/ethereum/src/contracts/rollup.ts
+++ b/yarn-project/ethereum/src/contracts/rollup.ts
@@ -124,7 +124,10 @@ export type FeeHeader = {
  * Checkpoint log data returned from the rollup contract
  */
 export type CheckpointLog = {
-  archive: Fr;
+  // Archive root carried as raw bytes (not Fr) on the L1-read path. A malicious proposer can store a checkpoint
+  // whose archive root is out of the BN254 field; eagerly converting it to Fr would throw and brick any node that
+  // reads this checkpoint on a sync/startup path. Conversion to Fr happens only at the ingestion boundary.
+  archive: Buffer32;
   headerHash: Buffer32;
   blobCommitmentsHash: Buffer32;
   attestationsHash: Buffer32;
@@ -696,7 +699,7 @@ export class RollupContract {
     await checkBlockTag(options?.blockNumber, this.client);
     const result = await this.rollup.read.getCheckpoint([BigInt(checkpointNumber)], options);
     return {
-      archive: Fr.fromString(result.archive),
+      archive: Buffer32.fromString(result.archive),
       headerHash: Buffer32.fromString(result.headerHash),
       blobCommitmentsHash: Buffer32.fromString(result.blobCommitmentsHash),
       attestationsHash: Buffer32.fromString(result.attestationsHash),

--- a/yarn-project/ethereum/src/contracts/rollup.ts
+++ b/yarn-project/ethereum/src/contracts/rollup.ts
@@ -224,7 +224,7 @@ export type RollupStatusResponse = {
   provenCheckpointNumber: CheckpointNumber;
   // Archive roots are carried as raw bytes (not Fr) on the L1-read path. A malicious proposer can store a
   // checkpoint whose archive root is out of the BN254 field; eagerly converting it to Fr would throw and
-  // brick L1 sync. Conversion to Fr happens only at the checkpoint ingestion boundary (see A-1254).
+  // brick L1 sync. Conversion to Fr happens only at the checkpoint ingestion boundary.
   provenArchive: Buffer32;
   pendingCheckpointNumber: CheckpointNumber;
   pendingArchive: Buffer32;

--- a/yarn-project/ethereum/src/contracts/rollup.ts
+++ b/yarn-project/ethereum/src/contracts/rollup.ts
@@ -71,6 +71,13 @@ export type EpochProofPublicInputArgs = {
   proverId: `0x${string}`;
 };
 
+/**
+ * The viem ABI boundary shape of a checkpoint header. Structurally identical to
+ * `L1CheckpointHeader` in `@aztec/stdlib`, which is the canonical raw-header type used by all
+ * stdlib-and-downstream code. This package cannot depend on stdlib, so it keeps a local alias for the
+ * low-level viem calls (`validateHeader`, `getEpochProofPublicInputs`); callers pass `L1CheckpointHeader`,
+ * which is assignable to it.
+ */
 export type ViemHeader = {
   lastArchiveRoot: `0x${string}`;
   blockHeadersHash: `0x${string}`;
@@ -215,16 +222,20 @@ export type AttesterView = {
  */
 export type RollupStatusResponse = {
   provenCheckpointNumber: CheckpointNumber;
-  provenArchive: Fr;
+  // Archive roots are carried as raw bytes (not Fr) on the L1-read path. A malicious proposer can store a
+  // checkpoint whose archive root is out of the BN254 field; eagerly converting it to Fr would throw and
+  // brick L1 sync. Conversion to Fr happens only at the checkpoint ingestion boundary (see A-1254).
+  provenArchive: Buffer32;
   pendingCheckpointNumber: CheckpointNumber;
-  pendingArchive: Fr;
-  archiveOfMyCheckpoint: Fr;
+  pendingArchive: Buffer32;
+  archiveOfMyCheckpoint: Buffer32;
 };
 
 /** Arguments for the CheckpointProposed event. */
 export type CheckpointProposedArgs = {
   checkpointNumber: CheckpointNumber;
-  archive: Fr;
+  /** Raw archive root bytes; may be out of the BN254 field (see RollupStatusResponse). */
+  archive: Buffer32;
   versionedBlobHashes: Buffer[];
   /** Hash of attestations emitted in the CheckpointProposed event. */
   attestationsHash: Buffer32;
@@ -1157,10 +1168,10 @@ export class RollupContract {
     const result = await this.rollup.read.status([BigInt(checkpointNumber)], options);
     return {
       provenCheckpointNumber: CheckpointNumber.fromBigInt(result[0]),
-      provenArchive: Fr.fromString(result[1]),
+      provenArchive: Buffer32.fromString(result[1]),
       pendingCheckpointNumber: CheckpointNumber.fromBigInt(result[2]),
-      pendingArchive: Fr.fromString(result[3]),
-      archiveOfMyCheckpoint: Fr.fromString(result[4]),
+      pendingArchive: Buffer32.fromString(result[3]),
+      archiveOfMyCheckpoint: Buffer32.fromString(result[4]),
     };
   }
 
@@ -1173,8 +1184,8 @@ export class RollupContract {
     return Fr.fromString(await this.rollup.read.archive());
   }
 
-  async archiveAt(checkpointNumber: CheckpointNumber): Promise<Fr> {
-    return Fr.fromString(await this.rollup.read.archiveAt([BigInt(checkpointNumber)]));
+  async archiveAt(checkpointNumber: CheckpointNumber): Promise<Buffer32> {
+    return Buffer32.fromString(await this.rollup.read.archiveAt([BigInt(checkpointNumber)]));
   }
 
   getSequencerRewards(address: Hex | EthAddress): Promise<bigint> {
@@ -1371,7 +1382,7 @@ export class RollupContract {
         l1TransactionHash: log.transactionHash!,
         args: {
           checkpointNumber: CheckpointNumber.fromBigInt(log.args.checkpointNumber!),
-          archive: Fr.fromString(log.args.archive!),
+          archive: Buffer32.fromString(log.args.archive!),
           versionedBlobHashes: log.args.versionedBlobHashes!.map(h => Buffer.from(h.slice(2), 'hex')),
           attestationsHash: (() => {
             if (!log.args.attestationsHash) {

--- a/yarn-project/prover-node/src/prover-node-publisher.test.ts
+++ b/yarn-project/prover-node/src/prover-node-publisher.test.ts
@@ -133,12 +133,11 @@ describe('prover-node-publisher', () => {
       // Return the requested checkpoint
       rollup.getCheckpoint.mockImplementation((checkpointNumber: CheckpointNumber) =>
         Promise.resolve({
-          archive: checkpoints[checkpointNumber - 1].endArchiveRoot,
+          archive: Buffer32.fromField(checkpoints[checkpointNumber - 1].endArchiveRoot),
           attestationsHash: Buffer32.ZERO, // unused,
           payloadDigest: Buffer32.ZERO, // unused,
           headerHash: Buffer32.ZERO, // unused,
           blobCommitmentsHash: Buffer32.ZERO, // unused,
-          outHash: '0x', // unused,
           slotNumber: SlotNumber(0), // unused,
           feeHeader: {
             excessMana: 0n, // unused
@@ -201,12 +200,11 @@ describe('prover-node-publisher', () => {
     const checkpoints = Array.from({ length: 100 }, () => RootRollupPublicInputs.random());
     rollup.getCheckpoint.mockImplementation((n: CheckpointNumber) =>
       Promise.resolve({
-        archive: checkpoints[n - 1].endArchiveRoot,
+        archive: Buffer32.fromField(checkpoints[n - 1].endArchiveRoot),
         attestationsHash: Buffer32.ZERO,
         payloadDigest: Buffer32.ZERO,
         headerHash: Buffer32.ZERO,
         blobCommitmentsHash: Buffer32.ZERO,
-        outHash: '0x',
         slotNumber: SlotNumber(0),
         feeHeader: { excessMana: 0n, manaUsed: 0n, ethPerFeeAsset: 0n, congestionCost: 0n, proverCost: 0n },
       }),
@@ -264,12 +262,11 @@ describe('prover-node-publisher', () => {
     // Return the requested checkpoint
     rollup.getCheckpoint.mockImplementation((checkpointNumber: CheckpointNumber) =>
       Promise.resolve({
-        archive: checkpoints[checkpointNumber - 1].endArchiveRoot,
+        archive: Buffer32.fromField(checkpoints[checkpointNumber - 1].endArchiveRoot),
         attestationsHash: Buffer32.ZERO, // unused,
         payloadDigest: Buffer32.ZERO, // unused,
         headerHash: Buffer32.ZERO, // unused,
         blobCommitmentsHash: Buffer32.ZERO, // unused,
-        outHash: '0x', // unused,
         slotNumber: SlotNumber(0), // unused,
         feeHeader: {
           excessMana: 0n, // unused

--- a/yarn-project/prover-node/src/prover-node-publisher.ts
+++ b/yarn-project/prover-node/src/prover-node-publisher.ts
@@ -3,6 +3,7 @@ import { MAX_CHECKPOINTS_PER_EPOCH } from '@aztec/constants';
 import type { RollupContract, ViemCommitteeAttestation } from '@aztec/ethereum/contracts';
 import type { L1TxUtils } from '@aztec/ethereum/l1-tx-utils';
 import { CheckpointNumber, EpochNumber } from '@aztec/foundation/branded-types';
+import { Buffer32 } from '@aztec/foundation/buffer';
 import { areArraysEqual } from '@aztec/foundation/collection';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { EthAddress } from '@aztec/foundation/eth-address';
@@ -152,9 +153,11 @@ export class ProverNodePublisher {
       );
     }
 
-    // Check the archive for the immediate checkpoint before the epoch
+    // Check the archive for the immediate checkpoint before the epoch. The on-chain archive is carried as raw
+    // bytes (a malicious proposer can store an out-of-BN254-range value); compare via Buffer32 rather than
+    // converting it to Fr, so a mismatching out-of-range value reports a mismatch instead of throwing.
     const checkpointLog = await this.rollupContract.getCheckpoint(CheckpointNumber(fromCheckpoint - 1));
-    if (!publicInputs.previousArchiveRoot.equals(checkpointLog.archive)) {
+    if (!checkpointLog.archive.equals(Buffer32.fromField(publicInputs.previousArchiveRoot))) {
       throw new Error(
         `Previous archive root mismatch: ${publicInputs.previousArchiveRoot.toString()} !== ${checkpointLog.archive.toString()}`,
       );
@@ -162,7 +165,7 @@ export class ProverNodePublisher {
 
     // Check the archive for the last checkpoint in the epoch
     const endCheckpointLog = await this.rollupContract.getCheckpoint(toCheckpoint);
-    if (!publicInputs.endArchiveRoot.equals(endCheckpointLog.archive)) {
+    if (!endCheckpointLog.archive.equals(Buffer32.fromField(publicInputs.endArchiveRoot))) {
       throw new Error(
         `End archive root mismatch: ${publicInputs.endArchiveRoot.toString()} !== ${endCheckpointLog.archive.toString()}`,
       );

--- a/yarn-project/prover-node/src/prover-node-publisher.ts
+++ b/yarn-project/prover-node/src/prover-node-publisher.ts
@@ -12,7 +12,7 @@ import { RollupAbi } from '@aztec/l1-artifacts';
 import type { PublisherConfig, TxSenderConfig } from '@aztec/sequencer-client';
 import { CommitteeAttestation, CommitteeAttestationsAndSigners } from '@aztec/stdlib/block';
 import type { Proof } from '@aztec/stdlib/proofs';
-import type { CheckpointHeader, RootRollupPublicInputs } from '@aztec/stdlib/rollup';
+import { type CheckpointHeader, type RootRollupPublicInputs, toL1CheckpointHeader } from '@aztec/stdlib/rollup';
 import type { L1PublishProofStats } from '@aztec/stdlib/stats';
 import { type TelemetryClient, getTelemetryClient } from '@aztec/telemetry-client';
 
@@ -331,7 +331,7 @@ export class ProverNodePublisher {
         outHash: args.publicInputs.outHash.toString(),
         proverId: EthAddress.fromField(args.publicInputs.constants.proverId).toString(),
       } /*_args*/,
-      args.headers.map(header => header.toViem()) /*_headers*/,
+      args.headers.map(header => toL1CheckpointHeader(header)) /*_headers*/,
       getEthBlobEvaluationInputs(args.batchedBlobInputs) /*_blobPublicInputs*/,
     ] as const;
   }

--- a/yarn-project/sequencer-client/src/config.ts
+++ b/yarn-project/sequencer-client/src/config.ts
@@ -64,6 +64,7 @@ export const DefaultSequencerConfig = {
   injectUnrecoverableSignatureAttestation: false,
   fishermanMode: false,
   shuffleAttestationOrdering: false,
+  injectOutOfRangeCheckpointHeader: false,
   skipPushProposedBlocksToArchiver: false,
   skipPublishingCheckpointsPercent: 0,
   maxBlocksPerCheckpoint: DEFAULT_MAX_BLOCKS_PER_CHECKPOINT,
@@ -234,6 +235,12 @@ export const sequencerConfigMappings: ConfigMappingsType<SequencerConfig> = {
   shuffleAttestationOrdering: {
     description: 'Shuffle attestation ordering to create invalid ordering (for testing only)',
     ...booleanConfigHelper(DefaultSequencerConfig.shuffleAttestationOrdering),
+  },
+  injectOutOfRangeCheckpointHeader: {
+    description:
+      'Overwrite the propose calldata checkpoint header accumulatedFees with a value above the field modulus, ' +
+      'producing a checkpoint honest archivers cannot decode (for testing only)',
+    ...booleanConfigHelper(DefaultSequencerConfig.injectOutOfRangeCheckpointHeader),
   },
   ...sharedSequencerConfigMappings,
   buildCheckpointIfEmpty: {

--- a/yarn-project/sequencer-client/src/publisher/sequencer-publisher.test.ts
+++ b/yarn-project/sequencer-client/src/publisher/sequencer-publisher.test.ts
@@ -24,7 +24,7 @@ import { EmpireBaseAbi, RollupAbi } from '@aztec/l1-artifacts';
 import { CommitteeAttestationsAndSigners, L2Block, Signature } from '@aztec/stdlib/block';
 import { Checkpoint } from '@aztec/stdlib/checkpoint';
 import { EmptyL1RollupConstants } from '@aztec/stdlib/epoch-helpers';
-import { CheckpointHeader } from '@aztec/stdlib/rollup';
+import { CheckpointHeader, toL1CheckpointHeader } from '@aztec/stdlib/rollup';
 
 import { jest } from '@jest/globals';
 import { type MockProxy, mock } from 'jest-mock-extended';
@@ -251,7 +251,7 @@ describe('SequencerPublisher', () => {
 
     const args = [
       {
-        header: header.toViem(),
+        header: toL1CheckpointHeader(header),
         archive: toHex(archive),
         oracleInput: {
           feeAssetPriceModifier: 0n,

--- a/yarn-project/sequencer-client/src/publisher/sequencer-publisher.ts
+++ b/yarn-project/sequencer-client/src/publisher/sequencer-publisher.ts
@@ -142,6 +142,11 @@ export type InvalidateCheckpointRequest = {
 
 type EnqueueProposeCheckpointOpts = {
   txTimeoutAt?: Date;
+  /**
+   * When set, overwrite the propose calldata header's `accumulatedFees` with a value above the BN254 field modulus
+   * before encoding, producing a checkpoint that honest archivers cannot decode (for testing only, A-1254 repro).
+   */
+  injectOutOfRangeCheckpointHeader?: boolean;
 };
 
 export interface RequestWithExpiry {
@@ -1162,7 +1167,10 @@ export class SequencerPublisher {
       ...checkpoint.toCheckpointInfo(),
       txTimeoutAt: opts.txTimeoutAt,
     });
-    await this.addProposeTx(checkpoint, proposeTxArgs, { txTimeoutAt: opts.txTimeoutAt });
+    await this.addProposeTx(checkpoint, proposeTxArgs, {
+      txTimeoutAt: opts.txTimeoutAt,
+      injectOutOfRangeCheckpointHeader: opts.injectOutOfRangeCheckpointHeader,
+    });
   }
 
   public enqueueInvalidateCheckpoint(
@@ -1254,7 +1262,10 @@ export class SequencerPublisher {
     this.l1TxUtils.restart();
   }
 
-  private async prepareProposeTx(encodedData: L1ProcessArgs) {
+  private async prepareProposeTx(
+    encodedData: L1ProcessArgs,
+    opts: { injectOutOfRangeCheckpointHeader?: boolean } = {},
+  ) {
     const kzg = Blob.getViemKzgInstance();
     const blobInput = getPrefixedEthBlobCommitments(encodedData.blobs);
     this.log.debug('Validating blob input', { blobInput });
@@ -1315,9 +1326,21 @@ export class SequencerPublisher {
     }
     const signers = encodedData.attestationsAndSigners.getSigners().map(signer => signer.toString());
 
+    const viemHeader = encodedData.header.toViem();
+    if (opts.injectOutOfRangeCheckpointHeader) {
+      // A-1254 repro: overwrite a uint256 header field with a value above the BN254 field modulus. The clean
+      // CheckpointHeader on encodedData is left untouched so the pre-broadcast validateBlockHeader simulation still
+      // passes; only the calldata sent to L1 carries the out-of-range value, which honest archivers cannot decode.
+      viemHeader.accumulatedFees = 2n ** 256n - 1n;
+      this.log.warn('INJECTING out-of-range accumulatedFees into checkpoint header (A-1254 repro)', {
+        accumulatedFees: viemHeader.accumulatedFees.toString(),
+        slotNumber: viemHeader.slotNumber.toString(),
+      });
+    }
+
     const args = [
       {
-        header: encodedData.header.toViem(),
+        header: viemHeader,
         archive: toHex(encodedData.archive),
         oracleInput: {
           feeAssetPriceModifier: encodedData.feeAssetPriceModifier,
@@ -1342,7 +1365,9 @@ export class SequencerPublisher {
     const slot = checkpoint.header.slotNumber;
     const timer = new Timer();
     const kzg = Blob.getViemKzgInstance();
-    const { rollupData, blobEvaluationGas } = await this.prepareProposeTx(encodedData);
+    const { rollupData, blobEvaluationGas } = await this.prepareProposeTx(encodedData, {
+      injectOutOfRangeCheckpointHeader: opts.injectOutOfRangeCheckpointHeader,
+    });
     const startBlock = await this.l1TxUtils.getBlockNumber();
 
     // Send the blobs to the blob client preemptively. This helps in tests where the sequencer mistakingly thinks that the propose

--- a/yarn-project/sequencer-client/src/publisher/sequencer-publisher.ts
+++ b/yarn-project/sequencer-client/src/publisher/sequencer-publisher.ts
@@ -858,7 +858,7 @@ export class SequencerPublisher {
         checkpointNumber,
         forcePendingCheckpointNumber: CheckpointNumber(checkpointNumber - 1),
         // The rollback target is checkpoint N-1 (the last valid checkpoint), whose archive is always in
-        // range, so narrowing the raw `Fr | Buffer32` back to `Fr` here is safe.
+        // range, so converting the raw `Buffer32` back to `Fr` here is safe.
         lastArchive: Fr.fromBuffer(validationResult.checkpoint.lastArchive.toBuffer()),
         reason,
       };

--- a/yarn-project/sequencer-client/src/publisher/sequencer-publisher.ts
+++ b/yarn-project/sequencer-client/src/publisher/sequencer-publisher.ts
@@ -144,7 +144,7 @@ type EnqueueProposeCheckpointOpts = {
   txTimeoutAt?: Date;
   /**
    * When set, overwrite the propose calldata header's `accumulatedFees` with a value above the BN254 field modulus
-   * before encoding, producing a checkpoint that honest archivers cannot decode (for testing only, A-1254 repro).
+   * before encoding, producing a checkpoint that honest archivers cannot decode (for testing only).
    */
   injectOutOfRangeCheckpointHeader?: boolean;
 };
@@ -1328,11 +1328,11 @@ export class SequencerPublisher {
 
     const viemHeader = toL1CheckpointHeader(encodedData.header);
     if (opts.injectOutOfRangeCheckpointHeader) {
-      // A-1254 repro: overwrite a uint256 header field with a value above the BN254 field modulus. The clean
+      // Repro: overwrite a uint256 header field with a value above the BN254 field modulus. The clean
       // CheckpointHeader on encodedData is left untouched so the pre-broadcast validateBlockHeader simulation still
       // passes; only the calldata sent to L1 carries the out-of-range value, which honest archivers cannot decode.
       viemHeader.accumulatedFees = 2n ** 256n - 1n;
-      this.log.warn('INJECTING out-of-range accumulatedFees into checkpoint header (A-1254 repro)', {
+      this.log.warn('INJECTING out-of-range accumulatedFees into checkpoint header (repro)', {
         accumulatedFees: viemHeader.accumulatedFees.toString(),
         slotNumber: viemHeader.slotNumber.toString(),
       });

--- a/yarn-project/sequencer-client/src/publisher/sequencer-publisher.ts
+++ b/yarn-project/sequencer-client/src/publisher/sequencer-publisher.ts
@@ -50,7 +50,7 @@ import {
   getNextL1SlotTimestamp,
   getTimestampForSlot,
 } from '@aztec/stdlib/epoch-helpers';
-import type { CheckpointHeader } from '@aztec/stdlib/rollup';
+import { type CheckpointHeader, toL1CheckpointHeader } from '@aztec/stdlib/rollup';
 import type { L1PublishCheckpointStats } from '@aztec/stdlib/stats';
 import { type TelemetryClient, type Tracer, getTelemetryClient, trackSpan } from '@aztec/telemetry-client';
 
@@ -773,7 +773,7 @@ export class SequencerPublisher {
     const flags = { ignoreDA: true, ignoreSignatures: true };
 
     const args = [
-      header.toViem(),
+      toL1CheckpointHeader(header),
       CommitteeAttestationsAndSigners.packAttestations([]),
       [], // no signers
       Signature.empty().toViemSignature(),
@@ -1326,7 +1326,7 @@ export class SequencerPublisher {
     }
     const signers = encodedData.attestationsAndSigners.getSigners().map(signer => signer.toString());
 
-    const viemHeader = encodedData.header.toViem();
+    const viemHeader = toL1CheckpointHeader(encodedData.header);
     if (opts.injectOutOfRangeCheckpointHeader) {
       // A-1254 repro: overwrite a uint256 header field with a value above the BN254 field modulus. The clean
       // CheckpointHeader on encodedData is left untouched so the pre-broadcast validateBlockHeader simulation still

--- a/yarn-project/sequencer-client/src/publisher/sequencer-publisher.ts
+++ b/yarn-project/sequencer-client/src/publisher/sequencer-publisher.ts
@@ -33,7 +33,7 @@ import {
 import { CheckpointNumber, SlotNumber } from '@aztec/foundation/branded-types';
 import { trimmedBytesLength } from '@aztec/foundation/buffer';
 import { pick } from '@aztec/foundation/collection';
-import type { Fr } from '@aztec/foundation/curves/bn254';
+import { Fr } from '@aztec/foundation/curves/bn254';
 import { TimeoutError } from '@aztec/foundation/error';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { Signature } from '@aztec/foundation/eth-signature';
@@ -857,7 +857,9 @@ export class SequencerPublisher {
         gasUsed,
         checkpointNumber,
         forcePendingCheckpointNumber: CheckpointNumber(checkpointNumber - 1),
-        lastArchive: validationResult.checkpoint.lastArchive,
+        // The rollback target is checkpoint N-1 (the last valid checkpoint), whose archive is always in
+        // range, so narrowing the raw `Fr | Buffer32` back to `Fr` here is safe.
+        lastArchive: Fr.fromBuffer(validationResult.checkpoint.lastArchive.toBuffer()),
         reason,
       };
     } catch (err) {

--- a/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.test.ts
@@ -6,6 +6,7 @@ import {
   IndexWithinCheckpoint,
   SlotNumber,
 } from '@aztec/foundation/branded-types';
+import { Buffer32 } from '@aztec/foundation/buffer';
 import { timesAsync } from '@aztec/foundation/collection';
 import { Secp256k1Signer } from '@aztec/foundation/crypto/secp256k1-signer';
 import { Fr } from '@aztec/foundation/curves/bn254';
@@ -982,8 +983,8 @@ describe('CheckpointProposalJob', () => {
         valid: false,
         reason: 'invalid-attestation',
         checkpoint: {
-          archive: Fr.random(),
-          lastArchive: Fr.random(),
+          archive: Buffer32.fromField(Fr.random()),
+          lastArchive: Buffer32.fromField(Fr.random()),
           slotNumber: SlotNumber(1),
           checkpointNumber: CheckpointNumber(1),
           timestamp: 0n,
@@ -1019,8 +1020,8 @@ describe('CheckpointProposalJob', () => {
         valid: false,
         reason: 'invalid-attestation',
         checkpoint: {
-          archive: Fr.random(),
-          lastArchive: Fr.random(),
+          archive: Buffer32.fromField(Fr.random()),
+          lastArchive: Buffer32.fromField(Fr.random()),
           slotNumber: SlotNumber(1),
           checkpointNumber: CheckpointNumber(1),
           timestamp: 0n,
@@ -1052,8 +1053,8 @@ describe('CheckpointProposalJob', () => {
         valid: false,
         reason: 'invalid-attestation',
         checkpoint: {
-          archive: Fr.random(),
-          lastArchive: Fr.random(),
+          archive: Buffer32.fromField(Fr.random()),
+          lastArchive: Buffer32.fromField(Fr.random()),
           slotNumber: SlotNumber(1),
           checkpointNumber: CheckpointNumber(1),
           timestamp: 0n,

--- a/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.ts
+++ b/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.ts
@@ -398,7 +398,10 @@ export class CheckpointProposalJob implements Traceable {
       }
     }
 
-    await this.publisher.enqueueProposeCheckpoint(checkpoint, attestations, attestationsSignature, { txTimeoutAt });
+    await this.publisher.enqueueProposeCheckpoint(checkpoint, attestations, attestationsSignature, {
+      txTimeoutAt,
+      injectOutOfRangeCheckpointHeader: this.config.injectOutOfRangeCheckpointHeader,
+    });
   }
 
   /**

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.test.ts
@@ -8,6 +8,7 @@ import {
   IndexWithinCheckpoint,
   SlotNumber,
 } from '@aztec/foundation/branded-types';
+import { Buffer32 } from '@aztec/foundation/buffer';
 import { omit, times, timesParallel } from '@aztec/foundation/collection';
 import { Secp256k1Signer } from '@aztec/foundation/crypto/secp256k1-signer';
 import { Fr } from '@aztec/foundation/curves/bn254';
@@ -114,8 +115,8 @@ describe('sequencer', () => {
     checkpoint: {
       checkpointNumber: CheckpointNumber(1),
       timestamp: 0n,
-      archive: Fr.ZERO,
-      lastArchive: Fr.ZERO,
+      archive: Buffer32.ZERO,
+      lastArchive: Buffer32.ZERO,
       slotNumber: SlotNumber(1),
     },
     committee: [],
@@ -947,8 +948,8 @@ describe('sequencer', () => {
         checkpoint: {
           checkpointNumber: CheckpointNumber(1),
           timestamp: 1000n,
-          archive: Fr.random(),
-          lastArchive: Fr.random(),
+          archive: Buffer32.fromField(Fr.random()),
+          lastArchive: Buffer32.fromField(Fr.random()),
           slotNumber: SlotNumber(newSlotNumber),
         },
         committee: [validator2],

--- a/yarn-project/slasher/src/watchers/attestations_block_watcher.test.ts
+++ b/yarn-project/slasher/src/watchers/attestations_block_watcher.test.ts
@@ -1,5 +1,6 @@
 import type { EpochCache, EpochCommitteeInfo } from '@aztec/epoch-cache';
 import { CheckpointNumber, EpochNumber, SlotNumber } from '@aztec/foundation/branded-types';
+import { Buffer32 } from '@aztec/foundation/buffer';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import type {
@@ -38,8 +39,8 @@ describe('AttestationsBlockWatcher', () => {
 
     // Set up common test data
     checkpointInfo = {
-      archive: Fr.random(),
-      lastArchive: Fr.random(),
+      archive: Buffer32.fromField(Fr.random()),
+      lastArchive: Buffer32.fromField(Fr.random()),
       slotNumber: SlotNumber(1),
       checkpointNumber: CheckpointNumber(1),
       timestamp: BigInt(Math.floor(Date.now() / 1000)),
@@ -125,8 +126,8 @@ describe('AttestationsBlockWatcher', () => {
     // an invalidCheckpointDetected (own attestations) and a descendentOfInvalidAttestationsCheckpointDetected
     // (extends a rejected ancestor) for the same checkpoint.
     const childCheckpointInfo: CheckpointInfo = {
-      archive: Fr.random(),
-      lastArchive: Fr.fromBuffer(checkpointInfo.archive.toBuffer()), // Parent archive (the rejected ancestor)
+      archive: Buffer32.fromField(Fr.random()),
+      lastArchive: checkpointInfo.archive, // Parent archive (the rejected ancestor)
       slotNumber: SlotNumber(2),
       checkpointNumber: CheckpointNumber(2),
       timestamp: BigInt(Math.floor(Date.now() / 1000)),
@@ -202,8 +203,8 @@ describe('AttestationsBlockWatcher', () => {
     handler.mockClear();
 
     const descendantCheckpointInfo: CheckpointInfo = {
-      archive: Fr.random(),
-      lastArchive: Fr.fromBuffer(checkpointInfo.archive.toBuffer()),
+      archive: Buffer32.fromField(Fr.random()),
+      lastArchive: checkpointInfo.archive,
       slotNumber: SlotNumber(2),
       checkpointNumber: CheckpointNumber(2),
       timestamp: BigInt(Math.floor(Date.now() / 1000)),
@@ -236,8 +237,8 @@ describe('AttestationsBlockWatcher', () => {
     // descendant (D2) that both has its own invalid attestations and extends an earlier descendant (D1)
     // is reported through two events; the watcher slashes its proposer for each offense independently.
     const d2: CheckpointInfo = {
-      archive: Fr.random(),
-      lastArchive: Fr.random(),
+      archive: Buffer32.fromField(Fr.random()),
+      lastArchive: Buffer32.fromField(Fr.random()),
       slotNumber: SlotNumber(3),
       checkpointNumber: CheckpointNumber(3),
       timestamp: BigInt(Math.floor(Date.now() / 1000)),
@@ -273,7 +274,7 @@ describe('AttestationsBlockWatcher', () => {
     await watcher.handleDescendantOfInvalid({
       type: 'descendentOfInvalidAttestationsCheckpointDetected',
       checkpoint: d2,
-      ancestorArchiveRoot: Fr.random(),
+      ancestorArchiveRoot: Buffer32.fromField(Fr.random()),
       ancestorCheckpointNumber: CheckpointNumber(1),
     });
 
@@ -292,8 +293,8 @@ describe('AttestationsBlockWatcher', () => {
     epochCache.getProposerFromEpochCommittee.mockReturnValue(undefined);
 
     const descendant: CheckpointInfo = {
-      archive: Fr.random(),
-      lastArchive: Fr.random(),
+      archive: Buffer32.fromField(Fr.random()),
+      lastArchive: Buffer32.fromField(Fr.random()),
       slotNumber: SlotNumber(2),
       checkpointNumber: CheckpointNumber(2),
       timestamp: BigInt(Math.floor(Date.now() / 1000)),
@@ -301,7 +302,7 @@ describe('AttestationsBlockWatcher', () => {
     await watcher.handleDescendantOfInvalid({
       type: 'descendentOfInvalidAttestationsCheckpointDetected',
       checkpoint: descendant,
-      ancestorArchiveRoot: Fr.random(),
+      ancestorArchiveRoot: Buffer32.fromField(Fr.random()),
       ancestorCheckpointNumber: CheckpointNumber(1),
     });
 

--- a/yarn-project/slasher/src/watchers/attestations_block_watcher.test.ts
+++ b/yarn-project/slasher/src/watchers/attestations_block_watcher.test.ts
@@ -126,7 +126,7 @@ describe('AttestationsBlockWatcher', () => {
     // (extends a rejected ancestor) for the same checkpoint.
     const childCheckpointInfo: CheckpointInfo = {
       archive: Fr.random(),
-      lastArchive: checkpointInfo.archive, // Parent archive (the rejected ancestor)
+      lastArchive: Fr.fromBuffer(checkpointInfo.archive.toBuffer()), // Parent archive (the rejected ancestor)
       slotNumber: SlotNumber(2),
       checkpointNumber: CheckpointNumber(2),
       timestamp: BigInt(Math.floor(Date.now() / 1000)),
@@ -203,7 +203,7 @@ describe('AttestationsBlockWatcher', () => {
 
     const descendantCheckpointInfo: CheckpointInfo = {
       archive: Fr.random(),
-      lastArchive: checkpointInfo.archive,
+      lastArchive: Fr.fromBuffer(checkpointInfo.archive.toBuffer()),
       slotNumber: SlotNumber(2),
       checkpointNumber: CheckpointNumber(2),
       timestamp: BigInt(Math.floor(Date.now() / 1000)),

--- a/yarn-project/slasher/src/watchers/checkpoint_equivocation_watcher.test.ts
+++ b/yarn-project/slasher/src/watchers/checkpoint_equivocation_watcher.test.ts
@@ -1,5 +1,6 @@
 import type { EpochCacheInterface } from '@aztec/epoch-cache';
 import { CheckpointNumber, SlotNumber } from '@aztec/foundation/branded-types';
+import { Buffer32 } from '@aztec/foundation/buffer';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import {
@@ -32,7 +33,7 @@ describe('CheckpointEquivocationWatcher', () => {
     type: L2BlockSourceEvents.CheckpointEquivocationDetected,
     slotNumber: SlotNumber(10),
     checkpointNumber: CheckpointNumber(2),
-    l1ArchiveRoot: Fr.random(),
+    l1ArchiveRoot: Buffer32.fromField(Fr.random()),
     proposedArchiveRoot: Fr.random(),
     ...overrides,
   });

--- a/yarn-project/stdlib/src/block/attestation_info.ts
+++ b/yarn-project/stdlib/src/block/attestation_info.ts
@@ -1,3 +1,4 @@
+import type { Buffer32 } from '@aztec/foundation/buffer';
 import { recoverAddress } from '@aztec/foundation/crypto/secp256k1-signer';
 import type { EthAddress } from '@aztec/foundation/eth-address';
 
@@ -47,8 +48,17 @@ export function getAttestationInfoFromPayload(
   payload: ConsensusPayload,
   attestations: CommitteeAttestation[],
 ): AttestationInfo[] {
-  const hashedPayload = getHashedSignaturePayloadTypedData(payload);
+  return getAttestationInfoFromDigest(getHashedSignaturePayloadTypedData(payload), attestations);
+}
 
+/**
+ * Extracts attestation information given a precomputed consensus digest. Used when the digest must be derived
+ * from raw (possibly out-of-range) header/archive bytes without building a full ConsensusPayload (see A-1254).
+ */
+export function getAttestationInfoFromDigest(
+  hashedPayload: Buffer32,
+  attestations: CommitteeAttestation[],
+): AttestationInfo[] {
   return attestations.map(attestation => {
     // If signature is empty, check if we have an address directly
     if (attestation.signature.isEmpty()) {

--- a/yarn-project/stdlib/src/block/attestation_info.ts
+++ b/yarn-project/stdlib/src/block/attestation_info.ts
@@ -53,7 +53,7 @@ export function getAttestationInfoFromPayload(
 
 /**
  * Extracts attestation information given a precomputed consensus digest. Used when the digest must be derived
- * from raw (possibly out-of-range) header/archive bytes without building a full ConsensusPayload (see A-1254).
+ * from raw (possibly out-of-range) header/archive bytes without building a full ConsensusPayload.
  */
 export function getAttestationInfoFromDigest(
   hashedPayload: Buffer32,

--- a/yarn-project/stdlib/src/block/l2_block_source.ts
+++ b/yarn-project/stdlib/src/block/l2_block_source.ts
@@ -8,6 +8,7 @@ import {
   type SlotNumber,
   SlotNumberSchema,
 } from '@aztec/foundation/branded-types';
+import type { Buffer32 } from '@aztec/foundation/buffer';
 import type { Fr } from '@aztec/foundation/curves/bn254';
 import type { EthAddress } from '@aztec/foundation/eth-address';
 import { schemas } from '@aztec/foundation/schemas';
@@ -445,7 +446,8 @@ export type CheckpointEquivocationDetectedEvent = {
   type: 'checkpointEquivocationDetected';
   slotNumber: SlotNumber;
   checkpointNumber: CheckpointNumber;
-  l1ArchiveRoot: Fr;
+  /** Archive root from the L1-confirmed checkpoint; may be raw bytes if the malicious header was out of range. */
+  l1ArchiveRoot: Fr | Buffer32;
   proposedArchiveRoot: Fr;
 };
 
@@ -459,8 +461,8 @@ export type DescendentOfInvalidAttestationsCheckpointEvent = {
   type: 'descendentOfInvalidAttestationsCheckpointDetected';
   /** The descendant checkpoint being rejected. */
   checkpoint: CheckpointInfo;
-  /** Archive root of the rejected ancestor this descendant builds on. */
-  ancestorArchiveRoot: Fr;
+  /** Archive root of the rejected ancestor this descendant builds on; may be raw bytes if out of range. */
+  ancestorArchiveRoot: Fr | Buffer32;
   /** Checkpoint number of the rejected ancestor. */
   ancestorCheckpointNumber: CheckpointNumber;
 };

--- a/yarn-project/stdlib/src/block/l2_block_source.ts
+++ b/yarn-project/stdlib/src/block/l2_block_source.ts
@@ -446,8 +446,8 @@ export type CheckpointEquivocationDetectedEvent = {
   type: 'checkpointEquivocationDetected';
   slotNumber: SlotNumber;
   checkpointNumber: CheckpointNumber;
-  /** Archive root from the L1-confirmed checkpoint; may be raw bytes if the malicious header was out of range. */
-  l1ArchiveRoot: Fr | Buffer32;
+  /** Archive root from the L1-confirmed checkpoint, as raw bytes (may be out of range for a malicious header). */
+  l1ArchiveRoot: Buffer32;
   proposedArchiveRoot: Fr;
 };
 
@@ -461,8 +461,8 @@ export type DescendentOfInvalidAttestationsCheckpointEvent = {
   type: 'descendentOfInvalidAttestationsCheckpointDetected';
   /** The descendant checkpoint being rejected. */
   checkpoint: CheckpointInfo;
-  /** Archive root of the rejected ancestor this descendant builds on; may be raw bytes if out of range. */
-  ancestorArchiveRoot: Fr | Buffer32;
+  /** Archive root of the rejected ancestor this descendant builds on, as raw bytes (may be out of range). */
+  ancestorArchiveRoot: Buffer32;
   /** Checkpoint number of the rejected ancestor. */
   ancestorCheckpointNumber: CheckpointNumber;
 };

--- a/yarn-project/stdlib/src/checkpoint/checkpoint.ts
+++ b/yarn-project/stdlib/src/checkpoint/checkpoint.ts
@@ -6,6 +6,7 @@ import {
   IndexWithinCheckpoint,
   SlotNumber,
 } from '@aztec/foundation/branded-types';
+import { Buffer32 } from '@aztec/foundation/buffer';
 import { pick, sum } from '@aztec/foundation/collection';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { BufferReader, serializeSignedBigInt, serializeToBuffer } from '@aztec/foundation/serialize';
@@ -119,8 +120,8 @@ export class Checkpoint {
 
   public toCheckpointInfo(): CheckpointInfo {
     return {
-      archive: this.archive.root,
-      lastArchive: this.header.lastArchiveRoot,
+      archive: Buffer32.fromField(this.archive.root),
+      lastArchive: Buffer32.fromField(this.header.lastArchiveRoot),
       slotNumber: this.header.slotNumber,
       checkpointNumber: this.number,
       timestamp: this.header.timestamp,

--- a/yarn-project/stdlib/src/checkpoint/checkpoint_info.ts
+++ b/yarn-project/stdlib/src/checkpoint/checkpoint_info.ts
@@ -14,7 +14,7 @@ import { z } from 'zod';
 export type CheckpointInfo = {
   /**
    * Archive root after this checkpoint. Carried as `Fr | Buffer32` so a rejected checkpoint with an
-   * out-of-range archive root (which cannot be represented as an `Fr`) is still describable (see A-1254).
+   * out-of-range archive root (which cannot be represented as an `Fr`) is still describable.
    */
   archive: Fr | Buffer32;
   lastArchive: Fr;

--- a/yarn-project/stdlib/src/checkpoint/checkpoint_info.ts
+++ b/yarn-project/stdlib/src/checkpoint/checkpoint_info.ts
@@ -13,12 +13,13 @@ import { z } from 'zod';
 
 export type CheckpointInfo = {
   /**
-   * Archive root after this checkpoint. Carried as `Fr | Buffer32` so a rejected checkpoint with an
-   * out-of-range archive root (which cannot be represented as an `Fr`) is still describable.
+   * Archive root after this checkpoint, as raw bytes. Carried as `Buffer32` (not `Fr`) because a checkpoint
+   * rejected for an out-of-range archive root has a root that does not fit in the BN254 field; conversion to
+   * `Fr` happens only at the ingestion boundary, once the checkpoint is known to be valid and in range.
    */
-  archive: Fr | Buffer32;
-  /** Archive root this checkpoint builds on; `Fr | Buffer32` for the same out-of-range reason as `archive`. */
-  lastArchive: Fr | Buffer32;
+  archive: Buffer32;
+  /** Archive root this checkpoint builds on, as raw bytes (may be out of range for the same reason as `archive`). */
+  lastArchive: Buffer32;
   slotNumber: SlotNumber;
   checkpointNumber: CheckpointNumber;
   timestamp: bigint;
@@ -26,8 +27,8 @@ export type CheckpointInfo = {
 
 export function randomCheckpointInfo(checkpointNumber?: CheckpointNumber | number): CheckpointInfo {
   return {
-    archive: Fr.random(),
-    lastArchive: Fr.random(),
+    archive: Buffer32.fromField(Fr.random()),
+    lastArchive: Buffer32.fromField(Fr.random()),
     slotNumber: SlotNumber(Math.floor(Math.random() * 100000) + 1),
     checkpointNumber: CheckpointNumber(checkpointNumber ?? Math.floor(Math.random() * 100000) + 1),
     timestamp: BigInt(Math.floor(Date.now() / 1000)),
@@ -35,33 +36,25 @@ export function randomCheckpointInfo(checkpointNumber?: CheckpointNumber | numbe
 }
 
 export const CheckpointInfoSchema = z.object({
-  archive: z.union([schemas.Fr, schemas.Buffer32]),
-  lastArchive: z.union([schemas.Fr, schemas.Buffer32]),
+  archive: schemas.Buffer32,
+  lastArchive: schemas.Buffer32,
   slotNumber: SlotNumberSchema,
   checkpointNumber: CheckpointNumberSchema,
   timestamp: schemas.BigInt,
 });
 
 export function serializeCheckpointInfo(info: CheckpointInfo): Buffer {
-  // Both Fr and Buffer32 serialize to the same 32 raw big-endian bytes, so the on-disk format is unchanged.
   return serializeToBuffer(info.archive, info.lastArchive, info.slotNumber, info.checkpointNumber, info.timestamp);
 }
 
 export function deserializeCheckpointInfo(buffer: Buffer | BufferReader): CheckpointInfo {
   const reader = BufferReader.asReader(buffer);
   return {
-    // The archive root may be out of the BN254 field (rejected out-of-range checkpoint), so read the raw 32
-    // bytes and only narrow to Fr when in range, falling back to Buffer32 otherwise.
-    archive: archiveFromBuffer(reader.readBytes(32)),
-    // Mirror `archive`: read the raw 32 bytes and only narrow to Fr when in range.
-    lastArchive: archiveFromBuffer(reader.readBytes(32)),
+    // Archive roots are stored as raw 32 bytes; a rejected checkpoint may carry an out-of-range value.
+    archive: Buffer32.fromBuffer(reader.readBytes(32)),
+    lastArchive: Buffer32.fromBuffer(reader.readBytes(32)),
     slotNumber: SlotNumber(reader.readNumber()),
     checkpointNumber: CheckpointNumber(reader.readNumber()),
     timestamp: reader.readBigInt(),
   };
-}
-
-/** Narrows a raw 32-byte archive root to `Fr` when it fits in the field, otherwise keeps it as `Buffer32`. */
-export function archiveFromBuffer(bytes: Buffer): Fr | Buffer32 {
-  return BigInt(`0x${bytes.toString('hex')}`) < Fr.MODULUS ? Fr.fromBuffer(bytes) : Buffer32.fromBuffer(bytes);
 }

--- a/yarn-project/stdlib/src/checkpoint/checkpoint_info.ts
+++ b/yarn-project/stdlib/src/checkpoint/checkpoint_info.ts
@@ -17,7 +17,8 @@ export type CheckpointInfo = {
    * out-of-range archive root (which cannot be represented as an `Fr`) is still describable.
    */
   archive: Fr | Buffer32;
-  lastArchive: Fr;
+  /** Archive root this checkpoint builds on; `Fr | Buffer32` for the same out-of-range reason as `archive`. */
+  lastArchive: Fr | Buffer32;
   slotNumber: SlotNumber;
   checkpointNumber: CheckpointNumber;
   timestamp: bigint;
@@ -35,7 +36,7 @@ export function randomCheckpointInfo(checkpointNumber?: CheckpointNumber | numbe
 
 export const CheckpointInfoSchema = z.object({
   archive: z.union([schemas.Fr, schemas.Buffer32]),
-  lastArchive: schemas.Fr,
+  lastArchive: z.union([schemas.Fr, schemas.Buffer32]),
   slotNumber: SlotNumberSchema,
   checkpointNumber: CheckpointNumberSchema,
   timestamp: schemas.BigInt,
@@ -52,7 +53,8 @@ export function deserializeCheckpointInfo(buffer: Buffer | BufferReader): Checkp
     // The archive root may be out of the BN254 field (rejected out-of-range checkpoint), so read the raw 32
     // bytes and only narrow to Fr when in range, falling back to Buffer32 otherwise.
     archive: archiveFromBuffer(reader.readBytes(32)),
-    lastArchive: reader.readObject(Fr),
+    // Mirror `archive`: read the raw 32 bytes and only narrow to Fr when in range.
+    lastArchive: archiveFromBuffer(reader.readBytes(32)),
     slotNumber: SlotNumber(reader.readNumber()),
     checkpointNumber: CheckpointNumber(reader.readNumber()),
     timestamp: reader.readBigInt(),

--- a/yarn-project/stdlib/src/checkpoint/checkpoint_info.ts
+++ b/yarn-project/stdlib/src/checkpoint/checkpoint_info.ts
@@ -4,6 +4,7 @@ import {
   SlotNumber,
   SlotNumberSchema,
 } from '@aztec/foundation/branded-types';
+import { Buffer32 } from '@aztec/foundation/buffer';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { schemas } from '@aztec/foundation/schemas';
 import { BufferReader, serializeToBuffer } from '@aztec/foundation/serialize';
@@ -11,7 +12,11 @@ import { BufferReader, serializeToBuffer } from '@aztec/foundation/serialize';
 import { z } from 'zod';
 
 export type CheckpointInfo = {
-  archive: Fr;
+  /**
+   * Archive root after this checkpoint. Carried as `Fr | Buffer32` so a rejected checkpoint with an
+   * out-of-range archive root (which cannot be represented as an `Fr`) is still describable (see A-1254).
+   */
+  archive: Fr | Buffer32;
   lastArchive: Fr;
   slotNumber: SlotNumber;
   checkpointNumber: CheckpointNumber;
@@ -29,7 +34,7 @@ export function randomCheckpointInfo(checkpointNumber?: CheckpointNumber | numbe
 }
 
 export const CheckpointInfoSchema = z.object({
-  archive: schemas.Fr,
+  archive: z.union([schemas.Fr, schemas.Buffer32]),
   lastArchive: schemas.Fr,
   slotNumber: SlotNumberSchema,
   checkpointNumber: CheckpointNumberSchema,
@@ -37,16 +42,24 @@ export const CheckpointInfoSchema = z.object({
 });
 
 export function serializeCheckpointInfo(info: CheckpointInfo): Buffer {
+  // Both Fr and Buffer32 serialize to the same 32 raw big-endian bytes, so the on-disk format is unchanged.
   return serializeToBuffer(info.archive, info.lastArchive, info.slotNumber, info.checkpointNumber, info.timestamp);
 }
 
 export function deserializeCheckpointInfo(buffer: Buffer | BufferReader): CheckpointInfo {
   const reader = BufferReader.asReader(buffer);
   return {
-    archive: reader.readObject(Fr),
+    // The archive root may be out of the BN254 field (rejected out-of-range checkpoint), so read the raw 32
+    // bytes and only narrow to Fr when in range, falling back to Buffer32 otherwise.
+    archive: archiveFromBuffer(reader.readBytes(32)),
     lastArchive: reader.readObject(Fr),
     slotNumber: SlotNumber(reader.readNumber()),
     checkpointNumber: CheckpointNumber(reader.readNumber()),
     timestamp: reader.readBigInt(),
   };
+}
+
+/** Narrows a raw 32-byte archive root to `Fr` when it fits in the field, otherwise keeps it as `Buffer32`. */
+export function archiveFromBuffer(bytes: Buffer): Fr | Buffer32 {
+  return BigInt(`0x${bytes.toString('hex')}`) < Fr.MODULUS ? Fr.fromBuffer(bytes) : Buffer32.fromBuffer(bytes);
 }

--- a/yarn-project/stdlib/src/checkpoint/digest.ts
+++ b/yarn-project/stdlib/src/checkpoint/digest.ts
@@ -1,9 +1,13 @@
-import type { Buffer32 } from '@aztec/foundation/buffer';
+import { Buffer32 } from '@aztec/foundation/buffer';
 import type { Fr } from '@aztec/foundation/curves/bn254';
 
-import { ConsensusPayload } from '../p2p/consensus_payload.js';
-import { type CoordinationSignatureContext, getHashedSignaturePayloadTypedData } from '../p2p/signature_utils.js';
-import { CheckpointHeader } from '../rollup/checkpoint_header.js';
+import { encodeCheckpointPayloadToSign } from '../p2p/consensus_payload.js';
+import {
+  type CoordinationSignatureContext,
+  type Signable,
+  getHashedSignaturePayloadTypedData,
+} from '../p2p/signature_utils.js';
+import type { CheckpointHeader } from '../rollup/checkpoint_header.js';
 
 /**
  * Computes the EIP-712 payload digest for a checkpoint proposal — the digest validators sign
@@ -11,18 +15,23 @@ import { CheckpointHeader } from '../rollup/checkpoint_header.js';
  *
  * The result is the same `bytes32` that gets stored in `tempCheckpointLogs[checkpointNumber].payloadDigest`,
  * so this helper is also reused when constructing simulation state overrides for pipelined proposals.
+ *
+ * Accepts either a validated `CheckpointHeader` (via `header`) or a raw header hash (via `headerHash`), and
+ * an archive root as `Fr` or raw `Buffer32`. The raw-hash/raw-archive form lets the archiver verify the
+ * digest of a malicious, possibly out-of-range, checkpoint without converting it into an `Fr`/`CheckpointHeader`.
  */
-export function computeCheckpointPayloadDigest(args: {
-  header: CheckpointHeader;
-  archiveRoot: Fr;
-  feeAssetPriceModifier: bigint;
-  signatureContext: CoordinationSignatureContext;
-}): Buffer32 {
-  const consensusPayload = new ConsensusPayload(
-    args.header,
-    args.archiveRoot,
-    args.feeAssetPriceModifier,
-    args.signatureContext,
-  );
-  return getHashedSignaturePayloadTypedData(consensusPayload);
+export function computeCheckpointPayloadDigest(
+  args: {
+    archiveRoot: Fr | Buffer32;
+    feeAssetPriceModifier: bigint;
+    signatureContext: CoordinationSignatureContext;
+  } & ({ header: CheckpointHeader } | { headerHash: Fr }),
+): Buffer32 {
+  const headerHash = 'header' in args ? args.header.hash() : args.headerHash;
+  const signable: Signable = {
+    primaryType: 'CheckpointAttestation',
+    signatureContext: args.signatureContext,
+    getPayloadToSign: () => encodeCheckpointPayloadToSign(args.archiveRoot, headerHash, args.feeAssetPriceModifier),
+  };
+  return getHashedSignaturePayloadTypedData(signable);
 }

--- a/yarn-project/stdlib/src/checkpoint/digest.ts
+++ b/yarn-project/stdlib/src/checkpoint/digest.ts
@@ -1,4 +1,4 @@
-import { Buffer32 } from '@aztec/foundation/buffer';
+import type { Buffer32 } from '@aztec/foundation/buffer';
 import type { Fr } from '@aztec/foundation/curves/bn254';
 
 import { encodeCheckpointPayloadToSign } from '../p2p/consensus_payload.js';
@@ -16,13 +16,13 @@ import type { CheckpointHeader } from '../rollup/checkpoint_header.js';
  * The result is the same `bytes32` that gets stored in `tempCheckpointLogs[checkpointNumber].payloadDigest`,
  * so this helper is also reused when constructing simulation state overrides for pipelined proposals.
  *
- * Accepts either a validated `CheckpointHeader` (via `header`) or a raw header hash (via `headerHash`), and
- * an archive root as `Fr` or raw `Buffer32`. The raw-hash/raw-archive form lets the archiver verify the
- * digest of a malicious, possibly out-of-range, checkpoint without converting it into an `Fr`/`CheckpointHeader`.
+ * Accepts either a validated `CheckpointHeader` (via `header`) or a raw header hash (via `headerHash`). The
+ * archive root is always taken as raw `Buffer32` bytes, so the raw-hash form lets the archiver verify the
+ * digest of a malicious, possibly out-of-range, checkpoint without converting it into a `CheckpointHeader`.
  */
 export function computeCheckpointPayloadDigest(
   args: {
-    archiveRoot: Fr | Buffer32;
+    archiveRoot: Buffer32;
     feeAssetPriceModifier: bigint;
     signatureContext: CoordinationSignatureContext;
   } & ({ header: CheckpointHeader } | { headerHash: Fr }),

--- a/yarn-project/stdlib/src/checkpoint/simulation_overrides.ts
+++ b/yarn-project/stdlib/src/checkpoint/simulation_overrides.ts
@@ -5,6 +5,7 @@ import {
   type SimulationOverridesPlan,
 } from '@aztec/ethereum/contracts';
 import { CheckpointNumber } from '@aztec/foundation/branded-types';
+import { Buffer32 } from '@aztec/foundation/buffer';
 import type { Logger } from '@aztec/foundation/log';
 
 import type { CoordinationSignatureContext } from '../p2p/signature_utils.js';
@@ -90,7 +91,7 @@ export async function buildCheckpointSimulationOverridesPlan(
       slotNumber: header.slotNumber,
       payloadDigest: computeCheckpointPayloadDigest({
         header,
-        archiveRoot: archive.root,
+        archiveRoot: Buffer32.fromField(archive.root),
         feeAssetPriceModifier,
         signatureContext: input.signatureContext,
       }),

--- a/yarn-project/stdlib/src/interfaces/configs.ts
+++ b/yarn-project/stdlib/src/interfaces/configs.ts
@@ -128,7 +128,7 @@ export interface SequencerConfig {
   pauseProposingForSlots?: SlotNumber[];
   /**
    * Overwrite the propose calldata's checkpoint header `accumulatedFees` with a value above the BN254 field modulus
-   * before sending to L1, producing a checkpoint that honest archivers cannot decode (for testing only, A-1254 repro).
+   * before sending to L1, producing a checkpoint that honest archivers cannot decode (for testing only).
    */
   injectOutOfRangeCheckpointHeader?: boolean;
 }

--- a/yarn-project/stdlib/src/interfaces/configs.ts
+++ b/yarn-project/stdlib/src/interfaces/configs.ts
@@ -126,6 +126,11 @@ export interface SequencerConfig {
   skipBroadcastCheckpointProposal?: boolean;
   /** List of slots for which the sequencer will not produce a proposal (for testing only). Attestation paths are unaffected. */
   pauseProposingForSlots?: SlotNumber[];
+  /**
+   * Overwrite the propose calldata's checkpoint header `accumulatedFees` with a value above the BN254 field modulus
+   * before sending to L1, producing a checkpoint that honest archivers cannot decode (for testing only, A-1254 repro).
+   */
+  injectOutOfRangeCheckpointHeader?: boolean;
 }
 
 export const SequencerConfigSchema = zodFor<SequencerConfig>()(
@@ -177,6 +182,7 @@ export const SequencerConfigSchema = zodFor<SequencerConfig>()(
     skipBroadcastProposals: z.boolean().optional(),
     skipBroadcastCheckpointProposal: z.boolean().optional(),
     pauseProposingForSlots: z.array(SlotNumberSchema).optional(),
+    injectOutOfRangeCheckpointHeader: z.boolean().optional(),
   }),
 );
 

--- a/yarn-project/stdlib/src/p2p/consensus_payload.ts
+++ b/yarn-project/stdlib/src/p2p/consensus_payload.ts
@@ -1,3 +1,4 @@
+import { Buffer32 } from '@aztec/foundation/buffer';
 import { keccak256 } from '@aztec/foundation/crypto/keccak';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { schemas } from '@aztec/foundation/schemas';
@@ -21,6 +22,30 @@ import {
   readCoordinationSignatureContext,
   serializeCoordinationSignatureContext,
 } from './signature_utils.js';
+
+/**
+ * Encodes the L1 `ProposePayload` (archive, oracleInput, headerHash) that validators sign and the rollup
+ * verifies during `propose()`. Works on raw 32-byte values, so it can encode an out-of-range archive root
+ * or header hash (the bytes are taken verbatim). Mirrors `ConsensusPayload.getPayloadToSign`.
+ */
+export function encodeCheckpointPayloadToSign(
+  archiveRoot: Fr | Buffer32,
+  headerHash: Fr,
+  feeAssetPriceModifier: bigint,
+): Buffer {
+  // Matches the L1 ProposePayload struct in ProposeLib.sol.
+  const abi = parseAbiParameters(
+    '(' +
+      'bytes32, ' + // archive
+      '(int256), ' + // oracleInput
+      'bytes32' + // headerHash
+      ')',
+  );
+  const encodedData = encodeAbiParameters(abi, [
+    [archiveRoot.toString(), [feeAssetPriceModifier], headerHash.toString()],
+  ] as const);
+  return hexToBuffer(encodedData);
+}
 
 /** Checkpoint consensus payload as signed by validators and verified on L1. */
 export class ConsensusPayload implements Signable {
@@ -55,19 +80,7 @@ export class ConsensusPayload implements Signable {
   }
 
   getPayloadToSign(): Buffer {
-    // Matches the L1 ProposePayload struct in ProposeLib.sol.
-    const abi = parseAbiParameters(
-      '(' +
-        'bytes32, ' + // archive
-        '(int256), ' + // oracleInput
-        'bytes32' + // headerHash
-        ')',
-    );
-    const archiveRoot = this.archive.toString();
-    const headerHash = this.header.hash().toString();
-    const encodedData = encodeAbiParameters(abi, [[archiveRoot, [this.feeAssetPriceModifier], headerHash]] as const);
-
-    return hexToBuffer(encodedData);
+    return encodeCheckpointPayloadToSign(this.archive, this.header.hash(), this.feeAssetPriceModifier);
   }
 
   /**

--- a/yarn-project/stdlib/src/p2p/consensus_payload.ts
+++ b/yarn-project/stdlib/src/p2p/consensus_payload.ts
@@ -29,7 +29,7 @@ import {
  * or header hash (the bytes are taken verbatim). Mirrors `ConsensusPayload.getPayloadToSign`.
  */
 export function encodeCheckpointPayloadToSign(
-  archiveRoot: Fr | Buffer32,
+  archiveRoot: Buffer32,
   headerHash: Fr,
   feeAssetPriceModifier: bigint,
 ): Buffer {
@@ -80,7 +80,11 @@ export class ConsensusPayload implements Signable {
   }
 
   getPayloadToSign(): Buffer {
-    return encodeCheckpointPayloadToSign(this.archive, this.header.hash(), this.feeAssetPriceModifier);
+    return encodeCheckpointPayloadToSign(
+      Buffer32.fromField(this.archive),
+      this.header.hash(),
+      this.feeAssetPriceModifier,
+    );
   }
 
   /**

--- a/yarn-project/stdlib/src/rollup/checkpoint_header.ts
+++ b/yarn-project/stdlib/src/rollup/checkpoint_header.ts
@@ -1,4 +1,3 @@
-import type { ViemHeader } from '@aztec/ethereum/contracts';
 import { SlotNumber } from '@aztec/foundation/branded-types';
 import { sha256ToField } from '@aztec/foundation/crypto/sha256';
 import { Fr } from '@aztec/foundation/curves/bn254';
@@ -230,49 +229,12 @@ export class CheckpointHeader {
     return CheckpointHeader.fromBuffer(hexToBuffer(str));
   }
 
-  static fromViem(header: ViemHeader) {
-    return new CheckpointHeader(
-      Fr.fromString(header.lastArchiveRoot),
-      Fr.fromString(header.blockHeadersHash),
-      Fr.fromString(header.blobsHash),
-      Fr.fromString(header.inHash),
-      Fr.fromString(header.outHash),
-      SlotNumber.fromBigInt(header.slotNumber),
-      header.timestamp,
-      new EthAddress(hexToBuffer(header.coinbase)),
-      new AztecAddress(hexToBuffer(header.feeRecipient)),
-      new GasFees(header.gasFees.feePerDaGas, header.gasFees.feePerL2Gas),
-      new Fr(header.totalManaUsed),
-      new Fr(header.accumulatedFees),
-    );
-  }
-
   /**
    * Returns the slot number as a SlotNumber branded type.
    * @deprecated Use slotNumber directly instead.
    */
   getSlotNumber(): SlotNumber {
     return this.slotNumber;
-  }
-
-  toViem(): ViemHeader {
-    return {
-      lastArchiveRoot: this.lastArchiveRoot.toString(),
-      blockHeadersHash: this.blockHeadersHash.toString(),
-      blobsHash: this.blobsHash.toString(),
-      inHash: this.inHash.toString(),
-      outHash: this.epochOutHash.toString(),
-      slotNumber: BigInt(this.slotNumber),
-      timestamp: this.timestamp,
-      coinbase: this.coinbase.toString(),
-      feeRecipient: `0x${this.feeRecipient.toBuffer().toString('hex').padStart(64, '0')}`,
-      gasFees: {
-        feePerDaGas: this.gasFees.feePerDaGas,
-        feePerL2Gas: this.gasFees.feePerL2Gas,
-      },
-      totalManaUsed: this.totalManaUsed.toBigInt(),
-      accumulatedFees: this.accumulatedFees.toBigInt(),
-    };
   }
 
   toInspect() {

--- a/yarn-project/stdlib/src/rollup/index.ts
+++ b/yarn-project/stdlib/src/rollup/index.ts
@@ -11,6 +11,7 @@ export * from './checkpoint_merge_rollup_private_inputs.js';
 export * from './checkpoint_rollup_public_inputs.js';
 export * from './checkpoint_root_rollup_private_inputs.js';
 export * from './epoch_constant_data.js';
+export * from './l1_checkpoint_header.js';
 export * from './private_tx_base_rollup_private_inputs.js';
 export * from './public_tx_base_rollup_private_inputs.js';
 export * from './public_chonk_verifier_private_inputs.js';

--- a/yarn-project/stdlib/src/rollup/l1_checkpoint_header.test.ts
+++ b/yarn-project/stdlib/src/rollup/l1_checkpoint_header.test.ts
@@ -1,0 +1,113 @@
+import { Fr } from '@aztec/foundation/curves/bn254';
+
+import { CheckpointHeader } from './checkpoint_header.js';
+import {
+  type L1CheckpointHeader,
+  OutOfRangeFieldError,
+  getOutOfRangeFields,
+  l1CheckpointHeaderHash,
+  toCheckpointHeader,
+  toL1CheckpointHeader,
+  tryToCheckpointHeader,
+} from './l1_checkpoint_header.js';
+
+const MODULUS_HEX = `0x${Fr.MODULUS.toString(16).padStart(64, '0')}` as `0x${string}`;
+const MAX_UINT256 = 2n ** 256n - 1n;
+const MAX_UINT256_HEX = `0x${MAX_UINT256.toString(16)}` as `0x${string}`;
+
+describe('L1CheckpointHeader', () => {
+  describe('l1CheckpointHeaderHash', () => {
+    it('equals CheckpointHeader.hash for random in-range headers (pins the byte layout)', () => {
+      for (let i = 0; i < 20; i++) {
+        const header = CheckpointHeader.random();
+        expect(l1CheckpointHeaderHash(toL1CheckpointHeader(header)).toString()).toEqual(header.hash().toString());
+      }
+    });
+
+    it('produces an in-range hash even when a field is out of range', () => {
+      const raw = toL1CheckpointHeader(CheckpointHeader.random());
+      raw.accumulatedFees = MAX_UINT256;
+      const hash = l1CheckpointHeaderHash(raw);
+      expect(hash.toBigInt()).toBeLessThan(Fr.MODULUS);
+    });
+  });
+
+  describe('round-trip', () => {
+    it('toL1CheckpointHeader then toCheckpointHeader recovers the original header', () => {
+      const header = CheckpointHeader.random();
+      const recovered = toCheckpointHeader(toL1CheckpointHeader(header));
+      expect(recovered.equals(header)).toBe(true);
+    });
+  });
+
+  describe('out-of-range field detection', () => {
+    // The exploitable Fr-valued fields per A-1254 plus the others that are also Fr-valued on the wire.
+    const exploitableFields: (keyof L1CheckpointHeader)[] = [
+      'lastArchiveRoot',
+      'blockHeadersHash',
+      'blobsHash',
+      'inHash',
+      'outHash',
+      'feeRecipient',
+      'totalManaUsed',
+      'accumulatedFees',
+    ];
+
+    const hexFields = new Set<keyof L1CheckpointHeader>([
+      'lastArchiveRoot',
+      'blockHeadersHash',
+      'blobsHash',
+      'inHash',
+      'outHash',
+      'feeRecipient',
+    ]);
+
+    const setField = (raw: L1CheckpointHeader, field: keyof L1CheckpointHeader, value: bigint): L1CheckpointHeader => ({
+      ...raw,
+      [field]: hexFields.has(field) ? (`0x${value.toString(16).padStart(64, '0')}` as `0x${string}`) : value,
+    });
+
+    it('accepts an in-range header (every field at MODULUS - 1)', () => {
+      let raw = toL1CheckpointHeader(CheckpointHeader.random());
+      for (const field of exploitableFields) {
+        raw = setField(raw, field, Fr.MODULUS - 1n);
+      }
+      expect(getOutOfRangeFields(raw)).toEqual([]);
+      expect(() => toCheckpointHeader(raw)).not.toThrow();
+    });
+
+    for (const field of exploitableFields) {
+      it(`flags ${field} when set to exactly MODULUS`, () => {
+        const raw = setField(toL1CheckpointHeader(CheckpointHeader.random()), field, Fr.MODULUS);
+        expect(getOutOfRangeFields(raw)).toContain(field);
+        const result = tryToCheckpointHeader(raw);
+        expect(result.ok).toBe(false);
+        expect(() => toCheckpointHeader(raw)).toThrow(OutOfRangeFieldError);
+      });
+
+      it(`flags ${field} when set to 2^256 - 1`, () => {
+        const raw = setField(toL1CheckpointHeader(CheckpointHeader.random()), field, MAX_UINT256);
+        expect(getOutOfRangeFields(raw)).toContain(field);
+        expect(() => toCheckpointHeader(raw)).toThrow(OutOfRangeFieldError);
+      });
+    }
+
+    it('OutOfRangeFieldError carries the offending field names', () => {
+      let raw = toL1CheckpointHeader(CheckpointHeader.random());
+      raw = setField(raw, 'accumulatedFees', MAX_UINT256);
+      raw = setField(raw, 'outHash', BigInt(MODULUS_HEX));
+      try {
+        toCheckpointHeader(raw);
+        throw new Error('expected toCheckpointHeader to throw');
+      } catch (err) {
+        expect(err).toBeInstanceOf(OutOfRangeFieldError);
+        expect((err as OutOfRangeFieldError).fields).toEqual(expect.arrayContaining(['outHash', 'accumulatedFees']));
+      }
+    });
+
+    it('rejects an out-of-range header passed as 2^256 - 1 hex on a hash field', () => {
+      const raw = { ...toL1CheckpointHeader(CheckpointHeader.random()), inHash: MAX_UINT256_HEX };
+      expect(getOutOfRangeFields(raw)).toContain('inHash');
+    });
+  });
+});

--- a/yarn-project/stdlib/src/rollup/l1_checkpoint_header.test.ts
+++ b/yarn-project/stdlib/src/rollup/l1_checkpoint_header.test.ts
@@ -41,7 +41,7 @@ describe('L1CheckpointHeader', () => {
   });
 
   describe('out-of-range field detection', () => {
-    // The exploitable Fr-valued fields per A-1254 plus the others that are also Fr-valued on the wire.
+    // The exploitable Fr-valued fields plus the others that are also Fr-valued on the wire.
     const exploitableFields: (keyof L1CheckpointHeader)[] = [
       'lastArchiveRoot',
       'blockHeadersHash',

--- a/yarn-project/stdlib/src/rollup/l1_checkpoint_header.ts
+++ b/yarn-project/stdlib/src/rollup/l1_checkpoint_header.ts
@@ -1,0 +1,172 @@
+import { toBufferBE } from '@aztec/foundation/bigint-buffer';
+import { SlotNumber } from '@aztec/foundation/branded-types';
+import { Buffer32 } from '@aztec/foundation/buffer';
+import { sha256ToField } from '@aztec/foundation/crypto/sha256';
+import { Fr } from '@aztec/foundation/curves/bn254';
+import { EthAddress } from '@aztec/foundation/eth-address';
+import { bigintToUInt64BE } from '@aztec/foundation/serialize';
+import { hexToBuffer } from '@aztec/foundation/string';
+
+import { AztecAddress } from '../aztec-address/index.js';
+import { GasFees } from '../gas/index.js';
+import { CheckpointHeader } from './checkpoint_header.js';
+
+/**
+ * The raw, ABI-shaped form of a checkpoint header as it appears at the viem boundary: what
+ * `decodeFunctionData` produces for `propose`, what `propose`/`validateHeaderWithAttestations`
+ * consume, and the carrier for not-yet-validated header bytes during L1 sync.
+ *
+ * Unlike {@link CheckpointHeader}, the fields keep their raw wire representation (hex strings and
+ * bigints) so the struct can hold values that fall outside the BN254 scalar field. A malicious
+ * proposer can land such out-of-range values on L1; constructing an {@link L1CheckpointHeader} from
+ * them must never throw. Converting to a {@link CheckpointHeader} (which validates the field ranges)
+ * is the explicit, fallible boundary handled by {@link toCheckpointHeader} / {@link tryToCheckpointHeader}.
+ *
+ * Note: the field named `outHash` here is the epoch out hash; it maps to `CheckpointHeader.epochOutHash`.
+ * The name is kept to match the on-chain `ProposedHeader` struct produced by viem.
+ */
+export type L1CheckpointHeader = {
+  lastArchiveRoot: `0x${string}`;
+  blockHeadersHash: `0x${string}`;
+  blobsHash: `0x${string}`;
+  inHash: `0x${string}`;
+  outHash: `0x${string}`;
+  slotNumber: bigint;
+  timestamp: bigint;
+  coinbase: `0x${string}`;
+  feeRecipient: `0x${string}`;
+  gasFees: { feePerDaGas: bigint; feePerL2Gas: bigint };
+  totalManaUsed: bigint;
+  accumulatedFees: bigint;
+};
+
+/** Error thrown when an {@link L1CheckpointHeader} carries field values outside the BN254 scalar field. */
+export class OutOfRangeFieldError extends Error {
+  constructor(public readonly fields: string[]) {
+    super(`Checkpoint header has out-of-range field(s): ${fields.join(', ')}`);
+    this.name = 'OutOfRangeFieldError';
+  }
+}
+
+/** The Fr-valued fields of a checkpoint header that may overflow the BN254 scalar field. */
+const FR_VALUED_FIELDS = [
+  'lastArchiveRoot',
+  'blockHeadersHash',
+  'blobsHash',
+  'inHash',
+  'outHash',
+  'feeRecipient',
+  'totalManaUsed',
+  'accumulatedFees',
+] as const;
+
+function bigintFromHexOrValue(value: `0x${string}` | bigint): bigint {
+  return typeof value === 'bigint' ? value : BigInt(value);
+}
+
+/** Returns the names of the header fields whose value is greater than or equal to the BN254 modulus. */
+export function getOutOfRangeFields(header: L1CheckpointHeader): string[] {
+  return FR_VALUED_FIELDS.filter(field => bigintFromHexOrValue(header[field]) >= Fr.MODULUS);
+}
+
+/**
+ * Hashes an {@link L1CheckpointHeader} using the exact byte layout of {@link CheckpointHeader.toBuffer}
+ * (and the on-chain `ProposedHeaderLib.hash` `abi.encodePacked`). Because the result is a sha256 hash
+ * reduced into the field, it is always in range even when some input field is not. For an in-range header
+ * the result equals {@link CheckpointHeader.hash}, which is what lets us verify the payload digest of a
+ * malicious header without ever constructing a {@link CheckpointHeader}.
+ */
+export function l1CheckpointHeaderHash(header: L1CheckpointHeader): Fr {
+  // Layout must match CheckpointHeader.toBuffer and ProposedHeaderLib.hash. Each Fr-valued field is its
+  // raw 32-byte big-endian value (substituted directly even when out of range), slotNumber is a 32-byte
+  // field, timestamp is uint64, coinbase is 20 bytes, and the two gas fees are uint128 each.
+  const buffer = Buffer.concat([
+    toBufferBE(BigInt(header.lastArchiveRoot), 32),
+    toBufferBE(BigInt(header.blockHeadersHash), 32),
+    toBufferBE(BigInt(header.blobsHash), 32),
+    toBufferBE(BigInt(header.inHash), 32),
+    toBufferBE(BigInt(header.outHash), 32),
+    toBufferBE(header.slotNumber, 32),
+    bigintToUInt64BE(header.timestamp),
+    hexToBuffer(header.coinbase),
+    toBufferBE(BigInt(header.feeRecipient), 32),
+    toBufferBE(header.gasFees.feePerDaGas, 16),
+    toBufferBE(header.gasFees.feePerL2Gas, 16),
+    toBufferBE(header.totalManaUsed, 32),
+    toBufferBE(header.accumulatedFees, 32),
+  ]);
+  return sha256ToField([buffer]);
+}
+
+/** Converts a validated, in-range {@link CheckpointHeader} into its raw {@link L1CheckpointHeader} wire form. */
+export function toL1CheckpointHeader(header: CheckpointHeader): L1CheckpointHeader {
+  return {
+    lastArchiveRoot: header.lastArchiveRoot.toString(),
+    blockHeadersHash: header.blockHeadersHash.toString(),
+    blobsHash: header.blobsHash.toString(),
+    inHash: header.inHash.toString(),
+    outHash: header.epochOutHash.toString(),
+    slotNumber: BigInt(header.slotNumber),
+    timestamp: header.timestamp,
+    coinbase: header.coinbase.toString(),
+    feeRecipient: `0x${header.feeRecipient.toBuffer().toString('hex').padStart(64, '0')}`,
+    gasFees: {
+      feePerDaGas: header.gasFees.feePerDaGas,
+      feePerL2Gas: header.gasFees.feePerL2Gas,
+    },
+    totalManaUsed: header.totalManaUsed.toBigInt(),
+    accumulatedFees: header.accumulatedFees.toBigInt(),
+  };
+}
+
+/**
+ * Attempts to convert a raw {@link L1CheckpointHeader} into a validated {@link CheckpointHeader}.
+ * Returns the offending field names instead of throwing when any field is out of range.
+ */
+export function tryToCheckpointHeader(
+  header: L1CheckpointHeader,
+): { ok: true; header: CheckpointHeader } | { ok: false; fields: string[] } {
+  const fields = getOutOfRangeFields(header);
+  if (fields.length > 0) {
+    return { ok: false, fields };
+  }
+  return {
+    ok: true,
+    header: new CheckpointHeader(
+      Fr.fromString(header.lastArchiveRoot),
+      Fr.fromString(header.blockHeadersHash),
+      Fr.fromString(header.blobsHash),
+      Fr.fromString(header.inHash),
+      Fr.fromString(header.outHash),
+      SlotNumber.fromBigInt(header.slotNumber),
+      header.timestamp,
+      new EthAddress(hexToBuffer(header.coinbase)),
+      new AztecAddress(hexToBuffer(header.feeRecipient)),
+      new GasFees(header.gasFees.feePerDaGas, header.gasFees.feePerL2Gas),
+      new Fr(header.totalManaUsed),
+      new Fr(header.accumulatedFees),
+    ),
+  };
+}
+
+/**
+ * Converts a raw {@link L1CheckpointHeader} into a validated {@link CheckpointHeader}, throwing an
+ * {@link OutOfRangeFieldError} carrying the offending field names when any field is out of range.
+ */
+export function toCheckpointHeader(header: L1CheckpointHeader): CheckpointHeader {
+  const result = tryToCheckpointHeader(header);
+  if (!result.ok) {
+    throw new OutOfRangeFieldError(result.fields);
+  }
+  return result.header;
+}
+
+/** Builds a random in-range {@link L1CheckpointHeader} for testing. */
+export function randomL1CheckpointHeader(overrides: Partial<L1CheckpointHeader> = {}): L1CheckpointHeader {
+  return { ...toL1CheckpointHeader(CheckpointHeader.random()), ...overrides };
+}
+
+/** Returns the raw 32-byte big-endian representation of an {@link Fr} or {@link Buffer32}. */
+export function archiveRootToBuffer32(archive: Fr | Buffer32): Buffer32 {
+  return archive instanceof Buffer32 ? archive : Buffer32.fromField(archive);
+}

--- a/yarn-project/stdlib/src/rollup/l1_checkpoint_header.ts
+++ b/yarn-project/stdlib/src/rollup/l1_checkpoint_header.ts
@@ -1,6 +1,5 @@
 import { toBufferBE } from '@aztec/foundation/bigint-buffer';
 import { SlotNumber } from '@aztec/foundation/branded-types';
-import { Buffer32 } from '@aztec/foundation/buffer';
 import { sha256ToField } from '@aztec/foundation/crypto/sha256';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { EthAddress } from '@aztec/foundation/eth-address';
@@ -164,9 +163,4 @@ export function toCheckpointHeader(header: L1CheckpointHeader): CheckpointHeader
 /** Builds a random in-range {@link L1CheckpointHeader} for testing. */
 export function randomL1CheckpointHeader(overrides: Partial<L1CheckpointHeader> = {}): L1CheckpointHeader {
   return { ...toL1CheckpointHeader(CheckpointHeader.random()), ...overrides };
-}
-
-/** Returns the raw 32-byte big-endian representation of an {@link Fr} or {@link Buffer32}. */
-export function archiveRootToBuffer32(archive: Fr | Buffer32): Buffer32 {
-  return archive instanceof Buffer32 ? archive : Buffer32.fromField(archive);
 }


### PR DESCRIPTION
Part of A-1254.

A malicious proposer can post a checkpoint whose header (or archive root) carries a `uint256` value above the BN254 scalar field modulus. Before this change the archiver eagerly converted those L1-read values into `Fr` while decoding, which throws for an out-of-range value; the throw was uncaught and the node's L1 sync point stalled permanently (a brick). This PR is the archiver-side defense-in-depth that complements the merged L1 range checks (#24199): an out-of-range checkpoint is now treated as an invalid checkpoint that is skipped/invalidated, exactly like one with bad attestations, instead of throwing and stalling the sync point.

What this fix does:

- Introduces a single raw-header type `L1CheckpointHeader` (plain type + free helpers in `stdlib`) that fully replaces `CheckpointHeader.fromViem`/`toViem`. It keeps the viem wire shape, can hold out-of-range values without throwing, and hashes to the same value as `CheckpointHeader` for in-range inputs (pinned by a test).
- Carries the archive root as raw `Buffer32` across the whole L1-read sync path (`RollupContract.status`, `getCheckpointProposedEvents`, `archiveAt`), converting to `Fr` only at the single checkpoint-ingestion boundary.
- `CalldataRetriever` now returns a raw header + raw archive and performs no field-range validation; it verifies the propose candidate using a raw EIP-712 digest helper, so decode no longer falls through to the trace-fallback "hash mismatch" throw for a malicious header.
- Always runs `validateCheckpointAttestations` (now consuming the raw header) before building a published checkpoint; rejects via the existing insufficient/invalid-attestation reasons and advances the sync point. Fails loudly only in the catastrophic case where a header is out of range yet a committee quorum signed it — which the L1 fix makes unreachable on a patched chain.
- Widens `CheckpointInfo.archive`, `RejectedCheckpoint.archiveRoot`, and the affected `L2BlockSource` events to `Fr | Buffer32`. The on-disk storage format is unchanged.

Tests:

- Unit tests pinning the `L1CheckpointHeader` hash byte layout against `CheckpointHeader.hash`, and verifying out-of-range detection for each exploitable field at exactly `MODULUS` and `2^256 - 1`.
- An archiver integration test that injects an out-of-range header field into the propose calldata and asserts the checkpoint is skipped, recorded as rejected, and the L1 sync point advances rather than stalling.
- A `setStorageAt`-based e2e (`epochs_out_of_range_header.test.ts`) that overwrites a checkpoint's archive root in L1 storage with an out-of-range value and asserts the honest node keeps syncing. This test was implemented and compiles but was not run to completion locally due to e2e runtime.

The L1 range checks (#24199) is already merged into the base branch and prevents new out-of-range fields from landing via `propose`. This fix here is the archiver's defense for pre-upgrade chains and future-added fields.