### PR TITLE
chore(bb): forward-port v5-next secp256r1 lookup-table change (needs bb owner)

### DIFF
--- a/barretenberg/cpp/src/barretenberg/circuit_checker/ultra_circuit_builder_lookup.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/circuit_checker/ultra_circuit_builder_lookup.test.cpp
@@ -4,6 +4,7 @@
 
 #include <gtest/gtest.h>
 #include <unordered_map>
+#include <unordered_set>
 
 using namespace bb;
 
@@ -119,6 +120,40 @@ TEST_F(UltraCircuitBuilderLookup, DifferentTablesGetUniqueIndices)
 
     // Exactly three different tables should have been created
     EXPECT_EQ(builder.get_num_lookup_tables(), 3UL);
+}
+
+TEST_F(UltraCircuitBuilderLookup, Secp256r1FixedBaseTablesGetUniquePositiveIndices)
+{
+    Builder builder;
+    std::unordered_set<size_t> table_indices;
+
+    const auto first_id = static_cast<size_t>(plookup::BasicTableId::SECP256R1_FIXED_BASE_XLO_0);
+    const auto end_id = static_cast<size_t>(plookup::BasicTableId::SECP256R1_FIXED_BASE_END);
+    for (size_t id = first_id; id < end_id; ++id) {
+        const auto& table = builder.get_table(static_cast<plookup::BasicTableId>(id));
+        EXPECT_GT(table.table_index, 0UL);
+        EXPECT_TRUE(table_indices.insert(table.table_index).second);
+    }
+
+    EXPECT_NO_THROW(builder.finalize_circuit());
+}
+
+TEST_F(UltraCircuitBuilderLookup, FinalizationRejectsDuplicateTableIndices)
+{
+    Builder builder;
+    builder.get_table(plookup::BasicTableId::UINT_XOR_SLICE_6_ROTATE_0);
+    builder.get_table(plookup::BasicTableId::UINT_AND_SLICE_6_ROTATE_0);
+    builder.get_lookup_tables()[1].table_index = builder.get_lookup_tables()[0].table_index;
+
+    EXPECT_THROW_OR_ABORT(builder.finalize_circuit(), "Lookup table indices must be unique within a circuit");
+}
+
+TEST_F(UltraCircuitBuilderLookup, FinalizationRejectsZeroTableIndex)
+{
+    Builder builder;
+    builder.get_table(plookup::BasicTableId::UINT_XOR_SLICE_6_ROTATE_0).table_index = 0;
+
+    EXPECT_THROW_OR_ABORT(builder.finalize_circuit(), "Lookup table indices must be positive");
 }
 
 // Verifies correct behavior when key_b_index is not provided (2-to-1 lookup without second index)

--- a/barretenberg/cpp/src/barretenberg/circuit_checker/ultra_circuit_builder_lookup.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/circuit_checker/ultra_circuit_builder_lookup.test.cpp
@@ -124,9 +124,8 @@ TEST_F(UltraCircuitBuilderLookup, DifferentTablesGetUniqueIndices)
 
 // Every basic table reachable through any MultiTable must receive a unique, positive circuit-local
 // table_index. The LogDeriv lookup relation identifies a table solely by table_index (not BasicTableId),
-// so a generator that stores anything other than the builder-assigned index — e.g. a window or bit-slice
-// position — silently collapses distinct tables to one identity. This sweeps the whole table space so
-// any such generator (not just secp256r1 fixed-base) is caught.
+// so a generator that stores anything other than the builder-assigned index silently collapses distinct tables to one
+// identity. This sweeps the whole table space so any such generator is caught.
 TEST_F(UltraCircuitBuilderLookup, AllMultiTableBasicTablesGetUniquePositiveIndices)
 {
     Builder builder;

--- a/barretenberg/cpp/src/barretenberg/circuit_checker/ultra_circuit_builder_lookup.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/circuit_checker/ultra_circuit_builder_lookup.test.cpp
@@ -122,19 +122,27 @@ TEST_F(UltraCircuitBuilderLookup, DifferentTablesGetUniqueIndices)
     EXPECT_EQ(builder.get_num_lookup_tables(), 3UL);
 }
 
-TEST_F(UltraCircuitBuilderLookup, Secp256r1FixedBaseTablesGetUniquePositiveIndices)
+// Every basic table reachable through any MultiTable must receive a unique, positive circuit-local
+// table_index. The LogDeriv lookup relation identifies a table solely by table_index (not BasicTableId),
+// so a generator that stores anything other than the builder-assigned index — e.g. a window or bit-slice
+// position — silently collapses distinct tables to one identity. This sweeps the whole table space so
+// any such generator (not just secp256r1 fixed-base) is caught.
+TEST_F(UltraCircuitBuilderLookup, AllMultiTableBasicTablesGetUniquePositiveIndices)
 {
     Builder builder;
-    std::unordered_set<size_t> table_indices;
-
-    const auto first_id = static_cast<size_t>(plookup::BasicTableId::SECP256R1_FIXED_BASE_XLO_0);
-    const auto end_id = static_cast<size_t>(plookup::BasicTableId::SECP256R1_FIXED_BASE_END);
-    for (size_t id = first_id; id < end_id; ++id) {
-        const auto& table = builder.get_table(static_cast<plookup::BasicTableId>(id));
-        EXPECT_GT(table.table_index, 0UL);
-        EXPECT_TRUE(table_indices.insert(table.table_index).second);
+    for (size_t mt = 0; mt < static_cast<size_t>(plookup::MultiTableId::NUM_MULTI_TABLES); ++mt) {
+        const auto& multitable = plookup::get_multitable(static_cast<plookup::MultiTableId>(mt));
+        for (const auto id : multitable.basic_table_ids) {
+            builder.get_table(id);
+        }
     }
 
+    std::unordered_set<size_t> seen;
+    for (const auto& table : builder.get_lookup_tables()) {
+        EXPECT_GT(table.table_index, 0UL) << "non-positive index for basic table id " << static_cast<size_t>(table.id);
+        EXPECT_TRUE(seen.insert(table.table_index).second)
+            << "duplicate table_index " << table.table_index << " for basic table id " << static_cast<size_t>(table.id);
+    }
     EXPECT_NO_THROW(builder.finalize_circuit());
 }
 

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/plookup_tables/plookup_tables.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/plookup_tables/plookup_tables.cpp
@@ -285,22 +285,22 @@ BasicTable create_basic_table(const BasicTableId id, const size_t index)
     if (id_var >= static_cast<size_t>(SECP256R1_FIXED_BASE_XLO_0) &&
         id_var < static_cast<size_t>(SECP256R1_FIXED_BASE_XHI_0)) {
         return secp256r1_fixed_base::table::generate_basic_table_runtime<secp256r1_fixed_base::table::AXIS_XLO>(
-            id, id_var - static_cast<size_t>(SECP256R1_FIXED_BASE_XLO_0));
+            id, id_var - static_cast<size_t>(SECP256R1_FIXED_BASE_XLO_0), index);
     }
     if (id_var >= static_cast<size_t>(SECP256R1_FIXED_BASE_XHI_0) &&
         id_var < static_cast<size_t>(SECP256R1_FIXED_BASE_YLO_0)) {
         return secp256r1_fixed_base::table::generate_basic_table_runtime<secp256r1_fixed_base::table::AXIS_XHI>(
-            id, id_var - static_cast<size_t>(SECP256R1_FIXED_BASE_XHI_0));
+            id, id_var - static_cast<size_t>(SECP256R1_FIXED_BASE_XHI_0), index);
     }
     if (id_var >= static_cast<size_t>(SECP256R1_FIXED_BASE_YLO_0) &&
         id_var < static_cast<size_t>(SECP256R1_FIXED_BASE_YHI_0)) {
         return secp256r1_fixed_base::table::generate_basic_table_runtime<secp256r1_fixed_base::table::AXIS_YLO>(
-            id, id_var - static_cast<size_t>(SECP256R1_FIXED_BASE_YLO_0));
+            id, id_var - static_cast<size_t>(SECP256R1_FIXED_BASE_YLO_0), index);
     }
     if (id_var >= static_cast<size_t>(SECP256R1_FIXED_BASE_YHI_0) &&
         id_var < static_cast<size_t>(SECP256R1_FIXED_BASE_END)) {
         return secp256r1_fixed_base::table::generate_basic_table_runtime<secp256r1_fixed_base::table::AXIS_YHI>(
-            id, id_var - static_cast<size_t>(SECP256R1_FIXED_BASE_YHI_0));
+            id, id_var - static_cast<size_t>(SECP256R1_FIXED_BASE_YHI_0), index);
     }
     switch (id) {
     case AES_SPARSE_MAP: {

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/plookup_tables/secp256r1_fixed_base.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/plookup_tables/secp256r1_fixed_base.cpp
@@ -143,17 +143,18 @@ template <table::AxisIndex axis> generate_fn_ptr generate_fn_for_window(size_t w
 }
 } // namespace
 
-template <table::AxisIndex axis> BasicTable table::generate_basic_table_runtime(BasicTableId id, size_t window_idx)
+template <table::AxisIndex axis>
+BasicTable table::generate_basic_table_runtime(BasicTableId id, size_t window_idx, size_t table_index)
 {
     BB_ASSERT_LT(window_idx, NUM_WINDOWS);
-    return generate_fn_for_window<axis>(window_idx)(id, window_idx);
+    return generate_fn_for_window<axis>(window_idx)(id, table_index);
 }
 
 // Explicit instantiations for the four axes.
-template BasicTable table::generate_basic_table_runtime<table::AXIS_XLO>(BasicTableId, size_t);
-template BasicTable table::generate_basic_table_runtime<table::AXIS_XHI>(BasicTableId, size_t);
-template BasicTable table::generate_basic_table_runtime<table::AXIS_YLO>(BasicTableId, size_t);
-template BasicTable table::generate_basic_table_runtime<table::AXIS_YHI>(BasicTableId, size_t);
+template BasicTable table::generate_basic_table_runtime<table::AXIS_XLO>(BasicTableId, size_t, size_t);
+template BasicTable table::generate_basic_table_runtime<table::AXIS_XHI>(BasicTableId, size_t, size_t);
+template BasicTable table::generate_basic_table_runtime<table::AXIS_YLO>(BasicTableId, size_t, size_t);
+template BasicTable table::generate_basic_table_runtime<table::AXIS_YHI>(BasicTableId, size_t, size_t);
 
 namespace {
 // Returns `&table::get_values<axis, window_idx>` for a runtime (axis, window_idx). The per-axis 32-entry

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/plookup_tables/secp256r1_fixed_base.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/plookup_tables/secp256r1_fixed_base.hpp
@@ -116,10 +116,11 @@ class table : public Secp256r1FixedBaseParams {
     static BasicTable generate_basic_table(BasicTableId id, size_t table_index);
 
     /**
-     * @brief Runtime dispatch helper used by plookup_tables.cpp::create_basic_table. Given an axis and a
-     * runtime window_idx ∈ [0, NUM_WINDOWS), instantiate the corresponding generator.
+     * @brief Runtime dispatch helper used by plookup_tables.cpp::create_basic_table. Selects table contents using
+     * window_idx and assigns the independently supplied circuit-local table_index.
      */
-    template <AxisIndex axis> static BasicTable generate_basic_table_runtime(BasicTableId id, size_t table_index);
+    template <AxisIndex axis>
+    static BasicTable generate_basic_table_runtime(BasicTableId id, size_t window_idx, size_t table_index);
 
     /**
      * @brief Construct one of the 10 MultiTables described in the file-header docstring.

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.cpp
@@ -51,6 +51,13 @@ template <typename ExecutionTrace> void UltraCircuitBuilder_<ExecutionTrace>::fi
      * our circuit is finalized, and we must not to execute these functions again.
      */
     if (!this->circuit_finalized) {
+        std::unordered_set<size_t> table_indices;
+        for (const auto& table : lookup_tables) {
+            BB_ASSERT_GT(table.table_index, 0U, "Lookup table indices must be positive");
+            BB_ASSERT(table_indices.insert(table.table_index).second,
+                      "Lookup table indices must be unique within a circuit");
+        }
+
         process_non_native_field_multiplications();
 #ifndef ULTRA_FUZZ
         this->rom_ram_logic.process_ROM_arrays(this);


### PR DESCRIPTION
Forward-port of the v5-next **secp256r1 lookup-table** change (3 commits) into `next`, extracted from the backlog PR #24849:

- `fix(bb): assign unique secp256r1 lookup table indices`
- `test(bb): generalize lookup table-index invariant across all tables`
- `comment cleanup`

**⚠️ This will not build as-is and needs a barretenberg owner.** These cherry-pick without a text conflict, but `next`'s barretenberg has diverged heavily (`ultra_circuit_builder.cpp` is ~half rewritten on `next` vs the fork point). The combination is semantically inconsistent: `bb` aborts while deriving the Chonk VK for `verify_private_authwit` — `Assertion failed: (get_value().on_curve())` / `cycle_group: Point is not on curve` (SIGABRT). That crash is why #24849 failed CI, so these commits were removed from #24849 and isolated here.

Action needed: a bb owner should decide whether this secp256r1 lookup-index change is still relevant on v6, and if so reapply it against `next`'s current `ultra_circuit_builder`. Draft until reconciled.

Files: `secp256r1_fixed_base.{hpp,cpp}`, `plookup_tables.cpp`, `ultra_circuit_builder.cpp`, `ultra_circuit_builder_lookup.test.cpp`.