### PR TITLE
fix(archiver): treat re-publish of preloaded protocol contracts as idempotent

### DIFF
--- a/yarn-project/archiver/src/modules/data_store_updater.test.ts
+++ b/yarn-project/archiver/src/modules/data_store_updater.test.ts
@@ -1,11 +1,15 @@
+import { CONTRACT_CLASS_LOG_SIZE_IN_FIELDS, CONTRACT_CLASS_PUBLISHED_MAGIC_VALUE } from '@aztec/constants';
 import { BlockNumber, CheckpointNumber, IndexWithinCheckpoint, SlotNumber } from '@aztec/foundation/branded-types';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { openTmpStore } from '@aztec/kv-store/lmdb-v2';
+import { ProtocolContractAddress } from '@aztec/protocol-contracts';
 import { ContractClassPublishedEvent } from '@aztec/protocol-contracts/class-registry';
 import { ContractInstancePublishedEvent } from '@aztec/protocol-contracts/instance-registry';
+import { BundledProtocolContractsProvider } from '@aztec/protocol-contracts/providers/bundle';
+import { bufferAsFields } from '@aztec/stdlib/abi';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
 import { GENESIS_BLOCK_HEADER_HASH, L2Block } from '@aztec/stdlib/block';
-import { ContractClassLog, PrivateLog } from '@aztec/stdlib/logs';
+import { ContractClassLog, ContractClassLogFields, PrivateLog } from '@aztec/stdlib/logs';
 import { CheckpointHeader } from '@aztec/stdlib/rollup';
 import '@aztec/stdlib/testing/jest';
 import { BlockHeader } from '@aztec/stdlib/tx';
@@ -15,10 +19,39 @@ import { readFileSync } from 'fs';
 import { dirname, resolve } from 'path';
 import { fileURLToPath } from 'url';
 
+import { registerProtocolContracts } from '../factory.js';
 import { type ArchiverDataStores, createArchiverDataStores } from '../store/data_stores.js';
 import { L2TipsCache } from '../store/l2_tips_cache.js';
 import { makeCheckpoint, makePublishedCheckpoint } from '../test/mock_structs.js';
 import { ArchiverDataStoreUpdater } from './data_store_updater.js';
+
+/**
+ * Builds a ContractClassPublished log for a real bundled protocol contract class. The log carries the
+ * protocol contract's actual fields so that the class id the data store updater recomputes matches the
+ * bundled protocol class id (otherwise the updater would skip it as a mismatched id).
+ */
+function buildProtocolContractClassLog(contractClass: {
+  artifactHash: Fr;
+  privateFunctionsRoot: Fr;
+  packedBytecode: Buffer;
+  id: Fr;
+}): ContractClassLog {
+  const fields = [
+    new Fr(CONTRACT_CLASS_PUBLISHED_MAGIC_VALUE),
+    contractClass.id,
+    new Fr(1), // version
+    contractClass.artifactHash,
+    contractClass.privateFunctionsRoot,
+    // The remaining fields encode the packed bytecode; size it to fill the rest of the log so that
+    // ContractClassPublishedEvent.fromLog reads back the full bytecode buffer.
+    ...bufferAsFields(contractClass.packedBytecode, CONTRACT_CLASS_LOG_SIZE_IN_FIELDS - 5),
+  ];
+  return new ContractClassLog(
+    ProtocolContractAddress.ContractClassRegistry,
+    new ContractClassLogFields(fields),
+    fields.length,
+  );
+}
 
 /** Loads the sample ContractClassPublished event payload from protocol-contracts fixtures. */
 function getSampleContractClassPublishedEventPayload(): Buffer {
@@ -82,6 +115,38 @@ describe('ArchiverDataStoreUpdater', () => {
       const retrievedInstance = await store.contractInstances.getContractInstance(instanceAddress, timestamp);
       expect(retrievedInstance).toBeDefined();
       expect(retrievedInstance?.address.equals(instanceAddress)).toBe(true);
+    });
+
+    it('treats an on-chain re-publish of a preloaded protocol contract class as idempotent (A-1257)', async () => {
+      // Protocol contracts are preloaded at synthetic block 0 via registerProtocolContracts. When a
+      // bundled protocol contract class is later (re-)published on chain, the archiver must not throw
+      // when re-adding the already-present class, which would otherwise stall L1 sync.
+      await registerProtocolContracts(store);
+
+      const provider = new BundledProtocolContractsProvider();
+      const protocolContract = await provider.getProtocolContractArtifact('ContractClassRegistry');
+      const protocolClassId = protocolContract.contractClass.id;
+
+      // The class is queryable from the block-0 preload.
+      expect(await store.contractClasses.getContractClass(protocolClassId)).toBeDefined();
+
+      // Build a block whose tx emits a ContractClassPublished log for the bundled protocol class id.
+      const block = await L2Block.random(BlockNumber(1), {
+        checkpointNumber: CheckpointNumber(1),
+        indexWithinCheckpoint: IndexWithinCheckpoint(0),
+      });
+      block.body.txEffects[0].contractClassLogs = [buildProtocolContractClassLog(protocolContract.contractClass)];
+
+      // Sanity check: the log decodes to the expected protocol class id (so the updater does not skip it).
+      expect(
+        ContractClassPublishedEvent.fromLog(block.body.txEffects[0].contractClassLogs[0]).contractClassId.equals(
+          protocolClassId,
+        ),
+      ).toBe(true);
+
+      // Adding the block must not throw, and the protocol class must remain queryable afterwards.
+      await expect(updater.addProposedBlock(block)).resolves.not.toThrow();
+      expect(await store.contractClasses.getContractClass(protocolClassId)).toBeDefined();
     });
 
     it('removes contract class and instance data when blocks are pruned via setCheckpointData', async () => {

--- a/yarn-project/archiver/src/store/contract_class_store.test.ts
+++ b/yarn-project/archiver/src/store/contract_class_store.test.ts
@@ -1,6 +1,7 @@
 import { BlockNumber } from '@aztec/foundation/branded-types';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { openTmpStore } from '@aztec/kv-store/lmdb-v2';
+import { ProtocolContractClassId } from '@aztec/protocol-contracts';
 import {
   type ContractClassPublic,
   type ContractClassPublicWithCommitment,
@@ -56,6 +57,43 @@ describe('ContractClassStore', () => {
 
     it('returns undefined if contract class is not found', async () => {
       await expect(contractClassStore.getContractClass(Fr.random())).resolves.toBeUndefined();
+    });
+  });
+
+  describe('protocol contract classes (A-1257)', () => {
+    // Protocol contracts are preloaded at synthetic block 0. A later on-chain (re-)publish of a
+    // bundled protocol class id must be treated as a no-op rather than a hard error, and must never
+    // delete the preloaded entry.
+    let protocolClass: ContractClassPublic;
+    const preloadBlock = 0;
+
+    beforeEach(async () => {
+      const base = await makeContractClassPublic();
+      protocolClass = { ...base, id: ProtocolContractClassId.ContractClassRegistry };
+      await contractClassStore.addContractClasses([await withCommitment(protocolClass)], BlockNumber(preloadBlock));
+    });
+
+    it('treats re-publish of a preloaded protocol class as a no-op and keeps it queryable', async () => {
+      const originalCommitment = await computePublicBytecodeCommitment(protocolClass.packedBytecode);
+      await expect(
+        contractClassStore.addContractClasses([await withCommitment(protocolClass)], BlockNumber(50)),
+      ).resolves.not.toThrow();
+      await expect(contractClassStore.getContractClass(protocolClass.id)).resolves.toMatchObject(protocolClass);
+      // The block-0 preload must be left untouched: the re-publish must not clobber the stored bytecode commitment.
+      await expect(contractClassStore.getBytecodeCommitment(protocolClass.id)).resolves.toEqual(originalCommitment);
+    });
+
+    it('does not delete a protocol class', async () => {
+      await contractClassStore.deleteContractClasses([protocolClass], BlockNumber(preloadBlock));
+      await expect(contractClassStore.getContractClass(protocolClass.id)).resolves.toMatchObject(protocolClass);
+    });
+
+    it('still throws when a non-protocol class is added twice', async () => {
+      const nonProtocolClass = await makeContractClassPublic(123);
+      await contractClassStore.addContractClasses([await withCommitment(nonProtocolClass)], BlockNumber(10));
+      await expect(
+        contractClassStore.addContractClasses([await withCommitment(nonProtocolClass)], BlockNumber(11)),
+      ).rejects.toThrow(/already exists/);
     });
   });
 });

--- a/yarn-project/archiver/src/store/contract_class_store.ts
+++ b/yarn-project/archiver/src/store/contract_class_store.ts
@@ -2,6 +2,7 @@ import { Fr } from '@aztec/foundation/curves/bn254';
 import { toArray } from '@aztec/foundation/iterable';
 import { BufferReader, numToUInt8, serializeToBuffer } from '@aztec/foundation/serialize';
 import type { AztecAsyncKVStore, AztecAsyncMap } from '@aztec/kv-store';
+import { isProtocolContractClass } from '@aztec/protocol-contracts';
 import type {
   ContractClassPublic,
   ContractClassPublicWithBlockNumber,
@@ -50,6 +51,12 @@ export class ContractClassStore {
     await this.db.transactionAsync(async () => {
       const key = contractClass.id.toString();
       if (await this.#contractClasses.hasAsync(key)) {
+        // Protocol contracts are preloaded at block 0, so a later on-chain (re-)publish of a bundled
+        // protocol class id is valid and must be a no-op. Keep the existing block-0 entry untouched
+        // (do not bump its block number) so it survives reorgs of the publishing block.
+        if (isProtocolContractClass(contractClass.id)) {
+          return;
+        }
         throw new Error(`Contract class ${key} already exists, cannot add again at block ${blockNumber}`);
       }
       await this.#contractClasses.set(
@@ -61,6 +68,11 @@ export class ContractClassStore {
   }
 
   async deleteContractClass(contractClass: ContractClassPublic, blockNumber: number): Promise<void> {
+    // Protocol contracts are preloaded at block 0 and must never be deleted, even when the block that
+    // (re-)published them on-chain is unwound by a reorg.
+    if (isProtocolContractClass(contractClass.id)) {
+      return;
+    }
     const restoredContractClass = await this.#contractClasses.getAsync(contractClass.id.toString());
     if (restoredContractClass && deserializeContractClassPublic(restoredContractClass).l2BlockNumber >= blockNumber) {
       await this.db.transactionAsync(async () => {

--- a/yarn-project/archiver/src/store/contract_instance_store.test.ts
+++ b/yarn-project/archiver/src/store/contract_instance_store.test.ts
@@ -1,6 +1,7 @@
 import { BlockNumber } from '@aztec/foundation/branded-types';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { openTmpStore } from '@aztec/kv-store/lmdb-v2';
+import { ProtocolContractAddress } from '@aztec/protocol-contracts';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
 import { type ContractInstanceWithAddress, SerializableContractInstance } from '@aztec/stdlib/contract';
 import '@aztec/stdlib/testing/jest';
@@ -50,6 +51,58 @@ describe('ContractInstanceStore', () => {
 
     it('throws when adding the same contract instance twice', async () => {
       await expect(contractInstanceStore.addContractInstances([contractInstance], BlockNumber(2))).rejects.toThrow(
+        /already exists/,
+      );
+    });
+  });
+
+  describe('protocol contract instances (A-1257)', () => {
+    // Protocol contracts are preloaded at synthetic block 0. A later on-chain (re-)publish of a
+    // bundled protocol instance must be treated as a no-op rather than a hard error, and must never
+    // delete the preloaded entry.
+    let protocolInstance: ContractInstanceWithAddress;
+    const timestamp = 3600n;
+    const preloadBlock = 0;
+
+    beforeEach(async () => {
+      const classId = Fr.random();
+      const randomInstance = await SerializableContractInstance.random({
+        currentContractClassId: classId,
+        originalContractClassId: classId,
+      });
+      protocolInstance = { ...randomInstance, address: ProtocolContractAddress.ContractClassRegistry };
+      await contractInstanceStore.addContractInstances([protocolInstance], BlockNumber(preloadBlock));
+    });
+
+    it('treats re-publish of a preloaded protocol instance as a no-op and keeps it queryable', async () => {
+      await expect(
+        contractInstanceStore.addContractInstances([protocolInstance], BlockNumber(50)),
+      ).resolves.not.toThrow();
+      await expect(
+        contractInstanceStore.getContractInstance(protocolInstance.address, timestamp),
+      ).resolves.toMatchObject(protocolInstance);
+      // The block-0 preload must be left untouched: the re-publish must not bump the recorded deployment block.
+      await expect(
+        contractInstanceStore.getContractInstanceDeploymentBlockNumber(protocolInstance.address),
+      ).resolves.toEqual(preloadBlock);
+    });
+
+    it('does not delete a protocol instance', async () => {
+      await contractInstanceStore.deleteContractInstances([protocolInstance]);
+      await expect(
+        contractInstanceStore.getContractInstance(protocolInstance.address, timestamp),
+      ).resolves.toMatchObject(protocolInstance);
+    });
+
+    it('still throws when a non-protocol instance is added twice', async () => {
+      const classId = Fr.random();
+      const randomInstance = await SerializableContractInstance.random({
+        currentContractClassId: classId,
+        originalContractClassId: classId,
+      });
+      const nonProtocolInstance = { ...randomInstance, address: await AztecAddress.random() };
+      await contractInstanceStore.addContractInstances([nonProtocolInstance], BlockNumber(10));
+      await expect(contractInstanceStore.addContractInstances([nonProtocolInstance], BlockNumber(11))).rejects.toThrow(
         /already exists/,
       );
     });

--- a/yarn-project/archiver/src/store/contract_instance_store.ts
+++ b/yarn-project/archiver/src/store/contract_instance_store.ts
@@ -1,5 +1,6 @@
 import type { Fr } from '@aztec/foundation/curves/bn254';
 import type { AztecAsyncKVStore, AztecAsyncMap } from '@aztec/kv-store';
+import { isProtocolContract } from '@aztec/protocol-contracts';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
 import {
   type ContractInstanceUpdateWithAddress,
@@ -72,6 +73,11 @@ export class ContractInstanceStore {
     return this.db.transactionAsync(async () => {
       const key = contractInstance.address.toString();
       if (await this.#contractInstances.hasAsync(key)) {
+        // Protocol contracts are preloaded at block 0, so a later on-chain (re-)publish of a bundled
+        // protocol instance is valid and must be a no-op. Keep the existing block-0 entry untouched.
+        if (isProtocolContract(contractInstance.address)) {
+          return;
+        }
         throw new Error(
           `Contract instance at ${key} already exists (deployed at block ${await this.#contractInstancePublishedAt.getAsync(key)}), cannot add again at block ${blockNumber}`,
         );
@@ -82,6 +88,11 @@ export class ContractInstanceStore {
   }
 
   deleteContractInstance(contractInstance: ContractInstanceWithAddress): Promise<void> {
+    // Protocol contracts are preloaded at block 0 and must never be deleted, even when the block that
+    // (re-)published them on-chain is unwound by a reorg.
+    if (isProtocolContract(contractInstance.address)) {
+      return Promise.resolve();
+    }
     return this.db.transactionAsync(async () => {
       await this.#contractInstances.delete(contractInstance.address.toString());
       await this.#contractInstancePublishedAt.delete(contractInstance.address.toString());

--- a/yarn-project/protocol-contracts/src/protocol_contract.ts
+++ b/yarn-project/protocol-contracts/src/protocol_contract.ts
@@ -1,8 +1,9 @@
+import type { Fr } from '@aztec/foundation/curves/bn254';
 import type { ContractArtifact } from '@aztec/stdlib/abi';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
 import type { ContractClassIdPreimage, ContractClassWithId, ContractInstanceWithAddress } from '@aztec/stdlib/contract';
 
-import { ProtocolContractAddress } from './protocol_contract_data.js';
+import { ProtocolContractAddress, ProtocolContractClassId } from './protocol_contract_data.js';
 
 /** Represents a canonical contract in the protocol. */
 export interface ProtocolContract {
@@ -18,6 +19,13 @@ export interface ProtocolContract {
 
 export function isProtocolContract(address: AztecAddress) {
   return Object.values(ProtocolContractAddress).some(a => a.equals(address));
+}
+
+const protocolContractClassIds = new Set(Object.values(ProtocolContractClassId).map(id => id.toString()));
+
+/** Returns whether the given contract class id belongs to a bundled protocol contract. */
+export function isProtocolContractClass(classId: Fr): boolean {
+  return protocolContractClassIds.has(classId.toString());
 }
 
 export { type ProtocolContractsProvider } from './provider/protocol_contracts_provider.js';


### PR DESCRIPTION
## Motivation

The archiver preloads every bundled protocol contract class (and its canonical instance) into its local store at synthetic block 0, before L1 sync. World-state genesis, however, seeds no registration nullifiers for those classes/instances. As a result a *first* on-chain `ContractClassRegistry.publish` of a bundled protocol class id is protocol-valid (fresh class-id nullifier + `ContractClassPublished` log). On replay the archiver recomputes the same class id and unconditionally re-inserts it, but the store throws on the pre-existing block-0 key (`Contract class <id> already exists, cannot add again`). Because that insert runs inside the block/checkpoint store transaction, the throw aborts persistence, and L1 sync retries the same valid checkpoint indefinitely — a sync stall.

## Approach

Make the archiver treat protocol-preloaded entries as idempotent and immutable, guarded at the store layer (the single chokepoint for both the add-throw and the block-gated delete):

- `addContractClass` / `addContractInstance`: when the key already exists and it is a protocol class id / magic protocol address, treat the (re-)publish as a no-op and keep the existing block-0 entry — crucially **without** bumping its recorded block number. Genuine non-protocol duplicates still throw unchanged.
- `deleteContractClass` / `deleteContractInstance`: skip deletion for protocol entries, so a reorg of the publishing block can never roll out the preload.

Keeping the preload at block 0 is deliberate: `deleteContractClass` only deletes when the stored `l2BlockNumber >= blockNumber`, so block 0 makes protocol entries survive any reorg; bumping to the publish block would let a deep reorg delete them.

The instance-side guards are defensive only: on-chain `publish_for_public_execution` always emits the *derived* address, never a magic address, so the instance store is not reached with a magic address via the on-chain replay path today — the guards exist for symmetry and to protect future code paths.

This is a non-breaking, node-local resilience fix. A follow-up PR (PR2) seeds the protocol registration nullifiers into world-state genesis so the on-chain re-publish is rejected at the protocol level — the root-cause fix for the class path.

## Changes

- **protocol-contracts**: add `isProtocolContractClass(classId)` (sibling of the existing `isProtocolContract(address)`), backed by a set of the generated `ProtocolContractClassId` values.
- **archiver**: idempotent add + protected delete for protocol classes and instances in `ContractClassStore` / `ContractInstanceStore`.
- **archiver (tests)**: store unit tests (idempotent re-add stays queryable with block-0 / bytecode-commitment preserved, protected delete, non-protocol duplicate still throws — for both classes and instances) and an A-1257 integration test that preloads protocol contracts, builds an `L2Block` carrying a `ContractClassPublished` log for a bundled class id, and asserts `addProposedBlock` commits and the class stays queryable.

Fixes A-1257