### PR TITLE
feat(bb): detect unexplained duplicate witnesses

### DIFF
--- a/barretenberg/cpp/src/barretenberg/boomerang_value_detection/WITNESS_DUPLICATE_DETECTION.md
+++ b/barretenberg/cpp/src/barretenberg/boomerang_value_detection/WITNESS_DUPLICATE_DETECTION.md
@@ -1,0 +1,653 @@
+# Witness duplicate detection
+
+This document describes the witness duplicate detection mechanism in
+`boomerang_value_detection`.
+
+The analyzer flags witness values that repeat without a circuit-level reason. It
+collects every repeated value, removes the ones that a known relation explains,
+and reports whatever survives. Most of that work happens in the
+[candidate filtering pipeline](#candidate-filtering-pipeline). Two terms recur
+throughout:
+
+- **Provenance** is a structured tag a producer attaches to a derived witness at
+  construction time, identifying what produced the witness so the analyzer can
+  group witnesses that constraints genuinely force equal. See
+  [Construction-time provenance](#construction-time-provenance).
+- **Materialization** is the deterministic placement of a derived value into
+  known circuit rows or table slots, such as a Straus table cell or an `ecc_op`
+  limb. A duplicate confined to such rows is expected. See
+  [Materialization filters](#materialization-filters).
+
+## Contents
+
+- [What the analyzer looks for](#what-the-analyzer-looks-for)
+- [Graph model](#graph-model)
+- [Candidate filtering pipeline](#candidate-filtering-pipeline)
+- [Structural overlays](#structural-overlays)
+- [Construction-time provenance](#construction-time-provenance)
+- [Provenance soundness rule](#provenance-soundness-rule)
+- [Provenance categories](#provenance-categories)
+- [Rerun-varying filters](#rerun-varying-filters)
+- [Materialization filters](#materialization-filters)
+- [Suggested review order](#suggested-review-order)
+- [Adding or reviewing a suppression](#adding-or-reviewing-a-suppression)
+- [Appendix: how duplicate witnesses arise for each overlay](#appendix-how-duplicate-witnesses-arise-for-each-overlay)
+
+## What the analyzer looks for
+
+The analyzer searches for repeated witness values that the circuit doesn't
+explain. A repeated value is suspicious when two real witness variables have the
+same assigned field value but aren't forced equal by copy constraints, gate
+constraints, table consistency, or a known deterministic materialization rule.
+
+The report is value-first: the analyzer groups real witness indices by
+`builder.get_variable(idx)`. The analyzer ignores a value with only one
+occurrence. A value with several occurrences stays visible until one of the
+explanation mechanisms proves that all occurrences are non-problematic.
+
+The safe default is to report. A duplicate must not be hidden only because its
+value resembles a common gadget constant or table output.
+
+## Graph model
+
+The analyzer builds a graph over real witness indices. Edges in the main graph
+represent ordinary constraint dependencies: if a gate ties several wires
+together, their real witness indices are connected. Copy constraints are already
+encoded through `real_variable_index`, so two copy-equal witness indices
+collapse to one real index before duplicate detection.
+
+Duplicate suppression also uses duplicate-search overlays. These overlays are
+separate from the main graph. They don't change circuit semantics and serve only
+to decide whether a repeated value is already explained by a known structural
+relation.
+
+A structural overlay suppresses a duplicate value only when all occurrences of
+that value are in the same duplicate component. If only some occurrences touch an
+overlay, the value remains visible. The analyzer treats a partial explanation as
+incomplete evidence.
+
+```mermaid
+flowchart TB
+    subgraph FULL["All occurrences in one component: suppressed"]
+        direction LR
+        a1((w1)) --- a2((w2)) --- a3((w3))
+    end
+    subgraph PARTIAL["One occurrence unconnected: stays visible"]
+        direction LR
+        b1((w1)) --- b2((w2))
+        b3((w3))
+    end
+```
+
+The circles are witnesses holding the same value; the lines are overlay edges.
+
+## Candidate filtering pipeline
+
+`StaticAnalyzer::fill_witness_duplicate_map` applies the following pipeline. Each
+stage removes the values it can explain and passes the rest on; whatever survives
+is reported.
+
+```mermaid
+flowchart TD
+    A["Repeated values<br/>grouped by field value"] --> B["Drop single-occurrence values"]
+    B --> C["Build duplicate-search overlays"]
+    C --> D{"Databus overlay<br/>explains all occurrences?"}
+    D -- yes --> Z(["Suppressed"])
+    D -- no --> E{"Cryptographic-binding rule<br/>explains all occurrences?"}
+    E -- yes --> Z
+    E -- no --> F{"Structural components<br/>connect all occurrences?"}
+    F -- yes --> Z
+    F -- "partial / no" --> G["Remove rerun-varying filter values"]
+    G -- filtered --> Z
+    G --> H["Triage value filters<br/>(TRIAGE_VALUE_FILTERS mode only)"]
+    H -- filtered --> Z
+    H --> I["Materialization filters"]
+    I -- filtered --> Z
+    I --> R(["Reported with indices<br/>and gate-type distribution"])
+```
+
+1. Build `filtered_witness_value_map` from witness value to the set of real
+   witness indices carrying that value. Candidate construction doesn't drop
+   values just because they're common constants, table values, or
+   caller-provided mock-proof values.
+2. Remove values with a single occurrence.
+3. Build duplicate-search overlays for known relations.
+4. Remove a value if the databus overlay connects all its occurrences.
+5. Remove a value if the narrow cryptographic-binding rule for the batch-merge
+   ECC-op hash rehash explains all its occurrences.
+6. Remove a value if the combined structural overlay components connect all its
+   occurrences.
+7. Keep values that only partially intersect the databus, cryptographic-binding,
+   or structural overlays.
+8. Remove caller-supplied rerun-varying filter values (see
+   [Rerun-varying filters](#rerun-varying-filters)). To compute these values,
+   the analyzer rebuilds the same circuit shape with randomized inputs and
+   compares the original duplicate witness slots against the rerun witness slots.
+9. In `TRIAGE_VALUE_FILTERS` mode only, remove common high-volume values and
+   caller-provided filter values after source-aware checks. `EXPLANATION_ONLY`
+   mode skips this value-only step.
+10. Apply narrow materialization filters for MSM, ECC-op, elliptic, modulus
+    arithmetic, constants, and fixed witnesses (see
+    [Materialization filters](#materialization-filters)).
+11. Print any remaining repeated values with their indices and gate-type
+    distribution.
+
+The gate-type distribution in the output is intentionally part of triage. A
+remaining duplicate in ordinary arithmetic rows is more interesting than one
+isolated to expected materialization rows.
+
+## Structural overlays
+
+The overlay set includes these explanation sources:
+
+- ROM/RAM memory table structure
+- databus reads
+- non-native-field derivations
+- arithmetic derivations
+- elliptic operation derivations
+- ECC-op table structure
+- lookup table structure
+- Straus table structure
+- construction-time duplicate provenance groups
+- a cryptographic-binding duplicate explanation for the batch-merge ECC-op hash
+  rehash
+
+The layout-based overlays recognize established gate and table layouts. They
+stay narrow and source-aware: each one must explain only values whose repeated
+occurrences come from the same structural relation. For how each source produces
+duplicate witnesses in the first place, see the
+[appendix](#appendix-how-duplicate-witnesses-arise-for-each-overlay).
+
+`build_provenance_duplicate_adjacency` produces the construction-time provenance
+overlay. It groups real witness indices by provenance key and connects all
+indices in each group.
+
+## Construction-time provenance
+
+Some producers have more information than the analyzer can recover from
+selectors after the fact. Those producers tag derived witnesses at construction
+time using the analyzer-only channel on `CircuitBuilderBase`:
+
+```cpp
+std::unordered_map<uint32_t, DuplicateProvenance> witness_duplicate_provenance;
+```
+
+You can find producer-side integrations with this search tag:
+
+```text
+BOOMERANG_DUPLICATE_PROVENANCE
+```
+
+Every piece of code outside `boomerang_value_detection/` that reads, writes,
+propagates, or supports this construction-time duplicate provenance channel must
+carry that tag near the integration point and point back to this file.
+
+The map key is a real variable index. The value is a structured group key:
+
+```cpp
+struct DuplicateProvenance {
+    DuplicateProvenanceCategory category;
+    std::vector<uint64_t> local_id;
+};
+```
+
+`category` identifies the producer family. `local_id` is a producer-scoped
+sequence of identity words. Build producer-local ids with
+`duplicate_provenance_local_id`, `append_duplicate_provenance_identity`, and the
+builder-local interned provenance identity helper, so that nested provenance and
+raw witness identities encode consistently without recursively expanding large
+keys. The builder assigns interned ids by exact `DuplicateProvenance` equality;
+the hash table is only an implementation detail for lookup. Use named enums or
+constants for producer-local discriminator words, not unexplained literals.
+
+The public API is:
+
+```cpp
+static DuplicateProvenance make_duplicate_provenance(DuplicateProvenanceCategory category,
+                                                     DuplicateProvenanceLocalId local_id);
+static DuplicateProvenance make_duplicate_provenance(DuplicateProvenanceCategory category,
+                                                     std::initializer_list<uint64_t> local_id);
+static DuplicateProvenance make_duplicate_provenance(DuplicateProvenanceCategory category, uint64_t local_id);
+void tag_duplicate_provenance(uint32_t witness_index, const DuplicateProvenance& group_key);
+const std::unordered_map<uint32_t, DuplicateProvenance>& get_duplicate_provenance() const;
+uint64_t get_duplicate_provenance_id(const DuplicateProvenance& group_key);
+DuplicateProvenanceLocalId get_duplicate_provenance_interned_identity(const DuplicateProvenance& group_key);
+```
+
+`tag_duplicate_provenance` canonicalizes the witness through
+`real_variable_index`. The channel isn't serialized and takes no part in
+proving.
+
+`assert_equal` propagates provenance across copy constraints. If the canonical
+representative lacks a key and the merged witness has one, `assert_equal` copies
+the key to the canonical real index. If both sides have different keys,
+`assert_equal` rewrites the old key to the canonical key throughout the map,
+because the new copy constraint forces those groups equal.
+
+This normal provenance overlay deliberately excludes
+`POSEIDON2_CRYPTOGRAPHIC_BINDING`. That category marks a different kind of
+evidence, described in the following section, and the analyzer must not treat it
+as constraint-forced equality.
+
+## Provenance soundness rule
+
+A producer can assign the same duplicate provenance group key to two witnesses
+only if the circuit constraints force those two witnesses to hold equal values
+on every satisfying assignment.
+
+Good local ids are based on witness identity and the deterministic operation
+that created the output. Use real variable indices, operation discriminators,
+table ids, row or column slots, and fixed-width parameters. Don't base them on
+runtime values alone.
+
+Two independently assigned witnesses with equal values must receive different
+provenance keys unless a constraint forces them equal.
+
+Prefer under-tagging to over-tagging. Untagged duplicates are noisy. Incorrectly
+grouped duplicates can hide real bugs.
+
+## Provenance categories
+
+`BIGFIELD_REDUCTION`
+
+Covers deterministic reduction intermediates:
+
+- double-width limb decomposition outputs
+- `self_reduce` quotient and remainder limbs
+- `unsafe_evaluate_multiply_add` carry limbs
+
+Keys include an operation discriminator, relevant input limb identities, width
+parameters where needed, and an output slot.
+
+`MSM_TABLE`
+
+Covers deterministic group-operation and table materializations:
+
+- `cycle_group` double outputs
+- `cycle_group` add/subtract outputs
+- Straus ROM table cell coordinates
+- Straus ROM read outputs
+- Straus plookup read outputs
+
+Keys include operation discriminators, affine field identities, table identity,
+selected table slot, and coordinate slot. The x and y coordinates of one point
+use distinct coordinate slots.
+
+`POSEIDON2_PERMUTATION`
+
+Covers Poseidon2 round intermediates. The key derives from the identity of the
+four input-state elements before the initial linear layer mutates the state,
+plus the exact generated-state slot (initial layer, external/internal round, and
+state element). Different slots in one permutation use different keys.
+
+`POSEIDON2_CRYPTOGRAPHIC_BINDING`
+
+Covers the single intended Chonk/batch-merge rehash pattern. The hiding kernel
+first computes the running ECC-op commitment hash from
+`witness_commitments.get_ecc_op_wires()`. The batch-merge recursive verifier
+then recomputes the same hash as the transcript challenge `HASH_i` over the
+proof-supplied `COLUMN_0_i` through `COLUMN_3_i` commitments.
+
+This category isn't a normal provenance group:
+`BatchMergeVerifier::check_hash_consistency` binds the two computations by
+comparing the selected transcript hash with `split_challenge(running_hash)[0]`,
+and carries the existing 2^-127 collision caveat. The analyzer suppresses
+duplicates in this category only when every duplicate occurrence is in the same
+cryptographic-binding group and the group contains both roles: `RUNNING_HASH`
+and `TRANSCRIPT_HASH`. A same-role duplicate remains visible.
+
+`DATABUS_READ`
+
+Covers fixed-slot databus materializations and variable-index read outputs.
+Appended bus entries and constant/fixed-index reads use a `(bus_idx, slot)`
+identity. Non-fixed index reads use `(bus_idx, index witness identity)` and
+deliberately don't share the source slot key merely because the current index
+value selects that slot.
+
+`ECC_OP_TABLE`
+
+Covers the four point limbs materialized into Mega's `ecc_op` block. The key is
+based on opcode, per-circuit serialization slot, and limb slot. The analyzer
+doesn't tag random ops. The four limbs of one op must not share one key, because
+they aren't forced equal to each other.
+
+`LOOKUP_TABLE`
+
+Covers generic lookup accumulator witnesses. Keys include table identity,
+one-key or two-key mode, key witness identities, column, and row. If a key
+witness already has duplicate provenance, the lookup key identity includes that
+key. Distinct key witnesses that merely hold the same field value must not share
+a lookup provenance key.
+
+`RANGE_DECOMPOSITION`
+
+Covers limbed range-decomposition outputs. Keys include the input real variable
+identity, total bit length, target limb width, and limb slot.
+
+## Rerun-varying filters
+
+Some gadgets, notably AES lookup-heavy circuits, can produce repeated witness
+values that are tied to runtime inputs rather than to a fixed reused witness. The
+analyzer supports an opt-in rerun filter for these cases:
+
+1. Build the baseline circuit and call `fill_witness_duplicate_map` in
+   `EXPLANATION_ONLY` mode.
+2. Rebuild the same circuit shape with randomized inputs one or more times.
+3. Call `get_rerun_varying_duplicate_values` on the baseline analyzer with the
+   rerun builders.
+4. Rebuild or re-analyze the baseline circuit with those values passed as
+   `rerun_varying_filter_values`.
+
+The comparison is slot-based. For each remaining duplicate value in the baseline
+map, the helper checks the same real witness indices in each rerun builder. If
+any corresponding rerun witness has a different value, the baseline value counts
+as input-dependent and the analyzer can filter it. This catches small values as
+well as high-entropy values, because the decision doesn't depend on the numeric
+magnitude of the field element.
+
+This isn't a default suppression, by design. Use it for known noisy diagnostics
+where the circuit shape is stable across reruns. Don't use it to replace
+provenance or structural overlays for a relation that constraints can explain
+directly.
+
+## Materialization filters
+
+After structural overlays, the analyzer applies narrow use-site filters. These
+remove values only when every occurrence stays within a known non-problematic
+materialization pattern:
+
+- `MSM_TABLE` provenance mixed only with memory-only ROM/RAM copies
+- every occurrence has `ECC_OP_TABLE` provenance and appears only in `ecc_op`
+  plus fixed/modulus or Poseidon materialization rows
+- elliptic outputs mixed only with fixed/modulus materialization rows
+- fixed witnesses and BN254 modulus-arithmetic rows
+- ordinary constants and `fix_witness` rows
+
+These filters check where a witness is used, not just what value it holds. A
+provenance category by itself isn't enough to suppress a duplicate; the
+occurrences must still be explained by a precise key or component, or by a narrow
+use-site pattern.
+
+## Suggested review order
+
+For a human review, the diff is easiest to audit in this order:
+
+1. `duplicate_provenance.hpp` and the `CircuitBuilderBase` API, including
+   `assert_equal` propagation.
+2. Producer tags, one category at a time: bigfield, databus, Poseidon2, ECC-op,
+   MSM/Straus, lookup, and range decomposition.
+3. Analyzer consumption in `graph.cpp`: provenance overlay, structural overlays,
+   then materialization filters in `fill_witness_duplicate_map`.
+4. Focused provenance tests in `graph_description_provenance.test.cpp` and
+   producer-specific tests.
+5. Slow recursive duplicate tests, which are the integration signal that the
+   analyzer considers no remaining duplicate dangerous.
+
+## Adding or reviewing a suppression
+
+When adding a new suppression mechanism, answer these questions:
+
+1. What exact constraint or table relation forces all grouped witnesses equal?
+2. Does the grouping key use witness identity rather than runtime value?
+3. Which operation, table, row, column, coordinate, or limb slot prevents
+   unrelated outputs from sharing a key?
+4. Can key construction add gates? If yes, it isn't acceptable.
+5. What happens when two distinct witnesses happen to carry the same field
+   value?
+6. Is partial-overlay contact kept visible?
+7. Is there a positive test for the intended suppression and a negative test for
+   a same-valued but unrelated duplicate?
+
+If any answer is unclear, keep the duplicate visible.
+
+## Appendix: how duplicate witnesses arise for each overlay
+
+Each structural overlay exists because a specific circuit construct legitimately
+produces the same field value on several independent witnesses. Without the
+overlay, those witnesses would all surface as unexplained duplicates. The entries
+below describe, for each source, how the repeated witnesses are created and what
+forces them equal. Every overlay except the last derives its equality from circuit
+constraints; the cryptographic-binding overlay is the sole exception.
+
+Every entry shares the same shape: one value the circuit reuses spreads across
+several fresh witnesses through a construct, and the overlay reconnects them so
+the repeat is explained rather than reported.
+
+```mermaid
+flowchart LR
+    subgraph SRC["one value the circuit reuses (ROM read, table, elliptic op, …)"]
+        direction LR
+        u1(("witness")) -. overlay .- u2(("witness"))
+        u2 -. overlay .- u3(("witness"))
+    end
+```
+
+**Reading the diagrams below.** A solid arrow means the circuit writes that
+witness. A dotted line is the equality the overlay adds — those witnesses collapse
+into one component and the duplicate is suppressed. A red outline marks a witness
+that deliberately stays visible, because no constraint forces it equal.
+
+### ROM/RAM memory table structure
+
+```mermaid
+flowchart TB
+    subgraph ROM["ROM slot i stores V — every read returns V"]
+        direction LR
+        romR1(("read = V")) -. overlay .- romR2(("read = V"))
+        romR2 -. overlay .- romS(("sorted row = V"))
+    end
+    subgraph RAM["RAM slot i — a read reuses the last write; a new write does not"]
+        direction LR
+        ramW(("write V")) -. overlay .- ramR(("read = V"))
+        ramW2(("second write = V")):::visible
+    end
+    classDef visible stroke:#e06c75,stroke-width:3px
+```
+
+_All reads of a ROM slot, plus its sorted row, hold the stored value and collapse.
+In RAM a read can reuse the previous write, but a second independent write of the
+same value stays visible (red)._
+
+A ROM or RAM table compiles to read/write gates plus a sorted, finalized copy of
+the memory transcript. One stored value therefore appears as several witnesses:
+the value written into the slot, each unsorted read output, and the matching
+sorted memory row. Every read of the same ROM slot returns the same value, so the
+read outputs duplicate each other and the stored value. The memory-consistency
+argument — record tags linked through `tau` to the sorted rows — forces them
+equal, so the overlay connects the outputs that belong to one table and slot. RAM
+is more restrictive: a read may reuse only the value established by the
+immediately previous access to that slot. Two writes of the same value stay
+independent, and visible, because nothing forces them equal.
+
+### Databus reads
+
+```mermaid
+flowchart TB
+    subgraph FIXED["Constant index → bus slot 3 (= V): entry and its reads all equal"]
+        direction LR
+        busE(("bus entry = V")) -. overlay .- busO1(("read = V"))
+        busO1 -. overlay .- busO2(("read = V"))
+    end
+    subgraph VARI["Variable index: only reads via the same index witness collapse"]
+        direction LR
+        busA(("read via x = V")) -. overlay .- busB(("read via x = V"))
+        busC(("read via y = V")):::visible
+    end
+    classDef visible stroke:#e06c75,stroke-width:3px
+```
+
+_A fixed index ties the appended entry and all its reads together. With a variable
+index, only reads made through the same index witness collapse; a different index
+witness that happens to select the same slot stays visible (red)._
+
+On Mega, a databus read gate copies one entry of a bus vector (for example
+calldata or return data) into a fresh output witness. Reading a fixed index more
+than once, or appending an entry and later reading it, produces several witnesses
+that the databus relation forces equal to that bus slot. For a constant index the
+overlay connects the appended entry and every read output for that slot. For a
+variable index it connects only the reads made through the same index witness;
+distinct index witnesses that merely hold the same value stay visible, because
+their equality is a runtime coincidence rather than a constraint.
+
+### Non-native-field derivations
+
+```mermaid
+flowchart LR
+    subgraph NNF["bigfield limb decomposition / reduction (same inputs and selectors)"]
+        direction LR
+        nnfL1(("limb = L")) -. overlay .- nnfL2(("limb = L"))
+    end
+```
+
+_Deterministic limb and reduction outputs recur across the gate wires; the gate
+relation forces the equal wires together._
+
+Non-native (bigfield) arithmetic lowers to prime-limb arithmetic gates and
+dedicated non-native-field custom gates that deterministically build limb
+decompositions and reduction intermediates. The same limb value recurs across the
+wires of these gates. For each such gate the overlay connects the wires carrying
+equal values, which the gate's own relation forces equal.
+
+### Arithmetic derivations
+
+```mermaid
+flowchart TB
+    arP(("peer witness P"))
+    subgraph DER["derived from P under the same modulus selectors"]
+        direction LR
+        arD1(("derived = D")) -. overlay .- arD2(("derived = D"))
+    end
+    arP --> arD1
+    arP --> arD2
+```
+
+_The same peer and modulus selectors fix the derived value, so it is recomputed
+identically. Only the derived witnesses collapse — never the peer._
+
+Some stdlib helpers emit the same derived witness more than once from the same
+peer witness under identical BN254 base-field modulus selectors — for example the
+multiply-add identity `q_m·peer·derived + q_c = 0`. Because the gate fixes
+`derived` deterministically from `peer` and the selectors, repeating the operation
+produces duplicate derived witnesses. The overlay connects derived witnesses that
+share the same peer and selector signature (both orientations for the commutative
+product) and never connects a derived witness to its peer.
+
+### Elliptic operation derivations
+
+```mermaid
+flowchart TB
+    subgraph ELL["same add / double, same input points → same (x3, y3)"]
+        direction TB
+        elX1(("x3")) -. "overlay (x)" .- elX2(("x3"))
+        elY1(("y3")) -. "overlay (y)" .- elY2(("y3"))
+    end
+```
+
+_Repeating the operation reproduces x3 and y3. The x-outputs and y-outputs form
+separate components, so an accidental x == y stays visible._
+
+The elliptic gate computes an add or double and writes the output coordinates
+`(x3, y3)`. Repeating the same operation with copied input witnesses reproduces
+the same outputs, so `x3` and `y3` recur as fresh witnesses. The overlay connects
+outputs that share an operation signature — operation type, sign or double flag,
+and input coordinate values — and keeps the x-output and y-output components
+separate so an accidental `x == y` equality stays visible.
+
+### ECC-op table structure
+
+```mermaid
+flowchart LR
+    subgraph ECC["same opcode + point pushed twice (e.g. zero-poly commitments in batch-merge)"]
+        direction TB
+        a0(("push A limb 0")) -. overlay .- b0(("push B limb 0"))
+        a1(("push A limb 1")) -. overlay .- b1(("push B limb 1"))
+        a2(("push A limb 2")) -. overlay .- b2(("push B limb 2"))
+        a3(("push A limb 3")) -. overlay .- b3(("push B limb 3"))
+    end
+```
+
+_When the same op and point are pushed twice, their four limbs repeat. Only
+corresponding limbs collapse; the four limbs of one op are never joined to each
+other._
+
+On Mega, points pushed to the Goblin ECC-op queue are serialized into four limb
+witnesses per op in the `ecc_op` block. When the same opcode and point tuple is
+pushed more than once, its four limbs repeat. This happens structurally in
+batch-merge proofs, where inactive subtable commitments are commitments to the
+zero polynomial and so coincide. The overlay connects corresponding limbs only
+when the full opcode-and-point tuple repeats and every limb also has a
+materialization gate outside the `ecc_op` block. The four limbs of one op are
+never connected to each other, because constraints don't force them equal.
+
+### Lookup table structure
+
+```mermaid
+flowchart TB
+    subgraph LK["same fixed-base table and key → same point (x, y)"]
+        direction TB
+        lkX1(("x")) -. overlay .- lkX2(("x"))
+        lkY1(("y")) -. overlay .- lkY2(("y"))
+    end
+```
+
+_Re-reading the same table with the same key returns the same point coordinates.
+Distinct key witnesses that merely share a value are not collapsed._
+
+`STRAUS_EC_POINT` lookup tables are deterministic fixed-base MSM tables:
+re-reading the same table with the same key returns the same point coordinates,
+but each read emits fresh output witnesses that otherwise look like unexplained
+duplicates. The overlay connects the x-outputs, and separately the y-outputs, of
+reads that share a table index and key identity. Distinct key witnesses that
+merely hold the same value aren't collapsed.
+
+### Straus table structure
+
+```mermaid
+flowchart LR
+    subgraph ST["one precomputed point P, materialized on several witnesses"]
+        direction LR
+        stM1(("holds P")) -. overlay .- stM2(("holds P"))
+        stM2 -. overlay .- stM3(("holds P"))
+    end
+```
+
+_While the table is built, one point is materialized on several fresh witnesses;
+the overlay ties them back to the same point._
+
+Straus MSM helpers build point tables by routing fixed-base lookup outputs and
+variable-base addends through ROM and memory rows. While the table is
+constructed, the same point coordinate is materialized on several of these fresh
+witnesses. The overlay connects the witnesses that the table construction ties to
+one point, rather than treating each materialization as an independent duplicate.
+
+### Construction-time duplicate provenance groups
+
+Some producers have information the analyzer can't recover from selectors after
+the fact. Those producers tag the witnesses at construction time (see
+[Construction-time provenance](#construction-time-provenance)), and this overlay
+connects all real indices that share a provenance key.
+`POSEIDON2_CRYPTOGRAPHIC_BINDING` is excluded here and handled by the
+cryptographic-binding overlay instead.
+
+### Cryptographic-binding rehash
+
+```mermaid
+flowchart TB
+    ckA["hiding kernel:<br/>hash of ECC-op wires"] --> ckH1(("RUNNING_HASH"))
+    ckB["batch-merge verifier:<br/>hash of transcript columns"] --> ckH2(("TRANSCRIPT_HASH"))
+    ckH1 -. "bound by check_hash_consistency<br/>(cryptographic, 2^-127 caveat)" .- ckH2
+```
+
+_Two different computations produce the same hash value. The equality is
+cryptographic, not constraint-forced, so the duplicate is suppressed only when
+both roles are present._
+
+This is the one overlay whose equality comes from a cryptographic argument rather
+than circuit constraints. The hiding kernel and the batch-merge recursive verifier
+compute the same running ECC-op commitment hash by two different routes, so the
+two hash witnesses hold the same value. `BatchMergeVerifier::check_hash_consistency`
+binds them, carrying the existing 2^-127 collision caveat. The overlay suppresses
+the duplicate only when the group holds both the `RUNNING_HASH` and
+`TRANSCRIPT_HASH` roles; a same-role duplicate stays visible. See the
+[`POSEIDON2_CRYPTOGRAPHIC_BINDING`](#provenance-categories) category for the full
+rule.

--- a/barretenberg/cpp/src/barretenberg/boomerang_value_detection/graph.cpp
+++ b/barretenberg/cpp/src/barretenberg/boomerang_value_detection/graph.cpp
@@ -7,7 +7,10 @@
 #include "./graph.hpp"
 #include "./gate_patterns.hpp"
 #include "barretenberg/common/assert.hpp"
+#include "barretenberg/stdlib/primitives/bigfield/constants.hpp"
 #include "barretenberg/stdlib/primitives/circuit_builders/circuit_builders.hpp"
+#include "barretenberg/stdlib_circuit_builders/duplicate_provenance.hpp"
+#include "barretenberg/stdlib_circuit_builders/plookup_tables/aes128.hpp"
 #include "barretenberg/stdlib_circuit_builders/ultra_circuit_builder.hpp"
 #include <algorithm>
 #include <array>
@@ -17,6 +20,279 @@
 
 using namespace bb::plookup;
 using namespace bb;
+
+namespace {
+
+using DuplicateAdjacency = std::unordered_map<uint32_t, std::vector<uint32_t>>;
+
+template <typename T> void hash_combine(size_t& seed, const T& value)
+{
+    constexpr size_t HASH_COMBINE_CONSTANT = 0x9e3779b9;
+    seed ^= std::hash<T>{}(value) + HASH_COMBINE_CONSTANT + (seed << 6) + (seed >> 2);
+}
+
+template <typename FF> struct ArithmeticDerivationSignature {
+    FF q_m;
+    FF linear_scaling;
+    FF q_c;
+    uint32_t peer_variable = 0;
+
+    bool operator==(const ArithmeticDerivationSignature& other) const = default;
+};
+
+template <typename FF> struct ArithmeticDerivationSignatureHasher {
+    size_t operator()(const ArithmeticDerivationSignature<FF>& signature) const
+    {
+        size_t seed = 0;
+        hash_combine(seed, signature.q_m);
+        hash_combine(seed, signature.linear_scaling);
+        hash_combine(seed, signature.q_c);
+        hash_combine(seed, signature.peer_variable);
+        return seed;
+    }
+};
+
+template <typename FF> struct EllipticOperationSignature {
+    bool is_double = false;
+    FF q_sign_or_double;
+    std::array<FF, 4> inputs;
+
+    bool operator==(const EllipticOperationSignature& other) const = default;
+};
+
+template <typename FF> struct EllipticOperationSignatureHasher {
+    size_t operator()(const EllipticOperationSignature<FF>& signature) const
+    {
+        size_t seed = 0;
+        hash_combine(seed, signature.is_double);
+        hash_combine(seed, signature.q_sign_or_double);
+        for (const auto& input : signature.inputs) {
+            hash_combine(seed, input);
+        }
+        return seed;
+    }
+};
+
+template <typename FF> struct EccOpPointSignature {
+    FF opcode;
+    std::array<FF, 4> point;
+
+    bool operator==(const EccOpPointSignature& other) const = default;
+};
+
+template <typename FF> struct EccOpPointSignatureHasher {
+    size_t operator()(const EccOpPointSignature<FF>& signature) const
+    {
+        size_t seed = 0;
+        hash_combine(seed, signature.opcode);
+        for (const auto& limb : signature.point) {
+            hash_combine(seed, limb);
+        }
+        return seed;
+    }
+};
+
+using DuplicateIdentityKey = DuplicateProvenanceLocalId;
+
+struct DuplicateIdentityKeyHasher {
+    size_t operator()(const DuplicateIdentityKey& key) const
+    {
+        size_t seed = 0;
+        for (const uint64_t identity : key) {
+            hash_combine(seed, identity);
+        }
+        return seed;
+    }
+};
+
+struct LookupAccessSignature {
+    size_t table_index = 0;
+    DuplicateIdentityKey key_identity;
+
+    bool operator==(const LookupAccessSignature& other) const = default;
+};
+
+struct LookupAccessSignatureHasher {
+    size_t operator()(const LookupAccessSignature& signature) const
+    {
+        size_t seed = 0;
+        hash_combine(seed, signature.table_index);
+        DuplicateIdentityKeyHasher hash_key;
+        hash_combine(seed, hash_key(signature.key_identity));
+        return seed;
+    }
+};
+
+void connect_duplicate_variables(DuplicateAdjacency& duplicate_adjacency,
+                                 const std::vector<uint32_t>& variables,
+                                 uint32_t zero_idx)
+{
+    std::vector<uint32_t> filtered_variables;
+    filtered_variables.reserve(variables.size());
+    for (auto variable_index : variables) {
+        if (variable_index != zero_idx) {
+            filtered_variables.emplace_back(variable_index);
+        }
+    }
+    std::sort(filtered_variables.begin(), filtered_variables.end());
+    auto unique_pointer = std::unique(filtered_variables.begin(), filtered_variables.end());
+    filtered_variables.erase(unique_pointer, filtered_variables.end());
+    if (filtered_variables.size() < 2) {
+        return;
+    }
+    for (size_t i = 0; i < filtered_variables.size() - 1; i++) {
+        duplicate_adjacency[filtered_variables[i]].emplace_back(filtered_variables[i + 1]);
+        duplicate_adjacency[filtered_variables[i + 1]].emplace_back(filtered_variables[i]);
+    }
+}
+
+std::unordered_set<uint32_t> collect_duplicate_graph_variables(const DuplicateAdjacency& duplicate_adjacency)
+{
+    std::unordered_set<uint32_t> duplicate_variables;
+    duplicate_variables.reserve(duplicate_adjacency.size() * 2);
+    for (const auto& [node, neighbors] : duplicate_adjacency) {
+        duplicate_variables.insert(node);
+        duplicate_variables.insert(neighbors.begin(), neighbors.end());
+    }
+    return duplicate_variables;
+}
+
+bool all_connected_in_duplicate_graph(const std::vector<uint32_t>& ordered_indices,
+                                      const DuplicateAdjacency& duplicate_adjacency)
+{
+    if (ordered_indices.empty()) {
+        return false;
+    }
+    std::unordered_set<uint32_t> visited;
+    std::stack<uint32_t> frontier;
+    frontier.push(ordered_indices[0]);
+    while (!frontier.empty()) {
+        uint32_t node = frontier.top();
+        frontier.pop();
+        if (visited.contains(node)) {
+            continue;
+        }
+        visited.insert(node);
+        if (auto it = duplicate_adjacency.find(node); it != duplicate_adjacency.end()) {
+            for (auto neighbor : it->second) {
+                frontier.push(neighbor);
+            }
+        }
+    }
+    return std::all_of(
+        ordered_indices.begin(), ordered_indices.end(), [&](uint32_t idx) { return visited.contains(idx); });
+}
+
+bool duplicate_set_is_connected_in_overlay(const std::vector<uint32_t>& ordered_indices,
+                                           const DuplicateAdjacency& duplicate_adjacency,
+                                           const std::unordered_set<uint32_t>& duplicate_variables)
+{
+    return !duplicate_variables.empty() &&
+           std::all_of(ordered_indices.begin(),
+                       ordered_indices.end(),
+                       [&](uint32_t idx) { return duplicate_variables.contains(idx); }) &&
+           all_connected_in_duplicate_graph(ordered_indices, duplicate_adjacency);
+}
+
+bool duplicate_set_intersects_overlay(const std::vector<uint32_t>& ordered_indices,
+                                      const std::unordered_set<uint32_t>& duplicate_variables)
+{
+    return std::any_of(ordered_indices.begin(), ordered_indices.end(), [&](uint32_t idx) {
+        return duplicate_variables.contains(idx);
+    });
+}
+
+std::unordered_map<uint32_t, size_t> build_duplicate_component_ids(const DuplicateAdjacency& duplicate_adjacency)
+{
+    std::unordered_map<uint32_t, size_t> component_ids;
+    component_ids.reserve(duplicate_adjacency.size());
+    size_t next_component_id = 0;
+
+    for (const auto& [start, _] : duplicate_adjacency) {
+        if (component_ids.contains(start)) {
+            continue;
+        }
+        std::stack<uint32_t> frontier;
+        frontier.push(start);
+        while (!frontier.empty()) {
+            uint32_t node = frontier.top();
+            frontier.pop();
+            if (component_ids.contains(node)) {
+                continue;
+            }
+            component_ids[node] = next_component_id;
+            if (auto it = duplicate_adjacency.find(node); it != duplicate_adjacency.end()) {
+                for (auto neighbor : it->second) {
+                    frontier.push(neighbor);
+                }
+            }
+        }
+        next_component_id++;
+    }
+
+    return component_ids;
+}
+
+bool duplicate_set_is_connected_in_overlay_components(const std::vector<uint32_t>& ordered_indices,
+                                                      const std::unordered_map<uint32_t, size_t>& component_ids)
+{
+    if (ordered_indices.empty()) {
+        return false;
+    }
+    auto first_it = component_ids.find(ordered_indices[0]);
+    if (first_it == component_ids.end()) {
+        return false;
+    }
+    const size_t component_id = first_it->second;
+    return std::all_of(ordered_indices.begin(), ordered_indices.end(), [&](uint32_t idx) {
+        auto it = component_ids.find(idx);
+        return it != component_ids.end() && it->second == component_id;
+    });
+}
+
+bool duplicate_set_intersects_overlay_components(const std::vector<uint32_t>& ordered_indices,
+                                                 const std::unordered_map<uint32_t, size_t>& component_ids)
+{
+    return std::any_of(
+        ordered_indices.begin(), ordered_indices.end(), [&](uint32_t idx) { return component_ids.contains(idx); });
+}
+
+constexpr uint64_t DATABUS_VARIABLE_INDEX_READ_OVERLAY_TAG = 1;
+
+DuplicateIdentityKey databus_read_key(size_t bus_idx, uint32_t read_index)
+{
+    return duplicate_provenance_local_id({ static_cast<uint64_t>(bus_idx), read_index });
+}
+
+DuplicateIdentityKey duplicate_identity_key(std::initializer_list<uint64_t> identities)
+{
+    return duplicate_provenance_local_id(identities);
+}
+
+DuplicateIdentityKey duplicate_identity_key(std::initializer_list<uint64_t> prefix, const DuplicateIdentityKey& suffix)
+{
+    auto key = duplicate_provenance_local_id(prefix);
+    append_duplicate_provenance_identity(key, suffix);
+    return key;
+}
+
+std::optional<DuplicateIdentityKey> cryptographic_binding_group_key(const DuplicateProvenance& provenance)
+{
+    const auto binding_role = get_duplicate_cryptographic_binding_role(provenance.local_id);
+    if (duplicate_provenance_category(provenance) != DuplicateProvenanceCategory::POSEIDON2_CRYPTOGRAPHIC_BINDING ||
+        provenance.local_id.empty() ||
+        provenance.local_id[DUPLICATE_CRYPTOGRAPHIC_BINDING_KIND_INDEX] !=
+            static_cast<uint64_t>(DuplicateCryptographicBindingKind::BATCH_MERGE_ECC_OP_HASH) ||
+        !binding_role.has_value()) {
+        return std::nullopt;
+    }
+
+    DuplicateIdentityKey key = provenance.local_id;
+    key.erase(key.begin() + static_cast<std::ptrdiff_t>(DUPLICATE_CRYPTOGRAPHIC_BINDING_ROLE_INDEX));
+    return key;
+}
+
+} // namespace
 
 namespace cdg {
 
@@ -45,8 +321,10 @@ inline void StaticAnalyzer_<FF, CircuitBuilder>::process_gate_variables(std::vec
         return;
     }
     for (auto& var_idx : gate_variables) {
-        KeyPair key = std::make_pair(var_idx, &blk);
+        const void* block_ptr = &blk;
+        KeyPair key = std::make_pair(var_idx, block_ptr);
         variable_gates[key].emplace_back(gate_index);
+        variable_gate_refs[var_idx].emplace_back(block_ptr, gate_index);
     }
     for (const auto& variable_index : gate_variables) {
         variables_gate_counts[variable_index] += 1;
@@ -354,6 +632,649 @@ template <typename FF, typename CircuitBuilder> void StaticAnalyzer_<FF, Circuit
     }
 }
 
+template <typename FF, typename CircuitBuilder>
+std::unordered_map<uint32_t, std::vector<uint32_t>> StaticAnalyzer_<FF, CircuitBuilder>::
+    build_provenance_duplicate_adjacency() const
+{
+    // Construction-time provenance overlay: producers (bigfield, MSM, Poseidon2, databus, ecc-op) tag witnesses they
+    // deterministically derive with a group key that, by the soundness contract, is shared only when the constraints
+    // force the witnesses equal. Connect all real indices sharing a key. See WITNESS_DUPLICATE_DETECTION.md.
+    std::unordered_map<DuplicateProvenance, std::vector<uint32_t>, DuplicateProvenanceHasher> variables_by_group;
+    for (const auto& [real_index, group_key] : circuit_builder.get_duplicate_provenance()) {
+        if (duplicate_provenance_category(group_key) == DuplicateProvenanceCategory::POSEIDON2_CRYPTOGRAPHIC_BINDING) {
+            continue;
+        }
+        variables_by_group[group_key].emplace_back(real_index);
+    }
+    DuplicateAdjacency duplicate_adjacency;
+    for (auto& [_, variables] : variables_by_group) {
+        connect_duplicate_variables(duplicate_adjacency, variables, circuit_builder.zero_idx());
+    }
+    return duplicate_adjacency;
+}
+
+template <typename FF, typename CircuitBuilder>
+std::unordered_map<uint32_t, std::vector<uint32_t>> StaticAnalyzer_<FF, CircuitBuilder>::
+    build_memory_table_duplicate_adjacency() const
+{
+    // This is a duplicate-search-only overlay. These edges do not belong to the main circuit graph; they only explain
+    // repeated witness values that are known to be the same because of a concrete ROM/RAM access relation.
+    DuplicateAdjacency duplicate_adjacency;
+    auto& memory_block = circuit_builder.blocks.memory;
+
+    auto connect_variables = [&](const std::vector<uint32_t>& variables) {
+        connect_duplicate_variables(duplicate_adjacency, variables, circuit_builder.zero_idx());
+    };
+
+    auto get_memory_sorted_tag = [&](uint32_t record_witness) -> std::optional<uint32_t> {
+        // The builder tags each memory record witness, and tau maps that tag to the tag used by the sorted/finalized
+        // memory rows. If this link is absent, do not infer duplicate equivalence from the memory block.
+        const uint32_t real_record_witness = circuit_builder.real_variable_index[record_witness];
+        if (real_record_witness >= circuit_builder.real_variable_tags.size()) {
+            return std::nullopt;
+        }
+        const uint32_t record_tag = circuit_builder.real_variable_tags[real_record_witness];
+        if (record_tag == DEFAULT_TAG) {
+            return std::nullopt;
+        }
+        auto tau_it = circuit_builder.tau().find(record_tag);
+        if (tau_it == circuit_builder.tau().end() || tau_it->second == DEFAULT_TAG || tau_it->second == record_tag) {
+            return std::nullopt;
+        }
+        return tau_it->second;
+    };
+
+    // Finalized ROM/RAM tables are represented by sorted memory rows. Index them once by record tag so every table can
+    // recover its own sorted rows without rescanning the whole memory block.
+    std::unordered_map<uint32_t, std::vector<size_t>> memory_rows_by_record_tag;
+    memory_rows_by_record_tag.reserve(circuit_builder.rom_ram_logic.rom_arrays.size() +
+                                      circuit_builder.rom_ram_logic.ram_arrays.size());
+    for (size_t row = 0; row < memory_block.size(); row++) {
+        const uint32_t real_record_witness = circuit_builder.real_variable_index[memory_block.w_4()[row]];
+        if (real_record_witness < circuit_builder.real_variable_tags.size()) {
+            const uint32_t record_tag = circuit_builder.real_variable_tags[real_record_witness];
+            if (record_tag != DEFAULT_TAG) {
+                memory_rows_by_record_tag[record_tag].emplace_back(row);
+            }
+        }
+    }
+
+    const std::vector<size_t> empty_memory_rows;
+    auto memory_rows_with_record_tag = [&](uint32_t record_tag) -> const std::vector<size_t>& {
+        auto it = memory_rows_by_record_tag.find(record_tag);
+        return it == memory_rows_by_record_tag.end() ? empty_memory_rows : it->second;
+    };
+
+    auto add_real_witness = [&](std::vector<uint32_t>& variables, uint32_t witness_index) {
+        variables.emplace_back(circuit_builder.real_variable_index[witness_index]);
+    };
+
+    for (const auto& rom_array : circuit_builder.rom_ram_logic.rom_arrays) {
+        // ROM reads are safe duplicates only within one ROM table and one slot. The table state gives the source
+        // witness stored at that slot, the transcript records give the unsorted read witnesses, and the sorted rows
+        // give the finalized read witnesses for the same table.
+        const size_t table_size = rom_array.state.size();
+        std::vector<std::vector<uint32_t>> by_position(table_size);
+        for (size_t index = 0; index < table_size; index++) {
+            if (rom_array.state[index][0] != UNINITIALIZED_MEMORY_RECORD) {
+                add_real_witness(by_position[index], rom_array.state[index][0]);
+            }
+            if (rom_array.state[index][1] != UNINITIALIZED_MEMORY_RECORD &&
+                rom_array.state[index][1] != circuit_builder.zero_idx()) {
+                add_real_witness(by_position[index], rom_array.state[index][1]);
+            }
+        }
+        for (const auto& record : rom_array.records) {
+            if (record.index < table_size) {
+                add_real_witness(by_position[record.index], record.value_column1_witness);
+                if (record.value_column2_witness != circuit_builder.zero_idx()) {
+                    add_real_witness(by_position[record.index], record.value_column2_witness);
+                }
+            }
+        }
+
+        if (!rom_array.records.empty()) {
+            auto sorted_tag = get_memory_sorted_tag(rom_array.records[0].record_witness);
+            if (sorted_tag.has_value()) {
+                for (size_t row : memory_rows_with_record_tag(*sorted_tag)) {
+                    const uint32_t index =
+                        static_cast<uint32_t>(uint256_t(circuit_builder.get_variable(memory_block.w_l()[row])));
+                    if (index < table_size) {
+                        add_real_witness(by_position[index], memory_block.w_r()[row]);
+                        if (memory_block.w_o()[row] != circuit_builder.zero_idx()) {
+                            add_real_witness(by_position[index], memory_block.w_o()[row]);
+                        }
+                    }
+                }
+            }
+        }
+
+        for (auto& vars_at_pos : by_position) {
+            connect_variables(vars_at_pos);
+        }
+    }
+
+    struct RamAccessDuplicateVariables {
+        uint32_t index = 0;
+        bool is_read = false;
+        std::vector<uint32_t> variables;
+    };
+
+    for (const auto& ram_array : circuit_builder.rom_ram_logic.ram_arrays) {
+        // RAM duplicates are more restrictive than ROM: a read may reuse the value from the immediately previous access
+        // to the same table/index, but repeated writes are still meaningful positives and must not be collapsed.
+        const size_t table_size = ram_array.state.size();
+        std::vector<RamAccessDuplicateVariables> accesses;
+        accesses.reserve(ram_array.records.size());
+
+        for (const auto& record : ram_array.records) {
+            RamAccessDuplicateVariables access{
+                .index = record.index,
+                .is_read = record.access_type == bb::RamRecord::AccessType::READ,
+            };
+            add_real_witness(access.variables, record.value_witness);
+            accesses.emplace_back(access);
+        }
+
+        if (!ram_array.records.empty()) {
+            auto sorted_tag = get_memory_sorted_tag(ram_array.records[0].record_witness);
+            if (sorted_tag.has_value()) {
+                const auto& sorted_rows = memory_rows_with_record_tag(*sorted_tag);
+                // If the counts differ, we cannot reliably pair transcript accesses with sorted rows for this RAM
+                // table, so leave those duplicate values visible rather than guessing.
+                if (sorted_rows.size() == accesses.size()) {
+                    // Pair each transcript access with its sorted-memory row. The sorted row output is the same access,
+                    // so it can be collapsed with the transcript value before we reason about read-after-access chains.
+                    for (size_t i = 0; i < sorted_rows.size(); i++) {
+                        std::vector<uint32_t> same_access_variables = accesses[i].variables;
+                        add_real_witness(same_access_variables, memory_block.w_o()[sorted_rows[i]]);
+                        connect_variables(same_access_variables);
+                        accesses[i].variables = std::move(same_access_variables);
+                    }
+                }
+            }
+        }
+
+        std::vector<std::optional<size_t>> previous_access_by_position(table_size);
+        for (size_t i = 0; i < accesses.size(); i++) {
+            if (accesses[i].index >= table_size) {
+                continue;
+            }
+            auto& previous_access = previous_access_by_position[accesses[i].index];
+            if (accesses[i].is_read && previous_access.has_value()) {
+                // A RAM read is allowed to repeat exactly the value established by the previous access to this slot.
+                // Writes do not get this treatment: two writes of the same value are still independent witnesses.
+                std::vector<uint32_t> connected_read_variables = accesses[*previous_access].variables;
+                connected_read_variables.insert(
+                    connected_read_variables.end(), accesses[i].variables.begin(), accesses[i].variables.end());
+                connect_variables(connected_read_variables);
+            }
+            previous_access = i;
+        }
+    }
+
+    return duplicate_adjacency;
+}
+
+template <typename FF, typename CircuitBuilder>
+std::unordered_map<uint32_t, std::vector<uint32_t>> StaticAnalyzer_<FF, CircuitBuilder>::
+    build_lookup_table_duplicate_adjacency() const
+{
+    // STRAUS_EC_POINT lookup tables are deterministic fixed-base MSM tables. Re-reading the same table/key pair
+    // produces the same point coordinates, but the lookup outputs are fresh witnesses and otherwise look duplicated.
+    DuplicateAdjacency duplicate_adjacency;
+    const auto& lookup_tables = circuit_builder.get_lookup_tables();
+    if (lookup_tables.empty()) {
+        return duplicate_adjacency;
+    }
+
+    std::unordered_map<size_t, BasicTableId> table_id_by_index;
+    table_id_by_index.reserve(lookup_tables.size());
+    for (const auto& table : lookup_tables) {
+        table_id_by_index.emplace(table.table_index, table.id);
+    }
+
+    auto real_index = [&](uint32_t witness_index) { return circuit_builder.real_variable_index[witness_index]; };
+    auto key_identity = [&](uint32_t witness_index) {
+        const uint32_t real_key_index = real_index(witness_index);
+        const auto& provenance = circuit_builder.get_duplicate_provenance();
+        auto provenance_it = provenance.find(real_key_index);
+        if (provenance_it != provenance.end()) {
+            return duplicate_provenance_nested_identity(provenance_it->second);
+        }
+        return duplicate_identity_key({ DUPLICATE_PROVENANCE_RAW_IDENTITY_TAG, static_cast<uint64_t>(real_key_index) });
+    };
+
+    std::unordered_map<LookupAccessSignature, std::vector<uint32_t>, LookupAccessSignatureHasher> x_outputs_by_lookup;
+    std::unordered_map<LookupAccessSignature, std::vector<uint32_t>, LookupAccessSignatureHasher> y_outputs_by_lookup;
+
+    auto& lookup_block = circuit_builder.blocks.lookup;
+    for (size_t row = 0; row < lookup_block.size(); row++) {
+        if (read_gate_selector(lookup_block, GateKind::Lookup, row) != FF::one()) {
+            continue;
+        }
+        const size_t table_index = static_cast<size_t>(uint256_t(lookup_block.q_3()[row]));
+        auto table_id_it = table_id_by_index.find(table_index);
+        if (table_id_it == table_id_by_index.end() || table_id_it->second != BasicTableId::STRAUS_EC_POINT) {
+            continue;
+        }
+
+        LookupAccessSignature signature{ .table_index = table_index,
+                                         .key_identity = key_identity(lookup_block.w_l()[row]) };
+        x_outputs_by_lookup[signature].emplace_back(real_index(lookup_block.w_r()[row]));
+        y_outputs_by_lookup[signature].emplace_back(real_index(lookup_block.w_o()[row]));
+    }
+
+    for (auto& [_, variables] : x_outputs_by_lookup) {
+        connect_duplicate_variables(duplicate_adjacency, variables, circuit_builder.zero_idx());
+    }
+    for (auto& [_, variables] : y_outputs_by_lookup) {
+        connect_duplicate_variables(duplicate_adjacency, variables, circuit_builder.zero_idx());
+    }
+
+    return duplicate_adjacency;
+}
+
+template <typename FF, typename CircuitBuilder>
+std::unordered_map<uint32_t, std::vector<uint32_t>> StaticAnalyzer_<FF, CircuitBuilder>::
+    build_straus_table_duplicate_adjacency() const
+{
+    // Straus MSM helpers repeat fixed-base lookup outputs and variable-base addends through ROM/memory rows while
+    // deriving table entries. Those fresh witnesses carry the same point coordinates and are connected by the table
+    // construction rather than being independent duplicate values.
+    DuplicateAdjacency duplicate_adjacency;
+    auto real_index = [&](uint32_t witness_index) { return circuit_builder.real_variable_index[witness_index]; };
+    std::unordered_map<FF, std::vector<uint32_t>> straus_variables_by_value;
+    auto add_straus_variable = [&](uint32_t real_variable_index) {
+        if (real_variable_index != circuit_builder.zero_idx()) {
+            straus_variables_by_value[circuit_builder.get_variable(real_variable_index)].emplace_back(
+                real_variable_index);
+        }
+    };
+    auto is_real_witness = [&](uint32_t witness_index) {
+        return witness_index != UNINITIALIZED_MEMORY_RECORD && witness_index != circuit_builder.zero_idx();
+    };
+
+    struct PointWitnesses {
+        uint32_t x = 0;
+        uint32_t y = 0;
+
+        bool operator==(const PointWitnesses& other) const = default;
+    };
+
+    struct PointWitnessesHasher {
+        size_t operator()(const PointWitnesses& point) const
+        {
+            size_t seed = 0;
+            hash_combine(seed, point.x);
+            hash_combine(seed, point.y);
+            return seed;
+        }
+    };
+
+    struct PointValue {
+        FF x;
+        FF y;
+
+        bool operator==(const PointValue& other) const = default;
+    };
+
+    struct PointValueHasher {
+        size_t operator()(const PointValue& point) const
+        {
+            size_t seed = 0;
+            hash_combine(seed, point.x);
+            hash_combine(seed, point.y);
+            return seed;
+        }
+    };
+
+    auto same_point = [](const PointWitnesses& lhs, const PointWitnesses& rhs) {
+        return lhs.x == rhs.x && lhs.y == rhs.y;
+    };
+    auto point_values = [&](const PointWitnesses& point) {
+        return std::array<FF, 2>{ circuit_builder.get_variable(point.x), circuit_builder.get_variable(point.y) };
+    };
+    auto point_value_signature = [&](const PointWitnesses& point) {
+        const auto values = point_values(point);
+        return PointValue{ .x = values[0], .y = values[1] };
+    };
+    auto same_point_value = [&](const PointWitnesses& lhs, const PointWitnesses& rhs) {
+        return point_values(lhs) == point_values(rhs);
+    };
+
+    std::unordered_map<PointWitnesses, std::vector<std::pair<PointWitnesses, PointWitnesses>>, PointWitnessesHasher>
+        elliptic_inputs_by_output;
+    std::unordered_map<PointValue, std::vector<PointWitnesses>, PointValueHasher> elliptic_addends_by_value;
+    for (auto& block : circuit_builder.blocks.get()) {
+        for (size_t row = 0; row + 1 < block.size(); row++) {
+            if (read_gate_selector(block, GateKind::Elliptic, row) != FF::one() || !block.q_m()[row].is_zero()) {
+                continue;
+            }
+            PointWitnesses first_input{ .x = real_index(block.w_r()[row]), .y = real_index(block.w_o()[row]) };
+            PointWitnesses second_input{ .x = real_index(block.w_l()[row + 1]), .y = real_index(block.w_4()[row + 1]) };
+            PointWitnesses gate_output{ .x = real_index(block.w_r()[row + 1]), .y = real_index(block.w_o()[row + 1]) };
+            elliptic_inputs_by_output[gate_output].emplace_back(first_input, second_input);
+            elliptic_addends_by_value[point_value_signature(second_input)].emplace_back(second_input);
+        }
+    }
+
+    std::unordered_set<PointValue, PointValueHasher> repeated_elliptic_addend_values;
+    for (const auto& [point_value, addends] : elliptic_addends_by_value) {
+        if (addends.size() < 2) {
+            continue;
+        }
+        repeated_elliptic_addend_values.insert(point_value);
+        for (const auto& addend : addends) {
+            add_straus_variable(addend.x);
+            add_straus_variable(addend.y);
+        }
+    }
+
+    std::unordered_map<size_t, BasicTableId> table_id_by_index;
+    for (const auto& table : circuit_builder.get_lookup_tables()) {
+        table_id_by_index.emplace(table.table_index, table.id);
+    }
+
+    // A STRAUS lookup output names a deterministic fixed-base table point. The same point can be materialized through
+    // memory rows and then consumed as an elliptic-add input, so connect those coordinate witnesses by point value.
+    std::unordered_set<PointValue, PointValueHasher> straus_lookup_point_values;
+    auto& lookup_block = circuit_builder.blocks.lookup;
+    for (size_t row = 0; row < lookup_block.size(); row++) {
+        if (read_gate_selector(lookup_block, GateKind::Lookup, row) != FF::one()) {
+            continue;
+        }
+        const size_t table_index = static_cast<size_t>(uint256_t(lookup_block.q_3()[row]));
+        auto table_id_it = table_id_by_index.find(table_index);
+        if (table_id_it == table_id_by_index.end() || table_id_it->second != BasicTableId::STRAUS_EC_POINT) {
+            continue;
+        }
+
+        PointWitnesses lookup_point{ .x = real_index(lookup_block.w_r()[row]),
+                                     .y = real_index(lookup_block.w_o()[row]) };
+        straus_lookup_point_values.insert(point_value_signature(lookup_point));
+        add_straus_variable(lookup_point.x);
+        add_straus_variable(lookup_point.y);
+    }
+
+    for (const auto& [point_value, addends] : elliptic_addends_by_value) {
+        if (!straus_lookup_point_values.contains(point_value)) {
+            continue;
+        }
+        for (const auto& addend : addends) {
+            add_straus_variable(addend.x);
+            add_straus_variable(addend.y);
+        }
+    }
+
+    auto& memory_block = circuit_builder.blocks.memory;
+    for (size_t row = 0; row < memory_block.size(); row++) {
+        if (read_gate_selector(memory_block, GateKind::Memory, row) != FF::one()) {
+            continue;
+        }
+        PointWitnesses memory_point{ .x = real_index(memory_block.w_r()[row]),
+                                     .y = real_index(memory_block.w_o()[row]) };
+        const auto memory_point_value = point_value_signature(memory_point);
+        if (!repeated_elliptic_addend_values.contains(memory_point_value) &&
+            !straus_lookup_point_values.contains(memory_point_value)) {
+            continue;
+        }
+        add_straus_variable(memory_point.x);
+        add_straus_variable(memory_point.y);
+    }
+
+    auto find_base_for_step = [&](const PointWitnesses& previous,
+                                  const PointWitnesses& output) -> std::optional<PointWitnesses> {
+        auto it = elliptic_inputs_by_output.find(output);
+        if (it == elliptic_inputs_by_output.end()) {
+            return std::nullopt;
+        }
+        for (const auto& [first_input, second_input] : it->second) {
+            if (same_point(first_input, previous)) {
+                return second_input;
+            }
+            if (same_point(second_input, previous)) {
+                return first_input;
+            }
+        }
+        return std::nullopt;
+    };
+
+    for (const auto& rom_array : circuit_builder.rom_ram_logic.rom_arrays) {
+        const size_t table_size = rom_array.state.size();
+        if (table_size < 2) {
+            continue;
+        }
+
+        std::vector<PointWitnesses> slots;
+        slots.reserve(table_size);
+        bool complete_point_table = true;
+        for (size_t index = 0; index < table_size; index++) {
+            if (!is_real_witness(rom_array.state[index][0]) || !is_real_witness(rom_array.state[index][1])) {
+                complete_point_table = false;
+                break;
+            }
+            slots.push_back({ .x = real_index(rom_array.state[index][0]), .y = real_index(rom_array.state[index][1]) });
+        }
+        if (!complete_point_table) {
+            continue;
+        }
+
+        std::unordered_map<PointValue, std::vector<PointWitnesses>, PointValueHasher> rom_slots_by_point_value;
+        for (const auto& slot : slots) {
+            rom_slots_by_point_value[point_value_signature(slot)].emplace_back(slot);
+        }
+        for (const auto& [point_value, repeated_slots] : rom_slots_by_point_value) {
+            auto addend_it = elliptic_addends_by_value.find(point_value);
+            if (repeated_slots.size() < 2 || addend_it == elliptic_addends_by_value.end()) {
+                continue;
+            }
+            for (const auto& slot : repeated_slots) {
+                add_straus_variable(slot.x);
+                add_straus_variable(slot.y);
+            }
+            for (const auto& addend : addend_it->second) {
+                add_straus_variable(addend.x);
+                add_straus_variable(addend.y);
+            }
+        }
+
+        std::optional<PointWitnesses> table_base;
+        std::vector<PointWitnesses> step_bases;
+        step_bases.reserve(table_size - 1);
+        bool is_straus_table = true;
+        for (size_t index = 1; index < table_size; index++) {
+            auto base = find_base_for_step(slots[index - 1], slots[index]);
+            if (!base.has_value()) {
+                is_straus_table = false;
+                break;
+            }
+            if (!table_base.has_value()) {
+                table_base = base;
+            } else if (!same_point_value(*table_base, *base)) {
+                is_straus_table = false;
+                break;
+            }
+            step_bases.emplace_back(*base);
+        }
+        if (!is_straus_table || !table_base.has_value()) {
+            continue;
+        }
+
+        std::vector<uint32_t> x_variables;
+        std::vector<uint32_t> y_variables;
+        x_variables.reserve(table_size + step_bases.size());
+        y_variables.reserve(table_size + step_bases.size());
+        for (const auto& base : step_bases) {
+            x_variables.emplace_back(base.x);
+            y_variables.emplace_back(base.y);
+            add_straus_variable(base.x);
+            add_straus_variable(base.y);
+        }
+        for (const auto& slot : slots) {
+            x_variables.emplace_back(slot.x);
+            y_variables.emplace_back(slot.y);
+            add_straus_variable(slot.x);
+            add_straus_variable(slot.y);
+        }
+        connect_duplicate_variables(duplicate_adjacency, x_variables, circuit_builder.zero_idx());
+        connect_duplicate_variables(duplicate_adjacency, y_variables, circuit_builder.zero_idx());
+    }
+
+    for (auto& [_, variables] : straus_variables_by_value) {
+        connect_duplicate_variables(duplicate_adjacency, variables, circuit_builder.zero_idx());
+    }
+
+    return duplicate_adjacency;
+}
+
+template <typename FF, typename CircuitBuilder>
+std::unordered_set<uint32_t> StaticAnalyzer_<FF, CircuitBuilder>::get_databus_read_value_variables() const
+{
+    std::unordered_set<uint32_t> databus_read_value_variables;
+    if constexpr (!IsMegaBuilder<CircuitBuilder>) {
+        return databus_read_value_variables;
+    } else {
+        auto& busread_block = circuit_builder.blocks.busread;
+        for (size_t row = 0; row < busread_block.size(); row++) {
+            if (read_gate_selector(busread_block, GateKind::BusRead, row) == FF::one()) {
+                databus_read_value_variables.insert(circuit_builder.real_variable_index[busread_block.w_l()[row]]);
+            }
+        }
+        return databus_read_value_variables;
+    }
+}
+
+template <typename FF, typename CircuitBuilder>
+std::unordered_map<uint32_t, std::vector<uint32_t>> StaticAnalyzer_<FF, CircuitBuilder>::
+    build_databus_read_duplicate_adjacency() const
+{
+    DuplicateAdjacency duplicate_adjacency;
+    if constexpr (!IsMegaBuilder<CircuitBuilder>) {
+        return duplicate_adjacency;
+    } else {
+        auto connect_variables = [&](const std::vector<uint32_t>& variables) {
+            connect_duplicate_variables(duplicate_adjacency, variables, circuit_builder.zero_idx());
+        };
+
+        auto selected_bus_index = [&](size_t row) -> std::optional<size_t> {
+            auto& busread_block = circuit_builder.blocks.busread;
+            const std::array<FF, 5> selectors = { busread_block.q_1()[row],
+                                                  busread_block.q_2()[row],
+                                                  busread_block.q_3()[row],
+                                                  busread_block.q_4()[row],
+                                                  busread_block.q_m()[row] };
+            std::optional<size_t> result;
+            for (size_t idx = 0; idx < selectors.size(); idx++) {
+                if (selectors[idx] == FF::one()) {
+                    if (result.has_value()) {
+                        return std::nullopt;
+                    }
+                    result = idx;
+                } else if (!selectors[idx].is_zero()) {
+                    return std::nullopt;
+                }
+            }
+            return result;
+        };
+
+        auto index_identity = [&](uint32_t witness_index) {
+            const uint32_t real_index = circuit_builder.real_variable_index[witness_index];
+            const auto& provenance = circuit_builder.get_duplicate_provenance();
+            auto provenance_it = provenance.find(real_index);
+            if (provenance_it != provenance.end()) {
+                return duplicate_provenance_nested_identity(provenance_it->second);
+            }
+            return duplicate_identity_key({ DUPLICATE_PROVENANCE_RAW_IDENTITY_TAG, static_cast<uint64_t>(real_index) });
+        };
+
+        std::unordered_map<DuplicateIdentityKey, std::vector<uint32_t>, DuplicateIdentityKeyHasher>
+            access_variables_by_bus_and_index;
+        auto& busread_block = circuit_builder.blocks.busread;
+        for (size_t row = 0; row < busread_block.size(); row++) {
+            if (read_gate_selector(busread_block, GateKind::BusRead, row) != FF::one()) {
+                continue;
+            }
+            auto bus_idx = selected_bus_index(row);
+            if (!bus_idx.has_value()) {
+                continue;
+            }
+            const uint32_t index_witness = busread_block.w_r()[row];
+            const uint32_t real_index_witness = circuit_builder.real_variable_index[index_witness];
+            const uint32_t read_index = static_cast<uint32_t>(uint256_t(circuit_builder.get_variable(index_witness)));
+            const auto& bus_vector = circuit_builder.get_bus_vector(*bus_idx);
+            if (read_index >= bus_vector.size()) {
+                continue;
+            }
+
+            const uint32_t output = circuit_builder.real_variable_index[busread_block.w_l()[row]];
+            if (real_index_witness == circuit_builder.zero_idx() ||
+                constant_variable_indices_set.contains(real_index_witness)) {
+                // A fixed index selects one concrete bus slot, so the appended bus entry and every read output for that
+                // slot are forced equal by the databus relation.
+                auto& access_variables = access_variables_by_bus_and_index[databus_read_key(*bus_idx, read_index)];
+                access_variables.emplace_back(circuit_builder.real_variable_index[bus_vector[read_index]]);
+                access_variables.emplace_back(output);
+            } else {
+                // A variable index must not be collapsed by its current value. Reads of the same bus through the same
+                // index witness are deterministic, but distinct same-valued index witnesses remain visible.
+                auto& access_variables = access_variables_by_bus_and_index[duplicate_identity_key(
+                    { DATABUS_VARIABLE_INDEX_READ_OVERLAY_TAG, static_cast<uint64_t>(*bus_idx) },
+                    index_identity(index_witness))];
+                access_variables.emplace_back(output);
+            }
+        }
+
+        for (auto& [_, variables] : access_variables_by_bus_and_index) {
+            connect_variables(variables);
+        }
+        return duplicate_adjacency;
+    }
+}
+
+template <typename FF, typename CircuitBuilder>
+std::unordered_map<uint32_t, std::vector<uint32_t>> StaticAnalyzer_<FF, CircuitBuilder>::
+    build_non_native_field_duplicate_adjacency() const
+{
+    DuplicateAdjacency duplicate_adjacency;
+
+    auto connect_variables = [&](const std::vector<uint32_t>& variables) {
+        connect_duplicate_variables(duplicate_adjacency, variables, circuit_builder.zero_idx());
+    };
+
+    auto add_real_wire = [&](std::vector<uint32_t>& variables, uint32_t witness_index) {
+        variables.emplace_back(circuit_builder.real_variable_index[witness_index]);
+    };
+
+    for (auto& block : circuit_builder.blocks.get()) {
+        for (size_t row = 0; row < block.size(); row++) {
+            if (is_non_native_field_prime_limb_gate(block, row)) {
+                auto selectors = bb::gate_patterns::read_selectors(block, row, GateKind::Arith);
+                auto wires = bb::gate_patterns::extract_wires(block, row, bb::gate_patterns::ARITHMETIC, selectors);
+                std::vector<uint32_t> variables;
+                variables.reserve(wires.size());
+                for (auto wire : wires) {
+                    add_real_wire(variables, wire);
+                }
+                connect_variables(variables);
+            }
+            if (is_non_native_field_custom_gate(block, row)) {
+                auto selectors = bb::gate_patterns::read_selectors(block, row, GateKind::Nnf);
+                auto wires =
+                    bb::gate_patterns::extract_wires(block, row, bb::gate_patterns::NON_NATIVE_FIELD, selectors);
+                std::vector<uint32_t> variables;
+                variables.reserve(wires.size());
+                for (auto wire : wires) {
+                    add_real_wire(variables, wire);
+                }
+                connect_variables(variables);
+            }
+        }
+    }
+
+    return duplicate_adjacency;
+}
+
 /**
  * @brief Construct a new StaticAnalyzer for Ultra Circuit Builder or Mega Circuit Builder
  * @tparam FF field type used in the circuit
@@ -541,6 +1462,1039 @@ std::vector<ConnectedComponent> StaticAnalyzer_<FF, CircuitBuilder>::find_connec
     mark_finalize_connected_components();
     mark_process_rom_connected_component();
     return connected_components;
+}
+static inline bool is_bn254_fq_modulus_derived_value(const bb::fr& value)
+{
+    uint256_t val_uint = value;
+    static constexpr uint256_t fq_mod_top = uint256_t(0x30644e72e131a029ULL) << 192 | uint256_t(0xb85045b6ULL) << 160;
+    static constexpr uint256_t top_mask = (uint256_t(1) << 256) - (uint256_t(1) << 160);
+    return (val_uint & top_mask) == fq_mod_top;
+}
+
+static inline bool is_triage_noise_witness_value(const bb::fr& value)
+{
+    static std::unordered_set<bb::fr> common_values;
+    static bool common_table_values_initialized = false;
+    if (!common_table_values_initialized) {
+        auto aes_sbox_table = bb::plookup::aes128_tables::generate_aes_sbox_table(BasicTableId::AES_SBOX_MAP, 0);
+        for (auto& table_value : aes_sbox_table.column_1) {
+            common_values.insert(table_value);
+        }
+        for (auto& table_value : aes_sbox_table.column_2) {
+            common_values.insert(table_value);
+        }
+        for (auto& table_value : aes_sbox_table.column_3) {
+            common_values.insert(table_value);
+        }
+        common_table_values_initialized = true;
+        for (size_t i = 0; i < 252; i++) {
+            common_values.insert(uint256_t(1) << i);
+        }
+        static constexpr uint256_t fq_modulus =
+            uint256_t(0x3C208C16D87CFD47ULL, 0x97816a916871ca8dULL, 0xb85045b68181585dULL, 0x30644e72e131a029ULL);
+        common_values.insert(bb::fr(fq_modulus));
+        common_values.insert(bb::fr(fq_modulus - 1));
+        common_values.insert(bb::fr(fq_modulus - 2));
+        common_values.insert(bb::fr(fq_modulus + 1));
+        common_values.insert(bb::fr(fq_modulus >> 1));
+        common_values.insert(bb::fr((fq_modulus + 1) >> 1));
+        static constexpr uint256_t two_to_136 = uint256_t(1) << 136;
+        static constexpr uint256_t neg_modulus = bb::fr::modulus - fq_modulus;
+        common_values.insert(bb::fr(neg_modulus));
+        common_values.insert(bb::fr(neg_modulus & (two_to_136 - 1)));
+        common_values.insert(bb::fr(neg_modulus >> 136));
+    }
+    if (value.is_zero() || value == bb::fr::one() || value == -bb::fr::one()) {
+        return true;
+    }
+    if (common_values.contains(value)) {
+        return true;
+    }
+    if (is_bn254_fq_modulus_derived_value(value)) {
+        return true;
+    }
+    uint256_t converted = value;
+    static constexpr auto positive_ceiling = uint256_t(1) << 32;
+    static constexpr auto negative_ceiling = bb::fr::modulus;
+    static constexpr auto negative_floor = negative_ceiling - positive_ceiling;
+    for (size_t shift = 0; shift < 256; shift += 32) {
+        const auto shifted_small_value_mask = (positive_ceiling - 1) << shift;
+        if (converted != 0 && (converted & shifted_small_value_mask) == converted) {
+            return true;
+        }
+    }
+    return converted < positive_ceiling || (converted > negative_floor && converted < negative_ceiling);
+}
+
+template <typename FF, typename CircuitBuilder>
+bool StaticAnalyzer_<FF, CircuitBuilder>::is_non_native_field_custom_gate(auto& block, size_t gate_idx) const
+{
+    if (read_gate_selector(block, GateKind::Nnf, gate_idx).is_zero()) {
+        return false;
+    }
+
+    const auto& q_1 = block.q_1()[gate_idx];
+    const auto& q_2 = block.q_2()[gate_idx];
+    const auto& q_3 = block.q_3()[gate_idx];
+    const auto& q_4 = block.q_4()[gate_idx];
+    const auto& q_m = block.q_m()[gate_idx];
+    const auto& q_c = block.q_c()[gate_idx];
+
+    if (!q_1.is_zero() || !q_c.is_zero()) {
+        return false;
+    }
+    // Recognize the exact selector modes emitted by range_constrain_two_limbs() and non-native multiplication:
+    // limb accumulation 1/2 and product 1/2/3.
+    return (q_2.is_zero() && q_3 == FF::one() && q_4 == FF::one() && q_m.is_zero()) ||
+           (q_2.is_zero() && q_3 == FF::one() && q_4.is_zero() && q_m == FF::one()) ||
+           (q_2 == FF::one() && q_3 == FF::one() && q_4.is_zero() && q_m.is_zero()) ||
+           (q_2 == FF::one() && q_3.is_zero() && q_4 == FF::one() && q_m.is_zero()) ||
+           (q_2 == FF::one() && q_3.is_zero() && q_4.is_zero() && q_m == FF::one());
+}
+
+template <typename FF, typename CircuitBuilder>
+bool StaticAnalyzer_<FF, CircuitBuilder>::is_non_native_field_prime_limb_gate(auto& block, size_t gate_idx) const
+{
+    const auto q_arith = read_gate_selector(block, GateKind::Arith, gate_idx);
+    if (q_arith != FF::one() && q_arith != FF(2) && q_arith != FF(3)) {
+        return false;
+    }
+
+    const auto& q_m = block.q_m()[gate_idx];
+    const auto& q_1 = block.q_1()[gate_idx];
+    const auto& q_2 = block.q_2()[gate_idx];
+    const auto& q_3 = block.q_3()[gate_idx];
+    const auto& q_4 = block.q_4()[gate_idx];
+    const auto& q_c = block.q_c()[gate_idx];
+
+    auto is_native_field_modulus_limb_selector = [](const FF& selector) {
+        uint256_t selector_uint = selector;
+        static constexpr uint256_t native_modulus_minus_one = bb::fr::modulus - 1;
+        static constexpr uint256_t lower_127_mask = (uint256_t(1) << 127) - 1;
+        return selector_uint == (native_modulus_minus_one & lower_127_mask) ||
+               selector_uint == (native_modulus_minus_one >> 127);
+    };
+    auto is_modulus_selector = [&](const FF& selector) {
+        return is_bn254_fq_modulus_derived_value(selector) || is_native_field_modulus_limb_selector(selector);
+    };
+    auto is_power_of_two_selector = [](const FF& selector) {
+        uint256_t selector_uint = selector;
+        return selector_uint > 0 && (selector_uint & (selector_uint - 1)) == 0;
+    };
+    auto is_zero_or_power_of_two_selector = [&](const FF& selector) {
+        return selector.is_zero() || is_power_of_two_selector(selector);
+    };
+    auto is_zero_power_two_or_modulus_selector = [&](const FF& selector) {
+        return is_zero_or_power_of_two_selector(selector) || is_modulus_selector(selector);
+    };
+    const bool has_modulus_selector = is_modulus_selector(q_m) || is_modulus_selector(q_1) ||
+                                      is_modulus_selector(q_2) || is_modulus_selector(q_3) ||
+                                      is_modulus_selector(q_4) || is_modulus_selector(q_c);
+    const bool has_limb_modulus_selector =
+        is_modulus_selector(q_1) || is_modulus_selector(q_2) || is_modulus_selector(q_3) || is_modulus_selector(q_c);
+
+    auto is_zero_or_one_selector = [](const FF& selector) { return selector.is_zero() || selector == FF::one(); };
+    if (q_arith == FF::one() && q_m.is_zero() && q_4 == -FF::one() && q_c.is_zero() && is_zero_or_one_selector(q_1) &&
+        is_zero_or_one_selector(q_2) && is_zero_or_one_selector(q_3)) {
+        return false;
+    }
+
+    // q_arith == 3 is a special mini-add mode used by non-native field addition/subtraction. It can carry arbitrary
+    // limb scaling constants, so require a modulus-derived selector to avoid treating ordinary hand-written q=3
+    // arithmetic rows as structural non-native rows.
+    if (q_arith == FF(3)) {
+        return q_1.is_zero() && q_4.is_zero() && has_modulus_selector;
+    }
+
+    // Shifted limb accumulation gates emitted by bigfield reductions:
+    //   k1 * a + k2 * b + k3 * c + p' * d + d_shift = 0
+    if (q_arith == FF(2)) {
+        return q_m.is_zero() && has_modulus_selector;
+    }
+
+    // Linear limb/recomposition gates around bigfield reductions:
+    //   k1 * a + k2 * b + p' * c + d = 0
+    //   p' * a + k * b + p' * c + p'' = 0
+    // These are paired with the q_arith == 2 shifted accumulators above. They contain one or more modulus-derived
+    // selectors plus powers of two used for limb shifts.
+    if (q_m.is_zero() && (q_4.is_zero() || q_4 == FF::one()) && is_zero_power_two_or_modulus_selector(q_1) &&
+        is_zero_power_two_or_modulus_selector(q_2) && is_zero_power_two_or_modulus_selector(q_3)) {
+        return is_modulus_selector(q_1) || is_modulus_selector(q_2) || is_modulus_selector(q_3) ||
+               is_modulus_selector(q_c);
+    }
+
+    // Non-native product/reduction rows can place modulus-derived coefficients in both q_m and q_4 while keeping the
+    // other limb terms linear. The q_2 coefficient is operation-dependent and may be an arbitrary challenge-derived
+    // scaling in cycle-group table construction.
+    if (is_modulus_selector(q_m) && is_modulus_selector(q_4) && q_3 == FF::one()) {
+        return true;
+    }
+    if (is_modulus_selector(q_m) && q_4.is_zero() && is_modulus_selector(q_3) &&
+        is_zero_or_power_of_two_selector(q_1) && is_zero_or_power_of_two_selector(q_2)) {
+        return true;
+    }
+    if (q_m.is_zero() && is_modulus_selector(q_4) && is_zero_power_two_or_modulus_selector(q_1) &&
+        is_zero_power_two_or_modulus_selector(q_2) && is_zero_power_two_or_modulus_selector(q_3)) {
+        return true;
+    }
+    if (q_m == FF::one() && is_modulus_selector(q_4) && (q_3 == FF::one() || is_modulus_selector(q_3)) &&
+        is_zero_power_two_or_modulus_selector(q_1) && is_zero_power_two_or_modulus_selector(q_2)) {
+        return true;
+    }
+    if (!q_m.is_zero() && is_modulus_selector(q_4) && (q_3 == FF::one() || is_modulus_selector(q_3)) && q_1.is_zero() &&
+        q_2.is_zero()) {
+        return true;
+    }
+
+    // These are the arithmetic identities emitted by bigfield prime-limb checks:
+    //   a * b + p' * c = 0
+    //   a * b + p' = 0
+    //   a * b + k1 * a + k2 * b + p' * c = 0
+    //   k1 * a + k2 * b + p' * c = 0
+    //   p' * a + p' * c = 0
+    // where p' is -BN254::Fq::modulus in the native field. Values constrained only by these gates are
+    // non-native reduction intermediates, and duplicate numeric values do not indicate witness reuse.
+    if (!(q_m.is_zero() || q_m == FF::one())) {
+        return false;
+    }
+    return has_limb_modulus_selector;
+}
+
+template <typename FF, typename CircuitBuilder>
+bool StaticAnalyzer_<FF, CircuitBuilder>::variable_only_in_non_native_field_prime_limb_gates(uint32_t var_idx) const
+{
+    using BlockType = std::conditional_t<IsMegaBuilder<CircuitBuilder>, bb::MegaTraceBlock, bb::UltraTraceBlock>;
+
+    auto it = variable_gate_refs.find(var_idx);
+    if (it == variable_gate_refs.end()) {
+        return false;
+    }
+    for (const auto& [block_ptr, gate_idx] : it->second) {
+        auto& block = *const_cast<BlockType*>(static_cast<const BlockType*>(block_ptr));
+        const bool is_prime_limb_gate = is_non_native_field_prime_limb_gate(block, gate_idx);
+        if (!is_prime_limb_gate && !is_non_native_field_custom_gate(block, gate_idx)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+template <typename FF, typename CircuitBuilder>
+bool StaticAnalyzer_<FF, CircuitBuilder>::is_fixed_witness_gate(auto& block, size_t gate_idx, uint32_t var_idx) const
+{
+    return read_gate_selector(block, GateKind::Arith, gate_idx) == FF::one() && block.q_1()[gate_idx] == FF::one() &&
+           block.q_m()[gate_idx].is_zero() && block.q_2()[gate_idx].is_zero() && block.q_3()[gate_idx].is_zero() &&
+           block.q_4()[gate_idx].is_zero() && circuit_builder.real_variable_index[block.w_l()[gate_idx]] == var_idx;
+}
+
+template <typename FF, typename CircuitBuilder>
+bool StaticAnalyzer_<FF, CircuitBuilder>::is_modulus_arithmetic_gate(auto& block, size_t gate_idx) const
+{
+    if (read_gate_selector(block, GateKind::Arith, gate_idx).is_zero()) {
+        return false;
+    }
+    auto is_nontrivial_modulus_selector = [](const FF& selector) {
+        return selector != -FF::one() && is_bn254_fq_modulus_derived_value(selector);
+    };
+    return is_nontrivial_modulus_selector(block.q_m()[gate_idx]) ||
+           is_nontrivial_modulus_selector(block.q_1()[gate_idx]) ||
+           is_nontrivial_modulus_selector(block.q_2()[gate_idx]) ||
+           is_nontrivial_modulus_selector(block.q_3()[gate_idx]) ||
+           is_nontrivial_modulus_selector(block.q_4()[gate_idx]) ||
+           is_nontrivial_modulus_selector(block.q_c()[gate_idx]);
+}
+
+template <typename FF, typename CircuitBuilder>
+bool StaticAnalyzer_<FF, CircuitBuilder>::variable_only_in_modulus_arithmetic_gates(uint32_t var_idx) const
+{
+    using BlockType = std::conditional_t<IsMegaBuilder<CircuitBuilder>, bb::MegaTraceBlock, bb::UltraTraceBlock>;
+
+    auto it = variable_gate_refs.find(var_idx);
+    if (it == variable_gate_refs.end()) {
+        return false;
+    }
+    for (const auto& [block_ptr, gate_idx] : it->second) {
+        auto& block = *const_cast<BlockType*>(static_cast<const BlockType*>(block_ptr));
+        if (is_fixed_witness_gate(block, gate_idx, var_idx)) {
+            continue;
+        }
+        if (!is_modulus_arithmetic_gate(block, gate_idx)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+template <typename FF, typename CircuitBuilder>
+bool StaticAnalyzer_<FF, CircuitBuilder>::variable_only_in_memory_gates(uint32_t var_idx) const
+{
+    auto it = variable_gate_refs.find(var_idx);
+    if (it == variable_gate_refs.end()) {
+        return false;
+    }
+    const void* memory_block_ptr = static_cast<const void*>(&circuit_builder.blocks.memory);
+    return std::all_of(
+        it->second.begin(), it->second.end(), [&](const auto& gate_ref) { return gate_ref.first == memory_block_ptr; });
+}
+
+template <typename FF, typename CircuitBuilder>
+bool StaticAnalyzer_<FF, CircuitBuilder>::variable_only_in_msm_table_materialization_gates(uint32_t var_idx) const
+{
+    using BlockType = std::conditional_t<IsMegaBuilder<CircuitBuilder>, bb::MegaTraceBlock, bb::UltraTraceBlock>;
+
+    auto it = variable_gate_refs.find(var_idx);
+    if (it == variable_gate_refs.end()) {
+        return false;
+    }
+    const void* arithmetic_block_ptr = static_cast<const void*>(&circuit_builder.blocks.arithmetic);
+    const void* elliptic_block_ptr = static_cast<const void*>(&circuit_builder.blocks.elliptic);
+    const void* lookup_block_ptr = static_cast<const void*>(&circuit_builder.blocks.lookup);
+    const void* memory_block_ptr = static_cast<const void*>(&circuit_builder.blocks.memory);
+    for (const auto& [block_ptr, gate_idx] : it->second) {
+        if (block_ptr == elliptic_block_ptr || block_ptr == lookup_block_ptr || block_ptr == memory_block_ptr) {
+            continue;
+        }
+        if (block_ptr == arithmetic_block_ptr) {
+            auto& block = *const_cast<BlockType*>(static_cast<const BlockType*>(block_ptr));
+            if (is_fixed_witness_gate(block, gate_idx, var_idx) || is_modulus_arithmetic_gate(block, gate_idx)) {
+                continue;
+            }
+        }
+        return false;
+    }
+    return true;
+}
+
+template <typename FF, typename CircuitBuilder>
+bool StaticAnalyzer_<FF, CircuitBuilder>::variable_only_in_elliptic_materialization_gates(uint32_t var_idx) const
+{
+    using BlockType = std::conditional_t<IsMegaBuilder<CircuitBuilder>, bb::MegaTraceBlock, bb::UltraTraceBlock>;
+
+    auto it = variable_gate_refs.find(var_idx);
+    if (it == variable_gate_refs.end()) {
+        return false;
+    }
+    const void* arithmetic_block_ptr = static_cast<const void*>(&circuit_builder.blocks.arithmetic);
+    const void* elliptic_block_ptr = static_cast<const void*>(&circuit_builder.blocks.elliptic);
+    bool has_elliptic_row = false;
+    bool has_materialization_row = false;
+    for (const auto& [block_ptr, gate_idx] : it->second) {
+        auto& block = *const_cast<BlockType*>(static_cast<const BlockType*>(block_ptr));
+        if (block_ptr == elliptic_block_ptr) {
+            has_elliptic_row = true;
+            continue;
+        }
+        if (block_ptr == arithmetic_block_ptr &&
+            (is_fixed_witness_gate(block, gate_idx, var_idx) || is_modulus_arithmetic_gate(block, gate_idx))) {
+            has_materialization_row = true;
+            continue;
+        }
+        return false;
+    }
+    return has_elliptic_row && has_materialization_row;
+}
+
+template <typename FF, typename CircuitBuilder>
+bool StaticAnalyzer_<FF, CircuitBuilder>::variable_only_in_ecc_op_materialization_gates(uint32_t var_idx) const
+{
+    if constexpr (!IsMegaBuilder<CircuitBuilder>) {
+        return false;
+    } else {
+        auto it = variable_gate_refs.find(var_idx);
+        if (it == variable_gate_refs.end()) {
+            return false;
+        }
+        const void* arithmetic_block_ptr = static_cast<const void*>(&circuit_builder.blocks.arithmetic);
+        const void* ecc_op_block_ptr = static_cast<const void*>(&circuit_builder.blocks.ecc_op);
+        const void* poseidon2_block_ptr = static_cast<const void*>(&circuit_builder.blocks.poseidon2);
+        bool has_ecc_op_row = false;
+        bool has_materialization_row = false;
+        for (const auto& [block_ptr, gate_idx] : it->second) {
+            if (block_ptr == ecc_op_block_ptr) {
+                has_ecc_op_row = true;
+                continue;
+            }
+            if (block_ptr == poseidon2_block_ptr) {
+                has_materialization_row = true;
+                continue;
+            }
+            if (block_ptr == arithmetic_block_ptr) {
+                auto& block = *const_cast<bb::MegaTraceBlock*>(static_cast<const bb::MegaTraceBlock*>(block_ptr));
+                if (is_fixed_witness_gate(block, gate_idx, var_idx) || is_modulus_arithmetic_gate(block, gate_idx)) {
+                    has_materialization_row = true;
+                    continue;
+                }
+            }
+            return false;
+        }
+        return has_ecc_op_row && has_materialization_row;
+    }
+}
+
+template <typename FF, typename CircuitBuilder>
+std::unordered_map<uint32_t, std::vector<uint32_t>> StaticAnalyzer_<FF, CircuitBuilder>::
+    build_arithmetic_derivation_duplicate_adjacency() const
+{
+    // Some stdlib helpers emit the same derived witness more than once from the same peer witness and identical
+    // non-native modulus selectors. Connect only those derived witnesses; do not connect them to the peer itself.
+    DuplicateAdjacency duplicate_adjacency;
+    std::
+        unordered_map<ArithmeticDerivationSignature<FF>, std::vector<uint32_t>, ArithmeticDerivationSignatureHasher<FF>>
+            derived_variables_by_signature;
+
+    auto add_derived_variable = [&](const ArithmeticDerivationSignature<FF>& signature, uint32_t witness_index) {
+        const uint32_t real_index = circuit_builder.real_variable_index[witness_index];
+        if (real_index != circuit_builder.zero_idx()) {
+            derived_variables_by_signature[signature].emplace_back(real_index);
+        }
+    };
+
+    for (auto& block : circuit_builder.blocks.get()) {
+        for (size_t row = 0; row < block.size(); row++) {
+            if (read_gate_selector(block, GateKind::Arith, row) != FF::one()) {
+                continue;
+            }
+
+            const auto& q_m = block.q_m()[row];
+            const auto& q_1 = block.q_1()[row];
+            const auto& q_2 = block.q_2()[row];
+            const auto& q_3 = block.q_3()[row];
+            const auto& q_4 = block.q_4()[row];
+            const auto& q_c = block.q_c()[row];
+            if (q_m.is_zero() || !q_3.is_zero() || !q_4.is_zero() || !is_bn254_fq_modulus_derived_value(q_c)) {
+                continue;
+            }
+
+            auto add_oriented_derivation = [&](uint32_t derived_witness, uint32_t peer_witness, const FF& linear) {
+                const uint32_t peer_real_index = circuit_builder.real_variable_index[peer_witness];
+                if (peer_real_index == circuit_builder.zero_idx()) {
+                    return;
+                }
+
+                ArithmeticDerivationSignature<FF> signature{
+                    .q_m = q_m,
+                    .linear_scaling = linear,
+                    .q_c = q_c,
+                    .peer_variable = peer_real_index,
+                };
+                add_derived_variable(signature, derived_witness);
+            };
+
+            if (q_1.is_zero() && q_2.is_zero()) {
+                // Pure product identity: q_m * peer * derived + q_c = 0. Since multiplication is commutative, add both
+                // orientations. Only duplicated derived witnesses sharing the same peer get connected.
+                add_oriented_derivation(block.w_l()[row], block.w_r()[row], FF::zero());
+                add_oriented_derivation(block.w_r()[row], block.w_l()[row], FF::zero());
+                continue;
+            }
+
+            const bool derived_on_left = !q_1.is_zero() && q_2.is_zero();
+            const bool derived_on_right = q_1.is_zero() && !q_2.is_zero();
+            if (derived_on_left == derived_on_right) {
+                continue;
+            }
+            add_oriented_derivation(derived_on_left ? block.w_l()[row] : block.w_r()[row],
+                                    derived_on_left ? block.w_r()[row] : block.w_l()[row],
+                                    derived_on_left ? q_1 : q_2);
+        }
+    }
+
+    for (auto& [_, variables] : derived_variables_by_signature) {
+        connect_duplicate_variables(duplicate_adjacency, variables, circuit_builder.zero_idx());
+    }
+    return duplicate_adjacency;
+}
+
+template <typename FF, typename CircuitBuilder>
+std::unordered_map<uint32_t, std::vector<uint32_t>> StaticAnalyzer_<FF, CircuitBuilder>::
+    build_elliptic_operation_duplicate_adjacency() const
+{
+    // Repeating the same elliptic add/double operation with copied input witnesses deterministically repeats x3/y3.
+    // Keep x-output and y-output components separate so accidental x == y equality remains visible.
+    DuplicateAdjacency duplicate_adjacency;
+    std::unordered_map<EllipticOperationSignature<FF>, std::vector<uint32_t>, EllipticOperationSignatureHasher<FF>>
+        x_outputs_by_signature;
+    std::unordered_map<EllipticOperationSignature<FF>, std::vector<uint32_t>, EllipticOperationSignatureHasher<FF>>
+        y_outputs_by_signature;
+
+    auto real_value = [&](uint32_t witness_index) {
+        return circuit_builder.get_variable(circuit_builder.real_variable_index[witness_index]);
+    };
+    auto real_index = [&](uint32_t witness_index) { return circuit_builder.real_variable_index[witness_index]; };
+
+    for (auto& block : circuit_builder.blocks.get()) {
+        for (size_t row = 0; row + 1 < block.size(); row++) {
+            if (read_gate_selector(block, GateKind::Elliptic, row) != FF::one()) {
+                continue;
+            }
+
+            const bool is_double = block.q_m()[row] == FF::one();
+            const bool is_add = block.q_m()[row].is_zero();
+            if (!is_double && !is_add) {
+                continue;
+            }
+
+            EllipticOperationSignature<FF> signature{
+                .is_double = is_double,
+                .q_sign_or_double = is_double ? FF::one() : block.q_1()[row],
+                .inputs = { real_value(block.w_r()[row]),
+                            real_value(block.w_o()[row]),
+                            is_double ? FF::zero() : real_value(block.w_l()[row + 1]),
+                            is_double ? FF::zero() : real_value(block.w_4()[row + 1]) },
+            };
+            x_outputs_by_signature[signature].emplace_back(real_index(block.w_r()[row + 1]));
+            y_outputs_by_signature[signature].emplace_back(real_index(block.w_o()[row + 1]));
+        }
+    }
+
+    for (auto& [_, variables] : x_outputs_by_signature) {
+        connect_duplicate_variables(duplicate_adjacency, variables, circuit_builder.zero_idx());
+    }
+    for (auto& [_, variables] : y_outputs_by_signature) {
+        connect_duplicate_variables(duplicate_adjacency, variables, circuit_builder.zero_idx());
+    }
+    return duplicate_adjacency;
+}
+
+template <typename FF, typename CircuitBuilder>
+std::unordered_map<uint32_t, std::vector<uint32_t>> StaticAnalyzer_<FF, CircuitBuilder>::
+    build_ecc_op_table_duplicate_adjacency() const
+{
+    DuplicateAdjacency duplicate_adjacency;
+    if constexpr (!IsMegaBuilder<CircuitBuilder>) {
+        return duplicate_adjacency;
+    } else {
+        // Repeated transcript commitments are materialized as repeated ECC-op table point tuples. This happens
+        // structurally in batch-merge proofs, where inactive subtable commitments are commitments to the zero
+        // polynomial. Connect corresponding limbs only when the full opcode+point tuple repeats.
+        using PointVariables = std::array<uint32_t, 4>;
+        std::unordered_map<EccOpPointSignature<FF>, std::vector<PointVariables>, EccOpPointSignatureHasher<FF>>
+            point_variables_by_signature;
+
+        auto real_index = [&](uint32_t witness_index) { return circuit_builder.real_variable_index[witness_index]; };
+        auto real_value = [&](uint32_t witness_index) {
+            return circuit_builder.get_variable(real_index(witness_index));
+        };
+
+        auto& block = circuit_builder.blocks.ecc_op;
+        const void* ecc_op_block_ptr = static_cast<const void*>(&block);
+        auto has_materialization_gate = [&](uint32_t real_variable_index) {
+            auto it = variable_gate_refs.find(real_variable_index);
+            if (it == variable_gate_refs.end()) {
+                return false;
+            }
+            return std::any_of(it->second.begin(), it->second.end(), [&](const auto& gate_ref) {
+                return gate_ref.first != ecc_op_block_ptr;
+            });
+        };
+
+        for (size_t row = 0; row + 1 < block.size(); row++) {
+            if (block.w_l()[row] == circuit_builder.zero_idx()) {
+                continue;
+            }
+            PointVariables point_variables{ real_index(block.w_r()[row]),
+                                            real_index(block.w_o()[row]),
+                                            real_index(block.w_4()[row]),
+                                            real_index(block.w_r()[row + 1]) };
+            if (!std::all_of(point_variables.begin(), point_variables.end(), has_materialization_gate)) {
+                continue;
+            }
+
+            EccOpPointSignature<FF> signature{
+                .opcode = real_value(block.w_l()[row]),
+                .point = { real_value(block.w_r()[row]),
+                           real_value(block.w_o()[row]),
+                           real_value(block.w_4()[row]),
+                           real_value(block.w_r()[row + 1]) },
+            };
+            point_variables_by_signature[signature].push_back(point_variables);
+        }
+
+        for (auto& [_, point_variables] : point_variables_by_signature) {
+            if (point_variables.size() < 2) {
+                continue;
+            }
+            for (size_t limb_idx = 0; limb_idx < 4; limb_idx++) {
+                std::vector<uint32_t> limb_variables;
+                limb_variables.reserve(point_variables.size());
+                for (const auto& variables : point_variables) {
+                    limb_variables.emplace_back(variables[limb_idx]);
+                }
+                connect_duplicate_variables(duplicate_adjacency, limb_variables, circuit_builder.zero_idx());
+            }
+        }
+
+        return duplicate_adjacency;
+    }
+}
+
+/**
+ * @brief Generate a map [WitnessValue] -> [VariableSet] for repeated witness values.
+ *
+ * @details Explanation-only mode does not drop candidates by value alone. Triage mode additionally removes common
+ * values and caller-provided filter values after structural/provenance checks. Rerun-varying filter values are
+ * computed by rebuilding the same circuit with randomized inputs and are removed independently of triage mode.
+ *
+ * @tparam FF
+ * @tparam CircuitBuilder
+ */
+template <typename FF, typename CircuitBuilder>
+void StaticAnalyzer_<FF, CircuitBuilder>::fill_witness_duplicate_map(
+    const std::unordered_set<FF>& additional_filter_values,
+    WitnessDuplicateFilterMode filter_mode,
+    const std::unordered_set<FF>& rerun_varying_filter_values)
+{
+    // We only need to fill the map once
+    if (!filtered_witness_value_map.empty()) {
+        return;
+    }
+    const auto databus_read_value_variables = get_databus_read_value_variables();
+    std::unordered_map<uint32_t, std::pair<DuplicateIdentityKey, DuplicateCryptographicBindingRole>>
+        cryptographic_binding_by_variable;
+    for (const auto& [real_index, group_key] : circuit_builder.get_duplicate_provenance()) {
+        auto binding_group_key = cryptographic_binding_group_key(group_key);
+        const auto binding_role = get_duplicate_cryptographic_binding_role(group_key.local_id);
+        if (!binding_group_key.has_value() || !binding_role.has_value()) {
+            continue;
+        }
+        cryptographic_binding_by_variable.emplace(
+            real_index, std::make_pair(std::move(binding_group_key.value()), binding_role.value()));
+    }
+    auto duplicate_set_is_cryptographic_binding = [&](const std::vector<uint32_t>& ordered_indices) {
+        if (ordered_indices.empty()) {
+            return false;
+        }
+        auto first_it = cryptographic_binding_by_variable.find(ordered_indices[0]);
+        if (first_it == cryptographic_binding_by_variable.end()) {
+            return false;
+        }
+        const DuplicateIdentityKey& group_key = first_it->second.first;
+        bool has_running_hash = false;
+        bool has_transcript_hash = false;
+        for (uint32_t idx : ordered_indices) {
+            auto it = cryptographic_binding_by_variable.find(idx);
+            if (it == cryptographic_binding_by_variable.end() || it->second.first != group_key) {
+                return false;
+            }
+            has_running_hash |= it->second.second == DuplicateCryptographicBindingRole::RUNNING_HASH;
+            has_transcript_hash |= it->second.second == DuplicateCryptographicBindingRole::TRANSCRIPT_HASH;
+        }
+        return has_running_hash && has_transcript_hash;
+    };
+    auto duplicate_set_intersects_cryptographic_binding = [&](const std::vector<uint32_t>& ordered_indices) {
+        return std::any_of(ordered_indices.begin(), ordered_indices.end(), [&](uint32_t idx) {
+            return cryptographic_binding_by_variable.contains(idx);
+        });
+    };
+    // Scan through already detected variables and add their values. Do not drop candidates by value alone: a common
+    // field value can still be a real witness duplicate unless a structural/provenance explanation removes it below.
+    for (auto [variable_index, count] : variables_gate_counts) {
+        if (count == 0) {
+            continue;
+        }
+        BB_ASSERT(variable_index == circuit_builder.real_variable_index[variable_index]);
+        auto witness_value = circuit_builder.get_variable(variable_index);
+        filtered_witness_value_map[witness_value].insert(variable_index);
+    }
+    // Remove single-occurrence values
+    std::vector<bb::fr> values_for_removal;
+    values_for_removal.reserve(filtered_witness_value_map.size());
+    for (const auto& [value, index_set] : filtered_witness_value_map) {
+        if (index_set.size() <= 1) {
+            values_for_removal.push_back(value);
+        }
+    }
+    for (auto& val : values_for_removal) {
+        filtered_witness_value_map.erase(val);
+    }
+    // Build duplicate-search overlays even when main graph connectivity is disabled. These edges are used only by this
+    // duplicate filter and never mutate variable_adjacency_lists.
+    values_for_removal.clear();
+    auto memory_duplicate_adjacency_lists = build_memory_table_duplicate_adjacency();
+    std::unordered_map<uint32_t, std::vector<uint32_t>> databus_duplicate_adjacency_lists =
+        build_databus_read_duplicate_adjacency();
+    const auto databus_duplicate_variables = collect_duplicate_graph_variables(databus_duplicate_adjacency_lists);
+    std::unordered_map<uint32_t, std::vector<uint32_t>> non_native_duplicate_adjacency_lists =
+        build_non_native_field_duplicate_adjacency();
+    std::unordered_map<uint32_t, std::vector<uint32_t>> arithmetic_derivation_duplicate_adjacency_lists =
+        build_arithmetic_derivation_duplicate_adjacency();
+    std::unordered_map<uint32_t, std::vector<uint32_t>> elliptic_operation_duplicate_adjacency_lists =
+        build_elliptic_operation_duplicate_adjacency();
+    std::unordered_map<uint32_t, std::vector<uint32_t>> ecc_op_table_duplicate_adjacency_lists =
+        build_ecc_op_table_duplicate_adjacency();
+    std::unordered_map<uint32_t, std::vector<uint32_t>> lookup_table_duplicate_adjacency_lists =
+        build_lookup_table_duplicate_adjacency();
+    std::unordered_map<uint32_t, std::vector<uint32_t>> straus_table_duplicate_adjacency_lists =
+        build_straus_table_duplicate_adjacency();
+    std::unordered_map<uint32_t, std::vector<uint32_t>> structural_duplicate_adjacency_lists =
+        memory_duplicate_adjacency_lists;
+    auto merge_structural_overlay = [&](const auto& overlay) {
+        for (const auto& [node, neighbors] : overlay) {
+            auto& structural_neighbors = structural_duplicate_adjacency_lists[node];
+            structural_neighbors.insert(structural_neighbors.end(), neighbors.begin(), neighbors.end());
+        }
+    };
+    merge_structural_overlay(non_native_duplicate_adjacency_lists);
+    merge_structural_overlay(arithmetic_derivation_duplicate_adjacency_lists);
+    merge_structural_overlay(elliptic_operation_duplicate_adjacency_lists);
+    merge_structural_overlay(ecc_op_table_duplicate_adjacency_lists);
+    merge_structural_overlay(lookup_table_duplicate_adjacency_lists);
+    merge_structural_overlay(straus_table_duplicate_adjacency_lists);
+    merge_structural_overlay(build_provenance_duplicate_adjacency());
+    const auto structural_duplicate_component_ids = build_duplicate_component_ids(structural_duplicate_adjacency_lists);
+    for (auto& [value, index_set] : filtered_witness_value_map) {
+        std::vector<uint32_t> ordered_indices(index_set.begin(), index_set.end());
+        std::sort(ordered_indices.begin(), ordered_indices.end());
+        const bool has_databus_read = std::any_of(ordered_indices.begin(), ordered_indices.end(), [&](uint32_t idx) {
+            return databus_read_value_variables.contains(idx);
+        });
+        const bool has_non_databus_read =
+            std::any_of(ordered_indices.begin(), ordered_indices.end(), [&](uint32_t idx) {
+                return !databus_read_value_variables.contains(idx);
+            });
+        // Source-aware overlays are allowed to remove a duplicate only when every occurrence is connected by the
+        // expected access relation. If a value touches an overlay but is not fully explained by it, keep it visible
+        // so the next filter pass — or the human triaging output — can decide.
+        if (duplicate_set_is_connected_in_overlay(
+                ordered_indices, databus_duplicate_adjacency_lists, databus_duplicate_variables)) {
+            values_for_removal.push_back(value);
+            continue;
+        }
+        if (duplicate_set_intersects_overlay(ordered_indices, databus_duplicate_variables) ||
+            (has_databus_read && has_non_databus_read)) {
+            continue;
+        }
+        if (duplicate_set_is_cryptographic_binding(ordered_indices)) {
+            values_for_removal.push_back(value);
+            continue;
+        }
+        if (duplicate_set_intersects_cryptographic_binding(ordered_indices)) {
+            continue;
+        }
+        if (duplicate_set_is_connected_in_overlay_components(ordered_indices, structural_duplicate_component_ids)) {
+            values_for_removal.push_back(value);
+            continue;
+        }
+        if (duplicate_set_intersects_overlay_components(ordered_indices, structural_duplicate_component_ids)) {
+            continue;
+        }
+        // No structural overlay explains this duplicate. Keep it visible.
+    }
+    for (auto& val : values_for_removal) {
+        filtered_witness_value_map.erase(val);
+    }
+    values_for_removal.clear();
+    for (auto& [value, _] : filtered_witness_value_map) {
+        if (rerun_varying_filter_values.contains(value)) {
+            values_for_removal.push_back(value);
+        }
+    }
+    for (auto& val : values_for_removal) {
+        filtered_witness_value_map.erase(val);
+    }
+    values_for_removal.clear();
+    if (filter_mode == WitnessDuplicateFilterMode::TRIAGE_VALUE_FILTERS) {
+        for (auto& [value, index_set] : filtered_witness_value_map) {
+            if (is_triage_noise_witness_value(value)) {
+                values_for_removal.push_back(value);
+                continue;
+            }
+            if (!additional_filter_values.contains(value)) {
+                continue;
+            }
+            const bool has_databus_read = std::any_of(index_set.begin(), index_set.end(), [&](uint32_t idx) {
+                return databus_read_value_variables.contains(idx);
+            });
+            const bool has_non_databus_read = std::any_of(index_set.begin(), index_set.end(), [&](uint32_t idx) {
+                return !databus_read_value_variables.contains(idx);
+            });
+            if (!(has_databus_read && has_non_databus_read)) {
+                values_for_removal.push_back(value);
+            }
+        }
+        for (auto& val : values_for_removal) {
+            filtered_witness_value_map.erase(val);
+        }
+        values_for_removal.clear();
+    }
+    const auto& duplicate_provenance = circuit_builder.get_duplicate_provenance();
+    for (auto& [value, index_set] : filtered_witness_value_map) {
+        bool has_msm_table_materialization = false;
+        bool all_msm_table_neighborhood = true;
+        for (auto& idx : index_set) {
+            auto provenance_it = duplicate_provenance.find(idx);
+            const bool is_msm_table =
+                provenance_it != duplicate_provenance.end() &&
+                duplicate_provenance_category(provenance_it->second) == DuplicateProvenanceCategory::MSM_TABLE;
+            if (is_msm_table) {
+                has_msm_table_materialization = true;
+                if (!variable_only_in_msm_table_materialization_gates(idx)) {
+                    all_msm_table_neighborhood = false;
+                    break;
+                }
+                continue;
+            }
+            if (!variable_only_in_memory_gates(idx)) {
+                all_msm_table_neighborhood = false;
+                break;
+            }
+        }
+        if (has_msm_table_materialization && all_msm_table_neighborhood) {
+            values_for_removal.push_back(value);
+        }
+    }
+    for (auto& val : values_for_removal) {
+        filtered_witness_value_map.erase(val);
+    }
+    values_for_removal.clear();
+    for (auto& [value, index_set] : filtered_witness_value_map) {
+        bool all_ecc_op_materializations = true;
+        for (auto& idx : index_set) {
+            auto provenance_it = duplicate_provenance.find(idx);
+            if (provenance_it == duplicate_provenance.end() ||
+                duplicate_provenance_category(provenance_it->second) != DuplicateProvenanceCategory::ECC_OP_TABLE ||
+                !variable_only_in_ecc_op_materialization_gates(idx)) {
+                all_ecc_op_materializations = false;
+                break;
+            }
+        }
+        if (all_ecc_op_materializations) {
+            values_for_removal.push_back(value);
+        }
+    }
+    for (auto& val : values_for_removal) {
+        filtered_witness_value_map.erase(val);
+    }
+    values_for_removal.clear();
+    for (auto& [value, index_set] : filtered_witness_value_map) {
+        bool all_elliptic_w4_materializations = true;
+        for (auto& idx : index_set) {
+            if (!variable_only_in_elliptic_materialization_gates(idx)) {
+                all_elliptic_w4_materializations = false;
+                break;
+            }
+        }
+        if (all_elliptic_w4_materializations) {
+            values_for_removal.push_back(value);
+        }
+    }
+    for (auto& val : values_for_removal) {
+        filtered_witness_value_map.erase(val);
+    }
+    values_for_removal.clear();
+    for (auto& [value, index_set] : filtered_witness_value_map) {
+        bool all_modulus_arithmetic = true;
+        for (auto& idx : index_set) {
+            if (!variable_only_in_modulus_arithmetic_gates(idx)) {
+                all_modulus_arithmetic = false;
+                break;
+            }
+        }
+        if (all_modulus_arithmetic) {
+            values_for_removal.push_back(value);
+        }
+    }
+    for (auto& val : values_for_removal) {
+        filtered_witness_value_map.erase(val);
+    }
+    // Filter out variables that are constant or constrained via fix_witness.
+    // fix_witness creates an arithmetic gate: q_1=1, q_c=-value, all other selectors/wires zero.
+    // The value is baked into q_c, so duplicates are safe.
+    auto is_fixed_witness = [&](uint32_t var_idx) -> bool {
+        using BlockType = std::conditional_t<IsMegaBuilder<CircuitBuilder>, bb::MegaTraceBlock, bb::UltraTraceBlock>;
+
+        auto it = variable_gate_refs.find(var_idx);
+        if (it == variable_gate_refs.end()) {
+            return false;
+        }
+        for (const auto& [block_ptr, gate_idx] : it->second) {
+            auto& block = *const_cast<BlockType*>(static_cast<const BlockType*>(block_ptr));
+            if (is_fixed_witness_gate(block, gate_idx, var_idx)) {
+                return true;
+            }
+        }
+        return false;
+    };
+    values_for_removal.resize(0);
+    for (const auto& [value, index_set] : filtered_witness_value_map) {
+        bool all_fixed_or_constant = true;
+        for (auto& idx : index_set) {
+            if (!constant_variable_indices_set.contains(idx) && !is_fixed_witness(idx)) {
+                all_fixed_or_constant = false;
+                break;
+            }
+        }
+        if (all_fixed_or_constant) {
+            values_for_removal.push_back(value);
+        }
+    }
+    for (auto& val : values_for_removal) {
+        filtered_witness_value_map.erase(val);
+    }
+    // Filter non-native field reduction intermediates. Bigfield prime-limb checks constrain quotient/remainder
+    // witnesses with arithmetic gates containing BN254 Fq modulus-derived selectors. Repeated values here are
+    // artifacts of the native quotient/remainder arithmetic, not independent witness reuse.
+    values_for_removal.clear();
+    for (auto& [value, index_set] : filtered_witness_value_map) {
+        bool all_prime_limb_reduction_intermediates = true;
+        for (auto& idx : index_set) {
+            if (!variable_only_in_non_native_field_prime_limb_gates(idx)) {
+                all_prime_limb_reduction_intermediates = false;
+                break;
+            }
+        }
+        if (all_prime_limb_reduction_intermediates) {
+            values_for_removal.push_back(value);
+        }
+    }
+    for (auto& val : values_for_removal) {
+        filtered_witness_value_map.erase(val);
+    }
+    // Filter out false positives from ECC op negation patterns (ADD(x,y), ADD(x,-y), EQ)
+    // When negating a point, the x-coordinate is reused, creating duplicate witness values that are not a concern.
+    if constexpr (IsMegaBuilder<CircuitBuilder>) {
+        auto& ecc_op_block = circuit_builder.blocks.ecc_op;
+        auto& wires = ecc_op_block.wires;
+        size_t num_rows = ecc_op_block.size();
+        // Collect the x_lo/x_hi limb *variables* from ADD-ADD-EQ triples where the two ADD points are concrete
+        // negations. We suppress only these specific ecc_op-block occurrences, not every witness that happens to hold
+        // the same field value — an unrelated under-constrained duplicate sharing the value must stay visible.
+        std::unordered_set<uint32_t> ecc_negation_x_variables;
+        // Each ecc op occupies 2 rows. Iterate ops (stride 2) and check consecutive triples.
+        size_t num_ops = num_rows / 2;
+        for (size_t op_idx = 0; op_idx + 2 < num_ops; op_idx++) {
+            size_t row_a = op_idx * 2;
+            size_t row_b = (op_idx + 1) * 2;
+            size_t row_c = (op_idx + 2) * 2;
+            // Row layout: wires[0] = opcode, wires[1] = x_lo, wires[2] = x_hi, wires[3] = y_lo
+            uint32_t op_a = circuit_builder.real_variable_index[wires[0][row_a]];
+            uint32_t op_b = circuit_builder.real_variable_index[wires[0][row_b]];
+            uint32_t op_c = circuit_builder.real_variable_index[wires[0][row_c]];
+            if (op_a != circuit_builder.add_accum_op_idx || op_b != circuit_builder.add_accum_op_idx ||
+                op_c != circuit_builder.equality_op_idx) {
+                continue;
+            }
+            // Check if the two ADDs share the same x_lo and x_hi witness values
+            uint32_t x_lo_a = circuit_builder.real_variable_index[wires[1][row_a]];
+            uint32_t x_lo_b = circuit_builder.real_variable_index[wires[1][row_b]];
+            uint32_t x_hi_a = circuit_builder.real_variable_index[wires[2][row_a]];
+            uint32_t x_hi_b = circuit_builder.real_variable_index[wires[2][row_b]];
+            auto x_lo_val_a = circuit_builder.get_variable(x_lo_a);
+            auto x_lo_val_b = circuit_builder.get_variable(x_lo_b);
+            auto x_hi_val_a = circuit_builder.get_variable(x_hi_a);
+            auto x_hi_val_b = circuit_builder.get_variable(x_hi_b);
+            uint32_t y_lo_a = circuit_builder.real_variable_index[wires[3][row_a]];
+            uint32_t y_lo_b = circuit_builder.real_variable_index[wires[3][row_b]];
+            uint32_t y_hi_a = circuit_builder.real_variable_index[wires[1][row_a + 1]];
+            uint32_t y_hi_b = circuit_builder.real_variable_index[wires[1][row_b + 1]];
+            auto y_lo_val_a = circuit_builder.get_variable(y_lo_a);
+            auto y_lo_val_b = circuit_builder.get_variable(y_lo_b);
+            auto y_hi_val_a = circuit_builder.get_variable(y_hi_a);
+            auto y_hi_val_b = circuit_builder.get_variable(y_hi_b);
+            using Fq = curve::BN254::BaseField;
+            constexpr size_t CHUNK_SIZE = 2 * stdlib::NUM_LIMB_BITS_IN_FIELD_SIMULATION;
+            auto y_a = Fq((uint256_t(y_hi_val_a) << CHUNK_SIZE) + uint256_t(y_lo_val_a));
+            auto y_b = Fq((uint256_t(y_hi_val_b) << CHUNK_SIZE) + uint256_t(y_lo_val_b));
+            if (x_lo_val_a == x_lo_val_b && x_hi_val_a == x_hi_val_b && y_a == -y_b) {
+                ecc_negation_x_variables.insert(x_lo_a);
+                ecc_negation_x_variables.insert(x_lo_b);
+                ecc_negation_x_variables.insert(x_hi_a);
+                ecc_negation_x_variables.insert(x_hi_b);
+            }
+        }
+        values_for_removal.clear();
+        for (auto& [value, index_set] : filtered_witness_value_map) {
+            for (auto it = index_set.begin(); it != index_set.end();) {
+                it = ecc_negation_x_variables.contains(*it) ? index_set.erase(it) : std::next(it);
+            }
+            if (index_set.size() < 2) {
+                values_for_removal.push_back(value);
+            }
+        }
+        for (auto& val : values_for_removal) {
+            filtered_witness_value_map.erase(val);
+        }
+    }
+    // Build count from the final filtered map
+    std::vector<std::pair<bb::fr, size_t>> count;
+    count.reserve(filtered_witness_value_map.size());
+    for (const auto& [value, index_set] : filtered_witness_value_map) {
+        count.emplace_back(value, index_set.size());
+    }
+    std::sort(count.begin(), count.end(), [](auto& a, auto& b) { return a.second > b.second; });
+    info("Total repeated values: ", count.size());
+    for (size_t i = 0; i < (10 < count.size() ? 10 : count.size()); i++) {
+        info("Value: ", count[i].first, " : ", count[i].second, " times");
+    }
+    if (count.empty()) {
+        info("No repeats found");
+        return;
+    }
+    // Build block labels for gate-type distribution
+    std::vector<std::string> block_labels;
+    {
+        auto blocks_ref = circuit_builder.blocks.get();
+        if constexpr (IsMegaBuilder<CircuitBuilder> || IsUltraBuilder<CircuitBuilder>) {
+            auto labels = circuit_builder.blocks.get_labels();
+            for (size_t i = 0; i < labels.size(); i++) {
+                block_labels.emplace_back(labels[i]);
+            }
+        } else {
+            for (size_t i = 0; i < blocks_ref.size(); i++) {
+                block_labels.push_back("block_" + std::to_string(i));
+            }
+        }
+    }
+
+    for (size_t c = 0; c < std::min(size_t(10), count.size()); c++) {
+        auto& val = count[c].first;
+        uint256_t val_uint = val;
+        static constexpr uint256_t LO_MASK = (uint256_t(1) << 136) - 1;
+        uint256_t lo_chunk = val_uint & LO_MASK;
+        uint256_t hi_chunk = val_uint >> 136;
+        info("Indices of value #", c, " (", val, ", ", count[c].second, " times):");
+        info("  lo_136=0x", lo_chunk, " hi=0x", hi_chunk);
+        // Print only the first 3 indices
+        size_t printed = 0;
+        for (auto& index : filtered_witness_value_map[val]) {
+            info("  ind ", index);
+            if (++printed >= 3) {
+                if (count[c].second > 3) {
+                    info("  ... (", count[c].second - 3, " more)");
+                }
+                break;
+            }
+        }
+        // Print gate-type distribution across all indices of this value.
+        // Scan blocks directly since variable_gates may not cover all variables.
+        {
+            std::unordered_set<uint32_t> index_set(filtered_witness_value_map[val].begin(),
+                                                   filtered_witness_value_map[val].end());
+            std::unordered_map<std::string, size_t> gate_distribution;
+            auto blocks_ref = circuit_builder.blocks.get();
+            for (size_t b = 0; b < blocks_ref.size(); b++) {
+                auto& blk = blocks_ref[b];
+                size_t hits = 0;
+                for (size_t row = 0; row < blk.size(); row++) {
+                    if (index_set.contains(circuit_builder.real_variable_index[blk.w_l()[row]]) ||
+                        index_set.contains(circuit_builder.real_variable_index[blk.w_r()[row]]) ||
+                        index_set.contains(circuit_builder.real_variable_index[blk.w_o()[row]]) ||
+                        index_set.contains(circuit_builder.real_variable_index[blk.w_4()[row]])) {
+                        hits++;
+                    }
+                }
+                if (hits > 0) {
+                    gate_distribution[block_labels[b]] = hits;
+                }
+            }
+            if (!gate_distribution.empty()) {
+                info("  Gate-type distribution:");
+                for (auto& [label, gate_count] : gate_distribution) {
+                    info("    ", label, ": ", gate_count, " gate(s)");
+                }
+            }
+        }
+    }
 }
 
 /**
@@ -1384,6 +3338,38 @@ void StaticAnalyzer_<FF, CircuitBuilder>::print_memory_gate_info(size_t gate_ind
     } else {
         return;
     }
+}
+
+template <typename FF, typename CircuitBuilder>
+std::unordered_set<FF> StaticAnalyzer_<FF, CircuitBuilder>::get_rerun_varying_duplicate_values(
+    const std::vector<const CircuitBuilder*>& rerun_builders) const
+{
+    std::unordered_set<FF> varying_values;
+    for (const auto* rerun_builder : rerun_builders) {
+        BB_ASSERT(rerun_builder != nullptr, "rerun builder pointer must not be null");
+    }
+
+    for (const auto& [value, index_set] : filtered_witness_value_map) {
+        bool value_varies = false;
+        for (const auto* rerun_builder : rerun_builders) {
+            for (uint32_t index : index_set) {
+                if (index >= rerun_builder->real_variable_index.size() ||
+                    rerun_builder->real_variable_index[index] >= rerun_builder->get_variables().size() ||
+                    rerun_builder->get_variable(index) != value) {
+                    value_varies = true;
+                    break;
+                }
+            }
+            if (value_varies) {
+                break;
+            }
+        }
+        if (value_varies) {
+            varying_values.insert(value);
+        }
+    }
+
+    return varying_values;
 }
 
 /**

--- a/barretenberg/cpp/src/barretenberg/boomerang_value_detection/graph.hpp
+++ b/barretenberg/cpp/src/barretenberg/boomerang_value_detection/graph.hpp
@@ -8,6 +8,7 @@
 #include "./gate_patterns.hpp"
 #include "barretenberg/stdlib_circuit_builders/mega_circuit_builder.hpp"
 #include "barretenberg/stdlib_circuit_builders/ultra_circuit_builder.hpp"
+#include <array>
 #include <list>
 #include <set>
 #include <typeinfo>
@@ -69,6 +70,10 @@ struct ConnectedComponent {
     const std::vector<uint32_t>& vars() const { return variable_indices; }
 };
 
+// Explanation-only mode reports every repeated witness value that is not removed by a concrete structural or provenance
+// explanation. Triage mode additionally applies value-only noise filters for high-volume diagnostic runs.
+enum class WitnessDuplicateFilterMode { EXPLANATION_ONLY, TRIAGE_VALUE_FILTERS };
+
 /*
  * This class describes an arithmetic circuit as an undirected graph, where vertices are variables from the circuit.
  * Edges describe connections between variables through gates. We want to find variables that weren't properly
@@ -106,6 +111,7 @@ template <typename FF, typename CircuitBuilder> class StaticAnalyzer_ {
     }
     void process_gate_variables(std::vector<uint32_t>& gate_variables, size_t gate_index, auto& blk);
     std::unordered_map<uint32_t, size_t> get_variables_gate_counts() const { return this->variables_gate_counts; };
+    const auto& get_witness_duplicate_map() const { return filtered_witness_value_map; }
 
     /**
      * @brief Extract gate variables using a declarative pattern
@@ -117,7 +123,12 @@ template <typename FF, typename CircuitBuilder> class StaticAnalyzer_ {
                                                  bb::GateKind kind);
 
     void process_execution_trace();
-
+    void fill_witness_duplicate_map(
+        const std::unordered_set<FF>& additional_filter_values = {},
+        WitnessDuplicateFilterMode filter_mode = WitnessDuplicateFilterMode::EXPLANATION_ONLY,
+        const std::unordered_set<FF>& rerun_varying_filter_values = {});
+    std::unordered_set<FF> get_rerun_varying_duplicate_values(
+        const std::vector<const CircuitBuilder*>& rerun_builders) const;
     // Methods with special handling that can't be inlined as pure patterns
     std::vector<uint32_t> get_rom_table_connected_component(const bb::RomTranscript& rom_array);
     std::vector<uint32_t> get_ram_table_connected_component(const bb::RamTranscript& ram_array);
@@ -132,6 +143,16 @@ template <typename FF, typename CircuitBuilder> class StaticAnalyzer_ {
     void mark_process_rom_connected_component();
     bool is_gate_sorted_rom(auto& memory_block, size_t gate_idx) const;
     bool variable_only_in_sorted_rom_gates(uint32_t var_idx, auto& blk) const;
+    bool is_non_native_field_custom_gate(auto& block, size_t gate_idx) const;
+    bool is_non_native_field_prime_limb_gate(auto& block, size_t gate_idx) const;
+    bool is_fixed_witness_gate(auto& block, size_t gate_idx, uint32_t var_idx) const;
+    bool is_modulus_arithmetic_gate(auto& block, size_t gate_idx) const;
+    bool variable_only_in_non_native_field_prime_limb_gates(uint32_t var_idx) const;
+    bool variable_only_in_modulus_arithmetic_gates(uint32_t var_idx) const;
+    bool variable_only_in_memory_gates(uint32_t var_idx) const;
+    bool variable_only_in_msm_table_materialization_gates(uint32_t var_idx) const;
+    bool variable_only_in_elliptic_materialization_gates(uint32_t var_idx) const;
+    bool variable_only_in_ecc_op_materialization_gates(uint32_t var_idx) const;
     std::vector<ConnectedComponent> find_connected_components();
     void connect_all_variables_in_vector(const std::vector<uint32_t>& variables_vector);
 
@@ -167,7 +188,16 @@ template <typename FF, typename CircuitBuilder> class StaticAnalyzer_ {
     // Store reference to the circuit builder
     CircuitBuilder& circuit_builder;
     bool connect_variables;
-
+    std::unordered_map<uint32_t, std::vector<uint32_t>> build_memory_table_duplicate_adjacency() const;
+    std::unordered_map<uint32_t, std::vector<uint32_t>> build_databus_read_duplicate_adjacency() const;
+    std::unordered_map<uint32_t, std::vector<uint32_t>> build_provenance_duplicate_adjacency() const;
+    std::unordered_map<uint32_t, std::vector<uint32_t>> build_non_native_field_duplicate_adjacency() const;
+    std::unordered_map<uint32_t, std::vector<uint32_t>> build_arithmetic_derivation_duplicate_adjacency() const;
+    std::unordered_map<uint32_t, std::vector<uint32_t>> build_elliptic_operation_duplicate_adjacency() const;
+    std::unordered_map<uint32_t, std::vector<uint32_t>> build_ecc_op_table_duplicate_adjacency() const;
+    std::unordered_map<uint32_t, std::vector<uint32_t>> build_lookup_table_duplicate_adjacency() const;
+    std::unordered_map<uint32_t, std::vector<uint32_t>> build_straus_table_duplicate_adjacency() const;
+    std::unordered_set<uint32_t> get_databus_read_value_variables() const;
     std::unordered_map<uint32_t, std::vector<uint32_t>>
         variable_adjacency_lists; // we use this data structure to contain information about variables and their
                                   // connections between each other
@@ -178,10 +208,16 @@ template <typename FF, typename CircuitBuilder> class StaticAnalyzer_ {
     std::unordered_map<KeyPair, std::vector<size_t>, KeyHasher, KeyEquals>
         variable_gates; // we use this data structure to store gates and TraceBlocks for every variables, where static
                         // analyzer finds them in the circuit.
+    // Same information as variable_gates, indexed directly by variable for source-aware duplicate filters.
+    std::unordered_map<uint32_t, std::vector<std::pair<const void*, size_t>>> variable_gate_refs;
     std::unordered_set<uint32_t> variables_in_one_gate;
     std::unordered_set<uint32_t> constant_variable_indices_set;
 
     std::vector<ConnectedComponent> connected_components;
+
+    std::unordered_map<bb::fr, std::set<uint32_t>>
+        filtered_witness_value_map; // We use the filtered map to discover untethered duplicates of the same
+                                    // high-entropy value within the circuit-builder
 };
 
 // Type aliases for convenience

--- a/barretenberg/cpp/src/barretenberg/boomerang_value_detection/graph_description.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/boomerang_value_detection/graph_description.test.cpp
@@ -46,6 +46,467 @@ TEST(boomerang_ultra_circuit_constructor, test_graph_for_arithmetic_gates)
 }
 
 /**
+ * @brief Test duplicate discovery
+ *
+ */
+TEST(boomerang_ultra_circuit_constructor, test_duplicate_discovery)
+{
+    UltraCircuitBuilder circuit_constructor = UltraCircuitBuilder();
+    auto value_one = bb::fr::random_element();
+    auto value_two = bb ::fr::random_element();
+    auto value_three = bb::fr::random_element();
+    for (size_t i = 0; i < 4; i++) {
+        uint32_t left_idx = circuit_constructor.add_variable(value_one);
+        uint32_t right_idx = circuit_constructor.add_variable(value_two);
+        uint32_t result_idx = circuit_constructor.add_variable(value_three);
+
+        uint32_t add_idx = circuit_constructor.add_variable(value_one + value_two + value_three + fr(i % 2));
+        circuit_constructor.create_big_add_gate(
+            { left_idx, right_idx, result_idx, add_idx, fr(1), fr(1), fr(1), fr(-1), fr(0) });
+    }
+
+    StaticAnalyzer analyzer = StaticAnalyzer(circuit_constructor);
+    analyzer.fill_witness_duplicate_map();
+    const auto& duplicate_map = analyzer.get_witness_duplicate_map();
+    EXPECT_TRUE(duplicate_map.contains(value_one));
+    EXPECT_TRUE(duplicate_map.contains(value_two));
+    EXPECT_TRUE(duplicate_map.contains(value_three));
+}
+
+TEST(boomerang_ultra_circuit_constructor, duplicate_filter_keeps_distinct_same_gate_witnesses)
+{
+    UltraCircuitBuilder circuit_constructor;
+    const auto repeated_value = bb::fr::random_element();
+    const auto balancing_value = -(repeated_value + repeated_value);
+
+    const uint32_t left_idx = circuit_constructor.add_variable(repeated_value);
+    const uint32_t right_idx = circuit_constructor.add_variable(repeated_value);
+    const uint32_t balancing_idx = circuit_constructor.add_variable(balancing_value);
+
+    circuit_constructor.create_big_add_gate(
+        { left_idx, right_idx, balancing_idx, circuit_constructor.zero_idx(), fr(1), fr(1), fr(1), fr(0), fr(0) });
+
+    StaticAnalyzer analyzer = StaticAnalyzer(circuit_constructor);
+    analyzer.fill_witness_duplicate_map();
+    EXPECT_TRUE(analyzer.get_witness_duplicate_map().contains(repeated_value));
+}
+
+TEST(boomerang_ultra_circuit_constructor, duplicate_filter_keeps_common_value_witnesses)
+{
+    UltraCircuitBuilder circuit_constructor;
+    const auto repeated_value = bb::fr::one();
+    const auto balancing_value = -(repeated_value + repeated_value);
+
+    const uint32_t left_idx = circuit_constructor.add_variable(repeated_value);
+    const uint32_t right_idx = circuit_constructor.add_variable(repeated_value);
+    const uint32_t balancing_idx = circuit_constructor.add_variable(balancing_value);
+
+    circuit_constructor.create_big_add_gate(
+        { left_idx, right_idx, balancing_idx, circuit_constructor.zero_idx(), fr(1), fr(1), fr(1), fr(0), fr(0) });
+
+    StaticAnalyzer analyzer = StaticAnalyzer(circuit_constructor);
+    analyzer.fill_witness_duplicate_map();
+    EXPECT_TRUE(analyzer.get_witness_duplicate_map().contains(repeated_value));
+}
+
+TEST(boomerang_ultra_circuit_constructor, duplicate_filter_keeps_caller_filtered_unexplained_witnesses)
+{
+    UltraCircuitBuilder circuit_constructor;
+    const auto repeated_value = bb::fr::random_element();
+    const auto balancing_value = -(repeated_value + repeated_value);
+
+    const uint32_t left_idx = circuit_constructor.add_variable(repeated_value);
+    const uint32_t right_idx = circuit_constructor.add_variable(repeated_value);
+    const uint32_t balancing_idx = circuit_constructor.add_variable(balancing_value);
+
+    circuit_constructor.create_big_add_gate(
+        { left_idx, right_idx, balancing_idx, circuit_constructor.zero_idx(), fr(1), fr(1), fr(1), fr(0), fr(0) });
+
+    StaticAnalyzer analyzer = StaticAnalyzer(circuit_constructor);
+    analyzer.fill_witness_duplicate_map({ repeated_value });
+    EXPECT_TRUE(analyzer.get_witness_duplicate_map().contains(repeated_value));
+}
+
+TEST(boomerang_ultra_circuit_constructor, test_non_native_prime_limb_intermediate_duplicate_filter)
+{
+    UltraCircuitBuilder circuit_constructor = UltraCircuitBuilder();
+    auto repeated_value = bb::fr::random_element();
+    const bb::fr fq_modulus_selector = (uint256_t(0x30644e72e131a029ULL) << 192) + (uint256_t(0xb85045b6ULL) << 160);
+
+    for (size_t i = 0; i < 3; i++) {
+        uint32_t repeated_idx = circuit_constructor.add_variable(repeated_value);
+        const auto other_value = bb::fr::random_element();
+        const auto left_scaling = bb::fr::random_element();
+        const auto right_scaling = bb::fr::random_element();
+        uint32_t other_idx = circuit_constructor.add_variable(other_value);
+        uint32_t compensating_idx = circuit_constructor.add_variable(
+            -(left_scaling * repeated_value + right_scaling * other_value) / fq_modulus_selector);
+        circuit_constructor.create_big_add_gate({ repeated_idx,
+                                                  other_idx,
+                                                  compensating_idx,
+                                                  circuit_constructor.zero_idx(),
+                                                  left_scaling,
+                                                  right_scaling,
+                                                  fq_modulus_selector,
+                                                  fr(0),
+                                                  fr(0) });
+    }
+
+    auto nnf_repeated_value = bb::fr::random_element();
+    for (size_t i = 0; i < 3; i++) {
+        uint32_t repeated_idx = circuit_constructor.add_variable(nnf_repeated_value);
+        uint32_t peer_idx = circuit_constructor.add_variable(bb::fr::random_element());
+        {
+            auto row = circuit_constructor.nnf_selectors_row(UltraCircuitBuilder::NON_NATIVE_FIELD_1);
+            row.wires = { repeated_idx, peer_idx, circuit_constructor.zero_idx(), circuit_constructor.zero_idx() };
+            circuit_constructor.blocks.nnf.append_gate(row);
+        }
+        {
+            auto row = circuit_constructor.nnf_selectors_row(UltraCircuitBuilder::NNF_NONE);
+            row.wires = { circuit_constructor.zero_idx(),
+                          circuit_constructor.zero_idx(),
+                          circuit_constructor.zero_idx(),
+                          circuit_constructor.zero_idx() };
+            circuit_constructor.blocks.nnf.append_gate(row);
+        }
+        circuit_constructor.increment_num_gates(2);
+
+        const auto other_value = bb::fr::random_element();
+        uint32_t other_idx = circuit_constructor.add_variable(other_value);
+        const bb::fr q_c = -(fq_modulus_selector * (other_value + nnf_repeated_value));
+        circuit_constructor.create_big_add_gate({ other_idx,
+                                                  circuit_constructor.zero_idx(),
+                                                  repeated_idx,
+                                                  circuit_constructor.zero_idx(),
+                                                  fq_modulus_selector,
+                                                  fr(0),
+                                                  fq_modulus_selector,
+                                                  fr(0),
+                                                  q_c });
+    }
+
+    auto nnf_only_repeated_value = bb::fr::random_element();
+    for (size_t i = 0; i < 3; i++) {
+        uint32_t repeated_idx = circuit_constructor.add_variable(nnf_only_repeated_value);
+        uint32_t peer_idx = circuit_constructor.add_variable(bb::fr::random_element());
+        {
+            auto row = circuit_constructor.nnf_selectors_row(UltraCircuitBuilder::NON_NATIVE_FIELD_1);
+            row.wires = { repeated_idx, peer_idx, circuit_constructor.zero_idx(), circuit_constructor.zero_idx() };
+            circuit_constructor.blocks.nnf.append_gate(row);
+        }
+        {
+            auto row = circuit_constructor.nnf_selectors_row(UltraCircuitBuilder::NNF_NONE);
+            row.wires = { circuit_constructor.zero_idx(),
+                          circuit_constructor.zero_idx(),
+                          circuit_constructor.zero_idx(),
+                          circuit_constructor.zero_idx() };
+            circuit_constructor.blocks.nnf.append_gate(row);
+        }
+        circuit_constructor.increment_num_gates(2);
+    }
+
+    auto product_repeated_value = bb::fr::random_element();
+    for (size_t i = 0; i < 3; i++) {
+        const auto left_value = bb::fr::random_element();
+        const auto right_value = bb::fr::random_element();
+        const auto output_value = bb::fr::random_element();
+        uint32_t left_idx = circuit_constructor.add_variable(left_value);
+        uint32_t right_idx = circuit_constructor.add_variable(right_value);
+        uint32_t output_idx = circuit_constructor.add_variable(output_value);
+        uint32_t repeated_idx = circuit_constructor.add_variable(product_repeated_value);
+        const bb::fr left_scaling = bb::fr::random_element();
+        const bb::fr const_scaling = -(left_value * right_value * fq_modulus_selector + left_value * left_scaling +
+                                       output_value + product_repeated_value * fq_modulus_selector);
+        circuit_constructor.create_big_mul_add_gate({ .a = left_idx,
+                                                      .b = right_idx,
+                                                      .c = output_idx,
+                                                      .d = repeated_idx,
+                                                      .mul_scaling = fq_modulus_selector,
+                                                      .a_scaling = left_scaling,
+                                                      .b_scaling = fr(0),
+                                                      .c_scaling = fr(1),
+                                                      .d_scaling = fq_modulus_selector,
+                                                      .const_scaling = const_scaling });
+    }
+
+    auto shifted_repeated_value = bb::fr::random_element();
+    for (size_t i = 0; i < 3; i++) {
+        const auto left_value = bb::fr::random_element();
+        const auto right_value = bb::fr::random_element();
+        const auto out_value = bb::fr::random_element();
+        const bb::fr left_scaling = fr(1);
+        const bb::fr right_scaling = uint256_t(1) << 14;
+        const bb::fr out_scaling = uint256_t(1) << 28;
+        uint32_t left_idx = circuit_constructor.add_variable(left_value);
+        uint32_t right_idx = circuit_constructor.add_variable(right_value);
+        uint32_t out_idx = circuit_constructor.add_variable(out_value);
+        uint32_t compensating_idx =
+            circuit_constructor.add_variable(-(shifted_repeated_value + left_scaling * left_value +
+                                               right_scaling * right_value + out_scaling * out_value) /
+                                             fq_modulus_selector);
+        uint32_t repeated_idx = circuit_constructor.add_variable(shifted_repeated_value);
+        circuit_constructor.create_big_add_gate({ left_idx,
+                                                  right_idx,
+                                                  out_idx,
+                                                  compensating_idx,
+                                                  left_scaling,
+                                                  right_scaling,
+                                                  out_scaling,
+                                                  fq_modulus_selector,
+                                                  fr(0) },
+                                                true);
+        circuit_constructor.create_big_add_gate({ circuit_constructor.zero_idx(),
+                                                  circuit_constructor.zero_idx(),
+                                                  circuit_constructor.zero_idx(),
+                                                  repeated_idx,
+                                                  fr(0),
+                                                  fr(0),
+                                                  fr(0),
+                                                  fr(0),
+                                                  fr(0) });
+    }
+
+    StaticAnalyzer analyzer = StaticAnalyzer(circuit_constructor);
+    analyzer.fill_witness_duplicate_map();
+    EXPECT_TRUE(analyzer.get_witness_duplicate_map().empty());
+}
+
+TEST(boomerang_ultra_circuit_constructor, test_non_native_duplicate_filter_suppresses_connected_limb_chain)
+{
+    UltraCircuitBuilder circuit_constructor = UltraCircuitBuilder();
+    const auto repeated_value = bb::fr::random_element();
+    const bb::fr fq_modulus_selector = (uint256_t(0x30644e72e131a029ULL) << 192) + (uint256_t(0xb85045b6ULL) << 160);
+
+    uint32_t previous_idx = circuit_constructor.add_variable(repeated_value);
+    for (size_t i = 0; i < 5; i++) {
+        uint32_t peer_idx = circuit_constructor.add_variable(-(fr(1) + fq_modulus_selector) * repeated_value);
+        uint32_t next_idx = circuit_constructor.add_variable(repeated_value);
+        circuit_constructor.create_big_add_gate({ previous_idx,
+                                                  peer_idx,
+                                                  next_idx,
+                                                  circuit_constructor.zero_idx(),
+                                                  fr(1),
+                                                  fr(1),
+                                                  fq_modulus_selector,
+                                                  fr(0),
+                                                  fr(0) });
+        previous_idx = next_idx;
+    }
+
+    StaticAnalyzer analyzer = StaticAnalyzer(circuit_constructor, /*connect_variables=*/false);
+    analyzer.fill_witness_duplicate_map();
+    EXPECT_FALSE(analyzer.get_witness_duplicate_map().contains(repeated_value));
+}
+
+TEST(boomerang_ultra_circuit_constructor, test_non_native_duplicate_filter_suppresses_connected_product_rows)
+{
+    UltraCircuitBuilder circuit_constructor = UltraCircuitBuilder();
+    const bb::fr fq_modulus_selector = (uint256_t(0x30644e72e131a029ULL) << 192) + (uint256_t(0xb85045b6ULL) << 160);
+
+    const auto product_repeated_value = bb::fr::random_element();
+    uint32_t previous_product_idx = circuit_constructor.add_variable(product_repeated_value);
+    for (size_t i = 0; i < 3; i++) {
+        const auto peer_value =
+            -(fq_modulus_selector * product_repeated_value) / (fq_modulus_selector * product_repeated_value + fr(1));
+        uint32_t peer_idx = circuit_constructor.add_variable(peer_value);
+        uint32_t next_product_idx = circuit_constructor.add_variable(product_repeated_value);
+        circuit_constructor.create_big_mul_add_gate({ .a = previous_product_idx,
+                                                      .b = peer_idx,
+                                                      .c = next_product_idx,
+                                                      .d = circuit_constructor.zero_idx(),
+                                                      .mul_scaling = fq_modulus_selector,
+                                                      .a_scaling = fr(0),
+                                                      .b_scaling = fr(1),
+                                                      .c_scaling = fq_modulus_selector,
+                                                      .d_scaling = fr(0),
+                                                      .const_scaling = fr(0) });
+        previous_product_idx = next_product_idx;
+    }
+
+    const auto q4_repeated_value = bb::fr::random_element();
+    uint32_t previous_q4_idx = circuit_constructor.add_variable(q4_repeated_value);
+    for (size_t i = 0; i < 3; i++) {
+        const auto left_value = fr(7 + i);
+        const auto right_value = -(fr(1) + fq_modulus_selector) * q4_repeated_value / left_value;
+        uint32_t left_idx = circuit_constructor.add_variable(left_value);
+        uint32_t right_idx = circuit_constructor.add_variable(right_value);
+        uint32_t next_q4_idx = circuit_constructor.add_variable(q4_repeated_value);
+        circuit_constructor.create_big_mul_add_gate({ .a = left_idx,
+                                                      .b = right_idx,
+                                                      .c = previous_q4_idx,
+                                                      .d = next_q4_idx,
+                                                      .mul_scaling = fr(1),
+                                                      .a_scaling = fr(0),
+                                                      .b_scaling = fr(0),
+                                                      .c_scaling = fr(1),
+                                                      .d_scaling = fq_modulus_selector,
+                                                      .const_scaling = fr(0) });
+        previous_q4_idx = next_q4_idx;
+    }
+
+    StaticAnalyzer analyzer = StaticAnalyzer(circuit_constructor, /*connect_variables=*/false);
+    analyzer.fill_witness_duplicate_map();
+    EXPECT_FALSE(analyzer.get_witness_duplicate_map().contains(product_repeated_value));
+    EXPECT_FALSE(analyzer.get_witness_duplicate_map().contains(q4_repeated_value));
+}
+
+TEST(boomerang_ultra_circuit_constructor, test_non_native_duplicate_filter_suppresses_fixed_witness_bridge)
+{
+    UltraCircuitBuilder circuit_constructor = UltraCircuitBuilder();
+    const auto repeated_value = bb::fr::random_element();
+    const bb::fr fq_modulus_selector = (uint256_t(0x30644e72e131a029ULL) << 192) + (uint256_t(0xb85045b6ULL) << 160);
+
+    uint32_t fixed_idx = circuit_constructor.add_variable(repeated_value);
+    circuit_constructor.fix_witness(fixed_idx, repeated_value);
+    uint32_t repeated_idx = circuit_constructor.add_variable(repeated_value);
+    uint32_t next_repeated_idx = circuit_constructor.add_variable(repeated_value);
+    const auto balancing_value =
+        -(repeated_value * repeated_value + fq_modulus_selector * repeated_value) / fq_modulus_selector;
+    uint32_t balancing_idx = circuit_constructor.add_variable(balancing_value);
+
+    circuit_constructor.create_big_mul_add_gate({ .a = fixed_idx,
+                                                  .b = repeated_idx,
+                                                  .c = balancing_idx,
+                                                  .d = next_repeated_idx,
+                                                  .mul_scaling = fr(1),
+                                                  .a_scaling = fr(0),
+                                                  .b_scaling = fr(0),
+                                                  .c_scaling = fq_modulus_selector,
+                                                  .d_scaling = fq_modulus_selector,
+                                                  .const_scaling = fr(0) });
+
+    StaticAnalyzer analyzer = StaticAnalyzer(circuit_constructor, /*connect_variables=*/false);
+    analyzer.fill_witness_duplicate_map();
+    EXPECT_FALSE(analyzer.get_witness_duplicate_map().contains(repeated_value));
+}
+
+TEST(boomerang_ultra_circuit_constructor, test_arithmetic_derivation_duplicate_filter_suppresses_mirrored_rows)
+{
+    UltraCircuitBuilder circuit_constructor = UltraCircuitBuilder();
+    const bb::fr q_c = (uint256_t(0x30644e72e131a029ULL) << 192) + (uint256_t(0xb85045b6ULL) << 160);
+    const bb::fr peer_value = bb::fr::random_element();
+    const bb::fr pure_product_q_m = fr(0x9d80);
+    const bb::fr pure_product_value = -q_c / (pure_product_q_m * peer_value);
+    uint32_t peer_idx = circuit_constructor.add_variable(peer_value);
+    uint32_t pure_product_left_idx = circuit_constructor.add_variable(pure_product_value);
+    uint32_t pure_product_right_idx = circuit_constructor.add_variable(pure_product_value);
+    circuit_constructor.create_big_mul_add_gate({ .a = peer_idx,
+                                                  .b = pure_product_left_idx,
+                                                  .c = circuit_constructor.zero_idx(),
+                                                  .d = circuit_constructor.zero_idx(),
+                                                  .mul_scaling = pure_product_q_m,
+                                                  .a_scaling = fr(0),
+                                                  .b_scaling = fr(0),
+                                                  .c_scaling = fr(0),
+                                                  .d_scaling = fr(0),
+                                                  .const_scaling = q_c });
+    circuit_constructor.create_big_mul_add_gate({ .a = pure_product_right_idx,
+                                                  .b = peer_idx,
+                                                  .c = pure_product_right_idx,
+                                                  .d = circuit_constructor.zero_idx(),
+                                                  .mul_scaling = pure_product_q_m,
+                                                  .a_scaling = fr(0),
+                                                  .b_scaling = fr(0),
+                                                  .c_scaling = fr(0),
+                                                  .d_scaling = fr(0),
+                                                  .const_scaling = q_c });
+
+    const bb::fr linear_q_m = fr(0x5a0);
+    const bb::fr linear_scaling = -fr(0xb3f);
+    const bb::fr linear_value = -q_c / (linear_q_m * peer_value + linear_scaling);
+    uint32_t linear_left_idx = circuit_constructor.add_variable(linear_value);
+    uint32_t linear_right_idx = circuit_constructor.add_variable(linear_value);
+    circuit_constructor.create_big_mul_add_gate({ .a = peer_idx,
+                                                  .b = linear_left_idx,
+                                                  .c = circuit_constructor.zero_idx(),
+                                                  .d = circuit_constructor.zero_idx(),
+                                                  .mul_scaling = linear_q_m,
+                                                  .a_scaling = fr(0),
+                                                  .b_scaling = linear_scaling,
+                                                  .c_scaling = fr(0),
+                                                  .d_scaling = fr(0),
+                                                  .const_scaling = q_c });
+    circuit_constructor.create_big_mul_add_gate({ .a = linear_right_idx,
+                                                  .b = peer_idx,
+                                                  .c = linear_right_idx,
+                                                  .d = circuit_constructor.zero_idx(),
+                                                  .mul_scaling = linear_q_m,
+                                                  .a_scaling = linear_scaling,
+                                                  .b_scaling = fr(0),
+                                                  .c_scaling = fr(0),
+                                                  .d_scaling = fr(0),
+                                                  .const_scaling = q_c });
+
+    StaticAnalyzer analyzer = StaticAnalyzer(circuit_constructor, /*connect_variables=*/false);
+    analyzer.fill_witness_duplicate_map();
+    EXPECT_FALSE(analyzer.get_witness_duplicate_map().contains(pure_product_value));
+    EXPECT_FALSE(analyzer.get_witness_duplicate_map().contains(linear_value));
+}
+
+TEST(boomerang_ultra_circuit_constructor, test_elliptic_duplicate_filter_suppresses_repeated_operation_outputs)
+{
+    using affine_element = grumpkin::g1::affine_element;
+    using element = grumpkin::g1::element;
+    UltraCircuitBuilder circuit_constructor = UltraCircuitBuilder();
+
+    affine_element p1 = crypto::pedersen_commitment::commit_native({ bb::fr(1) }, 0);
+    affine_element p2 = crypto::pedersen_commitment::commit_native({ bb::fr(1) }, 1);
+    affine_element p3(element(p1) + element(p2));
+
+    for (size_t i = 0; i < 3; i++) {
+        uint32_t x1 = circuit_constructor.add_variable(p1.x);
+        uint32_t y1 = circuit_constructor.add_variable(p1.y);
+        uint32_t x2 = circuit_constructor.add_variable(p2.x);
+        uint32_t y2 = circuit_constructor.add_variable(p2.y);
+        uint32_t x3 = circuit_constructor.add_variable(p3.x);
+        uint32_t y3 = circuit_constructor.add_variable(p3.y);
+        circuit_constructor.create_ecc_add_gate({ x1, y1, x2, y2, x3, y3, /*is_addition=*/true });
+    }
+
+    StaticAnalyzer analyzer = StaticAnalyzer(circuit_constructor, /*connect_variables=*/false);
+    analyzer.fill_witness_duplicate_map();
+    EXPECT_FALSE(analyzer.get_witness_duplicate_map().contains(p3.x));
+    EXPECT_FALSE(analyzer.get_witness_duplicate_map().contains(p3.y));
+}
+
+TEST(boomerang_ultra_circuit_constructor, test_non_native_duplicate_filter_keeps_plain_gate_use)
+{
+    UltraCircuitBuilder circuit_constructor = UltraCircuitBuilder();
+    const auto repeated_value = bb::fr::random_element();
+    const bb::fr fq_modulus_selector = (uint256_t(0x30644e72e131a029ULL) << 192) + (uint256_t(0xb85045b6ULL) << 160);
+
+    for (size_t i = 0; i < 3; i++) {
+        uint32_t repeated_idx = circuit_constructor.add_variable(repeated_value);
+        const auto other_value = bb::fr::random_element();
+        uint32_t other_idx = circuit_constructor.add_variable(other_value);
+        const bb::fr q_c = -(fq_modulus_selector * (other_value + repeated_value));
+        circuit_constructor.create_big_add_gate({ other_idx,
+                                                  circuit_constructor.zero_idx(),
+                                                  repeated_idx,
+                                                  circuit_constructor.zero_idx(),
+                                                  fq_modulus_selector,
+                                                  fr(0),
+                                                  fq_modulus_selector,
+                                                  fr(0),
+                                                  q_c });
+
+        if (i == 0) {
+            const auto left_value = bb::fr::random_element();
+            const auto right_value = bb::fr::random_element();
+            uint32_t left_idx = circuit_constructor.add_variable(left_value);
+            uint32_t right_idx = circuit_constructor.add_variable(right_value);
+            uint32_t add_idx = circuit_constructor.add_variable(left_value + right_value + repeated_value);
+            circuit_constructor.create_big_add_gate(
+                { left_idx, right_idx, repeated_idx, add_idx, fr(1), fr(1), fr(1), fr(-1), fr(0) });
+        }
+    }
+
+    StaticAnalyzer analyzer = StaticAnalyzer(circuit_constructor);
+    analyzer.fill_witness_duplicate_map();
+    EXPECT_TRUE(analyzer.get_witness_duplicate_map().contains(repeated_value));
+}
+
+/**
  * @brief Test graph description of Ultra Circuit Builder with arithmetic gates with shifts
  *
  * @details This test verifies that:

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/circuit_builder_base.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/circuit_builder_base.hpp
@@ -12,10 +12,12 @@
 #include "barretenberg/honk/execution_trace/gate_data.hpp"
 #include "barretenberg/public_input_component/public_component_key.hpp"
 #include "barretenberg/serialize/msgpack.hpp"
+#include "duplicate_provenance.hpp"
 #include "pairing_points_tagging.hpp"
 #include <utility>
 
 #include <algorithm>
+#include <optional>
 #include <span>
 #include <unordered_map>
 
@@ -271,7 +273,111 @@ template <typename FF_> class CircuitBuilderBase {
   protected:
     std::unordered_map<uint32_t, std::string> variable_names;
 
+    // BOOMERANG_DUPLICATE_PROVENANCE: See
+    // barretenberg/cpp/src/barretenberg/boomerang_value_detection/WITNESS_DUPLICATE_DETECTION.md. Analyzer-only. Maps a
+    // real variable index to the provenance group its producer guarantees is constraint-forced-equal (see
+    // duplicate_provenance.hpp and WITNESS_DUPLICATE_DETECTION.md). NOT part of the proving path or serialization;
+    // picked up by the defaulted copy ctor / operator==.
+    std::unordered_map<uint32_t, DuplicateProvenance> witness_duplicate_provenance;
+    std::unordered_map<DuplicateProvenance, uint64_t, DuplicateProvenanceHasher> witness_duplicate_provenance_ids;
+    uint64_t next_witness_duplicate_provenance_id = 0;
+    std::optional<DuplicateProvenanceLocalId> active_duplicate_cryptographic_binding_scope;
+
   public:
+    /**
+     * @brief Build a 64-bit duplicate-provenance group key from a category and a producer-scoped local id.
+     * @details Two witnesses sharing a key are asserted by their producer to be forced equal by constraints.
+     */
+    static DuplicateProvenance make_duplicate_provenance(DuplicateProvenanceCategory category,
+                                                         DuplicateProvenanceLocalId local_id)
+    {
+        return DuplicateProvenance{ .category = category, .local_id = std::move(local_id) };
+    }
+
+    static DuplicateProvenance make_duplicate_provenance(DuplicateProvenanceCategory category,
+                                                         std::initializer_list<uint64_t> local_id)
+    {
+        return make_duplicate_provenance(category, DuplicateProvenanceLocalId(local_id));
+    }
+
+    static DuplicateProvenance make_duplicate_provenance(DuplicateProvenanceCategory category, uint64_t local_id)
+    {
+        return make_duplicate_provenance(category, DuplicateProvenanceLocalId{ local_id });
+    }
+
+    /**
+     * @brief Tag a witness with a duplicate-provenance group key.
+     * @details Keyed by the witness's real variable index. Producers must honor the soundness contract: same key
+     * implies the constraints force the witnesses equal. Analyzer-only; no effect on proving.
+     */
+    void tag_duplicate_provenance(uint32_t witness_index, const DuplicateProvenance& group_key)
+    {
+        witness_duplicate_provenance[real_variable_index[witness_index]] = group_key;
+    }
+
+    const std::unordered_map<uint32_t, DuplicateProvenance>& get_duplicate_provenance() const
+    {
+        return witness_duplicate_provenance;
+    }
+
+    uint64_t get_duplicate_provenance_id(const DuplicateProvenance& group_key)
+    {
+        auto [it, inserted] =
+            witness_duplicate_provenance_ids.try_emplace(group_key, next_witness_duplicate_provenance_id);
+        if (inserted) {
+            ++next_witness_duplicate_provenance_id;
+        }
+        return it->second;
+    }
+
+    DuplicateProvenanceLocalId get_duplicate_provenance_interned_identity(const DuplicateProvenance& group_key)
+    {
+        return duplicate_provenance_interned_identity(get_duplicate_provenance_id(group_key));
+    }
+
+    class ScopedDuplicateCryptographicBinding {
+      public:
+        ScopedDuplicateCryptographicBinding(CircuitBuilderBase& builder, DuplicateProvenanceLocalId scope)
+            : builder(builder)
+            , previous_scope(std::move(builder.active_duplicate_cryptographic_binding_scope))
+        {
+            builder.active_duplicate_cryptographic_binding_scope = std::move(scope);
+        }
+
+        ScopedDuplicateCryptographicBinding(const ScopedDuplicateCryptographicBinding&) = delete;
+        ScopedDuplicateCryptographicBinding& operator=(const ScopedDuplicateCryptographicBinding&) = delete;
+
+        ScopedDuplicateCryptographicBinding(ScopedDuplicateCryptographicBinding&& other) noexcept
+            : builder(other.builder)
+            , previous_scope(std::move(other.previous_scope))
+            , active(other.active)
+        {
+            other.active = false;
+        }
+
+        ~ScopedDuplicateCryptographicBinding()
+        {
+            if (active) {
+                builder.active_duplicate_cryptographic_binding_scope = std::move(previous_scope);
+            }
+        }
+
+      private:
+        CircuitBuilderBase& builder;
+        std::optional<DuplicateProvenanceLocalId> previous_scope;
+        bool active = true;
+    };
+
+    ScopedDuplicateCryptographicBinding scoped_duplicate_cryptographic_binding(DuplicateProvenanceLocalId scope)
+    {
+        return ScopedDuplicateCryptographicBinding(*this, std::move(scope));
+    }
+
+    const std::optional<DuplicateProvenanceLocalId>& get_duplicate_cryptographic_binding_scope() const
+    {
+        return active_duplicate_cryptographic_binding_scope;
+    }
+
     /**
      * @brief Assign a name to a variable (equivalence class)
      * @details Should be one name per equivalence class

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/circuit_builder_base_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/circuit_builder_base_impl.hpp
@@ -142,6 +142,25 @@ void CircuitBuilderBase<FF>::assert_equal(const uint32_t a_variable_idx,
     if (real_variable_tags[a_real_idx] == DEFAULT_TAG) {
         real_variable_tags[a_real_idx] = real_variable_tags[b_real_idx];
     }
+
+    // BOOMERANG_DUPLICATE_PROVENANCE: See
+    // barretenberg/cpp/src/barretenberg/boomerang_value_detection/WITNESS_DUPLICATE_DETECTION.md.
+    auto a_provenance_it = witness_duplicate_provenance.find(a_real_idx);
+    auto b_provenance_it = witness_duplicate_provenance.find(b_real_idx);
+    if (a_provenance_it == witness_duplicate_provenance.end() &&
+        b_provenance_it != witness_duplicate_provenance.end()) {
+        witness_duplicate_provenance[a_real_idx] = b_provenance_it->second;
+    } else if (a_provenance_it != witness_duplicate_provenance.end() &&
+               b_provenance_it != witness_duplicate_provenance.end() &&
+               a_provenance_it->second != b_provenance_it->second) {
+        const auto old_key = b_provenance_it->second;
+        const auto new_key = a_provenance_it->second;
+        for (auto& [_, key] : witness_duplicate_provenance) {
+            if (key == old_key) {
+                key = new_key;
+            }
+        }
+    }
 }
 
 template <typename FF_>

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/duplicate_provenance.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/duplicate_provenance.hpp
@@ -1,0 +1,136 @@
+#pragma once
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <initializer_list>
+#include <optional>
+#include <utility>
+#include <vector>
+
+namespace bb {
+
+inline constexpr uint64_t DUPLICATE_PROVENANCE_RAW_IDENTITY_TAG = 0;
+inline constexpr uint64_t DUPLICATE_PROVENANCE_NESTED_PROVENANCE_TAG = 1;
+inline constexpr uint64_t DUPLICATE_PROVENANCE_INTERNED_ID_TAG = 2;
+inline constexpr size_t DUPLICATE_PROVENANCE_HASH_COMBINE_CONSTANT = 0x9e3779b9;
+
+/**
+ * @brief Categories for the analyzer-only witness-duplicate provenance channel.
+ * @details BOOMERANG_DUPLICATE_PROVENANCE: See
+ * barretenberg/cpp/src/barretenberg/boomerang_value_detection/WITNESS_DUPLICATE_DETECTION.md.
+ * @details Producers (bigfield, MSM, Poseidon2, databus, ecc-op, lookup reads, range decompositions) tag the witnesses
+ * they deterministically derive so the boomerang static analyzer can soundly suppress their duplicate values. A
+ * category plus a producer-scoped local identity form a provenance group key. Two witnesses may share a key ONLY IF the
+ * circuit constraints force them equal on every satisfying assignment. This channel is not part of the proving path or
+ * serialization.
+ */
+enum class DuplicateProvenanceCategory : uint8_t {
+    NONE = 0,
+    BIGFIELD_REDUCTION,
+    MSM_TABLE,
+    POSEIDON2_PERMUTATION,
+    DATABUS_READ,
+    ECC_OP_TABLE,
+    LOOKUP_TABLE,
+    RANGE_DECOMPOSITION,
+    POSEIDON2_CRYPTOGRAPHIC_BINDING,
+};
+
+enum class DuplicateCryptographicBindingKind : uint64_t {
+    BATCH_MERGE_ECC_OP_HASH = 0,
+};
+
+enum class DuplicateCryptographicBindingRole : uint64_t {
+    RUNNING_HASH = 0,
+    TRANSCRIPT_HASH = 1,
+};
+
+inline constexpr size_t DUPLICATE_CRYPTOGRAPHIC_BINDING_KIND_INDEX = 0;
+inline constexpr size_t DUPLICATE_CRYPTOGRAPHIC_BINDING_ROLE_INDEX = 1;
+inline constexpr size_t DUPLICATE_CRYPTOGRAPHIC_BINDING_SCOPE_SIZE = 2;
+
+using DuplicateProvenanceLocalId = std::vector<uint64_t>;
+
+struct DuplicateProvenance {
+    DuplicateProvenanceCategory category = DuplicateProvenanceCategory::NONE;
+    DuplicateProvenanceLocalId local_id;
+
+    bool operator==(const DuplicateProvenance& other) const = default;
+};
+
+inline DuplicateProvenanceCategory duplicate_provenance_category(const DuplicateProvenance& group_key)
+{
+    return group_key.category;
+}
+
+inline DuplicateProvenanceLocalId duplicate_provenance_local_id(std::initializer_list<uint64_t> identities)
+{
+    return DuplicateProvenanceLocalId(identities);
+}
+
+inline DuplicateProvenanceLocalId batch_merge_ecc_op_hash_binding_local_id(DuplicateCryptographicBindingRole role,
+                                                                           std::initializer_list<uint64_t> suffix = {})
+{
+    DuplicateProvenanceLocalId identities;
+    identities.reserve(DUPLICATE_CRYPTOGRAPHIC_BINDING_SCOPE_SIZE + suffix.size());
+    identities.emplace_back(static_cast<uint64_t>(DuplicateCryptographicBindingKind::BATCH_MERGE_ECC_OP_HASH));
+    identities.emplace_back(static_cast<uint64_t>(role));
+    identities.insert(identities.end(), suffix.begin(), suffix.end());
+    return identities;
+}
+
+inline std::optional<DuplicateCryptographicBindingRole> get_duplicate_cryptographic_binding_role(
+    const DuplicateProvenanceLocalId& identities)
+{
+    if (identities.size() <= DUPLICATE_CRYPTOGRAPHIC_BINDING_ROLE_INDEX) {
+        return std::nullopt;
+    }
+
+    const auto role =
+        static_cast<DuplicateCryptographicBindingRole>(identities[DUPLICATE_CRYPTOGRAPHIC_BINDING_ROLE_INDEX]);
+    switch (role) {
+    case DuplicateCryptographicBindingRole::RUNNING_HASH:
+    case DuplicateCryptographicBindingRole::TRANSCRIPT_HASH:
+        return role;
+    }
+
+    return std::nullopt;
+}
+
+inline void append_duplicate_provenance_identity(DuplicateProvenanceLocalId& identities, uint64_t identity)
+{
+    identities.emplace_back(identity);
+}
+
+inline void append_duplicate_provenance_identity(DuplicateProvenanceLocalId& identities,
+                                                 const DuplicateProvenanceLocalId& suffix)
+{
+    identities.insert(identities.end(), suffix.begin(), suffix.end());
+}
+
+inline DuplicateProvenanceLocalId duplicate_provenance_nested_identity(const DuplicateProvenance& provenance)
+{
+    DuplicateProvenanceLocalId identities{ DUPLICATE_PROVENANCE_NESTED_PROVENANCE_TAG,
+                                           static_cast<uint64_t>(provenance.category) };
+    append_duplicate_provenance_identity(identities, provenance.local_id);
+    return identities;
+}
+
+inline DuplicateProvenanceLocalId duplicate_provenance_interned_identity(uint64_t interned_id)
+{
+    return DuplicateProvenanceLocalId{ DUPLICATE_PROVENANCE_INTERNED_ID_TAG, interned_id };
+}
+
+struct DuplicateProvenanceHasher {
+    size_t operator()(const DuplicateProvenance& provenance) const
+    {
+        size_t seed = std::hash<uint8_t>()(static_cast<uint8_t>(provenance.category));
+        for (const uint64_t identity : provenance.local_id) {
+            seed ^= std::hash<uint64_t>()(identity) + DUPLICATE_PROVENANCE_HASH_COMBINE_CONSTANT + (seed << 6) +
+                    (seed >> 2);
+        }
+        return seed;
+    }
+};
+
+} // namespace bb


### PR DESCRIPTION
A mechanism for detecting duplicate witness issues in circuits. Specifically targets the cases when the same values suddenly appears in the circuit twice without any logical connections between those appearances. Can point to high-level boomerangs