### PR TITLE
chore: add logging to pxe stores

### DIFF
--- a/yarn-project/key-store/src/key_store.ts
+++ b/yarn-project/key-store/src/key_store.ts
@@ -3,6 +3,7 @@ import { poseidon2HashWithSeparator } from '@aztec/foundation/crypto/poseidon';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { GrumpkinScalar, Point } from '@aztec/foundation/curves/grumpkin';
 import { toArray } from '@aztec/foundation/iterable';
+import { createLogger } from '@aztec/foundation/log';
 import { type Bufferable, serializeToBuffer } from '@aztec/foundation/serialize';
 import type { AztecAsyncKVStore, AztecAsyncMap } from '@aztec/kv-store';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
@@ -28,6 +29,9 @@ function secretKeyStorageSuffix(prefix: KeyPrefix): string {
  */
 export class KeyStore {
   public static readonly SCHEMA_VERSION = 1;
+
+  logger = createLogger('key_store');
+
   #db: AztecAsyncKVStore;
   #keys: AztecAsyncMap<string, Buffer>;
 
@@ -41,6 +45,7 @@ export class KeyStore {
    * @returns A promise that resolves to the newly created account's CompleteAddress.
    */
   public createAccount(): Promise<CompleteAddress> {
+    this.logger.debug('createAccount');
     const sk = Fr.random();
     const partialAddress = Fr.random();
     return this.addAccount(sk, partialAddress);
@@ -53,6 +58,8 @@ export class KeyStore {
    * @returns The account's complete address.
    */
   public async addAccount(sk: Fr, partialAddress: PartialAddress): Promise<CompleteAddress> {
+    // Intentionally do not log `sk` (secret key). `partialAddress` is public address-derivation material.
+    this.logger.debug('addAccount', { partialAddress });
     const {
       masterNullifierHidingKey,
       masterIncomingViewingSecretKey,
@@ -111,6 +118,7 @@ export class KeyStore {
    * @returns A Promise that resolves to an array of account addresses.
    */
   public async getAccounts(): Promise<AztecAddress[]> {
+    this.logger.debug('getAccounts');
     const allMapKeys = await toArray(this.#keys.keysAsync());
     // We return account addresses based on the map keys that end with '-ivsk_m'
     const accounts = allMapKeys.filter(key => key.endsWith('-ivsk_m')).map(key => key.split('-')[0]);
@@ -119,6 +127,7 @@ export class KeyStore {
 
   /** Checks whether an account is registered in the key store. */
   public async hasAccount(account: AztecAddress): Promise<boolean> {
+    this.logger.debug('hasAccount', { account });
     return !!(await this.#keys.getAsync(`${account.toString()}-ivsk_m`));
   }
 
@@ -130,6 +139,7 @@ export class KeyStore {
    * @returns The key validation request.
    */
   public getKeyValidationRequest(pkMHash: Fr, contractAddress: AztecAddress): Promise<KeyValidationRequest> {
+    this.logger.debug('getKeyValidationRequest', { pkMHash, contractAddress });
     return this.#db.transactionAsync(async () => {
       const [keyPrefix, account] = await this.getKeyPrefixAndAccount(pkMHash);
 
@@ -178,6 +188,7 @@ export class KeyStore {
    * @throws If the account does not exist in the key store.
    */
   public async getMasterNullifierPublicKey(account: AztecAddress): Promise<PublicKey> {
+    this.logger.debug('getMasterNullifierPublicKey', { account });
     return Point.fromBuffer(await this.#getMasterKeyBuffer(account, 'npk_m'));
   }
 
@@ -186,6 +197,7 @@ export class KeyStore {
    * @throws If the account does not exist in the key store.
    */
   public async getMasterIncomingViewingPublicKey(account: AztecAddress): Promise<PublicKey> {
+    this.logger.debug('getMasterIncomingViewingPublicKey', { account });
     return Point.fromBuffer(await this.#getMasterKeyBuffer(account, 'ivpk_m'));
   }
 
@@ -194,6 +206,7 @@ export class KeyStore {
    * @throws If the account does not exist in the key store.
    */
   public async getMasterOutgoingViewingPublicKey(account: AztecAddress): Promise<PublicKey> {
+    this.logger.debug('getMasterOutgoingViewingPublicKey', { account });
     return Point.fromBuffer(await this.#getMasterKeyBuffer(account, 'ovpk_m'));
   }
 
@@ -202,6 +215,7 @@ export class KeyStore {
    * @throws If the account does not exist in the key store.
    */
   public async getMasterTaggingPublicKey(account: AztecAddress): Promise<PublicKey> {
+    this.logger.debug('getMasterTaggingPublicKey', { account });
     return Point.fromBuffer(await this.#getMasterKeyBuffer(account, 'tpk_m'));
   }
 
@@ -210,6 +224,7 @@ export class KeyStore {
    * @throws If the account does not exist in the key store.
    */
   public async getMasterMessageSigningPublicKey(account: AztecAddress): Promise<PublicKey> {
+    this.logger.debug('getMasterMessageSigningPublicKey', { account });
     return Point.fromBuffer(await this.#getMasterKeyBuffer(account, 'mspk_m'));
   }
 
@@ -218,6 +233,7 @@ export class KeyStore {
    * @throws If the account does not exist in the key store.
    */
   public async getMasterFallbackPublicKey(account: AztecAddress): Promise<PublicKey> {
+    this.logger.debug('getMasterFallbackPublicKey', { account });
     return Point.fromBuffer(await this.#getMasterKeyBuffer(account, 'fbpk_m'));
   }
 
@@ -226,6 +242,7 @@ export class KeyStore {
    * @throws If the account does not exist in the key store.
    */
   public async getMasterMessageSigningSecretKey(account: AztecAddress): Promise<GrumpkinScalar> {
+    this.logger.debug('getMasterMessageSigningSecretKey', { account });
     return GrumpkinScalar.fromBuffer(await this.#getMasterKeyBuffer(account, 'mssk_m'));
   }
 
@@ -234,6 +251,7 @@ export class KeyStore {
    * @throws If the account does not exist in the key store.
    */
   public async getMasterFallbackSecretKey(account: AztecAddress): Promise<GrumpkinScalar> {
+    this.logger.debug('getMasterFallbackSecretKey', { account });
     return GrumpkinScalar.fromBuffer(await this.#getMasterKeyBuffer(account, 'fbsk_m'));
   }
 
@@ -242,6 +260,7 @@ export class KeyStore {
    * @throws If the account does not exist in the key store.
    */
   public async getMasterIncomingViewingSecretKey(account: AztecAddress): Promise<GrumpkinScalar> {
+    this.logger.debug('getMasterIncomingViewingSecretKey', { account });
     return GrumpkinScalar.fromBuffer(await this.#getMasterKeyBuffer(account, 'ivsk_m'));
   }
 
@@ -253,6 +272,7 @@ export class KeyStore {
    * @returns A Promise that resolves to the application outgoing viewing secret key.
    */
   public async getAppOutgoingViewingSecretKey(account: AztecAddress, app: AztecAddress): Promise<Fr> {
+    this.logger.debug('getAppOutgoingViewingSecretKey', { account, app });
     const masterOutgoingViewingSecretKey = GrumpkinScalar.fromBuffer(await this.#getMasterKeyBuffer(account, 'ovsk_m'));
 
     return poseidon2HashWithSeparator(
@@ -269,6 +289,7 @@ export class KeyStore {
    * @dev Used when feeding the sk_m to the kernel circuit for keys verification.
    */
   public getMasterSecretKey(pkMHash: Fr): Promise<GrumpkinScalar> {
+    this.logger.debug('getMasterSecretKey', { pkMHash });
     return this.#db.transactionAsync(async () => {
       const [keyPrefix, account] = await this.getKeyPrefixAndAccount(pkMHash);
 
@@ -306,6 +327,7 @@ export class KeyStore {
    * @returns True if the account has a key with the given hash.
    */
   public accountHasKey(account: AztecAddress, pkMHash: Fr): Promise<boolean> {
+    this.logger.debug('accountHasKey', { account, pkMHash });
     return this.#db.transactionAsync(async () => {
       const pkMHashBuffer = serializeToBuffer(pkMHash);
       for (const prefix of KEY_PREFIXES) {
@@ -325,6 +347,7 @@ export class KeyStore {
    * in the key store.
    */
   public async getKeyPrefixAndAccount(value: Bufferable): Promise<[KeyPrefix, AztecAddress]> {
+    this.logger.debug('getKeyPrefixAndAccount');
     const valueBuffer = serializeToBuffer(value);
     for await (const [key, val] of this.#keys.entriesAsync()) {
       // Browser returns Uint8Array, Node.js returns Buffer

--- a/yarn-project/kv-store/src/stores/l2_tips_store.ts
+++ b/yarn-project/kv-store/src/stores/l2_tips_store.ts
@@ -1,4 +1,5 @@
 import { BlockNumber, CheckpointNumber } from '@aztec/foundation/branded-types';
+import { type Logger, createLogger } from '@aztec/foundation/log';
 import { type BlockHash, type CheckpointId, type L2BlockTag, L2TipsStoreBase } from '@aztec/stdlib/block';
 
 import type { AztecAsyncMap } from '../interfaces/map.js';
@@ -12,6 +13,8 @@ type StoredCheckpointId = { number: number; hash: string };
  * Used by nodes that need to persist chain state across restarts.
  */
 export class L2TipsKVStore extends L2TipsStoreBase {
+  private readonly logger: Logger;
+
   private readonly l2TipsStore: AztecAsyncMap<L2BlockTag, BlockNumber>;
   private readonly l2TipCheckpointsStore: AztecAsyncMap<L2BlockTag, StoredCheckpointId>;
   private readonly l2BlockHashesStore: AztecAsyncMap<BlockNumber, string>;
@@ -22,20 +25,24 @@ export class L2TipsKVStore extends L2TipsStoreBase {
     initialBlockHash: BlockHash,
   ) {
     super(initialBlockHash);
+    this.logger = createLogger('l2_tips_store', { instanceId: namespace });
     this.l2TipsStore = store.openMap([namespace, 'l2_tips'].join('_'));
     this.l2TipCheckpointsStore = store.openMap([namespace, 'l2_tip_checkpoints'].join('_'));
     this.l2BlockHashesStore = store.openMap([namespace, 'l2_block_hashes'].join('_'));
   }
 
   protected getTip(tag: L2BlockTag): Promise<BlockNumber | undefined> {
+    this.logger.debug('getTip', { tag });
     return this.l2TipsStore.getAsync(tag);
   }
 
   protected setTip(tag: L2BlockTag, blockNumber: BlockNumber): Promise<void> {
+    this.logger.debug('setTip', { tag, blockNumber });
     return this.l2TipsStore.set(tag, blockNumber);
   }
 
   protected async getTipCheckpoint(tag: L2BlockTag): Promise<CheckpointId | undefined> {
+    this.logger.debug('getTipCheckpoint', { tag });
     const stored = await this.l2TipCheckpointsStore.getAsync(tag);
     if (stored === undefined) {
       return undefined;
@@ -44,24 +51,29 @@ export class L2TipsKVStore extends L2TipsStoreBase {
   }
 
   protected setTipCheckpoint(tag: L2BlockTag, checkpoint: CheckpointId): Promise<void> {
+    this.logger.debug('setTipCheckpoint', { tag, checkpoint });
     return this.l2TipCheckpointsStore.set(tag, { number: checkpoint.number, hash: checkpoint.hash });
   }
 
   protected getStoredBlockHash(blockNumber: BlockNumber): Promise<string | undefined> {
+    this.logger.debug('getStoredBlockHash', { blockNumber });
     return this.l2BlockHashesStore.getAsync(blockNumber);
   }
 
   protected setBlockHash(blockNumber: BlockNumber, hash: string): Promise<void> {
+    this.logger.debug('setBlockHash', { blockNumber, hash });
     return this.l2BlockHashesStore.set(blockNumber, hash);
   }
 
   protected async deleteBlockHashesBefore(blockNumber: BlockNumber): Promise<void> {
+    this.logger.debug('deleteBlockHashesBefore', { blockNumber });
     for await (const key of this.l2BlockHashesStore.keysAsync({ end: blockNumber })) {
       await this.l2BlockHashesStore.delete(key);
     }
   }
 
   protected runInTransaction<T>(fn: () => Promise<T>): Promise<T> {
+    this.logger.debug('runInTransaction');
     return this.store.transactionAsync(fn);
   }
 }

--- a/yarn-project/pxe/src/storage/address_store/address_store.ts
+++ b/yarn-project/pxe/src/storage/address_store/address_store.ts
@@ -1,9 +1,12 @@
 import { toArray } from '@aztec/foundation/iterable';
+import { createLogger } from '@aztec/foundation/log';
 import type { AztecAsyncArray, AztecAsyncKVStore, AztecAsyncMap } from '@aztec/kv-store';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
 import { CompleteAddress } from '@aztec/stdlib/contract';
 
 export class AddressStore {
+  logger = createLogger('address_store');
+
   #store: AztecAsyncKVStore;
   #completeAddresses: AztecAsyncArray<Buffer>;
   #completeAddressIndex: AztecAsyncMap<string, number>;
@@ -16,6 +19,7 @@ export class AddressStore {
   }
 
   addCompleteAddress(completeAddress: CompleteAddress): Promise<boolean> {
+    this.logger.debug('addCompleteAddress', { address: completeAddress.address });
     return this.#store.transactionAsync(async () => {
       // TODO readd this
       // await this.#addScope(completeAddress.address);
@@ -44,6 +48,7 @@ export class AddressStore {
   }
 
   getCompleteAddress(account: AztecAddress): Promise<CompleteAddress | undefined> {
+    this.logger.debug('getCompleteAddress', { account });
     return this.#store.transactionAsync(async () => {
       const index = await this.#completeAddressIndex.getAsync(account.toString());
       if (index === undefined) {
@@ -56,6 +61,7 @@ export class AddressStore {
   }
 
   getCompleteAddresses(): Promise<CompleteAddress[]> {
+    this.logger.debug('getCompleteAddresses');
     return this.#store.transactionAsync(async () => {
       return await Promise.all(
         (await toArray(this.#completeAddresses.valuesAsync())).map(v => CompleteAddress.fromBuffer(v)),

--- a/yarn-project/pxe/src/storage/anchor_block_store/anchor_block_store.ts
+++ b/yarn-project/pxe/src/storage/anchor_block_store/anchor_block_store.ts
@@ -1,3 +1,4 @@
+import { createLogger } from '@aztec/foundation/log';
 import type { AztecAsyncKVStore, AztecAsyncSingleton } from '@aztec/kv-store';
 import { BlockHeader } from '@aztec/stdlib/tx';
 
@@ -6,6 +7,8 @@ import { BlockHeader } from '@aztec/stdlib/tx';
  * advances or reorgs.
  */
 export class AnchorBlockStore {
+  logger = createLogger('anchor_block_store');
+
   #store: AztecAsyncKVStore;
   #synchronizedHeader: AztecAsyncSingleton<Buffer>;
 
@@ -22,10 +25,12 @@ export class AnchorBlockStore {
    * support for reentrancy).
    */
   async setHeader(header: BlockHeader): Promise<void> {
+    this.logger.debug('setHeader', { blockNumber: header.getBlockNumber() });
     await this.#synchronizedHeader.set(header.toBuffer());
   }
 
   async getBlockHeader(): Promise<BlockHeader> {
+    this.logger.debug('getBlockHeader');
     const headerBuffer = await this.#store.transactionAsync(() => this.#synchronizedHeader.getAsync());
     if (!headerBuffer) {
       throw new Error(`Trying to get block header with a not-yet-synchronized PXE - this should never happen`);

--- a/yarn-project/pxe/src/storage/capsule_store/capsule_store.ts
+++ b/yarn-project/pxe/src/storage/capsule_store/capsule_store.ts
@@ -100,6 +100,7 @@ export class CapsuleStore implements StagedStore {
    * @param jobId - The jobId identifying which staged data to commit
    */
   async commit(jobId: string): Promise<void> {
+    this.logger.debug('commit', { jobId });
     const jobStagedCapsules = this.#getJobStagedCapsules(jobId);
 
     for (const [key, value] of jobStagedCapsules) {
@@ -120,6 +121,7 @@ export class CapsuleStore implements StagedStore {
    * Discards staged data without committing.
    */
   discardStaged(jobId: string): Promise<void> {
+    this.logger.debug('discardStaged', { jobId });
     this.#stagedCapsules.delete(jobId);
     return Promise.resolve();
   }
@@ -136,6 +138,7 @@ export class CapsuleStore implements StagedStore {
    * network state it's backed by local PXE db.
    */
   setCapsule(contractAddress: AztecAddress, slot: Fr, capsule: Fr[], jobId: string, scope: AztecAddress) {
+    this.logger.debug('setCapsule', { contractAddress, slot, scope, jobId });
     const dbSlotKey = dbSlotToKey(contractAddress, slot, scope);
 
     // A store overrides any pre-existing data on the slot
@@ -149,6 +152,7 @@ export class CapsuleStore implements StagedStore {
    * @returns The stored data or `null` if no data is stored under the slot.
    */
   getCapsule(contractAddress: AztecAddress, slot: Fr, jobId: string, scope: AztecAddress): Promise<Fr[] | null> {
+    this.logger.debug('getCapsule', { contractAddress, slot, scope, jobId });
     return this.#store.transactionAsync(() => this.#getCapsuleInternal(contractAddress, slot, jobId, scope));
   }
 
@@ -177,6 +181,7 @@ export class CapsuleStore implements StagedStore {
    * @param slot - The slot in the database to delete.
    */
   deleteCapsule(contractAddress: AztecAddress, slot: Fr, jobId: string, scope: AztecAddress) {
+    this.logger.debug('deleteCapsule', { contractAddress, slot, scope, jobId });
     // When we commit this, we will interpret null as a deletion, so we'll propagate the delete to the KV store
     this.#deleteOnStage(jobId, dbSlotToKey(contractAddress, slot, scope));
   }
@@ -200,6 +205,7 @@ export class CapsuleStore implements StagedStore {
     jobId: string,
     scope: AztecAddress,
   ): Promise<void> {
+    this.logger.debug('copyCapsule', { contractAddress, srcSlot, dstSlot, numEntries, scope, jobId });
     // This transactional context gives us "copy atomicity":
     // there shouldn't be concurrent writes to what's being copied here.
     // Equally important: this in practice is expected to perform thousands of DB operations
@@ -243,6 +249,7 @@ export class CapsuleStore implements StagedStore {
     jobId: string,
     scope: AztecAddress,
   ): Promise<void> {
+    this.logger.debug('appendToCapsuleArray', { contractAddress, baseSlot, entries: content.length, scope, jobId });
     // We wrap this in a transaction to serialize concurrent calls from Promise.all.
     // Without this, concurrent appends to the same array could race: both read length=0,
     // both write at the same slots, one overwrites the other.
@@ -266,6 +273,7 @@ export class CapsuleStore implements StagedStore {
   }
 
   readCapsuleArray(contractAddress: AztecAddress, baseSlot: Fr, jobId: string, scope: AztecAddress): Promise<Fr[][]> {
+    this.logger.debug('readCapsuleArray', { contractAddress, baseSlot, scope, jobId });
     // I'm leaving this transactional context here though because I'm assuming this
     // gives us "read array atomicity": there shouldn't be concurrent writes to what's being copied
     // here.
@@ -295,6 +303,7 @@ export class CapsuleStore implements StagedStore {
   }
 
   setCapsuleArray(contractAddress: AztecAddress, baseSlot: Fr, content: Fr[][], jobId: string, scope: AztecAddress) {
+    this.logger.debug('setCapsuleArray', { contractAddress, baseSlot, entries: content.length, scope, jobId });
     // This transactional context in theory isn't so critical now because we aren't
     // writing to DB so if there's exceptions midway and it blows up, no visible impact
     // to persistent storage will happen.

--- a/yarn-project/pxe/src/storage/contract_store/contract_store.ts
+++ b/yarn-project/pxe/src/storage/contract_store/contract_store.ts
@@ -1,6 +1,7 @@
 import type { FUNCTION_TREE_HEIGHT } from '@aztec/constants';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { toArray } from '@aztec/foundation/iterable';
+import { createLogger } from '@aztec/foundation/log';
 import { BufferReader, numToUInt8, serializeToBuffer } from '@aztec/foundation/serialize';
 import type { MembershipWitness } from '@aztec/foundation/trees';
 import type { AztecAsyncKVStore, AztecAsyncMap } from '@aztec/kv-store';
@@ -100,6 +101,8 @@ export class SerializableContractClassData {
  * the required information and facilitate cryptographic proof generation.
  */
 export class ContractStore {
+  logger = createLogger('contract_store');
+
   /** Map from contract class id to private function tree. */
   // TODO: Update it to be LRU cache so that it doesn't keep all the data all the time.
   #privateFunctionTrees: Map<string, PrivateFunctionsTree> = new Map();
@@ -139,6 +142,7 @@ export class ContractStore {
     contract: ContractArtifact,
     contractClassWithIdAndPreimage?: ContractClassWithId & ContractClassIdPreimage,
   ): Promise<Fr> {
+    this.logger.debug('addContractArtifact', { contractName: contract.name });
     const contractClass = contractClassWithIdAndPreimage ?? (await getContractClassFromArtifact(contract));
     const key = contractClass.id.toString();
 
@@ -169,6 +173,7 @@ export class ContractStore {
   }
 
   async addContractInstance(contract: ContractInstanceWithAddress): Promise<void> {
+    this.logger.debug('addContractInstance', { address: contract.address });
     await this.#store.transactionAsync(async () => {
       await this.#contractInstances.set(
         contract.address.toString(),
@@ -213,6 +218,7 @@ export class ContractStore {
   // Public getters
 
   getContractsAddresses(): Promise<AztecAddress[]> {
+    this.logger.debug('getContractsAddresses');
     return this.#store.transactionAsync(async () => {
       const keys = await toArray(this.#contractInstances.keysAsync());
       return keys.map(AztecAddress.fromStringUnsafe);
@@ -221,6 +227,7 @@ export class ContractStore {
 
   /** Returns a contract instance for a given address. */
   public getContractInstance(contractAddress: AztecAddress): Promise<ContractInstanceWithAddress | undefined> {
+    this.logger.debug('getContractInstance', { contractAddress });
     return this.#store.transactionAsync(async () => {
       const contract = await this.#contractInstances.getAsync(contractAddress.toString());
       return contract && SerializableContractInstance.fromBuffer(contract).withAddress(contractAddress);
@@ -229,6 +236,7 @@ export class ContractStore {
 
   /** Returns the raw contract artifact for a given class id. */
   public async getContractArtifact(contractClassId: Fr): Promise<ContractArtifact | undefined> {
+    this.logger.debug('getContractArtifact', { contractClassId });
     const key = contractClassId.toString();
     const cached = this.#contractArtifactCache.get(key);
     if (cached) {
@@ -248,6 +256,7 @@ export class ContractStore {
   public async getContractClassWithPreimage(
     contractClassId: Fr,
   ): Promise<(ContractClassWithId & ContractClassIdPreimage) | undefined> {
+    this.logger.debug('getContractClassWithPreimage', { contractClassId });
     const key = contractClassId.toString();
     const buf = await this.#store.transactionAsync(() => this.#contractClassData.getAsync(key));
     if (!buf) {
@@ -265,6 +274,7 @@ export class ContractStore {
   public async getContract(
     address: AztecAddress,
   ): Promise<(ContractInstanceWithAddress & ContractArtifact) | undefined> {
+    this.logger.debug('getContract', { address });
     const instance = await this.getContractInstance(address);
     if (!instance) {
       return;
@@ -287,6 +297,7 @@ export class ContractStore {
     contractAddress: AztecAddress,
     selector: FunctionSelector,
   ): Promise<FunctionArtifactWithContractName | undefined> {
+    this.logger.debug('getFunctionArtifact', { contractAddress, selector });
     const artifact = await this.#getArtifactByAddress(contractAddress);
     if (!artifact) {
       return undefined;
@@ -299,6 +310,7 @@ export class ContractStore {
     contractAddress: AztecAddress,
     selector: FunctionSelector,
   ): Promise<FunctionArtifactWithContractName> {
+    this.logger.debug('getFunctionArtifactWithDebugMetadata', { contractAddress, selector });
     const artifact = await this.getFunctionArtifact(contractAddress, selector);
     if (!artifact) {
       throw new Error(`Function artifact not found for contract ${contractAddress} and selector ${selector}.`);
@@ -313,6 +325,7 @@ export class ContractStore {
   public async getPublicFunctionArtifact(
     contractAddress: AztecAddress,
   ): Promise<FunctionArtifactWithContractName | undefined> {
+    this.logger.debug('getPublicFunctionArtifact', { contractAddress });
     const artifact = await this.#getArtifactByAddress(contractAddress);
     const fn = artifact && artifact.functions.find(f => f.functionType === FunctionType.PUBLIC);
     return fn && { ...fn, contractName: artifact.name };
@@ -322,6 +335,7 @@ export class ContractStore {
     contractAddress: AztecAddress,
     selector: FunctionSelector,
   ): Promise<FunctionAbi | undefined> {
+    this.logger.debug('getFunctionAbi', { contractAddress, selector });
     const artifact = await this.#getArtifactByAddress(contractAddress);
     return artifact && (await findFunctionAbiBySelector(artifact, selector));
   }
@@ -337,6 +351,7 @@ export class ContractStore {
     contractAddress: AztecAddress,
     selector: FunctionSelector,
   ): Promise<FunctionDebugMetadata | undefined> {
+    this.logger.debug('getFunctionDebugMetadata', { contractAddress, selector });
     const artifact = await this.#getArtifactByAddress(contractAddress);
     if (!artifact) {
       return undefined;
@@ -348,6 +363,7 @@ export class ContractStore {
   public async getPublicFunctionDebugMetadata(
     contractAddress: AztecAddress,
   ): Promise<FunctionDebugMetadata | undefined> {
+    this.logger.debug('getPublicFunctionDebugMetadata', { contractAddress });
     const artifact = await this.#getArtifactByAddress(contractAddress);
     const fn = artifact && artifact.functions.find(f => f.functionType === FunctionType.PUBLIC);
     return fn && getFunctionDebugMetadata(artifact, fn);
@@ -364,22 +380,26 @@ export class ContractStore {
     contractClassId: Fr,
     selector: FunctionSelector,
   ): Promise<MembershipWitness<typeof FUNCTION_TREE_HEIGHT> | undefined> {
+    this.logger.debug('getFunctionMembershipWitness', { contractClassId, selector });
     const tree = await this.#getPrivateFunctionTreeForClassId(contractClassId);
     return tree?.getFunctionMembershipWitness(selector);
   }
 
   public async getDebugContractName(contractAddress: AztecAddress) {
+    this.logger.debug('getDebugContractName', { contractAddress });
     const artifact = await this.#getArtifactByAddress(contractAddress);
     return artifact?.name;
   }
 
   public async getDebugFunctionName(contractAddress: AztecAddress, selector: FunctionSelector) {
+    this.logger.debug('getDebugFunctionName', { contractAddress, selector });
     const artifact = await this.#getArtifactByAddress(contractAddress);
     const fn = artifact && (await findFunctionAbiBySelector(artifact, selector));
     return `${artifact?.name ?? contractAddress}:${fn?.name ?? selector}`;
   }
 
   public async getFunctionCall(functionName: string, args: any[], to: AztecAddress): Promise<FunctionCall> {
+    this.logger.debug('getFunctionCall', { to, functionName });
     const contract = await this.getContract(to);
     if (!contract) {
       throw new Error(

--- a/yarn-project/pxe/src/storage/fact_store/fact_store.ts
+++ b/yarn-project/pxe/src/storage/fact_store/fact_store.ts
@@ -100,6 +100,11 @@ export class FactStore implements StagedStore {
     originBlock: OriginBlock | undefined,
     jobId: string,
   ): Promise<void> {
+    this.logger.debug('recordFact', {
+      factCollectionKey: factCollectionKey.toString(),
+      retractable: originBlock !== undefined,
+      jobId,
+    });
     return this.#withJobLock(jobId, () => {
       this.#stagedOpsFor(jobId).push({
         kind: 'recordFact',
@@ -115,6 +120,7 @@ export class FactStore implements StagedStore {
    * Idempotent: deleting a collection that does not exist is a no-op.
    */
   deleteFactCollection(factCollectionKey: FactCollectionKey, jobId: string): Promise<void> {
+    this.logger.debug('deleteFactCollection', { factCollectionKey: factCollectionKey.toString(), jobId });
     return this.#withJobLock(jobId, () => {
       this.#stagedOpsFor(jobId).push({ kind: 'deleteFactCollection', key: factCollectionKey });
       return Promise.resolve();
@@ -125,6 +131,7 @@ export class FactStore implements StagedStore {
    * Returns the fact collection for the (scope-qualified) key, or undefined if it has no facts.
    */
   async getFactCollection(factCollectionKey: FactCollectionKey, jobId: string): Promise<FactCollection | undefined> {
+    this.logger.debug('getFactCollection', { factCollectionKey: factCollectionKey.toString(), jobId });
     const collectionKey = factCollectionKey.toString();
     const committed = await this.#store.transactionAsync(() => this.#readCollectionsFromDb([factCollectionKey]));
 
@@ -143,6 +150,7 @@ export class FactStore implements StagedStore {
     factCollectionTypeKey: FactCollectionTypeKey,
     jobId: string,
   ): Promise<FactCollection[]> {
+    this.logger.debug('getFactCollectionsByType', { factCollectionTypeKey: factCollectionTypeKey.toString(), jobId });
     const typeKey = factCollectionTypeKey.toString();
     const committed = await this.#readCollectionsFromDbByType(typeKey);
 
@@ -161,6 +169,7 @@ export class FactStore implements StagedStore {
    * auto-commit the outer transaction.
    */
   async commit(jobId: string): Promise<void> {
+    this.logger.debug('commit', { jobId });
     for (const op of this.#stagedOpsFor(jobId)) {
       switch (op.kind) {
         case 'recordFact':
@@ -180,6 +189,7 @@ export class FactStore implements StagedStore {
 
   /** Discards all staged operations for the given job without persisting them. */
   discardStaged(jobId: string): Promise<void> {
+    this.logger.debug('discardStaged', { jobId });
     this.#clearJobData(jobId);
     return Promise.resolve();
   }
@@ -194,6 +204,7 @@ export class FactStore implements StagedStore {
    * mid-job could re-introduce records originating from deleted blocks or change state underneath a job's view.
    */
   async rollback(toBlock: BlockNum): Promise<void> {
+    this.logger.debug('rollback', { toBlock });
     if (this.#opsForJob.size > 0) {
       throw new Error('PXE fact store rollback is not allowed while jobs are running');
     }

--- a/yarn-project/pxe/src/storage/note_store/note_store.ts
+++ b/yarn-project/pxe/src/storage/note_store/note_store.ts
@@ -96,6 +96,7 @@ export class NoteStore implements StagedStore {
    * @param jobId - The job context for staged writes
    */
   public addNotes(notes: NoteDao[], scope: AztecAddress, jobId: string): Promise<void[]> {
+    this.logger.debug('addNotes', { noteCount: notes.length, scope, jobId });
     return this.#withJobLock(jobId, () =>
       this.#store.transactionAsync(() =>
         Promise.all(
@@ -152,6 +153,11 @@ export class NoteStore implements StagedStore {
    * @returns Filtered and deduplicated notes (a note might be present in multiple scopes, but returned at most once)
    */
   getNotes(filter: NotesFilter, jobId: string): Promise<NoteDao[]> {
+    this.logger.debug('getNotes', {
+      contractAddress: filter.contractAddress,
+      scopeCount: filter.scopes.length,
+      jobId,
+    });
     if (filter.scopes.length === 0) {
       return Promise.resolve([]);
     }
@@ -266,6 +272,7 @@ export class NoteStore implements StagedStore {
    * @throws If any nullifier has no matching note in this store, or was emitted at block 0.
    */
   applyNullifiers(siloedNullifiers: DataInBlock<Fr>[], jobId: string): Promise<NoteDao[]> {
+    this.logger.debug('applyNullifiers', { nullifierCount: siloedNullifiers.length, jobId });
     if (siloedNullifiers.length === 0) {
       return Promise.resolve([]);
     }
@@ -319,6 +326,7 @@ export class NoteStore implements StagedStore {
    * @param jobId - The jobId identifying which staged data to commit
    */
   async commit(jobId: string): Promise<void> {
+    this.logger.debug('commit', { jobId });
     for (const [nullifier, storedNote] of this.#getNotesForJob(jobId)) {
       await this.#notes.set(nullifier, storedNote.toBuffer());
       await this.#notesByContractAddress.set(storedNote.noteDao.contractAddress.toString(), nullifier);
@@ -334,6 +342,7 @@ export class NoteStore implements StagedStore {
   }
 
   discardStaged(jobId: string): Promise<void> {
+    this.logger.debug('discardStaged', { jobId });
     this.#clearJobData(jobId);
     return Promise.resolve();
   }
@@ -383,6 +392,7 @@ export class NoteStore implements StagedStore {
 
   /** Returns the nullifiers (note ids) of all notes created at the given block number. Used by delete-on-prune. */
   public async nullifiersOfNotesAtBlock(blockNumber: number): Promise<string[]> {
+    this.logger.debug('nullifiersOfNotesAtBlock', { blockNumber });
     const nullifiers: string[] = [];
     for await (const nullifier of this.#notesByBlockNumber.getValuesAsync(blockNumber)) {
       nullifiers.push(nullifier);
@@ -401,6 +411,7 @@ export class NoteStore implements StagedStore {
    * nullifier emissions anchored to deleted blocks.
    */
   public async rollback(toBlock: number): Promise<void> {
+    this.logger.debug('rollback', { toBlock });
     if (this.#notesForJob.size > 0 || this.#nullifierEmissionsForJob.size > 0) {
       throw new Error('PXE note store rollback is not allowed while jobs are running');
     }

--- a/yarn-project/pxe/src/storage/private_event_store/private_event_store.ts
+++ b/yarn-project/pxe/src/storage/private_event_store/private_event_store.ts
@@ -90,6 +90,11 @@ export class PrivateEventStore implements StagedStore {
     metadata: PrivateEventMetadata,
     jobId: string,
   ) {
+    this.logger.debug('storePrivateEventLog', {
+      contractAddress: metadata.contractAddress,
+      scope: metadata.scope,
+      jobId,
+    });
     return this.#withJobLock(jobId, () =>
       this.#store.transactionAsync(async () => {
         const { contractAddress, scope, txHash, l2BlockNumber, l2BlockHash, txIndexInBlock, eventIndexInTx } = metadata;
@@ -146,6 +151,12 @@ export class PrivateEventStore implements StagedStore {
     eventSelector: EventSelector,
     filter: PrivateEventStoreFilter,
   ): Promise<PackedPrivateEvent[]> {
+    this.logger.debug('getPrivateEvents', {
+      contractAddress: filter.contractAddress,
+      eventSelector,
+      fromBlock: filter.fromBlock,
+      toBlock: filter.toBlock,
+    });
     return this.#store.transactionAsync(async () => {
       const key = this.#keyFor(filter.contractAddress, eventSelector);
       const targetScopes = new Set(filter.scopes.map(s => s.toString()));
@@ -228,6 +239,7 @@ export class PrivateEventStore implements StagedStore {
 
   /** Returns the ids (siloed event commitments) of all events emitted at the given block number. Used by delete-on-prune. */
   public async eventIdsAtBlock(blockNumber: number): Promise<string[]> {
+    this.logger.debug('eventIdsAtBlock', { blockNumber });
     const eventIds: string[] = [];
     for await (const eventId of this.#eventsByBlockNumber.getValuesAsync(blockNumber)) {
       eventIds.push(eventId);
@@ -245,6 +257,7 @@ export class PrivateEventStore implements StagedStore {
    * uncommitted staged writes, since rolling back mid-job could later re-introduce events anchored to deleted blocks.
    */
   public async rollback(toBlock: number): Promise<void> {
+    this.logger.debug('rollback', { toBlock });
     if (this.#eventsForJob.size > 0) {
       throw new Error('PXE private event store rollback is not allowed while jobs are running');
     }
@@ -282,6 +295,7 @@ export class PrivateEventStore implements StagedStore {
    * @param jobId - The jobId identifying which staged data to commit
    */
   async commit(jobId: string): Promise<void> {
+    this.logger.debug('commit', { jobId });
     // Note: Don't use #withJobLock here - commit runs within JobCoordinator's transactionAsync,
     // and awaiting the lock would create a microtask boundary with no pending DB request,
     // causing IndexedDB to auto-commit the transaction.
@@ -303,6 +317,7 @@ export class PrivateEventStore implements StagedStore {
    * Discards in memory job data without persisting it.
    */
   discardStaged(jobId: string): Promise<void> {
+    this.logger.debug('discardStaged', { jobId });
     this.#clearJobData(jobId);
     return Promise.resolve();
   }

--- a/yarn-project/pxe/src/storage/tagging_store/recipient_tagging_store.ts
+++ b/yarn-project/pxe/src/storage/tagging_store/recipient_tagging_store.ts
@@ -1,3 +1,4 @@
+import { createLogger } from '@aztec/foundation/log';
 import type { AztecAsyncKVStore, AztecAsyncMap } from '@aztec/kv-store';
 import type { AppTaggingSecret } from '@aztec/stdlib/logs';
 
@@ -13,6 +14,8 @@ import type { StagedStore } from '../../job_coordinator/job_coordinator.js';
  */
 export class RecipientTaggingStore implements StagedStore {
   storeName: string = 'recipient_tagging';
+
+  logger = createLogger('recipient_tagging_store');
 
   #store: AztecAsyncKVStore;
 
@@ -83,6 +86,7 @@ export class RecipientTaggingStore implements StagedStore {
    * @remark This method must run in a DB transaction context. It's designed to be called from JobCoordinator#commitJob.
    */
   async commit(jobId: string): Promise<void> {
+    this.logger.debug('commit', { jobId });
     const highestAgedIndexForJob = this.#highestAgedIndexForJob.get(jobId);
     if (highestAgedIndexForJob) {
       for (const [secret, index] of highestAgedIndexForJob.entries()) {
@@ -101,16 +105,19 @@ export class RecipientTaggingStore implements StagedStore {
   }
 
   discardStaged(jobId: string): Promise<void> {
+    this.logger.debug('discardStaged', { jobId });
     this.#highestAgedIndexForJob.delete(jobId);
     this.#highestFinalizedIndexForJob.delete(jobId);
     return Promise.resolve();
   }
 
   getHighestAgedIndex(secret: AppTaggingSecret, jobId: string): Promise<number | undefined> {
+    this.logger.debug('getHighestAgedIndex', { secret, jobId });
     return this.#store.transactionAsync(() => this.#readHighestAgedIndex(jobId, secret.toString()));
   }
 
   updateHighestAgedIndex(secret: AppTaggingSecret, index: number, jobId: string): Promise<void> {
+    this.logger.debug('updateHighestAgedIndex', { secret, index, jobId });
     return this.#store.transactionAsync(async () => {
       const currentIndex = await this.#readHighestAgedIndex(jobId, secret.toString());
       if (currentIndex !== undefined && index <= currentIndex) {
@@ -122,10 +129,12 @@ export class RecipientTaggingStore implements StagedStore {
   }
 
   getHighestFinalizedIndex(secret: AppTaggingSecret, jobId: string): Promise<number | undefined> {
+    this.logger.debug('getHighestFinalizedIndex', { secret, jobId });
     return this.#store.transactionAsync(() => this.#readHighestFinalizedIndex(jobId, secret.toString()));
   }
 
   updateHighestFinalizedIndex(secret: AppTaggingSecret, index: number, jobId: string): Promise<void> {
+    this.logger.debug('updateHighestFinalizedIndex', { secret, index, jobId });
     return this.#store.transactionAsync(async () => {
       const currentIndex = await this.#readHighestFinalizedIndex(jobId, secret.toString());
       if (currentIndex !== undefined && index < currentIndex) {

--- a/yarn-project/pxe/src/storage/tagging_store/sender_tagging_store.ts
+++ b/yarn-project/pxe/src/storage/tagging_store/sender_tagging_store.ts
@@ -1,3 +1,4 @@
+import { createLogger } from '@aztec/foundation/log';
 import type { AztecAsyncKVStore, AztecAsyncMap } from '@aztec/kv-store';
 import { AppTaggingSecret, SiloedTag, type TaggingIndexRange } from '@aztec/stdlib/logs';
 import { TxEffect, TxHash } from '@aztec/stdlib/tx';
@@ -15,6 +16,8 @@ type PendingIndexesEntry = { lowestIndex: number; highestIndex: number; txHash: 
  */
 export class SenderTaggingStore implements StagedStore {
   readonly storeName = 'sender_tagging';
+
+  logger = createLogger('sender_tagging_store');
 
   #store: AztecAsyncKVStore;
 
@@ -100,6 +103,7 @@ export class SenderTaggingStore implements StagedStore {
    * @remark This method must run in a DB transaction context. It's designed to be called from JobCoordinator#commitJob.
    */
   async commit(jobId: string): Promise<void> {
+    this.logger.debug('commit', { jobId });
     const pendingIndexesForJob = this.#pendingIndexesForJob.get(jobId);
     if (pendingIndexesForJob) {
       for (const [secret, pendingIndexes] of pendingIndexesForJob.entries()) {
@@ -122,6 +126,7 @@ export class SenderTaggingStore implements StagedStore {
   }
 
   discardStaged(jobId: string): Promise<void> {
+    this.logger.debug('discardStaged', { jobId });
     this.#pendingIndexesForJob.delete(jobId);
     this.#lastFinalizedIndexesForJob.delete(jobId);
     return Promise.resolve();
@@ -141,6 +146,7 @@ export class SenderTaggingStore implements StagedStore {
    * @throws If a different range already exists for the same (secret, txHash) pair.
    */
   storePendingIndexes(ranges: TaggingIndexRange[], txHash: TxHash, jobId: string): Promise<void> {
+    this.logger.debug('storePendingIndexes', { rangeCount: ranges.length, txHash, jobId });
     if (ranges.length === 0) {
       return Promise.resolve();
     }
@@ -223,6 +229,7 @@ export class SenderTaggingStore implements StagedStore {
     endIndex: number,
     jobId: string,
   ): Promise<TxHash[]> {
+    this.logger.debug('getTxHashesOfPendingIndexes', { secret, startIndex, endIndex, jobId });
     return this.#store.transactionAsync(async () => {
       const existing = await this.#readPendingIndexes(jobId, secret.toString());
       const txHashes = existing
@@ -238,6 +245,7 @@ export class SenderTaggingStore implements StagedStore {
    * @returns The last (highest) finalized index for the given secret.
    */
   getLastFinalizedIndex(secret: AppTaggingSecret, jobId: string): Promise<number | undefined> {
+    this.logger.debug('getLastFinalizedIndex', { secret, jobId });
     return this.#store.transactionAsync(() => this.#readLastFinalizedIndex(jobId, secret.toString()));
   }
 
@@ -248,6 +256,7 @@ export class SenderTaggingStore implements StagedStore {
    * @returns The last used index.
    */
   getLastUsedIndex(secret: AppTaggingSecret, jobId: string): Promise<number | undefined> {
+    this.logger.debug('getLastUsedIndex', { secret, jobId });
     const secretStr = secret.toString();
 
     return this.#store.transactionAsync(async () => {
@@ -270,6 +279,7 @@ export class SenderTaggingStore implements StagedStore {
    * Drops all pending indexes corresponding to the given transaction hashes.
    */
   dropPendingIndexes(txHashes: TxHash[], jobId: string): Promise<void> {
+    this.logger.debug('dropPendingIndexes', { txHashCount: txHashes.length, jobId });
     if (txHashes.length === 0) {
       return Promise.resolve();
     }
@@ -361,6 +371,7 @@ export class SenderTaggingStore implements StagedStore {
    * indexes.
    */
   async finalizePendingIndexes(txHashes: TxHash[], jobId: string): Promise<void> {
+    this.logger.debug('finalizePendingIndexes', { txHashCount: txHashes.length, jobId });
     if (txHashes.length === 0) {
       return;
     }
@@ -425,6 +436,7 @@ export class SenderTaggingStore implements StagedStore {
    * @param jobId - job context for staged writes to this store. See `JobCoordinator` for more details.
    */
   async finalizePendingIndexesOfAPartiallyRevertedTx(txEffect: TxEffect, jobId: string): Promise<void> {
+    this.logger.debug('finalizePendingIndexesOfAPartiallyRevertedTx', { txHash: txEffect.txHash, jobId });
     const txHashStr = txEffect.txHash.toString();
 
     // Build a set of all siloed tag values that made it onchain (first field of each private log).

--- a/yarn-project/pxe/src/storage/tagging_store/tagging_secret_sources_store.ts
+++ b/yarn-project/pxe/src/storage/tagging_store/tagging_secret_sources_store.ts
@@ -1,5 +1,6 @@
 import { Point } from '@aztec/foundation/curves/grumpkin';
 import { toArray } from '@aztec/foundation/iterable';
+import { createLogger } from '@aztec/foundation/log';
 import type { AztecAsyncKVStore, AztecAsyncMap, AztecAsyncMultiMap } from '@aztec/kv-store';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
 
@@ -16,6 +17,8 @@ import { AztecAddress } from '@aztec/stdlib/aztec-address';
  *   and so these must not be reused to preserve privacy.
  */
 export class TaggingSecretSourcesStore {
+  logger = createLogger('tagging_secret_sources_store');
+
   #store: AztecAsyncKVStore;
   #senders: AztecAsyncMap<string, true>;
   #sharedSecretsByRecipient: AztecAsyncMultiMap<string, string>;
@@ -28,6 +31,7 @@ export class TaggingSecretSourcesStore {
   }
 
   addSender(address: AztecAddress): Promise<boolean> {
+    this.logger.debug('addSender', { address });
     return this.#store.transactionAsync(async () => {
       if (await this.#senders.hasAsync(address.toString())) {
         return false;
@@ -40,12 +44,14 @@ export class TaggingSecretSourcesStore {
   }
 
   getSenders(): Promise<AztecAddress[]> {
+    this.logger.debug('getSenders');
     return this.#store.transactionAsync(async () => {
       return (await toArray(this.#senders.keysAsync())).map(AztecAddress.fromStringUnsafe);
     });
   }
 
   removeSender(address: AztecAddress): Promise<boolean> {
+    this.logger.debug('removeSender', { address });
     return this.#store.transactionAsync(async () => {
       if (!(await this.#senders.hasAsync(address.toString()))) {
         return false;
@@ -62,6 +68,7 @@ export class TaggingSecretSourcesStore {
    * @returns true if the secret was newly added, false if it was already registered for that recipient.
    */
   addSharedSecret(recipient: AztecAddress, secret: Point): Promise<boolean> {
+    this.logger.debug('addSharedSecret', { recipient });
     return this.#store.transactionAsync(async () => {
       const secretStr = secret.toString();
       // MultiMap.set silently ignores an identical (key, value), so we scan to report whether this is a new secret.
@@ -79,6 +86,7 @@ export class TaggingSecretSourcesStore {
 
   /** Returns the pre-shared tagging secrets registered for a given recipient. */
   getSharedSecretsForRecipient(recipient: AztecAddress): Promise<Point[]> {
+    this.logger.debug('getSharedSecretsForRecipient', { recipient });
     return this.#store.transactionAsync(async () => {
       return (await toArray(this.#sharedSecretsByRecipient.getValuesAsync(recipient.toString()))).map(secret =>
         Point.fromString(secret),
@@ -88,6 +96,7 @@ export class TaggingSecretSourcesStore {
 
   /** Returns every registered pre-shared tagging secret, each paired with the recipient it is scoped to. */
   getAllSharedSecrets(): Promise<{ recipient: AztecAddress; secret: Point }[]> {
+    this.logger.debug('getAllSharedSecrets');
     return this.#store.transactionAsync(async () => {
       const entries = await toArray(this.#sharedSecretsByRecipient.entriesAsync());
       return entries.map(([recipient, secret]) => ({
@@ -102,6 +111,7 @@ export class TaggingSecretSourcesStore {
    * @returns true if the secret was registered and removed, false if it was not registered for that recipient.
    */
   removeSharedSecret(recipient: AztecAddress, secret: Point): Promise<boolean> {
+    this.logger.debug('removeSharedSecret', { recipient });
     return this.#store.transactionAsync(async () => {
       const secretStr = secret.toString();
       for await (const existing of this.#sharedSecretsByRecipient.getValuesAsync(recipient.toString())) {


### PR DESCRIPTION
Adds `debug` level logs to every PXE store public method, to help troubleshooting eventual storage issues.

Closes F-773