### PR TITLE
perf(bot): parallelize independent bot factory setup steps

### DIFF
--- a/yarn-project/bot/src/factory.test.ts
+++ b/yarn-project/bot/src/factory.test.ts
@@ -1,0 +1,87 @@
+import { promiseWithResolvers } from '@aztec/foundation/promise';
+import type { AztecNode, AztecNodeAdmin, AztecNodeAdminConfig } from '@aztec/stdlib/interfaces/client';
+import type { EmbeddedWallet } from '@aztec/wallets/embedded';
+
+import { mock } from 'jest-mock-extended';
+
+import { type BotConfig, getBotDefaultConfig } from './config.js';
+import { BotFactory } from './factory.js';
+import type { BotStore } from './store/index.js';
+
+class TestBotFactory extends BotFactory {
+  public override withNoMinTxsPerBlock<T>(fn: () => Promise<T>): Promise<T> {
+    return super.withNoMinTxsPerBlock(fn);
+  }
+}
+
+describe('BotFactory.withNoMinTxsPerBlock', () => {
+  let minTxsPerBlock: number | undefined;
+  let setConfigCalls: (number | undefined)[];
+  let factory: TestBotFactory;
+
+  beforeEach(() => {
+    minTxsPerBlock = 3;
+    setConfigCalls = [];
+
+    const aztecNodeAdmin = mock<AztecNodeAdmin>();
+    aztecNodeAdmin.getConfig.mockImplementation(() => Promise.resolve({ minTxsPerBlock } as AztecNodeAdminConfig));
+    aztecNodeAdmin.setConfig.mockImplementation(config => {
+      setConfigCalls.push(config.minTxsPerBlock);
+      minTxsPerBlock = config.minTxsPerBlock;
+      return Promise.resolve();
+    });
+
+    const config: BotConfig = { ...getBotDefaultConfig(), flushSetupTransactions: true };
+    const wallet = mock<EmbeddedWallet>();
+    factory = new TestBotFactory(config, wallet, mock<BotStore>(), mock<AztecNode>(), aztecNodeAdmin);
+  });
+
+  it('zeroes minTxsPerBlock around a call and restores it after', async () => {
+    await factory.withNoMinTxsPerBlock(() => {
+      expect(minTxsPerBlock).toBe(0);
+      return Promise.resolve();
+    });
+
+    expect(setConfigCalls).toEqual([0, 3]);
+    expect(minTxsPerBlock).toBe(3);
+  });
+
+  it('zeroes once and restores once across overlapping calls', async () => {
+    const gates = [promiseWithResolvers<void>(), promiseWithResolvers<void>(), promiseWithResolvers<void>()];
+    const calls = gates.map(gate => factory.withNoMinTxsPerBlock(() => gate.promise));
+
+    gates[0].resolve();
+    await calls[0];
+    expect(minTxsPerBlock).toBe(0);
+
+    gates[1].resolve();
+    await calls[1];
+    expect(minTxsPerBlock).toBe(0);
+
+    gates[2].resolve();
+    await calls[2];
+    expect(setConfigCalls).toEqual([0, 3]);
+    expect(minTxsPerBlock).toBe(3);
+  });
+
+  it('restores minTxsPerBlock when the wrapped call fails', async () => {
+    await expect(factory.withNoMinTxsPerBlock(() => Promise.reject(new Error('boom')))).rejects.toThrow('boom');
+
+    expect(setConfigCalls).toEqual([0, 3]);
+    expect(minTxsPerBlock).toBe(3);
+  });
+
+  it('restores minTxsPerBlock when one of several overlapping calls fails', async () => {
+    const gate = promiseWithResolvers<void>();
+    const failing = factory.withNoMinTxsPerBlock(() => Promise.reject(new Error('boom')));
+    const succeeding = factory.withNoMinTxsPerBlock(() => gate.promise);
+
+    await expect(failing).rejects.toThrow('boom');
+    expect(minTxsPerBlock).toBe(0);
+
+    gate.resolve();
+    await succeeding;
+    expect(setConfigCalls).toEqual([0, 3]);
+    expect(minTxsPerBlock).toBe(3);
+  });
+});

--- a/yarn-project/bot/src/factory.ts
+++ b/yarn-project/bot/src/factory.ts
@@ -45,6 +45,11 @@ const FEE_JUICE_TOP_UP_THRESHOLD = 100n * 10n ** 18n;
 export class BotFactory {
   private log = createLogger('bot');
 
+  /** Number of in-flight withNoMinTxsPerBlock calls; see that method for why they are counted. */
+  private noMinTxsPerBlockDepth = 0;
+  /** Set by the first withNoMinTxsPerBlock entrant; resolves to the minTxsPerBlock value to restore. */
+  private savedMinTxsPerBlock?: Promise<{ minTxsPerBlock?: number }>;
+
   constructor(
     private readonly config: BotConfig,
     private readonly wallet: EmbeddedWallet,
@@ -88,23 +93,35 @@ export class BotFactory {
   }> {
     const defaultAccountAddress = await this.setupAccount();
     await this.ensureFeeJuiceBalance(defaultAccountAddress);
-    const token0 = await this.setupTokenContract(defaultAccountAddress, this.config.tokenSalt, 'BotToken0', 'BOT0');
-    const token1 = await this.setupTokenContract(defaultAccountAddress, this.config.tokenSalt, 'BotToken1', 'BOT1');
-    const liquidityToken = await this.setupTokenContract(
-      defaultAccountAddress,
-      this.config.tokenSalt,
-      'BotLPToken',
-      'BOTLP',
-    );
-    const amm = await this.setupAmmContract(
-      defaultAccountAddress,
-      this.config.tokenSalt,
-      token0,
-      token1,
-      liquidityToken,
-    );
 
-    await this.fundAmm(defaultAccountAddress, defaultAccountAddress, amm, token0, token1, liquidityToken);
+    const salt = this.config.tokenSalt;
+
+    // token0, token1 and the LP token are independent contracts with no shared state, so deploy them
+    // concurrently rather than one slot at a time.
+    const [token0, token1, liquidityToken] = await Promise.all([
+      this.setupTokenContract(defaultAccountAddress, salt, 'BotToken0', 'BOT0'),
+      this.setupTokenContract(defaultAccountAddress, salt, 'BotToken1', 'BOT1'),
+      this.setupTokenContract(defaultAccountAddress, salt, 'BotLPToken', 'BOTLP'),
+    ]);
+
+    const ammDeploy = AMMContract.deploy(this.wallet, token0.address, token1.address, liquidityToken.address, {
+      salt,
+      universalDeploy: true,
+    });
+    const ammAddress = (await ammDeploy.getInstance()).address;
+
+    // The AMM constructor only stores the (already-derived) token addresses, and set_minter only records
+    // the AMM address on the LP token: neither reads the other's on-chain state, so the AMM deploy, the
+    // LP-minter grant, and the token0/token1 mints are mutually independent and run concurrently.
+    const [amm] = await Promise.all([
+      this.deployAmmContract(defaultAccountAddress, ammDeploy),
+      this.grantLpTokenMinter(defaultAccountAddress, liquidityToken, ammAddress),
+      this.mintAmmLiquidity(defaultAccountAddress, token0, token1),
+    ]);
+
+    // add_liquidity spends the minted token0/token1 balances and mints LP tokens, so it must follow both
+    // the mints and the minter grant, and target the deployed AMM.
+    await this.addAmmLiquidity(defaultAccountAddress, defaultAccountAddress, amm, token0, token1, liquidityToken);
     this.log.info(`AMM initialized and funded`);
 
     return { wallet: this.wallet, defaultAccountAddress, amm, token0, token1, node: this.aztecNode };
@@ -142,25 +159,32 @@ export class BotFactory {
     const rollupContract = new RollupContract(l1Client, l1ContractAddresses.rollupAddress.toString());
     const rollupVersion = await rollupContract.getVersion();
 
-    // Deploy TestContract (pays from the standing balance funded above).
-    const contract = await this.setupTestContract(defaultAccountAddress);
+    // Derive the TestContract address up front (deterministic from the salt). Seeding L1→L2 messages only
+    // needs the L2 recipient address — the messages are queued on L1 and don't require the L2 contract to
+    // exist yet (they're consumed later, after setup completes) — so the deploy (an L2 tx paying from the
+    // standing balance funded above) and the L1 seeding run concurrently.
+    const testContractDeploy = TestContract.deploy(this.wallet, {
+      salt: this.config.tokenSalt,
+      universalDeploy: true,
+    });
+    const contractAddress = (await testContractDeploy.getInstance()).address;
 
     // Recover any pending messages from store (clean up stale ones first)
     await this.store.cleanupOldPendingMessages();
     const pendingMessages = await this.store.getUnconsumedL1ToL2Messages();
 
-    // Seed initial L1→L2 messages if pipeline is empty
+    // Seed initial L1→L2 messages if pipeline is empty. The seeds are sent one at a time: they share the
+    // bot's L1 account, so concurrent sends would race on the L1 nonce.
     const seedCount = Math.max(0, this.config.l1ToL2SeedCount - pendingMessages.length);
-    for (let i = 0; i < seedCount; i++) {
-      await seedL1ToL2Message(
-        l1Client,
-        EthAddress.fromString(l1ContractAddresses.inboxAddress.toString()),
-        contract.address,
-        rollupVersion,
-        this.store,
-        this.log,
-      );
-    }
+    const inboxAddress = EthAddress.fromString(l1ContractAddresses.inboxAddress.toString());
+    const [contract] = await Promise.all([
+      this.deployTestContract(defaultAccountAddress, testContractDeploy),
+      (async () => {
+        for (let i = 0; i < seedCount; i++) {
+          await seedL1ToL2Message(l1Client, inboxAddress, contractAddress, rollupVersion, this.store, this.log);
+        }
+      })(),
+    ]);
 
     // Block until at least one message is ready
     const allMessages = await this.store.getUnconsumedL1ToL2Messages();
@@ -184,10 +208,8 @@ export class BotFactory {
     };
   }
 
-  private async setupTestContract(deployer: AztecAddress): Promise<TestContract> {
-    const deployOpts: DeployOptions = { from: deployer };
-    const deploy = TestContract.deploy(this.wallet, { salt: this.config.tokenSalt, universalDeploy: true });
-    const instance = await this.registerOrDeployContract('TestContract', deploy, deployOpts);
+  private async deployTestContract(deployer: AztecAddress, deploy: DeployMethod<TestContract>): Promise<TestContract> {
+    const instance = await this.registerOrDeployContract('TestContract', deploy, { from: deployer });
     return TestContract.at(instance.address, this.wallet);
   }
 
@@ -292,34 +314,37 @@ export class BotFactory {
     return TokenContract.at(instance.address, this.wallet);
   }
 
-  private async setupAmmContract(
-    deployer: AztecAddress,
-    salt: Fr,
-    token0: TokenContract,
-    token1: TokenContract,
-    lpToken: TokenContract,
-  ): Promise<AMMContract> {
-    const deployOpts: DeployOptions = { from: deployer };
-    const deploy = AMMContract.deploy(this.wallet, token0.address, token1.address, lpToken.address, {
-      salt,
-      universalDeploy: true,
-    });
-    const instance = await this.registerOrDeployContract('AMM', deploy, deployOpts);
+  private async deployAmmContract(deployer: AztecAddress, deploy: DeployMethod<AMMContract>): Promise<AMMContract> {
+    const instance = await this.registerOrDeployContract('AMM', deploy, { from: deployer });
     const amm = AMMContract.at(instance.address, this.wallet);
-
     this.log.info(`AMM deployed at ${amm.address}`);
-    const setMinterInteraction = lpToken.methods.set_minter(amm.address, true);
-    const { receipt: minterReceipt } = await setMinterInteraction.send({
-      from: deployer,
-      wait: { timeout: this.config.txMinedWaitSeconds },
-    });
-    this.log.info(`Set LP token minter to AMM txHash=${minterReceipt.txHash.toString()}`);
-    this.log.info(`Liquidity token initialized`);
-
     return amm;
   }
 
-  private async fundAmm(
+  /** Grants the AMM minting rights over the LP token. set_minter only records the address, so it does not
+   * require the AMM contract to be deployed first. */
+  private async grantLpTokenMinter(deployer: AztecAddress, lpToken: TokenContract, amm: AztecAddress): Promise<void> {
+    const { receipt } = await lpToken.methods.set_minter(amm, true).send({
+      from: deployer,
+      wait: { timeout: this.config.txMinedWaitSeconds },
+    });
+    this.log.info(`Set LP token minter to AMM txHash=${receipt.txHash.toString()}`);
+  }
+
+  private async mintAmmLiquidity(minter: AztecAddress, token0: TokenContract, token1: TokenContract): Promise<void> {
+    this.log.info(`Minting ${MINT_BALANCE} tokens of each BotToken0 and BotToken1 for ${minter}`);
+    const mintBatch = new BatchCall(this.wallet, [
+      token0.methods.mint_to_private(minter, MINT_BALANCE),
+      token1.methods.mint_to_private(minter, MINT_BALANCE),
+    ]);
+    const { receipt } = await mintBatch.send({
+      from: minter,
+      wait: { timeout: this.config.txMinedWaitSeconds },
+    });
+    this.log.info(`Sent mint tx: ${receipt.txHash.toString()}`);
+  }
+
+  private async addAmmLiquidity(
     defaultAccountAddress: AztecAddress,
     liquidityProvider: AztecAddress,
     amm: AMMContract,
@@ -327,22 +352,6 @@ export class BotFactory {
     token1: TokenContract,
     lpToken: TokenContract,
   ): Promise<void> {
-    const getPrivateBalances = () =>
-      Promise.all([
-        token0.methods
-          .balance_of_private(liquidityProvider)
-          .simulate({ from: liquidityProvider })
-          .then(r => r.result),
-        token1.methods
-          .balance_of_private(liquidityProvider)
-          .simulate({ from: liquidityProvider })
-          .then(r => r.result),
-        lpToken.methods
-          .balance_of_private(liquidityProvider)
-          .simulate({ from: liquidityProvider })
-          .then(r => r.result),
-      ]);
-
     const authwitNonce = Fr.random();
 
     // keep some tokens for swapping
@@ -350,12 +359,6 @@ export class BotFactory {
     const amount0Min = MINT_BALANCE / 4;
     const amount1Max = MINT_BALANCE / 2;
     const amount1Min = MINT_BALANCE / 4;
-
-    const [t0Bal, t1Bal, lpBal] = await getPrivateBalances();
-
-    this.log.info(
-      `Minting ${MINT_BALANCE} tokens of each BotToken0 and BotToken1. Current private balances of ${liquidityProvider}: token0=${t0Bal}, token1=${t1Bal}, lp=${lpBal}`,
-    );
 
     // Add authwitnesses for the transfers in AMM::add_liquidity function
     const token0Authwit = await this.wallet.createAuthWit(defaultAccountAddress, {
@@ -381,36 +384,33 @@ export class BotFactory {
         .getFunctionCall(),
     });
 
-    const mintBatch = new BatchCall(this.wallet, [
-      token0.methods.mint_to_private(liquidityProvider, MINT_BALANCE),
-      token1.methods.mint_to_private(liquidityProvider, MINT_BALANCE),
-    ]);
-    const { receipt: mintReceipt } = await mintBatch.send({
-      from: liquidityProvider,
-      wait: { timeout: this.config.txMinedWaitSeconds },
-    });
+    const { receipt } = await amm.methods
+      .add_liquidity(amount0Max, amount1Max, amount0Min, amount1Min, authwitNonce)
+      .send({
+        from: liquidityProvider,
+        authWitnesses: [token0Authwit, token1Authwit],
+        wait: { timeout: this.config.txMinedWaitSeconds },
+      });
 
-    this.log.info(`Sent mint tx: ${mintReceipt.txHash.toString()}`);
-
-    const addLiquidityInteraction = amm.methods.add_liquidity(
-      amount0Max,
-      amount1Max,
-      amount0Min,
-      amount1Min,
-      authwitNonce,
-    );
-    const { receipt: addLiquidityReceipt } = await addLiquidityInteraction.send({
-      from: liquidityProvider,
-      authWitnesses: [token0Authwit, token1Authwit],
-      wait: { timeout: this.config.txMinedWaitSeconds },
-    });
-
-    this.log.info(`Sent tx to add liquidity to the AMM: ${addLiquidityReceipt.txHash.toString()}`);
+    this.log.info(`Sent tx to add liquidity to the AMM: ${receipt.txHash.toString()}`);
     this.log.info(`Liquidity added`);
 
-    const [newT0Bal, newT1Bal, newLPBal] = await getPrivateBalances();
+    const [t0Bal, t1Bal, lpBal] = await Promise.all([
+      token0.methods
+        .balance_of_private(liquidityProvider)
+        .simulate({ from: liquidityProvider })
+        .then(r => r.result),
+      token1.methods
+        .balance_of_private(liquidityProvider)
+        .simulate({ from: liquidityProvider })
+        .then(r => r.result),
+      lpToken.methods
+        .balance_of_private(liquidityProvider)
+        .simulate({ from: liquidityProvider })
+        .then(r => r.result),
+    ]);
     this.log.info(
-      `Updated private balances of ${defaultAccountAddress} after minting and funding AMM: token0=${newT0Bal}, token1=${newT1Bal}, lp=${newLPBal}`,
+      `Updated private balances of ${defaultAccountAddress} after minting and funding AMM: token0=${t0Bal}, token1=${t1Bal}, lp=${lpBal}`,
     );
   }
 
@@ -593,19 +593,36 @@ export class BotFactory {
     return claim as L2AmountClaim;
   }
 
-  private async withNoMinTxsPerBlock<T>(fn: () => Promise<T>): Promise<T> {
+  protected async withNoMinTxsPerBlock<T>(fn: () => Promise<T>): Promise<T> {
     if (!this.aztecNodeAdmin || !this.config.flushSetupTransactions) {
       this.log.verbose(`No node admin client or flushing not requested (not setting minTxsPerBlock to 0)`);
       return fn();
     }
-    const { minTxsPerBlock } = await this.aztecNodeAdmin.getConfig();
-    this.log.warn(`Setting sequencer minTxsPerBlock to 0 from ${minTxsPerBlock} to flush setup transactions`);
-    await this.aztecNodeAdmin.setConfig({ minTxsPerBlock: 0 });
+    const aztecNodeAdmin = this.aztecNodeAdmin;
+    // Setup steps run concurrently, so this wrapper can be re-entered while another call is in flight.
+    // Reference-count the entrants: the first saves the current value and zeroes it, the last restores it.
+    // A naive save/zero/restore per call could interleave, with a late entrant reading the already-zeroed
+    // value and "restoring" 0 at the end.
+    if (this.noMinTxsPerBlockDepth++ === 0) {
+      this.savedMinTxsPerBlock = (async () => {
+        const { minTxsPerBlock } = await aztecNodeAdmin.getConfig();
+        this.log.warn(`Setting sequencer minTxsPerBlock to 0 from ${minTxsPerBlock} to flush setup transactions`);
+        await aztecNodeAdmin.setConfig({ minTxsPerBlock: 0 });
+        return { minTxsPerBlock };
+      })();
+    }
     try {
+      await this.savedMinTxsPerBlock;
       return await fn();
     } finally {
-      this.log.warn(`Restoring sequencer minTxsPerBlock to ${minTxsPerBlock}`);
-      await this.aztecNodeAdmin.setConfig({ minTxsPerBlock });
+      if (--this.noMinTxsPerBlockDepth === 0) {
+        // If saving/zeroing itself failed there is nothing to restore.
+        const saved = await this.savedMinTxsPerBlock!.catch(() => undefined);
+        if (saved) {
+          this.log.warn(`Restoring sequencer minTxsPerBlock to ${saved.minTxsPerBlock}`);
+          await aztecNodeAdmin.setConfig({ minTxsPerBlock: saved.minTxsPerBlock });
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
Parallelizes the independent setup steps in the bot factory (`@aztec/bot`, `bot/src/factory.ts`).
This is production bot code that runs against live networks, so the changes are strictly
behavior-preserving: same contracts at the same (salt-derived) addresses, same amounts, same final
state. Only the ordering/concurrency of provably-independent setup steps changes.

The bot factory is the single largest cost in the `single-node/bot` e2e suite: each `*.create` runs
the production sequencer at 12s L2 slots (`PIPELINING_SETUP_OPTS`) and deploys/mints one tx per slot,
fully serial. `AmmBot.create` alone was ~74s (7 serial txs).

## Dependency graph per bot type

Edges below are "must be mined before", verified against the Noir contract source
(`token_contract`, `amm_contract`).

### Transaction bot -- `setup()` (unchanged)

`setupAccount` -> register recipient -> `ensureFeeJuiceBalance` -> deploy token -> mint. This chain is
fully data-dependent: funding gates the deploy, the deploy gates the mint. The recipient
(`createSchnorrAccount`) is register-only (no tx), and the private+public mints are already batched
into one tx. Nothing is independent, so `setup()` is left serial.

### AMM bot -- `setupAmm()`

Steps: deploy token0 (D0), token1 (D1), LP token (DL), AMM (DA); `set_minter` granting the AMM rights
over the LP token (SM); mint token0+token1 to the provider (M, one batched tx); `add_liquidity` (AL).

- D0, D1, DL: independent -- distinct contracts, no cross-references.
- DA: the AMM constructor only stores the three token addresses (no calls into the tokens). Those
  addresses are salt-derived, so DA needs only the (pre-derived) addresses, not the token deploys mined.
- SM: `Token::set_minter` just writes `minters[amm] = true`; it does not call or validate the AMM
  contract. It needs the LP token deployed and the (derivable) AMM address only -- not the AMM deployed.
  The deployer is authorized because the Token constructor sets `minters[admin] = true`.
- M: `mint_to_private`/`mint_to_public` require the caller be a minter; the deployer is admin=minter
  from the constructor, so the token0/token1 mints need only those tokens deployed (no `set_minter`).
- AL: `add_liquidity` transfers token0/token1 from the provider (needs M for balances), mints LP
  tokens (needs SM so the AMM is an LP minter), and targets the AMM (needs DA).

Restructured from 7 serial txs into 3 slot-phases:

- Phase 1: `Promise.all([D0, D1, DL])`
- Phase 2: `Promise.all([DA, SM, M])`
- Phase 3: `AL`

### Cross-chain bot -- `setupCrossChain()`

Steps: deploy TestContract (an L2 tx), seed N L1->L2 messages (L1 txs), wait for the first message ready.

- The seeds reference only the L2 recipient (TestContract) address, which is salt-derived. L1->L2
  messages are queued on L1 and do not require the L2 contract to exist yet; they are consumed later in
  `bot.run()`, after setup completes. So the L2 deploy and the L1 seeding are independent.
- The L2 deploy pays via the L2 wallet/PXE account; the seeds use the bot's L1 client -- different
  accounts, so there is no L1 nonce interaction between them.

Restructured to overlap the deploy with the seed loop: `Promise.all([deploy TestContract, seed loop])`,
then the message-ready wait.

## What stayed serial, and why

- The whole transaction-bot `setup()` (data-dependent chain, nothing independent).
- `ensureFeeJuiceBalance` before every deploy (funding must precede spending).
- `add_liquidity` after its mints + minter grant + AMM deploy.
- The individual L1->L2 seeds inside the loop: they share the bot's single L1 account, so concurrent
  sends would race on the L1 nonce. The suite already documents this nonce hazard. Only the loop as a
  whole overlaps the (L2) TestContract deploy.

## Production safety / idempotent re-entry

- Every deploy still goes through `registerOrDeployContract`, which checks
  `getContractMetadata(address).isContractPublished` per contract and only registers (no tx) if already
  deployed. If one parallel deploy fails and the others succeed, the next `*.create` recovers: the
  succeeded contracts register-only, the failed one redeploys. Addresses are salt-derived and identical
  across runs.
- `set_minter` is idempotent (writes `true` again). The AMM path's mint and `add_liquidity` always run
  (no balance guard) -- unchanged from the previous `fundAmm`.
- Same-sender concurrent `.send()`s are safe by construction: the PXE serializes simulate/prove through
  its `SerialQueue` and setup txs pay with random tx nonces. The bot runs the same `EmbeddedWallet` ->
  PXE path in the e2e suite and in production.
- Deliberate, benign failure-path change: because Phase 2 runs DA/SM/M concurrently, a failure of one no
  longer prevents the others from being sent. Their effects (a deployed-but-unused AMM, a minter grant,
  an extra mint) are all idempotent-safe, and `add_liquidity` uses fixed amounts, so re-entry converges
  to the same final state.
- `withNoMinTxsPerBlock` (the `flushSetupTransactions` save/zero/restore wrapper around each setup tx)
  was not safe to re-enter concurrently: interleaved save/zero/restore could read the already-zeroed
  value and "restore" `minTxsPerBlock` to 0 permanently. It now reference-counts entrants -- the first
  saves and zeroes, the last restores -- with unit tests covering the overlapping and failure paths
  (`bot/src/factory.test.ts`). Serial callers see the exact same RPC sequence as before.

Final state is identical in every path: same contract addresses, same minter grant, same minted
amounts, same liquidity.

## Local evidence

Two full local runs of `single-node/bot/bot.test.ts` (production sequencer, 12s L2 slots), all 10
tests passing in both. Hook durations from factory log timestamps, against the round-4 local baseline
measured on the same machine at the same cadence (findings from #24534):

- `Bot.create` (transaction-bot hook, untouched): 31.8s vs 32.2s baseline -- unchanged, as intended.
- `AmmBot.create`: 57.2s vs 73.9s baseline (-16.7s). The three token deploy txs go out within 300ms of
  each other; the AMM deploy, `set_minter` and the mint batch all go out within the following slot.
- `CrossChainBot.create`: 24.0s vs 43.5s baseline (-19.5s). The TestContract deploy overlaps both L1
  seeds; the first message is ready almost immediately after the deploy is mined.
- Suite-level `beforeHooksMs`: 116.9s vs 153.7s baseline (-36.8s), matching the per-hook deltas.
- Unit: `bot/src/factory.test.ts` (4 tests) covering the `withNoMinTxsPerBlock` reentrancy fix.

## Expected effect on CI

- `AmmBot.create`: 7 serial txs -> 3 slot-phases (~87s on CI per #24534's spans -> ~55-60s).
- `CrossChainBot.create`: deploy overlaps the seed pipeline (~43s -> ~25s).
- Transaction bot: unchanged.
- Aggregate: roughly -35 to -45s on the bot suite's beforeAll wall time.
- Fix-phase proof metric (once #24534's `setup:bot` instrumentation is on this base): the amm-bot and
  cross-chain `setup:bot` occurrences drop per the numbers above. Measured CI numbers to be appended
  when a full run lands.


## Measured impact

The bot suite (a single shard) drops 216.3s → 118.3s total (**−98.0s, −45%**); beforeHooks 215.9s →
118.0s.

- No `setup:bot` spans exist on this base (that instrumentation lives in the unmerged #24534), so the
  metric is the suite-level hook fold, which covers all three nested bot factory setups (Bot, AmmBot,
  CrossChainBot).
- Noise context from the same run pair: untouched light suites move −2 to −3s per shard
  (private_initialization −2.9s/shard over 20 shards, deploy_method −2.1s/shard over 14), and the
  largest counter-move is validators_sentinel +24s (multi-node variance). A −98s single-shard delta is
  far outside that envelope.
- The CI delta exceeds the local −36.8s because the CI baseline pays more missed-slot penalties per
  serial tx (baseline beforeHooks 215.9s on CI vs 153.7s locally at the same 12s cadence); collapsing
  7 serial txs into 3 slot-phases removes proportionally more where slots are more often missed.

Baseline CI run 1783393028773172 (merge-base 30966a45, full). PR CI run 1783427250198215 (x-fast).


Fixes A-1408
