### PR TITLE
test(e2e): instrument common spans for wall-clock tracking

### DIFF
--- a/yarn-project/.claude/skills/track-e2e-times/SKILL.md
+++ b/yarn-project/.claude/skills/track-e2e-times/SKILL.md
@@ -1,0 +1,169 @@
+---
+name: track-e2e-times
+description: Collect and aggregate e2e test wall-clock timings — run the suite with the timing instrumentation on, find the per-worker JSONL it produces, and print per-test sums plus a ranked span leaderboard. Use when asked to measure, profile, or break down where the e2e suite spends time.
+argument-hint: <folder-with-jsonl>
+---
+
+# Track e2e times
+
+The e2e suite is instrumented to record, per test, how long it spends in jest before/after hooks and
+the test body, plus a set of named **spans** for the repeated operations that dominate e2e wall-clock
+(standing up the environment, waiting for blocks/checkpoints/proofs, client-side proving, warp scans).
+This skill covers two things and nothing else:
+
+1. **Collect** — run the suite with timing on and locate the JSONL it writes.
+2. **Aggregate** — turn that JSONL into per-test sum tables and a ranked span leaderboard locally.
+
+There is a separate, out-of-band workflow for publishing aggregate numbers to a running tracking log;
+that is not part of this skill. Everything here is local: run, find the files, print tables.
+
+## How the instrumentation works
+
+The jest `testEnvironment` for `end-to-end` is `src/shared/timing_env.mjs`, wired in
+`yarn-project/end-to-end/package.json`. It is always installed but **gated on the `TEST_TIMING_FILE`
+env var**: when that var is unset it behaves like the base environment and records nothing (the
+`span()` wrapper in `src/fixtures/timing.ts` calls through with zero overhead). Set `TEST_TIMING_FILE`
+to a path and the environment writes JSONL there.
+
+Relevant env vars:
+
+- `TEST_TIMING_FILE` — path to the JSONL output file. **Required** to turn timing on. The environment
+  *appends*, and runs once per jest worker process, so a single file accumulates every suite that
+  worker ran. Use one file per test command.
+- `TEST_TIMING_SPANS=1` — optional. Additionally emit one `type:"span"` line per individual span
+  occurrence (owner, span tag, ms) for deep dives. Off by default to keep the file one line per test.
+
+## Step 1 — Collect: run the suite with timing on
+
+Run any e2e test (or the whole suite) with `TEST_TIMING_FILE` pointed at a scratch path. From
+`yarn-project`:
+
+```bash
+TEST_TIMING_FILE=/tmp/e2e-timings.jsonl \
+  yarn workspace @aztec/end-to-end test:e2e e2e_block_building.test.ts
+```
+
+For the per-occurrence span lines as well:
+
+```bash
+TEST_TIMING_FILE=/tmp/e2e-timings.jsonl TEST_TIMING_SPANS=1 \
+  yarn workspace @aztec/end-to-end test:e2e e2e_block_building.test.ts
+```
+
+If a run spreads across several jest workers and each worker writes its own file, collect them all
+into one folder and point the aggregation at the folder — the recipes below read `*.jsonl`.
+
+To aggregate a CI run instead of a local one, the per-worker JSONL each CI test command produced is
+uploaded to S3 keyed by the job's `CI_LOG_ID`. From the repo root:
+
+```bash
+./ci.sh test-timings <CI_LOG_ID> <folder>
+```
+
+That downloads every `<LOG_ID>.log.gz` for the job and gunzips them to `*.jsonl` in `<folder>`. The
+`CI_LOG_ID` is the decimal id in a job's `ci.aztec-labs.com/<id>` dashboard URL.
+
+## The JSONL line schema
+
+One JSON object per line, one line per test and one suite-scoped line per file. Fields:
+
+| Field | Meaning |
+|---|---|
+| `suite` | The `.test.ts` basename the line came from. |
+| `type` | `"test"` (one `it()`), `"suite"` (the file's `beforeAll`/`afterAll`, `name` is `null`), or `"span"` (a raw occurrence, only with `TEST_TIMING_SPANS=1`). |
+| `name` | Full test name (describe chain + `it`), or `null` for a suite line. |
+| `status` | `"passed"` / `"failed"`. |
+| `beforeHooksMs` | Sum of `beforeEach` hooks (test lines) or `beforeAll` (suite line). |
+| `afterHooksMs` | Sum of `afterEach` hooks (test lines) or `afterAll` (suite line). |
+| `bodyMs` | The `it()` body wall-clock (test lines only). |
+| `setupFnMs` / `teardownFnMs` | Back-compat fields, derived from the `spawn:env:<mode>` / `teardown:env` spans. |
+| `totalMs` | Whole-test wall-clock (test lines), or `beforeHooksMs + afterHooksMs` (suite line). |
+| `startedAt` | ISO timestamp of test start (test lines). |
+| `commit` / `branch` / `runId` | Run metadata from `COMMIT_HASH` / `TARGET_BRANCH`|`REF_NAME` / `RUN_ID` (may be `null` locally). |
+| `spans` | Map of `category:label` tag → `{ count, totalMs, busyMs, maxMs }` (see below). |
+
+All `*Ms` values are integers (rounded at flush).
+
+### The span model
+
+Each test/suite line carries a `spans` map. For every `category:label` tag the test touched it records:
+
+- **`count`** — number of occurrences. Multiplicity is itself a signal (e.g. waited for a checkpoint
+  14× points at a loop that could batch).
+- **`totalMs`** — naive sum of the occurrences' durations. Correct for serial repeats.
+- **`busyMs`** — wall-clock of the **union** of the occurrences' `[start, end)` intervals. This is
+  concurrency-correct: a `Promise.all` of 12 concurrent 3s spans reads ~3s here, not ~36s. A
+  `busyMs ≪ totalMs` gap flags work run serially that could be parallel.
+- **`maxMs`** — longest single occurrence, to catch one pathological wait hiding in a cheap average.
+
+Tags follow a stable `category:label` taxonomy (`spawn:`, `wait:`, `tx:`, `warp:`, `wallet:`,
+`deploy:`, `other:`), tagged **by concept, not by function** — e.g. every checkpoint waiter maps to
+`wait:checkpoint` — so a tag is a stable aggregation key regardless of which helper a test called.
+
+Spans do **not** partition `bodyMs`: a parent span includes its children, so `sum(spans) ≠ bodyMs`.
+Tagging is at the leaf wait/spawn/tx level where additivity holds. `busyMs` is the right number to
+rank by; sum `busyMs` per tag across the run to see where wall-clock goes.
+
+## Step 2 — Aggregate locally
+
+### Per-test sums
+
+`row.sh` (this directory) prints a one-line summary of the run's aggregate sums (test count, overall,
+setup, setup.ts-fn, body, teardown) plus the wall-clock window:
+
+```bash
+bash row.sh <folder-with-jsonl>
+```
+
+It reads `*.jsonl` from the folder, sums the buckets across all `type:"test"` lines, and prints to
+stderr. It warns if the test count is far below a full run (~950) — a partial or cache-served run is
+not comparable to a full one.
+
+> Sums, not wall-clock: files run in parallel, so the column sums far exceed the run's actual wall
+> time. The `(HH:MM–HH:MM)` window the script prints is the real wall-clock span.
+
+### Span leaderboard
+
+The ranked "where does the suite spend wall-clock" table is a small jq over the `spans` maps. It rolls
+every tag up across all test and suite lines, summing `busyMs` and `count`, taking the max `maxMs`, and
+sorts by total `busyMs` descending:
+
+```bash
+cat <folder>/*.jsonl | jq -rs '[ .[] | select(.type=="test" or .type=="suite") | (.spans // {}) | to_entries[] ]
+  | group_by(.key)
+  | map({ tag: .[0].key, count: (map(.value.count) | add),
+          busyMs: (map(.value.busyMs) | add), maxMs: (map(.value.maxMs) | max) })
+  | sort_by(-.busyMs) | .[] | "\(.busyMs)\t\(.count)\t\(.maxMs)\t\(.tag)"'
+```
+
+Output columns are `busyMs`, `count`, `maxMs`, `tag` — the top rows are where to invest in speedups.
+
+For a single tag's per-test breakdown (which tests contribute the most to one tag):
+
+```bash
+cat <folder>/*.jsonl | jq -rs --arg tag wait:checkpoint '
+  [ .[] | select(.type=="test" or .type=="suite") | select(.spans[$tag])
+    | { name, busyMs: .spans[$tag].busyMs, count: .spans[$tag].count } ]
+  | sort_by(-.busyMs) | .[] | "\(.busyMs)\t\(.count)\t\(.name)"'
+```
+
+With `TEST_TIMING_SPANS=1`, each `type:"span"` line is a single occurrence (`name` = owning test,
+`span` = tag, `ms` = duration), so you can histogram or list the raw occurrences of one tag directly.
+
+## Key points
+
+- **Timing is off unless `TEST_TIMING_FILE` is set** — the instrumentation is zero-cost when unset and
+  cannot change test behavior or timing.
+- **One file per worker, appended** — collect all of a run's files into one folder before aggregating.
+- **Rank by `busyMs`** — it is concurrency-correct; `totalMs` double-counts parallel work.
+- **`spans` is additive across lines** but not within a test (parents include children); sum per tag
+  across the run, do not expect spans to add up to `bodyMs`.
+- **Full-run vs full-run only** — a partial or cache-served run emits far fewer than ~950 tests and is
+  not comparable.
+
+## Reference
+
+- `row.sh` (this directory) — aggregate JSONL → summary sums + leaderboard.
+- `yarn-project/end-to-end/src/shared/timing_env.mjs` — the jest timing environment that writes the JSONL.
+- `yarn-project/end-to-end/src/fixtures/timing.ts` — the `span()` / `spanSync()` / `withSpanOwner()` wrappers.
+- `./ci.sh test-timings <CI_LOG_ID> <folder>` — download a CI job's per-worker JSONL (repo root).

--- a/yarn-project/.claude/skills/track-e2e-times/SKILL.md
+++ b/yarn-project/.claude/skills/track-e2e-times/SKILL.md
@@ -22,7 +22,7 @@ that is not part of this skill. Everything here is local: run, find the files, p
 The jest `testEnvironment` for `end-to-end` is `src/shared/timing_env.mjs`, wired in
 `yarn-project/end-to-end/package.json`. It is always installed but **gated on the `TEST_TIMING_FILE`
 env var**: when that var is unset it behaves like the base environment and records nothing (the
-`span()` wrapper in `src/fixtures/timing.ts` calls through with zero overhead). Set `TEST_TIMING_FILE`
+`testSpan()` wrapper in `src/fixtures/timing.ts` calls through with zero overhead). Set `TEST_TIMING_FILE`
 to a path and the environment writes JSONL there.
 
 Relevant env vars:
@@ -76,7 +76,7 @@ One JSON object per line, one line per test and one suite-scoped line per file. 
 | `beforeHooksMs` | Sum of `beforeEach` hooks (test lines) or `beforeAll` (suite line). |
 | `afterHooksMs` | Sum of `afterEach` hooks (test lines) or `afterAll` (suite line). |
 | `bodyMs` | The `it()` body wall-clock (test lines only). |
-| `setupFnMs` / `teardownFnMs` | Back-compat fields, derived from the `spawn:env:<mode>` / `teardown:env` spans. |
+| `setupFnMs` / `teardownFnMs` | Back-compat fields, derived from the `setup:env:<mode>` / `teardown:env` spans. |
 | `totalMs` | Whole-test wall-clock (test lines), or `beforeHooksMs + afterHooksMs` (suite line). |
 | `startedAt` | ISO timestamp of test start (test lines). |
 | `commit` / `branch` / `runId` | Run metadata from `COMMIT_HASH` / `TARGET_BRANCH`|`REF_NAME` / `RUN_ID` (may be `null` locally). |
@@ -96,7 +96,7 @@ Each test/suite line carries a `spans` map. For every `category:label` tag the t
   `busyMs ≪ totalMs` gap flags work run serially that could be parallel.
 - **`maxMs`** — longest single occurrence, to catch one pathological wait hiding in a cheap average.
 
-Tags follow a stable `category:label` taxonomy (`spawn:`, `wait:`, `tx:`, `warp:`, `wallet:`,
+Tags follow a stable `category:label` taxonomy (`setup:`, `wait:`, `tx:`, `warp:`, `wallet:`,
 `deploy:`, `other:`), tagged **by concept, not by function** — e.g. every checkpoint waiter maps to
 `wait:checkpoint` — so a tag is a stable aggregation key regardless of which helper a test called.
 
@@ -165,5 +165,5 @@ With `TEST_TIMING_SPANS=1`, each `type:"span"` line is a single occurrence (`nam
 
 - `row.sh` (this directory) — aggregate JSONL → summary sums + leaderboard.
 - `yarn-project/end-to-end/src/shared/timing_env.mjs` — the jest timing environment that writes the JSONL.
-- `yarn-project/end-to-end/src/fixtures/timing.ts` — the `span()` / `spanSync()` / `withSpanOwner()` wrappers.
+- `yarn-project/end-to-end/src/fixtures/timing.ts` — the `testSpan()` / `testSpanSync()` / `withTestSpanOwner()` wrappers.
 - `./ci.sh test-timings <CI_LOG_ID> <folder>` — download a CI job's per-worker JSONL (repo root).

--- a/yarn-project/.claude/skills/track-e2e-times/row.sh
+++ b/yarn-project/.claude/skills/track-e2e-times/row.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Aggregate downloaded e2e test-timing JSONL into local summary tables: the run's aggregate sums
+# (test count, overall / setup / setup.ts-fn / body / teardown), the wall-clock window, and a ranked
+# span leaderboard. Reads every *.jsonl in the given folder.
+#
+# Usage: row.sh <folder-with-jsonl>
+#   <folder>  a directory of *.jsonl produced by a timed run (TEST_TIMING_FILE) or downloaded via
+#             `./ci.sh test-timings <CI_LOG_ID> <folder>`.
+set -euo pipefail
+
+folder=${1:?Usage: row.sh <folder-with-jsonl>}
+
+shopt -s nullglob
+files=("$folder"/*.jsonl)
+[ ${#files[@]} -gt 0 ] || { echo "row.sh: no *.jsonl files in $folder" >&2; exit 1; }
+
+# Sums across all per-test measurements, plus the run's commit/branch/runId and the wall-clock window
+# (first test start -> last test end).
+IFS=$'\t' read -r tests overall setup setupfn body teardown commit branch runid startISO endISO < <(
+  cat "$folder"/*.jsonl | jq -rs '
+      (map(select(.type=="test"))) as $t
+    | {
+        tests:    ($t | length),
+        overall:  (map(.totalMs) | add),
+        setup:    (map(.beforeHooksMs) | add),
+        setupfn:  (map(.setupFnMs) | add),
+        body:     ($t | map(.bodyMs) | add),
+        teardown: (map(.afterHooksMs) | add),
+        commit:   ($t | map(.commit) | first),
+        branch:   ($t | map(.branch) | first),
+        runid:    ($t | map(.runId) | first),
+        startISO: ($t | map(.startedAt) | min),
+        endISO:   ( $t
+                    | map((.startedAt | sub("\\.[0-9]+Z$"; "Z") | fromdateiso8601) + (.totalMs / 1000))
+                    | max | todateiso8601 )
+      }
+    | [ .tests, .overall, .setup, .setupfn, .body, .teardown, .commit, .branch, .runid, .startISO, .endISO ]
+    | @tsv'
+)
+
+# Insert thousands separators into an integer.
+group() { printf '%s' "$1" | rev | sed 's/[0-9]\{3\}/&,/g' | rev | sed 's/^,//'; }
+
+# Format milliseconds as "Xh Ym Zs (N,NNN ms)", dropping leading zero units.
+fmt() {
+  local ms=$1 s h m sec out=""
+  s=$(( (ms + 500) / 1000 )); h=$(( s / 3600 )); m=$(( (s % 3600) / 60 )); sec=$(( s % 60 ))
+  [ "$h" -gt 0 ] && out="${h}h "
+  { [ "$h" -gt 0 ] || [ "$m" -gt 0 ]; } && out="${out}${m}m "
+  out="${out}${sec}s"
+  printf '%s (%s ms)' "$out" "$(group "$ms")"
+}
+
+date_str=$(date -u -d "$startISO" +%Y-%m-%d)
+start_hm=$(date -u -d "$startISO" +%H:%M)
+end_hm=$(date -u -d "$endISO" +%H:%M)
+short=${commit:0:8}
+
+echo "tests=$tests  commit=$short  branch=$branch  runId=$runid"
+echo "window=${date_str} ${start_hm}-${end_hm} UTC"
+echo "overall=$(fmt "$overall") | setup=$(fmt "$setup") | setup.ts=$(fmt "$setupfn") | body=$(fmt "$body") | teardown=$(fmt "$teardown")"
+[ "$tests" -lt 800 ] && echo "WARNING: only $tests tests — likely a partial/cache-hit run, NOT comparable to full runs (~950)." >&2
+[ "$runid" = "null" ] && echo "NOTE: runId is null — RUN_ID was not set for this run (expected for local runs)." >&2
+
+# Span leaderboard: roll every category:label tag up across all test/suite lines, summing busyMs (the
+# concurrency-correct wall-clock) and count, taking the max maxMs, sorted by busyMs descending.
+echo ""
+echo "span leaderboard (busyMs | count | maxMs | tag):"
+cat "$folder"/*.jsonl | jq -rs '
+    [ .[] | select(.type=="test" or .type=="suite") | (.spans // {}) | to_entries[] ]
+  | group_by(.key)
+  | map({ tag: .[0].key, count: (map(.value.count) | add),
+          busyMs: (map(.value.busyMs) | add), maxMs: (map(.value.maxMs) | max) })
+  | sort_by(-.busyMs) | .[] | "\(.busyMs)\t\(.count)\t\(.maxMs)\t\(.tag)"'

--- a/yarn-project/end-to-end/src/fixtures/setup.ts
+++ b/yarn-project/end-to-end/src/fixtures/setup.ts
@@ -76,7 +76,7 @@ import { MNEMONIC, TEST_MAX_PENDING_TX_POOL_COUNT, TEST_PEER_CHECK_INTERVAL_MS }
 import { getACVMConfig } from './get_acvm_config.js';
 import { getBBConfig } from './get_bb_config.js';
 import { isMetricsLoggingRequested, setupMetricsLogger } from './logging.js';
-import { span } from './timing.js';
+import { testSpan } from './timing.js';
 import { getEndToEndTestTelemetryClient } from './with_telemetry_utils.js';
 
 export { startAnvil };
@@ -315,7 +315,7 @@ export function setup(
   // swing in setup cost, so the three factories are comparable on the span leaderboard. The internals
   // (anvil / l1-deploy / sequencer-start / pxe / wallet:create) decompose this further.
   const proverMode = opts.realProofs ? 'real' : opts.startProverNode ? 'fake' : 'none';
-  return span(`spawn:env:${proverMode}`, async () => {
+  return testSpan(`setup:env:${proverMode}`, async () => {
     const ctx = await setupInner(numberOfAccounts, opts, pxeOpts, chain);
     if (process.env.EXIT_E2E_AFTER_SETUP) {
       ctx.logger.info('EXIT_E2E_AFTER_SETUP is set; aborting before the test body runs');
@@ -370,7 +370,7 @@ async function setupInner(
       if (!isAnvilTestChain(chain.id)) {
         throw new Error(`No ETHEREUM_HOSTS set but non anvil chain requested`);
       }
-      const res = await span('spawn:env:anvil', () =>
+      const res = await testSpan('setup:env:anvil', () =>
         startAnvil({
           l1BlockTime: opts.ethereumSlotDuration,
           accounts: opts.anvilAccounts,
@@ -473,7 +473,7 @@ async function setupInner(
     await l1Client.getTransactionCount({ address: l1Client.account.address });
     logger.trace('Deployed Multicall3');
 
-    const deployL1ContractsValues: DeployAztecL1ContractsReturnType = await span('spawn:env:l1-deploy', () =>
+    const deployL1ContractsValues: DeployAztecL1ContractsReturnType = await testSpan('setup:env:l1-deploy', () =>
       deployAztecL1Contracts(config.l1RpcUrls[0], publisherPrivKeyHex!, chain.id, {
         ...getL1ContractsConfigEnvVars(),
         ...opts,
@@ -579,7 +579,7 @@ async function setupInner(
       : config;
     logger.trace('Prepared aztec node config');
 
-    const aztecNodeService = await span('spawn:env:sequencer-start', () =>
+    const aztecNodeService = await testSpan('setup:env:sequencer-start', () =>
       withLoggerBindings({ actor: 'node-0' }, () =>
         createAztecNodeService(
           initialNodeConfig,
@@ -603,7 +603,7 @@ async function setupInner(
         rpcTxProviders: [aztecNodeService],
       };
 
-      ({ proverNode } = await span('spawn:env:prover-node', () =>
+      ({ proverNode } = await testSpan('setup:env:prover-node', () =>
         createAndSyncProverNode(
           proverNodePrivateKeyHex,
           config,
@@ -626,7 +626,7 @@ async function setupInner(
     pxeConfig.dataDirectory = path.join(directoryToCleanup, randomBytes(8).toString('hex'));
     // For tests we only want proving enabled if specifically requested
     pxeConfig.proverEnabled = !!pxeOpts.proverEnabled;
-    const wallet = await span('spawn:env:pxe', () =>
+    const wallet = await testSpan('setup:env:pxe', () =>
       TestWallet.create(aztecNodeService, pxeConfig, {
         loggerActorLabel: 'pxe-0',
         // In-process node implements the debug API, so register public function signatures for named traces.
@@ -664,13 +664,13 @@ async function setupInner(
     // + a simulated store call) with no on-chain tx, independent of the sequencer.
     if (numberOfAccounts > 0) {
       logger.info(`Creating ${numberOfAccounts} initializerless test accounts`);
-      await span('wallet:create', () => createFundedInitializerlessAccounts(wallet, defaultAccounts));
+      await testSpan('wallet:create', () => createFundedInitializerlessAccounts(wallet, defaultAccounts));
       accounts = defaultAccounts.map(a => a.address);
     }
     logger.trace('Created funded test accounts');
 
     const teardown = () =>
-      span('teardown:env', async () => {
+      testSpan('teardown:env', async () => {
         try {
           await tryStop(wallet, logger);
           await tryStop(aztecNodeService, logger);

--- a/yarn-project/end-to-end/src/fixtures/setup.ts
+++ b/yarn-project/end-to-end/src/fixtures/setup.ts
@@ -76,6 +76,7 @@ import { MNEMONIC, TEST_MAX_PENDING_TX_POOL_COUNT, TEST_PEER_CHECK_INTERVAL_MS }
 import { getACVMConfig } from './get_acvm_config.js';
 import { getBBConfig } from './get_bb_config.js';
 import { isMetricsLoggingRequested, setupMetricsLogger } from './logging.js';
+import { span } from './timing.js';
 import { getEndToEndTestTelemetryClient } from './with_telemetry_utils.js';
 
 export { startAnvil };
@@ -299,39 +300,29 @@ function assertContractArtifactsVersion() {
 }
 
 /**
- * Records a function-level timing span into the shared collector installed by the e2e timing
- * environment. No-op unless TEST_TIMING_FILE is set (the env only installs the collector then). The
- * span is tagged with the name of the currently running test so the env can attribute it to the
- * right line; `null` during beforeAll/afterAll lands it on the suite-scoped line.
- */
-function recordFnSpan(kind: 'setup' | 'teardown', ms: number) {
-  const collector = (globalThis as { __e2eTimings?: { current: string | null; fnSpans: unknown[] } }).__e2eTimings;
-  collector?.fnSpans.push({ name: collector.current, kind, ms });
-}
-
-/**
  * Sets up the environment for the end-to-end tests.
  * @param numberOfAccounts - The number of new accounts to be created once the PXE is initiated.
  * @param opts - Options to pass to the node initialization and to the setup script.
  * @param pxeOpts - Options to pass to the PXE initialization.
  */
-export async function setup(
+export function setup(
   numberOfAccounts = 1,
   opts: SetupOptions = {},
   pxeOpts: Partial<PXEConfig> = {},
   chain: Chain = foundry,
 ): Promise<EndToEndContext> {
-  const setupStart = performance.now();
-  try {
+  // Tag the top-level env spin-up with the prover mode (none → fake → real), the largest config-driven
+  // swing in setup cost, so the three factories are comparable on the span leaderboard. The internals
+  // (anvil / l1-deploy / sequencer-start / pxe / wallet:create) decompose this further.
+  const proverMode = opts.realProofs ? 'real' : opts.startProverNode ? 'fake' : 'none';
+  return span(`spawn:env:${proverMode}`, async () => {
     const ctx = await setupInner(numberOfAccounts, opts, pxeOpts, chain);
     if (process.env.EXIT_E2E_AFTER_SETUP) {
       ctx.logger.info('EXIT_E2E_AFTER_SETUP is set; aborting before the test body runs');
       throw new Error('EXIT_E2E_AFTER_SETUP');
     }
     return ctx;
-  } finally {
-    recordFnSpan('setup', performance.now() - setupStart);
-  }
+  });
 }
 
 async function setupInner(
@@ -379,13 +370,15 @@ async function setupInner(
       if (!isAnvilTestChain(chain.id)) {
         throw new Error(`No ETHEREUM_HOSTS set but non anvil chain requested`);
       }
-      const res = await startAnvil({
-        l1BlockTime: opts.ethereumSlotDuration,
-        accounts: opts.anvilAccounts,
-        port: opts.anvilPort ?? (process.env.ANVIL_PORT ? parseInt(process.env.ANVIL_PORT) : undefined),
-        slotsInAnEpoch: opts.anvilSlotsInAnEpoch,
-        dateProvider,
-      });
+      const res = await span('spawn:env:anvil', () =>
+        startAnvil({
+          l1BlockTime: opts.ethereumSlotDuration,
+          accounts: opts.anvilAccounts,
+          port: opts.anvilPort ?? (process.env.ANVIL_PORT ? parseInt(process.env.ANVIL_PORT) : undefined),
+          slotsInAnEpoch: opts.anvilSlotsInAnEpoch,
+          dateProvider,
+        }),
+      );
       anvil = res.anvil;
       config.l1RpcUrls = [res.rpcUrl];
     }
@@ -480,11 +473,8 @@ async function setupInner(
     await l1Client.getTransactionCount({ address: l1Client.account.address });
     logger.trace('Deployed Multicall3');
 
-    const deployL1ContractsValues: DeployAztecL1ContractsReturnType = await deployAztecL1Contracts(
-      config.l1RpcUrls[0],
-      publisherPrivKeyHex!,
-      chain.id,
-      {
+    const deployL1ContractsValues: DeployAztecL1ContractsReturnType = await span('spawn:env:l1-deploy', () =>
+      deployAztecL1Contracts(config.l1RpcUrls[0], publisherPrivKeyHex!, chain.id, {
         ...getL1ContractsConfigEnvVars(),
         ...opts,
         ...opts.l1ContractsArgs,
@@ -494,7 +484,7 @@ async function setupInner(
         initialValidators: opts.initialValidators,
         feeJuicePortalInitialBalance: fundingNeeded,
         realVerifier: false,
-      },
+      }),
     );
 
     Object.assign(config, deployL1ContractsValues.l1ContractAddresses);
@@ -589,11 +579,13 @@ async function setupInner(
       : config;
     logger.trace('Prepared aztec node config');
 
-    const aztecNodeService = await withLoggerBindings({ actor: 'node-0' }, () =>
-      createAztecNodeService(
-        initialNodeConfig,
-        { dateProvider, telemetry: telemetryClient, p2pClientDeps },
-        { genesis, dontStartSequencer: opts.skipInitialSequencer },
+    const aztecNodeService = await span('spawn:env:sequencer-start', () =>
+      withLoggerBindings({ actor: 'node-0' }, () =>
+        createAztecNodeService(
+          initialNodeConfig,
+          { dateProvider, telemetry: telemetryClient, p2pClientDeps },
+          { genesis, dontStartSequencer: opts.skipInitialSequencer },
+        ),
       ),
     );
     const sequencerClient = aztecNodeService.getSequencer();
@@ -611,15 +603,17 @@ async function setupInner(
         rpcTxProviders: [aztecNodeService],
       };
 
-      ({ proverNode } = await createAndSyncProverNode(
-        proverNodePrivateKeyHex,
-        config,
-        {
-          ...config.proverNodeConfig,
-          dataDirectory: proverNodeDataDirectory,
-        },
-        { dateProvider, p2pClientDeps, telemetry: telemetryClient },
-        { genesis },
+      ({ proverNode } = await span('spawn:env:prover-node', () =>
+        createAndSyncProverNode(
+          proverNodePrivateKeyHex,
+          config,
+          {
+            ...config.proverNodeConfig,
+            dataDirectory: proverNodeDataDirectory,
+          },
+          { dateProvider, p2pClientDeps, telemetry: telemetryClient },
+          { genesis },
+        ),
       ));
       logger.trace('Created prover node');
     }
@@ -632,12 +626,14 @@ async function setupInner(
     pxeConfig.dataDirectory = path.join(directoryToCleanup, randomBytes(8).toString('hex'));
     // For tests we only want proving enabled if specifically requested
     pxeConfig.proverEnabled = !!pxeOpts.proverEnabled;
-    const wallet = await TestWallet.create(aztecNodeService, pxeConfig, {
-      loggerActorLabel: 'pxe-0',
-      // In-process node implements the debug API, so register public function signatures for named traces.
-      nodeDebug: aztecNodeService,
-      ...opts.pxeCreationOptions,
-    });
+    const wallet = await span('spawn:env:pxe', () =>
+      TestWallet.create(aztecNodeService, pxeConfig, {
+        loggerActorLabel: 'pxe-0',
+        // In-process node implements the debug API, so register public function signatures for named traces.
+        nodeDebug: aztecNodeService,
+        ...opts.pxeCreationOptions,
+      }),
+    );
 
     if (opts.walletMinFeePadding !== undefined) {
       wallet.setMinFeePadding(opts.walletMinFeePadding);
@@ -668,40 +664,39 @@ async function setupInner(
     // + a simulated store call) with no on-chain tx, independent of the sequencer.
     if (numberOfAccounts > 0) {
       logger.info(`Creating ${numberOfAccounts} initializerless test accounts`);
-      await createFundedInitializerlessAccounts(wallet, defaultAccounts);
+      await span('wallet:create', () => createFundedInitializerlessAccounts(wallet, defaultAccounts));
       accounts = defaultAccounts.map(a => a.address);
     }
     logger.trace('Created funded test accounts');
 
-    const teardown = async () => {
-      const teardownStart = performance.now();
-      try {
-        await tryStop(wallet, logger);
-        await tryStop(aztecNodeService, logger);
-        await tryStop(proverNode, logger);
-
-        if (acvmConfig?.cleanup) {
-          await acvmConfig.cleanup();
-        }
-
-        if (bbConfig?.cleanup) {
-          await bbConfig.cleanup();
-        }
-
-        await tryStop(anvil, logger);
-
-        await tryRmDir(directoryToCleanup, logger);
-      } catch (err) {
-        logger.error(`Error during e2e test teardown`, err);
-      } finally {
+    const teardown = () =>
+      span('teardown:env', async () => {
         try {
-          await telemetryClient.stop();
+          await tryStop(wallet, logger);
+          await tryStop(aztecNodeService, logger);
+          await tryStop(proverNode, logger);
+
+          if (acvmConfig?.cleanup) {
+            await acvmConfig.cleanup();
+          }
+
+          if (bbConfig?.cleanup) {
+            await bbConfig.cleanup();
+          }
+
+          await tryStop(anvil, logger);
+
+          await tryRmDir(directoryToCleanup, logger);
         } catch (err) {
-          logger.error(`Error during telemetry client stop`, err);
+          logger.error(`Error during e2e test teardown`, err);
+        } finally {
+          try {
+            await telemetryClient.stop();
+          } catch (err) {
+            logger.error(`Error during telemetry client stop`, err);
+          }
         }
-        recordFnSpan('teardown', performance.now() - teardownStart);
-      }
-    };
+      });
 
     return {
       anvil,

--- a/yarn-project/end-to-end/src/fixtures/timing.ts
+++ b/yarn-project/end-to-end/src/fixtures/timing.ts
@@ -1,11 +1,11 @@
 /**
- * E2e span instrumentation. Wrapping a shared test helper in {@link span} / {@link spanSync} records
- * how long it ran, attributed to the test (or suite) that was executing, so a full CI run can be
- * aggregated into a ranked list of where the suite spends wall-clock (setup, protocol waits, client
+ * E2e span instrumentation. Wrapping a shared test helper in {@link testSpan} / {@link testSpanSync}
+ * records how long it ran, attributed to the test (or suite) that was executing, so a full CI run can
+ * be aggregated into a ranked list of where the suite spends wall-clock (setup, protocol waits, client
  * proving, warp scans, ...). See the A-1178 timing environment in `shared/timing_env.mjs`.
  *
  * Everything here is gated on the collector installed by that environment, which only exists when
- * `TEST_TIMING_FILE` is set. When it is unset, {@link span} calls `fn()` directly with no extra work
+ * `TEST_TIMING_FILE` is set. When it is unset, {@link testSpan} calls `fn()` directly with no extra work
  * and no clock reads — instrumentation is exactly zero-cost and cannot change a test's behavior or
  * timing.
  */
@@ -15,17 +15,17 @@ import { AsyncLocalStorage } from 'node:async_hooks';
  * Async-context owner override. A span normally attributes itself to the running test
  * (`collector.current`), but a background producer (e.g. the mempool feeder) runs interleaved with
  * arbitrary tests, so its spans would smear across whichever test happened to be current when each
- * round fired. Running such work inside {@link withSpanOwner} pins every span in that async call tree
- * to a fixed owner instead — isolated by async context from concurrent test-body spans.
+ * round fired. Running such work inside {@link withTestSpanOwner} pins every span in that async call
+ * tree to a fixed owner instead — isolated by async context from concurrent test-body spans.
  */
 const ownerOverride = new AsyncLocalStorage<string | null>();
 
 /**
- * Runs `fn` with every {@link span} inside its async call tree attributed to `owner` instead of the
+ * Runs `fn` with every {@link testSpan} inside its async call tree attributed to `owner` instead of the
  * currently running test. Use a non-test sentinel owner (e.g. `other:mempool-feeder`) to keep a
  * background producer's spans out of the per-test view.
  */
-export function withSpanOwner<T>(owner: string, fn: () => Promise<T>): Promise<T> {
+export function withTestSpanOwner<T>(owner: string, fn: () => Promise<T>): Promise<T> {
   return ownerOverride.run(owner, fn);
 }
 
@@ -33,7 +33,7 @@ export function withSpanOwner<T>(owner: string, fn: () => Promise<T>): Promise<T
 export type TimingSpan = {
   /** Full name of the test running when the span started, or `null` if inside a beforeAll/afterAll hook. */
   owner: string | null;
-  /** Stable `category:label` tag, aggregated across occurrences (e.g. `wait:checkpoint`, `spawn:node`). */
+  /** Stable `category:label` tag, aggregated across occurrences (e.g. `wait:checkpoint`, `setup:node`). */
   name: string;
   /** `performance.now()` at span start. */
   start: number;
@@ -63,11 +63,11 @@ function getCollector(): SpanCollector | undefined {
  * started. The span is recorded even when `fn` throws. Pure passthrough: when no collector is
  * installed (i.e. `TEST_TIMING_FILE` is unset) this calls `fn()` directly with zero overhead.
  *
- * Use stable `category:label` tags and prefer wrapping at the leaf wait/spawn/tx level — labels are
+ * Use stable `category:label` tags and prefer wrapping at the leaf wait/setup/tx level — labels are
  * forever aggregation keys, and leaf-level tagging keeps spans additive. See `SPEEDUP_FOLLOWUPS` and
  * the A-1179 design doc for the tag taxonomy.
  */
-export async function span<T>(name: string, fn: () => Promise<T>): Promise<T> {
+export async function testSpan<T>(name: string, fn: () => Promise<T>): Promise<T> {
   const collector = getCollector();
   if (!collector) {
     return fn();
@@ -81,8 +81,8 @@ export async function span<T>(name: string, fn: () => Promise<T>): Promise<T> {
   }
 }
 
-/** Synchronous variant of {@link span} for non-async helpers. Same zero-cost guarantee when unset. */
-export function spanSync<T>(name: string, fn: () => T): T {
+/** Synchronous variant of {@link testSpan} for non-async helpers. Same zero-cost guarantee when unset. */
+export function testSpanSync<T>(name: string, fn: () => T): T {
   const collector = getCollector();
   if (!collector) {
     return fn();

--- a/yarn-project/end-to-end/src/fixtures/timing.ts
+++ b/yarn-project/end-to-end/src/fixtures/timing.ts
@@ -1,0 +1,97 @@
+/**
+ * E2e span instrumentation. Wrapping a shared test helper in {@link span} / {@link spanSync} records
+ * how long it ran, attributed to the test (or suite) that was executing, so a full CI run can be
+ * aggregated into a ranked list of where the suite spends wall-clock (setup, protocol waits, client
+ * proving, warp scans, ...). See the A-1178 timing environment in `shared/timing_env.mjs`.
+ *
+ * Everything here is gated on the collector installed by that environment, which only exists when
+ * `TEST_TIMING_FILE` is set. When it is unset, {@link span} calls `fn()` directly with no extra work
+ * and no clock reads — instrumentation is exactly zero-cost and cannot change a test's behavior or
+ * timing.
+ */
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+/**
+ * Async-context owner override. A span normally attributes itself to the running test
+ * (`collector.current`), but a background producer (e.g. the mempool feeder) runs interleaved with
+ * arbitrary tests, so its spans would smear across whichever test happened to be current when each
+ * round fired. Running such work inside {@link withSpanOwner} pins every span in that async call tree
+ * to a fixed owner instead — isolated by async context from concurrent test-body spans.
+ */
+const ownerOverride = new AsyncLocalStorage<string | null>();
+
+/**
+ * Runs `fn` with every {@link span} inside its async call tree attributed to `owner` instead of the
+ * currently running test. Use a non-test sentinel owner (e.g. `other:mempool-feeder`) to keep a
+ * background producer's spans out of the per-test view.
+ */
+export function withSpanOwner<T>(owner: string, fn: () => Promise<T>): Promise<T> {
+  return ownerOverride.run(owner, fn);
+}
+
+/** One recorded span occurrence on the process-wide `performance.now()` clock. */
+export type TimingSpan = {
+  /** Full name of the test running when the span started, or `null` if inside a beforeAll/afterAll hook. */
+  owner: string | null;
+  /** Stable `category:label` tag, aggregated across occurrences (e.g. `wait:checkpoint`, `spawn:node`). */
+  name: string;
+  /** `performance.now()` at span start. */
+  start: number;
+  /** `performance.now()` at span end. */
+  end: number;
+};
+
+/**
+ * The collector shared by the timing environment on `globalThis.__e2eTimings`. `current` is the full
+ * name of the test currently running (`null` during beforeAll/afterAll); the environment sets it. The
+ * `spans` array accumulates every recorded span until the environment folds it into the per-test /
+ * per-suite JSONL line at flush.
+ */
+export type SpanCollector = {
+  /** Full name of the running test, or `null` during a beforeAll/afterAll hook. */
+  current: string | null;
+  /** All recorded spans, drained by the timing environment at flush time. */
+  spans: TimingSpan[];
+};
+
+function getCollector(): SpanCollector | undefined {
+  return (globalThis as { __e2eTimings?: SpanCollector }).__e2eTimings;
+}
+
+/**
+ * Times `fn` and records a span tagged `name`, attributed to the test (or suite) running when it
+ * started. The span is recorded even when `fn` throws. Pure passthrough: when no collector is
+ * installed (i.e. `TEST_TIMING_FILE` is unset) this calls `fn()` directly with zero overhead.
+ *
+ * Use stable `category:label` tags and prefer wrapping at the leaf wait/spawn/tx level — labels are
+ * forever aggregation keys, and leaf-level tagging keeps spans additive. See `SPEEDUP_FOLLOWUPS` and
+ * the A-1179 design doc for the tag taxonomy.
+ */
+export async function span<T>(name: string, fn: () => Promise<T>): Promise<T> {
+  const collector = getCollector();
+  if (!collector) {
+    return fn();
+  }
+  const owner = ownerOverride.getStore() ?? collector.current;
+  const start = performance.now();
+  try {
+    return await fn();
+  } finally {
+    collector.spans.push({ owner, name, start, end: performance.now() });
+  }
+}
+
+/** Synchronous variant of {@link span} for non-async helpers. Same zero-cost guarantee when unset. */
+export function spanSync<T>(name: string, fn: () => T): T {
+  const collector = getCollector();
+  if (!collector) {
+    return fn();
+  }
+  const owner = ownerOverride.getStore() ?? collector.current;
+  const start = performance.now();
+  try {
+    return fn();
+  } finally {
+    collector.spans.push({ owner, name, start, end: performance.now() });
+  }
+}

--- a/yarn-project/end-to-end/src/fixtures/wait_helpers.ts
+++ b/yarn-project/end-to-end/src/fixtures/wait_helpers.ts
@@ -35,7 +35,7 @@ export type WaitForBlockOpts = {
 export function waitForBlockNumber(node: AztecNode, target: number, opts: WaitForBlockOpts = {}): Promise<BlockNumber> {
   const tag = opts.tag ?? 'proposed';
   const compare = opts.compare ?? ((actual, target) => actual >= target);
-  return testSpan(`wait-${tag}`, () =>
+  return testSpan(`wait:${tag}`, () =>
     // Wrap the matched value: retryUntil treats any falsy return as "keep polling", so a legitimate
     // match of block 0 (e.g. a freshly-pruned tip) would otherwise loop until timeout.
     retryUntil(

--- a/yarn-project/end-to-end/src/fixtures/wait_helpers.ts
+++ b/yarn-project/end-to-end/src/fixtures/wait_helpers.ts
@@ -11,6 +11,8 @@ import type { AztecNode, CheckpointTag } from '@aztec/stdlib/interfaces/client';
 import type { L2ToL1MembershipWitness } from '@aztec/stdlib/messaging';
 import type { TxHash, TxReceipt, TxStatus } from '@aztec/stdlib/tx';
 
+import { span } from './timing.js';
+
 /** Options for the block-number polling helpers. */
 export type WaitForBlockOpts = {
   /** Which chain tip to read; defaults to 'proposed'. */
@@ -33,17 +35,19 @@ export type WaitForBlockOpts = {
 export function waitForBlockNumber(node: AztecNode, target: number, opts: WaitForBlockOpts = {}): Promise<BlockNumber> {
   const tag = opts.tag ?? 'proposed';
   const compare = opts.compare ?? ((actual, target) => actual >= target);
-  // Wrap the matched value: retryUntil treats any falsy return as "keep polling", so a legitimate
-  // match of block 0 (e.g. a freshly-pruned tip) would otherwise loop until timeout.
-  return retryUntil(
-    async () => {
-      const blockNumber = await node.getBlockNumber(tag);
-      return compare(blockNumber, target) ? { blockNumber } : undefined;
-    },
-    `block ${tag} ${compare} ${target}`,
-    opts.timeout ?? 60,
-    opts.interval ?? 1,
-  ).then(({ blockNumber }) => blockNumber);
+  return span(tag === 'proven' ? 'wait:proven-block' : 'wait:block', () =>
+    // Wrap the matched value: retryUntil treats any falsy return as "keep polling", so a legitimate
+    // match of block 0 (e.g. a freshly-pruned tip) would otherwise loop until timeout.
+    retryUntil(
+      async () => {
+        const blockNumber = await node.getBlockNumber(tag);
+        return compare(blockNumber, target) ? { blockNumber } : undefined;
+      },
+      `block ${tag} ${compare} ${target}`,
+      opts.timeout ?? 60,
+      opts.interval ?? 1,
+    ).then(({ blockNumber }) => blockNumber),
+  );
 }
 
 /** Convenience for {@link waitForBlockNumber} on the proven tip. */
@@ -84,18 +88,20 @@ export function waitForNodeCheckpoint(
 ): Promise<CheckpointNumber> {
   const tag = opts.tag ?? 'checkpointed';
   const compare = opts.compare ?? ((actual, target) => actual >= target);
-  // Wrap the matched value: retryUntil treats any falsy return as "keep polling", so a legitimate
-  // match of checkpoint 0 (e.g. proven === 0 or checkpointed <= 1 after a prune) would otherwise
-  // loop until timeout instead of resolving.
-  return retryUntil(
-    async () => {
-      const checkpointNumber = await node.getCheckpointNumber(tag);
-      return compare(checkpointNumber, target) ? { checkpointNumber } : undefined;
-    },
-    `node checkpoint ${tag} ${compare} ${target}`,
-    opts.timeout ?? 30,
-    opts.interval ?? 0.5,
-  ).then(({ checkpointNumber }) => checkpointNumber);
+  return span(tag === 'proven' ? 'wait:proven-checkpoint' : 'wait:checkpoint', () =>
+    // Wrap the matched value: retryUntil treats any falsy return as "keep polling", so a legitimate
+    // match of checkpoint 0 (e.g. proven === 0 or checkpointed <= 1 after a prune) would otherwise
+    // loop until timeout instead of resolving.
+    retryUntil(
+      async () => {
+        const checkpointNumber = await node.getCheckpointNumber(tag);
+        return compare(checkpointNumber, target) ? { checkpointNumber } : undefined;
+      },
+      `node checkpoint ${tag} ${compare} ${target}`,
+      opts.timeout ?? 30,
+      opts.interval ?? 0.5,
+    ).then(({ checkpointNumber }) => checkpointNumber),
+  );
 }
 
 /** Convenience for {@link waitForNodeCheckpoint} on the proven tip. */
@@ -112,7 +118,7 @@ export function waitForNodeProvenCheckpoint(
  * {@link waitForTx}; resolves with the receipts in input order.
  */
 export function waitForTxs(node: AztecNode, txHashes: TxHash[], opts?: WaitOpts): Promise<TxReceipt[]> {
-  return Promise.all(txHashes.map(txHash => waitForTx(node, txHash, opts)));
+  return span('wait:tx-mined', () => Promise.all(txHashes.map(txHash => waitForTx(node, txHash, opts))));
 }
 
 /** Options for {@link waitForBlocksAtSlots}. */
@@ -138,15 +144,17 @@ export async function waitForBlocksAtSlots(
 ): Promise<void> {
   const from = opts.from ?? INITIAL_L2_BLOCK_NUM;
   const limit = opts.limit ?? 10;
-  await retryUntil(
-    async () => {
-      const blocks = await node.getBlocks(from, limit);
-      const foundSlots = blocks.map(block => block.header.getSlot());
-      return slots.every(slot => foundSlots.includes(slot)) || undefined;
-    },
-    `blocks at slots ${slots.join(', ')}`,
-    opts.timeout ?? 20,
-    opts.interval ?? 1,
+  await span('wait:block', () =>
+    retryUntil(
+      async () => {
+        const blocks = await node.getBlocks(from, limit);
+        const foundSlots = blocks.map(block => block.header.getSlot());
+        return slots.every(slot => foundSlots.includes(slot)) || undefined;
+      },
+      `blocks at slots ${slots.join(', ')}`,
+      opts.timeout ?? 20,
+      opts.interval ?? 1,
+    ),
   );
 }
 
@@ -161,11 +169,13 @@ export function waitForL2ToL1Witness(
   message: Fr,
   opts: { timeout?: number; interval?: number } = {},
 ): Promise<L2ToL1MembershipWitness> {
-  return retryUntil(
-    () => node.getL2ToL1MembershipWitness(txHash, message),
-    `L2-to-L1 membership witness for ${txHash.toString()}`,
-    opts.timeout ?? 30,
-    opts.interval ?? 1,
+  return span('wait:l2-to-l1-witness', () =>
+    retryUntil(
+      () => node.getL2ToL1MembershipWitness(txHash, message),
+      `L2-to-L1 membership witness for ${txHash.toString()}`,
+      opts.timeout ?? 30,
+      opts.interval ?? 1,
+    ),
   );
 }
 
@@ -189,15 +199,17 @@ export function waitForTxReceipt(
   predicate: (receipt: TxReceipt) => boolean,
   opts: WaitForTxReceiptOpts = {},
 ): Promise<TxReceipt> {
-  return retryUntil(
-    async () => {
-      const receipt = await node.getTxReceipt(txHash);
-      return predicate(receipt) ? { receipt } : undefined;
-    },
-    `tx receipt for ${txHash.toString()}`,
-    opts.timeout ?? 30,
-    opts.interval ?? 1,
-  ).then(({ receipt }) => receipt);
+  return span('wait:tx-mined', () =>
+    retryUntil(
+      async () => {
+        const receipt = await node.getTxReceipt(txHash);
+        return predicate(receipt) ? { receipt } : undefined;
+      },
+      `tx receipt for ${txHash.toString()}`,
+      opts.timeout ?? 30,
+      opts.interval ?? 1,
+    ).then(({ receipt }) => receipt),
+  );
 }
 
 /** Polls until `node.getTxReceipt(txHash).status === status`. Thin wrapper over {@link waitForTxReceipt}. */
@@ -234,17 +246,19 @@ export function waitForPendingTxCount(
   opts: WaitForPendingTxCountOpts = {},
 ): Promise<number> {
   const compare = opts.compare ?? ((actual, target) => actual >= target);
-  // Wrap the matched value: retryUntil treats any falsy return as "keep polling", so a legitimate
-  // match of 0 pending txs would otherwise loop until timeout instead of resolving.
-  return retryUntil(
-    async () => {
-      const count = await node.getPendingTxCount();
-      return compare(count, target) ? { count } : undefined;
-    },
-    `pending tx count ${compare} ${target}`,
-    opts.timeout ?? 30,
-    opts.interval ?? 1,
-  ).then(({ count }) => count);
+  return span('wait:pending-tx', () =>
+    // Wrap the matched value: retryUntil treats any falsy return as "keep polling", so a legitimate
+    // match of 0 pending txs would otherwise loop until timeout instead of resolving.
+    retryUntil(
+      async () => {
+        const count = await node.getPendingTxCount();
+        return compare(count, target) ? { count } : undefined;
+      },
+      `pending tx count ${compare} ${target}`,
+      opts.timeout ?? 30,
+      opts.interval ?? 1,
+    ).then(({ count }) => count),
+  );
 }
 
 /** Options for {@link waitForSequencerState}. */
@@ -266,10 +280,18 @@ export type WaitForSequencerStateOpts = {
  * Replaces the hand-rolled `state-changed` on/off subscriptions duplicated across the fee, cross-chain,
  * and keystore-reload tests.
  */
-export async function waitForSequencerState(
+export function waitForSequencerState(
   sequencer: Sequencer,
   state: SequencerState,
   opts: WaitForSequencerStateOpts = {},
+): Promise<void> {
+  return span('wait:sequencer-state', () => waitForSequencerStateInner(sequencer, state, opts));
+}
+
+async function waitForSequencerStateInner(
+  sequencer: Sequencer,
+  state: SequencerState,
+  opts: WaitForSequencerStateOpts,
 ): Promise<void> {
   const timeout = opts.timeout ?? 30000;
   const { promise, resolve, reject } = promiseWithResolvers<void>();

--- a/yarn-project/end-to-end/src/fixtures/wait_helpers.ts
+++ b/yarn-project/end-to-end/src/fixtures/wait_helpers.ts
@@ -11,7 +11,7 @@ import type { AztecNode, CheckpointTag } from '@aztec/stdlib/interfaces/client';
 import type { L2ToL1MembershipWitness } from '@aztec/stdlib/messaging';
 import type { TxHash, TxReceipt, TxStatus } from '@aztec/stdlib/tx';
 
-import { span } from './timing.js';
+import { testSpan } from './timing.js';
 
 /** Options for the block-number polling helpers. */
 export type WaitForBlockOpts = {
@@ -35,7 +35,7 @@ export type WaitForBlockOpts = {
 export function waitForBlockNumber(node: AztecNode, target: number, opts: WaitForBlockOpts = {}): Promise<BlockNumber> {
   const tag = opts.tag ?? 'proposed';
   const compare = opts.compare ?? ((actual, target) => actual >= target);
-  return span(tag === 'proven' ? 'wait:proven-block' : 'wait:block', () =>
+  return testSpan(`wait-${tag}`, () =>
     // Wrap the matched value: retryUntil treats any falsy return as "keep polling", so a legitimate
     // match of block 0 (e.g. a freshly-pruned tip) would otherwise loop until timeout.
     retryUntil(
@@ -88,7 +88,7 @@ export function waitForNodeCheckpoint(
 ): Promise<CheckpointNumber> {
   const tag = opts.tag ?? 'checkpointed';
   const compare = opts.compare ?? ((actual, target) => actual >= target);
-  return span(tag === 'proven' ? 'wait:proven-checkpoint' : 'wait:checkpoint', () =>
+  return testSpan(tag === 'proven' ? 'wait:proven-checkpoint' : 'wait:checkpoint', () =>
     // Wrap the matched value: retryUntil treats any falsy return as "keep polling", so a legitimate
     // match of checkpoint 0 (e.g. proven === 0 or checkpointed <= 1 after a prune) would otherwise
     // loop until timeout instead of resolving.
@@ -118,7 +118,7 @@ export function waitForNodeProvenCheckpoint(
  * {@link waitForTx}; resolves with the receipts in input order.
  */
 export function waitForTxs(node: AztecNode, txHashes: TxHash[], opts?: WaitOpts): Promise<TxReceipt[]> {
-  return span('wait:tx-mined', () => Promise.all(txHashes.map(txHash => waitForTx(node, txHash, opts))));
+  return testSpan('wait:tx-mined', () => Promise.all(txHashes.map(txHash => waitForTx(node, txHash, opts))));
 }
 
 /** Options for {@link waitForBlocksAtSlots}. */
@@ -144,7 +144,7 @@ export async function waitForBlocksAtSlots(
 ): Promise<void> {
   const from = opts.from ?? INITIAL_L2_BLOCK_NUM;
   const limit = opts.limit ?? 10;
-  await span('wait:block', () =>
+  await testSpan('wait:block', () =>
     retryUntil(
       async () => {
         const blocks = await node.getBlocks(from, limit);
@@ -169,7 +169,7 @@ export function waitForL2ToL1Witness(
   message: Fr,
   opts: { timeout?: number; interval?: number } = {},
 ): Promise<L2ToL1MembershipWitness> {
-  return span('wait:l2-to-l1-witness', () =>
+  return testSpan('wait:l2-to-l1-witness', () =>
     retryUntil(
       () => node.getL2ToL1MembershipWitness(txHash, message),
       `L2-to-L1 membership witness for ${txHash.toString()}`,
@@ -199,7 +199,7 @@ export function waitForTxReceipt(
   predicate: (receipt: TxReceipt) => boolean,
   opts: WaitForTxReceiptOpts = {},
 ): Promise<TxReceipt> {
-  return span('wait:tx-mined', () =>
+  return testSpan('wait:tx-mined', () =>
     retryUntil(
       async () => {
         const receipt = await node.getTxReceipt(txHash);
@@ -246,7 +246,7 @@ export function waitForPendingTxCount(
   opts: WaitForPendingTxCountOpts = {},
 ): Promise<number> {
   const compare = opts.compare ?? ((actual, target) => actual >= target);
-  return span('wait:pending-tx', () =>
+  return testSpan('wait:pending-tx', () =>
     // Wrap the matched value: retryUntil treats any falsy return as "keep polling", so a legitimate
     // match of 0 pending txs would otherwise loop until timeout instead of resolving.
     retryUntil(
@@ -285,7 +285,7 @@ export function waitForSequencerState(
   state: SequencerState,
   opts: WaitForSequencerStateOpts = {},
 ): Promise<void> {
-  return span('wait:sequencer-state', () => waitForSequencerStateInner(sequencer, state, opts));
+  return testSpan('wait:sequencer-state', () => waitForSequencerStateInner(sequencer, state, opts));
 }
 
 async function waitForSequencerStateInner(

--- a/yarn-project/end-to-end/src/multi-node/multi_node_test_context.ts
+++ b/yarn-project/end-to-end/src/multi-node/multi_node_test_context.ts
@@ -19,6 +19,7 @@ import type { SlashingProtectionDatabase } from '@aztec/validator-ha-signer/type
 import { type GetContractReturnType, getAddress, getContract } from 'viem';
 import { privateKeyToAccount } from 'viem/accounts';
 
+import { span } from '../fixtures/timing.js';
 import { getPrivateKeyFromIndex } from '../fixtures/utils.js';
 import {
   SingleNodeTestContext,
@@ -302,10 +303,12 @@ export class MultiNodeTestContext extends SingleNodeTestContext {
     target: CheckpointNumber,
     opts: { nodes?: AztecNode[]; timeout?: number; interval?: number } = {},
   ): Promise<void> {
-    return this.waitForAllNodes(tips => tips.proven.checkpoint.number >= target, {
-      ...opts,
-      description: `proven checkpoint >= ${target}`,
-    });
+    return span('wait:proven-checkpoint', () =>
+      this.waitForAllNodes(tips => tips.proven.checkpoint.number >= target, {
+        ...opts,
+        description: `proven checkpoint >= ${target}`,
+      }),
+    );
   }
 
   /** Waits until every node's checkpointed checkpoint tip reaches `target`. */
@@ -313,10 +316,12 @@ export class MultiNodeTestContext extends SingleNodeTestContext {
     target: CheckpointNumber,
     opts: { nodes?: AztecNode[]; timeout?: number; interval?: number } = {},
   ): Promise<void> {
-    return this.waitForAllNodes(tips => tips.checkpointed.checkpoint.number >= target, {
-      ...opts,
-      description: `checkpointed checkpoint >= ${target}`,
-    });
+    return span('wait:checkpoint', () =>
+      this.waitForAllNodes(tips => tips.checkpointed.checkpoint.number >= target, {
+        ...opts,
+        description: `checkpointed checkpoint >= ${target}`,
+      }),
+    );
   }
 
   /**
@@ -329,16 +334,18 @@ export class MultiNodeTestContext extends SingleNodeTestContext {
     match: (block: BlockResponse) => boolean = block => block.header.globalVariables.slotNumber === slot,
     opts: { nodes?: AztecNode[]; timeout?: number; interval?: number } = {},
   ): Promise<void> {
-    return this.waitForAllNodes(
-      async (tips, node) => {
-        const blockNumber = tag === 'proposed' ? tips.proposed.number : tips.checkpointed.block.number;
-        if (blockNumber === 0) {
-          return false;
-        }
-        const block = await node.getBlock(blockNumber);
-        return !!block && match(block);
-      },
-      { ...opts, description: `${tag} block at slot ${slot}` },
+    return span('wait:block', () =>
+      this.waitForAllNodes(
+        async (tips, node) => {
+          const blockNumber = tag === 'proposed' ? tips.proposed.number : tips.checkpointed.block.number;
+          if (blockNumber === 0) {
+            return false;
+          }
+          const block = await node.getBlock(blockNumber);
+          return !!block && match(block);
+        },
+        { ...opts, description: `${tag} block at slot ${slot}` },
+      ),
     );
   }
 
@@ -349,44 +356,48 @@ export class MultiNodeTestContext extends SingleNodeTestContext {
    * Returns the matched slots and their proposer addresses. Encapsulates the slot-search loop
    * duplicated across the multi-validator tests.
    */
-  public async findSlotsWithProposers(
+  public findSlotsWithProposers(
     count: number,
     predicate: (proposers: EthAddress[]) => boolean,
     opts: { fromSlot?: SlotNumber; margin?: number; maxAttempts?: number } = {},
   ): Promise<{ slots: SlotNumber[]; proposers: EthAddress[] }> {
-    const margin = opts.margin ?? 4;
-    const maxAttempts = opts.maxAttempts ?? 200;
-    let candidate = opts.fromSlot ?? SlotNumber(Number(this.epochCache.getEpochAndSlotNow().slot) + margin);
+    return span('warp:find-proposer', async () => {
+      const margin = opts.margin ?? 4;
+      const maxAttempts = opts.maxAttempts ?? 200;
+      let candidate = opts.fromSlot ?? SlotNumber(Number(this.epochCache.getEpochAndSlotNow().slot) + margin);
 
-    for (let attempt = 0; attempt < maxAttempts; attempt++) {
-      try {
-        const slots = Array.from({ length: count }, (_, i) => SlotNumber(candidate + i));
-        const maybeProposers = await Promise.all(
-          slots.map(slot => this.epochCache.getProposerAttesterAddressInSlot(slot)),
-        );
-        if (maybeProposers.every((p): p is EthAddress => p !== undefined) && predicate(maybeProposers)) {
-          return { slots, proposers: maybeProposers };
-        }
-        candidate = SlotNumber(candidate + 1);
-      } catch (err) {
-        const msg = err instanceof Error ? err.message : String(err);
-        if (!msg.includes('EpochNotStable')) {
-          throw err;
-        }
-        const block = await this.l1Client.getBlock({ includeTransactions: false });
-        const warpBy = this.epochDuration * this.L2_SLOT_DURATION_IN_S;
-        const newTs = Number(block.timestamp) + warpBy;
-        this.logger.warn(`Hit EpochNotStable at candidate ${candidate}, warping L1 forward by ${warpBy}s to ${newTs}`);
-        await this.context.cheatCodes.eth.warp(newTs, { resetBlockInterval: true });
-        const newCurrentSlot = Number(this.epochCache.getEpochAndSlotNow().slot);
-        if (candidate < newCurrentSlot + margin) {
-          candidate = SlotNumber(newCurrentSlot + margin);
+      for (let attempt = 0; attempt < maxAttempts; attempt++) {
+        try {
+          const slots = Array.from({ length: count }, (_, i) => SlotNumber(candidate + i));
+          const maybeProposers = await Promise.all(
+            slots.map(slot => this.epochCache.getProposerAttesterAddressInSlot(slot)),
+          );
+          if (maybeProposers.every((p): p is EthAddress => p !== undefined) && predicate(maybeProposers)) {
+            return { slots, proposers: maybeProposers };
+          }
+          candidate = SlotNumber(candidate + 1);
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          if (!msg.includes('EpochNotStable')) {
+            throw err;
+          }
+          const block = await this.l1Client.getBlock({ includeTransactions: false });
+          const warpBy = this.epochDuration * this.L2_SLOT_DURATION_IN_S;
+          const newTs = Number(block.timestamp) + warpBy;
+          this.logger.warn(
+            `Hit EpochNotStable at candidate ${candidate}, warping L1 forward by ${warpBy}s to ${newTs}`,
+          );
+          await this.context.cheatCodes.eth.warp(newTs, { resetBlockInterval: true });
+          const newCurrentSlot = Number(this.epochCache.getEpochAndSlotNow().slot);
+          if (candidate < newCurrentSlot + margin) {
+            candidate = SlotNumber(newCurrentSlot + margin);
+          }
         }
       }
-    }
-    throw new Error(
-      `Could not find ${count} consecutive slots matching the proposer predicate after ${maxAttempts} attempts`,
-    );
+      throw new Error(
+        `Could not find ${count} consecutive slots matching the proposer predicate after ${maxAttempts} attempts`,
+      );
+    });
   }
 
   /**
@@ -415,16 +426,20 @@ export class MultiNodeTestContext extends SingleNodeTestContext {
     const mode = opts.mode ?? 'all';
     const timeout = opts.timeout ?? this.L2_SLOT_DURATION_IN_S * 4;
     const interval = opts.interval ?? 0.5;
-    return retryUntil(
-      async () => {
-        const perNode = await Promise.all(nodes.map(node => node.getSlashOffenses('all').then(os => os.filter(match))));
-        const converged =
-          mode === 'all' ? perNode.every(matches => matches.length > 0) : perNode.some(m => m.length > 0);
-        return converged ? perNode.flat() : undefined;
-      },
-      `offense on ${mode} node(s)`,
-      timeout,
-      interval,
+    return span('wait:offense', () =>
+      retryUntil(
+        async () => {
+          const perNode = await Promise.all(
+            nodes.map(node => node.getSlashOffenses('all').then(os => os.filter(match))),
+          );
+          const converged =
+            mode === 'all' ? perNode.every(matches => matches.length > 0) : perNode.some(m => m.length > 0);
+          return converged ? perNode.flat() : undefined;
+        },
+        `offense on ${mode} node(s)`,
+        timeout,
+        interval,
+      ),
     );
   }
 }

--- a/yarn-project/end-to-end/src/multi-node/multi_node_test_context.ts
+++ b/yarn-project/end-to-end/src/multi-node/multi_node_test_context.ts
@@ -19,7 +19,7 @@ import type { SlashingProtectionDatabase } from '@aztec/validator-ha-signer/type
 import { type GetContractReturnType, getAddress, getContract } from 'viem';
 import { privateKeyToAccount } from 'viem/accounts';
 
-import { span } from '../fixtures/timing.js';
+import { testSpan } from '../fixtures/timing.js';
 import { getPrivateKeyFromIndex } from '../fixtures/utils.js';
 import {
   SingleNodeTestContext,
@@ -303,7 +303,7 @@ export class MultiNodeTestContext extends SingleNodeTestContext {
     target: CheckpointNumber,
     opts: { nodes?: AztecNode[]; timeout?: number; interval?: number } = {},
   ): Promise<void> {
-    return span('wait:proven-checkpoint', () =>
+    return testSpan('wait:proven-checkpoint', () =>
       this.waitForAllNodes(tips => tips.proven.checkpoint.number >= target, {
         ...opts,
         description: `proven checkpoint >= ${target}`,
@@ -316,7 +316,7 @@ export class MultiNodeTestContext extends SingleNodeTestContext {
     target: CheckpointNumber,
     opts: { nodes?: AztecNode[]; timeout?: number; interval?: number } = {},
   ): Promise<void> {
-    return span('wait:checkpoint', () =>
+    return testSpan('wait:checkpoint', () =>
       this.waitForAllNodes(tips => tips.checkpointed.checkpoint.number >= target, {
         ...opts,
         description: `checkpointed checkpoint >= ${target}`,
@@ -334,7 +334,7 @@ export class MultiNodeTestContext extends SingleNodeTestContext {
     match: (block: BlockResponse) => boolean = block => block.header.globalVariables.slotNumber === slot,
     opts: { nodes?: AztecNode[]; timeout?: number; interval?: number } = {},
   ): Promise<void> {
-    return span('wait:block', () =>
+    return testSpan('wait:block', () =>
       this.waitForAllNodes(
         async (tips, node) => {
           const blockNumber = tag === 'proposed' ? tips.proposed.number : tips.checkpointed.block.number;
@@ -361,7 +361,7 @@ export class MultiNodeTestContext extends SingleNodeTestContext {
     predicate: (proposers: EthAddress[]) => boolean,
     opts: { fromSlot?: SlotNumber; margin?: number; maxAttempts?: number } = {},
   ): Promise<{ slots: SlotNumber[]; proposers: EthAddress[] }> {
-    return span('warp:find-proposer', async () => {
+    return testSpan('warp:find-proposer', async () => {
       const margin = opts.margin ?? 4;
       const maxAttempts = opts.maxAttempts ?? 200;
       let candidate = opts.fromSlot ?? SlotNumber(Number(this.epochCache.getEpochAndSlotNow().slot) + margin);
@@ -426,7 +426,7 @@ export class MultiNodeTestContext extends SingleNodeTestContext {
     const mode = opts.mode ?? 'all';
     const timeout = opts.timeout ?? this.L2_SLOT_DURATION_IN_S * 4;
     const interval = opts.interval ?? 0.5;
-    return span('wait:offense', () =>
+    return testSpan('wait:offense', () =>
       retryUntil(
         async () => {
           const perNode = await Promise.all(

--- a/yarn-project/end-to-end/src/multi-node/slashing/setup.ts
+++ b/yarn-project/end-to-end/src/multi-node/slashing/setup.ts
@@ -14,6 +14,7 @@ import type { TxHash } from '@aztec/stdlib/tx';
 
 import { jest } from '@jest/globals';
 
+import { span } from '../../fixtures/timing.js';
 import { submitTxsTo } from '../../shared/submit-transactions.js';
 import type { TestWallet } from '../../test-wallet/test_wallet.js';
 import type { MultiNodeTestContext } from '../multi_node_test_context.js';
@@ -64,19 +65,23 @@ export function awaitProposalExecution(
   timeoutSeconds: number,
   logger: Logger,
 ): Promise<bigint> {
-  return new Promise<bigint>((resolve, reject) => {
-    const timeout = setTimeout(() => {
-      logger.warn(`Timed out waiting for proposal execution`);
-      reject(new Error(`Timeout waiting for proposal execution after ${timeoutSeconds}s`));
-    }, timeoutSeconds * 1000);
+  return span(
+    'wait:slash-execution',
+    () =>
+      new Promise<bigint>((resolve, reject) => {
+        const timeout = setTimeout(() => {
+          logger.warn(`Timed out waiting for proposal execution`);
+          reject(new Error(`Timeout waiting for proposal execution after ${timeoutSeconds}s`));
+        }, timeoutSeconds * 1000);
 
-    const unwatch = slashingProposer.listenToRoundExecuted(args => {
-      logger.warn(`Slash from round ${args.round} executed`);
-      clearTimeout(timeout);
-      unwatch();
-      resolve(args.round);
-    });
-  });
+        const unwatch = slashingProposer.listenToRoundExecuted(args => {
+          logger.warn(`Slash from round ${args.round} executed`);
+          clearTimeout(timeout);
+          unwatch();
+          resolve(args.round);
+        });
+      }),
+  );
 }
 
 export async function awaitCommitteeExists({
@@ -88,13 +93,15 @@ export async function awaitCommitteeExists({
 }): Promise<readonly `0x${string}`[]> {
   logger.info(`Waiting for committee to be set`);
   let committee: EthAddress[] | undefined;
-  await retryUntil(
-    async () => {
-      committee = await rollup.getCurrentEpochCommittee();
-      return committee && committee.length > 0;
-    },
-    'non-empty committee',
-    60,
+  await span('wait:committee', () =>
+    retryUntil(
+      async () => {
+        committee = await rollup.getCurrentEpochCommittee();
+        return committee && committee.length > 0;
+      },
+      'non-empty committee',
+      60,
+    ),
   );
   logger.warn(`Committee has been formed`, { committee: committee!.map(c => c.toString()) });
   return committee!.map(c => c.toString() as `0x${string}`);
@@ -117,7 +124,7 @@ export async function awaitCommitteeExists({
  * to warp close to the target (rather than stage sequencers an epoch ahead) use this and warp the
  * final `minLeadSlots` in themselves.
  */
-export async function findUpcomingProposerSlot({
+export function findUpcomingProposerSlot({
   epochCache,
   cheatCodes,
   targetProposer,
@@ -132,31 +139,33 @@ export async function findUpcomingProposerSlot({
   minLeadSlots: number;
   maxSlotsToScan?: number;
 }): Promise<SlotNumber> {
-  let candidate = Number(await cheatCodes.getSlot()) + minLeadSlots;
+  return span('warp:find-proposer', async () => {
+    let candidate = Number(await cheatCodes.getSlot()) + minLeadSlots;
 
-  for (let scanned = 0; scanned < maxSlotsToScan; scanned++) {
-    let proposer: EthAddress | undefined;
-    try {
-      proposer = await epochCache.getProposerAttesterAddressInSlot(SlotNumber(candidate));
-    } catch (err) {
-      if (!(err instanceof Error) || !err.message.includes('EpochNotStable')) {
-        throw err;
+    for (let scanned = 0; scanned < maxSlotsToScan; scanned++) {
+      let proposer: EthAddress | undefined;
+      try {
+        proposer = await epochCache.getProposerAttesterAddressInSlot(SlotNumber(candidate));
+      } catch (err) {
+        if (!(err instanceof Error) || !err.message.includes('EpochNotStable')) {
+          throw err;
+        }
+        await cheatCodes.advanceToNextEpoch();
+        const newCurrentSlot = Number(await cheatCodes.getSlot());
+        // Keep the lead after the warp: never return a slot we could no longer warp ahead of.
+        candidate = Math.max(candidate, newCurrentSlot + minLeadSlots);
+        continue;
       }
-      await cheatCodes.advanceToNextEpoch();
-      const newCurrentSlot = Number(await cheatCodes.getSlot());
-      // Keep the lead after the warp: never return a slot we could no longer warp ahead of.
-      candidate = Math.max(candidate, newCurrentSlot + minLeadSlots);
-      continue;
+
+      if (proposer && proposer.equals(targetProposer)) {
+        logger.warn(`Found target proposer ${targetProposer} at slot ${candidate}`);
+        return SlotNumber(candidate);
+      }
+      candidate++;
     }
 
-    if (proposer && proposer.equals(targetProposer)) {
-      logger.warn(`Found target proposer ${targetProposer} at slot ${candidate}`);
-      return SlotNumber(candidate);
-    }
-    candidate++;
-  }
-
-  throw new Error(`Target proposer ${targetProposer} not found within ${maxSlotsToScan} slots`);
+    throw new Error(`Target proposer ${targetProposer} not found within ${maxSlotsToScan} slots`);
+  });
 }
 
 /**
@@ -176,7 +185,7 @@ export async function findUpcomingProposerSlot({
  * Returns the target epoch and the concrete target slot so the caller can warp to it after starting
  * sequencers.
  */
-export async function advanceToEpochBeforeProposer({
+export function advanceToEpochBeforeProposer({
   epochCache,
   cheatCodes,
   targetProposer,
@@ -191,38 +200,40 @@ export async function advanceToEpochBeforeProposer({
   maxAttempts?: number;
   warmupSlots?: number;
 }): Promise<{ targetEpoch: EpochNumber; targetSlot: SlotNumber }> {
-  const { epochDuration } = await cheatCodes.getConfig();
+  return span('warp:find-proposer', async () => {
+    const { epochDuration } = await cheatCodes.getConfig();
 
-  for (let attempt = 0; attempt < maxAttempts; attempt++) {
-    const currentEpoch = await cheatCodes.getEpoch();
-    // Check the NEXT epoch's slots so we stay one epoch before the target,
-    // giving the caller time to start sequencers before the target epoch arrives.
-    const nextEpoch = Number(currentEpoch) + 1;
-    const epochStartSlot = nextEpoch * Number(epochDuration);
-    // Skip the first `warmupSlots` slots so the caller keeps a warm-up margin after warping to one
-    // slot before the epoch (see the doc comment above).
-    const startSlot = epochStartSlot + warmupSlots;
-    const endSlot = epochStartSlot + Number(epochDuration);
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+      const currentEpoch = await cheatCodes.getEpoch();
+      // Check the NEXT epoch's slots so we stay one epoch before the target,
+      // giving the caller time to start sequencers before the target epoch arrives.
+      const nextEpoch = Number(currentEpoch) + 1;
+      const epochStartSlot = nextEpoch * Number(epochDuration);
+      // Skip the first `warmupSlots` slots so the caller keeps a warm-up margin after warping to one
+      // slot before the epoch (see the doc comment above).
+      const startSlot = epochStartSlot + warmupSlots;
+      const endSlot = epochStartSlot + Number(epochDuration);
 
-    logger.info(
-      `Checking next epoch ${nextEpoch} (slots ${startSlot}-${endSlot - 1}) for proposer ${targetProposer} (current epoch: ${currentEpoch})`,
-    );
+      logger.info(
+        `Checking next epoch ${nextEpoch} (slots ${startSlot}-${endSlot - 1}) for proposer ${targetProposer} (current epoch: ${currentEpoch})`,
+      );
 
-    for (let s = startSlot; s < endSlot; s++) {
-      const proposer = await epochCache.getProposerAttesterAddressInSlot(SlotNumber(s));
-      if (proposer && proposer.equals(targetProposer)) {
-        logger.warn(
-          `Found target proposer ${targetProposer} in slot ${s} of epoch ${nextEpoch}. Staying at epoch ${currentEpoch} to allow sequencer startup.`,
-        );
-        return { targetEpoch: EpochNumber(nextEpoch), targetSlot: SlotNumber(s) };
+      for (let s = startSlot; s < endSlot; s++) {
+        const proposer = await epochCache.getProposerAttesterAddressInSlot(SlotNumber(s));
+        if (proposer && proposer.equals(targetProposer)) {
+          logger.warn(
+            `Found target proposer ${targetProposer} in slot ${s} of epoch ${nextEpoch}. Staying at epoch ${currentEpoch} to allow sequencer startup.`,
+          );
+          return { targetEpoch: EpochNumber(nextEpoch), targetSlot: SlotNumber(s) };
+        }
       }
+
+      logger.info(`Target proposer not found in epoch ${nextEpoch}, advancing to next epoch`);
+      await cheatCodes.advanceToNextEpoch();
     }
 
-    logger.info(`Target proposer not found in epoch ${nextEpoch}, advancing to next epoch`);
-    await cheatCodes.advanceToNextEpoch();
-  }
-
-  throw new Error(`Target proposer ${targetProposer} not found in any slot after ${maxAttempts} epoch attempts`);
+    throw new Error(`Target proposer ${targetProposer} not found in any slot after ${maxAttempts} epoch attempts`);
+  });
 }
 
 export async function awaitOffenseDetected({
@@ -242,15 +253,17 @@ export async function awaitOffenseDetected({
 }) {
   const targetOffenseCount = waitUntilOffenseCount ?? 1;
   logger.warn(`Waiting for ${pluralize('offense', targetOffenseCount)} to be detected`);
-  const offenses = await retryUntil(
-    async () => {
-      const offenses = await nodeAdmin.getSlashOffenses('all');
-      if (offenses.length >= targetOffenseCount) {
-        return offenses;
-      }
-    },
-    'non-empty offenses',
-    timeoutSeconds,
+  const offenses = await span('wait:offense', () =>
+    retryUntil(
+      async () => {
+        const offenses = await nodeAdmin.getSlashOffenses('all');
+        if (offenses.length >= targetOffenseCount) {
+          return offenses;
+        }
+      },
+      'non-empty offenses',
+      timeoutSeconds,
+    ),
   );
   logger.info(
     `Hit ${offenses.length} offenses on rounds ${unique(offenses.map(o => getRoundForOffense(o, { slashingRoundSize, epochDuration })))}`,
@@ -288,59 +301,61 @@ export async function awaitCommitteeKicked({
     throw new Error('No slashing proposer configured. Cannot test slashing.');
   }
 
-  await cheatCodes.debugRollup();
+  await span('wait:committee-kicked', async () => {
+    await cheatCodes.debugRollup();
 
-  // Use the slash offset to ensure we are in the right epoch for tally
-  const slashOffsetInRounds = await slashingProposer.getSlashOffsetInRounds();
-  const slashingRoundSizeInEpochs = slashingRoundSize / aztecEpochDuration;
-  const slashingOffsetInEpochs = Number(slashOffsetInRounds) * slashingRoundSizeInEpochs;
-  const firstEpochInOffenseRound = offenseEpoch - (offenseEpoch % slashingRoundSizeInEpochs);
-  const targetEpoch = firstEpochInOffenseRound + slashingOffsetInEpochs;
-  logger.info(`Advancing to epoch ${targetEpoch} so we start slashing`);
-  await cheatCodes.advanceToEpoch(EpochNumber(targetEpoch), { offset: -aztecSlotDuration / 2 });
+    // Use the slash offset to ensure we are in the right epoch for tally
+    const slashOffsetInRounds = await slashingProposer.getSlashOffsetInRounds();
+    const slashingRoundSizeInEpochs = slashingRoundSize / aztecEpochDuration;
+    const slashingOffsetInEpochs = Number(slashOffsetInRounds) * slashingRoundSizeInEpochs;
+    const firstEpochInOffenseRound = offenseEpoch - (offenseEpoch % slashingRoundSizeInEpochs);
+    const targetEpoch = firstEpochInOffenseRound + slashingOffsetInEpochs;
+    logger.info(`Advancing to epoch ${targetEpoch} so we start slashing`);
+    await cheatCodes.advanceToEpoch(EpochNumber(targetEpoch), { offset: -aztecSlotDuration / 2 });
 
-  const attestersPre = await rollup.getAttesters();
-  expect(attestersPre.length).toBe(committee.length);
+    const attestersPre = await rollup.getAttesters();
+    expect(attestersPre.length).toBe(committee.length);
 
-  for (const attester of attestersPre) {
-    const attesterInfo = await rollup.getAttesterView(attester);
-    expect(attesterInfo.status).toEqual(1); // Validating
-  }
+    for (const attester of attestersPre) {
+      const attesterInfo = await rollup.getAttesterView(attester);
+      expect(attesterInfo.status).toEqual(1); // Validating
+    }
 
-  // Allow up to four round-lengths so that under proposer pipelining, where individual rounds
-  // sometimes fail to gather quorum because parts of the committee miss votes due to chain-state
-  // races, we still see a later round execute the slash.
-  const timeout = slashingRoundSize * 4 * aztecSlotDuration + 30;
-  logger.info(`Waiting for slash to be executed (timeout ${timeout}s)`);
-  await awaitProposalExecution(slashingProposer, timeout, logger);
+    // Allow up to four round-lengths so that under proposer pipelining, where individual rounds
+    // sometimes fail to gather quorum because parts of the committee miss votes due to chain-state
+    // races, we still see a later round execute the slash.
+    const timeout = slashingRoundSize * 4 * aztecSlotDuration + 30;
+    logger.info(`Waiting for slash to be executed (timeout ${timeout}s)`);
+    await awaitProposalExecution(slashingProposer, timeout, logger);
 
-  // The attesters should still form the committee but they should be reduced to the "living" status
-  await cheatCodes.debugRollup();
-  const committeePostSlashing = await rollup.getCurrentEpochCommittee();
-  expect(committeePostSlashing?.length).toBe(attestersPre.length);
+    // The attesters should still form the committee but they should be reduced to the "living" status
+    await cheatCodes.debugRollup();
+    const committeePostSlashing = await rollup.getCurrentEpochCommittee();
+    expect(committeePostSlashing?.length).toBe(attestersPre.length);
 
-  const attestersPostSlashing = await rollup.getAttesters();
-  expect(attestersPostSlashing.length).toBe(0);
+    const attestersPostSlashing = await rollup.getAttesters();
+    expect(attestersPostSlashing.length).toBe(0);
 
-  for (const attester of attestersPre) {
-    const attesterInfo = await rollup.getAttesterView(attester);
-    expect(attesterInfo.status).toEqual(2); // Living
-  }
+    for (const attester of attestersPre) {
+      const attesterInfo = await rollup.getAttesterView(attester);
+      expect(attesterInfo.status).toEqual(2); // Living
+    }
 
-  logger.info(`Advancing to check current committee`);
-  await cheatCodes.debugRollup();
-  await cheatCodes.advanceToEpoch(
-    EpochNumber((await cheatCodes.getEpoch()) + (await rollup.getLagInEpochsForValidatorSet()) + 1),
-  );
-  await cheatCodes.debugRollup();
+    logger.info(`Advancing to check current committee`);
+    await cheatCodes.debugRollup();
+    await cheatCodes.advanceToEpoch(
+      EpochNumber((await cheatCodes.getEpoch()) + (await rollup.getLagInEpochsForValidatorSet()) + 1),
+    );
+    await cheatCodes.debugRollup();
 
-  const committeeNextEpoch = await rollup.getCurrentEpochCommittee();
-  // The committee should be undefined, since the validator set is empty
-  // and the tests currently using this helper always set a target committee size.
-  expect(committeeNextEpoch).toBeUndefined();
+    const committeeNextEpoch = await rollup.getCurrentEpochCommittee();
+    // The committee should be undefined, since the validator set is empty
+    // and the tests currently using this helper always set a target committee size.
+    expect(committeeNextEpoch).toBeUndefined();
 
-  const attestersNextEpoch = await rollup.getAttesters();
-  expect(attestersNextEpoch.length).toBe(0);
+    const attestersNextEpoch = await rollup.getAttesters();
+    expect(attestersNextEpoch.length).toBe(0);
+  });
 }
 
 /** Resolves the slot at which `node` includes `txHash`, by reading the tx receipt and block header. */

--- a/yarn-project/end-to-end/src/multi-node/slashing/setup.ts
+++ b/yarn-project/end-to-end/src/multi-node/slashing/setup.ts
@@ -14,7 +14,7 @@ import type { TxHash } from '@aztec/stdlib/tx';
 
 import { jest } from '@jest/globals';
 
-import { span } from '../../fixtures/timing.js';
+import { testSpan } from '../../fixtures/timing.js';
 import { submitTxsTo } from '../../shared/submit-transactions.js';
 import type { TestWallet } from '../../test-wallet/test_wallet.js';
 import type { MultiNodeTestContext } from '../multi_node_test_context.js';
@@ -65,7 +65,7 @@ export function awaitProposalExecution(
   timeoutSeconds: number,
   logger: Logger,
 ): Promise<bigint> {
-  return span(
+  return testSpan(
     'wait:slash-execution',
     () =>
       new Promise<bigint>((resolve, reject) => {
@@ -93,7 +93,7 @@ export async function awaitCommitteeExists({
 }): Promise<readonly `0x${string}`[]> {
   logger.info(`Waiting for committee to be set`);
   let committee: EthAddress[] | undefined;
-  await span('wait:committee', () =>
+  await testSpan('wait:committee', () =>
     retryUntil(
       async () => {
         committee = await rollup.getCurrentEpochCommittee();
@@ -139,7 +139,7 @@ export function findUpcomingProposerSlot({
   minLeadSlots: number;
   maxSlotsToScan?: number;
 }): Promise<SlotNumber> {
-  return span('warp:find-proposer', async () => {
+  return testSpan('warp:find-proposer', async () => {
     let candidate = Number(await cheatCodes.getSlot()) + minLeadSlots;
 
     for (let scanned = 0; scanned < maxSlotsToScan; scanned++) {
@@ -200,7 +200,7 @@ export function advanceToEpochBeforeProposer({
   maxAttempts?: number;
   warmupSlots?: number;
 }): Promise<{ targetEpoch: EpochNumber; targetSlot: SlotNumber }> {
-  return span('warp:find-proposer', async () => {
+  return testSpan('warp:find-proposer', async () => {
     const { epochDuration } = await cheatCodes.getConfig();
 
     for (let attempt = 0; attempt < maxAttempts; attempt++) {
@@ -253,7 +253,7 @@ export async function awaitOffenseDetected({
 }) {
   const targetOffenseCount = waitUntilOffenseCount ?? 1;
   logger.warn(`Waiting for ${pluralize('offense', targetOffenseCount)} to be detected`);
-  const offenses = await span('wait:offense', () =>
+  const offenses = await testSpan('wait:offense', () =>
     retryUntil(
       async () => {
         const offenses = await nodeAdmin.getSlashOffenses('all');
@@ -301,7 +301,7 @@ export async function awaitCommitteeKicked({
     throw new Error('No slashing proposer configured. Cannot test slashing.');
   }
 
-  await span('wait:committee-kicked', async () => {
+  await testSpan('wait:committee-kicked', async () => {
     await cheatCodes.debugRollup();
 
     // Use the slash offset to ensure we are in the right epoch for tally

--- a/yarn-project/end-to-end/src/shared/timing_env.d.mts
+++ b/yarn-project/end-to-end/src/shared/timing_env.d.mts
@@ -1,0 +1,39 @@
+/** A single recorded span occurrence on the shared `performance.now()` clock. */
+export type TimingSpan = {
+  /** Full name of the test running when the span started, or `null` during a beforeAll/afterAll hook. */
+  owner?: string | null;
+  /** Stable `category:label` tag. */
+  name?: string;
+  /** Clock value at span start. */
+  start: number;
+  /** Clock value at span end. */
+  end: number;
+};
+
+/** Aggregate of one tag's occurrences. */
+export type SpanAggregate = {
+  count: number;
+  totalMs: number;
+  busyMs: number;
+  maxMs: number;
+};
+
+/**
+ * Aggregates a list of `{ start, end }` spans of one tag into `{ count, totalMs, busyMs, maxMs }`.
+ * Does not mutate the input array.
+ */
+export function aggregateSpans(spans: TimingSpan[]): SpanAggregate;
+
+/**
+ * Groups `spans` by owner then tag, attaches a `spans` aggregate map to the matching record (or
+ * `suiteRecord` for `null`-owner spans), derives back-compat `setupFnMs` / `teardownFnMs`, drops spans
+ * whose owner matches no record, and returns the raw per-occurrence list (empty unless `emitSpanLines`).
+ */
+export function foldSpansInto(
+  spans: TimingSpan[],
+  options: {
+    recordsByName: Map<string, Record<string, unknown>>;
+    suiteRecord: Record<string, unknown>;
+    emitSpanLines?: boolean;
+  },
+): { owner: string | null; name: string; ms: number }[];

--- a/yarn-project/end-to-end/src/shared/timing_env.mjs
+++ b/yarn-project/end-to-end/src/shared/timing_env.mjs
@@ -6,7 +6,7 @@ import CustomEnvironment from '../../../foundation/src/jest/env.mjs';
 // Per-test e2e timing environment. Gated entirely on the TEST_TIMING_FILE env var: when unset, this
 // behaves exactly like the base CustomEnvironment (it only delegates). When set, it records, per test
 // worker process, the time spent in jest before/after hooks and the test body, and folds in the named
-// spans recorded via the `span()` wrapper (fixtures/timing.ts) through a collector shared on
+// spans recorded via the `testSpan()` wrapper (fixtures/timing.ts) through a collector shared on
 // `this.global`.
 //
 // Output is one JSONL file per worker process (the env runs once per worker). Each line carries a
@@ -191,95 +191,14 @@ export default class TimingEnvironment extends CustomEnvironment {
     return parts.join(' ');
   }
 
-  /**
-   * Aggregates a list of `{ start, end }` spans of one tag into `{ count, totalMs, busyMs, maxMs }`.
-   * `totalMs` is the naive sum of per-occurrence durations (correct for serial repeats); `busyMs` is
-   * the duration of the union of the `[start, end)` intervals (concurrency-correct — N concurrent
-   * spans collapse to their wall-clock span instead of summing to ~N×); `maxMs` is the longest single
-   * occurrence. All durations are on the shared process-wide `performance.now()` clock.
-   */
-  aggregateSpans(spans) {
-    let totalMs = 0;
-    let maxMs = 0;
-    for (const span of spans) {
-      const ms = span.end - span.start;
-      totalMs += ms;
-      if (ms > maxMs) {
-        maxMs = ms;
-      }
-    }
-    // busyMs: sort by start and merge overlapping intervals, summing the merged lengths.
-    const sorted = [...spans].sort((a, b) => a.start - b.start);
-    let busyMs = 0;
-    let mergeStart = null;
-    let mergeEnd = null;
-    for (const span of sorted) {
-      if (mergeStart === null) {
-        mergeStart = span.start;
-        mergeEnd = span.end;
-      } else if (span.start <= mergeEnd) {
-        if (span.end > mergeEnd) {
-          mergeEnd = span.end;
-        }
-      } else {
-        busyMs += mergeEnd - mergeStart;
-        mergeStart = span.start;
-        mergeEnd = span.end;
-      }
-    }
-    if (mergeStart !== null) {
-      busyMs += mergeEnd - mergeStart;
-    }
-    return { count: spans.length, totalMs, busyMs, maxMs };
-  }
-
-  /**
-   * Groups the collected spans by owner, then by tag, and attaches a `spans` map of aggregates to the
-   * matching per-test / suite record. Also derives the back-compat `setupFnMs` / `teardownFnMs` fields
-   * from the `spawn:env:<mode>` / `teardown:env` aggregates. Spans whose owner matches no record (e.g.
-   * the pinned `other:mempool-feeder` owner) are dropped. Drains `collector.spans` once done.
-   */
+  /** Folds the collected spans into the per-test / suite records via {@link foldSpansInto}, then drains the collector. */
   foldSpans() {
-    // Group by owner (null owner → suite record), then by tag.
-    const byOwner = new Map();
-    for (const span of this.collector.spans) {
-      const owner = span.owner ?? null;
-      let byName = byOwner.get(owner);
-      if (!byName) {
-        byName = new Map();
-        byOwner.set(owner, byName);
-      }
-      let list = byName.get(span.name);
-      if (!list) {
-        list = [];
-        byName.set(span.name, list);
-      }
-      list.push(span);
-      if (this.emitSpanLines) {
-        this.rawSpans.push({ owner, name: span.name, ms: span.end - span.start });
-      }
-    }
-
-    for (const [owner, byName] of byOwner) {
-      const record = owner === null ? this.suiteRecord : this.recordsByName.get(owner);
-      if (!record) {
-        continue;
-      }
-      const aggregates = {};
-      for (const [name, list] of byName) {
-        aggregates[name] = this.aggregateSpans(list);
-      }
-      record.spans = aggregates;
-      // Back-compat: the legacy fn-span buckets are derived from the top-level env spawn/teardown tags.
-      // The top-level setup is tagged `spawn:env:<proverMode>` (the mode is a closed set, distinct from
-      // the `:anvil`/`:l1-deploy`/... sub-phase tags), so sum those three exact tags.
-      const setupFnMs =
-        (aggregates['spawn:env:none']?.totalMs ?? 0) +
-        (aggregates['spawn:env:fake']?.totalMs ?? 0) +
-        (aggregates['spawn:env:real']?.totalMs ?? 0);
-      record.setupFnMs = setupFnMs + (record.setupFnMs ?? 0);
-      record.teardownFnMs = (aggregates['teardown:env']?.totalMs ?? 0) + (record.teardownFnMs ?? 0);
-    }
+    const rawSpans = foldSpansInto(this.collector.spans, {
+      recordsByName: this.recordsByName,
+      suiteRecord: this.suiteRecord,
+      emitSpanLines: this.emitSpanLines,
+    });
+    this.rawSpans.push(...rawSpans);
     this.collector.spans = [];
   }
 
@@ -345,4 +264,100 @@ export default class TimingEnvironment extends CustomEnvironment {
     }
     return JSON.stringify(obj);
   }
+}
+
+/**
+ * Aggregates a list of `{ start, end }` spans of one tag into `{ count, totalMs, busyMs, maxMs }`.
+ * `totalMs` is the naive sum of per-occurrence durations (correct for serial repeats); `busyMs` is
+ * the duration of the union of the `[start, end)` intervals (concurrency-correct — N concurrent
+ * spans collapse to their wall-clock span instead of summing to ~N×); `maxMs` is the longest single
+ * occurrence. All durations are on the shared process-wide `performance.now()` clock. Does not mutate
+ * the input array.
+ */
+export function aggregateSpans(spans) {
+  let totalMs = 0;
+  let maxMs = 0;
+  for (const span of spans) {
+    const ms = span.end - span.start;
+    totalMs += ms;
+    if (ms > maxMs) {
+      maxMs = ms;
+    }
+  }
+  // busyMs: sort by start and merge overlapping intervals, summing the merged lengths.
+  const sorted = [...spans].sort((a, b) => a.start - b.start);
+  let busyMs = 0;
+  let mergeStart = null;
+  let mergeEnd = null;
+  for (const span of sorted) {
+    if (mergeStart === null) {
+      mergeStart = span.start;
+      mergeEnd = span.end;
+    } else if (span.start <= mergeEnd) {
+      if (span.end > mergeEnd) {
+        mergeEnd = span.end;
+      }
+    } else {
+      busyMs += mergeEnd - mergeStart;
+      mergeStart = span.start;
+      mergeEnd = span.end;
+    }
+  }
+  if (mergeStart !== null) {
+    busyMs += mergeEnd - mergeStart;
+  }
+  return { count: spans.length, totalMs, busyMs, maxMs };
+}
+
+/**
+ * Groups `spans` by owner, then by tag, and attaches a `spans` map of aggregates to the matching
+ * per-test record (looked up in `recordsByName`) or, for `null`-owner spans, to `suiteRecord`. Also
+ * derives the back-compat `setupFnMs` / `teardownFnMs` fields from the `setup:env:<mode>` /
+ * `teardown:env` aggregates (additive over any pre-existing value). Spans whose owner matches no
+ * record (e.g. the pinned `other:mempool-feeder` owner) are dropped. Returns the raw per-occurrence
+ * list (`{ owner, name, ms }`), which is empty unless `emitSpanLines` is set.
+ */
+export function foldSpansInto(spans, { recordsByName, suiteRecord, emitSpanLines = false }) {
+  const rawSpans = [];
+  // Group by owner (null owner → suite record), then by tag.
+  const byOwner = new Map();
+  for (const span of spans) {
+    const owner = span.owner ?? null;
+    let byName = byOwner.get(owner);
+    if (!byName) {
+      byName = new Map();
+      byOwner.set(owner, byName);
+    }
+    let list = byName.get(span.name);
+    if (!list) {
+      list = [];
+      byName.set(span.name, list);
+    }
+    list.push(span);
+    if (emitSpanLines) {
+      rawSpans.push({ owner, name: span.name, ms: span.end - span.start });
+    }
+  }
+
+  for (const [owner, byName] of byOwner) {
+    const record = owner === null ? suiteRecord : recordsByName.get(owner);
+    if (!record) {
+      continue;
+    }
+    const aggregates = {};
+    for (const [name, list] of byName) {
+      aggregates[name] = aggregateSpans(list);
+    }
+    record.spans = aggregates;
+    // Back-compat: the legacy fn-span buckets are derived from the top-level env setup/teardown tags.
+    // The top-level setup is tagged `setup:env:<proverMode>` (the mode is a closed set, distinct from
+    // the `:anvil`/`:l1-deploy`/... sub-phase tags), so sum those three exact tags.
+    const setupFnMs =
+      (aggregates['setup:env:none']?.totalMs ?? 0) +
+      (aggregates['setup:env:fake']?.totalMs ?? 0) +
+      (aggregates['setup:env:real']?.totalMs ?? 0);
+    record.setupFnMs = setupFnMs + (record.setupFnMs ?? 0);
+    record.teardownFnMs = (aggregates['teardown:env']?.totalMs ?? 0) + (record.teardownFnMs ?? 0);
+  }
+  return rawSpans;
 }

--- a/yarn-project/end-to-end/src/shared/timing_env.mjs
+++ b/yarn-project/end-to-end/src/shared/timing_env.mjs
@@ -5,13 +5,23 @@ import CustomEnvironment from '../../../foundation/src/jest/env.mjs';
 
 // Per-test e2e timing environment. Gated entirely on the TEST_TIMING_FILE env var: when unset, this
 // behaves exactly like the base CustomEnvironment (it only delegates). When set, it records, per test
-// worker process, the time spent in jest before/after hooks and the test body, and merges in the
-// function-level time captured by setup.ts/teardown.ts via a collector shared on `this.global`.
+// worker process, the time spent in jest before/after hooks and the test body, and folds in the named
+// spans recorded via the `span()` wrapper (fixtures/timing.ts) through a collector shared on
+// `this.global`.
 //
 // Output is one JSONL file per worker process (the env runs once per worker). Each line carries a
 // `type` discriminator and is one of:
 //   - `type: 'test'` (`name` set): beforeEach hooks, the it() body, afterEach hooks for one test; or
 //   - `type: 'suite'` (`name: null`): the suite-scoped beforeAll/afterAll hooks for the whole file.
+//
+// Each line also gains a `spans` map: per `category:label` tag the test/suite touched, the collector
+// records `{ count, totalMs, busyMs, maxMs }`. `busyMs` is the duration of the union of the spans'
+// `[start, end)` intervals on the shared `performance.now()` clock, so concurrent spans (Promise.all
+// fan-out) do not inflate it the way `totalMs` does. The legacy `setupFnMs`/`teardownFnMs` fields are
+// kept for back-compat, derived from the `setup:env`/`teardown:env` spans.
+//
+// When `TEST_TIMING_SPANS=1`, the collector additionally retains every raw span occurrence and emits
+// one `type:"span"` line per occurrence (owner, name, ms) for deep dives, at the cost of a larger file.
 export default class TimingEnvironment extends CustomEnvironment {
   constructor(config, context) {
     super(config, context);
@@ -28,10 +38,17 @@ export default class TimingEnvironment extends CustomEnvironment {
       runId: process.env.RUN_ID ?? null,
     };
 
-    // Shared collector. setup.ts (running in the sandbox realm) reads `globalThis.__e2eTimings`; this
-    // env (host realm) reads `this.global.__e2eTimings` — they are the same object. `current` is the
-    // full name of the test currently running (null during beforeAll/afterAll), used to tag fn spans.
-    this.collector = { current: null, fnSpans: [] };
+    // Opt-in per-occurrence emission for deep dives (off by default keeps the JSONL one line per test).
+    this.emitSpanLines = process.env.TEST_TIMING_SPANS === '1';
+
+    // Shared collector. The instrumented helpers (running in the sandbox realm) read
+    // `globalThis.__e2eTimings`; this env (host realm) reads `this.global.__e2eTimings` — they are the
+    // same object. `current` is the full name of the test currently running (null during
+    // beforeAll/afterAll), used to attribute each span to a test or to the suite-scoped line. `spans`
+    // accumulates every recorded span until flush. The `start`/`end` timestamps come from the sandbox
+    // realm's `performance.now()`; Node's perf clock is process-wide (one monotonic origin across all
+    // realms), so merging the intervals here for `busyMs` is valid.
+    this.collector = { current: null, spans: [] };
     this.global.__e2eTimings = this.collector;
 
     // Records to flush as JSONL on teardown. One per test plus one suite-scoped record.
@@ -44,6 +61,8 @@ export default class TimingEnvironment extends CustomEnvironment {
     this.testStarts = new Map();
     // Guards against double-flushing (we flush on both the teardown event and the teardown method).
     this.flushed = false;
+    // Raw per-occurrence spans retained only when TEST_TIMING_SPANS=1, emitted as `type:"span"` lines.
+    this.rawSpans = [];
   }
 
   // Flush on the teardown method too: the jest lifecycle always calls this, whereas the 'teardown'
@@ -133,7 +152,6 @@ export default class TimingEnvironment extends CustomEnvironment {
         if (record && event.test?.errors?.length) {
           record.status = 'failed';
         }
-        this.mergeFnSpans(name, record);
         this.collector.current = null;
         break;
       }
@@ -173,48 +191,105 @@ export default class TimingEnvironment extends CustomEnvironment {
     return parts.join(' ');
   }
 
-  /** Moves fn spans tagged with `name` into the matching record's setup/teardown buckets. */
-  mergeFnSpans(name, record) {
-    if (!record) {
-      return;
-    }
-    const remaining = [];
-    for (const span of this.collector.fnSpans) {
-      if (span.name === name) {
-        if (span.kind === 'setup') {
-          record.setupFnMs += span.ms;
-        } else if (span.kind === 'teardown') {
-          record.teardownFnMs += span.ms;
-        }
-      } else {
-        remaining.push(span);
+  /**
+   * Aggregates a list of `{ start, end }` spans of one tag into `{ count, totalMs, busyMs, maxMs }`.
+   * `totalMs` is the naive sum of per-occurrence durations (correct for serial repeats); `busyMs` is
+   * the duration of the union of the `[start, end)` intervals (concurrency-correct — N concurrent
+   * spans collapse to their wall-clock span instead of summing to ~N×); `maxMs` is the longest single
+   * occurrence. All durations are on the shared process-wide `performance.now()` clock.
+   */
+  aggregateSpans(spans) {
+    let totalMs = 0;
+    let maxMs = 0;
+    for (const span of spans) {
+      const ms = span.end - span.start;
+      totalMs += ms;
+      if (ms > maxMs) {
+        maxMs = ms;
       }
     }
-    this.collector.fnSpans = remaining;
+    // busyMs: sort by start and merge overlapping intervals, summing the merged lengths.
+    const sorted = [...spans].sort((a, b) => a.start - b.start);
+    let busyMs = 0;
+    let mergeStart = null;
+    let mergeEnd = null;
+    for (const span of sorted) {
+      if (mergeStart === null) {
+        mergeStart = span.start;
+        mergeEnd = span.end;
+      } else if (span.start <= mergeEnd) {
+        if (span.end > mergeEnd) {
+          mergeEnd = span.end;
+        }
+      } else {
+        busyMs += mergeEnd - mergeStart;
+        mergeStart = span.start;
+        mergeEnd = span.end;
+      }
+    }
+    if (mergeStart !== null) {
+      busyMs += mergeEnd - mergeStart;
+    }
+    return { count: spans.length, totalMs, busyMs, maxMs };
   }
 
-  /** Finalizes the suite-scoped record (untagged fn spans + beforeAll/afterAll) and writes all JSONL. */
+  /**
+   * Groups the collected spans by owner, then by tag, and attaches a `spans` map of aggregates to the
+   * matching per-test / suite record. Also derives the back-compat `setupFnMs` / `teardownFnMs` fields
+   * from the `spawn:env:<mode>` / `teardown:env` aggregates. Spans whose owner matches no record (e.g.
+   * the pinned `other:mempool-feeder` owner) are dropped. Drains `collector.spans` once done.
+   */
+  foldSpans() {
+    // Group by owner (null owner → suite record), then by tag.
+    const byOwner = new Map();
+    for (const span of this.collector.spans) {
+      const owner = span.owner ?? null;
+      let byName = byOwner.get(owner);
+      if (!byName) {
+        byName = new Map();
+        byOwner.set(owner, byName);
+      }
+      let list = byName.get(span.name);
+      if (!list) {
+        list = [];
+        byName.set(span.name, list);
+      }
+      list.push(span);
+      if (this.emitSpanLines) {
+        this.rawSpans.push({ owner, name: span.name, ms: span.end - span.start });
+      }
+    }
+
+    for (const [owner, byName] of byOwner) {
+      const record = owner === null ? this.suiteRecord : this.recordsByName.get(owner);
+      if (!record) {
+        continue;
+      }
+      const aggregates = {};
+      for (const [name, list] of byName) {
+        aggregates[name] = this.aggregateSpans(list);
+      }
+      record.spans = aggregates;
+      // Back-compat: the legacy fn-span buckets are derived from the top-level env spawn/teardown tags.
+      // The top-level setup is tagged `spawn:env:<proverMode>` (the mode is a closed set, distinct from
+      // the `:anvil`/`:l1-deploy`/... sub-phase tags), so sum those three exact tags.
+      const setupFnMs =
+        (aggregates['spawn:env:none']?.totalMs ?? 0) +
+        (aggregates['spawn:env:fake']?.totalMs ?? 0) +
+        (aggregates['spawn:env:real']?.totalMs ?? 0);
+      record.setupFnMs = setupFnMs + (record.setupFnMs ?? 0);
+      record.teardownFnMs = (aggregates['teardown:env']?.totalMs ?? 0) + (record.teardownFnMs ?? 0);
+    }
+    this.collector.spans = [];
+  }
+
+  /** Folds spans into records, finalizes the suite-scoped record, and writes all JSONL. */
   finalizeAndFlush() {
     if (this.flushed || !this.timingFile) {
       return;
     }
     this.flushed = true;
-    const suite = {
-      setupFnMs: 0,
-      beforeHooksMs: this.suiteRecord.beforeHooksMs,
-      teardownFnMs: 0,
-      afterHooksMs: this.suiteRecord.afterHooksMs,
-    };
-    for (const span of this.collector.fnSpans) {
-      if (span.name === null || span.name === undefined) {
-        if (span.kind === 'setup') {
-          suite.setupFnMs += span.ms;
-        } else if (span.kind === 'teardown') {
-          suite.teardownFnMs += span.ms;
-        }
-      }
-    }
-    this.collector.fnSpans = [];
+    this.foldSpans();
 
     const lines = [];
     for (const record of this.records) {
@@ -225,13 +300,17 @@ export default class TimingEnvironment extends CustomEnvironment {
         type: 'suite',
         name: null,
         status: 'passed',
-        setupFnMs: suite.setupFnMs,
-        beforeHooksMs: suite.beforeHooksMs,
-        teardownFnMs: suite.teardownFnMs,
-        afterHooksMs: suite.afterHooksMs,
-        totalMs: suite.beforeHooksMs + suite.afterHooksMs,
+        setupFnMs: this.suiteRecord.setupFnMs ?? 0,
+        beforeHooksMs: this.suiteRecord.beforeHooksMs,
+        teardownFnMs: this.suiteRecord.teardownFnMs ?? 0,
+        afterHooksMs: this.suiteRecord.afterHooksMs,
+        totalMs: this.suiteRecord.beforeHooksMs + this.suiteRecord.afterHooksMs,
+        spans: this.suiteRecord.spans,
       }),
     );
+    for (const raw of this.rawSpans) {
+      lines.push(this.toLine({ type: 'span', name: raw.owner, span: raw.name, ms: raw.ms }));
+    }
 
     const payload = lines.join('\n') + '\n';
     try {
@@ -246,12 +325,22 @@ export default class TimingEnvironment extends CustomEnvironment {
     }
   }
 
-  /** Flattens metadata onto a record and serializes to a single JSON line. */
+  /** Flattens metadata onto a record and serializes to a single JSON line, rounding all Ms fields. */
   toLine(record) {
     const obj = { suite: this.suite, ...record, ...this.meta };
     for (const key of Object.keys(obj)) {
       if (key.endsWith('Ms') && typeof obj[key] === 'number') {
         obj[key] = Math.round(obj[key]);
+      }
+    }
+    // Round the nested span aggregates' Ms fields too (totalMs/busyMs/maxMs per tag).
+    if (obj.spans && typeof obj.spans === 'object') {
+      for (const agg of Object.values(obj.spans)) {
+        for (const key of Object.keys(agg)) {
+          if (key.endsWith('Ms') && typeof agg[key] === 'number') {
+            agg[key] = Math.round(agg[key]);
+          }
+        }
       }
     }
     return JSON.stringify(obj);

--- a/yarn-project/end-to-end/src/shared/timing_env.test.ts
+++ b/yarn-project/end-to-end/src/shared/timing_env.test.ts
@@ -1,0 +1,101 @@
+import { aggregateSpans, foldSpansInto } from './timing_env.mjs';
+
+describe('aggregateSpans', () => {
+  it('sums serial non-overlapping spans', () => {
+    expect(
+      aggregateSpans([
+        { start: 0, end: 10 },
+        { start: 20, end: 30 },
+      ]),
+    ).toEqual({ count: 2, totalMs: 20, busyMs: 20, maxMs: 10 });
+  });
+
+  it('collapses concurrent spans into their union for busyMs', () => {
+    const result = aggregateSpans([
+      { start: 0, end: 100 },
+      { start: 10, end: 50 },
+      { start: 20, end: 120 },
+    ]);
+    // totalMs naively sums all three (100 + 40 + 100); busyMs is the union [0, 120).
+    expect(result).toEqual({ count: 3, totalMs: 240, busyMs: 120, maxMs: 100 });
+    // The concurrency property: union wall-clock is strictly below the naive sum.
+    expect(result.busyMs).toBeLessThan(result.totalMs);
+  });
+
+  it('handles fully nested spans', () => {
+    expect(
+      aggregateSpans([
+        { start: 0, end: 100 },
+        { start: 10, end: 20 },
+      ]),
+    ).toEqual({ count: 2, totalMs: 110, busyMs: 100, maxMs: 100 });
+  });
+
+  it('treats touching spans as one contiguous interval', () => {
+    expect(
+      aggregateSpans([
+        { start: 0, end: 5 },
+        { start: 5, end: 10 },
+      ]),
+    ).toEqual({ count: 2, totalMs: 10, busyMs: 10, maxMs: 5 });
+  });
+
+  it('keeps a gap between disjoint spans out of busyMs', () => {
+    expect(
+      aggregateSpans([
+        { start: 0, end: 5 },
+        { start: 6, end: 10 },
+      ]),
+    ).toEqual({ count: 2, totalMs: 9, busyMs: 9, maxMs: 5 });
+  });
+
+  it('sorts internally and does not mutate the caller array when input is unsorted', () => {
+    const input = [
+      { start: 20, end: 120 },
+      { start: 10, end: 50 },
+      { start: 0, end: 100 },
+    ];
+    const snapshot = input.map(s => ({ ...s }));
+    const result = aggregateSpans(input);
+    expect(result.busyMs).toEqual(120);
+    expect(input).toEqual(snapshot);
+  });
+});
+
+describe('foldSpansInto', () => {
+  it('attaches per-tag aggregates and derives setup/teardown from the renamed setup:env keys', () => {
+    const testRecord: Record<string, unknown> = { type: 'test', name: 'suite testA', setupFnMs: 0, teardownFnMs: 0 };
+    const recordsByName = new Map([['suite testA', testRecord]]);
+    const suiteRecord: Record<string, unknown> = { name: null, beforeHooksMs: 0, afterHooksMs: 0 };
+
+    const spans = [
+      { owner: 'suite testA', name: 'wait:block', start: 0, end: 10 },
+      { owner: 'suite testA', name: 'wait:block', start: 20, end: 35 },
+      { owner: null, name: 'setup:env:fake', start: 0, end: 500 },
+      { owner: null, name: 'teardown:env', start: 600, end: 700 },
+      { owner: 'other:mempool-feeder', name: 'wait:block', start: 0, end: 999 },
+    ];
+
+    const rawSpans = foldSpansInto(spans, { recordsByName, suiteRecord });
+
+    const testSpans = testRecord.spans as Record<string, unknown>;
+    expect(testSpans['wait:block']).toEqual({ count: 2, totalMs: 25, busyMs: 25, maxMs: 15 });
+    // Back-compat derivation reads the renamed `setup:env:fake` tag; a 0 here means Rename B was missed.
+    expect(suiteRecord.setupFnMs).toEqual(500);
+    expect(suiteRecord.teardownFnMs).toEqual(100);
+    // The unknown owner matches no record, so nothing is attributed to it and no record is created.
+    expect(recordsByName.has('other:mempool-feeder')).toBe(false);
+    // No per-occurrence lines unless emitSpanLines is set.
+    expect(rawSpans).toEqual([]);
+  });
+
+  it('emits per-occurrence raw spans only when emitSpanLines is set', () => {
+    const recordsByName = new Map();
+    const suiteRecord = { name: null };
+    const spans = [{ owner: null, name: 'setup:env:none', start: 0, end: 7 }];
+
+    expect(foldSpansInto(spans, { recordsByName, suiteRecord, emitSpanLines: true })).toEqual([
+      { owner: null, name: 'setup:env:none', ms: 7 },
+    ]);
+  });
+});

--- a/yarn-project/end-to-end/src/single-node/single_node_test_context.ts
+++ b/yarn-project/end-to-end/src/single-node/single_node_test_context.ts
@@ -46,6 +46,7 @@ import {
   SCHNORR_HARDCODED_PRIVATE_KEY,
   SchnorrHardcodedKeyAccountContract,
 } from '../fixtures/schnorr_hardcoded_account_contract.js';
+import { span } from '../fixtures/timing.js';
 import {
   type EndToEndContext,
   type SetupOptions,
@@ -361,30 +362,34 @@ export class SingleNodeTestContext {
     const proverNodePrivateKey = this.getNextPrivateKey();
     const proverIndex = this.proverNodes.length + 1;
     const { mockGossipSubNetwork } = this.context;
-    const { proverNode } = await withLoggerBindings({ actor: `prover-${proverIndex}` }, () =>
-      createAndSyncProverNode(
-        proverNodePrivateKey,
-        {
-          ...this.context.config,
-          p2pEnabled: this.context.config.p2pEnabled || mockGossipSubNetwork !== undefined,
-          proverId: EthAddress.fromNumber(proverIndex),
-          dontStart: opts.dontStart,
-          ...opts,
-        },
-        {
-          dataDirectory: join(this.context.config.dataDirectory!, randomBytes(8).toString('hex')),
-        },
-        {
-          dateProvider: this.context.dateProvider,
-          p2pClientDeps: {
-            p2pServiceFactory: mockGossipSubNetwork ? getMockPubSubP2PServiceFactory(mockGossipSubNetwork) : undefined,
-            rpcTxProviders: [this.context.aztecNode],
+    const { proverNode } = await span('spawn:node', () =>
+      withLoggerBindings({ actor: `prover-${proverIndex}` }, () =>
+        createAndSyncProverNode(
+          proverNodePrivateKey,
+          {
+            ...this.context.config,
+            p2pEnabled: this.context.config.p2pEnabled || mockGossipSubNetwork !== undefined,
+            proverId: EthAddress.fromNumber(proverIndex),
+            dontStart: opts.dontStart,
+            ...opts,
           },
-        },
-        {
-          genesis: this.context.genesis,
-          dontStart: opts.dontStart,
-        },
+          {
+            dataDirectory: join(this.context.config.dataDirectory!, randomBytes(8).toString('hex')),
+          },
+          {
+            dateProvider: this.context.dateProvider,
+            p2pClientDeps: {
+              p2pServiceFactory: mockGossipSubNetwork
+                ? getMockPubSubP2PServiceFactory(mockGossipSubNetwork)
+                : undefined,
+              rpcTxProviders: [this.context.aztecNode],
+            },
+          },
+          {
+            genesis: this.context.genesis,
+            dontStart: opts.dontStart,
+          },
+        ),
       ),
     );
     this.proverNodes.push(proverNode);
@@ -408,27 +413,31 @@ export class SingleNodeTestContext {
     const resolvedConfig = { ...this.context.config, ...opts };
     const p2pEnabled = resolvedConfig.p2pEnabled || mockGossipSubNetwork !== undefined;
     const p2pIp = resolvedConfig.p2pIp ?? (p2pEnabled ? '127.0.0.1' : undefined);
-    const node = await withLoggerBindings({ actor: `${actorPrefix}-${nodeIndex}` }, () =>
-      createAztecNodeService(
-        {
-          ...resolvedConfig,
-          dataDirectory: join(this.context.config.dataDirectory!, randomBytes(8).toString('hex')),
-          validatorPrivateKeys: opts.validatorPrivateKeys ?? new SecretValue([]),
-          nodeId: resolvedConfig.nodeId || `${actorPrefix}-${nodeIndex}`,
-          p2pEnabled,
-          p2pIp,
-        },
-        {
-          dateProvider: this.context.dateProvider,
-          p2pClientDeps: {
-            p2pServiceFactory: mockGossipSubNetwork ? getMockPubSubP2PServiceFactory(mockGossipSubNetwork) : undefined,
+    const node = await span('spawn:node', () =>
+      withLoggerBindings({ actor: `${actorPrefix}-${nodeIndex}` }, () =>
+        createAztecNodeService(
+          {
+            ...resolvedConfig,
+            dataDirectory: join(this.context.config.dataDirectory!, randomBytes(8).toString('hex')),
+            validatorPrivateKeys: opts.validatorPrivateKeys ?? new SecretValue([]),
+            nodeId: resolvedConfig.nodeId || `${actorPrefix}-${nodeIndex}`,
+            p2pEnabled,
+            p2pIp,
           },
-          slashingProtectionDb: opts.slashingProtectionDb,
-        },
-        {
-          genesis: this.context.genesis,
-          ...opts,
-        },
+          {
+            dateProvider: this.context.dateProvider,
+            p2pClientDeps: {
+              p2pServiceFactory: mockGossipSubNetwork
+                ? getMockPubSubP2PServiceFactory(mockGossipSubNetwork)
+                : undefined,
+            },
+            slashingProtectionDb: opts.slashingProtectionDb,
+          },
+          {
+            genesis: this.context.genesis,
+            ...opts,
+          },
+        ),
       ),
     );
 
@@ -448,11 +457,13 @@ export class SingleNodeTestContext {
     // Cover at least two full epochs of wall time so callers issuing the wait mid-epoch
     // still have headroom — the prior `30 * epochDuration` mixed units (slots vs seconds)
     // and timed out at 120s for configs whose epoch wall time is 144s+.
-    await waitUntilL1Timestamp(
-      this.l1Client,
-      start - BigInt(this.L1_BLOCK_TIME_IN_S),
-      undefined,
-      2 * this.epochDuration * this.L2_SLOT_DURATION_IN_S,
+    await span('wait:epoch', () =>
+      waitUntilL1Timestamp(
+        this.l1Client,
+        start - BigInt(this.L1_BLOCK_TIME_IN_S),
+        undefined,
+        2 * this.epochDuration * this.L2_SLOT_DURATION_IN_S,
+      ),
     );
     return start;
   }
@@ -531,21 +542,25 @@ export class SingleNodeTestContext {
 
   /** Waits until the given checkpoint number is mined. */
   public async waitUntilCheckpointNumber(target: CheckpointNumber, timeout = 120) {
-    await retryUntil(
-      () => Promise.resolve(target <= this.monitor.checkpointNumber),
-      `Wait until checkpoint ${target}`,
-      timeout,
-      0.1,
+    await span('wait:checkpoint', () =>
+      retryUntil(
+        () => Promise.resolve(target <= this.monitor.checkpointNumber),
+        `Wait until checkpoint ${target}`,
+        timeout,
+        0.1,
+      ),
     );
   }
 
   /** Waits until the given checkpoint number is marked as proven. */
   public async waitUntilProvenCheckpointNumber(target: CheckpointNumber, timeout = 120) {
-    await retryUntil(
-      () => Promise.resolve(target <= this.monitor.provenCheckpointNumber),
-      `Wait proven checkpoint ${target}`,
-      timeout,
-      0.1,
+    await span('wait:proven-checkpoint', () =>
+      retryUntil(
+        () => Promise.resolve(target <= this.monitor.provenCheckpointNumber),
+        `Wait proven checkpoint ${target}`,
+        timeout,
+        0.1,
+      ),
     );
     return this.monitor.provenCheckpointNumber;
   }
@@ -561,7 +576,9 @@ export class SingleNodeTestContext {
     // Use a timeout that accounts for the full proof submission window
     const proofSubmissionWindowDuration =
       this.constants.proofSubmissionEpochs * this.epochDuration * this.L2_SLOT_DURATION_IN_S;
-    await waitUntilL1Timestamp(this.l1Client, oneSlotBefore, undefined, proofSubmissionWindowDuration * 2);
+    await span('wait:proof-window', () =>
+      waitUntilL1Timestamp(this.l1Client, oneSlotBefore, undefined, proofSubmissionWindowDuration * 2),
+    );
   }
 
   /**
@@ -599,29 +616,31 @@ export class SingleNodeTestContext {
     const target = this.buildWindowTimestampForSlot(slot, { lead: opts.lead });
     const timeout = opts.timeout ?? this.L2_SLOT_DURATION_IN_S * 3;
     this.logger.info(`Waiting until L1 reaches build window of slot ${slot}`, { slot, target });
-    await waitUntilL1Timestamp(this.l1Client, target, undefined, timeout);
+    await span('wait:slot', () => waitUntilL1Timestamp(this.l1Client, target, undefined, timeout));
     return slot;
   }
 
   /** Waits for the aztec node to sync to the target block number. */
   public async waitForNodeToSync(blockNumber: BlockNumber, type: 'proven' | 'finalized' | 'historic') {
     const waitTime = ARCHIVER_POLL_INTERVAL + WORLD_STATE_BLOCK_CHECK_INTERVAL;
-    let synched = false;
-    while (!synched) {
-      await sleep(waitTime);
-      const [syncState, tips] = await Promise.all([
-        this.context.aztecNode.getWorldStateSyncStatus(),
-        await this.context.aztecNode.getChainTips(),
-      ]);
-      this.logger.info(`Wait for node synch ${blockNumber} ${type}`, { blockNumber, type, syncState, tips });
-      if (type === 'proven') {
-        synched = tips.proven.block.number >= blockNumber && syncState.latestBlockNumber >= blockNumber;
-      } else if (type === 'finalized') {
-        synched = syncState.finalizedBlockNumber >= blockNumber;
-      } else {
-        synched = syncState.oldestHistoricBlockNumber >= blockNumber;
+    await span('wait:node-sync', async () => {
+      let synched = false;
+      while (!synched) {
+        await sleep(waitTime);
+        const [syncState, tips] = await Promise.all([
+          this.context.aztecNode.getWorldStateSyncStatus(),
+          await this.context.aztecNode.getChainTips(),
+        ]);
+        this.logger.info(`Wait for node synch ${blockNumber} ${type}`, { blockNumber, type, syncState, tips });
+        if (type === 'proven') {
+          synched = tips.proven.block.number >= blockNumber && syncState.latestBlockNumber >= blockNumber;
+        } else if (type === 'finalized') {
+          synched = syncState.finalizedBlockNumber >= blockNumber;
+        } else {
+          synched = syncState.oldestHistoricBlockNumber >= blockNumber;
+        }
       }
-    }
+    });
   }
 
   /**
@@ -635,16 +654,18 @@ export class SingleNodeTestContext {
     opts: { timeout?: number } = {},
   ): Promise<void> {
     const proverIds = this.proverNodes.map(node => node.getProverNode()!.getProverId());
-    await retryUntil(
-      async () => {
-        const haveSubmitted = await Promise.all(
-          proverIds.map(proverId => this.rollup.getHasSubmittedProof(epoch, epochLength, proverId)),
-        );
-        this.logger.info(`Proof submissions: ${haveSubmitted.join(', ')}`);
-        return haveSubmitted.every(submitted => submitted);
-      },
-      'Provers have submitted proofs',
-      opts.timeout ?? 120,
+    await span('wait:proof-submitted', () =>
+      retryUntil(
+        async () => {
+          const haveSubmitted = await Promise.all(
+            proverIds.map(proverId => this.rollup.getHasSubmittedProof(epoch, epochLength, proverId)),
+          );
+          this.logger.info(`Proof submissions: ${haveSubmitted.join(', ')}`);
+          return haveSubmitted.every(submitted => submitted);
+        },
+        'Provers have submitted proofs',
+        opts.timeout ?? 120,
+      ),
     );
   }
 
@@ -911,20 +932,24 @@ export class SingleNodeTestContext {
     opts: { timeout?: number } = {},
   ): Promise<Parameters<SequencerEvents[E]>[0]> {
     const timeout = opts.timeout ?? 60_000;
-    return executeTimeout(
-      signal =>
-        new Promise<Parameters<SequencerEvents[E]>[0]>(resolve => {
-          const listener = (args: Parameters<SequencerEvents[E]>[0]) => {
-            if (match(args)) {
-              sequencer.off(event, listener as SequencerEvents[E]);
-              resolve(args);
-            }
-          };
-          signal.addEventListener('abort', () => sequencer.off(event, listener as SequencerEvents[E]), { once: true });
-          sequencer.on(event, listener as SequencerEvents[E]);
-        }),
-      timeout,
-      `wait for sequencer event ${String(event)}`,
+    return span('wait:sequencer-state', () =>
+      executeTimeout(
+        signal =>
+          new Promise<Parameters<SequencerEvents[E]>[0]>(resolve => {
+            const listener = (args: Parameters<SequencerEvents[E]>[0]) => {
+              if (match(args)) {
+                sequencer.off(event, listener as SequencerEvents[E]);
+                resolve(args);
+              }
+            };
+            signal.addEventListener('abort', () => sequencer.off(event, listener as SequencerEvents[E]), {
+              once: true,
+            });
+            sequencer.on(event, listener as SequencerEvents[E]);
+          }),
+        timeout,
+        `wait for sequencer event ${String(event)}`,
+      ),
     );
   }
 

--- a/yarn-project/end-to-end/src/single-node/single_node_test_context.ts
+++ b/yarn-project/end-to-end/src/single-node/single_node_test_context.ts
@@ -46,7 +46,7 @@ import {
   SCHNORR_HARDCODED_PRIVATE_KEY,
   SchnorrHardcodedKeyAccountContract,
 } from '../fixtures/schnorr_hardcoded_account_contract.js';
-import { span } from '../fixtures/timing.js';
+import { testSpan } from '../fixtures/timing.js';
 import {
   type EndToEndContext,
   type SetupOptions,
@@ -362,7 +362,7 @@ export class SingleNodeTestContext {
     const proverNodePrivateKey = this.getNextPrivateKey();
     const proverIndex = this.proverNodes.length + 1;
     const { mockGossipSubNetwork } = this.context;
-    const { proverNode } = await span('spawn:node', () =>
+    const { proverNode } = await testSpan('setup:node', () =>
       withLoggerBindings({ actor: `prover-${proverIndex}` }, () =>
         createAndSyncProverNode(
           proverNodePrivateKey,
@@ -413,7 +413,7 @@ export class SingleNodeTestContext {
     const resolvedConfig = { ...this.context.config, ...opts };
     const p2pEnabled = resolvedConfig.p2pEnabled || mockGossipSubNetwork !== undefined;
     const p2pIp = resolvedConfig.p2pIp ?? (p2pEnabled ? '127.0.0.1' : undefined);
-    const node = await span('spawn:node', () =>
+    const node = await testSpan('setup:node', () =>
       withLoggerBindings({ actor: `${actorPrefix}-${nodeIndex}` }, () =>
         createAztecNodeService(
           {
@@ -457,7 +457,7 @@ export class SingleNodeTestContext {
     // Cover at least two full epochs of wall time so callers issuing the wait mid-epoch
     // still have headroom — the prior `30 * epochDuration` mixed units (slots vs seconds)
     // and timed out at 120s for configs whose epoch wall time is 144s+.
-    await span('wait:epoch', () =>
+    await testSpan('wait:epoch', () =>
       waitUntilL1Timestamp(
         this.l1Client,
         start - BigInt(this.L1_BLOCK_TIME_IN_S),
@@ -542,7 +542,7 @@ export class SingleNodeTestContext {
 
   /** Waits until the given checkpoint number is mined. */
   public async waitUntilCheckpointNumber(target: CheckpointNumber, timeout = 120) {
-    await span('wait:checkpoint', () =>
+    await testSpan('wait:checkpoint', () =>
       retryUntil(
         () => Promise.resolve(target <= this.monitor.checkpointNumber),
         `Wait until checkpoint ${target}`,
@@ -554,7 +554,7 @@ export class SingleNodeTestContext {
 
   /** Waits until the given checkpoint number is marked as proven. */
   public async waitUntilProvenCheckpointNumber(target: CheckpointNumber, timeout = 120) {
-    await span('wait:proven-checkpoint', () =>
+    await testSpan('wait:proven-checkpoint', () =>
       retryUntil(
         () => Promise.resolve(target <= this.monitor.provenCheckpointNumber),
         `Wait proven checkpoint ${target}`,
@@ -576,7 +576,7 @@ export class SingleNodeTestContext {
     // Use a timeout that accounts for the full proof submission window
     const proofSubmissionWindowDuration =
       this.constants.proofSubmissionEpochs * this.epochDuration * this.L2_SLOT_DURATION_IN_S;
-    await span('wait:proof-window', () =>
+    await testSpan('wait:proof-window', () =>
       waitUntilL1Timestamp(this.l1Client, oneSlotBefore, undefined, proofSubmissionWindowDuration * 2),
     );
   }
@@ -616,14 +616,14 @@ export class SingleNodeTestContext {
     const target = this.buildWindowTimestampForSlot(slot, { lead: opts.lead });
     const timeout = opts.timeout ?? this.L2_SLOT_DURATION_IN_S * 3;
     this.logger.info(`Waiting until L1 reaches build window of slot ${slot}`, { slot, target });
-    await span('wait:slot', () => waitUntilL1Timestamp(this.l1Client, target, undefined, timeout));
+    await testSpan('wait:slot', () => waitUntilL1Timestamp(this.l1Client, target, undefined, timeout));
     return slot;
   }
 
   /** Waits for the aztec node to sync to the target block number. */
   public async waitForNodeToSync(blockNumber: BlockNumber, type: 'proven' | 'finalized' | 'historic') {
     const waitTime = ARCHIVER_POLL_INTERVAL + WORLD_STATE_BLOCK_CHECK_INTERVAL;
-    await span('wait:node-sync', async () => {
+    await testSpan('wait:node-sync', async () => {
       let synched = false;
       while (!synched) {
         await sleep(waitTime);
@@ -654,7 +654,7 @@ export class SingleNodeTestContext {
     opts: { timeout?: number } = {},
   ): Promise<void> {
     const proverIds = this.proverNodes.map(node => node.getProverNode()!.getProverId());
-    await span('wait:proof-submitted', () =>
+    await testSpan('wait:proof-submitted', () =>
       retryUntil(
         async () => {
           const haveSubmitted = await Promise.all(
@@ -932,7 +932,7 @@ export class SingleNodeTestContext {
     opts: { timeout?: number } = {},
   ): Promise<Parameters<SequencerEvents[E]>[0]> {
     const timeout = opts.timeout ?? 60_000;
-    return span('wait:sequencer-state', () =>
+    return testSpan('wait:sequencer-state', () =>
       executeTimeout(
         signal =>
           new Promise<Parameters<SequencerEvents[E]>[0]>(resolve => {

--- a/yarn-project/end-to-end/src/test-wallet/utils.ts
+++ b/yarn-project/end-to-end/src/test-wallet/utils.ts
@@ -19,7 +19,7 @@ import { type OffchainEffect, type ProvingStats, Tx, TxHash, type TxReceipt } fr
 
 import { inspect } from 'util';
 
-import { span, withSpanOwner } from '../fixtures/timing.js';
+import { testSpan, withTestSpanOwner } from '../fixtures/timing.js';
 import type { TestWallet } from './test_wallet.js';
 
 export type ProvenTxSendOpts = {
@@ -41,7 +41,7 @@ export class ProvenTx extends Tx {
   send(options?: Omit<ProvenTxSendOpts, 'wait'>): Promise<TxReceipt>;
   send<W extends ProvenTxSendOpts['wait']>(options: ProvenTxSendOpts & { wait: W }): Promise<ProvenTxSendReturn<W>>;
   send(options?: ProvenTxSendOpts): Promise<TxHash | TxReceipt> {
-    return span('tx:send', () => this.sendInner(options));
+    return testSpan('tx:send', () => this.sendInner(options));
   }
 
   private async sendInner(options?: ProvenTxSendOpts): Promise<TxHash | TxReceipt> {
@@ -75,7 +75,7 @@ export function proveInteraction(
   interaction: ContractFunctionInteraction | DeployMethod | BatchCall,
   options: SendInteractionOptions | DeployOptions,
 ): Promise<ProvenTx> {
-  return span('tx:prove', async () => {
+  return testSpan('tx:prove', async () => {
     const execPayload = await interaction.request(options);
     return wallet.proveTx(execPayload, toSendOptions(options));
   });
@@ -144,7 +144,7 @@ export function startMempoolFeeder(
   // Pin the feeder's prove/send spans to a fixed non-test owner. It runs interleaved with arbitrary
   // tests, so without this its tx:prove/tx:send spans would smear onto whichever test was current
   // when each round fired; the pinned owner matches no test/suite record, excluding them cleanly.
-  const loop = withSpanOwner('other:mempool-feeder', async () => {
+  const loop = withTestSpanOwner('other:mempool-feeder', async () => {
     while (!stopped) {
       try {
         const pendingCount = await node.getPendingTxCount();

--- a/yarn-project/end-to-end/src/test-wallet/utils.ts
+++ b/yarn-project/end-to-end/src/test-wallet/utils.ts
@@ -19,6 +19,7 @@ import { type OffchainEffect, type ProvingStats, Tx, TxHash, type TxReceipt } fr
 
 import { inspect } from 'util';
 
+import { span, withSpanOwner } from '../fixtures/timing.js';
 import type { TestWallet } from './test_wallet.js';
 
 export type ProvenTxSendOpts = {
@@ -39,7 +40,11 @@ export class ProvenTx extends Tx {
 
   send(options?: Omit<ProvenTxSendOpts, 'wait'>): Promise<TxReceipt>;
   send<W extends ProvenTxSendOpts['wait']>(options: ProvenTxSendOpts & { wait: W }): Promise<ProvenTxSendReturn<W>>;
-  async send(options?: ProvenTxSendOpts): Promise<TxHash | TxReceipt> {
+  send(options?: ProvenTxSendOpts): Promise<TxHash | TxReceipt> {
+    return span('tx:send', () => this.sendInner(options));
+  }
+
+  private async sendInner(options?: ProvenTxSendOpts): Promise<TxHash | TxReceipt> {
     const txHash = this.getTxHash();
     await this.node.sendTx(this).catch(err => {
       throw this.contextualizeError(err, inspect(this));
@@ -65,13 +70,15 @@ export class ProvenTx extends Tx {
   }
 }
 
-export async function proveInteraction(
+export function proveInteraction(
   wallet: TestWallet,
   interaction: ContractFunctionInteraction | DeployMethod | BatchCall,
   options: SendInteractionOptions | DeployOptions,
-) {
-  const execPayload = await interaction.request(options);
-  return wallet.proveTx(execPayload, toSendOptions(options));
+): Promise<ProvenTx> {
+  return span('tx:prove', async () => {
+    const execPayload = await interaction.request(options);
+    return wallet.proveTx(execPayload, toSendOptions(options));
+  });
 }
 
 /** Builds an interaction for index `i` of a batch. */
@@ -134,7 +141,10 @@ export function startMempoolFeeder(
   const intervalMs = opts.intervalMs ?? 1000;
   let stopped = false;
 
-  const loop = (async () => {
+  // Pin the feeder's prove/send spans to a fixed non-test owner. It runs interleaved with arbitrary
+  // tests, so without this its tx:prove/tx:send spans would smear onto whichever test was current
+  // when each round fired; the pinned owner matches no test/suite record, excluding them cleanly.
+  const loop = withSpanOwner('other:mempool-feeder', async () => {
     while (!stopped) {
       try {
         const pendingCount = await node.getPendingTxCount();
@@ -147,7 +157,7 @@ export function startMempoolFeeder(
       }
       await sleep(intervalMs);
     }
-  })();
+  });
 
   return {
     async [Symbol.asyncDispose]() {


### PR DESCRIPTION
## Motivation

A-1178 (#24281) measures each e2e test's wall-clock as four coarse buckets (`setupFnMs`, `beforeHooksMs`, `bodyMs`, `afterHooksMs`). That tells us a test is slow but not *where* it loses time. Most e2e tests spend their wall-clock in the same handful of operations — standing up the environment, waiting for a tx to be mined/checkpointed/proven, waiting for a committee to form or an offense to be detected, client-side proving of seed txs, and warp scans hunting for a proposer slot.

This decomposes that time into **named spans** so a single aggregate query over a full CI run answers *"across the suite, how much total wall-clock goes into proving / spinning up nodes / waiting for checkpoints?"* — a ranked list of where to invest in speedups. It extends A-1178 and builds on the consolidation (#24201/#24310) and helpers (#24404) work that turned each repeated operation into one shared definition, so wrapping it once instruments every test with no per-test edits.

This is **instrumentation / data-gathering only** — no test behavior or timing changes.

## Approach

- A generic `testSpan(name, fn)` / `testSpanSync(name, fn)` wrapper (`fixtures/timing.ts`) records `{ owner, name, start, end }` into the shared collector installed by the timing environment. When `TEST_TIMING_FILE` is unset there is no collector, so `testSpan()` calls `fn()` directly — exactly zero-cost, with no clock reads.
- At flush, the timing environment groups spans by owner then tag and computes four numbers per `(owner, tag)`:
  - `count` — multiplicity is itself a signal (waited for a checkpoint 14× points at a loop to batch).
  - `totalMs` — naive sum (correct for serial repeats).
  - `busyMs` — duration of the **union** of the spans' intervals; concurrency-correct, so a `Promise.all` of 12 concurrent 3s spans reads ~3s instead of ~36s. The `busyMs ≪ totalMs` signature flags work that is run serially where it could be parallel.
  - `maxMs` — longest single occurrence, to catch one pathological wait hiding in a cheap average.
- The aggregates attach as an additive `spans` map on each `type:"test"` / `type:"suite"` JSONL line. `setupFnMs` / `teardownFnMs` are kept for back-compat, now derived from the `setup:env:<mode>` / `teardown:env` tags.
- Tags follow a stable `category:label` taxonomy (`setup:`, `wait:`, `tx:`, `warp:`, `wallet:`, `deploy:`, `other:`), tagged **by concept, not by function** — e.g. every checkpoint waiter maps to `wait:checkpoint` — so a label is a forever aggregation key regardless of which helper a test happened to call.
- **One clock.** All spans use `performance.now()`. I verified Node's `perf_hooks` clock is process-wide: a `performance.now()` taken inside a fresh `vm` context (the jest sandbox realm) shares the same monotonic origin as the host realm (delta ~0.002ms; a fresh `perf_hooks.performance` inside a separate context anchors to the same `timeOrigin`). Interval-merging for `busyMs` across the sandbox and host realms is therefore valid, so **`busyMs` is included** (no fallback to `totalMs`-only needed).
- **Background loop.** `startMempoolFeeder` runs interleaved with arbitrary tests; without care its prove/send spans would smear onto whichever test was current when each round fired. Its production is run inside an `AsyncLocalStorage`-scoped owner override (`other:mempool-feeder`), which pins every span in its async call tree to a fixed owner — isolated from concurrent test-body spans. That owner matches no test/suite record, so the feeder's spans are cleanly excluded from the per-test view.

## Changes by phase

- **Phase 0 — collector + `testSpan()` + flush aggregation.** New `fixtures/timing.ts` (`testSpan`/`testSpanSync`/`withTestSpanOwner`). `timing_env.mjs` collector generalized from `fnSpans` to a `spans` array; `finalizeAndFlush` groups by owner/tag, merges intervals for `busyMs`, attaches the `spans` map, and derives the back-compat fields.
- **Phase 1 — shared waits + `setup:node`.** Wrapped the waiters in `fixtures/wait_helpers.ts` (`wait:proposed` / `wait:proven`, `wait:checkpoint` / `wait:proven-checkpoint`, `wait:tx-mined`, `wait:l2-to-l1-witness`, `wait:pending-tx`, `wait:sequencer-state`) and the wait methods on `SingleNodeTestContext` / `MultiNodeTestContext` (`wait:epoch`, `wait:slot`, `wait:proof-window`, `wait:node-sync`, `wait:proof-submitted`, `wait:offense`, the multi-node `wait:checkpoint`/`wait:proven-checkpoint`/`wait:block` convergence waiters). Wrapped `createNode`/`createProverNode` with `setup:node`.
- **Phase 2 — decompose `setup:env`.** Cracked the opaque setup in `fixtures/setup.ts` into `setup:env:anvil`, `:l1-deploy`, `:sequencer-start`, `:prover-node`, `:pxe`, and `wallet:create`. The top-level `setup:env` is tagged with the prover mode (`setup:env:none` / `:fake` / `:real`) so the three factories are comparable.
- **Phase 3 — tx leaf wraps.** `proveInteraction` → `tx:prove`, `ProvenTx.send` → `tx:send`; everything else (`proveTxs`/`proveAndSendTxs`/the submit helpers) aggregates through those leaves. `startMempoolFeeder` handled as above.
- **Phase 4 — slashing/governance waiters.** Wrapped `awaitCommitteeExists` (`wait:committee`), `awaitOffenseDetected` (`wait:offense`), `awaitCommitteeKicked` (`wait:committee-kicked`), `awaitProposalExecution` (`wait:slash-execution`), and the `findUpcomingProposerSlot` / `advanceToEpochBeforeProposer` / `findSlotsWithProposers` scans (`warp:find-proposer`).
- **Phase 5 — reporting.** The JSONL schema now carries the per-line `spans` map, and `TEST_TIMING_SPANS=1` emits one `type:"span"` line per occurrence (owner, name, ms) for deep dives. The repo now also ships a `track-e2e-times` skill (`yarn-project/.claude/skills/track-e2e-times/`) covering how to **collect and aggregate** the span timings locally: run the suite with `TEST_TIMING_FILE` set, find the per-worker JSONL, and print per-test sums plus the ranked span leaderboard (via the bundled `row.sh`). Only the step of publishing aggregate numbers to a running tracking log remains a separate out-of-band workflow. The leaderboard rollup is a small additive jq over the new `spans` maps:

  ```
  jq -rs '[ .[] | select(.type=="test" or .type=="suite") | (.spans // {}) | to_entries[] ]
    | group_by(.key)
    | map({ tag: .[0].key, count: (map(.value.count) | add),
            busyMs: (map(.value.busyMs) | add), maxMs: (map(.value.maxMs) | max) })
    | sort_by(-.busyMs) | .[] | "\(.busyMs)\t\(.count)\t\(.maxMs)\t\(.tag)"'
  ```

  The existing `row.sh` is unaffected — it filters `type=="test"` and reads the unchanged `setupFnMs`/`bodyMs`/etc., ignoring the new `spans` key and `type:"span"` lines.

## Notes

- `waitForEpoch`/`waitForSlot` (added to `@aztec/ethereum`'s `rollup_cheat_codes.ts` by #24404) are deliberately **not** instrumented in-package: that package should not depend on the e2e timing collector, and the `wait:epoch`/`wait:slot` concepts they cover are already captured at the e2e-context wrapper layer (`waitUntilEpochStarts`, the slot waiters). They have no e2e callers yet; a future call site picks them up via its context wrapper.
- Spans do not partition `bodyMs` — a parent span includes its children, so `sum(spans) ≠ bodyMs`. Tagging is at the leaf wait/setup/tx level where additivity holds; the few intentional nests (e.g. `wait:committee-kicked` contains `wait:slash-execution`) carry distinct tags.

Verified: `yarn build`, `yarn lint end-to-end`, `yarn format --check end-to-end` all pass. The flush aggregation (busyMs interval merge, back-compat derivation, feeder-owner exclusion, opt-in raw lines) is covered by unit tests in `end-to-end/src/shared/timing_env.test.ts`, which exercise the extracted `aggregateSpans` / `foldSpansInto` pure functions directly.

Fixes A-1179



## Example timing output

Each e2e test run in CI emits one JSONL record per test and per suite, carrying a `spans` map keyed by `category:label` tag, where each value is `{count, totalMs, busyMs, maxMs}` (`busyMs` is the de-overlapped union duration, so concurrent occurrences of a span are counted once). An illustrative `type:"test"` line from CI run 28469687883 (commit de3635e74eb):

```json
{
  "suite": "optimistic.parallel",
  "type": "test",
  "name": "single-node/proving/optimistic happy path proves multiple epochs via checkpoint-driven flow",
  "status": "passed",
  "setupFnMs": 4707,
  "beforeHooksMs": 4717,
  "bodyMs": 327324,
  "teardownFnMs": 615,
  "afterHooksMs": 624,
  "totalMs": 332668,
  "startedAt": "2026-06-30T19:20:58.279Z",
  "spans": {
    "setup:env:anvil": {
      "count": 1,
      "totalMs": 82,
      "busyMs": 82,
      "maxMs": 82
    },
    "setup:env:l1-deploy": {
      "count": 1,
      "totalMs": 470,
      "busyMs": 470,
      "maxMs": 470
    },
    "setup:env:sequencer-start": {
      "count": 1,
      "totalMs": 3141,
      "busyMs": 3141,
      "maxMs": 3141
    },
    "setup:env:prover-node": {
      "count": 1,
      "totalMs": 139,
      "busyMs": 139,
      "maxMs": 139
    },
    "setup:env:pxe": {
      "count": 1,
      "totalMs": 391,
      "busyMs": 391,
      "maxMs": 391
    },
    "wallet:create": {
      "count": 1,
      "totalMs": 79,
      "busyMs": 79,
      "maxMs": 79
    },
    "setup:env:fake": {
      "count": 1,
      "totalMs": 4707,
      "busyMs": 4707,
      "maxMs": 4707
    },
    "wait:epoch": {
      "count": 5,
      "totalMs": 180210,
      "busyMs": 180210,
      "maxMs": 36067
    },
    "tx:prove": {
      "count": 4,
      "totalMs": 2123,
      "busyMs": 2123,
      "maxMs": 621
    },
    "tx:send": {
      "count": 4,
      "totalMs": 144305,
      "busyMs": 144305,
      "maxMs": 36124
    },
    "wait:proven-checkpoint": {
      "count": 4,
      "totalMs": 0,
      "busyMs": 0,
      "maxMs": 0
    },
    "wait:node-sync": {
      "count": 4,
      "totalMs": 401,
      "busyMs": 401,
      "maxMs": 101
    },
    "teardown:env": {
      "count": 1,
      "totalMs": 615,
      "busyMs": 615,
      "maxMs": 615
    }
  },
  "commit": "de3635e74eb89071b52939d1583d072ba2c3852c",
  "branch": "spl/a1179-track-common-spans",
  "runId": "28469687883"
}
```

