### PR TITLE
resolve conflicts: #24689 fix(aztec-nr)!: compute note property selectors from the packed layout

### DIFF
--- a/docs/docs-developers/docs/resources/migration_notes.md
+++ b/docs/docs-developers/docs/resources/migration_notes.md
@@ -9,9 +9,6 @@ Aztec is in active development. Each version may introduce breaking changes that
 
 ## TBD
 
-<<<<<<< HEAD
-## 5.0.1
-=======
 ### [Aztec.nr] Note property selectors are typed and use packed-layout indices
 
 The selectors in the generated `properties()` used the field's position in the note struct declaration, which pointed at the wrong packed field for any note with an earlier field packing to more than one `Field` (a `Point`, an array, a nested struct). Selector indices are now the field's offset in the note's packed representation, so `select`/`sort` criteria constrain the field they name.
@@ -23,7 +20,8 @@ Breaking changes:
 - `select` takes its value typed as the property's type. Cast the value if a mixed-type comparison was intentional.
 - `properties()` cannot be used with a custom `Packable` layout. Define property selectors manually for such notes.
 - Every note field type must implement `Packable`, even when the note's own `Packable` is hand-written.
->>>>>>> 10e339a580 (fix(aztec-nr)!: compute note property selectors from the packed layout (#24689))
+
+## 5.0.1
 
 ### [Aztec.nr] History note nullification helpers renamed and restricted to own-contract notes
 


### PR DESCRIPTION
Automated conflict-resolution attempt for #24866 (`fwd-port-24689`). Merges next + v5-next PR #24689.

Conflict was in `docs/docs-developers/docs/resources/migration_notes.md`. Resolved as a union: kept next's `## 5.0.1` heading and placed PR #24689's new Aztec.nr note (typed note property selectors / packed-layout indices) under the `## TBD` section, per the docs convention that new migration notes go under TBD and published entries are not modified. No entries dropped.

Confidence: high. Single docs union with no code changes; no artifact regeneration required.

Review carefully.