### PR TITLE
fix(config): fail loudly on invalid or fractional numeric config

### DIFF
--- a/yarn-project/bot/src/config.ts
+++ b/yarn-project/bot/src/config.ts
@@ -2,6 +2,7 @@ import {
   type ConfigMappingsType,
   SecretValue,
   booleanConfigHelper,
+  floatConfigHelper,
   getConfigFromMappings,
   getDefaultConfig,
   numberConfigHelper,
@@ -103,7 +104,7 @@ export const BotConfigSchema = zodFor<BotConfig>()(
       privateTransfersPerTx: z.number().int().nonnegative(),
       publicTransfersPerTx: z.number().int().nonnegative(),
       feePaymentMethod: z.literal('fee_juice'),
-      minFeePadding: z.number().int().nonnegative(),
+      minFeePadding: z.number().nonnegative(),
       noStart: z.boolean(),
       txMinedWaitSeconds: z.number(),
       followChain: z.enum(BotFollowChain),
@@ -204,7 +205,7 @@ export const botConfigMappings: ConfigMappingsType<BotConfig> = {
   minFeePadding: {
     env: 'BOT_MIN_FEE_PADDING',
     description: 'How much is the bot willing to overpay vs. the current base fee',
-    ...numberConfigHelper(3),
+    ...floatConfigHelper(3),
   },
   noStart: {
     env: 'BOT_NO_START',

--- a/yarn-project/ethereum/src/l1_tx_utils/config.ts
+++ b/yarn-project/ethereum/src/l1_tx_utils/config.ts
@@ -73,7 +73,7 @@ export const l1TxUtilsConfigMappings: ConfigMappingsType<L1TxUtilsConfig> = {
   gasLimitBufferPercentage: {
     description: 'How much to increase calculated gas limit by (percentage)',
     env: 'L1_GAS_LIMIT_BUFFER_PERCENTAGE',
-    ...numberConfigHelper(20),
+    ...floatConfigHelper(20),
   },
   maxGwei: {
     description: 'Maximum gas price in gwei to be used for transactions.',
@@ -90,12 +90,12 @@ export const l1TxUtilsConfigMappings: ConfigMappingsType<L1TxUtilsConfig> = {
   priorityFeeBumpPercentage: {
     description: 'How much to increase priority fee by each attempt (percentage)',
     env: 'L1_PRIORITY_FEE_BUMP_PERCENTAGE',
-    ...numberConfigHelper(20),
+    ...floatConfigHelper(20),
   },
   priorityFeeRetryBumpPercentage: {
     description: 'How much to increase priority fee by each retry attempt (percentage)',
     env: 'L1_PRIORITY_FEE_RETRY_BUMP_PERCENTAGE',
-    ...numberConfigHelper(50),
+    ...floatConfigHelper(50),
   },
   minimumPriorityFeePerGas: {
     description:

--- a/yarn-project/foundation/src/config/config.test.ts
+++ b/yarn-project/foundation/src/config/config.test.ts
@@ -1,6 +1,12 @@
 import { jest } from '@jest/globals';
 
-import { type ConfigMappingsType, bigintConfigHelper, getConfigFromMappings, numberConfigHelper } from './index.js';
+import {
+  type ConfigMappingsType,
+  bigintConfigHelper,
+  getConfigFromMappings,
+  numberConfigHelper,
+  optionalNumberConfigHelper,
+} from './index.js';
 
 describe('Config', () => {
   describe('getConfigFromMappings', () => {
@@ -129,6 +135,51 @@ describe('Config', () => {
 
         consoleSpy.mockRestore();
       });
+    });
+  });
+
+  describe('numberConfigHelper', () => {
+    it('parses integer strings', () => {
+      const { parseEnv } = numberConfigHelper(5);
+      expect(parseEnv!('42')).toBe(42);
+      expect(parseEnv!('0')).toBe(0);
+      expect(parseEnv!('-7')).toBe(-7);
+    });
+
+    it('returns the default value for non-numeric input', () => {
+      const { parseEnv } = numberConfigHelper(5);
+      expect(parseEnv!('not-a-number')).toBe(5);
+    });
+
+    it('throws instead of silently truncating a decimal value', () => {
+      const { parseEnv } = numberConfigHelper(5);
+      expect(() => parseEnv!('0.8')).toThrow();
+      expect(() => parseEnv!('3.14')).toThrow();
+    });
+
+    it('throws for values that are not safe integers', () => {
+      const { parseEnv } = numberConfigHelper(5);
+      expect(() => parseEnv!('1e30')).toThrow();
+      expect(() => parseEnv!('Infinity')).toThrow();
+    });
+  });
+
+  describe('optionalNumberConfigHelper', () => {
+    it('parses integer strings', () => {
+      const { parseEnv } = optionalNumberConfigHelper();
+      expect(parseEnv!('42')).toBe(42);
+      expect(parseEnv!('0')).toBe(0);
+    });
+
+    it('throws instead of silently truncating a decimal value', () => {
+      const { parseEnv } = optionalNumberConfigHelper();
+      expect(() => parseEnv!('0.5')).toThrow();
+      expect(() => parseEnv!('3.14')).toThrow();
+    });
+
+    it('throws for non-numeric input', () => {
+      const { parseEnv } = optionalNumberConfigHelper();
+      expect(() => parseEnv!('not-a-number')).toThrow();
     });
   });
 

--- a/yarn-project/foundation/src/config/config.test.ts
+++ b/yarn-project/foundation/src/config/config.test.ts
@@ -3,9 +3,11 @@ import { jest } from '@jest/globals';
 import {
   type ConfigMappingsType,
   bigintConfigHelper,
+  floatConfigHelper,
   getConfigFromMappings,
   numberConfigHelper,
   optionalNumberConfigHelper,
+  percentageConfigHelper,
 } from './index.js';
 
 describe('Config', () => {
@@ -146,9 +148,9 @@ describe('Config', () => {
       expect(parseEnv!('-7')).toBe(-7);
     });
 
-    it('returns the default value for non-numeric input', () => {
+    it('throws for non-numeric input instead of falling back to the default', () => {
       const { parseEnv } = numberConfigHelper(5);
-      expect(parseEnv!('not-a-number')).toBe(5);
+      expect(() => parseEnv!('not-a-number')).toThrow();
     });
 
     it('throws instead of silently truncating a decimal value', () => {
@@ -161,6 +163,79 @@ describe('Config', () => {
       const { parseEnv } = numberConfigHelper(5);
       expect(() => parseEnv!('1e30')).toThrow();
       expect(() => parseEnv!('Infinity')).toThrow();
+    });
+
+    it('applies the default only when the env var is unset, not when it is invalid', () => {
+      const originalEnv = process.env;
+      const envVar = 'L1_MINIMUM_PRIORITY_FEE_PER_GAS_GWEI';
+      try {
+        interface TestConfig {
+          value: number;
+        }
+        const mappings: ConfigMappingsType<TestConfig> = {
+          value: { env: envVar, description: 'test', ...numberConfigHelper(5) },
+        };
+
+        // Unset -> default
+        process.env = { ...originalEnv };
+        delete process.env[envVar];
+        expect(getConfigFromMappings(mappings).value).toBe(5);
+
+        // Empty -> default
+        process.env = { ...originalEnv, [envVar]: '' };
+        expect(getConfigFromMappings(mappings).value).toBe(5);
+
+        // Set but invalid -> throws
+        process.env = { ...originalEnv, [envVar]: 'not-a-number' };
+        expect(() => getConfigFromMappings(mappings)).toThrow();
+      } finally {
+        process.env = originalEnv;
+      }
+    });
+  });
+
+  describe('floatConfigHelper', () => {
+    it('parses floating-point strings', () => {
+      const { parseEnv } = floatConfigHelper(1.5);
+      expect(parseEnv!('0.8')).toBe(0.8);
+      expect(parseEnv!('42')).toBe(42);
+      expect(parseEnv!('-2.5')).toBe(-2.5);
+    });
+
+    it('throws for invalid input instead of falling back to the default', () => {
+      const { parseEnv } = floatConfigHelper(1.5);
+      expect(() => parseEnv!('not-a-number')).toThrow();
+      expect(() => parseEnv!('Infinity')).toThrow();
+    });
+
+    it('runs the validation function on the parsed value', () => {
+      const { parseEnv } = floatConfigHelper(1.5, val => {
+        if (val < 0) {
+          throw new Error('must be non-negative');
+        }
+      });
+      expect(parseEnv!('2.5')).toBe(2.5);
+      expect(() => parseEnv!('-1')).toThrow('must be non-negative');
+    });
+  });
+
+  describe('percentageConfigHelper', () => {
+    it('parses 0-1 values', () => {
+      const { parseEnv } = percentageConfigHelper(0.5);
+      expect(parseEnv!('0.25')).toBe(0.25);
+      expect(parseEnv!('0')).toBe(0);
+      expect(parseEnv!('1')).toBe(1);
+    });
+
+    it('throws for out-of-range values', () => {
+      const { parseEnv } = percentageConfigHelper(0.5);
+      expect(() => parseEnv!('1.5')).toThrow();
+      expect(() => parseEnv!('-0.1')).toThrow();
+    });
+
+    it('throws for invalid input instead of falling back to the default', () => {
+      const { parseEnv } = percentageConfigHelper(0.5);
+      expect(() => parseEnv!('not-a-number')).toThrow();
     });
   });
 

--- a/yarn-project/foundation/src/config/index.ts
+++ b/yarn-project/foundation/src/config/index.ts
@@ -119,21 +119,29 @@ export function omitConfigMappings<T, K extends keyof T>(
 }
 
 /**
- * Generates parseEnv and default values for a numerical config value.
- * @param defaultVal - The default numerical value to use if the environment variable is not set or is invalid
- * @returns Object with parseEnv and default values for a numerical config value
+ * Generates parseEnv and default values for an integer config value.
+ *
+ * The default is used only when the environment variable is unset or empty. A set-but-invalid
+ * value (non-numeric, fractional, or outside the safe-integer range) throws rather than silently
+ * falling back to the default.
+ * @param defaultVal - The default value to use when the environment variable is unset
+ * @returns Object with parseEnv and default values for an integer config value
  */
 export function numberConfigHelper(defaultVal: number): Pick<ConfigMapping<number>, 'parseEnv' | 'defaultValue'> {
   return {
-    parseEnv: (val: string) => safeParseNumber(val, defaultVal),
+    parseEnv: (val: string) => parseSafeInteger(val),
     defaultValue: defaultVal,
   };
 }
 
 /**
- * Generates parseEnv and default values for a numerical config value.
- * @param defaultVal - The default numerical value to use if the environment variable is not set or is invalid
- * @returns Object with parseEnv and default values for a numerical config value
+ * Generates parseEnv and default values for a floating-point config value.
+ *
+ * The default is used only when the environment variable is unset or empty. A set-but-invalid
+ * value (not a finite number) throws rather than silently falling back to the default.
+ * @param defaultVal - The default value to use when the environment variable is unset
+ * @param validationFn - Optional extra validation applied to the parsed value; should throw on invalid input
+ * @returns Object with parseEnv and default values for a floating-point config value
  */
 export function floatConfigHelper(
   defaultVal: number,
@@ -141,7 +149,7 @@ export function floatConfigHelper(
 ): Pick<ConfigMapping<number>, 'parseEnv' | 'defaultValue'> {
   return {
     parseEnv: (val: string): number => {
-      const parsed = safeParseFloat(val, defaultVal);
+      const parsed = parseFiniteNumber(val);
       validationFn?.(parsed);
       return parsed;
     },
@@ -150,12 +158,17 @@ export function floatConfigHelper(
 }
 
 /**
- * Parses an environment variable to a 0-1 percentage value
+ * Generates parseEnv and default values for a 0-1 percentage config value.
+ *
+ * The default is used only when the environment variable is unset or empty. A set-but-invalid
+ * value (not a finite number, or outside the 0-1 range) throws rather than silently falling back
+ * to the default.
+ * @param defaultVal - The default value to use when the environment variable is unset
  */
 export function percentageConfigHelper(defaultVal: number): Pick<ConfigMapping<number>, 'parseEnv' | 'defaultValue'> {
   return {
     parseEnv: (val: string): number => {
-      const parsed = safeParseFloat(val, defaultVal);
+      const parsed = parseFiniteNumber(val);
       if (parsed < 0 || parsed > 1) {
         throw new TypeError(`Invalid percentage value: ${parsed} should be between 0 and 1`);
       }
@@ -355,30 +368,19 @@ function parseSafeInteger(value: string): number {
 }
 
 /**
- * Safely parses an integer from a string.
- * If the value is not a number, the default value is returned. Numeric values that are not safe
- * integers (e.g. decimals like `0.8`) throw rather than being silently truncated to an integer.
+ * Parses a string into a finite floating-point number, throwing if the value is not a finite number.
+ *
+ * Invalid input (e.g. `'abc'`, or an overflow to `Infinity`) throws rather than being silently
+ * swallowed, so a misconfigured value fails loudly instead of falling back to the config default.
  * @param value - The string value to parse
- * @param defaultValue - The default value to return
- * @returns Either the parsed value or the default value
+ * @returns The parsed number
  */
-function safeParseNumber(value: string, defaultValue: number): number {
-  if (Number.isNaN(parseFloat(value))) {
-    return defaultValue;
-  }
-  return parseSafeInteger(value);
-}
-
-/**
- * Safely parses a floating point number from a string.
- * If the value is not a number, the default value is returned.
- * @param value - The string value to parse
- * @param defaultValue - The default value to return
- * @returns Either parsed value or default value
- */
-function safeParseFloat(value: string, defaultValue: number): number {
+function parseFiniteNumber(value: string): number {
   const parsedValue = parseFloat(value);
-  return Number.isNaN(parsedValue) ? defaultValue : parsedValue;
+  if (!Number.isFinite(parsedValue)) {
+    throw new Error(`Invalid number config value '${value}'`);
+  }
+  return parsedValue;
 }
 
 /**

--- a/yarn-project/foundation/src/config/index.ts
+++ b/yarn-project/foundation/src/config/index.ts
@@ -205,13 +205,7 @@ export function bigintConfigHelper(
  */
 export function optionalNumberConfigHelper(): Pick<ConfigMapping<number>, 'parseEnv'> {
   return {
-    parseEnv: (val: string) => {
-      const parsedValue = parseInt(val);
-      if (!Number.isSafeInteger(parsedValue)) {
-        throw new Error(`Invalid number: ${val}`);
-      }
-      return parsedValue;
-    },
+    parseEnv: (val: string) => parseSafeInteger(val),
   };
 }
 
@@ -344,15 +338,35 @@ export function secretFqConfigHelper(defaultValue?: Fq): {
 }
 
 /**
- * Safely parses a number from a string.
- * If the value is not a number or is not a safe integer, the default value is returned.
+ * Parses a string into a safe integer, throwing if the value is numeric but not an integer.
+ *
+ * Unlike `parseInt`, this does not silently truncate decimals: `'0.8'` throws rather than
+ * becoming `0`. A fractional value indicates the caller intended a non-integer where only
+ * integers are supported (use `floatConfigHelper`/`percentageConfigHelper` for those).
+ * @param value - The string value to parse
+ * @returns The parsed integer value
+ */
+function parseSafeInteger(value: string): number {
+  const parsedValue = parseFloat(value);
+  if (!Number.isSafeInteger(parsedValue)) {
+    throw new Error(`Invalid integer config value '${value}'; expected a whole number`);
+  }
+  return parsedValue;
+}
+
+/**
+ * Safely parses an integer from a string.
+ * If the value is not a number, the default value is returned. Numeric values that are not safe
+ * integers (e.g. decimals like `0.8`) throw rather than being silently truncated to an integer.
  * @param value - The string value to parse
  * @param defaultValue - The default value to return
- * @returns Either parsed value or default value
+ * @returns Either the parsed value or the default value
  */
 function safeParseNumber(value: string, defaultValue: number): number {
-  const parsedValue = parseInt(value, 10);
-  return Number.isSafeInteger(parsedValue) ? parsedValue : defaultValue;
+  if (Number.isNaN(parseFloat(value))) {
+    return defaultValue;
+  }
+  return parseSafeInteger(value);
 }
 
 /**

--- a/yarn-project/p2p/src/config.ts
+++ b/yarn-project/p2p/src/config.ts
@@ -3,6 +3,7 @@ import {
   SecretValue,
   bigintConfigHelper,
   booleanConfigHelper,
+  floatConfigHelper,
   getConfigFromMappings,
   getDefaultConfig,
   numberConfigHelper,
@@ -435,17 +436,17 @@ export const p2pConfigMappings: ConfigMappingsType<P2PConfig> = {
   gossipsubTxTopicWeight: {
     env: 'P2P_GOSSIPSUB_TX_TOPIC_WEIGHT',
     description: 'The weight of the tx topic for the gossipsub protocol.',
-    ...numberConfigHelper(1),
+    ...floatConfigHelper(1),
   },
   gossipsubTxInvalidMessageDeliveriesWeight: {
     env: 'P2P_GOSSIPSUB_TX_INVALID_MESSAGE_DELIVERIES_WEIGHT',
     description: 'The weight of the tx invalid message deliveries for the gossipsub protocol.',
-    ...numberConfigHelper(-20),
+    ...floatConfigHelper(-20),
   },
   gossipsubTxInvalidMessageDeliveriesDecay: {
     env: 'P2P_GOSSIPSUB_TX_INVALID_MESSAGE_DELIVERIES_DECAY',
     description: 'Determines how quickly the penalty for invalid message deliveries decays over time. Between 0 and 1.',
-    ...numberConfigHelper(0.5),
+    ...floatConfigHelper(0.5),
   },
   peerPenaltyValues: {
     env: 'P2P_PEER_PENALTY_VALUES',

--- a/yarn-project/sequencer-client/src/config.ts
+++ b/yarn-project/sequencer-client/src/config.ts
@@ -129,7 +129,7 @@ export const sequencerConfigMappings: ConfigMappingsType<SequencerConfig> = {
     description:
       'Per-block budget multiplier applied to DA gas and blob fields in place of perBlockAllocationMultiplier.' +
       ' Defaults higher than the general multiplier so the largest contract class deploy fits a single block.',
-    ...numberConfigHelper(DefaultSequencerConfig.perBlockDAAllocationMultiplier),
+    ...floatConfigHelper(DefaultSequencerConfig.perBlockDAAllocationMultiplier),
   },
   redistributeCheckpointBudget: {
     env: 'SEQ_REDISTRIBUTE_CHECKPOINT_BUDGET',


### PR DESCRIPTION
## Human-written summary

Invalid numeric values in config were silently ignored and replaced with the default. Also, config entries defined with `numberConfigHelper` accepted non-integer values but silently truncated them. 

## Context

The numeric config helpers mishandled bad input in two ways:

- `numberConfigHelper` / `optionalNumberConfigHelper` parsed with `parseInt`, which silently truncated decimals — an integer config set to `0.8` became `0` with no warning. In the worst case (A-1312) that turned a fractional retention window into `0`, i.e. "delete immediately".
- `numberConfigHelper`, `floatConfigHelper` and `percentageConfigHelper` swallowed any unparseable value and returned the config default (the JSDoc even documented "...or is invalid"), so a typo'd env var ran silently with an unexpected value.

## Approach

The config default is for an **unset** env var only — empty/unset is already resolved to the default before `parseEnv` runs, so the only thing `parseEnv` returning a default achieved was hiding bad input. The helpers now parse strictly and throw on any set-but-invalid value:

- `numberConfigHelper` / `optionalNumberConfigHelper`: parse with `parseFloat` and require a safe integer (no more silent truncation).
- `floatConfigHelper` / `percentageConfigHelper`: require a finite number; percentage additionally enforces 0–1.

`bigint`, `enum` and the secret helpers already threw on invalid input. `booleanConfigHelper` is intentionally unchanged: `parseBooleanEnv` is a total function (unrecognized tokens map to `false`), it never substitutes the configured default.

Auditing all ~150 `numberConfigHelper` call sites then surfaced options that legitimately take fractional values and would now wrongly reject them; these were moved to `floatConfigHelper`:

- p2p gossipsub tx scoring — topic weight, invalid-message-delivery weight, and decay (default `0.5`), which feed libp2p's float `TopicScoreParams`.
- sequencer `perBlockDAAllocationMultiplier` (default `1.5`); its sibling `perBlockAllocationMultiplier` already used `floatConfigHelper`.
- L1 tx fee percentages — `gasLimitBufferPercentage`, `priorityFeeBumpPercentage`, `priorityFeeRetryBumpPercentage`.
- bot `minFeePadding`, consumed as the fractional overpay factor `1 + padding`; its zod schema no longer pins it to an integer.

## Impact

A node whose numeric config env var (or CLI flag) is set to a non-numeric, fractional (for integer options), or out-of-range value now fails at startup with a clear error instead of silently running with a truncated or default value. Operators relying on the old lenient behavior must correct the value.

Fixes A-1398