### PR TITLE
resolve #24567: complete prefilled-nullifiers on next's IPC world-state

### DIFF
--- a/yarn-project/world-state/src/native/ipc_world_state_instance.ts
+++ b/yarn-project/world-state/src/native/ipc_world_state_instance.ts
@@ -26,6 +26,7 @@ import type {
   TreeMeta as WsdbTreeMeta,
 } from '@aztec/wsdb';
 
+import assert from 'node:assert';
 import { cpus } from 'node:os';
 
 import type { WorldStateInstrumentation } from '../instrumentation/instrumentation.js';
@@ -205,6 +206,23 @@ function getWsdbExtraArgs(
       data.value.toBuffer().toString('hex'),
     ]);
     args.push('--prefilled-public-data', JSON.stringify(pairs));
+  }
+
+  // Nullifiers to pre-insert into the genesis nullifier tree (empty by default, so production genesis roots are
+  // unchanged). The native indexed nullifier tree requires its prefilled leaves to be unique and strictly
+  // increasing, so we enforce that here before handing them to the aztec-wsdb subprocess rather than failing deep
+  // inside C++ tree construction. Each nullifier is serialised as a 64-char hex string, matching the JSON-array
+  // format `--prefilled-nullifiers` is parsed with in wsdb_ipc_server.cpp.
+  const prefilledNullifiers = genesis.prefilledNullifiers ?? [];
+  if (prefilledNullifiers.length > 0) {
+    for (let i = 1; i < prefilledNullifiers.length; i++) {
+      assert(
+        prefilledNullifiers[i].toBigInt() > prefilledNullifiers[i - 1].toBigInt(),
+        'Prefilled genesis nullifiers must be unique and strictly increasing',
+      );
+    }
+    const hexNullifiers = prefilledNullifiers.map(n => n.toBuffer().toString('hex'));
+    args.push('--prefilled-nullifiers', JSON.stringify(hexNullifiers));
   }
 
   const genesisTimestamp = Number(genesis.genesisTimestamp);


### PR DESCRIPTION
## What

Completes the half-applied forward-port of v5-next's #24567 ("support prefilled nullifiers in genesis state") onto `next`'s aztec-wsdb IPC world-state architecture.

On `v5-forward-port`, #24567 was inconsistent: `stdlib/.../genesis_data.ts` (the `prefilledNullifiers?: Fr[]` field), `world-state/src/testing.ts` (`getGenesisValues` accepts and sorts prefilled nullifiers), and the barretenberg C++ world_state / wsdb IPC server all carried prefilled-nullifier support — but the TS IPC world-state instance silently dropped them on the way to the subprocess. Genesis code plumbed prefilled nullifiers toward a binding that ignored them.

`next` removed the NAPI `NativeWorldState` class that v5's #24567 modified and instead spawns an `aztec-wsdb` subprocess, configured entirely via command-line args. So v5's binding change could not be copied verbatim.

## How prefilled nullifiers now flow on next's IPC path

1. `genesis_data.ts` / `testing.ts` build `GenesisData.prefilledNullifiers` (sorted ascending).
2. Every world-state creation path funnels through `IpcWorldState.spawn` → `getWsdbExtraArgs(...)`, the single place `GenesisData` is turned into subprocess CLI args.
3. `getWsdbExtraArgs` now appends `--prefilled-nullifiers <json>` when the list is non-empty, where `<json>` is a JSON array of 64-char hex strings (`fr.toBuffer().toString('hex')`) — the exact format `parse_prefilled_nullifiers` reads in `wsdb_ipc_server.cpp`. This mirrors the existing `--prefilled-public-data` arg.
4. `cli.cpp` parses `--prefilled-nullifiers`, `wsdb_ipc_server.cpp` decodes the hex array, and `WorldState` seeds them into the genesis nullifier tree — all already present from the forward-port.

The strictly-increasing / unique validation from v5's NAPI constructor is ported into `getWsdbExtraArgs` so a bad list fails fast with a clear message before the subprocess is spawned, rather than deep inside C++ tree construction.

## Changed

- `yarn-project/world-state/src/native/ipc_world_state_instance.ts`: forward `genesis.prefilledNullifiers` as `--prefilled-nullifiers`; add the strictly-increasing/unique assertion; import `node:assert`.

## Verification

Confirmed by inspection (no full build — too slow):
- All `IpcWorldState.spawn` call sites in `native_world_state.ts` (ephemeral/tmp/new/onOpen) route through `getWsdbExtraArgs`, so this is the only integration point needed.
- Hex encoding matches the working `--prefilled-public-data` path and `hex_to_fr` in `wsdb_ipc_server.cpp` (strips optional `0x`, else raw hex).
- CLI flag name (`--prefilled-nullifiers`) matches `cli.cpp`.
- The assertion message exactly matches what `testing.test.ts` case (d) ("rejects prefilled nullifiers that are not strictly increasing") asserts via `.rejects.toThrow(...)`. Because the assert runs synchronously inside `spawn` before the subprocess launches, that rejection test passes without a built binary.

## For a world-state owner to verify with a build

- Run `yarn-project/world-state/src/testing.test.ts` — cases (a)–(c) compute genesis archive roots against a real `aztec-wsdb` binary. In particular, case (c) asserts a non-empty prefilled-nullifier genesis yields a deterministic root differing from empty genesis, and case matching `getGenesisValues` sorting confirms the seeded root. These require the C++ `aztec-wsdb` binary + full TS build, not run here.
- Confirm the genesis nullifier-tree root produced via the IPC path is bit-identical to the v5 NAPI path for the same nullifier set (the C++ `world_state.test.cpp` already covers the tree-construction side).