### PR TITLE
feat(pxe): add resolveCustomRequest hook for caller-defined requests

### DIFF
--- a/docs/docs-developers/docs/foundational-topics/pxe/execution_hooks.md
+++ b/docs/docs-developers/docs/foundational-topics/pxe/execution_hooks.md
@@ -93,3 +93,13 @@ let env = TestEnvironment::new_opts(
 Pass a `resolveTaggingSecretStrategy` hook when [creating the PXE](#configuring-hooks). It receives a `TaggingSecretStrategyRequest` with the executing contract's address and the message's sender, recipient, and delivery mode (`'constrained'` or `'unconstrained'`), so a wallet can apply per-application or per-recipient policies, or surface the decision to the user, instead of returning a fixed value.
 
 When the hook is absent, the PXE applies a privacy-safe default: unconstrained delivery uses an [address-derived shared secret](../../aztec-nr/framework-description/note_delivery.md#tagging-secret-strategy), which leaves no onchain trace, while constrained delivery fails rather than silently revealing the recipient through a [non-interactive handshake](../../aztec-nr/framework-description/note_delivery.md#tagging-secret-strategy).
+
+## `resolveCustomRequest`
+
+A general-purpose hook for *custom*, caller-defined requests. A contract reaches for it when it needs something it cannot get on its own: not from its local notes, not from the protocol's existing oracles. The contract gives the request a `kind` and an opaque `payload`, and the wallet returns an opaque response. Because the request is caller-defined, the wallet decides per `kind` how to answer, whether by reading state it holds, contacting another party, or fetching offchain data.
+
+### In production
+
+Pass a `resolveCustomRequest` hook when [creating the PXE](#configuring-hooks). It receives a `CustomRequest` with the issuing contract's address and class ID, the request `kind`, and the opaque `payload`, and returns the response. Because any contract can issue a request, the hook should check both the `kind` and the issuing contract before answering, dispatching on `kind` to the matching resolver.
+
+When the hook is absent, the request cannot be served and simulation fails.

--- a/noir-projects/aztec-nr/aztec/src/oracle/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/mod.nr
@@ -41,6 +41,8 @@ pub mod fact_store;
 #[generate_oracle_tests]
 pub mod public_call;
 pub mod tx_resolution;
+#[generate_oracle_tests]
+pub mod resolve_custom_request;
 #[generate_oracle_tests_excluding(
     @[
         quote { resolve_tagging_strategy_oracle }, // TODO: implement once we support more complex types

--- a/noir-projects/aztec-nr/aztec/src/oracle/resolve_custom_request.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/resolve_custom_request.nr
@@ -1,0 +1,17 @@
+//! A generic, hook-backed request resolved outside the circuit. See [`resolve_custom_request`].
+
+/// Resolves a custom, caller-defined request outside the circuit.
+///
+/// Unlike the protocol's built-in oracles, this one carries no fixed meaning: the contract chooses a `kind` and an
+/// opaque `payload`, and PXE (or a resolver it is configured with) produces the response however it needs to, whether
+/// from local state, by coordinating with a third party, or by fetching offchain data. `kind` selects the request type
+/// so a single resolver can serve many such types; everything specific to a request goes in `payload`.
+pub unconstrained fn resolve_custom_request<let M: u32, let N: u32>(kind: Field, payload: [Field; M]) -> [Field; N] {
+    resolve_custom_request_oracle(kind, payload)
+}
+
+#[oracle(aztec_prv_resolveCustomRequest)]
+unconstrained fn resolve_custom_request_oracle<let M: u32, let N: u32>(
+    _kind: Field,
+    _payload: [Field; M],
+) -> [Field; N] {}

--- a/noir-projects/aztec-nr/aztec/src/oracle/version.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/version.nr
@@ -11,7 +11,7 @@
 /// immediately if AZTEC_NR_MINOR > PXE_MINOR because if a contract is updated to use a newer Aztec.nr dependency
 /// without actually using any of the new oracles then there is no reason to throw.
 pub global ORACLE_VERSION_MAJOR: Field = 30;
-pub global ORACLE_VERSION_MINOR: Field = 1;
+pub global ORACLE_VERSION_MINOR: Field = 2;
 
 /// Asserts that the version of the oracle is compatible with the version expected by the contract.
 pub fn assert_compatible_oracle_version() {

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/oracle_registry.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/oracle_registry.ts
@@ -562,6 +562,14 @@ export const ORACLE_REGISTRY = {
     ],
     returnType: RESOLVED_TAGGING_STRATEGY,
   }),
+
+  aztec_prv_resolveCustomRequest: makeEntry({
+    params: [
+      { name: 'kind', type: FIELD },
+      { name: 'payload', type: ARRAY(FIELD) },
+    ],
+    returnType: ARRAY(FIELD),
+  }),
 } satisfies Record<string, OracleRegistryEntry>;
 
 // ─── Registry Infrastructure ─────────────────────────────────────────────────

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution_oracle.test.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution_oracle.test.ts
@@ -17,6 +17,7 @@ import { jest } from '@jest/globals';
 import { mock } from 'jest-mock-extended';
 
 import type { ContractSyncService } from '../../contract_sync/contract_sync_service.js';
+import type { ResolveCustomRequest } from '../../hooks/resolve_custom_request.js';
 import type {
   ResolveTaggingSecretStrategy,
   TaggingSecretStrategy,
@@ -165,6 +166,30 @@ describe('PrivateExecutionOracle', () => {
         .mockResolvedValue(await SerializableContractInstance.random({ currentContractClassId: contractClassId }));
       return { oracle, resolveTaggingSecretStrategy };
     };
+  });
+
+  describe('resolveCustomRequest', () => {
+    it('relays the request to the hook with the issuing contract context and returns its result', async () => {
+      const result = [Fr.random(), Fr.random()];
+      const resolveCustomRequest = jest.fn<ResolveCustomRequest>().mockResolvedValue(result);
+      const oracle = makeOracle({ hooks: { resolveCustomRequest } });
+      const contractClassId = Fr.random();
+      jest
+        .spyOn(oracle, 'getContractInstance')
+        .mockResolvedValue(await SerializableContractInstance.random({ currentContractClassId: contractClassId }));
+
+      const kind = Fr.random();
+      const payload = [Fr.random(), Fr.random(), Fr.random()];
+      await expect(oracle.resolveCustomRequest(kind, payload)).resolves.toEqual(result);
+      expect(resolveCustomRequest).toHaveBeenCalledWith({ contractAddress, contractClassId, kind, payload });
+    });
+
+    it('throws when no resolveCustomRequest hook is configured', async () => {
+      const oracle = makeOracle();
+      await expect(oracle.resolveCustomRequest(Fr.random(), [Fr.random()])).rejects.toThrow(
+        'no resolveCustomRequest hook',
+      );
+    });
   });
 
   const makeOracle = (overrides: Partial<PrivateExecutionOracleArgs> = {}): PrivateExecutionOracle => {

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution_oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution_oracle.ts
@@ -29,6 +29,7 @@ import {
   type TxContext,
 } from '@aztec/stdlib/tx';
 
+import type { ResolveCustomRequest } from '../../hooks/resolve_custom_request.js';
 import type {
   ResolveTaggingSecretStrategy,
   TaggingSecretStrategy,
@@ -185,6 +186,19 @@ export class PrivateExecutionOracle extends UtilityExecutionOracle implements IP
    */
   public getSenderForTags(): Promise<Option<AztecAddress>> {
     return Promise.resolve(this.defaultSenderForTags ? Option.some(this.defaultSenderForTags) : Option.none());
+  }
+
+  /**
+   * Resolves a custom, caller-defined request via the {@link ResolveCustomRequest} hook, which produces the response
+   * however it needs to. Throws when no hook is configured, since the request cannot be served.
+   */
+  public async resolveCustomRequest(kind: Fr, payload: Fr[]): Promise<Fr[]> {
+    const hook: ResolveCustomRequest | undefined = this.hooks?.resolveCustomRequest;
+    if (!hook) {
+      throw new Error('Cannot serve a request: no resolveCustomRequest hook is configured');
+    }
+    const { currentContractClassId } = await this.getContractInstance(this.contractAddress);
+    return hook({ contractAddress: this.contractAddress, contractClassId: currentContractClassId, kind, payload });
   }
 
   /**

--- a/yarn-project/pxe/src/hooks/execution_hooks.ts
+++ b/yarn-project/pxe/src/hooks/execution_hooks.ts
@@ -1,4 +1,5 @@
 import type { AuthorizeUtilityCall } from './authorize_utility_call.js';
+import type { ResolveCustomRequest } from './resolve_custom_request.js';
 import type { ResolveTaggingSecretStrategy } from './resolve_tagging_secret_strategy.js';
 
 /**
@@ -43,6 +44,12 @@ export interface ExecutionHooks {
    * See {@link ResolveTaggingSecretStrategy} for the request shape and defaults.
    */
   resolveTaggingSecretStrategy?: ResolveTaggingSecretStrategy;
+  /**
+   * Resolves a custom, caller-defined request a circuit cannot serve from local state. Any contract can issue one, so
+   * an implementor should verify both the request `kind` and the issuing contract (its address and class ID) before
+   * fulfilling it. Rejected when absent; see {@link ResolveCustomRequest}.
+   */
+  resolveCustomRequest?: ResolveCustomRequest;
 }
 
 /**

--- a/yarn-project/pxe/src/hooks/index.ts
+++ b/yarn-project/pxe/src/hooks/index.ts
@@ -4,6 +4,7 @@ export type {
   UtilityCallAuthorizationResponse,
 } from './authorize_utility_call.js';
 export { type ExecutionHooks, composeHooks } from './execution_hooks.js';
+export { type CustomRequest, type ResolveCustomRequest } from './resolve_custom_request.js';
 export {
   type ResolveTaggingSecretStrategy,
   type TaggingSecretStrategy,

--- a/yarn-project/pxe/src/hooks/resolve_custom_request.ts
+++ b/yarn-project/pxe/src/hooks/resolve_custom_request.ts
@@ -1,0 +1,24 @@
+import type { Fr } from '@aztec/foundation/curves/bn254';
+import type { AztecAddress } from '@aztec/stdlib/aztec-address';
+
+/**
+ * A custom, caller-defined request resolved via the {@link ResolveCustomRequest} hook. It carries no fixed meaning:
+ * `kind` selects the request type so one hook can serve many such types, and `payload` holds the opaque,
+ * request-specific arguments. The resolver answers by whatever means it needs (local state, a third party,
+ * offchain data).
+ */
+export type CustomRequest = {
+  /** The address of the contract issuing the request. */
+  contractAddress: AztecAddress;
+  /** The issuing contract's class ID, so resolvers can apply class-level (not just per-address) policy. */
+  contractClassId: Fr;
+  /** Discriminates the request type, letting one hook serve many such types. */
+  kind: Fr;
+  /** Opaque, request-specific arguments. */
+  payload: Fr[];
+};
+
+/**
+ * Hook resolving a {@link CustomRequest}. The resolver produces the response however it needs to.
+ */
+export type ResolveCustomRequest = (request: CustomRequest) => Promise<Fr[]>;

--- a/yarn-project/pxe/src/oracle_version.ts
+++ b/yarn-project/pxe/src/oracle_version.ts
@@ -11,7 +11,7 @@
 /// if AZTEC_NR_MINOR > PXE_MINOR because if a contract is updated to use a newer Aztec.nr dependency without actually
 /// using any of the new oracles then there is no reason to throw.
 export const ORACLE_VERSION_MAJOR = 30;
-export const ORACLE_VERSION_MINOR = 1;
+export const ORACLE_VERSION_MINOR = 2;
 
 /// This hash is computed from the `ORACLE_REGISTRY` declaration (each oracle's name, ordered parameter names and
 /// types, and return type) and is used to detect when the oracle interface changes. When it does, you need to either:
@@ -19,4 +19,4 @@ export const ORACLE_VERSION_MINOR = 1;
 /// - increment only `ORACLE_VERSION_MINOR` if the change is additive (a new oracle was added).
 ///
 /// These constants must be kept in sync between this file and `noir-projects/aztec-nr/aztec/src/oracle/version.nr`.
-export const ORACLE_INTERFACE_HASH = '2a441f29ab01b252bc74b91b07fc2514891c28bffdfa0042d80494271b75edee';
+export const ORACLE_INTERFACE_HASH = '7147e8e6a20550545a9cfc21a9eed8a61dd27a4855160891c7cd25e1dc1b5b73';

--- a/yarn-project/txe/src/rpc_translator.ts
+++ b/yarn-project/txe/src/rpc_translator.ts
@@ -1162,6 +1162,15 @@ export class RPCTranslator {
   }
 
   // eslint-disable-next-line camelcase
+  aztec_prv_resolveCustomRequest(...inputs: ForeignCallArgs) {
+    return callTxeHandler({
+      oracle: 'aztec_prv_resolveCustomRequest',
+      inputs,
+      handler: ([kind, payload]) => this.handlerAsPrivate().resolveCustomRequest(kind, payload),
+    });
+  }
+
+  // eslint-disable-next-line camelcase
   aztec_prv_getAppTaggingSecret(...inputs: ForeignCallArgs) {
     return callTxeHandler({
       oracle: 'aztec_prv_getAppTaggingSecret',


### PR DESCRIPTION
## Motivation

Contracts sometimes need a value they cannot derive locally or from the protocol's existing oracles. The first case is interactive handshakes, where a sender needs the recipient's signature to establish a shared secret, but there is no generic way for a contract to ask the wallet to fulfill an arbitrary request.

## The change

Adds a generic, hook-backed request primitive:

- A contract calls `resolve_custom_request(kind, payload)` and PXE routes it to a wallet-supplied `resolveCustomRequest` hook, returning the opaque response.
- `kind` selects the request type so a single hook can serve many; everything request-specific goes in the opaque `payload`. The request carries the issuing contract's address and class ID so a resolver can gate per contract.

There is no consumer yet; the interactive-handshake flow that uses this primitive lands in a follow-up.
