### PR TITLE
fix(e2e): keep timing_env testEnvironment through yarn prepare

### DIFF
--- a/yarn-project/end-to-end/package.local.json
+++ b/yarn-project/end-to-end/package.local.json
@@ -3,6 +3,7 @@
     "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --passWithNoTests src/fixtures"
   },
   "jest": {
-    "setupFilesAfterEnv": ["../../foundation/src/jest/setupAfterEnv.mjs", "jest-extended/all", "./shared/jest_setup.ts"]
+    "setupFilesAfterEnv": ["../../foundation/src/jest/setupAfterEnv.mjs", "jest-extended/all", "./shared/jest_setup.ts"],
+    "testEnvironment": "./shared/timing_env.mjs"
   }
 }


### PR DESCRIPTION
Same fix as #24328, on the `merge-train/fairies-v5` train (we don't know when #24331 lands here).

`testEnvironment` is an inherited field, so the override must live in `package.local.json` (applied last) or `yarn prepare` reverts it and the pre-commit `prepare:check` fails. Base `package.json` already points at `./shared/timing_env.mjs` (from #24281), so this is the one-line `package.local.json` addition only.

`node scripts/update_package_jsons.mjs --check` passes.