### PR TITLE
chore(fwd-port): #24662 feat(txe): add option to authorize all utility call targets

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
@@ -92,13 +92,27 @@ pub struct TestEnvironment {
 /// );
 /// ```
 pub struct TestEnvironmentOptions {
+<<<<<<< HEAD
     tagging_secret_strategy: Option<TaggingSecretStrategy>,
+=======
+    default_unconstrained_tagging_secret_strategy: Option<TaggingSecretStrategy>,
+    default_constrained_tagging_secret_strategy: Option<TaggingSecretStrategy>,
+    authorize_all_utility_call_targets: bool,
+>>>>>>> 97b4c75c95 (feat(txe): add option to authorize all utility call targets (#24662))
 }
 
 impl TestEnvironmentOptions {
     /// Creates a new `TestEnvironmentOptions` with default values.
     pub fn new() -> Self {
+<<<<<<< HEAD
         Self { tagging_secret_strategy: Option::none() }
+=======
+        Self {
+            default_unconstrained_tagging_secret_strategy: Option::none(),
+            default_constrained_tagging_secret_strategy: Option::none(),
+            authorize_all_utility_call_targets: false,
+        }
+>>>>>>> 97b4c75c95 (feat(txe): add option to authorize all utility call targets (#24662))
     }
 
     /// Sets the [`TaggingSecretStrategy`] the wallet reports through the
@@ -110,6 +124,29 @@ impl TestEnvironmentOptions {
         self.tagging_secret_strategy = Option::some(strategy);
         *self
     }
+<<<<<<< HEAD
+=======
+
+    /// Sets `strategy` for both delivery modes: the equivalent of a PXE `resolveTaggingSecretStrategy` hook that
+    /// ignores the request's mode. See
+    /// [`with_default_tag_secret_strategy`](Self::with_default_tag_secret_strategy) to configure a single mode.
+    pub fn with_default_tag_secret_strategy_all_modes(&mut self, strategy: TaggingSecretStrategy) -> Self {
+        let _ = self.with_default_tag_secret_strategy(OnchainDeliveryMode::onchain_unconstrained(), strategy);
+        self.with_default_tag_secret_strategy(OnchainDeliveryMode::onchain_constrained(), strategy)
+    }
+
+    /// Authorizes all cross-contract utility call targets for the entire test.
+    ///
+    /// Removes the need to list targets on each call via
+    /// [`CallPrivateOptions::with_authorized_utility_call_targets`] and its siblings.
+    ///
+    /// By default, cross-contract utility calls are denied, mirroring a wallet that authorizes no such call. Use
+    /// this in tests that do not care about utility call authorization.
+    pub fn with_all_utility_call_targets_authorized(&mut self) -> Self {
+        self.authorize_all_utility_call_targets = true;
+        *self
+    }
+>>>>>>> 97b4c75c95 (feat(txe): add option to authorize all utility call targets (#24662))
 }
 
 /// Configuration values for [`TestEnvironment::private_context_opts`]. Meant to be used by calling `new` and then
@@ -619,6 +656,8 @@ impl TestEnvironment {
 
         // Forward the configured strategy to the wallet.
         txe_oracles::set_tagging_secret_strategy(options.tagging_secret_strategy);
+
+        txe_oracles::set_authorize_all_utility_call_targets(options.authorize_all_utility_call_targets);
 
         Self {
             // Use an offset to avoid secret collision with account secrets. Without this, when

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/txe_oracles.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/txe_oracles.nr
@@ -21,8 +21,13 @@ use crate::protocol::{
 /// [`oracle::version`](crate::oracle::version), which covers oracles used during contract execution by PXE.
 ///
 /// The TypeScript counterparts are in `yarn-project/txe/src/txe_oracle_version.ts`.
+<<<<<<< HEAD
 pub global TXE_ORACLE_VERSION_MAJOR: Field = 2;
 pub global TXE_ORACLE_VERSION_MINOR: Field = 3;
+=======
+pub global TXE_ORACLE_VERSION_MAJOR: Field = 3;
+pub global TXE_ORACLE_VERSION_MINOR: Field = 1;
+>>>>>>> 97b4c75c95 (feat(txe): add option to authorize all utility call targets (#24662))
 
 /// Asserts that the TXE oracle interface version is compatible.
 pub unconstrained fn assert_compatible_txe_oracle_version() {
@@ -267,6 +272,9 @@ pub unconstrained fn send_l1_to_l2_message(
 
 #[oracle(aztec_txe_setTaggingSecretStrategy)]
 pub unconstrained fn set_tagging_secret_strategy(strategy: Option<TaggingSecretStrategy>) {}
+
+#[oracle(aztec_txe_setAuthorizeAllUtilityCallTargets)]
+pub unconstrained fn set_authorize_all_utility_call_targets(authorize_all: bool) {}
 
 #[oracle(aztec_txe_privateCallNewFlow)]
 unconstrained fn private_call_new_flow_oracle<let M: u32, let N: u32, let S: u32, let T: u32>(

--- a/noir-projects/noir-contracts/contracts/test/nested_utility_contract/src/test.nr
+++ b/noir-projects/noir-contracts/contracts/test/nested_utility_contract/src/test.nr
@@ -1,11 +1,19 @@
 use crate::NestedUtility;
 use aztec::{
     protocol::{address::AztecAddress, traits::FromField},
-    test::helpers::test_environment::{CallPrivateOptions, ExecuteUtilityOptions, TestEnvironment, ViewPrivateOptions},
+    test::helpers::test_environment::{
+        CallPrivateOptions, ExecuteUtilityOptions, TestEnvironment, TestEnvironmentOptions, ViewPrivateOptions,
+    },
 };
 
 unconstrained fn setup() -> (TestEnvironment, AztecAddress, AztecAddress, AztecAddress) {
-    let mut env = TestEnvironment::new();
+    setup_with_opts(TestEnvironmentOptions::new())
+}
+
+unconstrained fn setup_with_opts(
+    options: TestEnvironmentOptions,
+) -> (TestEnvironment, AztecAddress, AztecAddress, AztecAddress) {
+    let mut env = TestEnvironment::new_opts(options);
     let account = env.create_light_account();
     let addr_a = env.deploy("NestedUtility").without_initializer();
     let addr_b = env.deploy("NestedUtility").without_initializer();
@@ -86,6 +94,21 @@ unconstrained fn cross_contract_utility_call_from_private_view_succeeds_with_aut
         NestedUtility::at(addr_a).delegate_pow_view(addr_b, 2, 3),
     );
     assert_eq(result, 8);
+}
+
+#[test]
+unconstrained fn all_call_types_succeed_with_all_utility_call_targets_authorized() {
+    let (env, account, addr_a, addr_b) = setup_with_opts(TestEnvironmentOptions::new()
+        .with_all_utility_call_targets_authorized());
+
+    let utility_result = env.execute_utility(NestedUtility::at(addr_a).delegate_pow_utility(addr_b, 2, 3));
+    assert_eq(utility_result, 8);
+
+    let private_result = env.call_private(account, NestedUtility::at(addr_a).delegate_pow_private(addr_b, 2, 3));
+    assert_eq(private_result, 8);
+
+    let view_result = env.view_private(account, NestedUtility::at(addr_a).delegate_pow_view(addr_b, 2, 3));
+    assert_eq(view_result, 8);
 }
 
 #[test]

--- a/yarn-project/txe/src/oracle/interfaces.ts
+++ b/yarn-project/txe/src/oracle/interfaces.ts
@@ -73,7 +73,22 @@ export interface ITxeExecutionOracle {
   addAccount(secret: Fr): Promise<CompleteAddress>;
   addAuthWitness(address: AztecAddress, messageHash: Fr): Promise<void>;
   sendL1ToL2Message(content: Fr, secretHash: Fr, sender: EthAddress, recipient: AztecAddress): Promise<Fr>;
+<<<<<<< HEAD
   setTaggingSecretStrategy(strategy: Option<TaggingSecretStrategy>): void;
+=======
+  /**
+   * Configures the tagging secret strategy the test's simulated wallet resolves for each delivery mode. A `none`
+   * clears that mode, so it falls back to the default strategy (or, when both modes end up unset, to no hook at all).
+   */
+  setTaggingSecretStrategies(
+    unconstrainedStrategy: Option<TaggingSecretStrategy>,
+    constrainedStrategy: Option<TaggingSecretStrategy>,
+  ): void;
+  /**
+   * Configures whether the test's simulated wallet authorizes every cross-contract utility call target.
+   */
+  setAuthorizeAllUtilityCallTargets(authorizeAll: boolean): void;
+>>>>>>> 97b4c75c95 (feat(txe): add option to authorize all utility call targets (#24662))
   getLastBlockTimestamp(): Promise<bigint>;
   getLastTxEffects(): Promise<{
     txHash: TxHash;

--- a/yarn-project/txe/src/oracle/txe_oracle_registry.ts
+++ b/yarn-project/txe/src/oracle/txe_oracle_registry.ts
@@ -324,6 +324,10 @@ export const TXE_ORACLE_REGISTRY = {
     params: [{ name: 'strategy', type: OPTION(TAGGING_SECRET_STRATEGY) }],
   }),
 
+  aztec_txe_setAuthorizeAllUtilityCallTargets: makeEntry({
+    params: [{ name: 'authorizeAll', type: BOOL }],
+  }),
+
   aztec_txe_getLastBlockTimestamp: makeEntry({
     returnType: BIGINT,
   }),

--- a/yarn-project/txe/src/oracle/txe_oracle_top_level_context.ts
+++ b/yarn-project/txe/src/oracle/txe_oracle_top_level_context.ts
@@ -123,7 +123,12 @@ export class TXEOracleTopLevelContext implements IMiscOracle, ITxeExecutionOracl
     private version: Fr,
     private chainId: Fr,
     private authwits: Map<string, AuthWitness>,
+<<<<<<< HEAD
     private taggingSecretStrategy: TaggingSecretStrategy | undefined,
+=======
+    private taggingSecretStrategies: TXETaggingSecretStrategies,
+    private authorizeAllUtilityCallTargets: boolean,
+>>>>>>> 97b4c75c95 (feat(txe): add option to authorize all utility call targets (#24662))
     private readonly artifactResolver: TXEArtifactResolver,
     private readonly rootPath: string,
     private readonly packageName: string,
@@ -358,6 +363,10 @@ export class TXEOracleTopLevelContext implements IMiscOracle, ITxeExecutionOracl
 
   setTaggingSecretStrategy(strategy: Option<TaggingSecretStrategy>): void {
     this.taggingSecretStrategy = strategy.value;
+  }
+
+  setAuthorizeAllUtilityCallTargets(authorizeAll: boolean): void {
+    this.authorizeAllUtilityCallTargets = authorizeAll;
   }
 
   async sendL1ToL2Message(content: Fr, secretHash: Fr, sender: EthAddress, recipient: AztecAddress): Promise<Fr> {
@@ -973,9 +982,25 @@ export class TXEOracleTopLevelContext implements IMiscOracle, ITxeExecutionOracl
     }
   }
 
+<<<<<<< HEAD
   close(): [bigint, Map<string, AuthWitness>, TaggingSecretStrategy | undefined] {
     this.logger.debug('Exiting Top Level Context');
     return [this.nextBlockTimestamp, this.authwits, this.taggingSecretStrategy];
+=======
+  close(): {
+    nextBlockTimestamp: bigint;
+    authwits: Map<string, AuthWitness>;
+    taggingSecretStrategies: TXETaggingSecretStrategies;
+    authorizeAllUtilityCallTargets: boolean;
+  } {
+    this.logger.debug('Exiting Top Level Context');
+    return {
+      nextBlockTimestamp: this.nextBlockTimestamp,
+      authwits: this.authwits,
+      taggingSecretStrategies: this.taggingSecretStrategies,
+      authorizeAllUtilityCallTargets: this.authorizeAllUtilityCallTargets,
+    };
+>>>>>>> 97b4c75c95 (feat(txe): add option to authorize all utility call targets (#24662))
   }
 
   private async getLastBlockNumber(): Promise<BlockNumber> {
@@ -987,6 +1012,9 @@ export class TXEOracleTopLevelContext implements IMiscOracle, ITxeExecutionOracl
     callerContext: 'private' | 'private view' | 'utility',
     authorizedTargets: AztecAddress[],
   ): ExecutionHooks['authorizeUtilityCall'] | undefined {
+    if (this.authorizeAllUtilityCallTargets) {
+      return authorizeAllUtilityCallsHook;
+    }
     if (authorizedTargets.length === 0) {
       return undefined;
     }
@@ -996,3 +1024,11 @@ export class TXEOracleTopLevelContext implements IMiscOracle, ITxeExecutionOracl
       });
   }
 }
+
+/**
+ * An `authorizeUtilityCall` hook that authorizes every cross-contract utility call.
+ *
+ * Backs the `aztec_txe_setAuthorizeAllUtilityCallTargets` oracle.
+ */
+export const authorizeAllUtilityCallsHook: NonNullable<ExecutionHooks['authorizeUtilityCall']> = () =>
+  Promise.resolve({ authorized: true });

--- a/yarn-project/txe/src/oracle/txe_oracle_version.ts
+++ b/yarn-project/txe/src/oracle/txe_oracle_version.ts
@@ -5,8 +5,13 @@
  *
  * The Noir counterparts are in `noir-projects/aztec-nr/aztec/src/test/helpers/txe_oracles.nr`.
  */
+<<<<<<< HEAD
 export const TXE_ORACLE_VERSION_MAJOR = 2;
 export const TXE_ORACLE_VERSION_MINOR = 3;
+=======
+export const TXE_ORACLE_VERSION_MAJOR = 3;
+export const TXE_ORACLE_VERSION_MINOR = 1;
+>>>>>>> 97b4c75c95 (feat(txe): add option to authorize all utility call targets (#24662))
 
 /**
  * This hash is computed from the TXE oracle interfaces (IAvmExecutionOracle and ITxeExecutionOracle) and is used to
@@ -14,4 +19,8 @@ export const TXE_ORACLE_VERSION_MINOR = 3;
  *   - TXE_ORACLE_VERSION_MAJOR (and reset MINOR to 0) for breaking changes, or
  *   - TXE_ORACLE_VERSION_MINOR for additive changes (new oracle method added).
  */
+<<<<<<< HEAD
 export const TXE_ORACLE_INTERFACE_HASH = '4ed3618087fafb4aa63c6580996a69bf6bc257844035a2019692586b5b8daf34';
+=======
+export const TXE_ORACLE_INTERFACE_HASH = '89c60f191f8f60ef72d592e46dd6c4afff10dc47a9e14f4f8d37e31e40857d9c';
+>>>>>>> 97b4c75c95 (feat(txe): add option to authorize all utility call targets (#24662))

--- a/yarn-project/txe/src/rpc_translator.ts
+++ b/yarn-project/txe/src/rpc_translator.ts
@@ -229,6 +229,15 @@ export class RPCTranslator {
     });
   }
 
+  // eslint-disable-next-line camelcase
+  aztec_txe_setAuthorizeAllUtilityCallTargets(...inputs: ForeignCallArgs) {
+    return callTxeHandler({
+      oracle: 'aztec_txe_setAuthorizeAllUtilityCallTargets',
+      inputs,
+      handler: ([authorizeAll]) => this.handlerAsTxe().setAuthorizeAllUtilityCallTargets(authorizeAll),
+    });
+  }
+
   // PXE oracles
 
   // eslint-disable-next-line camelcase

--- a/yarn-project/txe/src/txe_session.ts
+++ b/yarn-project/txe/src/txe_session.ts
@@ -60,7 +60,7 @@ import { DEFAULT_ADDRESS, MAX_OFFCHAIN_EFFECTS_PER_TXE_QUERY, MAX_OFFCHAIN_EFFEC
 import type { IAvmExecutionOracle, ITxeExecutionOracle } from './oracle/interfaces.js';
 import { TXEOraclePublicContext } from './oracle/txe_oracle_public_context.js';
 import { callTxeLegacyHandler } from './oracle/txe_oracle_registry.js';
-import { TXEOracleTopLevelContext } from './oracle/txe_oracle_top_level_context.js';
+import { TXEOracleTopLevelContext, authorizeAllUtilityCallsHook } from './oracle/txe_oracle_top_level_context.js';
 import { TXE_ORACLE_VERSION_MAJOR, TXE_ORACLE_VERSION_MINOR } from './oracle/txe_oracle_version.js';
 import { TXEPrivateExecutionOracle } from './oracle/txe_private_execution_oracle.js';
 import { RPCTranslator, UnavailableOracleError } from './rpc_translator.js';
@@ -237,7 +237,12 @@ function emptyLastCallState(): LastCallState {
 export class TXESession implements TXESessionStateHandler {
   private state: SessionState = { name: 'TOP_LEVEL' };
   private authwits: Map<string, AuthWitness> = new Map();
+<<<<<<< HEAD
   private taggingSecretStrategy: TaggingSecretStrategy | undefined = undefined;
+=======
+  private taggingSecretStrategies: TXETaggingSecretStrategies = new Map();
+  private authorizeAllUtilityCallTargets = false;
+>>>>>>> 97b4c75c95 (feat(txe): add option to authorize all utility call targets (#24662))
   private lastCallInfo: LastCallState = emptyLastCallState();
   private txeOracleVersion: { major: number; minor: number } | undefined;
 
@@ -365,7 +370,12 @@ export class TXESession implements TXESessionStateHandler {
       version,
       chainId,
       new Map(),
+<<<<<<< HEAD
       undefined,
+=======
+      new Map(),
+      false, // authorizeAllUtilityCallTargets
+>>>>>>> 97b4c75c95 (feat(txe): add option to authorize all utility call targets (#24662))
       artifactResolver,
       rootPath,
       packageName,
@@ -695,7 +705,12 @@ export class TXESession implements TXESessionStateHandler {
       this.version,
       this.chainId,
       this.authwits,
+<<<<<<< HEAD
       this.taggingSecretStrategy,
+=======
+      this.taggingSecretStrategies,
+      this.authorizeAllUtilityCallTargets,
+>>>>>>> 97b4c75c95 (feat(txe): add option to authorize all utility call targets (#24662))
       this.artifactResolver,
       this.rootPath,
       this.packageName,
@@ -776,7 +791,12 @@ export class TXESession implements TXESessionStateHandler {
       txResolver: this.stateMachine.txResolver,
       simulator: new WASMSimulator(),
       hooks: composeHooks({
+<<<<<<< HEAD
         resolveTaggingSecretStrategy: taggingSecretStrategy ? () => Promise.resolve(taggingSecretStrategy) : undefined,
+=======
+        resolveTaggingSecretStrategy: makeResolveTaggingSecretStrategyHook(this.taggingSecretStrategies),
+        authorizeUtilityCall: this.authorizeAllUtilityCallTargets ? authorizeAllUtilityCallsHook : undefined,
+>>>>>>> 97b4c75c95 (feat(txe): add option to authorize all utility call targets (#24662))
       }),
       transientArrayService,
     });
@@ -877,6 +897,9 @@ export class TXESession implements TXESessionStateHandler {
       scopes: await this.keyStore.getAccounts(),
       simulator: new WASMSimulator(),
       utilityExecutor: this.utilityExecutorForContractSync(anchorBlockHeader),
+      hooks: composeHooks({
+        authorizeUtilityCall: this.authorizeAllUtilityCallTargets ? authorizeAllUtilityCallsHook : undefined,
+      }),
       // Execution-tree root (top-level utility run): own store; nested frames inherit it.
       transientArrayService: new TransientArrayService(),
     });
@@ -905,9 +928,18 @@ export class TXESession implements TXESessionStateHandler {
     // TODO: persisting authwits this way is quite unfortunate: they create a temporary utility context that would
     // otherwise reset them, so we'd not be able to pass more than one per execution. Ideally authwits would be passed
     // alongside a contract call instead of pre-seeded.
+<<<<<<< HEAD
     [this.nextBlockTimestamp, this.authwits, this.taggingSecretStrategy] = (
       this.oracleHandler as TXEOracleTopLevelContext
     ).close();
+=======
+    ({
+      nextBlockTimestamp: this.nextBlockTimestamp,
+      authwits: this.authwits,
+      taggingSecretStrategies: this.taggingSecretStrategies,
+      authorizeAllUtilityCallTargets: this.authorizeAllUtilityCallTargets,
+    } = (this.oracleHandler as TXEOracleTopLevelContext).close());
+>>>>>>> 97b4c75c95 (feat(txe): add option to authorize all utility call targets (#24662))
   }
 
   private async exitPrivateState() {


### PR DESCRIPTION
Forward-port of #24662 (`feat(txe): add option to authorize all utility call targets`) from `v5-next` into `next`.

Cherry-pick **conflicted** — conflict markers are committed on this branch. Resolve them, run the formatter/tests, then mark ready for review.

**Conflicting files:** noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr,noir-projects/aztec-nr/aztec/src/test/helpers/txe_oracles.nr yarn-project/txe/src/oracle/interfaces.ts,yarn-project/txe/src/oracle/txe_oracle_top_level_context.ts yarn-project/txe/src/oracle/txe_oracle_version.ts,yarn-project/txe/src/txe_session.ts

Part of the v5-next → next backlog. Companion automation: #24848. See the tracking gist for the full list.