### PR TITLE
feat(e2e): track per-test setup/hook timings

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -42,7 +42,7 @@ function print_usage {
   echo_cmd "shell"                 "Drop into a shell in the current running build instance container."
   echo_cmd "shell-host"            "Drop into a shell in the current running build host."
   echo_cmd "log"                   "Display the log of the given log ID."
-  echo_cmd "e2e-timings"           "Download per-test e2e timing JSONL for a job: e2e-timings <ci_log_id> <folder>."
+  echo_cmd "test-timings"          "Download per-test timing JSONL for a job: test-timings <ci_log_id> <folder>."
   echo_cmd "kill"                  "Terminate running EC2 instance with instance_name."
   echo_cmd "draft"                 "Mark the current PR as draft (no automatic CI runs when pushing)."
   echo_cmd "ready"                 "Mark the current PR as ready (enable automatic CI runs when pushing)."
@@ -425,27 +425,27 @@ case "$cmd" in
     fi
     ;;
 
-  e2e-timings)
-    # Download all per-test e2e timing files for a CI job and gunzip them into a folder.
+  test-timings)
+    # Download all per-test timing files for a CI job and gunzip them into a folder.
     # ci_log_id is the job's top-level log id (the decimal id in its ci.aztec-labs.com URL).
     # Each downloaded file is named after the test's individual log id (ci.aztec-labs.com/<log_id>).
-    # Usage: ./ci.sh e2e-timings <ci_log_id> <folder>
+    # Usage: ./ci.sh test-timings <ci_log_id> <folder>
     ci_log_id="${1:-}"
     folder="${2:-}"
     if [ -z "$ci_log_id" ] || [ -z "$folder" ]; then
-      echo "usage: $(basename $0) e2e-timings <ci_log_id> <folder>"
+      echo "usage: $(basename $0) test-timings <ci_log_id> <folder>"
       exit 1
     fi
     mkdir -p "$folder"
     aws ${S3_BUILD_CACHE_AWS_PARAMS:-} s3 cp --recursive \
-      "s3://aztec-ci-artifacts/logs/e2e-timings/${ci_log_id}/" "$folder/"
+      "s3://aztec-ci-artifacts/logs/test-timings/${ci_log_id}/" "$folder/"
     for f in "$folder"/*.log.gz; do
       [ -e "$f" ] || continue
       out="${f%.log.gz}.jsonl"
       gunzip -c "$f" > "$out"
       rm -f "$f"
     done
-    echo "Downloaded e2e timings for job $ci_log_id into $folder/"
+    echo "Downloaded test timings for job $ci_log_id into $folder/"
     ;;
 
   #################

--- a/ci.sh
+++ b/ci.sh
@@ -42,7 +42,7 @@ function print_usage {
   echo_cmd "shell"                 "Drop into a shell in the current running build instance container."
   echo_cmd "shell-host"            "Drop into a shell in the current running build host."
   echo_cmd "log"                   "Display the log of the given log ID."
-  echo_cmd "e2e-timings"           "Download per-test e2e timing JSONL for a run: e2e-timings <run_id> <folder>."
+  echo_cmd "e2e-timings"           "Download per-test e2e timing JSONL for a job: e2e-timings <ci_log_id> <folder>."
   echo_cmd "kill"                  "Terminate running EC2 instance with instance_name."
   echo_cmd "draft"                 "Mark the current PR as draft (no automatic CI runs when pushing)."
   echo_cmd "ready"                 "Mark the current PR as ready (enable automatic CI runs when pushing)."
@@ -426,24 +426,26 @@ case "$cmd" in
     ;;
 
   e2e-timings)
-    # Download all per-test e2e timing files for a CI run and gunzip them into a folder.
-    # Usage: ./ci.sh e2e-timings <run_id> <folder>
-    run_id="${1:-}"
+    # Download all per-test e2e timing files for a CI job and gunzip them into a folder.
+    # ci_log_id is the job's top-level log id (the decimal id in its ci.aztec-labs.com URL).
+    # Each downloaded file is named after the test's individual log id (ci.aztec-labs.com/<log_id>).
+    # Usage: ./ci.sh e2e-timings <ci_log_id> <folder>
+    ci_log_id="${1:-}"
     folder="${2:-}"
-    if [ -z "$run_id" ] || [ -z "$folder" ]; then
-      echo "usage: $(basename $0) e2e-timings <run_id> <folder>"
+    if [ -z "$ci_log_id" ] || [ -z "$folder" ]; then
+      echo "usage: $(basename $0) e2e-timings <ci_log_id> <folder>"
       exit 1
     fi
     mkdir -p "$folder"
     aws ${S3_BUILD_CACHE_AWS_PARAMS:-} s3 cp --recursive \
-      "s3://aztec-ci-artifacts/logs/e2e-timings/${run_id}/" "$folder/"
+      "s3://aztec-ci-artifacts/logs/e2e-timings/${ci_log_id}/" "$folder/"
     for f in "$folder"/*.log.gz; do
       [ -e "$f" ] || continue
       out="${f%.log.gz}.jsonl"
       gunzip -c "$f" > "$out"
       rm -f "$f"
     done
-    echo "Downloaded e2e timings for run $run_id into $folder/"
+    echo "Downloaded e2e timings for job $ci_log_id into $folder/"
     ;;
 
   #################

--- a/ci.sh
+++ b/ci.sh
@@ -42,6 +42,7 @@ function print_usage {
   echo_cmd "shell"                 "Drop into a shell in the current running build instance container."
   echo_cmd "shell-host"            "Drop into a shell in the current running build host."
   echo_cmd "log"                   "Display the log of the given log ID."
+  echo_cmd "e2e-timings"           "Download per-test e2e timing JSONL for a run: e2e-timings <run_id> <folder>."
   echo_cmd "kill"                  "Terminate running EC2 instance with instance_name."
   echo_cmd "draft"                 "Mark the current PR as draft (no automatic CI runs when pushing)."
   echo_cmd "ready"                 "Mark the current PR as ready (enable automatic CI runs when pushing)."
@@ -422,6 +423,27 @@ case "$cmd" in
         exit 1
       fi
     fi
+    ;;
+
+  e2e-timings)
+    # Download all per-test e2e timing files for a CI run and gunzip them into a folder.
+    # Usage: ./ci.sh e2e-timings <run_id> <folder>
+    run_id="${1:-}"
+    folder="${2:-}"
+    if [ -z "$run_id" ] || [ -z "$folder" ]; then
+      echo "usage: $(basename $0) e2e-timings <run_id> <folder>"
+      exit 1
+    fi
+    mkdir -p "$folder"
+    aws ${S3_BUILD_CACHE_AWS_PARAMS:-} s3 cp --recursive \
+      "s3://aztec-ci-artifacts/logs/e2e-timings/${run_id}/" "$folder/"
+    for f in "$folder"/*.log.gz; do
+      [ -e "$f" ] || continue
+      out="${f%.log.gz}.jsonl"
+      gunzip -c "$f" > "$out"
+      rm -f "$f"
+    done
+    echo "Downloaded e2e timings for run $run_id into $folder/"
     ;;
 
   #################

--- a/ci3/docker_isolate
+++ b/ci3/docker_isolate
@@ -76,6 +76,7 @@ cid=$(docker run -d \
   -e USE_HOME_TMP \
   -e AVM \
   -e ELU_MONITOR_FILE \
+  -e E2E_TIMING_FILE \
   "${arg_env_vars[@]}" \
   aztecprotocol/build:3.0 \
   /bin/bash -c "$cmd")

--- a/ci3/docker_isolate
+++ b/ci3/docker_isolate
@@ -76,7 +76,8 @@ cid=$(docker run -d \
   -e USE_HOME_TMP \
   -e AVM \
   -e ELU_MONITOR_FILE \
-  -e E2E_TIMING_FILE \
+  -e TEST_TIMING_FILE \
+  -e RUN_ID \
   "${arg_env_vars[@]}" \
   aztecprotocol/build:3.0 \
   /bin/bash -c "$cmd")

--- a/ci3/exec_test
+++ b/ci3/exec_test
@@ -46,6 +46,10 @@ export VERBOSE=1
 # ELU monitor file path (e2e tests write event loop data here, uploaded after test finishes).
 export ELU_MONITOR_FILE=$HOME/.elu_monitor_$$.log
 
+# Per-test timing file (e2e tests write JSONL here, uploaded to S3 after test finishes).
+# $$ is this exec_test pid, so it is unique per parallel test command.
+export E2E_TIMING_FILE=$HOME/.e2e_timing_$$.log
+
 # Run the test with timestamps via process substitution (preserves exit code)
 set +e
 if [ "${ISOLATE:-0}" -eq 1 ]; then
@@ -62,6 +66,14 @@ if [ -s "$ELU_MONITOR_FILE" ]; then
   echo "ELU file: $ELU_MONITOR_FILE ($(wc -l < "$ELU_MONITOR_FILE") lines, $(wc -c < "$ELU_MONITOR_FILE") bytes)"
   cat "$ELU_MONITOR_FILE" | cache_log "elufile:${NAME:-unknown}"
   rm -f "$ELU_MONITOR_FILE"
+fi
+
+# Upload per-test timing data to S3 if present (written by e2e tests, absent for C++/Rust/Noir).
+# Object lands at s3://aztec-ci-artifacts/logs/e2e-timings/<RUN_ID>/<NAME>.log.gz (gzipped JSONL).
+if [ -s "$E2E_TIMING_FILE" ]; then
+  echo "E2E timing file: $E2E_TIMING_FILE ($(wc -l < "$E2E_TIMING_FILE") lines, $(wc -c < "$E2E_TIMING_FILE") bytes)"
+  cat "$E2E_TIMING_FILE" | gzip | cache_s3_transfer_to e2e-timings "${RUN_ID:-unknown}/${NAME:-unknown}"
+  rm -f "$E2E_TIMING_FILE"
 fi
 
 exit $code

--- a/ci3/exec_test
+++ b/ci3/exec_test
@@ -48,7 +48,7 @@ export ELU_MONITOR_FILE=$HOME/.elu_monitor_$$.log
 
 # Per-test timing file (e2e tests write JSONL here, uploaded to S3 after test finishes).
 # $$ is this exec_test pid, so it is unique per parallel test command.
-export E2E_TIMING_FILE=$HOME/.e2e_timing_$$.log
+export TEST_TIMING_FILE=$HOME/.test_timing_$$.log
 
 # Run the test with timestamps via process substitution (preserves exit code)
 set +e
@@ -70,13 +70,17 @@ fi
 
 # Upload per-test timing data to S3 if present (written by e2e tests, absent for C++/Rust/Noir).
 # Keyed by the job's CI_LOG_ID (the decimal id in a job's dashboard URL) and the individual test's
-# log id (E2E_LOG_ID, passed by run_test_cmd; same id as the test's log at ci.aztec-labs.com/<id>),
+# log id (LOG_ID, passed by run_test_cmd; same id as the test's log at ci.aztec-labs.com/<id>),
 # so a test log maps directly to its timing file.
-# Object lands at s3://aztec-ci-artifacts/logs/e2e-timings/<CI_LOG_ID>/<LOG_ID>.log.gz (gzipped JSONL).
-if [ -s "$E2E_TIMING_FILE" ]; then
-  echo "E2E timing file: $E2E_TIMING_FILE ($(wc -l < "$E2E_TIMING_FILE") lines, $(wc -c < "$E2E_TIMING_FILE") bytes)"
-  cat "$E2E_TIMING_FILE" | gzip | cache_s3_transfer_to e2e-timings "${CI_LOG_ID:-unknown}/${E2E_LOG_ID:-${NAME:-unknown}}"
-  rm -f "$E2E_TIMING_FILE"
+# Object lands at s3://aztec-ci-artifacts/logs/test-timings/<CI_LOG_ID>/<LOG_ID>.log.gz (gzipped JSONL).
+if [ -s "$TEST_TIMING_FILE" ]; then
+  if [ -z "${CI_LOG_ID:-}" ] || [ -z "${LOG_ID:-}" ]; then
+    echo "Warning: not uploading test timings; CI_LOG_ID or LOG_ID missing (CI_LOG_ID='${CI_LOG_ID:-}' LOG_ID='${LOG_ID:-}')."
+  else
+    echo "Test timing file: $TEST_TIMING_FILE ($(wc -l <"$TEST_TIMING_FILE") lines, $(wc -c <"$TEST_TIMING_FILE") bytes)"
+    cat "$TEST_TIMING_FILE" | gzip | cache_s3_transfer_to test-timings "${CI_LOG_ID}/${LOG_ID}"
+  fi
+  rm -f "$TEST_TIMING_FILE"
 fi
 
 exit $code

--- a/ci3/exec_test
+++ b/ci3/exec_test
@@ -69,10 +69,13 @@ if [ -s "$ELU_MONITOR_FILE" ]; then
 fi
 
 # Upload per-test timing data to S3 if present (written by e2e tests, absent for C++/Rust/Noir).
-# Object lands at s3://aztec-ci-artifacts/logs/e2e-timings/<RUN_ID>/<NAME>.log.gz (gzipped JSONL).
+# Keyed by the job's CI_LOG_ID (the decimal id in a job's dashboard URL) and the individual test's
+# log id (E2E_LOG_ID, passed by run_test_cmd; same id as the test's log at ci.aztec-labs.com/<id>),
+# so a test log maps directly to its timing file.
+# Object lands at s3://aztec-ci-artifacts/logs/e2e-timings/<CI_LOG_ID>/<LOG_ID>.log.gz (gzipped JSONL).
 if [ -s "$E2E_TIMING_FILE" ]; then
   echo "E2E timing file: $E2E_TIMING_FILE ($(wc -l < "$E2E_TIMING_FILE") lines, $(wc -c < "$E2E_TIMING_FILE") bytes)"
-  cat "$E2E_TIMING_FILE" | gzip | cache_s3_transfer_to e2e-timings "${RUN_ID:-unknown}/${NAME:-unknown}"
+  cat "$E2E_TIMING_FILE" | gzip | cache_s3_transfer_to e2e-timings "${CI_LOG_ID:-unknown}/${E2E_LOG_ID:-${NAME:-unknown}}"
   rm -f "$E2E_TIMING_FILE"
 fi
 

--- a/ci3/run_test_cmd
+++ b/ci3/run_test_cmd
@@ -199,9 +199,9 @@ function run_test {
   # Reset timer and run the test in background (for prompt signal handling) using exec_test.
   SECONDS=0
   set +e
-  # Pass this attempt's log id so exec_test can name the test's e2e timing file after it
+  # Pass this attempt's log id so exec_test can name the test's timing file after it
   # (matching the test's log at ci.aztec-labs.com/<log_key>). Tracks rotate_log on retries.
-  E2E_LOG_ID=$log_key $ci3/exec_test "$cmd" >> "$tmp_file" 2>&1 &
+  LOG_ID=$log_key $ci3/exec_test "$cmd" >> "$tmp_file" 2>&1 &
   test_pid=$!
   wait $test_pid
   code=$?

--- a/ci3/run_test_cmd
+++ b/ci3/run_test_cmd
@@ -199,7 +199,9 @@ function run_test {
   # Reset timer and run the test in background (for prompt signal handling) using exec_test.
   SECONDS=0
   set +e
-  $ci3/exec_test "$cmd" >> "$tmp_file" 2>&1 &
+  # Pass this attempt's log id so exec_test can name the test's e2e timing file after it
+  # (matching the test's log at ci.aztec-labs.com/<log_key>). Tracks rotate_log on retries.
+  E2E_LOG_ID=$log_key $ci3/exec_test "$cmd" >> "$tmp_file" 2>&1 &
   test_pid=$!
   wait $test_pid
   code=$?

--- a/yarn-project/end-to-end/eslint.config.js
+++ b/yarn-project/end-to-end/eslint.config.js
@@ -1,9 +1,14 @@
 import base from '@aztec/foundation/eslint';
 
+import { globalIgnores } from 'eslint/config';
 import globals from 'globals';
 
 export default [
   ...base,
+  // The timing test environment is loaded by jest at runtime from source (not compiled into dest),
+  // and imports foundation's env across packages, so it is excluded from the TS project. Ignore it
+  // from linting too, matching how foundation ignores its own src/jest/*.mjs env files.
+  globalIgnores(['src/shared/timing_env.mjs']),
   {
     files: ['**/*.mjs'],
     languageOptions: {

--- a/yarn-project/end-to-end/package.json
+++ b/yarn-project/end-to-end/package.json
@@ -170,6 +170,6 @@
     "setupFiles": [
       "../../foundation/src/jest/setup.mjs"
     ],
-    "testEnvironment": "../../foundation/src/jest/env.mjs"
+    "testEnvironment": "./shared/timing_env.mjs"
   }
 }

--- a/yarn-project/end-to-end/src/fixtures/setup.ts
+++ b/yarn-project/end-to-end/src/fixtures/setup.ts
@@ -301,6 +301,17 @@ function assertContractArtifactsVersion() {
 }
 
 /**
+ * Records a function-level timing span into the shared collector installed by the e2e timing
+ * environment. No-op unless E2E_TIMING_FILE is set (the env only installs the collector then). The
+ * span is tagged with the name of the currently running test so the env can attribute it to the
+ * right line; `null` during beforeAll/afterAll lands it on the suite-scoped line.
+ */
+function recordFnSpan(kind: 'setup' | 'teardown', ms: number) {
+  const collector = (globalThis as { __e2eTimings?: { current: string | null; fnSpans: unknown[] } }).__e2eTimings;
+  collector?.fnSpans.push({ name: collector.current, kind, ms });
+}
+
+/**
  * Sets up the environment for the end-to-end tests.
  * @param numberOfAccounts - The number of new accounts to be created once the PXE is initiated.
  * @param opts - Options to pass to the node initialization and to the setup script.
@@ -311,6 +322,20 @@ export async function setup(
   opts: SetupOptions = {},
   pxeOpts: Partial<PXEConfig> = {},
   chain: Chain = foundry,
+): Promise<EndToEndContext> {
+  const setupStart = performance.now();
+  try {
+    return await setupInner(numberOfAccounts, opts, pxeOpts, chain);
+  } finally {
+    recordFnSpan('setup', performance.now() - setupStart);
+  }
+}
+
+async function setupInner(
+  numberOfAccounts: number,
+  opts: SetupOptions,
+  pxeOpts: Partial<PXEConfig>,
+  chain: Chain,
 ): Promise<EndToEndContext> {
   assertContractArtifactsVersion();
   let anvil: Anvil | undefined;
@@ -672,6 +697,7 @@ export async function setup(
     }
 
     const teardown = async () => {
+      const teardownStart = performance.now();
       try {
         await tryStop(wallet, logger);
         await tryStop(aztecNodeService, logger);
@@ -696,6 +722,7 @@ export async function setup(
         } catch (err) {
           logger.error(`Error during telemetry client stop`, err);
         }
+        recordFnSpan('teardown', performance.now() - teardownStart);
       }
     };
 

--- a/yarn-project/end-to-end/src/fixtures/setup.ts
+++ b/yarn-project/end-to-end/src/fixtures/setup.ts
@@ -302,7 +302,7 @@ function assertContractArtifactsVersion() {
 
 /**
  * Records a function-level timing span into the shared collector installed by the e2e timing
- * environment. No-op unless E2E_TIMING_FILE is set (the env only installs the collector then). The
+ * environment. No-op unless TEST_TIMING_FILE is set (the env only installs the collector then). The
  * span is tagged with the name of the currently running test so the env can attribute it to the
  * right line; `null` during beforeAll/afterAll lands it on the suite-scoped line.
  */

--- a/yarn-project/end-to-end/src/shared/timing_env.mjs
+++ b/yarn-project/end-to-end/src/shared/timing_env.mjs
@@ -41,6 +41,15 @@ export default class TimingEnvironment extends CustomEnvironment {
     // Start times keyed by hook type (beforeAll/beforeEach/afterAll/afterEach).
     this.hookStarts = {};
     this.testStarts = new Map();
+    // Guards against double-flushing (we flush on both the teardown event and the teardown method).
+    this.flushed = false;
+  }
+
+  // Flush on the teardown method too: the jest lifecycle always calls this, whereas the 'teardown'
+  // event is not reliably delivered when a test run is interrupted. Whichever fires first wins.
+  async teardown() {
+    this.finalizeAndFlush();
+    await super.teardown();
   }
 
   async handleTestEvent(event, state) {
@@ -184,6 +193,10 @@ export default class TimingEnvironment extends CustomEnvironment {
 
   /** Finalizes the suite-scoped record (untagged fn spans + beforeAll/afterAll) and writes all JSONL. */
   finalizeAndFlush() {
+    if (this.flushed || !this.timingFile) {
+      return;
+    }
+    this.flushed = true;
     const suite = {
       setupFnMs: 0,
       beforeHooksMs: this.suiteRecord.beforeHooksMs,

--- a/yarn-project/end-to-end/src/shared/timing_env.mjs
+++ b/yarn-project/end-to-end/src/shared/timing_env.mjs
@@ -1,0 +1,237 @@
+import { appendFileSync, writeFileSync } from 'node:fs';
+import { basename } from 'node:path';
+
+import CustomEnvironment from '../../../foundation/src/jest/env.mjs';
+
+// Per-test e2e timing environment. Gated entirely on the E2E_TIMING_FILE env var: when unset, this
+// behaves exactly like the base CustomEnvironment (it only delegates). When set, it records, per test
+// worker process, the time spent in jest before/after hooks and the test body, and merges in the
+// function-level time captured by setup.ts/teardown.ts via a collector shared on `this.global`.
+//
+// Output is one JSONL file per worker process (the env runs once per worker). Each line is either:
+//   - a per-test line (`name` set): beforeEach hooks, the it() body, afterEach hooks; or
+//   - a single suite-scoped line (`name: null`): beforeAll/afterAll hooks for the whole file.
+export default class TimingEnvironment extends CustomEnvironment {
+  constructor(config, context) {
+    super(config, context);
+
+    this.timingFile = process.env.E2E_TIMING_FILE;
+    if (!this.timingFile) {
+      return;
+    }
+
+    this.suite = basename(context?.testPath ?? config?.testPath ?? 'unknown').replace(/\.test\.[cm]?[jt]s$/, '');
+    this.meta = {
+      commit: process.env.COMMIT_HASH ?? null,
+      branch: process.env.TARGET_BRANCH ?? process.env.REF_NAME ?? null,
+      runId: process.env.RUN_ID ?? null,
+    };
+
+    // Shared collector. setup.ts (running in the sandbox realm) reads `globalThis.__e2eTimings`; this
+    // env (host realm) reads `this.global.__e2eTimings` — they are the same object. `current` is the
+    // full name of the test currently running (null during beforeAll/afterAll), used to tag fn spans.
+    this.collector = { current: null, fnSpans: [] };
+    this.global.__e2eTimings = this.collector;
+
+    // Records to flush as JSONL on teardown. One per test plus one suite-scoped record.
+    this.records = [];
+    this.recordsByName = new Map();
+    // The suite-scoped record (beforeAll/afterAll); bodyMs/totalMs are computed at flush time.
+    this.suiteRecord = { name: null, status: 'passed', beforeHooksMs: 0, afterHooksMs: 0 };
+    // Start times keyed by hook type (beforeAll/beforeEach/afterAll/afterEach).
+    this.hookStarts = {};
+    this.testStarts = new Map();
+  }
+
+  async handleTestEvent(event, state) {
+    // Run the base env first so its unhandledRejection patching for after-hooks stays intact.
+    await super.handleTestEvent(event, state);
+
+    if (!this.timingFile) {
+      return;
+    }
+
+    const now = Date.now();
+    switch (event.name) {
+      case 'hook_start': {
+        this.hookStarts[event.hook.type] = now;
+        break;
+      }
+      case 'hook_success':
+      case 'hook_failure': {
+        const start = this.hookStarts[event.hook.type];
+        if (start === undefined) {
+          break;
+        }
+        delete this.hookStarts[event.hook.type];
+        const ms = now - start;
+        if (event.hook.type === 'beforeEach') {
+          this.addToCurrent('beforeHooksMs', ms);
+        } else if (event.hook.type === 'afterEach') {
+          this.addToCurrent('afterHooksMs', ms);
+        } else if (event.hook.type === 'beforeAll') {
+          this.suiteRecord.beforeHooksMs += ms;
+        } else if (event.hook.type === 'afterAll') {
+          this.suiteRecord.afterHooksMs += ms;
+        }
+        break;
+      }
+      case 'test_start': {
+        const name = this.fullTestName(event.test);
+        const record = {
+          name,
+          status: 'passed',
+          setupFnMs: 0,
+          beforeHooksMs: 0,
+          bodyMs: 0,
+          teardownFnMs: 0,
+          afterHooksMs: 0,
+          totalMs: 0,
+          startedAt: new Date(now).toISOString(),
+        };
+        this.records.push(record);
+        this.recordsByName.set(name, record);
+        this.testStarts.set(name, now);
+        this.collector.current = name;
+        break;
+      }
+      case 'test_fn_start': {
+        this.testStarts.set(`fn:${this.fullTestName(event.test)}`, now);
+        break;
+      }
+      case 'test_fn_success':
+      case 'test_fn_failure': {
+        const name = this.fullTestName(event.test);
+        const start = this.testStarts.get(`fn:${name}`);
+        const record = this.recordsByName.get(name);
+        if (record && start !== undefined) {
+          record.bodyMs = now - start;
+        }
+        if (record && event.name === 'test_fn_failure') {
+          record.status = 'failed';
+        }
+        break;
+      }
+      case 'test_done': {
+        const name = this.fullTestName(event.test);
+        const record = this.recordsByName.get(name);
+        const start = this.testStarts.get(name);
+        if (record && start !== undefined) {
+          record.totalMs = now - start;
+        }
+        if (record && event.test?.errors?.length) {
+          record.status = 'failed';
+        }
+        this.mergeFnSpans(name, record);
+        this.collector.current = null;
+        break;
+      }
+      case 'teardown': {
+        this.finalizeAndFlush();
+        break;
+      }
+      default:
+        break;
+    }
+  }
+
+  /** The record for the test currently running, if any. */
+  currentRecord() {
+    return this.collector.current ? this.recordsByName.get(this.collector.current) : undefined;
+  }
+
+  /** Adds `ms` to a hook bucket on the current per-test record, or the suite record during beforeAll/afterAll. */
+  addToCurrent(field, ms) {
+    const record = this.currentRecord();
+    if (record) {
+      record[field] += ms;
+    }
+  }
+
+  /** Builds the full test name by walking up the describe blocks, matching jest's currentTestName. */
+  fullTestName(test) {
+    if (!test) {
+      return null;
+    }
+    const parts = [];
+    let node = test;
+    while (node && node.name && node.name !== 'ROOT_DESCRIBE_BLOCK') {
+      parts.unshift(node.name);
+      node = node.parent;
+    }
+    return parts.join(' ');
+  }
+
+  /** Moves fn spans tagged with `name` into the matching record's setup/teardown buckets. */
+  mergeFnSpans(name, record) {
+    if (!record) {
+      return;
+    }
+    const remaining = [];
+    for (const span of this.collector.fnSpans) {
+      if (span.name === name) {
+        if (span.kind === 'setup') {
+          record.setupFnMs += span.ms;
+        } else if (span.kind === 'teardown') {
+          record.teardownFnMs += span.ms;
+        }
+      } else {
+        remaining.push(span);
+      }
+    }
+    this.collector.fnSpans = remaining;
+  }
+
+  /** Finalizes the suite-scoped record (untagged fn spans + beforeAll/afterAll) and writes all JSONL. */
+  finalizeAndFlush() {
+    const suite = {
+      setupFnMs: 0,
+      beforeHooksMs: this.suiteRecord.beforeHooksMs,
+      teardownFnMs: 0,
+      afterHooksMs: this.suiteRecord.afterHooksMs,
+    };
+    for (const span of this.collector.fnSpans) {
+      if (span.name === null || span.name === undefined) {
+        if (span.kind === 'setup') {
+          suite.setupFnMs += span.ms;
+        } else if (span.kind === 'teardown') {
+          suite.teardownFnMs += span.ms;
+        }
+      }
+    }
+    this.collector.fnSpans = [];
+
+    const lines = [];
+    for (const record of this.records) {
+      lines.push(this.toLine({ ...record }));
+    }
+    lines.push(
+      this.toLine({
+        name: null,
+        status: 'passed',
+        setupFnMs: suite.setupFnMs,
+        beforeHooksMs: suite.beforeHooksMs,
+        teardownFnMs: suite.teardownFnMs,
+        afterHooksMs: suite.afterHooksMs,
+        totalMs: suite.beforeHooksMs + suite.afterHooksMs,
+      }),
+    );
+
+    const payload = lines.join('\n') + '\n';
+    try {
+      // One file per worker process, but a worker may run several suites: append so we keep them all.
+      appendFileSync(this.timingFile, payload);
+    } catch {
+      try {
+        writeFileSync(this.timingFile, payload);
+      } catch {
+        // Timing is best-effort; never fail a test because we couldn't write the file.
+      }
+    }
+  }
+
+  /** Flattens metadata onto a record and serializes to a single JSON line. */
+  toLine(record) {
+    return JSON.stringify({ suite: this.suite, ...record, ...this.meta });
+  }
+}

--- a/yarn-project/end-to-end/src/shared/timing_env.mjs
+++ b/yarn-project/end-to-end/src/shared/timing_env.mjs
@@ -8,9 +8,10 @@ import CustomEnvironment from '../../../foundation/src/jest/env.mjs';
 // worker process, the time spent in jest before/after hooks and the test body, and merges in the
 // function-level time captured by setup.ts/teardown.ts via a collector shared on `this.global`.
 //
-// Output is one JSONL file per worker process (the env runs once per worker). Each line is either:
-//   - a per-test line (`name` set): beforeEach hooks, the it() body, afterEach hooks; or
-//   - a single suite-scoped line (`name: null`): beforeAll/afterAll hooks for the whole file.
+// Output is one JSONL file per worker process (the env runs once per worker). Each line carries a
+// `type` discriminator and is one of:
+//   - `type: 'test'` (`name` set): beforeEach hooks, the it() body, afterEach hooks for one test; or
+//   - `type: 'suite'` (`name: null`): the suite-scoped beforeAll/afterAll hooks for the whole file.
 export default class TimingEnvironment extends CustomEnvironment {
   constructor(config, context) {
     super(config, context);
@@ -88,6 +89,7 @@ export default class TimingEnvironment extends CustomEnvironment {
       case 'test_start': {
         const name = this.fullTestName(event.test);
         const record = {
+          type: 'test',
           name,
           status: 'passed',
           setupFnMs: 0,
@@ -220,6 +222,7 @@ export default class TimingEnvironment extends CustomEnvironment {
     }
     lines.push(
       this.toLine({
+        type: 'suite',
         name: null,
         status: 'passed',
         setupFnMs: suite.setupFnMs,

--- a/yarn-project/end-to-end/src/shared/timing_env.mjs
+++ b/yarn-project/end-to-end/src/shared/timing_env.mjs
@@ -3,7 +3,7 @@ import { basename } from 'node:path';
 
 import CustomEnvironment from '../../../foundation/src/jest/env.mjs';
 
-// Per-test e2e timing environment. Gated entirely on the E2E_TIMING_FILE env var: when unset, this
+// Per-test e2e timing environment. Gated entirely on the TEST_TIMING_FILE env var: when unset, this
 // behaves exactly like the base CustomEnvironment (it only delegates). When set, it records, per test
 // worker process, the time spent in jest before/after hooks and the test body, and merges in the
 // function-level time captured by setup.ts/teardown.ts via a collector shared on `this.global`.
@@ -15,7 +15,7 @@ export default class TimingEnvironment extends CustomEnvironment {
   constructor(config, context) {
     super(config, context);
 
-    this.timingFile = process.env.E2E_TIMING_FILE;
+    this.timingFile = process.env.TEST_TIMING_FILE;
     if (!this.timingFile) {
       return;
     }
@@ -245,6 +245,12 @@ export default class TimingEnvironment extends CustomEnvironment {
 
   /** Flattens metadata onto a record and serializes to a single JSON line. */
   toLine(record) {
-    return JSON.stringify({ suite: this.suite, ...record, ...this.meta });
+    const obj = { suite: this.suite, ...record, ...this.meta };
+    for (const key of Object.keys(obj)) {
+      if (key.endsWith('Ms') && typeof obj[key] === 'number') {
+        obj[key] = Math.round(obj[key]);
+      }
+    }
+    return JSON.stringify(obj);
   }
 }

--- a/yarn-project/end-to-end/tsconfig.json
+++ b/yarn-project/end-to-end/tsconfig.json
@@ -119,5 +119,6 @@
       "path": "../world-state"
     }
   ],
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["node_modules", "**/node_modules", "**/.*/", "src/shared/timing_env.mjs"]
 }


### PR DESCRIPTION
## What

Adds per-test timing capture to the e2e suite (A-1178, Phase 1), distinguishing **function-level** time inside our `setup()`/`teardown()` from **hook-level** time across jest's before/after hooks, and uploads one JSONL file per test to S3 with a `ci.sh` command to pull a run's timings back.

This is the PR-independent subset that does not depend on the e2e consolidation reorg (#24201). The reorg-gated pieces (`wait:*`/compute body split, multi-node/prover-node start attribution) are deliberately deferred — those files don't exist on this base.

Fixes A-1180

Fixes A-1181

## How

- **`yarn-project/end-to-end/src/shared/timing_env.mjs`** (new) — a `TimingEnvironment` subclass of foundation's `CustomEnvironment`. Calls `await super.handleTestEvent()` first (preserves the base env's unhandled-rejection patching), then times jest-circus events (`hook_start`/`hook_success`/`hook_failure` by hook type, `test_fn_*` for the body, `test_start`/`test_done` for total). Installs a collector on `this.global` and flushes JSONL on env `teardown`. Entirely gated on `E2E_TIMING_FILE`; a pure delegate otherwise.
- **`package.json`** — `jest.testEnvironment` → `./shared/timing_env.mjs`.
- **`fixtures/setup.ts`** — wraps the exported `setup()` and the inner `teardown` closure (both `ctx.teardown()` and the exported `teardown(context)` funnel through it) in try/finally, pushing their durations to `globalThis.__e2eTimings`, tagged with the running test (or `null` during `beforeAll`/`afterAll`).
- **`ci3/exec_test`** — exports `E2E_TIMING_FILE` and, after the test, uploads the gzipped file via `cache_s3_transfer_to`.
- **`ci3/run_test_cmd`** — passes the attempt's log id to `exec_test` as `E2E_LOG_ID` (tracks `rotate_log` on retries).
- **`ci.sh`** — new `e2e-timings <ci_log_id> <folder>` command: `aws s3 cp --recursive` the job's prefix and gunzip each file to `<log_id>.jsonl`.
- `tsconfig.json` / `eslint.config.js` — exclude/ignore the env `.mjs` (it imports foundation's env across packages and jest loads it from source), matching how foundation already ignores its own `src/jest/*.mjs`.

## JSONL schema (one line per test)

```jsonc
{ "suite":"e2e_fees", "name":"pays fee via private payment", "status":"passed",
  "commit":"abc1234", "branch":"merge-train/spartan-v5", "runId":"177...",
  "startedAt":"2026-06-24T12:00:02.000Z",
  "setupFnMs":42000, "beforeHooksMs":47000, "bodyMs":13000,
  "teardownFnMs":2500, "afterHooksMs":3000, "totalMs":63000 }
```

`beforeAll`/`afterAll` (once per describe) are emitted on a single suite-scoped line with `name: null`.

## Examples from this PR's CI run

```json5
  // type:"test" — per-test, with beforeEach setup on the test line
  { "suite":"epochs_invalidate_block.parallel", "type":"test",
    "name":"e2e_epochs/epochs_invalidate_block proposer invalidates previous checkpoint…",
    "status":"passed", "setupFnMs":14330, "beforeHooksMs":19357, "bodyMs":179667,
    "teardownFnMs":732, "afterHooksMs":765, "totalMs":199797,
    "startedAt":"2026-06-25T12:58:34.643Z",
    "commit":"1925654a900…", "branch":"spl/a-1178-track-running-times", "runId":"28171484400" }
```

```json5
  // type:"suite" — the former name:null line (beforeAll/afterAll for the whole file)
  { "suite":"e2e_amm", "type":"suite", "name":null, "status":"passed",
    "setupFnMs":32591, "beforeHooksMs":61200, "teardownFnMs":102, "afterHooksMs":103, "totalMs":61303,
    "commit":"1925654a900…", "branch":"spl/a-1178-track-running-times", "runId":"28171484400" }
```

## Storage & retrieval

- S3 object: `s3://aztec-ci-artifacts/logs/e2e-timings/<CI_LOG_ID>/<LOG_ID>.log.gz` (gzipped JSONL).
  - `CI_LOG_ID` = the job's top-level log id (the decimal id in a job's `ci.aztec-labs.com/<id>` URL) — per-job, so it's collision-free under grind.
  - `LOG_ID` = the test's individual log id, the same id as the test's log at `ci.aztec-labs.com/<log_id>`, so a test log maps straight to its timing file.
- Download: `./ci.sh e2e-timings <ci_log_id> <folder>` → `<folder>/<LOG_ID>.jsonl` per test (the `suite`/`name` fields inside identify the test).

## Notes

- References A-1178 / A-1179 / A-1180 / A-1181 (Phase-1 subset; no auto-closing keywords).
- No `ci-no-squash` label — single commit on merge.
