### PR TITLE
resolve conflicts: #24820 chore: clarify scope of packable impl detection

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/macros/notes.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/notes.nr
@@ -161,23 +161,6 @@ comptime fn generate_note_properties(s: TypeDefinition) -> Quoted {
 
         impl aztec::note::note_interface::NoteProperties<$struct_name> for $name {
             fn properties() -> $struct_name {
-<<<<<<< HEAD
-=======
-                let note_type_name = $note_type_name;
-                let fields_packed_len: u32 = $accumulated_offset;
-                let note_packed_len: u32 = <$typ as aztec::protocol::traits::Packable>::N;
-                // We only reject custom Packable layouts whose total packed length differs from the derived
-                // layout's. A hand-written pack() that keeps the same total length but reorders same-width fields
-                // is deliberately not caught: the selectors are computed from declared field order and would
-                // silently point at the wrong packed slot. Detecting it would require knowing whether Packable was
-                // derived or hand-written, which comptime cannot currently tell us. Custom layouts must define their
-                // PropertySelectors manually.
-                std::static_assert(
-                    fields_packed_len == note_packed_len,
-                    f"{note_type_name}'s auto-generated note properties assume the #[derive(Packable)] layout ({fields_packed_len} fields), but its hand-written Packable packs to {note_packed_len}. Derive Packable, or define property selectors manually for the custom layout. See https://docs.aztec.network/errors/15",
-                );
-
->>>>>>> 15c7a1e5a9 (chore: clarify scope of packable impl detection (#24820))
                 $struct_name {
                     $properties
                 }


### PR DESCRIPTION
Automated conflict-resolution attempt for #24871 (`fwd-port-24820`). Merges next + v5-next PR #24820.

## Resolution

One file conflicted: `noir-projects/aztec-nr/aztec/src/macros/notes.nr`.

The conflict hunk was inside `generate_note_properties`'s `properties()` body. The v5 (incoming) side added a `std::static_assert` block comparing `fields_packed_len` (`$accumulated_offset`) against the Packable-derived `note_packed_len`, plus PR #24820's clarifying comment about custom Packable layouts.

On `next`, `generate_note_properties` uses a completely different property-generation approach: each field selector is fixed at `offset: 0, length: 32` indexed by `i`, and there is no `$accumulated_offset` (nor `$note_type_name`/`$typ`) defined in that function's scope. next's packed-length validation lives elsewhere (the `note_packed_len <= max_note_packed_len` check in `generate_note_type_impl`).

Grafting the incoming block onto next would reference undefined quote-interpolation variables (`$accumulated_offset`) and would break compilation, and would introduce a length-equality check that next's architecture does not use. PR #24820 itself only refines a comment on that equality check — a check that does not exist on next.

Resolution: kept next's state (dropped the incoming block). The substance of #24820 (comment clarification on the packed-length equality check) is not applicable to next's current note-property macro.

## Confidence

Medium. The mechanical resolution is clean (no markers remain, result is identical to next). The judgement call — that #24820's clarification has no landing spot on next because the underlying check is absent — is worth a human eye from someone familiar with the divergence between the v5 and next note macros. No generated artifacts were involved; no regeneration required.