### PR TITLE
test(e2e): adopt shared wait helpers

### DIFF
--- a/yarn-project/end-to-end/src/automine/genesis_timestamp.parallel.test.ts
+++ b/yarn-project/end-to-end/src/automine/genesis_timestamp.parallel.test.ts
@@ -1,9 +1,9 @@
 import { generateSchnorrAccounts } from '@aztec/accounts/testing';
 import { NO_FROM } from '@aztec/aztec.js/account';
 import { createLogger } from '@aztec/aztec.js/log';
-import { retryUntil } from '@aztec/foundation/retry';
 
 import type { EndToEndContext } from '../fixtures/utils.js';
+import { waitForBlockNumber, waitForNodeCheckpoint } from '../fixtures/wait_helpers.js';
 import { proveInteraction } from '../test-wallet/utils.js';
 import { AutomineTestContext } from './automine_test_context.js';
 
@@ -60,10 +60,8 @@ describe('automine/genesis_timestamp', () => {
 
   const awaitBlockCheckpointed = async () => {
     const { aztecNode } = context;
-    // REFACTOR: hand-rolled retryUntil polling on block number and checkpoint number; a helper like
-    // waitForBlockNumber / waitForCheckpointNumber would replace both calls.
-    await retryUntil(async () => (await aztecNode.getBlockNumber()) >= 1, 'wait for block >= 1', 60);
-    await retryUntil(async () => (await aztecNode.getCheckpointNumber()) >= 1, 'wait for checkpoint >= 1', 60);
+    await waitForBlockNumber(aztecNode, 1);
+    await waitForNodeCheckpoint(aztecNode, 1, { timeout: 60, interval: 1 });
     logger.info(`Block number after advancing: ${await aztecNode.getBlockNumber()}`);
   };
 

--- a/yarn-project/end-to-end/src/fixtures/wait_helpers.ts
+++ b/yarn-project/end-to-end/src/fixtures/wait_helpers.ts
@@ -3,11 +3,13 @@ import type { Fr } from '@aztec/aztec.js/fields';
 import { waitForTx } from '@aztec/aztec.js/node';
 import { INITIAL_L2_BLOCK_NUM } from '@aztec/aztec.js/protocol';
 import type { BlockNumber, CheckpointNumber, SlotNumber } from '@aztec/foundation/branded-types';
+import { promiseWithResolvers } from '@aztec/foundation/promise';
 import { retryUntil } from '@aztec/foundation/retry';
+import type { Sequencer, SequencerEvents, SequencerState } from '@aztec/sequencer-client';
 import type { L2BlockTag } from '@aztec/stdlib/block';
 import type { AztecNode, CheckpointTag } from '@aztec/stdlib/interfaces/client';
 import type { L2ToL1MembershipWitness } from '@aztec/stdlib/messaging';
-import type { TxHash, TxReceipt } from '@aztec/stdlib/tx';
+import type { TxHash, TxReceipt, TxStatus } from '@aztec/stdlib/tx';
 
 /** Options for the block-number polling helpers. */
 export type WaitForBlockOpts = {
@@ -160,4 +162,142 @@ export function waitForL2ToL1Witness(
     opts.timeout ?? 30,
     opts.interval ?? 1,
   );
+}
+
+/** Options for the tx-receipt polling helpers. */
+export type WaitForTxReceiptOpts = {
+  /** Seconds before the poll rejects; defaults to 30. */
+  timeout?: number;
+  /** Seconds between polls; defaults to 1. */
+  interval?: number;
+};
+
+/**
+ * Polls `node.getTxReceipt(txHash)` until `predicate(receipt)` holds, resolving with the receipt.
+ * Wraps the `retryUntil` that the block-building reorg tests hand-roll while waiting for a tx to
+ * transition between statuses (pruned, re-included, ...).
+ * @returns The receipt once the predicate holds.
+ */
+export function waitForTxReceipt(
+  node: AztecNode,
+  txHash: TxHash,
+  predicate: (receipt: TxReceipt) => boolean,
+  opts: WaitForTxReceiptOpts = {},
+): Promise<TxReceipt> {
+  return retryUntil(
+    async () => {
+      const receipt = await node.getTxReceipt(txHash);
+      return predicate(receipt) ? { receipt } : undefined;
+    },
+    `tx receipt for ${txHash.toString()}`,
+    opts.timeout ?? 30,
+    opts.interval ?? 1,
+  ).then(({ receipt }) => receipt);
+}
+
+/** Polls until `node.getTxReceipt(txHash).status === status`. Thin wrapper over {@link waitForTxReceipt}. */
+export function waitForTxStatus(
+  node: AztecNode,
+  txHash: TxHash,
+  status: TxStatus,
+  opts: WaitForTxReceiptOpts = {},
+): Promise<TxReceipt> {
+  return waitForTxReceipt(node, txHash, receipt => receipt.status === status, opts);
+}
+
+/** Compares the node's pending-tx count against the target; defaults to `>=`. */
+export type PendingTxCountComparator = (actual: number, target: number) => boolean;
+
+/** Options for {@link waitForPendingTxCount}. */
+export type WaitForPendingTxCountOpts = {
+  /** How the node's pending-tx count must relate to `target`; defaults to `(actual, target) => actual >= target`. */
+  compare?: PendingTxCountComparator;
+  /** Seconds before the poll rejects; defaults to 30. */
+  timeout?: number;
+  /** Seconds between polls; defaults to 1. */
+  interval?: number;
+};
+
+/**
+ * Polls `node.getPendingTxCount()` until `opts.compare(actual, target)` holds (default `>=`).
+ * Replaces the hand-rolled mempool-size poll in the slashing tests.
+ * @returns The pending-tx count once the comparison holds.
+ */
+export function waitForPendingTxCount(
+  node: AztecNode,
+  target: number,
+  opts: WaitForPendingTxCountOpts = {},
+): Promise<number> {
+  const compare = opts.compare ?? ((actual, target) => actual >= target);
+  // Wrap the matched value: retryUntil treats any falsy return as "keep polling", so a legitimate
+  // match of 0 pending txs would otherwise loop until timeout instead of resolving.
+  return retryUntil(
+    async () => {
+      const count = await node.getPendingTxCount();
+      return compare(count, target) ? { count } : undefined;
+    },
+    `pending tx count ${compare} ${target}`,
+    opts.timeout ?? 30,
+    opts.interval ?? 1,
+  ).then(({ count }) => count);
+}
+
+/** Options for {@link waitForSequencerState}. */
+export type WaitForSequencerStateOpts = {
+  /** Milliseconds before the wait rejects; defaults to 30000. */
+  timeout?: number;
+  /**
+   * Action to run after subscribing to the sequencer but before awaiting the transition. Subscribing
+   * first guarantees the state change the action triggers is not missed between the action and the
+   * listener attaching.
+   */
+  after?: () => unknown;
+};
+
+/**
+ * Resolves once `sequencer` reaches `state`. Subscribes to the `state-changed` event first, then (if
+ * `opts.after` is given) runs the action, then resolves immediately if the sequencer is already at
+ * `state`, otherwise waits for the transition. The listener is cleaned up on both resolve and timeout.
+ * Replaces the hand-rolled `state-changed` on/off subscriptions duplicated across the fee, cross-chain,
+ * and keystore-reload tests.
+ */
+export async function waitForSequencerState(
+  sequencer: Sequencer,
+  state: SequencerState,
+  opts: WaitForSequencerStateOpts = {},
+): Promise<void> {
+  const timeout = opts.timeout ?? 30000;
+  const { promise, resolve, reject } = promiseWithResolvers<void>();
+
+  let settled = false;
+  const handler = (args: Parameters<SequencerEvents['state-changed']>[0]) => {
+    if (args.newState === state) {
+      finish(resolve);
+    }
+  };
+  const timer = setTimeout(
+    () => finish(() => reject(new Error(`Timeout waiting for sequencer ${state} state`))),
+    timeout,
+  );
+  function finish(complete: () => void) {
+    if (settled) {
+      return;
+    }
+    settled = true;
+    clearTimeout(timer);
+    sequencer.off('state-changed', handler);
+    complete();
+  }
+
+  sequencer.on('state-changed', handler);
+  try {
+    await opts.after?.();
+    if (sequencer.status().state === state) {
+      finish(resolve);
+    }
+    await promise;
+  } catch (err) {
+    finish(() => {});
+    throw err;
+  }
 }

--- a/yarn-project/end-to-end/src/fixtures/wait_helpers.ts
+++ b/yarn-project/end-to-end/src/fixtures/wait_helpers.ts
@@ -15,6 +15,8 @@ import type { TxHash, TxReceipt, TxStatus } from '@aztec/stdlib/tx';
 export type WaitForBlockOpts = {
   /** Which chain tip to read; defaults to 'proposed'. */
   tag?: L2BlockTag;
+  /** How the node's block number must relate to `target`; defaults to `(actual, target) => actual >= target`. */
+  compare?: (actual: number, target: number) => boolean;
   /** Seconds before the poll rejects; defaults to 60. */
   timeout?: number;
   /** Seconds between polls; defaults to 1. */
@@ -22,20 +24,23 @@ export type WaitForBlockOpts = {
 };
 
 /**
- * Polls `node.getBlockNumber(tag)` until it reaches `target`. Replaces the ad-hoc
- * `retryUntil(() => node.getBlockNumber(tag) >= target)` polls scattered across the suite.
- * @returns The block number once it reaches `target`.
+ * Polls `node.getBlockNumber(tag)` until `opts.compare(actual, target)` holds (default `>=`). Replaces
+ * the ad-hoc `retryUntil(() => node.getBlockNumber(tag) <op> target)` polls scattered across the suite,
+ * where the node may sync forward or prune backward — the caller passes the comparator for whichever it
+ * expects.
+ * @returns The block number once the comparison holds.
  */
 export function waitForBlockNumber(node: AztecNode, target: number, opts: WaitForBlockOpts = {}): Promise<BlockNumber> {
   const tag = opts.tag ?? 'proposed';
+  const compare = opts.compare ?? ((actual, target) => actual >= target);
   // Wrap the matched value: retryUntil treats any falsy return as "keep polling", so a legitimate
   // match of block 0 (e.g. a freshly-pruned tip) would otherwise loop until timeout.
   return retryUntil(
     async () => {
       const blockNumber = await node.getBlockNumber(tag);
-      return blockNumber >= target ? { blockNumber } : undefined;
+      return compare(blockNumber, target) ? { blockNumber } : undefined;
     },
-    `block ${tag} >= ${target}`,
+    `block ${tag} ${compare} ${target}`,
     opts.timeout ?? 60,
     opts.interval ?? 1,
   ).then(({ blockNumber }) => blockNumber);

--- a/yarn-project/end-to-end/src/multi-node/block-production/high_tps.test.ts
+++ b/yarn-project/end-to-end/src/multi-node/block-production/high_tps.test.ts
@@ -4,7 +4,6 @@ import type { Logger } from '@aztec/aztec.js/log';
 import { waitForTx } from '@aztec/aztec.js/node';
 import { BlockNumber, SlotNumber } from '@aztec/foundation/branded-types';
 import { chunkBy } from '@aztec/foundation/collection';
-import { sleepUntil } from '@aztec/foundation/sleep';
 import type { SpamContract } from '@aztec/noir-test-contracts.js/Spam';
 import { getSlotAtTimestamp, getTimestampForSlot } from '@aztec/stdlib/epoch-helpers';
 
@@ -127,9 +126,9 @@ describe('multi-node/block-production/high_tps', () => {
     logger.warn(
       `Waiting until ${startSequencersAt.toISOString()} (${leadSeconds}s before L2 slot ${targetSlot} starts)`,
     );
-    // REFACTOR: manual slot-timing calculation followed by sleepUntil; replace with a helper
-    // such as test.waitUntilBuildWindowForSlot(targetSlot) that encapsulates lead-time arithmetic.
-    await sleepUntil(startSequencersAt, context.dateProvider.nowAsDate());
+    // Wall-clock wait (the production sequencers must run in real time, so we don't warp here). The
+    // build-window helper derives the same `slotStart(targetSlot) - leadSeconds` target as above.
+    await test.waitForBuildWindowForSlot(targetSlot, { lead: leadSeconds });
 
     await test.startSequencers(nodes);
     logger.warn(`Started all sequencers`);

--- a/yarn-project/end-to-end/src/multi-node/block-production/proof_boundary.parallel.test.ts
+++ b/yarn-project/end-to-end/src/multi-node/block-production/proof_boundary.parallel.test.ts
@@ -91,17 +91,7 @@ describe('multi-node/block-production/proof_boundary', () => {
   };
 
   const computeBoundarySlot = async () => {
-    // REFACTOR: hand-rolled retryUntil polling for first checkpoint; replace with
-    // test.waitUntilCheckpointNumber(CheckpointNumber(1)) from MultiNodeTestContext.
-    await retryUntil(
-      async () => {
-        await test.monitor.run(true);
-        return test.monitor.checkpointNumber >= CheckpointNumber(1);
-      },
-      'first checkpoint mined',
-      120,
-      0.5,
-    );
+    await test.waitUntilCheckpointNumber(CheckpointNumber(1));
 
     const firstCheckpoint = await test.rollup.getCheckpoint(CheckpointNumber(1));
     const firstCheckpointEpoch = getEpochAtSlot(firstCheckpoint.slotNumber, test.constants);

--- a/yarn-project/end-to-end/src/multi-node/governance/upgrade_governance_proposer.test.ts
+++ b/yarn-project/end-to-end/src/multi-node/governance/upgrade_governance_proposer.test.ts
@@ -2,6 +2,7 @@ import { RollupContract } from '@aztec/ethereum/contracts';
 import { deployL1Contract } from '@aztec/ethereum/deploy-l1-contract';
 import { L1TxUtils, createL1TxUtils } from '@aztec/ethereum/l1-tx-utils';
 import { SlotNumber } from '@aztec/foundation/branded-types';
+import { retryUntil } from '@aztec/foundation/retry';
 import { sleep } from '@aztec/foundation/sleep';
 import {
   GovernanceAbi,
@@ -60,7 +61,6 @@ describe('multi-node/governance/upgrade_governance_proposer', () => {
   // Creates 4 validator nodes configured to signal a new GovernanceProposerPayload. Waits for quorum,
   // warps past round boundary, submits the round winner, then drives the full governance lifecycle
   // (vote, execution delay, execute). Asserts the governance contract's governanceProposer changes.
-  // REFACTOR: while(true) + sleep(12000) polling for quorum is hand-rolled; replace with retryUntil
   it('should cast votes to upgrade governanceProposer', async () => {
     const governanceProposer = getContract({
       address: getAddress(
@@ -146,14 +146,15 @@ describe('multi-node/governance/upgrade_governance_proposer', () => {
     const quorumSize = await governanceProposer.read.QUORUM_SIZE();
     test.logger.info(`Quorum size: ${quorumSize}, round size: ${await governanceProposer.read.ROUND_SIZE()}`);
 
-    let govData;
-    while (true) {
-      govData = await govInfo();
-      if (govData.leaderVotes >= quorumSize) {
-        break;
-      }
-      await sleep(12000);
-    }
+    const govData = await retryUntil(
+      async () => {
+        const data = await govInfo();
+        return data.leaderVotes >= quorumSize ? data : undefined;
+      },
+      'quorum of signals',
+      Number(quorumSize) * GOVERNANCE_TIMING.aztecSlotDuration * 3,
+      GOVERNANCE_TIMING.aztecSlotDuration,
+    );
 
     expect(govData.leaderVotes).toBeGreaterThan(govBefore.leaderVotes);
 

--- a/yarn-project/end-to-end/src/multi-node/high-availability/ha_checkpoint_handoff.test.ts
+++ b/yarn-project/end-to-end/src/multi-node/high-availability/ha_checkpoint_handoff.test.ts
@@ -10,7 +10,6 @@ import type { CheckpointData, ProposedCheckpointData } from '@aztec/stdlib/check
 
 import { jest } from '@jest/globals';
 
-import type { EndToEndContext } from '../../fixtures/utils.js';
 import {
   MOCK_GOSSIP_MULTI_VALIDATOR_OPTS,
   MULTI_VALIDATOR_REORG_TIMING,
@@ -67,7 +66,6 @@ const VALIDATOR_COUNT = 4;
  * S2→peer uses the test-only `pauseProposingForSlots` hook.
  */
 describe('multi-node/high-availability/ha_checkpoint_handoff', () => {
-  let context: EndToEndContext;
   let logger: Logger;
   let rollup: RollupContract;
 
@@ -102,7 +100,7 @@ describe('multi-node/high-availability/ha_checkpoint_handoff', () => {
       aztecTargetCommitteeSize: VALIDATOR_COUNT,
     });
 
-    ({ context, logger, rollup } = test);
+    ({ logger, rollup } = test);
 
     // Create 4 nodes in 2 HA pairs (pk1+pk2, pk3+pk4) sharing keys + a per-pair slashing-protection DB.
     // Distinct coinbases per node let the secondary assertion prove which peer produced S2's checkpoint;
@@ -155,56 +153,32 @@ describe('multi-node/high-availability/ha_checkpoint_handoff', () => {
         ? undefined
         : haPairs.find(pair => pair.addresses.includes(proposer.toString().toLowerCase()));
 
-    // REFACTOR: hand-rolled slot-search loop with manual epoch arithmetic and warp-on-EpochNotStable retry
-    // (same pattern as invalid-attestations/invalidate_block and recovery/proposal_failure_recovery) — a shared
-    // "find slots matching a proposer predicate, warping past EpochNotStable" helper should replace it.
-    let candidate = Number(test.epochCache.getEpochAndSlotNow().slot) + 4;
-    const maxAttempts = 200;
-    for (let attempt = 0; attempt < maxAttempts; attempt++) {
-      try {
-        const [p1, p2] = await Promise.all([
-          test.epochCache.getProposerAttesterAddressInSlot(SlotNumber(candidate)),
-          test.epochCache.getProposerAttesterAddressInSlot(SlotNumber(candidate + 1)),
-        ]);
-        const pairS1 = matchingPair(p1);
-        const pairS2 = matchingPair(p2);
-        if (pairS1 !== undefined && pairS1 === pairS2) {
-          const [builder, peer] = pairS1.nodes;
-          logger.warn(`Found consecutive same-pair proposal slots ${candidate} and ${candidate + 1}.`, {
-            slotS1: candidate,
-            slotS2: candidate + 1,
-            proposerS1: p1?.toString(),
-            proposerS2: p2?.toString(),
-            pairAddresses: pairS1.addresses,
-          });
-          return {
-            slotS1: SlotNumber(candidate),
-            slotS2: SlotNumber(candidate + 1),
-            builder,
-            peer,
-            peerCoinbase: pairS1.coinbases[1],
-            builderArchiver: builder.getBlockSource() as Archiver,
-            peerArchiver: peer.getBlockSource() as Archiver,
-          };
-        }
-        candidate++;
-      } catch (err) {
-        const msg = err instanceof Error ? err.message : String(err);
-        if (!msg.includes('EpochNotStable')) {
-          throw err;
-        }
-        const block = await test.l1Client.getBlock({ includeTransactions: false });
-        const warpBy = test.epochDuration * test.L2_SLOT_DURATION_IN_S;
-        const newTs = Number(block.timestamp) + warpBy;
-        logger.warn(`Hit EpochNotStable at candidate ${candidate}, warping L1 forward by ${warpBy}s to ${newTs}`);
-        await context.cheatCodes.eth.warp(newTs, { resetBlockInterval: true });
-        const newCurrentSlot = Number(test.epochCache.getEpochAndSlotNow().slot);
-        if (candidate < newCurrentSlot + 4) {
-          candidate = newCurrentSlot + 4;
-        }
-      }
-    }
-    throw new Error(`Could not find two consecutive slots both proposed by the same HA pair`);
+    const {
+      slots: [slotS1, slotS2],
+      proposers: [p1, p2],
+    } = await test.findSlotsWithProposers(2, ([proposerS1, proposerS2]) => {
+      const pairS1 = matchingPair(proposerS1);
+      return pairS1 !== undefined && pairS1 === matchingPair(proposerS2);
+    });
+
+    const pair = matchingPair(p1)!;
+    const [builder, peer] = pair.nodes;
+    logger.warn(`Found consecutive same-pair proposal slots ${slotS1} and ${slotS2}.`, {
+      slotS1,
+      slotS2,
+      proposerS1: p1.toString(),
+      proposerS2: p2.toString(),
+      pairAddresses: pair.addresses,
+    });
+    return {
+      slotS1,
+      slotS2,
+      builder,
+      peer,
+      peerCoinbase: pair.coinbases[1],
+      builderArchiver: builder.getBlockSource() as Archiver,
+      peerArchiver: peer.getBlockSource() as Archiver,
+    };
   }
 
   afterEach(async () => {

--- a/yarn-project/end-to-end/src/multi-node/invalid-attestations/invalidate_block.parallel.test.ts
+++ b/yarn-project/end-to-end/src/multi-node/invalid-attestations/invalidate_block.parallel.test.ts
@@ -565,50 +565,13 @@ describe('multi-node/invalid-attestations/invalidate_block', () => {
         minTxsPerBlock: 0,
       }),
     );
-    // REFACTOR: hand-rolled slot-search with EpochNotStable warp fallback; replace with a shared
-    // helper such as findNextTwoSlotsWithDistinctProposers(test, fromSlot) that encapsulates the
-    // EpochNotStable retry-and-warp loop.
-    let badSlot1: SlotNumber | undefined;
-    let p1Proposer: EthAddress | undefined;
-    let p2Proposer: EthAddress | undefined;
-    let candidate = Number(test.epochCache.getEpochAndSlotNow().slot) + 4;
-    const maxAttempts = 200;
-    for (let attempt = 0; attempt < maxAttempts && badSlot1 === undefined; attempt++) {
-      try {
-        const [p1, p2] = await Promise.all([
-          test.epochCache.getProposerAttesterAddressInSlot(SlotNumber(candidate)),
-          test.epochCache.getProposerAttesterAddressInSlot(SlotNumber(candidate + 1)),
-        ]);
-        if (p1 && p2 && !p1.equals(p2)) {
-          badSlot1 = SlotNumber(candidate);
-          p1Proposer = p1;
-          p2Proposer = p2;
-          break;
-        }
-        candidate++;
-      } catch (err) {
-        const msg = err instanceof Error ? err.message : String(err);
-        if (!msg.includes('EpochNotStable')) {
-          throw err;
-        }
-        const block = await test.l1Client.getBlock({ includeTransactions: false });
-        const warpBy = test.epochDuration * test.L2_SLOT_DURATION_IN_S;
-        const newTs = Number(block.timestamp) + warpBy;
-        logger.warn(`Hit EpochNotStable at candidate ${candidate}, warping L1 forward by ${warpBy}s to ${newTs}`);
-        await test.context.cheatCodes.eth.warp(newTs, { resetBlockInterval: true });
-        const newCurrentSlot = Number(test.epochCache.getEpochAndSlotNow().slot);
-        if (candidate < newCurrentSlot + 4) {
-          candidate = newCurrentSlot + 4;
-        }
-      }
-    }
-    if (badSlot1 === undefined || !p1Proposer || !p2Proposer) {
-      throw new Error(`Could not find two consecutive slots with different proposers after ${maxAttempts} attempts`);
-    }
-    const badSlot2 = SlotNumber.add(badSlot1, 1);
+    const {
+      slots: [badSlot1, badSlot2],
+      proposers: [p1Proposer, p2Proposer],
+    } = await test.findSlotsWithProposers(2, ([p1, p2]) => !p1.equals(p2));
 
-    const p1NodeIndex = nodes.findIndex(n => n.getSequencer()!.validatorAddresses!.some(a => a.equals(p1Proposer!)));
-    const p2NodeIndex = nodes.findIndex(n => n.getSequencer()!.validatorAddresses!.some(a => a.equals(p2Proposer!)));
+    const p1NodeIndex = nodes.findIndex(n => n.getSequencer()!.validatorAddresses!.some(a => a.equals(p1Proposer)));
+    const p2NodeIndex = nodes.findIndex(n => n.getSequencer()!.validatorAddresses!.some(a => a.equals(p2Proposer)));
     if (p1NodeIndex === -1 || p2NodeIndex === -1) {
       throw new Error(`Could not find nodes for proposers P1=${p1Proposer} P2=${p2Proposer}`);
     }

--- a/yarn-project/end-to-end/src/multi-node/slashing/attested_invalid_proposal.parallel.test.ts
+++ b/yarn-project/end-to-end/src/multi-node/slashing/attested_invalid_proposal.parallel.test.ts
@@ -18,6 +18,7 @@ import { TxHash } from '@aztec/stdlib/tx';
 import { jest } from '@jest/globals';
 
 import { getPrivateKeyFromIndex } from '../../fixtures/utils.js';
+import { waitForPendingTxCount } from '../../fixtures/wait_helpers.js';
 import type { TestWallet } from '../../test-wallet/test_wallet.js';
 import {
   MultiNodeTestContext,
@@ -244,17 +245,7 @@ describe('multi-node/slashing/attested_invalid_proposal', () => {
       targetSlot,
     });
 
-    // REFACTOR: retryUntil polling pendingTxCount should be replaced with a waitForPendingTxCount helper
-    await retryUntil(
-      async () => {
-        const pendingTxCount = await badProposerNode.getPendingTxCount();
-        test.logger.info(`Bad proposer pending tx count is ${pendingTxCount}`);
-        return pendingTxCount >= 3;
-      },
-      'bad proposer pending txs',
-      AZTEC_SLOT_DURATION,
-      0.5,
-    );
+    await waitForPendingTxCount(badProposerNode, 3, { timeout: AZTEC_SLOT_DURATION, interval: 0.5 });
 
     const badProposerBlockProposedEvents: BlockProposedEvent[] = [];
     badProposerNode

--- a/yarn-project/end-to-end/src/p2p/fee_asset_price_oracle_gossip.test.ts
+++ b/yarn-project/end-to-end/src/p2p/fee_asset_price_oracle_gossip.test.ts
@@ -5,7 +5,6 @@ import { RollupContract, STATE_VIEW_ADDRESS } from '@aztec/ethereum/contracts';
 import { CheckpointNumber } from '@aztec/foundation/branded-types';
 import { Signature } from '@aztec/foundation/eth-signature';
 import { retryUntil } from '@aztec/foundation/retry';
-import { sleep } from '@aztec/foundation/sleep';
 import type { SequencerClient } from '@aztec/sequencer-client';
 import { tryStop } from '@aztec/stdlib/interfaces/server';
 import { CheckpointAttestation, ConsensusPayload } from '@aztec/stdlib/p2p';
@@ -96,7 +95,6 @@ describe('e2e_p2p_network', () => {
   // Deploys a MockStateView L1 contract, sets an initial oracle price, then starts 4 validator nodes
   // and a prover. Adjusts the oracle price twice and uses retryUntil to confirm the rollup's on-chain
   // price converges to each target within the gossip propagation window.
-  // REFACTOR: sleep(8000) for peer discovery is hand-rolled; replace with t.waitForP2PMeshConnectivity
   it('should rollup txs from all peers', async () => {
     // create the bootstrap node for the network
     if (!t.bootstrapNodeEnr) {
@@ -144,8 +142,8 @@ describe('e2e_p2p_network', () => {
       shouldCollectMetrics(),
     ));
 
-    // wait a bit for peers to discover each other
-    await sleep(8000);
+    // Wait for the validators to discover each other and form a gossip mesh before proceeding.
+    await t.waitForP2PMeshConnectivity(nodes);
 
     // We need to `createNodes` before we setup account, because
     // those nodes actually form the committee, and so we cannot build

--- a/yarn-project/end-to-end/src/p2p/gossip_network.test.ts
+++ b/yarn-project/end-to-end/src/p2p/gossip_network.test.ts
@@ -1,6 +1,5 @@
 import type { Archiver } from '@aztec/archiver';
 import type { AztecNodeConfig, AztecNodeService } from '@aztec/aztec-node';
-import { waitForTx } from '@aztec/aztec.js/node';
 import { TxHash } from '@aztec/aztec.js/tx';
 import { BlockNumber } from '@aztec/foundation/branded-types';
 import { Signature } from '@aztec/foundation/eth-signature';
@@ -21,6 +20,7 @@ import {
   createNonValidatorNode,
   createProverNode,
 } from '../fixtures/setup_p2p_test.js';
+import { waitForTxs } from '../fixtures/wait_helpers.js';
 import { type AlertConfig, GrafanaClient } from '../quality_of_service/grafana_client.js';
 import { P2PNetworkTest, SHORTENED_BLOCK_TIME_CONFIG_NO_PRUNES, WAIT_FOR_TX_TIMEOUT } from './p2p_network.js';
 import { submitTransactions } from './shared.js';
@@ -104,7 +104,6 @@ describe('e2e_p2p_network', () => {
   // Stands up 4 validators + 1 prover + 1 re-execution monitor, submits 2 txs per node, and waits
   // for all txs to mine. Checks attestation signers match the validator set and confirms the prover
   // eventually produces a proven block (collecting txs from p2p rather than RPC).
-  // REFACTOR: Promise.all over waitForTx calls is hand-rolled; extract to a shared helper
   it('should rollup txs from all peers', async () => {
     // create the bootstrap node for the network
     if (!t.bootstrapNodeEnr) {
@@ -185,14 +184,8 @@ describe('e2e_p2p_network', () => {
 
     t.logger.info('Waiting for transactions to be mined');
     // now ensure that all txs were successfully mined
-    await Promise.all(
-      txsSentViaDifferentNodes.flatMap((txs, i) =>
-        txs.map((txHash, j) => {
-          t.logger.info(`Waiting for tx ${i}-${j}: ${txHash.toString()} to be mined`);
-          return waitForTx(nodes[0], txHash, { timeout: WAIT_FOR_TX_TIMEOUT });
-        }),
-      ),
-    );
+    const allTxHashes = txsSentViaDifferentNodes.flat();
+    await waitForTxs(nodes[0], allTxHashes, { timeout: WAIT_FOR_TX_TIMEOUT });
     t.logger.info('All transactions mined');
 
     // Gather signers from attestations downloaded from L1

--- a/yarn-project/end-to-end/src/single-node/block-building/block_building.test.ts
+++ b/yarn-project/end-to-end/src/single-node/block-building/block_building.test.ts
@@ -11,8 +11,6 @@ import { CheatCodes } from '@aztec/aztec/testing';
 import { asyncMap } from '@aztec/foundation/async-map';
 import { BlockNumber, EpochNumber } from '@aztec/foundation/branded-types';
 import { times, unique } from '@aztec/foundation/collection';
-import { retryUntil } from '@aztec/foundation/retry';
-import { sleep } from '@aztec/foundation/sleep';
 import { TokenContract } from '@aztec/noir-contracts.js/Token';
 import { StatefulTestContract } from '@aztec/noir-test-contracts.js/StatefulTest';
 import { TestContract } from '@aztec/noir-test-contracts.js/Test';
@@ -28,6 +26,13 @@ import { jest } from '@jest/globals';
 import 'jest-extended';
 
 import { DUPLICATE_NULLIFIER_ERROR, PIPELINING_SETUP_OPTS } from '../../fixtures/fixtures.js';
+import {
+  waitForBlockNumber,
+  waitForProvenBlock,
+  waitForTxReceipt,
+  waitForTxStatus,
+  waitForTxs,
+} from '../../fixtures/wait_helpers.js';
 import { TestWallet } from '../../test-wallet/test_wallet.js';
 import { proveInteraction } from '../../test-wallet/utils.js';
 import { setupBlockProducer } from '../setup.js';
@@ -147,7 +152,7 @@ describe('single-node/block-building/block_building', () => {
       });
 
       // Await txs to be mined and assert they are mined across multiple different blocks.
-      const receipts = await Promise.all(txHashes.map(txHash => waitForTx(aztecNode, txHash)));
+      const receipts = await waitForTxs(aztecNode, txHashes);
       const blockNumbers = receipts.map(r => r.blockNumber!).sort((a, b) => a - b);
       logger.info(`Txs mined on blocks: ${unique(blockNumbers)}`);
       // Spread must be at least 1 — i.e. txs are split across at least 2 distinct blocks. This fails
@@ -197,7 +202,7 @@ describe('single-node/block-building/block_building', () => {
       }
 
       // Await txs to be mined and assert they are all mined on the same block
-      const receipts = await Promise.all(txHashes.map(txHash => waitForTx(aztecNode, txHash)));
+      const receipts = await waitForTxs(aztecNode, txHashes);
       expect(receipts.map(r => r.blockNumber)).toEqual(times(TX_COUNT, () => receipts[0].blockNumber));
 
       // Assert all contracts got initialized
@@ -232,7 +237,7 @@ describe('single-node/block-building/block_building', () => {
       }
 
       // Await txs to be mined and assert they are all mined on the same block
-      const receipts = await Promise.all(txHashes.map(txHash => waitForTx(aztecNode, txHash)));
+      const receipts = await waitForTxs(aztecNode, txHashes);
       expect(receipts.map(r => r.blockNumber)).toEqual(times(TX_COUNT, () => receipts[0].blockNumber));
     });
 
@@ -544,8 +549,7 @@ describe('single-node/block-building/block_building', () => {
 
       // Under pipelining, with `aztecSlotDuration=12s`, each empty checkpoint contains one empty
       // block and lands roughly every 12s. Allow up to 60s for three empty blocks to appear.
-      // REFACTOR: raw retryUntil poll on block number; replace with a waitForBlock(n) DSL helper
-      await retryUntil(async () => (await aztecNode.getBlockNumber()) >= 3, 'wait-block', 60, 1);
+      await waitForBlockNumber(aztecNode, 3);
     });
 
     // Regression for https://github.com/AztecProtocol/aztec-packages/issues/7537
@@ -557,8 +561,7 @@ describe('single-node/block-building/block_building', () => {
         additionallyFundedAccounts: await generateSchnorrAccounts(1, 'schnorr'),
       });
       ({ logger, aztecNode, wallet } = test.context);
-      // REFACTOR: sleep-based wait; replace with a waitForBlock(1) or equivalent readiness helper
-      await sleep(1000);
+      await waitForBlockNumber(aztecNode, 1);
 
       const [accountData] = test.context.additionallyFundedAccounts;
 
@@ -664,7 +667,7 @@ describe('single-node/block-building/block_building', () => {
 
   // Tests that the sequencer handles L2 reorgs correctly: detects stale proofs, prunes affected txs,
   // and re-includes those that were built against a proven block.
-  // Uses cheatCodes.rollup.advanceToNextEpoch, markAsProven, advanceToEpoch, retryUntil.
+  // Uses cheatCodes.rollup.advanceToNextEpoch, markAsProven, advanceToEpoch, and tx-status wait helpers.
   describe('reorgs', () => {
     let contract: StatefulTestContract;
     let cheatCodes: CheatCodes;
@@ -700,8 +703,7 @@ describe('single-node/block-building/block_building', () => {
       // interval mining, so we drive proven manually here (and again inside each test).
       await cheatCodes.rollup.markAsProven();
       const bn = await aztecNode.getBlockNumber();
-      // REFACTOR: raw retryUntil poll on proven block number; replace with waitForProvenBlock(n) helper
-      await retryUntil(async () => (await aztecNode.getBlockNumber('proven')) >= bn, 'wait-proven', 60, 1);
+      await waitForProvenBlock(aztecNode, bn);
     });
 
     afterEach(() => test.teardown());
@@ -735,26 +737,14 @@ describe('single-node/block-building/block_building', () => {
 
       // Wait until the sequencer kicks out tx1
       logger.info(`Waiting for node to prune tx1`);
-      // REFACTOR: raw retryUntil polling for tx status transition; replace with a waitForTxPruned() helper
-      await retryUntil(
-        async () => (await aztecNode.getTxReceipt(tx1.txHash)).status === TxStatus.PENDING,
-        'wait for pruning',
-        15,
-        0.11,
-      );
+      await waitForTxStatus(aztecNode, tx1.txHash, TxStatus.PENDING, { timeout: 15, interval: 0.11 });
 
       // And wait until it is brought back tx1
       logger.info(`Waiting for node to re-include tx1`);
-      // REFACTOR: raw retryUntil polling for re-inclusion; replace with a waitForTxReincluded() helper
-      await retryUntil(
-        async () => {
-          const receipt = await aztecNode.getTxReceipt(tx1.txHash);
-          return receipt.isMined() && receipt.hasExecutionSucceeded();
-        },
-        'wait for re-inclusion',
-        15,
-        1,
-      );
+      await waitForTxReceipt(aztecNode, tx1.txHash, receipt => receipt.isMined() && receipt.hasExecutionSucceeded(), {
+        timeout: 15,
+        interval: 1,
+      });
 
       // Tx1 should have been mined in a block with the same number but different hash now
       const newTx1Receipt = await aztecNode.getTxReceipt(tx1.txHash);

--- a/yarn-project/end-to-end/src/single-node/block-building/debug_trace.test.ts
+++ b/yarn-project/end-to-end/src/single-node/block-building/debug_trace.test.ts
@@ -6,7 +6,6 @@ import type { PublisherManager } from '@aztec/ethereum/publisher-manager';
 import type { ExtendedViemWalletClient } from '@aztec/ethereum/types';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import type { Logger } from '@aztec/foundation/log';
-import { retryUntil } from '@aztec/foundation/retry';
 import { bufferToHex } from '@aztec/foundation/string';
 import type { TestSequencerClient } from '@aztec/sequencer-client/test';
 import type { AztecNode, AztecNodeAdmin } from '@aztec/stdlib/interfaces/client';
@@ -16,6 +15,7 @@ import 'jest-extended';
 import { type Hex, decodeFunctionData, encodeFunctionData, multicall3Abi } from 'viem';
 
 import { getPrivateKeyFromIndex } from '../../fixtures/utils.js';
+import { waitForBlockNumber } from '../../fixtures/wait_helpers.js';
 import { setupBlockProducer } from '../setup.js';
 import type { SingleNodeTestContext } from '../single_node_test_context.js';
 
@@ -86,7 +86,7 @@ describe('single-node/block-building/debug_trace', () => {
 
   // In this test we deploy a simple forwarder contract to L1, this serves as an additional proxy
   // Intercepts sendAndMonitorTransaction to forward the Multicall3 call via the Forwarder proxy.
-  // Waits for 2 new blocks via retryUntil; asserts the chain advances.
+  // Waits for 2 new blocks; asserts the chain advances.
   it('can process blocks using debug trace', async () => {
     // We intercept calls to sendAndMonitorTransaction to forward inner calls via the forwarder
     const l1Utils: L1TxUtils[] = (publisherManager as any).publishers;
@@ -132,17 +132,7 @@ describe('single-node/block-building/debug_trace', () => {
     const numBlocksToMine = 2;
     const startBlockNumber = await aztecNode.getBlockNumber();
     await aztecNodeAdmin.setConfig({ minTxsPerBlock: 0 });
-    // REFACTOR: raw retryUntil poll on block number; replace with a waitForBlock(n) DSL helper
-    const result = await retryUntil(
-      async () => {
-        const blockNumber = await aztecNode.getBlockNumber();
-        return blockNumber >= startBlockNumber + numBlocksToMine;
-      },
-      'block number check',
-      60,
-      1,
-    );
-    expect(result).toBeTrue();
+    await waitForBlockNumber(aztecNode, startBlockNumber + numBlocksToMine);
 
     // Restore the original sendAndMonitorTransaction
     l1Utils[0].sendAndMonitorTransaction = originalSendAndMonitor;
@@ -252,17 +242,7 @@ describe('single-node/block-building/debug_trace', () => {
     const numBlocksToMine = 3;
     const startBlockNumber = await aztecNode.getBlockNumber();
     await aztecNodeAdmin.setConfig({ minTxsPerBlock: 0 });
-    // REFACTOR: raw retryUntil poll on block number; replace with a waitForBlock(n) DSL helper
-    const result = await retryUntil(
-      async () => {
-        const blockNumber = await aztecNode.getBlockNumber();
-        return blockNumber >= startBlockNumber + numBlocksToMine;
-      },
-      'block number check',
-      60,
-      1,
-    );
-    expect(result).toBeTrue();
+    await waitForBlockNumber(aztecNode, startBlockNumber + numBlocksToMine);
 
     // Restore the original sendAndMonitorTransaction
     l1Utils[0].sendAndMonitorTransaction = originalSendAndMonitor;

--- a/yarn-project/end-to-end/src/single-node/block-building/multiple_blobs.test.ts
+++ b/yarn-project/end-to-end/src/single-node/block-building/multiple_blobs.test.ts
@@ -3,7 +3,7 @@ import { BatchCall, NO_WAIT } from '@aztec/aztec.js/contracts';
 import { publishContractClass } from '@aztec/aztec.js/deployment';
 import { Fr } from '@aztec/aztec.js/fields';
 import type { Logger } from '@aztec/aztec.js/log';
-import { type AztecNode, waitForTx } from '@aztec/aztec.js/node';
+import type { AztecNode } from '@aztec/aztec.js/node';
 import type { Wallet } from '@aztec/aztec.js/wallet';
 import { encodeCheckpointBlobDataFromBlocks } from '@aztec/blob-lib/encoding';
 import { FIELDS_PER_BLOB } from '@aztec/constants';
@@ -15,6 +15,7 @@ import { L2Block } from '@aztec/stdlib/block';
 import type { AztecNodeAdmin } from '@aztec/stdlib/interfaces/client';
 
 import { PIPELINING_SETUP_OPTS } from '../../fixtures/fixtures.js';
+import { waitForTxs } from '../../fixtures/wait_helpers.js';
 import { setupBlockProducer } from '../setup.js';
 import type { SingleNodeTestContext } from '../single_node_test_context.js';
 
@@ -81,13 +82,10 @@ describe('single-node/block-building/multiple_blobs', () => {
 
     // Send them simultaneously to be picked up by the sequencer
     const sendResults = await Promise.all(provenTxs.map(tx => tx.send({ from: defaultAccountAddress, wait: NO_WAIT })));
-    // REFACTOR: Promise.all over individual waitForTx calls; a waitForTxs batch helper would
-    // consolidate this into a single polling loop.
     // Wait for all to be mined
-    const receipts = await Promise.all(
-      sendResults.map(({ txHash }) => {
-        return waitForTx(aztecNode, txHash);
-      }),
+    const receipts = await waitForTxs(
+      aztecNode,
+      sendResults.map(({ txHash }) => txHash),
     );
     // Check that all txs are in the same block.
     const blockNumber = receipts[0].blockNumber!;

--- a/yarn-project/end-to-end/src/single-node/cross-chain/l1_to_l2.parallel.test.ts
+++ b/yarn-project/end-to-end/src/single-node/cross-chain/l1_to_l2.parallel.test.ts
@@ -16,6 +16,7 @@ import { jest } from '@jest/globals';
 
 import { L1_DIRECT_WRITE_ACCOUNT_INDEX, PIPELINING_SETUP_OPTS } from '../../fixtures/fixtures.js';
 import { sendL1ToL2Message } from '../../fixtures/l1_to_l2_messaging.js';
+import { waitForBlockNumber } from '../../fixtures/wait_helpers.js';
 import type { CrossChainTestHarness } from '../../shared/cross_chain_test_harness.js';
 import { CrossChainMessagingTest } from './cross_chain_messaging_test.js';
 
@@ -95,26 +96,14 @@ describe('single-node/cross-chain/l1_to_l2', () => {
     return newBlock;
   };
 
-  // REFACTOR: hand-rolled retryUntil polling for a block to reach the checkpointed chain tip; replace
-  // with a shared waitForBlockCheckpointed(node, blockNumber) helper in the e2e fixture utilities.
   const waitForBlockToCheckpoint = async (blockNumber: BlockNumber) => {
-    return await retryUntil(
-      async () => {
-        const checkpointedBlockNumber = await aztecNode.getBlockNumber('checkpointed');
-        const isCheckpointed = checkpointedBlockNumber >= blockNumber;
-        if (!isCheckpointed) {
-          return undefined;
-        }
-        const [checkpointedBlock] = await aztecNode.getBlocks(blockNumber, 1, {
-          includeL1PublishInfo: true,
-          includeAttestations: true,
-          onlyCheckpointed: true,
-        });
-        return checkpointedBlock.checkpointNumber;
-      },
-      'wait for block to checkpoint',
-      60,
-    );
+    await waitForBlockNumber(aztecNode, blockNumber, { tag: 'checkpointed', timeout: 60 });
+    const [checkpointedBlock] = await aztecNode.getBlocks(blockNumber, 1, {
+      includeL1PublishInfo: true,
+      includeAttestations: true,
+      onlyCheckpointed: true,
+    });
+    return checkpointedBlock.checkpointNumber;
   };
 
   const advanceCheckpoint = async () => {

--- a/yarn-project/end-to-end/src/single-node/cross-chain/l2_to_l1.parallel.test.ts
+++ b/yarn-project/end-to-end/src/single-node/cross-chain/l2_to_l1.parallel.test.ts
@@ -6,7 +6,7 @@ import { OutboxContract, RollupContract, type ViemL2ToL1Msg } from '@aztec/ether
 import { retryUntil } from '@aztec/foundation/retry';
 import { OutboxAbi } from '@aztec/l1-artifacts';
 import { TestContract } from '@aztec/noir-test-contracts.js/Test';
-import { type Sequencer, type SequencerEvents, SequencerState } from '@aztec/sequencer-client';
+import { SequencerState } from '@aztec/sequencer-client';
 import { computeL2ToL1MessageHash } from '@aztec/stdlib/hash';
 import type { AztecNode, AztecNodeAdmin } from '@aztec/stdlib/interfaces/client';
 import { type L2ToL1MembershipWitness, getL2ToL1MessageLeafId } from '@aztec/stdlib/messaging';
@@ -16,35 +16,9 @@ import { jest } from '@jest/globals';
 import { type Hex, decodeEventLog } from 'viem';
 
 import { PIPELINING_SETUP_OPTS } from '../../fixtures/fixtures.js';
+import { waitForSequencerState } from '../../fixtures/wait_helpers.js';
 import type { CrossChainTestHarness } from '../../shared/cross_chain_test_harness.js';
 import { CrossChainMessagingTest } from './cross_chain_messaging_test.js';
-
-/**
- * Waits for the sequencer to reach IDLE state so that subsequent setConfig() calls take effect on
- * the next checkpoint job rather than racing with an in-flight one. Mirrors the helper in
- * `e2e_fees/gas_estimation.test.ts`.
- */
-// REFACTOR: duplicated from e2e_fees/gas_estimation.test.ts; extract to a shared fixture helper
-// (e.g. waitForSequencerState) so both call sites can share it without copy-pasting.
-function waitForSequencerIdle(sequencer: Sequencer, timeout = 30000): Promise<void> {
-  if (sequencer.status().state === SequencerState.IDLE) {
-    return Promise.resolve();
-  }
-  return new Promise((resolve, reject) => {
-    const timer = setTimeout(() => {
-      sequencer.off('state-changed', handler);
-      reject(new Error('Timeout waiting for sequencer IDLE state'));
-    }, timeout);
-    const handler = (args: Parameters<SequencerEvents['state-changed']>[0]) => {
-      if (args.newState === SequencerState.IDLE) {
-        clearTimeout(timer);
-        sequencer.off('state-changed', handler);
-        resolve();
-      }
-    };
-    sequencer.on('state-changed', handler);
-  });
-}
 
 // L2→L1 messaging via Outbox: tree structure, multi-tx blocks, and multi-block checkpoints.
 // Uses CrossChainMessagingTest with startProverNode=true (prod sequencer, pipelining preset:
@@ -100,7 +74,7 @@ describe('single-node/cross-chain/l2_to_l1', () => {
 
     // Configure the node to be able to rollup only 1 tx.
     await aztecNodeAdmin.setConfig({ minTxsPerBlock: 1 });
-    await waitForSequencerIdle(t.context.sequencer!.getSequencer());
+    await waitForSequencerState(t.context.sequencer!.getSequencer(), SequencerState.IDLE);
 
     const { receipt: txReceipt } = await new BatchCall(wallet, [
       contract.methods.create_l2_to_l1_message_arbitrary_recipient_private(contents[0], recipient),
@@ -134,7 +108,7 @@ describe('single-node/cross-chain/l2_to_l1', () => {
 
     // One tx per block so the message-bearing tx owns its checkpoint.
     await aztecNodeAdmin.setConfig({ minTxsPerBlock: 1 });
-    await waitForSequencerIdle(t.context.sequencer!.getSequencer());
+    await waitForSequencerState(t.context.sequencer!.getSequencer(), SequencerState.IDLE);
 
     // Send the message-bearing tx and note where it first landed.
     const { receipt: txReceipt } = await contract.methods
@@ -201,7 +175,7 @@ describe('single-node/cross-chain/l2_to_l1', () => {
 
     // Configure the node to include the 2 txs in the same block.
     await aztecNodeAdmin.setConfig({ minTxsPerBlock: 2 });
-    await waitForSequencerIdle(t.context.sequencer!.getSequencer());
+    await waitForSequencerState(t.context.sequencer!.getSequencer(), SequencerState.IDLE);
 
     // Send the 2 txs.
     const [{ receipt: noMessageReceipt }, { receipt: withMessageReceipt }] = await Promise.all([
@@ -226,7 +200,7 @@ describe('single-node/cross-chain/l2_to_l1', () => {
   it('2 txs (balanced), one with 3 messages (unbalanced), one with 4 messages (balanced)', async () => {
     // Force txs to be in the same block.
     await aztecNodeAdmin!.setConfig({ minTxsPerBlock: 2 });
-    await waitForSequencerIdle(t.context.sequencer!.getSequencer());
+    await waitForSequencerState(t.context.sequencer!.getSequencer(), SequencerState.IDLE);
 
     const tx0 = generateMessages(3);
     const tx1 = generateMessages(4);
@@ -281,7 +255,7 @@ describe('single-node/cross-chain/l2_to_l1', () => {
   it('3 txs (unbalanced), one with 3 messages (unbalanced), one with 1 message (the subtree root), one with 2 messages (balanced)', async () => {
     // Force txs to be in the same block.
     await aztecNodeAdmin!.setConfig({ minTxsPerBlock: 3 });
-    await waitForSequencerIdle(t.context.sequencer!.getSequencer());
+    await waitForSequencerState(t.context.sequencer!.getSequencer(), SequencerState.IDLE);
 
     const tx0 = generateMessages(3);
     const tx1 = generateMessages(1);
@@ -352,7 +326,7 @@ describe('single-node/cross-chain/l2_to_l1', () => {
       minBlocksForCheckpoint: 2,
       maxBlocksPerCheckpoint: 2,
     });
-    await waitForSequencerIdle(t.context.sequencer!.getSequencer());
+    await waitForSequencerState(t.context.sequencer!.getSequencer(), SequencerState.IDLE);
 
     // Send the 2 txs. minBlocksForCheckpoint=2 keeps the sequencer from publishing until both have
     // been packed (one per block), so they always end up in the same checkpoint.

--- a/yarn-project/end-to-end/src/single-node/cross-chain/token_bridge_private.test.ts
+++ b/yarn-project/end-to-end/src/single-node/cross-chain/token_bridge_private.test.ts
@@ -2,13 +2,13 @@ import { AztecAddress, EthAddress } from '@aztec/aztec.js/addresses';
 import { Fr } from '@aztec/aztec.js/fields';
 import type { Logger } from '@aztec/aztec.js/log';
 import type { AztecNode } from '@aztec/aztec.js/node';
-import { retryUntil } from '@aztec/foundation/retry';
 import type { TokenContract } from '@aztec/noir-contracts.js/Token';
 import type { TokenBridgeContract } from '@aztec/noir-contracts.js/TokenBridge';
 
 import { jest } from '@jest/globals';
 
 import { L1_DIRECT_WRITE_ACCOUNT_INDEX, PIPELINING_SETUP_OPTS } from '../../fixtures/fixtures.js';
+import { waitForL2ToL1Witness } from '../../fixtures/wait_helpers.js';
 import type { CrossChainTestHarness } from '../../shared/cross_chain_test_harness.js';
 import type { TestWallet } from '../../test-wallet/test_wallet.js';
 import { CrossChainMessagingTest } from './cross_chain_messaging_test.js';
@@ -95,14 +95,9 @@ describe('single-node/cross-chain/token_bridge_private', () => {
     // Advance the epoch until the tx is proven since the messages are inserted to the outbox when the epoch is proven.
     await t.advanceToEpochProven(l2TxReceipt);
 
-    // REFACTOR: hand-rolled retryUntil polling for L2→L1 membership witness; replace with a
-    // waitForL2ToL1MessageWitness(node, txHash, leaf) helper shared across bridge tests.
-    const l2ToL1MessageResult = await retryUntil(
-      () => aztecNode.getL2ToL1MembershipWitness(l2TxReceipt.txHash, l2ToL1Message),
-      'l2 to l1 membership witness',
-      60,
-      1,
-    );
+    const l2ToL1MessageResult = await waitForL2ToL1Witness(aztecNode, l2TxReceipt.txHash, l2ToL1Message, {
+      timeout: 60,
+    });
 
     // Check balance before and after exit.
     expect(await crossChainTestHarness.getL1BalanceOf(ethAccount)).toBe(l1TokenBalance - bridgeAmount);

--- a/yarn-project/end-to-end/src/single-node/cross-chain/token_bridge_public.parallel.test.ts
+++ b/yarn-project/end-to-end/src/single-node/cross-chain/token_bridge_public.parallel.test.ts
@@ -1,5 +1,4 @@
 import { Fr } from '@aztec/aztec.js/fields';
-import { retryUntil } from '@aztec/foundation/retry';
 
 import { jest } from '@jest/globals';
 
@@ -8,6 +7,7 @@ import {
   NO_L1_TO_L2_MSG_ERROR,
   PIPELINING_SETUP_OPTS,
 } from '../../fixtures/fixtures.js';
+import { waitForL2ToL1Witness } from '../../fixtures/wait_helpers.js';
 import { CrossChainMessagingTest } from './cross_chain_messaging_test.js';
 
 // Public L1→L2 token deposit and L2→L1 withdrawal via the TokenBridge. Uses CrossChainMessagingTest
@@ -105,14 +105,9 @@ describe('single-node/cross-chain/token_bridge_public', () => {
     // Advance the epoch until the tx is proven since the messages are inserted to the outbox when the epoch is proven.
     await t.advanceToEpochProven(l2TxReceipt);
 
-    // REFACTOR: hand-rolled retryUntil polling for L2→L1 membership witness; replace with a
-    // waitForL2ToL1MessageWitness(node, txHash, leaf) helper shared across bridge tests.
-    const l2ToL1MessageResult = await retryUntil(
-      () => aztecNode.getL2ToL1MembershipWitness(l2TxReceipt.txHash, l2ToL1Message),
-      'l2 to l1 membership witness',
-      60,
-      1,
-    );
+    const l2ToL1MessageResult = await waitForL2ToL1Witness(aztecNode, l2TxReceipt.txHash, l2ToL1Message, {
+      timeout: 60,
+    });
 
     // Check balance before and after exit.
     expect(await crossChainTestHarness.getL1BalanceOf(ethAccount)).toBe(l1TokenBalance - bridgeAmount);

--- a/yarn-project/end-to-end/src/single-node/fees/fee_asset_price_oracle.test.ts
+++ b/yarn-project/end-to-end/src/single-node/fees/fee_asset_price_oracle.test.ts
@@ -96,35 +96,27 @@ describe('single-node/fees/fee_asset_price_oracle', () => {
     const initialOnChainPrice = await rollup.getEthPerFeeAsset();
     logger.info(`Initial on-chain price: ${initialOnChainPrice}, target oracle price: ${targetOraclePrice}`);
 
-    // REFACTOR: hand-rolled retryUntil polling loop waiting for price convergence; a DSL helper for
-    // "wait until rollup price is within N bps of oracle" would make the intent clearer.
-    await retryUntil(
-      async () => {
-        const currentPrice = await rollup.getEthPerFeeAsset();
-        logger.info(`Current on-chain price: ${currentPrice}, waiting for: ${targetOraclePrice}`);
-        return diffInBps(currentPrice, targetOraclePrice) == 0n;
-      },
-      'price convergence toward oracle',
-      PRICE_CONVERGENCE_TIMEOUT_SECONDS,
-      PRICE_CONVERGENCE_POLL_INTERVAL_SECONDS,
-    );
+    // Polls the rollup's fee-asset price until it converges to within 0 bps of the oracle target.
+    const waitForPriceConvergence = (target: bigint) =>
+      retryUntil(
+        async () => {
+          const currentPrice = await rollup.getEthPerFeeAsset();
+          logger.info(`Current on-chain price: ${currentPrice}, waiting for: ${target}`);
+          return diffInBps(currentPrice, target) == 0n;
+        },
+        'price convergence toward oracle',
+        PRICE_CONVERGENCE_TIMEOUT_SECONDS,
+        PRICE_CONVERGENCE_POLL_INTERVAL_SECONDS,
+      );
+
+    await waitForPriceConvergence(targetOraclePrice);
 
     const priceAfterFirstAlignment = await rollup.getEthPerFeeAsset();
     const targetOraclePrice2 = (BigInt(priceAfterFirstAlignment) * 995n) / 1000n;
     await mockStateView.setEthPerFeeAsset(targetOraclePrice2);
     logger.info(`Set uniswap price to ${targetOraclePrice2}`);
 
-    // REFACTOR: second hand-rolled retryUntil polling loop for price convergence; same as above.
-    await retryUntil(
-      async () => {
-        const currentPrice = await rollup.getEthPerFeeAsset();
-        logger.info(`Current on-chain price: ${currentPrice}, waiting for: ${targetOraclePrice2}`);
-        return diffInBps(currentPrice, targetOraclePrice2) == 0n;
-      },
-      'price convergence toward oracle',
-      PRICE_CONVERGENCE_TIMEOUT_SECONDS,
-      PRICE_CONVERGENCE_POLL_INTERVAL_SECONDS,
-    );
+    await waitForPriceConvergence(targetOraclePrice2);
 
     const finalPrice = await rollup.getEthPerFeeAsset();
     logger.info(`Final on-chain price: ${finalPrice}`);

--- a/yarn-project/end-to-end/src/single-node/fees/fee_settings.test.ts
+++ b/yarn-project/end-to-end/src/single-node/fees/fee_settings.test.ts
@@ -12,6 +12,7 @@ import { jest } from '@jest/globals';
 import { inspect } from 'util';
 
 import { DEFAULT_MIN_FEE_PADDING } from '../../fixtures/fixtures.js';
+import { waitForBlockNumber, waitForNodeCheckpoint } from '../../fixtures/wait_helpers.js';
 import type { TestWallet } from '../../test-wallet/test_wallet.js';
 import { proveInteraction } from '../../test-wallet/utils.js';
 import { FeesTest } from './fees_test.js';
@@ -145,21 +146,8 @@ describe('single-node/fees/fee_settings', () => {
     // Pick a baseline from the post-checkpoint chain state. The prove step itself is
     // made deterministic by prepareTxsWithMockedMinFees below.
     const getCurrentMinFeesAfterCheckpoint = async (checkpointedBlock: BlockNumber) => {
-      // REFACTOR: hand-rolled retryUntil polling for a checkpointed block number; replace with a
-      // waitUntilCheckpointedBlockNumber(node, blockNumber) helper in the e2e fixture utilities.
-      return await retryUntil(
-        async () => {
-          const currentCheckpointedBlock = await aztecNode.getBlockNumber('checkpointed');
-          if (currentCheckpointedBlock < checkpointedBlock) {
-            return undefined;
-          }
-
-          return await aztecNode.getCurrentMinFees();
-        },
-        `L2 min fees after block ${checkpointedBlock} is checkpointed`,
-        60,
-        1,
-      );
+      await waitForBlockNumber(aztecNode, checkpointedBlock, { tag: 'checkpointed', timeout: 60 });
+      return await aztecNode.getCurrentMinFees();
     };
 
     const proveTx = async (minFeePadding: number | undefined) => {
@@ -291,14 +279,7 @@ describe('single-node/fees/fee_settings', () => {
       // `checkpointed` tip must strictly advance.
       const RECOVERY_TARGET = CheckpointNumber.add(checkpointBefore, 3);
       const RECOVERY_BUDGET_SECONDS = AZTEC_SLOT_DURATION * 6;
-      // REFACTOR: hand-rolled retryUntil polling for checkpoint number; replace with a
-      // waitForCheckpointNumber(node, target) helper from EpochsTestContext or a shared utility.
-      await retryUntil(
-        async () => (await aztecNode.getCheckpointNumber('checkpointed')) >= RECOVERY_TARGET,
-        `chain advances at least ${RECOVERY_TARGET - checkpointBefore} checkpoints past governance bump`,
-        RECOVERY_BUDGET_SECONDS,
-        1,
-      );
+      await waitForNodeCheckpoint(aztecNode, RECOVERY_TARGET, { timeout: RECOVERY_BUDGET_SECONDS, interval: 1 });
 
       // Healthy pipelining produces one checkpoint per L2 slot, so an advance of 3 checkpoints
       // covers exactly 3 slots. If a pipelined header was invalidated and dropped (the A-1057

--- a/yarn-project/end-to-end/src/single-node/fees/gas_estimation.parallel.test.ts
+++ b/yarn-project/end-to-end/src/single-node/fees/gas_estimation.parallel.test.ts
@@ -5,7 +5,7 @@ import type { Wallet } from '@aztec/aztec.js/wallet';
 import type { Logger } from '@aztec/foundation/log';
 import type { FPCContract } from '@aztec/noir-contracts.js/FPC';
 import { TokenContract as BananaCoin } from '@aztec/noir-contracts.js/Token';
-import { type Sequencer, type SequencerEvents, SequencerState } from '@aztec/sequencer-client';
+import { SequencerState } from '@aztec/sequencer-client';
 import {
   GAS_ESTIMATION_DA_GAS_LIMIT,
   GAS_ESTIMATION_L2_GAS_LIMIT,
@@ -22,37 +22,8 @@ import { jest } from '@jest/globals';
 import { inspect } from 'util';
 
 import { PIPELINING_SETUP_OPTS, getPaddedMaxFeesPerGas } from '../../fixtures/fixtures.js';
+import { waitForSequencerState } from '../../fixtures/wait_helpers.js';
 import { FeesTest } from './fees_test.js';
-
-/**
- * Waits for the sequencer to reach IDLE state.
- * This ensures any in-progress checkpoint job has completed and the next job will use the current config.
- */
-function waitForSequencerIdle(sequencer: Sequencer, timeout = 30000): Promise<void> {
-  // If already idle, no need to wait
-  if (sequencer.status().state === SequencerState.IDLE) {
-    return Promise.resolve();
-  }
-
-  // REFACTOR: raw sequencer event listener with manual timer; replace with a shared
-  // waitForSequencerState(sequencer, SequencerState.IDLE) helper in the e2e fixtures.
-  return new Promise((resolve, reject) => {
-    const timer = setTimeout(() => {
-      sequencer.off('state-changed', handler);
-      reject(new Error('Timeout waiting for sequencer IDLE state'));
-    }, timeout);
-
-    const handler = (args: Parameters<SequencerEvents['state-changed']>[0]) => {
-      if (args.newState === SequencerState.IDLE) {
-        clearTimeout(timer);
-        sequencer.off('state-changed', handler);
-        resolve();
-      }
-    };
-
-    sequencer.on('state-changed', handler);
-  });
-}
 
 // Gas estimation accuracy and FPC teardown gas prediction. Uses FeesTest (prod sequencer, pipelining
 // preset: ethSlot=4s, aztecSlot=12s, inboxLag=2, minTxsPerBlock=0), fake in-proc prover node, and
@@ -147,7 +118,7 @@ describe('single-node/fees/gas_estimation', () => {
 
     // Wait for any in-progress checkpoint job to complete before sending txs.
     // This ensures the next checkpoint job will use the updated minTxsPerBlock config.
-    await waitForSequencerIdle(sequencer);
+    await waitForSequencerState(sequencer, SequencerState.IDLE);
 
     const [withEstimate, withoutEstimate] = await sendTransfers(estimatedGas);
 
@@ -197,7 +168,7 @@ describe('single-node/fees/gas_estimation', () => {
     const sequencer = t.context.sequencer!.getSequencer();
     await t.aztecNodeAdmin.setConfig({ minTxsPerBlock: 2, maxTxsPerBlock: 2 });
     // Wait for any in-progress checkpoint job to complete so the next job picks up the updated config.
-    await waitForSequencerIdle(sequencer);
+    await waitForSequencerState(sequencer, SequencerState.IDLE);
 
     const [withEstimate, withoutEstimate] = await sendTransfers(estimatedGas, paymentMethod);
 

--- a/yarn-project/end-to-end/src/single-node/proving/upload_failed_proof.test.ts
+++ b/yarn-project/end-to-end/src/single-node/proving/upload_failed_proof.test.ts
@@ -2,7 +2,7 @@ import type { AztecNodeConfig } from '@aztec/aztec-node';
 import { EthAddress } from '@aztec/aztec.js/addresses';
 import type { Logger } from '@aztec/aztec.js/log';
 import { tryRmDir } from '@aztec/foundation/fs';
-import { retryUntil } from '@aztec/foundation/retry';
+import { promiseWithResolvers } from '@aztec/foundation/promise';
 import { sleep } from '@aztec/foundation/sleep';
 import { downloadEpochProvingJob, rerunEpochProvingJob } from '@aztec/prover-node';
 import type { TestProverNode } from '@aztec/prover-node/test';
@@ -83,26 +83,27 @@ describe('single-node/proving/upload_failed_proof', () => {
     });
 
     // And track when the epoch failure upload is complete
-    let epochUploadUrl: string | undefined = undefined;
+    const { promise: epochUploaded, resolve: onEpochUploaded } = promiseWithResolvers<string>();
     const origTryUploadEpochFailure = proverNode.tryUploadSessionFailure.bind(proverNode);
     proverNode.tryUploadSessionFailure = async (session: any) => {
-      epochUploadUrl = await origTryUploadEpochFailure(session);
-      return epochUploadUrl;
+      const url = await origTryUploadEpochFailure(session);
+      if (url !== undefined) {
+        onEpochUploaded(url);
+      }
+      return url;
     };
 
     // Wait until the start of epoch one so prover node starts proving epoch 0,
     // and wait for the data to be uploaded to the remote file store
     await test.waitUntilEpochStarts(1);
-    // REFACTOR: hand-rolled retryUntil polling a local variable for the upload completion; a DSL
-    // helper or a Promise-based event on the prover node would avoid the polling loop.
-    await retryUntil(() => epochUploadUrl !== undefined, 'Upload epoch failure', 240, 1);
+    const epochUploadUrl = await epochUploaded;
 
     // Stop everything, we're going to prove on a fresh instance
     await test.teardown();
 
     const rerunDownloadPath = join(rerunDownloadDir, 'data.bin');
     logger.warn(`Downloading epoch proving job data and state`, { uploadPath, rerunDataDir, rerunDownloadPath });
-    await downloadEpochProvingJob(epochUploadUrl!, logger, {
+    await downloadEpochProvingJob(epochUploadUrl, logger, {
       dataDirectory: rerunDataDir,
       jobDataDownloadPath: rerunDownloadPath,
     });

--- a/yarn-project/end-to-end/src/single-node/sequencer/escape_hatch_vote_only.test.ts
+++ b/yarn-project/end-to-end/src/single-node/sequencer/escape_hatch_vote_only.test.ts
@@ -2,13 +2,12 @@ import { CheatCodes, EthCheatCodes } from '@aztec/aztec/testing';
 import { GovernanceProposerContract, RollupContract } from '@aztec/ethereum/contracts';
 import type { DeployAztecL1ContractsReturnType } from '@aztec/ethereum/deploy-aztec-l1-contracts';
 import { deployL1Contract } from '@aztec/ethereum/deploy-l1-contract';
-import { EpochNumber } from '@aztec/foundation/branded-types';
+import { EpochNumber, SlotNumber } from '@aztec/foundation/branded-types';
 import { times } from '@aztec/foundation/collection';
 import { SecretValue } from '@aztec/foundation/config';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import type { Logger } from '@aztec/foundation/log';
-import { retryUntil } from '@aztec/foundation/retry';
 import { EscapeHatchAbi } from '@aztec/l1-artifacts/EscapeHatchAbi';
 import { EscapeHatchBytecode } from '@aztec/l1-artifacts/EscapeHatchBytecode';
 import { EscapeHatchStorage } from '@aztec/l1-artifacts/EscapeHatchStorage';
@@ -47,7 +46,7 @@ jest.setTimeout(1000 * 60 * 5);
 // Tests the sequencer's behavior during an EscapeHatch voting window. One node running a 4-validator
 // committee with pipelining opts (ethSlot=4s, aztecSlot=12s, epoch=4, proofSubEpochs=15). The
 // beforeEach deploys a custom EscapeHatch L1 contract and wires it into the rollup. Timing driven by
-// cheatCodes.rollup.advanceToEpoch + retryUntil waits.
+// cheatCodes.rollup.advanceToEpoch + waitForEpoch/waitForSlot waits.
 // Setup: setupBlockProducer (no prover node) with { ...PIPELINING_SETUP_OPTS, overridden slots,
 // aztecTargetCommitteeSize=4 }.
 describe('single-node/sequencer/escape_hatch_vote_only', () => {
@@ -84,7 +83,7 @@ describe('single-node/sequencer/escape_hatch_vote_only', () => {
       governanceProposerRoundSize: ROUND_SIZE,
       governanceProposerQuorum: QUORUM_SIZE,
       // Inherit the PIPELINING_SETUP_OPTS fast slot durations (eth=4s, aztec=12s, blockDurationMs=3000).
-      // These slots are restated as named constants so the retryUntil timeouts below scale with them.
+      // These slots are restated as named constants so the wait timeouts below scale with them.
       ethereumSlotDuration: ETHEREUM_SLOT_DURATION,
       aztecSlotDuration: AZTEC_SLOT_DURATION,
       blockDurationMs: 3000,
@@ -162,7 +161,7 @@ describe('single-node/sequencer/escape_hatch_vote_only', () => {
 
   // Verifies that when the escape hatch is open the sequencer casts governance votes every slot without
   // building blocks or checkpoints, and that no failure events are emitted in the vote-only window.
-  // Waits two full epochs via retryUntil, then checks vote count >= slots elapsed and checkpoint count = 0.
+  // Waits two full epochs, then checks vote count >= slots elapsed and checkpoint count = 0.
   it('casts governance signals and advances checkpoints while escape hatch is closed', async () => {
     const sequencer = sequencerClient!.getSequencer();
 
@@ -246,14 +245,9 @@ describe('single-node/sequencer/escape_hatch_vote_only', () => {
     const initialStats = await getStats();
 
     // We will wait until epochs advance
-    // REFACTOR: retryUntil on epoch arithmetic should be replaced with a cheatCodes.rollup.waitForEpoch helper
-    await retryUntil(
-      async () =>
-        (await rollup.getEpochNumberForSlotNumber(await rollup.getSlotNumber())) >= initialStats.epoch + EpochNumber(2),
-      'epoch to advance',
-      AZTEC_SLOT_DURATION * AZTEC_EPOCH_DURATION * 3,
-      1,
-    );
+    await cheatCodes.rollup.waitForEpoch(EpochNumber(initialStats.epoch + EpochNumber(2)), {
+      timeout: AZTEC_SLOT_DURATION * AZTEC_EPOCH_DURATION * 3,
+    });
 
     // Snapshot the slot we will assert against now; under proposer pipelining the sequencer signs a vote in build
     // slot N for target slot N+1 and submits it at the start of N+1, so the votes corresponding to slots up through
@@ -262,14 +256,8 @@ describe('single-node/sequencer/escape_hatch_vote_only', () => {
     const slotAtMeasurement = await rollup.getSlotNumber();
     const slotsPassed = slotAtMeasurement - initialStats.slot;
     expect(slotsPassed).toBeGreaterThan(0);
-    const drainTarget = slotAtMeasurement + 2;
-    // REFACTOR: retryUntil on slot polling should be replaced with a rollup slot-wait helper
-    await retryUntil(
-      () => rollup.getSlotNumber().then(s => s >= drainTarget),
-      'pipelined vote drain',
-      AZTEC_SLOT_DURATION * 4,
-      1,
-    );
+    const drainTarget = SlotNumber(slotAtMeasurement + 2);
+    await cheatCodes.rollup.waitForSlot(drainTarget, { timeout: AZTEC_SLOT_DURATION * 4 });
 
     const finalStats = await getStats();
     expect(finalStats.votes - initialStats.votes).toBeGreaterThanOrEqual(slotsPassed);

--- a/yarn-project/end-to-end/src/single-node/sequencer/gov_proposal.parallel.test.ts
+++ b/yarn-project/end-to-end/src/single-node/sequencer/gov_proposal.parallel.test.ts
@@ -264,12 +264,7 @@ describe('single-node/sequencer/gov_proposal', () => {
     // Wait through the target slot end plus the two-L1-slot sync tolerance before starting the vote-only round.
     const voteOnlySlot = SlotNumber(Number(checkpointAfterBlobDisable.l2SlotNumber) + 2);
     logger.warn(`Waiting until slot ${voteOnlySlot} before starting vote-only round`);
-    await retryUntil(
-      async () => ((await rollup.getSlotNumber()) >= voteOnlySlot ? true : undefined),
-      'stale pipelined checkpoint to expire after disabling blob client',
-      AZTEC_SLOT_DURATION * 4,
-      1,
-    );
+    await cheatCodes.rollup.waitForSlot(voteOnlySlot, { timeout: AZTEC_SLOT_DURATION * 4 });
 
     // Select the voting round.
     const { round, roundDuration, nextRoundBeginsAtSlot } = await setupVotingRound();
@@ -280,8 +275,7 @@ describe('single-node/sequencer/gov_proposal', () => {
     const nextRoundEndsAtSlot = SlotNumber(nextRoundBeginsAtSlot + Number(roundDuration));
     const timeout = AZTEC_SLOT_DURATION * Number(roundDuration + 2n) + 20;
     logger.warn(`Waiting until slot ${nextRoundEndsAtSlot} for round to end (timeout ${timeout}s)`);
-    // REFACTOR: retryUntil on slot polling should be replaced with a rollup slot-wait helper
-    await retryUntil(() => rollup.getSlotNumber().then(s => s > nextRoundEndsAtSlot), 'round end', timeout, 1);
+    await cheatCodes.rollup.waitForSlot(SlotNumber(nextRoundEndsAtSlot + 1), { timeout });
 
     // We should have voted despite being unable to build blocks
     await verifyVotes(round, roundDuration);

--- a/yarn-project/end-to-end/src/single-node/sequencer/reload_keystore.test.ts
+++ b/yarn-project/end-to-end/src/single-node/sequencer/reload_keystore.test.ts
@@ -9,7 +9,7 @@ import { BlockNumber } from '@aztec/foundation/branded-types';
 import { SecretValue } from '@aztec/foundation/config';
 import type { EthPrivateKey } from '@aztec/node-keystore';
 import { StatefulTestContractArtifact } from '@aztec/noir-test-contracts.js/StatefulTest';
-import { type SequencerClient, type SequencerEvents, SequencerState } from '@aztec/sequencer-client';
+import { type SequencerClient, SequencerState } from '@aztec/sequencer-client';
 import type { TestSequencer, TestSequencerClient } from '@aztec/sequencer-client/test';
 import type { AztecNodeAdmin } from '@aztec/stdlib/interfaces/client';
 import type { ValidatorClient } from '@aztec/validator-client';
@@ -22,6 +22,7 @@ import { privateKeyToAccount } from 'viem/accounts';
 
 import { PIPELINING_SETUP_OPTS } from '../../fixtures/fixtures.js';
 import { getPrivateKeyFromIndex } from '../../fixtures/utils.js';
+import { waitForSequencerState } from '../../fixtures/wait_helpers.js';
 import { setupBlockProducer } from '../setup.js';
 import type { SingleNodeTestContext } from '../single_node_test_context.js';
 
@@ -34,60 +35,6 @@ const PUBLISHER_KEY_INDEX = 3;
 const VALIDATOR_COUNT = 4;
 const COMMITTEE_SIZE = VALIDATOR_COUNT;
 const INITIAL_KEYSTORE_COUNT = 3;
-
-// REFACTOR: hand-rolled state-changed on/off subscription with a manual timeout that runs an action and
-// waits for the sequencer to return to IDLE — a waitForSequencerState(IDLE, { after }) DSL helper should
-// replace it (also duplicated as waitForSequencerIdle in e2e_multiple_blobs / e2e_fees / l2_to_l1).
-async function waitForSequencerIdleAfter(
-  sequencer: TestSequencer,
-  action: () => Promise<unknown>,
-  timeout = 30_000,
-): Promise<void> {
-  let settled = false;
-  let resolveIdle!: () => void;
-  let rejectIdle!: (err: Error) => void;
-  const idlePromise = new Promise<void>((resolve, reject) => {
-    resolveIdle = resolve;
-    rejectIdle = reject;
-  });
-
-  let cleanup = () => {};
-  const finish = (complete: () => void) => {
-    if (settled) {
-      return;
-    }
-    settled = true;
-    cleanup();
-    complete();
-  };
-
-  const handler = (args: Parameters<SequencerEvents['state-changed']>[0]) => {
-    if (args.newState === SequencerState.IDLE) {
-      finish(resolveIdle);
-    }
-  };
-
-  const timer = setTimeout(
-    () => finish(() => rejectIdle(new Error('Timeout waiting for sequencer IDLE state'))),
-    timeout,
-  );
-  cleanup = () => {
-    clearTimeout(timer);
-    sequencer.off('state-changed', handler);
-  };
-
-  sequencer.on('state-changed', handler);
-  try {
-    await action();
-    if (sequencer.status().state === SequencerState.IDLE) {
-      finish(resolveIdle);
-    }
-    await idlePromise;
-  } catch (err) {
-    finish(() => {});
-    throw err;
-  }
-}
 
 // Tests that the sequencer node's keystore can be hot-reloaded at runtime via the admin API.
 // One node with 4 validators staked, committee size 4. Initially only 3 validators are in the
@@ -261,7 +208,9 @@ describe('single-node/sequencer/reload_keystore', () => {
     // Send a tx and confirm the block uses one of the new per-validator coinbases.
     // Whichever validator is the proposer, its coinbase must be from the reloaded keystore.
     // A checkpoint job may already be waiting for txs with the old coinbase, so let it expire before sending.
-    await waitForSequencerIdleAfter(sequencer, () => cheatCodes.rollup.advanceToNextSlot());
+    await waitForSequencerState(sequencer, SequencerState.IDLE, {
+      after: () => cheatCodes.rollup.advanceToNextSlot(),
+    });
 
     const allNewCoinbasesLower = newCoinbases.map(c => c.toString().toLowerCase());
 

--- a/yarn-project/end-to-end/src/single-node/sync/synching.test.ts
+++ b/yarn-project/end-to-end/src/single-node/sync/synching.test.ts
@@ -47,7 +47,7 @@ import { GovernanceProposerContract, RollupContract } from '@aztec/ethereum/cont
 import { createL1TxUtils } from '@aztec/ethereum/l1-tx-utils';
 import { CheckpointNumber } from '@aztec/foundation/branded-types';
 import { Signature } from '@aztec/foundation/eth-signature';
-import { sleep } from '@aztec/foundation/sleep';
+import { retryUntil } from '@aztec/foundation/retry';
 import { bufferToHex, hexToBuffer } from '@aztec/foundation/string';
 import { Timer } from '@aztec/foundation/timer';
 import { RollupAbi } from '@aztec/l1-artifacts';
@@ -68,6 +68,7 @@ import { getContract } from 'viem';
 import { PIPELINING_SETUP_OPTS } from '../../fixtures/fixtures.js';
 import { mintTokensToPrivate } from '../../fixtures/token_utils.js';
 import { type EndToEndContext, setupPXEAndGetWallet } from '../../fixtures/utils.js';
+import { waitForBlockNumber } from '../../fixtures/wait_helpers.js';
 import { TestWallet } from '../../test-wallet/test_wallet.js';
 import { setupBlockProducer } from '../setup.js';
 
@@ -658,11 +659,13 @@ describe('single-node/sync/synching', () => {
 
           await rollup.write.prune();
 
-          // We need to sleep a bit to make sure that we have caught the prune and deleted blocks.
-          // REFACTOR: sleep-based wait for archiver to process the prune event; a retryUntil or event-based
-          // helper (waitForArchiverCheckpoint or similar) should replace this sleep.
-          await sleep(3000);
-          expect(await archiver.getCheckpointNumber()).toBe(provenThrough);
+          // Wait for the archiver to catch the prune and roll its checkpoint number back to the proven tip.
+          await retryUntil(
+            async () => (await archiver.getCheckpointNumber()) === provenThrough || undefined,
+            'archiver to process prune',
+            30,
+            0.5,
+          );
 
           const contractClassIdsAfter = await archiver.getContractClassIds();
 
@@ -727,10 +730,8 @@ describe('single-node/sync/synching', () => {
             hash: await rollup.write.prune(),
           });
 
-          // REFACTOR: sleep-based wait for node to process prune and update block number; a retryUntil
-          // waiting on getBlockNumber() < blockBeforePrune should replace this sleep.
-          await sleep(5000);
-          expect(await aztecNode.getBlockNumber()).toBeLessThan(blockBeforePrune);
+          // Wait for the node to observe the prune and roll its block number back below the pre-prune tip.
+          await waitForBlockNumber(aztecNode, blockBeforePrune, { compare: (actual, target) => actual < target });
 
           // We need to start the pxe after the re-org for now, because it won't handle it otherwise
           const { wallet } = await setupPXEAndGetWallet(aztecNode!, aztecNode!);

--- a/yarn-project/ethereum/src/test/rollup_cheat_codes.ts
+++ b/yarn-project/ethereum/src/test/rollup_cheat_codes.ts
@@ -4,6 +4,7 @@ import type { ViemPublicClient } from '@aztec/ethereum/types';
 import { CheckpointNumber, EpochNumber, SlotNumber } from '@aztec/foundation/branded-types';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { createLogger } from '@aztec/foundation/log';
+import { retryUntil } from '@aztec/foundation/retry';
 import type { DateProvider } from '@aztec/foundation/timer';
 import { RollupAbi } from '@aztec/l1-artifacts/RollupAbi';
 
@@ -242,6 +243,32 @@ export class RollupCheatCodes {
         `Proven tip moved: ${tipsBefore.proven} -> ${tipsAfter.proven}. Pending tip: ${tipsAfter.pending}.`,
       );
     });
+  }
+
+  /**
+   * Polls the rollup until its current epoch reaches `epoch`. Unlike {@link advanceToEpoch} this does
+   * not warp the L1 clock; it only waits for the chain to reach `epoch` through external activity.
+   */
+  public async waitForEpoch(epoch: EpochNumber, opts: { timeout?: number; interval?: number } = {}): Promise<void> {
+    await retryUntil(
+      async () => (await this.getEpoch()) >= epoch || undefined,
+      `rollup epoch >= ${epoch}`,
+      opts.timeout ?? 60,
+      opts.interval ?? 1,
+    );
+  }
+
+  /**
+   * Polls the rollup until its current slot reaches `slot`. Unlike {@link advanceToSlot} this does not
+   * warp the L1 clock; it only waits for the chain to reach `slot` through external activity.
+   */
+  public async waitForSlot(slot: SlotNumber, opts: { timeout?: number; interval?: number } = {}): Promise<void> {
+    await retryUntil(
+      async () => (await this.getSlot()) >= slot || undefined,
+      `rollup slot >= ${slot}`,
+      opts.timeout ?? 60,
+      opts.interval ?? 1,
+    );
   }
 
   /**


### PR DESCRIPTION
## Motivation

The e2e suite is littered with hand-rolled `retryUntil` / `sleep` / `Promise.all(...waitForTx)` polls, each flagged with a `// REFACTOR:` marker. Most duplicate logic that already exists in the shared `fixtures/wait_helpers.ts` library or on the test contexts. This PR resolves those markers by adopting the shared helpers (and adding a handful of small new ones), removing the duplicated, brittle wait code.

Stacked on top of #24345 (`spl/e2e-speed-up-1`), which shipped the warp/build-window helpers this PR adopts.

## Approach

Every change is **behavior-preserving**: the original loop's timeout, polling interval, and comparator/predicate are matched exactly. The mechanism is swapped, not what the test waits for or asserts. Where an existing helper didn't quite match the original semantics, the helper was extended with an option rather than the test's behavior being changed.

- **Adoption** (most families): replace a hand-rolled poll with a call to a helper that already ships in `wait_helpers.ts` or on `SingleNodeTestContext` / `MultiNodeTestContext`.
- **New helpers** (the minority): small additions to `wait_helpers.ts` and `RollupCheatCodes`, each behavior-preserving and adopted in the same change.

33 of 50 `// REFACTOR:` markers are resolved. The remaining 17 are deliberately deferred (see Follow-ups) - they are single-use, read from a data source no shared helper covers, or are the riskiest swaps that warrant their own focused change.

## Changes (by helper-family)

**Adoption of existing `wait_helpers.ts` functions**
- Block-number waits to `waitForBlockNumber` / `waitForProvenBlock`: `block_building`, `debug_trace`, `genesis_timestamp`, `l1_to_l2`, `fee_settings`.
- Node checkpoint waits to `waitForNodeCheckpoint`: `genesis_timestamp`, `fee_settings`.
- Batch tx waits to `waitForTxs`: `block_building` (3 sites), `multiple_blobs`, `gossip_network`.
- L2-to-L1 witness waits to `waitForL2ToL1Witness`: `token_bridge_public`, `token_bridge_private`.
- Monitor checkpoint wait to `MultiNodeTestContext.waitUntilCheckpointNumber`: `proof_boundary`.
- P2P mesh readiness to `waitForP2PMeshConnectivity` (replaces a fixed `sleep(8000)`): `fee_asset_price_oracle_gossip`.
- Build-window wall-clock wait to `waitForBuildWindowForSlot`: `high_tps`.
- Slot-search with `EpochNotStable` warp to existing `MultiNodeTestContext.findSlotsWithProposers`: `invalidate_block`, `ha_checkpoint_handoff`.

**New helpers (added + adopted)**
- `wait_helpers.ts`: `waitForTxReceipt` / `waitForTxStatus` (tx-status transitions in `block_building`), `waitForPendingTxCount` (`attested_invalid_proposal`), `waitForSequencerState` with an `after`-action hook - and **deleted** the three duplicated `waitForSequencerIdle` copies in `l2_to_l1`, `gas_estimation`, and `reload_keystore`.
- `waitForBlockNumber` extended with a `compare` option for the prune-backward poll in `synching`.
- `RollupCheatCodes.waitForEpoch` / `waitForSlot` (poll-only, no warp), adopted in `escape_hatch_vote_only` and `gov_proposal`.

**Inline cleanups (no shared helper warranted)**
- `fee_asset_price_oracle`: two identical price-convergence polls consolidated into one local helper.
- `upgrade_governance_proposer`: `while(true) + sleep(12000)` quorum poll to `retryUntil`.
- `upload_failed_proof`: local-variable upload poll to `promiseWithResolvers` resolved from the upload callback.
- `synching`: archiver-prune `sleep(3000)` to `retryUntil` on the archiver checkpoint number.

## Follow-ups (deferred markers)

These were left in place because adopting a helper would either change behavior or add a single-use abstraction:

- `proof_fails:109` - rollback detection reads the L1 rollup contract (`RollupContract.getCheckpointNumber`), not the node; swapping to a node helper would change the data source. Needs a rollup-contract-based wait.
- `snapshot_sync:89` - reads `ChainMonitor.checkpointNumber` (not the node) with `>` semantics; the test uses the legacy `EndToEndContext`, which has no `waitUntilCheckpointNumber`.
- `long_proving_time:74` - the loop records peak proving-job parallelism on every iteration; that sampling is the behavior under test, so it can't be replaced by a plain wait.
- `preferred_gossip_network:183` - per-node exact peer counts in a heterogeneous topology; doesn't map onto `waitForP2PMeshConnectivity`'s uniform `>=` check.
- `gov_proposal:245` - ChainMonitor poll that returns a full snapshot (checkpoint + slot) consumed downstream; no helper returns that.
- `failures:100` - a two-call `advanceToNextEpoch` + `catchUpProvenChain` sequence, not a hand-rolled poll.
- Family-13 one-offs (`pruned_blocks:117`, `offchain_payment:215`, `snapshot_sync:100`, `l1_to_l2:130`) - single-use, heterogeneous polls (error-message match, note-balance, readdir, advance-block-per-poll) that already use `retryUntil` rather than a sleep.
- `state_vars:439` - a chain-advance-by-sending-txs loop (side-effecting), not a poll.
- `optimistic:115` - a disposable sampler; single call-site.
- `rediscovery:61` - a `sleep(2500)` guarding against port conflicts between node restarts, not connectivity.
- `bridging_race.notest.ts:70/77` - in a disabled `.notest.ts` file.
- `fee_settings:121` - the L1-base-fee-spike + oracle-rotation loop returns a value and is fee-domain specific; warrants its own focused `RollupCheatCodes` change.

## Verification

`yarn build`, `yarn lint`, and `yarn format` all pass on the touched packages (`end-to-end`, `ethereum`). The e2e tests themselves are validated by CI on this stacked PR.
