### PR TITLE
feat(bench): publish block-capacity benchmark to the custom dashboard pipeline

### DIFF
--- a/.github/workflows/nightly-spartan-bench.yml
+++ b/.github/workflows/nightly-spartan-bench.yml
@@ -524,6 +524,11 @@ jobs:
           AWS_SHUTDOWN_TIME: 240
           NO_SPOT: 1
           SKIP_NETWORK_DEPLOY: "1"
+          # Publishes to the custom network-dashboard pipeline (GCS) tagged as the
+          # block-capacity benchmark, grouped as one sweep per run.
+          BENCH_SWEEP_ID: block-capacity-${{ github.run_id }}
+          BENCH_SWEEP_LABEL: block-capacity
+          BENCH_BENCHMARK_TYPE: block-capacity
         run: |
           ./.github/ci3.sh network-block-capacity-bench block-capacity nightly-block-capacity "${{ needs.select-image.outputs.docker_image }}"
 

--- a/ci.sh
+++ b/ci.sh
@@ -363,7 +363,7 @@ case "$cmd" in
     export INSTANCE_POSTFIX="n-block-cap-bench"
     skip_network_deploy=0
     [ "${SKIP_NETWORK_DEPLOY:-0}" = "1" ] && skip_network_deploy=1
-    bootstrap_ec2 "SKIP_NETWORK_DEPLOY=$skip_network_deploy ./bootstrap.sh ci-network-block-capacity-bench $*"
+    bootstrap_ec2 "BENCH_SWEEP_ID=${BENCH_SWEEP_ID:-} BENCH_SWEEP_LABEL=${BENCH_SWEEP_LABEL:-block-capacity} BENCH_BENCHMARK_TYPE=${BENCH_BENCHMARK_TYPE:-block-capacity} SKIP_NETWORK_DEPLOY=$skip_network_deploy ./bootstrap.sh ci-network-block-capacity-bench $*"
     ;;
   network-bench-10tps)
     # Args: <scenario> <namespace> [docker_image]

--- a/spartan/bootstrap.sh
+++ b/spartan/bootstrap.sh
@@ -222,7 +222,39 @@ function block_capacity_bench {
   gcp_auth
   export_admin_api_key
   export K8S_ENRICHER=${K8S_ENRICHER:-1}
-  block_capacity_bench_cmds | parallelize 1
+  export BENCH_RUN_ID="${BENCH_RUN_ID:-$(date -u +%Y%m%d)-block-capacity-${COMMIT_HASH:0:10}}"
+
+  # Capture the test exit code but don't abort: even a partial run produced blocks
+  # worth scraping. We scrape below, then re-surface the failure at the end.
+  local test_rc=0
+  block_capacity_bench_cmds | parallelize 1 || test_rc=$?
+  if [[ "$test_rc" -ne 0 ]]; then
+    echo "[block_capacity_bench] test exited ${test_rc}; scraping captured data anyway"
+  fi
+
+  # Publish to the custom pipeline (GCS -> network-dashboard) alongside the
+  # legacy github-action-benchmark output the workflow still uploads.
+  local metadata="/tmp/block_capacity_timing_data.json"
+  local run_json="bench-out/bench-block-capacity-${BENCH_RUN_ID}.json"
+  if [[ -f "$metadata" ]]; then
+    local started=$(jq -r .startedAt < "$metadata")
+    local ended=$(jq -r .endedAt < "$metadata")
+    echo "Scraping block-capacity run ${BENCH_RUN_ID} (started=${started} ended=${ended})"
+    NAMESPACE="$NAMESPACE" GCP_PROJECT_ID="${GCP_PROJECT_ID:-}" ./scripts/bench_10tps/bench_scrape.ts \
+      --run-id "$BENCH_RUN_ID" \
+      --started "$started" \
+      --ended "$ended" \
+      --sweep-id "${BENCH_SWEEP_ID:-$BENCH_RUN_ID}" \
+      --sweep-label "${BENCH_SWEEP_LABEL:-block-capacity}" \
+      --benchmark-type "${BENCH_BENCHMARK_TYPE:-block-capacity}" \
+      --output "$run_json" \
+      || echo "[block_capacity_bench] scraper failed (non-fatal)"
+    network_bench_upload "$run_json" || echo "[network_bench] upload failed (non-fatal)"
+  else
+    echo "[block_capacity_bench] no timing metadata at ${metadata}; skipping custom-pipeline scrape"
+  fi
+
+  return "$test_rc"
 }
 
 # One point of the inclusion sweep: a fixed 1 TPS of high-value txs (the

--- a/spartan/scripts/bench_10tps/bench_output.schema.json
+++ b/spartan/scripts/bench_10tps/bench_output.schema.json
@@ -682,6 +682,11 @@
           "type": "number",
           "minimum": 0
         },
+        "manaPerSec": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Mana consumed per second while building this block (totalManaUsed / buildDuration), from the l2-block-built log. The headline throughput signal for the block-capacity benchmark. Optional; absent when the block-built log was not captured."
+        },
         "totalPublicGas": {
           "type": "object",
           "additionalProperties": false,

--- a/spartan/scripts/bench_10tps/bench_scrape.ts
+++ b/spartan/scripts/bench_10tps/bench_scrape.ts
@@ -1218,6 +1218,7 @@ type BlockRecord = {
   silentlySkippedCount: number;
   silentlySkippedDurationMs: number;
   buildDurationSeconds: number;
+  manaPerSec?: number;
   totalPublicGas?: { daGas: number; l2Gas: number };
   totalSizeInBytes?: number;
   source: "log";
@@ -1313,6 +1314,9 @@ async function scrapeBlocks(
           ? finiteOrZero(numberPayloadField(processorPayload ?? {}, "duration"))
           : finiteOrZero(numberPayloadField(built.jsonPayload, "duration")) /
             1000,
+      manaPerSec: numberOrUndefined(
+        numberPayloadField(built?.jsonPayload ?? {}, "manaPerSec"),
+      ),
       totalPublicGas: processorPayload?.totalPublicGas as
         | { daGas: number; l2Gas: number }
         | undefined,

--- a/yarn-project/end-to-end/src/spartan/block_capacity.test.ts
+++ b/yarn-project/end-to-end/src/spartan/block_capacity.test.ts
@@ -67,8 +67,12 @@ describe('block capacity benchmark', () => {
   let aztecNode: AztecNode;
   let originalSequencerConfig: Awaited<ReturnType<typeof getSequencersConfig>> | undefined;
   const benchmarkData: Array<{ name: string; unit: string; value: number }> = [];
+  // Window handed to bench_scrape.ts so the custom pipeline can scrape this run's
+  // blocks/metrics (see spartan/bootstrap.sh block_capacity_bench).
+  let benchStartedAt: string | undefined;
 
   beforeAll(async () => {
+    benchStartedAt = new Date().toISOString();
     logger.info('Setting up block capacity benchmark', {
       numWallets: NUM_WALLETS,
       txRealProofs,
@@ -139,6 +143,19 @@ describe('block capacity benchmark', () => {
       await writeFile(process.env.BENCH_OUTPUT, JSON.stringify(finalData));
       logger.info('Wrote benchmark output', { path: process.env.BENCH_OUTPUT, entries: finalData.length });
     }
+
+    // Hand the run window to the custom-pipeline scraper (bench_scrape.ts), which
+    // reads this file to bound its Prometheus/log queries for the block-capacity run.
+    const timingMetadataPath = '/tmp/block_capacity_timing_data.json';
+    await writeFile(
+      timingMetadataPath,
+      JSON.stringify({
+        startedAt: benchStartedAt ?? new Date().toISOString(),
+        endedAt: new Date().toISOString(),
+        runId: process.env.BENCH_RUN_ID,
+      }),
+    );
+    logger.info('Wrote block-capacity timing metadata', { path: timingMetadataPath });
 
     // Restore original sequencer config
     if (originalSequencerConfig?.[0]) {


### PR DESCRIPTION
Part of the nightly-benchmarking migration (A-1228). Brings the **block-capacity** benchmark onto the custom `network-dashboard` pipeline, reusing the scrape→GCS→dashboard path the daily inclusion sweep established.

## What

- **`block_capacity.test.ts`** writes `/tmp/block_capacity_timing_data.json` (run start/end) in `afterAll`, mirroring `n_tps.test.ts` — this is the window `bench_scrape.ts` needs.
- **`spartan/bootstrap.sh block_capacity_bench`** scrapes that window with `bench_scrape.ts --benchmark-type block-capacity` and uploads the v5 run JSON via `network_bench_upload`. The test's exit code is captured and re-surfaced so a degraded run still publishes the blocks it produced.
- **`bench_scrape.ts`** now captures `manaPerSec` per block from the `l2-block-built` log — the headline block-capacity throughput metric — added as an optional field on block records (schema updated).
- **`ci.sh` / `nightly-spartan-bench.yml`** thread `BENCH_SWEEP_ID` / `BENCH_SWEEP_LABEL` / `BENCH_BENCHMARK_TYPE`, so the run is tagged `block-capacity` and grouped as one sweep per nightly run.

The dashboard's `BENCHMARK_TYPES` already reserves a `block-capacity` slot, so these runs appear in the sidebar and render in the generic block/timeseries views immediately. Dedicated block-capacity panels (max txs/block, mana/s trend, public-process duration) are a small follow-up in the `explorations` repo.

## Why this shape

Block-capacity's per-block facts (txCount, build duration, public gas, mana/s) are exactly what the scraper already parses from block logs, so no parallel scrape path is needed — just a new `benchmarkType` and the mana/s enrichment.

## Notes / dependencies

- The legacy `github-action-benchmark` upload is intentionally **left in place** here; it's removed only once real-proving and block-capacity are both publishing to the custom pipeline (the deferred retire-github-action-benchmark work).
- Populated block data depends on **helm-sa having `roles/logging.viewer`** (separate infra PR) — otherwise the `gcloud logging read` pass returns empty and block records are null, same failure mode as the inclusion sweep.
- Not run end-to-end (needs a live cluster). Bash/YAML/JSON validated; the scrape path is identical to the proven inclusion-sweep flow.