### PR TITLE
fix(p2p): frame gossipsub msgId and restrict allowedTopics (A-1256)

### DIFF
--- a/yarn-project/p2p/package.json
+++ b/yarn-project/p2p/package.json
@@ -101,8 +101,7 @@
     "semver": "^7.6.0",
     "sha3": "^2.1.4",
     "snappy": "^7.2.2",
-    "tslib": "^2.4.0",
-    "xxhash-wasm": "^1.1.0"
+    "tslib": "^2.4.0"
   },
   "devDependencies": {
     "@aztec/archiver": "workspace:^",

--- a/yarn-project/p2p/src/services/encoding.test.ts
+++ b/yarn-project/p2p/src/services/encoding.test.ts
@@ -1,8 +1,36 @@
-import { MAX_TX_SIZE_KB, TopicType } from '@aztec/stdlib/p2p';
+import { MAX_TX_SIZE_KB, P2PMessage, TopicType } from '@aztec/stdlib/p2p';
 
 import { compressSync, uncompressSync } from 'snappy';
 
-import { SnappyTransform, readSnappyPreamble } from './encoding.js';
+import { SnappyTransform, getMsgIdFn, readSnappyPreamble } from './encoding.js';
+
+describe('getMsgIdFn', () => {
+  it('frames the topic length so a boundary-shifted (topic, data) pair does not collide', async () => {
+    const topic = '/aztec/tx/0.1.0';
+    const data = new P2PMessage(Buffer.from('deadbeefcafe', 'hex')).toMessageData();
+
+    // Aztec gossip data starts with a 4-byte BE length prefix, so data[0] === 0x00.
+    expect(data[0]).toBe(0x00);
+
+    // Shift one byte across the topic/data boundary: T' = T + data[0], D' = data[1:]. Under a raw
+    // topic||data concatenation these hash identically to (T, data) — the suppression attack.
+    const shiftedTopic = topic + String.fromCharCode(data[0]);
+    const shiftedData = data.subarray(1);
+
+    const id = await getMsgIdFn({ topic, data });
+    const shiftedId = await getMsgIdFn({ topic: shiftedTopic, data: shiftedData });
+
+    expect(Buffer.from(shiftedId).equals(Buffer.from(id))).toBe(false);
+  });
+
+  it('is deterministic for the same (topic, data)', async () => {
+    const topic = '/aztec/tx/0.1.0';
+    const data = new P2PMessage(Buffer.from('0102030405', 'hex')).toMessageData();
+    const a = await getMsgIdFn({ topic, data });
+    const b = await getMsgIdFn({ topic, data });
+    expect(Buffer.from(a).equals(Buffer.from(b))).toBe(true);
+  });
+});
 
 describe('readSnappyPreamble', () => {
   describe('basic varint decoding', () => {

--- a/yarn-project/p2p/src/services/encoding.ts
+++ b/yarn-project/p2p/src/services/encoding.ts
@@ -49,11 +49,20 @@ export function msgIdToStrFn(msgId: Uint8Array): string {
  * Follows similarly to:
  * https://github.com/ethereum/consensus-specs/blob/v1.1.0-alpha.7/specs/altair/p2p-interface.md#topics-and-messages
  *
+ * The topic length is framed into the hash input (`uint32be(topicLen) || topic || data`) so the
+ * `(topic, data)` boundary is unambiguous. A raw `topic || data` concatenation is not injective —
+ * shifting bytes across the boundary (e.g. `(topic + data[0], data[1:])`) yields the same bytes and
+ * thus the same id, letting an unsubscribed-topic message pre-occupy a real message's seenCache slot
+ * and suppress it as a duplicate.
+ *
  * @param message - The libp2p message
  * @returns The message identifier
  */
-export async function getMsgIdFn({ topic, data }: Message): Promise<Uint8Array> {
-  const buffer = Buffer.concat([Buffer.from(topic), data]);
+export async function getMsgIdFn({ topic, data }: Pick<Message, 'topic' | 'data'>): Promise<Uint8Array> {
+  const topicBytes = Buffer.from(topic);
+  const framedTopicLength = Buffer.allocUnsafe(4);
+  framedTopicLength.writeUInt32BE(topicBytes.length);
+  const buffer = Buffer.concat([framedTopicLength, topicBytes, data]);
   const hash = await webcrypto.subtle.digest('SHA-256', buffer);
   return Buffer.from(hash.slice(0, 20));
 }

--- a/yarn-project/p2p/src/services/encoding.ts
+++ b/yarn-project/p2p/src/services/encoding.ts
@@ -2,12 +2,10 @@
 import { createLogger } from '@aztec/foundation/log';
 import { MAX_TX_SIZE_KB, TopicType, getTopicFromString } from '@aztec/stdlib/p2p';
 
-import type { RPC } from '@chainsafe/libp2p-gossipsub/message';
 import type { DataTransform } from '@chainsafe/libp2p-gossipsub/types';
 import type { Message } from '@libp2p/interface';
 import { webcrypto } from 'node:crypto';
 import { compressSync, uncompressSync } from 'snappy';
-import xxhashFactory from 'xxhash-wasm';
 
 /** Thrown when a Snappy-compressed response exceeds the allowed decompressed size. */
 export class OversizedSnappyResponseError extends Error {
@@ -17,25 +15,8 @@ export class OversizedSnappyResponseError extends Error {
   }
 }
 
-// Load WASM
-const xxhash = await xxhashFactory();
-
-// Use salt to prevent msgId from being mined for collisions
-const h64Seed = BigInt(Math.floor(Math.random() * 1e9));
-
 // Shared buffer to convert msgId to string
 const sharedMsgIdBuf = Buffer.alloc(20);
-
-/**
- * The function used to generate a gossipsub message id
- * We use the first 8 bytes of SHA256(data) for content addressing
- */
-export function fastMsgIdFn(rpcMsg: RPC.Message): string {
-  if (rpcMsg.data) {
-    return xxhash.h64Raw(rpcMsg.data, h64Seed).toString(16);
-  }
-  return '0000000000000000';
-}
 
 export function msgIdToStrFn(msgId: Uint8Array): string {
   // This happens serially, no need to reallocate the buffer

--- a/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
+++ b/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
@@ -83,7 +83,7 @@ import { type PubSubLibp2p, convertToMultiaddr } from '../../util.js';
 import { getVersions } from '../../versioning.js';
 import { AztecDatastore } from '../data_store.js';
 import { DiscV5Service } from '../discv5/discV5_service.js';
-import { SnappyTransform, fastMsgIdFn, getMsgIdFn, msgIdToStrFn } from '../encoding.js';
+import { SnappyTransform, getMsgIdFn, msgIdToStrFn } from '../encoding.js';
 import { APP_SPECIFIC_WEIGHT, gossipScoreThresholds } from '../gossipsub/scoring.js';
 import { createAllTopicScoreParams } from '../gossipsub/topic_score_params.js';
 import type { PeerManagerInterface } from '../peer-manager/interface.js';
@@ -505,9 +505,12 @@ export class LibP2PService extends WithTracer implements P2PService {
           mcacheGossip: config.gossipsubMcacheGossip,
           seenTTL: config.gossipsubSeenTTL,
           allowedTopics,
+          // No fastMsgIdFn: the fast-path dedup cache keys on a non-cryptographic 64-bit hash of the
+          // raw data only (no topic), so a collision — accidental or engineered via a weak seed — drops
+          // a different message with no fallback to the full id. Dedup instead rests solely on the
+          // cryptographic, topic-framed msgIdFn below.
           msgIdFn: getMsgIdFn,
           msgIdToStrFn: msgIdToStrFn,
-          fastMsgIdFn: fastMsgIdFn,
           dataTransform: new SnappyTransform(),
           metricsRegister: otelMetricsAdapter,
           metricsTopicStrToLabel: metricsTopicStrToLabels(protocolVersion),

--- a/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
+++ b/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
@@ -413,6 +413,13 @@ export class LibP2PService extends WithTracer implements P2PService {
       expectedBlockProposalsPerSlot: config.expectedBlockProposalsPerSlot,
     });
 
+    // Restrict gossipsub to exactly the topics we subscribe to. Without this, an arbitrary-topic
+    // message is transformed, msg-id'd and inserted into the seenCache before the subscription check,
+    // so a crafted topic colliding on msg id can suppress a real message as a duplicate.
+    const allowedTopics = getTopicsForConfig(config.disableTransactions).map(topic =>
+      createTopicString(topic, protocolVersion),
+    );
+
     const node = await createLibp2p({
       start: false,
       peerId,
@@ -497,6 +504,7 @@ export class LibP2PService extends WithTracer implements P2PService {
           mcacheLength: config.gossipsubMcacheLength,
           mcacheGossip: config.gossipsubMcacheGossip,
           seenTTL: config.gossipsubSeenTTL,
+          allowedTopics,
           msgIdFn: getMsgIdFn,
           msgIdToStrFn: msgIdToStrFn,
           fastMsgIdFn: fastMsgIdFn,

--- a/yarn-project/yarn.lock
+++ b/yarn-project/yarn.lock
@@ -1774,7 +1774,6 @@ __metadata:
     typescript: "npm:^5.3.3"
     uint8arrays: "npm:^5.0.3"
     viem: "npm:@aztec/viem@2.38.2"
-    xxhash-wasm: "npm:^1.1.0"
   languageName: unknown
   linkType: soft
 
@@ -22052,13 +22051,6 @@ __metadata:
   version: 4.0.2
   resolution: "xtend@npm:4.0.2"
   checksum: 10/ac5dfa738b21f6e7f0dd6e65e1b3155036d68104e67e5d5d1bde74892e327d7e5636a076f625599dc394330a731861e87343ff184b0047fef1360a7ec0a5a36a
-  languageName: node
-  linkType: hard
-
-"xxhash-wasm@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "xxhash-wasm@npm:1.1.0"
-  checksum: 10/cad149dabda4ec4ce7c2edd98815c4cc21eadab72f631c832af110066867850fb86b9430499707358d3e23cafe6d71d0a5c16be8f1864f213e4cd1aa74bd9556
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes A-1256.

## Problem

The gossipsub full message id was `SHA256(topic || data)[0..20]` with **no framing** between the topic string and the message bytes, and `LibP2PService` set no `allowedTopics`. Raw concatenation isn't injective: for a real message `(T, D)`, a peer can craft `T' = T + D[0]`, `D' = D[1:]` so `T' || D'` is byte-identical to `T || D` → same msgId. ChainSafe gossipsub transforms the arbitrary-topic message and inserts that id into `seenCache` **before** the subscription check (it isn't delivered to us, since we're not subscribed to `T'`). When the genuine proposal/attestation arrives on `T`, gossipsub drops it as a **duplicate** before application validation, peer scoring, or handling — suppressing a time-sensitive consensus message within the slot.

## Fix (defense in depth — either alone breaks the attack)

1. **Frame the msgId input** as `uint32be(topicLen) || topic || data` (`encoding.ts`). The topic length pins the `(topic, data)` boundary, so a boundary-shifted pair no longer collides. (`getMsgIdFn`'s parameter is narrowed to `Pick<Message, 'topic' | 'data'>` — the only fields it reads — which stays assignable to gossipsub's `msgIdFn` slot.)
2. **Set exact `allowedTopics`** (`libp2p_service.ts`) to the subscribed Aztec topic strings. Verified against the installed gossipsub: the allowlist is enforced in `handleReceivedRpc` *before* `handleReceivedMessage`/`seenCache.put`, so an unsubscribed-topic message is dropped before transform / msgId / seenCache.

## Test

`encoding.test.ts`: builds a real `P2PMessage.toMessageData()` buffer (confirming `data[0] === 0x00`), constructs the shifted `(T', D')`, and asserts the two msg ids now differ (they collided before the framing change); plus a determinism check.

## Compatibility

`msgId` is computed locally for dedup; changing the function doesn't change any on-wire format. During a rolling upgrade, mixed nodes briefly compute different ids for the same message (minor IHAVE/IWANT inefficiency), with no correctness impact.