### PR TITLE
fix(ethereum): broadcast L1 deploy txs one at a time on anvil to dodge automine race

### DIFF
--- a/l1-contracts/.rebuild_patterns
+++ b/l1-contracts/.rebuild_patterns
@@ -1,5 +1,6 @@
 ^l1-contracts/src/.*\.sol$
 ^l1-contracts/test/.*\.sol$
 ^l1-contracts/script/.*\.sol$
+^l1-contracts/scripts/forge_broadcast\.js$
 ^l1-contracts/bootstrap.sh
 ^l1-contracts/foundry.toml

--- a/l1-contracts/scripts/forge_broadcast.js
+++ b/l1-contracts/scripts/forge_broadcast.js
@@ -1,15 +1,13 @@
 #!/usr/bin/env node
 // forge_broadcast.js — Run `forge script --broadcast` fast and reliably on anvil.
 //
-// anvil's automine mines a deploy's transactions essentially instantly, which is what we want for
-// speed. But its auto-miner can race a batched broadcast: it mines a block on the first ready tx
-// and may leave txs that arrived just after the trigger sitting in the pool, so forge waits forever
-// for their receipts. To get both speed and reliability we keep automine ON and run a lightweight
-// watchdog: every few ms we check the txpool and, if anything is still pending, `evm_mine` to flush
-// it. In the common case automine has already mined everything and the watchdog is a no-op; in the
-// racy case it drains the stragglers within a few ms.
-//
-// Only activates when anvil is in automine mode.
+// anvil's automine mines each deploy transaction essentially instantly, which is what we want for
+// speed. But a batched broadcast (forge's default sends many txs at once) can race the auto-miner:
+// it mines a block on the first ready tx and may leave txs that arrived just after the trigger
+// sitting in the pool, so forge waits forever for their receipts. We avoid the race without touching
+// anvil's mining mode by broadcasting one tx at a time on anvil (`--batch-size 1`): with only a
+// single tx in flight there is nothing for the auto-miner to strand. A hard timeout guards against
+// a broadcast hanging indefinitely; real chains keep forge's faster default batch size.
 //
 // Usage: ./scripts/forge_broadcast.js <forge script args...>
 //        (without --broadcast or --batch-size — added automatically)
@@ -18,8 +16,6 @@ import { spawn } from "node:child_process";
 import { writeSync } from "node:fs";
 
 const log = (msg) => process.stderr.write(`[forge_broadcast] ${msg}\n`);
-const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
-const toNumber = (v) => (typeof v === "number" ? v : Number(BigInt(v)));
 
 async function rpc(url, method, params = []) {
   const res = await fetch(url, {
@@ -38,77 +34,58 @@ function extractArg(args, flag) {
   return i >= 0 && i < args.length - 1 ? args[i + 1] : undefined;
 }
 
-// Keep automine on; poll the pool every `intervalMs` and mine any pending txs the auto-miner left
-// behind. Returns a stop function that halts polling and drains anything still pending.
-function startRaceWatchdog(rpcUrl, intervalMs = 25) {
-  let stopped = false;
-  let busy = false;
-  const mineIfPending = async () => {
-    const status = await rpc(rpcUrl, "txpool_status");
-    if (toNumber(status.pending ?? 0) > 0) {
-      await rpc(rpcUrl, "evm_mine");
-      return true;
-    }
-    return false;
-  };
-  const tick = async () => {
-    if (stopped || busy) return;
-    busy = true;
-    try {
-      await mineIfPending();
-    } catch (err) {
-      log(`watchdog error: ${err.message}`);
-    } finally {
-      busy = false;
-    }
-  };
-  const timer = setInterval(tick, intervalMs);
-  timer.unref?.();
-  return async () => {
-    stopped = true;
-    clearInterval(timer);
-    while (busy) await sleep(2);
-    for (let i = 0; i < 1000; i++) {
-      try {
-        if (!(await mineIfPending())) break;
-      } catch (err) {
-        log(`final drain error: ${err.message}`);
-        break;
-      }
-    }
-  };
-}
-
 const args = process.argv.slice(2);
 const rpcUrl = extractArg(args, "--rpc-url");
 
-const [isAnvil, isAutomine] = rpcUrl
-  ? await Promise.all([
-      rpc(rpcUrl, "web3_clientVersion").then((v) => v.toLowerCase().includes("anvil")).catch(() => false),
-      rpc(rpcUrl, "anvil_getAutomine").catch(() => false),
-    ])
-  : [false, false];
+// Detect anvil so we broadcast one tx at a time there (avoiding the automine batch race) while
+// leaving real chains on forge's faster default batch size.
+const isAnvil = rpcUrl
+  ? await rpc(rpcUrl, "web3_clientVersion")
+      .then((v) => v.toLowerCase().includes("anvil"))
+      .catch(() => false)
+  : false;
 
-// Keep automine ON for speed; the watchdog only catches what the auto-miner races on.
-const stopWatchdog = isAnvil && isAutomine ? startRaceWatchdog(rpcUrl) : undefined;
+const batchSize = isAnvil ? "1" : "8";
+const timeoutMs =
+  Number(process.env.FORGE_BROADCAST_TIMEOUT_MS) ||
+  (isAnvil ? 120_000 : 1_200_000);
 
-const proc = spawn("forge", ["script", ...args, "--broadcast", "--batch-size", "8"], {
-  stdio: ["ignore", "pipe", "inherit"],
-});
+const proc = spawn(
+  "forge",
+  ["script", ...args, "--broadcast", "--batch-size", batchSize],
+  {
+    stdio: ["ignore", "pipe", "inherit"],
+  },
+);
 
 const stdout = [];
 proc.stdout.on("data", (chunk) => stdout.push(chunk));
 
+let timedOut = false;
 const exitCode = await new Promise((resolve) => {
-  proc.on("error", () => resolve(1));
-  proc.on("close", (code) => resolve(code ?? 1));
+  const timeout = setTimeout(() => {
+    timedOut = true;
+    log(`Broadcast timed out after ${timeoutMs}ms; killing forge.`);
+    proc.kill("SIGTERM");
+    const sigkill = setTimeout(() => proc.kill("SIGKILL"), 5_000);
+    sigkill.unref?.();
+  }, timeoutMs);
+  timeout.unref?.();
+  proc.on("error", () => {
+    clearTimeout(timeout);
+    resolve(1);
+  });
+  proc.on("close", (code) => {
+    clearTimeout(timeout);
+    resolve(timedOut ? 1 : (code ?? 1));
+  });
 });
 
-try {
-  await stopWatchdog?.();
-} catch {}
-
-log(exitCode === 0 ? "Broadcast succeeded." : `Broadcast failed (exit ${exitCode}).`);
+log(
+  exitCode === 0
+    ? "Broadcast succeeded."
+    : `Broadcast failed (exit ${exitCode}).`,
+);
 const data = Buffer.concat(stdout);
 if (data.length > 0) writeSync(1, data);
 process.exit(exitCode);

--- a/l1-contracts/scripts/forge_broadcast.js
+++ b/l1-contracts/scripts/forge_broadcast.js
@@ -5,9 +5,13 @@
 // speed. But a batched broadcast (forge's default sends many txs at once) can race the auto-miner:
 // it mines a block on the first ready tx and may leave txs that arrived just after the trigger
 // sitting in the pool, so forge waits forever for their receipts. We avoid the race without touching
-// anvil's mining mode by broadcasting one tx at a time on anvil (`--batch-size 1`): with only a
-// single tx in flight there is nothing for the auto-miner to strand. A hard timeout guards against
-// a broadcast hanging indefinitely; real chains keep forge's faster default batch size.
+// anvil's mining mode by broadcasting one tx at a time (`--batch-size 1`) only when anvil has
+// automine ON: with a single tx in flight there is nothing for the auto-miner to strand.
+//
+// When anvil is in interval (or no) mining mode the race does not exist — the miner drains the whole
+// pool on each block — and serializing to one tx per block would stall the deploy for a full block
+// interval per transaction, blowing past the broadcast timeout. There (and on real chains) we keep a
+// larger batch size. A hard timeout guards against a broadcast hanging indefinitely.
 //
 // Usage: ./scripts/forge_broadcast.js <forge script args...>
 //        (without --broadcast or --batch-size — added automatically)
@@ -37,15 +41,19 @@ function extractArg(args, flag) {
 const args = process.argv.slice(2);
 const rpcUrl = extractArg(args, "--rpc-url");
 
-// Detect anvil so we broadcast one tx at a time there (avoiding the automine batch race) while
-// leaving real chains on forge's faster default batch size.
-const isAnvil = rpcUrl
-  ? await rpc(rpcUrl, "web3_clientVersion")
-      .then((v) => v.toLowerCase().includes("anvil"))
-      .catch(() => false)
-  : false;
+// Broadcast one tx at a time only on an automining anvil, where batching races the auto-miner.
+// Interval-mining anvil and real chains keep a larger batch size: there is no race there, and
+// serializing would stall the deploy one block interval per tx.
+const [isAnvil, isAutomine] = rpcUrl
+  ? await Promise.all([
+      rpc(rpcUrl, "web3_clientVersion")
+        .then((v) => v.toLowerCase().includes("anvil"))
+        .catch(() => false),
+      rpc(rpcUrl, "anvil_getAutomine").catch(() => false),
+    ])
+  : [false, false];
 
-const batchSize = isAnvil ? "1" : "8";
+const batchSize = isAnvil && isAutomine ? "1" : "8";
 const timeoutMs =
   Number(process.env.FORGE_BROADCAST_TIMEOUT_MS) ||
   (isAnvil ? 120_000 : 1_200_000);


### PR DESCRIPTION
## Context

anvil's automine races a batched `forge script` broadcast: it mines a block on the first ready tx and leaves txs that arrived just after the trigger sitting in the pool, so forge waits forever for their receipts. The previous workaround kept automine on and ran a JS txpool watchdog that `evm_mine`d any stragglers — extra moving parts on every deploy.

This PR is a fix for an issue introduced in https://github.com/AztecProtocol/aztec-packages/pull/24316.

## Approach

Sidestep the race instead of policing it: on anvil, broadcast one tx at a time (`--batch-size 1`). With only a single tx in flight there is nothing for the auto-miner to strand, and automine still mines it instantly so deploys stay fast. Real chains keep forge's default batch size.

- Drop the watchdog, the `anvil_getAutomine` probe, and all mining-mode manipulation; keep `web3_clientVersion` anvil detection only to choose the batch size.
- Add a hard broadcast timeout (`FORGE_BROADCAST_TIMEOUT_MS`, default 120s anvil / 600s otherwise) that SIGTERMs then SIGKILLs forge and exits non-zero, so a hung broadcast fails fast instead of waiting out the jest hook budget.
- Preserve the buffer-stdout-and-flush-after-exit behavior the TS deploy helper relies on to parse `JSON DEPLOY RESULT:`.

Validated locally: 20/20 fresh-anvil deploys clean at ~350ms (on par with the watchdog path, far faster than interval mining), and `@aztec/ethereum` `rollup_cheat_codes.test.ts` passes.