### PR TITLE
feat(prover-node): stop caching checkpoint txs; re-fetch from the pool for failure upload (A-1216)

### DIFF
--- a/yarn-project/prover-node/src/job/checkpoint-prover.test.ts
+++ b/yarn-project/prover-node/src/job/checkpoint-prover.test.ts
@@ -17,6 +17,7 @@ import { jest } from '@jest/globals';
 import { mock } from 'jest-mock-extended';
 
 import { ProverNodeJobMetrics } from '../metrics.js';
+import { SessionManager } from '../session-manager.js';
 import { CheckpointProver, type CheckpointProverArgs, type CheckpointProverDeps } from './checkpoint-prover.js';
 
 describe('CheckpointProver', () => {
@@ -318,6 +319,46 @@ describe('CheckpointProver', () => {
       // The owner is notified exactly once, with this prover, so it can upload a checkpoint post-mortem.
       expect(onFailed).toHaveBeenCalledTimes(1);
       expect(onFailed).toHaveBeenCalledWith(prover);
+
+      await cleanup(prover);
+    });
+  });
+
+  // ---------------- tx re-fetch for failure upload ----------------
+
+  describe('getTxsForUpload', () => {
+    // A minimal Tx stand-in: getTxsForUpload only keys the map by getTxHash().toString().
+    const fakeTx = (hash: string) => ({ getTxHash: () => ({ toString: () => hash }) }) as unknown as Tx;
+
+    it('re-fetches txs from the pool on demand (the prover caches nothing)', async () => {
+      // The prover holds no tx map — the pool is the source of truth. Let the eager gather fail so the
+      // pipeline unwinds, then reconfigure the pool and re-fetch, mirroring a post-failure upload.
+      const prover = makeProver();
+      await prover.whenBlockProofsReady().catch(() => {});
+
+      txProvider.getTxsForBlock.mockReset();
+      txProvider.getTxsForBlock.mockResolvedValue({ txs: [fakeTx('0xaa'), fakeTx('0xbb')], missingTxs: [] });
+
+      const uploaded = await prover.getTxsForUpload();
+      // One fetch per block; returns the pool's txs keyed by hash.
+      expect(txProvider.getTxsForBlock).toHaveBeenCalledTimes(checkpoint.blocks.length);
+      expect(uploaded.get('0xaa')).toBeDefined();
+      expect(uploaded.get('0xbb')).toBeDefined();
+
+      await cleanup(prover);
+    });
+
+    it('failure-upload re-fetches from the pool and builds complete EpochProvingJobData', async () => {
+      const prover = makeProver();
+      await prover.whenBlockProofsReady().catch(() => {});
+
+      txProvider.getTxsForBlock.mockReset();
+      txProvider.getTxsForBlock.mockResolvedValue({ txs: [fakeTx('0xaa')], missingTxs: [] });
+
+      const data = await SessionManager.buildProvingData([prover]);
+      expect(data.txs.get('0xaa')).toBeDefined();
+      expect(data.checkpoints).toEqual([checkpoint]);
+      expect(data.epochNumber).toEqual(prover.epochNumber);
 
       await cleanup(prover);
     });

--- a/yarn-project/prover-node/src/job/checkpoint-prover.ts
+++ b/yarn-project/prover-node/src/job/checkpoint-prover.ts
@@ -18,7 +18,7 @@ import type { Checkpoint } from '@aztec/stdlib/checkpoint';
 import type { ForkMerkleTreeOperations, ITxProvider } from '@aztec/stdlib/interfaces/server';
 import { CheckpointConstantData } from '@aztec/stdlib/rollup';
 import { MerkleTreeId } from '@aztec/stdlib/trees';
-import type { BlockHeader, ProcessedTx, Tx } from '@aztec/stdlib/tx';
+import type { BlockHeader, ProcessedTx, Tx, TxHash } from '@aztec/stdlib/tx';
 
 import type { ProverNodeJobMetrics } from '../metrics.js';
 
@@ -98,9 +98,6 @@ export class CheckpointProver {
   readonly previousBlockHeader: BlockHeader;
   readonly l1ToL2Messages: Fr[];
   readonly previousArchiveSiblingPath: Tuple<Fr, typeof ARCHIVE_HEIGHT>;
-
-  /** Per-prover tx map — populated by the internal gather. Empty until then. */
-  readonly txs: Map<string, Tx> = new Map();
 
   /** Resolved by the sub-tree on success, rejected on cancel/failure. */
   private readonly blockProofs: PromiseWithResolvers<SubTreeResult['blockProofOutputs']> = promiseWithResolvers();
@@ -232,20 +229,45 @@ export class CheckpointProver {
     this.blockProofs.reject(err);
   }
 
-  private async gatherTxs(): Promise<Map<string, Tx>> {
+  /** Fetches every tx in this checkpoint from the tx pool (by hash, via the block tx effects). */
+  private async fetchTxs(): Promise<{ txs: Map<string, Tx>; missingTxs: TxHash[] }> {
     const deadline = new Date(this.deps.dateProvider.now() + this.deps.txGatheringTimeoutMs);
     const txsByBlock = await Promise.all(
       this.checkpoint.blocks.map(block => this.deps.txProvider.getTxsForBlock(block, { deadline })),
     );
-    const txs = txsByBlock.map(({ txs }) => txs).flat();
-    const missingTxs = txsByBlock.map(({ missingTxs }) => missingTxs).flat();
+    const txs = txsByBlock.flatMap(({ txs }) => txs);
+    const missingTxs = txsByBlock.flatMap(({ missingTxs }) => missingTxs);
+    return { txs: new Map<string, Tx>(txs.map(tx => [tx.getTxHash().toString(), tx])), missingTxs };
+  }
 
+  private async gatherTxs(): Promise<Map<string, Tx>> {
+    const { txs, missingTxs } = await this.fetchTxs();
     if (missingTxs.length > 0) {
       throw new Error(
         `Txs not found for checkpoint ${this.checkpoint.number}: ${missingTxs.map(hash => hash.toString()).join(', ')}`,
       );
     }
-    return new Map<string, Tx>(txs.map(tx => [tx.getTxHash().toString(), tx]));
+    return txs;
+  }
+
+  /**
+   * Re-fetches this checkpoint's txs from the tx pool for a post-mortem failure upload.
+   *
+   * The prover does not cache txs on the heap — they are consumed during proving and dropped — so the
+   * durable pool (which keeps a mined tx until L1 finality, with A-1274's retention margin covering a
+   * lagging prover) is the source of truth, read back by hash here. Best-effort: any tx the pool can
+   * no longer supply is logged and omitted rather than failing the upload, since a partial post-mortem
+   * snapshot is still useful for diagnosis.
+   */
+  public async getTxsForUpload(): Promise<Map<string, Tx>> {
+    const { txs, missingTxs } = await this.fetchTxs();
+    if (missingTxs.length > 0) {
+      this.deps.log.warn(
+        `Missing ${missingTxs.length} tx(s) re-fetching checkpoint ${this.checkpoint.number} for failure upload`,
+        { checkpointNumber: this.checkpoint.number, missingTxCount: missingTxs.length },
+      );
+    }
+    return txs;
   }
 
   private async executeCheckpoint(txs: Map<string, Tx>): Promise<void> {
@@ -259,9 +281,9 @@ export class CheckpointProver {
         await this.deps.checkpointProveOverride();
       }
 
-      for (const [hash, tx] of txs) {
-        this.txs.set(hash, tx);
-      }
+      // The gathered txs are consumed locally below (public processing + sub-tree) and then dropped.
+      // They are deliberately not retained on the instance: the tx pool is the durable source and
+      // `getTxsForUpload` re-fetches them by hash if a post-mortem upload needs them.
 
       const { chainId, version } = this.checkpoint.blocks[0].header.globalVariables;
       const checkpointConstants = CheckpointConstantData.from({

--- a/yarn-project/prover-node/src/prover-node.ts
+++ b/yarn-project/prover-node/src/prover-node.ts
@@ -621,7 +621,7 @@ export class ProverNode implements L2BlockStreamEventHandler, ProverNodeApi, Tra
     if (!this.config.proverNodeFailedEpochStore || checkpoints.length === 0) {
       return undefined;
     }
-    const data = SessionManager.buildProvingData(checkpoints);
+    const data = await SessionManager.buildProvingData(checkpoints);
     return await uploadEpochProofFailure(
       this.config.proverNodeFailedEpochStore,
       // The session's own id; `uploadEpochProofFailure` already prefixes the path with the epoch number.
@@ -657,7 +657,7 @@ export class ProverNode implements L2BlockStreamEventHandler, ProverNodeApi, Tra
         });
         return undefined;
       }
-      const data = SessionManager.buildProvingData([prover]);
+      const data = await SessionManager.buildProvingData([prover]);
       return await uploadEpochProofFailure(
         this.config.proverNodeFailedEpochStore,
         // The prover's content-addressed id; the epoch number is already in the upload path.

--- a/yarn-project/prover-node/src/session-manager.ts
+++ b/yarn-project/prover-node/src/session-manager.ts
@@ -435,14 +435,17 @@ export class SessionManager {
    * checkpoint provers. Includes every checkpoint regardless of whether sub-tree proving
    * completed — partial state is still useful for post-mortem analysis.
    */
-  public static buildProvingData(checkpoints: readonly CheckpointProver[]): EpochProvingJobData {
+  public static async buildProvingData(checkpoints: readonly CheckpointProver[]): Promise<EpochProvingJobData> {
     if (checkpoints.length === 0) {
       throw new Error('Cannot build proving data from an empty checkpoint set');
     }
+    // Provers no longer cache their txs; re-fetch each checkpoint's txs from the tx pool (concurrently)
+    // for the snapshot. The pool retains them past the proving window (A-1274), so this is durable.
+    const perCheckpoint = await Promise.all(checkpoints.map(async c => ({ c, txs: await c.getTxsForUpload() })));
     const txs = new Map();
     const l1ToL2Messages: Record<number, Fr[]> = {};
-    for (const c of checkpoints) {
-      for (const [hash, tx] of c.txs) {
+    for (const { c, txs: checkpointTxs } of perCheckpoint) {
+      for (const [hash, tx] of checkpointTxs) {
         txs.set(hash, tx);
       }
       l1ToL2Messages[c.checkpoint.number] = c.l1ToL2Messages;


### PR DESCRIPTION
## What

Stops the prover-node from holding every checkpoint's `Tx` objects in memory for the whole proof-submission window.

- Drops `CheckpointProver.txs` (an instance map that was populated at gather and never cleared). `executeCheckpoint` now consumes the gathered txs locally and lets them go out of scope.
- The only reader of the cached txs *after* execution was failure upload. `SessionManager.buildProvingData` now re-fetches each checkpoint's txs from the tx pool (via a new `CheckpointProver.getTxsForUpload`, concurrently across checkpoints) instead of reading the cached map. It becomes `async`, and the two `prover-node` upload call sites `await` it.

## Why

A live heap snapshot of a prover-node under load showed thousands of retained input `Tx` objects (client proofs + public inputs) — one set per registered `CheckpointProver`, held until the 100-epoch submission window expired. The tx pool already stores these txs durably on disk (kept until L1 finality, with A-1274's retention margin covering a lagging prover), so the in-memory copy is pure duplication of data the pool holds.

Re-fetch is safe: at failure time the txs were used for proving moments ago, so they are almost always still resident in the local pool (reqresp covers the rest); the A-1274 margin guarantees the durable case. Re-fetch is best-effort — a tx the pool can no longer supply is logged and omitted rather than failing the post-mortem, since a partial snapshot is still useful.

Note the rerun/replay path (`rerun-epoch-proving-job.ts`) is unaffected — it rebuilds from the already-uploaded `jobData.txs`, not from live prover state.

## Testing

- `yarn build`, full `@aztec/prover-node` suite (184/184).
- New tests: a `CheckpointProver` caches no txs and re-fetches from the pool on demand; failure upload rebuilds complete `EpochProvingJobData` by re-fetching.

## Depends on

A-1274 (tx-pool retention margin behind finality) — guarantees the pool keeps txs long enough for a lagging prover's failure-upload re-fetch.