### PR TITLE
feat: labs repo downloads aztec toolchain

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ Dependencies flow barretenberg → noir → l1-contracts → yarn-project. From 
 
 When a change spans multiple components, rebuild in dependency order: first `barretenberg/cpp/` with `cmake --preset default && cd build && ninja`, then `barretenberg/ts/` with `./bootstrap.sh` (which generates TS bindings from C++), then `noir/` with `./bootstrap.sh` if noir changes are needed, then `noir-projects/` to compile contracts, then `l1-contracts/` with `forge build`, and finally `yarn-project/` with `yarn build` from inside `yarn-project/` (not the git root).
 
-The noir-projects build scripts default `$NARGO` to `noir/noir-repo/target/release/nargo`. Do not override this with a globally installed nargo — version mismatches produce opaque bytecode failures in downstream components.
+The noir-projects build scripts default `$NARGO` per side: `noir-projects/fnd/**` uses the submodule build at `noir/noir-repo/target/release/nargo`, while `noir-projects/labs/**` uses `labs-aztec-toolchain/bin/nargo`, which is provisioned from the versions pinned in `labs-aztec-toolchain/bootstrap.sh`. Do not override either with a globally installed nargo — version mismatches produce opaque bytecode failures in downstream components.
 </build_system>
 
 <bumping_noir>

--- a/Makefile
+++ b/Makefile
@@ -360,8 +360,7 @@ labs-aztec-toolchain:
 
 # If we are running on the monorepo, we need to additionally depend on targets
 # that generate/place the binaries.
-# TODO(fcarreiro): comment this out when pinning binaries.
-labs-aztec-toolchain: noir bb-cpp-native
+# labs-aztec-toolchain: noir bb-cpp-native
 
 #==============================================================================
 # Noir Projects
@@ -383,7 +382,7 @@ noir-projects-labs-format-check: labs-aztec-toolchain
 
 # The fnd and labs checks share the nargo dependency cache, so on the monorepo they are
 # serialized (labs after fnd) rather than allowed to run in parallel.
-# TODO(fcarreiro): comment this out when pinning binaries.
+# TODO(fcarreiro): comment this out when we don't build fnd components anymore.
 noir-projects-labs-format-check: noir-projects-fnd-format-check
 
 noir-protocol-circuits: noir bb-cpp-native noir-projects-fnd-format-check

--- a/labs-aztec-toolchain/README.md
+++ b/labs-aztec-toolchain/README.md
@@ -1,1 +1,5 @@
-Toolchain to process contracts, etc. Points to BB, nargo.
+Owns where the binaries labs components build with come from, so those components work the same in the monorepo and in a split labs repo.
+
+`bootstrap.sh` pins a bb and a noir version and provisions `bin/`: `bb` via bbup, `nargo`/`noir-profiler` via noirup, `bb-avm` from its own release artifact (amd64 linux only), and `acvm` compiled from the noir release source, since nothing publishes it. `bin/.pin` records what was installed and is what makes a re-run incremental.
+
+Consumers take `NARGO`/`BB` from `bin/`, the toolchain identity from `bootstrap.sh hash` (for cache keys), and the pinned noir version from `bootstrap.sh noir_version`.

--- a/labs-aztec-toolchain/bootstrap.sh
+++ b/labs-aztec-toolchain/bootstrap.sh
@@ -1,13 +1,38 @@
 #!/usr/bin/env bash
 source $(git rev-parse --show-toplevel)/ci3/source_bootstrap
 
-ROOT=$(git rev-parse --show-toplevel)
 TARGET_DIR=bin
 BB_BINARY=bb
 BB_AVM_BINARY=bb-avm
 NARGO_BINARY=nargo
-NOIR_PROFILER_BINARY=noir-profiler
 ACVM_BINARY=acvm
+NOIR_PROFILER_BINARY=noir-profiler
+# Records what was provisioned into TARGET_DIR (written by both build flows).
+# Needed because the binaries alone cannot answer "which release is this":
+# nargo only reports its base cargo version, never the nightly/release tag.
+PIN_FILE=$TARGET_DIR/.pin
+
+# Pinned versions installed in the labs repo (see build_labs).
+# The monorepo links the locally built binaries instead.
+# Note that BB is downloaded from the AztecProtocol/barretenberg mirror first (via bbup).
+BB_VERSION=6.0.0-nightly.20260729
+NOIR_VERSION=1.0.0-beta.25
+# The installers and sources are fetched at build time; overridable for testing/mirroring.
+BBUP_URL=${BBUP_URL:-https://raw.githubusercontent.com/AztecProtocol/aztec-packages/86f69c8751f63ca604a1dab5967f208b211a1611/barretenberg/bbup/bbup}
+NOIRUP_URL=${NOIRUP_URL:-https://raw.githubusercontent.com/noir-lang/noirup/324a51fca2c410d2477400316efc5ce0d743a5b3/noirup}
+# bbup's artifact name is hardcoded to the plain bb, so the AVM-enabled build is taken
+# straight from the release. The URLs are tried in order: the barretenberg mirror, which
+# bb is also published to first, then aztec-packages.
+BB_AVM_ARTIFACT=barretenberg-avm-amd64-linux.tar.gz
+BB_AVM_URLS=${BB_AVM_URLS:-"
+  https://github.com/AztecProtocol/barretenberg/releases/download/v$BB_VERSION/$BB_AVM_ARTIFACT
+  https://github.com/AztecProtocol/aztec-packages/releases/download/v$BB_VERSION/$BB_AVM_ARTIFACT
+"}
+# No noir release ships acvm and acvm_cli is not published to crates.io, so it is compiled
+# from the release source tree. Noir tags releases "v<semver>" and nightlies unprefixed.
+NOIR_TAG=$NOIR_VERSION
+[[ $NOIR_TAG == nightly-* ]] || NOIR_TAG=v$NOIR_TAG
+NOIR_SOURCE_URL=${NOIR_SOURCE_URL:-https://github.com/noir-lang/noir/archive/refs/tags/$NOIR_TAG.tar.gz}
 
 function link_tool {
   local full_path=$1
@@ -18,11 +43,15 @@ function link_tool {
   echo "Created symlink: $TARGET_DIR/$name -> $full_path"
 }
 
+# Keeping this function in case it's useful for the foundation.
 function build_monorepo {
   echo "Setting up labs' aztec toolchain..."
-  local bb_full_path="$ROOT/barretenberg/cpp/build/bin/$BB_BINARY"
-  local nargo_full_path="$ROOT/noir/noir-repo/target/release/$NARGO_BINARY"
-  local noir_profiler_full_path="$ROOT/noir/noir-repo/target/release/$NOIR_PROFILER_BINARY"
+  # Can be overridden by caller.
+  MONOREPO_ROOT=${MONOREPO_ROOT:-$(git rev-parse --show-toplevel)}
+
+  local bb_full_path="$MONOREPO_ROOT/barretenberg/cpp/build/bin/$BB_BINARY"
+  local nargo_full_path="$MONOREPO_ROOT/noir/noir-repo/target/release/$NARGO_BINARY"
+  local noir_profiler_full_path="$MONOREPO_ROOT/noir/noir-repo/target/release/$NOIR_PROFILER_BINARY"
 
   if [ ! -f $bb_full_path ] || [ ! -f $nargo_full_path ] || [ ! -f $noir_profiler_full_path ]; then
     echo_stderr "Required binaries not found, exiting."
@@ -32,6 +61,7 @@ function build_monorepo {
     exit 1
   fi
 
+  clean
   mkdir -p "$TARGET_DIR"
   link_tool "$bb_full_path" "$BB_BINARY"
   link_tool "$nargo_full_path" "$NARGO_BINARY"
@@ -42,22 +72,250 @@ function build_monorepo {
   # absent binary fails at the point of use.
   local optional_path
   for optional_path in \
-    "$ROOT/barretenberg/cpp/build/bin/$BB_AVM_BINARY" \
-    "$ROOT/noir/noir-repo/target/release/$ACVM_BINARY"; do
+    "$MONOREPO_ROOT/barretenberg/cpp/build/bin/$BB_AVM_BINARY" \
+    "$MONOREPO_ROOT/noir/noir-repo/target/release/$ACVM_BINARY"; do
     if [ -f "$optional_path" ]; then
       link_tool "$optional_path" "$(basename "$optional_path")"
     fi
   done
 
+  # Record the full noir version: the exact tag when the submodule sits on one,
+  # otherwise the binary's base version (a bare commit is not installable, so
+  # it is not a useful record). Tags may be missing in shallow CI checkouts.
+  git -C "$MONOREPO_ROOT/noir/noir-repo" fetch --tags --quiet 2>/dev/null || true
+  local noir_full_version
+  if ! noir_full_version=$(git -C "$MONOREPO_ROOT/noir/noir-repo" describe --tags --exact-match HEAD 2>/dev/null); then
+    noir_full_version=$("$nargo_full_path" --version | sed -n 's/^nargo version = //p')
+  fi
+  {
+    echo "bb=local"
+    echo "noir=$noir_full_version"
+  } > "$PIN_FILE"
+
   echo "Done."
+}
+
+# The pin record ties the provisioned binaries to the pinned versions AND their
+# content hashes: matching versions alone would not detect corrupted or swapped
+# binaries in TARGET_DIR. Hashes are recorded per binary and only for those
+# present, so the absence of an optional binary is part of the record too.
+function labs_pin_record {
+  echo "bb=$BB_VERSION"
+  echo "noir=$NOIR_VERSION"
+  local name
+  for name in "$BB_BINARY" "$BB_AVM_BINARY" "$NARGO_BINARY" "$NOIR_PROFILER_BINARY" "$ACVM_BINARY"; do
+    if [ -f "$TARGET_DIR/$name" ]; then
+      echo "${name}_hash=$(git hash-object "$TARGET_DIR/$name")"
+    fi
+  done
+}
+
+# Reads a key from the pin record; empty when the record or the key is absent.
+function pin_value {
+  sed -n "s/^$1=//p" "$PIN_FILE" 2>/dev/null
+}
+
+# A binary is current when it exists, was provisioned from the release we pin now, and
+# still hashes to what was recorded. A missing file, a moved pin, and a content mismatch
+# (corruption, manual overwrite) all mean it has to be fetched again.
+function is_current {
+  local name=$1 release_key=$2 pinned_version=$3
+  local file=$TARGET_DIR/$name
+  [ -f "$file" ] &&
+    [ "$(pin_value "$release_key")" = "$pinned_version" ] &&
+    [ "$(pin_value "${name}_hash")" = "$(git hash-object "$file")" ]
+}
+
+# Drops a binary that cannot be provisioned on this machine. Whatever put it there (a
+# monorepo-style symlink, a manual copy) is unrelated to what this flow installs, and
+# keeping it would leave the record attesting contents from a different provisioning.
+function drop_unprovisionable {
+  if [ -e "$TARGET_DIR/$1" ]; then
+    echo "Removing $1: cannot be provisioned here, and unrelated to what was just installed."
+    rm -f "$TARGET_DIR/$1"
+  fi
+}
+
+function install_bb {
+  local tmp=$1
+  echo "Installing $BB_BINARY $BB_VERSION via bbup..."
+  curl -fsSL "$BBUP_URL" -o "$tmp/bbup"
+  chmod +x "$tmp/bbup"
+  rm -f "$TARGET_DIR/$BB_BINARY" # Remove the destination first.
+  BB_PATH="$PWD/$TARGET_DIR" "$tmp/bbup" -v "$BB_VERSION" --no-modify-path
+}
+
+# bb-avm is released for amd64 linux only, see build_release_dir in barretenberg/cpp/bootstrap.sh.
+function bb_avm_released_here {
+  [ "$(uname -s)" = "Linux" ] && [ "$(uname -m)" = "x86_64" ]
+}
+
+function install_bb_avm {
+  local tmp=$1
+  local archive=$tmp/$BB_AVM_ARTIFACT
+  echo "Installing $BB_AVM_BINARY $BB_VERSION from release..."
+  local url found=false
+  for url in $BB_AVM_URLS; do
+    if curl -fsSL "$url" -o "$archive"; then
+      found=true
+      break
+    fi
+    echo "Not available at $url."
+  done
+  if ! $found; then
+    echo_stderr "Could not download $BB_AVM_ARTIFACT for v$BB_VERSION from any known release URL."
+    exit 1
+  fi
+  rm -f "$TARGET_DIR/$BB_AVM_BINARY" # Remove the destination first.
+  tar xzf "$archive" -C "$TARGET_DIR" "$BB_AVM_BINARY"
+}
+
+function install_noir {
+  local tmp=$1
+  echo "Installing $NARGO_BINARY/$NOIR_PROFILER_BINARY $NOIR_VERSION via noirup..."
+  curl -fsSL "$NOIRUP_URL" -o "$tmp/noirup"
+  chmod +x "$tmp/noirup"
+  mkdir -p "$tmp/nargo_home/bin"
+  NARGO_HOME="$tmp/nargo_home" "$tmp/noirup" -v "$NOIR_VERSION"
+  rm -f "$TARGET_DIR/$NARGO_BINARY" "$TARGET_DIR/$NOIR_PROFILER_BINARY" # Remove the destinations first.
+  cp -f "$tmp/nargo_home/bin/$NARGO_BINARY" "$TARGET_DIR/$NARGO_BINARY"
+  cp -f "$tmp/nargo_home/bin/$NOIR_PROFILER_BINARY" "$TARGET_DIR/$NOIR_PROFILER_BINARY"
+}
+
+function install_acvm {
+  local tmp=$1
+  local src=$tmp/noir
+  local cargo_home=$tmp/cargo-home
+  local cargo_root=$tmp/cargo-root
+  # The key carries the platform because this is a compiled binary; keys derived from
+  # cache_content_hash get that for free, this one is just the pinned version.
+  local cache_key=labs-acvm-$NOIR_VERSION-$(uname -s | tr '[:upper:]' '[:lower:]')-$(uname -m).zst
+
+  rm -f "$TARGET_DIR/$ACVM_BINARY" # Remove the destination first.
+
+  # A build from scratch takes ~5 minutes: ~1.5 of compiling, the rest fetching the ~330
+  # dependency crates, which the isolated CARGO_HOME below means paying again every time.
+  # Nothing but the pinned noir version and the platform goes into the result (the build is
+  # byte-reproducible, see the path remapping below), so a cached binary is as good as a
+  # fresh one, down to the hash the pin records.
+  if cache_download "$cache_key"; then
+    echo "Restored $ACVM_BINARY $NOIR_VERSION from the build cache."
+    return
+  fi
+
+  echo "Building $ACVM_BINARY $NOIR_VERSION from source (no release ships it)..."
+  mkdir -p "$src"
+  curl -fsSL "$NOIR_SOURCE_URL" | tar xz -C "$src" --strip-components=1
+
+  # Materialise the toolchain before building. rustup installs a missing channel into the
+  # shared RUSTUP_HOME, which the isolated CARGO_HOME below does not cover, and two units
+  # installing the same channel at once make one roll back the other's install, leaving a
+  # toolchain with no cargo in it. This is the lock the repo's other cargo builds take; hold
+  # it only for the install, so the compile itself still runs alongside them.
+  (
+    flock -x 200
+    cd "$src" && cargo --version >/dev/null
+  ) 200>/tmp/rustup.lock
+
+  # Every path cargo writes to lives under $tmp, so the trap that removes $tmp removes the
+  # entire build: CARGO_HOME keeps the fetched crates out of the user's registry cache,
+  # --root keeps the binary and its install manifest out of ~/.cargo/bin, and
+  # CARGO_TARGET_DIR keeps the object files out of the source tree.
+  # The paths are remapped out of the binary because the pin records acvm's content hash
+  # and that hash feeds downstream cache keys: left in, $tmp's random name would make
+  # every build of the same source produce different bytes.
+  # GIT_COMMIT/GIT_DIRTY are what noirc_driver's build script would otherwise read from a
+  # git checkout, which a release tarball is not.
+  # Cargo runs from inside the source tree so rustup picks up noir's rust-toolchain.toml:
+  # the workspace pins an MSRV newer than the cargo many machines have on PATH, and from
+  # anywhere else the build dies on a version mismatch instead.
+  (
+    cd "$src"
+    CARGO_HOME=$cargo_home \
+    CARGO_TARGET_DIR=$tmp/cargo-target \
+    RUSTFLAGS="--remap-path-prefix=$src=/noir --remap-path-prefix=$cargo_home=/cargo" \
+    GIT_COMMIT=$NOIR_TAG \
+    GIT_DIRTY=false \
+    SOURCE_DATE_EPOCH=0 \
+      cargo install --locked --path tooling/acvm_cli --root "$cargo_root"
+  )
+
+  cp -f "$cargo_root/bin/$ACVM_BINARY" "$TARGET_DIR/$ACVM_BINARY"
+  cache_upload "$cache_key" "$TARGET_DIR/$ACVM_BINARY"
 }
 
 function build_labs {
   echo "Setting up labs' aztec toolchain..."
-  # TODO(fcarreiro): Implement.
-  echo_stderr "Not operational yet."
-  exit 1
+  echo "Pinned versions: bb $BB_VERSION, noir $NOIR_VERSION"
+
   mkdir -p "$TARGET_DIR"
+
+  # Every binary is checked on its own, but the flows that provision them are coarser:
+  # bbup and noirup each install their whole release in one shot, so a stale nargo also
+  # refetches noir-profiler, while bb-avm (its own release artifact) and acvm (a source
+  # build) are provisioned individually.
+  local fetch_bb=false fetch_bb_avm=false fetch_noir=false fetch_acvm=false
+  is_current "$BB_BINARY" bb "$BB_VERSION" || fetch_bb=true
+  is_current "$BB_AVM_BINARY" bb "$BB_VERSION" || fetch_bb_avm=true
+  is_current "$NARGO_BINARY" noir "$NOIR_VERSION" || fetch_noir=true
+  is_current "$NOIR_PROFILER_BINARY" noir "$NOIR_VERSION" || fetch_noir=true
+  is_current "$ACVM_BINARY" noir "$NOIR_VERSION" || fetch_acvm=true
+
+  if ! $fetch_bb && ! $fetch_bb_avm && ! $fetch_noir && ! $fetch_acvm; then
+    echo "Toolchain matches pinned versions and hashes, nothing to download."
+    return
+  fi
+
+  local tmp=$(mktemp -d)
+  trap "rm -rf $tmp" EXIT
+
+  if $fetch_bb; then
+    install_bb "$tmp"
+  else
+    echo "$BB_BINARY $BB_VERSION already provisioned."
+  fi
+
+  if $fetch_bb_avm; then
+    if bb_avm_released_here; then
+      install_bb_avm "$tmp"
+    else
+      # Absence is tolerated: its consumers (AVM proving) only run on amd64 linux anyway.
+      echo "Skipping $BB_AVM_BINARY: released for amd64 linux only."
+      drop_unprovisionable "$BB_AVM_BINARY"
+    fi
+  else
+    echo "$BB_AVM_BINARY $BB_VERSION already provisioned."
+  fi
+
+  if $fetch_noir; then
+    install_noir "$tmp"
+  else
+    echo "$NARGO_BINARY/$NOIR_PROFILER_BINARY $NOIR_VERSION already provisioned."
+  fi
+
+  # The record is written before the acvm build, the one step that takes minutes and can
+  # fail on its own (it compiles noir), so a failure there does not cost the downloads that
+  # already succeeded. A stale acvm goes first: the record hashes what is on disk, and an
+  # interrupted run must not leave it attesting contents that are about to be replaced.
+  if $fetch_acvm; then
+    rm -f "$TARGET_DIR/$ACVM_BINARY"
+  fi
+  labs_pin_record > "$PIN_FILE"
+
+  if $fetch_acvm; then
+    if command -v cargo &>/dev/null; then
+      install_acvm "$tmp"
+    else
+      # Absence is tolerated: acvm's consumers fall back to the wasm simulator without it.
+      echo "Skipping $ACVM_BINARY: it has to be built and cargo is not installed."
+      drop_unprovisionable "$ACVM_BINARY"
+    fi
+  else
+    echo "$ACVM_BINARY $NOIR_VERSION already provisioned."
+  fi
+
+  labs_pin_record > "$PIN_FILE"
+  echo "Done."
 }
 
 function clean {
@@ -65,20 +323,20 @@ function clean {
 }
 
 function build {
-  build_monorepo
+  build_labs
 }
 
-# The nargo release version (e.g. "1.0.0-beta.25"), read from the binary itself
-# so it works both on the monorepo and in the labs repo. Note this is the base
-# cargo version: a nargo built from a nightly or arbitrary commit still reports
-# the version of the release it was cut from.
+# The full noir version as recorded at provisioning time (e.g. "1.0.0-beta.25"
+# or "nightly-2026-06-02"), read from the pin record: the binary only reports
+# its base cargo version, which cannot distinguish a nightly from the release
+# it was cut from.
 function noir_version {
-  local nargo="$TARGET_DIR/$NARGO_BINARY"
-  if [ ! -f "$nargo" ]; then
-    echo_stderr "Cannot get noir version, nargo not found (build first): $nargo"
+  local pinned=$(pin_value noir)
+  if [ -z "$pinned" ]; then
+    echo_stderr "Cannot get noir version, no pin record at $PIN_FILE (build first)."
     exit 1
   fi
-  "$nargo" --version | sed -n 's/^nargo version = //p'
+  echo "${pinned#v}"
 }
 
 function hash {
@@ -116,11 +374,6 @@ case "$cmd" in
     ;;
   "hash")
     hash
-    ;;
-  bench|bench_cmds)
-    # Empty handling just to make this command valid.
-    ;;
-  test|test_cmds|test_download)
     ;;
   *)
     default_cmd_handler "$@"

--- a/noir-projects/labs/contract-snapshots/README.md
+++ b/noir-projects/labs/contract-snapshots/README.md
@@ -23,13 +23,13 @@ test_programs/
 
 ### Prerequisites
 
-`nargo` must be built. From the repo root:
+`nargo` must be provisioned. From the repo root:
 
 ```sh
-(cd noir && ./bootstrap.sh)
+(cd labs-aztec-toolchain && ./bootstrap.sh)
 ```
 
-By default the test harness looks for `nargo` at `../../noir/noir-repo/target/release/nargo`. Override with `NARGO=/path/to/nargo cargo test`.
+By default the test harness looks for `nargo` at `../../../labs-aztec-toolchain/bin/nargo`. Override with `NARGO=/path/to/nargo cargo test`.
 
 ### Running
 


### PR DESCRIPTION
Implements the labs-repo side of `labs-aztec-toolchain`: instead of linking locally built binaries, `build_labs` provisions the pinned toolchain from releases. Follows #25047 (merged). With the Makefile dependency on `noir bb-cpp-native` commented out, the monorepo takes the same downloaded toolchain, so `build_monorepo` is now unused — kept in case the foundation side wants it.

Closes https://linear.app/aztec-labs/issue/A-1532/source-bbnargo-from-an-aztec-toolchain-directory-for-labs .

## Provisioning (`build_labs`)

Pins at the top of the script: `BB_VERSION=6.0.0-nightly.20260729` and `NOIR_VERSION=1.0.0-beta.25`. Every source URL is env-overridable (`BBUP_URL`, `NOIRUP_URL`, `BB_AVM_URLS`, `NOIR_SOURCE_URL`) for testing and mirroring, and `NOIR_TAG` covers noir's two tag shapes (`v<semver>` for releases, unprefixed for nightlies).

- **bb** via bbup, curled from `next` at build time and run with `BB_PATH=<toolchain bin>` + `--no-modify-path`.
- **nargo + noir-profiler** via noirup, curled from noir-lang/noirup `main` and run with an isolated `NARGO_HOME` (noir releases ship the profiler next to nargo; no shell config or `~/.nargo` is touched).
- **bb-avm** straight from the release: bbup's artifact name is hardcoded to the plain bb, so this fetches `barretenberg-avm-amd64-linux.tar.gz` itself, barretenberg mirror first and aztec-packages as fallback, matching bbup's order. It is published for amd64 linux only, so elsewhere it is skipped rather than fatal — its consumers (AVM proving) only run there anyway.
- **acvm** compiled from the noir release source tarball, because nothing publishes it: no noir release asset, and `acvm_cli` is not on crates.io.

Every path cargo writes to lives under the run's `mktemp -d` and dies with it — `CARGO_HOME` (so the fetched crates stay out of the user's registry cache), `CARGO_TARGET_DIR`, the `--root` install prefix, and the extracted source. Three details behind that:

- Cargo runs from *inside* the source tree so rustup picks up noir's `rust-toolchain.toml`. From anywhere else the ambient cargo is used, and a cargo older than noir's MSRV fails the build (hit for real with a 1.85 on `PATH`).
- `RUSTFLAGS` remaps the temp paths out of the binary. Left in, the `mktemp` name lands in the executable and every build of the same source produces different bytes, which would poison the pin hash and every downstream cache key derived from `bootstrap.sh hash`.
- `GIT_COMMIT`/`GIT_DIRTY` are passed in because `noirc_driver`'s build script reads them from a git checkout, and a release tarball is not one.

A build from scratch is ~5 minutes (~1.5 compiling, the rest fetching ~330 dependency crates that the isolated `CARGO_HOME` discards), so the built binary goes through the ci3 build cache under `labs-acvm-<noir version>-<platform>`. The key carries the platform explicitly since, unlike keys derived from `cache_content_hash`, it is otherwise just a version.

## Pin record and per-binary staleness

`bin/.pin` records the pinned versions **and a `git hash-object` content hash per binary**, written only for those present — so an optional binary's absence is part of the record too. `is_current <binary> <release key> <version>` then answers for one binary: it exists, the recorded release matches the pin, and the recorded hash matches the actual contents. Matching versions alone would not catch a corrupted or swapped binary.

Checks are per binary, feeding install flows that are coarser: bbup and noirup each provision a whole release in one shot, while bb-avm and acvm are provisioned individually. A corrupt `nargo` therefore re-runs only noirup; a missing `bb-avm` re-downloads only its artifact. Where a binary cannot be provisioned on the machine (bb-avm off amd64 linux, acvm with no cargo), `drop_unprovisionable` removes whatever sits in its place, so the record never attests contents from a different provisioning. Each install `rm -f`s its destination first: unpacking or copying onto a leftover symlink writes *through* it, into the linked build output.

The record is written once before the acvm build and again at the end, so a failed source build does not cost the downloads that already succeeded; a stale acvm is dropped before that first write so an interrupted run cannot leave the record attesting contents that are about to be replaced.

`noir_version` reads **only** the pin record: the binary reports its base cargo version, which cannot distinguish a nightly from the release it was cut from. `hash` covers the three required binaries plus bb-avm/acvm when present — what the toolchain provides, including their absence, is part of its identity.

## bbup

`install_bb` runs bbup with `--no-modify-path`, which is not part of this PR: that flag and the idempotent `update_shell_config` go in through #25060 against `next`. Until it lands, `build_labs` with the default `BBUP_URL` fails on the unknown flag (tested here via a `file://` override); once it does, `BBUP_URL` can pin that commit instead of tracking `next`.

## Docs

`labs-aztec-toolchain/README.md` describes what the component provisions and what consumers read from it; root `CLAUDE.md` now states the `$NARGO` default per side (`fnd/**` submodule build, `labs/**` toolchain); `noir-projects/labs/contract-snapshots/README.md` no longer points at the submodule build.

## Testing

Real downloads and builds:

- bb-avm fetched from the release (147 MB), `bb-avm --version` → `6.0.0-nightly.20260729`.
- acvm built three times in fresh temp dirs → byte-identical every time (`git hash-object` `458823a1…`), `acvm version = 0.40.0`. Afterwards: temp dir gone, no `~/.cargo/bin/acvm`, and the user's registry cache entry count unchanged.
- Cache round trip via `CACHE_LOCAL_DIR`: miss → build → upload (12 MB → 4.4 MB), then hit → restored with its exec bit in 0.26s instead of ~5 min, pin recording the restored hash.

Staleness scenarios, with stand-in installers so no release traffic was involved:

- cold install; no-op rerun; corrupt `nargo` → only noirup; missing `bb` → only bbup; missing `noir-profiler` → only noirup.
- simulated non-amd64 (`setarch linux32`) → bb-avm skipped and dropped; no cargo on `PATH` → acvm skipped, dropped, and its hash absent from the record.
- failed source download mid-build → record stays honest (no `acvm_hash`, corrupt file removed) and the next run retries only acvm, without re-downloading bb or nargo.
- monorepo-style symlinks in `bin/` taken over by downloads with all five pretend build outputs left byte-identical.

## Notes

- On a cache miss the acvm build is ~5 minutes, and ci3 only uploads from CI, so the first person to build a newly pinned noir version pays it locally.
- The pin record attests contents from install time onward; it does not validate a fresh download against a known-good checksum. If we ever want that, the script would need to carry expected per-platform hashes.
