### PR TITLE
perf(e2e): batch same-sender setup txs into single txs

### DIFF
--- a/yarn-project/end-to-end/src/single-node/fees/fees_test.ts
+++ b/yarn-project/end-to-end/src/single-node/fees/fees_test.ts
@@ -1,4 +1,5 @@
 import type { AztecAddress } from '@aztec/aztec.js/addresses';
+import { BatchCall } from '@aztec/aztec.js/contracts';
 import { Fr } from '@aztec/aztec.js/fields';
 import { createLogger } from '@aztec/aztec.js/log';
 import type { AztecNode } from '@aztec/aztec.js/node';
@@ -401,16 +402,24 @@ export class FeesTest extends SingleNodeTestContext {
   public async applyFundAliceWithBananas() {
     this.logger.info('Applying fund Alice with bananas setup');
 
-    // The private and public mints touch disjoint balances, so they are sent concurrently to share a
-    // slot instead of paying one slot each.
-    await Promise.all([
-      this.mintPrivateBananas(this.ALICE_INITIAL_BANANAS, this.aliceAddress),
-      testSpan('tx:mint', () =>
-        this.bananaCoin.methods.mint_to_public(this.aliceAddress, this.ALICE_INITIAL_BANANAS).send({
-          from: this.aliceAddress,
-        }),
-      ),
-    ]);
+    // Both mints are alice sends on BananaCoin touching disjoint balances, so they ride a single
+    // BatchCall tx (one proof, one slot) rather than two concurrent txs. The PXE serializes proving,
+    // so two concurrent sends would still be proven back-to-back and land in consecutive slots.
+    const { result: privateBalanceBefore } = await this.bananaCoin.methods
+      .balance_of_private(this.aliceAddress)
+      .simulate({ from: this.aliceAddress });
+
+    await testSpan('tx:mint', () =>
+      new BatchCall(this.wallet, [
+        this.bananaCoin.methods.mint_to_private(this.aliceAddress, this.ALICE_INITIAL_BANANAS),
+        this.bananaCoin.methods.mint_to_public(this.aliceAddress, this.ALICE_INITIAL_BANANAS),
+      ]).send({ from: this.aliceAddress }),
+    );
+
+    const { result: privateBalanceAfter } = await this.bananaCoin.methods
+      .balance_of_private(this.aliceAddress)
+      .simulate({ from: this.aliceAddress });
+    expect(privateBalanceAfter).toEqual(privateBalanceBefore + this.ALICE_INITIAL_BANANAS);
   }
 
   public async applyFundAliceWithPrivateBananas() {


### PR DESCRIPTION
## Context

#24569 overlapped the fees harness's independent setup txs with `Promise.all`, but the fix-phase capture showed only ~1/3 of the projected gain (−162s). The overlap was real (`tx:mint` busy/total ≈ 0.68), yet concurrent txs still land in *consecutive* 12s slots: the PXE serializes `simulateTx`/`proveTx` on a single queue, so the second concurrent tx is only proven after the first and misses the first's slot. Overlapping cannot remove whole slots — only batching can.

This PR batches same-sender setup calls into a single `BatchCall` tx: one proof, one tx, one slot.

## What was batched

`FeesTest.applyFundAliceWithBananas` (`end-to-end/src/single-node/fees/fees_test.ts`) previously sent alice's private and public banana mints as two concurrent txs. Both are alice sends on `BananaCoin` touching disjoint balances, so they now ride one `BatchCall([mint_to_private, mint_to_public])` tx. The private-balance before/after assertion is preserved as the behavioral check; the public mint's effect is checked by the downstream tests that spend alice's public bananas. Precedent for the pattern already lives in this tree (`mintNotes` in `fixtures/token_utils.ts` batches multiple `mint_to_private` calls).

This touches the fees suites that fund alice in setup: `account_init`, `gas_estimation`, `private_payments`, and `fee_juice_payments`.

## Surveyed and skipped

- `applyFPCSetup`: a single `deploy:fpc` tx — no same-sender pair inside the phase. Folding the FPC deploy into the mint batch (one class publication + app calls is within the class-log limit) would remove the remaining consecutive slot, but it merges two harness phases that four test files compose differently via `Promise.all`, and deploy-inside-BatchCall is not a proven pattern here — a restructure, not a mechanical merge. Left as a possible follow-up.
- `applySponsoredFPCSetup`: no on-chain tx — it only calls `wallet.registerContract` locally; the sponsored FPC is genesis-funded and its class preloaded. Nothing to batch.
- `applyBaseSetup` chain: the auth-registry publish short-circuits (genesis-seeded by #24568) and `applyDeployBananaToken` is a single deploy tx. No consecutive same-sender pair.
- Two different contract deploys cannot share a tx (`MAX_CONTRACT_CLASS_LOGS_PER_TX = 1`), which rules out any two-deploy batch (e.g. cross-chain token+bridge).
- Cross-chain harness deploys and `bot/src/factory.ts` are out of scope (the latter lives on #24581's stack).

## Local span evidence (account_init, 5/5 green on all runs)

Suite-scoped beforeAll spans from `TEST_TIMING_FILE` captures:

| run | tx:mint count | tx:mint busyMs | deploy:fpc busyMs | beforeHooksMs |
|-----|---------------|----------------|-------------------|---------------|
| baseline (before) | 2 | 23618 | 23713 | 71607 |
| run 1 (after) | 1 | 11834 | 24065 | 72372 |
| run 2 (after) | 1 | 11807 | 23743 | 71678 |

The mint phase drops from two consecutive slots (~23.6s) to one (~11.8s), one proof and one tx fewer per shard. account_init's total beforeAll is flat locally because its mint phase runs concurrently with `applyFPCSetup` and `deploy:fpc` still pays 2 slots (PXE proves the mint batch first), remaining the phase's critical path — the direct wall-clock win lands on suites where the mints are the phase (e.g. `fee_juice_payments`), and the fewer-proofs contention win applies everywhere.

## Stacking

Stacked on #24569 (`spl/e2e-overlap-setup-txs`), itself stacked on #24564. Retarget to `merge-train/spartan-v5` once #24569 merges.

Fixes A-1409

## Measured impact

The batch lands exactly as the local runs predicted: 13 mint txs merged run-wide, with the wall-clock
win concentrated on the suites where the mint phase is the critical path.

- `tx:mint`: 42 → 29 occurrences (one merged per fees shard); busyMs 523s → 431s (−92s of tx/proving
  work). In the PR run busyMs equals totalMs — there are no overlapping mint txs left to union.
- Suites where the mint is critical-path: `failures` −12.0s, `fee_juice_payments` −11.5s (≈ one 12s
  slot each, as designed).
- Suites where the mint overlaps `applyFPCSetup` are flat as expected: `account_init` −0.4s,
  `private_payments.parallel` +2s (×8 shards), `gas_estimation.parallel` +3s (×3) — `deploy:fpc` is
  unchanged (13 occurrences, ~23s / 2 slots each) and remains their setup critical path, so removing
  a slot from the mint branch of the `Promise.all` doesn't move the union.
- Run-wide sum over common suites: −8s, i.e. neutral outside the two critical-path suites; the noise
  envelope on untouched suites in this run pair is ±20–37s (bot −20s, private_initialization +37s).

Net: ~−23s wall on two suites plus 13 fewer txs/proofs per run (less proving contention and one less
tx per fees shard through the sequencer). The remaining ~12s/shard lever on the overlapped fees
suites is folding the FPC deploy into the same batch (one class publication + app calls is within
`MAX_CONTRACT_CLASS_LOGS_PER_TX`), noted above as a follow-up.

Baseline CI run 1783394912998666 (#24569 `ci/x-fast`, the stack base). PR CI run 1783432285938536
(`ci/x-fast`).
