### PR TITLE
refactor(noir-contracts): drop unneeded constrained delivery

### DIFF
--- a/noir-projects/noir-contracts/contracts/account/ecdsa_k_account_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/account/ecdsa_k_account_contract/src/main.nr
@@ -29,7 +29,7 @@ pub contract EcdsaKAccount {
         // The deployment transaction is typically sent from a separate account (e.g. a fee-paying deployer), which
         // would otherwise be used as the sender for tags. We override it with this account's own address so the
         // recipient can discover the note by registering the account address, regardless of who deployed it.
-        self.storage.signing_public_key.initialize(pub_key_note).deliver(MessageDelivery::onchain_constrained()
+        self.storage.signing_public_key.initialize(pub_key_note).deliver(MessageDelivery::onchain_unconstrained()
             .with_sender(self.address));
     }
 

--- a/noir-projects/noir-contracts/contracts/account/ecdsa_r_account_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/account/ecdsa_r_account_contract/src/main.nr
@@ -29,7 +29,7 @@ pub contract EcdsaRAccount {
         // The deployment transaction is typically sent from a separate account (e.g. a fee-paying deployer), which
         // would otherwise be used as the sender for tags. We override it with this account's own address so the
         // recipient can discover the note by registering the account address, regardless of who deployed it.
-        self.storage.signing_public_key.initialize(pub_key_note).deliver(MessageDelivery::onchain_constrained()
+        self.storage.signing_public_key.initialize(pub_key_note).deliver(MessageDelivery::onchain_unconstrained()
             .with_sender(self.address));
     }
 

--- a/noir-projects/noir-contracts/contracts/account/schnorr_account_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/account/schnorr_account_contract/src/main.nr
@@ -39,7 +39,7 @@ pub contract SchnorrAccount {
         // The deployment transaction is typically sent from a separate account (e.g. a fee-paying deployer), which
         // would otherwise be used as the sender for tags. We override it with this account's own address so the
         // recipient can discover the note by registering the account address, regardless of who deployed it.
-        self.storage.signing_public_key.initialize(pub_key_note).deliver(MessageDelivery::onchain_constrained()
+        self.storage.signing_public_key.initialize(pub_key_note).deliver(MessageDelivery::onchain_unconstrained()
             .with_sender(self.address));
     }
 

--- a/noir-projects/noir-contracts/contracts/account/simulated_ecdsa_account_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/account/simulated_ecdsa_account_contract/src/main.nr
@@ -27,9 +27,9 @@ pub contract SimulatedEcdsaAccount {
     // Does NOT use #[initializer] so that the macro does not inject
     // assert_initialization_matches_address_preimage_private, which would fail during kernelless
     // simulation because the stub instance has a different initialization hash than the real account.
-    // Emits side effects matching the *shape* of the real EcdsaKAccount / EcdsaRAccount constructor (the
-    // key-note storage plus the constrained-delivery handshake bootstrap it triggers) so that kernelless gas
-    // estimation produces accurate results. See the body for the per-effect breakdown and the coupling this creates.
+    // Emits the same shape of side effects as the real constructor (one nullifier for
+    // SinglePrivateImmutable initialization, one note hash for the key note, and one private
+    // log tied to that note hash) so that gas estimation produces accurate results.
     #[external("private")]
     fn constructor(_signing_pub_key_x: [u8; 32], _signing_pub_key_y: [u8; 32]) {
         // Safety: Random seeds are only used to produce dummy side effects that match the shape of
@@ -56,30 +56,6 @@ pub contract SimulatedEcdsaAccount {
             BoundedVec::from_array(dummy_log),
             self.context.side_effect_counter,
         );
-
-        // The real constructor delivers the key note with `MessageDelivery::onchain_constrained()`, and a
-        // first send bootstraps a handshake: a nested call to `HandshakeRegistry::non_interactive_handshake`
-        // inserts a handshake note (note hash + initialization nullifier) and emits two logs (the note-delivery
-        // log and the recipient discovery log), and the constrained send emits a chain nullifier. We reproduce
-        // only the *shape* of those side effects so gas estimation stays accurate without running the real
-        // handshake.
-        //
-        // This couples the stub to constrained delivery's emitted shape: if the handshake bootstrap or
-        // chain-nullifier emission changes, update these dummies to match or the gas-parity assertion in
-        // e2e_kernelless_simulation.test.ts will fail.
-
-        // Handshake note hash and its initialization nullifier.
-        self.context.push_note_hash(seed + 4);
-        self.context.push_nullifier_unsafe(seed + 5);
-
-        // Chain nullifier emitted by the constrained send.
-        self.context.push_nullifier_unsafe(seed + 6);
-
-        // Handshake note-delivery log and recipient discovery log.
-        let dummy_handshake_note_log: [Field; MESSAGE_CIPHERTEXT_LEN] = [seed + 7; MESSAGE_CIPHERTEXT_LEN];
-        self.context.emit_private_log_unsafe(seed + 8, BoundedVec::from_array(dummy_handshake_note_log));
-        let dummy_handshake_discovery_log: [Field; MESSAGE_CIPHERTEXT_LEN] = [seed + 9; MESSAGE_CIPHERTEXT_LEN];
-        self.context.emit_private_log_unsafe(seed + 10, BoundedVec::from_array(dummy_handshake_discovery_log));
     }
 
     // @dev: If you globally change the entrypoint signature don't forget to update account_entrypoint.ts

--- a/noir-projects/noir-contracts/contracts/account/simulated_schnorr_account_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/account/simulated_schnorr_account_contract/src/main.nr
@@ -29,9 +29,9 @@ pub contract SimulatedSchnorrAccount {
     // Does NOT use #[initializer] so that the macro does not inject
     // assert_initialization_matches_address_preimage_private, which would fail during kernelless
     // simulation because the stub instance has a different initialization hash than the real account.
-    // Emits side effects matching the *shape* of the real SchnorrAccount constructor (the key-note storage
-    // plus the constrained-delivery handshake bootstrap it triggers) so that kernelless gas estimation
-    // produces accurate results. See the body for the per-effect breakdown and the coupling this creates.
+    // Emits the same shape of side effects as the real constructor (one nullifier for
+    // SinglePrivateImmutable initialization, one note hash for the key note, and one private
+    // log tied to that note hash) so that gas estimation produces accurate results.
     #[external("private")]
     fn constructor(_signing_pub_key_x: Field, _signing_pub_key_y: Field) {
         // Safety: Random seeds are only used to produce dummy side effects that match the shape of
@@ -58,30 +58,6 @@ pub contract SimulatedSchnorrAccount {
             BoundedVec::from_array(dummy_log),
             self.context.side_effect_counter,
         );
-
-        // The real constructor delivers the key note with `MessageDelivery::onchain_constrained()`, and a
-        // first send bootstraps a handshake: a nested call to `HandshakeRegistry::non_interactive_handshake`
-        // inserts a handshake note (note hash + initialization nullifier) and emits two logs (the note-delivery
-        // log and the recipient discovery log), and the constrained send emits a chain nullifier. We reproduce
-        // only the shape of those side effects so gas estimation stays accurate without running the real
-        // handshake.
-        //
-        // This couples the stub to constrained delivery's emitted shape: if the handshake bootstrap or
-        // chain-nullifier emission changes, update these dummies to match or the gas-parity assertion in
-        // e2e_kernelless_simulation.test.ts will fail.
-
-        // Handshake note hash and its initialization nullifier.
-        self.context.push_note_hash(seed + 4);
-        self.context.push_nullifier_unsafe(seed + 5);
-
-        // Chain nullifier emitted by the constrained send.
-        self.context.push_nullifier_unsafe(seed + 6);
-
-        // Handshake note-delivery log and recipient discovery log.
-        let dummy_handshake_note_log: [Field; MESSAGE_CIPHERTEXT_LEN] = [seed + 7; MESSAGE_CIPHERTEXT_LEN];
-        self.context.emit_private_log_unsafe(seed + 8, BoundedVec::from_array(dummy_handshake_note_log));
-        let dummy_handshake_discovery_log: [Field; MESSAGE_CIPHERTEXT_LEN] = [seed + 9; MESSAGE_CIPHERTEXT_LEN];
-        self.context.emit_private_log_unsafe(seed + 10, BoundedVec::from_array(dummy_handshake_discovery_log));
     }
 
     // @dev: If you globally change the entrypoint signature don't forget to update account_entrypoint.ts

--- a/noir-projects/noir-contracts/contracts/test/child_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/child_contract/src/main.nr
@@ -52,7 +52,7 @@ pub contract Child {
     fn private_set_value(new_value: Field, owner: AztecAddress) -> Field {
         let note = FieldNote { value: new_value };
 
-        self.storage.private_values.at(owner).insert(note).deliver(MessageDelivery::onchain_constrained());
+        self.storage.private_values.at(owner).insert(note).deliver(MessageDelivery::onchain_unconstrained());
         new_value
     }
 

--- a/noir-projects/noir-contracts/contracts/test/counter/counter_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/counter/counter_contract/src/main.nr
@@ -20,13 +20,13 @@ pub contract Counter {
     #[external("private")]
     // We can name our initializer anything we want as long as it's marked as aztec(initializer)
     fn initialize(headstart: u64, owner: AztecAddress) {
-        self.storage.counters.at(owner).add(headstart as u128).deliver(MessageDelivery::onchain_constrained());
+        self.storage.counters.at(owner).add(headstart as u128).deliver(MessageDelivery::onchain_unconstrained());
     }
 
     #[external("private")]
     fn increment(owner: AztecAddress) {
         debug_log_format("Incrementing counter for owner {0}", [owner.to_field()]);
-        self.storage.counters.at(owner).add(1).deliver(MessageDelivery::onchain_constrained());
+        self.storage.counters.at(owner).add(1).deliver(MessageDelivery::onchain_unconstrained());
     }
 
     #[external("private")]
@@ -35,8 +35,8 @@ pub contract Counter {
             "Incrementing counter twice for owner {0}",
             [owner.to_field()],
         );
-        self.storage.counters.at(owner).add(1).deliver(MessageDelivery::onchain_constrained());
-        self.storage.counters.at(owner).add(1).deliver(MessageDelivery::onchain_constrained());
+        self.storage.counters.at(owner).add(1).deliver(MessageDelivery::onchain_unconstrained());
+        self.storage.counters.at(owner).add(1).deliver(MessageDelivery::onchain_unconstrained());
     }
 
     #[external("private")]
@@ -45,14 +45,14 @@ pub contract Counter {
             "Incrementing and decrementing counter for owner {0}",
             [owner.to_field()],
         );
-        self.storage.counters.at(owner).add(1).deliver(MessageDelivery::onchain_constrained());
-        self.storage.counters.at(owner).sub(1).deliver(MessageDelivery::onchain_constrained());
+        self.storage.counters.at(owner).add(1).deliver(MessageDelivery::onchain_unconstrained());
+        self.storage.counters.at(owner).sub(1).deliver(MessageDelivery::onchain_unconstrained());
     }
 
     #[external("private")]
     fn decrement(owner: AztecAddress) {
         debug_log_format("Decrementing counter for owner {0}", [owner.to_field()]);
-        self.storage.counters.at(owner).sub(1).deliver(MessageDelivery::onchain_constrained());
+        self.storage.counters.at(owner).sub(1).deliver(MessageDelivery::onchain_unconstrained());
     }
 
     #[external("utility")]
@@ -64,7 +64,7 @@ pub contract Counter {
     fn increment_self_and_other(other_counter: AztecAddress, owner: AztecAddress) {
         debug_log_format("Incrementing counter for other {0}", [owner.to_field()]);
 
-        self.storage.counters.at(owner).add(1).deliver(MessageDelivery::onchain_constrained());
+        self.storage.counters.at(owner).add(1).deliver(MessageDelivery::onchain_unconstrained());
 
         self.call(Counter::at(other_counter).increment(owner));
     }

--- a/noir-projects/noir-contracts/contracts/test/nested_utility_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/nested_utility_contract/src/main.nr
@@ -40,7 +40,7 @@ pub contract NestedUtility {
     fn set_pow_args(x: Field, n: Field) {
         let owner = self.msg_sender();
         self.storage.pow_args.at(owner).initialize_or_replace(|_| PowNote { x, n }).deliver(
-            MessageDelivery::onchain_constrained(),
+            MessageDelivery::onchain_unconstrained(),
         );
     }
 

--- a/noir-projects/noir-contracts/contracts/test/no_constructor_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/no_constructor_contract/src/main.nr
@@ -32,7 +32,7 @@ pub contract NoConstructor {
         let owner = self.msg_sender();
         let note = FieldNote { value };
 
-        self.storage.private_mutable.at(owner).initialize(note).deliver(MessageDelivery::onchain_constrained());
+        self.storage.private_mutable.at(owner).initialize(note).deliver(MessageDelivery::onchain_unconstrained());
     }
 
     /// Helper function used to test that call to `initialize_private_mutable` was successful or not yet performed.

--- a/noir-projects/noir-contracts/contracts/test/private_init_test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/private_init_test_contract/src/main.nr
@@ -22,7 +22,7 @@ pub contract PrivateInitTest {
     fn initialize(initial_value: Field) {
         let owner = self.msg_sender();
         self.storage.value.at(owner).initialize(FieldNote { value: initial_value }).deliver(
-            MessageDelivery::onchain_constrained(),
+            MessageDelivery::onchain_unconstrained(),
         );
     }
 
@@ -30,7 +30,7 @@ pub contract PrivateInitTest {
     fn private_init_check_write_value(new_value: Field) {
         let owner = self.msg_sender();
         self.storage.value.at(owner).replace(|_old| FieldNote { value: new_value }).deliver(
-            MessageDelivery::onchain_constrained(),
+            MessageDelivery::onchain_unconstrained(),
         );
     }
 

--- a/noir-projects/noir-contracts/contracts/test/scope_test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/scope_test_contract/src/main.nr
@@ -29,7 +29,7 @@ pub contract ScopeTest {
     #[external("private")]
     fn create_note(owner: AztecAddress, value: Field) {
         let note = FieldNote { value };
-        self.storage.note.at(owner).initialize(note).deliver(MessageDelivery::onchain_constrained());
+        self.storage.note.at(owner).initialize(note).deliver(MessageDelivery::onchain_unconstrained());
     }
 
     /// Reads the note owned by the specified owner and returns its value.

--- a/noir-projects/noir-contracts/contracts/test/static_child_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/static_child_contract/src/main.nr
@@ -46,7 +46,7 @@ pub contract StaticChild {
     #[view]
     fn private_illegal_set_value(new_value: Field, owner: AztecAddress) -> Field {
         let note = FieldNote { value: new_value };
-        self.storage.a_private_value.at(owner).insert(note).deliver(MessageDelivery::onchain_constrained());
+        self.storage.a_private_value.at(owner).insert(note).deliver(MessageDelivery::onchain_unconstrained());
         new_value
     }
 
@@ -55,7 +55,7 @@ pub contract StaticChild {
     fn private_set_value(new_value: Field, owner: AztecAddress, sender: AztecAddress) -> Field {
         let note = FieldNote { value: new_value };
 
-        self.storage.a_private_value.at(owner).insert(note).deliver(MessageDelivery::onchain_constrained());
+        self.storage.a_private_value.at(owner).insert(note).deliver(MessageDelivery::onchain_unconstrained());
         new_value
     }
 

--- a/noir-projects/noir-contracts/contracts/test/test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/test_contract/src/main.nr
@@ -132,7 +132,7 @@ pub contract Test {
     #[external("private")]
     fn call_create_note(value: u128, owner: AztecAddress, storage_slot: Field, make_tx_hybrid: bool) {
         let note = UintNote { value };
-        create_note(self.context, owner, storage_slot, note).deliver(MessageDelivery::onchain_constrained());
+        create_note(self.context, owner, storage_slot, note).deliver(MessageDelivery::onchain_unconstrained());
 
         if make_tx_hybrid {
             self.enqueue_self.dummy_public_call();

--- a/noir-projects/noir-contracts/contracts/test/updatable_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/updatable_contract/src/main.nr
@@ -27,7 +27,7 @@ contract Updatable {
     fn initialize(initial_value: Field) {
         let owner = self.msg_sender();
         let note = FieldNote { value: initial_value };
-        self.storage.private_value.at(owner).initialize(note).deliver(MessageDelivery::onchain_constrained());
+        self.storage.private_value.at(owner).initialize(note).deliver(MessageDelivery::onchain_unconstrained());
         self.enqueue_self._initialize_public_value(initial_value);
     }
 

--- a/noir-projects/noir-contracts/contracts/test/updated_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/updated_contract/src/main.nr
@@ -28,7 +28,7 @@ contract Updated {
         let owner = self.msg_sender();
 
         self.storage.private_value.at(owner).replace(|_old| FieldNote { value: 27 }).deliver(
-            MessageDelivery::onchain_constrained(),
+            MessageDelivery::onchain_unconstrained(),
         );
     }
 

--- a/yarn-project/aztec/scripts/templates/counter/contract/src/main.nr
+++ b/yarn-project/aztec/scripts/templates/counter/contract/src/main.nr
@@ -24,17 +24,17 @@ pub contract Counter {
     #[initializer]
     #[external("private")]
     fn constructor(initial_value: u128, owner: AztecAddress) {
-        // Delivers the note to the recipient onchain with provable correctness.
+        // Delivers the note to the recipient onchain.
         // Without delivery, the recipient can't find or decrypt the note.
         self.storage.counters.at(owner).add(initial_value).deliver(
-            MessageDelivery::onchain_constrained(),
+            MessageDelivery::onchain_unconstrained(),
         );
     }
 
     // Adds 1 to the owner's counter.
     #[external("private")]
     fn increment(owner: AztecAddress) {
-        self.storage.counters.at(owner).add(1).deliver(MessageDelivery::onchain_constrained());
+        self.storage.counters.at(owner).add(1).deliver(MessageDelivery::onchain_unconstrained());
     }
 
     // Returns the current value of the owner's counter.


### PR DESCRIPTION
## Summary

Follow-up to #24312: audits where `MessageDelivery::onchain_constrained()` is used and drops it where it buys nothing. Constrained delivery only matters when the message sender isn't incentivized to deliver correctly and differs from the recipient; it also costs an extra nullifier, a handshake bootstrap, and serializes sends per `(sender, recipient, secret)` chain.

- **Account constructors** (`schnorr`, `ecdsa_k`, `ecdsa_r`) self-deliver the signing-key note — with `.with_sender(self.address)`, sender and recipient are both the account, so the guarantee is vacuous. Note integrity is already constrained in-circuit by `create_note` before delivery, and discoverability is preserved by the sender override plus the self-note sender scan. Now `onchain_unconstrained().with_sender(self.address)`.
- **Simulated account stubs** (`SimulatedSchnorrAccount` / `SimulatedEcdsaAccount`) reverted to their pre-#23866 shape — #23866 both wired constrained delivery into the real accounts and added the matching handshake dummies to these kernelless gas-estimation stubs.
- **Test / example contracts** that deliver notes to `self.msg_sender()` (counter, child, static_child, scope_test, no_constructor, nested_utility, test, updated, updatable, private_init_test, and the counter scaffold) downgraded to `onchain_unconstrained()`.