### PR TITLE
refactor(pxe): unify the app-silo primitive for tagging and encryption

### DIFF
--- a/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution_oracle.test.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution_oracle.test.ts
@@ -133,7 +133,7 @@ describe('PrivateExecutionOracle', () => {
       const point = await Point.random();
       const { oracle } = await makeHookedOracle({ type: 'arbitrary-secret', secret: point }, Fr.random());
 
-      const expected = await AppTaggingSecret.compute(point, contractAddress, recipient);
+      const expected = await AppTaggingSecret.computeDirectional(point, contractAddress, recipient);
       await expect(
         oracle.resolveTaggingStrategy(sender, recipient, AppTaggingSecretKind.UNCONSTRAINED),
       ).resolves.toEqual({ type: 'unconstrained-secret', secret: expected.secret });

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution_oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution_oracle.ts
@@ -229,7 +229,11 @@ export class PrivateExecutionOracle extends UtilityExecutionOracle implements IP
         return this.#addressDerivedSecret(sender, recipient);
       case 'arbitrary-secret': {
         // App-silo the raw arbitrary secret point here so wallets never replicate the derivation.
-        const appTaggingSecret = await AppTaggingSecret.compute(strategy.secret, this.contractAddress, recipient);
+        const appTaggingSecret = await AppTaggingSecret.computeDirectional(
+          strategy.secret,
+          this.contractAddress,
+          recipient,
+        );
         return { type: 'unconstrained-secret', secret: appTaggingSecret.secret };
       }
     }
@@ -305,13 +309,7 @@ export class PrivateExecutionOracle extends UtilityExecutionOracle implements IP
   async #calculateAppTaggingSecret(contractAddress: AztecAddress, sender: AztecAddress, recipient: AztecAddress) {
     const senderCompleteAddress = await this.getCompleteAddressOrFail(sender);
     const senderIvsk = await this.keyStore.getMasterIncomingViewingSecretKey(sender);
-    return AppTaggingSecret.computeUnconstrained(
-      senderCompleteAddress,
-      senderIvsk,
-      recipient,
-      contractAddress,
-      recipient,
-    );
+    return AppTaggingSecret.computeViaEcdh(senderCompleteAddress, senderIvsk, recipient, contractAddress, recipient);
   }
 
   async #getIndexToUseForSecret(secret: AppTaggingSecret): Promise<number> {

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
@@ -25,12 +25,7 @@ import { siloNullifier } from '@aztec/stdlib/hash';
 import type { AztecNode } from '@aztec/stdlib/interfaces/server';
 import type { KeyValidationRequest } from '@aztec/stdlib/kernel';
 import { PublicKeys, computeAddressSecret, hashPublicKey } from '@aztec/stdlib/keys';
-import {
-  AppTaggingSecret,
-  FlatPublicLogs,
-  type PendingTaggedLog,
-  deriveAppSiloedSharedSecret,
-} from '@aztec/stdlib/logs';
+import { AppTaggingSecret, FlatPublicLogs, type PendingTaggedLog, appSiloEcdhSharedSecret } from '@aztec/stdlib/logs';
 import { getNonNullifiedL1ToL2MessageWitness } from '@aztec/stdlib/messaging';
 import type { NoteStatus } from '@aztec/stdlib/note';
 import { MerkleTreeId, type NullifierMembershipWitness, PublicDataWitness } from '@aztec/stdlib/trees';
@@ -872,7 +867,7 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
 
     const ephPkPoints = ephPks.readAll(this.ephemeralArrayService);
     const secrets = await Promise.all(
-      ephPkPoints.map(({ x, y }) => deriveAppSiloedSharedSecret(addressSecret, new Point(x, y), this.contractAddress)),
+      ephPkPoints.map(({ x, y }) => appSiloEcdhSharedSecret(addressSecret, new Point(x, y), this.contractAddress)),
     );
 
     return EphemeralArray.fromValues(this.ephemeralArrayService, secrets);

--- a/yarn-project/pxe/src/logs/log_service.ts
+++ b/yarn-project/pxe/src/logs/log_service.ts
@@ -242,7 +242,7 @@ export class LogService {
       ...(await this.#getSecretsForSenders(recipientCompleteAddress, recipientIvsk)),
       ...(await this.taggingSecretSourcesStore.getSharedSecretsForRecipient(recipient)),
     ];
-    return Promise.all(points.map(secret => AppTaggingSecret.compute(secret, contractAddress, recipient)));
+    return Promise.all(points.map(secret => AppTaggingSecret.computeDirectional(secret, contractAddress, recipient)));
   }
 
   async #getSecretsForSenders(

--- a/yarn-project/stdlib/src/logs/app_tagging_secret.test.ts
+++ b/yarn-project/stdlib/src/logs/app_tagging_secret.test.ts
@@ -49,20 +49,20 @@ describe('AppTaggingSecret', () => {
     });
   });
 
-  describe('compute', () => {
+  describe('computeDirectional', () => {
     it('is a deterministic function of the point, app and recipient', async () => {
       const point = await Point.random();
       const app = await AztecAddress.random();
       const recipient = await AztecAddress.random();
 
-      const a = await AppTaggingSecret.compute(point, app, recipient);
-      const b = await AppTaggingSecret.compute(point, app, recipient);
+      const a = await AppTaggingSecret.computeDirectional(point, app, recipient);
+      const b = await AppTaggingSecret.computeDirectional(point, app, recipient);
       expect(b.secret).toEqual(a.secret);
 
-      const otherApp = await AppTaggingSecret.compute(point, await AztecAddress.random(), recipient);
+      const otherApp = await AppTaggingSecret.computeDirectional(point, await AztecAddress.random(), recipient);
       expect(otherApp.secret).not.toEqual(a.secret);
 
-      const otherRecipient = await AppTaggingSecret.compute(point, app, await AztecAddress.random());
+      const otherRecipient = await AppTaggingSecret.computeDirectional(point, app, await AztecAddress.random());
       expect(otherRecipient.secret).not.toEqual(a.secret);
     });
 
@@ -92,9 +92,17 @@ describe('AppTaggingSecret', () => {
       expect(pointFromRecipient).toBeDefined();
       expect(pointFromSender).toEqual(pointFromRecipient);
 
-      const secretViaEcdh = await AppTaggingSecret.compute(pointFromRecipient!, app, recipientComplete.address);
+      const secretViaEcdh = await AppTaggingSecret.computeDirectional(
+        pointFromRecipient!,
+        app,
+        recipientComplete.address,
+      );
       // Registering the shared point directly (bypassing ECDH) derives the identical secret.
-      const secretViaRegistration = await AppTaggingSecret.compute(pointFromSender!, app, recipientComplete.address);
+      const secretViaRegistration = await AppTaggingSecret.computeDirectional(
+        pointFromSender!,
+        app,
+        recipientComplete.address,
+      );
 
       expect(secretViaRegistration.secret).toEqual(secretViaEcdh.secret);
       expect(secretViaRegistration.app).toEqual(app);

--- a/yarn-project/stdlib/src/logs/app_tagging_secret.ts
+++ b/yarn-project/stdlib/src/logs/app_tagging_secret.ts
@@ -9,6 +9,7 @@ import { AztecAddress } from '../aztec-address/index.js';
 import type { CompleteAddress } from '../contract/complete_address.js';
 import { computeAddressSecret, computePreaddress } from '../keys/derivation.js';
 import { AppTaggingSecretKind } from './app_tagging_secret_kind.js';
+import { appSiloEcdhSharedSecretPoint } from './shared_secret_derivation.js';
 
 const AppTaggingSecretKindSchema = z.union([
   z.literal(AppTaggingSecretKind.UNCONSTRAINED),
@@ -32,32 +33,35 @@ export class AppTaggingSecret {
   /**
    * Derives an app-siloed, recipient-directional tagging secret from a shared tagging secret point.
    *
+   * App-silos the point via {@link appSiloEcdhSharedSecretPoint}, then directs the result to `recipient`:
+   * `h([s_app, recipient])`. The directional step stops a symmetric shared secret (ECDH against an address, or an
+   * arbitrary registered point) from colliding bidirectionally, so two parties never share a tag sequence.
+   *
    * The point is obtained either via {@link computeSharedTaggingSecret} (an ECDH key exchange against a sender) or
-   * registered directly as a pre-shared secret. Each secret point yields a distinct tagging secret per (app, recipient)
-   * pair.
+   * registered directly as a pre-shared secret.
    *
    * @param taggingSecretPoint - The shared tagging secret point (ECDH output, or a directly registered pre-shared secret)
    * @param app - Contract address to silo the secret to
    * @param recipient - Recipient of the log. Defines the "direction of the secret".
    * @returns The secret that can be used along with an index to compute a tag to be included in a log.
    */
-  static async compute(
+  static async computeDirectional(
     taggingSecretPoint: Point,
     app: AztecAddress,
     recipient: AztecAddress,
   ): Promise<AppTaggingSecret> {
-    const appTaggingSecret = await poseidon2Hash([taggingSecretPoint.x, taggingSecretPoint.y, app]);
-    const directionalAppTaggingSecret = await poseidon2Hash([appTaggingSecret, recipient]);
+    const appSiloedSecret = await appSiloEcdhSharedSecretPoint(taggingSecretPoint, app);
+    const directionalAppTaggingSecret = await poseidon2Hash([appSiloedSecret, recipient]);
 
     return new AppTaggingSecret(directionalAppTaggingSecret, app);
   }
 
   /**
-   * Derives the unconstrained tagging secret for `(externalAddress, recipient, app)` by performing the ECDH key
-   * exchange against `externalAddress` and then siloing and directing the result. Returns undefined if
-   * `externalAddress` is not a valid address.
+   * Derives the tagging secret for `(externalAddress, recipient, app)` by performing an ECDH key exchange against
+   * `externalAddress` to obtain the shared point, then siloing and directing it via {@link computeDirectional}.
+   * Returns undefined if `externalAddress` is not a valid address.
    */
-  static async computeUnconstrained(
+  static async computeViaEcdh(
     localAddress: CompleteAddress,
     localIvsk: Fq,
     externalAddress: AztecAddress,
@@ -69,7 +73,7 @@ export class AppTaggingSecret {
       return undefined;
     }
 
-    return AppTaggingSecret.compute(taggingSecretPoint, app, recipient);
+    return AppTaggingSecret.computeDirectional(taggingSecretPoint, app, recipient);
   }
 
   toString(): string {

--- a/yarn-project/stdlib/src/logs/shared_secret_derivation.ts
+++ b/yarn-project/stdlib/src/logs/shared_secret_derivation.ts
@@ -2,16 +2,14 @@ import { DomainSeparator } from '@aztec/constants';
 import { Grumpkin } from '@aztec/foundation/crypto/grumpkin';
 import { poseidon2HashWithSeparator } from '@aztec/foundation/crypto/poseidon';
 import type { Fr } from '@aztec/foundation/curves/bn254';
-import type { GrumpkinScalar } from '@aztec/foundation/curves/grumpkin';
+import type { GrumpkinScalar, Point } from '@aztec/foundation/curves/grumpkin';
 
 import type { AztecAddress } from '../aztec-address/index.js';
 import type { PublicKey } from '../keys/public_key.js';
 
 /**
- * Derives an app-siloed ECDH shared secret.
- *
- * Computes the raw ECDH shared secret `S = secretKey * publicKey`, then app-silos it:
- * `s_app = h(DOM_SEP__APP_SILOED_ECDH_SHARED_SECRET, S.x, S.y, contractAddress)`
+ * Derives an app-siloed ECDH shared secret from keys: ECDHs `S = secretKey * publicKey`, then app-silos it via
+ * {@link appSiloEcdhSharedSecretPoint}.
  *
  * @param secretKey - The secret key used to derive shared secret.
  * @param publicKey - The public key used to derive shared secret.
@@ -19,7 +17,7 @@ import type { PublicKey } from '../keys/public_key.js';
  * @returns The app-siloed shared secret as a Field.
  * @throws If the publicKey is zero.
  */
-export async function deriveAppSiloedSharedSecret(
+export async function appSiloEcdhSharedSecret(
   secretKey: GrumpkinScalar,
   publicKey: PublicKey,
   contractAddress: AztecAddress,
@@ -30,8 +28,17 @@ export async function deriveAppSiloedSharedSecret(
     );
   }
   const rawSharedSecret = await Grumpkin.mul(publicKey, secretKey);
-  return poseidon2HashWithSeparator(
-    [rawSharedSecret.x, rawSharedSecret.y, contractAddress],
-    DomainSeparator.APP_SILOED_ECDH_SHARED_SECRET,
-  );
+  return appSiloEcdhSharedSecretPoint(rawSharedSecret, contractAddress);
+}
+
+/**
+ * App-silos a shared secret point: `s_app = h(DOM_SEP__APP_SILOED_ECDH_SHARED_SECRET, S.x, S.y, app)`.
+ *
+ * Mirrors `compute_app_siloed_shared_secret` in aztec-nr.
+ *
+ * @param point - The raw shared secret point `S`.
+ * @param app - The contract address to silo to.
+ */
+export function appSiloEcdhSharedSecretPoint(point: Point, app: AztecAddress): Promise<Fr> {
+  return poseidon2HashWithSeparator([point.x, point.y, app], DomainSeparator.APP_SILOED_ECDH_SHARED_SECRET);
 }


### PR DESCRIPTION
## Why we are doing this

App-siloing an ECDH shared secret to a contract address (`s_app = h(S.x, S.y, app)`) was done **two different ways**:

- **Tagging** used a bare `poseidon2Hash([S.x, S.y, app])` — no domain separator.
- **Encryption** (and Noir's `compute_app_siloed_shared_secret`) used `poseidon2HashWithSeparator([S.x, S.y, app], APP_SILOED_ECDH_SHARED_SECRET)`.

So the tagging silo was the odd one out: a second, separator-less primitive doing morally the same job as the one encryption and the contracts already use. Two ways to app-silo the same point is exactly the kind of "is this the same thing or not?" wart that makes the tagging code hard to reason about.

## Our fix

Collapse both onto a single primitive, `appSiloEcdhSharedSecretPoint(point, app)` (the separator-based silo). The keys-input encryption path (`appSiloEcdhSharedSecret`) and the tagging path now both go through it, and it mirrors Noir's `compute_app_siloed_shared_secret` exactly. "The tagging secret is the same app-silo encryption uses, then directed to the recipient" becomes a single invariant a reviewer asserts once.

Because tagging now uses the separator, the derived tagging-secret value changes — so this is a behavioral change, not a pure no-op refactor.

### Naming

The old names didn't say what they did, so they were renamed alongside the unification:

- `AppTaggingSecret.compute` → `computeDirectional`: the result binds the recipient; the name now says so.
- `AppTaggingSecret.computeUnconstrained` → `computeViaEcdh`: "unconstrained" named the delivery mode, but **both** factories return an unconstrained-kind secret, so it distinguished nothing — what actually sets this one apart is the ECDH key exchange it does first.
- `deriveAppSiloedSharedSecret` → `appSiloEcdhSharedSecret` (plus the new `appSiloEcdhSharedSecretPoint`): surfaces the `APP_SILOED_ECDH_SHARED_SECRET` separator the helper commits to.
