### PR TITLE
test(e2e): pin gas_estimation public-payment txs to one block to deflake fee comparison

### DIFF
--- a/yarn-project/end-to-end/src/single-node/fees/gas_estimation.parallel.test.ts
+++ b/yarn-project/end-to-end/src/single-node/fees/gas_estimation.parallel.test.ts
@@ -188,7 +188,22 @@ describe('single-node/fees/gas_estimation', () => {
     const estimatedGas = await estimateGasLimits(sim2.gasUsed!);
     logGasEstimate(estimatedGas);
 
+    // Pin both transfers into the same block so they share one block.gasFees. The assertions below
+    // compare the estimated and unestimated transactionFees directly (toBeLessThan / toBeGreaterThan),
+    // which only isolates the teardown-refund difference when both txs are billed at the same L2 gas
+    // price. Under the pipelining preset (minTxsPerBlock: 0, two blocks per slot) the two concurrent
+    // sends would otherwise land in different blocks whose feePerL2Gas can differ several-fold as the
+    // L1 base fee evolves on a freshly-deployed chain, flipping the comparison.
+    const sequencer = t.context.sequencer!.getSequencer();
+    await t.aztecNodeAdmin.setConfig({ minTxsPerBlock: 2, maxTxsPerBlock: 2 });
+    // Wait for any in-progress checkpoint job to complete so the next job picks up the updated config.
+    await waitForSequencerIdle(sequencer);
+
     const [withEstimate, withoutEstimate] = await sendTransfers(estimatedGas, paymentMethod);
+
+    // Guards the same-block invariant the fee comparisons below rely on; if a batching change ever lets
+    // the two txs split across blocks again, this fails clearly instead of resurfacing as a flaky fee assertion.
+    expect(withEstimate.blockNumber).toEqual(withoutEstimate.blockNumber);
 
     const teardownFixedFee = gasSettings.teardownGasLimits.computeFee(gasSettings.maxFeesPerGas).toBigInt();
 


### PR DESCRIPTION
## Problem

The `single-node/fees/gas_estimation` test `estimates gas with public payment method` flakes (CI hash `8b1cc7ba303cf26f`, FLAKED-then-retried-green on this branch). The first-attempt failure is the fee comparison at line 200:

```
expect(received).toBeLessThan(expected)
Expected: < 1044344170000000n
Received:   4341054744900000n
```

## Root cause (grounded in logs + source)

The test sends two token-transfer txs concurrently via `sendTransfers`: `withEstimate` uses tight estimated teardown gas limits, `withoutEstimate` uses the large default limits. It expects `withEstimate` to pay less, because unused teardown gas is not refunded. `transactionFee` scales with the landing block's `feePerL2Gas`.

Under the pipelining preset (`minTxsPerBlock: 0`, two blocks per slot) the two txs are not pinned to a block, so they land in different blocks:

- `withEstimate` (`0x1a3c0ed…`, billed `l2Gas=979281`) -> block 18, `feePerL2Gas=4432900000` -> `txFee=4341054744900000` (the failing `Received`).
- `withoutEstimate` (`0x0461a777…`, billed `l2Gas=1702550`) -> block 19, `feePerL2Gas=613400000` -> `txFee=1044344170000000` (the `Expected <` bound).

On a freshly-deployed chain the L1 base fee steps down across checkpoint boundaries (here `l1BaseFee` `10721937` -> `1462645`, with `congestionCost=0` and `ethPerFeeAsset` constant), so the two blocks' `feePerL2Gas` differ ~7.2x. That price gap swamps the teardown-refund difference and flips the comparison. A passing run had the same tx split but a flat price across the boundary, so it held by luck. The L2 gas price derives from `l1BaseFee` in `sequencer-client/src/global_variable_builder/fee_predictor.ts` (`computeManaMinFee`).

## Fix

Mirror the sibling `estimates gas with Fee Juice payment method` test in the same file: set `minTxsPerBlock: 2, maxTxsPerBlock: 2` and wait for the sequencer to go idle before sending, so both txs land in the same block and share one `feePerL2Gas`. This isolates the teardown-refund difference the test actually verifies.

- No behavioral assertion is relaxed or removed.
- The sibling's `totalManaUsed === gasLimits.l2Gas * 2` assertion is deliberately not copied: the two public-payment txs bill different mana by design.
- Added an explicit `expect(withEstimate.blockNumber).toEqual(withoutEstimate.blockNumber)` so a future batching regression fails clearly rather than resurfacing as a fee-comparison flake.

## Verification

- `yarn build` passes (whole project).
- Red/green could not be reproduced locally: the failure requires the L1-base-fee step to fall between the two tx blocks, which is nondeterministic startup timing (the passing run shows it depends on chance). The green direction is structurally guaranteed by the same-block pin and is the same idiom the non-flaky Fee Juice sibling already uses; the assertion arithmetic was verified to hold at every observed `feePerL2Gas`.