### PR TITLE
fix: add missing timeout to json-rpc fetch client

### DIFF
--- a/yarn-project/foundation/src/json-rpc/client/fetch.ts
+++ b/yarn-project/foundation/src/json-rpc/client/fetch.ts
@@ -36,6 +36,7 @@ export async function defaultFetch(
       method: 'POST',
       body: jsonStringify(body),
       headers: { 'content-type': 'application/json', ...extraHeaders },
+      signal: AbortSignal.timeout(60000),
     });
   } catch (err) {
     const errorMessage = `Error fetching from host ${host}: ${inspect(err)}`;


### PR DESCRIPTION
Closes #24354

Adds an \AbortSignal\ timeout to the native Node.js \etch\ client used by \defaultFetch\ in the JSON-RPC client.

Currently, because native Node \etch\ lacks a default timeout, if the Aztec testnet RPC node gets congested or drops the TCP connection silently during heavy simulation requests (e.g. \simulatePublicCalls\), the SDK hangs infinitely without throwing an error. Because it never throws, the internal \NoRetryError\ and \makeBackoff\ logic built into \makeFetch\ is never triggered.

Adding \signal: AbortSignal.timeout(60000)\ ensures the request cleanly rejects with a TimeoutError, allowing the retry logic to catch it and handle node congestion gracefully.