### PR TITLE
chore(fwd-port): #24740 feat: weblock controlled opfs pool

### DIFF
--- a/yarn-project/kv-store/src/sqlite-opfs/errors.ts
+++ b/yarn-project/kv-store/src/sqlite-opfs/errors.ts
@@ -42,3 +42,56 @@ const SQLITE3MC_DECRYPT_ERROR_PATTERNS: readonly RegExp[] = [
 export function isDecryptFailureMessage(message: string): boolean {
   return SQLITE3MC_DECRYPT_ERROR_PATTERNS.some(p => p.test(message));
 }
+<<<<<<< HEAD
+=======
+
+/**
+ * Error thrown by sqlite-opfs when the on-disk database image is corrupt
+ * (`SQLITE_CORRUPT`, result code 11 — "database disk image is malformed").
+ *
+ * Distinct from {@link SqliteEncryptionError}: no key recovers a corrupt image,
+ * so there is nothing to retry. The only escape is to delete the store and start
+ * fresh, so consumers pattern-match on `instanceof SqliteCorruptionError` to wipe
+ * and reopen rather than surfacing a dead-end error.
+ **/
+export class SqliteCorruptionError extends Error {
+  constructor(message: string, opts?: { cause?: unknown }) {
+    super(message, opts?.cause !== undefined ? { cause: opts.cause } : undefined);
+    this.name = 'SqliteCorruptionError';
+  }
+}
+
+/** Error thrown when another browser context already owns a store's OPFS pool. */
+export class SqlitePoolBusyError extends Error {
+  constructor(public readonly poolDirectory: string) {
+    super(`SQLite-OPFS pool "${poolDirectory}" is already in use by another store instance`);
+    this.name = 'SqlitePoolBusyError';
+  }
+}
+
+/** Error thrown when the browser context does not expose the Web Locks API required by the OPFS SAH pool. */
+export class SqliteWebLocksUnavailableError extends Error {
+  constructor() {
+    super('SQLite-OPFS requires the Web Locks API, but it is unavailable in this browser context');
+    this.name = 'SqliteWebLocksUnavailableError';
+  }
+}
+
+/**
+ * Strings/codes raised by SQLite when a database image is corrupt. Kept disjoint
+ * from {@link SQLITE3MC_DECRYPT_ERROR_PATTERNS}: "file is not a database"
+ * (SQLITE_NOTADB) is the decrypt signal, whereas a malformed image is the
+ * genuinely-unrecoverable SQLITE_CORRUPT.
+ **/
+const SQLITE_CORRUPTION_ERROR_PATTERNS: readonly RegExp[] = [
+  /database disk image is malformed/i,
+  /\bSQLITE_CORRUPT\b/i,
+];
+
+/**
+ * Returns `true` if `message` matches one of the known SQLite corruption strings.
+ **/
+export function isCorruptionMessage(message: string): boolean {
+  return SQLITE_CORRUPTION_ERROR_PATTERNS.some(p => p.test(message));
+}
+>>>>>>> 386f120fb2 (feat: weblock controlled opfs pool (#24740))

--- a/yarn-project/kv-store/src/sqlite-opfs/index.ts
+++ b/yarn-project/kv-store/src/sqlite-opfs/index.ts
@@ -5,6 +5,7 @@ import { initStoreForRollupAndSchemaVersion } from '../utils.js';
 import { AztecSQLiteOPFSStore } from './store.js';
 
 export { AztecSQLiteOPFSStore } from './store.js';
+<<<<<<< HEAD
 export { SqliteEncryptionError } from './errors.js';
 export type { SqliteEncryptionErrorCode } from './errors.js';
 
@@ -23,6 +24,16 @@ export async function createStore(
   const store = await AztecSQLiteOPFSStore.open(createLogger('kv-store:sqlite-opfs'), name, false);
   return initStoreForRollupAndSchemaVersion(store, schemaVersion, config.rollupAddress, log);
 }
+=======
+export {
+  SqliteCorruptionError,
+  SqliteEncryptionError,
+  SqlitePoolBusyError,
+  SqliteWebLocksUnavailableError,
+} from './errors.js';
+export type { SqliteEncryptionErrorCode } from './errors.js';
+export { OPFS_POOL_DIR_PREFIX, deletePoolDirectory, deleteStore, listStores, storePoolDirectory } from './manage.js';
+>>>>>>> 386f120fb2 (feat: weblock controlled opfs pool (#24740))
 
 export function openTmpStore(ephemeral: boolean = false): Promise<AztecSQLiteOPFSStore> {
   return AztecSQLiteOPFSStore.open(createLogger('kv-store:sqlite-opfs'), undefined, ephemeral);

--- a/yarn-project/kv-store/src/sqlite-opfs/manage.ts
+++ b/yarn-project/kv-store/src/sqlite-opfs/manage.ts
@@ -1,0 +1,46 @@
+import { normalizePoolDirectory, withPoolLock } from './pool_lock.js';
+
+/** Prefix for the per-store OPFS SAH pool directories owned by this package. */
+export const OPFS_POOL_DIR_PREFIX = '.aztec-kv-';
+
+/**
+ * OPFS directory holding a store's SAH pool. One directory per store: the SAH-pool VFS allows only one
+ * concurrent instance per directory and its capacity does not grow automatically, so sharing a pool across
+ * stores would make concurrently opened stores contend for locks and orphaned stores exhaust pool slots.
+ */
+export function storePoolDirectory(effectiveName: string): string {
+  return `${OPFS_POOL_DIR_PREFIX}${effectiveName}`;
+}
+
+/**
+ * Lists the names of every persistent sqlite-opfs store in this origin, by enumerating the per-store pool
+ * directories. Includes stores other than the current one, so wallets can surface and clean up data for
+ * networks/versions no longer in use.
+ */
+export async function listStores(): Promise<string[]> {
+  const root = await navigator.storage.getDirectory();
+  const names: string[] = [];
+  for await (const [entryName, handle] of root.entries()) {
+    if (handle.kind === 'directory' && entryName.startsWith(OPFS_POOL_DIR_PREFIX)) {
+      names.push(entryName.slice(OPFS_POOL_DIR_PREFIX.length));
+    }
+  }
+  return names;
+}
+
+/**
+ * Permanently deletes a store by effective name (as returned by {@link listStores}). The store must be closed:
+ * an open store holds the directory's Web Lock and the removal will reject with `SqlitePoolBusyError`.
+ */
+export async function deleteStore(effectiveName: string): Promise<void> {
+  await deletePoolDirectory(storePoolDirectory(effectiveName));
+}
+
+/** Permanently deletes one OPFS SAH-pool directory after exclusively locking it. */
+export async function deletePoolDirectory(poolDirectory: string): Promise<void> {
+  poolDirectory = normalizePoolDirectory(poolDirectory);
+  await withPoolLock(poolDirectory, async () => {
+    const root = await navigator.storage.getDirectory();
+    await root.removeEntry(poolDirectory, { recursive: true });
+  });
+}

--- a/yarn-project/kv-store/src/sqlite-opfs/pool_lock.ts
+++ b/yarn-project/kv-store/src/sqlite-opfs/pool_lock.ts
@@ -1,0 +1,62 @@
+import { SqlitePoolBusyError, SqliteWebLocksUnavailableError } from './errors.js';
+
+export const DEFAULT_SAH_POOL_DIRECTORY = '.aztec-kv';
+
+const WEB_LOCK_PREFIX = 'aztec.sqlite-opfs.pool:';
+
+export interface PoolLockLease {
+  release(): Promise<void>;
+}
+
+export function normalizePoolDirectory(poolDirectory?: string): string {
+  const path = poolDirectory
+    ?.split('/')
+    .filter(segment => segment.length > 0)
+    .join('/');
+  return path || DEFAULT_SAH_POOL_DIRECTORY;
+}
+
+export async function acquirePoolLock(poolDirectory?: string): Promise<PoolLockLease> {
+  if (!navigator.locks) {
+    throw new SqliteWebLocksUnavailableError();
+  }
+  const normalizedDirectory = normalizePoolDirectory(poolDirectory);
+  const acquired = Promise.withResolvers<Lock | null>();
+  const hold = Promise.withResolvers<void>();
+  const request = navigator.locks.request(
+    `${WEB_LOCK_PREFIX}${normalizedDirectory}`,
+    { mode: 'exclusive', ifAvailable: true },
+    async lock => {
+      acquired.resolve(lock);
+      if (lock) {
+        await hold.promise;
+      }
+    },
+  );
+  request.catch(acquired.reject);
+
+  if (!(await acquired.promise)) {
+    await request;
+    throw new SqlitePoolBusyError(normalizedDirectory);
+  }
+
+  let released = false;
+  return {
+    release: async () => {
+      if (!released) {
+        released = true;
+        hold.resolve();
+      }
+      await request;
+    },
+  };
+}
+
+export async function withPoolLock<T>(poolDirectory: string, callback: () => Promise<T>): Promise<T> {
+  const lease = await acquirePoolLock(poolDirectory);
+  try {
+    return await callback();
+  } finally {
+    await lease.release();
+  }
+}

--- a/yarn-project/kv-store/src/sqlite-opfs/store.ts
+++ b/yarn-project/kv-store/src/sqlite-opfs/store.ts
@@ -14,6 +14,7 @@ import { SqliteEncryptionError } from './errors.js';
 import { SQLiteOPFSAztecMap } from './map.js';
 import type { ResultRow, SqlValue, WorkerRequest, WorkerResponse } from './messages.js';
 import { SQLiteOPFSAztecMultiMap } from './multi_map.js';
+import { type PoolLockLease, acquirePoolLock, normalizePoolDirectory } from './pool_lock.js';
 import { SQLiteOPFSAztecSet } from './set.js';
 import { SQLiteOPFSAztecSingleton } from './singleton.js';
 
@@ -36,12 +37,14 @@ export class AztecSQLiteOPFSStore implements AztecAsyncKVStore {
   #nextId = 0;
   #inTx = false;
   #closed = false;
+  #workerFailed = false;
 
   private constructor(
     worker: Worker,
     name: string,
     log: Logger,
     public readonly isEphemeral: boolean,
+    private readonly poolLock?: PoolLockLease,
   ) {
     this.#worker = worker;
     this.#name = name;
@@ -57,6 +60,7 @@ export class AztecSQLiteOPFSStore implements AztecAsyncKVStore {
       handler.resolve(ev.data);
     };
     this.#worker.onerror = ev => {
+      this.#workerFailed = true;
       this.#log.error(`SQLite worker crashed: ${ev.message}`);
       this.#rejectPending(`SQLite worker crashed: ${ev.message}`);
     };
@@ -69,6 +73,10 @@ export class AztecSQLiteOPFSStore implements AztecAsyncKVStore {
    * Pass `poolDirectory` to place the SAH Pool in a non-default OPFS subdirectory —
    * required when multiple stores coexist in the same tab, because the SAH Pool holds
    * an exclusive lock on its directory.
+   *
+   * Persistent stores hold an origin-wide Web Lock for the pool directory until close
+   * or delete. If another store instance already owns it, open fails immediately with
+   * `SqlitePoolBusyError`.
    *
    * Pass `encryptionKey` (exactly 32 bytes) to enable at-rest encryption via sqlite3mc's
    * ChaCha20 page cipher. The key buffer is **transferred** to the worker — its
@@ -102,22 +110,26 @@ export class AztecSQLiteOPFSStore implements AztecAsyncKVStore {
     log.debug(
       `Opening SQLite-OPFS ${ephemeral ? 'ephemeral ' : ''}${encryptionKey ? 'encrypted ' : ''}database ${dbName}`,
     );
-    const worker = new Worker(new URL('./worker.js', import.meta.url), { type: 'module' });
-    const store = new AztecSQLiteOPFSStore(worker, dbName, log, ephemeral);
-    // Transfer (not clone) the key buffer to the worker so we don't leave a
-    // second copy on the main thread. Caveat: this detaches the caller's
-    // encryptionKey.buffer — subsequent reads from the same Uint8Array are empty.
-    const transfer = encryptionKey ? [encryptionKey.buffer as ArrayBuffer] : undefined;
+    const effectivePoolDirectory = ephemeral ? undefined : normalizePoolDirectory(poolDirectory);
+    const poolLock = effectivePoolDirectory ? await acquirePoolLock(effectivePoolDirectory) : undefined;
+    let worker: Worker | undefined;
     try {
+      worker = new Worker(new URL('./worker.js', import.meta.url), { type: 'module' });
+      const store = new AztecSQLiteOPFSStore(worker, dbName, log, ephemeral, poolLock);
+      // Transfer (not clone) the key buffer to the worker so we don't leave a
+      // second copy on the main thread. Caveat: this detaches the caller's
+      // encryptionKey.buffer — subsequent reads from the same Uint8Array are empty.
+      const transfer = encryptionKey ? [encryptionKey.buffer as ArrayBuffer] : undefined;
       await store.#sendRequest(
-        { type: 'init', id: store.#allocId(), dbName, ephemeral, poolDirectory, encryptionKey },
+        { type: 'init', id: store.#allocId(), dbName, ephemeral, poolDirectory: effectivePoolDirectory, encryptionKey },
         transfer,
       );
+      return store;
     } catch (err) {
-      worker.terminate();
+      worker?.terminate();
+      await poolLock?.release();
       throw err;
     }
-    return store;
   }
 
   openMap<K extends Key, V extends Value>(name: string): AztecAsyncMap<K, V> {
@@ -179,12 +191,16 @@ export class AztecSQLiteOPFSStore implements AztecAsyncKVStore {
       return;
     }
     this.#closed = true;
-    await this.#txQueue.end();
-    await this.#sendRequest({ type: 'deleteDb', id: this.#allocId(), dbName: this.#name }).catch(err =>
-      this.#log.warn(`SQLite deleteDb failed: ${err instanceof Error ? err.message : err}`),
-    );
-    this.#worker.terminate();
-    this.#rejectPending('SQLite store deleted');
+    try {
+      await this.#txQueue.end();
+      await this.#sendRequest({ type: 'deleteDb', id: this.#allocId(), dbName: this.#name }).catch(err =>
+        this.#log.warn(`SQLite deleteDb failed: ${err instanceof Error ? err.message : err}`),
+      );
+    } finally {
+      this.#worker.terminate();
+      this.#rejectPending('SQLite store deleted');
+      await this.poolLock?.release();
+    }
   }
 
   /**
@@ -204,10 +220,14 @@ export class AztecSQLiteOPFSStore implements AztecAsyncKVStore {
       return;
     }
     this.#closed = true;
-    await this.#txQueue.end();
-    await this.#sendRequest({ type: 'close', id: this.#allocId() }).catch(() => {});
-    this.#worker.terminate();
-    this.#rejectPending('SQLite store closed');
+    try {
+      await this.#txQueue.end();
+      await this.#sendRequest({ type: 'close', id: this.#allocId() }).catch(() => {});
+    } finally {
+      this.#worker.terminate();
+      this.#rejectPending('SQLite store closed');
+      await this.poolLock?.release();
+    }
   }
 
   backupTo(_dstPath: string, _compact?: boolean): Promise<void> {
@@ -268,6 +288,9 @@ export class AztecSQLiteOPFSStore implements AztecAsyncKVStore {
   }
 
   #sendRequest(req: WorkerRequest, transfer?: Transferable[]): Promise<WorkerResponse> {
+    if (this.#workerFailed) {
+      return Promise.reject(new Error('SQLite worker has crashed'));
+    }
     return new Promise<WorkerResponse>((resolve, reject) => {
       this.#pending.set(req.id, {
         resolve: resp => {

--- a/yarn-project/kv-store/src/sqlite-opfs/store_management.test.ts
+++ b/yarn-project/kv-store/src/sqlite-opfs/store_management.test.ts
@@ -1,0 +1,99 @@
+import { mockLogger } from '../interfaces/utils.js';
+import { AztecSQLiteOPFSStore, SqlitePoolBusyError, SqliteWebLocksUnavailableError } from './index.js';
+import { deleteStore, listStores, storePoolDirectory } from './manage.js';
+import { acquirePoolLock } from './pool_lock.js';
+
+const openByName = (name: string) => AztecSQLiteOPFSStore.open(mockLogger, name, false, storePoolDirectory(name));
+
+describe('sqlite-opfs store management', () => {
+  it('round-trips data for a store reopened by name', async () => {
+    const store = await openByName('mech_roundtrip');
+    await store.openSingleton<string>('payload').set('data');
+    await store.close();
+
+    const reopened = await openByName('mech_roundtrip');
+    expect(await reopened.openSingleton<string>('payload').getAsync()).toEqual('data');
+    await reopened.close();
+    await deleteStore('mech_roundtrip');
+  });
+
+  it('opens two different stores concurrently in the same tab', async () => {
+    const a = await openByName('mech_concurrent_a');
+    const b = await openByName('mech_concurrent_b');
+
+    await a.openSingleton<string>('k').set('a');
+    await b.openSingleton<string>('k').set('b');
+    expect(await a.openSingleton<string>('k').getAsync()).toEqual('a');
+    expect(await b.openSingleton<string>('k').getAsync()).toEqual('b');
+
+    await a.close();
+    await b.close();
+    await deleteStore('mech_concurrent_a');
+    await deleteStore('mech_concurrent_b');
+  });
+
+  it('allows only one concurrent opener for a fresh store', async () => {
+    const name = 'mech_same_store';
+    const results = await Promise.allSettled([openByName(name), openByName(name)]);
+    const opened = results.filter(result => result.status === 'fulfilled').map(result => result.value);
+    const rejected = results.filter(result => result.status === 'rejected').map(result => result.reason);
+
+    expect(opened).toHaveLength(1);
+    expect(rejected).toHaveLength(1);
+    expect(rejected[0]).toBeInstanceOf(SqlitePoolBusyError);
+
+    await opened[0].close();
+    const reopened = await openByName(name);
+    await reopened.close();
+    await deleteStore(name);
+  });
+
+  it('fails clearly when Web Locks are unavailable', async () => {
+    const descriptor = Object.getOwnPropertyDescriptor(navigator, 'locks');
+    Object.defineProperty(navigator, 'locks', { configurable: true, value: undefined });
+    try {
+      await expect(acquirePoolLock('mech_no_web_locks')).rejects.toThrow(SqliteWebLocksUnavailableError);
+    } finally {
+      if (descriptor) {
+        Object.defineProperty(navigator, 'locks', descriptor);
+      } else {
+        delete (navigator as unknown as { locks?: LockManager }).locks;
+      }
+    }
+  });
+
+  it('lists created stores and deletes them', async () => {
+    const store = await openByName('mech_managed');
+    await store.openSingleton<string>('k').set('v');
+    await store.close();
+
+    expect(await listStores()).toContain('mech_managed');
+    await deleteStore('mech_managed');
+    expect(await listStores()).not.toContain('mech_managed');
+
+    // Recreating after deletion starts empty.
+    const fresh = await openByName('mech_managed');
+    expect(await fresh.openSingleton<string>('k').getAsync()).toBeUndefined();
+    await fresh.close();
+    await deleteStore('mech_managed');
+  });
+
+  // Regression test: close() must not resolve until the worker has released the SAH pool's OPFS
+  // handles, otherwise deleteStore races Chromium's async reclaim of the terminated worker and
+  // intermittently throws NoModificationAllowedError. Looped to amplify the race window.
+  it('deletes a store immediately after close, repeatedly', async () => {
+    for (let i = 0; i < 20; i++) {
+      const store = await openByName('mech_close_release');
+      await store.openSingleton<string>('k').set(`v${i}`);
+      await store.close();
+      await deleteStore('mech_close_release');
+    }
+  });
+
+  it('refuses to delete a store that is currently open', async () => {
+    const store = await openByName('mech_locked');
+    await expect(deleteStore('mech_locked')).rejects.toThrow(SqlitePoolBusyError);
+    await store.close();
+    await deleteStore('mech_locked');
+  });
+});

--- a/yarn-project/kv-store/src/sqlite-opfs/worker.ts
+++ b/yarn-project/kv-store/src/sqlite-opfs/worker.ts
@@ -3,6 +3,7 @@ import sqlite3InitModule, { type Database, type SAHPoolUtil, type Sqlite3Static 
 
 import { SqliteEncryptionError, type SqliteEncryptionErrorCode, isDecryptFailureMessage } from './errors.js';
 import type { ResultRow, SqlValue, WorkerRequest, WorkerResponse } from './messages.js';
+import { DEFAULT_SAH_POOL_DIRECTORY } from './pool_lock.js';
 
 const SCHEMA_SQL = `
   CREATE TABLE IF NOT EXISTS data (
@@ -19,7 +20,6 @@ const SCHEMA_SQL = `
   CREATE UNIQUE INDEX IF NOT EXISTS idx_container_key_hash ON data(container, key, hash);
 `;
 
-const DEFAULT_SAH_POOL_DIRECTORY = '.aztec-kv';
 const SAH_POOL_VFS_NAME = 'aztec-kv-opfs';
 const MC_SAH_POOL_VFS_NAME = `multipleciphers-${SAH_POOL_VFS_NAME}`;
 
@@ -91,9 +91,32 @@ async function handleInit(
 }
 
 function handleClose(): void {
+<<<<<<< HEAD
   db?.close();
   db = undefined;
   dbPath = undefined;
+=======
+  try {
+    db?.close();
+  } finally {
+    db = undefined;
+    dbPath = undefined;
+    releasePool();
+  }
+}
+
+/**
+ * Releases the SAH pool's OPFS sync access handles before the terminal RPC is acked. Worker
+ * termination releases them only asynchronously, so without this a caller that deletes or reopens
+ * the store directory right after close()/delete() resolves races Chromium's cleanup
+ * (NoModificationAllowedError from removeEntry, or a hang installing a new pool on the directory).
+ * pauseVfs releases the handles without touching file contents; the worker is terminated right
+ * after, so the pool is never resumed.
+ */
+function releasePool(): void {
+  pool?.pauseVfs();
+  pool = undefined;
+>>>>>>> 386f120fb2 (feat: weblock controlled opfs pool (#24740))
 }
 
 async function handleExport(): Promise<Uint8Array> {
@@ -197,7 +220,15 @@ function respond(msg: WorkerResponse): void {
     }
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
-    respond({ type: 'err', id: req.id, message, encryptionCode: detectEncryptionCode(req, err, message) });
+    const encryptionCode = detectEncryptionCode(req, err, message);
+    if (req.type === 'init') {
+      try {
+        handleClose();
+      } catch {
+        // The main thread terminates this worker after a failed init, which releases any remaining OPFS handles.
+      }
+    }
+    respond({ type: 'err', id: req.id, message, encryptionCode });
   }
 };
 

--- a/yarn-project/wallets/src/embedded/store_encryption.ts
+++ b/yarn-project/wallets/src/embedded/store_encryption.ts
@@ -8,7 +8,16 @@
  *     surfaces, so callers don't leak the SAH Pool's OPFS lock.
  */
 import type { Logger } from '@aztec/foundation/log';
+<<<<<<< HEAD
 import { AztecSQLiteOPFSStore, SqliteEncryptionError } from '@aztec/kv-store/sqlite-opfs';
+=======
+import {
+  AztecSQLiteOPFSStore,
+  SqliteCorruptionError,
+  SqliteEncryptionError,
+  deletePoolDirectory,
+} from '@aztec/kv-store/sqlite-opfs';
+>>>>>>> 386f120fb2 (feat: weblock controlled opfs pool (#24740))
 
 /** Which of the embedded wallet's two stores failed to open. */
 export type EmbeddedStoreName = 'pxe' | 'wallet';
@@ -50,6 +59,31 @@ const defaultOpenStore: OpenSqliteEncryptedStoreFn = (log, name, poolDirectory, 
   AztecSQLiteOPFSStore.open(log, name, false, poolDirectory, encryptionKey);
 
 /**
+<<<<<<< HEAD
+=======
+ * Internal seam for tests to inject a fake store wiper. Defaults to removing the store's OPFS pool directory
+ * outright. Not part of the public API.
+ *
+ * @internal
+ */
+export type WipeSqliteStoreFn = (poolDirectory: string | undefined) => Promise<void>;
+
+/**
+ * Deletes a store's OPFS pool directory. Safe to call only after a *failed* open() — a live store's SAH pool holds
+ * a lock on the directory and the removal would reject. A store with no `poolDirectory` lives in the shared default
+ * pool, which we won't blow away (it would take unrelated stores with it), so wiping is a no-op there.
+ */
+const defaultWipeStore: WipeSqliteStoreFn = async poolDirectory => {
+  if (!poolDirectory) {
+    return;
+  }
+  await deletePoolDirectory(poolDirectory).catch(() => {
+    // Already gone / never created — nothing to wipe.
+  });
+};
+
+/**
+>>>>>>> 386f120fb2 (feat: weblock controlled opfs pool (#24740))
  * Opens the PXE and wallet stores in sequence, both encrypted with keys obtained from `getEncryptionKey`.
  *
  * The callback is invoked once per store (twice total per call) because `AztecSQLiteOPFSStore.open` *transfers*


### PR DESCRIPTION
Forward-port of #24740 (`feat: weblock controlled opfs pool`) from `v5-next` into `next`.

Cherry-pick **conflicted** — conflict markers are committed on this branch. Resolve them, run the formatter/tests, then mark ready for review.

**Conflicting files:** yarn-project/kv-store/src/sqlite-opfs/errors.ts,yarn-project/kv-store/src/sqlite-opfs/index.ts yarn-project/kv-store/src/sqlite-opfs/manage.ts,yarn-project/kv-store/src/sqlite-opfs/store_management.test.ts yarn-project/kv-store/src/sqlite-opfs/worker.ts,yarn-project/wallets/src/embedded/store_encryption.ts

Part of the v5-next → next backlog. Companion automation: #24848. See the tracking gist for the full list.