### PR TITLE
fix(p2p): bound declared contract-class bytecode length before allocating (A-1258)

### DIFF
--- a/yarn-project/p2p/src/msg_validators/tx_validator/data_validator.test.ts
+++ b/yarn-project/p2p/src/msg_validators/tx_validator/data_validator.test.ts
@@ -26,6 +26,8 @@ import {
   type Tx,
 } from '@aztec/stdlib/tx';
 
+import { jest } from '@jest/globals';
+
 import { DataTxValidator } from './data_validator.js';
 
 const mockTxs = (numTxs: number) =>
@@ -362,6 +364,43 @@ describe('TxDataValidator', () => {
       expect(result.result === 'invalid' && result.reason[0]).toMatch(
         new RegExp(`${TX_ERROR_INCORRECT_CONTRACT_CLASS_ID}|${TX_ERROR_MALFORMED_CONTRACT_CLASS_LOG}`),
       );
+    });
+
+    it('rejects an over-large declared bytecode length without allocating it', async () => {
+      const tx = await mockTx(5, {
+        numberOfNonRevertiblePublicCallRequests: 1,
+        numberOfRevertiblePublicCallRequests: 0,
+      });
+      // A small log that declares a 16 MiB packed-bytecode length. The fixed-size class log can only
+      // carry ~93 KiB, so decoding it must reject rather than Buffer.alloc the attacker-declared size.
+      const overLargeByteLength = 16 * 1024 * 1024;
+      const headerFields = [
+        new Fr(CONTRACT_CLASS_PUBLISHED_MAGIC_VALUE),
+        Fr.random(),
+        new Fr(1),
+        Fr.random(),
+        Fr.random(),
+        new Fr(overLargeByteLength),
+      ];
+      const allFields = [
+        ...headerFields,
+        ...Array(CONTRACT_CLASS_LOG_SIZE_IN_FIELDS - headerFields.length).fill(Fr.ZERO),
+      ];
+      const fields = new ContractClassLogFields(allFields);
+      const log = new ContractClassLog(ProtocolContractAddress.ContractClassRegistry, fields, headerFields.length);
+      await injectContractClassLog(tx, log, headerFields.length);
+      await tx.recomputeHash();
+
+      const allocSpy = jest.spyOn(Buffer, 'alloc');
+      try {
+        const result = await validator.validateTx(tx);
+        expect(result.result).toBe('invalid');
+        expect(result.result === 'invalid' && result.reason[0]).toBe(TX_ERROR_MALFORMED_CONTRACT_CLASS_LOG);
+        // The declared length was never allocated.
+        expect(allocSpy.mock.calls.some(([size]) => Number(size) >= overLargeByteLength)).toBe(false);
+      } finally {
+        allocSpy.mockRestore();
+      }
     });
   });
 });

--- a/yarn-project/protocol-contracts/src/class-registry/contract_class_published_event.ts
+++ b/yarn-project/protocol-contracts/src/class-registry/contract_class_published_event.ts
@@ -36,7 +36,12 @@ export class ContractClassPublishedEvent {
     const version = reader.readField().toNumber();
     const artifactHash = reader.readField();
     const privateFunctionsRoot = reader.readField();
-    const packedPublicBytecode = bufferFromFields(reader.readFieldArray(fieldsWithoutTag.length - reader.cursor));
+    const bytecodeFields = reader.readFieldArray(fieldsWithoutTag.length - reader.cursor);
+    // The fixed-size class log can hold at most this many packed-bytecode bytes (every payload field
+    // carries 31 bytes). Bound the declared length to it so a malformed log can't declare a multi-MiB
+    // length backed by a tiny payload and force a large allocation during early (pre-proof) validation.
+    const maxByteLength = (bytecodeFields.length - 1) * (Fr.SIZE_IN_BYTES - 1);
+    const packedPublicBytecode = bufferFromFields(bytecodeFields, maxByteLength);
 
     return new ContractClassPublishedEvent(
       contractClassId,

--- a/yarn-project/stdlib/src/abi/buffer.test.ts
+++ b/yarn-project/stdlib/src/abi/buffer.test.ts
@@ -53,4 +53,9 @@ describe('buffer', () => {
     expect(result.length).toBe(31);
     expect(result.toString('hex')).toEqual(buffer.toString('hex'));
   });
+
+  it('returns an empty buffer for an empty field array', () => {
+    const result = bufferFromFields([]);
+    expect(result.length).toBe(0);
+  });
 });

--- a/yarn-project/stdlib/src/abi/buffer.ts
+++ b/yarn-project/stdlib/src/abi/buffer.ts
@@ -45,6 +45,11 @@ export function bufferAsFields(input: Buffer, targetLength: number): Fr[] {
  * @returns A buffer of exactly `byteLength` bytes.
  */
 export function bufferFromFields(fields: Fr[], maxByteLength?: number): Buffer {
+  // A valid bufferAsFields output always has at least the leading byte-length field, so an empty
+  // input encodes no data. Guard so `length` (the destructured head) is never undefined.
+  if (fields.length === 0) {
+    return Buffer.alloc(0);
+  }
   const [length, ...payload] = fields;
   const byteLength = length.toNumber();
   if (maxByteLength !== undefined && byteLength > maxByteLength) {

--- a/yarn-project/stdlib/src/abi/buffer.ts
+++ b/yarn-project/stdlib/src/abi/buffer.ts
@@ -38,11 +38,18 @@ export function bufferAsFields(input: Buffer, targetLength: number): Fr[] {
  * bytecode commitment computations to diverge from what the circuit produced.
  *
  * @param fields - An output from bufferAsFields: [byteLength, ...payloadFields].
+ * @param maxByteLength - Optional upper bound on the declared byte length. When the field array comes
+ *   from untrusted input (e.g. a gossiped contract-class log), pass the payload capacity so an
+ *   attacker-declared length cannot force a large `Buffer.alloc` before the value is otherwise
+ *   rejected. Throws if the declared length exceeds it, before allocating.
  * @returns A buffer of exactly `byteLength` bytes.
  */
-export function bufferFromFields(fields: Fr[]): Buffer {
+export function bufferFromFields(fields: Fr[], maxByteLength?: number): Buffer {
   const [length, ...payload] = fields;
   const byteLength = length.toNumber();
+  if (maxByteLength !== undefined && byteLength > maxByteLength) {
+    throw new Error(`Declared byte length ${byteLength} exceeds maximum ${maxByteLength}`);
+  }
   const raw = Buffer.concat(payload.map(f => f.toBuffer().subarray(1)));
   if (raw.length >= byteLength) {
     return raw.subarray(0, byteLength);


### PR DESCRIPTION
Fixes A-1258.

## Problem

`DataTxValidator` decodes contract-class publication logs **before** proof validation (data validation runs ahead of proof validation on the req/resp, block-proposal, RPC, and gossip paths). The decode trusts the declared public-bytecode length field:

- `bufferFromFields` (`stdlib/src/abi/buffer.ts`) reads the declared `byteLength` and, when the payload is shorter, does `Buffer.alloc(byteLength)` — trusting the declared length over the bytes actually present.
- `ContractClassPublishedEvent.fromLog` decodes the bytecode via `bufferFromFields`, and `DataTxValidator.#hasCorrectContractClassIds` calls `fromLog` before any class-id / proof rejection.

A contract-class log is a fixed `CONTRACT_CLASS_LOG_SIZE_IN_FIELDS` array, so the real packed bytecode is capped at ~93 KiB. But the declared length is unbounded: a ~96 KiB log declaring 16 MiB forces a 16 MiB allocation on every node that validates the tx, before the proof check rejects it — a memory-pressure / validation-amplification path.

## Fix

- Add an optional `maxByteLength` parameter to `bufferFromFields`; when provided, it throws (before allocating) if the declared length exceeds it. Callers that don't pass it keep the documented blob-reconstruction padding behaviour unchanged.
- `fromLog` passes the fixed log's payload capacity (`payloadFields × 31`), so an over-declared length is rejected before allocation. `DataTxValidator` already wraps `fromLog` in try/catch, so the throw becomes a clean pre-proof `TX_ERROR_MALFORMED_CONTRACT_CLASS_LOG` rejection.

## Tests

- `data_validator.test.ts`: a log declaring a 16 MiB length is rejected, and `Buffer.alloc` is never called with the declared size (test time drops from ~1.2s to ~40ms — no large allocation). Run against the pre-fix compiled code, the allocation still happened (red); green after the fix.
- Existing `contract_class_published_event.test.ts` "fits a max-size public bytecode" and the `buffer.test.ts` padding tests confirm legitimate max-size bytecode and the padding contract are unaffected.