### PR TITLE
fix(ethereum): mine empty L1 blocks without touching the mempool

### DIFF
--- a/yarn-project/ethereum/src/test/eth_cheat_codes.ts
+++ b/yarn-project/ethereum/src/test/eth_cheat_codes.ts
@@ -478,56 +478,44 @@ export class EthCheatCodes {
   }
 
   /**
-   * Mines an empty block by temporarily removing all pending transactions from the mempool,
-   * mining a block, and then re-adding the transactions back to the pool.
+   * Mines empty blocks while leaving any pending transactions untouched in the mempool.
+   *
+   * Never manipulates the mempool, so it is immune to the race that dropping and re-adding txs has against a
+   * concurrent publisher that is monitoring and re-broadcasting the same in-flight tx (with that approach the
+   * in-flight tx could reappear in the pool and be swept into the "empty" block, mining a proposal the caller
+   * expected to stay pending). Works in two steps: first the block gas limit is temporarily lowered below the
+   * intrinsic cost of any transaction (21000 gas) and the blocks are mined, so no pending tx is includable;
+   * then those blocks are reorged out and replaced with empty blocks mined at the restored gas limit. The
+   * reorg is needed because anvil applies a new gas limit only to future blocks: without it the just-mined
+   * blocks would keep the tiny gas limit, and an `eth_call` against `latest` (whose gas is capped by the
+   * block gas limit) would revert with "intrinsic gas too high".
    */
   public async mineEmptyBlock(blockCount: number = 1): Promise<void> {
     await this.execWithPausedAnvil(async () => {
-      // Get all pending and queued transactions from the pool
-      const txs = await this.getTxPoolContents();
-
-      this.logger.debug(`Found ${txs.length} transactions in pool`);
-
-      // Get raw transactions before dropping them
-      const rawTxs: Hex[] = [];
-      for (const tx of txs) {
-        try {
-          const rawTx = await this.doRpcCall('debug_getRawTransaction', [tx.hash]);
-          if (rawTx) {
-            rawTxs.push(rawTx);
-            this.logger.debug(`Got raw tx for ${tx.hash}`);
-          } else {
-            this.logger.warn(`No raw tx found for ${tx.hash}`);
-          }
-        } catch {
-          this.logger.warn(`Failed to get raw transaction for ${tx.hash}`);
-        }
+      const originalGasLimit = await this.getBlockGasLimit();
+      try {
+        await this.setBlockGasLimit(1n);
+        await this.doMine(blockCount);
+      } finally {
+        await this.setBlockGasLimit(originalGasLimit);
       }
-
-      this.logger.debug(`Retrieved ${rawTxs.length} raw transactions`);
-
-      // Drop all transactions from the mempool
-      await this.doRpcCall('anvil_dropAllTransactions', []);
-
-      // Mine an empty block
-      await this.doMine(blockCount);
-
-      // Re-add the transactions to the pool
-      for (const rawTx of rawTxs) {
-        try {
-          const txHash = await this.doRpcCall('eth_sendRawTransaction', [rawTx]);
-          this.logger.debug(`Re-added transaction ${txHash}`);
-        } catch (err) {
-          this.logger.warn(`Failed to re-add transaction: ${err}`);
-        }
-      }
-
-      if (rawTxs.length !== txs.length) {
-        this.logger.warn(`Failed to add all txs back: had ${txs.length} but re-added ${rawTxs.length}`);
-      }
+      // Replace the tiny-gas-limit blocks with empty blocks at the restored gas limit, keeping the same
+      // height and timestamps. The reorged-out blocks held no transactions, so nothing returns to the pool.
+      await this.doRpcCall('anvil_reorg', [blockCount, []]);
     });
 
     this.logger.warn(`Mined ${blockCount} empty L1 ${pluralize('block', blockCount)}`);
+  }
+
+  /** Returns the gas limit of the latest mined L1 block. */
+  public async getBlockGasLimit(): Promise<bigint> {
+    const block = await this.doRpcCall('eth_getBlockByNumber', ['latest', false]);
+    return BigInt(block.gasLimit);
+  }
+
+  /** Sets the block gas limit applied to subsequently mined L1 blocks. */
+  public async setBlockGasLimit(gasLimit: bigint): Promise<void> {
+    await this.doRpcCall('anvil_setBlockGasLimit', [toHex(gasLimit)]);
   }
 
   public async execWithPausedAnvil<T>(fn: () => Promise<T>): Promise<T> {

--- a/yarn-project/sequencer-client/src/publisher/l1_publisher.integration.test.ts
+++ b/yarn-project/sequencer-client/src/publisher/l1_publisher.integration.test.ts
@@ -1035,20 +1035,6 @@ describe('L1Publisher integration', () => {
       );
     };
 
-    // Advances one L1 block while keeping the in-flight publish tx unmined, so the publisher's
-    // monitor observes its txTimeoutAt elapse on a still-pending tx and cancels it. We must not use
-    // mineEmptyBlock here: it drops the pending tx, mines, then re-adds it, and the block it mines
-    // can land exactly at txTimeoutAt with the re-added propose included. The monitor checks "mined"
-    // before "timed out", so a propose mined at the timeout boundary is reported as a successful
-    // proposal rather than cancelled, flaking the timeout assertions. Dropping the pending txs and
-    // not re-adding them guarantees the timeout fires while the tx is absent from the chain.
-    const mineBlockWithoutPendingTxs = async () => {
-      for (const tx of await ethCheatCodes.getTxPoolContents()) {
-        await ethCheatCodes.dropTransaction(tx.hash);
-      }
-      await ethCheatCodes.mine();
-    };
-
     it(`cancels block proposal when the L2 slot ends`, async () => {
       const { checkpoint } = await buildSingleCheckpoint();
       await enqueueProposeL2Checkpoint(checkpoint);
@@ -1057,7 +1043,7 @@ describe('L1Publisher integration', () => {
       // Advance one L1 block at a time without mining the publish tx.
       // While we are on the same L2 slot, sendRequests should not resolve.
       while (true) {
-        await mineBlockWithoutPendingTxs();
+        await ethCheatCodes.mineEmptyBlock();
         await ethCheatCodes.syncDateProvider();
         const currentL2Slot = await rollup.getSlotNumber();
         const { slot: nextL2Slot } = epochCache.getEpochAndSlotInNextL1Slot();
@@ -1098,7 +1084,7 @@ describe('L1Publisher integration', () => {
       // After N L1 blocks, the publisher should have bumped the gas and resent the tx
       const l1SlotsUntilSpeedUp = 1;
       for (let i = 0; i < l1SlotsUntilSpeedUp; i++) {
-        await mineBlockWithoutPendingTxs();
+        await ethCheatCodes.mineEmptyBlock();
         await ethCheatCodes.syncDateProvider();
       }
 
@@ -1131,7 +1117,7 @@ describe('L1Publisher integration', () => {
 
       // Let the proposal timeout by mining empty blocks until we're past the L2 slot
       while (true) {
-        await mineBlockWithoutPendingTxs();
+        await ethCheatCodes.mineEmptyBlock();
         await ethCheatCodes.syncDateProvider();
         const { slot: nextL2Slot } = epochCache.getEpochAndSlotInNextL1Slot();
 

--- a/yarn-project/sequencer-client/src/publisher/l1_publisher.integration.test.ts
+++ b/yarn-project/sequencer-client/src/publisher/l1_publisher.integration.test.ts
@@ -1035,6 +1035,20 @@ describe('L1Publisher integration', () => {
       );
     };
 
+    // Advances one L1 block while keeping the in-flight publish tx unmined, so the publisher's
+    // monitor observes its txTimeoutAt elapse on a still-pending tx and cancels it. We must not use
+    // mineEmptyBlock here: it drops the pending tx, mines, then re-adds it, and the block it mines
+    // can land exactly at txTimeoutAt with the re-added propose included. The monitor checks "mined"
+    // before "timed out", so a propose mined at the timeout boundary is reported as a successful
+    // proposal rather than cancelled, flaking the timeout assertions. Dropping the pending txs and
+    // not re-adding them guarantees the timeout fires while the tx is absent from the chain.
+    const mineBlockWithoutPendingTxs = async () => {
+      for (const tx of await ethCheatCodes.getTxPoolContents()) {
+        await ethCheatCodes.dropTransaction(tx.hash);
+      }
+      await ethCheatCodes.mine();
+    };
+
     it(`cancels block proposal when the L2 slot ends`, async () => {
       const { checkpoint } = await buildSingleCheckpoint();
       await enqueueProposeL2Checkpoint(checkpoint);
@@ -1043,7 +1057,7 @@ describe('L1Publisher integration', () => {
       // Advance one L1 block at a time without mining the publish tx.
       // While we are on the same L2 slot, sendRequests should not resolve.
       while (true) {
-        await ethCheatCodes.mineEmptyBlock();
+        await mineBlockWithoutPendingTxs();
         await ethCheatCodes.syncDateProvider();
         const currentL2Slot = await rollup.getSlotNumber();
         const { slot: nextL2Slot } = epochCache.getEpochAndSlotInNextL1Slot();
@@ -1084,7 +1098,7 @@ describe('L1Publisher integration', () => {
       // After N L1 blocks, the publisher should have bumped the gas and resent the tx
       const l1SlotsUntilSpeedUp = 1;
       for (let i = 0; i < l1SlotsUntilSpeedUp; i++) {
-        await ethCheatCodes.mineEmptyBlock();
+        await mineBlockWithoutPendingTxs();
         await ethCheatCodes.syncDateProvider();
       }
 
@@ -1117,7 +1131,7 @@ describe('L1Publisher integration', () => {
 
       // Let the proposal timeout by mining empty blocks until we're past the L2 slot
       while (true) {
-        await ethCheatCodes.mineEmptyBlock();
+        await mineBlockWithoutPendingTxs();
         await ethCheatCodes.syncDateProvider();
         const { slot: nextL2Slot } = epochCache.getEpochAndSlotInNextL1Slot();
 


### PR DESCRIPTION
## Problem

`L1Publisher integration › timeouts › cancels block proposal when the L2 slot ends` flakes in CI (failed run http://ci.aztec-labs.com/997f3ffdac47572f). The same commit passes on retry. The failure is `expect(sendRequestsResult).toBeNull()` receiving a successful propose result (`sentActions: ["propose"], successfulActions: ["propose"]`) instead of `null`: the propose got mined when the test required it to stay pending until the L2 slot timeout cancelled it.

## Root cause

The three `timeouts` tests advance L1 blocks with `ethCheatCodes.mineEmptyBlock()` while a propose tx is in flight (anvil automine off). The old `mineEmptyBlock` worked by: read the pool, `anvil_dropAllTransactions`, `hardhat_mine`, then re-add the raw txs via `eth_sendRawTransaction`. That drop -> mine -> re-add sequence is **not atomic** against the publisher, which is concurrently monitoring its in-flight tx on a 1s loop. During the window between the drop and the mine, the tx reappears in the pool (the publisher re-broadcasts it, and `mineEmptyBlock` itself re-adds it on the prior iteration), so the supposedly-empty block is not empty — `hardhat_mine` sweeps the pending propose into it. The propose is mined, the monitor reports MINED, and `sendRequests` resolves with a successful proposal instead of `null`.

Log evidence from the failed run:

- `Sent L1 transaction 0xd2d5… nonce 0 isBlobTx:true` — one propose send, no speed-ups anywhere in the run.
- `Mined 1 empty L1 block` (call #1), then on call #2: `Failed to re-add transaction: … Details: nonce too low`. The re-add of the propose failed because its nonce was **already consumed on-chain** — i.e. `mineEmptyBlock`'s own mine step had just included it.
- `L1 transaction 0x08fa… with nonce 0 mined` blockNumber 36 — the propose mined into the "empty" block.

This was reproduced deterministically at the anvil level: with the old implementation, dropping all txs, re-broadcasting (as the publisher monitor does), then `hardhat_mine` produces a block containing the pending tx.

The previous explanation in this PR — "the re-added propose lands in the block whose timestamp == `txTimeoutAt`, and the monitor checks mined before timed-out" — was incomplete. The boundary timestamp is incidental (a consequence of the 12s L1-block grid and where the loop happened to be); the real determinant is that the tx is present in the pool when `mineEmptyBlock` mines. The monitor's mined-before-timeout ordering is a red herring here: once a tx is mined, it is mined regardless of check order.

## Fix

Reimplement `mineEmptyBlock` so it never touches the mempool, eliminating the race for **all** callers rather than working around it in one test:

- Temporarily lower the block gas limit below any transaction's 21000-gas intrinsic minimum, so `hardhat_mine` cannot include any pending tx; the pending tx stays in the pool untouched.
- Restore the gas limit, then `anvil_reorg` the just-mined blocks into empty blocks at the restored gas limit (same height and timestamps). The reorg is required because anvil applies a new gas limit only to future blocks — without it the just-mined blocks would keep the tiny limit and a later `eth_call` against `latest` (whose gas is capped by the block gas limit) would revert with "intrinsic gas too high".

This is strictly more robust than dropping the pending tx (the approach in #24401 / this PR's prior commit): it removes the drop/re-add window entirely instead of narrowing it, and it preserves pending txs (the existing `eth_cheat_codes.test.ts` contract). Consequently the test-local `mineBlockWithoutPendingTxs` workaround is removed and the three timeout tests call `mineEmptyBlock()` again — the change to the test file is a net revert.

## Verification

- Deterministic RED: with the old implementation, drop-all -> re-broadcast -> `hardhat_mine` mines the pending tx into the "empty" block.
- Unit `eth_cheat_codes.test.ts › mineEmptyBlock › mines an empty block while preserving pending transactions`: passes (block advances, block empty, pending tx preserved and mined later).
- All three `timeouts` integration tests pass; the cancel test passes 3/3 repeats.
- Full `ethereum/src/l1_tx_utils/l1_tx_utils.test.ts` (51 tests, 22 `mineEmptyBlock` calls incl. multi-block) passes — the L1TxUtils monitor suite that interacts most with `mineEmptyBlock`.

## Relation to #24401

#24401 independently landed the same drop-pending-txs-without-re-add workaround in these tests. This PR supersedes that approach by fixing the shared `mineEmptyBlock` helper, so no per-test workaround is needed.
