### PR TITLE
fix(txe): authorize sync_state utility calls in inlined contexts

### DIFF
--- a/noir-projects/labs/noir-contracts/contracts/test/nested_utility_contract/src/main.nr
+++ b/noir-projects/labs/noir-contracts/contracts/test/nested_utility_contract/src/main.nr
@@ -1,12 +1,27 @@
 // Demonstrates nested utility calls by implementing pow_utility(x, n) = x^n recursively,
 // and calling it from a private function via pow_private.
+//
+// A custom sync_state hook additionally makes a cross-contract utility call to the instance stored in the
+// sync-target capsule (when one is set), so tests can cover authorization of utility calls made during
+// contract sync.
 
-use aztec::macros::aztec;
+use aztec::{
+    macros::{aztec, AztecConfig},
+    messages::{
+        discovery::{ComputeNoteHash, ComputeNoteNullifier, CustomMessageHandler, do_sync_state},
+        processing::offchain::OffchainInboxSync,
+    },
+    oracle::{call_utility_function::call_utility_function, capsules},
+    protocol::{address::AztecAddress, hash::sha256_to_field},
+};
 
 mod pow_note;
 mod test;
 
-#[aztec]
+global SYNC_UTILITY_TARGET_SLOT: Field = sha256_to_field("SYNC_UTILITY_TARGET".as_bytes());
+global SYNC_CALL_RESULT_SLOT: Field = sha256_to_field("SYNC_CALL_RESULT".as_bytes());
+
+#[aztec(AztecConfig::new().custom_sync_state(sync_with_cross_contract_utility_call))]
 pub contract NestedUtility {
     use crate::pow_note::PowNote;
     use aztec::macros::{functions::{external, view}, storage::storage};
@@ -96,4 +111,35 @@ pub contract NestedUtility {
             self.utility.call(NestedUtility::at(target).pow_utility(x, n))
         }
     }
+}
+
+/// Calls `pow_utility` on the instance stored in the sync-target capsule (when one is set), recording the result in
+/// the sync-call-result capsule, then forwards to [`do_sync_state`] so that normal note discovery still happens.
+unconstrained fn sync_with_cross_contract_utility_call(
+    contract_address: AztecAddress,
+    compute_note_hash: ComputeNoteHash,
+    compute_note_nullifier: ComputeNoteNullifier,
+    process_custom_message: Option<CustomMessageHandler>,
+    offchain_inbox_sync: Option<OffchainInboxSync>,
+    scope: AztecAddress,
+) {
+    let maybe_target: Option<AztecAddress> = capsules::load(contract_address, SYNC_UTILITY_TARGET_SLOT, scope);
+    if maybe_target.is_some() {
+        let call = NestedUtility::at(maybe_target.unwrap()).pow_utility(2, 3);
+        let return_values: [Field; 1] = call_utility_function(call.target_contract, call.selector, call.args);
+        capsules::store(
+            contract_address,
+            SYNC_CALL_RESULT_SLOT,
+            return_values[0],
+            scope,
+        );
+    }
+    do_sync_state(
+        contract_address,
+        compute_note_hash,
+        compute_note_nullifier,
+        process_custom_message,
+        offchain_inbox_sync,
+        scope,
+    );
 }

--- a/noir-projects/labs/noir-contracts/contracts/test/nested_utility_contract/src/test.nr
+++ b/noir-projects/labs/noir-contracts/contracts/test/nested_utility_contract/src/test.nr
@@ -1,5 +1,6 @@
-use crate::NestedUtility;
+use crate::{NestedUtility, SYNC_CALL_RESULT_SLOT, SYNC_UTILITY_TARGET_SLOT};
 use aztec::{
+    oracle::{call_utility_function::call_utility_function, capsules},
     protocol::{address::AztecAddress, traits::FromField},
     test::helpers::test_environment::{
         CallPrivateOptions, ExecuteUtilityOptions, TestEnvironment, TestEnvironmentOptions, ViewPrivateOptions,
@@ -18,6 +19,39 @@ unconstrained fn setup_with_opts(
     let addr_a = env.deploy("NestedUtility").without_initializer();
     let addr_b = env.deploy("NestedUtility").without_initializer();
     (env, account, addr_a, addr_b)
+}
+
+/// Seeds `sync_caller`'s sync-target capsule with `sync_call_target`, so that syncing `sync_caller` makes it call
+/// `sync_call_target`'s `pow_utility`.
+unconstrained fn setup_with_sync_call_target(
+    options: TestEnvironmentOptions,
+) -> (TestEnvironment, AztecAddress, AztecAddress, AztecAddress) {
+    let (env, account, sync_caller, sync_call_target) = setup_with_opts(options);
+    env.utility_context_at(sync_caller, |_context| {
+        capsules::store(
+            sync_caller,
+            SYNC_UTILITY_TARGET_SLOT,
+            sync_call_target,
+            account,
+        );
+    });
+    (env, account, sync_caller, sync_call_target)
+}
+
+/// Makes a cross-contract utility call to `pow_utility` on `target`, forcing `target` to be synced first.
+unconstrained fn call_pow_on(target: AztecAddress) -> Field {
+    let call = NestedUtility::at(target).pow_utility(2, 10);
+    let return_values: [Field; 1] = call_utility_function(call.target_contract, call.selector, call.args);
+    return_values[0]
+}
+
+/// Returns the result recorded by `sync_caller`'s sync hook after its cross-contract call, or none if it never ran.
+unconstrained fn read_sync_call_result(
+    env: TestEnvironment,
+    sync_caller: AztecAddress,
+    scope: AztecAddress,
+) -> Option<Field> {
+    env.utility_context_at(sync_caller, |_context| capsules::load(sync_caller, SYNC_CALL_RESULT_SLOT, scope))
 }
 
 #[test]
@@ -109,6 +143,35 @@ unconstrained fn all_call_types_succeed_with_all_utility_call_targets_authorized
 
     let view_result = env.view_private(account, NestedUtility::at(addr_a).delegate_pow_view(addr_b, 2, 3));
     assert_eq(view_result, 8);
+}
+
+#[test]
+unconstrained fn sync_state_call_succeeds_in_utility_context_with_all_utility_call_targets_authorized() {
+    let (env, account, sync_caller, sync_call_target) = setup_with_sync_call_target(TestEnvironmentOptions::new()
+        .with_all_utility_call_targets_authorized());
+
+    let result = env.utility_context_at(sync_call_target, |_context| call_pow_on(sync_caller));
+
+    assert_eq(result, 1024);
+    assert_eq(read_sync_call_result(env, sync_caller, account), Option::some(8));
+}
+
+#[test]
+unconstrained fn sync_state_call_succeeds_in_private_context_with_all_utility_call_targets_authorized() {
+    let (env, account, sync_caller, sync_call_target) = setup_with_sync_call_target(TestEnvironmentOptions::new()
+        .with_all_utility_call_targets_authorized());
+
+    let result = env.private_context_at(sync_call_target, |_context| call_pow_on(sync_caller));
+
+    assert_eq(result, 1024);
+    assert_eq(read_sync_call_result(env, sync_caller, account), Option::some(8));
+}
+
+#[test(should_fail_with = "Cross-contract utility call denied")]
+unconstrained fn sync_state_call_denied_by_default() {
+    let (env, _, sync_caller, sync_call_target) = setup_with_sync_call_target(TestEnvironmentOptions::new());
+
+    let _ = env.utility_context_at(sync_call_target, |_context| call_pow_on(sync_caller));
 }
 
 #[test]

--- a/yarn-project/txe/src/rpc_translator.ts
+++ b/yarn-project/txe/src/rpc_translator.ts
@@ -912,6 +912,16 @@ export class RPCTranslator {
     });
   }
 
+  // eslint-disable-next-line camelcase
+  aztec_utl_callUtilityFunction(...inputs: ForeignCallArgs) {
+    return callTxeHandler({
+      oracle: 'aztec_utl_callUtilityFunction',
+      inputs,
+      handler: ([contractAddress, functionSelector, args]) =>
+        this.handlerAsUtility().callUtilityFunction(contractAddress, functionSelector, args),
+    });
+  }
+
   // AVM opcodes
 
   // eslint-disable-next-line camelcase

--- a/yarn-project/txe/src/txe_session.ts
+++ b/yarn-project/txe/src/txe_session.ts
@@ -780,10 +780,7 @@ export class TXESession implements TXESessionStateHandler {
       scopes: await this.keyStore.getAccounts(),
       txResolver: this.stateMachine.txResolver,
       simulator: new WASMSimulator(),
-      hooks: composeHooks({
-        resolveTaggingSecretStrategy: makeResolveTaggingSecretStrategyHook(this.taggingSecretStrategies),
-        authorizeUtilityCall: this.authorizeAllUtilityCallTargets ? authorizeAllUtilityCallsHook : undefined,
-      }),
+      hooks: this.buildExecutionHooks(),
       transientArrayService,
     });
 
@@ -883,9 +880,7 @@ export class TXESession implements TXESessionStateHandler {
       scopes: await this.keyStore.getAccounts(),
       simulator: new WASMSimulator(),
       utilityExecutor: this.utilityExecutorForContractSync(anchorBlockHeader),
-      hooks: composeHooks({
-        authorizeUtilityCall: this.authorizeAllUtilityCallTargets ? authorizeAllUtilityCallsHook : undefined,
-      }),
+      hooks: this.buildExecutionHooks(),
       // Execution-tree root (top-level utility run): own store; nested frames inherit it.
       transientArrayService: new TransientArrayService(),
     });
@@ -1013,6 +1008,7 @@ export class TXESession implements TXESessionStateHandler {
           scopes,
           simulator,
           utilityExecutor: this.utilityExecutorForContractSync(anchorBlock),
+          hooks: this.buildExecutionHooks(),
           // Top-level utility entrypoint: gets a fresh store. Nested frames inherit it via UtilityExecutionOracle.
           transientArrayService: new TransientArrayService(),
         });
@@ -1034,5 +1030,13 @@ export class TXESession implements TXESessionStateHandler {
         throw createSimulationError(err instanceof Error ? err : new Error('Unknown error contract data sync'));
       }
     };
+  }
+
+  /** Execution hooks for the oracles this session builds. Every oracle construction site must use this. */
+  private buildExecutionHooks() {
+    return composeHooks({
+      resolveTaggingSecretStrategy: makeResolveTaggingSecretStrategyHook(this.taggingSecretStrategies),
+      authorizeUtilityCall: this.authorizeAllUtilityCallTargets ? authorizeAllUtilityCallsHook : undefined,
+    });
   }
 }


### PR DESCRIPTION
## Problem

`TestEnvironmentOptions::with_all_utility_call_targets_authorized()` did not apply to utility calls made from a contract's `sync_state`: the TXE session's contract-sync executor built its `UtilityExecutionOracle` without the `hooks` object carrying the authorization callback, so any cross-contract utility call made during sync was denied with "No authorizeUtilityCall hook configured" regardless of the option. The other oracle construction sites (top-level flows and the inlined contexts' own oracles) passed the hook correctly.

The scenario was also unreachable from inlined contexts: the RPC translator never implemented `aztec_utl_callUtilityFunction`, so a cross-contract utility call from `env.private_context` / `env.utility_context` failed with "Unknown oracle" (an error TXE itself flags as "unexpected, please report it").

## Fix

- Add the missing `aztec_utl_callUtilityFunction` method to TXE's RPC translator, so inlined contexts support cross-contract utility calls.
- Factor a `buildExecutionHooks()` helper on `TXESession` and use it at every oracle construction site, including the contract-sync executor, so session options apply on all execution paths.
- Cover it with a capsule-gated `custom_sync_state` hook on `NestedUtility` that records its cross-contract call's result, plus tests for sync-time calls from both inlined contexts (authorized and default-denied).