### PR TITLE
fix(docs): resolve a working nargo for aztec-nr doc generation

### DIFF
--- a/docs/scripts/aztec_nr_docs_generation/README.md
+++ b/docs/scripts/aztec_nr_docs_generation/README.md
@@ -20,7 +20,13 @@ Or from the docs root:
 
 ## Requirements
 
-- `nargo` must be available in PATH or set via `NARGO` environment variable
+- A working `nargo`, resolved in this priority order:
+  1. The `NARGO` environment variable, if set (the script fails if it points to a binary that cannot run)
+  2. The repo-built binary at `noir/noir-repo/target/release/nargo`
+  3. `aztec-nargo` in PATH (installed by `aztec-up`, version-matched to the toolchain)
+  4. `nargo` in PATH
+- Each candidate is test-run before being selected, so a binary built for another platform (for example a Linux build in a macOS checkout) is skipped
+- The script warns when the selected nargo was built from a different noir commit than the `noir/noir-repo` submodule pins, since mismatched compilers can fail in opaque ways
 - The `aztec-nr` workspace must be at `../noir-projects/aztec-nr` relative to the docs folder
 
 ## Output

--- a/docs/scripts/aztec_nr_docs_generation/generate_aztec_nr_docs.sh
+++ b/docs/scripts/aztec_nr_docs_generation/generate_aztec_nr_docs.sh
@@ -57,20 +57,36 @@ echo_error() {
     echo -e "${RED}[ERROR]${NC} $1"
 }
 
-# Check if nargo is available
-if ! command -v nargo &> /dev/null; then
-    # Try to use the nargo from the noir-repo if available
-    NARGO="${NARGO:-$DOCS_ROOT/../noir/noir-repo/target/release/nargo}"
+# Resolve which nargo to use, in priority order:
+#   1. $NARGO env var (e.g. exported by docs/bootstrap.sh)
+#   2. The nargo built from the noir submodule
+#   3. aztec-nargo from an aztec toolchain install (version-matched to the toolchain)
+#   4. Any nargo on PATH
+# Candidates are test-run rather than existence-checked because the repo-built
+# binary may target another platform (e.g. a Linux build in a macOS checkout).
+nargo_runs() {
+    "$1" --version &> /dev/null
+}
+
+REPO_NARGO="$DOCS_ROOT/../noir/noir-repo/target/release/nargo"
+if [[ -n "${NARGO:-}" ]]; then
     # Convert to absolute path (important since we cd to aztec-nr directory later)
     if [[ "$NARGO" != /* ]]; then
         NARGO="$(cd "$DOCS_ROOT" && cd "$(dirname "$NARGO")" && pwd)/$(basename "$NARGO")"
     fi
-    if [[ ! -x "$NARGO" ]]; then
-        echo_error "nargo not found. Please ensure nargo is installed or set NARGO environment variable."
+    if ! nargo_runs "$NARGO"; then
+        echo_error "NARGO is set to '$NARGO' but it cannot be executed."
         exit 1
     fi
+elif nargo_runs "$REPO_NARGO"; then
+    NARGO="$REPO_NARGO"
+elif AZTEC_NARGO="$(command -v aztec-nargo 2> /dev/null)" && nargo_runs "$AZTEC_NARGO"; then
+    NARGO="$AZTEC_NARGO"
+elif PATH_NARGO="$(command -v nargo 2> /dev/null)" && nargo_runs "$PATH_NARGO"; then
+    NARGO="$PATH_NARGO"
 else
-    NARGO="nargo"
+    echo_error "No working nargo found. Install the aztec toolchain (aztec-up), build the noir submodule, or set the NARGO environment variable."
+    exit 1
 fi
 
 echo_info "Using nargo: $NARGO"
@@ -79,12 +95,20 @@ echo_info "Version: $VERSION"
 echo_info "Output folder: $OUTPUT_FOLDER"
 echo_info "Output directory: $OUTPUT_DIR"
 
+# A nargo built from a different noir commit than the submodule pins can fail
+# in opaque ways (e.g. stack overflows in `nargo doc`), so warn on mismatch.
+PINNED_NOIR_COMMIT="$(git -C "$DOCS_ROOT/.." ls-tree HEAD noir/noir-repo 2> /dev/null | awk '{print $3}' || true)"
+NARGO_NOIR_COMMIT="$("$NARGO" --version 2> /dev/null | sed -n 's/.*git version hash: \([0-9a-f]*\).*/\1/p' || true)"
+if [[ -n "$PINNED_NOIR_COMMIT" && -n "$NARGO_NOIR_COMMIT" && "$PINNED_NOIR_COMMIT" != "$NARGO_NOIR_COMMIT" ]]; then
+    echo_warn "nargo was built from noir commit ${NARGO_NOIR_COMMIT:0:10} but the noir submodule pins ${PINNED_NOIR_COMMIT:0:10}. Doc generation may fail; use a matching nargo if it does."
+fi
+
 # Change to aztec-nr directory
 cd "$AZTEC_NR_DIR"
 
 # Generate documentation
 echo_info "Generating aztec-nr documentation..."
-$NARGO doc --workspace
+"$NARGO" doc --workspace
 
 # Check if docs were generated
 if [[ ! -d "$AZTEC_NR_DIR/target/docs" ]]; then


### PR DESCRIPTION
## Problem

`yarn start` in `docs/` runs `generate:aztec-nr-api`, which resolved `nargo` as "whatever is first on PATH", and only consulted the `NARGO` env var when no global `nargo` existed. Two failure modes:

- A stale global `nargo` (e.g. 1.0.0-beta.16 vs the pinned 1.0.0-beta.22) wins over everything and crashes `nargo doc --workspace` with an opaque `thread 'main' has overflowed its stack`.
- The `NARGO` export in `docs/bootstrap.sh` was dead code on any machine with a global `nargo` installed.

Additionally, the repo-built binary at `noir/noir-repo/target/release/nargo` can exist but be unrunnable (e.g. a Linux aarch64 build in a macOS checkout), which the old `-x` check did not catch (`Exec format error`).

## Fix

Resolve `nargo` in priority order, test-running each candidate (`--version`) instead of only checking existence:

1. `$NARGO` env var — honored unconditionally; fails loudly if it points to a broken binary
2. The repo-built binary from the noir submodule
3. `aztec-nargo` on PATH (installed by `aztec-up`, version-matched to the toolchain)
4. `nargo` on PATH

Also warn when the selected nargo was built from a different noir commit than the `noir/noir-repo` submodule pins, so version mismatches surface as a readable message instead of a stack overflow.

## Consumers audited

- `docs/bootstrap.sh`: exports `NARGO` — now actually honored (CI's `yarn build` does not invoke this generator, so no CI behavior change).
- `docs/scripts/netlify-preview-build.sh`: installs a version-matched `nargo` onto PATH via noirup; no repo build or `aztec-nargo` exists there, so it resolves via (4) as before.
- Local `yarn start`: now picks `aztec-nargo` instead of a stale global `nargo`.
- Other docs scripts checked for the same pattern: only this script resolves `nargo` (the TypeScript/CLI/node-API generators use typedoc/jq/gh).

## Testing

- `NARGO=/usr/bin/false ./generate_aztec_nr_docs.sh` → `[ERROR] NARGO is set to '/usr/bin/false' but it cannot be executed.`, exit 1 (previously silently ignored in favor of PATH).
- Reproduced the original failure environment (unrunnable Linux ELF at the repo path, stale beta.16 `nargo` on PATH, `aztec-nargo` beta.22 installed): the script skips the ELF, selects `aztec-nargo`, prints the submodule-pin mismatch warning, and generates the docs.
