### PR TITLE
resolve conflicts: #24752 refactor(pxe): compute oracle interface hash from wire-structural mapping labels

### DIFF
--- a/yarn-project/pxe/src/contract_function_simulator/oracle/oracle_type_mappings.test.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/oracle_type_mappings.test.ts
@@ -19,11 +19,7 @@ import {
   MEMBERSHIP_WITNESS,
   OPTION,
   POINT,
-<<<<<<< HEAD
   PROVIDED_SECRET,
-=======
-  RESOLVED_TAGGING_STRATEGY,
->>>>>>> d2db074640 (refactor(pxe): compute oracle interface hash from wire-structural mapping labels (#24752))
   type SlotShape,
   type TypeMapping,
   U8,
@@ -100,7 +96,6 @@ describe('oracle type mappings', () => {
     });
   });
 
-<<<<<<< HEAD
   describe('PROVIDED_SECRET', () => {
     it('deserializes a secret and delivery mode from a two-field slot', () => {
       const provided = PROVIDED_SECRET.deserialization!.fn([new FieldReader([new Fr(42), new Fr(3)])]);
@@ -111,25 +106,6 @@ describe('oracle type mappings', () => {
     it('declares the two-field wire shape', () => {
       expect(PROVIDED_SECRET.shape).toEqual([{ len: 2 }]);
     });
-=======
-  describe('RESOLVED_TAGGING_STRATEGY', () => {
-    const secret = new Fr(42);
-
-    it('rejects an unknown strategy kind', () => {
-      expect(() => deserializeStrategy(new Fr(99), Fr.ZERO)).toThrow('Unrecognized resolved tagging strategy kind');
-    });
-
-    it.each([
-      ['non-interactive handshake', new Fr(1)],
-      ['interactive handshake', new Fr(3)],
-    ])('rejects %s with a nonzero secret', (_name, kind) => {
-      expect(() => deserializeStrategy(kind, secret)).toThrow(`Resolved tagging strategy ${kind.toNumber()}`);
-    });
-
-    function deserializeStrategy(kind: Fr, secret: Fr): ResolvedTaggingStrategy {
-      return RESOLVED_TAGGING_STRATEGY.deserialization!.fn([new FieldReader([kind]), new FieldReader([secret])]);
-    }
->>>>>>> d2db074640 (refactor(pxe): compute oracle interface hash from wire-structural mapping labels (#24752))
   });
 
   describe('AZTEC_ADDRESS', () => {

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
@@ -1108,30 +1108,6 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
     );
   }
 
-<<<<<<< HEAD
-=======
-  async #getTxEffectOption(txHash: TxHash): Promise<Option<TxEffectData>> {
-    const receipt = await this.aztecNodeReadCache.getTxReceiptWithEffect(txHash);
-    if (!receipt.isMined() || !receipt.txEffect || receipt.blockNumber > this.anchorBlockHeader.getBlockNumber()) {
-      return Option.none();
-    }
-    return Option.some(this.#toTxEffectData(receipt.txEffect));
-  }
-
-  #toTxEffectData(txEffect: TxEffect): TxEffectData {
-    return {
-      ...txEffect,
-      revertCode: txEffect.revertCode.getCode(),
-      publicLogs: FlatPublicLogs.fromLogs(txEffect.publicLogs),
-      contractClassLogs: txEffect.contractClassLogs.map(log => ({
-        contractAddress: log.contractAddress,
-        fields: log.fields.toFields(),
-        emittedLength: log.emittedLength,
-      })),
-    };
-  }
-
->>>>>>> d2db074640 (refactor(pxe): compute oracle interface hash from wire-structural mapping labels (#24752))
   /** Runs a query concurrently with a validation that the block hash is not ahead of the anchor block. */
   async #queryWithBlockHashNotAfterAnchor<T>(blockHash: BlockHash, query: () => Promise<T>): Promise<T> {
     // Most contracts query state at the "current" block, which is the anchor. Skip the validation when we can.

--- a/yarn-project/pxe/src/oracle_version.ts
+++ b/yarn-project/pxe/src/oracle_version.ts
@@ -19,8 +19,4 @@ export const ORACLE_VERSION_MINOR = 5;
 /// - increment only `ORACLE_VERSION_MINOR` if the change is additive (a new oracle was added).
 ///
 /// These constants must be kept in sync between this file and `noir-projects/aztec-nr/aztec/src/oracle/version.nr`.
-<<<<<<< HEAD
 export const ORACLE_INTERFACE_HASH = 'f71b9662ec851e74593764a87792b0a91c181e1410aac49a4507f0bba949f6be';
-=======
-export const ORACLE_INTERFACE_HASH = 'fec4d3a95fc57a62a20bfeb659bb3bfd91b31cd93e07f8cf97b368f9f55cc67b';
->>>>>>> d2db074640 (refactor(pxe): compute oracle interface hash from wire-structural mapping labels (#24752))

--- a/yarn-project/txe/src/oracle/txe_oracle_version.ts
+++ b/yarn-project/txe/src/oracle/txe_oracle_version.ts
@@ -14,8 +14,4 @@ export const TXE_ORACLE_VERSION_MINOR = 3;
  *   - TXE_ORACLE_VERSION_MAJOR (and reset MINOR to 0) for breaking changes, or
  *   - TXE_ORACLE_VERSION_MINOR for additive changes (new oracle method added).
  */
-<<<<<<< HEAD
 export const TXE_ORACLE_INTERFACE_HASH = '4ed3618087fafb4aa63c6580996a69bf6bc257844035a2019692586b5b8daf34';
-=======
-export const TXE_ORACLE_INTERFACE_HASH = '4e443d3255e6a8d12457815e271febb677956d94fb3c921e23c65e514b175a8a';
->>>>>>> d2db074640 (refactor(pxe): compute oracle interface hash from wire-structural mapping labels (#24752))


### PR DESCRIPTION
Automated conflict-resolution attempt for #24870 (`fwd-port-24752`). Merges next + v5-next PR #24752. Review carefully.

## Resolution notes

Confidence: medium-high.

Four conflicted files resolved:

- **`yarn-project/pxe/src/oracle_version.ts`** and **`yarn-project/txe/src/oracle/txe_oracle_version.ts`** — pinned interface-hash artifacts. Kept next's hashes (`ORACLE_INTERFACE_HASH` / `TXE_ORACLE_INTERFACE_HASH`). Did NOT hand-merge the v5 hash values. **These will need regeneration** once the wire-structural label refactor is fully reconciled on the next line — the pinned hashes must be recomputed from `ORACLE_REGISTRY` / `TXE_ORACLE_REGISTRY` and re-pinned.

- **`yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts`** — next had removed the `#getTxEffectOption` / `#toTxEffectData` private methods entirely (no remaining references in the file). PR #24752 only tweaked `#toTxEffectData` (adding a `revertCode` line), which is moot against next's deletion. Kept next's state (methods stay removed).

- **`yarn-project/pxe/src/contract_function_simulator/oracle/oracle_type_mappings.test.ts`** — the genuine PR #24752 content for this file (BYTE→U8 rename, LEAF/SCALAR builders, new `label` describe block) applied cleanly in the non-conflicting hunks. The two conflicts were a pure v5↔next divergence: v5 tests `RESOLVED_TAGGING_STRATEGY`, next tests `PROVIDED_SECRET`. Kept next's `PROVIDED_SECRET` import and describe block and dropped the incoming `RESOLVED_TAGGING_STRATEGY` test, because next's `resolvedTaggingStrategyFromFields` does not reject a nonzero secret for kinds 1/3 — the incoming test's "rejects ... with a nonzero secret" cases would fail against next's implementation. Both symbols exist in next's registry, but only the `PROVIDED_SECRET` behavior matches next.

## Flag for human judgement

- Artifact regeneration of both interface hashes is required (see above).
- Confirm dropping the `RESOLVED_TAGGING_STRATEGY` test is intended for the next line, i.e. that next deliberately removed the nonzero-secret validation.