### PR TITLE
test(e2e): sync anvil clock before sequencer start

### DIFF
--- a/yarn-project/end-to-end/src/fixtures/setup.ts
+++ b/yarn-project/end-to-end/src/fixtures/setup.ts
@@ -541,8 +541,7 @@ async function setupInner<TDeployExtraL1ContractsReturnType = unknown>(
     }
 
     if (enableAutomine) {
-      await ethCheatCodes.setAutomine(false);
-      await ethCheatCodes.setIntervalMining(config.ethereumSlotDuration);
+      await ethCheatCodes.startIntervalMiningWithFreshBlock(config.ethereumSlotDuration);
     }
 
     // In compose mode (no local anvil), sync dateProvider to L1 time since it may have drifted

--- a/yarn-project/ethereum/src/test/eth_cheat_codes.test.ts
+++ b/yarn-project/ethereum/src/test/eth_cheat_codes.test.ts
@@ -3,7 +3,7 @@ import { times, timesAsync } from '@aztec/foundation/collection';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { type Logger, createLogger } from '@aztec/foundation/log';
 import { sleep } from '@aztec/foundation/sleep';
-import { DateProvider } from '@aztec/foundation/timer';
+import { DateProvider, TestDateProvider } from '@aztec/foundation/timer';
 import { getErrorCause } from '@aztec/foundation/types';
 import { TestERC20Abi, TestERC20Bytecode } from '@aztec/l1-artifacts';
 
@@ -275,6 +275,40 @@ describe('EthCheatCodes', () => {
       const blockNumber = await cheatCodes.blockNumber();
       await cheatCodes.mine(increment);
       expect(await cheatCodes.blockNumber()).toBe(blockNumber + increment);
+    });
+  });
+
+  describe('startIntervalMiningWithFreshBlock', () => {
+    const expectAutoBlockAfter = async (blockNumber: number) => {
+      for (let i = 0; i < 20; i++) {
+        await sleep(100);
+        if ((await cheatCodes.blockNumber()) > blockNumber) {
+          return;
+        }
+      }
+      expect(await cheatCodes.blockNumber()).toBeGreaterThan(blockNumber);
+    };
+
+    it('starts interval mining from a freshly mined block and syncs the date provider', async () => {
+      const interval = 1;
+      const dateProvider = new TestDateProvider();
+      cheatCodes = new EthCheatCodes([rpcUrl], dateProvider);
+
+      const blockNumber = await cheatCodes.blockNumber();
+      const timestamp = await cheatCodes.lastBlockTimestamp();
+
+      await sleep((interval + 1) * 1000);
+      await cheatCodes.startIntervalMiningWithFreshBlock(interval);
+
+      const minedBlockNumber = await cheatCodes.blockNumber();
+      const minedTimestamp = await cheatCodes.lastBlockTimestamp();
+
+      expect(minedBlockNumber).toBe(blockNumber + 1);
+      expect(minedTimestamp).toBeGreaterThan(timestamp);
+      expect(await cheatCodes.isAutoMining()).toBe(false);
+      expect(await cheatCodes.getIntervalMining()).toBe(interval);
+      expect(Math.abs(dateProvider.now() - minedTimestamp * 1000)).toBeLessThan(1_000);
+      await expectAutoBlockAfter(minedBlockNumber);
     });
   });
 

--- a/yarn-project/ethereum/src/test/eth_cheat_codes.ts
+++ b/yarn-project/ethereum/src/test/eth_cheat_codes.ts
@@ -207,6 +207,22 @@ export class EthCheatCodes {
   }
 
   /**
+   * Starts interval mining from a freshly mined block and syncs the date provider to the block timestamp.
+   */
+  public async startIntervalMiningWithFreshBlock(seconds: number): Promise<void> {
+    if (seconds <= 0) {
+      throw new Error(`Interval mining requires a positive interval, got ${seconds}`);
+    }
+
+    await this.setAutomine(false);
+    await this.setIntervalMining(0, { silent: true });
+    await this.evmMine();
+    await this.syncDateProvider();
+    await this.setIntervalMining(seconds);
+    this.logger.warn(`Started L1 interval mining at ${seconds} seconds from a fresh block`);
+  }
+
+  /**
    * Set the automine status of the underlying anvil chain
    * @param automine - The automine status to set
    */


### PR DESCRIPTION
Adds an EthCheatCodes helper that disables automine, mines a fresh block, syncs the TestDateProvider, and starts interval mining. Used when e2e setup hands off from automined L1 deployment to interval mining before sequencer startup.

Should prevent a flake where anvil was left with a different date as the `TestDateProvider` after the automines triggered by the L1 deployment, and on the first L1 block mined the date provider automatically synced to the anvil date, warping time under the running node and causing a prune.