### PR TITLE
fix(aztec-nr): restrict raw note-enqueue sink to pub(crate)

### DIFF
--- a/noir-projects/labs/aztec-nr/aztec/src/messages/processing/mod.nr
+++ b/noir-projects/labs/aztec-nr/aztec/src/messages/processing/mod.nr
@@ -4,7 +4,7 @@ pub mod offchain;
 pub use crate::oracle::tx_resolution::ResolvedTx;
 
 mod note_validation_request;
-pub use note_validation_request::NoteValidationRequest;
+pub(crate) use note_validation_request::NoteValidationRequest;
 
 pub mod log_retrieval_request;
 pub mod log_retrieval_response;
@@ -51,6 +51,12 @@ pub struct OffchainMessageWithTx {
 
 /// Enqueues a note for validation and storage by PXE.
 ///
+/// The caller must guarantee that every enqueued note's unique hash is actually included in
+/// `tx_hash`'s effects; enqueuing one that is absent bricks sync for that contract. The built-in discovery paths
+/// guarantee this by running nonce discovery first (see
+/// [`process_private_note_msg`](crate::messages::discovery::private_notes)), which is why this is not exposed to
+/// contracts.
+///
 /// Once validated, the note becomes retrievable via the `get_notes` oracle. The note will be scoped to
 /// `contract_address`, meaning other contracts will not be able to access it unless authorized.
 ///
@@ -71,7 +77,7 @@ pub struct OffchainMessageWithTx {
 /// This determines which PXE account can see the note - other accounts will not be able to access it (e.g. other
 /// accounts will not be able to see one another's token balance notes, even in the same PXE) unless authorized. In
 /// most cases `recipient` equals `owner`, but they can differ in scenarios like delegated discovery.
-pub unconstrained fn enqueue_note_for_validation(
+pub(crate) unconstrained fn enqueue_note_for_validation(
     contract_address: AztecAddress,
     owner: AztecAddress,
     storage_slot: Field,

--- a/noir-projects/labs/aztec-nr/aztec/src/messages/processing/note_validation_request.nr
+++ b/noir-projects/labs/aztec-nr/aztec/src/messages/processing/note_validation_request.nr
@@ -5,7 +5,7 @@ use crate::protocol::{address::AztecAddress, traits::{Deserialize, Serialize}};
 /// `aztec_utl_validateAndStoreEnqueuedNotesAndEvents` oracle expects for values of this type to be stored in a
 /// `EphemeralArray`.
 #[derive(Serialize, Deserialize)]
-pub struct NoteValidationRequest {
+pub(crate) struct NoteValidationRequest {
     contract_address: AztecAddress,
     owner: AztecAddress,
     storage_slot: Field,
@@ -19,7 +19,7 @@ pub struct NoteValidationRequest {
 }
 
 impl NoteValidationRequest {
-    pub fn new(
+    pub(crate) fn new(
         contract_address: AztecAddress,
         owner: AztecAddress,
         storage_slot: Field,


### PR DESCRIPTION
Fixes [F-832 ](https://linear.app/aztec-labs/issue/F-832/aztec-packages-aztec-nr-custom-message-handler-can-enqueue-an)

Reduce `enqueue_note_for_validation` and `NoteValidationRequest` from `pub` to `pub(crate)`. These are only ever called by aztec-nr's own discovery paths, which run nonce discovery before enqueuing so every enqueued note's unique hash is guaranteed present in the tx effects.

Addresses F-832 as API hygiene rather than a security boundary. Two distinct threat models:

1. F-832's actual threat: malicious sender vs honest contract. The honest author uses documented, pub APIs in good faith. A pub raw sink that looks like "the way to deliver a note from a handler" invites them to wire it up, and then any sender could brick others. Removing it from the pub surface means an honest author can't build the vulnerable pattern.
2. Malicious/broken contract author. Unpreventable: they can recompute the slot, push directly, or just panic in a handler. aztec-nr can't and does not need to stop this. The only people harmed are users who chose to run that bad contract, and the blast radius is that one contract's scope.

Maybe we do not even deem this `pub(crate)` restriction worth it as I do not think custom message handlers have high demand at this point. But it felt easy enough to restrict the API here. If they ever do have large demand perhaps we should think through our APIs a bit further as to help custom message handlers avoid foot-guns. Once custom handlers become more heavily used we could consider APIs that at least push devs towards inclusion being checked or provide boilerplate for safe custom handlers