### PR TITLE
resolve conflicts: #24479 feat: assert non revertible phase when setting fee payer

### DIFF
--- a/docs/docs-developers/docs/resources/migration_notes.md
+++ b/docs/docs-developers/docs/resources/migration_notes.md
@@ -9,7 +9,6 @@ Aztec is in active development. Each version may introduce breaking changes that
 
 ## TBD
 
-<<<<<<< HEAD
 ## 5.0.1
 
 ### [Aztec.nr] History note nullification helpers renamed and restricted to own-contract notes
@@ -26,8 +25,6 @@ These helpers derive the note's nullifier from the executing contract's app-silo
 
 **Impact**: Update call sites to the new names. Own-contract usage (the common case) is unaffected beyond the rename. `assert_note_existed_by` is unchanged and still supports notes of any contract, since note-hash inclusion involves no keys.
 
-=======
->>>>>>> da9ac1c883 (feat: assert non revertible phase when setting fee payer (#24479))
 ### [Aztec.nr] `set_as_fee_payer` now asserts it is called during the setup phase
 
 `PrivateContext::set_as_fee_payer` now asserts that execution is still in the setup (non-revertible) phase, i.e. that `end_setup` has not yet been called by any function in the transaction. Electing a fee payer in the revertible phase was never safe: compensation collected by the fee payer after `end_setup` can be discarded if a public call later reverts, while the protocol still debits the fee payer's fee-juice balance.


### PR DESCRIPTION
Automated conflict-resolution attempt for #24855 (`fwd-port-24479`). Merges next + v5-next PR #24479. Review carefully.

## Conflict details

Single conflicted file: `docs/docs-developers/docs/resources/migration_notes.md`.

The only conflict hunk sat around the `## 5.0.1` section. next (HEAD) added a `## 5.0.1` section documenting the renamed `history::note` nullification helpers; PR #24479's incoming side was empty at that location because its actual migration note (`set_as_fee_payer` now asserts the setup phase) already appears immediately below the conflict as unconflicted content.

Resolution: union kept — next's `## 5.0.1` history-helper note is retained, and PR #24479's `set_as_fee_payer` note remains present below it. All markers removed; no notes dropped.

## Confidence

High. Docs-only change; both migration notes are preserved. No generated/pinned artifacts were involved, so no regeneration required.