### PR TITLE
fix(docs): pull bb.js runtime deps via portal in examples

### DIFF
--- a/docs/examples/ts/bootstrap.sh
+++ b/docs/examples/ts/bootstrap.sh
@@ -147,6 +147,7 @@ validate_project() {
 
         local aztec_deps=("${AZTEC_DEPS[@]}")
         local explicit_link_deps=("${EXPLICIT_LINK_DEPS[@]}")
+        local portal_deps=("${PORTAL_DEPS[@]}")
         local npm_deps=("${NPM_DEPS[@]}")
 
         if [ "$PARSED_DEPS_FOUND" = true ]; then
@@ -160,6 +161,12 @@ validate_project() {
             if [ ${#explicit_link_deps[@]} -gt 0 ]; then
                 echo_stderr "Adding explicit link deps: ${explicit_link_deps[*]}"
                 yarn add "${explicit_link_deps[@]}"
+            fi
+
+            # Install portal dependencies (like link:, but also installs the package's own deps)
+            if [ ${#portal_deps[@]} -gt 0 ]; then
+                echo_stderr "Adding portal deps: ${portal_deps[*]}"
+                yarn add "${portal_deps[@]}"
             fi
 
             # Install external npm dependencies

--- a/docs/examples/ts/lib.sh
+++ b/docs/examples/ts/lib.sh
@@ -5,10 +5,18 @@
 # parse_dependencies <config_file> <repo_root>
 #
 # Reads a config.yaml via yq and classifies each dependency entry into one of
-# three global arrays:
+# these global arrays:
 #   AZTEC_DEPS          — @aztec/* packages resolved to pkg@link:<repo_root>/yarn-project/<name>
 #   EXPLICIT_LINK_DEPS  — link: packages resolved to pkg@link:<repo_root>/<path>
+#   PORTAL_DEPS         — portal: packages resolved to pkg@portal:<repo_root>/<path>
 #   NPM_DEPS            — npm: packages (bare names, e.g. viem)
+#
+# link: vs portal:: link: symlinks the package but does NOT install its own dependencies (the
+# consumer must supply them), whereas portal: also installs the package's declared dependencies at
+# the versions it pins. Use portal: for standalone packages whose runtime deps the example needs
+# (e.g. @aztec/bb.js, which needs pako/msgpackr/...) so the package's own package.json is the single
+# source of truth — rather than hand-mirroring its dependency list here (which drifts and, when left
+# unversioned, floats to breaking majors).
 #
 # Also sets PARSED_DEPS_FOUND to "true" if any dependency was found, "false" otherwise.
 parse_dependencies() {
@@ -17,6 +25,7 @@ parse_dependencies() {
 
     AZTEC_DEPS=()
     EXPLICIT_LINK_DEPS=()
+    PORTAL_DEPS=()
     NPM_DEPS=()
     PARSED_DEPS_FOUND=false
 
@@ -42,12 +51,19 @@ parse_dependencies() {
             local link_pkg_name="${link_spec%%:*}"
             local link_path="${link_spec#*:}"
             EXPLICIT_LINK_DEPS+=("${link_pkg_name}@link:${repo_root}/${link_path}")
+        elif [[ "$pkg" =~ ^portal: ]]; then
+            # Portal (installs the package's own deps): portal:@aztec/bb.js:barretenberg/ts/bb.js
+            #   -> @aztec/bb.js@portal:$repo_root/barretenberg/ts/bb.js
+            local portal_spec="${pkg#portal:}"
+            local portal_pkg_name="${portal_spec%%:*}"
+            local portal_path="${portal_spec#*:}"
+            PORTAL_DEPS+=("${portal_pkg_name}@portal:${repo_root}/${portal_path}")
         elif [[ "$pkg" =~ ^@ ]]; then
             # @aztec/* package - auto-link from yarn-project/
             local pkg_name="${pkg#@aztec/}"
             AZTEC_DEPS+=("${pkg}@link:${repo_root}/yarn-project/${pkg_name}")
         else
-            echo "Warning: Unknown dependency format '$pkg' (use '@aztec/pkg', 'link:pkg:path', or 'npm:pkg')" >&2
+            echo "Warning: Unknown dependency format '$pkg' (use '@aztec/pkg', 'link:pkg:path', 'portal:pkg:path', or 'npm:pkg')" >&2
         fi
     done < <(yq eval '.dependencies[]' "$config_file")
 }

--- a/docs/examples/ts/recursive_verification/config.yaml
+++ b/docs/examples/ts/recursive_verification/config.yaml
@@ -29,3 +29,8 @@ dependencies:
   - "link:@aztec/noir-acvm_js:noir/packages/acvm_js"
   - "link:@aztec/noir-noirc_abi:noir/packages/noirc_abi"
   - "link:@aztec/noir-types:noir/packages/types"
+  # Runtime dep of @aztec/noir-noir_js (used by its debug.mjs). noir_js is link:'d (not portal:'d)
+  # because its @aztec/noir-* deps are pinned to unpublished versions, so portal can't fetch them —
+  # link: does not install a package's own deps, so pako must be supplied here. Pinned to noir_js's
+  # own range (^2.1.0) so it can't float to the breaking pako 3.0.0.
+  - "npm:pako@^2.1.0"

--- a/docs/examples/ts/recursive_verification/config.yaml
+++ b/docs/examples/ts/recursive_verification/config.yaml
@@ -19,17 +19,13 @@ dependencies:
   - "@aztec/kv-store"
   - "@aztec/pxe"
   - "@aztec/noir-contracts.js"
-  # Packages outside yarn-project/ - use explicit link paths
-  - "link:@aztec/bb.js:barretenberg/ts/bb.js"
+  # Packages outside yarn-project/. bb.js is pulled via portal: (not link:) so its own runtime deps
+  # (pako, msgpackr, comlink, ...) are installed automatically at the versions bb.js pins — instead of
+  # hand-listing them here, which drifts from bb.js and, left unversioned, floated to a breaking major
+  # (pako 3.0.0 dropped the ESM default export bb.js relies on).
+  - "portal:@aztec/bb.js:barretenberg/ts/bb.js"
   - "link:@aztec/noir-noir_js:noir/packages/noir_js"
   # Transitive dependencies of @aztec/noir-noir_js
   - "link:@aztec/noir-acvm_js:noir/packages/acvm_js"
   - "link:@aztec/noir-noirc_abi:noir/packages/noirc_abi"
   - "link:@aztec/noir-types:noir/packages/types"
-  # Runtime deps of @aztec/bb.js (linked, so its own deps are not auto-installed)
-  - "npm:pako"
-  - "npm:msgpackr"
-  - "npm:comlink"
-  - "npm:idb-keyval"
-  - "npm:commander"
-  - "npm:tslib"


### PR DESCRIPTION
## Problem

`ci/docs/examples/bootstrap.sh execute` is failing repo-wide (every fresh install since 2026-06-26) with:

```
@aztec/bb.js/src/barretenberg_wasm/fetch_code/node/index.ts:4
import pako from 'pako';
SyntaxError: The requested module 'pako' does not provide an export named 'default'
```

## Root cause

The `recursive_verification` example links `@aztec/bb.js` via yarn's `link:` protocol, which symlinks the package but does **not** install its own dependencies. To compensate, the example's `config.yaml` hand-listed bb.js's runtime deps (`pako`, `msgpackr`, `comlink`, `idb-keyval`, `commander`, `tslib`) — but **unversioned** (`npm:pako`). The bootstrap turns those into `yarn add pako` = **latest**.

`pako@3.0.0` (published 2026-06-26) dropped the CommonJS/ESM default export (its ESM entry moved to named-exports-only), so bb.js's `import pako from 'pako'` throws under the runner's `tsx/esm` + `--preserve-symlinks`. Pre-06-26 the same bare install resolved 2.2.0 and worked; that's why older `next` runs were green.

## Fix

Add `portal:` support to the examples dependency parser (`lib.sh`/`bootstrap.sh`) and pull bb.js via `portal:` instead of `link:` + a hand-mirrored dep list. `portal:` installs the package's declared dependencies at the versions it pins, so:

- `pako` resolves to **2.2.0** (bb.js pins `^2.1.0`), not 3.0.0.
- The manual `npm:` list is deleted — **bb.js's own `package.json` is the single source of truth**, so this drift/float class of regression can't recur.

`link:` (which intentionally does not install deps) remains for the noir packages.

## Verification

- Reproduced locally on the CI Node (v24.12.0): `import pako from 'pako'` works on 2.1.0/2.2.0, throws the exact CI error on 3.0.0.
- Verified `yarn add @aztec/bb.js@portal:<path>` installs bb.js's transitive deps at its pinned ranges (pako 2.2.0, msgpackr 1.12.1, comlink 4.4.2); yarn itself notes portal + `--preserve-symlinks` is the intended pairing (which the runner already uses).
- Verified the parser emits `@aztec/bb.js@portal:<repo>/barretenberg/ts/bb.js` with no manual npm deps and no warnings; `bash -n` clean.
- Not run locally: the full `docs/examples` execute pipeline (needs the built monorepo + a live network) — relying on CI for the end-to-end confirmation.