### PR TITLE
fix(docs-examples): pin typescript to 5.x in execute runner

### DIFF
--- a/docs/docs-developers/docs/tutorials/js_tutorials/aztecjs-getting-started.md
+++ b/docs/docs-developers/docs/tutorials/js_tutorials/aztecjs-getting-started.md
@@ -24,7 +24,7 @@ yarn init -y
 Next, add the TypeScript dependencies:
 
 ```sh
-yarn add typescript @types/node tsx
+yarn add "typescript@^5.3.3" @types/node tsx
 ```
 
 :::tip

--- a/docs/examples/ts/aztecjs_runner/run.sh
+++ b/docs/examples/ts/aztecjs_runner/run.sh
@@ -115,7 +115,10 @@ setup_project() {
         [ ${#NPM_DEPS[@]} -gt 0 ] && yarn_add_with_retry "${NPM_DEPS[@]}"
     fi
 
-    yarn_add_with_retry -D typescript tsx
+    # Pin typescript to the 5.x line used across the monorepo. An unpinned
+    # `yarn add typescript` now resolves to the 7.x native port, whose package
+    # layout has no lib/_tsc.js, so yarn 4's builtin compat patch fails to apply.
+    yarn_add_with_retry -D "typescript@^5.3.3" tsx
 
     # Copy tsconfig
     cp "$EXAMPLES_DIR/tsconfig.template.json" tsconfig.json


### PR DESCRIPTION
The `docs/examples/bootstrap.sh execute` step is failing CI. The example
runner does an unpinned `yarn add -D typescript tsx`, and `typescript@latest`
on npm is now `7.0.2` (the native port). Its package layout has no
`lib/_tsc.js`, so Yarn 4's builtin compat patch fails to apply:

```
Error: typescript@patch:...npm%3A7.0.2...: ENOENT: no such file or directory, lstat '.../lib/_tsc.js'
```

Pin the install to `typescript@^5.3.3` — the same line the rest of the monorepo
uses (resolves to 5.9.3) and matching the existing pin in
`docs/examples/ts/bootstrap.sh`. Verified with Yarn 4.13.0: the unpinned add
reproduces the `_tsc.js` error, the pinned add applies the compat patch cleanly.