### PR TITLE
fix(p2p): reject proposal when expected proposer is undefined

### DIFF
--- a/yarn-project/p2p/src/msg_validators/proposal_validator/proposal_validator.test.ts
+++ b/yarn-project/p2p/src/msg_validators/proposal_validator/proposal_validator.test.ts
@@ -215,12 +215,12 @@ describe('ProposalValidator', () => {
       expect(result).toEqual({ result: 'reject', severity: PeerErrorSeverity.MidToleranceError });
     });
 
-    it('accepts when proposer is undefined (open committee)', async () => {
+    it('rejects with high tolerance error when proposer is undefined (open committee)', async () => {
       const proposal = await factory(currentSlot, Secp256k1Signer.random());
 
       epochCache.getProposerAttesterAddressInSlot.mockResolvedValue(undefined);
       const result = await validator.validate(proposal);
-      expect(result).toEqual({ result: 'accept' });
+      expect(result).toEqual({ result: 'reject', severity: PeerErrorSeverity.HighToleranceError });
     });
 
     it('rejects with low tolerance error on NoCommitteeError', async () => {

--- a/yarn-project/p2p/src/msg_validators/proposal_validator/proposal_validator.ts
+++ b/yarn-project/p2p/src/msg_validators/proposal_validator/proposal_validator.ts
@@ -97,7 +97,11 @@ export class ProposalValidator {
 
       // Proposer check
       const expectedProposer = await this.epochCache.getProposerAttesterAddressInSlot(slotNumber);
-      if (expectedProposer !== undefined && !proposer.equals(expectedProposer)) {
+      if (expectedProposer === undefined) {
+        this.logger.warn(`Penalizing peer for proposal with no expected proposer for current slot ${slotNumber}`);
+        return { result: 'reject', severity: PeerErrorSeverity.HighToleranceError };
+      }
+      if (!proposer.equals(expectedProposer)) {
         this.logger.warn(`Penalizing peer for invalid proposer for current slot ${slotNumber}`, {
           expectedProposer,
           proposer: proposer.toString(),


### PR DESCRIPTION
## Summary

Experiment to validate [A-1326](https://linear.app/aztec-labs/issue/A-1326/proposal-accepted-when-expectedproposer-is-undefined-consensus-bypass): when `getProposerAttesterAddressInSlot` resolves to `undefined`, `ProposalValidator` currently skips the proposer-identity check entirely and accepts the proposal. This applies the audit's suggested fix — reject instead of skip — mirroring `CheckpointAttestationValidator`, which already rejects in the equivalent case.

Note: `expectedProposer` resolves to `undefined` specifically when the committee is configured empty (`targetCommitteeSize == 0`, i.e. permissionless/open-committee mode where "anyone may propose") — `sequencer.ts`'s `checkCanPropose` treats that same case as `canPropose = true` for every node. This PR is intended to surface, via CI (in particular any multi-node/permissionless e2e coverage), whether rejecting proposals in that mode breaks anything that currently relies on it.

## Test plan

- Updated `proposal_validator.test.ts`'s "open committee" cases to expect rejection instead of acceptance
- `yarn workspace @aztec/p2p test src/msg_validators/proposal_validator/proposal_validator.test.ts` passes locally (49/49)
- `yarn build` passes
- Relying on CI (multi-node/e2e) to reveal any behavior that depends on the previous accept-when-undefined path