### PR TITLE
resolve conflicts: #24636 feat: getTxEffects oracle

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/oracle/version.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/version.nr
@@ -11,11 +11,7 @@
 /// immediately if AZTEC_NR_MINOR > PXE_MINOR because if a contract is updated to use a newer Aztec.nr dependency
 /// without actually using any of the new oracles then there is no reason to throw.
 pub global ORACLE_VERSION_MAJOR: Field = 30;
-<<<<<<< HEAD
 pub global ORACLE_VERSION_MINOR: Field = 5;
-=======
-pub global ORACLE_VERSION_MINOR: Field = 8;
->>>>>>> 7a77232ed7 (feat: getTxEffects oracle (#24636))
 
 /// Asserts that the version of the oracle is compatible with the version expected by the contract.
 pub fn assert_compatible_oracle_version() {

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution.test.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution.test.ts
@@ -1,4 +1,4 @@
-import { BlockNumber } from '@aztec/foundation/branded-types';
+import { BlockNumber, EpochNumber, SlotNumber } from '@aztec/foundation/branded-types';
 import { Grumpkin } from '@aztec/foundation/crypto/grumpkin';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { GrumpkinScalar } from '@aztec/foundation/curves/grumpkin';
@@ -28,9 +28,6 @@ import { PublicKeys, deriveKeys, hashPublicKey } from '@aztec/stdlib/keys';
 import { AppTaggingSecret, AppTaggingSecretKind, SiloedTag } from '@aztec/stdlib/logs';
 import { Note, NoteDao } from '@aztec/stdlib/note';
 import { makeL2Tips, randomContractInstanceWithAddress } from '@aztec/stdlib/testing';
-<<<<<<< HEAD
-import { BlockHeader, CallContext, Capsule, GlobalVariables, TxHash } from '@aztec/stdlib/tx';
-=======
 import {
   BlockHeader,
   CallContext,
@@ -43,7 +40,6 @@ import {
   TxHash,
   TxStatus,
 } from '@aztec/stdlib/tx';
->>>>>>> 7a77232ed7 (feat: getTxEffects oracle (#24636))
 
 import { mock } from 'jest-mock-extended';
 import type { _MockProxy } from 'jest-mock-extended/lib/Mock.js';
@@ -672,9 +668,7 @@ describe('Utility Execution test suite', () => {
       });
     });
 
-<<<<<<< HEAD
-=======
-    describe('node read cache', () => {
+    describe('getTxEffects', () => {
       const makeTxEffect = (txHash: TxHash) => TxEffect.from({ ...TxEffect.empty(), txHash });
       const makeMinedReceipt = (
         txHash: TxHash,
@@ -693,49 +687,6 @@ describe('Utility Execution test suite', () => {
           EpochNumber(1),
           txEffect,
         );
-
-      it('reuses tx-effect reads within a utility execution', async () => {
-        const oracle = makeOracle({ scopes: [scope] });
-        const txHash = TxHash.random();
-        aztecNode.getTxReceipt.mockResolvedValue(makeMinedReceipt(txHash));
-
-        const first = await oracle.getTxEffect(txHash);
-        const second = await oracle.getTxEffect(txHash);
-
-        expect(first).toEqual(second);
-        expect(aztecNode.getTxReceipt).toHaveBeenCalledTimes(1);
-      });
-
-      it('does not share cached reads across utility executions', async () => {
-        const txHash = TxHash.random();
-        aztecNode.getTxReceipt.mockResolvedValue(makeMinedReceipt(txHash));
-
-        const firstOracle = makeOracle({ scopes: [scope] });
-        const secondOracle = makeOracle({ scopes: [scope] });
-
-        // Cache works as usual
-        await firstOracle.getTxEffect(txHash);
-        await firstOracle.getTxEffect(txHash);
-        expect(aztecNode.getTxReceipt).toHaveBeenCalledTimes(1);
-
-        // Same call in new oracle, goes to actual node since cache is clean
-        await secondOracle.getTxEffect(txHash);
-        expect(aztecNode.getTxReceipt).toHaveBeenCalledTimes(2);
-      });
-
-      it('does not cache failed tx-effect reads', async () => {
-        const oracle = makeOracle({ scopes: [scope] });
-        const txHash = TxHash.random();
-        aztecNode.getTxReceipt.mockRejectedValueOnce(new Error('temporary failure'));
-        aztecNode.getTxReceipt.mockResolvedValueOnce(makeMinedReceipt(txHash));
-
-        await expect(oracle.getTxEffect(txHash)).rejects.toThrow('temporary failure');
-
-        const result = await oracle.getTxEffect(txHash);
-
-        expect(result.isSome()).toBe(true);
-        expect(aztecNode.getTxReceipt).toHaveBeenCalledTimes(2);
-      });
 
       it('returns aligned tx-effect options for tx hash batches', async () => {
         const service = new EphemeralArrayService();
@@ -765,7 +716,7 @@ describe('Utility Execution test suite', () => {
         expect(aztecNode.getTxReceipt).toHaveBeenCalledTimes(3);
       });
 
-      it('does not share batched tx-effect reads across utility executions', async () => {
+      it('deduplicates repeated tx hashes within a batch', async () => {
         const service = new EphemeralArrayService();
         const txHash = TxHash.random();
         aztecNode.getTxReceipt.mockResolvedValue(makeMinedReceipt(txHash));
@@ -779,57 +730,8 @@ describe('Utility Execution test suite', () => {
         await secondOracle.getTxEffects(EphemeralArray.fromValues(service, [txHash]));
         expect(aztecNode.getTxReceipt).toHaveBeenCalledTimes(2);
       });
-
-      it('reuses archive witness reads within a utility execution', async () => {
-        const oracle = makeOracle({ scopes: [scope] });
-        const referenceBlockHash = await anchorBlockHeader.hash();
-        const blockHash = BlockHash.random();
-        const witness = MembershipWitness.empty(ARCHIVE_HEIGHT);
-        aztecNode.getBlockHashMembershipWitness.mockResolvedValue(witness);
-
-        const first = await oracle.getBlockHashMembershipWitness(referenceBlockHash, blockHash);
-        const second = await oracle.getBlockHashMembershipWitness(referenceBlockHash, blockHash);
-
-        expect(first).toEqual(second);
-        expect(aztecNode.getBlockHashMembershipWitness).toHaveBeenCalledTimes(1);
-      });
-
-      it('returns aligned archive-membership booleans for block hash batches', async () => {
-        const service = new EphemeralArrayService();
-        const oracle = makeOracle({ scopes: [scope] });
-        const referenceBlockHash = await anchorBlockHeader.hash();
-        const presentBlockHash = BlockHash.random();
-        const missingBlockHash = BlockHash.random();
-        const witness = MembershipWitness.empty(ARCHIVE_HEIGHT);
-
-        aztecNode.getBlockHashMembershipWitness.mockImplementation((_referenceBlockHash, blockHash) =>
-          Promise.resolve(blockHash.equals(presentBlockHash) ? witness : undefined),
-        );
-
-        const result = await oracle.areBlockHashesInArchive(
-          referenceBlockHash,
-          EphemeralArray.fromValues(service, [presentBlockHash, missingBlockHash, presentBlockHash]),
-        );
-
-        expect(result.readAll(service)).toEqual([true, false, true]);
-        expect(aztecNode.getBlockHashMembershipWitness).toHaveBeenCalledTimes(2);
-      });
-
-      it('reuses public storage reads within a utility execution', async () => {
-        const oracle = makeOracle({ scopes: [scope] });
-        const blockHash = await anchorBlockHeader.hash();
-        const startStorageSlot = Fr.random();
-        aztecNode.getPublicStorageAt.mockResolvedValue(new Fr(7));
-
-        const first = await oracle.getFromPublicStorage(blockHash, contractAddress, startStorageSlot, 2);
-        const second = await oracle.getFromPublicStorage(blockHash, contractAddress, startStorageSlot, 2);
-
-        expect(first).toEqual(second);
-        expect(aztecNode.getPublicStorageAt).toHaveBeenCalledTimes(2);
-      });
     });
 
->>>>>>> 7a77232ed7 (feat: getTxEffects oracle (#24636))
     describe('fact store', () => {
       const service = new EphemeralArrayService();
       const typeId = new Fr(10);

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
@@ -667,11 +667,6 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
       throw new Error('Invalid tx hash passed into aztec_utl_getTxEffect oracle handler');
     }
 
-<<<<<<< HEAD
-    const receipt = await this.aztecNode.getTxReceipt(txHash, { includeTxEffect: true });
-    if (!receipt.isMined() || !receipt.txEffect || receipt.blockNumber > this.anchorBlockHeader.getBlockNumber()) {
-      return Option.none();
-=======
     return await this.#getTxEffectOption(txHash);
   }
 
@@ -681,7 +676,6 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
     const invalidHash = hashes.find(txHash => txHash.hash.isZero());
     if (invalidHash) {
       throw new Error('Invalid tx hash passed into aztec_utl_getTxEffects oracle handler');
->>>>>>> 7a77232ed7 (feat: getTxEffects oracle (#24636))
     }
 
     const uniqueTxHashes = uniqueBy(hashes, h => h.toString());
@@ -1116,7 +1110,7 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
   }
 
   async #getTxEffectOption(txHash: TxHash): Promise<Option<TxEffectData>> {
-    const receipt = await this.aztecNodeReadCache.getTxReceiptWithEffect(txHash);
+    const receipt = await this.aztecNode.getTxReceipt(txHash, { includeTxEffect: true });
     if (!receipt.isMined() || !receipt.txEffect || receipt.blockNumber > this.anchorBlockHeader.getBlockNumber()) {
       return Option.none();
     }

--- a/yarn-project/pxe/src/oracle_version.ts
+++ b/yarn-project/pxe/src/oracle_version.ts
@@ -11,11 +11,7 @@
 /// if AZTEC_NR_MINOR > PXE_MINOR because if a contract is updated to use a newer Aztec.nr dependency without actually
 /// using any of the new oracles then there is no reason to throw.
 export const ORACLE_VERSION_MAJOR = 30;
-<<<<<<< HEAD
 export const ORACLE_VERSION_MINOR = 5;
-=======
-export const ORACLE_VERSION_MINOR = 8;
->>>>>>> 7a77232ed7 (feat: getTxEffects oracle (#24636))
 
 /// This hash is computed from the `ORACLE_REGISTRY` declaration (each oracle's name, ordered parameter names and
 /// types, and return type) and is used to detect when the oracle interface changes. When it does, you need to either:
@@ -23,8 +19,4 @@ export const ORACLE_VERSION_MINOR = 8;
 /// - increment only `ORACLE_VERSION_MINOR` if the change is additive (a new oracle was added).
 ///
 /// These constants must be kept in sync between this file and `noir-projects/aztec-nr/aztec/src/oracle/version.nr`.
-<<<<<<< HEAD
 export const ORACLE_INTERFACE_HASH = 'f71b9662ec851e74593764a87792b0a91c181e1410aac49a4507f0bba949f6be';
-=======
-export const ORACLE_INTERFACE_HASH = 'b302a8e65d37043c0a0dc08a39895603122dce334843f0442462edb3f56e32e2';
->>>>>>> 7a77232ed7 (feat: getTxEffects oracle (#24636))


### PR DESCRIPTION
Automated conflict-resolution attempt for #24862 (`fwd-port-24636`). Merges next + v5-next PR #24636 ("feat: getTxEffects oracle"). Review carefully.

## Resolution summary

- **`oracle/version.nr`, `oracle_version.ts`** (pinned/generated version artifacts): kept next's values (`ORACLE_VERSION_MINOR = 5`, next's `ORACLE_INTERFACE_HASH`). The `ORACLE_REGISTRY` now contains the new `aztec_utl_getTxEffects` entry (applied cleanly by the cherry-pick), so **these version constants must be regenerated** to match — the minor bump and interface hash were NOT hand-merged.
- **`utility_execution_oracle.ts`**: kept next's node-access API. The incoming v5 code routed reads through `this.aztecNodeReadCache.getTxReceiptWithEffect(...)`, a read-cache construct that does not exist in next. `#getTxEffectOption` was adapted to next's `this.aztecNode.getTxReceipt(txHash, { includeTxEffect: true })`. `getTxEffect` now delegates to `#getTxEffectOption`, and the new `getTxEffects` batch method (with `uniqueBy` dedup) is integrated.
- **`utility_execution.test.ts`**: next has no `node read cache` describe block, and the v5 caching tests (`reuses tx-effect reads`, `does not share cached reads`, `does not cache failed`, plus the archive/public-storage cache tests) assert read-cache behavior absent from next — they would fail here. Integrated only the two tests that exercise PR #24636's actual feature (`getTxEffects` batch alignment + intra-batch dedup), under a new `describe('getTxEffects')`, and added the `EpochNumber`/`SlotNumber` imports they need. The dedup test was renamed to describe next's behavior (`deduplicates repeated tx hashes within a batch`).

## Needs human judgment / follow-up

- **Regeneration required**: `ORACLE_VERSION_MINOR` and `ORACLE_INTERFACE_HASH` (both `oracle_version.ts` and `version.nr`) must be regenerated from the updated `ORACLE_REGISTRY`; the pinned Aztec.nr/PXE oracle-version check will otherwise be out of sync.
- **Dropped test coverage**: the v5 read-cache tests were intentionally not ported because next lacks the read cache. Confirm that decision, and re-add caching tests if next is expected to gain that behavior.
- Confidence: medium. Marker resolution is clean and the ported tests are consistent with next's implementation, but the adaptation of the read-cache path and the dropped tests warrant review, and regeneration has not been run (no build per task constraints).
