### PR TITLE
chore(fwd-port): #24567 feat(world-state): support prefilled nullifiers in genesis state

### DIFF
--- a/barretenberg/cpp/src/barretenberg/nodejs_module/world_state/world_state.cpp
+++ b/barretenberg/cpp/src/barretenberg/nodejs_module/world_state/world_state.cpp
@@ -1,0 +1,1015 @@
+#include "barretenberg/world_state/world_state.hpp"
+
+#include <algorithm>
+#include <any>
+#include <array>
+#include <cstdint>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <sstream>
+#include <stdexcept>
+#include <sys/types.h>
+#include <unordered_map>
+
+#include "barretenberg/crypto/merkle_tree/hash_path.hpp"
+#include "barretenberg/crypto/merkle_tree/indexed_tree/indexed_leaf.hpp"
+#include "barretenberg/crypto/merkle_tree/response.hpp"
+#include "barretenberg/crypto/merkle_tree/types.hpp"
+#include "barretenberg/ecc/curves/bn254/fr.hpp"
+#include "barretenberg/messaging/header.hpp"
+#include "barretenberg/nodejs_module/util/async_op.hpp"
+#include "barretenberg/nodejs_module/world_state/world_state.hpp"
+#include "barretenberg/nodejs_module/world_state/world_state_message.hpp"
+#include "barretenberg/serialize/msgpack.hpp"
+#include "barretenberg/world_state/fork.hpp"
+#include "barretenberg/world_state/types.hpp"
+#include "napi.h"
+
+using namespace bb::nodejs;
+using namespace bb::world_state;
+using namespace bb::crypto::merkle_tree;
+using namespace bb::messaging;
+
+const uint64_t DEFAULT_MAP_SIZE = 1024UL * 1024;
+
+WorldStateWrapper::WorldStateWrapper(const Napi::CallbackInfo& info)
+    : ObjectWrap(info)
+{
+    uint64_t thread_pool_size = 16;
+    std::string data_dir;
+    std::unordered_map<MerkleTreeId, uint64_t> map_size{
+        { MerkleTreeId::ARCHIVE, DEFAULT_MAP_SIZE },
+        { MerkleTreeId::NULLIFIER_TREE, DEFAULT_MAP_SIZE },
+        { MerkleTreeId::NOTE_HASH_TREE, DEFAULT_MAP_SIZE },
+        { MerkleTreeId::PUBLIC_DATA_TREE, DEFAULT_MAP_SIZE },
+        { MerkleTreeId::L1_TO_L2_MESSAGE_TREE, DEFAULT_MAP_SIZE },
+    };
+    std::unordered_map<MerkleTreeId, uint32_t> tree_height;
+    std::unordered_map<MerkleTreeId, index_t> tree_prefill;
+    std::vector<PublicDataLeafValue> prefilled_public_data;
+    std::vector<bb::fr> prefilled_nullifiers;
+    std::vector<MerkleTreeId> tree_ids{
+        MerkleTreeId::NULLIFIER_TREE,        MerkleTreeId::NOTE_HASH_TREE, MerkleTreeId::PUBLIC_DATA_TREE,
+        MerkleTreeId::L1_TO_L2_MESSAGE_TREE, MerkleTreeId::ARCHIVE,
+    };
+    uint32_t initial_header_generator_point = 0;
+
+    Napi::Env env = info.Env();
+
+    size_t data_dir_index = 0;
+    if (info.Length() > data_dir_index && info[data_dir_index].IsString()) {
+        data_dir = info[data_dir_index].As<Napi::String>();
+    } else {
+        throw Napi::TypeError::New(env, "Directory needs to be a string");
+    }
+
+    size_t tree_height_index = 1;
+    if (info.Length() > tree_height_index && info[tree_height_index].IsObject()) {
+        Napi::Object obj = info[tree_height_index].As<Napi::Object>();
+
+        for (auto tree_id : tree_ids) {
+            if (obj.Has(tree_id)) {
+                tree_height[tree_id] = obj.Get(tree_id).As<Napi::Number>().Uint32Value();
+            }
+        }
+    } else {
+        throw Napi::TypeError::New(env, "Tree heights must be a map");
+    }
+
+    size_t tree_prefill_index = 2;
+    if (info.Length() > tree_prefill_index && info[tree_prefill_index].IsObject()) {
+        Napi::Object obj = info[tree_prefill_index].As<Napi::Object>();
+
+        for (auto tree_id : tree_ids) {
+            if (obj.Has(tree_id)) {
+                tree_prefill[tree_id] = obj.Get(tree_id).As<Napi::Number>().Uint32Value();
+            }
+        }
+    } else {
+        throw Napi::TypeError::New(env, "Tree prefill must be a map");
+    }
+
+    size_t prefilled_public_data_index = 3;
+    if (info.Length() > prefilled_public_data_index && info[prefilled_public_data_index].IsArray()) {
+        Napi::Array arr = info[prefilled_public_data_index].As<Napi::Array>();
+        for (uint32_t i = 0; i < arr.Length(); ++i) {
+            Napi::Array deserialized = arr.Get(i).As<Napi::Array>();
+            if (deserialized.Length() != 2 || !deserialized.Get(uint32_t(0)).IsBuffer() ||
+                !deserialized.Get(uint32_t(1)).IsBuffer()) {
+                throw Napi::TypeError::New(env, "Prefilled public data value must be a buffer array of size 2");
+            }
+            Napi::Buffer<uint8_t> slot_buf = deserialized.Get(uint32_t(0)).As<Napi::Buffer<uint8_t>>();
+            Napi::Buffer<uint8_t> value_buf = deserialized.Get(uint32_t(1)).As<Napi::Buffer<uint8_t>>();
+            uint256_t slot = 0;
+            uint256_t value = 0;
+            for (size_t j = 0; j < 32; ++j) {
+                slot = (slot << 8) | slot_buf[j];
+                value = (value << 8) | value_buf[j];
+            }
+            prefilled_public_data.push_back(PublicDataLeafValue(slot, value));
+        }
+    } else {
+        throw Napi::TypeError::New(env, "Prefilled public data must be an array");
+    }
+
+    size_t prefilled_nullifiers_index = 4;
+    if (info.Length() > prefilled_nullifiers_index && info[prefilled_nullifiers_index].IsArray()) {
+        Napi::Array arr = info[prefilled_nullifiers_index].As<Napi::Array>();
+        for (uint32_t i = 0; i < arr.Length(); ++i) {
+            if (!arr.Get(i).IsBuffer()) {
+                throw Napi::TypeError::New(env, "Prefilled nullifier value must be a buffer");
+            }
+            Napi::Buffer<uint8_t> nullifier_buf = arr.Get(i).As<Napi::Buffer<uint8_t>>();
+            if (nullifier_buf.Length() != 32) {
+                throw Napi::TypeError::New(env, "Prefilled nullifier value must be a 32-byte buffer");
+            }
+            uint256_t nullifier = 0;
+            for (size_t j = 0; j < 32; ++j) {
+                nullifier = (nullifier << 8) | nullifier_buf[j];
+            }
+            prefilled_nullifiers.emplace_back(nullifier);
+        }
+    } else {
+        throw Napi::TypeError::New(env, "Prefilled nullifiers must be an array");
+    }
+
+    size_t initial_header_generator_point_index = 5;
+    if (info.Length() > initial_header_generator_point_index && info[initial_header_generator_point_index].IsNumber()) {
+        initial_header_generator_point = info[initial_header_generator_point_index].As<Napi::Number>().Uint32Value();
+    } else {
+        throw Napi::TypeError::New(env, "Header generator point needs to be a number");
+    }
+
+    uint64_t genesis_timestamp = 0;
+    size_t genesis_timestamp_index = 6;
+    if (info.Length() > genesis_timestamp_index) {
+        if (info[genesis_timestamp_index].IsNumber()) {
+            genesis_timestamp = static_cast<uint64_t>(info[genesis_timestamp_index].As<Napi::Number>().Int64Value());
+        } else {
+            throw Napi::TypeError::New(env, "Genesis timestamp needs to be a number");
+        }
+    }
+
+    // optional parameters
+    size_t map_size_index = 7;
+    if (info.Length() > map_size_index) {
+        if (info[map_size_index].IsObject()) {
+            Napi::Object obj = info[map_size_index].As<Napi::Object>();
+
+            for (auto tree_id : tree_ids) {
+                if (obj.Has(tree_id)) {
+                    // Int64Value is the widest integer accessor in N-API (no Uint64Value exists)
+                    int64_t val = obj.Get(tree_id).As<Napi::Number>().Int64Value();
+                    if (val <= 0) {
+                        throw Napi::TypeError::New(env, "Map size must be a positive number");
+                    }
+                    map_size[tree_id] = static_cast<uint64_t>(val);
+                }
+            }
+        } else if (info[map_size_index].IsNumber()) {
+            // Int64Value is the widest integer accessor in N-API (no Uint64Value exists)
+            int64_t val = info[map_size_index].As<Napi::Number>().Int64Value();
+            if (val <= 0) {
+                throw Napi::TypeError::New(env, "Map size must be a positive number");
+            }
+            uint64_t size = static_cast<uint64_t>(val);
+            for (auto tree_id : tree_ids) {
+                map_size[tree_id] = size;
+            }
+        } else {
+            throw Napi::TypeError::New(env, "Map size must be a number or an object");
+        }
+    }
+
+    size_t thread_pool_size_index = 8;
+    if (info.Length() > thread_pool_size_index) {
+        if (!info[thread_pool_size_index].IsNumber()) {
+            throw Napi::TypeError::New(env, "Thread pool size must be a number");
+        }
+
+        thread_pool_size = info[thread_pool_size_index].As<Napi::Number>().Uint32Value();
+    }
+
+    // `ephemeral` opens each underlying LMDB env with `MDB_NOSYNC | MDB_NOMETASYNC` —
+    // commits never block on fsync, files stay sparse, and a crash mid-write yields an
+    // unrecoverable env. Intended for throwaway scratch state (TXE test sessions).
+    bool ephemeral = false;
+    size_t ephemeral_index = 9;
+    if (info.Length() > ephemeral_index) {
+        if (!info[ephemeral_index].IsBoolean()) {
+            throw Napi::TypeError::New(env, "Ephemeral flag must be a boolean");
+        }
+        ephemeral = info[ephemeral_index].As<Napi::Boolean>().Value();
+    }
+
+    _ws = std::make_unique<WorldState>(thread_pool_size,
+                                       data_dir,
+                                       map_size,
+                                       tree_height,
+                                       tree_prefill,
+                                       prefilled_public_data,
+                                       prefilled_nullifiers,
+                                       initial_header_generator_point,
+                                       genesis_timestamp,
+                                       ephemeral);
+
+    _dispatcher.register_target(
+        WorldStateMessageType::GET_TREE_INFO,
+        [this](msgpack::object& obj, msgpack::sbuffer& buffer) { return get_tree_info(obj, buffer); });
+
+    _dispatcher.register_target(
+        WorldStateMessageType::GET_STATE_REFERENCE,
+        [this](msgpack::object& obj, msgpack::sbuffer& buffer) { return get_state_reference(obj, buffer); });
+
+    _dispatcher.register_target(
+        WorldStateMessageType::GET_INITIAL_STATE_REFERENCE,
+        [this](msgpack::object& obj, msgpack::sbuffer& buffer) { return get_initial_state_reference(obj, buffer); });
+
+    _dispatcher.register_target(
+        WorldStateMessageType::GET_LEAF_VALUE,
+        [this](msgpack::object& obj, msgpack::sbuffer& buffer) { return get_leaf_value(obj, buffer); });
+
+    _dispatcher.register_target(
+        WorldStateMessageType::GET_LEAF_PREIMAGE,
+        [this](msgpack::object& obj, msgpack::sbuffer& buffer) { return get_leaf_preimage(obj, buffer); });
+
+    _dispatcher.register_target(
+        WorldStateMessageType::GET_SIBLING_PATH,
+        [this](msgpack::object& obj, msgpack::sbuffer& buffer) { return get_sibling_path(obj, buffer); });
+
+    _dispatcher.register_target(WorldStateMessageType::GET_BLOCK_NUMBERS_FOR_LEAF_INDICES,
+                                [this](msgpack::object& obj, msgpack::sbuffer& buffer) {
+                                    return get_block_numbers_for_leaf_indices(obj, buffer);
+                                });
+
+    _dispatcher.register_target(
+        WorldStateMessageType::FIND_LEAF_INDICES,
+        [this](msgpack::object& obj, msgpack::sbuffer& buffer) { return find_leaf_indices(obj, buffer); });
+
+    _dispatcher.register_target(
+        WorldStateMessageType::FIND_SIBLING_PATHS,
+        [this](msgpack::object& obj, msgpack::sbuffer& buffer) { return find_sibling_paths(obj, buffer); });
+
+    _dispatcher.register_target(
+        WorldStateMessageType::FIND_LOW_LEAF,
+        [this](msgpack::object& obj, msgpack::sbuffer& buffer) { return find_low_leaf(obj, buffer); });
+
+    _dispatcher.register_target(
+        WorldStateMessageType::APPEND_LEAVES,
+        [this](msgpack::object& obj, msgpack::sbuffer& buffer) { return append_leaves(obj, buffer); });
+
+    _dispatcher.register_target(
+        WorldStateMessageType::BATCH_INSERT,
+        [this](msgpack::object& obj, msgpack::sbuffer& buffer) { return batch_insert(obj, buffer); });
+
+    _dispatcher.register_target(
+        WorldStateMessageType::SEQUENTIAL_INSERT,
+        [this](msgpack::object& obj, msgpack::sbuffer& buffer) { return sequential_insert(obj, buffer); });
+
+    _dispatcher.register_target(
+        WorldStateMessageType::UPDATE_ARCHIVE,
+        [this](msgpack::object& obj, msgpack::sbuffer& buffer) { return update_archive(obj, buffer); });
+
+    _dispatcher.register_target(WorldStateMessageType::COMMIT,
+                                [this](msgpack::object& obj, msgpack::sbuffer& buffer) { return commit(obj, buffer); });
+
+    _dispatcher.register_target(
+        WorldStateMessageType::ROLLBACK,
+        [this](msgpack::object& obj, msgpack::sbuffer& buffer) { return rollback(obj, buffer); });
+
+    _dispatcher.register_target(
+        WorldStateMessageType::SYNC_BLOCK,
+        [this](msgpack::object& obj, msgpack::sbuffer& buffer) { return sync_block(obj, buffer); });
+
+    _dispatcher.register_target(
+        WorldStateMessageType::CREATE_FORK,
+        [this](msgpack::object& obj, msgpack::sbuffer& buffer) { return create_fork(obj, buffer); });
+
+    _dispatcher.register_target(
+        WorldStateMessageType::DELETE_FORK,
+        [this](msgpack::object& obj, msgpack::sbuffer& buffer) { return delete_fork(obj, buffer); });
+
+    _dispatcher.register_target(
+        WorldStateMessageType::FINALIZE_BLOCKS,
+        [this](msgpack::object& obj, msgpack::sbuffer& buffer) { return set_finalized(obj, buffer); });
+
+    _dispatcher.register_target(WorldStateMessageType::UNWIND_BLOCKS,
+                                [this](msgpack::object& obj, msgpack::sbuffer& buffer) { return unwind(obj, buffer); });
+
+    _dispatcher.register_target(
+        WorldStateMessageType::REMOVE_HISTORICAL_BLOCKS,
+        [this](msgpack::object& obj, msgpack::sbuffer& buffer) { return remove_historical(obj, buffer); });
+
+    _dispatcher.register_target(
+        WorldStateMessageType::GET_STATUS,
+        [this](msgpack::object& obj, msgpack::sbuffer& buffer) { return get_status(obj, buffer); });
+
+    _dispatcher.register_target(WorldStateMessageType::CLOSE,
+                                [this](msgpack::object& obj, msgpack::sbuffer& buffer) { return close(obj, buffer); });
+
+    _dispatcher.register_target(
+        WorldStateMessageType::CREATE_CHECKPOINT,
+        [this](msgpack::object& obj, msgpack::sbuffer& buffer) { return checkpoint(obj, buffer); });
+
+    _dispatcher.register_target(
+        WorldStateMessageType::COMMIT_CHECKPOINT,
+        [this](msgpack::object& obj, msgpack::sbuffer& buffer) { return commit_checkpoint(obj, buffer); });
+
+    _dispatcher.register_target(
+        WorldStateMessageType::REVERT_CHECKPOINT,
+        [this](msgpack::object& obj, msgpack::sbuffer& buffer) { return revert_checkpoint(obj, buffer); });
+
+    _dispatcher.register_target(
+        WorldStateMessageType::COMMIT_ALL_CHECKPOINTS,
+        [this](msgpack::object& obj, msgpack::sbuffer& buffer) { return commit_all_checkpoints_to(obj, buffer); });
+
+    _dispatcher.register_target(
+        WorldStateMessageType::REVERT_ALL_CHECKPOINTS,
+        [this](msgpack::object& obj, msgpack::sbuffer& buffer) { return revert_all_checkpoints_to(obj, buffer); });
+
+    _dispatcher.register_target(
+        WorldStateMessageType::COPY_STORES,
+        [this](msgpack::object& obj, msgpack::sbuffer& buffer) { return copy_stores(obj, buffer); });
+}
+
+Napi::Value WorldStateWrapper::call(const Napi::CallbackInfo& info)
+{
+    Napi::Env env = info.Env();
+    // keep this in a shared pointer so that AsyncOperation can resolve/reject the promise once the execution is
+    // complete on an separate thread
+    auto deferred = std::make_shared<Napi::Promise::Deferred>(env);
+
+    if (info.Length() < 1) {
+        deferred->Reject(Napi::TypeError::New(env, "Wrong number of arguments").Value());
+    } else if (!info[0].IsBuffer()) {
+        deferred->Reject(Napi::TypeError::New(env, "Argument must be a buffer").Value());
+    } else if (!_ws) {
+        deferred->Reject(Napi::TypeError::New(env, "World state has been closed").Value());
+    } else {
+        auto buffer = info[0].As<Napi::Buffer<char>>();
+        size_t length = buffer.Length();
+        // we mustn't access the Napi::Env outside of this top-level function
+        // so copy the data to a variable we own
+        // and make it a shared pointer so that it doesn't get destroyed as soon as we exit this code block
+        auto data = std::make_shared<std::vector<char>>(length);
+        std::copy_n(buffer.Data(), length, data->data());
+
+        auto* op = new AsyncOperation(env, deferred, [=, this](msgpack::sbuffer& buf) {
+            msgpack::object_handle obj_handle = msgpack::unpack(data->data(), length);
+            msgpack::object obj = obj_handle.get();
+            _dispatcher.on_new_data(obj, buf);
+        });
+
+        // Napi is now responsible for destroying this object
+        op->Queue();
+    }
+
+    return deferred->Promise();
+}
+
+Napi::Value WorldStateWrapper::getHandle(const Napi::CallbackInfo& info)
+{
+    Napi::Env env = info.Env();
+
+    if (!_ws) {
+        throw Napi::Error::New(env, "World state has been closed");
+    }
+
+    // Return a NAPI External that wraps the raw WorldState pointer
+    // This allows other NAPI functions to access the WorldState instance
+    return Napi::External<WorldState>::New(env, _ws.get());
+}
+
+bool WorldStateWrapper::get_tree_info(msgpack::object& obj, msgpack::sbuffer& buffer) const
+{
+    TypedMessage<GetTreeInfoRequest> request;
+    obj.convert(request);
+    auto info = _ws->get_tree_info(request.value.revision, request.value.treeId);
+
+    MsgHeader header(request.header.messageId);
+    messaging::TypedMessage<GetTreeInfoResponse> resp_msg(
+        WorldStateMessageType::GET_TREE_INFO,
+        header,
+        { request.value.treeId, info.meta.root, info.meta.size, info.meta.depth });
+
+    msgpack::pack(buffer, resp_msg);
+
+    return true;
+}
+
+bool WorldStateWrapper::get_state_reference(msgpack::object& obj, msgpack::sbuffer& buffer) const
+{
+    TypedMessage<GetStateReferenceRequest> request;
+    obj.convert(request);
+    auto state = _ws->get_state_reference(request.value.revision);
+
+    MsgHeader header(request.header.messageId);
+    messaging::TypedMessage<GetStateReferenceResponse> resp_msg(
+        WorldStateMessageType::GET_STATE_REFERENCE, header, { state });
+
+    msgpack::pack(buffer, resp_msg);
+
+    return true;
+}
+
+bool WorldStateWrapper::get_initial_state_reference(msgpack::object& obj, msgpack::sbuffer& buffer) const
+{
+    HeaderOnlyMessage request;
+    obj.convert(request);
+    auto state = _ws->get_initial_state_reference();
+
+    MsgHeader header(request.header.messageId);
+    messaging::TypedMessage<GetInitialStateReferenceResponse> resp_msg(
+        WorldStateMessageType::GET_INITIAL_STATE_REFERENCE, header, { state });
+
+    msgpack::pack(buffer, resp_msg);
+
+    return true;
+}
+
+bool WorldStateWrapper::get_leaf_value(msgpack::object& obj, msgpack::sbuffer& buffer) const
+{
+    TypedMessage<GetLeafValueRequest> request;
+    obj.convert(request);
+
+    switch (request.value.treeId) {
+    case MerkleTreeId::NOTE_HASH_TREE:
+    case MerkleTreeId::L1_TO_L2_MESSAGE_TREE:
+    case MerkleTreeId::ARCHIVE: {
+        auto leaf = _ws->get_leaf<bb::fr>(request.value.revision, request.value.treeId, request.value.leafIndex);
+
+        MsgHeader header(request.header.messageId);
+        messaging::TypedMessage<std::optional<bb::fr>> resp_msg(WorldStateMessageType::GET_LEAF_VALUE, header, leaf);
+        msgpack::pack(buffer, resp_msg);
+        break;
+    }
+
+    case MerkleTreeId::PUBLIC_DATA_TREE: {
+        auto leaf = _ws->get_leaf<crypto::merkle_tree::PublicDataLeafValue>(
+            request.value.revision, request.value.treeId, request.value.leafIndex);
+        MsgHeader header(request.header.messageId);
+        messaging::TypedMessage<std::optional<PublicDataLeafValue>> resp_msg(
+            WorldStateMessageType::GET_LEAF_VALUE, header, leaf);
+        msgpack::pack(buffer, resp_msg);
+        break;
+    }
+
+    case MerkleTreeId::NULLIFIER_TREE: {
+        auto leaf = _ws->get_leaf<crypto::merkle_tree::NullifierLeafValue>(
+            request.value.revision, request.value.treeId, request.value.leafIndex);
+        MsgHeader header(request.header.messageId);
+        messaging::TypedMessage<std::optional<NullifierLeafValue>> resp_msg(
+            WorldStateMessageType::GET_LEAF_VALUE, header, leaf);
+        msgpack::pack(buffer, resp_msg);
+        break;
+    }
+
+    default:
+        throw std::runtime_error("Unsupported tree type");
+    }
+
+    return true;
+}
+
+bool WorldStateWrapper::get_leaf_preimage(msgpack::object& obj, msgpack::sbuffer& buffer) const
+{
+    TypedMessage<GetLeafPreimageRequest> request;
+    obj.convert(request);
+
+    MsgHeader header(request.header.messageId);
+
+    switch (request.value.treeId) {
+    case MerkleTreeId::NULLIFIER_TREE: {
+        auto leaf = _ws->get_indexed_leaf<NullifierLeafValue>(
+            request.value.revision, request.value.treeId, request.value.leafIndex);
+        messaging::TypedMessage<std::optional<IndexedLeaf<NullifierLeafValue>>> resp_msg(
+            WorldStateMessageType::GET_LEAF_PREIMAGE, header, leaf);
+        msgpack::pack(buffer, resp_msg);
+        break;
+    }
+
+    case MerkleTreeId::PUBLIC_DATA_TREE: {
+        auto leaf = _ws->get_indexed_leaf<PublicDataLeafValue>(
+            request.value.revision, request.value.treeId, request.value.leafIndex);
+
+        messaging::TypedMessage<std::optional<IndexedLeaf<PublicDataLeafValue>>> resp_msg(
+            WorldStateMessageType::GET_LEAF_PREIMAGE, header, leaf);
+        msgpack::pack(buffer, resp_msg);
+        break;
+    }
+
+    default:
+        throw std::runtime_error("Unsupported tree type");
+    }
+
+    return true;
+}
+
+bool WorldStateWrapper::get_sibling_path(msgpack::object& obj, msgpack::sbuffer& buffer) const
+{
+    TypedMessage<GetSiblingPathRequest> request;
+    obj.convert(request);
+
+    fr_sibling_path path = _ws->get_sibling_path(request.value.revision, request.value.treeId, request.value.leafIndex);
+
+    MsgHeader header(request.header.messageId);
+    messaging::TypedMessage<fr_sibling_path> resp_msg(WorldStateMessageType::GET_SIBLING_PATH, header, path);
+
+    msgpack::pack(buffer, resp_msg);
+
+    return true;
+}
+
+bool WorldStateWrapper::get_block_numbers_for_leaf_indices(msgpack::object& obj, msgpack::sbuffer& buffer) const
+{
+    TypedMessage<GetBlockNumbersForLeafIndicesRequest> request;
+    obj.convert(request);
+
+    GetBlockNumbersForLeafIndicesResponse response;
+    _ws->get_block_numbers_for_leaf_indices(
+        request.value.revision, request.value.treeId, request.value.leafIndices, response.blockNumbers);
+
+    MsgHeader header(request.header.messageId);
+    messaging::TypedMessage<GetBlockNumbersForLeafIndicesResponse> resp_msg(
+        WorldStateMessageType::GET_BLOCK_NUMBERS_FOR_LEAF_INDICES, header, response);
+
+    msgpack::pack(buffer, resp_msg);
+
+    return true;
+}
+
+bool WorldStateWrapper::find_leaf_indices(msgpack::object& obj, msgpack::sbuffer& buffer) const
+{
+    TypedMessage<TreeIdAndRevisionRequest> request;
+    obj.convert(request);
+
+    FindLeafIndicesResponse response;
+
+    switch (request.value.treeId) {
+    case MerkleTreeId::NOTE_HASH_TREE:
+    case MerkleTreeId::L1_TO_L2_MESSAGE_TREE:
+    case MerkleTreeId::ARCHIVE: {
+        TypedMessage<FindLeafIndicesRequest<bb::fr>> r1;
+        obj.convert(r1);
+        _ws->find_leaf_indices<bb::fr>(
+            request.value.revision, request.value.treeId, r1.value.leaves, response.indices, r1.value.startIndex);
+        break;
+    }
+
+    case MerkleTreeId::PUBLIC_DATA_TREE: {
+        TypedMessage<FindLeafIndicesRequest<crypto::merkle_tree::PublicDataLeafValue>> r2;
+        obj.convert(r2);
+        _ws->find_leaf_indices<PublicDataLeafValue>(
+            request.value.revision, request.value.treeId, r2.value.leaves, response.indices, r2.value.startIndex);
+        break;
+    }
+    case MerkleTreeId::NULLIFIER_TREE: {
+        TypedMessage<FindLeafIndicesRequest<crypto::merkle_tree::NullifierLeafValue>> r3;
+        obj.convert(r3);
+        _ws->find_leaf_indices<NullifierLeafValue>(
+            request.value.revision, request.value.treeId, r3.value.leaves, response.indices, r3.value.startIndex);
+        break;
+    }
+    default:
+        throw std::runtime_error("Unsupported tree type");
+    }
+
+    MsgHeader header(request.header.messageId);
+    messaging::TypedMessage<FindLeafIndicesResponse> resp_msg(
+        WorldStateMessageType::FIND_LEAF_INDICES, header, response);
+    msgpack::pack(buffer, resp_msg);
+
+    return true;
+}
+
+bool WorldStateWrapper::find_sibling_paths(msgpack::object& obj, msgpack::sbuffer& buffer) const
+{
+    TypedMessage<TreeIdAndRevisionRequest> request;
+    obj.convert(request);
+
+    FindLeafPathsResponse response;
+
+    switch (request.value.treeId) {
+    case MerkleTreeId::NOTE_HASH_TREE:
+    case MerkleTreeId::L1_TO_L2_MESSAGE_TREE:
+    case MerkleTreeId::ARCHIVE: {
+        TypedMessage<FindLeafPathsRequest<bb::fr>> r1;
+        obj.convert(r1);
+        _ws->find_sibling_paths<bb::fr>(request.value.revision, request.value.treeId, r1.value.leaves, response.paths);
+        break;
+    }
+
+    case MerkleTreeId::PUBLIC_DATA_TREE: {
+        TypedMessage<FindLeafPathsRequest<crypto::merkle_tree::PublicDataLeafValue>> r2;
+        obj.convert(r2);
+        _ws->find_sibling_paths<PublicDataLeafValue>(
+            request.value.revision, request.value.treeId, r2.value.leaves, response.paths);
+        break;
+    }
+    case MerkleTreeId::NULLIFIER_TREE: {
+        TypedMessage<FindLeafPathsRequest<crypto::merkle_tree::NullifierLeafValue>> r3;
+        obj.convert(r3);
+        _ws->find_sibling_paths<NullifierLeafValue>(
+            request.value.revision, request.value.treeId, r3.value.leaves, response.paths);
+        break;
+    }
+    default:
+        throw std::runtime_error("Unsupported tree type");
+    }
+
+    MsgHeader header(request.header.messageId);
+    messaging::TypedMessage<FindLeafPathsResponse> resp_msg(
+        WorldStateMessageType::FIND_SIBLING_PATHS, header, response);
+    msgpack::pack(buffer, resp_msg);
+
+    return true;
+}
+
+bool WorldStateWrapper::find_low_leaf(msgpack::object& obj, msgpack::sbuffer& buffer) const
+{
+    TypedMessage<FindLowLeafRequest> request;
+    obj.convert(request);
+
+    GetLowIndexedLeafResponse low_leaf_info =
+        _ws->find_low_leaf_index(request.value.revision, request.value.treeId, request.value.key);
+
+    MsgHeader header(request.header.messageId);
+    TypedMessage<FindLowLeafResponse> response(
+        WorldStateMessageType::FIND_LOW_LEAF, header, { low_leaf_info.is_already_present, low_leaf_info.index });
+    msgpack::pack(buffer, response);
+
+    return true;
+}
+
+bool WorldStateWrapper::append_leaves(msgpack::object& obj, msgpack::sbuffer& buf)
+{
+    TypedMessage<TreeIdOnlyRequest> request;
+    obj.convert(request);
+
+    switch (request.value.treeId) {
+    case MerkleTreeId::NOTE_HASH_TREE:
+    case MerkleTreeId::L1_TO_L2_MESSAGE_TREE:
+    case MerkleTreeId::ARCHIVE: {
+        TypedMessage<AppendLeavesRequest<bb::fr>> r1;
+        obj.convert(r1);
+        _ws->append_leaves<bb::fr>(r1.value.treeId, r1.value.leaves, r1.value.forkId);
+        break;
+    }
+    case MerkleTreeId::PUBLIC_DATA_TREE: {
+        TypedMessage<AppendLeavesRequest<crypto::merkle_tree::PublicDataLeafValue>> r2;
+        obj.convert(r2);
+        _ws->append_leaves<crypto::merkle_tree::PublicDataLeafValue>(r2.value.treeId, r2.value.leaves, r2.value.forkId);
+        break;
+    }
+    case MerkleTreeId::NULLIFIER_TREE: {
+        TypedMessage<AppendLeavesRequest<crypto::merkle_tree::NullifierLeafValue>> r3;
+        obj.convert(r3);
+        _ws->append_leaves<crypto::merkle_tree::NullifierLeafValue>(r3.value.treeId, r3.value.leaves, r3.value.forkId);
+        break;
+    }
+    default:
+        throw std::runtime_error("Unsupported tree type");
+    }
+
+    MsgHeader header(request.header.messageId);
+    messaging::TypedMessage<EmptyResponse> resp_msg(WorldStateMessageType::APPEND_LEAVES, header, {});
+    msgpack::pack(buf, resp_msg);
+
+    return true;
+}
+
+bool WorldStateWrapper::batch_insert(msgpack::object& obj, msgpack::sbuffer& buffer)
+{
+    TypedMessage<TreeIdOnlyRequest> request;
+    obj.convert(request);
+
+    switch (request.value.treeId) {
+    case MerkleTreeId::PUBLIC_DATA_TREE: {
+        TypedMessage<BatchInsertRequest<PublicDataLeafValue>> r1;
+        obj.convert(r1);
+        auto result = _ws->batch_insert_indexed_leaves<crypto::merkle_tree::PublicDataLeafValue>(
+            request.value.treeId, r1.value.leaves, r1.value.subtreeDepth, r1.value.forkId);
+        MsgHeader header(request.header.messageId);
+        messaging::TypedMessage<BatchInsertionResult<PublicDataLeafValue>> resp_msg(
+            WorldStateMessageType::BATCH_INSERT, header, result);
+        msgpack::pack(buffer, resp_msg);
+
+        break;
+    }
+    case MerkleTreeId::NULLIFIER_TREE: {
+        TypedMessage<BatchInsertRequest<NullifierLeafValue>> r2;
+        obj.convert(r2);
+        auto result = _ws->batch_insert_indexed_leaves<crypto::merkle_tree::NullifierLeafValue>(
+            request.value.treeId, r2.value.leaves, r2.value.subtreeDepth, r2.value.forkId);
+        MsgHeader header(request.header.messageId);
+        messaging::TypedMessage<BatchInsertionResult<NullifierLeafValue>> resp_msg(
+            WorldStateMessageType::BATCH_INSERT, header, result);
+        msgpack::pack(buffer, resp_msg);
+        break;
+    }
+    default:
+        throw std::runtime_error("Unsupported tree type");
+    }
+
+    return true;
+}
+
+bool WorldStateWrapper::sequential_insert(msgpack::object& obj, msgpack::sbuffer& buffer)
+{
+    TypedMessage<TreeIdOnlyRequest> request;
+    obj.convert(request);
+
+    switch (request.value.treeId) {
+    case MerkleTreeId::PUBLIC_DATA_TREE: {
+        TypedMessage<InsertRequest<PublicDataLeafValue>> r1;
+        obj.convert(r1);
+        auto result = _ws->insert_indexed_leaves<crypto::merkle_tree::PublicDataLeafValue>(
+            request.value.treeId, r1.value.leaves, r1.value.forkId);
+        MsgHeader header(request.header.messageId);
+        messaging::TypedMessage<SequentialInsertionResult<PublicDataLeafValue>> resp_msg(
+            WorldStateMessageType::SEQUENTIAL_INSERT, header, result);
+        msgpack::pack(buffer, resp_msg);
+
+        break;
+    }
+    case MerkleTreeId::NULLIFIER_TREE: {
+        TypedMessage<InsertRequest<NullifierLeafValue>> r2;
+        obj.convert(r2);
+        auto result = _ws->insert_indexed_leaves<crypto::merkle_tree::NullifierLeafValue>(
+            request.value.treeId, r2.value.leaves, r2.value.forkId);
+        MsgHeader header(request.header.messageId);
+        messaging::TypedMessage<SequentialInsertionResult<NullifierLeafValue>> resp_msg(
+            WorldStateMessageType::SEQUENTIAL_INSERT, header, result);
+        msgpack::pack(buffer, resp_msg);
+        break;
+    }
+    default:
+        throw std::runtime_error("Unsupported tree type");
+    }
+
+    return true;
+}
+
+bool WorldStateWrapper::update_archive(msgpack::object& obj, msgpack::sbuffer& buf)
+{
+    TypedMessage<UpdateArchiveRequest> request;
+    obj.convert(request);
+
+    _ws->update_archive(request.value.blockStateRef, request.value.blockHeaderHash, request.value.forkId);
+
+    MsgHeader header(request.header.messageId);
+    messaging::TypedMessage<EmptyResponse> resp_msg(WorldStateMessageType::UPDATE_ARCHIVE, header, {});
+    msgpack::pack(buf, resp_msg);
+
+    return true;
+}
+
+bool WorldStateWrapper::commit(msgpack::object& obj, msgpack::sbuffer& buf)
+{
+    HeaderOnlyMessage request;
+    obj.convert(request);
+
+    WorldStateStatusFull status;
+    _ws->commit(status);
+
+    MsgHeader header(request.header.messageId);
+    messaging::TypedMessage<WorldStateStatusFull> resp_msg(WorldStateMessageType::COMMIT, header, { status });
+    msgpack::pack(buf, resp_msg);
+
+    return true;
+}
+
+bool WorldStateWrapper::rollback(msgpack::object& obj, msgpack::sbuffer& buf)
+{
+    HeaderOnlyMessage request;
+    obj.convert(request);
+
+    _ws->rollback();
+
+    MsgHeader header(request.header.messageId);
+    messaging::TypedMessage<EmptyResponse> resp_msg(WorldStateMessageType::ROLLBACK, header, {});
+    msgpack::pack(buf, resp_msg);
+
+    return true;
+}
+
+bool WorldStateWrapper::sync_block(msgpack::object& obj, msgpack::sbuffer& buf)
+{
+    TypedMessage<SyncBlockRequest> request;
+    obj.convert(request);
+
+    WorldStateStatusFull status = _ws->sync_block(request.value.blockStateRef,
+                                                  request.value.blockHeaderHash,
+                                                  request.value.paddedNoteHashes,
+                                                  request.value.paddedL1ToL2Messages,
+                                                  request.value.paddedNullifiers,
+                                                  request.value.publicDataWrites,
+                                                  request.value.expectedArchiveRoot,
+                                                  request.value.expectedPreviousArchiveRoot);
+
+    MsgHeader header(request.header.messageId);
+    messaging::TypedMessage<WorldStateStatusFull> resp_msg(WorldStateMessageType::SYNC_BLOCK, header, { status });
+    msgpack::pack(buf, resp_msg);
+
+    return true;
+}
+
+bool WorldStateWrapper::create_fork(msgpack::object& obj, msgpack::sbuffer& buf)
+{
+    TypedMessage<CreateForkRequest> request;
+    obj.convert(request);
+
+    std::optional<block_number_t> blockNumber =
+        request.value.latest ? std::nullopt : std::optional<block_number_t>(request.value.blockNumber);
+
+    uint64_t forkId = _ws->create_fork(blockNumber);
+
+    MsgHeader header(request.header.messageId);
+    messaging::TypedMessage<CreateForkResponse> resp_msg(WorldStateMessageType::CREATE_FORK, header, { forkId });
+    msgpack::pack(buf, resp_msg);
+
+    return true;
+}
+
+bool WorldStateWrapper::delete_fork(msgpack::object& obj, msgpack::sbuffer& buf)
+{
+    TypedMessage<DeleteForkRequest> request;
+    obj.convert(request);
+
+    _ws->delete_fork(request.value.forkId);
+
+    MsgHeader header(request.header.messageId);
+    messaging::TypedMessage<EmptyResponse> resp_msg(WorldStateMessageType::DELETE_FORK, header, {});
+    msgpack::pack(buf, resp_msg);
+
+    return true;
+}
+
+bool WorldStateWrapper::close(msgpack::object& obj, msgpack::sbuffer& buf)
+{
+    HeaderOnlyMessage request;
+    obj.convert(request);
+
+    // The only reason this API exists is for testing purposes in TS (e.g. close db, open new db instance to test
+    // persistence)
+    _ws.reset(nullptr);
+
+    MsgHeader header(request.header.messageId);
+    messaging::TypedMessage<EmptyResponse> resp_msg(WorldStateMessageType::CLOSE, header, {});
+    msgpack::pack(buf, resp_msg);
+
+    return true;
+}
+
+bool WorldStateWrapper::set_finalized(msgpack::object& obj, msgpack::sbuffer& buf) const
+{
+    TypedMessage<BlockShiftRequest> request;
+    obj.convert(request);
+    WorldStateStatusSummary status = _ws->set_finalized_blocks(request.value.toBlockNumber);
+    MsgHeader header(request.header.messageId);
+    messaging::TypedMessage<WorldStateStatusSummary> resp_msg(
+        WorldStateMessageType::FINALIZE_BLOCKS, header, { status });
+    msgpack::pack(buf, resp_msg);
+
+    return true;
+}
+
+bool WorldStateWrapper::unwind(msgpack::object& obj, msgpack::sbuffer& buf) const
+{
+    TypedMessage<BlockShiftRequest> request;
+    obj.convert(request);
+
+    WorldStateStatusFull status = _ws->unwind_blocks(request.value.toBlockNumber);
+
+    MsgHeader header(request.header.messageId);
+    messaging::TypedMessage<WorldStateStatusFull> resp_msg(WorldStateMessageType::UNWIND_BLOCKS, header, { status });
+    msgpack::pack(buf, resp_msg);
+
+    return true;
+}
+
+bool WorldStateWrapper::remove_historical(msgpack::object& obj, msgpack::sbuffer& buf) const
+{
+    TypedMessage<BlockShiftRequest> request;
+    obj.convert(request);
+    WorldStateStatusFull status = _ws->remove_historical_blocks(request.value.toBlockNumber);
+
+    MsgHeader header(request.header.messageId);
+    messaging::TypedMessage<WorldStateStatusFull> resp_msg(
+        WorldStateMessageType::REMOVE_HISTORICAL_BLOCKS, header, { status });
+    msgpack::pack(buf, resp_msg);
+
+    return true;
+}
+
+bool WorldStateWrapper::checkpoint(msgpack::object& obj, msgpack::sbuffer& buffer)
+{
+    TypedMessage<ForkIdOnlyRequest> request;
+    obj.convert(request);
+
+    uint32_t depth = _ws->checkpoint(request.value.forkId);
+
+    MsgHeader header(request.header.messageId);
+    CheckpointDepthResponse resp_value{ depth };
+    messaging::TypedMessage<CheckpointDepthResponse> resp_msg(
+        WorldStateMessageType::CREATE_CHECKPOINT, header, resp_value);
+    msgpack::pack(buffer, resp_msg);
+
+    return true;
+}
+
+bool WorldStateWrapper::commit_checkpoint(msgpack::object& obj, msgpack::sbuffer& buffer)
+{
+    TypedMessage<ForkIdOnlyRequest> request;
+    obj.convert(request);
+
+    _ws->commit_checkpoint(request.value.forkId);
+
+    MsgHeader header(request.header.messageId);
+    messaging::TypedMessage<WorldStateStatusFull> resp_msg(WorldStateMessageType::COMMIT_CHECKPOINT, header, {});
+    msgpack::pack(buffer, resp_msg);
+
+    return true;
+}
+
+bool WorldStateWrapper::revert_checkpoint(msgpack::object& obj, msgpack::sbuffer& buffer)
+{
+    TypedMessage<ForkIdOnlyRequest> request;
+    obj.convert(request);
+
+    _ws->revert_checkpoint(request.value.forkId);
+
+    MsgHeader header(request.header.messageId);
+    messaging::TypedMessage<WorldStateStatusFull> resp_msg(WorldStateMessageType::REVERT_CHECKPOINT, header, {});
+    msgpack::pack(buffer, resp_msg);
+
+    return true;
+}
+
+bool WorldStateWrapper::commit_all_checkpoints_to(msgpack::object& obj, msgpack::sbuffer& buffer)
+{
+    TypedMessage<ForkIdWithDepthRequest> request;
+    obj.convert(request);
+
+    _ws->commit_all_checkpoints_to(request.value.forkId, request.value.depth);
+
+    MsgHeader header(request.header.messageId);
+    messaging::TypedMessage<WorldStateStatusFull> resp_msg(WorldStateMessageType::COMMIT_ALL_CHECKPOINTS, header, {});
+    msgpack::pack(buffer, resp_msg);
+
+    return true;
+}
+
+bool WorldStateWrapper::revert_all_checkpoints_to(msgpack::object& obj, msgpack::sbuffer& buffer)
+{
+    TypedMessage<ForkIdWithDepthRequest> request;
+    obj.convert(request);
+
+    _ws->revert_all_checkpoints_to(request.value.forkId, request.value.depth);
+
+    MsgHeader header(request.header.messageId);
+    messaging::TypedMessage<WorldStateStatusFull> resp_msg(WorldStateMessageType::REVERT_ALL_CHECKPOINTS, header, {});
+    msgpack::pack(buffer, resp_msg);
+
+    return true;
+}
+
+bool WorldStateWrapper::get_status(msgpack::object& obj, msgpack::sbuffer& buf) const
+{
+    HeaderOnlyMessage request;
+    obj.convert(request);
+
+    WorldStateStatusSummary status;
+    _ws->get_status_summary(status);
+
+    MsgHeader header(request.header.messageId);
+    messaging::TypedMessage<WorldStateStatusSummary> resp_msg(WorldStateMessageType::GET_STATUS, header, { status });
+    msgpack::pack(buf, resp_msg);
+
+    return true;
+}
+
+bool WorldStateWrapper::copy_stores(msgpack::object& obj, msgpack::sbuffer& buffer)
+{
+    TypedMessage<CopyStoresRequest> request;
+    obj.convert(request);
+
+    _ws->copy_stores(request.value.dstPath, request.value.compact.value_or(false));
+
+    MsgHeader header(request.header.messageId);
+    messaging::TypedMessage<WorldStateStatusFull> resp_msg(WorldStateMessageType::COPY_STORES, header, {});
+    msgpack::pack(buffer, resp_msg);
+
+    return true;
+}
+
+Napi::Function WorldStateWrapper::get_class(Napi::Env env)
+{
+    return DefineClass(env,
+                       "WorldState",
+                       {
+                           WorldStateWrapper::InstanceMethod("call", &WorldStateWrapper::call),
+                           WorldStateWrapper::InstanceMethod("getHandle", &WorldStateWrapper::getHandle),
+                       });
+}

--- a/barretenberg/cpp/src/barretenberg/world_state/world_state.cpp
+++ b/barretenberg/cpp/src/barretenberg/world_state/world_state.cpp
@@ -39,6 +39,7 @@ WorldState::WorldState(uint64_t thread_pool_size,
                        const std::unordered_map<MerkleTreeId, uint32_t>& tree_heights,
                        const std::unordered_map<MerkleTreeId, index_t>& tree_prefill,
                        const std::vector<PublicDataLeafValue>& prefilled_public_data,
+                       const std::vector<bb::fr>& prefilled_nullifiers,
                        uint32_t initial_header_generator_point,
                        uint64_t genesis_timestamp,
                        bool ephemeral)
@@ -51,7 +52,7 @@ WorldState::WorldState(uint64_t thread_pool_size,
 {
     // We set the max readers to be high, at least the number of given threads or the default if higher
     uint64_t maxReaders = std::max(thread_pool_size, DEFAULT_MIN_NUMBER_OF_READERS);
-    create_canonical_fork(data_dir, map_size, prefilled_public_data, maxReaders, ephemeral);
+    create_canonical_fork(data_dir, map_size, prefilled_public_data, prefilled_nullifiers, maxReaders, ephemeral);
     try {
         attempt_tree_resync();
     } catch (std::exception& e) {
@@ -73,6 +74,7 @@ WorldState::WorldState(uint64_t thread_pool_size,
                              tree_heights,
                              tree_prefill,
                              std::vector<PublicDataLeafValue>(),
+                             std::vector<bb::fr>(),
                              initial_header_generator_point,
                              genesis_timestamp,
                              ephemeral)
@@ -84,6 +86,7 @@ WorldState::WorldState(uint64_t thread_pool_size,
                        const std::unordered_map<MerkleTreeId, uint32_t>& tree_heights,
                        const std::unordered_map<MerkleTreeId, index_t>& tree_prefill,
                        const std::vector<PublicDataLeafValue>& prefilled_public_data,
+                       const std::vector<bb::fr>& prefilled_nullifiers,
                        uint32_t initial_header_generator_point,
                        uint64_t genesis_timestamp,
                        bool ephemeral)
@@ -99,6 +102,7 @@ WorldState::WorldState(uint64_t thread_pool_size,
                  tree_heights,
                  tree_prefill,
                  prefilled_public_data,
+                 prefilled_nullifiers,
                  initial_header_generator_point,
                  genesis_timestamp,
                  ephemeral)
@@ -118,6 +122,7 @@ WorldState::WorldState(uint64_t thread_pool_size,
                  tree_heights,
                  tree_prefill,
                  std::vector<PublicDataLeafValue>(),
+                 std::vector<bb::fr>(),
                  initial_header_generator_point,
                  genesis_timestamp,
                  ephemeral)
@@ -126,6 +131,7 @@ WorldState::WorldState(uint64_t thread_pool_size,
 void WorldState::create_canonical_fork(const std::string& dataDir,
                                        const std::unordered_map<MerkleTreeId, uint64_t>& dbSize,
                                        const std::vector<PublicDataLeafValue>& prefilled_public_data,
+                                       const std::vector<bb::fr>& prefilled_nullifiers,
                                        uint64_t maxReaders,
                                        bool ephemeral)
 {
@@ -148,9 +154,15 @@ void WorldState::create_canonical_fork(const std::string& dataDir,
     {
         uint32_t levels = _tree_heights.at(MerkleTreeId::NULLIFIER_TREE);
         index_t initial_size = _initial_tree_size.at(MerkleTreeId::NULLIFIER_TREE);
+        std::vector<NullifierLeafValue> prefilled_nullifier_leaves;
+        prefilled_nullifier_leaves.reserve(prefilled_nullifiers.size());
+        for (const auto& nullifier : prefilled_nullifiers) {
+            prefilled_nullifier_leaves.emplace_back(nullifier);
+        }
         auto store = std::make_unique<NullifierStore>(
             getMerkleTreeName(MerkleTreeId::NULLIFIER_TREE), levels, _persistentStores->nullifierStore);
-        auto tree = std::make_unique<NullifierTree>(std::move(store), _workers, initial_size);
+        auto tree =
+            std::make_unique<NullifierTree>(std::move(store), _workers, initial_size, prefilled_nullifier_leaves);
         fork->_trees.insert({ MerkleTreeId::NULLIFIER_TREE, TreeWithStore(std::move(tree)) });
     }
     {

--- a/barretenberg/cpp/src/barretenberg/world_state/world_state.hpp
+++ b/barretenberg/cpp/src/barretenberg/world_state/world_state.hpp
@@ -82,11 +82,15 @@ class WorldState {
                const std::unordered_map<MerkleTreeId, uint32_t>& tree_heights,
                const std::unordered_map<MerkleTreeId, index_t>& tree_prefill,
                const std::vector<PublicDataLeafValue>& prefilled_public_data,
+               const std::vector<bb::fr>& prefilled_nullifiers,
                uint32_t initial_header_generator_point,
                uint64_t genesis_timestamp = 0,
                bool ephemeral = false);
 
     /**
+     * @param prefilled_nullifiers Nullifier leaves to pre-insert into the genesis nullifier tree (e.g. the protocol
+     *                  contract registration nullifiers). Must be unique and strictly increasing in field value, and
+     *                  distinct from the padding leaves implied by the nullifier tree prefill size.
      * @param ephemeral When true, every underlying LMDB env opens with `MDB_NOSYNC |
      *                  MDB_NOMETASYNC`. Commits return without waiting for fsync; the kernel
      *                  flushes lazily, files stay sparse. Intended for throwaway scratch
@@ -99,6 +103,7 @@ class WorldState {
                const std::unordered_map<MerkleTreeId, uint32_t>& tree_heights,
                const std::unordered_map<MerkleTreeId, index_t>& tree_prefill,
                const std::vector<PublicDataLeafValue>& prefilled_public_data,
+               const std::vector<bb::fr>& prefilled_nullifiers,
                uint32_t initial_header_generator_point,
                uint64_t genesis_timestamp = 0,
                bool ephemeral = false);
@@ -326,6 +331,7 @@ class WorldState {
     void create_canonical_fork(const std::string& dataDir,
                                const std::unordered_map<MerkleTreeId, uint64_t>& dbSize,
                                const std::vector<PublicDataLeafValue>& prefilled_public_data,
+                               const std::vector<bb::fr>& prefilled_nullifiers,
                                uint64_t maxReaders,
                                bool ephemeral);
 

--- a/barretenberg/cpp/src/barretenberg/world_state/world_state.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/world_state/world_state.test.cpp
@@ -211,6 +211,57 @@ TEST_F(WorldStateTest, GetInitialTreeInfoForAllTrees)
     }
 }
 
+TEST_F(WorldStateTest, GetInitialTreeInfoWithPrefilledNullifiers)
+{
+    // Prefilled nullifier leaves must be unique and strictly increasing, and larger than the padding leaves that fill
+    // the initial 128-leaf prefill region (whose keys are the low integers 0..127), so we use full-size field values.
+    std::vector<bb::fr> prefilled_nullifiers = {
+        bb::fr("0x073b5e41abe9d7f8466bca9c81c9572b558f953bbd70081317f6a80ac65f3dd5"),
+        bb::fr("0x0d99507b7ecac720c73bf197a0e7366a5ed80c1c1b0afe8ff8c6ecc7b5a7aefe"),
+        bb::fr("0x1c0bf82e0c51834780e61ef091b17e3a1d39ae891db7a70bfdb5221f134996ac"),
+    };
+
+    std::string data_dir_prefilled = random_temp_directory();
+    std::filesystem::create_directories(data_dir_prefilled);
+
+    WorldState ws_prefilled(thread_pool_size,
+                            data_dir_prefilled,
+                            map_size,
+                            tree_heights,
+                            tree_prefill,
+                            std::vector<PublicDataLeafValue>(),
+                            prefilled_nullifiers,
+                            initial_header_generator_point);
+
+    // Baseline world state with no prefilled nullifiers (the canonical empty genesis).
+    WorldState ws(thread_pool_size, data_dir, map_size, tree_heights, tree_prefill, initial_header_generator_point);
+
+    auto prefilled = ws_prefilled.get_tree_info(WorldStateRevision::committed(), MerkleTreeId::NULLIFIER_TREE);
+    auto info = ws.get_tree_info(WorldStateRevision::committed(), MerkleTreeId::NULLIFIER_TREE);
+
+    // The prefilled nullifiers occupy the last slots of the 128-leaf initial prefill region (they replace padding
+    // leaves rather than being appended), so the tree size stays 128 for both.
+    EXPECT_EQ(prefilled.meta.size, 128);
+    EXPECT_EQ(info.meta.size, 128);
+
+    // Seeding the nullifiers changes the nullifier-tree root away from the empty-genesis baseline.
+    EXPECT_NE(prefilled.meta.root, info.meta.root);
+    // The empty-genesis baseline root is unchanged from the canonical value, confirming that a default (empty)
+    // prefilled-nullifiers list leaves the genesis nullifier-tree root bit-identical to today.
+    EXPECT_EQ(info.meta.root, bb::fr("0x18935581a8ed73d08ffd00386fba55ba6c89f3ab848a76b8fedfa9034cee0454"));
+
+    // The seeded nullifiers are present in the tree.
+    for (const auto& nullifier : prefilled_nullifiers) {
+        assert_leaf_exists<NullifierLeafValue>(ws_prefilled,
+                                               WorldStateRevision::committed(),
+                                               MerkleTreeId::NULLIFIER_TREE,
+                                               NullifierLeafValue(nullifier),
+                                               true);
+    }
+
+    std::filesystem::remove_all(data_dir_prefilled);
+}
+
 TEST_F(WorldStateTest, GetInitialTreeInfoWithPrefilledPublicData)
 {
     std::string data_dir_prefilled = random_temp_directory();
@@ -225,6 +276,7 @@ TEST_F(WorldStateTest, GetInitialTreeInfoWithPrefilledPublicData)
                             tree_heights,
                             tree_prefill,
                             prefilled_values,
+                            std::vector<bb::fr>(),
                             initial_header_generator_point);
 
     WorldState ws(thread_pool_size, data_dir, map_size, tree_heights, tree_prefill, initial_header_generator_point);

--- a/barretenberg/cpp/src/barretenberg/wsdb/cli.cpp
+++ b/barretenberg/cpp/src/barretenberg/wsdb/cli.cpp
@@ -65,6 +65,11 @@ int parse_and_run_wsdb(int argc, char* argv[])
     msgpack_run_command->add_option(
         "--prefilled-public-data", prefilled_public_data_json, "Prefilled public data as JSON array");
 
+    // Prefilled nullifiers as JSON array of nullifier_hex strings
+    std::string prefilled_nullifiers_json;
+    msgpack_run_command->add_option(
+        "--prefilled-nullifiers", prefilled_nullifiers_json, "Prefilled genesis nullifiers as JSON array");
+
     uint64_t genesis_timestamp = 0;
     msgpack_run_command->add_option("--genesis-timestamp", genesis_timestamp, "Genesis block timestamp (default: 0)");
 
@@ -98,6 +103,7 @@ int parse_and_run_wsdb(int argc, char* argv[])
                                        threads,
                                        initial_header_generator_point,
                                        prefilled_public_data_json,
+                                       prefilled_nullifiers_json,
                                        genesis_timestamp,
                                        request_ring_size,
                                        response_ring_size);

--- a/barretenberg/cpp/src/barretenberg/wsdb/wsdb_ipc_server.cpp
+++ b/barretenberg/cpp/src/barretenberg/wsdb/wsdb_ipc_server.cpp
@@ -131,6 +131,34 @@ static std::vector<PublicDataLeafValue> parse_prefilled_public_data(const std::s
 }
 
 // ---------------------------------------------------------------------------
+// Parse prefilled nullifiers from JSON: ["nullifier_hex",...]
+// Each hex string is a 64-char (32-byte) hex-encoded field element.
+// ---------------------------------------------------------------------------
+
+static std::vector<fr> parse_prefilled_nullifiers(const std::string& json)
+{
+    std::vector<fr> result;
+    if (json.empty() || json == "[]") {
+        return result;
+    }
+
+    std::string current;
+    bool in_string = false;
+
+    for (char c : json) {
+        if (c == '"') {
+            in_string = !in_string;
+        } else if (in_string) {
+            current += c;
+        } else if ((c == ',' || c == ']') && !current.empty()) {
+            result.push_back(hex_to_fr(current));
+            current.clear();
+        }
+    }
+    return result;
+}
+
+// ---------------------------------------------------------------------------
 // IPC server execution
 // ---------------------------------------------------------------------------
 
@@ -142,6 +170,7 @@ int execute_wsdb_server(const std::string& input_path,
                         uint32_t threads,
                         uint32_t initial_header_generator_point,
                         const std::string& prefilled_public_data_json,
+                        const std::string& prefilled_nullifiers_json,
                         uint64_t genesis_timestamp,
                         size_t request_ring_size,
                         size_t response_ring_size)
@@ -173,6 +202,14 @@ int execute_wsdb_server(const std::string& input_path,
         std::cerr << "Parsed " << prefilled_public_data.size() << " prefilled public data entries" << '\n';
     }
 
+    // Parse prefilled nullifiers: JSON array of "nullifier_hex" strings. The caller (TS world-state) passes the same
+    // canonical genesis nullifiers it seeds via the napi path, so the IPC genesis nullifier-tree root matches.
+    std::vector<bb::fr> prefilled_nullifiers;
+    if (!prefilled_nullifiers_json.empty()) {
+        prefilled_nullifiers = parse_prefilled_nullifiers(prefilled_nullifiers_json);
+        std::cerr << "Parsed " << prefilled_nullifiers.size() << " prefilled nullifiers" << '\n';
+    }
+
     // Create WorldState
     std::cerr << "Creating WorldState at " << data_dir << " with " << threads << " threads" << '\n';
     auto ws = std::make_unique<WorldState>(threads,
@@ -181,6 +218,7 @@ int execute_wsdb_server(const std::string& input_path,
                                            tree_height,
                                            tree_prefill,
                                            prefilled_public_data,
+                                           prefilled_nullifiers,
                                            initial_header_generator_point,
                                            genesis_timestamp);
 

--- a/barretenberg/cpp/src/barretenberg/wsdb/wsdb_ipc_server.hpp
+++ b/barretenberg/cpp/src/barretenberg/wsdb/wsdb_ipc_server.hpp
@@ -20,6 +20,7 @@ int execute_wsdb_server(const std::string& input_path,
                         uint32_t threads,
                         uint32_t initial_header_generator_point,
                         const std::string& prefilled_public_data_json,
+                        const std::string& prefilled_nullifiers_json,
                         uint64_t genesis_timestamp,
                         size_t request_ring_size,
                         size_t response_ring_size);

--- a/yarn-project/stdlib/src/world-state/genesis_data.ts
+++ b/yarn-project/stdlib/src/world-state/genesis_data.ts
@@ -1,9 +1,18 @@
+import type { Fr } from '@aztec/foundation/curves/bn254';
+
 import type { PublicDataTreeLeaf } from '../trees/index.js';
 
 /** Data used to initialize the genesis block, including prefilled public state and an optional timestamp. */
 export type GenesisData = {
   /** Public data tree leaves to pre-populate in the genesis state (e.g. fee juice balances). */
   prefilledPublicData: PublicDataTreeLeaf[];
+  /**
+   * Nullifiers to pre-insert into the genesis nullifier tree. Optional; defaults to an empty list, which leaves the
+   * nullifier tree at its canonical empty-genesis state so that production genesis roots are unchanged. When non-empty,
+   * the leaves must be unique and strictly increasing in field value (the native world state enforces this before
+   * construction). Test networks pass a non-empty list to seed e.g. standard-contract registration nullifiers.
+   */
+  prefilledNullifiers?: Fr[];
   /** Timestamp for the genesis block header. Defaults to 0 (canonical empty genesis) in production. */
   genesisTimestamp: bigint;
 };
@@ -11,6 +20,7 @@ export type GenesisData = {
 /** An empty genesis data with no prefilled state and a zero timestamp. */
 export const EMPTY_GENESIS_DATA: GenesisData = {
   prefilledPublicData: [],
+  prefilledNullifiers: [],
   genesisTimestamp: 0n,
 };
 

--- a/yarn-project/world-state/src/native/native_world_state_instance.ts
+++ b/yarn-project/world-state/src/native/native_world_state_instance.ts
@@ -18,6 +18,7 @@ import type {
 
 /** Backend-agnostic handle to a running aztec-wsdb world state, accessed by the TS layer. */
 export interface NativeWorldStateInstance {
+<<<<<<< HEAD
   getTreeInfo(treeId: MerkleTreeId, revision: WorldStateRevision): Promise<TreeInfo>;
   getStateReference(revision: WorldStateRevision): Promise<Record<number, TreeStateReference>>;
   getInitialStateReference(): Promise<Record<number, TreeStateReference>>;
@@ -101,4 +102,289 @@ export interface NativeWorldStateInstance {
    * terminates the underlying aztec-wsdb process. Idempotent.
    */
   close(): Promise<void>;
+=======
+  call<T extends WorldStateMessageType>(
+    messageType: T,
+    body: WorldStateRequest[T] & WorldStateRequestCategories,
+  ): Promise<WorldStateResponse[T]>;
+  // TODO(dbanks12): this returns any type, but we should strongly type it
+  getHandle(): any;
+}
+
+/**
+ * Strongly-typed interface to access the WorldState class in the native world_state_napi module.
+ */
+export class NativeWorldState implements NativeWorldStateInstance {
+  private open = true;
+
+  // We maintain a map of queue to fork
+  private queues = new Map<number, WorldStateOpsQueue>();
+
+  private instance: MsgpackChannel<WorldStateMessageType, WorldStateRequest, WorldStateResponse>;
+
+  /** Creates a new native WorldState instance */
+  constructor(
+    private readonly dataDir: string,
+    private readonly wsTreeMapSizes: WorldStateTreeMapSizes,
+    private readonly genesis: GenesisData = EMPTY_GENESIS_DATA,
+    private readonly instrumentation: WorldStateInstrumentation,
+    bindings?: LoggerBindings,
+    private readonly log: Logger = createLogger('world-state:database', bindings),
+    private readonly ephemeral: boolean = false,
+  ) {
+    const threads = Math.min(cpus().length, MAX_WORLD_STATE_THREADS);
+    log.info(
+      `Creating world state data store at directory ${dataDir} with map sizes ${JSON.stringify(
+        wsTreeMapSizes,
+      )} and ${threads} threads (ephemeral=${ephemeral}).`,
+    );
+    const prefilledPublicDataBufferArray = genesis.prefilledPublicData.map(d => [
+      d.slot.toBuffer(),
+      d.value.toBuffer(),
+    ]);
+    // Nullifiers to pre-insert into the genesis nullifier tree (empty by default, so production genesis roots are
+    // unchanged). The native indexed nullifier tree requires its prefilled leaves to be unique and strictly
+    // increasing, so we enforce that here before handing them over rather than failing deep inside the C++ tree
+    // construction.
+    const prefilledNullifiers = genesis.prefilledNullifiers ?? [];
+    for (let i = 1; i < prefilledNullifiers.length; i++) {
+      assert(
+        prefilledNullifiers[i].toBigInt() > prefilledNullifiers[i - 1].toBigInt(),
+        'Prefilled genesis nullifiers must be unique and strictly increasing',
+      );
+    }
+    const prefilledNullifiersBufferArray = prefilledNullifiers.map(n => n.toBuffer());
+    const ws = new BaseNativeWorldState(
+      dataDir,
+      {
+        [MerkleTreeId.NULLIFIER_TREE]: NULLIFIER_TREE_HEIGHT,
+        [MerkleTreeId.NOTE_HASH_TREE]: NOTE_HASH_TREE_HEIGHT,
+        [MerkleTreeId.PUBLIC_DATA_TREE]: PUBLIC_DATA_TREE_HEIGHT,
+        [MerkleTreeId.L1_TO_L2_MESSAGE_TREE]: L1_TO_L2_MSG_TREE_HEIGHT,
+        [MerkleTreeId.ARCHIVE]: ARCHIVE_HEIGHT,
+      },
+      {
+        [MerkleTreeId.NULLIFIER_TREE]: 2 * MAX_NULLIFIERS_PER_TX,
+        [MerkleTreeId.PUBLIC_DATA_TREE]: 2 * MAX_TOTAL_PUBLIC_DATA_UPDATE_REQUESTS_PER_TX,
+      },
+      prefilledPublicDataBufferArray,
+      prefilledNullifiersBufferArray,
+      DomainSeparator.BLOCK_HEADER_HASH,
+      Number(genesis.genesisTimestamp),
+      {
+        [MerkleTreeId.NULLIFIER_TREE]: wsTreeMapSizes.nullifierTreeMapSizeKb,
+        [MerkleTreeId.NOTE_HASH_TREE]: wsTreeMapSizes.noteHashTreeMapSizeKb,
+        [MerkleTreeId.PUBLIC_DATA_TREE]: wsTreeMapSizes.publicDataTreeMapSizeKb,
+        [MerkleTreeId.L1_TO_L2_MESSAGE_TREE]: wsTreeMapSizes.messageTreeMapSizeKb,
+        [MerkleTreeId.ARCHIVE]: wsTreeMapSizes.archiveTreeMapSizeKb,
+      },
+      threads,
+      ephemeral,
+    );
+    this.instance = new MsgpackChannel(ws);
+    // Manually create the queue for the canonical fork
+    this.queues.set(0, new WorldStateOpsQueue());
+  }
+
+  public getDataDir() {
+    return this.dataDir;
+  }
+
+  public clone() {
+    return new NativeWorldState(
+      this.dataDir,
+      this.wsTreeMapSizes,
+      this.genesis,
+      this.instrumentation,
+      this.log.getBindings(),
+      this.log,
+      this.ephemeral,
+    );
+  }
+
+  /**
+   * Gets the native WorldState handle from the underlying native instance.
+   * We call the getHandle() method on the native WorldState to get a NAPI External
+   * that wraps the underlying C++ WorldState pointer.
+   * @returns The NAPI External handle to the native WorldState instance,since
+   * the NAPI external type is opaque, we return any (we could also use an opaque symbol type)
+   */
+  public getHandle(): any {
+    const worldStateWrapper = (this.instance as any).dest;
+
+    if (!worldStateWrapper) {
+      throw new Error('No WorldStateWrapper found');
+    }
+
+    if (typeof worldStateWrapper.getHandle !== 'function') {
+      throw new Error('WorldStateWrapper does not have getHandle method');
+    }
+
+    // Call getHandle() to get the NAPI External
+    try {
+      return worldStateWrapper.getHandle();
+    } catch (error) {
+      this.log.error('Failed to get native WorldState handle', error);
+    }
+  }
+
+  /**
+   * Sends a message to the native instance and returns the response.
+   * @param messageType - The type of message to send
+   * @param body - The message body
+   * @param responseHandler - A callback accepting the response, executed on the job queue
+   * @param errorHandler - A callback called on request error, executed on the job queue
+   * @returns The response to the message
+   */
+  public async call<T extends WorldStateMessageType>(
+    messageType: T,
+    body: WorldStateRequest[T] & WorldStateRequestCategories,
+    // allows for the pre-processing of responses on the job queue before being passed back
+    responseHandler = (response: WorldStateResponse[T]): WorldStateResponse[T] => response,
+    errorHandler = (_: string) => {},
+  ): Promise<WorldStateResponse[T]> {
+    // Here we determine which fork the request is being executed against and whether it requires uncommitted data
+    // We use the fork Id to select the appropriate request queue and the uncommitted data flag to pass to the queue
+    let forkId = -1;
+    // We assume it includes uncommitted unless explicitly told otherwise
+    let committedOnly = false;
+
+    // Canonical requests ALWAYS go against the canonical fork
+    // These include things like block syncs/unwinds etc
+    // These requests don't contain a fork ID
+    if (isWithCanonical(body)) {
+      forkId = 0;
+    } else if (isWithForkId(body)) {
+      forkId = body.forkId;
+    } else if (isWithRevision(body)) {
+      forkId = body.revision.forkId;
+      committedOnly = body.revision.includeUncommitted === false;
+    } else {
+      const _: never = body;
+      throw new Error(`Unable to determine forkId for message=${WorldStateMessageType[messageType]}`);
+    }
+
+    // Get the queue or create a new one
+    let requestQueue = this.queues.get(forkId);
+    if (requestQueue === undefined) {
+      requestQueue = new WorldStateOpsQueue();
+      this.queues.set(forkId, requestQueue);
+    }
+
+    // Enqueue the request and wait for the response. The per-fork queue is cleaned up in `finally` even on
+    // error, so the JS-side queues map cannot outlive the native fork (e.g. when the native fork was already
+    // destroyed by an unwind/historical-prune and DELETE_FORK rejects with "Fork not found").
+    let shouldDeleteForkQueue = false;
+    try {
+      const response = await requestQueue.execute(
+        async () => {
+          assert.notEqual(messageType, WorldStateMessageType.CLOSE, 'Use close() to close the native instance');
+          assert.equal(this.open, true, 'Native instance is closed');
+          let response: WorldStateResponse[T];
+          try {
+            response = await this._sendMessage(messageType, body);
+          } catch (error: any) {
+            errorHandler(error.message);
+            throw error;
+          }
+          return responseHandler(response);
+        },
+        messageType,
+        committedOnly,
+      );
+      return response;
+    } catch (err: any) {
+      shouldDeleteForkQueue = forkId !== 0 && err?.message === 'Fork not found';
+      throw err;
+    } finally {
+      if (messageType === WorldStateMessageType.DELETE_FORK || shouldDeleteForkQueue) {
+        await requestQueue.stop();
+        this.queues.delete(forkId);
+      }
+    }
+  }
+
+  /**
+   * Stops the native instance.
+   */
+  public async close(): Promise<void> {
+    if (!this.open) {
+      return;
+    }
+    this.open = false;
+    const queue = this.queues.get(0)!;
+
+    await queue.execute(
+      async () => {
+        await this._sendMessage(WorldStateMessageType.CLOSE, { canonical: true });
+      },
+      WorldStateMessageType.CLOSE,
+      false,
+    );
+    await queue.stop();
+  }
+
+  private async _sendMessage<T extends WorldStateMessageType>(
+    messageType: T,
+    body: WorldStateRequest[T] & WorldStateRequestCategories,
+  ): Promise<WorldStateResponse[T]> {
+    let logMetadata: Record<string, any> = {};
+
+    if (body) {
+      if ('treeId' in body) {
+        logMetadata['treeId'] = MerkleTreeId[body.treeId];
+      }
+
+      if ('revision' in body) {
+        logMetadata = { ...logMetadata, ...body.revision };
+      }
+
+      if ('forkId' in body) {
+        logMetadata['forkId'] = body.forkId;
+      }
+
+      if ('blockNumber' in body) {
+        logMetadata['blockNumber'] = body.blockNumber;
+      }
+
+      if ('toBlockNumber' in body) {
+        logMetadata['toBlockNumber'] = body.toBlockNumber;
+      }
+
+      if ('leafIndex' in body) {
+        logMetadata['leafIndex'] = body.leafIndex;
+      }
+
+      if ('blockHeaderHash' in body) {
+        logMetadata['blockHeaderHash'] = '0x' + body.blockHeaderHash.toString('hex');
+      }
+
+      if ('leaves' in body) {
+        logMetadata['leavesCount'] = body.leaves.length;
+      }
+
+      // sync operation
+      if ('paddedNoteHashes' in body) {
+        logMetadata['notesCount'] = body.paddedNoteHashes.length;
+        logMetadata['nullifiersCount'] = body.paddedNullifiers.length;
+        logMetadata['l1ToL2MessagesCount'] = body.paddedL1ToL2Messages.length;
+        logMetadata['publicDataWritesCount'] = body.publicDataWrites.length;
+      }
+    }
+
+    try {
+      const { duration, response } = await this.instance.sendMessage(messageType, body);
+      this.log.trace(`Call ${WorldStateMessageType[messageType]} took (ms)`, {
+        duration,
+        ...logMetadata,
+      });
+
+      this.instrumentation.recordRoundTrip(duration.totalUs, messageType);
+      return response;
+    } catch (error) {
+      this.log.error(`Call ${WorldStateMessageType[messageType]} failed: ${error}`, error, logMetadata);
+      throw error;
+    }
+  }
+>>>>>>> a4e3a445ee (feat(world-state): support prefilled nullifiers in genesis state (#24567))
 }

--- a/yarn-project/world-state/src/testing.test.ts
+++ b/yarn-project/world-state/src/testing.test.ts
@@ -1,12 +1,17 @@
+import { GENESIS_ARCHIVE_ROOT } from '@aztec/constants';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { MerkleTreeId, PublicDataTreeLeaf } from '@aztec/stdlib/trees';
-import type { GenesisData } from '@aztec/stdlib/world-state';
+import { EMPTY_GENESIS_DATA, type GenesisData } from '@aztec/stdlib/world-state';
 
 import { jest } from '@jest/globals';
 
 import { NativeWorldStateService } from './native/index.js';
+import { getGenesisValues } from './testing.js';
 
 jest.setTimeout(60_000);
+
+const archiveRoot = async (ws: NativeWorldStateService) =>
+  new Fr((await ws.getCommitted().getTreeInfo(MerkleTreeId.ARCHIVE)).root);
 
 describe('generateGenesisValues world state backend equivalence', () => {
   // A genesis with both non-empty prefilled public data and a non-zero timestamp, so the
@@ -19,9 +24,6 @@ describe('generateGenesisValues world state backend equivalence', () => {
     ],
     genesisTimestamp: 1234567890n,
   };
-
-  const archiveRoot = async (ws: NativeWorldStateService) =>
-    new Fr((await ws.getCommitted().getTreeInfo(MerkleTreeId.ARCHIVE)).root);
 
   // The consensus-critical guarantee behind computing genesis values on the fsync-off ephemeral
   // backend instead of tmp: both backends must derive the exact same on-chain genesis archive root.
@@ -36,5 +38,98 @@ describe('generateGenesisValues world state backend equivalence', () => {
       await tmpWs.close();
       await ephemeralWs.close();
     }
+  });
+});
+
+describe('genesis prefilled nullifiers', () => {
+  // (a) With no public data, no timestamp and no prefilled nullifiers, generateGenesisValues takes its fast path and
+  // returns the pinned GENESIS_ARCHIVE_ROOT constant without spinning up a world state.
+  it('empty genesis returns the canonical GENESIS_ARCHIVE_ROOT via the fast path', async () => {
+    const { genesisArchiveRoot } = await getGenesisValues([]);
+    expect(genesisArchiveRoot).toEqual(new Fr(GENESIS_ARCHIVE_ROOT));
+  });
+
+  // (a) The fast-path constant must equal the root actually computed from an empty-nullifier genesis, i.e. the
+  // GENESIS_ARCHIVE_ROOT constant is correct for the default (empty) prefilled-nullifiers list on this branch.
+  it('the empty-genesis archive root matches a freshly computed empty world state', async () => {
+    const ws = await NativeWorldStateService.ephemeral(EMPTY_GENESIS_DATA);
+    try {
+      expect(await archiveRoot(ws)).toEqual(new Fr(GENESIS_ARCHIVE_ROOT));
+    } finally {
+      await ws.close();
+    }
+  });
+
+  // (b) An explicit empty prefilled-nullifiers list must be behaviour-neutral: threading it through the non-fast path
+  // (public data present) yields exactly the same root as a genesis that omits the field entirely.
+  it('an explicit empty prefilledNullifiers produces the same root as omitting the field', async () => {
+    const publicData = [new PublicDataTreeLeaf(new Fr(1000), new Fr(2000))];
+    const withoutField: GenesisData = { prefilledPublicData: publicData, genesisTimestamp: 42n };
+    const withEmpty: GenesisData = { prefilledPublicData: publicData, genesisTimestamp: 42n, prefilledNullifiers: [] };
+    const wsWithout = await NativeWorldStateService.ephemeral(withoutField);
+    const wsEmpty = await NativeWorldStateService.ephemeral(withEmpty);
+    try {
+      expect(await archiveRoot(wsEmpty)).toEqual(await archiveRoot(wsWithout));
+    } finally {
+      await wsWithout.close();
+      await wsEmpty.close();
+    }
+  });
+
+  // (c) A non-empty, sorted, unique nullifier list produces a deterministic root that differs from the empty genesis.
+  it('a non-empty prefilledNullifiers list yields a deterministic root that differs from the empty genesis', async () => {
+    // Values must exceed the padding leaves that fill the initial prefill region and be strictly increasing.
+    const nullifiers = [new Fr(1000n), new Fr(2000n), new Fr(3000n)];
+    const genesisWith: GenesisData = { prefilledPublicData: [], genesisTimestamp: 0n, prefilledNullifiers: nullifiers };
+    const genesisEmpty: GenesisData = { prefilledPublicData: [], genesisTimestamp: 0n, prefilledNullifiers: [] };
+    const wsWith1 = await NativeWorldStateService.ephemeral(genesisWith);
+    const wsWith2 = await NativeWorldStateService.ephemeral(genesisWith);
+    const wsEmpty = await NativeWorldStateService.ephemeral(genesisEmpty);
+    try {
+      const rootWith1 = await archiveRoot(wsWith1);
+      const rootWith2 = await archiveRoot(wsWith2);
+      const rootEmpty = await archiveRoot(wsEmpty);
+      expect(rootWith1).toEqual(rootWith2);
+      expect(rootWith1).not.toEqual(rootEmpty);
+    } finally {
+      await wsWith1.close();
+      await wsWith2.close();
+      await wsEmpty.close();
+    }
+  });
+
+  // (c) getGenesisValues sorts an unsorted list ascending and produces a genesis whose root matches direct construction.
+  it('getGenesisValues sorts prefilled nullifiers and seeds them into the genesis', async () => {
+    const unsorted = [new Fr(3000n), new Fr(1000n), new Fr(2000n)];
+    const { genesis, genesisArchiveRoot } = await getGenesisValues([], undefined, [], 0n, unsorted);
+    expect(genesis.prefilledNullifiers).toEqual([new Fr(1000n), new Fr(2000n), new Fr(3000n)]);
+    const ws = await NativeWorldStateService.ephemeral(genesis);
+    try {
+      expect(await archiveRoot(ws)).toEqual(genesisArchiveRoot);
+    } finally {
+      await ws.close();
+    }
+  });
+
+  // (d) The defensive TS-side check rejects prefilled nullifiers that are not unique and strictly increasing before
+  // handing them to the native tree.
+  it('rejects prefilled nullifiers that are not strictly increasing', async () => {
+    const descending: GenesisData = {
+      prefilledPublicData: [],
+      genesisTimestamp: 0n,
+      prefilledNullifiers: [new Fr(3000n), new Fr(1000n)],
+    };
+    await expect(NativeWorldStateService.ephemeral(descending)).rejects.toThrow(
+      'Prefilled genesis nullifiers must be unique and strictly increasing',
+    );
+
+    const duplicate: GenesisData = {
+      prefilledPublicData: [],
+      genesisTimestamp: 0n,
+      prefilledNullifiers: [new Fr(1000n), new Fr(1000n)],
+    };
+    await expect(NativeWorldStateService.ephemeral(duplicate)).rejects.toThrow(
+      'Prefilled genesis nullifiers must be unique and strictly increasing',
+    );
   });
 });

--- a/yarn-project/world-state/src/testing.ts
+++ b/yarn-project/world-state/src/testing.ts
@@ -8,16 +8,18 @@ import type { GenesisData } from '@aztec/stdlib/world-state';
 import { NativeWorldStateService } from './native/index.js';
 
 async function generateGenesisValues(genesis: GenesisData) {
-  if (!genesis.prefilledPublicData.length && genesis.genesisTimestamp === 0n) {
+  // The GENESIS_ARCHIVE_ROOT constant reflects the canonical empty genesis (no public data, no prefilled nullifiers,
+  // timestamp 0), so we can only short-circuit when this genesis adds none of those on top.
+  if (!genesis.prefilledPublicData.length && genesis.genesisTimestamp === 0n && !genesis.prefilledNullifiers?.length) {
     return {
       genesisArchiveRoot: new Fr(GENESIS_ARCHIVE_ROOT),
     };
   }
 
-  // Compute the genesis values on a throwaway world state. The archive root derives only from the
-  // prefilled public data and the genesis timestamp, so the fsync-off ephemeral store (no version
-  // manager, no crash-recoverability) produces an identical root while skipping the fsync overhead
-  // that `tmp` pays. close() removes the tmpdir.
+  // Compute the genesis values on a throwaway world state. The archive root derives deterministically from the
+  // prefilled public data, the prefilled nullifiers, and the genesis timestamp, so the fsync-off ephemeral store (no
+  // version manager, no crash-recoverability) produces an identical root while skipping the fsync overhead that `tmp`
+  // pays. close() removes the tmpdir.
   const ws = await NativeWorldStateService.ephemeral(genesis);
   const genesisArchiveRoot = new Fr((await ws.getCommitted().getTreeInfo(MerkleTreeId.ARCHIVE)).root);
   await ws.close();
@@ -34,6 +36,7 @@ export async function getGenesisValues(
   initialAccountFeeJuice = defaultInitialAccountFeeJuice,
   genesisPublicData: PublicDataTreeLeaf[] = [],
   genesisTimestamp: bigint = 0n,
+  prefilledNullifiers: Fr[] = [],
 ) {
   // Top up the accounts with fee juice.
   let prefilledPublicData = await Promise.all(
@@ -47,7 +50,11 @@ export async function getGenesisValues(
 
   prefilledPublicData.sort((a, b) => (b.slot.lt(a.slot) ? 1 : -1));
 
-  const genesis: GenesisData = { prefilledPublicData, genesisTimestamp };
+  // The indexed nullifier tree requires its prefilled leaves to be unique and strictly increasing, so sort ascending
+  // here (a copy, to avoid mutating the caller's array) rather than relying on the caller's ordering.
+  const sortedNullifiers = [...prefilledNullifiers].sort((a, b) => (a.toBigInt() < b.toBigInt() ? -1 : 1));
+
+  const genesis: GenesisData = { prefilledPublicData, prefilledNullifiers: sortedNullifiers, genesisTimestamp };
   const { genesisArchiveRoot } = await generateGenesisValues(genesis);
 
   return {


### PR DESCRIPTION
Forward-port of #24567 (`feat(world-state): support prefilled nullifiers in genesis state`) from `v5-next` into `next`.

Cherry-pick **conflicted** — conflict markers are committed on this branch. Resolve them, run the formatter/tests, then mark ready for review.

**Conflicting files:** barretenberg/cpp/src/barretenberg/nodejs_module/world_state/world_state.cpp,yarn-project/world-state/src/native/native_world_state_instance.ts

Part of the v5-next → next backlog. Companion automation: #24848. See the tracking gist for the full list.