### PR TITLE
feat!: make node.getContract take a reference block

### DIFF
--- a/docs/examples/webapp-tutorial/src/embedded-wallet.ts
+++ b/docs/examples/webapp-tutorial/src/embedded-wallet.ts
@@ -80,8 +80,9 @@ export class EmbeddedWallet extends BaseEmbeddedWallet {
   // docs:end:initialize
 
   static async #getSponsoredFPCContract() {
-    const { SponsoredFPCContractArtifact } =
-      await import("@aztec/noir-contracts.js/SponsoredFPC");
+    const { SponsoredFPCContractArtifact } = await import(
+      "@aztec/noir-contracts.js/SponsoredFPC"
+    );
     const instance = await getContractInstanceFromInstantiationParams(
       SponsoredFPCContractArtifact,
       { salt: new Fr(SPONSORED_FPC_SALT) },
@@ -123,7 +124,7 @@ export class EmbeddedWallet extends BaseEmbeddedWallet {
     address: AztecAddress,
     artifact: ContractArtifact,
   ) {
-    const instance = await this.aztecNode.getContract(address);
+    const instance = await this.aztecNode.getContract("latest", address);
     if (!instance) {
       throw new Error(`Contract not found onchain at ${address}`);
     }

--- a/playground/src/components/contract/Contract.tsx
+++ b/playground/src/components/contract/Contract.tsx
@@ -200,7 +200,7 @@ export function ContractComponent() {
       if (currentContractAddress) {
         const { isContractPublished } = await wallet.getContractMetadata(currentContractAddress);
         if (isContractPublished) {
-          const contractInstance = await node.getContract(currentContractAddress);
+          const contractInstance = await node.getContract('latest', currentContractAddress);
 
           await wallet.registerContract(contractInstance, currentContractArtifact);
           const contract = Contract.at(currentContractAddress, currentContractArtifact, wallet);

--- a/playground/src/components/contract/components/CreateContractDialog.tsx
+++ b/playground/src/components/contract/components/CreateContractDialog.tsx
@@ -141,7 +141,7 @@ export function CreateContractDialog({
   const registerExistingContract = async () => {
     setIsRegistering(true);
     try {
-      const contract = await node.getContract(AztecAddress.fromString(address));
+      const contract = await node.getContract('latest', AztecAddress.fromString(address));
       if (!contract) {
         throw new Error('Contract with this address was not found in node');
       }

--- a/yarn-project/aztec-node/src/aztec-node/server.test.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.test.ts
@@ -33,14 +33,14 @@ import {
   type L2Tips,
 } from '@aztec/stdlib/block';
 import type { CheckpointData, ProposedCheckpointData } from '@aztec/stdlib/checkpoint';
-import type { ContractDataSource } from '@aztec/stdlib/contract';
+import type { ContractDataSource, ContractInstanceWithAddress } from '@aztec/stdlib/contract';
 import { EmptyL1RollupConstants, type L1RollupConstants } from '@aztec/stdlib/epoch-helpers';
 import { GasFees } from '@aztec/stdlib/gas';
 import type { L2LogsSource, MerkleTreeReadOperations, WorldStateSynchronizer } from '@aztec/stdlib/interfaces/server';
 import { InboxLeaf } from '@aztec/stdlib/messaging';
 import type { L1ToL2MessageSource } from '@aztec/stdlib/messaging';
 import { CheckpointHeader } from '@aztec/stdlib/rollup';
-import { mockTx } from '@aztec/stdlib/testing';
+import { mockTx, randomContractInstanceWithAddress } from '@aztec/stdlib/testing';
 import {
   AppendOnlyTreeSnapshot,
   MerkleTreeId,
@@ -116,6 +116,7 @@ describe('aztec node', () => {
   let merkleTreeOps: MockProxy<MerkleTreeReadOperations>;
   let worldState: MockProxy<WorldStateSynchronizer>;
   let l2BlockSource: MockProxy<L2BlockSource>;
+  let contractSource: MockProxy<ContractDataSource>;
   let l1ToL2MessageSource: MockProxy<L1ToL2MessageSource>;
   let lastBlockNumber: BlockNumber;
   let node: TestAztecNodeService;
@@ -204,7 +205,7 @@ describe('aztec node', () => {
     l1ToL2MessageSource = mock<L1ToL2MessageSource>();
 
     // all txs use the same allowed FPC class
-    const contractSource = mock<ContractDataSource>();
+    contractSource = mock<ContractDataSource>();
 
     const nodeConfigFromEnvVars: AztecNodeConfig = getConfigEnvVars();
     nodeConfig = {
@@ -419,6 +420,40 @@ describe('aztec node', () => {
       it('returns undefined for non-existent block', async () => {
         l2BlockSource.getBlockData.mockResolvedValue(undefined);
         expect(await node.getBlock(BlockNumber(3))).toEqual(undefined);
+      });
+    });
+
+    describe('getContract', () => {
+      let address: AztecAddress;
+      let instance: ContractInstanceWithAddress;
+      const referenceTimestamp = 4242n;
+
+      beforeEach(async () => {
+        instance = await randomContractInstanceWithAddress();
+        address = instance.address;
+
+        l2BlockSource.getBlockData.mockResolvedValue({
+          header: BlockHeader.empty({
+            globalVariables: GlobalVariables.empty({ blockNumber: BlockNumber(1), timestamp: referenceTimestamp }),
+          }),
+          archive: L2Block.empty().archive,
+          blockHash: BlockHash.random(),
+          checkpointNumber: CheckpointNumber(1),
+          indexWithinCheckpoint: IndexWithinCheckpoint(0),
+        });
+
+        contractSource.getContract.mockImplementation((_address, timestamp) =>
+          Promise.resolve(timestamp === referenceTimestamp ? instance : undefined),
+        );
+      });
+
+      it('resolves the reference block to its timestamp and reads the instance as of that block', async () => {
+        expect(await node.getContract(BlockNumber(1), address)).toEqual(instance);
+      });
+
+      it('throws when the reference block is not part of the chain', async () => {
+        l2BlockSource.getBlockData.mockResolvedValue(undefined);
+        await expect(node.getContract(BlockHash.random(), address)).rejects.toThrow(/not found/);
       });
     });
 

--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -1219,8 +1219,17 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, AztecNodeDeb
     return this.contractDataSource.getContractClass(id);
   }
 
-  public getContract(address: AztecAddress): Promise<ContractInstanceWithAddress | undefined> {
-    return this.contractDataSource.getContract(address);
+  public async getContract(
+    referenceBlock: BlockParameter,
+    address: AztecAddress,
+  ): Promise<ContractInstanceWithAddress | undefined> {
+    const blockData = await this.getBlockData(referenceBlock);
+    if (!blockData) {
+      throw new Error(
+        `Reference block ${inspectBlockParameter(referenceBlock)} not found when querying contract ${address}. If the node API has been queried with an anchor block hash, possibly a reorg has occurred.`,
+      );
+    }
+    return this.contractDataSource.getContract(address, blockData.header.globalVariables.timestamp);
   }
 
   public getPrivateLogsByTags(query: PrivateLogsQuery): Promise<LogResult[][]> {

--- a/yarn-project/aztec.js/src/contract/fastforward_contract_update.ts
+++ b/yarn-project/aztec.js/src/contract/fastforward_contract_update.ts
@@ -31,7 +31,7 @@ export async function fastForwardContractUpdate(args: {
 }): Promise<SimulationOverrides> {
   const { instanceAddress, newClassId, node } = args;
 
-  const instance = await node.getContract(instanceAddress);
+  const instance = await node.getContract('latest', instanceAddress);
   if (!instance) {
     throw new Error(`Instance not deployed at ${instanceAddress}. Deploy it before fast-forwarding an update.`);
   }

--- a/yarn-project/cli-wallet/src/cmds/register_contract.ts
+++ b/yarn-project/cli-wallet/src/cmds/register_contract.ts
@@ -23,7 +23,7 @@ export async function registerContract(
   const contractArtifact = await getContractArtifact(artifactPath, log);
   const hasInitializer = getAllFunctionAbis(contractArtifact).some(fn => fn.isInitializer);
   const constructorArtifact = hasInitializer ? getInitializer(contractArtifact, initializer) : undefined;
-  let contractInstance = await node.getContract(address);
+  let contractInstance = await node.getContract('latest', address);
   if (!contractInstance) {
     log(`Contract not found in the node at ${address}. Computing instance locally...`);
     contractInstance = await getContractInstanceFromInstantiationParams(contractArtifact, {

--- a/yarn-project/end-to-end/src/bench/node_rpc_perf.test.ts
+++ b/yarn-project/end-to-end/src/bench/node_rpc_perf.test.ts
@@ -162,7 +162,7 @@ describe('e2e_node_rpc_perf', () => {
     logger.info(`Token contract deployed at ${contractAddress}`);
 
     // Get contract class ID for benchmarking getContractClass
-    const contractInstance = await aztecNode.getContract(contractAddress);
+    const contractInstance = await aztecNode.getContract('latest', contractAddress);
     contractClassId = contractInstance!.currentContractClassId;
 
     logger.info(`Building ${BLOCKS_TO_BUILD} blocks with transactions...`);
@@ -264,7 +264,7 @@ describe('e2e_node_rpc_perf', () => {
     });
 
     it('benchmarks getContract', async () => {
-      const { stats } = await benchmark('getContract', () => aztecNode.getContract(contractAddress));
+      const { stats } = await benchmark('getContract', () => aztecNode.getContract('latest', contractAddress));
       addResult('getContract', stats);
       expect(stats.avg).toBeLessThan(2000);
     });

--- a/yarn-project/end-to-end/src/composed/e2e_persistence.test.ts
+++ b/yarn-project/end-to-end/src/composed/e2e_persistence.test.ts
@@ -239,7 +239,7 @@ describe('Aztec persistence', () => {
     });
 
     it('the node has the contract', async () => {
-      await expect(context.aztecNode.getContract(contractAddress)).resolves.toBeDefined();
+      await expect(context.aztecNode.getContract('latest', contractAddress)).resolves.toBeDefined();
     });
 
     it('pxe does not know of the deployed contract', async () => {

--- a/yarn-project/end-to-end/src/e2e_deploy_contract/contract_class_registration.test.ts
+++ b/yarn-project/end-to-end/src/e2e_deploy_contract/contract_class_registration.test.ts
@@ -151,7 +151,7 @@ describe('e2e_deploy_contract contract class registration', () => {
             logs[0].toBuffer(),
           );
 
-          const deployed = await aztecNode.getContract(instance.address);
+          const deployed = await aztecNode.getContract('latest', instance.address);
           expect(deployed).toBeDefined();
           expect(deployed!.address).toEqual(instance.address);
           expect(deployed!.currentContractClassId).toEqual(contractClass.id);

--- a/yarn-project/end-to-end/src/spartan/setup_test_wallets.ts
+++ b/yarn-project/end-to-end/src/spartan/setup_test_wallets.ts
@@ -156,7 +156,7 @@ async function deployAccountWithDiagnostics(
   await retry(
     async () => {
       // Check if already deployed (handles case where previous attempt succeeded but waitForTx timed out)
-      const existing = await aztecNode.getContract(account.address);
+      const existing = await aztecNode.getContract('latest', account.address);
       if (existing) {
         logger.info(`${accountLabel} already deployed at ${account.address}, skipping`);
         return;

--- a/yarn-project/pxe/src/contract_sync/contract_sync_service.test.ts
+++ b/yarn-project/pxe/src/contract_sync/contract_sync_service.test.ts
@@ -55,8 +55,9 @@ describe('ContractSyncService', () => {
     } as ContractInstanceWithAddress);
 
     aztecNode = mock<AztecNode>();
-    // readCurrentClassId reads from public storage; Fr.ZERO causes fallback to originalContractClassId
-    aztecNode.getPublicStorageAt.mockResolvedValue(Fr.ZERO);
+    // verifyCurrentClassId reads the instance from the node at the anchor block; returning undefined causes
+    // readCurrentClassId to fall back to the local originalContractClassId, which matches so verification passes.
+    aztecNode.getContract.mockResolvedValue(undefined);
 
     noteStore = mock<NoteStore>();
     // syncNoteNullifiers returns early when no notes

--- a/yarn-project/pxe/src/contract_sync/helpers.ts
+++ b/yarn-project/pxe/src/contract_sync/helpers.ts
@@ -1,20 +1,20 @@
-import { ProtocolContractAddress, isProtocolContract } from '@aztec/protocol-contracts';
+import { isProtocolContract } from '@aztec/protocol-contracts';
 import type { FunctionCall, FunctionSelector } from '@aztec/stdlib/abi';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
 import type { ContractInstance } from '@aztec/stdlib/contract';
-import { DelayedPublicMutableValues, DelayedPublicMutableValuesWithHash } from '@aztec/stdlib/delayed-public-mutable';
 import type { AztecNode } from '@aztec/stdlib/interfaces/client';
 import type { BlockHeader } from '@aztec/stdlib/tx';
 
 import type { ContractStore } from '../storage/contract_store/contract_store.js';
 
 /**
- * Read the current class id of a contract from the execution data provider or AztecNode. If not found, class id
- * from the instance is used.
+ * Read the current class id of a contract as of the given block, as seen by the AztecNode. The node resolves it from
+ * the same scheduled value change the AVM enforces against the public data tree. If the node has no record of the
+ * instance (e.g. it was never publicly deployed), the original class id from the local instance is used.
  * @param contractAddress - The address of the contract to read the class id for.
- * @param instance - The instance of the contract.
- * @param aztecNode - The Aztec node to query for storage.
- * @param header - The header of the block at which to load the DelayedPublicMutable storing the class id.
+ * @param instance - The local instance of the contract, used as a fallback when the node doesn't know it.
+ * @param aztecNode - The Aztec node to query.
+ * @param header - The header of the block at which to resolve the current class id.
  * @returns The current class id.
  */
 export async function readCurrentClassId(
@@ -23,17 +23,10 @@ export async function readCurrentClassId(
   aztecNode: AztecNode,
   header: BlockHeader,
 ) {
-  const blockHash = await header.hash();
-  const timestamp = header.globalVariables.timestamp;
-  const { delayedPublicMutableSlot } = await DelayedPublicMutableValuesWithHash.getContractUpdateSlots(contractAddress);
-  const delayedPublicMutableValues = await DelayedPublicMutableValues.readFromTree(delayedPublicMutableSlot, slot =>
-    aztecNode.getPublicStorageAt(blockHash, ProtocolContractAddress.ContractInstanceRegistry, slot),
-  );
-  let currentClassId = delayedPublicMutableValues.svc.getCurrentAt(timestamp)[0];
-  if (currentClassId.isZero()) {
-    currentClassId = instance.originalContractClassId;
-  }
-  return currentClassId;
+  const nodeInstance = await aztecNode.getContract(await header.hash(), contractAddress);
+  // If the contract was upgraded then the node WILL know of that and return a non-undefined instance. An undefined
+  // result therefore means that no upgrade has happened, and therefore that the original class is the current one.
+  return nodeInstance?.currentContractClassId ?? instance.originalContractClassId;
 }
 
 export async function syncScope(

--- a/yarn-project/pxe/src/pxe.test.ts
+++ b/yarn-project/pxe/src/pxe.test.ts
@@ -293,9 +293,9 @@ describe('PXE', () => {
         finalized: tipId,
       });
 
-      // This is read when PXE tries to resolve the
-      // class id of a contract instance
-      node.getPublicStorageAt.mockResolvedValue(Fr.ZERO);
+      // Read when PXE resolves the current class id of a contract instance at the anchor block. Returning undefined
+      // makes readCurrentClassId fall back to the local instance's originalContractClassId.
+      node.getContract.mockResolvedValue(undefined);
 
       // Used to sync private logs from the node - the return array needs to have the same length as the number of tags
       // on the input.

--- a/yarn-project/stdlib/src/interfaces/aztec-node.test.ts
+++ b/yarn-project/stdlib/src/interfaces/aztec-node.test.ts
@@ -532,7 +532,7 @@ describe('AztecNodeApiSchema', () => {
   });
 
   it('getContract', async () => {
-    const response = await context.client.getContract(await AztecAddress.random());
+    const response = await context.client.getContract('latest', await AztecAddress.random());
     expect(response).toEqual({
       address: expect.any(AztecAddress),
       currentContractClassId: expect.any(Fr),
@@ -916,7 +916,11 @@ class MockAztecNode implements AztecNode {
     const contractClass = await getContractClassFromArtifact(this.artifact);
     return contractClass;
   }
-  async getContract(address: AztecAddress): Promise<ContractInstanceWithAddress | undefined> {
+  async getContract(
+    referenceBlock: BlockParameter,
+    address: AztecAddress,
+  ): Promise<ContractInstanceWithAddress | undefined> {
+    expect(referenceBlock).toEqual('latest');
     expect(address).toBeInstanceOf(AztecAddress);
     const instance = {
       version: 2 as const,

--- a/yarn-project/stdlib/src/interfaces/aztec-node.ts
+++ b/yarn-project/stdlib/src/interfaces/aztec-node.ts
@@ -522,10 +522,17 @@ export interface AztecNode {
   getContractClass(id: Fr): Promise<ContractClassPublic | undefined>;
 
   /**
-   * Returns a publicly deployed contract instance given its address.
+   * Returns a publicly deployed contract instance given its address. Its current class id is resolved as of the given
+   * reference block.
+   *
+   * Returns `undefined` if the instance has not been published (i.e. `publish_for_public_execution` was never called
+   * on the `ContractInstanceRegistry`). A contract whose class has been updated will never return `undefined`:
+   * scheduling an update requires the contract's deployment nullifier, which is only emitted by publishing, so any
+   * updatable contract has necessarily been published.
+   * @param referenceBlock - The block parameter (block number, block hash, or 'latest') at which to get the data.
    * @param address - Address of the deployed contract.
    */
-  getContract(address: AztecAddress): Promise<ContractInstanceWithAddress | undefined>;
+  getContract(referenceBlock: BlockParameter, address: AztecAddress): Promise<ContractInstanceWithAddress | undefined>;
 
   /**
    * Returns the ENR of this node for peer discovery, if available.
@@ -758,7 +765,7 @@ export const AztecNodeApiSchema: ApiSchemaFor<AztecNode> = {
   getContractClass: z.function({ input: z.tuple([schemas.Fr]), output: ContractClassPublicSchema.optional() }),
 
   getContract: z.function({
-    input: z.tuple([schemas.AztecAddress]),
+    input: z.tuple([BlockParameterSchema, schemas.AztecAddress]),
     output: ContractInstanceWithAddressSchema.optional(),
   }),
 

--- a/yarn-project/wallet-sdk/src/base-wallet/base_wallet.ts
+++ b/yarn-project/wallet-sdk/src/base-wallet/base_wallet.ts
@@ -612,7 +612,7 @@ export abstract class BaseWallet implements Wallet {
    */
   async getContractMetadata(address: AztecAddress) {
     const instance = await this.pxe.getContractInstance(address);
-    const publiclyRegisteredContractPromise = this.aztecNode.getContract(address);
+    const publiclyRegisteredContractPromise = this.aztecNode.getContract('latest', address);
 
     let initializationStatus: ContractInitializationStatus;
     if (instance) {


### PR DESCRIPTION
PXE needs the class id at the anchor block, but the node only exposed the latest one. This forced PXE to reimplement the class id detection by raw reads of the trees combined with delayed public mutable interpretation of said data, which unnecessarily coupled PXE and the registry contracts. With this PR we simply query the data from the node, which will always be available if there's an upgrade, making the original class a safe fallback.