### PR TITLE
fix: exclude tmp from yarn-project clean-lite

### DIFF
--- a/yarn-project/bootstrap.sh
+++ b/yarn-project/bootstrap.sh
@@ -298,7 +298,7 @@ case "$cmd" in
     git clean -fdx
     ;;
   "clean-lite")
-    files=$(git ls-files --ignored --others --exclude-standard | grep -vE '(node_modules/|^\.yarn/)' || true)
+    files=$(git ls-files --ignored --others --exclude-standard | grep -vE '(node_modules/|^\.yarn/|^tmp/)' || true)
     if [ -n "$files" ]; then
       echo "$files" | xargs rm -rf
     fi


### PR DESCRIPTION
The `clean-lite` step runs on every `yarn-project` bootstrap build (directly, and via the root `make` -> `yarn-project` target). It deletes git-ignored files (build artifacts) via:

```bash
git ls-files --ignored --others --exclude-standard | grep -vE '(node_modules/|^\.yarn/)' | xargs rm -rf
```

It already spared `node_modules/` and `.yarn/`, but not the top-level `yarn-project/tmp/` scratch directory, so local scratch files there were wiped on every build. This adds `^tmp/` to the exclusion so `tmp/` survives normal builds.

Note: the full `git clean` (`./bootstrap.sh clean`) still wipes everything, as before — this only affects the build-time `clean-lite`.