### PR TITLE
chore: add withWallet variant

### DIFF
--- a/docs/docs-developers/docs/resources/migration_notes.md
+++ b/docs/docs-developers/docs/resources/migration_notes.md
@@ -13,7 +13,7 @@ Aztec is in active development. Each version may introduce breaking changes that
 
 `@aztec/noir-contracts.js` no longer includes the protocol contracts: the `FeeJuice`, `ContractClassRegistry`, and `ContractInstanceRegistry` artifacts and typed wrappers have been removed from the package, so imports such as `@aztec/noir-contracts.js/FeeJuice` no longer resolve. These names are also no longer available to the `aztec` CLI's contract-name lookup (e.g. in `aztec example-contracts`).
 
-Protocol contracts are distributed via `@aztec/protocol-contracts` (artifacts and canonical deployment data), and typed wrappers for them are exported from `@aztec/aztec.js/protocol`. The `aztec.js` wrappers are bound to the contract's canonical address, so `.at()` takes only the wallet.
+Protocol contracts are distributed via `@aztec/protocol-contracts` (artifacts and canonical deployment data), and typed wrappers for them are exported from `@aztec/aztec.js/protocol`. The `aztec.js` wrappers are bound to the contract's canonical address, so attaching takes only the wallet: there is no address parameter.
 
 **Migration:**
 
@@ -22,7 +22,18 @@ Protocol contracts are distributed via `@aztec/protocol-contracts` (artifacts an
 + import { FeeJuiceContract } from '@aztec/aztec.js/protocol';
 
 - const feeJuice = FeeJuiceContract.at(ProtocolContractAddress.FeeJuice, wallet);
-+ const feeJuice = FeeJuiceContract.at(wallet);
++ const feeJuice = FeeJuiceContract.withWallet(wallet);
+```
+
+### [Aztec.js] Protocol contract wrappers: `at(wallet)` deprecated in favor of `withWallet(wallet)`
+
+The protocol contract wrappers exported from `@aztec/aztec.js/protocol` (`FeeJuiceContract`, `ContractClassRegistryContract`, `ContractInstanceRegistryContract`) rename their static `at(wallet)` to `withWallet(wallet)`. These wrappers are bound to the contract's canonical address, so their only parameter is the wallet to act through; `withWallet` states that directly and matches the existing `withWallet` instance method, whereas the one-argument `at` read as if it took an address. `at(wallet)` still works but is deprecated and will be removed in a future release.
+
+**Migration:**
+
+```diff
+- const feeJuice = FeeJuiceContract.at(wallet);
++ const feeJuice = FeeJuiceContract.withWallet(wallet);
 ```
 
 ### [Aztec.nr] Standard contracts re-pinned at new addresses

--- a/yarn-project/aztec.js/src/deployment/publish_class.ts
+++ b/yarn-project/aztec.js/src/deployment/publish_class.ts
@@ -19,7 +19,7 @@ export async function publishContractClass(
 ): Promise<ContractFunctionInteraction> {
   const { artifactHash, privateFunctionsRoot, publicBytecodeCommitment, packedBytecode } =
     await getContractClassFromArtifact(artifact);
-  const classRegistry = ContractClassRegistryContract.at(wallet);
+  const classRegistry = ContractClassRegistryContract.withWallet(wallet);
 
   const encodedBytecode = bufferAsFields(packedBytecode, MAX_PACKED_PUBLIC_BYTECODE_SIZE_IN_FIELDS);
   return classRegistry.methods.publish(artifactHash, privateFunctionsRoot, publicBytecodeCommitment).with({

--- a/yarn-project/aztec.js/src/deployment/publish_instance.ts
+++ b/yarn-project/aztec.js/src/deployment/publish_instance.ts
@@ -10,7 +10,7 @@ import type { Wallet } from '../wallet/wallet.js';
  * @param instance - The instance to publish.
  */
 export function publishInstance(wallet: Wallet, instance: ContractInstanceWithAddress): ContractFunctionInteraction {
-  const contractInstanceRegistry = ContractInstanceRegistryContract.at(wallet);
+  const contractInstanceRegistry = ContractInstanceRegistryContract.withWallet(wallet);
   const { salt, currentContractClassId: contractClassId, publicKeys, deployer: instanceDeployer } = instance;
   const isUniversalDeploy = instanceDeployer.isZero();
   return contractInstanceRegistry.methods.publish_for_public_execution(

--- a/yarn-project/aztec.js/src/scripts/generate_protocol_contract_types.ts
+++ b/yarn-project/aztec.js/src/scripts/generate_protocol_contract_types.ts
@@ -112,8 +112,14 @@ export class ${contractName} extends ContractBase {
     super(ProtocolContractAddress.${protocolContractName}, ${contractName}Artifact, wallet);
   }
 
-  public static at(wallet: Wallet): ${contractName} {
+  /** Returns an interface to the canonical ${contractName} instance, bound to the given wallet. */
+  public static withWallet(wallet: Wallet): ${contractName} {
     return new ${contractName}(wallet);
+  }
+
+  /** @deprecated Use \`withWallet\` instead. */
+  public static at(wallet: Wallet): ${contractName} {
+    return ${contractName}.withWallet(wallet);
   }
 
   public declare methods: {${methodsMatch[1]}

--- a/yarn-project/end-to-end/src/bench/client_flows/client_flows_benchmark.ts
+++ b/yarn-project/end-to-end/src/bench/client_flows/client_flows_benchmark.ts
@@ -216,7 +216,7 @@ export class ClientFlowsBenchmark {
     this.adminAddress = adminAddress;
     this.sequencerAddress = sequencerAddress;
 
-    this.feeJuiceContract = FeeJuiceContract.at(this.adminWallet);
+    this.feeJuiceContract = FeeJuiceContract.withWallet(this.adminWallet);
     this.coinbase = EthAddress.random();
 
     const userPXEConfig = getPXEConfig();
@@ -247,7 +247,7 @@ export class ClientFlowsBenchmark {
 
   async applySetupFeeJuice() {
     this.logger.info('Applying fee juice setup');
-    this.feeJuiceContract = FeeJuiceContract.at(this.adminWallet);
+    this.feeJuiceContract = FeeJuiceContract.withWallet(this.adminWallet);
 
     this.feeJuiceBridgeTestHarness = await FeeJuicePortalTestingHarnessFactory.create({
       aztecNode: this.context.aztecNodeService,

--- a/yarn-project/end-to-end/src/shared/gas_portal_test_harness.ts
+++ b/yarn-project/end-to-end/src/shared/gas_portal_test_harness.ts
@@ -48,7 +48,7 @@ export class FeeJuicePortalTestingHarnessFactory {
       throw new Error('Fee Juice portal not deployed on L1');
     }
 
-    const gasL2 = FeeJuiceContract.at(wallet);
+    const gasL2 = FeeJuiceContract.withWallet(wallet);
 
     return new GasBridgingTestHarness(
       aztecNode,

--- a/yarn-project/end-to-end/src/single-node/fees/fees_test.ts
+++ b/yarn-project/end-to-end/src/single-node/fees/fees_test.ts
@@ -249,13 +249,13 @@ export class FeesTest extends SingleNodeTestContext {
     // We set Alice as the FPC admin to avoid the need for deployment of another account.
     this.fpcAdmin = this.aliceAddress;
 
-    this.feeJuiceContract = FeeJuiceContract.at(this.wallet);
+    this.feeJuiceContract = FeeJuiceContract.withWallet(this.wallet);
   }
 
   async applySetupFeeJuice() {
     this.logger.info('Applying fee juice setup');
 
-    this.feeJuiceContract = FeeJuiceContract.at(this.wallet);
+    this.feeJuiceContract = FeeJuiceContract.withWallet(this.wallet);
 
     this.getGasBalanceFn = getBalancesFn('⛽', this.feeJuiceContract.methods.balance_of_public, this.logger);
 


### PR DESCRIPTION
`at(wallet)` was bad, it's a remnant from they being `contract.at(addr, wallet)` and then `addr` being removed. I marked `at` as deprecated and added `withWallet`.