### PR TITLE
fix(sequencer): make lifecycle idempotent and restartable

### DIFF
--- a/yarn-project/ethereum/src/publisher_manager.test.ts
+++ b/yarn-project/ethereum/src/publisher_manager.test.ts
@@ -447,7 +447,7 @@ describe('PublisherManager', () => {
       expect(funder.interrupted).toBe(false);
     });
 
-    it('is idempotent on double start (does not orphan a funding loop)', async () => {
+    it('is idempotent on double start (does not orphan a loop or re-spawn monitors)', async () => {
       mockPublishers = createMockPublishers(1);
       const funder = new TestL1TxUtils(EthAddress.random()) as TestL1TxUtils & L1TxUtils;
       funder.balance = 5000n;
@@ -465,6 +465,23 @@ describe('PublisherManager', () => {
       // A second start must reuse the already-running funding loop, not spawn a new one that leaks.
       expect(loopAfterSecond).toBe(loopAfterFirst);
       expect(loopAfterSecond?.isRunning()).toBe(true);
+      // And it must not re-run loadStateAndResumeMonitoring, which would spawn a duplicate background
+      // monitor per pending nonce.
+      expect(mockPublishers[0].loadCount).toBe(1);
+    });
+
+    it('reloads monitoring on a start that follows a stop (restart), not on a bare double start', async () => {
+      mockPublishers = createMockPublishers(1);
+      publisherManager = new PublisherManager(mockPublishers, {});
+
+      await publisherManager.start();
+      expect(mockPublishers[0].loadCount).toBe(1);
+
+      await publisherManager.stop();
+      await publisherManager.start();
+
+      // A real restart (after stop) reloads state so in-flight txs resume monitoring.
+      expect(mockPublishers[0].loadCount).toBe(2);
     });
 
     it('is idempotent on double stop', async () => {

--- a/yarn-project/ethereum/src/publisher_manager.test.ts
+++ b/yarn-project/ethereum/src/publisher_manager.test.ts
@@ -418,6 +418,67 @@ describe('PublisherManager', () => {
     });
   });
 
+  describe('lifecycle', () => {
+    it('stop interrupts all publishers and the funder', async () => {
+      mockPublishers = createMockPublishers(3);
+      const funder = new TestL1TxUtils(EthAddress.random()) as TestL1TxUtils & L1TxUtils;
+      publisherManager = new PublisherManager(mockPublishers, {}, { funder });
+
+      await publisherManager.start();
+      await publisherManager.stop();
+
+      expect(mockPublishers.every(p => p.interrupted)).toBe(true);
+      expect(funder.interrupted).toBe(true);
+    });
+
+    it('start after stop clears the interrupted flag so publishing works again', async () => {
+      mockPublishers = createMockPublishers(3);
+      const funder = new TestL1TxUtils(EthAddress.random()) as TestL1TxUtils & L1TxUtils;
+      publisherManager = new PublisherManager(mockPublishers, {}, { funder });
+
+      await publisherManager.start();
+      await publisherManager.stop();
+      expect(mockPublishers.every(p => p.interrupted)).toBe(true);
+
+      // Restart: interrupted must be cleared, otherwise sendTransaction would throw InterruptError.
+      await publisherManager.start();
+
+      expect(mockPublishers.every(p => !p.interrupted)).toBe(true);
+      expect(funder.interrupted).toBe(false);
+    });
+
+    it('is idempotent on double start (does not orphan a funding loop)', async () => {
+      mockPublishers = createMockPublishers(1);
+      const funder = new TestL1TxUtils(EthAddress.random()) as TestL1TxUtils & L1TxUtils;
+      funder.balance = 5000n;
+      publisherManager = new PublisherManager(
+        mockPublishers,
+        { publisherFundingThreshold: 100n, publisherFundingAmount: 50n },
+        { funder },
+      );
+
+      await publisherManager.start();
+      const loopAfterFirst = (publisherManager as any).fundingPromise;
+      await publisherManager.start();
+      const loopAfterSecond = (publisherManager as any).fundingPromise;
+
+      // A second start must reuse the already-running funding loop, not spawn a new one that leaks.
+      expect(loopAfterSecond).toBe(loopAfterFirst);
+      expect(loopAfterSecond?.isRunning()).toBe(true);
+    });
+
+    it('is idempotent on double stop', async () => {
+      mockPublishers = createMockPublishers(2);
+      publisherManager = new PublisherManager(mockPublishers, {});
+
+      await publisherManager.start();
+      await publisherManager.stop();
+      await expect(publisherManager.stop()).resolves.not.toThrow();
+
+      expect(mockPublishers.every(p => p.interrupted)).toBe(true);
+    });
+  });
+
   function createMockPublishers(count: number, addresses: EthAddress[] = []): (TestL1TxUtils & L1TxUtils)[] {
     const tempAddress = [...addresses];
     return times(
@@ -431,6 +492,9 @@ class TestL1TxUtils {
   public state: TxUtilsState = TxUtilsState.IDLE;
   public lastMinedAtBlockNumber: bigint | undefined = undefined;
   public balance: bigint = 1000n;
+  /** Mirrors the real ReadOnlyL1TxUtils.interrupted flag so tests can assert publishing is re-enabled. */
+  public interrupted = false;
+  public loadCount = 0;
   public sendAndMonitorTransaction = jest.fn<() => Promise<any>>().mockResolvedValue({
     receipt: { transactionHash: '0xabc', status: 'success' },
     state: {},
@@ -446,7 +510,16 @@ class TestL1TxUtils {
     return this.senderAddress;
   }
 
-  public async loadStateAndResumeMonitoring() {}
+  public loadStateAndResumeMonitoring() {
+    this.loadCount++;
+    return Promise.resolve();
+  }
 
-  public interrupt() {}
+  public interrupt() {
+    this.interrupted = true;
+  }
+
+  public restart() {
+    this.interrupted = false;
+  }
 }

--- a/yarn-project/ethereum/src/publisher_manager.ts
+++ b/yarn-project/ethereum/src/publisher_manager.ts
@@ -42,6 +42,7 @@ export class PublisherManager<UtilsType extends L1TxUtils = L1TxUtils> {
   private static readonly FUNDING_CHECK_INTERVAL_MS = 2 * 60 * 1000;
   protected funder?: UtilsType;
   protected fundingPromise?: RunningPromise;
+  private started = false;
 
   constructor(
     protected publishers: UtilsType[],
@@ -73,10 +74,17 @@ export class PublisherManager<UtilsType extends L1TxUtils = L1TxUtils> {
    * Loads the state of all publishers and the funder, clears any interrupted flag left by a previous
    * {@link stop} so publishing works again after a restart, and starts periodic funding checks.
    *
-   * Idempotent and safe to call as a restart after {@link stop}: the funding loop is only started when
-   * it is not already running, so a second call does not orphan a poll loop.
+   * Idempotent: a redundant start while already started is a no-op, so it neither orphans a funding loop
+   * nor re-runs `loadStateAndResumeMonitoring` (which would spawn a second background monitor per pending
+   * nonce). Safe to call as a restart after {@link stop} to re-enable publishing.
    */
   public async start(): Promise<void> {
+    if (this.started) {
+      this.log.debug('PublisherManager already started, ignoring start');
+      return;
+    }
+    this.started = true;
+
     // Clear the interrupted flag set by a previous stop() so a restarted manager can publish again.
     // On a first start this is a no-op (the flag is already clear).
     this.publishers.forEach(pub => pub.restart());
@@ -108,6 +116,7 @@ export class PublisherManager<UtilsType extends L1TxUtils = L1TxUtils> {
    * clears the interrupted flag.
    */
   public async stop(): Promise<void> {
+    this.started = false;
     await this.fundingPromise?.stop();
     this.fundingPromise = undefined;
     this.publishers.forEach(pub => pub.interrupt());

--- a/yarn-project/ethereum/src/publisher_manager.ts
+++ b/yarn-project/ethereum/src/publisher_manager.ts
@@ -69,8 +69,19 @@ export class PublisherManager<UtilsType extends L1TxUtils = L1TxUtils> {
     }
   }
 
-  /** Loads the state of all publishers and the funder, and starts periodic funding checks. */
+  /**
+   * Loads the state of all publishers and the funder, clears any interrupted flag left by a previous
+   * {@link stop} so publishing works again after a restart, and starts periodic funding checks.
+   *
+   * Idempotent and safe to call as a restart after {@link stop}: the funding loop is only started when
+   * it is not already running, so a second call does not orphan a poll loop.
+   */
   public async start(): Promise<void> {
+    // Clear the interrupted flag set by a previous stop() so a restarted manager can publish again.
+    // On a first start this is a no-op (the flag is already clear).
+    this.publishers.forEach(pub => pub.restart());
+    this.funder?.restart();
+
     await Promise.all([
       ...this.publishers.map(pub => pub.loadStateAndResumeMonitoring()),
       this.funder?.loadStateAndResumeMonitoring(),
@@ -79,7 +90,8 @@ export class PublisherManager<UtilsType extends L1TxUtils = L1TxUtils> {
     if (
       this.funder &&
       this.config.publisherFundingThreshold !== undefined &&
-      this.config.publisherFundingAmount !== undefined
+      this.config.publisherFundingAmount !== undefined &&
+      !this.fundingPromise?.isRunning()
     ) {
       this.fundingPromise = new RunningPromise(
         () => this.triggerFundingIfNeeded(),
@@ -90,9 +102,14 @@ export class PublisherManager<UtilsType extends L1TxUtils = L1TxUtils> {
     }
   }
 
-  /** Stops the funding loop and interrupts all publishers. */
+  /**
+   * Stops the funding loop and interrupts all publishers so no further L1 txs are sent. Idempotent:
+   * safe to call multiple times. After a stop the manager can be restarted via {@link start}, which
+   * clears the interrupted flag.
+   */
   public async stop(): Promise<void> {
     await this.fundingPromise?.stop();
+    this.fundingPromise = undefined;
     this.publishers.forEach(pub => pub.interrupt());
     this.funder?.interrupt();
   }

--- a/yarn-project/foundation/src/promise/running-promise.test.ts
+++ b/yarn-project/foundation/src/promise/running-promise.test.ts
@@ -27,6 +27,33 @@ describe('RunningPromise', () => {
     await runningPromise.stop();
   });
 
+  describe('idempotency', () => {
+    it('a second start does not spawn a second poll loop', async () => {
+      runningPromise.start();
+      expect(counter).toEqual(1);
+      expect(runningPromise.isRunning()).toBe(true);
+
+      // Starting again while already running must be a no-op, not a second concurrent loop.
+      runningPromise.start();
+      expect(counter).toEqual(1);
+
+      await jest.advanceTimersToNextTimerAsync();
+      // Exactly one loop advanced the counter, not two.
+      expect(counter).toEqual(2);
+    });
+
+    it('stop is safe to call when never started and when already stopped', async () => {
+      await expect(runningPromise.stop()).resolves.toBeUndefined();
+
+      runningPromise.start();
+      await runningPromise.stop();
+      expect(runningPromise.isRunning()).toBe(false);
+
+      await expect(runningPromise.stop()).resolves.toBeUndefined();
+      expect(runningPromise.isRunning()).toBe(false);
+    });
+  });
+
   describe('trigger', () => {
     it('immediately runs the function when not running and awaits for completion', async () => {
       await runningPromise.trigger();

--- a/yarn-project/sequencer-client/src/client/sequencer-client.ts
+++ b/yarn-project/sequencer-client/src/client/sequencer-client.ts
@@ -180,16 +180,24 @@ export class SequencerClient {
     this.validatorClient?.updateConfig(config);
   }
 
-  /** Starts the sequencer. */
+  /**
+   * Starts (or restarts) the sequencer, validator, publishers, and metrics. Each underlying start is
+   * idempotent, so this is safe to call after a previous {@link stop} to resume building and publishing.
+   * The publisher manager is started before the sequencer's poll loop so publishers are un-interrupted
+   * (their interrupted flag cleared by {@link PublisherManager.start}) before the sequencer tries to
+   * publish to L1 — otherwise the first post-restart publish would throw an InterruptError.
+   */
   public async start() {
     await this.validatorClient?.start();
+    await this.publisherManager.start();
     this.sequencer.start();
     this.l1Metrics?.start();
-    await this.publisherManager.start();
   }
 
   /**
-   * Stops the sequencer from processing new txs.
+   * Stops the sequencer, validator, publishers, and metrics, fully draining in-flight work. Idempotent:
+   * safe to call multiple times. Terminal shutdown for production teardown; the client may nonetheless be
+   * restarted via {@link start}.
    */
   public async stop() {
     await this.sequencer.stop();

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.test.ts
@@ -458,6 +458,63 @@ describe('sequencer', () => {
       expect([SequencerState.STOPPED, SequencerState.STOPPING]).not.toContain(sequencer.status().state);
     });
 
+    it('refuses to start while stopping, so no fresh poll loop is orphaned mid-stop', async () => {
+      sequencer.start();
+      const loopBeforeStop = sequencer.getRunningPromise();
+
+      // Park stop() in the STOPPING state by hanging stopAll until we release it.
+      const { promise: stopAllHang, resolve: releaseStopAll } = promiseWithResolvers<void>();
+      publisherFactory.stopAll.mockReturnValueOnce(stopAllHang);
+
+      const stopPromise = sequencer.stop();
+      expect(sequencer.status().state).toBe(SequencerState.STOPPING);
+
+      // A start() landing mid-stop must be refused, not allocate a new loop the stop would orphan.
+      sequencer.start();
+      expect(sequencer.getRunningPromise()).toBe(loopBeforeStop);
+
+      releaseStopAll();
+      await stopPromise;
+      expect(sequencer.status().state).toBe(SequencerState.STOPPED);
+    });
+
+    it('interrupts and drains a fallback send registered after the stop began (last in-flight work())', async () => {
+      sequencer.start();
+
+      // Park stop() before the poll loop is awaited, then register a fallback send during that window —
+      // this stands in for the last in-flight work() enqueuing a fallback send after stop() started.
+      // The interrupt+drain must still catch it, since interruption happens after the loop stops.
+      const { promise: stopAllHang, resolve: releaseStopAll } = promiseWithResolvers<void>();
+      publisherFactory.stopAll.mockReturnValueOnce(stopAllHang);
+
+      const stopPromise = sequencer.stop();
+
+      const { promise: sendHang, resolve: releaseSend } = promiseWithResolvers<undefined>();
+      sequencer.trackFallbackSendForTest(
+        publisher,
+        sendHang.then(() => {
+          if (publisher.interrupt.mock.calls.length === 0) {
+            throw new Error('late fallback send completed without being interrupted by stop()');
+          }
+          return undefined;
+        }),
+      );
+      expect(sequencer.getPendingFallbackSendCount()).toBe(1);
+
+      // Release the stopAll park; stop() then stops the loop and enters drainPendingFallbackSends,
+      // which interrupts the tracked wrapper before awaiting it. Only after that do we release the
+      // (now short-circuited) send so stop() can complete.
+      releaseStopAll();
+      await new Promise(resolve => setTimeout(resolve, 0));
+      expect(publisher.interrupt).toHaveBeenCalled();
+
+      releaseSend(undefined);
+      await stopPromise;
+
+      expect(sequencer.getPendingFallbackSendCount()).toBe(0);
+      expect(sequencer.status().state).toBe(SequencerState.STOPPED);
+    });
+
     it('drains an in-flight fallback send on stop, leaving nothing dangling across a restart', async () => {
       // Drive the fire-and-forget fallback path (vote/prune when we cannot build) with a send that
       // hangs until we release it, mimicking a wrapper publisher sleeping in waitForTargetSlot.
@@ -1813,6 +1870,10 @@ class TestSequencer extends Sequencer {
 
   public getPendingFallbackSendCount() {
     return this.pendingFallbackSends.size;
+  }
+
+  public trackFallbackSendForTest(publisher: SequencerPublisher, send: Promise<unknown>) {
+    return this.trackFallbackSend(publisher, send);
   }
 
   public checkCanProposeForTest(slot: SlotNumber) {

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.test.ts
@@ -13,6 +13,7 @@ import { Secp256k1Signer } from '@aztec/foundation/crypto/secp256k1-signer';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { Signature } from '@aztec/foundation/eth-signature';
+import { promiseWithResolvers } from '@aztec/foundation/promise';
 import { TestDateProvider } from '@aztec/foundation/timer';
 import type { P2P } from '@aztec/p2p';
 import type { SlasherClientInterface } from '@aztec/slasher';
@@ -405,6 +406,103 @@ describe('sequencer', () => {
 
     it('accepts a multiplier at or above the network minimum', () => {
       expect(() => sequencer.updateConfig({ perBlockAllocationMultiplier: 1.5 })).not.toThrow();
+    });
+  });
+
+  describe('lifecycle', () => {
+    afterEach(async () => {
+      await sequencer.stop();
+    });
+
+    it('start is idempotent: a second start does not orphan or replace the poll loop', () => {
+      sequencer.start();
+      const firstLoop = sequencer.getRunningPromise();
+      expect(sequencer.isRunning()).toBe(true);
+
+      sequencer.start();
+      const secondLoop = sequencer.getRunningPromise();
+
+      // The second start must be a no-op reusing the same loop, not a fresh RunningPromise that
+      // leaves the first loop running with no handle to stop it.
+      expect(secondLoop).toBe(firstLoop);
+      expect(sequencer.isRunning()).toBe(true);
+    });
+
+    it('stop is a terminal teardown that stops the poll loop and moves to STOPPED', async () => {
+      sequencer.start();
+      expect(sequencer.isRunning()).toBe(true);
+
+      await sequencer.stop();
+
+      expect(sequencer.isRunning()).toBe(false);
+      expect(sequencer.status().state).toBe(SequencerState.STOPPED);
+    });
+
+    it('stop is idempotent: a second stop is a no-op', async () => {
+      sequencer.start();
+      await sequencer.stop();
+      await expect(sequencer.stop()).resolves.not.toThrow();
+      expect(sequencer.status().state).toBe(SequencerState.STOPPED);
+    });
+
+    it('can be restarted after a stop and resumes the poll loop', async () => {
+      sequencer.start();
+      await sequencer.stop();
+      expect(sequencer.isRunning()).toBe(false);
+
+      sequencer.start();
+
+      expect(sequencer.isRunning()).toBe(true);
+      // The loop is live again (start runs work() immediately, so the exact state may already have
+      // advanced past IDLE); the point is it is no longer STOPPED/STOPPING.
+      expect([SequencerState.STOPPED, SequencerState.STOPPING]).not.toContain(sequencer.status().state);
+    });
+
+    it('drains an in-flight fallback send on stop, leaving nothing dangling across a restart', async () => {
+      // Drive the fire-and-forget fallback path (vote/prune when we cannot build) with a send that
+      // hangs until we release it, mimicking a wrapper publisher sleeping in waitForTargetSlot.
+      const differentHash = Fr.random().toString();
+      worldState.status.mockResolvedValue({
+        state: WorldStateRunningState.IDLE,
+        syncSummary: {
+          latestBlockNumber: BlockNumber(lastBlockNumber + 1),
+          latestBlockHash: differentHash,
+        } as WorldStateSyncStatus,
+      });
+      const startDeadline = sequencer.getTimeTable().getBuildStartDeadline(SlotNumber(newSlotNumber));
+      dateProvider.setTime((startDeadline + 1) * 1000);
+      validatorClient.getValidatorAddresses.mockReturnValue([signer.address]);
+      epochCache.getProposerAttesterAddressInSlot.mockResolvedValue(signer.address);
+      slasherClient.getProposerActions.mockResolvedValue([
+        { type: 'vote-offenses' as const, round: 1n, votes: [], committees: [] },
+      ]);
+      publisher.enqueueSlashingActions.mockResolvedValue(true);
+
+      // The fallback send resolves only when we release it, and only after the sequencer interrupts it.
+      const { promise: sendHang, resolve: releaseSend } = promiseWithResolvers<undefined>();
+      publisher.sendRequestsAt.mockReturnValueOnce(
+        sendHang.then(() => {
+          if (publisher.interrupt.mock.calls.length === 0) {
+            throw new Error('fallback send completed without being interrupted by stop()');
+          }
+          return undefined;
+        }),
+      );
+
+      await sequencer.work();
+      expect(publisher.sendRequestsAt).toHaveBeenCalled();
+      expect(sequencer.getPendingFallbackSendCount()).toBe(1);
+
+      // stop() must interrupt the fallback wrapper and await it, so once the sleeper is released it
+      // short-circuits (no stale tx) and the tracking set is empty before a restart could clear
+      // the interrupted flag.
+      const stopPromise = sequencer.stop();
+      releaseSend(undefined);
+      await stopPromise;
+
+      expect(publisher.interrupt).toHaveBeenCalled();
+      expect(sequencer.getPendingFallbackSendCount()).toBe(0);
+      expect(sequencer.status().state).toBe(SequencerState.STOPPED);
     });
   });
 
@@ -1703,6 +1801,18 @@ class TestSequencer extends Sequencer {
 
   public async awaitLastProposalSubmission() {
     await this.lastCheckpointProposalJob?.awaitPendingSubmission();
+  }
+
+  public getRunningPromise() {
+    return this.runningPromise;
+  }
+
+  public isRunning() {
+    return this.runningPromise?.isRunning() ?? false;
+  }
+
+  public getPendingFallbackSendCount() {
+    return this.pendingFallbackSends.size;
   }
 
   public checkCanProposeForTest(slot: SlotNumber) {

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.ts
@@ -286,10 +286,18 @@ export class Sequencer extends (EventEmitter as new () => TypedEventEmitter<Sequ
   /**
    * Starts (or restarts) the sequencer and moves it to the IDLE state. Idempotent: if the poll loop is
    * already running this is a no-op, so a double start never orphans a second loop. Safe to call after a
-   * previous {@link stop} to resume building — the caller is responsible for restarting the publishers
-   * (see {@link SequencerClient.start}) so that L1 publishing is re-enabled.
+   * previous {@link stop} has fully resolved to resume building — the caller is responsible for restarting
+   * the publishers (see {@link SequencerClient.start}) so that L1 publishing is re-enabled.
+   *
+   * Lifecycle calls are expected to be serialized by the caller. As a guard against a start racing an
+   * in-progress {@link stop}, a start while STOPPING is refused: allocating a fresh poll loop mid-stop
+   * would leave a running loop that the still-in-flight stop would then mark STOPPED, orphaning it.
    */
   public start() {
+    if (this.state === SequencerState.STOPPING) {
+      this.log.warn('Attempted to start sequencer while it is stopping; ignoring');
+      return;
+    }
     if (this.runningPromise?.isRunning()) {
       this.log.warn('Attempted to start sequencer that is already running');
       return;
@@ -323,13 +331,11 @@ export class Sequencer extends (EventEmitter as new () => TypedEventEmitter<Sequ
     this.log.info(`Stopping sequencer`);
     this.setState(SequencerState.STOPPING, undefined, { force: true });
     this.lastCheckpointProposalJob?.interrupt();
-    // Interrupt the fallback senders' own interruptible sleeps (independent of the pooled L1TxUtils),
-    // so a sleeper waiting for a target slot wakes immediately and short-circuits instead of surviving
-    // the stop as a dangling promise that a later restart could re-arm into a stale-slot send.
-    for (const { publisher } of this.pendingFallbackSends) {
-      publisher.interrupt();
-    }
     await this.publisherFactory.stopAll();
+    // Stop the poll loop and await the in-flight work() iteration. work() enqueues its fire-and-forget
+    // fallback send synchronously before returning, so once this resolves no further work() will run and
+    // pendingFallbackSends holds every send that will ever exist. Only then do we interrupt and drain
+    // them — interrupting before this point would miss a send registered by the last in-flight work().
     await this.runningPromise?.stop();
     await this.lastCheckpointProposalJob?.awaitPendingSubmission();
     await this.drainPendingFallbackSends();
@@ -337,8 +343,17 @@ export class Sequencer extends (EventEmitter as new () => TypedEventEmitter<Sequ
     this.log.info('Stopped sequencer');
   }
 
-  /** Awaits every tracked fallback send to settle, then clears the tracking set. */
+  /**
+   * Interrupts every tracked fallback sender's own interruptible sleep (independent of the pooled
+   * L1TxUtils) so a sleeper waiting for a target slot wakes immediately and short-circuits, then awaits
+   * all of them to settle and clears the tracking set. This guarantees no dangling sleeper survives the
+   * stop that a later restart (which clears the interrupted flag) could re-arm into a stale-slot send.
+   * Must be called after the poll loop has stopped, so the set is final.
+   */
   private async drainPendingFallbackSends(): Promise<void> {
+    for (const { publisher } of this.pendingFallbackSends) {
+      publisher.interrupt();
+    }
     const pending = [...this.pendingFallbackSends].map(entry => entry.done);
     if (pending.length > 0) {
       await Promise.allSettled(pending);
@@ -350,7 +365,7 @@ export class Sequencer extends (EventEmitter as new () => TypedEventEmitter<Sequ
    * Registers a fire-and-forget fallback send so {@link stop} can interrupt its wrapper publisher and
    * await its completion. The entry removes itself once the send settles.
    */
-  private trackFallbackSend(publisher: SequencerPublisher, send: Promise<unknown>): void {
+  protected trackFallbackSend(publisher: SequencerPublisher, send: Promise<unknown>): void {
     const entry = { publisher, done: Promise.resolve() };
     entry.done = send.then(
       () => {

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.ts
@@ -79,7 +79,7 @@ type SequencerSlotContext = {
  * - Votes for proposals and slashes on L1
  */
 export class Sequencer extends (EventEmitter as new () => TypedEventEmitter<SequencerEvents>) {
-  private runningPromise?: RunningPromise;
+  protected runningPromise?: RunningPromise;
   private state = SequencerState.STOPPED;
   private stateSlotNumber: SlotNumber | undefined;
   /** Wall-clock time (ms, via the date provider) at which the current state was entered. */
@@ -109,6 +109,16 @@ export class Sequencer extends (EventEmitter as new () => TypedEventEmitter<Sequ
 
   /** The last checkpoint proposal job, tracked so we can await its pending L1 submission during shutdown. */
   protected lastCheckpointProposalJob: CheckpointProposalJob | undefined;
+
+  /**
+   * In-flight fire-and-forget fallback submissions (votes/prune when we cannot build, or escape-hatch
+   * votes). Each entry pairs the wrapper publisher — whose own interruptible sleep is independent of the
+   * pooled L1TxUtils — with the promise of its scheduled send. On {@link stop} we interrupt every wrapper
+   * (waking its sleep so it short-circuits) and await every promise, guaranteeing no sleeper survives the
+   * stop. This is what keeps a later restart (which clears the interrupted flag) from un-gating a stale
+   * sleeper and publishing a stale-slot tx.
+   */
+  protected pendingFallbackSends = new Set<{ publisher: SequencerPublisher; done: Promise<void> }>();
 
   /** Proposer schedule and block sub-slot timetable for the sequencer, rebuilt on every config update. */
   protected timetable!: ProposerTimetable;
@@ -273,8 +283,17 @@ export class Sequencer extends (EventEmitter as new () => TypedEventEmitter<Sequ
     getKzg();
   }
 
-  /** Starts the sequencer and moves to IDLE state. */
+  /**
+   * Starts (or restarts) the sequencer and moves it to the IDLE state. Idempotent: if the poll loop is
+   * already running this is a no-op, so a double start never orphans a second loop. Safe to call after a
+   * previous {@link stop} to resume building — the caller is responsible for restarting the publishers
+   * (see {@link SequencerClient.start}) so that L1 publishing is re-enabled.
+   */
   public start() {
+    if (this.runningPromise?.isRunning()) {
+      this.log.warn('Attempted to start sequencer that is already running');
+      return;
+    }
     this.runningPromise = new RunningPromise(
       this.safeWork.bind(this),
       this.log,
@@ -290,16 +309,58 @@ export class Sequencer extends (EventEmitter as new () => TypedEventEmitter<Sequ
     return this.runningPromise?.trigger();
   }
 
-  /** Stops the sequencer from building blocks and moves to STOPPED state. */
+  /**
+   * Stops the sequencer from building blocks and moves it to STOPPED state. Fully drains before
+   * returning: interrupts the tracked checkpoint job and every in-flight fire-and-forget fallback send,
+   * stops the poll loop, and awaits all pending L1 submissions. Idempotent: a second call while already
+   * stopped/stopping is a no-op. The sequencer may be started again afterwards via {@link start}.
+   */
   public async stop(): Promise<void> {
+    if (this.state === SequencerState.STOPPED || this.state === SequencerState.STOPPING) {
+      this.log.debug(`Sequencer already ${this.state.toLowerCase()}, ignoring stop`);
+      return;
+    }
     this.log.info(`Stopping sequencer`);
     this.setState(SequencerState.STOPPING, undefined, { force: true });
     this.lastCheckpointProposalJob?.interrupt();
+    // Interrupt the fallback senders' own interruptible sleeps (independent of the pooled L1TxUtils),
+    // so a sleeper waiting for a target slot wakes immediately and short-circuits instead of surviving
+    // the stop as a dangling promise that a later restart could re-arm into a stale-slot send.
+    for (const { publisher } of this.pendingFallbackSends) {
+      publisher.interrupt();
+    }
     await this.publisherFactory.stopAll();
     await this.runningPromise?.stop();
     await this.lastCheckpointProposalJob?.awaitPendingSubmission();
+    await this.drainPendingFallbackSends();
     this.setState(SequencerState.STOPPED, undefined, { force: true });
     this.log.info('Stopped sequencer');
+  }
+
+  /** Awaits every tracked fallback send to settle, then clears the tracking set. */
+  private async drainPendingFallbackSends(): Promise<void> {
+    const pending = [...this.pendingFallbackSends].map(entry => entry.done);
+    if (pending.length > 0) {
+      await Promise.allSettled(pending);
+    }
+    this.pendingFallbackSends.clear();
+  }
+
+  /**
+   * Registers a fire-and-forget fallback send so {@link stop} can interrupt its wrapper publisher and
+   * await its completion. The entry removes itself once the send settles.
+   */
+  private trackFallbackSend(publisher: SequencerPublisher, send: Promise<unknown>): void {
+    const entry = { publisher, done: Promise.resolve() };
+    entry.done = send.then(
+      () => {
+        this.pendingFallbackSends.delete(entry);
+      },
+      () => {
+        this.pendingFallbackSends.delete(entry);
+      },
+    );
+    this.pendingFallbackSends.add(entry);
   }
 
   /** Main sequencer loop with a try/catch */
@@ -1023,10 +1084,12 @@ export class Sequencer extends (EventEmitter as new () => TypedEventEmitter<Sequ
     // Votes are EIP-712-signed for `targetSlot` (the pipelined slot in which the multicall is
     // expected to mine). Delay submission to the start of `targetSlot` so the tx mines in the
     // slot the votes were signed for. We fire-and-forget so we don't block the sequencer's
-    // work loop while waiting for the target slot to start.
-    void publisher.sendRequestsAt(targetSlot).catch(err => {
+    // work loop while waiting for the target slot to start, but track it so stop() can interrupt
+    // the wrapper's sleep and await it, leaving no dangling sleeper across a restart.
+    const send = publisher.sendRequestsAt(targetSlot).catch(err => {
       this.log.error(`Failed to publish fallback requests despite sync failure for slot ${slot}`, err, { slot });
     });
+    this.trackFallbackSend(publisher, send);
   }
 
   private async tryEnqueuePruneIfPrunable(targetSlot: SlotNumber, publisher: SequencerPublisher): Promise<boolean> {
@@ -1096,10 +1159,12 @@ export class Sequencer extends (EventEmitter as new () => TypedEventEmitter<Sequ
     // the multicall mines in the slot the votes were signed for; otherwise the L1 contract reads
     // `signaler = getCurrentProposer()` against the wrong slot and signature verification fails
     // silently inside Multicall3. Fire-and-forget so we don't block the sequencer's work loop while
-    // waiting for the target slot to start, mirroring tryVoteAndPruneWhenCannotBuild.
-    void publisher.sendRequestsAt(targetSlot).catch(err => {
+    // waiting for the target slot to start, mirroring tryVoteAndPruneWhenCannotBuild. Tracked so
+    // stop() can interrupt the wrapper's sleep and await it, leaving no dangling sleeper across a restart.
+    const send = publisher.sendRequestsAt(targetSlot).catch(err => {
       this.log.error(`Failed to publish escape-hatch votes for slot ${slot}`, err, { slot, targetSlot });
     });
+    this.trackFallbackSend(publisher, send);
   }
 
   /**


### PR DESCRIPTION
## Context

`Sequencer.start()` and `PublisherManager.start()` were not idempotent: a second `start()` orphaned the previous `RunningPromise` poll loop (leaving two loops racing), and a stopped-then-restarted sequencer never cleared the publishers' `interrupted` flag — so it would build and propose blocks but silently never publish to L1. This blocked merging sequential scenarios in tests (`invalidate_block.parallel` needed a forced stop between scenarios) and is a prerequisite for stop→drain→warp→restart test tooling.

## Approach

- Make `start()`/`stop()` idempotent across `SequencerClient`, `Sequencer`, and `PublisherManager`: a redundant `start()` no-ops instead of orphaning a loop, and `start()` while `STOPPING` is refused to close the start-races-stop race.
- Add a working restart path: `PublisherManager.start()` now clears the `interrupted` flag (via the previously-unused `restart()` methods on the publishers and funder), and `SequencerClient.start()` starts the publisher manager before the sequencer loop so publishers are un-interrupted before the first publish.
- Prevent a stale-slot tx across restart: the two fire-and-forget fallback sends (vote-and-prune / escape-hatch) are tracked, and `stop()` interrupts each wrapper's independent sleep and awaits it after the poll loop stops, so no dangling sleeper survives to be re-armed by a later restart.
- `stop()` remains a complete terminal drain for production teardown; it is merely also re-startable once fully resolved.

Lifecycle calls are assumed to be serialized by the caller (all current callers are); this does not add a mutex for truly concurrent start/stop.