### PR TITLE
chore(spartan): add fairies API key for mainnet rpc

### DIFF
--- a/spartan/terraform/deploy-rpc/environments/mainnet/main.tf
+++ b/spartan/terraform/deploy-rpc/environments/mainnet/main.tf
@@ -127,6 +127,11 @@ module "environment" {
       gcp_secret_manager_secret_name = "mainnet-rpc-consumer-client8"
       rate_limit_minute              = 0
     }
+    client9 = {
+      username                       = "mainnet-rpc-consumer-client9"
+      gcp_secret_manager_secret_name = "mainnet-rpc-consumer-client9"
+      rate_limit_minute              = 0
+    }
   }
 
   IRM_METRICS_ENABLED = true


### PR DESCRIPTION
Adds `client9` (`mainnet-rpc-consumer-client9`) to the mainnet RPC consumers, following #24693 (client8).

The GCP Secret Manager secret is already created and this has been `terraform apply`-ed to the mainnet environment — the plan was exactly the two expected resources (KongConsumer + ExternalSecret) and is now live. Rate limit 0 = unlimited, matching the other consumers.