### PR TITLE
feat!: close down access to context member fields

### DIFF
--- a/docs/docs-developers/docs/resources/migration_notes.md
+++ b/docs/docs-developers/docs/resources/migration_notes.md
@@ -9,6 +9,25 @@ Aztec is in active development. Each version may introduce breaking changes that
 
 ## TBD
 
+### [Aztec.nr] `PrivateContext` data fields are no longer public
+
+`PrivateContext`'s data fields are now private (or crate-internal): its public API is now exclusively its methods. Contracts that read these fields directly must switch to the corresponding getter. A new `get_side_effect_counter()` getter exposes the side-effect counter, and a new `is_static_call()` getter replaces reaching into `inputs.call_context`. The `get_anchor_block_header()` getter already existed.
+
+**Migration:**
+
+```diff
+- let header = context.anchor_block_header;
++ let header = context.get_anchor_block_header();
+
+- let counter = context.side_effect_counter;
++ let counter = context.get_side_effect_counter();
+
+- let is_static = context.inputs.call_context.is_static_call;
++ let is_static = context.is_static_call();
+```
+
+**Impact**: Direct field access on `PrivateContext` (e.g. `context.anchor_block_header`, `context.side_effect_counter`, `context.inputs`) no longer compiles. Contract state should be read through the context's methods.
+
 ### [PXE] Browser KV-store default is now SQLite-OPFS; the IndexedDB entrypoint moved and will be deprecated
 
 The browser PXE data store and the embedded wallet (`@aztec/wallets`) now persist to SQLite-OPFS instead of IndexedDB by default. The recommended way to obtain the browser backend is `@aztec/kv-store/sqlite-opfs`.

--- a/noir-projects/aztec-nr/aztec/src/context/private_context.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/private_context.nr
@@ -138,43 +138,43 @@ use crate::protocol::{
 #[derive(Eq)]
 pub struct PrivateContext {
     // docs:start:private-context
-    pub inputs: PrivateContextInputs,
-    pub side_effect_counter: u32,
+    inputs: PrivateContextInputs,
+    side_effect_counter: u32,
 
-    pub min_revertible_side_effect_counter: u32,
-    pub is_fee_payer: bool,
+    min_revertible_side_effect_counter: u32,
+    is_fee_payer: bool,
 
-    pub args_hash: Field,
-    pub return_hash: Field,
+    args_hash: Field,
+    return_hash: Field,
 
-    pub expiration_timestamp: u64,
+    pub(crate) expiration_timestamp: u64,
 
     pub(crate) note_hash_read_requests: BoundedVec<Scoped<Counted<Field>>, MAX_NOTE_HASH_READ_REQUESTS_PER_CALL>,
     pub(crate) nullifier_read_requests: BoundedVec<Scoped<Counted<Field>>, MAX_NULLIFIER_READ_REQUESTS_PER_CALL>,
     key_validation_requests_and_separators: BoundedVec<KeyValidationRequestAndSeparator, MAX_KEY_VALIDATION_REQUESTS_PER_CALL>,
 
-    pub note_hashes: BoundedVec<Counted<NoteHash>, MAX_NOTE_HASHES_PER_CALL>,
-    pub nullifiers: BoundedVec<Counted<Nullifier>, MAX_NULLIFIERS_PER_CALL>,
+    pub(crate) note_hashes: BoundedVec<Counted<NoteHash>, MAX_NOTE_HASHES_PER_CALL>,
+    pub(crate) nullifiers: BoundedVec<Counted<Nullifier>, MAX_NULLIFIERS_PER_CALL>,
 
-    pub private_call_requests: BoundedVec<PrivateCallRequest, MAX_PRIVATE_CALL_STACK_LENGTH_PER_CALL>,
-    pub public_call_requests: BoundedVec<Counted<PublicCallRequest>, MAX_ENQUEUED_CALLS_PER_CALL>,
-    pub public_teardown_call_request: PublicCallRequest,
-    pub l2_to_l1_msgs: BoundedVec<Counted<L2ToL1Message>, MAX_L2_TO_L1_MSGS_PER_CALL>,
+    pub(crate) private_call_requests: BoundedVec<PrivateCallRequest, MAX_PRIVATE_CALL_STACK_LENGTH_PER_CALL>,
+    public_call_requests: BoundedVec<Counted<PublicCallRequest>, MAX_ENQUEUED_CALLS_PER_CALL>,
+    public_teardown_call_request: PublicCallRequest,
+    l2_to_l1_msgs: BoundedVec<Counted<L2ToL1Message>, MAX_L2_TO_L1_MSGS_PER_CALL>,
     // docs:end:private-context
 
     // Header of a block whose state is used during private execution (not the block the transaction is included in).
-    pub anchor_block_header: BlockHeader,
+    pub(crate) anchor_block_header: BlockHeader,
 
-    pub private_logs: BoundedVec<Counted<PrivateLogData>, MAX_PRIVATE_LOGS_PER_CALL>,
-    pub contract_class_logs_hashes: BoundedVec<Counted<LogHash>, MAX_CONTRACT_CLASS_LOGS_PER_CALL>,
+    private_logs: BoundedVec<Counted<PrivateLogData>, MAX_PRIVATE_LOGS_PER_CALL>,
+    contract_class_logs_hashes: BoundedVec<Counted<LogHash>, MAX_CONTRACT_CLASS_LOGS_PER_CALL>,
 
     // Contains the last key validation request for each key type. This is used to cache the last request and avoid
     // fetching the same request multiple times. The index of the array corresponds to the key type (0 nullifier, 1
     // incoming, 2 outgoing, 3 tagging).
-    pub last_key_validation_requests: [Option<KeyValidationRequest>; NUM_KEY_TYPES],
+    last_key_validation_requests: [Option<KeyValidationRequest>; NUM_KEY_TYPES],
 
-    pub expected_non_revertible_side_effect_counter: u32,
-    pub expected_revertible_side_effect_counter: u32,
+    expected_non_revertible_side_effect_counter: u32,
+    expected_revertible_side_effect_counter: u32,
 }
 
 impl PrivateContext {
@@ -303,6 +303,19 @@ impl PrivateContext {
         self.inputs.call_context.function_selector
     }
 
+    /// Returns whether this call is being executed as part of a static call.
+    ///
+    /// Similar to Solidity's `STATICCALL`, a static call is read-only: neither this function nor any of its nested
+    /// calls may emit side-effects (new notes, nullifiers, logs, L2->L1 messages, etc.). A call is considered static
+    /// if it was invoked as a static call or if any of its ancestor calls were.
+    ///
+    /// # Returns
+    /// * `bool` - `true` if this call (or an ancestor call) is a static call.
+    ///
+    pub fn is_static_call(self) -> bool {
+        self.inputs.call_context.is_static_call
+    }
+
     /// Returns the hash of the arguments passed to the current function.
     ///
     /// Very low-level function: You shouldn't need to call this. The #[external("private")] macro calls this, and it
@@ -318,6 +331,19 @@ impl PrivateContext {
     ///
     pub fn get_args_hash(self) -> Field {
         self.args_hash
+    }
+
+    /// Returns the current value of the side-effect counter, i.e. the counter that will be assigned to the next
+    /// side-effect emitted by this function.
+    ///
+    /// Low-level function: Ordinarily, smart contract developers will not need to access this. See `next_counter` for
+    /// details on how side-effect counters are assigned and why they exist.
+    ///
+    /// # Returns
+    /// * `u32` - The current side-effect counter.
+    ///
+    pub fn get_side_effect_counter(self) -> u32 {
+        self.side_effect_counter
     }
 
     /// Pushes a new note_hash to the Aztec blockchain's global Note Hash Tree (a state tree).

--- a/noir-projects/aztec-nr/aztec/src/context/public_context.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/public_context.nr
@@ -67,8 +67,8 @@ use crate::protocol::{
 /// fundamentally different from optimising a public function.
 ///
 pub struct PublicContext {
-    pub args_hash: Option<Field>,
-    pub compute_args_hash: fn() -> Field,
+    args_hash: Option<Field>,
+    compute_args_hash: fn() -> Field,
 }
 
 impl Eq for PublicContext {

--- a/noir-projects/aztec-nr/aztec/src/macros/internals_functions_generation/external/private.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/internals_functions_generation/external/private.nr
@@ -74,7 +74,7 @@ pub(crate) comptime fn generate_private_external(f: FunctionDefinition) -> Quote
 
     let view_check = if is_fn_view(f) {
         let assertion_message = f"Function {original_function_name} can only be called statically".as_quoted_str();
-        quote { assert(self.context.inputs.call_context.is_static_call, $assertion_message); }
+        quote { assert(self.context.is_static_call(), $assertion_message); }
     } else {
         quote {}
     };

--- a/noir-projects/aztec-nr/aztec/src/messages/delivery/constrained_delivery.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/delivery/constrained_delivery.nr
@@ -124,7 +124,7 @@ mod test {
         env.private_context(|context| {
             // The real registry call is covered by integration tests; this unit test only needs a coherent child
             // call result so `PrivateContext` records the request.
-            let child_call_end_counter = context.side_effect_counter + 1;
+            let child_call_end_counter = context.get_side_effect_counter() + 1;
             let empty_returns_hash: Field = 0;
             let _ = OracleMock::mock("aztec_prv_callPrivateFunction")
                 .returns((child_call_end_counter, empty_returns_hash))

--- a/noir-projects/aztec-nr/aztec/src/messages/delivery/tag_secret_source.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/delivery/tag_secret_source.nr
@@ -24,19 +24,13 @@ impl TagSecretSource {
 
     /// Establishes a fresh non-interactive handshake, publishing information about the recipient onchain.
     pub(crate) fn new_non_interactive_handshake() -> Self {
-        Self {
-            kind: NEW_NON_INTERACTIVE_HANDSHAKE,
-            secrets: AppSiloedHandshakeSecrets { shared: 0, sender_only: 0 },
-        }
+        Self { kind: NEW_NON_INTERACTIVE_HANDSHAKE, secrets: AppSiloedHandshakeSecrets { shared: 0, sender_only: 0 } }
     }
 
     /// A ready-to-use unconstrained secret the wallet resolved. Sound only for unconstrained delivery, which derives
     /// the discovery tag from the shared secret alone and never folds in a sender-only secret.
     pub(crate) fn unconstrained_secret(secret: Field) -> Self {
-        Self {
-            kind: UNCONSTRAINED_SECRET,
-            secrets: AppSiloedHandshakeSecrets { shared: secret, sender_only: 0 },
-        }
+        Self { kind: UNCONSTRAINED_SECRET, secrets: AppSiloedHandshakeSecrets { shared: secret, sender_only: 0 } }
     }
 
     /// Returns the app-siloed handshake secrets, performing any handshake creation the source requires.
@@ -117,10 +111,7 @@ mod test {
     unconstrained fn unconstrained_secret_obtains_its_secret() {
         let env = TestEnvironment::new();
         env.private_context(|context| {
-            assert_eq(
-                TagSecretSource::unconstrained_secret(42).obtain_secrets(context, SENDER, RECIPIENT).shared,
-                42,
-            );
+            assert_eq(TagSecretSource::unconstrained_secret(42).obtain_secrets(context, SENDER, RECIPIENT).shared, 42);
         });
     }
 
@@ -134,7 +125,7 @@ mod test {
             let returns = secrets.serialize();
             let returns_hash = hash_args(returns);
             execution_cache::store(returns, returns_hash);
-            let child_call_end_counter = context.side_effect_counter + 1;
+            let child_call_end_counter = context.get_side_effect_counter() + 1;
             let _ = OracleMock::mock("aztec_prv_callPrivateFunction")
                 .returns((child_call_end_counter, returns_hash))
                 .times(1);

--- a/noir-projects/aztec-nr/aztec/src/note/lifecycle.nr
+++ b/noir-projects/aztec-nr/aztec/src/note/lifecycle.nr
@@ -46,7 +46,7 @@ pub fn create_note<Note>(
 where
     Note: NoteType + NoteHash + Packable,
 {
-    let note_hash_counter = context.side_effect_counter;
+    let note_hash_counter = context.get_side_effect_counter();
 
     // Safety: We use the randomness to preserve the privacy of the note recipient by preventing brute-forcing, so a
     // malicious sender could use non-random values to make the note less private. But they already know the full note

--- a/noir-projects/contract-snapshots/tests/snapshots/expand/token_contract/snapshots__expanded.snap
+++ b/noir-projects/contract-snapshots/tests/snapshots/expand/token_contract/snapshots__expanded.snap
@@ -2883,7 +2883,7 @@ pub contract Token {
         };
         let within_revertible_phase: bool = self.context.in_revertible_phase();
         aztec::macros::functions::initialization_utils::assert_is_initialized_private(self.context);
-        assert(self.context.inputs.call_context.is_static_call, "Function private_get_decimals can only be called statically");
+        assert(self.context.is_static_call(), "Function private_get_decimals can only be called statically");
         let macro__returned__values: u8 = self.storage.decimals.read();
         let serialized_params: [Field; 1] = <u8 as aztec::protocol::traits::Serialize>::serialize(macro__returned__values);
         self.context.set_return_hash(serialized_params);
@@ -2910,7 +2910,7 @@ pub contract Token {
         };
         let within_revertible_phase: bool = self.context.in_revertible_phase();
         aztec::macros::functions::initialization_utils::assert_is_initialized_private(self.context);
-        assert(self.context.inputs.call_context.is_static_call, "Function private_get_name can only be called statically");
+        assert(self.context.is_static_call(), "Function private_get_name can only be called statically");
         let macro__returned__values: FieldCompressedString = self.storage.name.read();
         let serialized_params: [Field; 1] = <FieldCompressedString as aztec::protocol::traits::Serialize>::serialize(macro__returned__values);
         self.context.set_return_hash(serialized_params);
@@ -2937,7 +2937,7 @@ pub contract Token {
         };
         let within_revertible_phase: bool = self.context.in_revertible_phase();
         aztec::macros::functions::initialization_utils::assert_is_initialized_private(self.context);
-        assert(self.context.inputs.call_context.is_static_call, "Function private_get_symbol can only be called statically");
+        assert(self.context.is_static_call(), "Function private_get_symbol can only be called statically");
         let macro__returned__values: FieldCompressedString = self.storage.symbol.read();
         let serialized_params: [Field; 1] = <FieldCompressedString as aztec::protocol::traits::Serialize>::serialize(macro__returned__values);
         self.context.set_return_hash(serialized_params);

--- a/noir-projects/noir-contracts/contracts/account/simulated_ecdsa_account_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/account/simulated_ecdsa_account_contract/src/main.nr
@@ -54,7 +54,7 @@ pub contract SimulatedEcdsaAccount {
         self.context.emit_raw_note_log_unsafe(
             seed + 3,
             BoundedVec::from_array(dummy_log),
-            self.context.side_effect_counter,
+            self.context.get_side_effect_counter(),
         );
     }
 

--- a/noir-projects/noir-contracts/contracts/account/simulated_schnorr_account_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/account/simulated_schnorr_account_contract/src/main.nr
@@ -56,7 +56,7 @@ pub contract SimulatedSchnorrAccount {
         self.context.emit_raw_note_log_unsafe(
             seed + 3,
             BoundedVec::from_array(dummy_log),
-            self.context.side_effect_counter,
+            self.context.get_side_effect_counter(),
         );
     }
 

--- a/noir-projects/noir-contracts/contracts/test/test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/test_contract/src/main.nr
@@ -381,7 +381,7 @@ pub contract Test {
 
     #[external("private")]
     fn assert_header_private(header_hash: Field) {
-        assert(self.context.anchor_block_header.hash() == header_hash, "Invalid header hash");
+        assert(self.context.get_anchor_block_header().hash() == header_hash, "Invalid header hash");
     }
 
     // TODO(4840): add AVM opcodes for getting header (members)

--- a/noir-projects/noir-contracts/contracts/test/test_contract/src/test/deployment_proofs.nr
+++ b/noir-projects/noir-contracts/contracts/test/test_contract/src/test/deployment_proofs.nr
@@ -43,20 +43,30 @@ unconstrained fn contract_historical_proofs_happy_path() {
     let (env, contract_address, _owner, init_hash) = setup();
 
     env.private_context_opts(PrivateContextOptions::new().at_anchor_block_number(CONTRACT_DEPLOYED_AT - 1), |context| {
-        assert_contract_bytecode_was_not_published_by(context.anchor_block_header, contract_address);
+        assert_contract_bytecode_was_not_published_by(context.get_anchor_block_header(), contract_address);
     });
 
     env.private_context_opts(PrivateContextOptions::new().at_anchor_block_number(CONTRACT_DEPLOYED_AT), |context| {
-        assert_contract_bytecode_was_published_by(context.anchor_block_header, contract_address);
+        assert_contract_bytecode_was_published_by(context.get_anchor_block_header(), contract_address);
     });
 
     env.private_context_opts(
         PrivateContextOptions::new().at_anchor_block_number(CONTRACT_INITIALIZED_AT - 1),
-        |context| { assert_contract_was_not_initialized_by(context.anchor_block_header, contract_address, init_hash); },
+        |context| {
+            assert_contract_was_not_initialized_by(
+                context.get_anchor_block_header(),
+                contract_address,
+                init_hash,
+            );
+        },
     );
 
     env.private_context_opts(PrivateContextOptions::new().at_anchor_block_number(CONTRACT_INITIALIZED_AT), |context| {
-        assert_contract_was_initialized_by(context.anchor_block_header, contract_address, init_hash);
+        assert_contract_was_initialized_by(
+            context.get_anchor_block_header(),
+            contract_address,
+            init_hash,
+        );
     });
 }
 
@@ -67,7 +77,7 @@ unconstrained fn assert_contract_bytecode_was_published_by_before_deployment_fai
     // Note that we're only testing that the function fails, but not that it would correct reject bad hints from an
     // oracle
     env.private_context_opts(PrivateContextOptions::new().at_anchor_block_number(CONTRACT_DEPLOYED_AT - 1), |context| {
-        assert_contract_bytecode_was_published_by(context.anchor_block_header, contract_address);
+        assert_contract_bytecode_was_published_by(context.get_anchor_block_header(), contract_address);
     });
 }
 
@@ -79,7 +89,13 @@ unconstrained fn assert_contract_was_initialized_by_before_initialization_fails(
     // oracle
     env.private_context_opts(
         PrivateContextOptions::new().at_anchor_block_number(CONTRACT_INITIALIZED_AT - 1),
-        |context| { assert_contract_was_initialized_by(context.anchor_block_header, contract_address, init_hash); },
+        |context| {
+            assert_contract_was_initialized_by(
+                context.get_anchor_block_header(),
+                contract_address,
+                init_hash,
+            );
+        },
     );
 }
 
@@ -90,7 +106,7 @@ unconstrained fn assert_contract_bytecode_was_not_published_by_of_deployed_fails
     // Note that we're only testing that the function fails, but not that it would correct reject bad hints from an
     // oracle
     env.private_context_opts(PrivateContextOptions::new().at_anchor_block_number(CONTRACT_DEPLOYED_AT), |context| {
-        assert_contract_bytecode_was_not_published_by(context.anchor_block_header, contract_address);
+        assert_contract_bytecode_was_not_published_by(context.get_anchor_block_header(), contract_address);
     });
 }
 
@@ -99,7 +115,11 @@ unconstrained fn assert_contract_was_initialized_by_with_wrong_init_hash_fails()
     let (env, contract_address, _owner, _init_hash) = setup();
 
     env.private_context_opts(PrivateContextOptions::new().at_anchor_block_number(CONTRACT_INITIALIZED_AT), |context| {
-        assert_contract_was_initialized_by(context.anchor_block_header, contract_address, 0xdeadbeef);
+        assert_contract_was_initialized_by(
+            context.get_anchor_block_header(),
+            contract_address,
+            0xdeadbeef,
+        );
     });
 }
 
@@ -110,6 +130,10 @@ unconstrained fn assert_contract_was_not_initialized_by_of_initialized_fails() {
     // Note that we're only testing that the function fails, but not that it would correct reject bad hints from an
     // oracle
     env.private_context_opts(PrivateContextOptions::new().at_anchor_block_number(CONTRACT_INITIALIZED_AT), |context| {
-        assert_contract_was_not_initialized_by(context.anchor_block_header, contract_address, init_hash);
+        assert_contract_was_not_initialized_by(
+            context.get_anchor_block_header(),
+            contract_address,
+            init_hash,
+        );
     });
 }


### PR DESCRIPTION
This just makes a bunch of `pub` fields be either private or `pub(crate)`, adding getters when needed, to allow better local reasoning about correctness of complex modules such as `PrivateContext`.

Closes https://github.com/AztecProtocol/aztec-claude/issues/1952.