### PR TITLE
fix: release OPFS handles before sqlite worker close/delete ack

### DIFF
--- a/yarn-project/kv-store/scripts/run-browser-tests.sh
+++ b/yarn-project/kv-store/scripts/run-browser-tests.sh
@@ -15,7 +15,9 @@ set -euo pipefail
 
 cd "$(dirname "$0")/.."
 
-files=$(find src/deprecated/indexeddb src/sqlite-opfs -name '*.test.ts' 2>/dev/null | sort)
+# -type f: vitest failure screenshots land in __screenshots__/<test-file>/, creating
+# directories whose names match the *.test.ts glob.
+files=$(find src/deprecated/indexeddb src/sqlite-opfs -type f -name '*.test.ts' 2>/dev/null | sort)
 
 if [ -z "$files" ]; then
   echo "No test files found in src/deprecated/indexeddb or src/sqlite-opfs"

--- a/yarn-project/kv-store/src/sqlite-opfs/store_management.test.ts
+++ b/yarn-project/kv-store/src/sqlite-opfs/store_management.test.ts
@@ -47,6 +47,18 @@ describe('sqlite-opfs store management', () => {
     await deleteStore('mech_managed');
   });
 
+  // Regression test: close() must not resolve until the worker has released the SAH pool's OPFS
+  // handles, otherwise deleteStore races Chromium's async reclaim of the terminated worker and
+  // intermittently throws NoModificationAllowedError. Looped to amplify the race window.
+  it('deletes a store immediately after close, repeatedly', async () => {
+    for (let i = 0; i < 20; i++) {
+      const store = await openByName('mech_close_release');
+      await store.openSingleton<string>('k').set(`v${i}`);
+      await store.close();
+      await deleteStore('mech_close_release');
+    }
+  });
+
   it('refuses to delete a store that is currently open', async () => {
     const store = await openByName('mech_locked');
     await expect(deleteStore('mech_locked')).rejects.toThrow();

--- a/yarn-project/kv-store/src/sqlite-opfs/worker.ts
+++ b/yarn-project/kv-store/src/sqlite-opfs/worker.ts
@@ -94,6 +94,20 @@ function handleClose(): void {
   db?.close();
   db = undefined;
   dbPath = undefined;
+  releasePool();
+}
+
+/**
+ * Releases the SAH pool's OPFS sync access handles before the terminal RPC is acked. Worker
+ * termination releases them only asynchronously, so without this a caller that deletes or reopens
+ * the store directory right after close()/delete() resolves races Chromium's cleanup
+ * (NoModificationAllowedError from removeEntry, or a hang installing a new pool on the directory).
+ * pauseVfs releases the handles without touching file contents; the worker is terminated right
+ * after, so the pool is never resumed.
+ */
+function releasePool(): void {
+  pool?.pauseVfs();
+  pool = undefined;
 }
 
 async function handleExport(): Promise<Uint8Array> {
@@ -125,6 +139,10 @@ function handleDeleteDb(dbName: string): void {
     pool.unlink(path);
   } catch {
     // File may not exist; ignore.
+  }
+  // Guarded because pauseVfs refuses (SQLITE_MISUSE) while any file is open through the VFS.
+  if (!db) {
+    releasePool();
   }
 }
 


### PR DESCRIPTION
Fixes a flake on the SQLite db management browser tests. 