### PR TITLE
test: skip GlvExtremeMagnitudeScalars on wasm to avoid suite timeout

### DIFF
--- a/barretenberg/cpp/src/barretenberg/ecc/scalar_multiplication/scalar_multiplication.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/scalar_multiplication/scalar_multiplication.test.cpp
@@ -1938,6 +1938,9 @@ TYPED_TEST(ScalarMultiplicationTest, ExternalGlvDoubledDirect)
 }
 TYPED_TEST(ScalarMultiplicationTest, GlvExtremeMagnitudeScalars)
 {
+#ifdef __wasm__
+    GTEST_SKIP() << "GLV extreme-magnitude sweep is native-only; the ~50-probe naive comparison times out on wasm.";
+#endif
     this->test_glv_extreme_magnitude_scalars();
 }
 TYPED_TEST(ScalarMultiplicationTest, EffectiveNumBitsBandSmallScalars)


### PR DESCRIPTION
The wasm `ecc_tests` suite (`ScalarMultiplicationTest/1`, Grumpkin) is tight on its wall-clock budget. `GlvExtremeMagnitudeScalars` ran ~50 magnitude probes, each followed by a naive-MSM comparison over 600 points, and tipped the suite over the `timeout` wrapper:

```
14:54:54 [ RUN ] ScalarMultiplicationTest/1.GlvExtremeMagnitudeScalars
14:54:57 timeout: sending signal TERM to command 'bash'
```

This skips the test on wasm via `GTEST_SKIP()` under `#ifdef __wasm__`, matching the existing native-only pattern already used for the other large synthetic-MSM cases in this file (e.g. `BatchDriverSharedPathRagged`, the `MSMDedup*` cases). Native coverage is unchanged.