### PR TITLE
fix(ci): stop merge-train PRs running the same commit multiple times

### DIFF
--- a/.github/workflows/ci3.yml
+++ b/.github/workflows/ci3.yml
@@ -14,8 +14,11 @@ on:
   merge_group: {}
 
 concurrency:
-  # Allow full concurrency for merge-train PRs, one-run-per-branch for everything else.
-  group: ci3-${{ (startsWith(github.event.pull_request.head.ref, 'merge-train/') && github.run_id) || github.event.merge_group.head_ref || github.ref_name }}
+  # merge-train PRs: one run per commit — distinct commits run concurrently (each is a real
+  # train state to test), but duplicate events for the same commit (synchronize + the bot's
+  # label re-applies) collapse. Keying on head.sha instead of run_id is what collapses them;
+  # run_id is unique per run and never collapsed anything. Everything else: one run per branch.
+  group: ci3-${{ (startsWith(github.event.pull_request.head.ref, 'merge-train/') && github.event.pull_request.head.sha) || github.event.merge_group.head_ref || github.ref_name }}
   cancel-in-progress: true
 
 jobs:

--- a/ci3/bootstrap_ec2
+++ b/ci3/bootstrap_ec2
@@ -72,6 +72,14 @@ fi
 # connect/kill helpers so the launch and connect names never drift.
 instance_name=$(aws_instance_name "$REF_NAME" "$arch" "${INSTANCE_POSTFIX:-}")
 
+# Merge-train PRs are intentionally not cancelled per-commit (see ci3.yml concurrency), so
+# several distinct commits build concurrently. Append the commit sha so each gets its own
+# instance and they don't reap each other. ci.sh's connect helpers match the Name tag by
+# substring, so the sha-free base from aws_instance_name still resolves these.
+if [[ "$REF_NAME" == merge-train/* ]]; then
+  instance_name="${instance_name}_${current_commit:0:9}"
+fi
+
 state_dir=$(mktemp -d /tmp/aws_request_instance.XXXXXX)
 
 if semver check "$REF_NAME"; then


### PR DESCRIPTION
## Problem

A single merge-train commit spawned **three** concurrent CI runs (observed on PR #24431 for commit `b7940093a5` — three `pull_request` runs, same SHA, same second), each launching its own EC2 box with the identical name.

## Root cause

Merge-train PRs are intentionally exempt from CI cancellation so each *distinct* accumulated train commit gets tested. But the concurrency group keyed on `github.run_id`:

```
group: ci3-${{ (startsWith(github.event.pull_request.head.ref, 'merge-train/') && github.run_id) || ... }}
```

`github.run_id` is unique **per run**, so `cancel-in-progress` never collapsed anything — including duplicate `pull_request` events for the *same* commit. When a sub-PR merges into `merge-train/spartan`, the bot fires a burst at one SHA: a `synchronize` plus re-applying the `ci-no-squash` and `ci-full-no-test-cache` labels (the `labeled` type is enabled). Each became its own uncancellable run.

Those runs then all built the same instance name (`aztec-packages_merge-train_spartan_amd64_x-full-no-test-cache`) and raced `bootstrap_ec2`'s same-name reap (a check-then-launch race), so all three boxes survived.

## Fix

- **`ci3.yml`** — key the merge-train concurrency group on `github.event.pull_request.head.sha` instead of `github.run_id`. Same-commit duplicate events now collapse (`cancel-in-progress`); distinct commits still run concurrently. Non-merge-train PRs, `merge_group`, and `push` are untouched — the changed operand is only selected when the head ref is `merge-train/*` (for everything else `startsWith(...)` is false and the expression falls through to `merge_group.head_ref || ref_name` exactly as before).
- **`bootstrap_ec2`** — append the commit sha to merge-train instance names, so the distinct commits that *do* run concurrently get their own boxes instead of colliding / reaping each other. `ci.sh`'s connect helpers match the Name tag by substring, so the sha-free base name from `aws_instance_name` still resolves them.

## Verification

- Merge a sub-PR into `merge-train/spartan`; confirm the `synchronize` + two `labeled` events collapse to **one** in-progress `ci3` run for that SHA and exactly one instance is requested.
- Non-regression: push two commits quickly to a normal PR; the older run is cancelled, only the latest proceeds (unchanged).