### PR TITLE
feat(wallets): interactive handshake responder in EmbeddedWallet

### DIFF
--- a/yarn-project/wallets/src/embedded/embedded_wallet.test.ts
+++ b/yarn-project/wallets/src/embedded/embedded_wallet.test.ts
@@ -112,7 +112,7 @@ describe('EmbeddedWallet', () => {
     });
   });
 
-  describe('respondToInteractiveHandshake', () => {
+  describe('interactive handshakes', () => {
     let walletDB: WalletDB;
     let completeAddress: CompleteAddress;
     let registerTaggingSecretSource: jest.MockedFunction<PXE['registerTaggingSecretSource']>;
@@ -178,12 +178,39 @@ describe('EmbeddedWallet', () => {
       expect(registerTaggingSecretSource).not.toHaveBeenCalled();
       expect(await walletDB.listHandshakeBackups()).toEqual([]);
     });
+
+    it("re-derives an account's handshakes from backup, mapping each stored ephPkX to the source ephPk", async () => {
+      // The recipient authorized two handshakes; a PXE reinstall keeps the durable wallet DB but loses the sources.
+      const firstEphPkX = Fr.random();
+      const secondEphPkX = Fr.random();
+      await walletDB.storeHandshakeBackup({ recipient: completeAddress.address, ephPkX: firstEphPkX });
+      await walletDB.storeHandshakeBackup({ recipient: completeAddress.address, ephPkX: secondEphPkX });
+      // A different account's handshake must not be dragged in: PXE could not derive its secret here anyway.
+      await walletDB.storeHandshakeBackup({ recipient: (await CompleteAddress.random()).address, ephPkX: Fr.random() });
+
+      await wallet.restoreInteractiveHandshakesForAccount(completeAddress.address);
+
+      // Both of this account's handshakes are re-registered (order is not significant) and the other account's is
+      // not, each stored ephPkX mapped back to the source ephPk.
+      expect(registerTaggingSecretSource).toHaveBeenCalledTimes(2);
+      expect(registerTaggingSecretSource.mock.calls).toContainEqual([
+        { kind: 'handshake', recipient: completeAddress.address, ephPk: firstEphPkX },
+      ]);
+      expect(registerTaggingSecretSource.mock.calls).toContainEqual([
+        { kind: 'handshake', recipient: completeAddress.address, ephPk: secondEphPkX },
+      ]);
+    });
   });
 });
 
 class TestWallet extends EmbeddedWallet {
   override getAccounts(): Promise<Aliased<AztecAddress>[]> {
     return Promise.resolve([]);
+  }
+
+  // Exposes the protected per-account handshake restore, which production drives from account registration.
+  override restoreInteractiveHandshakesForAccount(recipient: AztecAddress): Promise<void> {
+    return super.restoreInteractiveHandshakesForAccount(recipient);
   }
 }
 

--- a/yarn-project/wallets/src/embedded/embedded_wallet.test.ts
+++ b/yarn-project/wallets/src/embedded/embedded_wallet.test.ts
@@ -1,12 +1,20 @@
 import { NO_FROM } from '@aztec/aztec.js/account';
 import type { Aliased } from '@aztec/aztec.js/wallet';
-import { Fr } from '@aztec/foundation/curves/bn254';
+import { Fq, Fr } from '@aztec/foundation/curves/bn254';
+import { openTmpStore } from '@aztec/kv-store/lmdb-v2';
 import type { PXE } from '@aztec/pxe/server';
+import {
+  INTERACTIVE_HANDSHAKE_REQUEST_KIND,
+  STANDARD_HANDSHAKE_REGISTRY_ADDRESS,
+  STANDARD_HANDSHAKE_REGISTRY_CLASS_ID,
+} from '@aztec/standard-contracts/handshake-registry/constants';
 import { FunctionCall, FunctionSelector, FunctionType } from '@aztec/stdlib/abi';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
+import { CompleteAddress } from '@aztec/stdlib/contract';
 import { Gas, GasFees } from '@aztec/stdlib/gas';
 import type { AztecNode } from '@aztec/stdlib/interfaces/client';
 import type { PrivateKernelTailCircuitPublicInputs } from '@aztec/stdlib/kernel';
+import { deriveMasterMessageSigningSecretKey, derivePublicKeyFromSecretKey } from '@aztec/stdlib/keys';
 import {
   ExecutionPayload,
   PrivateCallExecutionResult,
@@ -18,7 +26,7 @@ import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 
 import type { AccountContractsProvider } from './account-contract-providers/types.js';
 import { EmbeddedWallet } from './embedded_wallet.js';
-import type { WalletDB } from './wallet_db.js';
+import { WalletDB } from './wallet_db.js';
 
 describe('EmbeddedWallet', () => {
   let pxe: PXE;
@@ -101,6 +109,74 @@ describe('EmbeddedWallet', () => {
           fee: { gasSettings: { gasLimits: Gas.from({ daGas: 5000, l2Gas: 2000 }) } },
         }),
       ).rejects.toThrow('Declared DA gas limit (5000) exceeds the maximum this network allows per tx (1000)');
+    });
+  });
+
+  describe('respondToInteractiveHandshake', () => {
+    let walletDB: WalletDB;
+    let completeAddress: CompleteAddress;
+    let registerTaggingSecretSource: jest.MockedFunction<PXE['registerTaggingSecretSource']>;
+
+    let accountSecretKey: Fr;
+
+    beforeEach(async () => {
+      walletDB = new WalletDB(await openTmpStore('embedded-wallet-test'), () => {});
+      completeAddress = await CompleteAddress.random();
+      accountSecretKey = Fr.random();
+      await walletDB.storeAccount(completeAddress.address, {
+        type: 'schnorr',
+        secretKey: accountSecretKey,
+        salt: Fr.random(),
+        signingKey: Fq.random(),
+        alias: 'alice',
+      });
+
+      registerTaggingSecretSource = jest.fn<PXE['registerTaggingSecretSource']>().mockResolvedValue(undefined);
+      pxe = {
+        registerTaggingSecretSource,
+        getRegisteredAccounts: jest.fn<PXE['getRegisteredAccounts']>().mockResolvedValue([completeAddress]),
+      } as unknown as PXE;
+      wallet = new TestWallet(pxe, node, walletDB, {} as AccountContractsProvider);
+    });
+
+    it('registers the handshake with PXE, persists the backup, and signs for the requested account', async () => {
+      const ephPkX = Fr.random();
+      const recipientSignature = await wallet.respondToInteractiveHandshake({
+        contractAddress: STANDARD_HANDSHAKE_REGISTRY_ADDRESS,
+        contractClassId: STANDARD_HANDSHAKE_REGISTRY_CLASS_ID,
+        kind: INTERACTIVE_HANDSHAKE_REQUEST_KIND,
+        payload: [completeAddress.address.toField(), new Fr(1), new Fr(1), ephPkX],
+      });
+
+      expect(recipientSignature.publicKeys).toEqual(completeAddress.publicKeys);
+      expect(recipientSignature.partialAddress).toEqual(completeAddress.partialAddress);
+      expect(registerTaggingSecretSource).toHaveBeenCalledWith({
+        kind: 'handshake',
+        recipient: completeAddress.address,
+        ephPk: ephPkX,
+      });
+      expect(await walletDB.listHandshakeBackups()).toEqual([{ recipient: completeAddress.address, ephPkX }]);
+
+      // The signing key must be the master message-signing key derived from the persisted account secret.
+      const mspk = await derivePublicKeyFromSecretKey(deriveMasterMessageSigningSecretKey(accountSecretKey));
+      const [mspkX, mspkYIsPositive] = mspk.toXAndSign();
+      expect(recipientSignature.mspkX).toEqual(mspkX);
+      expect(recipientSignature.mspkYIsPositive).toEqual(mspkYIsPositive);
+    });
+
+    it('rejects a request for an account not registered on the PXE, with no side effects', async () => {
+      const stranger = await CompleteAddress.random();
+
+      await expect(
+        wallet.respondToInteractiveHandshake({
+          contractAddress: STANDARD_HANDSHAKE_REGISTRY_ADDRESS,
+          contractClassId: STANDARD_HANDSHAKE_REGISTRY_CLASS_ID,
+          kind: INTERACTIVE_HANDSHAKE_REQUEST_KIND,
+          payload: [stranger.address.toField(), new Fr(1), new Fr(1), Fr.random()],
+        }),
+      ).rejects.toThrow('account not held by this wallet');
+      expect(registerTaggingSecretSource).not.toHaveBeenCalled();
+      expect(await walletDB.listHandshakeBackups()).toEqual([]);
     });
   });
 });

--- a/yarn-project/wallets/src/embedded/embedded_wallet.ts
+++ b/yarn-project/wallets/src/embedded/embedded_wallet.ts
@@ -156,11 +156,10 @@ export class EmbeddedWallet extends BaseWallet {
   }
 
   /**
-   * Authorizes an interactive handshake for one of this wallet's accounts: validates that the request comes from the
-   * standard HandshakeRegistry, registers the handshake with PXE so scanning discovers the channel's messages,
-   * durably backs up the channel's identity in the wallet DB, and only then signs. Callers are expected to gate this
-   * on user consent; the returned signature is what travels back to the sender over whatever channel carried the
-   * request.
+   * Authorizes an interactive handshake for one of this wallet's accounts, wiring PXE, key derivation, and the
+   * wallet DB backup into {@link createInteractiveHandshakeResponder}, which enforces the validate, register,
+   * back up, then sign order. Callers are expected to gate this on user consent; the returned signature travels
+   * back to the sender over whatever channel carried the request.
    */
   respondToInteractiveHandshake(request: InteractiveHandshakeCustomRequest): Promise<RecipientSignature> {
     const responder = createInteractiveHandshakeResponder({

--- a/yarn-project/wallets/src/embedded/embedded_wallet.ts
+++ b/yarn-project/wallets/src/embedded/embedded_wallet.ts
@@ -31,6 +31,7 @@ import { AztecAddress } from '@aztec/stdlib/aztec-address';
 import { getContractClassFromArtifact } from '@aztec/stdlib/contract';
 import { GasSettings } from '@aztec/stdlib/gas';
 import type { AztecNode } from '@aztec/stdlib/interfaces/client';
+import { deriveMasterMessageSigningSecretKey } from '@aztec/stdlib/keys';
 import {
   type ContractOverrides,
   ExecutionPayload,
@@ -43,11 +44,19 @@ import {
   mergeExecutionPayloads,
 } from '@aztec/stdlib/tx';
 import { BaseWallet, type SimulateViaEntrypointOptions, getGasLimits } from '@aztec/wallet-sdk/base-wallet';
+import {
+  type InteractiveHandshakeCustomRequest,
+  type RecipientSignature,
+  createInteractiveHandshakeResponder,
+} from '@aztec/wallet-sdk/delivery';
 
 import type { AccountContractsProvider } from './account-contract-providers/types.js';
 import { type AccountType, WalletDB } from './wallet_db.js';
 
-/** Options for the PXE instance created by the EmbeddedWallet. */
+/**
+ * Options for the PXE instance created by the EmbeddedWallet. Sender-side delivery hooks (e.g. an interactive
+ * handshake resolver from `@aztec/wallet-sdk/delivery`) ride `hooks.resolveCustomRequest`.
+ */
 export type EmbeddedWalletPXEOptions = Partial<PXEConfig> & PXECreationOptions;
 
 /** Splits a unified EmbeddedWalletPXEOptions into PXEConfig overrides and PXECreationOptions. */
@@ -144,6 +153,25 @@ export class EmbeddedWallet extends BaseWallet {
       }
     }
     return storedSenders;
+  }
+
+  /**
+   * Authorizes an interactive handshake for one of this wallet's accounts: validates that the request comes from the
+   * standard HandshakeRegistry, registers the handshake with PXE so scanning discovers the channel's messages,
+   * durably backs up the channel's identity in the wallet DB, and only then signs. Callers are expected to gate this
+   * on user consent; the returned signature is what travels back to the sender over whatever channel carried the
+   * request.
+   */
+  respondToInteractiveHandshake(request: InteractiveHandshakeCustomRequest): Promise<RecipientSignature> {
+    const responder = createInteractiveHandshakeResponder({
+      pxe: this.pxe,
+      // The master message-signing secret key deliberately never touches PXE or the key store; it is derived
+      // on demand from the account secret persisted in the wallet DB.
+      getSigningKey: async recipient =>
+        deriveMasterMessageSigningSecretKey((await this.walletDB.retrieveAccount(recipient)).secretKey),
+      backup: { store: entry => this.walletDB.storeHandshakeBackup(entry) },
+    });
+    return responder(request);
   }
 
   /**

--- a/yarn-project/wallets/src/embedded/embedded_wallet.ts
+++ b/yarn-project/wallets/src/embedded/embedded_wallet.ts
@@ -48,6 +48,7 @@ import {
   type InteractiveHandshakeCustomRequest,
   type RecipientSignature,
   createInteractiveHandshakeResponder,
+  restoreInteractiveHandshakes,
 } from '@aztec/wallet-sdk/delivery';
 
 import type { AccountContractsProvider } from './account-contract-providers/types.js';
@@ -168,9 +169,20 @@ export class EmbeddedWallet extends BaseWallet {
       // on demand from the account secret persisted in the wallet DB.
       getSigningKey: async recipient =>
         deriveMasterMessageSigningSecretKey((await this.walletDB.retrieveAccount(recipient)).secretKey),
-      backup: { store: entry => this.walletDB.storeHandshakeBackup(entry) },
+      backup: entry => this.walletDB.storeHandshakeBackup(entry),
     });
     return responder(request);
+  }
+
+  /**
+   * Re-registers an account's interactive handshakes from durable backup into PXE. Interactive handshakes are the one
+   * piece of account metadata PXE cannot rebuild from the chain, so they are restored as the account itself is
+   * registered into PXE (see {@link createAccountInternal}), when the account's keys are present for PXE to derive
+   * each handshake's scanning secret. Idempotent, and a no-op for an account with no backed-up handshakes.
+   */
+  protected async restoreInteractiveHandshakesForAccount(recipient: AztecAddress): Promise<void> {
+    const entries = (await this.walletDB.listHandshakeBackups()).filter(entry => entry.recipient.equals(recipient));
+    await restoreInteractiveHandshakes(this.pxe, entries);
   }
 
   /**
@@ -447,6 +459,9 @@ export class EmbeddedWallet extends BaseWallet {
         !existingArtifact ? await accountManager.getAccountContract().getContractArtifact() : undefined,
         accountManager.getSecretKey(),
       );
+      // The account's keys are now in PXE, so its interactive handshakes (account metadata PXE cannot rebuild from
+      // the chain) can be re-registered from backup for scanning to rediscover their messages.
+      await this.restoreInteractiveHandshakesForAccount(instance.address);
       if (type === 'schnorr_initializerless') {
         const constructor = artifact.functions.find(f => f.name === 'constructor');
         if (!constructor) {

--- a/yarn-project/wallets/src/embedded/wallet_db.test.ts
+++ b/yarn-project/wallets/src/embedded/wallet_db.test.ts
@@ -195,4 +195,49 @@ describe('WalletDB', () => {
       },
     );
   });
+
+  describe('storeHandshakeBackup / listHandshakeBackups', () => {
+    it('returns empty list initially', async () => {
+      expect(await db.listHandshakeBackups()).toEqual([]);
+    });
+
+    it('round-trips entries across recipients', async () => {
+      const recipient1 = await AztecAddress.random();
+      const recipient2 = await AztecAddress.random();
+      const entry1 = { recipient: recipient1, ephPkX: Fr.random() };
+      const entry2 = { recipient: recipient1, ephPkX: Fr.random() };
+      const entry3 = { recipient: recipient2, ephPkX: Fr.random() };
+      await db.storeHandshakeBackup(entry1);
+      await db.storeHandshakeBackup(entry2);
+      await db.storeHandshakeBackup(entry3);
+
+      const entries = await db.listHandshakeBackups();
+      expect(entries).toHaveLength(3);
+      expect(entries).toContainEqual(entry1);
+      expect(entries).toContainEqual(entry2);
+      expect(entries).toContainEqual(entry3);
+    });
+
+    it('re-storing the same entry is idempotent', async () => {
+      const entry = { recipient: await AztecAddress.random(), ephPkX: Fr.random() };
+      await db.storeHandshakeBackup(entry);
+      await db.storeHandshakeBackup(entry);
+
+      expect(await db.listHandshakeBackups()).toEqual([entry]);
+    });
+
+    it("deleteAccount removes only that account's backup entries", async () => {
+      const deleted = await AztecAddress.random();
+      const kept = await AztecAddress.random();
+      await db.storeAccount(deleted, makeAccountData('schnorr', 'alice'));
+      const keptEntry = { recipient: kept, ephPkX: Fr.random() };
+      await db.storeHandshakeBackup({ recipient: deleted, ephPkX: Fr.random() });
+      await db.storeHandshakeBackup({ recipient: deleted, ephPkX: Fr.random() });
+      await db.storeHandshakeBackup(keptEntry);
+
+      await db.deleteAccount(deleted);
+
+      expect(await db.listHandshakeBackups()).toEqual([keptEntry]);
+    });
+  });
 });

--- a/yarn-project/wallets/src/embedded/wallet_db.ts
+++ b/yarn-project/wallets/src/embedded/wallet_db.ts
@@ -65,8 +65,8 @@ export class WalletDB {
   }
 
   /**
-   * Durably persists an interactive handshake's recoverable identity. Idempotent for the same entry. This is the one
-   * piece of wallet state that cannot be rebuilt from the chain plus account keys.
+   * Durably persists an interactive handshake's recoverable identity, the one piece of wallet state that cannot be
+   * rebuilt from the chain plus account keys. Idempotent for the same entry.
    */
   async storeHandshakeBackup({ recipient, ephPkX }: InteractiveHandshakeBackupEntry) {
     // Self-contained fixed-width value (32-byte recipient + 32-byte ephPkX), so listing does not depend on the

--- a/yarn-project/wallets/src/embedded/wallet_db.ts
+++ b/yarn-project/wallets/src/embedded/wallet_db.ts
@@ -3,6 +3,7 @@ import { Fq, Fr } from '@aztec/foundation/curves/bn254';
 import type { LogFn } from '@aztec/foundation/log';
 import type { AztecAsyncKVStore, AztecAsyncMap } from '@aztec/kv-store';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
+import type { InteractiveHandshakeBackupEntry } from '@aztec/wallet-sdk/delivery';
 
 export const AccountTypes = ['schnorr', 'schnorr_initializerless', 'ecdsasecp256r1', 'ecdsasecp256k1'] as const;
 export type AccountType = (typeof AccountTypes)[number];
@@ -17,6 +18,7 @@ export const WALLET_DATA_SCHEMA_VERSION = 1;
 export class WalletDB {
   private accounts: AztecAsyncMap<string, Buffer>;
   private aliases: AztecAsyncMap<string, Buffer>;
+  private handshakeBackups: AztecAsyncMap<string, Buffer>;
 
   constructor(
     private store: AztecAsyncKVStore,
@@ -24,6 +26,7 @@ export class WalletDB {
   ) {
     this.accounts = store.openMap<string, Buffer>('accounts');
     this.aliases = store.openMap<string, Buffer>('aliases');
+    this.handshakeBackups = store.openMap<string, Buffer>('handshakeBackups');
   }
 
   async storeAccount(
@@ -59,6 +62,31 @@ export class WalletDB {
   async storeSender(address: AztecAddress, alias: string, log: LogFn = this.userLog) {
     await this.aliases.set(`senders:${alias}`, Buffer.from(address.toString()));
     log(`Sender stored in database with alias ${alias}`);
+  }
+
+  /**
+   * Durably persists an interactive handshake's recoverable identity. Idempotent for the same entry. This is the one
+   * piece of wallet state that cannot be rebuilt from the chain plus account keys.
+   */
+  async storeHandshakeBackup({ recipient, ephPkX }: InteractiveHandshakeBackupEntry) {
+    // Self-contained fixed-width value (32-byte recipient + 32-byte ephPkX), so listing does not depend on the
+    // key format.
+    await this.handshakeBackups.set(
+      `${recipient.toString()}:${ephPkX.toString()}`,
+      Buffer.concat([recipient.toBuffer(), ephPkX.toBuffer()]),
+    );
+  }
+
+  /** Retrieves every persisted interactive-handshake backup entry. */
+  async listHandshakeBackups(): Promise<InteractiveHandshakeBackupEntry[]> {
+    const entries: InteractiveHandshakeBackupEntry[] = [];
+    for await (const value of this.handshakeBackups.valuesAsync()) {
+      entries.push({
+        recipient: AztecAddress.fromBuffer(value.subarray(0, 32)),
+        ephPkX: Fr.fromBuffer(value.subarray(32)),
+      });
+    }
+    return entries;
   }
 
   async retrieveAccount(address: AztecAddress | string) {
@@ -131,6 +159,11 @@ export class WalletDB {
     const alias = aliasesByAddress.get(address.toString());
     if (alias) {
       await this.aliases.delete(`accounts:${alias}`);
+    }
+    // A deleted account's handshake channels are unrecoverable by design; drop their backup rows.
+    const prefix = `${address.toString()}:`;
+    for await (const key of this.handshakeBackups.keysAsync({ start: prefix, end: `${prefix}\uffff` })) {
+      await this.handshakeBackups.delete(key);
     }
   }
 


### PR DESCRIPTION
Wires the interactive-handshake responder into the wallet product so wallets built on EmbeddedWallet write nothing:

- WalletDB gains a `handshakeBackups` table (fixed-width self-contained values, idempotent keying, no schema-version bump since bumping selects a fresh store; `deleteAccount` drops the deleted account's rows).
- `EmbeddedWallet.respondToInteractiveHandshake(request)` builds the responder from the wallet's own pieces: the signing key derived on demand from the persisted account secret, the backup backed by WalletDB. Callers gate on user consent.
- Sender side needs no new surface: a resolver rides the existing `EmbeddedWalletPXEOptions.hooks.resolveCustomRequest`.

Part 2/2 of the F-795 minimal wallet API. Recovery sweep, docs plus registerSender deprecation, and rehandshake follow per the plan.