### PR TITLE
feat(txe): add option to authorize all utility call targets

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
@@ -98,6 +98,7 @@ pub struct TestEnvironment {
 pub struct TestEnvironmentOptions {
     default_unconstrained_tagging_secret_strategy: Option<TaggingSecretStrategy>,
     default_constrained_tagging_secret_strategy: Option<TaggingSecretStrategy>,
+    authorize_all_utility_call_targets: bool,
 }
 
 impl TestEnvironmentOptions {
@@ -106,6 +107,7 @@ impl TestEnvironmentOptions {
         Self {
             default_unconstrained_tagging_secret_strategy: Option::none(),
             default_constrained_tagging_secret_strategy: Option::none(),
+            authorize_all_utility_call_targets: false,
         }
     }
 
@@ -135,6 +137,18 @@ impl TestEnvironmentOptions {
     pub fn with_default_tag_secret_strategy_all_modes(&mut self, strategy: TaggingSecretStrategy) -> Self {
         let _ = self.with_default_tag_secret_strategy(OnchainDeliveryMode::onchain_unconstrained(), strategy);
         self.with_default_tag_secret_strategy(OnchainDeliveryMode::onchain_constrained(), strategy)
+    }
+
+    /// Authorizes all cross-contract utility call targets for the entire test.
+    ///
+    /// Removes the need to list targets on each call via
+    /// [`CallPrivateOptions::with_authorized_utility_call_targets`] and its siblings.
+    ///
+    /// By default, cross-contract utility calls are denied, mirroring a wallet that authorizes no such call. Use
+    /// this in tests that do not care about utility call authorization.
+    pub fn with_all_utility_call_targets_authorized(&mut self) -> Self {
+        self.authorize_all_utility_call_targets = true;
+        *self
     }
 }
 
@@ -646,6 +660,8 @@ impl TestEnvironment {
             options.default_unconstrained_tagging_secret_strategy,
             options.default_constrained_tagging_secret_strategy,
         );
+
+        txe_oracles::set_authorize_all_utility_call_targets(options.authorize_all_utility_call_targets);
 
         Self {
             // Use an offset to avoid secret collision with account secrets. Without this, when

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/txe_oracles.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/txe_oracles.nr
@@ -22,7 +22,7 @@ use crate::protocol::{
 ///
 /// The TypeScript counterparts are in `yarn-project/txe/src/txe_oracle_version.ts`.
 pub global TXE_ORACLE_VERSION_MAJOR: Field = 3;
-pub global TXE_ORACLE_VERSION_MINOR: Field = 0;
+pub global TXE_ORACLE_VERSION_MINOR: Field = 1;
 
 /// Asserts that the TXE oracle interface version is compatible.
 pub unconstrained fn assert_compatible_txe_oracle_version() {
@@ -270,6 +270,9 @@ pub unconstrained fn set_tagging_secret_strategies(
     unconstrained_strategy: Option<TaggingSecretStrategy>,
     constrained_strategy: Option<TaggingSecretStrategy>,
 ) {}
+
+#[oracle(aztec_txe_setAuthorizeAllUtilityCallTargets)]
+pub unconstrained fn set_authorize_all_utility_call_targets(authorize_all: bool) {}
 
 #[oracle(aztec_txe_privateCallNewFlow)]
 unconstrained fn private_call_new_flow_oracle<let M: u32, let N: u32, let S: u32, let T: u32>(

--- a/noir-projects/noir-contracts/contracts/test/nested_utility_contract/src/test.nr
+++ b/noir-projects/noir-contracts/contracts/test/nested_utility_contract/src/test.nr
@@ -1,11 +1,19 @@
 use crate::NestedUtility;
 use aztec::{
     protocol::{address::AztecAddress, traits::FromField},
-    test::helpers::test_environment::{CallPrivateOptions, ExecuteUtilityOptions, TestEnvironment, ViewPrivateOptions},
+    test::helpers::test_environment::{
+        CallPrivateOptions, ExecuteUtilityOptions, TestEnvironment, TestEnvironmentOptions, ViewPrivateOptions,
+    },
 };
 
 unconstrained fn setup() -> (TestEnvironment, AztecAddress, AztecAddress, AztecAddress) {
-    let mut env = TestEnvironment::new();
+    setup_with_opts(TestEnvironmentOptions::new())
+}
+
+unconstrained fn setup_with_opts(
+    options: TestEnvironmentOptions,
+) -> (TestEnvironment, AztecAddress, AztecAddress, AztecAddress) {
+    let mut env = TestEnvironment::new_opts(options);
     let account = env.create_light_account();
     let addr_a = env.deploy("NestedUtility").without_initializer();
     let addr_b = env.deploy("NestedUtility").without_initializer();
@@ -85,6 +93,33 @@ unconstrained fn cross_contract_utility_call_from_private_view_succeeds_with_aut
         ViewPrivateOptions::new().with_authorized_utility_call_targets([addr_b]),
         NestedUtility::at(addr_a).delegate_pow_view(addr_b, 2, 3),
     );
+    assert_eq(result, 8);
+}
+
+#[test]
+unconstrained fn cross_contract_utility_call_from_utility_succeeds_with_all_targets_authorized() {
+    let (env, _, addr_a, addr_b) = setup_with_opts(TestEnvironmentOptions::new()
+        .with_all_utility_call_targets_authorized());
+
+    let result: Field = env.execute_utility(NestedUtility::at(addr_a).delegate_pow_utility(addr_b, 2, 3));
+    assert_eq(result, 8);
+}
+
+#[test]
+unconstrained fn cross_contract_utility_call_from_private_succeeds_with_all_targets_authorized() {
+    let (env, account, addr_a, addr_b) = setup_with_opts(TestEnvironmentOptions::new()
+        .with_all_utility_call_targets_authorized());
+
+    let result: Field = env.call_private(account, NestedUtility::at(addr_a).delegate_pow_private(addr_b, 2, 3));
+    assert_eq(result, 8);
+}
+
+#[test]
+unconstrained fn cross_contract_utility_call_from_private_view_succeeds_with_all_targets_authorized() {
+    let (env, account, addr_a, addr_b) = setup_with_opts(TestEnvironmentOptions::new()
+        .with_all_utility_call_targets_authorized());
+
+    let result: Field = env.view_private(account, NestedUtility::at(addr_a).delegate_pow_view(addr_b, 2, 3));
     assert_eq(result, 8);
 }
 

--- a/noir-projects/noir-contracts/contracts/test/nested_utility_contract/src/test.nr
+++ b/noir-projects/noir-contracts/contracts/test/nested_utility_contract/src/test.nr
@@ -97,30 +97,18 @@ unconstrained fn cross_contract_utility_call_from_private_view_succeeds_with_aut
 }
 
 #[test]
-unconstrained fn cross_contract_utility_call_from_utility_succeeds_with_all_targets_authorized() {
-    let (env, _, addr_a, addr_b) = setup_with_opts(TestEnvironmentOptions::new()
-        .with_all_utility_call_targets_authorized());
-
-    let result: Field = env.execute_utility(NestedUtility::at(addr_a).delegate_pow_utility(addr_b, 2, 3));
-    assert_eq(result, 8);
-}
-
-#[test]
-unconstrained fn cross_contract_utility_call_from_private_succeeds_with_all_targets_authorized() {
+unconstrained fn all_call_types_succeed_with_all_utility_call_targets_authorized() {
     let (env, account, addr_a, addr_b) = setup_with_opts(TestEnvironmentOptions::new()
         .with_all_utility_call_targets_authorized());
 
-    let result: Field = env.call_private(account, NestedUtility::at(addr_a).delegate_pow_private(addr_b, 2, 3));
-    assert_eq(result, 8);
-}
+    let utility_result = env.execute_utility(NestedUtility::at(addr_a).delegate_pow_utility(addr_b, 2, 3));
+    assert_eq(utility_result, 8);
 
-#[test]
-unconstrained fn cross_contract_utility_call_from_private_view_succeeds_with_all_targets_authorized() {
-    let (env, account, addr_a, addr_b) = setup_with_opts(TestEnvironmentOptions::new()
-        .with_all_utility_call_targets_authorized());
+    let private_result = env.call_private(account, NestedUtility::at(addr_a).delegate_pow_private(addr_b, 2, 3));
+    assert_eq(private_result, 8);
 
-    let result: Field = env.view_private(account, NestedUtility::at(addr_a).delegate_pow_view(addr_b, 2, 3));
-    assert_eq(result, 8);
+    let view_result = env.view_private(account, NestedUtility::at(addr_a).delegate_pow_view(addr_b, 2, 3));
+    assert_eq(view_result, 8);
 }
 
 #[test]

--- a/yarn-project/txe/src/oracle/interfaces.ts
+++ b/yarn-project/txe/src/oracle/interfaces.ts
@@ -81,6 +81,10 @@ export interface ITxeExecutionOracle {
     unconstrainedStrategy: Option<TaggingSecretStrategy>,
     constrainedStrategy: Option<TaggingSecretStrategy>,
   ): void;
+  /**
+   * Configures whether the test's simulated wallet authorizes every cross-contract utility call target.
+   */
+  setAuthorizeAllUtilityCallTargets(authorizeAll: boolean): void;
   getLastBlockTimestamp(): Promise<bigint>;
   getLastTxEffects(): Promise<{
     txHash: TxHash;

--- a/yarn-project/txe/src/oracle/txe_oracle_registry.ts
+++ b/yarn-project/txe/src/oracle/txe_oracle_registry.ts
@@ -327,6 +327,10 @@ export const TXE_ORACLE_REGISTRY = {
     ],
   }),
 
+  aztec_txe_setAuthorizeAllUtilityCallTargets: makeEntry({
+    params: [{ name: 'authorizeAll', type: BOOL }],
+  }),
+
   aztec_txe_getLastBlockTimestamp: makeEntry({
     returnType: BIGINT,
   }),

--- a/yarn-project/txe/src/oracle/txe_oracle_top_level_context.ts
+++ b/yarn-project/txe/src/oracle/txe_oracle_top_level_context.ts
@@ -126,6 +126,7 @@ export class TXEOracleTopLevelContext implements IMiscOracle, ITxeExecutionOracl
     private chainId: Fr,
     private authwits: Map<string, AuthWitness>,
     private taggingSecretStrategies: TXETaggingSecretStrategies,
+    private authorizeAllUtilityCallTargets: boolean,
     private readonly artifactResolver: TXEArtifactResolver,
     private readonly rootPath: string,
     private readonly packageName: string,
@@ -371,6 +372,10 @@ export class TXEOracleTopLevelContext implements IMiscOracle, ITxeExecutionOracl
     };
     apply(AppTaggingSecretKind.UNCONSTRAINED, unconstrainedStrategy);
     apply(AppTaggingSecretKind.CONSTRAINED, constrainedStrategy);
+  }
+
+  setAuthorizeAllUtilityCallTargets(authorizeAll: boolean): void {
+    this.authorizeAllUtilityCallTargets = authorizeAll;
   }
 
   async sendL1ToL2Message(content: Fr, secretHash: Fr, sender: EthAddress, recipient: AztecAddress): Promise<Fr> {
@@ -974,9 +979,19 @@ export class TXEOracleTopLevelContext implements IMiscOracle, ITxeExecutionOracl
     }
   }
 
-  close(): [bigint, Map<string, AuthWitness>, TXETaggingSecretStrategies] {
+  close(): {
+    nextBlockTimestamp: bigint;
+    authwits: Map<string, AuthWitness>;
+    taggingSecretStrategies: TXETaggingSecretStrategies;
+    authorizeAllUtilityCallTargets: boolean;
+  } {
     this.logger.debug('Exiting Top Level Context');
-    return [this.nextBlockTimestamp, this.authwits, this.taggingSecretStrategies];
+    return {
+      nextBlockTimestamp: this.nextBlockTimestamp,
+      authwits: this.authwits,
+      taggingSecretStrategies: this.taggingSecretStrategies,
+      authorizeAllUtilityCallTargets: this.authorizeAllUtilityCallTargets,
+    };
   }
 
   private async getLastBlockNumber(): Promise<BlockNumber> {
@@ -988,6 +1003,9 @@ export class TXEOracleTopLevelContext implements IMiscOracle, ITxeExecutionOracl
     callerContext: 'private' | 'private view' | 'utility',
     authorizedTargets: AztecAddress[],
   ): ExecutionHooks['authorizeUtilityCall'] | undefined {
+    if (this.authorizeAllUtilityCallTargets) {
+      return authorizeAllUtilityCallsHook;
+    }
     if (authorizedTargets.length === 0) {
       return undefined;
     }
@@ -997,3 +1015,11 @@ export class TXEOracleTopLevelContext implements IMiscOracle, ITxeExecutionOracl
       });
   }
 }
+
+/**
+ * An `authorizeUtilityCall` hook that authorizes every cross-contract utility call.
+ *
+ * Backs the `aztec_txe_setAuthorizeAllUtilityCallTargets` oracle.
+ */
+export const authorizeAllUtilityCallsHook: NonNullable<ExecutionHooks['authorizeUtilityCall']> = () =>
+  Promise.resolve({ authorized: true });

--- a/yarn-project/txe/src/oracle/txe_oracle_version.ts
+++ b/yarn-project/txe/src/oracle/txe_oracle_version.ts
@@ -6,7 +6,7 @@
  * The Noir counterparts are in `noir-projects/aztec-nr/aztec/src/test/helpers/txe_oracles.nr`.
  */
 export const TXE_ORACLE_VERSION_MAJOR = 3;
-export const TXE_ORACLE_VERSION_MINOR = 0;
+export const TXE_ORACLE_VERSION_MINOR = 1;
 
 /**
  * This hash is computed from the TXE oracle interfaces (IAvmExecutionOracle and ITxeExecutionOracle) and is used to
@@ -14,4 +14,4 @@ export const TXE_ORACLE_VERSION_MINOR = 0;
  *   - TXE_ORACLE_VERSION_MAJOR (and reset MINOR to 0) for breaking changes, or
  *   - TXE_ORACLE_VERSION_MINOR for additive changes (new oracle method added).
  */
-export const TXE_ORACLE_INTERFACE_HASH = 'bea75bd85baebd7aa1438efb1defab496d27540bc805a8d854bb74b8d45fd859';
+export const TXE_ORACLE_INTERFACE_HASH = '89c60f191f8f60ef72d592e46dd6c4afff10dc47a9e14f4f8d37e31e40857d9c';

--- a/yarn-project/txe/src/rpc_translator.ts
+++ b/yarn-project/txe/src/rpc_translator.ts
@@ -230,6 +230,15 @@ export class RPCTranslator {
     });
   }
 
+  // eslint-disable-next-line camelcase
+  aztec_txe_setAuthorizeAllUtilityCallTargets(...inputs: ForeignCallArgs) {
+    return callTxeHandler({
+      oracle: 'aztec_txe_setAuthorizeAllUtilityCallTargets',
+      inputs,
+      handler: ([authorizeAll]) => this.handlerAsTxe().setAuthorizeAllUtilityCallTargets(authorizeAll),
+    });
+  }
+
   // PXE oracles
 
   // eslint-disable-next-line camelcase

--- a/yarn-project/txe/src/txe_session.ts
+++ b/yarn-project/txe/src/txe_session.ts
@@ -63,7 +63,7 @@ import {
 } from './oracle/tagging_secret_strategy.js';
 import { TXEOraclePublicContext } from './oracle/txe_oracle_public_context.js';
 import { callTxeLegacyHandler } from './oracle/txe_oracle_registry.js';
-import { TXEOracleTopLevelContext } from './oracle/txe_oracle_top_level_context.js';
+import { TXEOracleTopLevelContext, authorizeAllUtilityCallsHook } from './oracle/txe_oracle_top_level_context.js';
 import { TXE_ORACLE_VERSION_MAJOR, TXE_ORACLE_VERSION_MINOR } from './oracle/txe_oracle_version.js';
 import { TXEPrivateExecutionOracle } from './oracle/txe_private_execution_oracle.js';
 import { RPCTranslator, UnavailableOracleError } from './rpc_translator.js';
@@ -241,6 +241,7 @@ export class TXESession implements TXESessionStateHandler {
   private state: SessionState = { name: 'TOP_LEVEL' };
   private authwits: Map<string, AuthWitness> = new Map();
   private taggingSecretStrategies: TXETaggingSecretStrategies = new Map();
+  private authorizeAllUtilityCallTargets = false;
   private lastCallInfo: LastCallState = emptyLastCallState();
   private txeOracleVersion: { major: number; minor: number } | undefined;
 
@@ -361,6 +362,7 @@ export class TXESession implements TXESessionStateHandler {
       chainId,
       new Map(),
       new Map(),
+      false, // authorizeAllUtilityCallTargets
       artifactResolver,
       rootPath,
       packageName,
@@ -691,6 +693,7 @@ export class TXESession implements TXESessionStateHandler {
       this.chainId,
       this.authwits,
       this.taggingSecretStrategies,
+      this.authorizeAllUtilityCallTargets,
       this.artifactResolver,
       this.rootPath,
       this.packageName,
@@ -770,6 +773,7 @@ export class TXESession implements TXESessionStateHandler {
       simulator: new WASMSimulator(),
       hooks: composeHooks({
         resolveTaggingSecretStrategy: makeResolveTaggingSecretStrategyHook(this.taggingSecretStrategies),
+        authorizeUtilityCall: this.authorizeAllUtilityCallTargets ? authorizeAllUtilityCallsHook : undefined,
       }),
       transientArrayService,
     });
@@ -870,6 +874,9 @@ export class TXESession implements TXESessionStateHandler {
       scopes: await this.keyStore.getAccounts(),
       simulator: new WASMSimulator(),
       utilityExecutor: this.utilityExecutorForContractSync(anchorBlockHeader),
+      hooks: composeHooks({
+        authorizeUtilityCall: this.authorizeAllUtilityCallTargets ? authorizeAllUtilityCallsHook : undefined,
+      }),
       // Execution-tree root (top-level utility run): own store; nested frames inherit it.
       transientArrayService: new TransientArrayService(),
     });
@@ -898,9 +905,12 @@ export class TXESession implements TXESessionStateHandler {
     // TODO: persisting authwits this way is quite unfortunate: they create a temporary utility context that would
     // otherwise reset them, so we'd not be able to pass more than one per execution. Ideally authwits would be passed
     // alongside a contract call instead of pre-seeded.
-    [this.nextBlockTimestamp, this.authwits, this.taggingSecretStrategies] = (
-      this.oracleHandler as TXEOracleTopLevelContext
-    ).close();
+    ({
+      nextBlockTimestamp: this.nextBlockTimestamp,
+      authwits: this.authwits,
+      taggingSecretStrategies: this.taggingSecretStrategies,
+      authorizeAllUtilityCallTargets: this.authorizeAllUtilityCallTargets,
+    } = (this.oracleHandler as TXEOracleTopLevelContext).close());
   }
 
   private async exitPrivateState() {


### PR DESCRIPTION
## Motivation

Every TXE test making a cross-contract utility call has to list the exact target addresses on each call's options, even when the test doesn't care about authorization. The targets can also be internal to the called contract, so tests end up encoding the callee's call graph. Suggested by @nventuro in the #24040 review.

## The change

- `TestEnvironmentOptions` gains `with_all_utility_call_targets_authorized()`. When set, the simulated wallet authorizes every cross-contract utility call for the entire test.
- Backed by a new `aztec_txe_setAuthorizeAllUtilityCallTargets` oracle. TXE oracle minor version bumped.
- Per-call `with_authorized_utility_call_targets` still works, and cross-contract utility calls stay denied by default.

Fixes F-733