### PR TITLE
feat(docs): dual-track page views to Aztec Labs Matomo with consent gating

### DIFF
--- a/docs/src/components/Matomo/matomo.jsx
+++ b/docs/src/components/Matomo/matomo.jsx
@@ -26,6 +26,19 @@ export default function useMatomo() {
   const trackerUrl = `${urlBase}matomo.php`;
   const srcUrl = `${urlBase}matomo.js`;
 
+  // Secondary Matomo instance (Aztec Labs). Registered as an additional tracker
+  // on the shared _paq queue so it inherits the same consent handling and
+  // page-view calls as the primary tracker above.
+  const azteclabsTrackerUrl = "https://azteclabs.matomo.cloud/matomo.php";
+  const azteclabsSiteId = "23";
+  const crossDomainLinkingDomains = [
+    "*.aztec.network",
+    "*.docs.aztec.network",
+    "*.noir-lang.org",
+    "*.play.aztec-labs.com",
+    "*.testnet.aztec.network",
+  ];
+
   window._paq = window._paq || [];
 
   useEffect(() => {
@@ -36,11 +49,20 @@ export default function useMatomo() {
   }, []);
 
   useEffect(() => {
+    // Hold all tracking (for every tracker on the shared _paq queue) until the
+    // user opts in via the banner below. Matomo persists the choice in its own
+    // cookie, so returning visitors who accepted are tracked automatically.
+    pushInstruction("requireConsent");
     pushInstruction("setTrackerUrl", trackerUrl);
     pushInstruction("setSiteId", getSiteId(env));
     if (env !== "prod") {
       pushInstruction("setSecureCookie", false);
     }
+
+    pushInstruction("addTracker", azteclabsTrackerUrl, azteclabsSiteId);
+    pushInstruction("setDomains", crossDomainLinkingDomains);
+    pushInstruction("enableCrossDomainLinking");
+    pushInstruction("enableLinkTracking");
 
     const doc = document;
     const scriptElement = doc.createElement("script");
@@ -71,14 +93,14 @@ export default function useMatomo() {
     localStorage.setItem("matomoConsent", false);
     setShowBanner(false);
   };
-  
+
   // Add global debug function for console access
   useEffect(() => {
-    if (env !== "prod" && typeof window !== 'undefined') {
+    if (env !== "prod" && typeof window !== "undefined") {
       window.forceNPS = () => {
-        const event = new CustomEvent('forceShowNPS');
+        const event = new CustomEvent("forceShowNPS");
         window.dispatchEvent(event);
-        console.log('🔧 Forcing NPS widget to show');
+        console.log("🔧 Forcing NPS widget to show");
       };
 
       // Clean up on unmount


### PR DESCRIPTION
## What

Adds the **Aztec Labs Matomo** instance (`azteclabs.matomo.cloud`, site ID `23`) to the docs site as a second analytics tracker, and gates all tracking behind the existing cookie-consent banner.

Change is confined to `docs/src/components/Matomo/matomo.jsx`.

### Dual-tracking
- Registers the azteclabs instance via Matomo's `addTracker` on the shared `_paq` queue, so every page view is sent to **both** the existing `noirlang.matomo.cloud` (site 6) tracker and the new azteclabs (site 23) one.
- Adds `setDomains` + `enableCrossDomainLinking` + `enableLinkTracking` for cross-domain tracking across the aztec.network / docs.aztec.network / noir-lang.org / play.aztec-labs.com / testnet.aztec.network properties.

### Real consent-gating
- Adds `requireConsent` so **no** tracking request fires to either instance until the user clicks "I accept cookies". This also closes a pre-existing gap where the noirlang tracker beaconed on page load regardless of consent.
- The choice is persisted in Matomo's own cookie (via the existing `rememberConsentGiven` / `forgetConsentGiven` handlers), so returning visitors who accepted are tracked automatically without re-prompting.

## Testing

Verified end-to-end in a browser against a local Docusaurus dev server:

| State | Result |
|---|---|
| Fresh visitor, no consent | Matomo loaded, both trackers registered (`consentRequired: true`), banner shown, **0 beacons** to either instance |
| Click "I accept cookies" | Held page view flushed to both — noirlang (`idsite=6`) + azteclabs (`idsite=23`), each with `consent=1` |
| Navigate to another page | Banner gone, `hasRememberedConsent: true`, page view auto-tracked to both, no re-prompt |
| Refuse path | `forgetConsentGiven` leaves consent unremembered, so nothing tracks |