### PR TITLE
fix(sequencer): gate waitForMinTxs on age-eligible pending tx count

### DIFF
--- a/yarn-project/p2p/src/client/interface.ts
+++ b/yarn-project/p2p/src/client/interface.ts
@@ -182,6 +182,9 @@ export type P2P = P2PClient & {
   /** Returns the number of pending txs in the mempool. */
   getPendingTxCount(): Promise<number>;
 
+  /** Returns the number of pending txs that have been in the pool long enough to be eligible for block building. */
+  getEligiblePendingTxCount(): Promise<number>;
+
   /**
    * Protects existing transactions by hash for a given slot.
    * Returns hashes of transactions that weren't found in the pool.

--- a/yarn-project/p2p/src/client/interface.ts
+++ b/yarn-project/p2p/src/client/interface.ts
@@ -182,8 +182,11 @@ export type P2P = P2PClient & {
   /** Returns the number of pending txs in the mempool. */
   getPendingTxCount(): Promise<number>;
 
-  /** Returns the number of pending txs that have been in the pool long enough to be eligible for block building. */
-  getEligiblePendingTxCount(): Promise<number>;
+  /**
+   * Returns whether at least `minCount` pending txs have been in the pool long enough to be eligible for block
+   * building. Early-exits once the threshold is met instead of counting every eligible tx.
+   */
+  hasEligiblePendingTxs(minCount: number): Promise<boolean>;
 
   /**
    * Protects existing transactions by hash for a given slot.

--- a/yarn-project/p2p/src/client/p2p_client.ts
+++ b/yarn-project/p2p/src/client/p2p_client.ts
@@ -458,8 +458,8 @@ export class P2PClient extends WithTracer implements P2P {
     return this.txPool.getPendingTxCount();
   }
 
-  public getEligiblePendingTxCount(): Promise<number> {
-    return this.txPool.getEligiblePendingTxCount();
+  public hasEligiblePendingTxs(minCount: number): Promise<boolean> {
+    return this.txPool.hasEligiblePendingTxs(minCount);
   }
 
   public async *iteratePendingTxs(opts?: { includeProof?: boolean }): AsyncIterableIterator<Tx> {

--- a/yarn-project/p2p/src/client/p2p_client.ts
+++ b/yarn-project/p2p/src/client/p2p_client.ts
@@ -458,6 +458,10 @@ export class P2PClient extends WithTracer implements P2P {
     return this.txPool.getPendingTxCount();
   }
 
+  public getEligiblePendingTxCount(): Promise<number> {
+    return this.txPool.getEligiblePendingTxCount();
+  }
+
   public async *iteratePendingTxs(opts?: { includeProof?: boolean }): AsyncIterableIterator<Tx> {
     for (const txHash of await this.txPool.getPendingTxHashes()) {
       const tx = await this.txPool.getTxByHash(txHash, opts);

--- a/yarn-project/p2p/src/mem_pools/tx_pool_v2/interfaces.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool_v2/interfaces.ts
@@ -224,6 +224,9 @@ export interface TxPoolV2 extends TypedEventEmitter<TxPoolV2Events> {
   /** Gets the count of pending transactions */
   getPendingTxCount(): Promise<number>;
 
+  /** Gets the count of pending transactions old enough per minTxPoolAgeMs. Age-filtered counterpart of getPendingTxCount. */
+  getEligiblePendingTxCount(): Promise<number>;
+
   /** Gets mined transaction hashes with their block IDs */
   getMinedTxHashes(): Promise<[TxHash, L2BlockId][]>;
 

--- a/yarn-project/p2p/src/mem_pools/tx_pool_v2/interfaces.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool_v2/interfaces.ts
@@ -224,8 +224,12 @@ export interface TxPoolV2 extends TypedEventEmitter<TxPoolV2Events> {
   /** Gets the count of pending transactions */
   getPendingTxCount(): Promise<number>;
 
-  /** Gets the count of pending transactions old enough per minTxPoolAgeMs. Age-filtered counterpart of getPendingTxCount. */
-  getEligiblePendingTxCount(): Promise<number>;
+  /**
+   * Returns whether at least `minCount` pending transactions are old enough per minTxPoolAgeMs to be eligible
+   * for block building. Stops scanning once the threshold is reached, so it is cheaper than counting all
+   * eligible txs when only a few are needed.
+   */
+  hasEligiblePendingTxs(minCount: number): Promise<boolean>;
 
   /** Gets mined transaction hashes with their block IDs */
   getMinedTxHashes(): Promise<[TxHash, L2BlockId][]>;

--- a/yarn-project/p2p/src/mem_pools/tx_pool_v2/tx_pool_indices.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool_v2/tx_pool_indices.ts
@@ -228,6 +228,18 @@ export class TxPoolIndices {
     return this.#pendingByPriority.length;
   }
 
+  /**
+   * Counts pending transactions received at or before maxReceivedAt, i.e. those old enough to be
+   * eligible for block building. Age-filtered counterpart of {@link getPendingTxCount}.
+   */
+  getEligiblePendingTxCount(maxReceivedAt: number): number {
+    let count = 0;
+    for (const _ of this.iterateEligiblePendingByPriority('desc', maxReceivedAt)) {
+      count++;
+    }
+    return count;
+  }
+
   /** Gets the lowest priority pending transaction hashes (up to limit) */
   getLowestPriorityPending(limit: number): string[] {
     if (limit <= 0) {

--- a/yarn-project/p2p/src/mem_pools/tx_pool_v2/tx_pool_indices.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool_v2/tx_pool_indices.ts
@@ -229,15 +229,26 @@ export class TxPoolIndices {
   }
 
   /**
-   * Counts pending transactions received at or before maxReceivedAt, i.e. those old enough to be
-   * eligible for block building. Age-filtered counterpart of {@link getPendingTxCount}.
+   * Returns whether at least `minCount` pending transactions were received at or before maxReceivedAt,
+   * i.e. are old enough to be eligible for block building. Stops as soon as the threshold is met, so it
+   * does not scan the whole pool when only a handful of eligible txs are needed. The total pending count
+   * is an upper bound on the eligible count, so a pool with fewer than `minCount` pending can never
+   * satisfy the threshold and short-circuits without scanning.
    */
-  getEligiblePendingTxCount(maxReceivedAt: number): number {
+  hasEligiblePendingTxs(maxReceivedAt: number, minCount: number): boolean {
+    if (minCount <= 0) {
+      return true;
+    }
+    if (this.#pendingByPriority.length < minCount) {
+      return false;
+    }
     let count = 0;
     for (const _ of this.iterateEligiblePendingByPriority('desc', maxReceivedAt)) {
-      count++;
+      if (++count >= minCount) {
+        return true;
+      }
     }
-    return count;
+    return false;
   }
 
   /** Gets the lowest priority pending transaction hashes (up to limit) */

--- a/yarn-project/p2p/src/mem_pools/tx_pool_v2/tx_pool_v2.test.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool_v2/tx_pool_v2.test.ts
@@ -5414,6 +5414,34 @@ describe('TxPoolV2', () => {
       expect(toStrings(eligible)).toEqual([hashOf(tx)]);
     });
 
+    it('getEligiblePendingTxCount excludes fresh txs and counts them once they age in', async () => {
+      const txs = await Promise.all([mockTxWithFee(1, 10), mockTxWithFee(2, 20), mockTxWithFee(3, 30)]);
+      await agePool.addPendingTxs(txs);
+
+      // Fresh txs (added at 10000, cutoff 10000 - 2000 = 8000) count as pending but not as eligible
+      expect(await agePool.getPendingTxCount()).toBe(3);
+      expect(await agePool.getEligiblePendingTxCount()).toBe(0);
+
+      // Once the minimum age elapses they all become eligible
+      currentTime = 12_001;
+      expect(await agePool.getPendingTxCount()).toBe(3);
+      expect(await agePool.getEligiblePendingTxCount()).toBe(3);
+    });
+
+    it('getEligiblePendingTxCount counts only txs old enough at a partial cutoff', async () => {
+      const tx1 = await mockTxWithFee(1, 10);
+      await agePool.addPendingTxs([tx1]);
+
+      currentTime = 11_000;
+      const tx2 = await mockTxWithFee(2, 20);
+      await agePool.addPendingTxs([tx2]);
+
+      // At 12500: tx1 (added at 10000) is old enough, tx2 (added at 11000) is not
+      currentTime = 12_500;
+      expect(await agePool.getPendingTxCount()).toBe(2);
+      expect(await agePool.getEligiblePendingTxCount()).toBe(1);
+    });
+
     it('tx becomes eligible at exactly minTxPoolAgeMs', async () => {
       const tx = await mockTxWithFee(1, 10);
       await agePool.addPendingTxs([tx]);

--- a/yarn-project/p2p/src/mem_pools/tx_pool_v2/tx_pool_v2.test.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool_v2/tx_pool_v2.test.ts
@@ -5414,21 +5414,24 @@ describe('TxPoolV2', () => {
       expect(toStrings(eligible)).toEqual([hashOf(tx)]);
     });
 
-    it('getEligiblePendingTxCount excludes fresh txs and counts them once they age in', async () => {
+    it('hasEligiblePendingTxs is false for fresh txs and true once they age in', async () => {
       const txs = await Promise.all([mockTxWithFee(1, 10), mockTxWithFee(2, 20), mockTxWithFee(3, 30)]);
       await agePool.addPendingTxs(txs);
 
-      // Fresh txs (added at 10000, cutoff 10000 - 2000 = 8000) count as pending but not as eligible
+      // Fresh txs (added at 10000, cutoff 10000 - 2000 = 8000) are pending but not yet eligible
       expect(await agePool.getPendingTxCount()).toBe(3);
-      expect(await agePool.getEligiblePendingTxCount()).toBe(0);
+      expect(await agePool.hasEligiblePendingTxs(1)).toBe(false);
+      // A threshold of 0 is always satisfied, even when nothing is eligible yet
+      expect(await agePool.hasEligiblePendingTxs(0)).toBe(true);
 
       // Once the minimum age elapses they all become eligible
       currentTime = 12_001;
-      expect(await agePool.getPendingTxCount()).toBe(3);
-      expect(await agePool.getEligiblePendingTxCount()).toBe(3);
+      expect(await agePool.hasEligiblePendingTxs(3)).toBe(true);
+      // The pool only holds 3 txs, so it can never satisfy a higher threshold
+      expect(await agePool.hasEligiblePendingTxs(4)).toBe(false);
     });
 
-    it('getEligiblePendingTxCount counts only txs old enough at a partial cutoff', async () => {
+    it('hasEligiblePendingTxs counts only txs old enough at a partial cutoff', async () => {
       const tx1 = await mockTxWithFee(1, 10);
       await agePool.addPendingTxs([tx1]);
 
@@ -5439,7 +5442,9 @@ describe('TxPoolV2', () => {
       // At 12500: tx1 (added at 10000) is old enough, tx2 (added at 11000) is not
       currentTime = 12_500;
       expect(await agePool.getPendingTxCount()).toBe(2);
-      expect(await agePool.getEligiblePendingTxCount()).toBe(1);
+      expect(await agePool.hasEligiblePendingTxs(1)).toBe(true);
+      // Two txs pending but only one eligible, so the threshold of 2 is not met
+      expect(await agePool.hasEligiblePendingTxs(2)).toBe(false);
     });
 
     it('tx becomes eligible at exactly minTxPoolAgeMs', async () => {

--- a/yarn-project/p2p/src/mem_pools/tx_pool_v2/tx_pool_v2.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool_v2/tx_pool_v2.ts
@@ -156,8 +156,8 @@ export class AztecKVTxPoolV2 extends (EventEmitter as new () => TypedEventEmitte
     return this.#queue.put(() => Promise.resolve(this.#impl.getPendingTxCount()));
   }
 
-  getEligiblePendingTxCount(): Promise<number> {
-    return this.#queue.put(() => Promise.resolve(this.#impl.getEligiblePendingTxCount()));
+  hasEligiblePendingTxs(minCount: number): Promise<boolean> {
+    return this.#queue.put(() => Promise.resolve(this.#impl.hasEligiblePendingTxs(minCount)));
   }
 
   getMinedTxHashes(): Promise<[TxHash, L2BlockId][]> {

--- a/yarn-project/p2p/src/mem_pools/tx_pool_v2/tx_pool_v2.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool_v2/tx_pool_v2.ts
@@ -156,6 +156,10 @@ export class AztecKVTxPoolV2 extends (EventEmitter as new () => TypedEventEmitte
     return this.#queue.put(() => Promise.resolve(this.#impl.getPendingTxCount()));
   }
 
+  getEligiblePendingTxCount(): Promise<number> {
+    return this.#queue.put(() => Promise.resolve(this.#impl.getEligiblePendingTxCount()));
+  }
+
   getMinedTxHashes(): Promise<[TxHash, L2BlockId][]> {
     return this.#queue.put(() => Promise.resolve(this.#impl.getMinedTxHashes()));
   }

--- a/yarn-project/p2p/src/mem_pools/tx_pool_v2/tx_pool_v2_impl.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool_v2/tx_pool_v2_impl.ts
@@ -814,6 +814,11 @@ export class TxPoolV2Impl {
     return this.#indices.getPendingTxCount();
   }
 
+  getEligiblePendingTxCount(): number {
+    const maxReceivedAt = this.#dateProvider.now() - this.#config.minTxPoolAgeMs;
+    return this.#indices.getEligiblePendingTxCount(maxReceivedAt);
+  }
+
   getMinedTxHashes(): [TxHash, L2BlockId][] {
     return this.#indices.getMinedTxs().map(([hash, blockId]) => [TxHash.fromString(hash), blockId]);
   }

--- a/yarn-project/p2p/src/mem_pools/tx_pool_v2/tx_pool_v2_impl.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool_v2/tx_pool_v2_impl.ts
@@ -814,9 +814,9 @@ export class TxPoolV2Impl {
     return this.#indices.getPendingTxCount();
   }
 
-  getEligiblePendingTxCount(): number {
+  hasEligiblePendingTxs(minCount: number): boolean {
     const maxReceivedAt = this.#dateProvider.now() - this.#config.minTxPoolAgeMs;
-    return this.#indices.getEligiblePendingTxCount(maxReceivedAt);
+    return this.#indices.hasEligiblePendingTxs(maxReceivedAt, minCount);
   }
 
   getMinedTxHashes(): [TxHash, L2BlockId][] {

--- a/yarn-project/p2p/src/test-helpers/testbench-utils.ts
+++ b/yarn-project/p2p/src/test-helpers/testbench-utils.ts
@@ -171,6 +171,10 @@ export class InMemoryTxPool extends EventEmitter implements TxPoolV2 {
     return Promise.resolve(this.txsByHash.size);
   }
 
+  getEligiblePendingTxCount(): Promise<number> {
+    return this.getPendingTxCount();
+  }
+
   getMinedTxHashes(): Promise<[TxHash, L2BlockId][]> {
     return Promise.resolve([]);
   }

--- a/yarn-project/p2p/src/test-helpers/testbench-utils.ts
+++ b/yarn-project/p2p/src/test-helpers/testbench-utils.ts
@@ -171,8 +171,8 @@ export class InMemoryTxPool extends EventEmitter implements TxPoolV2 {
     return Promise.resolve(this.txsByHash.size);
   }
 
-  getEligiblePendingTxCount(): Promise<number> {
-    return this.getPendingTxCount();
+  async hasEligiblePendingTxs(minCount: number): Promise<boolean> {
+    return (await this.getPendingTxCount()) >= minCount;
   }
 
   getMinedTxHashes(): Promise<[TxHash, L2BlockId][]> {

--- a/yarn-project/sequencer-client/src/sequencer/automine/automine_sequencer.ts
+++ b/yarn-project/sequencer-client/src/sequencer/automine/automine_sequencer.ts
@@ -362,8 +362,7 @@ export class AutomineSequencer {
       return;
     }
     try {
-      const pending = await this.deps.p2pClient.getEligiblePendingTxCount();
-      if (pending > 0) {
+      if (await this.deps.p2pClient.hasEligiblePendingTxs(1)) {
         // Fire-and-forget; the build result is delivered via `buildIfPending()` callers,
         // not via the poller.
         void this.buildIfPending().catch(err => {
@@ -389,15 +388,16 @@ export class AutomineSequencer {
     }
     await this.reconcileDateProvider();
 
-    const txCount = await this.deps.p2pClient.getEligiblePendingTxCount();
-    // For mempool-driven builds, wait for at least `minTxsPerBlock` pending txs (or 1 if not set)
+    // For mempool-driven builds, wait for at least `minTxsPerBlock` age-eligible txs (or 1 if not set)
     // before building. This mirrors the production sequencer's `waitForMinTxs` behavior, and is
     // required for tests that bundle multiple txs into one block via `setConfig({ minTxsPerBlock })`.
-    // Explicit empty-block / warp paths pass `allowEmpty: true` and bypass this gate.
+    // Explicit empty-block / warp paths pass `allowEmpty: true`, giving minRequired 0, which
+    // hasEligiblePendingTxs treats as always satisfied so the gate is bypassed.
     const minRequired = allowEmpty ? 0 : Math.max(this.deps.config.minTxsPerBlock ?? 1, 1);
-    if (txCount < minRequired) {
+    if (!(await this.deps.p2pClient.hasEligiblePendingTxs(minRequired))) {
       return undefined;
     }
+    const txCount = await this.deps.p2pClient.getPendingTxCount();
 
     // Decide target slot from the pending block's timestamp — picks up any prior
     // `setNextBlockTimestamp` call (e.g. queued by runWarp) instead of assuming +1 over

--- a/yarn-project/sequencer-client/src/sequencer/automine/automine_sequencer.ts
+++ b/yarn-project/sequencer-client/src/sequencer/automine/automine_sequencer.ts
@@ -362,7 +362,7 @@ export class AutomineSequencer {
       return;
     }
     try {
-      const pending = await this.deps.p2pClient.getPendingTxCount();
+      const pending = await this.deps.p2pClient.getEligiblePendingTxCount();
       if (pending > 0) {
         // Fire-and-forget; the build result is delivered via `buildIfPending()` callers,
         // not via the poller.
@@ -389,7 +389,7 @@ export class AutomineSequencer {
     }
     await this.reconcileDateProvider();
 
-    const txCount = await this.deps.p2pClient.getPendingTxCount();
+    const txCount = await this.deps.p2pClient.getEligiblePendingTxCount();
     // For mempool-driven builds, wait for at least `minTxsPerBlock` pending txs (or 1 if not set)
     // before building. This mirrors the production sequencer's `waitForMinTxs` behavior, and is
     // required for tests that bundle multiple txs into one block via `setConfig({ minTxsPerBlock })`.

--- a/yarn-project/sequencer-client/src/sequencer/automine/automine_sequencer.ts
+++ b/yarn-project/sequencer-client/src/sequencer/automine/automine_sequencer.ts
@@ -397,7 +397,6 @@ export class AutomineSequencer {
     if (!(await this.deps.p2pClient.hasEligiblePendingTxs(minRequired))) {
       return undefined;
     }
-    const txCount = await this.deps.p2pClient.getPendingTxCount();
 
     // Decide target slot from the pending block's timestamp — picks up any prior
     // `setNextBlockTimestamp` call (e.g. queued by runWarp) instead of assuming +1 over
@@ -439,7 +438,6 @@ export class AutomineSequencer {
       blockNumber: nextBlockNumber,
       slot: targetSlot,
       slotTimestamp: slotBoundaryTs,
-      txCount,
       allowEmpty,
     });
 

--- a/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.test.ts
@@ -218,6 +218,9 @@ describe('CheckpointProposalJob', () => {
       }),
     });
     p2p.broadcastProposal.mockResolvedValue(undefined);
+    // Default the tx-availability gate to "enough txs"; tests that exercise the gate override these.
+    p2p.hasEligiblePendingTxs.mockResolvedValue(true);
+    p2p.getPendingTxCount.mockResolvedValue(0);
 
     worldState = mockDeep<WorldStateSynchronizer>();
     const mockFork = mock<MerkleTreeWriteOperations>({
@@ -707,7 +710,7 @@ describe('CheckpointProposalJob', () => {
 
     // Set up p2p mocks
     p2p.getPendingTxCount.mockResolvedValue(txs.length);
-    p2p.getEligiblePendingTxCount.mockResolvedValue(txs.length);
+    p2p.hasEligiblePendingTxs.mockImplementation(minCount => Promise.resolve(txs.length >= minCount));
     p2p.iterateEligiblePendingTxs.mockImplementation(() => mockTxIterator(Promise.resolve(txs)));
 
     // Create blocks with incrementing block numbers
@@ -1217,7 +1220,7 @@ describe('CheckpointProposalJob', () => {
 
       // Not enough txs to build a block
       p2p.getPendingTxCount.mockResolvedValue(2);
-      p2p.getEligiblePendingTxCount.mockResolvedValue(2);
+      p2p.hasEligiblePendingTxs.mockImplementation(minCount => Promise.resolve(2 >= minCount));
 
       // Install spy on waitUntilNextSubslot to verify it's called with expected deadlines
       const waitSpy = jest.spyOn(job, 'waitUntilNextSubslot');
@@ -1246,7 +1249,7 @@ describe('CheckpointProposalJob', () => {
 
       // 10 pending txs (>= minTxsPerBlock) but 0 eligible: the builder's eligible iterator would yield nothing.
       p2p.getPendingTxCount.mockResolvedValue(10);
-      p2p.getEligiblePendingTxCount.mockResolvedValue(0);
+      p2p.hasEligiblePendingTxs.mockResolvedValue(false);
 
       // Place us past the wait-for-txs deadline (subslot deadline at +10s, minus minBlockDuration 2s = +8s),
       // so waitForMinTxs gives up on its first poll instead of spinning on the polling interval.
@@ -1272,7 +1275,7 @@ describe('CheckpointProposalJob', () => {
       const block = await makeBlock(txs, globalVariables);
 
       p2p.getPendingTxCount.mockResolvedValue(10);
-      p2p.getEligiblePendingTxCount.mockResolvedValue(10);
+      p2p.hasEligiblePendingTxs.mockImplementation(minCount => Promise.resolve(10 >= minCount));
       p2p.iterateEligiblePendingTxs.mockImplementation(() => mockTxIterator(Promise.resolve(txs)));
 
       checkpointBuilder.seedBlocks([block], [txs]);
@@ -1328,7 +1331,7 @@ describe('CheckpointProposalJob', () => {
       const block = await makeBlock(txs, globalVariables);
 
       p2p.getPendingTxCount.mockResolvedValue(10);
-      p2p.getEligiblePendingTxCount.mockResolvedValue(10);
+      p2p.hasEligiblePendingTxs.mockImplementation(minCount => Promise.resolve(10 >= minCount));
       p2p.iterateEligiblePendingTxs.mockImplementation(() => mockTxIterator(Promise.resolve(txs)));
 
       checkpointBuilder.seedBlocks([block], [txs]);
@@ -1426,7 +1429,7 @@ describe('CheckpointProposalJob', () => {
 
       const txs = await Promise.all([makeTx(1, chainId)]);
       p2p.getPendingTxCount.mockResolvedValue(txs.length);
-      p2p.getEligiblePendingTxCount.mockResolvedValue(txs.length);
+      p2p.hasEligiblePendingTxs.mockImplementation(minCount => Promise.resolve(txs.length >= minCount));
       p2p.iterateEligiblePendingTxs.mockImplementation(() => mockTxIterator(Promise.resolve(txs)));
 
       const checkpoint = await job.executeAndAwait();
@@ -1439,7 +1442,7 @@ describe('CheckpointProposalJob', () => {
     it('forces checkpoint build when buildCheckpointIfEmpty is true and time allows', async () => {
       // Mock minimal txs (less than minTxsPerBlock)
       p2p.getPendingTxCount.mockResolvedValue(1);
-      p2p.getEligiblePendingTxCount.mockResolvedValue(1);
+      p2p.hasEligiblePendingTxs.mockImplementation(minCount => Promise.resolve(1 >= minCount));
       const txs = await Promise.all([makeTx(1, chainId)]);
       p2p.iterateEligiblePendingTxs.mockImplementation(() => mockTxIterator(Promise.resolve(txs)));
 
@@ -1465,7 +1468,7 @@ describe('CheckpointProposalJob', () => {
       const block = await makeBlock(txs, globalVariables);
 
       p2p.getPendingTxCount.mockResolvedValue(txs.length);
-      p2p.getEligiblePendingTxCount.mockResolvedValue(txs.length);
+      p2p.hasEligiblePendingTxs.mockImplementation(minCount => Promise.resolve(txs.length >= minCount));
       p2p.iterateEligiblePendingTxs.mockImplementation(() => mockTxIterator(Promise.resolve(txs)));
 
       checkpointBuilder.seedBlocks([block], [txs]);
@@ -1490,7 +1493,7 @@ describe('CheckpointProposalJob', () => {
     it('handles block build failure gracefully', async () => {
       const txs = await Promise.all([makeTx(1, chainId)]);
       p2p.getPendingTxCount.mockResolvedValue(txs.length);
-      p2p.getEligiblePendingTxCount.mockResolvedValue(txs.length);
+      p2p.hasEligiblePendingTxs.mockImplementation(minCount => Promise.resolve(txs.length >= minCount));
       p2p.iterateEligiblePendingTxs.mockImplementation(() => mockTxIterator(Promise.resolve(txs)));
 
       // Set up MockCheckpointBuilder to throw on build

--- a/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.test.ts
@@ -707,6 +707,7 @@ describe('CheckpointProposalJob', () => {
 
     // Set up p2p mocks
     p2p.getPendingTxCount.mockResolvedValue(txs.length);
+    p2p.getEligiblePendingTxCount.mockResolvedValue(txs.length);
     p2p.iterateEligiblePendingTxs.mockImplementation(() => mockTxIterator(Promise.resolve(txs)));
 
     // Create blocks with incrementing block numbers
@@ -1216,6 +1217,7 @@ describe('CheckpointProposalJob', () => {
 
       // Not enough txs to build a block
       p2p.getPendingTxCount.mockResolvedValue(2);
+      p2p.getEligiblePendingTxCount.mockResolvedValue(2);
 
       // Install spy on waitUntilNextSubslot to verify it's called with expected deadlines
       const waitSpy = jest.spyOn(job, 'waitUntilNextSubslot');
@@ -1234,6 +1236,31 @@ describe('CheckpointProposalJob', () => {
       expect(waitSpy.mock.calls[0][0]).toEqual(buildFrameStartSeconds() + 2);
     });
 
+    it('does not build when pending txs are not yet age-eligible and the wait deadline has passed', async () => {
+      // A single buildable sub-slot is available, so the only thing that can stop the build is the
+      // age-eligibility gate. The mempool holds plenty of pending txs, but none are old enough to build.
+      jest
+        .spyOn(job.getTimetable(), 'selectNextSubslot')
+        .mockReturnValueOnce(subslot(10, 0, true))
+        .mockReturnValue(noSubslot());
+
+      // 10 pending txs (>= minTxsPerBlock) but 0 eligible: the builder's eligible iterator would yield nothing.
+      p2p.getPendingTxCount.mockResolvedValue(10);
+      p2p.getEligiblePendingTxCount.mockResolvedValue(0);
+
+      // Place us past the wait-for-txs deadline (subslot deadline at +10s, minus minBlockDuration 2s = +8s),
+      // so waitForMinTxs gives up on its first poll instead of spinning on the polling interval.
+      dateProvider.setTime((buildFrameStartSeconds() + 9) * 1000);
+
+      job.updateConfig({ minTxsPerBlock: 5, buildCheckpointIfEmpty: false });
+      const checkpoint = await job.executeAndAwait();
+
+      // The gate must wait for eligibility rather than read the raw pending count: no block is built.
+      expect(checkpoint).toBeUndefined();
+      expect(checkpointBuilder.buildBlockCalls).toHaveLength(0);
+      expect(publisher.enqueueProposeCheckpoint).not.toHaveBeenCalled();
+    });
+
     it('stops building when selectNextSubslot returns false', async () => {
       // Mock timetable to stop after 1 block (simulating time running out)
       jest
@@ -1245,6 +1272,7 @@ describe('CheckpointProposalJob', () => {
       const block = await makeBlock(txs, globalVariables);
 
       p2p.getPendingTxCount.mockResolvedValue(10);
+      p2p.getEligiblePendingTxCount.mockResolvedValue(10);
       p2p.iterateEligiblePendingTxs.mockImplementation(() => mockTxIterator(Promise.resolve(txs)));
 
       checkpointBuilder.seedBlocks([block], [txs]);
@@ -1300,6 +1328,7 @@ describe('CheckpointProposalJob', () => {
       const block = await makeBlock(txs, globalVariables);
 
       p2p.getPendingTxCount.mockResolvedValue(10);
+      p2p.getEligiblePendingTxCount.mockResolvedValue(10);
       p2p.iterateEligiblePendingTxs.mockImplementation(() => mockTxIterator(Promise.resolve(txs)));
 
       checkpointBuilder.seedBlocks([block], [txs]);
@@ -1397,6 +1426,7 @@ describe('CheckpointProposalJob', () => {
 
       const txs = await Promise.all([makeTx(1, chainId)]);
       p2p.getPendingTxCount.mockResolvedValue(txs.length);
+      p2p.getEligiblePendingTxCount.mockResolvedValue(txs.length);
       p2p.iterateEligiblePendingTxs.mockImplementation(() => mockTxIterator(Promise.resolve(txs)));
 
       const checkpoint = await job.executeAndAwait();
@@ -1409,6 +1439,7 @@ describe('CheckpointProposalJob', () => {
     it('forces checkpoint build when buildCheckpointIfEmpty is true and time allows', async () => {
       // Mock minimal txs (less than minTxsPerBlock)
       p2p.getPendingTxCount.mockResolvedValue(1);
+      p2p.getEligiblePendingTxCount.mockResolvedValue(1);
       const txs = await Promise.all([makeTx(1, chainId)]);
       p2p.iterateEligiblePendingTxs.mockImplementation(() => mockTxIterator(Promise.resolve(txs)));
 
@@ -1434,6 +1465,7 @@ describe('CheckpointProposalJob', () => {
       const block = await makeBlock(txs, globalVariables);
 
       p2p.getPendingTxCount.mockResolvedValue(txs.length);
+      p2p.getEligiblePendingTxCount.mockResolvedValue(txs.length);
       p2p.iterateEligiblePendingTxs.mockImplementation(() => mockTxIterator(Promise.resolve(txs)));
 
       checkpointBuilder.seedBlocks([block], [txs]);
@@ -1458,6 +1490,7 @@ describe('CheckpointProposalJob', () => {
     it('handles block build failure gracefully', async () => {
       const txs = await Promise.all([makeTx(1, chainId)]);
       p2p.getPendingTxCount.mockResolvedValue(txs.length);
+      p2p.getEligiblePendingTxCount.mockResolvedValue(txs.length);
       p2p.iterateEligiblePendingTxs.mockImplementation(() => mockTxIterator(Promise.resolve(txs)));
 
       // Set up MockCheckpointBuilder to throw on build

--- a/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.timing.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.timing.test.ts
@@ -292,7 +292,7 @@ describe('CheckpointProposalJob Timing Tests', () => {
   /** Set up p2p mock to return the given transactions */
   function mockP2pWithTxs(txs: Tx[]): void {
     p2p.getPendingTxCount.mockResolvedValue(txs.length);
-    p2p.getEligiblePendingTxCount.mockResolvedValue(txs.length);
+    p2p.hasEligiblePendingTxs.mockImplementation(minCount => Promise.resolve(txs.length >= minCount));
     p2p.iterateEligiblePendingTxs.mockImplementation(() => mockTxIterator(Promise.resolve(txs)));
   }
 
@@ -435,7 +435,7 @@ describe('CheckpointProposalJob Timing Tests', () => {
     p2p.broadcastProposal.mockResolvedValue(undefined);
     p2p.broadcastCheckpointProposal.mockResolvedValue(undefined);
     p2p.getPendingTxCount.mockResolvedValue(100); // Always have enough txs
-    p2p.getEligiblePendingTxCount.mockResolvedValue(100); // Always have enough eligible txs
+    p2p.hasEligiblePendingTxs.mockResolvedValue(true); // Always have enough eligible txs
 
     worldState = mockDeep<WorldStateSynchronizer>();
     const mockFork = mock<MerkleTreeWriteOperations>({
@@ -1151,7 +1151,7 @@ describe('CheckpointProposalJob Timing Tests', () => {
       const { blocks, txs } = await createTestBlocksAndTxs(2);
       mockP2pWithTxs(txs);
       // Force a single WAITING_FOR_TXS poll before the first block by reporting no eligible txs once.
-      p2p.getEligiblePendingTxCount.mockResolvedValueOnce(0);
+      p2p.hasEligiblePendingTxs.mockResolvedValueOnce(false);
       checkpointBuilder.seedBlocks(
         blocks,
         blocks.map((_, i) => [txs[i]]),

--- a/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.timing.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.timing.test.ts
@@ -292,6 +292,7 @@ describe('CheckpointProposalJob Timing Tests', () => {
   /** Set up p2p mock to return the given transactions */
   function mockP2pWithTxs(txs: Tx[]): void {
     p2p.getPendingTxCount.mockResolvedValue(txs.length);
+    p2p.getEligiblePendingTxCount.mockResolvedValue(txs.length);
     p2p.iterateEligiblePendingTxs.mockImplementation(() => mockTxIterator(Promise.resolve(txs)));
   }
 
@@ -434,6 +435,7 @@ describe('CheckpointProposalJob Timing Tests', () => {
     p2p.broadcastProposal.mockResolvedValue(undefined);
     p2p.broadcastCheckpointProposal.mockResolvedValue(undefined);
     p2p.getPendingTxCount.mockResolvedValue(100); // Always have enough txs
+    p2p.getEligiblePendingTxCount.mockResolvedValue(100); // Always have enough eligible txs
 
     worldState = mockDeep<WorldStateSynchronizer>();
     const mockFork = mock<MerkleTreeWriteOperations>({
@@ -1148,8 +1150,8 @@ describe('CheckpointProposalJob Timing Tests', () => {
     it('passes the target slot (not the build slot) to setState for every build-frame state', async () => {
       const { blocks, txs } = await createTestBlocksAndTxs(2);
       mockP2pWithTxs(txs);
-      // Force a single WAITING_FOR_TXS poll before the first block by reporting no pending txs once.
-      p2p.getPendingTxCount.mockResolvedValueOnce(0);
+      // Force a single WAITING_FOR_TXS poll before the first block by reporting no eligible txs once.
+      p2p.getEligiblePendingTxCount.mockResolvedValueOnce(0);
       checkpointBuilder.seedBlocks(
         blocks,
         blocks.map((_, i) => [txs[i]]),

--- a/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.ts
+++ b/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.ts
@@ -1049,7 +1049,7 @@ export class CheckpointProposalJob implements Traceable {
 
     try {
       // Wait until we have enough txs to build the block
-      const { availableTxs, canStartBuilding, minTxs } = await this.waitForMinTxs(opts);
+      const { canStartBuilding, minTxs } = await this.waitForMinTxs(opts);
       if (!canStartBuilding) {
         this.logCheckpointEvent('block-build-failed', `Block build failed for slot ${this.targetSlot}`, {
           reason: 'insufficient_txs',
@@ -1057,22 +1057,20 @@ export class CheckpointProposalJob implements Traceable {
           slot: this.targetSlot,
           checkpointNumber: this.checkpointNumber,
           indexWithinCheckpoint,
-          availableTxs,
           minTxs,
         });
         this.log.verbose(
-          `Not enough age-eligible txs to build block ${blockNumber} at index ${indexWithinCheckpoint} in slot ${this.targetSlot} (needs ${minTxs} eligible, ${availableTxs} pending)`,
+          `Not enough age-eligible txs to build block ${blockNumber} at index ${indexWithinCheckpoint} in slot ${this.targetSlot} (needs ${minTxs} eligible)`,
           {
             reason: 'insufficient_txs',
             blockNumber,
             slot: this.targetSlot,
             checkpointNumber: this.checkpointNumber,
             indexWithinCheckpoint,
-            availableTxs,
             minTxs,
           },
         );
-        this.eventEmitter.emit('block-tx-count-check-failed', { minTxs, availableTxs, slot: this.targetSlot });
+        this.eventEmitter.emit('block-tx-count-check-failed', { minTxs, slot: this.targetSlot });
         this.metrics.recordBlockProposalFailed('insufficient_txs');
         return { failure: 'insufficient-txs' };
       }
@@ -1086,10 +1084,11 @@ export class CheckpointProposalJob implements Traceable {
         tx => !txHashesAlreadyIncluded.has(tx.txHash.toString()),
       );
 
-      this.log.debug(
-        `Building block ${blockNumber} at index ${indexWithinCheckpoint} for slot ${this.targetSlot} with ${availableTxs} available txs`,
-        { slot: this.targetSlot, blockNumber, indexWithinCheckpoint },
-      );
+      this.log.debug(`Building block ${blockNumber} at index ${indexWithinCheckpoint} for slot ${this.targetSlot}`, {
+        slot: this.targetSlot,
+        blockNumber,
+        indexWithinCheckpoint,
+      });
       this.setState(SequencerState.CREATING_BLOCK);
 
       // Per-block limits are operator overrides (from SEQ_MAX_L2_BLOCK_GAS etc.) further capped
@@ -1241,7 +1240,7 @@ export class CheckpointProposalJob implements Traceable {
     blockNumber: BlockNumber;
     indexWithinCheckpoint: IndexWithinCheckpoint;
     buildDeadline: Date | undefined;
-  }): Promise<{ canStartBuilding: boolean; availableTxs: number; minTxs: number }> {
+  }): Promise<{ canStartBuilding: boolean; minTxs: number }> {
     const { indexWithinCheckpoint, blockNumber, buildDeadline, forceCreate } = opts;
 
     // We only allow a block with 0 txs in the first block of the checkpoint
@@ -1258,7 +1257,7 @@ export class CheckpointProposalJob implements Traceable {
       // If we're past deadline, or we have no deadline, give up
       const now = this.dateProvider.nowAsDate();
       if (startBuildingDeadline === undefined || now >= startBuildingDeadline) {
-        return { canStartBuilding: false, availableTxs: await this.p2pClient.getPendingTxCount(), minTxs };
+        return { canStartBuilding: false, minTxs };
       }
 
       // Wait a bit before checking again
@@ -1270,7 +1269,7 @@ export class CheckpointProposalJob implements Traceable {
       await this.waitForTxsPollingInterval();
     }
 
-    return { canStartBuilding: true, availableTxs: await this.p2pClient.getPendingTxCount(), minTxs };
+    return { canStartBuilding: true, minTxs };
   }
 
   private async getSignedCommitteeAttestations(

--- a/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.ts
+++ b/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.ts
@@ -1252,7 +1252,7 @@ export class CheckpointProposalJob implements Traceable {
       ? new Date(buildDeadline.getTime() - this.timetable.minBlockDuration * 1000)
       : undefined;
 
-    let availableTxs = await this.p2pClient.getPendingTxCount();
+    let availableTxs = await this.p2pClient.getEligiblePendingTxCount();
 
     while (!forceCreate && availableTxs < minTxs) {
       // If we're past deadline, or we have no deadline, give up
@@ -1268,7 +1268,7 @@ export class CheckpointProposalJob implements Traceable {
         { blockNumber, slot: this.targetSlot, indexWithinCheckpoint },
       );
       await this.waitForTxsPollingInterval();
-      availableTxs = await this.p2pClient.getPendingTxCount();
+      availableTxs = await this.p2pClient.getEligiblePendingTxCount();
     }
 
     return { canStartBuilding: true, availableTxs, minTxs };

--- a/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.ts
+++ b/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.ts
@@ -1061,7 +1061,7 @@ export class CheckpointProposalJob implements Traceable {
           minTxs,
         });
         this.log.verbose(
-          `Not enough txs to build block ${blockNumber} at index ${indexWithinCheckpoint} in slot ${this.targetSlot} (got ${availableTxs} txs but needs ${minTxs})`,
+          `Not enough age-eligible txs to build block ${blockNumber} at index ${indexWithinCheckpoint} in slot ${this.targetSlot} (needs ${minTxs} eligible, ${availableTxs} pending)`,
           {
             reason: 'insufficient_txs',
             blockNumber,
@@ -1252,26 +1252,25 @@ export class CheckpointProposalJob implements Traceable {
       ? new Date(buildDeadline.getTime() - this.timetable.minBlockDuration * 1000)
       : undefined;
 
-    let availableTxs = await this.p2pClient.getEligiblePendingTxCount();
-
-    while (!forceCreate && availableTxs < minTxs) {
+    // Gate on age-eligible txs so we don't start building on txs the builder would then filter out for being
+    // too fresh. hasEligiblePendingTxs early-exits once minTxs are eligible instead of counting the whole pool.
+    while (!forceCreate && !(await this.p2pClient.hasEligiblePendingTxs(minTxs))) {
       // If we're past deadline, or we have no deadline, give up
       const now = this.dateProvider.nowAsDate();
       if (startBuildingDeadline === undefined || now >= startBuildingDeadline) {
-        return { canStartBuilding: false, availableTxs, minTxs };
+        return { canStartBuilding: false, availableTxs: await this.p2pClient.getPendingTxCount(), minTxs };
       }
 
       // Wait a bit before checking again
       this.setState(SequencerState.WAITING_FOR_TXS);
       this.log.verbose(
-        `Waiting for enough txs to build block ${blockNumber} at index ${indexWithinCheckpoint} in slot ${this.targetSlot} (have ${availableTxs} but need ${minTxs})`,
-        { blockNumber, slot: this.targetSlot, indexWithinCheckpoint },
+        `Waiting for ${minTxs} age-eligible txs to build block ${blockNumber} at index ${indexWithinCheckpoint} in slot ${this.targetSlot}`,
+        { blockNumber, slot: this.targetSlot, indexWithinCheckpoint, minTxs },
       );
       await this.waitForTxsPollingInterval();
-      availableTxs = await this.p2pClient.getEligiblePendingTxCount();
     }
 
-    return { canStartBuilding: true, availableTxs, minTxs };
+    return { canStartBuilding: true, availableTxs: await this.p2pClient.getPendingTxCount(), minTxs };
   }
 
   private async getSignedCommitteeAttestations(

--- a/yarn-project/sequencer-client/src/sequencer/events.ts
+++ b/yarn-project/sequencer-client/src/sequencer/events.ts
@@ -49,7 +49,7 @@ export type SequencerEvents = {
     simulatedPending: CheckpointNumber | undefined;
   }) => void;
   ['proposer-rollup-check-failed']: (args: { reason: string; slot: SlotNumber }) => void;
-  ['block-tx-count-check-failed']: (args: { minTxs: number; availableTxs: number; slot: SlotNumber }) => void;
+  ['block-tx-count-check-failed']: (args: { minTxs: number; slot: SlotNumber }) => void;
   ['block-build-failed']: (args: { reason: string; slot: SlotNumber }) => void;
   ['block-proposed']: (args: {
     blockNumber: BlockNumber;

--- a/yarn-project/sequencer-client/src/test/utils.ts
+++ b/yarn-project/sequencer-client/src/test/utils.ts
@@ -90,6 +90,7 @@ export async function makeBlock(txs: Tx[], globalVariables: GlobalVariables): Pr
  */
 export function mockPendingTxs(p2p: MockProxy<P2P>, txs: Tx[]): void {
   p2p.getPendingTxCount.mockResolvedValue(txs.length);
+  p2p.getEligiblePendingTxCount.mockResolvedValue(txs.length);
   p2p.iteratePendingTxs.mockImplementation(() => mockTxIterator(Promise.resolve(txs)));
   p2p.iterateEligiblePendingTxs.mockImplementation(() => mockTxIterator(Promise.resolve(txs)));
 }

--- a/yarn-project/sequencer-client/src/test/utils.ts
+++ b/yarn-project/sequencer-client/src/test/utils.ts
@@ -90,7 +90,7 @@ export async function makeBlock(txs: Tx[], globalVariables: GlobalVariables): Pr
  */
 export function mockPendingTxs(p2p: MockProxy<P2P>, txs: Tx[]): void {
   p2p.getPendingTxCount.mockResolvedValue(txs.length);
-  p2p.getEligiblePendingTxCount.mockResolvedValue(txs.length);
+  p2p.hasEligiblePendingTxs.mockImplementation(minCount => Promise.resolve(txs.length >= minCount));
   p2p.iteratePendingTxs.mockImplementation(() => mockTxIterator(Promise.resolve(txs)));
   p2p.iterateEligiblePendingTxs.mockImplementation(() => mockTxIterator(Promise.resolve(txs)));
 }

--- a/yarn-project/txe/src/state_machine/dummy_p2p_client.ts
+++ b/yarn-project/txe/src/state_machine/dummy_p2p_client.ts
@@ -122,8 +122,8 @@ export class DummyP2P implements P2P {
     throw new Error('DummyP2P does not implement "getPendingTxCount"');
   }
 
-  public getEligiblePendingTxCount(): Promise<number> {
-    throw new Error('DummyP2P does not implement "getEligiblePendingTxCount"');
+  public hasEligiblePendingTxs(_minCount: number): Promise<boolean> {
+    throw new Error('DummyP2P does not implement "hasEligiblePendingTxs"');
   }
 
   public start(): Promise<void> {

--- a/yarn-project/txe/src/state_machine/dummy_p2p_client.ts
+++ b/yarn-project/txe/src/state_machine/dummy_p2p_client.ts
@@ -122,6 +122,10 @@ export class DummyP2P implements P2P {
     throw new Error('DummyP2P does not implement "getPendingTxCount"');
   }
 
+  public getEligiblePendingTxCount(): Promise<number> {
+    throw new Error('DummyP2P does not implement "getEligiblePendingTxCount"');
+  }
+
   public start(): Promise<void> {
     throw new Error('DummyP2P does not implement "start"');
   }


### PR DESCRIPTION
## Context

`waitForMinTxs` decided whether enough txs were available to build a block by polling `p2pClient.getPendingTxCount()`, which counts all pending txs regardless of age. The block builder, however, only iterates txs older than `minTxPoolAgeMs` (2000ms in production). When a fresh burst lands on a near-empty mempool the gate returned `canStartBuilding: true` immediately while the eligible iterator yielded zero txs, so the builder threw `InsufficientValidTxsError` and the sub-slot was wasted (worst case on the last sub-slot: an empty checkpoint and a skipped slot). The gate never actually waited for txs to age in.

## Approach

Add an age-aware predicate `hasEligiblePendingTxs(minCount)` through the tx-pool → P2P → client layers and gate block building on it instead of the raw pending count, so the gate and the builder agree on age eligibility and the poll loop waits for aging (bounded by the existing `startBuildingDeadline`).

A predicate rather than an eligible *count*: the gate only needs to know whether at least `minTxs` eligible txs exist, and `minTxs` is typically 0 or 1. `hasEligiblePendingTxs` early-exits as soon as the threshold is met and short-circuits in O(1) when the total pending count is already below `minCount` (eligible txs are a subset of pending), instead of scanning the whole pool on every poll. `getPendingTxCount()` stays O(1) and is reused only for the informational tx count in logs/events; its semantics are unchanged. The two automine sequencer gates switch to the same predicate (a no-op under automine's `minTxPoolAgeMs=0`, kept for consistency).

## API changes

New `hasEligiblePendingTxs(minCount): Promise<boolean>` on the internal `TxPoolV2` and `P2P` interfaces (and the `TxPoolIndices`/`TxPoolV2Impl` layers). No public RPC change — stdlib's `P2PApi` is untouched.

Fixes A-1251