### PR TITLE
refactor: cache Aztec node reads per execution

### DIFF
--- a/yarn-project/pxe/src/contract_function_simulator/aztec_node_read_cache.test.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/aztec_node_read_cache.test.ts
@@ -1,0 +1,107 @@
+import { ARCHIVE_HEIGHT } from '@aztec/constants';
+import { BlockNumber, EpochNumber, SlotNumber } from '@aztec/foundation/branded-types';
+import { Fr } from '@aztec/foundation/curves/bn254';
+import { promiseWithResolvers } from '@aztec/foundation/promise';
+import { MembershipWitness } from '@aztec/foundation/trees';
+import { AztecAddress } from '@aztec/stdlib/aztec-address';
+import { BlockHash } from '@aztec/stdlib/block';
+import type { AztecNode } from '@aztec/stdlib/interfaces/server';
+import { PublicDataWitness } from '@aztec/stdlib/trees';
+import { MinedTxReceipt, TxEffect, TxExecutionResult, TxHash, TxStatus } from '@aztec/stdlib/tx';
+
+import { mock } from 'jest-mock-extended';
+
+import { AztecNodeReadCache } from './aztec_node_read_cache.js';
+
+describe('AztecNodeReadCache', () => {
+  let aztecNode: ReturnType<typeof mock<AztecNode>>;
+  let cache: AztecNodeReadCache;
+
+  const makeMinedReceipt = (txHash: TxHash) =>
+    new MinedTxReceipt(
+      txHash,
+      TxStatus.FINALIZED,
+      TxExecutionResult.SUCCESS,
+      0n,
+      BlockHash.random(),
+      BlockNumber(1),
+      SlotNumber(1),
+      0,
+      EpochNumber(1),
+      TxEffect.empty(),
+    );
+
+  beforeEach(() => {
+    aztecNode = mock<AztecNode>();
+    cache = new AztecNodeReadCache(aztecNode);
+  });
+
+  it('shares concurrent tx receipt reads', async () => {
+    const txHash = TxHash.random();
+    const deferred = promiseWithResolvers<MinedTxReceipt<{ includeTxEffect: true }>>();
+    aztecNode.getTxReceipt.mockReturnValue(deferred.promise);
+
+    const first = cache.getTxReceiptWithEffect(txHash);
+    const second = cache.getTxReceiptWithEffect(txHash);
+    const receipt = makeMinedReceipt(txHash);
+    deferred.resolve(receipt);
+
+    await expect(Promise.all([first, second])).resolves.toEqual([receipt, receipt]);
+    expect(aztecNode.getTxReceipt).toHaveBeenCalledTimes(1);
+  });
+
+  it('evicts rejected reads so callers can retry', async () => {
+    const txHash = TxHash.random();
+    const receipt = makeMinedReceipt(txHash);
+    aztecNode.getTxReceipt.mockRejectedValueOnce(new Error('temporary failure'));
+    aztecNode.getTxReceipt.mockResolvedValueOnce(receipt);
+
+    await expect(cache.getTxReceiptWithEffect(txHash)).rejects.toThrow('temporary failure');
+    await expect(cache.getTxReceiptWithEffect(txHash)).resolves.toBe(receipt);
+    expect(aztecNode.getTxReceipt).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps cache entries separate by method and arguments', async () => {
+    const blockHash = BlockHash.random();
+    const leafSlot = Fr.random();
+    const blockWitness = MembershipWitness.empty(ARCHIVE_HEIGHT);
+    const publicDataWitness = PublicDataWitness.random();
+    aztecNode.getBlockHashMembershipWitness.mockResolvedValue(blockWitness);
+    aztecNode.getPublicDataWitness.mockResolvedValue(publicDataWitness);
+
+    await expect(cache.getBlockHashMembershipWitness(blockHash, blockHash)).resolves.toBe(blockWitness);
+    await expect(cache.getPublicDataWitness(blockHash, leafSlot)).resolves.toBe(publicDataWitness);
+
+    expect(aztecNode.getBlockHashMembershipWitness).toHaveBeenCalledTimes(1);
+    expect(aztecNode.getPublicDataWitness).toHaveBeenCalledTimes(1);
+  });
+
+  it('caches successful undefined results', async () => {
+    const referenceBlockHash = BlockHash.random();
+    const blockHash = BlockHash.random();
+    aztecNode.getBlockHashMembershipWitness.mockResolvedValue(undefined);
+
+    await expect(cache.getBlockHashMembershipWitness(referenceBlockHash, blockHash)).resolves.toBeUndefined();
+    await expect(cache.getBlockHashMembershipWitness(referenceBlockHash, blockHash)).resolves.toBeUndefined();
+
+    expect(aztecNode.getBlockHashMembershipWitness).toHaveBeenCalledTimes(1);
+  });
+
+  it('reuses cached slots across overlapping public storage ranges', async () => {
+    const blockHash = BlockHash.random();
+    const contractAddress = await AztecAddress.random();
+    const startStorageSlot = new Fr(100);
+    aztecNode.getPublicStorageAt.mockImplementation(async (_block, _contract, slot) => new Fr(slot.value + 1n));
+
+    await expect(cache.getPublicStorageRange(blockHash, contractAddress, startStorageSlot, 2)).resolves.toEqual([
+      new Fr(101),
+      new Fr(102),
+    ]);
+    await expect(cache.getPublicStorageRange(blockHash, contractAddress, new Fr(101), 2)).resolves.toEqual([
+      new Fr(102),
+      new Fr(103),
+    ]);
+
+    expect(aztecNode.getPublicStorageAt).toHaveBeenCalledTimes(3);
+  });
+});

--- a/yarn-project/pxe/src/contract_function_simulator/aztec_node_read_cache.test.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/aztec_node_read_cache.test.ts
@@ -91,7 +91,9 @@ describe('AztecNodeReadCache', () => {
     const blockHash = BlockHash.random();
     const contractAddress = await AztecAddress.random();
     const startStorageSlot = new Fr(100);
-    aztecNode.getPublicStorageAt.mockImplementation(async (_block, _contract, slot) => new Fr(slot.value + 1n));
+    aztecNode.getPublicStorageAt.mockImplementation((_block, _contract, slot) =>
+      Promise.resolve(new Fr(slot.value + 1n)),
+    );
 
     await expect(cache.getPublicStorageRange(blockHash, contractAddress, startStorageSlot, 2)).resolves.toEqual([
       new Fr(101),

--- a/yarn-project/pxe/src/contract_function_simulator/aztec_node_read_cache.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/aztec_node_read_cache.ts
@@ -1,0 +1,89 @@
+import { Fr } from '@aztec/foundation/curves/bn254';
+import type { AztecAddress } from '@aztec/stdlib/aztec-address';
+import type { BlockHash, BlockParameter } from '@aztec/stdlib/block';
+import type { AztecNode } from '@aztec/stdlib/interfaces/server';
+import type { TxHash } from '@aztec/stdlib/tx';
+
+/**
+ * Per-execution cache for immutable Aztec node reads.
+ */
+export class AztecNodeReadCache {
+  private readonly cache = new Map<string, Promise<unknown>>();
+
+  constructor(private readonly aztecNode: AztecNode) {}
+
+  /** Fetches a block without reissuing the same node request. */
+  public getBlock(block: BlockParameter) {
+    return this.#cachedRead(`block:${this.#keyPart(block)}`, () => this.aztecNode.getBlock(block));
+  }
+
+  /** Fetches a transaction receipt with its effect attached. */
+  public getTxReceiptWithEffect(txHash: TxHash) {
+    return this.#cachedRead(`tx-receipt-with-effect:${txHash.toString()}`, () =>
+      this.aztecNode.getTxReceipt(txHash, { includeTxEffect: true } as const),
+    );
+  }
+
+  /** Fetches an archive-tree witness for a block hash. */
+  public getBlockHashMembershipWitness(referenceBlock: BlockParameter, blockHash: BlockHash) {
+    return this.#cachedRead(
+      `block-hash-membership-witness:${this.#keyPart(referenceBlock)}:${blockHash.toString()}`,
+      () => this.aztecNode.getBlockHashMembershipWitness(referenceBlock, blockHash),
+    );
+  }
+
+  /** Fetches a public-data-tree witness for a leaf slot. */
+  public getPublicDataWitness(referenceBlock: BlockParameter, leafSlot: Fr) {
+    return this.#cachedRead(`public-data-witness:${this.#keyPart(referenceBlock)}:${leafSlot.toString()}`, () =>
+      this.aztecNode.getPublicDataWitness(referenceBlock, leafSlot),
+    );
+  }
+
+  /** Fetches public storage for a single slot. */
+  public getPublicStorageAt(referenceBlock: BlockParameter, contractAddress: AztecAddress, storageSlot: Fr) {
+    return this.#cachedRead(
+      `public-storage:${this.#keyPart(referenceBlock)}:${contractAddress.toString()}:${storageSlot.toString()}`,
+      () => this.aztecNode.getPublicStorageAt(referenceBlock, contractAddress, storageSlot),
+    );
+  }
+
+  /** Fetches a contiguous public storage range, reusing cached reads for overlapping slots. */
+  public getPublicStorageRange(
+    referenceBlock: BlockParameter,
+    contractAddress: AztecAddress,
+    startStorageSlot: Fr,
+    numberOfElements: number,
+  ) {
+    const slots = Array(numberOfElements)
+      .fill(0)
+      .map((_, i) => new Fr(startStorageSlot.value + BigInt(i)));
+
+    return Promise.all(slots.map(storageSlot => this.getPublicStorageAt(referenceBlock, contractAddress, storageSlot)));
+  }
+
+  #cachedRead<T>(key: string, fetch: () => Promise<T>): Promise<T> {
+    const cached = this.cache.get(key);
+    if (cached) {
+      return cached as Promise<T>;
+    }
+
+    const promise = fetch();
+    promise.catch(() => this.cache.delete(key));
+    this.cache.set(key, promise);
+    return promise;
+  }
+
+  #keyPart(value: unknown): string {
+    if (['string', 'number', 'bigint', 'boolean'].includes(typeof value)) {
+      return String(value);
+    }
+    if (value && typeof value === 'object') {
+      const toString = (value as { toString?: () => string }).toString;
+      if (toString && toString !== Object.prototype.toString) {
+        return toString.call(value);
+      }
+      return JSON.stringify(value, (_key, nested) => (typeof nested === 'bigint' ? nested.toString() : nested));
+    }
+    return String(value);
+  }
+}

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution.test.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution.test.ts
@@ -678,7 +678,7 @@ describe('Utility Execution test suite', () => {
           0n,
           BlockHash.random(),
           BlockNumber(syncedBlockNumber),
-          SlotNumber(syncedBlockNumber),
+          SlotNumber(1),
           0,
           EpochNumber(1),
           txEffect,

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution.test.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution.test.ts
@@ -1,7 +1,9 @@
-import { BlockNumber } from '@aztec/foundation/branded-types';
+import { ARCHIVE_HEIGHT } from '@aztec/constants';
+import { BlockNumber, EpochNumber, SlotNumber } from '@aztec/foundation/branded-types';
 import { Grumpkin } from '@aztec/foundation/crypto/grumpkin';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { GrumpkinScalar } from '@aztec/foundation/curves/grumpkin';
+import { MembershipWitness } from '@aztec/foundation/trees';
 import type { KeyStore } from '@aztec/key-store';
 import { openTmpStore } from '@aztec/kv-store/lmdb-v2';
 import { StatefulTestContractArtifact } from '@aztec/noir-test-contracts.js/StatefulTest';
@@ -28,7 +30,17 @@ import { PublicKeys, deriveKeys, hashPublicKey } from '@aztec/stdlib/keys';
 import { AppTaggingSecret, AppTaggingSecretKind, SiloedTag } from '@aztec/stdlib/logs';
 import { Note, NoteDao } from '@aztec/stdlib/note';
 import { makeL2Tips, randomContractInstanceWithAddress } from '@aztec/stdlib/testing';
-import { BlockHeader, CallContext, Capsule, GlobalVariables, TxHash } from '@aztec/stdlib/tx';
+import {
+  BlockHeader,
+  CallContext,
+  Capsule,
+  GlobalVariables,
+  MinedTxReceipt,
+  TxEffect,
+  TxExecutionResult,
+  TxHash,
+  TxStatus,
+} from '@aztec/stdlib/tx';
 
 import { mock } from 'jest-mock-extended';
 import type { _MockProxy } from 'jest-mock-extended/lib/Mock.js';
@@ -654,6 +666,92 @@ describe('Utility Execution test suite', () => {
             ),
           },
         ]);
+      });
+    });
+
+    describe('node read cache', () => {
+      const makeMinedReceipt = (txHash: TxHash, txEffect = TxEffect.empty()) =>
+        new MinedTxReceipt(
+          txHash,
+          TxStatus.FINALIZED,
+          TxExecutionResult.SUCCESS,
+          0n,
+          BlockHash.random(),
+          BlockNumber(syncedBlockNumber),
+          SlotNumber(syncedBlockNumber),
+          0,
+          EpochNumber(1),
+          txEffect,
+        );
+
+      it('reuses tx-effect reads within a utility execution', async () => {
+        const oracle = makeOracle({ scopes: [scope] });
+        const txHash = TxHash.random();
+        aztecNode.getTxReceipt.mockResolvedValue(makeMinedReceipt(txHash));
+
+        const first = await oracle.getTxEffect(txHash);
+        const second = await oracle.getTxEffect(txHash);
+
+        expect(first).toEqual(second);
+        expect(aztecNode.getTxReceipt).toHaveBeenCalledTimes(1);
+      });
+
+      it('does not share cached reads across utility executions', async () => {
+        const txHash = TxHash.random();
+        aztecNode.getTxReceipt.mockResolvedValue(makeMinedReceipt(txHash));
+
+        const firstOracle = makeOracle({ scopes: [scope] });
+        const secondOracle = makeOracle({ scopes: [scope] });
+
+        // Cache works as usual
+        await firstOracle.getTxEffect(txHash);
+        await firstOracle.getTxEffect(txHash);
+        expect(aztecNode.getTxReceipt).toHaveBeenCalledTimes(1);
+
+        // Same call in new oracle, goes to actual node since cache is clean
+        await secondOracle.getTxEffect(txHash);
+        expect(aztecNode.getTxReceipt).toHaveBeenCalledTimes(2);
+      });
+
+      it('does not cache failed tx-effect reads', async () => {
+        const oracle = makeOracle({ scopes: [scope] });
+        const txHash = TxHash.random();
+        aztecNode.getTxReceipt.mockRejectedValueOnce(new Error('temporary failure'));
+        aztecNode.getTxReceipt.mockResolvedValueOnce(makeMinedReceipt(txHash));
+
+        await expect(oracle.getTxEffect(txHash)).rejects.toThrow('temporary failure');
+
+        const result = await oracle.getTxEffect(txHash);
+
+        expect(result.isSome()).toBe(true);
+        expect(aztecNode.getTxReceipt).toHaveBeenCalledTimes(2);
+      });
+
+      it('reuses archive witness reads within a utility execution', async () => {
+        const oracle = makeOracle({ scopes: [scope] });
+        const referenceBlockHash = await anchorBlockHeader.hash();
+        const blockHash = BlockHash.random();
+        const witness = MembershipWitness.empty(ARCHIVE_HEIGHT);
+        aztecNode.getBlockHashMembershipWitness.mockResolvedValue(witness);
+
+        const first = await oracle.getBlockHashMembershipWitness(referenceBlockHash, blockHash);
+        const second = await oracle.getBlockHashMembershipWitness(referenceBlockHash, blockHash);
+
+        expect(first).toEqual(second);
+        expect(aztecNode.getBlockHashMembershipWitness).toHaveBeenCalledTimes(1);
+      });
+
+      it('reuses public storage reads within a utility execution', async () => {
+        const oracle = makeOracle({ scopes: [scope] });
+        const blockHash = await anchorBlockHeader.hash();
+        const startStorageSlot = Fr.random();
+        aztecNode.getPublicStorageAt.mockResolvedValue(new Fr(7));
+
+        const first = await oracle.getFromPublicStorage(blockHash, contractAddress, startStorageSlot, 2);
+        const second = await oracle.getFromPublicStorage(blockHash, contractAddress, startStorageSlot, 2);
+
+        expect(first).toEqual(second);
+        expect(aztecNode.getPublicStorageAt).toHaveBeenCalledTimes(2);
       });
     });
 

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
@@ -56,6 +56,7 @@ import type { PrivateEventStore } from '../../storage/private_event_store/privat
 import type { RecipientTaggingStore } from '../../storage/tagging_store/recipient_tagging_store.js';
 import type { TaggingSecretSourcesStore } from '../../storage/tagging_store/tagging_secret_sources_store.js';
 import type { AnchoredContractData } from '../anchored_contract_data.js';
+import { AztecNodeReadCache } from '../aztec_node_read_cache.js';
 import { EphemeralArrayService } from '../ephemeral_array_service.js';
 import { BoundedVec } from '../noir-structs/bounded_vec.js';
 import type { EmbeddedCurvePoint } from '../noir-structs/embedded_curve_point.js';
@@ -119,6 +120,7 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
   private offchainEffects: OffchainEffect[] = [];
   private readonly ephemeralArrayService = new EphemeralArrayService();
   protected readonly transientArrayService: TransientArrayService;
+  private readonly aztecNodeReadCache: AztecNodeReadCache;
 
   // We store oracle version to be able to show a nice error message when an oracle handler is missing.
   private contractOracleVersion: { major: number; minor: number } | undefined;
@@ -172,6 +174,7 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
     this.hooks = args.hooks;
     this.utilityExecutor = args.utilityExecutor;
     this.transientArrayService = args.transientArrayService;
+    this.aztecNodeReadCache = new AztecNodeReadCache(args.aztecNode);
   }
 
   public assertCompatibleOracleVersion(major: number, minor: number): void {
@@ -265,7 +268,7 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
     // hash at all. If the block hash did not exist by the reference block hash, then the node will not return the
     // membership witness as there is none.
     const witness = await this.#queryWithBlockHashNotAfterAnchor(referenceBlockHash, () =>
-      this.aztecNode.getBlockHashMembershipWitness(referenceBlockHash, blockHash),
+      this.aztecNodeReadCache.getBlockHashMembershipWitness(referenceBlockHash, blockHash),
     );
     return witness ? Option.some(witness) : Option.none();
   }
@@ -318,7 +321,7 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
    */
   public async getPublicDataWitness(blockHash: BlockHash, leafSlot: Fr): Promise<PublicDataWitness> {
     const witness = await this.#queryWithBlockHashNotAfterAnchor(blockHash, () =>
-      this.aztecNode.getPublicDataWitness(blockHash, leafSlot),
+      this.aztecNodeReadCache.getPublicDataWitness(blockHash, leafSlot),
     );
     if (!witness) {
       throw new Error(`Public data witness not found for slot ${leafSlot} at block hash ${blockHash.toString()}.`);
@@ -509,16 +512,16 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
     numberOfElements: number,
   ) {
     return this.#queryWithBlockHashNotAfterAnchor(blockHash, async () => {
-      const slots = Array(numberOfElements)
-        .fill(0)
-        .map((_, i) => new Fr(startStorageSlot.value + BigInt(i)));
-
-      const values = await Promise.all(
-        slots.map(storageSlot => this.aztecNode.getPublicStorageAt(blockHash, contractAddress, storageSlot)),
+      const values = await this.aztecNodeReadCache.getPublicStorageRange(
+        blockHash,
+        contractAddress,
+        startStorageSlot,
+        numberOfElements,
       );
 
       this.logger.debug(
-        `Oracle storage read: slots=[${slots.map(slot => slot.toString()).join(', ')}] address=${contractAddress.toString()} values=[${values.join(', ')}]`,
+        `Oracle storage read: start=${startStorageSlot.toString()} count=${numberOfElements} ` +
+          `address=${contractAddress.toString()} values=[${values.join(', ')}]`,
       );
 
       return values;
@@ -664,7 +667,7 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
       throw new Error('Invalid tx hash passed into aztec_utl_getTxEffect oracle handler');
     }
 
-    const receipt = await this.aztecNode.getTxReceipt(txHash, { includeTxEffect: true });
+    const receipt = await this.aztecNodeReadCache.getTxReceiptWithEffect(txHash);
     if (!receipt.isMined() || !receipt.txEffect || receipt.blockNumber > this.anchorBlockHeader.getBlockNumber()) {
       return Option.none();
     }
@@ -1077,9 +1080,7 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
    */
   async #fetchTxEffects(txHashes: TxHash[]): Promise<Map<string, IndexedTxEffect>> {
     const uniqueTxHashes = uniqueBy(txHashes, h => h.toString());
-    const fetched = await Promise.all(
-      uniqueTxHashes.map(h => this.aztecNode.getTxReceipt(h, { includeTxEffect: true })),
-    );
+    const fetched = await Promise.all(uniqueTxHashes.map(h => this.aztecNodeReadCache.getTxReceiptWithEffect(h)));
     return new Map(
       uniqueTxHashes
         .map((h, i): [string, IndexedTxEffect | undefined] => {
@@ -1113,7 +1114,7 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
     const [response] = await Promise.all([
       query(),
       (async () => {
-        const block = await this.aztecNode.getBlock(blockHash);
+        const block = await this.aztecNodeReadCache.getBlock(blockHash);
         const header = block?.header;
         if (!header) {
           throw new Error(`Could not find block header for block hash ${blockHash}`);


### PR DESCRIPTION
First part of integrating the enhancements explored at https://github.com/aztec-labs-eng/oxide/pull/257

Closes F-808