### PR TITLE
fix: build ipc-runtime via Makefile dep, not from ipc-codegen bootstraps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -288,7 +288,7 @@ bb-full-tests: bb-cpp-wasm-threads-tests bb-cpp-asan-tests bb-cpp-smt-tests
 #==============================================================================
 
 .PHONY: ipc-codegen ipc-codegen-tests
-ipc-codegen:
+ipc-codegen: ipc-runtime
 	$(call build,$@,ipc-codegen)
 
 ipc-codegen-tests: ipc-codegen

--- a/ipc-codegen/echo_example/ts/bootstrap.sh
+++ b/ipc-codegen/echo_example/ts/bootstrap.sh
@@ -13,8 +13,9 @@ $NODE "$CODEGEN/src/generate.ts" \
   --client \
   --out "$DIR/src/generated"
 
-(cd "$REPO_ROOT/ipc-runtime" && ./bootstrap.sh)
-(cd "$REPO_ROOT/ipc-runtime/ts" && yarn install --immutable && yarn build)
+# ipc-runtime is built by the Makefile (ipc-codegen depends on it) so its ts/dest
+# is ready for the file: link below; don't reinstall the shared ipc-runtime/ts
+# here — concurrent build units doing so corrupt its node_modules.
 rm -rf "$DIR/node_modules"
 (cd "$DIR" && npm install --no-package-lock --quiet)
 (cd "$DIR" && node_modules/.bin/tsc --noEmit)

--- a/ipc-codegen/echo_example/ts_package/bootstrap.sh
+++ b/ipc-codegen/echo_example/ts_package/bootstrap.sh
@@ -18,8 +18,9 @@ $NODE "$CODEGEN/src/generate.ts" \
   --ipc-runtime-dependency "file:../../../ipc-runtime/ts"
 
 (cd "$DIR/../cpp" && ./bootstrap.sh)
-(cd "$REPO_ROOT/ipc-runtime" && ./bootstrap.sh)
-(cd "$REPO_ROOT/ipc-runtime/ts" && yarn install --immutable && yarn build)
+# ipc-runtime is built by the Makefile (ipc-codegen depends on it) so its ts/dest
+# and NAPI addon are ready for the file: link below; don't reinstall the shared
+# ipc-runtime/ts here — concurrent build units doing so corrupt its node_modules.
 
 platform_dir="$(
   node -e "const arch = { x64: 'amd64', arm64: 'arm64' }[process.arch] ?? process.arch; const os = { linux: 'linux', darwin: 'macos' }[process.platform] ?? process.platform; console.log(arch + '-' + os);"


### PR DESCRIPTION
## Problem

Intermittent CI failures in the `ipc-codegen build` job:

```
YN0001: Error: ENOENT: no such file or directory, lstat '.../ipc-runtime/ts/node_modules/typescript/bin/tsc'
```

## Root cause

The echo-example bootstraps under `ipc-codegen` each build the **shared** `ipc-runtime` tree directly:

```sh
# echo_example/ts/bootstrap.sh and echo_example/ts_package/bootstrap.sh
(cd "$REPO_ROOT/ipc-runtime" && ./bootstrap.sh)
(cd "$REPO_ROOT/ipc-runtime/ts" && yarn install --immutable && yarn build)
```

`ipc-runtime/ts` is therefore installed by multiple independent build units (its own `ipc-runtime` build, plus both echo bootstraps). When the CI fan-out runs these concurrently on a shared checkout, two `yarn install`s mutate `ipc-runtime/ts/node_modules` at the same time — one is mid-repopulating `typescript/` while another's link step `lstat`s `typescript/bin/tsc`, which isn't there yet → `ENOENT`. It's intermittent because it only fails when the fetch/link windows overlap. (The log tell: a second `--immutable` install of the same dir, seconds after a warm success, re-fetches `typescript` fresh — only possible if another process disturbed its `node_modules` mid-build.)

This is not a yarn-cache issue; it's concurrent writers on one `node_modules`.

## Fix

Use the Makefile to ensure the dependency, the same way `wsdb` already does:

- `ipc-codegen: ipc-runtime` — make builds `ipc-runtime` once, first.
- Remove the redundant in-bootstrap `ipc-runtime` builds from both echo bootstraps.

The echo examples now consume the already-built `ipc-runtime/ts` through their `file:` link and write only their own `node_modules`, so there is a single writer of the shared tree.

## Note

Local full-bootstrap not run; relying on CI to exercise the ipc-codegen echo matrix (UDS + SHM, all languages), which is exactly the path this touches.