### PR TITLE
resolve conflicts: #24662 feat(txe): add option to authorize all utility call targets

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
@@ -92,27 +92,14 @@ pub struct TestEnvironment {
 /// );
 /// ```
 pub struct TestEnvironmentOptions {
-<<<<<<< HEAD
     tagging_secret_strategy: Option<TaggingSecretStrategy>,
-=======
-    default_unconstrained_tagging_secret_strategy: Option<TaggingSecretStrategy>,
-    default_constrained_tagging_secret_strategy: Option<TaggingSecretStrategy>,
     authorize_all_utility_call_targets: bool,
->>>>>>> 97b4c75c95 (feat(txe): add option to authorize all utility call targets (#24662))
 }
 
 impl TestEnvironmentOptions {
     /// Creates a new `TestEnvironmentOptions` with default values.
     pub fn new() -> Self {
-<<<<<<< HEAD
-        Self { tagging_secret_strategy: Option::none() }
-=======
-        Self {
-            default_unconstrained_tagging_secret_strategy: Option::none(),
-            default_constrained_tagging_secret_strategy: Option::none(),
-            authorize_all_utility_call_targets: false,
-        }
->>>>>>> 97b4c75c95 (feat(txe): add option to authorize all utility call targets (#24662))
+        Self { tagging_secret_strategy: Option::none(), authorize_all_utility_call_targets: false }
     }
 
     /// Sets the [`TaggingSecretStrategy`] the wallet reports through the
@@ -123,16 +110,6 @@ impl TestEnvironmentOptions {
     pub fn with_tagging_secret_strategy(&mut self, strategy: TaggingSecretStrategy) -> Self {
         self.tagging_secret_strategy = Option::some(strategy);
         *self
-    }
-<<<<<<< HEAD
-=======
-
-    /// Sets `strategy` for both delivery modes: the equivalent of a PXE `resolveTaggingSecretStrategy` hook that
-    /// ignores the request's mode. See
-    /// [`with_default_tag_secret_strategy`](Self::with_default_tag_secret_strategy) to configure a single mode.
-    pub fn with_default_tag_secret_strategy_all_modes(&mut self, strategy: TaggingSecretStrategy) -> Self {
-        let _ = self.with_default_tag_secret_strategy(OnchainDeliveryMode::onchain_unconstrained(), strategy);
-        self.with_default_tag_secret_strategy(OnchainDeliveryMode::onchain_constrained(), strategy)
     }
 
     /// Authorizes all cross-contract utility call targets for the entire test.
@@ -146,7 +123,6 @@ impl TestEnvironmentOptions {
         self.authorize_all_utility_call_targets = true;
         *self
     }
->>>>>>> 97b4c75c95 (feat(txe): add option to authorize all utility call targets (#24662))
 }
 
 /// Configuration values for [`TestEnvironment::private_context_opts`]. Meant to be used by calling `new` and then

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/txe_oracles.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/txe_oracles.nr
@@ -21,13 +21,8 @@ use crate::protocol::{
 /// [`oracle::version`](crate::oracle::version), which covers oracles used during contract execution by PXE.
 ///
 /// The TypeScript counterparts are in `yarn-project/txe/src/txe_oracle_version.ts`.
-<<<<<<< HEAD
 pub global TXE_ORACLE_VERSION_MAJOR: Field = 2;
-pub global TXE_ORACLE_VERSION_MINOR: Field = 3;
-=======
-pub global TXE_ORACLE_VERSION_MAJOR: Field = 3;
-pub global TXE_ORACLE_VERSION_MINOR: Field = 1;
->>>>>>> 97b4c75c95 (feat(txe): add option to authorize all utility call targets (#24662))
+pub global TXE_ORACLE_VERSION_MINOR: Field = 4;
 
 /// Asserts that the TXE oracle interface version is compatible.
 pub unconstrained fn assert_compatible_txe_oracle_version() {

--- a/yarn-project/txe/src/oracle/interfaces.ts
+++ b/yarn-project/txe/src/oracle/interfaces.ts
@@ -73,22 +73,11 @@ export interface ITxeExecutionOracle {
   addAccount(secret: Fr): Promise<CompleteAddress>;
   addAuthWitness(address: AztecAddress, messageHash: Fr): Promise<void>;
   sendL1ToL2Message(content: Fr, secretHash: Fr, sender: EthAddress, recipient: AztecAddress): Promise<Fr>;
-<<<<<<< HEAD
   setTaggingSecretStrategy(strategy: Option<TaggingSecretStrategy>): void;
-=======
-  /**
-   * Configures the tagging secret strategy the test's simulated wallet resolves for each delivery mode. A `none`
-   * clears that mode, so it falls back to the default strategy (or, when both modes end up unset, to no hook at all).
-   */
-  setTaggingSecretStrategies(
-    unconstrainedStrategy: Option<TaggingSecretStrategy>,
-    constrainedStrategy: Option<TaggingSecretStrategy>,
-  ): void;
   /**
    * Configures whether the test's simulated wallet authorizes every cross-contract utility call target.
    */
   setAuthorizeAllUtilityCallTargets(authorizeAll: boolean): void;
->>>>>>> 97b4c75c95 (feat(txe): add option to authorize all utility call targets (#24662))
   getLastBlockTimestamp(): Promise<bigint>;
   getLastTxEffects(): Promise<{
     txHash: TxHash;

--- a/yarn-project/txe/src/oracle/txe_oracle_top_level_context.ts
+++ b/yarn-project/txe/src/oracle/txe_oracle_top_level_context.ts
@@ -123,12 +123,8 @@ export class TXEOracleTopLevelContext implements IMiscOracle, ITxeExecutionOracl
     private version: Fr,
     private chainId: Fr,
     private authwits: Map<string, AuthWitness>,
-<<<<<<< HEAD
     private taggingSecretStrategy: TaggingSecretStrategy | undefined,
-=======
-    private taggingSecretStrategies: TXETaggingSecretStrategies,
     private authorizeAllUtilityCallTargets: boolean,
->>>>>>> 97b4c75c95 (feat(txe): add option to authorize all utility call targets (#24662))
     private readonly artifactResolver: TXEArtifactResolver,
     private readonly rootPath: string,
     private readonly packageName: string,
@@ -982,25 +978,9 @@ export class TXEOracleTopLevelContext implements IMiscOracle, ITxeExecutionOracl
     }
   }
 
-<<<<<<< HEAD
-  close(): [bigint, Map<string, AuthWitness>, TaggingSecretStrategy | undefined] {
+  close(): [bigint, Map<string, AuthWitness>, TaggingSecretStrategy | undefined, boolean] {
     this.logger.debug('Exiting Top Level Context');
-    return [this.nextBlockTimestamp, this.authwits, this.taggingSecretStrategy];
-=======
-  close(): {
-    nextBlockTimestamp: bigint;
-    authwits: Map<string, AuthWitness>;
-    taggingSecretStrategies: TXETaggingSecretStrategies;
-    authorizeAllUtilityCallTargets: boolean;
-  } {
-    this.logger.debug('Exiting Top Level Context');
-    return {
-      nextBlockTimestamp: this.nextBlockTimestamp,
-      authwits: this.authwits,
-      taggingSecretStrategies: this.taggingSecretStrategies,
-      authorizeAllUtilityCallTargets: this.authorizeAllUtilityCallTargets,
-    };
->>>>>>> 97b4c75c95 (feat(txe): add option to authorize all utility call targets (#24662))
+    return [this.nextBlockTimestamp, this.authwits, this.taggingSecretStrategy, this.authorizeAllUtilityCallTargets];
   }
 
   private async getLastBlockNumber(): Promise<BlockNumber> {

--- a/yarn-project/txe/src/oracle/txe_oracle_version.ts
+++ b/yarn-project/txe/src/oracle/txe_oracle_version.ts
@@ -5,13 +5,8 @@
  *
  * The Noir counterparts are in `noir-projects/aztec-nr/aztec/src/test/helpers/txe_oracles.nr`.
  */
-<<<<<<< HEAD
 export const TXE_ORACLE_VERSION_MAJOR = 2;
-export const TXE_ORACLE_VERSION_MINOR = 3;
-=======
-export const TXE_ORACLE_VERSION_MAJOR = 3;
-export const TXE_ORACLE_VERSION_MINOR = 1;
->>>>>>> 97b4c75c95 (feat(txe): add option to authorize all utility call targets (#24662))
+export const TXE_ORACLE_VERSION_MINOR = 4;
 
 /**
  * This hash is computed from the TXE oracle interfaces (IAvmExecutionOracle and ITxeExecutionOracle) and is used to
@@ -19,8 +14,4 @@ export const TXE_ORACLE_VERSION_MINOR = 1;
  *   - TXE_ORACLE_VERSION_MAJOR (and reset MINOR to 0) for breaking changes, or
  *   - TXE_ORACLE_VERSION_MINOR for additive changes (new oracle method added).
  */
-<<<<<<< HEAD
 export const TXE_ORACLE_INTERFACE_HASH = '4ed3618087fafb4aa63c6580996a69bf6bc257844035a2019692586b5b8daf34';
-=======
-export const TXE_ORACLE_INTERFACE_HASH = '89c60f191f8f60ef72d592e46dd6c4afff10dc47a9e14f4f8d37e31e40857d9c';
->>>>>>> 97b4c75c95 (feat(txe): add option to authorize all utility call targets (#24662))

--- a/yarn-project/txe/src/txe_session.ts
+++ b/yarn-project/txe/src/txe_session.ts
@@ -237,12 +237,8 @@ function emptyLastCallState(): LastCallState {
 export class TXESession implements TXESessionStateHandler {
   private state: SessionState = { name: 'TOP_LEVEL' };
   private authwits: Map<string, AuthWitness> = new Map();
-<<<<<<< HEAD
   private taggingSecretStrategy: TaggingSecretStrategy | undefined = undefined;
-=======
-  private taggingSecretStrategies: TXETaggingSecretStrategies = new Map();
   private authorizeAllUtilityCallTargets = false;
->>>>>>> 97b4c75c95 (feat(txe): add option to authorize all utility call targets (#24662))
   private lastCallInfo: LastCallState = emptyLastCallState();
   private txeOracleVersion: { major: number; minor: number } | undefined;
 
@@ -370,12 +366,8 @@ export class TXESession implements TXESessionStateHandler {
       version,
       chainId,
       new Map(),
-<<<<<<< HEAD
       undefined,
-=======
-      new Map(),
       false, // authorizeAllUtilityCallTargets
->>>>>>> 97b4c75c95 (feat(txe): add option to authorize all utility call targets (#24662))
       artifactResolver,
       rootPath,
       packageName,
@@ -705,12 +697,8 @@ export class TXESession implements TXESessionStateHandler {
       this.version,
       this.chainId,
       this.authwits,
-<<<<<<< HEAD
       this.taggingSecretStrategy,
-=======
-      this.taggingSecretStrategies,
       this.authorizeAllUtilityCallTargets,
->>>>>>> 97b4c75c95 (feat(txe): add option to authorize all utility call targets (#24662))
       this.artifactResolver,
       this.rootPath,
       this.packageName,
@@ -791,12 +779,8 @@ export class TXESession implements TXESessionStateHandler {
       txResolver: this.stateMachine.txResolver,
       simulator: new WASMSimulator(),
       hooks: composeHooks({
-<<<<<<< HEAD
         resolveTaggingSecretStrategy: taggingSecretStrategy ? () => Promise.resolve(taggingSecretStrategy) : undefined,
-=======
-        resolveTaggingSecretStrategy: makeResolveTaggingSecretStrategyHook(this.taggingSecretStrategies),
         authorizeUtilityCall: this.authorizeAllUtilityCallTargets ? authorizeAllUtilityCallsHook : undefined,
->>>>>>> 97b4c75c95 (feat(txe): add option to authorize all utility call targets (#24662))
       }),
       transientArrayService,
     });
@@ -928,18 +912,9 @@ export class TXESession implements TXESessionStateHandler {
     // TODO: persisting authwits this way is quite unfortunate: they create a temporary utility context that would
     // otherwise reset them, so we'd not be able to pass more than one per execution. Ideally authwits would be passed
     // alongside a contract call instead of pre-seeded.
-<<<<<<< HEAD
-    [this.nextBlockTimestamp, this.authwits, this.taggingSecretStrategy] = (
+    [this.nextBlockTimestamp, this.authwits, this.taggingSecretStrategy, this.authorizeAllUtilityCallTargets] = (
       this.oracleHandler as TXEOracleTopLevelContext
     ).close();
-=======
-    ({
-      nextBlockTimestamp: this.nextBlockTimestamp,
-      authwits: this.authwits,
-      taggingSecretStrategies: this.taggingSecretStrategies,
-      authorizeAllUtilityCallTargets: this.authorizeAllUtilityCallTargets,
-    } = (this.oracleHandler as TXEOracleTopLevelContext).close());
->>>>>>> 97b4c75c95 (feat(txe): add option to authorize all utility call targets (#24662))
   }
 
   private async exitPrivateState() {


### PR DESCRIPTION
Automated conflict-resolution attempt for #24865 (`fwd-port-24662`). Merges next + v5-next PR #24662. Review carefully.

## Resolution approach

The v5 branch had already refactored the TXE tagging-secret-strategy API (split `default_unconstrained_`/`default_constrained_` fields, `setTaggingSecretStrategies(unconstrained, constrained)`, `TXETaggingSecretStrategies` map, `makeResolveTaggingSecretStrategyHook`). `next` has NOT adopted that refactor — it still uses the singular `tagging_secret_strategy` / `setTaggingSecretStrategy` form. All conflicts were the collision of that unrelated tagging refactor against next's simpler form.

Resolution kept next's singular tagging API everywhere and layered in only PR #24662's actual feature — the "authorize all utility call targets" option:

- `test_environment.nr`: kept `tagging_secret_strategy: Option<...>`, added `authorize_all_utility_call_targets: bool` field, its `new()` default, and the `with_all_utility_call_targets_authorized()` method. Dropped the v5-only `with_default_tag_secret_strategy_all_modes` helper (depends on APIs not present on next).
- `interfaces.ts`: kept `setTaggingSecretStrategy(...)`, added `setAuthorizeAllUtilityCallTargets(boolean)`.
- `txe_oracle_top_level_context.ts`: constructor keeps `taggingSecretStrategy` param, adds `authorizeAllUtilityCallTargets: boolean`. `close()` kept next's tuple return form, extended to `[bigint, Map, TaggingSecretStrategy | undefined, boolean]` (did NOT adopt v5's object-return refactor).
- `txe_session.ts`: kept `taggingSecretStrategy` field + `undefined` constructor arg, added `authorizeAllUtilityCallTargets` field, arg, both `authorizeUtilityCall` hook wirings, and tuple destructuring of `close()` extended with the boolean. No `TXETaggingSecretStrategies` / `makeResolveTaggingSecretStrategyHook` imports were pulled in.

The clean (non-conflicting) parts of the cherry-pick — the `set_authorize_all_utility_call_targets` oracle, registry entry, `rpc_translator` handler, `authorizeAllUtilityCallsHook`, and the new `nested_utility_contract` test — were preserved as-is and verified to reference the retained API.

## Requires regeneration / human attention

- **TXE oracle version**: next's lineage is MAJOR=2 (v5 is MAJOR=3). I kept MAJOR=2 and bumped MINOR 3 -> 4 in both `txe_oracles.nr` and `txe_oracle_version.ts` to reflect the additive oracle. Confirm this is the desired version.
- **`TXE_ORACLE_INTERFACE_HASH`**: kept next's hash unchanged. The interface changed (new oracle method), so this hash MUST be regenerated before merge — the version-compat check will otherwise fail.
- Not built/tested here (per task constraints). Please run the TS build + noir compile.

Confidence: medium-high. The mechanical merge is straightforward; the main judgement calls are the version number (2.4) and the deferred interface-hash regeneration.
