### PR TITLE
fix(release-image): stamp stdlib/package.json with release version

### DIFF
--- a/release-image/Dockerfile
+++ b/release-image/Dockerfile
@@ -18,6 +18,9 @@ WORKDIR "/usr/src/yarn-project"
 # Ensure the correct version shows in aztec --version
 ARG VERSION
 RUN echo '{".": "'$VERSION'"}' > /usr/src/.release-please-manifest.json
+# Stamp the version into stdlib/package.json, which getPackageVersion() reads at runtime.
+RUN jq --arg v "$VERSION" '.version = $v' /usr/src/yarn-project/stdlib/package.json > /tmp/p.json \
+    && mv /tmp/p.json /usr/src/yarn-project/stdlib/package.json
 
 # Stamp aztec_version into the shipped contract artifacts. The build-time stamp in
 # noir-projects/noir-contracts/bootstrap.sh writes "dev" unconditionally; $VERSION here is the authoritative release


### PR DESCRIPTION
## Summary
- Forward-port of #23393 from v4
- The release-image Dockerfile stamps `.release-please-manifest.json` but not `stdlib/package.json`, which `getPackageVersion()` reads at runtime
- This causes `getNodeVersion` RPC to return `"dev"` instead of the actual release version on v5 testnet
- Adds the missing `jq` stamp step for `stdlib/package.json`
