### PR TITLE
chore: add perf as a valid PR title prefix

### DIFF
--- a/.github/workflows/pull-request-title.yml
+++ b/.github/workflows/pull-request-title.yml
@@ -28,6 +28,7 @@ jobs:
           types: |
             fix
             feat
+            perf
             chore
             refactor
             docs


### PR DESCRIPTION
Allow `perf` as a Conventional Commit type for PR titles, alongside `feat`, `fix`, `chore`, etc.