### PR TITLE
feat(ci): auto forward-port v5 merge-train PRs to next

### DIFF
--- a/.github/workflows/auto-port-v5-merge-trains.yml
+++ b/.github/workflows/auto-port-v5-merge-trains.yml
@@ -1,0 +1,25 @@
+name: Auto-label v5 merge-train PRs for forward-port
+
+# Forward-port every PR that lands in a v5 merge-train to public `next` by
+# default. We add the `port-to-next` label when the PR opens; backport.yml acts
+# on it when the PR merges, cherry-picking that single PR onto port-to-next-
+# staging (individual granularity keeps conflicts small). Labelling on open makes
+# the intent visible for the PR's whole life and leaves an opt-out window: remove
+# `port-to-next` before merge for v5-only work such as release-line artifacts.
+#
+# New release lines need their train pattern added below (e.g. merge-train/*-v6).
+on:
+  pull_request_target:
+    types: [opened]
+    branches:
+      - 'merge-train/*-v5'
+
+jobs:
+  label:
+    name: Add port-to-next label
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add port-to-next label
+        env:
+          GH_TOKEN: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
+        run: gh pr edit ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --add-label port-to-next

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -9,18 +9,25 @@ jobs:
     name: Check labels
     runs-on: ubuntu-latest
     outputs:
-      state: ${{ steps.check.outputs.label_check }}
+      state: ${{ steps.check.outputs.state }}
     steps:
+      # The agilepathway label-checker action only supports a single prefix in
+      # prefix_mode, so `any_of: backport-to-,port-to-next` errored out and the
+      # gate never opened (silently breaking both backports and forward-ports).
+      # Check the prefixes directly instead.
       - id: check
-        uses: agilepathway/label-checker@825944377ab3bce1269b38c99b718767e2ca6bbc
-        with:
-          prefix_mode: true
-          any_of: backport-to-,port-to-next
-          repo_token: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
-          allow_failure: true
-      - name: Print status
         shell: bash
-        run: 'echo "Label detection status: ${{ steps.check.outputs.label_check }}"'
+        env:
+          LABELS_JSON: ${{ toJson(github.event.pull_request.labels.*.name) }}
+        run: |
+          echo "Labels: $LABELS_JSON"
+          if echo "$LABELS_JSON" | jq -e 'any(.[]; startswith("backport-to-") or startswith("port-to-next"))' >/dev/null; then
+            echo "Label detection status: success"
+            echo "state=success" >> "$GITHUB_OUTPUT"
+          else
+            echo "Label detection status: failure"
+            echo "state=failure" >> "$GITHUB_OUTPUT"
+          fi
 
   backport:
     needs: [label_checker]

--- a/.github/workflows/port-v5-next-to-next.yml
+++ b/.github/workflows/port-v5-next-to-next.yml
@@ -1,13 +1,16 @@
 name: Port v5-next to next
 
-# Daily forward-port: accumulate everything new from `v5-next` onto the
+# Whole-branch forward-port: accumulate everything new from `v5-next` onto the
 # long-lived `port-v5-next-to-next` branch (merging `next` and `v5-next` into
 # it) and open/update one large PR against `next`. See scripts/port_to_next.sh.
-
+#
+# SUPERSEDED by per-PR forward-porting (auto-port-v5-merge-trains.yml applies the
+# `port-to-next` label to each v5 merge-train PR; backport.yml ports it). Because
+# `next` was cut from a reshaped snapshot of `v5-next`, a whole-branch merge fights
+# ~300 byte-level false conflicts and never converges. The daily schedule is
+# therefore disabled; kept for manual `workflow_dispatch` as an occasional
+# drift-check (its conflicted PR shows what the per-PR path may have missed).
 on:
-  schedule:
-    # Daily at 06:30 UTC.
-    - cron: "30 6 * * *"
   workflow_dispatch:
     inputs:
       source_branch:

--- a/scripts/backport_to_staging.sh
+++ b/scripts/backport_to_staging.sh
@@ -149,6 +149,37 @@ if [[ $CONTINUE_MODE -eq 0 ]]; then
   echo "Merge commit: $MERGE_COMMIT"
   git fetch origin "$MERGE_COMMIT"
 
+  # When forward-porting into next, skip release-line artifacts that are
+  # meaningless on the mainline: release-version bumps, per-release upgrade/deploy
+  # scripts, regenerated-fixture refreshes, and the plumbing commits a release
+  # line creates when it merges its own public snapshot. A PR is skipped only when
+  # its subject marks it as such, or every file it touches is an artifact path.
+  if [[ "$TARGET_BRANCH" == "next" ]]; then
+    EXCLUDE_SUBJECTS='^chore\(release\)|regenerate pinned|re-pin standard contracts|regenerate standard-contract|resolve v[0-9]+ -> v[0-9]+-next|public-v[0-9]+-next merge|refresh pinned'
+    EXCLUDE_GLOBS=('l1-contracts/src/periphery/V*UpgradePayload*' 'l1-contracts/script/deploy/DeployRollupForUpgrade*' 'l1-contracts/*/V*_UPGRADE_RUNBOOK.md' '.github/workflows/*-v*-next.yml')
+    MERGE_SUBJECT=$(git show -s --format=%s "$MERGE_COMMIT")
+    SKIP_ARTIFACT=0
+    if [[ "$MERGE_SUBJECT" =~ $EXCLUDE_SUBJECTS ]]; then
+      SKIP_ARTIFACT=1
+    else
+      ALL_EXCLUDED=1
+      while IFS= read -r f; do
+        [[ -z "$f" ]] && continue
+        matched=0
+        for g in "${EXCLUDE_GLOBS[@]}"; do
+          # shellcheck disable=SC2254
+          case "$f" in $g) matched=1; break ;; esac
+        done
+        [[ $matched -eq 0 ]] && { ALL_EXCLUDED=0; break; }
+      done < <(git diff --no-renames --name-only "${MERGE_COMMIT}^1" "$MERGE_COMMIT")
+      [[ $ALL_EXCLUDED -eq 1 ]] && SKIP_ARTIFACT=1
+    fi
+    if [[ $SKIP_ARTIFACT -eq 1 ]]; then
+      echo "Skipping PR #$PR_NUMBER: release-line artifact, not forward-ported to $TARGET_BRANCH."
+      exit 0
+    fi
+  fi
+
   # Detect if merge commit has multiple parents (merge commit vs squash commit)
   PARENT_COUNT=$(git rev-list --parents -n 1 "$MERGE_COMMIT" | wc -w)
   # First word is the commit itself, remaining are parents
@@ -161,6 +192,15 @@ if [[ $CONTINUE_MODE -eq 0 ]]; then
 
   echo "Cherry-picking $MERGE_COMMIT..."
   if ! git cherry-pick $CHERRY_PICK_ARGS "$MERGE_COMMIT" --no-edit; then
+    # No unmerged paths means the patch applied to nothing: the change is already
+    # present in the target (e.g. a fix that also reached next independently, or
+    # a next->release backport bounced back). Skip it quietly instead of treating
+    # it as a conflict, so auto-forward-porting does not raise false alarms.
+    if [[ -z "$(git diff --name-only --diff-filter=U)" ]]; then
+      git cherry-pick --skip >/dev/null 2>&1 || git reset --hard >/dev/null
+      echo "PR #$PR_NUMBER is already present in $TARGET_BRANCH; nothing to port."
+      exit 0
+    fi
     git cherry-pick --abort 2>/dev/null || true
     echo "Error: Failed to cherry-pick. Fix conflicts manually, then run: ./scripts/backport_to_staging.sh --continue $PR_NUMBER $TARGET_BRANCH" >&2
     exit 1


### PR DESCRIPTION
## Problem

`next` was cut from a reshaped snapshot of `v5-next`, so the daily whole-branch merge (`port-v5-next-to-next.yml`) fights ~300 byte-level false conflicts against `next`'s reshaped history and never converges. Genuinely-new v5 work is a small, recent set, but it drowns in that noise.

## Change

Replace the whole-branch merge with per-PR forward-porting, reusing the existing `port-to-next` → `backport.yml` → `port-to-next-staging` pipeline:

- **`auto-port-v5-merge-trains.yml`** (new): on open, label every PR into a `merge-train/*-v5` branch with `port-to-next`, so `backport.yml` cherry-picks it individually when it merges. Opt out by removing the label before merge.
- **`backport_to_staging.sh`**: skip empty cherry-picks (change already in `next` — e.g. a next→release backport bounced back) instead of reporting a false conflict; and when the target is `next`, skip release-line artifacts (release bumps, per-release upgrade/deploy scripts, regenerated fixtures, v5-merge plumbing).
- **`port-v5-next-to-next.yml`**: disable the superseded daily schedule; keep `workflow_dispatch` as a manual drift-check.

Individual-PR granularity keeps each conflict small (one PR against `next`, resolved by the existing ClaudeBox path) instead of one unreviewable 300-file blob.

New release lines need their train pattern added to the labeler (e.g. `merge-train/*-v6`).