### PR TITLE
fix(ci): shallow-clone benchmark uploads with 6-month retention

### DIFF
--- a/.github/workflows/ci3.yml
+++ b/.github/workflows/ci3.yml
@@ -165,22 +165,19 @@ jobs:
               --data "$(jq -n --arg c "#backports" --arg t "$TEXT" '{channel:$c, text:$t}')"
           fi
 
+      # Uses ci3/upload_benchmarks rather than github-action-benchmark: the action full-clones
+      # the multi-GB data repo per upload; the script does a shallow sparse clone and enforces
+      # the retention policy (--maintain: prune stale dirs, squash history older than 6 months).
       - name: Upload benchmarks
         if: env.BENCH_UPLOAD == '1'
-        uses: benchmark-action/github-action-benchmark@52576c92bccf6ac60c8223ec7eb2565637cae9ba # v1.22.1
-        with: &ci_benchmark_args
-          name: Aztec Benchmarks
-          benchmark-data-dir-path: "bench/${{ env.BENCH_BRANCH }}"
-          tool: "customSmallerIsBetter"
-          output-file-path: ./bench-out/bench.json
-          gh-repository: github.com/AztecProtocol/benchmark-page-data
-          github-token: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
-          auto-push: true
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-          alert-threshold: "105%"
-          comment-on-alert: false
-          fail-on-alert: false
-          max-items-in-chart: 100
+        env: &ci_benchmark_env
+          GITHUB_TOKEN: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
+          COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: &ci_benchmark_run |
+          args=("Aztec Benchmarks" "bench/${BENCH_BRANCH:-}" ./bench-out/bench.json "$COMMIT_SHA")
+          # Retention maintenance only on the next branch's uploads to bound concurrency.
+          [ "${BENCH_BRANCH:-}" == "next" ] && args+=(--maintain)
+          ./ci3/upload_benchmarks "${args[@]}"
 
   # Validates that a nightly tag's embedded date matches today's UTC date.
   # Prevents stale or replayed nightly tags from triggering scenario tests.
@@ -323,8 +320,8 @@ jobs:
 
       - name: Upload benchmarks
         if: env.ENABLE_DEPLOY_BENCH == '1'
-        uses: benchmark-action/github-action-benchmark@52576c92bccf6ac60c8223ec7eb2565637cae9ba # v1.22.1
-        with: *ci_benchmark_args
+        env: *ci_benchmark_env
+        run: *ci_benchmark_run
 
       - name: Notify Slack and dispatch ClaudeBox on failure
         if: failure() && startsWith(github.ref, 'refs/tags/v')
@@ -422,20 +419,11 @@ jobs:
 
       - name: Upload benchmarks
         if: always() && env.ENABLE_DEPLOY_BENCH == '1'
-        uses: benchmark-action/github-action-benchmark@52576c92bccf6ac60c8223ec7eb2565637cae9ba # v1.22.1
-        with:
-          name: Spartan
-          benchmark-data-dir-path: "bench/pr-${{ github.event.pull_request.number }}"
-          tool: "customSmallerIsBetter"
-          output-file-path: ./bench-out/bench.json
-          gh-repository: github.com/AztecProtocol/benchmark-page-data
-          github-token: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
-          auto-push: true
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-          alert-threshold: "120%"
-          comment-on-alert: false
-          fail-on-alert: false
-          max-items-in-chart: 100
+        env:
+          GITHUB_TOKEN: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
+          COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: ./ci3/upload_benchmarks "Spartan" "bench/pr-$PR_NUMBER" ./bench-out/bench.json "$COMMIT_SHA"
 
   # KIND-based e2e tests that run on a local Kubernetes cluster.
   # One-time use: label is removed after the job runs.

--- a/.github/workflows/ci3.yml
+++ b/.github/workflows/ci3.yml
@@ -166,18 +166,13 @@ jobs:
           fi
 
       # Uses ci3/upload_benchmarks rather than github-action-benchmark: the action full-clones
-      # the multi-GB data repo per upload; the script does a shallow sparse clone and enforces
-      # the retention policy (--maintain: prune stale dirs, squash history older than 6 months).
+      # the multi-GB data repo per upload; the script does a shallow sparse clone instead.
       - name: Upload benchmarks
         if: env.BENCH_UPLOAD == '1'
         env: &ci_benchmark_env
           GITHUB_TOKEN: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
           COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
-        run: &ci_benchmark_run |
-          args=("Aztec Benchmarks" "bench/${BENCH_BRANCH:-}" ./bench-out/bench.json "$COMMIT_SHA")
-          # Retention maintenance only on the next branch's uploads to bound concurrency.
-          [ "${BENCH_BRANCH:-}" == "next" ] && args+=(--maintain)
-          ./ci3/upload_benchmarks "${args[@]}"
+        run: &ci_benchmark_run ./ci3/upload_benchmarks "Aztec Benchmarks" "bench/${BENCH_BRANCH:-}" ./bench-out/bench.json "$COMMIT_SHA"
 
   # Validates that a nightly tag's embedded date matches today's UTC date.
   # Prevents stale or replayed nightly tags from triggering scenario tests.

--- a/ci3/upload_benchmarks
+++ b/ci3/upload_benchmarks
@@ -1,0 +1,218 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Upload a benchmark datapoint to the benchmark dashboard data repo, writing the same
+# window.BENCHMARK_DATA format as benchmark-action/github-action-benchmark.
+#
+# Replaces that action for uploads: the action full-clones the data repo (multiple GB of
+# append-only history) to add a single datapoint. This script does a shallow, blob-filtered,
+# sparse clone of just the target data dir instead, and in --maintain mode enforces a retention
+# policy so the repo cannot grow without bound:
+#   - data dirs with no update in RETENTION_MONTHS are pruned from the tip
+#   - history older than RETENTION_MONTHS is squashed into a single root commit (cheap: uses a
+#     blob-less clone; squashing rewrites only commit objects, never trees or blobs)
+#
+# Usage: upload_benchmarks <entry-name> <data-dir> <bench-json> <commit-sha> [--maintain]
+#   entry-name  Chart entry name, e.g. "Aztec Benchmarks"
+#   data-dir    Directory in the data repo, e.g. "bench/next"
+#   bench-json  Path to a customSmallerIsBetter JSON file: [{name, value, unit}, ...]
+#   commit-sha  The source-repo commit the results belong to
+#
+# Env:
+#   GITHUB_TOKEN      Token with push access to the data repo (required unless BENCH_REPO_URL).
+#   BENCH_REPO        Data repo slug (default: AztecProtocol/benchmark-page-data).
+#   BENCH_REPO_URL    Full clone URL override; bypasses token auth (used by tests).
+#   SOURCE_REPO_URL   Repo the commit sha belongs to (default: https://github.com/AztecProtocol/aztec-packages).
+#   MAX_ITEMS         Datapoints kept per entry series (default: 100).
+#   RETENTION_MONTHS  Retention window for prune and squash (default: 6).
+
+entry_name=$1
+data_dir=${2%/}
+bench_json=$3
+commit_sha=$4
+maintain=${5:-}
+
+bench_repo=${BENCH_REPO:-AztecProtocol/benchmark-page-data}
+repo_url=${BENCH_REPO_URL:-https://x-access-token:${GITHUB_TOKEN:-}@github.com/$bench_repo}
+source_repo_url=${SOURCE_REPO_URL:-https://github.com/AztecProtocol/aztec-packages}
+max_items=${MAX_ITEMS:-100}
+retention_months=${RETENTION_MONTHS:-6}
+
+[ -f "$bench_json" ] || { echo "upload_benchmarks: bench json not found: $bench_json" >&2; exit 1; }
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+# Build the datapoint entry. Commit metadata comes from the GitHub API when available so the
+# dashboard can render author/link info; degrade to bare sha metadata otherwise.
+build_entry() {
+  local commit_info
+  if ! commit_info=$(curl -sf --max-time 15 \
+      ${GITHUB_TOKEN:+-H "Authorization: Bearer $GITHUB_TOKEN"} \
+      "https://api.github.com/repos/${source_repo_url##*github.com/}/commits/$commit_sha" 2>/dev/null); then
+    commit_info='{}'
+  fi
+  jq -n \
+    --argjson info "$commit_info" \
+    --arg id "$commit_sha" \
+    --arg url "$source_repo_url/commit/$commit_sha" \
+    --arg now_iso "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    --slurpfile benches "$bench_json" \
+    '{
+      commit: {
+        author: { name: ($info.commit.author.name // "unknown"), username: ($info.author.login // "") },
+        committer: { name: ($info.commit.committer.name // "unknown"), username: ($info.committer.login // "") },
+        id: $id,
+        message: ($info.commit.message // "" | split("\n")[0]),
+        timestamp: ($info.commit.author.date // $now_iso),
+        url: ($info.html_url // $url)
+      },
+      date: (now * 1000 | floor),
+      tool: "customSmallerIsBetter",
+      benches: $benches[0]
+    }'
+}
+
+# Append the entry to <data-dir>/data.js in a fresh shallow sparse clone and push.
+# Also removes any dirs listed in $tmp/prune_dirs (populated by maintain).
+append_and_push() {
+  local dir="$tmp/append"
+  rm -rf "$dir"
+  git clone -q --depth=1 --single-branch -b gh-pages --filter=blob:none --sparse "$repo_url" "$dir"
+  git -C "$dir" sparse-checkout set "$data_dir" >/dev/null
+
+  local data_js="$dir/$data_dir/data.js"
+  mkdir -p "$dir/$data_dir"
+  local current='{"lastUpdate":0,"repoUrl":"","entries":{}}'
+  if [ -f "$data_js" ]; then
+    # Strip the "window.BENCHMARK_DATA = " prefix (and any trailing semicolon/newline).
+    current=$(sed '1s/^window\.BENCHMARK_DATA *= *//' "$data_js")
+  else
+    # New data dir: give it the same dashboard page as an existing dir.
+    local template
+    template=$(git -C "$dir" ls-tree -r --name-only HEAD | grep '/index.html$' | head -1 || true)
+    if [ -n "$template" ]; then
+      git -C "$dir" show "HEAD:$template" > "$dir/$data_dir/index.html"
+    fi
+  fi
+
+  jq --arg name "$entry_name" \
+     --arg repo_url "$source_repo_url" \
+     --argjson entry "$(cat "$tmp/entry.json")" \
+     --argjson max "$max_items" \
+     '.lastUpdate = (now * 1000 | floor)
+      | .repoUrl = $repo_url
+      | .entries[$name] = ((.entries[$name] // []) + [$entry] | if length > $max then .[length - $max:] else . end)' \
+     <<< "$current" > "$tmp/data.json"
+  { printf 'window.BENCHMARK_DATA = '; cat "$tmp/data.json"; } > "$data_js"
+
+  git -C "$dir" add "$data_dir"
+
+  if [ -f "$tmp/did_squash" ]; then
+    date +%s > "$dir/bench/.squash-stamp"
+    git -C "$dir" add bench/.squash-stamp
+  fi
+
+  if [ -s "$tmp/prune_dirs" ]; then
+    while IFS= read -r stale; do
+      # --cached + --sparse: removes from the tree without needing the blobs checked out.
+      git -C "$dir" rm -rq --cached --sparse --ignore-unmatch -- "$stale"
+      echo "Pruned stale benchmark dir: $stale"
+    done < "$tmp/prune_dirs"
+  fi
+
+  git -C "$dir" -c user.name="aztec-bot" -c user.email="tech@aztecprotocol.com" \
+    commit -qm "$entry_name ($data_dir) @ $commit_sha"
+  git -C "$dir" push -q origin HEAD:gh-pages
+}
+
+# Retention maintenance, run against a blob-less clone of the retention window:
+#  - collect data dirs whose newest touching commit is older than the retention window
+#  - if history extends beyond the window, squash it into a single root commit. Trees and blobs
+#    are content-addressed and reused as-is, so only commit objects are rewritten and pushed.
+maintain() {
+  local dir="$tmp/maintain"
+  # Clone 2 months beyond the retention window. The graft boundary lands on the oldest included
+  # commit, so the buffer guarantees every commit relevant to the retention cutoff is present
+  # with real parentage, making the per-dir last-touch computation below exact.
+  local since="-$((retention_months + 2)) months"
+  if ! git clone -q --bare --single-branch -b gh-pages --filter=blob:none --shallow-since="$since" \
+      "$repo_url" "$dir" 2>/dev/null; then
+    echo "maintain: clone failed (no commits in window?); skipping maintenance" >&2
+    return 0
+  fi
+  local orig_head
+  orig_head=$(git -C "$dir" rev-parse gh-pages)
+
+  # In a shallow clone the graft root diffs against the empty tree, claiming to "touch" every
+  # file; exclude roots from last-touch queries there. A dir no commit besides the root touched
+  # was then last modified before the clone window began, i.e. well past the retention cutoff.
+  local not_root=()
+  if [ -s "$dir/shallow" ]; then
+    local graft_roots
+    mapfile -t graft_roots < <(git -C "$dir" rev-list --max-parents=0 gh-pages)
+    not_root=(--not "${graft_roots[@]}")
+  fi
+  local cutoff
+  cutoff=$(date -d "-$retention_months months" +%s)
+  git -C "$dir" ls-tree -r --name-only gh-pages | grep '/.*/data.js$' | while IFS= read -r f; do
+    local d=${f%/data.js} last
+    [ "$d" = "$data_dir" ] && continue
+    last=$(git -C "$dir" log -1 --format=%ct gh-pages ${not_root[@]+"${not_root[@]}"} -- "$d/" 2>/dev/null || true)
+    if [ "${last:-0}" -lt "$cutoff" ]; then
+      echo "$d"
+    fi
+  done > "$tmp/prune_dirs" || true
+
+  # Shallow graft present => commits older than the buffered window exist => squash them.
+  # Rate-limited to monthly via a stamp file at the tip (a marker commit wouldn't work: the
+  # graft trails the cutoff daily, and right after a squash the marker sits below the graft
+  # where the next clone can't see it).
+  if [ ! -s "$dir/shallow" ]; then
+    return 0
+  fi
+  local last_squash
+  last_squash=$(git -C "$dir" show gh-pages:bench/.squash-stamp 2>/dev/null || echo 0)
+  if [ "${last_squash:-0}" -gt "$(date -d '-1 month' +%s)" ] 2>/dev/null; then
+    return 0
+  fi
+  local squash_msg="chore(bench): squash history older than $retention_months months"
+  echo "Squashing benchmark history older than $retention_months months..."
+  local commits new c
+  mapfile -t commits < <(git -C "$dir" rev-list --reverse --first-parent gh-pages)
+  new=$(GIT_AUTHOR_NAME="aztec-bot" GIT_AUTHOR_EMAIL="tech@aztecprotocol.com" \
+    GIT_AUTHOR_DATE="$(git -C "$dir" log -1 --format=%aI "${commits[0]}")" \
+    GIT_COMMITTER_NAME="aztec-bot" GIT_COMMITTER_EMAIL="tech@aztecprotocol.com" \
+    git -C "$dir" commit-tree "${commits[0]}^{tree}" -m "$squash_msg")
+  for c in "${commits[@]:1}"; do
+    local an ae ad cn ce cd
+    IFS=$'\x01' read -r an ae ad cn ce cd < <(git -C "$dir" log -1 --format=$'%an\x01%ae\x01%aI\x01%cn\x01%ce\x01%cI' "$c")
+    new=$(git -C "$dir" log -1 --format=%B "$c" |
+      GIT_AUTHOR_NAME="$an" GIT_AUTHOR_EMAIL="$ae" GIT_AUTHOR_DATE="$ad" \
+      GIT_COMMITTER_NAME="$cn" GIT_COMMITTER_EMAIL="$ce" GIT_COMMITTER_DATE="$cd" \
+      git -C "$dir" commit-tree "$c^{tree}" -p "$new" -F -)
+  done
+  # Lease on the sha we cloned: if someone pushed meanwhile, skip; next maintain retries.
+  if git -C "$dir" push -q --force-with-lease="gh-pages:$orig_head" origin "$new:refs/heads/gh-pages"; then
+    touch "$tmp/did_squash"
+  else
+    echo "Concurrent push detected; skipping squash this round." >&2
+  fi
+}
+
+build_entry > "$tmp/entry.json"
+: > "$tmp/prune_dirs"
+
+if [ "$maintain" = "--maintain" ]; then
+  maintain
+fi
+
+for attempt in 1 2 3; do
+  if append_and_push; then
+    echo "Benchmark datapoint uploaded to $bench_repo:$data_dir (entry: $entry_name)"
+    exit 0
+  fi
+  echo "Push attempt $attempt failed (concurrent update?); retrying..." >&2
+  sleep $((attempt * 5))
+done
+echo "upload_benchmarks: failed to push after 3 attempts" >&2
+exit 1

--- a/ci3/upload_benchmarks
+++ b/ci3/upload_benchmarks
@@ -5,11 +5,13 @@ set -euo pipefail
 #
 # Replaces that action for uploads: the action full-clones the data repo (multiple GB of
 # append-only history) to add a single datapoint. This script does a shallow, blob-filtered,
-# sparse clone of just the target data dir instead, and in --maintain mode enforces a retention
-# policy so the repo cannot grow without bound:
-#   - data dirs with no update in RETENTION_MONTHS are pruned from the tip
-#   - history older than RETENTION_MONTHS is squashed into a single root commit (cheap: uses a
-#     blob-less clone; squashing rewrites only commit objects, never trees or blobs)
+# sparse clone of just the target data dir instead, and in --maintain mode prunes data dirs
+# with no update in RETENTION_MONTHS from the tip.
+#
+# History squashing is deliberately NOT done here. Pushing rewritten history from a partial
+# clone forces git to lazy-fetch promisor objects one at a time to build the pack — it ground
+# for 93 minutes in CI before the connection dropped. Squash old history out-of-band from a
+# full clone when the repo needs it.
 #
 # Usage: upload_benchmarks <entry-name> <data-dir> <bench-json> <commit-sha> [--maintain]
 #   entry-name  Chart entry name, e.g. "Aztec Benchmarks"
@@ -23,7 +25,8 @@ set -euo pipefail
 #   BENCH_REPO_URL    Full clone URL override; bypasses token auth (used by tests).
 #   SOURCE_REPO_URL   Repo the commit sha belongs to (default: https://github.com/AztecProtocol/aztec-packages).
 #   MAX_ITEMS         Datapoints kept per entry series (default: 100).
-#   RETENTION_MONTHS  Retention window for prune and squash (default: 6).
+#   RETENTION_MONTHS  Retention window for pruning stale dirs (default: 6).
+#   RETRY_SLEEP       Base seconds between push retries (default: 5; tests set 0).
 
 entry_name=$1
 data_dir=${2%/}
@@ -36,6 +39,7 @@ repo_url=${BENCH_REPO_URL:-https://x-access-token:${GITHUB_TOKEN:-}@github.com/$
 source_repo_url=${SOURCE_REPO_URL:-https://github.com/AztecProtocol/aztec-packages}
 max_items=${MAX_ITEMS:-100}
 retention_months=${RETENTION_MONTHS:-6}
+retry_sleep=${RETRY_SLEEP:-5}
 
 [ -f "$bench_json" ] || { echo "upload_benchmarks: bench json not found: $bench_json" >&2; exit 1; }
 
@@ -74,18 +78,21 @@ build_entry() {
 
 # Append the entry to <data-dir>/data.js in a fresh shallow sparse clone and push.
 # Also removes any dirs listed in $tmp/prune_dirs (populated by maintain).
+# Called inside an `if`, which suppresses errexit for the whole body — every step that must
+# not fail silently carries an explicit `|| return 1` so a failure aborts before the push.
 append_and_push() {
   local dir="$tmp/append"
   rm -rf "$dir"
-  git clone -q --depth=1 --single-branch -b gh-pages --filter=blob:none --sparse "$repo_url" "$dir"
-  git -C "$dir" sparse-checkout set "$data_dir" >/dev/null
+  git clone -q --depth=1 --single-branch -b gh-pages --filter=blob:none --sparse "$repo_url" "$dir" || return 1
+  git -C "$dir" sparse-checkout set "$data_dir" >/dev/null || return 1
 
   local data_js="$dir/$data_dir/data.js"
   mkdir -p "$dir/$data_dir"
-  local current='{"lastUpdate":0,"repoUrl":"","entries":{}}'
+  local current_json="$tmp/current.json"
+  echo '{"lastUpdate":0,"repoUrl":"","entries":{}}' > "$current_json"
   if [ -f "$data_js" ]; then
     # Strip the "window.BENCHMARK_DATA = " prefix (and any trailing semicolon/newline).
-    current=$(sed '1s/^window\.BENCHMARK_DATA *= *//' "$data_js")
+    sed '1s/^window\.BENCHMARK_DATA *= *//' "$data_js" > "$current_json" || return 1
   else
     # New data dir: give it the same dashboard page as an existing dir.
     local template
@@ -95,40 +102,37 @@ append_and_push() {
     fi
   fi
 
+  # The entry and the existing data are passed to jq as files, never argv: Linux caps a single
+  # argv element at 128KB and a full CI entry exceeds that.
   jq --arg name "$entry_name" \
      --arg repo_url "$source_repo_url" \
-     --argjson entry "$(cat "$tmp/entry.json")" \
+     --slurpfile entry "$tmp/entry.json" \
      --argjson max "$max_items" \
      '.lastUpdate = (now * 1000 | floor)
       | .repoUrl = $repo_url
-      | .entries[$name] = ((.entries[$name] // []) + [$entry] | if length > $max then .[length - $max:] else . end)' \
-     <<< "$current" > "$tmp/data.json"
+      | .entries[$name] = ((.entries[$name] // []) + $entry | if length > $max then .[length - $max:] else . end)' \
+     "$current_json" > "$tmp/data.json" || return 1
+  [ -s "$tmp/data.json" ] || return 1
   { printf 'window.BENCHMARK_DATA = '; cat "$tmp/data.json"; } > "$data_js"
 
-  git -C "$dir" add "$data_dir"
-
-  if [ -f "$tmp/did_squash" ]; then
-    date +%s > "$dir/bench/.squash-stamp"
-    git -C "$dir" add bench/.squash-stamp
-  fi
+  git -C "$dir" add "$data_dir" || return 1
 
   if [ -s "$tmp/prune_dirs" ]; then
     while IFS= read -r stale; do
       # --cached + --sparse: removes from the tree without needing the blobs checked out.
-      git -C "$dir" rm -rq --cached --sparse --ignore-unmatch -- "$stale"
+      git -C "$dir" rm -rq --cached --sparse --ignore-unmatch -- "$stale" || return 1
       echo "Pruned stale benchmark dir: $stale"
     done < "$tmp/prune_dirs"
   fi
 
   git -C "$dir" -c user.name="aztec-bot" -c user.email="tech@aztecprotocol.com" \
-    commit -qm "$entry_name ($data_dir) @ $commit_sha"
-  git -C "$dir" push -q origin HEAD:gh-pages
+    commit -qm "$entry_name ($data_dir) @ $commit_sha" || return 1
+  git -C "$dir" push -q origin HEAD:gh-pages || return 1
 }
 
-# Retention maintenance, run against a blob-less clone of the retention window:
-#  - collect data dirs whose newest touching commit is older than the retention window
-#  - if history extends beyond the window, squash it into a single root commit. Trees and blobs
-#    are content-addressed and reused as-is, so only commit objects are rewritten and pushed.
+# Retention maintenance, run against a blob-less clone of the retention window: collect data
+# dirs whose newest touching commit is older than the window. They are removed from the tip
+# by the subsequent append commit.
 maintain() {
   local dir="$tmp/maintain"
   # Clone 2 months beyond the retention window. The graft boundary lands on the oldest included
@@ -140,8 +144,6 @@ maintain() {
     echo "maintain: clone failed (no commits in window?); skipping maintenance" >&2
     return 0
   fi
-  local orig_head
-  orig_head=$(git -C "$dir" rev-parse gh-pages)
 
   # In a shallow clone the graft root diffs against the empty tree, claiming to "touch" every
   # file; exclude roots from last-touch queries there. A dir no commit besides the root touched
@@ -162,41 +164,6 @@ maintain() {
       echo "$d"
     fi
   done > "$tmp/prune_dirs" || true
-
-  # Shallow graft present => commits older than the buffered window exist => squash them.
-  # Rate-limited to monthly via a stamp file at the tip (a marker commit wouldn't work: the
-  # graft trails the cutoff daily, and right after a squash the marker sits below the graft
-  # where the next clone can't see it).
-  if [ ! -s "$dir/shallow" ]; then
-    return 0
-  fi
-  local last_squash
-  last_squash=$(git -C "$dir" show gh-pages:bench/.squash-stamp 2>/dev/null || echo 0)
-  if [ "${last_squash:-0}" -gt "$(date -d '-1 month' +%s)" ] 2>/dev/null; then
-    return 0
-  fi
-  local squash_msg="chore(bench): squash history older than $retention_months months"
-  echo "Squashing benchmark history older than $retention_months months..."
-  local commits new c
-  mapfile -t commits < <(git -C "$dir" rev-list --reverse --first-parent gh-pages)
-  new=$(GIT_AUTHOR_NAME="aztec-bot" GIT_AUTHOR_EMAIL="tech@aztecprotocol.com" \
-    GIT_AUTHOR_DATE="$(git -C "$dir" log -1 --format=%aI "${commits[0]}")" \
-    GIT_COMMITTER_NAME="aztec-bot" GIT_COMMITTER_EMAIL="tech@aztecprotocol.com" \
-    git -C "$dir" commit-tree "${commits[0]}^{tree}" -m "$squash_msg")
-  for c in "${commits[@]:1}"; do
-    local an ae ad cn ce cd
-    IFS=$'\x01' read -r an ae ad cn ce cd < <(git -C "$dir" log -1 --format=$'%an\x01%ae\x01%aI\x01%cn\x01%ce\x01%cI' "$c")
-    new=$(git -C "$dir" log -1 --format=%B "$c" |
-      GIT_AUTHOR_NAME="$an" GIT_AUTHOR_EMAIL="$ae" GIT_AUTHOR_DATE="$ad" \
-      GIT_COMMITTER_NAME="$cn" GIT_COMMITTER_EMAIL="$ce" GIT_COMMITTER_DATE="$cd" \
-      git -C "$dir" commit-tree "$c^{tree}" -p "$new" -F -)
-  done
-  # Lease on the sha we cloned: if someone pushed meanwhile, skip; next maintain retries.
-  if git -C "$dir" push -q --force-with-lease="gh-pages:$orig_head" origin "$new:refs/heads/gh-pages"; then
-    touch "$tmp/did_squash"
-  else
-    echo "Concurrent push detected; skipping squash this round." >&2
-  fi
 }
 
 build_entry > "$tmp/entry.json"
@@ -212,7 +179,7 @@ for attempt in 1 2 3; do
     exit 0
   fi
   echo "Push attempt $attempt failed (concurrent update?); retrying..." >&2
-  sleep $((attempt * 5))
+  sleep $((attempt * retry_sleep))
 done
 echo "upload_benchmarks: failed to push after 3 attempts" >&2
 exit 1

--- a/ci3/upload_benchmarks
+++ b/ci3/upload_benchmarks
@@ -5,15 +5,9 @@ set -euo pipefail
 #
 # Replaces that action for uploads: the action full-clones the data repo (multiple GB of
 # append-only history) to add a single datapoint. This script does a shallow, blob-filtered,
-# sparse clone of just the target data dir instead, and in --maintain mode prunes data dirs
-# with no update in RETENTION_MONTHS from the tip.
+# sparse clone of just the target data dir instead.
 #
-# History squashing is deliberately NOT done here. Pushing rewritten history from a partial
-# clone forces git to lazy-fetch promisor objects one at a time to build the pack — it ground
-# for 93 minutes in CI before the connection dropped. Squash old history out-of-band from a
-# full clone when the repo needs it.
-#
-# Usage: upload_benchmarks <entry-name> <data-dir> <bench-json> <commit-sha> [--maintain]
+# Usage: upload_benchmarks <entry-name> <data-dir> <bench-json> <commit-sha>
 #   entry-name  Chart entry name, e.g. "Aztec Benchmarks"
 #   data-dir    Directory in the data repo, e.g. "bench/next"
 #   bench-json  Path to a customSmallerIsBetter JSON file: [{name, value, unit}, ...]
@@ -25,20 +19,17 @@ set -euo pipefail
 #   BENCH_REPO_URL    Full clone URL override; bypasses token auth (used by tests).
 #   SOURCE_REPO_URL   Repo the commit sha belongs to (default: https://github.com/AztecProtocol/aztec-packages).
 #   MAX_ITEMS         Datapoints kept per entry series (default: 100).
-#   RETENTION_MONTHS  Retention window for pruning stale dirs (default: 6).
 #   RETRY_SLEEP       Base seconds between push retries (default: 5; tests set 0).
 
 entry_name=$1
 data_dir=${2%/}
 bench_json=$3
 commit_sha=$4
-maintain=${5:-}
 
 bench_repo=${BENCH_REPO:-AztecProtocol/benchmark-page-data}
 repo_url=${BENCH_REPO_URL:-https://x-access-token:${GITHUB_TOKEN:-}@github.com/$bench_repo}
 source_repo_url=${SOURCE_REPO_URL:-https://github.com/AztecProtocol/aztec-packages}
 max_items=${MAX_ITEMS:-100}
-retention_months=${RETENTION_MONTHS:-6}
 retry_sleep=${RETRY_SLEEP:-5}
 
 [ -f "$bench_json" ] || { echo "upload_benchmarks: bench json not found: $bench_json" >&2; exit 1; }
@@ -77,7 +68,6 @@ build_entry() {
 }
 
 # Append the entry to <data-dir>/data.js in a fresh shallow sparse clone and push.
-# Also removes any dirs listed in $tmp/prune_dirs (populated by maintain).
 # Called inside an `if`, which suppresses errexit for the whole body — every step that must
 # not fail silently carries an explicit `|| return 1` so a failure aborts before the push.
 append_and_push() {
@@ -117,61 +107,12 @@ append_and_push() {
 
   git -C "$dir" add "$data_dir" || return 1
 
-  if [ -s "$tmp/prune_dirs" ]; then
-    while IFS= read -r stale; do
-      # --cached + --sparse: removes from the tree without needing the blobs checked out.
-      git -C "$dir" rm -rq --cached --sparse --ignore-unmatch -- "$stale" || return 1
-      echo "Pruned stale benchmark dir: $stale"
-    done < "$tmp/prune_dirs"
-  fi
-
   git -C "$dir" -c user.name="aztec-bot" -c user.email="tech@aztecprotocol.com" \
     commit -qm "$entry_name ($data_dir) @ $commit_sha" || return 1
   git -C "$dir" push -q origin HEAD:gh-pages || return 1
 }
 
-# Retention maintenance, run against a blob-less clone of the retention window: collect data
-# dirs whose newest touching commit is older than the window. They are removed from the tip
-# by the subsequent append commit.
-maintain() {
-  local dir="$tmp/maintain"
-  # Clone 2 months beyond the retention window. The graft boundary lands on the oldest included
-  # commit, so the buffer guarantees every commit relevant to the retention cutoff is present
-  # with real parentage, making the per-dir last-touch computation below exact.
-  local since="-$((retention_months + 2)) months"
-  if ! git clone -q --bare --single-branch -b gh-pages --filter=blob:none --shallow-since="$since" \
-      "$repo_url" "$dir" 2>/dev/null; then
-    echo "maintain: clone failed (no commits in window?); skipping maintenance" >&2
-    return 0
-  fi
-
-  # In a shallow clone the graft root diffs against the empty tree, claiming to "touch" every
-  # file; exclude roots from last-touch queries there. A dir no commit besides the root touched
-  # was then last modified before the clone window began, i.e. well past the retention cutoff.
-  local not_root=()
-  if [ -s "$dir/shallow" ]; then
-    local graft_roots
-    mapfile -t graft_roots < <(git -C "$dir" rev-list --max-parents=0 gh-pages)
-    not_root=(--not "${graft_roots[@]}")
-  fi
-  local cutoff
-  cutoff=$(date -d "-$retention_months months" +%s)
-  git -C "$dir" ls-tree -r --name-only gh-pages | grep '/.*/data.js$' | while IFS= read -r f; do
-    local d=${f%/data.js} last
-    [ "$d" = "$data_dir" ] && continue
-    last=$(git -C "$dir" log -1 --format=%ct gh-pages ${not_root[@]+"${not_root[@]}"} -- "$d/" 2>/dev/null || true)
-    if [ "${last:-0}" -lt "$cutoff" ]; then
-      echo "$d"
-    fi
-  done > "$tmp/prune_dirs" || true
-}
-
 build_entry > "$tmp/entry.json"
-: > "$tmp/prune_dirs"
-
-if [ "$maintain" = "--maintain" ]; then
-  maintain
-fi
 
 for attempt in 1 2 3; do
   if append_and_push; then

--- a/ci3/upload_benchmarks_test
+++ b/ci3/upload_benchmarks_test
@@ -31,7 +31,7 @@ commit_at() { # date msg
 }
 
 # 41 weekly commits, from 40 weeks ago (~9 months) to now. bench/stale stops being updated at
-# week -28 (~6.5 months ago), so it is past the 6-month retention cutoff.
+# week -28, exercising append behavior alongside untouched sibling dirs.
 for i in $(seq 40 -1 0); do
   when=$(date -d "-$i weeks" --iso-8601=seconds)
   echo "window.BENCHMARK_DATA = $(jq -n --argjson e "$(datapoint c$i $i)" '{lastUpdate:0,repoUrl:"r",entries:{"Aztec Benchmarks":[$e]}}')" > bench/next/data.js
@@ -58,7 +58,7 @@ check_tip() { # path -> stdout data.js json
   git -C origin.git show "gh-pages:$1" | sed '1s/^window\.BENCHMARK_DATA *= *//'
 }
 
-# --- Test 1: plain append, no maintain ---
+# --- Test 1: plain append ---
 run_script "Aztec Benchmarks" bench/next bench.json deadbeef1 > /dev/null
 n=$(check_tip bench/next/data.js | jq '.entries["Aztec Benchmarks"] | length')
 [ "$n" -eq 2 ] || fail "test1: expected 2 entries, got $n"
@@ -68,60 +68,41 @@ benchname=$(check_tip bench/next/data.js | jq -r '.entries["Aztec Benchmarks"][-
 [ "$benchname" = "proof_time" ] || fail "test1: bench name: $benchname"
 git -C origin.git show gh-pages:bench/stale/data.js > /dev/null || fail "test1: stale dir should be untouched"
 [ "$(git -C origin.git rev-list --count gh-pages)" -eq 42 ] || fail "test1: expected 42 commits"
-pass "test1: append without maintain"
+pass "test1: append"
 
-# --- Test 2: maintain prunes stale dir, never rewrites history ---
-run_script "Aztec Benchmarks" bench/next bench.json deadbeef2 --maintain > /dev/null
-new_count=$(git -C origin.git rev-list --count gh-pages)
-[ "$new_count" -eq 43 ] || fail "test2: expected exactly one new commit (42 -> $new_count)"
-# stale dir pruned, active + top-level + full history preserved
-git -C origin.git show gh-pages:bench/stale/data.js > /dev/null 2>&1 && fail "test2: stale dir not pruned"
-git -C origin.git show gh-pages:bench/index.html > /dev/null || fail "test2: top-level file lost"
-n=$(check_tip bench/next/data.js | jq '.entries["Aztec Benchmarks"] | length')
-[ "$n" -eq 3 ] || fail "test2: expected 3 entries after second append, got $n"
-git -C origin.git log --format=%s gh-pages | grep -q "bench update week -40" || fail "test2: old history lost"
-pass "test2: maintain prune without history rewrite (commits: 42 -> $new_count)"
-
-# --- Test 3: maintain is idempotent (nothing new pruned) ---
-count_before=$(git -C origin.git rev-list --count gh-pages)
-run_script "Aztec Benchmarks" bench/next bench.json deadbeef3 --maintain > /dev/null
-count_after=$(git -C origin.git rev-list --count gh-pages)
-[ "$count_after" -eq $((count_before + 1)) ] || fail "test3: expected exactly one new commit ($count_before -> $count_after)"
-pass "test3: maintain idempotent"
-
-# --- Test 4: append to a brand-new data dir creates data.js + index.html ---
+# --- Test 2: append to a brand-new data dir creates data.js + index.html ---
 run_script "Spartan" bench/pr-1234 bench.json cafef00d > /dev/null
 n=$(check_tip bench/pr-1234/data.js | jq '.entries["Spartan"] | length')
-[ "$n" -eq 1 ] || fail "test4: new dir entry count: $n"
-git -C origin.git show gh-pages:bench/pr-1234/index.html > /dev/null || fail "test4: index.html not created"
-pass "test4: new data dir initialized"
+[ "$n" -eq 1 ] || fail "test2: new dir entry count: $n"
+git -C origin.git show gh-pages:bench/pr-1234/index.html > /dev/null || fail "test2: index.html not created"
+pass "test2: new data dir initialized"
 
-# --- Test 5: MAX_ITEMS trims the series ---
+# --- Test 3: MAX_ITEMS trims the series ---
 for i in 1 2 3; do
   MAX_ITEMS=3 BENCH_REPO_URL="file://$WORK/origin.git" GITHUB_TOKEN= "$SCRIPT" "Spartan" bench/pr-1234 bench.json trim$i > /dev/null
 done
 n=$(check_tip bench/pr-1234/data.js | jq '.entries["Spartan"] | length')
-[ "$n" -eq 3 ] || fail "test5: expected 3 entries after trim, got $n"
+[ "$n" -eq 3 ] || fail "test3: expected 3 entries after trim, got $n"
 first=$(check_tip bench/pr-1234/data.js | jq -r '.entries["Spartan"][0].commit.id')
-[ "$first" = "trim1" ] || fail "test5: oldest kept entry: $first"
-pass "test5: MAX_ITEMS trim"
+[ "$first" = "trim1" ] || fail "test3: oldest kept entry: $first"
+pass "test3: MAX_ITEMS trim"
 
-# --- Test 6: entry larger than the 128KB per-argv-element limit still uploads ---
+# --- Test 4: entry larger than the 128KB per-argv-element limit still uploads ---
 # (regression: --argjson "$(cat entry.json)" died with "Argument list too long" in CI)
 jq -n '[range(3000) | {name: ("bench_\(.)_" + ("x" * 60)), value: ., unit: "ms"}]' > big_bench.json
-[ "$(wc -c < big_bench.json)" -gt 131072 ] || fail "test6: fixture not big enough"
-run_script "Aztec Benchmarks" bench/next big_bench.json bigentry1 > /dev/null || fail "test6: upload failed"
+[ "$(wc -c < big_bench.json)" -gt 131072 ] || fail "test4: fixture not big enough"
+run_script "Aztec Benchmarks" bench/next big_bench.json bigentry1 > /dev/null || fail "test4: upload failed"
 n=$(check_tip bench/next/data.js | jq '.entries["Aztec Benchmarks"][-1].benches | length')
-[ "$n" -eq 3000 ] || fail "test6: expected 3000 benches in entry, got $n"
-pass "test6: >128KB entry uploads intact"
+[ "$n" -eq 3000 ] || fail "test4: expected 3000 benches in entry, got $n"
+pass "test4: >128KB entry uploads intact"
 
-# --- Test 7: unreachable data repo fails loudly, pushes nothing ---
+# --- Test 5: unreachable data repo fails loudly, pushes nothing ---
 # (regression: a mid-append jq failure was swallowed by the if-suppressed errexit and a
 # truncated data.js was committed and pushed as a "success")
 if RETRY_SLEEP=0 BENCH_REPO_URL="file://$WORK/nonexistent.git" GITHUB_TOKEN= \
     "$SCRIPT" "Aztec Benchmarks" bench/next bench.json deadbeef9 > /dev/null 2>&1; then
-  fail "test7: expected nonzero exit for unreachable repo"
+  fail "test5: expected nonzero exit for unreachable repo"
 fi
-pass "test7: failure is loud"
+pass "test5: failure is loud"
 
 echo "ALL TESTS PASSED"

--- a/ci3/upload_benchmarks_test
+++ b/ci3/upload_benchmarks_test
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Self-contained test for ci3/upload_benchmarks against a local fixture data repo. Run directly.
+SCRIPT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/upload_benchmarks"
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+cd "$WORK"
+
+fail() { echo "FAIL: $1" >&2; exit 1; }
+pass() { echo "PASS: $1"; }
+
+# --- Build fixture: bare repo with 8 months of weekly commits ---
+git init -q --bare origin.git -b gh-pages
+git -C origin.git config uploadpack.allowFilter true
+git -C origin.git config uploadpack.allowAnySHA1InWant true
+
+git clone -q origin.git seed 2>/dev/null
+cd seed
+git checkout -q -b gh-pages
+mkdir -p bench/next bench/stale bench/data-top
+echo "<html>dashboard</html>" > bench/next/index.html
+echo "<html>dashboard</html>" > bench/stale/index.html
+echo "top-level" > bench/index.html
+
+datapoint() { # sha value
+  echo "{\"commit\":{\"id\":\"$1\"},\"date\":0,\"tool\":\"customSmallerIsBetter\",\"benches\":[{\"name\":\"t\",\"value\":$2,\"unit\":\"ms\"}]}"
+}
+
+commit_at() { # date msg
+  GIT_AUTHOR_DATE="$1" GIT_COMMITTER_DATE="$1" git -c user.name=fixture -c user.email=f@x commit -qam "$2"
+}
+
+# 41 weekly commits, from 40 weeks ago (~9 months) to now. bench/stale stops being updated at
+# week -28 (~6.5 months ago), so it is past the 6-month retention cutoff.
+for i in $(seq 40 -1 0); do
+  when=$(date -d "-$i weeks" --iso-8601=seconds)
+  echo "window.BENCHMARK_DATA = $(jq -n --argjson e "$(datapoint c$i $i)" '{lastUpdate:0,repoUrl:"r",entries:{"Aztec Benchmarks":[$e]}}')" > bench/next/data.js
+  if [ "$i" -ge 28 ]; then
+    cp bench/next/data.js bench/stale/data.js
+  fi
+  git add -A
+  commit_at "$when" "bench update week -$i"
+done
+git push -q origin gh-pages
+cd "$WORK"
+total_commits=$(git -C origin.git rev-list --count gh-pages)
+[ "$total_commits" -eq 41 ] || fail "fixture should have 41 commits, has $total_commits"
+
+# bench.json input
+echo '[{"name":"proof_time","value":123.4,"unit":"ms"},{"name":"mem","value":9,"unit":"MB"}]' > bench.json
+
+run_script() {
+  BENCH_REPO_URL="file://$WORK/origin.git" GITHUB_TOKEN= SOURCE_REPO_URL=https://github.com/AztecProtocol/aztec-packages \
+    "$SCRIPT" "$@"
+}
+
+check_tip() { # path -> stdout data.js json
+  git -C origin.git show "gh-pages:$1" | sed '1s/^window\.BENCHMARK_DATA *= *//'
+}
+
+# --- Test 1: plain append, no maintain ---
+run_script "Aztec Benchmarks" bench/next bench.json deadbeef1 > /dev/null
+n=$(check_tip bench/next/data.js | jq '.entries["Aztec Benchmarks"] | length')
+[ "$n" -eq 2 ] || fail "test1: expected 2 entries, got $n"
+last=$(check_tip bench/next/data.js | jq -r '.entries["Aztec Benchmarks"][-1].commit.id')
+[ "$last" = "deadbeef1" ] || fail "test1: last entry commit id: $last"
+benchname=$(check_tip bench/next/data.js | jq -r '.entries["Aztec Benchmarks"][-1].benches[0].name')
+[ "$benchname" = "proof_time" ] || fail "test1: bench name: $benchname"
+git -C origin.git show gh-pages:bench/stale/data.js > /dev/null || fail "test1: stale dir should be untouched"
+[ "$(git -C origin.git rev-list --count gh-pages)" -eq 42 ] || fail "test1: expected 42 commits"
+pass "test1: append without maintain"
+
+# --- Test 2: maintain squashes >6mo history and prunes stale dir ---
+run_script "Aztec Benchmarks" bench/next bench.json deadbeef2 --maintain > /dev/null
+new_count=$(git -C origin.git rev-list --count gh-pages)
+# squash boundary = retention+2 months ≈ 35 weeks: root + weeks -33..-0 + 2 appends ≈ 37
+[ "$new_count" -lt 39 ] || fail "test2: history not squashed (count=$new_count)"
+root=$(git -C origin.git rev-list --max-parents=0 gh-pages)
+[ "$(echo "$root" | wc -l)" -eq 1 ] || fail "test2: multiple roots"
+# stale dir pruned, active + top-level preserved
+git -C origin.git show gh-pages:bench/stale/data.js > /dev/null 2>&1 && fail "test2: stale dir not pruned"
+git -C origin.git show gh-pages:bench/index.html > /dev/null || fail "test2: top-level file lost"
+n=$(check_tip bench/next/data.js | jq '.entries["Aztec Benchmarks"] | length')
+[ "$n" -eq 3 ] || fail "test2: expected 3 entries after second append, got $n"
+# recent commit messages preserved through rewrite
+git -C origin.git log --format=%s gh-pages | grep -q "bench update week -30" || fail "test2: recent history lost"
+git -C origin.git log --format=%s gh-pages | grep -q "bench update week -36" && fail "test2: old history survived"
+git -C origin.git show gh-pages:bench/.squash-stamp > /dev/null || fail "test2: squash stamp missing"
+pass "test2: maintain squash + prune (commits: 42 -> $new_count)"
+
+# --- Test 3: maintain is idempotent (no shallow -> no squash, nothing new pruned) ---
+count_before=$(git -C origin.git rev-list --count gh-pages)
+run_script "Aztec Benchmarks" bench/next bench.json deadbeef3 --maintain > /dev/null
+count_after=$(git -C origin.git rev-list --count gh-pages)
+[ "$count_after" -eq $((count_before + 1)) ] || fail "test3: expected exactly one new commit ($count_before -> $count_after)"
+pass "test3: maintain idempotent"
+
+# --- Test 4: append to a brand-new data dir creates data.js + index.html ---
+run_script "Spartan" bench/pr-1234 bench.json cafef00d > /dev/null
+n=$(check_tip bench/pr-1234/data.js | jq '.entries["Spartan"] | length')
+[ "$n" -eq 1 ] || fail "test4: new dir entry count: $n"
+git -C origin.git show gh-pages:bench/pr-1234/index.html > /dev/null || fail "test4: index.html not created"
+pass "test4: new data dir initialized"
+
+# --- Test 5: MAX_ITEMS trims the series ---
+for i in 1 2 3; do
+  MAX_ITEMS=3 BENCH_REPO_URL="file://$WORK/origin.git" GITHUB_TOKEN= "$SCRIPT" "Spartan" bench/pr-1234 bench.json trim$i > /dev/null
+done
+n=$(check_tip bench/pr-1234/data.js | jq '.entries["Spartan"] | length')
+[ "$n" -eq 3 ] || fail "test5: expected 3 entries after trim, got $n"
+first=$(check_tip bench/pr-1234/data.js | jq -r '.entries["Spartan"][0].commit.id')
+[ "$first" = "trim1" ] || fail "test5: oldest kept entry: $first"
+pass "test5: MAX_ITEMS trim"
+
+echo "ALL TESTS PASSED"

--- a/ci3/upload_benchmarks_test
+++ b/ci3/upload_benchmarks_test
@@ -70,25 +70,19 @@ git -C origin.git show gh-pages:bench/stale/data.js > /dev/null || fail "test1: 
 [ "$(git -C origin.git rev-list --count gh-pages)" -eq 42 ] || fail "test1: expected 42 commits"
 pass "test1: append without maintain"
 
-# --- Test 2: maintain squashes >6mo history and prunes stale dir ---
+# --- Test 2: maintain prunes stale dir, never rewrites history ---
 run_script "Aztec Benchmarks" bench/next bench.json deadbeef2 --maintain > /dev/null
 new_count=$(git -C origin.git rev-list --count gh-pages)
-# squash boundary = retention+2 months ≈ 35 weeks: root + weeks -33..-0 + 2 appends ≈ 37
-[ "$new_count" -lt 39 ] || fail "test2: history not squashed (count=$new_count)"
-root=$(git -C origin.git rev-list --max-parents=0 gh-pages)
-[ "$(echo "$root" | wc -l)" -eq 1 ] || fail "test2: multiple roots"
-# stale dir pruned, active + top-level preserved
+[ "$new_count" -eq 43 ] || fail "test2: expected exactly one new commit (42 -> $new_count)"
+# stale dir pruned, active + top-level + full history preserved
 git -C origin.git show gh-pages:bench/stale/data.js > /dev/null 2>&1 && fail "test2: stale dir not pruned"
 git -C origin.git show gh-pages:bench/index.html > /dev/null || fail "test2: top-level file lost"
 n=$(check_tip bench/next/data.js | jq '.entries["Aztec Benchmarks"] | length')
 [ "$n" -eq 3 ] || fail "test2: expected 3 entries after second append, got $n"
-# recent commit messages preserved through rewrite
-git -C origin.git log --format=%s gh-pages | grep -q "bench update week -30" || fail "test2: recent history lost"
-git -C origin.git log --format=%s gh-pages | grep -q "bench update week -36" && fail "test2: old history survived"
-git -C origin.git show gh-pages:bench/.squash-stamp > /dev/null || fail "test2: squash stamp missing"
-pass "test2: maintain squash + prune (commits: 42 -> $new_count)"
+git -C origin.git log --format=%s gh-pages | grep -q "bench update week -40" || fail "test2: old history lost"
+pass "test2: maintain prune without history rewrite (commits: 42 -> $new_count)"
 
-# --- Test 3: maintain is idempotent (no shallow -> no squash, nothing new pruned) ---
+# --- Test 3: maintain is idempotent (nothing new pruned) ---
 count_before=$(git -C origin.git rev-list --count gh-pages)
 run_script "Aztec Benchmarks" bench/next bench.json deadbeef3 --maintain > /dev/null
 count_after=$(git -C origin.git rev-list --count gh-pages)
@@ -111,5 +105,23 @@ n=$(check_tip bench/pr-1234/data.js | jq '.entries["Spartan"] | length')
 first=$(check_tip bench/pr-1234/data.js | jq -r '.entries["Spartan"][0].commit.id')
 [ "$first" = "trim1" ] || fail "test5: oldest kept entry: $first"
 pass "test5: MAX_ITEMS trim"
+
+# --- Test 6: entry larger than the 128KB per-argv-element limit still uploads ---
+# (regression: --argjson "$(cat entry.json)" died with "Argument list too long" in CI)
+jq -n '[range(3000) | {name: ("bench_\(.)_" + ("x" * 60)), value: ., unit: "ms"}]' > big_bench.json
+[ "$(wc -c < big_bench.json)" -gt 131072 ] || fail "test6: fixture not big enough"
+run_script "Aztec Benchmarks" bench/next big_bench.json bigentry1 > /dev/null || fail "test6: upload failed"
+n=$(check_tip bench/next/data.js | jq '.entries["Aztec Benchmarks"][-1].benches | length')
+[ "$n" -eq 3000 ] || fail "test6: expected 3000 benches in entry, got $n"
+pass "test6: >128KB entry uploads intact"
+
+# --- Test 7: unreachable data repo fails loudly, pushes nothing ---
+# (regression: a mid-append jq failure was swallowed by the if-suppressed errexit and a
+# truncated data.js was committed and pushed as a "success")
+if RETRY_SLEEP=0 BENCH_REPO_URL="file://$WORK/nonexistent.git" GITHUB_TOKEN= \
+    "$SCRIPT" "Aztec Benchmarks" bench/next bench.json deadbeef9 > /dev/null 2>&1; then
+  fail "test7: expected nonzero exit for unreachable repo"
+fi
+pass "test7: failure is loud"
 
 echo "ALL TESTS PASSED"


### PR DESCRIPTION
The "Upload benchmarks" CI step takes ~8 minutes. Root cause: `benchmark-action/github-action-benchmark` does a **full clone** of `AztecProtocol/benchmark-page-data` (no depth/filter/single-branch) to append one datapoint. That repo's gh-pages history is **~4GB**.

## Changes

`ci3/upload_benchmarks` replaces the action at all three upload sites in `ci3.yml`. It writes the identical `window.BENCHMARK_DATA` format (verified against the live data), so the dashboards are unaffected. It is deliberately append-only — no retention or history maintenance:

- Appends use a `--depth=1 --filter=blob:none --sparse` clone scoped to the target data dir: measured against the live repo, **~4.5s / 89MB** versus ~8min / 4GB. Because the clone is depth=1, this stays fast no matter how large history grows. Push conflicts with concurrent uploads are handled by retrying from a fresh clone.
- Commit metadata for datapoints (author/message/link) comes from the GitHub API, matching what the action recorded; it degrades to bare-sha metadata if the API is unavailable.
- The datapoint entry is passed to jq as a file, never argv: a full CI entry exceeds Linux's 128KB per-argv-element cap (`Argument list too long`).
- Every critical step aborts the upload attempt explicitly (`|| return 1`): the retry loop's `if` suppresses `set -e` inside the function, and a swallowed mid-append failure would otherwise commit and push a truncated `data.js` as a "success".
- `ci3/upload_benchmarks_test` is a self-contained fixture-repo test (run it directly) covering append, new-dir initialization, `MAX_ITEMS` trimming, >128KB entries, and loud failure on an unreachable repo.

An earlier revision of this PR also squashed/pruned old history in-job ("retention maintenance"). That was removed: a merge-queue run showed that pushing rewritten history from a partial clone lazy-fetches promisor objects one at a time (93 minutes, then the connection dropped), and measurement shows ~96% of the repo's weight is the *recent* six months of large `data.js` versions anyway — old-history squashing barely shrinks it and is unnecessary for upload speed.

## Notes

- Dropped behavior from the action: the `alert-threshold` comparison. It was configured with `comment-on-alert: false` / `fail-on-alert: false` at all three sites, so it had no observable effect.
- Pre-existing quirk, preserved: the nightly tag job runs with an empty `BENCH_BRANCH` and writes to `bench/data.js` at the repo top level (updated as recently as today). The script keeps writing there rather than silently changing the destination.
- Follow-up worth considering: `bench/next/data.js` is ~70MB *at the tip* because every datapoint embeds the full metric set (~700KB), which is also why the data repo grows ~25MB/day and the dashboard ships 70MB to every browser. Narrowing the schema is where the real size win is.
