### PR TITLE
fix(stdlib): cap the unbounded arrays in Tx and HashedValues schemas

### DIFF
--- a/yarn-project/stdlib/src/tx/hashed_values.test.ts
+++ b/yarn-project/stdlib/src/tx/hashed_values.test.ts
@@ -1,4 +1,3 @@
-import { MAX_FR_CALLDATA_TO_ALL_ENQUEUED_CALLS } from '@aztec/constants';
 import { times } from '@aztec/foundation/collection';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { jsonStringify } from '@aztec/foundation/json-rpc';
@@ -12,28 +11,29 @@ describe('HashedValues', () => {
     await expect(HashedValues.schema.parseAsync(JSON.parse(json))).resolves.toEqual(values);
   });
 
-  const parseWithValueCount = (count: number) =>
-    HashedValues.schema.parseAsync(
-      JSON.parse(
-        jsonStringify(
-          new HashedValues(
-            times(count, i => new Fr(i)),
-            Fr.ZERO,
+  describe('schemaFor', () => {
+    const parseWithValueCount = (maxValues: number | undefined, count: number) =>
+      HashedValues.schemaFor(maxValues).parseAsync(
+        JSON.parse(
+          jsonStringify(
+            new HashedValues(
+              times(count, i => new Fr(i)),
+              Fr.ZERO,
+            ),
           ),
         ),
-      ),
-    );
+      );
 
-  it('accepts as many values as a tx can spend on calldata', async () => {
-    await expect(parseWithValueCount(MAX_FR_CALLDATA_TO_ALL_ENQUEUED_CALLS)).resolves.toHaveProperty(
-      'values.length',
-      MAX_FR_CALLDATA_TO_ALL_ENQUEUED_CALLS,
-    );
-  });
+    it('accepts up to the requested number of values', async () => {
+      await expect(parseWithValueCount(10, 10)).resolves.toHaveProperty('values.length', 10);
+    });
 
-  it('rejects more values than a tx can spend on calldata', async () => {
-    await expect(parseWithValueCount(MAX_FR_CALLDATA_TO_ALL_ENQUEUED_CALLS + 1)).rejects.toThrow(
-      expect.objectContaining({ name: 'ZodError' }),
-    );
+    it('rejects more than the requested number of values', async () => {
+      await expect(parseWithValueCount(10, 11)).rejects.toThrow(expect.objectContaining({ name: 'ZodError' }));
+    });
+
+    it('accepts any number of values when unbounded', async () => {
+      await expect(parseWithValueCount(undefined, 500)).resolves.toHaveProperty('values.length', 500);
+    });
   });
 });

--- a/yarn-project/stdlib/src/tx/hashed_values.test.ts
+++ b/yarn-project/stdlib/src/tx/hashed_values.test.ts
@@ -1,3 +1,6 @@
+import { MAX_FR_CALLDATA_TO_ALL_ENQUEUED_CALLS } from '@aztec/constants';
+import { times } from '@aztec/foundation/collection';
+import { Fr } from '@aztec/foundation/curves/bn254';
 import { jsonStringify } from '@aztec/foundation/json-rpc';
 
 import { HashedValues } from './hashed_values.js';
@@ -7,5 +10,30 @@ describe('HashedValues', () => {
     const values = HashedValues.random();
     const json = jsonStringify(values);
     await expect(HashedValues.schema.parseAsync(JSON.parse(json))).resolves.toEqual(values);
+  });
+
+  const parseWithValueCount = (count: number) =>
+    HashedValues.schema.parseAsync(
+      JSON.parse(
+        jsonStringify(
+          new HashedValues(
+            times(count, i => new Fr(i)),
+            Fr.ZERO,
+          ),
+        ),
+      ),
+    );
+
+  it('accepts as many values as a tx can spend on calldata', async () => {
+    await expect(parseWithValueCount(MAX_FR_CALLDATA_TO_ALL_ENQUEUED_CALLS)).resolves.toHaveProperty(
+      'values.length',
+      MAX_FR_CALLDATA_TO_ALL_ENQUEUED_CALLS,
+    );
+  });
+
+  it('rejects more values than a tx can spend on calldata', async () => {
+    await expect(parseWithValueCount(MAX_FR_CALLDATA_TO_ALL_ENQUEUED_CALLS + 1)).rejects.toThrow(
+      expect.objectContaining({ name: 'ZodError' }),
+    );
   });
 });

--- a/yarn-project/stdlib/src/tx/hashed_values.ts
+++ b/yarn-project/stdlib/src/tx/hashed_values.ts
@@ -1,4 +1,3 @@
-import { MAX_FR_CALLDATA_TO_ALL_ENQUEUED_CALLS } from '@aztec/constants';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { BufferReader, BufferSink, serializeToSink } from '@aztec/foundation/serialize';
 import type { FieldsOf } from '@aztec/foundation/types';
@@ -29,14 +28,17 @@ export class HashedValues {
   }
 
   static get schema(): ZodFor<HashedValues> {
-    return z
-      .object({
-        // A tx cannot spend more than its whole calldata budget on a single call, and no other caller of this
-        // schema (private args, authwit args) comes close to that many fields.
-        values: z.array(schemas.Fr).max(MAX_FR_CALLDATA_TO_ALL_ENQUEUED_CALLS),
-        hash: schemas.Fr,
-      })
-      .transform(HashedValues.from);
+    return HashedValues.schemaFor();
+  }
+
+  /**
+   * Returns a schema that additionally rejects more than `maxValues` values. The bound belongs to the caller
+   * rather than to this class: the same container carries public calldata, private call arguments and authwit
+   * arguments, and those have different limits.
+   */
+  static schemaFor(maxValues?: number): ZodFor<HashedValues> {
+    const values = maxValues === undefined ? z.array(schemas.Fr) : z.array(schemas.Fr).max(maxValues);
+    return z.object({ values, hash: schemas.Fr }).transform(HashedValues.from);
   }
 
   static from(fields: FieldsOf<HashedValues>): HashedValues {

--- a/yarn-project/stdlib/src/tx/hashed_values.ts
+++ b/yarn-project/stdlib/src/tx/hashed_values.ts
@@ -1,3 +1,4 @@
+import { MAX_FR_CALLDATA_TO_ALL_ENQUEUED_CALLS } from '@aztec/constants';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { BufferReader, BufferSink, serializeToSink } from '@aztec/foundation/serialize';
 import type { FieldsOf } from '@aztec/foundation/types';
@@ -30,7 +31,9 @@ export class HashedValues {
   static get schema(): ZodFor<HashedValues> {
     return z
       .object({
-        values: z.array(schemas.Fr),
+        // A tx cannot spend more than its whole calldata budget on a single call, and no other caller of this
+        // schema (private args, authwit args) comes close to that many fields.
+        values: z.array(schemas.Fr).max(MAX_FR_CALLDATA_TO_ALL_ENQUEUED_CALLS),
         hash: schemas.Fr,
       })
       .transform(HashedValues.from);

--- a/yarn-project/stdlib/src/tx/tx.test.ts
+++ b/yarn-project/stdlib/src/tx/tx.test.ts
@@ -1,4 +1,8 @@
-import { PRIVATE_LOG_SIZE_IN_FIELDS } from '@aztec/constants';
+import {
+  MAX_CONTRACT_CLASS_LOGS_PER_TX,
+  MAX_FR_CALLDATA_TO_ALL_ENQUEUED_CALLS,
+  PRIVATE_LOG_SIZE_IN_FIELDS,
+} from '@aztec/constants';
 import { makeTuple } from '@aztec/foundation/array';
 import { times } from '@aztec/foundation/collection';
 import { randomBytes } from '@aztec/foundation/crypto/random';
@@ -13,7 +17,7 @@ import { ContractClassLogFields } from '../logs/contract_class_log.js';
 import { PrivateLog } from '../logs/private_log.js';
 import { L2ToL1Message, ScopedL2ToL1Message } from '../messaging/l2_to_l1_message.js';
 import { mockTx } from '../tests/mocks.js';
-import { MAX_CONTRACT_CLASS_LOG_FIELDS_PER_TX, MAX_PUBLIC_FUNCTION_CALLDATA_PER_TX, Tx, TxArray } from './tx.js';
+import { MAX_PUBLIC_FUNCTION_CALLDATA_PER_TX, Tx, TxArray } from './tx.js';
 
 describe('Tx', () => {
   it('convert to and from buffer', async () => {
@@ -60,15 +64,23 @@ describe('Tx', () => {
       );
     });
 
-    it('accepts contract class logs from both accumulated data sets', async () => {
-      const tx = await parseWithArray('contractClassLogFields', MAX_CONTRACT_CLASS_LOG_FIELDS_PER_TX);
-      expect(tx.contractClassLogFields).toHaveLength(MAX_CONTRACT_CLASS_LOG_FIELDS_PER_TX);
+    it('accepts as many contract class logs as a tx can accumulate', async () => {
+      const tx = await parseWithArray('contractClassLogFields', MAX_CONTRACT_CLASS_LOGS_PER_TX);
+      expect(tx.contractClassLogFields).toHaveLength(MAX_CONTRACT_CLASS_LOGS_PER_TX);
     });
 
     it('rejects more contract class logs than a tx can accumulate', async () => {
-      await expect(parseWithArray('contractClassLogFields', MAX_CONTRACT_CLASS_LOG_FIELDS_PER_TX + 1)).rejects.toThrow(
+      await expect(parseWithArray('contractClassLogFields', MAX_CONTRACT_CLASS_LOGS_PER_TX + 1)).rejects.toThrow(
         expect.objectContaining({ name: 'ZodError' }),
       );
+    });
+
+    it('rejects a calldata entry with more fields than a tx can spend on calldata', async () => {
+      const json = JSON.parse(jsonStringify(await mockTx()));
+      json.publicFunctionCalldata[0].values = times(MAX_FR_CALLDATA_TO_ALL_ENQUEUED_CALLS + 1, () =>
+        Fr.ZERO.toString(),
+      );
+      await expect(Tx.schema.parseAsync(json)).rejects.toThrow(expect.objectContaining({ name: 'ZodError' }));
     });
   });
 

--- a/yarn-project/stdlib/src/tx/tx.test.ts
+++ b/yarn-project/stdlib/src/tx/tx.test.ts
@@ -1,5 +1,6 @@
 import { PRIVATE_LOG_SIZE_IN_FIELDS } from '@aztec/constants';
 import { makeTuple } from '@aztec/foundation/array';
+import { times } from '@aztec/foundation/collection';
 import { randomBytes } from '@aztec/foundation/crypto/random';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { EthAddress } from '@aztec/foundation/eth-address';
@@ -8,10 +9,11 @@ import { jsonStringify } from '@aztec/foundation/json-rpc';
 import { AztecAddress } from '../aztec-address/index.js';
 import { LogHash, ScopedLogHash } from '../kernel/log_hash.js';
 import { PrivateKernelTailCircuitPublicInputs } from '../kernel/private_kernel_tail_circuit_public_inputs.js';
+import { ContractClassLogFields } from '../logs/contract_class_log.js';
 import { PrivateLog } from '../logs/private_log.js';
 import { L2ToL1Message, ScopedL2ToL1Message } from '../messaging/l2_to_l1_message.js';
 import { mockTx } from '../tests/mocks.js';
-import { Tx, TxArray } from './tx.js';
+import { MAX_CONTRACT_CLASS_LOG_FIELDS_PER_TX, MAX_PUBLIC_FUNCTION_CALLDATA_PER_TX, Tx, TxArray } from './tx.js';
 
 describe('Tx', () => {
   it('convert to and from buffer', async () => {
@@ -31,6 +33,43 @@ describe('Tx', () => {
     const tx = await mockTx();
     const json = jsonStringify(tx);
     expect(await Tx.schema.parseAsync(JSON.parse(json))).toEqual(tx);
+  });
+
+  describe('schema array limits', () => {
+    // Parses a tx from json after replacing one of its arrays with `count` copies of a valid entry. The
+    // schema recomputes the tx hash and does not cross-check the arrays against the kernel outputs, so the
+    // resulting tx is well-formed as far as parsing is concerned.
+    const parseWithArray = async (field: 'publicFunctionCalldata' | 'contractClassLogFields', count: number) => {
+      const json = JSON.parse(jsonStringify(await mockTx()));
+      const entry =
+        field === 'publicFunctionCalldata'
+          ? json.publicFunctionCalldata[0]
+          : JSON.parse(jsonStringify(ContractClassLogFields.random()));
+      json[field] = times(count, () => entry);
+      return await Tx.schema.parseAsync(json);
+    };
+
+    it('accepts one calldata entry per call a tx can enqueue', async () => {
+      const tx = await parseWithArray('publicFunctionCalldata', MAX_PUBLIC_FUNCTION_CALLDATA_PER_TX);
+      expect(tx.publicFunctionCalldata).toHaveLength(MAX_PUBLIC_FUNCTION_CALLDATA_PER_TX);
+    });
+
+    it('rejects more calldata entries than a tx can enqueue', async () => {
+      await expect(parseWithArray('publicFunctionCalldata', MAX_PUBLIC_FUNCTION_CALLDATA_PER_TX + 1)).rejects.toThrow(
+        expect.objectContaining({ name: 'ZodError' }),
+      );
+    });
+
+    it('accepts contract class logs from both accumulated data sets', async () => {
+      const tx = await parseWithArray('contractClassLogFields', MAX_CONTRACT_CLASS_LOG_FIELDS_PER_TX);
+      expect(tx.contractClassLogFields).toHaveLength(MAX_CONTRACT_CLASS_LOG_FIELDS_PER_TX);
+    });
+
+    it('rejects more contract class logs than a tx can accumulate', async () => {
+      await expect(parseWithArray('contractClassLogFields', MAX_CONTRACT_CLASS_LOG_FIELDS_PER_TX + 1)).rejects.toThrow(
+        expect.objectContaining({ name: 'ZodError' }),
+      );
+    });
   });
 
   describe('getPrivateTxEffectsSizeInFields', () => {

--- a/yarn-project/stdlib/src/tx/tx.ts
+++ b/yarn-project/stdlib/src/tx/tx.ts
@@ -1,4 +1,9 @@
-import { DA_GAS_PER_FIELD, TX_DA_GAS_OVERHEAD } from '@aztec/constants';
+import {
+  DA_GAS_PER_FIELD,
+  MAX_CONTRACT_CLASS_LOGS_PER_TX,
+  MAX_ENQUEUED_CALLS_PER_TX,
+  TX_DA_GAS_OVERHEAD,
+} from '@aztec/constants';
 import { type BaseBuffer32, Buffer32 } from '@aztec/foundation/buffer';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import type { ZodFor } from '@aztec/foundation/schemas';
@@ -32,6 +37,18 @@ import { TxHash } from './tx_hash.js';
 // exceed this still serialize correctly — the sink falls back to its standard doubling growth — just
 // with the existing cost.
 const TX_SINK_PRESIZE_BYTES = 131072;
+
+/**
+ * Upper bound on the calldata entries a tx can carry: one per enqueued call, and a tx can fill both the
+ * revertible and non-revertible call request arrays plus a teardown call.
+ */
+export const MAX_PUBLIC_FUNCTION_CALLDATA_PER_TX = 2 * MAX_ENQUEUED_CALLS_PER_TX + 1;
+
+/**
+ * Upper bound on the contract class logs a tx can carry. Log hashes are accumulated in both the revertible
+ * and non-revertible accumulated data, and the fields of each are carried alongside the tx.
+ */
+export const MAX_CONTRACT_CLASS_LOG_FIELDS_PER_TX = 2 * MAX_CONTRACT_CLASS_LOGS_PER_TX;
 
 /**
  * The interface of an L2 transaction.
@@ -172,8 +189,8 @@ export class Tx extends Gossipable {
       .object({
         data: PrivateKernelTailCircuitPublicInputs.schema,
         chonkProof: ChonkProof.schema,
-        contractClassLogFields: z.array(ContractClassLogFields.schema),
-        publicFunctionCalldata: z.array(HashedValues.schema),
+        contractClassLogFields: z.array(ContractClassLogFields.schema).max(MAX_CONTRACT_CLASS_LOG_FIELDS_PER_TX),
+        publicFunctionCalldata: z.array(HashedValues.schema).max(MAX_PUBLIC_FUNCTION_CALLDATA_PER_TX),
       })
       .transform(Tx.create);
   }

--- a/yarn-project/stdlib/src/tx/tx.ts
+++ b/yarn-project/stdlib/src/tx/tx.ts
@@ -2,6 +2,7 @@ import {
   DA_GAS_PER_FIELD,
   MAX_CONTRACT_CLASS_LOGS_PER_TX,
   MAX_ENQUEUED_CALLS_PER_TX,
+  MAX_FR_CALLDATA_TO_ALL_ENQUEUED_CALLS,
   TX_DA_GAS_OVERHEAD,
 } from '@aztec/constants';
 import { type BaseBuffer32, Buffer32 } from '@aztec/foundation/buffer';
@@ -39,16 +40,12 @@ import { TxHash } from './tx_hash.js';
 const TX_SINK_PRESIZE_BYTES = 131072;
 
 /**
- * Upper bound on the calldata entries a tx can carry: one per enqueued call, and a tx can fill both the
- * revertible and non-revertible call request arrays plus a teardown call.
+ * Upper bound on the calldata entries a tx can carry: one per enqueued call, plus one for the teardown call.
+ * The revertible and non-revertible call request arrays are each sized `MAX_ENQUEUED_CALLS_PER_TX`, but the
+ * private tail circuit fills them by partitioning a single array of that size, so their lengths sum to it. The
+ * teardown request is propagated separately and can only be set once.
  */
-export const MAX_PUBLIC_FUNCTION_CALLDATA_PER_TX = 2 * MAX_ENQUEUED_CALLS_PER_TX + 1;
-
-/**
- * Upper bound on the contract class logs a tx can carry. Log hashes are accumulated in both the revertible
- * and non-revertible accumulated data, and the fields of each are carried alongside the tx.
- */
-export const MAX_CONTRACT_CLASS_LOG_FIELDS_PER_TX = 2 * MAX_CONTRACT_CLASS_LOGS_PER_TX;
+export const MAX_PUBLIC_FUNCTION_CALLDATA_PER_TX = MAX_ENQUEUED_CALLS_PER_TX + 1;
 
 /**
  * The interface of an L2 transaction.
@@ -189,8 +186,10 @@ export class Tx extends Gossipable {
       .object({
         data: PrivateKernelTailCircuitPublicInputs.schema,
         chonkProof: ChonkProof.schema,
-        contractClassLogFields: z.array(ContractClassLogFields.schema).max(MAX_CONTRACT_CLASS_LOG_FIELDS_PER_TX),
-        publicFunctionCalldata: z.array(HashedValues.schema).max(MAX_PUBLIC_FUNCTION_CALLDATA_PER_TX),
+        contractClassLogFields: z.array(ContractClassLogFields.schema).max(MAX_CONTRACT_CLASS_LOGS_PER_TX),
+        publicFunctionCalldata: z
+          .array(HashedValues.schemaFor(MAX_FR_CALLDATA_TO_ALL_ENQUEUED_CALLS))
+          .max(MAX_PUBLIC_FUNCTION_CALLDATA_PER_TX),
       })
       .transform(Tx.create);
   }


### PR DESCRIPTION
## Context

`Tx.schema` accepted `contractClassLogFields` and `publicFunctionCalldata` arrays of any length, and
the `HashedValues.schema` those calldata entries are built from accepted any number of values. Three
unauthenticated node RPC methods take a full tx — `sendTx`, `isValidTx` and `simulatePublicCalls` —
so until now the only thing bounding those arrays at the RPC boundary was `RPC_MAX_BODY_SIZE`. A
caller could post a tx whose calldata array is orders of magnitude larger than any real tx, and the
node would deserialize all of it and compute the tx hash before protocol-level validation rejected
it.

Follow-up to #25026, which capped simulation overrides and checkpoint-data range queries.

## Approach

Each array is capped at what the protocol can actually produce:

- `publicFunctionCalldata` → `MAX_ENQUEUED_CALLS_PER_TX + 1` (33). One entry per enqueued call, plus
  the teardown call. `MAX_ENQUEUED_CALLS_PER_TX` is a whole-tx bound rather than a per-phase one: the
  revertible and non-revertible call request arrays are each sized `MAX_ENQUEUED_CALLS_PER_TX` in the
  circuit ABI, but `split_to_public` in the private tail fills them by *partitioning* a single
  `ClaimedLengthArray<_, MAX_ENQUEUED_CALLS_PER_TX>`, so their lengths sum to 32 rather than reaching
  it each. The teardown request is a separate field that "can only be set once", hence the `+ 1`.
  `mockTx` with its defaults and a teardown call produces exactly 33.
- `contractClassLogFields` → `MAX_CONTRACT_CLASS_LOGS_PER_TX` (1). Same partitioning argument:
  `getNonEmptyContractClassLogsHashes` concatenates both accumulated data sets, but they are filled
  from one array of that size.
- The fields within a calldata entry → `MAX_FR_CALLDATA_TO_ALL_ENQUEUED_CALLS` (16000). A tx cannot
  spend more than its whole calldata budget on a single call. That also clears every producer by a
  wide margin: the largest payload the client builds is packed bytecode for a contract class
  publication, bounded by `MAX_PACKED_PUBLIC_BYTECODE_SIZE_IN_FIELDS` (3000).

The last of those is applied through a new `HashedValues.schemaFor(maxValues)` rather than baked into
`HashedValues.schema`, because that schema is shared with `TxExecutionRequest.argsOfCalls`,
`PrivateExecutionResult` and the wallet's `extraHashedArgs` — a public calldata budget is not the
right bound for private call arguments or authwit arguments. `Tx.schema` is the only caller that opts
in.

## Note for reviewers

`Tx.schema` is also used to deserialize txs from the tx file store, so an over-tight bound would
reject previously-valid stored data rather than just bad RPC input. The values above are protocol
ceilings, so stored and gossiped txs stay parseable; the only behavior change is that a tx exceeding
them is now rejected while parsing instead of later, by `DataTxValidator`. Note that gossip and the
reqresp protocols go through `Tx.fromBuffer`, not the schema, so validator coverage there is
unchanged.

Fixes A-1527