### PR TITLE
test: deflake e2e_offchain_payment reorg reprocessing race

### DIFF
--- a/yarn-project/end-to-end/src/e2e_offchain_payment.test.ts
+++ b/yarn-project/end-to-end/src/e2e_offchain_payment.test.ts
@@ -42,6 +42,12 @@ describe('e2e_offchain_payment', () => {
     ({ contract } = await OffchainPaymentContract.deploy(wallet).send({ from: accounts[0] }));
   });
 
+  // The reorg test pauses the AutomineSequencer to keep the poller from racing its post-reorg assertions;
+  // resume here so a pause is never left dangling (resume is a no-op when not paused).
+  afterEach(() => {
+    aztecNodeService.getAutomineSequencer()?.resume();
+  });
+
   async function forceEmptyBlock() {
     const blockBefore = await aztecNode.getBlockNumber();
     logger.info(`Forcing empty block. Current L2 block: ${blockBefore}`);
@@ -49,8 +55,14 @@ describe('e2e_offchain_payment', () => {
     logger.info(`Empty block mined. New L2 block: ${await aztecNode.getBlockNumber()}`);
   }
 
+  // Reverts the chain to `checkpointBeforeTx`. Pauses the AutomineSequencer first: reverting restores the
+  // un-mined transfer tx to the pending pool, and the sequencer's mempool poller would otherwise re-mine it
+  // within ~50ms, racing the post-reorg balance assertions. Pausing only gates the poller; explicit ops
+  // (revertToCheckpoint, the later forceEmptyBlock re-mine) still run. The sequencer stays paused until the
+  // afterEach resume, so the explicit re-mine is the only thing that rebuilds the reverted block.
   async function forceReorg(checkpointBeforeTx: number) {
     const automine = aztecNodeService.getAutomineSequencer()!;
+    automine.pause();
     await automine.revertToCheckpoint(checkpointBeforeTx);
     logger.info(`Reverted to checkpoint ${checkpointBeforeTx}`);
   }
@@ -190,9 +202,10 @@ describe('e2e_offchain_payment', () => {
     const { result: aliceAfterRollback } = await contract.methods.get_balance(alice).simulate({ from: alice });
     expect(aliceAfterRollback).toBe(mintAmount);
 
-    // The p2p tx pool marks rolled-back txs as pending again, so the AutomineSequencer
-    // re-mines the transfer tx automatically. Force a block build so the PXE re-syncs
-    // and reprocesses the offchain-delivered notes.
+    // The reorg restored the transfer tx to the pending pool. With the sequencer still paused (so the
+    // mempool poller cannot win the re-mine race), force a block build: `forceEmptyBlock` permits an empty
+    // block but still drains the pending pool, so it re-mines the restored transfer deterministically. This
+    // drives the PXE to re-sync and reprocess the offchain-delivered notes without re-enqueuing them.
     await forceEmptyBlock();
 
     // Wait for the PXE to process the re-mined block and update its note view.


### PR DESCRIPTION
## Problem

`e2e_offchain_payment.test.ts` › "reprocesses an offchain-delivered payment after an L1 reorg" flakes (CI run `7d8ad07c73ce84e2`) with:

```
expect(received).toBe(expected) // Object.is equality
  Expected: 100n
  Received: 60n
  > 191 |     expect(aliceAfterRollback).toBe(mintAmount);
```

`60n == 100 - 40`: the reverted transfer's effect was still visible to the PXE when the post-reorg balance was read, instead of the rolled-back full mint of `100n`.

## Root cause

A race between the `AutomineSequencer`'s automatic re-mine of the restored transfer tx and the test's post-reorg assertions:

- `forceReorg` → `revertToCheckpoint(6)` prunes block 7 **and** restores the un-mined transfer to the pending pool (`p2pClient.sync()` in `runRevert`, `automine_sequencer.ts:629`), then returns. It does not itself re-mine.
- The sequencer runs a ~50ms mempool poller (`automine_sequencer.ts:175`, default `pollIntervalMs` 50ms) whose `buildIfPending` autonomously re-mines block 7 from the restored pool.
- The PXE has `autoSync: true`, so `get_balance(...).simulate()` re-syncs before every read. Whether Alice's read at line 191 returns `100n` (PXE at pruned tip, block 6) or `60n` (PXE re-synced to the re-mined block 7) depends purely on this timing.

The failed log shows `Updated pxe last block to 7` landing between Bob's read (passes) and Alice's read (fails); the passed log keeps the PXE pinned at block 6 across both reads. Both runs show `Building automine checkpoint {checkpointNumber:7, txCount:1}`, confirming the *poller* drives the re-mine.

## Fix (test only)

`yarn-project/end-to-end/src/e2e_offchain_payment.test.ts`:

- `forceReorg`: `automine.pause()` *before* `revertToCheckpoint`. `pause()` gates only the mempool poller; explicit ops (`revertToCheckpoint`, `buildEmptyBlock`) still run. Pausing before the transfer is restored to the pool means the poller can never enqueue an auto re-mine, so the post-reorg assertions observe a stable pruned state.
- Stay paused through the explicit `forceEmptyBlock()`. `buildEmptyBlock` (`allowEmpty:true`) permits an empty block but still drains the pending pool, so it deterministically re-mines the restored transfer with no poller racing it. The existing `retryUntil` still waits for the PXE re-sync, so the reprocessing behavior under test is preserved.
- Add an `afterEach` that calls `getAutomineSequencer()?.resume()` (idempotent), so a pause is never left dangling.

This removes the nondeterministic auto re-mine that raced the assertions rather than relaxing the `aliceAfterRollback == 100` assertion — which is behavioral (it verifies the reorg rolled Alice's note state back) and is kept. Not a skip, not a `.test_patterns.yml` entry.

## Verification

- `yarn build`: exit 0, no type errors.
- Local e2e red/green not run: the race is nondeterministic (a single local pass would not prove the fix) and the test is infra-heavy. The fix is grounded in the log timeline (PXE re-sync to block 7 lands between Bob's and Alice's reads only in the failed run) and the source mechanism (poller-driven re-mine gated by `paused`; `buildEmptyBlock` still drains pending), and was cross-checked to confirm it does not break the later `retryUntil`.
