### PR TITLE
chore(bench): retire github-action-benchmark for network benchmarks

### DIFF
--- a/.github/workflows/nightly-spartan-bench.yml
+++ b/.github/workflows/nightly-spartan-bench.yml
@@ -88,185 +88,6 @@ jobs:
         run: spartan/scripts/wait_for_ci3.ts "${{ needs.select-image.outputs.source_ref }}"
 
   # ---------------------------------------------------------------------------
-  # TPS benchmark (env tps-scenario, namespace nightly-bench)
-  # ---------------------------------------------------------------------------
-  deploy-bench-network:
-    needs: [select-image, wait-for-ci3]
-    if: ${{ github.repository == 'AztecProtocol/aztec-packages' }}
-    uses: ./.github/workflows/deploy-network.yml
-    with:
-      network: tps-scenario
-      namespace: nightly-bench
-      semver: ${{ needs.select-image.outputs.nightly_tag }}
-      ref: ${{ needs.select-image.outputs.source_ref }}
-      use_internal_docker_registry: ${{ needs.select-image.outputs.use_internal_docker_registry == 'true' }}
-      skip_notify_on_failure: true
-    secrets: inherit
-
-  wait-bench-l2-block:
-    needs:
-      - select-image
-      - deploy-bench-network
-    if: ${{ github.repository == 'AztecProtocol/aztec-packages' }}
-    runs-on: ubuntu-latest
-    timeout-minutes: 120
-    steps:
-      - name: Checkout
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
-        with:
-          ref: ${{ needs.select-image.outputs.source_ref }}
-
-      - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
-        with:
-          credentials_json: ${{ secrets.GCP_SA_KEY }}
-
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
-        with:
-          install_components: gke-gcloud-auth-plugin
-
-      - name: Wait for first L2 block
-        env:
-          GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
-          NAMESPACE: nightly-bench
-        run: |
-          cd spartan
-          ./bootstrap.sh wait_for_l2_block tps-scenario
-
-  benchmark:
-    needs:
-      - select-image
-      - wait-bench-l2-block
-    if: ${{ github.repository == 'AztecProtocol/aztec-packages' }}
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - name: Checkout
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
-        with:
-          ref: ${{ needs.select-image.outputs.source_ref }}
-
-      - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
-          aws-region: us-east-2
-
-      - name: Run benchmarks
-        timeout-minutes: 240
-        env:
-          GITHUB_TOKEN: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
-          BUILD_INSTANCE_SSH_KEY: ${{ secrets.BUILD_INSTANCE_SSH_KEY }}
-          GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
-          GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-          RUN_ID: ${{ github.run_id }}
-          AWS_SHUTDOWN_TIME: 240
-          NO_SPOT: 1
-          SKIP_NETWORK_DEPLOY: "1"
-        run: |
-          # Pass the arguments expected in ./bootstrap.sh ci-network-bench
-          ./.github/ci3.sh network-bench tps-scenario nightly-bench "${{ needs.select-image.outputs.docker_image }}"
-
-      - name: Download benchmarks
-        if: always()
-        run: |
-          if ./ci.sh gh-spartan-bench; then
-            echo "ENABLE_DEPLOY_BENCH=1" >> "$GITHUB_ENV"
-          fi
-
-      - name: Upload benchmarks
-        if: always() && env.ENABLE_DEPLOY_BENCH == '1'
-        uses: benchmark-action/github-action-benchmark@52576c92bccf6ac60c8223ec7eb2565637cae9ba # v1.22.1
-        with:
-          name: Spartan
-          benchmark-data-dir-path: "bench/next"
-          tool: "customSmallerIsBetter"
-          output-file-path: ./bench-out/bench.json
-          gh-repository: github.com/AztecProtocol/benchmark-page-data
-          github-token: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
-          auto-push: true
-          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
-          alert-threshold: "120%"
-          comment-on-alert: false
-          fail-on-alert: false
-          max-items-in-chart: 100
-
-  cleanup-bench:
-    if: ${{ always() && github.repository == 'AztecProtocol/aztec-packages' }}
-    needs:
-      - select-image
-      - deploy-bench-network
-      - wait-bench-l2-block
-      - benchmark
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - name: Checkout
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
-        with:
-          ref: ${{ needs.select-image.outputs.source_ref }}
-
-      - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
-          aws-region: us-east-2
-
-      - name: Cleanup network resources
-        uses: ./.github/actions/network-teardown
-        with:
-          env_file: tps-scenario
-          namespace: nightly-bench
-          gcp_sa_key: ${{ secrets.GCP_SA_KEY }}
-          gcp_project_id: ${{ secrets.GCP_PROJECT_ID }}
-
-  notify-bench:
-    if: ${{ always() && github.event_name != 'workflow_dispatch' && github.repository == 'AztecProtocol/aztec-packages' }}
-    needs:
-      - select-image
-      - deploy-bench-network
-      - wait-bench-l2-block
-      - benchmark
-      - cleanup-bench
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
-        with:
-          ref: ${{ needs.select-image.outputs.source_ref }}
-
-      - name: Notify Slack on success
-        if: ${{ needs.benchmark.result == 'success' }}
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-        run: |
-          export CI=1
-          TAG="${{ needs.select-image.outputs.nightly_tag || 'unknown' }}"
-          RUN_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          ./ci3/slack_notify \
-            "Nightly Spartan TPS benchmarks PASSED (nightly tag ${TAG}) :white_check_mark: <${RUN_URL}|View Run>" \
-            "#alerts-next-scenario"
-
-      - name: Notify Slack and dispatch ClaudeBox on failure
-        if: ${{ needs.benchmark.result != 'success' }}
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
-        run: |
-          TAG="${{ needs.select-image.outputs.nightly_tag || 'unknown' }}"
-          RUN_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          ./ci3/slack_notify_with_claudebox_kickoff "#alerts-next-scenario" \
-            "Nightly Spartan Benchmarks FAILED (nightly tag ${TAG}): <${RUN_URL}|View Run> (🤖)" \
-            "Nightly Spartan benchmarks failed (nightly tag ${TAG}). CI run: ${RUN_URL}. Investigate the benchmark failure and identify the root cause." \
-            --link "$RUN_URL"
-
-  # ---------------------------------------------------------------------------
   # Proving benchmark (env prove-n-tps-fake, namespace prove-n-tps-fake)
   # ---------------------------------------------------------------------------
   deploy-proving-network:
@@ -348,30 +169,6 @@ jobs:
           SKIP_NETWORK_DEPLOY: "1"
         run: |
           ./.github/ci3.sh network-proving-bench prove-n-tps-fake prove-n-tps-fake "${{ needs.select-image.outputs.docker_image }}"
-
-      - name: Download benchmarks
-        if: always()
-        run: |
-          if ./ci.sh gh-spartan-proving-bench; then
-            echo "ENABLE_DEPLOY_BENCH=1" >> "$GITHUB_ENV"
-          fi
-
-      - name: Upload benchmarks
-        if: always() && env.ENABLE_DEPLOY_BENCH == '1'
-        uses: benchmark-action/github-action-benchmark@52576c92bccf6ac60c8223ec7eb2565637cae9ba # v1.22.1
-        with:
-          name: Spartan
-          benchmark-data-dir-path: "bench/next"
-          tool: "customSmallerIsBetter"
-          output-file-path: ./bench-out/bench.json
-          github-token: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
-          gh-repository: github.com/AztecProtocol/benchmark-page-data
-          auto-push: true
-          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
-          alert-threshold: "120%"
-          comment-on-alert: false
-          fail-on-alert: false
-          max-items-in-chart: 100
 
   cleanup-proving:
     if: ${{ always() && github.repository == 'AztecProtocol/aztec-packages' }}
@@ -527,30 +324,6 @@ jobs:
         run: |
           ./.github/ci3.sh network-block-capacity-bench block-capacity nightly-block-capacity "${{ needs.select-image.outputs.docker_image }}"
 
-      - name: Download benchmarks
-        if: always()
-        run: |
-          if ./ci.sh gh-spartan-block-capacity-bench; then
-            echo "ENABLE_DEPLOY_BENCH=1" >> "$GITHUB_ENV"
-          fi
-
-      - name: Upload benchmarks
-        if: always() && env.ENABLE_DEPLOY_BENCH == '1'
-        uses: benchmark-action/github-action-benchmark@52576c92bccf6ac60c8223ec7eb2565637cae9ba # v1.22.1
-        with:
-          name: Spartan
-          benchmark-data-dir-path: "bench/next"
-          tool: "customSmallerIsBetter"
-          output-file-path: ./bench-out/bench.json
-          gh-repository: github.com/AztecProtocol/benchmark-page-data
-          github-token: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
-          auto-push: true
-          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
-          alert-threshold: "120%"
-          comment-on-alert: false
-          fail-on-alert: false
-          max-items-in-chart: 100
-
   cleanup-block-capacity:
     if: ${{ always() && github.repository == 'AztecProtocol/aztec-packages' }}
     needs:
@@ -624,14 +397,13 @@ jobs:
 
   status:
     runs-on: ubuntu-latest
-    needs: [benchmark, proving-benchmark, block-capacity-benchmark]
+    needs: [proving-benchmark, block-capacity-benchmark]
     if: ${{ always() && github.repository == 'AztecProtocol/aztec-packages' }}
     steps:
       - name: Check benchmark results
         run: |
-          if [[ "${{ needs.benchmark.result }}" != "success" || "${{ needs.proving-benchmark.result }}" != "success" || "${{ needs.block-capacity-benchmark.result }}" != "success" ]]; then
+          if [[ "${{ needs.proving-benchmark.result }}" != "success" || "${{ needs.block-capacity-benchmark.result }}" != "success" ]]; then
             echo "One or more benchmark jobs failed"
-            echo "benchmark: ${{ needs.benchmark.result }}"
             echo "proving-benchmark: ${{ needs.proving-benchmark.result }}"
             echo "block-capacity-benchmark: ${{ needs.block-capacity-benchmark.result }}"
             exit 1

--- a/.github/workflows/weekly-proving-bench.yml
+++ b/.github/workflows/weekly-proving-bench.yml
@@ -136,33 +136,6 @@ jobs:
         run: |
           ./.github/ci3.sh network-proving-bench prove-n-tps-real prove-n-tps-real
 
-      - name: Download benchmarks
-        if: always()
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        run: |
-          if ./ci.sh gh-spartan-proving-bench; then
-            echo "ENABLE_DEPLOY_BENCH=1" >> "$GITHUB_ENV"
-          fi
-
-      - name: Upload benchmarks
-        if: always() && env.ENABLE_DEPLOY_BENCH == '1'
-        uses: benchmark-action/github-action-benchmark@52576c92bccf6ac60c8223ec7eb2565637cae9ba # v1.22.1
-        with:
-          name: Spartan
-          benchmark-data-dir-path: "bench/next"
-          tool: "customSmallerIsBetter"
-          output-file-path: ./bench-out/bench.json
-          github-token: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
-          gh-repository: github.com/AztecProtocol/benchmark-page-data
-          auto-push: true
-          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
-          alert-threshold: "120%"
-          comment-on-alert: false
-          fail-on-alert: false
-          max-items-in-chart: 100
-
   cleanup:
     if: ${{ always() && github.repository == 'AztecProtocol/aztec-packages' }}
     needs:


### PR DESCRIPTION
A-1230. Makes the custom `network-dashboard` pipeline the single source of truth for the nightly/weekly network benchmarks and removes the duplicate github-action-benchmark publishing path.

## Changes

- **`nightly-spartan-bench.yml`** — remove the legacy **tps-scenario** benchmark leg entirely (`deploy-bench-network` / `wait-bench-l2-block` / `benchmark` / `cleanup-bench` / `notify-bench`). It published *only* to github-action-benchmark and is superseded by the inclusion sweep (`nightly-bench-inclusion-sweep.yml`). The `status` job no longer gates on it.
- **`nightly-spartan-bench.yml`** — remove the github-action-benchmark upload from the **proving** and **block-capacity** jobs (they now publish to the custom pipeline).
- **`weekly-proving-bench.yml`** — remove the github-action-benchmark upload (real proving now publishes to the custom pipeline).

Net: **zero `github-action-benchmark` references** remain in either workflow (232 lines removed from nightly, 27 from weekly).

## Deliberately left in place

- The on-demand **PR-triggered `ci-network-bench` job** (`ci3.yml`, opt-in `ci-network-bench` label) and its `network-bench` / `gh-spartan-bench` plumbing — a developer tool, not the nightly dashboard.
- The **e2e microbenchmark** suite (`gh-bench` / `gh-deploy-bench`, `yarn-project/end-to-end/src/bench/*`) — a separate benchmark system.

## Merge order (important)

Depends on and **must merge after** the custom-pipeline PRs so nothing goes dark mid-migration:
- #24913 (block capacity → custom pipeline)
- #24914 (real proving → custom pipeline)
- plus the inclusion sweep, already live.

Both custom-pipeline paths also need helm-sa `roles/logging.viewer` applied for populated data. Recommend confirming a nightly + weekly actually upload to the dashboard before merging this.