### PR TITLE
perf(e2e): parallelize setup & p2p work and lighten throwaway txs

### DIFF
--- a/yarn-project/end-to-end/src/fixtures/setup.ts
+++ b/yarn-project/end-to-end/src/fixtures/setup.ts
@@ -525,30 +525,32 @@ async function setupInner(
     }
     logger.trace('Deployed L1 rollup contracts');
 
-    // Use metricsPort-based telemetry if provided, otherwise use the regular telemetry client
-    const telemetryClient = opts.metricsPort
-      ? await getEndToEndTestTelemetryClient(opts.metricsPort)
-      : await getTelemetryClient(opts.telemetryConfig);
+    // These boot steps are independent and write disjoint config keys, so run them concurrently:
+    // telemetry returns a client (no config write), shared blob storage writes blobFileStore* keys,
+    // and the ACVM/BB config resolvers write their own acvm*/bb* keys.
+    const [telemetryClient, , acvmConfig, bbConfig] = await Promise.all([
+      // Use metricsPort-based telemetry if provided, otherwise use the regular telemetry client
+      opts.metricsPort ? getEndToEndTestTelemetryClient(opts.metricsPort) : getTelemetryClient(opts.telemetryConfig),
+      setupSharedBlobStorage(config),
+      getACVMConfig(logger),
+      getBBConfig(logger),
+    ]);
     logger.trace('Created telemetry client');
-
-    await setupSharedBlobStorage(config);
     logger.trace('Set up shared blob storage');
 
-    logger.verbose('Creating and synching an aztec node', config);
-
-    const acvmConfig = await getACVMConfig(logger);
     if (acvmConfig) {
       config.acvmWorkingDirectory = acvmConfig.acvmWorkingDirectory;
       config.acvmBinaryPath = acvmConfig.acvmBinaryPath;
     }
     logger.trace('Resolved ACVM config');
 
-    const bbConfig = await getBBConfig(logger);
     if (bbConfig) {
       config.bbBinaryPath = bbConfig.bbBinaryPath;
       config.bbWorkingDirectory = bbConfig.bbWorkingDirectory;
     }
     logger.trace('Resolved Barretenberg config');
+
+    logger.verbose('Creating and synching an aztec node', config);
 
     let mockGossipSubNetwork: MockGossipSubNetwork | undefined;
     let p2pClientDeps: P2PClientDeps | undefined = undefined;

--- a/yarn-project/end-to-end/src/p2p/gossip_network.test.ts
+++ b/yarn-project/end-to-end/src/p2p/gossip_network.test.ts
@@ -177,10 +177,12 @@ describe('e2e_p2p_network', () => {
     );
 
     t.logger.info('Submitting transactions');
-    for (const node of nodes) {
-      const context = await submitTransactions(t.logger, node, NUM_TXS_PER_NODE, t.fundedAccount);
-      txsSentViaDifferentNodes.push(context);
-    }
+    // Each submitTransactions call builds its own wallet/PXE, so submissions are independent and can run
+    // concurrently. Promise.all preserves node order, keeping txsSentViaDifferentNodes[i] aligned with nodes[i].
+    const submitted = await Promise.all(
+      nodes.map(node => submitTransactions(t.logger, node, NUM_TXS_PER_NODE, t.fundedAccount)),
+    );
+    txsSentViaDifferentNodes.push(...submitted);
 
     t.logger.info('Waiting for transactions to be mined');
     // now ensure that all txs were successfully mined

--- a/yarn-project/end-to-end/src/p2p/preferred_gossip_network.test.ts
+++ b/yarn-project/end-to-end/src/p2p/preferred_gossip_network.test.ts
@@ -365,10 +365,12 @@ describe('e2e_p2p_preferred_network', () => {
 
     // Send the required number of transactions to each node
     t.logger.info('Submitting transactions');
-    for (const node of nodes) {
-      const txs = await submitTransactions(t.logger, node, NUM_TXS_PER_NODE, t.fundedAccount);
-      txsSentViaDifferentNodes.push(txs);
-    }
+    // Each submitTransactions call builds its own wallet/PXE, so submissions are independent and can run
+    // concurrently. Promise.all preserves node order, keeping txsSentViaDifferentNodes[i] aligned with nodes[i].
+    const submitted = await Promise.all(
+      nodes.map(node => submitTransactions(t.logger, node, NUM_TXS_PER_NODE, t.fundedAccount)),
+    );
+    txsSentViaDifferentNodes.push(...submitted);
 
     t.logger.info('Waiting for transactions to be mined');
     // now ensure that all txs were successfully mined

--- a/yarn-project/end-to-end/src/p2p/rediscovery.test.ts
+++ b/yarn-project/end-to-end/src/p2p/rediscovery.test.ts
@@ -113,10 +113,12 @@ describe('e2e_p2p_rediscovery', () => {
 
     await t.waitForP2PMeshConnectivity(newNodes, NUM_VALIDATORS, 120);
 
-    for (const node of newNodes) {
-      const txs = await submitTransactions(t.logger, node, NUM_TXS_PER_NODE, t.fundedAccount);
-      txsSentViaDifferentNodes.push(txs);
-    }
+    // Each submitTransactions call builds its own wallet/PXE, so submissions are independent and can run
+    // concurrently. Promise.all preserves node order, keeping txsSentViaDifferentNodes[i] aligned with newNodes[i].
+    const submitted = await Promise.all(
+      newNodes.map(node => submitTransactions(t.logger, node, NUM_TXS_PER_NODE, t.fundedAccount)),
+    );
+    txsSentViaDifferentNodes.push(...submitted);
 
     // now ensure that all txs were successfully mined
     await Promise.all(

--- a/yarn-project/end-to-end/src/shared/submit-transactions.ts
+++ b/yarn-project/end-to-end/src/shared/submit-transactions.ts
@@ -1,9 +1,10 @@
 import { AztecAddress } from '@aztec/aztec.js/addresses';
-import { NO_WAIT } from '@aztec/aztec.js/contracts';
-import { Fr, GrumpkinScalar } from '@aztec/aztec.js/fields';
+import { NO_WAIT, getContractInstanceFromInstantiationParams } from '@aztec/aztec.js/contracts';
+import { Fr } from '@aztec/aztec.js/fields';
 import type { Logger } from '@aztec/aztec.js/log';
 import { TxHash, type TxReceipt, TxStatus } from '@aztec/aztec.js/tx';
 import { times } from '@aztec/foundation/collection';
+import { TestContract, TestContractArtifact } from '@aztec/noir-test-contracts.js/Test';
 
 import type { TestWallet } from '../test-wallet/test_wallet.js';
 
@@ -14,12 +15,19 @@ export const submitTxsTo = async (
   numTxs: number,
   logger: Logger,
 ): Promise<TxHash[]> => {
+  // Register (without deploying) a single TestContract instance to source cheap throwaway txs from.
+  // emit_nullifier is #[noinitcheck], so it runs on a register-only instance — this avoids a full
+  // account-contract deployment per tx, which is all these callers were paying for a mined/gossiped tx.
+  const testContractInstance = await getContractInstanceFromInstantiationParams(TestContractArtifact, {
+    salt: Fr.random(),
+  });
+  await wallet.registerContract(testContractInstance, TestContractArtifact);
+  const contract = TestContract.at(testContractInstance.address, wallet);
+
   const txHashes: TxHash[] = [];
   await Promise.all(
     times(numTxs, async () => {
-      const accountManager = await wallet.createSchnorrAccount(Fr.random(), Fr.random(), GrumpkinScalar.random());
-      const deployMethod = await accountManager.getDeployMethod();
-      const { txHash } = await deployMethod.send({ from: submitter, wait: NO_WAIT });
+      const { txHash } = await contract.methods.emit_nullifier(Fr.random()).send({ from: submitter, wait: NO_WAIT });
 
       logger.info(`Tx sent with hash ${txHash}`);
       const receipt: TxReceipt = await wallet.getTxReceipt(txHash);

--- a/yarn-project/ethereum/src/test/chain_monitor.ts
+++ b/yarn-project/ethereum/src/test/chain_monitor.ts
@@ -36,9 +36,20 @@ export type ChainMonitorEventMap = {
   'l2-fees': [L2FeeData];
 };
 
+/** Options for tuning what the {@link ChainMonitor} polls on each new L1 block. */
+export type ChainMonitorOptions = {
+  /**
+   * Whether to fetch L2 fee/oracle data (5 extra rollup reads per new L1 block) and emit `l2-fees`.
+   * Defaults to `true`. Set to `false` for tests that only care about slot/checkpoint/proven state to
+   * avoid the extra round-trips.
+   */
+  includeFeeData?: boolean;
+};
+
 /** Utility class that polls the chain on quick intervals and logs new L1 blocks, L2 blocks, and L2 proofs. */
 export class ChainMonitor extends EventEmitter<ChainMonitorEventMap> {
   private readonly l1Client: ViemClient;
+  private readonly includeFeeData: boolean;
   private inbox: InboxContract | undefined;
   private handle: NodeJS.Timeout | undefined;
   // eslint-disable-next-line aztec-custom/no-non-primitive-in-collections
@@ -68,9 +79,11 @@ export class ChainMonitor extends EventEmitter<ChainMonitorEventMap> {
     private readonly dateProvider: DateProvider = new DateProvider(),
     private readonly logger = createLogger('aztecjs:utils:chain_monitor'),
     private readonly intervalMs = 200,
+    options: ChainMonitorOptions = {},
   ) {
     super();
     this.l1Client = rollup.client;
+    this.includeFeeData = options.includeFeeData ?? true;
   }
 
   start() {
@@ -183,11 +196,13 @@ export class ChainMonitor extends EventEmitter<ChainMonitorEventMap> {
       this.emit('l2-slot', { l2SlotNumber, timestamp });
     }
 
-    const feeData = await this.fetchFeeData(timestamp);
-    if (this.hasFeeDataChanged(feeData)) {
-      msg += ` with L2 min fee ${feeData.minFeePerMana}`;
-      this.l2FeeData = feeData;
-      this.emit('l2-fees', feeData);
+    if (this.includeFeeData) {
+      const feeData = await this.fetchFeeData(timestamp);
+      if (this.hasFeeDataChanged(feeData)) {
+        msg += ` with L2 min fee ${feeData.minFeePerMana}`;
+        this.l2FeeData = feeData;
+        this.emit('l2-fees', feeData);
+      }
     }
 
     this.logger.info(msg, {


### PR DESCRIPTION
Round of low-risk e2e test-suite speedups that touch only test fixtures and test-support code (no production behavior change).

## Approach

- Parallelize the four independent setup boot steps (telemetry client, shared blob storage, ACVM config, BB config) in `setupInner` — they write disjoint config keys, so `Promise.all` is safe.
- Parallelize the per-node `submitTransactions` loops in the gossip / preferred-gossip / rediscovery P2P tests (`Promise.all` preserves index order; `gossip_network_no_cheat` deliberately left serial).
- Replace the per-tx full Schnorr account deployment in `submitTxsTo` with register-only `TestContract.emit_nullifier` throwaway txs (`#[noinitcheck]`, so no on-chain deploy) — same tx count, much lighter per-tx proving and DA across the P2P and slashing throwaway-tx paths.
- Add an opt-out flag to `ChainMonitor` fee-data polling (default preserves current behavior) so slot-heavy tests can skip 5 rollup reads per L1 block.