### PR TITLE
fix: reject aztecSlotDuration not a multiple of ethereumSlotDuration

### DIFF
--- a/yarn-project/end-to-end/src/multi-node/invalid-attestations/invalidate_block.parallel.test.ts
+++ b/yarn-project/end-to-end/src/multi-node/invalid-attestations/invalidate_block.parallel.test.ts
@@ -66,7 +66,7 @@ describe('multi-node/invalid-attestations/invalidate_block', () => {
     // Uses multiple-blocks-per-slot timing configuration.
     test = await MultiNodeTestContext.setup({
       ...MOCK_GOSSIP_MULTI_VALIDATOR_OPTS,
-      ethereumSlotDuration: 8,
+      ethereumSlotDuration: 12,
       aztecSlotDuration: 36,
       blockDurationMs: 6000,
       initialValidators: validators,

--- a/yarn-project/end-to-end/src/p2p/reqresp/utils.ts
+++ b/yarn-project/end-to-end/src/p2p/reqresp/utils.ts
@@ -34,7 +34,7 @@ export async function createReqrespTest(options: ReqrespOptions = {}): Promise<P
     // To collect metrics - run in aztec-packages `docker compose --profile metrics up`
     metricsPort: shouldCollectMetrics(),
     initialConfig: {
-      ethereumSlotDuration: 8,
+      ethereumSlotDuration: 12,
       aztecSlotDuration: 36,
       blockDurationMs: 6000,
       minTxsPerBlock: 1,

--- a/yarn-project/ethereum/src/config.test.ts
+++ b/yarn-project/ethereum/src/config.test.ts
@@ -1,0 +1,37 @@
+import { assertValidSlotDurations, validateSlotDurations } from './config.js';
+
+describe('validateSlotDurations', () => {
+  it('returns no errors for a sound config', () => {
+    expect(validateSlotDurations({ ethereumSlotDuration: 12, aztecSlotDuration: 36 })).toEqual([]);
+  });
+
+  it('errors when aztecSlotDuration is not a multiple of ethereumSlotDuration', () => {
+    expect(validateSlotDurations({ ethereumSlotDuration: 8, aztecSlotDuration: 36 })).toContainEqual(
+      expect.stringContaining('must be a multiple'),
+    );
+  });
+
+  it('errors when ethereumSlotDuration is non-positive', () => {
+    expect(validateSlotDurations({ ethereumSlotDuration: 0, aztecSlotDuration: 36 })).toContainEqual(
+      expect.stringContaining('ethereumSlotDuration must be positive'),
+    );
+  });
+
+  it('errors when aztecSlotDuration is non-positive', () => {
+    expect(validateSlotDurations({ ethereumSlotDuration: 12, aztecSlotDuration: 0 })).toContainEqual(
+      expect.stringContaining('aztecSlotDuration must be positive'),
+    );
+  });
+});
+
+describe('assertValidSlotDurations', () => {
+  it('does not throw for a sound config', () => {
+    expect(() => assertValidSlotDurations({ ethereumSlotDuration: 12, aztecSlotDuration: 36 })).not.toThrow();
+  });
+
+  it('throws when aztecSlotDuration is not a multiple of ethereumSlotDuration', () => {
+    expect(() => assertValidSlotDurations({ ethereumSlotDuration: 8, aztecSlotDuration: 36 })).toThrow(
+      /must be a multiple/,
+    );
+  });
+});

--- a/yarn-project/ethereum/src/config.ts
+++ b/yarn-project/ethereum/src/config.ts
@@ -246,6 +246,41 @@ export const l1ContractsConfigMappings: ConfigMappingsType<L1ContractsConfig> = 
  */
 export const DefaultL1ContractsConfig = getDefaultConfig(l1ContractsConfigMappings);
 
+/**
+ * Validates that `ethereumSlotDuration` and `aztecSlotDuration` are positive and that the L2 slot is an exact
+ * multiple of the L1 slot. Every L2 slot boundary must land on an L1 slot boundary; a non-multiple pairing
+ * desyncs the epoch/checkpoint timing math throughout the sequencer, validator client, and timetables. Returns
+ * a list of error messages (empty when valid).
+ */
+export function validateSlotDurations(
+  config: Pick<L1ContractsConfig, 'ethereumSlotDuration' | 'aztecSlotDuration'>,
+): string[] {
+  const errors: string[] = [];
+  if (config.ethereumSlotDuration <= 0) {
+    errors.push(`ethereumSlotDuration must be positive (got ${config.ethereumSlotDuration})`);
+  }
+  if (config.aztecSlotDuration <= 0) {
+    errors.push(`aztecSlotDuration must be positive (got ${config.aztecSlotDuration})`);
+  }
+  if (config.ethereumSlotDuration > 0 && config.aztecSlotDuration % config.ethereumSlotDuration !== 0) {
+    errors.push(
+      `aztecSlotDuration (${config.aztecSlotDuration}s) must be a multiple of ethereumSlotDuration ` +
+        `(${config.ethereumSlotDuration}s)`,
+    );
+  }
+  return errors;
+}
+
+/** Throws if {@link validateSlotDurations} reports any errors. */
+export function assertValidSlotDurations(
+  config: Pick<L1ContractsConfig, 'ethereumSlotDuration' | 'aztecSlotDuration'>,
+): void {
+  const errors = validateSlotDurations(config);
+  if (errors.length > 0) {
+    throw new Error(`Invalid slot duration configuration:\n${errors.map(e => `  - ${e}`).join('\n')}`);
+  }
+}
+
 export const genesisStateConfigMappings: ConfigMappingsType<GenesisStateConfig> = {
   testAccounts: {
     env: 'TEST_ACCOUNTS',

--- a/yarn-project/ethereum/src/deploy_aztec_l1_contracts.ts
+++ b/yarn-project/ethereum/src/deploy_aztec_l1_contracts.ts
@@ -19,7 +19,7 @@ import { mainnet, sepolia } from 'viem/chains';
 
 import { createEthereumChain, isAnvilTestChain } from './chain.js';
 import { createExtendedL1Client } from './client.js';
-import type { L1ContractsConfig } from './config.js';
+import { type L1ContractsConfig, assertValidSlotDurations } from './config.js';
 import { deployMulticall3 } from './contracts/multicall.js';
 import { RollupContract } from './contracts/rollup.js';
 import type { L1ContractAddresses } from './l1_contract_addresses.js';
@@ -282,6 +282,7 @@ export async function deployAztecL1Contracts(
   args: DeployAztecL1ContractsArgs,
 ): Promise<DeployAztecL1ContractsReturnType> {
   logger.info(`Deploying L1 contracts with config: ${jsonStringify(args)}`);
+  assertValidSlotDurations(args);
   if (args.initialValidators && args.initialValidators.length > 0 && args.existingTokenAddress) {
     throw new Error(
       'Cannot deploy with both initialValidators and existingTokenAddress. ' +

--- a/yarn-project/stdlib/src/config/network-consensus-config.ts
+++ b/yarn-project/stdlib/src/config/network-consensus-config.ts
@@ -1,4 +1,4 @@
-import { type L1ContractsConfig, l1ContractsConfigMappings } from '@aztec/ethereum/config';
+import { type L1ContractsConfig, l1ContractsConfigMappings, validateSlotDurations } from '@aztec/ethereum/config';
 import { type EnvVar, pickConfigMappings } from '@aztec/foundation/config';
 
 import type { SequencerConfig } from '../interfaces/configs.js';
@@ -156,20 +156,9 @@ export function validateNetworkConsensusConfig(config: NetworkConsensusConfig): 
     return errors;
   }
 
-  if (config.ethereumSlotDuration <= 0) {
-    errors.push(`ethereumSlotDuration must be positive (got ${config.ethereumSlotDuration})`);
-  }
+  errors.push(...validateSlotDurations(config));
   if (config.blockDurationMs <= 0) {
     errors.push(`blockDurationMs must be positive (got ${config.blockDurationMs})`);
-  }
-  if (config.aztecSlotDuration <= 0) {
-    errors.push(`aztecSlotDuration must be positive (got ${config.aztecSlotDuration})`);
-  }
-  if (config.ethereumSlotDuration > 0 && config.aztecSlotDuration % config.ethereumSlotDuration !== 0) {
-    errors.push(
-      `aztecSlotDuration (${config.aztecSlotDuration}s) must be a multiple of ethereumSlotDuration ` +
-        `(${config.ethereumSlotDuration}s)`,
-    );
   }
   if (config.blockDurationMs / 1000 > config.aztecSlotDuration) {
     errors.push(


### PR DESCRIPTION
L2 slot boundaries must land on L1 slot boundaries, but nothing enforced this at runtime. A check for exactly this relationship already existed (`validateNetworkConsensusConfig` in stdlib), but it was only exercised by a CLI unit test gating the three static mainnet/testnet/devnet config files — never wired into e2e test setup or the L1-contract deployment path itself.

## Approach

- Add `validateSlotDurations`/`assertValidSlotDurations` to `ethereum/src/config.ts` and call it from `deployAztecL1Contracts`, the shared choke point used by e2e tests, spartan deployments, and CLI deploys, so a bad pairing now fails fast with a clear error.
- Refactor `validateNetworkConsensusConfig` to reuse the shared check instead of duplicating it.
- Fix the three e2e configs this caught: all paired `aztecSlotDuration: 36` with `ethereumSlotDuration: 8` (4.5 L1 slots per L2 slot). Corrected to `ethereumSlotDuration: 12`, matching the `36s`/`12s` convention already used elsewhere in the same test suites.