### PR TITLE
fix(aztec-nr): reject infinity ephemeral key in message encryption

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/keys/ephemeral.nr
+++ b/noir-projects/aztec-nr/aztec/src/keys/ephemeral.nr
@@ -37,6 +37,9 @@ pub fn generate_positive_ephemeral_key_pair() -> (Scalar, EmbeddedCurvePoint) {
     let eph_sk = unsafe { generate_secret_key_for_positive_public_key() };
     let eph_pk = fixed_base_scalar_mul(eph_sk);
 
+    // The point at infinity has x = 0, which is not a valid x-coordinate on the curve, so the recipient could
+    // never reconstruct the key from it and the message would be undecryptable.
+    assert(!eph_pk.is_infinite(), "Ephemeral public key is the point at infinity");
     assert(get_sign_of_point(eph_pk), "Got an ephemeral public key with a negative y coordinate");
 
     (eph_sk, eph_pk)
@@ -63,6 +66,7 @@ unconstrained fn generate_secret_key_for_positive_public_key() -> EmbeddedCurveS
 mod test {
     use crate::utils::point::get_sign_of_point;
     use super::generate_positive_ephemeral_key_pair;
+    use std::test::OracleMock;
 
     #[test]
     fn generate_positive_ephemeral_key_pair_produces_positive_keys() {
@@ -72,5 +76,12 @@ mod test {
             let (_, pk) = generate_positive_ephemeral_key_pair();
             assert(get_sign_of_point(pk));
         }
+    }
+
+    #[test(should_fail_with = "point at infinity")]
+    unconstrained fn generate_positive_ephemeral_key_pair_rejects_zero_randomness() {
+        // Making the randomness oracle return 0 emulates a malicious sender substituting eph_sk = 0.
+        let _ = OracleMock::mock("aztec_misc_getRandomField").returns(0);
+        let _ = generate_positive_ephemeral_key_pair();
     }
 }


### PR DESCRIPTION
## Problem

When encrypting a message, the ephemeral secret key comes from an unconstrained routine, so a malicious sender can substitute any value while proving. Substituting `eph_sk = 0` yields the point at infinity as the ephemeral public key, which passed the y-sign check: its y-coordinate is 0, which counts as positive. Its x-coordinate (0) is then broadcast, but 0 is not a valid x-coordinate on the curve, so the recipient can never reconstruct the key and the message is permanently undecryptable. This breaks the constrained-delivery guarantee that a note delivered by an untrusted sender remains decryptable by the recipient.

## Fix

`generate_positive_ephemeral_key_pair` now asserts the ephemeral public key is not the point at infinity, alongside the existing sign check. A test emulates the substitution by mocking the randomness oracle to return 0.

Fixes F-799