### PR TITLE
resolve conflicts: #24270 feat: allow custom proof submission target address

### DIFF
--- a/yarn-project/prover-node/src/prover-node-publisher.test.ts
+++ b/yarn-project/prover-node/src/prover-node-publisher.test.ts
@@ -102,10 +102,7 @@ describe('prover-node-publisher', () => {
       fromCheckpoint: CheckpointNumber(fromCheckpoint),
       toCheckpoint: CheckpointNumber(toCheckpoint),
       publicInputs: ourPublicInputs,
-<<<<<<< HEAD
       headers: makeHeadersForRange(fromCheckpoint, toCheckpoint),
-=======
->>>>>>> 547967def3 (feat: allow custom proof submission target address (#24270))
       proof: Proof.empty(),
       batchedBlobInputs: ourBatchedBlob,
       attestations: [],
@@ -206,34 +203,6 @@ describe('prover-node-publisher', () => {
       const rollupAddress = EthAddress.random().toString();
       (rollup as any).address = rollupAddress;
       publisher = new ProverNodePublisher(config, { rollupContract: rollup, l1TxUtils: l1Utils });
-<<<<<<< HEAD
-=======
-
-      await publisher.submitEpochProof(setupPublishData(65, 32, 33, 64));
-      expect(l1Utils.sendAndMonitorTransaction).toHaveBeenCalledWith(expect.objectContaining({ to: rollupAddress }));
-    });
-
-    it('redirects the submit tx to the configured proof submission target', async () => {
-      (rollup as any).address = EthAddress.random().toString();
-      const target = EthAddress.random();
-      publisher = new ProverNodePublisher(config, {
-        rollupContract: rollup,
-        l1TxUtils: l1Utils,
-        proofSubmissionTarget: target,
-      });
-
-      await publisher.submitEpochProof(setupPublishData(65, 32, 33, 64));
-      expect(l1Utils.sendAndMonitorTransaction).toHaveBeenCalledWith(
-        expect.objectContaining({ to: target.toString() }),
-      );
-    });
-  });
-
-  it('waits until the proven checkpoint reaches the checkpoint before the proof start', async () => {
-    const checkpoints = Array.from({ length: 100 }, () => RootRollupPublicInputs.random());
-    const fromCheckpoint = CheckpointNumber(33);
-    const toCheckpoint = CheckpointNumber(64);
->>>>>>> 547967def3 (feat: allow custom proof submission target address (#24270))
 
       await publisher.submitEpochProof(setupPublishData(65, 32, 33, 64));
       expect(l1Utils.sendAndMonitorTransaction).toHaveBeenCalledWith(

--- a/yarn-project/prover-node/src/prover-node-publisher.ts
+++ b/yarn-project/prover-node/src/prover-node-publisher.ts
@@ -291,14 +291,10 @@ export class ProverNodePublisher {
       args: txArgs,
     });
     try {
-<<<<<<< HEAD
       const { receipt } = await this.l1TxUtils.sendAndMonitorTransaction(
         { to: this.proofSubmissionTarget, data },
         { txTimeoutAt: args.deadline },
       );
-=======
-      const { receipt } = await this.l1TxUtils.sendAndMonitorTransaction({ to: this.proofSubmissionTarget, data });
->>>>>>> 547967def3 (feat: allow custom proof submission target address (#24270))
       if (receipt.status !== 'success') {
         const errorMsg = await this.l1TxUtils.tryGetErrorFromRevertedTx(
           data,

--- a/yarn-project/prover-node/src/prover-node.test.ts
+++ b/yarn-project/prover-node/src/prover-node.test.ts
@@ -169,7 +169,6 @@ describe('ProverNode', () => {
     expect(proverNode.getLastProcessedCheckpoint()).toEqual(CheckpointNumber(3));
     const originalProver = proverNode.getCheckpointStore().listAll()[0];
 
-<<<<<<< HEAD
     // The prune target is block 2 (in checkpoint 2), but the event's checkpointed tip is inflated to the rebuilt 3.
     // getBlockData also feeds collectRegisterData when the rebuild re-registers, so it carries a header too.
     l2BlockSource.getBlockData.mockResolvedValue({
@@ -181,33 +180,6 @@ describe('ProverNode', () => {
       block: { number: BlockNumber(2), hash: '0x02' },
       checkpointed: makeTipId(3),
       proven: makeTipId(2),
-=======
-    config = {
-      proverNodeMaxPendingJobs: 3,
-      proverNodePollingIntervalMs: 10,
-      proverNodeMaxParallelBlocksPerEpoch: 32,
-      txGatheringIntervalMs: 100,
-      txGatheringBatchSize: 10,
-      txGatheringMaxParallelRequestsPerNode: 5,
-      proverNodeFailedEpochStore: undefined,
-      txGatheringTimeoutMs: 1000,
-      proverNodeEpochProvingDelayMs: undefined,
-      proverNodeDisableProofPublish: false,
-      proofSubmissionTargetAddress: undefined,
-    };
-
-    // World state returns a new mock db every time it is asked to fork
-    worldState.fork.mockImplementation(() => Promise.resolve(mock<MerkleTreeWriteOperations>()));
-    worldState.status.mockResolvedValue({
-      state: WorldStateRunningState.RUNNING,
-      syncSummary: {
-        latestBlockNumber: BlockNumber(1),
-        latestBlockHash: '',
-        finalizedBlockNumber: BlockNumber.ZERO,
-        oldestHistoricBlockNumber: BlockNumber.ZERO,
-        treesAreSynched: true,
-      },
->>>>>>> 547967def3 (feat: allow custom proof submission target address (#24270))
     });
 
     // The orphaned prover for checkpoint 3 is marked pruned, and the cursor was clamped below 3.


### PR DESCRIPTION
Automated conflict-resolution attempt for #24853 (`fwd-port-24270`). Merges next + v5-next PR #24270.

## Resolution summary

All three conflicted files resolved to be byte-identical to `next`. The `next` branch already contains PR #24270's feature (the `proofSubmissionTarget`/`proofSubmissionTargetAddress` config and the two "proof submission target" tests). The committed conflict markers were caused by purely structural differences between v5-next's version of #24270 and next's:

- `prover-node-publisher.ts`: kept next's `sendAndMonitorTransaction({ to: this.proofSubmissionTarget, data }, { txTimeoutAt: args.deadline })` — next adds the deadline second arg; both sides already target `this.proofSubmissionTarget`.
- `prover-node-publisher.test.ts`: kept next's `headers: makeHeadersForRange(...)` field in the `setupPublishData` helper, and kept next's two-arg `toHaveBeenCalledWith(..., expect.anything())` assertions in the target tests. Dropped a stray v5-only `waits until the proven checkpoint...` fragment that does not exist in next.
- `prover-node.test.ts`: next refactored `beforeEach` to pass `{}` instead of a `config` object, so v5's `config = { ..., proofSubmissionTargetAddress: undefined }` block is obsolete here; kept next's chain-pruned regression test. The config-field change lives in `config.ts` (which merged cleanly).

## Confidence

High. Each resolved file was diffed against `origin/next` and confirmed identical, so it compiles as next does. No generated/pinned artifacts were involved. No regeneration required.

Not built or tested here (resolution only) — CI should confirm.