### PR TITLE
feat: add scheduled mainnet pending-slash alert

### DIFF
--- a/.claude/agents/network-logs.md
+++ b/.claude/agents/network-logs.md
@@ -328,6 +328,42 @@ When the user asks for a healthcheck across multiple networks (e.g., "how are al
 
 Use ✅ for healthy, ⚠️ for degraded, ❌ for down/erroring. Follow the table with brief per-network details only if there are issues worth calling out. Remember deployment-specific notes: next-net resets daily (check block height is reasonable for time of day), mainnet runs in fisherman mode (no L1 submissions, `0xf3e591ac` errors are expected).
 
+### 12. Pending Slashes (mainnet fisherman node)
+
+Report the validators that the mainnet fisherman node has queued for slashing, with the reason and the amount. Each pending offense is an INFO log. The node writes it before any on-chain payload or vote. This signal is earlier than the on-chain slash round.
+
+**Scope rules for this recipe:**
+- Query **only** the pending-offense log. Do **not** query votes, ready-to-execute rounds, or executed rounds. Those steps are visible on-chain, so they are out of scope here.
+- Do **not** add a `severity` filter. The pending-offense log is INFO, not WARNING. A `severity>=WARNING` filter returns no results.
+- There is no p2p signal for how many other validators want to slash. The node does not gossip slash intent. The on-chain round vote tally is the only cross-validator count, and it is out of scope for this recipe.
+
+```bash
+gcloud logging read '
+  resource.type="k8s_container"
+  resource.labels.cluster_name="aztec-gke-public"
+  resource.labels.namespace_name="mainnet"
+  resource.labels.pod_name="mainnet-fisherman-aztec-node-0"
+  resource.labels.container_name="aztec"
+  jsonPayload.message=~"Adding pending offense"
+' --limit=200 --format='table[no-heading](timestamp.date("%m-%d %H:%M"), jsonPayload.validator, jsonPayload.offenseType, jsonPayload.amount, jsonPayload.epochOrSlot)' --freshness=13h --project=<project>
+```
+
+Each row is one pending slash: **validator, offense type, amount, epoch or slot**. The `offenseType` field is already a readable name. The `amount` field is the amount that the watcher proposed. The final slash amount uses the configured tiers, so treat the amount as indicative.
+
+**Fail loud (required).** Run the liveness query below first. If the pod wrote no logs in the window, or if the pod is active but the pending-offense query returns no rows, report a **possible log-format drift**. Do not report an all-clear. A silent empty result is the failure mode that hid the July 2026 slashing incident.
+
+```bash
+gcloud logging read '
+  resource.type="k8s_container"
+  resource.labels.cluster_name="aztec-gke-public"
+  resource.labels.namespace_name="mainnet"
+  resource.labels.pod_name="mainnet-fisherman-aztec-node-0"
+  resource.labels.container_name="aztec"
+' --limit=1 --format='table[no-heading](timestamp)' --freshness=13h --project=<project>
+```
+
+**Version note.** The message text `Adding pending offense` is coupled to the running node image. This recipe is validated against v5.0.1. The mainnet image is set at deploy time, so it can change. Re-validate this recipe when mainnet upgrades.
+
 ## Known Noise Patterns
 
 These patterns appear frequently and are usually harmless — exclude or downplay them:

--- a/.github/workflows/slashing-check-mainnet.yml
+++ b/.github/workflows/slashing-check-mainnet.yml
@@ -1,0 +1,42 @@
+name: Slashing Check (mainnet)
+
+# Every 12 hours, query the mainnet fisherman node for pending slash offenses and
+# post them to Slack. This is an internal early-warning alert. It reads logs only.
+# It adds no logs or metrics to the node. Payloads, votes, and executed rounds are
+# out of scope, because they are visible on-chain.
+
+on:
+  schedule:
+    - cron: '0 */12 * * *'
+  workflow_dispatch:
+
+jobs:
+  slashing-check:
+    if: ${{ github.event_name != 'schedule' || github.repository == 'AztecProtocol/aztec-packages' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+
+      - name: Run pending-slash check
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          GH_TOKEN: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
+          CI: "1"
+        run: |
+          PROMPT="Query pending slash offenses on mainnet for the last 12 hours.
+
+          Use the network-logs skill. Follow the 'Pending Slashes (mainnet fisherman node)' recipe in .claude/agents/network-logs.md.
+          Cluster: aztec-gke-public. Namespace: mainnet. Pod: mainnet-fisherman-aztec-node-0. Freshness: 13h.
+
+          Report every pending slash offense that the fisherman node recorded. For each offense, give the validator, the offense type, the amount, and the epoch or slot. Match only the 'Adding pending offense' log. Do not add a severity filter, because the log is INFO. Do not report votes, ready-to-execute rounds, or executed rounds. Those are visible on-chain.
+
+          First, run the liveness query in the recipe. If the pod wrote no logs in the window, or if the pod is active but the offense query returns no rows, report a possible log-format drift. Do not report an all-clear.
+
+          Post the result to #alerts-mainnet via respond_to_user as a table:
+          | Validator | Offense | Amount | Epoch/Slot |
+          If there are no pending offenses and the pod is active, say that clearly."
+
+          ./ci3/slack_notify_with_claudebox_kickoff "#alerts-mainnet" \
+            "Pending-slash check for mainnet (last 12h)" \
+            "$PROMPT"


### PR DESCRIPTION
## Summary

This change adds an internal alert for pending slashes on mainnet. A scheduled workflow runs every 12 hours. It queries the mainnet fisherman node for pending slash offenses. It posts the offenses to the `#alerts-mainnet` Slack channel.

The alert reads logs only. It adds no logs or metrics to the node.

## What the alert reports

For each pending offense, the alert reports one row:

| Field | Source field |
|---|---|
| Validator | `jsonPayload.validator` |
| Offense type | `jsonPayload.offenseType` (readable name) |
| Amount | `jsonPayload.amount` (proposed amount) |
| Epoch or slot | `jsonPayload.epochOrSlot` |

The data comes from the `Adding pending offense` INFO log in the slasher.

## Scope

- The alert reports **pending** offenses only. It does not report votes, ready-to-execute rounds, or executed rounds. Those steps are visible on-chain.
- The alert does not use a `severity` filter. The pending-offense log is INFO, not WARNING. A `severity>=WARNING` filter returns no results.
- The alert does not report a cross-validator intent count. The node does not gossip slash intent over p2p.

## Query target

- Cluster: `aztec-gke-public`
- Namespace: `mainnet`
- Pod: `mainnet-fisherman-aztec-node-0`
- Freshness: 13 hours. The small overlap prevents a gap at the 12-hour boundary.

## Fail-loud behavior

The alert runs a liveness query first. If the pod wrote no logs in the window, or if the pod is active but the offense query returns no rows, the alert reports a possible log-format drift. It does not report an all-clear. A silent empty result is the failure mode that hid the earlier mainnet slashing incident.

## Version note

The `Adding pending offense` message text depends on the running node image. This change is validated against v5.0.1. The mainnet image is set at deploy time, so it can change. Re-validate the recipe when mainnet upgrades.

## Files

| File | Change |
|---|---|
| `.github/workflows/slashing-check-mainnet.yml` | New scheduled workflow. Cron runs every 12 hours. Manual dispatch is also available. |
| `.claude/agents/network-logs.md` | New recipe: "Pending Slashes (mainnet fisherman node)". |

## How to test

1. Open the Actions tab.
2. Run the "Slashing Check (mainnet)" workflow with `workflow_dispatch`.
3. Confirm that a message appears in `#alerts-mainnet`.

Note: the scheduled cron runs from the default branch only. Use manual dispatch to test before this change merges to the default branch.
