### PR TITLE
resolve conflicts: #24634 feat: add batch is block in archive oracle

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/oracle/version.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/version.nr
@@ -11,11 +11,7 @@
 /// immediately if AZTEC_NR_MINOR > PXE_MINOR because if a contract is updated to use a newer Aztec.nr dependency
 /// without actually using any of the new oracles then there is no reason to throw.
 pub global ORACLE_VERSION_MAJOR: Field = 30;
-<<<<<<< HEAD
 pub global ORACLE_VERSION_MINOR: Field = 5;
-=======
-pub global ORACLE_VERSION_MINOR: Field = 7;
->>>>>>> 296717987f (feat: add batch is block in archive oracle (#24634))
 
 /// Asserts that the version of the oracle is compatible with the version expected by the contract.
 pub fn assert_compatible_oracle_version() {

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution.test.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution.test.ts
@@ -1,6 +1,8 @@
+import { ARCHIVE_HEIGHT } from '@aztec/constants';
 import { BlockNumber } from '@aztec/foundation/branded-types';
 import { Grumpkin } from '@aztec/foundation/crypto/grumpkin';
 import { Fr } from '@aztec/foundation/curves/bn254';
+import { MembershipWitness } from '@aztec/foundation/trees';
 import { GrumpkinScalar } from '@aztec/foundation/curves/grumpkin';
 import type { KeyStore } from '@aztec/key-store';
 import { openTmpStore } from '@aztec/kv-store/lmdb-v2';
@@ -657,80 +659,7 @@ describe('Utility Execution test suite', () => {
       });
     });
 
-<<<<<<< HEAD
-=======
     describe('node read cache', () => {
-      const makeMinedReceipt = (txHash: TxHash, txEffect = TxEffect.empty()) =>
-        new MinedTxReceipt(
-          txHash,
-          TxStatus.FINALIZED,
-          TxExecutionResult.SUCCESS,
-          0n,
-          BlockHash.random(),
-          BlockNumber(syncedBlockNumber),
-          SlotNumber(1),
-          0,
-          EpochNumber(1),
-          txEffect,
-        );
-
-      it('reuses tx-effect reads within a utility execution', async () => {
-        const oracle = makeOracle({ scopes: [scope] });
-        const txHash = TxHash.random();
-        aztecNode.getTxReceipt.mockResolvedValue(makeMinedReceipt(txHash));
-
-        const first = await oracle.getTxEffect(txHash);
-        const second = await oracle.getTxEffect(txHash);
-
-        expect(first).toEqual(second);
-        expect(aztecNode.getTxReceipt).toHaveBeenCalledTimes(1);
-      });
-
-      it('does not share cached reads across utility executions', async () => {
-        const txHash = TxHash.random();
-        aztecNode.getTxReceipt.mockResolvedValue(makeMinedReceipt(txHash));
-
-        const firstOracle = makeOracle({ scopes: [scope] });
-        const secondOracle = makeOracle({ scopes: [scope] });
-
-        // Cache works as usual
-        await firstOracle.getTxEffect(txHash);
-        await firstOracle.getTxEffect(txHash);
-        expect(aztecNode.getTxReceipt).toHaveBeenCalledTimes(1);
-
-        // Same call in new oracle, goes to actual node since cache is clean
-        await secondOracle.getTxEffect(txHash);
-        expect(aztecNode.getTxReceipt).toHaveBeenCalledTimes(2);
-      });
-
-      it('does not cache failed tx-effect reads', async () => {
-        const oracle = makeOracle({ scopes: [scope] });
-        const txHash = TxHash.random();
-        aztecNode.getTxReceipt.mockRejectedValueOnce(new Error('temporary failure'));
-        aztecNode.getTxReceipt.mockResolvedValueOnce(makeMinedReceipt(txHash));
-
-        await expect(oracle.getTxEffect(txHash)).rejects.toThrow('temporary failure');
-
-        const result = await oracle.getTxEffect(txHash);
-
-        expect(result.isSome()).toBe(true);
-        expect(aztecNode.getTxReceipt).toHaveBeenCalledTimes(2);
-      });
-
-      it('reuses archive witness reads within a utility execution', async () => {
-        const oracle = makeOracle({ scopes: [scope] });
-        const referenceBlockHash = await anchorBlockHeader.hash();
-        const blockHash = BlockHash.random();
-        const witness = MembershipWitness.empty(ARCHIVE_HEIGHT);
-        aztecNode.getBlockHashMembershipWitness.mockResolvedValue(witness);
-
-        const first = await oracle.getBlockHashMembershipWitness(referenceBlockHash, blockHash);
-        const second = await oracle.getBlockHashMembershipWitness(referenceBlockHash, blockHash);
-
-        expect(first).toEqual(second);
-        expect(aztecNode.getBlockHashMembershipWitness).toHaveBeenCalledTimes(1);
-      });
-
       it('returns aligned archive-membership booleans for block hash batches', async () => {
         const service = new EphemeralArrayService();
         const oracle = makeOracle({ scopes: [scope] });
@@ -749,24 +678,9 @@ describe('Utility Execution test suite', () => {
         );
 
         expect(result.readAll(service)).toEqual([true, false, true]);
-        expect(aztecNode.getBlockHashMembershipWitness).toHaveBeenCalledTimes(2);
-      });
-
-      it('reuses public storage reads within a utility execution', async () => {
-        const oracle = makeOracle({ scopes: [scope] });
-        const blockHash = await anchorBlockHeader.hash();
-        const startStorageSlot = Fr.random();
-        aztecNode.getPublicStorageAt.mockResolvedValue(new Fr(7));
-
-        const first = await oracle.getFromPublicStorage(blockHash, contractAddress, startStorageSlot, 2);
-        const second = await oracle.getFromPublicStorage(blockHash, contractAddress, startStorageSlot, 2);
-
-        expect(first).toEqual(second);
-        expect(aztecNode.getPublicStorageAt).toHaveBeenCalledTimes(2);
       });
     });
 
->>>>>>> 296717987f (feat: add batch is block in archive oracle (#24634))
     describe('fact store', () => {
       const service = new EphemeralArrayService();
       const typeId = new Fr(10);

--- a/yarn-project/pxe/src/oracle_version.ts
+++ b/yarn-project/pxe/src/oracle_version.ts
@@ -11,11 +11,7 @@
 /// if AZTEC_NR_MINOR > PXE_MINOR because if a contract is updated to use a newer Aztec.nr dependency without actually
 /// using any of the new oracles then there is no reason to throw.
 export const ORACLE_VERSION_MAJOR = 30;
-<<<<<<< HEAD
 export const ORACLE_VERSION_MINOR = 5;
-=======
-export const ORACLE_VERSION_MINOR = 7;
->>>>>>> 296717987f (feat: add batch is block in archive oracle (#24634))
 
 /// This hash is computed from the `ORACLE_REGISTRY` declaration (each oracle's name, ordered parameter names and
 /// types, and return type) and is used to detect when the oracle interface changes. When it does, you need to either:
@@ -23,8 +19,4 @@ export const ORACLE_VERSION_MINOR = 7;
 /// - increment only `ORACLE_VERSION_MINOR` if the change is additive (a new oracle was added).
 ///
 /// These constants must be kept in sync between this file and `noir-projects/aztec-nr/aztec/src/oracle/version.nr`.
-<<<<<<< HEAD
 export const ORACLE_INTERFACE_HASH = 'f71b9662ec851e74593764a87792b0a91c181e1410aac49a4507f0bba949f6be';
-=======
-export const ORACLE_INTERFACE_HASH = '416b0e7d3e6dca5803ebe2a65ea93f1e79759dc39ef8ec4c52eeba5e2b0f3fca';
->>>>>>> 296717987f (feat: add batch is block in archive oracle (#24634))


### PR DESCRIPTION
Automated conflict-resolution attempt for #24861 (`fwd-port-24634`). Merges next + v5-next PR #24634 (`feat: add batch is block in archive oracle`). Review carefully.

## What was resolved
Three files had committed conflict markers:

- **`noir-projects/aztec-nr/aztec/src/oracle/version.nr`** (pinned/generated version constant): kept next's `ORACLE_VERSION_MINOR = 5`. **Requires regeneration** — do not hand-bump. Once the new oracle is genuinely present on next, the minor version and interface hash must be regenerated together.
- **`yarn-project/pxe/src/oracle_version.ts`** (pinned/generated): kept next's `ORACLE_VERSION_MINOR = 5` and next's `ORACLE_INTERFACE_HASH`. **Requires regeneration** — the interface hash must be recomputed from the `ORACLE_REGISTRY` declaration, not hand-merged.
- **`yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution.test.ts`**: kept next's state and added only #24634's actual new test (`returns aligned archive-membership booleans for block hash batches`) in a `describe('node read cache')` block, plus the `ARCHIVE_HEIGHT` and `MembershipWitness` imports it needs.

## Flags for human review (LOW confidence on the test file)

- The incoming conflict hunk on the test file dragged in an entire v5-only `node read cache` describe block (tx-effect caching, "does not share cached reads", archive-witness reuse, public-storage reuse). Those tests are **not** part of #24634 and do not exist on next, so I excluded them per "keep next's state". Only #24634's single new test was integrated.
- I dropped the `expect(aztecNode.getBlockHashMembershipWitness).toHaveBeenCalledTimes(2)` assertion from that test: it relied on the v5-only read-cache deduplication, which does not exist on next. The behavioral assertion on the returned booleans is kept.
- **Source reconciliation needed (out of my 3-file scope):** `utility_execution_oracle.ts` `areBlockHashesInArchive` (applied cleanly during cherry-pick, not a conflicted file) references `this.aztecNodeReadCache.getBlockHashMembershipWitness`, but `aztecNodeReadCache` does not exist on next (next uses `this.aztecNode`). This will not compile on next and must be reconciled before the added test can pass.

## Not built or tested
Marker resolution only, per task constraints. Regeneration of oracle version/hash artifacts and the source reconciliation above are still required.
