### PR TITLE
chore: add rate-limited testnet rpc client

### DIFF
--- a/spartan/terraform/deploy-rpc/environments/testnet/main.tf
+++ b/spartan/terraform/deploy-rpc/environments/testnet/main.tf
@@ -72,17 +72,30 @@ locals {
     })
   }
 
+  # Consumers listed here get no per-minute cap (rate_limit_minute = 0). Consumers that need a
+  # finite cap go in rate_limited_consumers instead, since this loop hardcodes 0 for every entry.
   consumer_secret_names = [
     "testnet-rpc-consumer-client1"
   ]
 
-  consumers = {
-    for name in local.consumer_secret_names : name => {
-      username                       = name
-      gcp_secret_manager_secret_name = name
-      rate_limit_minute              = 0
+  rate_limited_consumers = {
+    "testnet-rpc-consumer-client2" = {
+      username                       = "testnet-rpc-consumer-client2"
+      gcp_secret_manager_secret_name = "testnet-rpc-consumer-client2"
+      rate_limit_minute              = 3000
     }
   }
+
+  consumers = merge(
+    {
+      for name in local.consumer_secret_names : name => {
+        username                       = name
+        gcp_secret_manager_secret_name = name
+        rate_limit_minute              = 0
+      }
+    },
+    local.rate_limited_consumers
+  )
 }
 
 module "environment" {


### PR DESCRIPTION
Adds `client2` to the testnet RPC consumers with a per-minute rate limit (`rate_limit_minute = 3000`), kept out of the unlimited `consumer_secret_names` loop via a separate `rate_limited_consumers` map.

Secret created and already `terraform apply`-ed against live testnet; the plan was exactly the three expected resources (KongConsumer + ExternalSecret + rate-limiting KongPlugin), `0 to change, 0 to destroy`. Verified live: KongConsumer `PROGRAMMED=True`, ExternalSecret `SecretSynced`, rate-limit plugin `minute=3000, limit_by=consumer, policy=local`.

`policy=local` is per Kong pod (testnet runs a single gateway pod, so the effective cap is 3000/min).