### PR TITLE
test(e2e): increase slashing proposer search attempts

### DIFF
--- a/yarn-project/end-to-end/src/e2e_slashing/attested_invalid_proposal.test.ts
+++ b/yarn-project/end-to-end/src/e2e_slashing/attested_invalid_proposal.test.ts
@@ -121,7 +121,7 @@ async function advanceToEpochBeforePipelinedTargetSlot({
   cheatCodes,
   targetProposer,
   logger,
-  maxAttempts = 30,
+  maxAttempts = 100,
 }: {
   epochCache: EpochCacheInterface;
   cheatCodes: RollupCheatCodes;


### PR DESCRIPTION
Increase the slashing invalid-proposal test helper attempt window from 30 to 100 epochs to fix flake.