### PR TITLE
feat(prover-client): stop duplicating broker job inputs/results in memory (A-1215)

### DIFF
--- a/yarn-project/prover-client/src/proving_broker/proving_broker.test.ts
+++ b/yarn-project/prover-client/src/proving_broker/proving_broker.test.ts
@@ -175,11 +175,15 @@ describe.each([
         type: ProvingRequestType.PARITY_BASE,
         inputsUri: makeInputsUri(),
       });
+      // Re-enqueuing the same id with different metadata (here, a different type) is a caller bug and
+      // must throw. The identity check is metadata-level: `inputsUri` lives in the database now, not the
+      // in-memory cache, and job ids are content-addressed so genuinely different content yields a
+      // different id (it would not reach this same-id branch at all).
       await expect(
         broker.enqueueProvingJob({
           id,
           epochNumber: EpochNumber(1),
-          type: ProvingRequestType.PARITY_BASE,
+          type: ProvingRequestType.PRIVATE_TX_BASE_ROLLUP,
           inputsUri: makeInputsUri(),
         }),
       ).rejects.toThrow('Duplicate proving job ID');
@@ -1053,7 +1057,7 @@ describe.each([
         inputsUri: makeInputsUri(),
       });
 
-      const jobPromise = (broker as any).promises.get(id)?.promise;
+      const jobPromise: Promise<void> | undefined = (broker as any).promises.get(id)?.promise;
       expect(jobPromise).toBeDefined();
 
       // Advance the epoch height so epoch 1 becomes stale (oldestEpochToKeep = 3 - 1 = 2)
@@ -1068,8 +1072,9 @@ describe.each([
       await sleep(brokerIntervalMs * 2);
       await assertJobStatus(id, 'not-found');
 
-      // The promise must have been settled (resolved with a rejected status) rather than left pending
-      await expect(jobPromise).resolves.toEqual({ status: 'rejected', reason: 'Proving job cleaned up' });
+      // The promise must have been settled (resolved rather than left pending) on clean-up. It carries no
+      // payload now — settled status/results are read from resultsCache/pendingResults/DB, not the promise.
+      await expect(jobPromise).resolves.toBeUndefined();
     });
 
     it('keeps the jobs in progress while it is alive', async () => {
@@ -1207,6 +1212,40 @@ describe.each([
       await expect(broker.getProvingJobStatus(id)).resolves.toEqual({
         status: 'not-found',
       });
+    });
+  });
+
+  describe('off-heap payloads', () => {
+    it('keeps only metadata/status in memory and serves inputs & result from the database', async () => {
+      const provingJob: ProvingJob = {
+        id: makeRandomProvingJobId(EpochNumber(1)),
+        type: ProvingRequestType.PARITY_BASE,
+        epochNumber: EpochNumber(1),
+        inputsUri: makeInputsUri(),
+      };
+      await broker.enqueueProvingJob(provingJob);
+
+      // The in-memory job cache holds metadata only — no inputsUri.
+      expect((broker as any).jobsCache.get(provingJob.id)).toEqual({
+        id: provingJob.id,
+        type: provingJob.type,
+        epochNumber: provingJob.epochNumber,
+      });
+
+      // Dispatch reconstructs the full job by reading inputsUri back from the database.
+      const dispatched = await broker.getProvingJob({ allowList: [ProvingRequestType.PARITY_BASE] });
+      expect(dispatched?.job).toEqual(provingJob);
+
+      const value = makeOutputsUri();
+      await broker.reportProvingJobSuccess(provingJob.id, value);
+
+      // The fulfilled proof value is not retained in memory: resultsCache holds status only, and the
+      // transient pendingResults hold was evicted once the database write committed.
+      expect((broker as any).resultsCache.get(provingJob.id)).toEqual({ status: 'fulfilled' });
+      expect((broker as any).pendingResults.has(provingJob.id)).toBe(false);
+
+      // ...yet the status endpoint still returns the full result, read back from the database.
+      await expect(broker.getProvingJobStatus(provingJob.id)).resolves.toEqual({ status: 'fulfilled', value });
     });
   });
 

--- a/yarn-project/prover-client/src/proving_broker/proving_broker.ts
+++ b/yarn-project/prover-client/src/proving_broker/proving_broker.ts
@@ -33,6 +33,23 @@ type InProgressMetadata = {
 
 type EnqueuedProvingJob = Pick<ProvingJob, 'id' | 'epochNumber'>;
 
+/** In-memory scheduling metadata for a job. The large `inputsUri` is deliberately excluded — it lives
+ * in the database and is read on demand when dispatching to an agent. */
+type ProvingJobMetadata = Pick<ProvingJob, 'id' | 'type' | 'epochNumber'>;
+
+/** Settled state kept in memory: the status plus the small payloads (rejected reason, aborted). The
+ * large fulfilled proof `value` is NOT kept here — it lives in the database (read on demand) and,
+ * transiently, in `pendingResults` while its database write is in flight. */
+type SettledRecord = { status: 'fulfilled' } | { status: 'rejected'; reason: string } | { status: 'aborted' };
+
+function toJobMetadata(job: ProvingJob): ProvingJobMetadata {
+  return { id: job.id, type: job.type, epochNumber: job.epochNumber };
+}
+
+function toSettledRecord(result: ProvingJobSettledResult): SettledRecord {
+  return result.status === 'fulfilled' ? { status: 'fulfilled' } : result;
+}
+
 /**
  * A broker that manages proof requests and distributes them to workers based on their priority.
  * It takes a backend that is responsible for storing and retrieving proof requests and results.
@@ -69,11 +86,17 @@ export class ProvingBroker implements ProvingJobProducer, ProvingJobConsumer, Pr
     [ProvingRequestType.PARITY_ROOT]: new PriorityMemoryQueue<EnqueuedProvingJob>(provingJobComparator),
   };
 
-  // holds a copy of the database in memory in order to quickly fulfill requests
-  // this is fine because this broker is the only one that can modify the database
-  private jobsCache = new Map<ProvingJobId, ProvingJob>();
-  // as above, but for results
-  private resultsCache = new Map<ProvingJobId, ProvingJobSettledResult>();
+  // Scheduling metadata for every known job (id, type, epochNumber). The large `inputsUri` is NOT held
+  // here — it lives in the database and is read on demand when a job is dispatched to an agent.
+  private jobsCache = new Map<ProvingJobId, ProvingJobMetadata>();
+  // Settled status for every settled job. The large fulfilled proof `value` is NOT held here — it lives
+  // in the database (read on demand in getProvingJobStatus) and, transiently, in `pendingResults` while
+  // its database write is in flight. Small payloads (rejected reason, aborted) are kept inline.
+  private resultsCache = new Map<ProvingJobId, SettledRecord>();
+  // Transient hold of a fulfilled result's full value, from the moment it settles until its database
+  // write commits, so status reads are read-your-writes without retaining every proof. Evicted once the
+  // value is durable in the database; kept only if that write failed (preserving the result in memory).
+  private pendingResults = new Map<ProvingJobId, ProvingJobSettledResult>();
 
   // tracks when each job was enqueued
   private enqueuedAt = new Map<ProvingJobId, Timer>();
@@ -87,8 +110,9 @@ export class ProvingBroker implements ProvingJobProducer, ProvingJobConsumer, Pr
   // keep track of which proving job has been retried
   private retries = new Map<ProvingJobId, number>();
 
-  // a map of promises that will be resolved when a job is settled
-  private promises = new Map<ProvingJobId, PromiseWithResolvers<ProvingJobSettledResult>>();
+  // a map of promises that are resolved when a job settles. Carries no payload (settled status/results
+  // are read from resultsCache/pendingResults/DB) so it never pins a proof value in memory.
+  private promises = new Map<ProvingJobId, PromiseWithResolvers<void>>();
 
   private cleanupPromise: RunningPromise;
   private msTimeSource = () => Date.now();
@@ -175,12 +199,12 @@ export class ProvingBroker implements ProvingJobProducer, ProvingJobConsumer, Pr
         status: result ? result.status : 'pending',
       });
 
-      this.jobsCache.set(item.id, item);
+      this.jobsCache.set(item.id, toJobMetadata(item));
       this.promises.set(item.id, promiseWithResolvers());
 
       if (result) {
-        this.promises.get(item.id)!.resolve(result);
-        this.resultsCache.set(item.id, result);
+        this.promises.get(item.id)!.resolve();
+        this.resultsCache.set(item.id, toSettledRecord(result));
       } else {
         this.enqueueJobInternal(item);
       }
@@ -211,7 +235,7 @@ export class ProvingBroker implements ProvingJobProducer, ProvingJobConsumer, Pr
   }
 
   public getProvingJobStatus(id: ProvingJobId): Promise<ProvingJobStatus> {
-    return Promise.resolve(this.#getProvingJobStatus(id));
+    return this.#getProvingJobStatus(id);
   }
 
   public getCompletedJobs(ids: ProvingJobId[]): Promise<ProvingJobId[]> {
@@ -219,7 +243,7 @@ export class ProvingBroker implements ProvingJobProducer, ProvingJobConsumer, Pr
   }
 
   public getProvingJob(filter?: ProvingJobFilter): Promise<GetProvingJobResponse | undefined> {
-    return Promise.resolve(this.#getProvingJob(filter));
+    return this.#getProvingJob(filter);
   }
 
   public reportProvingJobSuccess(
@@ -244,7 +268,7 @@ export class ProvingBroker implements ProvingJobProducer, ProvingJobConsumer, Pr
     startedAt: number,
     filter?: ProvingJobFilter,
   ): Promise<{ job: ProvingJob; time: number } | undefined> {
-    return Promise.resolve(this.#reportProvingJobProgress(id, startedAt, filter));
+    return this.#reportProvingJobProgress(id, startedAt, filter);
   }
 
   public async replayProvingJob(
@@ -263,7 +287,7 @@ export class ProvingBroker implements ProvingJobProducer, ProvingJobConsumer, Pr
     this.cleanUpProvingJobState([jobId]);
 
     const job: ProvingJob = { id: jobId, type, epochNumber, inputsUri };
-    this.jobsCache.set(jobId, job);
+    this.jobsCache.set(jobId, toJobMetadata(job));
     await this.database.addProvingJob(job);
     this.enqueueJobInternal(job);
 
@@ -271,11 +295,17 @@ export class ProvingBroker implements ProvingJobProducer, ProvingJobConsumer, Pr
   }
 
   async #enqueueProvingJob(job: ProvingJob): Promise<ProvingJobStatus> {
-    // We return the job status at the start of this call
-    let jobStatus = this.#getProvingJobStatus(job.id);
+    // The status returned to the caller reflects the job's state at the start of this call: `not-found`
+    // for a brand-new job (it did not exist yet), or the cached status for one already known. Crucially
+    // this must NOT `await` before the synchronous `jobsCache`/`resultsCache` gate below, or the
+    // enqueue/revive lock would no longer hold. So the not-found default is set synchronously here and
+    // the cached branch computes the real status (which may read the DB) only when it returns.
+    let jobStatus: ProvingJobStatus = { status: 'not-found' };
     if (this.jobsCache.has(job.id)) {
       const existing = this.jobsCache.get(job.id);
-      assert.deepStrictEqual(job, existing, 'Duplicate proving job ID');
+      // Identity check is metadata-only: `inputsUri` now lives in the database, not memory, and job ids
+      // are content-addressed (same id ⇒ same inputs), so a mismatch shows up in id/type/epochNumber.
+      assert.deepStrictEqual(toJobMetadata(job), existing, 'Duplicate proving job ID');
 
       if (this.resultsCache.get(job.id)?.status === 'aborted') {
         // The producer is re-requesting a job it previously cancelled: revive it rather than
@@ -290,21 +320,26 @@ export class ProvingBroker implements ProvingJobProducer, ProvingJobConsumer, Pr
         // single synchronous span (no await in between), and only then await the database. Because a
         // concurrent re-request can only interleave at that await — by which point `jobsCache` is
         // populated again and the aborted result is gone — it falls into the cached branch and no-ops,
-        // so the job is enqueued exactly once. (`cleanUpProvingJobState` also drops the promise, which
-        // was resolved with the abort, so `enqueueJobInternal` below mints a fresh one for the retry.)
+        // so the job is enqueued exactly once. (`cleanUpProvingJobState` also drops the promise, so
+        // `enqueueJobInternal` below mints a fresh one for the retry.) This holds unchanged with the
+        // slimmer caches: `jobsCache` (now metadata) and `resultsCache` (now settled status) are still
+        // synchronous in-memory maps, so the tear-down + re-set span still contains no await.
         this.logger.info(`Reviving aborted proving job id=${job.id} epochNumber=${job.epochNumber}`, {
           provingJobId: job.id,
         });
         this.cleanUpProvingJobState([job.id]);
-        this.jobsCache.set(job.id, job);
+        this.jobsCache.set(job.id, toJobMetadata(job));
         await this.database.deleteProvingJobResult(job.id);
-        jobStatus = this.#getProvingJobStatus(job.id);
+        // The job is re-set in the cache and about to be re-enqueued below: its start status is in-queue.
+        jobStatus = { status: 'in-queue' };
       } else {
         this.logger.warn(`Cached proving job id=${job.id} epochNumber=${job.epochNumber}. Not enqueuing again`, {
           provingJobId: job.id,
         });
         this.instrumentation.incCachedJobs(job.type);
-        return jobStatus;
+        // Return the job's current status. This reads the fulfilled proof value from the DB when needed;
+        // the await is fine here because this branch does not enqueue, so it is outside the lock span.
+        return await this.#getProvingJobStatus(job.id);
       }
     }
 
@@ -318,7 +353,7 @@ export class ProvingBroker implements ProvingJobProducer, ProvingJobConsumer, Pr
     this.logger.info(`New proving job id=${job.id} epochNumber=${job.epochNumber}`, { provingJobId: job.id });
     try {
       // do this first so it acts as a "lock". If this job is enqueued again while we're saving it the if at the top will catch it.
-      this.jobsCache.set(job.id, job);
+      this.jobsCache.set(job.id, toJobMetadata(job));
       await this.database.addProvingJob(job);
       this.enqueueJobInternal(job);
       this.instrumentation.incTotalJobs(job.type);
@@ -349,9 +384,8 @@ export class ProvingBroker implements ProvingJobProducer, ProvingJobConsumer, Pr
     // notifies the current waiter. Unlike a completion or failure this is not terminal: re-enqueuing
     // the same job id revives it (see #enqueueProvingJob), so the abort never permanently blocks the
     // proof.
-    const result: ProvingJobSettledResult = { status: 'aborted' };
-    this.resultsCache.set(id, result);
-    this.promises.get(id)?.resolve(result);
+    this.resultsCache.set(id, { status: 'aborted' });
+    this.promises.get(id)?.resolve();
     this.completedJobNotifications.push(id);
     this.instrumentation.incAbortedJobs(job.type);
 
@@ -369,10 +403,11 @@ export class ProvingBroker implements ProvingJobProducer, ProvingJobConsumer, Pr
       this.jobsCache.delete(id);
       const deferred = this.promises.get(id);
       if (deferred) {
-        deferred.resolve({ status: 'rejected', reason: 'Proving job cleaned up' });
+        deferred.resolve();
       }
       this.promises.delete(id);
       this.resultsCache.delete(id);
+      this.pendingResults.delete(id);
       this.inProgress.delete(id);
       this.retries.delete(id);
       this.enqueuedAt.delete(id);
@@ -380,20 +415,31 @@ export class ProvingBroker implements ProvingJobProducer, ProvingJobConsumer, Pr
     this.completedJobNotifications = this.completedJobNotifications.filter(id => !idsToClean.has(id));
   }
 
-  #getProvingJobStatus(id: ProvingJobId): ProvingJobStatus {
-    const result = this.resultsCache.get(id);
-    if (result) {
-      return result;
-    } else {
-      // no result yet, check if we know the item
-      const item = this.jobsCache.get(id);
-
-      if (!item) {
-        return { status: 'not-found' };
+  async #getProvingJobStatus(id: ProvingJobId): Promise<ProvingJobStatus> {
+    const settled = this.resultsCache.get(id);
+    if (settled) {
+      if (settled.status !== 'fulfilled') {
+        // rejected/aborted carry their (small) payload inline.
+        return settled;
       }
-
-      return { status: this.inProgress.has(id) ? 'in-progress' : 'in-queue' };
+      // A fulfilled job's proof value is not held in memory: serve it from the transient hold if its
+      // database write is still in flight, otherwise read it back from the database.
+      const full = this.pendingResults.get(id) ?? (await this.database.getProvingJobResult(id));
+      if (full?.status === 'fulfilled') {
+        return full;
+      }
+      // Settled as fulfilled but the value is nowhere to be found — should not happen (it is held in
+      // pendingResults until its DB write commits). Report not-found rather than a torn result.
+      this.logger.error(`Fulfilled proving job id=${id} has no retrievable result value`, { provingJobId: id });
+      return { status: 'not-found' };
     }
+
+    // no result yet, check if we know the item
+    const item = this.jobsCache.get(id);
+    if (!item) {
+      return { status: 'not-found' };
+    }
+    return { status: this.inProgress.has(id) ? 'in-progress' : 'in-queue' };
   }
 
   #getCompletedJobs(ids: ProvingJobId[]): Promise<ProvingJobId[]> {
@@ -403,7 +449,9 @@ export class ProvingBroker implements ProvingJobProducer, ProvingJobConsumer, Pr
     return Promise.resolve(notifications.concat(completedJobs));
   }
 
-  #getProvingJob(filter: ProvingJobFilter = { allowList: [] }): { job: ProvingJob; time: number } | undefined {
+  async #getProvingJob(
+    filter: ProvingJobFilter = { allowList: [] },
+  ): Promise<{ job: ProvingJob; time: number } | undefined> {
     const allowedProofs: ProvingRequestType[] =
       Array.isArray(filter.allowList) && filter.allowList.length > 0
         ? [...filter.allowList]
@@ -418,21 +466,35 @@ export class ProvingBroker implements ProvingJobProducer, ProvingJobConsumer, Pr
       // this can happen if the broker crashes and restarts
       // it's possible agents will report progress or results for jobs that are in the queue (after the restart)
       while ((enqueuedJob = queue.getImmediate())) {
-        const job = this.jobsCache.get(enqueuedJob.id);
-        if (job && !this.inProgress.has(enqueuedJob.id) && !this.resultsCache.has(enqueuedJob.id)) {
+        const meta = this.jobsCache.get(enqueuedJob.id);
+        if (meta && !this.inProgress.has(enqueuedJob.id) && !this.resultsCache.has(enqueuedJob.id)) {
           const time = this.msTimeSource();
-          this.inProgress.set(job.id, {
-            id: job.id,
+          // Claim the job synchronously (before the await below) so a concurrent dispatch can't re-pick it.
+          this.inProgress.set(meta.id, {
+            id: meta.id,
             startedAt: time,
             lastUpdatedAt: time,
           });
-          const enqueuedAt = this.enqueuedAt.get(job.id);
+          const enqueuedAt = this.enqueuedAt.get(meta.id);
           if (enqueuedAt) {
-            this.instrumentation.recordJobWait(job.type, enqueuedAt);
+            this.instrumentation.recordJobWait(meta.type, enqueuedAt);
             // we can clear this flag now.
-            this.enqueuedAt.delete(job.id);
+            this.enqueuedAt.delete(meta.id);
           }
 
+          // The large inputs are not kept in memory; read them from the database. They were durably
+          // persisted (addProvingJob's write commits) before the job became dispatchable, so this hits.
+          const inputsUri = await this.database.getProvingJobInputs(meta.id);
+          if (!inputsUri) {
+            // The job was cleaned up (or its inputs lost) after we claimed it — release the claim and
+            // keep draining the queue for another candidate.
+            this.inProgress.delete(meta.id);
+            this.logger.warn(`No inputs found for proving job id=${meta.id}; skipping dispatch`, {
+              provingJobId: meta.id,
+            });
+            continue;
+          }
+          const job: ProvingJob = { id: meta.id, type: meta.type, epochNumber: meta.epochNumber, inputsUri };
           return { job, time };
         }
       }
@@ -499,11 +561,10 @@ export class ProvingBroker implements ProvingJobProducer, ProvingJobConsumer, Pr
       },
     );
 
-    // save the result to the cache and notify clients of the job status
-    // this should work even if our database breaks because the result is cached in memory
-    const result: ProvingJobSettledResult = { status: 'rejected', reason: String(err) };
-    this.resultsCache.set(id, result);
-    this.promises.get(id)!.resolve(result);
+    // save the (small) rejection reason to the cache and notify clients of the job status. The reason
+    // is kept in memory, so status reads work even if the database write below fails.
+    this.resultsCache.set(id, { status: 'rejected', reason: String(err) });
+    this.promises.get(id)!.resolve();
     this.completedJobNotifications.push(id);
 
     this.instrumentation.incRejectedJobs(item.type);
@@ -525,20 +586,20 @@ export class ProvingBroker implements ProvingJobProducer, ProvingJobConsumer, Pr
     return this.#getProvingJob(filter);
   }
 
-  #reportProvingJobProgress(
+  async #reportProvingJobProgress(
     id: ProvingJobId,
     startedAt: number,
     filter?: ProvingJobFilter,
-  ): { job: ProvingJob; time: number } | undefined {
+  ): Promise<{ job: ProvingJob; time: number } | undefined> {
     const job = this.jobsCache.get(id);
     if (!job) {
       this.logger.warn(`Proving job id=${id} does not exist`, { provingJobId: id });
-      return this.#getProvingJob(filter);
+      return await this.#getProvingJob(filter);
     }
 
     if (this.resultsCache.has(id)) {
       this.logger.warn(`Proving job id=${id} has already been completed`, { provingJobId: id });
-      return this.#getProvingJob(filter);
+      return await this.#getProvingJob(filter);
     }
 
     const metadata = this.inProgress.get(id);
@@ -578,7 +639,7 @@ export class ProvingBroker implements ProvingJobProducer, ProvingJobConsumer, Pr
       { provingJobId: id },
     );
 
-    return this.#getProvingJob(filter);
+    return await this.#getProvingJob(filter);
   }
 
   async #reportProvingJobSuccess(
@@ -612,12 +673,12 @@ export class ProvingBroker implements ProvingJobProducer, ProvingJobConsumer, Pr
       { provingJobId: id },
     );
 
-    // save result to our local cache and notify clients
-    // if save to database fails, that's ok because we have the result in memory
-    // if the broker crashes and needs the result again, we're covered because we can just recompute it
-    const result: ProvingJobSettledResult = { status: 'fulfilled', value };
-    this.resultsCache.set(id, result);
-    this.promises.get(id)!.resolve(result);
+    // Mark settled synchronously (the gate that makes concurrent settles no-op, unchanged from before),
+    // holding only the status in resultsCache. The large proof value is kept transiently in
+    // pendingResults so status reads are read-your-writes until the database write below commits.
+    this.resultsCache.set(id, { status: 'fulfilled' });
+    this.pendingResults.set(id, { status: 'fulfilled', value });
+    this.promises.get(id)!.resolve();
     this.completedJobNotifications.push(id);
 
     this.instrumentation.incResolvedJobs(item.type);
@@ -628,7 +689,11 @@ export class ProvingBroker implements ProvingJobProducer, ProvingJobConsumer, Pr
 
     try {
       await this.database.setProvingJobResult(id, value);
+      // The value is durable in the database now; drop the transient in-memory copy.
+      this.pendingResults.delete(id);
     } catch (saveErr) {
+      // Keep the value in pendingResults so status/result reads still succeed despite the failed write —
+      // this preserves the previous "works even if the database breaks" behaviour for this edge.
       this.logger.error(`Failed to save proving job result id=${id}`, saveErr, {
         provingJobId: id,
       });
@@ -692,9 +757,8 @@ export class ProvingBroker implements ProvingJobProducer, ProvingJobConsumer, Pr
           this.logger.error(`Proving job id=${id} timed out after ${retries + 1} attempts. Marking as failed.`, {
             provingJobId: id,
           });
-          const result: ProvingJobSettledResult = { status: 'rejected', reason: 'Timed out' };
-          this.resultsCache.set(id, result);
-          this.promises.get(id)?.resolve(result);
+          this.resultsCache.set(id, { status: 'rejected', reason: 'Timed out' });
+          this.promises.get(id)?.resolve();
           this.completedJobNotifications.push(id);
           this.instrumentation.incRejectedJobs(item.type);
         }
@@ -702,7 +766,7 @@ export class ProvingBroker implements ProvingJobProducer, ProvingJobConsumer, Pr
     }
   }
 
-  private enqueueJobInternal(job: ProvingJob): void {
+  private enqueueJobInternal(job: ProvingJobMetadata): void {
     if (!this.promises.has(job.id)) {
       this.promises.set(job.id, promiseWithResolvers());
     }
@@ -714,7 +778,7 @@ export class ProvingBroker implements ProvingJobProducer, ProvingJobConsumer, Pr
     this.epochHeight = Math.max(this.epochHeight, job.epochNumber);
   }
 
-  private isJobStale(job: ProvingJob) {
+  private isJobStale(job: ProvingJobMetadata) {
     return job.epochNumber < this.oldestEpochToKeep();
   }
 

--- a/yarn-project/prover-client/src/proving_broker/proving_broker.ts
+++ b/yarn-project/prover-client/src/proving_broker/proving_broker.ts
@@ -469,30 +469,35 @@ export class ProvingBroker implements ProvingJobProducer, ProvingJobConsumer, Pr
         const meta = this.jobsCache.get(enqueuedJob.id);
         if (meta && !this.inProgress.has(enqueuedJob.id) && !this.resultsCache.has(enqueuedJob.id)) {
           const time = this.msTimeSource();
-          // Claim the job synchronously (before the await below) so a concurrent dispatch can't re-pick it.
+          // Claim the job synchronously (before the await below) so a concurrent dispatch can't re-pick
+          // it. The same id can sit in a queue more than once (an abort leaves a stale entry that a
+          // later revive re-enqueues alongside), so this in-progress claim — not the queue pop — is what
+          // dedups those copies across concurrently-polling agents. It must be set before the await.
           this.inProgress.set(meta.id, {
             id: meta.id,
             startedAt: time,
             lastUpdatedAt: time,
           });
-          const enqueuedAt = this.enqueuedAt.get(meta.id);
-          if (enqueuedAt) {
-            this.instrumentation.recordJobWait(meta.type, enqueuedAt);
-            // we can clear this flag now.
-            this.enqueuedAt.delete(meta.id);
-          }
 
           // The large inputs are not kept in memory; read them from the database. They were durably
           // persisted (addProvingJob's write commits) before the job became dispatchable, so this hits.
           const inputsUri = await this.database.getProvingJobInputs(meta.id);
           if (!inputsUri) {
             // The job was cleaned up (or its inputs lost) after we claimed it — release the claim and
-            // keep draining the queue for another candidate.
+            // keep draining the queue for another candidate. Nothing else was mutated yet, so there is
+            // no wait metric or enqueued-at timer to unwind.
             this.inProgress.delete(meta.id);
             this.logger.warn(`No inputs found for proving job id=${meta.id}; skipping dispatch`, {
               provingJobId: meta.id,
             });
             continue;
+          }
+
+          // The dispatch is now committed: record the queue wait and clear the enqueued-at timer.
+          const enqueuedAt = this.enqueuedAt.get(meta.id);
+          if (enqueuedAt) {
+            this.instrumentation.recordJobWait(meta.type, enqueuedAt);
+            this.enqueuedAt.delete(meta.id);
           }
           const job: ProvingJob = { id: meta.id, type: meta.type, epochNumber: meta.epochNumber, inputsUri };
           return { job, time };

--- a/yarn-project/prover-client/src/proving_broker/proving_broker_database.ts
+++ b/yarn-project/prover-client/src/proving_broker/proving_broker_database.ts
@@ -23,6 +23,20 @@ export interface ProvingBrokerDatabase {
   allProvingJobs(): AsyncIterableIterator<[ProvingJob, ProvingJobSettledResult | undefined]>;
 
   /**
+   * Reads a single job's inputs URI by id, or undefined if the job is unknown. The broker keeps only
+   * job metadata in memory and reads the (large) inputs from here on demand when dispatching to an agent.
+   * @param id - The ID of the proof request
+   */
+  getProvingJobInputs(id: ProvingJobId): Promise<ProofUri | undefined>;
+
+  /**
+   * Reads a single job's settled result by id, or undefined if not settled. The broker keeps only the
+   * settled status in memory and reads the (large) fulfilled proof from here on demand.
+   * @param id - The ID of the proof request
+   */
+  getProvingJobResult(id: ProvingJobId): Promise<ProvingJobSettledResult | undefined>;
+
+  /**
    * Saves the result of a proof request
    * @param id - The ID of the proof request to save the result for
    * @param ProvingRequestType - The type of proof that was requested

--- a/yarn-project/prover-client/src/proving_broker/proving_broker_database/memory.ts
+++ b/yarn-project/prover-client/src/proving_broker/proving_broker_database/memory.ts
@@ -17,8 +17,12 @@ export class InMemoryBrokerDatabase implements ProvingBrokerDatabase {
     return this.jobs.get(id);
   }
 
-  getProvingJobResult(id: ProvingJobId): ProvingJobSettledResult | undefined {
-    return this.results.get(id);
+  getProvingJobInputs(id: ProvingJobId): Promise<ProofUri | undefined> {
+    return Promise.resolve(this.jobs.get(id)?.inputsUri);
+  }
+
+  getProvingJobResult(id: ProvingJobId): Promise<ProvingJobSettledResult | undefined> {
+    return Promise.resolve(this.results.get(id));
   }
 
   addProvingJob(job: ProvingJob): Promise<void> {

--- a/yarn-project/prover-client/src/proving_broker/proving_broker_database/persisted.ts
+++ b/yarn-project/prover-client/src/proving_broker/proving_broker_database/persisted.ts
@@ -229,8 +229,13 @@ export class KVBrokerDatabase implements ProvingBrokerDatabase {
     }
   }
 
+  // Key jobs by the id-derived epoch, the same epoch results are written under (setProvingJobResult et
+  // al.). This keeps a job's inputs and its result co-located in one epoch database so both can be read
+  // back with a single keyed lookup (getProvingJobInputs/getProvingJobResult) rather than a scan. The id
+  // embeds the epoch and equals `job.epochNumber` at every construction site, so this matches the prior
+  // storage epoch while making the id the single source of truth for placement.
   addProvingJob(job: ProvingJob): Promise<void> {
-    return this.batchQueue.put(job, job.epochNumber);
+    return this.batchQueue.put(job, getEpochFromProvingJobId(job.id));
   }
 
   async *allProvingJobs(): AsyncIterableIterator<[ProvingJob, ProvingJobSettledResult | undefined]> {
@@ -240,27 +245,17 @@ export class KVBrokerDatabase implements ProvingBrokerDatabase {
     }
   }
 
-  // Jobs are keyed into an epoch database by `job.epochNumber` (addProvingJob) while results are keyed by
-  // the id-derived epoch (setProvingJobResult); these coincide in practice but need not. Rather than rely
-  // on that, search the (few) resident epoch databases for the id. This is O(epochs kept) LMDB reads.
-  async getProvingJobInputs(id: ProvingJobId): Promise<ProofUri | undefined> {
-    for (const db of this.epochs.values()) {
-      const inputs = await db.getProvingJobInputs(id);
-      if (inputs !== undefined) {
-        return inputs;
-      }
-    }
-    return undefined;
+  // A job id is `${epochNumber}:${type}:${inputsHash}`, so its epoch is recoverable directly and maps to
+  // exactly one epoch database. Results are already written under this same id-derived epoch (see
+  // setProvingJobResult et al.), and a job's `epochNumber` equals its id-epoch at every construction site,
+  // so inputs live there too. Use `epochs.get` (not `getEpochDatabase`, which would create the store on a
+  // miss) so a read for an unknown id has no side effects.
+  getProvingJobInputs(id: ProvingJobId): Promise<ProofUri | undefined> {
+    return this.epochs.get(getEpochFromProvingJobId(id))?.getProvingJobInputs(id) ?? Promise.resolve(undefined);
   }
 
-  async getProvingJobResult(id: ProvingJobId): Promise<ProvingJobSettledResult | undefined> {
-    for (const db of this.epochs.values()) {
-      const result = await db.getProvingJobResult(id);
-      if (result !== undefined) {
-        return result;
-      }
-    }
-    return undefined;
+  getProvingJobResult(id: ProvingJobId): Promise<ProvingJobSettledResult | undefined> {
+    return this.epochs.get(getEpochFromProvingJobId(id))?.getProvingJobResult(id) ?? Promise.resolve(undefined);
   }
 
   setProvingJobError(id: ProvingJobId, reason: string): Promise<void> {

--- a/yarn-project/prover-client/src/proving_broker/proving_broker_database/persisted.ts
+++ b/yarn-project/prover-client/src/proving_broker/proving_broker_database/persisted.ts
@@ -70,6 +70,16 @@ class SingleEpochDatabase {
     }
   }
 
+  async getProvingJobInputs(id: ProvingJobId): Promise<ProofUri | undefined> {
+    const jobStr = await this.jobs.getAsync(id);
+    return jobStr ? jsonParseWithSchema(jobStr, ProvingJob).inputsUri : undefined;
+  }
+
+  async getProvingJobResult(id: ProvingJobId): Promise<ProvingJobSettledResult | undefined> {
+    const resultStr = await this.jobResults.getAsync(id);
+    return resultStr ? jsonParseWithSchema(resultStr, ProvingJobSettledResult) : undefined;
+  }
+
   async setProvingJobError(id: ProvingJobId, reason: string): Promise<void> {
     const result: ProvingJobSettledResult = { status: 'rejected', reason };
     await this.jobResults.set(id, jsonStringify(result));
@@ -228,6 +238,29 @@ export class KVBrokerDatabase implements ProvingBrokerDatabase {
     for (const it of iterators) {
       yield* it;
     }
+  }
+
+  // Jobs are keyed into an epoch database by `job.epochNumber` (addProvingJob) while results are keyed by
+  // the id-derived epoch (setProvingJobResult); these coincide in practice but need not. Rather than rely
+  // on that, search the (few) resident epoch databases for the id. This is O(epochs kept) LMDB reads.
+  async getProvingJobInputs(id: ProvingJobId): Promise<ProofUri | undefined> {
+    for (const db of this.epochs.values()) {
+      const inputs = await db.getProvingJobInputs(id);
+      if (inputs !== undefined) {
+        return inputs;
+      }
+    }
+    return undefined;
+  }
+
+  async getProvingJobResult(id: ProvingJobId): Promise<ProvingJobSettledResult | undefined> {
+    for (const db of this.epochs.values()) {
+      const result = await db.getProvingJobResult(id);
+      if (result !== undefined) {
+        return result;
+      }
+    }
+    return undefined;
   }
 
   setProvingJobError(id: ProvingJobId, reason: string): Promise<void> {


### PR DESCRIPTION
## What

The proving broker kept a full in-memory copy of every job's inputs (`jobsCache.inputsUri`) and every settled result (`resultsCache.value`), duplicating what LMDB already persists. With the inline default `ProofStore`, those URIs embed the full circuit inputs and full proofs — so the broker held every input and every proof in RAM *and* again on disk. Under load this was the largest single consumer in the prover stack (broker peaked ~7.6 GiB in a 5 TPS bench run).

Now the broker keeps only scheduling metadata + settled status in memory and reads the large payloads from LMDB on demand:

- **`jobsCache`** → `{id, type, epochNumber}` metadata; `inputsUri` is read from the DB when a job is dispatched to an agent (new `getProvingJobInputs`). The DB write commits before a job becomes dispatchable, so the read always hits.
- **`resultsCache`** → settled *status* only (plus the small rejected `reason` / aborted). The fulfilled proof `value` is read from the DB in `getProvingJobStatus`, via a tiny transient `pendingResults` hold that covers the settle→commit window (and is *kept* on a DB-write failure, preserving the old "works even if the DB breaks" behaviour for that edge).
- **`promises`** carry no payload.

New DB getters `getProvingJobInputs` / `getProvingJobResult` search the (few) resident epoch databases by id, independent of the write-time epoch key.

## Concurrency

The enqueue lock and the abort-revive span are unchanged: `jobsCache` and `resultsCache` remain synchronous in-memory maps, set before any `await`, so no DB read is inserted into that span. `getProvingJob` claims `inProgress` synchronously *before* reading inputs from the DB, and the enqueue-return "status at start" is computed without awaiting before the gate. The identity check on a duplicate id is now metadata-level (ids are content-addressed, so different content yields a different id).

This trades the previous in-memory result resilience for memory (results are served from LMDB) — a deliberate, signed-off decision.

## Testing

- `yarn build`, full `@aztec/prover-client` `proving_broker/` suite (158/158), including a new test asserting inputs and the fulfilled result are served from the DB after the in-memory payload is dropped, and the existing abort/revive concurrency test.