### PR TITLE
feat(spartan): WIF + Artifact Registry for treasury-infra CI

### DIFF
--- a/spartan/terraform/gke-cluster/docker-registry.tf
+++ b/spartan/terraform/gke-cluster/docker-registry.tf
@@ -30,3 +30,22 @@ resource "google_artifact_registry_repository_iam_member" "ci_docker_registry_wr
   role       = "roles/artifactregistry.writer"
   member     = "serviceAccount:${google_service_account.ci.email}"
 }
+
+# Docker repository for images built by aztec-labs-eng/treasury-infra (e.g. propose-watcher)
+resource "google_artifact_registry_repository" "treasury_infra" {
+  project       = var.project
+  location      = var.region
+  repository_id = "treasury-infra"
+  description   = "Images built by aztec-labs-eng/treasury-infra CI"
+  format        = "DOCKER"
+
+  depends_on = [google_project_service.artifact_registry]
+}
+
+resource "google_artifact_registry_repository_iam_member" "treasury_infra_ci_writer" {
+  project    = google_artifact_registry_repository.treasury_infra.project
+  location   = google_artifact_registry_repository.treasury_infra.location
+  repository = google_artifact_registry_repository.treasury_infra.name
+  role       = "roles/artifactregistry.writer"
+  member     = "serviceAccount:${google_service_account.treasury_infra_ci.email}"
+}

--- a/spartan/terraform/gke-cluster/iam.tf
+++ b/spartan/terraform/gke-cluster/iam.tf
@@ -108,3 +108,40 @@ data "google_iam_policy" "all_users_storage_read" {
     ]
   }
 }
+
+# CI service account for the aztec-labs-eng/treasury-infra repo (propose-watcher images)
+resource "google_service_account" "treasury_infra_ci" {
+  account_id   = "treasury-infra-ci"
+  display_name = "treasury-infra GitHub Actions CI"
+  description  = "Pushes images from aztec-labs-eng/treasury-infra GitHub Actions via WIF"
+}
+
+# Workload Identity pool for GitHub Actions OIDC tokens
+resource "google_iam_workload_identity_pool" "github" {
+  workload_identity_pool_id = "github"
+  display_name              = "GitHub Actions"
+}
+
+# Trust GitHub-issued tokens, restricted to the treasury-infra repository
+resource "google_iam_workload_identity_pool_provider" "treasury_infra" {
+  workload_identity_pool_id          = google_iam_workload_identity_pool.github.workload_identity_pool_id
+  workload_identity_pool_provider_id = "treasury-infra"
+  display_name                       = "treasury-infra repo"
+
+  attribute_mapping = {
+    "google.subject"       = "assertion.sub"
+    "attribute.repository" = "assertion.repository"
+  }
+  attribute_condition = "assertion.repository == \"aztec-labs-eng/treasury-infra\""
+
+  oidc {
+    issuer_uri = "https://token.actions.githubusercontent.com"
+  }
+}
+
+# Allow workflows from that repository to impersonate the CI service account
+resource "google_service_account_iam_member" "treasury_infra_ci_wif" {
+  service_account_id = google_service_account.treasury_infra_ci.name
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.github.name}/attribute.repository/aztec-labs-eng/treasury-infra"
+}


### PR DESCRIPTION
Adds the IAM for `aztec-labs-eng/treasury-infra` GitHub Actions to push Docker images (the propose-watcher service, [treasury-infra#4](https://github.com/aztec-labs-eng/treasury-infra/pull/4)) to Artifact Registry in `testnet-440309` — keyless via Workload Identity Federation, as requested by Alex instead of ad-hoc gcloud commands.

**What it declares** (in `spartan/terraform/gke-cluster/`):
- `iam.tf`: service account `treasury-infra-ci`, a `github` Workload Identity pool, an OIDC provider trusting GitHub-issued tokens **with an attribute condition pinning it to exactly the `aztec-labs-eng/treasury-infra` repository**, and the `workloadIdentityUser` binding.
- `docker-registry.tf`: Docker repository `treasury-infra` (us-west1) and an `artifactregistry.writer` binding for the CI service account **scoped to that one repository** — nothing project-wide.

**Notes for the applier:**
- `terraform validate` passes; I don't have permissions to plan/apply against the live state (editor only).
- A previously hand-created `treasury-infra` AR repo and `treasury-infra-ci` SA were deleted before this PR, so `terraform apply` creates everything fresh — no imports needed. Expected plan: **6 to add, 0 to change, 0 to destroy**.
- GKE image pulls need nothing: `aztec-gke-nodes-sa` already has project-level `artifactregistry.reader` (managed in this same file).
- The consuming workflow and repo variables are already in place on the treasury-infra side; once this applies, its `build-push` job works immediately.