### PR TITLE
fix(node): fork-aware getWorldState that fails closed on sync errors

### DIFF
--- a/yarn-project/aztec-node/src/aztec-node/server.test.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.test.ts
@@ -69,6 +69,7 @@ import {
 } from '@aztec/stdlib/tx';
 import { getPackageVersion } from '@aztec/stdlib/update-checker';
 import type { ValidatorClient } from '@aztec/validator-client';
+import { WorldStateSynchronizerError } from '@aztec/world-state';
 
 import { jest } from '@jest/globals';
 import { mkdtempSync, rmSync, writeFileSync } from 'fs';
@@ -108,6 +109,15 @@ class TestAztecNodeService extends AztecNodeService {
     return super.getWorldState(block);
   }
 }
+
+/** Builds minimal block metadata for a given block number and hash, as returned by the block source. */
+const makeBlockData = (blockNumber: BlockNumber, blockHash: BlockHash = BlockHash.random()): BlockData => ({
+  header: BlockHeader.empty({ globalVariables: GlobalVariables.empty({ blockNumber }) }),
+  archive: L2Block.empty().archive,
+  blockHash,
+  checkpointNumber: CheckpointNumber(1),
+  indexWithinCheckpoint: IndexWithinCheckpoint(0),
+});
 
 describe('aztec node', () => {
   let p2p: MockProxy<P2P>;
@@ -185,11 +195,21 @@ describe('aztec node', () => {
     worldState = mock<WorldStateSynchronizer>({
       getCommitted: () => merkleTreeOps,
     });
-    worldState.syncImmediate.mockImplementation(() => Promise.resolve(lastBlockNumber));
+    // Mirrors the real synchronizer contract: resolves with the synced block, rejects when the target is
+    // beyond what the block source can provide.
+    worldState.syncImmediate.mockImplementation((target?: BlockNumber) =>
+      target !== undefined && target > lastBlockNumber
+        ? Promise.reject(
+            new WorldStateSynchronizerError(
+              `Unable to sync to block number ${target} (last synced is ${lastBlockNumber})`,
+            ),
+          )
+        : Promise.resolve(lastBlockNumber),
+    );
 
     l2BlockSource = mock<L2BlockSource>();
     l2BlockSource.getBlockNumber.mockImplementation(((query?: BlockQuery) => {
-      if (!query) {
+      if (!query || 'tag' in query) {
         return Promise.resolve(lastBlockNumber);
       }
       if ('number' in query) {
@@ -197,6 +217,17 @@ describe('aztec node', () => {
       }
       return Promise.resolve(undefined);
     }) as L2BlockSource['getBlockNumber']);
+    // World-state queries resolve every block parameter to a concrete (number, hash) via getBlockData, mirroring
+    // the getBlockNumber resolution above but returning full block metadata.
+    l2BlockSource.getBlockData.mockImplementation(((query?: BlockQuery) => {
+      if (!query || 'tag' in query) {
+        return Promise.resolve(makeBlockData(lastBlockNumber));
+      }
+      if ('number' in query) {
+        return Promise.resolve(query.number <= lastBlockNumber ? makeBlockData(query.number) : undefined);
+      }
+      return Promise.resolve(undefined);
+    }) as L2BlockSource['getBlockData']);
     l2BlockSource.getL1Constants.mockResolvedValue(testL1Constants);
     l2BlockSource.getGenesisBlockHash.mockReturnValue(BlockHash.random());
 
@@ -617,67 +648,76 @@ describe('aztec node', () => {
     describe('getWorldState', () => {
       let snapshotMerkleTreeOps: MockProxy<MerkleTreeReadOperations>;
       let initialHeader: BlockHeader;
+      let initialBlockHash: BlockHash;
+
+      // A block's fork hash is derived deterministically from its number so tests can assert the exact hash
+      // threaded through resolution -> sync -> snapshot. Block 0 hashes to the genesis header hash.
+      const hashForBlock = (blockNumber: BlockNumber): BlockHash =>
+        blockNumber === BlockNumber.ZERO ? initialBlockHash : new BlockHash(new Fr(1_000_000n + BigInt(blockNumber)));
 
       beforeEach(async () => {
         lastBlockNumber = BlockNumber(5);
         initialHeader = BlockHeader.empty({
           globalVariables: GlobalVariables.empty({ blockNumber: BlockNumber.ZERO }),
         });
-        // Archiver resolves the initial block hash to block number 0 directly.
-        const initialBlockHash = await initialHeader.hash();
-        l2BlockSource.getBlockNumber.mockImplementation(((query?: BlockQuery) =>
+        initialBlockHash = await initialHeader.hash();
+        // The block source resolves each query variant to concrete block metadata: tags and the no-arg case to
+        // the latest block, numbers within range to themselves (undefined past the tip), and the genesis hash to
+        // block 0. Unknown hashes resolve to undefined.
+        l2BlockSource.getBlockData.mockImplementation(((query?: BlockQuery) =>
           Promise.resolve(
-            !query
-              ? lastBlockNumber
+            !query || 'tag' in query
+              ? makeBlockData(lastBlockNumber, hashForBlock(lastBlockNumber))
               : 'number' in query
-                ? query.number
+                ? query.number <= lastBlockNumber
+                  ? makeBlockData(query.number, hashForBlock(query.number))
+                  : undefined
                 : 'hash' in query && query.hash.equals(initialBlockHash)
-                  ? BlockNumber.ZERO
+                  ? makeBlockData(BlockNumber.ZERO, initialBlockHash)
                   : undefined,
-          )) as L2BlockSource['getBlockNumber']);
-        // #getInitialHeaderHash still sources from worldStateSynchronizer (used in error messages).
-        merkleTreeOps.getInitialHeader.mockReturnValue(initialHeader);
+          )) as L2BlockSource['getBlockData']);
         snapshotMerkleTreeOps = mock<MerkleTreeReadOperations>();
-        worldState.getSnapshot.mockReturnValue(snapshotMerkleTreeOps);
+        worldState.getVerifiedSnapshot.mockResolvedValue(snapshotMerkleTreeOps);
       });
 
       it('returns committed db for latest', async () => {
         const result = await node.getWorldState('latest');
         expect(result).toBe(merkleTreeOps);
-        expect(worldState.getSnapshot).not.toHaveBeenCalled();
+        expect(worldState.getVerifiedSnapshot).not.toHaveBeenCalled();
       });
 
       it('returns snapshot for a block number within sync range', async () => {
         const result = await node.getWorldState(BlockNumber(3));
         expect(result).toBe(snapshotMerkleTreeOps);
-        expect(worldState.getSnapshot).toHaveBeenCalledWith(BlockNumber(3));
+        expect(worldState.getVerifiedSnapshot).toHaveBeenCalledWith(BlockNumber(3), hashForBlock(BlockNumber(3)));
       });
 
       it('throws for a block number beyond sync range', async () => {
-        await expect(node.getWorldState(BlockNumber(10))).rejects.toThrow(/not yet synced/);
+        // A number past the tip cannot be resolved to block metadata. This is transient (the block may still
+        // arrive), so it is retried and then surfaced rather than serving state at the wrong height.
+        await expect(node.getWorldState(BlockNumber(10))).rejects.toThrow(/Block not found for number=10/);
       });
 
       it('throws for a block hash whose block number is beyond sync range', async () => {
         const blockHash = BlockHash.random();
-        l2BlockSource.getBlockNumber.mockImplementation(((query?: BlockQuery) =>
+        l2BlockSource.getBlockData.mockImplementation(((query?: BlockQuery) =>
           Promise.resolve(
-            query && 'hash' in query ? BlockNumber(10) : lastBlockNumber,
-          )) as L2BlockSource['getBlockNumber']);
+            query && 'hash' in query ? makeBlockData(BlockNumber(10), blockHash) : undefined,
+          )) as L2BlockSource['getBlockData']);
 
-        await expect(node.getWorldState(blockHash)).rejects.toThrow(/not yet synced/);
+        await expect(node.getWorldState(blockHash)).rejects.toThrow(/Unable to sync to block number 10/);
       });
 
       it('resolves block hash to block number via archiver and returns snapshot', async () => {
         const blockHash = BlockHash.random();
-        l2BlockSource.getBlockNumber.mockImplementation(((query?: BlockQuery) =>
+        l2BlockSource.getBlockData.mockImplementation(((query?: BlockQuery) =>
           Promise.resolve(
-            query && 'hash' in query ? BlockNumber(3) : lastBlockNumber,
-          )) as L2BlockSource['getBlockNumber']);
-        snapshotMerkleTreeOps.getLeafValue.mockResolvedValue(blockHash);
+            query && 'hash' in query ? makeBlockData(BlockNumber(3), blockHash) : undefined,
+          )) as L2BlockSource['getBlockData']);
 
         const result = await node.getWorldState(blockHash);
         expect(result).toBe(snapshotMerkleTreeOps);
-        expect(worldState.getSnapshot).toHaveBeenCalledWith(BlockNumber(3));
+        expect(worldState.getVerifiedSnapshot).toHaveBeenCalledWith(BlockNumber(3), blockHash);
       });
 
       it('drives a reorg-aware sync to the requested block hash', async () => {
@@ -685,52 +725,156 @@ describe('aztec node', () => {
         // exact (number, hash) so the synchronizer barriers on the archive-tree commit and detects reorgs,
         // rather than syncing to bare latest height and racing the snapshot read.
         const blockHash = BlockHash.random();
-        l2BlockSource.getBlockNumber.mockImplementation(((query?: BlockQuery) =>
+        l2BlockSource.getBlockData.mockImplementation(((query?: BlockQuery) =>
           Promise.resolve(
-            query && 'hash' in query ? BlockNumber(3) : lastBlockNumber,
-          )) as L2BlockSource['getBlockNumber']);
-        snapshotMerkleTreeOps.getLeafValue.mockResolvedValue(blockHash);
+            query && 'hash' in query ? makeBlockData(BlockNumber(3), blockHash) : undefined,
+          )) as L2BlockSource['getBlockData']);
 
         await node.getWorldState(blockHash);
 
         expect(worldState.syncImmediate).toHaveBeenCalledWith(BlockNumber(3), blockHash);
       });
 
-      it('syncs to latest height without a hash when querying by block number', async () => {
+      it('syncs to the resolved fork hash when querying by block number', async () => {
+        // Number queries pin a fork too: the resolved hash is threaded to the sync so a reorg that replaced
+        // the block at that height is detected instead of silently served.
         await node.getWorldState(BlockNumber(3));
-        expect(worldState.syncImmediate).toHaveBeenCalledWith(lastBlockNumber, undefined);
+        expect(worldState.syncImmediate).toHaveBeenCalledWith(BlockNumber(3), hashForBlock(BlockNumber(3)));
       });
 
       it('throws when block hash is not found in archiver', async () => {
         const blockHash = BlockHash.random();
 
-        await expect(node.getWorldState(blockHash)).rejects.toThrow(/not found when querying world state/);
+        await expect(node.getWorldState(blockHash)).rejects.toThrow(/not found when resolving query/);
       });
 
-      it('throws when world-state block hash does not match requested hash (reorg)', async () => {
+      it('propagates a reorg (block hash mismatch) error from the synchronizer', async () => {
+        // The synchronizer verifies the requested hash against the synced fork and throws on mismatch;
+        // getWorldState no longer re-checks the hash itself, so once retries are exhausted (the hash keeps
+        // resolving, the sync keeps failing) it must surface that error to the caller.
         const blockHash = BlockHash.random();
-        const differentHash = BlockHash.random();
-        l2BlockSource.getBlockNumber.mockImplementation(((query?: BlockQuery) =>
+        l2BlockSource.getBlockData.mockImplementation(((query?: BlockQuery) =>
           Promise.resolve(
-            query && 'hash' in query ? BlockNumber(3) : lastBlockNumber,
-          )) as L2BlockSource['getBlockNumber']);
-        // World state returns a different hash for the same block number
-        snapshotMerkleTreeOps.getLeafValue.mockResolvedValue(differentHash);
+            query && 'hash' in query ? makeBlockData(BlockNumber(3), blockHash) : undefined,
+          )) as L2BlockSource['getBlockData']);
+        worldState.syncImmediate.mockRejectedValue(new WorldStateSynchronizerError('Block hash mismatch at block 3'));
 
-        await expect(node.getWorldState(blockHash)).rejects.toThrow(/not found in world state at block number/);
+        await expect(node.getWorldState(blockHash)).rejects.toThrow(/Block hash mismatch/);
+      });
+
+      it('throws instead of returning stale committed state when sync fails', async () => {
+        // Regression guard: a sync failure used to be swallowed and the latest committed db returned
+        // regardless, serving stale state with no signal that synchronization had failed.
+        worldState.syncImmediate.mockRejectedValue(new Error('sync failed'));
+
+        await expect(node.getWorldState('latest')).rejects.toThrow(/sync failed/);
+      });
+
+      it('serves a tag query whose tip advances past the pre-sync latest block', async () => {
+        // The tag tip can move while world state syncs (e.g. during catch-up, blocks arrive already proven),
+        // so the query must resolve the tag up front and drive the sync to that exact block, instead of
+        // syncing to a stale latest height and then failing the range check against a newer resolution.
+        l2BlockSource.getBlockData.mockImplementation(((query?: BlockQuery) =>
+          Promise.resolve(
+            query && 'tag' in query && query.tag === 'proven'
+              ? makeBlockData(BlockNumber(7), hashForBlock(BlockNumber(7)))
+              : undefined,
+          )) as L2BlockSource['getBlockData']);
+        worldState.syncImmediate.mockImplementation((target?: BlockNumber) =>
+          Promise.resolve(target ?? lastBlockNumber),
+        );
+
+        const result = await node.getWorldState('proven');
+
+        expect(result).toBe(snapshotMerkleTreeOps);
+        expect(worldState.getVerifiedSnapshot).toHaveBeenCalledWith(BlockNumber(7), hashForBlock(BlockNumber(7)));
+      });
+
+      it('retries with a re-resolved target when a prune makes the sync target unreachable', async () => {
+        // A prune can land between resolving the query and syncing to the resolved block, making the
+        // target permanently unreachable. The retry re-resolves the tag against the post-prune chain.
+        let checkpointedTip = BlockNumber(4);
+        l2BlockSource.getBlockData.mockImplementation(((query?: BlockQuery) =>
+          Promise.resolve(
+            query && 'tag' in query && query.tag === 'checkpointed'
+              ? makeBlockData(checkpointedTip, hashForBlock(checkpointedTip))
+              : undefined,
+          )) as L2BlockSource['getBlockData']);
+        worldState.syncImmediate.mockImplementationOnce(() => {
+          checkpointedTip = BlockNumber(3);
+          return Promise.reject(new WorldStateSynchronizerError('Unable to sync to block number 4 (last synced is 3)'));
+        });
+
+        const result = await node.getWorldState('checkpointed');
+
+        expect(result).toBe(snapshotMerkleTreeOps);
+        expect(worldState.getVerifiedSnapshot).toHaveBeenCalledWith(BlockNumber(3), hashForBlock(BlockNumber(3)));
+      });
+
+      it('converts a mid-query prune of a hash anchor into a clear reorg error', async () => {
+        // The hash resolves before the prune, then the sync fails because the block is gone; the retry
+        // re-resolves the (now unknown) hash, surfacing the descriptive reorg error instead of the raw
+        // sync failure.
+        const blockHash = BlockHash.random();
+        let pruned = false;
+        l2BlockSource.getBlockData.mockImplementation(((query?: BlockQuery) =>
+          Promise.resolve(
+            query && 'hash' in query ? (pruned ? undefined : makeBlockData(BlockNumber(3), blockHash)) : undefined,
+          )) as L2BlockSource['getBlockData']);
+        worldState.syncImmediate.mockImplementation(() => {
+          pruned = true;
+          return Promise.reject(new WorldStateSynchronizerError('Block hash mismatch at block 3'));
+        });
+
+        await expect(node.getWorldState(blockHash)).rejects.toThrow(/not found when resolving query/);
       });
 
       it('returns snapshot at block 0 for initial header hash', async () => {
         // Block 0 is a first-class historical block: its state lives in the trees' persisted block-0
-        // payload. getWorldState resolves the genesis hash to block number 0 and returns the snapshot.
-        const initialBlockHash = await initialHeader.hash();
-        // The archive at block 0 contains the genesis header hash at index 0, which is what the
-        // double-check compares against after the snapshot is resolved.
-        snapshotMerkleTreeOps.getLeafValue.mockResolvedValue(initialBlockHash);
-
+        // payload. getWorldState resolves the genesis hash to block number 0 and returns the verified snapshot.
         const result = await node.getWorldState(initialBlockHash);
         expect(result).toBe(snapshotMerkleTreeOps);
-        expect(worldState.getSnapshot).toHaveBeenCalledWith(BlockNumber.ZERO);
+        expect(worldState.getVerifiedSnapshot).toHaveBeenCalledWith(BlockNumber.ZERO, initialBlockHash);
+      });
+
+      it('re-resolves a tag query onto the new fork when a reorg flips the block hash mid-flight', async () => {
+        // Proven tip is block 10 on fork A; a reorg replaces it with fork B while we sync. The sync rejects the
+        // stale fork-A hash, and the retry must re-resolve the tag and serve fork B rather than silently
+        // returning wrong-fork state.
+        const hashA = new BlockHash(new Fr(0xaa));
+        const hashB = new BlockHash(new Fr(0xbb));
+        let reorged = false;
+        l2BlockSource.getBlockData.mockImplementation(((query?: BlockQuery) =>
+          Promise.resolve(
+            query && 'tag' in query && query.tag === 'proven'
+              ? makeBlockData(BlockNumber(10), reorged ? hashB : hashA)
+              : undefined,
+          )) as L2BlockSource['getBlockData']);
+        worldState.syncImmediate.mockImplementation((target?: BlockNumber, blockHash?: BlockHash) => {
+          reorged = true;
+          return blockHash?.equals(hashB)
+            ? Promise.resolve(target ?? lastBlockNumber)
+            : Promise.reject(new WorldStateSynchronizerError(`Block hash mismatch at block ${target}`));
+        });
+
+        const result = await node.getWorldState('proven');
+
+        expect(result).toBe(snapshotMerkleTreeOps);
+        expect(worldState.getVerifiedSnapshot).toHaveBeenCalledWith(BlockNumber(10), hashB);
+      });
+
+      it('retries when snapshot-stage fork verification fails and heals after re-resolution', async () => {
+        // syncImmediate reports success, but reading the snapshot back detects that the fork flipped
+        // underneath. The retry re-resolves and the second verified snapshot succeeds.
+        worldState.syncImmediate.mockResolvedValue(lastBlockNumber);
+        worldState.getVerifiedSnapshot
+          .mockRejectedValueOnce(new WorldStateSynchronizerError('Block hash mismatch at block 3'))
+          .mockResolvedValue(snapshotMerkleTreeOps);
+
+        const result = await node.getWorldState(BlockNumber(3));
+
+        expect(result).toBe(snapshotMerkleTreeOps);
+        expect(worldState.getVerifiedSnapshot).toHaveBeenCalledTimes(2);
       });
     });
 

--- a/yarn-project/aztec-node/src/modules/node_world_state_queries.ts
+++ b/yarn-project/aztec-node/src/modules/node_world_state_queries.ts
@@ -3,6 +3,7 @@ import { BlockNumber, type CheckpointNumber, type EpochNumber } from '@aztec/fou
 import { chunkBy } from '@aztec/foundation/collection';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { type Logger, createLogger } from '@aztec/foundation/log';
+import { sleep } from '@aztec/foundation/sleep';
 import { MembershipWitness, type SiblingPath } from '@aztec/foundation/trees';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
 import {
@@ -10,6 +11,7 @@ import {
   type BlockParameter,
   type DataInBlock,
   type L2BlockSource,
+  type NormalizedBlockParameter,
   inspectBlockParameter,
 } from '@aztec/stdlib/block';
 import { computePublicDataTreeLeafSlot } from '@aztec/stdlib/hash';
@@ -23,8 +25,15 @@ import {
   PublicDataWitness,
 } from '@aztec/stdlib/trees';
 import type { TxHash } from '@aztec/stdlib/tx';
+import { WorldStateSynchronizerError } from '@aztec/world-state';
 
 import { normalizeBlockParameter } from './block_parameter.js';
+
+/** Attempts at resolving a query and syncing world state to it before giving up (see {@link NodeWorldStateQueries.getWorldState}). */
+const WORLD_STATE_SYNC_ATTEMPTS = 3;
+
+/** Delay between world-state sync attempts. */
+const WORLD_STATE_SYNC_RETRY_DELAY_MS = 100;
 
 /** Dependencies required to build a {@link NodeWorldStateQueries}. */
 export interface NodeWorldStateQueriesDeps {
@@ -128,7 +137,7 @@ export class NodeWorldStateQueries {
     // The Noir circuit checks the archive membership proof against `anchor_block_header.last_archive.root`,
     // which is the archive tree root BEFORE the anchor block was added (i.e. the state after block N-1).
     // So we need the world state at block N-1, not block N, to produce a sibling path matching that root.
-    const referenceBlockNumber = await this.resolveBlockNumber(referenceBlock);
+    const referenceBlockNumber = await this.#resolveBlockNumber(referenceBlock);
     if (referenceBlockNumber === BlockNumber.ZERO) {
       // Block 0 (the initial block) has an empty archive, so no membership witness can exist.
       return undefined;
@@ -270,91 +279,96 @@ export class NodeWorldStateQueries {
   }
 
   /**
-   * Returns an instance of MerkleTreeOperations having first ensured the world state is fully synched
-   * @param block - The block parameter (block number, block hash, or 'latest') at which to get the data.
+   * Returns an instance of MerkleTreeOperations having first ensured the world state is synced to the requested
+   * block on the correct fork. Every query variant is resolved to a concrete (block number, block hash), which is
+   * threaded through both the sync and the snapshot read so a reorg that replaced the block at that height is
+   * detected rather than served silently. Transient failures — a prune landing between resolution and sync, or a
+   * fork flip caught at either the sync or the snapshot stage — are retried a few times, re-resolving the query
+   * against the updated chain each time; resolution failures such as an unknown block hash are terminal and thrown
+   * immediately.
+   * @param block - The block parameter (block number, block hash, or tag) at which to get the data.
    * @returns An instance of a committed MerkleTreeOperations
    */
   public async getWorldState(block: BlockParameter) {
     const query = normalizeBlockParameter(block);
 
-    // When the request anchors on a specific block hash, resolve it against the archiver up front and
-    // drive the world-state sync to that exact block number and hash. Resolving against the archiver
-    // first fails fast with a clear reorg error if the hash is unknown, and passing the hash to the
-    // synchronizer makes the sync reorg-aware: it barriers until the archive-tree commit for that block
-    // has landed and verifies it matches the requested fork, instead of syncing to bare latest height
-    // and then racing the snapshot read below against an in-flight archive-tree write.
-    const requestedHash = 'hash' in query ? query.hash : undefined;
-    const anchorBlockNumber = requestedHash !== undefined ? await this.resolveBlockNumber(query) : undefined;
-
-    let blockSyncedTo: BlockNumber = BlockNumber.ZERO;
-    try {
-      // Attempt to sync the world state if necessary
-      blockSyncedTo = await this.#syncWorldState(anchorBlockNumber, requestedHash);
-    } catch (err) {
-      this.log.error(`Error getting world state: ${err}`);
+    for (let attempt = 1; ; attempt++) {
+      try {
+        return await this.#resolveWorldState(query);
+      } catch (err) {
+        if (attempt >= WORLD_STATE_SYNC_ATTEMPTS || !(err instanceof WorldStateSynchronizerError)) {
+          throw err;
+        }
+        this.log.verbose(`Retrying world state query after sync failure: ${err.message}`, {
+          attempt,
+          block: inspectBlockParameter(block),
+        });
+        await sleep(WORLD_STATE_SYNC_RETRY_DELAY_MS);
+      }
     }
+  }
 
+  /**
+   * Resolves `query` to a concrete (block number, block hash), syncs world state to that exact fork, and returns
+   * the committed db (for `proposed` queries) or the fork-verified snapshot at the resolved block.
+   */
+  async #resolveWorldState(query: NormalizedBlockParameter) {
+    // User requests 'latest on the current fork', so the committed db is returned unverified
     if ('tag' in query && query.tag === 'proposed') {
-      this.log.debug(`Using committed db for latest block, world state synced upto ${blockSyncedTo}`);
+      this.log.debug(`Using committed db for latest block`);
+      await this.worldStateSynchronizer.syncImmediate();
       return this.worldStateSynchronizer.getCommitted();
     }
 
-    const blockNumber = anchorBlockNumber ?? (await this.resolveBlockNumber(query));
+    // Resolve the query against the block source BEFORE syncing to a concrete (number, hash), and drive the sync to
+    // that exact fork. Resolving after the sync races the block source: the resolved tip can advance past what world
+    // state synced while the sync is in flight. Passing the hash makes the sync reorg-aware — it barriers until the
+    // archive-tree commit for that block has landed and verifies it matches the requested fork, throwing otherwise.
+    const { blockNumber, blockHash } = await this.#resolveBlockNumberAndHash(query);
+    const blockSyncedTo = await this.worldStateSynchronizer.syncImmediate(blockNumber, blockHash);
 
-    // Check it's within world state sync range
-    if (blockNumber > blockSyncedTo) {
-      throw new Error(
-        `Queried block ${inspectBlockParameter(block)} not yet synced by the node (node is synced upto ${blockSyncedTo}).`,
-      );
+    // The fork could flip between it returning and the snapshot being read, so getVerifiedSnapshot pins the
+    // returned view to the resolved fork (re-resolved by the retry loop on mismatch).
+    this.log.debug(`Using verified snapshot for block ${blockNumber}, world state synced upto ${blockSyncedTo}`);
+    return await this.worldStateSynchronizer.getVerifiedSnapshot(blockNumber, blockHash);
+  }
+
+  /** Resolves any {@link BlockParameter} variant to its concrete `(blockNumber, blockHash)` via the block source. */
+  async #resolveBlockNumberAndHash(
+    query: NormalizedBlockParameter,
+  ): Promise<{ blockNumber: BlockNumber; blockHash: BlockHash }> {
+    const blockData = await this.blockSource.getBlockData(query);
+    if (blockData === undefined) {
+      this.#throwOnUndefinedBlockData(query);
     }
-    this.log.debug(`Using snapshot for block ${blockNumber}, world state synced upto ${blockSyncedTo}`);
-
-    const snapshot = this.worldStateSynchronizer.getSnapshot(blockNumber);
-
-    // Double-check world-state synced to the same block hash as was requested.
-    // Block 0 is skipped: the snapshot returned by `getSnapshot(0)` is the *pre*-genesis archive
-    // (size 0), so leaf 0 is not yet inserted from that snapshot's view even though block 0's hash
-    // does live at archive index 0 in the committed tree. The genesis hash is already validated by
-    // the archiver when it resolves the hash query to block number 0.
-    if (requestedHash !== undefined && blockNumber !== BlockNumber.ZERO) {
-      const blockHash = await snapshot.getLeafValue(MerkleTreeId.ARCHIVE, BigInt(blockNumber));
-      if (!blockHash || !requestedHash.equals(blockHash)) {
-        throw new Error(
-          `Block hash ${requestedHash.toString()} not found in world state at block number ${blockNumber} (world state has ${blockHash?.toString() ?? 'no hash'} at that index, genesis header hash is ${this.blockSource.getGenesisBlockHash().toString()}). If the node API has been queried with anchor block hash possibly a reorg has occurred.`,
-        );
-      }
-    }
-
-    return snapshot;
+    return { blockNumber: blockData.header.getBlockNumber(), blockHash: blockData.blockHash };
   }
 
   /** Resolves any {@link BlockParameter} variant to a concrete block number. */
-  public async resolveBlockNumber(block: BlockParameter): Promise<BlockNumber> {
-    const query = normalizeBlockParameter(block);
-    const blockNumber = await this.blockSource.getBlockNumber(query);
+  async #resolveBlockNumber(block: BlockParameter): Promise<BlockNumber> {
+    const blockQuery = normalizeBlockParameter(block);
+    const blockNumber = await this.blockSource.getBlockNumber(blockQuery);
     if (blockNumber === undefined) {
-      if ('hash' in query) {
-        throw new Error(
-          `Block hash ${query.hash.toString()} not found when querying world state. If the node API has been queried with anchor block hash possibly a reorg has occurred.`,
-        );
-      }
-      if ('archive' in query) {
-        throw new Error(`Block with archive ${query.archive.toString()} not found.`);
-      }
-      throw new Error(`Block not found for ${inspectBlockParameter(block)}.`);
+      this.#throwOnUndefinedBlockData(blockQuery);
     }
     return blockNumber;
   }
 
   /**
-   * Ensure the world state is synced.
-   * @param targetBlockNumber - Block to sync up to. Defaults to the latest block known to the archiver.
-   * @param blockHash - If provided, the synchronizer verifies the block at `targetBlockNumber` matches this
-   * hash, resyncing (and so detecting reorgs) if it does not yet match or has been reorged away.
-   * @returns A promise that fulfils once the world state is synced
+   * Hash and archive misses are terminal (an unknown block, likely a reorg); tag and number misses are transient —
+   * the block may have been pruned between the tag->number resolution and this data read, or may simply not have
+   * arrived yet — and surface as {@link WorldStateSynchronizerError} so the retry loop re-resolves against the
+   * current chain.
    */
-  async #syncWorldState(targetBlockNumber?: BlockNumber, blockHash?: BlockHash): Promise<BlockNumber> {
-    const target = targetBlockNumber ?? (await this.blockSource.getBlockNumber());
-    return await this.worldStateSynchronizer.syncImmediate(target, blockHash);
+  #throwOnUndefinedBlockData(query: NormalizedBlockParameter): never {
+    if ('hash' in query) {
+      throw new Error(
+        `Block hash ${query.hash.toString()} not found when resolving query. If the node API has been queried with anchor block hash possibly a reorg has occurred.`,
+      );
+    }
+    if ('archive' in query) {
+      throw new Error(`Block with archive ${query.archive.toString()} not found when resolving query.`);
+    }
+    throw new WorldStateSynchronizerError(`Block not found for ${inspectBlockParameter(query)} when resolving query.`);
   }
 }

--- a/yarn-project/aztec-node/src/modules/node_world_state_queries.ts
+++ b/yarn-project/aztec-node/src/modules/node_world_state_queries.ts
@@ -284,8 +284,8 @@ export class NodeWorldStateQueries {
    * threaded through both the sync and the snapshot read so a reorg that replaced the block at that height is
    * detected rather than served silently. Transient failures — a prune landing between resolution and sync, or a
    * fork flip caught at either the sync or the snapshot stage — are retried a few times, re-resolving the query
-   * against the updated chain each time; resolution failures such as an unknown block hash are terminal and thrown
-   * immediately.
+   * against the updated chain each time; terminal failures — an unknown block hash at resolution, or a block whose
+   * history world state has pruned away — are thrown immediately.
    * @param block - The block parameter (block number, block hash, or tag) at which to get the data.
    * @returns An instance of a committed MerkleTreeOperations
    */

--- a/yarn-project/stdlib/src/interfaces/world_state.ts
+++ b/yarn-project/stdlib/src/interfaces/world_state.ts
@@ -73,7 +73,9 @@ export interface WorldStateSynchronizer extends ReadonlyWorldStateAccess, ForkMe
    *
    * Rejects if the block at `blockNumber` does not match `blockHash` (a reorg), or if the block's hash cannot be
    * read from the requested view. Both are transient from a caller's perspective: re-resolving the query against
-   * the current chain and retrying may succeed or produce a more precise error.
+   * the current chain and retrying may succeed or produce a more precise error. However, if the block's history
+   * has been pruned away (it predates the oldest historical block kept by world state), the rejection is terminal:
+   * retrying cannot bring the data back.
    */
   getVerifiedSnapshot(blockNumber: BlockNumber, blockHash: BlockHash): Promise<MerkleTreeReadOperations>;
 

--- a/yarn-project/stdlib/src/interfaces/world_state.ts
+++ b/yarn-project/stdlib/src/interfaces/world_state.ts
@@ -65,6 +65,18 @@ export interface ReadonlyWorldStateAccess {
 
 /** Defines the interface for a world state synchronizer. */
 export interface WorldStateSynchronizer extends ReadonlyWorldStateAccess, ForkMerkleTreeOperations {
+  /**
+   * Returns a read handle to the world state at `blockNumber`, but only after verifying that the block at that
+   * height is on the fork identified by `blockHash`. This pins the returned view to a specific fork so a reorg
+   * that replaced the block at `blockNumber` cannot be served silently, closing the gap between resolving a query
+   * and reading its snapshot.
+   *
+   * Rejects if the block at `blockNumber` does not match `blockHash` (a reorg), or if the block's hash cannot be
+   * read from the requested view. Both are transient from a caller's perspective: re-resolving the query against
+   * the current chain and retrying may succeed or produce a more precise error.
+   */
+  getVerifiedSnapshot(blockNumber: BlockNumber, blockHash: BlockHash): Promise<MerkleTreeReadOperations>;
+
   /** Starts the synchronizer. */
   start(): Promise<void | PromiseWithResolvers<void>>;
 

--- a/yarn-project/txe/esbuild/stubs/world_state_stub.ts
+++ b/yarn-project/txe/esbuild/stubs/world_state_stub.ts
@@ -7,3 +7,10 @@ export function createWorldState(..._args: unknown[]): never {
 export function createWorldStateSynchronizer(..._args: unknown[]): never {
   throwStub('createWorldStateSynchronizer');
 }
+
+export class WorldStateSynchronizerError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = 'WorldStateSynchronizerError';
+  }
+}

--- a/yarn-project/txe/src/state_machine/synchronizer.ts
+++ b/yarn-project/txe/src/state_machine/synchronizer.ts
@@ -58,6 +58,11 @@ export class TXESynchronizer implements WorldStateSynchronizer {
     return this.nativeWorldStateService.getSnapshot(BlockNumber(blockNumber));
   }
 
+  /** Gets a snapshot at the given block number. The TXE has no reorgs, so the fork hash is not verified. */
+  public getVerifiedSnapshot(blockNumber: number, _blockHash: BlockHash): Promise<MerkleTreeReadOperations> {
+    return Promise.resolve(this.getSnapshot(blockNumber));
+  }
+
   /** Backups the db to the target path. */
   public backupTo(dstPath: string, compact?: boolean): Promise<Record<Exclude<SnapshotDataKeys, 'archiver'>, string>> {
     return this.nativeWorldStateService.backupTo(dstPath, compact);

--- a/yarn-project/world-state/src/synchronizer/errors.ts
+++ b/yarn-project/world-state/src/synchronizer/errors.ts
@@ -1,5 +1,13 @@
+/**
+ * Thrown by {@link ServerWorldStateSynchronizer.syncImmediate} when world state cannot be synced to the requested
+ * target: either the block is not available from the block source (`block_not_available`, e.g. it was pruned away)
+ * or the synced block does not match the requested hash (`block_hash_mismatch`, i.e. a reorg). Both causes are
+ * transient from the caller's perspective: re-resolving the query against the current chain and retrying may succeed
+ * or produce a more precise error.
+ */
 export class WorldStateSynchronizerError extends Error {
   constructor(message: string, options?: ErrorOptions) {
     super(message, options);
+    this.name = 'WorldStateSynchronizerError';
   }
 }

--- a/yarn-project/world-state/src/synchronizer/index.ts
+++ b/yarn-project/world-state/src/synchronizer/index.ts
@@ -1,2 +1,3 @@
 export * from './server_world_state_synchronizer.js';
 export * from './factory.js';
+export * from './errors.js';

--- a/yarn-project/world-state/src/synchronizer/server_world_state_synchronizer.test.ts
+++ b/yarn-project/world-state/src/synchronizer/server_world_state_synchronizer.test.ts
@@ -7,6 +7,7 @@ import type { Checkpoint } from '@aztec/stdlib/checkpoint';
 import { type MerkleTreeReadOperations, WorldStateRunningState } from '@aztec/stdlib/interfaces/server';
 import type { L1ToL2MessageSource } from '@aztec/stdlib/messaging';
 import { mockCheckpointAndMessages } from '@aztec/stdlib/testing';
+import { MerkleTreeId } from '@aztec/stdlib/trees';
 import type { BlockHeader } from '@aztec/stdlib/tx';
 
 import { jest } from '@jest/globals';
@@ -275,6 +276,48 @@ describe('ServerWorldStateSynchronizer', () => {
     expect(merkleTreeDb.handleL2BlockAndMessages.mock.calls[3][1]).toEqual(checkpoints[2].messages);
     expect(merkleTreeDb.handleL2BlockAndMessages.mock.calls[4][1]).toEqual([]);
     expect(merkleTreeDb.handleL2BlockAndMessages.mock.calls[5][1]).toEqual([]);
+  });
+
+  describe('getVerifiedSnapshot', () => {
+    let snapshot: MockProxy<MerkleTreeReadOperations>;
+
+    beforeEach(() => {
+      snapshot = mock<MerkleTreeReadOperations>();
+      merkleTreeDb.getSnapshot.mockReturnValue(snapshot);
+    });
+
+    it('returns the snapshot when the archive leaf matches the requested block hash', async () => {
+      const hash = new BlockHash(new Fr(123n));
+      snapshot.getLeafValue.mockResolvedValue(new Fr(123n));
+
+      await expect(server.getVerifiedSnapshot(BlockNumber(4), hash)).resolves.toBe(snapshot);
+      // The archive leaf is read from the snapshot's own view, at the block-number index.
+      expect(snapshot.getLeafValue).toHaveBeenCalledWith(MerkleTreeId.ARCHIVE, 4n);
+    });
+
+    it('throws when the archive leaf does not match the requested block hash', async () => {
+      snapshot.getLeafValue.mockResolvedValue(new Fr(42n));
+
+      await expect(server.getVerifiedSnapshot(BlockNumber(4), new BlockHash(new Fr(123n)))).rejects.toThrow(
+        /block hash mismatch/i,
+      );
+    });
+
+    it('throws when the archive leaf cannot be read', async () => {
+      snapshot.getLeafValue.mockResolvedValue(undefined);
+
+      await expect(server.getVerifiedSnapshot(BlockNumber(4), new BlockHash(new Fr(123n)))).rejects.toThrow(
+        /unable to read block hash/i,
+      );
+    });
+
+    it('verifies block 0 against the initial header hash rather than the empty archive', async () => {
+      const genesisHash = new BlockHash(new Fr(777n));
+      merkleTreeRead.getInitialHeader.mockReturnValue({ hash: () => Promise.resolve(genesisHash) } as BlockHeader);
+
+      await expect(server.getVerifiedSnapshot(BlockNumber.ZERO, genesisHash)).resolves.toBe(snapshot);
+      expect(snapshot.getLeafValue).not.toHaveBeenCalled();
+    });
   });
 });
 

--- a/yarn-project/world-state/src/synchronizer/server_world_state_synchronizer.test.ts
+++ b/yarn-project/world-state/src/synchronizer/server_world_state_synchronizer.test.ts
@@ -15,6 +15,7 @@ import { type MockProxy, mock } from 'jest-mock-extended';
 
 import type { MerkleTreeAdminDatabase, WorldStateConfig } from '../index.js';
 import { type WorldStateStatusSummary, buildEmptyWorldStateStatusFull } from '../native/message.js';
+import { WorldStateSynchronizerError } from './errors.js';
 import { ServerWorldStateSynchronizer } from './server_world_state_synchronizer.js';
 
 describe('ServerWorldStateSynchronizer', () => {
@@ -303,12 +304,27 @@ describe('ServerWorldStateSynchronizer', () => {
       );
     });
 
-    it('throws when the archive leaf cannot be read', async () => {
+    it('throws a retryable error when the archive leaf cannot be read', async () => {
       snapshot.getLeafValue.mockResolvedValue(undefined);
 
-      await expect(server.getVerifiedSnapshot(BlockNumber(4), new BlockHash(new Fr(123n)))).rejects.toThrow(
-        /unable to read block hash/i,
-      );
+      const error = await server.getVerifiedSnapshot(BlockNumber(4), new BlockHash(new Fr(123n))).catch(err => err);
+      expect(error).toBeInstanceOf(WorldStateSynchronizerError);
+      expect(error.message).toMatch(/unable to read block hash/i);
+    });
+
+    it('throws a terminal error when the block predates the oldest historical block', async () => {
+      snapshot.getLeafValue.mockResolvedValue(undefined);
+      merkleTreeDb.getStatusSummary.mockResolvedValue({
+        unfinalizedBlockNumber: BlockNumber(6),
+        finalizedBlockNumber: BlockNumber(4),
+        oldestHistoricalBlock: BlockNumber(4),
+        treesAreSynched: true,
+      } satisfies WorldStateStatusSummary);
+
+      const error = await server.getVerifiedSnapshot(BlockNumber(2), new BlockHash(new Fr(123n))).catch(err => err);
+      expect(error).not.toBeInstanceOf(WorldStateSynchronizerError);
+      expect(error.message).toMatch(/unable to find leaf/i);
+      expect(error.message).toMatch(/pruned/i);
     });
 
     it('verifies block 0 against the initial header hash rather than the empty archive', async () => {

--- a/yarn-project/world-state/src/synchronizer/server_world_state_synchronizer.ts
+++ b/yarn-project/world-state/src/synchronizer/server_world_state_synchronizer.ts
@@ -78,6 +78,37 @@ export class ServerWorldStateSynchronizer
     return this.merkleTreeDb.getSnapshot(blockNumber);
   }
 
+  public async getVerifiedSnapshot(blockNumber: BlockNumber, blockHash: BlockHash): Promise<MerkleTreeReadOperations> {
+    const snapshot = this.merkleTreeDb.getSnapshot(blockNumber);
+    // Block 0's snapshot is the pre-genesis archive view (size 0), so archive leaf 0 is not visible from it;
+    // verify against the initial header hash instead. For later blocks, read archive leaf `blockNumber` from the
+    // snapshot's own view so the exact handle we return is validated against the requested fork.
+    const actualHash =
+      blockNumber === BlockNumber.ZERO
+        ? (await this.merkleTreeCommitted.getInitialHeader().hash()).toString()
+        : (await snapshot.getLeafValue(MerkleTreeId.ARCHIVE, BigInt(blockNumber)))?.toString();
+
+    if (actualHash === undefined) {
+      throw new WorldStateSynchronizerError(`Unable to read block hash at block ${blockNumber} to verify snapshot`, {
+        cause: { reason: 'block_not_available', targetBlockNumber: blockNumber },
+      });
+    }
+    if (actualHash !== blockHash.toString()) {
+      throw new WorldStateSynchronizerError(
+        `Block hash mismatch at block ${blockNumber} (expected ${blockHash} but got ${actualHash})`,
+        {
+          cause: {
+            reason: 'block_hash_mismatch',
+            targetBlockNumber: blockNumber,
+            expectedHash: blockHash.toString(),
+            actualHash,
+          },
+        },
+      );
+    }
+    return snapshot;
+  }
+
   public fork(blockNumber?: BlockNumber, opts?: { closeDelayMs?: number }): Promise<MerkleTreeWriteOperations> {
     return this.merkleTreeDb.fork(blockNumber, opts);
   }

--- a/yarn-project/world-state/src/synchronizer/server_world_state_synchronizer.ts
+++ b/yarn-project/world-state/src/synchronizer/server_world_state_synchronizer.ts
@@ -89,6 +89,15 @@ export class ServerWorldStateSynchronizer
         : (await snapshot.getLeafValue(MerkleTreeId.ARCHIVE, BigInt(blockNumber)))?.toString();
 
     if (actualHash === undefined) {
+      // A missing archive leaf means either the block's history has been pruned away (permanent: the block predates
+      // the oldest historical block kept by world state) or a reorg flipped the fork between the sync and this read
+      // (transient). Only the latter is worth retrying, so it alone surfaces as WorldStateSynchronizerError.
+      const { oldestHistoricalBlock } = await this.merkleTreeDb.getStatusSummary();
+      if (blockNumber < oldestHistoricalBlock) {
+        throw new Error(
+          `Unable to find leaf for block ${blockNumber} in the archive tree: world state history has been pruned to block ${oldestHistoricalBlock}`,
+        );
+      }
       throw new WorldStateSynchronizerError(`Unable to read block hash at block ${blockNumber} to verify snapshot`, {
         cause: { reason: 'block_not_available', targetBlockNumber: blockNumber },
       });


### PR DESCRIPTION
## Context

`getWorldState` backs most node RPC tree/witness queries, and had three related problems:

- World-state sync failures were swallowed (logged and ignored), so queries were served from whatever state the node had — stale reads with no signal to the caller.
- For tag and number queries, the target block was resolved *after* syncing, so an archiver tip advancing mid-request (routine during catch-up) made valid queries fail spuriously with "not yet synced".
- Resolution pinned only a block *height*, never a *fork*: a reorg replacing the block at that height between resolution, sync, and snapshot read was served silently — e.g. a `proven` query could be answered with a same-height block from a new fork that is not proven.

## Approach

- Every query variant (number, hash, archive, tag) now resolves up front to a concrete (block number, block hash) via the archiver's `getBlockData`, and the sync is driven to that exact block and hash so the synchronizer barriers on it and detects fork mismatches.
- A new `WorldStateSynchronizer.getVerifiedSnapshot(blockNumber, blockHash)` verifies the snapshot's own archive view matches the requested fork before handing it out (block 0 is checked against the initial header hash, since its snapshot predates the genesis archive leaf), closing the remaining window between sync and snapshot read.
- Sync and fork-verification failures surface as `WorldStateSynchronizerError` and are retried a few times with the query re-resolved each time, so prunes and fork flips heal onto the current chain instead of failing or serving wrong-fork state. Hash and archive resolution misses stay terminal with a clear reorg error; tag and number misses are treated as transient.
- `proposed`/`latest` queries keep their "latest on the current fork" semantics: plain sync plus the committed db, unverified.

## API changes

- `WorldStateSynchronizer` gains `getVerifiedSnapshot(blockNumber, blockHash)`, implemented by `ServerWorldStateSynchronizer` (fork-verified) and `TXESynchronizer` (passthrough, no reorgs). Other `getSnapshot` callers are unchanged.
- Node RPC queries at a block now fail instead of silently returning stale state when world state cannot sync, and the error messages for unknown or unsyncable blocks have changed accordingly.

Fixes A-1339