### PR TITLE
resolve conflicts: #24631 feat: preserve stores on schema version or rollup address change

### DIFF
--- a/docs/docs-developers/docs/resources/migration_notes.md
+++ b/docs/docs-developers/docs/resources/migration_notes.md
@@ -9,7 +9,6 @@ Aztec is in active development. Each version may introduce breaking changes that
 
 ## TBD
 
-<<<<<<< HEAD
 ## 5.0.1
 
 ### [Aztec.nr] History note nullification helpers renamed and restricted to own-contract notes
@@ -50,22 +49,10 @@ This change also removes `createStore` from `@aztec/kv-store/sqlite-opfs` and `@
 ## 5.0.0
 
 ### [PXE] Local PXE database is reset on upgrade
-=======
-### [PXE] Stores are now selected by `(l1ChainId, rollupAddress, schemaVersion)` instead of being wiped on mismatch
->>>>>>> 0bb0628549 (feat: preserve stores on schema version or rollup address change (#24631))
 
-Previously, connecting a PXE or embedded wallet to a different or redeployed rollup, or bumping the store schema version, wiped the existing on-disk store in place. That meant master account keys could be destroyed simply by pointing a wallet at a different network. PXE data stores now exist per `(l1ChainId, rollupAddress, schemaVersion)` triple, and switching networks (or upgrading) selects or creates the matching store instead of overwriting previous ones. The embedded wallet's `wallet_data` store is partitioned the same way, so accounts and aliases are per network: switching networks starts with an empty account list until accounts are re-imported, and switching back finds the originals intact.
+The persisted tagging stores now key every entry by the self-describing `<kind>:<secret>:<app>` form of `AppTaggingSecret`; unconstrained secrets previously used a two-part `<secret>:<app>` key. This bumps the PXE data schema version, and there is no forward migration for the old keys: on first open the PXE clears any database whose stored schema version differs from the current one. The wipe resets the entire PXE store, not just the tagging data, because all of it shares one backing database.
 
-**Impact**: The first start after upgrading to this version begins with a fresh, empty store; the pre-upgrade data is not deleted. On Node.js environments (lmdb-v2) pre-upgrade data stays at `<dataDirectory>/<name>` while new per-identity `pxe_data` stores live under `<dataDirectory>/<name>-stores/`. The embedded Node.js wallet previously stored data in cwd-relative, rollup-address-suffixed directories instead (`pxe_data_<rollupAddress>/pxe_data` for the PXE store, `wallet_data_<rollupAddress>/wallet_data` for the wallet store): if you used it before this release, that is where the old data lives. The embedded wallet now defaults its data root to `aztec-wallet-data/`, with per-identity wallet stores under `<dataDirectory>/wallet_data-stores/` on Node.js and OPFS store names prefixed `wallet_data_` in the browser. Browser apps can enumerate and clean up `pxe_data` and `wallet_data` stores for networks no longer in use with the new `listStores()` / `deleteStore()` utilities:
-
-```ts
-import { deleteStore, listStores } from '@aztec/kv-store/sqlite-opfs';
-
-const names = await listStores();
-await deleteStore(names[0]);
-```
-
-This change also removes `createStore` from `@aztec/kv-store/sqlite-opfs` and `@aztec/kv-store/deprecated/indexeddb`: stores are now opened by name with `AztecSQLiteOPFSStore.open` / `AztecIndexedDBStore.open`.
+**Impact**: On upgrade your local PXE state is reset. You must re-register accounts and re-sync from genesis. Wallets should surface a "your local state was reset, please re-register accounts and re-sync" path.
 
 ### [Aztec.nr] `TestEnvironmentOptions::with_tagging_secret_strategy` replaced
 

--- a/yarn-project/pxe/src/storage/backwards_compatibility_tests/pxe_db_compatibility.test.ts
+++ b/yarn-project/pxe/src/storage/backwards_compatibility_tests/pxe_db_compatibility.test.ts
@@ -1,11 +1,8 @@
+import { Fr } from '@aztec/foundation/curves/bn254';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { KeyStore } from '@aztec/key-store';
-<<<<<<< HEAD
-import { createStore, openTmpStore } from '@aztec/kv-store/lmdb-v2';
-=======
 import type { AztecAsyncKVStore } from '@aztec/kv-store';
 import { openTmpStore } from '@aztec/kv-store/lmdb-v2';
->>>>>>> 0bb0628549 (feat: preserve stores on schema version or rollup address change (#24631))
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
 import { GENESIS_BLOCK_HEADER_HASH } from '@aztec/stdlib/block';
 
@@ -29,6 +26,9 @@ expect.extend({ toMatchFile });
 const __dirname = dirname(fileURLToPath(import.meta.url));
 // The last schema in which the key store still persisted the message-signing and fallback secret keys.
 const PRE_MESSAGE_AND_FALLBACK_SECRET_KEY_REMOVAL_PXE_SCHEMA_VERSION = 10;
+// The last schema in which the tagging stores keyed unconstrained entries by the legacy two-part AppTaggingSecret
+// format (`<secret>:<app>`), before every key moved to the self-describing `<kind>:<secret>:<app>` form.
+const PRE_KIND_PREFIXED_TAGGING_KEY_PXE_SCHEMA_VERSION = 12;
 
 /**
  * Asserts that `value` matches the per-store snapshot file `__snapshots__/<name>.json`. Each store gets its own file
@@ -147,8 +147,6 @@ async function collectOpenedStores() {
 }
 
 /**
-<<<<<<< HEAD
-=======
  * Seeds rows into a `pxe_data` store opened at `oldSchemaVersion`, then opens the store for the current
  * `PXE_DATA_SCHEMA_VERSION`. The schema version is part of the store identity, so the current version selects a
  * fresh store: `assertNotRead` proves the legacy rows are invisible to new code, and `assertLegacyIntact` proves
@@ -195,7 +193,6 @@ async function expectFreshStoreSelectedOnUpgradeFrom(
 }
 
 /**
->>>>>>> 0bb0628549 (feat: preserve stores on schema version or rollup address change (#24631))
  * Backwards-compatibility test suite for PXE storage. The intent is to detect any change to the bytes PXE writes to
  * disk that would render existing on-device data unreadable after a version bump. Each schema test (in
  * `schema_tests.ts`) drives the production write path of one store class, then snapshots every sub-store the class
@@ -214,44 +211,6 @@ async function expectFreshStoreSelectedOnUpgradeFrom(
 describe('PXE storage compatibility test suite', () => {
   it('never reads key-store rows written under an older schema version, and leaves them intact', async () => {
     const account = AztecAddress.fromStringUnsafe('0x0b3683ee9df3ed6ed7027145bd6093f783b0bb4d8354501d906db7bb8cb58ea3');
-<<<<<<< HEAD
-    const dataDirectory = await mkdtemp(join(tmpdir(), 'pxe-schema-reset-'));
-    const config = {
-      dataDirectory,
-      dataStoreMapSizeKb: 1024,
-      rollupAddress: EthAddress.ZERO,
-    };
-
-    try {
-      const oldStore = await createStore(
-        'pxe_data',
-        PRE_MESSAGE_AND_FALLBACK_SECRET_KEY_REMOVAL_PXE_SCHEMA_VERSION,
-        config,
-      );
-      try {
-        await oldStore
-          .openMap<string, Buffer>('key_store')
-          .set(
-            `${account.toString()}-ivsk_m`,
-            Buffer.from('1fb01c42d1aaa2662041b899c77cb19e08192193acc5a94405f1b43c974eba7a', 'hex'),
-          );
-      } finally {
-        await oldStore.close();
-      }
-
-      const currentStore = await createStore('pxe_data', PXE_DATA_SCHEMA_VERSION, config);
-      try {
-        const keyStore = new KeyStore(currentStore);
-        // Opening a below-current-version DB triggers DatabaseVersionManager to wipe it, so the account written under
-        // the old schema is gone and the new code never reads its now-incompatible rows.
-        await expect(keyStore.hasAccount(account)).resolves.toBe(false);
-      } finally {
-        await currentStore.close();
-      }
-    } finally {
-      await rm(dataDirectory, { recursive: true, force: true, maxRetries: 3 });
-    }
-=======
     const ivskKey = `${account.toString()}-ivsk_m`;
     const ivskValue = Buffer.from('1fb01c42d1aaa2662041b899c77cb19e08192193acc5a94405f1b43c974eba7a', 'hex');
     await expectFreshStoreSelectedOnUpgradeFrom(
@@ -283,7 +242,6 @@ describe('PXE storage compatibility test suite', () => {
         expect(await oldStore.openMap<string, number>('highest_aged_index').getAsync(legacyKey)).toBe(13);
       },
     );
->>>>>>> 0bb0628549 (feat: preserve stores on schema version or rollup address change (#24631))
   });
 
   it('opens the expected set of stores', async () => {


### PR DESCRIPTION
Automated conflict-resolution attempt for #24860 (`fwd-port-24631`). Merges next + v5-next PR #24631.

## Resolution summary

Two files had committed conflict markers.

### `docs/.../migration_notes.md` (UNION)
Restored next's version of the file. next already contains PR #24631's note verbatim (under the `## 5.0.1` heading: "[PXE] Stores are now selected by `(l1ChainId, rollupAddress, schemaVersion)`..."), whereas v5-next carried it under `## TBD`. The committed conflict presentation had mangled next's separate `## 5.0.0` "[PXE] Local PXE database is reset on upgrade" note by dropping its body; restoring next's version brings that body back and keeps both notes. No notes dropped.

### `yarn-project/pxe/.../pxe_db_compatibility.test.ts`
Took PR #24631's complete version. A three-way diff (next vs PR #24631) confirms next has **no** independent changes to this file: every difference is part of the wipe-to-preserve feature itself (adds `Fr` import, drops `createStore` for the new `openStore` from `entrypoints/server/store.js`, adds `PRE_KIND_PREFIXED_TAGGING_KEY_PXE_SCHEMA_VERSION`, the `expectFreshStoreSelectedOnUpgradeFrom` helper, and rewrites/adds the two upgrade tests). The committed conflict markers would, if resolved hunk-by-hunk to the incoming side, have left the file referencing an unimported `Fr` and an undefined `PRE_KIND_PREFIXED_TAGGING_KEY_PXE_SCHEMA_VERSION`, so the whole-file adoption is required. Verified the branch's source already carries the supporting PR #24631 changes: `openStore` is exported from `pxe/src/entrypoints/server/store.ts` with a matching signature, and `createStore` is no longer exported from `kv-store/lmdb-v2` — so next's old test would not compile against current source.

## Confidence
High. No generated/pinned artifacts were involved, so no regeneration is required. Not built or tested locally per task constraints; a CI build/test run is the remaining check.