### PR TITLE
test(e2e): deflake sync_after_reorg by waiting on the rollup's actual prune predicate

### DIFF
--- a/yarn-project/end-to-end/src/single-node/recovery/sync_after_reorg.test.ts
+++ b/yarn-project/end-to-end/src/single-node/recovery/sync_after_reorg.test.ts
@@ -1,6 +1,7 @@
 import type { AztecNodeService } from '@aztec/aztec-node';
 import type { Logger } from '@aztec/aztec.js/log';
 import { CheckpointNumber } from '@aztec/foundation/branded-types';
+import { retryUntil } from '@aztec/foundation/retry';
 import { executeTimeout } from '@aztec/foundation/timer';
 
 import type { EndToEndContext } from '../../fixtures/utils.js';
@@ -9,8 +10,8 @@ import { SingleNodeTestContext, jest, setupWithProver } from './setup.js';
 // Regression test ensuring a new node can sync world-state after an unpruned reorg (issue #12206).
 // SingleNodeTestContext with single node, no prover, prod-seq, interval mining. Timing: all defaults
 // (ethSlot=8s/12s CI, aztecSlot=16s/24s, epoch=6, proofSubmissionEpochs=1). The test stops the
-// sequencer mid-run, advances into epoch 2 via waitUntilEpochStarts, then creates a second node and
-// verifies it syncs cleanly despite the reorg window.
+// sequencer mid-run, waits until the unproven checkpoints become prunable on L1, then creates a
+// second node and verifies it syncs cleanly despite the reorg window.
 describe('single-node/recovery/sync_after_reorg', () => {
   let context: EndToEndContext;
   let logger: Logger;
@@ -31,9 +32,10 @@ describe('single-node/recovery/sync_after_reorg', () => {
   });
 
   // Regression for https://github.com/AztecProtocol/aztec-packages/issues/12206.
-  // Waits for 5 checkpoints, stops the main sequencer node, waits for epoch 2 to start (creating
-  // a reorg window), then creates a fresh non-validator node with a 10s timeout and verifies its
-  // block number is 0 (it did not get stuck on a reorg'd block).
+  // Waits for 5 checkpoints, stops the main sequencer node, waits until the rollup would prune the
+  // unproven checkpoints on the next L1 block (opening a reorg window), then creates a fresh
+  // non-validator node with a 10s timeout and verifies its block number is 0 (it did not get stuck
+  // on a reorg'd block).
   it('new node can sync world-state after unpruned reorg', async () => {
     // Wait until there are a few checkpoints in there
     // With pipelining, each checkpoint takes ~2 L2 slots (the sequencer must wait for
@@ -44,8 +46,21 @@ describe('single-node/recovery/sync_after_reorg', () => {
     logger.warn(`Stopping the main node`);
     await (context.aztecNode as AztecNodeService).stop();
 
-    // Wait for an extra epoch, so a reorg would invalidate these blocks
-    await test.waitUntilEpochStarts(2);
+    // Wait until the unproven checkpoints become prunable, so a fresh node will reorg them out on
+    // sync. We poll the rollup's own prune predicate rather than hardcoding an epoch boundary: the
+    // checkpoints become prunable `proofSubmissionEpochs + 1` epochs after the *first* checkpoint's
+    // epoch, and on a freshly-deployed chain the cold-start clock warp can land that first
+    // checkpoint in epoch 0 or epoch 1, shifting the deadline. We evaluate `canPruneAtTime` at the
+    // current L1 block timestamp, which is stricter than the archiver's own check (it looks one L1
+    // block further ahead): once it holds for a block, it holds for every later block the fresh
+    // archiver could sync to, so the archiver's `handleEpochPrune` is guaranteed to fire.
+    logger.warn(`Waiting until the rollup can prune the unproven checkpoints`);
+    await retryUntil(
+      async () => test.rollup.canPruneAtTime(BigInt(await context.cheatCodes.eth.lastBlockTimestamp())),
+      `rollup can prune unproven checkpoints`,
+      L2_SLOT_DURATION_IN_S * 12,
+      0.5,
+    );
 
     // Add a new node and watch it sync
     // We add a timeout since the archiver never finishes syncing and this promise does not resolve is the bug is not fixed


### PR DESCRIPTION
## Flake

`single-node/recovery/sync_after_reorg.test.ts` → "new node can sync world-state after unpruned reorg" was flagged FLAKED on `merge-train/spartan-v5` (CI hash `32e4c65996158955`, group `e2e-p2p-epoch-flakes`). The first attempt failed; the retry passed.

First-attempt failure:

```
expect(received).toEqual(expected) // deep equality
Expected: 0
Received: 5
> 54 |     expect(await node.getBlockNumber()).toEqual(0);
```

The fresh node synced all 5 unproven blocks instead of pruning them back to genesis.

## Root cause

The test stops the sequencer, opens a reorg window, then asserts a fresh node prunes the unproven checkpoints back to block 0 on initial sync. The fresh archiver only prunes when `rollup.canPruneAtTime` is true (`l1_synchronizer.ts` `handleEpochPrune`). The contract allows pruning once the current epoch reaches `getEpochForCheckpoint(proven + 1) + proofSubmissionEpochs + 1` — with `proofSubmissionEpochs = 1` that is `oldestPendingEpoch + 2`, where `oldestPendingEpoch` is the epoch of the first (oldest pending) checkpoint, since nothing is ever proven (no prover node).

The test hardcoded `waitUntilEpochStarts(2)`, which is only correct when the first checkpoint lands in epoch 0. On a freshly-deployed chain the L1-contract deploy warps the sim clock (~17×12s) and the sequencer comes up late, so the first checkpoint can land in epoch 0 or epoch 1 depending on cold-start timing:

- Passing CI run: first checkpoint at L2 slot 3 → epoch 0 → deadline epoch 2 → waiting for epoch 2 made it prunable → "Removed 5 checkpoints after checkpoint 0 due to predicted reorg" → block 0.
- Failing CI run: first checkpoint at L2 slot 6 → epoch 1 → deadline epoch 3 → waiting only for epoch 2 left proofs still acceptable → `canPruneAtTime` false → no prune → fresh node kept all 5 blocks.

This is the same cold-start clock-warp family as the already-merged proving-test fixes (#24364, #24372), but this reorg-recovery test is not covered by them.

## Fix

Replace the hardcoded `waitUntilEpochStarts(2)` with a poll of the rollup's own prune predicate (`canPruneAtTime` at the current L1 block timestamp) before creating the fresh node. This is robust to where the cold-start warp lands the first checkpoint, and tests the exact precondition the fresh archiver's `handleEpochPrune` checks. Evaluating at the current block timestamp is stricter than the archiver's check (which looks one L1 block further ahead), so once the wait returns the archiver's prune is guaranteed to fire. The behavioral assertion (fresh node prunes to block 0 during a prunable reorg window) is preserved.

## Verification

- Full `yarn build` passes.
- Ran the test locally — passes (the fresh archiver waits on the new poll, prunes the 5 checkpoints, and reaches block 0). The failing path requires the specific cold-start timing that only manifests under CI load (here the first checkpoint landed in epoch 0), so the red case is reasoned from the two CI logs and the contract math rather than reproduced locally.