### PR TITLE
resolve conflicts: #24604 feat(pxe)!: Add AppTaggingSecret kinds to keys in tagging stores

### DIFF
--- a/docs/docs-developers/docs/resources/migration_notes.md
+++ b/docs/docs-developers/docs/resources/migration_notes.md
@@ -9,7 +9,6 @@ Aztec is in active development. Each version may introduce breaking changes that
 
 ## TBD
 
-<<<<<<< HEAD
 ## 5.0.1
 
 ### [Aztec.nr] History note nullification helpers renamed and restricted to own-contract notes
@@ -49,8 +48,6 @@ This change also removes `createStore` from `@aztec/kv-store/sqlite-opfs` and `@
 
 ## 5.0.0
 
-=======
->>>>>>> 736f39189c (feat(pxe)!: Add AppTaggingSecret kinds to keys in tagging stores (#24604))
 ### [PXE] Local PXE database is reset on upgrade
 
 The persisted tagging stores now key every entry by the self-describing `<kind>:<secret>:<app>` form of `AppTaggingSecret`; unconstrained secrets previously used a two-part `<secret>:<app>` key. This bumps the PXE data schema version, and there is no forward migration for the old keys: on first open the PXE clears any database whose stored schema version differs from the current one. The wipe resets the entire PXE store, not just the tagging data, because all of it shares one backing database.


### PR DESCRIPTION
Automated conflict-resolution attempt for #24859 (`fwd-port-24604`). Merges next + v5-next PR #24604.

Only `docs/docs-developers/docs/resources/migration_notes.md` conflicted. The incoming (v5) side of the hunk was empty: PR #24604's migration note ("### [PXE] Local PXE database is reset on upgrade") already exists in the common region below the markers, since next also carries that note. next's side additionally introduced the `## 5.0.1` section (with its own new notes) and the `## 5.0.0` header. Resolution keeps next's `## 5.0.1` and `## 5.0.0` headers and preserves PR #24604's note underneath `## 5.0.0` — union of both, nothing dropped.

No generated artifacts were part of this conflict; no regeneration required.

Confidence: high. Review carefully.