### PR TITLE
fix(p2p): bound reqresp response buffering before size check

### DIFF
--- a/yarn-project/p2p/src/services/encoding.ts
+++ b/yarn-project/p2p/src/services/encoding.ts
@@ -7,11 +7,29 @@ import type { Message } from '@libp2p/interface';
 import { webcrypto } from 'node:crypto';
 import { compressSync, uncompressSync } from 'snappy';
 
+/**
+ * Fallback maximum response size (in KB) applied when no explicit per-request bound is supplied.
+ * Used both as the `SnappyTransform` default and as the reception-side fallback in `readMessage`.
+ */
+export const DEFAULT_MAX_RESPONSE_SIZE_KB = 10 * 1024;
+
 /** Thrown when a Snappy-compressed response exceeds the allowed decompressed size. */
 export class OversizedSnappyResponseError extends Error {
   constructor(decompressedSize: number, maxSizeKb: number) {
     super(`Decompressed size ${decompressedSize} exceeds maximum allowed size of ${maxSizeKb}kb`);
     this.name = 'OversizedSnappyResponseError';
+  }
+}
+
+/**
+ * Thrown when the compressed bytes accumulated while reading a response stream exceed the reception
+ * bound, before the full payload is buffered. Distinct from {@link OversizedSnappyResponseError},
+ * which guards the decompressed size after the stream has already been fully received.
+ */
+export class ResponseSizeLimitExceededError extends Error {
+  constructor(accumulatedBytes: number, limitBytes: number) {
+    super(`Accumulated response size ${accumulatedBytes} bytes exceeds reception limit of ${limitBytes} bytes`);
+    this.name = 'ResponseSizeLimitExceededError';
   }
 }
 
@@ -66,7 +84,7 @@ const DefaultMaxSizesKb: Record<TopicType, number> = {
 export class SnappyTransform implements DataTransform {
   constructor(
     private maxSizesKb: Record<TopicType, number> = DefaultMaxSizesKb,
-    private defaultMaxSizeKb: number = 10 * 1024,
+    private defaultMaxSizeKb: number = DEFAULT_MAX_RESPONSE_SIZE_KB,
     private logger = createLogger('p2p:snappy-transform'),
   ) {}
 

--- a/yarn-project/p2p/src/services/reqresp/reqresp.test.ts
+++ b/yarn-project/p2p/src/services/reqresp/reqresp.test.ts
@@ -15,6 +15,7 @@ import {
   startNodes,
   stopNodes,
 } from '../../test-helpers/reqresp-nodes.js';
+import { ResponseSizeLimitExceededError } from '../encoding.js';
 import type { PeerManager } from '../peer-manager/peer_manager.js';
 import type { PeerScoring } from '../peer-manager/peer_scoring.js';
 import { type ReqRespResponse, ReqRespSubProtocol } from './interface.js';
@@ -462,6 +463,33 @@ describe('ReqResp', () => {
         Buffer.from('request'),
       );
       expectSuccess(txResp);
+    });
+  });
+
+  describe('readMessage response size bounding', () => {
+    it('aborts reception once accumulated bytes exceed the size bound', async () => {
+      nodes = await createNodes(peerScoring, 1);
+      const { req } = nodes[0];
+
+      const totalDataChunks = 20;
+      let pulled = 0;
+
+      // A SUCCESS status chunk followed by oversized data chunks. `pulled` counts how many data
+      // chunks the reader drained, so we can prove reception aborts early instead of buffering the
+      // whole stream: with the fix the first 64KB chunk trips the bound (pulled === 1); without it
+      // the reader drains all 20 (pulled === 20) before the concat/size check.
+      async function* source() {
+        yield Buffer.from([ReqRespStatus.SUCCESS]);
+        for (let i = 0; i < totalDataChunks; i++) {
+          pulled++;
+          yield Buffer.alloc(64 * 1024);
+        }
+      }
+
+      // maxSizeKb = 10 => bound = 10 * 1024 * 2 = 20,480 bytes, so a single 64KB data chunk exceeds it.
+      await expect((req as any).readMessage(source(), 10)).rejects.toBeInstanceOf(ResponseSizeLimitExceededError);
+
+      expect(pulled).toBeLessThan(totalDataChunks);
     });
   });
 });

--- a/yarn-project/p2p/src/services/reqresp/reqresp.ts
+++ b/yarn-project/p2p/src/services/reqresp/reqresp.ts
@@ -11,7 +11,12 @@ import { pipeline } from 'node:stream/promises';
 import type { Uint8ArrayList } from 'uint8arraylist';
 
 import { IndividualReqRespTimeoutError } from '../../errors/reqresp.error.js';
-import { OversizedSnappyResponseError, SnappyTransform } from '../encoding.js';
+import {
+  DEFAULT_MAX_RESPONSE_SIZE_KB,
+  OversizedSnappyResponseError,
+  ResponseSizeLimitExceededError,
+  SnappyTransform,
+} from '../encoding.js';
 import type { PeerScoring } from '../peer-manager/peer_scoring.js';
 import {
   DEFAULT_INDIVIDUAL_REQUEST_TIMEOUT_MS,
@@ -291,6 +296,14 @@ export class ReqResp implements ReqRespInterface {
    * - The first chunk should contain a control byte, indicating the status of the response see `ReqRespStatus`
    * - The second chunk should contain the response data
    *
+   * To bound memory usage we abort reception as soon as the accumulated compressed bytes exceed a
+   * bound derived from `maxSizeKb`, before the full stream has been buffered. Without this a peer we
+   * dialed could stream data up to the request timeout, forcing us to buffer arbitrarily much (the
+   * `maxSizeKb` guard in `inboundTransformData` only runs after the whole compressed payload is
+   * concatenated, so it does nothing to cap reception memory). Snappy can expand incompressible input
+   * to ~1.17x its size, so we allow 2x `maxSizeKb`: comfortably above the worst-case expansion of a
+   * legitimate max-size response, while still capping buffered memory at twice the permitted size.
+   *
    * @param source - The async iterable source of data chunks
    * @param maxSizeKb - Optional maximum expected size in KB for the decompressed response
    */
@@ -298,10 +311,20 @@ export class ReqResp implements ReqRespInterface {
     let status: ReqRespStatus | undefined;
     const chunks: Uint8Array[] = [];
 
+    const maxAccumulatedBytes = (maxSizeKb ?? DEFAULT_MAX_RESPONSE_SIZE_KB) * 1024 * 2;
+    let accumulatedBytes = 0;
+
     try {
       for await (const chunk of source) {
         const statusParsed = status !== undefined;
         if (statusParsed) {
+          // Use `byteLength` (the logical length) rather than `chunk.subarray().length`: calling
+          // `subarray()` on a `Uint8ArrayList` consolidates its backing buffers into a single copy,
+          // which would materialize the very chunk we are trying to reject.
+          accumulatedBytes += chunk.byteLength;
+          if (accumulatedBytes > maxAccumulatedBytes) {
+            throw new ResponseSizeLimitExceededError(accumulatedBytes, maxAccumulatedBytes);
+          }
           chunks.push(chunk.subarray());
           continue;
         }
@@ -560,6 +583,13 @@ export class ReqResp implements ReqRespInterface {
     // Oversized snappy response: the peer is sending data that exceeds the allowed size.
     // This is a protocol violation that wastes bandwidth, so penalize harshly.
     if (e instanceof OversizedSnappyResponseError) {
+      this.logger.warn(`Oversized response from peer ${peerId.toString()} in ${subProtocol}: ${e.message}`, logTags);
+      return PeerErrorSeverity.LowToleranceError;
+    }
+
+    // Response exceeded the reception buffer bound: the peer streamed more compressed data than the
+    // per-request size limit allows. Same protocol violation as above, penalize harshly.
+    if (e instanceof ResponseSizeLimitExceededError) {
       this.logger.warn(`Oversized response from peer ${peerId.toString()} in ${subProtocol}: ${e.message}`, logTags);
       return PeerErrorSeverity.LowToleranceError;
     }


### PR DESCRIPTION
## Context

`readMessage` on the requesting side accumulated **all** response chunks into memory before the snappy `maxSizeKb` validation ran (that guard lives in `SnappyTransform.inboundTransformData`, which only executes after the full compressed stream has been buffered). A peer we dialed could send a valid `SUCCESS` status chunk and then stream data up to the request timeout, forcing the requesting node to buffer arbitrarily much (~1.2 GB/response at 1 Gbps within the 10s timeout) → remote-triggerable OOM, amplified by concurrent in-flight requests.

## Approach

- Track a running byte total in the `readMessage` loop and abort as soon as it exceeds a bound derived from `maxSizeKb`, before buffering more chunks. The bound is `maxSizeKb * 1024 * 2`: snappy can expand incompressible input to ~1.17x, so 2x sits comfortably above the worst case (a legitimate max-size response is never rejected) while capping buffered memory at twice the permitted post-decompression size.
- Uses `chunk.byteLength` rather than `chunk.subarray().length` — calling `subarray()` on a `Uint8ArrayList` consolidates its backing buffers into a copy, which would materialize the very chunk we are trying to reject.
- Throws a dedicated `ResponseSizeLimitExceededError`, penalized as a `LowToleranceError` via the existing `categorizeResponseError`/`handleResponseError` path, so the offending peer's stream is torn down and it is scored down.
- The existing decompressed-size preamble check in `inboundTransformData` still guards the decompression-bomb variant; this closes the residual reception-side buffering gap. Per-request bound only — aggregate in-flight amplification across peers is tracked separately.

Fixes A-1399