### PR TITLE
chore(fwd-port): #24636 feat: getTxEffects oracle

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/oracle/message_processing.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/message_processing.nr
@@ -66,3 +66,11 @@ pub unconstrained fn get_tx_effect(tx_hash: Field) -> Option<TxEffect> {
 
 #[oracle(aztec_utl_getTxEffect)]
 unconstrained fn get_tx_effect_oracle(tx_hash: Field) -> Option<TxEffect> {}
+
+/// Fetches all effects of settled transactions by hash, preserving request order.
+pub unconstrained fn get_tx_effects(tx_hashes: EphemeralArray<Field>) -> EphemeralArray<Option<TxEffect>> {
+    get_tx_effects_oracle(tx_hashes)
+}
+
+#[oracle(aztec_utl_getTxEffects)]
+unconstrained fn get_tx_effects_oracle(tx_hashes: EphemeralArray<Field>) -> EphemeralArray<Option<TxEffect>> {}

--- a/noir-projects/aztec-nr/aztec/src/oracle/version.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/version.nr
@@ -11,7 +11,11 @@
 /// immediately if AZTEC_NR_MINOR > PXE_MINOR because if a contract is updated to use a newer Aztec.nr dependency
 /// without actually using any of the new oracles then there is no reason to throw.
 pub global ORACLE_VERSION_MAJOR: Field = 30;
+<<<<<<< HEAD
 pub global ORACLE_VERSION_MINOR: Field = 5;
+=======
+pub global ORACLE_VERSION_MINOR: Field = 8;
+>>>>>>> 7a77232ed7 (feat: getTxEffects oracle (#24636))
 
 /// Asserts that the version of the oracle is compatible with the version expected by the contract.
 pub fn assert_compatible_oracle_version() {

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/oracle_registry.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/oracle_registry.ts
@@ -256,6 +256,11 @@ export const ORACLE_REGISTRY = {
     returnType: OPTION(TX_EFFECT),
   }),
 
+  aztec_utl_getTxEffects: makeEntry({
+    params: [{ name: 'txHashes', type: EPHEMERAL_ARRAY(TX_HASH) }],
+    returnType: EPHEMERAL_ARRAY(OPTION(TX_EFFECT)),
+  }),
+
   aztec_utl_setCapsule: makeEntry({
     params: [
       { name: 'contractAddress', type: AZTEC_ADDRESS },

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution.test.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution.test.ts
@@ -28,7 +28,22 @@ import { PublicKeys, deriveKeys, hashPublicKey } from '@aztec/stdlib/keys';
 import { AppTaggingSecret, AppTaggingSecretKind, SiloedTag } from '@aztec/stdlib/logs';
 import { Note, NoteDao } from '@aztec/stdlib/note';
 import { makeL2Tips, randomContractInstanceWithAddress } from '@aztec/stdlib/testing';
+<<<<<<< HEAD
 import { BlockHeader, CallContext, Capsule, GlobalVariables, TxHash } from '@aztec/stdlib/tx';
+=======
+import {
+  BlockHeader,
+  CallContext,
+  Capsule,
+  DroppedTxReceipt,
+  GlobalVariables,
+  MinedTxReceipt,
+  TxEffect,
+  TxExecutionResult,
+  TxHash,
+  TxStatus,
+} from '@aztec/stdlib/tx';
+>>>>>>> 7a77232ed7 (feat: getTxEffects oracle (#24636))
 
 import { mock } from 'jest-mock-extended';
 import type { _MockProxy } from 'jest-mock-extended/lib/Mock.js';
@@ -657,6 +672,164 @@ describe('Utility Execution test suite', () => {
       });
     });
 
+<<<<<<< HEAD
+=======
+    describe('node read cache', () => {
+      const makeTxEffect = (txHash: TxHash) => TxEffect.from({ ...TxEffect.empty(), txHash });
+      const makeMinedReceipt = (
+        txHash: TxHash,
+        txEffect = makeTxEffect(txHash),
+        blockNumber = BlockNumber(syncedBlockNumber),
+      ) =>
+        new MinedTxReceipt(
+          txHash,
+          TxStatus.FINALIZED,
+          TxExecutionResult.SUCCESS,
+          0n,
+          BlockHash.random(),
+          blockNumber,
+          SlotNumber(1),
+          0,
+          EpochNumber(1),
+          txEffect,
+        );
+
+      it('reuses tx-effect reads within a utility execution', async () => {
+        const oracle = makeOracle({ scopes: [scope] });
+        const txHash = TxHash.random();
+        aztecNode.getTxReceipt.mockResolvedValue(makeMinedReceipt(txHash));
+
+        const first = await oracle.getTxEffect(txHash);
+        const second = await oracle.getTxEffect(txHash);
+
+        expect(first).toEqual(second);
+        expect(aztecNode.getTxReceipt).toHaveBeenCalledTimes(1);
+      });
+
+      it('does not share cached reads across utility executions', async () => {
+        const txHash = TxHash.random();
+        aztecNode.getTxReceipt.mockResolvedValue(makeMinedReceipt(txHash));
+
+        const firstOracle = makeOracle({ scopes: [scope] });
+        const secondOracle = makeOracle({ scopes: [scope] });
+
+        // Cache works as usual
+        await firstOracle.getTxEffect(txHash);
+        await firstOracle.getTxEffect(txHash);
+        expect(aztecNode.getTxReceipt).toHaveBeenCalledTimes(1);
+
+        // Same call in new oracle, goes to actual node since cache is clean
+        await secondOracle.getTxEffect(txHash);
+        expect(aztecNode.getTxReceipt).toHaveBeenCalledTimes(2);
+      });
+
+      it('does not cache failed tx-effect reads', async () => {
+        const oracle = makeOracle({ scopes: [scope] });
+        const txHash = TxHash.random();
+        aztecNode.getTxReceipt.mockRejectedValueOnce(new Error('temporary failure'));
+        aztecNode.getTxReceipt.mockResolvedValueOnce(makeMinedReceipt(txHash));
+
+        await expect(oracle.getTxEffect(txHash)).rejects.toThrow('temporary failure');
+
+        const result = await oracle.getTxEffect(txHash);
+
+        expect(result.isSome()).toBe(true);
+        expect(aztecNode.getTxReceipt).toHaveBeenCalledTimes(2);
+      });
+
+      it('returns aligned tx-effect options for tx hash batches', async () => {
+        const service = new EphemeralArrayService();
+        const oracle = makeOracle({ scopes: [scope] });
+        const presentTxHash = TxHash.random();
+        const pendingTxHash = TxHash.random();
+        const futureTxHash = TxHash.random();
+
+        aztecNode.getTxReceipt.mockImplementation(txHash => {
+          if (txHash.equals(presentTxHash)) {
+            return Promise.resolve(makeMinedReceipt(txHash));
+          }
+          if (txHash.equals(futureTxHash)) {
+            return Promise.resolve(makeMinedReceipt(txHash, makeTxEffect(txHash), BlockNumber(syncedBlockNumber + 1)));
+          }
+          return Promise.resolve(new DroppedTxReceipt(txHash));
+        });
+
+        const result = await oracle.getTxEffects(
+          EphemeralArray.fromValues(service, [presentTxHash, pendingTxHash, futureTxHash, presentTxHash]),
+        );
+        const options = result.readAll(service);
+
+        expect(options.map(option => option.isSome())).toEqual([true, false, false, true]);
+        expect(options[0].value?.txHash).toEqual(presentTxHash);
+        expect(options[3].value?.txHash).toEqual(presentTxHash);
+        expect(aztecNode.getTxReceipt).toHaveBeenCalledTimes(3);
+      });
+
+      it('does not share batched tx-effect reads across utility executions', async () => {
+        const service = new EphemeralArrayService();
+        const txHash = TxHash.random();
+        aztecNode.getTxReceipt.mockResolvedValue(makeMinedReceipt(txHash));
+
+        const firstOracle = makeOracle({ scopes: [scope] });
+        const secondOracle = makeOracle({ scopes: [scope] });
+
+        await firstOracle.getTxEffects(EphemeralArray.fromValues(service, [txHash, txHash]));
+        expect(aztecNode.getTxReceipt).toHaveBeenCalledTimes(1);
+
+        await secondOracle.getTxEffects(EphemeralArray.fromValues(service, [txHash]));
+        expect(aztecNode.getTxReceipt).toHaveBeenCalledTimes(2);
+      });
+
+      it('reuses archive witness reads within a utility execution', async () => {
+        const oracle = makeOracle({ scopes: [scope] });
+        const referenceBlockHash = await anchorBlockHeader.hash();
+        const blockHash = BlockHash.random();
+        const witness = MembershipWitness.empty(ARCHIVE_HEIGHT);
+        aztecNode.getBlockHashMembershipWitness.mockResolvedValue(witness);
+
+        const first = await oracle.getBlockHashMembershipWitness(referenceBlockHash, blockHash);
+        const second = await oracle.getBlockHashMembershipWitness(referenceBlockHash, blockHash);
+
+        expect(first).toEqual(second);
+        expect(aztecNode.getBlockHashMembershipWitness).toHaveBeenCalledTimes(1);
+      });
+
+      it('returns aligned archive-membership booleans for block hash batches', async () => {
+        const service = new EphemeralArrayService();
+        const oracle = makeOracle({ scopes: [scope] });
+        const referenceBlockHash = await anchorBlockHeader.hash();
+        const presentBlockHash = BlockHash.random();
+        const missingBlockHash = BlockHash.random();
+        const witness = MembershipWitness.empty(ARCHIVE_HEIGHT);
+
+        aztecNode.getBlockHashMembershipWitness.mockImplementation((_referenceBlockHash, blockHash) =>
+          Promise.resolve(blockHash.equals(presentBlockHash) ? witness : undefined),
+        );
+
+        const result = await oracle.areBlockHashesInArchive(
+          referenceBlockHash,
+          EphemeralArray.fromValues(service, [presentBlockHash, missingBlockHash, presentBlockHash]),
+        );
+
+        expect(result.readAll(service)).toEqual([true, false, true]);
+        expect(aztecNode.getBlockHashMembershipWitness).toHaveBeenCalledTimes(2);
+      });
+
+      it('reuses public storage reads within a utility execution', async () => {
+        const oracle = makeOracle({ scopes: [scope] });
+        const blockHash = await anchorBlockHeader.hash();
+        const startStorageSlot = Fr.random();
+        aztecNode.getPublicStorageAt.mockResolvedValue(new Fr(7));
+
+        const first = await oracle.getFromPublicStorage(blockHash, contractAddress, startStorageSlot, 2);
+        const second = await oracle.getFromPublicStorage(blockHash, contractAddress, startStorageSlot, 2);
+
+        expect(first).toEqual(second);
+        expect(aztecNode.getPublicStorageAt).toHaveBeenCalledTimes(2);
+      });
+    });
+
+>>>>>>> 7a77232ed7 (feat: getTxEffects oracle (#24636))
     describe('fact store', () => {
       const service = new EphemeralArrayService();
       const typeId = new Fr(10);

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
@@ -35,6 +35,7 @@ import {
   type Capsule,
   type IndexedTxEffect,
   type OffchainEffect,
+  type TxEffect,
   type TxHash,
 } from '@aztec/stdlib/tx';
 
@@ -666,21 +667,31 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
       throw new Error('Invalid tx hash passed into aztec_utl_getTxEffect oracle handler');
     }
 
+<<<<<<< HEAD
     const receipt = await this.aztecNode.getTxReceipt(txHash, { includeTxEffect: true });
     if (!receipt.isMined() || !receipt.txEffect || receipt.blockNumber > this.anchorBlockHeader.getBlockNumber()) {
       return Option.none();
+=======
+    return await this.#getTxEffectOption(txHash);
+  }
+
+  /** Fetches transaction effects for all hashes, preserving request order. */
+  public async getTxEffects(txHashes: EphemeralArray<TxHash>): Promise<EphemeralArray<Option<TxEffectData>>> {
+    const hashes = txHashes.readAll(this.ephemeralArrayService);
+    const invalidHash = hashes.find(txHash => txHash.hash.isZero());
+    if (invalidHash) {
+      throw new Error('Invalid tx hash passed into aztec_utl_getTxEffects oracle handler');
+>>>>>>> 7a77232ed7 (feat: getTxEffects oracle (#24636))
     }
 
-    const txEffect = receipt.txEffect;
-    return Option.some({
-      ...txEffect,
-      publicLogs: FlatPublicLogs.fromLogs(txEffect.publicLogs),
-      contractClassLogs: txEffect.contractClassLogs.map(log => ({
-        contractAddress: log.contractAddress,
-        fields: log.fields.toFields(),
-        emittedLength: log.emittedLength,
-      })),
-    });
+    const uniqueTxHashes = uniqueBy(hashes, h => h.toString());
+    const options = await Promise.all(uniqueTxHashes.map(txHash => this.#getTxEffectOption(txHash)));
+    const optionsByHash = new Map(uniqueTxHashes.map((txHash, i) => [txHash.toString(), options[i]]));
+
+    return EphemeralArray.fromValues(
+      this.ephemeralArrayService,
+      hashes.map(txHash => optionsByHash.get(txHash.toString())!),
+    );
   }
 
   public setCapsule(contractAddress: AztecAddress, slot: Fr, capsule: Fr[], scope: AztecAddress): void {
@@ -1102,6 +1113,26 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
         })
         .filter((entry): entry is [string, IndexedTxEffect] => entry[1] !== undefined),
     );
+  }
+
+  async #getTxEffectOption(txHash: TxHash): Promise<Option<TxEffectData>> {
+    const receipt = await this.aztecNodeReadCache.getTxReceiptWithEffect(txHash);
+    if (!receipt.isMined() || !receipt.txEffect || receipt.blockNumber > this.anchorBlockHeader.getBlockNumber()) {
+      return Option.none();
+    }
+    return Option.some(this.#toTxEffectData(receipt.txEffect));
+  }
+
+  #toTxEffectData(txEffect: TxEffect): TxEffectData {
+    return {
+      ...txEffect,
+      publicLogs: FlatPublicLogs.fromLogs(txEffect.publicLogs),
+      contractClassLogs: txEffect.contractClassLogs.map(log => ({
+        contractAddress: log.contractAddress,
+        fields: log.fields.toFields(),
+        emittedLength: log.emittedLength,
+      })),
+    };
   }
 
   /** Runs a query concurrently with a validation that the block hash is not ahead of the anchor block. */

--- a/yarn-project/pxe/src/oracle_version.ts
+++ b/yarn-project/pxe/src/oracle_version.ts
@@ -11,7 +11,11 @@
 /// if AZTEC_NR_MINOR > PXE_MINOR because if a contract is updated to use a newer Aztec.nr dependency without actually
 /// using any of the new oracles then there is no reason to throw.
 export const ORACLE_VERSION_MAJOR = 30;
+<<<<<<< HEAD
 export const ORACLE_VERSION_MINOR = 5;
+=======
+export const ORACLE_VERSION_MINOR = 8;
+>>>>>>> 7a77232ed7 (feat: getTxEffects oracle (#24636))
 
 /// This hash is computed from the `ORACLE_REGISTRY` declaration (each oracle's name, ordered parameter names and
 /// types, and return type) and is used to detect when the oracle interface changes. When it does, you need to either:
@@ -19,4 +23,8 @@ export const ORACLE_VERSION_MINOR = 5;
 /// - increment only `ORACLE_VERSION_MINOR` if the change is additive (a new oracle was added).
 ///
 /// These constants must be kept in sync between this file and `noir-projects/aztec-nr/aztec/src/oracle/version.nr`.
+<<<<<<< HEAD
 export const ORACLE_INTERFACE_HASH = 'f71b9662ec851e74593764a87792b0a91c181e1410aac49a4507f0bba949f6be';
+=======
+export const ORACLE_INTERFACE_HASH = 'b302a8e65d37043c0a0dc08a39895603122dce334843f0442462edb3f56e32e2';
+>>>>>>> 7a77232ed7 (feat: getTxEffects oracle (#24636))

--- a/yarn-project/txe/src/rpc_translator.ts
+++ b/yarn-project/txe/src/rpc_translator.ts
@@ -623,6 +623,15 @@ export class RPCTranslator {
   }
 
   // eslint-disable-next-line camelcase
+  aztec_utl_getTxEffects(...inputs: ForeignCallArgs) {
+    return callTxeHandler({
+      oracle: 'aztec_utl_getTxEffects',
+      inputs,
+      handler: ([txHashes]) => this.handlerAsUtility().getTxEffects(txHashes),
+    });
+  }
+
+  // eslint-disable-next-line camelcase
   aztec_utl_setCapsule(...inputs: ForeignCallArgs) {
     return callTxeHandler({
       oracle: 'aztec_utl_setCapsule',


### PR DESCRIPTION
Forward-port of #24636 (`feat: getTxEffects oracle`) from `v5-next` into `next`.

Cherry-pick **conflicted** — conflict markers are committed on this branch. Resolve them, run the formatter/tests, then mark ready for review.

**Conflicting files:** noir-projects/aztec-nr/aztec/src/oracle/version.nr,yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution.test.ts yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts,yarn-project/pxe/src/oracle_version.ts

Part of the v5-next → next backlog. Companion automation: #24848. See the tracking gist for the full list.