### PR TITLE
fix(p2p): bump global reqresp limits

### DIFF
--- a/yarn-project/p2p/src/services/reqresp/rate-limiter/rate_limits.ts
+++ b/yarn-project/p2p/src/services/reqresp/rate-limiter/rate_limits.ts
@@ -9,7 +9,7 @@ export const DEFAULT_RATE_LIMITS: ReqRespSubProtocolRateLimits = {
     },
     globalLimit: {
       quotaTimeMs: 1000,
-      quotaCount: 10,
+      quotaCount: 50,
     },
   },
   [ReqRespSubProtocol.STATUS]: {
@@ -19,7 +19,7 @@ export const DEFAULT_RATE_LIMITS: ReqRespSubProtocolRateLimits = {
     },
     globalLimit: {
       quotaTimeMs: 1000,
-      quotaCount: 10,
+      quotaCount: 50,
     },
   },
   [ReqRespSubProtocol.AUTH]: {
@@ -49,7 +49,7 @@ export const DEFAULT_RATE_LIMITS: ReqRespSubProtocolRateLimits = {
     },
     globalLimit: {
       quotaTimeMs: 1000,
-      quotaCount: 10,
+      quotaCount: 50,
     },
   },
   [ReqRespSubProtocol.BLOCK_TXS]: {


### PR DESCRIPTION
Otherwise very few peers can exhaust the global quota of a node.

Fixes A-1335
