### PR TITLE
resolve conflicts: #24599 feat!: make inbox secrets be multiple fields

### DIFF
--- a/docs/docs-developers/docs/resources/migration_notes.md
+++ b/docs/docs-developers/docs/resources/migration_notes.md
@@ -9,7 +9,6 @@ Aztec is in active development. Each version may introduce breaking changes that
 
 ## TBD
 
-<<<<<<< HEAD
 ## 5.0.1
 
 ### [Aztec.nr] History note nullification helpers renamed and restricted to own-contract notes
@@ -64,8 +63,6 @@ configure the TXE default wallet strategy hook; contract-fixed delivery derivati
 For mode-specific defaults and hook semantics, see the
 [`resolveTaggingSecretStrategy` test helper docs](../foundational-topics/pxe/execution_hooks.md#resolvetaggingsecretstrategy).
 
-=======
->>>>>>> 9f1167e6d4 (feat!: make inbox secrets be multiple fields (#24599))
 ### [Aztec.nr] L1-to-L2 message consumption takes the secret as an array
 
 `PrivateContext::consume_l1_to_l2_message` and `PublicContext::consume_l1_to_l2_message` now take the message secret as an arbitrary-length array `[Field; N]` instead of a single `Field`, so a consumer can derive its secret hash from more than one field. The helpers `compute_secret_hash` and `compute_l1_to_l2_message_nullifier` are likewise now generic over the secret length. A single-field secret behaves exactly as before (the hashes are unchanged for `N = 1`) — just wrap it in an array.


### PR DESCRIPTION
Automated conflict-resolution attempt for #24858 (`fwd-port-24599`). Merges next + v5-next PR #24599.

## Conflict resolved

- `docs/docs-developers/docs/resources/migration_notes.md` — single conflict hunk. next added `## 5.0.1` and `## 5.0.0` sections between `## TBD` and #24599's `### [Aztec.nr] L1-to-L2 message consumption takes the secret as an array` note. The incoming (v5) side of the hunk was empty; #24599's actual migration note was already common content immediately after the marker. Resolved as a UNION: removed the three marker lines only, keeping next's 5.0.1/5.0.0 sections and #24599's L1-to-L2 note. Dropped nothing.

## Confidence

High. next already contains #24599's migration note, so the resolved file is byte-identical to `origin/next`'s version of this file. No generated/pinned artifacts were involved; no regeneration required.

Review carefully.