### PR TITLE
fix(archiver): index zero-field logs under empty tag instead of throwing (A-1253)

### DIFF
--- a/yarn-project/archiver/src/store/log_store.test.ts
+++ b/yarn-project/archiver/src/store/log_store.test.ts
@@ -129,6 +129,33 @@ describe('LogStore', () => {
       const [byTag] = await logStore.getPublicLogsByTags({ contractAddress: CONTRACT, tags: [new Tag(Fr.ZERO)] });
       expect(byTag).toEqual([]);
     });
+
+    it('prunes a zero-field public log alongside normal logs (empty-tag key tracked for deletion)', async () => {
+      const ckpt = await makeCheckpointWithLogs(1, {
+        numTxsPerBlock: 1,
+        publicLogs: { numLogsPerTx: 2, contractAddress: CONTRACT },
+      });
+      const block = ckpt.checkpoint.blocks[0];
+      // First public log carries zero fields (no tag, indexed under the empty tag); the second keeps a
+      // normal tagged form. Both must be dropped when the block is pruned on reorg.
+      block.body.txEffects[0].publicLogs[0] = new PublicLog(CONTRACT, []);
+      const normalTag = new Tag(new Fr(0xc0ffee));
+      block.body.txEffects[0].publicLogs[1].fields[0] = normalTag.value;
+      await blockStore.addProposedBlock(block);
+      await logStore.addLogs([block]);
+
+      // Both logs are indexed for the block, and the tagged one is queryable.
+      expect((await logStore.getPublicLogsForBlock(block.number)).length).toBe(2);
+      const [taggedBefore] = await logStore.getPublicLogsByTags({ contractAddress: CONTRACT, tags: [normalTag] });
+      expect(taggedBefore.length).toBe(1);
+
+      await logStore.deleteLogs([block]);
+
+      // The reorg trim drops every key recorded for the block — including the empty-tag one.
+      expect(await logStore.getPublicLogsForBlock(block.number)).toEqual([]);
+      const [taggedAfter] = await logStore.getPublicLogsByTags({ contractAddress: CONTRACT, tags: [normalTag] });
+      expect(taggedAfter).toEqual([]);
+    });
   });
 
   describe('getPrivateLogsByTags', () => {

--- a/yarn-project/archiver/src/store/log_store.test.ts
+++ b/yarn-project/archiver/src/store/log_store.test.ts
@@ -5,7 +5,14 @@ import { AztecAddress } from '@aztec/stdlib/aztec-address';
 import { BlockHash, GENESIS_BLOCK_HEADER_HASH } from '@aztec/stdlib/block';
 import { Checkpoint, type PublishedCheckpoint } from '@aztec/stdlib/checkpoint';
 import { MAX_LOGS_PER_TAG } from '@aztec/stdlib/interfaces/api-limit';
-import { LogCursor, SiloedTag, Tag, queryAllPrivateLogsByTags, queryAllPublicLogsByTags } from '@aztec/stdlib/logs';
+import {
+  LogCursor,
+  PublicLog,
+  SiloedTag,
+  Tag,
+  queryAllPrivateLogsByTags,
+  queryAllPublicLogsByTags,
+} from '@aztec/stdlib/logs';
 import '@aztec/stdlib/testing/jest';
 import type { AppendOnlyTreeSnapshot } from '@aztec/stdlib/trees';
 
@@ -98,6 +105,29 @@ describe('LogStore', () => {
 
       const after = await logStore.getPrivateLogsByTags({ tags: [tag] });
       expect(after[0].length).toBe(0);
+    });
+
+    it('ingests a zero-field public log without throwing and omits it from tagged lookup', async () => {
+      const ckpt = await makeCheckpointWithLogs(1, {
+        numTxsPerBlock: 1,
+        publicLogs: { numLogsPerTx: 1, contractAddress: CONTRACT },
+      });
+      const block = ckpt.checkpoint.blocks[0];
+      // A protocol-valid public log can carry zero fields (raw AVM EMITPUBLICLOG with logSize=0); it has
+      // no tag. Previously fieldHex(fields[0]) read off an empty array and aborted the whole store txn.
+      block.body.txEffects[0].publicLogs[0] = new PublicLog(CONTRACT, []);
+      await blockStore.addProposedBlock(block);
+
+      await expect(logStore.addLogs([block])).resolves.toBe(true);
+
+      // The untagged log is still retrievable via the per-block read...
+      const pub = await logStore.getPublicLogsForBlock(block.number);
+      expect(pub.length).toBe(1);
+      expect(pub[0].logData).toEqual([]);
+
+      // ...but a real (64-hex-char) tag query never matches it.
+      const [byTag] = await logStore.getPublicLogsByTags({ contractAddress: CONTRACT, tags: [new Tag(Fr.ZERO)] });
+      expect(byTag).toEqual([]);
     });
   });
 

--- a/yarn-project/archiver/src/store/log_store.ts
+++ b/yarn-project/archiver/src/store/log_store.ts
@@ -26,6 +26,7 @@ import {
   endOfTxRange,
   fieldHex,
   incKey,
+  tagHexForLog,
 } from './log_store_codec.js';
 
 /**
@@ -100,7 +101,7 @@ export class LogStore {
           let publicLogIndexWithinTx = 0;
 
           for (const log of txEffect.privateLogs) {
-            const tagHex = fieldHex(log.fields[0]);
+            const tagHex = tagHexForLog(log.fields);
             const key = encodeKey(tagHex, blockNumber, txIndexWithinBlock, privateLogIndexWithinTx);
             const value = encodeValue({
               txHash,
@@ -115,7 +116,7 @@ export class LogStore {
 
           for (const log of txEffect.publicLogs) {
             const contractHex = fieldHex(log.contractAddress);
-            const tagHex = fieldHex(log.fields[0]);
+            const tagHex = tagHexForLog(log.fields);
             const key = encodeKey(
               encodePublicPrefix(contractHex, tagHex),
               blockNumber,

--- a/yarn-project/archiver/src/store/log_store_codec.ts
+++ b/yarn-project/archiver/src/store/log_store_codec.ts
@@ -37,6 +37,17 @@ export function fieldHex(value: Fr | { toString: () => string }): string {
   return value.toString().slice(2);
 }
 
+/**
+ * Tag prefix for a log: the hex of its first field, or the empty string when the log carries no fields.
+ * A protocol-valid public log can have zero fields (e.g. a raw AVM `EMITPUBLICLOG` with `logSize = 0`),
+ * which has no tag to index by. Encoding it under the empty tag keeps it retrievable via the per-block
+ * read (and droppable on reorg) while never matching a real 64-hex-char tag query — instead of reading
+ * `fields[0]` off an empty array and aborting the whole block-ingestion transaction.
+ */
+export function tagHexForLog(fields: Fr[]): string {
+  return fields.length > 0 ? fieldHex(fields[0]) : '';
+}
+
 /** Encodes a number as 8-char zero-padded lowercase hex (matches a u32 big-endian byte buffer's lex order). */
 export function u32Hex(n: number): string {
   return n.toString(16).padStart(NUMERIC_HEX_LEN, '0');


### PR DESCRIPTION
Fixes A-1253.

## Problem

A protocol-valid public log can carry **zero fields** — `PublicLog(nonzeroContractAddress, [])` — reachable by any tx that bypasses the high-level aztec.nr helpers (the AVM `EMITPUBLICLOG` opcode accepts `logSize = 0`). `LogStore` used `fields[0]` as the tag-index key, so `fieldHex(undefined)` threw inside the `addLogs` transaction. Because that runs inside `addProposedBlock`/`addCheckpoints`' larger store transaction, the throw aborted the entire block/checkpoint update — a single such tx in an accepted block stalls L1 sync for every node that ingests it (the same valid checkpoint is retried forever).

## Fix (Fix A — archiver-only, lowest risk)

A log with no fields has no tag. Index it under the **empty tag** (`tagHexForLog` returns `''` for a zero-field log):

- it stays retrievable via the per-block read (`getPublicLogsForBlock`) and is dropped on reorg via the per-block secondary index, exactly like any other log;
- the empty-tag key sorts before every real key for the contract, so a real 64-hex-char tag query never matches it.

`PublicLog.fields` is a variable-length `Fr[]` (the actual crash surface); `PrivateLog.fields` is a fixed padded tuple so its `fields[0]` is always present, but the shared helper is applied to both loops for consistency and is behaviour-preserving for private logs.

## Test

`log_store.test.ts`: constructs `new PublicLog(CONTRACT, [])`, asserts `addLogs` resolves (previously threw), the log is returned by `getPublicLogsForBlock`, and a tag query omits it.