### PR TITLE
chore(fwd-port): #24644 feat!: forbid external note validation checks

### DIFF
--- a/docs/docs-developers/docs/aztec-nr/framework-description/advanced/how_to_prove_history.md
+++ b/docs/docs-developers/docs/aztec-nr/framework-description/advanced/how_to_prove_history.md
@@ -56,15 +56,17 @@ Prove a note exists in the note hash tree:
 To prove a note was valid (existed AND wasn't nullified) at a historical block:
 
 ```rust
-use aztec::history::note::assert_note_was_valid_by;
+use aztec::history::note::assert_local_note_was_valid_by;
 
 let header = self.context.get_anchor_block_header();
-assert_note_was_valid_by(header, hinted_note, &mut self.context);
+assert_local_note_was_valid_by(header, hinted_note, &mut self.context);
 ```
 
 This verifies both:
 1. The note was included in the note hash tree
 2. The note's nullifier was not in the nullifier tree
+
+The `assert_local_note_was_*` helpers only work for the executing contract's own notes: this is because it is not possible for a contract to retrieve the app-siloed nullifier hiding secret key that corresponds to another contract. To prove facts about another contract's notes, use `assert_note_existed_by`, which supports notes of any contract (see [Prove note inclusion](#prove-note-inclusion)).
 
 ## Prove at a specific historical block
 
@@ -83,13 +85,13 @@ Using `get_block_header_at` adds ~3k constraints to prove Archive tree membershi
 
 ## Prove a note was nullified
 
-To prove a note has been spent/nullified:
+To prove a note has been nullified:
 
 ```rust
-use aztec::history::note::assert_note_was_nullified_by;
+use aztec::history::note::assert_local_note_was_nullified_by;
 
 let header = self.context.get_anchor_block_header();
-assert_note_was_nullified_by(header, confirmed_note, &mut self.context);
+assert_local_note_was_nullified_by(header, confirmed_note, &mut self.context);
 ```
 
 ## Prove contract bytecode was published
@@ -137,10 +139,10 @@ The `aztec::history` module provides these functions:
 
 | Function | Module | Purpose |
 |----------|--------|---------|
-| `assert_note_existed_by` | `history::note` | Prove note exists in note hash tree |
-| `assert_note_was_valid_by` | `history::note` | Prove note exists and is not nullified |
-| `assert_note_was_nullified_by` | `history::note` | Prove note's nullifier is in nullifier tree |
-| `assert_note_was_not_nullified_by` | `history::note` | Prove note's nullifier is not in nullifier tree |
+| `assert_note_existed_by` | `history::note` | Prove note exists in note hash tree (any contract) |
+| `assert_local_note_was_valid_by` | `history::note` | Prove own note exists and is not nullified |
+| `assert_local_note_was_nullified_by` | `history::note` | Prove own note's nullifier is in nullifier tree |
+| `assert_local_note_was_not_nullified_by` | `history::note` | Prove own note's nullifier is not in nullifier tree |
 | `assert_nullifier_existed_by` | `history::nullifier` | Prove a siloed nullifier exists |
 | `assert_nullifier_did_not_exist_by` | `history::nullifier` | Prove a siloed nullifier does not exist |
 | `assert_contract_bytecode_was_published_by` | `history::deployment` | Prove a contract's bytecode was published |

--- a/docs/docs-developers/docs/resources/migration_notes.md
+++ b/docs/docs-developers/docs/resources/migration_notes.md
@@ -9,8 +9,11 @@ Aztec is in active development. Each version may introduce breaking changes that
 
 ## TBD
 
+<<<<<<< HEAD
 ## 5.0.1
 
+=======
+>>>>>>> 8b1903c998 (feat!: forbid external note validation checks (#24644))
 ### [Aztec.nr] History note nullification helpers renamed and restricted to own-contract notes
 
 The `history::note` helpers that recompute a note's nullifier have been renamed with a `local_` prefix and now assert that the note belongs to the executing contract:

--- a/noir-projects/aztec-nr/aztec/src/history/note.nr
+++ b/noir-projects/aztec-nr/aztec/src/history/note.nr
@@ -15,6 +15,19 @@ use crate::{
 
 mod test;
 
+/// Asserts that a note existed in the note hash tree by the time a block was mined.
+///
+/// Proves note inclusion at `block_header` by checking membership of the note's unique note hash, and returns a
+/// [`ConfirmedNote`] describing it.
+///
+/// ## Cross-contract notes
+///
+/// Unlike the nullification helpers, this works for notes of **any** contract, not just the executing one: note hashes
+/// are siloed with the note's own contract address (carried by the [`HintedNote`]) and no secret keys are involved.
+///
+/// To reason about whether such a note has been nullified, see [`assert_local_note_was_nullified_by`] and
+/// [`assert_local_note_was_not_nullified_by`], which — in contrast — can only be used for the executing contract's own
+/// notes.
 pub fn assert_note_existed_by<Note>(block_header: BlockHeader, hinted_note: HintedNote<Note>) -> ConfirmedNote<Note>
 where
     Note: NoteHash,
@@ -46,7 +59,17 @@ where
     ConfirmedNote::new(hinted_note, unique_note_hash)
 }
 
-pub fn assert_note_was_valid_by<Note>(
+/// Asserts a note existed and had not yet been nullified by a given block.
+///
+/// Combines [`assert_note_existed_by`] and [`assert_local_note_was_not_nullified_by`]: it proves both that the note
+/// existed at `block_header` and that it had not been nullified then. A contract typically uses this as a security gate
+/// before acting on a note whose validity at some past block matters.
+///
+/// ## Local notes only
+///
+/// Like [`assert_local_note_was_not_nullified_by`], this can only be used for notes of the executing contract. Use
+/// [`assert_note_existed_by`] on its own to prove existence of another contract's notes.
+pub fn assert_local_note_was_valid_by<Note>(
     block_header: BlockHeader,
     hinted_note: HintedNote<Note>,
     context: &mut PrivateContext,
@@ -55,10 +78,16 @@ where
     Note: NoteHash,
 {
     let confirmed_note = assert_note_existed_by(block_header, hinted_note);
-    assert_note_was_not_nullified_by(block_header, confirmed_note, context);
+    assert_local_note_was_not_nullified_by(block_header, confirmed_note, context);
 }
 
-pub fn assert_note_was_nullified_by<Note>(
+/// Asserts a note had been nullified by a given block.
+///
+/// ## Local notes only
+///
+/// This can only be used for notes of the executing contract. Use [`assert_note_existed_by`] on its own to prove
+/// existence of another contract's notes.
+pub fn assert_local_note_was_nullified_by<Note>(
     block_header: BlockHeader,
     confirmed_note: ConfirmedNote<Note>,
     context: &mut PrivateContext,
@@ -66,6 +95,11 @@ pub fn assert_note_was_nullified_by<Note>(
 where
     Note: NoteHash,
 {
+    assert(
+        confirmed_note.contract_address == context.this_address(),
+        "Note nullification history is only supported for the executing contract's own notes",
+    );
+
     let note_hash_for_nullification = compute_confirmed_note_hash_for_nullification(confirmed_note);
     let inner_nullifier =
         confirmed_note.note.compute_nullifier(context, confirmed_note.owner, note_hash_for_nullification);
@@ -75,7 +109,13 @@ where
     assert_nullifier_existed_by(block_header, siloed_nullifier);
 }
 
-pub fn assert_note_was_not_nullified_by<Note>(
+/// Asserts a note had **not** been nullified by a given block.
+///
+/// ## Local notes only
+///
+/// This can only be used for notes of the executing contract. Use [`assert_note_existed_by`] on its own to prove
+/// existence of another contract's notes.
+pub fn assert_local_note_was_not_nullified_by<Note>(
     block_header: BlockHeader,
     confirmed_note: ConfirmedNote<Note>,
     context: &mut PrivateContext,
@@ -83,6 +123,11 @@ pub fn assert_note_was_not_nullified_by<Note>(
 where
     Note: NoteHash,
 {
+    assert(
+        confirmed_note.contract_address == context.this_address(),
+        "Note nullification history is only supported for the executing contract's own notes",
+    );
+
     let note_hash_for_nullification = compute_confirmed_note_hash_for_nullification(confirmed_note);
 
     let inner_nullifier =

--- a/noir-projects/aztec-nr/aztec/src/history/note/test.nr
+++ b/noir-projects/aztec-nr/aztec/src/history/note/test.nr
@@ -1,6 +1,15 @@
-use crate::history::{note::{assert_note_existed_by, assert_note_was_valid_by}, test};
+use crate::history::{
+    note::{
+        assert_local_note_was_not_nullified_by, assert_local_note_was_nullified_by, assert_local_note_was_valid_by,
+        assert_note_existed_by,
+    },
+    test,
+};
 
+use crate::note::ConfirmedNote;
+use crate::protocol::{address::AztecAddress, traits::{FromField, ToField}};
 use crate::test::helpers::test_environment::PrivateContextOptions;
+use crate::test::mocks::mock_note::MockNote;
 
 #[test]
 unconstrained fn succeeds_on_blocks_after_note_creation() {
@@ -28,7 +37,7 @@ unconstrained fn validity_fails_on_blocks_before_note_creation() {
 
     env.private_context_opts(PrivateContextOptions::new().at_anchor_block_number(test::NOTE_CREATED_AT - 1), |context| {
         let header = context.anchor_block_header;
-        assert_note_was_valid_by(header, hinted_note, context);
+        assert_local_note_was_valid_by(header, hinted_note, context);
     });
 }
 
@@ -38,7 +47,7 @@ unconstrained fn succeeds_on_blocks_after_creation_and_before_nullification() {
 
     env.private_context_opts(PrivateContextOptions::new().at_anchor_block_number(test::NOTE_CREATED_AT), |context| {
         let header = context.anchor_block_header;
-        assert_note_was_valid_by(header, hinted_note, context);
+        assert_local_note_was_valid_by(header, hinted_note, context);
     });
 }
 
@@ -48,6 +57,47 @@ unconstrained fn fails_on_blocks_after_note_nullification() {
 
     env.private_context_opts(PrivateContextOptions::new().at_anchor_block_number(test::NOTE_NULLIFIED_AT), |context| {
         let header = context.anchor_block_header;
-        assert_note_was_valid_by(header, hinted_note, context);
+        assert_local_note_was_valid_by(header, hinted_note, context);
+    });
+}
+
+unconstrained fn foreign_hinted_note(executing_contract: AztecAddress) -> crate::note::HintedNote<MockNote> {
+    let foreign_contract = AztecAddress::from_field(executing_contract.to_field() + 1);
+    MockNote::new(69).contract_address(foreign_contract).build_hinted_note()
+}
+
+#[test(should_fail_with = "only supported for the executing contract's own notes")]
+unconstrained fn validity_fails_for_foreign_contract_note() {
+    let (env, hinted_note) = test::create_note();
+    let executing_contract = AztecAddress::from_field(hinted_note.contract_address.to_field() + 1);
+
+    let opts = PrivateContextOptions::new().at_anchor_block_number(test::NOTE_CREATED_AT).at_contract_address(
+        executing_contract,
+    );
+    env.private_context_opts(opts, |context| {
+        let header = context.anchor_block_header;
+        assert_local_note_was_valid_by(header, hinted_note, context);
+    });
+}
+
+#[test(should_fail_with = "only supported for the executing contract's own notes")]
+unconstrained fn nullified_fails_for_foreign_contract_note() {
+    let (env, _) = test::create_note();
+
+    env.private_context_opts(PrivateContextOptions::new().at_anchor_block_number(test::NOTE_CREATED_AT), |context| {
+        let header = context.anchor_block_header;
+        let foreign_note = ConfirmedNote::new(foreign_hinted_note(context.this_address()), 0);
+        assert_local_note_was_nullified_by(header, foreign_note, context);
+    });
+}
+
+#[test(should_fail_with = "only supported for the executing contract's own notes")]
+unconstrained fn not_nullified_fails_for_foreign_contract_note() {
+    let (env, _) = test::create_note();
+
+    env.private_context_opts(PrivateContextOptions::new().at_anchor_block_number(test::NOTE_CREATED_AT), |context| {
+        let header = context.anchor_block_header;
+        let foreign_note = ConfirmedNote::new(foreign_hinted_note(context.this_address()), 0);
+        assert_local_note_was_not_nullified_by(header, foreign_note, context);
     });
 }

--- a/noir-projects/aztec-nr/aztec/src/history/nullifier/test.nr
+++ b/noir-projects/aztec-nr/aztec/src/history/nullifier/test.nr
@@ -1,5 +1,5 @@
 use crate::history::{
-    note::{assert_note_existed_by, assert_note_was_not_nullified_by, assert_note_was_nullified_by},
+    note::{assert_local_note_was_not_nullified_by, assert_local_note_was_nullified_by, assert_note_existed_by},
     nullifier::{assert_nullifier_did_not_exist_by, assert_nullifier_existed_by},
     test,
 };
@@ -14,7 +14,7 @@ unconstrained fn note_is_nullified_succeeds_on_blocks_after_note_nullification()
     env.private_context_opts(PrivateContextOptions::new().at_anchor_block_number(test::NOTE_NULLIFIED_AT), |context| {
         let header = context.anchor_block_header;
         let confirmed_note = assert_note_existed_by(header, hinted_note);
-        assert_note_was_nullified_by(header, confirmed_note, context);
+        assert_local_note_was_nullified_by(header, confirmed_note, context);
     });
 }
 
@@ -27,7 +27,7 @@ unconstrained fn note_is_nullified_fails_on_blocks_before_note_nullification() {
         |context| {
             let header = context.anchor_block_header;
             let confirmed_note = assert_note_existed_by(header, hinted_note);
-            assert_note_was_nullified_by(header, confirmed_note, context);
+            assert_local_note_was_nullified_by(header, confirmed_note, context);
         },
     );
 }
@@ -74,7 +74,7 @@ unconstrained fn note_not_nullified_succeeds_in_blocks_before_note_nullification
         |context| {
             let header = context.anchor_block_header;
             let confirmed_note = assert_note_existed_by(header, hinted_note);
-            assert_note_was_not_nullified_by(header, confirmed_note, context);
+            assert_local_note_was_not_nullified_by(header, confirmed_note, context);
         },
     );
 }
@@ -86,7 +86,7 @@ unconstrained fn note_not_nullified_fails_in_blocks_after_note_nullification_fai
     env.private_context_opts(PrivateContextOptions::new().at_anchor_block_number(test::NOTE_NULLIFIED_AT), |context| {
         let header = context.anchor_block_header;
         let confirmed_note = assert_note_existed_by(header, hinted_note);
-        assert_note_was_not_nullified_by(header, confirmed_note, context);
+        assert_local_note_was_not_nullified_by(header, confirmed_note, context);
     });
 }
 

--- a/yarn-project/txe/esbuild/plugins/size_guard.mjs
+++ b/yarn-project/txe/esbuild/plugins/size_guard.mjs
@@ -11,6 +11,10 @@
 
 // Bump log:
 // - 2026-05-27: initial limits.
+<<<<<<< HEAD
+=======
+// - 2026-07-13: bumped total to 14.5 MiB.
+>>>>>>> 8b1903c998 (feat!: forbid external note validation checks (#24644))
 export const sizeLimits = [
   // Shared chunks emitted by code-splitting; carry the simulator + PXE + world-state graph.
   // Spikes here usually mean a heavy dep crept into the eager import path.


### PR DESCRIPTION
Forward-port of #24644 (`feat!: forbid external note validation checks`) from `v5-next` into `next`.

Cherry-pick **conflicted** — conflict markers are committed on this branch. Resolve them, run the formatter/tests, then mark ready for review.

**Conflicting files:** docs/docs-developers/docs/resources/migration_notes.md,yarn-project/txe/esbuild/plugins/size_guard.mjs

Part of the v5-next → next backlog. Companion automation: #24848. See the tracking gist for the full list.