### PR TITLE
fix(e2e): keep timing_env testEnvironment through yarn prepare

### DIFF
--- a/yarn-project/end-to-end/package.local.json
+++ b/yarn-project/end-to-end/package.local.json
@@ -3,6 +3,7 @@
     "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --passWithNoTests src/fixtures"
   },
   "jest": {
-    "setupFilesAfterEnv": ["../../foundation/src/jest/setupAfterEnv.mjs", "jest-extended/all", "./shared/jest_setup.ts"]
+    "setupFilesAfterEnv": ["../../foundation/src/jest/setupAfterEnv.mjs", "jest-extended/all", "./shared/jest_setup.ts"],
+    "testEnvironment": "./shared/timing_env.mjs"
   }
 }


### PR DESCRIPTION
## Problem

PR #24281 added `end-to-end/src/shared/timing_env.mjs` and set the jest `testEnvironment` to `./shared/timing_env.mjs` directly in `end-to-end/package.json`. But `testEnvironment` is an **inherited** field: the package.json generator (`scripts/update_package_jsons.mjs`) shallow-merges each package's `jest` block with the parent winning, and `package.common.json` sets `testEnvironment` to `../../foundation/src/jest/env.mjs`.

As a result, `yarn prepare` reverts the override back to the foundation env, and `yarn prepare:check` (run by the pre-commit hook) fails. The inconsistency reached `merge-train/spartan-v5` because GitHub squash-merge doesn't run the local pre-commit hook, so anyone merging this base and committing locally now hits the failure.

## Fix

Move the `testEnvironment` override into `end-to-end/package.local.json`, which the generator applies **last**, so the timing test environment survives `prepare` and the generated `end-to-end/package.json` stays consistent with the inherits sources.

Verified: `node scripts/update_package_jsons.mjs --check` passes with this change and leaves `end-to-end/package.json` pointing at `./shared/timing_env.mjs`.