### PR TITLE
feat(world-state): support prefilled nullifiers in genesis state

### DIFF
--- a/barretenberg/cpp/src/barretenberg/nodejs_module/world_state/world_state.cpp
+++ b/barretenberg/cpp/src/barretenberg/nodejs_module/world_state/world_state.cpp
@@ -48,6 +48,7 @@ WorldStateWrapper::WorldStateWrapper(const Napi::CallbackInfo& info)
     std::unordered_map<MerkleTreeId, uint32_t> tree_height;
     std::unordered_map<MerkleTreeId, index_t> tree_prefill;
     std::vector<PublicDataLeafValue> prefilled_public_data;
+    std::vector<bb::fr> prefilled_nullifiers;
     std::vector<MerkleTreeId> tree_ids{
         MerkleTreeId::NULLIFIER_TREE,        MerkleTreeId::NOTE_HASH_TREE, MerkleTreeId::PUBLIC_DATA_TREE,
         MerkleTreeId::L1_TO_L2_MESSAGE_TREE, MerkleTreeId::ARCHIVE,
@@ -112,7 +113,28 @@ WorldStateWrapper::WorldStateWrapper(const Napi::CallbackInfo& info)
         throw Napi::TypeError::New(env, "Prefilled public data must be an array");
     }
 
-    size_t initial_header_generator_point_index = 4;
+    size_t prefilled_nullifiers_index = 4;
+    if (info.Length() > prefilled_nullifiers_index && info[prefilled_nullifiers_index].IsArray()) {
+        Napi::Array arr = info[prefilled_nullifiers_index].As<Napi::Array>();
+        for (uint32_t i = 0; i < arr.Length(); ++i) {
+            if (!arr.Get(i).IsBuffer()) {
+                throw Napi::TypeError::New(env, "Prefilled nullifier value must be a buffer");
+            }
+            Napi::Buffer<uint8_t> nullifier_buf = arr.Get(i).As<Napi::Buffer<uint8_t>>();
+            if (nullifier_buf.Length() != 32) {
+                throw Napi::TypeError::New(env, "Prefilled nullifier value must be a 32-byte buffer");
+            }
+            uint256_t nullifier = 0;
+            for (size_t j = 0; j < 32; ++j) {
+                nullifier = (nullifier << 8) | nullifier_buf[j];
+            }
+            prefilled_nullifiers.emplace_back(nullifier);
+        }
+    } else {
+        throw Napi::TypeError::New(env, "Prefilled nullifiers must be an array");
+    }
+
+    size_t initial_header_generator_point_index = 5;
     if (info.Length() > initial_header_generator_point_index && info[initial_header_generator_point_index].IsNumber()) {
         initial_header_generator_point = info[initial_header_generator_point_index].As<Napi::Number>().Uint32Value();
     } else {
@@ -120,7 +142,7 @@ WorldStateWrapper::WorldStateWrapper(const Napi::CallbackInfo& info)
     }
 
     uint64_t genesis_timestamp = 0;
-    size_t genesis_timestamp_index = 5;
+    size_t genesis_timestamp_index = 6;
     if (info.Length() > genesis_timestamp_index) {
         if (info[genesis_timestamp_index].IsNumber()) {
             genesis_timestamp = static_cast<uint64_t>(info[genesis_timestamp_index].As<Napi::Number>().Int64Value());
@@ -130,7 +152,7 @@ WorldStateWrapper::WorldStateWrapper(const Napi::CallbackInfo& info)
     }
 
     // optional parameters
-    size_t map_size_index = 6;
+    size_t map_size_index = 7;
     if (info.Length() > map_size_index) {
         if (info[map_size_index].IsObject()) {
             Napi::Object obj = info[map_size_index].As<Napi::Object>();
@@ -160,7 +182,7 @@ WorldStateWrapper::WorldStateWrapper(const Napi::CallbackInfo& info)
         }
     }
 
-    size_t thread_pool_size_index = 7;
+    size_t thread_pool_size_index = 8;
     if (info.Length() > thread_pool_size_index) {
         if (!info[thread_pool_size_index].IsNumber()) {
             throw Napi::TypeError::New(env, "Thread pool size must be a number");
@@ -173,7 +195,7 @@ WorldStateWrapper::WorldStateWrapper(const Napi::CallbackInfo& info)
     // commits never block on fsync, files stay sparse, and a crash mid-write yields an
     // unrecoverable env. Intended for throwaway scratch state (TXE test sessions).
     bool ephemeral = false;
-    size_t ephemeral_index = 8;
+    size_t ephemeral_index = 9;
     if (info.Length() > ephemeral_index) {
         if (!info[ephemeral_index].IsBoolean()) {
             throw Napi::TypeError::New(env, "Ephemeral flag must be a boolean");
@@ -187,6 +209,7 @@ WorldStateWrapper::WorldStateWrapper(const Napi::CallbackInfo& info)
                                        tree_height,
                                        tree_prefill,
                                        prefilled_public_data,
+                                       prefilled_nullifiers,
                                        initial_header_generator_point,
                                        genesis_timestamp,
                                        ephemeral);

--- a/barretenberg/cpp/src/barretenberg/world_state/world_state.cpp
+++ b/barretenberg/cpp/src/barretenberg/world_state/world_state.cpp
@@ -39,6 +39,7 @@ WorldState::WorldState(uint64_t thread_pool_size,
                        const std::unordered_map<MerkleTreeId, uint32_t>& tree_heights,
                        const std::unordered_map<MerkleTreeId, index_t>& tree_prefill,
                        const std::vector<PublicDataLeafValue>& prefilled_public_data,
+                       const std::vector<bb::fr>& prefilled_nullifiers,
                        uint32_t initial_header_generator_point,
                        uint64_t genesis_timestamp,
                        bool ephemeral)
@@ -51,7 +52,7 @@ WorldState::WorldState(uint64_t thread_pool_size,
 {
     // We set the max readers to be high, at least the number of given threads or the default if higher
     uint64_t maxReaders = std::max(thread_pool_size, DEFAULT_MIN_NUMBER_OF_READERS);
-    create_canonical_fork(data_dir, map_size, prefilled_public_data, maxReaders, ephemeral);
+    create_canonical_fork(data_dir, map_size, prefilled_public_data, prefilled_nullifiers, maxReaders, ephemeral);
     try {
         attempt_tree_resync();
     } catch (std::exception& e) {
@@ -73,6 +74,7 @@ WorldState::WorldState(uint64_t thread_pool_size,
                              tree_heights,
                              tree_prefill,
                              std::vector<PublicDataLeafValue>(),
+                             std::vector<bb::fr>(),
                              initial_header_generator_point,
                              genesis_timestamp,
                              ephemeral)
@@ -84,6 +86,7 @@ WorldState::WorldState(uint64_t thread_pool_size,
                        const std::unordered_map<MerkleTreeId, uint32_t>& tree_heights,
                        const std::unordered_map<MerkleTreeId, index_t>& tree_prefill,
                        const std::vector<PublicDataLeafValue>& prefilled_public_data,
+                       const std::vector<bb::fr>& prefilled_nullifiers,
                        uint32_t initial_header_generator_point,
                        uint64_t genesis_timestamp,
                        bool ephemeral)
@@ -99,6 +102,7 @@ WorldState::WorldState(uint64_t thread_pool_size,
                  tree_heights,
                  tree_prefill,
                  prefilled_public_data,
+                 prefilled_nullifiers,
                  initial_header_generator_point,
                  genesis_timestamp,
                  ephemeral)
@@ -118,6 +122,7 @@ WorldState::WorldState(uint64_t thread_pool_size,
                  tree_heights,
                  tree_prefill,
                  std::vector<PublicDataLeafValue>(),
+                 std::vector<bb::fr>(),
                  initial_header_generator_point,
                  genesis_timestamp,
                  ephemeral)
@@ -126,6 +131,7 @@ WorldState::WorldState(uint64_t thread_pool_size,
 void WorldState::create_canonical_fork(const std::string& dataDir,
                                        const std::unordered_map<MerkleTreeId, uint64_t>& dbSize,
                                        const std::vector<PublicDataLeafValue>& prefilled_public_data,
+                                       const std::vector<bb::fr>& prefilled_nullifiers,
                                        uint64_t maxReaders,
                                        bool ephemeral)
 {
@@ -148,9 +154,15 @@ void WorldState::create_canonical_fork(const std::string& dataDir,
     {
         uint32_t levels = _tree_heights.at(MerkleTreeId::NULLIFIER_TREE);
         index_t initial_size = _initial_tree_size.at(MerkleTreeId::NULLIFIER_TREE);
+        std::vector<NullifierLeafValue> prefilled_nullifier_leaves;
+        prefilled_nullifier_leaves.reserve(prefilled_nullifiers.size());
+        for (const auto& nullifier : prefilled_nullifiers) {
+            prefilled_nullifier_leaves.emplace_back(nullifier);
+        }
         auto store = std::make_unique<NullifierStore>(
             getMerkleTreeName(MerkleTreeId::NULLIFIER_TREE), levels, _persistentStores->nullifierStore);
-        auto tree = std::make_unique<NullifierTree>(std::move(store), _workers, initial_size);
+        auto tree =
+            std::make_unique<NullifierTree>(std::move(store), _workers, initial_size, prefilled_nullifier_leaves);
         fork->_trees.insert({ MerkleTreeId::NULLIFIER_TREE, TreeWithStore(std::move(tree)) });
     }
     {

--- a/barretenberg/cpp/src/barretenberg/world_state/world_state.hpp
+++ b/barretenberg/cpp/src/barretenberg/world_state/world_state.hpp
@@ -82,11 +82,15 @@ class WorldState {
                const std::unordered_map<MerkleTreeId, uint32_t>& tree_heights,
                const std::unordered_map<MerkleTreeId, index_t>& tree_prefill,
                const std::vector<PublicDataLeafValue>& prefilled_public_data,
+               const std::vector<bb::fr>& prefilled_nullifiers,
                uint32_t initial_header_generator_point,
                uint64_t genesis_timestamp = 0,
                bool ephemeral = false);
 
     /**
+     * @param prefilled_nullifiers Nullifier leaves to pre-insert into the genesis nullifier tree (e.g. the protocol
+     *                  contract registration nullifiers). Must be unique and strictly increasing in field value, and
+     *                  distinct from the padding leaves implied by the nullifier tree prefill size.
      * @param ephemeral When true, every underlying LMDB env opens with `MDB_NOSYNC |
      *                  MDB_NOMETASYNC`. Commits return without waiting for fsync; the kernel
      *                  flushes lazily, files stay sparse. Intended for throwaway scratch
@@ -99,6 +103,7 @@ class WorldState {
                const std::unordered_map<MerkleTreeId, uint32_t>& tree_heights,
                const std::unordered_map<MerkleTreeId, index_t>& tree_prefill,
                const std::vector<PublicDataLeafValue>& prefilled_public_data,
+               const std::vector<bb::fr>& prefilled_nullifiers,
                uint32_t initial_header_generator_point,
                uint64_t genesis_timestamp = 0,
                bool ephemeral = false);
@@ -326,6 +331,7 @@ class WorldState {
     void create_canonical_fork(const std::string& dataDir,
                                const std::unordered_map<MerkleTreeId, uint64_t>& dbSize,
                                const std::vector<PublicDataLeafValue>& prefilled_public_data,
+                               const std::vector<bb::fr>& prefilled_nullifiers,
                                uint64_t maxReaders,
                                bool ephemeral);
 

--- a/barretenberg/cpp/src/barretenberg/world_state/world_state.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/world_state/world_state.test.cpp
@@ -211,6 +211,57 @@ TEST_F(WorldStateTest, GetInitialTreeInfoForAllTrees)
     }
 }
 
+TEST_F(WorldStateTest, GetInitialTreeInfoWithPrefilledNullifiers)
+{
+    // Prefilled nullifier leaves must be unique and strictly increasing, and larger than the padding leaves that fill
+    // the initial 128-leaf prefill region (whose keys are the low integers 0..127), so we use full-size field values.
+    std::vector<bb::fr> prefilled_nullifiers = {
+        bb::fr("0x073b5e41abe9d7f8466bca9c81c9572b558f953bbd70081317f6a80ac65f3dd5"),
+        bb::fr("0x0d99507b7ecac720c73bf197a0e7366a5ed80c1c1b0afe8ff8c6ecc7b5a7aefe"),
+        bb::fr("0x1c0bf82e0c51834780e61ef091b17e3a1d39ae891db7a70bfdb5221f134996ac"),
+    };
+
+    std::string data_dir_prefilled = random_temp_directory();
+    std::filesystem::create_directories(data_dir_prefilled);
+
+    WorldState ws_prefilled(thread_pool_size,
+                            data_dir_prefilled,
+                            map_size,
+                            tree_heights,
+                            tree_prefill,
+                            std::vector<PublicDataLeafValue>(),
+                            prefilled_nullifiers,
+                            initial_header_generator_point);
+
+    // Baseline world state with no prefilled nullifiers (the canonical empty genesis).
+    WorldState ws(thread_pool_size, data_dir, map_size, tree_heights, tree_prefill, initial_header_generator_point);
+
+    auto prefilled = ws_prefilled.get_tree_info(WorldStateRevision::committed(), MerkleTreeId::NULLIFIER_TREE);
+    auto info = ws.get_tree_info(WorldStateRevision::committed(), MerkleTreeId::NULLIFIER_TREE);
+
+    // The prefilled nullifiers occupy the last slots of the 128-leaf initial prefill region (they replace padding
+    // leaves rather than being appended), so the tree size stays 128 for both.
+    EXPECT_EQ(prefilled.meta.size, 128);
+    EXPECT_EQ(info.meta.size, 128);
+
+    // Seeding the nullifiers changes the nullifier-tree root away from the empty-genesis baseline.
+    EXPECT_NE(prefilled.meta.root, info.meta.root);
+    // The empty-genesis baseline root is unchanged from the canonical value, confirming that a default (empty)
+    // prefilled-nullifiers list leaves the genesis nullifier-tree root bit-identical to today.
+    EXPECT_EQ(info.meta.root, bb::fr("0x18935581a8ed73d08ffd00386fba55ba6c89f3ab848a76b8fedfa9034cee0454"));
+
+    // The seeded nullifiers are present in the tree.
+    for (const auto& nullifier : prefilled_nullifiers) {
+        assert_leaf_exists<NullifierLeafValue>(ws_prefilled,
+                                               WorldStateRevision::committed(),
+                                               MerkleTreeId::NULLIFIER_TREE,
+                                               NullifierLeafValue(nullifier),
+                                               true);
+    }
+
+    std::filesystem::remove_all(data_dir_prefilled);
+}
+
 TEST_F(WorldStateTest, GetInitialTreeInfoWithPrefilledPublicData)
 {
     std::string data_dir_prefilled = random_temp_directory();
@@ -225,6 +276,7 @@ TEST_F(WorldStateTest, GetInitialTreeInfoWithPrefilledPublicData)
                             tree_heights,
                             tree_prefill,
                             prefilled_values,
+                            std::vector<bb::fr>(),
                             initial_header_generator_point);
 
     WorldState ws(thread_pool_size, data_dir, map_size, tree_heights, tree_prefill, initial_header_generator_point);

--- a/barretenberg/cpp/src/barretenberg/wsdb/cli.cpp
+++ b/barretenberg/cpp/src/barretenberg/wsdb/cli.cpp
@@ -83,6 +83,11 @@ int parse_and_run_wsdb(int argc, char* argv[])
     msgpack_run_command->add_option(
         "--prefilled-public-data", prefilled_public_data_json, "Prefilled public data as JSON array");
 
+    // Prefilled nullifiers as JSON array of nullifier_hex strings
+    std::string prefilled_nullifiers_json;
+    msgpack_run_command->add_option(
+        "--prefilled-nullifiers", prefilled_nullifiers_json, "Prefilled genesis nullifiers as JSON array");
+
     uint64_t genesis_timestamp = 0;
     msgpack_run_command->add_option("--genesis-timestamp", genesis_timestamp, "Genesis block timestamp (default: 0)");
 
@@ -121,6 +126,7 @@ int parse_and_run_wsdb(int argc, char* argv[])
                                        threads,
                                        initial_header_generator_point,
                                        prefilled_public_data_json,
+                                       prefilled_nullifiers_json,
                                        genesis_timestamp,
                                        request_ring_size,
                                        response_ring_size);

--- a/barretenberg/cpp/src/barretenberg/wsdb/wsdb_ipc_server.cpp
+++ b/barretenberg/cpp/src/barretenberg/wsdb/wsdb_ipc_server.cpp
@@ -169,6 +169,34 @@ static std::vector<PublicDataLeafValue> parse_prefilled_public_data(const std::s
 }
 
 // ---------------------------------------------------------------------------
+// Parse prefilled nullifiers from JSON: ["nullifier_hex",...]
+// Each hex string is a 64-char (32-byte) hex-encoded field element.
+// ---------------------------------------------------------------------------
+
+static std::vector<fr> parse_prefilled_nullifiers(const std::string& json)
+{
+    std::vector<fr> result;
+    if (json.empty() || json == "[]") {
+        return result;
+    }
+
+    std::string current;
+    bool in_string = false;
+
+    for (char c : json) {
+        if (c == '"') {
+            in_string = !in_string;
+        } else if (in_string) {
+            current += c;
+        } else if ((c == ',' || c == ']') && !current.empty()) {
+            result.push_back(hex_to_fr(current));
+            current.clear();
+        }
+    }
+    return result;
+}
+
+// ---------------------------------------------------------------------------
 // IPC server execution
 // ---------------------------------------------------------------------------
 
@@ -180,6 +208,7 @@ int execute_wsdb_server(const std::string& input_path,
                         uint32_t threads,
                         uint32_t initial_header_generator_point,
                         const std::string& prefilled_public_data_json,
+                        const std::string& prefilled_nullifiers_json,
                         uint64_t genesis_timestamp,
                         size_t request_ring_size,
                         size_t response_ring_size)
@@ -211,6 +240,14 @@ int execute_wsdb_server(const std::string& input_path,
         std::cerr << "Parsed " << prefilled_public_data.size() << " prefilled public data entries" << '\n';
     }
 
+    // Parse prefilled nullifiers: JSON array of "nullifier_hex" strings. The caller (TS world-state) passes the same
+    // canonical genesis nullifiers it seeds via the napi path, so the IPC genesis nullifier-tree root matches.
+    std::vector<bb::fr> prefilled_nullifiers;
+    if (!prefilled_nullifiers_json.empty()) {
+        prefilled_nullifiers = parse_prefilled_nullifiers(prefilled_nullifiers_json);
+        std::cerr << "Parsed " << prefilled_nullifiers.size() << " prefilled nullifiers" << '\n';
+    }
+
     // Create WorldState
     std::cerr << "Creating WorldState at " << data_dir << " with " << threads << " threads" << '\n';
     auto ws = std::make_unique<WorldState>(threads,
@@ -219,6 +256,7 @@ int execute_wsdb_server(const std::string& input_path,
                                            tree_height,
                                            tree_prefill,
                                            prefilled_public_data,
+                                           prefilled_nullifiers,
                                            initial_header_generator_point,
                                            genesis_timestamp);
 

--- a/barretenberg/cpp/src/barretenberg/wsdb/wsdb_ipc_server.hpp
+++ b/barretenberg/cpp/src/barretenberg/wsdb/wsdb_ipc_server.hpp
@@ -20,6 +20,7 @@ int execute_wsdb_server(const std::string& input_path,
                         uint32_t threads,
                         uint32_t initial_header_generator_point,
                         const std::string& prefilled_public_data_json,
+                        const std::string& prefilled_nullifiers_json,
                         uint64_t genesis_timestamp,
                         size_t request_ring_size,
                         size_t response_ring_size);

--- a/yarn-project/stdlib/src/world-state/genesis_data.ts
+++ b/yarn-project/stdlib/src/world-state/genesis_data.ts
@@ -1,9 +1,18 @@
+import type { Fr } from '@aztec/foundation/curves/bn254';
+
 import type { PublicDataTreeLeaf } from '../trees/index.js';
 
 /** Data used to initialize the genesis block, including prefilled public state and an optional timestamp. */
 export type GenesisData = {
   /** Public data tree leaves to pre-populate in the genesis state (e.g. fee juice balances). */
   prefilledPublicData: PublicDataTreeLeaf[];
+  /**
+   * Nullifiers to pre-insert into the genesis nullifier tree. Optional; defaults to an empty list, which leaves the
+   * nullifier tree at its canonical empty-genesis state so that production genesis roots are unchanged. When non-empty,
+   * the leaves must be unique and strictly increasing in field value (the native world state enforces this before
+   * construction). Test networks pass a non-empty list to seed e.g. standard-contract registration nullifiers.
+   */
+  prefilledNullifiers?: Fr[];
   /** Timestamp for the genesis block header. Defaults to 0 (canonical empty genesis) in production. */
   genesisTimestamp: bigint;
 };
@@ -11,6 +20,7 @@ export type GenesisData = {
 /** An empty genesis data with no prefilled state and a zero timestamp. */
 export const EMPTY_GENESIS_DATA: GenesisData = {
   prefilledPublicData: [],
+  prefilledNullifiers: [],
   genesisTimestamp: 0n,
 };
 

--- a/yarn-project/world-state/src/native/native_world_state_instance.ts
+++ b/yarn-project/world-state/src/native/native_world_state_instance.ts
@@ -71,6 +71,18 @@ export class NativeWorldState implements NativeWorldStateInstance {
       d.slot.toBuffer(),
       d.value.toBuffer(),
     ]);
+    // Nullifiers to pre-insert into the genesis nullifier tree (empty by default, so production genesis roots are
+    // unchanged). The native indexed nullifier tree requires its prefilled leaves to be unique and strictly
+    // increasing, so we enforce that here before handing them over rather than failing deep inside the C++ tree
+    // construction.
+    const prefilledNullifiers = genesis.prefilledNullifiers ?? [];
+    for (let i = 1; i < prefilledNullifiers.length; i++) {
+      assert(
+        prefilledNullifiers[i].toBigInt() > prefilledNullifiers[i - 1].toBigInt(),
+        'Prefilled genesis nullifiers must be unique and strictly increasing',
+      );
+    }
+    const prefilledNullifiersBufferArray = prefilledNullifiers.map(n => n.toBuffer());
     const ws = new BaseNativeWorldState(
       dataDir,
       {
@@ -85,6 +97,7 @@ export class NativeWorldState implements NativeWorldStateInstance {
         [MerkleTreeId.PUBLIC_DATA_TREE]: 2 * MAX_TOTAL_PUBLIC_DATA_UPDATE_REQUESTS_PER_TX,
       },
       prefilledPublicDataBufferArray,
+      prefilledNullifiersBufferArray,
       DomainSeparator.BLOCK_HEADER_HASH,
       Number(genesis.genesisTimestamp),
       {

--- a/yarn-project/world-state/src/testing.test.ts
+++ b/yarn-project/world-state/src/testing.test.ts
@@ -1,12 +1,17 @@
+import { GENESIS_ARCHIVE_ROOT } from '@aztec/constants';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { MerkleTreeId, PublicDataTreeLeaf } from '@aztec/stdlib/trees';
-import type { GenesisData } from '@aztec/stdlib/world-state';
+import { EMPTY_GENESIS_DATA, type GenesisData } from '@aztec/stdlib/world-state';
 
 import { jest } from '@jest/globals';
 
 import { NativeWorldStateService } from './native/index.js';
+import { getGenesisValues } from './testing.js';
 
 jest.setTimeout(60_000);
+
+const archiveRoot = async (ws: NativeWorldStateService) =>
+  new Fr((await ws.getCommitted().getTreeInfo(MerkleTreeId.ARCHIVE)).root);
 
 describe('generateGenesisValues world state backend equivalence', () => {
   // A genesis with both non-empty prefilled public data and a non-zero timestamp, so the
@@ -19,9 +24,6 @@ describe('generateGenesisValues world state backend equivalence', () => {
     ],
     genesisTimestamp: 1234567890n,
   };
-
-  const archiveRoot = async (ws: NativeWorldStateService) =>
-    new Fr((await ws.getCommitted().getTreeInfo(MerkleTreeId.ARCHIVE)).root);
 
   // The consensus-critical guarantee behind computing genesis values on the fsync-off ephemeral
   // backend instead of tmp: both backends must derive the exact same on-chain genesis archive root.
@@ -36,5 +38,98 @@ describe('generateGenesisValues world state backend equivalence', () => {
       await tmpWs.close();
       await ephemeralWs.close();
     }
+  });
+});
+
+describe('genesis prefilled nullifiers', () => {
+  // (a) With no public data, no timestamp and no prefilled nullifiers, generateGenesisValues takes its fast path and
+  // returns the pinned GENESIS_ARCHIVE_ROOT constant without spinning up a world state.
+  it('empty genesis returns the canonical GENESIS_ARCHIVE_ROOT via the fast path', async () => {
+    const { genesisArchiveRoot } = await getGenesisValues([]);
+    expect(genesisArchiveRoot).toEqual(new Fr(GENESIS_ARCHIVE_ROOT));
+  });
+
+  // (a) The fast-path constant must equal the root actually computed from an empty-nullifier genesis, i.e. the
+  // GENESIS_ARCHIVE_ROOT constant is correct for the default (empty) prefilled-nullifiers list on this branch.
+  it('the empty-genesis archive root matches a freshly computed empty world state', async () => {
+    const ws = await NativeWorldStateService.ephemeral(EMPTY_GENESIS_DATA);
+    try {
+      expect(await archiveRoot(ws)).toEqual(new Fr(GENESIS_ARCHIVE_ROOT));
+    } finally {
+      await ws.close();
+    }
+  });
+
+  // (b) An explicit empty prefilled-nullifiers list must be behaviour-neutral: threading it through the non-fast path
+  // (public data present) yields exactly the same root as a genesis that omits the field entirely.
+  it('an explicit empty prefilledNullifiers produces the same root as omitting the field', async () => {
+    const publicData = [new PublicDataTreeLeaf(new Fr(1000), new Fr(2000))];
+    const withoutField: GenesisData = { prefilledPublicData: publicData, genesisTimestamp: 42n };
+    const withEmpty: GenesisData = { prefilledPublicData: publicData, genesisTimestamp: 42n, prefilledNullifiers: [] };
+    const wsWithout = await NativeWorldStateService.ephemeral(withoutField);
+    const wsEmpty = await NativeWorldStateService.ephemeral(withEmpty);
+    try {
+      expect(await archiveRoot(wsEmpty)).toEqual(await archiveRoot(wsWithout));
+    } finally {
+      await wsWithout.close();
+      await wsEmpty.close();
+    }
+  });
+
+  // (c) A non-empty, sorted, unique nullifier list produces a deterministic root that differs from the empty genesis.
+  it('a non-empty prefilledNullifiers list yields a deterministic root that differs from the empty genesis', async () => {
+    // Values must exceed the padding leaves that fill the initial prefill region and be strictly increasing.
+    const nullifiers = [new Fr(1000n), new Fr(2000n), new Fr(3000n)];
+    const genesisWith: GenesisData = { prefilledPublicData: [], genesisTimestamp: 0n, prefilledNullifiers: nullifiers };
+    const genesisEmpty: GenesisData = { prefilledPublicData: [], genesisTimestamp: 0n, prefilledNullifiers: [] };
+    const wsWith1 = await NativeWorldStateService.ephemeral(genesisWith);
+    const wsWith2 = await NativeWorldStateService.ephemeral(genesisWith);
+    const wsEmpty = await NativeWorldStateService.ephemeral(genesisEmpty);
+    try {
+      const rootWith1 = await archiveRoot(wsWith1);
+      const rootWith2 = await archiveRoot(wsWith2);
+      const rootEmpty = await archiveRoot(wsEmpty);
+      expect(rootWith1).toEqual(rootWith2);
+      expect(rootWith1).not.toEqual(rootEmpty);
+    } finally {
+      await wsWith1.close();
+      await wsWith2.close();
+      await wsEmpty.close();
+    }
+  });
+
+  // (c) getGenesisValues sorts an unsorted list ascending and produces a genesis whose root matches direct construction.
+  it('getGenesisValues sorts prefilled nullifiers and seeds them into the genesis', async () => {
+    const unsorted = [new Fr(3000n), new Fr(1000n), new Fr(2000n)];
+    const { genesis, genesisArchiveRoot } = await getGenesisValues([], undefined, [], 0n, unsorted);
+    expect(genesis.prefilledNullifiers).toEqual([new Fr(1000n), new Fr(2000n), new Fr(3000n)]);
+    const ws = await NativeWorldStateService.ephemeral(genesis);
+    try {
+      expect(await archiveRoot(ws)).toEqual(genesisArchiveRoot);
+    } finally {
+      await ws.close();
+    }
+  });
+
+  // (d) The defensive TS-side check rejects prefilled nullifiers that are not unique and strictly increasing before
+  // handing them to the native tree.
+  it('rejects prefilled nullifiers that are not strictly increasing', async () => {
+    const descending: GenesisData = {
+      prefilledPublicData: [],
+      genesisTimestamp: 0n,
+      prefilledNullifiers: [new Fr(3000n), new Fr(1000n)],
+    };
+    await expect(NativeWorldStateService.ephemeral(descending)).rejects.toThrow(
+      'Prefilled genesis nullifiers must be unique and strictly increasing',
+    );
+
+    const duplicate: GenesisData = {
+      prefilledPublicData: [],
+      genesisTimestamp: 0n,
+      prefilledNullifiers: [new Fr(1000n), new Fr(1000n)],
+    };
+    await expect(NativeWorldStateService.ephemeral(duplicate)).rejects.toThrow(
+      'Prefilled genesis nullifiers must be unique and strictly increasing',
+    );
   });
 });

--- a/yarn-project/world-state/src/testing.ts
+++ b/yarn-project/world-state/src/testing.ts
@@ -8,16 +8,18 @@ import type { GenesisData } from '@aztec/stdlib/world-state';
 import { NativeWorldStateService } from './native/index.js';
 
 async function generateGenesisValues(genesis: GenesisData) {
-  if (!genesis.prefilledPublicData.length && genesis.genesisTimestamp === 0n) {
+  // The GENESIS_ARCHIVE_ROOT constant reflects the canonical empty genesis (no public data, no prefilled nullifiers,
+  // timestamp 0), so we can only short-circuit when this genesis adds none of those on top.
+  if (!genesis.prefilledPublicData.length && genesis.genesisTimestamp === 0n && !genesis.prefilledNullifiers?.length) {
     return {
       genesisArchiveRoot: new Fr(GENESIS_ARCHIVE_ROOT),
     };
   }
 
-  // Compute the genesis values on a throwaway world state. The archive root derives only from the
-  // prefilled public data and the genesis timestamp, so the fsync-off ephemeral store (no version
-  // manager, no crash-recoverability) produces an identical root while skipping the fsync overhead
-  // that `tmp` pays. close() removes the tmpdir.
+  // Compute the genesis values on a throwaway world state. The archive root derives deterministically from the
+  // prefilled public data, the prefilled nullifiers, and the genesis timestamp, so the fsync-off ephemeral store (no
+  // version manager, no crash-recoverability) produces an identical root while skipping the fsync overhead that `tmp`
+  // pays. close() removes the tmpdir.
   const ws = await NativeWorldStateService.ephemeral(genesis);
   const genesisArchiveRoot = new Fr((await ws.getCommitted().getTreeInfo(MerkleTreeId.ARCHIVE)).root);
   await ws.close();
@@ -34,6 +36,7 @@ export async function getGenesisValues(
   initialAccountFeeJuice = defaultInitialAccountFeeJuice,
   genesisPublicData: PublicDataTreeLeaf[] = [],
   genesisTimestamp: bigint = 0n,
+  prefilledNullifiers: Fr[] = [],
 ) {
   // Top up the accounts with fee juice.
   let prefilledPublicData = await Promise.all(
@@ -47,7 +50,11 @@ export async function getGenesisValues(
 
   prefilledPublicData.sort((a, b) => (b.slot.lt(a.slot) ? 1 : -1));
 
-  const genesis: GenesisData = { prefilledPublicData, genesisTimestamp };
+  // The indexed nullifier tree requires its prefilled leaves to be unique and strictly increasing, so sort ascending
+  // here (a copy, to avoid mutating the caller's array) rather than relying on the caller's ordering.
+  const sortedNullifiers = [...prefilledNullifiers].sort((a, b) => (a.toBigInt() < b.toBigInt() ? -1 : 1));
+
+  const genesis: GenesisData = { prefilledPublicData, prefilledNullifiers: sortedNullifiers, genesisTimestamp };
   const { genesisArchiveRoot } = await generateGenesisValues(genesis);
 
   return {


### PR DESCRIPTION
## What

Adds opt-in plumbing to seed nullifier leaves into the genesis nullifier tree, threaded through the C++ world state and the TypeScript world-state layer. The field is optional and defaults to empty, so **production genesis is unchanged** — every existing genesis root stays bit-identical to today.

- **C++**: `WorldState` constructors, the napi binding, `create_canonical_fork`, and the standalone `aztec-wsdb` IPC server gain a `prefilled_nullifiers` input, inserted as the nullifier tree's initial leaves. The indexed nullifier tree requires those leaves to be unique and strictly increasing (and distinct from the padding leaves), which the tree already enforces; the TS side additionally checks it before the native call for a friendlier error.
- **TS**: `GenesisData.prefilledNullifiers` (optional, defaults to `[]`) threads through `native_world_state_instance.ts`. `getGenesisValues` gains an optional `prefilledNullifiers` param (sorted ascending on the way in), and the `GENESIS_ARCHIVE_ROOT` fast-path in `generateGenesisValues` now also checks the nullifier list is empty, so the short-circuit only fires for the canonical empty genesis.

## Why

Mechanism for round-4 e2e speedup PR 1b, which will seed the standard-contract (AuthRegistry / PublicChecks / HandshakeRegistry) registration nullifiers at genesis in the e2e fixtures so their publish txs short-circuit. This PR carries no consumers and is intentionally behavior- and timing-neutral: with the field empty (the only value ever passed in production), the native tree, all genesis roots, and the archive root are identical to before.

## Relationship to #24254

This is a deliberate subset port of #24254 ("seed protocol contract registration nullifiers at genesis"), kept shape- and signature-identical wherever it does not diverge, so that when #24254 itself reaches the v5 line the mechanism merges as "already applied". The intentional divergences:

- `prefilledNullifiers` is **optional and defaults to empty** here (#24254 made it required and non-empty by default via `DEFAULT_GENESIS_DATA`).
- This PR does **not** port `DEFAULT_GENESIS_DATA`, the protocol-contract nullifier generation (`protocol-contracts/src/genesis_data.ts`, `scripts/generate_data.ts`), or **any** constant recomputation (`GENESIS_ARCHIVE_ROOT`, `constants.nr`, `constants.gen.ts`, `ConstantsGen.sol`, `aztec_constants.hpp`, checkpoint / AVM golden fixtures). With the field empty, every genesis root is unchanged, which is the invariant CI must prove.

## Testing (local)

- C++ `world_state_tests`: `GetInitialTreeInfoForAllTrees` (unchanged — still asserts the current empty-nullifier root `0x18935581…` and `GENESIS_ARCHIVE_ROOT`, proving empty-field behavior is bit-identical), `GetInitialTreeInfoWithPrefilledPublicData` (updated to pass an empty nullifier vector), and a new `GetInitialTreeInfoWithPrefilledNullifiers` (seeding changes the root, tree size stays 128, seeded leaves are present) — 3/3 pass.
- `@aztec/world-state` `testing.test.ts` (7/7): empty genesis returns `GENESIS_ARCHIVE_ROOT` via the fast path; the empty-genesis computed root matches that constant; an explicit empty `prefilledNullifiers` yields the same root as omitting the field; a non-empty sorted list yields a deterministic root that differs from empty; `getGenesisValues` sorts and seeds; and non-strictly-increasing (descending / duplicate) lists are rejected by the defensive check.
- Regression: `@aztec/world-state` `native_world_state.test.ts` (53/53), `@aztec/stdlib` `l2_block.test.ts` (3/3, confirms the genesis nullifier root is unchanged), `@aztec/prover-client` `lightweight_checkpoint_builder.test.ts` (7/7).
- Full `yarn build`, plus `yarn format`/`yarn lint` on the touched packages, are clean.

## Notes

This PR is intentionally behavior- and timing-neutral; no e2e behavior changes until PR 1b adopts the mechanism.

## Measured impact

None expected, and none observed. `prefilledNullifiers` defaults to `[]`, so the production genesis
payload and roots are bit-identical (asserted by the unchanged C++ empty-nullifier root and
`GENESIS_ARCHIVE_ROOT` tests); no fixture opts into a non-empty list in this PR.

CI timings confirm neutrality: per-suite beforeHooks deltas scatter in both directions within the
per-suite noise floor — largest were runtime_config −12.8s, token_bridge −12.7s, account_init +11.5s,
failures +11.0s — with the fees suites essentially flat (private_payments −3.4s, gas_estimation
−0.2s) and no systematic direction. The summed beforeHooks delta over all 276 suites present in both
runs is −122.8s (~−2%), well inside accumulated run-to-run variance.

Baseline CI run 1783374468714213 (merge-base e1711d3efa, full). PR CI run 1783389062016888 (x-fast).



Part of A-1404
