### PR TITLE
fix(sequencer): use evmMine in automine auto-settle to avoid dropping test L1 txs

### DIFF
--- a/yarn-project/sequencer-client/src/sequencer/automine/automine_sequencer.ts
+++ b/yarn-project/sequencer-client/src/sequencer/automine/automine_sequencer.ts
@@ -715,9 +715,12 @@ export class AutomineSequencer {
     await rollupCheatCodes.markAsProven(target);
     // Settlement is a direct L1 storage write that mines no block, unlike a real epoch proof landing
     // on L1. The archiver's L1 sync short-circuits while the L1 block hash is unchanged, so it would
-    // never re-read the proven tip until the next build/warp mines a block. Mine one empty L1 block so
-    // the block hash advances, then force an immediate sync that observes the new proven checkpoint.
-    await this.deps.ethCheatCodes.mineEmptyBlock();
+    // never re-read the proven tip until the next build/warp mines a block. Mine one L1 block so the
+    // block hash advances, then force an immediate sync that observes the new proven checkpoint. Use
+    // evmMine (not mineEmptyBlock): mineEmptyBlock drops+re-adds the mempool non-atomically, which can
+    // silently lose a test's concurrently-submitted direct L1 tx. evm_mine just includes whatever is
+    // pending, which is fine here — we only need the block hash to advance.
+    await this.deps.ethCheatCodes.evmMine();
     await this.deps.archiver.syncImmediate();
 
     this.log.verbose(`Proved up to checkpoint ${target}`, { target, proven, startEpoch, endEpoch });


### PR DESCRIPTION
The local-network `AutomineSequencer` auto-settle loop hangs a test's direct L1 tx (~180s viem `WaitForTransactionReceiptTimeoutError`), surfacing as the `e2e_token_bridge_tutorial` flake.

## Context

After `markAsProven`, `runProve()` called `mineEmptyBlock()` purely to advance the L1 block hash so the archiver re-reads the proven tip. `mineEmptyBlock` drops and re-adds the anvil mempool non-atomically (snapshot → `anvil_dropAllTransactions` → mine → re-add snapshotted txs). A direct test L1 tx submitted in the snapshot→drop window is dropped and never re-added; with the sequencer otherwise idle it is never mined, so the caller hangs until viem times out.

## Approach

Replace `mineEmptyBlock()` with `evmMine()` at that call site. `evm_mine` advances the block hash and includes whatever is pending, with no mempool drop and no automine toggle — so there is no race window. The call site only needs a new block hash, not an empty block.

`mineEmptyBlock()` itself is unchanged: its other callers invoke it single-threaded with no concurrent external tx and some rely on the block being empty, and making it race-safe across independent RPC clients is out of scope.