### PR TITLE
test(e2e): 10x faster deploy L1 contracts via on-demand mining under anvil automine

### DIFF
--- a/l1-contracts/scripts/forge_broadcast.js
+++ b/l1-contracts/scripts/forge_broadcast.js
@@ -1,10 +1,13 @@
 #!/usr/bin/env node
-// forge_broadcast.js — Run `forge script --broadcast` safely on anvil.
+// forge_broadcast.js — Run `forge script --broadcast` fast and reliably on anvil.
 //
-// Bug: anvil's auto-miner races with batched transactions. When a batch is sent,
-// anvil mines a block for the first tx but the rest arrive after the auto-mine
-// trigger fired, leaving them stranded or dropped. Temporarily switching to 1s
-// interval mining for the duration of the broadcast avoids both variants.
+// anvil's automine mines a deploy's transactions essentially instantly, which is what we want for
+// speed. But its auto-miner can race a batched broadcast: it mines a block on the first ready tx
+// and may leave txs that arrived just after the trigger sitting in the pool, so forge waits forever
+// for their receipts. To get both speed and reliability we keep automine ON and run a lightweight
+// watchdog: every few ms we check the txpool and, if anything is still pending, `evm_mine` to flush
+// it. In the common case automine has already mined everything and the watchdog is a no-op; in the
+// racy case it drains the stragglers within a few ms.
 //
 // Only activates when anvil is in automine mode.
 //
@@ -15,6 +18,8 @@ import { spawn } from "node:child_process";
 import { writeSync } from "node:fs";
 
 const log = (msg) => process.stderr.write(`[forge_broadcast] ${msg}\n`);
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+const toNumber = (v) => (typeof v === "number" ? v : Number(BigInt(v)));
 
 async function rpc(url, method, params = []) {
   const res = await fetch(url, {
@@ -33,6 +38,47 @@ function extractArg(args, flag) {
   return i >= 0 && i < args.length - 1 ? args[i + 1] : undefined;
 }
 
+// Keep automine on; poll the pool every `intervalMs` and mine any pending txs the auto-miner left
+// behind. Returns a stop function that halts polling and drains anything still pending.
+function startRaceWatchdog(rpcUrl, intervalMs = 25) {
+  let stopped = false;
+  let busy = false;
+  const mineIfPending = async () => {
+    const status = await rpc(rpcUrl, "txpool_status");
+    if (toNumber(status.pending ?? 0) > 0) {
+      await rpc(rpcUrl, "evm_mine");
+      return true;
+    }
+    return false;
+  };
+  const tick = async () => {
+    if (stopped || busy) return;
+    busy = true;
+    try {
+      await mineIfPending();
+    } catch (err) {
+      log(`watchdog error: ${err.message}`);
+    } finally {
+      busy = false;
+    }
+  };
+  const timer = setInterval(tick, intervalMs);
+  timer.unref?.();
+  return async () => {
+    stopped = true;
+    clearInterval(timer);
+    while (busy) await sleep(2);
+    for (let i = 0; i < 1000; i++) {
+      try {
+        if (!(await mineIfPending())) break;
+      } catch (err) {
+        log(`final drain error: ${err.message}`);
+        break;
+      }
+    }
+  };
+}
+
 const args = process.argv.slice(2);
 const rpcUrl = extractArg(args, "--rpc-url");
 
@@ -43,10 +89,8 @@ const [isAnvil, isAutomine] = rpcUrl
     ])
   : [false, false];
 
-if (isAnvil && isAutomine) {
-  await rpc(rpcUrl, "evm_setAutomine", [false]);
-  await rpc(rpcUrl, "evm_setIntervalMining", [1]);
-}
+// Keep automine ON for speed; the watchdog only catches what the auto-miner races on.
+const stopWatchdog = isAnvil && isAutomine ? startRaceWatchdog(rpcUrl) : undefined;
 
 const proc = spawn("forge", ["script", ...args, "--broadcast", "--batch-size", "8"], {
   stdio: ["ignore", "pipe", "inherit"],
@@ -60,12 +104,9 @@ const exitCode = await new Promise((resolve) => {
   proc.on("close", (code) => resolve(code ?? 1));
 });
 
-if (isAnvil && isAutomine) {
-  try {
-    await rpc(rpcUrl, "evm_setIntervalMining", [0]);
-    await rpc(rpcUrl, "evm_setAutomine", [true]);
-  } catch {}
-}
+try {
+  await stopWatchdog?.();
+} catch {}
 
 log(exitCode === 0 ? "Broadcast succeeded." : `Broadcast failed (exit ${exitCode}).`);
 const data = Buffer.concat(stdout);


### PR DESCRIPTION
## Summary

Deploying the L1 rollup contracts under anvil **automine** is paced at ~4.2s if we let anvil's block interval drive mining, and unreliable if we lean on plain automine: the auto-miner mines a block on the first ready tx of a concurrently-broadcast batch and can strand the rest in the pool ([foundry-rs/foundry#14891](https://github.com/foundry-rs/foundry/pull/14891)), so `forge` waits forever for their receipts.

`forge_broadcast.js` already wraps the deploy. This reworks the wrapper to be both fast and reliable: keep anvil automine **on** (batches mine instantly) and run a lightweight watchdog that polls the txpool every 25ms and `evm_mine`s anything the auto-miner left pending. In the common case automine has already mined everything and the watchdog is a no-op; in the racy case it drains the stragglers within a few ms. This replaces the previous wrapper behavior of disabling automine and mining on a 1s interval.

No foundry/anvil version bump — stays on v1.4.1.

## Measured impact

Measured on real e2e runs against a local anvil v1.4.1 (isolated on its own `ANVIL_PORT`, default `automineL1Setup`). The L1 deploy step is the `Deploying L1 contracts` → `Deployed L1 contracts` span in `deployAztecL1Contracts`; suite setup is the timing harness's `setupFnMs`.

The old 1s-interval wrapper mined the ~55M-gas / ~30-tx deploy at one block per second (~4–5 blocks); the watchdog now lets automine mine them instantly. The deploy is identical across suites, so every e2e test that does a fresh setup sees the same saving.

| e2e suite | L1 deploy step | total suite setup (`setupFnMs`) |
|---|---|---|
| `e2e_pxe` | **4.49s → 0.34s** (~13×) | **10.70s → 7.13s** (−3.6s, ~33%) |
| `e2e_event_only` | → **0.30s** | → **6.71s** |
| `e2e_private_voting_contract` | → **0.30s** | → **6.71s** |

(Before/after both measured for `e2e_pxe`; the other two show the post-change deploy/setup. The deploy step is suite-independent — the before is ~4.5s everywhere.)

## Scope

- **anvil-only.** The watchdog and every mining RPC (`evm_mine`) only run when the target RPC is anvil **and** in automine mode (detected via `web3_clientVersion` + `anvil_getAutomine`). Against a real network the wrapper sends no mining RPCs and runs `forge script --broadcast --batch-size 8`, identical to before — prod deploy behavior is unchanged.
- The wrapper is consumed at runtime from `yarn-project/l1-artifacts/l1-contracts/scripts/` (copied from `l1-contracts/scripts/` by `copy-foundry-artifacts.sh` during the build), so the speedup takes effect after a normal build.
