### PR TITLE
test(e2e): drop advancePastGenesis now that genesis uses a real timestamp

### DIFF
--- a/yarn-project/end-to-end/src/composed/ha/e2e_ha_full.parallel.test.ts
+++ b/yarn-project/end-to-end/src/composed/ha/e2e_ha_full.parallel.test.ts
@@ -232,9 +232,6 @@ describe('HA Full Setup', () => {
           startProverNode: true,
           // The bootstrap node is only an RPC/P2P anchor. HA validators are the first block producers in this suite.
           disableValidator: true,
-          // This node cannot build blocks (validation is disabled and the committee's HA nodes start later),
-          // so setup must not wait for a block past genesis.
-          advancePastGenesis: false,
           // Enable P2P for transaction gossip
           p2pEnabled: true,
           // Enable slashing for testing governance + slashing vote coordination

--- a/yarn-project/end-to-end/src/e2e_genesis_timestamp.test.ts
+++ b/yarn-project/end-to-end/src/e2e_genesis_timestamp.test.ts
@@ -9,11 +9,9 @@ import { proveInteraction } from './test-wallet/utils.js';
 
 // Verifies that genesis-anchored transactions (proved while PXE is pinned to block 0) can be
 // included in blocks after block 1, and that PXE can prove transactions anchored to genesis even
-// after the chain has advanced (public data tree diverged). Uses AUTOMINE_E2E_OPTS with
-// advancePastGenesis=false, two deployable accounts in additionallyFundedAccounts, and pxe
-// syncChainTip='proven' so the anchor stays at genesis until a real proof lands, which never happens
-// in these tests (no prover node running). (v5: replaced skipAccountDeployment with
-// advancePastGenesis=false + explicit additionallyFundedAccounts.)
+// after the chain has advanced (public data tree diverged). Uses AUTOMINE_E2E_OPTS, two deployable
+// accounts in additionallyFundedAccounts, and pxe syncChainTip='proven' so the anchor stays at
+// genesis until a real proof lands, which never happens in these tests (no prover node running).
 describe('e2e_genesis_timestamp', () => {
   let context: EndToEndContext;
 
@@ -28,12 +26,11 @@ describe('e2e_genesis_timestamp', () => {
       0,
       {
         ...AUTOMINE_E2E_OPTS,
-        // This suite pins the proven tip at genesis (no prover node, syncChainTip:'proven',
-        // advancePastGenesis:false) and asserts on genesis-anchored txs. Mining the L1 setup txs
-        // instantly shifts how far L1 time advances past the rollup genesis during deployment, which
-        // breaks those genesis-anchoring assumptions, so keep L1 setup on the anvil block interval.
+        // This suite pins the proven tip at genesis (no prover node, syncChainTip:'proven') and
+        // asserts on genesis-anchored txs. Mining the L1 setup txs instantly shifts how far L1 time
+        // advances past the rollup genesis during deployment, which breaks those genesis-anchoring
+        // assumptions, so keep L1 setup on the anvil block interval.
         automineL1Setup: false,
-        advancePastGenesis: false,
         // This test proves genesis-anchored account deployment txs, so it needs deployable accounts
         additionallyFundedAccounts: await generateSchnorrAccounts(2, 'schnorr'),
       },

--- a/yarn-project/end-to-end/src/fixtures/setup.ts
+++ b/yarn-project/end-to-end/src/fixtures/setup.ts
@@ -30,7 +30,6 @@ import { randomBytes } from '@aztec/foundation/crypto/random';
 import { tryRmDir } from '@aztec/foundation/fs';
 import { withLoggerBindings } from '@aztec/foundation/log/server';
 import { retryUntil } from '@aztec/foundation/retry';
-import { sleep } from '@aztec/foundation/sleep';
 import { DateProvider, TestDateProvider } from '@aztec/foundation/timer';
 import { SponsoredFPCContract } from '@aztec/noir-contracts.js/SponsoredFPC';
 import { getVKTreeRoot } from '@aztec/noir-protocol-circuits-types/vk-tree';
@@ -205,11 +204,6 @@ export type SetupOptions = {
   zkPassportArgs?: ZKPassportArgs;
   /** Whether to fund the sponsored FPC in genesis (defaults to false). */
   fundSponsoredFPC?: boolean;
-  /**
-   * Whether to advance the chain past genesis by mining an empty block during setup (defaults to true).
-   * Set to false for tests that must observe the chain at genesis (block 0).
-   */
-  advancePastGenesis?: boolean;
   /** L1 contracts deployment arguments. */
   l1ContractsArgs?: Partial<DeployAztecL1ContractsArgs>;
   /** Wallet minimum fee padding multiplier */
@@ -569,27 +563,6 @@ async function setupInner(
       p2pClientDeps = { p2pServiceFactory: getMockPubSubP2PServiceFactory(mockGossipSubNetwork) };
     }
 
-    // Transactions built against the genesis state must be included in block 1, otherwise they are dropped.
-    // To avoid test failures from dropped transactions, we ensure progression beyond genesis before proceeding.
-    const originalMinTxsPerBlock = config.minTxsPerBlock;
-    if (originalMinTxsPerBlock === undefined) {
-      throw new Error('minTxsPerBlock is undefined in e2e test setup');
-    }
-    const originalBuildCheckpointIfEmpty = config.buildCheckpointIfEmpty ?? false;
-
-    // Allow an empty checkpoint so the empty block can be built; leave untouched when not advancing.
-    const advancePastGenesis = (opts.advancePastGenesis ?? true) && !opts.skipInitialSequencer;
-    config.minTxsPerBlock = advancePastGenesis ? 0 : originalMinTxsPerBlock;
-    // Pipelining is always on: the proposer builds during slot N-1 for slot N. A tx submitted at slot N
-    // start arrives after that build, so forcing minTxsPerBlock=1 would stall the chain on alternating
-    // slots -- hence empty checkpoints are allowed (minTxsPerBlock=0) while advancing past genesis.
-    // Automine is unaffected: its runBuild clamps mempool builds to Math.max(minTxsPerBlock ?? 1, 1) and
-    // still requires minValidTxs: 1.
-    const shouldTemporarilyBuildEmptyCheckpoints = advancePastGenesis && config.useAutomineSequencer !== true;
-    if (shouldTemporarilyBuildEmptyCheckpoints) {
-      config.buildCheckpointIfEmpty = true;
-    }
-
     config.p2pEnabled = opts.mockGossipSubNetwork || config.p2pEnabled;
     config.p2pIp = opts.p2pIp ?? config.p2pIp ?? '127.0.0.1';
 
@@ -694,35 +667,6 @@ async function setupInner(
       accounts = defaultAccounts.map(a => a.address);
     }
     logger.trace('Created funded test accounts');
-
-    // Advancing past genesis needs a running sequencer to build the empty block; advancePastGenesis is
-    // already false when skipInitialSequencer is set.
-    if (advancePastGenesis) {
-      logger.info('Mining an empty block to progress past genesis');
-      const automine = aztecNodeService.getAutomineSequencer();
-      if (automine) {
-        await automine.buildEmptyBlock();
-      }
-      while ((await aztecNodeService.getBlockNumber()) === 0) {
-        await sleep(2000);
-      }
-    } else if (opts.skipInitialSequencer) {
-      logger.info('Sequencer not started on initial node, skipping block progression');
-    }
-    logger.trace('Advanced chain past genesis');
-
-    // Now we restore the original minTxsPerBlock setting if we changed it.
-    if (sequencerClient) {
-      const sequencer = sequencerClient.getSequencer();
-      if (config.minTxsPerBlock !== originalMinTxsPerBlock) {
-        sequencer.updateConfig({ minTxsPerBlock: originalMinTxsPerBlock });
-      }
-      if (shouldTemporarilyBuildEmptyCheckpoints) {
-        sequencer.updateConfig({ buildCheckpointIfEmpty: originalBuildCheckpointIfEmpty });
-        config.buildCheckpointIfEmpty = originalBuildCheckpointIfEmpty;
-      }
-    }
-    logger.trace('Restored sequencer config');
 
     const teardown = async () => {
       const teardownStart = performance.now();


### PR DESCRIPTION
## Motivation

The e2e setup advanced the chain past genesis by mining an empty block 1 — temporarily forcing `minTxsPerBlock=0` and `buildCheckpointIfEmpty=true` — to work around the genesis block's `timestamp=0`. With `timestamp=0`, transactions anchored to genesis had their expiration clamped to `0 + MAX_TX_LIFETIME` (~Jan 2 1970), so they could only ever be included in block 1, otherwise they were dropped. That special case is what `advancePastGenesis` (default `true`) existed to avoid.

Since #22359 the e2e setup passes `genesisTimestamp = Date.now()` through to world state in **every** setup path (`setupInner`, and `p2p_network` which inherits it). Genesis-anchored transactions therefore get a sensible expiration and can be included in any block — the block-1 special case no longer applies.

## Changes

- Remove the `advancePastGenesis` option from `SetupOptions` and the empty-block advance + `minTxsPerBlock`/`buildCheckpointIfEmpty` juggling from `setupInner`.
- Drop the now-redundant `advancePastGenesis: false` from `e2e_genesis_timestamp` and `e2e_ha_full`, and update their comments.
- Remove the now-unused `sleep` import.

## Behaviour change

Tests now observe the chain at genesis (block 0) after `setup()` instead of block 1; their first transaction lands in block 1 instead of block 2. Tests using `skipInitialSequencer` (e.g. all `MultiNodeTestContext` suites) already started at block 0, so they are unaffected.

The behaviour this guarded against (genesis-anchored txs being dropped) is already covered by `e2e_genesis_timestamp`, which proves genesis-anchored txs land in blocks after block 1.

Fixes A-1292