### PR TITLE
resolve conflicts: #24561 fix(txe): align tagging strategy oracle with PXE

### DIFF
--- a/docs/docs-developers/docs/resources/migration_notes.md
+++ b/docs/docs-developers/docs/resources/migration_notes.md
@@ -9,7 +9,6 @@ Aztec is in active development. Each version may introduce breaking changes that
 
 ## TBD
 
-<<<<<<< HEAD
 ## 5.0.1
 
 ### [Aztec.nr] History note nullification helpers renamed and restricted to own-contract notes
@@ -55,8 +54,6 @@ The persisted tagging stores now key every entry by the self-describing `<kind>:
 
 **Impact**: On upgrade your local PXE state is reset. You must re-register accounts and re-sync from genesis. Wallets should surface a "your local state was reset, please re-register accounts and re-sync" path.
 
-=======
->>>>>>> 6dd127124d (fix(txe): align tagging strategy oracle with PXE (#24561))
 ### [Aztec.nr] `TestEnvironmentOptions::with_tagging_secret_strategy` replaced
 
 `TestEnvironmentOptions::with_tagging_secret_strategy` is now `with_default_tag_secret_strategy_all_modes` for tests


### PR DESCRIPTION
Automated conflict-resolution attempt for #24856 (`fwd-port-24561`). Merges next + v5-next PR #24561.

## Resolution

Single conflict in `docs/docs-developers/docs/resources/migration_notes.md`. next had promoted the old `## TBD` entries into versioned `## 5.0.1` / `## 5.0.0` sections; the incoming side of the conflict was empty. PR #24561's migration note (`[Aztec.nr] TestEnvironmentOptions::with_tagging_secret_strategy replaced`) was already present as post-conflict common content, grouped with the other Aztec.nr `## 5.0.0` notes.

Resolved as a UNION: kept next's `## 5.0.1`/`## 5.0.0` sections and preserved PR #24561's note. Only the three conflict-marker lines were removed; no prose was dropped from either side.

Confidence: high. This is a docs-only, additive conflict with no generated artifacts involved and no code logic to reconcile. Reviewer may wish to confirm the placement of the TestEnvironmentOptions note under `## 5.0.0` is acceptable versus `## TBD`.