### PR TITLE
chore(aztec-nr): pin protocol_types to a monorepo git tag

### DIFF
--- a/noir-projects/labs/aztec-nr/aztec/Nargo.toml
+++ b/noir-projects/labs/aztec-nr/aztec/Nargo.toml
@@ -5,6 +5,6 @@ compiler_version = ">=0.18.0"
 type = "lib"
 
 [dependencies]
-protocol_types = { path = "../../../fnd/noir-protocol-circuits/crates/types" }
+protocol_types = { git = "https://github.com/AztecProtocol/aztec-packages", tag = "v6.0.0-nightly.20260729", directory = "noir-projects/fnd/noir-protocol-circuits/crates/types" }
 sha256 = { tag = "v0.3.0", git = "https://github.com/noir-lang/sha256" }
 poseidon = { tag = "v0.3.0", git = "https://github.com/noir-lang/poseidon" }

--- a/noir-projects/labs/aztec-nr/bootstrap.sh
+++ b/noir-projects/labs/aztec-nr/bootstrap.sh
@@ -95,17 +95,15 @@ function release_git_push {
 
   cd release-out
 
-  # Update Nargo.toml files to reference noir-protocol-circuits from the monorepo tag
-  monorepo_url="https://github.com/AztecProtocol/aztec-packages"
-  monorepo_protocol_circuits_path="noir-projects/fnd/noir-protocol-circuits"
-
   # Find all Nargo.toml files that reference noir-protocol-circuits
   nargo_files="$(find . -name 'Nargo.toml' | xargs grep --files-with-matches 'noir-protocol-circuits' || true)"
 
-  # Replace relative paths with git references
+  # Move the noir-protocol-circuits pin from whatever monorepo tag the sources track to the tag
+  # being released. Only lines mentioning noir-protocol-circuits are touched, so the other git
+  # dependencies keep their own tags.
   for nargo_file in $nargo_files; do
     sed --regexp-extended --in-place \
-      "s;path\s*=\s*\".*noir-protocol-circuits(.*)\";git=\"$monorepo_url\", tag=\"$tag_name\", directory=\"$monorepo_protocol_circuits_path\1\";" \
+      "/noir-protocol-circuits/ s;tag\s*=\s*\"[^\"]*\";tag = \"$tag_name\";" \
       $nargo_file
   done
 

--- a/noir-projects/labs/bootstrap.sh
+++ b/noir-projects/labs/bootstrap.sh
@@ -11,11 +11,16 @@ function format_check {
   # Under heavy parallel CI load the VPC DNS resolver drops lookups
   # ("Could not resolve host: github.com"), leaving a half-cloned dependency dir
   # that then fails with "Cannot read file .../Nargo.toml". Retry the download,
-  # wiping the partial dependency cache after a failure so the next attempt
-  # re-clones cleanly. A warm cache is left intact on success.
+  # dropping only the dependencies that never finished cloning so the next
+  # attempt re-fetches just those. Completed clones are kept: protocol_types is
+  # served from a several-hundred-megabyte clone of aztec-packages, so wiping
+  # the whole cache on each attempt costs far more than the flake it works
+  # around. Cache layout is $HOME/nargo/<host>/<org>/<repo>/<ref>, and a clone
+  # that did not complete has no resolvable HEAD.
   local nargo=$root/noir/noir-repo/target/release/nargo
   local fmt_check="( set -e; for dir in noir-contracts aztec-nr protocol-fuzzer/contracts; do (cd \"\$dir\" && \"$nargo\" fmt --check); done )"
-  RETRY_SLEEP=10 retry "$fmt_check || { rm -rf \"\$HOME/nargo\"; exit 1; }"
+  local drop_partial_clones="for dep in \"\$HOME\"/nargo/*/*/*/*; do [ -d \"\$dep\" ] || continue; git -C \"\$dep\" rev-parse --verify --quiet HEAD >/dev/null 2>&1 || rm -rf \"\$dep\"; done"
+  RETRY_SLEEP=10 retry "$fmt_check || { $drop_partial_clones; exit 1; }"
 }
 
 function build {

--- a/noir-projects/labs/noir-contracts/bootstrap.sh
+++ b/noir-projects/labs/noir-contracts/bootstrap.sh
@@ -51,8 +51,7 @@ function get_contract_hash {
         ../barretenberg/cpp/.rebuild_patterns \
         ../barretenberg/ts/.rebuild_patterns \
         "^docs/examples/$contract_path/" \
-        "^noir-projects/labs/aztec-nr/" \
-        "^noir-projects/fnd/noir-protocol-circuits/crates/types/")
+        "^noir-projects/labs/aztec-nr/")
   else
     # Called from noir-contracts
     hash_str \
@@ -62,8 +61,7 @@ function get_contract_hash {
         ../../../barretenberg/cpp/.rebuild_patterns \
         ../../../barretenberg/ts/.rebuild_patterns \
         "^noir-projects/labs/noir-contracts/contracts/$contract_path/" \
-        "^noir-projects/labs/aztec-nr/" \
-        "^noir-projects/fnd/noir-protocol-circuits/crates/types/")
+        "^noir-projects/labs/aztec-nr/")
   fi
 }
 export -f get_contract_hash
@@ -308,7 +306,6 @@ function bench_cmds {
       ../../../barretenberg/ts/.rebuild_patterns \
       "^noir-projects/labs/noir-contracts/" \
       "^noir-projects/labs/aztec-nr/" \
-      "^noir-projects/fnd/noir-protocol-circuits/crates/types/" \
       "^noir-projects/labs/noir-contracts/scripts/bench_artifact_sizes.sh"))
   echo "$hash noir-projects/labs/noir-contracts/scripts/bench_artifact_sizes.sh"
 }


### PR DESCRIPTION
## Summary

First step of the monorepo split on `monorepo-split/labs`: labs Noir code stops referencing in-repo foundation code and consumes it as a pinned dependency instead. Base is `monorepo-split/labs`, not `next`.

`aztec-nr`'s `protocol_types` is the only cross-group Nargo dependency. It now resolves from a git tag on aztec-packages instead of a relative path into `noir-projects/fnd`, pinned to `v6.0.0-nightly.20260729`, the first tag carrying the fnd/labs layout and one whose `crates/types` tree is byte-identical to `next`. A tag is required rather than a branch: nargo clones `--depth 1 --branch <ref>` and caches by url+ref, so a branch pin would fetch once and then never update.

Recompiling `auth_registry_contract` against the pin yields an artifact differing only in debug `file_map` paths. Those are not inputs to `computeArtifactHash`, so class ids and the standard-contract pin do not move.

Supporting changes:

- Drops the `noir-projects/fnd/noir-protocol-circuits/crates/types/` cache-hash inputs from the labs contract hashes. The pin lives in `labs/aztec-nr/aztec/Nargo.toml`, already covered by the adjacent `labs/aztec-nr/` pattern, which also means `aztec-nr`'s own cache key now tracks its protocol_types dependency for the first time.
- Rewrites the aztec-nr mirror release substitution from path-to-git, which no longer matches anything, into a tag-to-tag rewrite restricted to the protocol_types line.
- Narrows the format-check retry to drop only the dependencies that failed to clone, rather than wiping the whole nargo cache. With protocol_types pinned, that cache is several hundred megabytes, so re-fetching all of it on each attempt costs more than the flake it works around.
