### PR TITLE
resolve conflicts: #24743 chore: handle legacy duplicate opaque handles

### DIFF
--- a/yarn-project/kv-store/src/sqlite-opfs/store.ts
+++ b/yarn-project/kv-store/src/sqlite-opfs/store.ts
@@ -14,11 +14,7 @@ import { SqliteEncryptionError } from './errors.js';
 import { SQLiteOPFSAztecMap } from './map.js';
 import type { ResultRow, SqlValue, WorkerRequest, WorkerResponse } from './messages.js';
 import { SQLiteOPFSAztecMultiMap } from './multi_map.js';
-<<<<<<< HEAD
-=======
 import { quarantineDuplicatePool } from './pool_integrity.js';
-import { type PoolLockLease, acquirePoolLock, normalizePoolDirectory } from './pool_lock.js';
->>>>>>> cfbd62af4c (chore: handle legacy duplicate opaque handles (#24743))
 import { SQLiteOPFSAztecSet } from './set.js';
 import { SQLiteOPFSAztecSingleton } from './singleton.js';
 
@@ -114,21 +110,12 @@ export class AztecSQLiteOPFSStore implements AztecAsyncKVStore {
     // encryptionKey.buffer — subsequent reads from the same Uint8Array are empty.
     const transfer = encryptionKey ? [encryptionKey.buffer as ArrayBuffer] : undefined;
     try {
-<<<<<<< HEAD
-=======
-      if (effectivePoolDirectory) {
-        const quarantine = await quarantineDuplicatePool(effectivePoolDirectory);
+      if (poolDirectory) {
+        const quarantine = await quarantineDuplicatePool(poolDirectory);
         if (quarantine) {
           log.warn(`Quarantined SQLite-OPFS pool with duplicate logical file mappings`, quarantine);
         }
       }
-      worker = new Worker(new URL('./worker.js', import.meta.url), { type: 'module' });
-      const store = new AztecSQLiteOPFSStore(worker, dbName, log, ephemeral, poolLock);
-      // Transfer (not clone) the key buffer to the worker so we don't leave a
-      // second copy on the main thread. Caveat: this detaches the caller's
-      // encryptionKey.buffer — subsequent reads from the same Uint8Array are empty.
-      const transfer = encryptionKey ? [encryptionKey.buffer as ArrayBuffer] : undefined;
->>>>>>> cfbd62af4c (chore: handle legacy duplicate opaque handles (#24743))
       await store.#sendRequest(
         { type: 'init', id: store.#allocId(), dbName, ephemeral, poolDirectory, encryptionKey },
         transfer,


### PR DESCRIPTION
Automated conflict-resolution attempt for #24869 (`fwd-port-24743`). Merges next + v5-next PR #24743 ("chore: handle legacy duplicate opaque handles"). Review carefully.

## What was resolved
`yarn-project/kv-store/src/sqlite-opfs/store.ts` had committed conflict markers in two hunks:

1. **Imports** — kept next's imports and added only #24743's genuine addition, `import { quarantineDuplicatePool } from './pool_integrity.js';`. Dropped the incoming `import { PoolLockLease, acquirePoolLock, normalizePoolDirectory } from './pool_lock.js';` line: that is pre-existing v5 baseline context (from #24740's Web Lock work), **not** part of #24743, and next has no pool-lock support.
2. **`open()` body** — kept next's structure (worker/store created before the `try` with the 4-arg constructor, single `transfer` declaration) and inserted #24743's quarantine block at the top of the `try`, keyed off next's existing `poolDirectory` parameter instead of the v5-only `effectivePoolDirectory`/`poolLock` locals.

`store_management.test.ts` was listed as a conflicted file but carried no markers on the branch (added cleanly by the cherry-pick); it was left untouched.

## Important: this forward-port is incomplete and will not build as-is
PR #24743 was built on top of a v5-only stack that never landed on `next`. On `next`, `yarn-project/kv-store/src/sqlite-opfs/` is missing:

- `pool_lock.ts` (provides `normalizePoolDirectory`, `acquirePoolLock`, `PoolLockLease`)
- `manage.ts` (provides `deleteStore`, `listStores`, `storePoolDirectory`)

The cherry-pick added `pool_integrity.ts` and `store_management.test.ts`, but both import `./pool_lock.js` (and the test also imports `./manage.js`), so the package will fail to compile until the underlying weblock/pool-management work (PR #24740 and any siblings) is also forward-ported. Resolving the markers cannot fix this — it needs those modules ported first, or #24743's feature scoped down to what `next` supports.

No generated artifacts were involved; no regeneration required.

## Confidence
Low overall. The marker resolution within store.ts is correct and self-consistent, but the branch depends on modules absent from `next`, so it needs human judgment on how to complete (or split) the forward-port before it can build/merge.
