### PR TITLE
fix: prevent access to secrets not in scope

### DIFF
--- a/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution.test.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution.test.ts
@@ -552,8 +552,8 @@ describe('Utility Execution test suite', () => {
         const contractAddressA = await AztecAddress.random();
         const contractAddressB = await AztecAddress.random();
 
-        const oracleA = makeOracle({ contractAddress: contractAddressA });
-        const oracleB = makeOracle({ contractAddress: contractAddressB });
+        const oracleA = makeOracle({ contractAddress: contractAddressA, scopes: [owner] });
+        const oracleB = makeOracle({ contractAddress: contractAddressB, scopes: [owner] });
 
         const ephPksArray = EphemeralArray.fromValues<EmbeddedCurvePoint>(service, [ephPk]);
         const responseA = await oracleA.getSharedSecrets(owner, ephPksArray, contractAddressA);
@@ -581,15 +581,14 @@ describe('Utility Execution test suite', () => {
         );
       });
 
-      it('returns no secrets when the PXE does not hold the keys for the address', async () => {
+      it('rejects a recipient outside the allowed scopes', async () => {
         const ephSk = GrumpkinScalar.random();
         const ephPk = await Grumpkin.mul(Grumpkin.generator, ephSk);
 
-        const foreignAddress = await AztecAddress.random();
         const ephPksArray = EphemeralArray.fromValues<EmbeddedCurvePoint>(service, [ephPk]);
-        const response = await utilityExecutionOracle.getSharedSecrets(foreignAddress, ephPksArray, contractAddress);
-
-        expect(response.readAll(service)).toEqual([]);
+        await expect(utilityExecutionOracle.getSharedSecrets(owner, ephPksArray, contractAddress)).rejects.toThrow(
+          /not in the allowed scopes/,
+        );
       });
     });
 
@@ -631,10 +630,8 @@ describe('Utility Execution test suite', () => {
           );
         });
 
-        const result = await utilityExecutionOracle.getPendingTaggedLogsV2(
-          owner,
-          EphemeralArray.fromValues(service, providedSecrets),
-        );
+        const oracle = makeOracle({ scopes: [owner] });
+        const result = await oracle.getPendingTaggedLogsV2(owner, EphemeralArray.fromValues(service, providedSecrets));
 
         const queried = aztecNode.getPrivateLogsByTags.mock.calls.flatMap(([query]) =>
           query.tags.map(entry => ('tag' in entry ? entry.tag.value.toString() : entry.value.toString())),
@@ -654,6 +651,16 @@ describe('Utility Execution test suite', () => {
             ),
           },
         ]);
+      });
+
+      it('rejects a scope outside the allowed scopes', async () => {
+        const outOfScope = await AztecAddress.random();
+        await expect(
+          utilityExecutionOracle.getPendingTaggedLogsV2(
+            outOfScope,
+            EphemeralArray.fromValues<ProvidedSecret>(service, []),
+          ),
+        ).rejects.toThrow(/not in the allowed scopes/);
       });
     });
 

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
@@ -48,6 +48,7 @@ import { TxResolverService } from '../../messages/tx_resolver_service.js';
 import { NoteService } from '../../notes/note_service.js';
 import { ORACLE_VERSION_MAJOR } from '../../oracle_version.js';
 import type { AddressStore } from '../../storage/address_store/address_store.js';
+import { assertAllowedScope } from '../../storage/allowed_scopes.js';
 import type { CapsuleService } from '../../storage/capsule_store/capsule_service.js';
 import { FactCollectionKey, FactCollectionTypeKey, anchoredTipBlockNumbers } from '../../storage/fact_store/index.js';
 import type { FactService, OriginBlock } from '../../storage/fact_store/index.js';
@@ -595,6 +596,7 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
       this.recipientTaggingStore,
       this.taggingSecretSourcesStore,
       this.addressStore,
+      this.scopes,
       this.jobId,
       this.logger.getBindings(),
     );
@@ -853,8 +855,8 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
    * @param address - The recipient address.
    * @param ephPks - Ephemeral array containing the serialized Points.
    * @param contractAddress - The contract address for app-siloing (validated against execution context).
-   * @returns A new ephemeral array containing the computed shared secrets, or an empty array when the PXE does not
-   * hold the keys for `address`, signaling that no secrets can be derived for it.
+   * @returns A new ephemeral array containing the computed shared secrets.
+   * @throws If `address` is not in the execution's allowed scopes.
    */
   public async getSharedSecrets(
     address: AztecAddress,
@@ -866,17 +868,10 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
         `getSharedSecrets called with contract address ${contractAddress}, expected ${this.contractAddress}`,
       );
     }
-    const recipientCompleteAddress = await this.addressStore.getCompleteAddress(address);
-    if (!recipientCompleteAddress) {
-      this.logger.warn(
-        `Computing shared secrets for address ${address} whose keys are not held - returning no secrets`,
-        {
-          address,
-          contractAddress: this.contractAddress,
-        },
-      );
-      return EphemeralArray.fromValues<Fr>(this.ephemeralArrayService, []);
-    }
+
+    assertAllowedScope(address, this.scopes);
+
+    const recipientCompleteAddress = await this.getCompleteAddressOrFail(address);
     const ivpkMHash = await hashPublicKey(recipientCompleteAddress.publicKeys.ivpkM);
     const ivskM = await this.keyStore.getMasterSecretKey(ivpkMHash);
     const addressSecret = await computeAddressSecret(await recipientCompleteAddress.getPreaddress(), ivskM);

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
@@ -855,7 +855,8 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
    * @param address - The recipient address.
    * @param ephPks - Ephemeral array containing the serialized Points.
    * @param contractAddress - The contract address for app-siloing (validated against execution context).
-   * @returns A new ephemeral array containing the computed shared secrets.
+   * @returns A new ephemeral array containing the computed shared secrets, or an empty array when the PXE does not
+   * hold the keys for `address`.
    * @throws If `address` is not in the execution's allowed scopes.
    */
   public async getSharedSecrets(
@@ -871,7 +872,19 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
 
     assertAllowedScope(address, this.scopes);
 
-    const recipientCompleteAddress = await this.getCompleteAddressOrFail(address);
+    // An address can be in scope without the PXE holding its keys (e.g. syncing a registered but non-owned account),
+    // in which case no secrets can be derived and we return an empty array rather than failing.
+    const recipientCompleteAddress = await this.addressStore.getCompleteAddress(address);
+    if (!recipientCompleteAddress) {
+      this.logger.warn(
+        `Computing shared secrets for address ${address} whose keys are not held - returning no secrets`,
+        {
+          address,
+          contractAddress: this.contractAddress,
+        },
+      );
+      return EphemeralArray.fromValues<Fr>(this.ephemeralArrayService, []);
+    }
     const ivpkMHash = await hashPublicKey(recipientCompleteAddress.publicKeys.ivpkM);
     const ivskM = await this.keyStore.getMasterSecretKey(ivpkMHash);
     const addressSecret = await computeAddressSecret(await recipientCompleteAddress.getPreaddress(), ivskM);

--- a/yarn-project/pxe/src/logs/log_service.test.ts
+++ b/yarn-project/pxe/src/logs/log_service.test.ts
@@ -321,13 +321,17 @@ describe('LogService', () => {
       contractAddress = await AztecAddress.random();
 
       const l2TipsProvider = mock<L2TipsProvider>();
-      ({ aztecNode, keyStore, taggingSecretSourcesStore, addressStore, logService } =
-        await createTestLogService(l2TipsProvider));
+      const scopes: AztecAddress[] = [];
+      ({ aztecNode, keyStore, taggingSecretSourcesStore, addressStore, logService } = await createTestLogService(
+        l2TipsProvider,
+        scopes,
+      ));
       l2TipsProvider.getL2Tips.mockResolvedValue(makeL2Tips(0));
 
       const completeAddress = await keyStore.addAccount(await deriveKeys(Fr.random()), Fr.random());
       await addressStore.addCompleteAddress(completeAddress);
       recipient = completeAddress.address;
+      scopes.push(recipient);
 
       sharedSecret = await Point.random();
     });
@@ -396,6 +400,13 @@ describe('LogService', () => {
       expect(txHashes).not.toContainEqual(directionalLog.txHash);
     });
 
+    it('rejects a recipient outside the allowed scopes', async () => {
+      const outOfScope = await AztecAddress.random();
+      await expect(logService.fetchTaggedLogs(contractAddress, outOfScope, [])).rejects.toThrow(
+        /not in the allowed scopes/,
+      );
+    });
+
     function handshakeTags(secret: Point, app: AztecAddress): Promise<SiloedTag[]> {
       return Promise.all(
         [AppTaggingSecretKind.UNCONSTRAINED, AppTaggingSecretKind.CONSTRAINED].map(async kind =>
@@ -421,7 +432,8 @@ describe('LogService', () => {
       contractAddress = await AztecAddress.random();
 
       const l2TipsProvider = mock<L2TipsProvider>();
-      const testContext = await createTestLogService(l2TipsProvider);
+      const scopes: AztecAddress[] = [];
+      const testContext = await createTestLogService(l2TipsProvider, scopes);
       ({ aztecNode, keyStore, taggingSecretSourcesStore, addressStore, logService } = testContext);
       l2TipsProvider.getL2Tips.mockResolvedValue(makeL2Tips(testContext.anchorBlockHeader.globalVariables.blockNumber));
 
@@ -429,6 +441,7 @@ describe('LogService', () => {
       recipientCompleteAddress = await keyStore.addAccount(await deriveKeys(new Fr(1)), Fr.random());
       recipient = recipientCompleteAddress.address;
       await addressStore.addCompleteAddress(recipientCompleteAddress);
+      scopes.push(recipient);
 
       sender = await AztecAddress.random();
 
@@ -469,7 +482,10 @@ describe('LogService', () => {
   });
 });
 
-async function createTestLogService(l2TipsProvider: MockProxy<L2TipsProvider> = mock<L2TipsProvider>()) {
+async function createTestLogService(
+  l2TipsProvider: MockProxy<L2TipsProvider> = mock<L2TipsProvider>(),
+  scopes: AztecAddress[] = [],
+) {
   const keyStore = new KeyStore(await openTmpStore('test'));
   const recipientTaggingStore = new RecipientTaggingStore(await openTmpStore('test'));
   const taggingSecretSourcesStore = new TaggingSecretSourcesStore(await openTmpStore('test'));
@@ -486,6 +502,7 @@ async function createTestLogService(l2TipsProvider: MockProxy<L2TipsProvider> = 
     recipientTaggingStore,
     taggingSecretSourcesStore,
     addressStore,
+    scopes,
     'test',
   );
 

--- a/yarn-project/pxe/src/logs/log_service.ts
+++ b/yarn-project/pxe/src/logs/log_service.ts
@@ -24,6 +24,7 @@ import type { LogRetrievalResponse } from '../contract_function_simulator/noir-s
 import type { PendingTaggedLog } from '../contract_function_simulator/noir-structs/pending_tagged_log.js';
 import { ResolvedTx } from '../contract_function_simulator/noir-structs/resolved_tx.js';
 import { AddressStore } from '../storage/address_store/address_store.js';
+import { assertAllowedScope } from '../storage/allowed_scopes.js';
 import type { RecipientTaggingStore } from '../storage/tagging_store/recipient_tagging_store.js';
 import type { TaggingSecretSourcesStore } from '../storage/tagging_store/tagging_secret_sources_store.js';
 import {
@@ -47,6 +48,7 @@ export class LogService {
     private readonly recipientTaggingStore: RecipientTaggingStore,
     private readonly taggingSecretSourcesStore: TaggingSecretSourcesStore,
     private readonly addressStore: AddressStore,
+    private readonly scopes: AztecAddress[],
     private readonly jobId: string,
     bindings?: LoggerBindings,
   ) {
@@ -189,6 +191,8 @@ export class LogService {
     recipient: AztecAddress,
     providedSecrets: AppTaggingSecret[],
   ): Promise<PendingTaggedLog[]> {
+    assertAllowedScope(recipient, this.scopes);
+
     this.log.verbose(
       `Fetching tagged logs for contract ${contractAddress.toString()} and recipient ${recipient.toString()}`,
     );

--- a/yarn-project/pxe/src/notes/note_service.ts
+++ b/yarn-project/pxe/src/notes/note_service.ts
@@ -26,7 +26,7 @@ export class NoteService {
    *
    * @param owner - The owner of the notes. If undefined, returns notes for all known owners.
    * @param status - The status of notes to fetch.
-   * @param scopes - The accounts whose notes we can access in this call. Currently optional and will default to all.
+   * @param scopes - The accounts whose notes we can access in this call. An empty list matches no notes.
    */
   public async getNotes(
     contractAddress: AztecAddress,


### PR DESCRIPTION
Some stores were being accessed without checking if the associated accounts were in scope or not. For logs I added this to the service, but we're not yet consistent in how we use services (call-lived, tx-lived?) so in other cases it is just inlined in the oracle.