### PR TITLE
resolve conflicts: #24740 feat: weblock controlled opfs pool

### DIFF
--- a/yarn-project/kv-store/src/sqlite-opfs/errors.ts
+++ b/yarn-project/kv-store/src/sqlite-opfs/errors.ts
@@ -42,24 +42,6 @@ const SQLITE3MC_DECRYPT_ERROR_PATTERNS: readonly RegExp[] = [
 export function isDecryptFailureMessage(message: string): boolean {
   return SQLITE3MC_DECRYPT_ERROR_PATTERNS.some(p => p.test(message));
 }
-<<<<<<< HEAD
-=======
-
-/**
- * Error thrown by sqlite-opfs when the on-disk database image is corrupt
- * (`SQLITE_CORRUPT`, result code 11 — "database disk image is malformed").
- *
- * Distinct from {@link SqliteEncryptionError}: no key recovers a corrupt image,
- * so there is nothing to retry. The only escape is to delete the store and start
- * fresh, so consumers pattern-match on `instanceof SqliteCorruptionError` to wipe
- * and reopen rather than surfacing a dead-end error.
- **/
-export class SqliteCorruptionError extends Error {
-  constructor(message: string, opts?: { cause?: unknown }) {
-    super(message, opts?.cause !== undefined ? { cause: opts.cause } : undefined);
-    this.name = 'SqliteCorruptionError';
-  }
-}
 
 /** Error thrown when another browser context already owns a store's OPFS pool. */
 export class SqlitePoolBusyError extends Error {
@@ -76,22 +58,3 @@ export class SqliteWebLocksUnavailableError extends Error {
     this.name = 'SqliteWebLocksUnavailableError';
   }
 }
-
-/**
- * Strings/codes raised by SQLite when a database image is corrupt. Kept disjoint
- * from {@link SQLITE3MC_DECRYPT_ERROR_PATTERNS}: "file is not a database"
- * (SQLITE_NOTADB) is the decrypt signal, whereas a malformed image is the
- * genuinely-unrecoverable SQLITE_CORRUPT.
- **/
-const SQLITE_CORRUPTION_ERROR_PATTERNS: readonly RegExp[] = [
-  /database disk image is malformed/i,
-  /\bSQLITE_CORRUPT\b/i,
-];
-
-/**
- * Returns `true` if `message` matches one of the known SQLite corruption strings.
- **/
-export function isCorruptionMessage(message: string): boolean {
-  return SQLITE_CORRUPTION_ERROR_PATTERNS.some(p => p.test(message));
-}
->>>>>>> 386f120fb2 (feat: weblock controlled opfs pool (#24740))

--- a/yarn-project/kv-store/src/sqlite-opfs/index.ts
+++ b/yarn-project/kv-store/src/sqlite-opfs/index.ts
@@ -5,9 +5,9 @@ import { initStoreForRollupAndSchemaVersion } from '../utils.js';
 import { AztecSQLiteOPFSStore } from './store.js';
 
 export { AztecSQLiteOPFSStore } from './store.js';
-<<<<<<< HEAD
-export { SqliteEncryptionError } from './errors.js';
+export { SqliteEncryptionError, SqlitePoolBusyError, SqliteWebLocksUnavailableError } from './errors.js';
 export type { SqliteEncryptionErrorCode } from './errors.js';
+export { OPFS_POOL_DIR_PREFIX, deletePoolDirectory, deleteStore, listStores, storePoolDirectory } from './manage.js';
 
 export async function createStore(
   name: string,
@@ -24,16 +24,6 @@ export async function createStore(
   const store = await AztecSQLiteOPFSStore.open(createLogger('kv-store:sqlite-opfs'), name, false);
   return initStoreForRollupAndSchemaVersion(store, schemaVersion, config.rollupAddress, log);
 }
-=======
-export {
-  SqliteCorruptionError,
-  SqliteEncryptionError,
-  SqlitePoolBusyError,
-  SqliteWebLocksUnavailableError,
-} from './errors.js';
-export type { SqliteEncryptionErrorCode } from './errors.js';
-export { OPFS_POOL_DIR_PREFIX, deletePoolDirectory, deleteStore, listStores, storePoolDirectory } from './manage.js';
->>>>>>> 386f120fb2 (feat: weblock controlled opfs pool (#24740))
 
 export function openTmpStore(ephemeral: boolean = false): Promise<AztecSQLiteOPFSStore> {
   return AztecSQLiteOPFSStore.open(createLogger('kv-store:sqlite-opfs'), undefined, ephemeral);

--- a/yarn-project/kv-store/src/sqlite-opfs/worker.ts
+++ b/yarn-project/kv-store/src/sqlite-opfs/worker.ts
@@ -91,32 +91,12 @@ async function handleInit(
 }
 
 function handleClose(): void {
-<<<<<<< HEAD
-  db?.close();
-  db = undefined;
-  dbPath = undefined;
-=======
   try {
     db?.close();
   } finally {
     db = undefined;
     dbPath = undefined;
-    releasePool();
   }
-}
-
-/**
- * Releases the SAH pool's OPFS sync access handles before the terminal RPC is acked. Worker
- * termination releases them only asynchronously, so without this a caller that deletes or reopens
- * the store directory right after close()/delete() resolves races Chromium's cleanup
- * (NoModificationAllowedError from removeEntry, or a hang installing a new pool on the directory).
- * pauseVfs releases the handles without touching file contents; the worker is terminated right
- * after, so the pool is never resumed.
- */
-function releasePool(): void {
-  pool?.pauseVfs();
-  pool = undefined;
->>>>>>> 386f120fb2 (feat: weblock controlled opfs pool (#24740))
 }
 
 async function handleExport(): Promise<Uint8Array> {

--- a/yarn-project/wallets/src/embedded/store_encryption.ts
+++ b/yarn-project/wallets/src/embedded/store_encryption.ts
@@ -8,16 +8,7 @@
  *     surfaces, so callers don't leak the SAH Pool's OPFS lock.
  */
 import type { Logger } from '@aztec/foundation/log';
-<<<<<<< HEAD
 import { AztecSQLiteOPFSStore, SqliteEncryptionError } from '@aztec/kv-store/sqlite-opfs';
-=======
-import {
-  AztecSQLiteOPFSStore,
-  SqliteCorruptionError,
-  SqliteEncryptionError,
-  deletePoolDirectory,
-} from '@aztec/kv-store/sqlite-opfs';
->>>>>>> 386f120fb2 (feat: weblock controlled opfs pool (#24740))
 
 /** Which of the embedded wallet's two stores failed to open. */
 export type EmbeddedStoreName = 'pxe' | 'wallet';
@@ -59,31 +50,6 @@ const defaultOpenStore: OpenSqliteEncryptedStoreFn = (log, name, poolDirectory, 
   AztecSQLiteOPFSStore.open(log, name, false, poolDirectory, encryptionKey);
 
 /**
-<<<<<<< HEAD
-=======
- * Internal seam for tests to inject a fake store wiper. Defaults to removing the store's OPFS pool directory
- * outright. Not part of the public API.
- *
- * @internal
- */
-export type WipeSqliteStoreFn = (poolDirectory: string | undefined) => Promise<void>;
-
-/**
- * Deletes a store's OPFS pool directory. Safe to call only after a *failed* open() — a live store's SAH pool holds
- * a lock on the directory and the removal would reject. A store with no `poolDirectory` lives in the shared default
- * pool, which we won't blow away (it would take unrelated stores with it), so wiping is a no-op there.
- */
-const defaultWipeStore: WipeSqliteStoreFn = async poolDirectory => {
-  if (!poolDirectory) {
-    return;
-  }
-  await deletePoolDirectory(poolDirectory).catch(() => {
-    // Already gone / never created — nothing to wipe.
-  });
-};
-
-/**
->>>>>>> 386f120fb2 (feat: weblock controlled opfs pool (#24740))
  * Opens the PXE and wallet stores in sequence, both encrypted with keys obtained from `getEncryptionKey`.
  *
  * The callback is invoked once per store (twice total per call) because `AztecSQLiteOPFSStore.open` *transfers*


### PR DESCRIPTION
Automated conflict-resolution attempt for #24868 (`fwd-port-24740`). Merges `next` + v5-next PR #24740 ("feat: weblock controlled opfs pool").

## What conflicted and how it was resolved

The cherry-pick applied #24740's patch hunks onto `next`. Conflicts occurred exactly where #24740's patch **context** referenced *earlier* v5-only machinery that `next` does not have yet (`SqliteCorruptionError`/`isCorruptionMessage`, the worker's `releasePool`/`pauseVfs`, and the wallet's `WipeSqliteStoreFn`/`defaultWipeStore`). The files git auto-merged (e.g. `store.ts`, which imports only `SqliteEncryptionError`, not `SqliteCorruptionError`, plus the new `pool_lock.ts`/`manage.ts`) confirm the intended shape: apply #24740's genuine change onto `next`'s code without dragging in the unrelated earlier-v5 code.

- **`errors.ts`** — kept `next`'s content and added only #24740's two new classes (`SqlitePoolBusyError`, `SqliteWebLocksUnavailableError`). Did **not** add `SqliteCorruptionError`/`isCorruptionMessage`/corruption patterns (they belong to a separate v5 change not in `next`, and nothing in the resolved tree references them).
- **`index.ts`** — kept `next`'s `createStore` and its imports, and added #24740's new exports: the two pool errors plus the `manage.ts` re-exports (`OPFS_POOL_DIR_PREFIX`, `deletePoolDirectory`, `deleteStore`, `listStores`, `storePoolDirectory`). Did not export `SqliteCorruptionError`.
- **`worker.ts`** — applied #24740's genuine change (wrap `db.close()` in `try/finally` so cleanup always runs) to `next`'s `handleClose`, without the earlier-v5 `releasePool()`/`pauseVfs` helper. `next` never released the pool on close (the main thread terminates the worker), so this preserves `next`'s behavior while adding the exception-safety #24740 intended.
- **`store_encryption.ts`** — kept `next`'s version. #24740's only change here swaps `root.removeEntry` for `deletePoolDirectory` **inside `defaultWipeStore`**, but `defaultWipeStore`/`WipeSqliteStoreFn` are earlier-v5 machinery absent from `next` and not wired into `openEncryptedEmbeddedStores`. There is no applicable change to integrate, so `next`'s file stands unchanged.

`manage.ts`, `pool_lock.ts`, and `store_management.test.ts` were added/merged cleanly by the cherry-pick (no markers) and are the full v5 versions.

## Confidence

Medium–high. All conflict markers removed; no dangling references to dropped symbols; every import/export in the resolved module resolves (verified by grep, not a build). Not built or tested per the resolution task's constraints — a normal CI build/test run should validate.

Points for human review:
- The deliberate decision to **not** forward-port `SqliteCorruptionError`/corruption-wipe and the worker `releasePool`/`pauseVfs` on close. These are from a separate v5 change; if the intent is to bring the whole v5 sqlite-opfs module across, that separate change should be forward-ported too (and would then also re-enable #24740's `store_encryption.ts` wipe tweak). As scoped to #24740 alone, they are correctly excluded here.
- No generated/pinned artifacts were involved; no regeneration required.
