### PR TITLE
refactor(aztec-nr): shared no-op sync handler for stateless contracts

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/messages/discovery/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/discovery/mod.nr
@@ -174,6 +174,19 @@ pub unconstrained fn do_sync_state_without_handshake_discovery(
     );
 }
 
+/// A [`CustomSyncHandler`] that skips state synchronization entirely.
+///
+/// For contracts that hold no private state and emit no messages, there is nothing to discover: syncing would only
+/// perform unnecessary RPC calls.
+pub unconstrained fn do_sync_state_no_op(
+    _contract_address: AztecAddress,
+    _compute_note_hash: ComputeNoteHash,
+    _compute_note_nullifier: ComputeNoteNullifier,
+    _process_custom_message: Option<CustomMessageHandler>,
+    _offchain_inbox_sync: Option<OffchainInboxSync>,
+    _scope: AztecAddress,
+) {}
+
 unconstrained fn sync_state_with_secrets(
     contract_address: AztecAddress,
     compute_note_hash: ComputeNoteHash,

--- a/noir-projects/noir-contracts/contracts/account/schnorr_initializerless_account_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/account/schnorr_initializerless_account_contract/src/main.nr
@@ -1,24 +1,6 @@
-use aztec::{
-    macros::{aztec, AztecConfig},
-    messages::{
-        discovery::{ComputeNoteHash, ComputeNoteNullifier, CustomMessageHandler},
-        processing::offchain::OffchainInboxSync,
-    },
-    protocol::address::AztecAddress,
-};
+use aztec::{macros::{aztec, AztecConfig}, messages::discovery::do_sync_state_no_op};
 
-/// Empty override to opt-out of state syncing. This contract does not hold private state,
-/// so runnning the sync process just results in unnecessary RPC calls
-unconstrained fn no_sync(
-    _contract_address: AztecAddress,
-    _compute_note_hash: ComputeNoteHash,
-    _compute_note_nullifier: ComputeNoteNullifier,
-    _process_custom_message: Option<CustomMessageHandler>,
-    _offchain_inbox_sync: Option<OffchainInboxSync>,
-    _scope: AztecAddress,
-) {}
-
-#[aztec(AztecConfig::new().custom_sync_state(crate::no_sync))]
+#[aztec(AztecConfig::new().custom_sync_state(do_sync_state_no_op))]
 pub contract SchnorrInitializerlessAccount {
     use aztec::{
         authwit::{

--- a/noir-projects/noir-contracts/contracts/standard/auth_registry_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/standard/auth_registry_contract/src/main.nr
@@ -1,4 +1,4 @@
-use aztec::macros::aztec;
+use aztec::{macros::{aztec, AztecConfig}, messages::discovery::do_sync_state_no_op};
 
 /// A contract that manages public authentication witnesses (authwits) on the Aztec network.
 ///
@@ -14,7 +14,7 @@ use aztec::macros::aztec;
 /// Note that there is no expiration time enforced on the approved actions in this contract as this can be achieved by
 /// including an expiration timestamp in the `message` (`message_hash` preimage) and having the consumer contract
 /// constrain that value.
-#[aztec]
+#[aztec(AztecConfig::new().custom_sync_state(do_sync_state_no_op))]
 pub contract AuthRegistry {
     use aztec::{
         authwit::auth::{assert_current_call_valid_authwit, compute_authwit_message_hash, IS_VALID_SELECTOR},

--- a/noir-projects/noir-contracts/contracts/standard/multi_call_entrypoint_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/standard/multi_call_entrypoint_contract/src/main.nr
@@ -8,9 +8,9 @@
 //
 // Note that this contract should not be grouped with protocol contracts as it is not part of the protocol. We keep
 // it here for now as it allows us to use hardcoded address.
-use aztec::macros::aztec;
+use aztec::{macros::{aztec, AztecConfig}, messages::discovery::do_sync_state_no_op};
 
-#[aztec]
+#[aztec(AztecConfig::new().custom_sync_state(do_sync_state_no_op))]
 pub contract MultiCallEntrypoint {
     use aztec::{authwit::entrypoint::app::AppPayload, macros::functions::{allow_phase_change, external}};
 

--- a/noir-projects/noir-contracts/contracts/standard/public_checks_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/standard/public_checks_contract/src/main.nr
@@ -1,13 +1,13 @@
 mod test;
 
-use aztec::macros::aztec;
+use aztec::{macros::{aztec, AztecConfig}, messages::discovery::do_sync_state_no_op};
 
 /// The purpose of this contract is to perform a check in public without revealing what contract enqueued the public
 /// call. This can be achieved by enqueueing an `incognito` public call.
 ///
 /// Note that this contract should not be grouped with protocol contracts as it is not part of the protocol. We keep
 /// it here for now as it allows us to use hardcoded address.
-#[aztec]
+#[aztec(AztecConfig::new().custom_sync_state(do_sync_state_no_op))]
 pub contract PublicChecks {
     use aztec::{macros::functions::{external, view}, utils::comparison::compare};
 


### PR DESCRIPTION
## Summary

- AuthRegistry, MultiCallEntrypoint and PublicChecks hold no private state, but used the default `sync_state`, which performs pointless discovery RPC calls and embeds the HandshakeRegistry address in their bytecode.
- Adds a shared `do_sync_state_no_op` handler to aztec-nr and wires it into those three contracts, plus SchnorrInitializerlessAccount, which previously carried its own local copy of the same no-op.
- The pinned standard-contract artifacts are untouched, so shipped artifacts and addresses only change at the next intentional re-pin.