### PR TITLE
fix(e2e): dedupe automine test cmds causing mass container-kill flakes

### DIFF
--- a/yarn-project/end-to-end/bootstrap.sh
+++ b/yarn-project/end-to-end/bootstrap.sh
@@ -53,13 +53,6 @@ function test_cmds {
   local tests=(
     # List all standalone and nested tests, except for the ones listed above.
     src/automine/*.test.ts
-    src/automine/contracts/*.test.ts
-    src/automine/contracts/deploy/*.test.ts
-    src/automine/contracts/nested/*.test.ts
-    src/automine/token/*.test.ts
-    src/automine/accounts/*.test.ts
-    src/automine/effects/*.test.ts
-    src/automine/delivery/*.test.ts
     src/automine/!(simulation)/**/*.test.ts
     src/automine/simulation/!(avm_simulator).test.ts
     src/single-node/!(prover)/**/*.test.ts


### PR DESCRIPTION
Stacked on #24477. Fixes the 49-per-run automine FLAKEs reported there and on this PR's first run.

**Root cause** (`yarn-project/end-to-end/bootstrap.sh`): the `tests` array listed the automine subdirectories explicitly and also kept the `src/automine/!(simulation)/**/*.test.ts` catch-all (a merge artifact from merging merge-train/fairies-v5 into mv/e2e-onchain-delivery-harness), so every nested automine test was emitted as two byte-identical cmds (268 jobs for 145 tests). Both copies run under the same docker container name. When the two copies overlap in time, the later one's docker_isolate force-removes the earlier one's live container (or wins the name-conflict retry added in #24477), the earlier test fails, and its automatic retry (which gets a fresh `NAME_POSTFIX`) passes: a deterministic FLAKED-with-code-0 for every overlapping pair, which is why the count sits near 49 on every run and why only `src/automine/**` flakes. When the copies do not overlap, the second is skipped by the test cache, hiding the duplication. The parent branch's "docker container name conflicts" were the same duplication seen from the other side.
