### PR TITLE
fix(world-state): verify archive root in sync_block to reject divergent state

### DIFF
--- a/barretenberg/cpp/src/barretenberg/nodejs_module/world_state/world_state.cpp
+++ b/barretenberg/cpp/src/barretenberg/nodejs_module/world_state/world_state.cpp
@@ -781,7 +781,9 @@ bool WorldStateWrapper::sync_block(msgpack::object& obj, msgpack::sbuffer& buf)
                                                   request.value.paddedNoteHashes,
                                                   request.value.paddedL1ToL2Messages,
                                                   request.value.paddedNullifiers,
-                                                  request.value.publicDataWrites);
+                                                  request.value.publicDataWrites,
+                                                  request.value.expectedArchiveRoot,
+                                                  request.value.expectedPreviousArchiveRoot);
 
     MsgHeader header(request.header.messageId);
     messaging::TypedMessage<WorldStateStatusFull> resp_msg(WorldStateMessageType::SYNC_BLOCK, header, { status });

--- a/barretenberg/cpp/src/barretenberg/nodejs_module/world_state/world_state_message.hpp
+++ b/barretenberg/cpp/src/barretenberg/nodejs_module/world_state/world_state_message.hpp
@@ -248,6 +248,8 @@ struct SyncBlockRequest {
     block_number_t blockNumber;
     StateReference blockStateRef;
     bb::fr blockHeaderHash;
+    bb::fr expectedArchiveRoot;
+    bb::fr expectedPreviousArchiveRoot;
     std::vector<bb::fr> paddedNoteHashes, paddedL1ToL2Messages;
     std::vector<crypto::merkle_tree::NullifierLeafValue> paddedNullifiers;
     std::vector<crypto::merkle_tree::PublicDataLeafValue> publicDataWrites;
@@ -255,6 +257,8 @@ struct SyncBlockRequest {
     SERIALIZATION_FIELDS(blockNumber,
                          blockStateRef,
                          blockHeaderHash,
+                         expectedArchiveRoot,
+                         expectedPreviousArchiveRoot,
                          paddedNoteHashes,
                          paddedL1ToL2Messages,
                          paddedNullifiers,

--- a/barretenberg/cpp/src/barretenberg/world_state/world_state.cpp
+++ b/barretenberg/cpp/src/barretenberg/world_state/world_state.cpp
@@ -602,10 +602,32 @@ WorldStateStatusFull WorldState::sync_block(const StateReference& block_state_re
                                             const std::vector<bb::fr>& notes,
                                             const std::vector<bb::fr>& l1_to_l2_messages,
                                             const std::vector<crypto::merkle_tree::NullifierLeafValue>& nullifiers,
-                                            const std::vector<crypto::merkle_tree::PublicDataLeafValue>& public_writes)
+                                            const std::vector<crypto::merkle_tree::PublicDataLeafValue>& public_writes,
+                                            const std::optional<bb::fr>& expected_archive_root,
+                                            const std::optional<bb::fr>& expected_previous_archive_root)
 {
     validate_trees_are_equally_synched();
     rollback();
+
+    // The archive tree is an append-only accumulator of block header hashes, so a single bad leaf (e.g. from a
+    // mishandled reorg) is never self-corrected: every later root stays noncanonical while the other state trees
+    // can re-converge from block effects. The checks further down only verify the appended leaf is the tip and
+    // that the four non-archive trees match the block state reference — neither catches a divergent archive root.
+    // So verify the local archive root against canonical both before appending (the parent root must equal the
+    // block's lastArchive) and after (the resulting root must equal the block's archive), failing before commit
+    // so the divergence is never persisted.
+    if (expected_previous_archive_root.has_value()) {
+        const bb::fr actual_previous_archive_root =
+            get_tree_info(WorldStateRevision::committed(), MerkleTreeId::ARCHIVE).meta.root;
+        if (actual_previous_archive_root != expected_previous_archive_root.value()) {
+            throw std::runtime_error(
+                format("Can't sync block: local archive root ",
+                       actual_previous_archive_root,
+                       " does not match the block's previous archive root ",
+                       expected_previous_archive_root.value(),
+                       "; world state has diverged from the canonical chain and must be resynced"));
+        }
+    }
 
     Fork::SharedPtr fork = retrieve_fork(CANONICAL_FORK_ID);
     Signal signal(static_cast<uint32_t>(fork->_trees.size()));
@@ -679,6 +701,21 @@ WorldStateStatusFull WorldState::sync_block(const StateReference& block_state_re
 
         if (!is_same_state_reference(WorldStateRevision::uncommitted(), block_state_ref)) {
             throw std::runtime_error("Can't synch block: block state does not match world state");
+        }
+
+        // The archive tree is not part of the block state reference (see is_same_state_reference), so verify the
+        // resulting archive root against the canonical block's archive root explicitly.
+        if (expected_archive_root.has_value()) {
+            const bb::fr actual_archive_root =
+                get_tree_info(WorldStateRevision::uncommitted(), MerkleTreeId::ARCHIVE).meta.root;
+            if (actual_archive_root != expected_archive_root.value()) {
+                throw std::runtime_error(
+                    format("Can't sync block: resulting archive root ",
+                           actual_archive_root,
+                           " does not match the block's archive root ",
+                           expected_archive_root.value(),
+                           "; world state has diverged from the canonical chain and must be resynced"));
+            }
         }
 
         std::pair<bool, std::string> result = commit(status);

--- a/barretenberg/cpp/src/barretenberg/world_state/world_state.hpp
+++ b/barretenberg/cpp/src/barretenberg/world_state/world_state.hpp
@@ -300,7 +300,9 @@ class WorldState {
                                     const std::vector<bb::fr>& notes,
                                     const std::vector<bb::fr>& l1_to_l2_messages,
                                     const std::vector<crypto::merkle_tree::NullifierLeafValue>& nullifiers,
-                                    const std::vector<crypto::merkle_tree::PublicDataLeafValue>& public_writes);
+                                    const std::vector<crypto::merkle_tree::PublicDataLeafValue>& public_writes,
+                                    const std::optional<bb::fr>& expected_archive_root = std::nullopt,
+                                    const std::optional<bb::fr>& expected_previous_archive_root = std::nullopt);
 
     uint32_t checkpoint(const uint64_t& forkId);
     void commit_checkpoint(const uint64_t& forkId);

--- a/barretenberg/cpp/src/barretenberg/world_state/world_state.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/world_state/world_state.test.cpp
@@ -640,6 +640,74 @@ TEST_F(WorldStateTest, SyncExternalBlockFromEmpty)
                  std::runtime_error);
 }
 
+TEST_F(WorldStateTest, SyncBlockRejectsDivergentArchiveRoot)
+{
+    StateReference block_state_ref = {
+        { MerkleTreeId::NULLIFIER_TREE,
+          { fr("0x2e2e2d8b72294a440c728a646f01476624063f0b50dcfe293cc0fc26bef9e311"), 129 } },
+        { MerkleTreeId::NOTE_HASH_TREE,
+          { fr("0x25c4ef02ba2bec9490376d5b56b8f1a8e5bcf5ecff91636e76660b68c2a9952d"), 1 } },
+        { MerkleTreeId::PUBLIC_DATA_TREE,
+          { fr("0x1e2d8d1c3ea2449b3e4787d8295df3f137e08b56e891c006b3d93faef56ca3df"), 129 } },
+        { MerkleTreeId::L1_TO_L2_MESSAGE_TREE,
+          { fr("0x22c6f7877092ecea5b313b22515e31f2e1e37349b787da10eff298800e3c7c0c"), 1 } },
+    };
+
+    // Learn the canonical previous (genesis) and resulting archive roots from an untracked sync.
+    bb::fr previous_root;
+    bb::fr resulting_root;
+    {
+        WorldState scratch(
+            thread_pool_size, data_dir, map_size, tree_heights, tree_prefill, initial_header_generator_point);
+        previous_root = scratch.get_tree_info(WorldStateRevision::committed(), MerkleTreeId::ARCHIVE).meta.root;
+        scratch.sync_block(
+            block_state_ref, fr(1), { 42 }, { 43 }, { NullifierLeafValue(144) }, { { PublicDataLeafValue(145, 1) } });
+        resulting_root = scratch.get_tree_info(WorldStateRevision::committed(), MerkleTreeId::ARCHIVE).meta.root;
+    }
+
+    std::string data_dir2 = random_temp_directory();
+    std::filesystem::create_directories(data_dir2);
+    WorldState ws(thread_pool_size, data_dir2, map_size, tree_heights, tree_prefill, initial_header_generator_point);
+
+    // A wrong previous archive root is rejected before any leaves are appended.
+    EXPECT_THROW(ws.sync_block(block_state_ref,
+                               fr(1),
+                               { 42 },
+                               { 43 },
+                               { NullifierLeafValue(144) },
+                               { { PublicDataLeafValue(145, 1) } },
+                               resulting_root,
+                               previous_root + fr(1)),
+                 std::runtime_error);
+
+    // A wrong resulting archive root is rejected before commit.
+    EXPECT_THROW(ws.sync_block(block_state_ref,
+                               fr(1),
+                               { 42 },
+                               { 43 },
+                               { NullifierLeafValue(144) },
+                               { { PublicDataLeafValue(145, 1) } },
+                               resulting_root + fr(1),
+                               previous_root),
+                 std::runtime_error);
+
+    // Both rejections rolled back cleanly: world state is still at the genesis archive root.
+    EXPECT_EQ(ws.get_tree_info(WorldStateRevision::committed(), MerkleTreeId::ARCHIVE).meta.root, previous_root);
+
+    // Matching roots are accepted and advance the chain.
+    WorldStateStatusFull status = ws.sync_block(block_state_ref,
+                                                fr(1),
+                                                { 42 },
+                                                { 43 },
+                                                { NullifierLeafValue(144) },
+                                                { { PublicDataLeafValue(145, 1) } },
+                                                resulting_root,
+                                                previous_root);
+    WorldStateStatusSummary expected(1, 0, 1, true);
+    EXPECT_EQ(status.summary, expected);
+    EXPECT_EQ(ws.get_tree_info(WorldStateRevision::committed(), MerkleTreeId::ARCHIVE).meta.root, resulting_root);
+}
+
 TEST_F(WorldStateTest, SyncBlockFromDirtyState)
 {
     WorldState ws(thread_pool_size, data_dir, map_size, tree_heights, tree_prefill, initial_header_generator_point);
@@ -946,4 +1014,72 @@ TEST_F(WorldStateTest, GetBlockForIndex)
         EXPECT_TRUE(blockNumbers[0].has_value());
         EXPECT_EQ(blockNumbers[0].value(), 1);
     }
+}
+
+// Demonstrates the bug: syncing an empty block with a bogus block_header_hash succeeds when the optional
+// expected-archive-root arguments are omitted.  The 4-tree state-ref check passes (nothing changed), but
+// the wrong hash is committed to the ARCHIVE, silently diverging from the canonical chain.
+TEST_F(WorldStateTest, SyncEmptyBlockAcceptsBogusHashWithoutArchiveCheck)
+{
+    // Learn the canonical previous and resulting archive roots from an empty-block sync on a scratch instance.
+    bb::fr previous_archive_root;
+    bb::fr canonical_archive_root;
+    {
+        WorldState scratch(
+            thread_pool_size, data_dir, map_size, tree_heights, tree_prefill, initial_header_generator_point);
+        previous_archive_root = scratch.get_tree_info(WorldStateRevision::committed(), MerkleTreeId::ARCHIVE).meta.root;
+        StateReference genesis_state_ref = scratch.get_state_reference(WorldStateRevision::committed());
+        scratch.sync_block(genesis_state_ref, fr(1), {}, {}, {}, {});
+        canonical_archive_root =
+            scratch.get_tree_info(WorldStateRevision::committed(), MerkleTreeId::ARCHIVE).meta.root;
+    }
+
+    std::string data_dir2 = random_temp_directory();
+    std::filesystem::create_directories(data_dir2);
+    WorldState ws(thread_pool_size, data_dir2, map_size, tree_heights, tree_prefill, initial_header_generator_point);
+
+    StateReference genesis_state_ref = ws.get_state_reference(WorldStateRevision::committed());
+
+    // Sync an empty block using a bogus hash — no expected-archive-root arguments provided.
+    EXPECT_NO_THROW(ws.sync_block(genesis_state_ref, fr(42), {}, {}, {}, {}));
+
+    bb::fr actual_archive_root = ws.get_tree_info(WorldStateRevision::committed(), MerkleTreeId::ARCHIVE).meta.root;
+
+    // The bogus hash committed successfully, so the resulting archive root differs from the canonical one.
+    EXPECT_NE(actual_archive_root, canonical_archive_root);
+    EXPECT_NE(actual_archive_root, previous_archive_root);
+}
+
+// Demonstrates the fix: supplying the canonical expected archive roots causes sync_block to reject the bogus
+// block_header_hash for an empty block, and rolls back cleanly.
+TEST_F(WorldStateTest, SyncEmptyBlockRejectsBogusHashWhenArchiveRootsAreChecked)
+{
+    // Learn the canonical previous and resulting archive roots from an empty-block sync on a scratch instance.
+    bb::fr previous_archive_root;
+    bb::fr canonical_archive_root;
+    {
+        WorldState scratch(
+            thread_pool_size, data_dir, map_size, tree_heights, tree_prefill, initial_header_generator_point);
+        previous_archive_root = scratch.get_tree_info(WorldStateRevision::committed(), MerkleTreeId::ARCHIVE).meta.root;
+        StateReference genesis_state_ref = scratch.get_state_reference(WorldStateRevision::committed());
+        scratch.sync_block(genesis_state_ref, fr(1), {}, {}, {}, {});
+        canonical_archive_root =
+            scratch.get_tree_info(WorldStateRevision::committed(), MerkleTreeId::ARCHIVE).meta.root;
+    }
+
+    std::string data_dir2 = random_temp_directory();
+    std::filesystem::create_directories(data_dir2);
+    WorldState ws(thread_pool_size, data_dir2, map_size, tree_heights, tree_prefill, initial_header_generator_point);
+
+    StateReference genesis_state_ref = ws.get_state_reference(WorldStateRevision::committed());
+
+    // Sync an empty block using a bogus hash, but supply the canonical archive roots for validation.
+    // The resulting archive root will not match canonical_archive_root, so this must throw.
+    EXPECT_THROW(
+        ws.sync_block(genesis_state_ref, fr(42), {}, {}, {}, {}, canonical_archive_root, previous_archive_root),
+        std::runtime_error);
+
+    // The committed archive root must be unchanged (rollback was clean).
+    EXPECT_EQ(ws.get_tree_info(WorldStateRevision::committed(), MerkleTreeId::ARCHIVE).meta.root,
+              previous_archive_root);
 }

--- a/barretenberg/cpp/src/barretenberg/wsdb/wsdb_commands.hpp
+++ b/barretenberg/cpp/src/barretenberg/wsdb/wsdb_commands.hpp
@@ -320,6 +320,8 @@ struct WsdbSyncBlock {
     block_number_t blockNumber;
     StateReference blockStateRef;
     bb::fr blockHeaderHash;
+    bb::fr expectedArchiveRoot;
+    bb::fr expectedPreviousArchiveRoot;
     std::vector<bb::fr> paddedNoteHashes;
     std::vector<bb::fr> paddedL1ToL2Messages;
     std::vector<NullifierLeafValue> paddedNullifiers;
@@ -328,6 +330,8 @@ struct WsdbSyncBlock {
     SERIALIZATION_FIELDS(blockNumber,
                          blockStateRef,
                          blockHeaderHash,
+                         expectedArchiveRoot,
+                         expectedPreviousArchiveRoot,
                          paddedNoteHashes,
                          paddedL1ToL2Messages,
                          paddedNullifiers,

--- a/barretenberg/cpp/src/barretenberg/wsdb/wsdb_execute.cpp
+++ b/barretenberg/cpp/src/barretenberg/wsdb/wsdb_execute.cpp
@@ -303,8 +303,14 @@ WsdbRollback::Response WsdbRollback::execute(WsdbRequest& request) &&
 
 WsdbSyncBlock::Response WsdbSyncBlock::execute(WsdbRequest& request) &&
 {
-    WorldStateStatusFull status = request.world_state.sync_block(
-        blockStateRef, blockHeaderHash, paddedNoteHashes, paddedL1ToL2Messages, paddedNullifiers, publicDataWrites);
+    WorldStateStatusFull status = request.world_state.sync_block(blockStateRef,
+                                                                 blockHeaderHash,
+                                                                 paddedNoteHashes,
+                                                                 paddedL1ToL2Messages,
+                                                                 paddedNullifiers,
+                                                                 publicDataWrites,
+                                                                 expectedArchiveRoot,
+                                                                 expectedPreviousArchiveRoot);
     return Response{ .status = status };
 }
 

--- a/yarn-project/world-state/src/native/ipc_world_state_instance.ts
+++ b/yarn-project/world-state/src/native/ipc_world_state_instance.ts
@@ -548,6 +548,9 @@ export class IpcWorldState implements NativeWorldStateInstance {
           blocknumber: Number(b.blockNumber),
           blockstateref: blockStateRefToMap(b.blockStateRef as Map<number, readonly [Buffer, number | bigint]>) as any,
           blockheaderhash: new Uint8Array(b.blockHeaderHash),
+          // Forwarded so the wsdb (IPC) sync path enforces the same archive-root divergence check as the napi path.
+          expectedarchiveroot: new Uint8Array(b.expectedArchiveRoot),
+          expectedpreviousarchiveroot: new Uint8Array(b.expectedPreviousArchiveRoot),
           paddednotehashes: b.paddedNoteHashes.map(l => new Uint8Array(l as Buffer)),
           paddedl1tol2messages: b.paddedL1ToL2Messages.map(l => new Uint8Array(l as Buffer)),
           paddednullifiers: b.paddedNullifiers.map(l => ({
@@ -558,6 +561,7 @@ export class IpcWorldState implements NativeWorldStateInstance {
             value: new Uint8Array((l as { slot: Buffer; value: Buffer }).value),
           })),
         });
+
         return convertStatusFull(resp.status) as WorldStateResponse[T];
       }
 

--- a/yarn-project/world-state/src/native/message.ts
+++ b/yarn-project/world-state/src/native/message.ts
@@ -423,6 +423,10 @@ interface SyncBlockRequest extends WithCanonicalForkId {
   blockNumber: BlockNumber;
   blockStateRef: BlockStateReference;
   blockHeaderHash: Buffer;
+  /** Canonical archive root after this block; world state rejects the sync if its computed root differs. */
+  expectedArchiveRoot: Buffer;
+  /** Canonical archive root before this block (the block's lastArchive); verified against the local root. */
+  expectedPreviousArchiveRoot: Buffer;
   paddedNoteHashes: readonly SerializedLeafValue[];
   paddedL1ToL2Messages: readonly SerializedLeafValue[];
   paddedNullifiers: readonly SerializedLeafValue[];

--- a/yarn-project/world-state/src/native/native_world_state.test.ts
+++ b/yarn-project/world-state/src/native/native_world_state.test.ts
@@ -9,7 +9,7 @@ import {
   NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP,
   PUBLIC_DATA_TREE_HEIGHT,
 } from '@aztec/constants';
-import { BlockNumber } from '@aztec/foundation/branded-types';
+import { BlockNumber, SlotNumber } from '@aztec/foundation/branded-types';
 import { timesAsync } from '@aztec/foundation/collection';
 import { randomBytes } from '@aztec/foundation/crypto/random';
 import { Fr } from '@aztec/foundation/curves/bn254';
@@ -32,7 +32,7 @@ import { tmpdir } from 'os';
 import { join } from 'path';
 
 import type { WorldStateTreeMapSizes } from '../synchronizer/factory.js';
-import { assertSameState, compareChains, mockBlock, mockEmptyBlock } from '../test/utils.js';
+import { assertSameState, compareChains, mockBlock, mockEmptyBlock, updateBlockState } from '../test/utils.js';
 import { INITIAL_NULLIFIER_TREE_SIZE, INITIAL_PUBLIC_DATA_TREE_SIZE } from '../world-state-db/merkle_tree_db.js';
 import type { WorldStateStatusSummary } from './message.js';
 import { NativeWorldStateService, WORLD_STATE_DB_VERSION, WORLD_STATE_DIR } from './native_world_state.js';
@@ -1040,6 +1040,93 @@ describe('NativeWorldState', () => {
         expect(unwindStatus.summary.finalizedBlockNumber).toBe(2);
         expect(unwindStatus.summary.oldestHistoricalBlock).toBe(1);
       }
+    });
+  });
+
+  describe('Archive root divergence on empty blocks', () => {
+    let ws: NativeWorldStateService;
+
+    beforeEach(async () => {
+      ws = await NativeWorldStateService.new(EthAddress.random(), dataDir, wsTreeMapSizes);
+    });
+
+    afterEach(async () => {
+      await ws.close();
+    });
+
+    const emptyMessages = () => Array(16).fill(0).map(Fr.zero);
+
+    // A *different* empty block at height 1: the same (empty) contents as the canonical block, but a different slot,
+    // so a different block-header hash — the proposer-race orphan from A-1235, not a tampered block.
+    const buildDifferentBlockOne = async (slotNumber: number) => {
+      const fork = await ws.fork();
+      const block = L2Block.empty();
+      block.header.globalVariables.blockNumber = BlockNumber(1);
+      block.header.globalVariables.slotNumber = SlotNumber(slotNumber);
+      const messages = emptyMessages();
+      await updateBlockState(block, messages, fork);
+      await fork.close();
+      return { block, messages };
+    };
+
+    // The canonical chain L1 finalized: block 1, then block 2 chained onto it (block 2's lastArchive == block 1's
+    // archive root). Built on a throwaway fork so it never touches the world state under test.
+    const buildCanonicalChain = async () => {
+      const fork = await ws.fork();
+      const { block: canonicalOne } = await mockEmptyBlock(BlockNumber(1), fork);
+      const { block: canonicalTwo, messages: canonicalTwoMessages } = await mockEmptyBlock(BlockNumber(2), fork);
+      await fork.close();
+      return { canonicalOne, canonicalTwo, canonicalTwoMessages };
+    };
+
+    // The core blind spot: two empty blocks at the same height with different headers are indistinguishable to the
+    // four-tree state reference, yet they are different blocks with different archive roots.
+    it('two empty blocks at the same height with different headers share a state reference but not an archive root', async () => {
+      const { canonicalOne } = await buildCanonicalChain();
+      const { block: orphanOne } = await buildDifferentBlockOne(99);
+
+      // The four non-archive trees are identical (empty blocks insert no leaves), so is_same_state_reference cannot
+      // tell the two blocks apart...
+      expect(orphanOne.header.state).toEqual(canonicalOne.header.state);
+      // ...yet they are genuinely different blocks, with different header hashes and different archive roots.
+      expect((await orphanOne.hash()).equals(await canonicalOne.hash())).toBe(false);
+      expect(orphanOne.archive.root.equals(canonicalOne.archive.root)).toBe(false);
+    });
+
+    // The seeding step: a self-consistent orphan block passes every check, so world state takes the wrong block and
+    // ends up on the orphan fork — it has no way, from this block alone, to know it is not the canonical block 1.
+    it('silently accepts a different empty block at the same height (how the wrong block gets in)', async () => {
+      const { canonicalOne } = await buildCanonicalChain();
+      const { block: orphanOne, messages: orphanMessages } = await buildDifferentBlockOne(99);
+
+      await expect(ws.handleL2BlockAndMessages(orphanOne, orphanMessages)).resolves.toBeDefined();
+
+      // World state is now on the orphan fork: its committed archive root is the orphan's, not canonical block 1's.
+      const archive = await ws.getCommitted().getTreeInfo(MerkleTreeId.ARCHIVE);
+      expect(Fr.fromBuffer(archive.root).equals(orphanOne.archive.root)).toBe(true);
+      expect(Fr.fromBuffer(archive.root).equals(canonicalOne.archive.root)).toBe(false);
+    });
+
+    // The fix: once world state has taken the orphan, the canonical successor (which chains off the real block 1)
+    // no longer matches world state's committed archive root, and the pre-append guard rejects it before committing.
+    it('rejects the canonical successor of a wrongly-synced orphan, catching the archive divergence (the fix)', async () => {
+      const { canonicalTwo, canonicalTwoMessages } = await buildCanonicalChain();
+      const { block: orphanOne, messages: orphanMessages } = await buildDifferentBlockOne(99);
+
+      // The orphan commits cleanly (it is a self-consistent block 1).
+      await expect(ws.handleL2BlockAndMessages(orphanOne, orphanMessages)).resolves.toBeDefined();
+      const archiveBefore = await ws.getCommitted().getTreeInfo(MerkleTreeId.ARCHIVE);
+
+      // canonicalTwo.lastArchive == canonicalOne's archive root, which no longer matches world state's committed
+      // (orphan) archive root, so the pre-append guard throws before committing.
+      await expect(ws.handleL2BlockAndMessages(canonicalTwo, canonicalTwoMessages)).rejects.toThrow(
+        /diverged from the canonical chain/,
+      );
+
+      // Clean rollback: the archive tree is untouched.
+      const archiveAfter = await ws.getCommitted().getTreeInfo(MerkleTreeId.ARCHIVE);
+      expect(archiveAfter.root).toEqual(archiveBefore.root);
+      expect(archiveAfter.size).toEqual(archiveBefore.size);
     });
   });
 

--- a/yarn-project/world-state/src/native/native_world_state.ts
+++ b/yarn-project/world-state/src/native/native_world_state.ts
@@ -294,6 +294,9 @@ export class NativeWorldStateService implements MerkleTreeDatabase {
         {
           blockNumber: l2Block.number,
           blockHeaderHash: (await l2Block.hash()).toBuffer(),
+          // Forwarded so the native sync verifies the archive root against canonical and rejects a divergent tree.
+          expectedArchiveRoot: l2Block.archive.root.toBuffer(),
+          expectedPreviousArchiveRoot: l2Block.header.lastArchive.root.toBuffer(),
           paddedL1ToL2Messages: paddedL1ToL2Messages.map(serializeLeaf),
           paddedNoteHashes: paddedNoteHashes.map(serializeLeaf),
           paddedNullifiers: paddedNullifiers.map(serializeLeaf),

--- a/yarn-project/world-state/src/test/utils.ts
+++ b/yarn-project/world-state/src/test/utils.ts
@@ -60,7 +60,16 @@ export async function updateBlockState(block: L2Block, l1ToL2Messages: Fr[], for
   await Promise.all([publicDataInsert, nullifierInsert, noteHashInsert, messageInsert]);
 
   const state = await fork.getStateReference();
-  block.header = BlockHeader.from({ ...block.header, state });
+
+  // Capture the archive root *before* appending this block so the header's lastArchive chains off the previous block.
+  // sync_block now verifies lastArchive against the committed archive root, so a block carrying an unchained value
+  // (e.g. the random lastArchive from L2Block.random) would be rejected as a divergence from the canonical chain.
+  const previousArchive = await fork.getTreeInfo(MerkleTreeId.ARCHIVE);
+  block.header = BlockHeader.from({
+    ...block.header,
+    state,
+    lastArchive: new AppendOnlyTreeSnapshot(Fr.fromBuffer(previousArchive.root), Number(previousArchive.size)),
+  });
   await fork.updateArchive(block.header);
 
   const archiveState = await fork.getTreeInfo(MerkleTreeId.ARCHIVE);


### PR DESCRIPTION
Fixes A-1235

## Short version

The A-1235 symptom was a mainnet fisherman rejecting every proposal with
`ReExInitialStateMismatchError`. The proposal/canonical `lastArchive.root` was correct; the local
world-state archive root was wrong.

The important distinction for review is:

- v4.3.0 appears vulnerable to a specific block-stream/cache race that can seed this state.
- v5 has already hardened that specific race.
- v5 still lacks the world-state archive-root invariant, so if any other path ever writes a bad
  archive leaf, the corruption can still be committed silently.

This change is therefore defense in depth at the only layer that can conclusively reject a bad
archive tree before it is persisted: `WorldState::sync_block`.

## What went wrong

World state maintains the archive tree as an append-only accumulator of block-header hashes. During
`sync_block`, v4.3.0 appended the new block header hash and then checked:

- `is_archive_tip`: the just-appended header hash is the tip leaf.
- `is_same_state_reference`: nullifier, note hash, public data, and L1-to-L2 message trees match the
  block state reference.

Neither check verifies the archive root against canonical block data:

- before append: local archive root must equal the block's `lastArchive.root`;
- after append: computed archive root must equal the block's `archive.root`.

That means an orphan block can be internally self-consistent and still poison the archive tree.
If the orphan and canonical block at the same height have the same effects, commonly because both
are empty, the four non-archive trees can reconverge while the archive tree remains permanently
forked.

The resulting sequence is:

1. World state syncs an orphan block at height `F`.
2. The archiver later canonicalizes a different block at height `F`.
3. The block stream should prune world state to `F - 1`.
4. In the suspected v4 race, it prunes only to `F`, so the orphan archive leaf remains.
5. World state syncs canonical descendants starting at `F + 1` on top of the orphan leaf.
6. The four-tree state-reference check passes, but every archive root from `F` onward is off-chain.

## The v4 block-stream/cache race

The original explainer says roughly: `getL2Tips` had processed the reorg, while the archiver had not
yet swapped orphan `F` for canonical `F`.

More precisely, this is not about committed DB state being partially updated. The block/checkpoint
mutation is one LMDB writer transaction. The race is that v4's `L2TipsCache` can publish a tip
computed from the uncommitted writer view, while separate block/header reads still use committed
read transactions.

In v4.3.0:

- `ArchiverDataStoreUpdater.addCheckpoints()` wraps prune, checkpoint insertion, logs, contract data,
  and `l2TipsCache.refresh()` in one `store.transactionAsync(...)`.
- `L2TipsCache.refresh()` assigns `#tipsPromise = this.loadFromStore()` before the writer transaction
  commits.
- The LMDB wrapper reuses the active write transaction for reads inside that callback, so
  `loadFromStore()` can see the post-reorg uncommitted view.
- A concurrent consumer calling `archiver.getL2Tips()` can receive that cached future/post-reorg tip.
- The same consumer's later `getBlockHeader(F)` call is outside the writer context, so it opens a
  normal committed read transaction and can still see the pre-reorg orphan at `F`.

The v4 `L2BlockStream` performs exactly this mixed read pattern:

```ts
const sourceTips = await this.l2BlockSource.getL2Tips();
const localTips = await this.localData.getL2Tips();

let latestBlockNumber = localTips.proposed.number;
const sourceCache = new BlockHashCache([sourceTips.proposed]);
while (!(await this.areBlockHashesEqualAt(latestBlockNumber, { sourceCache }))) {
  latestBlockNumber--;
}
```

`areBlockHashesEqualAt()` then asks the source for a per-height hash via `getBlockHeader(blockNumber)`.
So a single pass can be planned from a future/post-reorg tip but compare old committed per-height
headers. If both local world state and the committed archiver still have the orphan at `F`, the walk
can falsely conclude `F` is the common ancestor. Pruning to `F` keeps block `F`; the correct target
was `F - 1`.

That is the suspected seed path for A-1235. The live evidence proves the archive tree forked; the
historical interleaving predates retained logs, so treat this as the best source-grounded mechanism,
not as directly logged fact.

## What v5 changes in this area

v5 has multiple changes that make the specific v4 race much less plausible.

### 1. Tip cache refresh is post-commit

In v5, `L2TipsCache` says refresh should happen after the writer transaction has committed, and
`ArchiverDataStoreUpdater` does exactly that:

```ts
const result = await this.stores.db.transactionAsync(async () => {
  // mutate blocks/checkpoints/logs/etc.
  return ...;
});
await this.l2TipsCache?.refresh();
return result;
```

So the cache is loaded from committed DB state, and an aborted writer cannot replace the cache with
a future view.

### 2. `getL2TipsData()` is one DB snapshot

v5 moves chain-tip construction into `BlockStore.getL2TipsData(genesisBlockHash)` and wraps it in a
single `db.transactionAsync(...)`. It also validates the resulting tier ordering:

- finalized <= proven <= checkpointed <= proposed;
- checkpointed block <= proposed block.

That is materially stronger than v4's `L2TipsCache.loadFromStore()`, which assembled tip numbers and
block data through several independent store calls.

### 3. The block stream fails closed on incoherent source reads

v5's `L2BlockStream` no longer uses the old checkpoint-prefetch path in the same way. It drives from
a source tips snapshot, compares per-height hashes via `getBlockData({ number })`, and adds guards:

- missing local hash compares unequal rather than accidentally stopping the walk;
- missing source data at or below the advertised source proposed tip aborts the pass;
- source tips are re-read after a prune before downstream reconciliation;
- the download pass verifies the delivered proposed block hash matches the snapshot's proposed hash;
- tier advancement is skipped if the block download plan did not complete.

These are all aimed at preventing a stale or mixed source snapshot from becoming an under-deep prune.
Over-deep or skipped reconciliation is recoverable; under-deep pruning is dangerous because it can
leave the losing fork's block at the divergence height.

## Why this change still matters on v5

The v5 block stream fixes the known/suspected seed path, but it does not add the missing invariant to
world state.

Without this patch, `sync_block` can still commit a divergent archive tree if any future path presents
it with a self-consistent block whose non-archive state matches:

- a different reorg bug;
- a cache/snapshot bug elsewhere;
- operator/datadir corruption;
- a future refactor that bypasses one of the v5 block-stream protections.

Once a bad archive leaf is committed, appending more canonical leaves does not repair it. The archive
root remains noncanonical forever while the four non-archive trees can look healthy.

The fix makes `sync_block` verify the archive tree at the source of truth:

```cpp
// Before append: committed local root must be the block's parent archive root.
actual_previous_archive_root == expected_previous_archive_root

// After append, before commit: uncommitted computed root must be the block's archive root.
actual_archive_root == expected_archive_root
```

These checks turn silent permanent corruption into a loud sync failure before commit. The node may
need a datadir resync, but it will not write and seal in the divergent archive leaf.

## Reviewer checklist

- Confirm the TS/native message path passes both canonical roots:
  - `expectedPreviousArchiveRoot = l2Block.header.lastArchive.root`
  - `expectedArchiveRoot = l2Block.archive.root`
- Confirm native `sync_block` checks the previous root before `add_value`.
- Confirm native `sync_block` checks the resulting root before `commit`.
- Confirm errors clearly tell operators that local world state diverged and must be resynced.
- Confirm tests cover the archive-only divergence case, not just non-archive state-reference mismatch.

## Expected operator behavior

This patch prevents recurrence; it does not repair an already-poisoned archive tree. A node that
already has the bad historical leaf must wipe/resync its world-state datadir.
