### PR TITLE
test(e2e): run prover client.test.ts in CI

### DIFF
--- a/yarn-project/end-to-end/bootstrap.sh
+++ b/yarn-project/end-to-end/bootstrap.sh
@@ -27,58 +27,40 @@ function test_cmds {
   local run_test_script="yarn-project/end-to-end/scripts/run_test.sh"
   local prefix="$hash:ISOLATE=1:TIMEOUT=20m"
 
-  # prover/full has its own dedicated lines below and is excluded from the generic globs. The rest of
-  # prover/ (currently just client) mirrors full: real Barretenberg under CI_FULL with the heavy
-  # 16-CPU/96g budget, fake proofs otherwise. The REAL_PROOFS = !FAKE_PROOFS toggle in the test means
-  # omitting FAKE_PROOFS selects real proving, which is why the real variant needs full_real's budget.
+  # On full CI we enable real proofs and allocate more resources to the e2e prover tests
   if [ "$CI_FULL" -eq 1 ]; then
-    echo "$prefix:TIMEOUT=20m:CPUS=16:MEM=96g:NAME=e2e_prover_full_real $run_test_script simple single-node/prover/full"
-    for test in src/single-node/prover/!(full).test.ts; do
+    for test in src/single-node/prover/server/*.test.ts; do
       local name=${test#src/}
       name=${name%.test.ts}
       echo "$prefix:TIMEOUT=20m:CPUS=16:MEM=96g:NAME=${name}_real $run_test_script simple ${test#src/}"
     done
+    for test in src/single-node/prover/client/*.test.ts; do
+      local name=${test#src/}
+      name=${name%.test.ts}
+      echo "$prefix:TIMEOUT=10m:CPUS=2:MEM=4g:NAME=${name}_real $run_test_script simple ${test#src/}"
+    done
   else
-    echo "$prefix:NAME=e2e_prover_full_fake FAKE_PROOFS=1 $run_test_script simple single-node/prover/full"
-    for test in src/single-node/prover/!(full).test.ts; do
+    for test in src/single-node/prover/**/*.test.ts; do
       local name=${test#src/}
       name=${name%.test.ts}
       echo "$prefix:NAME=${name}_fake FAKE_PROOFS=1 $run_test_script simple ${test#src/}"
     done
   fi
+
+  # Long-running avm_simulator
   echo "$prefix:TIMEOUT=30m:NAME=automine/simulation/avm_simulator $(set_dump_avm e2e_avm_simulator) $run_test_script simple src/automine/simulation/avm_simulator.test.ts"
 
   local tests=(
     # List all standalone and nested tests, except for the ones listed above.
     src/automine/*.test.ts
-    src/automine/contracts/*.test.ts
-    src/automine/contracts/deploy/*.test.ts
-    src/automine/contracts/nested/*.test.ts
-    src/automine/token/*.test.ts
-    src/automine/accounts/*.test.ts
-    src/automine/effects/*.test.ts
+    src/automine/!(simulation)/**/*.test.ts
     src/automine/simulation/!(avm_simulator).test.ts
-    src/single-node/block-building/*.test.ts
-    src/single-node/proving/*.test.ts
-    src/single-node/l1-reorgs/*.test.ts
-    src/single-node/recovery/*.test.ts
-    src/single-node/partial-proofs/*.test.ts
-    src/single-node/sequencer/*.test.ts
-    src/single-node/fees/*.test.ts
-    src/single-node/cross-chain/*.test.ts
-    src/single-node/bot/*.test.ts
-    src/single-node/sync/*.test.ts
-    src/infra/*.test.ts
-    src/single-node/misc/*.test.ts
-    src/multi-node/block-production/*.test.ts
-    src/multi-node/recovery/*.test.ts
-    src/multi-node/invalid-attestations/*.test.ts
-    src/multi-node/high-availability/*.test.ts
-    src/multi-node/slashing/*.test.ts
-    src/multi-node/governance/*.test.ts
-    src/p2p/*.test.ts
-    src/p2p/reqresp/*.test.ts
+    src/single-node/!(prover)/**/*.test.ts
+    src/infra/**/*.test.ts
+    src/multi-node/**/*.test.ts
+    src/p2p/**/*.test.ts
   )
+
   for test in "${tests[@]}"; do
     # Derive a CI test name from the path: drop the leading "src/" and trailing ".test.ts".
     # This keeps e2e_<dir>/<file> names while also handling the multi-node/ category folder.

--- a/yarn-project/end-to-end/bootstrap.sh
+++ b/yarn-project/end-to-end/bootstrap.sh
@@ -27,10 +27,24 @@ function test_cmds {
   local run_test_script="yarn-project/end-to-end/scripts/run_test.sh"
   local prefix="$hash:ISOLATE=1:TIMEOUT=20m"
 
+  # prover/full has its own dedicated lines below and is excluded from the generic globs. The rest of
+  # prover/ (currently just client) mirrors full: real Barretenberg under CI_FULL with the heavy
+  # 16-CPU/96g budget, fake proofs otherwise. The REAL_PROOFS = !FAKE_PROOFS toggle in the test means
+  # omitting FAKE_PROOFS selects real proving, which is why the real variant needs full_real's budget.
   if [ "$CI_FULL" -eq 1 ]; then
     echo "$prefix:TIMEOUT=20m:CPUS=16:MEM=96g:NAME=e2e_prover_full_real $run_test_script simple single-node/prover/full"
+    for test in src/single-node/prover/!(full).test.ts; do
+      local name=${test#src/}
+      name=${name%.test.ts}
+      echo "$prefix:TIMEOUT=20m:CPUS=16:MEM=96g:NAME=${name}_real $run_test_script simple ${test#src/}"
+    done
   else
     echo "$prefix:NAME=e2e_prover_full_fake FAKE_PROOFS=1 $run_test_script simple single-node/prover/full"
+    for test in src/single-node/prover/!(full).test.ts; do
+      local name=${test#src/}
+      name=${name%.test.ts}
+      echo "$prefix:NAME=${name}_fake FAKE_PROOFS=1 $run_test_script simple ${test#src/}"
+    done
   fi
   echo "$prefix:TIMEOUT=30m:NAME=automine/simulation/avm_simulator $(set_dump_avm e2e_avm_simulator) $run_test_script simple src/automine/simulation/avm_simulator.test.ts"
 

--- a/yarn-project/end-to-end/src/single-node/prover/client/client.test.ts
+++ b/yarn-project/end-to-end/src/single-node/prover/client/client.test.ts
@@ -7,9 +7,9 @@ import { FeeJuicePortalAbi, TestERC20Abi } from '@aztec/l1-artifacts';
 import { jest } from '@jest/globals';
 import { type GetContractReturnType, getContract } from 'viem';
 
-import { FullProverTest } from '../../fixtures/e2e_prover_test.js';
-import { PIPELINING_SETUP_OPTS } from '../../fixtures/fixtures.js';
-import { proveInteraction } from '../../test-wallet/utils.js';
+import { FullProverTest } from '../../../fixtures/e2e_prover_test.js';
+import { PIPELINING_SETUP_OPTS } from '../../../fixtures/fixtures.js';
+import { proveInteraction } from '../../../test-wallet/utils.js';
 
 // Set a very long 20 minute timeout.
 const TIMEOUT = 1_200_000;

--- a/yarn-project/end-to-end/src/single-node/prover/server/full.test.ts
+++ b/yarn-project/end-to-end/src/single-node/prover/server/full.test.ts
@@ -22,9 +22,9 @@ import TOML from '@iarna/toml';
 import { jest } from '@jest/globals';
 import { type GetContractReturnType, getContract } from 'viem';
 
-import { FullProverTest } from '../../fixtures/e2e_prover_test.js';
-import { PIPELINING_SETUP_OPTS } from '../../fixtures/fixtures.js';
-import { ProvenTx, proveInteraction } from '../../test-wallet/utils.js';
+import { FullProverTest } from '../../../fixtures/e2e_prover_test.js';
+import { PIPELINING_SETUP_OPTS } from '../../../fixtures/fixtures.js';
+import { ProvenTx, proveInteraction } from '../../../test-wallet/utils.js';
 
 const REAL_PROOFS = !parseBooleanEnv(process.env.FAKE_PROOFS);
 


### PR DESCRIPTION
## Motivation

`single-node/prover/client.test.ts` ran in no CI job: `prover/` was excluded from the auto-discovery globs (so `full.test.ts`, dispatched via bespoke lines, wouldn't run twice), and `client` had no dedicated line, so it fell through the gap. This wires it in.

## Changes

- Split `prover/` into `prover/server/` (`full.test.ts`, full pipeline) and `prover/client/` (`client.test.ts`, client-side proving slice), each globbed by its own loop.
- Real proofs under `CI_FULL=1`, fake (`FAKE_PROOFS=1`) otherwise.
- Simplified the generic auto-discovery `tests=()` globs (`**` recursion + `!(prover)` exclusion) in place of the hand-maintained per-folder list.

## Resulting prover jobs

- `CI_FULL=1` (real): `single-node/prover/server/full_real` (16 CPU / 96g / 20m) + `single-node/prover/client/client_real` (2 CPU / 4g / 10m)
- `CI_FULL=0` (fake): `single-node/prover/server/full_fake` + `single-node/prover/client/client_fake`

`test_cmds` output is otherwise identical to `merge-train/spartan-v5` — no other test added, dropped, or double-counted.

Fixes A-1301
