### PR TITLE
fix(txe): size guard counts runtime JS only, not sourcemaps

### DIFF
--- a/yarn-project/txe/esbuild.config.mjs
+++ b/yarn-project/txe/esbuild.config.mjs
@@ -217,10 +217,18 @@ const result = await build({
 // Dump the full metafile so we can audit chunk graph / imports separately from the build.
 await writeFile('dest/metafile.json', JSON.stringify(result.metafile, null, 2));
 
-const totalBytes = Object.values(result.metafile.outputs).reduce((sum, o) => sum + o.bytes, 0);
+// Report runtime JS and external sourcemaps separately: the size guard bounds the JS (what V8
+// parses at cold start), while the `.map` files are loaded lazily and only tracked for growth.
+const jsBytes = Object.entries(result.metafile.outputs)
+  .filter(([p]) => !p.endsWith('.map'))
+  .reduce((sum, [, o]) => sum + o.bytes, 0);
+const mapBytes = Object.entries(result.metafile.outputs)
+  .filter(([p]) => p.endsWith('.map'))
+  .reduce((sum, [, o]) => sum + o.bytes, 0);
 const ms = Date.now() - start;
+const toMiB = b => (b / 1024 / 1024).toFixed(1);
 // eslint-disable-next-line no-console
-console.log(`Bundled TXE in ${ms}ms (${(totalBytes / 1024 / 1024).toFixed(1)} MiB total)`);
+console.log(`Bundled TXE in ${ms}ms (${toMiB(jsBytes)} MiB JS + ${toMiB(mapBytes)} MiB sourcemaps)`);
 
 // Surface the heaviest inputs per bundle. Pass `--inspect` on the command line to print.
 if (process.argv.includes('--inspect')) {

--- a/yarn-project/txe/esbuild/plugins/size_guard.mjs
+++ b/yarn-project/txe/esbuild/plugins/size_guard.mjs
@@ -1,20 +1,30 @@
 /**
  * Post-build size guard. Catches unintended bundle growth without involving CI separately.
  *
- * Each entry pairs a regex against the output path with a `maxKB` cap and a `description` that
- * shows up in the failure message. The build fails (exit 1) if any matching file exceeds its
- * cap, or if the total bundle size exceeds `totalLimitMiB`.
+ * Each entry in `sizeLimits` pairs a regex against the output path with a `maxKB` cap and a
+ * `description` that shows up in the failure message. The build fails (exit 1) if any matching
+ * file exceeds its cap, if the total runtime JS exceeds `totalLimitMiB`, or if the total external
+ * sourcemap size exceeds `sourcemapLimitMiB`.
  *
- * When a legitimate change pushes a chunk over its limit, raise the number AND append a one-line
- * entry to the bump log so the history of size bumps stays auditable.
+ * The JS total and the sourcemap total are tracked separately. `sourcemap: 'external'` in
+ * esbuild.config.mjs keeps the `.map` files out of the runtime parse path (V8 only parses the
+ * `.js`; Node loads a `.map` lazily for stack traces), so folding them into the runtime-bundle
+ * number would measure the wrong thing — sourcemaps are ~2x the JS here. The sourcemap cap exists
+ * only to notice runaway map growth, so it is deliberately loose.
+ *
+ * When a legitimate change pushes a chunk or total over its limit, raise the number AND append a
+ * one-line entry to the bump log so the history of size bumps stays auditable.
  */
 
 // Bump log:
 // - 2026-05-27: initial limits.
 // - 2026-07-08: total 14 -> 15 MiB. Merging public-v5-next into v5-next pulled in the interactive-handshake
 //   support (recipient- and sender-side) and the enlarged HandshakeRegistry contract chunk, pushing the TXE
-//   bundle to ~14.01 MiB. No individual chunk exceeded its cap.
-// - 2026-07-13: bumped total to 14.5 MiB.
+//   bundle to ~14.01 MiB. No individual chunk exceeded its cap. (Total counted JS + sourcemaps back then.)
+// - 2026-07-13: bumped total to 14.5 MiB (stopgap; total still counted JS + sourcemaps).
+// - 2026-07-20: total now counts runtime JS only, excluding external `.map` sourcemaps (~66% of the old
+//   number). Reset to 6 MiB against ~4.74 MiB of JS today; reverts the 14.5 stopgap. Sourcemap total gets
+//   its own loose cap (`sourcemapLimitMiB`, 12 MiB against ~9.3 MiB today) so map growth is still watched.
 export const sizeLimits = [
   // Shared chunks emitted by code-splitting; carry the simulator + PXE + world-state graph.
   // Spikes here usually mean a heavy dep crept into the eager import path.
@@ -26,7 +36,12 @@ export const sizeLimits = [
   { pattern: /^dest\/bin\/index\.js$/, maxKB: 8, description: 'CLI entrypoint stub' },
 ];
 
-export const totalLimitMiB = 15;
+// Cap on the total runtime JS (`.js` outputs). This is what V8 parses at cold start.
+export const totalLimitMiB = 6;
+
+// Loose cap on the total external sourcemap size (`.map` outputs). Not on the runtime parse path;
+// exists only to flag runaway growth.
+export const sourcemapLimitMiB = 12;
 
 /**
  * Validates a built esbuild `metafile` against the configured limits. Logs all violations then
@@ -34,9 +49,14 @@ export const totalLimitMiB = 15;
  */
 export function enforceSizeLimits(metafile) {
   const violations = [];
-  let totalBytes = 0;
+  let totalJsBytes = 0;
+  let totalMapBytes = 0;
   for (const [outPath, out] of Object.entries(metafile.outputs)) {
-    totalBytes += out.bytes;
+    if (outPath.endsWith('.map')) {
+      totalMapBytes += out.bytes;
+      continue;
+    }
+    totalJsBytes += out.bytes;
     for (const limit of sizeLimits) {
       if (limit.pattern.test(outPath)) {
         const sizeKB = out.bytes / 1024;
@@ -46,9 +66,13 @@ export function enforceSizeLimits(metafile) {
       }
     }
   }
-  const totalMiB = totalBytes / 1024 / 1024;
-  if (totalMiB > totalLimitMiB) {
-    violations.push(`  total: ${totalMiB.toFixed(2)} MiB > ${totalLimitMiB} MiB`);
+  const totalJsMiB = totalJsBytes / 1024 / 1024;
+  if (totalJsMiB > totalLimitMiB) {
+    violations.push(`  runtime JS total: ${totalJsMiB.toFixed(2)} MiB > ${totalLimitMiB} MiB`);
+  }
+  const totalMapMiB = totalMapBytes / 1024 / 1024;
+  if (totalMapMiB > sourcemapLimitMiB) {
+    violations.push(`  sourcemap total: ${totalMapMiB.toFixed(2)} MiB > ${sourcemapLimitMiB} MiB`);
   }
   if (violations.length === 0) {
     return;


### PR DESCRIPTION
## Summary

The TXE bundle size guard (`enforceSizeLimits` in `yarn-project/txe/esbuild/plugins/size_guard.mjs`) summed **every** esbuild `metafile.outputs` entry — including the external `.map` sourcemaps — against `totalLimitMiB`. Since `esbuild.config.mjs` sets `sourcemap: 'external'` specifically so the runtime bundles stay small, counting `.map` files meant the guard mostly measured sourcemap size, not the runtime bundle.

Measured on the current bundle:

| | Size |
| -- | -- |
| Runtime JS (`.js`) | 4.74 MiB |
| Sourcemaps (`.map`) | 9.32 MiB |
| Old counted total | 14.06 MiB |

So ~66% of the guarded number was sourcemaps. This is what tipped the guard over its limit on a sub-KB per-contract bytecode change.

## Changes

- `enforceSizeLimits` now tracks two totals: runtime JS (`.js` outputs) and sourcemaps (`.map` outputs). The JS total is checked against `totalLimitMiB`; the sourcemap total against a new, deliberately loose `sourcemapLimitMiB`.
- Reset `totalLimitMiB` `15 → 6` MiB (~1.3 MiB / ~27% headroom over the ~4.74 MiB of JS today). Reverts the 14.5 stopgap.
- Added `sourcemapLimitMiB = 12` MiB (~2.7 MiB headroom over ~9.3 MiB today) so map growth is still watched, per the issue's optional suggestion.
- Bump log gets a 2026-07-20 entry documenting the semantic switch to JS-only; header docstring rewritten to explain the two-total scheme.
- The build's info line now prints `X MiB JS + Y MiB sourcemaps` instead of one combined figure.

## Verification

Guard logic exercised against metafiles mirroring real sizes:

- Current bundle → pass
- +4 KB per-contract change (the scenario that tripped the guard) → pass
- Sourcemaps grown past 12 MiB → trips *sourcemap total* only
- Real JS grown past 6 MiB → trips *runtime JS total*
- Sourcemaps never counted toward the JS total

A real end-to-end `node ./esbuild.config.mjs` run also passed without tripping the guard.

Closes F-812.