### PR TITLE
test(sequencer-client): freeze clock with ManualDateProvider to deflake checkpoint build-offset assertion

### DIFF
--- a/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.test.ts
@@ -13,7 +13,7 @@ import { TimeoutError } from '@aztec/foundation/error';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { Signature } from '@aztec/foundation/eth-signature';
 import { promiseWithResolvers } from '@aztec/foundation/promise';
-import { TestDateProvider } from '@aztec/foundation/timer';
+import { ManualDateProvider } from '@aztec/foundation/timer';
 import type { TypedEventEmitter } from '@aztec/foundation/types';
 import { type P2P, P2PClientState } from '@aztec/p2p';
 import type { SlasherClientInterface } from '@aztec/slasher';
@@ -89,7 +89,7 @@ describe('CheckpointProposalJob', () => {
   let l2BlockSource: MockProxy<L2BlockSource>;
   let blockSink: MockProxy<L2BlockSink & ProposedCheckpointSink>;
   let slasherClient: MockProxy<SlasherClientInterface>;
-  let dateProvider: TestDateProvider;
+  let dateProvider: ManualDateProvider;
   let metrics: MockProxy<SequencerMetrics>;
   let checkpointMetrics: MockProxy<CheckpointProposalJobMetricsRecorder>;
   let job: TestCheckpointProposalJob;
@@ -165,7 +165,9 @@ describe('CheckpointProposalJob', () => {
       rollupManaLimit: Number.MAX_SAFE_INTEGER,
     };
 
-    dateProvider = new TestDateProvider();
+    // ManualDateProvider freezes time (it does not track real wall-clock progression), so timing-sensitive
+    // assertions on dateProvider.now() are deterministic regardless of how long the test takes to execute.
+    dateProvider = new ManualDateProvider();
     // Set time to be at the start of the slot (slot 1 starts at l1GenesisTime + slotDuration - ethereumSlotDuration)
     const slotStartTime = Number(l1GenesisTime) + newSlotNumber * slotDuration - ethereumSlotDuration;
     dateProvider.setTime(slotStartTime * 1000); // Convert to milliseconds
@@ -417,8 +419,9 @@ describe('CheckpointProposalJob', () => {
       // We build checkpoint 2 on top of proposed parent at checkpoint 1.
       checkpointNumber = CheckpointNumber(2);
 
-      const checkpoint = await createCheckpointProposalJob({
-        targetSlot: SlotNumber(newSlotNumber + 1),
+      const targetSlot = SlotNumber(newSlotNumber + 1);
+      const pipelinedJob = createCheckpointProposalJob({
+        targetSlot,
         proposedCheckpointData: {
           checkpointNumber: CheckpointNumber(1),
           header: CheckpointHeader.empty(),
@@ -429,13 +432,21 @@ describe('CheckpointProposalJob', () => {
           totalManaUsed: 5000n,
           feeAssetPriceModifier: 100n,
         },
-      }).executeAndAwait();
+      });
+
+      // Anchor the (frozen) clock at the build-frame opening for the target slot before executing, since the
+      // job reads dateProvider.now() when recording the offset.
+      dateProvider.setTime(pipelinedJob.getTimetable().getBuildFrameStart(targetSlot) * 1000);
+
+      const checkpoint = await pipelinedJob.executeAndAwait();
 
       expect(checkpoint).toBeDefined();
       expect(checkpointMetrics.startCheckpointTiming).toHaveBeenCalledWith(expect.any(Number));
       expect(checkpointMetrics.recordPipelinedCheckpointBuildStartOffsetFromSlotBoundary).toHaveBeenCalledTimes(1);
+      // The build frame opens at target_slot_start - S - E, and the build slot boundary measured against is
+      // target_slot_start - S, so the offset is exactly -E (one ethereum slot before the boundary).
       const [offsetMs] = checkpointMetrics.recordPipelinedCheckpointBuildStartOffsetFromSlotBoundary.mock.calls[0];
-      expect(Math.abs(offsetMs + ethereumSlotDuration * 1000)).toBeLessThan(100);
+      expect(offsetMs).toBe(-ethereumSlotDuration * 1000);
     });
 
     it('skips building if not enough txs and not forced', async () => {


### PR DESCRIPTION
Deflakes the `CheckpointProposalJob › single block mode › records pipelined checkpoint build start offset from the wall-clock slot boundary` unit test, which intermittently fails on the v5 line (e.g. CI run `1e53239b902e768a`, `Expected: < 100 / Received: 112`).

## Root cause

The suite constructed its clock with `TestDateProvider`, which does **not** freeze time — `now()` returns `Date.now() + offset`, so it keeps tracking real wall-clock progression after the anchor. This test never re-anchored the clock before `executeAndAwait()`, so the real time elapsed inside the async build path (`setupTxsAndBlock`, `Promise.all`, `makeBlock`, archiver-sync wait) leaked straight into the recorded offset. The assertion `expect(Math.abs(offsetMs + ethereumSlotDuration * 1000)).toBeLessThan(100)` measures that real elapsed time, so under CI event-loop contention (a sibling test in the same suite holds the loop for ~84s) it crosses the 100ms budget and fails.

## Fix

- Switch the suite to the frozen `ManualDateProvider` — the same provider the sibling `checkpoint_proposal_job.timing.test.ts` already uses for exactly this reason. Time no longer advances while the test runs.
- Re-anchor the (now frozen) clock at the build-frame opening (`getTimetable().getBuildFrameStart(targetSlot)`) before executing, since the job reads `dateProvider.now()` when recording the offset.
- Tighten the assertion to the exact design value `toBe(-ethereumSlotDuration * 1000)` — the build frame opens one ethereum slot before the build-slot boundary. This is now deterministic, so the incidental `< 100ms` jitter tolerance is no longer needed.

This preserves the behavioral intent (recorded offset equals the build-frame-to-slot-boundary distance) rather than relaxing it.

## Notes

- Confined to a single test file (+18/−7); no production code changes.
- Base is `merge-train/spartan-v5`: this test's source diverges substantially from the `next` line, so the fix is scoped to the v5 release line.
- Red/green verified: with an injected delay the original assertion reproduces the CI failure (`Received: 168`); with the fix the full suite passes and the offset is deterministically `-12000` even under the same injected delay.
