### PR TITLE
feat(foundation): use native libsecp256k1 for gossip signature recovery

### DIFF
--- a/yarn-project/bootstrap.sh
+++ b/yarn-project/bootstrap.sh
@@ -251,6 +251,7 @@ function bench_cmds {
   echo "$hash BENCH_OUTPUT=bench-out/kv_store.bench.json yarn-project/scripts/run_test.sh kv-store/src/bench/map_bench.test.ts"
   echo "$hash BENCH_OUTPUT=bench-out/tx_pool_v2.bench.json yarn-project/scripts/run_test.sh p2p/src/mem_pools/tx_pool_v2/tx_pool_v2_bench.test.ts"
   echo "$hash BENCH_OUTPUT=bench-out/tx_validator.bench.json yarn-project/scripts/run_test.sh p2p/src/msg_validators/tx_validator/tx_validator_bench.test.ts"
+  echo "$hash BENCH_OUTPUT=bench-out/signature_recovery.bench.json yarn-project/scripts/run_test.sh foundation/src/crypto/secp256k1-signer/signature_recovery.bench.test.ts"
   echo "$hash:ISOLATE=1:CPUS=16:MEM=32g:TIMEOUT=1800 BENCH_OUTPUT=bench-out/p2p_client_batch_tx_requester.bench.json yarn-project/scripts/run_test.sh p2p/src/client/test/p2p_client.batch_tx_requester.bench.test.ts"
   echo "$hash BENCH_OUTPUT=bench-out/tx.bench.json yarn-project/scripts/run_test.sh stdlib/src/tx/tx_bench.test.ts"
   echo "$hash:ISOLATE=1:CPUS=10:MEM=16g:LOG_LEVEL=silent BENCH_OUTPUT=bench-out/proving_broker.bench.json yarn-project/scripts/run_test.sh prover-client/src/test/proving_broker_testbench.test.ts"

--- a/yarn-project/foundation/package.json
+++ b/yarn-project/foundation/package.json
@@ -151,6 +151,7 @@
     "@noble/curves": "=1.7.0",
     "@noble/hashes": "^1.6.1",
     "@scure/bip39": "^2.0.1",
+    "bcrypto": "^5.4.0",
     "bn.js": "^5.2.3",
     "colorette": "^2.0.20",
     "detect-node": "^2.1.0",

--- a/yarn-project/foundation/src/crypto/secp256k1-signer/native_recovery.test.ts
+++ b/yarn-project/foundation/src/crypto/secp256k1-signer/native_recovery.test.ts
@@ -1,0 +1,32 @@
+import { Buffer32 } from '@aztec/foundation/buffer';
+
+import { secp256k1 } from '@noble/curves/secp256k1';
+
+import { Signature } from '../../eth-signature/eth_signature.js';
+import { Secp256k1Signer } from './secp256k1_signer.js';
+import { recoverPublicKey } from './utils.js';
+
+/**
+ * `recoverPublicKey` routes elliptic-curve recovery through native libsecp256k1 when available
+ * (Node) and falls back to `@noble/curves` otherwise. Recovered keys must be byte-for-byte
+ * identical across both backends. In Node the public function exercises the native path; we
+ * compute the `@noble/curves` result directly here and assert parity.
+ */
+describe('secp256k1 recovery backend parity', () => {
+  const nobleRecover = (hash: Buffer32, signature: Signature): Buffer => {
+    const { r, s, v } = signature;
+    const recoveryBit = v === 27 || v === 0 ? 0 : 1;
+    const sig = new secp256k1.Signature(r.toBigInt(), s.toBigInt()).addRecoveryBit(recoveryBit);
+    return Buffer.from(sig.recoverPublicKey(hash.buffer).toHex(false), 'hex');
+  };
+
+  it('native and @noble/curves recover identical public keys', () => {
+    for (let i = 0; i < 50; i++) {
+      const signer = new Secp256k1Signer(Buffer32.random());
+      const hash = Buffer32.random();
+      const signature = signer.sign(hash);
+
+      expect(recoverPublicKey(hash, signature)).toEqual(nobleRecover(hash, signature));
+    }
+  });
+});

--- a/yarn-project/foundation/src/crypto/secp256k1-signer/native_recovery.test.ts
+++ b/yarn-project/foundation/src/crypto/secp256k1-signer/native_recovery.test.ts
@@ -2,31 +2,132 @@ import { Buffer32 } from '@aztec/foundation/buffer';
 
 import { secp256k1 } from '@noble/curves/secp256k1';
 
+import { EthAddress } from '../../eth-address/index.js';
 import { Signature } from '../../eth-signature/eth_signature.js';
+import { keccak256 } from '../keccak/index.js';
 import { Secp256k1Signer } from './secp256k1_signer.js';
-import { recoverPublicKey } from './utils.js';
+import {
+  type RecoveryOpts,
+  Secp256k1Error,
+  flipSignature,
+  generateUnrecoverableSignature,
+  makeEthSignDigest,
+  recoverAddress,
+  recoverPublicKey,
+  toRecoveryBit,
+  tryRecoverAddress,
+} from './utils.js';
 
-/**
- * `recoverPublicKey` routes elliptic-curve recovery through native libsecp256k1 when available
- * (Node) and falls back to `@noble/curves` otherwise. Recovered keys must be byte-for-byte
- * identical across both backends. In Node the public function exercises the native path; we
- * compute the `@noble/curves` result directly here and assert parity.
- */
-describe('secp256k1 recovery backend parity', () => {
-  const nobleRecover = (hash: Buffer32, signature: Signature): Buffer => {
-    const { r, s, v } = signature;
-    const recoveryBit = v === 27 || v === 0 ? 0 : 1;
-    const sig = new secp256k1.Signature(r.toBigInt(), s.toBigInt()).addRecoveryBit(recoveryBit);
-    return Buffer.from(sig.recoverPublicKey(hash.buffer).toHex(false), 'hex');
+// `recoverPublicKey` routes elliptic-curve recovery through native libsecp256k1 when available
+// (Node) and falls back to `@noble/curves` otherwise. These tests assert the native path is
+// behaviourally identical to the pure-JS path across every signature variety: recovered keys and
+// addresses must be byte-for-byte equal, and success/failure must agree. The reference below is a
+// faithful re-implementation of the `@noble/curves` path (the pre-change implementation).
+
+/** Reference `@noble/curves` recovery, independent of the native binding. */
+function nobleRecoverPublicKey(hash: Buffer32, signature: Signature, opts: RecoveryOpts = {}): Buffer {
+  const { r, s, v } = signature;
+  if (!opts.allowYParityAsV && v !== 27 && v !== 28) {
+    throw new Secp256k1Error(`Invalid v value ${v} (expected 27 or 28)`);
+  }
+  const sig = new secp256k1.Signature(r.toBigInt(), s.toBigInt()).addRecoveryBit(toRecoveryBit(v));
+  if (!opts.allowMalleable && sig.hasHighS()) {
+    throw new Secp256k1Error('Signature has high s-value (malleable signature)');
+  }
+  return Buffer.from(sig.recoverPublicKey(hash.buffer).toHex(false), 'hex');
+}
+
+function nobleRecoverAddress(hash: Buffer32, signature: Signature, opts?: RecoveryOpts): EthAddress {
+  return new EthAddress(keccak256(nobleRecoverPublicKey(hash, signature, opts).subarray(1)).subarray(12));
+}
+
+/** Asserts the native and `@noble/curves` paths agree — same value on success, same failure otherwise. */
+function expectEquivalent(hash: Buffer32, signature: Signature, opts?: RecoveryOpts) {
+  const capture = <T>(fn: () => T): { value?: T; threw: boolean } => {
+    try {
+      return { value: fn(), threw: false };
+    } catch {
+      return { threw: true };
+    }
   };
 
-  it('native and @noble/curves recover identical public keys', () => {
-    for (let i = 0; i < 50; i++) {
-      const signer = new Secp256k1Signer(Buffer32.random());
-      const hash = Buffer32.random();
-      const signature = signer.sign(hash);
+  const native = capture(() => recoverPublicKey(hash, signature, opts));
+  const noble = capture(() => nobleRecoverPublicKey(hash, signature, opts));
 
-      expect(recoverPublicKey(hash, signature)).toEqual(nobleRecover(hash, signature));
+  expect(native.threw).toBe(noble.threw);
+  if (!native.threw) {
+    expect(native.value).toEqual(noble.value);
+    expect(recoverAddress(hash, signature, opts).toString()).toEqual(
+      nobleRecoverAddress(hash, signature, opts).toString(),
+    );
+  }
+  // tryRecoverAddress must agree on both value and definedness.
+  expect(tryRecoverAddress(hash, signature, opts)?.toString()).toEqual(
+    noble.threw ? undefined : nobleRecoverAddress(hash, signature, opts).toString(),
+  );
+}
+
+describe('secp256k1 native/noble recovery equivalence', () => {
+  it('agrees on standard signatures across both recovery bits (v=27 and v=28)', () => {
+    const seen = new Set<number>();
+    for (let i = 0; i < 100; i++) {
+      const signer = Secp256k1Signer.random();
+      const digest = Buffer32.random();
+      const signature = signer.sign(digest);
+      seen.add(signature.v);
+      expectEquivalent(digest, signature);
+      // Recovered address must also match the actual signer.
+      expect(recoverAddress(digest, signature).toString()).toEqual(signer.address.toString());
+    }
+    // Both parities should occur over 100 random signatures.
+    expect([...seen].sort()).toEqual([27, 28]);
+  });
+
+  it('agrees on eth-signed-message digests', () => {
+    for (let i = 0; i < 20; i++) {
+      const signer = Secp256k1Signer.random();
+      const message = Buffer32.random();
+      const digest = makeEthSignDigest(message);
+      expectEquivalent(digest, signer.sign(digest));
+    }
+  });
+
+  it('agrees on high-s (malleable) signatures', () => {
+    for (let i = 0; i < 20; i++) {
+      const signer = Secp256k1Signer.random();
+      const digest = Buffer32.random();
+      const flipped = flipSignature(signer.sign(digest));
+      // Both reject by default and both accept (identically) with allowMalleable.
+      expectEquivalent(digest, flipped);
+      expectEquivalent(digest, flipped, { allowMalleable: true });
+      expect(recoverAddress(digest, flipped, { allowMalleable: true }).toString()).toEqual(signer.address.toString());
+    }
+  });
+
+  it('agrees on y-parity encoded v values (0/1) with allowYParityAsV', () => {
+    for (let i = 0; i < 20; i++) {
+      const signer = Secp256k1Signer.random();
+      const digest = Buffer32.random();
+      const signature = signer.sign(digest);
+      const yParity = new Signature(signature.r, signature.s, signature.v - 27);
+      // Rejected by default, accepted (identically) with allowYParityAsV.
+      expectEquivalent(digest, yParity);
+      expectEquivalent(digest, yParity, { allowYParityAsV: true });
+    }
+  });
+
+  it('agrees on invalid v values', () => {
+    const signer = Secp256k1Signer.random();
+    const digest = Buffer32.random();
+    const signature = signer.sign(digest);
+    for (const v of [2, 5, 26, 29, 255]) {
+      expectEquivalent(digest, new Signature(signature.r, signature.s, v));
+    }
+  });
+
+  it('agrees on unrecoverable signatures', () => {
+    for (let i = 0; i < 20; i++) {
+      expectEquivalent(Buffer32.random(), generateUnrecoverableSignature());
     }
   });
 });

--- a/yarn-project/foundation/src/crypto/secp256k1-signer/signature_recovery.bench.test.ts
+++ b/yarn-project/foundation/src/crypto/secp256k1-signer/signature_recovery.bench.test.ts
@@ -1,0 +1,71 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { type RecordableHistogram, createHistogram } from 'node:perf_hooks';
+
+import { Buffer32 } from '../../buffer/buffer32.js';
+import type { Signature } from '../../eth-signature/eth_signature.js';
+import { Secp256k1Signer } from './secp256k1_signer.js';
+import { recoverAddress, recoverPublicKey } from './utils.js';
+
+// Signature recovery (ecrecover) is the dominant cost of authenticating inbound gossip on a
+// validator: every checkpoint attestation and block/checkpoint proposal signature is recovered.
+// This benchmark tracks the per-signature recovery cost, which the native libsecp256k1 path drives.
+const SIGNATURES = 200;
+const WARMUP_ROUNDS = 2;
+const MEASURED_ROUNDS = 20;
+
+describe('secp256k1 signature recovery', () => {
+  const digest = Buffer32.fromBuffer(Buffer.from('ab'.repeat(32), 'hex'));
+  const signatures: Signature[] = [];
+
+  let recoverPublicKeyHistogram: RecordableHistogram;
+  let recoverAddressHistogram: RecordableHistogram;
+
+  beforeAll(() => {
+    recoverPublicKeyHistogram = createHistogram();
+    recoverAddressHistogram = createHistogram();
+    for (let i = 0; i < SIGNATURES; i++) {
+      signatures.push(Secp256k1Signer.random().sign(digest));
+    }
+  });
+
+  afterAll(async () => {
+    if (!process.env.BENCH_OUTPUT) {
+      return;
+    }
+    const data: { name: string; value: number; unit: string }[] = [];
+    const record = (name: string, histogram: RecordableHistogram) => {
+      data.push({ name: `${name}/avg`, value: histogram.mean / 1000, unit: 'us' });
+      data.push({ name: `${name}/p50`, value: histogram.percentile(50) / 1000, unit: 'us' });
+      data.push({ name: `${name}/p95`, value: histogram.percentile(95) / 1000, unit: 'us' });
+    };
+    record('Secp256k1/recoverPublicKey', recoverPublicKeyHistogram);
+    record('Secp256k1/recoverAddress', recoverAddressHistogram);
+
+    await fs.mkdir(path.dirname(process.env.BENCH_OUTPUT), { recursive: true });
+    await fs.writeFile(process.env.BENCH_OUTPUT, JSON.stringify(data, null, 2));
+  });
+
+  const measure = (histogram: RecordableHistogram, op: (signature: Signature) => unknown) => {
+    for (let round = 0; round < WARMUP_ROUNDS; round++) {
+      for (const signature of signatures) {
+        op(signature);
+      }
+    }
+    for (let round = 0; round < MEASURED_ROUNDS; round++) {
+      for (const signature of signatures) {
+        const start = process.hrtime.bigint();
+        op(signature);
+        histogram.record(Math.max(1, Number(process.hrtime.bigint() - start)));
+      }
+    }
+  };
+
+  it('recovers public keys from signatures', () => {
+    measure(recoverPublicKeyHistogram, signature => recoverPublicKey(digest, signature));
+  });
+
+  it('recovers addresses from signatures', () => {
+    measure(recoverAddressHistogram, signature => recoverAddress(digest, signature));
+  });
+});

--- a/yarn-project/foundation/src/crypto/secp256k1-signer/signature_recovery.bench.test.ts
+++ b/yarn-project/foundation/src/crypto/secp256k1-signer/signature_recovery.bench.test.ts
@@ -1,29 +1,47 @@
+import { secp256k1 } from '@noble/curves/secp256k1';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { type RecordableHistogram, createHistogram } from 'node:perf_hooks';
 
 import { Buffer32 } from '../../buffer/buffer32.js';
+import { EthAddress } from '../../eth-address/index.js';
 import type { Signature } from '../../eth-signature/eth_signature.js';
+import { keccak256 } from '../keccak/index.js';
 import { Secp256k1Signer } from './secp256k1_signer.js';
-import { recoverAddress, recoverPublicKey } from './utils.js';
+import { recoverAddress, recoverPublicKey, toRecoveryBit } from './utils.js';
 
 // Signature recovery (ecrecover) is the dominant cost of authenticating inbound gossip on a
 // validator: every checkpoint attestation and block/checkpoint proposal signature is recovered.
-// This benchmark tracks the per-signature recovery cost, which the native libsecp256k1 path drives.
+// The production path (`native`) uses native libsecp256k1 when available; the `noble` variant is the
+// pure-JS `@noble/curves` fallback. Tracking both makes the speedup visible and catches a regression
+// in either backend.
 const SIGNATURES = 200;
 const WARMUP_ROUNDS = 2;
 const MEASURED_ROUNDS = 20;
+
+/** Pure-JS `@noble/curves` recovery — mirrors the fallback branch of `recoverPublicKey`. */
+function nobleRecoverPublicKey(hash: Buffer32, signature: Signature): Buffer {
+  const { r, s, v } = signature;
+  const sig = new secp256k1.Signature(r.toBigInt(), s.toBigInt()).addRecoveryBit(toRecoveryBit(v));
+  return Buffer.from(sig.recoverPublicKey(hash.buffer).toHex(false), 'hex');
+}
+
+function publicKeyToAddress(publicKey: Buffer): EthAddress {
+  return new EthAddress(keccak256(publicKey.subarray(1)).subarray(12));
+}
 
 describe('secp256k1 signature recovery', () => {
   const digest = Buffer32.fromBuffer(Buffer.from('ab'.repeat(32), 'hex'));
   const signatures: Signature[] = [];
 
-  let recoverPublicKeyHistogram: RecordableHistogram;
-  let recoverAddressHistogram: RecordableHistogram;
+  const histograms = {
+    'recoverPublicKey/native': createHistogram(),
+    'recoverPublicKey/noble': createHistogram(),
+    'recoverAddress/native': createHistogram(),
+    'recoverAddress/noble': createHistogram(),
+  };
 
   beforeAll(() => {
-    recoverPublicKeyHistogram = createHistogram();
-    recoverAddressHistogram = createHistogram();
     for (let i = 0; i < SIGNATURES; i++) {
       signatures.push(Secp256k1Signer.random().sign(digest));
     }
@@ -34,14 +52,11 @@ describe('secp256k1 signature recovery', () => {
       return;
     }
     const data: { name: string; value: number; unit: string }[] = [];
-    const record = (name: string, histogram: RecordableHistogram) => {
-      data.push({ name: `${name}/avg`, value: histogram.mean / 1000, unit: 'us' });
-      data.push({ name: `${name}/p50`, value: histogram.percentile(50) / 1000, unit: 'us' });
-      data.push({ name: `${name}/p95`, value: histogram.percentile(95) / 1000, unit: 'us' });
-    };
-    record('Secp256k1/recoverPublicKey', recoverPublicKeyHistogram);
-    record('Secp256k1/recoverAddress', recoverAddressHistogram);
-
+    for (const [name, histogram] of Object.entries(histograms)) {
+      data.push({ name: `Secp256k1/${name}/avg`, value: histogram.mean / 1000, unit: 'us' });
+      data.push({ name: `Secp256k1/${name}/p50`, value: histogram.percentile(50) / 1000, unit: 'us' });
+      data.push({ name: `Secp256k1/${name}/p95`, value: histogram.percentile(95) / 1000, unit: 'us' });
+    }
     await fs.mkdir(path.dirname(process.env.BENCH_OUTPUT), { recursive: true });
     await fs.writeFile(process.env.BENCH_OUTPUT, JSON.stringify(data, null, 2));
   });
@@ -61,11 +76,21 @@ describe('secp256k1 signature recovery', () => {
     }
   };
 
-  it('recovers public keys from signatures', () => {
-    measure(recoverPublicKeyHistogram, signature => recoverPublicKey(digest, signature));
+  it('recovers public keys (native)', () => {
+    measure(histograms['recoverPublicKey/native'], signature => recoverPublicKey(digest, signature));
   });
 
-  it('recovers addresses from signatures', () => {
-    measure(recoverAddressHistogram, signature => recoverAddress(digest, signature));
+  it('recovers public keys (noble)', () => {
+    measure(histograms['recoverPublicKey/noble'], signature => nobleRecoverPublicKey(digest, signature));
+  });
+
+  it('recovers addresses (native)', () => {
+    measure(histograms['recoverAddress/native'], signature => recoverAddress(digest, signature));
+  });
+
+  it('recovers addresses (noble)', () => {
+    measure(histograms['recoverAddress/noble'], signature =>
+      publicKeyToAddress(nobleRecoverPublicKey(digest, signature)),
+    );
   });
 });

--- a/yarn-project/foundation/src/crypto/secp256k1-signer/utils.ts
+++ b/yarn-project/foundation/src/crypto/secp256k1-signer/utils.ts
@@ -1,4 +1,6 @@
 import { secp256k1 } from '@noble/curves/secp256k1';
+import isNode from 'detect-node';
+import { createRequire } from 'node:module';
 
 import { Buffer32 } from '../../buffer/buffer32.js';
 import { EthAddress } from '../../eth-address/index.js';
@@ -6,6 +8,38 @@ import { Signature } from '../../eth-signature/eth_signature.js';
 import { keccak256 } from '../keccak/index.js';
 
 const ETH_SIGN_PREFIX = '\x19Ethereum Signed Message:\n32';
+
+/** Subset of the bcrypto native secp256k1 binding used for public-key recovery. */
+interface NativeSecp256k1 {
+  /**
+   * Recovers a public key from a message hash and a compact (64-byte r||s) signature.
+   * @returns The recovered public key, or null if recovery fails.
+   */
+  recover(msg: Buffer, sig: Buffer, param: number, compress?: boolean): Buffer | null;
+}
+
+let nativeSecp256k1: NativeSecp256k1 | null | undefined;
+
+/**
+ * Loads the native libsecp256k1 binding (via bcrypto) for signature recovery, caching the result.
+ * Returns null in non-Node environments (e.g. browser/PXE bundles) or if the native addon is
+ * unavailable, in which case callers fall back to the pure-JS `@noble/curves` implementation.
+ */
+function getNativeSecp256k1(): NativeSecp256k1 | null {
+  if (nativeSecp256k1 !== undefined) {
+    return nativeSecp256k1;
+  }
+  if (!isNode) {
+    return (nativeSecp256k1 = null);
+  }
+  try {
+    const require = createRequire(import.meta.url);
+    nativeSecp256k1 = require('bcrypto/lib/native/secp256k1') as NativeSecp256k1;
+  } catch {
+    nativeSecp256k1 = null;
+  }
+  return nativeSecp256k1;
+}
 
 /** Signature recovery options */
 type RecoveryOpts = {
@@ -203,9 +237,21 @@ export function recoverPublicKey(hash: Buffer32, signature: Signature, opts: Rec
     throw new Secp256k1Error(`Invalid v value ${v} (expected 27 or 28)`);
   }
   const recoveryBit = toRecoveryBit(v);
+  // Constructing the noble Signature validates that r and s are in range, matching the rejection
+  // behavior for out-of-range values regardless of which recovery backend runs below.
   const sig = new secp256k1.Signature(r.toBigInt(), s.toBigInt()).addRecoveryBit(recoveryBit);
   if (!opts.allowMalleable && sig.hasHighS()) {
     throw new Secp256k1Error('Signature has high s-value (malleable signature)');
+  }
+  // The expensive part is the elliptic-curve recovery below. Route it through native libsecp256k1
+  // when available (Node), falling back to the pure-JS `@noble/curves` implementation otherwise.
+  const native = getNativeSecp256k1();
+  if (native) {
+    const publicKey = native.recover(hash.buffer, Buffer.concat([r.buffer, s.buffer]), recoveryBit, false);
+    if (!publicKey) {
+      throw new Secp256k1Error('Failed to recover public key from signature');
+    }
+    return publicKey;
   }
   const publicKey = sig.recoverPublicKey(hash.buffer).toHex(false);
   return Buffer.from(publicKey, 'hex');

--- a/yarn-project/foundation/src/crypto/secp256k1-signer/utils.ts
+++ b/yarn-project/foundation/src/crypto/secp256k1-signer/utils.ts
@@ -42,7 +42,7 @@ function getNativeSecp256k1(): NativeSecp256k1 | null {
 }
 
 /** Signature recovery options */
-type RecoveryOpts = {
+export type RecoveryOpts = {
   /**
    * Whether to allow s-values in the high half of the curve (s >= CURVE.n/2).
    * These are discouraged by EIP2 to prevent signature malleability, and outright

--- a/yarn-project/yarn.lock
+++ b/yarn-project/yarn.lock
@@ -1379,6 +1379,7 @@ __metadata:
     "@types/pako": "npm:^2.0.0"
     "@types/supertest": "npm:^2.0.12"
     "@typescript/native-preview": "npm:7.0.0-dev.20260113.1"
+    bcrypto: "npm:^5.4.0"
     bn.js: "npm:^5.2.3"
     colorette: "npm:^2.0.20"
     comlink: "npm:^4.4.1"


### PR DESCRIPTION
## Summary

Routes the validator's `ecrecover` hot path through native **libsecp256k1** (via the `bcrypto` binding already present in the dependency tree) instead of the pure-JS `@noble/curves` field arithmetic.

CPU profiling of a validator main thread under sustained 10 TPS load (bench-inclusion-sweep, 72 txs/block) found secp256k1 public-key recovery to be ~3.6% of total main-thread wall time (~8.8% of the thread's actual compute) — the dominant cost of authenticating inbound gossip (checkpoint attestations and block/checkpoint proposals from a ~48-member committee; ~zero from txs), second only to tx deserialization.

## Changes

- `foundation/secp256k1-signer/utils.ts`: add a cached, Node-guarded loader for the native binding. `recoverPublicKey` keeps the `@noble/curves` `Signature` construction (preserving exact range and high-s / malleability rejection semantics) and only swaps the expensive elliptic-curve recovery — the profile hot spot — for the native `recover()`. Falls back to `@noble/curves` when the native addon is unavailable (browser/PXE bundles).
- `foundation/package.json`: add `bcrypto` dependency (dedupes to the already-locked 5.5.2; single-line lockfile change).
- New `native_recovery.test.ts`: differential parity test asserting native and `@noble/curves` recover byte-for-byte identical public keys.

Public API (`recoverPublicKey` / `recoverAddress`) is unchanged.

## Verification

- Signer tests (incl. viem differential fuzzing — now proving native == viem byte-for-byte) pass.
- Downstream stdlib `signature_utils` / `attestation_utils` / `block_proposal` tests pass.
- Full `yarn build`, format, and lint clean.
- Micro-benchmark: ~27x faster recovery (853 µs → 31 µs per op). Since ecrecover was ~8.8% of thread compute, this removes nearly all of it.
