### PR TITLE
chore: add new client

### DIFF
--- a/spartan/terraform/deploy-rpc/environments/mainnet/main.tf
+++ b/spartan/terraform/deploy-rpc/environments/mainnet/main.tf
@@ -122,6 +122,11 @@ module "environment" {
       gcp_secret_manager_secret_name = "mainnet-rpc-consumer-client7"
       rate_limit_minute              = 0
     }
+    client8 = {
+      username                       = "mainnet-rpc-consumer-client8"
+      gcp_secret_manager_secret_name = "mainnet-rpc-consumer-client8"
+      rate_limit_minute              = 0
+    }
   }
 
   IRM_METRICS_ENABLED = true


### PR DESCRIPTION
Adds `client8` (`mainnet-rpc-consumer-client8`) to the mainnet RPC consumers, following #24688 (client6+7).

The GCP Secret Manager secret is already created and this has been `terraform apply`-ed to the mainnet environment — the plan was exactly the two expected resources (KongConsumer + ExternalSecret) and is now live. Rate limit 0 = unlimited, matching the other consumers.