### PR TITLE
fix(archiver): fully clean up removed blocks whose txs were re-included elsewhere

### DIFF
--- a/yarn-project/archiver/src/store/block_store.test.ts
+++ b/yarn-project/archiver/src/store/block_store.test.ts
@@ -2898,6 +2898,45 @@ describe('BlockStore', () => {
       expect(removedBlocks).toEqual([]);
     });
 
+    it('fully cleans up blocks sharing a tx effect', async () => {
+      // Two blocks carrying the same tx, as when a tx is re-included after its original proposal expired.
+      // Inserting block2 pointed the shared tx's index entry at block2, so deleting block1 must not remove it:
+      // doing so makes block2 unreadable, and a cleanup that skips unreadable blocks would then leak block2's
+      // row and tx effects to be overwritten in place by later inserts at the same number.
+      const block1 = await L2Block.random(BlockNumber(1), {
+        checkpointNumber: CheckpointNumber(1),
+        indexWithinCheckpoint: IndexWithinCheckpoint(0),
+        txsPerBlock: 2,
+      });
+      const block2 = await L2Block.random(BlockNumber(2), {
+        checkpointNumber: CheckpointNumber(1),
+        indexWithinCheckpoint: IndexWithinCheckpoint(1),
+        lastArchive: block1.archive,
+        txsPerBlock: 2,
+      });
+      const sharedTx = block1.body.txEffects[0];
+      block2.body.txEffects[0] = sharedTx;
+
+      await addProposedBlocks(blockStore, [block1, block2]);
+      expect((await blockStore.getTxEffect(sharedTx.txHash))?.l2BlockNumber).toBe(2);
+
+      const removedBlocks = await blockStore.removeBlocksAfter(BlockNumber(0));
+
+      expect(removedBlocks.map(b => b.number)).toEqual([1, 2]);
+      expect(await blockStore.getLatestL2BlockNumber()).toBe(0);
+      for (const tx of [sharedTx, block1.body.txEffects[1], block2.body.txEffects[1]]) {
+        expect(await blockStore.getTxEffect(tx.txHash)).toBeUndefined();
+      }
+      for (const block of [block1, block2]) {
+        expect(await blockStore.getBlock({ number: block.number })).toBeUndefined();
+        expect(await blockStore.getBlockNumber({ hash: await block.hash() })).toBeUndefined();
+        expect(await blockStore.getBlockNumber({ archive: block.archive.root })).toBeUndefined();
+      }
+
+      // The store accepts the same chain again: nothing stale was left behind.
+      await expect(addProposedBlocks(blockStore, [block1, block2])).resolves.toBe(true);
+    });
+
     it('cleans up related data (tx effects, hash index, archive index)', async () => {
       const block1 = await L2Block.random(BlockNumber(1), {
         checkpointNumber: CheckpointNumber(1),

--- a/yarn-project/archiver/src/store/block_store.ts
+++ b/yarn-project/archiver/src/store/block_store.ts
@@ -537,20 +537,40 @@ export class BlockStore {
   }
 
   /** Deletes a block and all associated data (tx effects, indices). */
-  private async deleteBlock(block: L2Block): Promise<void> {
+  private async deleteBlock(blockNumber: number, blockStorage: BlockStorage): Promise<void> {
     // Delete the block from the main blocks map
-    await this.#blocks.delete(block.number);
+    await this.#blocks.delete(blockNumber);
 
-    // Delete all tx effects for this block
-    await Promise.all(block.body.txEffects.map(tx => this.#txEffects.delete(tx.txHash.toString())));
+    const blockHash = bufferToHex(blockStorage.blockHash);
+
+    // Delete the tx effects of the block's txs, skipping entries that no longer point at this block: a tx
+    // also present in another stored block (e.g. re-included after its original proposal expired) has had
+    // its entry overwritten, and deleting it here would orphan that block's index.
+    const blockTxsBuffer = await this.#blockTxs.getAsync(blockHash);
+    if (blockTxsBuffer !== undefined) {
+      const reader = BufferReader.asReader(blockTxsBuffer);
+      const txHashes: string[] = [];
+      while (!reader.isEmpty()) {
+        txHashes.push(reader.readObject(TxHash).toString());
+      }
+      await Promise.all(txHashes.map(txHash => this.deleteTxEffectIfOwnedBy(txHash, blockStorage.blockHash)));
+    }
 
     // Delete block txs mapping
-    const blockHash = (await block.hash()).toString();
     await this.#blockTxs.delete(blockHash);
 
     // Clean up indices
     await this.#blockHashIndex.delete(blockHash);
-    await this.#blockArchiveIndex.delete(block.archive.root.toString());
+    await this.#blockArchiveIndex.delete(AppendOnlyTreeSnapshot.fromBuffer(blockStorage.archive).root.toString());
+  }
+
+  /** Deletes a tx effect only if it is still owned by (points at) the given block. */
+  private async deleteTxEffectIfOwnedBy(txHash: string, blockHash: Buffer): Promise<void> {
+    const stored = await this.#txEffects.getAsync(txHash);
+    // An IndexedTxEffect starts with the owning block hash (32 bytes) — see getTxLocation.
+    if (stored && Buffer.from(stored.buffer, stored.byteOffset, 32).equals(blockHash)) {
+      await this.#txEffects.delete(txHash);
+    }
   }
 
   /**
@@ -749,16 +769,24 @@ export class BlockStore {
 
       // Iterate from blockNumber + 1 to latestBlockNumber
       for (let bn = blockNumber + 1; bn <= latestBlockNumber; bn++) {
-        const block = await this.getBlock({ number: BlockNumber(bn) });
+        const blockStorage = await this.#blocks.getAsync(bn);
 
-        if (block === undefined) {
+        if (blockStorage === undefined) {
           this.#log.warn(`Cannot remove block ${bn} from the store since we don't have it`);
           continue;
         }
 
-        removedBlocks.push(block);
-        await this.deleteBlock(block);
-        this.#log.debug(`Removed block ${bn} ${(await block.hash()).toString()}`);
+        // Load the full block for the returned list when possible, but clean up from the raw row regardless:
+        // a block whose body can no longer be fully loaded must still release its row, tx effects, and indices,
+        // or later inserts at this number leave stale tx-effect entries pointing into the new chain.
+        const block = await this.getBlockFromBlockStorage(bn, blockStorage);
+        if (block !== undefined) {
+          removedBlocks.push(block);
+        } else {
+          this.#log.warn(`Removing block ${bn} whose body could not be fully loaded`);
+        }
+        await this.deleteBlock(bn, blockStorage);
+        this.#log.debug(`Removed block ${bn} ${bufferToHex(blockStorage.blockHash)}`);
       }
 
       return removedBlocks;


### PR DESCRIPTION
## Problem

`BlockStore`'s tx-effect index (txHash → owning block hash/position) can be corrupted when the same tx exists in two stored blocks at once — routine when a checkpoint proposal expires and the sequencer re-includes its txs:

1. **Blind delete** — `deleteBlock` removed `#txEffects` entries by txHash without checking the entry still points at the block being deleted. Inserting the re-included block repoints the shared tx's entry at the new block; deleting the old block then destroys the new block's entry, making that block unreadable (`Could not find tx effect for tx…`).
2. **Skip-on-unreadable leak** — `removeBlocksAfter` did `getBlock(bn) === undefined → warn + continue`, so an unreadable block's row, tx effects, and indices were never released. `addCheckpoints` later overwrites the leaked row in place ("L1 data is authoritative"), leaving **stale** tx-effect entries pointing at coordinates now occupied by different txs.

Downstream symptoms of a corrupted index: `getTxReceipt` reporting positions the chain no longer has, unreadable blocks being silently dropped from `getBlocks`/`getCheckpoints` responses (consumers see a checkpoint with missing blocks and no error), and `getL2ToL1MembershipWitness` resolving the wrong tx and throwing `The L2ToL1Message you are trying to prove inclusion of does not exist` for a message that is on-chain and proven.

## Fix

`removeBlocksAfter` now cleans up from the raw storage row, so blocks whose bodies can no longer be fully loaded still release their row, tx effects (enumerated from `#blockTxs`), and hash/archive indices. `deleteBlock` only deletes a tx-effect entry that is still owned by the block being removed (compares the entry's leading block hash), so a re-included tx's index survives the removal of its old block.

The regression test adds two proposed blocks sharing a tx effect and asserts `removeBlocksAfter` removes both and leaves no residue. Before this change it fails: block 1 is removed, block 2 becomes unreadable and leaks.

## Verification

- New test in `block_store.test.ts` (fails on the previous implementation, passes now).
- The modified store was additionally exercised standalone against the published 5.0.0 packages (this file is identical between v5.0.0 and next): shared-tx cleanup, index integrity (hash/archive lookups, re-adding the same chain), and plain suffix-removal behavior all pass; the old implementation fails the shared-tx case.

Related observation while debugging downstream (can file separately if useful): during reorg ingestion there is a read window where `getCheckpoints(n, …, { includeBlocks: true })` returns a checkpoint whose blocks are missing or empty with no warning — unreadable or not-yet-visible blocks are silently filtered out. Consumers that treat the returned payload as complete lose data; a loud error or a retryable signal would be safer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
