### PR TITLE
test: fix proof_boundary startup race

### DIFF
--- a/yarn-project/end-to-end/src/multi-node/block-production/proof_boundary.parallel.test.ts
+++ b/yarn-project/end-to-end/src/multi-node/block-production/proof_boundary.parallel.test.ts
@@ -58,9 +58,10 @@ describe('multi-node/block-production/proof_boundary', () => {
 
     const minTxsPerBlock = validatorOverrides.minTxsPerBlock ?? 0;
     const maxTxsPerBlock = validatorOverrides.maxTxsPerBlock ?? 1;
-    logger.warn(`Initial setup complete. Starting ${NODE_COUNT} validator nodes.`);
+    logger.warn(`Initial setup complete. Creating ${NODE_COUNT} validator nodes with sequencers paused.`);
+    // Ensure every validator can handle the first proposal before any sequencer begins its polling loop.
     nodes = await asyncMap(validators, ({ privateKey }) =>
-      test.createValidatorNode([privateKey], { minTxsPerBlock, maxTxsPerBlock }),
+      test.createValidatorNode([privateKey], { dontStartSequencer: true, minTxsPerBlock, maxTxsPerBlock }),
     );
 
     proverNode = await test.createProverNode({
@@ -71,6 +72,11 @@ describe('multi-node/block-production/proof_boundary', () => {
     context.proverNode = proverNode;
 
     logger.warn(`Test setup completed.`, { validators: validators.map(v => v.attester.toString()) });
+  };
+
+  const startSequencers = async () => {
+    await test.startSequencers(nodes);
+    logger.warn(`Started ${NODE_COUNT} validator sequencers.`);
   };
 
   const collectSequencerEvents = (sequencers: SequencerClient[]) => {
@@ -216,6 +222,7 @@ describe('multi-node/block-production/proof_boundary', () => {
 
     const sequencers = nodes.map(node => node.getSequencer()!);
     const events = collectSequencerEvents(sequencers);
+    await startSequencers();
 
     const { boundarySlot, boundaryTs } = await computeBoundarySlot();
 
@@ -264,6 +271,7 @@ describe('multi-node/block-production/proof_boundary', () => {
 
     const sequencers = nodes.map(node => node.getSequencer()!);
     const events = collectSequencerEvents(sequencers);
+    await startSequencers();
 
     const { boundarySlot, boundaryTs } = await computeBoundarySlot();
 
@@ -298,6 +306,7 @@ describe('multi-node/block-production/proof_boundary', () => {
 
     const sequencers = nodes.map(node => node.getSequencer()!);
     const events = collectSequencerEvents(sequencers);
+    await startSequencers();
 
     const { boundarySlot, boundaryEpoch } = await computeBoundarySlot();
 
@@ -335,6 +344,7 @@ describe('multi-node/block-production/proof_boundary', () => {
 
     const sequencers = nodes.map(node => node.getSequencer()!);
     const events = collectSequencerEvents(sequencers);
+    await startSequencers();
 
     const { boundarySlot } = await computeBoundarySlot();
     const slotN = SlotNumber(Number(boundarySlot) - 1);
@@ -374,6 +384,7 @@ describe('multi-node/block-production/proof_boundary', () => {
 
     const sequencers = nodes.map(node => node.getSequencer()!);
     const events = collectSequencerEvents(sequencers);
+    await startSequencers();
 
     const { boundarySlot } = await computeBoundarySlot();
     const slotN = SlotNumber(Number(boundarySlot) - 1);


### PR DESCRIPTION
## What

Fixes a low-frequency (~1 in 140) startup-race flake in the `proof_boundary` multi-node e2e suite (CI hash `c06563e7d2b7e067`, group `e2e-p2p-epoch-flakes`). All five scenarios time out in the shared `computeBoundarySlot()` helper at `waitUntilCheckpointNumber(1)` — the 3-validator committee never produces its first checkpoint.

## Why

`setupTest` created the three validator nodes sequentially (`asyncMap`) and started each sequencer at node construction. A node subscribes to the gossip topics when its P2P client starts (unconditionally, at node creation), but the in-memory mock gossip bus has no message replay. So when the first-created validator happened to draw the first slot's proposer, it broadcast the inaugural block proposal before the other two committee members had been created and subscribed — the proposal was lost, the 3-of-3 quorum was missed, and the chain forked onto genesis and never produced checkpoint 1. It's randao-dependent (fatal only when the first-created node is the first proposer), hence the low frequency.

## Fix

Create the validator nodes with `dontStartSequencer: true`, then `startSequencers(nodes)` once all three exist. All peers subscribe to gossip at creation, so no proposal is broadcast before the whole committee is on the bus. This matches the pattern already used by the non-flaky sibling tests `first_slot.test.ts` and `block-production/setup.ts`.

## Scope

Test-only change. Related to A-1419, which tracks the underlying product-level recovery race (competing block-1 re-executions surfacing as `BlockNumberNotSequentialError`). This PR implements that issue's "keep the test startup barrier" acceptance criterion but does **not** resolve A-1419 — the product-side race is unchanged.