### PR TITLE
chore(ci): remove merge-train/spartan-v6 and v6-next wiring

### DIFF
--- a/.github/workflows/merge-train-create-pr.yml
+++ b/.github/workflows/merge-train-create-pr.yml
@@ -24,8 +24,8 @@ jobs:
             branch="${{ github.ref_name }}"
 
             # Determine base branch. Most trains target next; trains suffixed
-            # with -v<N> (e.g. spartan-v5, fairies-v5, spartan-v6) target the
-            # matching release line (v5-next, v6-next) instead.
+            # with -v<N> (e.g. spartan-v5, fairies-v5) target the matching
+            # release line (v5-next) instead.
             base_branch="next"
             if [[ "$branch" =~ -v([0-9]+)$ ]]; then
               base_branch="v${BASH_REMATCH[1]}-next"
@@ -55,10 +55,10 @@ jobs:
 
               # Create PR with ci-no-squash label
               labels="ci-no-squash"
-              if [[ "$branch" == "merge-train/spartan" || "$branch" == "merge-train/spartan-v5" || "$branch" == "merge-train/spartan-v6" || "$branch" == "merge-train/ci" ]]; then
+              if [[ "$branch" == "merge-train/spartan" || "$branch" == "merge-train/spartan-v5" || "$branch" == "merge-train/ci" ]]; then
                 labels="$labels,ci-full-no-test-cache"
               fi
-              # Trains targeting a v<N>-next release line (v5-next, v6-next) are
+              # Trains targeting a v<N>-next release line (v5-next) are
               # forward-ported into their base via the private-port-next driver.
               if [[ "$base_branch" =~ ^v[0-9]+-next$ ]]; then
                 labels="$labels,private-port-next"

--- a/.github/workflows/merge-train-next-to-branches.yml
+++ b/.github/workflows/merge-train-next-to-branches.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - next
       - v5-next
-      - v6-next
 
 jobs:
   merge-to-trains:
@@ -28,16 +27,12 @@ jobs:
           GH_TOKEN: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
           COMMIT_SHA: ${{ github.sha }}
         run: |
-          # The -v<N> trains track the matching release line (v5-next, v6-next);
-          # every other train tracks next. Sync only the trains fed by the
-          # branch that was just pushed.
+          # The -v<N> trains track the matching release line (v5-next); every
+          # other train tracks next. Sync only the trains fed by the branch
+          # that was just pushed.
           if [[ "${{ github.ref_name }}" == "v5-next" ]]; then
             for branch in merge-train/spartan-v5 merge-train/fairies-v5; do
               ./scripts/merge-train/merge-next.sh "$branch" v5-next || true
-            done
-          elif [[ "${{ github.ref_name }}" == "v6-next" ]]; then
-            for branch in merge-train/spartan-v6; do
-              ./scripts/merge-train/merge-next.sh "$branch" v6-next || true
             done
           else
             for branch in merge-train/avm merge-train/barretenberg merge-train/ci merge-train/docs merge-train/fairies merge-train/spartan; do

--- a/.github/workflows/merge-train-stale-check.yml
+++ b/.github/workflows/merge-train-stale-check.yml
@@ -38,22 +38,6 @@ jobs:
           BASE_BRANCH: v5-next
         run: ./ci3/merge_train_stale_check merge-train/spartan-v5 '#team-alpha'
 
-  spartan-v6:
-    name: Check merge-train/spartan-v6
-    if: ${{ github.event_name != 'schedule' || github.repository == 'AztecProtocol/aztec-packages' }}
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: read
-    steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
-      - name: Run stale check
-        env:
-          GH_TOKEN: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-          BASE_BRANCH: v6-next
-        run: ./ci3/merge_train_stale_check merge-train/spartan-v6 '#team-alpha'
-
   fairies-v5:
     name: Check merge-train/fairies-v5
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ Otherwise infer from the component being worked in:
 | `barretenberg/cpp/src/barretenberg/vm2/**` | `merge-train/avm` |
 | everything else | `next` |
 
-The bases above target the `next` line. For work scoped to a release line, use the matching `merge-train/spartan-v<N>` in place of `merge-train/spartan`: `merge-train/spartan-v5` targets `v5-next`, and `merge-train/spartan-v6` targets `v6-next` (the public staging line for v6 work).
+The bases above target the `next` line. For work scoped to the v5 release line, use `merge-train/spartan-v5` (which targets `v5-next`) in place of `merge-train/spartan`.
 
 Use the discovered base in `git diff origin/<base>...HEAD` and `git log origin/<base>..HEAD`. Always `git fetch` before creating branches so the base is not stale.
 </critical_never_assume_master>


### PR DESCRIPTION
Removes the `merge-train/spartan-v6` → `v6-next` wiring. The v6 line was a temporary public staging line while work settled on `next`; now that `next` is the mainline, it's being retired in favour of `merge-train/spartan`.

Changes:
- `merge-train-next-to-branches.yml`: drop the `v6-next` push trigger and its `elif` sync branch.
- `merge-train-stale-check.yml`: drop the `spartan-v6` job. This is the one with an active consequence — it runs daily from `next` and would start failing / paging `#team-alpha` once the branch is deleted.
- `merge-train-create-pr.yml`: drop the `spartan-v6` label reference and the `v6-next` comment mentions. The generic `-v<N>` base-branch handling stays, so the v5 line is unaffected.
- `CLAUDE.md`: drop the `spartan-v6 → v6-next` note from the base-branch section.

Companion cleanup (done separately): the open A-137x stack that sat on `merge-train/spartan-v6` has been rebased onto `merge-train/spartan`, and the `v6-next` / `merge-train/spartan-v6` branches are being deleted. Everything on those branches is already present on `v5-next`, so nothing is lost.
