### PR TITLE
chore: remove unused l1-contracts repo mirror from release flow

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -660,12 +660,10 @@ function private_release {
   fi
 
   # Publish @aztec/l1-artifacts to the internal registry. 13 yarn-project packages depend on it at the
-  # release version, so it must exist before yarn-project's release smoke-test installs them. We call
-  # only the npm publish, not l1-contracts' full `release` — that also git-mirrors tags to the public
-  # AztecProtocol/l1-contracts repo, which the private flow must not do. amd64 only (npm packages are
-  # platform-independent; mirrors the publish guard below).
+  # release version, so it must exist before yarn-project's release smoke-test installs them. amd64
+  # only (npm packages are platform-independent; mirrors the publish guard below).
   if [ $(arch) != arm64 ]; then
-    l1-contracts/bootstrap.sh release_l1_artifacts_npm
+    l1-contracts/bootstrap.sh release
   fi
 
   # Publish for real, in dependency order: bb.js, the noir packages, ipc-runtime, and wsdb must be on

--- a/docs/docs-developers/docs/foundational-topics/ethereum-aztec-messaging/index.md
+++ b/docs/docs-developers/docs/foundational-topics/ethereum-aztec-messaging/index.md
@@ -118,6 +118,29 @@ The following diagram shows the overall architecture, combining the earlier sect
 
 <Image img={require("@site/static/img/com-abs-7.png")} />
 
+## Using the L1 contract interfaces in your own project
+
+Portal contracts import Aztec's L1 interfaces (`IRegistry`, `IInbox`, `IOutbox`, `IRollup`, and supporting libraries). These ship in the [`@aztec/l1-artifacts`](https://www.npmjs.com/package/@aztec/l1-artifacts) npm package as a self-contained Foundry project under `l1-contracts/`, versioned to match each Aztec release:
+
+```bash
+npm install @aztec/l1-artifacts@<aztec-version>
+```
+
+In a Foundry project, add remappings so `@aztec/*` imports (and the bundled OpenZeppelin copy) resolve into the package:
+
+```toml
+# foundry.toml
+remappings = [
+  "@aztec/=node_modules/@aztec/l1-artifacts/l1-contracts/src/",
+  "@oz/=node_modules/@aztec/l1-artifacts/l1-contracts/lib/openzeppelin-contracts/contracts/",
+  "@aztec-blob-lib/=node_modules/@aztec/l1-artifacts/l1-contracts/src/core/libraries/rollup/"
+]
+```
+
+Then import interfaces as `@aztec/core/interfaces/IRollup.sol`, `@aztec/governance/interfaces/IRegistry.sol`, and so on. Note that `forge install` cannot fetch the package: it only clones whole git repositories, and the L1 contract sources include generated files that exist only in built distributions, so npm is the supported channel.
+
+In a Hardhat project, import with full package paths (`@aztec/l1-artifacts/l1-contracts/src/core/interfaces/IRollup.sol`), or configure equivalent aliases pointing at `node_modules/@aztec/l1-artifacts/l1-contracts/src`.
+
 ## See also
 
 - [Communicating Cross-Chain](../../aztec-nr/framework-description/ethereum_aztec_messaging.md) - Practical guide with code examples for L1-L2 messaging

--- a/docs/docs-developers/docs/tutorials/js_tutorials/aave_bridge.md
+++ b/docs/docs-developers/docs/tutorials/js_tutorials/aave_bridge.md
@@ -110,11 +110,13 @@ Start with the Hardhat + Aztec template. This provides a pre-configured Hardhat 
 
 This template is a community-maintained starter. If the repository is unavailable, you can set up a Hardhat project manually and add the `@aztec/*` Solidity remappings from the [cross-chain messaging docs](../../foundational-topics/ethereum-aztec-messaging/index.md).
 
-You may need to update the `@aztec/l1-contracts` tag in the template's `package.json` to match your Aztec version, e.g.:
+If the template still pins `@aztec/l1-contracts` as a git dependency, replace it in `package.json` with the `@aztec/l1-artifacts` npm package at the version matching your Aztec version, e.g.:
 
 ```json
-"@aztec/l1-contracts": "git+https://github.com/AztecProtocol/l1-contracts.git#v5.0.1"
+"@aztec/l1-artifacts": "5.0.1"
 ```
+
+The package ships the L1 contract sources under `@aztec/l1-artifacts/l1-contracts/src`; update any `@aztec/*` Solidity remappings or aliases in the project to point at `node_modules/@aztec/l1-artifacts/l1-contracts/src`.
 
 :::
 
@@ -312,13 +314,13 @@ The portal is where the magic happens. It bridges Aztec's cross-chain messages w
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
-import {IRegistry} from "@aztec/l1-contracts/src/governance/interfaces/IRegistry.sol";
-import {IInbox} from "@aztec/l1-contracts/src/core/interfaces/messagebridge/IInbox.sol";
-import {IOutbox} from "@aztec/l1-contracts/src/core/interfaces/messagebridge/IOutbox.sol";
-import {IRollup} from "@aztec/l1-contracts/src/core/interfaces/IRollup.sol";
-import {DataStructures} from "@aztec/l1-contracts/src/core/libraries/DataStructures.sol";
-import {Hash} from "@aztec/l1-contracts/src/core/libraries/crypto/Hash.sol";
-import {Epoch} from "@aztec/l1-contracts/src/core/libraries/TimeLib.sol";
+import {IRegistry} from "@aztec/l1-artifacts/l1-contracts/src/governance/interfaces/IRegistry.sol";
+import {IInbox} from "@aztec/l1-artifacts/l1-contracts/src/core/interfaces/messagebridge/IInbox.sol";
+import {IOutbox} from "@aztec/l1-artifacts/l1-contracts/src/core/interfaces/messagebridge/IOutbox.sol";
+import {IRollup} from "@aztec/l1-artifacts/l1-contracts/src/core/interfaces/IRollup.sol";
+import {DataStructures} from "@aztec/l1-artifacts/l1-contracts/src/core/libraries/DataStructures.sol";
+import {Hash} from "@aztec/l1-artifacts/l1-contracts/src/core/libraries/crypto/Hash.sol";
+import {Epoch} from "@aztec/l1-artifacts/l1-contracts/src/core/libraries/TimeLib.sol";
 
 #include_code portal_setup /docs/examples/solidity/aave_bridge/AavePortal.sol raw
 }

--- a/docs/docs-developers/docs/tutorials/js_tutorials/aave_bridge.md
+++ b/docs/docs-developers/docs/tutorials/js_tutorials/aave_bridge.md
@@ -110,7 +110,7 @@ Start with the Hardhat + Aztec template. This provides a pre-configured Hardhat 
 
 This template is a community-maintained starter. If the repository is unavailable, you can set up a Hardhat project manually and add the `@aztec/*` Solidity remappings from the [cross-chain messaging docs](../../foundational-topics/ethereum-aztec-messaging/index.md).
 
-If the template still pins `@aztec/l1-contracts` as a git dependency, replace it in `package.json` with the `@aztec/l1-artifacts` npm package at the version matching your Aztec version, e.g.:
+You may need to replace the `@aztec/l1-contracts` dependency in `package.json` with the `@aztec/l1-artifacts` npm package at the version matching your Aztec version, e.g.:
 
 ```json
 "@aztec/l1-artifacts": "5.0.1"

--- a/docs/docs-developers/docs/tutorials/js_tutorials/token_bridge.md
+++ b/docs/docs-developers/docs/tutorials/js_tutorials/token_bridge.md
@@ -39,14 +39,14 @@ cd hardhat-aztec-example
 yarn add @aztec/aztec.js@#include_version_without_prefix @aztec/accounts@#include_version_without_prefix @aztec/stdlib@#include_version_without_prefix @aztec/wallets@#include_version_without_prefix @aztec/viem@2.38.2 tsx
 ```
 
-:::note Match the `@aztec/l1-contracts` version
-The starter repo pins its `@aztec/l1-contracts` dependency to an older release. In `package.json`, update the tag to match the network version used in this tutorial, then run `yarn install` again:
+:::note Use `@aztec/l1-artifacts` for the L1 interfaces
+The starter repo may still pin `@aztec/l1-contracts` as a git dependency; that repository is no longer updated. In `package.json`, replace it with the `@aztec/l1-artifacts` npm package at the version used in this tutorial, then run `yarn install` again:
 
 ```json
-"@aztec/l1-contracts": "git+https://github.com/AztecProtocol/l1-contracts.git##include_aztec_version"
+"@aztec/l1-artifacts": "#include_version_without_prefix"
 ```
 
-The L1 interfaces the portal imports later in this tutorial must match the contracts deployed by your running network.
+The package ships the L1 contract sources under `@aztec/l1-artifacts/l1-contracts/src`. If the project resolves `@aztec/*` Solidity imports through remappings or aliases, point them at `node_modules/@aztec/l1-artifacts/l1-contracts/src`. The interfaces the portal imports later in this tutorial must match the contracts deployed by your running network.
 :::
 
 Now start the local network in another terminal:

--- a/docs/docs-developers/docs/tutorials/testing_governance_rollup_upgrade.md
+++ b/docs/docs-developers/docs/tutorials/testing_governance_rollup_upgrade.md
@@ -50,40 +50,22 @@ Note the `registryAddress` from the output.
 
 ---
 
-## Step 2: Clone and Set Up l1-contracts
+## Step 2: Download the l1-contracts bundle
 
-Clone the l1-contracts repo and checkout the version matching your Aztec installation. Run `aztec --version` to find your version:
+The [`@aztec/l1-artifacts`](https://www.npmjs.com/package/@aztec/l1-artifacts) npm package bundles a self-contained Foundry project with the L1 contract sources, prebuilt artifacts, deploy scripts, and governance payload contracts. Download the version matching your Aztec installation (run `aztec --version` to find it):
 
 ```bash
-git clone https://github.com/AztecProtocol/l1-contracts.git
+npm pack @aztec/l1-artifacts@#release_version
+mkdir l1-contracts
+tar xzf aztec-l1-artifacts-#release_version.tgz --strip-components=2 -C l1-contracts package/l1-contracts
 cd l1-contracts
-git checkout #release_version
 ```
 
-Install dependencies and set up the build environment:
+No further setup is needed: the bundle includes the library dependencies and the generated verifier, and forge downloads the matching solc version automatically on first use.
 
-```bash
-# Install forge dependencies
-mkdir -p lib
-cd lib
-git clone --depth 1 https://github.com/foundry-rs/forge-std forge-std
-git clone --depth 1 https://github.com/OpenZeppelin/openzeppelin-contracts openzeppelin-contracts
-cd ..
-
-# Install solc (uses forge's built-in svm). The Aztec installer ships
-# Foundry as `aztec-forge`/`aztec-cast`/`aztec-anvil` -- substitute your
-# own `forge` install if you have one.
-aztec-forge build --use 0.8.30 src/core/libraries/ConstantsGen.sol
-cp ~/.svm/0.8.30/solc-0.8.30 ./solc-0.8.30
-
-# Copy the HonkVerifier to the generated directory (required for build)
-mkdir -p generated
-cp src/HonkVerifier.sol generated/HonkVerifier.sol
-
-# Remove zkpassport-dependent files (not needed for rollup deployment)
-rm -f src/mock/StakingAssetHandler.sol
-rm -rf src/mock/staking_asset_handler/
-```
+:::note
+The Aztec installer ships Foundry as `aztec-forge`, `aztec-cast`, and `aztec-anvil`. Substitute your own `forge` and `cast` installs in the commands below if you have them.
+:::
 
 ---
 

--- a/docs/docs-developers/docs/tutorials/testing_governance_rollup_upgrade.md
+++ b/docs/docs-developers/docs/tutorials/testing_governance_rollup_upgrade.md
@@ -101,8 +101,6 @@ export AZTEC_SLASHING_VETOER=0x0000000000000000000000000000000000000000
 export AZTEC_SLASHING_DISABLE_DURATION=0
 export AZTEC_MANA_TARGET=100000000
 export AZTEC_EXIT_DELAY_SECONDS=0
-# Must match the running network and stay above the protocol floor; 0 reverts
-# the deployment with FeeLib__ProvingCostBelowFloor.
 export AZTEC_PROVING_COST_PER_MANA=100
 export AZTEC_SLASH_AMOUNT_SMALL=0
 export AZTEC_SLASH_AMOUNT_MEDIUM=0

--- a/docs/docs-developers/docs/tutorials/testing_governance_rollup_upgrade.md
+++ b/docs/docs-developers/docs/tutorials/testing_governance_rollup_upgrade.md
@@ -101,7 +101,9 @@ export AZTEC_SLASHING_VETOER=0x0000000000000000000000000000000000000000
 export AZTEC_SLASHING_DISABLE_DURATION=0
 export AZTEC_MANA_TARGET=100000000
 export AZTEC_EXIT_DELAY_SECONDS=0
-export AZTEC_PROVING_COST_PER_MANA=0
+# Must match the running network and stay above the protocol floor; 0 reverts
+# the deployment with FeeLib__ProvingCostBelowFloor.
+export AZTEC_PROVING_COST_PER_MANA=100
 export AZTEC_SLASH_AMOUNT_SMALL=0
 export AZTEC_SLASH_AMOUNT_MEDIUM=0
 export AZTEC_SLASH_AMOUNT_LARGE=0
@@ -128,6 +130,10 @@ export NEW_ROLLUP_ADDRESS=0x...
 ---
 
 ## Step 5: Deploy Governance Payload
+
+:::tip
+The deploy script in Step 4 also deploys this payload and prints it as `payloadAddress` in its JSON output. You can export that address as `PAYLOAD_ADDRESS` and skip this step.
+:::
 
 **Important:** Place flags before the contract path to avoid argument parsing issues.
 

--- a/docs/docs-developers/docs/tutorials/testing_governance_rollup_upgrade.md
+++ b/docs/docs-developers/docs/tutorials/testing_governance_rollup_upgrade.md
@@ -138,7 +138,7 @@ aztec-forge create \
   --rpc-url $L1_RPC_URL \
   --private-key $PRIVATE_KEY \
   --broadcast \
-  test/governance/scenario/RegisterNewRollupVersionPayload.sol:RegisterNewRollupVersionPayload \
+  src/periphery/RegisterNewRollupVersionPayload.sol:RegisterNewRollupVersionPayload \
   --constructor-args $REGISTRY_ADDRESS $NEW_ROLLUP_ADDRESS
 ```
 

--- a/l1-contracts/bootstrap.sh
+++ b/l1-contracts/bootstrap.sh
@@ -282,79 +282,6 @@ function validator_costs {
   python3 scripts/process_gas_reports.py no_validators.json 100_validators.json 100_validators_slashing.json
 }
 
-# First argument is a branch name (e.g. master, or the latest version e.g. 1.2.3) to push to the head of.
-# Second argument is the tag name (e.g. v1.2.3, or commit-<hash>).
-# Third argument is the semver for package.json (e.g. 1.2.3 or 1.2.3-commit.<hash>)
-#
-#   v1.2.3    commit-123cafebabe
-#      |     /
-#   v1.2.2  commit-123deadbeef
-#      |   /
-#   v1.2.1
-#
-function release_git_push {
-  local branch_name=$1
-  local tag_name=$2
-  local version=$3
-  local mirrored_repo_url="https://github.com/AztecProtocol/l1-contracts.git"
-
-  # Clean up our release directory.
-  rm -rf release-out && mkdir release-out
-
-  # Copy our git files to our release directory.
-  git archive HEAD | tar -x -C release-out
-
-  # Copy from noir-projects. Bootstrap must have ran in noir-projects.
-  cp ../noir-projects/noir-protocol-circuits/target/keys/rollup_root_verifier.sol release-out/src/HonkVerifier.sol
-
-  # Push the release from the clean export of HEAD, in a subshell so the caller's working directory
-  # is preserved. Later release steps (e.g. release_l1_artifacts_npm) rely on the gitignored build
-  # outputs that live in the working tree, outside this git-archive copy.
-  (
-    cd release-out
-
-    # Update the package version in package.json.
-    # TODO remove package.json.
-    release_prep_package_json $version
-
-    # CI needs to authenticate from GITHUB_TOKEN.
-    gh auth setup-git &>/dev/null || true
-
-    git init &>/dev/null
-    git remote add origin "$mirrored_repo_url" &>/dev/null
-    git fetch origin --quiet
-
-    # Checkout the existing branch or create it if it doesn't exist.
-    if git ls-remote --heads origin "$branch_name" | grep -q "$branch_name"; then
-      # Update branch reference without checkout.
-      git branch -f "$branch_name" origin/"$branch_name"
-      # Point HEAD to the branch.
-      git symbolic-ref HEAD refs/heads/"$branch_name"
-      # Move to latest commit, keep working tree.
-      git reset --soft origin/"$branch_name"
-    else
-      git checkout -b "$branch_name"
-    fi
-
-    if git rev-parse "$tag_name" >/dev/null 2>&1; then
-      echo "Tag $tag_name already exists. Skipping release."
-    else
-      git add .
-      git commit -m "Release $tag_name." >/dev/null
-      git tag -a "$tag_name" -m "Release $tag_name."
-      do_or_dryrun git push origin "$branch_name" --quiet
-      do_or_dryrun git push origin --quiet --force "$tag_name" --tags
-
-      echo "Release complete ($tag_name) on branch $branch_name."
-    fi
-
-    do_or_dryrun git push origin "$branch_name" --quiet
-    do_or_dryrun git push origin --quiet --force "$tag_name" --tags
-
-    echo "Release complete ($tag_name) on branch $branch_name."
-  )
-}
-
 function coverage {
   echo_header "l1-contracts coverage"
   forge --version
@@ -507,8 +434,8 @@ function coverage_serve {
 # by the runtime forge deploy path). yarn-project consumes this via portal in-repo and via the
 # published version downstream, so it must publish before yarn-project's release (whose smoke test
 # installs packages that depend on @aztec/l1-artifacts@<version>).
-function release_l1_artifacts_npm {
-  echo_header "l1-contracts release l1-artifacts npm"
+function release {
+  echo_header "l1-contracts release"
   local version=${REF_NAME#v}
 
   # dest/ and the bundled foundry subtree are gitignored build outputs left in the working tree by
@@ -527,17 +454,6 @@ function release_l1_artifacts_npm {
   sed -i 's|^solc = "\./solc-\(.*\)"|solc_version = "\1"|' "$bundle/foundry.toml"
 
   (cd l1-artifacts && retry "deploy_npm $version")
-}
-
-function release {
-  echo_header "l1-contracts release"
-  local branch=$(dist_tag)
-  if [ $branch = latest ]; then
-    branch=master
-  fi
-
-  release_git_push $branch $REF_NAME ${REF_NAME#v}
-  release_l1_artifacts_npm
 }
 
 case "$cmd" in

--- a/l1-contracts/l1-artifacts/package.json
+++ b/l1-contracts/l1-artifacts/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "exports": {
     "./network-defaults.json": "./l1-contracts/scripts/network-defaults.json",
+    "./l1-contracts/*": "./l1-contracts/*",
     "./*": "./dest/*.js",
     ".": "./dest/index.js"
   },

--- a/l1-contracts/l1-artifacts/scripts/copy-foundry-artifacts.sh
+++ b/l1-contracts/l1-artifacts/scripts/copy-foundry-artifacts.sh
@@ -23,11 +23,10 @@ cp -rp "$src/script/deploy" "l1-contracts/script/"  # only deploy/, other script
 mkdir -p "l1-contracts/test/script"
 cp -p "$src/test/shouting.t.sol" "l1-contracts/test/"
 cp -p "$src"/test/script/*.sol "l1-contracts/test/script/"
-# Governance payload contracts that the rollup-upgrade docs tutorial deploys from the published
-# bundle (docs/docs-developers/docs/tutorials/testing_governance_rollup_upgrade.md). They compile
-# against src/ interfaces only.
-mkdir -p "l1-contracts/test/governance/scenario" "l1-contracts/test/governance/governance"
-cp -p "$src/test/governance/scenario/RegisterNewRollupVersionPayload.sol" "l1-contracts/test/governance/scenario/"
+# EmptyPayload for the rollup-upgrade docs tutorial's quick-test path
+# (docs/docs-developers/docs/tutorials/testing_governance_rollup_upgrade.md); the tutorial's main
+# payload, RegisterNewRollupVersionPayload, ships with src/periphery. Compiles against src/ only.
+mkdir -p "l1-contracts/test/governance/governance"
 cp -p "$src/test/governance/governance/TestPayloads.sol" "l1-contracts/test/governance/governance/"
 cp -p "$src"/{foundry.toml,foundry.lock,package.json,solc-*} "l1-contracts/"
 # Copy the forge broadcast wrapper (now a plain .js source file) and the network defaults

--- a/l1-contracts/l1-artifacts/scripts/copy-foundry-artifacts.sh
+++ b/l1-contracts/l1-artifacts/scripts/copy-foundry-artifacts.sh
@@ -23,6 +23,12 @@ cp -rp "$src/script/deploy" "l1-contracts/script/"  # only deploy/, other script
 mkdir -p "l1-contracts/test/script"
 cp -p "$src/test/shouting.t.sol" "l1-contracts/test/"
 cp -p "$src"/test/script/*.sol "l1-contracts/test/script/"
+# Governance payload contracts that the rollup-upgrade docs tutorial deploys from the published
+# bundle (docs/docs-developers/docs/tutorials/testing_governance_rollup_upgrade.md). They compile
+# against src/ interfaces only.
+mkdir -p "l1-contracts/test/governance/scenario" "l1-contracts/test/governance/governance"
+cp -p "$src/test/governance/scenario/RegisterNewRollupVersionPayload.sol" "l1-contracts/test/governance/scenario/"
+cp -p "$src/test/governance/governance/TestPayloads.sol" "l1-contracts/test/governance/governance/"
 cp -p "$src"/{foundry.toml,foundry.lock,package.json,solc-*} "l1-contracts/"
 # Copy the forge broadcast wrapper (now a plain .js source file) and the network defaults
 # (read at deploy time via foundry fs_permissions / vm.readFile).


### PR DESCRIPTION
Stop pushing release tags to the AztecProtocol/l1-contracts mirror; the @aztec/l1-artifacts npm package is the supported distribution channel.

The public and private release flows now share the same l1-contracts release entrypoint (the npm publish).

To cover the mirror's remaining consumers:
- expose the bundled foundry subtree via package exports
- ship the governance payload contracts the rollup-upgrade tutorial deploys (RegisterNewRollupVersionPayload, TestPayloads)
- point the tutorials at @aztec/l1-artifacts instead of the mirror
