### PR TITLE
test(e2e): skip token bridge deploy and pre-deploy cross-chain L1 contracts

### DIFF
--- a/yarn-project/end-to-end/src/fixtures/setup.ts
+++ b/yarn-project/end-to-end/src/fixtures/setup.ts
@@ -197,20 +197,14 @@ export type SetupOptions<TDeployExtraL1ContractsReturnType = unknown> = {
    * Deploy extra L1 contracts a test needs here (e.g. a cross-chain token portal + ERC20) so they
    * mine instantly under automine instead of paying the L1 block interval once the node is running
    * (and racing the live sequencer/archiver). The resolved value is exposed on the returned context
-   * as `l1DeployResult`. The hook receives a viem extended L1 client already pointed at the account
-   * selected by `l1ClientAccountIndex`.
+   * as `extraL1DeployResult`. The hook receives setup's L1 deployer client (the same one used to
+   * deploy Multicall3).
    */
-  deployL1Contracts?: (deps: {
+  deployExtraL1Contracts?: (deps: {
     l1Client: ExtendedViemWalletClient;
     deployL1ContractsValues: DeployAztecL1ContractsReturnType;
     logger: Logger;
   }) => Promise<TDeployExtraL1ContractsReturnType>;
-  /**
-   * Mnemonic account index for the L1 client passed to the `deployL1Contracts` hook. Defaults to the
-   * first account; set it when the hook deploys contracts whose owner must match an account the test
-   * later writes with (e.g. a pre-deployed ERC20 minted from the same harness account).
-   */
-  l1ClientAccountIndex?: number;
   /** How many accounts to seed and unlock in anvil. */
   anvilAccounts?: number;
   /** Port to start anvil (defaults to 8545) */
@@ -284,8 +278,8 @@ export type EndToEndContext<TDeployExtraL1ContractsReturnType = unknown> = {
   proverDelayer: Delayer | undefined;
   /** Genesis data used for setting up nodes. */
   genesis: GenesisData | undefined;
-  /** Resolved value of the `deployL1Contracts` setup hook, if one was provided. */
-  l1DeployResult: TDeployExtraL1ContractsReturnType;
+  /** Resolved value of the `deployExtraL1Contracts` setup hook, if one was provided. */
+  extraL1DeployResult: TDeployExtraL1ContractsReturnType;
   /** ACVM config (only set if running locally). */
   acvmConfig: Awaited<ReturnType<typeof getACVMConfig>>;
   /** BB config (only set if running locally). */
@@ -533,21 +527,17 @@ async function setupInner<TDeployExtraL1ContractsReturnType = unknown>(
 
     // Deploy any test-specific L1 contracts while automine is still on and before the node starts,
     // so they mine instantly rather than paying the L1 block interval once the sequencer is live.
-    let l1DeployResult: TDeployExtraL1ContractsReturnType = undefined as TDeployExtraL1ContractsReturnType;
-    if (opts.deployL1Contracts) {
-      logger.trace('Running deployL1Contracts hook');
-      const hookL1Client = createExtendedL1Client(
-        config.l1RpcUrls,
-        MNEMONIC,
-        chain,
-        undefined,
-        opts.l1ClientAccountIndex,
-      );
-      l1DeployResult = await opts.deployL1Contracts({
-        l1Client: hookL1Client,
+    let extraL1DeployResult: TDeployExtraL1ContractsReturnType = undefined as TDeployExtraL1ContractsReturnType;
+    if (opts.deployExtraL1Contracts) {
+      logger.trace('Running deployExtraL1Contracts hook');
+      extraL1DeployResult = await opts.deployExtraL1Contracts({
+        l1Client,
         deployL1ContractsValues,
         logger,
       });
+      // The hook reused `l1Client` to send deploy txs, so refresh viem's nonce cache to avoid a
+      // stale cached nonce for later transactions on the publisher account.
+      await l1Client.getTransactionCount({ address: l1Client.account.address });
     }
 
     if (enableAutomine) {
@@ -755,7 +745,7 @@ async function setupInner<TDeployExtraL1ContractsReturnType = unknown>(
       logger,
       mockGossipSubNetwork,
       genesis,
-      l1DeployResult,
+      extraL1DeployResult,
       proverNode,
       sequencerDelayer,
       proverDelayer,

--- a/yarn-project/end-to-end/src/fixtures/setup.ts
+++ b/yarn-project/end-to-end/src/fixtures/setup.ts
@@ -190,6 +190,20 @@ export type SetupOptions = {
    * that assert on genesis-relative L1 timing need to opt out with `false`.
    */
   automineL1Setup?: boolean;
+  /**
+   * Hook invoked after the Aztec L1 rollup contracts are deployed but BEFORE the node/sequencer
+   * start, while anvil automine is still enabled (when `automineL1Setup` is true, the default).
+   * Deploy extra L1 contracts a test needs here (e.g. a cross-chain token portal + ERC20) so they
+   * mine instantly under automine instead of paying the L1 block interval once the node is running
+   * (and racing the live sequencer/archiver). The resolved value is exposed on the returned context
+   * as `l1DeployResult`.
+   */
+  deployL1Contracts?: (deps: {
+    l1RpcUrls: string[];
+    chain: Chain;
+    deployL1ContractsValues: DeployAztecL1ContractsReturnType;
+    logger: Logger;
+  }) => Promise<unknown>;
   /** How many accounts to seed and unlock in anvil. */
   anvilAccounts?: number;
   /** Port to start anvil (defaults to 8545) */
@@ -263,6 +277,8 @@ export type EndToEndContext = {
   proverDelayer: Delayer | undefined;
   /** Genesis data used for setting up nodes. */
   genesis: GenesisData | undefined;
+  /** Resolved value of the `deployL1Contracts` setup hook, if one was provided. */
+  l1DeployResult: unknown;
   /** ACVM config (only set if running locally). */
   acvmConfig: Awaited<ReturnType<typeof getACVMConfig>>;
   /** BB config (only set if running locally). */
@@ -508,6 +524,19 @@ async function setupInner(
       }
     }
 
+    // Deploy any test-specific L1 contracts while automine is still on and before the node starts,
+    // so they mine instantly rather than paying the L1 block interval once the sequencer is live.
+    let l1DeployResult: unknown;
+    if (opts.deployL1Contracts) {
+      logger.trace('Running deployL1Contracts hook');
+      l1DeployResult = await opts.deployL1Contracts({
+        l1RpcUrls: config.l1RpcUrls,
+        chain,
+        deployL1ContractsValues,
+        logger,
+      });
+    }
+
     if (enableAutomine) {
       await ethCheatCodes.setAutomine(false);
       await ethCheatCodes.setIntervalMining(config.ethereumSlotDuration);
@@ -713,6 +742,7 @@ async function setupInner(
       logger,
       mockGossipSubNetwork,
       genesis,
+      l1DeployResult,
       proverNode,
       sequencerDelayer,
       proverDelayer,

--- a/yarn-project/end-to-end/src/fixtures/setup.ts
+++ b/yarn-project/end-to-end/src/fixtures/setup.ts
@@ -24,6 +24,7 @@ import {
 import type { Delayer } from '@aztec/ethereum/l1-tx-utils';
 import { EthCheatCodes, EthCheatCodesWithState, startAnvil, warmBlobKzg } from '@aztec/ethereum/test';
 import type { Anvil } from '@aztec/ethereum/test';
+import type { ExtendedViemWalletClient } from '@aztec/ethereum/types';
 import { BlockNumber, EpochNumber } from '@aztec/foundation/branded-types';
 import { SecretValue } from '@aztec/foundation/config';
 import { randomBytes } from '@aztec/foundation/crypto/random';
@@ -152,7 +153,7 @@ export async function setupPXEAndGetWallet(
 }
 
 /** Options for the e2e tests setup */
-export type SetupOptions = {
+export type SetupOptions<TDeployExtraL1ContractsReturnType = unknown> = {
   /** State load */
   stateLoad?: string;
   /** Whether to enable metrics collection, if undefined, metrics collection is disabled */
@@ -196,14 +197,20 @@ export type SetupOptions = {
    * Deploy extra L1 contracts a test needs here (e.g. a cross-chain token portal + ERC20) so they
    * mine instantly under automine instead of paying the L1 block interval once the node is running
    * (and racing the live sequencer/archiver). The resolved value is exposed on the returned context
-   * as `l1DeployResult`.
+   * as `l1DeployResult`. The hook receives a viem extended L1 client already pointed at the account
+   * selected by `l1ClientAccountIndex`.
    */
   deployL1Contracts?: (deps: {
-    l1RpcUrls: string[];
-    chain: Chain;
+    l1Client: ExtendedViemWalletClient;
     deployL1ContractsValues: DeployAztecL1ContractsReturnType;
     logger: Logger;
-  }) => Promise<unknown>;
+  }) => Promise<TDeployExtraL1ContractsReturnType>;
+  /**
+   * Mnemonic account index for the L1 client passed to the `deployL1Contracts` hook. Defaults to the
+   * first account; set it when the hook deploys contracts whose owner must match an account the test
+   * later writes with (e.g. a pre-deployed ERC20 minted from the same harness account).
+   */
+  l1ClientAccountIndex?: number;
   /** How many accounts to seed and unlock in anvil. */
   anvilAccounts?: number;
   /** Port to start anvil (defaults to 8545) */
@@ -234,7 +241,7 @@ export type SetupOptions = {
 } & Partial<AztecNodeConfig>;
 
 /** Context for an end-to-end test as returned by the `setup` function */
-export type EndToEndContext = {
+export type EndToEndContext<TDeployExtraL1ContractsReturnType = unknown> = {
   /** The Anvil instance (only set if anvil was started locally). */
   anvil: Anvil | undefined;
   /** The Aztec Node service or client a connected to it. */
@@ -278,7 +285,7 @@ export type EndToEndContext = {
   /** Genesis data used for setting up nodes. */
   genesis: GenesisData | undefined;
   /** Resolved value of the `deployL1Contracts` setup hook, if one was provided. */
-  l1DeployResult: unknown;
+  l1DeployResult: TDeployExtraL1ContractsReturnType;
   /** ACVM config (only set if running locally). */
   acvmConfig: Awaited<ReturnType<typeof getACVMConfig>>;
   /** BB config (only set if running locally). */
@@ -321,12 +328,12 @@ function assertContractArtifactsVersion() {
  * @param opts - Options to pass to the node initialization and to the setup script.
  * @param pxeOpts - Options to pass to the PXE initialization.
  */
-export function setup(
+export function setup<TDeployExtraL1ContractsReturnType = unknown>(
   numberOfAccounts = 1,
-  opts: SetupOptions = {},
+  opts: SetupOptions<TDeployExtraL1ContractsReturnType> = {},
   pxeOpts: Partial<PXEConfig> = {},
   chain: Chain = foundry,
-): Promise<EndToEndContext> {
+): Promise<EndToEndContext<TDeployExtraL1ContractsReturnType>> {
   // Tag the top-level env spin-up with the prover mode (none → fake → real), the largest config-driven
   // swing in setup cost, so the three factories are comparable on the span leaderboard. The internals
   // (anvil / l1-deploy / sequencer-start / pxe / wallet:create) decompose this further.
@@ -341,12 +348,12 @@ export function setup(
   });
 }
 
-async function setupInner(
+async function setupInner<TDeployExtraL1ContractsReturnType = unknown>(
   numberOfAccounts: number,
-  opts: SetupOptions,
+  opts: SetupOptions<TDeployExtraL1ContractsReturnType>,
   pxeOpts: Partial<PXEConfig>,
   chain: Chain,
-): Promise<EndToEndContext> {
+): Promise<EndToEndContext<TDeployExtraL1ContractsReturnType>> {
   assertContractArtifactsVersion();
   const logger = getLogger();
   let anvil: Anvil | undefined;
@@ -526,12 +533,18 @@ async function setupInner(
 
     // Deploy any test-specific L1 contracts while automine is still on and before the node starts,
     // so they mine instantly rather than paying the L1 block interval once the sequencer is live.
-    let l1DeployResult: unknown;
+    let l1DeployResult: TDeployExtraL1ContractsReturnType = undefined as TDeployExtraL1ContractsReturnType;
     if (opts.deployL1Contracts) {
       logger.trace('Running deployL1Contracts hook');
-      l1DeployResult = await opts.deployL1Contracts({
-        l1RpcUrls: config.l1RpcUrls,
+      const hookL1Client = createExtendedL1Client(
+        config.l1RpcUrls,
+        MNEMONIC,
         chain,
+        undefined,
+        opts.l1ClientAccountIndex,
+      );
+      l1DeployResult = await opts.deployL1Contracts({
+        l1Client: hookL1Client,
         deployL1ContractsValues,
         logger,
       });

--- a/yarn-project/end-to-end/src/shared/cross_chain_test_harness.ts
+++ b/yarn-project/end-to-end/src/shared/cross_chain_test_harness.ts
@@ -43,6 +43,7 @@ export async function deployAndInitializeTokenAndBridgeContracts(
   rollupRegistryAddress: EthAddress,
   owner: AztecAddress,
   underlyingERC20Address: EthAddress,
+  predeployedTokenPortalAddress?: EthAddress,
 ): Promise<{
   /**
    * The L2 token contract instance.
@@ -65,8 +66,9 @@ export async function deployAndInitializeTokenAndBridgeContracts(
    */
   underlyingERC20: any;
 }> {
-  // deploy the token portal
-  const { address: tokenPortalAddress } = await deployL1Contract(l1Client, TokenPortalAbi, TokenPortalBytecode);
+  // Deploy the token portal, unless it was already deployed before the node started (under automine).
+  const tokenPortalAddress =
+    predeployedTokenPortalAddress ?? (await deployL1Contract(l1Client, TokenPortalAbi, TokenPortalBytecode)).address;
   const tokenPortal = getContract({
     address: tokenPortalAddress.toString(),
     abi: TokenPortalAbi,
@@ -135,6 +137,7 @@ export class CrossChainTestHarness {
     ownerAddress: AztecAddress,
     logger: Logger,
     underlyingERC20Address: EthAddress,
+    predeployedTokenPortalAddress?: EthAddress,
   ): Promise<CrossChainTestHarness> {
     const ethAccount = EthAddress.fromString((await l1Client.getAddresses())[0]);
     const l1ContractAddresses = (await aztecNode.getNodeInfo()).l1ContractAddresses;
@@ -147,6 +150,7 @@ export class CrossChainTestHarness {
       l1ContractAddresses.registryAddress,
       ownerAddress,
       underlyingERC20Address,
+      predeployedTokenPortalAddress,
     );
     logger.info('Deployed and initialized token, portal and its bridge.');
 

--- a/yarn-project/end-to-end/src/single-node/cross-chain/cross_chain_messaging_test.ts
+++ b/yarn-project/end-to-end/src/single-node/cross-chain/cross_chain_messaging_test.ts
@@ -24,6 +24,8 @@ import type { PXEConfig } from '@aztec/pxe/server';
 import { getEpochAtSlot } from '@aztec/stdlib/epoch-helpers';
 import type { AztecNodeAdmin } from '@aztec/stdlib/interfaces/client';
 
+import { mnemonicToAccount } from 'viem/accounts';
+
 import { MNEMONIC } from '../../fixtures/fixtures.js';
 import { type SetupOptions, ensureAuthRegistryPublished, setup } from '../../fixtures/setup.js';
 import { CrossChainTestHarness } from '../../shared/cross_chain_test_harness.js';
@@ -127,19 +129,23 @@ export class CrossChainMessagingTest extends SingleNodeTestContext {
           ...opts.proverNodeConfig,
           txGatheringTimeoutMs: opts.proverNodeConfig?.txGatheringTimeoutMs ?? 10 * 60 * 1000,
         },
-        // The deploy hook's L1 client must use the harness account index: the pre-deployed ERC20's
-        // owner is set to this account, and the harness later mints from the same account.
-        l1ClientAccountIndex: this.l1HarnessAccountIndex,
         // Deploy the cross-chain token portal + ERC20 before the node starts, while anvil is still
         // automining, instead of paying the L1 block interval for them once the sequencer is live.
-        deployL1Contracts: this.deployTokenBridge
+        deployExtraL1Contracts: this.deployTokenBridge
           ? async ({ l1Client, logger }) => {
+              // The harness mints the underlying ERC20 from `l1HarnessAccountIndex` and `TestERC20.mint`
+              // is onlyMinter, so its owner/initial-minter must be that account even though setup's
+              // publisher client sends the deploy tx.
+              const harnessAddress = mnemonicToAccount(MNEMONIC, {
+                addressIndex: this.l1HarnessAccountIndex ?? 0,
+              }).address;
               const { address: underlyingERC20Address } = await deployL1Contract(
                 l1Client,
                 TestERC20Abi,
                 TestERC20Bytecode,
-                ['Underlying', 'UND', l1Client.account.address],
+                ['Underlying', 'UND', harnessAddress],
               );
+              // The TokenPortal's initialize is permissionless, so it can be deployed by the publisher.
               const { address: tokenPortalAddress } = await deployL1Contract(
                 l1Client,
                 TokenPortalAbi,
@@ -253,7 +259,7 @@ export class CrossChainMessagingTest extends SingleNodeTestContext {
     }
 
     // The ERC20 and token portal were deployed before the node started (under automine) by the
-    // `deployL1Contracts` setup hook above; the harness reuses them and only deploys the L2 token,
+    // `deployExtraL1Contracts` setup hook above; the harness reuses them and only deploys the L2 token,
     // L2 bridge, and the portal init that need the running node.
     const { underlyingERC20Address, tokenPortalAddress: predeployedTokenPortalAddress } = this.preDeployedCrossChainL1!;
 

--- a/yarn-project/end-to-end/src/single-node/cross-chain/cross_chain_messaging_test.ts
+++ b/yarn-project/end-to-end/src/single-node/cross-chain/cross_chain_messaging_test.ts
@@ -13,10 +13,11 @@ import type {
 } from '@aztec/ethereum/deploy-aztec-l1-contracts';
 import { deployL1Contract } from '@aztec/ethereum/deploy-l1-contract';
 import { pickL1ContractAddresses } from '@aztec/ethereum/l1-contract-addresses';
+import type { ExtendedViemWalletClient } from '@aztec/ethereum/types';
 import { EpochNumber } from '@aztec/foundation/branded-types';
 import { retryUntil } from '@aztec/foundation/retry';
 import { sleep } from '@aztec/foundation/sleep';
-import { TestERC20Abi, TestERC20Bytecode } from '@aztec/l1-artifacts';
+import { TestERC20Abi, TestERC20Bytecode, TokenPortalAbi, TokenPortalBytecode } from '@aztec/l1-artifacts';
 import { TokenContract } from '@aztec/noir-contracts.js/Token';
 import { TokenBridgeContract } from '@aztec/noir-contracts.js/TokenBridge';
 import type { PXEConfig } from '@aztec/pxe/server';
@@ -42,6 +43,9 @@ export class CrossChainMessagingTest extends SingleNodeTestContext {
   private deployL1ContractsArgs: Partial<DeployAztecL1ContractsArgs>;
   private pxeOpts: Partial<PXEConfig>;
   private l1HarnessAccountIndex?: number;
+  private deployTokenBridge: boolean;
+  /** L1 token portal + ERC20 deployed before the node started (under automine) by the setup hook. */
+  private preDeployedCrossChainL1?: { underlyingERC20Address: EthAddress; tokenPortalAddress: EthAddress };
   private testName: string;
   aztecNode!: AztecNode;
   aztecNodeConfig!: AztecNodeConfig;
@@ -53,6 +57,8 @@ export class CrossChainMessagingTest extends SingleNodeTestContext {
   user2Address!: AztecAddress;
   crossChainTestHarness!: CrossChainTestHarness;
   ethAccount!: EthAddress;
+  /** L1 client used for cross-chain L1 interactions (token portal, inbox), tied to `l1HarnessAccountIndex`. */
+  harnessL1Client!: ExtendedViemWalletClient;
   l2Token!: TokenContract;
   l2Bridge!: TokenBridgeContract;
 
@@ -78,6 +84,7 @@ export class CrossChainMessagingTest extends SingleNodeTestContext {
     deployL1ContractsArgs: Partial<DeployAztecL1ContractsArgs> = {},
     pxeOpts: Partial<PXEConfig> = {},
     l1HarnessAccountIndex?: number,
+    deployTokenBridge = true,
   ) {
     super();
     this.testName = testName;
@@ -89,6 +96,7 @@ export class CrossChainMessagingTest extends SingleNodeTestContext {
     };
     this.pxeOpts = pxeOpts;
     this.l1HarnessAccountIndex = l1HarnessAccountIndex;
+    this.deployTokenBridge = deployTokenBridge;
     this.requireEpochProven = opts.startProverNode ?? false;
   }
 
@@ -112,6 +120,35 @@ export class CrossChainMessagingTest extends SingleNodeTestContext {
           ...opts.proverNodeConfig,
           txGatheringTimeoutMs: opts.proverNodeConfig?.txGatheringTimeoutMs ?? 10 * 60 * 1000,
         },
+        // Deploy the cross-chain token portal + ERC20 before the node starts, while anvil is still
+        // automining, instead of paying the L1 block interval for them once the sequencer is live.
+        deployL1Contracts: this.deployTokenBridge
+          ? async ({ l1RpcUrls, chain, logger }) => {
+              const harnessL1Client = createExtendedL1Client(
+                l1RpcUrls,
+                MNEMONIC,
+                chain,
+                undefined,
+                this.l1HarnessAccountIndex,
+              );
+              const { address: underlyingERC20Address } = await deployL1Contract(
+                harnessL1Client,
+                TestERC20Abi,
+                TestERC20Bytecode,
+                ['Underlying', 'UND', harnessL1Client.account.address],
+              );
+              const { address: tokenPortalAddress } = await deployL1Contract(
+                harnessL1Client,
+                TokenPortalAbi,
+                TokenPortalBytecode,
+              );
+              this.preDeployedCrossChainL1 = { underlyingERC20Address, tokenPortalAddress };
+              logger.verbose(
+                `Pre-deployed cross-chain L1 ERC20 ${underlyingERC20Address} and portal ${tokenPortalAddress}`,
+              );
+              return this.preDeployedCrossChainL1;
+            }
+          : undefined,
       },
       { ...this.pxeOpts, ...pxeOpts },
     );
@@ -193,12 +230,29 @@ export class CrossChainMessagingTest extends SingleNodeTestContext {
       undefined,
       this.l1HarnessAccountIndex,
     );
+    this.harnessL1Client = harnessL1Client;
+    this.ethAccount = EthAddress.fromString((await harnessL1Client.getAddresses())[0]);
 
-    const underlyingERC20Address = await deployL1Contract(harnessL1Client, TestERC20Abi, TestERC20Bytecode, [
-      'Underlying',
-      'UND',
-      harnessL1Client.account.address,
-    ]).then(({ address }) => address);
+    // L1 contract handles every cross-chain test needs, independent of the token bridge.
+    const l1Client = createExtendedL1Client(this.aztecNodeConfig.l1RpcUrls, MNEMONIC);
+    this.l1Client = l1Client;
+    const l1Contracts = pickL1ContractAddresses(this.aztecNodeConfig);
+    this.rollup = new RollupContract(l1Client, l1Contracts.rollupAddress.toString());
+    this.inbox = new InboxContract(l1Client, l1Contracts.inboxAddress.toString());
+    this.outbox = new OutboxContract(l1Client, l1Contracts.outboxAddress.toString());
+
+    // Tests that only pass arbitrary L1<->L2 messages (not token bridging) never touch the L2 token,
+    // bridge, or portal. Skip the token+portal+bridge deploy (an L1 ERC20, an L1 portal, and two L2
+    // contract deploys plus their init txs) entirely for them.
+    if (!this.deployTokenBridge) {
+      this.logger.info('Skipping token bridge deploy; test only needs L1 handles and ethAccount');
+      return;
+    }
+
+    // The ERC20 and token portal were deployed before the node started (under automine) by the
+    // `deployL1Contracts` setup hook above; the harness reuses them and only deploys the L2 token,
+    // L2 bridge, and the portal init that need the running node.
+    const { underlyingERC20Address, tokenPortalAddress: predeployedTokenPortalAddress } = this.preDeployedCrossChainL1!;
 
     this.logger.verbose(`Setting up cross chain harness...`);
     this.crossChainTestHarness = await CrossChainTestHarness.new(
@@ -208,6 +262,7 @@ export class CrossChainMessagingTest extends SingleNodeTestContext {
       this.ownerAddress,
       this.logger,
       underlyingERC20Address,
+      predeployedTokenPortalAddress,
     );
 
     this.logger.verbose(`L2 token deployed to: ${this.crossChainTestHarness.l2Token.address}`);
@@ -220,14 +275,6 @@ export class CrossChainMessagingTest extends SingleNodeTestContext {
     // There is an issue with the reviver so we are getting strings sometimes. Working around it here.
     this.ethAccount = EthAddress.fromString(crossChainContext.ethAccount.toString());
     const tokenPortalAddress = EthAddress.fromString(crossChainContext.tokenPortal.toString());
-
-    const l1Client = createExtendedL1Client(this.aztecNodeConfig.l1RpcUrls, MNEMONIC);
-    this.l1Client = l1Client;
-
-    const l1Contracts = pickL1ContractAddresses(this.aztecNodeConfig);
-    this.rollup = new RollupContract(l1Client, l1Contracts.rollupAddress.toString());
-    this.inbox = new InboxContract(l1Client, l1Contracts.inboxAddress.toString());
-    this.outbox = new OutboxContract(l1Client, l1Contracts.outboxAddress.toString());
 
     this.crossChainTestHarness = new CrossChainTestHarness(
       this.aztecNode,

--- a/yarn-project/end-to-end/src/single-node/cross-chain/cross_chain_messaging_test.ts
+++ b/yarn-project/end-to-end/src/single-node/cross-chain/cross_chain_messaging_test.ts
@@ -30,6 +30,14 @@ import { CrossChainTestHarness } from '../../shared/cross_chain_test_harness.js'
 import type { TestWallet } from '../../test-wallet/test_wallet.js';
 import { SingleNodeTestContext, type SingleNodeTestOpts } from '../single_node_test_context.js';
 
+/** Optional configuration for {@link CrossChainMessagingTest}. */
+export type CrossChainMessagingTestOpts = {
+  /** Mnemonic account index for the harness L1 client (token portal, inbox, minting). Defaults to the first account. */
+  l1HarnessAccountIndex?: number;
+  /** Whether to deploy the L1/L2 token bridge. Set to false for suites that only pass arbitrary messages. Defaults to true. */
+  deployTokenBridge?: boolean;
+};
+
 /**
  * The cross-chain-messaging harness over the single-node topology: extends {@link SingleNodeTestContext}
  * so it reuses the base node tracking / chain monitor / teardown machinery, but builds its environment
@@ -83,8 +91,7 @@ export class CrossChainMessagingTest extends SingleNodeTestContext {
     opts: SetupOptions = {},
     deployL1ContractsArgs: Partial<DeployAztecL1ContractsArgs> = {},
     pxeOpts: Partial<PXEConfig> = {},
-    l1HarnessAccountIndex?: number,
-    deployTokenBridge = true,
+    crossChainOpts: CrossChainMessagingTestOpts = {},
   ) {
     super();
     this.testName = testName;
@@ -95,8 +102,8 @@ export class CrossChainMessagingTest extends SingleNodeTestContext {
       ...deployL1ContractsArgs,
     };
     this.pxeOpts = pxeOpts;
-    this.l1HarnessAccountIndex = l1HarnessAccountIndex;
-    this.deployTokenBridge = deployTokenBridge;
+    this.l1HarnessAccountIndex = crossChainOpts.l1HarnessAccountIndex;
+    this.deployTokenBridge = crossChainOpts.deployTokenBridge ?? true;
     this.requireEpochProven = opts.startProverNode ?? false;
   }
 
@@ -120,25 +127,21 @@ export class CrossChainMessagingTest extends SingleNodeTestContext {
           ...opts.proverNodeConfig,
           txGatheringTimeoutMs: opts.proverNodeConfig?.txGatheringTimeoutMs ?? 10 * 60 * 1000,
         },
+        // The deploy hook's L1 client must use the harness account index: the pre-deployed ERC20's
+        // owner is set to this account, and the harness later mints from the same account.
+        l1ClientAccountIndex: this.l1HarnessAccountIndex,
         // Deploy the cross-chain token portal + ERC20 before the node starts, while anvil is still
         // automining, instead of paying the L1 block interval for them once the sequencer is live.
         deployL1Contracts: this.deployTokenBridge
-          ? async ({ l1RpcUrls, chain, logger }) => {
-              const harnessL1Client = createExtendedL1Client(
-                l1RpcUrls,
-                MNEMONIC,
-                chain,
-                undefined,
-                this.l1HarnessAccountIndex,
-              );
+          ? async ({ l1Client, logger }) => {
               const { address: underlyingERC20Address } = await deployL1Contract(
-                harnessL1Client,
+                l1Client,
                 TestERC20Abi,
                 TestERC20Bytecode,
-                ['Underlying', 'UND', harnessL1Client.account.address],
+                ['Underlying', 'UND', l1Client.account.address],
               );
               const { address: tokenPortalAddress } = await deployL1Contract(
-                harnessL1Client,
+                l1Client,
                 TokenPortalAbi,
                 TokenPortalBytecode,
               );

--- a/yarn-project/end-to-end/src/single-node/cross-chain/l1_to_l2.parallel.test.ts
+++ b/yarn-project/end-to-end/src/single-node/cross-chain/l1_to_l2.parallel.test.ts
@@ -61,10 +61,9 @@ describe('single-node/cross-chain/l1_to_l2', () => {
       // (e.g. a missed checkpoint publish that prunes the pipelined proposed chain) doesn't
       // drop the wallet's in-flight tx via handlePrunedBlocks.
       { syncChainTip: 'checkpointed' },
-      L1_DIRECT_WRITE_ACCOUNT_INDEX,
       // This suite only passes arbitrary L1→L2 messages to its own TestContract; it never bridges
       // tokens, so skip the token+portal+bridge deploy and use the test's L1 handles directly.
-      false,
+      { l1HarnessAccountIndex: L1_DIRECT_WRITE_ACCOUNT_INDEX, deployTokenBridge: false },
     );
     await t.setup();
 

--- a/yarn-project/end-to-end/src/single-node/cross-chain/l1_to_l2.parallel.test.ts
+++ b/yarn-project/end-to-end/src/single-node/cross-chain/l1_to_l2.parallel.test.ts
@@ -17,7 +17,6 @@ import { jest } from '@jest/globals';
 import { L1_DIRECT_WRITE_ACCOUNT_INDEX, PIPELINING_SETUP_OPTS } from '../../fixtures/fixtures.js';
 import { sendL1ToL2Message } from '../../fixtures/l1_to_l2_messaging.js';
 import { waitForBlockNumber } from '../../fixtures/wait_helpers.js';
-import type { CrossChainTestHarness } from '../../shared/cross_chain_test_harness.js';
 import { CrossChainMessagingTest } from './cross_chain_messaging_test.js';
 
 jest.setTimeout(300_000);
@@ -30,7 +29,6 @@ jest.setTimeout(300_000);
 describe('single-node/cross-chain/l1_to_l2', () => {
   let t: CrossChainMessagingTest;
   let log: Logger;
-  let crossChainTestHarness: CrossChainTestHarness;
   let aztecNode: AztecNode;
   let wallet: Wallet;
   let user1Address: AztecAddress;
@@ -64,16 +62,27 @@ describe('single-node/cross-chain/l1_to_l2', () => {
       // drop the wallet's in-flight tx via handlePrunedBlocks.
       { syncChainTip: 'checkpointed' },
       L1_DIRECT_WRITE_ACCOUNT_INDEX,
+      // This suite only passes arbitrary L1→L2 messages to its own TestContract; it never bridges
+      // tokens, so skip the token+portal+bridge deploy and use the test's L1 handles directly.
+      false,
     );
     await t.setup();
 
-    ({ logger: log, crossChainTestHarness, wallet, user1Address, aztecNode } = t);
+    ({ logger: log, wallet, user1Address, aztecNode } = t);
     ({ contract: testContract } = await TestContract.deploy(wallet).send({ from: user1Address }));
   }, 300_000);
 
   afterEach(async () => {
     await t.teardown();
   });
+
+  // Sends an L1→L2 message from the harness L1 account. This suite skips the token bridge, so the
+  // message context is built from the test's L1 handles rather than a CrossChainTestHarness.
+  const sendMessageToL2 = (message: { recipient: AztecAddress; content: Fr; secretHash: Fr }) =>
+    sendL1ToL2Message(message, {
+      l1Client: t.harnessL1Client,
+      l1ContractAddresses: t.deployL1ContractsValues.l1ContractAddresses,
+    });
 
   const getConsumeMethod = (scope: 'private' | 'public') =>
     scope === 'private'
@@ -183,10 +192,7 @@ describe('single-node/cross-chain/l1_to_l2', () => {
     // Generate and send the message to the L1 contract
     const [secret, secretHash] = await generateClaimSecret();
     const message = { recipient: testContract.address, content: Fr.random(), secretHash };
-    const { msgHash: message1Hash, globalLeafIndex: actualMessage1Index } = await sendL1ToL2Message(
-      message,
-      crossChainTestHarness,
-    );
+    const { msgHash: message1Hash, globalLeafIndex: actualMessage1Index } = await sendMessageToL2(message);
 
     await waitForMessageReady(message1Hash, scope);
 
@@ -194,7 +200,7 @@ describe('single-node/cross-chain/l1_to_l2', () => {
     expect(actualMessage1Index.toBigInt()).toBe(message1Index);
 
     const sendConsumeMsgTx = async (index: Fr) => {
-      const call = getConsumeMethod(scope)(message.content, secret, crossChainTestHarness.ethAccount, index);
+      const call = getConsumeMethod(scope)(message.content, secret, t.ethAccount, index);
       if (scope === 'public') {
         await call.simulate({ from: user1Address });
       }
@@ -206,10 +212,7 @@ describe('single-node/cross-chain/l1_to_l2', () => {
 
     // We send and consume the exact same message the second time to test that oracles correctly return the new
     // non-nullified message
-    const { msgHash: message2Hash, globalLeafIndex: actualMessage2Index } = await sendL1ToL2Message(
-      message,
-      crossChainTestHarness,
-    );
+    const { msgHash: message2Hash, globalLeafIndex: actualMessage2Index } = await sendMessageToL2(message);
 
     // We check that the duplicate message was correctly inserted by checking that its message index is defined
     await waitForMessageReady(message2Hash, scope);
@@ -268,7 +271,7 @@ describe('single-node/cross-chain/l1_to_l2', () => {
     log.warn(`Sending L1 to L2 message`);
     const [secret, secretHash] = await generateClaimSecret();
     const message = { recipient: testContract.address, content: Fr.random(), secretHash };
-    const { msgHash, globalLeafIndex } = await sendL1ToL2Message(message, crossChainTestHarness);
+    const { msgHash, globalLeafIndex } = await sendMessageToL2(message);
 
     // Wait until the Aztec node has synced it
     const msgCheckpointNumber = await waitForMessageFetched(msgHash);
@@ -295,8 +298,7 @@ describe('single-node/cross-chain/l1_to_l2', () => {
     expect(await aztecNode.getL1ToL2MessageMembershipWitness('latest', msgHash)).toBeUndefined();
 
     // Define L2 function to consume the message
-    const consume = () =>
-      getConsumeMethod(scope)(message.content, secret, crossChainTestHarness.ethAccount, globalLeafIndex);
+    const consume = () => getConsumeMethod(scope)(message.content, secret, t.ethAccount, globalLeafIndex);
 
     // Wait until the message is ready to be consumed, checking that it cannot be consumed beforehand
     await waitForMessageReady(msgHash, scope, async () => {

--- a/yarn-project/end-to-end/src/single-node/cross-chain/l2_to_l1.parallel.test.ts
+++ b/yarn-project/end-to-end/src/single-node/cross-chain/l2_to_l1.parallel.test.ts
@@ -17,7 +17,6 @@ import { type Hex, decodeEventLog } from 'viem';
 
 import { PIPELINING_SETUP_OPTS } from '../../fixtures/fixtures.js';
 import { waitForSequencerState } from '../../fixtures/wait_helpers.js';
-import type { CrossChainTestHarness } from '../../shared/cross_chain_test_harness.js';
 import { CrossChainMessagingTest } from './cross_chain_messaging_test.js';
 
 // L2→L1 messaging via Outbox: tree structure, multi-tx blocks, and multi-block checkpoints.
@@ -29,9 +28,10 @@ describe('single-node/cross-chain/l2_to_l1', () => {
   // multi-tx flows exceed the default 300s per-test budget.
   jest.setTimeout(15 * 60 * 1000);
 
-  const t = new CrossChainMessagingTest('l2_to_l1', { startProverNode: true });
+  // This suite only passes arbitrary L2→L1 messages from its own TestContract; it never bridges
+  // tokens, so skip the token+portal+bridge deploy (last arg) and use the test's L1 handles directly.
+  const t = new CrossChainMessagingTest('l2_to_l1', { startProverNode: true }, {}, {}, undefined, false);
 
-  let crossChainTestHarness: CrossChainTestHarness;
   let aztecNode: AztecNode;
   let aztecNodeAdmin: AztecNodeAdmin;
   let msgSender: EthAddress;
@@ -46,7 +46,7 @@ describe('single-node/cross-chain/l2_to_l1', () => {
   beforeAll(async () => {
     await t.setup({ ...PIPELINING_SETUP_OPTS }, { syncChainTip: 'checkpointed' });
 
-    ({ crossChainTestHarness, aztecNode, aztecNodeAdmin, wallet, user1Address, rollup, outbox } = t);
+    ({ aztecNode, aztecNodeAdmin, wallet, user1Address, rollup, outbox } = t);
 
     msgSender = EthAddress.fromString(t.deployL1ContractsValues.l1Client.account.address);
 
@@ -68,7 +68,7 @@ describe('single-node/cross-chain/l2_to_l1', () => {
   // Proves the epoch, then consumes both messages from L1 via the Outbox and asserts the MessageConsumed
   // event is emitted and the message cannot be consumed a second time.
   it('1 tx with 2 messages, one from public, one from private, to a non-registered portal address', async () => {
-    const recipient = crossChainTestHarness.ethAccount;
+    const recipient = t.ethAccount;
     const contents = [Fr.random(), Fr.random()];
     const messages = contents.map(content => makeL2ToL1Message(recipient, content));
 
@@ -370,7 +370,7 @@ describe('single-node/cross-chain/l2_to_l1', () => {
       sender: { actor: contract.address.toString() as Hex, version },
       recipient: {
         actor: recipient.toString() as Hex,
-        chainId: BigInt(crossChainTestHarness.l1Client.chain.id),
+        chainId: BigInt(t.l1Client.chain.id),
       },
       content: content.toString() as Hex,
     };

--- a/yarn-project/end-to-end/src/single-node/cross-chain/l2_to_l1.parallel.test.ts
+++ b/yarn-project/end-to-end/src/single-node/cross-chain/l2_to_l1.parallel.test.ts
@@ -29,8 +29,8 @@ describe('single-node/cross-chain/l2_to_l1', () => {
   jest.setTimeout(15 * 60 * 1000);
 
   // This suite only passes arbitrary L2→L1 messages from its own TestContract; it never bridges
-  // tokens, so skip the token+portal+bridge deploy (last arg) and use the test's L1 handles directly.
-  const t = new CrossChainMessagingTest('l2_to_l1', { startProverNode: true }, {}, {}, undefined, false);
+  // tokens, so skip the token+portal+bridge deploy and use the test's L1 handles directly.
+  const t = new CrossChainMessagingTest('l2_to_l1', { startProverNode: true }, {}, {}, { deployTokenBridge: false });
 
   let aztecNode: AztecNode;
   let aztecNodeAdmin: AztecNodeAdmin;

--- a/yarn-project/end-to-end/src/single-node/cross-chain/token_bridge_failure_cases.test.ts
+++ b/yarn-project/end-to-end/src/single-node/cross-chain/token_bridge_failure_cases.test.ts
@@ -17,7 +17,15 @@ import { CrossChainMessagingTest } from './cross_chain_messaging_test.js';
 // inboxLag=2, minTxsPerBlock=0), EpochTestSettler for auto-proving, and CrossChainTestHarness for
 // L1↔L2 token portal bridging.
 describe('single-node/cross-chain/token_bridge_failure_cases', () => {
-  const t = new CrossChainMessagingTest('token_bridge_failure_cases', {}, {}, {}, L1_DIRECT_WRITE_ACCOUNT_INDEX);
+  const t = new CrossChainMessagingTest(
+    'token_bridge_failure_cases',
+    {},
+    {},
+    {},
+    {
+      l1HarnessAccountIndex: L1_DIRECT_WRITE_ACCOUNT_INDEX,
+    },
+  );
   let version: number = 1;
 
   let { crossChainTestHarness, ethAccount, l2Bridge, ownerAddress, user1Address, user2Address, rollup } = t;

--- a/yarn-project/end-to-end/src/single-node/cross-chain/token_bridge_private.test.ts
+++ b/yarn-project/end-to-end/src/single-node/cross-chain/token_bridge_private.test.ts
@@ -27,7 +27,7 @@ describe('single-node/cross-chain/token_bridge_private', () => {
     { startProverNode: true },
     {},
     {},
-    L1_DIRECT_WRITE_ACCOUNT_INDEX,
+    { l1HarnessAccountIndex: L1_DIRECT_WRITE_ACCOUNT_INDEX },
   );
 
   let crossChainTestHarness: CrossChainTestHarness;

--- a/yarn-project/end-to-end/src/single-node/cross-chain/token_bridge_public.parallel.test.ts
+++ b/yarn-project/end-to-end/src/single-node/cross-chain/token_bridge_public.parallel.test.ts
@@ -24,7 +24,7 @@ describe('single-node/cross-chain/token_bridge_public', () => {
     { startProverNode: true },
     {},
     {},
-    L1_DIRECT_WRITE_ACCOUNT_INDEX,
+    { l1HarnessAccountIndex: L1_DIRECT_WRITE_ACCOUNT_INDEX },
   );
 
   let { crossChainTestHarness, ethAccount, aztecNode, logger, ownerAddress, l2Bridge, l2Token, wallet, user2Address } =


### PR DESCRIPTION
Stacked on top of #24345. Continues the e2e speedup work, targeting two levers that cut wasted setup work in the single-node cross-chain suites.

## 1. Skip the token bridge deploy for arbitrary-message cross-chain tests (A-1185)

`l1_to_l2.parallel` and `l2_to_l1.parallel` only pass arbitrary L1↔L2 messages from their own `TestContract`; they never touch the L2 token, bridge, or portal — they use the cross-chain harness solely for `ethAccount` and the L1 client/contract handles. They were nonetheless paying for the full token+portal+bridge setup (an L1 ERC20 deploy, an L1 portal deploy, two L2 contract deploys, and their init txs) on every run.

`CrossChainMessagingTest` now takes a `deployTokenBridge` flag (default `true`). When `false`, it sets up the L1 handles + `ethAccount` and skips the token bridge entirely. The two suites pass `false` and read the L1 bits directly off the test object. No coverage lost — neither suite asserts anything on the token bridge.

## 2. Deploy cross-chain L1 contracts before the node starts, under automine

When a test needs extra L1 contracts (e.g. the cross-chain token portal + ERC20), deploying them after the node is running means paying the L1 block interval per deploy and racing the live sequencer/archiver. `setup` already mines its own L1 contract deployment under anvil automine before the node starts; this adds a `deployL1Contracts` hook to `SetupOptions` that runs in that same window, so a test's L1 deploys mine instantly and finish before any node exists. The resolved value is exposed on the context as `l1DeployResult`.

The token-bridge path of `CrossChainMessagingTest` now uses this hook to deploy the ERC20 + token portal pre-node; `CrossChainTestHarness` accepts the pre-deployed portal address and skips its own portal deploy (backward compatible — existing callers that pass nothing still deploy it). This benefits `token_bridge_private`, `token_bridge_public`, and `token_bridge_failure_cases`.

## Notes

- The `deployL1Contracts` hook is general-purpose; any suite that deploys L1 contracts in setup can move them into the automine window.
- A second codex pass over the deferred-speedup catalogue surfaced further low-risk items (fold the warp into the shared multi-node `waitForProvenCheckpoint`; audited automine swaps for a few fee tests) that are left for follow-ups.
