### PR TITLE
fix(archiver): clean up removed blocks from raw rows and ownership-check tx-effect deletes

### DIFF
--- a/yarn-project/archiver/src/store/block_store.test.ts
+++ b/yarn-project/archiver/src/store/block_store.test.ts
@@ -2898,6 +2898,45 @@ describe('BlockStore', () => {
       expect(removedBlocks).toEqual([]);
     });
 
+    it('fully cleans up blocks sharing a tx effect', async () => {
+      // Two blocks carrying the same tx, as when a tx is re-included after its original proposal expired.
+      // Inserting block2 pointed the shared tx's index entry at block2, so deleting block1 must not remove it:
+      // doing so makes block2 unreadable, and a cleanup that skips unreadable blocks would then leak block2's
+      // row and tx effects to be overwritten in place by later inserts at the same number.
+      const block1 = await L2Block.random(BlockNumber(1), {
+        checkpointNumber: CheckpointNumber(1),
+        indexWithinCheckpoint: IndexWithinCheckpoint(0),
+        txsPerBlock: 2,
+      });
+      const block2 = await L2Block.random(BlockNumber(2), {
+        checkpointNumber: CheckpointNumber(1),
+        indexWithinCheckpoint: IndexWithinCheckpoint(1),
+        lastArchive: block1.archive,
+        txsPerBlock: 2,
+      });
+      const sharedTx = block1.body.txEffects[0];
+      block2.body.txEffects[0] = sharedTx;
+
+      await addProposedBlocks(blockStore, [block1, block2]);
+      expect((await blockStore.getTxEffect(sharedTx.txHash))?.l2BlockNumber).toBe(2);
+
+      const removedBlocks = await blockStore.removeBlocksAfter(BlockNumber(0));
+
+      expect(removedBlocks.map(b => b.number)).toEqual([1, 2]);
+      expect(await blockStore.getLatestL2BlockNumber()).toBe(0);
+      for (const tx of [sharedTx, block1.body.txEffects[1], block2.body.txEffects[1]]) {
+        expect(await blockStore.getTxEffect(tx.txHash)).toBeUndefined();
+      }
+      for (const block of [block1, block2]) {
+        expect(await blockStore.getBlock({ number: block.number })).toBeUndefined();
+        expect(await blockStore.getBlockNumber({ hash: await block.hash() })).toBeUndefined();
+        expect(await blockStore.getBlockNumber({ archive: block.archive.root })).toBeUndefined();
+      }
+
+      // The store accepts the same chain again: nothing stale was left behind.
+      await expect(addProposedBlocks(blockStore, [block1, block2])).resolves.toBe(true);
+    });
+
     it('cleans up related data (tx effects, hash index, archive index)', async () => {
       const block1 = await L2Block.random(BlockNumber(1), {
         checkpointNumber: CheckpointNumber(1),

--- a/yarn-project/archiver/src/store/block_store.ts
+++ b/yarn-project/archiver/src/store/block_store.ts
@@ -555,7 +555,7 @@ export class BlockStore {
       while (!reader.isEmpty()) {
         txHashes.push(reader.readObject(TxHash).toString());
       }
-      await Promise.all(txHashes.map(txHash => this.deleteTxEffectIfOwnedBy(txHash, blockStorage.blockHash)));
+      await Promise.all(txHashes.map(txHash => this.deleteTxEffect(txHash, blockStorage.blockHash)));
     }
 
     // Delete block txs mapping
@@ -567,7 +567,7 @@ export class BlockStore {
   }
 
   /** Deletes a tx effect only if it is still owned by (points at) the given block. */
-  private async deleteTxEffectIfOwnedBy(txHash: string, blockHash: Buffer): Promise<void> {
+  private async deleteTxEffect(txHash: string, blockHash: Buffer): Promise<void> {
     const stored = await this.#txEffects.getAsync(txHash);
     if (stored === undefined) {
       this.#log.warn(`Missing tx effect for tx ${txHash} while removing its block`, {
@@ -577,9 +577,7 @@ export class BlockStore {
       return;
     }
     // An IndexedTxEffect starts with the owning block hash (32 bytes) — see getTxLocation.
-    if (Buffer.from(stored.buffer, stored.byteOffset, 32).equals(blockHash)) {
-      await this.#txEffects.delete(txHash);
-    } else {
+    if (!Buffer.from(stored.buffer, stored.byteOffset, 32).equals(blockHash)) {
       // Fires only when two stored blocks listed the same tx — a state upstream validation should make
       // unreachable. Keep the entry (it belongs to the surviving block) but flag the duplication loudly.
       this.#log.warn(`Tx effect for tx ${txHash} is owned by a block other than the one being removed`, {
@@ -587,7 +585,10 @@ export class BlockStore {
         removedBlockHash: bufferToHex(blockHash),
         owningBlockHash: bufferToHex(Buffer.from(stored.buffer, stored.byteOffset, 32)),
       });
+      return;
     }
+
+    await this.#txEffects.delete(txHash);
   }
 
   /**

--- a/yarn-project/archiver/src/store/block_store.ts
+++ b/yarn-project/archiver/src/store/block_store.ts
@@ -543,9 +543,11 @@ export class BlockStore {
 
     const blockHash = bufferToHex(blockStorage.blockHash);
 
-    // Delete the tx effects of the block's txs, skipping entries that no longer point at this block: a tx
-    // also present in another stored block (e.g. re-included after its original proposal expired) has had
-    // its entry overwritten, and deleting it here would orphan that block's index.
+    // Delete the tx effects of the block's txs, skipping entries that no longer point at this block: if
+    // another stored block also contains the tx, the entry points at that block, and deleting it here would
+    // orphan that block's index. Honest chains never store the same tx twice (duplicate nullifiers are
+    // rejected at build, re-execution, and world-state sync), so the store must not turn such a state into
+    // corruption of the surviving block if it ever appears.
     const blockTxsBuffer = await this.#blockTxs.getAsync(blockHash);
     if (blockTxsBuffer !== undefined) {
       const reader = BufferReader.asReader(blockTxsBuffer);
@@ -567,9 +569,24 @@ export class BlockStore {
   /** Deletes a tx effect only if it is still owned by (points at) the given block. */
   private async deleteTxEffectIfOwnedBy(txHash: string, blockHash: Buffer): Promise<void> {
     const stored = await this.#txEffects.getAsync(txHash);
+    if (stored === undefined) {
+      this.#log.warn(`Missing tx effect for tx ${txHash} while removing its block`, {
+        txHash,
+        blockHash: bufferToHex(blockHash),
+      });
+      return;
+    }
     // An IndexedTxEffect starts with the owning block hash (32 bytes) — see getTxLocation.
-    if (stored && Buffer.from(stored.buffer, stored.byteOffset, 32).equals(blockHash)) {
+    if (Buffer.from(stored.buffer, stored.byteOffset, 32).equals(blockHash)) {
       await this.#txEffects.delete(txHash);
+    } else {
+      // Fires only when two stored blocks listed the same tx — a state upstream validation should make
+      // unreachable. Keep the entry (it belongs to the surviving block) but flag the duplication loudly.
+      this.#log.warn(`Tx effect for tx ${txHash} is owned by a block other than the one being removed`, {
+        txHash,
+        removedBlockHash: bufferToHex(blockHash),
+        owningBlockHash: bufferToHex(Buffer.from(stored.buffer, stored.byteOffset, 32)),
+      });
     }
   }
 

--- a/yarn-project/archiver/src/store/block_store.ts
+++ b/yarn-project/archiver/src/store/block_store.ts
@@ -537,20 +537,40 @@ export class BlockStore {
   }
 
   /** Deletes a block and all associated data (tx effects, indices). */
-  private async deleteBlock(block: L2Block): Promise<void> {
+  private async deleteBlock(blockNumber: number, blockStorage: BlockStorage): Promise<void> {
     // Delete the block from the main blocks map
-    await this.#blocks.delete(block.number);
+    await this.#blocks.delete(blockNumber);
 
-    // Delete all tx effects for this block
-    await Promise.all(block.body.txEffects.map(tx => this.#txEffects.delete(tx.txHash.toString())));
+    const blockHash = bufferToHex(blockStorage.blockHash);
+
+    // Delete the tx effects of the block's txs, skipping entries that no longer point at this block: a tx
+    // also present in another stored block (e.g. re-included after its original proposal expired) has had
+    // its entry overwritten, and deleting it here would orphan that block's index.
+    const blockTxsBuffer = await this.#blockTxs.getAsync(blockHash);
+    if (blockTxsBuffer !== undefined) {
+      const reader = BufferReader.asReader(blockTxsBuffer);
+      const txHashes: string[] = [];
+      while (!reader.isEmpty()) {
+        txHashes.push(reader.readObject(TxHash).toString());
+      }
+      await Promise.all(txHashes.map(txHash => this.deleteTxEffectIfOwnedBy(txHash, blockStorage.blockHash)));
+    }
 
     // Delete block txs mapping
-    const blockHash = (await block.hash()).toString();
     await this.#blockTxs.delete(blockHash);
 
     // Clean up indices
     await this.#blockHashIndex.delete(blockHash);
-    await this.#blockArchiveIndex.delete(block.archive.root.toString());
+    await this.#blockArchiveIndex.delete(AppendOnlyTreeSnapshot.fromBuffer(blockStorage.archive).root.toString());
+  }
+
+  /** Deletes a tx effect only if it is still owned by (points at) the given block. */
+  private async deleteTxEffectIfOwnedBy(txHash: string, blockHash: Buffer): Promise<void> {
+    const stored = await this.#txEffects.getAsync(txHash);
+    // An IndexedTxEffect starts with the owning block hash (32 bytes) — see getTxLocation.
+    if (stored && Buffer.from(stored.buffer, stored.byteOffset, 32).equals(blockHash)) {
+      await this.#txEffects.delete(txHash);
+    }
   }
 
   /**
@@ -749,16 +769,24 @@ export class BlockStore {
 
       // Iterate from blockNumber + 1 to latestBlockNumber
       for (let bn = blockNumber + 1; bn <= latestBlockNumber; bn++) {
-        const block = await this.getBlock({ number: BlockNumber(bn) });
+        const blockStorage = await this.#blocks.getAsync(bn);
 
-        if (block === undefined) {
+        if (blockStorage === undefined) {
           this.#log.warn(`Cannot remove block ${bn} from the store since we don't have it`);
           continue;
         }
 
-        removedBlocks.push(block);
-        await this.deleteBlock(block);
-        this.#log.debug(`Removed block ${bn} ${(await block.hash()).toString()}`);
+        // Load the full block for the returned list when possible, but clean up from the raw row regardless:
+        // a block whose body can no longer be fully loaded must still release its row, tx effects, and indices,
+        // or later inserts at this number leave stale tx-effect entries pointing into the new chain.
+        const block = await this.getBlockFromBlockStorage(bn, blockStorage);
+        if (block !== undefined) {
+          removedBlocks.push(block);
+        } else {
+          this.#log.warn(`Removing block ${bn} whose body could not be fully loaded`);
+        }
+        await this.deleteBlock(bn, blockStorage);
+        this.#log.debug(`Removed block ${bn} ${bufferToHex(blockStorage.blockHash)}`);
       }
 
       return removedBlocks;


### PR DESCRIPTION
## Problem

Two defects in `BlockStore` block removal could corrupt the tx-effect index (txHash → owning block hash/position) if the store ever held two blocks sharing a tx:

1. **Blind delete** — `deleteBlock` removed `#txEffects` entries by txHash without checking the entry still pointed at the block being deleted. If another stored block contained the same tx, that block's entry was destroyed collaterally, making the block unreadable (`Could not find tx effect for tx…`).
2. **Skip-on-unreadable leak** — `removeBlocksAfter` did `getBlock(bn) === undefined → warn + continue`, so an unreadable block's row, tx effects, and indices were never released. A later `addCheckpoints` overwrites the leaked row in place ("L1 data is authoritative"), leaving stale tx-effect entries pointing at coordinates now occupied by different txs — `getTxReceipt` then reports positions the chain no longer has, and `getL2ToL1MembershipWitness` resolves the wrong tx and throws `The L2ToL1Message you are trying to prove inclusion of does not exist`.

This is hardening, not an incident fix. No honest code path produces two stored blocks sharing a tx: duplicate nullifiers are rejected at block building (double-spend validation against the build fork), at validator re-execution, and at world-state sync (nullifier leaves are non-updateable). The incident that prompted the investigation turned out to be a downstream client bug following a v5 behavior change in `L2BlockSynchronizer`, unrelated to the store. The store should still not amplify a duplicated-tx state into silent corruption if it ever appears — e.g. via a future upstream bug, or byzantine tx effects that repeat a txHash with distinct nullifiers (invisible to every nullifier-based check).

## Fix

- `removeBlocksAfter` cleans up from the raw storage row, so blocks whose bodies can no longer be fully loaded still release their row, tx effects (enumerated from `#blockTxs`), and hash/archive indices.
- `deleteBlock` only deletes a tx-effect entry still owned by the block being removed (compares the entry's leading block hash).
- Both anomalies now log a warning (an entry owned by another block, or a missing entry). These states should be unreachable, so a warning in production logs is direct evidence of an upstream bug worth investigating — previously the ownership skip was silent, hiding exactly that signal.

## Cost

The added reads are confined to prune/reorg paths: one `#blockTxs` read plus one tx-effect point read per tx of each *removed* block (roughly doubling point reads on block removal). Block ingestion and query paths are untouched.

## Verification

- Regression test from #24732: two proposed blocks sharing a tx effect; asserts removal releases both blocks fully with no residue (fails on the pre-fix implementation).
- Full `block_store.test.ts` suite passes (160 tests).

Recreates #24732 with the original commit cherry-picked and authorship preserved (thanks @benesjan). On top of it, this PR updates the description and code comments to match what the follow-up investigation established about how a duplicated-tx state can and cannot arise, and adds the anomaly warnings. Supersedes #24732.

Related to A-1426
