### PR TITLE
fix: port reusable network-teardown action to v5-next

### DIFF
--- a/.github/actions/network-teardown/action.yml
+++ b/.github/actions/network-teardown/action.yml
@@ -1,0 +1,52 @@
+name: "Spartan network teardown"
+description: >
+  Tear down a deployed Spartan network (delete any Chaos Mesh experiments and
+  the Kubernetes namespace) directly on the GitHub runner. This replaces the
+  EC2-backed `ci3.sh network-teardown` path for cleanup: teardown is pure
+  gcloud/kubectl work, so there is no need to provision a build instance.
+inputs:
+  env_file:
+    description: "Spartan environment file name (e.g. tps-scenario), used to source CLUSTER and GCP_REGION."
+    required: true
+  namespace:
+    description: "Kubernetes namespace to tear down."
+    required: true
+  gcp_sa_key:
+    description: "GCP service account key JSON (secrets.GCP_SA_KEY)."
+    required: true
+  gcp_project_id:
+    description: "GCP project id (secrets.GCP_PROJECT_ID)."
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - name: Setup gcloud and install GKE auth plugin
+      uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v2.1.4
+      with:
+        install_components: "gke-gcloud-auth-plugin"
+
+    - name: Tear down network
+      shell: bash
+      env:
+        GCP_SA_KEY: ${{ inputs.gcp_sa_key }}
+        GCP_PROJECT_ID: ${{ inputs.gcp_project_id }}
+        NAMESPACE: ${{ inputs.namespace }}
+        ENV_FILE: ${{ inputs.env_file }}
+        GOOGLE_APPLICATION_CREDENTIALS: /tmp/gcp-key.json
+        CI: "1"
+      run: |
+        set -euo pipefail
+        # Store the GCP service account key for gcloud auth and the teardown.
+        set +x
+        umask 077
+        printf '%s' "$GCP_SA_KEY" > "$GOOGLE_APPLICATION_CREDENTIALS"
+        jq -e . "$GOOGLE_APPLICATION_CREDENTIALS" >/dev/null
+
+        cd "$(git rev-parse --show-toplevel)/spartan"
+        # Reuse the same env + auth + teardown scripts the EC2 path runs, but
+        # execute them directly on the runner instead of via bootstrap_ec2.
+        source ./scripts/source_env_basic.sh
+        source ./scripts/gcp_auth.sh
+        source_env_basic "$ENV_FILE"
+        gcp_auth
+        ./scripts/network_teardown.sh

--- a/.github/workflows/nightly-bench-10tps.yml
+++ b/.github/workflows/nightly-bench-10tps.yml
@@ -173,15 +173,12 @@ jobs:
           ref: ${{ needs.select-image.outputs.source_ref }}
 
       - name: Cleanup network resources
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          GITHUB_TOKEN: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
-          BUILD_INSTANCE_SSH_KEY: ${{ secrets.BUILD_INSTANCE_SSH_KEY }}
-          GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
-          GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
-          NO_SPOT: 1
-        run: ./.github/ci3.sh network-teardown bench-10tps bench-10tps
+        uses: ./.github/actions/network-teardown
+        with:
+          env_file: bench-10tps
+          namespace: bench-10tps
+          gcp_sa_key: ${{ secrets.GCP_SA_KEY }}
+          gcp_project_id: ${{ secrets.GCP_PROJECT_ID }}
 
   notify-failure:
     if: ${{ always() && failure() && github.event_name != 'workflow_dispatch' }}

--- a/.github/workflows/nightly-spartan-bench.yml
+++ b/.github/workflows/nightly-spartan-bench.yml
@@ -178,15 +178,12 @@ jobs:
           ref: ${{ needs.select-image.outputs.source_ref }}
 
       - name: Cleanup network resources
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          GITHUB_TOKEN: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
-          BUILD_INSTANCE_SSH_KEY: ${{ secrets.BUILD_INSTANCE_SSH_KEY }}
-          GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
-          GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
-          NO_SPOT: 1
-        run: ./.github/ci3.sh network-teardown tps-scenario nightly-bench
+        uses: ./.github/actions/network-teardown
+        with:
+          env_file: tps-scenario
+          namespace: nightly-bench
+          gcp_sa_key: ${{ secrets.GCP_SA_KEY }}
+          gcp_project_id: ${{ secrets.GCP_PROJECT_ID }}
 
   notify-bench-failure:
     if: ${{ always() && failure() && github.event_name != 'workflow_dispatch' }}
@@ -329,15 +326,12 @@ jobs:
           ref: ${{ needs.select-image.outputs.source_ref }}
 
       - name: Cleanup network resources
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          GITHUB_TOKEN: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
-          BUILD_INSTANCE_SSH_KEY: ${{ secrets.BUILD_INSTANCE_SSH_KEY }}
-          GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
-          GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
-          NO_SPOT: 1
-        run: ./.github/ci3.sh network-teardown prove-n-tps-fake prove-n-tps-fake
+        uses: ./.github/actions/network-teardown
+        with:
+          env_file: prove-n-tps-fake
+          namespace: prove-n-tps-fake
+          gcp_sa_key: ${{ secrets.GCP_SA_KEY }}
+          gcp_project_id: ${{ secrets.GCP_PROJECT_ID }}
 
   notify-proving-failure:
     if: ${{ always() && failure() && github.event_name != 'workflow_dispatch' }}
@@ -480,15 +474,12 @@ jobs:
           ref: ${{ needs.select-image.outputs.source_ref }}
 
       - name: Cleanup network resources
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          GITHUB_TOKEN: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
-          BUILD_INSTANCE_SSH_KEY: ${{ secrets.BUILD_INSTANCE_SSH_KEY }}
-          GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
-          GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
-          NO_SPOT: 1
-        run: ./.github/ci3.sh network-teardown block-capacity nightly-block-capacity
+        uses: ./.github/actions/network-teardown
+        with:
+          env_file: block-capacity
+          namespace: nightly-block-capacity
+          gcp_sa_key: ${{ secrets.GCP_SA_KEY }}
+          gcp_project_id: ${{ secrets.GCP_PROJECT_ID }}
 
   notify-block-capacity-failure:
     if: ${{ always() && failure() && github.event_name != 'workflow_dispatch' }}

--- a/.github/workflows/test-network-scenarios.yml
+++ b/.github/workflows/test-network-scenarios.yml
@@ -60,16 +60,13 @@ jobs:
 
       - name: Cleanup network resources
         if: always()
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          GITHUB_TOKEN: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
-          BUILD_INSTANCE_SSH_KEY: ${{ secrets.BUILD_INSTANCE_SSH_KEY }}
-          GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
-          GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
-          NO_SPOT: 1
-        run: |
-          ./.github/ci3.sh network-teardown "${{ inputs.env_file }}" "${NAMESPACE}-${{ matrix.test_set }}" || true
+        continue-on-error: true
+        uses: ./.github/actions/network-teardown
+        with:
+          env_file: ${{ inputs.env_file }}
+          namespace: ${{ env.NAMESPACE }}-${{ matrix.test_set }}
+          gcp_sa_key: ${{ secrets.GCP_SA_KEY }}
+          gcp_project_id: ${{ secrets.GCP_PROJECT_ID }}
 
       - name: Notify Slack and dispatch ClaudeBox on failure
         if: failure()


### PR DESCRIPTION
## What

Cherry-picks `ef43cb7fa20` (*"ci: reusable network-teardown action that runs on GitHub runners"*) from `next` onto the v5 line.

This is a clean port — `.github/actions/network-teardown/action.yml` is byte-identical to `next`, and the three workflow files (`nightly-bench-10tps.yml`, `nightly-spartan-bench.yml`, `test-network-scenarios.yml`) get the same teardown-refactor hunks applied on top of their v5-specific config.

## Why

The nightly Spartan Benchmarks run on the private repo's default branch (`next`), whose `cleanup-*` jobs were refactored on 2026-06-17 to call the local composite action:

```yaml
- name: Checkout
  with:
    ref: ${{ needs.select-image.outputs.source_ref }}   # the nightly TAG
- name: Cleanup network resources
  uses: ./.github/actions/network-teardown
```

The checkout pins `source_ref` (the nightly tag). When the deployed tag is a **v5** nightly tag, that tree did **not** contain `.github/actions/network-teardown` (the action was only ever on the `next` line), so cleanup failed with:

```
Can't find 'action.yml' … under '.github/actions/network-teardown'.
Did you forget to run actions/checkout before running your local action?
```

This left network resources orphaned on every failure (observed in nightly run #95). Porting the action to `v5-next` means future v5 nightly tags include it, so the cleanup checkout resolves the action correctly.

`weekly-proving-bench.yml` and `ci3.yml` keep the older `ci3.sh network-teardown` form — matching `next` exactly (the original commit did not touch them).

## Routing

Targets `v5-next` directly (not via `merge-train/spartan-v5`) since the commit already exists on `next`; routing through the merge train would attempt a redundant port back to private `next`. This PR syncs to private `v5-next`.