### PR TITLE
refactor(testing): route warpL2Time cheat codes through automine debug RPC

### DIFF
--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -1101,6 +1101,20 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, AztecNodeDeb
     return await this.automineSequencer.prove(upToCheckpoint);
   }
 
+  public async warpL2TimeAtLeastTo(targetTimestamp: number): Promise<void> {
+    if (!this.automineSequencer) {
+      throw new BadRequestError('Cannot warp L2 time: no automine sequencer is running');
+    }
+    await this.automineSequencer.warpTo(targetTimestamp);
+  }
+
+  public async warpL2TimeAtLeastBy(duration: number): Promise<void> {
+    if (!this.automineSequencer) {
+      throw new BadRequestError('Cannot warp L2 time: no automine sequencer is running');
+    }
+    await this.automineSequencer.warpBy(duration);
+  }
+
   /**
    * Returns a committed world-state view at `block`, driving sync first. Delegates to
    * {@link NodeWorldStateQueries.getWorldState}; kept as a protected method so subclasses and tests can

--- a/yarn-project/aztec/src/testing/cheat_codes.ts
+++ b/yarn-project/aztec/src/testing/cheat_codes.ts
@@ -1,129 +1,47 @@
 import { EthCheatCodes, RollupCheatCodes } from '@aztec/ethereum/test';
-import { SlotNumber } from '@aztec/foundation/branded-types';
-import { createLogger } from '@aztec/foundation/log';
 import type { DateProvider } from '@aztec/foundation/timer';
-import type { AutomineSequencer } from '@aztec/sequencer-client/automine';
 import type { AztecNode, AztecNodeDebug } from '@aztec/stdlib/interfaces/client';
 
 /**
  * A class that provides utility functions for interacting with the chain.
- * @deprecated There used to be 3 kinds of cheat codes: eth, rollup and aztec. We have nuked the Aztec ones because
- * they became unused (we now have better testing tools). If you are introducing a new functionality to the cheat
- * codes, please consider whether it makes sense to just introduce new utils in your tests instead.
  */
 export class CheatCodes {
-  private logger = createLogger('aztecjs:cheat_codes');
-
   constructor(
     /** Cheat codes for L1.*/
     public eth: EthCheatCodes,
     /** Cheat codes for the Aztec Rollup contract on L1. */
     public rollup: RollupCheatCodes,
-    /** When wired, redirects time-warps through the AutomineSequencer queue (test-only). */
-    private automine?: AutomineSequencer,
   ) {}
 
-  static async create(
-    rpcUrls: string[],
-    node: AztecNode,
-    dateProvider: DateProvider,
-    automine?: AutomineSequencer,
-  ): Promise<CheatCodes> {
+  static async create(rpcUrls: string[], node: AztecNode, dateProvider: DateProvider): Promise<CheatCodes> {
     const ethCheatCodes = new EthCheatCodes(rpcUrls, dateProvider);
     const rollupCheatCodes = new RollupCheatCodes(
       ethCheatCodes,
       await node.getNodeInfo().then(n => n.l1ContractAddresses),
     );
-    return new CheatCodes(ethCheatCodes, rollupCheatCodes, automine);
+    return new CheatCodes(ethCheatCodes, rollupCheatCodes);
   }
 
   /**
-   * Warps the L1 timestamp to a target timestamp and mines an L2 block that advances the L2 timestamp to at least
-   * the target timestamp. If the target timestamp falls within the current L2 slot (which already has a block),
-   * the timestamp is automatically adjusted forward to the start of the next slot so that `mineBlock()` succeeds.
-   * @param node - The Aztec node used to force an empty block to be mined.
-   * @param targetTimestamp - The target timestamp to warp to (in seconds)
+   * Warps the L1 timestamp to at least `targetTimestamp` and mines an L2 block advancing the L2 timestamp to at least
+   * the target. Forwards to the node's debug API, which serializes the warp through the automine sequencer queue.
+   * @param node - The Aztec node whose debug API performs the warp. Must run an automine sequencer.
+   * @param targetTimestamp - The target timestamp to warp to (in seconds).
+   * @deprecated Call `node.warpL2TimeAtLeastTo(targetTimestamp)` on the node debug API directly.
    */
-  async warpL2TimeAtLeastTo(node: AztecNode & AztecNodeDebug, targetTimestamp: bigint | number) {
-    const targetBigInt = BigInt(targetTimestamp);
-    const currentTimestamp = BigInt(await this.eth.lastBlockTimestamp());
-
-    if (targetBigInt <= currentTimestamp) {
-      throw new Error(
-        `warpL2TimeAtLeastTo: target timestamp ${targetBigInt} is not in the future (current L1 timestamp is ${currentTimestamp}).`,
-      );
-    }
-
-    // AutomineSequencer owns time control through its serial queue — delegate to keep warps atomic
-    // with respect to any in-flight build, and avoid the mineBlock-loop hack below.
-    // `warpTo` internally builds an empty L2 checkpoint, which auto-mines exactly one L1 block at
-    // the target slot boundary, so no separate `node.mineBlock()` is needed here.
-    if (this.automine) {
-      await this.automine.warpTo(Number(targetBigInt));
-      return;
-    }
-
-    const currentSlot = await this.rollup.getSlot();
-    let effectiveTargetSlot = await this.rollup.getSlotAt(targetBigInt);
-    let effectiveTimestamp = await this.rollup.getTimestampForSlot(effectiveTargetSlot);
-
-    if (effectiveTimestamp < targetBigInt || effectiveTargetSlot <= currentSlot) {
-      const adjustedSlot = SlotNumber(Math.max(effectiveTargetSlot + 1, currentSlot + 1));
-      const adjustedTimestamp = await this.rollup.getTimestampForSlot(adjustedSlot);
-      this.logger.warn(
-        `warpL2TimeAtLeastTo: target timestamp ${targetBigInt} does not align with a future L2 slot boundary. ` +
-          `Auto-adjusting to start of slot ${adjustedSlot} at timestamp ${adjustedTimestamp}.`,
-      );
-      effectiveTimestamp = adjustedTimestamp;
-      effectiveTargetSlot = adjustedSlot;
-    }
-
-    await this.eth.warp(effectiveTimestamp, { resetBlockInterval: true });
-
-    // The sequencer's polling loop may have a `work()` cycle in flight that captured pre-warp slot/timestamp values
-    // just before our warp landed. That cycle would mine an L2 block at the stale slot — the L1 sync prunes such a
-    // block from the canonical chain, but it lingers in local world state and the PXE will use it as the anchor for
-    // subsequent txs, leading to `expiration_timestamp` values that are already in the past relative to L1. Mine
-    // until we observe an L2 block at (or past) the post-warp slot, ensuring the next tx anchors to a fresh block.
-    const maxAttempts = 5;
-    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-      await node.mineBlock();
-      const blockData = await node.getBlockData('latest');
-      const blockSlot = blockData?.header.globalVariables.slotNumber;
-      if (blockSlot !== undefined && BigInt(blockSlot) >= BigInt(effectiveTargetSlot)) {
-        return;
-      }
-      this.logger.warn(
-        `warpL2TimeAtLeastTo: mined L2 block at slot ${blockSlot}, expected at least ${effectiveTargetSlot}. ` +
-          `Retrying mineBlock (attempt ${attempt}/${maxAttempts}).`,
-      );
-    }
-    throw new Error(
-      `warpL2TimeAtLeastTo: failed to mine an L2 block at or past slot ${effectiveTargetSlot} after ${maxAttempts} attempts.`,
-    );
+  warpL2TimeAtLeastTo(node: AztecNode & AztecNodeDebug, targetTimestamp: bigint | number): Promise<void> {
+    return node.warpL2TimeAtLeastTo(Number(targetTimestamp));
   }
 
   /**
-   * Warps the L1 timestamp forward by a specified duration and mines an L2 block that advances the L2 timestamp at
-   * least by the duration. If the duration is too short to cross an L2 slot boundary, the warp is automatically
-   * extended to the start of the next slot so that `mineBlock()` succeeds.
-   * @param node - The Aztec node used to force an empty block to be mined.
-   * @param duration - The duration to advance time by (in seconds)
+   * Warps the L1 timestamp forward by at least `duration` seconds and mines an L2 block advancing the L2 timestamp at
+   * least by the duration. Forwards to the node's debug API, which serializes the warp through the automine sequencer
+   * queue.
+   * @param node - The Aztec node whose debug API performs the warp. Must run an automine sequencer.
+   * @param duration - The duration to advance time by (in seconds).
+   * @deprecated Call `node.warpL2TimeAtLeastBy(duration)` on the node debug API directly.
    */
-  async warpL2TimeAtLeastBy(node: AztecNode & AztecNodeDebug, duration: bigint | number) {
-    if (BigInt(duration) <= 0n) {
-      throw new Error(`warpL2TimeAtLeastBy: duration must be positive, got ${duration} seconds.`);
-    }
-
-    // Advance relative to whichever clock leads. A live sequencer mines L2 blocks at slot boundaries that can run
-    // ahead of anvil's L1 timestamp, so basing the target on L1 alone would advance the L2 timestamp by less than
-    // `duration`. Anchoring to the latest L2 block timestamp when it leads guarantees the post-warp L2 block is at
-    // least `duration` ahead of the current one.
-    const currentL1Timestamp = BigInt(await this.eth.lastBlockTimestamp());
-    const latestBlockData = await node.getBlockData('latest');
-    const latestL2Timestamp = latestBlockData ? BigInt(latestBlockData.header.globalVariables.timestamp) : 0n;
-    const baseTimestamp = latestL2Timestamp > currentL1Timestamp ? latestL2Timestamp : currentL1Timestamp;
-    const targetTimestamp = baseTimestamp + BigInt(duration);
-    await this.warpL2TimeAtLeastTo(node, targetTimestamp);
+  warpL2TimeAtLeastBy(node: AztecNode & AztecNodeDebug, duration: bigint | number): Promise<void> {
+    return node.warpL2TimeAtLeastBy(Number(duration));
   }
 }

--- a/yarn-project/aztec/src/testing/cheat_codes.ts
+++ b/yarn-project/aztec/src/testing/cheat_codes.ts
@@ -3,7 +3,8 @@ import type { DateProvider } from '@aztec/foundation/timer';
 import type { AztecNode, AztecNodeDebug } from '@aztec/stdlib/interfaces/client';
 
 /**
- * A class that provides utility functions for interacting with the chain.
+ * Wrapper for Aztec Debug API.
+ * @deprecated use the AztecNode debug API directly.
  */
 export class CheatCodes {
   constructor(

--- a/yarn-project/end-to-end/src/composed/e2e_cheat_codes.test.ts
+++ b/yarn-project/end-to-end/src/composed/e2e_cheat_codes.test.ts
@@ -7,23 +7,6 @@ import { createAztecNodeDebugClient } from '@aztec/stdlib/interfaces/client';
 
 const { AZTEC_NODE_URL = 'http://localhost:8080', ETHEREUM_HOSTS = 'http://localhost:8545' } = process.env;
 
-async function retryOnFutureTimestampRace(fn: () => Promise<void>) {
-  const maxAttempts = 5;
-  let lastError: unknown;
-  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-    try {
-      await fn();
-      return;
-    } catch (err) {
-      lastError = err;
-      if (!(err instanceof Error) || !err.message.includes('is not in the future')) {
-        throw err;
-      }
-    }
-  }
-  throw lastError;
-}
-
 // Unlike the non-composed e2e_cheat_codes.test.ts these tests are testing that the AztecNodeDebug endpoints get
 // correctly exposed on the node.
 // Runs against a pre-started docker-compose network (AZTEC_NODE_URL + ETHEREUM_HOSTS); no in-proc setup().
@@ -70,19 +53,19 @@ describe('e2e_cheat_codes', () => {
   });
 
   it('warpL2TimeAtLeastBy with sub-slot duration auto-adjusts to next slot', async () => {
-    await retryOnFutureTimestampRace(async () => {
-      const blockBefore = await aztecNode.getBlock(await aztecNode.getBlockNumber());
-      const timestampBefore = Number(blockBefore!.header.globalVariables.timestamp);
+    const blockBefore = await aztecNode.getBlock(await aztecNode.getBlockNumber());
+    const timestampBefore = Number(blockBefore!.header.globalVariables.timestamp);
 
-      // Duration of 1 second is less than a slot, but should still succeed via auto-adjust.
-      await cheatCodes.warpL2TimeAtLeastBy(nodeDebug, 1);
+    // Duration of 1 second is less than a slot, but should still produce a block via auto-adjust. warpL2TimeAtLeastBy
+    // reads the current L1 time inside the sequencer queue and adds the duration, so the target is always in the
+    // future by the time the warp runs — no timestamp race.
+    await cheatCodes.warpL2TimeAtLeastBy(nodeDebug, 1);
 
-      const blockNumber = await aztecNode.getBlockNumber();
-      const block = await aztecNode.getBlock(blockNumber);
-      expect(block).toBeDefined();
-      const timestampAfter = Number(block!.header.globalVariables.timestamp);
-      expect(timestampAfter).toBeGreaterThan(timestampBefore);
-    });
+    const blockNumber = await aztecNode.getBlockNumber();
+    const block = await aztecNode.getBlock(blockNumber);
+    expect(block).toBeDefined();
+    const timestampAfter = Number(block!.header.globalVariables.timestamp);
+    expect(timestampAfter).toBeGreaterThan(timestampBefore);
   });
 
   it('warpL2TimeAtLeastBy with zero duration throws', async () => {
@@ -90,25 +73,25 @@ describe('e2e_cheat_codes', () => {
   });
 
   it('warpL2TimeAtLeastTo with target in current slot auto-adjusts to next slot', async () => {
-    // Target is 1 second ahead of L1 time — still in the current slot, so auto-adjust should kick in.
-    // The sequencer running in this composed test advances L1 by a full slot when it proposes a block,
-    // and that warp can land between our `lastBlockTimestamp()` read and the cheat code's internal
-    // re-read, racing `currentL1 + 1` into the past. Retry on that specific race with a fresh target;
-    // a subsequent slot-jump within the retry window is improbable enough that a small cap suffices.
-    await retryOnFutureTimestampRace(async () => {
-      const currentL1Timestamp = Number(await cheatCodes.eth.lastBlockTimestamp());
-      const targetTimestamp = currentL1Timestamp + 1;
-      await cheatCodes.warpL2TimeAtLeastTo(nodeDebug, targetTimestamp);
-      const blockNumber = await aztecNode.getBlockNumber();
-      const block = await aztecNode.getBlock(blockNumber);
-      expect(block).toBeDefined();
-      expect(Number(block!.header.globalVariables.timestamp)).toBeGreaterThanOrEqual(targetTimestamp);
-    });
+    // Target is 1 second ahead of L1 time — still in the current slot, so auto-adjust rounds up to the next slot
+    // boundary and builds there. The sequencer can advance L1 (e.g. an auto-settle epoch proof mines an empty L1
+    // block) between our `lastBlockTimestamp()` read and the warp running on the queue; if that pushes L1 past the
+    // target the warp no-ops rather than throwing, so we assert against whichever clock leads.
+    const targetTimestamp = Number(await cheatCodes.eth.lastBlockTimestamp()) + 1;
+    await cheatCodes.warpL2TimeAtLeastTo(nodeDebug, targetTimestamp);
+
+    const block = await aztecNode.getBlock(await aztecNode.getBlockNumber());
+    expect(block).toBeDefined();
+    const l2Timestamp = Number(block!.header.globalVariables.timestamp);
+    const l1Timestamp = Number(await cheatCodes.eth.lastBlockTimestamp());
+    expect(Math.max(l2Timestamp, l1Timestamp)).toBeGreaterThanOrEqual(targetTimestamp);
   });
 
-  it('warpL2TimeAtLeastTo with past timestamp throws', async () => {
-    const currentL1Timestamp = Number(await cheatCodes.eth.lastBlockTimestamp());
-    const pastTimestamp = currentL1Timestamp - 1000;
-    await expect(cheatCodes.warpL2TimeAtLeastTo(nodeDebug, pastTimestamp)).rejects.toThrow('is not in the future');
+  it('warpL2TimeAtLeastTo with past timestamp is a no-op', async () => {
+    const blockNumberBefore = await aztecNode.getBlockNumber();
+    const pastTimestamp = Number(await cheatCodes.eth.lastBlockTimestamp()) - 1000;
+
+    await expect(cheatCodes.warpL2TimeAtLeastTo(nodeDebug, pastTimestamp)).resolves.toBeUndefined();
+    expect(await aztecNode.getBlockNumber()).toBe(blockNumberBefore);
   });
 });

--- a/yarn-project/end-to-end/src/fixtures/setup.ts
+++ b/yarn-project/end-to-end/src/fixtures/setup.ts
@@ -613,12 +613,7 @@ export async function setup(
       wallet.setMinFeePadding(opts.walletMinFeePadding);
     }
 
-    const cheatCodes = await CheatCodes.create(
-      config.l1RpcUrls,
-      aztecNodeService,
-      dateProvider,
-      aztecNodeService.getAutomineSequencer(),
-    );
+    const cheatCodes = await CheatCodes.create(config.l1RpcUrls, aztecNodeService, dateProvider);
 
     if (
       (opts.aztecTargetCommitteeSize && opts.aztecTargetCommitteeSize > 0) ||

--- a/yarn-project/sequencer-client/src/sequencer/automine/automine_sequencer.ts
+++ b/yarn-project/sequencer-client/src/sequencer/automine/automine_sequencer.ts
@@ -274,14 +274,22 @@ export class AutomineSequencer {
   /**
    * Warps L1 timestamp to `targetTimestampSec`. Rounded up to the next aztec-slot
    * boundary so the next build lands on a fresh slot. Atomic with respect to builds —
-   * the queue ensures no build is in flight while the warp executes.
+   * the queue ensures no build is in flight while the warp executes. A no-op when the
+   * target is already at or behind the current L1 time (see {@link runWarp}).
    */
   public warpTo(targetTimestampSec: number): Promise<void> {
     return this.queue.put(() => this.runWarp(targetTimestampSec));
   }
 
-  /** Warps L1 timestamp forward by `deltaSec` seconds from the current L1 time. */
+  /**
+   * Warps L1 timestamp forward by `deltaSec` seconds from the current L1 time, rounded up to the next
+   * aztec-slot boundary. Throws if `deltaSec` is not positive (warping "by" a non-positive amount is a
+   * caller bug — unlike {@link warpTo}, which no-ops on a past target).
+   */
   public warpBy(deltaSec: number): Promise<void> {
+    if (deltaSec <= 0) {
+      throw new Error(`warpL2TimeAtLeastBy: duration must be positive, got ${deltaSec} seconds.`);
+    }
     return this.queue.put(async () => {
       const current = await this.deps.ethCheatCodes.lastBlockTimestamp();
       await this.runWarp(current + deltaSec);

--- a/yarn-project/stdlib/src/interfaces/aztec-node-debug.test.ts
+++ b/yarn-project/stdlib/src/interfaces/aztec-node-debug.test.ts
@@ -33,6 +33,14 @@ describe('AztecNodeDebugApiSchema', () => {
     expect(await context.client.prove(CheckpointNumber(3))).toEqual(3);
   });
 
+  it('warpL2TimeAtLeastTo', async () => {
+    await context.client.warpL2TimeAtLeastTo(1234567890);
+  });
+
+  it('warpL2TimeAtLeastBy', async () => {
+    await context.client.warpL2TimeAtLeastBy(42);
+  });
+
   it('registerContractFunctionSignatures', async () => {
     await context.client.registerContractFunctionSignatures(['test()']);
   });
@@ -45,6 +53,14 @@ class MockAztecNodeDebug implements AztecNodeDebug {
 
   prove(upToCheckpoint?: CheckpointNumber): Promise<CheckpointNumber> {
     return Promise.resolve(upToCheckpoint ?? CheckpointNumber(7));
+  }
+
+  warpL2TimeAtLeastTo(_targetTimestamp: number): Promise<void> {
+    return Promise.resolve();
+  }
+
+  warpL2TimeAtLeastBy(_duration: number): Promise<void> {
+    return Promise.resolve();
   }
 
   registerContractFunctionSignatures(_signatures: string[]): Promise<void> {

--- a/yarn-project/stdlib/src/interfaces/aztec-node-debug.ts
+++ b/yarn-project/stdlib/src/interfaces/aztec-node-debug.ts
@@ -38,6 +38,26 @@ export interface AztecNodeDebug {
   prove(upToCheckpoint?: CheckpointNumber): Promise<CheckpointNumber>;
 
   /**
+   * Warps L1 time forward to at least `targetTimestamp` and builds an empty L2 checkpoint at the next slot boundary,
+   * advancing the L2 timestamp to at least the target. The warp is serialized with block building, so it never
+   * interleaves with an in-flight build. A no-op when `targetTimestamp` is already at or behind the current L1 time.
+   *
+   * @param targetTimestamp - Target L1 timestamp, in seconds.
+   * @throws If no automine sequencer is running (only the automine sequencer supports time warps).
+   */
+  warpL2TimeAtLeastTo(targetTimestamp: number): Promise<void>;
+
+  /**
+   * Warps L1 time forward by at least `duration` seconds from the current L1 time and builds an empty L2 checkpoint
+   * at the next slot boundary. The warp is serialized with block building, so it never interleaves with an in-flight
+   * build.
+   *
+   * @param duration - Number of seconds to advance; must be positive.
+   * @throws If no automine sequencer is running, or if `duration` is not positive.
+   */
+  warpL2TimeAtLeastBy(duration: number): Promise<void>;
+
+  /**
    * Registers public function signatures so the node can resolve selectors to names in public-execution stack
    * traces. The mapping lives only in unpersisted node memory, is not gossiped, and is exposed here (rather than on
    * the main node API) because it is a debug-only, unauthenticated write that should not be reachable on prod nodes.
@@ -49,6 +69,8 @@ export interface AztecNodeDebug {
 export const AztecNodeDebugApiSchema: ApiSchemaFor<AztecNodeDebug> = {
   mineBlock: z.function({ input: z.tuple([]), output: z.void() }),
   prove: z.function({ input: z.tuple([optional(CheckpointNumberSchema)]), output: CheckpointNumberSchema }),
+  warpL2TimeAtLeastTo: z.function({ input: z.tuple([z.number()]), output: z.void() }),
+  warpL2TimeAtLeastBy: z.function({ input: z.tuple([z.number()]), output: z.void() }),
   registerContractFunctionSignatures: z.function({
     input: z.tuple([z.array(z.string().max(MAX_SIGNATURE_LEN)).max(MAX_SIGNATURES_PER_REGISTER_CALL)]),
     output: z.void(),


### PR DESCRIPTION
## Context

The `warpL2Time*` cheat codes predate the automine sequencer. They drove time via the `mineBlock` debug RPC plus direct L1 manipulation: in-process they shortcut to the automine sequencer, but out-of-process (the only such caller, `composed/e2e_cheat_codes`) they fell back to a flaky `eth.warp()` + `mineBlock()` retry loop — flaky enough that it recently needed a `retryOnFutureTimestampRace` band-aid to stay green. These helpers are only used in test environments running a local network, which already defaults to an automine sequencer.

## Approach

- Add `warpL2TimeAtLeastTo` / `warpL2TimeAtLeastBy` to the `AztecNodeDebug` RPC, wired straight to the `AutomineSequencer`'s queue-serialized `warpTo`/`warpBy`, mirroring how the existing `prove` debug RPC works. They throw a `BadRequestError` when no automine sequencer is running.
- `warpL2TimeAtLeastBy` throws on a non-positive duration; `warpL2TimeAtLeastTo` no-ops on a past target. The latter removes the future-timestamp race the band-aid worked around, so `retryOnFutureTimestampRace` is gone.
- `CheatCodes.warpL2Time*` are now thin `@deprecated` forwarders to the node debug API; the legacy `eth.warp()` + `mineBlock()` fallback and the `automine` constructor field are removed, and the class-level deprecation notice is dropped.

## API changes

`AztecNodeDebug` gains `warpL2TimeAtLeastTo(targetTimestamp)` and `warpL2TimeAtLeastBy(duration)` in the `aztecDebug` RPC namespace. `CheatCodes.create` no longer takes an `automine` argument.

Fixes A-1289