### PR TITLE
fix(bench): grant helm-sa logging.viewer for scraper log reads

### DIFF
--- a/spartan/terraform/gke-cluster/iam.tf
+++ b/spartan/terraform/gke-cluster/iam.tf
@@ -50,6 +50,18 @@ resource "google_project_iam_member" "helm_sa_roles" {
   member   = "serviceAccount:${google_service_account.helm_sa.email}"
 }
 
+# helm-sa is the CI deploy identity (GitHub Actions secret GCP_SA_KEY). The bench
+# scraper runs `gcloud logging read` as this account to collect block/event/
+# sequencer-state records (l2-block-handled / l2-block-built / public-processor
+# logs); without logging read the reads are permission-denied and the scraper
+# silently emits empty block data (null totalTxsMined, empty build/validator
+# fields). Prometheus metrics use a kube port-forward and are unaffected.
+resource "google_project_iam_member" "helm_sa_logging_viewer" {
+  project = var.project
+  role    = "roles/logging.viewer"
+  member  = "serviceAccount:${google_service_account.helm_sa.email}"
+}
+
 # Create a service account for CI
 resource "google_service_account" "ci" {
   account_id   = var.ci_service_account_id


### PR DESCRIPTION
## Problem

The nightly inclusion-sweep dashboard shows **Tx Mined: -** and empty block-build / validator-count fields, while all Prometheus-derived metrics (inclusion TPS, latency, saturation, proving-infra) populate normally.

Root cause: the bench scraper (`spartan/scripts/bench_10tps/bench_scrape.ts`) pulls from **two sources with different auth**:

- **PromQL** via a `kubectl port-forward` to the in-cluster Prometheus — feeds all `timeSeries` / `saturation` / `provingInfra`. Worked.
- **`gcloud logging read`** — feeds `blocks`, `events`, `sequencerStateSlots` (parsed from `l2-block-handled` / `l2-block-built` / public-processor log entries). These are the **only** source of `summary.totalTxsMined` and the block-build/validator fields. Failed.

The scraper runs `gcloud logging read` as **`helm-sa`** — the CI deploy identity behind the `GCP_SA_KEY` secret (confirmed via `.github/local_workflow.sh`, which uses `testnet-helm-sa.json`). `helm-sa` has the network-deployer roles (`container.admin` / `storage.admin` / `secretmanager.admin` / …) but **no logging read role**, so the reads were permission-denied. Each block/event/sequencer scrape is individually try/caught and defaults to empty, so the run still uploads with full metrics but null block data — surfacing as `-` on the dashboard days later.

Verified against GCP Cloud Logging that the logs exist, are structured `jsonPayload`, and the scraper's exact filter matches thousands of rows — so this is purely the missing IAM permission, not a logging-config or code issue.

## Fix

Grant `roles/logging.viewer` to `helm-sa`. These are standard `k8s_container` app logs in the `_Default` bucket, so `viewer` suffices (`privateLogViewer` not needed). The `ci` service account already has this via `ci_observer_roles`, but `helm-sa` is the identity the deploy/bench workflows actually authenticate as.

Takes effect on the next `terraform apply` of the `gke-cluster` module against `testnet-440309`.

## Follow-up (not in this PR)

`scrapeBlocks` swallows a `logging read` permission error identically to a legitimate "0 blocks" result. Making it fail loudly (or stamp `logScrapeFailed` on the run JSON) would surface this at run time instead of as a silent `-`.