### PR TITLE
fix(bench): handle void worker-wallet returns in inclusion sweep

### DIFF
--- a/yarn-project/end-to-end/src/test-wallet/worker_wallet.test.ts
+++ b/yarn-project/end-to-end/src/test-wallet/worker_wallet.test.ts
@@ -1,0 +1,22 @@
+import type { ContractArtifact } from '@aztec/stdlib/abi';
+import type { ContractInstancePreimage } from '@aztec/stdlib/contract';
+
+import { WorkerWallet } from './worker_wallet.js';
+
+describe('WorkerWallet', () => {
+  // The private constructor spawns a worker; call() only touches the transport client, so we build the
+  // instance directly with a stub client and never start a worker.
+  const walletRespondingWith = (requestResult: unknown): WorkerWallet => {
+    const client = { request: () => Promise.resolve(requestResult) };
+    return Reflect.construct(WorkerWallet, [undefined, client]);
+  };
+
+  // registerContract / registerContractClass return void, which the worker serializes as `undefined`.
+  // Feeding that to JSON.parse throws `"undefined" is not valid JSON` — the crash that failed every
+  // inclusion-sweep bench point during setup.
+  it('resolves a void-returning method when the worker responds with undefined', async () => {
+    const wallet = walletRespondingWith(undefined);
+    await expect(wallet.registerContract({} as ContractInstancePreimage)).resolves.toBeUndefined();
+    await expect(wallet.registerContractClass({} as ContractArtifact)).resolves.toBeUndefined();
+  });
+});

--- a/yarn-project/end-to-end/src/test-wallet/worker_wallet.ts
+++ b/yarn-project/end-to-end/src/test-wallet/worker_wallet.ts
@@ -116,15 +116,17 @@ export class WorkerWallet implements Wallet {
     return wallet;
   }
 
-  private async callRaw(fn: string, ...args: any[]): Promise<string> {
+  private async callRaw(fn: string, ...args: any[]): Promise<string | undefined> {
     const argsJson = jsonStringify(args);
-    return (await this.client.request({ fn, args: argsJson })) as string;
+    return (await this.client.request({ fn, args: argsJson })) as string | undefined;
   }
 
   private async call(fn: string, ...args: any[]): Promise<any> {
     const resultJson = await this.callRaw(fn, ...args);
     const methodSchema = (WorkerWalletSchema as ApiSchema)[fn];
-    return getSchemaReturnType(methodSchema).parseAsync(JSON.parse(resultJson));
+    // Void-returning methods (e.g. registerContract) serialize to `undefined` on the worker side, which
+    // JSON.parse cannot handle; hand it straight to the schema, whose `z.void()` output accepts undefined.
+    return getSchemaReturnType(methodSchema).parseAsync(resultJson === undefined ? undefined : JSON.parse(resultJson));
   }
 
   getChainInfo(): Promise<ChainInfo> {


### PR DESCRIPTION
## Problem

Every point of the [Nightly Bench Inclusion Sweep](https://github.com/AztecProtocol/aztec-packages/actions/runs/29801774127) (1/5/10 TPS) failed identically, ~5ms into the `n_tps.test.ts` body, during `registerSponsoredFPC` setup:

```
SyntaxError: "undefined" is not valid JSON
    at JSON.parse (<anonymous>)
    at WorkerWallet.call (test-wallet/worker_wallet.ts:127)
    at registerSponsoredFPC (fixtures/setup.ts:821)
```

`WorkerWallet.call` unconditionally `JSON.parse`d the worker's transport response. But void-returning methods — `registerContract`, `registerContractClass` (both `output: z.void()` in `WalletSchema`) — return nothing, and `jsonStringify(undefined)` yields `undefined`, which arrives at the client as the JS value `undefined` over the structured-clone transport. `JSON.parse(undefined)` coerces to `JSON.parse("undefined")` and throws.

The crash is in test setup, before any transactions are sent, so it is deterministic and independent of TPS — hence all three points failed the same way. The deployed network and the `6.0.0-nightly.20260721` image are not implicated.

## Fix

Pass an `undefined` response straight to the method's schema (its `z.void()` output accepts `undefined`) instead of `JSON.parse`-ing it, and widen `callRaw`'s return type to `string | undefined`.

## Test

Adds `worker_wallet.test.ts`, which builds a `WorkerWallet` over a stub transport that returns `undefined` and asserts `registerContract` / `registerContractClass` resolve. Verified red/green: against the old code it fails with the exact CI error (`"undefined" is not valid JSON`); with the fix it passes.