### PR TITLE
fix(validator): serialize competing block proposal re-executions

### DIFF
--- a/yarn-project/foundation/src/queue/index.ts
+++ b/yarn-project/foundation/src/queue/index.ts
@@ -3,4 +3,5 @@ export * from './priority_memory_queue.js';
 export * from './serial_queue.js';
 export * from './bounded_serial_queue.js';
 export * from './semaphore.js';
+export * from './keyed_gate.js';
 export * from './batch_queue.js';

--- a/yarn-project/foundation/src/queue/keyed_gate.test.ts
+++ b/yarn-project/foundation/src/queue/keyed_gate.test.ts
@@ -1,0 +1,64 @@
+import { KeyedGate } from './keyed_gate.js';
+
+describe('KeyedGate', () => {
+  it('serializes access for the same key', async () => {
+    const gate = new KeyedGate<string>();
+    const releaseFirst = await gate.acquire('shared');
+    let secondAcquired = false;
+
+    const acquireSecond = async () => {
+      const release = await gate.acquire('shared');
+      secondAcquired = true;
+      return release;
+    };
+    const secondRelease = acquireSecond();
+
+    await Promise.resolve();
+    expect(secondAcquired).toBe(false);
+
+    releaseFirst();
+    const releaseSecond = await secondRelease;
+    expect(secondAcquired).toBe(true);
+    releaseSecond();
+  });
+
+  it('allows concurrent access for different keys', async () => {
+    const gate = new KeyedGate<string>();
+    const releaseFirst = await gate.acquire('first');
+
+    const releaseSecond = await gate.acquire('second');
+
+    releaseFirst();
+    releaseSecond();
+  });
+
+  it('does not release more than once', async () => {
+    const gate = new KeyedGate<string>();
+    const releaseFirst = await gate.acquire('shared');
+    let secondAcquired = false;
+    let thirdAcquired = false;
+
+    const acquireNext = async (onAcquire: () => void) => {
+      const release = await gate.acquire('shared');
+      onAcquire();
+      return release;
+    };
+    const secondRelease = acquireNext(() => {
+      secondAcquired = true;
+    });
+    const thirdRelease = acquireNext(() => {
+      thirdAcquired = true;
+    });
+
+    releaseFirst();
+    releaseFirst();
+    const releaseSecond = await secondRelease;
+    expect(secondAcquired).toBe(true);
+    expect(thirdAcquired).toBe(false);
+
+    releaseSecond();
+    const releaseThird = await thirdRelease;
+    expect(thirdAcquired).toBe(true);
+    releaseThird();
+  });
+});

--- a/yarn-project/foundation/src/queue/keyed_gate.ts
+++ b/yarn-project/foundation/src/queue/keyed_gate.ts
@@ -1,0 +1,36 @@
+import { Semaphore } from './semaphore.js';
+
+/** A single-key semaphore together with the number of holders and waiters using it. */
+type Gate = {
+  semaphore: Semaphore;
+  users: number;
+};
+
+/**
+ * Provides mutually exclusive access per key while allowing work for different keys to proceed concurrently.
+ * Gates are removed when their last holder or waiter releases them.
+ */
+export class KeyedGate<Key> {
+  private readonly gates = new Map<Key, Gate>();
+
+  /** Acquires the gate for `key` and returns its idempotent release function. */
+  public async acquire(key: Key): Promise<() => void> {
+    const gate = this.gates.get(key) ?? { semaphore: new Semaphore(1), users: 0 };
+    this.gates.set(key, gate);
+    gate.users++;
+    await gate.semaphore.acquire();
+
+    let released = false;
+    return () => {
+      if (released) {
+        return;
+      }
+      released = true;
+      gate.semaphore.release();
+      gate.users--;
+      if (gate.users === 0) {
+        this.gates.delete(key);
+      }
+    };
+  }
+}

--- a/yarn-project/validator-client/src/proposal_handler.test.ts
+++ b/yarn-project/validator-client/src/proposal_handler.test.ts
@@ -809,6 +809,22 @@ describe('ProposalHandler checkpoint validation', () => {
       expect(blockSource.syncImmediate).toHaveBeenCalled();
     });
 
+    it('rejects a proposal if its block appears while waiting for a stale fork to be pruned', async () => {
+      const proposalArchive = Fr.random();
+      const { proposal, blockHandler } = await setupGenesisProposal(proposalArchive);
+      dateProvider.setTime(1_000);
+      blockSource.getBlockData.mockResolvedValueOnce(blockAt(Fr.random())).mockResolvedValue(blockAt(proposalArchive));
+
+      const result = await blockHandler.handleBlockProposal(proposal, {} as any, false);
+
+      expect(result).toEqual({
+        isValid: false,
+        blockNumber: BlockNumber(INITIAL_L2_BLOCK_NUM),
+        reason: 'block_number_already_exists',
+      });
+      expect(blockSource.syncImmediate).toHaveBeenCalled();
+    });
+
     it('falls back to block_number_already_exists when the stale fork is not pruned before the deadline', async () => {
       const { proposal, blockHandler } = await setupGenesisProposal(Fr.random());
       // A different block keeps occupying this number and never gets pruned.
@@ -901,6 +917,38 @@ describe('ProposalHandler checkpoint validation', () => {
       expect(reexecute.mock.calls.filter(([proposal]) => proposal === proposalB)).toHaveLength(1);
       expect(targetHeight.insertedArchives).toEqual([archiveA.toString(), archiveB.toString()]);
       expect(targetHeight.getBlockData()?.archive.root.equals(archiveB)).toBe(true);
+    });
+
+    it('waits again if another stale block repopulates the height after the awaited prune', async () => {
+      dateProvider.setTime(1_000);
+      const { proposal, blockHandler } = await setupGenesisProposal(Fr.random());
+      const staleBlock = blockAt(Fr.random());
+      const repopulatedBlock = blockAt(Fr.random());
+      blockSource.getBlockData
+        .mockResolvedValueOnce(undefined)
+        .mockResolvedValueOnce(staleBlock)
+        .mockResolvedValueOnce(staleBlock)
+        .mockResolvedValueOnce(undefined)
+        .mockResolvedValueOnce(repopulatedBlock)
+        .mockResolvedValueOnce(repopulatedBlock)
+        .mockResolvedValue(undefined);
+      const proposalBlock = {
+        archive: new AppendOnlyTreeSnapshot(proposal.archive, 1),
+        header: proposal.blockHeader,
+      } as unknown as L2Block;
+      const reexecute = jest.spyOn(blockHandler, 'reexecuteTransactions').mockResolvedValue({
+        block: proposalBlock,
+        failedTxs: [],
+        reexecutionTimeMs: 1,
+        totalManaUsed: 0,
+      });
+
+      const result = await blockHandler.handleBlockProposal(proposal, mock<PeerId>(), true);
+
+      expect(result).toEqual(expect.objectContaining({ isValid: true }));
+      expect(blockSource.syncImmediate).toHaveBeenCalledTimes(2);
+      expect(reexecute).toHaveBeenCalledTimes(1);
+      expect(blockSource.addBlock).toHaveBeenCalledWith(proposalBlock);
     });
 
     it('returns block_number_already_exists when an external insert wins the addBlock race', async () => {

--- a/yarn-project/validator-client/src/proposal_handler.test.ts
+++ b/yarn-project/validator-client/src/proposal_handler.test.ts
@@ -6,9 +6,10 @@ import { MAX_FEE_ASSET_PRICE_MODIFIER_BPS } from '@aztec/ethereum/contracts';
 import { BlockNumber, CheckpointNumber, SlotNumber } from '@aztec/foundation/branded-types';
 import { Secp256k1Signer } from '@aztec/foundation/crypto/secp256k1-signer';
 import { Fr } from '@aztec/foundation/curves/bn254';
+import { promiseWithResolvers } from '@aztec/foundation/promise';
 import { TestDateProvider } from '@aztec/foundation/timer';
 import { type FieldsOf, unfreeze } from '@aztec/foundation/types';
-import type { P2P } from '@aztec/p2p';
+import type { P2P, PeerId } from '@aztec/p2p';
 import type { BlockProposalValidator } from '@aztec/p2p/msg_validators';
 import { BlockHash } from '@aztec/stdlib/block';
 import type { BlockData, L2Block, L2BlockSink, L2BlockSource } from '@aztec/stdlib/block';
@@ -16,7 +17,7 @@ import { type Checkpoint, CheckpointReexecutionTracker, type ProposedCheckpointD
 import type { L1RollupConstants } from '@aztec/stdlib/epoch-helpers';
 import type { ITxProvider, ValidatorClientFullConfig, WorldStateSynchronizer } from '@aztec/stdlib/interfaces/server';
 import type { L1ToL2MessageSource } from '@aztec/stdlib/messaging';
-import { accumulateCheckpointOutHashes } from '@aztec/stdlib/messaging';
+import { accumulateCheckpointOutHashes, computeInHashFromL1ToL2Messages } from '@aztec/stdlib/messaging';
 import { CheckpointHeader } from '@aztec/stdlib/rollup';
 import {
   TEST_COORDINATION_SIGNATURE_CONTEXT,
@@ -716,6 +717,29 @@ describe('ProposalHandler checkpoint validation', () => {
   // node never re-acquired the block and missed the later checkpoint attestation. The guard must reject
   // only genuine duplicates (same archive) and otherwise wait for the local prune.
   describe('handleBlockProposal block-number guard (reorg-aware)', () => {
+    /** Stateful fake for the single archiver height involved in competing proposal tests. */
+    class TargetHeightBlockStore {
+      private block?: L2Block;
+
+      public readonly insertedArchives: string[] = [];
+
+      /** Returns the block currently occupying the target height. */
+      public getBlockData(): BlockData | undefined {
+        return this.block as unknown as BlockData | undefined;
+      }
+
+      /** Inserts a block at the target height. */
+      public addBlock(block: L2Block): void {
+        this.block = block;
+        this.insertedArchives.push(block.archive.root.toString());
+      }
+
+      /** Models the archiver pruning the current uncheckpointed block. */
+      public prune(): void {
+        this.block = undefined;
+      }
+    }
+
     /**
      * Builds a proposal whose parent resolves to genesis (so blockNumber = INITIAL_L2_BLOCK_NUM) and a
      * handler wired to accept it up to the block-number guard.
@@ -724,6 +748,8 @@ describe('ProposalHandler checkpoint validation', () => {
       const proposal = await makeBlockProposal({
         blockHeader: makeBlockHeader(1, { slotNumber: SlotNumber(1) }),
         archiveRoot: proposalArchive,
+        inHash: computeInHashFromL1ToL2Messages([]),
+        txHashes: [],
       });
 
       // Parent archive == genesis archive → genesis path → blockNumber = INITIAL_L2_BLOCK_NUM.
@@ -796,6 +822,141 @@ describe('ProposalHandler checkpoint validation', () => {
         blockNumber: BlockNumber(INITIAL_L2_BLOCK_NUM),
         reason: 'block_number_already_exists',
       });
+    });
+
+    it('waits for a competing proposal to be pruned before re-executing and inserting its replacement', async () => {
+      dateProvider.setTime(1_000);
+      const archiveA = Fr.random();
+      const archiveB = Fr.random();
+      const { proposal: proposalA, blockHandler } = await setupGenesisProposal(archiveA);
+      const proposalB = await makeBlockProposal({
+        blockHeader: makeBlockHeader(1, { slotNumber: SlotNumber(2) }),
+        archiveRoot: archiveB,
+        inHash: computeInHashFromL1ToL2Messages([]),
+        txHashes: [],
+      });
+      expect(proposalB.blockHeader.lastArchive.root.equals(proposalA.blockHeader.lastArchive.root)).toBe(true);
+
+      const targetHeight = new TargetHeightBlockStore();
+      blockSource.getBlockData.mockImplementation(() => Promise.resolve(targetHeight.getBlockData()));
+      blockSource.addBlock.mockImplementation(block => Promise.resolve(targetHeight.addBlock(block)));
+
+      const reexecutionAStarted = promiseWithResolvers<void>();
+      const allowReexecutionA = promiseWithResolvers<void>();
+      const proposalBReadyForGate = promiseWithResolvers<void>();
+      const pruneWaitStarted = promiseWithResolvers<void>();
+      const allowPrune = promiseWithResolvers<void>();
+      let checkpointDataReads = 0;
+      blockSource.getCheckpointsData.mockImplementation(() => {
+        checkpointDataReads++;
+        if (checkpointDataReads === 2) {
+          proposalBReadyForGate.resolve();
+        }
+        return Promise.resolve([]);
+      });
+      blockSource.syncImmediate.mockImplementation(async () => {
+        pruneWaitStarted.resolve();
+        await allowPrune.promise;
+        targetHeight.prune();
+      });
+
+      const blockFor = (proposal: typeof proposalA) =>
+        ({
+          archive: new AppendOnlyTreeSnapshot(proposal.archive, 1),
+          header: proposal.blockHeader,
+        }) as unknown as L2Block;
+      const reexecute = jest.spyOn(blockHandler, 'reexecuteTransactions').mockImplementation(async proposal => {
+        if (proposal === proposalA) {
+          reexecutionAStarted.resolve();
+          await allowReexecutionA.promise;
+        }
+        return {
+          block: blockFor(proposal),
+          failedTxs: [],
+          reexecutionTimeMs: 1,
+          totalManaUsed: 0,
+        };
+      });
+
+      const resultA = blockHandler.handleBlockProposal(proposalA, mock<PeerId>(), true);
+      await reexecutionAStarted.promise;
+
+      const resultB = blockHandler.handleBlockProposal(proposalB, mock<PeerId>(), true);
+      await proposalBReadyForGate.promise;
+      await Promise.resolve();
+      expect(reexecute.mock.calls.filter(([proposal]) => proposal === proposalB)).toHaveLength(0);
+
+      allowReexecutionA.resolve();
+      await pruneWaitStarted.promise;
+      expect(targetHeight.insertedArchives).toEqual([archiveA.toString()]);
+      expect(reexecute.mock.calls.filter(([proposal]) => proposal === proposalB)).toHaveLength(0);
+
+      allowPrune.resolve();
+      const results = await Promise.allSettled([resultA, resultB]);
+
+      expect(results).toEqual([
+        { status: 'fulfilled', value: expect.objectContaining({ isValid: true }) },
+        { status: 'fulfilled', value: expect.objectContaining({ isValid: true }) },
+      ]);
+      expect(reexecute.mock.calls.filter(([proposal]) => proposal === proposalB)).toHaveLength(1);
+      expect(targetHeight.insertedArchives).toEqual([archiveA.toString(), archiveB.toString()]);
+      expect(targetHeight.getBlockData()?.archive.root.equals(archiveB)).toBe(true);
+    });
+
+    it('returns block_number_already_exists when an external insert wins the addBlock race', async () => {
+      dateProvider.setTime(1_000);
+      const proposalArchive = Fr.random();
+      const competingArchive = Fr.random();
+      const { proposal, blockHandler } = await setupGenesisProposal(proposalArchive);
+      const targetHeight = new TargetHeightBlockStore();
+      const proposalBlock = {
+        archive: new AppendOnlyTreeSnapshot(proposalArchive, 1),
+        header: proposal.blockHeader,
+      } as unknown as L2Block;
+      const competingBlock = {
+        archive: new AppendOnlyTreeSnapshot(competingArchive, 1),
+        header: proposal.blockHeader,
+      } as unknown as L2Block;
+      blockSource.getBlockData.mockImplementation(() => Promise.resolve(targetHeight.getBlockData()));
+      blockSource.addBlock.mockImplementation(() => {
+        targetHeight.addBlock(competingBlock);
+        throw new Error('non-sequential insert');
+      });
+      jest.spyOn(blockHandler, 'reexecuteTransactions').mockResolvedValue({
+        block: proposalBlock,
+        failedTxs: [],
+        reexecutionTimeMs: 1,
+        totalManaUsed: 0,
+      });
+
+      await expect(blockHandler.handleBlockProposal(proposal, mock<PeerId>(), true)).resolves.toEqual({
+        isValid: false,
+        blockNumber: BlockNumber(INITIAL_L2_BLOCK_NUM),
+        reason: 'block_number_already_exists',
+        reexecutionResult: expect.objectContaining({ block: proposalBlock }),
+      });
+      expect(targetHeight.getBlockData()?.archive.root.equals(competingArchive)).toBe(true);
+    });
+
+    it('propagates an addBlock failure when the target height remains empty', async () => {
+      dateProvider.setTime(1_000);
+      const proposalArchive = Fr.random();
+      const { proposal, blockHandler } = await setupGenesisProposal(proposalArchive);
+      const proposalBlock = {
+        archive: new AppendOnlyTreeSnapshot(proposalArchive, 1),
+        header: proposal.blockHeader,
+      } as unknown as L2Block;
+      const insertError = new Error('storage unavailable');
+      blockSource.getBlockData.mockResolvedValue(undefined);
+      blockSource.addBlock.mockRejectedValue(insertError);
+      jest.spyOn(blockHandler, 'reexecuteTransactions').mockResolvedValue({
+        block: proposalBlock,
+        failedTxs: [],
+        reexecutionTimeMs: 1,
+        totalManaUsed: 0,
+      });
+
+      await expect(blockHandler.handleBlockProposal(proposal, mock<PeerId>(), true)).rejects.toBe(insertError);
     });
   });
 });

--- a/yarn-project/validator-client/src/proposal_handler.ts
+++ b/yarn-project/validator-client/src/proposal_handler.ts
@@ -16,6 +16,7 @@ import { TimeoutError } from '@aztec/foundation/error';
 import { FifoSet } from '@aztec/foundation/fifo-set';
 import type { LogData } from '@aztec/foundation/log';
 import { createLogger } from '@aztec/foundation/log';
+import { Semaphore } from '@aztec/foundation/queue';
 import { retryUntil } from '@aztec/foundation/retry';
 import { DateProvider, Timer } from '@aztec/foundation/timer';
 import type { P2P, PeerId } from '@aztec/p2p';
@@ -164,6 +165,38 @@ type BlockProposalSlotValidationResult =
 
 const MAX_TRACKED_INVALID_PROPOSAL_SLOTS = 1000;
 
+/** A single-key semaphore together with the number of holders and waiters using it. */
+type Gate = {
+  semaphore: Semaphore;
+  users: number;
+};
+
+/** Provides mutually exclusive access per key and removes idle gates. */
+class KeyedGate<Key> {
+  private readonly gates = new Map<Key, Gate>();
+
+  /** Acquires the gate for `key` and returns its idempotent release function. */
+  public async acquire(key: Key): Promise<() => void> {
+    const gate = this.gates.get(key) ?? { semaphore: new Semaphore(1), users: 0 };
+    this.gates.set(key, gate);
+    gate.users++;
+    await gate.semaphore.acquire();
+
+    let released = false;
+    return () => {
+      if (released) {
+        return;
+      }
+      released = true;
+      gate.semaphore.release();
+      gate.users--;
+      if (gate.users === 0) {
+        this.gates.delete(key);
+      }
+    };
+  }
+}
+
 /** Block-proposal validation failures that constitute a slashable invalid-block offense. */
 export const SLASHABLE_BLOCK_PROPOSAL_VALIDATION_RESULT: BlockProposalValidationFailureReason[] = [
   'state_mismatch',
@@ -210,6 +243,9 @@ export const SLASHABLE_CHECKPOINT_PROPOSAL_VALIDATION_RESULT: Record<
  */
 export class ProposalHandler {
   public readonly tracer: Tracer;
+
+  /** Serializes proposal re-execution and insertion within the archiver's block-number conflict domain. */
+  private readonly blockNumberGates = new KeyedGate<BlockNumber>();
 
   /** Cached last checkpoint validation result to avoid double-validation on validator nodes.
    *  Keyed by signed-payload hash so two proposals at the same (slot, archive) but with a
@@ -584,35 +620,78 @@ export class ProposalHandler {
       log: this.log,
     });
 
-    // Try re-executing the transactions in the proposal if needed
-    let reexecutionResult;
-    try {
-      this.log.verbose(`Re-executing transactions in the proposal`, proposalInfo);
-      reexecutionResult = await this.reexecuteTransactions(
-        proposal,
+    while (true) {
+      const releaseBlockNumberGate = await this.blockNumberGates.acquire(blockNumber);
+      let blockObservedWhileHoldingGate: BlockData | undefined;
+      try {
+        blockObservedWhileHoldingGate = await this.blockSource.getBlockData({ number: blockNumber });
+        if (!blockObservedWhileHoldingGate) {
+          if (this.getReexecutionDeadline(slotNumber).getTime() - this.dateProvider.now() <= 0) {
+            return { isValid: false, blockNumber, reason: 'timeout' };
+          }
+
+          // Keep the block-number gate from this final absence check through re-execution and insertion.
+          let reexecutionResult;
+          try {
+            this.log.verbose(`Re-executing transactions in the proposal`, proposalInfo);
+            reexecutionResult = await this.reexecuteTransactions(
+              proposal,
+              blockNumber,
+              checkpointNumber,
+              txs,
+              l1ToL2Messages,
+              previousCheckpointOutHashes,
+            );
+          } catch (error) {
+            this.log.error(`Error reexecuting txs while processing block proposal`, error, proposalInfo);
+            const reason = this.getReexecuteFailureReason(error);
+            return { isValid: false, blockNumber, reason, reexecutionResult };
+          }
+
+          if (reexecutionResult.block && !this.config.skipPushProposedBlocksToArchiver) {
+            try {
+              await this.blockSource.addBlock(reexecutionResult.block);
+            } catch (error) {
+              const competingBlock = await this.blockSource.getBlockData({ number: blockNumber });
+              if (!competingBlock) {
+                throw error;
+              }
+              this.log.warn(`Another block was inserted while processing block proposal`, {
+                ...proposalInfo,
+                existingSlot: competingBlock.header.getSlot(),
+                existingArchive: competingBlock.archive.root.toString(),
+                outcome: 'concurrent_block_insert',
+              });
+              return { isValid: false, blockNumber, reason: 'block_number_already_exists', reexecutionResult };
+            }
+          }
+
+          this.log.info(
+            `Successfully re-executed block ${blockNumber} proposal at index ${proposal.indexWithinCheckpoint} on slot ${slotNumber}`,
+            { ...proposalInfo, ...pick(reexecutionResult, 'reexecutionTimeMs', 'totalManaUsed') },
+          );
+
+          return { isValid: true, blockNumber, reexecutionResult };
+        }
+      } finally {
+        releaseBlockNumberGate();
+      }
+
+      // A competing proposal populated the height while this handler was queued. Do not hold the gate while
+      // waiting for that block to be pruned; after the wait, loop to reacquire and re-check atomically.
+      const existingBlockAfterPrune = await this.resolveExistingBlockAtNumber(
         blockNumber,
-        checkpointNumber,
-        txs,
-        l1ToL2Messages,
-        previousCheckpointOutHashes,
+        proposal.archive,
+        slotNumber,
       );
-    } catch (error) {
-      this.log.error(`Error reexecuting txs while processing block proposal`, error, proposalInfo);
-      const reason = this.getReexecuteFailureReason(error);
-      return { isValid: false, blockNumber, reason, reexecutionResult };
+      if (existingBlockAfterPrune) {
+        this.log.warn(`Block number ${blockNumber} already exists, skipping processing`, {
+          ...proposalInfo,
+          existingArchive: blockObservedWhileHoldingGate?.archive.root.toString(),
+        });
+        return { isValid: false, blockNumber, reason: 'block_number_already_exists' };
+      }
     }
-
-    // If we succeeded, push this block into the archiver (unless disabled)
-    if (reexecutionResult?.block && !this.config.skipPushProposedBlocksToArchiver) {
-      await this.blockSource.addBlock(reexecutionResult.block);
-    }
-
-    this.log.info(
-      `Successfully re-executed block ${blockNumber} proposal at index ${proposal.indexWithinCheckpoint} on slot ${slotNumber}`,
-      { ...proposalInfo, ...pick(reexecutionResult, 'reexecutionTimeMs', 'totalManaUsed') },
-    );
-
-    return { isValid: true, blockNumber, reexecutionResult };
   }
 
   private async validateNewBlockInSlot(blockProposal: BlockProposal): Promise<BlockProposalSlotValidationResult> {

--- a/yarn-project/validator-client/src/proposal_handler.ts
+++ b/yarn-project/validator-client/src/proposal_handler.ts
@@ -16,7 +16,7 @@ import { TimeoutError } from '@aztec/foundation/error';
 import { FifoSet } from '@aztec/foundation/fifo-set';
 import type { LogData } from '@aztec/foundation/log';
 import { createLogger } from '@aztec/foundation/log';
-import { Semaphore } from '@aztec/foundation/queue';
+import { KeyedGate } from '@aztec/foundation/queue';
 import { retryUntil } from '@aztec/foundation/retry';
 import { DateProvider, Timer } from '@aztec/foundation/timer';
 import type { P2P, PeerId } from '@aztec/p2p';
@@ -165,37 +165,10 @@ type BlockProposalSlotValidationResult =
 
 const MAX_TRACKED_INVALID_PROPOSAL_SLOTS = 1000;
 
-/** A single-key semaphore together with the number of holders and waiters using it. */
-type Gate = {
-  semaphore: Semaphore;
-  users: number;
-};
-
-/** Provides mutually exclusive access per key and removes idle gates. */
-class KeyedGate<Key> {
-  private readonly gates = new Map<Key, Gate>();
-
-  /** Acquires the gate for `key` and returns its idempotent release function. */
-  public async acquire(key: Key): Promise<() => void> {
-    const gate = this.gates.get(key) ?? { semaphore: new Semaphore(1), users: 0 };
-    this.gates.set(key, gate);
-    gate.users++;
-    await gate.semaphore.acquire();
-
-    let released = false;
-    return () => {
-      if (released) {
-        return;
-      }
-      released = true;
-      gate.semaphore.release();
-      gate.users--;
-      if (gate.users === 0) {
-        this.gates.delete(key);
-      }
-    };
-  }
-}
+/** Result of attempting work that requires a block number to remain unoccupied. */
+type BlockNumberGateAttempt<Result> =
+  | { status: 'completed'; result: Result }
+  | { status: 'occupied'; block: BlockData };
 
 /** Block-proposal validation failures that constitute a slashable invalid-block offense. */
 export const SLASHABLE_BLOCK_PROPOSAL_VALIDATION_RESULT: BlockProposalValidationFailureReason[] = [
@@ -620,77 +593,78 @@ export class ProposalHandler {
       log: this.log,
     });
 
-    while (true) {
-      const releaseBlockNumberGate = await this.blockNumberGates.acquire(blockNumber);
-      let blockObservedWhileHoldingGate: BlockData | undefined;
+    const reexecutionDeadline = this.getReexecutionDeadline(slotNumber).getTime();
+
+    const reexecuteAndInsert = async (): Promise<BlockProposalValidationResult> => {
+      if (reexecutionDeadline - this.dateProvider.now() <= 0) {
+        return { isValid: false, blockNumber, reason: 'timeout' };
+      }
+
+      let reexecutionResult;
       try {
-        blockObservedWhileHoldingGate = await this.blockSource.getBlockData({ number: blockNumber });
-        if (!blockObservedWhileHoldingGate) {
-          if (this.getReexecutionDeadline(slotNumber).getTime() - this.dateProvider.now() <= 0) {
-            return { isValid: false, blockNumber, reason: 'timeout' };
+        this.log.verbose(`Re-executing transactions in the proposal`, proposalInfo);
+        reexecutionResult = await this.reexecuteTransactions(
+          proposal,
+          blockNumber,
+          checkpointNumber,
+          txs,
+          l1ToL2Messages,
+          previousCheckpointOutHashes,
+        );
+      } catch (error) {
+        this.log.error(`Error reexecuting txs while processing block proposal`, error, proposalInfo);
+        const reason = this.getReexecuteFailureReason(error);
+        return { isValid: false, blockNumber, reason, reexecutionResult };
+      }
+
+      if (reexecutionResult.block && !this.config.skipPushProposedBlocksToArchiver) {
+        try {
+          await this.blockSource.addBlock(reexecutionResult.block);
+        } catch (error) {
+          const competingBlock = await this.blockSource.getBlockData({ number: blockNumber });
+          if (!competingBlock) {
+            throw error;
           }
-
-          // Keep the block-number gate from this final absence check through re-execution and insertion.
-          let reexecutionResult;
-          try {
-            this.log.verbose(`Re-executing transactions in the proposal`, proposalInfo);
-            reexecutionResult = await this.reexecuteTransactions(
-              proposal,
-              blockNumber,
-              checkpointNumber,
-              txs,
-              l1ToL2Messages,
-              previousCheckpointOutHashes,
-            );
-          } catch (error) {
-            this.log.error(`Error reexecuting txs while processing block proposal`, error, proposalInfo);
-            const reason = this.getReexecuteFailureReason(error);
-            return { isValid: false, blockNumber, reason, reexecutionResult };
-          }
-
-          if (reexecutionResult.block && !this.config.skipPushProposedBlocksToArchiver) {
-            try {
-              await this.blockSource.addBlock(reexecutionResult.block);
-            } catch (error) {
-              const competingBlock = await this.blockSource.getBlockData({ number: blockNumber });
-              if (!competingBlock) {
-                throw error;
-              }
-              this.log.warn(`Another block was inserted while processing block proposal`, {
-                ...proposalInfo,
-                existingSlot: competingBlock.header.getSlot(),
-                existingArchive: competingBlock.archive.root.toString(),
-                outcome: 'concurrent_block_insert',
-              });
-              return { isValid: false, blockNumber, reason: 'block_number_already_exists', reexecutionResult };
-            }
-          }
-
-          this.log.info(
-            `Successfully re-executed block ${blockNumber} proposal at index ${proposal.indexWithinCheckpoint} on slot ${slotNumber}`,
-            { ...proposalInfo, ...pick(reexecutionResult, 'reexecutionTimeMs', 'totalManaUsed') },
-          );
-
-          return { isValid: true, blockNumber, reexecutionResult };
+          this.log.warn(`Another block was inserted while processing block proposal`, {
+            ...proposalInfo,
+            existingSlot: competingBlock.header.getSlot(),
+            existingArchive: competingBlock.archive.root.toString(),
+            outcome: 'concurrent_block_insert',
+          });
+          return { isValid: false, blockNumber, reason: 'block_number_already_exists', reexecutionResult };
         }
-      } finally {
-        releaseBlockNumberGate();
       }
 
-      // A competing proposal populated the height while this handler was queued. Do not hold the gate while
-      // waiting for that block to be pruned; after the wait, loop to reacquire and re-check atomically.
-      const existingBlockAfterPrune = await this.resolveExistingBlockAtNumber(
-        blockNumber,
-        proposal.archive,
-        slotNumber,
+      this.log.info(
+        `Successfully re-executed block ${blockNumber} proposal at index ${proposal.indexWithinCheckpoint} on slot ${slotNumber}`,
+        { ...proposalInfo, ...pick(reexecutionResult, 'reexecutionTimeMs', 'totalManaUsed') },
       );
-      if (existingBlockAfterPrune) {
-        this.log.warn(`Block number ${blockNumber} already exists, skipping processing`, {
-          ...proposalInfo,
-          existingArchive: blockObservedWhileHoldingGate?.archive.root.toString(),
-        });
-        return { isValid: false, blockNumber, reason: 'block_number_already_exists' };
+
+      return { isValid: true, blockNumber, reexecutionResult };
+    };
+
+    while (true) {
+      const attempt = await this.runWithAvailableBlockNumber(blockNumber, reexecuteAndInsert);
+      if (attempt.status === 'completed') {
+        return attempt.result;
       }
+
+      // This is the only place this loop waits. runWithAvailableBlockNumber has already released the gate, so
+      // another proposal at this height can finish while resolveExistingBlockAtNumber forces archiver sync and
+      // waits, bounded by the re-execution deadline, for that proposal to be pruned.
+      const existingBlock = await this.resolveExistingBlockAtNumber(blockNumber, proposal.archive, slotNumber);
+      if (!existingBlock) {
+        // A prune was observed. Reacquire the gate and atomically re-check the height before re-executing. If a
+        // different block won that race, the next iteration waits for that block under the same deadline.
+        continue;
+      }
+
+      // A matching block appeared, or a different block remained until the deadline. Both are safe rejections.
+      this.log.warn(`Block number ${blockNumber} already exists, skipping processing`, {
+        ...proposalInfo,
+        existingArchive: existingBlock.archive.root.toString(),
+      });
+      return { isValid: false, blockNumber, reason: 'block_number_already_exists' };
     }
   }
 
@@ -802,6 +776,23 @@ export class ProposalHandler {
         return existingBlock;
       }
       throw err;
+    }
+  }
+
+  /**
+   * Runs `action` while holding the block-number gate only if the target height is empty. The gate remains held
+   * through the action, coupling the final absence check to re-execution and insertion.
+   */
+  private async runWithAvailableBlockNumber<Result>(
+    blockNumber: BlockNumber,
+    action: () => Promise<Result>,
+  ): Promise<BlockNumberGateAttempt<Result>> {
+    const releaseBlockNumberGate = await this.blockNumberGates.acquire(blockNumber);
+    try {
+      const block = await this.blockSource.getBlockData({ number: blockNumber });
+      return block ? { status: 'occupied', block } : { status: 'completed', result: await action() };
+    } finally {
+      releaseBlockNumberGate();
     }
   }
 

--- a/yarn-project/validator-client/src/validator.test.ts
+++ b/yarn-project/validator-client/src/validator.test.ts
@@ -887,13 +887,18 @@ describe('ValidatorClient', () => {
       // is still in the future, leaving a retry window for the parent-block archive lookup.
       const buildSlotTime = 1n + BigInt(proposal.slotNumber - 1) * BigInt(checkpointsBuilder.getConfig().slotDuration);
       dateProvider.setTime(Number(buildSlotTime * 1000n));
-      blockSource.getBlockData.mockResolvedValueOnce(undefined);
-      blockSource.getBlockData.mockResolvedValueOnce(undefined);
-      blockSource.getBlockData.mockResolvedValueOnce(undefined);
+      let parentSynced = false;
+      blockSource.getBlockData.mockImplementation(query =>
+        Promise.resolve('number' in query || !parentSynced ? undefined : parentBlockData),
+      );
+      blockSource.syncImmediate.mockImplementation(() => {
+        parentSynced = true;
+        return Promise.resolve();
+      });
+
       const isValid = await validatorClient.validateBlockProposal(proposal, sender);
-      // Archive lookups: 1 direct + 2 retryUntil (undefined) + 1 retryUntil (success) = 4
-      // Plus 1 number-based existence check after parent block is found = 5 total
-      expect(blockSource.getBlockData).toHaveBeenCalledTimes(5);
+
+      expect(blockSource.syncImmediate).toHaveBeenCalled();
       expect(isValid).toBe(true);
     });
 


### PR DESCRIPTION
## Summary

- serialize block proposal re-execution and insertion per block number
- release the height gate while waiting for a competing block to be pruned, then reacquire and re-check before running the replacement
- reconcile inserts from outside the proposal handler without hiding unrelated archiver failures
- add deterministic coverage where proposal B waits for proposal A to be pruned and then successfully re-executes and inserts

## Testing

- `yarn workspace @aztec/validator-client test src/proposal_handler.test.ts` (35/35 passed)
- `yarn lint validator-client`
- `yarn format validator-client --check`
- `git diff --check`
- `yarn build` currently reports 46 unrelated generated Noir artifact, end-to-end contract binding, and IVC size errors; no errors are in validator-client or the changed files