### PR TITLE
refactor(aztec-nr): unify existing-handshake lookup for tag secret sources

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/messages/delivery/tag.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/delivery/tag.nr
@@ -4,8 +4,10 @@
 
 use crate::context::PrivateContext;
 use crate::messages::delivery::{
-    constrained_delivery::emit_sequence_nullifier, handshake::get_existing_app_siloed_handshake_secrets,
-    OnchainDeliveryMode, tag_derivation::TagDerivation, tag_secret_source::TagSecretSource,
+    constrained_delivery::emit_sequence_nullifier,
+    OnchainDeliveryMode,
+    tag_derivation::{existing_handshake_secrets_or_else, TagDerivation},
+    tag_secret_source::TagSecretSource,
 };
 use crate::oracle::notes::get_next_tagging_index;
 use crate::oracle::resolve_tagging_strategy::resolve_tagging_strategy;
@@ -14,7 +16,6 @@ use crate::protocol::{
     constants::{DOM_SEP__CONSTRAINED_MSG_LOG_TAG, DOM_SEP__UNCONSTRAINED_MSG_LOG_TAG},
     hash::{compute_log_tag, poseidon2_hash},
 };
-use crate::standard_addresses::STANDARD_HANDSHAKE_REGISTRY_ADDRESS;
 
 /// Derives the discovery log tag for an on-chain delivery.
 ///
@@ -40,12 +41,9 @@ fn default_tag_secret_source(
     recipient: AztecAddress,
     mode: OnchainDeliveryMode,
 ) -> TagSecretSource {
-    // Safety: this only selects which source backs the tag. An existing handshake's secrets are constrained against the
-    // registry before a constrained tag is emitted; otherwise the wallet's resolved source runs.
-    let existing =
-        unsafe { get_existing_app_siloed_handshake_secrets(STANDARD_HANDSHAKE_REGISTRY_ADDRESS, sender, recipient) };
-
-    existing.map_or_else(
+    existing_handshake_secrets_or_else(
+        sender,
+        recipient,
         || {
             // Safety: the strategy only selects which source runs; each source constrains (or rejects) its own
             // secret before a constrained tag is emitted, so an untrusted strategy can't produce a valid unbacked
@@ -53,7 +51,6 @@ fn default_tag_secret_source(
             let strategy = unsafe { resolve_tagging_strategy(sender, recipient, mode) };
             strategy.into()
         },
-        |handshake_secrets| TagSecretSource::existing_handshake(handshake_secrets),
     )
 }
 

--- a/noir-projects/aztec-nr/aztec/src/messages/delivery/tag_derivation.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/delivery/tag_derivation.nr
@@ -44,15 +44,12 @@ impl TagDerivation {
     /// Resolves this choice into the [`TagSecretSource`] backing the message tag.
     pub(crate) fn into_tag_secret_source(self, sender: AztecAddress, recipient: AztecAddress) -> TagSecretSource {
         if self.kind == NON_INTERACTIVE_HANDSHAKE {
-            // Safety: this only selects which source backs the tag. A reused handshake's secrets are constrained
-            // against the registry before a constrained tag is emitted, and a fresh handshake is created in a
-            // constrained manner in `obtain_secrets`.
-            let existing = unsafe {
-                get_existing_app_siloed_handshake_secrets(STANDARD_HANDSHAKE_REGISTRY_ADDRESS, sender, recipient)
-            };
-            existing.map_or_else(|| TagSecretSource::new_non_interactive_handshake(), |secrets| {
-                TagSecretSource::existing_handshake(secrets)
-            })
+            // A fresh handshake is created in a constrained manner in `obtain_secrets`.
+            existing_handshake_secrets_or_else(
+                sender,
+                recipient,
+                || TagSecretSource::new_non_interactive_handshake(),
+            )
         } else {
             // Safety: the secret is untrusted, but address-derived tagging is unconstrained-only, where a wrong
             // secret only yields an undiscoverable tag. An invalid recipient has no shared secret, so we fall back
@@ -61,6 +58,22 @@ impl TagDerivation {
             TagSecretSource::unconstrained_secret(secret)
         }
     }
+}
+
+/// Resolves to the secrets of a non-interactive handshake already registered for `(sender, recipient)`, or to
+/// `fallback()` when none exists yet. Shared by the wallet-resolved default (`default_tag_secret_source`) and the
+/// [`TagDerivation::non_interactive_handshake`] override, which only differ in what backs the tag otherwise.
+pub(crate) fn existing_handshake_secrets_or_else<Env>(
+    sender: AztecAddress,
+    recipient: AztecAddress,
+    fallback: fn[Env]() -> TagSecretSource,
+) -> TagSecretSource {
+    // Safety: this only selects which source backs the tag. A reused handshake's secrets are constrained against
+    // the registry before a constrained tag is emitted; the fallback source constrains (or rejects) its own secret
+    // the same way.
+    let existing =
+        unsafe { get_existing_app_siloed_handshake_secrets(STANDARD_HANDSHAKE_REGISTRY_ADDRESS, sender, recipient) };
+    existing.map_or_else(fallback, |secrets| TagSecretSource::existing_handshake(secrets))
 }
 
 mod test {

--- a/noir-projects/aztec-nr/aztec/src/messages/delivery/tag_derivation.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/delivery/tag_derivation.nr
@@ -61,8 +61,7 @@ impl TagDerivation {
 }
 
 /// Resolves to the secrets of a non-interactive handshake already registered for `(sender, recipient)`, or to
-/// `fallback()` when none exists yet. Shared by the wallet-resolved default (`default_tag_secret_source`) and the
-/// [`TagDerivation::non_interactive_handshake`] override, which only differ in what backs the tag otherwise.
+/// `fallback()` when none exists yet.
 pub(crate) fn existing_handshake_secrets_or_else<Env>(
     sender: AztecAddress,
     recipient: AztecAddress,


### PR DESCRIPTION
## Summary
- `default_tag_secret_source` (the wallet-resolved default) and `TagDerivation::into_tag_secret_source`'s non-interactive-handshake branch both looked up an existing registered handshake for `(sender, recipient)` and mapped it to `TagSecretSource::existing_handshake(secrets)`, only differing in what ran when none existed.
- Extracts that shared lookup into `existing_handshake_secrets_or_else`, parameterized by the fallback closure, in `tag_derivation.nr`.

## Test plan
- [x] `nargo check` passes for the `aztec` package
- [x] Confirmed the pre-existing local `nargo test` failures for this file's tests (missing TXE oracle resolver) are unrelated to this change by reproducing them on the unmodified base branch