### PR TITLE
feat(bbup): add --no-modify-path, dedupe PATH entries

### DIFF
--- a/barretenberg/bbup/README.md
+++ b/barretenberg/bbup/README.md
@@ -39,6 +39,12 @@ You can install any specific version of `bb` with the `-v` flag. Example:
 bbup -v 0.56.0
 ```
 
+For scripted or CI use, `--no-modify-path` skips updating shell configuration files (`.bashrc`, `.zshrc`, fish config). Combine with `BB_PATH` to control the install destination:
+
+```bash
+BB_PATH=/some/dir bbup -v 0.56.0 --no-modify-path
+```
+
 You can also pass [any Noir version](https://github.com/noir-lang/noir/tags) with the `-nv` flag, or specify `nightly` for the nightly version. Examples:
 
 ```bash

--- a/barretenberg/bbup/bbup
+++ b/barretenberg/bbup/bbup
@@ -13,6 +13,7 @@ SUCCESS="✓"
 ERROR="✗"
 
 BB_PATH=${BB_PATH:-"$HOME/.bb"}
+MODIFY_PATH=true
 
 # Utility functions
 print_spinner() {
@@ -132,7 +133,9 @@ install_bb() {
     rm -rf "$temp_dir"
 
     # Update shell configuration
-    update_shell_config "$BB_PATH"
+    if [ "$MODIFY_PATH" = true ]; then
+        update_shell_config "$BB_PATH"
+    fi
 
     printf "${GREEN}${SUCCESS} Installed barretenberg to ${BB_PATH}${NC}\n"
 }
@@ -140,18 +143,19 @@ install_bb() {
 update_shell_config() {
     local bb_bin_path=$1
     local path_entry="export PATH=\"${bb_bin_path}:\$PATH\""
+    local fish_path_entry="set -gx PATH ${bb_bin_path} \$PATH"
 
-    # Update various shell configs if they exist
-    if [ -f "${HOME}/.bashrc" ]; then
+    # Update various shell configs if they exist and don't already have the entry
+    if [ -f "${HOME}/.bashrc" ] && ! grep -qxF "$path_entry" "${HOME}/.bashrc"; then
         echo "$path_entry" >> "${HOME}/.bashrc"
     fi
 
-    if [ -f "${HOME}/.zshrc" ]; then
+    if [ -f "${HOME}/.zshrc" ] && ! grep -qxF "$path_entry" "${HOME}/.zshrc"; then
         echo "$path_entry" >> "${HOME}/.zshrc"
     fi
 
-    if [ -f "${HOME}/.config/fish/config.fish" ]; then
-        echo "set -gx PATH ${bb_bin_path} \$PATH" >> "${HOME}/.config/fish/config.fish"
+    if [ -f "${HOME}/.config/fish/config.fish" ] && ! grep -qxF "$fish_path_entry" "${HOME}/.config/fish/config.fish"; then
+        echo "$fish_path_entry" >> "${HOME}/.config/fish/config.fish"
     fi
 
     # Update current session's PATH
@@ -173,6 +177,10 @@ main() {
             -nv|--noir-version)
                 noir_version="$2"
                 shift 2
+                ;;
+            --no-modify-path)
+                MODIFY_PATH=false
+                shift
                 ;;
             *)
                 printf "${RED}${ERROR} Unknown option: $1${NC}\n"

--- a/barretenberg/bbup/bootstrap.sh
+++ b/barretenberg/bbup/bootstrap.sh
@@ -7,10 +7,12 @@ export hash=$(cache_content_hash .rebuild_patterns)
 # Paths are relative to repo root.
 # We append the hash as a comment. This ensures the test harness and cache and skip future runs.
 function test_cmds {
+  # 0.72.1 covers the pre-0.77.0 artifact naming, which was only published for amd64 linux.
   if [ $(arch) == "amd64" ]; then
-    echo -e "$hash barretenberg/bbup/run_test.sh 0.72.1"
+    echo -e "$hash barretenberg/bbup/run_test.sh install 0.72.1"
   fi
-  echo -e "$hash barretenberg/bbup/run_test.sh 0.77.1"
+  echo -e "$hash barretenberg/bbup/run_test.sh install 0.77.1"
+  echo -e "$hash barretenberg/bbup/run_test.sh shell_config 0.77.1"
 }
 
 # This is not called in ci. It is just for a developer to run the tests.

--- a/barretenberg/bbup/run_test.sh
+++ b/barretenberg/bbup/run_test.sh
@@ -1,28 +1,104 @@
 #!/usr/bin/env bash
+# Tests for bbup, the standalone bb installer. Modes (driven from bootstrap.sh):
+#   install <version>       installs into a scratch BB_PATH and checks the bb placed there
+#                           reports the requested version, and that --no-modify-path left the
+#                           shell configs alone.
+#   shell_config <version>  checks the PATH entry bbup writes without that flag: it must land
+#                           in each shell config once, no matter how many times bbup runs.
+# Both modes point HOME at a scratch dir, so a run never writes to the caller's own dotfiles.
 
 set -e
 
 cd $(dirname $0)/
 
-VERSION=$1
+MODE=$1
+VERSION=$2
 
 TEMP_DIR=$(mktemp -d)
 trap 'rm -rf $TEMP_DIR' EXIT
 
-for attempt in {1..3}; do
-    set +e
-    BB_PATH=$TEMP_DIR ./bbup -v $VERSION && break
-    status=$?
-    if ! [[ $status -eq 22 && $attempt -lt 3 ]]; then
-        exit $status
-    fi
-    set -e
-    echo "bbup failed with exit code 22 possibly indicating bad download, retrying..."
-done
+export HOME=$TEMP_DIR/home
+# bbup only edits configs that already exist, so seed every one it knows about.
+SHELL_CONFIGS=($HOME/.bashrc $HOME/.zshrc $HOME/.config/fish/config.fish)
+mkdir -p $HOME/.config/fish
+touch "${SHELL_CONFIGS[@]}"
 
-if ! grep "$VERSION" <<< $($TEMP_DIR/bb --version) > /dev/null; then
-    echo "Did not find expected version of bb"
-    echo "Expected: $VERSION"
-    echo "Found: $SEEN_VERSION"
-    exit 1
-fi
+# Installs the pinned version into $1, passing any further arguments through to bbup.
+# Exit code 22 is curl failing on the release download, i.e. a flaky network rather than a
+# broken bbup, so it gets a couple more attempts.
+function install_bb {
+    local bb_path=$1
+    shift
+    local attempt status
+    for attempt in {1..3}; do
+        set +e
+        BB_PATH=$bb_path ./bbup -v $VERSION "$@"
+        status=$?
+        set -e
+        [ $status -eq 0 ] && return 0
+        if [ $status -ne 22 ] || [ $attempt -eq 3 ]; then
+            return $status
+        fi
+        echo "bbup failed with exit code 22 possibly indicating bad download, retrying..."
+    done
+}
+
+# Number of lines in config $2 that mention install dir $1, whichever shell's PATH syntax
+# that config uses.
+function path_entries {
+    grep -c -F "$1" "$2" || true
+}
+
+function test_install {
+    local bb_path=$TEMP_DIR/install
+    install_bb $bb_path --no-modify-path
+
+    local seen_version=$($bb_path/bb --version)
+    if ! grep "$VERSION" <<< "$seen_version" > /dev/null; then
+        echo "Did not find expected version of bb"
+        echo "Expected: $VERSION"
+        echo "Found: $seen_version"
+        exit 1
+    fi
+
+    # The point of the flag: the install stays invisible to the shell, so the seeded configs
+    # are still empty. Asserting emptiness rather than the absence of the PATH line also
+    # catches anything else bbup might decide to write.
+    local config
+    for config in "${SHELL_CONFIGS[@]}"; do
+        if [ -s "$config" ]; then
+            echo "bbup --no-modify-path wrote to $config:"
+            cat "$config"
+            exit 1
+        fi
+    done
+}
+
+function test_shell_config {
+    local bb_path=$TEMP_DIR/install
+
+    # The same directory installed twice: the second run must find its entry already there
+    # and leave the config alone, rather than appending a duplicate.
+    install_bb $bb_path
+    install_bb $bb_path
+
+    local config entries
+    for config in "${SHELL_CONFIGS[@]}"; do
+        entries=$(path_entries $bb_path "$config")
+        if [ "$entries" != 1 ]; then
+            echo "Expected exactly one PATH entry for $bb_path in $config, found $entries:"
+            cat "$config"
+            exit 1
+        fi
+    done
+}
+
+case "$MODE" in
+    install|shell_config)
+        test_$MODE
+        ;;
+    *)
+        echo "Usage: $0 <install|shell_config> <version>"
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
## What

- `--no-modify-path` skips `update_shell_config`, so a scripted install can place `bb` in a chosen `BB_PATH` without editing the invoking user's `.bashrc`/`.zshrc`/`config.fish`.
- The shell-config edits it *does* make are idempotent: every run used to append another `PATH` line to each config.
- README documents the flag alongside `BB_PATH`.

Required for https://linear.app/aztec-labs/issue/A-1532/source-bbnargo-from-an-aztec-toolchain-directory-for-labs .

## Why now

`labs-aztec-toolchain` provisions its pinned `bb` by fetching `bbup` from this repo and running it with `--no-modify-path` into the component's `bin/`. That branch pins the raw URL, so this has to be on `next` before the pin can point at a commit.

## Verification

Ran the real script against the pinned nightly with `HOME` redirected to a scratch dir seeded with an empty `.bashrc`, `.zshrc` and `config.fish`:

- with `--no-modify-path`: `bb` installed into the given `BB_PATH` (`bb --version` → `6.0.0-nightly.20260729`), all three configs still 0 lines.
- without the flag, run twice: exactly one entry in each of the three configs.