### PR TITLE
fix(pxe): validate a BoundedVec against its storage array on deserialization

### DIFF
--- a/yarn-project/pxe/src/contract_function_simulator/oracle/oracle_type_mappings.test.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/oracle_type_mappings.test.ts
@@ -227,6 +227,22 @@ describe('oracle type mappings', () => {
       );
     });
 
+    it('rejects a length beyond the storage array capacity', () => {
+      const storage = new FieldReader([new Fr(1), new Fr(2)]);
+      const length = new FieldReader([new Fr(3)]);
+      expect(() => BOUNDED_VEC(FIELD).deserialization!.fn([storage, length])).toThrow(
+        'length 3 exceeds the 2 element(s) its storage array holds',
+      );
+    });
+
+    it('rejects a storage array that is not a whole number of elements', () => {
+      const storage = new FieldReader([new Fr(1), new Fr(2), new Fr(3)]);
+      const length = new FieldReader([new Fr(1)]);
+      expect(() => BOUNDED_VEC(POINT).deserialization!.fn([storage, length])).toThrow(
+        'storage array holds 3 field(s), which is not a whole number of 2-field elements',
+      );
+    });
+
     it('reads two input slots', () => {
       expect(slotsOf(BOUNDED_VEC(FIELD))).toBe(2); // storage + length
     });

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/oracle_type_mappings.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/oracle_type_mappings.ts
@@ -712,8 +712,23 @@ export function BOUNDED_VEC<T>(inner: TypeMapping<T>): BoundedVecMapping<T> {
           fn: ([storageReader, lengthReader]) => {
             // slot 0 is the padded storage, slot 1 the actual length. Parse only the first `length` elements out of
             // storage, then drain the trailing zero-padding so the storage reader is fully consumed.
-            const maxLength = storageReader.remainingFields() / fieldWidth(inner.shape);
+            const elementWidth = fieldWidth(inner.shape);
+            const storageFields = storageReader.remainingFields();
+            if (storageFields % elementWidth !== 0) {
+              throw new Error(
+                `Malformed BoundedVec: storage array holds ${storageFields} field(s), which is not a whole number of ` +
+                  `${elementWidth}-field elements`,
+              );
+            }
+            // The BoundedVec's maximum length is determined by the size of the storage array, so its length is bounded
+            // by it.
+            const maxLength = storageFields / elementWidth;
             const length = lengthReader.readField().toNumber();
+            if (length > maxLength) {
+              throw new Error(
+                `Malformed BoundedVec: length ${length} exceeds the ${maxLength} element(s) its storage array holds`,
+              );
+            }
             const elements = unpackElements(inner, storageReader, length);
             storageReader.skip(storageReader.remainingFields());
             return BoundedVec.from<T>({ data: elements, maxLength });


### PR DESCRIPTION
This just catches a misconstructred oracle call.