### PR TITLE
fix(ipc): auto-claim shm client slots

### DIFF
--- a/ipc-codegen/src/typescript_package_codegen.ts
+++ b/ipc-codegen/src/typescript_package_codegen.ts
@@ -311,7 +311,9 @@ async function connectClient(
       }
 ${supportsShm ? `      if (transport === 'shm') {
         return createNapiShmAsyncClient(ipcPath.replace(/\\.shm$/, ''), {
-          clientId: options.clientId ?? 0,
+          // Pass clientId through as-is: when unset, the client self-allocates a
+          // free producer slot (don't default to 0, which aliases every client).
+          clientId: options.clientId,
           customAddonPath: options.napiPath,
         });
       }

--- a/ipc-runtime/cpp/ipc_runtime/ipc_client.hpp
+++ b/ipc-runtime/cpp/ipc_runtime/ipc_client.hpp
@@ -2,12 +2,18 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <limits>
 #include <memory>
 #include <span>
 #include <string>
 #include <sys/types.h>
 
 namespace ipc {
+
+// Passed as the MPSC-SHM client id to mean "atomically claim a free slot on
+// connect" rather than pinning a specific one. This is the default for
+// make_client / create_mpsc_shm; an explicit id is only used by tests.
+inline constexpr std::size_t kAutoClientId = std::numeric_limits<std::size_t>::max();
 
 /**
  * @brief Abstract interface for IPC client
@@ -84,7 +90,7 @@ class IpcClient {
     static std::unique_ptr<IpcClient> create_shm(const std::string& base_name);
     // Multi-producer SHM: one request ring per client slot and one response
     // ring per client slot. This is what make_client("*.shm") selects.
-    static std::unique_ptr<IpcClient> create_mpsc_shm(const std::string& base_name, size_t client_id);
+    static std::unique_ptr<IpcClient> create_mpsc_shm(const std::string& base_name, size_t client_id = kAutoClientId);
 };
 
 /**
@@ -95,12 +101,12 @@ class IpcClient {
  *  - "*.shm"  → IpcClient::create_mpsc_shm(<basename>, client_id)
  *
  * Returns nullptr if the suffix is not recognised. `shm_client_id` is only
- * consulted for the SHM path; for MPSC-SHM, each connecting client picks a
- * distinct slot (0..max_clients-1).
+ * consulted for the SHM path; it defaults to kAutoClientId, so each connecting
+ * client atomically claims a distinct free slot (0..max_clients-1) on connect.
  *
  * @param input_path Path passed by the caller (often a CLI flag).
- * @param shm_client_id Client slot to claim in MPSC-SHM mode. Ignored for UDS.
+ * @param shm_client_id MPSC-SHM slot to pin, or kAutoClientId to self-allocate. Ignored for UDS.
  */
-std::unique_ptr<IpcClient> make_client(const std::string& input_path, std::size_t shm_client_id = 0);
+std::unique_ptr<IpcClient> make_client(const std::string& input_path, std::size_t shm_client_id = kAutoClientId);
 
 } // namespace ipc

--- a/ipc-runtime/cpp/ipc_runtime/mpsc_shm_client.hpp
+++ b/ipc-runtime/cpp/ipc_runtime/mpsc_shm_client.hpp
@@ -24,8 +24,13 @@ namespace ipc {
  */
 class MpscShmClient : public IpcClient {
   public:
+    // client_id == kAutoClientId (the default for make_client / create_mpsc_shm)
+    // makes connect() atomically claim a free producer slot from the server's
+    // shared slot table, so callers don't have to coordinate unique ids. An
+    // explicit id pins a specific slot (used by tests).
     MpscShmClient(std::string base_name, size_t client_id)
         : base_name_(std::move(base_name))
+        , auto_claim_(client_id == kAutoClientId)
         , client_id_(client_id)
     {}
 
@@ -48,6 +53,14 @@ class MpscShmClient : public IpcClient {
 
         for (size_t attempt = 0; attempt < max_attempts; ++attempt) {
             try {
+                // Self-allocate a producer slot when no explicit id was given.
+                // The claim is held for the connection's lifetime and released by
+                // close()/destruction so the slot can be reused.
+                if (auto_claim_) {
+                    slot_claim_ = MpscSlotClaim::claim(base_name_ + "_req");
+                    client_id_ = slot_claim_->id();
+                }
+
                 // Connect as producer to the MPSC request system
                 producer_ = MpscProducer::connect(base_name_ + "_req", client_id_);
 
@@ -59,6 +72,7 @@ class MpscShmClient : public IpcClient {
             } catch (...) {
                 producer_.reset();
                 response_ring_.reset();
+                slot_claim_.reset();
                 if (attempt + 1 == max_attempts) {
                     return false;
                 }
@@ -112,6 +126,7 @@ class MpscShmClient : public IpcClient {
     {
         producer_.reset();
         response_ring_.reset();
+        slot_claim_.reset(); // release our producer slot for reuse
     }
 
     void wakeup() override
@@ -123,7 +138,9 @@ class MpscShmClient : public IpcClient {
 
   private:
     std::string base_name_;
+    bool auto_claim_;
     size_t client_id_;
+    std::optional<MpscSlotClaim> slot_claim_;
     std::optional<MpscProducer> producer_;
     std::optional<SpscShm> response_ring_;
 };

--- a/ipc-runtime/cpp/ipc_runtime/shm.test.cpp
+++ b/ipc-runtime/cpp/ipc_runtime/shm.test.cpp
@@ -505,4 +505,218 @@ TEST(ShmTest, MpscReactorPipelinedConcurrencyAndOrder)
     server->close();
 }
 
+TEST(ShmTest, MpscReactorMultiClientResponseRouting)
+{
+    constexpr uint32_t NUM_CLIENTS = 4;
+    constexpr uint32_t K = 128;
+    constexpr size_t RING_SIZE = 64UL * 1024;
+
+    std::string base_name = "shm_mpsc_multi_" + std::to_string(getpid());
+    auto server = IpcServer::create_mpsc_shm(base_name, NUM_CLIENTS, RING_SIZE, RING_SIZE);
+    ASSERT_TRUE(server->listen()) << "MPSC multi-client server failed to listen";
+
+    ReactorTestPool pool(8);
+    std::thread server_thread([&]() {
+        server->run_reactor([&pool](int, std::span<const uint8_t> req, IpcServer::Respond respond) {
+            std::vector<uint8_t> r(req.begin(), req.end());
+            pool.enqueue([r = std::move(r), respond = std::move(respond)]() mutable {
+                uint32_t seq = 0;
+                std::memcpy(&seq, r.data() + sizeof(uint32_t), sizeof(uint32_t));
+                std::this_thread::sleep_for(std::chrono::microseconds(20 * (seq % 8)));
+                respond(std::move(r));
+            });
+        });
+    });
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+    std::atomic<int> wrong_client{ 0 };
+    std::atomic<int> out_of_order{ 0 };
+    std::atomic<int> stalls{ 0 };
+
+    auto run_client = [&](uint32_t c) {
+        auto client = IpcClient::create_mpsc_shm(base_name, c);
+        if (!client->connect()) {
+            stalls++;
+            return;
+        }
+        for (uint32_t s = 0; s < K; s++) {
+            uint32_t msg[2] = { c, s };
+            while (!client->send(msg, sizeof(msg), 100'000'000ULL)) {
+            }
+        }
+        for (uint32_t s = 0; s < K; s++) {
+            std::span<const uint8_t> resp;
+            size_t empties = 0;
+            while ((resp = client->receive(100'000'000ULL)).empty()) {
+                if (++empties > 50) {
+                    stalls++;
+                    break;
+                }
+            }
+            if (resp.empty()) {
+                break;
+            }
+            uint32_t got[2] = { 0, 0 };
+            std::memcpy(got, resp.data(), sizeof(got));
+            if (got[0] != c) {
+                wrong_client++;
+            }
+            if (got[1] != s) {
+                out_of_order++;
+            }
+            client->release(resp.size());
+        }
+        client->close();
+    };
+
+    std::vector<std::thread> clients;
+    for (uint32_t c = 0; c < NUM_CLIENTS; c++) {
+        clients.emplace_back(run_client, c);
+    }
+    for (auto& t : clients) {
+        t.join();
+    }
+
+    server->request_shutdown();
+    server_thread.join();
+    server->close();
+
+    EXPECT_EQ(wrong_client.load(), 0) << "responses were routed to the wrong client";
+    EXPECT_EQ(out_of_order.load(), 0) << "responses arrived out of order within a client";
+    EXPECT_EQ(stalls.load(), 0) << "a client stalled waiting for its responses";
+}
+
+TEST(ShmTest, MpscReactorAutoClaimMultiClient)
+{
+    constexpr uint32_t NUM_CLIENTS = 4;
+    constexpr uint32_t K = 128;
+    constexpr size_t RING_SIZE = 64UL * 1024;
+
+    std::string base_name = "shm_mpsc_autoclaim_" + std::to_string(getpid());
+    auto server = IpcServer::create_mpsc_shm(base_name, NUM_CLIENTS, RING_SIZE, RING_SIZE);
+    ASSERT_TRUE(server->listen()) << "MPSC auto-claim server failed to listen";
+
+    ReactorTestPool pool(8);
+    std::thread server_thread([&]() {
+        server->run_reactor([&pool](int, std::span<const uint8_t> req, IpcServer::Respond respond) {
+            std::vector<uint8_t> r(req.begin(), req.end());
+            pool.enqueue([r = std::move(r), respond = std::move(respond)]() mutable {
+                uint32_t seq = 0;
+                std::memcpy(&seq, r.data() + sizeof(uint32_t), sizeof(uint32_t));
+                std::this_thread::sleep_for(std::chrono::microseconds(20 * (seq % 8)));
+                respond(std::move(r));
+            });
+        });
+    });
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+    std::atomic<int> wrong_client{ 0 };
+    std::atomic<int> out_of_order{ 0 };
+    std::atomic<int> stalls{ 0 };
+
+    auto run_client = [&](uint32_t c) {
+        auto client = IpcClient::create_mpsc_shm(base_name);
+        if (!client->connect()) {
+            stalls++;
+            return;
+        }
+        for (uint32_t s = 0; s < K; s++) {
+            uint32_t msg[2] = { c, s };
+            while (!client->send(msg, sizeof(msg), 100'000'000ULL)) {
+            }
+        }
+        for (uint32_t s = 0; s < K; s++) {
+            std::span<const uint8_t> resp;
+            size_t empties = 0;
+            while ((resp = client->receive(100'000'000ULL)).empty()) {
+                if (++empties > 50) {
+                    stalls++;
+                    break;
+                }
+            }
+            if (resp.empty()) {
+                break;
+            }
+            uint32_t got[2] = { 0, 0 };
+            std::memcpy(got, resp.data(), sizeof(got));
+            if (got[0] != c) {
+                wrong_client++;
+            }
+            if (got[1] != s) {
+                out_of_order++;
+            }
+            client->release(resp.size());
+        }
+        client->close();
+    };
+
+    std::vector<std::thread> clients;
+    for (uint32_t c = 0; c < NUM_CLIENTS; c++) {
+        clients.emplace_back(run_client, c);
+    }
+    for (auto& t : clients) {
+        t.join();
+    }
+
+    server->request_shutdown();
+    server_thread.join();
+    server->close();
+
+    EXPECT_EQ(wrong_client.load(), 0) << "self-allocated clients aliased onto a shared slot";
+    EXPECT_EQ(out_of_order.load(), 0) << "responses arrived out of order within a client";
+    EXPECT_EQ(stalls.load(), 0) << "a client stalled";
+}
+
+TEST(ShmTest, MpscSlotFreedOnDisconnectAndReclaimed)
+{
+    constexpr size_t NUM_CLIENTS = 1;
+    constexpr size_t RING_SIZE = 16UL * 1024;
+
+    std::string base_name = "shm_mpsc_reuse_" + std::to_string(getpid());
+    auto server = IpcServer::create_mpsc_shm(base_name, NUM_CLIENTS, RING_SIZE, RING_SIZE);
+    ASSERT_TRUE(server->listen()) << "server failed to listen";
+
+    ReactorTestPool pool(2);
+    std::thread server_thread([&]() {
+        server->run_reactor([&pool](int, std::span<const uint8_t> req, IpcServer::Respond respond) {
+            std::vector<uint8_t> r(req.begin(), req.end());
+            pool.enqueue([r = std::move(r), respond = std::move(respond)]() mutable { respond(std::move(r)); });
+        });
+    });
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+    auto round_trip = [](IpcClient& client, uint32_t value) -> bool {
+        if (!client.send(&value, sizeof(value), 100'000'000ULL)) {
+            return false;
+        }
+        std::span<const uint8_t> resp;
+        size_t empties = 0;
+        while ((resp = client.receive(100'000'000ULL)).empty()) {
+            if (++empties > 50) {
+                return false;
+            }
+        }
+        uint32_t got = 0;
+        std::memcpy(&got, resp.data(), sizeof(got));
+        client.release(resp.size());
+        return got == value;
+    };
+
+    {
+        auto a = IpcClient::create_mpsc_shm(base_name);
+        ASSERT_TRUE(a->connect()) << "client A failed to connect";
+        EXPECT_TRUE(round_trip(*a, 0x1111)) << "client A round-trip failed";
+        a->close();
+    }
+
+    auto b = IpcClient::create_mpsc_shm(base_name);
+    ASSERT_TRUE(b->connect()) << "client B failed to reclaim the freed slot";
+    EXPECT_TRUE(round_trip(*b, 0x2222)) << "client B round-trip over the reused ring failed";
+    b->close();
+
+    server->request_shutdown();
+    server_thread.join();
+    server->close();
+}
+
 } // namespace

--- a/ipc-runtime/cpp/ipc_runtime/shm/mpsc_shm.cpp
+++ b/ipc-runtime/cpp/ipc_runtime/shm/mpsc_shm.cpp
@@ -4,12 +4,14 @@
 #include <atomic>
 #include <cerrno>
 #include <climits>
+#include <csignal>
 #include <cstdint>
 #include <cstring>
 #include <fcntl.h>
 #include <stdexcept>
 #include <string>
 #include <sys/mman.h>
+#include <sys/stat.h>
 #include <unistd.h>
 #include <utility>
 #include <vector>
@@ -83,7 +85,9 @@ MpscConsumer MpscConsumer::create(const std::string& name, size_t num_producers,
 
     // Create doorbell shared memory
     std::string doorbell_name = name + "_doorbell";
-    size_t doorbell_len = sizeof(MpscDoorbell);
+    // The doorbell mapping also carries the per-slot owner table (one atomic per
+    // producer), so clients can self-allocate a slot on connect.
+    size_t doorbell_len = sizeof(MpscDoorbell) + num_producers * sizeof(std::atomic<uint32_t>);
 
     int doorbell_fd = shm_open(doorbell_name.c_str(), O_RDWR | O_CREAT | O_EXCL, 0600);
     if (doorbell_fd < 0) {
@@ -110,6 +114,12 @@ MpscConsumer MpscConsumer::create(const std::string& name, size_t num_producers,
     // Initialize doorbell (use placement new to avoid memset on non-trivial type)
     new (doorbell) MpscDoorbell{};
     doorbell->seq.store(0, std::memory_order_release);
+    doorbell->num_slots.store(static_cast<uint32_t>(num_producers), std::memory_order_release);
+    // Initialize the per-slot owner table to "free" (pid 0).
+    std::atomic<uint32_t>* slot_owners = mpsc_slot_owners(doorbell);
+    for (size_t i = 0; i < num_producers; i++) {
+        new (&slot_owners[i]) std::atomic<uint32_t>(0);
+    }
 
     // Create all SPSC rings
     std::vector<SpscShm> rings;
@@ -427,6 +437,112 @@ void MpscProducer::publish(size_t n)
     // SpscShm::publish for why that handshake is unsafe across processes).
     doorbell_->seq.fetch_add(1, std::memory_order_release);
     futex_wake(reinterpret_cast<volatile uint32_t*>(&doorbell_->seq), 1);
+}
+
+// ----- MpscSlotClaim Implementation -----
+
+namespace {
+// True if `pid` refers to a live process we could in principle signal. Only a
+// definitive ESRCH (no such process) is treated as dead, so a slot owned by a
+// live-but-unsignalable process (EPERM) is never wrongly reclaimed.
+bool pid_alive(uint32_t pid)
+{
+    if (pid == 0) {
+        return false;
+    }
+    return ::kill(static_cast<pid_t>(pid), 0) == 0 || errno != ESRCH;
+}
+} // namespace
+
+MpscSlotClaim MpscSlotClaim::claim(const std::string& name)
+{
+    std::string doorbell_name = name + "_doorbell";
+    int fd = shm_open(doorbell_name.c_str(), O_RDWR, 0600);
+    if (fd < 0) {
+        throw std::runtime_error("MpscSlotClaim::claim: shm_open doorbell failed (server not listening?): " +
+                                 std::string(std::strerror(errno)));
+    }
+
+    struct stat st{};
+    if (fstat(fd, &st) != 0 || static_cast<size_t>(st.st_size) < sizeof(MpscDoorbell)) {
+        int e = errno;
+        ::close(fd);
+        throw std::runtime_error("MpscSlotClaim::claim: fstat doorbell failed: " + std::string(std::strerror(e)));
+    }
+    size_t len = static_cast<size_t>(st.st_size);
+
+    auto* doorbell = static_cast<MpscDoorbell*>(mmap(nullptr, len, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0));
+    if (doorbell == MAP_FAILED) {
+        int e = errno;
+        ::close(fd);
+        throw std::runtime_error("MpscSlotClaim::claim: mmap doorbell failed: " + std::string(std::strerror(e)));
+    }
+
+    size_t num_slots = doorbell->num_slots.load(std::memory_order_acquire);
+    std::atomic<uint32_t>* owners = mpsc_slot_owners(doorbell);
+    auto my_pid = static_cast<uint32_t>(getpid());
+
+    // A couple of passes absorbs transient CAS contention between concurrent
+    // claimants before declaring the server full.
+    for (int pass = 0; pass < 3; pass++) {
+        for (size_t i = 0; i < num_slots; i++) {
+            uint32_t owner = owners[i].load(std::memory_order_acquire);
+            if (owner != 0 && pid_alive(owner)) {
+                continue; // owned by a live client
+            }
+            // Free, or owned by a dead process — try to take it.
+            if (owners[i].compare_exchange_strong(owner, my_pid, std::memory_order_acq_rel)) {
+                return MpscSlotClaim(fd, doorbell, len, i);
+            }
+            // Lost the race for this slot; keep scanning.
+        }
+    }
+
+    munmap(doorbell, len);
+    ::close(fd);
+    throw std::runtime_error("MpscSlotClaim::claim: no free slot (all " + std::to_string(num_slots) +
+                             " producer slots in use)");
+}
+
+MpscSlotClaim::MpscSlotClaim(MpscSlotClaim&& other) noexcept
+    : fd_(other.fd_)
+    , map_(other.map_)
+    , len_(other.len_)
+    , id_(other.id_)
+{
+    other.fd_ = -1;
+    other.map_ = nullptr;
+    other.len_ = 0;
+}
+
+MpscSlotClaim& MpscSlotClaim::operator=(MpscSlotClaim&& other) noexcept
+{
+    if (this != &other) {
+        this->~MpscSlotClaim();
+        fd_ = other.fd_;
+        map_ = other.map_;
+        len_ = other.len_;
+        id_ = other.id_;
+        other.fd_ = -1;
+        other.map_ = nullptr;
+        other.len_ = 0;
+    }
+    return *this;
+}
+
+MpscSlotClaim::~MpscSlotClaim()
+{
+    if (map_ != nullptr) {
+        // Release the slot so another client (or a reconnect) can take it.
+        std::atomic<uint32_t>* owners = mpsc_slot_owners(static_cast<MpscDoorbell*>(map_));
+        owners[id_].store(0, std::memory_order_release);
+        munmap(map_, len_);
+        map_ = nullptr;
+    }
+    if (fd_ >= 0) {
+        ::close(fd_);
+        fd_ = -1;
+    }
 }
 
 } // namespace ipc

--- a/ipc-runtime/cpp/ipc_runtime/shm/mpsc_shm.hpp
+++ b/ipc-runtime/cpp/ipc_runtime/shm/mpsc_shm.hpp
@@ -28,7 +28,65 @@ struct alignas(64) MpscDoorbell {
     // Producer-written (written by producers in publish()). Consumers wait on
     // this seq with a futex; producers bump it and wake unconditionally.
     alignas(64) std::atomic<uint32_t> seq;
-    std::array<uint8_t, 60> _pad0;
+    // Number of producer slots (= num_producers). Written once by the consumer at
+    // create(); read by clients to bound the slot-claim scan. Kept here (offset 4)
+    // so `seq` stays at offset 0 and the doorbell mapping/wakeup path is unchanged.
+    std::atomic<uint32_t> num_slots;
+    std::array<uint8_t, 56> _pad0;
+};
+static_assert(sizeof(MpscDoorbell) == 64, "MpscDoorbell layout must stay 64 bytes (seq at offset 0)");
+
+// The per-slot owner table follows the doorbell in the same shared mapping: one
+// std::atomic<uint32_t> per producer slot, holding the owning client's pid (0 =
+// free). Clients claim a slot here on connect (see MpscSlotClaim); the consumer
+// never reads it (it just round-robin-polls all rings). Total mapping size is
+// sizeof(MpscDoorbell) + num_slots * sizeof(std::atomic<uint32_t>).
+inline std::atomic<uint32_t>* mpsc_slot_owners(MpscDoorbell* doorbell)
+{
+    return reinterpret_cast<std::atomic<uint32_t>*>(reinterpret_cast<char*>(doorbell) + sizeof(MpscDoorbell));
+}
+
+/**
+ * @brief RAII claim on a free producer slot, taken by a client on connect.
+ *
+ * Maps the MPSC doorbell region and atomically claims the lowest-indexed slot
+ * that is free, or owned by a dead process (reclaimed). The claimed index is the
+ * client's producer/response ring id. The slot is released (set free) on
+ * destruction. This is what makes connect() self-allocating: callers no longer
+ * have to coordinate unique client ids out of band (the previous default of 0
+ * silently aliased every client onto one ring pair).
+ *
+ * Dead-owner reclaim uses kill(pid, 0); a crashed client can't run its own
+ * release, so its slot is reclaimed by the next claimant. This only prevents
+ * live clients from aliasing onto one slot; it does not guarantee recovery from
+ * stale in-flight requests left by a crashed owner.
+ */
+class MpscSlotClaim {
+  public:
+    // Claim a slot on `name`'s doorbell (`name` is the MPSC base, e.g. "<path>_req").
+    // Throws std::runtime_error if the doorbell is absent (server not up) or full.
+    static MpscSlotClaim claim(const std::string& name);
+
+    MpscSlotClaim(MpscSlotClaim&& other) noexcept;
+    MpscSlotClaim& operator=(MpscSlotClaim&& other) noexcept;
+    MpscSlotClaim(const MpscSlotClaim&) = delete;
+    MpscSlotClaim& operator=(const MpscSlotClaim&) = delete;
+    ~MpscSlotClaim();
+
+    size_t id() const { return id_; }
+
+  private:
+    MpscSlotClaim(int fd, void* map, size_t len, size_t id)
+        : fd_(fd)
+        , map_(map)
+        , len_(len)
+        , id_(id)
+    {}
+
+    int fd_ = -1;
+    void* map_ = nullptr;
+    size_t len_ = 0;
+    size_t id_ = 0;
 };
 
 /**

--- a/ipc-runtime/cpp/napi/msgpack_client_async.cpp
+++ b/ipc-runtime/cpp/napi/msgpack_client_async.cpp
@@ -20,7 +20,9 @@ MsgpackClientAsync::MsgpackClientAsync(const Napi::CallbackInfo& info)
     }
     std::string shm_name = info[0].As<Napi::String>();
 
-    std::size_t client_id = 0;
+    // Optional second arg pins a specific MPSC slot; otherwise self-allocate one
+    // on connect (kAutoClientId) so multiple clients don't alias onto slot 0.
+    std::size_t client_id = ipc::kAutoClientId;
     if (info.Length() >= 2 && info[1].IsNumber()) {
         client_id = static_cast<std::size_t>(info[1].As<Napi::Number>().Uint32Value());
     }

--- a/ipc-runtime/cpp/napi/msgpack_client_wrapper.cpp
+++ b/ipc-runtime/cpp/napi/msgpack_client_wrapper.cpp
@@ -20,8 +20,9 @@ MsgpackClientWrapper::MsgpackClientWrapper(const Napi::CallbackInfo& info)
     }
     std::string shm_name = info[0].As<Napi::String>();
 
-    // Optional second arg: MPSC client slot id (defaults to 0).
-    std::size_t client_id = 0;
+    // Optional second arg pins a specific MPSC slot; otherwise self-allocate one
+    // on connect (kAutoClientId).
+    std::size_t client_id = ipc::kAutoClientId;
     if (info.Length() >= 2 && info[1].IsNumber()) {
         client_id = static_cast<std::size_t>(info[1].As<Napi::Number>().Uint32Value());
     }

--- a/ipc-runtime/ts/src/shm_client.ts
+++ b/ipc-runtime/ts/src/shm_client.ts
@@ -157,7 +157,11 @@ export function createNapiShmSyncClient(
 ): NapiShmSyncClient {
   const napi = loadIpcRuntimeNapi(options.customAddonPath);
   return new NapiShmSyncClient(
-    new napi.MsgpackClient(shmName, options.clientId ?? 0),
+    // Omit the slot id when not given so the native side self-allocates a free
+    // slot (kAutoClientId) instead of aliasing every client onto slot 0.
+    options.clientId === undefined
+      ? new napi.MsgpackClient(shmName)
+      : new napi.MsgpackClient(shmName, options.clientId),
   );
 }
 
@@ -167,6 +171,10 @@ export function createNapiShmAsyncClient(
 ): NapiShmAsyncClient {
   const napi = loadIpcRuntimeNapi(options.customAddonPath);
   return new NapiShmAsyncClient(
-    new napi.MsgpackClientAsync(shmName, options.clientId ?? 0),
+    // Omit the slot id when not given so the native side self-allocates a free
+    // slot (kAutoClientId) instead of aliasing every client onto slot 0.
+    options.clientId === undefined
+      ? new napi.MsgpackClientAsync(shmName)
+      : new napi.MsgpackClientAsync(shmName, options.clientId),
   );
 }

--- a/yarn-project/world-state/src/native/ipc_pipelined_read_correlation.test.ts
+++ b/yarn-project/world-state/src/native/ipc_pipelined_read_correlation.test.ts
@@ -1,0 +1,93 @@
+import { Fr } from '@aztec/foundation/curves/bn254';
+import type { MerkleTreeWriteOperations } from '@aztec/stdlib/interfaces/server';
+import { MerkleTreeId } from '@aztec/stdlib/trees';
+
+import { jest } from '@jest/globals';
+
+import { NativeWorldStateService } from './native_world_state.js';
+
+jest.setTimeout(120_000);
+
+const TRANSPORTS = ['uds', 'shm'] as const;
+const N = 128;
+const ITERATIONS = 40;
+
+describe('IPC world-state pipelined read correlation', () => {
+  for (const transport of TRANSPORTS) {
+    describe(`transport=${transport}`, () => {
+      let prevTransport: string | undefined;
+      let ws: NativeWorldStateService;
+      let fork: MerkleTreeWriteOperations;
+      let leaves: Fr[];
+
+      beforeAll(async () => {
+        prevTransport = process.env.WSDB_TRANSPORT;
+        process.env.WSDB_TRANSPORT = transport;
+        ws = await NativeWorldStateService.tmp();
+
+        fork = await ws.fork();
+        leaves = Array.from({ length: N }, (_, i) => new Fr(BigInt(i) * 0x1_0000_0001n + 1n));
+        await fork.appendLeaves(MerkleTreeId.NOTE_HASH_TREE, leaves);
+      });
+
+      afterAll(async () => {
+        await fork?.close().catch(() => {});
+        await ws?.close();
+        if (prevTransport === undefined) {
+          delete process.env.WSDB_TRANSPORT;
+        } else {
+          process.env.WSDB_TRANSPORT = prevTransport;
+        }
+      });
+
+      it('matches every response across concurrent same-type reads', async () => {
+        for (let iter = 0; iter < ITERATIONS; iter++) {
+          const got = await Promise.all(
+            leaves.map((_, i) => fork.getLeafValue(MerkleTreeId.NOTE_HASH_TREE, BigInt(i))),
+          );
+          for (let i = 0; i < N; i++) {
+            const v = got[i];
+            if (v === undefined || !v.equals(leaves[i])) {
+              const belongsTo = v === undefined ? 'undefined' : String(leaves.findIndex(l => l.equals(v)));
+              throw new Error(
+                `[${transport}] iter ${iter}: getLeafValue(index=${i}) returned value for index ` +
+                  `${belongsTo}; expected ${leaves[i].toString()}, got ${v?.toString() ?? 'undefined'}`,
+              );
+            }
+          }
+        }
+      });
+
+      it('matches every response across concurrent mixed-type reads', async () => {
+        for (let iter = 0; iter < ITERATIONS; iter++) {
+          const checks: Promise<void>[] = [];
+          for (let i = 0; i < N; i++) {
+            const idx = BigInt(i);
+            checks.push(
+              (async () => {
+                const v = await fork.getLeafValue(MerkleTreeId.NOTE_HASH_TREE, idx);
+                if (v === undefined || !v.equals(leaves[i])) {
+                  throw new Error(
+                    `[${transport}] iter ${iter}: getLeafValue(${i}) wrong: ${v?.toString() ?? 'undefined'}`,
+                  );
+                }
+              })(),
+            );
+            checks.push(
+              (async () => {
+                const idxs = await fork.findLeafIndices(MerkleTreeId.NOTE_HASH_TREE, [leaves[i]]);
+                if (idxs[0] !== idx) {
+                  throw new Error(
+                    `[${transport}] iter ${iter}: findLeafIndices(${i}) returned ${idxs[0]}, expected ${idx}`,
+                  );
+                }
+              })(),
+            );
+            checks.push(fork.getSiblingPath(MerkleTreeId.NOTE_HASH_TREE, idx).then(() => undefined));
+          }
+          await Promise.all(checks);
+        }
+      });
+    });
+  }
+});


### PR DESCRIPTION
## Summary

- make MPSC SHM clients self-allocate a free producer slot when no explicit client id is provided
- pass omitted TS/NAPI client ids through to the native auto-claim path instead of defaulting to slot 0
- add C++ and world-state regression tests for multi-client SHM response correlation and clean slot reuse

## Why

Multiple SHM clients were defaulting to producer slot 0. In the wsdb/AVM topology that means separate clients can share one request/response ring pair and steal or mis-correlate responses. The fix adds a small owner table to the existing MPSC doorbell mapping so clients can atomically claim distinct slots.

This intentionally does not try to recover stale in-flight requests left by a crashed client. Clean disconnect releases the claimed slot for reuse.

## Validation

- cmake --build build --target ipc_runtime_tests -j
- ./build/ipc_runtime_tests --gtest_filter='ShmTest.MpscReactorMultiClientResponseRouting:ShmTest.MpscReactorAutoClaimMultiClient:ShmTest.MpscSlotFreedOnDisconnectAndReclaimed'

Note: the fresh next-based worktree had no yarn install state, so the TS world-state test is left for CI here. It passed earlier in the existing built ipc-5 worktree before this was split into a standalone PR.
