### PR TITLE
feat(bench): publish real-proving benchmark to the custom dashboard pipeline

### DIFF
--- a/.github/workflows/nightly-spartan-bench.yml
+++ b/.github/workflows/nightly-spartan-bench.yml
@@ -346,6 +346,12 @@ jobs:
           AWS_SHUTDOWN_TIME: 180
           NO_SPOT: 1
           SKIP_NETWORK_DEPLOY: "1"
+          # Publishes to the custom network-dashboard pipeline (GCS). Fake/fixed-delay
+          # proving, so it's tagged simulated-proving (distinct from the weekly
+          # real-proving run).
+          BENCH_SWEEP_ID: simulated-proving-${{ github.run_id }}
+          BENCH_SWEEP_LABEL: simulated-proving
+          BENCH_BENCHMARK_TYPE: simulated-proving
         run: |
           ./.github/ci3.sh network-proving-bench prove-n-tps-fake prove-n-tps-fake "${{ needs.select-image.outputs.docker_image }}"
 

--- a/.github/workflows/weekly-proving-bench.yml
+++ b/.github/workflows/weekly-proving-bench.yml
@@ -133,6 +133,11 @@ jobs:
           AWS_SHUTDOWN_TIME: 180
           NO_SPOT: 1
           SKIP_NETWORK_DEPLOY: "1"
+          # Publishes to the custom network-dashboard pipeline (GCS) tagged as the
+          # real-proving benchmark, grouped as one sweep per run.
+          BENCH_SWEEP_ID: real-proving-${{ github.run_id }}
+          BENCH_SWEEP_LABEL: real-proving
+          BENCH_BENCHMARK_TYPE: real-proving
         run: |
           ./.github/ci3.sh network-proving-bench prove-n-tps-real prove-n-tps-real
 

--- a/ci.sh
+++ b/ci.sh
@@ -353,7 +353,7 @@ case "$cmd" in
     export INSTANCE_POSTFIX="n-proving-bench"
     skip_network_deploy=0
     [ "${SKIP_NETWORK_DEPLOY:-0}" = "1" ] && skip_network_deploy=1
-    bootstrap_ec2 "SKIP_NETWORK_DEPLOY=$skip_network_deploy ./bootstrap.sh ci-network-proving-bench $*"
+    bootstrap_ec2 "BENCH_SWEEP_ID=${BENCH_SWEEP_ID:-} BENCH_SWEEP_LABEL=${BENCH_SWEEP_LABEL:-} BENCH_BENCHMARK_TYPE=${BENCH_BENCHMARK_TYPE:-} SKIP_NETWORK_DEPLOY=$skip_network_deploy ./bootstrap.sh ci-network-proving-bench $*"
     ;;
   network-block-capacity-bench)
     # Args: <scenario> <namespace> [docker_image]

--- a/spartan/bootstrap.sh
+++ b/spartan/bootstrap.sh
@@ -208,7 +208,40 @@ function proving_bench {
   gcp_auth
   export_admin_api_key
   export K8S_ENRICHER=${K8S_ENRICHER:-1}
-  proving_bench_cmds | parallelize 1
+  export BENCH_RUN_ID="${BENCH_RUN_ID:-$(date -u +%Y%m%d)-proving-${COMMIT_HASH:0:10}}"
+  # real proving (prove-n-tps-real, REAL_VERIFIER=true) vs fake/simulated timings.
+  local benchmark_type="${BENCH_BENCHMARK_TYPE:-$([ "${REAL_VERIFIER:-}" = "true" ] && echo real-proving || echo simulated-proving)}"
+
+  local test_rc=0
+  proving_bench_cmds | parallelize 1 || test_rc=$?
+  if [[ "$test_rc" -ne 0 ]]; then
+    echo "[proving_bench] test exited ${test_rc}; scraping captured data anyway"
+  fi
+
+  # Publish to the custom pipeline (GCS -> network-dashboard) alongside the
+  # legacy github-action-benchmark output the workflow still uploads.
+  local metadata="/tmp/n_tps_prove_timing_data.json"
+  local run_json="bench-out/bench-${benchmark_type}-${BENCH_RUN_ID}.json"
+  if [[ -f "$metadata" ]]; then
+    local started=$(jq -r .startedAt < "$metadata")
+    local ended=$(jq -r .endedAt < "$metadata")
+    echo "Scraping ${benchmark_type} run ${BENCH_RUN_ID} (started=${started} ended=${ended})"
+    NAMESPACE="$NAMESPACE" GCP_PROJECT_ID="${GCP_PROJECT_ID:-}" ./scripts/bench_10tps/bench_scrape.ts \
+      --run-id "$BENCH_RUN_ID" \
+      --started "$started" \
+      --ended "$ended" \
+      --target-tps "${TARGET_TPS:-1}" \
+      --sweep-id "${BENCH_SWEEP_ID:-$BENCH_RUN_ID}" \
+      --sweep-label "${BENCH_SWEEP_LABEL:-$benchmark_type}" \
+      --benchmark-type "$benchmark_type" \
+      --output "$run_json" \
+      || echo "[proving_bench] scraper failed (non-fatal)"
+    network_bench_upload "$run_json" || echo "[network_bench] upload failed (non-fatal)"
+  else
+    echo "[proving_bench] no timing metadata at ${metadata}; skipping custom-pipeline scrape"
+  fi
+
+  return "$test_rc"
 }
 
 function block_capacity_bench {

--- a/spartan/scripts/bench_10tps/bench_scrape.ts
+++ b/spartan/scripts/bench_10tps/bench_scrape.ts
@@ -840,6 +840,32 @@ const PROVING_INFRA_DEFS: Record<string, TimeSeriesDef> = {
     unit: "count",
     query: queueRateByJobType("aztec_proving_queue_resolved_jobs_count"),
   },
+  // Epoch proving: how long the prover node takes to prove a job (epoch) and how
+  // much it has proven. The headline real-proving signal — compare against the
+  // epoch wall-clock (AZTEC_PROOF_SUBMISSION_EPOCHS * epoch duration).
+  epochProvingDurationP50: {
+    metric: "aztec_prover_node_job_duration",
+    unit: "s",
+    query: proverNodeHist(0.5, "aztec_prover_node_job_duration_seconds_bucket"),
+  },
+  epochProvingDurationP99: {
+    metric: "aztec_prover_node_job_duration",
+    unit: "s",
+    query: proverNodeHist(
+      0.99,
+      "aztec_prover_node_job_duration_seconds_bucket",
+    ),
+  },
+  provenBlocks: {
+    metric: "aztec_prover_node_job_blocks",
+    unit: "count",
+    query: `sum(aztec_prover_node_job_blocks${NS})`,
+  },
+  provenTransactions: {
+    metric: "aztec_prover_node_job_transactions",
+    unit: "count",
+    query: `sum(aztec_prover_node_job_transactions${NS})`,
+  },
 };
 
 // Scrape a map of slug -> PromQL def via query_range. One failing query emits an

--- a/yarn-project/end-to-end/src/spartan/n_tps_prove.test.ts
+++ b/yarn-project/end-to-end/src/spartan/n_tps_prove.test.ts
@@ -133,6 +133,9 @@ describe(`prove ${TARGET_TPS}TPS test`, () => {
   let rollupCheatCodes: RollupCheatCodes;
   let ethEndpoint: ServiceEndpoint | undefined;
   let metricsStartSnapshot: MetricsSnapshot | undefined;
+  // Window handed to bench_scrape.ts so the custom pipeline can scrape this run's
+  // proving-infra series (see spartan/bootstrap.sh proving_bench).
+  let benchStartedAt: string | undefined;
 
   afterAll(async () => {
     if (process.env.BENCH_OUTPUT && metrics && metricsStartSnapshot) {
@@ -212,6 +215,19 @@ describe(`prove ${TARGET_TPS}TPS test`, () => {
       await writeFile(process.env.BENCH_OUTPUT, JSON.stringify(metrics.toGithubActionBenchmarkJSON()));
     }
 
+    // Hand the run window to the custom-pipeline scraper (bench_scrape.ts), which
+    // reads this file to bound its Prometheus queries for the proving run.
+    const timingMetadataPath = '/tmp/n_tps_prove_timing_data.json';
+    await writeFile(
+      timingMetadataPath,
+      JSON.stringify({
+        startedAt: benchStartedAt ?? new Date().toISOString(),
+        endedAt: new Date().toISOString(),
+        runId: process.env.BENCH_RUN_ID,
+      }),
+    );
+    logger.info('Wrote proving-bench timing metadata', { path: timingMetadataPath });
+
     if (testWallets) {
       for (const tw of testWallets) {
         await tw.cleanup();
@@ -247,6 +263,7 @@ describe(`prove ${TARGET_TPS}TPS test`, () => {
       server: new URL(`http://127.0.0.1:${promPortForward.port}`),
     });
     metricsStartSnapshot = await captureMetricsSnapshot(prometheusClient, logger);
+    benchStartedAt = new Date().toISOString();
     promPortForward.process.kill();
     logger.info('Metrics snapshot captured');
 


### PR DESCRIPTION
A-1229 (aztec-packages side). Brings the **real-proving** benchmark onto the custom `network-dashboard` pipeline, reusing the scrape→GCS→dashboard path from the inclusion sweep and block capacity. Paired dashboard PR: AztecProtocol/explorations#TBD.

## What

- **`n_tps_prove.test.ts`** writes `/tmp/n_tps_prove_timing_data.json` (the measurement window, captured at the metrics-start snapshot) in `afterAll` — the window `bench_scrape.ts` needs.
- **`spartan/bootstrap.sh proving_bench`** scrapes that window and uploads the v5 run JSON via `network_bench_upload`. `benchmarkType` defaults from `REAL_VERIFIER` (`real-proving` for `prove-n-tps-real`, `simulated-proving` for the fake run) and can be overridden per workflow. The test exit code is captured and re-surfaced so a degraded run still publishes.
- **`bench_scrape.ts` `provingInfra`** gains the headline real-proving signals — **epoch proving duration p50/p99** (`aztec_prover_node_job_duration_seconds`) and **proven blocks / transactions** — reusing the exact metrics `n_tps_prove.test.ts` already queries. These join the existing hint-gen and proving-queue-by-job_type (≈per-circuit) series.
- **`ci.sh` + both proving workflows** thread `BENCH_SWEEP_ID` / `BENCH_SWEEP_LABEL` / `BENCH_BENCHMARK_TYPE`. Weekly `prove-n-tps-real` → `real-proving`; nightly `prove-n-tps-fake` → `simulated-proving`.

Both `real-proving` and `simulated-proving` are already registered `BENCHMARK_TYPES` on the dashboard, so runs appear as their own sidebar entries per day automatically.

## Notes / dependencies

- Legacy `github-action-benchmark` upload **left in place** here; removed only when the retire-GAB work lands (deferred until real-proving + block-capacity are both live).
- Populated block/log data depends on **helm-sa `roles/logging.viewer`** (separate infra PR).
- Not run end-to-end (needs a live cluster). Bash/YAML validated; TS syntax-checked via node type-stripping; the scrape path is identical to the proven inclusion/block-capacity flow.