### PR TITLE
chore: add rpc consumers

### DIFF
--- a/spartan/terraform/deploy-rpc/environments/mainnet/main.tf
+++ b/spartan/terraform/deploy-rpc/environments/mainnet/main.tf
@@ -82,7 +82,9 @@ locals {
     "mainnet-rpc-consumer-client7",
     "mainnet-rpc-consumer-client8",
     "mainnet-rpc-consumer-client9",
-    "mainnet-rpc-consumer-client10"
+    "mainnet-rpc-consumer-client10",
+    "mainnet-rpc-consumer-client11",
+    "mainnet-rpc-consumer-client12"
   ]
 
   consumers = {


### PR DESCRIPTION
Adds mainnet RPC gateway consumers `client11` and `client12`, both unlimited rate (`rate_limit_minute = 0`).