### PR TITLE
fix(world-state): backport archive root guard from #24229

### DIFF
--- a/barretenberg/cpp/src/barretenberg/nodejs_module/world_state/world_state.cpp
+++ b/barretenberg/cpp/src/barretenberg/nodejs_module/world_state/world_state.cpp
@@ -741,7 +741,9 @@ bool WorldStateWrapper::sync_block(msgpack::object& obj, msgpack::sbuffer& buf)
                                                   request.value.paddedNoteHashes,
                                                   request.value.paddedL1ToL2Messages,
                                                   request.value.paddedNullifiers,
-                                                  request.value.publicDataWrites);
+                                                  request.value.publicDataWrites,
+                                                  request.value.expectedArchiveRoot,
+                                                  request.value.expectedPreviousArchiveRoot);
 
     MsgHeader header(request.header.messageId);
     messaging::TypedMessage<WorldStateStatusFull> resp_msg(WorldStateMessageType::SYNC_BLOCK, header, { status });

--- a/barretenberg/cpp/src/barretenberg/nodejs_module/world_state/world_state_message.hpp
+++ b/barretenberg/cpp/src/barretenberg/nodejs_module/world_state/world_state_message.hpp
@@ -248,6 +248,8 @@ struct SyncBlockRequest {
     block_number_t blockNumber;
     StateReference blockStateRef;
     bb::fr blockHeaderHash;
+    bb::fr expectedArchiveRoot;
+    bb::fr expectedPreviousArchiveRoot;
     std::vector<bb::fr> paddedNoteHashes, paddedL1ToL2Messages;
     std::vector<crypto::merkle_tree::NullifierLeafValue> paddedNullifiers;
     std::vector<crypto::merkle_tree::PublicDataLeafValue> publicDataWrites;
@@ -255,6 +257,8 @@ struct SyncBlockRequest {
     MSGPACK_FIELDS(blockNumber,
                    blockStateRef,
                    blockHeaderHash,
+                   expectedArchiveRoot,
+                   expectedPreviousArchiveRoot,
                    paddedNoteHashes,
                    paddedL1ToL2Messages,
                    paddedNullifiers,

--- a/barretenberg/cpp/src/barretenberg/world_state/world_state.cpp
+++ b/barretenberg/cpp/src/barretenberg/world_state/world_state.cpp
@@ -584,10 +584,32 @@ WorldStateStatusFull WorldState::sync_block(const StateReference& block_state_re
                                             const std::vector<bb::fr>& notes,
                                             const std::vector<bb::fr>& l1_to_l2_messages,
                                             const std::vector<crypto::merkle_tree::NullifierLeafValue>& nullifiers,
-                                            const std::vector<crypto::merkle_tree::PublicDataLeafValue>& public_writes)
+                                            const std::vector<crypto::merkle_tree::PublicDataLeafValue>& public_writes,
+                                            const std::optional<bb::fr>& expected_archive_root,
+                                            const std::optional<bb::fr>& expected_previous_archive_root)
 {
     validate_trees_are_equally_synched();
     rollback();
+
+    // The archive tree is an append-only accumulator of block header hashes, so a single bad leaf (e.g. from a
+    // mishandled reorg) is never self-corrected: every later root stays noncanonical while the other state trees
+    // can re-converge from block effects. The checks further down only verify the appended leaf is the tip and
+    // that the four non-archive trees match the block state reference — neither catches a divergent archive root.
+    // So verify the local archive root against canonical both before appending (the parent root must equal the
+    // block's lastArchive) and after (the resulting root must equal the block's archive), failing before commit
+    // so the divergence is never persisted.
+    if (expected_previous_archive_root.has_value()) {
+        const bb::fr actual_previous_archive_root =
+            get_tree_info(WorldStateRevision::committed(), MerkleTreeId::ARCHIVE).meta.root;
+        if (actual_previous_archive_root != expected_previous_archive_root.value()) {
+            throw std::runtime_error(
+                format("Can't sync block: local archive root ",
+                       actual_previous_archive_root,
+                       " does not match the block's previous archive root ",
+                       expected_previous_archive_root.value(),
+                       "; world state has diverged from the canonical chain and must be resynced"));
+        }
+    }
 
     Fork::SharedPtr fork = retrieve_fork(CANONICAL_FORK_ID);
     Signal signal(static_cast<uint32_t>(fork->_trees.size()));
@@ -661,6 +683,21 @@ WorldStateStatusFull WorldState::sync_block(const StateReference& block_state_re
 
         if (!is_same_state_reference(WorldStateRevision::uncommitted(), block_state_ref)) {
             throw std::runtime_error("Can't synch block: block state does not match world state");
+        }
+
+        // The archive tree is not part of the block state reference (see is_same_state_reference), so verify the
+        // resulting archive root against the canonical block's archive root explicitly.
+        if (expected_archive_root.has_value()) {
+            const bb::fr actual_archive_root =
+                get_tree_info(WorldStateRevision::uncommitted(), MerkleTreeId::ARCHIVE).meta.root;
+            if (actual_archive_root != expected_archive_root.value()) {
+                throw std::runtime_error(
+                    format("Can't sync block: resulting archive root ",
+                           actual_archive_root,
+                           " does not match the block's archive root ",
+                           expected_archive_root.value(),
+                           "; world state has diverged from the canonical chain and must be resynced"));
+            }
         }
 
         std::pair<bool, std::string> result = commit(status);

--- a/barretenberg/cpp/src/barretenberg/world_state/world_state.hpp
+++ b/barretenberg/cpp/src/barretenberg/world_state/world_state.hpp
@@ -285,7 +285,9 @@ class WorldState {
                                     const std::vector<bb::fr>& notes,
                                     const std::vector<bb::fr>& l1_to_l2_messages,
                                     const std::vector<crypto::merkle_tree::NullifierLeafValue>& nullifiers,
-                                    const std::vector<crypto::merkle_tree::PublicDataLeafValue>& public_writes);
+                                    const std::vector<crypto::merkle_tree::PublicDataLeafValue>& public_writes,
+                                    const std::optional<bb::fr>& expected_archive_root = std::nullopt,
+                                    const std::optional<bb::fr>& expected_previous_archive_root = std::nullopt);
 
     uint32_t checkpoint(const uint64_t& forkId);
     void commit_checkpoint(const uint64_t& forkId);

--- a/barretenberg/cpp/src/barretenberg/world_state/world_state.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/world_state/world_state.test.cpp
@@ -628,6 +628,74 @@ TEST_F(WorldStateTest, SyncExternalBlockFromEmpty)
                  std::runtime_error);
 }
 
+TEST_F(WorldStateTest, SyncBlockRejectsDivergentArchiveRoot)
+{
+    StateReference block_state_ref = {
+        { MerkleTreeId::NULLIFIER_TREE,
+          { fr("0x1a8a3172ecd372de7d144459831cfabf0496159a5defd0f2ecb8f5124f1717af"), 129 } },
+        { MerkleTreeId::NOTE_HASH_TREE,
+          { fr("0x2496ae3983b59733967ef32aecb041134d5f17bd2b040def30e699432dcc8967"), 1 } },
+        { MerkleTreeId::PUBLIC_DATA_TREE,
+          { fr("0x0cef6cc2f1127a3f0e87e391b283f77e7d9e2c4843ca817fd5d62928bf08f719"), 129 } },
+        { MerkleTreeId::L1_TO_L2_MESSAGE_TREE,
+          { fr("0x149be5d1559bbefa0006c5e55ed982c43a1db53848e2f59385523d0c40d74a94"), 1 } },
+    };
+
+    // Learn the canonical previous (genesis) and resulting archive roots from an untracked sync.
+    bb::fr previous_root;
+    bb::fr resulting_root;
+    {
+        WorldState scratch(
+            thread_pool_size, data_dir, map_size, tree_heights, tree_prefill, initial_header_generator_point);
+        previous_root = scratch.get_tree_info(WorldStateRevision::committed(), MerkleTreeId::ARCHIVE).meta.root;
+        scratch.sync_block(
+            block_state_ref, fr(1), { 42 }, { 43 }, { NullifierLeafValue(144) }, { { PublicDataLeafValue(145, 1) } });
+        resulting_root = scratch.get_tree_info(WorldStateRevision::committed(), MerkleTreeId::ARCHIVE).meta.root;
+    }
+
+    std::string data_dir2 = random_temp_directory();
+    std::filesystem::create_directories(data_dir2);
+    WorldState ws(thread_pool_size, data_dir2, map_size, tree_heights, tree_prefill, initial_header_generator_point);
+
+    // A wrong previous archive root is rejected before any leaves are appended.
+    EXPECT_THROW(ws.sync_block(block_state_ref,
+                               fr(1),
+                               { 42 },
+                               { 43 },
+                               { NullifierLeafValue(144) },
+                               { { PublicDataLeafValue(145, 1) } },
+                               resulting_root,
+                               previous_root + fr(1)),
+                 std::runtime_error);
+
+    // A wrong resulting archive root is rejected before commit.
+    EXPECT_THROW(ws.sync_block(block_state_ref,
+                               fr(1),
+                               { 42 },
+                               { 43 },
+                               { NullifierLeafValue(144) },
+                               { { PublicDataLeafValue(145, 1) } },
+                               resulting_root + fr(1),
+                               previous_root),
+                 std::runtime_error);
+
+    // Both rejections rolled back cleanly: world state is still at the genesis archive root.
+    EXPECT_EQ(ws.get_tree_info(WorldStateRevision::committed(), MerkleTreeId::ARCHIVE).meta.root, previous_root);
+
+    // Matching roots are accepted and advance the chain.
+    WorldStateStatusFull status = ws.sync_block(block_state_ref,
+                                                fr(1),
+                                                { 42 },
+                                                { 43 },
+                                                { NullifierLeafValue(144) },
+                                                { { PublicDataLeafValue(145, 1) } },
+                                                resulting_root,
+                                                previous_root);
+    WorldStateStatusSummary expected(1, 0, 1, true);
+    EXPECT_EQ(status.summary, expected);
+    EXPECT_EQ(ws.get_tree_info(WorldStateRevision::committed(), MerkleTreeId::ARCHIVE).meta.root, resulting_root);
+}
+
 TEST_F(WorldStateTest, SyncBlockFromDirtyState)
 {
     WorldState ws(thread_pool_size, data_dir, map_size, tree_heights, tree_prefill, initial_header_generator_point);
@@ -934,4 +1002,72 @@ TEST_F(WorldStateTest, GetBlockForIndex)
         EXPECT_TRUE(blockNumbers[0].has_value());
         EXPECT_EQ(blockNumbers[0].value(), 1);
     }
+}
+
+// Demonstrates the bug: syncing an empty block with a bogus block_header_hash succeeds when the optional
+// expected-archive-root arguments are omitted.  The 4-tree state-ref check passes (nothing changed), but
+// the wrong hash is committed to the ARCHIVE, silently diverging from the canonical chain.
+TEST_F(WorldStateTest, SyncEmptyBlockAcceptsBogusHashWithoutArchiveCheck)
+{
+    // Learn the canonical previous and resulting archive roots from an empty-block sync on a scratch instance.
+    bb::fr previous_archive_root;
+    bb::fr canonical_archive_root;
+    {
+        WorldState scratch(
+            thread_pool_size, data_dir, map_size, tree_heights, tree_prefill, initial_header_generator_point);
+        previous_archive_root = scratch.get_tree_info(WorldStateRevision::committed(), MerkleTreeId::ARCHIVE).meta.root;
+        StateReference genesis_state_ref = scratch.get_state_reference(WorldStateRevision::committed());
+        scratch.sync_block(genesis_state_ref, fr(1), {}, {}, {}, {});
+        canonical_archive_root =
+            scratch.get_tree_info(WorldStateRevision::committed(), MerkleTreeId::ARCHIVE).meta.root;
+    }
+
+    std::string data_dir2 = random_temp_directory();
+    std::filesystem::create_directories(data_dir2);
+    WorldState ws(thread_pool_size, data_dir2, map_size, tree_heights, tree_prefill, initial_header_generator_point);
+
+    StateReference genesis_state_ref = ws.get_state_reference(WorldStateRevision::committed());
+
+    // Sync an empty block using a bogus hash — no expected-archive-root arguments provided.
+    EXPECT_NO_THROW(ws.sync_block(genesis_state_ref, fr(42), {}, {}, {}, {}));
+
+    bb::fr actual_archive_root = ws.get_tree_info(WorldStateRevision::committed(), MerkleTreeId::ARCHIVE).meta.root;
+
+    // The bogus hash committed successfully, so the resulting archive root differs from the canonical one.
+    EXPECT_NE(actual_archive_root, canonical_archive_root);
+    EXPECT_NE(actual_archive_root, previous_archive_root);
+}
+
+// Demonstrates the fix: supplying the canonical expected archive roots causes sync_block to reject the bogus
+// block_header_hash for an empty block, and rolls back cleanly.
+TEST_F(WorldStateTest, SyncEmptyBlockRejectsBogusHashWhenArchiveRootsAreChecked)
+{
+    // Learn the canonical previous and resulting archive roots from an empty-block sync on a scratch instance.
+    bb::fr previous_archive_root;
+    bb::fr canonical_archive_root;
+    {
+        WorldState scratch(
+            thread_pool_size, data_dir, map_size, tree_heights, tree_prefill, initial_header_generator_point);
+        previous_archive_root = scratch.get_tree_info(WorldStateRevision::committed(), MerkleTreeId::ARCHIVE).meta.root;
+        StateReference genesis_state_ref = scratch.get_state_reference(WorldStateRevision::committed());
+        scratch.sync_block(genesis_state_ref, fr(1), {}, {}, {}, {});
+        canonical_archive_root =
+            scratch.get_tree_info(WorldStateRevision::committed(), MerkleTreeId::ARCHIVE).meta.root;
+    }
+
+    std::string data_dir2 = random_temp_directory();
+    std::filesystem::create_directories(data_dir2);
+    WorldState ws(thread_pool_size, data_dir2, map_size, tree_heights, tree_prefill, initial_header_generator_point);
+
+    StateReference genesis_state_ref = ws.get_state_reference(WorldStateRevision::committed());
+
+    // Sync an empty block using a bogus hash, but supply the canonical archive roots for validation.
+    // The resulting archive root will not match canonical_archive_root, so this must throw.
+    EXPECT_THROW(
+        ws.sync_block(genesis_state_ref, fr(42), {}, {}, {}, {}, canonical_archive_root, previous_archive_root),
+        std::runtime_error);
+
+    // The committed archive root must be unchanged (rollback was clean).
+    EXPECT_EQ(ws.get_tree_info(WorldStateRevision::committed(), MerkleTreeId::ARCHIVE).meta.root,
+              previous_archive_root);
 }

--- a/yarn-project/world-state/src/native/message.ts
+++ b/yarn-project/world-state/src/native/message.ts
@@ -1,7 +1,6 @@
 import { BlockNumber } from '@aztec/foundation/branded-types';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import type { Tuple } from '@aztec/foundation/serialize';
-import type { BlockHash } from '@aztec/stdlib/block';
 import { AppendOnlyTreeSnapshot, MerkleTreeId } from '@aztec/stdlib/trees';
 import type { StateReference } from '@aztec/stdlib/tx';
 import type { UInt32 } from '@aztec/stdlib/types';
@@ -423,7 +422,11 @@ interface UpdateArchiveRequest extends WithForkId {
 interface SyncBlockRequest extends WithCanonicalForkId {
   blockNumber: BlockNumber;
   blockStateRef: BlockStateReference;
-  blockHeaderHash: BlockHash;
+  blockHeaderHash: Buffer;
+  /** Canonical archive root after this block; world state rejects the sync if its computed root differs. */
+  expectedArchiveRoot: Buffer;
+  /** Canonical archive root before this block (the block's lastArchive); verified against the local root. */
+  expectedPreviousArchiveRoot: Buffer;
   paddedNoteHashes: readonly SerializedLeafValue[];
   paddedL1ToL2Messages: readonly SerializedLeafValue[];
   paddedNullifiers: readonly SerializedLeafValue[];

--- a/yarn-project/world-state/src/native/native_world_state.test.ts
+++ b/yarn-project/world-state/src/native/native_world_state.test.ts
@@ -9,7 +9,7 @@ import {
   NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP,
   PUBLIC_DATA_TREE_HEIGHT,
 } from '@aztec/constants';
-import { BlockNumber } from '@aztec/foundation/branded-types';
+import { BlockNumber, SlotNumber } from '@aztec/foundation/branded-types';
 import { timesAsync } from '@aztec/foundation/collection';
 import { randomBytes } from '@aztec/foundation/crypto/random';
 import { Fr } from '@aztec/foundation/curves/bn254';
@@ -30,7 +30,7 @@ import { tmpdir } from 'os';
 import { join } from 'path';
 
 import type { WorldStateTreeMapSizes } from '../synchronizer/factory.js';
-import { assertSameState, compareChains, mockBlock, mockEmptyBlock } from '../test/utils.js';
+import { assertSameState, compareChains, mockBlock, mockEmptyBlock, updateBlockState } from '../test/utils.js';
 import { INITIAL_NULLIFIER_TREE_SIZE, INITIAL_PUBLIC_DATA_TREE_SIZE } from '../world-state-db/merkle_tree_db.js';
 import type { WorldStateStatusSummary } from './message.js';
 import { NativeWorldStateService, WORLD_STATE_DB_VERSION, WORLD_STATE_DIR } from './native_world_state.js';
@@ -1009,6 +1009,93 @@ describe('NativeWorldState', () => {
         expect(unwindStatus.summary.finalizedBlockNumber).toBe(2);
         expect(unwindStatus.summary.oldestHistoricalBlock).toBe(1);
       }
+    });
+  });
+
+  describe('Archive root divergence on empty blocks', () => {
+    let ws: NativeWorldStateService;
+
+    beforeEach(async () => {
+      ws = await NativeWorldStateService.new(EthAddress.random(), dataDir, wsTreeMapSizes);
+    });
+
+    afterEach(async () => {
+      await ws.close();
+    });
+
+    const emptyMessages = () => Array(16).fill(0).map(Fr.zero);
+
+    // A *different* empty block at height 1: the same (empty) contents as the canonical block, but a different slot,
+    // so a different block-header hash — the proposer-race orphan from A-1235, not a tampered block.
+    const buildDifferentBlockOne = async (slotNumber: number) => {
+      const fork = await ws.fork();
+      const block = L2Block.empty();
+      block.header.globalVariables.blockNumber = BlockNumber(1);
+      block.header.globalVariables.slotNumber = SlotNumber(slotNumber);
+      const messages = emptyMessages();
+      await updateBlockState(block, messages, fork);
+      await fork.close();
+      return { block, messages };
+    };
+
+    // The canonical chain L1 finalized: block 1, then block 2 chained onto it (block 2's lastArchive == block 1's
+    // archive root). Built on a throwaway fork so it never touches the world state under test.
+    const buildCanonicalChain = async () => {
+      const fork = await ws.fork();
+      const { block: canonicalOne } = await mockEmptyBlock(BlockNumber(1), fork);
+      const { block: canonicalTwo, messages: canonicalTwoMessages } = await mockEmptyBlock(BlockNumber(2), fork);
+      await fork.close();
+      return { canonicalOne, canonicalTwo, canonicalTwoMessages };
+    };
+
+    // The core blind spot: two empty blocks at the same height with different headers are indistinguishable to the
+    // four-tree state reference, yet they are different blocks with different archive roots.
+    it('two empty blocks at the same height with different headers share a state reference but not an archive root', async () => {
+      const { canonicalOne } = await buildCanonicalChain();
+      const { block: orphanOne } = await buildDifferentBlockOne(99);
+
+      // The four non-archive trees are identical (empty blocks insert no leaves), so is_same_state_reference cannot
+      // tell the two blocks apart...
+      expect(orphanOne.header.state).toEqual(canonicalOne.header.state);
+      // ...yet they are genuinely different blocks, with different header hashes and different archive roots.
+      expect((await orphanOne.hash()).equals(await canonicalOne.hash())).toBe(false);
+      expect(orphanOne.archive.root.equals(canonicalOne.archive.root)).toBe(false);
+    });
+
+    // The seeding step: a self-consistent orphan block passes every check, so world state takes the wrong block and
+    // ends up on the orphan fork — it has no way, from this block alone, to know it is not the canonical block 1.
+    it('silently accepts a different empty block at the same height (how the wrong block gets in)', async () => {
+      const { canonicalOne } = await buildCanonicalChain();
+      const { block: orphanOne, messages: orphanMessages } = await buildDifferentBlockOne(99);
+
+      await expect(ws.handleL2BlockAndMessages(orphanOne, orphanMessages)).resolves.toBeDefined();
+
+      // World state is now on the orphan fork: its committed archive root is the orphan's, not canonical block 1's.
+      const archive = await ws.getCommitted().getTreeInfo(MerkleTreeId.ARCHIVE);
+      expect(Fr.fromBuffer(archive.root).equals(orphanOne.archive.root)).toBe(true);
+      expect(Fr.fromBuffer(archive.root).equals(canonicalOne.archive.root)).toBe(false);
+    });
+
+    // The fix: once world state has taken the orphan, the canonical successor (which chains off the real block 1)
+    // no longer matches world state's committed archive root, and the pre-append guard rejects it before committing.
+    it('rejects the canonical successor of a wrongly-synced orphan, catching the archive divergence (the fix)', async () => {
+      const { canonicalTwo, canonicalTwoMessages } = await buildCanonicalChain();
+      const { block: orphanOne, messages: orphanMessages } = await buildDifferentBlockOne(99);
+
+      // The orphan commits cleanly (it is a self-consistent block 1).
+      await expect(ws.handleL2BlockAndMessages(orphanOne, orphanMessages)).resolves.toBeDefined();
+      const archiveBefore = await ws.getCommitted().getTreeInfo(MerkleTreeId.ARCHIVE);
+
+      // canonicalTwo.lastArchive == canonicalOne's archive root, which no longer matches world state's committed
+      // (orphan) archive root, so the pre-append guard throws before committing.
+      await expect(ws.handleL2BlockAndMessages(canonicalTwo, canonicalTwoMessages)).rejects.toThrow(
+        /diverged from the canonical chain/,
+      );
+
+      // Clean rollback: the archive tree is untouched.
+      const archiveAfter = await ws.getCommitted().getTreeInfo(MerkleTreeId.ARCHIVE);
+      expect(archiveAfter.root).toEqual(archiveBefore.root);
+      expect(archiveAfter.size).toEqual(archiveBefore.size);
     });
   });
 

--- a/yarn-project/world-state/src/native/native_world_state.ts
+++ b/yarn-project/world-state/src/native/native_world_state.ts
@@ -232,7 +232,10 @@ export class NativeWorldStateService implements MerkleTreeDatabase {
         WorldStateMessageType.SYNC_BLOCK,
         {
           blockNumber: l2Block.number,
-          blockHeaderHash: await l2Block.hash(),
+          blockHeaderHash: (await l2Block.hash()).toBuffer(),
+          // Forwarded so the native sync verifies the archive root against canonical and rejects a divergent tree.
+          expectedArchiveRoot: l2Block.archive.root.toBuffer(),
+          expectedPreviousArchiveRoot: l2Block.header.lastArchive.root.toBuffer(),
           paddedL1ToL2Messages: paddedL1ToL2Messages.map(serializeLeaf),
           paddedNoteHashes: paddedNoteHashes.map(serializeLeaf),
           paddedNullifiers: paddedNullifiers.map(serializeLeaf),

--- a/yarn-project/world-state/src/test/utils.ts
+++ b/yarn-project/world-state/src/test/utils.ts
@@ -60,7 +60,16 @@ export async function updateBlockState(block: L2Block, l1ToL2Messages: Fr[], for
   await Promise.all([publicDataInsert, nullifierInsert, noteHashInsert, messageInsert]);
 
   const state = await fork.getStateReference();
-  block.header = BlockHeader.from({ ...block.header, state });
+
+  // Capture the archive root *before* appending this block so the header's lastArchive chains off the previous block.
+  // sync_block now verifies lastArchive against the committed archive root, so a block carrying an unchained value
+  // (e.g. the random lastArchive from L2Block.random) would be rejected as a divergence from the canonical chain.
+  const previousArchive = await fork.getTreeInfo(MerkleTreeId.ARCHIVE);
+  block.header = BlockHeader.from({
+    ...block.header,
+    state,
+    lastArchive: new AppendOnlyTreeSnapshot(Fr.fromBuffer(previousArchive.root), Number(previousArchive.size)),
+  });
   await fork.updateArchive(block.header);
 
   const archiveState = await fork.getTreeInfo(MerkleTreeId.ARCHIVE);


### PR DESCRIPTION
## Summary
- backport #24229 archive-root verification in native world-state sync_block
- forward canonical previous/resulting archive roots through the native world-state message path
- adapt the C++ regression constants to v4 tree roots and keep the v4-only transport surface

## Tests
- yarn workspace @aztec/world-state build
- ../barretenberg/cpp/bootstrap.sh build_preset clang20 --target nodejs_module
- yarn build:native (from barretenberg/ts)
- yarn workspace @aztec/world-state test src/native/native_world_state.test.ts
- ../barretenberg/cpp/bootstrap.sh build_preset clang20 --target world_state_tests
- ../barretenberg/cpp/build/bin/world_state_tests --gtest_filter=WorldStateTest.SyncBlockRejectsDivergentArchiveRoot