### PR TITLE
test(e2e): fix epoch-2 tip race in proof_fails after-epoch-end test

### DIFF
--- a/yarn-project/end-to-end/src/single-node/proving/proof_fails.parallel.test.ts
+++ b/yarn-project/end-to-end/src/single-node/proving/proof_fails.parallel.test.ts
@@ -106,27 +106,29 @@ describe('single-node/proving/proof_fails', () => {
     // timestamp gate moves with the warp), then releases, reverts past the deadline, and the
     // post-deadline propose triggers the prune in real time.
     await test.warpToEpochStart(2);
-    // REFACTOR: hand-rolled retryUntil polling rollup.getCheckpointNumber for rollback detection;
-    // a DSL helper like waitForRollback(checkpoint) would make the intent clearer.
-    await retryUntil(
-      async () => (await rollup.getCheckpointNumber()) < checkpointBeforeRollback,
+
+    // Wait until the prune is processed and a new checkpoint mined.
+    const checkpointAfterRollback = await retryUntil(
+      async () => {
+        const checkpoint = await rollup.getCheckpointNumber();
+        return checkpoint > 0 && checkpoint < checkpointBeforeRollback ? checkpoint : undefined;
+      },
       'rollup rolled back',
       L2_SLOT_DURATION_IN_S * 4,
       0.2,
     );
+
+    // The post-rollback chain tip should be in epoch 2, since the rollback-triggering propose
+    // was made during epoch 2, after the deadline.
+    expect(checkpointAfterRollback).toBeLessThan(checkpointBeforeRollback);
+    const latestCheckpoint = await rollup.getCheckpoint(checkpointAfterRollback);
+    expect(getEpochAtSlot(latestCheckpoint.slotNumber, test.constants)).toEqual(EpochNumber(2));
 
     // The prover tx should have been rejected as it was submitted past the deadline
     const lastProverTxHash = proverDelayer.getSentTxHashes().at(-1);
     expect(lastProverTxHash).toBeDefined();
     const lastProverTxReceipt = await l1Client.getTransactionReceipt({ hash: lastProverTxHash! });
     expect(lastProverTxReceipt.status).toEqual('reverted');
-
-    // The post-rollback chain tip should be in epoch 2 (the rollback-triggering propose was made
-    // during epoch 2, after the deadline)
-    const checkpointAfterRollback = await rollup.getCheckpointNumber();
-    expect(checkpointAfterRollback).toBeLessThan(checkpointBeforeRollback);
-    const latestCheckpoint = await rollup.getCheckpoint(checkpointAfterRollback);
-    expect(getEpochAtSlot(latestCheckpoint.slotNumber, test.constants)).toEqual(EpochNumber(2));
 
     logger.warn(`Test succeeded`);
   });


### PR DESCRIPTION
Fixes a genuine timing flake in `single-node/proving/proof_fails.parallel.test.ts` › `does not allow submitting proof after epoch end`, observed in CI run `99ed463db48b9cf2` on the v5 line (`Expected: 2, Received: 0` at the final epoch assertion).

This test ran into a situation where the proposer `prune`d the unproven chain without `propose`ing a new checkpoint, so the check for "has the last checkpoint been mined in epoch 2" failed, since there was _no checkpoint at all_ in the entire chain.

This fixes it so we wait until there's actually a checkpoint mined. In parallel, I'm looking into _why_ the proposer decided to prune without proposing.