### PR TITLE
chore: add new client

### DIFF
--- a/spartan/terraform/deploy-ethereum/variables.tf
+++ b/spartan/terraform/deploy-ethereum/variables.tf
@@ -6,6 +6,7 @@ variable "API_KEY_SECRET_NAMES" {
     "eth-sepolia-rpc-consumer-client2",
     "eth-sepolia-rpc-consumer-client3",
     "eth-sepolia-rpc-consumer-client4",
+    "eth-sepolia-rpc-consumer-client5",
   ]
 }
 


### PR DESCRIPTION
Adds `eth-sepolia-rpc-consumer-client5` to `API_KEY_SECRET_NAMES` for the Ethereum RPC gateway.

Secret already created in Secret Manager and `terraform apply`-ed against `aztec-gke-public/ethereum/deploy-ethereum`; plan was the expected 2 resources (KongConsumer + ExternalSecret), 0 changed, 0 destroyed. Rate limit 0 = unlimited. Verified live: KongConsumer `PROGRAMMED=True`, ExternalSecret `SecretSynced`, and the key authenticates on both the mainnet and sepolia execution routes (keyless requests still 401).