### PR TITLE
feat(prover-node): tear down checkpoint sub-tree once block proofs are ready (A-1213)

### DIFF
--- a/yarn-project/prover-node/src/job/checkpoint-prover.test.ts
+++ b/yarn-project/prover-node/src/job/checkpoint-prover.test.ts
@@ -5,6 +5,7 @@ import { Fr } from '@aztec/foundation/curves/bn254';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { type Logger, createLogger } from '@aztec/foundation/log';
 import { promiseWithResolvers } from '@aztec/foundation/promise';
+import { sleep } from '@aztec/foundation/sleep';
 import { DateProvider } from '@aztec/foundation/timer';
 import type { EpochProverFactory } from '@aztec/prover-client';
 import type { ChonkCache, SubTreeResult } from '@aztec/prover-client/orchestrator';
@@ -339,6 +340,75 @@ describe('CheckpointProver', () => {
       prover.cancel({ routine: true });
       await prover.whenDone();
       expect(stop).toHaveBeenCalledTimes(1);
+    });
+
+    it('whenDone() stays pending until the sub-tree result lands and teardown completes', async () => {
+      // Decouple the sub-tree result from the block-completion loop: the execute loop finishes
+      // enqueueing block-level proving (so runPromise resolves) while the sub-tree's proofs — and the
+      // success-driven teardown they trigger — are still outstanding. whenDone() must not report
+      // completion during that window, or a caller (reap/shutdown) would consider the prover unwound
+      // while its sub-tree is still proving and holding memory.
+      checkpoint = await Checkpoint.random(CheckpointNumber(1), { numBlocks: 2, txsPerBlock: 0 });
+
+      txProvider.getTxsForBlock.mockReset();
+      txProvider.getTxsForBlock.mockResolvedValue({ txs: [], missingTxs: [] });
+
+      const blockProofOutputs = [{ tag: 'block-proof-output' }] as unknown as SubTreeResult['blockProofOutputs'];
+      const resultGate = promiseWithResolvers<SubTreeResult>();
+      const lastBlockNumber = checkpoint.blocks[checkpoint.blocks.length - 1].number;
+      const lastBlockCompleted = promiseWithResolvers<void>();
+      const stop = jest.fn(() => Promise.resolve());
+
+      const subTree = {
+        getSubTreeResult: () => resultGate.promise,
+        startNewBlock: () => Promise.resolve(),
+        startChonkVerifierCircuits: () => Promise.resolve(),
+        addTxs: () => Promise.resolve(),
+        // Signal when the final block finishes enqueueing, but leave the sub-tree result pending so
+        // proofs (and teardown) stay outstanding until the test resolves the gate explicitly.
+        setBlockCompleted: (blockNumber: number) => {
+          if (blockNumber === lastBlockNumber) {
+            lastBlockCompleted.resolve();
+          }
+          return Promise.resolve();
+        },
+        cancel: () => {},
+        stop,
+      };
+      proverFactory.createCheckpointSubTreeOrchestrator.mockResolvedValue(subTree as any);
+      dbProvider.fork.mockResolvedValue({
+        appendLeaves: () => Promise.resolve(),
+        close: () => Promise.resolve(),
+      } as any);
+      publicProcessorFactory.create.mockReturnValue({ process: () => Promise.resolve([[], []]) } as any);
+
+      const prover = makeProver();
+
+      // Block-level proving is now fully enqueued (runPromise about to resolve) with proofs still pending.
+      await lastBlockCompleted.promise;
+
+      let settled = false;
+      const donePromise = prover.whenDone().then(() => {
+        settled = true;
+      });
+
+      // whenDone() must remain pending: enqueueing is done, but proofs and teardown are not. The gate is
+      // still closed, so this cannot flake true early — with the bug, whenDone() resolves off runPromise.
+      await sleep(50);
+      expect(settled).toBe(false);
+      expect(stop).not.toHaveBeenCalled();
+
+      // The proofs land: block proofs resolve, the sub-tree is torn down, and only now does whenDone().
+      resultGate.resolve({
+        blockProofOutputs,
+        previousArchiveSiblingPath: makeTuple(ARCHIVE_HEIGHT, () => Fr.ZERO),
+      });
+      await donePromise;
+
+      expect(settled).toBe(true);
+      expect(stop).toHaveBeenCalledTimes(1);
+      expect(prover.isFailed()).toBe(false);
+      expect(onFailed).not.toHaveBeenCalled();
     });
   });
 

--- a/yarn-project/prover-node/src/job/checkpoint-prover.test.ts
+++ b/yarn-project/prover-node/src/job/checkpoint-prover.test.ts
@@ -7,7 +7,7 @@ import { type Logger, createLogger } from '@aztec/foundation/log';
 import { promiseWithResolvers } from '@aztec/foundation/promise';
 import { DateProvider } from '@aztec/foundation/timer';
 import type { EpochProverFactory } from '@aztec/prover-client';
-import type { ChonkCache } from '@aztec/prover-client/orchestrator';
+import type { ChonkCache, SubTreeResult } from '@aztec/prover-client/orchestrator';
 import type { PublicProcessorFactory } from '@aztec/simulator/server';
 import { Checkpoint } from '@aztec/stdlib/checkpoint';
 import type { ForkMerkleTreeOperations, ITxProvider } from '@aztec/stdlib/interfaces/server';
@@ -279,6 +279,66 @@ describe('CheckpointProver', () => {
       prover.cancel();
       expect(prover.isCancelled()).toBe(true);
       await prover.whenDone();
+    });
+  });
+
+  // ---------------- teardown on completion ----------------
+
+  describe('teardown on completion', () => {
+    it('releases the sub-tree once block proofs are ready, still returning the outputs', async () => {
+      // Empty-tx blocks let the execute loop complete without real public processing. The sub-tree
+      // result is gated on the final block completing, so resolution happens after the loop's work.
+      checkpoint = await Checkpoint.random(CheckpointNumber(1), { numBlocks: 2, txsPerBlock: 0 });
+
+      txProvider.getTxsForBlock.mockReset();
+      txProvider.getTxsForBlock.mockResolvedValue({ txs: [], missingTxs: [] });
+
+      const blockProofOutputs = [{ tag: 'block-proof-output' }] as unknown as SubTreeResult['blockProofOutputs'];
+      const resultGate = promiseWithResolvers<SubTreeResult>();
+      const lastBlockNumber = checkpoint.blocks[checkpoint.blocks.length - 1].number;
+      const stop = jest.fn(() => Promise.resolve());
+
+      const subTree = {
+        getSubTreeResult: () => resultGate.promise,
+        startNewBlock: () => Promise.resolve(),
+        startChonkVerifierCircuits: () => Promise.resolve(),
+        addTxs: () => Promise.resolve(),
+        // Resolve the sub-tree result only after the final block finishes, mirroring production
+        // where proofs land after every block has been added.
+        setBlockCompleted: (blockNumber: number) => {
+          if (blockNumber === lastBlockNumber) {
+            resultGate.resolve({
+              blockProofOutputs,
+              previousArchiveSiblingPath: makeTuple(ARCHIVE_HEIGHT, () => Fr.ZERO),
+            });
+          }
+          return Promise.resolve();
+        },
+        cancel: () => {},
+        stop,
+      };
+      proverFactory.createCheckpointSubTreeOrchestrator.mockResolvedValue(subTree as any);
+      dbProvider.fork.mockResolvedValue({
+        appendLeaves: () => Promise.resolve(),
+        close: () => Promise.resolve(),
+      } as any);
+      publicProcessorFactory.create.mockReturnValue({ process: () => Promise.resolve([[], []]) } as any);
+
+      const prover = makeProver();
+
+      // The block-proof outputs survive teardown via the resolved promise.
+      await expect(prover.whenBlockProofsReady()).resolves.toBe(blockProofOutputs);
+      await prover.whenDone();
+
+      // The sub-tree orchestrator was released exactly once, and completion is not a failure.
+      expect(stop).toHaveBeenCalledTimes(1);
+      expect(prover.isFailed()).toBe(false);
+      expect(onFailed).not.toHaveBeenCalled();
+
+      // A subsequent reap cancel is a no-op on the already-released sub-tree (stop not called again).
+      prover.cancel({ routine: true });
+      await prover.whenDone();
+      expect(stop).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/yarn-project/prover-node/src/job/checkpoint-prover.ts
+++ b/yarn-project/prover-node/src/job/checkpoint-prover.ts
@@ -123,6 +123,8 @@ export class CheckpointProver {
   private readonly runPromise: Promise<void>;
   /** Tracks the cancel-driven teardown so `whenDone()` can await it. */
   private cancelPromise?: Promise<void>;
+  /** Tracks the success-driven sub-tree teardown (once block proofs are captured) so `whenDone()` can await it. */
+  private teardownPromise?: Promise<void>;
 
   constructor(
     args: CheckpointProverArgs,
@@ -189,6 +191,9 @@ export class CheckpointProver {
     await this.runPromise.catch(() => {});
     if (this.cancelPromise) {
       await this.cancelPromise;
+    }
+    if (this.teardownPromise) {
+      await this.teardownPromise;
     }
   }
 
@@ -301,6 +306,14 @@ export class CheckpointProver {
           // Spans processing + proving (from executeCheckpoint start, after tx gathering) to proofs ready.
           this.deps.metrics.recordCheckpointProving(checkpointTimer.ms());
           this.blockProofs.resolve(result.blockProofOutputs);
+          // Release the sub-tree orchestrator now that its output is captured. The block-proof outputs
+          // survive via the resolved promise; everything else the sub-tree held — per-tx AVM inputs, and
+          // the base/merge/parity proof trees — is dead once proving completes, yet the prover is retained
+          // for the whole proof-submission window. Dropping it here is what stops that retention from
+          // accumulating across every proven checkpoint. Post-completion consumers (the top-tree job, a
+          // rebuilt EpochSession, failure upload) read only `whenBlockProofsReady()` and this prover's own
+          // fields (`checkpoint`, `txs`, headers, sibling paths), never the sub-tree.
+          this.teardownPromise = this.teardownSubTree();
         },
         err => this.failBlockProofs(err instanceof Error ? err : new Error(String(err))),
       );

--- a/yarn-project/prover-node/src/job/checkpoint-prover.ts
+++ b/yarn-project/prover-node/src/job/checkpoint-prover.ts
@@ -189,6 +189,13 @@ export class CheckpointProver {
   /** Resolves when all in-flight work for this prover has fully unwound. */
   public async whenDone(): Promise<void> {
     await this.runPromise.catch(() => {});
+    // `runPromise` resolves once block-level proving is *enqueued*, but the sub-tree's proofs (and the
+    // success-driven teardown they trigger) land later, on the `getSubTreeResult()` callback. Awaiting
+    // `blockProofs` here bridges that gap: on success the callback resolves `blockProofs` and then
+    // synchronously sets `teardownPromise` before this await resumes, so the teardown is observable
+    // below; on failure/cancel `blockProofs` rejects and teardown is driven by the `finally`/cancel
+    // paths already awaited via `runPromise`/`cancelPromise`.
+    await this.blockProofs.promise.catch(() => {});
     if (this.cancelPromise) {
       await this.cancelPromise;
     }


### PR DESCRIPTION
## What

Reduces prover-node memory by tearing down each checkpoint's sub-tree orchestrator as soon as its block proofs are captured, instead of retaining it for the whole proof-submission window.

Each `CheckpointProver` held its `CheckpointSubTreeOrchestrator` — and every `TxProvingState`, AVM circuit input, and base/merge/parity proof it carried — alive until the prover was reaped at the end of the submission window, long after the checkpoint's block proofs were produced. Across every proven checkpoint this accumulates and dominates prover-node memory under load.

Now, once the sub-tree's `SubTreeResult` is captured, the `CheckpointProver` drops the sub-tree orchestrator. The block-proof outputs survive via the resolved promise; post-completion consumers (the top-tree job, a rebuilt `EpochSession`, failure upload) read only `whenBlockProofsReady()` and the prover's own fields (`checkpoint`, `txs`, headers, sibling paths), never the sub-tree. Teardown is tracked so `whenDone()` awaits it and stays idempotent with the cancel/reap path.

## Correctness

- Teardown of the sub-tree runs exactly once: `teardownSubTree()` captures the orchestrator and nulls the field in a synchronous prefix before any `await`, so the success-driven teardown and a concurrent cancel/reap can't both call `stop()`.
- `whenDone()` awaits the block-proof settlement between `runPromise` and the teardown check, so it can't report completion in the window where block-level proving has finished enqueueing (`runPromise` resolved) but the sub-tree proofs — and the teardown they trigger — are still outstanding.

## Scope

This reclaims the *cross-checkpoint retention* of already-proven sub-trees. It does **not** free the intermediates of checkpoints that are *still proving* (the in-flight AVM inputs / base-rollup hints / recursive proofs). Freeing those as they are consumed is a separate, more invasive change and is deliberately left as a follow-up.

The broker remains a separate large consumer (A-1215), as does the prover-node's `BrokerCircuitProverFacade` inline-inputs retention (A-1517).

## Testing

- `yarn build`, full `@aztec/prover-node` `checkpoint-prover` suite.
- New tests: the sub-tree is released exactly once on completion while the block-proof outputs still resolve; a subsequent reap cancel is a no-op; and `whenDone()` stays pending until the sub-tree result lands and teardown completes (asserted by calling it before the result resolves).
