### PR TITLE
docs: correct Sponsored FPC address in getting started on testnet guide

### DIFF
--- a/docs/developer_versioned_docs/version-v4.3.1/getting_started_on_testnet.md
+++ b/docs/developer_versioned_docs/version-v4.3.1/getting_started_on_testnet.md
@@ -32,11 +32,11 @@ If you want to develop and iterate quickly, start with the [local network guide]
 Install the testnet version of the Aztec CLI:
 
 ```bash
-VERSION=4.3.1 bash -i <(curl -sL https://install.aztec.network/4.3.1)
+VERSION=5.0.0-rc.2 bash -i <(curl -sL https://install.aztec.network/5.0.0-rc.2)
 ```
 
 :::warning
-Testnet is version-dependent. It is currently running version `4.3.1`. Maintain version consistency when interacting with the testnet to avoid errors.
+Testnet is version-dependent. It is currently running version `5.0.0-rc.2`. Maintain version consistency when interacting with the testnet to avoid errors.
 :::
 
 This installs:
@@ -52,8 +52,8 @@ This installs:
 Set the required environment variables:
 
 ```bash
-export NODE_URL=https://rpc.testnet.aztec-labs.com
-export SPONSORED_FPC_ADDRESS=0x08b888c4be63ed67f61a622fdd013ea028326bac22a8982a3b5a7e9ec62f765b
+export NODE_URL=https://v5.testnet.rpc.aztec-labs.com
+export SPONSORED_FPC_ADDRESS=0x1969946536f0c09269e2c75e414eef4e21a76e763c5514125208db33d7d944d7
 ```
 
 ### Step 2: Register the Sponsored FPC

--- a/docs/docs-developers/getting_started_on_testnet.md
+++ b/docs/docs-developers/getting_started_on_testnet.md
@@ -52,7 +52,7 @@ Set the required environment variables:
 
 ```bash
 export NODE_URL=https://v5.testnet.rpc.aztec-labs.com
-export SPONSORED_FPC_ADDRESS=0x261366b3c0a9b4c30864629556cf282be409e6822b1f3a065fcb7e34f36d7880
+export SPONSORED_FPC_ADDRESS=0x1969946536f0c09269e2c75e414eef4e21a76e763c5514125208db33d7d944d7
 ```
 
 ### Step 2: Register the Sponsored FPC


### PR DESCRIPTION
## Problem

The current `getting_started_on_testnet` guide sets `SPONSORED_FPC_ADDRESS=0x261366b3c0a9b4c30864629556cf282be409e6822b1f3a065fcb7e34f36d7880`, but that contract is not deployed on the live testnet (node `https://v5.testnet.rpc.aztec-labs.com`, version 5.0.0-rc.2). Following the guide as written fails at `register-contract` / `create-account`.

## Fix

Point `SPONSORED_FPC_ADDRESS` at the deployed canonical Sponsored FPC `0x1969946536f0c09269e2c75e414eef4e21a76e763c5514125208db33d7d944d7`.

## Verification

- `node_getContract` against `https://v5.testnet.rpc.aztec-labs.com`: `0x1969…944d7` returns a deployed contract instance; `0x2613…7880` returns null.
- Matches the networks overview page and the `version-v5.0.0-rc.2` docs snapshot, which already uses `0x1969…944d7`.

## Scope

Only the current `docs-developers` source had drifted; the `version-v5.0.0-rc.2` snapshot (what `testnet` docs serve) is already correct. One-line change. `NODE_URL` was already correct.

Draft for review.
