### PR TITLE
fix(p2p): guard ENR address parsing against malformed TCP fields (A-1255)

### DIFF
--- a/yarn-project/p2p/src/bootstrap/bootstrap.ts
+++ b/yarn-project/p2p/src/bootstrap/bootstrap.ts
@@ -84,15 +84,21 @@ export class BootstrapNode implements P2PBootstrapApi {
       this.logger.info('Advertised socket address updated', { addr: addr.toString() });
     });
     this.node.on('discovered', async (enr: SignableENR) => {
-      const addr = await enr.getFullMultiaddr('udp');
-      this.logger.verbose(`Discovered new peer`, { enr: enr.encodeTxt(), addr: addr?.toString() });
-      // discv5's discovered() only updates routing table entries that already exist. Nodes that
-      // established a session with an empty-IP ENR are never inserted, so even after their ENR
-      // gains a valid socket address the routing table stays empty and FINDNODE always returns 0
-      // peers. Calling addEnr() here does an insertOrUpdate regardless of prior state, fixing
-      // the routing table so these nodes become discoverable to other peers.
-      if (addr) {
-        this.node.addEnr(enr);
+      try {
+        const addr = await enr.getFullMultiaddr('udp');
+        this.logger.verbose(`Discovered new peer`, { enr: enr.encodeTxt(), addr: addr?.toString() });
+        // discv5's discovered() only updates routing table entries that already exist. Nodes that
+        // established a session with an empty-IP ENR are never inserted, so even after their ENR
+        // gains a valid socket address the routing table stays empty and FINDNODE always returns 0
+        // peers. Calling addEnr() here does an insertOrUpdate regardless of prior state, fixing
+        // the routing table so these nodes become discoverable to other peers.
+        if (addr) {
+          this.node.addEnr(enr);
+        }
+      } catch (err) {
+        // A malformed ENR address field makes the parser throw. As an async listener this would crash
+        // the bootnode on an unhandled rejection — catch, log, and drop the ENR instead.
+        this.logger.warn(`Dropping discovered ENR with unparseable address`, { err });
       }
     });
 

--- a/yarn-project/p2p/src/services/discv5/discV5_service.ts
+++ b/yarn-project/p2p/src/services/discv5/discV5_service.ts
@@ -317,14 +317,21 @@ export class DiscV5Service extends EventEmitter implements PeerDiscoveryService 
   }
 
   private async onEnrAdded(enr: ENR) {
-    const multiAddrTcp = await enr.getFullMultiaddr('tcp');
-    const multiAddrUdp = await enr.getFullMultiaddr('udp');
-    this.logger.debug(`Added ENR ${enr.encodeTxt()}`, { multiAddrTcp, multiAddrUdp, nodeId: enr.nodeId });
-    // A peer just entered the routing table — persist it so we can re-seed discovery after a restart.
-    if (this.persistedEnrs && this.shouldPersist(enr)) {
-      await this.persistedEnrs.persist(enr);
+    try {
+      const multiAddrTcp = await enr.getFullMultiaddr('tcp');
+      const multiAddrUdp = await enr.getFullMultiaddr('udp');
+      this.logger.debug(`Added ENR ${enr.encodeTxt()}`, { multiAddrTcp, multiAddrUdp, nodeId: enr.nodeId });
+      // A peer just entered the routing table — persist it so we can re-seed discovery after a restart.
+      if (this.persistedEnrs && this.shouldPersist(enr)) {
+        await this.persistedEnrs.persist(enr);
+      }
+      this.onDiscovered(enr);
+    } catch (err) {
+      // A malformed ENR address field (e.g. a 3-byte TCP port) makes @nethermindeth/enr throw while
+      // parsing the multiaddr. This is an async event listener, so an unhandled rejection would crash
+      // the process — catch, log, and drop the ENR instead.
+      this.logger.warn(`Dropping ENR with unparseable address`, { nodeId: enr.nodeId, err });
     }
-    this.onDiscovered(enr);
   }
 
   private async onPeerDiscovered(enr: ENR) {
@@ -372,6 +379,17 @@ export class DiscV5Service extends EventEmitter implements PeerDiscoveryService 
     const value = enr.kvs.get(AZTEC_ENR_KEY);
     if (!value) {
       this.logger.debug(`Peer node ${enr.nodeId} does not have aztec key in ENR`);
+      return false;
+    }
+
+    // A malformed TCP field (e.g. a non-2-byte port) makes @nethermindeth/enr throw while building the
+    // multiaddr. Reject such an ENR here so it's never emitted as a full peer or re-parsed by an
+    // unguarded listener (which would crash the process). A missing TCP addr is allowed — those peers
+    // are simply skipped at dial time.
+    try {
+      enr.getLocationMultiaddr('tcp');
+    } catch (err) {
+      this.logger.debug(`Peer node ${enr.nodeId} has an unparseable TCP address`, { err });
       return false;
     }
 

--- a/yarn-project/p2p/src/services/discv5/discv5_service.test.ts
+++ b/yarn-project/p2p/src/services/discv5/discv5_service.test.ts
@@ -8,11 +8,13 @@ import { getTelemetryClient } from '@aztec/telemetry-client';
 import { jest } from '@jest/globals';
 import type { PeerId } from '@libp2p/interface';
 import { createSecp256k1PeerId } from '@libp2p/peer-id-factory';
+import { multiaddr } from '@multiformats/multiaddr';
 import type { IDiscv5CreateOptions } from '@nethermindeth/discv5';
+import { ENR, SignableENR } from '@nethermindeth/enr';
 
 import { BootstrapNode } from '../../bootstrap/bootstrap.js';
 import { type BootnodeConfig, DEFAULT_PUBLIC_IP_SERVICES, type P2PConfig, getP2PDefaultConfig } from '../../config.js';
-import { AZTEC_ENR_CLIENT_VERSION_KEY } from '../../types/index.js';
+import { AZTEC_ENR_CLIENT_VERSION_KEY, AZTEC_ENR_KEY, PeerEvent } from '../../types/index.js';
 import { PeerDiscoveryState } from '../service.js';
 import { DiscV5Service } from './discV5_service.js';
 import { PersistedEnrStore } from './persisted_enr_store.js';
@@ -389,6 +391,45 @@ describe('Discv5Service', () => {
     const node = await createNode();
     const enr = node.getEnr();
     expect(enr.kvs.get(AZTEC_ENR_CLIENT_VERSION_KEY)?.toString()).toEqual(testPackageVersion);
+  });
+
+  describe('malformed ENR address handling', () => {
+    // Builds an ENR with valid ip/udp and a (correct-version) aztec key, but a malformed 3-byte TCP
+    // value that makes @nethermindeth/enr throw while parsing the multiaddr. Returns the malformed ENR
+    // and a valid control built from the same identity (valid version, no malformed TCP).
+    const makeMalformedTcpEnr = async (aztecKey: Buffer) => {
+      const peerId = await createSecp256k1PeerId();
+      const signable = SignableENR.createFromPeerId(peerId);
+      signable.setLocationMultiaddr(multiaddr('/ip4/127.0.0.1/udp/9999'));
+      signable.set(AZTEC_ENR_KEY, aztecKey);
+      const control = ENR.decodeTxt(signable.encodeTxt());
+      signable.set('tcp', Buffer.from([0x00, 0x00, 0x00]));
+      const malformed = ENR.decodeTxt(signable.encodeTxt());
+      return { control, malformed };
+    };
+
+    it('validateEnr rejects an ENR whose TCP address will not parse', async () => {
+      const service = await createNode();
+      const aztecKey = Buffer.from(service.getEnr().kvs.get(AZTEC_ENR_KEY)!);
+      const { control, malformed } = await makeMalformedTcpEnr(aztecKey);
+
+      // The control (same valid version, no malformed TCP) validates; only the malformed TCP is rejected.
+      expect((service as any).validateEnr(control)).toBe(true);
+      expect((service as any).validateEnr(malformed)).toBe(false);
+    });
+
+    it('onEnrAdded does not reject or emit DISCOVERED for a malformed-TCP ENR', async () => {
+      const service = await createNode();
+      const aztecKey = Buffer.from(service.getEnr().kvs.get(AZTEC_ENR_KEY)!);
+      const { malformed } = await makeMalformedTcpEnr(aztecKey);
+
+      const discovered: ENR[] = [];
+      service.on(PeerEvent.DISCOVERED, (enr: ENR) => discovered.push(enr));
+
+      // Before the fix this rejected with a RangeError, crashing the process as an unhandled rejection.
+      await expect((service as any).onEnrAdded(malformed)).resolves.toBeUndefined();
+      expect(discovered).toEqual([]);
+    });
   });
 
   const testPackageVersion = 'test-discv5-service';

--- a/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
+++ b/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
@@ -1,6 +1,6 @@
 import type { EpochCacheInterface } from '@aztec/epoch-cache';
 import { BlockNumber, type SlotNumber } from '@aztec/foundation/branded-types';
-import { maxBy, merge } from '@aztec/foundation/collection';
+import { compactArray, maxBy, merge } from '@aztec/foundation/collection';
 import { type Logger, createLibp2pComponentLogger, createLogger } from '@aztec/foundation/log';
 import { RunningPromise } from '@aztec/foundation/running-promise';
 import { Timer } from '@aztec/foundation/timer';
@@ -383,21 +383,27 @@ export class LibP2PService extends WithTracer implements P2PService {
     const protocolVersion = compressComponentVersions(versions);
 
     const preferredPeersEnrs: ENR[] = config.preferredPeers.map(enr => ENR.decodeTxt(enr));
-    const directPeers = (
+    const directPeers = compactArray(
       await Promise.all(
         preferredPeersEnrs.map(async enr => {
-          const peerId = await enr.peerId();
-          const address = enr.getLocationMultiaddr('tcp');
-          if (address === undefined) {
-            throw new Error(`Direct peer ${peerId.toString()} has no TCP address, ENR: ${enr.encodeTxt()}`);
+          try {
+            const peerId = await enr.peerId();
+            const address = enr.getLocationMultiaddr('tcp');
+            if (address === undefined) {
+              throw new Error(`Direct peer ${peerId.toString()} has no TCP address, ENR: ${enr.encodeTxt()}`);
+            }
+            return {
+              id: peerId,
+              addrs: [address],
+            };
+          } catch (err) {
+            // A malformed configured ENR shouldn't abort node setup — skip it and log.
+            logger.warn(`Skipping preferred peer with invalid ENR`, { err });
+            return undefined;
           }
-          return {
-            id: peerId,
-            addrs: [address],
-          };
         }),
-      )
-    ).filter(peer => peer !== undefined);
+      ),
+    );
 
     const announceTcpMultiaddr = config.p2pIp ? [convertToMultiaddr(config.p2pIp, p2pPort, 'tcp')] : [];
 

--- a/yarn-project/p2p/src/services/peer-manager/peer_manager.ts
+++ b/yarn-project/p2p/src/services/peer-manager/peer_manager.ts
@@ -1,4 +1,5 @@
 import type { EpochCacheInterface } from '@aztec/epoch-cache';
+import { compactArray } from '@aztec/foundation/collection';
 import { makeEthSignDigest, tryRecoverAddress } from '@aztec/foundation/crypto/secp256k1-signer';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import type { EthAddress } from '@aztec/foundation/eth-address';
@@ -199,21 +200,27 @@ export class PeerManager implements PeerManagerInterface {
       .then(peerIds => peerIds.forEach(peerId => this.preferredPeers.add(peerId.toString())))
       .catch(e => this.logger.error('Error initializing preferred peers', e));
 
-    const directPeers = (
+    const directPeers = compactArray(
       await Promise.all(
         preferredPeersEnrs.map(async enr => {
-          const peerId = await enr.peerId();
-          const address = enr.getLocationMultiaddr('tcp');
-          if (address === undefined) {
-            throw new Error(`Direct peer ${peerId.toString()} has no TCP address, ENR: ${enr.encodeTxt()}`);
+          try {
+            const peerId = await enr.peerId();
+            const address = enr.getLocationMultiaddr('tcp');
+            if (address === undefined) {
+              throw new Error(`Direct peer ${peerId.toString()} has no TCP address, ENR: ${enr.encodeTxt()}`);
+            }
+            return {
+              id: peerId,
+              addrs: [address],
+            };
+          } catch (err) {
+            // A malformed configured ENR shouldn't abort preferred-peer setup — skip it and log.
+            this.logger.warn(`Skipping preferred peer with invalid ENR`, { err });
+            return undefined;
           }
-          return {
-            id: peerId,
-            addrs: [address],
-          };
         }),
-      )
-    ).filter(peer => peer !== undefined);
+      ),
+    );
 
     await Promise.all(
       directPeers.map(peer => {


### PR DESCRIPTION
Fixes A-1255.

## Problem

A discovery peer can advertise a signed ENR with valid `ip`/`udp` contact data and the expected Aztec ENR version key, but a **malformed** `tcp` field (e.g. 3 bytes instead of a 2-byte port). `DiscV5Service.validateEnr` only checked the aztec key + version, so upstream discv5 accepted the session and emitted `enrAdded`. The unguarded async `onEnrAdded` listener then awaited `enr.getFullMultiaddr('tcp')`, which throws `RangeError` on the malformed value; as an async EventEmitter listener the rejection is unhandled and **the node process exits**. One malformed, UDP-contactable, same-version ENR crashes any p2p-enabled node.

## Audit

A sweep of every `getFullMultiaddr` / `getLocationMultiaddr` call in `p2p/src` found the same unguarded-parse pattern in more than one place:

| Site | ENR source | Crash today | Action |
|------|-----------|-------------|--------|
| `discV5_service.ts` `onEnrAdded` | remote | yes | guard + drop |
| `bootstrap.ts` `discovered` listener | remote | yes (crashes the **bootnode**) | guard + drop |
| `peer_manager.ts` `handleDiscoveredPeer` | remote | no (caught by wrapper) | covered by `validateEnr` rejecting malformed-addr ENRs |
| `peer_manager.ts` / `libp2p_service.ts` `preferredPeers` | config | aborts setup | skip + log |

## Fix

- Guard `onEnrAdded` and the bootnode `discovered` listener so a parser exception is caught, logged, and the ENR dropped — no unhandled rejection.
- `validateEnr` rejects an ENR whose TCP multiaddr won't parse, so it's never emitted as a full peer (`PeerEvent.DISCOVERED`) or re-parsed by `handleDiscoveredPeer`. A *missing* TCP addr stays allowed — those peers are simply skipped at dial time; only an *unparseable* one is rejected.
- `preferredPeers` ENR parsing skips and logs a malformed configured ENR instead of aborting node / preferred-peer setup.

The self-ENR log line (`discV5_service.ts:199-200`) is intentionally left unguarded — it reads our own ENR, which we build and which can't be attacker-malformed.

## Tests

`discv5_service.test.ts`: builds a same-version ENR with valid `ip`/`udp` and a 3-byte `tcp` value, and asserts (a) `validateEnr` rejects it while a valid control built from the same identity passes — isolating the TCP check — and (b) `onEnrAdded` resolves (no unhandled rejection, previously a `RangeError`) and never emits `DISCOVERED`.

Note: `discV5_service.ts` overlapped with the already-merged PR #24169; this branch is off the post-merge `merge-train/spartan-v5`, so no conflict.