### PR TITLE
fix: stop parsing the acvm output witness in the server prover

### DIFF
--- a/yarn-project/bb-prover/src/prover/server/bb_prover.ts
+++ b/yarn-project/bb-prover/src/prover/server/bb_prover.ts
@@ -11,39 +11,39 @@ import { runInDirectory } from '@aztec/foundation/fs';
 import { createLogger } from '@aztec/foundation/log';
 import {
   type ServerProtocolArtifact,
-  convertBlockMergeRollupOutputsFromWitnessMap,
+  convertBlockMergeRollupOutputsFromPublicInputFields,
   convertBlockMergeRollupPrivateInputsToWitnessMap,
-  convertBlockRootEmptyTxFirstRollupOutputsFromWitnessMap,
+  convertBlockRootEmptyTxFirstRollupOutputsFromPublicInputFields,
   convertBlockRootEmptyTxFirstRollupPrivateInputsToWitnessMap,
-  convertBlockRootFirstRollupOutputsFromWitnessMap,
+  convertBlockRootFirstRollupOutputsFromPublicInputFields,
   convertBlockRootFirstRollupPrivateInputsToWitnessMap,
-  convertBlockRootRollupOutputsFromWitnessMap,
+  convertBlockRootRollupOutputsFromPublicInputFields,
   convertBlockRootRollupPrivateInputsToWitnessMap,
-  convertBlockRootSingleTxFirstRollupOutputsFromWitnessMap,
+  convertBlockRootSingleTxFirstRollupOutputsFromPublicInputFields,
   convertBlockRootSingleTxFirstRollupPrivateInputsToWitnessMap,
-  convertBlockRootSingleTxRollupOutputsFromWitnessMap,
+  convertBlockRootSingleTxRollupOutputsFromPublicInputFields,
   convertBlockRootSingleTxRollupPrivateInputsToWitnessMap,
-  convertCheckpointMergeRollupOutputsFromWitnessMap,
+  convertCheckpointMergeRollupOutputsFromPublicInputFields,
   convertCheckpointMergeRollupPrivateInputsToWitnessMap,
-  convertCheckpointPaddingRollupOutputsFromWitnessMap,
+  convertCheckpointPaddingRollupOutputsFromPublicInputFields,
   convertCheckpointPaddingRollupPrivateInputsToWitnessMap,
-  convertCheckpointRootRollupOutputsFromWitnessMap,
+  convertCheckpointRootRollupOutputsFromPublicInputFields,
   convertCheckpointRootRollupPrivateInputsToWitnessMap,
-  convertCheckpointRootSingleBlockRollupOutputsFromWitnessMap,
+  convertCheckpointRootSingleBlockRollupOutputsFromPublicInputFields,
   convertCheckpointRootSingleBlockRollupPrivateInputsToWitnessMap,
-  convertParityBaseOutputsFromWitnessMap,
+  convertParityBaseOutputsFromPublicInputFields,
   convertParityBasePrivateInputsToWitnessMap,
-  convertParityRootOutputsFromWitnessMap,
+  convertParityRootOutputsFromPublicInputFields,
   convertParityRootPrivateInputsToWitnessMap,
-  convertPrivateTxBaseRollupOutputsFromWitnessMap,
+  convertPrivateTxBaseRollupOutputsFromPublicInputFields,
   convertPrivateTxBaseRollupPrivateInputsToWitnessMap,
-  convertPublicChonkVerifierOutputsFromWitnessMap,
+  convertPublicChonkVerifierOutputsFromPublicInputFields,
   convertPublicChonkVerifierPrivateInputsToWitnessMap,
-  convertPublicTxBaseRollupOutputsFromWitnessMap,
+  convertPublicTxBaseRollupOutputsFromPublicInputFields,
   convertPublicTxBaseRollupPrivateInputsToWitnessMap,
-  convertRootRollupOutputsFromWitnessMap,
+  convertRootRollupOutputsFromPublicInputFields,
   convertRootRollupPrivateInputsToWitnessMap,
-  convertTxMergeRollupOutputsFromWitnessMap,
+  convertTxMergeRollupOutputsFromPublicInputFields,
   convertTxMergeRollupPrivateInputsToWitnessMap,
   getServerCircuitArtifact,
 } from '@aztec/noir-protocol-circuits-types/server';
@@ -87,8 +87,9 @@ import { VerificationKeyData } from '@aztec/stdlib/vks';
 import { Attributes, type TelemetryClient, getTelemetryClient, trackSpan } from '@aztec/telemetry-client';
 
 import { promises as fs } from 'fs';
-import { ungzip } from 'pako';
 import * as path from 'path';
+import { promisify } from 'util';
+import { gunzip } from 'zlib';
 
 import { BBJsFactory, type BBJsProofResult } from '../../bb/bb_js_backend.js';
 import type { ACVMConfig, BBConfig } from '../../config.js';
@@ -97,6 +98,20 @@ import { ProverInstrumentation } from '../../instrumentation.js';
 import { constructRecursiveProofFromBuffers } from '../proof_utils.js';
 
 const logger = createLogger('bb-prover');
+
+const gunzipAsync = promisify(gunzip);
+
+/** Cache of decompressed circuit bytecode; the bytecode is static per circuit type. */
+const bytecodeCache = new Map<ServerProtocolArtifact, Promise<Buffer>>();
+
+function getDecompressedBytecode(circuitType: ServerProtocolArtifact, bytecodeBase64: string): Promise<Buffer> {
+  let bytecode = bytecodeCache.get(circuitType);
+  if (!bytecode) {
+    bytecode = gunzipAsync(Buffer.from(bytecodeBase64, 'base64'));
+    bytecodeCache.set(circuitType, bytecode);
+  }
+  return bytecode;
+}
 
 export interface BBProverConfig extends BBConfig, ACVMConfig {
   // list of circuits supported by this prover. defaults to all circuits if empty
@@ -147,7 +162,7 @@ export class BBNativeRollupProver implements ServerCircuitProver {
       'ParityBaseArtifact',
       RECURSIVE_PROOF_LENGTH,
       convertParityBasePrivateInputsToWitnessMap,
-      convertParityBaseOutputsFromWitnessMap,
+      convertParityBaseOutputsFromPublicInputFields,
     );
   }
 
@@ -165,7 +180,7 @@ export class BBNativeRollupProver implements ServerCircuitProver {
       'ParityRootArtifact',
       NESTED_RECURSIVE_PROOF_LENGTH,
       convertParityRootPrivateInputsToWitnessMap,
-      convertParityRootOutputsFromWitnessMap,
+      convertParityRootOutputsFromPublicInputFields,
     );
   }
 
@@ -197,7 +212,7 @@ export class BBNativeRollupProver implements ServerCircuitProver {
       artifactName,
       NESTED_RECURSIVE_ROLLUP_HONK_PROOF_LENGTH,
       convertPublicChonkVerifierPrivateInputsToWitnessMap,
-      convertPublicChonkVerifierOutputsFromWitnessMap,
+      convertPublicChonkVerifierOutputsFromPublicInputFields,
     );
 
     const verificationKey = this.getVerificationKeyDataForCircuit(artifactName);
@@ -220,7 +235,7 @@ export class BBNativeRollupProver implements ServerCircuitProver {
       'PrivateTxBaseRollupArtifact',
       NESTED_RECURSIVE_ROLLUP_HONK_PROOF_LENGTH,
       convertPrivateTxBaseRollupPrivateInputsToWitnessMap,
-      convertPrivateTxBaseRollupOutputsFromWitnessMap,
+      convertPrivateTxBaseRollupOutputsFromPublicInputFields,
     );
   }
 
@@ -237,7 +252,7 @@ export class BBNativeRollupProver implements ServerCircuitProver {
       'PublicTxBaseRollupArtifact',
       NESTED_RECURSIVE_ROLLUP_HONK_PROOF_LENGTH,
       convertPublicTxBaseRollupPrivateInputsToWitnessMap,
-      convertPublicTxBaseRollupOutputsFromWitnessMap,
+      convertPublicTxBaseRollupOutputsFromPublicInputFields,
     );
   }
 
@@ -254,7 +269,7 @@ export class BBNativeRollupProver implements ServerCircuitProver {
       'TxMergeRollupArtifact',
       NESTED_RECURSIVE_ROLLUP_HONK_PROOF_LENGTH,
       convertTxMergeRollupPrivateInputsToWitnessMap,
-      convertTxMergeRollupOutputsFromWitnessMap,
+      convertTxMergeRollupOutputsFromPublicInputFields,
     );
   }
 
@@ -266,7 +281,7 @@ export class BBNativeRollupProver implements ServerCircuitProver {
       'BlockRootFirstRollupArtifact',
       NESTED_RECURSIVE_ROLLUP_HONK_PROOF_LENGTH,
       convertBlockRootFirstRollupPrivateInputsToWitnessMap,
-      convertBlockRootFirstRollupOutputsFromWitnessMap,
+      convertBlockRootFirstRollupOutputsFromPublicInputFields,
     );
   }
 
@@ -278,7 +293,7 @@ export class BBNativeRollupProver implements ServerCircuitProver {
       'BlockRootSingleTxFirstRollupArtifact',
       NESTED_RECURSIVE_ROLLUP_HONK_PROOF_LENGTH,
       convertBlockRootSingleTxFirstRollupPrivateInputsToWitnessMap,
-      convertBlockRootSingleTxFirstRollupOutputsFromWitnessMap,
+      convertBlockRootSingleTxFirstRollupOutputsFromPublicInputFields,
     );
   }
 
@@ -290,7 +305,7 @@ export class BBNativeRollupProver implements ServerCircuitProver {
       'BlockRootEmptyTxFirstRollupArtifact',
       NESTED_RECURSIVE_ROLLUP_HONK_PROOF_LENGTH,
       convertBlockRootEmptyTxFirstRollupPrivateInputsToWitnessMap,
-      convertBlockRootEmptyTxFirstRollupOutputsFromWitnessMap,
+      convertBlockRootEmptyTxFirstRollupOutputsFromPublicInputFields,
     );
   }
 
@@ -302,7 +317,7 @@ export class BBNativeRollupProver implements ServerCircuitProver {
       'BlockRootRollupArtifact',
       NESTED_RECURSIVE_ROLLUP_HONK_PROOF_LENGTH,
       convertBlockRootRollupPrivateInputsToWitnessMap,
-      convertBlockRootRollupOutputsFromWitnessMap,
+      convertBlockRootRollupOutputsFromPublicInputFields,
     );
   }
 
@@ -314,7 +329,7 @@ export class BBNativeRollupProver implements ServerCircuitProver {
       'BlockRootSingleTxRollupArtifact',
       NESTED_RECURSIVE_ROLLUP_HONK_PROOF_LENGTH,
       convertBlockRootSingleTxRollupPrivateInputsToWitnessMap,
-      convertBlockRootSingleTxRollupOutputsFromWitnessMap,
+      convertBlockRootSingleTxRollupOutputsFromPublicInputFields,
     );
   }
 
@@ -326,7 +341,7 @@ export class BBNativeRollupProver implements ServerCircuitProver {
       'BlockMergeRollupArtifact',
       NESTED_RECURSIVE_ROLLUP_HONK_PROOF_LENGTH,
       convertBlockMergeRollupPrivateInputsToWitnessMap,
-      convertBlockMergeRollupOutputsFromWitnessMap,
+      convertBlockMergeRollupOutputsFromPublicInputFields,
     );
   }
 
@@ -340,7 +355,7 @@ export class BBNativeRollupProver implements ServerCircuitProver {
       'CheckpointRootRollupArtifact',
       NESTED_RECURSIVE_ROLLUP_HONK_PROOF_LENGTH,
       convertCheckpointRootRollupPrivateInputsToWitnessMap,
-      convertCheckpointRootRollupOutputsFromWitnessMap,
+      convertCheckpointRootRollupOutputsFromPublicInputFields,
     );
   }
 
@@ -354,7 +369,7 @@ export class BBNativeRollupProver implements ServerCircuitProver {
       'CheckpointRootSingleBlockRollupArtifact',
       NESTED_RECURSIVE_ROLLUP_HONK_PROOF_LENGTH,
       convertCheckpointRootSingleBlockRollupPrivateInputsToWitnessMap,
-      convertCheckpointRootSingleBlockRollupOutputsFromWitnessMap,
+      convertCheckpointRootSingleBlockRollupOutputsFromPublicInputFields,
     );
   }
 
@@ -368,7 +383,7 @@ export class BBNativeRollupProver implements ServerCircuitProver {
       'CheckpointPaddingRollupArtifact',
       NESTED_RECURSIVE_ROLLUP_HONK_PROOF_LENGTH,
       convertCheckpointPaddingRollupPrivateInputsToWitnessMap,
-      convertCheckpointPaddingRollupOutputsFromWitnessMap,
+      convertCheckpointPaddingRollupOutputsFromPublicInputFields,
     );
   }
 
@@ -382,7 +397,7 @@ export class BBNativeRollupProver implements ServerCircuitProver {
       'CheckpointMergeRollupArtifact',
       NESTED_RECURSIVE_ROLLUP_HONK_PROOF_LENGTH,
       convertCheckpointMergeRollupPrivateInputsToWitnessMap,
-      convertCheckpointMergeRollupOutputsFromWitnessMap,
+      convertCheckpointMergeRollupOutputsFromPublicInputFields,
     );
   }
 
@@ -399,7 +414,7 @@ export class BBNativeRollupProver implements ServerCircuitProver {
       'RootRollupArtifact',
       ULTRA_KECCAK_PROOF_LENGTH,
       convertRootRollupPrivateInputsToWitnessMap,
-      convertRootRollupOutputsFromWitnessMap,
+      convertRootRollupOutputsFromPublicInputFields,
     );
 
     const recursiveProof = makeRecursiveProofFromBinary(proof.binaryProof, NESTED_RECURSIVE_PROOF_LENGTH);
@@ -418,7 +433,7 @@ export class BBNativeRollupProver implements ServerCircuitProver {
     artifactName: ServerProtocolArtifact,
     proofLength: PROOF_LENGTH,
     convertInput: (input: CircuitInputType) => WitnessMap,
-    convertOutput: (outputWitness: WitnessMap) => CircuitOutputType,
+    convertOutput: (publicInputFields: Uint8Array[]) => CircuitOutputType,
   ) {
     const { circuitOutput, proof } = await this.createRecursiveProof(
       input,
@@ -442,7 +457,7 @@ export class BBNativeRollupProver implements ServerCircuitProver {
     input: Input,
     circuitType: ServerProtocolArtifact,
     convertInput: (input: Input) => WitnessMap,
-    convertOutput: (outputWitness: WitnessMap) => Output,
+    convertOutput: (publicInputFields: Uint8Array[]) => Output,
     workingDirectory: string,
   ): Promise<{ circuitOutput: Output; proofResult: BBJsProofResult }> {
     // Have the ACVM write the partial witness here (still needs a temp directory)
@@ -461,29 +476,16 @@ export class BBNativeRollupProver implements ServerCircuitProver {
     logger.debug(`Generating witness data for ${circuitType}`);
 
     const inputWitness = convertInput(input);
-    const foreignCallHandler = undefined;
-    const witnessResult = await simulator.executeProtocolCircuit(inputWitness, artifact, foreignCallHandler);
-    const output = convertOutput(witnessResult.witness);
+    const witnessResult = await simulator.executeProtocolCircuitToWitnessFile(inputWitness, artifact);
 
-    const circuitName = mapProtocolArtifactNameToCircuitName(circuitType);
-    this.instrumentation.recordDuration('witGenDuration', circuitName, witnessResult.duration);
-    this.instrumentation.recordSize('witGenInputSize', circuitName, input.toBuffer().length);
-    this.instrumentation.recordSize('witGenOutputSize', circuitName, output.toBuffer().length);
-
-    logger.info(`Generated witness`, {
-      circuitName,
-      duration: witnessResult.duration,
-      inputSize: input.toBuffer().length,
-      outputSize: output.toBuffer().length,
-      eventName: 'circuit-witness-generation',
-    } satisfies CircuitWitnessGenerationStats);
-
-    // Read and decompress the witness for bb.js
-    const witnessGz = await fs.readFile(outputWitnessFile);
-    const witness = ungzip(witnessGz);
+    // Read and decompress the witness for bb.js. The gzip magic check keeps this forward-compatible with the ACVM
+    // output witness compression being removed.
+    const witnessFileData = await fs.readFile(outputWitnessFile);
+    const witness =
+      witnessFileData[0] === 0x1f && witnessFileData[1] === 0x8b ? await gunzipAsync(witnessFileData) : witnessFileData;
 
     // Decompress bytecode for bb.js
-    const bytecode = ungzip(Buffer.from(artifact.bytecode, 'base64'));
+    const bytecode = await getDecompressedBytecode(circuitType, artifact.bytecode);
 
     // Prove the circuit via bb.js API
     logger.debug(`Proving ${circuitType} via bb.js...`);
@@ -501,6 +503,23 @@ export class BBNativeRollupProver implements ServerCircuitProver {
     } catch (error) {
       throw new ProvingError(`Failed to generate proof for ${circuitType}: ${error}`);
     }
+
+    // The circuit outputs are the proof's public inputs; decode them from there instead of parsing the full output
+    // witness generated by the ACVM.
+    const output = convertOutput(proofResult.publicInputFields);
+
+    const circuitName = mapProtocolArtifactNameToCircuitName(circuitType);
+    this.instrumentation.recordDuration('witGenDuration', circuitName, witnessResult.duration);
+    this.instrumentation.recordSize('witGenInputSize', circuitName, input.toBuffer().length);
+    this.instrumentation.recordSize('witGenOutputSize', circuitName, output.toBuffer().length);
+
+    logger.info(`Generated witness`, {
+      circuitName,
+      duration: witnessResult.duration,
+      inputSize: input.toBuffer().length,
+      outputSize: output.toBuffer().length,
+      eventName: 'circuit-witness-generation',
+    } satisfies CircuitWitnessGenerationStats);
 
     return {
       circuitOutput: output,
@@ -560,7 +579,7 @@ export class BBNativeRollupProver implements ServerCircuitProver {
    * @param circuitType - The type of circuit to be executed
    * @param proofLength - The length of the proof to be generated. This is a dummy parameter to aid in type checking
    * @param convertInput - Function for mapping the input object to a witness map.
-   * @param convertOutput - Function for parsing the output witness to it's corresponding object
+   * @param convertOutput - Function for decoding the circuit outputs from the proof's public input fields
    * @returns The circuits output object and it's proof
    */
   private async createRecursiveProof<
@@ -572,7 +591,7 @@ export class BBNativeRollupProver implements ServerCircuitProver {
     circuitType: ServerProtocolArtifact,
     proofLength: PROOF_LENGTH,
     convertInput: (input: CircuitInputType) => WitnessMap,
-    convertOutput: (outputWitness: WitnessMap) => CircuitOutputType,
+    convertOutput: (publicInputFields: Uint8Array[]) => CircuitOutputType,
   ): Promise<{ circuitOutput: CircuitOutputType; proof: RecursiveProof<PROOF_LENGTH> }> {
     // Still need runInDirectory for ACVM witness generation temp files
     const operation = async (workingDirectory: string) => {

--- a/yarn-project/noir-protocol-circuits-types/src/execution/server.test.ts
+++ b/yarn-project/noir-protocol-circuits-types/src/execution/server.test.ts
@@ -1,0 +1,35 @@
+import { Fr } from '@aztec/foundation/curves/bn254';
+import { executeCircuit } from '@aztec/noir-acvm_js';
+import { ParityPublicInputs } from '@aztec/stdlib/parity';
+import { makeParityBasePrivateInputs } from '@aztec/stdlib/testing';
+
+import { ServerCircuitArtifacts } from '../artifacts/server.js';
+import { foreignCallHandler } from '../utils/server/foreign_call_handler.js';
+import {
+  convertParityBaseOutputsFromPublicInputFields,
+  convertParityBaseOutputsFromWitnessMap,
+  convertParityBasePrivateInputsToWitnessMap,
+} from './server.js';
+
+describe('convertOutputsFromPublicInputFields', () => {
+  it('decodes ParityBase outputs from proof public input fields identically to the witness map decode', async () => {
+    const inputs = makeParityBasePrivateInputs(/*seed=*/ 1);
+    const inputWitness = convertParityBasePrivateInputsToWitnessMap(inputs);
+    const bytecode = Buffer.from(ServerCircuitArtifacts.ParityBaseArtifact.bytecode, 'base64');
+    const outputWitness = await executeCircuit(bytecode, inputWitness, foreignCallHandler);
+
+    const expected = convertParityBaseOutputsFromWitnessMap(outputWitness);
+
+    // bb returns the circuit's public inputs as an ordered field array: the return values (laid out right after the
+    // parameter witnesses), possibly followed by recursion artifacts such as pairing points. Reconstruct that array
+    // from the executed witness, including trailing non-return witnesses to check the decode ignores them.
+    const numParameterWitnesses = inputWitness.size;
+    const numReturnFields = ParityPublicInputs.getFields(expected).length;
+    const publicInputFields: Uint8Array[] = [];
+    for (let i = numParameterWitnesses; i < numParameterWitnesses + numReturnFields + 4; i++) {
+      publicInputFields.push(new Uint8Array(Fr.fromString(outputWitness.get(i)!).toBuffer()));
+    }
+
+    expect(convertParityBaseOutputsFromPublicInputFields(publicInputFields)).toEqual(expected);
+  });
+});

--- a/yarn-project/noir-protocol-circuits-types/src/execution/server.ts
+++ b/yarn-project/noir-protocol-circuits-types/src/execution/server.ts
@@ -460,6 +460,196 @@ export function convertParityRootOutputsFromWitnessMap(outputs: WitnessMap, simu
   return mapParityPublicInputsFromNoir(publicInputs);
 }
 
+/** Decodes the outputs of the base parity circuit from the ordered public input fields of its proof. */
+export function convertParityBaseOutputsFromPublicInputFields(publicInputFields: Uint8Array[]): ParityPublicInputs {
+  const publicInputs = convertOutputsFromPublicInputFields<ParityBaseReturnType>(
+    'ParityBaseArtifact',
+    publicInputFields,
+  );
+  return mapParityPublicInputsFromNoir(publicInputs);
+}
+
+/** Decodes the outputs of the root parity circuit from the ordered public input fields of its proof. */
+export function convertParityRootOutputsFromPublicInputFields(publicInputFields: Uint8Array[]): ParityPublicInputs {
+  const publicInputs = convertOutputsFromPublicInputFields<ParityRootReturnType>(
+    'ParityRootArtifact',
+    publicInputFields,
+  );
+  return mapParityPublicInputsFromNoir(publicInputs);
+}
+
+/** Decodes the outputs of the public chonk verifier circuit from the ordered public input fields of its proof. */
+export function convertPublicChonkVerifierOutputsFromPublicInputFields(
+  publicInputFields: Uint8Array[],
+): PublicChonkVerifierPublicInputs {
+  const publicInputs = convertOutputsFromPublicInputFields<ChonkVerifierPublicReturnType>(
+    'PublicChonkVerifier',
+    publicInputFields,
+  );
+  return mapPublicChonkVerifierPublicInputsFromNoir(publicInputs);
+}
+
+/** Decodes the outputs of the private tx base rollup circuit from the ordered public input fields of its proof. */
+export function convertPrivateTxBaseRollupOutputsFromPublicInputFields(
+  publicInputFields: Uint8Array[],
+): TxRollupPublicInputs {
+  const publicInputs = convertOutputsFromPublicInputFields<RollupTxBasePrivateReturnType>(
+    'PrivateTxBaseRollupArtifact',
+    publicInputFields,
+  );
+  return mapTxRollupPublicInputsFromNoir(publicInputs);
+}
+
+/** Decodes the outputs of the public tx base rollup circuit from the ordered public input fields of its proof. */
+export function convertPublicTxBaseRollupOutputsFromPublicInputFields(
+  publicInputFields: Uint8Array[],
+): TxRollupPublicInputs {
+  const publicInputs = convertOutputsFromPublicInputFields<RollupTxBasePublicReturnType>(
+    'PublicTxBaseRollupArtifact',
+    publicInputFields,
+  );
+  return mapTxRollupPublicInputsFromNoir(publicInputs);
+}
+
+/** Decodes the outputs of the tx merge rollup circuit from the ordered public input fields of its proof. */
+export function convertTxMergeRollupOutputsFromPublicInputFields(
+  publicInputFields: Uint8Array[],
+): TxRollupPublicInputs {
+  const publicInputs = convertOutputsFromPublicInputFields<RollupTxMergeReturnType>(
+    'TxMergeRollupArtifact',
+    publicInputFields,
+  );
+  return mapTxRollupPublicInputsFromNoir(publicInputs);
+}
+
+/** Decodes the outputs of the first block root rollup circuit from the ordered public input fields of its proof. */
+export function convertBlockRootFirstRollupOutputsFromPublicInputFields(
+  publicInputFields: Uint8Array[],
+): BlockRollupPublicInputs {
+  const publicInputs = convertOutputsFromPublicInputFields<RollupBlockRootFirstReturnType>(
+    'BlockRootFirstRollupArtifact',
+    publicInputFields,
+  );
+  return mapBlockRollupPublicInputsFromNoir(publicInputs);
+}
+
+/**
+ * Decodes the outputs of the first single-tx block root rollup circuit from the ordered public input fields of its
+ * proof.
+ */
+export function convertBlockRootSingleTxFirstRollupOutputsFromPublicInputFields(
+  publicInputFields: Uint8Array[],
+): BlockRollupPublicInputs {
+  const publicInputs = convertOutputsFromPublicInputFields<RollupBlockRootFirstSingleTxReturnType>(
+    'BlockRootSingleTxFirstRollupArtifact',
+    publicInputFields,
+  );
+  return mapBlockRollupPublicInputsFromNoir(publicInputs);
+}
+
+/**
+ * Decodes the outputs of the first empty-tx block root rollup circuit from the ordered public input fields of its
+ * proof.
+ */
+export function convertBlockRootEmptyTxFirstRollupOutputsFromPublicInputFields(
+  publicInputFields: Uint8Array[],
+): BlockRollupPublicInputs {
+  const publicInputs = convertOutputsFromPublicInputFields<RollupBlockRootFirstEmptyTxReturnType>(
+    'BlockRootEmptyTxFirstRollupArtifact',
+    publicInputFields,
+  );
+  return mapBlockRollupPublicInputsFromNoir(publicInputs);
+}
+
+/** Decodes the outputs of the block root rollup circuit from the ordered public input fields of its proof. */
+export function convertBlockRootRollupOutputsFromPublicInputFields(
+  publicInputFields: Uint8Array[],
+): BlockRollupPublicInputs {
+  const publicInputs = convertOutputsFromPublicInputFields<RollupBlockRootReturnType>(
+    'BlockRootRollupArtifact',
+    publicInputFields,
+  );
+  return mapBlockRollupPublicInputsFromNoir(publicInputs);
+}
+
+/** Decodes the outputs of the single-tx block root rollup circuit from the ordered public input fields of its proof. */
+export function convertBlockRootSingleTxRollupOutputsFromPublicInputFields(
+  publicInputFields: Uint8Array[],
+): BlockRollupPublicInputs {
+  const publicInputs = convertOutputsFromPublicInputFields<RollupBlockRootSingleTxReturnType>(
+    'BlockRootSingleTxRollupArtifact',
+    publicInputFields,
+  );
+  return mapBlockRollupPublicInputsFromNoir(publicInputs);
+}
+
+/** Decodes the outputs of the block merge rollup circuit from the ordered public input fields of its proof. */
+export function convertBlockMergeRollupOutputsFromPublicInputFields(
+  publicInputFields: Uint8Array[],
+): BlockRollupPublicInputs {
+  const publicInputs = convertOutputsFromPublicInputFields<RollupBlockMergeReturnType>(
+    'BlockMergeRollupArtifact',
+    publicInputFields,
+  );
+  return mapBlockRollupPublicInputsFromNoir(publicInputs);
+}
+
+/** Decodes the outputs of the checkpoint root rollup circuit from the ordered public input fields of its proof. */
+export function convertCheckpointRootRollupOutputsFromPublicInputFields(
+  publicInputFields: Uint8Array[],
+): CheckpointRollupPublicInputs {
+  const publicInputs = convertOutputsFromPublicInputFields<RollupCheckpointRootReturnType>(
+    'CheckpointRootRollupArtifact',
+    publicInputFields,
+  );
+  return mapCheckpointRollupPublicInputsFromNoir(publicInputs);
+}
+
+/**
+ * Decodes the outputs of the single-block checkpoint root rollup circuit from the ordered public input fields of its
+ * proof.
+ */
+export function convertCheckpointRootSingleBlockRollupOutputsFromPublicInputFields(
+  publicInputFields: Uint8Array[],
+): CheckpointRollupPublicInputs {
+  const publicInputs = convertOutputsFromPublicInputFields<RollupCheckpointRootSingleBlockReturnType>(
+    'CheckpointRootSingleBlockRollupArtifact',
+    publicInputFields,
+  );
+  return mapCheckpointRollupPublicInputsFromNoir(publicInputs);
+}
+
+/** Decodes the outputs of the checkpoint padding rollup circuit from the ordered public input fields of its proof. */
+export function convertCheckpointPaddingRollupOutputsFromPublicInputFields(
+  publicInputFields: Uint8Array[],
+): CheckpointRollupPublicInputs {
+  const publicInputs = convertOutputsFromPublicInputFields<RollupCheckpointRootReturnType>(
+    'CheckpointPaddingRollupArtifact',
+    publicInputFields,
+  );
+  return mapCheckpointRollupPublicInputsFromNoir(publicInputs);
+}
+
+/** Decodes the outputs of the checkpoint merge rollup circuit from the ordered public input fields of its proof. */
+export function convertCheckpointMergeRollupOutputsFromPublicInputFields(
+  publicInputFields: Uint8Array[],
+): CheckpointRollupPublicInputs {
+  const publicInputs = convertOutputsFromPublicInputFields<RollupCheckpointMergeReturnType>(
+    'CheckpointMergeRollupArtifact',
+    publicInputFields,
+  );
+  return mapCheckpointRollupPublicInputsFromNoir(publicInputs);
+}
+
+/** Decodes the outputs of the root rollup circuit from the ordered public input fields of its proof. */
+export function convertRootRollupOutputsFromPublicInputFields(publicInputFields: Uint8Array[]): RootRollupPublicInputs {
+  const publicInputs = convertOutputsFromPublicInputFields<RollupRootReturnType>(
+    'RootRollupArtifact',
+    publicInputFields,
+  );
+  return mapRootRollupPublicInputsFromNoir(publicInputs);
+}
+
 function convertPrivateInputsToWitnessMap<InputsType>(
   artifactName: ServerProtocolArtifact,
   inputs: InputsType,
@@ -480,5 +670,21 @@ function convertOutputsFromWitnessMap<ReturnType>(
   // Decode the witness map into two fields, the return values and the inputs.
   const decoded: DecodedInputs = abiDecode(abi, outputs);
   // Cast the return value as the return type.
+  return decoded.return_value;
+}
+
+/**
+ * Decodes circuit outputs from the ordered public input fields of a proof. For server circuits the public inputs are
+ * the circuit's return values, possibly followed by recursion artifacts such as pairing points, which the decode
+ * ignores. Decoding against a parameters-stripped ABI reads the return values from index 0 in ABI declaration order.
+ */
+function convertOutputsFromPublicInputFields<ReturnType>(
+  artifactName: ServerProtocolArtifact,
+  publicInputFields: Uint8Array[],
+): ReturnType {
+  const abi = ServerCircuitArtifacts[artifactName].abi;
+  const witnessMap: WitnessMap = new Map();
+  publicInputFields.forEach((field, i) => witnessMap.set(i, `0x${Buffer.from(field).toString('hex')}`));
+  const decoded: DecodedInputs = abiDecode({ ...abi, parameters: [] }, witnessMap);
   return decoded.return_value;
 }

--- a/yarn-project/simulator/src/private/acvm_native.ts
+++ b/yarn-project/simulator/src/private/acvm_native.ts
@@ -144,6 +144,91 @@ export async function executeNativeCircuit(
   }
 }
 
+/**
+ * Executes a circuit with the native ACVM and leaves the output witness in a file, without parsing it. Unlike
+ * `executeNativeCircuit` this does not pass `--print`, so the (potentially huge) output witness is never buffered on
+ * stdout nor parsed into a map — callers that only need the witness file (e.g. the server prover, which recovers the
+ * circuit outputs from the proof's public inputs) skip that cost entirely.
+ * @param inputWitness - The circuit's input witness
+ * @param bytecode - The circuit bytecode
+ * @param workingDirectory - A directory to use for temporary files by the ACVM
+ * @param pathToAcvm - The path to the ACVM binary
+ * @param outputFilename - The file to store the output witness in, encoded using Bincode
+ */
+export async function executeNativeCircuitToWitnessFile(
+  inputWitness: WitnessMap,
+  bytecode: Buffer,
+  workingDirectory: string,
+  pathToAcvm: string,
+  outputFilename: string,
+  loggerOrBindings?: Logger | LoggerBindings,
+): Promise<Omit<ACVMSuccess, 'witness'> | ACVMFailure> {
+  const logger = resolveLogger('simulator:acvm-native', loggerOrBindings);
+  const bytecodeFilename = 'bytecode';
+  const witnessFilename = 'input_witness.toml';
+
+  // convert the witness map to TOML format
+  const witnessLines: string[] = [];
+  inputWitness.forEach((value: string, key: number) => {
+    witnessLines.push(`${key} = '${value}'`);
+  });
+
+  try {
+    // Check that the directory exists
+    await fs.access(workingDirectory);
+  } catch {
+    return { status: ACVM_RESULT.FAILURE, reason: `Working directory ${workingDirectory} does not exist` };
+  }
+
+  try {
+    // Write the bytecode and input witness to the working directory
+    await fs.writeFile(`${workingDirectory}/${bytecodeFilename}`, bytecode);
+    await fs.writeFile(`${workingDirectory}/${witnessFilename}`, witnessLines.join('\n'));
+
+    // Execute the ACVM using the given args
+    const args = [
+      `execute`,
+      `--working-directory`,
+      `${workingDirectory}`,
+      `--bytecode`,
+      `${bytecodeFilename}`,
+      `--input-witness`,
+      `${witnessFilename}`,
+      '--output-witness',
+      'output-witness',
+    ];
+
+    logger.debug(`Calling ACVM with ${args.join(' ')}`);
+
+    const processPromise = new Promise<void>((resolve, reject) => {
+      const errChunks: Buffer[] = [];
+      let errLen = 0;
+      const acvm = proc.spawn(pathToAcvm, args);
+      acvm.stderr.on('data', (data: Buffer) => {
+        errChunks.push(data);
+        errLen += data.length;
+      });
+      acvm.on('close', code => {
+        if (code === 0) {
+          resolve();
+        } else {
+          const stderr = Buffer.concat(errChunks, errLen).toString('utf-8');
+          logger.error(`From ACVM: ${stderr}`);
+          reject(stderr);
+        }
+      });
+    });
+
+    const timer = new Timer();
+    await processPromise;
+    const duration = timer.ms();
+    await fs.copyFile(`${workingDirectory}/output-witness.gz`, outputFilename);
+    return { status: ACVM_RESULT.SUCCESS, duration };
+  } catch (error) {
+    return { status: ACVM_RESULT.FAILURE, reason: `${error}` };
+  }
+}
+
 export class NativeACVMSimulator implements CircuitSimulator {
   private logger: Logger;
 
@@ -185,6 +270,43 @@ export class NativeACVMSimulator implements CircuitSimulator {
       }
 
       return result;
+    };
+
+    return await runInDirectory(this.workingDirectory, operation, false, this.logger);
+  }
+
+  /**
+   * Executes a protocol circuit natively and writes the output witness to the configured witness file, without
+   * parsing the witness. Callers that only need the witness file (e.g. the server prover, which recovers the circuit
+   * outputs from the proof's public inputs) avoid buffering and parsing the full output witness.
+   */
+  async executeProtocolCircuitToWitnessFile(
+    input: ACVMWitness,
+    artifact: NoirCompiledCircuitWithName,
+  ): Promise<{ duration: number }> {
+    const witnessFilename = this.witnessFilename;
+    if (!witnessFilename) {
+      throw new Error('A witness filename is required to execute a circuit to a witness file');
+    }
+
+    const operation = async (directory: string) => {
+      // Decode the bytecode from base64 since the acvm does not know about base64 encoding
+      const decodedBytecode = Buffer.from(artifact.bytecode, 'base64');
+      // Execute the circuit
+      const result = await executeNativeCircuitToWitnessFile(
+        input,
+        decodedBytecode,
+        directory,
+        this.pathToAcvm,
+        witnessFilename,
+        this.logger,
+      );
+
+      if (result.status == ACVM_RESULT.FAILURE) {
+        throw new Error(`Failed to generate witness: ${result.reason}`);
+      }
+
+      return { duration: result.duration };
     };
 
     return await runInDirectory(this.workingDirectory, operation, false, this.logger);


### PR DESCRIPTION
# fix: stop parsing the acvm output witness in the server prover

## Problem

`BBNativeRollupProver.generateProofWithBB` pays several avoidable main-thread costs on every server proof:

- `NativeACVMSimulator` runs the ACVM with `--print`, buffers the entire output witness (~600k entries for the large rollup circuits) on stdout as text, and parses it into a JS `Map` — the code's own TODO calls this out. That map exists only to feed `convertOutput`.
- `convertOutput(witnessMap)` then runs a full ABI decode, including re-decoding the entire parameter set we already hold as typed objects, just to extract a few hundred public-output fields.
- The ~40MB output witness file is decompressed with synchronous pako on the main thread.
- The static circuit bytecode is re-decompressed with pako on every call.

These costs are invisible at low concurrency (hidden behind multi-second proofs), but under heavy multi-proof admission they serialize job admission on the node main thread. In an external prover harness running this exact data path against v5 nightlies, profiling showed the main thread plus V8 workers pinned for minutes on pako inflate, witness parsing, `Buffer`-per-witness-entry allocation, and noirc_abi WASM, while a 160-core box idled at 15–25%.

## Change

- **noir-protocol-circuits-types**: new `convert<X>OutputsFromPublicInputFields` converters (one per server circuit) that decode the circuit outputs from the ordered public input fields bb already returns with the proof (`BBJsProofResult.publicInputFields`). For these circuits the public inputs are the return values in witness-index order: decoding against a parameters-stripped ABI reads them from index 0 in ABI declaration order, and trailing recursion artifacts (e.g. pairing points) are ignored by the decode.
- **simulator**: a parse-free native ACVM execution mode (`executeNativeCircuitToWitnessFile` / `NativeACVMSimulator.executeProtocolCircuitToWitnessFile`) that omits `--print` and only produces the output witness file. Purely additive; `executeProtocolCircuit` and its other callers are unchanged.
- **bb-prover**: `generateProofWithBB` uses the parse-free ACVM mode, decodes `circuitOutput` from `proofResult.publicInputFields` via the new converters, gunzips the witness with async `node:zlib` (moving the inflate to the UV pool) behind a gzip magic check (forward-compatible with removal of ACVM output compression), and caches decompressed circuit bytecode per circuit type.

## Validation

- New unit test in `noir-protocol-circuits-types` executes the real ParityBase circuit and asserts the fields-based decode equals the existing witness-map decode, including that trailing non-return fields are ignored.
- `prover-client` `bb_prover_parity.test.ts` (real bb + acvm binaries) passes: base parity proofs, whose outputs are decoded via the new path, feed root parity, so recursion verifies output correctness end-to-end.
- `prover-client` `bb_prover_full_rollup.test.ts` (full epoch: parity, block root, checkpoint root/padding/merge, root rollup — all with real proving and recursion) passes.
- Full `noir-protocol-circuits-types` and `simulator` suites pass; `yarn build` clean.

## Perf

Numbers below were measured in a downstream prover harness that runs this identical data path (same decode, same parse-free ACVM invocation) on v5 nightlies, proving full epochs across all 18 server circuits — not re-measured inside this repo:

- Node process during heavy multi-proof admission: from ~5 cores pinned to ~8% of one core.
- End-to-end epoch proving throughput roughly doubled on a 160-core machine (proof admission no longer serialized behind main-thread witness handling).
