### PR TITLE
fix(p2p): reject reqresp requests larger than a single muxer frame

### DIFF
--- a/yarn-project/p2p/src/errors/reqresp.error.ts
+++ b/yarn-project/p2p/src/errors/reqresp.error.ts
@@ -12,7 +12,7 @@ export class IndividualReqRespTimeoutError extends Error {
 /** Oversized reqresp request error
  *
  * Thrown locally (before dialing) when a request payload does not fit in a single muxer frame. Such a request would
- * reach the responder split across multiple chunks, and only the first chunk is processed.
+ * reach the responder split across multiple chunks, which are never reassembled into one request.
  * @category Errors
  */
 export class OversizedReqRespRequestError extends Error {

--- a/yarn-project/p2p/src/errors/reqresp.error.ts
+++ b/yarn-project/p2p/src/errors/reqresp.error.ts
@@ -8,3 +8,22 @@ export class IndividualReqRespTimeoutError extends Error {
     super(`Request to peer timed out`);
   }
 }
+
+/** Oversized reqresp request error
+ *
+ * Thrown locally (before dialing) when a request payload does not fit in a single muxer frame. Such a request would
+ * reach the responder split across multiple chunks, and only the first chunk is processed.
+ * @category Errors
+ */
+export class OversizedReqRespRequestError extends Error {
+  constructor(
+    public readonly subProtocol: string,
+    public readonly payloadSizeBytes: number,
+    public readonly maxSizeBytes: number,
+  ) {
+    super(
+      `Request payload of ${payloadSizeBytes} bytes for ${subProtocol} exceeds the ${maxSizeBytes} byte limit of a single muxer frame`,
+    );
+    this.name = 'OversizedReqRespRequestError';
+  }
+}

--- a/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
+++ b/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
@@ -90,7 +90,7 @@ import type { PeerManagerInterface } from '../peer-manager/interface.js';
 import { PeerManager } from '../peer-manager/peer_manager.js';
 import { PeerScoring } from '../peer-manager/peer_scoring.js';
 import type { BatchTxRequesterLibP2PService } from '../reqresp/batch-tx-requester/interface.js';
-import type { P2PReqRespConfig } from '../reqresp/config.js';
+import { type P2PReqRespConfig, YAMUX_MAX_MESSAGE_SIZE_BYTES } from '../reqresp/config.js';
 import {
   AuthRequest,
   BlockTxsRequest,
@@ -457,7 +457,8 @@ export class LibP2PService extends WithTracer implements P2PService {
       ],
       datastore,
       peerDiscovery,
-      streamMuxers: [yamux(), mplex()],
+      // Pin the yamux frame size: MAX_REQRESP_REQUEST_SIZE_BYTES relies on a reqresp request fitting in one frame.
+      streamMuxers: [yamux({ maxMessageSize: YAMUX_MAX_MESSAGE_SIZE_BYTES }), mplex()],
       connectionEncryption: [noise()],
       connectionManager: {
         minConnections: 0, // Disable libp2p peer dialing, we do it manually

--- a/yarn-project/p2p/src/services/reqresp/config.ts
+++ b/yarn-project/p2p/src/services/reqresp/config.ts
@@ -5,6 +5,23 @@ export const DEFAULT_OVERALL_REQUEST_TIMEOUT_MS = 10_000; // Not currently used
 export const DEFAULT_REQRESP_DIAL_TIMEOUT_MS = 5_000;
 export const DEFAULT_OPTIMISTIC_NEGOTIATION = false;
 
+/**
+ * Max size of a yamux frame, header included. This is the library default, pinned explicitly when configuring the
+ * muxer in the libp2p service so a dependency upgrade cannot silently change it.
+ */
+export const YAMUX_MAX_MESSAGE_SIZE_BYTES = 64 * 1024;
+
+/** Size of a yamux data frame header. */
+const YAMUX_HEADER_LENGTH_BYTES = 12;
+
+/**
+ * Max size of a reqresp request payload. A request must fit in a single muxer frame: the responder never reassembles
+ * a request from multiple chunks (see `ReqResp.processStream`), and yamux splits writes larger than one frame into
+ * multiple frames, each of which arrives as a separate chunk. mplex only splits at 1 MiB, so yamux is the binding
+ * constraint.
+ */
+export const MAX_REQRESP_REQUEST_SIZE_BYTES = YAMUX_MAX_MESSAGE_SIZE_BYTES - YAMUX_HEADER_LENGTH_BYTES;
+
 // For use in tests.
 export const DEFAULT_P2P_REQRESP_CONFIG: P2PReqRespConfig = {
   overallRequestTimeoutMs: DEFAULT_OVERALL_REQUEST_TIMEOUT_MS,

--- a/yarn-project/p2p/src/services/reqresp/reqresp.test.ts
+++ b/yarn-project/p2p/src/services/reqresp/reqresp.test.ts
@@ -6,7 +6,9 @@ import { Tx, TxArray, TxHash, TxHashArray } from '@aztec/stdlib/tx';
 import { describe, expect, it, jest } from '@jest/globals';
 import type { PeerId } from '@libp2p/interface';
 import { type MockProxy, mock } from 'jest-mock-extended';
+import type { Libp2p } from 'libp2p';
 
+import { OversizedReqRespRequestError } from '../../errors/reqresp.error.js';
 import {
   MOCK_SUB_PROTOCOL_HANDLERS,
   type ReqRespNode,
@@ -15,11 +17,13 @@ import {
   startNodes,
   stopNodes,
 } from '../../test-helpers/reqresp-nodes.js';
-import { ResponseSizeLimitExceededError } from '../encoding.js';
+import { ResponseSizeLimitExceededError, SnappyTransform } from '../encoding.js';
 import type { PeerManager } from '../peer-manager/peer_manager.js';
 import type { PeerScoring } from '../peer-manager/peer_scoring.js';
+import { MAX_REQRESP_REQUEST_SIZE_BYTES, type P2PReqRespConfig } from './config.js';
 import { type ReqRespResponse, ReqRespSubProtocol } from './interface.js';
 import { GoodByeReason, reqGoodbyeHandler } from './protocols/goodbye.js';
+import { ReqResp } from './reqresp.js';
 import { ReqRespStatus } from './status.js';
 
 const PING_REQUEST = Buffer.from('ping');
@@ -490,6 +494,65 @@ describe('ReqResp', () => {
       await expect((req as any).readMessage(source(), 10)).rejects.toBeInstanceOf(ResponseSizeLimitExceededError);
 
       expect(pulled).toBeLessThan(totalDataChunks);
+    });
+  });
+
+  // A request must fit in a single muxer frame: yamux splits larger writes into multiple frames, each arriving as
+  // its own chunk, and the responder never reassembles them into one request. Guard against a request type growing
+  // past that limit and surfacing as a confusing decoding error on the responder.
+  describe('sendRequestToPeer', () => {
+    let req: ReqResp;
+
+    beforeEach(() => {
+      const config: P2PReqRespConfig = {
+        overallRequestTimeoutMs: 4000,
+        individualRequestTimeoutMs: 2000,
+        dialTimeoutMs: 1000,
+        p2pOptimisticNegotiation: false,
+      };
+      req = new ReqResp(config, mock<Libp2p>(), peerScoring);
+    });
+
+    afterEach(async () => {
+      // Stop the connection sampler so its cleanup interval does not leak past the test.
+      await (req as any).connectionSampler.stop();
+    });
+
+    it('rejects a request payload that does not fit in a single muxer frame, without dialing the peer', async () => {
+      const dialSpy = jest.spyOn((req as any).connectionSampler, 'dialProtocol');
+      const payload = Buffer.alloc(MAX_REQRESP_REQUEST_SIZE_BYTES + 1);
+
+      await expect(req.sendRequestToPeer(mock<PeerId>(), ReqRespSubProtocol.PING, payload)).rejects.toThrow(
+        OversizedReqRespRequestError,
+      );
+
+      expect(dialSpy).not.toHaveBeenCalled();
+      // The oversized request is our own bug, so the remote peer must not be penalized for it.
+      expect(peerScoring.penalizePeer).not.toHaveBeenCalled();
+    });
+
+    it('sends a request payload at exactly the single-frame limit', async () => {
+      const snappy = new SnappyTransform();
+      const stream = {
+        id: 'test-stream',
+        metadata: {},
+        source: (async function* () {
+          yield Buffer.from([ReqRespStatus.SUCCESS]);
+          yield snappy.outboundTransformData(Buffer.from('pong'));
+        })(),
+        sink: async (source: AsyncIterable<Buffer>) => {
+          for await (const _chunk of source) {
+            // Consume the request.
+          }
+        },
+        close: () => Promise.resolve(),
+      };
+      jest.spyOn((req as any).connectionSampler, 'dialProtocol').mockResolvedValue(stream);
+
+      const payload = Buffer.alloc(MAX_REQRESP_REQUEST_SIZE_BYTES);
+      const response = await req.sendRequestToPeer(mock<PeerId>(), ReqRespSubProtocol.PING, payload);
+
+      expect(response).toEqual({ status: ReqRespStatus.SUCCESS, data: Buffer.from('pong') });
     });
   });
 });

--- a/yarn-project/p2p/src/services/reqresp/reqresp.ts
+++ b/yarn-project/p2p/src/services/reqresp/reqresp.ts
@@ -10,7 +10,7 @@ import type { Libp2p } from 'libp2p';
 import { pipeline } from 'node:stream/promises';
 import type { Uint8ArrayList } from 'uint8arraylist';
 
-import { IndividualReqRespTimeoutError } from '../../errors/reqresp.error.js';
+import { IndividualReqRespTimeoutError, OversizedReqRespRequestError } from '../../errors/reqresp.error.js';
 import {
   DEFAULT_MAX_RESPONSE_SIZE_KB,
   OversizedSnappyResponseError,
@@ -21,6 +21,7 @@ import type { PeerScoring } from '../peer-manager/peer_scoring.js';
 import {
   DEFAULT_INDIVIDUAL_REQUEST_TIMEOUT_MS,
   DEFAULT_REQRESP_DIAL_TIMEOUT_MS,
+  MAX_REQRESP_REQUEST_SIZE_BYTES,
   type P2PReqRespConfig,
 } from './config.js';
 import { ConnectionSampler, RandomSampler } from './connection-sampler/connection_sampler.js';
@@ -212,6 +213,11 @@ export class ReqResp implements ReqRespInterface {
     payload: Buffer,
     dialTimeout: number = this.dialTimeoutMs,
   ): Promise<ReqRespResponse> {
+    // Thrown before the try block so the generic error handling below does not penalize the peer for our own bug.
+    if (payload.length > MAX_REQRESP_REQUEST_SIZE_BYTES) {
+      throw new OversizedReqRespRequestError(subProtocol, payload.length, MAX_REQRESP_REQUEST_SIZE_BYTES);
+    }
+
     let stream: Stream | undefined;
     try {
       this.metrics.recordRequestSent(subProtocol);


### PR DESCRIPTION
A reqresp request payload must fit in a single muxer frame: yamux splits writes larger than 64KiB (minus the 12-byte frame header) into multiple frames, each of which arrives at the responder as a separate chunk, and the responder never reassembles a request from multiple chunks. A request type growing past that limit would surface as a confusing decoding error on the responder instead of failing at the sender.

- Assert the payload size in `sendRequestToPeer` before dialing, throwing a descriptive `OversizedReqRespRequestError` locally. The check runs before the generic error handling so the remote peer is not penalized for a local bug.
- Pin `maxMessageSize` on the yamux muxer to its library default (64KiB) so a dependency upgrade cannot silently change the limit the assertion relies on.
- Tests: an oversized payload is rejected without dialing the peer and without penalizing it; a payload at exactly the limit round-trips successfully.

Related to #24552.

## No current subprotocol can exceed the limit

The limit is 65,524 bytes (64KiB yamux frame minus the 12-byte header). **No reqresp subprotocol today can produce a request anywhere near it**, so this assertion cannot fire on legitimate traffic:

- `GOODBYE`: 1 byte (the reason code).
- `PING`: a few bytes.
- `STATUS`: a `StatusMessage` (component versions string, block numbers, block hash) — tens of bytes.
- `AUTH`: an `AuthRequest` (`StatusMessage` plus a 32-byte challenge) — tens of bytes.
- `TX`: the request type is `TxHashArray` (4 + 32·n bytes), but this subprotocol currently has no sender — only the server-side handler remains.
- `BLOCK_TXS`: the only request that scales with anything. Serialized as `archiveRoot` (32 bytes) + tx-indices `BitVector` (4 + ⌈N/8⌉ bytes, N = tx count of the proposal) + tx-hashes commitment (32 bytes) + optional full-hash vector (4 + 32·H bytes). Pinned-peer and smart-peer requests send indices only (H = 0). Dumb-peer requests include full hashes but chunk them to `txBatchSize`, which is always the default 8 in production (`BatchTxRequester` is constructed without opts, and the option is not wired to any config). N is capped at deserialization by `MAX_TXS_PER_BLOCK = 2^16`, so even a maliciously large proposal yields a worst-case request of ~8.5KB — about 13% of the limit. A realistic 32-tx block produces requests of a few hundred bytes.

Breaching the limit would take a proposal with ~460k txs (which `BitVector.fromBuffer` rejects at 2^16 anyway) or a `txBatchSize` over ~1,800 with full hashes enabled — neither is reachable today. The assertion exists so that if a future change makes a request type scale past the limit, it fails loudly at the sender instead of as a decoding error at the responder.
