### PR TITLE
resolve conflicts: #24739 fix: handle corruption errors

### DIFF
--- a/docs/examples/ts/aztecjs_runner/run.sh
+++ b/docs/examples/ts/aztecjs_runner/run.sh
@@ -115,14 +115,10 @@ setup_project() {
         [ ${#NPM_DEPS[@]} -gt 0 ] && yarn_add_with_retry "${NPM_DEPS[@]}"
     fi
 
-<<<<<<< HEAD
     # Pin typescript to the 5.x line used across the monorepo. An unpinned
     # `yarn add typescript` now resolves to the 7.x native port, whose package
     # layout has no lib/_tsc.js, so yarn 4's builtin compat patch fails to apply.
     yarn_add_with_retry -D "typescript@^5.3.3" tsx
-=======
-    yarn_add_with_retry -D typescript@^5.3.3 tsx
->>>>>>> 007dcc2ae6 (fix: handle corruption errors (#24739))
 
     # Copy tsconfig
     cp "$EXAMPLES_DIR/tsconfig.template.json" tsconfig.json


### PR DESCRIPTION
Automated conflict-resolution attempt for #24867 (`fwd-port-24739`). Merges next + v5-next PR #24739.

## Resolution summary

- **docs/examples/ts/aztecjs_runner/run.sh** — the only file with committed conflict markers. Both sides pin `typescript@^5.3.3`; next's side additionally carried an explanatory comment about the 7.x native-port compat break. Kept next's fully-commented, quoted form (`typescript@^5.3.3`) since it is functionally identical to the incoming change and strictly more informative. Confident.
- **yarn-project/pxe/src/entrypoints/client/store.ts** — listed as a conflicting file but had no committed markers on `fwd-port-24739`; it already contains the forward-ported corruption-handling logic (`SqliteCorruptionError` catch + `deleteStore` + reopen). No changes needed. Confident.

No generated/pinned artifacts were involved, so no regeneration is required.

Confidence: high. Review carefully.