### PR TITLE
fix(archiver): resolve L2-to-L1 witness from a single store snapshot

### DIFF
--- a/yarn-project/archiver/src/archiver.ts
+++ b/yarn-project/archiver/src/archiver.ts
@@ -203,6 +203,7 @@ export class Archiver extends ArchiverDataSourceBase implements L2BlockSink, Tra
     this.outboxTreesResolver = new OutboxTreesResolver(
       this.outbox,
       this,
+      this.dataStores.db,
       () => Promise.resolve(this.getL1BlockNumber()),
       l1Constants.epochDuration,
     );

--- a/yarn-project/archiver/src/modules/outbox_trees_resolver.test.ts
+++ b/yarn-project/archiver/src/modules/outbox_trees_resolver.test.ts
@@ -9,6 +9,7 @@ import {
 } from '@aztec/foundation/branded-types';
 import { sha256Trunc } from '@aztec/foundation/crypto/sha256';
 import { Fr } from '@aztec/foundation/curves/bn254';
+import type { AztecAsyncKVStore } from '@aztec/kv-store';
 import { type L2ToL1MembershipWitness, computeEpochOutHash } from '@aztec/stdlib/messaging';
 import { TxHash } from '@aztec/stdlib/tx';
 
@@ -41,7 +42,13 @@ describe('OutboxTreesResolver lazy roots cache', () => {
       return Promise.resolve(makeZeroRoots());
     });
 
-    resolver = new OutboxTreesResolver(outbox, archiver, () => Promise.resolve(syncedL1Block), EPOCH_DURATION);
+    resolver = new OutboxTreesResolver(
+      outbox,
+      archiver,
+      makeFakeStore(),
+      () => Promise.resolve(syncedL1Block),
+      EPOCH_DURATION,
+    );
   });
 
   // Exercises the private #getRoots path through a witness request whose epoch has no blocks,
@@ -83,6 +90,7 @@ describe('OutboxTreesResolver lazy roots cache', () => {
     const notSyncedResolver = new OutboxTreesResolver(
       outbox,
       archiver,
+      makeFakeStore(),
       () => Promise.resolve(undefined),
       EPOCH_DURATION,
     );
@@ -114,7 +122,7 @@ describe('OutboxTreesResolver witness building', () => {
     outbox = mock<OutboxContract>();
     archiver = mock<OutboxTreesArchiverView>();
     // Witness tests fetch the covering roots once at synced block 0 via the outbox mock.
-    resolver = new OutboxTreesResolver(outbox, archiver, () => Promise.resolve(0n), EPOCH_DURATION);
+    resolver = new OutboxTreesResolver(outbox, archiver, makeFakeStore(), () => Promise.resolve(0n), EPOCH_DURATION);
   });
 
   it('returns undefined when the tx is not yet in a block', async () => {
@@ -216,6 +224,7 @@ describe('OutboxTreesResolver witness building', () => {
     const drifting = new OutboxTreesResolver(
       outbox,
       archiver,
+      makeFakeStore(),
       () => Promise.resolve(BigInt(syncedCalls++)),
       EPOCH_DURATION,
     );
@@ -225,6 +234,17 @@ describe('OutboxTreesResolver witness building', () => {
 });
 
 // --- Helpers ----------------------------------------------------------------
+
+/**
+ * Store double whose `transactionAsync` just runs the callback. The archiver view is mocked here, so
+ * there is no real snapshot to isolate; the resolver only needs the callback invoked. Snapshot
+ * consistency of the real store is covered by the kv-store transaction tests.
+ */
+function makeFakeStore(): AztecAsyncKVStore {
+  const store = mock<AztecAsyncKVStore>();
+  store.transactionAsync.mockImplementation(callback => callback());
+  return store;
+}
 
 function makeZeroRoots(): Fr[] {
   return Array.from({ length: MAX_CHECKPOINTS_PER_EPOCH }, () => Fr.ZERO);

--- a/yarn-project/archiver/src/modules/outbox_trees_resolver.ts
+++ b/yarn-project/archiver/src/modules/outbox_trees_resolver.ts
@@ -3,6 +3,7 @@ import type { BlockNumber, EpochNumber } from '@aztec/foundation/branded-types';
 import { chunkBy } from '@aztec/foundation/collection';
 import type { Fr } from '@aztec/foundation/curves/bn254';
 import { type Logger, createLogger } from '@aztec/foundation/log';
+import type { AztecAsyncKVStore } from '@aztec/kv-store';
 import type { L2Block } from '@aztec/stdlib/block';
 import type { CheckpointData } from '@aztec/stdlib/checkpoint';
 import { getEpochAtSlot } from '@aztec/stdlib/epoch-helpers';
@@ -56,6 +57,7 @@ export class OutboxTreesResolver {
   constructor(
     private readonly outbox: OutboxContract,
     private readonly archiver: OutboxTreesArchiverView,
+    private readonly store: AztecAsyncKVStore,
     private readonly getSyncedL1BlockNumber: () => Promise<bigint | undefined>,
     private readonly epochDuration: number,
     private readonly log: Logger = createLogger('archiver:outbox'),
@@ -73,6 +75,9 @@ export class OutboxTreesResolver {
     message: Fr,
     messageIndexInTx?: number,
   ): Promise<L2ToL1MembershipWitness | undefined> {
+    // Read the tx effect once up front only to learn which epoch's Outbox roots to fetch. The roots
+    // read hits L1, so it stays outside the store transaction below: holding the archiver's writer
+    // lock across a network round-trip would stall block sync.
     const indexed = await this.archiver.getTxEffect(txHash);
     if (!indexed) {
       this.log.trace(`No tx effect for tx, no witness available`, { txHash });
@@ -87,23 +92,39 @@ export class OutboxTreesResolver {
       return undefined;
     }
 
-    const receipt = {
-      txHash,
-      epochNumber,
-      blockNumber: indexed.l2BlockNumber,
-      txIndexInBlock: indexed.txIndexInBlock,
-    };
-
     const syncedBefore = await this.getSyncedL1BlockNumber();
     try {
-      return await computeL2ToL1MembershipWitness(this.#node, roots, message, receipt, messageIndexInTx);
+      // Assemble the witness inside a single store transaction so every archiver read it depends on
+      // (the tx effect, the epoch's blocks, the target block and the checkpoint metadata) observes one
+      // consistent snapshot. `transactionAsync` serializes against writers, and the substore reads
+      // below bind to it automatically, so no store commit can land mid-assembly and splice together
+      // two different chain states — which would otherwise surface as a spurious "message does not
+      // exist" error even when the tx-effect index is healthy.
+      return await this.store.transactionAsync(async () => {
+        // Re-read the tx effect within the snapshot so the receipt's block number and tx index stay
+        // consistent with the block and checkpoint data read while building the witness. The epoch is
+        // reused from the pre-transaction read (it selected the roots above); if a reorg moved the tx
+        // to a different epoch in between, the block lookups simply miss and the helper returns
+        // undefined for the caller to retry.
+        const indexedInSnapshot = await this.archiver.getTxEffect(txHash);
+        if (!indexedInSnapshot) {
+          return undefined;
+        }
+        const receipt = {
+          txHash,
+          epochNumber,
+          blockNumber: indexedInSnapshot.l2BlockNumber,
+          txIndexInBlock: indexedInSnapshot.txIndexInBlock,
+        };
+        return await computeL2ToL1MembershipWitness(this.#node, roots, message, receipt, messageIndexInTx);
+      });
     } catch (err) {
       // The helper throws if the locally-assembled epoch root disagrees with the cached Outbox root.
-      // The cached roots are pinned to the node's synced L1 block, but the helper reads block /
-      // checkpoint data live, so if the archiver advanced mid-assembly the two can momentarily reflect
-      // different heights and produce a transient mismatch. When the synced block moved during
-      // assembly we treat the mismatch as transient and return undefined so the caller can retry; a
-      // mismatch at a stable synced block is a genuine node/L1 disagreement and must surface.
+      // The cached roots are pinned to the node's synced L1 block, but the block / checkpoint data is
+      // read from a store snapshot taken after that fetch, so if the archiver advanced in between the
+      // two can reflect different heights and produce a transient mismatch. When the synced block moved
+      // during assembly we treat the mismatch as transient and return undefined so the caller can
+      // retry; a mismatch at a stable synced block is a genuine node/L1 disagreement and must surface.
       const syncedAfter = await this.getSyncedL1BlockNumber();
       if (syncedBefore !== syncedAfter && err instanceof Error && err.message.includes('does not match Outbox')) {
         this.log.debug(`Transient outbox root mismatch during sync, returning no witness`, {

--- a/yarn-project/kv-store/src/lmdb-v2/store.test.ts
+++ b/yarn-project/kv-store/src/lmdb-v2/store.test.ts
@@ -115,6 +115,36 @@ describe('AztecLMDBStoreV2', () => {
     });
   });
 
+  it('gives reads inside a transaction a consistent snapshot while a concurrent write is queued', async () => {
+    const map = store.openMap<string, string>('snapshot');
+    await map.set('k', 'v1');
+
+    const started = promiseWithResolvers<void>();
+    const release = promiseWithResolvers<void>();
+
+    const snapshotReads = store.transactionAsync(async () => {
+      const first = await map.getAsync('k');
+      started.resolve();
+      await release.promise;
+      const second = await map.getAsync('k');
+      return [first, second];
+    });
+
+    await started.promise;
+    // Queue a competing write for the same key. The single writer serializes it behind the in-flight
+    // transaction, so it cannot commit until that transaction finishes.
+    const concurrentWrite = map.set('k', 'v2');
+    release.resolve();
+
+    const [first, second] = await snapshotReads;
+    await concurrentWrite;
+
+    // Both reads inside the transaction observe the pre-write value; the queued write only lands after.
+    expect(first).toBe('v1');
+    expect(second).toBe('v1');
+    expect(await map.getAsync('k')).toBe('v2');
+  });
+
   it('should serialize writes correctly', async () => {
     const key = Buffer.from('foo');
     const inc = () =>


### PR DESCRIPTION
`getL2ToL1MembershipWitness` assembled its witness from several non-atomic archiver reads (`getTxEffect`, then the epoch blocks, target block and checkpoint metadata read inside `computeL2ToL1MembershipWitness`). A store commit landing between those reads could splice together two different chain states and surface a spurious "message does not exist" error even when the tx-effect index was healthy.

Wrap the witness assembly in a single `store.transactionAsync` so every archiver read binds to one write transaction and observes a consistent snapshot (the store serializes writers, so no commit can interleave). The L1 Outbox roots fetch stays outside the transaction to avoid holding the archiver's writer lock across a network round-trip, and the tx effect is re-read inside the snapshot so the receipt's block number and tx index stay consistent with the block data.

Cost: witness assembly briefly serializes with archiver writers (it holds the store's writer queue while it reads), but the work under the lock is pure store reads plus an in-memory tree build — no network I/O.

Context: this came out of the A-1426 investigation. The incident symptom itself turned out to be a downstream client bug following a v5 behavior change in `L2BlockSynchronizer` — not this race, and not archiver index corruption. This PR is therefore hardening against a real but so-far-unobserved torn-read window, not the incident fix. See #24765 for the companion store hardening from the same investigation.

Related to A-1426
