### PR TITLE
fix(prover-client): don't retain inline job inputs in the facade without a failed-proof store (A-1517)

### DIFF
--- a/yarn-project/prover-client/src/proving_broker/broker_prover_facade.test.ts
+++ b/yarn-project/prover-client/src/proving_broker/broker_prover_facade.test.ts
@@ -54,6 +54,50 @@ describe('BrokerCircuitProverFacade', () => {
     expect(errorProofStore.saveProofInput).not.toHaveBeenCalled();
   });
 
+  it('does not retain the inputs URI for in-flight jobs when no failed-proof store is configured', async () => {
+    // With no failed-proof store there is no consumer for the retained inputs URI (only
+    // `backupFailedProofInputs` reads it). With the default InlineProofStore that URI embeds the full
+    // circuit inputs, so the facade must not pin it in memory for the in-flight window.
+    // Stop the shared facade so it doesn't drain this job's completion notification from the broker,
+    // which would otherwise force this facade onto the slow full-snapshot sync path.
+    await facade.stop();
+    const facadeNoFailedStore = new BrokerCircuitProverFacade(broker, proofStore);
+    facadeNoFailedStore.start();
+    try {
+      const inputs = makeParityBasePrivateInputs();
+      const controller = new AbortController();
+
+      const resultPromise = promiseWithResolvers<any>();
+      const enqueueSpy = jest.spyOn(broker, 'enqueueProvingJob');
+      jest.spyOn(prover, 'getBaseParityProof').mockReturnValue(resultPromise.promise);
+
+      const proofPromise = facadeNoFailedStore.getBaseParityProof(inputs, controller.signal, EpochNumber(42));
+
+      // Wait until the job has been sent to the broker — past the point where the URI would be retained.
+      await retryFastUntil(() => enqueueSpy.mock.calls.length > 0, 'job to be enqueued');
+
+      // The broker still receives the inputs URI...
+      const enqueued = enqueueSpy.mock.calls[0][0] as { inputsUri?: string };
+      expect(enqueued.inputsUri).toBeTruthy();
+
+      // ...but the facade does not hold onto it for the in-flight job.
+      const jobs = (facadeNoFailedStore as any).jobs as Map<string, { inputsUri?: string }>;
+      expect(jobs.size).toBe(1);
+      expect([...jobs.values()][0].inputsUri).toBeUndefined();
+
+      // The job still completes normally.
+      const result = makePublicInputsAndRecursiveProof(
+        makeParityPublicInputs(),
+        makeRecursiveProof(RECURSIVE_PROOF_LENGTH),
+        VerificationKeyData.makeFakeHonk(),
+      );
+      resultPromise.resolve(result);
+      await expect(proofPromise).resolves.toEqual(result);
+    } finally {
+      await facadeNoFailedStore.stop();
+    }
+  });
+
   it('handles multiple calls for the same job', async () => {
     const inputs = makeParityBasePrivateInputs();
     const controller = new AbortController();

--- a/yarn-project/prover-client/src/proving_broker/broker_prover_facade.ts
+++ b/yarn-project/prover-client/src/proving_broker/broker_prover_facade.ts
@@ -145,7 +145,14 @@ export class BrokerCircuitProverFacade implements ServerCircuitProver {
 
     try {
       const inputsUri = await this.proofStore.saveProofInput(id, type, inputs);
-      job.inputsUri = inputsUri;
+      // Only retain the inputs URI on the long-lived job when a failed-proof store is configured: it is
+      // read solely by `backupFailedProofInputs` on failure. With the default `InlineProofStore` the URI
+      // embeds the full circuit inputs, so retaining it for every in-flight job would pin those inputs in
+      // memory until the job settles for no purpose when no failed-proof store exists. The broker still
+      // receives the URI below regardless; this only governs what the facade holds onto.
+      if (this.failedProofStore) {
+        job.inputsUri = inputsUri;
+      }
 
       // Send the job to the broker
       const jobStatus = await this.broker.enqueueProvingJob({ id, type, inputsUri, epochNumber });


### PR DESCRIPTION
## What

`BrokerCircuitProverFacade` (prover-node side) kept each in-flight job's `inputsUri` in its `jobs` map from enqueue until the job settled. With the default `InlineProofStore` that URI embeds the **full circuit inputs**, and the only thing that reads it after enqueue is `backupFailedProofInputs` on failure. So when no `failedProofStore` is configured, the facade pinned every in-flight job's full inputs in memory for no purpose.

This only retains `inputsUri` on the long-lived job when a `failedProofStore` is configured. The broker still receives the URI on enqueue regardless — this governs only what the facade holds onto.

## Why it matters here

`PROVER_PROOF_STORE` is unset in every environment, so the facade always uses `InlineProofStore` (URI == payload). `PROVER_FAILED_PROOF_STORE` is:

- **unset** on `bench-inclusion-sweep` and the staging environments → the retained inline inputs were pure dead weight; this change reclaims that memory in the environments we benchmark memory in;
- **set** (GCS) on mainnet / mainnet-v4 / testnet / next-net → unchanged: those keep retaining the URI and still back up failed-proof inputs.

## Scope

Follow-up to A-1215 (broker-side), flagged by @alexghr in review of #24990 (producer side keeps its own copy). This is the minimal, safe slice: it does not change prod behaviour. Bounding the in-flight inputs footprint on networks that *do* set a failed-proof store (via a file-store `PROVER_PROOF_STORE`, or fetching inputs by id at failure) remains possible future work.

## Testing

- New unit test: with no `failedProofStore`, the facade does not retain `inputsUri` for an in-flight job (while the broker still receives it), and the job still completes normally.
- The existing "handles proof errors" test (which configures a failed-proof store) still asserts the failed-proof backup runs.
- Full `@aztec/prover-client` `proving_broker/` suite: 159/159. Build, format, lint clean.
