### PR TITLE
fix(sequencer): recover fee-estimation caches from transient L1 read failures

### DIFF
--- a/yarn-project/sequencer-client/src/global_variable_builder/fee_predictor.test.ts
+++ b/yarn-project/sequencer-client/src/global_variable_builder/fee_predictor.test.ts
@@ -9,6 +9,7 @@ import { CheckpointNumber } from '@aztec/foundation/branded-types';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { createLogger } from '@aztec/foundation/log';
+import { promiseWithResolvers } from '@aztec/foundation/promise';
 import { DateProvider } from '@aztec/foundation/timer';
 import { FEE_ORACLE_LAG, type GasFees, ManaUsageEstimate, computeExcessMana } from '@aztec/stdlib/gas';
 
@@ -375,6 +376,43 @@ describe('FeePredictor state caching', () => {
     await expect(getState.call(predictor)).rejects.toThrow('L1 RPC request failed');
     // Same L1 block: must recompute rather than replay the cached rejection.
     await expect(getState.call(predictor)).resolves.toBe(state);
+    expect(fetchState).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not clear the block marker when a stale fetch for an older block rejects', async () => {
+    const blockN = 1n;
+    const blockNext = 2n;
+    const getBlockNumber = jest
+      .fn<() => Promise<bigint>>()
+      .mockResolvedValueOnce(blockN)
+      .mockResolvedValueOnce(blockNext);
+
+    const fetchN = promiseWithResolvers<unknown>();
+    const state = { manaTarget: 1n } as unknown;
+    const fetchState = jest
+      .fn<() => Promise<unknown>>()
+      .mockImplementationOnce(() => fetchN.promise)
+      .mockResolvedValue(state);
+
+    const predictor: FeePredictor = Object.create(FeePredictor.prototype);
+    Reflect.set(predictor, 'publicClient', { getBlockNumber });
+    Reflect.set(predictor, 'cachedL1BlockNumber', undefined);
+    Reflect.set(predictor, 'cachedState', undefined);
+    Reflect.set(predictor, 'fetchState', fetchState);
+
+    const getState = Reflect.get(FeePredictor.prototype, 'getState') as () => Promise<unknown>;
+
+    // Fetch for block N stays in flight; the block N+1 call advances the marker meanwhile.
+    const callN = getState.call(predictor);
+    const callNext = getState.call(predictor);
+
+    // The stale N fetch now rejects. It must NOT clear the marker (which now points at N+1).
+    fetchN.reject(new Error('stale L1 RPC request failed'));
+
+    await expect(callN).rejects.toThrow('stale L1 RPC request failed');
+    await expect(callNext).resolves.toBe(state);
+
+    expect(Reflect.get(predictor, 'cachedL1BlockNumber')).toBe(blockNext);
     expect(fetchState).toHaveBeenCalledTimes(2);
   });
 });

--- a/yarn-project/sequencer-client/src/global_variable_builder/fee_predictor.test.ts
+++ b/yarn-project/sequencer-client/src/global_variable_builder/fee_predictor.test.ts
@@ -12,6 +12,7 @@ import { createLogger } from '@aztec/foundation/log';
 import { DateProvider } from '@aztec/foundation/timer';
 import { FEE_ORACLE_LAG, type GasFees, ManaUsageEstimate, computeExcessMana } from '@aztec/stdlib/gas';
 
+import { jest } from '@jest/globals';
 import { foundry } from 'viem/chains';
 
 import { FeePredictor } from './fee_predictor.js';
@@ -351,4 +352,29 @@ describe('FeePredictor', () => {
       nextCheckpointOffset++;
     }
   }, 60_000);
+});
+
+describe('FeePredictor state caching', () => {
+  it('recovers from a transient L1 read failure without waiting for a new L1 block', async () => {
+    const blockNumber = 1n;
+    const getBlockNumber = jest.fn<() => Promise<bigint>>(() => Promise.resolve(blockNumber));
+    const state = { manaTarget: 1n } as unknown;
+    const fetchState = jest
+      .fn<() => Promise<unknown>>()
+      .mockRejectedValueOnce(new Error('L1 RPC request failed'))
+      .mockResolvedValue(state);
+
+    const predictor: FeePredictor = Object.create(FeePredictor.prototype);
+    Reflect.set(predictor, 'publicClient', { getBlockNumber });
+    Reflect.set(predictor, 'cachedL1BlockNumber', undefined);
+    Reflect.set(predictor, 'cachedState', undefined);
+    Reflect.set(predictor, 'fetchState', fetchState);
+
+    const getState = Reflect.get(FeePredictor.prototype, 'getState') as () => Promise<unknown>;
+
+    await expect(getState.call(predictor)).rejects.toThrow('L1 RPC request failed');
+    // Same L1 block: must recompute rather than replay the cached rejection.
+    await expect(getState.call(predictor)).resolves.toBe(state);
+    expect(fetchState).toHaveBeenCalledTimes(2);
+  });
 });

--- a/yarn-project/sequencer-client/src/global_variable_builder/fee_predictor.ts
+++ b/yarn-project/sequencer-client/src/global_variable_builder/fee_predictor.ts
@@ -63,9 +63,13 @@ export class FeePredictor {
       this.cachedL1BlockNumber = blockNumber;
       // Reset the cached block number on failure so a transient L1 RPC error does not leave a
       // rejected promise cached for this block, which would replay the same rejection on every
-      // subsequent call until the next L1 block arrives.
+      // subsequent call until the next L1 block arrives. Only clear it if it still points at the
+      // block this attempt was for, so a stale rejection from an older block cannot wipe a marker
+      // a newer call already advanced (which would also defeat the monotonic block-number guard).
       this.cachedState = this.fetchState(blockNumber).catch(err => {
-        this.cachedL1BlockNumber = undefined;
+        if (this.cachedL1BlockNumber === blockNumber) {
+          this.cachedL1BlockNumber = undefined;
+        }
         throw err;
       });
     }

--- a/yarn-project/sequencer-client/src/global_variable_builder/fee_predictor.ts
+++ b/yarn-project/sequencer-client/src/global_variable_builder/fee_predictor.ts
@@ -61,7 +61,13 @@ export class FeePredictor {
     const blockNumber = await this.publicClient.getBlockNumber({ cacheTime: 0 });
     if (this.cachedL1BlockNumber === undefined || blockNumber > this.cachedL1BlockNumber) {
       this.cachedL1BlockNumber = blockNumber;
-      this.cachedState = this.fetchState(blockNumber);
+      // Reset the cached block number on failure so a transient L1 RPC error does not leave a
+      // rejected promise cached for this block, which would replay the same rejection on every
+      // subsequent call until the next L1 block arrives.
+      this.cachedState = this.fetchState(blockNumber).catch(err => {
+        this.cachedL1BlockNumber = undefined;
+        throw err;
+      });
     }
     return this.cachedState!;
   }

--- a/yarn-project/sequencer-client/src/global_variable_builder/fee_provider.test.ts
+++ b/yarn-project/sequencer-client/src/global_variable_builder/fee_provider.test.ts
@@ -1,3 +1,4 @@
+import { promiseWithResolvers } from '@aztec/foundation/promise';
 import { GasFees, ManaUsageEstimate } from '@aztec/stdlib/gas';
 
 import { jest } from '@jest/globals';
@@ -61,6 +62,42 @@ describe('FeeProviderImpl', () => {
 
     // A subsequent call at the SAME L1 block must recompute rather than replay the cached rejection.
     await expect(provider.getCurrentMinFees()).resolves.toEqual(new GasFees(0, 42));
+    expect(computeCurrentMinFees).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not clear the block marker when a stale computation for an older block rejects', async () => {
+    const blockN = 1n;
+    const blockNext = 2n;
+    const getBlockNumber = jest
+      .fn<() => Promise<bigint>>()
+      .mockResolvedValueOnce(blockN)
+      .mockResolvedValueOnce(blockNext);
+
+    const computeN = promiseWithResolvers<GasFees>();
+    const computeCurrentMinFees = jest
+      .fn<() => Promise<GasFees>>()
+      .mockImplementationOnce(() => computeN.promise)
+      .mockResolvedValue(new GasFees(0, 42));
+
+    const provider: FeeProviderImpl = Object.create(FeeProviderImpl.prototype);
+    Reflect.set(provider, 'publicClient', { getBlockNumber });
+    Reflect.set(provider, 'currentL1BlockNumber', undefined);
+    Reflect.set(provider, 'currentMinFees', Promise.resolve(new GasFees(0, 0)));
+    Reflect.set(provider, 'computeCurrentMinFees', computeCurrentMinFees);
+
+    // Call at block N starts a computation that stays in flight.
+    const callN = provider.getCurrentMinFees();
+    // Call at block N+1 advances the marker while the N computation is still pending.
+    const callNext = provider.getCurrentMinFees();
+
+    // The stale N computation now rejects. It must NOT clear the marker (which now points at N+1).
+    computeN.reject(new Error('stale L1 RPC request failed'));
+
+    await expect(callN).rejects.toThrow('stale L1 RPC request failed');
+    await expect(callNext).resolves.toEqual(new GasFees(0, 42));
+
+    // Marker still reflects the newer block; the N+1 computation ran exactly once (no spurious recompute).
+    expect(Reflect.get(provider, 'currentL1BlockNumber')).toBe(blockNext);
     expect(computeCurrentMinFees).toHaveBeenCalledTimes(2);
   });
 });

--- a/yarn-project/sequencer-client/src/global_variable_builder/fee_provider.test.ts
+++ b/yarn-project/sequencer-client/src/global_variable_builder/fee_provider.test.ts
@@ -41,4 +41,26 @@ describe('FeeProviderImpl', () => {
 
     expect(getPredictedMinFees).toHaveBeenCalledWith(ManaUsageEstimate.Target);
   });
+
+  it('recovers from a transient L1 read failure without waiting for a new L1 block', async () => {
+    const blockNumber = 1n;
+    const getBlockNumber = jest.fn<() => Promise<bigint>>(() => Promise.resolve(blockNumber));
+    const computeCurrentMinFees = jest
+      .fn<() => Promise<GasFees>>()
+      .mockRejectedValueOnce(new Error('L1 RPC request failed'))
+      .mockResolvedValue(new GasFees(0, 42));
+
+    const provider: FeeProviderImpl = Object.create(FeeProviderImpl.prototype);
+    Reflect.set(provider, 'publicClient', { getBlockNumber });
+    Reflect.set(provider, 'currentL1BlockNumber', undefined);
+    Reflect.set(provider, 'currentMinFees', Promise.resolve(new GasFees(0, 0)));
+    Reflect.set(provider, 'computeCurrentMinFees', computeCurrentMinFees);
+
+    // First call fails on the transient L1 read.
+    await expect(provider.getCurrentMinFees()).rejects.toThrow('L1 RPC request failed');
+
+    // A subsequent call at the SAME L1 block must recompute rather than replay the cached rejection.
+    await expect(provider.getCurrentMinFees()).resolves.toEqual(new GasFees(0, 42));
+    expect(computeCurrentMinFees).toHaveBeenCalledTimes(2);
+  });
 });

--- a/yarn-project/sequencer-client/src/global_variable_builder/fee_provider.ts
+++ b/yarn-project/sequencer-client/src/global_variable_builder/fee_provider.ts
@@ -66,14 +66,19 @@ export class FeeProviderImpl implements FeeProvider {
     // fulfillment, so a prior rejection does not short-circuit the new computation. If the new
     // computation fails (e.g. a transient L1 RPC error), reset the cached block number so the
     // next call recomputes instead of permanently replaying the rejected promise — otherwise a
-    // single transient failure would wedge fee estimation until the next L1 block arrives.
+    // single transient failure would wedge fee estimation until the next L1 block arrives. Only
+    // clear it if it still points at the block this attempt was for, so a stale rejection from an
+    // older block cannot wipe a marker a newer call already advanced (which would also defeat the
+    // monotonic block-number guard).
     if (this.currentL1BlockNumber === undefined || blockNumber > this.currentL1BlockNumber) {
       this.currentL1BlockNumber = blockNumber;
       this.currentMinFees = this.currentMinFees
         .catch(() => undefined)
         .then(() =>
           this.computeCurrentMinFees().catch(err => {
-            this.currentL1BlockNumber = undefined;
+            if (this.currentL1BlockNumber === blockNumber) {
+              this.currentL1BlockNumber = undefined;
+            }
             throw err;
           }),
         );

--- a/yarn-project/sequencer-client/src/global_variable_builder/fee_provider.ts
+++ b/yarn-project/sequencer-client/src/global_variable_builder/fee_provider.ts
@@ -61,10 +61,22 @@ export class FeeProviderImpl implements FeeProvider {
     // Get the current block number
     const blockNumber = await this.publicClient.getBlockNumber({ cacheTime: 0 });
 
-    // If the L1 block number has changed then chain a new promise to get the current min fees
+    // If the L1 block number has changed then chain a new promise to get the current min fees.
+    // We chain off the previous promise's settlement (via a swallowing catch) rather than its
+    // fulfillment, so a prior rejection does not short-circuit the new computation. If the new
+    // computation fails (e.g. a transient L1 RPC error), reset the cached block number so the
+    // next call recomputes instead of permanently replaying the rejected promise — otherwise a
+    // single transient failure would wedge fee estimation until the next L1 block arrives.
     if (this.currentL1BlockNumber === undefined || blockNumber > this.currentL1BlockNumber) {
       this.currentL1BlockNumber = blockNumber;
-      this.currentMinFees = this.currentMinFees.then(() => this.computeCurrentMinFees());
+      this.currentMinFees = this.currentMinFees
+        .catch(() => undefined)
+        .then(() =>
+          this.computeCurrentMinFees().catch(err => {
+            this.currentL1BlockNumber = undefined;
+            throw err;
+          }),
+        );
     }
     return this.currentMinFees;
   }


### PR DESCRIPTION
## Problem

In the docs-examples CI job (`docs/examples/bootstrap.sh execute`), `example_swap` and `recursive_verification` exhausted all 5 retry attempts on the same signature during `.send()` fee estimation:

```
Error: An unknown error occurred while executing the contract function "getTimestampForSlot".
  args: (54)   Details: L1 RPC request failed   code: -32702
```

Stack: `sendTx -> completeFeeOptions -> getMinFees -> aztecNode.getPredictedMinFees / getCurrentMinFees` (over JSON-RPC to the node). The failing reads are node-side, in `FeeProviderImpl.computeCurrentMinFees` (`getTimestampForSlot` / `getManaMinFeeAt`) and `FeePredictor.fetchState`.

Failing run: http://ci.aztec-labs.com/66ef70e6044f13bd (branch `merge-train/spartan-v5`, commit `0e1827b945`).

## Root cause

`FeeProviderImpl.getCurrentMinFees` and `FeePredictor.getState` cache a promise keyed on the L1 block number, refreshing only when the block advances. When the cached computation rejects (a transient `L1 RPC request failed` blip against the single 1-CPU anvil the docs-examples job runs), the rejected promise is replayed on every subsequent call at the same L1 block.

`getCurrentMinFees` was worse: it chained the next computation via `currentMinFees.then(() => computeCurrentMinFees())`. Once `currentMinFees` is rejected, `.then(onFulfilled)` propagates the rejection and never invokes `computeCurrentMinFees` again — so the cache stays poisoned permanently, regardless of L1 block advancement, until the node restarts.

Because fee estimation fails before any L1 tx is submitted, no new L1 block is mined by that path, so a single blip permanently wedges `.send()` on the node. The CI log confirms this: after one transient failure on `getManaMinFeeAt`, `getTimestampForSlot(54)` failed identically across all 5 retries of both examples — even though the node kept mining L1 blocks (148-152) for the examples' own contract deploys in the same second. This rules out a live node/anvil stall and pinpoints the poisoned promise cache.

## Fix

- `getCurrentMinFees`: chain off the previous promise's settlement (via a swallowing `.catch`) rather than its fulfillment, so a prior rejection no longer short-circuits the new computation; and reset the cached L1 block number when the computation rejects so the next call recomputes at the same block.
- `getState` (FeePredictor): reset the cached L1 block number on rejection for the same reason.

Both are idempotent read paths, so recomputing on the next call is safe.

## Testing

- Added unit tests to `fee_provider.test.ts` and `fee_predictor.test.ts` that fail (red) against the current code and pass (green) with the fix: a transient rejection followed by a call at the same L1 block must recompute rather than replay the cached rejection.
- Red/green verified locally: both new tests fail on the unpatched source and the full `sequencer-client` fee suites pass (13 tests) with the fix.
- A deterministic docs-examples repro was not feasible (it depends on a transient L1 RPC blip under CI contention), so the tests target the poisoning mechanism directly.