### PR TITLE
fix(aztec.js): give waitForNode a bounded default timeout

### DIFF
--- a/yarn-project/aztec.js/src/utils/node.test.ts
+++ b/yarn-project/aztec.js/src/utils/node.test.ts
@@ -1,4 +1,5 @@
 import { BlockNumber, EpochNumber, SlotNumber } from '@aztec/foundation/branded-types';
+import { TimeoutError } from '@aztec/foundation/error';
 import { BlockHash } from '@aztec/stdlib/block';
 import type { AztecNode } from '@aztec/stdlib/interfaces/client';
 import {
@@ -14,7 +15,7 @@ import {
 
 import { type MockProxy, mock } from 'jest-mock-extended';
 
-import { waitForTx } from './node.js';
+import { waitForNode, waitForTx } from './node.js';
 
 describe('waitForTx', () => {
   let node: MockProxy<AztecNode>;
@@ -135,5 +136,26 @@ describe('waitForTx', () => {
       const receipt = await waitForTx(node, txHash, { timeout: 1, interval: 0.1 });
       expect(receipt.status).toBe(TxStatus.CHECKPOINTED);
     });
+  });
+});
+
+describe('waitForNode', () => {
+  let node: MockProxy<AztecNode>;
+
+  beforeEach(() => {
+    node = mock();
+  });
+
+  it('resolves once the node becomes reachable', async () => {
+    node.getNodeInfo.mockRejectedValueOnce(new Error('not up yet')).mockResolvedValueOnce({} as any);
+
+    await expect(waitForNode(node, undefined, { timeout: 5, interval: 0.01 })).resolves.toBeUndefined();
+    expect(node.getNodeInfo).toHaveBeenCalledTimes(2);
+  });
+
+  it('rejects with a TimeoutError when the node stays unreachable', async () => {
+    node.getNodeInfo.mockRejectedValue(new Error('unreachable'));
+
+    await expect(waitForNode(node, undefined, { timeout: 0.05, interval: 0.01 })).rejects.toThrow(TimeoutError);
   });
 });

--- a/yarn-project/aztec.js/src/utils/node.ts
+++ b/yarn-project/aztec.js/src/utils/node.ts
@@ -6,18 +6,31 @@ import { SortedTxStatuses, TxStatus } from '@aztec/stdlib/tx';
 
 import { DefaultWaitOpts, type WaitOpts } from '../contract/wait_opts.js';
 
-export const waitForNode = async (node: AztecNode, logger?: Logger) => {
-  await retryUntil(async () => {
-    try {
-      logger?.verbose('Attempting to contact Aztec node...');
-      await node.getNodeInfo();
-      logger?.verbose('Contacted Aztec node');
-      return true;
-    } catch {
-      logger?.verbose('Failed to contact Aztec Node');
-    }
-    return undefined;
-  }, 'RPC Get Node Info');
+/**
+ * Waits for an Aztec node to become reachable, polling {@link AztecNode.getNodeInfo} until it succeeds.
+ * @param node - The Aztec node to contact.
+ * @param logger - Optional logger for polling progress.
+ * @param opts - Optional timeout and interval (in seconds). `timeout` defaults to {@link DefaultWaitOpts.timeout};
+ * pass `timeout: 0` to wait indefinitely.
+ * @throws TimeoutError if the node stays unreachable past the timeout.
+ */
+export const waitForNode = async (node: AztecNode, logger?: Logger, opts?: Pick<WaitOpts, 'timeout' | 'interval'>) => {
+  await retryUntil(
+    async () => {
+      try {
+        logger?.verbose('Attempting to contact Aztec node...');
+        await node.getNodeInfo();
+        logger?.verbose('Contacted Aztec node');
+        return true;
+      } catch {
+        logger?.verbose('Failed to contact Aztec Node');
+      }
+      return undefined;
+    },
+    'RPC Get Node Info',
+    opts?.timeout ?? DefaultWaitOpts.timeout,
+    opts?.interval ?? DefaultWaitOpts.interval,
+  );
 };
 
 /** Returns true if the receipt status is at least the desired status level. */


### PR DESCRIPTION
Fixes #24602.

## Problem

`waitForNode` polls `getNodeInfo()` forever when the node is unreachable, with no way for the caller to bound the wait:

- It calls `retryUntil(fn, 'RPC Get Node Info')` — passing no `timeout`.
- `retryUntil` defaults `timeout = 0`, and `0` is the documented "never time out" sentinel, so the timeout branch is dead.
- `waitForNode` exposed no parameter to override this, so a caller could not cap the wait at all.

The result: a dApp/CLI/service pointed at a wrong URL or a down node hangs silently at startup, indistinguishable from "node still starting." This is also inconsistent with the sibling `waitForTx` in the same file, which forwards `opts?.timeout ?? DefaultWaitOpts.timeout` (300s).

## Fix

Add an optional `{ timeout, interval }` argument to `waitForNode` and default it to `DefaultWaitOpts` (300s / 1s), mirroring `waitForTx`. An unreachable node now rejects with a `TimeoutError`.

## Behavioral change

The default wait changes from infinite to 300s. Callers that relied on waiting indefinitely can restore the old behavior by passing `{ timeout: 0 }`. 300s is generous for a reachable node and matches the existing `waitForTx` / `DefaultWaitOpts` default.

## Tests

Added to `node.test.ts` (reusing the existing `jest-mock-extended` style):

- resolves once the node becomes reachable
- rejects with a `TimeoutError` when the node stays unreachable (bounded)
