### PR TITLE
test(validator-client): deflake integration test with frozen clock

### DIFF
--- a/yarn-project/validator-client/src/validator.integration.test.ts
+++ b/yarn-project/validator-client/src/validator.integration.test.ts
@@ -13,7 +13,7 @@ import { Fr } from '@aztec/foundation/curves/bn254';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { type Logger, createLogger } from '@aztec/foundation/log';
 import type { Hex } from '@aztec/foundation/string';
-import { TestDateProvider } from '@aztec/foundation/timer';
+import { ManualDateProvider } from '@aztec/foundation/timer';
 import { type KeyStore, KeystoreManager } from '@aztec/node-keystore';
 import { getVKTreeRoot } from '@aztec/noir-protocol-circuits-types/vk-tree';
 import type { P2P, PeerId } from '@aztec/p2p';
@@ -82,7 +82,7 @@ describe('ValidatorClient Integration', () => {
   let proposerPrivateKey: Hex<32>;
   let validatorSigner: Secp256k1Signer;
   let validatorPrivateKey: Hex<32>;
-  let dateProvider: TestDateProvider;
+  let dateProvider: ManualDateProvider;
   let txProvider: TestTxProvider;
   let keyStoreManager: KeystoreManager;
   let blobClient: MockProxy<BlobClientInterface>;
@@ -373,7 +373,7 @@ describe('ValidatorClient Integration', () => {
     // Set up common dependencies
     logger = createLogger('validator:test');
     rollupAddress = EthAddress.random();
-    dateProvider = new TestDateProvider();
+    dateProvider = new ManualDateProvider();
     txProvider = new TestTxProvider();
     blobClient = mock<BlobClientInterface>();
     blobClient.canUpload.mockReturnValue(false);
@@ -544,6 +544,10 @@ describe('ValidatorClient Integration', () => {
       // Only validate first 2 blocks
       await attestorValidateBlocks(blocks.slice(0, 2));
 
+      // Advance past slot 1's attestation deadline so the validator's bounded wait for the
+      // never-synced terminal block (block 3) times out at once instead of polling the full window.
+      dateProvider.setTime(Number(getTimestampForSlot(SlotNumber(slotNumber + 1), l1Constants)) * 1000);
+
       // Attestation should fail because block 3 wasn't validated
       // The validator will timeout waiting for block with matching archive
       const attestations = await attestor.validator.attestToCheckpointProposal(proposal, mockPeerId);
@@ -574,6 +578,10 @@ describe('ValidatorClient Integration', () => {
       );
 
       await attestorValidateBlocks(blocks);
+
+      // Advance past slot 1's attestation deadline so the validator's bounded wait for a block
+      // matching the (random) archive times out at once instead of polling the full window.
+      dateProvider.setTime(Number(getTimestampForSlot(SlotNumber(slotNumber + 1), l1Constants)) * 1000);
 
       // Attestation should fail because archive doesn't match any block
       const attestations = await attestor.validator.attestToCheckpointProposal(badProposal, mockPeerId);


### PR DESCRIPTION
## Motivation

`ValidatorClient Integration` (`validator.integration.test.ts`) flakes (~7 failures across `next` and `merge-train/spartan-v5`). The block re-execution deadline is the slot attestation deadline (~24s) checked against the date provider's clock. `TestDateProvider` advances with real wall-clock from the `beforeEach` anchor, so the budget is consumed by the two heavy fixture setups before re-execution runs. On a slow CI box a block that should re-execute hits the deadline, processes 0 txs, and is rejected as an empty non-first block — the rejection the mana-limit test expects only for the overflowing block.

## Approach

Use the frozen `ManualDateProvider` so re-execution can't race wall-clock. The two tests that depend on a `retryUntil` timing out now advance the clock past the attestation deadline so the timeout fires immediately instead of polling the full window. No assertion changed.

## Changes

- **validator-client (tests)**: `validator.integration.test.ts` uses `ManualDateProvider`; two timeout-dependent tests advance the clock past the deadline.

Fixes A-1265