### PR TITLE
fix(ci): move nightly bench inclusion sweep to 06:00 UTC

### DIFF
--- a/.github/workflows/nightly-bench-inclusion-sweep.yml
+++ b/.github/workflows/nightly-bench-inclusion-sweep.yml
@@ -9,7 +9,11 @@ name: Nightly Bench Inclusion Sweep
 
 on:
   schedule:
-    - cron: "30 3 * * *"
+    # 06:00 UTC, matching the other nightly consumers (spartan-bench, deploy-next-net).
+    # The nightly git tag + docker image this sweep resolves are produced by the
+    # Nightly Release Tag workflow at 04:00 UTC; running earlier races that job and
+    # fails "Verify source git ref" with "couldn't find remote ref".
+    - cron: "0 6 * * *"
   workflow_dispatch:
     inputs:
       docker_image:


### PR DESCRIPTION
## Problem

The **Nightly Bench Inclusion Sweep** ([failing run](https://github.com/AztecProtocol/aztec-packages/actions/runs/29801774127)) resolves the nightly git tag + docker image for the current day and verifies the tag exists:

```
git fetch --depth 1 origin refs/tags/v6.0.0-nightly.20260721:...
fatal: couldn't find remote ref refs/tags/v6.0.0-nightly.20260721
```

That tag is created by the separate **Nightly Release Tag** workflow at `0 4 * * *` (04:00 UTC), but the sweep was scheduled at `30 3 * * *` (03:30 UTC) — 30 min *before* the tag exists. GitHub's scheduled-run jitter preserves the gap (today the sweep ran at 04:38 UTC, the tag was created at 05:04 UTC), so `Verify source git ref` fails and the downstream `cleanup`/`notify-failure` jobs cascade.

## Fix

Move the sweep to `0 6 * * *` (06:00 UTC), aligning it with the other nightly *consumers* (`nightly-spartan-bench`, `deploy-next-net`) which already run at 06:00 — a 2h margin over the 04:00 tag job.