### PR TITLE
feat(e2e): constrained delivery and discovery with two PXEs

### DIFF
--- a/noir-projects/noir-contracts/contracts/test/constrained_delivery_test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/constrained_delivery_test_contract/src/main.nr
@@ -8,6 +8,7 @@ pub contract ConstrainedDeliveryTest {
     use aztec::{
         macros::{events::event, functions::external, storage::storage},
         messages::delivery::{MessageDelivery, OnchainDeliveryMode},
+        note::note_viewer_options::NoteViewerOptions,
         oracle::notes::get_next_tagging_index,
         protocol::{
             address::AztecAddress,
@@ -41,8 +42,8 @@ pub contract ConstrainedDeliveryTest {
     }
 
     #[external("private")]
-    fn emit_note(recipient: AztecAddress) {
-        self.storage.notes.at(recipient).insert(FieldNote { value: 1 }).deliver(MessageDelivery::onchain_constrained());
+    fn emit_note(recipient: AztecAddress, value: Field) {
+        self.storage.notes.at(recipient).insert(FieldNote { value }).deliver(MessageDelivery::onchain_constrained());
     }
 
     #[external("private")]
@@ -51,8 +52,8 @@ pub contract ConstrainedDeliveryTest {
     }
 
     #[external("private")]
-    fn emit_event(recipient: AztecAddress) {
-        self.emit(DeliveryEvent { value: 1 }).deliver_to(recipient, MessageDelivery::onchain_constrained());
+    fn emit_event(recipient: AztecAddress, value: Field) {
+        self.emit(DeliveryEvent { value }).deliver_to(recipient, MessageDelivery::onchain_constrained());
     }
 
     #[external("private")]
@@ -71,6 +72,24 @@ pub contract ConstrainedDeliveryTest {
     ) -> Option<Field> {
         let registry = HandshakeRegistry::at(STANDARD_HANDSHAKE_REGISTRY_ADDRESS);
         self.call(registry.get_app_siloed_secret(sender, recipient, mode))
+    }
+
+    /// Returns the number of `FieldNote`s discovered for `owner`.
+    #[external("utility")]
+    unconstrained fn get_note_count(owner: AztecAddress) -> u32 {
+        self.storage.notes.at(owner).view_notes(NoteViewerOptions::new()).len()
+    }
+
+    /// Returns the sum of all `FieldNote` values discovered for `owner`. With distinct delivered values, the sum
+    /// confirms each note was actually decrypted rather than merely counted.
+    #[external("utility")]
+    unconstrained fn get_notes_sum(owner: AztecAddress) -> Field {
+        let notes = self.storage.notes.at(owner).view_notes(NoteViewerOptions::new());
+        let mut sum: Field = 0;
+        for i in 0..notes.len() {
+            sum += notes.get(i).value;
+        }
+        sum
     }
 
     /// Test-only: emits a log under the constrained tag for `(secret, index)` WITHOUT the sequence nullifier. A landed

--- a/noir-projects/noir-contracts/contracts/test/constrained_delivery_test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/constrained_delivery_test_contract/src/main.nr
@@ -74,22 +74,11 @@ pub contract ConstrainedDeliveryTest {
         self.call(registry.get_app_siloed_secret(sender, recipient, mode))
     }
 
-    /// Returns the number of `FieldNote`s discovered for `owner`.
+    /// Returns the values of all `FieldNote`s discovered for `owner`. The e2e test derives both the count and the
+    /// sum from this, confirming each delivered note was discovered and decrypted.
     #[external("utility")]
-    unconstrained fn get_note_count(owner: AztecAddress) -> u32 {
-        self.storage.notes.at(owner).view_notes(NoteViewerOptions::new()).len()
-    }
-
-    /// Returns the sum of all `FieldNote` values discovered for `owner`. With distinct delivered values, the sum
-    /// confirms each note was actually decrypted rather than merely counted.
-    #[external("utility")]
-    unconstrained fn get_notes_sum(owner: AztecAddress) -> Field {
-        let notes = self.storage.notes.at(owner).view_notes(NoteViewerOptions::new());
-        let mut sum: Field = 0;
-        for i in 0..notes.len() {
-            sum += notes.get(i).value;
-        }
-        sum
+    unconstrained fn get_note_values(owner: AztecAddress) -> BoundedVec<Field, 10> {
+        self.storage.notes.at(owner).view_notes(NoteViewerOptions::new()).map(|note| note.value)
     }
 
     /// Test-only: emits a log under the constrained tag for `(secret, index)` WITHOUT the sequence nullifier. A landed

--- a/noir-projects/noir-contracts/contracts/test/constrained_delivery_test_contract/src/test.nr
+++ b/noir-projects/noir-contracts/contracts/test/constrained_delivery_test_contract/src/test.nr
@@ -45,7 +45,7 @@ unconstrained fn rehandshake_replaces_registry_secret_for_future_delivery() {
     let test_contract = ConstrainedDeliveryTest::at(test_address);
     let registry = HandshakeRegistry::at(registry_address);
 
-    env.call_private_opts(sender, authorizing(registry_address), test_contract.emit_event(recipient));
+    env.call_private_opts(sender, authorizing(registry_address), test_contract.emit_event(recipient, 1));
     let first_secret = env
         .execute_utility_opts(
             ExecuteUtilityOptions::new().with_from(test_address),
@@ -62,7 +62,7 @@ unconstrained fn rehandshake_replaces_registry_secret_for_future_delivery() {
         .expect(f"re-handshake should have stored a replacement handshake");
     assert(first_secret != second_secret, "re-handshake should produce a distinct secret");
 
-    env.call_private_opts(sender, authorizing(registry_address), test_contract.emit_event(recipient));
+    env.call_private_opts(sender, authorizing(registry_address), test_contract.emit_event(recipient, 1));
 
     let next_index = env.call_private(sender, test_contract.next_index_for_secret(second_secret));
     assert_eq(next_index, 1);
@@ -84,5 +84,5 @@ unconstrained fn fails_at_index_above_zero_without_prior_nullifier() {
 
     env.call_private(sender, test_contract.emit_constrained_log_without_nullifier(secret, 0));
 
-    let _ = env.call_private_opts(sender, authorizing(registry_address), test_contract.emit_event(recipient));
+    let _ = env.call_private_opts(sender, authorizing(registry_address), test_contract.emit_event(recipient, 1));
 }

--- a/yarn-project/end-to-end/src/e2e_constrained_delivery.test.ts
+++ b/yarn-project/end-to-end/src/e2e_constrained_delivery.test.ts
@@ -218,11 +218,6 @@ describe('cross-PXE constrained delivery', () => {
     // PXE B simulates both the app contract and the registry while discovering, so it must know both.
     await ensureHandshakeRegistryPublished(walletB, recipient);
     await walletB.registerContract(instance, ConstrainedDeliveryTestContract.artifact);
-
-    // The sender needs the recipient's keys to bootstrap the non-interactive handshake. Discovery on PXE B is
-    // registry-based (it reads the HandshakeRegistry with the recipient's own keys), so PXE B intentionally does
-    // not register `sender`.
-    await walletA.registerSender(recipient);
   });
 
   afterAll(async () => {

--- a/yarn-project/end-to-end/src/e2e_constrained_delivery.test.ts
+++ b/yarn-project/end-to-end/src/e2e_constrained_delivery.test.ts
@@ -172,56 +172,56 @@ describe('cross-PXE constrained delivery', () => {
   jest.setTimeout(300_000);
 
   let aztecNode: AztecNode & AztecNodeDebug;
-  let walletA: TestWallet;
-  let walletB: TestWallet;
+  let walletSender: TestWallet;
+  let walletRecipient: TestWallet;
   let sender: AztecAddress;
   let recipient: AztecAddress;
   let additionallyFundedAccounts: InitialAccountData[];
-  let contract: ConstrainedDeliveryTestContract;
-  let teardownA: () => Promise<void>;
-  let teardownB: () => Promise<void>;
+  let contractSender: ConstrainedDeliveryTestContract;
+  let teardownSender: () => Promise<void>;
+  let teardownRecipient: () => Promise<void>;
 
   beforeAll(async () => {
     // PXE A holds the sender. The recipient is funded at genesis here but created and deployed on PXE B below.
     ({
       aztecNode,
       additionallyFundedAccounts,
-      wallet: walletA,
+      wallet: walletSender,
       accounts: [sender],
-      teardown: teardownA,
+      teardown: teardownSender,
     } = await setup(1, {
       ...AUTOMINE_E2E_OPTS,
       additionallyFundedAccounts: await generateSchnorrAccounts(1, 'schnorr'),
     }));
 
     // PXE B holds the recipient on the same node; the recipient account's keys live only here.
-    ({ wallet: walletB, teardown: teardownB } = await setupPXEAndGetWallet(
+    ({ wallet: walletRecipient, teardown: teardownRecipient } = await setupPXEAndGetWallet(
       aztecNode,
       aztecNode,
       {},
       undefined,
       'pxe-b',
     ));
-    const recipientAccount = await walletB.createSchnorrAccount(
+    const recipientAccount = await walletRecipient.createSchnorrAccount(
       additionallyFundedAccounts[0].secret,
       additionallyFundedAccounts[0].salt,
     );
     await (await recipientAccount.getDeployMethod()).send({ from: NO_FROM });
     recipient = recipientAccount.address;
 
-    await ensureHandshakeRegistryPublished(walletA, sender);
-    const { contract: deployed, instance } = await ConstrainedDeliveryTestContract.deploy(walletA).send({
+    await ensureHandshakeRegistryPublished(walletSender, sender);
+    const { contract: deployed, instance } = await ConstrainedDeliveryTestContract.deploy(walletSender).send({
       from: sender,
     });
-    contract = deployed;
+    contractSender = deployed;
 
-    await ensureHandshakeRegistryPublished(walletB, recipient);
-    await walletB.registerContract(instance, ConstrainedDeliveryTestContract.artifact);
+    await ensureHandshakeRegistryPublished(walletRecipient, recipient);
+    await walletRecipient.registerContract(instance, ConstrainedDeliveryTestContract.artifact);
   });
 
   afterAll(async () => {
-    await teardownB();
-    await teardownA();
+    await teardownRecipient();
+    await teardownSender();
   });
 
   it('delivers multiple constrained events from PXE A that PXE B discovers', async () => {
@@ -231,18 +231,21 @@ describe('cross-PXE constrained delivery', () => {
     const eventValues = [10n, 20n, 30n];
     const blockNumbers: number[] = [];
     for (const value of eventValues) {
-      const { receipt } = await contract.methods.emit_event(recipient, value).send({ from: sender });
+      const { receipt } = await contractSender.methods.emit_event(recipient, value).send({ from: sender });
       blockNumbers.push(receipt.blockNumber!);
     }
 
-    await walletB.sync();
+    await walletRecipient.sync();
 
-    const events = await walletB.getPrivateEvents<DeliveryEvent>(ConstrainedDeliveryTestContract.events.DeliveryEvent, {
-      contractAddress: contract.address,
-      fromBlock: BlockNumber(Math.min(...blockNumbers)),
-      toBlock: BlockNumber(Math.max(...blockNumbers) + 1),
-      scopes: [recipient],
-    });
+    const events = await walletRecipient.getPrivateEvents<DeliveryEvent>(
+      ConstrainedDeliveryTestContract.events.DeliveryEvent,
+      {
+        contractAddress: contractSender.address,
+        fromBlock: BlockNumber(Math.min(...blockNumbers)),
+        toBlock: BlockNumber(Math.max(...blockNumbers) + 1),
+        scopes: [recipient],
+      },
+    );
 
     const discovered = events.map(e => e.event.value);
     expect(discovered.length).toBe(eventValues.length);
@@ -255,19 +258,16 @@ describe('cross-PXE constrained delivery', () => {
     // Same recipient and handshake as the events above, so these notes land at the following sequence indices.
     const noteValues = [40n, 50n, 60n];
     for (const value of noteValues) {
-      await contract.methods.emit_note(recipient, value).send({ from: sender });
+      await contractSender.methods.emit_note(recipient, value).send({ from: sender });
     }
 
-    await walletB.sync();
+    await walletRecipient.sync();
 
-    const constrainedDeliveryB = ConstrainedDeliveryTestContract.at(contract.address, walletB);
+    const contractRecipient = ConstrainedDeliveryTestContract.at(contractSender.address, walletRecipient);
     // Count proves every delivered note was discovered; the sum of distinct values proves each was decrypted.
-    const { result: count } = await constrainedDeliveryB.methods
-      .get_note_count(recipient)
-      .simulate({ from: recipient });
-    expect(count).toEqual(BigInt(noteValues.length));
-
-    const { result: sum } = await constrainedDeliveryB.methods.get_notes_sum(recipient).simulate({ from: recipient });
-    expect(sum).toEqual(noteValues.reduce((acc, value) => acc + value, 0n));
+    const { result } = await contractRecipient.methods.get_note_values(recipient).simulate({ from: recipient });
+    const values: bigint[] = result.storage.slice(0, Number(result.len));
+    expect(values.length).toBe(noteValues.length);
+    expect(values.reduce((acc, value) => acc + value, 0n)).toEqual(noteValues.reduce((acc, value) => acc + value, 0n));
   });
 });

--- a/yarn-project/end-to-end/src/e2e_constrained_delivery.test.ts
+++ b/yarn-project/end-to-end/src/e2e_constrained_delivery.test.ts
@@ -267,7 +267,6 @@ describe('cross-PXE constrained delivery', () => {
     // Count proves every delivered note was discovered; the sum of distinct values proves each was decrypted.
     const { result } = await contractRecipient.methods.get_note_values(recipient).simulate({ from: recipient });
     const values: bigint[] = result.storage.slice(0, Number(result.len));
-    expect(values.length).toBe(noteValues.length);
-    expect(values.reduce((acc, value) => acc + value, 0n)).toEqual(noteValues.reduce((acc, value) => acc + value, 0n));
+    expect(values).toEqual(noteValues);
   });
 });

--- a/yarn-project/end-to-end/src/e2e_constrained_delivery.test.ts
+++ b/yarn-project/end-to-end/src/e2e_constrained_delivery.test.ts
@@ -215,7 +215,6 @@ describe('cross-PXE constrained delivery', () => {
     });
     contract = deployed;
 
-    // PXE B simulates both the app contract and the registry while discovering, so it must know both.
     await ensureHandshakeRegistryPublished(walletB, recipient);
     await walletB.registerContract(instance, ConstrainedDeliveryTestContract.artifact);
   });

--- a/yarn-project/end-to-end/src/e2e_constrained_delivery.test.ts
+++ b/yarn-project/end-to-end/src/e2e_constrained_delivery.test.ts
@@ -1,14 +1,23 @@
+import { type InitialAccountData, generateSchnorrAccounts } from '@aztec/accounts/testing';
+import { NO_FROM } from '@aztec/aztec.js/account';
 import type { AztecAddress } from '@aztec/aztec.js/addresses';
 import { BatchCall } from '@aztec/aztec.js/contracts';
+import type { AztecNode } from '@aztec/aztec.js/node';
 import type { Wallet } from '@aztec/aztec.js/wallet';
+import { BlockNumber } from '@aztec/foundation/branded-types';
 import { HandshakeRegistryContract } from '@aztec/noir-contracts.js/HandshakeRegistry';
-import { ConstrainedDeliveryTestContract } from '@aztec/noir-test-contracts.js/ConstrainedDeliveryTest';
+import {
+  ConstrainedDeliveryTestContract,
+  type DeliveryEvent,
+} from '@aztec/noir-test-contracts.js/ConstrainedDeliveryTest';
 import { STANDARD_HANDSHAKE_REGISTRY_ADDRESS } from '@aztec/standard-contracts/handshake-registry/constants';
+import type { AztecNodeDebug } from '@aztec/stdlib/interfaces/client';
 
 import { jest } from '@jest/globals';
 
 import { AUTOMINE_E2E_OPTS } from './fixtures/fixtures.js';
-import { ensureHandshakeRegistryPublished, setup } from './fixtures/setup.js';
+import { ensureHandshakeRegistryPublished, setup, setupPXEAndGetWallet } from './fixtures/setup.js';
+import { TestWallet } from './test-wallet/test_wallet.js';
 
 const ONCHAIN_CONSTRAINED = { inner: 3 };
 
@@ -41,14 +50,14 @@ describe('constrained delivery', () => {
   afterAll(() => teardown());
 
   it('reuses an existing standard-registry constrained handshake', async () => {
-    await contract.methods.emit_note(recipient).send({ from: sender });
+    await contract.methods.emit_note(recipient, 1).send({ from: sender });
 
     const { result: secretAfterFirstSend } = await contract.methods
       .get_app_siloed_secret(sender, recipient, ONCHAIN_CONSTRAINED)
       .simulate({ from: sender });
     expect(secretAfterFirstSend).toBeDefined();
 
-    await contract.methods.emit_event(recipient).send({ from: sender });
+    await contract.methods.emit_event(recipient, 1).send({ from: sender });
 
     const { result: secret } = await contract.methods
       .get_app_siloed_secret(sender, recipient, ONCHAIN_CONSTRAINED)
@@ -73,8 +82,8 @@ describe('constrained delivery', () => {
     // parallel sends to a single pair ever become supported. The working alternative is the batched test below.
     it.failing('cannot fan out constrained sends on the same sequence in parallel', async () => {
       await Promise.all([
-        contract.methods.emit_note(recipient).send({ from: sender }),
-        contract.methods.emit_note(recipient).send({ from: sender }),
+        contract.methods.emit_note(recipient, 1).send({ from: sender }),
+        contract.methods.emit_note(recipient, 1).send({ from: sender }),
       ]);
     });
 
@@ -106,8 +115,8 @@ describe('constrained delivery', () => {
         .send({ from: sender });
 
       await new BatchCall(wallet, [
-        contract.methods.emit_note(batchRecipient2),
-        contract.methods.emit_note(batchRecipient2),
+        contract.methods.emit_note(batchRecipient2, 1),
+        contract.methods.emit_note(batchRecipient2, 1),
       ]).send({ from: sender });
 
       const { result: secret } = await contract.methods
@@ -141,8 +150,8 @@ describe('constrained delivery', () => {
     // so the next index is 1, not 2. Confirms the constraint is in the utility read, not the batching mechanism.
     it('re-handshakes instead of reusing when BatchCall sends bootstrap a new recipient in the same tx', async () => {
       await new BatchCall(wallet, [
-        contract.methods.emit_note(batchRecipient4),
-        contract.methods.emit_note(batchRecipient4),
+        contract.methods.emit_note(batchRecipient4, 1),
+        contract.methods.emit_note(batchRecipient4, 1),
       ]).send({ from: sender });
 
       const { result: secret } = await contract.methods
@@ -153,5 +162,118 @@ describe('constrained delivery', () => {
       const { result: index } = await contract.methods.next_index_for_secret(secret).simulate({ from: sender });
       expect(index).toEqual(1n);
     });
+  });
+});
+
+// A constrained message sent by an account on one PXE is discovered and read by a recipient whose account lives on a
+// separate PXE, with no shared in-memory state: PXE B finds the message purely from on-chain logs plus the
+// HandshakeRegistry. The two PXEs share one node, following the e2e_2_pxes pattern.
+describe('cross-PXE constrained delivery', () => {
+  jest.setTimeout(300_000);
+
+  let aztecNode: AztecNode & AztecNodeDebug;
+  let walletA: TestWallet;
+  let walletB: TestWallet;
+  let sender: AztecAddress;
+  let recipient: AztecAddress;
+  let additionallyFundedAccounts: InitialAccountData[];
+  let contract: ConstrainedDeliveryTestContract;
+  let teardownA: () => Promise<void>;
+  let teardownB: () => Promise<void>;
+
+  beforeAll(async () => {
+    // PXE A holds the sender. The recipient is funded at genesis here but created and deployed on PXE B below.
+    ({
+      aztecNode,
+      additionallyFundedAccounts,
+      wallet: walletA,
+      accounts: [sender],
+      teardown: teardownA,
+    } = await setup(1, {
+      ...AUTOMINE_E2E_OPTS,
+      additionallyFundedAccounts: await generateSchnorrAccounts(1, 'schnorr'),
+    }));
+
+    // PXE B holds the recipient on the same node; the recipient account's keys live only here.
+    ({ wallet: walletB, teardown: teardownB } = await setupPXEAndGetWallet(
+      aztecNode,
+      aztecNode,
+      {},
+      undefined,
+      'pxe-b',
+    ));
+    const recipientAccount = await walletB.createSchnorrAccount(
+      additionallyFundedAccounts[0].secret,
+      additionallyFundedAccounts[0].salt,
+    );
+    await (await recipientAccount.getDeployMethod()).send({ from: NO_FROM });
+    recipient = recipientAccount.address;
+
+    await ensureHandshakeRegistryPublished(walletA, sender);
+    const { contract: deployed, instance } = await ConstrainedDeliveryTestContract.deploy(walletA).send({
+      from: sender,
+    });
+    contract = deployed;
+
+    // PXE B simulates both the app contract and the registry while discovering, so it must know both.
+    await ensureHandshakeRegistryPublished(walletB, recipient);
+    await walletB.registerContract(instance, ConstrainedDeliveryTestContract.artifact);
+
+    // The sender needs the recipient's keys to bootstrap the non-interactive handshake. Discovery on PXE B is
+    // registry-based (it reads the HandshakeRegistry with the recipient's own keys), so PXE B intentionally does
+    // not register `sender`.
+    await walletA.registerSender(recipient);
+  });
+
+  afterAll(async () => {
+    await teardownB();
+    await teardownA();
+  });
+
+  it('delivers multiple constrained events from PXE A that PXE B discovers', async () => {
+    // Distinct values prove PXE B decrypts each message's content, not merely that a tagged log arrived; delivering
+    // several on one sequence proves both the bootstrap send (index 0) and the reused-handshake sends are
+    // discovered. Constrained sends to one pair are strictly ordered, so they go one tx at a time.
+    const eventValues = [10n, 20n, 30n];
+    const blockNumbers: number[] = [];
+    for (const value of eventValues) {
+      const { receipt } = await contract.methods.emit_event(recipient, value).send({ from: sender });
+      blockNumbers.push(receipt.blockNumber!);
+    }
+
+    await walletB.sync();
+
+    const events = await walletB.getPrivateEvents<DeliveryEvent>(ConstrainedDeliveryTestContract.events.DeliveryEvent, {
+      contractAddress: contract.address,
+      fromBlock: BlockNumber(Math.min(...blockNumbers)),
+      toBlock: BlockNumber(Math.max(...blockNumbers) + 1),
+      scopes: [recipient],
+    });
+
+    const discovered = events.map(e => e.event.value);
+    expect(discovered.length).toBe(eventValues.length);
+    for (const value of eventValues) {
+      expect(discovered).toContainEqual(value);
+    }
+  });
+
+  it('delivers multiple constrained notes from PXE A that PXE B reads back', async () => {
+    // Same recipient and handshake as the events above, so these notes land at the following sequence indices.
+    const noteValues = [40n, 50n, 60n];
+    for (const value of noteValues) {
+      await contract.methods.emit_note(recipient, value).send({ from: sender });
+    }
+
+    await walletB.sync();
+
+    const constrainedDeliveryB = ConstrainedDeliveryTestContract.at(contract.address, walletB);
+    // Count proves every delivered note was discovered; the sum of distinct values proves each was decrypted.
+    const { result: count } = await constrainedDeliveryB.methods
+      .get_note_count(recipient)
+      .simulate({ from: recipient });
+    expect(count).toEqual(BigInt(noteValues.length));
+
+    const { result: sum } = await constrainedDeliveryB.methods.get_notes_sum(recipient).simulate({ from: recipient });
+    expect(sum).toEqual(noteValues.reduce((acc, value) => acc + value, 0n));
   });
 });


### PR DESCRIPTION
Fixes [F-664](https://linear.app/aztec-labs/issue/F-664/e2e-test-constrained-delivery-via-non-interactive-handshake)

Add e2e tests for discovering events and notes sent with constrained delivery. 