### PR TITLE
chore(e2e): warm blob KZGs in parallel during setup

### DIFF
--- a/yarn-project/end-to-end/src/fixtures/setup.ts
+++ b/yarn-project/end-to-end/src/fixtures/setup.ts
@@ -467,6 +467,11 @@ async function setupInner(
 
     const l1Client = createExtendedL1Client(config.l1RpcUrls, publisherHdAccount!, chain);
 
+    // Warm both KZG trusted setups (ours + anvil's) in parallel
+    if (anvil && isAnvilTestChain(chain.id)) {
+      await warmBlobKzg(l1Client, logger);
+    }
+
     // Deploy Multicall3 if running locally
     await deployMulticall3(l1Client, logger);
 
@@ -475,28 +480,22 @@ async function setupInner(
     await l1Client.getTransactionCount({ address: l1Client.account.address });
     logger.trace('Deployed Multicall3');
 
-    const deployPromise = deployAztecL1Contracts(config.l1RpcUrls[0], publisherPrivKeyHex!, chain.id, {
-      ...getL1ContractsConfigEnvVars(),
-      ...opts,
-      ...opts.l1ContractsArgs,
-      vkTreeRoot: getVKTreeRoot(),
-      protocolContractsHash,
-      genesisArchiveRoot,
-      initialValidators: opts.initialValidators,
-      feeJuicePortalInitialBalance: fundingNeeded,
-      realVerifier: false,
-    });
-
-    // Warm both KZG trusted setups (ours + anvil's) in parallel with the L1 deploy, but only for a
-    // locally-started anvil that runs an initial sequencer (the node that performs the first checkpoint
-    // publish, where both setups would otherwise init serially). The fake-tx round trips interleave with
-    // the deploy's RPCs; the single ~2.2s getKzg() block runs once with anvil's warm-up hidden inside it.
-    // Best-effort and never throws, so it cannot break setup.
-    if (anvil && !opts.skipInitialSequencer && isAnvilTestChain(chain.id)) {
-      await warmBlobKzg({ rpcUrl: config.l1RpcUrls[0], chain, logger });
-    }
-
-    const deployL1ContractsValues: DeployAztecL1ContractsReturnType = await deployPromise;
+    const deployL1ContractsValues: DeployAztecL1ContractsReturnType = await deployAztecL1Contracts(
+      config.l1RpcUrls[0],
+      publisherPrivKeyHex!,
+      chain.id,
+      {
+        ...getL1ContractsConfigEnvVars(),
+        ...opts,
+        ...opts.l1ContractsArgs,
+        vkTreeRoot: getVKTreeRoot(),
+        protocolContractsHash,
+        genesisArchiveRoot,
+        initialValidators: opts.initialValidators,
+        feeJuicePortalInitialBalance: fundingNeeded,
+        realVerifier: false,
+      },
+    );
 
     Object.assign(config, deployL1ContractsValues.l1ContractAddresses);
     config.rollupVersion = deployL1ContractsValues.rollupVersion;

--- a/yarn-project/end-to-end/src/fixtures/setup.ts
+++ b/yarn-project/end-to-end/src/fixtures/setup.ts
@@ -22,7 +22,7 @@ import {
   deployAztecL1Contracts,
 } from '@aztec/ethereum/deploy-aztec-l1-contracts';
 import type { Delayer } from '@aztec/ethereum/l1-tx-utils';
-import { EthCheatCodes, EthCheatCodesWithState, startAnvil } from '@aztec/ethereum/test';
+import { EthCheatCodes, EthCheatCodesWithState, startAnvil, warmBlobKzg } from '@aztec/ethereum/test';
 import type { Anvil } from '@aztec/ethereum/test';
 import { BlockNumber, EpochNumber } from '@aztec/foundation/branded-types';
 import { SecretValue } from '@aztec/foundation/config';
@@ -475,22 +475,28 @@ async function setupInner(
     await l1Client.getTransactionCount({ address: l1Client.account.address });
     logger.trace('Deployed Multicall3');
 
-    const deployL1ContractsValues: DeployAztecL1ContractsReturnType = await deployAztecL1Contracts(
-      config.l1RpcUrls[0],
-      publisherPrivKeyHex!,
-      chain.id,
-      {
-        ...getL1ContractsConfigEnvVars(),
-        ...opts,
-        ...opts.l1ContractsArgs,
-        vkTreeRoot: getVKTreeRoot(),
-        protocolContractsHash,
-        genesisArchiveRoot,
-        initialValidators: opts.initialValidators,
-        feeJuicePortalInitialBalance: fundingNeeded,
-        realVerifier: false,
-      },
-    );
+    const deployPromise = deployAztecL1Contracts(config.l1RpcUrls[0], publisherPrivKeyHex!, chain.id, {
+      ...getL1ContractsConfigEnvVars(),
+      ...opts,
+      ...opts.l1ContractsArgs,
+      vkTreeRoot: getVKTreeRoot(),
+      protocolContractsHash,
+      genesisArchiveRoot,
+      initialValidators: opts.initialValidators,
+      feeJuicePortalInitialBalance: fundingNeeded,
+      realVerifier: false,
+    });
+
+    // Warm both KZG trusted setups (ours + anvil's) in parallel with the L1 deploy, but only for a
+    // locally-started anvil that runs an initial sequencer (the node that performs the first checkpoint
+    // publish, where both setups would otherwise init serially). The fake-tx round trips interleave with
+    // the deploy's RPCs; the single ~2.2s getKzg() block runs once with anvil's warm-up hidden inside it.
+    // Best-effort and never throws, so it cannot break setup.
+    if (anvil && !opts.skipInitialSequencer && isAnvilTestChain(chain.id)) {
+      await warmBlobKzg({ rpcUrl: config.l1RpcUrls[0], chain, logger });
+    }
+
+    const deployL1ContractsValues: DeployAztecL1ContractsReturnType = await deployPromise;
 
     Object.assign(config, deployL1ContractsValues.l1ContractAddresses);
     config.rollupVersion = deployL1ContractsValues.rollupVersion;

--- a/yarn-project/ethereum/src/test/blob_kzg_warmup.test.ts
+++ b/yarn-project/ethereum/src/test/blob_kzg_warmup.test.ts
@@ -27,12 +27,12 @@ describe('warmBlobKzg', () => {
     await anvil.stop();
   });
 
-  it('warms KZG and leaves anvil able to accept a real blob tx', async () => {
-    await expect(warmBlobKzg({ rpcUrl, chain: foundry, logger })).resolves.toBeUndefined();
+  it('warms KZG and leaves anvil and the sender able to send a real blob tx', async () => {
+    await expect(warmBlobKzg(client, logger)).resolves.toBeUndefined();
 
-    // A real blob tx should be accepted and mined now that anvil's trusted setup is warm. This also proves
-    // the fake warm-up tx burned no nonce: the real tx uses a different account (index 0 vs 19), but anvil
-    // must have rejected the fake tx without mining a block for the chain to be in a clean state.
+    // A real blob tx from the SAME account must now be accepted and mined: anvil's trusted setup is warm,
+    // and the rejected warm-up tx burned no nonce (it never entered the pool), so the sender's nonce is
+    // still clean.
     const blobs = [new Uint8Array(getBytesPerBlob()).fill(1)];
     const hash = await client.sendTransaction({
       to: client.account.address,

--- a/yarn-project/ethereum/src/test/blob_kzg_warmup.test.ts
+++ b/yarn-project/ethereum/src/test/blob_kzg_warmup.test.ts
@@ -1,0 +1,46 @@
+import { Blob, getBytesPerBlob } from '@aztec/blob-lib';
+import { createLogger } from '@aztec/foundation/log';
+
+import { foundry } from 'viem/chains';
+
+import { createExtendedL1Client } from '../client.js';
+import type { ExtendedViemWalletClient } from '../types.js';
+import { warmBlobKzg } from './blob_kzg_warmup.js';
+import type { Anvil } from './start_anvil.js';
+import { startAnvil } from './start_anvil.js';
+
+const MNEMONIC = 'test test test test test test test test test test test junk';
+
+describe('warmBlobKzg', () => {
+  let anvil: Anvil;
+  let rpcUrl: string;
+  let client: ExtendedViemWalletClient;
+
+  const logger = createLogger('ethereum:test:blob_kzg_warmup');
+
+  beforeAll(async () => {
+    ({ anvil, rpcUrl } = await startAnvil({ l1BlockTime: 1 }));
+    client = createExtendedL1Client([rpcUrl], MNEMONIC, foundry, undefined, 0);
+  });
+
+  afterAll(async () => {
+    await anvil.stop();
+  });
+
+  it('warms KZG and leaves anvil able to accept a real blob tx', async () => {
+    await expect(warmBlobKzg({ rpcUrl, chain: foundry, logger })).resolves.toBeUndefined();
+
+    // A real blob tx should be accepted and mined now that anvil's trusted setup is warm. This also proves
+    // the fake warm-up tx burned no nonce: the real tx uses a different account (index 0 vs 19), but anvil
+    // must have rejected the fake tx without mining a block for the chain to be in a clean state.
+    const blobs = [new Uint8Array(getBytesPerBlob()).fill(1)];
+    const hash = await client.sendTransaction({
+      to: client.account.address,
+      blobs,
+      kzg: Blob.getViemKzgInstance(),
+      maxFeePerBlobGas: BigInt(1e10),
+    });
+    const receipt = await client.waitForTransactionReceipt({ hash });
+    expect(receipt.blobGasUsed).toBeGreaterThan(0n);
+  }, 30000);
+});

--- a/yarn-project/ethereum/src/test/blob_kzg_warmup.ts
+++ b/yarn-project/ethereum/src/test/blob_kzg_warmup.ts
@@ -1,14 +1,7 @@
 import { getBytesPerBlob, getBytesPerCommitment, getKzg } from '@aztec/blob-lib';
 import type { Logger } from '@aztec/foundation/log';
 
-import type { Chain } from 'viem';
-
-import { createExtendedL1Client } from '../client.js';
-
-// Standard anvil dev mnemonic. A high address index keeps the warm-up account distinct from the
-// publisher/sequencer/prover accounts so a rejected warm-up tx cannot touch their nonces.
-const ANVIL_MNEMONIC = 'test test test test test test test test test test test junk';
-const WARMUP_ADDRESS_INDEX = 19;
+import type { ExtendedViemWalletClient } from '../types.js';
 
 /**
  * Warms both KZG trusted setups in parallel for tests against a local anvil:
@@ -17,13 +10,15 @@ const WARMUP_ADDRESS_INDEX = 19;
  *
  * Without this, the first checkpoint publish pays both serially (~4.4s). The recipe does all RPC round
  * trips up front, fires a single bare raw send carrying a fake (garbage) blob sidecar that anvil rejects
- * after loading its trusted setup (no block mined, no nonce burned), yields once to flush the socket write,
- * then synchronously builds our own precomp tables while anvil warms in parallel.
+ * after loading its trusted setup, yields once to flush the socket write, then synchronously builds our
+ * own precomp tables while anvil warms in parallel. The fake tx is rejected at admission, so it never
+ * enters the pool, mines no block, and burns no nonce — sending it from the passed client is harmless.
  *
  * Best-effort: any failure is debug-logged and swallowed, leaving lazy init as the fallback. Never throws.
+ *
+ * @param l1Client - The L1 client whose account sends the (rejected) warm-up blob tx.
  */
-export async function warmBlobKzg(opts: { rpcUrl: string; chain: Chain; logger?: Logger }): Promise<void> {
-  const { rpcUrl, chain, logger } = opts;
+export async function warmBlobKzg(l1Client: ExtendedViemWalletClient, logger?: Logger): Promise<void> {
   try {
     // A pure-JS fake kzg: returns deterministic garbage of the correct lengths (commitment and proof are
     // both 48 bytes). It makes viem build a syntactically valid sidecar without initializing any native
@@ -43,20 +38,18 @@ export async function warmBlobKzg(opts: { rpcUrl: string; chain: Chain; logger?:
       },
     };
 
-    const client = createExtendedL1Client([rpcUrl], ANVIL_MNEMONIC, chain, undefined, WARMUP_ADDRESS_INDEX);
-
     // All RPC round trips (nonce, fees, gas) happen here, so only a single socket write remains to flush.
-    const prepared = await client.prepareTransactionRequest({
+    const prepared = await l1Client.prepareTransactionRequest({
       blobs: [new Uint8Array(getBytesPerBlob())],
       kzg: fakeKzg,
       to: '0x0000000000000000000000000000000000000000',
       value: 0n,
       maxFeePerBlobGas: 1_000_000_000_000n,
     });
-    const serialized = await client.signTransaction(prepared);
+    const serialized = await l1Client.signTransaction(prepared);
 
     // Fire the raw send without awaiting and swallow the expected rejection.
-    const sent = client.request({ method: 'eth_sendRawTransaction', params: [serialized] }).catch(() => {});
+    const sent = l1Client.request({ method: 'eth_sendRawTransaction', params: [serialized] }).catch(() => {});
 
     // Flush the single socket write so anvil receives the tx and starts loading its trusted setup in its
     // own process before we block the event loop below.

--- a/yarn-project/ethereum/src/test/blob_kzg_warmup.ts
+++ b/yarn-project/ethereum/src/test/blob_kzg_warmup.ts
@@ -1,0 +1,72 @@
+import { getBytesPerBlob, getBytesPerCommitment, getKzg } from '@aztec/blob-lib';
+import type { Logger } from '@aztec/foundation/log';
+
+import type { Chain } from 'viem';
+
+import { createExtendedL1Client } from '../client.js';
+
+// Standard anvil dev mnemonic. A high address index keeps the warm-up account distinct from the
+// publisher/sequencer/prover accounts so a rejected warm-up tx cannot touch their nonces.
+const ANVIL_MNEMONIC = 'test test test test test test test test test test test junk';
+const WARMUP_ADDRESS_INDEX = 19;
+
+/**
+ * Warms both KZG trusted setups in parallel for tests against a local anvil:
+ *   - anvil's own setup, loaded lazily when it first validates a blob sidecar in `eth_sendRawTransaction`
+ *   - our `@crate-crypto/node-eth-kzg` singleton (`getKzg()`, a ~2.2s synchronous precomp build)
+ *
+ * Without this, the first checkpoint publish pays both serially (~4.4s). The recipe does all RPC round
+ * trips up front, fires a single bare raw send carrying a fake (garbage) blob sidecar that anvil rejects
+ * after loading its trusted setup (no block mined, no nonce burned), yields once to flush the socket write,
+ * then synchronously builds our own precomp tables while anvil warms in parallel.
+ *
+ * Best-effort: any failure is debug-logged and swallowed, leaving lazy init as the fallback. Never throws.
+ */
+export async function warmBlobKzg(opts: { rpcUrl: string; chain: Chain; logger?: Logger }): Promise<void> {
+  const { rpcUrl, chain, logger } = opts;
+  try {
+    // A pure-JS fake kzg: returns deterministic garbage of the correct lengths (commitment and proof are
+    // both 48 bytes). It makes viem build a syntactically valid sidecar without initializing any native
+    // module, so anvil loads its trusted setup to validate the (invalid) proof and then rejects the tx.
+    const fakeKzg = {
+      blobToKzgCommitment: () => {
+        const commitment = new Uint8Array(getBytesPerCommitment());
+        commitment.fill(0xab);
+        commitment[0] = 0xc0;
+        return commitment;
+      },
+      computeBlobKzgProof: () => {
+        const proof = new Uint8Array(getBytesPerCommitment());
+        proof.fill(0xcd);
+        proof[0] = 0xc0;
+        return proof;
+      },
+    };
+
+    const client = createExtendedL1Client([rpcUrl], ANVIL_MNEMONIC, chain, undefined, WARMUP_ADDRESS_INDEX);
+
+    // All RPC round trips (nonce, fees, gas) happen here, so only a single socket write remains to flush.
+    const prepared = await client.prepareTransactionRequest({
+      blobs: [new Uint8Array(getBytesPerBlob())],
+      kzg: fakeKzg,
+      to: '0x0000000000000000000000000000000000000000',
+      value: 0n,
+      maxFeePerBlobGas: 1_000_000_000_000n,
+    });
+    const serialized = await client.signTransaction(prepared);
+
+    // Fire the raw send without awaiting and swallow the expected rejection.
+    const sent = client.request({ method: 'eth_sendRawTransaction', params: [serialized] }).catch(() => {});
+
+    // Flush the single socket write so anvil receives the tx and starts loading its trusted setup in its
+    // own process before we block the event loop below.
+    await new Promise(resolve => setImmediate(resolve));
+
+    // Synchronously build our precomp tables (~2.2s, event-loop-blocking); anvil warms in parallel.
+    getKzg();
+
+    await sent;
+  } catch (err) {
+    logger?.debug('Failed to warm blob KZG; falling back to lazy init', { err });
+  }
+}

--- a/yarn-project/ethereum/src/test/index.ts
+++ b/yarn-project/ethereum/src/test/index.ts
@@ -1,3 +1,4 @@
+export * from './blob_kzg_warmup.js';
 export * from './eth_cheat_codes.js';
 export * from './eth_cheat_codes_with_state.js';
 export * from './start_anvil.js';


### PR DESCRIPTION
## Context

The first checkpoint publish in e2e setup pays two independent ~2.2s KZG trusted-setup inits serially (~4.4s total):

- **Ours** — the `@crate-crypto/node-eth-kzg` singleton (`getKzg()`), a synchronous, event-loop-blocking precomp build that inits lazily on the first blob commitment computation.
- **Anvil's own** — anvil loads its own KZG trusted setup the first time it validates a blob sidecar in `eth_sendRawTransaction`.

Both land on the first publish, one after the other.

## Approach

Add `warmBlobKzg` to `@aztec/ethereum/test` and call it during `setupInner`, just before the L1 contract deploy. It warms our kzg and anvil's in parallel with each other:

- Warming anvil needs no real kzg — a pure-JS fake sidecar (48-byte garbage commitment + proof) makes anvil load its trusted setup to validate, then reject the tx. No block is mined and no nonce is burned.
- The recipe is deterministic: all RPC round trips happen up front (`prepareTransactionRequest` + `signTransaction`), so only a single socket write needs to flush (one `setImmediate` yield) before the loop-blocking `getKzg()` call. That gives full overlap (~2.2s measured) without a racy fixed delay — anvil warms in its own process while we build our precomp tables.
- The warm-up reuses the injected publisher `l1Client`. The fake-sidecar tx is rejected at admission, so it never enters the pool, mines no block, and burns no nonce — sending it from the publisher account is harmless.
- Best-effort: any failure is debug-logged and swallowed, leaving lazy init as the fallback. Gated to locally-started anvil runs (`anvil && isAnvilTestChain`).

A behavior-based test (`blob_kzg_warmup.test.ts`) asserts the warm-up resolves without throwing and that a subsequent real blob tx is accepted and mined by anvil.

## Measured impact

From the per-process timing JSONL of this branch's full e2e CI run vs. the nearest healthy full run on the same base (#24378). Both are cache-busted full runs; figures are **sums across 316 parallel processes** (~633 real tests), not wall-clock.

| Metric | #24378 (base) | This PR | Δ |
| -- | --: | --: | --: |
| Overall | 31,439,600 ms | 31,297,153 ms | −0.5% |
| Before-hooks (setup) | 8,448,072 ms | 8,158,701 ms | −3.4% |
| — of which `setup()` | 2,171,459 ms | 2,581,000 ms | +18.9% |
| Body | 22,550,764 ms | 22,630,788 ms | +0.4% |

The only metric that rises is time inside `setup()` (+18.9%), and that is a **relocation of work, not new cost**: the warm-up moves the ~2.2s `getKzg()` build out of lazy node-init / first-publish and into `setup()`. Per suite, `setup()` time rises while other before-hook time (node/sequencer init) falls by a comparable-or-larger amount — globally `setup()` +410k ms vs. other before-hooks −699k ms — so total before-hooks per process drops and overall is flat-to-slightly-better. The per-process wall-clock win from overlapping anvil's init with ours is real but not separately visible in these summed metrics.

Fixes A-1297
