### PR TITLE
resolve conflicts: #24644 feat!: forbid external note validation checks

### DIFF
--- a/docs/docs-developers/docs/resources/migration_notes.md
+++ b/docs/docs-developers/docs/resources/migration_notes.md
@@ -9,11 +9,8 @@ Aztec is in active development. Each version may introduce breaking changes that
 
 ## TBD
 
-<<<<<<< HEAD
 ## 5.0.1
 
-=======
->>>>>>> 8b1903c998 (feat!: forbid external note validation checks (#24644))
 ### [Aztec.nr] History note nullification helpers renamed and restricted to own-contract notes
 
 The `history::note` helpers that recompute a note's nullifier have been renamed with a `local_` prefix and now assert that the note belongs to the executing contract:

--- a/yarn-project/txe/esbuild/plugins/size_guard.mjs
+++ b/yarn-project/txe/esbuild/plugins/size_guard.mjs
@@ -11,10 +11,7 @@
 
 // Bump log:
 // - 2026-05-27: initial limits.
-<<<<<<< HEAD
-=======
 // - 2026-07-13: bumped total to 14.5 MiB.
->>>>>>> 8b1903c998 (feat!: forbid external note validation checks (#24644))
 export const sizeLimits = [
   // Shared chunks emitted by code-splitting; carry the simulator + PXE + world-state graph.
   // Spikes here usually mean a heavy dep crept into the eager import path.


### PR DESCRIPTION
Automated conflict-resolution attempt for #24863 (`fwd-port-24644`). Merges next + v5-next PR #24644.

## Resolution summary

Two files had committed conflict markers; both hunks were trivial (one side empty), so the resolution is a clean union.

- `docs/docs-developers/docs/resources/migration_notes.md`: kept next's `## 5.0.1` heading (incoming side was empty). The renamed-history-helpers note from #24644 was already present below the conflict and is untouched. Union preserved.
- `yarn-project/txe/esbuild/plugins/size_guard.mjs`: kept the incoming bump-log line `// - 2026-07-13: bumped total to 14.5 MiB.` (next side was empty).

## Flag for human review

In `size_guard.mjs`, the added bump-log comment says the total was bumped to 14.5 MiB, but `totalLimitMiB` remains at next's value of `14` (that line was outside the conflict and unchanged on both sides). This inconsistency is inherited from the forward-port, not introduced here. Confirm whether `totalLimitMiB` should be raised to match the log entry, or the log line adjusted.

No generated/pinned artifacts were involved, so no regeneration is required.

Confidence: high on the marker resolution; please verify the size-guard limit intent noted above.