### PR TITLE
docs: require self-contained code comments

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,6 +113,8 @@ Do write jsdoc, rustdoc, or natspec comments for documenting public methods.
 Do not explain *what* the code does — well-named identifiers cover that. Comments of the form `// increment counter` / `// loop over peers` / `// return early on error` are noise and should be deleted rather than added.
 
 Do not reference the current task, PR, caller, or author (`// used by X`, `// fix for issue #123`, `// AI-generated`), and do not add banner-style section comments (`// ===== HELPERS =====`). Both rot the moment the surrounding code is moved.
+
+Keep comments self-contained: whatever a comment points to must be understandable from the repo alone. The repo is public but Linear issues are private, so never cite them (`// see A-1234`). Likewise do not reference an implementation plan that lives outside the repo (`// this fixes item 4`, `// tackles section C`) — describe the actual constraint or behavior instead.
 </writing_comments>
 
 <jargon>


### PR DESCRIPTION
Adds a rule to the `<writing_comments>` section of the root `CLAUDE.md`: code comments must be understandable from the repo alone.

- The repo is public but Linear issues are private, so comments must never cite them (e.g. `// see A-1234`).
- Comments must not reference an implementation plan that lives outside the repo (e.g. `// this fixes item 4`, `// tackles section C`) — describe the actual constraint or behavior instead.

Placed in the root `CLAUDE.md` (not `yarn-project/`) since it applies to comments in any language across all components, alongside the existing rule against referencing PR/issue numbers.