### PR TITLE
fix(p2p): process one request per reqresp stream to enforce rate limit

### DIFF
--- a/yarn-project/p2p/src/services/reqresp/reqresp.test.ts
+++ b/yarn-project/p2p/src/services/reqresp/reqresp.test.ts
@@ -21,7 +21,7 @@ import { ResponseSizeLimitExceededError, SnappyTransform } from '../encoding.js'
 import type { PeerManager } from '../peer-manager/peer_manager.js';
 import type { PeerScoring } from '../peer-manager/peer_scoring.js';
 import { MAX_REQRESP_REQUEST_SIZE_BYTES, type P2PReqRespConfig } from './config.js';
-import { type ReqRespResponse, ReqRespSubProtocol } from './interface.js';
+import { type ReqRespResponse, ReqRespSubProtocol, type ReqRespSubProtocolHandler } from './interface.js';
 import { GoodByeReason, reqGoodbyeHandler } from './protocols/goodbye.js';
 import { ReqResp } from './reqresp.js';
 import { ReqRespStatus } from './status.js';
@@ -44,6 +44,64 @@ describe('ReqResp', () => {
     if (nodes) {
       await stopNodes(nodes);
     }
+  });
+
+  // Req/resp is one-request-one-response, but a malicious peer can write many request frames on a single
+  // stream. Each frame arrives as its own chunk, and the rate limiter is only checked once per stream, so
+  // processing every chunk would let one token drive unbounded handler invocations. processStream must
+  // therefore invoke the handler at most once per stream.
+  describe('processStream', () => {
+    let req: ReqResp;
+
+    beforeEach(() => {
+      const config: P2PReqRespConfig = {
+        overallRequestTimeoutMs: 4000,
+        individualRequestTimeoutMs: 2000,
+        dialTimeoutMs: 1000,
+        p2pOptimisticNegotiation: false,
+      };
+      req = new ReqResp(config, mock<Libp2p>(), peerScoring);
+    });
+
+    afterEach(async () => {
+      // Stop the connection sampler so its cleanup interval does not leak past the test.
+      await (req as any).connectionSampler.stop();
+    });
+
+    it('invokes the handler at most once per stream, ignoring extra frames', async () => {
+      const handler = jest.fn<ReqRespSubProtocolHandler>().mockResolvedValue(Buffer.from('pong'));
+      // Register via a fresh handlers object so we do not mutate the shared MOCK_SUB_PROTOCOL_HANDLERS.
+      (req as any).subProtocolHandlers = { [ReqRespSubProtocol.PING]: handler };
+
+      const received: Buffer[] = [];
+      const incomingStream = {
+        connection: { remotePeer: mock<PeerId>() },
+        stream: {
+          metadata: {},
+          // A malicious peer pushes three request frames on the one stream it opened.
+          source: (async function* () {
+            for (const frame of [Buffer.from('req-1'), Buffer.from('req-2'), Buffer.from('req-3')]) {
+              yield frame;
+            }
+          })(),
+          sink: async (source: AsyncIterable<Buffer>) => {
+            for await (const chunk of source) {
+              received.push(chunk);
+            }
+          },
+        },
+      };
+
+      await (req as any).processStream(ReqRespSubProtocol.PING, incomingStream);
+
+      // Only the first frame is handled; the remaining two are discarded when the stream closes.
+      expect(handler).toHaveBeenCalledTimes(1);
+
+      // The sink receives exactly one SUCCESS status byte followed by one response payload.
+      expect(received).toHaveLength(2);
+      expect(received[0][0]).toBe(ReqRespStatus.SUCCESS);
+      expect(new SnappyTransform().inboundTransformData(Buffer.from(received[1])).toString('utf-8')).toEqual('pong');
+    });
   });
 
   it('should perform a ping request', async () => {

--- a/yarn-project/p2p/src/services/reqresp/reqresp.ts
+++ b/yarn-project/p2p/src/services/reqresp/reqresp.ts
@@ -469,6 +469,9 @@ export class ReqResp implements ReqRespInterface {
     await pipeline(
       stream.source,
       async function* (source: any) {
+        // Req/resp is one-request-one-response: an honest sender writes a single payload and half-closes.
+        // Process only the first chunk and return, so extra frames a peer queues on the same stream cannot
+        // drive further handler invocations that bypass the per-stream rate-limit check in streamHandler.
         for await (const chunk of source) {
           const response = await handler(connection.remotePeer, chunk.subarray());
 
@@ -483,6 +486,7 @@ export class ReqResp implements ReqRespInterface {
 
           yield SUCCESS;
           yield snappy.outboundTransformData(response);
+          return;
         }
       },
       stream.sink,


### PR DESCRIPTION
## Context

The reqresp rate limiter is consulted once per inbound stream (`streamHandler`), but the sub-protocol handler was invoked once per chunk read from that stream (`processStream`). Req/resp is one-request-one-response and an honest sender writes a single payload before half-closing, but a malicious peer can open one stream (costing a single rate-limit token) and then push many request frames on it — each frame arrives as its own chunk and drives a full handler invocation (mempool / block / tree lookups). Per-peer and global rate limits are bypassed by the fan-out factor.

## Approach

Make `processStream` handle exactly one request per stream: after emitting the response for the first chunk, the pipeline generator returns instead of looping over the rest of the source. Extra frames a peer queued on the same stream are discarded when the stream closes, so work is bounded to one request per token. This does not regress legitimate traffic — no code path pipelines multiple requests on a single stream, and the one-chunk-per-request framing is already in force.

The alternative (per-invocation rate checks inside the loop) was rejected: nothing pipelines, and mid-stream status signalling is broken on the requester side, which parses the first chunk as status and concatenates the rest as data.

Adds a unit test that drives `processStream` with three frames on one stream and asserts the handler runs once and the sink receives a single SUCCESS + response pair.

Fixes A-1324