### PR TITLE
perf(e2e): stopDrainWarpRestart primitive + pipeline_prune pilot

### DIFF
--- a/yarn-project/end-to-end/src/multi-node/recovery/pipeline_prune.test.ts
+++ b/yarn-project/end-to-end/src/multi-node/recovery/pipeline_prune.test.ts
@@ -11,6 +11,7 @@ import { executeTimeout } from '@aztec/foundation/timer';
 import type { TestContract } from '@aztec/noir-test-contracts.js/Test';
 import type { SequencerEvents } from '@aztec/sequencer-client';
 import { L2BlockSourceEvents } from '@aztec/stdlib/block';
+import { getTimestampForSlot } from '@aztec/stdlib/epoch-helpers';
 
 import { jest } from '@jest/globals';
 
@@ -159,6 +160,34 @@ describe('multi-node/recovery/pipeline_prune', () => {
     // The sequencer keeps building blocks and broadcasting via P2P, but won't submit the checkpoint to L1
     targetSequencer.updateConfig({ skipPublishingCheckpointsPercent: 100 });
 
+    // Wait for the orphan blocks to actually exist before warping: the target proposer builds them during
+    // slot proposerSlotToNotPublish - 1 and broadcasts them via P2P carrying that submission slot, but never
+    // publishes the enclosing checkpoint. Only once node[0]'s archiver holds them as a proposed (uncheckpointed)
+    // tip is there anything for pruneOrphanProposedBlocks to prune — warping before they arrive would fire no prune.
+    await test.waitForAllNodesToReachBlockAtSlot(
+      proposerSlotToNotPublish,
+      'proposed',
+      block => block.header.globalVariables.slotNumber >= proposerSlotToNotPublish,
+      { nodes: [nodes[0]], timeout: test.L2_SLOT_DURATION_IN_S * 3 },
+    );
+    logger.warn(`Orphan blocks for slot ${proposerSlotToNotPublish} are present; warping past the prune deadline`);
+
+    // Collapse the ~2-minute dead gap where the chain just waits for the L1 clock to roll past the orphan
+    // slot's checkpoint-proposal-received deadline (targetSlotStart(orphan) - E - D + tolerance) so
+    // pruneOrphanProposedBlocks fires. The archiver reads the shared TestDateProvider that eth.warp advances,
+    // so jumping the clock into the slot after the orphan one takes us safely past that deadline and the next
+    // archiver sync prunes. Sequencers are stopped/drained around the warp so it cannot interrupt a live build;
+    // we keep them stopped (restart:false) until the prune is confirmed so no restarted proposer builds against
+    // the still-unpruned tip before the archiver's next sync prunes it — they are restarted for recovery below.
+    const pruneWarpTarget =
+      getTimestampForSlot(SlotNumber(proposerSlotToNotPublish + 1), test.constants) +
+      BigInt(2 * test.constants.ethereumSlotDuration);
+    await test.stopDrainWarpRestart(
+      nodes,
+      () => test.context.cheatCodes.eth.warp(Number(pruneWarpTarget), { resetBlockInterval: true }),
+      { restart: false },
+    );
+
     const pruneTimeout = test.L2_SLOT_DURATION_IN_S * 5 * 1000;
     logger.warn(`Waiting for uncheckpointed blocks to be pruned (timeout=${pruneTimeout}ms)`);
     await executeTimeout(() => prunePromise, pruneTimeout);
@@ -176,9 +205,13 @@ describe('multi-node/recovery/pipeline_prune', () => {
     }
     logger.warn(`Pruning detected, block number now ${await archiver.getBlockNumber()}`);
 
-    // Re-enable checkpoint publishing
+    // Re-enable checkpoint publishing, then restart the sequencers to build the recovery checkpoint. Restarting
+    // only now (after the prune and after listeners are attached) keeps recovery from racing the prune and
+    // ensures every recovery block is captured for the pipelining assertion.
     logger.warn(`Re-enabling checkpoint publishing for validator ${proposerIndex}`);
     targetSequencer.updateConfig({ skipPublishingCheckpointsPercent: 0 });
+    await test.startSequencers(nodes);
+    logger.warn(`Restarted all sequencers for recovery`);
 
     // Wait for a new checkpoint (recovery) - where all txs end up mined
     const timeout = test.L2_SLOT_DURATION_IN_S * 5;

--- a/yarn-project/end-to-end/src/single-node/single_node_test_context.ts
+++ b/yarn-project/end-to-end/src/single-node/single_node_test_context.ts
@@ -991,4 +991,64 @@ export class SingleNodeTestContext {
     }
     expect(failEvents).toEqual([]);
   }
+
+  /**
+   * Warps the L1 clock forward while no sequencer is building, then (by default) resumes building.
+   *
+   * Warping the shared `TestDateProvider` under live sequencers is what produced the reorg /
+   * `block-build-failed: "Sequencer was interrupted"` events seen in earlier revert attempts: a warp
+   * mid-`work()` jumps every node's clock at once. This primitive removes that hazard by pausing and
+   * draining every sequencer around the warp:
+   *
+   * 1. Wait each sequencer to reach `IDLE`, so its last `work()` iteration has finished and issued any
+   *    L1 submission. This keeps the subsequent `stop()` from landing mid-build and emitting a spurious
+   *    interrupt fail-event. It is test hygiene, not a hard drain — the real drain is step 2's `stop()`.
+   * 2. `stop()` each sequencer. `SequencerClient.stop()` fully drains: it stops the poll loop, awaits the
+   *    in-flight `work()`, awaits the tracked checkpoint job's pending submission, and interrupts+awaits
+   *    every fire-and-forget fallback send. After it resolves, nothing that sequencer enqueued can still
+   *    publish across the warp.
+   * 3. Run `warpFn()` with nobody building.
+   * 4. Restart each sequencer via `start()` (default). `SequencerClient.start()` restarts the publisher
+   *    manager first (clearing the pooled publishers' `interrupted` flag) so post-restart L1 publishing
+   *    works again, then re-arms the poll loop. Pass `restart: false` to leave the sequencers stopped
+   *    (e.g. when the nodes are about to be torn down anyway).
+   *
+   * The warp target is entirely `warpFn`'s responsibility, so this stays reusable across the Phase-2
+   * sites. Only the sequencers of `nodes` are paused; archivers, provers, and the chain monitor keep
+   * running, so any clock-driven effect of the warp (e.g. an orphan-block prune) still fires.
+   *
+   * @param nodes - Nodes whose sequencers are paused around the warp.
+   * @param warpFn - Performs the actual L1-clock warp; invoked once, with every sequencer stopped.
+   * @param opts.restart - Restart the sequencers after the warp (default `true`).
+   * @param opts.idleTimeout - Per-sequencer timeout (ms) for the IDLE pre-wait (default 2 L2 slots).
+   */
+  public async stopDrainWarpRestart(
+    nodes: AztecNodeService[],
+    warpFn: () => Promise<void>,
+    opts: { restart?: boolean; idleTimeout?: number } = {},
+  ): Promise<void> {
+    const restart = opts.restart ?? true;
+    const idleTimeout = opts.idleTimeout ?? this.L2_SLOT_DURATION_IN_S * 2 * 1000;
+    const sequencers = this.getSequencers(nodes);
+
+    await testSpan('warp:stop-drain-warp-restart', async () => {
+      this.logger.warn(`Draining ${sequencers.length} sequencers to IDLE before warp`);
+      await Promise.all(
+        sequencers.map(s =>
+          this.waitForSequencerState(s.getSequencer(), SequencerState.IDLE, { timeout: idleTimeout }),
+        ),
+      );
+
+      this.logger.warn(`Stopping ${sequencers.length} sequencers for warp`);
+      await Promise.all(sequencers.map(s => s.stop()));
+
+      this.logger.warn(`Warping with all sequencers stopped`);
+      await warpFn();
+
+      if (restart) {
+        this.logger.warn(`Restarting ${sequencers.length} sequencers after warp`);
+        await Promise.all(sequencers.map(s => s.start()));
+      }
+    });
+  }
 }


### PR DESCRIPTION
Stacked on #24449 — depends on the idempotent/restartable sequencer lifecycle it adds. Rebase onto `merge-train/spartan-v5` once #24449 merges.

## Context

Several multi-node e2e tests are dominated by wall-clock waits for the L1 clock to roll while live sequencers sit idle. Warping the shared clock under a running sequencer previously interrupted in-flight builds (the reorg / "Sequencer was interrupted" failures behind earlier revert attempts). Now that the lifecycle is idempotent and restartable (#24449), the sequencers can be cleanly paused and drained around a warp.

## Approach

- Add `stopDrainWarpRestart(nodes, warpFn, opts?)` on `SingleNodeTestContext` (inherited by `MultiNodeTestContext`): wait every sequencer to `IDLE`, `stop()` (full drain), run `warpFn()` with nobody building, then `start()` again (default; `restart: false` leaves them stopped). The warp target is the caller's responsibility, so the primitive is reusable across the remaining Phase-2 sites. Archivers, provers and the chain monitor keep running, so clock-driven effects (e.g. an orphan-block prune) still fire.
- Apply it to `pipeline_prune` to collapse its ~126s dead gap: once the orphan blocks are built and publishing is disabled, warp L1 two blocks into the slot after the orphaned one (past the no-proposal prune deadline) instead of waiting wall-clock, then restart the sequencers only after the prune is confirmed. `TX_COUNT` is unchanged, so `assertMultipleBlocksPerSlot` and `assertProposerPipelining` still hold.

The `pipeline_prune` speedup is validated by this PR's CI run — the multi-node suite can't be run locally.