### PR TITLE
fix(node): warm KZG trusted setup at startup

### DIFF
--- a/yarn-project/aztec-node/src/factory.ts
+++ b/yarn-project/aztec-node/src/factory.ts
@@ -11,7 +11,7 @@ import { pickL1ContractAddresses } from '@aztec/ethereum/l1-contract-addresses';
 import type { L1TxUtils } from '@aztec/ethereum/l1-tx-utils';
 import { compactArray } from '@aztec/foundation/collection';
 import { type Logger, createLogger } from '@aztec/foundation/log';
-import { DateProvider, Timer } from '@aztec/foundation/timer';
+import { DateProvider } from '@aztec/foundation/timer';
 import { type KeyStore, KeystoreManager, loadKeystores, mergeKeystores } from '@aztec/node-keystore';
 import { trySnapshotSync } from '@aztec/node-lib/actions';
 import { createForwarderL1TxUtilsFromSigners, createL1TxUtilsFromSigners } from '@aztec/node-lib/factories';
@@ -101,9 +101,7 @@ export async function createAztecNodeService(
   // attestation forwarding is skipped. Paying it here keeps it off the gossip path. Idempotent, so
   // it is a no-op for sequencers (warmed in Sequencer.init) and for tests that pre-warm via
   // warmBlobKzg.
-  const kzgTimer = new Timer();
-  getKzg();
-  log.verbose(`Warmed KZG trusted setup`, { durationMs: kzgTimer.ms() });
+  getKzg(log);
 
   const packageVersion = getPackageVersion();
   const telemetry = deps.telemetry ?? getTelemetryClient();

--- a/yarn-project/aztec-node/src/factory.ts
+++ b/yarn-project/aztec-node/src/factory.ts
@@ -2,7 +2,7 @@ import { createArchiver } from '@aztec/archiver';
 import { BBCircuitVerifier, BatchChonkVerifier, QueuedIVCVerifier } from '@aztec/bb-prover';
 import { TestCircuitVerifier } from '@aztec/bb-prover/test';
 import { createBlobClientWithFileStores } from '@aztec/blob-client/client';
-import { Blob } from '@aztec/blob-lib';
+import { Blob, getKzg } from '@aztec/blob-lib';
 import { EpochCache } from '@aztec/epoch-cache';
 import { createEthereumChain } from '@aztec/ethereum/chain';
 import { getPublicClient, makeL1HttpTransport } from '@aztec/ethereum/client';
@@ -11,7 +11,7 @@ import { pickL1ContractAddresses } from '@aztec/ethereum/l1-contract-addresses';
 import type { L1TxUtils } from '@aztec/ethereum/l1-tx-utils';
 import { compactArray } from '@aztec/foundation/collection';
 import { type Logger, createLogger } from '@aztec/foundation/log';
-import { DateProvider } from '@aztec/foundation/timer';
+import { DateProvider, Timer } from '@aztec/foundation/timer';
 import { type KeyStore, KeystoreManager, loadKeystores, mergeKeystores } from '@aztec/node-keystore';
 import { trySnapshotSync } from '@aztec/node-lib/actions';
 import { createForwarderL1TxUtilsFromSigners, createL1TxUtilsFromSigners } from '@aztec/node-lib/factories';
@@ -93,6 +93,17 @@ export async function createAztecNodeService(
   // Initialise the bb.js sync WASM singleton here, before any subsystem runs.
   const { BarretenbergSync } = await import('@aztec/bb.js');
   await BarretenbergSync.initSingleton();
+
+  // Warm the KZG trusted-setup singleton before any subsystem runs. getKzg() synchronously builds
+  // its precomputation tables on first use (~2s locally, blocking the event loop; 12-15s under
+  // production CPU limits). If that first use is instead the archiver reconstructing blobs or the
+  // proposal handler uploading them, the stalled loop overruns the gossipsub mcache window and
+  // attestation forwarding is skipped. Paying it here keeps it off the gossip path. Idempotent, so
+  // it is a no-op for sequencers (warmed in Sequencer.init) and for tests that pre-warm via
+  // warmBlobKzg.
+  const kzgTimer = new Timer();
+  getKzg();
+  log.verbose(`Warmed KZG trusted setup`, { durationMs: kzgTimer.ms() });
 
   const packageVersion = getPackageVersion();
   const telemetry = deps.telemetry ?? getTelemetryClient();

--- a/yarn-project/blob-lib/src/kzg_context.ts
+++ b/yarn-project/blob-lib/src/kzg_context.ts
@@ -1,3 +1,6 @@
+import type { Logger } from '@aztec/foundation/log';
+import { elapsedSync } from '@aztec/foundation/timer';
+
 import type { DasContextJs } from '@crate-crypto/node-eth-kzg';
 import { createRequire } from 'module';
 
@@ -30,12 +33,17 @@ export function getBytesPerCommitment(): number {
 let kzgInstance: DasContextJs | undefined;
 
 /**
- * Returns the lazily-initialized KZG context.
- * The first call takes ~3 seconds to initialize the precomputation tables.
+ * Returns the lazily-initialized KZG context. The first call synchronously builds the
+ * precomputation tables (~2s locally, blocking the event loop; longer under constrained CPU), so
+ * callers on a latency-sensitive path should warm it ahead of time. Pass a logger to record how
+ * long that first build took.
+ * @param logger - Optional logger; when provided, the initial table build is timed and logged.
  */
-export function getKzg(): DasContextJs {
+export function getKzg(logger?: Logger): DasContextJs {
   if (!kzgInstance) {
-    kzgInstance = loadNativeModule().DasContextJs.create({ usePrecomp: true });
+    const [durationMs, instance] = elapsedSync(() => loadNativeModule().DasContextJs.create({ usePrecomp: true }));
+    kzgInstance = instance;
+    logger?.verbose(`Loaded KZG trusted setup`, { durationMs });
   }
   return kzgInstance;
 }


### PR DESCRIPTION
## Context

An RPC node logged `Gossip validation for checkpoint_attestation took 15533ms, approaching mcache eviction window of 8400ms` shortly after startup. Investigation (see A-1425) showed the validations were not slow — the Node.js event loop was fully blocked for 12–15s, and the attestations were queued behind it. The blocking call is `getKzg()`, which lazily builds the `@crate-crypto/node-eth-kzg` precomputation tables synchronously (~2s locally, 12–15s under the pod's CPU limits) on first use.

On a plain RPC node that first use is the archiver reconstructing blobs during sync, or the proposal handler uploading blobs right after a checkpoint arrives — both immediately adjacent to gossip traffic, so the stalled loop overruns the gossipsub mcache window (8.4s) and attestation forwarding is skipped. Sequencers already avoid this via `Sequencer.init()`, so only non-sequencer nodes were affected.

## Approach

Warm the KZG singleton in `createAztecNodeService`, right after the existing bb.js WASM singleton init and before any subsystem runs. The cost is unchanged (every full node reconstructs blobs and pays it eventually) — it just moves off the gossip path to a point where blocking the loop is harmless. `getKzg()` is an idempotent per-process singleton, so this is a no-op for sequencers and for tests that pre-warm via `warmBlobKzg` (all e2e setups do), and adds no work for pure unit tests, which never construct a full node.

Fixes A-1425