### PR TITLE
fix(pxe): widen tracked sender tagging ranges with onchain discovery evidence

### DIFF
--- a/yarn-project/pxe/src/storage/tagging_store/sender_tagging_store.test.ts
+++ b/yarn-project/pxe/src/storage/tagging_store/sender_tagging_store.test.ts
@@ -108,22 +108,36 @@ describe('SenderTaggingStore', () => {
       );
     });
 
-    it('keeps the existing range when storing a different range with skipExisting', async () => {
+    it('keeps the existing range when storing a sub-range with mergeExisting', async () => {
       const txHash = TxHash.random();
 
       // Prove-time entry spanning setup and app-logic phase logs.
       await taggingStore.storePendingIndexes([range(secret1, 4, 6)], txHash, 'test');
 
       // Discovery of the surviving sub-range of a partially reverted tx must not throw nor shrink the entry.
-      await taggingStore.storePendingIndexes([range(secret1, 4)], txHash, 'test', { skipExisting: true });
+      await taggingStore.storePendingIndexes([range(secret1, 4)], txHash, 'test', { mergeExisting: true });
 
       expect(await taggingStore.getLastUsedIndex(secret1, 'test')).toBe(6);
     });
 
-    it('stores a range for an untracked tx when skipExisting is set', async () => {
+    it('widens the existing range when storing a range beyond it with mergeExisting', async () => {
       const txHash = TxHash.random();
 
-      await taggingStore.storePendingIndexes([range(secret1, 5)], txHash, 'test', { skipExisting: true });
+      // A prior window discovered only part of the tx's range.
+      await taggingStore.storePendingIndexes([range(secret1, 4, 6)], txHash, 'test');
+
+      // Discovery evidences further onchain indexes for the same tx — the entry must grow to cover them.
+      await taggingStore.storePendingIndexes([range(secret1, 7, 8)], txHash, 'test', { mergeExisting: true });
+
+      const txHashes = await taggingStore.getTxHashesOfPendingIndexes(secret1, 0, 10, 'test');
+      expect(txHashes).toEqual([txHash]);
+      expect(await taggingStore.getLastUsedIndex(secret1, 'test')).toBe(8);
+    });
+
+    it('stores a range for an untracked tx when mergeExisting is set', async () => {
+      const txHash = TxHash.random();
+
+      await taggingStore.storePendingIndexes([range(secret1, 5)], txHash, 'test', { mergeExisting: true });
 
       const txHashes = await taggingStore.getTxHashesOfPendingIndexes(secret1, 0, 10, 'test');
       expect(txHashes).toEqual([txHash]);

--- a/yarn-project/pxe/src/storage/tagging_store/sender_tagging_store.ts
+++ b/yarn-project/pxe/src/storage/tagging_store/sender_tagging_store.ts
@@ -136,19 +136,20 @@ export class SenderTaggingStore implements StagedStore {
    * to be stored in the db.
    * @param txHash - The tx in which the tagging indexes were used in private logs.
    * @param jobId - job context for staged writes to this store. See `JobCoordinator` for more details.
-   * @param opts - With `skipExisting`, an existing entry for the same (secret, txHash) pair is left untouched even
-   * when the ranges differ. Discovery from onchain logs needs this: for a partially reverted tx the chain only shows
-   * the surviving (non-revertible phase) sub-range of the range recorded at prove time, and receipt reconciliation
-   * is responsible for resolving that difference.
+   * @param opts - With `mergeExisting`, an existing entry for the same (secret, txHash) pair is widened to the union
+   * of the stored and incoming ranges instead of throwing on a mismatch. Discovery from onchain logs needs this: it
+   * may see only the surviving (non-revertible phase) sub-range of a partially reverted tx recorded at prove time
+   * (receipt reconciliation resolves that difference), or indexes beyond a partially discovered entry when a tx
+   * from another PXE straddles a sync window boundary.
    * @throws If the highestIndex is further than window length from the highest finalized index for the same secret.
    * @throws If the lowestIndex is lower than or equal to the last finalized index for the same secret.
-   * @throws If a different range already exists for the same (secret, txHash) pair (unless `skipExisting` is set).
+   * @throws If a different range already exists for the same (secret, txHash) pair (unless `mergeExisting` is set).
    */
   storePendingIndexes(
     ranges: TaggingIndexRange[],
     txHash: TxHash,
     jobId: string,
-    opts: { skipExisting?: boolean } = {},
+    opts: { mergeExisting?: boolean } = {},
   ): Promise<void> {
     if (ranges.length === 0) {
       return Promise.resolve();
@@ -197,19 +198,36 @@ export class SenderTaggingStore implements StagedStore {
         const existingEntry = pendingData.find(entry => entry.txHash === txHashStr);
 
         if (existingEntry) {
-          // Assert that the ranges are equal — different ranges for the same (secret, txHash) indicates a bug,
-          // except for callers that opt out because they only see the onchain sub-range of a partially reverted tx.
-          if (
-            !opts.skipExisting &&
-            (existingEntry.lowestIndex !== range.lowestIndex || existingEntry.highestIndex !== range.highestIndex)
-          ) {
+          const rangesEqual =
+            existingEntry.lowestIndex === range.lowestIndex && existingEntry.highestIndex === range.highestIndex;
+          if (rangesEqual) {
+            // Exact duplicate — skip
+          } else if (opts.mergeExisting) {
+            // Widen the entry to the union of both ranges. Never shrink: the stored entry may cover prove-time
+            // indexes the chain doesn't show (partially reverted tx), and the incoming range may evidence onchain
+            // indexes the entry doesn't cover yet — dropping either side risks reusing a tag that is already public.
+            this.#writePendingIndexes(
+              jobId,
+              secretStr,
+              pendingData.map(entry =>
+                entry === existingEntry
+                  ? {
+                      lowestIndex: Math.min(entry.lowestIndex, range.lowestIndex),
+                      highestIndex: Math.max(entry.highestIndex, range.highestIndex),
+                      txHash: entry.txHash,
+                    }
+                  : entry,
+              ),
+            );
+          } else {
+            // Different ranges for the same (secret, txHash) indicate a bug in callers that record indexes at prove
+            // time.
             throw new Error(
               `Conflicting range for secret ${secretStr} and txHash ${txHashStr}: ` +
                 `existing [${existingEntry.lowestIndex}, ${existingEntry.highestIndex}] vs ` +
                 `new [${range.lowestIndex}, ${range.highestIndex}]`,
             );
           }
-          // Exact duplicate — skip
         } else {
           this.#writePendingIndexes(jobId, secretStr, [
             ...pendingData,

--- a/yarn-project/pxe/src/storage/tagging_store/sender_tagging_store.ts
+++ b/yarn-project/pxe/src/storage/tagging_store/sender_tagging_store.ts
@@ -198,14 +198,10 @@ export class SenderTaggingStore implements StagedStore {
         const existingEntry = pendingData.find(entry => entry.txHash === txHashStr);
 
         if (existingEntry) {
-          const rangesEqual =
-            existingEntry.lowestIndex === range.lowestIndex && existingEntry.highestIndex === range.highestIndex;
-          if (rangesEqual) {
-            // Exact duplicate — skip
-          } else if (opts.mergeExisting) {
-            // Widen the entry to the union of both ranges. Never shrink: the stored entry may cover prove-time
-            // indexes the chain doesn't show (partially reverted tx), and the incoming range may evidence onchain
-            // indexes the entry doesn't cover yet — dropping either side risks reusing a tag that is already public.
+          if (opts.mergeExisting) {
+            // Widen the entry to the union of both ranges, never shrink it: replacing would drop prove-time
+            // indexes the chain doesn't show (partially reverted tx), and skipping would drop onchain indexes
+            // discovered in a later sync window (tx straddling the window boundary).
             this.#writePendingIndexes(
               jobId,
               secretStr,
@@ -219,7 +215,10 @@ export class SenderTaggingStore implements StagedStore {
                   : entry,
               ),
             );
-          } else {
+          } else if (
+            existingEntry.lowestIndex !== range.lowestIndex ||
+            existingEntry.highestIndex !== range.highestIndex
+          ) {
             // Different ranges for the same (secret, txHash) indicate a bug in callers that record indexes at prove
             // time.
             throw new Error(
@@ -228,6 +227,7 @@ export class SenderTaggingStore implements StagedStore {
                 `new [${range.lowestIndex}, ${range.highestIndex}]`,
             );
           }
+          // Exact duplicate: skip.
         } else {
           this.#writePendingIndexes(jobId, secretStr, [
             ...pendingData,

--- a/yarn-project/pxe/src/tagging/sender_sync/sync_sender_tagging_indexes.test.ts
+++ b/yarn-project/pxe/src/tagging/sender_sync/sync_sender_tagging_indexes.test.ts
@@ -507,6 +507,62 @@ describe('syncSenderTaggingIndexes', () => {
     expect(await taggingStore.getLastFinalizedIndex(secret, 'test')).toBeUndefined();
   });
 
+  /**
+   * Single-sync window straddle: a foreign tx's tags span the boundary between two consecutive sync windows, so the
+   * window loop assembles the tx's range piecewise — window 1 stores the lower index, window 2 evidences the higher
+   * one for the same (secret, txHash). The second write must widen the entry from window 1 rather than conflict with
+   * it, and the final index choice must cover the full onchain range.
+   */
+  it('assembles a pending range piecewise when a tx straddles the sync window boundary', async () => {
+    await setUp();
+
+    // A tx finalized at index 0 makes the finalized index advance during window 1, so the loop proceeds to window 2.
+    const finalizedTxHash = TxHash.random();
+    const finalizedTag = await computeSiloedTagForIndex(0);
+
+    // The straddling tx used the last index of window 1 and the first index of window 2.
+    const straddlingTxHash = TxHash.random();
+    const lowerStraddleIndex = UNFINALIZED_TAGGING_INDEXES_WINDOW_LEN - 1;
+    const upperStraddleIndex = UNFINALIZED_TAGGING_INDEXES_WINDOW_LEN;
+    const lowerStraddleTag = await computeSiloedTagForIndex(lowerStraddleIndex);
+    const upperStraddleTag = await computeSiloedTagForIndex(upperStraddleIndex);
+
+    aztecNode.getPrivateLogsByTags.mockImplementation(query => {
+      const tags = query.tags as SiloedTag[];
+      return Promise.resolve(
+        tags.map((tag: SiloedTag) => {
+          if (tag.equals(finalizedTag)) {
+            return [makeLog(finalizedTxHash, finalizedTag.value)];
+          } else if (tag.equals(lowerStraddleTag)) {
+            return [makeLog(straddlingTxHash, lowerStraddleTag.value)];
+          } else if (tag.equals(upperStraddleTag)) {
+            return [makeLog(straddlingTxHash, upperStraddleTag.value)];
+          }
+          return [];
+        }),
+      );
+    });
+
+    aztecNode.getTxReceipt.mockImplementation((hash: TxHash) => {
+      if (hash.equals(finalizedTxHash)) {
+        return Promise.resolve(mined(hash, TxStatus.FINALIZED, 14));
+      } else if (hash.equals(straddlingTxHash)) {
+        // Mined but not finalized, so no receipt status change resolves the straddling entry during this sync.
+        return Promise.resolve(mined(hash, TxStatus.PROPOSED, 16));
+      }
+      throw new Error(`Unexpected tx hash: ${hash.toString()}`);
+    });
+
+    await syncSenderTaggingIndexes(secret, aztecNode, taggingStore, MOCK_ANCHOR_BLOCK_HASH, 'test');
+
+    // The straddled range must have been assembled piecewise — one logs query per window.
+    expect(aztecNode.getPrivateLogsByTags).toHaveBeenCalledTimes(2);
+
+    expect(await taggingStore.getLastFinalizedIndex(secret, 'test')).toBe(0);
+    // The next index choice must account for both straddled onchain tags.
+    expect(await taggingStore.getLastUsedIndex(secret, 'test')).toBe(upperStraddleIndex);
+  });
+
   it('handles a partially reverted transaction', async () => {
     await setUp();
 

--- a/yarn-project/pxe/src/tagging/sender_sync/sync_sender_tagging_indexes.test.ts
+++ b/yarn-project/pxe/src/tagging/sender_sync/sync_sender_tagging_indexes.test.ts
@@ -555,11 +555,32 @@ describe('syncSenderTaggingIndexes', () => {
 
     await syncSenderTaggingIndexes(secret, aztecNode, taggingStore, MOCK_ANCHOR_BLOCK_HASH, 'test');
 
-    // The straddled range must have been assembled piecewise — one logs query per window.
+    // The straddled range must have been assembled piecewise: window 1's logs query covers the lower straddle index
+    // but not the upper, and window 2's query the reverse. (Each window fits in a single RPC page, so there is one
+    // logs call per window.)
     expect(aztecNode.getPrivateLogsByTags).toHaveBeenCalledTimes(2);
+    const queriedTags = aztecNode.getPrivateLogsByTags.mock.calls.map(([query]) => query.tags as SiloedTag[]);
+    expect(queriedTags[0].some(tag => tag.equals(lowerStraddleTag))).toBe(true);
+    expect(queriedTags[0].some(tag => tag.equals(upperStraddleTag))).toBe(false);
+    expect(queriedTags[1].some(tag => tag.equals(upperStraddleTag))).toBe(true);
+    expect(queriedTags[1].some(tag => tag.equals(lowerStraddleTag))).toBe(false);
 
     expect(await taggingStore.getLastFinalizedIndex(secret, 'test')).toBe(0);
     // The next index choice must account for both straddled onchain tags.
+    expect(await taggingStore.getLastUsedIndex(secret, 'test')).toBe(upperStraddleIndex);
+
+    // The straddling tx later finalizes. A single widened entry finalizes cleanly at the upper index — a duplicate
+    // entry for the same txHash would instead trip the multiple-pending-entries guard during finalization.
+    aztecNode.getTxReceipt.mockImplementation((hash: TxHash) => {
+      if (hash.equals(straddlingTxHash)) {
+        return Promise.resolve(mined(hash, TxStatus.FINALIZED, 18));
+      }
+      throw new Error(`Unexpected tx hash: ${hash.toString()}`);
+    });
+
+    await syncSenderTaggingIndexes(secret, aztecNode, taggingStore, MOCK_ANCHOR_BLOCK_HASH, 'test');
+
+    expect(await taggingStore.getLastFinalizedIndex(secret, 'test')).toBe(upperStraddleIndex);
     expect(await taggingStore.getLastUsedIndex(secret, 'test')).toBe(upperStraddleIndex);
   });
 

--- a/yarn-project/pxe/src/tagging/sender_sync/sync_sender_tagging_indexes.test.ts
+++ b/yarn-project/pxe/src/tagging/sender_sync/sync_sender_tagging_indexes.test.ts
@@ -461,6 +461,52 @@ describe('syncSenderTaggingIndexes', () => {
     expect(await taggingStore.getLastUsedIndex(secret, 'test')).toBe(4);
   });
 
+  /**
+   * Cross-device straddle: another PXE sharing this directional secret sent a tx, and an earlier window discovered
+   * only part of its index range, so the store already tracks a narrower entry for the same (secret, txHash).
+   * Discovery must widen the entry to cover every index evidenced onchain — silently keeping the narrower entry
+   * would let this PXE pick a next index whose tag is already public.
+   */
+  it('widens a tracked pending range when discovery evidences further indexes for the same tx', async () => {
+    await setUp();
+
+    const foreignTxHash = TxHash.random();
+
+    // An earlier window discovered only the first index of the foreign tx.
+    await taggingStore.storePendingIndexes(
+      [{ extendedSecret: secret, lowestIndex: 10, highestIndex: 10 }],
+      foreignTxHash,
+      'test',
+    );
+
+    // The chain shows the tx actually used indexes 10 and 11.
+    const tag10 = await computeSiloedTagForIndex(10);
+    const tag11 = await computeSiloedTagForIndex(11);
+
+    aztecNode.getPrivateLogsByTags.mockImplementation(query => {
+      const tags = query.tags as SiloedTag[];
+      return Promise.resolve(
+        tags.map((tag: SiloedTag) => {
+          if (tag.equals(tag10)) {
+            return [makeLog(foreignTxHash, tag10.value)];
+          } else if (tag.equals(tag11)) {
+            return [makeLog(foreignTxHash, tag11.value)];
+          }
+          return [];
+        }),
+      );
+    });
+
+    // The tx is mined but not yet finalized, so no receipt status change resolves the entry during this sync.
+    aztecNode.getTxReceipt.mockResolvedValue(mined(foreignTxHash, TxStatus.PROPOSED, 14));
+
+    await syncSenderTaggingIndexes(secret, aztecNode, taggingStore, MOCK_ANCHOR_BLOCK_HASH, 'test');
+
+    // The next index choice must account for the onchain tag at index 11.
+    expect(await taggingStore.getLastUsedIndex(secret, 'test')).toBe(11);
+    expect(await taggingStore.getLastFinalizedIndex(secret, 'test')).toBeUndefined();
+  });
+
   it('handles a partially reverted transaction', async () => {
     await setUp();
 

--- a/yarn-project/pxe/src/tagging/sender_sync/sync_sender_tagging_indexes.test.ts
+++ b/yarn-project/pxe/src/tagging/sender_sync/sync_sender_tagging_indexes.test.ts
@@ -464,8 +464,8 @@ describe('syncSenderTaggingIndexes', () => {
   /**
    * Cross-device straddle: another PXE sharing this directional secret sent a tx, and an earlier window discovered
    * only part of its index range, so the store already tracks a narrower entry for the same (secret, txHash).
-   * Discovery must widen the entry to cover every index evidenced onchain — silently keeping the narrower entry
-   * would let this PXE pick a next index whose tag is already public.
+   * Discovery must widen the entry to cover every index evidenced onchain, so that the next index choice accounts
+   * for them.
    */
   it('widens a tracked pending range when discovery evidences further indexes for the same tx', async () => {
     await setUp();
@@ -561,9 +561,7 @@ describe('syncSenderTaggingIndexes', () => {
     expect(aztecNode.getPrivateLogsByTags).toHaveBeenCalledTimes(2);
     const queriedTags = aztecNode.getPrivateLogsByTags.mock.calls.map(([query]) => query.tags as SiloedTag[]);
     expect(queriedTags[0].some(tag => tag.equals(lowerStraddleTag))).toBe(true);
-    expect(queriedTags[0].some(tag => tag.equals(upperStraddleTag))).toBe(false);
     expect(queriedTags[1].some(tag => tag.equals(upperStraddleTag))).toBe(true);
-    expect(queriedTags[1].some(tag => tag.equals(lowerStraddleTag))).toBe(false);
 
     expect(await taggingStore.getLastFinalizedIndex(secret, 'test')).toBe(0);
     // The next index choice must account for both straddled onchain tags.

--- a/yarn-project/pxe/src/tagging/sender_sync/utils/load_and_store_new_tagging_indexes.test.ts
+++ b/yarn-project/pxe/src/tagging/sender_sync/utils/load_and_store_new_tagging_indexes.test.ts
@@ -77,7 +77,7 @@ describe('loadAndStoreNewTaggingIndexes', () => {
       [{ extendedSecret: secret, lowestIndex: index, highestIndex: index }],
       txHash,
       'test',
-      { skipExisting: true },
+      { mergeExisting: true },
     );
   });
 
@@ -109,7 +109,7 @@ describe('loadAndStoreNewTaggingIndexes', () => {
       [{ extendedSecret: secret, lowestIndex: index1, highestIndex: index2 }],
       txHash,
       'test',
-      { skipExisting: true },
+      { mergeExisting: true },
     );
   });
 
@@ -142,13 +142,13 @@ describe('loadAndStoreNewTaggingIndexes', () => {
       [{ extendedSecret: secret, lowestIndex: index1, highestIndex: index1 }],
       txHash1,
       'test',
-      { skipExisting: true },
+      { mergeExisting: true },
     );
     expect(taggingStore.storePendingIndexes).toHaveBeenCalledWith(
       [{ extendedSecret: secret, lowestIndex: index2, highestIndex: index2 }],
       txHash2,
       'test',
-      { skipExisting: true },
+      { mergeExisting: true },
     );
   });
 
@@ -173,13 +173,13 @@ describe('loadAndStoreNewTaggingIndexes', () => {
       [{ extendedSecret: secret, lowestIndex: index, highestIndex: index }],
       txHash1,
       'test',
-      { skipExisting: true },
+      { mergeExisting: true },
     );
     expect(taggingStore.storePendingIndexes).toHaveBeenCalledWith(
       [{ extendedSecret: secret, lowestIndex: index, highestIndex: index }],
       txHash2,
       'test',
-      { skipExisting: true },
+      { mergeExisting: true },
     );
   });
 
@@ -227,19 +227,19 @@ describe('loadAndStoreNewTaggingIndexes', () => {
       [{ extendedSecret: secret, lowestIndex: 1, highestIndex: 8 }],
       txHash1,
       'test',
-      { skipExisting: true },
+      { mergeExisting: true },
     );
     expect(taggingStore.storePendingIndexes).toHaveBeenCalledWith(
       [{ extendedSecret: secret, lowestIndex: 3, highestIndex: 5 }],
       txHash2,
       'test',
-      { skipExisting: true },
+      { mergeExisting: true },
     );
     expect(taggingStore.storePendingIndexes).toHaveBeenCalledWith(
       [{ extendedSecret: secret, lowestIndex: 9, highestIndex: 9 }],
       txHash3,
       'test',
-      { skipExisting: true },
+      { mergeExisting: true },
     );
   });
 
@@ -275,7 +275,7 @@ describe('loadAndStoreNewTaggingIndexes', () => {
       [{ extendedSecret: secret, lowestIndex: start, highestIndex: start }],
       txHashAtStart,
       'test',
-      { skipExisting: true },
+      { mergeExisting: true },
     );
   });
 });

--- a/yarn-project/pxe/src/tagging/sender_sync/utils/load_and_store_new_tagging_indexes.ts
+++ b/yarn-project/pxe/src/tagging/sender_sync/utils/load_and_store_new_tagging_indexes.ts
@@ -37,13 +37,14 @@ export async function loadAndStoreNewTaggingIndexes(
   const txIndexesMap = getTxIndexesMap(txsForTags, start, siloedTagsForWindow.length);
 
   // Now we iterate over the map, construct the tagging index ranges and store them in the db. A tx already tracked
-  // in the store is skipped rather than range-checked: if this PXE sent the tx and it partially reverted, the chain
-  // only shows the surviving sub-range of the prove-time entry, and the receipt reconciliation step of the sync owns
-  // resolving that difference.
+  // in the store is merged rather than range-checked: if this PXE sent the tx and it partially reverted, the chain
+  // only shows the surviving sub-range of the prove-time entry (the receipt reconciliation step of the sync owns
+  // resolving that difference), and a tx from another PXE may straddle a sync window boundary, in which case the
+  // entry is widened so the next index choice accounts for every tag known to be public.
   for (const [txHashStr, indexes] of txIndexesMap.entries()) {
     const txHash = TxHash.fromString(txHashStr);
     const ranges = [{ extendedSecret, lowestIndex: Math.min(...indexes), highestIndex: Math.max(...indexes) }];
-    await taggingStore.storePendingIndexes(ranges, txHash, jobId, { skipExisting: true });
+    await taggingStore.storePendingIndexes(ranges, txHash, jobId, { mergeExisting: true });
   }
 }
 


### PR DESCRIPTION
Stacked on #24655. Found while reviewing #24655. This is the "Window straddle" residual edge flagged in https://gist.github.com/nventuro/0aa690736b1d2865e27197723a814e9d (latent regardless of reverts); the fix takes the gist's suggested "extend an entry monotonically" option.

#24655 made discovery skip a differing range for an already tracked (secret, txHash) pair instead of throwing.
Before #24655 this same scenario hit the "Conflicting range" throw and permanently wedged the secret, so it was broken either way.

Fix: replace `skipExisting` with `mergeExisting`. On a range mismatch, discovery widens the stored entry to the union of both ranges (grow-only, driven by onchain evidence). The partial revert case is unchanged: the discovered sub-range unions to the existing prove-time entry, and the finalized receipt step still resolves it. The prove-time persist path keeps the strict conflict throw.

Red-green:
- "widens a tracked pending range when discovery evidences further indexes for the same tx" fails on the base branch with lastUsed 10 instead of 11, and passes with the merge.
- "assembles a pending range piecewise when a tx straddles the sync window boundary" drives the actual window-advance loop: a tx with tags on both sides of the window boundary gets stored as [83, 83] by window 1 and widened by window 2. It throws "Conflicting range existing [83, 83] vs new [84, 84]" on fairies-v5, under-reports lastUsed as 83 on the base branch, and passes with the merge (including a follow-up sync that finalizes the widened entry cleanly).

Store-level tests pin the union semantics: a sub-range keeps the entry, a range beyond it widens it, an untracked tx still stores.

