### PR TITLE
feat: deploy new eth nodes

### DIFF
--- a/spartan/bootstrap.sh
+++ b/spartan/bootstrap.sh
@@ -14,6 +14,7 @@ source ./scripts/gcp_auth.sh
 function build {
   denoise "helm lint ./aztec-bot/"
   denoise "helm lint ./aztec-chaos-scenarios/"
+  denoise "helm lint ./charts/otel-metrics-collector/"
   denoise "helm lint ./aztec-keystore/"
   denoise "helm lint ./aztec-node/ --set global.aztecImage.tag=lint"
   denoise "helm lint ./aztec-prover-stack/"

--- a/spartan/charts/otel-metrics-collector/Chart.yaml
+++ b/spartan/charts/otel-metrics-collector/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: otel-metrics-collector
+description: OpenTelemetry Collector for scraping Prometheus metrics and exporting OTLP/HTTP
+type: application
+version: 0.1.0
+appVersion: "0.154.0"

--- a/spartan/charts/otel-metrics-collector/templates/_helpers.tpl
+++ b/spartan/charts/otel-metrics-collector/templates/_helpers.tpl
@@ -1,0 +1,64 @@
+{{- define "otel-metrics-collector.fullname" -}}
+{{- .Values.fullnameOverride | default .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "otel-metrics-collector.configName" -}}
+{{- printf "%s-config" (include "otel-metrics-collector.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "otel-metrics-collector.selectorLabels" -}}
+app.kubernetes.io/name: {{ .Chart.Name }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/component: metrics
+{{- end -}}
+
+{{- define "otel-metrics-collector.labels" -}}
+{{- $base := dict "app.kubernetes.io/name" .Chart.Name "app.kubernetes.io/instance" .Release.Name "app.kubernetes.io/component" "metrics" -}}
+{{- $labels := mergeOverwrite (deepCopy (.Values.labels | default dict)) $base -}}
+{{- toYaml $labels -}}
+{{- end -}}
+
+{{- define "otel-metrics-collector.resourceAttributes" -}}
+{{- $defaults := dict "service.name" (include "otel-metrics-collector.fullname" .) "service.namespace" .Release.Namespace "k8s.namespace.name" .Release.Namespace -}}
+{{- $attrs := mergeOverwrite $defaults (.Values.resourceAttributes | default dict) -}}
+{{- $result := list -}}
+{{- range $key, $value := $attrs -}}
+{{- $result = append $result (dict "action" "upsert" "key" $key "value" $value) -}}
+{{- end -}}
+{{- toYaml $result -}}
+{{- end -}}
+
+{{- define "otel-metrics-collector.scrapeConfigs" -}}
+{{- $result := list -}}
+{{- range $config := .Values.scrapeConfigs -}}
+{{- $scrapeConfig := dict "job_name" $config.job_name "scrape_interval" ($config.scrape_interval | default "15s") "metrics_path" ($config.metrics_path | default "/metrics") -}}
+{{- $_ := set $scrapeConfig "static_configs" (list (dict "targets" $config.targets "labels" ($config.labels | default dict))) -}}
+{{- $metricRelabelConfigs := list -}}
+{{- range $rule := ($config.metric_relabel_configs | default list) -}}
+{{- $ruleConfig := dict "action" $rule.action -}}
+{{- with $rule.source_labels -}}
+{{- if gt (len .) 0 -}}
+{{- $_ := set $ruleConfig "source_labels" . -}}
+{{- end -}}
+{{- end -}}
+{{- with $rule.regex -}}
+{{- $_ := set $ruleConfig "regex" . -}}
+{{- end -}}
+{{- with $rule.target_label -}}
+{{- $_ := set $ruleConfig "target_label" . -}}
+{{- end -}}
+{{- with $rule.replacement -}}
+{{- $_ := set $ruleConfig "replacement" . -}}
+{{- end -}}
+{{- with $rule.separator -}}
+{{- $_ := set $ruleConfig "separator" . -}}
+{{- end -}}
+{{- $metricRelabelConfigs = append $metricRelabelConfigs $ruleConfig -}}
+{{- end -}}
+{{- if gt (len $metricRelabelConfigs) 0 -}}
+{{- $_ := set $scrapeConfig "metric_relabel_configs" $metricRelabelConfigs -}}
+{{- end -}}
+{{- $result = append $result $scrapeConfig -}}
+{{- end -}}
+{{- toYaml $result -}}
+{{- end -}}

--- a/spartan/charts/otel-metrics-collector/templates/configmap.yaml
+++ b/spartan/charts/otel-metrics-collector/templates/configmap.yaml
@@ -1,0 +1,37 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "otel-metrics-collector.configName" . }}
+  labels:
+    {{- include "otel-metrics-collector.labels" . | nindent 4 }}
+data:
+  collector.yaml: |-
+    extensions:
+      health_check:
+        endpoint: 0.0.0.0:13133
+    receivers:
+      prometheus:
+        config:
+          scrape_configs:
+            {{- include "otel-metrics-collector.scrapeConfigs" . | nindent 12 }}
+    processors:
+      resource:
+        attributes:
+          {{- include "otel-metrics-collector.resourceAttributes" . | nindent 10 }}
+      batch: {}
+    exporters:
+      otlphttp:
+        endpoint: ${env:OTEL_EXPORTER_OTLP_ENDPOINT}
+        compression: gzip
+    service:
+      extensions:
+        - health_check
+      pipelines:
+        metrics:
+          receivers:
+            - prometheus
+          processors:
+            - resource
+            - batch
+          exporters:
+            - otlphttp

--- a/spartan/charts/otel-metrics-collector/templates/deployment.yaml
+++ b/spartan/charts/otel-metrics-collector/templates/deployment.yaml
@@ -1,0 +1,59 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "otel-metrics-collector.fullname" . }}
+  labels:
+    {{- include "otel-metrics-collector.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicas }}
+  selector:
+    matchLabels:
+      {{- include "otel-metrics-collector.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "otel-metrics-collector.labels" . | nindent 8 }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+    spec:
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: otel-collector
+          image: {{ .Values.image | quote }}
+          args:
+            - --config=/conf/collector.yaml
+          env:
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "otel-metrics-collector.fullname" . }}
+                  key: endpoint
+          ports:
+            - name: health
+              containerPort: 13133
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /
+              port: health
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /
+              port: health
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: config
+              mountPath: /conf
+              readOnly: true
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "otel-metrics-collector.configName" . }}

--- a/spartan/charts/otel-metrics-collector/templates/externalsecret.yaml
+++ b/spartan/charts/otel-metrics-collector/templates/externalsecret.yaml
@@ -1,0 +1,21 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: {{ include "otel-metrics-collector.fullname" . }}
+spec:
+  refreshInterval: {{ .Values.externalSecret.refreshInterval | quote }}
+  secretStoreRef:
+    name: {{ .Values.externalSecret.secretStore.name | quote }}
+    kind: {{ .Values.externalSecret.secretStore.kind | quote }}
+  target:
+    name: {{ include "otel-metrics-collector.fullname" . }}
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      type: Opaque
+      data:
+        endpoint: {{ `{{ .url | trimSuffix "/v1/metrics" | trimSuffix "/" }}` | quote }}
+  data:
+    - secretKey: url
+      remoteRef:
+        key: {{ .Values.externalSecret.gcpSecretName | quote }}

--- a/spartan/charts/otel-metrics-collector/values.yaml
+++ b/spartan/charts/otel-metrics-collector/values.yaml
@@ -1,0 +1,28 @@
+fullnameOverride: ""
+
+externalSecret:
+  gcpSecretName: ""
+  refreshInterval: "1m"
+  secretStore:
+    name: "gcp-secret-store"
+    kind: "ClusterSecretStore"
+
+scrapeConfigs: []
+
+resourceAttributes: {}
+
+labels: {}
+
+image: "otel/opentelemetry-collector-contrib:0.154.0"
+
+replicas: 1
+
+nodeSelector: {}
+
+resources:
+  requests:
+    cpu: "50m"
+    memory: "128Mi"
+  limits:
+    cpu: "200m"
+    memory: "256Mi"

--- a/spartan/metrics/grafana/dashboards/aztec_kong.json
+++ b/spartan/metrics/grafana/dashboards/aztec_kong.json
@@ -97,7 +97,7 @@
             "uid": "${data_source}"
           },
           "editorMode": "code",
-          "expr": "count(count by (k8s_namespace_name, node_id) (kong_node_info{k8s_namespace_name=~\"$namespace\"}))",
+          "expr": "count(count by (k8s_namespace_name, node_id) (kong_node_info{network!=\"\", network!=\"ethereum\", network=~\"$network\", k8s_namespace_name=~\"$namespace\"}))",
           "instant": false,
           "legendFormat": "nodes",
           "range": true,
@@ -167,7 +167,7 @@
             "uid": "${data_source}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(kong_http_requests_total{k8s_namespace_name=~\"$namespace\", route=~\"$route\", consumer=~\"$consumer\"}[$__rate_interval]))",
+          "expr": "sum(rate(kong_http_requests_total{network!=\"\", network!=\"ethereum\", network=~\"$network\", k8s_namespace_name=~\"$namespace\", route=~\"$route\", consumer=~\"$consumer\"}[$__rate_interval]))",
           "instant": false,
           "legendFormat": "requests",
           "range": true,
@@ -245,7 +245,7 @@
             "uid": "${data_source}"
           },
           "editorMode": "code",
-          "expr": "((sum(rate(kong_http_requests_total{k8s_namespace_name=~\"$namespace\", route=~\"$route\", consumer=~\"$consumer\", code=~\"5..\"}[$__rate_interval])) or vector(0)) / clamp_min((sum(rate(kong_http_requests_total{k8s_namespace_name=~\"$namespace\", route=~\"$route\", consumer=~\"$consumer\"}[$__rate_interval])) or vector(0)), 0.000000001))",
+          "expr": "((sum(rate(kong_http_requests_total{network!=\"\", network!=\"ethereum\", network=~\"$network\", k8s_namespace_name=~\"$namespace\", route=~\"$route\", consumer=~\"$consumer\", code=~\"5..\"}[$__rate_interval])) or vector(0)) / clamp_min((sum(rate(kong_http_requests_total{network!=\"\", network!=\"ethereum\", network=~\"$network\", k8s_namespace_name=~\"$namespace\", route=~\"$route\", consumer=~\"$consumer\"}[$__rate_interval])) or vector(0)), 0.000000001))",
           "instant": false,
           "legendFormat": "5xx",
           "range": true,
@@ -323,7 +323,7 @@
             "uid": "${data_source}"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.95, sum by (le) (rate(kong_request_latency_ms_bucket{k8s_namespace_name=~\"$namespace\", route=~\"$route\"}[$__rate_interval]))) or histogram_quantile(0.95, sum by (le) (rate(kong_latency_bucket{k8s_namespace_name=~\"$namespace\", route=~\"$route\", type=\"request\"}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(kong_request_latency_ms_bucket{network!=\"\", network!=\"ethereum\", network=~\"$network\", k8s_namespace_name=~\"$namespace\", route=~\"$route\"}[$__rate_interval]))) or histogram_quantile(0.95, sum by (le) (rate(kong_latency_bucket{network!=\"\", network!=\"ethereum\", network=~\"$network\", k8s_namespace_name=~\"$namespace\", route=~\"$route\", type=\"request\"}[$__rate_interval])))",
           "instant": false,
           "legendFormat": "p95",
           "range": true,
@@ -397,7 +397,7 @@
             "uid": "${data_source}"
           },
           "editorMode": "code",
-          "expr": "sum(kong_upstream_target_health{k8s_namespace_name=~\"$namespace\", state=~\"unhealthy|dns_error\"}) or vector(0)",
+          "expr": "sum(kong_upstream_target_health{network!=\"\", network!=\"ethereum\", network=~\"$network\", k8s_namespace_name=~\"$namespace\", state=~\"unhealthy|dns_error\"}) or vector(0)",
           "instant": false,
           "legendFormat": "targets",
           "range": true,
@@ -510,7 +510,7 @@
             "uid": "${data_source}"
           },
           "editorMode": "code",
-          "expr": "sum by (route, code) (rate(kong_http_requests_total{k8s_namespace_name=~\"$namespace\", route=~\"$route\", consumer=~\"$consumer\"}[$__rate_interval]))",
+          "expr": "sum by (route, code) (rate(kong_http_requests_total{network!=\"\", network!=\"ethereum\", network=~\"$network\", k8s_namespace_name=~\"$namespace\", route=~\"$route\", consumer=~\"$consumer\"}[$__rate_interval]))",
           "instant": false,
           "legendFormat": "{{route}} {{code}}",
           "range": true,
@@ -609,7 +609,7 @@
             "uid": "${data_source}"
           },
           "editorMode": "code",
-          "expr": "sum by (consumer, code) (rate(kong_http_requests_total{k8s_namespace_name=~\"$namespace\", route=~\"$route\", consumer!=\"\", consumer=~\"$consumer\"}[$__rate_interval])) or sum by (consumer, code) (label_replace(rate(kong_http_requests_total{k8s_namespace_name=~\"$namespace\", route=~\"$route\", consumer=\"\"}[$__rate_interval]), \"consumer\", \"unauthenticated\", \"__name__\", \".*\"))",
+          "expr": "sum by (consumer, code) (rate(kong_http_requests_total{network!=\"\", network!=\"ethereum\", network=~\"$network\", k8s_namespace_name=~\"$namespace\", route=~\"$route\", consumer!=\"\", consumer=~\"$consumer\"}[$__rate_interval])) or sum by (consumer, code) (label_replace(rate(kong_http_requests_total{network!=\"\", network!=\"ethereum\", network=~\"$network\", k8s_namespace_name=~\"$namespace\", route=~\"$route\", consumer=\"\"}[$__rate_interval]), \"consumer\", \"unauthenticated\", \"__name__\", \".*\"))",
           "instant": false,
           "legendFormat": "{{consumer}} {{code}}",
           "range": true,
@@ -707,7 +707,7 @@
             "uid": "${data_source}"
           },
           "editorMode": "code",
-          "expr": "sum by (direction) (rate(kong_bandwidth_bytes_total{k8s_namespace_name=~\"$namespace\", route=~\"$route\", consumer=~\"$consumer\", direction=~\"ingress|egress\"}[$__rate_interval]))",
+          "expr": "sum by (direction) (rate(kong_bandwidth_bytes_total{network!=\"\", network!=\"ethereum\", network=~\"$network\", k8s_namespace_name=~\"$namespace\", route=~\"$route\", consumer=~\"$consumer\", direction=~\"ingress|egress\"}[$__rate_interval]))",
           "instant": false,
           "legendFormat": "{{direction}}",
           "range": true,
@@ -805,7 +805,7 @@
             "uid": "${data_source}"
           },
           "editorMode": "code",
-          "expr": "sum by (state) (kong_nginx_connections_total{k8s_namespace_name=~\"$namespace\", subsystem=\"http\", state=~\"active|reading|writing|waiting\"}) or sum by (state) (kong_nginx_http_current_connections{k8s_namespace_name=~\"$namespace\", state=~\"active|reading|writing|waiting\"})",
+          "expr": "sum by (state) (kong_nginx_connections_total{network!=\"\", network!=\"ethereum\", network=~\"$network\", k8s_namespace_name=~\"$namespace\", subsystem=\"http\", state=~\"active|reading|writing|waiting\"}) or sum by (state) (kong_nginx_http_current_connections{network!=\"\", network!=\"ethereum\", network=~\"$network\", k8s_namespace_name=~\"$namespace\", state=~\"active|reading|writing|waiting\"})",
           "instant": false,
           "legendFormat": "{{state}}",
           "range": true,
@@ -917,7 +917,7 @@
             "uid": "${data_source}"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.50, sum by (le, route) (rate(kong_request_latency_ms_bucket{k8s_namespace_name=~\"$namespace\", route=~\"$route\"}[$__rate_interval]))) or histogram_quantile(0.50, sum by (le, route) (rate(kong_latency_bucket{k8s_namespace_name=~\"$namespace\", route=~\"$route\", type=\"request\"}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.50, sum by (le, route) (rate(kong_request_latency_ms_bucket{network!=\"\", network!=\"ethereum\", network=~\"$network\", k8s_namespace_name=~\"$namespace\", route=~\"$route\"}[$__rate_interval]))) or histogram_quantile(0.50, sum by (le, route) (rate(kong_latency_bucket{network!=\"\", network!=\"ethereum\", network=~\"$network\", k8s_namespace_name=~\"$namespace\", route=~\"$route\", type=\"request\"}[$__rate_interval])))",
           "instant": false,
           "legendFormat": "{{route}} p50",
           "range": true,
@@ -929,7 +929,7 @@
             "uid": "${data_source}"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.95, sum by (le, route) (rate(kong_request_latency_ms_bucket{k8s_namespace_name=~\"$namespace\", route=~\"$route\"}[$__rate_interval]))) or histogram_quantile(0.95, sum by (le, route) (rate(kong_latency_bucket{k8s_namespace_name=~\"$namespace\", route=~\"$route\", type=\"request\"}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.95, sum by (le, route) (rate(kong_request_latency_ms_bucket{network!=\"\", network!=\"ethereum\", network=~\"$network\", k8s_namespace_name=~\"$namespace\", route=~\"$route\"}[$__rate_interval]))) or histogram_quantile(0.95, sum by (le, route) (rate(kong_latency_bucket{network!=\"\", network!=\"ethereum\", network=~\"$network\", k8s_namespace_name=~\"$namespace\", route=~\"$route\", type=\"request\"}[$__rate_interval])))",
           "instant": false,
           "legendFormat": "{{route}} p95",
           "range": true,
@@ -941,7 +941,7 @@
             "uid": "${data_source}"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.99, sum by (le, route) (rate(kong_request_latency_ms_bucket{k8s_namespace_name=~\"$namespace\", route=~\"$route\"}[$__rate_interval]))) or histogram_quantile(0.99, sum by (le, route) (rate(kong_latency_bucket{k8s_namespace_name=~\"$namespace\", route=~\"$route\", type=\"request\"}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.99, sum by (le, route) (rate(kong_request_latency_ms_bucket{network!=\"\", network!=\"ethereum\", network=~\"$network\", k8s_namespace_name=~\"$namespace\", route=~\"$route\"}[$__rate_interval]))) or histogram_quantile(0.99, sum by (le, route) (rate(kong_latency_bucket{network!=\"\", network!=\"ethereum\", network=~\"$network\", k8s_namespace_name=~\"$namespace\", route=~\"$route\", type=\"request\"}[$__rate_interval])))",
           "instant": false,
           "legendFormat": "{{route}} p99",
           "range": true,
@@ -1039,7 +1039,7 @@
             "uid": "${data_source}"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.95, sum by (le) (rate(kong_kong_latency_ms_bucket{k8s_namespace_name=~\"$namespace\", route=~\"$route\"}[$__rate_interval]))) or histogram_quantile(0.95, sum by (le) (rate(kong_latency_bucket{k8s_namespace_name=~\"$namespace\", route=~\"$route\", type=\"kong\"}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(kong_kong_latency_ms_bucket{network!=\"\", network!=\"ethereum\", network=~\"$network\", k8s_namespace_name=~\"$namespace\", route=~\"$route\"}[$__rate_interval]))) or histogram_quantile(0.95, sum by (le) (rate(kong_latency_bucket{network!=\"\", network!=\"ethereum\", network=~\"$network\", k8s_namespace_name=~\"$namespace\", route=~\"$route\", type=\"kong\"}[$__rate_interval])))",
           "instant": false,
           "legendFormat": "kong p95",
           "range": true,
@@ -1051,7 +1051,7 @@
             "uid": "${data_source}"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.95, sum by (le) (rate(kong_upstream_latency_ms_bucket{k8s_namespace_name=~\"$namespace\", route=~\"$route\"}[$__rate_interval]))) or histogram_quantile(0.95, sum by (le) (rate(kong_latency_bucket{k8s_namespace_name=~\"$namespace\", route=~\"$route\", type=\"upstream\"}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(kong_upstream_latency_ms_bucket{network!=\"\", network!=\"ethereum\", network=~\"$network\", k8s_namespace_name=~\"$namespace\", route=~\"$route\"}[$__rate_interval]))) or histogram_quantile(0.95, sum by (le) (rate(kong_latency_bucket{network!=\"\", network!=\"ethereum\", network=~\"$network\", k8s_namespace_name=~\"$namespace\", route=~\"$route\", type=\"upstream\"}[$__rate_interval])))",
           "instant": false,
           "legendFormat": "upstream p95",
           "range": true,
@@ -1167,7 +1167,7 @@
             "uid": "${data_source}"
           },
           "editorMode": "code",
-          "expr": "rate(kong_nginx_metric_errors_total{k8s_namespace_name=~\"$namespace\"}[$__rate_interval])",
+          "expr": "rate(kong_nginx_metric_errors_total{network!=\"\", network!=\"ethereum\", network=~\"$network\", k8s_namespace_name=~\"$namespace\"}[$__rate_interval])",
           "instant": false,
           "legendFormat": "metric errors",
           "range": true,
@@ -1265,7 +1265,7 @@
             "uid": "${data_source}"
           },
           "editorMode": "code",
-          "expr": "sum by (node_id) (kong_memory_workers_lua_vms_bytes{k8s_namespace_name=~\"$namespace\"})",
+          "expr": "sum by (node_id) (kong_memory_workers_lua_vms_bytes{network!=\"\", network!=\"ethereum\", network=~\"$network\", k8s_namespace_name=~\"$namespace\"})",
           "instant": false,
           "legendFormat": "{{node_id}}",
           "range": true,
@@ -1371,7 +1371,7 @@
             "uid": "${data_source}"
           },
           "editorMode": "code",
-          "expr": "100 * sum by (shared_dict) (kong_memory_lua_shared_dict_bytes{k8s_namespace_name=~\"$namespace\"}) / sum by (shared_dict) (kong_memory_lua_shared_dict_total_bytes{k8s_namespace_name=~\"$namespace\"})",
+          "expr": "100 * sum by (shared_dict) (kong_memory_lua_shared_dict_bytes{network!=\"\", network!=\"ethereum\", network=~\"$network\", k8s_namespace_name=~\"$namespace\"}) / sum by (shared_dict) (kong_memory_lua_shared_dict_total_bytes{network!=\"\", network!=\"ethereum\", network=~\"$network\", k8s_namespace_name=~\"$namespace\"})",
           "instant": false,
           "legendFormat": "{{shared_dict}}",
           "range": true,
@@ -1408,6 +1408,32 @@
         "type": "datasource"
       },
       {
+        "allValue": ".+",
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${data_source}"
+        },
+        "definition": "label_values(kong_node_info{network!=\"\", network!=\"ethereum\"}, network)",
+        "includeAll": true,
+        "label": "Aztec RPC network",
+        "multi": true,
+        "name": "network",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(kong_node_info{network!=\"\", network!=\"ethereum\"}, network)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "type": "query"
+      },
+      {
         "allValue": ".*",
         "current": {
           "selected": true,
@@ -1418,7 +1444,7 @@
           "type": "prometheus",
           "uid": "${data_source}"
         },
-        "definition": "label_values(kong_node_info,k8s_namespace_name)",
+        "definition": "label_values(kong_node_info{network!=\"\", network!=\"ethereum\", network=~\"$network\"}, k8s_namespace_name)",
         "includeAll": true,
         "label": "Kong namespace",
         "multi": true,
@@ -1426,7 +1452,7 @@
         "options": [],
         "query": {
           "qryType": 1,
-          "query": "label_values(kong_node_info,k8s_namespace_name)",
+          "query": "label_values(kong_node_info{network!=\"\", network!=\"ethereum\", network=~\"$network\"}, k8s_namespace_name)",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 1,
@@ -1444,7 +1470,7 @@
           "type": "prometheus",
           "uid": "${data_source}"
         },
-        "definition": "label_values(kong_http_requests_total{k8s_namespace_name=~\"$namespace\"}, route)",
+        "definition": "label_values(kong_http_requests_total{network!=\"\", network!=\"ethereum\", network=~\"$network\", k8s_namespace_name=~\"$namespace\"}, route)",
         "includeAll": true,
         "label": "Route",
         "multi": true,
@@ -1452,7 +1478,7 @@
         "options": [],
         "query": {
           "qryType": 1,
-          "query": "label_values(kong_http_requests_total{k8s_namespace_name=~\"$namespace\"}, route)",
+          "query": "label_values(kong_http_requests_total{network!=\"\", network!=\"ethereum\", network=~\"$network\", k8s_namespace_name=~\"$namespace\"}, route)",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 1,
@@ -1470,7 +1496,7 @@
           "type": "prometheus",
           "uid": "${data_source}"
         },
-        "definition": "label_values(kong_http_requests_total{k8s_namespace_name=~\"$namespace\", route=~\"$route\"}, consumer)",
+        "definition": "label_values(kong_http_requests_total{network!=\"\", network!=\"ethereum\", network=~\"$network\", k8s_namespace_name=~\"$namespace\", route=~\"$route\"}, consumer)",
         "includeAll": true,
         "label": "Consumer",
         "multi": true,
@@ -1478,7 +1504,7 @@
         "options": [],
         "query": {
           "qryType": 1,
-          "query": "label_values(kong_http_requests_total{k8s_namespace_name=~\"$namespace\", route=~\"$route\"}, consumer)",
+          "query": "label_values(kong_http_requests_total{network!=\"\", network!=\"ethereum\", network=~\"$network\", k8s_namespace_name=~\"$namespace\", route=~\"$route\"}, consumer)",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 1,

--- a/spartan/metrics/grafana/dashboards/l1_ethereum_rpc_nodes.json
+++ b/spartan/metrics/grafana/dashboards/l1_ethereum_rpc_nodes.json
@@ -1,0 +1,2267 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "id": 1,
+      "type": "row",
+      "title": "Gateway",
+      "collapsed": false,
+      "gridPos": {
+        "x": 0,
+        "y": 0,
+        "w": 24,
+        "h": 1
+      },
+      "panels": []
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "Gateway request rate",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${data_source}"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 1,
+        "w": 4,
+        "h": 5
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "decimals": 2,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
+          },
+          "noValue": "0"
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": ""
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "wideLayout": true,
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "showPercentChange": false,
+        "percentChangeColorMode": "standard"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${data_source}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(kong_http_requests_total{network=\"ethereum\",eth_chain=~\"$eth_chain\",eth_endpoint=~\"$eth_endpoint\",consumer=~\"$consumer\"}[$__rate_interval]))",
+          "legendFormat": "",
+          "range": true,
+          "instant": false,
+          "refId": "A"
+        }
+      ],
+      "pluginVersion": "12.3.6"
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "Gateway 5xx",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${data_source}"
+      },
+      "gridPos": {
+        "x": 4,
+        "y": 1,
+        "w": 4,
+        "h": 5
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "decimals": 3,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
+          },
+          "noValue": "0"
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": ""
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "wideLayout": true,
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "showPercentChange": false,
+        "percentChangeColorMode": "standard"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${data_source}"
+          },
+          "editorMode": "code",
+          "expr": "(sum(rate(kong_http_requests_total{network=\"ethereum\",eth_chain=~\"$eth_chain\",eth_endpoint=~\"$eth_endpoint\",consumer=~\"$consumer\",code=~\"5..\"}[$__rate_interval])) or vector(0)) / clamp_min(sum(rate(kong_http_requests_total{network=\"ethereum\",eth_chain=~\"$eth_chain\",eth_endpoint=~\"$eth_endpoint\",consumer=~\"$consumer\"}[$__rate_interval])), 0.000000001)",
+          "legendFormat": "",
+          "range": true,
+          "instant": false,
+          "refId": "A"
+        }
+      ],
+      "pluginVersion": "12.3.6"
+    },
+    {
+      "id": 4,
+      "type": "stat",
+      "title": "Request p95",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${data_source}"
+      },
+      "gridPos": {
+        "x": 8,
+        "y": 1,
+        "w": 4,
+        "h": 5
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms",
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
+          },
+          "noValue": "0"
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": ""
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "wideLayout": true,
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "showPercentChange": false,
+        "percentChangeColorMode": "standard"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${data_source}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(kong_request_latency_ms_bucket{network=\"ethereum\",eth_chain=~\"$eth_chain\",eth_endpoint=~\"$eth_endpoint\"}[$__rate_interval])))",
+          "legendFormat": "",
+          "range": true,
+          "instant": false,
+          "refId": "A"
+        }
+      ],
+      "pluginVersion": "12.3.6"
+    },
+    {
+      "id": 5,
+      "type": "stat",
+      "title": "Upstream p95",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${data_source}"
+      },
+      "gridPos": {
+        "x": 12,
+        "y": 1,
+        "w": 4,
+        "h": 5
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms",
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
+          },
+          "noValue": "0"
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": ""
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "wideLayout": true,
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "showPercentChange": false,
+        "percentChangeColorMode": "standard"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${data_source}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(kong_upstream_latency_ms_bucket{network=\"ethereum\",eth_chain=~\"$eth_chain\",eth_endpoint=~\"$eth_endpoint\"}[$__rate_interval])))",
+          "legendFormat": "",
+          "range": true,
+          "instant": false,
+          "refId": "A"
+        }
+      ],
+      "pluginVersion": "12.3.6"
+    },
+    {
+      "id": 6,
+      "type": "stat",
+      "title": "Unhealthy targets",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${data_source}"
+      },
+      "gridPos": {
+        "x": 16,
+        "y": 1,
+        "w": 4,
+        "h": 5
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
+          },
+          "noValue": "0"
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": ""
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "wideLayout": true,
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "showPercentChange": false,
+        "percentChangeColorMode": "standard"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${data_source}"
+          },
+          "editorMode": "code",
+          "expr": "sum(kong_upstream_target_health{network=\"ethereum\",state=~\"unhealthy|dns_error\"}) or vector(0)",
+          "legendFormat": "",
+          "range": true,
+          "instant": false,
+          "refId": "A"
+        }
+      ],
+      "pluginVersion": "12.3.6"
+    },
+    {
+      "id": 7,
+      "type": "stat",
+      "title": "Kong nodes",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${data_source}"
+      },
+      "gridPos": {
+        "x": 20,
+        "y": 1,
+        "w": 4,
+        "h": 5
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
+          },
+          "noValue": "0"
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": ""
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "wideLayout": true,
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "showPercentChange": false,
+        "percentChangeColorMode": "standard"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${data_source}"
+          },
+          "editorMode": "code",
+          "expr": "count(count by (node_id) (kong_node_info{network=\"ethereum\"}))",
+          "legendFormat": "",
+          "range": true,
+          "instant": false,
+          "refId": "A"
+        }
+      ],
+      "pluginVersion": "12.3.6"
+    },
+    {
+      "id": 8,
+      "type": "timeseries",
+      "title": "Request rate by endpoint and status",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${data_source}"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 6,
+        "w": 12,
+        "h": 8
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "color": {
+            "mode": "palette-classic"
+          },
+          "decimals": 2
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${data_source}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (eth_chain, eth_endpoint, code) (rate(kong_http_requests_total{network=\"ethereum\",eth_chain=~\"$eth_chain\",eth_endpoint=~\"$eth_endpoint\",consumer=~\"$consumer\"}[$__rate_interval]))",
+          "legendFormat": "{{eth_chain}} {{eth_endpoint}} {{code}}",
+          "range": true,
+          "instant": false,
+          "refId": "A"
+        }
+      ],
+      "pluginVersion": "12.3.6"
+    },
+    {
+      "id": 9,
+      "type": "timeseries",
+      "title": "Request rate by consumer",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${data_source}"
+      },
+      "gridPos": {
+        "x": 12,
+        "y": 6,
+        "w": 12,
+        "h": 8
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "color": {
+            "mode": "palette-classic"
+          },
+          "decimals": 2
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${data_source}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (consumer, code) (rate(kong_http_requests_total{network=\"ethereum\",eth_chain=~\"$eth_chain\",eth_endpoint=~\"$eth_endpoint\",consumer!=\"\",consumer=~\"$consumer\"}[$__rate_interval])) or sum by (consumer, code) (label_replace(rate(kong_http_requests_total{network=\"ethereum\",eth_chain=~\"$eth_chain\",eth_endpoint=~\"$eth_endpoint\",consumer=\"\"}[$__rate_interval]), \"consumer\", \"unauthenticated\", \"__name__\", \".*\"))",
+          "legendFormat": "{{consumer}} {{code}}",
+          "range": true,
+          "instant": false,
+          "refId": "A"
+        }
+      ],
+      "pluginVersion": "12.3.6"
+    },
+    {
+      "id": 10,
+      "type": "timeseries",
+      "title": "Gateway latency",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${data_source}"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 14,
+        "w": 12,
+        "h": 8
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms",
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${data_source}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum by (le, eth_endpoint) (rate(kong_request_latency_ms_bucket{network=\"ethereum\",eth_chain=~\"$eth_chain\",eth_endpoint=~\"$eth_endpoint\"}[$__rate_interval])))",
+          "legendFormat": "p50 {{eth_endpoint}}",
+          "range": true,
+          "instant": false,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${data_source}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by (le, eth_endpoint) (rate(kong_request_latency_ms_bucket{network=\"ethereum\",eth_chain=~\"$eth_chain\",eth_endpoint=~\"$eth_endpoint\"}[$__rate_interval])))",
+          "legendFormat": "p95 {{eth_endpoint}}",
+          "range": true,
+          "instant": false,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${data_source}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by (le, eth_endpoint) (rate(kong_request_latency_ms_bucket{network=\"ethereum\",eth_chain=~\"$eth_chain\",eth_endpoint=~\"$eth_endpoint\"}[$__rate_interval])))",
+          "legendFormat": "p99 {{eth_endpoint}}",
+          "range": true,
+          "instant": false,
+          "refId": "A"
+        }
+      ],
+      "pluginVersion": "12.3.6"
+    },
+    {
+      "id": 11,
+      "type": "timeseries",
+      "title": "Bandwidth",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${data_source}"
+      },
+      "gridPos": {
+        "x": 12,
+        "y": 14,
+        "w": 12,
+        "h": 8
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "Bps",
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${data_source}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (eth_endpoint, direction) (rate(kong_bandwidth_bytes_total{network=\"ethereum\",eth_chain=~\"$eth_chain\",eth_endpoint=~\"$eth_endpoint\",direction=~\"ingress|egress\"}[$__rate_interval]))",
+          "legendFormat": "{{eth_endpoint}} {{direction}}",
+          "range": true,
+          "instant": false,
+          "refId": "A"
+        }
+      ],
+      "pluginVersion": "12.3.6"
+    },
+    {
+      "id": 12,
+      "type": "row",
+      "title": "Reth",
+      "collapsed": false,
+      "gridPos": {
+        "x": 0,
+        "y": 22,
+        "w": 24,
+        "h": 1
+      },
+      "panels": []
+    },
+    {
+      "id": 13,
+      "type": "stat",
+      "title": "Reth scrape up",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${data_source}"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 23,
+        "w": 4,
+        "h": 5
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
+          },
+          "noValue": "0"
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": ""
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "wideLayout": true,
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "showPercentChange": false,
+        "percentChangeColorMode": "standard"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${data_source}"
+          },
+          "editorMode": "code",
+          "expr": "min(up{network=\"ethereum\",eth_chain=~\"$eth_chain\",eth_client=\"reth\"})",
+          "legendFormat": "",
+          "range": true,
+          "instant": false,
+          "refId": "A"
+        }
+      ],
+      "pluginVersion": "12.3.6"
+    },
+    {
+      "id": 14,
+      "type": "stat",
+      "title": "Connected peers",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${data_source}"
+      },
+      "gridPos": {
+        "x": 4,
+        "y": 23,
+        "w": 4,
+        "h": 5
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
+          },
+          "noValue": "0"
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": ""
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "wideLayout": true,
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "showPercentChange": false,
+        "percentChangeColorMode": "standard"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${data_source}"
+          },
+          "editorMode": "code",
+          "expr": "max(reth_network_connected_peers{network=\"ethereum\",eth_chain=~\"$eth_chain\",eth_client=\"reth\"})",
+          "legendFormat": "",
+          "range": true,
+          "instant": false,
+          "refId": "A"
+        }
+      ],
+      "pluginVersion": "12.3.6"
+    },
+    {
+      "id": 15,
+      "type": "stat",
+      "title": "Headers downloaded",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${data_source}"
+      },
+      "gridPos": {
+        "x": 8,
+        "y": 23,
+        "w": 4,
+        "h": 5
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
+          },
+          "noValue": "0"
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": ""
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "wideLayout": true,
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "showPercentChange": false,
+        "percentChangeColorMode": "standard"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${data_source}"
+          },
+          "editorMode": "code",
+          "expr": "max(reth_downloaders_headers_total_downloaded{network=\"ethereum\",eth_chain=~\"$eth_chain\",eth_client=\"reth\"})",
+          "legendFormat": "",
+          "range": true,
+          "instant": false,
+          "refId": "A"
+        }
+      ],
+      "pluginVersion": "12.3.6"
+    },
+    {
+      "id": 16,
+      "type": "stat",
+      "title": "Bodies downloaded",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${data_source}"
+      },
+      "gridPos": {
+        "x": 12,
+        "y": 23,
+        "w": 4,
+        "h": 5
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
+          },
+          "noValue": "0"
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": ""
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "wideLayout": true,
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "showPercentChange": false,
+        "percentChangeColorMode": "standard"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${data_source}"
+          },
+          "editorMode": "code",
+          "expr": "max(reth_downloaders_bodies_total_downloaded{network=\"ethereum\",eth_chain=~\"$eth_chain\",eth_client=\"reth\"})",
+          "legendFormat": "",
+          "range": true,
+          "instant": false,
+          "refId": "A"
+        }
+      ],
+      "pluginVersion": "12.3.6"
+    },
+    {
+      "id": 17,
+      "type": "stat",
+      "title": "Txpool total",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${data_source}"
+      },
+      "gridPos": {
+        "x": 16,
+        "y": 23,
+        "w": 4,
+        "h": 5
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
+          },
+          "noValue": "0"
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": ""
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "wideLayout": true,
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "showPercentChange": false,
+        "percentChangeColorMode": "standard"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${data_source}"
+          },
+          "editorMode": "code",
+          "expr": "max(reth_transaction_pool_total_transactions{network=\"ethereum\",eth_chain=~\"$eth_chain\",eth_client=\"reth\"})",
+          "legendFormat": "",
+          "range": true,
+          "instant": false,
+          "refId": "A"
+        }
+      ],
+      "pluginVersion": "12.3.6"
+    },
+    {
+      "id": 18,
+      "type": "stat",
+      "title": "Base fee",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${data_source}"
+      },
+      "gridPos": {
+        "x": 20,
+        "y": 23,
+        "w": 4,
+        "h": 5
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
+          },
+          "noValue": "0"
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": ""
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "wideLayout": true,
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "showPercentChange": false,
+        "percentChangeColorMode": "standard"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${data_source}"
+          },
+          "editorMode": "code",
+          "expr": "max(reth_transaction_pool_base_fee{network=\"ethereum\",eth_chain=~\"$eth_chain\",eth_client=\"reth\"})",
+          "legendFormat": "",
+          "range": true,
+          "instant": false,
+          "refId": "A"
+        }
+      ],
+      "pluginVersion": "12.3.6"
+    },
+    {
+      "id": 19,
+      "type": "timeseries",
+      "title": "RPC calls by method",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${data_source}"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 28,
+        "w": 12,
+        "h": 8
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${data_source}"
+          },
+          "editorMode": "code",
+          "expr": "topk(12, sum by (method) (rate(reth_rpc_server_calls_started_total{network=\"ethereum\",eth_chain=~\"$eth_chain\",eth_client=\"reth\"}[$__rate_interval])))",
+          "legendFormat": "{{method}}",
+          "range": true,
+          "instant": false,
+          "refId": "A"
+        }
+      ],
+      "pluginVersion": "12.3.6"
+    },
+    {
+      "id": 20,
+      "type": "timeseries",
+      "title": "Downloader progress rate",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${data_source}"
+      },
+      "gridPos": {
+        "x": 12,
+        "y": 28,
+        "w": 12,
+        "h": 8
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${data_source}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (eth_chain) (rate(reth_downloaders_headers_total_downloaded{network=\"ethereum\",eth_chain=~\"$eth_chain\",eth_client=\"reth\"}[$__rate_interval]))",
+          "legendFormat": "headers {{eth_chain}}",
+          "range": true,
+          "instant": false,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${data_source}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (eth_chain) (rate(reth_downloaders_bodies_total_downloaded{network=\"ethereum\",eth_chain=~\"$eth_chain\",eth_client=\"reth\"}[$__rate_interval]))",
+          "legendFormat": "bodies {{eth_chain}}",
+          "range": true,
+          "instant": false,
+          "refId": "A"
+        }
+      ],
+      "pluginVersion": "12.3.6"
+    },
+    {
+      "id": 21,
+      "type": "timeseries",
+      "title": "Txpool by subpool",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${data_source}"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 36,
+        "w": 12,
+        "h": 8
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${data_source}"
+          },
+          "editorMode": "code",
+          "expr": "max(reth_transaction_pool_pending_pool_transactions{network=\"ethereum\",eth_chain=~\"$eth_chain\",eth_client=\"reth\"})",
+          "legendFormat": "pending",
+          "range": true,
+          "instant": false,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${data_source}"
+          },
+          "editorMode": "code",
+          "expr": "max(reth_transaction_pool_basefee_pool_transactions{network=\"ethereum\",eth_chain=~\"$eth_chain\",eth_client=\"reth\"})",
+          "legendFormat": "basefee",
+          "range": true,
+          "instant": false,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${data_source}"
+          },
+          "editorMode": "code",
+          "expr": "max(reth_transaction_pool_queued_pool_transactions{network=\"ethereum\",eth_chain=~\"$eth_chain\",eth_client=\"reth\"})",
+          "legendFormat": "queued",
+          "range": true,
+          "instant": false,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${data_source}"
+          },
+          "editorMode": "code",
+          "expr": "max(reth_transaction_pool_blob_pool_transactions{network=\"ethereum\",eth_chain=~\"$eth_chain\",eth_client=\"reth\"})",
+          "legendFormat": "blob",
+          "range": true,
+          "instant": false,
+          "refId": "A"
+        }
+      ],
+      "pluginVersion": "12.3.6"
+    },
+    {
+      "id": 22,
+      "type": "timeseries",
+      "title": "Engine sync/forkchoice responses",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${data_source}"
+      },
+      "gridPos": {
+        "x": 12,
+        "y": 36,
+        "w": 12,
+        "h": 8
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${data_source}"
+          },
+          "editorMode": "code",
+          "expr": "rate(reth_consensus_engine_beacon_forkchoice_updated_valid{network=\"ethereum\",eth_chain=~\"$eth_chain\",eth_client=\"reth\"}[$__rate_interval])",
+          "legendFormat": "forkchoice valid",
+          "range": true,
+          "instant": false,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${data_source}"
+          },
+          "editorMode": "code",
+          "expr": "rate(reth_consensus_engine_beacon_forkchoice_updated_syncing{network=\"ethereum\",eth_chain=~\"$eth_chain\",eth_client=\"reth\"}[$__rate_interval])",
+          "legendFormat": "forkchoice syncing",
+          "range": true,
+          "instant": false,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${data_source}"
+          },
+          "editorMode": "code",
+          "expr": "rate(reth_consensus_engine_beacon_new_payload_valid{network=\"ethereum\",eth_chain=~\"$eth_chain\",eth_client=\"reth\"}[$__rate_interval])",
+          "legendFormat": "payload valid",
+          "range": true,
+          "instant": false,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${data_source}"
+          },
+          "editorMode": "code",
+          "expr": "rate(reth_consensus_engine_beacon_new_payload_syncing{network=\"ethereum\",eth_chain=~\"$eth_chain\",eth_client=\"reth\"}[$__rate_interval])",
+          "legendFormat": "payload syncing",
+          "range": true,
+          "instant": false,
+          "refId": "A"
+        }
+      ],
+      "pluginVersion": "12.3.6"
+    },
+    {
+      "id": 23,
+      "type": "row",
+      "title": "Lighthouse",
+      "collapsed": false,
+      "gridPos": {
+        "x": 0,
+        "y": 44,
+        "w": 24,
+        "h": 1
+      },
+      "panels": []
+    },
+    {
+      "id": 24,
+      "type": "stat",
+      "title": "Lighthouse scrape up",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${data_source}"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 45,
+        "w": 4,
+        "h": 5
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
+          },
+          "noValue": "0"
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": ""
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "wideLayout": true,
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "showPercentChange": false,
+        "percentChangeColorMode": "standard"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${data_source}"
+          },
+          "editorMode": "code",
+          "expr": "min(up{network=\"ethereum\",eth_chain=~\"$eth_chain\",eth_client=\"lighthouse\"})",
+          "legendFormat": "",
+          "range": true,
+          "instant": false,
+          "refId": "A"
+        }
+      ],
+      "pluginVersion": "12.3.6"
+    },
+    {
+      "id": 25,
+      "type": "stat",
+      "title": "Synced",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${data_source}"
+      },
+      "gridPos": {
+        "x": 4,
+        "y": 45,
+        "w": 4,
+        "h": 5
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
+          },
+          "noValue": "0"
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": ""
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "wideLayout": true,
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "showPercentChange": false,
+        "percentChangeColorMode": "standard"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${data_source}"
+          },
+          "editorMode": "code",
+          "expr": "max(sync_eth2_synced{network=\"ethereum\",eth_chain=~\"$eth_chain\",eth_client=\"lighthouse\"})",
+          "legendFormat": "",
+          "range": true,
+          "instant": false,
+          "refId": "A"
+        }
+      ],
+      "pluginVersion": "12.3.6"
+    },
+    {
+      "id": 26,
+      "type": "stat",
+      "title": "Head slot",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${data_source}"
+      },
+      "gridPos": {
+        "x": 8,
+        "y": 45,
+        "w": 4,
+        "h": 5
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
+          },
+          "noValue": "0"
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": ""
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "wideLayout": true,
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "showPercentChange": false,
+        "percentChangeColorMode": "standard"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${data_source}"
+          },
+          "editorMode": "code",
+          "expr": "max(beacon_head_slot{network=\"ethereum\",eth_chain=~\"$eth_chain\",eth_client=\"lighthouse\"})",
+          "legendFormat": "",
+          "range": true,
+          "instant": false,
+          "refId": "A"
+        }
+      ],
+      "pluginVersion": "12.3.6"
+    },
+    {
+      "id": 27,
+      "type": "stat",
+      "title": "Finalized epoch",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${data_source}"
+      },
+      "gridPos": {
+        "x": 12,
+        "y": 45,
+        "w": 4,
+        "h": 5
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
+          },
+          "noValue": "0"
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": ""
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "wideLayout": true,
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "showPercentChange": false,
+        "percentChangeColorMode": "standard"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${data_source}"
+          },
+          "editorMode": "code",
+          "expr": "max(beacon_finalized_epoch{network=\"ethereum\",eth_chain=~\"$eth_chain\",eth_client=\"lighthouse\"})",
+          "legendFormat": "",
+          "range": true,
+          "instant": false,
+          "refId": "A"
+        }
+      ],
+      "pluginVersion": "12.3.6"
+    },
+    {
+      "id": 28,
+      "type": "stat",
+      "title": "Slots/sec",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${data_source}"
+      },
+      "gridPos": {
+        "x": 16,
+        "y": 45,
+        "w": 4,
+        "h": 5
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "decimals": 2,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
+          },
+          "noValue": "0"
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": ""
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "wideLayout": true,
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "showPercentChange": false,
+        "percentChangeColorMode": "standard"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${data_source}"
+          },
+          "editorMode": "code",
+          "expr": "max(sync_slots_per_second{network=\"ethereum\",eth_chain=~\"$eth_chain\",eth_client=\"lighthouse\"})",
+          "legendFormat": "",
+          "range": true,
+          "instant": false,
+          "refId": "A"
+        }
+      ],
+      "pluginVersion": "12.3.6"
+    },
+    {
+      "id": 29,
+      "type": "stat",
+      "title": "Peers",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${data_source}"
+      },
+      "gridPos": {
+        "x": 20,
+        "y": 45,
+        "w": 4,
+        "h": 5
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
+          },
+          "noValue": "0"
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": ""
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "wideLayout": true,
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "showPercentChange": false,
+        "percentChangeColorMode": "standard"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${data_source}"
+          },
+          "editorMode": "code",
+          "expr": "max(libp2p_peers{network=\"ethereum\",eth_chain=~\"$eth_chain\",eth_client=\"lighthouse\"})",
+          "legendFormat": "",
+          "range": true,
+          "instant": false,
+          "refId": "A"
+        }
+      ],
+      "pluginVersion": "12.3.6"
+    },
+    {
+      "id": 30,
+      "type": "timeseries",
+      "title": "Beacon chain head",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${data_source}"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 50,
+        "w": 12,
+        "h": 8
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${data_source}"
+          },
+          "editorMode": "code",
+          "expr": "max by (eth_chain) (beacon_head_slot{network=\"ethereum\",eth_chain=~\"$eth_chain\",eth_client=\"lighthouse\"})",
+          "legendFormat": "head {{eth_chain}}",
+          "range": true,
+          "instant": false,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${data_source}"
+          },
+          "editorMode": "code",
+          "expr": "max by (eth_chain) (beacon_head_state_finalized_epoch{network=\"ethereum\",eth_chain=~\"$eth_chain\",eth_client=\"lighthouse\"})",
+          "legendFormat": "finalized epoch {{eth_chain}}",
+          "range": true,
+          "instant": false,
+          "refId": "A"
+        }
+      ],
+      "pluginVersion": "12.3.6"
+    },
+    {
+      "id": 31,
+      "type": "timeseries",
+      "title": "Lighthouse bandwidth",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${data_source}"
+      },
+      "gridPos": {
+        "x": 12,
+        "y": 50,
+        "w": 12,
+        "h": 8
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "Bps",
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${data_source}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (direction) (rate(libp2p_bandwidth_bytes_total{network=\"ethereum\",eth_chain=~\"$eth_chain\",eth_client=\"lighthouse\"}[$__rate_interval]))",
+          "legendFormat": "{{direction}}",
+          "range": true,
+          "instant": false,
+          "refId": "A"
+        }
+      ],
+      "pluginVersion": "12.3.6"
+    },
+    {
+      "id": 32,
+      "type": "timeseries",
+      "title": "Lighthouse storage and memory",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${data_source}"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 58,
+        "w": 12,
+        "h": 8
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${data_source}"
+          },
+          "editorMode": "code",
+          "expr": "max by (eth_chain) (store_disk_db_size{network=\"ethereum\",eth_chain=~\"$eth_chain\",eth_client=\"lighthouse\"})",
+          "legendFormat": "db {{eth_chain}}",
+          "range": true,
+          "instant": false,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${data_source}"
+          },
+          "editorMode": "code",
+          "expr": "max by (eth_chain) (process_resident_memory_bytes{network=\"ethereum\",eth_chain=~\"$eth_chain\",eth_client=\"lighthouse\"})",
+          "legendFormat": "rss {{eth_chain}}",
+          "range": true,
+          "instant": false,
+          "refId": "A"
+        }
+      ],
+      "pluginVersion": "12.3.6"
+    },
+    {
+      "id": 33,
+      "type": "timeseries",
+      "title": "Gossipsub messages",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${data_source}"
+      },
+      "gridPos": {
+        "x": 12,
+        "y": 58,
+        "w": 12,
+        "h": 8
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${data_source}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (msg_type) (rate(gossipsub_topic_msg_recv_counts_total{network=\"ethereum\",eth_chain=~\"$eth_chain\",eth_client=\"lighthouse\"}[$__rate_interval]))",
+          "legendFormat": "recv {{msg_type}}",
+          "range": true,
+          "instant": false,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${data_source}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(gossipsub_topic_msg_sent_counts_total{network=\"ethereum\",eth_chain=~\"$eth_chain\",eth_client=\"lighthouse\"}[$__rate_interval]))",
+          "legendFormat": "sent",
+          "range": true,
+          "instant": false,
+          "refId": "A"
+        }
+      ],
+      "pluginVersion": "12.3.6"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 41,
+  "tags": [
+    "ethereum",
+    "l1",
+    "kong",
+    "reth",
+    "lighthouse"
+  ],
+  "templating": {
+    "list": [
+      {
+        "name": "data_source",
+        "type": "datasource",
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "includeAll": false,
+        "options": [],
+        "current": {
+          "selected": false,
+          "text": "default",
+          "value": "default"
+        }
+      },
+      {
+        "name": "eth_chain",
+        "label": "chain",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${data_source}"
+        },
+        "definition": "label_values(up{network=\"ethereum\",eth_chain!=\"\",component=\"ethereum-node\"}, eth_chain)",
+        "query": {
+          "qryType": 1,
+          "query": "label_values(up{network=\"ethereum\",eth_chain!=\"\",component=\"ethereum-node\"}, eth_chain)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "includeAll": true,
+        "allValue": ".*",
+        "multi": true,
+        "sort": 1,
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        }
+      },
+      {
+        "name": "eth_endpoint",
+        "label": "endpoint",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${data_source}"
+        },
+        "definition": "label_values(up{network=\"ethereum\",eth_chain=~\"$eth_chain\",eth_endpoint!=\"\",component=\"ethereum-node\"}, eth_endpoint)",
+        "query": {
+          "qryType": 1,
+          "query": "label_values(up{network=\"ethereum\",eth_chain=~\"$eth_chain\",eth_endpoint!=\"\",component=\"ethereum-node\"}, eth_endpoint)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "includeAll": true,
+        "allValue": ".*",
+        "multi": true,
+        "sort": 1,
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        }
+      },
+      {
+        "name": "consumer",
+        "label": "consumer",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${data_source}"
+        },
+        "definition": "label_values(kong_http_requests_total{network=\"ethereum\",eth_chain=~\"$eth_chain\",eth_endpoint=~\"$eth_endpoint\"}, consumer)",
+        "query": {
+          "qryType": 1,
+          "query": "label_values(kong_http_requests_total{network=\"ethereum\",eth_chain=~\"$eth_chain\",eth_endpoint=~\"$eth_endpoint\"}, consumer)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "includeAll": true,
+        "allValue": ".*",
+        "multi": true,
+        "sort": 1,
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        }
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Ethereum RPC Nodes",
+  "uid": "l1-ethereum-rpc-nodes",
+  "version": 1,
+  "weekStart": ""
+}

--- a/spartan/terraform/deploy-aztec-infra/main.tf
+++ b/spartan/terraform/deploy-aztec-infra/main.tf
@@ -799,22 +799,15 @@ module "rpc_gateway" {
   RELEASE_PREFIX     = var.RELEASE_PREFIX
   CONSUMER_NAMESPACE = var.NAMESPACE
 
-  KONG_NAMESPACE                                   = var.RPC_GATEWAY_KONG_NAMESPACE != "" ? var.RPC_GATEWAY_KONG_NAMESPACE : var.NAMESPACE
-  KONG_HELM_RELEASE_NAME                           = var.RPC_GATEWAY_KONG_HELM_RELEASE_NAME
-  KONG_HELM_CHART_VERSION                          = var.RPC_GATEWAY_KONG_HELM_CHART_VERSION
-  KONG_INGRESS_CLASS                               = var.RPC_GATEWAY_KONG_INGRESS_CLASS
-  KONG_PROXY_SERVICE_TYPE                          = var.RPC_GATEWAY_KONG_PROXY_SERVICE_TYPE
-  KONG_PROXY_SERVICE_ANNOTATIONS                   = var.RPC_GATEWAY_KONG_PROXY_SERVICE_ANNOTATIONS
-  KONG_EXTRA_HELM_VALUES                           = var.RPC_GATEWAY_KONG_EXTRA_HELM_VALUES
-  KONG_SERVICE_MONITOR_ENABLED                     = var.RPC_GATEWAY_KONG_SERVICE_MONITOR_ENABLED
-  KONG_METRICS_SERVICE_ENABLED                     = var.RPC_GATEWAY_KONG_METRICS_SERVICE_ENABLED
-  KONG_METRICS_SERVICE_NAME                        = var.RPC_GATEWAY_KONG_METRICS_SERVICE_NAME
-  KONG_METRICS_SERVICE_TYPE                        = var.RPC_GATEWAY_KONG_METRICS_SERVICE_TYPE
-  KONG_METRICS_SERVICE_ANNOTATIONS                 = var.RPC_GATEWAY_KONG_METRICS_SERVICE_ANNOTATIONS
-  KONG_METRICS_SERVICE_LOAD_BALANCER_IP            = var.RPC_GATEWAY_KONG_METRICS_SERVICE_LOAD_BALANCER_IP
-  KONG_METRICS_SERVICE_LOAD_BALANCER_SOURCE_RANGES = var.RPC_GATEWAY_KONG_METRICS_SERVICE_LOAD_BALANCER_SOURCE_RANGES
-  KONG_METRICS_SERVICE_EXTERNAL_TRAFFIC_POLICY     = var.RPC_GATEWAY_KONG_METRICS_SERVICE_EXTERNAL_TRAFFIC_POLICY
-  KONG_OTEL_METRICS_GCP_SECRET_NAME                = var.RPC_GATEWAY_KONG_OTEL_METRICS_GCP_SECRET_NAME
+  KONG_NAMESPACE                 = var.RPC_GATEWAY_KONG_NAMESPACE != "" ? var.RPC_GATEWAY_KONG_NAMESPACE : var.NAMESPACE
+  KONG_HELM_RELEASE_NAME         = var.RPC_GATEWAY_KONG_HELM_RELEASE_NAME
+  KONG_HELM_CHART_VERSION        = var.RPC_GATEWAY_KONG_HELM_CHART_VERSION
+  KONG_INGRESS_CLASS             = var.RPC_GATEWAY_KONG_INGRESS_CLASS
+  KONG_PROXY_SERVICE_TYPE        = var.RPC_GATEWAY_KONG_PROXY_SERVICE_TYPE
+  KONG_PROXY_SERVICE_ANNOTATIONS = var.RPC_GATEWAY_KONG_PROXY_SERVICE_ANNOTATIONS
+  KONG_EXTRA_HELM_VALUES         = var.RPC_GATEWAY_KONG_EXTRA_HELM_VALUES
+  KONG_SERVICE_MONITOR_ENABLED   = var.RPC_GATEWAY_KONG_SERVICE_MONITOR_ENABLED
+  KONG_METRICS_SERVICE_ENABLED   = var.RPC_GATEWAY_KONG_OTEL_METRICS_GCP_SECRET_NAME != ""
 
   API_KEY_HEADER_NAME              = var.RPC_GATEWAY_API_KEY_HEADER_NAME
   ROUTES                           = local.rpc_gateway_routes
@@ -833,4 +826,40 @@ module "rpc_gateway" {
   GCP_MANAGED_CERTIFICATE_ENABLED = var.RPC_GATEWAY_GCP_MANAGED_CERTIFICATE_ENABLED
 
   depends_on = [helm_release.releases]
+}
+
+module "rpc_gateway_metrics_collector" {
+  count = var.RPC_GATEWAY_ENABLED && var.RPC_GATEWAY_KONG_OTEL_METRICS_GCP_SECRET_NAME != "" ? 1 : 0
+
+  source = "../modules/otel-metrics-collector"
+
+  providers = {
+    helm = helm.gke-cluster
+  }
+
+  NAMESPACE                               = module.rpc_gateway[0].metrics_service_namespace
+  RELEASE_NAME                            = "${var.RELEASE_PREFIX}-rpc-kong-otel-collector"
+  OTEL_COLLECTOR_ENDPOINT_GCP_SECRET_NAME = var.RPC_GATEWAY_KONG_OTEL_METRICS_GCP_SECRET_NAME
+  SCRAPE_CONFIGS = [
+    {
+      job_name        = "kong"
+      scrape_interval = "15s"
+      metrics_path    = "/metrics"
+      targets         = ["${module.rpc_gateway[0].metrics_service_name}.${module.rpc_gateway[0].metrics_service_namespace}.svc.cluster.local:${module.rpc_gateway[0].metrics_service_port}"]
+      labels = {
+        component = "kong"
+        network   = var.RELEASE_PREFIX
+      }
+    }
+  ]
+  RESOURCE_ATTRIBUTES = {
+    "service.name"    = "${var.RELEASE_PREFIX}-rpc-kong"
+    "network"         = var.RELEASE_PREFIX
+    "aztec.component" = "kong"
+  }
+  EXTERNAL_SECRET_STORE_NAME       = var.RPC_GATEWAY_EXTERNAL_SECRET_STORE_NAME
+  EXTERNAL_SECRET_STORE_KIND       = var.RPC_GATEWAY_EXTERNAL_SECRET_STORE_KIND
+  EXTERNAL_SECRET_REFRESH_INTERVAL = var.RPC_GATEWAY_EXTERNAL_SECRET_REFRESH_INTERVAL
+
+  depends_on = [module.rpc_gateway]
 }

--- a/spartan/terraform/deploy-aztec-infra/variables.tf
+++ b/spartan/terraform/deploy-aztec-infra/variables.tf
@@ -792,50 +792,8 @@ variable "RPC_GATEWAY_KONG_SERVICE_MONITOR_ENABLED" {
   default     = false
 }
 
-variable "RPC_GATEWAY_KONG_METRICS_SERVICE_ENABLED" {
-  description = "Whether to expose Kong's /metrics endpoint through a dedicated Service."
-  type        = bool
-  default     = false
-}
-
-variable "RPC_GATEWAY_KONG_METRICS_SERVICE_NAME" {
-  description = "Optional Kong metrics Service name. Defaults to RELEASE_PREFIX-kong-metrics."
-  type        = string
-  default     = ""
-}
-
-variable "RPC_GATEWAY_KONG_METRICS_SERVICE_TYPE" {
-  description = "Kong metrics Service type."
-  type        = string
-  default     = "ClusterIP"
-}
-
-variable "RPC_GATEWAY_KONG_METRICS_SERVICE_ANNOTATIONS" {
-  description = "Annotations applied to the Kong metrics Service."
-  type        = map(string)
-  default     = {}
-}
-
-variable "RPC_GATEWAY_KONG_METRICS_SERVICE_LOAD_BALANCER_IP" {
-  description = "Optional static IP assigned to the Kong metrics LoadBalancer Service."
-  type        = string
-  default     = ""
-}
-
-variable "RPC_GATEWAY_KONG_METRICS_SERVICE_LOAD_BALANCER_SOURCE_RANGES" {
-  description = "Optional source CIDRs allowed to reach the Kong metrics Service."
-  type        = list(string)
-  default     = []
-}
-
-variable "RPC_GATEWAY_KONG_METRICS_SERVICE_EXTERNAL_TRAFFIC_POLICY" {
-  description = "External traffic policy for the Kong metrics Service."
-  type        = string
-  default     = null
-}
-
 variable "RPC_GATEWAY_KONG_OTEL_METRICS_GCP_SECRET_NAME" {
-  description = "GCP Secret Manager secret name containing the central OTLP/HTTP collector endpoint. When empty, no local Kong metrics collector is deployed."
+  description = "GCP Secret Manager secret name containing the central OTLP/HTTP collector endpoint. When empty, no local Kong metrics collector is deployed by deploy-aztec-infra."
   type        = string
   default     = ""
 }

--- a/spartan/terraform/deploy-ethereum/main.tf
+++ b/spartan/terraform/deploy-ethereum/main.tf
@@ -1,0 +1,347 @@
+terraform {
+  backend "gcs" {
+    bucket = "aztec-terraform"
+    prefix = "aztec-gke-public/ethereum/deploy-ethereum/terraform.tfstate"
+  }
+
+  required_providers {
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 3.1.2"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 3.1.0"
+    }
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "kubernetes" {
+  alias          = "gke-cluster"
+  config_path    = "~/.kube/config"
+  config_context = local.k8s_cluster_context
+}
+
+provider "helm" {
+  alias = "gke-cluster"
+  kubernetes = {
+    config_path    = "~/.kube/config"
+    config_context = local.k8s_cluster_context
+  }
+}
+
+provider "google" {
+  project = local.gcp_project_id
+  region  = local.gcp_region
+}
+
+locals {
+  gcp_project_id      = "testnet-440309"
+  gcp_region          = "us-west1"
+  k8s_cluster_context = "gke_testnet-440309_us-west1-a_aztec-gke-public"
+
+  namespace           = "ethereum"
+  release_prefix      = "ethereum"
+  api_key_header_name = "apikey"
+  storage_class_name  = "standard-rwo"
+
+  ethereum_chains = {
+    sepolia = {
+      checkpoint_sync_url = "https://checkpoint-sync.sepolia.ethpandaops.io"
+      reth_p2p_port       = 32200
+      lighthouse_p2p_port = 32201
+      reth_storage        = "1.5Ti"
+      lighthouse_storage  = "256Gi"
+      reth_resources = {
+        requests = { cpu = "1", memory = "12Gi" }
+        limits   = { cpu = "4", memory = "24Gi" }
+      }
+      lighthouse_resources = {
+        requests = { cpu = "1", memory = "8Gi" }
+        limits   = { cpu = "4", memory = "16Gi" }
+      }
+      execution_hosts       = ["json-rpc.eth-sepolia.rpc.aztec-labs.com"]
+      beacon_hosts          = ["beacon.eth-sepolia.rpc.aztec-labs.com"]
+      reth_extra_args       = []
+      lighthouse_extra_args = []
+    }
+    mainnet = {
+      checkpoint_sync_url = "https://mainnet.checkpoint.sigp.io"
+      reth_p2p_port       = 32300
+      lighthouse_p2p_port = 32301
+      reth_storage        = "2.5Ti"
+      lighthouse_storage  = "256Gi"
+      reth_resources = {
+        requests = { cpu = "1", memory = "32Gi" }
+        limits   = { cpu = "8", memory = "64Gi" }
+      }
+      lighthouse_resources = {
+        requests = { cpu = "1", memory = "12Gi" }
+        limits   = { cpu = "8", memory = "24Gi" }
+      }
+      execution_hosts       = ["json-rpc.eth-mainnet.rpc.aztec-labs.com"]
+      beacon_hosts          = ["beacon.eth-mainnet.rpc.aztec-labs.com"]
+      reth_extra_args       = []
+      lighthouse_extra_args = []
+    }
+  }
+
+  simple_consumers = {
+    for secret_name in var.API_KEY_SECRET_NAMES : secret_name => {
+      username                       = secret_name
+      gcp_secret_manager_secret_name = secret_name
+      rate_limit_minute              = 0
+    }
+  }
+
+  consumers = merge(local.simple_consumers, var.CONSUMERS)
+
+  internal_load_balancer_addresses = merge([
+    for chain in keys(local.ethereum_chains) : {
+      "${chain}-reth"       = "${local.release_prefix}-${chain}-execution-internal"
+      "${chain}-lighthouse" = "${local.release_prefix}-${chain}-beacon-internal"
+    }
+  ]...)
+
+  gateway_routes = merge([
+    for chain, node in module.ethereum_nodes : {
+      "${chain}-execution" = {
+        hosts                       = local.ethereum_chains[chain].execution_hosts
+        route_namespace             = local.namespace
+        upstream_service_name       = node.reth_service_name
+        upstream_service_port       = node.reth_http_port
+        auth_mode                   = "keyed_only"
+        anonymous_rate_limit_minute = 0
+        path                        = "/"
+        path_type                   = "Prefix"
+        strip_path                  = false
+      }
+      "${chain}-beacon" = {
+        hosts                       = local.ethereum_chains[chain].beacon_hosts
+        route_namespace             = local.namespace
+        upstream_service_name       = node.lighthouse_service_name
+        upstream_service_port       = node.lighthouse_http_port
+        auth_mode                   = "keyed_only"
+        anonymous_rate_limit_minute = 0
+        path                        = "/"
+        path_type                   = "Prefix"
+        strip_path                  = false
+      }
+    }
+  ]...)
+}
+
+data "google_compute_subnetwork" "default" {
+  name   = "default"
+  region = local.gcp_region
+}
+
+resource "google_compute_address" "internal_load_balancer" {
+  for_each = local.internal_load_balancer_addresses
+
+  name         = each.value
+  address_type = "INTERNAL"
+  region       = local.gcp_region
+  subnetwork   = data.google_compute_subnetwork.default.id
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "kubernetes_namespace_v1" "ethereum" {
+  provider = kubernetes.gke-cluster
+
+  metadata {
+    name = local.namespace
+  }
+}
+
+module "ethereum_nodes" {
+  for_each = local.ethereum_chains
+
+  source = "../modules/ethereum-node"
+
+  providers = {
+    helm       = helm.gke-cluster
+    kubernetes = kubernetes.gke-cluster
+  }
+
+  NAMESPACE           = local.namespace
+  RELEASE_PREFIX      = each.key
+  CHAIN               = each.key
+  CHECKPOINT_SYNC_URL = each.value.checkpoint_sync_url
+
+  RETH_P2P_PORT      = each.value.reth_p2p_port
+  RETH_STORAGE       = each.value.reth_storage
+  STORAGE_CLASS_NAME = local.storage_class_name
+  RETH_RESOURCES = {
+    requests = {
+      cpu    = each.value.reth_resources.requests.cpu
+      memory = each.value.reth_resources.requests.memory
+    }
+    limits = {
+      cpu    = each.value.reth_resources.limits.cpu
+      memory = each.value.reth_resources.limits.memory
+    }
+  }
+  RETH_EXTRA_ARGS = each.value.reth_extra_args
+  RETH_INTERNAL_LOAD_BALANCER = {
+    ip = google_compute_address.internal_load_balancer["${each.key}-reth"].address
+  }
+
+  LIGHTHOUSE_P2P_PORT = each.value.lighthouse_p2p_port
+  LIGHTHOUSE_STORAGE  = each.value.lighthouse_storage
+  LIGHTHOUSE_RESOURCES = {
+    requests = {
+      cpu    = each.value.lighthouse_resources.requests.cpu
+      memory = each.value.lighthouse_resources.requests.memory
+    }
+    limits = {
+      cpu    = each.value.lighthouse_resources.limits.cpu
+      memory = each.value.lighthouse_resources.limits.memory
+    }
+  }
+  LIGHTHOUSE_EXTRA_ARGS = each.value.lighthouse_extra_args
+  LIGHTHOUSE_INTERNAL_LOAD_BALANCER = {
+    ip = google_compute_address.internal_load_balancer["${each.key}-lighthouse"].address
+  }
+
+  depends_on = [kubernetes_namespace_v1.ethereum]
+}
+
+module "rpc_gateway" {
+  source = "../modules/rpc-gateway"
+
+  providers = {
+    helm       = helm.gke-cluster
+    kubernetes = kubernetes.gke-cluster
+    google     = google
+  }
+
+  RELEASE_PREFIX     = local.release_prefix
+  CONSUMER_NAMESPACE = local.namespace
+
+  KONG_NAMESPACE                 = local.namespace
+  KONG_HELM_RELEASE_NAME         = var.KONG_HELM_RELEASE_NAME
+  KONG_HELM_CHART_VERSION        = var.KONG_HELM_CHART_VERSION
+  KONG_INGRESS_CLASS             = var.KONG_INGRESS_CLASS
+  KONG_PROXY_SERVICE_TYPE        = var.KONG_PROXY_SERVICE_TYPE
+  KONG_PROXY_SERVICE_ANNOTATIONS = var.KONG_PROXY_SERVICE_ANNOTATIONS
+  KONG_EXTRA_HELM_VALUES         = var.KONG_EXTRA_HELM_VALUES
+  KONG_NODE_SELECTOR             = { node-type = "infra" }
+  KONG_TRUSTED_IP_RANGES         = var.KONG_TRUSTED_IP_RANGES
+  KONG_SERVICE_MONITOR_ENABLED   = var.KONG_SERVICE_MONITOR_ENABLED
+  KONG_METRICS_SERVICE_ENABLED   = var.OTEL_COLLECTOR_ENDPOINT_GCP_SECRET_NAME != ""
+
+  API_KEY_HEADER_NAME     = local.api_key_header_name
+  ROUTES                  = local.gateway_routes
+  ROUTE_RESOURCE_SUFFIX   = "l1"
+  UPSTREAM_POLICY_ENABLED = false
+  CONSUMERS               = local.consumers
+
+  EXTERNAL_SECRET_STORE_NAME       = var.EXTERNAL_SECRET_STORE_NAME
+  EXTERNAL_SECRET_STORE_KIND       = var.EXTERNAL_SECRET_STORE_KIND
+  EXTERNAL_SECRET_REFRESH_INTERVAL = var.EXTERNAL_SECRET_REFRESH_INTERVAL
+
+  CREATE_DNS                      = var.CREATE_DNS
+  DNS_ZONE_NAME                   = var.DNS_ZONE_NAME
+  DNS_TTL                         = var.DNS_TTL
+  FRONTEND_ENABLED                = var.FRONTEND_ENABLED
+  FRONTEND_STATIC_IP_ENABLED      = var.FRONTEND_STATIC_IP_ENABLED
+  FRONTEND_STATIC_IP_NAME         = var.FRONTEND_STATIC_IP_NAME
+  GCP_MANAGED_CERTIFICATE_ENABLED = var.GCP_MANAGED_CERTIFICATE_ENABLED
+
+  depends_on = [module.ethereum_nodes]
+}
+
+module "ethereum_metrics_collector" {
+  count = var.OTEL_COLLECTOR_ENDPOINT_GCP_SECRET_NAME != "" ? 1 : 0
+
+  source = "../modules/otel-metrics-collector"
+
+  providers = {
+    helm = helm.gke-cluster
+  }
+
+  NAMESPACE                               = local.namespace
+  RELEASE_NAME                            = "${local.release_prefix}-metrics-collector"
+  OTEL_COLLECTOR_ENDPOINT_GCP_SECRET_NAME = var.OTEL_COLLECTOR_ENDPOINT_GCP_SECRET_NAME
+  NODE_SELECTOR                           = { node-type = "infra" }
+  SCRAPE_CONFIGS = concat(
+    [
+      {
+        job_name        = "ethereum-kong"
+        scrape_interval = "15s"
+        metrics_path    = "/metrics"
+        targets         = ["${module.rpc_gateway.metrics_service_name}.${module.rpc_gateway.metrics_service_namespace}.svc.cluster.local:${module.rpc_gateway.metrics_service_port}"]
+        labels = {
+          component = "kong"
+          network   = local.release_prefix
+        }
+        metric_relabel_configs = [
+          {
+            action        = "replace"
+            source_labels = ["route"]
+            regex         = "(ethereum\\.)?ethereum-(sepolia|mainnet)-(execution|beacon)-l1(\\..*)?"
+            target_label  = "eth_chain"
+            replacement   = "$2"
+          },
+          {
+            action        = "replace"
+            source_labels = ["route"]
+            regex         = "(ethereum\\.)?ethereum-(sepolia|mainnet)-(execution|beacon)-l1(\\..*)?"
+            target_label  = "eth_endpoint"
+            replacement   = "$3"
+          }
+        ]
+      }
+    ],
+    flatten([
+      for chain, node in module.ethereum_nodes : [
+        {
+          job_name        = "ethereum-reth-${chain}"
+          scrape_interval = "15s"
+          metrics_path    = "/"
+          targets         = ["${node.reth_service_name}.${node.namespace}.svc.cluster.local:9001"]
+          labels = {
+            component    = "ethereum-node"
+            network      = local.release_prefix
+            eth_chain    = chain
+            eth_client   = "reth"
+            eth_endpoint = "execution"
+          }
+        },
+        {
+          job_name        = "ethereum-lighthouse-${chain}"
+          scrape_interval = "15s"
+          metrics_path    = "/metrics"
+          targets         = ["${node.lighthouse_service_name}.${node.namespace}.svc.cluster.local:5054"]
+          labels = {
+            component    = "ethereum-node"
+            network      = local.release_prefix
+            eth_chain    = chain
+            eth_client   = "lighthouse"
+            eth_endpoint = "beacon"
+          }
+        }
+      ]
+    ])
+  )
+  RESOURCE_ATTRIBUTES = {
+    "network"         = local.release_prefix
+    "aztec.component" = "ethereum-metrics"
+  }
+  EXTERNAL_SECRET_STORE_NAME       = var.EXTERNAL_SECRET_STORE_NAME
+  EXTERNAL_SECRET_STORE_KIND       = var.EXTERNAL_SECRET_STORE_KIND
+  EXTERNAL_SECRET_REFRESH_INTERVAL = var.EXTERNAL_SECRET_REFRESH_INTERVAL
+
+  depends_on = [
+    module.ethereum_nodes,
+    module.rpc_gateway,
+  ]
+}

--- a/spartan/terraform/deploy-ethereum/outputs.tf
+++ b/spartan/terraform/deploy-ethereum/outputs.tf
@@ -1,0 +1,88 @@
+output "node_services" {
+  description = "Ethereum node Service names and ports keyed by chain."
+  value = {
+    for chain, node in module.ethereum_nodes : chain => {
+      namespace = node.namespace
+      reth = {
+        service                        = node.reth_service_name
+        internal_load_balancer_service = node.reth_internal_load_balancer_service_name
+        http_port                      = node.reth_http_port
+        ws_port                        = node.reth_ws_port
+        auth_port                      = node.reth_auth_port
+      }
+      lighthouse = {
+        service                        = node.lighthouse_service_name
+        internal_load_balancer_service = node.lighthouse_internal_load_balancer_service_name
+        http_port                      = node.lighthouse_http_port
+      }
+    }
+  }
+}
+
+output "internal_urls" {
+  description = "Direct internal URLs keyed by chain. Cluster URLs are Kubernetes-local; VPC URLs use static internal LoadBalancer IPs."
+  value = {
+    for chain, node in module.ethereum_nodes : chain => {
+      cluster = {
+        reth_http       = node.reth_http_url
+        reth_ws         = node.reth_ws_url
+        lighthouse_http = node.lighthouse_http_url
+      }
+      vpc = {
+        reth_http       = node.reth_internal_http_url
+        reth_ws         = node.reth_internal_ws_url
+        lighthouse_http = node.lighthouse_internal_http_url
+      }
+    }
+  }
+}
+
+output "internal_load_balancer_ips" {
+  description = "Static internal VPC IPs for direct Ethereum node access keyed by chain."
+  value = {
+    for chain, node in module.ethereum_nodes : chain => {
+      execution = node.reth_internal_load_balancer_ip
+      beacon    = node.lighthouse_internal_load_balancer_ip
+    }
+  }
+}
+
+output "external_hosts" {
+  description = "External Kong hostnames keyed by chain."
+  value = {
+    for chain, config in local.ethereum_chains : chain => {
+      execution = config.execution_hosts
+      beacon    = config.beacon_hosts
+    }
+  }
+}
+
+output "kong_routes" {
+  description = "Kong route names keyed by route alias."
+  value       = module.rpc_gateway.route_names
+}
+
+output "consumer_credential_secret_names" {
+  description = "Kubernetes Secret names referenced by KongConsumer credentials."
+  value       = module.rpc_gateway.consumer_credential_secret_names
+}
+
+output "kong_metrics_service" {
+  description = "Kong metrics Service details for scraping, or null fields when disabled."
+  value = {
+    namespace      = module.rpc_gateway.metrics_service_namespace
+    service        = module.rpc_gateway.metrics_service_name
+    port           = module.rpc_gateway.metrics_service_port
+    otel_collector = try(module.ethereum_metrics_collector[0].deployment_name, null)
+  }
+}
+
+output "frontend_load_balancer_ip" {
+  description = "Global static IP assigned to the public GKE frontend Ingress."
+  value       = module.rpc_gateway.frontend_load_balancer_ip
+}
+
+output "gcp_managed_certificate_names" {
+  description = "GKE ManagedCertificate resource names keyed by Ethereum gateway host."
+  value       = module.rpc_gateway.gcp_managed_certificate_names
+}

--- a/spartan/terraform/deploy-ethereum/variables.tf
+++ b/spartan/terraform/deploy-ethereum/variables.tf
@@ -1,0 +1,132 @@
+variable "API_KEY_SECRET_NAMES" {
+  description = "GCP Secret Manager secret names to expose as Kong API key consumers. Secret values are read by ExternalSecrets."
+  type        = list(string)
+  default = [
+    "eth-sepolia-rpc-consumer-client1",
+    "eth-sepolia-rpc-consumer-client2"
+  ]
+}
+
+variable "CONSUMERS" {
+  description = "Kong consumers keyed by name. Each value points at an existing GCP Secret Manager secret containing api_key."
+  type = map(object({
+    username                       = string
+    gcp_secret_manager_secret_name = string
+    rate_limit_minute              = number
+  }))
+  default = {}
+}
+
+variable "KONG_HELM_RELEASE_NAME" {
+  description = "Optional Helm release name for Kong. Defaults to ethereum-rpc-kong in the shared gateway module."
+  type        = string
+  default     = ""
+}
+
+variable "KONG_HELM_CHART_VERSION" {
+  description = "Kong ingress Helm chart version."
+  type        = string
+  default     = "0.24.0"
+}
+
+variable "KONG_INGRESS_CLASS" {
+  description = "Optional ingress class watched by Kong. Defaults to ethereum-rpc-kong in the shared gateway module."
+  type        = string
+  default     = ""
+}
+
+variable "KONG_PROXY_SERVICE_TYPE" {
+  description = "Kong proxy Service type. With frontend enabled this should normally stay ClusterIP plus NEG annotation."
+  type        = string
+  default     = "ClusterIP"
+}
+
+variable "KONG_PROXY_SERVICE_ANNOTATIONS" {
+  description = "Annotations applied to the Kong proxy Service."
+  type        = map(string)
+  default     = {}
+}
+
+variable "KONG_EXTRA_HELM_VALUES" {
+  description = "Additional YAML values passed to the Kong Helm chart."
+  type        = list(string)
+  default     = []
+}
+
+variable "KONG_TRUSTED_IP_RANGES" {
+  description = "Trusted proxy CIDR ranges for Kong real IP handling."
+  type        = list(string)
+  default     = ["35.191.0.0/16", "130.211.0.0/22"]
+}
+
+variable "KONG_SERVICE_MONITOR_ENABLED" {
+  description = "Whether the Kong Helm chart should create a ServiceMonitor."
+  type        = bool
+  default     = false
+}
+
+variable "OTEL_COLLECTOR_ENDPOINT_GCP_SECRET_NAME" {
+  description = "GCP Secret Manager secret name containing the central OTLP/HTTP collector endpoint. Empty disables metrics export."
+  type        = string
+  default     = "otel-collector-url"
+}
+
+variable "EXTERNAL_SECRET_STORE_NAME" {
+  description = "ExternalSecrets SecretStore or ClusterSecretStore name."
+  type        = string
+  default     = "gcp-secret-store"
+}
+
+variable "EXTERNAL_SECRET_STORE_KIND" {
+  description = "ExternalSecrets store kind."
+  type        = string
+  default     = "ClusterSecretStore"
+}
+
+variable "EXTERNAL_SECRET_REFRESH_INTERVAL" {
+  description = "ExternalSecret refresh interval."
+  type        = string
+  default     = "1m"
+}
+
+variable "CREATE_DNS" {
+  description = "Whether to create A records for Ethereum gateway hosts."
+  type        = bool
+  default     = true
+}
+
+variable "DNS_ZONE_NAME" {
+  description = "Cloud DNS managed zone name for Ethereum gateway hosts."
+  type        = string
+  default     = "rpc-aztec-labs-com"
+}
+
+variable "DNS_TTL" {
+  description = "TTL for Ethereum gateway DNS A records."
+  type        = number
+  default     = 300
+}
+
+variable "FRONTEND_ENABLED" {
+  description = "Whether to create a GKE frontend Ingress in front of Kong."
+  type        = bool
+  default     = true
+}
+
+variable "FRONTEND_STATIC_IP_ENABLED" {
+  description = "Whether to allocate a global static IP for the Ethereum gateway frontend."
+  type        = bool
+  default     = true
+}
+
+variable "FRONTEND_STATIC_IP_NAME" {
+  description = "Optional global static IP name for the Ethereum gateway frontend. Defaults to ethereum-rpc-frontend in the shared gateway module."
+  type        = string
+  default     = ""
+}
+
+variable "GCP_MANAGED_CERTIFICATE_ENABLED" {
+  description = "Whether to create GKE ManagedCertificates for Ethereum gateway hosts."
+  type        = bool
+  default     = true
+}

--- a/spartan/terraform/deploy-rpc/README.md
+++ b/spartan/terraform/deploy-rpc/README.md
@@ -19,3 +19,5 @@ GitHub Actions can deploy these environments through `.github/workflows/deploy-r
 RPC node environment is configured through each RPC entry's single `env` map. Common values such as `NETWORK`, `L1_CHAIN_ID`, and `RPC_MAX_BODY_SIZE` live in the environment-level `local.env`; rollup-specific values such as `ROLLUP_VERSION` are merged per RPC.
 
 API key consumers are Terraform inputs, but API key values are not. For each `CONSUMERS` entry, provide `gcp_secret_manager_secret_name`. Set `ALLOW_ANONYMOUS = true` on the environment module to allow anonymous usage, with `ANONYMOUS_RATE_LIMIT_MINUTE` controlling rate limit.
+
+RPC gateway routes accept `https://host/<api-key>` in addition to the configured API key header. Kong copies the first path segment into the auth header before `key-auth` runs, then strips that segment before proxying to the upstream service.

--- a/spartan/terraform/deploy-rpc/modules/environment/main.tf
+++ b/spartan/terraform/deploy-rpc/modules/environment/main.tf
@@ -20,6 +20,7 @@ locals {
   irm_extra_labels = {
     "app.kubernetes.io/component" = "metrics"
   }
+  rpc_gateway_metrics_enabled = var.OTEL_COLLECTOR_ENDPOINT_GCP_SECRET_NAME != "" || var.IRM_METRICS_ENABLED
 
   routed_rpcs = {
     for name, rpc in var.RPCS : name => rpc
@@ -85,11 +86,47 @@ module "rpc_gateway" {
 
   KONG_TRUSTED_IP_RANGES = ["35.191.0.0/16", "130.211.0.0/22"] # Google LB IP ranges https://docs.cloud.google.com/load-balancing/docs/firewall-rules
 
-  ROUTES                            = local.rpc_routes
-  CONSUMERS                         = var.CONSUMERS
-  KONG_OTEL_METRICS_GCP_SECRET_NAME = var.OTEL_COLLECTOR_ENDPOINT_GCP_SECRET_NAME
+  ROUTES                       = local.rpc_routes
+  CONSUMERS                    = var.CONSUMERS
+  KONG_METRICS_SERVICE_ENABLED = local.rpc_gateway_metrics_enabled
 
   depends_on = [module.rpc]
+}
+
+module "rpc_gateway_metrics_collector" {
+  count = var.OTEL_COLLECTOR_ENDPOINT_GCP_SECRET_NAME != "" ? 1 : 0
+
+  source = "../../../modules/otel-metrics-collector"
+
+  providers = {
+    helm = helm
+  }
+
+  NAMESPACE                               = var.NAMESPACE
+  RELEASE_NAME                            = "${var.RELEASE_PREFIX}-rpc-kong-otel-collector"
+  OTEL_COLLECTOR_ENDPOINT_GCP_SECRET_NAME = var.OTEL_COLLECTOR_ENDPOINT_GCP_SECRET_NAME
+  SCRAPE_CONFIGS = [
+    {
+      job_name        = "kong"
+      scrape_interval = "15s"
+      metrics_path    = "/metrics"
+      targets         = ["${module.rpc_gateway.metrics_service_name}.${module.rpc_gateway.metrics_service_namespace}.svc.cluster.local:${module.rpc_gateway.metrics_service_port}"]
+      labels = {
+        component = "kong"
+        network   = var.RELEASE_PREFIX
+      }
+    }
+  ]
+  RESOURCE_ATTRIBUTES = {
+    "service.name"    = "${var.RELEASE_PREFIX}-rpc-kong"
+    "network"         = var.RELEASE_PREFIX
+    "aztec.component" = "kong"
+  }
+  EXTERNAL_SECRET_STORE_NAME       = var.EXTERNAL_SECRET_STORE_NAME
+  EXTERNAL_SECRET_STORE_KIND       = var.EXTERNAL_SECRET_STORE_KIND
+  EXTERNAL_SECRET_REFRESH_INTERVAL = var.EXTERNAL_SECRET_REFRESH_INTERVAL
+
+  depends_on = [module.rpc_gateway]
 }
 
 resource "kubernetes_manifest" "irm_grafana_cloud_secret" {
@@ -103,10 +140,10 @@ resource "kubernetes_manifest" "irm_grafana_cloud_secret" {
       namespace = var.NAMESPACE
     }
     spec = {
-      refreshInterval = "1m"
+      refreshInterval = var.EXTERNAL_SECRET_REFRESH_INTERVAL
       secretStoreRef = {
-        name = "gcp-secret-store"
-        kind = "ClusterSecretStore"
+        name = var.EXTERNAL_SECRET_STORE_NAME
+        kind = var.EXTERNAL_SECRET_STORE_KIND
       }
       target = {
         name           = local.irm_secret_name

--- a/spartan/terraform/deploy-rpc/modules/environment/outputs.tf
+++ b/spartan/terraform/deploy-rpc/modules/environment/outputs.tf
@@ -31,8 +31,7 @@ output "kong_metrics_service" {
     namespace      = module.rpc_gateway.metrics_service_namespace
     service        = module.rpc_gateway.metrics_service_name
     port           = module.rpc_gateway.metrics_service_port
-    ingress        = module.rpc_gateway.metrics_service_load_balancer_ingress
-    otel_collector = module.rpc_gateway.otel_collector_deployment_name
+    otel_collector = try(module.rpc_gateway_metrics_collector[0].deployment_name, null)
   }
 }
 

--- a/spartan/terraform/deploy-rpc/modules/environment/variables.tf
+++ b/spartan/terraform/deploy-rpc/modules/environment/variables.tf
@@ -40,6 +40,24 @@ variable "OTEL_COLLECTOR_ENDPOINT_GCP_SECRET_NAME" {
   default     = "otel-collector-url"
 }
 
+variable "EXTERNAL_SECRET_STORE_NAME" {
+  description = "ExternalSecrets SecretStore or ClusterSecretStore name."
+  type        = string
+  default     = "gcp-secret-store"
+}
+
+variable "EXTERNAL_SECRET_STORE_KIND" {
+  description = "ExternalSecrets store kind."
+  type        = string
+  default     = "ClusterSecretStore"
+}
+
+variable "EXTERNAL_SECRET_REFRESH_INTERVAL" {
+  description = "ExternalSecret refresh interval."
+  type        = string
+  default     = "1m"
+}
+
 variable "IRM_METRICS_ENABLED" {
   description = "Whether to deploy Alloy to forward allowlisted RPC gateway metrics to Grafana Cloud."
   type        = bool

--- a/spartan/terraform/modules/ethereum-node/main.tf
+++ b/spartan/terraform/modules/ethereum-node/main.tf
@@ -1,0 +1,264 @@
+terraform {
+  required_providers {
+    helm = {
+      source = "hashicorp/helm"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+    random = {
+      source = "hashicorp/random"
+    }
+  }
+}
+
+resource "random_bytes" "jwt" {
+  length = 32
+}
+
+locals {
+  eth_panda_ops_repo = var.ETHEREUM_HELM_REPOSITORY
+
+  reth_image_parts      = split(":", var.RETH_IMAGE)
+  reth_image_repository = join(":", slice(local.reth_image_parts, 0, length(local.reth_image_parts) - 1))
+  reth_image_tag        = local.reth_image_parts[length(local.reth_image_parts) - 1]
+
+  lighthouse_image_parts      = split(":", var.LIGHTHOUSE_IMAGE)
+  lighthouse_image_repository = join(":", slice(local.lighthouse_image_parts, 0, length(local.lighthouse_image_parts) - 1))
+  lighthouse_image_tag        = local.lighthouse_image_parts[length(local.lighthouse_image_parts) - 1]
+
+  reth_release_name       = "${var.RELEASE_PREFIX}-reth"
+  lighthouse_release_name = "${var.RELEASE_PREFIX}-lighthouse"
+  reth_pvc_name           = "storage-${local.reth_release_name}-0"
+  lighthouse_pvc_name     = "storage-${local.lighthouse_release_name}-0"
+
+  common_values = {
+    replicas     = 1
+    jwt          = nonsensitive(random_bytes.jwt.hex)
+    nodeSelector = var.NODE_SELECTOR
+  }
+
+  reth_values = merge(local.common_values, {
+    fullnameOverride = local.reth_release_name
+    image = {
+      pullPolicy = var.IMAGE_PULL_POLICY
+      repository = local.reth_image_repository
+      tag        = local.reth_image_tag
+    }
+    resources = var.RETH_RESOURCES
+    p2pNodePort = {
+      enabled = true
+      port    = var.RETH_P2P_PORT
+    }
+    extraArgs = concat([
+      "--chain=${var.CHAIN}",
+    ], var.RETH_EXTRA_ARGS)
+    persistence = {
+      enabled       = true
+      existingClaim = kubernetes_persistent_volume_claim_v1.reth_storage.metadata[0].name
+    }
+    fileLogging = {
+      enabled = var.RETH_FILE_LOGGING_ENABLED
+    }
+    service = {
+      type                  = "ClusterIP"
+      internalTrafficPolicy = var.INTERNAL_TRAFFIC_POLICY
+    }
+  })
+
+  lighthouse_values = merge(local.common_values, {
+    fullnameOverride = local.lighthouse_release_name
+    image = {
+      pullPolicy = var.IMAGE_PULL_POLICY
+      repository = local.lighthouse_image_repository
+      tag        = local.lighthouse_image_tag
+    }
+    resources = var.LIGHTHOUSE_RESOURCES
+    checkpointSync = {
+      enabled = true
+      url     = var.CHECKPOINT_SYNC_URL
+    }
+    p2pNodePort = {
+      enabled = true
+      port    = var.LIGHTHOUSE_P2P_PORT
+    }
+    extraArgs = concat([
+      "--execution-endpoint=http://${local.reth_release_name}.${var.NAMESPACE}.svc.cluster.local:8551",
+      "--semi-supernode",
+      "--network=${var.CHAIN}",
+    ], var.LIGHTHOUSE_EXTRA_ARGS)
+    persistence = {
+      enabled       = true
+      existingClaim = kubernetes_persistent_volume_claim_v1.lighthouse_storage.metadata[0].name
+    }
+    service = {
+      type                  = "ClusterIP"
+      internalTrafficPolicy = var.INTERNAL_TRAFFIC_POLICY
+    }
+  })
+}
+
+resource "kubernetes_persistent_volume_claim_v1" "reth_storage" {
+  metadata {
+    name      = local.reth_pvc_name
+    namespace = var.NAMESPACE
+    labels = {
+      "app.kubernetes.io/instance"   = local.reth_release_name
+      "app.kubernetes.io/name"       = "reth"
+      "app.kubernetes.io/managed-by" = "Terraform"
+    }
+  }
+
+  spec {
+    access_modes       = ["ReadWriteOnce"]
+    storage_class_name = var.STORAGE_CLASS_NAME
+
+    resources {
+      requests = {
+        storage = var.RETH_STORAGE
+      }
+    }
+  }
+
+  wait_until_bound = false
+}
+
+resource "kubernetes_persistent_volume_claim_v1" "lighthouse_storage" {
+  metadata {
+    name      = local.lighthouse_pvc_name
+    namespace = var.NAMESPACE
+    labels = {
+      "app.kubernetes.io/instance"   = local.lighthouse_release_name
+      "app.kubernetes.io/name"       = "lighthouse"
+      "app.kubernetes.io/managed-by" = "Terraform"
+    }
+  }
+
+  spec {
+    access_modes       = ["ReadWriteOnce"]
+    storage_class_name = var.STORAGE_CLASS_NAME
+
+    resources {
+      requests = {
+        storage = var.LIGHTHOUSE_STORAGE
+      }
+    }
+  }
+
+  wait_until_bound = false
+}
+
+resource "helm_release" "reth" {
+  name             = local.reth_release_name
+  repository       = local.eth_panda_ops_repo
+  chart            = "reth"
+  version          = var.RETH_CHART_VERSION
+  namespace        = var.NAMESPACE
+  create_namespace = false
+  upgrade_install  = true
+  force_update     = true
+  recreate_pods    = true
+  reuse_values     = false
+  timeout          = var.HELM_TIMEOUT_SECONDS
+  wait             = var.HELM_WAIT
+
+  values = [yamlencode(local.reth_values)]
+}
+
+resource "helm_release" "lighthouse" {
+  name             = local.lighthouse_release_name
+  repository       = local.eth_panda_ops_repo
+  chart            = "lighthouse"
+  version          = var.LIGHTHOUSE_CHART_VERSION
+  namespace        = var.NAMESPACE
+  create_namespace = false
+  upgrade_install  = true
+  force_update     = true
+  recreate_pods    = true
+  reuse_values     = false
+  timeout          = var.HELM_TIMEOUT_SECONDS
+  wait             = var.HELM_WAIT
+
+  values = [yamlencode(local.lighthouse_values)]
+
+  depends_on = [helm_release.reth]
+}
+
+resource "kubernetes_service_v1" "reth_internal_load_balancer" {
+  count = var.RETH_INTERNAL_LOAD_BALANCER == null ? 0 : 1
+
+  metadata {
+    name      = "${local.reth_release_name}-internal"
+    namespace = var.NAMESPACE
+    annotations = {
+      "networking.gke.io/load-balancer-type" = "Internal"
+    }
+    labels = {
+      "app.kubernetes.io/instance" = local.reth_release_name
+      "app.kubernetes.io/name"     = "reth"
+    }
+  }
+
+  spec {
+    type             = "LoadBalancer"
+    load_balancer_ip = var.RETH_INTERNAL_LOAD_BALANCER.ip
+    selector = {
+      "app.kubernetes.io/instance" = local.reth_release_name
+      "app.kubernetes.io/name"     = "reth"
+    }
+
+    port {
+      name        = "http-rpc"
+      port        = 8545
+      protocol    = "TCP"
+      target_port = "http-rpc"
+    }
+
+    port {
+      name        = "ws-rpc"
+      port        = 8546
+      protocol    = "TCP"
+      target_port = "ws-rpc"
+    }
+  }
+
+  wait_for_load_balancer = false
+
+  depends_on = [helm_release.reth]
+}
+
+resource "kubernetes_service_v1" "lighthouse_internal_load_balancer" {
+  count = var.LIGHTHOUSE_INTERNAL_LOAD_BALANCER == null ? 0 : 1
+
+  metadata {
+    name      = "${local.lighthouse_release_name}-internal"
+    namespace = var.NAMESPACE
+    annotations = {
+      "networking.gke.io/load-balancer-type" = "Internal"
+    }
+    labels = {
+      "app.kubernetes.io/instance" = local.lighthouse_release_name
+      "app.kubernetes.io/name"     = "lighthouse"
+    }
+  }
+
+  spec {
+    type             = "LoadBalancer"
+    load_balancer_ip = var.LIGHTHOUSE_INTERNAL_LOAD_BALANCER.ip
+    selector = {
+      "app.kubernetes.io/instance" = local.lighthouse_release_name
+      "app.kubernetes.io/name"     = "lighthouse"
+    }
+
+    port {
+      name        = "http-api"
+      port        = 5052
+      protocol    = "TCP"
+      target_port = "http-api"
+    }
+  }
+
+  wait_for_load_balancer = false
+
+  depends_on = [helm_release.lighthouse]
+}

--- a/spartan/terraform/modules/ethereum-node/outputs.tf
+++ b/spartan/terraform/modules/ethereum-node/outputs.tf
@@ -1,0 +1,104 @@
+output "namespace" {
+  description = "Kubernetes namespace containing the Ethereum node pair."
+  value       = var.NAMESPACE
+}
+
+output "reth_release_name" {
+  description = "Reth Helm release name."
+  value       = helm_release.reth.name
+}
+
+output "reth_service_name" {
+  description = "Reth Kubernetes Service name."
+  value       = local.reth_release_name
+}
+
+output "reth_http_port" {
+  description = "Reth HTTP JSON-RPC service port."
+  value       = 8545
+}
+
+output "reth_pvc_name" {
+  description = "Terraform-managed Reth PVC name."
+  value       = kubernetes_persistent_volume_claim_v1.reth_storage.metadata[0].name
+}
+
+output "reth_ws_port" {
+  description = "Reth WebSocket service port."
+  value       = 8546
+}
+
+output "reth_auth_port" {
+  description = "Reth authenticated Engine API service port."
+  value       = 8551
+}
+
+output "reth_http_url" {
+  description = "Internal Reth HTTP JSON-RPC URL."
+  value       = "http://${local.reth_release_name}.${var.NAMESPACE}.svc.cluster.local:8545"
+}
+
+output "reth_ws_url" {
+  description = "Internal Reth WebSocket URL."
+  value       = "ws://${local.reth_release_name}.${var.NAMESPACE}.svc.cluster.local:8546"
+}
+
+output "reth_internal_load_balancer_service_name" {
+  description = "Reth internal LoadBalancer Service name, or null when disabled."
+  value       = try(kubernetes_service_v1.reth_internal_load_balancer[0].metadata[0].name, null)
+}
+
+output "reth_internal_load_balancer_ip" {
+  description = "Static internal VPC IP assigned to the Reth direct-access Service, or null when disabled."
+  value       = var.RETH_INTERNAL_LOAD_BALANCER == null ? null : var.RETH_INTERNAL_LOAD_BALANCER.ip
+}
+
+output "reth_internal_http_url" {
+  description = "VPC-internal Reth HTTP JSON-RPC URL, or null when disabled."
+  value       = var.RETH_INTERNAL_LOAD_BALANCER == null ? null : "http://${var.RETH_INTERNAL_LOAD_BALANCER.ip}:8545"
+}
+
+output "reth_internal_ws_url" {
+  description = "VPC-internal Reth WebSocket URL, or null when disabled."
+  value       = var.RETH_INTERNAL_LOAD_BALANCER == null ? null : "ws://${var.RETH_INTERNAL_LOAD_BALANCER.ip}:8546"
+}
+
+output "lighthouse_release_name" {
+  description = "Lighthouse Helm release name."
+  value       = helm_release.lighthouse.name
+}
+
+output "lighthouse_service_name" {
+  description = "Lighthouse Kubernetes Service name."
+  value       = local.lighthouse_release_name
+}
+
+output "lighthouse_http_port" {
+  description = "Lighthouse Beacon API service port."
+  value       = 5052
+}
+
+output "lighthouse_pvc_name" {
+  description = "Terraform-managed Lighthouse PVC name."
+  value       = kubernetes_persistent_volume_claim_v1.lighthouse_storage.metadata[0].name
+}
+
+output "lighthouse_http_url" {
+  description = "Internal Lighthouse Beacon API URL."
+  value       = "http://${local.lighthouse_release_name}.${var.NAMESPACE}.svc.cluster.local:5052"
+}
+
+output "lighthouse_internal_load_balancer_service_name" {
+  description = "Lighthouse internal LoadBalancer Service name, or null when disabled."
+  value       = try(kubernetes_service_v1.lighthouse_internal_load_balancer[0].metadata[0].name, null)
+}
+
+output "lighthouse_internal_load_balancer_ip" {
+  description = "Static internal VPC IP assigned to the Lighthouse direct-access Service, or null when disabled."
+  value       = var.LIGHTHOUSE_INTERNAL_LOAD_BALANCER == null ? null : var.LIGHTHOUSE_INTERNAL_LOAD_BALANCER.ip
+}
+
+output "lighthouse_internal_http_url" {
+  description = "VPC-internal Lighthouse Beacon API URL, or null when disabled."
+  value       = var.LIGHTHOUSE_INTERNAL_LOAD_BALANCER == null ? null : "http://${var.LIGHTHOUSE_INTERNAL_LOAD_BALANCER.ip}:5052"
+}

--- a/spartan/terraform/modules/ethereum-node/variables.tf
+++ b/spartan/terraform/modules/ethereum-node/variables.tf
@@ -1,0 +1,184 @@
+variable "NAMESPACE" {
+  description = "Kubernetes namespace to deploy into."
+  type        = string
+}
+
+variable "RELEASE_PREFIX" {
+  description = "Prefix used for Reth and Lighthouse Helm release names."
+  type        = string
+}
+
+variable "CHAIN" {
+  description = "Ethereum chain to sync."
+  type        = string
+
+  validation {
+    condition     = contains(["sepolia", "mainnet"], var.CHAIN)
+    error_message = "CHAIN must be either sepolia or mainnet."
+  }
+}
+
+variable "CHECKPOINT_SYNC_URL" {
+  description = "Checkpoint sync URL for Lighthouse."
+  type        = string
+}
+
+variable "ETHEREUM_HELM_REPOSITORY" {
+  description = "Helm repository containing the Reth and Lighthouse charts."
+  type        = string
+  default     = "https://ethpandaops.github.io/ethereum-helm-charts"
+}
+
+variable "IMAGE_PULL_POLICY" {
+  description = "Image pull policy for Reth and Lighthouse."
+  type        = string
+  default     = "Always"
+}
+
+variable "NODE_SELECTOR" {
+  description = "Node selector applied to Reth and Lighthouse pods."
+  type        = map(string)
+  default = {
+    node-type = "infra"
+  }
+}
+
+variable "STORAGE_CLASS_NAME" {
+  description = "Storage class for Reth and Lighthouse PVCs."
+  type        = string
+  default     = "premium-rwo"
+}
+
+variable "INTERNAL_TRAFFIC_POLICY" {
+  description = "Service internalTrafficPolicy value. Empty string leaves the chart default."
+  type        = string
+  default     = ""
+}
+
+variable "HELM_TIMEOUT_SECONDS" {
+  description = "Helm release timeout in seconds."
+  type        = number
+  default     = 600
+}
+
+variable "HELM_WAIT" {
+  description = "Whether Helm should wait for Kubernetes resources to become ready."
+  type        = bool
+  default     = false
+}
+
+variable "RETH_IMAGE" {
+  description = "Reth Docker image, including tag."
+  type        = string
+  default     = "ghcr.io/paradigmxyz/reth:v2.3.0"
+
+  validation {
+    condition     = length(split(":", var.RETH_IMAGE)) > 1
+    error_message = "RETH_IMAGE must include an explicit tag."
+  }
+}
+
+variable "RETH_CHART_VERSION" {
+  description = "Reth Helm chart version."
+  type        = string
+  default     = "0.1.8"
+}
+
+variable "RETH_STORAGE" {
+  description = "Reth PVC size."
+  type        = string
+}
+
+variable "RETH_P2P_PORT" {
+  description = "Reth P2P NodePort. Must not collide with legacy nodes while both stacks run."
+  type        = number
+}
+
+variable "RETH_INTERNAL_LOAD_BALANCER" {
+  description = "Reth direct-access internal LoadBalancer config. Null disables the Service."
+  type = object({
+    ip = string
+  })
+  default = null
+}
+
+variable "RETH_RESOURCES" {
+  description = "Reth resource requests and limits."
+  type = object({
+    requests = object({
+      cpu    = string
+      memory = string
+    })
+    limits = object({
+      cpu    = string
+      memory = string
+    })
+  })
+}
+
+variable "RETH_EXTRA_ARGS" {
+  description = "Additional Reth arguments appended after module-managed arguments."
+  type        = list(string)
+  default     = []
+}
+
+variable "RETH_FILE_LOGGING_ENABLED" {
+  description = "Whether Reth writes rotated log files into the data volume in addition to stdout."
+  type        = bool
+  default     = false
+}
+
+variable "LIGHTHOUSE_IMAGE" {
+  description = "Lighthouse Docker image, including tag."
+  type        = string
+  default     = "sigp/lighthouse:v8.2.0"
+
+  validation {
+    condition     = length(split(":", var.LIGHTHOUSE_IMAGE)) > 1
+    error_message = "LIGHTHOUSE_IMAGE must include an explicit tag."
+  }
+}
+
+variable "LIGHTHOUSE_CHART_VERSION" {
+  description = "Lighthouse Helm chart version."
+  type        = string
+  default     = "1.1.8"
+}
+
+variable "LIGHTHOUSE_STORAGE" {
+  description = "Lighthouse PVC size."
+  type        = string
+}
+
+variable "LIGHTHOUSE_P2P_PORT" {
+  description = "Lighthouse P2P NodePort. Must not collide with legacy nodes while both stacks run."
+  type        = number
+}
+
+variable "LIGHTHOUSE_INTERNAL_LOAD_BALANCER" {
+  description = "Lighthouse direct-access internal LoadBalancer config. Null disables the Service."
+  type = object({
+    ip = string
+  })
+  default = null
+}
+
+variable "LIGHTHOUSE_RESOURCES" {
+  description = "Lighthouse resource requests and limits."
+  type = object({
+    requests = object({
+      cpu    = string
+      memory = string
+    })
+    limits = object({
+      cpu    = string
+      memory = string
+    })
+  })
+}
+
+variable "LIGHTHOUSE_EXTRA_ARGS" {
+  description = "Additional Lighthouse arguments appended after module-managed arguments."
+  type        = list(string)
+  default     = []
+}

--- a/spartan/terraform/modules/otel-metrics-collector/main.tf
+++ b/spartan/terraform/modules/otel-metrics-collector/main.tf
@@ -1,0 +1,36 @@
+terraform {
+  required_providers {
+    helm = {
+      source = "hashicorp/helm"
+    }
+  }
+}
+
+resource "helm_release" "collector" {
+  name             = var.RELEASE_NAME
+  chart            = "${path.module}/../../../charts/otel-metrics-collector"
+  namespace        = var.NAMESPACE
+  create_namespace = false
+  upgrade_install  = true
+  wait             = true
+  timeout          = 300
+
+  values = [yamlencode({
+    fullnameOverride = var.RELEASE_NAME
+    externalSecret = {
+      gcpSecretName   = var.OTEL_COLLECTOR_ENDPOINT_GCP_SECRET_NAME
+      refreshInterval = var.EXTERNAL_SECRET_REFRESH_INTERVAL
+      secretStore = {
+        name = var.EXTERNAL_SECRET_STORE_NAME
+        kind = var.EXTERNAL_SECRET_STORE_KIND
+      }
+    }
+    scrapeConfigs      = var.SCRAPE_CONFIGS
+    resourceAttributes = var.RESOURCE_ATTRIBUTES
+    labels             = var.LABELS
+    image              = var.IMAGE
+    replicas           = var.REPLICAS
+    nodeSelector       = var.NODE_SELECTOR
+    resources          = var.RESOURCES
+  })]
+}

--- a/spartan/terraform/modules/otel-metrics-collector/outputs.tf
+++ b/spartan/terraform/modules/otel-metrics-collector/outputs.tf
@@ -1,0 +1,4 @@
+output "deployment_name" {
+  description = "OpenTelemetry Collector Deployment name."
+  value       = var.RELEASE_NAME
+}

--- a/spartan/terraform/modules/otel-metrics-collector/variables.tf
+++ b/spartan/terraform/modules/otel-metrics-collector/variables.tf
@@ -1,0 +1,99 @@
+variable "NAMESPACE" {
+  description = "Kubernetes namespace to deploy the metrics collector into."
+  type        = string
+}
+
+variable "RELEASE_NAME" {
+  description = "Name used for collector Kubernetes resources."
+  type        = string
+}
+
+variable "OTEL_COLLECTOR_ENDPOINT_GCP_SECRET_NAME" {
+  description = "GCP Secret Manager secret name containing the central OTLP/HTTP collector endpoint."
+  type        = string
+}
+
+variable "SCRAPE_CONFIGS" {
+  description = "Prometheus scrape configs for the local collector."
+  type = list(object({
+    job_name        = string
+    targets         = list(string)
+    metrics_path    = optional(string, "/metrics")
+    scrape_interval = optional(string, "15s")
+    labels          = optional(map(string), {})
+    metric_relabel_configs = optional(list(object({
+      action        = string
+      source_labels = optional(list(string), [])
+      regex         = optional(string)
+      target_label  = optional(string)
+      replacement   = optional(string)
+      separator     = optional(string)
+    })), [])
+  }))
+}
+
+variable "RESOURCE_ATTRIBUTES" {
+  description = "Additional OpenTelemetry resource attributes to upsert before export."
+  type        = map(string)
+  default     = {}
+}
+
+variable "LABELS" {
+  description = "Additional Kubernetes labels for collector resources."
+  type        = map(string)
+  default     = {}
+}
+
+variable "IMAGE" {
+  description = "OpenTelemetry Collector image."
+  type        = string
+  default     = "otel/opentelemetry-collector-contrib:0.154.0"
+}
+
+variable "REPLICAS" {
+  description = "Collector replica count."
+  type        = number
+  default     = 1
+}
+
+variable "NODE_SELECTOR" {
+  description = "Node selector applied to collector pods."
+  type        = map(string)
+  default     = {}
+}
+
+variable "RESOURCES" {
+  description = "Resource requests and limits for collector pods."
+  type = object({
+    requests = map(string)
+    limits   = map(string)
+  })
+  default = {
+    requests = {
+      cpu    = "50m"
+      memory = "128Mi"
+    }
+    limits = {
+      cpu    = "200m"
+      memory = "256Mi"
+    }
+  }
+}
+
+variable "EXTERNAL_SECRET_STORE_NAME" {
+  description = "ExternalSecrets SecretStore or ClusterSecretStore name."
+  type        = string
+  default     = "gcp-secret-store"
+}
+
+variable "EXTERNAL_SECRET_STORE_KIND" {
+  description = "ExternalSecrets store kind."
+  type        = string
+  default     = "ClusterSecretStore"
+}
+
+variable "EXTERNAL_SECRET_REFRESH_INTERVAL" {
+  description = "ExternalSecret refresh interval."
+  type        = string
+  default     = "1m"
+}

--- a/spartan/terraform/modules/rpc-gateway/main.tf
+++ b/spartan/terraform/modules/rpc-gateway/main.tf
@@ -17,7 +17,7 @@ locals {
   kong_helm_release_name = var.KONG_HELM_RELEASE_NAME != "" ? var.KONG_HELM_RELEASE_NAME : "${var.RELEASE_PREFIX}-rpc-kong"
   kong_ingress_class     = var.KONG_INGRESS_CLASS != "" ? var.KONG_INGRESS_CLASS : "${var.RELEASE_PREFIX}-rpc-kong"
 
-  upstream_policy_name         = "${var.RELEASE_PREFIX}-rpc-upstream-policy"
+  upstream_policy_name         = "${var.RELEASE_PREFIX}-${var.ROUTE_RESOURCE_SUFFIX}-upstream-policy"
   frontend_static_ip_name      = var.FRONTEND_STATIC_IP_NAME != "" ? var.FRONTEND_STATIC_IP_NAME : "${var.RELEASE_PREFIX}-rpc-frontend"
   frontend_service_name        = var.FRONTEND_SERVICE_NAME != "" ? var.FRONTEND_SERVICE_NAME : "${local.kong_helm_release_name}-gateway-proxy"
   frontend_backend_config_name = "${var.RELEASE_PREFIX}-rpc-kong-backend"
@@ -46,12 +46,13 @@ locals {
   route_plugin_names = {
     for name, route in var.ROUTES :
     name => join(",", compact([
-      "${var.RELEASE_PREFIX}-${name}-rpc-key-auth",
-      "${var.RELEASE_PREFIX}-${name}-rpc-prometheus"
+      "${var.RELEASE_PREFIX}-${name}-${var.ROUTE_RESOURCE_SUFFIX}-path-api-key",
+      "${var.RELEASE_PREFIX}-${name}-${var.ROUTE_RESOURCE_SUFFIX}-key-auth",
+      "${var.RELEASE_PREFIX}-${name}-${var.ROUTE_RESOURCE_SUFFIX}-prometheus"
     ]))
   }
 
-  metrics_service_enabled = var.KONG_METRICS_SERVICE_ENABLED || var.KONG_OTEL_METRICS_GCP_SECRET_NAME != ""
+  metrics_service_enabled = var.KONG_METRICS_SERVICE_ENABLED
   metrics_service_name    = var.KONG_METRICS_SERVICE_NAME != "" ? var.KONG_METRICS_SERVICE_NAME : "${var.RELEASE_PREFIX}-kong-metrics"
   metrics_service_selector = length(var.KONG_METRICS_SERVICE_SELECTOR) > 0 ? var.KONG_METRICS_SERVICE_SELECTOR : {
     "app.kubernetes.io/name"      = "gateway"
@@ -59,13 +60,10 @@ locals {
     "app.kubernetes.io/instance"  = local.kong_helm_release_name
   }
 
-  otel_collector_name        = "${var.RELEASE_PREFIX}-rpc-kong-otel-collector"
-  otel_collector_config_name = "${local.otel_collector_name}-config"
-  otel_collector_secret_name = local.otel_collector_name
 
   consumer_credential_secret_names = {
     for name, _ in var.CONSUMERS :
-    name => "${var.RELEASE_PREFIX}-${name}-rpc-key-auth"
+    name => "${var.RELEASE_PREFIX}-${name}-${var.ROUTE_RESOURCE_SUFFIX}-key-auth"
   }
 
   consumers_with_rate_limit = {
@@ -111,12 +109,14 @@ resource "helm_release" "kong" {
         serviceMonitor = {
           enabled = var.KONG_SERVICE_MONITOR_ENABLED
         }
+        nodeSelector = var.KONG_NODE_SELECTOR
       }
       controller = {
         ingressController = {
           ingressClass = local.kong_ingress_class
           installCRDs  = false
         }
+        nodeSelector = var.KONG_NODE_SELECTOR
       }
     })
   ], var.KONG_EXTRA_HELM_VALUES)
@@ -250,6 +250,45 @@ resource "google_dns_record_set" "rpc" {
   depends_on = [kubernetes_manifest.frontend_ingress]
 }
 
+resource "kubernetes_manifest" "path_api_key_plugin" {
+  for_each = var.ROUTES
+
+  manifest = {
+    apiVersion = "configuration.konghq.com/v1"
+    kind       = "KongPlugin"
+    metadata = {
+      name      = "${var.RELEASE_PREFIX}-${each.key}-${var.ROUTE_RESOURCE_SUFFIX}-path-api-key"
+      namespace = each.value.route_namespace
+      annotations = {
+        "kubernetes.io/ingress.class" = local.kong_ingress_class
+      }
+    }
+    plugin = "pre-function"
+    config = {
+      access = [
+        <<-LUA
+        if not kong.request.get_header("${var.API_KEY_HEADER_NAME}") then
+          local path = kong.request.get_path()
+          local api_key, upstream_path = path:match("^/([^/]+)/?(.*)$")
+
+          if api_key and api_key ~= "" then
+            ngx.req.set_header("${var.API_KEY_HEADER_NAME}", ngx.unescape_uri(api_key))
+
+            if upstream_path == "" then
+              kong.service.request.set_path("/")
+            else
+              kong.service.request.set_path("/" .. upstream_path)
+            end
+          end
+        end
+        LUA
+      ]
+    }
+  }
+
+  depends_on = [helm_release.kong]
+}
+
 resource "kubernetes_manifest" "key_auth_plugin" {
   for_each = var.ROUTES
 
@@ -257,7 +296,7 @@ resource "kubernetes_manifest" "key_auth_plugin" {
     apiVersion = "configuration.konghq.com/v1"
     kind       = "KongPlugin"
     metadata = {
-      name      = "${var.RELEASE_PREFIX}-${each.key}-rpc-key-auth"
+      name      = "${var.RELEASE_PREFIX}-${each.key}-${var.ROUTE_RESOURCE_SUFFIX}-key-auth"
       namespace = each.value.route_namespace
       annotations = {
         "kubernetes.io/ingress.class" = local.kong_ingress_class
@@ -288,7 +327,7 @@ resource "kubernetes_manifest" "prometheus_plugin" {
     apiVersion = "configuration.konghq.com/v1"
     kind       = "KongPlugin"
     metadata = {
-      name      = "${var.RELEASE_PREFIX}-${each.key}-rpc-prometheus"
+      name      = "${var.RELEASE_PREFIX}-${each.key}-${var.ROUTE_RESOURCE_SUFFIX}-prometheus"
       namespace = each.value.route_namespace
       annotations = {
         "kubernetes.io/ingress.class" = local.kong_ingress_class
@@ -307,252 +346,8 @@ resource "kubernetes_manifest" "prometheus_plugin" {
   depends_on = [helm_release.kong]
 }
 
-resource "kubernetes_manifest" "otel_collector_external_secret" {
-  count = var.KONG_OTEL_METRICS_GCP_SECRET_NAME != "" ? 1 : 0
-
-  manifest = {
-    apiVersion = "external-secrets.io/v1"
-    kind       = "ExternalSecret"
-    metadata = {
-      name      = local.otel_collector_secret_name
-      namespace = local.kong_namespace
-    }
-    spec = {
-      refreshInterval = var.EXTERNAL_SECRET_REFRESH_INTERVAL
-      secretStoreRef = {
-        name = var.EXTERNAL_SECRET_STORE_NAME
-        kind = var.EXTERNAL_SECRET_STORE_KIND
-      }
-      target = {
-        name           = local.otel_collector_secret_name
-        creationPolicy = "Owner"
-        template = {
-          engineVersion = "v2"
-          type          = "Opaque"
-          data = {
-            endpoint = "{{ .url | trimSuffix \"/v1/metrics\" | trimSuffix \"/\" }}"
-          }
-        }
-      }
-      data = [
-        {
-          secretKey = "url"
-          remoteRef = {
-            key = var.KONG_OTEL_METRICS_GCP_SECRET_NAME
-          }
-        }
-      ]
-    }
-  }
-
-  wait {
-    condition {
-      type   = "Ready"
-      status = "True"
-    }
-  }
-
-  depends_on = [helm_release.kong]
-}
-
-resource "kubernetes_manifest" "otel_collector_config" {
-  count = var.KONG_OTEL_METRICS_GCP_SECRET_NAME != "" ? 1 : 0
-
-  manifest = {
-    apiVersion = "v1"
-    kind       = "ConfigMap"
-    metadata = {
-      name      = local.otel_collector_config_name
-      namespace = local.kong_namespace
-    }
-    data = {
-      "collector.yaml" = yamlencode({
-        extensions = {
-          health_check = {
-            endpoint = "0.0.0.0:13133"
-          }
-        }
-        receivers = {
-          prometheus = {
-            config = {
-              scrape_configs = [
-                {
-                  job_name        = "kong"
-                  scrape_interval = "${var.KONG_OTEL_METRICS_PUSH_INTERVAL_SECONDS}s"
-                  metrics_path    = "/metrics"
-                  static_configs = [
-                    {
-                      targets = ["${local.metrics_service_name}.${local.kong_namespace}.svc.cluster.local:${var.KONG_METRICS_SERVICE_PORT}"]
-                      labels = {
-                        component = "kong"
-                        network   = var.RELEASE_PREFIX
-                      }
-                    }
-                  ]
-                }
-              ]
-            }
-          }
-        }
-        processors = {
-          resource = {
-            attributes = [
-              {
-                action = "upsert"
-                key    = "service.name"
-                value  = "${var.RELEASE_PREFIX}-rpc-kong"
-              },
-              {
-                action = "upsert"
-                key    = "service.namespace"
-                value  = local.kong_namespace
-              },
-              {
-                action = "upsert"
-                key    = "k8s.namespace.name"
-                value  = local.kong_namespace
-              },
-              {
-                action = "upsert"
-                key    = "network"
-                value  = var.RELEASE_PREFIX
-              },
-              {
-                action = "upsert"
-                key    = "aztec.component"
-                value  = "kong"
-              }
-            ]
-          }
-          batch = {}
-        }
-        exporters = {
-          otlphttp = {
-            endpoint    = "$${env:OTEL_EXPORTER_OTLP_ENDPOINT}"
-            compression = "gzip"
-          }
-        }
-        service = {
-          extensions = ["health_check"]
-          pipelines = {
-            metrics = {
-              receivers  = ["prometheus"]
-              processors = ["resource", "batch"]
-              exporters  = ["otlphttp"]
-            }
-          }
-        }
-      })
-    }
-  }
-
-  depends_on = [helm_release.kong]
-}
-
-resource "kubernetes_manifest" "otel_collector_deployment" {
-  count = var.KONG_OTEL_METRICS_GCP_SECRET_NAME != "" ? 1 : 0
-
-  manifest = {
-    apiVersion = "apps/v1"
-    kind       = "Deployment"
-    metadata = {
-      name      = local.otel_collector_name
-      namespace = local.kong_namespace
-      labels = {
-        "app.kubernetes.io/name"      = "kong-otel-collector"
-        "app.kubernetes.io/instance"  = local.kong_helm_release_name
-        "app.kubernetes.io/component" = "metrics"
-      }
-    }
-    spec = {
-      replicas = var.KONG_OTEL_METRICS_COLLECTOR_REPLICAS
-      selector = {
-        matchLabels = {
-          "app.kubernetes.io/name"      = "kong-otel-collector"
-          "app.kubernetes.io/instance"  = local.kong_helm_release_name
-          "app.kubernetes.io/component" = "metrics"
-        }
-      }
-      template = {
-        metadata = {
-          labels = {
-            "app.kubernetes.io/name"      = "kong-otel-collector"
-            "app.kubernetes.io/instance"  = local.kong_helm_release_name
-            "app.kubernetes.io/component" = "metrics"
-          }
-        }
-        spec = {
-          containers = [
-            {
-              name  = "otel-collector"
-              image = var.KONG_OTEL_METRICS_COLLECTOR_IMAGE
-              args  = ["--config=/conf/collector.yaml"]
-              env = [
-                {
-                  name = "OTEL_EXPORTER_OTLP_ENDPOINT"
-                  valueFrom = {
-                    secretKeyRef = {
-                      name = local.otel_collector_secret_name
-                      key  = "endpoint"
-                    }
-                  }
-                }
-              ]
-              ports = [
-                {
-                  name          = "health"
-                  containerPort = 13133
-                  protocol      = "TCP"
-                }
-              ]
-              readinessProbe = {
-                httpGet = {
-                  path = "/"
-                  port = "health"
-                }
-                initialDelaySeconds = 5
-                periodSeconds       = 10
-              }
-              livenessProbe = {
-                httpGet = {
-                  path = "/"
-                  port = "health"
-                }
-                initialDelaySeconds = 15
-                periodSeconds       = 20
-              }
-              resources = var.KONG_OTEL_METRICS_COLLECTOR_RESOURCES
-              volumeMounts = [
-                {
-                  name      = "config"
-                  mountPath = "/conf"
-                  readOnly  = true
-                }
-              ]
-            }
-          ]
-          volumes = [
-            {
-              name = "config"
-              configMap = {
-                name = local.otel_collector_config_name
-              }
-            }
-          ]
-        }
-      }
-    }
-  }
-
-  depends_on = [
-    kubernetes_manifest.otel_collector_external_secret,
-    kubernetes_manifest.otel_collector_config,
-    kubernetes_service_v1.metrics,
-  ]
-}
-
 resource "kubernetes_manifest" "upstream_policy" {
-  for_each = toset(distinct([for _, route in var.ROUTES : route.route_namespace]))
+  for_each = var.UPSTREAM_POLICY_ENABLED ? toset(distinct([for _, route in var.ROUTES : route.route_namespace])) : toset([])
 
   manifest = {
     apiVersion = "configuration.konghq.com/v1beta1"
@@ -602,7 +397,7 @@ resource "kubernetes_manifest" "consumer_rate_limit_plugin" {
     apiVersion = "configuration.konghq.com/v1"
     kind       = "KongPlugin"
     metadata = {
-      name      = "${var.RELEASE_PREFIX}-${each.key}-rpc-rate-limit"
+      name      = "${var.RELEASE_PREFIX}-${each.key}-${var.ROUTE_RESOURCE_SUFFIX}-rate-limit"
       namespace = var.CONSUMER_NAMESPACE
       annotations = {
         "kubernetes.io/ingress.class" = local.kong_ingress_class
@@ -627,7 +422,7 @@ resource "kubernetes_manifest" "consumer_key_external_secret" {
     apiVersion = "external-secrets.io/v1"
     kind       = "ExternalSecret"
     metadata = {
-      name      = "${var.RELEASE_PREFIX}-${each.key}-rpc-key-auth"
+      name      = "${var.RELEASE_PREFIX}-${each.key}-${var.ROUTE_RESOURCE_SUFFIX}-key-auth"
       namespace = var.CONSUMER_NAMESPACE
     }
     spec = {
@@ -689,7 +484,7 @@ resource "kubernetes_manifest" "consumer" {
       each.value.rate_limit_minute > 0 ? {
         annotations = {
           "kubernetes.io/ingress.class" = local.kong_ingress_class
-          "konghq.com/plugins"          = "${var.RELEASE_PREFIX}-${each.key}-rpc-rate-limit"
+          "konghq.com/plugins"          = "${var.RELEASE_PREFIX}-${each.key}-${var.ROUTE_RESOURCE_SUFFIX}-rate-limit"
         }
       } : {}
     )
@@ -710,7 +505,7 @@ resource "kubernetes_manifest" "anonymous_rate_limit_plugin" {
     apiVersion = "configuration.konghq.com/v1"
     kind       = "KongPlugin"
     metadata = {
-      name      = "${var.RELEASE_PREFIX}-${each.key}-anonymous-rpc-rate-limit"
+      name      = "${var.RELEASE_PREFIX}-${each.key}-anonymous-${var.ROUTE_RESOURCE_SUFFIX}-rate-limit"
       namespace = each.value.route_namespace
       annotations = {
         "kubernetes.io/ingress.class" = local.kong_ingress_class
@@ -739,7 +534,7 @@ resource "kubernetes_manifest" "anonymous_consumer" {
       namespace = each.value.route_namespace
       annotations = {
         "kubernetes.io/ingress.class" = local.kong_ingress_class
-        "konghq.com/plugins"          = "${var.RELEASE_PREFIX}-${each.key}-anonymous-rpc-rate-limit"
+        "konghq.com/plugins"          = "${var.RELEASE_PREFIX}-${each.key}-anonymous-${var.ROUTE_RESOURCE_SUFFIX}-rate-limit"
       }
     }
     username = "${var.RELEASE_PREFIX}-${each.key}-anonymous"
@@ -788,13 +583,13 @@ resource "kubernetes_manifest" "rpc_route" {
     apiVersion = "networking.k8s.io/v1"
     kind       = "Ingress"
     metadata = {
-      name      = "${var.RELEASE_PREFIX}-${each.key}-rpc"
+      name      = "${var.RELEASE_PREFIX}-${each.key}-${var.ROUTE_RESOURCE_SUFFIX}"
       namespace = each.value.route_namespace
       annotations = merge(
         {
           "kubernetes.io/ingress.class" = local.kong_ingress_class
           "konghq.com/plugins"          = local.route_plugin_names[each.key]
-          "konghq.com/strip-path"       = "false"
+          "konghq.com/strip-path"       = tostring(each.value.strip_path)
         },
         var.ROUTE_ANNOTATIONS
       )
@@ -808,8 +603,8 @@ resource "kubernetes_manifest" "rpc_route" {
             http = {
               paths = [
                 {
-                  path     = "/"
-                  pathType = "Prefix"
+                  path     = each.value.path
+                  pathType = each.value.path_type
                   backend = {
                     service = {
                       name = each.value.upstream_service_name
@@ -836,6 +631,7 @@ resource "kubernetes_manifest" "rpc_route" {
   }
 
   depends_on = [
+    kubernetes_manifest.path_api_key_plugin,
     kubernetes_manifest.key_auth_plugin,
     kubernetes_manifest.prometheus_plugin,
     kubernetes_manifest.upstream_policy,

--- a/spartan/terraform/modules/rpc-gateway/outputs.tf
+++ b/spartan/terraform/modules/rpc-gateway/outputs.tf
@@ -23,6 +23,11 @@ output "key_auth_plugin_names" {
   value       = { for name, plugin in kubernetes_manifest.key_auth_plugin : name => plugin.manifest.metadata.name }
 }
 
+output "path_api_key_plugin_names" {
+  description = "KongPlugin names for path-segment API key extraction, keyed by route."
+  value       = { for name, plugin in kubernetes_manifest.path_api_key_plugin : name => plugin.manifest.metadata.name }
+}
+
 output "prometheus_plugin_names" {
   description = "KongPlugin names for per-consumer Prometheus metrics, keyed by route."
   value       = { for name, plugin in kubernetes_manifest.prometheus_plugin : name => plugin.manifest.metadata.name }
@@ -35,7 +40,7 @@ output "kong_namespace" {
 
 output "upstream_policy_name" {
   description = "KongUpstreamPolicy name for RPC upstream balancing, or null when disabled."
-  value       = local.upstream_policy_name
+  value       = var.UPSTREAM_POLICY_ENABLED ? local.upstream_policy_name : null
 }
 
 output "metrics_service_name" {
@@ -56,11 +61,6 @@ output "metrics_service_port" {
 output "metrics_service_load_balancer_ingress" {
   description = "Kong metrics Service load balancer ingress status, or an empty list when disabled/not assigned yet."
   value       = local.metrics_service_enabled ? try(kubernetes_service_v1.metrics[0].status[0].load_balancer[0].ingress, []) : []
-}
-
-output "otel_collector_deployment_name" {
-  description = "Local OTel collector Deployment name for Kong metrics, or null when disabled."
-  value       = var.KONG_OTEL_METRICS_GCP_SECRET_NAME != "" ? local.otel_collector_name : null
 }
 
 output "frontend_load_balancer_ip" {

--- a/spartan/terraform/modules/rpc-gateway/variables.tf
+++ b/spartan/terraform/modules/rpc-gateway/variables.tf
@@ -68,6 +68,12 @@ variable "KONG_TRUSTED_IP_RANGES" {
   default     = []
 }
 
+variable "KONG_NODE_SELECTOR" {
+  description = "Node selector applied to Kong gateway and controller pods."
+  type        = map(string)
+  default     = {}
+}
+
 variable "KONG_EXTRA_HELM_VALUES" {
   description = "Additional YAML values passed to the Kong Helm chart."
   type        = list(string)
@@ -81,7 +87,7 @@ variable "KONG_SERVICE_MONITOR_ENABLED" {
 }
 
 variable "KONG_METRICS_SERVICE_ENABLED" {
-  description = "Whether to expose Kong's status /metrics endpoint through a Kubernetes Service. The service is also created automatically when local OTel collection is enabled."
+  description = "Whether to expose Kong's status /metrics endpoint through a Kubernetes Service."
   type        = bool
   default     = false
 }
@@ -134,48 +140,6 @@ variable "KONG_METRICS_SERVICE_SELECTOR" {
   default     = {}
 }
 
-variable "KONG_OTEL_METRICS_GCP_SECRET_NAME" {
-  description = "GCP Secret Manager secret name containing the central OTLP/HTTP collector endpoint. When empty, no local Kong metrics collector is deployed."
-  type        = string
-  default     = ""
-}
-
-variable "KONG_OTEL_METRICS_PUSH_INTERVAL_SECONDS" {
-  description = "How often the local OTel collector scrapes Kong metrics before exporting to the central collector."
-  type        = number
-  default     = 15
-}
-
-variable "KONG_OTEL_METRICS_COLLECTOR_IMAGE" {
-  description = "Container image for the local OTel collector that scrapes Kong metrics."
-  type        = string
-  default     = "otel/opentelemetry-collector-contrib:0.154.0"
-}
-
-variable "KONG_OTEL_METRICS_COLLECTOR_REPLICAS" {
-  description = "Replica count for the local Kong metrics OTel collector."
-  type        = number
-  default     = 1
-}
-
-variable "KONG_OTEL_METRICS_COLLECTOR_RESOURCES" {
-  description = "Resource requests and limits for the local Kong metrics OTel collector."
-  type = object({
-    requests = map(string)
-    limits   = map(string)
-  })
-  default = {
-    requests = {
-      cpu    = "50m"
-      memory = "128Mi"
-    }
-    limits = {
-      cpu    = "200m"
-      memory = "256Mi"
-    }
-  }
-}
-
 variable "API_KEY_HEADER_NAME" {
   description = "Header checked by Kong's key-auth plugin."
   type        = string
@@ -203,6 +167,9 @@ variable "ROUTES" {
     upstream_service_port       = number
     auth_mode                   = string
     anonymous_rate_limit_minute = number
+    path                        = optional(string, "/")
+    path_type                   = optional(string, "Prefix")
+    strip_path                  = optional(bool, false)
   }))
 
   validation {
@@ -221,10 +188,22 @@ variable "ROUTES" {
   }
 }
 
+variable "ROUTE_RESOURCE_SUFFIX" {
+  description = "Suffix used in generated route and plugin resource names."
+  type        = string
+  default     = "rpc"
+}
+
 variable "ROUTE_ANNOTATIONS" {
   description = "Additional annotations applied to every Kong-managed RPC Ingress."
   type        = map(string)
   default     = {}
+}
+
+variable "UPSTREAM_POLICY_ENABLED" {
+  description = "Whether to create the shared KongUpstreamPolicy used by annotated upstream Services."
+  type        = bool
+  default     = true
 }
 
 variable "CONSUMERS" {


### PR DESCRIPTION
This PR adds a new L1 node deployment using the latest Reth (full/pruning) and Lighthouse (semi supernode) releases. It also adds Kong gateways in front of the nodes in order to expose them safely and protect with API keys and deploys a OpenTelemetry collector to scrape the L1 nodes and push metrics to Grafana.

Fix A-1123 A-1124 A-1269